### PR TITLE
feat: main.py initialization + EventBus middleware

### DIFF
--- a/src/ante/eventbus/bus.py
+++ b/src/ante/eventbus/bus.py
@@ -27,6 +27,11 @@ class EventBus:
         self._handlers: dict[type[Event], list[tuple[int, EventHandler]]] = {}
         self._history: list[Event] = []
         self._history_size = history_size
+        self._middlewares: list[EventHandler] = []
+
+    def use(self, middleware: EventHandler) -> None:
+        """글로벌 미들웨어 등록. 모든 이벤트에 대해 호출된다."""
+        self._middlewares.append(middleware)
 
     def subscribe(
         self,
@@ -60,6 +65,19 @@ class EventBus:
     async def publish(self, event: Event) -> None:
         """이벤트를 모든 구독 핸들러에 순차 전달 + 히스토리 기록."""
         self._record_history(event)
+
+        # 글로벌 미들웨어 실행 (로깅, SQLite 영속화 등)
+        for mw in self._middlewares:
+            try:
+                result = mw(event)
+                if isawaitable(result):
+                    await result
+            except Exception:
+                logger.exception(
+                    "미들웨어 에러: %s for %s",
+                    mw.__qualname__,
+                    type(event).__name__,
+                )
 
         handlers = self._handlers.get(type(event), [])
         if not handlers:

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1,11 +1,85 @@
 """Ante - AI-Native Trading Engine entrypoint."""
 
 import asyncio
+import logging
+import signal
+from pathlib import Path
+
+from ante.config import Config, DynamicConfigService, SystemState
+from ante.core import Database
+from ante.eventbus import EventBus, EventHistoryStore
+
+logger = logging.getLogger(__name__)
 
 
 async def main() -> None:
-    """Main asyncio entrypoint."""
-    pass
+    """Main asyncio entrypoint.
+
+    시스템 초기화 순서 (architecture.md 참조):
+    1. Config.load() + validate()
+    2. Database 초기화
+    3. EventBus 초기화
+    4. SystemState 초기화
+    5. DynamicConfigService 초기화
+    6~13. (Phase 2+ 에서 추가)
+    """
+    # 1. Config
+    config = Config.load(config_dir=Path("config"))
+    config.validate()
+
+    # 로깅 설정
+    log_level = config.get("system.log_level", "INFO")
+    logging.basicConfig(
+        level=getattr(logging, log_level),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    logger.info("Ante 시작")
+
+    # 2. Database
+    db_path = config.get("db.path", "db/ante.db")
+    Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    db = Database(db_path)
+    await db.connect()
+    logger.info("Database 연결 완료: %s", db_path)
+
+    # 3. EventBus
+    history_size = config.get("eventbus.history_size", 1000)
+    eventbus = EventBus(history_size=history_size)
+
+    # EventHistoryStore — 모든 이벤트를 SQLite에 영속화
+    event_history = EventHistoryStore(db=db)
+    await event_history.initialize()
+    eventbus.use(event_history.record)
+    logger.info("EventBus 초기화 완료 (history_size=%d)", history_size)
+
+    # 4. SystemState (킬 스위치)
+    system_state = SystemState(db=db, eventbus=eventbus)
+    await system_state.initialize()
+    logger.info("SystemState 초기화 완료: %s", system_state.trading_state)
+
+    # 5. DynamicConfigService
+    dynamic_config = DynamicConfigService(db=db, eventbus=eventbus)
+    await dynamic_config.initialize()
+    logger.info("DynamicConfigService 초기화 완료")
+
+    # Graceful shutdown
+    shutdown_event = asyncio.Event()
+
+    def _signal_handler() -> None:
+        logger.info("종료 시그널 수신")
+        shutdown_event.set()
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _signal_handler)
+
+    logger.info("Ante 준비 완료 — 종료 시그널 대기 중")
+    await shutdown_event.wait()
+
+    # 종료 정리 (역순)
+    logger.info("Ante 종료 시작")
+    await db.close()
+    logger.info("Ante 종료 완료")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,0 +1,85 @@
+"""main.py 통합 초기화 테스트."""
+
+from pathlib import Path
+
+from ante.config import Config, DynamicConfigService, SystemState, TradingState
+from ante.core import Database
+from ante.eventbus import EventBus, EventHistoryStore
+from ante.eventbus.events import OrderRequestEvent
+
+
+async def test_full_initialization(tmp_path: Path) -> None:
+    """Config → Database → EventBus → SystemState → DynamicConfig 초기화."""
+    # 1. Config
+    toml = tmp_path / "system.toml"
+    toml.write_text(
+        '[db]\npath = "{}"\n\n[web]\nport = 8000\n'.format(str(tmp_path / "test.db"))
+    )
+    config = Config.load(config_dir=tmp_path)
+    config.validate()
+
+    # 2. Database
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+
+    # 3. EventBus + EventHistoryStore
+    eventbus = EventBus(history_size=100)
+    history_store = EventHistoryStore(db=db)
+    await history_store.initialize()
+    eventbus.use(history_store.record)
+
+    # 4. SystemState
+    system_state = SystemState(db=db, eventbus=eventbus)
+    await system_state.initialize()
+    assert system_state.trading_state == TradingState.ACTIVE
+
+    # 5. DynamicConfigService
+    dynamic_config = DynamicConfigService(db=db, eventbus=eventbus)
+    await dynamic_config.initialize()
+
+    # 검증: 이벤트 발행 → 인메모리 히스토리 + SQLite 영속화
+    event = OrderRequestEvent(symbol="005930", side="buy", quantity=10.0)
+    await eventbus.publish(event)
+
+    # 인메모리 히스토리
+    mem_history = eventbus.get_history()
+    assert len(mem_history) == 1
+    assert mem_history[0].symbol == "005930"
+
+    # SQLite 영속화
+    db_history = await history_store.query()
+    assert len(db_history) == 1
+    assert db_history[0]["event_type"] == "OrderRequestEvent"
+
+    # SystemState 상태 변경 → 이벤트 발행 + DB 영속화
+    await system_state.set_state(TradingState.HALTED, reason="test", changed_by="test")
+    assert system_state.trading_state == TradingState.HALTED
+
+    # DynamicConfig CRUD
+    await dynamic_config.set("test.key", 42, category="test")
+    assert await dynamic_config.get("test.key") == 42
+
+    # 정리
+    await db.close()
+
+
+async def test_eventbus_middleware_records_all_events(
+    tmp_path: Path,
+) -> None:
+    """EventBus 미들웨어가 모든 이벤트를 SQLite에 기록한다."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+
+    eventbus = EventBus()
+    store = EventHistoryStore(db=db)
+    await store.initialize()
+    eventbus.use(store.record)
+
+    # 여러 이벤트 발행
+    for i in range(5):
+        await eventbus.publish(OrderRequestEvent(symbol=f"sym{i}"))
+
+    rows = await store.query(limit=10)
+    assert len(rows) == 5
+
+    await db.close()


### PR DESCRIPTION
## Summary
- **main.py**: Phase 1 초기화 체인 구현 (Config → DB → EventBus → SystemState → DynamicConfig)
- **EventBus.use()**: 글로벌 미들웨어 패턴 추가 (모든 이벤트에 대해 실행)
- **EventHistoryStore**: 미들웨어로 연결하여 모든 이벤트 SQLite 영속화
- **Graceful shutdown**: SIGTERM/SIGINT 핸들링

## Test plan
- [x] 전체 초기화 체인 검증 (Config → DB → EventBus → SystemState → DynamicConfig)
- [x] EventBus 미들웨어가 모든 이벤트를 SQLite에 기록하는지 확인
- [x] 기존 57개 테스트 회귀 없음 (총 59개 통과)
- [x] ruff check + ruff format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)