### PR TITLE
feat: Strategy module — ABC, Validator, Loader, Registry

### DIFF
--- a/src/ante/strategy/__init__.py
+++ b/src/ante/strategy/__init__.py
@@ -1,0 +1,40 @@
+"""Strategy — 전략 정의·검증·등록·로딩."""
+
+from ante.strategy.base import (
+    DataProvider,
+    OrderAction,
+    OrderView,
+    PortfolioView,
+    Signal,
+    Strategy,
+    StrategyMeta,
+)
+from ante.strategy.context import StrategyContext
+from ante.strategy.exceptions import (
+    StrategyError,
+    StrategyLoadError,
+    StrategyValidationError,
+)
+from ante.strategy.loader import StrategyLoader
+from ante.strategy.registry import StrategyRecord, StrategyRegistry, StrategyStatus
+from ante.strategy.validator import StrategyValidator, ValidationResult
+
+__all__ = [
+    "DataProvider",
+    "OrderAction",
+    "OrderView",
+    "PortfolioView",
+    "Signal",
+    "Strategy",
+    "StrategyContext",
+    "StrategyError",
+    "StrategyLoadError",
+    "StrategyLoader",
+    "StrategyMeta",
+    "StrategyRecord",
+    "StrategyRegistry",
+    "StrategyStatus",
+    "StrategyValidationError",
+    "StrategyValidator",
+    "ValidationResult",
+]

--- a/src/ante/strategy/base.py
+++ b/src/ante/strategy/base.py
@@ -1,0 +1,160 @@
+"""Strategy ABC, Signal, StrategyMeta, OrderAction, Provider ABCs."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    pass
+
+
+# ── 메타데이터 ────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class StrategyMeta:
+    """전략 메타데이터. 모든 전략이 클래스 변수로 선언해야 함."""
+
+    name: str
+    version: str
+    description: str
+    author: str = "agent"
+    symbols: list[str] | None = None
+    timeframe: str = "1d"
+
+
+# ── 시그널 / 주문 액션 ────────────────────────────
+
+
+@dataclass(frozen=True)
+class Signal:
+    """전략이 생성하는 매매 시그널."""
+
+    symbol: str
+    side: str  # "buy" | "sell"
+    quantity: float
+    order_type: str = "market"
+    price: float | None = None
+    stop_price: float | None = None
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class OrderAction:
+    """전략이 요청하는 주문 관리 액션 (취소/정정)."""
+
+    action: str  # "cancel" | "modify"
+    order_id: str
+    quantity: float | None = None
+    price: float | None = None
+    reason: str = ""
+
+
+# ── Provider ABCs ─────────────────────────────────
+
+
+class DataProvider(ABC):
+    """데이터 조회 인터페이스."""
+
+    @abstractmethod
+    async def get_ohlcv(
+        self,
+        symbol: str,
+        timeframe: str = "1d",
+        limit: int = 100,
+    ) -> Any:
+        """OHLCV 데이터 조회."""
+        ...
+
+    @abstractmethod
+    async def get_current_price(self, symbol: str) -> float:
+        """현재가 조회."""
+        ...
+
+    @abstractmethod
+    async def get_indicator(
+        self,
+        symbol: str,
+        indicator: str,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        """기술 지표 데이터 조회."""
+        ...
+
+
+class PortfolioView(ABC):
+    """포트폴리오 읽기 전용 인터페이스."""
+
+    @abstractmethod
+    def get_positions(self, bot_id: str) -> dict[str, Any]:
+        """현재 보유 포지션 조회."""
+        ...
+
+    @abstractmethod
+    def get_balance(self, bot_id: str) -> dict[str, float]:
+        """봇 할당 자금 현황 조회."""
+        ...
+
+
+class OrderView(ABC):
+    """주문 조회 인터페이스."""
+
+    @abstractmethod
+    def get_open_orders(self, bot_id: str) -> list[dict[str, Any]]:
+        """미체결 주문 목록 조회."""
+        ...
+
+
+# ── Strategy ABC ──────────────────────────────────
+
+
+class Strategy(ABC):
+    """모든 전략의 기본 클래스."""
+
+    meta: StrategyMeta
+
+    def __init__(self, ctx: Any) -> None:
+        self.ctx = ctx
+
+    # ── 라이프사이클 ──
+
+    def on_start(self) -> None:
+        """봇 시작 시 1회 호출."""
+
+    def on_stop(self) -> None:
+        """봇 중지 시 1회 호출."""
+
+    # ── 시그널 생성 (핵심) ──
+
+    @abstractmethod
+    async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+        """주기적으로 호출되어 매매 시그널을 반환."""
+        ...
+
+    # ── 이벤트 핸들러 (선택) ──
+
+    async def on_fill(self, fill: dict[str, Any]) -> list[Signal]:
+        """주문 체결 통보."""
+        return []
+
+    async def on_order_update(self, update: dict[str, Any]) -> None:
+        """주문 상태 변경 통보."""
+
+    async def on_data(self, data: dict[str, Any]) -> list[Signal]:
+        """외부 데이터 수신."""
+        return []
+
+    async def on_position_corrected(self, correction: dict[str, Any]) -> None:
+        """대사에 의한 포지션 보정 통보."""
+
+    # ── 전략별 룰 / 파라미터 (선택) ──
+
+    def get_rules(self) -> dict[str, Any]:
+        """전략별 거래 룰 반환."""
+        return {}
+
+    def get_params(self) -> dict[str, Any]:
+        """백테스트 최적화 파라미터 반환."""
+        return {}

--- a/src/ante/strategy/context.py
+++ b/src/ante/strategy/context.py
@@ -1,0 +1,104 @@
+"""StrategyContext — 전략에 노출되는 제한된 API."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ante.strategy.base import DataProvider, OrderAction, OrderView, PortfolioView
+
+
+class StrategyContext:
+    """전략이 사용할 수 있는 API. Bot이 생성하여 전략에 주입."""
+
+    def __init__(
+        self,
+        bot_id: str,
+        data_provider: DataProvider,
+        portfolio: PortfolioView,
+        order_view: OrderView,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self.bot_id = bot_id
+        self._data = data_provider
+        self._portfolio = portfolio
+        self._orders = order_view
+        self._log = logger or logging.getLogger(f"ante.strategy.{bot_id}")
+        self._pending_actions: list[OrderAction] = []
+
+    # ── 데이터 조회 ──
+
+    async def get_ohlcv(
+        self,
+        symbol: str,
+        timeframe: str = "1d",
+        limit: int = 100,
+    ) -> Any:
+        """OHLCV 데이터 조회."""
+        return await self._data.get_ohlcv(symbol, timeframe, limit)
+
+    async def get_current_price(self, symbol: str) -> float:
+        """현재가 조회."""
+        return await self._data.get_current_price(symbol)
+
+    async def get_indicator(
+        self,
+        symbol: str,
+        indicator: str,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        """기술 지표 데이터 조회."""
+        return await self._data.get_indicator(symbol, indicator, params)
+
+    # ── 포트폴리오 조회 ──
+
+    def get_positions(self) -> dict[str, Any]:
+        """현재 보유 포지션 조회."""
+        return self._portfolio.get_positions(self.bot_id)
+
+    def get_balance(self) -> dict[str, float]:
+        """봇 할당 자금 현황 조회."""
+        return self._portfolio.get_balance(self.bot_id)
+
+    # ── 주문 관리 ──
+
+    def get_open_orders(self) -> list[dict[str, Any]]:
+        """미체결 주문 목록 조회."""
+        return self._orders.get_open_orders(self.bot_id)
+
+    def cancel_order(self, order_id: str, reason: str = "") -> None:
+        """미체결 주문 취소 요청."""
+        self._pending_actions.append(
+            OrderAction(action="cancel", order_id=order_id, reason=reason)
+        )
+
+    def modify_order(
+        self,
+        order_id: str,
+        quantity: float | None = None,
+        price: float | None = None,
+        reason: str = "",
+    ) -> None:
+        """미체결 주문 정정 요청."""
+        self._pending_actions.append(
+            OrderAction(
+                action="modify",
+                order_id=order_id,
+                quantity=quantity,
+                price=price,
+                reason=reason,
+            )
+        )
+
+    def _drain_actions(self) -> list[OrderAction]:
+        """Bot이 호출: 큐에 쌓인 주문 관리 액션을 모두 꺼내 반환."""
+        actions = self._pending_actions.copy()
+        self._pending_actions.clear()
+        return actions
+
+    # ── 로깅 ──
+
+    def log(self, message: str, level: str = "info") -> None:
+        """전략 로그 기록."""
+        log_level = getattr(logging, level.upper(), logging.INFO)
+        self._log.log(log_level, "[%s] %s", self.bot_id, message)

--- a/src/ante/strategy/exceptions.py
+++ b/src/ante/strategy/exceptions.py
@@ -1,0 +1,19 @@
+"""Strategy 모듈 예외."""
+
+
+class StrategyError(Exception):
+    """Strategy 기본 예외."""
+
+    pass
+
+
+class StrategyLoadError(StrategyError):
+    """전략 파일 로드 실패."""
+
+    pass
+
+
+class StrategyValidationError(StrategyError):
+    """전략 검증 실패."""
+
+    pass

--- a/src/ante/strategy/loader.py
+++ b/src/ante/strategy/loader.py
@@ -1,0 +1,60 @@
+"""StrategyLoader — 전략 파일 동적 로딩."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from ante.strategy.base import Strategy
+from ante.strategy.exceptions import StrategyLoadError
+
+
+class StrategyLoader:
+    """전략 파일을 동적으로 로드하여 Strategy 클래스를 반환."""
+
+    @staticmethod
+    def load(filepath: Path) -> type[Strategy]:
+        """전략 파일에서 Strategy 하위 클래스를 로드.
+
+        Args:
+            filepath: 전략 파일 경로
+
+        Returns:
+            Strategy를 상속한 클래스 (인스턴스 아님)
+
+        Raises:
+            StrategyLoadError: 파일 로드 실패 또는 Strategy 하위 클래스 미발견
+        """
+        if not filepath.exists():
+            raise StrategyLoadError(f"File not found: {filepath}")
+
+        spec = importlib.util.spec_from_file_location(
+            f"strategy_{filepath.stem}",
+            filepath,
+        )
+        if spec is None or spec.loader is None:
+            raise StrategyLoadError(f"Cannot load module: {filepath}")
+
+        module = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(module)
+        except Exception as e:
+            raise StrategyLoadError(f"Failed to execute module {filepath}: {e}") from e
+
+        strategy_classes = [
+            obj
+            for obj in vars(module).values()
+            if isinstance(obj, type)
+            and issubclass(obj, Strategy)
+            and obj is not Strategy
+        ]
+
+        if len(strategy_classes) == 0:
+            raise StrategyLoadError(f"No Strategy subclass found in {filepath}")
+        if len(strategy_classes) > 1:
+            raise StrategyLoadError(
+                f"Multiple Strategy subclasses in {filepath}: "
+                f"{[c.__name__ for c in strategy_classes]}"
+            )
+
+        return strategy_classes[0]

--- a/src/ante/strategy/registry.py
+++ b/src/ante/strategy/registry.py
@@ -1,0 +1,173 @@
+"""StrategyRegistry — 검증 완료된 전략 목록 관리."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ante.strategy.base import StrategyMeta
+from ante.strategy.exceptions import StrategyError
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+
+logger = logging.getLogger(__name__)
+
+STRATEGY_REGISTRY_SCHEMA = """
+CREATE TABLE IF NOT EXISTS strategies (
+    strategy_id          TEXT PRIMARY KEY,
+    name                 TEXT NOT NULL,
+    version              TEXT NOT NULL,
+    filepath             TEXT NOT NULL,
+    status               TEXT NOT NULL DEFAULT 'registered',
+    registered_at        TEXT NOT NULL,
+    description          TEXT DEFAULT '',
+    author               TEXT DEFAULT 'agent',
+    validation_warnings  TEXT DEFAULT '[]'
+);
+"""
+
+
+class StrategyStatus(StrEnum):
+    """전략 상태."""
+
+    REGISTERED = "registered"
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    ARCHIVED = "archived"
+
+
+@dataclass
+class StrategyRecord:
+    """Registry에 저장되는 전략 레코드."""
+
+    strategy_id: str
+    name: str
+    version: str
+    filepath: str
+    status: StrategyStatus
+    registered_at: datetime
+    description: str = ""
+    author: str = "agent"
+    validation_warnings: list[str] = field(default_factory=list)
+
+
+class StrategyRegistry:
+    """검증 완료된 전략 목록 관리. SQLite에 영속화."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    async def initialize(self) -> None:
+        """스키마 생성."""
+        await self._db.execute_script(STRATEGY_REGISTRY_SCHEMA)
+
+    async def register(
+        self,
+        filepath: Path,
+        meta: StrategyMeta,
+        warnings: list[str] | None = None,
+    ) -> StrategyRecord:
+        """전략 등록."""
+        strategy_id = f"{meta.name}_v{meta.version}"
+
+        if await self.exists(strategy_id):
+            raise StrategyError(f"Strategy already registered: {strategy_id}")
+
+        now = datetime.now(UTC)
+        record = StrategyRecord(
+            strategy_id=strategy_id,
+            name=meta.name,
+            version=meta.version,
+            filepath=str(filepath),
+            status=StrategyStatus.REGISTERED,
+            registered_at=now,
+            description=meta.description,
+            author=meta.author,
+            validation_warnings=warnings or [],
+        )
+
+        await self._db.execute(
+            """INSERT INTO strategies
+               (strategy_id, name, version, filepath, status,
+                registered_at, description, author,
+                validation_warnings)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                record.strategy_id,
+                record.name,
+                record.version,
+                record.filepath,
+                record.status.value,
+                record.registered_at.isoformat(),
+                record.description,
+                record.author,
+                json.dumps(record.validation_warnings),
+            ),
+        )
+        logger.info("전략 등록: %s", strategy_id)
+        return record
+
+    async def get(self, strategy_id: str) -> StrategyRecord | None:
+        """전략 레코드 조회."""
+        row = await self._db.fetch_one(
+            "SELECT * FROM strategies WHERE strategy_id = ?",
+            (strategy_id,),
+        )
+        if row is None:
+            return None
+        return self._row_to_record(row)
+
+    async def list_strategies(
+        self,
+        status: StrategyStatus | None = None,
+    ) -> list[StrategyRecord]:
+        """전략 목록 조회."""
+        if status:
+            rows = await self._db.fetch_all(
+                "SELECT * FROM strategies WHERE status = ? ORDER BY registered_at DESC",
+                (status.value,),
+            )
+        else:
+            rows = await self._db.fetch_all(
+                "SELECT * FROM strategies ORDER BY registered_at DESC"
+            )
+        return [self._row_to_record(row) for row in rows]
+
+    async def update_status(
+        self,
+        strategy_id: str,
+        status: StrategyStatus,
+    ) -> None:
+        """전략 상태 변경."""
+        await self._db.execute(
+            "UPDATE strategies SET status = ? WHERE strategy_id = ?",
+            (status.value, strategy_id),
+        )
+
+    async def exists(self, strategy_id: str) -> bool:
+        """전략 존재 여부 확인."""
+        row = await self._db.fetch_one(
+            "SELECT 1 FROM strategies WHERE strategy_id = ?",
+            (strategy_id,),
+        )
+        return row is not None
+
+    @staticmethod
+    def _row_to_record(row: dict) -> StrategyRecord:
+        return StrategyRecord(
+            strategy_id=row["strategy_id"],
+            name=row["name"],
+            version=row["version"],
+            filepath=row["filepath"],
+            status=StrategyStatus(row["status"]),
+            registered_at=datetime.fromisoformat(row["registered_at"]),
+            description=row["description"],
+            author=row["author"],
+            validation_warnings=json.loads(row["validation_warnings"]),
+        )

--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -1,0 +1,153 @@
+"""StrategyValidator — AST 기반 전략 파일 정적 검증."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class ValidationResult:
+    """검증 결과."""
+
+    valid: bool
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+class StrategyValidator:
+    """AST 기반 전략 파일 정적 검증."""
+
+    FORBIDDEN_MODULES: set[str] = {
+        "os",
+        "sys",
+        "subprocess",
+        "shutil",
+        "socket",
+        "http",
+        "urllib",
+        "requests",
+        "aiohttp",
+        "httpx",
+        "sqlite3",
+        "sqlalchemy",
+        "importlib",
+        "ctypes",
+        "pickle",
+        "pathlib",
+    }
+
+    def validate(self, filepath: Path) -> ValidationResult:
+        """전략 파일 정적 검증."""
+        errors: list[str] = []
+        warnings: list[str] = []
+
+        # 1. 파싱
+        try:
+            source = filepath.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(filepath))
+        except SyntaxError as e:
+            return ValidationResult(
+                valid=False,
+                errors=[f"Syntax error: {e}"],
+            )
+
+        # 2. Strategy 상속 클래스 존재
+        strategy_classes = self._find_strategy_classes(tree)
+        if len(strategy_classes) == 0:
+            errors.append("No class inheriting from Strategy found")
+        elif len(strategy_classes) > 1:
+            errors.append(
+                f"Multiple Strategy subclasses found: "
+                f"{[c.name for c in strategy_classes]}"
+            )
+
+        # 3. 필수 요소 검사
+        if len(strategy_classes) == 1:
+            cls = strategy_classes[0]
+            if not self._has_class_var(cls, "meta"):
+                errors.append("Missing 'meta' class variable (StrategyMeta)")
+            if not self._has_method(cls, "on_step"):
+                errors.append("Missing required method: on_step()")
+
+        # 4. 금지 모듈 import
+        forbidden = self._find_forbidden_imports(tree)
+        for module in forbidden:
+            errors.append(f"Forbidden import: {module}")
+
+        # 5. 위험 패턴 경고
+        warnings.extend(self._find_dangerous_patterns(tree))
+
+        return ValidationResult(
+            valid=len(errors) == 0,
+            errors=errors,
+            warnings=warnings,
+        )
+
+    def _find_strategy_classes(self, tree: ast.Module) -> list[ast.ClassDef]:
+        """Strategy를 상속하는 클래스 노드 탐색."""
+        result: list[ast.ClassDef] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                for base in node.bases:
+                    if isinstance(base, ast.Name) and base.id == "Strategy":
+                        result.append(node)
+                    elif isinstance(base, ast.Attribute) and base.attr == "Strategy":
+                        result.append(node)
+        return result
+
+    def _has_class_var(self, cls: ast.ClassDef, name: str) -> bool:
+        """클래스 변수 할당 존재 여부."""
+        for node in cls.body:
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == name:
+                        return True
+            elif isinstance(node, ast.AnnAssign):
+                if isinstance(node.target, ast.Name) and node.target.id == name:
+                    return True
+        return False
+
+    def _has_method(self, cls: ast.ClassDef, name: str) -> bool:
+        """메서드 정의 존재 여부."""
+        for node in cls.body:
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                if node.name == name:
+                    return True
+        return False
+
+    def _find_forbidden_imports(self, tree: ast.Module) -> list[str]:
+        """금지 모듈 import 탐색."""
+        found: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    top_module = alias.name.split(".")[0]
+                    if top_module in self.FORBIDDEN_MODULES:
+                        found.append(alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    top_module = node.module.split(".")[0]
+                    if top_module in self.FORBIDDEN_MODULES:
+                        found.append(node.module)
+        return found
+
+    def _find_dangerous_patterns(self, tree: ast.Module) -> list[str]:
+        """위험 패턴 탐지 (경고 수준)."""
+        warnings: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                if node.func.id in (
+                    "eval",
+                    "exec",
+                    "compile",
+                    "__import__",
+                ):
+                    warnings.append(
+                        f"Dangerous built-in call: "
+                        f"{node.func.id}() at line {node.lineno}"
+                    )
+                elif node.func.id == "open":
+                    warnings.append(f"File access via open() at line {node.lineno}")
+        return warnings

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -1,0 +1,456 @@
+"""Strategy 모듈 단위 테스트."""
+
+from pathlib import Path
+
+import pytest
+
+from ante.core import Database
+from ante.strategy import (
+    DataProvider,
+    OrderView,
+    PortfolioView,
+    Signal,
+    Strategy,
+    StrategyContext,
+    StrategyLoader,
+    StrategyMeta,
+    StrategyRegistry,
+    StrategyStatus,
+    StrategyValidator,
+)
+from ante.strategy.exceptions import StrategyError, StrategyLoadError
+
+# ── Test fixtures ─────────────────────────────────
+
+
+class FakeDataProvider(DataProvider):
+    async def get_ohlcv(self, symbol, timeframe="1d", limit=100):
+        return [{"close": 100.0}]
+
+    async def get_current_price(self, symbol):
+        return 100.0
+
+    async def get_indicator(self, symbol, indicator, params=None):
+        return {}
+
+
+class FakePortfolioView(PortfolioView):
+    def get_positions(self, bot_id):
+        return {}
+
+    def get_balance(self, bot_id):
+        return {"total": 1000000.0, "available": 500000.0, "reserved": 500000.0}
+
+
+class FakeOrderView(OrderView):
+    def get_open_orders(self, bot_id):
+        return []
+
+
+# ── Signal ────────────────────────────────────────
+
+
+class TestSignal:
+    def test_signal_frozen(self):
+        """Signal은 불변 객체이다."""
+        s = Signal(symbol="005930", side="buy", quantity=10.0)
+        with pytest.raises(AttributeError):
+            s.symbol = "other"  # type: ignore[misc]
+
+    def test_signal_defaults(self):
+        """Signal 기본값."""
+        s = Signal(symbol="005930", side="buy", quantity=10.0)
+        assert s.order_type == "market"
+        assert s.price is None
+        assert s.stop_price is None
+        assert s.reason == ""
+
+
+# ── Strategy ABC ──────────────────────────────────
+
+
+class TestStrategyABC:
+    def test_cannot_instantiate_without_on_step(self):
+        """on_step 미구현 시 인스턴스화 불가."""
+
+        class Incomplete(Strategy):
+            meta = StrategyMeta(name="x", version="1.0.0", description="x")
+
+        with pytest.raises(TypeError):
+            Incomplete(ctx=None)
+
+    def test_can_instantiate_with_on_step(self):
+        """on_step 구현 시 인스턴스화 가능."""
+
+        class Complete(Strategy):
+            meta = StrategyMeta(name="x", version="1.0.0", description="x")
+
+            async def on_step(self, context):
+                return []
+
+        s = Complete(ctx=None)
+        assert s.meta.name == "x"
+
+    async def test_default_on_fill_returns_empty(self):
+        """on_fill 기본 구현은 빈 리스트 반환."""
+
+        class S(Strategy):
+            meta = StrategyMeta(name="x", version="1.0.0", description="x")
+
+            async def on_step(self, context):
+                return []
+
+        s = S(ctx=None)
+        result = await s.on_fill({})
+        assert result == []
+
+    async def test_default_on_data_returns_empty(self):
+        """on_data 기본 구현은 빈 리스트 반환."""
+
+        class S(Strategy):
+            meta = StrategyMeta(name="x", version="1.0.0", description="x")
+
+            async def on_step(self, context):
+                return []
+
+        s = S(ctx=None)
+        result = await s.on_data({})
+        assert result == []
+
+
+# ── StrategyContext ────────────────────────────────
+
+
+class TestStrategyContext:
+    @pytest.fixture
+    def ctx(self):
+        return StrategyContext(
+            bot_id="bot1",
+            data_provider=FakeDataProvider(),
+            portfolio=FakePortfolioView(),
+            order_view=FakeOrderView(),
+        )
+
+    async def test_get_ohlcv(self, ctx):
+        result = await ctx.get_ohlcv("005930")
+        assert len(result) > 0
+
+    async def test_get_current_price(self, ctx):
+        price = await ctx.get_current_price("005930")
+        assert price == 100.0
+
+    def test_get_positions(self, ctx):
+        assert ctx.get_positions() == {}
+
+    def test_get_balance(self, ctx):
+        balance = ctx.get_balance()
+        assert "total" in balance
+
+    def test_get_open_orders(self, ctx):
+        assert ctx.get_open_orders() == []
+
+    def test_cancel_order(self, ctx):
+        """cancel_order가 pending_actions에 추가된다."""
+        ctx.cancel_order("ord1", reason="test")
+        actions = ctx._drain_actions()
+        assert len(actions) == 1
+        assert actions[0].action == "cancel"
+        assert actions[0].order_id == "ord1"
+
+    def test_modify_order(self, ctx):
+        """modify_order가 pending_actions에 추가된다."""
+        ctx.modify_order("ord1", quantity=5.0, price=1000.0)
+        actions = ctx._drain_actions()
+        assert len(actions) == 1
+        assert actions[0].action == "modify"
+        assert actions[0].quantity == 5.0
+
+    def test_drain_clears_actions(self, ctx):
+        """drain 후 pending_actions가 비워진다."""
+        ctx.cancel_order("ord1")
+        ctx._drain_actions()
+        assert ctx._drain_actions() == []
+
+
+# ── StrategyValidator ─────────────────────────────
+
+
+class TestStrategyValidator:
+    @pytest.fixture
+    def validator(self):
+        return StrategyValidator()
+
+    def _write_strategy(self, tmp_path: Path, code: str) -> Path:
+        filepath = tmp_path / "test_strategy.py"
+        filepath.write_text(code)
+        return filepath
+
+    def test_valid_strategy(self, validator, tmp_path):
+        """정상 전략 파일이 검증을 통과한다."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta, Signal
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="test", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+        assert len(result.errors) == 0
+
+    def test_syntax_error(self, validator, tmp_path):
+        """문법 오류 파일은 검증 실패."""
+        code = "def broken(\n"
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("Syntax error" in e for e in result.errors)
+
+    def test_no_strategy_class(self, validator, tmp_path):
+        """Strategy 상속 클래스가 없으면 실패."""
+        code = "class NotAStrategy:\n    pass\n"
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("No class" in e for e in result.errors)
+
+    def test_missing_meta(self, validator, tmp_path):
+        """meta 클래스 변수가 없으면 실패."""
+        code = """
+class TestStrategy(Strategy):
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("meta" in e for e in result.errors)
+
+    def test_missing_on_step(self, validator, tmp_path):
+        """on_step 메서드가 없으면 실패."""
+        code = """
+class TestStrategy(Strategy):
+    meta = None
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("on_step" in e for e in result.errors)
+
+    def test_forbidden_import_os(self, validator, tmp_path):
+        """금지 모듈 import 시 실패."""
+        code = """
+import os
+
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("Forbidden import: os" in e for e in result.errors)
+
+    def test_forbidden_from_import(self, validator, tmp_path):
+        """from X import Y 형태의 금지 모듈."""
+        code = """
+from subprocess import call
+
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("subprocess" in e for e in result.errors)
+
+    def test_dangerous_eval_warning(self, validator, tmp_path):
+        """eval 호출은 경고."""
+        code = """
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        eval("1+1")
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert len(result.warnings) > 0
+        assert any("eval" in w for w in result.warnings)
+
+    def test_open_warning(self, validator, tmp_path):
+        """open 호출은 경고."""
+        code = """
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        open("file.txt")
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert len(result.warnings) > 0
+        assert any("open" in w for w in result.warnings)
+
+    def test_multiple_strategy_classes(self, validator, tmp_path):
+        """복수 Strategy 클래스는 실패."""
+        code = """
+class A(Strategy):
+    meta = None
+    async def on_step(self, context):
+        return []
+
+class B(Strategy):
+    meta = None
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("Multiple" in e for e in result.errors)
+
+
+# ── StrategyLoader ────────────────────────────────
+
+
+class TestStrategyLoader:
+    def test_load_valid_strategy(self, tmp_path):
+        """정상 전략 파일을 로드한다."""
+        code = """
+from ante.strategy.base import Strategy, StrategyMeta, Signal
+
+class MyStrategy(Strategy):
+    meta = StrategyMeta(name="my", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+"""
+        filepath = tmp_path / "my_strategy.py"
+        filepath.write_text(code)
+
+        cls = StrategyLoader.load(filepath)
+        assert cls.__name__ == "MyStrategy"
+        assert issubclass(cls, Strategy)
+
+    def test_load_no_strategy(self, tmp_path):
+        """Strategy 클래스가 없는 파일은 에러."""
+        filepath = tmp_path / "empty.py"
+        filepath.write_text("x = 1\n")
+
+        with pytest.raises(StrategyLoadError, match="No Strategy subclass"):
+            StrategyLoader.load(filepath)
+
+    def test_load_file_not_found(self, tmp_path):
+        """파일이 없으면 에러."""
+        with pytest.raises(StrategyLoadError, match="File not found"):
+            StrategyLoader.load(tmp_path / "nonexistent.py")
+
+    def test_load_syntax_error(self, tmp_path):
+        """문법 오류 파일은 에러."""
+        filepath = tmp_path / "broken.py"
+        filepath.write_text("def broken(\n")
+
+        with pytest.raises(StrategyLoadError, match="Failed to execute"):
+            StrategyLoader.load(filepath)
+
+
+# ── StrategyRegistry ──────────────────────────────
+
+
+class TestStrategyRegistry:
+    @pytest.fixture
+    async def db(self, tmp_path):
+        database = Database(str(tmp_path / "test.db"))
+        await database.connect()
+        yield database
+        await database.close()
+
+    @pytest.fixture
+    async def registry(self, db):
+        r = StrategyRegistry(db=db)
+        await r.initialize()
+        return r
+
+    @pytest.fixture
+    def meta(self):
+        return StrategyMeta(
+            name="momentum",
+            version="1.0.0",
+            description="test strategy",
+        )
+
+    async def test_register(self, registry, meta, tmp_path):
+        """전략을 등록한다."""
+        filepath = tmp_path / "test.py"
+        filepath.write_text("")
+
+        record = await registry.register(filepath, meta)
+        assert record.strategy_id == "momentum_v1.0.0"
+        assert record.status == StrategyStatus.REGISTERED
+
+    async def test_register_duplicate_raises(self, registry, meta, tmp_path):
+        """중복 등록 시 에러."""
+        filepath = tmp_path / "test.py"
+        filepath.write_text("")
+
+        await registry.register(filepath, meta)
+        with pytest.raises(StrategyError, match="already registered"):
+            await registry.register(filepath, meta)
+
+    async def test_get(self, registry, meta, tmp_path):
+        """전략 레코드를 조회한다."""
+        filepath = tmp_path / "test.py"
+        filepath.write_text("")
+
+        await registry.register(filepath, meta)
+        record = await registry.get("momentum_v1.0.0")
+        assert record is not None
+        assert record.name == "momentum"
+
+    async def test_get_nonexistent(self, registry):
+        """존재하지 않는 전략은 None."""
+        assert await registry.get("nonexistent") is None
+
+    async def test_list_strategies(self, registry, tmp_path):
+        """전략 목록을 조회한다."""
+        for i in range(3):
+            meta = StrategyMeta(name=f"stg{i}", version="1.0.0", description="test")
+            filepath = tmp_path / f"stg{i}.py"
+            filepath.write_text("")
+            await registry.register(filepath, meta)
+
+        result = await registry.list_strategies()
+        assert len(result) == 3
+
+    async def test_list_by_status(self, registry, meta, tmp_path):
+        """상태별 필터링 조회."""
+        filepath = tmp_path / "test.py"
+        filepath.write_text("")
+
+        await registry.register(filepath, meta)
+        await registry.update_status("momentum_v1.0.0", StrategyStatus.ACTIVE)
+
+        active = await registry.list_strategies(status=StrategyStatus.ACTIVE)
+        assert len(active) == 1
+
+        registered = await registry.list_strategies(status=StrategyStatus.REGISTERED)
+        assert len(registered) == 0
+
+    async def test_update_status(self, registry, meta, tmp_path):
+        """전략 상태를 변경한다."""
+        filepath = tmp_path / "test.py"
+        filepath.write_text("")
+
+        await registry.register(filepath, meta)
+        await registry.update_status("momentum_v1.0.0", StrategyStatus.ACTIVE)
+
+        record = await registry.get("momentum_v1.0.0")
+        assert record is not None
+        assert record.status == StrategyStatus.ACTIVE
+
+    async def test_exists(self, registry, meta, tmp_path):
+        """존재 여부 확인."""
+        assert not await registry.exists("momentum_v1.0.0")
+
+        filepath = tmp_path / "test.py"
+        filepath.write_text("")
+        await registry.register(filepath, meta)
+
+        assert await registry.exists("momentum_v1.0.0")


### PR DESCRIPTION
## Summary
- **Strategy ABC**: 라이프사이클 메서드 (on_start/stop/step/fill/data)
- **Signal/OrderAction**: 불변 시그널·주문액션 데이터 클래스
- **StrategyContext**: 전략용 샌드박스 API (데이터·포트폴리오·주문 조회)
- **StrategyValidator**: AST 기반 정적 검증 (금지 import, 위험 패턴)
- **StrategyLoader**: importlib 동적 로딩
- **StrategyRegistry**: SQLite 영속화 전략 레코드 관리
- **DataProvider/PortfolioView/OrderView**: 모드 독립 ABC

## Test plan
- [x] Signal 불변성 + 기본값 (2 tests)
- [x] Strategy ABC 인스턴스화 검증 (4 tests)
- [x] StrategyContext 데이터/포트폴리오/주문 (8 tests)
- [x] StrategyValidator 정적 검증 (10 tests)
- [x] StrategyLoader 동적 로딩 (4 tests)
- [x] StrategyRegistry CRUD (8 tests)
- [x] ruff check + ruff format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)