### PR TITLE
feat: implement Treasury module (Phase 2-3)

### DIFF
--- a/src/ante/treasury/__init__.py
+++ b/src/ante/treasury/__init__.py
@@ -1,0 +1,12 @@
+"""Treasury — 중앙 자금(예산) 관리."""
+
+from ante.treasury.exceptions import InsufficientFundsError, TreasuryError
+from ante.treasury.models import BotBudget
+from ante.treasury.treasury import Treasury
+
+__all__ = [
+    "BotBudget",
+    "InsufficientFundsError",
+    "Treasury",
+    "TreasuryError",
+]

--- a/src/ante/treasury/exceptions.py
+++ b/src/ante/treasury/exceptions.py
@@ -1,0 +1,13 @@
+"""Treasury 모듈 예외."""
+
+
+class TreasuryError(Exception):
+    """Treasury 기본 예외."""
+
+    pass
+
+
+class InsufficientFundsError(TreasuryError):
+    """자금 부족."""
+
+    pass

--- a/src/ante/treasury/models.py
+++ b/src/ante/treasury/models.py
@@ -1,0 +1,19 @@
+"""Treasury 데이터 모델."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+
+@dataclass
+class BotBudget:
+    """봇별 예산 상태."""
+
+    bot_id: str
+    allocated: float = 0.0
+    available: float = 0.0
+    reserved: float = 0.0
+    spent: float = 0.0
+    returned: float = 0.0
+    last_updated: datetime = field(default_factory=lambda: datetime.now(UTC))

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -1,0 +1,397 @@
+"""Treasury — 중앙 자금(예산) 관리."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from ante.treasury.models import BotBudget
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+TREASURY_SCHEMA = """
+CREATE TABLE IF NOT EXISTS bot_budgets (
+    bot_id       TEXT PRIMARY KEY,
+    allocated    REAL NOT NULL DEFAULT 0.0,
+    available    REAL NOT NULL DEFAULT 0.0,
+    reserved     REAL NOT NULL DEFAULT 0.0,
+    spent        REAL NOT NULL DEFAULT 0.0,
+    returned     REAL NOT NULL DEFAULT 0.0,
+    last_updated TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS treasury_transactions (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    bot_id           TEXT,
+    transaction_type TEXT NOT NULL,
+    amount           REAL NOT NULL,
+    description      TEXT DEFAULT '',
+    created_at       TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS treasury_state (
+    key   TEXT PRIMARY KEY,
+    value REAL NOT NULL
+);
+"""
+
+
+class Treasury:
+    """중앙 자금(예산) 관리자.
+
+    전체 계좌 잔고를 소유하고, 봇별로 예산을 배분하며,
+    예산 범위 내에서 거래가 이루어지도록 관리한다.
+    """
+
+    def __init__(
+        self,
+        db: Database,
+        eventbus: EventBus,
+        commission_rate: float = 0.00015,
+    ) -> None:
+        self._db = db
+        self._eventbus = eventbus
+        self._commission_rate = commission_rate
+
+        self._account_balance: float = 0.0
+        self._budgets: dict[str, BotBudget] = {}
+        self._unallocated: float = 0.0
+        self._reservations: dict[str, float] = {}
+
+    async def initialize(self) -> None:
+        """스키마 생성 + DB 복원 + EventBus 구독."""
+        await self._db.execute_script(TREASURY_SCHEMA)
+        await self._load_from_db()
+        self._subscribe_events()
+        logger.info("Treasury 초기화 완료")
+
+    def _subscribe_events(self) -> None:
+        """EventBus 이벤트 구독."""
+        from ante.eventbus.events import (
+            OrderCancelledEvent,
+            OrderFailedEvent,
+            OrderFilledEvent,
+            OrderValidatedEvent,
+        )
+
+        self._eventbus.subscribe(
+            OrderValidatedEvent, self._on_order_validated, priority=80
+        )
+        self._eventbus.subscribe(OrderFilledEvent, self._on_order_filled, priority=80)
+        self._eventbus.subscribe(
+            OrderCancelledEvent, self._on_order_cancelled, priority=80
+        )
+        self._eventbus.subscribe(OrderFailedEvent, self._on_order_failed, priority=80)
+
+    # ── 계좌 잔고 ───────────────────────────────────
+
+    async def set_account_balance(self, balance: float) -> None:
+        """계좌 잔고 설정. 미할당 자금을 자동 재계산."""
+        self._account_balance = balance
+        total_allocated = sum(b.allocated for b in self._budgets.values())
+        self._unallocated = balance - total_allocated
+        await self._save_state()
+        logger.info("계좌 잔고 설정: %s", balance)
+
+    @property
+    def account_balance(self) -> float:
+        return self._account_balance
+
+    @property
+    def unallocated(self) -> float:
+        return self._unallocated
+
+    # ── 예산 조회 ───────────────────────────────────
+
+    async def get_available(self, bot_id: str) -> float:
+        """봇의 가용 예산 조회."""
+        budget = self._budgets.get(bot_id)
+        return budget.available if budget else 0.0
+
+    async def get_budget(self, bot_id: str) -> BotBudget | None:
+        """봇의 예산 상태 조회."""
+        return self._budgets.get(bot_id)
+
+    # ── 예산 할당/회수 ──────────────────────────────
+
+    async def allocate(self, bot_id: str, amount: float) -> bool:
+        """봇에 예산 할당. 미할당 자금에서 차감."""
+        if amount <= 0 or self._unallocated < amount:
+            return False
+
+        if bot_id not in self._budgets:
+            self._budgets[bot_id] = BotBudget(bot_id=bot_id)
+
+        budget = self._budgets[bot_id]
+        budget.allocated += amount
+        budget.available += amount
+        budget.last_updated = datetime.now(UTC)
+        self._unallocated -= amount
+
+        await self._save_budget(budget)
+        await self._save_state()
+        await self._log_transaction(bot_id, "allocate", amount)
+        logger.info("예산 할당: %s → %s", bot_id, amount)
+        return True
+
+    async def deallocate(self, bot_id: str, amount: float) -> bool:
+        """봇에서 예산 회수. 가용 예산 범위 내에서만 가능."""
+        budget = self._budgets.get(bot_id)
+        if not budget or amount <= 0 or budget.available < amount:
+            return False
+
+        budget.allocated -= amount
+        budget.available -= amount
+        budget.last_updated = datetime.now(UTC)
+        self._unallocated += amount
+
+        await self._save_budget(budget)
+        await self._save_state()
+        await self._log_transaction(bot_id, "deallocate", amount)
+        logger.info("예산 회수: %s ← %s", bot_id, amount)
+        return True
+
+    # ── 주문 자금 예약/해제 ─────────────────────────
+
+    async def reserve_for_order(
+        self, bot_id: str, order_id: str, amount: float
+    ) -> bool:
+        """주문 제출 시 자금 예약."""
+        budget = self._budgets.get(bot_id)
+        if not budget or budget.available < amount:
+            return False
+
+        budget.available -= amount
+        budget.reserved += amount
+        budget.last_updated = datetime.now(UTC)
+        self._reservations[order_id] = amount
+
+        await self._save_budget(budget)
+        return True
+
+    async def release_reservation(self, bot_id: str, order_id: str) -> None:
+        """주문 취소/실패 시 예약 해제."""
+        budget = self._budgets.get(bot_id)
+        amount = self._reservations.pop(order_id, 0.0)
+        if not budget or amount <= 0:
+            return
+
+        budget.reserved = max(0.0, budget.reserved - amount)
+        budget.available += amount
+        budget.last_updated = datetime.now(UTC)
+
+        await self._save_budget(budget)
+
+    # ── 이벤트 핸들러 ───────────────────────────────
+
+    async def _on_order_validated(self, event: object) -> None:
+        """룰 검증 통과 후 자금 예약 → 승인/거부 발행."""
+        from ante.eventbus.events import (
+            OrderApprovedEvent,
+            OrderRejectedEvent,
+            OrderValidatedEvent,
+        )
+
+        if not isinstance(event, OrderValidatedEvent):
+            return
+
+        price = event.price or 0.0
+        estimated_cost = event.quantity * price
+        commission_estimate = estimated_cost * self._commission_rate
+        total_reserve = estimated_cost + commission_estimate
+
+        if event.side == "buy":
+            success = await self.reserve_for_order(
+                event.bot_id, event.order_id, total_reserve
+            )
+            if not success:
+                available = await self.get_available(event.bot_id)
+                await self._eventbus.publish(
+                    OrderRejectedEvent(
+                        order_id=event.order_id,
+                        bot_id=event.bot_id,
+                        strategy_id=event.strategy_id,
+                        symbol=event.symbol,
+                        side=event.side,
+                        quantity=event.quantity,
+                        price=event.price,
+                        order_type=event.order_type,
+                        reason=(
+                            f"insufficient_budget: need {total_reserve:,.0f}, "
+                            f"available {available:,.0f}"
+                        ),
+                    )
+                )
+                return
+
+        await self._eventbus.publish(
+            OrderApprovedEvent(
+                order_id=event.order_id,
+                bot_id=event.bot_id,
+                strategy_id=event.strategy_id,
+                symbol=event.symbol,
+                side=event.side,
+                quantity=event.quantity,
+                price=event.price,
+                order_type=event.order_type,
+                stop_price=event.stop_price,
+                reserved_amount=(total_reserve if event.side == "buy" else 0.0),
+            )
+        )
+
+    async def _on_order_filled(self, event: object) -> None:
+        """체결 이벤트 처리 — 예약 자금 정산."""
+        from ante.eventbus.events import OrderFilledEvent
+
+        if not isinstance(event, OrderFilledEvent):
+            return
+
+        budget = self._budgets.get(event.bot_id)
+        if not budget:
+            return
+
+        fill_value = event.quantity * event.price
+        commission = event.commission
+
+        if event.side == "buy":
+            reserved_amount = self._reservations.pop(event.order_id, 0.0)
+            actual_cost = fill_value + commission
+            budget.reserved = max(0.0, budget.reserved - reserved_amount)
+            budget.spent += actual_cost
+            surplus = reserved_amount - actual_cost
+            if surplus > 0:
+                budget.available += surplus
+        else:
+            actual_proceeds = fill_value - commission
+            budget.returned += actual_proceeds
+            budget.available += actual_proceeds
+
+        budget.last_updated = datetime.now(UTC)
+        await self._save_budget(budget)
+        await self._log_transaction(
+            bot_id=event.bot_id,
+            tx_type="fill",
+            amount=fill_value,
+            description=(
+                f"{event.side} {event.symbol} {event.quantity} @ {event.price:,.0f}"
+            ),
+        )
+
+    async def _on_order_cancelled(self, event: object) -> None:
+        """주문 취소 시 예약 해제."""
+        from ante.eventbus.events import OrderCancelledEvent
+
+        if not isinstance(event, OrderCancelledEvent):
+            return
+        await self.release_reservation(event.bot_id, event.order_id)
+
+    async def _on_order_failed(self, event: object) -> None:
+        """주문 실패 시 예약 해제."""
+        from ante.eventbus.events import OrderFailedEvent
+
+        if not isinstance(event, OrderFailedEvent):
+            return
+        await self.release_reservation(event.bot_id, event.order_id)
+
+    # ── 모니터링 ────────────────────────────────────
+
+    def get_summary(self) -> dict[str, Any]:
+        """자금 현황 요약."""
+        total_allocated = sum(b.allocated for b in self._budgets.values())
+        total_reserved = sum(b.reserved for b in self._budgets.values())
+
+        return {
+            "account_balance": self._account_balance,
+            "total_allocated": total_allocated,
+            "total_reserved": total_reserved,
+            "unallocated": self._unallocated,
+            "bot_count": len(self._budgets),
+        }
+
+    # ── DB 영속화 ───────────────────────────────────
+
+    async def _load_from_db(self) -> None:
+        """DB에서 자금 상태 복원."""
+        # 계좌 잔고
+        row = await self._db.fetch_one(
+            "SELECT value FROM treasury_state WHERE key = 'account_balance'"
+        )
+        if row:
+            self._account_balance = float(row["value"])
+
+        row = await self._db.fetch_one(
+            "SELECT value FROM treasury_state WHERE key = 'unallocated'"
+        )
+        if row:
+            self._unallocated = float(row["value"])
+
+        # 봇 예산
+        rows = await self._db.fetch_all("SELECT * FROM bot_budgets")
+        for r in rows:
+            self._budgets[r["bot_id"]] = BotBudget(
+                bot_id=r["bot_id"],
+                allocated=float(r["allocated"]),
+                available=float(r["available"]),
+                reserved=float(r["reserved"]),
+                spent=float(r["spent"]),
+                returned=float(r["returned"]),
+                last_updated=datetime.fromisoformat(r["last_updated"]),
+            )
+
+    async def _save_state(self) -> None:
+        """계좌 상태 저장."""
+        for key, value in [
+            ("account_balance", self._account_balance),
+            ("unallocated", self._unallocated),
+        ]:
+            await self._db.execute(
+                """INSERT INTO treasury_state (key, value)
+                   VALUES (?, ?)
+                   ON CONFLICT(key) DO UPDATE SET value = excluded.value""",
+                (key, value),
+            )
+
+    async def _save_budget(self, budget: BotBudget) -> None:
+        """봇 예산 저장."""
+        await self._db.execute(
+            """INSERT INTO bot_budgets
+               (bot_id, allocated, available, reserved,
+                spent, returned, last_updated)
+               VALUES (?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(bot_id) DO UPDATE SET
+                 allocated = excluded.allocated,
+                 available = excluded.available,
+                 reserved = excluded.reserved,
+                 spent = excluded.spent,
+                 returned = excluded.returned,
+                 last_updated = excluded.last_updated""",
+            (
+                budget.bot_id,
+                budget.allocated,
+                budget.available,
+                budget.reserved,
+                budget.spent,
+                budget.returned,
+                budget.last_updated.isoformat(),
+            ),
+        )
+
+    async def _log_transaction(
+        self,
+        bot_id: str,
+        tx_type: str,
+        amount: float,
+        description: str = "",
+    ) -> None:
+        """자금 거래 이력 기록."""
+        await self._db.execute(
+            """INSERT INTO treasury_transactions
+               (bot_id, transaction_type, amount, description)
+               VALUES (?, ?, ?, ?)""",
+            (bot_id, tx_type, amount, description),
+        )

--- a/tests/unit/test_treasury.py
+++ b/tests/unit/test_treasury.py
@@ -1,0 +1,386 @@
+"""Treasury 모듈 단위 테스트."""
+
+import pytest
+
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import (
+    OrderApprovedEvent,
+    OrderCancelledEvent,
+    OrderFailedEvent,
+    OrderFilledEvent,
+    OrderRejectedEvent,
+    OrderValidatedEvent,
+)
+from ante.treasury import BotBudget, Treasury
+
+# ── Fixtures ─────────────────────────────────────
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+async def treasury(db, eventbus):
+    t = Treasury(db=db, eventbus=eventbus, commission_rate=0.00015)
+    await t.initialize()
+    await t.set_account_balance(10_000_000.0)
+    return t
+
+
+# ── BotBudget 모델 ───────────────────────────────
+
+
+class TestBotBudget:
+    def test_defaults(self):
+        """BotBudget 기본값 확인."""
+        b = BotBudget(bot_id="bot1")
+        assert b.allocated == 0.0
+        assert b.available == 0.0
+        assert b.reserved == 0.0
+        assert b.spent == 0.0
+        assert b.returned == 0.0
+
+
+# ── 계좌 잔고 ───────────────────────────────────
+
+
+class TestAccountBalance:
+    async def test_set_account_balance(self, treasury):
+        """계좌 잔고 설정."""
+        assert treasury.account_balance == 10_000_000.0
+        assert treasury.unallocated == 10_000_000.0
+
+    async def test_unallocated_after_allocation(self, treasury):
+        """할당 후 미할당 자금 감소."""
+        await treasury.allocate("bot1", 3_000_000.0)
+        assert treasury.unallocated == 7_000_000.0
+
+    async def test_set_balance_recalculates_unallocated(self, treasury):
+        """잔고 재설정 시 미할당 재계산."""
+        await treasury.allocate("bot1", 3_000_000.0)
+        await treasury.set_account_balance(5_000_000.0)
+        assert treasury.unallocated == 2_000_000.0
+
+
+# ── 예산 할당/회수 ──────────────────────────────
+
+
+class TestAllocation:
+    async def test_allocate(self, treasury):
+        """예산 할당."""
+        result = await treasury.allocate("bot1", 1_000_000.0)
+        assert result is True
+        budget = await treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 1_000_000.0
+        assert budget.available == 1_000_000.0
+
+    async def test_allocate_insufficient(self, treasury):
+        """미할당 자금 부족 시 실패."""
+        result = await treasury.allocate("bot1", 20_000_000.0)
+        assert result is False
+
+    async def test_allocate_zero(self, treasury):
+        """0 이하 할당 실패."""
+        assert await treasury.allocate("bot1", 0) is False
+        assert await treasury.allocate("bot1", -100) is False
+
+    async def test_deallocate(self, treasury):
+        """예산 회수."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        result = await treasury.deallocate("bot1", 500_000.0)
+        assert result is True
+        budget = await treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 500_000.0
+        assert budget.available == 500_000.0
+        assert treasury.unallocated == 9_500_000.0
+
+    async def test_deallocate_exceeds_available(self, treasury):
+        """가용 예산 초과 회수 실패."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.reserve_for_order("bot1", "ord1", 800_000.0)
+        result = await treasury.deallocate("bot1", 500_000.0)
+        assert result is False
+
+    async def test_deallocate_nonexistent(self, treasury):
+        """존재하지 않는 봇 회수 실패."""
+        result = await treasury.deallocate("nonexistent", 100.0)
+        assert result is False
+
+    async def test_multiple_allocations(self, treasury):
+        """동일 봇에 추가 할당."""
+        await treasury.allocate("bot1", 500_000.0)
+        await treasury.allocate("bot1", 300_000.0)
+        budget = await treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 800_000.0
+        assert budget.available == 800_000.0
+
+
+# ── 주문 자금 예약/해제 ─────────────────────────
+
+
+class TestReservation:
+    async def test_reserve(self, treasury):
+        """자금 예약."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        result = await treasury.reserve_for_order("bot1", "ord1", 500_000.0)
+        assert result is True
+        budget = await treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.available == 500_000.0
+        assert budget.reserved == 500_000.0
+
+    async def test_reserve_insufficient(self, treasury):
+        """가용 예산 부족 시 예약 실패."""
+        await treasury.allocate("bot1", 100_000.0)
+        result = await treasury.reserve_for_order("bot1", "ord1", 500_000.0)
+        assert result is False
+
+    async def test_release_reservation(self, treasury):
+        """예약 해제."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.reserve_for_order("bot1", "ord1", 500_000.0)
+        await treasury.release_reservation("bot1", "ord1")
+        budget = await treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.available == 1_000_000.0
+        assert budget.reserved == 0.0
+
+    async def test_release_unknown_order(self, treasury):
+        """존재하지 않는 주문 해제는 무시."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.release_reservation("bot1", "unknown_ord")
+        budget = await treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.available == 1_000_000.0
+
+
+# ── EventBus 통합 ───────────────────────────────
+
+
+class TestTreasuryEvents:
+    async def test_validated_buy_approved(self, treasury, eventbus):
+        """매수 주문 검증 통과 → 자금 예약 → OrderApprovedEvent."""
+        await treasury.allocate("bot1", 1_000_000.0)
+
+        received = []
+        eventbus.subscribe(OrderApprovedEvent, lambda e: received.append(e))
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=50_000.0,
+                order_type="market",
+            )
+        )
+
+        assert len(received) == 1
+        assert received[0].order_id == "ord1"
+        assert received[0].reserved_amount > 0
+
+        budget = await treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.reserved > 0
+        assert budget.available < 1_000_000.0
+
+    async def test_validated_buy_insufficient_rejected(self, treasury, eventbus):
+        """매수 자금 부족 → OrderRejectedEvent."""
+        await treasury.allocate("bot1", 100.0)
+
+        received = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: received.append(e))
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=50_000.0,
+                order_type="market",
+            )
+        )
+
+        assert len(received) == 1
+        assert "insufficient_budget" in received[0].reason
+
+    async def test_validated_sell_approved_no_reserve(self, treasury, eventbus):
+        """매도 주문은 자금 예약 없이 승인."""
+        await treasury.allocate("bot1", 1_000_000.0)
+
+        received = []
+        eventbus.subscribe(OrderApprovedEvent, lambda e: received.append(e))
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="sell",
+                quantity=10.0,
+                price=50_000.0,
+                order_type="market",
+            )
+        )
+
+        assert len(received) == 1
+        assert received[0].reserved_amount == 0.0
+
+    async def test_buy_filled_settles_reservation(self, treasury, eventbus):
+        """매수 체결 시 예약 자금 정산."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.reserve_for_order("bot1", "ord1", 500_100.0)
+
+        await eventbus.publish(
+            OrderFilledEvent(
+                order_id="ord1",
+                broker_order_id="bk1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=50_000.0,
+                commission=75.0,
+                order_type="market",
+            )
+        )
+
+        budget = await treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.reserved == 0.0
+        assert budget.spent == 500_075.0  # 500,000 + 75
+        # available: 1M - 500,100 (reserved) + 25 (surplus) = 499,925
+        assert budget.available == pytest.approx(499_925.0)
+
+    async def test_sell_filled_returns_funds(self, treasury, eventbus):
+        """매도 체결 시 자금 회수."""
+        await treasury.allocate("bot1", 1_000_000.0)
+
+        await eventbus.publish(
+            OrderFilledEvent(
+                order_id="ord2",
+                broker_order_id="bk2",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="sell",
+                quantity=10.0,
+                price=55_000.0,
+                commission=82.5,
+                order_type="market",
+            )
+        )
+
+        budget = await treasury.get_budget("bot1")
+        assert budget is not None
+        expected_proceeds = 550_000.0 - 82.5
+        assert budget.returned == expected_proceeds
+        assert budget.available == 1_000_000.0 + expected_proceeds
+
+    async def test_order_cancelled_releases(self, treasury, eventbus):
+        """주문 취소 시 예약 해제."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.reserve_for_order("bot1", "ord1", 500_000.0)
+
+        await eventbus.publish(
+            OrderCancelledEvent(
+                order_id="ord1",
+                broker_order_id="bk1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=50_000.0,
+            )
+        )
+
+        budget = await treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.available == 1_000_000.0
+        assert budget.reserved == 0.0
+
+    async def test_order_failed_releases(self, treasury, eventbus):
+        """주문 실패 시 예약 해제."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.reserve_for_order("bot1", "ord1", 500_000.0)
+
+        await eventbus.publish(
+            OrderFailedEvent(
+                order_id="ord1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=50_000.0,
+                order_type="market",
+                error_message="broker error",
+            )
+        )
+
+        budget = await treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.available == 1_000_000.0
+        assert budget.reserved == 0.0
+
+
+# ── 모니터링 ────────────────────────────────────
+
+
+class TestTreasurySummary:
+    async def test_summary(self, treasury):
+        """자금 현황 요약."""
+        await treasury.allocate("bot1", 3_000_000.0)
+        await treasury.allocate("bot2", 2_000_000.0)
+
+        summary = treasury.get_summary()
+        assert summary["account_balance"] == 10_000_000.0
+        assert summary["total_allocated"] == 5_000_000.0
+        assert summary["unallocated"] == 5_000_000.0
+        assert summary["bot_count"] == 2
+
+
+# ── DB 영속화 ───────────────────────────────────
+
+
+class TestTreasuryPersistence:
+    async def test_persists_across_instances(self, db, eventbus):
+        """Treasury 재시작 후 상태 복원."""
+        t1 = Treasury(db=db, eventbus=eventbus)
+        await t1.initialize()
+        await t1.set_account_balance(5_000_000.0)
+        await t1.allocate("bot1", 2_000_000.0)
+
+        # 새 인스턴스 생성
+        t2 = Treasury(db=db, eventbus=eventbus)
+        await t2.initialize()
+
+        assert t2.account_balance == 5_000_000.0
+        assert t2.unallocated == 3_000_000.0
+        budget = await t2.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 2_000_000.0
+        assert budget.available == 2_000_000.0


### PR DESCRIPTION
## Summary
- 중앙 자금(예산) 관리 모듈: 계좌 잔고, 봇별 예산 할당/회수, 주문 자금 예약/해제, 체결 정산
- EventBus 통합: OrderValidated→Approved/Rejected, OrderFilled/Cancelled/Failed 정산
- SQLite 영속화: bot_budgets, treasury_transactions, treasury_state 테이블
- 24개 단위 테스트 (전체 153개 통과)

## Test plan
- [x] 24개 Treasury 단위 테스트 통과
- [x] 전체 153개 테스트 통과
- [x] ruff check + format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)