### PR TITLE
feat: implement Bot module (Phase 2-4)

### DIFF
--- a/src/ante/bot/__init__.py
+++ b/src/ante/bot/__init__.py
@@ -1,0 +1,14 @@
+"""Bot — 전략 실행 봇 관리."""
+
+from ante.bot.bot import Bot
+from ante.bot.config import BotConfig, BotStatus
+from ante.bot.exceptions import BotError
+from ante.bot.manager import BotManager
+
+__all__ = [
+    "Bot",
+    "BotConfig",
+    "BotError",
+    "BotManager",
+    "BotStatus",
+]

--- a/src/ante/bot/bot.py
+++ b/src/ante/bot/bot.py
@@ -1,0 +1,247 @@
+"""Bot — 전략을 실행하는 개별 봇."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from ante.bot.config import BotConfig, BotStatus
+
+if TYPE_CHECKING:
+    from ante.eventbus.bus import EventBus
+    from ante.strategy.base import Signal, Strategy
+    from ante.strategy.context import StrategyContext
+
+logger = logging.getLogger(__name__)
+
+
+class Bot:
+    """전략을 실행하는 개별 봇.
+
+    각 봇은 독립 asyncio.Task로 실행되며,
+    주기적으로 on_step()을 호출하여 Signal을 수집하고
+    OrderRequestEvent로 변환하여 EventBus에 발행한다.
+    """
+
+    def __init__(
+        self,
+        config: BotConfig,
+        strategy_cls: type[Strategy],
+        ctx: StrategyContext,
+        eventbus: EventBus,
+    ) -> None:
+        self.config = config
+        self.bot_id = config.bot_id
+        self._strategy_cls = strategy_cls
+        self._ctx = ctx
+        self._eventbus = eventbus
+
+        self.status = BotStatus.CREATED
+        self.strategy: Strategy | None = None
+        self._task: asyncio.Task[None] | None = None
+        self.started_at: datetime | None = None
+        self.stopped_at: datetime | None = None
+        self.error_message: str | None = None
+
+    async def start(self) -> None:
+        """봇 시작. 전략 인스턴스화 + 실행 루프 Task 생성."""
+        from ante.eventbus.events import BotStartedEvent
+
+        self.strategy = self._strategy_cls(ctx=self._ctx)
+        self.strategy.on_start()
+
+        self.status = BotStatus.RUNNING
+        self.started_at = datetime.now(UTC)
+        self._task = asyncio.create_task(
+            self._run_loop(),
+            name=f"bot_{self.bot_id}",
+        )
+
+        await self._eventbus.publish(BotStartedEvent(bot_id=self.bot_id))
+        logger.info("봇 시작: %s", self.bot_id)
+
+    async def stop(self) -> None:
+        """봇 중지. 실행 루프 취소 + 전략 정리."""
+        from ante.eventbus.events import BotStoppedEvent
+
+        if self.status != BotStatus.RUNNING:
+            return
+
+        self.status = BotStatus.STOPPING
+
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+        if self.strategy:
+            self.strategy.on_stop()
+
+        self.status = BotStatus.STOPPED
+        self.stopped_at = datetime.now(UTC)
+
+        await self._eventbus.publish(BotStoppedEvent(bot_id=self.bot_id))
+        logger.info("봇 중지: %s", self.bot_id)
+
+    async def _run_loop(self) -> None:
+        """메인 실행 루프."""
+        from ante.eventbus.events import BotErrorEvent
+
+        try:
+            while self.status == BotStatus.RUNNING:
+                step_context = {
+                    "timestamp": datetime.now(UTC),
+                    "portfolio": self._ctx.get_positions(),
+                    "balance": self._ctx.get_balance(),
+                }
+
+                signals = await self.strategy.on_step(step_context)  # type: ignore[union-attr]
+                await self._publish_signals(signals)
+
+                actions = self._ctx._drain_actions()
+                await self._publish_actions(actions)
+
+                await asyncio.sleep(self.config.interval_seconds)
+
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self.status = BotStatus.ERROR
+            self.error_message = str(e)
+            logger.exception("봇 오류: %s", self.bot_id)
+            await self._eventbus.publish(
+                BotErrorEvent(
+                    bot_id=self.bot_id,
+                    error_message=str(e),
+                )
+            )
+
+    async def on_order_filled(self, event: object) -> None:
+        """체결 통보를 전략에 전달."""
+        from ante.eventbus.events import OrderFilledEvent
+
+        if not isinstance(event, OrderFilledEvent):
+            return
+        if not self.strategy or event.bot_id != self.bot_id:
+            return
+
+        follow_up = await self.strategy.on_fill(
+            {
+                "order_id": event.order_id,
+                "symbol": event.symbol,
+                "side": event.side,
+                "quantity": event.quantity,
+                "price": event.price,
+                "timestamp": event.timestamp,
+            }
+        )
+        await self._publish_signals(follow_up or [])
+
+    async def on_order_update(self, event: object) -> None:
+        """주문 상태 변경 통보를 전략에 전달."""
+        from ante.eventbus.events import (
+            OrderCancelledEvent,
+            OrderFailedEvent,
+            OrderRejectedEvent,
+            OrderSubmittedEvent,
+        )
+
+        bot_id = getattr(event, "bot_id", None)
+        if not self.strategy or bot_id != self.bot_id:
+            return
+
+        update: dict[str, Any] = {}
+        if isinstance(event, OrderSubmittedEvent):
+            update = {
+                "order_id": event.order_id,
+                "status": "submitted",
+                "symbol": event.symbol,
+                "side": event.side,
+            }
+        elif isinstance(event, OrderRejectedEvent):
+            update = {
+                "order_id": event.order_id,
+                "status": "rejected",
+                "symbol": event.symbol,
+                "side": event.side,
+                "reason": event.reason,
+            }
+        elif isinstance(event, OrderCancelledEvent):
+            update = {
+                "order_id": event.order_id,
+                "status": "cancelled",
+                "symbol": event.symbol,
+                "side": event.side,
+                "reason": event.reason,
+            }
+        elif isinstance(event, OrderFailedEvent):
+            update = {
+                "order_id": event.order_id,
+                "status": "failed",
+                "symbol": event.symbol,
+                "side": event.side,
+                "reason": event.error_message,
+            }
+
+        if update:
+            await self.strategy.on_order_update(update)
+
+    async def _publish_signals(self, signals: list[Signal]) -> None:
+        """Signal → OrderRequestEvent 변환 + EventBus 발행."""
+        from ante.eventbus.events import OrderRequestEvent
+
+        for signal in signals:
+            await self._eventbus.publish(
+                OrderRequestEvent(
+                    bot_id=self.bot_id,
+                    strategy_id=self.config.strategy_id,
+                    symbol=signal.symbol,
+                    side=signal.side,
+                    quantity=signal.quantity,
+                    order_type=signal.order_type,
+                    price=signal.price,
+                    stop_price=signal.stop_price,
+                    reason=signal.reason,
+                )
+            )
+
+    async def _publish_actions(self, actions: list[Any]) -> None:
+        """OrderAction → EventBus 이벤트 변환."""
+        from ante.eventbus.events import OrderCancelEvent, OrderModifyEvent
+
+        for action in actions:
+            if action.action == "cancel":
+                await self._eventbus.publish(
+                    OrderCancelEvent(
+                        bot_id=self.bot_id,
+                        order_id=action.order_id,
+                        reason=action.reason,
+                    )
+                )
+            elif action.action == "modify":
+                await self._eventbus.publish(
+                    OrderModifyEvent(
+                        bot_id=self.bot_id,
+                        order_id=action.order_id,
+                        quantity=action.quantity or 0.0,
+                        price=action.price,
+                        reason=action.reason,
+                    )
+                )
+
+    def get_info(self) -> dict[str, Any]:
+        """봇 상태 정보 반환."""
+        return {
+            "bot_id": self.bot_id,
+            "status": self.status.value,
+            "bot_type": self.config.bot_type,
+            "strategy_id": self.config.strategy_id,
+            "interval_seconds": self.config.interval_seconds,
+            "started_at": (self.started_at.isoformat() if self.started_at else None),
+            "stopped_at": (self.stopped_at.isoformat() if self.stopped_at else None),
+            "error_message": self.error_message,
+        }

--- a/src/ante/bot/config.py
+++ b/src/ante/bot/config.py
@@ -1,0 +1,28 @@
+"""Bot 설정 및 상태 정의."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class BotStatus(StrEnum):
+    """봇 상태."""
+
+    CREATED = "created"
+    RUNNING = "running"
+    STOPPING = "stopping"
+    STOPPED = "stopped"
+    ERROR = "error"
+
+
+@dataclass
+class BotConfig:
+    """봇 설정."""
+
+    bot_id: str
+    strategy_id: str
+    bot_type: str = "live"
+    interval_seconds: int = 60
+    symbols: list[str] | None = None
+    paper_initial_balance: float = 10_000_000.0

--- a/src/ante/bot/exceptions.py
+++ b/src/ante/bot/exceptions.py
@@ -1,0 +1,7 @@
+"""Bot 모듈 예외."""
+
+
+class BotError(Exception):
+    """Bot 기본 예외."""
+
+    pass

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -1,0 +1,218 @@
+"""BotManager — 봇 생명주기 중앙 관리."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from ante.bot.bot import Bot
+from ante.bot.config import BotConfig, BotStatus
+from ante.bot.exceptions import BotError
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+    from ante.strategy.base import Strategy
+    from ante.strategy.context import StrategyContext
+
+logger = logging.getLogger(__name__)
+
+BOT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS bots (
+    bot_id       TEXT PRIMARY KEY,
+    strategy_id  TEXT NOT NULL,
+    bot_type     TEXT NOT NULL DEFAULT 'live',
+    config_json  TEXT NOT NULL,
+    auto_start   BOOLEAN DEFAULT 0,
+    status       TEXT DEFAULT 'created',
+    created_at   TEXT DEFAULT (datetime('now')),
+    updated_at   TEXT DEFAULT (datetime('now'))
+);
+"""
+
+
+class BotManager:
+    """봇들의 생명주기를 중앙 관리."""
+
+    def __init__(
+        self,
+        eventbus: EventBus,
+        db: Database,
+    ) -> None:
+        self._eventbus = eventbus
+        self._db = db
+        self._bots: dict[str, Bot] = {}
+
+    async def initialize(self) -> None:
+        """스키마 생성 + EventBus 구독."""
+        await self._db.execute_script(BOT_SCHEMA)
+        self._subscribe_events()
+        logger.info("BotManager 초기화 완료")
+
+    def _subscribe_events(self) -> None:
+        """시스템 이벤트 구독."""
+        from ante.eventbus.events import BotStopEvent, TradingStateChangedEvent
+
+        self._eventbus.subscribe(BotStopEvent, self._on_bot_stop_request)
+        self._eventbus.subscribe(
+            TradingStateChangedEvent, self._on_trading_state_changed
+        )
+
+    async def create_bot(
+        self,
+        config: BotConfig,
+        strategy_cls: type[Strategy],
+        ctx: StrategyContext,
+    ) -> Bot:
+        """봇 생성. 전략 클래스와 StrategyContext를 직접 주입받는다."""
+        if config.bot_id in self._bots:
+            raise BotError(f"Bot already exists: {config.bot_id}")
+
+        bot = Bot(
+            config=config,
+            strategy_cls=strategy_cls,
+            ctx=ctx,
+            eventbus=self._eventbus,
+        )
+
+        self._register_bot_events(bot)
+        self._bots[config.bot_id] = bot
+        await self._save_bot_config(config)
+
+        logger.info("봇 생성: %s (전략: %s)", config.bot_id, config.strategy_id)
+        return bot
+
+    async def start_bot(self, bot_id: str) -> None:
+        """봇 시작."""
+        bot = self._get_bot(bot_id)
+        await bot.start()
+
+    async def stop_bot(self, bot_id: str) -> None:
+        """봇 중지."""
+        bot = self._get_bot(bot_id)
+        await bot.stop()
+
+    async def remove_bot(self, bot_id: str) -> None:
+        """봇 삭제. 실행 중이면 먼저 중지."""
+        bot = self._get_bot(bot_id)
+        if bot.status == BotStatus.RUNNING:
+            await bot.stop()
+
+        self._unregister_bot_events(bot)
+        del self._bots[bot_id]
+        await self._db.execute("DELETE FROM bots WHERE bot_id = ?", (bot_id,))
+        logger.info("봇 삭제: %s", bot_id)
+
+    async def stop_all(self) -> None:
+        """모든 봇 중지."""
+        tasks = [
+            bot.stop() for bot in self._bots.values() if bot.status == BotStatus.RUNNING
+        ]
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        logger.info("전체 봇 중지 완료")
+
+    def list_bots(self) -> list[dict[str, Any]]:
+        """봇 목록 조회."""
+        return [bot.get_info() for bot in self._bots.values()]
+
+    def get_bot(self, bot_id: str) -> Bot | None:
+        """봇 조회. 없으면 None."""
+        return self._bots.get(bot_id)
+
+    def _get_bot(self, bot_id: str) -> Bot:
+        """봇 조회. 없으면 예외."""
+        bot = self._bots.get(bot_id)
+        if bot is None:
+            raise BotError(f"Bot not found: {bot_id}")
+        return bot
+
+    # ── EventBus 핸들러 ──────────────────────────────
+
+    async def _on_bot_stop_request(self, event: object) -> None:
+        """BotStopEvent 수신 시 해당 봇 중지."""
+        from ante.eventbus.events import BotStopEvent
+
+        if not isinstance(event, BotStopEvent):
+            return
+        if event.bot_id in self._bots:
+            await self.stop_bot(event.bot_id)
+
+    async def _on_trading_state_changed(self, event: object) -> None:
+        """킬 스위치 HALTED 시 전체 봇 중지."""
+        from ante.eventbus.events import TradingStateChangedEvent
+
+        if not isinstance(event, TradingStateChangedEvent):
+            return
+        if event.new_state == "halted":
+            logger.warning("시스템 HALTED — 전체 봇 중지")
+            await self.stop_all()
+
+    # ── 봇 이벤트 구독 관리 ──────────────────────────
+
+    def _register_bot_events(self, bot: Bot) -> None:
+        """봇의 이벤트 핸들러 등록."""
+        from ante.eventbus.events import (
+            OrderCancelledEvent,
+            OrderFailedEvent,
+            OrderFilledEvent,
+            OrderRejectedEvent,
+            OrderSubmittedEvent,
+        )
+
+        self._eventbus.subscribe(OrderFilledEvent, bot.on_order_filled)
+        for event_type in (
+            OrderSubmittedEvent,
+            OrderRejectedEvent,
+            OrderCancelledEvent,
+            OrderFailedEvent,
+        ):
+            self._eventbus.subscribe(event_type, bot.on_order_update)
+
+    def _unregister_bot_events(self, bot: Bot) -> None:
+        """봇의 이벤트 핸들러 해제."""
+        from ante.eventbus.events import (
+            OrderCancelledEvent,
+            OrderFailedEvent,
+            OrderFilledEvent,
+            OrderRejectedEvent,
+            OrderSubmittedEvent,
+        )
+
+        self._eventbus.unsubscribe(OrderFilledEvent, bot.on_order_filled)
+        for event_type in (
+            OrderSubmittedEvent,
+            OrderRejectedEvent,
+            OrderCancelledEvent,
+            OrderFailedEvent,
+        ):
+            self._eventbus.unsubscribe(event_type, bot.on_order_update)
+
+    # ── DB ───────────────────────────────────────────
+
+    async def _save_bot_config(self, config: BotConfig) -> None:
+        """봇 설정 DB 저장."""
+        config_dict = {
+            "bot_id": config.bot_id,
+            "strategy_id": config.strategy_id,
+            "bot_type": config.bot_type,
+            "interval_seconds": config.interval_seconds,
+            "symbols": config.symbols,
+            "paper_initial_balance": config.paper_initial_balance,
+        }
+        await self._db.execute(
+            """INSERT INTO bots
+               (bot_id, strategy_id, bot_type, config_json)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(bot_id) DO UPDATE SET
+                 config_json = excluded.config_json,
+                 updated_at = datetime('now')""",
+            (
+                config.bot_id,
+                config.strategy_id,
+                config.bot_type,
+                json.dumps(config_dict),
+            ),
+        )

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -1,0 +1,530 @@
+"""Bot 모듈 단위 테스트."""
+
+import asyncio
+
+import pytest
+
+from ante.bot import Bot, BotConfig, BotError, BotManager, BotStatus
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import (
+    BotErrorEvent,
+    BotStartedEvent,
+    BotStopEvent,
+    BotStoppedEvent,
+    OrderCancelEvent,
+    OrderFilledEvent,
+    OrderRejectedEvent,
+    OrderRequestEvent,
+    TradingStateChangedEvent,
+)
+from ante.strategy import (
+    DataProvider,
+    OrderView,
+    PortfolioView,
+    Signal,
+    Strategy,
+    StrategyContext,
+    StrategyMeta,
+)
+
+# ── Fake 구현체 ──────────────────────────────────
+
+
+class FakeDataProvider(DataProvider):
+    async def get_ohlcv(self, symbol, timeframe="1d", limit=100):
+        return [{"close": 100.0}]
+
+    async def get_current_price(self, symbol):
+        return 100.0
+
+    async def get_indicator(self, symbol, indicator, params=None):
+        return {}
+
+
+class FakePortfolioView(PortfolioView):
+    def get_positions(self, bot_id):
+        return {}
+
+    def get_balance(self, bot_id):
+        return {"total": 1000000.0, "available": 500000.0}
+
+
+class FakeOrderView(OrderView):
+    def get_open_orders(self, bot_id):
+        return []
+
+
+class SimpleStrategy(Strategy):
+    """테스트용 간단한 전략."""
+
+    meta = StrategyMeta(name="simple", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+
+
+class BuyStrategy(Strategy):
+    """매수 시그널을 반환하는 전략."""
+
+    meta = StrategyMeta(name="buy", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return [
+            Signal(
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                reason="test buy",
+            )
+        ]
+
+
+class ErrorStrategy(Strategy):
+    """에러를 발생시키는 전략."""
+
+    meta = StrategyMeta(name="error", version="1.0.0", description="test")
+    call_count = 0
+
+    async def on_step(self, context):
+        ErrorStrategy.call_count += 1
+        raise RuntimeError("strategy error")
+
+
+class FillReactStrategy(Strategy):
+    """체결 시 후속 시그널을 반환하는 전략."""
+
+    meta = StrategyMeta(name="fill_react", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+
+    async def on_fill(self, fill):
+        return [
+            Signal(
+                symbol=fill["symbol"],
+                side="sell",
+                quantity=fill["quantity"],
+                reason="stop loss after fill",
+            )
+        ]
+
+
+# ── Fixtures ─────────────────────────────────────
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+def ctx():
+    return StrategyContext(
+        bot_id="bot1",
+        data_provider=FakeDataProvider(),
+        portfolio=FakePortfolioView(),
+        order_view=FakeOrderView(),
+    )
+
+
+@pytest.fixture
+def simple_config():
+    return BotConfig(
+        bot_id="bot1",
+        strategy_id="simple_v1.0.0",
+        interval_seconds=0,  # 테스트용: 즉시 반복
+    )
+
+
+# ── BotConfig / BotStatus ────────────────────────
+
+
+class TestBotConfig:
+    def test_defaults(self):
+        """BotConfig 기본값."""
+        c = BotConfig(bot_id="b1", strategy_id="s1")
+        assert c.bot_type == "live"
+        assert c.interval_seconds == 60
+
+    def test_bot_status_values(self):
+        """BotStatus 값."""
+        assert BotStatus.CREATED == "created"
+        assert BotStatus.RUNNING == "running"
+        assert BotStatus.ERROR == "error"
+
+
+# ── Bot 생명주기 ─────────────────────────────────
+
+
+class TestBot:
+    async def test_start_publishes_event(self, eventbus, ctx, simple_config):
+        """봇 시작 시 BotStartedEvent 발행."""
+        received = []
+        eventbus.subscribe(BotStartedEvent, lambda e: received.append(e))
+
+        bot = Bot(
+            config=simple_config,
+            strategy_cls=SimpleStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        await bot.start()
+        assert bot.status == BotStatus.RUNNING
+        assert len(received) == 1
+        assert received[0].bot_id == "bot1"
+
+        await bot.stop()
+
+    async def test_stop_publishes_event(self, eventbus, ctx, simple_config):
+        """봇 중지 시 BotStoppedEvent 발행."""
+        received = []
+        eventbus.subscribe(BotStoppedEvent, lambda e: received.append(e))
+
+        bot = Bot(
+            config=simple_config,
+            strategy_cls=SimpleStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        await bot.start()
+        await bot.stop()
+
+        assert bot.status == BotStatus.STOPPED
+        assert len(received) == 1
+
+    async def test_stop_idempotent(self, eventbus, ctx, simple_config):
+        """이미 중지된 봇은 다시 중지해도 무시."""
+        bot = Bot(
+            config=simple_config,
+            strategy_cls=SimpleStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        await bot.start()
+        await bot.stop()
+        await bot.stop()  # 두 번째 호출은 무시
+        assert bot.status == BotStatus.STOPPED
+
+    async def test_signal_to_order_event(self, eventbus, ctx):
+        """전략 Signal → OrderRequestEvent 변환."""
+        config = BotConfig(
+            bot_id="bot1",
+            strategy_id="buy_v1.0.0",
+            interval_seconds=0,
+        )
+        received = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: received.append(e))
+
+        bot = Bot(
+            config=config,
+            strategy_cls=BuyStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        await bot.start()
+        # 루프가 한 번 실행될 시간을 줌
+        await asyncio.sleep(0.05)
+        await bot.stop()
+
+        assert len(received) >= 1
+        assert received[0].symbol == "005930"
+        assert received[0].side == "buy"
+        assert received[0].quantity == 10.0
+        assert received[0].bot_id == "bot1"
+
+    async def test_error_isolation(self, eventbus, ctx):
+        """전략 에러 시 봇만 ERROR 상태로 전환."""
+        config = BotConfig(
+            bot_id="bot1",
+            strategy_id="error_v1.0.0",
+            interval_seconds=0,
+        )
+        received = []
+        eventbus.subscribe(BotErrorEvent, lambda e: received.append(e))
+
+        ErrorStrategy.call_count = 0
+        bot = Bot(
+            config=config,
+            strategy_cls=ErrorStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        await bot.start()
+        await asyncio.sleep(0.05)
+
+        assert bot.status == BotStatus.ERROR
+        assert bot.error_message == "strategy error"
+        assert len(received) >= 1
+
+    async def test_on_order_filled(self, eventbus, ctx, simple_config):
+        """체결 통보 → 전략 on_fill() 호출 → 후속 Signal 발행."""
+        config = BotConfig(
+            bot_id="bot1",
+            strategy_id="fill_react_v1.0.0",
+            interval_seconds=999,  # 루프 호출 방지
+        )
+        received = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: received.append(e))
+
+        bot = Bot(
+            config=config,
+            strategy_cls=FillReactStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        await bot.start()
+
+        # 체결 이벤트 전달
+        await bot.on_order_filled(
+            OrderFilledEvent(
+                order_id="ord1",
+                broker_order_id="bk1",
+                bot_id="bot1",
+                strategy_id="fill_react_v1.0.0",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=50000.0,
+                order_type="market",
+            )
+        )
+
+        assert len(received) == 1
+        assert received[0].side == "sell"
+        assert received[0].reason == "stop loss after fill"
+
+        await bot.stop()
+
+    async def test_on_order_filled_ignores_other_bot(
+        self, eventbus, ctx, simple_config
+    ):
+        """다른 봇의 체결 이벤트는 무시."""
+        received = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: received.append(e))
+
+        bot = Bot(
+            config=simple_config,
+            strategy_cls=FillReactStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        await bot.start()
+
+        await bot.on_order_filled(
+            OrderFilledEvent(
+                order_id="ord1",
+                broker_order_id="bk1",
+                bot_id="other_bot",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=50000.0,
+                order_type="market",
+            )
+        )
+
+        assert len(received) == 0
+        await bot.stop()
+
+    async def test_on_order_update_rejected(self, eventbus, ctx, simple_config):
+        """주문 거부 통보 → 전략 on_order_update() 호출."""
+        updates = []
+
+        class TrackStrategy(Strategy):
+            meta = StrategyMeta(name="t", version="1.0.0", description="t")
+
+            async def on_step(self, context):
+                return []
+
+            async def on_order_update(self, update):
+                updates.append(update)
+
+        bot = Bot(
+            config=simple_config,
+            strategy_cls=TrackStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        await bot.start()
+
+        await bot.on_order_update(
+            OrderRejectedEvent(
+                order_id="ord1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                order_type="market",
+                reason="insufficient funds",
+            )
+        )
+
+        assert len(updates) == 1
+        assert updates[0]["status"] == "rejected"
+        assert updates[0]["reason"] == "insufficient funds"
+
+        await bot.stop()
+
+    async def test_drain_actions_cancel(self, eventbus, ctx, simple_config):
+        """전략이 cancel_order() → OrderCancelEvent 발행."""
+
+        class CancelStrategy(Strategy):
+            meta = StrategyMeta(name="c", version="1.0.0", description="c")
+
+            async def on_step(self, context):
+                self.ctx.cancel_order("ord1", reason="test cancel")
+                return []
+
+        received = []
+        eventbus.subscribe(OrderCancelEvent, lambda e: received.append(e))
+
+        bot = Bot(
+            config=BotConfig(
+                bot_id="bot1",
+                strategy_id="c_v1.0.0",
+                interval_seconds=0,
+            ),
+            strategy_cls=CancelStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        await bot.start()
+        await asyncio.sleep(0.05)
+        await bot.stop()
+
+        assert len(received) >= 1
+        assert received[0].order_id == "ord1"
+        assert received[0].reason == "test cancel"
+
+    def test_get_info(self, eventbus, ctx, simple_config):
+        """봇 상태 정보 반환."""
+        bot = Bot(
+            config=simple_config,
+            strategy_cls=SimpleStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        info = bot.get_info()
+        assert info["bot_id"] == "bot1"
+        assert info["status"] == "created"
+
+
+# ── BotManager ───────────────────────────────────
+
+
+class TestBotManager:
+    @pytest.fixture
+    async def db(self, tmp_path):
+        database = Database(str(tmp_path / "test.db"))
+        await database.connect()
+        yield database
+        await database.close()
+
+    @pytest.fixture
+    async def manager(self, eventbus, db):
+        m = BotManager(eventbus=eventbus, db=db)
+        await m.initialize()
+        return m
+
+    async def test_create_bot(self, manager, eventbus, ctx):
+        """봇 생성."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        bot = await manager.create_bot(config, SimpleStrategy, ctx)
+        assert bot.status == BotStatus.CREATED
+        assert manager.get_bot("bot1") is bot
+
+    async def test_create_duplicate_raises(self, manager, eventbus, ctx):
+        """중복 봇 생성 시 에러."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        with pytest.raises(BotError, match="already exists"):
+            await manager.create_bot(config, SimpleStrategy, ctx)
+
+    async def test_start_and_stop(self, manager, eventbus, ctx):
+        """봇 시작/중지."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+        assert manager.get_bot("bot1").status == BotStatus.RUNNING
+
+        await manager.stop_bot("bot1")
+        assert manager.get_bot("bot1").status == BotStatus.STOPPED
+
+    async def test_remove_bot(self, manager, eventbus, ctx):
+        """봇 삭제."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.remove_bot("bot1")
+        assert manager.get_bot("bot1") is None
+
+    async def test_stop_all(self, manager, eventbus):
+        """전체 봇 중지."""
+        for i in range(3):
+            ctx = StrategyContext(
+                bot_id=f"bot{i}",
+                data_provider=FakeDataProvider(),
+                portfolio=FakePortfolioView(),
+                order_view=FakeOrderView(),
+            )
+            config = BotConfig(
+                bot_id=f"bot{i}",
+                strategy_id="s1",
+                interval_seconds=999,
+            )
+            await manager.create_bot(config, SimpleStrategy, ctx)
+            await manager.start_bot(f"bot{i}")
+
+        await manager.stop_all()
+        for i in range(3):
+            assert manager.get_bot(f"bot{i}").status == BotStatus.STOPPED
+
+    async def test_list_bots(self, manager, eventbus, ctx):
+        """봇 목록 조회."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        bots = manager.list_bots()
+        assert len(bots) == 1
+        assert bots[0]["bot_id"] == "bot1"
+
+    async def test_bot_stop_event(self, manager, eventbus, ctx):
+        """BotStopEvent 수신 시 봇 중지."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+
+        await eventbus.publish(BotStopEvent(bot_id="bot1", reason="rule violation"))
+
+        assert manager.get_bot("bot1").status == BotStatus.STOPPED
+
+    async def test_halt_stops_all(self, manager, eventbus, ctx):
+        """TradingStateChanged → HALTED 시 전체 봇 중지."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+
+        await eventbus.publish(
+            TradingStateChangedEvent(
+                old_state="active",
+                new_state="halted",
+                reason="critical",
+            )
+        )
+
+        assert manager.get_bot("bot1").status == BotStatus.STOPPED
+
+    async def test_not_found_raises(self, manager):
+        """존재하지 않는 봇 시작 시 에러."""
+        with pytest.raises(BotError, match="not found"):
+            await manager.start_bot("nonexistent")
+
+    async def test_bot_config_persisted(self, manager, eventbus, ctx, db):
+        """봇 설정이 DB에 저장됨."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        row = await db.fetch_one("SELECT * FROM bots WHERE bot_id = 'bot1'")
+        assert row is not None
+        assert row["strategy_id"] == "s1"


### PR DESCRIPTION
## Summary
- Bot: 전략 실행 루프 (on_step → Signal → OrderRequestEvent), 봇 단위 예외 격리 (독립 asyncio.Task)
- BotManager: 봇 생명주기 관리 (create/start/stop/remove/stop_all)
- EventBus 통합: BotStopEvent, TradingStateChanged → HALTED 시 전체 중지
- OrderFilledEvent → 전략 on_fill() 후속 Signal 발행
- OrderRejected/Cancelled/Failed/Submitted → 전략 on_order_update() 통보
- SQLite에 봇 설정 영속화

## Test plan
- [x] 22개 Bot 단위 테스트 통과
- [x] 전체 175개 테스트 통과
- [x] ruff check + format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)