### PR TITLE
feat: implement Broker Adapter module (Phase 3-1/3-2)

### DIFF
--- a/src/ante/broker/__init__.py
+++ b/src/ante/broker/__init__.py
@@ -1,0 +1,23 @@
+"""Broker Adapter — 증권사 API 추상화 및 구현체."""
+
+from ante.broker.base import BrokerAdapter
+from ante.broker.exceptions import (
+    APIError,
+    AuthenticationError,
+    BrokerError,
+    OrderNotFoundError,
+    RateLimitError,
+)
+from ante.broker.kis import KISAdapter
+from ante.broker.order_registry import OrderRegistry
+
+__all__ = [
+    "BrokerAdapter",
+    "KISAdapter",
+    "OrderRegistry",
+    "BrokerError",
+    "AuthenticationError",
+    "APIError",
+    "OrderNotFoundError",
+    "RateLimitError",
+]

--- a/src/ante/broker/base.py
+++ b/src/ante/broker/base.py
@@ -1,0 +1,153 @@
+"""BrokerAdapter 추상 기본 클래스.
+
+모든 증권사 구현체는 이 ABC를 상속한다.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
+from typing import Any
+
+
+class BrokerAdapter(ABC):
+    """증권사 API 어댑터 추상 기본 클래스."""
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        self.config = config
+        self.is_connected: bool = False
+
+    @abstractmethod
+    async def connect(self) -> None:
+        """API 연결 및 인증."""
+        ...
+
+    @abstractmethod
+    async def disconnect(self) -> None:
+        """연결 해제."""
+        ...
+
+    @abstractmethod
+    async def get_account_balance(self) -> dict[str, float]:
+        """계좌 잔고 조회.
+
+        Returns:
+            {"cash": float, "total_assets": float, ...}
+        """
+        ...
+
+    @abstractmethod
+    async def get_positions(self) -> list[dict[str, Any]]:
+        """보유 포지션 조회.
+
+        Returns:
+            [{"symbol": str, "quantity": float, "avg_price": float, ...}, ...]
+        """
+        ...
+
+    @abstractmethod
+    async def get_current_price(self, symbol: str) -> float:
+        """현재가 조회."""
+        ...
+
+    @abstractmethod
+    async def place_order(
+        self,
+        symbol: str,
+        side: str,
+        quantity: float,
+        order_type: str = "market",
+        price: float | None = None,
+        stop_price: float | None = None,
+    ) -> str:
+        """주문 접수.
+
+        Args:
+            symbol: 종목코드
+            side: "buy" | "sell"
+            quantity: 주문 수량
+            order_type: "market" | "limit"
+            price: 지정가 주문 시 가격
+            stop_price: stop 주문 가격 (브로커가 지원하는 경우)
+
+        Returns:
+            증권사 주문번호 (broker_order_id)
+        """
+        ...
+
+    @abstractmethod
+    async def cancel_order(self, order_id: str) -> bool:
+        """주문 취소.
+
+        Returns:
+            성공 여부
+        """
+        ...
+
+    @abstractmethod
+    async def get_order_status(self, order_id: str) -> dict[str, Any]:
+        """주문 상태 조회.
+
+        Returns:
+            {"order_id": str, "symbol": str, "side": str, "status": str, ...}
+        """
+        ...
+
+    @abstractmethod
+    async def get_pending_orders(self) -> list[dict[str, Any]]:
+        """미체결 주문 목록 조회."""
+        ...
+
+    @abstractmethod
+    async def realtime_price_stream(
+        self, symbols: list[str]
+    ) -> AsyncIterator[dict[str, Any]]:
+        """실시간 가격 스트리밍 (비동기 제너레이터)."""
+        ...
+        yield {}  # type: ignore[misc]
+
+    @abstractmethod
+    async def realtime_order_stream(self) -> AsyncIterator[dict[str, Any]]:
+        """실시간 주문 체결 스트리밍."""
+        ...
+        yield {}  # type: ignore[misc]
+
+    # ── 대사(Reconciliation)용 조회 ────────────────────
+
+    @abstractmethod
+    async def get_account_positions(self) -> list[dict[str, Any]]:
+        """증권사 실제 보유 잔고 조회 (대사용).
+
+        Returns:
+            [{"symbol": str, "quantity": float, "avg_price": float}, ...]
+        """
+        ...
+
+    @abstractmethod
+    async def get_order_history(
+        self,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """증권사 주문/체결 이력 조회 (대사용).
+
+        Returns:
+            [{"order_id": str, "symbol": str, "side": str,
+              "quantity": float, "filled_quantity": float,
+              "price": float, "status": str, "timestamp": str}, ...]
+        """
+        ...
+
+    # ── 헬퍼 메서드 ─────────────────────────────────
+
+    def normalize_symbol(self, symbol: str) -> str:
+        """종목코드 표준화 (예: '5930' → '005930')."""
+        return symbol.zfill(6) if symbol.isdigit() else symbol
+
+    async def health_check(self) -> bool:
+        """API 연결 상태 확인."""
+        try:
+            await self.get_account_balance()
+            return True
+        except Exception:
+            return False

--- a/src/ante/broker/exceptions.py
+++ b/src/ante/broker/exceptions.py
@@ -1,0 +1,36 @@
+"""Broker Adapter 모듈 예외."""
+
+
+class BrokerError(Exception):
+    """Broker 기본 예외."""
+
+    pass
+
+
+class AuthenticationError(BrokerError):
+    """인증 실패."""
+
+    pass
+
+
+class APIError(BrokerError):
+    """API 호출 실패."""
+
+    def __init__(
+        self, message: str, status_code: int = 0, error_code: str = ""
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.error_code = error_code
+
+
+class OrderNotFoundError(BrokerError):
+    """주문을 찾을 수 없음."""
+
+    pass
+
+
+class RateLimitError(BrokerError):
+    """Rate limit 초과."""
+
+    pass

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -1,0 +1,474 @@
+"""한국투자증권 (KIS) Open API 어댑터.
+
+KIS REST API + WebSocket을 통해 주문, 조회, 실시간 스트리밍을 처리한다.
+실행 시 aiohttp 패키지가 필요하다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from ante.broker.base import BrokerAdapter
+from ante.broker.exceptions import (
+    APIError,
+    AuthenticationError,
+    OrderNotFoundError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class KISAdapter(BrokerAdapter):
+    """한국투자증권 Open API 어댑터."""
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        super().__init__(config)
+
+        self.app_key: str = config["app_key"]
+        self.app_secret: str = config["app_secret"]
+        self.account_no: str = config["account_no"]
+        self.is_paper: bool = config.get("is_paper", False)
+
+        # API 엔드포인트
+        if self.is_paper:
+            self.base_url = "https://openapivts.koreainvestment.com:29443"
+            self.websocket_url = "ws://ops.koreainvestment.com:21000"
+        else:
+            self.base_url = "https://openapi.koreainvestment.com:9443"
+            self.websocket_url = "ws://ops.koreainvestment.com:31000"
+
+        # 인증
+        self.access_token: str | None = None
+        self.token_expires_at: datetime | None = None
+
+        # HTTP 세션
+        self._session: Any = None
+
+        # Rate limiting
+        self._request_times: list[datetime] = []
+        self._rate_limit_per_minute: int = 5 if self.is_paper else 20
+
+    async def connect(self) -> None:
+        """KIS API 연결 및 인증."""
+        try:
+            import aiohttp
+        except ImportError as e:
+            raise ImportError("aiohttp 패키지가 필요합니다: pip install aiohttp") from e
+
+        self._session = aiohttp.ClientSession()
+        await self._authenticate()
+        self.is_connected = True
+        logger.info("KIS API 연결 완료 (모의투자: %s)", self.is_paper)
+
+    async def disconnect(self) -> None:
+        """연결 해제."""
+        if self._session:
+            await self._session.close()
+            self._session = None
+        self.is_connected = False
+        logger.info("KIS API 연결 해제")
+
+    # ── 인증 ───────────────────────────────────────
+
+    async def _authenticate(self) -> None:
+        """OAuth2 접근 토큰 발급."""
+        url = f"{self.base_url}/oauth2/tokenP"
+        data = {
+            "grant_type": "client_credentials",
+            "appkey": self.app_key,
+            "appsecret": self.app_secret,
+        }
+
+        async with self._session.post(
+            url, json=data, headers={"content-type": "application/json"}
+        ) as response:
+            if response.status != 200:
+                text = await response.text()
+                raise AuthenticationError(f"인증 실패 (HTTP {response.status}): {text}")
+
+            result = await response.json()
+            self.access_token = result["access_token"]
+            self.token_expires_at = datetime.now(UTC) + timedelta(hours=24)
+            logger.info("KIS 토큰 발급 완료")
+
+    async def _ensure_authenticated(self) -> None:
+        """토큰 유효성 확인 및 재발급."""
+        if (
+            not self.access_token
+            or not self.token_expires_at
+            or datetime.now(UTC) >= self.token_expires_at - timedelta(minutes=5)
+        ):
+            await self._authenticate()
+
+    # ── Rate Limiting ──────────────────────────────
+
+    async def _rate_limit_wait(self) -> None:
+        """Rate limit 준수 대기."""
+        now = datetime.now(UTC)
+        cutoff = now - timedelta(minutes=1)
+        self._request_times = [t for t in self._request_times if t > cutoff]
+
+        if len(self._request_times) >= self._rate_limit_per_minute:
+            oldest = min(self._request_times)
+            wait_seconds = 60 - (now - oldest).total_seconds()
+            if wait_seconds > 0:
+                logger.debug("Rate limit 대기: %.1f초", wait_seconds)
+                await asyncio.sleep(wait_seconds)
+
+        self._request_times.append(now)
+
+    # ── 헤더/응답 처리 ─────────────────────────────
+
+    def _get_headers(self, tr_id: str = "") -> dict[str, str]:
+        """API 요청 헤더 구성."""
+        return {
+            "Content-Type": "application/json",
+            "authorization": f"Bearer {self.access_token}",
+            "appKey": self.app_key,
+            "appSecret": self.app_secret,
+            "tr_id": tr_id,
+            "custtype": "P",
+        }
+
+    async def _handle_response(self, response: Any) -> dict[str, Any]:
+        """API 응답 처리."""
+        if response.status != 200:
+            text = await response.text()
+            raise APIError(
+                f"HTTP {response.status}: {text}",
+                status_code=response.status,
+            )
+
+        result = await response.json()
+        if result.get("rt_cd") != "0":
+            raise APIError(
+                f"KIS API Error {result.get('rt_cd')}: {result.get('msg1', 'Unknown')}",
+                error_code=result.get("rt_cd", ""),
+            )
+        return result
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        tr_id: str,
+        params: dict[str, str] | None = None,
+        json_data: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """API 요청 공통 래퍼 (인증 + rate limit + 에러 처리)."""
+        await self._ensure_authenticated()
+        await self._rate_limit_wait()
+
+        headers = self._get_headers(tr_id)
+
+        if method == "GET":
+            async with self._session.get(url, headers=headers, params=params) as resp:
+                return await self._handle_response(resp)
+        else:
+            async with self._session.post(url, headers=headers, json=json_data) as resp:
+                return await self._handle_response(resp)
+
+    # ── 계좌 정보 조회 ─────────────────────────────
+
+    def _balance_params(self) -> dict[str, str]:
+        """잔고 조회 공통 파라미터."""
+        return {
+            "CANO": self.account_no[:8],
+            "ACNT_PRDT_CD": self.account_no[8:10],
+            "AFHR_FLPR_YN": "N",
+            "OFL_YN": "",
+            "INQR_DVSN": "01",
+            "UNPR_DVSN": "01",
+            "FUND_STTL_ICLD_YN": "N",
+            "FNCG_AMT_AUTO_RDPT_YN": "N",
+            "PRCS_DVSN": "00",
+            "CTX_AREA_FK100": "",
+            "CTX_AREA_NK100": "",
+        }
+
+    async def get_account_balance(self) -> dict[str, float]:
+        """계좌 잔고 조회."""
+        tr_id = "VTTC8434R" if self.is_paper else "TTTC8434R"
+        url = f"{self.base_url}/uapi/domestic-stock/v1/trading/inquire-balance"
+        result = await self._request("GET", url, tr_id, params=self._balance_params())
+
+        info = result["output2"][0] if result.get("output2") else {}
+        return {
+            "cash": float(info.get("dnca_tot_amt", 0)),
+            "total_assets": float(info.get("tot_evlu_amt", 0)),
+            "purchase_amount": float(info.get("pchs_amt_smtl_amt", 0)),
+            "eval_amount": float(info.get("evlu_amt_smtl_amt", 0)),
+            "total_profit_loss": float(info.get("evlu_pfls_smtl_amt", 0)),
+        }
+
+    async def get_positions(self) -> list[dict[str, Any]]:
+        """보유 포지션 조회."""
+        tr_id = "VTTC8434R" if self.is_paper else "TTTC8434R"
+        url = f"{self.base_url}/uapi/domestic-stock/v1/trading/inquire-balance"
+        result = await self._request("GET", url, tr_id, params=self._balance_params())
+
+        positions = []
+        for item in result.get("output1", []):
+            qty = float(item.get("hldg_qty", 0))
+            if qty > 0:
+                positions.append(
+                    {
+                        "symbol": item["pdno"],
+                        "name": item.get("prdt_name", ""),
+                        "quantity": qty,
+                        "avg_price": float(item.get("pchs_avg_pric", 0)),
+                        "current_price": float(item.get("prpr", 0)),
+                        "eval_amount": float(item.get("evlu_amt", 0)),
+                        "profit_loss": float(item.get("evlu_pfls_amt", 0)),
+                        "profit_loss_rate": float(item.get("evlu_erng_rt", 0)),
+                    }
+                )
+        return positions
+
+    async def get_current_price(self, symbol: str) -> float:
+        """현재가 조회."""
+        tr_id = "FHKST01010100"
+        url = f"{self.base_url}/uapi/domestic-stock/v1/quotations/inquire-price"
+        params = {
+            "fid_cond_mrkt_div_code": "J",
+            "fid_input_iscd": self.normalize_symbol(symbol),
+        }
+        result = await self._request("GET", url, tr_id, params=params)
+        return float(result["output"]["stck_prpr"])
+
+    # ── 주문 처리 ──────────────────────────────────
+
+    async def place_order(
+        self,
+        symbol: str,
+        side: str,
+        quantity: float,
+        order_type: str = "market",
+        price: float | None = None,
+        stop_price: float | None = None,
+    ) -> str:
+        """주문 접수. KIS는 stop order 미지원."""
+        if order_type in ("stop", "stop_limit"):
+            raise ValueError(
+                f"KIS does not support {order_type} orders natively. "
+                "Use StopOrderManager for stop order emulation."
+            )
+
+        if side == "buy":
+            tr_id = "VTTC0802U" if self.is_paper else "TTTC0802U"
+        else:
+            tr_id = "VTTC0801U" if self.is_paper else "TTTC0311U"
+
+        url = f"{self.base_url}/uapi/domestic-stock/v1/trading/order-cash"
+        order_data = self._build_order_data(symbol, side, quantity, order_type, price)
+
+        result = await self._request("POST", url, tr_id, json_data=order_data)
+        broker_order_id = result["output"]["ODNO"]
+        logger.info(
+            "주문 접수: %s %s %s %.0f주 → %s",
+            side,
+            order_type,
+            symbol,
+            quantity,
+            broker_order_id,
+        )
+        return broker_order_id
+
+    def _build_order_data(
+        self,
+        symbol: str,
+        side: str,
+        quantity: float,
+        order_type: str,
+        price: float | None,
+    ) -> dict[str, str]:
+        """KIS 주문 데이터 구성."""
+        data = {
+            "CANO": self.account_no[:8],
+            "ACNT_PRDT_CD": self.account_no[8:10],
+            "PDNO": self.normalize_symbol(symbol),
+            "ORD_DVSN": self._map_order_type(order_type),
+            "ORD_QTY": str(int(quantity)),
+            "ORD_UNPR": "0",
+        }
+        if order_type == "limit" and price is not None:
+            data["ORD_UNPR"] = str(int(price))
+        return data
+
+    def _map_order_type(self, order_type: str) -> str:
+        """KIS ORD_DVSN 코드 매핑."""
+        mapping = {
+            "market": "01",
+            "limit": "00",
+            "conditional": "02",
+            "best": "03",
+            "priority": "04",
+        }
+        return mapping.get(order_type, "01")
+
+    def _map_order_status(self, status_code: str) -> str:
+        """KIS 주문 상태 코드 매핑."""
+        mapping = {
+            "10": "pending",
+            "11": "confirmed",
+            "20": "partial_filled",
+            "30": "filled",
+            "40": "cancelled",
+            "50": "rejected",
+        }
+        return mapping.get(status_code, "unknown")
+
+    async def cancel_order(self, order_id: str) -> bool:
+        """주문 취소."""
+        tr_id = "VTTC0803U" if self.is_paper else "TTTC0803U"
+        url = f"{self.base_url}/uapi/domestic-stock/v1/trading/order-rvsecncl"
+        cancel_data = {
+            "CANO": self.account_no[:8],
+            "ACNT_PRDT_CD": self.account_no[8:10],
+            "ORGN_ODNO": order_id,
+            "ORD_DVSN": "01",
+            "RVSE_CNCL_DVSN_CD": "02",
+            "ORD_QTY": "0",
+            "ORD_UNPR": "0",
+            "QTY_ALL_ORD_YN": "Y",
+        }
+        await self._request("POST", url, tr_id, json_data=cancel_data)
+        logger.info("주문 취소 성공: %s", order_id)
+        return True
+
+    async def get_order_status(self, order_id: str) -> dict[str, Any]:
+        """주문 상태 조회."""
+        tr_id = "VTTC8036R" if self.is_paper else "TTTC8036R"
+        url = f"{self.base_url}/uapi/domestic-stock/v1/trading/inquire-psbl-rvsecncl"
+        params = {
+            "CANO": self.account_no[:8],
+            "ACNT_PRDT_CD": self.account_no[8:10],
+            "CTX_AREA_FK100": "",
+            "CTX_AREA_NK100": "",
+            "INQR_DVSN_1": "1",
+            "INQR_DVSN_2": "0",
+        }
+        result = await self._request("GET", url, tr_id, params=params)
+
+        for order in result.get("output", []):
+            if order.get("odno") == order_id:
+                return {
+                    "order_id": order["odno"],
+                    "symbol": order.get("pdno", ""),
+                    "side": "buy" if order.get("sll_buy_dvsn_cd") == "02" else "sell",
+                    "quantity": float(order.get("ord_qty", 0)),
+                    "filled_quantity": float(order.get("tot_ccld_qty", 0)),
+                    "remaining_quantity": float(order.get("rmn_qty", 0)),
+                    "status": self._map_order_status(order.get("ord_stat_cd", "")),
+                    "price": float(order.get("ord_unpr", 0)) or None,
+                    "avg_fill_price": float(order.get("avg_prvs", 0)) or None,
+                }
+
+        raise OrderNotFoundError(f"Order {order_id} not found")
+
+    async def get_pending_orders(self) -> list[dict[str, Any]]:
+        """미체결 주문 목록 조회."""
+        tr_id = "VTTC8036R" if self.is_paper else "TTTC8036R"
+        url = f"{self.base_url}/uapi/domestic-stock/v1/trading/inquire-psbl-rvsecncl"
+        params = {
+            "CANO": self.account_no[:8],
+            "ACNT_PRDT_CD": self.account_no[8:10],
+            "CTX_AREA_FK100": "",
+            "CTX_AREA_NK100": "",
+            "INQR_DVSN_1": "1",
+            "INQR_DVSN_2": "0",
+        }
+        result = await self._request("GET", url, tr_id, params=params)
+
+        orders = []
+        for order in result.get("output", []):
+            orders.append(
+                {
+                    "order_id": order.get("odno", ""),
+                    "symbol": order.get("pdno", ""),
+                    "side": "buy" if order.get("sll_buy_dvsn_cd") == "02" else "sell",
+                    "quantity": float(order.get("ord_qty", 0)),
+                    "filled_quantity": float(order.get("tot_ccld_qty", 0)),
+                    "remaining_quantity": float(order.get("rmn_qty", 0)),
+                    "status": self._map_order_status(order.get("ord_stat_cd", "")),
+                }
+            )
+        return orders
+
+    # ── 실시간 스트리밍 (구현 예정) ────────────────
+
+    async def realtime_price_stream(
+        self, symbols: list[str]
+    ) -> AsyncIterator[dict[str, Any]]:
+        """실시간 가격 스트리밍. WebSocket 연동 Phase에서 구현."""
+        raise NotImplementedError("실시간 가격 스트리밍은 추후 구현")
+        yield {}  # type: ignore[misc]
+
+    async def realtime_order_stream(self) -> AsyncIterator[dict[str, Any]]:
+        """실시간 주문 체결 스트리밍. WebSocket 연동 Phase에서 구현."""
+        raise NotImplementedError("실시간 주문 스트리밍은 추후 구현")
+        yield {}  # type: ignore[misc]
+
+    # ── 대사용 조회 ────────────────────────────────
+
+    async def get_account_positions(self) -> list[dict[str, Any]]:
+        """대사용 보유 잔고 조회."""
+        positions = await self.get_positions()
+        return [
+            {
+                "symbol": p["symbol"],
+                "quantity": p["quantity"],
+                "avg_price": p["avg_price"],
+            }
+            for p in positions
+        ]
+
+    async def get_order_history(
+        self,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """주문/체결 이력 조회."""
+        tr_id = "VTTC8001R" if self.is_paper else "TTTC8001R"
+        url = f"{self.base_url}/uapi/domestic-stock/v1/trading/inquire-daily-ccld"
+
+        now = datetime.now(UTC)
+        params = {
+            "CANO": self.account_no[:8],
+            "ACNT_PRDT_CD": self.account_no[8:10],
+            "INQR_STRT_DT": from_date or (now - timedelta(days=7)).strftime("%Y%m%d"),
+            "INQR_END_DT": to_date or now.strftime("%Y%m%d"),
+            "SLL_BUY_DVSN_CD": "00",
+            "INQR_DVSN": "00",
+            "PDNO": "",
+            "CCLD_DVSN": "00",
+            "ORD_GNO_BRNO": "",
+            "ODNO": "",
+            "INQR_DVSN_3": "00",
+            "INQR_DVSN_1": "",
+            "CTX_AREA_FK100": "",
+            "CTX_AREA_NK100": "",
+        }
+
+        result = await self._request("GET", url, tr_id, params=params)
+        history = []
+        for item in result.get("output1", []):
+            history.append(
+                {
+                    "order_id": item.get("odno", ""),
+                    "symbol": item.get("pdno", ""),
+                    "side": "buy" if item.get("sll_buy_dvsn_cd") == "02" else "sell",
+                    "quantity": float(item.get("ord_qty", 0)),
+                    "filled_quantity": float(item.get("tot_ccld_qty", 0)),
+                    "price": float(item.get("ord_unpr", 0)),
+                    "status": "filled"
+                    if float(item.get("tot_ccld_qty", 0)) > 0
+                    else "pending",
+                    "timestamp": item.get("ord_dt", ""),
+                }
+            )
+        return history

--- a/src/ante/broker/order_registry.py
+++ b/src/ante/broker/order_registry.py
@@ -1,0 +1,75 @@
+"""OrderRegistry — order_id → bot_id 매핑 관리.
+
+복수 봇이 같은 계좌에서 거래할 때,
+브로커가 반환하는 order_id가 어느 봇의 주문인지 추적한다.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+
+logger = logging.getLogger(__name__)
+
+ORDER_REGISTRY_SCHEMA = """
+CREATE TABLE IF NOT EXISTS order_registry (
+    order_id    TEXT PRIMARY KEY,
+    bot_id      TEXT NOT NULL,
+    symbol      TEXT NOT NULL,
+    created_at  TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_order_registry_bot
+    ON order_registry(bot_id);
+"""
+
+
+class OrderRegistry:
+    """order_id → bot_id 매핑 관리.
+
+    주문 제출 시 등록, 대사 시 조회.
+    """
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    async def initialize(self) -> None:
+        """스키마 생성."""
+        await self._db.execute_script(ORDER_REGISTRY_SCHEMA)
+        logger.info("OrderRegistry 초기화 완료")
+
+    async def register(self, order_id: str, bot_id: str, symbol: str) -> None:
+        """주문 제출 시 매핑 등록."""
+        await self._db.execute(
+            """INSERT INTO order_registry (order_id, bot_id, symbol)
+               VALUES (?, ?, ?)
+               ON CONFLICT(order_id) DO UPDATE SET
+                 bot_id = excluded.bot_id,
+                 symbol = excluded.symbol""",
+            (order_id, bot_id, symbol),
+        )
+        logger.debug("주문 등록: %s → %s (%s)", order_id, bot_id, symbol)
+
+    async def get_bot_id(self, order_id: str) -> str | None:
+        """order_id로 bot_id 조회."""
+        row = await self._db.fetch_one(
+            "SELECT bot_id FROM order_registry WHERE order_id = ?",
+            (order_id,),
+        )
+        return row["bot_id"] if row else None
+
+    async def get_orders_by_bot(self, bot_id: str) -> list[dict]:
+        """봇의 모든 주문 조회."""
+        return await self._db.fetch_all(
+            "SELECT * FROM order_registry WHERE bot_id = ? ORDER BY created_at DESC",
+            (bot_id,),
+        )
+
+    async def remove(self, order_id: str) -> None:
+        """매핑 삭제."""
+        await self._db.execute(
+            "DELETE FROM order_registry WHERE order_id = ?",
+            (order_id,),
+        )

--- a/tests/unit/test_broker.py
+++ b/tests/unit/test_broker.py
@@ -1,0 +1,503 @@
+"""Broker Adapter 모듈 단위 테스트."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.broker import (
+    APIError,
+    AuthenticationError,
+    BrokerAdapter,
+    BrokerError,
+    KISAdapter,
+    OrderNotFoundError,
+    OrderRegistry,
+    RateLimitError,
+)
+from ante.core import Database
+
+# ── 예외 계층 ──────────────────────────────────────
+
+
+class TestExceptions:
+    def test_hierarchy(self):
+        """예외 계층 구조."""
+        assert issubclass(AuthenticationError, BrokerError)
+        assert issubclass(APIError, BrokerError)
+        assert issubclass(OrderNotFoundError, BrokerError)
+        assert issubclass(RateLimitError, BrokerError)
+
+    def test_api_error_fields(self):
+        """APIError 필드."""
+        e = APIError("test", status_code=400, error_code="ERR001")
+        assert str(e) == "test"
+        assert e.status_code == 400
+        assert e.error_code == "ERR001"
+
+
+# ── BrokerAdapter ABC ──────────────────────────────
+
+
+class TestBrokerAdapterABC:
+    def test_cannot_instantiate(self):
+        """ABC 직접 인스턴스화 불가."""
+        with pytest.raises(TypeError):
+            BrokerAdapter({})  # type: ignore[abstract]
+
+    def test_normalize_symbol(self):
+        """종목코드 표준화."""
+
+        class DummyBroker(BrokerAdapter):
+            async def connect(self) -> None: ...
+            async def disconnect(self) -> None: ...
+            async def get_account_balance(self) -> dict[str, float]: ...
+            async def get_positions(self) -> list[dict[str, Any]]: ...
+            async def get_current_price(self, symbol: str) -> float: ...
+            async def place_order(
+                self,
+                symbol: str,
+                side: str,
+                quantity: float,
+                order_type: str = "market",
+                price: float | None = None,
+                stop_price: float | None = None,
+            ) -> str: ...
+            async def cancel_order(self, order_id: str) -> bool: ...
+            async def get_order_status(self, order_id: str) -> dict[str, Any]: ...
+            async def get_pending_orders(self) -> list[dict[str, Any]]: ...
+            async def realtime_price_stream(
+                self, symbols: list[str]
+            ) -> AsyncIterator[dict[str, Any]]:
+                yield {}
+
+            async def realtime_order_stream(self) -> AsyncIterator[dict[str, Any]]:
+                yield {}
+
+            async def get_account_positions(self) -> list[dict[str, Any]]: ...
+            async def get_order_history(
+                self, from_date: str | None = None, to_date: str | None = None
+            ) -> list[dict[str, Any]]: ...
+
+        broker = DummyBroker({})
+        assert broker.normalize_symbol("5930") == "005930"
+        assert broker.normalize_symbol("005930") == "005930"
+        assert broker.normalize_symbol("AAPL") == "AAPL"
+
+    def test_config_stored(self):
+        """config 저장."""
+
+        class MinBroker(BrokerAdapter):
+            async def connect(self) -> None: ...
+            async def disconnect(self) -> None: ...
+            async def get_account_balance(self) -> dict[str, float]: ...
+            async def get_positions(self) -> list[dict[str, Any]]: ...
+            async def get_current_price(self, symbol: str) -> float: ...
+            async def place_order(
+                self,
+                symbol: str,
+                side: str,
+                quantity: float,
+                order_type: str = "market",
+                price: float | None = None,
+                stop_price: float | None = None,
+            ) -> str: ...
+            async def cancel_order(self, order_id: str) -> bool: ...
+            async def get_order_status(self, order_id: str) -> dict[str, Any]: ...
+            async def get_pending_orders(self) -> list[dict[str, Any]]: ...
+            async def realtime_price_stream(
+                self, symbols: list[str]
+            ) -> AsyncIterator[dict[str, Any]]:
+                yield {}
+
+            async def realtime_order_stream(self) -> AsyncIterator[dict[str, Any]]:
+                yield {}
+
+            async def get_account_positions(self) -> list[dict[str, Any]]: ...
+            async def get_order_history(
+                self, from_date: str | None = None, to_date: str | None = None
+            ) -> list[dict[str, Any]]: ...
+
+        cfg = {"key": "value"}
+        broker = MinBroker(cfg)
+        assert broker.config == cfg
+        assert broker.is_connected is False
+
+
+# ── KISAdapter ─────────────────────────────────────
+
+
+KIS_CONFIG = {
+    "app_key": "test_key",
+    "app_secret": "test_secret",
+    "account_no": "1234567801",
+    "is_paper": True,
+}
+
+
+class TestKISAdapterInit:
+    def test_paper_mode(self):
+        """모의투자 모드 초기화."""
+        adapter = KISAdapter(KIS_CONFIG)
+        assert adapter.is_paper is True
+        assert "openapivts" in adapter.base_url
+        assert adapter._rate_limit_per_minute == 5
+        assert adapter.is_connected is False
+
+    def test_live_mode(self):
+        """실전투자 모드 초기화."""
+        config = {**KIS_CONFIG, "is_paper": False}
+        adapter = KISAdapter(config)
+        assert adapter.is_paper is False
+        assert "openapi.koreainvestment" in adapter.base_url
+        assert adapter._rate_limit_per_minute == 20
+
+
+class TestKISAdapterMapping:
+    def test_map_order_type(self):
+        """주문 유형 매핑."""
+        adapter = KISAdapter(KIS_CONFIG)
+        assert adapter._map_order_type("market") == "01"
+        assert adapter._map_order_type("limit") == "00"
+        assert adapter._map_order_type("unknown") == "01"
+
+    def test_map_order_status(self):
+        """주문 상태 코드 매핑."""
+        adapter = KISAdapter(KIS_CONFIG)
+        assert adapter._map_order_status("10") == "pending"
+        assert adapter._map_order_status("30") == "filled"
+        assert adapter._map_order_status("40") == "cancelled"
+        assert adapter._map_order_status("99") == "unknown"
+
+    def test_build_order_data_market(self):
+        """시장가 주문 데이터 구성."""
+        adapter = KISAdapter(KIS_CONFIG)
+        data = adapter._build_order_data("005930", "buy", 10.0, "market", None)
+        assert data["PDNO"] == "005930"
+        assert data["ORD_DVSN"] == "01"
+        assert data["ORD_QTY"] == "10"
+        assert data["ORD_UNPR"] == "0"
+
+    def test_build_order_data_limit(self):
+        """지정가 주문 데이터 구성."""
+        adapter = KISAdapter(KIS_CONFIG)
+        data = adapter._build_order_data("005930", "buy", 5.0, "limit", 70000.0)
+        assert data["ORD_DVSN"] == "00"
+        assert data["ORD_UNPR"] == "70000"
+
+    async def test_stop_order_raises(self):
+        """stop 주문은 ValueError."""
+        adapter = KISAdapter(KIS_CONFIG)
+        with pytest.raises(ValueError, match="stop"):
+            await adapter.place_order("005930", "buy", 10, order_type="stop")
+
+    def test_normalize_symbol(self):
+        """종목코드 표준화."""
+        adapter = KISAdapter(KIS_CONFIG)
+        assert adapter.normalize_symbol("5930") == "005930"
+        assert adapter.normalize_symbol("005930") == "005930"
+
+    def test_balance_params(self):
+        """잔고 조회 파라미터."""
+        adapter = KISAdapter(KIS_CONFIG)
+        params = adapter._balance_params()
+        assert params["CANO"] == "12345678"
+        assert params["ACNT_PRDT_CD"] == "01"
+
+
+class TestKISAdapterAPI:
+    """KIS API 호출 테스트 (aiohttp mock)."""
+
+    @pytest.fixture
+    def adapter(self):
+        a = KISAdapter(KIS_CONFIG)
+        a.access_token = "test_token"
+        a.token_expires_at = datetime.now(UTC) + timedelta(hours=23)
+        a.is_connected = True
+        return a
+
+    def _mock_response(self, json_data: dict, status: int = 200) -> AsyncMock:
+        """Mock aiohttp response."""
+        resp = AsyncMock()
+        resp.status = status
+        resp.json = AsyncMock(return_value=json_data)
+        resp.text = AsyncMock(return_value="error text")
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+        return resp
+
+    async def test_get_account_balance(self, adapter):
+        """계좌 잔고 조회."""
+        mock_resp = self._mock_response(
+            {
+                "rt_cd": "0",
+                "output2": [
+                    {
+                        "dnca_tot_amt": "5000000",
+                        "tot_evlu_amt": "10000000",
+                        "pchs_amt_smtl_amt": "4500000",
+                        "evlu_amt_smtl_amt": "5500000",
+                        "evlu_pfls_smtl_amt": "1000000",
+                    }
+                ],
+            }
+        )
+        session = MagicMock()
+        session.get = MagicMock(return_value=mock_resp)
+        adapter._session = session
+
+        balance = await adapter.get_account_balance()
+        assert balance["cash"] == 5_000_000.0
+        assert balance["total_assets"] == 10_000_000.0
+
+    async def test_get_positions(self, adapter):
+        """포지션 조회."""
+        mock_resp = self._mock_response(
+            {
+                "rt_cd": "0",
+                "output1": [
+                    {
+                        "pdno": "005930",
+                        "prdt_name": "삼성전자",
+                        "hldg_qty": "100",
+                        "pchs_avg_pric": "70000",
+                        "prpr": "75000",
+                        "evlu_amt": "7500000",
+                        "evlu_pfls_amt": "500000",
+                        "evlu_erng_rt": "7.14",
+                    },
+                    {
+                        "pdno": "000660",
+                        "prdt_name": "SK하이닉스",
+                        "hldg_qty": "0",
+                        "pchs_avg_pric": "0",
+                        "prpr": "0",
+                        "evlu_amt": "0",
+                        "evlu_pfls_amt": "0",
+                        "evlu_erng_rt": "0",
+                    },
+                ],
+                "output2": [],
+            }
+        )
+        session = MagicMock()
+        session.get = MagicMock(return_value=mock_resp)
+        adapter._session = session
+
+        positions = await adapter.get_positions()
+        assert len(positions) == 1
+        assert positions[0]["symbol"] == "005930"
+        assert positions[0]["quantity"] == 100.0
+
+    async def test_place_order(self, adapter):
+        """주문 접수."""
+        mock_resp = self._mock_response(
+            {"rt_cd": "0", "output": {"ODNO": "0001234567"}}
+        )
+        session = MagicMock()
+        session.post = MagicMock(return_value=mock_resp)
+        adapter._session = session
+
+        order_id = await adapter.place_order("005930", "buy", 10.0)
+        assert order_id == "0001234567"
+
+    async def test_place_order_stop_raises(self, adapter):
+        """stop 주문 시 ValueError."""
+        with pytest.raises(ValueError, match="stop"):
+            await adapter.place_order("005930", "buy", 10, order_type="stop")
+
+    async def test_cancel_order(self, adapter):
+        """주문 취소."""
+        mock_resp = self._mock_response({"rt_cd": "0"})
+        session = MagicMock()
+        session.post = MagicMock(return_value=mock_resp)
+        adapter._session = session
+
+        result = await adapter.cancel_order("0001234567")
+        assert result is True
+
+    async def test_get_order_status(self, adapter):
+        """주문 상태 조회."""
+        mock_resp = self._mock_response(
+            {
+                "rt_cd": "0",
+                "output": [
+                    {
+                        "odno": "0001234567",
+                        "pdno": "005930",
+                        "sll_buy_dvsn_cd": "02",
+                        "ord_qty": "10",
+                        "tot_ccld_qty": "10",
+                        "rmn_qty": "0",
+                        "ord_stat_cd": "30",
+                        "ord_unpr": "70000",
+                        "avg_prvs": "70000",
+                    }
+                ],
+            }
+        )
+        session = MagicMock()
+        session.get = MagicMock(return_value=mock_resp)
+        adapter._session = session
+
+        status = await adapter.get_order_status("0001234567")
+        assert status["order_id"] == "0001234567"
+        assert status["side"] == "buy"
+        assert status["status"] == "filled"
+        assert status["filled_quantity"] == 10.0
+
+    async def test_get_order_status_not_found(self, adapter):
+        """존재하지 않는 주문 조회 시 OrderNotFoundError."""
+        mock_resp = self._mock_response({"rt_cd": "0", "output": []})
+        session = MagicMock()
+        session.get = MagicMock(return_value=mock_resp)
+        adapter._session = session
+
+        with pytest.raises(OrderNotFoundError):
+            await adapter.get_order_status("nonexistent")
+
+    async def test_api_error_handling(self, adapter):
+        """API 에러 응답 처리."""
+        mock_resp = self._mock_response({"rt_cd": "1", "msg1": "잘못된 요청"})
+        session = MagicMock()
+        session.get = MagicMock(return_value=mock_resp)
+        adapter._session = session
+
+        with pytest.raises(APIError, match="잘못된 요청"):
+            await adapter.get_account_balance()
+
+    async def test_http_error_handling(self, adapter):
+        """HTTP 에러 응답 처리."""
+        mock_resp = self._mock_response({}, status=500)
+        session = MagicMock()
+        session.get = MagicMock(return_value=mock_resp)
+        adapter._session = session
+
+        with pytest.raises(APIError, match="HTTP 500"):
+            await adapter.get_account_balance()
+
+    async def test_get_pending_orders(self, adapter):
+        """미체결 주문 목록 조회."""
+        mock_resp = self._mock_response(
+            {
+                "rt_cd": "0",
+                "output": [
+                    {
+                        "odno": "001",
+                        "pdno": "005930",
+                        "sll_buy_dvsn_cd": "02",
+                        "ord_qty": "10",
+                        "tot_ccld_qty": "0",
+                        "rmn_qty": "10",
+                        "ord_stat_cd": "10",
+                    }
+                ],
+            }
+        )
+        session = MagicMock()
+        session.get = MagicMock(return_value=mock_resp)
+        adapter._session = session
+
+        orders = await adapter.get_pending_orders()
+        assert len(orders) == 1
+        assert orders[0]["status"] == "pending"
+
+    async def test_get_account_positions_for_reconcile(self, adapter):
+        """대사용 포지션 조회."""
+        mock_resp = self._mock_response(
+            {
+                "rt_cd": "0",
+                "output1": [
+                    {
+                        "pdno": "005930",
+                        "prdt_name": "삼성전자",
+                        "hldg_qty": "50",
+                        "pchs_avg_pric": "65000",
+                        "prpr": "70000",
+                        "evlu_amt": "3500000",
+                        "evlu_pfls_amt": "250000",
+                        "evlu_erng_rt": "7.69",
+                    }
+                ],
+                "output2": [],
+            }
+        )
+        session = MagicMock()
+        session.get = MagicMock(return_value=mock_resp)
+        adapter._session = session
+
+        positions = await adapter.get_account_positions()
+        assert len(positions) == 1
+        assert positions[0]["symbol"] == "005930"
+        assert positions[0]["quantity"] == 50.0
+        assert "name" not in positions[0]
+
+    async def test_realtime_streams_not_implemented(self, adapter):
+        """실시간 스트리밍은 NotImplementedError."""
+        with pytest.raises(NotImplementedError):
+            async for _ in adapter.realtime_price_stream(["005930"]):
+                pass
+
+        with pytest.raises(NotImplementedError):
+            async for _ in adapter.realtime_order_stream():
+                pass
+
+
+# ── OrderRegistry ──────────────────────────────────
+
+
+class TestOrderRegistry:
+    @pytest.fixture
+    async def db(self, tmp_path):
+        database = Database(str(tmp_path / "test.db"))
+        await database.connect()
+        yield database
+        await database.close()
+
+    @pytest.fixture
+    async def registry(self, db):
+        r = OrderRegistry(db)
+        await r.initialize()
+        return r
+
+    async def test_register_and_get(self, registry):
+        """주문 등록 및 조회."""
+        await registry.register("ord1", "bot1", "005930")
+        bot_id = await registry.get_bot_id("ord1")
+        assert bot_id == "bot1"
+
+    async def test_get_nonexistent(self, registry):
+        """존재하지 않는 주문 조회."""
+        bot_id = await registry.get_bot_id("nonexistent")
+        assert bot_id is None
+
+    async def test_register_upsert(self, registry):
+        """중복 등록 시 업데이트."""
+        await registry.register("ord1", "bot1", "005930")
+        await registry.register("ord1", "bot2", "005930")
+        bot_id = await registry.get_bot_id("ord1")
+        assert bot_id == "bot2"
+
+    async def test_get_orders_by_bot(self, registry):
+        """봇별 주문 조회."""
+        await registry.register("ord1", "bot1", "005930")
+        await registry.register("ord2", "bot1", "000660")
+        await registry.register("ord3", "bot2", "005930")
+
+        orders = await registry.get_orders_by_bot("bot1")
+        assert len(orders) == 2
+
+    async def test_remove(self, registry):
+        """매핑 삭제."""
+        await registry.register("ord1", "bot1", "005930")
+        await registry.remove("ord1")
+        bot_id = await registry.get_bot_id("ord1")
+        assert bot_id is None
+
+    async def test_remove_nonexistent(self, registry):
+        """존재하지 않는 주문 삭제 (무시)."""
+        await registry.remove("nonexistent")  # should not raise


### PR DESCRIPTION
## Summary
- BrokerAdapter ABC: 증권사 API 추상 인터페이스 (주문, 조회, 스트리밍, 대사)
- KISAdapter: 한국투자증권 Open API 구현체 (REST 인증, rate limiting, 주문/조회)
- OrderRegistry: order_id → bot_id 매핑 (SQLite 영속화, 복수 봇 대사 지원)
- 32개 테스트 (예외 계층, ABC, KIS 매핑/API mock, OrderRegistry CRUD)

## Test plan
- [x] ruff check 통과
- [x] ruff format 통과
- [x] pytest 207개 전체 통과 (기존 175 + 신규 32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)