### PR TITLE
feat: implement API Gateway module (Phase 3-3)

### DIFF
--- a/src/ante/gateway/__init__.py
+++ b/src/ante/gateway/__init__.py
@@ -1,0 +1,18 @@
+"""API Gateway — 증권사 API 호출 중앙 관리."""
+
+from ante.gateway.cache import ResponseCache
+from ante.gateway.data_provider import LiveDataProvider
+from ante.gateway.gateway import APIGateway
+from ante.gateway.queue import APIRequest, RequestPriority, RequestQueue
+from ante.gateway.rate_limiter import RateLimitConfig, RateLimiter
+
+__all__ = [
+    "APIGateway",
+    "LiveDataProvider",
+    "RateLimiter",
+    "RateLimitConfig",
+    "ResponseCache",
+    "RequestQueue",
+    "RequestPriority",
+    "APIRequest",
+]

--- a/src/ante/gateway/cache.py
+++ b/src/ante/gateway/cache.py
@@ -1,0 +1,67 @@
+"""ResponseCache — TTL 기반 응답 캐시."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class CacheEntry:
+    """캐시 항목."""
+
+    data: Any
+    created_at: float
+    ttl_seconds: float
+
+
+class ResponseCache:
+    """TTL 기반 응답 캐시. 동일 시세 조회 등 중복 API 호출 방지."""
+
+    DEFAULT_TTL: dict[str, float] = {
+        "price": 5,
+        "ohlcv": 60,
+        "balance": 30,
+        "positions": 30,
+    }
+
+    def __init__(self) -> None:
+        self._cache: dict[str, CacheEntry] = {}
+
+    def get(self, key: str) -> Any | None:
+        """캐시 조회. 만료 시 None."""
+        entry = self._cache.get(key)
+        if entry is None:
+            return None
+        if time.monotonic() - entry.created_at > entry.ttl_seconds:
+            del self._cache[key]
+            return None
+        return entry.data
+
+    def set(self, key: str, data: Any, ttl: float | None = None) -> None:
+        """캐시 저장."""
+        self._cache[key] = CacheEntry(
+            data=data,
+            created_at=time.monotonic(),
+            ttl_seconds=ttl or 30,
+        )
+
+    def make_key(self, endpoint: str, params: dict | None = None) -> str:
+        """요청을 캐시 키로 변환."""
+        param_str = "&".join(f"{k}={v}" for k, v in sorted((params or {}).items()))
+        return f"{endpoint}?{param_str}"
+
+    def invalidate(self, pattern: str = "") -> None:
+        """패턴에 매칭되는 캐시 무효화. 빈 문자열이면 전체 초기화."""
+        if not pattern:
+            self._cache.clear()
+        else:
+            keys_to_delete = [k for k in self._cache if pattern in k]
+            for k in keys_to_delete:
+                del self._cache[k]
+
+    @property
+    def size(self) -> int:
+        """캐시 항목 수."""
+        return len(self._cache)

--- a/src/ante/gateway/data_provider.py
+++ b/src/ante/gateway/data_provider.py
@@ -1,0 +1,40 @@
+"""LiveDataProvider — 라이브 모드에서 전략에 데이터를 제공."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ante.strategy.base import DataProvider
+
+if TYPE_CHECKING:
+    from ante.gateway.gateway import APIGateway
+
+
+class LiveDataProvider(DataProvider):
+    """라이브 모드 DataProvider. APIGateway 경유로 캐시 활용."""
+
+    def __init__(self, gateway: APIGateway) -> None:
+        self._gateway = gateway
+
+    async def get_ohlcv(
+        self,
+        symbol: str,
+        timeframe: str = "1d",
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """OHLCV 데이터 조회. 추후 DataPipeline 연동 시 확장."""
+        # Phase 4 (Data Pipeline)에서 Parquet 기반으로 교체 예정
+        return []
+
+    async def get_current_price(self, symbol: str) -> float:
+        """현재가 조회 (APIGateway 캐시 활용)."""
+        return await self._gateway.get_current_price(symbol)
+
+    async def get_indicator(
+        self,
+        symbol: str,
+        indicator: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """기술 지표 계산. 추후 구현."""
+        return {}

--- a/src/ante/gateway/gateway.py
+++ b/src/ante/gateway/gateway.py
@@ -1,0 +1,228 @@
+"""APIGateway — 증권사 API 호출 중앙 관리."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from ante.gateway.cache import ResponseCache
+from ante.gateway.rate_limiter import RateLimitConfig, RateLimiter
+
+if TYPE_CHECKING:
+    from ante.broker.base import BrokerAdapter
+    from ante.eventbus.bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+
+class APIGateway:
+    """증권사 API 호출 중앙 관리.
+
+    - Rate limit 준수
+    - 응답 캐시 (시세, 잔고 등)
+    - EventBus 이벤트 기반 주문 처리
+    """
+
+    def __init__(
+        self,
+        broker: BrokerAdapter,
+        eventbus: EventBus,
+        rate_config: RateLimitConfig | None = None,
+    ) -> None:
+        self._broker = broker
+        self._eventbus = eventbus
+        self._rate_limiter = RateLimiter(
+            rate_config or RateLimitConfig(max_requests=20, window_seconds=60)
+        )
+        self._cache = ResponseCache()
+        self._running = False
+
+    async def start(self) -> None:
+        """이벤트 구독 시작."""
+        self._subscribe_events()
+        self._running = True
+        logger.info("APIGateway 시작")
+
+    async def stop(self) -> None:
+        """중지."""
+        self._running = False
+        logger.info("APIGateway 중지")
+
+    def _subscribe_events(self) -> None:
+        """EventBus 이벤트 구독."""
+        from ante.eventbus.events import (
+            OrderApprovedEvent,
+            OrderCancelEvent,
+            OrderFilledEvent,
+            OrderModifyEvent,
+        )
+
+        self._eventbus.subscribe(
+            OrderApprovedEvent, self._on_order_approved, priority=50
+        )
+        self._eventbus.subscribe(OrderCancelEvent, self._on_order_cancel, priority=50)
+        self._eventbus.subscribe(OrderModifyEvent, self._on_order_modify, priority=50)
+        self._eventbus.subscribe(OrderFilledEvent, self._on_order_filled)
+
+    # ── 공개 API ──────────────────────────────────
+
+    async def get_current_price(self, symbol: str) -> float:
+        """현재가 조회 (캐시 우선)."""
+        cache_key = f"price:{symbol}"
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        await self._rate_limiter.acquire()
+        price = await self._broker.get_current_price(symbol)
+        self._cache.set(cache_key, price, ttl=5)
+        return price
+
+    async def get_positions(self) -> list[dict[str, Any]]:
+        """포지션 조회 (캐시 우선)."""
+        cache_key = "positions"
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        await self._rate_limiter.acquire()
+        positions = await self._broker.get_positions()
+        self._cache.set(cache_key, positions, ttl=30)
+        return positions
+
+    async def get_account_balance(self) -> dict[str, float]:
+        """잔고 조회 (캐시 우선)."""
+        cache_key = "balance"
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        await self._rate_limiter.acquire()
+        balance = await self._broker.get_account_balance()
+        self._cache.set(cache_key, balance, ttl=30)
+        return balance
+
+    async def submit_order(
+        self,
+        bot_id: str,
+        symbol: str,
+        side: str,
+        quantity: float,
+        order_type: str = "market",
+        price: float | None = None,
+    ) -> str:
+        """주문 제출. 캐시 없이 rate limit만 적용."""
+        await self._rate_limiter.acquire()
+        broker_order_id = await self._broker.place_order(
+            symbol=symbol,
+            side=side,
+            quantity=quantity,
+            order_type=order_type,
+            price=price,
+        )
+        logger.info(
+            "주문 제출: %s %s %s %.0f주 → %s",
+            bot_id,
+            side,
+            symbol,
+            quantity,
+            broker_order_id,
+        )
+        return broker_order_id
+
+    async def cancel_order(self, order_id: str) -> bool:
+        """주문 취소."""
+        await self._rate_limiter.acquire()
+        return await self._broker.cancel_order(order_id)
+
+    # ── EventBus 핸들러 ──────────────────────────────
+
+    async def _on_order_approved(self, event: object) -> None:
+        """Treasury 자금 확보 완료 → 증권사에 주문 제출."""
+        from ante.eventbus.events import (
+            OrderApprovedEvent,
+            OrderFailedEvent,
+            OrderSubmittedEvent,
+        )
+
+        if not isinstance(event, OrderApprovedEvent):
+            return
+
+        try:
+            broker_order_id = await self.submit_order(
+                bot_id=event.bot_id,
+                symbol=event.symbol,
+                side=event.side,
+                quantity=event.quantity,
+                order_type=event.order_type,
+                price=event.price,
+            )
+            await self._eventbus.publish(
+                OrderSubmittedEvent(
+                    order_id=event.order_id,
+                    bot_id=event.bot_id,
+                    strategy_id=event.strategy_id,
+                    broker_order_id=broker_order_id,
+                    symbol=event.symbol,
+                    side=event.side,
+                    quantity=event.quantity,
+                    order_type=event.order_type,
+                )
+            )
+        except Exception as e:
+            logger.error("주문 제출 실패: %s — %s", event.order_id, e)
+            await self._eventbus.publish(
+                OrderFailedEvent(
+                    order_id=event.order_id,
+                    bot_id=event.bot_id,
+                    strategy_id=event.strategy_id,
+                    symbol=event.symbol,
+                    side=event.side,
+                    quantity=event.quantity,
+                    price=event.price or 0.0,
+                    order_type=event.order_type,
+                    error_message=str(e),
+                )
+            )
+
+    async def _on_order_cancel(self, event: object) -> None:
+        """주문 취소 요청 → BrokerAdapter 전달 (룰 검증 생략)."""
+        from ante.eventbus.events import OrderCancelEvent, OrderCancelledEvent
+
+        if not isinstance(event, OrderCancelEvent):
+            return
+
+        try:
+            await self.cancel_order(event.order_id)
+            await self._eventbus.publish(
+                OrderCancelledEvent(
+                    order_id=event.order_id,
+                    bot_id=event.bot_id,
+                    strategy_id=event.strategy_id,
+                    symbol="",
+                    side="",
+                    quantity=0.0,
+                    price=0.0,
+                    reason=event.reason,
+                )
+            )
+        except Exception as e:
+            logger.error("주문 취소 실패: %s — %s", event.order_id, e)
+
+    async def _on_order_modify(self, event: object) -> None:
+        """주문 정정 요청 → 로깅만 (정정은 추후 구현)."""
+        from ante.eventbus.events import OrderModifyEvent
+
+        if not isinstance(event, OrderModifyEvent):
+            return
+        logger.warning("주문 정정은 추후 구현: %s", event.order_id)
+
+    async def _on_order_filled(self, event: object) -> None:
+        """체결 시 관련 캐시 무효화."""
+        from ante.eventbus.events import OrderFilledEvent
+
+        if not isinstance(event, OrderFilledEvent):
+            return
+        self._cache.invalidate("balance")
+        self._cache.invalidate("positions")
+        self._cache.invalidate(f"price:{event.symbol}")

--- a/src/ante/gateway/queue.py
+++ b/src/ante/gateway/queue.py
@@ -1,0 +1,64 @@
+"""RequestQueue — 우선순위 기반 API 요청 큐."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import Any
+
+
+class RequestPriority(IntEnum):
+    """요청 우선순위. 낮은 숫자가 높은 우선순위."""
+
+    ORDER = 0
+    ORDER_CANCEL = 1
+    BALANCE = 10
+    PRICE = 20
+    HISTORY = 30
+
+
+@dataclass
+class APIRequest:
+    """API 요청 래퍼."""
+
+    priority: RequestPriority
+    method: str
+    endpoint: str
+    params: dict[str, Any] | None = None
+    data: dict[str, Any] | None = None
+    requester_id: str = ""
+    future: asyncio.Future[Any] | None = field(default=None, repr=False)
+
+
+class RequestQueue:
+    """우선순위 기반 API 요청 큐."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.PriorityQueue[tuple[int, int, APIRequest]] = (
+            asyncio.PriorityQueue()
+        )
+        self._counter = 0
+
+    async def put(self, request: APIRequest) -> asyncio.Future[Any]:
+        """요청을 큐에 추가. Future를 반환하여 응답 대기 가능."""
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[Any] = loop.create_future()
+        request.future = future
+        self._counter += 1
+        await self._queue.put((request.priority, self._counter, request))
+        return future
+
+    async def get(self) -> APIRequest:
+        """우선순위 순으로 요청 꺼내기."""
+        _, _, request = await self._queue.get()
+        return request
+
+    def empty(self) -> bool:
+        """큐가 비었는지 확인."""
+        return self._queue.empty()
+
+    @property
+    def qsize(self) -> int:
+        """큐 크기."""
+        return self._queue.qsize()

--- a/src/ante/gateway/rate_limiter.py
+++ b/src/ante/gateway/rate_limiter.py
@@ -1,0 +1,55 @@
+"""Rate Limiter — 슬라이딩 윈도우 기반 API 호출 제한."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from dataclasses import dataclass
+
+
+@dataclass
+class RateLimitConfig:
+    """Rate limit 설정."""
+
+    max_requests: int
+    window_seconds: float
+
+
+class RateLimiter:
+    """슬라이딩 윈도우 기반 rate limiter.
+
+    asyncio.Lock으로 복수 봇의 동시 요청을 직렬화한다.
+    """
+
+    def __init__(self, config: RateLimitConfig) -> None:
+        self._config = config
+        self._timestamps: deque[float] = deque()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        """요청 슬롯 확보. 제한 초과 시 대기."""
+        async with self._lock:
+            now = time.monotonic()
+            while (
+                self._timestamps
+                and now - self._timestamps[0] > self._config.window_seconds
+            ):
+                self._timestamps.popleft()
+
+            if len(self._timestamps) >= self._config.max_requests:
+                wait = self._config.window_seconds - (now - self._timestamps[0])
+                if wait > 0:
+                    await asyncio.sleep(wait)
+
+            self._timestamps.append(time.monotonic())
+
+    @property
+    def pending_count(self) -> int:
+        """현재 윈도우 내 요청 수."""
+        now = time.monotonic()
+        while (
+            self._timestamps and now - self._timestamps[0] > self._config.window_seconds
+        ):
+            self._timestamps.popleft()
+        return len(self._timestamps)

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -1,0 +1,403 @@
+"""API Gateway 모듈 단위 테스트."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ante.eventbus import EventBus
+from ante.eventbus.events import (
+    OrderApprovedEvent,
+    OrderCancelEvent,
+    OrderCancelledEvent,
+    OrderFailedEvent,
+    OrderFilledEvent,
+    OrderSubmittedEvent,
+)
+from ante.gateway import (
+    APIGateway,
+    APIRequest,
+    LiveDataProvider,
+    RateLimitConfig,
+    RateLimiter,
+    RequestPriority,
+    RequestQueue,
+    ResponseCache,
+)
+
+# ── RateLimiter ────────────────────────────────────
+
+
+class TestRateLimiter:
+    async def test_acquire_within_limit(self):
+        """제한 내 요청은 즉시 통과."""
+        limiter = RateLimiter(RateLimitConfig(max_requests=5, window_seconds=60))
+        for _ in range(5):
+            await limiter.acquire()
+        assert limiter.pending_count == 5
+
+    async def test_acquire_blocks_at_limit(self):
+        """제한 초과 시 대기."""
+        limiter = RateLimiter(RateLimitConfig(max_requests=2, window_seconds=0.1))
+        await limiter.acquire()
+        await limiter.acquire()
+
+        start = time.monotonic()
+        await limiter.acquire()
+        elapsed = time.monotonic() - start
+        assert elapsed >= 0.05  # 일부 대기 발생
+
+    async def test_pending_count(self):
+        """윈도우 내 요청 수 추적."""
+        limiter = RateLimiter(RateLimitConfig(max_requests=10, window_seconds=60))
+        assert limiter.pending_count == 0
+        await limiter.acquire()
+        assert limiter.pending_count == 1
+
+
+# ── ResponseCache ──────────────────────────────────
+
+
+class TestResponseCache:
+    def test_set_and_get(self):
+        """캐시 저장 및 조회."""
+        cache = ResponseCache()
+        cache.set("key1", {"price": 50000}, ttl=60)
+        assert cache.get("key1") == {"price": 50000}
+
+    def test_get_expired(self):
+        """만료된 캐시는 None."""
+        cache = ResponseCache()
+        cache.set("key1", "data", ttl=0.001)
+        import time
+
+        time.sleep(0.01)
+        assert cache.get("key1") is None
+
+    def test_get_nonexistent(self):
+        """존재하지 않는 키는 None."""
+        cache = ResponseCache()
+        assert cache.get("nonexistent") is None
+
+    def test_invalidate_pattern(self):
+        """패턴 매칭 무효화."""
+        cache = ResponseCache()
+        cache.set("price:005930", 50000, ttl=60)
+        cache.set("price:000660", 30000, ttl=60)
+        cache.set("balance", 1000000, ttl=60)
+
+        cache.invalidate("price")
+        assert cache.get("price:005930") is None
+        assert cache.get("price:000660") is None
+        assert cache.get("balance") == 1000000
+
+    def test_invalidate_all(self):
+        """전체 캐시 초기화."""
+        cache = ResponseCache()
+        cache.set("key1", "a", ttl=60)
+        cache.set("key2", "b", ttl=60)
+
+        cache.invalidate()
+        assert cache.size == 0
+
+    def test_make_key(self):
+        """캐시 키 생성."""
+        cache = ResponseCache()
+        key = cache.make_key("price", {"symbol": "005930", "market": "J"})
+        assert "price" in key
+        assert "005930" in key
+
+    def test_size(self):
+        """캐시 크기."""
+        cache = ResponseCache()
+        assert cache.size == 0
+        cache.set("k1", "v1", ttl=60)
+        cache.set("k2", "v2", ttl=60)
+        assert cache.size == 2
+
+
+# ── RequestQueue ───────────────────────────────────
+
+
+class TestRequestQueue:
+    async def test_priority_ordering(self):
+        """우선순위 순서로 요청 꺼냄."""
+        q = RequestQueue()
+        await q.put(
+            APIRequest(priority=RequestPriority.PRICE, method="GET", endpoint="/price")
+        )
+        await q.put(
+            APIRequest(priority=RequestPriority.ORDER, method="POST", endpoint="/order")
+        )
+        await q.put(
+            APIRequest(
+                priority=RequestPriority.BALANCE, method="GET", endpoint="/balance"
+            )
+        )
+
+        req1 = await q.get()
+        req2 = await q.get()
+        req3 = await q.get()
+        assert req1.endpoint == "/order"  # ORDER=0 최우선
+        assert req2.endpoint == "/balance"  # BALANCE=10
+        assert req3.endpoint == "/price"  # PRICE=20
+
+    async def test_fifo_same_priority(self):
+        """동일 우선순위는 FIFO."""
+        q = RequestQueue()
+        await q.put(
+            APIRequest(priority=RequestPriority.PRICE, method="GET", endpoint="/price1")
+        )
+        await q.put(
+            APIRequest(priority=RequestPriority.PRICE, method="GET", endpoint="/price2")
+        )
+
+        req1 = await q.get()
+        req2 = await q.get()
+        assert req1.endpoint == "/price1"
+        assert req2.endpoint == "/price2"
+
+    async def test_put_returns_future(self):
+        """put은 Future를 반환."""
+        q = RequestQueue()
+        future = await q.put(
+            APIRequest(priority=RequestPriority.PRICE, method="GET", endpoint="/price")
+        )
+        assert isinstance(future, asyncio.Future)
+
+    async def test_empty_and_qsize(self):
+        """비어있는지 확인 및 크기."""
+        q = RequestQueue()
+        assert q.empty() is True
+        assert q.qsize == 0
+
+        await q.put(
+            APIRequest(priority=RequestPriority.PRICE, method="GET", endpoint="/p")
+        )
+        assert q.empty() is False
+        assert q.qsize == 1
+
+    def test_request_priority_values(self):
+        """RequestPriority 값."""
+        assert RequestPriority.ORDER < RequestPriority.ORDER_CANCEL
+        assert RequestPriority.ORDER_CANCEL < RequestPriority.BALANCE
+        assert RequestPriority.BALANCE < RequestPriority.PRICE
+        assert RequestPriority.PRICE < RequestPriority.HISTORY
+
+
+# ── APIGateway ─────────────────────────────────────
+
+
+class TestAPIGateway:
+    @pytest.fixture
+    def broker(self):
+        b = AsyncMock()
+        b.get_current_price = AsyncMock(return_value=50000.0)
+        b.get_positions = AsyncMock(
+            return_value=[{"symbol": "005930", "quantity": 100}]
+        )
+        b.get_account_balance = AsyncMock(return_value={"cash": 5000000.0})
+        b.place_order = AsyncMock(return_value="BROKER_ORD_001")
+        b.cancel_order = AsyncMock(return_value=True)
+        return b
+
+    @pytest.fixture
+    def eventbus(self):
+        return EventBus()
+
+    @pytest.fixture
+    async def gateway(self, broker, eventbus):
+        gw = APIGateway(
+            broker=broker,
+            eventbus=eventbus,
+            rate_config=RateLimitConfig(max_requests=100, window_seconds=60),
+        )
+        await gw.start()
+        return gw
+
+    async def test_get_current_price(self, gateway, broker):
+        """현재가 조회."""
+        price = await gateway.get_current_price("005930")
+        assert price == 50000.0
+        broker.get_current_price.assert_called_once_with("005930")
+
+    async def test_get_current_price_cached(self, gateway, broker):
+        """현재가 캐시 적중."""
+        await gateway.get_current_price("005930")
+        await gateway.get_current_price("005930")
+        assert broker.get_current_price.call_count == 1
+
+    async def test_get_positions(self, gateway, broker):
+        """포지션 조회."""
+        positions = await gateway.get_positions()
+        assert len(positions) == 1
+        assert positions[0]["symbol"] == "005930"
+
+    async def test_get_account_balance(self, gateway, broker):
+        """잔고 조회."""
+        balance = await gateway.get_account_balance()
+        assert balance["cash"] == 5000000.0
+
+    async def test_submit_order(self, gateway, broker):
+        """주문 제출."""
+        order_id = await gateway.submit_order(
+            bot_id="bot1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+        )
+        assert order_id == "BROKER_ORD_001"
+        broker.place_order.assert_called_once()
+
+    async def test_cancel_order(self, gateway, broker):
+        """주문 취소."""
+        result = await gateway.cancel_order("ORD001")
+        assert result is True
+        broker.cancel_order.assert_called_once_with("ORD001")
+
+
+# ── APIGateway EventBus 통합 ──────────────────────
+
+
+class TestAPIGatewayEvents:
+    @pytest.fixture
+    def broker(self):
+        b = AsyncMock()
+        b.place_order = AsyncMock(return_value="BROKER_ORD_001")
+        b.cancel_order = AsyncMock(return_value=True)
+        return b
+
+    @pytest.fixture
+    def eventbus(self):
+        return EventBus()
+
+    @pytest.fixture
+    async def gateway(self, broker, eventbus):
+        gw = APIGateway(
+            broker=broker,
+            eventbus=eventbus,
+            rate_config=RateLimitConfig(max_requests=100, window_seconds=60),
+        )
+        await gw.start()
+        return gw
+
+    async def test_order_approved_submits(self, gateway, eventbus, broker):
+        """OrderApprovedEvent → 주문 제출 → OrderSubmittedEvent."""
+        received = []
+        eventbus.subscribe(OrderSubmittedEvent, lambda e: received.append(e))
+
+        await eventbus.publish(
+            OrderApprovedEvent(
+                order_id="ord1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                order_type="market",
+                reserved_amount=500000.0,
+            )
+        )
+
+        assert len(received) == 1
+        assert received[0].broker_order_id == "BROKER_ORD_001"
+        assert received[0].order_id == "ord1"
+        assert received[0].bot_id == "bot1"
+
+    async def test_order_approved_failure(self, gateway, eventbus, broker):
+        """주문 제출 실패 → OrderFailedEvent."""
+        broker.place_order = AsyncMock(side_effect=RuntimeError("broker error"))
+
+        received = []
+        eventbus.subscribe(OrderFailedEvent, lambda e: received.append(e))
+
+        await eventbus.publish(
+            OrderApprovedEvent(
+                order_id="ord1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                order_type="market",
+                reserved_amount=500000.0,
+            )
+        )
+
+        assert len(received) == 1
+        assert "broker error" in received[0].error_message
+
+    async def test_order_cancel_event(self, gateway, eventbus, broker):
+        """OrderCancelEvent → 취소 → OrderCancelledEvent."""
+        received = []
+        eventbus.subscribe(OrderCancelledEvent, lambda e: received.append(e))
+
+        await eventbus.publish(
+            OrderCancelEvent(
+                bot_id="bot1",
+                strategy_id="s1",
+                order_id="ord1",
+                reason="test cancel",
+            )
+        )
+
+        assert len(received) == 1
+        assert received[0].order_id == "ord1"
+        assert received[0].reason == "test cancel"
+
+    async def test_order_filled_invalidates_cache(self, gateway, eventbus, broker):
+        """체결 시 캐시 무효화."""
+        # 캐시에 데이터 넣기
+        gateway._cache.set("balance", {"cash": 5000000}, ttl=60)
+        gateway._cache.set("positions", [], ttl=60)
+        gateway._cache.set("price:005930", 50000, ttl=60)
+
+        await eventbus.publish(
+            OrderFilledEvent(
+                order_id="ord1",
+                broker_order_id="bk1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=50000.0,
+                order_type="market",
+            )
+        )
+
+        assert gateway._cache.get("balance") is None
+        assert gateway._cache.get("positions") is None
+        assert gateway._cache.get("price:005930") is None
+
+
+# ── LiveDataProvider ───────────────────────────────
+
+
+class TestLiveDataProvider:
+    async def test_get_current_price(self):
+        """LiveDataProvider 현재가 조회."""
+        mock_gateway = AsyncMock()
+        mock_gateway.get_current_price = AsyncMock(return_value=50000.0)
+
+        provider = LiveDataProvider(mock_gateway)
+        price = await provider.get_current_price("005930")
+        assert price == 50000.0
+        mock_gateway.get_current_price.assert_called_once_with("005930")
+
+    async def test_get_ohlcv_returns_empty(self):
+        """OHLCV는 현재 빈 리스트 반환 (Phase 4에서 구현)."""
+        mock_gateway = AsyncMock()
+        provider = LiveDataProvider(mock_gateway)
+        result = await provider.get_ohlcv("005930")
+        assert result == []
+
+    async def test_get_indicator_returns_empty(self):
+        """지표는 현재 빈 dict 반환 (추후 구현)."""
+        mock_gateway = AsyncMock()
+        provider = LiveDataProvider(mock_gateway)
+        result = await provider.get_indicator("005930", "sma")
+        assert result == {}


### PR DESCRIPTION
## Summary
- RateLimiter: 슬라이딩 윈도우 기반 rate limiting (asyncio.Lock 직렬화)
- ResponseCache: TTL 기반 응답 캐시 (패턴 무효화 지원)
- RequestQueue: 우선순위 기반 API 요청 큐 (ORDER > BALANCE > PRICE)
- APIGateway: EventBus 통합 (OrderApproved→Submit, Cancel, 체결 시 캐시 무효화)
- LiveDataProvider: 전략용 데이터 제공 (APIGateway 캐시 활용)
- 28개 테스트, 전체 235개 통과

## Test plan
- [x] ruff check + format 통과
- [x] pytest 235개 전체 통과 (기존 207 + 신규 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)