### PR TITLE
feat: implement Trade module (Phase 3-4)

### DIFF
--- a/src/ante/trade/__init__.py
+++ b/src/ante/trade/__init__.py
@@ -1,0 +1,25 @@
+"""Trade 모듈 — 거래 기록, 포지션 추적, 성과 산출."""
+
+from ante.trade.models import (
+    PerformanceMetrics,
+    PositionSnapshot,
+    TradeRecord,
+    TradeStatus,
+    TradeType,
+)
+from ante.trade.performance import PerformanceTracker
+from ante.trade.position import PositionHistory
+from ante.trade.recorder import TradeRecorder
+from ante.trade.service import TradeService
+
+__all__ = [
+    "PerformanceMetrics",
+    "PerformanceTracker",
+    "PositionHistory",
+    "PositionSnapshot",
+    "TradeRecord",
+    "TradeRecorder",
+    "TradeService",
+    "TradeStatus",
+    "TradeType",
+]

--- a/src/ante/trade/models.py
+++ b/src/ante/trade/models.py
@@ -1,0 +1,78 @@
+"""Trade 모듈 데이터 모델."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from uuid import UUID
+
+
+class TradeType(StrEnum):
+    """거래 유형."""
+
+    BUY = "buy"
+    SELL = "sell"
+
+
+class TradeStatus(StrEnum):
+    """거래 상태."""
+
+    FILLED = "filled"
+    CANCELLED = "cancelled"
+    REJECTED = "rejected"
+    FAILED = "failed"
+    ADJUSTED = "adjusted"
+
+
+@dataclass
+class TradeRecord:
+    """개별 거래 기록."""
+
+    trade_id: UUID
+    bot_id: str
+    strategy_id: str
+    symbol: str
+    side: str
+    quantity: float
+    price: float
+    status: TradeStatus
+    order_type: str = ""
+    reason: str = ""
+    commission: float = 0.0
+    timestamp: datetime | None = None
+    order_id: str | None = None
+
+
+@dataclass
+class PositionSnapshot:
+    """특정 시점의 포지션 상태."""
+
+    bot_id: str
+    symbol: str
+    quantity: float
+    avg_entry_price: float
+    realized_pnl: float = 0.0
+    updated_at: str = ""
+
+
+@dataclass
+class PerformanceMetrics:
+    """봇/전략 성과 지표."""
+
+    total_trades: int = 0
+    winning_trades: int = 0
+    losing_trades: int = 0
+    win_rate: float = 0.0
+    total_pnl: float = 0.0
+    total_commission: float = 0.0
+    net_pnl: float = 0.0
+    avg_profit: float = 0.0
+    avg_loss: float = 0.0
+    profit_factor: float = 0.0
+    max_drawdown: float = 0.0
+    max_drawdown_amount: float = 0.0
+    sharpe_ratio: float | None = None
+    first_trade_at: datetime | None = None
+    last_trade_at: datetime | None = None
+    active_days: int = 0

--- a/src/ante/trade/performance.py
+++ b/src/ante/trade/performance.py
@@ -1,0 +1,209 @@
+"""PerformanceTracker — 봇/전략 성과 지표 산출."""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from ante.trade.models import PerformanceMetrics, TradeRecord, TradeStatus
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+
+logger = logging.getLogger(__name__)
+
+
+class PerformanceTracker:
+    """봇/전략의 성과 지표를 조회 시 계산."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    async def calculate(
+        self,
+        bot_id: str | None = None,
+        strategy_id: str | None = None,
+        from_date: datetime | None = None,
+        to_date: datetime | None = None,
+    ) -> PerformanceMetrics:
+        """성과 지표 계산.
+
+        bot_id 또는 strategy_id 중 하나 이상 필수.
+        """
+        trades = await self._get_filled_trades(
+            bot_id=bot_id,
+            strategy_id=strategy_id,
+            from_date=from_date,
+            to_date=to_date,
+        )
+
+        if not trades:
+            return self._empty_metrics()
+
+        # 매도 거래 기준 승/패 판정
+        sell_trades = [t for t in trades if t.side == "sell"]
+        pnl_list = await self._calculate_pnl_per_trade(sell_trades, bot_id)
+
+        winning = [p for p in pnl_list if p > 0]
+        losing = [p for p in pnl_list if p < 0]
+
+        total_trades = len(sell_trades)
+        winning_trades = len(winning)
+        losing_trades = len(losing)
+
+        total_profit = sum(winning) if winning else 0.0
+        total_loss = abs(sum(losing)) if losing else 0.0
+        total_commission = sum(t.commission for t in trades)
+
+        max_drawdown, max_drawdown_amount = self._calculate_mdd(pnl_list)
+
+        return PerformanceMetrics(
+            total_trades=total_trades,
+            winning_trades=winning_trades,
+            losing_trades=losing_trades,
+            win_rate=winning_trades / total_trades if total_trades > 0 else 0.0,
+            total_pnl=total_profit - total_loss,
+            total_commission=total_commission,
+            net_pnl=total_profit - total_loss - total_commission,
+            avg_profit=total_profit / winning_trades if winning_trades > 0 else 0.0,
+            avg_loss=total_loss / losing_trades if losing_trades > 0 else 0.0,
+            profit_factor=total_profit / total_loss if total_loss > 0 else float("inf"),
+            max_drawdown=max_drawdown,
+            max_drawdown_amount=max_drawdown_amount,
+            sharpe_ratio=self._calculate_sharpe(pnl_list),
+            first_trade_at=trades[0].timestamp,
+            last_trade_at=trades[-1].timestamp,
+            active_days=len({t.timestamp.date() for t in trades if t.timestamp}),
+        )
+
+    @staticmethod
+    def _calculate_mdd(pnl_list: list[float]) -> tuple[float, float]:
+        """MDD 계산. 누적 손익의 고점 대비 최대 하락.
+
+        Returns:
+            (비율, 금액) 튜플
+        """
+        if not pnl_list:
+            return 0.0, 0.0
+
+        cumulative: list[float] = []
+        running = 0.0
+        for pnl in pnl_list:
+            running += pnl
+            cumulative.append(running)
+
+        peak = cumulative[0]
+        max_dd_amount = 0.0
+
+        for value in cumulative:
+            if value > peak:
+                peak = value
+            drawdown = peak - value
+            if drawdown > max_dd_amount:
+                max_dd_amount = drawdown
+
+        max_dd_rate = max_dd_amount / peak if peak > 0 else 0.0
+        return max_dd_rate, max_dd_amount
+
+    @staticmethod
+    def _calculate_sharpe(
+        pnl_list: list[float],
+        risk_free_rate: float = 0.035,
+    ) -> float | None:
+        """샤프 비율 계산. 거래 30건 미만이면 None."""
+        if len(pnl_list) < 30:
+            return None
+
+        mean_return = statistics.mean(pnl_list)
+        std_return = statistics.stdev(pnl_list)
+
+        if std_return == 0:
+            return None
+
+        return (mean_return - risk_free_rate / 252) / std_return
+
+    async def _get_filled_trades(
+        self,
+        bot_id: str | None = None,
+        strategy_id: str | None = None,
+        from_date: datetime | None = None,
+        to_date: datetime | None = None,
+    ) -> list[TradeRecord]:
+        """체결 완료 거래 조회."""
+        conditions: list[str] = ["status = ?"]
+        params: list[Any] = [TradeStatus.FILLED.value]
+
+        if bot_id:
+            conditions.append("bot_id = ?")
+            params.append(bot_id)
+        if strategy_id:
+            conditions.append("strategy_id = ?")
+            params.append(strategy_id)
+        if from_date:
+            conditions.append("timestamp >= ?")
+            params.append(from_date.isoformat())
+        if to_date:
+            conditions.append("timestamp <= ?")
+            params.append(to_date.isoformat())
+
+        where = " AND ".join(conditions)
+        query = f"SELECT * FROM trades WHERE {where} ORDER BY timestamp ASC"
+
+        rows = await self._db.fetch_all(query, tuple(params))
+        return [self._row_to_record(row) for row in rows]
+
+    async def _calculate_pnl_per_trade(
+        self,
+        sell_trades: list[TradeRecord],
+        bot_id: str | None,
+    ) -> list[float]:
+        """매도 거래별 실현 손익 계산.
+
+        position_history의 pnl 데이터를 활용하되,
+        간단하게 (매도가 - 매입가) * 수량 - 수수료로 계산.
+        """
+        pnl_list: list[float] = []
+        for trade in sell_trades:
+            # position_history에서 해당 거래의 pnl 조회
+            row = await self._db.fetch_one(
+                """SELECT pnl FROM position_history
+                   WHERE bot_id = ? AND symbol = ? AND action = 'sell'
+                     AND price = ? AND quantity = ?
+                   ORDER BY created_at DESC LIMIT 1""",
+                (trade.bot_id, trade.symbol, trade.price, trade.quantity),
+            )
+            if row:
+                pnl_list.append(float(row["pnl"]))
+            else:
+                # fallback: 수수료 제외한 대략적 계산
+                pnl_list.append(-trade.commission if trade.commission else 0.0)
+        return pnl_list
+
+    @staticmethod
+    def _row_to_record(row: dict) -> TradeRecord:
+        """DB row → TradeRecord."""
+        from uuid import UUID
+
+        ts = row.get("timestamp")
+        return TradeRecord(
+            trade_id=UUID(row["trade_id"]),
+            bot_id=row["bot_id"],
+            strategy_id=row["strategy_id"],
+            symbol=row["symbol"],
+            side=row["side"],
+            quantity=float(row["quantity"]),
+            price=float(row["price"]),
+            status=TradeStatus(row["status"]),
+            order_type=row.get("order_type", ""),
+            reason=row.get("reason", ""),
+            commission=float(row.get("commission", 0)),
+            timestamp=datetime.fromisoformat(ts) if ts else None,
+            order_id=row.get("order_id"),
+        )
+
+    @staticmethod
+    def _empty_metrics() -> PerformanceMetrics:
+        """거래 없을 때 빈 지표."""
+        return PerformanceMetrics()

--- a/src/ante/trade/position.py
+++ b/src/ante/trade/position.py
@@ -1,0 +1,256 @@
+"""PositionHistory — 포지션 변동 추적.
+
+Trade 모듈의 positions 테이블이 시스템 유일의 포지션 소스이다.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ante.trade.models import PositionSnapshot, TradeRecord, TradeStatus
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+
+logger = logging.getLogger(__name__)
+
+POSITION_SCHEMA = """
+CREATE TABLE IF NOT EXISTS positions (
+    bot_id           TEXT NOT NULL,
+    symbol           TEXT NOT NULL,
+    quantity         REAL NOT NULL DEFAULT 0,
+    avg_entry_price  REAL NOT NULL DEFAULT 0.0,
+    realized_pnl     REAL NOT NULL DEFAULT 0.0,
+    updated_at       TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (bot_id, symbol)
+);
+
+CREATE TABLE IF NOT EXISTS position_history (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    bot_id         TEXT NOT NULL,
+    symbol         TEXT NOT NULL,
+    action         TEXT NOT NULL,
+    quantity       REAL NOT NULL,
+    price          REAL NOT NULL,
+    pnl            REAL DEFAULT 0.0,
+    timestamp      TEXT,
+    created_at     TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_position_history_bot
+    ON position_history(bot_id, timestamp);
+"""
+
+
+class PositionHistory:
+    """포지션 변동 이력 관리."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    async def initialize(self) -> None:
+        """스키마 생성."""
+        await self._db.execute_script(POSITION_SCHEMA)
+        logger.info("PositionHistory 초기화 완료")
+
+    async def on_trade(self, record: TradeRecord) -> None:
+        """체결 기록을 반영하여 포지션 상태 갱신."""
+        if record.status != TradeStatus.FILLED:
+            return
+
+        position = await self._get_current(record.bot_id, record.symbol)
+
+        if record.side == "buy":
+            total_cost = position["avg_entry_price"] * position["quantity"]
+            new_cost = record.price * record.quantity
+            new_quantity = position["quantity"] + record.quantity
+            new_avg = (
+                (total_cost + new_cost) / new_quantity if new_quantity > 0 else 0.0
+            )
+
+            await self._update_position(
+                record.bot_id,
+                record.symbol,
+                quantity=new_quantity,
+                avg_entry_price=new_avg,
+            )
+
+            await self._save_history(
+                bot_id=record.bot_id,
+                symbol=record.symbol,
+                action="buy",
+                quantity=record.quantity,
+                price=record.price,
+                pnl=0.0,
+                timestamp=record.timestamp,
+            )
+
+        elif record.side == "sell":
+            pnl = (record.price - position["avg_entry_price"]) * record.quantity
+            pnl -= record.commission
+            new_quantity = position["quantity"] - record.quantity
+
+            await self._update_position(
+                record.bot_id,
+                record.symbol,
+                quantity=max(new_quantity, 0),
+                avg_entry_price=position["avg_entry_price"]
+                if new_quantity > 0
+                else 0.0,
+                realized_pnl_delta=pnl,
+            )
+
+            await self._save_history(
+                bot_id=record.bot_id,
+                symbol=record.symbol,
+                action="sell",
+                quantity=record.quantity,
+                price=record.price,
+                pnl=pnl,
+                timestamp=record.timestamp,
+            )
+
+    async def get_positions(
+        self,
+        bot_id: str,
+        include_closed: bool = False,
+    ) -> list[PositionSnapshot]:
+        """봇의 현재 포지션 조회."""
+        if include_closed:
+            rows = await self._db.fetch_all(
+                "SELECT * FROM positions WHERE bot_id = ?", (bot_id,)
+            )
+        else:
+            rows = await self._db.fetch_all(
+                "SELECT * FROM positions WHERE bot_id = ? AND quantity > 0",
+                (bot_id,),
+            )
+        return [self._row_to_snapshot(row) for row in rows]
+
+    async def get_all_positions(self) -> list[PositionSnapshot]:
+        """전체 봇의 모든 포지션 조회 (대사 계좌 합산 검증용)."""
+        rows = await self._db.fetch_all("SELECT * FROM positions WHERE quantity > 0")
+        return [self._row_to_snapshot(row) for row in rows]
+
+    async def get_current(self, bot_id: str, symbol: str) -> dict:
+        """현재 포지션 조회 (public)."""
+        return await self._get_current(bot_id, symbol)
+
+    async def get_history(
+        self,
+        bot_id: str,
+        symbol: str | None = None,
+    ) -> list[dict]:
+        """포지션 변동 이력 조회."""
+        if symbol:
+            rows = await self._db.fetch_all(
+                "SELECT * FROM position_history"
+                " WHERE bot_id = ? AND symbol = ?"
+                " ORDER BY created_at DESC",
+                (bot_id, symbol),
+            )
+        else:
+            rows = await self._db.fetch_all(
+                "SELECT * FROM position_history"
+                " WHERE bot_id = ?"
+                " ORDER BY created_at DESC",
+                (bot_id,),
+            )
+        return [dict(row) for row in rows]
+
+    async def force_update(
+        self,
+        bot_id: str,
+        symbol: str,
+        quantity: float,
+        avg_entry_price: float,
+    ) -> None:
+        """Reconciler 전용: 포지션 강제 덮어쓰기."""
+        await self._db.execute(
+            """INSERT INTO positions
+               (bot_id, symbol, quantity, avg_entry_price, updated_at)
+               VALUES (?, ?, ?, ?, datetime('now'))
+               ON CONFLICT(bot_id, symbol) DO UPDATE SET
+                 quantity = excluded.quantity,
+                 avg_entry_price = excluded.avg_entry_price,
+                 updated_at = excluded.updated_at""",
+            (bot_id, symbol, quantity, avg_entry_price),
+        )
+
+    async def _get_current(self, bot_id: str, symbol: str) -> dict:
+        """현재 포지션 조회. 없으면 빈 포지션 반환."""
+        row = await self._db.fetch_one(
+            "SELECT * FROM positions WHERE bot_id = ? AND symbol = ?",
+            (bot_id, symbol),
+        )
+        if row:
+            return dict(row)
+        return {
+            "bot_id": bot_id,
+            "symbol": symbol,
+            "quantity": 0.0,
+            "avg_entry_price": 0.0,
+            "realized_pnl": 0.0,
+        }
+
+    async def _update_position(
+        self,
+        bot_id: str,
+        symbol: str,
+        quantity: float,
+        avg_entry_price: float,
+        realized_pnl_delta: float = 0.0,
+    ) -> None:
+        """포지션 상태 갱신."""
+        await self._db.execute(
+            """INSERT INTO positions
+               (bot_id, symbol, quantity, avg_entry_price,
+                realized_pnl, updated_at)
+               VALUES (?, ?, ?, ?, ?, datetime('now'))
+               ON CONFLICT(bot_id, symbol) DO UPDATE SET
+                 quantity = ?,
+                 avg_entry_price = ?,
+                 realized_pnl = realized_pnl + ?,
+                 updated_at = datetime('now')""",
+            (
+                bot_id,
+                symbol,
+                quantity,
+                avg_entry_price,
+                realized_pnl_delta,
+                quantity,
+                avg_entry_price,
+                realized_pnl_delta,
+            ),
+        )
+
+    async def _save_history(
+        self,
+        bot_id: str,
+        symbol: str,
+        action: str,
+        quantity: float,
+        price: float,
+        pnl: float,
+        timestamp: object | None,
+    ) -> None:
+        """포지션 변동 이력 저장."""
+        ts = timestamp.isoformat() if hasattr(timestamp, "isoformat") else None
+        await self._db.execute(
+            """INSERT INTO position_history
+               (bot_id, symbol, action, quantity, price, pnl, timestamp)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (bot_id, symbol, action, quantity, price, pnl, ts),
+        )
+
+    @staticmethod
+    def _row_to_snapshot(row: dict) -> PositionSnapshot:
+        """DB row → PositionSnapshot."""
+        return PositionSnapshot(
+            bot_id=row["bot_id"],
+            symbol=row["symbol"],
+            quantity=float(row["quantity"]),
+            avg_entry_price=float(row["avg_entry_price"]),
+            realized_pnl=float(row.get("realized_pnl", 0)),
+            updated_at=row.get("updated_at", ""),
+        )

--- a/src/ante/trade/recorder.py
+++ b/src/ante/trade/recorder.py
@@ -1,0 +1,277 @@
+"""TradeRecorder — 이벤트 기반 거래 자동 기록."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from ante.trade.models import TradeRecord, TradeStatus
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+    from ante.trade.position import PositionHistory
+
+logger = logging.getLogger(__name__)
+
+TRADE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS trades (
+    trade_id       TEXT PRIMARY KEY,
+    bot_id         TEXT NOT NULL,
+    strategy_id    TEXT NOT NULL,
+    symbol         TEXT NOT NULL,
+    side           TEXT NOT NULL,
+    quantity       REAL NOT NULL,
+    price          REAL NOT NULL,
+    status         TEXT NOT NULL,
+    order_type     TEXT DEFAULT '',
+    reason         TEXT DEFAULT '',
+    commission     REAL DEFAULT 0.0,
+    timestamp      TEXT,
+    order_id       TEXT,
+    created_at     TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_trades_bot ON trades(bot_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_trades_strategy ON trades(strategy_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_trades_symbol ON trades(symbol, timestamp);
+CREATE INDEX IF NOT EXISTS idx_trades_status ON trades(status);
+"""
+
+
+class TradeRecorder:
+    """EventBus 이벤트를 구독하여 거래를 자동 기록."""
+
+    def __init__(self, db: Database, position_history: PositionHistory) -> None:
+        self._db = db
+        self._position_history = position_history
+
+    async def initialize(self) -> None:
+        """스키마 생성."""
+        await self._db.execute_script(TRADE_SCHEMA)
+        logger.info("TradeRecorder 초기화 완료")
+
+    def subscribe(self, eventbus: EventBus) -> None:
+        """이벤트 구독 등록."""
+        from ante.eventbus.events import (
+            OrderCancelledEvent,
+            OrderFailedEvent,
+            OrderFilledEvent,
+            OrderRejectedEvent,
+        )
+
+        eventbus.subscribe(OrderFilledEvent, self._on_filled, priority=10)
+        eventbus.subscribe(OrderRejectedEvent, self._on_rejected, priority=10)
+        eventbus.subscribe(OrderFailedEvent, self._on_failed, priority=10)
+        eventbus.subscribe(OrderCancelledEvent, self._on_cancelled, priority=10)
+
+    async def _on_filled(self, event: object) -> None:
+        """체결 이벤트 → 거래 기록 + 포지션 갱신."""
+        from ante.eventbus.events import OrderFilledEvent
+
+        if not isinstance(event, OrderFilledEvent):
+            return
+
+        record = TradeRecord(
+            trade_id=event.event_id,
+            bot_id=event.bot_id,
+            strategy_id=event.strategy_id,
+            symbol=event.symbol,
+            side=event.side,
+            quantity=event.quantity,
+            price=event.price,
+            status=TradeStatus.FILLED,
+            order_type=event.order_type,
+            reason=event.reason,
+            commission=event.commission,
+            timestamp=event.timestamp,
+            order_id=event.order_id,
+        )
+        await self._save(record)
+        await self._position_history.on_trade(record)
+
+    async def _on_rejected(self, event: object) -> None:
+        """거부 이벤트 → 거부 기록 저장."""
+        from ante.eventbus.events import OrderRejectedEvent
+
+        if not isinstance(event, OrderRejectedEvent):
+            return
+
+        record = TradeRecord(
+            trade_id=event.event_id,
+            bot_id=event.bot_id,
+            strategy_id=event.strategy_id,
+            symbol=event.symbol,
+            side=event.side,
+            quantity=event.quantity,
+            price=event.price or 0.0,
+            status=TradeStatus.REJECTED,
+            order_type=event.order_type,
+            reason=event.reason,
+            timestamp=event.timestamp,
+        )
+        await self._save(record)
+
+    async def _on_failed(self, event: object) -> None:
+        """실패 이벤트 → 실패 기록 저장."""
+        from ante.eventbus.events import OrderFailedEvent
+
+        if not isinstance(event, OrderFailedEvent):
+            return
+
+        record = TradeRecord(
+            trade_id=event.event_id,
+            bot_id=event.bot_id,
+            strategy_id=event.strategy_id,
+            symbol=event.symbol,
+            side=event.side,
+            quantity=event.quantity,
+            price=0.0,
+            status=TradeStatus.FAILED,
+            order_type=event.order_type,
+            reason=event.error_message,
+            timestamp=event.timestamp,
+        )
+        await self._save(record)
+
+    async def _on_cancelled(self, event: object) -> None:
+        """취소 완료 이벤트 → 취소 기록 저장."""
+        from ante.eventbus.events import OrderCancelledEvent
+
+        if not isinstance(event, OrderCancelledEvent):
+            return
+
+        record = TradeRecord(
+            trade_id=event.event_id,
+            bot_id=event.bot_id,
+            strategy_id=event.strategy_id,
+            symbol=event.symbol,
+            side=event.side,
+            quantity=event.quantity,
+            price=0.0,
+            status=TradeStatus.CANCELLED,
+            order_type="",
+            reason=event.reason,
+            timestamp=event.timestamp,
+            order_id=event.order_id,
+        )
+        await self._save(record)
+
+    async def _save(self, record: TradeRecord) -> None:
+        """거래 기록을 SQLite에 저장."""
+        await self._db.execute(
+            """INSERT OR IGNORE INTO trades
+               (trade_id, bot_id, strategy_id, symbol, side, quantity, price,
+                status, order_type, reason, commission, timestamp, order_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                str(record.trade_id),
+                record.bot_id,
+                record.strategy_id,
+                record.symbol,
+                record.side,
+                record.quantity,
+                record.price,
+                record.status.value,
+                record.order_type,
+                record.reason,
+                record.commission,
+                record.timestamp.isoformat() if record.timestamp else None,
+                record.order_id,
+            ),
+        )
+
+    async def save(self, record: TradeRecord) -> None:
+        """거래 기록 저장 (public). Reconciler용."""
+        await self._save(record)
+
+    async def save_adjustment(
+        self,
+        bot_id: str,
+        symbol: str,
+        old_quantity: float,
+        new_quantity: float,
+        reason: str,
+    ) -> None:
+        """대사 보정 이력 기록."""
+        await self._db.execute(
+            """INSERT INTO trades
+               (trade_id, bot_id, strategy_id, symbol, side, quantity, price,
+                status, order_type, reason, timestamp)
+               VALUES (?, ?, '', ?, 'adjustment', ?, 0.0, 'adjusted', '', ?,
+                       datetime('now'))""",
+            (
+                str(uuid4()),
+                bot_id,
+                symbol,
+                abs(new_quantity - old_quantity),
+                reason,
+            ),
+        )
+
+    async def get_trades(
+        self,
+        bot_id: str | None = None,
+        strategy_id: str | None = None,
+        symbol: str | None = None,
+        status: TradeStatus | None = None,
+        from_date: datetime | None = None,
+        to_date: datetime | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[TradeRecord]:
+        """거래 기록 조회."""
+        conditions: list[str] = []
+        params: list[Any] = []
+
+        if bot_id:
+            conditions.append("bot_id = ?")
+            params.append(bot_id)
+        if strategy_id:
+            conditions.append("strategy_id = ?")
+            params.append(strategy_id)
+        if symbol:
+            conditions.append("symbol = ?")
+            params.append(symbol)
+        if status:
+            conditions.append("status = ?")
+            params.append(status.value)
+        if from_date:
+            conditions.append("timestamp >= ?")
+            params.append(from_date.isoformat())
+        if to_date:
+            conditions.append("timestamp <= ?")
+            params.append(to_date.isoformat())
+
+        where = " AND ".join(conditions) if conditions else "1=1"
+        query = f"""SELECT * FROM trades
+                    WHERE {where}
+                    ORDER BY timestamp DESC
+                    LIMIT ? OFFSET ?"""
+        params.extend([limit, offset])
+
+        rows = await self._db.fetch_all(query, tuple(params))
+        return [self._row_to_record(row) for row in rows]
+
+    @staticmethod
+    def _row_to_record(row: dict) -> TradeRecord:
+        """DB row → TradeRecord 변환."""
+        from uuid import UUID as _UUID
+
+        ts = row.get("timestamp")
+        return TradeRecord(
+            trade_id=_UUID(row["trade_id"]),
+            bot_id=row["bot_id"],
+            strategy_id=row["strategy_id"],
+            symbol=row["symbol"],
+            side=row["side"],
+            quantity=float(row["quantity"]),
+            price=float(row["price"]),
+            status=TradeStatus(row["status"]),
+            order_type=row.get("order_type", ""),
+            reason=row.get("reason", ""),
+            commission=float(row.get("commission", 0)),
+            timestamp=datetime.fromisoformat(ts) if ts else None,
+            order_id=row.get("order_id"),
+        )

--- a/src/ante/trade/service.py
+++ b/src/ante/trade/service.py
@@ -1,0 +1,184 @@
+"""TradeService — Trade 모듈 통합 인터페이스 (파사드)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from ante.trade.models import (
+    PerformanceMetrics,
+    PositionSnapshot,
+    TradeRecord,
+    TradeStatus,
+)
+
+if TYPE_CHECKING:
+    from ante.trade.performance import PerformanceTracker
+    from ante.trade.position import PositionHistory
+    from ante.trade.recorder import TradeRecorder
+
+
+class TradeService:
+    """Trade 모듈의 통합 인터페이스.
+
+    외부 모듈(Web API, CLI)은 이 클래스를 통해 접근.
+    """
+
+    def __init__(
+        self,
+        recorder: TradeRecorder,
+        position_history: PositionHistory,
+        performance: PerformanceTracker,
+    ) -> None:
+        self._recorder = recorder
+        self._position_history = position_history
+        self._performance = performance
+
+    # ── 거래 기록 조회 ────────────────────────────────
+
+    async def get_trades(
+        self,
+        bot_id: str | None = None,
+        strategy_id: str | None = None,
+        symbol: str | None = None,
+        status: TradeStatus | None = None,
+        from_date: datetime | None = None,
+        to_date: datetime | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[TradeRecord]:
+        """거래 기록 조회."""
+        return await self._recorder.get_trades(
+            bot_id=bot_id,
+            strategy_id=strategy_id,
+            symbol=symbol,
+            status=status,
+            from_date=from_date,
+            to_date=to_date,
+            limit=limit,
+            offset=offset,
+        )
+
+    # ── 포지션 조회 ──────────────────────────────────
+
+    async def get_positions(
+        self,
+        bot_id: str,
+        include_closed: bool = False,
+    ) -> list[PositionSnapshot]:
+        """봇의 현재 포지션 조회."""
+        return await self._position_history.get_positions(
+            bot_id=bot_id,
+            include_closed=include_closed,
+        )
+
+    async def get_all_positions(self) -> list[PositionSnapshot]:
+        """전체 봇의 모든 포지션 조회 (대사 계좌 합산 검증용)."""
+        return await self._position_history.get_all_positions()
+
+    async def get_position_history(
+        self,
+        bot_id: str,
+        symbol: str | None = None,
+    ) -> list[dict]:
+        """포지션 변동 이력 조회."""
+        return await self._position_history.get_history(
+            bot_id=bot_id,
+            symbol=symbol,
+        )
+
+    # ── 성과 지표 ────────────────────────────────────
+
+    async def get_performance(
+        self,
+        bot_id: str | None = None,
+        strategy_id: str | None = None,
+        from_date: datetime | None = None,
+        to_date: datetime | None = None,
+    ) -> PerformanceMetrics:
+        """성과 지표 조회."""
+        return await self._performance.calculate(
+            bot_id=bot_id,
+            strategy_id=strategy_id,
+            from_date=from_date,
+            to_date=to_date,
+        )
+
+    # ── 요약 ──────────────────────────────────────
+
+    async def get_summary(self, bot_id: str) -> dict:
+        """봇 요약 정보 (대시보드용)."""
+        positions = await self.get_positions(bot_id)
+        performance = await self.get_performance(bot_id=bot_id)
+        recent_trades = await self.get_trades(bot_id=bot_id, limit=10)
+
+        return {
+            "positions": positions,
+            "performance": performance,
+            "recent_trades": recent_trades,
+        }
+
+    # ── 대사(Reconciliation) 보정 ────────────────────
+
+    async def correct_position(
+        self,
+        bot_id: str,
+        symbol: str,
+        quantity: float,
+        avg_price: float | None = None,
+        reason: str = "",
+    ) -> dict:
+        """포지션을 브로커 기준으로 강제 보정. Reconciler가 호출."""
+        old = await self._position_history.get_current(bot_id=bot_id, symbol=symbol)
+        old_qty = old.get("quantity", 0)
+        old_avg = old.get("avg_entry_price", 0.0)
+
+        await self._position_history.force_update(
+            bot_id=bot_id,
+            symbol=symbol,
+            quantity=quantity,
+            avg_entry_price=avg_price if avg_price else old_avg,
+        )
+
+        await self._recorder.save_adjustment(
+            bot_id=bot_id,
+            symbol=symbol,
+            old_quantity=old_qty,
+            new_quantity=quantity,
+            reason=reason,
+        )
+
+        return {
+            "symbol": symbol,
+            "old_quantity": old_qty,
+            "new_quantity": quantity,
+            "old_avg_price": old_avg,
+            "new_avg_price": avg_price if avg_price else old_avg,
+            "reason": reason,
+        }
+
+    async def insert_adjustment(
+        self,
+        bot_id: str,
+        strategy_id: str,
+        fill: dict,
+        reason: str = "reconciliation",
+    ) -> None:
+        """누락된 체결 기록을 보정 추가. Reconciler가 호출."""
+        record = TradeRecord(
+            trade_id=uuid4(),
+            bot_id=bot_id,
+            strategy_id=strategy_id,
+            symbol=fill["symbol"],
+            side=fill["side"],
+            quantity=fill["quantity"],
+            price=fill["price"],
+            status=TradeStatus.ADJUSTED,
+            order_type=fill.get("order_type", ""),
+            reason=reason,
+            commission=fill.get("commission", 0.0),
+            timestamp=fill.get("timestamp"),
+            order_id=fill.get("order_id"),
+        )
+        await self._recorder.save(record)

--- a/tests/unit/test_trade.py
+++ b/tests/unit/test_trade.py
@@ -1,0 +1,791 @@
+"""Trade 모듈 단위 테스트."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from ante.core.database import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import (
+    OrderCancelledEvent,
+    OrderFailedEvent,
+    OrderFilledEvent,
+    OrderRejectedEvent,
+)
+from ante.trade.models import (
+    PerformanceMetrics,
+    PositionSnapshot,
+    TradeRecord,
+    TradeStatus,
+    TradeType,
+)
+from ante.trade.performance import PerformanceTracker
+from ante.trade.position import PositionHistory
+from ante.trade.recorder import TradeRecorder
+from ante.trade.service import TradeService
+
+# ── Fixtures ─────────────────────────────────────────
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """테스트용 SQLite DB."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    return db
+
+
+@pytest.fixture
+async def position_history(db):
+    ph = PositionHistory(db)
+    await ph.initialize()
+    return ph
+
+
+@pytest.fixture
+async def recorder(db, position_history):
+    rec = TradeRecorder(db, position_history)
+    await rec.initialize()
+    return rec
+
+
+@pytest.fixture
+async def performance(db, recorder):
+    return PerformanceTracker(db)
+
+
+@pytest.fixture
+async def service(recorder, position_history, performance):
+    return TradeService(recorder, position_history, performance)
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+def _make_filled_event(
+    *,
+    bot_id: str = "bot1",
+    strategy_id: str = "s1",
+    symbol: str = "005930",
+    side: str = "buy",
+    quantity: float = 10.0,
+    price: float = 50000.0,
+    commission: float = 0.0,
+    order_type: str = "market",
+    reason: str = "test",
+) -> OrderFilledEvent:
+    now = datetime.now(UTC)
+    return OrderFilledEvent(
+        event_id=uuid4(),
+        timestamp=now,
+        order_id="ord1",
+        broker_order_id="bk1",
+        bot_id=bot_id,
+        strategy_id=strategy_id,
+        symbol=symbol,
+        side=side,
+        quantity=quantity,
+        price=price,
+        commission=commission,
+        order_type=order_type,
+        reason=reason,
+    )
+
+
+# ── TradeRecorder ────────────────────────────────────
+
+
+class TestTradeRecorder:
+    async def test_on_filled_records_trade(self, recorder, db):
+        """OrderFilledEvent → trades 테이블에 기록."""
+        event = _make_filled_event()
+        await recorder._on_filled(event)
+
+        rows = await db.fetch_all("SELECT * FROM trades")
+        assert len(rows) == 1
+        assert rows[0]["bot_id"] == "bot1"
+        assert rows[0]["status"] == "filled"
+
+    async def test_on_filled_updates_position(self, recorder, position_history):
+        """체결 시 포지션도 갱신."""
+        event = _make_filled_event(side="buy", quantity=10, price=50000)
+        await recorder._on_filled(event)
+
+        pos = await position_history.get_current("bot1", "005930")
+        assert pos["quantity"] == 10
+        assert pos["avg_entry_price"] == 50000.0
+
+    async def test_on_rejected_records(self, recorder, db):
+        """OrderRejectedEvent → 거부 기록."""
+        event = OrderRejectedEvent(
+            event_id=uuid4(),
+            timestamp=datetime.now(UTC),
+            order_id="ord1",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            price=50000.0,
+            order_type="market",
+            reason="rule violation",
+        )
+        await recorder._on_rejected(event)
+
+        rows = await db.fetch_all("SELECT * FROM trades WHERE status = 'rejected'")
+        assert len(rows) == 1
+        assert rows[0]["reason"] == "rule violation"
+
+    async def test_on_failed_records(self, recorder, db):
+        """OrderFailedEvent → 실패 기록."""
+        event = OrderFailedEvent(
+            event_id=uuid4(),
+            timestamp=datetime.now(UTC),
+            order_id="ord1",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            price=0.0,
+            order_type="market",
+            error_message="broker error",
+        )
+        await recorder._on_failed(event)
+
+        rows = await db.fetch_all("SELECT * FROM trades WHERE status = 'failed'")
+        assert len(rows) == 1
+        assert rows[0]["reason"] == "broker error"
+
+    async def test_on_cancelled_records(self, recorder, db):
+        """OrderCancelledEvent → 취소 기록."""
+        event = OrderCancelledEvent(
+            event_id=uuid4(),
+            timestamp=datetime.now(UTC),
+            order_id="ord1",
+            broker_order_id="bk1",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            price=0.0,
+            reason="user cancel",
+        )
+        await recorder._on_cancelled(event)
+
+        rows = await db.fetch_all("SELECT * FROM trades WHERE status = 'cancelled'")
+        assert len(rows) == 1
+
+    async def test_duplicate_trade_id_ignored(self, recorder, db):
+        """동일 trade_id 중복 기록 방지 (INSERT OR IGNORE)."""
+        event = _make_filled_event()
+        await recorder._on_filled(event)
+        await recorder._on_filled(event)
+
+        rows = await db.fetch_all("SELECT * FROM trades")
+        assert len(rows) == 1
+
+    async def test_get_trades_filter_bot(self, recorder):
+        """봇별 거래 조회."""
+        await recorder._on_filled(_make_filled_event(bot_id="bot1"))
+        await recorder._on_filled(_make_filled_event(bot_id="bot2"))
+
+        trades = await recorder.get_trades(bot_id="bot1")
+        assert len(trades) == 1
+        assert trades[0].bot_id == "bot1"
+
+    async def test_get_trades_filter_status(self, recorder, db):
+        """상태별 거래 조회."""
+        await recorder._on_filled(_make_filled_event())
+
+        event = OrderFailedEvent(
+            event_id=uuid4(),
+            timestamp=datetime.now(UTC),
+            order_id="ord2",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            price=0.0,
+            order_type="market",
+            error_message="err",
+        )
+        await recorder._on_failed(event)
+
+        filled = await recorder.get_trades(status=TradeStatus.FILLED)
+        assert len(filled) == 1
+
+        failed = await recorder.get_trades(status=TradeStatus.FAILED)
+        assert len(failed) == 1
+
+    async def test_save_adjustment(self, recorder, db):
+        """대사 보정 이력 기록."""
+        await recorder.save_adjustment(
+            bot_id="bot1",
+            symbol="005930",
+            old_quantity=10,
+            new_quantity=15,
+            reason="broker mismatch",
+        )
+
+        rows = await db.fetch_all("SELECT * FROM trades WHERE status = 'adjusted'")
+        assert len(rows) == 1
+        assert rows[0]["quantity"] == 5  # abs(15-10)
+
+    async def test_eventbus_integration(self, recorder, eventbus):
+        """EventBus 구독 통합 테스트."""
+        recorder.subscribe(eventbus)
+
+        event = _make_filled_event()
+        await eventbus.publish(event)
+
+        trades = await recorder.get_trades()
+        assert len(trades) == 1
+
+
+# ── PositionHistory ──────────────────────────────────
+
+
+class TestPositionHistory:
+    async def test_buy_increases_quantity(self, position_history):
+        """매수 시 수량 증가."""
+        record = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(record)
+
+        pos = await position_history.get_current("bot1", "005930")
+        assert pos["quantity"] == 10
+        assert pos["avg_entry_price"] == 50000.0
+
+    async def test_buy_recalculates_avg_price(self, position_history):
+        """추가 매수 시 평균 매입가 재계산."""
+        record1 = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(record1)
+
+        record2 = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=60000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(record2)
+
+        pos = await position_history.get_current("bot1", "005930")
+        assert pos["quantity"] == 20
+        assert pos["avg_entry_price"] == 55000.0  # (50000*10 + 60000*10) / 20
+
+    async def test_sell_decreases_quantity(self, position_history):
+        """매도 시 수량 감소 + 실현 손익."""
+        # 매수
+        buy = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(buy)
+
+        # 일부 매도
+        sell = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="sell",
+            quantity=5,
+            price=55000,
+            status=TradeStatus.FILLED,
+            commission=100,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(sell)
+
+        pos = await position_history.get_current("bot1", "005930")
+        assert pos["quantity"] == 5
+        assert pos["avg_entry_price"] == 50000.0  # 유지
+        # pnl = (55000 - 50000) * 5 - 100 = 24900
+        assert pos["realized_pnl"] == pytest.approx(24900.0)
+
+    async def test_full_sell_clears_position(self, position_history):
+        """전량 매도 시 포지션 quantity=0, avg_entry_price=0."""
+        buy = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(buy)
+
+        sell = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="sell",
+            quantity=10,
+            price=55000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(sell)
+
+        pos = await position_history.get_current("bot1", "005930")
+        assert pos["quantity"] == 0
+        assert pos["avg_entry_price"] == 0.0
+
+    async def test_non_filled_ignored(self, position_history):
+        """체결 상태가 아닌 기록은 무시."""
+        record = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.CANCELLED,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(record)
+
+        pos = await position_history.get_current("bot1", "005930")
+        assert pos["quantity"] == 0
+
+    async def test_get_positions_excludes_closed(self, position_history):
+        """기본 조회 시 청산 포지션 제외."""
+        buy = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(buy)
+
+        # 다른 종목 매수 후 전량 청산
+        buy2 = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="000660",
+            side="buy",
+            quantity=5,
+            price=100000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(buy2)
+        sell2 = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="000660",
+            side="sell",
+            quantity=5,
+            price=110000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(sell2)
+
+        positions = await position_history.get_positions("bot1")
+        assert len(positions) == 1
+        assert positions[0].symbol == "005930"
+
+    async def test_get_positions_include_closed(self, position_history):
+        """include_closed=True 시 청산 포지션도 포함."""
+        buy = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(buy)
+        sell = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="sell",
+            quantity=10,
+            price=55000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(sell)
+
+        positions = await position_history.get_positions("bot1", include_closed=True)
+        assert len(positions) == 1
+        assert positions[0].quantity == 0
+
+    async def test_get_all_positions(self, position_history):
+        """전체 봇 포지션 조회."""
+        for bot in ["bot1", "bot2"]:
+            buy = TradeRecord(
+                trade_id=uuid4(),
+                bot_id=bot,
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10,
+                price=50000,
+                status=TradeStatus.FILLED,
+                timestamp=datetime.now(UTC),
+            )
+            await position_history.on_trade(buy)
+
+        positions = await position_history.get_all_positions()
+        assert len(positions) == 2
+
+    async def test_force_update(self, position_history):
+        """Reconciler 강제 포지션 덮어쓰기."""
+        await position_history.force_update(
+            bot_id="bot1",
+            symbol="005930",
+            quantity=100,
+            avg_entry_price=45000,
+        )
+
+        pos = await position_history.get_current("bot1", "005930")
+        assert pos["quantity"] == 100
+        assert pos["avg_entry_price"] == 45000
+
+    async def test_get_history(self, position_history):
+        """포지션 변동 이력 조회."""
+        buy = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(buy)
+        sell = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="sell",
+            quantity=5,
+            price=55000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(sell)
+
+        history = await position_history.get_history("bot1", "005930")
+        assert len(history) == 2  # buy + sell
+
+
+# ── PerformanceTracker ───────────────────────────────
+
+
+class TestPerformanceTracker:
+    async def test_empty_trades_returns_empty_metrics(self, performance):
+        """거래 없으면 빈 지표."""
+        metrics = await performance.calculate(bot_id="nonexistent")
+        assert metrics.total_trades == 0
+        assert metrics.win_rate == 0.0
+        assert metrics.net_pnl == 0.0
+
+    async def test_calculate_with_trades(self, recorder, position_history, performance):
+        """수익/손실 거래 혼합 시 성과 계산."""
+        now = datetime.now(UTC)
+
+        # 매수 1: 005930 10주 @ 50000
+        await recorder._on_filled(
+            _make_filled_event(
+                symbol="005930",
+                side="buy",
+                quantity=10,
+                price=50000,
+            )
+        )
+
+        # 매도 1: 005930 10주 @ 55000 (수익)
+        sell1 = OrderFilledEvent(
+            event_id=uuid4(),
+            timestamp=now + timedelta(hours=1),
+            order_id="ord2",
+            broker_order_id="bk2",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            price=55000.0,
+            commission=100.0,
+            order_type="market",
+        )
+        await recorder._on_filled(sell1)
+
+        # 매수 2: 000660 5주 @ 100000
+        buy2 = OrderFilledEvent(
+            event_id=uuid4(),
+            timestamp=now + timedelta(hours=2),
+            order_id="ord3",
+            broker_order_id="bk3",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="000660",
+            side="buy",
+            quantity=5.0,
+            price=100000.0,
+            order_type="market",
+        )
+        await recorder._on_filled(buy2)
+
+        # 매도 2: 000660 5주 @ 90000 (손실)
+        sell2 = OrderFilledEvent(
+            event_id=uuid4(),
+            timestamp=now + timedelta(hours=3),
+            order_id="ord4",
+            broker_order_id="bk4",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="000660",
+            side="sell",
+            quantity=5.0,
+            price=90000.0,
+            commission=50.0,
+            order_type="market",
+        )
+        await recorder._on_filled(sell2)
+
+        metrics = await performance.calculate(bot_id="bot1")
+        assert metrics.total_trades == 2  # 매도 2건
+        assert metrics.winning_trades == 1
+        assert metrics.losing_trades == 1
+        assert metrics.win_rate == pytest.approx(0.5)
+
+    async def test_mdd_calculation(self, performance):
+        """MDD 계산 정확성."""
+        # 고점 후 하락 → 회복 → 재하락
+        pnl_list = [100, 50, -200, 150, -300]
+        rate, amount = performance._calculate_mdd(pnl_list)
+        # cumulative: [100, 150, -50, 100, -200]
+        # peak: 150, max drawdown: 150 - (-200) = 350
+        assert amount == pytest.approx(350.0)
+        assert rate == pytest.approx(350.0 / 150.0)
+
+    async def test_mdd_empty(self, performance):
+        """빈 리스트 MDD = 0."""
+        rate, amount = performance._calculate_mdd([])
+        assert rate == 0.0
+        assert amount == 0.0
+
+    async def test_mdd_only_profits(self, performance):
+        """수익만 있으면 MDD = 0."""
+        rate, amount = performance._calculate_mdd([100, 200, 300])
+        assert amount == 0.0
+
+    async def test_sharpe_under_30_returns_none(self, performance):
+        """30건 미만이면 None."""
+        assert performance._calculate_sharpe([100, 200]) is None
+
+    async def test_sharpe_30_or_more(self, performance):
+        """30건 이상이면 샤프 비율 계산."""
+        pnl_list = [100.0 + i * 10 for i in range(30)]
+        result = performance._calculate_sharpe(pnl_list)
+        assert result is not None
+        assert isinstance(result, float)
+
+    async def test_sharpe_zero_std_returns_none(self, performance):
+        """표준편차 0이면 None."""
+        pnl_list = [100.0] * 30
+        assert performance._calculate_sharpe(pnl_list) is None
+
+    async def test_profit_factor_no_loss(self, recorder, position_history, performance):
+        """손실 없으면 profit_factor = inf."""
+        now = datetime.now(UTC)
+
+        await recorder._on_filled(
+            _make_filled_event(side="buy", quantity=10, price=50000)
+        )
+        sell = OrderFilledEvent(
+            event_id=uuid4(),
+            timestamp=now + timedelta(hours=1),
+            order_id="ord2",
+            broker_order_id="bk2",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            price=55000.0,
+            order_type="market",
+        )
+        await recorder._on_filled(sell)
+
+        metrics = await performance.calculate(bot_id="bot1")
+        assert metrics.profit_factor == float("inf")
+
+
+# ── TradeService ─────────────────────────────────────
+
+
+class TestTradeService:
+    async def test_get_summary(self, service, recorder):
+        """get_summary — 포지션 + 성과 + 최근 거래."""
+        await recorder._on_filled(
+            _make_filled_event(side="buy", quantity=10, price=50000)
+        )
+
+        summary = await service.get_summary("bot1")
+        assert "positions" in summary
+        assert "performance" in summary
+        assert "recent_trades" in summary
+
+    async def test_correct_position(self, service, position_history):
+        """포지션 강제 보정."""
+        # 기존 포지션 생성
+        buy = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(buy)
+
+        result = await service.correct_position(
+            bot_id="bot1",
+            symbol="005930",
+            quantity=15,
+            avg_price=48000,
+            reason="broker mismatch",
+        )
+
+        assert result["old_quantity"] == 10
+        assert result["new_quantity"] == 15
+        assert result["new_avg_price"] == 48000
+
+        # 보정 후 포지션 확인
+        pos = await position_history.get_current("bot1", "005930")
+        assert pos["quantity"] == 15
+
+    async def test_insert_adjustment(self, service, recorder):
+        """누락 체결 보정 추가."""
+        fill = {
+            "symbol": "005930",
+            "side": "buy",
+            "quantity": 5,
+            "price": 50000,
+        }
+        await service.insert_adjustment(
+            bot_id="bot1",
+            strategy_id="s1",
+            fill=fill,
+            reason="missed fill",
+        )
+
+        trades = await recorder.get_trades(bot_id="bot1")
+        assert len(trades) == 1
+        assert trades[0].status == TradeStatus.ADJUSTED
+
+    async def test_get_positions_delegates(self, service, position_history):
+        """포지션 조회 위임."""
+        buy = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(buy)
+
+        positions = await service.get_positions("bot1")
+        assert len(positions) == 1
+        assert isinstance(positions[0], PositionSnapshot)
+
+    async def test_get_performance_delegates(self, service):
+        """성과 조회 위임."""
+        metrics = await service.get_performance(bot_id="bot1")
+        assert isinstance(metrics, PerformanceMetrics)
+
+
+# ── Models ───────────────────────────────────────────
+
+
+class TestModels:
+    def test_trade_type_values(self):
+        """TradeType 값."""
+        assert TradeType.BUY == "buy"
+        assert TradeType.SELL == "sell"
+
+    def test_trade_status_values(self):
+        """TradeStatus 값."""
+        assert TradeStatus.FILLED == "filled"
+        assert TradeStatus.CANCELLED == "cancelled"
+        assert TradeStatus.REJECTED == "rejected"
+        assert TradeStatus.FAILED == "failed"
+        assert TradeStatus.ADJUSTED == "adjusted"
+
+    def test_performance_metrics_defaults(self):
+        """PerformanceMetrics 기본값."""
+        m = PerformanceMetrics()
+        assert m.total_trades == 0
+        assert m.sharpe_ratio is None
+        assert m.first_trade_at is None


### PR DESCRIPTION
## Summary
- **TradeRecorder**: EventBus 이벤트 구독 기반 자동 거래 기록 (filled/rejected/failed/cancelled)
- **PositionHistory**: 포지션 변동 추적 (평균매입가 재계산, 실현손익, 변동이력) — 시스템 유일의 포지션 소스
- **PerformanceTracker**: 성과 지표 산출 (MDD, Sharpe ratio, 승률, profit factor)
- **TradeService**: 파사드 패턴 통합 인터페이스 (조회, 보정, 요약)
- **37 unit tests** 전체 통과

## Test plan
- [x] TradeRecorder: 4종 이벤트 기록, 중복 방지, 필터 조회, EventBus 통합
- [x] PositionHistory: 매수/매도 수량·평균가 계산, 전량청산, 포지션 조회
- [x] PerformanceTracker: MDD/Sharpe/승률/profit factor 정확성
- [x] TradeService: 위임 동작, 보정 API, 요약 조회
- [x] 전체 272 테스트 통과 (기존 235 + 신규 37)

🤖 Generated with [Claude Code](https://claude.com/claude-code)