### PR TITLE
feat: implement Report Store module (Phase 4-3)

### DIFF
--- a/src/ante/report/__init__.py
+++ b/src/ante/report/__init__.py
@@ -1,0 +1,12 @@
+"""Report Store — 전략 검증 리포트 저장·관리."""
+
+from ante.report.feedback import PerformanceFeedback
+from ante.report.models import ReportStatus, StrategyReport
+from ante.report.store import ReportStore
+
+__all__ = [
+    "PerformanceFeedback",
+    "ReportStatus",
+    "ReportStore",
+    "StrategyReport",
+]

--- a/src/ante/report/feedback.py
+++ b/src/ante/report/feedback.py
@@ -1,0 +1,81 @@
+"""PerformanceFeedback — Agent 피드백용 실전 성과 조회."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ante.bot.manager import BotManager
+    from ante.trade.service import TradeService
+
+
+class PerformanceFeedback:
+    """Agent 피드백용 실전 성과 조회 서비스."""
+
+    def __init__(
+        self,
+        trade_service: TradeService,
+        bot_manager: BotManager,
+    ) -> None:
+        self._trade = trade_service
+        self._bots = bot_manager
+
+    async def get_bot_performance(self, bot_id: str) -> dict:
+        """봇의 실전 성과 조회."""
+        metrics = await self._trade.get_performance(bot_id=bot_id)
+        positions = await self._trade.get_positions(bot_id)
+        return {
+            "bot_id": bot_id,
+            "metrics": {
+                "total_trades": metrics.total_trades,
+                "win_rate": metrics.win_rate,
+                "net_pnl": metrics.net_pnl,
+                "profit_factor": metrics.profit_factor,
+                "max_drawdown": metrics.max_drawdown,
+                "sharpe_ratio": metrics.sharpe_ratio,
+            },
+            "current_positions": [
+                {
+                    "symbol": p.symbol,
+                    "quantity": p.quantity,
+                    "avg_price": p.avg_entry_price,
+                    "realized_pnl": p.realized_pnl,
+                }
+                for p in positions
+            ],
+        }
+
+    async def get_strategy_performance(self, strategy_id: str) -> dict:
+        """전략의 모든 봇 성과 집계."""
+        bots = self._bots.list_bots()
+        strategy_bots = [b for b in bots if b.get("strategy_id") == strategy_id]
+
+        performances = []
+        for bot in strategy_bots:
+            perf = await self.get_bot_performance(bot["bot_id"])
+            performances.append(perf)
+
+        return {
+            "strategy_id": strategy_id,
+            "bot_count": len(performances),
+            "bots": performances,
+        }
+
+    async def get_trade_history(
+        self,
+        bot_id: str,
+        limit: int = 100,
+    ) -> list[dict]:
+        """봇의 거래 이력 조회."""
+        trades = await self._trade.get_trades(bot_id=bot_id, limit=limit)
+        return [
+            {
+                "timestamp": (t.timestamp.isoformat() if t.timestamp else None),
+                "symbol": t.symbol,
+                "side": t.side,
+                "quantity": t.quantity,
+                "price": t.price,
+                "status": t.status.value,
+            }
+            for t in trades
+        ]

--- a/src/ante/report/models.py
+++ b/src/ante/report/models.py
@@ -1,0 +1,51 @@
+"""Report Store 데이터 모델."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+
+class ReportStatus(StrEnum):
+    """리포트 상태."""
+
+    SUBMITTED = "submitted"
+    REVIEWED = "reviewed"
+    ADOPTED = "adopted"
+    REJECTED = "rejected"
+    ARCHIVED = "archived"
+
+
+@dataclass
+class StrategyReport:
+    """전략 검증 리포트."""
+
+    report_id: str
+    strategy_name: str
+    strategy_version: str
+    strategy_path: str
+    status: ReportStatus
+    submitted_at: datetime
+    submitted_by: str = "agent"
+
+    # 백테스트 결과 요약
+    backtest_period: str = ""
+    total_return_pct: float = 0.0
+    total_trades: int = 0
+    sharpe_ratio: float | None = None
+    max_drawdown_pct: float | None = None
+    win_rate: float | None = None
+
+    # Agent 코멘트
+    summary: str = ""
+    rationale: str = ""
+    risks: str = ""
+    recommendations: str = ""
+
+    # 상세 데이터 (JSON)
+    detail_json: str = "{}"
+
+    # 사용자 피드백
+    user_notes: str = ""
+    reviewed_at: datetime | None = None

--- a/src/ante/report/store.py
+++ b/src/ante/report/store.py
@@ -1,0 +1,248 @@
+"""ReportStore — 리포트 저장·관리."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from ante.report.models import ReportStatus, StrategyReport
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+
+logger = logging.getLogger(__name__)
+
+REPORT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS reports (
+    report_id          TEXT PRIMARY KEY,
+    strategy_name      TEXT NOT NULL,
+    strategy_version   TEXT NOT NULL,
+    strategy_path      TEXT NOT NULL,
+    status             TEXT NOT NULL DEFAULT 'submitted',
+    submitted_at       TEXT NOT NULL,
+    submitted_by       TEXT DEFAULT 'agent',
+    backtest_period    TEXT DEFAULT '',
+    total_return_pct   REAL DEFAULT 0.0,
+    total_trades       INTEGER DEFAULT 0,
+    sharpe_ratio       REAL,
+    max_drawdown_pct   REAL,
+    win_rate           REAL,
+    summary            TEXT DEFAULT '',
+    rationale          TEXT DEFAULT '',
+    risks              TEXT DEFAULT '',
+    recommendations    TEXT DEFAULT '',
+    detail_json        TEXT DEFAULT '{}',
+    user_notes         TEXT DEFAULT '',
+    reviewed_at        TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_reports_strategy
+    ON reports(strategy_name);
+CREATE INDEX IF NOT EXISTS idx_reports_status
+    ON reports(status);
+"""
+
+
+class ReportStore:
+    """리포트 저장·관리."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    async def initialize(self) -> None:
+        """스키마 생성."""
+        await self._db.execute_script(REPORT_SCHEMA)
+        logger.info("ReportStore 초기화 완료")
+
+    async def submit(self, report: StrategyReport) -> str:
+        """리포트 제출."""
+        await self._db.execute(
+            """INSERT INTO reports
+               (report_id, strategy_name, strategy_version,
+                strategy_path, status, submitted_at, submitted_by,
+                backtest_period, total_return_pct, total_trades,
+                sharpe_ratio, max_drawdown_pct, win_rate,
+                summary, rationale, risks, recommendations,
+                detail_json)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                       ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                report.report_id,
+                report.strategy_name,
+                report.strategy_version,
+                report.strategy_path,
+                report.status.value,
+                report.submitted_at.isoformat(),
+                report.submitted_by,
+                report.backtest_period,
+                report.total_return_pct,
+                report.total_trades,
+                report.sharpe_ratio,
+                report.max_drawdown_pct,
+                report.win_rate,
+                report.summary,
+                report.rationale,
+                report.risks,
+                report.recommendations,
+                report.detail_json,
+            ),
+        )
+        logger.info(
+            "리포트 제출: %s (%s v%s)",
+            report.report_id,
+            report.strategy_name,
+            report.strategy_version,
+        )
+        return report.report_id
+
+    async def get(self, report_id: str) -> StrategyReport | None:
+        """리포트 조회."""
+        row = await self._db.fetch_one(
+            "SELECT * FROM reports WHERE report_id = ?",
+            (report_id,),
+        )
+        if not row:
+            return None
+        return self._row_to_report(row)
+
+    async def list_reports(
+        self,
+        strategy_name: str | None = None,
+        status: ReportStatus | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[StrategyReport]:
+        """리포트 목록 조회."""
+        conditions: list[str] = []
+        params: list[object] = []
+
+        if strategy_name:
+            conditions.append("strategy_name = ?")
+            params.append(strategy_name)
+        if status:
+            conditions.append("status = ?")
+            params.append(status.value)
+
+        where = " AND ".join(conditions) if conditions else "1=1"
+        query = (
+            f"SELECT * FROM reports WHERE {where}"
+            " ORDER BY submitted_at DESC"
+            " LIMIT ? OFFSET ?"
+        )
+        params.extend([limit, offset])
+
+        rows = await self._db.fetch_all(query, tuple(params))
+        return [self._row_to_report(row) for row in rows]
+
+    async def update_status(
+        self,
+        report_id: str,
+        status: ReportStatus,
+        user_notes: str = "",
+    ) -> None:
+        """리포트 상태 변경."""
+        reviewed_at = (
+            datetime.now().isoformat()
+            if status
+            in (
+                ReportStatus.REVIEWED,
+                ReportStatus.ADOPTED,
+                ReportStatus.REJECTED,
+            )
+            else None
+        )
+        await self._db.execute(
+            """UPDATE reports
+               SET status = ?, user_notes = ?, reviewed_at = ?
+               WHERE report_id = ?""",
+            (status.value, user_notes, reviewed_at, report_id),
+        )
+        logger.info("리포트 상태 변경: %s → %s", report_id, status)
+
+    async def delete(self, report_id: str) -> None:
+        """리포트 삭제."""
+        await self._db.execute(
+            "DELETE FROM reports WHERE report_id = ?",
+            (report_id,),
+        )
+
+    @staticmethod
+    def get_schema() -> dict:
+        """리포트 제출 스키마 반환."""
+        return {
+            "required_fields": [
+                "strategy_name",
+                "strategy_version",
+                "strategy_path",
+                "backtest_period",
+                "total_return_pct",
+                "total_trades",
+                "summary",
+                "rationale",
+            ],
+            "optional_fields": [
+                "sharpe_ratio",
+                "max_drawdown_pct",
+                "win_rate",
+                "risks",
+                "recommendations",
+                "detail_json",
+            ],
+            "format": "JSON",
+            "example": {
+                "strategy_name": "momentum_breakout",
+                "strategy_version": "1.0.0",
+                "strategy_path": "strategies/momentum_breakout.py",
+                "backtest_period": "2024-01 ~ 2026-03",
+                "total_return_pct": 15.3,
+                "total_trades": 42,
+                "sharpe_ratio": 1.2,
+                "max_drawdown_pct": -8.5,
+                "win_rate": 0.58,
+                "summary": "20일 이동평균 돌파 매매 전략",
+                "rationale": "모멘텀 효과를 활용한 추세 추종",
+                "risks": "횡보장에서 잦은 손절 발생 가능",
+            },
+        }
+
+    @staticmethod
+    def _row_to_report(row: dict) -> StrategyReport:
+        """DB row → StrategyReport 변환."""
+        submitted_at = row["submitted_at"]
+        reviewed_at = row.get("reviewed_at")
+        return StrategyReport(
+            report_id=row["report_id"],
+            strategy_name=row["strategy_name"],
+            strategy_version=row["strategy_version"],
+            strategy_path=row["strategy_path"],
+            status=ReportStatus(row["status"]),
+            submitted_at=(
+                datetime.fromisoformat(submitted_at)
+                if isinstance(submitted_at, str)
+                else submitted_at
+            ),
+            submitted_by=row.get("submitted_by", "agent"),
+            backtest_period=row.get("backtest_period", ""),
+            total_return_pct=float(row.get("total_return_pct", 0)),
+            total_trades=int(row.get("total_trades", 0)),
+            sharpe_ratio=(
+                float(row["sharpe_ratio"])
+                if row.get("sharpe_ratio") is not None
+                else None
+            ),
+            max_drawdown_pct=(
+                float(row["max_drawdown_pct"])
+                if row.get("max_drawdown_pct") is not None
+                else None
+            ),
+            win_rate=(
+                float(row["win_rate"]) if row.get("win_rate") is not None else None
+            ),
+            summary=row.get("summary", ""),
+            rationale=row.get("rationale", ""),
+            risks=row.get("risks", ""),
+            recommendations=row.get("recommendations", ""),
+            detail_json=row.get("detail_json", "{}"),
+            user_notes=row.get("user_notes", ""),
+            reviewed_at=(datetime.fromisoformat(reviewed_at) if reviewed_at else None),
+        )

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -1,0 +1,302 @@
+"""Report Store 모듈 단위 테스트."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.core.database import Database
+from ante.report.feedback import PerformanceFeedback
+from ante.report.models import ReportStatus, StrategyReport
+from ante.report.store import ReportStore
+from ante.trade.models import (
+    PerformanceMetrics,
+    PositionSnapshot,
+)
+
+# ── Fixtures ─────────────────────────────────────────
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """테스트용 SQLite DB."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    return db
+
+
+@pytest.fixture
+async def store(db):
+    s = ReportStore(db)
+    await s.initialize()
+    return s
+
+
+def _make_report(
+    *,
+    report_id: str = "rpt-001",
+    strategy_name: str = "momentum_breakout",
+    strategy_version: str = "1.0.0",
+    status: ReportStatus = ReportStatus.SUBMITTED,
+) -> StrategyReport:
+    return StrategyReport(
+        report_id=report_id,
+        strategy_name=strategy_name,
+        strategy_version=strategy_version,
+        strategy_path="strategies/momentum_breakout.py",
+        status=status,
+        submitted_at=datetime.now(UTC),
+        submitted_by="agent",
+        backtest_period="2024-01 ~ 2026-03",
+        total_return_pct=15.3,
+        total_trades=42,
+        sharpe_ratio=1.2,
+        max_drawdown_pct=-8.5,
+        win_rate=0.58,
+        summary="20일 이동평균 돌파 매매 전략",
+        rationale="모멘텀 효과를 활용한 추세 추종",
+        risks="횡보장에서 잦은 손절 발생 가능",
+        recommendations="변동성 높은 종목에 적용 권장",
+        detail_json='{"equity_curve": [100, 105, 110]}',
+    )
+
+
+# ── ReportStore ──────────────────────────────────────
+
+
+class TestReportStore:
+    async def test_submit_and_get(self, store):
+        """리포트 제출 및 조회."""
+        report = _make_report()
+        rid = await store.submit(report)
+        assert rid == "rpt-001"
+
+        fetched = await store.get("rpt-001")
+        assert fetched is not None
+        assert fetched.strategy_name == "momentum_breakout"
+        assert fetched.total_return_pct == pytest.approx(15.3)
+        assert fetched.sharpe_ratio == pytest.approx(1.2)
+        assert fetched.win_rate == pytest.approx(0.58)
+
+    async def test_get_nonexistent(self, store):
+        """존재하지 않는 리포트 조회 시 None."""
+        assert await store.get("nonexistent") is None
+
+    async def test_list_reports(self, store):
+        """리포트 목록 조회."""
+        await store.submit(_make_report(report_id="rpt-001"))
+        await store.submit(_make_report(report_id="rpt-002"))
+        await store.submit(
+            _make_report(
+                report_id="rpt-003",
+                strategy_name="mean_reversion",
+            )
+        )
+
+        all_reports = await store.list_reports()
+        assert len(all_reports) == 3
+
+    async def test_list_reports_filter_strategy(self, store):
+        """전략명으로 필터."""
+        await store.submit(_make_report(report_id="rpt-001"))
+        await store.submit(
+            _make_report(
+                report_id="rpt-002",
+                strategy_name="mean_reversion",
+            )
+        )
+
+        filtered = await store.list_reports(strategy_name="momentum_breakout")
+        assert len(filtered) == 1
+        assert filtered[0].report_id == "rpt-001"
+
+    async def test_list_reports_filter_status(self, store):
+        """상태로 필터."""
+        await store.submit(_make_report(report_id="rpt-001"))
+        await store.submit(
+            _make_report(
+                report_id="rpt-002",
+                status=ReportStatus.ADOPTED,
+            )
+        )
+
+        submitted = await store.list_reports(status=ReportStatus.SUBMITTED)
+        assert len(submitted) == 1
+
+    async def test_list_reports_pagination(self, store):
+        """페이지네이션."""
+        for i in range(5):
+            await store.submit(_make_report(report_id=f"rpt-{i:03d}"))
+
+        page1 = await store.list_reports(limit=2, offset=0)
+        page2 = await store.list_reports(limit=2, offset=2)
+        assert len(page1) == 2
+        assert len(page2) == 2
+
+    async def test_update_status(self, store):
+        """리포트 상태 변경."""
+        await store.submit(_make_report())
+
+        await store.update_status(
+            "rpt-001",
+            ReportStatus.ADOPTED,
+            user_notes="실전 적용 결정",
+        )
+
+        report = await store.get("rpt-001")
+        assert report is not None
+        assert report.status == ReportStatus.ADOPTED
+        assert report.user_notes == "실전 적용 결정"
+        assert report.reviewed_at is not None
+
+    async def test_update_status_archived_no_reviewed_at(self, store):
+        """보관 상태로 변경 시 reviewed_at 미설정."""
+        await store.submit(_make_report())
+
+        await store.update_status("rpt-001", ReportStatus.ARCHIVED)
+
+        report = await store.get("rpt-001")
+        assert report is not None
+        assert report.status == ReportStatus.ARCHIVED
+        assert report.reviewed_at is None
+
+    async def test_delete(self, store):
+        """리포트 삭제."""
+        await store.submit(_make_report())
+        await store.delete("rpt-001")
+
+        assert await store.get("rpt-001") is None
+
+    async def test_get_schema(self):
+        """리포트 스키마 조회."""
+        schema = ReportStore.get_schema()
+        assert "required_fields" in schema
+        assert "optional_fields" in schema
+        assert "example" in schema
+        assert "strategy_name" in schema["required_fields"]
+
+    async def test_nullable_fields(self, store):
+        """선택 필드 None 저장."""
+        report = StrategyReport(
+            report_id="rpt-null",
+            strategy_name="test",
+            strategy_version="0.1",
+            strategy_path="strategies/test.py",
+            status=ReportStatus.SUBMITTED,
+            submitted_at=datetime.now(UTC),
+            sharpe_ratio=None,
+            max_drawdown_pct=None,
+            win_rate=None,
+        )
+        await store.submit(report)
+
+        fetched = await store.get("rpt-null")
+        assert fetched is not None
+        assert fetched.sharpe_ratio is None
+        assert fetched.max_drawdown_pct is None
+        assert fetched.win_rate is None
+
+
+# ── Models ───────────────────────────────────────────
+
+
+class TestModels:
+    def test_report_status_values(self):
+        """ReportStatus 값."""
+        assert ReportStatus.SUBMITTED == "submitted"
+        assert ReportStatus.REVIEWED == "reviewed"
+        assert ReportStatus.ADOPTED == "adopted"
+        assert ReportStatus.REJECTED == "rejected"
+        assert ReportStatus.ARCHIVED == "archived"
+
+    def test_strategy_report_defaults(self):
+        """StrategyReport 기본값."""
+        report = StrategyReport(
+            report_id="rpt-001",
+            strategy_name="test",
+            strategy_version="1.0",
+            strategy_path="strategies/test.py",
+            status=ReportStatus.SUBMITTED,
+            submitted_at=datetime.now(UTC),
+        )
+        assert report.submitted_by == "agent"
+        assert report.detail_json == "{}"
+        assert report.user_notes == ""
+
+
+# ── PerformanceFeedback ──────────────────────────────
+
+
+class TestPerformanceFeedback:
+    @pytest.fixture
+    def mock_trade_service(self):
+        ts = AsyncMock()
+        ts.get_performance = AsyncMock(
+            return_value=PerformanceMetrics(
+                total_trades=10,
+                winning_trades=6,
+                losing_trades=4,
+                win_rate=0.6,
+                total_pnl=50000.0,
+                total_commission=1000.0,
+                net_pnl=49000.0,
+                avg_profit=12000.0,
+                avg_loss=3000.0,
+                profit_factor=2.0,
+                max_drawdown=0.05,
+                max_drawdown_amount=10000.0,
+                sharpe_ratio=1.5,
+            )
+        )
+        ts.get_positions = AsyncMock(
+            return_value=[
+                PositionSnapshot(
+                    bot_id="bot1",
+                    symbol="005930",
+                    quantity=100,
+                    avg_entry_price=50000.0,
+                    realized_pnl=10000.0,
+                )
+            ]
+        )
+        ts.get_trades = AsyncMock(return_value=[])
+        return ts
+
+    @pytest.fixture
+    def mock_bot_manager(self):
+        bm = MagicMock()
+        bm.list_bots.return_value = [
+            {"bot_id": "bot1", "strategy_id": "s1"},
+            {"bot_id": "bot2", "strategy_id": "s2"},
+        ]
+        return bm
+
+    async def test_get_bot_performance(self, mock_trade_service, mock_bot_manager):
+        """봇 성과 조회."""
+        fb = PerformanceFeedback(mock_trade_service, mock_bot_manager)
+        result = await fb.get_bot_performance("bot1")
+
+        assert result["bot_id"] == "bot1"
+        assert result["metrics"]["total_trades"] == 10
+        assert result["metrics"]["win_rate"] == 0.6
+        assert result["metrics"]["net_pnl"] == 49000.0
+        assert len(result["current_positions"]) == 1
+        assert result["current_positions"][0]["symbol"] == "005930"
+
+    async def test_get_strategy_performance(self, mock_trade_service, mock_bot_manager):
+        """전략 성과 집계."""
+        fb = PerformanceFeedback(mock_trade_service, mock_bot_manager)
+        result = await fb.get_strategy_performance("s1")
+
+        assert result["strategy_id"] == "s1"
+        assert result["bot_count"] == 1  # bot1만 s1 전략
+
+    async def test_get_trade_history(self, mock_trade_service, mock_bot_manager):
+        """거래 이력 조회."""
+        fb = PerformanceFeedback(mock_trade_service, mock_bot_manager)
+        result = await fb.get_trade_history("bot1", limit=50)
+
+        assert isinstance(result, list)
+        mock_trade_service.get_trades.assert_called_once_with(bot_id="bot1", limit=50)


### PR DESCRIPTION
## Summary
- **ReportStore**: 전략 검증 리포트 CRUD (SQLite 영속, 필터/페이지네이션)
- **PerformanceFeedback**: Agent 피드백용 실전 성과 조회 서비스
- **StrategyReport/ReportStatus**: 리포트 데이터 모델
- **16 unit tests** 전체 통과

## Test plan
- [x] ReportStore: 제출/조회/목록/필터/페이지네이션/상태변경/삭제/스키마
- [x] PerformanceFeedback: 봇 성과/전략 성과/거래 이력 조회
- [x] 전체 288 테스트 통과 (기존 272 + 신규 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)