### PR TITLE
feat: Notification module

### DIFF
--- a/src/ante/notification/__init__.py
+++ b/src/ante/notification/__init__.py
@@ -1,0 +1,12 @@
+"""Notification — 외부 알림 채널 관리."""
+
+from ante.notification.base import NotificationAdapter, NotificationLevel
+from ante.notification.service import NotificationService
+from ante.notification.telegram import TelegramAdapter
+
+__all__ = [
+    "NotificationAdapter",
+    "NotificationLevel",
+    "NotificationService",
+    "TelegramAdapter",
+]

--- a/src/ante/notification/base.py
+++ b/src/ante/notification/base.py
@@ -1,0 +1,33 @@
+"""Notification Adapter ABC + 알림 레벨."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from enum import StrEnum
+
+
+class NotificationLevel(StrEnum):
+    """알림 레벨."""
+
+    CRITICAL = "critical"
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
+class NotificationAdapter(ABC):
+    """알림 채널 추상 기본 클래스."""
+
+    @abstractmethod
+    async def send(self, level: NotificationLevel, message: str) -> bool:
+        """알림 발송. 성공 시 True."""
+
+    @abstractmethod
+    async def send_rich(
+        self,
+        level: NotificationLevel,
+        title: str,
+        body: str,
+        metadata: dict | None = None,
+    ) -> bool:
+        """서식이 있는 알림 발송."""

--- a/src/ante/notification/service.py
+++ b/src/ante/notification/service.py
@@ -1,0 +1,133 @@
+"""NotificationService — 알림 라우팅 + 필터링."""
+
+from __future__ import annotations
+
+import logging
+from datetime import time
+from typing import TYPE_CHECKING
+
+from ante.notification.base import NotificationAdapter, NotificationLevel
+
+if TYPE_CHECKING:
+    from ante.eventbus.bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationService:
+    """알림 라우팅 및 필터링 서비스."""
+
+    def __init__(
+        self,
+        adapter: NotificationAdapter,
+        eventbus: EventBus,
+        min_level: NotificationLevel = NotificationLevel.INFO,
+        quiet_start: time | None = None,
+        quiet_end: time | None = None,
+    ) -> None:
+        self._adapter = adapter
+        self._eventbus = eventbus
+        self._min_level = min_level
+        self._quiet_start = quiet_start
+        self._quiet_end = quiet_end
+
+    def subscribe(self) -> None:
+        """이벤트 구독 등록."""
+        from ante.eventbus.events import (
+            BotErrorEvent,
+            NotificationEvent,
+            OrderFilledEvent,
+            TradingStateChangedEvent,
+        )
+
+        self._eventbus.subscribe(NotificationEvent, self._on_notification, priority=0)
+        self._eventbus.subscribe(BotErrorEvent, self._on_bot_error, priority=0)
+        self._eventbus.subscribe(OrderFilledEvent, self._on_order_filled, priority=0)
+        self._eventbus.subscribe(
+            TradingStateChangedEvent,
+            self._on_trading_state_changed,
+            priority=0,
+        )
+
+    async def _on_notification(self, event: object) -> None:
+        """NotificationEvent 처리."""
+        from ante.eventbus.events import NotificationEvent
+
+        if not isinstance(event, NotificationEvent):
+            return
+
+        level = NotificationLevel(event.level)
+        if self._should_send(level):
+            await self._adapter.send_rich(
+                level=level,
+                title=event.message,
+                body=event.detail,
+                metadata=event.metadata or None,
+            )
+
+    async def _on_bot_error(self, event: object) -> None:
+        """봇 에러 자동 알림."""
+        from ante.eventbus.events import BotErrorEvent
+
+        if not isinstance(event, BotErrorEvent):
+            return
+
+        await self._adapter.send(
+            NotificationLevel.ERROR,
+            f"봇 에러 [{event.bot_id}]: {event.error_message}",
+        )
+
+    async def _on_order_filled(self, event: object) -> None:
+        """체결 완료 알림."""
+        from ante.eventbus.events import OrderFilledEvent
+
+        if not isinstance(event, OrderFilledEvent):
+            return
+
+        if not self._should_send(NotificationLevel.INFO):
+            return
+
+        await self._adapter.send(
+            NotificationLevel.INFO,
+            f"체결 [{event.bot_id}] {event.symbol} "
+            f"{event.side} {event.quantity}주 @ {event.price:,.0f}원",
+        )
+
+    async def _on_trading_state_changed(self, event: object) -> None:
+        """거래 상태 변경 알림."""
+        from ante.eventbus.events import TradingStateChangedEvent
+
+        if not isinstance(event, TradingStateChangedEvent):
+            return
+
+        await self._adapter.send(
+            NotificationLevel.CRITICAL,
+            f"거래 상태 변경: {event.old_state} → {event.new_state} ({event.reason})",
+        )
+
+    def _should_send(self, level: NotificationLevel) -> bool:
+        """알림 발송 여부. CRITICAL은 항상 발송."""
+        if level == NotificationLevel.CRITICAL:
+            return True
+
+        level_order = {
+            NotificationLevel.CRITICAL: 0,
+            NotificationLevel.ERROR: 1,
+            NotificationLevel.WARNING: 2,
+            NotificationLevel.INFO: 3,
+        }
+        if level_order.get(level, 3) > level_order.get(self._min_level, 3):
+            return False
+
+        if self._quiet_start and self._quiet_end:
+            from datetime import datetime
+
+            now = datetime.now().time()
+            if self._quiet_start <= self._quiet_end:
+                if self._quiet_start <= now <= self._quiet_end:
+                    return False
+            else:
+                if now >= self._quiet_start or now <= self._quiet_end:
+                    return False
+
+        return True

--- a/src/ante/notification/telegram.py
+++ b/src/ante/notification/telegram.py
@@ -1,0 +1,76 @@
+"""TelegramAdapter — 텔레그램 봇 API 기반 알림."""
+
+from __future__ import annotations
+
+import logging
+
+from ante.notification.base import NotificationAdapter, NotificationLevel
+
+logger = logging.getLogger(__name__)
+
+LEVEL_EMOJI = {
+    NotificationLevel.CRITICAL: "\U0001f6a8",
+    NotificationLevel.ERROR: "\u274c",
+    NotificationLevel.WARNING: "\u26a0\ufe0f",
+    NotificationLevel.INFO: "\u2139\ufe0f",
+}
+
+
+class TelegramAdapter(NotificationAdapter):
+    """텔레그램 봇 API 기반 알림."""
+
+    def __init__(self, bot_token: str, chat_id: str) -> None:
+        self._bot_token = bot_token
+        self._chat_id = chat_id
+        self._api_base = f"https://api.telegram.org/bot{bot_token}"
+
+    async def send(self, level: NotificationLevel, message: str) -> bool:
+        """알림 발송."""
+        emoji = LEVEL_EMOJI.get(level, "\U0001f4cc")
+        text = f"{emoji} [{level.value.upper()}] {message}"
+        return await self._send_message(text)
+
+    async def send_rich(
+        self,
+        level: NotificationLevel,
+        title: str,
+        body: str,
+        metadata: dict | None = None,
+    ) -> bool:
+        """서식이 있는 알림 발송."""
+        emoji = LEVEL_EMOJI.get(level, "\U0001f4cc")
+        parts = [f"{emoji} *{title}*", body]
+        if metadata:
+            details = "\n".join(f"  `{k}`: {v}" for k, v in metadata.items())
+            parts.append(f"\n{details}")
+        text = "\n".join(parts)
+        return await self._send_message(text, parse_mode="Markdown")
+
+    async def _send_message(self, text: str, parse_mode: str = "") -> bool:
+        """텔레그램 sendMessage API 호출."""
+        try:
+            import aiohttp
+        except ImportError:
+            logger.error(
+                "aiohttp가 설치되지 않았습니다. pip install aiohttp로 설치하세요."
+            )
+            return False
+
+        url = f"{self._api_base}/sendMessage"
+        payload: dict = {
+            "chat_id": self._chat_id,
+            "text": text,
+        }
+        if parse_mode:
+            payload["parse_mode"] = parse_mode
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, json=payload) as resp:
+                    if resp.status == 200:
+                        return True
+                    logger.warning("텔레그램 발송 실패: status=%d", resp.status)
+                    return False
+        except Exception as e:
+            logger.error("텔레그램 발송 오류: %s", e)
+            return False

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -1,0 +1,278 @@
+"""Notification 모듈 단위 테스트."""
+
+from datetime import time
+
+import pytest
+
+from ante.eventbus import EventBus
+from ante.eventbus.events import (
+    BotErrorEvent,
+    NotificationEvent,
+    OrderFilledEvent,
+    TradingStateChangedEvent,
+)
+from ante.notification.base import NotificationAdapter, NotificationLevel
+from ante.notification.service import NotificationService
+from ante.notification.telegram import LEVEL_EMOJI, TelegramAdapter
+
+# ── NotificationLevel ────────────────────────────────
+
+
+class TestNotificationLevel:
+    def test_values(self):
+        """레벨 값."""
+        assert NotificationLevel.CRITICAL == "critical"
+        assert NotificationLevel.ERROR == "error"
+        assert NotificationLevel.WARNING == "warning"
+        assert NotificationLevel.INFO == "info"
+
+    def test_ordering(self):
+        """레벨 비교 가능."""
+        levels = [
+            NotificationLevel.CRITICAL,
+            NotificationLevel.ERROR,
+            NotificationLevel.WARNING,
+            NotificationLevel.INFO,
+        ]
+        assert len(levels) == 4
+
+
+# ── NotificationAdapter ABC ──────────────────────────
+
+
+class TestNotificationAdapterABC:
+    def test_cannot_instantiate(self):
+        """ABC 직접 인스턴스화 불가."""
+        with pytest.raises(TypeError):
+            NotificationAdapter()
+
+
+# ── TelegramAdapter ──────────────────────────────────
+
+
+class TestTelegramAdapter:
+    def test_init(self):
+        """초기화."""
+        adapter = TelegramAdapter("token123", "chat456")
+        assert adapter._bot_token == "token123"
+        assert adapter._chat_id == "chat456"
+
+    def test_level_emoji_mapping(self):
+        """레벨별 이모지 매핑."""
+        assert LEVEL_EMOJI[NotificationLevel.CRITICAL] is not None
+        assert LEVEL_EMOJI[NotificationLevel.ERROR] is not None
+        assert LEVEL_EMOJI[NotificationLevel.WARNING] is not None
+        assert LEVEL_EMOJI[NotificationLevel.INFO] is not None
+
+
+# ── MockAdapter ──────────────────────────────────────
+
+
+class MockAdapter(NotificationAdapter):
+    """테스트용 Mock 어댑터."""
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[NotificationLevel, str]] = []
+        self.sent_rich: list[dict] = []
+
+    async def send(self, level: NotificationLevel, message: str) -> bool:
+        self.sent.append((level, message))
+        return True
+
+    async def send_rich(
+        self,
+        level: NotificationLevel,
+        title: str,
+        body: str,
+        metadata: dict | None = None,
+    ) -> bool:
+        self.sent_rich.append(
+            {
+                "level": level,
+                "title": title,
+                "body": body,
+                "metadata": metadata,
+            }
+        )
+        return True
+
+
+# ── NotificationService ──────────────────────────────
+
+
+class TestNotificationService:
+    @pytest.fixture
+    def adapter(self):
+        return MockAdapter()
+
+    @pytest.fixture
+    def eventbus(self):
+        return EventBus()
+
+    @pytest.fixture
+    def service(self, adapter, eventbus):
+        svc = NotificationService(
+            adapter=adapter,
+            eventbus=eventbus,
+        )
+        svc.subscribe()
+        return svc
+
+    async def test_notification_event(self, service, eventbus, adapter):
+        """NotificationEvent → send_rich 호출."""
+        await eventbus.publish(
+            NotificationEvent(
+                level="info",
+                message="테스트 알림",
+                detail="상세 내용",
+            )
+        )
+        assert len(adapter.sent_rich) == 1
+        assert adapter.sent_rich[0]["title"] == "테스트 알림"
+        assert adapter.sent_rich[0]["body"] == "상세 내용"
+
+    async def test_bot_error_event(self, service, eventbus, adapter):
+        """BotErrorEvent → send 호출."""
+        await eventbus.publish(
+            BotErrorEvent(
+                bot_id="bot1",
+                error_message="Connection timeout",
+            )
+        )
+        assert len(adapter.sent) == 1
+        assert "봇 에러" in adapter.sent[0][1]
+        assert "bot1" in adapter.sent[0][1]
+        assert adapter.sent[0][0] == NotificationLevel.ERROR
+
+    async def test_order_filled_event(self, service, eventbus, adapter):
+        """OrderFilledEvent → 체결 알림."""
+        await eventbus.publish(
+            OrderFilledEvent(
+                order_id="ord1",
+                broker_order_id="bk1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=100.0,
+                price=72000.0,
+                order_type="market",
+            )
+        )
+        assert len(adapter.sent) == 1
+        assert "체결" in adapter.sent[0][1]
+        assert "005930" in adapter.sent[0][1]
+
+    async def test_trading_state_changed(self, service, eventbus, adapter):
+        """TradingStateChangedEvent → CRITICAL 알림."""
+        await eventbus.publish(
+            TradingStateChangedEvent(
+                old_state="active",
+                new_state="halted",
+                reason="일일 손실 한도 초과",
+                changed_by="rule_engine",
+            )
+        )
+        assert len(adapter.sent) == 1
+        assert adapter.sent[0][0] == NotificationLevel.CRITICAL
+
+    async def test_min_level_filter(self, adapter, eventbus):
+        """min_level 이하만 발송."""
+        svc = NotificationService(
+            adapter=adapter,
+            eventbus=eventbus,
+            min_level=NotificationLevel.ERROR,
+        )
+        svc.subscribe()
+
+        # INFO 레벨 알림 — 필터됨
+        await eventbus.publish(
+            NotificationEvent(
+                level="info",
+                message="필터 테스트",
+                detail="",
+            )
+        )
+        assert len(adapter.sent_rich) == 0
+
+        # ERROR 레벨 알림 — 발송됨
+        await eventbus.publish(
+            NotificationEvent(
+                level="error",
+                message="에러 알림",
+                detail="",
+            )
+        )
+        assert len(adapter.sent_rich) == 1
+
+    async def test_critical_always_sent(self, adapter, eventbus):
+        """CRITICAL은 min_level 무시하고 항상 발송."""
+        svc = NotificationService(
+            adapter=adapter,
+            eventbus=eventbus,
+            min_level=NotificationLevel.ERROR,
+        )
+        svc.subscribe()
+
+        await eventbus.publish(
+            NotificationEvent(
+                level="critical",
+                message="긴급",
+                detail="",
+            )
+        )
+        assert len(adapter.sent_rich) == 1
+
+    async def test_quiet_hours_blocks(self, adapter, eventbus):
+        """quiet_hours 동안 비긴급 알림 차단."""
+        svc = NotificationService(
+            adapter=adapter,
+            eventbus=eventbus,
+            quiet_start=time(0, 0),
+            quiet_end=time(23, 59),
+        )
+        svc.subscribe()
+
+        await eventbus.publish(
+            NotificationEvent(
+                level="info",
+                message="조용한 시간",
+                detail="",
+            )
+        )
+        assert len(adapter.sent_rich) == 0
+
+    async def test_quiet_hours_allows_critical(self, adapter, eventbus):
+        """quiet_hours 중에도 CRITICAL은 발송."""
+        svc = NotificationService(
+            adapter=adapter,
+            eventbus=eventbus,
+            quiet_start=time(0, 0),
+            quiet_end=time(23, 59),
+        )
+        svc.subscribe()
+
+        await eventbus.publish(
+            NotificationEvent(
+                level="critical",
+                message="긴급 알림",
+                detail="",
+            )
+        )
+        assert len(adapter.sent_rich) == 1
+
+    async def test_notification_with_metadata(self, service, eventbus, adapter):
+        """메타데이터 포함 알림."""
+        await eventbus.publish(
+            NotificationEvent(
+                level="warning",
+                message="대사 불일치",
+                detail="3건 보정",
+                metadata={"bot_id": "bot1", "count": 3},
+            )
+        )
+        assert len(adapter.sent_rich) == 1
+        assert adapter.sent_rich[0]["metadata"] == {
+            "bot_id": "bot1",
+            "count": 3,
+        }


### PR DESCRIPTION
## Summary
- NotificationAdapter ABC + TelegramAdapter 구현
- NotificationService: EventBus 이벤트 라우팅, min_level 필터링, quiet hours, CRITICAL 바이패스
- 14 unit tests 전체 통과

## Test plan
- [x] `ruff check` + `ruff format` 통과
- [x] `pytest tests/unit/test_notification.py` 14 passed
- [x] 전체 테스트 302 passed