### PR TITLE
feat: implement Data Pipeline module (Phase 4-1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ description = "AI-Native Trading Engine"
 requires-python = ">=3.11"
 dependencies = [
     "aiosqlite>=0.20",
+    "polars>=1.0",
+    "click>=8.1",
+    "fastapi>=0.115",
+    "uvicorn>=0.34",
 ]
 
 [project.optional-dependencies]

--- a/src/ante/data/__init__.py
+++ b/src/ante/data/__init__.py
@@ -1,0 +1,22 @@
+"""Data Pipeline — 시세 데이터의 수집·정규화·적재·조회."""
+
+from ante.data.catalog import DataCatalog
+from ante.data.collector import DataCollector
+from ante.data.injector import DataInjector
+from ante.data.normalizer import DataNormalizer
+from ante.data.retention import RetentionPolicy
+from ante.data.schemas import OHLCV_COLUMNS, OHLCV_SCHEMA, TICK_SCHEMA, TIMEFRAMES
+from ante.data.store import ParquetStore
+
+__all__ = [
+    "DataCatalog",
+    "DataCollector",
+    "DataInjector",
+    "DataNormalizer",
+    "OHLCV_COLUMNS",
+    "OHLCV_SCHEMA",
+    "ParquetStore",
+    "RetentionPolicy",
+    "TICK_SCHEMA",
+    "TIMEFRAMES",
+]

--- a/src/ante/data/catalog.py
+++ b/src/ante/data/catalog.py
@@ -1,0 +1,52 @@
+"""Data Pipeline — 보유 데이터 탐색 인터페이스."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ante.data.schemas import OHLCV_SCHEMA, TIMEFRAMES
+
+if TYPE_CHECKING:
+    from ante.data.store import ParquetStore
+
+
+class DataCatalog:
+    """보유 데이터 탐색 인터페이스. CLI `ante data list/schema`에서 사용."""
+
+    def __init__(self, store: ParquetStore) -> None:
+        self._store = store
+
+    def list_datasets(self) -> list[dict]:
+        """보유 데이터셋 목록. 종목×타임프레임 조합."""
+        datasets = []
+        for tf in TIMEFRAMES:
+            symbols = self._store.list_symbols(tf)
+            for symbol in symbols:
+                date_range = self._store.get_date_range(symbol, tf)
+                datasets.append(
+                    {
+                        "symbol": symbol,
+                        "timeframe": tf,
+                        "start": date_range[0] if date_range else None,
+                        "end": date_range[1] if date_range else None,
+                    }
+                )
+        return datasets
+
+    def get_schema(
+        self, symbol: str | None = None, timeframe: str | None = None
+    ) -> dict:
+        """데이터셋 스키마 조회. 현재는 OHLCV 스키마 고정 반환."""
+        return {k: str(v) for k, v in OHLCV_SCHEMA.items()}
+
+    def get_storage_summary(self) -> dict:
+        """저장 용량 요약."""
+        usage = self._store.get_storage_usage()
+        total = sum(usage.values())
+        return {
+            "total_bytes": total,
+            "total_mb": round(total / 1024 / 1024, 1),
+            "by_timeframe": {
+                tf: round(size / 1024 / 1024, 1) for tf, size in usage.items()
+            },
+        }

--- a/src/ante/data/collector.py
+++ b/src/ante/data/collector.py
@@ -1,0 +1,155 @@
+"""Data Pipeline — 봇 운영 중 실시간 시세 데이터 수집."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ante.data.store import ParquetStore
+    from ante.eventbus import EventBus
+
+DataCallback = Callable[[str, str], Awaitable[list[dict]]]
+
+logger = logging.getLogger(__name__)
+
+
+class DataCollector:
+    """봇 운영 중 실시간 시세 데이터를 수집하여 Parquet에 적재.
+
+    APIGateway를 통해 주기적으로 시세를 조회하고,
+    메모리 버퍼에 쌓은 뒤 일정 건수/시간마다 Parquet에 flush한다.
+    """
+
+    def __init__(
+        self,
+        store: ParquetStore,
+        eventbus: EventBus,
+        buffer_size: int = 100,
+        flush_interval: float = 300.0,
+        collect_interval: float = 60.0,
+    ) -> None:
+        self._store = store
+        self._eventbus = eventbus
+        self._buffer: dict[str, list[dict]] = {}  # "symbol:timeframe" → rows
+        self._buffer_size = buffer_size
+        self._flush_interval = flush_interval
+        self._collect_interval = collect_interval
+        self._symbols: list[str] = []
+        self._timeframes: list[str] = []
+        self._collect_task: asyncio.Task | None = None
+        self._flush_task: asyncio.Task | None = None
+        self._running = False
+        self._data_callback: DataCallback | None = None
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    @property
+    def buffer(self) -> dict[str, list[dict]]:
+        return self._buffer
+
+    def set_data_callback(self, callback: DataCallback) -> None:
+        """데이터 수집 콜백 설정. 시그니처: async (symbol, tf) -> list[dict]."""
+        self._data_callback = callback
+
+    async def start(self, symbols: list[str], timeframes: list[str]) -> None:
+        """데이터 수집 시작."""
+        if self._running:
+            logger.warning("DataCollector is already running")
+            return
+
+        self._symbols = symbols
+        self._timeframes = timeframes
+        self._running = True
+        self._collect_task = asyncio.create_task(self._collect_loop())
+        self._flush_task = asyncio.create_task(self._flush_loop())
+        logger.info(
+            "DataCollector started: symbols=%s, timeframes=%s",
+            symbols,
+            timeframes,
+        )
+
+    async def stop(self) -> None:
+        """데이터 수집 중지. 남은 버퍼를 flush."""
+        self._running = False
+        if self._collect_task:
+            self._collect_task.cancel()
+            self._collect_task = None
+        if self._flush_task:
+            self._flush_task.cancel()
+            self._flush_task = None
+
+        # 남은 데이터 flush
+        await self.flush_all()
+        logger.info("DataCollector stopped")
+
+    async def add_data(self, symbol: str, timeframe: str, row: dict) -> None:
+        """외부에서 직접 데이터를 추가 (이벤트 기반 수집 시 사용)."""
+        key = f"{symbol}:{timeframe}"
+        if key not in self._buffer:
+            self._buffer[key] = []
+        self._buffer[key].append(row)
+
+        if len(self._buffer[key]) >= self._buffer_size:
+            await self._flush(key)
+
+    async def flush_all(self) -> int:
+        """모든 버퍼 데이터를 Parquet에 flush. flush된 총 건수 반환."""
+        total = 0
+        for key in list(self._buffer.keys()):
+            if self._buffer[key]:
+                count = len(self._buffer[key])
+                await self._flush(key)
+                total += count
+        return total
+
+    async def _collect_loop(self) -> None:
+        """주기적으로 시세 데이터 수집."""
+        while self._running:
+            if self._data_callback:
+                for symbol in self._symbols:
+                    for tf in self._timeframes:
+                        try:
+                            rows = await self._data_callback(symbol, tf)
+                            for row in rows:
+                                await self.add_data(symbol, tf, row)
+                        except Exception as e:
+                            logger.warning(
+                                "Data collection failed for %s/%s: %s",
+                                symbol,
+                                tf,
+                                e,
+                            )
+            try:
+                await asyncio.sleep(self._collect_interval)
+            except asyncio.CancelledError:
+                break
+
+    async def _flush_loop(self) -> None:
+        """주기적 버퍼 flush."""
+        while self._running:
+            try:
+                await asyncio.sleep(self._flush_interval)
+            except asyncio.CancelledError:
+                break
+            await self.flush_all()
+
+    async def _flush(self, key: str) -> None:
+        """버퍼의 데이터를 Parquet에 적재."""
+        rows = self._buffer.pop(key, [])
+        if not rows:
+            return
+        symbol, tf = key.split(":")
+        try:
+            await self._store.append(symbol, tf, rows)
+            logger.debug("Flushed %d rows for %s/%s", len(rows), symbol, tf)
+        except Exception as e:
+            logger.error("Failed to flush data for %s/%s: %s", symbol, tf, e)
+            # 실패 시 버퍼에 다시 넣기
+            if key not in self._buffer:
+                self._buffer[key] = []
+            self._buffer[key] = rows + self._buffer[key]

--- a/src/ante/data/injector.py
+++ b/src/ante/data/injector.py
@@ -1,0 +1,97 @@
+"""Data Pipeline — 외부 소스에서 과거 데이터를 Parquet에 주입."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+if TYPE_CHECKING:
+    from ante.data.normalizer import DataNormalizer
+    from ante.data.store import ParquetStore
+
+logger = logging.getLogger(__name__)
+
+
+class DataInjector:
+    """외부 소스(CSV, API 등)에서 과거 데이터를 정규화하여 Parquet에 주입."""
+
+    def __init__(self, store: ParquetStore, normalizer: DataNormalizer) -> None:
+        self._store = store
+        self._normalizer = normalizer
+
+    async def inject_csv(
+        self,
+        filepath: str | Path,
+        symbol: str,
+        timeframe: str,
+        source: str = "external",
+        format_hint: str | None = None,
+    ) -> int:
+        """CSV 파일에서 데이터 주입.
+
+        Args:
+            filepath: CSV 파일 경로
+            symbol: 종목 코드
+            timeframe: 타임프레임
+            source: 데이터 소스 식별자
+            format_hint: 소스별 컬럼 매핑 힌트
+
+        Returns:
+            주입된 행 수
+        """
+        filepath = Path(filepath)
+        if not filepath.exists():
+            raise FileNotFoundError(f"CSV 파일을 찾을 수 없습니다: {filepath}")
+
+        df = pl.read_csv(str(filepath))
+        if df.is_empty():
+            logger.warning("Empty CSV file: %s", filepath)
+            return 0
+
+        normalized = self._normalizer.normalize(
+            df, source=source, format_hint=format_hint
+        )
+        normalized = normalized.with_columns(pl.lit(symbol).alias("symbol"))
+
+        await self._store.write(symbol, timeframe, normalized)
+        logger.info(
+            "Injected %d rows from %s for %s/%s",
+            len(normalized),
+            filepath.name,
+            symbol,
+            timeframe,
+        )
+        return len(normalized)
+
+    async def inject_dataframe(
+        self,
+        df: pl.DataFrame,
+        symbol: str,
+        timeframe: str,
+        source: str = "external",
+    ) -> int:
+        """DataFrame을 직접 주입.
+
+        Args:
+            df: 정규화된 OHLCV DataFrame
+            symbol: 종목 코드
+            timeframe: 타임프레임
+            source: 데이터 소스 식별자
+
+        Returns:
+            주입된 행 수
+        """
+        if df.is_empty():
+            return 0
+
+        if "symbol" not in df.columns:
+            df = df.with_columns(pl.lit(symbol).alias("symbol"))
+        if "source" not in df.columns:
+            df = df.with_columns(pl.lit(source).alias("source"))
+
+        await self._store.write(symbol, timeframe, df)
+        logger.info("Injected %d rows for %s/%s", len(df), symbol, timeframe)
+        return len(df)

--- a/src/ante/data/normalizer.py
+++ b/src/ante/data/normalizer.py
@@ -1,0 +1,120 @@
+"""Data Pipeline — 다양한 소스의 데이터를 통일된 스키마로 정규화."""
+
+from __future__ import annotations
+
+import logging
+
+import polars as pl
+
+from ante.data.schemas import OHLCV_COLUMNS
+
+logger = logging.getLogger(__name__)
+
+# 소스별 컬럼 매핑 규칙
+COLUMN_MAPPINGS: dict[str, dict[str, str]] = {
+    "kis": {
+        "stck_bsop_date": "date",
+        "stck_clpr": "close",
+        "stck_oprc": "open",
+        "stck_hgpr": "high",
+        "stck_lwpr": "low",
+        "acml_vol": "volume",
+    },
+    "yahoo": {
+        "Date": "timestamp",
+        "Open": "open",
+        "High": "high",
+        "Low": "low",
+        "Close": "close",
+        "Volume": "volume",
+    },
+    "default": {
+        "date": "timestamp",
+        "datetime": "timestamp",
+        "time": "timestamp",
+        "open": "open",
+        "high": "high",
+        "low": "low",
+        "close": "close",
+        "volume": "volume",
+        "vol": "volume",
+    },
+}
+
+
+class DataNormalizer:
+    """다양한 소스의 DataFrame을 OHLCV 공통 스키마로 정규화."""
+
+    def normalize(
+        self,
+        df: pl.DataFrame,
+        source: str = "external",
+        format_hint: str | None = None,
+    ) -> pl.DataFrame:
+        """DataFrame을 OHLCV 스키마로 정규화.
+
+        Args:
+            df: 원본 DataFrame
+            source: 데이터 소스 식별자 ("kis", "yahoo", "external" 등)
+            format_hint: 소스별 컬럼 매핑 힌트. None이면 자동 감지.
+
+        Returns:
+            OHLCV 스키마에 맞춰 정규화된 DataFrame.
+        """
+        mapping_key = format_hint or source
+        mapping = COLUMN_MAPPINGS.get(mapping_key, COLUMN_MAPPINGS["default"])
+
+        # 컬럼 이름 매핑 적용
+        rename_map: dict[str, str] = {}
+        for src_col, dst_col in mapping.items():
+            if src_col in df.columns:
+                rename_map[src_col] = dst_col
+
+        if rename_map:
+            df = df.rename(rename_map)
+
+        # timestamp 컬럼 처리
+        df = self._normalize_timestamp(df)
+
+        # 숫자 컬럼 타입 변환
+        for col in ["open", "high", "low", "close"]:
+            if col in df.columns:
+                df = df.with_columns(pl.col(col).cast(pl.Float64))
+
+        if "volume" in df.columns:
+            df = df.with_columns(pl.col("volume").cast(pl.Int64))
+
+        # source 컬럼 추가
+        if "source" not in df.columns:
+            df = df.with_columns(pl.lit(source).alias("source"))
+
+        # symbol 컬럼 없으면 빈 문자열 (호출자가 채움)
+        if "symbol" not in df.columns:
+            df = df.with_columns(pl.lit("").alias("symbol"))
+
+        # 필요한 컬럼만 선택 (존재하는 것만)
+        available = [c for c in OHLCV_COLUMNS if c in df.columns]
+        df = df.select(available)
+
+        return df.sort("timestamp")
+
+    def _normalize_timestamp(self, df: pl.DataFrame) -> pl.DataFrame:
+        """timestamp 컬럼을 Datetime[ns]로 정규화."""
+        if "timestamp" not in df.columns:
+            raise ValueError("DataFrame에 timestamp 컬럼이 없습니다.")
+
+        ts_dtype = df["timestamp"].dtype
+        if ts_dtype == pl.Utf8:
+            # 문자열 → datetime 변환 시도
+            df = df.with_columns(pl.col("timestamp").str.to_datetime(time_zone="UTC"))
+        elif ts_dtype == pl.Date:
+            df = df.with_columns(
+                pl.col("timestamp").cast(pl.Datetime("ns")).dt.replace_time_zone("UTC")
+            )
+        elif isinstance(ts_dtype, pl.Datetime):
+            if ts_dtype.time_zone is None:
+                df = df.with_columns(pl.col("timestamp").dt.replace_time_zone("UTC"))
+        else:
+            raise ValueError(f"지원하지 않는 timestamp 타입: {ts_dtype}")
+
+        return df

--- a/src/ante/data/retention.py
+++ b/src/ante/data/retention.py
@@ -1,0 +1,87 @@
+"""Data Pipeline — 데이터 보존 정책. 오래된 데이터 삭제로 용량 관리."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from ante.data.store import ParquetStore
+
+logger = logging.getLogger(__name__)
+
+
+class RetentionPolicy:
+    """데이터 보존 정책 — 오래된 데이터 삭제로 용량 관리.
+
+    타임프레임별로 보존 기간을 설정하고, 초과된 데이터를 자동 삭제한다.
+    """
+
+    DEFAULT_RETENTION: dict[str, int] = {
+        "1m": 90,  # 1분봉: 90일
+        "5m": 180,  # 5분봉: 180일
+        "15m": 365,  # 15분봉: 1년
+        "1h": 365,  # 1시간봉: 1년
+        "1d": 3650,  # 일봉: 10년
+    }
+
+    def __init__(
+        self,
+        store: ParquetStore,
+        retention_days: dict[str, int] | None = None,
+    ) -> None:
+        self._store = store
+        self._retention = retention_days or self.DEFAULT_RETENTION.copy()
+
+    @property
+    def retention_days(self) -> dict[str, int]:
+        return self._retention
+
+    async def enforce(self, now: datetime | None = None) -> dict[str, int]:
+        """보존 정책 적용. 삭제된 파일 수를 timeframe별로 반환.
+
+        Args:
+            now: 기준 시간 (테스트용). None이면 현재 UTC.
+
+        Returns:
+            {"1m": 3, "5m": 1, ...} 형태의 삭제 건수
+        """
+        if now is None:
+            now = datetime.now(UTC)
+
+        deleted: dict[str, int] = {}
+
+        for tf, max_days in self._retention.items():
+            count = 0
+            symbols = self._store.list_symbols(tf)
+
+            for symbol in symbols:
+                date_range = self._store.get_date_range(symbol, tf)
+                if not date_range:
+                    continue
+
+                # Parquet 파일 순회
+                path = self._store.base_path / "ohlcv" / tf / symbol
+                if not path.exists():
+                    continue
+
+                for parquet_file in sorted(path.glob("*.parquet")):
+                    month_str = parquet_file.stem  # "2024-01"
+                    try:
+                        # 월 파일의 마지막 날을 기준으로 판단
+                        year, month = month_str.split("-")
+                        # 해당 월의 말일 근사치 (다음달 1일 - 1일)
+                        file_month_end = datetime(int(year), int(month), 28, tzinfo=UTC)
+                        age_days = (now - file_month_end).days
+
+                        if age_days > max_days:
+                            if self._store.delete_file(symbol, tf, month_str):
+                                count += 1
+                    except (ValueError, IndexError):
+                        logger.warning("Invalid parquet filename: %s", parquet_file)
+                        continue
+
+            if count > 0:
+                deleted[tf] = count
+                logger.info("Retention: deleted %d files for timeframe %s", count, tf)
+
+        return deleted

--- a/src/ante/data/schemas.py
+++ b/src/ante/data/schemas.py
@@ -1,0 +1,46 @@
+"""Data Pipeline — 정규화된 데이터 스키마 정의."""
+
+from __future__ import annotations
+
+import polars as pl
+
+# 모든 시세 데이터의 공통 스키마 (OHLCV)
+OHLCV_SCHEMA: dict[str, type[pl.DataType]] = {
+    "timestamp": pl.Datetime("ns"),
+    "symbol": pl.Utf8,
+    "open": pl.Float64,
+    "high": pl.Float64,
+    "low": pl.Float64,
+    "close": pl.Float64,
+    "volume": pl.Int64,
+    "source": pl.Utf8,
+}
+
+OHLCV_COLUMNS: list[str] = list(OHLCV_SCHEMA.keys())
+
+# 틱 데이터 스키마 (선택적 수집)
+TICK_SCHEMA: dict[str, type[pl.DataType]] = {
+    "timestamp": pl.Datetime("ns"),
+    "symbol": pl.Utf8,
+    "price": pl.Float64,
+    "volume": pl.Int64,
+    "side": pl.Utf8,
+}
+
+# 지원되는 타임프레임
+TIMEFRAMES: list[str] = ["1m", "5m", "15m", "1h", "1d"]
+
+
+def validate_ohlcv(df: pl.DataFrame) -> bool:
+    """OHLCV DataFrame이 스키마에 부합하는지 검증."""
+    required = {
+        "timestamp",
+        "symbol",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "source",
+    }
+    return required.issubset(set(df.columns))

--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -1,0 +1,158 @@
+"""Data Pipeline — Parquet 파일 읽기/쓰기/관리."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import polars as pl
+
+logger = logging.getLogger(__name__)
+
+
+class ParquetStore:
+    """Parquet 파일 관리. OHLCV 데이터의 읽기/쓰기/파티셔닝 담당."""
+
+    def __init__(
+        self, base_path: str | Path = "data/", compression: str = "snappy"
+    ) -> None:
+        self._base = Path(base_path)
+        self._compression = compression
+
+    @property
+    def base_path(self) -> Path:
+        return self._base
+
+    async def read(
+        self,
+        symbol: str,
+        timeframe: str,
+        start: str | None = None,
+        end: str | None = None,
+        limit: int | None = None,
+    ) -> pl.DataFrame:
+        """Parquet에서 OHLCV 데이터 읽기.
+
+        Args:
+            symbol: 종목 코드
+            timeframe: 타임프레임 (1m, 5m, 15m, 1h, 1d)
+            start: 시작 시간 (ISO 형식, inclusive)
+            end: 종료 시간 (ISO 형식, inclusive)
+            limit: 최근 N건만 반환
+        """
+        path = self._base / "ohlcv" / timeframe / symbol
+        if not path.exists():
+            return pl.DataFrame()
+
+        files = sorted(path.glob("*.parquet"))
+        if not files:
+            return pl.DataFrame()
+
+        dfs = []
+        for f in files:
+            try:
+                dfs.append(pl.read_parquet(f))
+            except Exception:
+                logger.warning("Failed to read parquet file: %s", f)
+                continue
+
+        if not dfs:
+            return pl.DataFrame()
+
+        df = pl.concat(dfs)
+
+        if start:
+            df = df.filter(
+                pl.col("timestamp") >= pl.lit(start).str.to_datetime(time_zone="UTC")
+            )
+        if end:
+            df = df.filter(
+                pl.col("timestamp") <= pl.lit(end).str.to_datetime(time_zone="UTC")
+            )
+
+        df = df.sort("timestamp")
+
+        if limit:
+            df = df.tail(limit)
+
+        return df
+
+    async def write(self, symbol: str, timeframe: str, data: pl.DataFrame) -> None:
+        """데이터를 Parquet에 기록. 월별 파티셔닝, 중복 제거(merge)."""
+        if data.is_empty():
+            return
+
+        path = self._base / "ohlcv" / timeframe / symbol
+        path.mkdir(parents=True, exist_ok=True)
+
+        # 월별 파티셔닝
+        month_col = data["timestamp"].dt.strftime("%Y-%m")
+        data_with_month = data.with_columns(month_col.alias("_month"))
+
+        for month_val in data_with_month["_month"].unique().to_list():
+            group = data_with_month.filter(pl.col("_month") == month_val).drop("_month")
+            filepath = path / f"{month_val}.parquet"
+
+            if filepath.exists():
+                try:
+                    existing = pl.read_parquet(filepath)
+                    merged = (
+                        pl.concat([existing, group])
+                        .unique(subset=["timestamp"])
+                        .sort("timestamp")
+                    )
+                    merged.write_parquet(str(filepath), compression=self._compression)
+                except Exception:
+                    logger.warning(
+                        "Failed to merge with existing file: %s, overwriting", filepath
+                    )
+                    group.sort("timestamp").write_parquet(
+                        str(filepath), compression=self._compression
+                    )
+            else:
+                group.sort("timestamp").write_parquet(
+                    str(filepath), compression=self._compression
+                )
+
+        logger.debug("Wrote %d rows for %s/%s", len(data), symbol, timeframe)
+
+    async def append(self, symbol: str, timeframe: str, rows: list[dict]) -> None:
+        """버퍼 데이터를 기존 Parquet에 추가."""
+        df = pl.DataFrame(rows)
+        await self.write(symbol, timeframe, df)
+
+    def list_symbols(self, timeframe: str = "1d") -> list[str]:
+        """보유 데이터의 종목 목록."""
+        path = self._base / "ohlcv" / timeframe
+        if not path.exists():
+            return []
+        return sorted([d.name for d in path.iterdir() if d.is_dir()])
+
+    def get_date_range(self, symbol: str, timeframe: str) -> tuple[str, str] | None:
+        """종목의 데이터 기간 조회. (첫 파일 stem, 마지막 파일 stem) 반환."""
+        path = self._base / "ohlcv" / timeframe / symbol
+        files = sorted(path.glob("*.parquet")) if path.exists() else []
+        if not files:
+            return None
+        return files[0].stem, files[-1].stem
+
+    def get_storage_usage(self) -> dict[str, int]:
+        """저장 용량 현황 (바이트). timeframe별 합산."""
+        usage: dict[str, int] = {}
+        ohlcv_path = self._base / "ohlcv"
+        if not ohlcv_path.exists():
+            return usage
+        for tf_dir in ohlcv_path.iterdir():
+            if tf_dir.is_dir():
+                size = sum(f.stat().st_size for f in tf_dir.rglob("*.parquet"))
+                usage[tf_dir.name] = size
+        return usage
+
+    def delete_file(self, symbol: str, timeframe: str, month: str) -> bool:
+        """특정 Parquet 파일 삭제. 성공 여부 반환."""
+        filepath = self._base / "ohlcv" / timeframe / symbol / f"{month}.parquet"
+        if filepath.exists():
+            filepath.unlink()
+            logger.info("Deleted parquet file: %s", filepath)
+            return True
+        return False

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -1,0 +1,573 @@
+"""Data Pipeline 모듈 단위 테스트."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import polars as pl
+import pytest
+
+from ante.data.catalog import DataCatalog
+from ante.data.collector import DataCollector
+from ante.data.injector import DataInjector
+from ante.data.normalizer import DataNormalizer
+from ante.data.retention import RetentionPolicy
+from ante.data.schemas import OHLCV_COLUMNS, TIMEFRAMES, validate_ohlcv
+from ante.data.store import ParquetStore
+
+# ── Fixtures ─────────────────────────────────────────
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    """테스트용 데이터 디렉토리."""
+    return tmp_path / "data"
+
+
+@pytest.fixture
+def store(data_dir):
+    return ParquetStore(base_path=data_dir)
+
+
+@pytest.fixture
+def normalizer():
+    return DataNormalizer()
+
+
+@pytest.fixture
+def catalog(store):
+    return DataCatalog(store)
+
+
+def _make_ohlcv_df(
+    symbol: str = "005930",
+    n: int = 5,
+    start: str = "2026-03-01T09:00:00",
+) -> pl.DataFrame:
+    """테스트용 OHLCV DataFrame 생성."""
+    timestamps = pl.datetime_range(
+        datetime.fromisoformat(start),
+        datetime.fromisoformat(start).replace(minute=n - 1),
+        interval="1m",
+        eager=True,
+        time_zone="UTC",
+    )
+    return pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": [symbol] * n,
+            "open": [50000.0 + i * 100 for i in range(n)],
+            "high": [50100.0 + i * 100 for i in range(n)],
+            "low": [49900.0 + i * 100 for i in range(n)],
+            "close": [50050.0 + i * 100 for i in range(n)],
+            "volume": [1000 + i * 10 for i in range(n)],
+            "source": ["test"] * n,
+        }
+    )
+
+
+# ── schemas.py 테스트 ─────────────────────────────────
+
+
+class TestSchemas:
+    def test_ohlcv_columns_list(self):
+        assert "timestamp" in OHLCV_COLUMNS
+        assert "symbol" in OHLCV_COLUMNS
+        assert "close" in OHLCV_COLUMNS
+        assert len(OHLCV_COLUMNS) == 8
+
+    def test_timeframes(self):
+        assert "1m" in TIMEFRAMES
+        assert "1d" in TIMEFRAMES
+
+    def test_validate_ohlcv_valid(self):
+        df = _make_ohlcv_df()
+        assert validate_ohlcv(df) is True
+
+    def test_validate_ohlcv_missing_column(self):
+        df = _make_ohlcv_df().drop("volume")
+        assert validate_ohlcv(df) is False
+
+
+# ── store.py 테스트 ─────────────────────────────────
+
+
+class TestParquetStore:
+    async def test_write_and_read(self, store):
+        df = _make_ohlcv_df()
+        await store.write("005930", "1m", df)
+
+        result = await store.read("005930", "1m")
+        assert len(result) == 5
+        assert result["symbol"][0] == "005930"
+
+    async def test_read_empty(self, store):
+        result = await store.read("999999", "1d")
+        assert result.is_empty()
+
+    async def test_write_creates_partitioned_files(self, store, data_dir):
+        df = _make_ohlcv_df()
+        await store.write("005930", "1m", df)
+
+        parquet_path = data_dir / "ohlcv" / "1m" / "005930" / "2026-03.parquet"
+        assert parquet_path.exists()
+
+    async def test_write_merge_dedup(self, store):
+        """같은 timestamp 데이터를 두 번 쓰면 중복 제거."""
+        df = _make_ohlcv_df(n=3)
+        await store.write("005930", "1m", df)
+        await store.write("005930", "1m", df)
+
+        result = await store.read("005930", "1m")
+        assert len(result) == 3  # 중복 제거됨
+
+    async def test_read_with_time_filter(self, store):
+        df = _make_ohlcv_df(n=10, start="2026-03-01T09:00:00")
+        await store.write("005930", "1m", df)
+
+        result = await store.read(
+            "005930",
+            "1m",
+            start="2026-03-01T09:03:00",
+            end="2026-03-01T09:07:00",
+        )
+        assert len(result) == 5
+
+    async def test_read_with_limit(self, store):
+        df = _make_ohlcv_df(n=10)
+        await store.write("005930", "1m", df)
+
+        result = await store.read("005930", "1m", limit=3)
+        assert len(result) == 3
+
+    async def test_append(self, store):
+        rows = [
+            {
+                "timestamp": datetime(2026, 3, 1, 9, 0, tzinfo=UTC),
+                "symbol": "005930",
+                "open": 50000.0,
+                "high": 50100.0,
+                "low": 49900.0,
+                "close": 50050.0,
+                "volume": 1000,
+                "source": "test",
+            }
+        ]
+        await store.append("005930", "1m", rows)
+        result = await store.read("005930", "1m")
+        assert len(result) == 1
+
+    async def test_list_symbols(self, store):
+        await store.write("005930", "1d", _make_ohlcv_df("005930"))
+        await store.write("000660", "1d", _make_ohlcv_df("000660"))
+
+        symbols = store.list_symbols("1d")
+        assert symbols == ["000660", "005930"]
+
+    async def test_list_symbols_empty(self, store):
+        assert store.list_symbols("1d") == []
+
+    async def test_get_date_range(self, store):
+        await store.write("005930", "1m", _make_ohlcv_df())
+        result = store.get_date_range("005930", "1m")
+        assert result is not None
+        assert result == ("2026-03", "2026-03")
+
+    async def test_get_date_range_none(self, store):
+        assert store.get_date_range("999999", "1m") is None
+
+    async def test_get_storage_usage(self, store):
+        await store.write("005930", "1d", _make_ohlcv_df())
+        usage = store.get_storage_usage()
+        assert "1d" in usage
+        assert usage["1d"] > 0
+
+    async def test_delete_file(self, store):
+        await store.write("005930", "1m", _make_ohlcv_df())
+        assert store.delete_file("005930", "1m", "2026-03") is True
+        result = await store.read("005930", "1m")
+        assert result.is_empty()
+
+    async def test_delete_file_nonexistent(self, store):
+        assert store.delete_file("005930", "1m", "2099-01") is False
+
+    async def test_write_empty_df(self, store):
+        empty = pl.DataFrame()
+        await store.write("005930", "1m", empty)
+        result = await store.read("005930", "1m")
+        assert result.is_empty()
+
+    async def test_multi_month_partitioning(self, store, data_dir):
+        """2개월에 걸친 데이터가 각각 별도 파일로 파티셔닝."""
+        ts_march = pl.datetime_range(
+            datetime(2026, 3, 1, 9, 0),
+            datetime(2026, 3, 1, 9, 2),
+            interval="1m",
+            eager=True,
+            time_zone="UTC",
+        )
+        ts_april = pl.datetime_range(
+            datetime(2026, 4, 1, 9, 0),
+            datetime(2026, 4, 1, 9, 2),
+            interval="1m",
+            eager=True,
+            time_zone="UTC",
+        )
+        timestamps = ts_march.extend(ts_april)
+        n = len(timestamps)
+        df = pl.DataFrame(
+            {
+                "timestamp": timestamps,
+                "symbol": ["005930"] * n,
+                "open": [50000.0] * n,
+                "high": [50100.0] * n,
+                "low": [49900.0] * n,
+                "close": [50050.0] * n,
+                "volume": [1000] * n,
+                "source": ["test"] * n,
+            }
+        )
+        await store.write("005930", "1m", df)
+
+        march_file = data_dir / "ohlcv" / "1m" / "005930" / "2026-03.parquet"
+        april_file = data_dir / "ohlcv" / "1m" / "005930" / "2026-04.parquet"
+        assert march_file.exists()
+        assert april_file.exists()
+
+
+# ── normalizer.py 테스트 ─────────────────────────────
+
+
+class TestDataNormalizer:
+    def test_normalize_default_format(self, normalizer):
+        df = pl.DataFrame(
+            {
+                "date": ["2026-03-01T09:00:00", "2026-03-01T09:01:00"],
+                "open": [50000, 50100],
+                "high": [50100, 50200],
+                "low": [49900, 50000],
+                "close": [50050, 50150],
+                "volume": [1000, 1100],
+            }
+        )
+        result = normalizer.normalize(df, source="external")
+        assert "timestamp" in result.columns
+        assert "source" in result.columns
+        assert result["source"][0] == "external"
+
+    def test_normalize_yahoo_format(self, normalizer):
+        df = pl.DataFrame(
+            {
+                "Date": ["2026-03-01T09:00:00", "2026-03-01T09:01:00"],
+                "Open": [50000, 50100],
+                "High": [50100, 50200],
+                "Low": [49900, 50000],
+                "Close": [50050, 50150],
+                "Volume": [1000, 1100],
+            }
+        )
+        result = normalizer.normalize(df, source="yahoo")
+        assert "timestamp" in result.columns
+        assert len(result) == 2
+
+    def test_normalize_adds_symbol_if_missing(self, normalizer):
+        df = pl.DataFrame(
+            {
+                "timestamp": ["2026-03-01T09:00:00"],
+                "open": [50000.0],
+                "high": [50100.0],
+                "low": [49900.0],
+                "close": [50050.0],
+                "volume": [1000],
+            }
+        )
+        result = normalizer.normalize(df)
+        assert "symbol" in result.columns
+        assert result["symbol"][0] == ""
+
+    def test_normalize_preserves_existing_source(self, normalizer):
+        df = pl.DataFrame(
+            {
+                "timestamp": ["2026-03-01T09:00:00"],
+                "open": [50000.0],
+                "high": [50100.0],
+                "low": [49900.0],
+                "close": [50050.0],
+                "volume": [1000],
+                "source": ["custom"],
+            }
+        )
+        result = normalizer.normalize(df)
+        assert result["source"][0] == "custom"
+
+    def test_normalize_no_timestamp_raises(self, normalizer):
+        df = pl.DataFrame({"open": [50000.0], "close": [50050.0]})
+        with pytest.raises(ValueError, match="timestamp"):
+            normalizer.normalize(df)
+
+    def test_normalize_date_type(self, normalizer):
+        """Date 타입 timestamp도 정규화."""
+        from datetime import date
+
+        df = pl.DataFrame(
+            {
+                "timestamp": [date(2026, 3, 1)],
+                "open": [50000.0],
+                "high": [50100.0],
+                "low": [49900.0],
+                "close": [50050.0],
+                "volume": [1000],
+            }
+        )
+        result = normalizer.normalize(df)
+        assert isinstance(result["timestamp"].dtype, pl.Datetime)
+
+    def test_normalize_casts_numeric_types(self, normalizer):
+        df = pl.DataFrame(
+            {
+                "timestamp": ["2026-03-01T09:00:00"],
+                "open": [50000],  # int
+                "high": [50100],
+                "low": [49900],
+                "close": [50050],
+                "volume": [1000],
+            }
+        )
+        result = normalizer.normalize(df)
+        assert result["open"].dtype == pl.Float64
+        assert result["volume"].dtype == pl.Int64
+
+
+# ── collector.py 테스트 ─────────────────────────────
+
+
+class TestDataCollector:
+    async def test_add_data_and_flush(self, store):
+        from unittest.mock import AsyncMock
+
+        eventbus = AsyncMock()
+        collector = DataCollector(store=store, eventbus=eventbus, buffer_size=3)
+
+        row = {
+            "timestamp": datetime(2026, 3, 1, 9, 0, tzinfo=UTC),
+            "symbol": "005930",
+            "open": 50000.0,
+            "high": 50100.0,
+            "low": 49900.0,
+            "close": 50050.0,
+            "volume": 1000,
+            "source": "test",
+        }
+        await collector.add_data("005930", "1m", row)
+        assert len(collector.buffer["005930:1m"]) == 1
+
+        flushed = await collector.flush_all()
+        assert flushed == 1
+        assert "005930:1m" not in collector.buffer
+
+    async def test_auto_flush_on_buffer_full(self, store):
+        from unittest.mock import AsyncMock
+
+        eventbus = AsyncMock()
+        collector = DataCollector(store=store, eventbus=eventbus, buffer_size=2)
+
+        for i in range(2):
+            row = {
+                "timestamp": datetime(2026, 3, 1, 9, i, tzinfo=UTC),
+                "symbol": "005930",
+                "open": 50000.0,
+                "high": 50100.0,
+                "low": 49900.0,
+                "close": 50050.0,
+                "volume": 1000,
+                "source": "test",
+            }
+            await collector.add_data("005930", "1m", row)
+
+        # buffer_size=2이므로 자동 flush됨
+        assert "005930:1m" not in collector.buffer
+
+        result = await store.read("005930", "1m")
+        assert len(result) == 2
+
+    async def test_start_and_stop(self, store):
+        from unittest.mock import AsyncMock
+
+        eventbus = AsyncMock()
+        collector = DataCollector(store=store, eventbus=eventbus, collect_interval=0.05)
+
+        await collector.start(["005930"], ["1m"])
+        assert collector.running is True
+
+        await asyncio.sleep(0.02)
+        await collector.stop()
+        assert collector.running is False
+
+    async def test_start_twice_ignored(self, store):
+        from unittest.mock import AsyncMock
+
+        eventbus = AsyncMock()
+        collector = DataCollector(store=store, eventbus=eventbus)
+
+        await collector.start(["005930"], ["1m"])
+        await collector.start(["005930"], ["1m"])  # 두 번째 호출은 무시
+        assert collector.running is True
+
+        await collector.stop()
+
+    async def test_data_callback(self, store):
+        from unittest.mock import AsyncMock
+
+        eventbus = AsyncMock()
+        collector = DataCollector(
+            store=store,
+            eventbus=eventbus,
+            collect_interval=0.05,
+            buffer_size=100,
+        )
+
+        async def mock_callback(symbol, tf):
+            return [
+                {
+                    "timestamp": datetime(2026, 3, 1, 9, 0, tzinfo=UTC),
+                    "symbol": symbol,
+                    "open": 50000.0,
+                    "high": 50100.0,
+                    "low": 49900.0,
+                    "close": 50050.0,
+                    "volume": 1000,
+                    "source": "test",
+                }
+            ]
+
+        collector.set_data_callback(mock_callback)
+        await collector.start(["005930"], ["1m"])
+        await asyncio.sleep(0.1)
+        await collector.stop()
+
+        result = await store.read("005930", "1m")
+        assert len(result) >= 1
+
+
+# ── injector.py 테스트 ─────────────────────────────
+
+
+class TestDataInjector:
+    async def test_inject_csv(self, store, normalizer, tmp_path):
+        csv_path = tmp_path / "test.csv"
+        csv_path.write_text(
+            "date,open,high,low,close,volume\n"
+            "2026-03-01T09:00:00,50000,50100,49900,50050,1000\n"
+            "2026-03-01T09:01:00,50100,50200,50000,50150,1100\n"
+        )
+
+        injector = DataInjector(store=store, normalizer=normalizer)
+        count = await injector.inject_csv(csv_path, "005930", "1m")
+        assert count == 2
+
+        result = await store.read("005930", "1m")
+        assert len(result) == 2
+
+    async def test_inject_csv_not_found(self, store, normalizer):
+        injector = DataInjector(store=store, normalizer=normalizer)
+        with pytest.raises(FileNotFoundError):
+            await injector.inject_csv("/nonexistent.csv", "005930", "1m")
+
+    async def test_inject_dataframe(self, store, normalizer):
+        df = _make_ohlcv_df(n=3)
+        injector = DataInjector(store=store, normalizer=normalizer)
+        count = await injector.inject_dataframe(df, "005930", "1m")
+        assert count == 3
+
+    async def test_inject_empty_dataframe(self, store, normalizer):
+        injector = DataInjector(store=store, normalizer=normalizer)
+        count = await injector.inject_dataframe(pl.DataFrame(), "005930", "1m")
+        assert count == 0
+
+
+# ── catalog.py 테스트 ─────────────────────────────
+
+
+class TestDataCatalog:
+    async def test_list_datasets_empty(self, catalog):
+        assert catalog.list_datasets() == []
+
+    async def test_list_datasets_with_data(self, store, catalog):
+        await store.write("005930", "1d", _make_ohlcv_df("005930"))
+        datasets = catalog.list_datasets()
+        assert len(datasets) == 1
+        assert datasets[0]["symbol"] == "005930"
+        assert datasets[0]["timeframe"] == "1d"
+
+    async def test_list_datasets_multi(self, store, catalog):
+        await store.write("005930", "1d", _make_ohlcv_df("005930"))
+        await store.write("005930", "1m", _make_ohlcv_df("005930"))
+        await store.write("000660", "1d", _make_ohlcv_df("000660"))
+
+        datasets = catalog.list_datasets()
+        assert len(datasets) == 3
+
+    def test_get_schema(self, catalog):
+        schema = catalog.get_schema()
+        assert "timestamp" in schema
+        assert "close" in schema
+
+    async def test_get_storage_summary_empty(self, catalog):
+        summary = catalog.get_storage_summary()
+        assert summary["total_bytes"] == 0
+        assert summary["total_mb"] == 0.0
+
+    async def test_get_storage_summary_with_data(self, store, catalog):
+        await store.write("005930", "1d", _make_ohlcv_df())
+        summary = catalog.get_storage_summary()
+        assert summary["total_bytes"] > 0
+        assert "1d" in summary["by_timeframe"]
+
+
+# ── retention.py 테스트 ─────────────────────────────
+
+
+class TestRetentionPolicy:
+    def test_default_retention_days(self, store):
+        policy = RetentionPolicy(store)
+        assert policy.retention_days["1m"] == 90
+        assert policy.retention_days["1d"] == 3650
+
+    def test_custom_retention_days(self, store):
+        custom = {"1m": 30, "1d": 100}
+        policy = RetentionPolicy(store, retention_days=custom)
+        assert policy.retention_days["1m"] == 30
+
+    async def test_enforce_deletes_old_data(self, store):
+        """보존 기간 초과 데이터 삭제."""
+        await store.write("005930", "1m", _make_ohlcv_df())
+
+        # 1분봉 보존 기간을 0일로 설정 → 모든 데이터 삭제 대상
+        policy = RetentionPolicy(store, retention_days={"1m": 0})
+        now = datetime(2026, 6, 1, tzinfo=UTC)
+        deleted = await policy.enforce(now=now)
+
+        assert "1m" in deleted
+        assert deleted["1m"] >= 1
+
+        result = await store.read("005930", "1m")
+        assert result.is_empty()
+
+    async def test_enforce_keeps_recent_data(self, store):
+        """보존 기간 내 데이터는 유지."""
+        await store.write("005930", "1m", _make_ohlcv_df())
+
+        policy = RetentionPolicy(store, retention_days={"1m": 365})
+        now = datetime(2026, 3, 15, tzinfo=UTC)
+        deleted = await policy.enforce(now=now)
+
+        # 2026-03 데이터는 15일 전이므로 삭제 안 됨
+        assert deleted == {}
+        result = await store.read("005930", "1m")
+        assert len(result) == 5
+
+    async def test_enforce_empty_store(self, store):
+        policy = RetentionPolicy(store)
+        deleted = await policy.enforce()
+        assert deleted == {}


### PR DESCRIPTION
## Summary
- Parquet 기반 OHLCV 데이터 저장/조회 (ParquetStore) — 월별 파티셔닝, 중복 제거 병합
- 실시간 데이터 수집 (DataCollector) — 버퍼 기반, 자동 flush
- 데이터 정규화 (DataNormalizer) — KIS, Yahoo 등 다양한 소스 지원
- 외부 데이터 주입 (DataInjector) — CSV, DataFrame 임포트
- 데이터 카탈로그 (DataCatalog) — CLI `ante data list/schema` 지원
- 보존 정책 (RetentionPolicy) — 타임프레임별 자동 삭제
- polars, click, fastapi, uvicorn 의존성 추가

## Test plan
- [x] 47개 단위 테스트 통과 (schemas, store, normalizer, collector, injector, catalog, retention)
- [x] 기존 302개 테스트 포함 전체 349개 통과
- [x] ruff check + ruff format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)