### PR TITLE
feat: 종목 심볼 체계 개선 — instrument 모듈 + exchange 컨텍스트 (#39)

### DIFF
--- a/src/ante/backtest/result.py
+++ b/src/ante/backtest/result.py
@@ -18,6 +18,7 @@ class BacktestTrade:
     commission: float
     slippage: float
     reason: str = ""
+    exchange: str = "KRX"
 
 
 @dataclass

--- a/src/ante/bot/bot.py
+++ b/src/ante/bot/bot.py
@@ -206,6 +206,7 @@ class Bot:
                     price=signal.price,
                     stop_price=signal.stop_price,
                     reason=signal.reason,
+                    exchange=self.config.exchange,
                 )
             )
 

--- a/src/ante/bot/config.py
+++ b/src/ante/bot/config.py
@@ -26,3 +26,4 @@ class BotConfig:
     interval_seconds: int = 60
     symbols: list[str] | None = None
     paper_initial_balance: float = 10_000_000.0
+    exchange: str = "KRX"

--- a/src/ante/broker/base.py
+++ b/src/ante/broker/base.py
@@ -16,6 +16,7 @@ class BrokerAdapter(ABC):
     def __init__(self, config: dict[str, Any]) -> None:
         self.config = config
         self.is_connected: bool = False
+        self.exchange: str = config.get("exchange", "KRX")
 
     @abstractmethod
     async def connect(self) -> None:

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -26,6 +26,7 @@ class KISAdapter(BrokerAdapter):
     """한국투자증권 Open API 어댑터."""
 
     def __init__(self, config: dict[str, Any]) -> None:
+        config.setdefault("exchange", "KRX")
         super().__init__(config)
 
         self.app_key: str = config["app_key"]

--- a/src/ante/broker/order_registry.py
+++ b/src/ante/broker/order_registry.py
@@ -36,9 +36,20 @@ class OrderRegistry:
         self._db = db
 
     async def initialize(self) -> None:
-        """스키마 생성."""
+        """스키마 생성 + 마이그레이션."""
         await self._db.execute_script(ORDER_REGISTRY_SCHEMA)
+        await self._migrate_exchange_column()
         logger.info("OrderRegistry 초기화 완료")
+
+    async def _migrate_exchange_column(self) -> None:
+        """exchange 컬럼 마이그레이션 (v0.2)."""
+        try:
+            await self._db.execute(
+                "ALTER TABLE order_registry ADD COLUMN exchange TEXT DEFAULT 'KRX'"
+            )
+            logger.info("order_registry 테이블에 exchange 컬럼 추가")
+        except Exception:
+            pass  # 이미 존재
 
     async def register(self, order_id: str, bot_id: str, symbol: str) -> None:
         """주문 제출 시 매핑 등록."""

--- a/src/ante/cli/commands/data.py
+++ b/src/ante/cli/commands/data.py
@@ -16,9 +16,12 @@ def data() -> None:
 
 @data.command("list")
 @click.option("--data-path", default="data/", help="데이터 디렉토리 경로")
+@click.option("--db-path", default="db/ante.db", help="DB 경로")
 @click.pass_context
-def data_list(ctx: click.Context, data_path: str) -> None:
+def data_list(ctx: click.Context, data_path: str, db_path: str) -> None:
     """보유 데이터셋 목록."""
+    import asyncio
+
     from ante.data.catalog import DataCatalog
     from ante.data.store import ParquetStore
 
@@ -31,7 +34,23 @@ def data_list(ctx: click.Context, data_path: str) -> None:
         fmt.output({"datasets": [], "count": 0})
         return
 
-    fmt.table(datasets, ["symbol", "timeframe", "start", "end"])
+    async def _enrich(items: list[dict]) -> list[dict]:
+        from ante.core.database import Database
+        from ante.instrument.service import InstrumentService
+
+        db = Database(db_path)
+        await db.connect()
+        try:
+            svc = InstrumentService(db)
+            await svc.initialize()
+            for item in items:
+                item["name"] = svc.get_name(item["symbol"])
+            return items
+        finally:
+            await db.close()
+
+    datasets = asyncio.run(_enrich(datasets))
+    fmt.table(datasets, ["symbol", "name", "timeframe", "start", "end"])
 
 
 @data.command()

--- a/src/ante/cli/commands/instrument.py
+++ b/src/ante/cli/commands/instrument.py
@@ -1,0 +1,117 @@
+"""ante instrument — 종목 마스터 데이터 관리 커맨드."""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+from ante.cli.main import get_formatter
+
+
+@click.group()
+def instrument() -> None:
+    """종목 마스터 데이터 관리."""
+
+
+@instrument.command("list")
+@click.option("--exchange", default="KRX", help="거래소 (기본: KRX)")
+@click.option(
+    "--type", "inst_type", default=None, help="종목 유형 필터 (stock, etf, etn 등)"
+)
+@click.option("--db-path", default="db/ante.db", help="DB 경로")
+@click.pass_context
+def instrument_list(
+    ctx: click.Context,
+    exchange: str,
+    inst_type: str | None,
+    db_path: str,
+) -> None:
+    """등록된 종목 목록 조회."""
+    from ante.core.database import Database
+    from ante.instrument.service import InstrumentService
+
+    fmt = get_formatter(ctx)
+
+    async def _run() -> list[dict]:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            svc = InstrumentService(db)
+            await svc.initialize()
+
+            query = "SELECT * FROM instruments WHERE exchange = ?"
+            params: list[object] = [exchange]
+
+            if inst_type:
+                query += " AND instrument_type = ?"
+                params.append(inst_type)
+
+            query += " ORDER BY symbol"
+            rows = await db.fetch_all(query, tuple(params))
+            return [
+                {
+                    "symbol": r["symbol"],
+                    "name": r["name"] or "",
+                    "name_en": r["name_en"] or "",
+                    "type": r["instrument_type"] or "",
+                    "listed": "Y" if r["listed"] else "N",
+                }
+                for r in rows
+            ]
+        finally:
+            await db.close()
+
+    results = asyncio.run(_run())
+
+    if not results:
+        fmt.output({"instruments": [], "count": 0})
+        return
+
+    fmt.table(results, ["symbol", "name", "name_en", "type", "listed"])
+
+
+@instrument.command()
+@click.argument("keyword")
+@click.option("--limit", default=20, help="최대 결과 수")
+@click.option("--db-path", default="db/ante.db", help="DB 경로")
+@click.pass_context
+def search(
+    ctx: click.Context,
+    keyword: str,
+    limit: int,
+    db_path: str,
+) -> None:
+    """키워드로 종목 검색 (종목코드, 한글명, 영문명)."""
+    from ante.core.database import Database
+    from ante.instrument.service import InstrumentService
+
+    fmt = get_formatter(ctx)
+
+    async def _run() -> list[dict]:
+        db = Database(db_path)
+        await db.connect()
+        try:
+            svc = InstrumentService(db)
+            await svc.initialize()
+            instruments = await svc.search(keyword, limit=limit)
+            return [
+                {
+                    "symbol": inst.symbol,
+                    "exchange": inst.exchange,
+                    "name": inst.name,
+                    "name_en": inst.name_en,
+                    "type": inst.instrument_type,
+                }
+                for inst in instruments
+            ]
+        finally:
+            await db.close()
+
+    results = asyncio.run(_run())
+
+    if not results:
+        fmt.output({"results": [], "count": 0})
+        return
+
+    fmt.table(results, ["symbol", "exchange", "name", "name_en", "type"])

--- a/src/ante/cli/main.py
+++ b/src/ante/cli/main.py
@@ -32,6 +32,7 @@ def get_formatter(ctx: click.Context) -> OutputFormatter:
 # 서브커맨드 등록
 from ante.cli.commands.backtest import backtest  # noqa: E402
 from ante.cli.commands.data import data  # noqa: E402
+from ante.cli.commands.instrument import instrument  # noqa: E402
 from ante.cli.commands.report import report  # noqa: E402
 from ante.cli.commands.strategy import strategy  # noqa: E402
 
@@ -39,3 +40,4 @@ cli.add_command(strategy)
 cli.add_command(data)
 cli.add_command(backtest)
 cli.add_command(report)
+cli.add_command(instrument)

--- a/src/ante/config/defaults.py
+++ b/src/ante/config/defaults.py
@@ -10,4 +10,5 @@ DEFAULTS: dict[str, object] = {
     "web.host": "0.0.0.0",
     "web.port": 8000,
     "eventbus.history_size": 1000,
+    "instrument.default_exchange": "KRX",
 }

--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -35,6 +35,7 @@ class OrderRequestEvent(Event):
     price: float | None = None
     stop_price: float | None = None
     reason: str = ""
+    exchange: str = "KRX"
 
 
 @dataclass(frozen=True)
@@ -73,6 +74,7 @@ class OrderValidatedEvent(Event):
     order_type: str = ""
     stop_price: float | None = None
     reason: str = ""
+    exchange: str = "KRX"
 
 
 @dataclass(frozen=True)
@@ -88,6 +90,7 @@ class OrderRejectedEvent(Event):
     price: float | None = None
     order_type: str = ""
     reason: str = ""
+    exchange: str = "KRX"
 
 
 @dataclass(frozen=True)
@@ -104,6 +107,7 @@ class OrderApprovedEvent(Event):
     order_type: str = ""
     stop_price: float | None = None
     reserved_amount: float = 0.0
+    exchange: str = "KRX"
 
 
 @dataclass(frozen=True)
@@ -118,6 +122,7 @@ class OrderSubmittedEvent(Event):
     side: str = ""
     quantity: float = 0.0
     order_type: str = ""
+    exchange: str = "KRX"
 
 
 @dataclass(frozen=True)
@@ -137,6 +142,7 @@ class OrderFilledEvent(Event):
     commission: float = 0.0
     order_type: str = ""
     reason: str = ""
+    exchange: str = "KRX"
 
 
 @dataclass(frozen=True)
@@ -152,6 +158,7 @@ class OrderCancelledEvent(Event):
     quantity: float = 0.0
     price: float = 0.0
     reason: str = ""
+    exchange: str = "KRX"
 
 
 @dataclass(frozen=True)
@@ -167,6 +174,7 @@ class OrderFailedEvent(Event):
     price: float = 0.0
     order_type: str = ""
     error_message: str = ""
+    exchange: str = "KRX"
 
 
 @dataclass(frozen=True)
@@ -186,6 +194,7 @@ class OrderUpdateEvent(Event):
     order_type: str = ""
     quantity: float = 0.0
     reason: str = ""
+    exchange: str = "KRX"
 
 
 # ── 시스템 이벤트 (System) ────────────────────────
@@ -291,6 +300,7 @@ class ExternalSignalEvent(Event):
     reason: str = ""
     confidence: float = 0.0
     metadata: dict = field(default_factory=dict)  # type: ignore[assignment]
+    exchange: str = "KRX"
 
 
 # ── 설정 변경 (Config) ───────────────────────────

--- a/src/ante/gateway/gateway.py
+++ b/src/ante/gateway/gateway.py
@@ -66,9 +66,9 @@ class APIGateway:
 
     # ── 공개 API ──────────────────────────────────
 
-    async def get_current_price(self, symbol: str) -> float:
+    async def get_current_price(self, symbol: str, exchange: str = "KRX") -> float:
         """현재가 조회 (캐시 우선)."""
-        cache_key = f"price:{symbol}"
+        cache_key = f"price:{exchange}:{symbol}"
         cached = self._cache.get(cache_key)
         if cached is not None:
             return cached
@@ -167,6 +167,7 @@ class APIGateway:
                     side=event.side,
                     quantity=event.quantity,
                     order_type=event.order_type,
+                    exchange=event.exchange,
                 )
             )
         except Exception as e:
@@ -182,6 +183,7 @@ class APIGateway:
                     price=event.price or 0.0,
                     order_type=event.order_type,
                     error_message=str(e),
+                    exchange=event.exchange,
                 )
             )
 
@@ -225,4 +227,4 @@ class APIGateway:
             return
         self._cache.invalidate("balance")
         self._cache.invalidate("positions")
-        self._cache.invalidate(f"price:{event.symbol}")
+        self._cache.invalidate(f"price:{event.exchange}:{event.symbol}")

--- a/src/ante/instrument/__init__.py
+++ b/src/ante/instrument/__init__.py
@@ -1,0 +1,6 @@
+"""Instrument — 종목 마스터 데이터 관리."""
+
+from ante.instrument.models import Instrument
+from ante.instrument.service import InstrumentService
+
+__all__ = ["Instrument", "InstrumentService"]

--- a/src/ante/instrument/models.py
+++ b/src/ante/instrument/models.py
@@ -1,0 +1,17 @@
+"""Instrument 데이터 모델."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Instrument:
+    """종목 마스터 데이터."""
+
+    symbol: str
+    exchange: str
+    name: str = ""
+    name_en: str = ""
+    instrument_type: str = ""  # "stock" | "etf" | "etn" | ...
+    logo_url: str = ""
+    listed: bool = True
+    updated_at: str = ""

--- a/src/ante/instrument/service.py
+++ b/src/ante/instrument/service.py
@@ -1,0 +1,117 @@
+"""InstrumentService — 종목 마스터 데이터 관리 서비스."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ante.instrument.models import Instrument
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+
+logger = logging.getLogger(__name__)
+
+INSTRUMENT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS instruments (
+    symbol           TEXT NOT NULL,
+    exchange         TEXT NOT NULL,
+    name             TEXT DEFAULT '',
+    name_en          TEXT DEFAULT '',
+    instrument_type  TEXT DEFAULT '',
+    logo_url         TEXT DEFAULT '',
+    listed           INTEGER DEFAULT 1,
+    updated_at       TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (symbol, exchange)
+);
+CREATE INDEX IF NOT EXISTS idx_instruments_name ON instruments(name);
+"""
+
+
+class InstrumentService:
+    """종목 마스터 데이터 조회·관리 서비스.
+
+    전체 종목을 메모리 캐시에 적재하여 동기 조회를 지원한다.
+    한국 상장 종목 ~2,500개 수준이므로 전체 메모리 적재가 합리적.
+    """
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+        self._cache: dict[tuple[str, str], Instrument] = {}
+
+    async def initialize(self) -> None:
+        """스키마 생성 + 캐시 워밍."""
+        await self._db.execute_script(INSTRUMENT_SCHEMA)
+        await self._warm_cache()
+        logger.info("InstrumentService 초기화 완료 (캐시: %d건)", len(self._cache))
+
+    async def _warm_cache(self) -> None:
+        """DB 전체 로드 → 메모리 캐시."""
+        rows = await self._db.fetch_all("SELECT * FROM instruments")
+        self._cache = {
+            (row["symbol"], row["exchange"]): self._row_to_instrument(row)
+            for row in rows
+        }
+
+    async def get(self, symbol: str, exchange: str = "KRX") -> Instrument | None:
+        """(symbol, exchange) 조회. 캐시 우선."""
+        return self._cache.get((symbol, exchange))
+
+    def get_name(self, symbol: str, exchange: str = "KRX") -> str:
+        """종목명 동기 조회. 캐시 미스 시 symbol 반환."""
+        inst = self._cache.get((symbol, exchange))
+        return inst.name if inst and inst.name else symbol
+
+    async def search(self, keyword: str, limit: int = 20) -> list[Instrument]:
+        """키워드로 종목 검색 (name, name_en, symbol LIKE)."""
+        pattern = f"%{keyword}%"
+        rows = await self._db.fetch_all(
+            "SELECT * FROM instruments "
+            "WHERE name LIKE ? OR name_en LIKE ? OR symbol LIKE ? "
+            "LIMIT ?",
+            (pattern, pattern, pattern, limit),
+        )
+        return [self._row_to_instrument(row) for row in rows]
+
+    async def bulk_upsert(self, instruments: list[Instrument]) -> int:
+        """대량 등록/갱신. 캐시도 갱신."""
+        count = 0
+        for inst in instruments:
+            await self._db.execute(
+                "INSERT INTO instruments "
+                "(symbol, exchange, name, name_en, "
+                "instrument_type, logo_url, listed, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now')) "
+                "ON CONFLICT(symbol, exchange) DO UPDATE SET "
+                "name=excluded.name, name_en=excluded.name_en, "
+                "instrument_type=excluded.instrument_type, "
+                "logo_url=excluded.logo_url, listed=excluded.listed, "
+                "updated_at=datetime('now')",
+                (
+                    inst.symbol,
+                    inst.exchange,
+                    inst.name,
+                    inst.name_en,
+                    inst.instrument_type,
+                    inst.logo_url,
+                    1 if inst.listed else 0,
+                ),
+            )
+            self._cache[(inst.symbol, inst.exchange)] = inst
+            count += 1
+        logger.info("종목 bulk_upsert 완료: %d건", count)
+        return count
+
+    @staticmethod
+    def _row_to_instrument(row: dict) -> Instrument:  # type: ignore[type-arg]
+        """DB row → Instrument 변환."""
+        return Instrument(
+            symbol=row["symbol"],
+            exchange=row["exchange"],
+            name=row["name"] or "",
+            name_en=row["name_en"] or "",
+            instrument_type=row["instrument_type"] or "",
+            logo_url=row["logo_url"] or "",
+            listed=bool(row["listed"]),
+            updated_at=row["updated_at"] or "",
+        )

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -75,6 +75,12 @@ async def main() -> None:
     await dynamic_config.initialize()
     logger.info("DynamicConfigService 초기화 완료")
 
+    # ── 5.5. InstrumentService ─────────────────────────
+    from ante.instrument import InstrumentService
+
+    instrument_service = InstrumentService(db=db)
+    await instrument_service.initialize()
+
     # ── 6. StrategyRegistry ──────────────────────────
     from ante.strategy import StrategyRegistry
 
@@ -200,6 +206,7 @@ async def main() -> None:
             adapter=adapter,
             eventbus=eventbus,
             min_level=NotificationLevel(min_level_str),
+            instrument_service=instrument_service,
         )
         notification_service.subscribe()
         logger.info("NotificationService 초기화 완료 (Telegram)")

--- a/src/ante/notification/service.py
+++ b/src/ante/notification/service.py
@@ -10,6 +10,7 @@ from ante.notification.base import NotificationAdapter, NotificationLevel
 
 if TYPE_CHECKING:
     from ante.eventbus.bus import EventBus
+    from ante.instrument.service import InstrumentService
 
 logger = logging.getLogger(__name__)
 
@@ -24,12 +25,14 @@ class NotificationService:
         min_level: NotificationLevel = NotificationLevel.INFO,
         quiet_start: time | None = None,
         quiet_end: time | None = None,
+        instrument_service: InstrumentService | None = None,
     ) -> None:
         self._adapter = adapter
         self._eventbus = eventbus
         self._min_level = min_level
         self._quiet_start = quiet_start
         self._quiet_end = quiet_end
+        self._instrument_service = instrument_service
 
     def subscribe(self) -> None:
         """이벤트 구독 등록."""
@@ -87,9 +90,15 @@ class NotificationService:
         if not self._should_send(NotificationLevel.INFO):
             return
 
+        display = event.symbol
+        if self._instrument_service:
+            name = self._instrument_service.get_name(event.symbol, event.exchange)
+            if name != event.symbol:
+                display = f"{event.symbol}({name})"
+
         await self._adapter.send(
             NotificationLevel.INFO,
-            f"체결 [{event.bot_id}] {event.symbol} "
+            f"체결 [{event.bot_id}] {display} "
             f"{event.side} {event.quantity}주 @ {event.price:,.0f}원",
         )
 

--- a/src/ante/rule/base.py
+++ b/src/ante/rule/base.py
@@ -53,6 +53,7 @@ class RuleContext:
     quantity: float
     order_type: str
     price: float | None = None
+    exchange: str = "KRX"
 
     # 시장/포지션 정보
     current_price: float = 0.0

--- a/src/ante/strategy/base.py
+++ b/src/ante/strategy/base.py
@@ -23,6 +23,7 @@ class StrategyMeta:
     author: str = "agent"
     symbols: list[str] | None = None
     timeframe: str = "1d"
+    exchange: str = "KRX"
 
 
 # ── 시그널 / 주문 액션 ────────────────────────────

--- a/src/ante/trade/models.py
+++ b/src/ante/trade/models.py
@@ -42,6 +42,7 @@ class TradeRecord:
     commission: float = 0.0
     timestamp: datetime | None = None
     order_id: str | None = None
+    exchange: str = "KRX"
 
 
 @dataclass
@@ -54,6 +55,7 @@ class PositionSnapshot:
     avg_entry_price: float
     realized_pnl: float = 0.0
     updated_at: str = ""
+    exchange: str = "KRX"
 
 
 @dataclass

--- a/src/ante/trade/position.py
+++ b/src/ante/trade/position.py
@@ -49,9 +49,21 @@ class PositionHistory:
         self._db = db
 
     async def initialize(self) -> None:
-        """스키마 생성."""
+        """스키마 생성 + 마이그레이션."""
         await self._db.execute_script(POSITION_SCHEMA)
+        await self._migrate_exchange_column()
         logger.info("PositionHistory 초기화 완료")
+
+    async def _migrate_exchange_column(self) -> None:
+        """exchange 컬럼 마이그레이션 (v0.2)."""
+        for table in ("positions", "position_history"):
+            try:
+                await self._db.execute(
+                    f"ALTER TABLE {table} ADD COLUMN exchange TEXT DEFAULT 'KRX'"  # noqa: S608
+                )
+                logger.info("%s 테이블에 exchange 컬럼 추가", table)
+            except Exception:
+                pass  # 이미 존재
 
     async def on_trade(self, record: TradeRecord) -> None:
         """체결 기록을 반영하여 포지션 상태 갱신."""

--- a/src/ante/trade/recorder.py
+++ b/src/ante/trade/recorder.py
@@ -48,9 +48,20 @@ class TradeRecorder:
         self._position_history = position_history
 
     async def initialize(self) -> None:
-        """스키마 생성."""
+        """스키마 생성 + 마이그레이션."""
         await self._db.execute_script(TRADE_SCHEMA)
+        await self._migrate_exchange_column()
         logger.info("TradeRecorder 초기화 완료")
+
+    async def _migrate_exchange_column(self) -> None:
+        """exchange 컬럼 마이그레이션 (v0.2)."""
+        try:
+            await self._db.execute(
+                "ALTER TABLE trades ADD COLUMN exchange TEXT DEFAULT 'KRX'"
+            )
+            logger.info("trades 테이블에 exchange 컬럼 추가")
+        except Exception:
+            pass  # 이미 존재
 
     def subscribe(self, eventbus: EventBus) -> None:
         """이벤트 구독 등록."""

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -353,7 +353,7 @@ class TestAPIGatewayEvents:
         # 캐시에 데이터 넣기
         gateway._cache.set("balance", {"cash": 5000000}, ttl=60)
         gateway._cache.set("positions", [], ttl=60)
-        gateway._cache.set("price:005930", 50000, ttl=60)
+        gateway._cache.set("price:KRX:005930", 50000, ttl=60)
 
         await eventbus.publish(
             OrderFilledEvent(
@@ -371,7 +371,7 @@ class TestAPIGatewayEvents:
 
         assert gateway._cache.get("balance") is None
         assert gateway._cache.get("positions") is None
-        assert gateway._cache.get("price:005930") is None
+        assert gateway._cache.get("price:KRX:005930") is None
 
 
 # ── LiveDataProvider ───────────────────────────────

--- a/tests/unit/test_instrument.py
+++ b/tests/unit/test_instrument.py
@@ -1,0 +1,431 @@
+"""Instrument 모듈 단위 테스트."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from ante.instrument.models import Instrument
+from ante.instrument.service import InstrumentService
+
+# ── Instrument 모델 ──────────────────────────────
+
+
+class TestInstrumentModel:
+    def test_create(self):
+        """Instrument 생성."""
+        inst = Instrument(symbol="005930", exchange="KRX", name="삼성전자")
+        assert inst.symbol == "005930"
+        assert inst.exchange == "KRX"
+        assert inst.name == "삼성전자"
+
+    def test_frozen(self):
+        """frozen dataclass — 불변."""
+        inst = Instrument(symbol="005930", exchange="KRX")
+        with pytest.raises(AttributeError):
+            inst.name = "변경"  # type: ignore[misc]
+
+    def test_defaults(self):
+        """기본값 확인."""
+        inst = Instrument(symbol="000660", exchange="KRX")
+        assert inst.name == ""
+        assert inst.name_en == ""
+        assert inst.instrument_type == ""
+        assert inst.logo_url == ""
+        assert inst.listed is True
+        assert inst.updated_at == ""
+
+
+# ── InstrumentService ────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def db(tmp_path):
+    """테스트용 DB."""
+    from ante.core.database import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    yield db
+    await db.close()
+
+
+@pytest_asyncio.fixture
+async def service(db):
+    """InstrumentService 인스턴스."""
+    svc = InstrumentService(db=db)
+    await svc.initialize()
+    return svc
+
+
+class TestInstrumentServiceInitialize:
+    @pytest.mark.asyncio
+    async def test_initialize_creates_table(self, db):
+        """initialize()가 instruments 테이블을 생성한다."""
+        svc = InstrumentService(db=db)
+        await svc.initialize()
+
+        row = await db.fetch_one(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='instruments'"
+        )
+        assert row is not None
+
+    @pytest.mark.asyncio
+    async def test_initialize_idempotent(self, db):
+        """중복 호출해도 에러 없음."""
+        svc = InstrumentService(db=db)
+        await svc.initialize()
+        await svc.initialize()
+
+
+class TestInstrumentServiceGet:
+    @pytest.mark.asyncio
+    async def test_get_cached(self, service):
+        """캐시에서 조회."""
+        inst = Instrument(symbol="005930", exchange="KRX", name="삼성전자")
+        await service.bulk_upsert([inst])
+
+        result = await service.get("005930", "KRX")
+        assert result is not None
+        assert result.name == "삼성전자"
+
+    @pytest.mark.asyncio
+    async def test_get_missing_returns_none(self, service):
+        """없는 종목은 None 반환."""
+        result = await service.get("999999", "KRX")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_default_exchange(self, service):
+        """exchange 기본값 KRX."""
+        inst = Instrument(symbol="005930", exchange="KRX", name="삼성전자")
+        await service.bulk_upsert([inst])
+
+        result = await service.get("005930")
+        assert result is not None
+        assert result.name == "삼성전자"
+
+
+class TestInstrumentServiceGetName:
+    @pytest.mark.asyncio
+    async def test_get_name(self, service):
+        """종목명 반환."""
+        inst = Instrument(symbol="005930", exchange="KRX", name="삼성전자")
+        await service.bulk_upsert([inst])
+
+        assert service.get_name("005930") == "삼성전자"
+
+    @pytest.mark.asyncio
+    async def test_get_name_fallback(self, service):
+        """캐시 미스 시 symbol 반환."""
+        assert service.get_name("999999") == "999999"
+
+    @pytest.mark.asyncio
+    async def test_get_name_empty_name(self, service):
+        """name이 빈 문자열이면 symbol 반환."""
+        inst = Instrument(symbol="005930", exchange="KRX", name="")
+        await service.bulk_upsert([inst])
+
+        assert service.get_name("005930") == "005930"
+
+
+class TestInstrumentServiceSearch:
+    @pytest.mark.asyncio
+    async def test_search_by_name(self, service):
+        """한글명 검색."""
+        instruments = [
+            Instrument(symbol="005930", exchange="KRX", name="삼성전자"),
+            Instrument(symbol="000660", exchange="KRX", name="SK하이닉스"),
+            Instrument(symbol="035420", exchange="KRX", name="NAVER"),
+        ]
+        await service.bulk_upsert(instruments)
+
+        results = await service.search("삼성")
+        assert len(results) == 1
+        assert results[0].symbol == "005930"
+
+    @pytest.mark.asyncio
+    async def test_search_by_symbol(self, service):
+        """종목코드 검색."""
+        instruments = [
+            Instrument(symbol="005930", exchange="KRX", name="삼성전자"),
+        ]
+        await service.bulk_upsert(instruments)
+
+        results = await service.search("0059")
+        assert len(results) == 1
+
+    @pytest.mark.asyncio
+    async def test_search_no_results(self, service):
+        """결과 없음."""
+        results = await service.search("없는종목")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_search_limit(self, service):
+        """limit 적용."""
+        instruments = [
+            Instrument(symbol=f"00{i:04d}", exchange="KRX", name=f"종목{i}")
+            for i in range(10)
+        ]
+        await service.bulk_upsert(instruments)
+
+        results = await service.search("종목", limit=3)
+        assert len(results) == 3
+
+
+class TestInstrumentServiceBulkUpsert:
+    @pytest.mark.asyncio
+    async def test_bulk_upsert_insert(self, service):
+        """신규 종목 등록."""
+        instruments = [
+            Instrument(symbol="005930", exchange="KRX", name="삼성전자"),
+            Instrument(symbol="000660", exchange="KRX", name="SK하이닉스"),
+        ]
+        count = await service.bulk_upsert(instruments)
+
+        assert count == 2
+        assert await service.get("005930") is not None
+        assert await service.get("000660") is not None
+
+    @pytest.mark.asyncio
+    async def test_bulk_upsert_update(self, service):
+        """기존 종목 갱신."""
+        inst1 = Instrument(symbol="005930", exchange="KRX", name="삼성전자(구)")
+        await service.bulk_upsert([inst1])
+
+        inst2 = Instrument(symbol="005930", exchange="KRX", name="삼성전자")
+        await service.bulk_upsert([inst2])
+
+        result = await service.get("005930")
+        assert result is not None
+        assert result.name == "삼성전자"
+
+    @pytest.mark.asyncio
+    async def test_bulk_upsert_updates_cache(self, service):
+        """upsert 후 캐시가 즉시 갱신된다."""
+        inst = Instrument(symbol="005930", exchange="KRX", name="삼성전자")
+        await service.bulk_upsert([inst])
+
+        assert service.get_name("005930") == "삼성전자"
+
+
+# ── exchange 필드 기본값 ──────────────────────────
+
+
+class TestExchangeDefaults:
+    def test_event_default_exchange(self):
+        """이벤트 exchange 기본값 KRX."""
+        from ante.eventbus.events import (
+            OrderFilledEvent,
+            OrderRequestEvent,
+        )
+
+        req = OrderRequestEvent(symbol="005930")
+        assert req.exchange == "KRX"
+
+        filled = OrderFilledEvent(symbol="005930")
+        assert filled.exchange == "KRX"
+
+    def test_bot_config_default_exchange(self):
+        """BotConfig exchange 기본값 KRX."""
+        from ante.bot.config import BotConfig
+
+        config = BotConfig(bot_id="bot-1", strategy_id="strat-1")
+        assert config.exchange == "KRX"
+
+    def test_strategy_meta_default_exchange(self):
+        """StrategyMeta exchange 기본값 KRX."""
+        from ante.strategy.base import StrategyMeta
+
+        meta = StrategyMeta(name="test", version="1.0", description="test")
+        assert meta.exchange == "KRX"
+
+    def test_trade_record_default_exchange(self):
+        """TradeRecord exchange 기본값 KRX."""
+        from uuid import uuid4
+
+        from ante.trade.models import TradeRecord, TradeStatus
+
+        record = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot-1",
+            strategy_id="strat-1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=70000,
+            status=TradeStatus.FILLED,
+        )
+        assert record.exchange == "KRX"
+
+    def test_position_snapshot_default_exchange(self):
+        """PositionSnapshot exchange 기본값 KRX."""
+        from ante.trade.models import PositionSnapshot
+
+        pos = PositionSnapshot(
+            bot_id="bot-1",
+            symbol="005930",
+            quantity=10,
+            avg_entry_price=70000,
+        )
+        assert pos.exchange == "KRX"
+
+    def test_backtest_trade_default_exchange(self):
+        """BacktestTrade exchange 기본값 KRX."""
+        from datetime import datetime
+
+        from ante.backtest.result import BacktestTrade
+
+        trade = BacktestTrade(
+            timestamp=datetime.now(),
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=70000,
+            commission=100,
+            slippage=0,
+        )
+        assert trade.exchange == "KRX"
+
+    def test_rule_context_default_exchange(self):
+        """RuleContext exchange 기본값 KRX."""
+        from ante.rule.base import RuleContext
+
+        ctx = RuleContext(
+            bot_id="bot-1",
+            strategy_id="strat-1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            order_type="market",
+        )
+        assert ctx.exchange == "KRX"
+
+
+# ── Notification 종목명 병기 ──────────────────────
+
+from ante.notification.base import NotificationAdapter, NotificationLevel  # noqa: E402
+
+
+class MockAdapter(NotificationAdapter):
+    """테스트용 알림 어댑터."""
+
+    def __init__(self):
+        self.messages: list[tuple[NotificationLevel, str]] = []
+
+    async def connect(self) -> None:
+        pass
+
+    async def disconnect(self) -> None:
+        pass
+
+    async def send(self, level: NotificationLevel, message: str) -> None:
+        self.messages.append((level, message))
+
+    async def send_rich(self, level, title, body, metadata=None) -> None:
+        self.messages.append((level, f"{title}: {body}"))
+
+
+from ante.notification.service import NotificationService  # noqa: E402
+
+
+class TestNotificationWithInstrumentName:
+    @pytest.mark.asyncio
+    async def test_order_filled_with_instrument_name(self, db):
+        """체결 알림에 종목명이 포함된다."""
+        from ante.eventbus import EventBus
+        from ante.eventbus.events import OrderFilledEvent
+
+        svc = InstrumentService(db=db)
+        await svc.initialize()
+        await svc.bulk_upsert(
+            [Instrument(symbol="005930", exchange="KRX", name="삼성전자")]
+        )
+
+        adapter = MockAdapter()
+        eventbus = EventBus()
+        notif = NotificationService(
+            adapter=adapter,
+            eventbus=eventbus,
+            instrument_service=svc,
+        )
+        notif.subscribe()
+
+        await eventbus.publish(
+            OrderFilledEvent(
+                bot_id="bot-1",
+                symbol="005930",
+                side="buy",
+                quantity=100,
+                price=71000,
+                exchange="KRX",
+            )
+        )
+
+        assert len(adapter.messages) == 1
+        _, msg = adapter.messages[0]
+        assert "005930(삼성전자)" in msg
+        assert "100주" in msg
+
+    @pytest.mark.asyncio
+    async def test_order_filled_without_instrument_service(self):
+        """instrument_service=None → symbol만 표시."""
+        from ante.eventbus import EventBus
+        from ante.eventbus.events import OrderFilledEvent
+
+        adapter = MockAdapter()
+        eventbus = EventBus()
+        notif = NotificationService(
+            adapter=adapter,
+            eventbus=eventbus,
+        )
+        notif.subscribe()
+
+        await eventbus.publish(
+            OrderFilledEvent(
+                bot_id="bot-1",
+                symbol="005930",
+                side="buy",
+                quantity=100,
+                price=71000,
+            )
+        )
+
+        assert len(adapter.messages) == 1
+        _, msg = adapter.messages[0]
+        assert "005930" in msg
+        assert "005930(" not in msg
+
+    @pytest.mark.asyncio
+    async def test_order_filled_unknown_symbol(self, db):
+        """캐시에 없는 종목 → symbol만 표시."""
+        from ante.eventbus import EventBus
+        from ante.eventbus.events import OrderFilledEvent
+
+        svc = InstrumentService(db=db)
+        await svc.initialize()
+
+        adapter = MockAdapter()
+        eventbus = EventBus()
+        notif = NotificationService(
+            adapter=adapter,
+            eventbus=eventbus,
+            instrument_service=svc,
+        )
+        notif.subscribe()
+
+        await eventbus.publish(
+            OrderFilledEvent(
+                bot_id="bot-1",
+                symbol="999999",
+                side="sell",
+                quantity=50,
+                price=10000,
+            )
+        )
+
+        assert len(adapter.messages) == 1
+        _, msg = adapter.messages[0]
+        assert "999999" in msg
+        assert "999999(" not in msg


### PR DESCRIPTION
## Summary

- **US-1**: `instrument` 모듈 신규 생성 — `instruments` 테이블 (symbol, exchange 복합 PK) + `InstrumentService` (메모리 캐시) + CLI (`ante instrument list/search`)
- **US-2**: 전체 시스템에 `exchange` 필드 추가 — 10개 이벤트, BotConfig, StrategyMeta, BrokerAdapter, RuleContext, TradeRecord, PositionSnapshot, BacktestTrade + DB 마이그레이션
- **US-4**: 알림 메시지에 종목명 병기 — `005930(삼성전자)` 형태
- **US-5**: CLI `ante data list` 출력에 종목명 컬럼 추가
- 기존 테스트 하위 호환성 유지 (모든 exchange 필드 default="KRX")

## Test plan

- [x] 신규 테스트 28개 통과 (`test_instrument.py`)
- [x] 전체 테스트 470개 통과 (기존 442 + 신규 28)
- [x] ruff check + ruff format 통과
- [x] CI lint + test 통과 확인

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)