### PR TITLE
feat: Approval 모듈 구현 — AI Agent 결재 체계 (#41)

### DIFF
--- a/src/ante/approval/__init__.py
+++ b/src/ante/approval/__init__.py
@@ -1,0 +1,11 @@
+"""Approval — AI Agent 결재 체계."""
+
+from ante.approval.models import ApprovalRequest, ApprovalStatus, ApprovalType
+from ante.approval.service import ApprovalService
+
+__all__ = [
+    "ApprovalRequest",
+    "ApprovalService",
+    "ApprovalStatus",
+    "ApprovalType",
+]

--- a/src/ante/approval/models.py
+++ b/src/ante/approval/models.py
@@ -1,0 +1,48 @@
+"""Approval 데이터 모델."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class ApprovalStatus(StrEnum):
+    """결재 상태."""
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    ON_HOLD = "on_hold"
+    EXPIRED = "expired"
+    CANCELLED = "cancelled"
+
+
+class ApprovalType(StrEnum):
+    """결재 유형."""
+
+    STRATEGY_ADOPT = "strategy_adopt"
+    BUDGET_CHANGE = "budget_change"
+    BOT_CREATE = "bot_create"
+    BOT_STOP = "bot_stop"
+    RULE_CHANGE = "rule_change"
+
+
+@dataclass
+class ApprovalRequest:
+    """결재 요청."""
+
+    id: str
+    type: str
+    status: str
+    requester: str
+    title: str
+    body: str = ""
+    params: dict = field(default_factory=dict)
+    reviews: list[dict] = field(default_factory=list)
+    history: list[dict] = field(default_factory=list)
+    reference_id: str = ""
+    expires_at: str = ""
+    created_at: str = ""
+    resolved_at: str = ""
+    resolved_by: str = ""
+    reject_reason: str = ""

--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -1,0 +1,531 @@
+"""ApprovalService — 결재 요청 관리."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from ante.approval.models import ApprovalRequest, ApprovalStatus
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+APPROVAL_SCHEMA = """
+CREATE TABLE IF NOT EXISTS approvals (
+    id              TEXT PRIMARY KEY,
+    type            TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'pending',
+    requester       TEXT NOT NULL,
+    title           TEXT NOT NULL,
+    body            TEXT NOT NULL DEFAULT '',
+    params          TEXT NOT NULL DEFAULT '{}',
+    reviews         TEXT NOT NULL DEFAULT '[]',
+    history         TEXT NOT NULL DEFAULT '[]',
+    reference_id    TEXT DEFAULT '',
+    expires_at      TEXT DEFAULT '',
+    created_at      TEXT DEFAULT (datetime('now')),
+    resolved_at     TEXT DEFAULT '',
+    resolved_by     TEXT DEFAULT '',
+    reject_reason   TEXT DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_approvals_status ON approvals(status);
+CREATE INDEX IF NOT EXISTS idx_approvals_type ON approvals(type);
+"""
+
+
+class ApprovalService:
+    """결재 요청 관리 서비스."""
+
+    def __init__(
+        self,
+        db: Database,
+        eventbus: EventBus,
+        executors: dict[str, Callable[..., Awaitable]] | None = None,
+    ) -> None:
+        self._db = db
+        self._eventbus = eventbus
+        self._executors = executors or {}
+
+    async def initialize(self) -> None:
+        """스키마 생성."""
+        await self._db.execute_script(APPROVAL_SCHEMA)
+        logger.info("ApprovalService 초기화 완료")
+
+    async def create(
+        self,
+        type: str,
+        requester: str,
+        title: str,
+        body: str = "",
+        params: dict | None = None,
+        reference_id: str = "",
+        expires_at: str = "",
+    ) -> ApprovalRequest:
+        """결재 요청 생성."""
+        request_id = str(uuid4())
+        now = datetime.now(UTC).isoformat()
+        params = params or {}
+
+        history = [
+            {
+                "action": "created",
+                "actor": requester,
+                "at": now,
+                "detail": "",
+            }
+        ]
+
+        request = ApprovalRequest(
+            id=request_id,
+            type=type,
+            status=ApprovalStatus.PENDING,
+            requester=requester,
+            title=title,
+            body=body,
+            params=params,
+            reviews=[],
+            history=history,
+            reference_id=reference_id,
+            expires_at=expires_at,
+            created_at=now,
+        )
+
+        await self._db.execute(
+            """INSERT INTO approvals
+               (id, type, status, requester, title, body, params,
+                reviews, history, reference_id, expires_at, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                request.id,
+                request.type,
+                request.status,
+                request.requester,
+                request.title,
+                request.body,
+                json.dumps(request.params, ensure_ascii=False),
+                json.dumps(request.reviews, ensure_ascii=False),
+                json.dumps(request.history, ensure_ascii=False),
+                request.reference_id,
+                request.expires_at,
+                request.created_at,
+            ),
+        )
+
+        logger.info(
+            "결재 요청 생성: %s (%s) by %s",
+            request.id,
+            request.type,
+            request.requester,
+        )
+
+        # ApprovalCreatedEvent 발행
+        from ante.eventbus.events import ApprovalCreatedEvent
+
+        await self._eventbus.publish(
+            ApprovalCreatedEvent(
+                approval_id=request.id,
+                approval_type=request.type,
+                requester=request.requester,
+                title=request.title,
+            )
+        )
+
+        return request
+
+    async def approve(
+        self,
+        id: str,
+        resolved_by: str = "user",
+    ) -> ApprovalRequest:
+        """결재 승인 + 자동 실행."""
+        request = await self.get(id)
+        if not request:
+            msg = f"결재 요청을 찾을 수 없음: {id}"
+            raise ValueError(msg)
+
+        if request.status != ApprovalStatus.PENDING:
+            msg = f"pending 상태에서만 승인 가능 (현재: {request.status})"
+            raise ValueError(msg)
+
+        now = datetime.now(UTC).isoformat()
+        request.history.append(
+            {"action": "approved", "actor": resolved_by, "at": now, "detail": ""}
+        )
+
+        await self._db.execute(
+            """UPDATE approvals
+               SET status = ?, resolved_at = ?, resolved_by = ?,
+                   history = ?
+               WHERE id = ?""",
+            (
+                ApprovalStatus.APPROVED,
+                now,
+                resolved_by,
+                json.dumps(request.history, ensure_ascii=False),
+                id,
+            ),
+        )
+
+        request.status = ApprovalStatus.APPROVED
+        request.resolved_at = now
+        request.resolved_by = resolved_by
+
+        logger.info("결재 승인: %s by %s", id, resolved_by)
+
+        # 자동 실행
+        executor = self._executors.get(request.type)
+        if executor:
+            try:
+                await executor(request.params)
+                logger.info("결재 실행 완료: %s (%s)", id, request.type)
+            except Exception:
+                logger.exception("결재 실행 실패: %s (%s)", id, request.type)
+
+        # ApprovalResolvedEvent 발행
+        from ante.eventbus.events import ApprovalResolvedEvent
+
+        await self._eventbus.publish(
+            ApprovalResolvedEvent(
+                approval_id=id,
+                approval_type=request.type,
+                resolution=ApprovalStatus.APPROVED,
+                resolved_by=resolved_by,
+            )
+        )
+
+        return request
+
+    async def reject(
+        self,
+        id: str,
+        resolved_by: str = "user",
+        reject_reason: str = "",
+    ) -> ApprovalRequest:
+        """결재 거절."""
+        request = await self.get(id)
+        if not request:
+            msg = f"결재 요청을 찾을 수 없음: {id}"
+            raise ValueError(msg)
+
+        if request.status != ApprovalStatus.PENDING:
+            msg = f"pending 상태에서만 거절 가능 (현재: {request.status})"
+            raise ValueError(msg)
+
+        now = datetime.now(UTC).isoformat()
+        request.history.append(
+            {
+                "action": "rejected",
+                "actor": resolved_by,
+                "at": now,
+                "detail": reject_reason,
+            }
+        )
+
+        await self._db.execute(
+            """UPDATE approvals
+               SET status = ?, resolved_at = ?, resolved_by = ?,
+                   reject_reason = ?, history = ?
+               WHERE id = ?""",
+            (
+                ApprovalStatus.REJECTED,
+                now,
+                resolved_by,
+                reject_reason,
+                json.dumps(request.history, ensure_ascii=False),
+                id,
+            ),
+        )
+
+        request.status = ApprovalStatus.REJECTED
+        request.resolved_at = now
+        request.resolved_by = resolved_by
+        request.reject_reason = reject_reason
+
+        logger.info("결재 거절: %s by %s (사유: %s)", id, resolved_by, reject_reason)
+
+        from ante.eventbus.events import ApprovalResolvedEvent
+
+        await self._eventbus.publish(
+            ApprovalResolvedEvent(
+                approval_id=id,
+                approval_type=request.type,
+                resolution=ApprovalStatus.REJECTED,
+                resolved_by=resolved_by,
+            )
+        )
+
+        return request
+
+    async def cancel(
+        self,
+        id: str,
+        requester: str,
+    ) -> ApprovalRequest:
+        """결재 철회 (요청자만 가능, pending/on_hold 상태에서만)."""
+        request = await self.get(id)
+        if not request:
+            msg = f"결재 요청을 찾을 수 없음: {id}"
+            raise ValueError(msg)
+
+        if request.requester != requester:
+            msg = f"본인 요청만 철회 가능 (요청자: {request.requester})"
+            raise ValueError(msg)
+
+        if request.status not in (ApprovalStatus.PENDING, ApprovalStatus.ON_HOLD):
+            msg = f"pending/on_hold 상태에서만 철회 가능 (현재: {request.status})"
+            raise ValueError(msg)
+
+        now = datetime.now(UTC).isoformat()
+        request.history.append(
+            {"action": "cancelled", "actor": requester, "at": now, "detail": ""}
+        )
+
+        await self._db.execute(
+            """UPDATE approvals
+               SET status = ?, resolved_at = ?, resolved_by = ?,
+                   history = ?
+               WHERE id = ?""",
+            (
+                ApprovalStatus.CANCELLED,
+                now,
+                requester,
+                json.dumps(request.history, ensure_ascii=False),
+                id,
+            ),
+        )
+
+        request.status = ApprovalStatus.CANCELLED
+        request.resolved_at = now
+        request.resolved_by = requester
+
+        logger.info("결재 철회: %s by %s", id, requester)
+
+        from ante.eventbus.events import ApprovalResolvedEvent
+
+        await self._eventbus.publish(
+            ApprovalResolvedEvent(
+                approval_id=id,
+                approval_type=request.type,
+                resolution=ApprovalStatus.CANCELLED,
+                resolved_by=requester,
+            )
+        )
+
+        return request
+
+    async def hold(self, id: str) -> ApprovalRequest:
+        """보류 전환."""
+        request = await self.get(id)
+        if not request:
+            msg = f"결재 요청을 찾을 수 없음: {id}"
+            raise ValueError(msg)
+
+        if request.status != ApprovalStatus.PENDING:
+            msg = f"pending 상태에서만 보류 가능 (현재: {request.status})"
+            raise ValueError(msg)
+
+        now = datetime.now(UTC).isoformat()
+        request.history.append(
+            {"action": "held", "actor": "user", "at": now, "detail": ""}
+        )
+
+        await self._db.execute(
+            """UPDATE approvals SET status = ?, history = ? WHERE id = ?""",
+            (
+                ApprovalStatus.ON_HOLD,
+                json.dumps(request.history, ensure_ascii=False),
+                id,
+            ),
+        )
+
+        request.status = ApprovalStatus.ON_HOLD
+        logger.info("결재 보류: %s", id)
+        return request
+
+    async def resume(self, id: str) -> ApprovalRequest:
+        """보류 해제 → pending."""
+        request = await self.get(id)
+        if not request:
+            msg = f"결재 요청을 찾을 수 없음: {id}"
+            raise ValueError(msg)
+
+        if request.status != ApprovalStatus.ON_HOLD:
+            msg = f"on_hold 상태에서만 재개 가능 (현재: {request.status})"
+            raise ValueError(msg)
+
+        now = datetime.now(UTC).isoformat()
+        request.history.append(
+            {"action": "resumed", "actor": "user", "at": now, "detail": ""}
+        )
+
+        await self._db.execute(
+            """UPDATE approvals SET status = ?, history = ? WHERE id = ?""",
+            (
+                ApprovalStatus.PENDING,
+                json.dumps(request.history, ensure_ascii=False),
+                id,
+            ),
+        )
+
+        request.status = ApprovalStatus.PENDING
+        logger.info("결재 재개: %s", id)
+        return request
+
+    async def add_review(
+        self,
+        id: str,
+        reviewer: str,
+        result: str,
+        detail: str = "",
+    ) -> ApprovalRequest:
+        """검토 의견 추가."""
+        request = await self.get(id)
+        if not request:
+            msg = f"결재 요청을 찾을 수 없음: {id}"
+            raise ValueError(msg)
+
+        now = datetime.now(UTC).isoformat()
+
+        review = {
+            "reviewer": reviewer,
+            "result": result,
+            "detail": detail,
+            "reviewed_at": now,
+        }
+        request.reviews.append(review)
+
+        request.history.append(
+            {
+                "action": "review_added",
+                "actor": reviewer,
+                "at": now,
+                "detail": f"{result}: {detail}" if detail else result,
+            }
+        )
+
+        await self._db.execute(
+            """UPDATE approvals SET reviews = ?, history = ? WHERE id = ?""",
+            (
+                json.dumps(request.reviews, ensure_ascii=False),
+                json.dumps(request.history, ensure_ascii=False),
+                id,
+            ),
+        )
+
+        logger.info("검토 의견 추가: %s by %s (%s)", id, reviewer, result)
+        return request
+
+    async def expire_stale(self) -> int:
+        """만료 기한이 지난 pending 요청 일괄 expired 처리."""
+        now = datetime.now(UTC).isoformat()
+
+        rows = await self._db.fetch_all(
+            """SELECT * FROM approvals
+               WHERE status = ? AND expires_at != '' AND expires_at < ?""",
+            (ApprovalStatus.PENDING, now),
+        )
+
+        count = 0
+        for row in rows:
+            request = self._row_to_request(row)
+            request.history.append(
+                {"action": "expired", "actor": "system", "at": now, "detail": ""}
+            )
+
+            await self._db.execute(
+                """UPDATE approvals
+                   SET status = ?, resolved_at = ?, resolved_by = ?,
+                       history = ?
+                   WHERE id = ?""",
+                (
+                    ApprovalStatus.EXPIRED,
+                    now,
+                    "system",
+                    json.dumps(request.history, ensure_ascii=False),
+                    request.id,
+                ),
+            )
+
+            from ante.eventbus.events import ApprovalResolvedEvent
+
+            await self._eventbus.publish(
+                ApprovalResolvedEvent(
+                    approval_id=request.id,
+                    approval_type=request.type,
+                    resolution=ApprovalStatus.EXPIRED,
+                    resolved_by="system",
+                )
+            )
+            count += 1
+
+        if count:
+            logger.info("만료 처리: %d건", count)
+        return count
+
+    async def get(self, id: str) -> ApprovalRequest | None:
+        """단건 조회."""
+        row = await self._db.fetch_one(
+            "SELECT * FROM approvals WHERE id = ?",
+            (id,),
+        )
+        if not row:
+            return None
+        return self._row_to_request(row)
+
+    async def list(
+        self,
+        status: str | None = None,
+        type: str | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[ApprovalRequest]:
+        """필터 조회."""
+        conditions: list[str] = []
+        params: list[object] = []
+
+        if status:
+            conditions.append("status = ?")
+            params.append(status)
+        if type:
+            conditions.append("type = ?")
+            params.append(type)
+
+        where = " AND ".join(conditions) if conditions else "1=1"
+        query = (
+            f"SELECT * FROM approvals WHERE {where}"  # noqa: S608
+            " ORDER BY created_at DESC"
+            " LIMIT ? OFFSET ?"
+        )
+        params.extend([limit, offset])
+
+        rows = await self._db.fetch_all(query, tuple(params))
+        return [self._row_to_request(row) for row in rows]
+
+    @staticmethod
+    def _row_to_request(row: dict) -> ApprovalRequest:
+        """DB row → ApprovalRequest 변환."""
+        return ApprovalRequest(
+            id=row["id"],
+            type=row["type"],
+            status=row["status"],
+            requester=row["requester"],
+            title=row["title"],
+            body=row.get("body", ""),
+            params=json.loads(row.get("params", "{}")),
+            reviews=json.loads(row.get("reviews", "[]")),
+            history=json.loads(row.get("history", "[]")),
+            reference_id=row.get("reference_id", ""),
+            expires_at=row.get("expires_at", ""),
+            created_at=row.get("created_at", ""),
+            resolved_at=row.get("resolved_at", ""),
+            resolved_by=row.get("resolved_by", ""),
+            reject_reason=row.get("reject_reason", ""),
+        )

--- a/src/ante/cli/commands/approval.py
+++ b/src/ante/cli/commands/approval.py
@@ -1,0 +1,372 @@
+"""ante approval — 결재 관리 커맨드."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import click
+
+from ante.cli.main import get_formatter
+
+
+@click.group()
+def approval() -> None:
+    """결재 관리."""
+
+
+@approval.command()
+@click.option("--type", "approval_type", required=True, help="결재 유형")
+@click.option("--title", required=True, help="요청 제목")
+@click.option("--body", default="", help="본문 (사유, 현황, 기대 효과 등)")
+@click.option("--params", "params_json", default="{}", help="실행 파라미터 (JSON)")
+@click.option("--reference-id", default="", help="참조 ID (report_id 등)")
+@click.option("--expires-in", default="", help="만료 기한 (예: 72h, 7d)")
+@click.option("--requester", default="agent", help="요청자 식별")
+@click.option("--db-path", default="db/ante.db", help="DB 경로")
+@click.pass_context
+def request(
+    ctx: click.Context,
+    approval_type: str,
+    title: str,
+    body: str,
+    params_json: str,
+    reference_id: str,
+    expires_in: str,
+    requester: str,
+    db_path: str,
+) -> None:
+    """결재 요청 생성."""
+    fmt = get_formatter(ctx)
+
+    try:
+        params = json.loads(params_json)
+    except json.JSONDecodeError as e:
+        fmt.error(f"잘못된 JSON 형식: {e}", code="INVALID_JSON")
+        raise SystemExit(1) from e
+
+    expires_at = _parse_expires_in(expires_in) if expires_in else ""
+
+    async def _create() -> dict:
+        from ante.approval import ApprovalService
+        from ante.core.database import Database
+        from ante.eventbus.bus import EventBus
+
+        db = Database(db_path)
+        await db.connect()
+        eventbus = EventBus()
+        service = ApprovalService(db=db, eventbus=eventbus)
+        await service.initialize()
+
+        req = await service.create(
+            type=approval_type,
+            requester=requester,
+            title=title,
+            body=body,
+            params=params,
+            reference_id=reference_id,
+            expires_at=expires_at,
+        )
+        await db.close()
+        return {
+            "id": req.id,
+            "type": req.type,
+            "status": req.status,
+            "title": req.title,
+        }
+
+    try:
+        result = asyncio.run(_create())
+        fmt.success(f"결재 요청 생성: {result['id']}", result)
+    except Exception as e:
+        fmt.error(str(e), code="APPROVAL_ERROR")
+        raise SystemExit(1) from e
+
+
+@approval.command("list")
+@click.option("--status", default=None, help="상태 필터")
+@click.option("--type", "approval_type", default=None, help="유형 필터")
+@click.option("--db-path", default="db/ante.db", help="DB 경로")
+@click.pass_context
+def approval_list(
+    ctx: click.Context,
+    status: str | None,
+    approval_type: str | None,
+    db_path: str,
+) -> None:
+    """결재 목록 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _list() -> list[dict]:
+        from ante.approval import ApprovalService
+        from ante.core.database import Database
+        from ante.eventbus.bus import EventBus
+
+        db = Database(db_path)
+        await db.connect()
+        eventbus = EventBus()
+        service = ApprovalService(db=db, eventbus=eventbus)
+        await service.initialize()
+
+        requests = await service.list(status=status, type=approval_type)
+        await db.close()
+        return [
+            {
+                "id": r.id[:8],
+                "type": r.type,
+                "status": r.status,
+                "requester": r.requester,
+                "title": r.title,
+                "created_at": r.created_at,
+            }
+            for r in requests
+        ]
+
+    try:
+        rows = asyncio.run(_list())
+        fmt.table(rows, ["id", "type", "status", "requester", "title", "created_at"])
+    except Exception as e:
+        fmt.error(str(e), code="APPROVAL_ERROR")
+        raise SystemExit(1) from e
+
+
+@approval.command()
+@click.argument("id")
+@click.option("--db-path", default="db/ante.db", help="DB 경로")
+@click.pass_context
+def info(ctx: click.Context, id: str, db_path: str) -> None:
+    """결재 상세 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _info() -> dict:
+        from ante.approval import ApprovalService
+        from ante.core.database import Database
+        from ante.eventbus.bus import EventBus
+
+        db = Database(db_path)
+        await db.connect()
+        eventbus = EventBus()
+        service = ApprovalService(db=db, eventbus=eventbus)
+        await service.initialize()
+
+        req = await _find_request(service, id)
+        await db.close()
+        return {
+            "id": req.id,
+            "type": req.type,
+            "status": req.status,
+            "requester": req.requester,
+            "title": req.title,
+            "body": req.body,
+            "params": req.params,
+            "reviews": req.reviews,
+            "history": req.history,
+            "reference_id": req.reference_id,
+            "expires_at": req.expires_at,
+            "created_at": req.created_at,
+            "resolved_at": req.resolved_at,
+            "resolved_by": req.resolved_by,
+            "reject_reason": req.reject_reason,
+        }
+
+    try:
+        result = asyncio.run(_info())
+        fmt.output(result)
+    except Exception as e:
+        fmt.error(str(e), code="APPROVAL_ERROR")
+        raise SystemExit(1) from e
+
+
+@approval.command()
+@click.argument("id")
+@click.option("--reviewer", required=True, help="검토자 식별")
+@click.option(
+    "--result",
+    "review_result",
+    required=True,
+    type=click.Choice(["pass", "warn", "fail"]),
+    help="검토 결과",
+)
+@click.option("--detail", default="", help="검토 상세")
+@click.option("--db-path", default="db/ante.db", help="DB 경로")
+@click.pass_context
+def review(
+    ctx: click.Context,
+    id: str,
+    reviewer: str,
+    review_result: str,
+    detail: str,
+    db_path: str,
+) -> None:
+    """검토 의견 추가."""
+    fmt = get_formatter(ctx)
+
+    async def _review() -> dict:
+        from ante.approval import ApprovalService
+        from ante.core.database import Database
+        from ante.eventbus.bus import EventBus
+
+        db = Database(db_path)
+        await db.connect()
+        eventbus = EventBus()
+        service = ApprovalService(db=db, eventbus=eventbus)
+        await service.initialize()
+
+        req = await service.add_review(
+            id=id,
+            reviewer=reviewer,
+            result=review_result,
+            detail=detail,
+        )
+        await db.close()
+        return {
+            "id": req.id,
+            "reviewer": reviewer,
+            "result": review_result,
+            "reviews_count": len(req.reviews),
+        }
+
+    try:
+        result = asyncio.run(_review())
+        fmt.success(f"검토 의견 추가: {reviewer} → {review_result}", result)
+    except Exception as e:
+        fmt.error(str(e), code="APPROVAL_ERROR")
+        raise SystemExit(1) from e
+
+
+@approval.command("cancel")
+@click.argument("id")
+@click.option("--requester", required=True, help="요청자 식별 (본인 확인용)")
+@click.option("--db-path", default="db/ante.db", help="DB 경로")
+@click.pass_context
+def cancel(ctx: click.Context, id: str, requester: str, db_path: str) -> None:
+    """결재 철회 (요청자만 가능)."""
+    fmt = get_formatter(ctx)
+
+    async def _cancel() -> dict:
+        from ante.approval import ApprovalService
+        from ante.core.database import Database
+        from ante.eventbus.bus import EventBus
+
+        db = Database(db_path)
+        await db.connect()
+        eventbus = EventBus()
+        service = ApprovalService(db=db, eventbus=eventbus)
+        await service.initialize()
+
+        req = await service.cancel(id=id, requester=requester)
+        await db.close()
+        return {"id": req.id, "status": req.status}
+
+    try:
+        result = asyncio.run(_cancel())
+        fmt.success(f"결재 철회: {result['id']}", result)
+    except Exception as e:
+        fmt.error(str(e), code="APPROVAL_ERROR")
+        raise SystemExit(1) from e
+
+
+@approval.command("approve")
+@click.argument("id")
+@click.option("--db-path", default="db/ante.db", help="DB 경로")
+@click.pass_context
+def approve(ctx: click.Context, id: str, db_path: str) -> None:
+    """결재 승인."""
+    fmt = get_formatter(ctx)
+
+    async def _approve() -> dict:
+        from ante.approval import ApprovalService
+        from ante.core.database import Database
+        from ante.eventbus.bus import EventBus
+
+        db = Database(db_path)
+        await db.connect()
+        eventbus = EventBus()
+        service = ApprovalService(db=db, eventbus=eventbus)
+        await service.initialize()
+
+        req = await service.approve(id=id)
+        await db.close()
+        return {"id": req.id, "status": req.status, "type": req.type}
+
+    try:
+        result = asyncio.run(_approve())
+        fmt.success(f"결재 승인: {result['id']}", result)
+    except Exception as e:
+        fmt.error(str(e), code="APPROVAL_ERROR")
+        raise SystemExit(1) from e
+
+
+@approval.command("reject")
+@click.argument("id")
+@click.option("--reason", default="", help="거절 사유")
+@click.option("--db-path", default="db/ante.db", help="DB 경로")
+@click.pass_context
+def reject(ctx: click.Context, id: str, reason: str, db_path: str) -> None:
+    """결재 거절."""
+    fmt = get_formatter(ctx)
+
+    async def _reject() -> dict:
+        from ante.approval import ApprovalService
+        from ante.core.database import Database
+        from ante.eventbus.bus import EventBus
+
+        db = Database(db_path)
+        await db.connect()
+        eventbus = EventBus()
+        service = ApprovalService(db=db, eventbus=eventbus)
+        await service.initialize()
+
+        req = await service.reject(id=id, reject_reason=reason)
+        await db.close()
+        return {"id": req.id, "status": req.status, "reject_reason": reason}
+
+    try:
+        result = asyncio.run(_reject())
+        fmt.success(f"결재 거절: {result['id']}", result)
+    except Exception as e:
+        fmt.error(str(e), code="APPROVAL_ERROR")
+        raise SystemExit(1) from e
+
+
+async def _find_request(service, id: str):  # type: ignore[no-untyped-def]
+    """ID 전체 또는 prefix로 결재 요청 검색."""
+    req = await service.get(id)
+    if req:
+        return req
+
+    # prefix 검색
+    all_requests = await service.list(limit=100)
+    matches = [r for r in all_requests if r.id.startswith(id)]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        ids = ", ".join(m.id[:8] for m in matches)
+        msg = f"여러 건이 일치합니다: {ids}"
+        raise ValueError(msg)
+
+    msg = f"결재 요청을 찾을 수 없음: {id}"
+    raise ValueError(msg)
+
+
+def _parse_expires_in(expires_in: str) -> str:
+    """'72h', '7d' 같은 상대 시간을 절대 시각 ISO 문자열로 변환."""
+    from datetime import UTC, datetime, timedelta
+
+    value = expires_in.rstrip("hHdD")
+    try:
+        num = int(value)
+    except ValueError as e:
+        msg = f"잘못된 expires-in 형식: {expires_in}"
+        raise ValueError(msg) from e
+
+    unit = expires_in[-1].lower()
+    if unit == "h":
+        delta = timedelta(hours=num)
+    elif unit == "d":
+        delta = timedelta(days=num)
+    else:
+        msg = f"지원하지 않는 시간 단위: {unit} (h 또는 d만 가능)"
+        raise ValueError(msg)
+
+    return (datetime.now(UTC) + delta).isoformat()

--- a/src/ante/cli/main.py
+++ b/src/ante/cli/main.py
@@ -30,12 +30,14 @@ def get_formatter(ctx: click.Context) -> OutputFormatter:
 
 
 # 서브커맨드 등록
+from ante.cli.commands.approval import approval  # noqa: E402
 from ante.cli.commands.backtest import backtest  # noqa: E402
 from ante.cli.commands.data import data  # noqa: E402
 from ante.cli.commands.instrument import instrument  # noqa: E402
 from ante.cli.commands.report import report  # noqa: E402
 from ante.cli.commands.strategy import strategy  # noqa: E402
 
+cli.add_command(approval)
 cli.add_command(strategy)
 cli.add_command(data)
 cli.add_command(backtest)

--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -315,3 +315,26 @@ class ConfigChangedEvent(Event):
     old_value: str = ""
     new_value: str = ""
     changed_by: str = ""
+
+
+# ── 결재 (Approval) ───────────────────────────
+
+
+@dataclass(frozen=True)
+class ApprovalCreatedEvent(Event):
+    """ApprovalService → EventBus: 결재 요청 생성."""
+
+    approval_id: str = ""
+    approval_type: str = ""
+    requester: str = ""
+    title: str = ""
+
+
+@dataclass(frozen=True)
+class ApprovalResolvedEvent(Event):
+    """ApprovalService → EventBus: 결재 처리 완료 (승인/거절/철회/만료)."""
+
+    approval_id: str = ""
+    approval_type: str = ""
+    resolution: str = ""
+    resolved_by: str = ""

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -188,6 +188,21 @@ async def main() -> None:
     await report_store.initialize()
     logger.info("ReportStore 초기화 완료")
 
+    # ── 14.5. ApprovalService ──────────────────────────
+    from ante.approval import ApprovalService
+
+    approval_executors: dict = {
+        "strategy_adopt": lambda params: report_store.update_status(
+            params["report_id"], "adopted"
+        ),
+        "bot_stop": lambda params: bot_manager.stop_bot(params["bot_id"]),
+    }
+    approval_service = ApprovalService(  # noqa: F841
+        db=db, eventbus=eventbus, executors=approval_executors
+    )
+    await approval_service.initialize()
+    logger.info("ApprovalService 초기화 완료")
+
     # ── 15. NotificationService ──────────────────────
     from ante.notification import (
         NotificationLevel,

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -1,0 +1,549 @@
+"""Approval 모듈 단위 테스트."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ante.approval.models import ApprovalRequest, ApprovalStatus, ApprovalType
+from ante.approval.service import ApprovalService
+from ante.core.database import Database
+from ante.eventbus.bus import EventBus
+from ante.eventbus.events import ApprovalCreatedEvent, ApprovalResolvedEvent
+
+# ── Fixtures ─────────────────────────────────────────
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """테스트용 SQLite DB."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    return db
+
+
+@pytest.fixture
+async def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+async def service(db, eventbus):
+    svc = ApprovalService(db=db, eventbus=eventbus)
+    await svc.initialize()
+    return svc
+
+
+# ── Models ───────────────────────────────────────────
+
+
+class TestModels:
+    def test_approval_status_values(self):
+        """ApprovalStatus 값."""
+        assert ApprovalStatus.PENDING == "pending"
+        assert ApprovalStatus.APPROVED == "approved"
+        assert ApprovalStatus.REJECTED == "rejected"
+        assert ApprovalStatus.ON_HOLD == "on_hold"
+        assert ApprovalStatus.EXPIRED == "expired"
+        assert ApprovalStatus.CANCELLED == "cancelled"
+
+    def test_approval_type_values(self):
+        """ApprovalType 값."""
+        assert ApprovalType.STRATEGY_ADOPT == "strategy_adopt"
+        assert ApprovalType.BUDGET_CHANGE == "budget_change"
+        assert ApprovalType.BOT_CREATE == "bot_create"
+        assert ApprovalType.BOT_STOP == "bot_stop"
+        assert ApprovalType.RULE_CHANGE == "rule_change"
+
+    def test_approval_request_defaults(self):
+        """ApprovalRequest 기본값."""
+        req = ApprovalRequest(
+            id="test-id",
+            type="budget_change",
+            status="pending",
+            requester="agent",
+            title="테스트 요청",
+        )
+        assert req.body == ""
+        assert req.params == {}
+        assert req.reviews == []
+        assert req.history == []
+        assert req.reference_id == ""
+        assert req.expires_at == ""
+
+
+# ── ApprovalService: 생성 및 조회 (US-1) ────────────
+
+
+class TestCreate:
+    async def test_create_request(self, service):
+        """결재 요청 생성."""
+        req = await service.create(
+            type="budget_change",
+            requester="agent:strategy-dev",
+            title="예산 증액 요청",
+            body="수익률 15%, 비중 확대 요청",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+
+        assert req.id
+        assert req.type == "budget_change"
+        assert req.status == "pending"
+        assert req.requester == "agent:strategy-dev"
+        assert req.title == "예산 증액 요청"
+        assert req.body == "수익률 15%, 비중 확대 요청"
+        assert req.params == {"bot_id": "bot-1", "amount": 25000000}
+        assert len(req.history) == 1
+        assert req.history[0]["action"] == "created"
+
+    async def test_create_with_reference(self, service):
+        """참조 ID가 있는 결재 요청."""
+        req = await service.create(
+            type="strategy_adopt",
+            requester="agent",
+            title="전략 채택 요청",
+            reference_id="report-123",
+        )
+        assert req.reference_id == "report-123"
+
+    async def test_create_with_expires(self, service):
+        """만료 시간이 있는 결재 요청."""
+        future = (datetime.now(UTC) + timedelta(hours=72)).isoformat()
+        req = await service.create(
+            type="budget_change",
+            requester="agent",
+            title="테스트",
+            expires_at=future,
+        )
+        assert req.expires_at == future
+
+    async def test_create_publishes_event(self, service, eventbus):
+        """생성 시 ApprovalCreatedEvent 발행."""
+        received = []
+
+        async def handler(event: object) -> None:
+            if isinstance(event, ApprovalCreatedEvent):
+                received.append(event)
+
+        eventbus.subscribe(ApprovalCreatedEvent, handler)
+
+        await service.create(
+            type="bot_create",
+            requester="agent",
+            title="봇 생성 요청",
+        )
+
+        assert len(received) == 1
+        assert received[0].approval_type == "bot_create"
+        assert received[0].requester == "agent"
+
+    async def test_get_request(self, service):
+        """단건 조회."""
+        created = await service.create(
+            type="budget_change",
+            requester="agent",
+            title="테스트",
+        )
+
+        fetched = await service.get(created.id)
+        assert fetched is not None
+        assert fetched.id == created.id
+        assert fetched.type == "budget_change"
+
+    async def test_get_nonexistent(self, service):
+        """존재하지 않는 요청 조회 시 None."""
+        assert await service.get("nonexistent") is None
+
+    async def test_list_all(self, service):
+        """전체 목록 조회."""
+        await service.create(type="budget_change", requester="agent", title="요청 1")
+        await service.create(type="bot_create", requester="agent", title="요청 2")
+        await service.create(type="bot_stop", requester="agent", title="요청 3")
+
+        all_requests = await service.list()
+        assert len(all_requests) == 3
+
+    async def test_list_filter_status(self, service):
+        """상태 필터 조회."""
+        req = await service.create(
+            type="budget_change", requester="agent", title="요청 1"
+        )
+        await service.create(type="bot_create", requester="agent", title="요청 2")
+        await service.approve(req.id)
+
+        pending = await service.list(status="pending")
+        assert len(pending) == 1
+
+        approved = await service.list(status="approved")
+        assert len(approved) == 1
+
+    async def test_list_filter_type(self, service):
+        """유형 필터 조회."""
+        await service.create(type="budget_change", requester="agent", title="요청 1")
+        await service.create(type="bot_create", requester="agent", title="요청 2")
+
+        budget = await service.list(type="budget_change")
+        assert len(budget) == 1
+        assert budget[0].type == "budget_change"
+
+    async def test_list_pagination(self, service):
+        """페이지네이션."""
+        for i in range(5):
+            await service.create(
+                type="budget_change", requester="agent", title=f"요청 {i}"
+            )
+
+        page1 = await service.list(limit=2, offset=0)
+        page2 = await service.list(limit=2, offset=2)
+        assert len(page1) == 2
+        assert len(page2) == 2
+
+
+# ── 승인·거절·보류 (US-2) ────────────────────────────
+
+
+class TestResolve:
+    async def test_approve(self, service):
+        """결재 승인."""
+        req = await service.create(
+            type="budget_change", requester="agent", title="승인 테스트"
+        )
+        approved = await service.approve(req.id)
+
+        assert approved.status == "approved"
+        assert approved.resolved_by == "user"
+        assert approved.resolved_at != ""
+        assert any(h["action"] == "approved" for h in approved.history)
+
+    async def test_approve_executes_handler(self, db, eventbus):
+        """승인 시 executor 실행."""
+        executed = []
+
+        async def mock_executor(params: dict) -> None:
+            executed.append(params)
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"budget_change": mock_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="실행 테스트",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        await svc.approve(req.id)
+
+        assert len(executed) == 1
+        assert executed[0]["bot_id"] == "bot-1"
+
+    async def test_approve_publishes_event(self, service, eventbus):
+        """승인 시 ApprovalResolvedEvent 발행."""
+        received = []
+
+        async def handler(event: object) -> None:
+            if isinstance(event, ApprovalResolvedEvent):
+                received.append(event)
+
+        eventbus.subscribe(ApprovalResolvedEvent, handler)
+
+        req = await service.create(
+            type="budget_change", requester="agent", title="이벤트 테스트"
+        )
+        await service.approve(req.id)
+
+        assert len(received) == 1
+        assert received[0].resolution == "approved"
+
+    async def test_approve_non_pending_fails(self, service):
+        """pending이 아닌 상태에서 승인 시 에러."""
+        req = await service.create(
+            type="budget_change", requester="agent", title="테스트"
+        )
+        await service.approve(req.id)
+
+        with pytest.raises(ValueError, match="pending 상태에서만 승인 가능"):
+            await service.approve(req.id)
+
+    async def test_reject(self, service):
+        """결재 거절."""
+        req = await service.create(
+            type="budget_change", requester="agent", title="거절 테스트"
+        )
+        rejected = await service.reject(req.id, reject_reason="리스크 과다")
+
+        assert rejected.status == "rejected"
+        assert rejected.reject_reason == "리스크 과다"
+        assert any(h["action"] == "rejected" for h in rejected.history)
+
+    async def test_reject_non_pending_fails(self, service):
+        """pending이 아닌 상태에서 거절 시 에러."""
+        req = await service.create(
+            type="budget_change", requester="agent", title="테스트"
+        )
+        await service.reject(req.id)
+
+        with pytest.raises(ValueError, match="pending 상태에서만 거절 가능"):
+            await service.reject(req.id)
+
+    async def test_hold_and_resume(self, service):
+        """보류 및 재개."""
+        req = await service.create(
+            type="budget_change", requester="agent", title="보류 테스트"
+        )
+
+        held = await service.hold(req.id)
+        assert held.status == "on_hold"
+        assert any(h["action"] == "held" for h in held.history)
+
+        resumed = await service.resume(req.id)
+        assert resumed.status == "pending"
+        assert any(h["action"] == "resumed" for h in resumed.history)
+
+    async def test_hold_non_pending_fails(self, service):
+        """pending이 아닌 상태에서 보류 시 에러."""
+        req = await service.create(
+            type="budget_change", requester="agent", title="테스트"
+        )
+        await service.approve(req.id)
+
+        with pytest.raises(ValueError, match="pending 상태에서만 보류 가능"):
+            await service.hold(req.id)
+
+    async def test_resume_non_hold_fails(self, service):
+        """on_hold가 아닌 상태에서 재개 시 에러."""
+        req = await service.create(
+            type="budget_change", requester="agent", title="테스트"
+        )
+
+        with pytest.raises(ValueError, match="on_hold 상태에서만 재개 가능"):
+            await service.resume(req.id)
+
+
+# ── 철회 (US-3) ──────────────────────────────────────
+
+
+class TestCancel:
+    async def test_cancel_pending(self, service):
+        """pending 상태에서 철회."""
+        req = await service.create(
+            type="budget_change", requester="agent:dev", title="철회 테스트"
+        )
+        cancelled = await service.cancel(req.id, requester="agent:dev")
+
+        assert cancelled.status == "cancelled"
+        assert any(h["action"] == "cancelled" for h in cancelled.history)
+
+    async def test_cancel_on_hold(self, service):
+        """on_hold 상태에서 철회."""
+        req = await service.create(
+            type="budget_change", requester="agent:dev", title="보류 후 철회"
+        )
+        await service.hold(req.id)
+        cancelled = await service.cancel(req.id, requester="agent:dev")
+
+        assert cancelled.status == "cancelled"
+
+    async def test_cancel_wrong_requester_fails(self, service):
+        """본인이 아닌 요청자가 철회 시 에러."""
+        req = await service.create(
+            type="budget_change", requester="agent:dev", title="테스트"
+        )
+
+        with pytest.raises(ValueError, match="본인 요청만 철회 가능"):
+            await service.cancel(req.id, requester="agent:other")
+
+    async def test_cancel_approved_fails(self, service):
+        """이미 승인된 요청 철회 시 에러."""
+        req = await service.create(
+            type="budget_change", requester="agent:dev", title="테스트"
+        )
+        await service.approve(req.id)
+
+        with pytest.raises(ValueError, match="pending/on_hold 상태에서만 철회 가능"):
+            await service.cancel(req.id, requester="agent:dev")
+
+    async def test_cancel_publishes_event(self, service, eventbus):
+        """철회 시 ApprovalResolvedEvent 발행."""
+        received = []
+
+        async def handler(event: object) -> None:
+            if isinstance(event, ApprovalResolvedEvent):
+                received.append(event)
+
+        eventbus.subscribe(ApprovalResolvedEvent, handler)
+
+        req = await service.create(
+            type="budget_change", requester="agent:dev", title="이벤트 테스트"
+        )
+        await service.cancel(req.id, requester="agent:dev")
+
+        assert len(received) == 1
+        assert received[0].resolution == "cancelled"
+
+
+# ── 사전 검증 (US-4) ────────────────────────────────
+
+
+class TestReview:
+    async def test_add_review(self, service):
+        """검토 의견 추가."""
+        req = await service.create(
+            type="budget_change", requester="agent", title="검토 테스트"
+        )
+
+        reviewed = await service.add_review(
+            id=req.id,
+            reviewer="treasury",
+            result="pass",
+            detail="가용 잔액 충분",
+        )
+
+        assert len(reviewed.reviews) == 1
+        assert reviewed.reviews[0]["reviewer"] == "treasury"
+        assert reviewed.reviews[0]["result"] == "pass"
+        assert reviewed.reviews[0]["detail"] == "가용 잔액 충분"
+        assert any(h["action"] == "review_added" for h in reviewed.history)
+
+    async def test_multiple_reviews(self, service):
+        """복수 검토 의견."""
+        req = await service.create(
+            type="budget_change", requester="agent", title="복수 검토"
+        )
+
+        await service.add_review(req.id, "treasury", "pass", "잔액 충분")
+        reviewed = await service.add_review(
+            req.id, "agent:risk-analyst", "warn", "변동성 주의"
+        )
+
+        assert len(reviewed.reviews) == 2
+
+    async def test_review_nonexistent_fails(self, service):
+        """존재하지 않는 요청에 검토 시 에러."""
+        with pytest.raises(ValueError, match="결재 요청을 찾을 수 없음"):
+            await service.add_review("nonexistent", "treasury", "pass")
+
+
+# ── 감사 이력 (US-5) ────────────────────────────────
+
+
+class TestHistory:
+    async def test_full_lifecycle_history(self, service):
+        """전체 생명주기 이력 추적."""
+        req = await service.create(
+            type="budget_change", requester="agent:dev", title="이력 테스트"
+        )
+        await service.add_review(req.id, "treasury", "pass", "잔액 충분")
+        await service.hold(req.id)
+        await service.resume(req.id)
+        result = await service.approve(req.id)
+
+        actions = [h["action"] for h in result.history]
+        assert actions == [
+            "created",
+            "review_added",
+            "held",
+            "resumed",
+            "approved",
+        ]
+
+    async def test_history_persisted(self, service):
+        """이력이 DB에 영속화."""
+        req = await service.create(
+            type="budget_change", requester="agent", title="영속화 테스트"
+        )
+        await service.approve(req.id)
+
+        fetched = await service.get(req.id)
+        assert fetched is not None
+        assert len(fetched.history) == 2
+        assert fetched.history[0]["action"] == "created"
+        assert fetched.history[1]["action"] == "approved"
+
+
+# ── 만료 처리 (US-6) ────────────────────────────────
+
+
+class TestExpire:
+    async def test_expire_stale(self, service):
+        """만료 기한이 지난 요청 일괄 처리."""
+        past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        await service.create(
+            type="budget_change",
+            requester="agent",
+            title="만료 테스트",
+            expires_at=past,
+        )
+
+        count = await service.expire_stale()
+        assert count == 1
+
+        requests = await service.list(status="expired")
+        assert len(requests) == 1
+        assert any(h["action"] == "expired" for h in requests[0].history)
+
+    async def test_expire_skips_non_pending(self, service):
+        """pending이 아닌 요청은 만료 처리 안 함."""
+        past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        req = await service.create(
+            type="budget_change",
+            requester="agent",
+            title="이미 승인됨",
+            expires_at=past,
+        )
+        await service.approve(req.id)
+
+        count = await service.expire_stale()
+        assert count == 0
+
+    async def test_expire_skips_no_expiry(self, service):
+        """만료 기한이 없는 요청은 만료 처리 안 함."""
+        await service.create(type="budget_change", requester="agent", title="무기한")
+
+        count = await service.expire_stale()
+        assert count == 0
+
+    async def test_expire_skips_future(self, service):
+        """만료 기한이 아직 안 된 요청은 만료 처리 안 함."""
+        future = (datetime.now(UTC) + timedelta(hours=72)).isoformat()
+        await service.create(
+            type="budget_change",
+            requester="agent",
+            title="아직 유효",
+            expires_at=future,
+        )
+
+        count = await service.expire_stale()
+        assert count == 0
+
+
+# ── 이벤트 모델 (US-7) ──────────────────────────────
+
+
+class TestEvents:
+    def test_approval_created_event(self):
+        """ApprovalCreatedEvent 기본값."""
+        event = ApprovalCreatedEvent(
+            approval_id="test-id",
+            approval_type="budget_change",
+            requester="agent",
+            title="테스트",
+        )
+        assert event.approval_id == "test-id"
+        assert event.event_id is not None
+        assert event.timestamp is not None
+
+    def test_approval_resolved_event(self):
+        """ApprovalResolvedEvent 기본값."""
+        event = ApprovalResolvedEvent(
+            approval_id="test-id",
+            approval_type="budget_change",
+            resolution="approved",
+            resolved_by="user",
+        )
+        assert event.resolution == "approved"
+        assert event.event_id is not None


### PR DESCRIPTION
## Summary

- AI Agent → 사용자 결재 체계(ApprovalService) 신규 구현
- 결재 요청 생성·승인·거절·보류·철회·만료 전체 상태 흐름 지원
- 사전 검증(reviews) 및 감사 이력(history) 추적
- CLI 커맨드 7종 + EventBus 이벤트 2종 + 38개 단위 테스트

## Changes

### 신규 파일
- `src/ante/approval/models.py` — `ApprovalRequest`, `ApprovalStatus`, `ApprovalType`
- `src/ante/approval/service.py` — `ApprovalService` (create, approve, reject, cancel, hold, resume, add_review, expire_stale, get, list)
- `src/ante/approval/__init__.py` — 모듈 export
- `src/ante/cli/commands/approval.py` — CLI 7개 커맨드 (request, list, info, review, cancel, approve, reject)
- `tests/unit/test_approval.py` — 38개 단위 테스트

### 수정 파일
- `src/ante/eventbus/events.py` — `ApprovalCreatedEvent`, `ApprovalResolvedEvent` 추가
- `src/ante/cli/main.py` — approval 커맨드 그룹 등록
- `src/ante/main.py` — ApprovalService 초기화 (14.5단계)

## Test plan

- [x] `pytest tests/unit/test_approval.py -v` — 38개 통과
- [x] `pytest tests/ -v` — 전체 508개 통과 (기존 테스트 영향 없음)
- [x] `ruff check` + `ruff format` 통과

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)