### PR TITLE
feat: Member 모듈 — 멤버 등록·인증·권한 관리 체계

### DIFF
--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -1,0 +1,363 @@
+"""ante member — 멤버 관리 커맨드."""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+from ante.cli.main import get_formatter
+
+
+@click.group()
+def member() -> None:
+    """멤버 등록·관리."""
+
+
+def _run(coro):  # noqa: ANN001, ANN202
+    """동기 CLI에서 async 함수 실행."""
+    return asyncio.run(coro)
+
+
+async def _create_service():  # noqa: ANN202
+    """CLI용 MemberService 인스턴스 생성."""
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+    from ante.member.service import MemberService
+
+    db = Database("db/ante.db")
+    await db.connect()
+    eventbus = EventBus()
+    service = MemberService(db, eventbus)
+    await service.initialize()
+    return service, db
+
+
+@member.command("list")
+@click.option(
+    "--type",
+    "member_type",
+    type=click.Choice(["human", "agent"]),
+    help="멤버 타입 필터",
+)
+@click.option("--org", help="조직 필터")
+@click.option(
+    "--status", type=click.Choice(["active", "suspended", "revoked"]), help="상태 필터"
+)
+@click.pass_context
+def member_list(
+    ctx: click.Context, member_type: str | None, org: str | None, status: str | None
+) -> None:
+    """멤버 목록 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _run_list() -> list[dict]:
+        service, db = await _create_service()
+        try:
+            members = await service.list(
+                member_type=member_type, org=org, status=status
+            )
+            return [
+                {
+                    "member_id": m.member_id,
+                    "type": m.type,
+                    "role": m.role,
+                    "org": m.org,
+                    "name": m.name,
+                    "status": m.status,
+                    "scopes": m.scopes,
+                    "created_at": m.created_at,
+                }
+                for m in members
+            ]
+        finally:
+            await db.close()
+
+    result = _run(_run_list())
+    if not result:
+        fmt.output({"message": "등록된 멤버가 없습니다.", "members": []})
+        return
+
+    if fmt.is_json:
+        fmt.output({"members": result})
+    else:
+        for m in result:
+            scopes = ", ".join(m["scopes"]) if m["scopes"] else "-"
+            click.echo(
+                f"  {m['member_id']:20s} {m['type']:6s} {m['role']:8s} "
+                f"{m['org']:15s} {m['status']:10s} {scopes}"
+            )
+
+
+@member.command("info")
+@click.argument("member_id")
+@click.pass_context
+def member_info(ctx: click.Context, member_id: str) -> None:
+    """멤버 상세 정보 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _run_info() -> dict | None:
+        service, db = await _create_service()
+        try:
+            m = await service.get(member_id)
+            if not m:
+                return None
+            return {
+                "member_id": m.member_id,
+                "type": m.type,
+                "role": m.role,
+                "org": m.org,
+                "name": m.name,
+                "status": m.status,
+                "scopes": m.scopes,
+                "created_at": m.created_at,
+                "created_by": m.created_by,
+                "last_active_at": m.last_active_at,
+            }
+        finally:
+            await db.close()
+
+    result = _run(_run_info())
+    if not result:
+        fmt.error(f"멤버를 찾을 수 없습니다: {member_id}")
+        return
+
+    if fmt.is_json:
+        fmt.output(result)
+    else:
+        click.echo(f"  Member ID : {result['member_id']}")
+        click.echo(f"  타입      : {result['type']}")
+        click.echo(f"  역할      : {result['role']}")
+        click.echo(f"  조직      : {result['org']}")
+        click.echo(f"  이름      : {result['name']}")
+        click.echo(f"  상태      : {result['status']}")
+        click.echo(f"  권한      : {', '.join(result['scopes']) or '-'}")
+        click.echo(f"  생성일    : {result['created_at']}")
+        click.echo(f"  생성자    : {result['created_by']}")
+
+
+@member.command("register")
+@click.option("--id", "member_id", required=True, help="멤버 ID")
+@click.option(
+    "--type",
+    "member_type",
+    required=True,
+    type=click.Choice(["human", "agent"]),
+    help="멤버 타입",
+)
+@click.option("--org", default="default", help="소속 조직")
+@click.option("--name", default="", help="표시 이름")
+@click.option("--scopes", default="", help="권한 범위 (쉼표 구분)")
+@click.pass_context
+def member_register(
+    ctx: click.Context,
+    member_id: str,
+    member_type: str,
+    org: str,
+    name: str,
+    scopes: str,
+) -> None:
+    """멤버 등록 (토큰 발급)."""
+    fmt = get_formatter(ctx)
+    scope_list = [s.strip() for s in scopes.split(",") if s.strip()] if scopes else []
+
+    async def _run_register() -> tuple[dict, str]:
+        service, db = await _create_service()
+        try:
+            m, token = await service.register(
+                member_id=member_id,
+                member_type=member_type,
+                org=org,
+                name=name,
+                scopes=scope_list,
+                registered_by="cli",
+            )
+            return {
+                "member_id": m.member_id,
+                "type": m.type,
+                "role": m.role,
+                "org": m.org,
+                "name": m.name,
+            }, token
+        finally:
+            await db.close()
+
+    try:
+        result, token = _run(_run_register())
+    except (ValueError, PermissionError) as e:
+        fmt.error(str(e))
+        return
+
+    if fmt.is_json:
+        fmt.output({**result, "token": token})
+    else:
+        fmt.success("멤버 등록 완료", result)
+        click.echo(f"  토큰: {token}")
+        click.echo("  이 토큰은 다시 표시되지 않습니다.")
+
+
+@member.command("suspend")
+@click.argument("member_id")
+@click.pass_context
+def member_suspend(ctx: click.Context, member_id: str) -> None:
+    """멤버 일시 정지."""
+    fmt = get_formatter(ctx)
+
+    async def _run_suspend() -> dict:
+        service, db = await _create_service()
+        try:
+            m = await service.suspend(member_id, suspended_by="cli")
+            return {"member_id": m.member_id, "status": m.status}
+        finally:
+            await db.close()
+
+    try:
+        result = _run(_run_suspend())
+    except (ValueError, PermissionError) as e:
+        fmt.error(str(e))
+        return
+
+    fmt.success(f"멤버 정지 완료: {member_id}", result)
+
+
+@member.command("reactivate")
+@click.argument("member_id")
+@click.pass_context
+def member_reactivate(ctx: click.Context, member_id: str) -> None:
+    """멤버 재활성화."""
+    fmt = get_formatter(ctx)
+
+    async def _run_reactivate() -> dict:
+        service, db = await _create_service()
+        try:
+            m = await service.reactivate(member_id, reactivated_by="cli")
+            return {"member_id": m.member_id, "status": m.status}
+        finally:
+            await db.close()
+
+    try:
+        result = _run(_run_reactivate())
+    except (ValueError, PermissionError) as e:
+        fmt.error(str(e))
+        return
+
+    fmt.success(f"멤버 재활성화 완료: {member_id}", result)
+
+
+@member.command("revoke")
+@click.argument("member_id")
+@click.confirmation_option(prompt="이 작업은 되돌릴 수 없습니다. 계속하시겠습니까?")
+@click.pass_context
+def member_revoke(ctx: click.Context, member_id: str) -> None:
+    """멤버 영구 폐기."""
+    fmt = get_formatter(ctx)
+
+    async def _run_revoke() -> dict:
+        service, db = await _create_service()
+        try:
+            m = await service.revoke(member_id, revoked_by="cli")
+            return {"member_id": m.member_id, "status": m.status}
+        finally:
+            await db.close()
+
+    try:
+        result = _run(_run_revoke())
+    except (ValueError, PermissionError) as e:
+        fmt.error(str(e))
+        return
+
+    fmt.success(f"멤버 폐기 완료: {member_id}", result)
+
+
+@member.command("rotate-token")
+@click.argument("member_id")
+@click.pass_context
+def member_rotate_token(ctx: click.Context, member_id: str) -> None:
+    """토큰 재발급 (기존 토큰 즉시 무효화)."""
+    fmt = get_formatter(ctx)
+
+    async def _run_rotate() -> tuple[dict, str]:
+        service, db = await _create_service()
+        try:
+            m, token = await service.rotate_token(member_id, rotated_by="cli")
+            return {"member_id": m.member_id}, token
+        finally:
+            await db.close()
+
+    try:
+        result, token = _run(_run_rotate())
+    except (ValueError, PermissionError) as e:
+        fmt.error(str(e))
+        return
+
+    if fmt.is_json:
+        fmt.output({**result, "token": token})
+    else:
+        click.echo("  기존 토큰이 즉시 무효화되었습니다.")
+        click.echo(f"  새 토큰: {token}")
+        click.echo("  이 토큰은 다시 표시되지 않습니다.")
+
+
+@member.command("reset-password")
+@click.option("--recovery-key", required=True, help="Recovery Key")
+@click.pass_context
+def member_reset_password(ctx: click.Context, recovery_key: str) -> None:
+    """Recovery Key로 패스워드 리셋."""
+    fmt = get_formatter(ctx)
+    new_password = click.prompt(
+        "새 패스워드", hide_input=True, confirmation_prompt=True
+    )
+
+    async def _run_reset() -> None:
+        service, db = await _create_service()
+        try:
+            # master 멤버를 찾아서 리셋
+            members = await service.list(member_type="human")
+            master = next((m for m in members if m.role == "master"), None)
+            if not master:
+                msg = "master 멤버가 존재하지 않습니다"
+                raise ValueError(msg)
+            await service.reset_password(master.member_id, recovery_key, new_password)
+        finally:
+            await db.close()
+
+    try:
+        _run(_run_reset())
+    except (ValueError, PermissionError) as e:
+        fmt.error(str(e))
+        return
+
+    fmt.success("패스워드가 변경되었습니다.")
+
+
+@member.command("regenerate-recovery-key")
+@click.pass_context
+def member_regenerate_recovery_key(ctx: click.Context) -> None:
+    """Recovery Key 재발급."""
+    fmt = get_formatter(ctx)
+    password = click.prompt("현재 패스워드", hide_input=True)
+
+    async def _run_regen() -> str:
+        service, db = await _create_service()
+        try:
+            members = await service.list(member_type="human")
+            master = next((m for m in members if m.role == "master"), None)
+            if not master:
+                msg = "master 멤버가 존재하지 않습니다"
+                raise ValueError(msg)
+            return await service.regenerate_recovery_key(master.member_id, password)
+        finally:
+            await db.close()
+
+    try:
+        new_key = _run(_run_regen())
+    except (ValueError, PermissionError) as e:
+        fmt.error(str(e))
+        return
+
+    if fmt.is_json:
+        fmt.output({"recovery_key": new_key})
+    else:
+        click.echo("  기존 복구 키가 폐기되었습니다.")
+        click.echo(f"\n  새 복구 키: {new_key}")
+        click.echo("\n  안전한 곳에 보관하세요. 이 키는 다시 표시되지 않습니다.")

--- a/src/ante/cli/main.py
+++ b/src/ante/cli/main.py
@@ -34,6 +34,7 @@ from ante.cli.commands.approval import approval  # noqa: E402
 from ante.cli.commands.backtest import backtest  # noqa: E402
 from ante.cli.commands.data import data  # noqa: E402
 from ante.cli.commands.instrument import instrument  # noqa: E402
+from ante.cli.commands.member import member  # noqa: E402
 from ante.cli.commands.report import report  # noqa: E402
 from ante.cli.commands.strategy import strategy  # noqa: E402
 
@@ -43,3 +44,4 @@ cli.add_command(data)
 cli.add_command(backtest)
 cli.add_command(report)
 cli.add_command(instrument)
+cli.add_command(member)

--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -338,3 +338,40 @@ class ApprovalResolvedEvent(Event):
     approval_type: str = ""
     resolution: str = ""
     resolved_by: str = ""
+
+
+# ── 멤버 (Member) ───────────────────────────────
+
+
+@dataclass(frozen=True)
+class MemberRegisteredEvent(Event):
+    """MemberService → EventBus: 멤버 등록 완료."""
+
+    member_id: str = ""
+    member_type: str = ""
+    role: str = ""
+    registered_by: str = ""
+
+
+@dataclass(frozen=True)
+class MemberSuspendedEvent(Event):
+    """MemberService → EventBus: 멤버 정지."""
+
+    member_id: str = ""
+    suspended_by: str = ""
+
+
+@dataclass(frozen=True)
+class MemberRevokedEvent(Event):
+    """MemberService → EventBus: 멤버 폐기."""
+
+    member_id: str = ""
+    revoked_by: str = ""
+
+
+@dataclass(frozen=True)
+class MemberAuthFailedEvent(Event):
+    """MemberService → EventBus: 인증 실패."""
+
+    member_id: str = ""
+    reason: str = ""

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -75,7 +75,14 @@ async def main() -> None:
     await dynamic_config.initialize()
     logger.info("DynamicConfigService 초기화 완료")
 
-    # ── 5.5. InstrumentService ─────────────────────────
+    # ── 5.5. MemberService ─────────────────────────────
+    from ante.member import MemberService
+
+    member_service = MemberService(db=db, eventbus=eventbus)
+    await member_service.initialize()
+    logger.info("MemberService 초기화 완료")
+
+    # ── 5.6. InstrumentService ─────────────────────────
     from ante.instrument import InstrumentService
 
     instrument_service = InstrumentService(db=db)

--- a/src/ante/member/__init__.py
+++ b/src/ante/member/__init__.py
@@ -1,0 +1,6 @@
+"""Member — 멤버 등록·인증·관리."""
+
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+from ante.member.service import MemberService
+
+__all__ = ["Member", "MemberRole", "MemberService", "MemberStatus", "MemberType"]

--- a/src/ante/member/auth.py
+++ b/src/ante/member/auth.py
@@ -1,0 +1,107 @@
+"""인증 유틸리티 — 토큰 생성·검증, 패스워드 해싱, Recovery Key."""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import string
+
+# ── 토큰 ─────────────────────────────────────────────
+
+TOKEN_PREFIX_HUMAN = "ante_hk_"
+TOKEN_PREFIX_AGENT = "ante_ak_"
+TOKEN_LENGTH = 32  # 접두어 제외 랜덤 부분 길이
+
+
+def generate_token(member_type: str) -> str:
+    """멤버 타입에 따른 API 토큰 생성."""
+    from ante.member.models import MemberType
+
+    if member_type == MemberType.HUMAN:
+        prefix = TOKEN_PREFIX_HUMAN
+    elif member_type == MemberType.AGENT:
+        prefix = TOKEN_PREFIX_AGENT
+    else:
+        msg = f"지원하지 않는 멤버 타입: {member_type}"
+        raise ValueError(msg)
+
+    random_part = secrets.token_urlsafe(TOKEN_LENGTH)
+    return f"{prefix}{random_part}"
+
+
+def hash_token(token: str) -> str:
+    """토큰을 SHA-256 해시로 변환. 빠른 조회를 위해 SHA-256 사용."""
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def verify_token(token: str, token_hash: str) -> bool:
+    """토큰과 해시 일치 확인."""
+    return secrets.compare_digest(hash_token(token), token_hash)
+
+
+def get_token_type(token: str) -> str | None:
+    """토큰 접두어로 멤버 타입 판별."""
+    from ante.member.models import MemberType
+
+    if token.startswith(TOKEN_PREFIX_HUMAN):
+        return MemberType.HUMAN
+    if token.startswith(TOKEN_PREFIX_AGENT):
+        return MemberType.AGENT
+    return None
+
+
+# ── 패스워드 ─────────────────────────────────────────
+
+SALT_LENGTH = 32
+HASH_ITERATIONS = 600_000  # OWASP 2023 권장
+
+
+def hash_password(password: str) -> str:
+    """패스워드를 PBKDF2-SHA256으로 해싱. salt:hash 형식으로 반환."""
+    salt = secrets.token_hex(SALT_LENGTH)
+    pw_hash = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode(),
+        salt.encode(),
+        HASH_ITERATIONS,
+    ).hex()
+    return f"{salt}:{pw_hash}"
+
+
+def verify_password(password: str, stored: str) -> bool:
+    """패스워드 검증."""
+    salt, expected_hash = stored.split(":", 1)
+    actual_hash = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode(),
+        salt.encode(),
+        HASH_ITERATIONS,
+    ).hex()
+    return secrets.compare_digest(actual_hash, expected_hash)
+
+
+# ── Recovery Key ─────────────────────────────────────
+
+RECOVERY_KEY_GROUPS = 6
+RECOVERY_KEY_GROUP_LEN = 4
+RECOVERY_KEY_PREFIX = "ANTE-RK-"
+
+
+def generate_recovery_key() -> str:
+    """Recovery Key 생성. 형식: ANTE-RK-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX."""
+    chars = string.ascii_uppercase + string.digits
+    groups = [
+        "".join(secrets.choice(chars) for _ in range(RECOVERY_KEY_GROUP_LEN))
+        for _ in range(RECOVERY_KEY_GROUPS)
+    ]
+    return RECOVERY_KEY_PREFIX + "-".join(groups)
+
+
+def hash_recovery_key(key: str) -> str:
+    """Recovery Key 해싱 (패스워드와 동일한 방식)."""
+    return hash_password(key)
+
+
+def verify_recovery_key(key: str, stored: str) -> bool:
+    """Recovery Key 검증."""
+    return verify_password(key, stored)

--- a/src/ante/member/models.py
+++ b/src/ante/member/models.py
@@ -1,0 +1,50 @@
+"""Member 데이터 모델."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class MemberType(StrEnum):
+    """멤버 타입."""
+
+    HUMAN = "human"
+    AGENT = "agent"
+
+
+class MemberRole(StrEnum):
+    """멤버 역할."""
+
+    MASTER = "master"
+    ADMIN = "admin"
+    DEFAULT = "default"
+
+
+class MemberStatus(StrEnum):
+    """멤버 상태."""
+
+    ACTIVE = "active"
+    SUSPENDED = "suspended"
+    REVOKED = "revoked"
+
+
+@dataclass
+class Member:
+    """시스템 행위 주체 (사람 또는 AI Agent)."""
+
+    member_id: str
+    type: str
+    role: str
+    org: str = "default"
+    name: str = ""
+    status: str = MemberStatus.ACTIVE
+    scopes: list[str] = field(default_factory=list)
+    token_hash: str = ""
+    password_hash: str = ""
+    recovery_key_hash: str = ""
+    created_at: str = ""
+    created_by: str = ""
+    last_active_at: str = ""
+    suspended_at: str = ""
+    revoked_at: str = ""

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -1,0 +1,577 @@
+"""MemberService — 멤버 등록·인증·관리."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from ante.member.auth import (
+    generate_recovery_key,
+    generate_token,
+    get_token_type,
+    hash_password,
+    hash_recovery_key,
+    hash_token,
+    verify_password,
+    verify_recovery_key,
+)
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+MEMBER_SCHEMA = """
+CREATE TABLE IF NOT EXISTS members (
+    member_id          TEXT PRIMARY KEY,
+    type               TEXT NOT NULL,
+    role               TEXT NOT NULL DEFAULT 'default',
+    org                TEXT NOT NULL DEFAULT 'default',
+    name               TEXT NOT NULL DEFAULT '',
+    status             TEXT NOT NULL DEFAULT 'active',
+    scopes             TEXT NOT NULL DEFAULT '[]',
+    token_hash         TEXT DEFAULT '',
+    password_hash      TEXT DEFAULT '',
+    recovery_key_hash  TEXT DEFAULT '',
+    created_at         TEXT DEFAULT (datetime('now')),
+    created_by         TEXT DEFAULT '',
+    last_active_at     TEXT DEFAULT '',
+    suspended_at       TEXT DEFAULT '',
+    revoked_at         TEXT DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_members_type ON members(type);
+CREATE INDEX IF NOT EXISTS idx_members_status ON members(status);
+CREATE INDEX IF NOT EXISTS idx_members_org ON members(org);
+"""
+
+
+def _row_to_member(row: dict) -> Member:
+    """DB 행을 Member 객체로 변환."""
+    return Member(
+        member_id=row["member_id"],
+        type=row["type"],
+        role=row["role"],
+        org=row.get("org", "default"),
+        name=row.get("name", ""),
+        status=row.get("status", MemberStatus.ACTIVE),
+        scopes=json.loads(row.get("scopes", "[]")),
+        token_hash=row.get("token_hash", ""),
+        password_hash=row.get("password_hash", ""),
+        recovery_key_hash=row.get("recovery_key_hash", ""),
+        created_at=row.get("created_at", ""),
+        created_by=row.get("created_by", ""),
+        last_active_at=row.get("last_active_at", ""),
+        suspended_at=row.get("suspended_at", ""),
+        revoked_at=row.get("revoked_at", ""),
+    )
+
+
+def _now() -> str:
+    """현재 UTC 시각 문자열."""
+    return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+
+
+class MemberService:
+    """멤버 등록·인증·관리 서비스."""
+
+    def __init__(self, db: Database, eventbus: EventBus) -> None:
+        self._db = db
+        self._eventbus = eventbus
+
+    async def initialize(self) -> None:
+        """스키마 생성."""
+        await self._db.execute_script(MEMBER_SCHEMA)
+        logger.info("MemberService 초기화 완료")
+
+    # ── Master 부트스트랩 ──────────────────────────────
+
+    async def bootstrap_master(
+        self,
+        member_id: str,
+        password: str,
+        name: str = "",
+    ) -> tuple[Member, str]:
+        """master 생성 + recovery key 반환. 최초 1회만 가능."""
+        existing = await self._db.fetch_one(
+            "SELECT member_id FROM members WHERE role = ?",
+            (MemberRole.MASTER,),
+        )
+        if existing:
+            msg = "master가 이미 존재합니다"
+            raise ValueError(msg)
+
+        recovery_key = generate_recovery_key()
+        now = _now()
+
+        member = Member(
+            member_id=member_id,
+            type=MemberType.HUMAN,
+            role=MemberRole.MASTER,
+            org="default",
+            name=name or member_id,
+            status=MemberStatus.ACTIVE,
+            scopes=[],
+            token_hash="",
+            password_hash=hash_password(password),
+            recovery_key_hash=hash_recovery_key(recovery_key),
+            created_at=now,
+            created_by="system",
+        )
+
+        await self._db.execute(
+            """INSERT INTO members
+               (member_id, type, role, org, name, status, scopes,
+                token_hash, password_hash, recovery_key_hash,
+                created_at, created_by)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                member.member_id,
+                member.type,
+                member.role,
+                member.org,
+                member.name,
+                member.status,
+                json.dumps(member.scopes),
+                member.token_hash,
+                member.password_hash,
+                member.recovery_key_hash,
+                member.created_at,
+                member.created_by,
+            ),
+        )
+
+        from ante.eventbus.events import MemberRegisteredEvent
+
+        await self._eventbus.publish(
+            MemberRegisteredEvent(
+                member_id=member.member_id,
+                member_type=member.type,
+                role=member.role,
+                registered_by="system",
+            )
+        )
+
+        logger.info("Master 멤버 생성 완료: %s", member.member_id)
+        return member, recovery_key
+
+    # ── 멤버 등록 ──────────────────────────────────────
+
+    async def register(
+        self,
+        member_id: str,
+        member_type: str,
+        role: str = MemberRole.DEFAULT,
+        org: str = "default",
+        name: str = "",
+        scopes: list[str] | None = None,
+        registered_by: str = "",
+    ) -> tuple[Member, str]:
+        """멤버 등록 + 토큰 반환."""
+        self._assert_type_role(member_type, role)
+
+        existing = await self.get(member_id)
+        if existing:
+            msg = f"이미 존재하는 member_id: {member_id}"
+            raise ValueError(msg)
+
+        token = generate_token(member_type)
+        now = _now()
+        scopes = scopes or []
+
+        member = Member(
+            member_id=member_id,
+            type=member_type,
+            role=role,
+            org=org,
+            name=name or member_id,
+            status=MemberStatus.ACTIVE,
+            scopes=scopes,
+            token_hash=hash_token(token),
+            created_at=now,
+            created_by=registered_by,
+        )
+
+        await self._db.execute(
+            """INSERT INTO members
+               (member_id, type, role, org, name, status, scopes,
+                token_hash, password_hash, recovery_key_hash,
+                created_at, created_by)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                member.member_id,
+                member.type,
+                member.role,
+                member.org,
+                member.name,
+                member.status,
+                json.dumps(member.scopes),
+                member.token_hash,
+                member.password_hash,
+                member.recovery_key_hash,
+                member.created_at,
+                member.created_by,
+            ),
+        )
+
+        from ante.eventbus.events import MemberRegisteredEvent
+
+        await self._eventbus.publish(
+            MemberRegisteredEvent(
+                member_id=member.member_id,
+                member_type=member.type,
+                role=member.role,
+                registered_by=registered_by,
+            )
+        )
+
+        logger.info("멤버 등록 완료: %s (type=%s)", member.member_id, member.type)
+        return member, token
+
+    # ── 인증 ───────────────────────────────────────────
+
+    async def authenticate(self, token: str) -> Member:
+        """토큰으로 멤버 인증. 접두어 기반 타입 강제."""
+        token_type = get_token_type(token)
+        if token_type is None:
+            await self._publish_auth_failed("", "유효하지 않은 토큰 형식")
+            msg = "유효하지 않은 토큰 형식"
+            raise PermissionError(msg)
+
+        t_hash = hash_token(token)
+        row = await self._db.fetch_one(
+            "SELECT * FROM members WHERE token_hash = ?",
+            (t_hash,),
+        )
+        if not row:
+            await self._publish_auth_failed("", "토큰과 일치하는 멤버 없음")
+            msg = "인증 실패"
+            raise PermissionError(msg)
+
+        member = _row_to_member(row)
+
+        if member.type != token_type:
+            await self._publish_auth_failed(
+                member.member_id, "토큰 접두어와 멤버 타입 불일치"
+            )
+            msg = f"{token_type} key로 {member.type} 멤버 인증 불가"
+            raise PermissionError(msg)
+
+        if member.status != MemberStatus.ACTIVE:
+            await self._publish_auth_failed(
+                member.member_id, f"비활성 멤버: {member.status}"
+            )
+            msg = f"비활성 멤버: {member.status}"
+            raise PermissionError(msg)
+
+        return member
+
+    async def authenticate_password(self, member_id: str, password: str) -> Member:
+        """패스워드 인증 (human 대시보드 로그인)."""
+        member = await self.get(member_id)
+        if not member:
+            await self._publish_auth_failed(member_id, "존재하지 않는 멤버")
+            msg = "인증 실패"
+            raise PermissionError(msg)
+
+        if member.type != MemberType.HUMAN:
+            await self._publish_auth_failed(member_id, "human 전용 인증")
+            msg = "패스워드 인증은 human 멤버만 가능합니다"
+            raise PermissionError(msg)
+
+        if member.status != MemberStatus.ACTIVE:
+            await self._publish_auth_failed(member_id, f"비활성 멤버: {member.status}")
+            msg = f"비활성 멤버: {member.status}"
+            raise PermissionError(msg)
+
+        if not member.password_hash or not verify_password(
+            password, member.password_hash
+        ):
+            await self._publish_auth_failed(member_id, "패스워드 불일치")
+            msg = "인증 실패"
+            raise PermissionError(msg)
+
+        return member
+
+    # ── 조회 ───────────────────────────────────────────
+
+    async def get(self, member_id: str) -> Member | None:
+        """단건 조회."""
+        row = await self._db.fetch_one(
+            "SELECT * FROM members WHERE member_id = ?",
+            (member_id,),
+        )
+        return _row_to_member(row) if row else None
+
+    async def list(
+        self,
+        member_type: str | None = None,
+        org: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[Member]:
+        """필터 조회."""
+        conditions: list[str] = []
+        params: list[str | int] = []
+
+        if member_type:
+            conditions.append("type = ?")
+            params.append(member_type)
+        if org:
+            conditions.append("org = ?")
+            params.append(org)
+        if status:
+            conditions.append("status = ?")
+            params.append(status)
+
+        where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+        params.extend([limit, offset])
+
+        rows = await self._db.fetch_all(
+            f"SELECT * FROM members{where} ORDER BY created_at DESC LIMIT ? OFFSET ?",  # noqa: S608
+            tuple(params),
+        )
+        return [_row_to_member(row) for row in rows]
+
+    # ── 상태 변경 ──────────────────────────────────────
+
+    async def suspend(self, member_id: str, suspended_by: str = "") -> Member:
+        """멤버 일시 정지."""
+        member = await self._get_or_raise(member_id)
+        self._assert_not_master(member, "suspend")
+        self._assert_status(member, MemberStatus.ACTIVE, "suspend")
+
+        now = _now()
+        await self._db.execute(
+            "UPDATE members SET status = ?, suspended_at = ? WHERE member_id = ?",
+            (MemberStatus.SUSPENDED, now, member_id),
+        )
+
+        from ante.eventbus.events import MemberSuspendedEvent
+
+        await self._eventbus.publish(
+            MemberSuspendedEvent(
+                member_id=member_id,
+                suspended_by=suspended_by,
+            )
+        )
+
+        logger.info("멤버 정지: %s (by %s)", member_id, suspended_by)
+        member.status = MemberStatus.SUSPENDED
+        member.suspended_at = now
+        return member
+
+    async def reactivate(self, member_id: str, reactivated_by: str = "") -> Member:
+        """멤버 재활성화."""
+        member = await self._get_or_raise(member_id)
+        self._assert_status(member, MemberStatus.SUSPENDED, "reactivate")
+
+        await self._db.execute(
+            "UPDATE members SET status = ? WHERE member_id = ?",
+            (MemberStatus.ACTIVE, member_id),
+        )
+
+        logger.info("멤버 재활성화: %s (by %s)", member_id, reactivated_by)
+        member.status = MemberStatus.ACTIVE
+        return member
+
+    async def revoke(self, member_id: str, revoked_by: str = "") -> Member:
+        """멤버 영구 폐기. 토큰 해시 삭제."""
+        member = await self._get_or_raise(member_id)
+        self._assert_not_master(member, "revoke")
+
+        now = _now()
+        await self._db.execute(
+            """UPDATE members
+               SET status = ?, token_hash = '', revoked_at = ?
+               WHERE member_id = ?""",
+            (MemberStatus.REVOKED, now, member_id),
+        )
+
+        from ante.eventbus.events import MemberRevokedEvent
+
+        await self._eventbus.publish(
+            MemberRevokedEvent(
+                member_id=member_id,
+                revoked_by=revoked_by,
+            )
+        )
+
+        logger.info("멤버 폐기: %s (by %s)", member_id, revoked_by)
+        member.status = MemberStatus.REVOKED
+        member.token_hash = ""
+        member.revoked_at = now
+        return member
+
+    # ── 토큰 관리 ──────────────────────────────────────
+
+    async def rotate_token(
+        self, member_id: str, rotated_by: str = ""
+    ) -> tuple[Member, str]:
+        """토큰 재발급. 기존 토큰 즉시 무효화."""
+        member = await self._get_or_raise(member_id)
+        self._assert_active(member, "rotate_token")
+
+        token = generate_token(member.type)
+        t_hash = hash_token(token)
+
+        await self._db.execute(
+            "UPDATE members SET token_hash = ? WHERE member_id = ?",
+            (t_hash, member_id),
+        )
+
+        logger.info("토큰 재발급: %s (by %s)", member_id, rotated_by)
+        member.token_hash = t_hash
+        return member, token
+
+    # ── 패스워드 관리 ──────────────────────────────────
+
+    async def change_password(
+        self, member_id: str, old_password: str, new_password: str
+    ) -> None:
+        """패스워드 변경 (human만)."""
+        member = await self._get_or_raise(member_id)
+        self._assert_human(member, "change_password")
+        self._assert_active(member, "change_password")
+
+        if not member.password_hash or not verify_password(
+            old_password, member.password_hash
+        ):
+            msg = "현재 패스워드가 일치하지 않습니다"
+            raise PermissionError(msg)
+
+        await self._db.execute(
+            "UPDATE members SET password_hash = ? WHERE member_id = ?",
+            (hash_password(new_password), member_id),
+        )
+        logger.info("패스워드 변경 완료: %s", member_id)
+
+    async def reset_password(
+        self, member_id: str, recovery_key: str, new_password: str
+    ) -> None:
+        """recovery key로 패스워드 리셋 (human만)."""
+        member = await self._get_or_raise(member_id)
+        self._assert_human(member, "reset_password")
+
+        if not member.recovery_key_hash or not verify_recovery_key(
+            recovery_key, member.recovery_key_hash
+        ):
+            await self._publish_auth_failed(member_id, "recovery key 불일치")
+            msg = "유효하지 않은 recovery key"
+            raise PermissionError(msg)
+
+        await self._db.execute(
+            "UPDATE members SET password_hash = ? WHERE member_id = ?",
+            (hash_password(new_password), member_id),
+        )
+        logger.info("패스워드 리셋 완료 (recovery key): %s", member_id)
+
+    async def regenerate_recovery_key(self, member_id: str, password: str) -> str:
+        """복구 키 재발급. 현재 패스워드 확인 필수."""
+        member = await self._get_or_raise(member_id)
+        self._assert_human(member, "regenerate_recovery_key")
+        self._assert_active(member, "regenerate_recovery_key")
+
+        if not member.password_hash or not verify_password(
+            password, member.password_hash
+        ):
+            msg = "현재 패스워드가 일치하지 않습니다"
+            raise PermissionError(msg)
+
+        recovery_key = generate_recovery_key()
+        await self._db.execute(
+            "UPDATE members SET recovery_key_hash = ? WHERE member_id = ?",
+            (hash_recovery_key(recovery_key), member_id),
+        )
+        logger.info("Recovery key 재발급 완료: %s", member_id)
+        return recovery_key
+
+    # ── 권한 관리 ──────────────────────────────────────
+
+    async def update_scopes(
+        self, member_id: str, scopes: list[str], updated_by: str = ""
+    ) -> Member:
+        """권한 범위 변경."""
+        member = await self._get_or_raise(member_id)
+        self._assert_active(member, "update_scopes")
+
+        await self._db.execute(
+            "UPDATE members SET scopes = ? WHERE member_id = ?",
+            (json.dumps(scopes), member_id),
+        )
+
+        logger.info("권한 변경: %s → %s (by %s)", member_id, scopes, updated_by)
+        member.scopes = scopes
+        return member
+
+    # ── 활동 추적 ──────────────────────────────────────
+
+    async def update_last_active(self, member_id: str) -> None:
+        """마지막 활동 시각 갱신."""
+        await self._db.execute(
+            "UPDATE members SET last_active_at = ? WHERE member_id = ?",
+            (_now(), member_id),
+        )
+
+    # ── 내부 헬퍼 ──────────────────────────────────────
+
+    async def _get_or_raise(self, member_id: str) -> Member:
+        """멤버 조회. 없으면 ValueError."""
+        member = await self.get(member_id)
+        if not member:
+            msg = f"존재하지 않는 멤버: {member_id}"
+            raise ValueError(msg)
+        return member
+
+    async def _publish_auth_failed(self, member_id: str, reason: str) -> None:
+        """인증 실패 이벤트 발행."""
+        from ante.eventbus.events import MemberAuthFailedEvent
+
+        await self._eventbus.publish(
+            MemberAuthFailedEvent(member_id=member_id, reason=reason)
+        )
+
+    @staticmethod
+    def _assert_type_role(member_type: str, role: str) -> None:
+        """타입-역할 불변식 검증."""
+        if member_type == MemberType.AGENT and role in (
+            MemberRole.MASTER,
+            MemberRole.ADMIN,
+        ):
+            msg = "agent 타입은 master 또는 admin 역할을 가질 수 없습니다"
+            raise PermissionError(msg)
+
+    @staticmethod
+    def _assert_not_master(member: Member, action: str) -> None:
+        """master 보호."""
+        if member.role == MemberRole.MASTER:
+            msg = f"master는 {action}할 수 없습니다"
+            raise PermissionError(msg)
+
+    @staticmethod
+    def _assert_active(member: Member, action: str) -> None:
+        """활성 상태 검증."""
+        if member.status != MemberStatus.ACTIVE:
+            msg = f"비활성 멤버는 {action}할 수 없습니다 (현재: {member.status})"
+            raise PermissionError(msg)
+
+    @staticmethod
+    def _assert_human(member: Member, action: str) -> None:
+        """human 전용 검증."""
+        if member.type != MemberType.HUMAN:
+            msg = f"{action}은(는) human 멤버만 가능합니다"
+            raise PermissionError(msg)
+
+    @staticmethod
+    def _assert_status(member: Member, expected: str, action: str) -> None:
+        """특정 상태 검증."""
+        if member.status != expected:
+            msg = (
+                f"{action}은(는) {expected} 상태에서만 "
+                f"가능합니다 (현재: {member.status})"
+            )
+            raise PermissionError(msg)

--- a/tests/unit/test_member.py
+++ b/tests/unit/test_member.py
@@ -1,0 +1,384 @@
+"""Member 모듈 단위 테스트."""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.core.database import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import (
+    MemberAuthFailedEvent,
+    MemberRegisteredEvent,
+    MemberRevokedEvent,
+    MemberSuspendedEvent,
+)
+from ante.member.auth import (
+    generate_recovery_key,
+    generate_token,
+    get_token_type,
+    hash_password,
+    hash_token,
+    verify_password,
+    verify_recovery_key,
+    verify_token,
+)
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+from ante.member.service import MemberService
+
+# ── Fixtures ─────────────────────────────────────────
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """테스트용 SQLite DB."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+async def service(db, eventbus):
+    svc = MemberService(db, eventbus)
+    await svc.initialize()
+    return svc
+
+
+# ── Models ───────────────────────────────────────────
+
+
+class TestModels:
+    def test_member_type_values(self):
+        assert MemberType.HUMAN == "human"
+        assert MemberType.AGENT == "agent"
+
+    def test_member_role_values(self):
+        assert MemberRole.MASTER == "master"
+        assert MemberRole.ADMIN == "admin"
+        assert MemberRole.DEFAULT == "default"
+
+    def test_member_status_values(self):
+        assert MemberStatus.ACTIVE == "active"
+        assert MemberStatus.SUSPENDED == "suspended"
+        assert MemberStatus.REVOKED == "revoked"
+
+    def test_member_dataclass(self):
+        m = Member(
+            member_id="test-01",
+            type=MemberType.AGENT,
+            role=MemberRole.DEFAULT,
+        )
+        assert m.member_id == "test-01"
+        assert m.org == "default"
+        assert m.scopes == []
+        assert m.status == MemberStatus.ACTIVE
+
+
+# ── Auth Utilities ───────────────────────────────────
+
+
+class TestAuth:
+    def test_generate_token_human(self):
+        token = generate_token(MemberType.HUMAN)
+        assert token.startswith("ante_hk_")
+
+    def test_generate_token_agent(self):
+        token = generate_token(MemberType.AGENT)
+        assert token.startswith("ante_ak_")
+
+    def test_generate_token_invalid_type(self):
+        with pytest.raises(ValueError, match="지원하지 않는 멤버 타입"):
+            generate_token("unknown")
+
+    def test_hash_and_verify_token(self):
+        token = generate_token(MemberType.HUMAN)
+        h = hash_token(token)
+        assert verify_token(token, h)
+        assert not verify_token("wrong_token", h)
+
+    def test_get_token_type(self):
+        assert get_token_type("ante_hk_abc") == MemberType.HUMAN
+        assert get_token_type("ante_ak_abc") == MemberType.AGENT
+        assert get_token_type("unknown_abc") is None
+
+    def test_hash_and_verify_password(self):
+        stored = hash_password("secret123")
+        assert verify_password("secret123", stored)
+        assert not verify_password("wrong", stored)
+
+    def test_recovery_key_format(self):
+        key = generate_recovery_key()
+        assert key.startswith("ANTE-RK-")
+        parts = key.replace("ANTE-RK-", "").split("-")
+        assert len(parts) == 6
+        assert all(len(p) == 4 for p in parts)
+
+    def test_recovery_key_verify(self):
+        from ante.member.auth import hash_recovery_key
+
+        key = generate_recovery_key()
+        h = hash_recovery_key(key)
+        assert verify_recovery_key(key, h)
+        assert not verify_recovery_key("ANTE-RK-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX", h)
+
+
+# ── MemberService ────────────────────────────────────
+
+
+class TestBootstrapMaster:
+    async def test_bootstrap_creates_master(self, service):
+        member, recovery_key = await service.bootstrap_master(
+            member_id="owner", password="pass123", name="대표"
+        )
+        assert member.member_id == "owner"
+        assert member.type == MemberType.HUMAN
+        assert member.role == MemberRole.MASTER
+        assert member.name == "대표"
+        assert recovery_key.startswith("ANTE-RK-")
+
+    async def test_bootstrap_twice_fails(self, service):
+        await service.bootstrap_master("owner", "pass123")
+        with pytest.raises(ValueError, match="master가 이미 존재합니다"):
+            await service.bootstrap_master("owner2", "pass456")
+
+    async def test_bootstrap_publishes_event(self, service, eventbus):
+        events = []
+        eventbus.subscribe(MemberRegisteredEvent, events.append)
+        await service.bootstrap_master("owner", "pass123")
+        assert len(events) == 1
+        assert events[0].member_id == "owner"
+        assert events[0].role == "master"
+
+
+class TestRegister:
+    async def test_register_agent(self, service):
+        member, token = await service.register(
+            member_id="agent-01",
+            member_type=MemberType.AGENT,
+            org="strategy-lab",
+            name="전략봇 1호",
+            scopes=["strategy:write", "data:read"],
+            registered_by="owner",
+        )
+        assert member.member_id == "agent-01"
+        assert member.type == MemberType.AGENT
+        assert member.role == MemberRole.DEFAULT
+        assert member.org == "strategy-lab"
+        assert token.startswith("ante_ak_")
+        assert member.scopes == ["strategy:write", "data:read"]
+
+    async def test_register_duplicate_fails(self, service):
+        await service.register("agent-01", MemberType.AGENT)
+        with pytest.raises(ValueError, match="이미 존재하는"):
+            await service.register("agent-01", MemberType.AGENT)
+
+    async def test_register_agent_as_master_fails(self, service):
+        with pytest.raises(PermissionError, match="agent 타입은 master"):
+            await service.register(
+                "bad-agent", MemberType.AGENT, role=MemberRole.MASTER
+            )
+
+    async def test_register_agent_as_admin_fails(self, service):
+        with pytest.raises(PermissionError, match="agent 타입은 master 또는 admin"):
+            await service.register("bad-agent", MemberType.AGENT, role=MemberRole.ADMIN)
+
+
+class TestAuthenticate:
+    async def test_authenticate_token(self, service):
+        _, token = await service.register("agent-01", MemberType.AGENT)
+        member = await service.authenticate(token)
+        assert member.member_id == "agent-01"
+
+    async def test_authenticate_invalid_prefix(self, service):
+        with pytest.raises(PermissionError, match="유효하지 않은 토큰 형식"):
+            await service.authenticate("invalid_token_xyz")
+
+    async def test_authenticate_wrong_token(self, service):
+        await service.register("agent-01", MemberType.AGENT)
+        with pytest.raises(PermissionError, match="인증 실패"):
+            await service.authenticate("ante_ak_nonexistent_token")
+
+    async def test_authenticate_suspended_member(self, service):
+        _, token = await service.register("agent-01", MemberType.AGENT)
+        await service.suspend("agent-01", suspended_by="owner")
+        with pytest.raises(PermissionError, match="비활성 멤버"):
+            await service.authenticate(token)
+
+    async def test_authenticate_type_mismatch(self, service, db):
+        """agent 토큰으로 human 멤버를 인증할 수 없다."""
+        _, token = await service.register(
+            "human-01", MemberType.HUMAN, registered_by="owner"
+        )
+        # 토큰은 ante_hk_ 이지만, DB를 직접 조작하여 type을 agent로 변경
+        await db.execute(
+            "UPDATE members SET type = ? WHERE member_id = ?",
+            (MemberType.AGENT, "human-01"),
+        )
+        with pytest.raises(PermissionError, match="인증 불가"):
+            await service.authenticate(token)
+
+
+class TestAuthenticatePassword:
+    async def test_password_auth(self, service):
+        await service.bootstrap_master("owner", "pass123")
+        member = await service.authenticate_password("owner", "pass123")
+        assert member.member_id == "owner"
+
+    async def test_wrong_password(self, service):
+        await service.bootstrap_master("owner", "pass123")
+        with pytest.raises(PermissionError, match="인증 실패"):
+            await service.authenticate_password("owner", "wrong")
+
+    async def test_agent_cannot_password_auth(self, service):
+        await service.register("agent-01", MemberType.AGENT)
+        with pytest.raises(PermissionError, match="human 멤버만"):
+            await service.authenticate_password("agent-01", "anything")
+
+    async def test_nonexistent_member(self, service):
+        with pytest.raises(PermissionError, match="인증 실패"):
+            await service.authenticate_password("ghost", "pass")
+
+
+class TestSuspendReactivateRevoke:
+    async def test_suspend_and_reactivate(self, service):
+        await service.register("agent-01", MemberType.AGENT)
+        m = await service.suspend("agent-01", suspended_by="owner")
+        assert m.status == MemberStatus.SUSPENDED
+
+        m = await service.reactivate("agent-01", reactivated_by="owner")
+        assert m.status == MemberStatus.ACTIVE
+
+    async def test_suspend_master_fails(self, service):
+        await service.bootstrap_master("owner", "pass123")
+        with pytest.raises(PermissionError, match="master는 suspend"):
+            await service.suspend("owner")
+
+    async def test_revoke(self, service):
+        await service.register("agent-01", MemberType.AGENT)
+        m = await service.revoke("agent-01", revoked_by="owner")
+        assert m.status == MemberStatus.REVOKED
+        assert m.token_hash == ""
+
+    async def test_revoke_master_fails(self, service):
+        await service.bootstrap_master("owner", "pass123")
+        with pytest.raises(PermissionError, match="master는 revoke"):
+            await service.revoke("owner")
+
+    async def test_reactivate_active_fails(self, service):
+        await service.register("agent-01", MemberType.AGENT)
+        with pytest.raises(PermissionError, match="suspended 상태에서만"):
+            await service.reactivate("agent-01")
+
+    async def test_suspend_publishes_event(self, service, eventbus):
+        events = []
+        eventbus.subscribe(MemberSuspendedEvent, events.append)
+        await service.register("agent-01", MemberType.AGENT)
+        await service.suspend("agent-01", suspended_by="owner")
+        assert len(events) == 1
+        assert events[0].member_id == "agent-01"
+
+    async def test_revoke_publishes_event(self, service, eventbus):
+        events = []
+        eventbus.subscribe(MemberRevokedEvent, events.append)
+        await service.register("agent-01", MemberType.AGENT)
+        await service.revoke("agent-01", revoked_by="owner")
+        assert len(events) == 1
+
+
+class TestRotateToken:
+    async def test_rotate_token(self, service):
+        _, old_token = await service.register("agent-01", MemberType.AGENT)
+        _, new_token = await service.rotate_token("agent-01", rotated_by="owner")
+        assert old_token != new_token
+        # 새 토큰으로 인증 성공
+        m = await service.authenticate(new_token)
+        assert m.member_id == "agent-01"
+        # 기존 토큰으로 인증 실패
+        with pytest.raises(PermissionError):
+            await service.authenticate(old_token)
+
+
+class TestPasswordManagement:
+    async def test_change_password(self, service):
+        await service.bootstrap_master("owner", "pass123")
+        await service.change_password("owner", "pass123", "newpass")
+        m = await service.authenticate_password("owner", "newpass")
+        assert m.member_id == "owner"
+
+    async def test_change_password_wrong_old(self, service):
+        await service.bootstrap_master("owner", "pass123")
+        with pytest.raises(PermissionError, match="패스워드가 일치하지"):
+            await service.change_password("owner", "wrong", "newpass")
+
+    async def test_reset_password_with_recovery_key(self, service):
+        _, recovery_key = await service.bootstrap_master("owner", "pass123")
+        await service.reset_password("owner", recovery_key, "resetpass")
+        m = await service.authenticate_password("owner", "resetpass")
+        assert m.member_id == "owner"
+
+    async def test_reset_password_wrong_key(self, service):
+        await service.bootstrap_master("owner", "pass123")
+        with pytest.raises(PermissionError, match="유효하지 않은 recovery key"):
+            await service.reset_password(
+                "owner", "ANTE-RK-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX", "newpass"
+            )
+
+    async def test_regenerate_recovery_key(self, service):
+        _, old_key = await service.bootstrap_master("owner", "pass123")
+        new_key = await service.regenerate_recovery_key("owner", "pass123")
+        assert new_key != old_key
+        assert new_key.startswith("ANTE-RK-")
+        # 새 키로 패스워드 리셋 가능
+        await service.reset_password("owner", new_key, "resetpass2")
+        # 기존 키로 리셋 불가
+        with pytest.raises(PermissionError):
+            await service.reset_password("owner", old_key, "hack")
+
+
+class TestScopes:
+    async def test_update_scopes(self, service):
+        await service.register("agent-01", MemberType.AGENT)
+        m = await service.update_scopes(
+            "agent-01", ["strategy:write", "data:read"], updated_by="owner"
+        )
+        assert m.scopes == ["strategy:write", "data:read"]
+        # DB에 반영 확인
+        fetched = await service.get("agent-01")
+        assert fetched.scopes == ["strategy:write", "data:read"]
+
+
+class TestList:
+    async def test_list_all(self, service):
+        await service.register("agent-01", MemberType.AGENT)
+        await service.register("agent-02", MemberType.AGENT, org="risk")
+        members = await service.list()
+        assert len(members) == 2
+
+    async def test_list_by_type(self, service):
+        await service.bootstrap_master("owner", "pass123")
+        await service.register("agent-01", MemberType.AGENT)
+        humans = await service.list(member_type=MemberType.HUMAN)
+        assert len(humans) == 1
+        assert humans[0].type == MemberType.HUMAN
+
+    async def test_list_by_org(self, service):
+        await service.register("a1", MemberType.AGENT, org="strategy-lab")
+        await service.register("a2", MemberType.AGENT, org="risk")
+        result = await service.list(org="risk")
+        assert len(result) == 1
+        assert result[0].member_id == "a2"
+
+
+class TestAuthFailedEvent:
+    async def test_auth_failed_publishes_event(self, service, eventbus):
+        events = []
+        eventbus.subscribe(MemberAuthFailedEvent, events.append)
+        with pytest.raises(PermissionError):
+            await service.authenticate("invalid_token")
+        assert len(events) == 1
+        assert events[0].reason == "유효하지 않은 토큰 형식"


### PR DESCRIPTION
## Summary
- Member 모듈 신규 구현: human/agent 타입의 멤버를 등록·인증·관리하는 체계
- 토큰 접두어(`ante_hk_`/`ante_ak_`)로 human/agent 인증을 물리적으로 분리
- MemberService: master 부트스트랩, 멤버 등록, 토큰/패스워드 인증, 상태 관리(정지/폐기/재활성화), 토큰 재발급, 패스워드 변경/리셋, Recovery Key, 권한(scope) 관리
- CLI 커맨드 9종: list, info, register, suspend, reactivate, revoke, rotate-token, reset-password, regenerate-recovery-key
- EventBus 이벤트 4종: MemberRegistered, Suspended, Revoked, AuthFailed
- 보안 불변식: agent는 master/admin 역할 불가, master는 정지/폐기 불가

## Test plan
- [x] 46개 단위 테스트 (models, auth utils, service 전체 메서드)
- [x] 전체 테스트 스위트 516개 통과 확인
- [x] ruff check + format 통과

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)