### PR TITLE
feat: StrategyContext Factory + PaperExecutor — live/paper 봇 실행 인프라

### DIFF
--- a/src/ante/bot/__init__.py
+++ b/src/ante/bot/__init__.py
@@ -2,6 +2,7 @@
 
 from ante.bot.bot import Bot
 from ante.bot.config import BotConfig, BotStatus
+from ante.bot.context_factory import StrategyContextFactory
 from ante.bot.exceptions import BotError
 from ante.bot.manager import BotManager
 
@@ -11,4 +12,5 @@ __all__ = [
     "BotError",
     "BotManager",
     "BotStatus",
+    "StrategyContextFactory",
 ]

--- a/src/ante/bot/context_factory.py
+++ b/src/ante/bot/context_factory.py
@@ -1,0 +1,81 @@
+"""StrategyContextFactory — 봇 유형별 StrategyContext 자동 조립."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ante.bot.config import BotConfig
+from ante.bot.providers.paper import PaperExecutor, PaperOrderView, PaperPortfolioView
+from ante.strategy.context import StrategyContext
+
+if TYPE_CHECKING:
+    from ante.bot.providers.live import LiveOrderView, LivePortfolioView
+    from ante.strategy.base import DataProvider
+
+logger = logging.getLogger(__name__)
+
+
+class StrategyContextFactory:
+    """봇 유형(live/paper)에 따라 적절한 StrategyContext를 생성.
+
+    main.py에서 생성되어 BotManager에 주입된다.
+    """
+
+    def __init__(
+        self,
+        data_provider: DataProvider,
+        live_portfolio: LivePortfolioView | None = None,
+        live_order_view: LiveOrderView | None = None,
+        paper_executor: PaperExecutor | None = None,
+    ) -> None:
+        self._data_provider = data_provider
+        self._live_portfolio = live_portfolio
+        self._live_order_view = live_order_view
+        self._paper_executor = paper_executor
+
+    def create(self, config: BotConfig) -> StrategyContext:
+        """BotConfig 기반으로 적절한 StrategyContext 생성."""
+        if config.bot_type == "paper":
+            return self._create_paper_context(config)
+        return self._create_live_context(config)
+
+    def _create_live_context(self, config: BotConfig) -> StrategyContext:
+        """Live 봇용 StrategyContext 생성."""
+        if self._live_portfolio is None or self._live_order_view is None:
+            msg = "Live 봇 생성에 필요한 Provider가 설정되지 않았습니다"
+            raise ValueError(msg)
+
+        ctx = StrategyContext(
+            bot_id=config.bot_id,
+            data_provider=self._data_provider,
+            portfolio=self._live_portfolio,
+            order_view=self._live_order_view,
+        )
+        logger.info("Live StrategyContext 생성: %s", config.bot_id)
+        return ctx
+
+    def _create_paper_context(self, config: BotConfig) -> StrategyContext:
+        """Paper 봇용 StrategyContext 생성."""
+        paper_portfolio = PaperPortfolioView(
+            bot_id=config.bot_id,
+            initial_balance=config.paper_initial_balance,
+        )
+        paper_order_view = PaperOrderView(portfolio=paper_portfolio)
+
+        # PaperExecutor에 봇 등록
+        if self._paper_executor:
+            self._paper_executor.register_bot(config.bot_id, paper_portfolio)
+
+        ctx = StrategyContext(
+            bot_id=config.bot_id,
+            data_provider=self._data_provider,
+            portfolio=paper_portfolio,
+            order_view=paper_order_view,
+        )
+        logger.info(
+            "Paper StrategyContext 생성: %s (잔고: %s)",
+            config.bot_id,
+            config.paper_initial_balance,
+        )
+        return ctx

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -12,6 +12,7 @@ from ante.bot.config import BotConfig, BotStatus
 from ante.bot.exceptions import BotError
 
 if TYPE_CHECKING:
+    from ante.bot.context_factory import StrategyContextFactory
     from ante.core.database import Database
     from ante.eventbus.bus import EventBus
     from ante.strategy.base import Strategy
@@ -40,9 +41,11 @@ class BotManager:
         self,
         eventbus: EventBus,
         db: Database,
+        context_factory: StrategyContextFactory | None = None,
     ) -> None:
         self._eventbus = eventbus
         self._db = db
+        self._context_factory = context_factory
         self._bots: dict[str, Bot] = {}
 
     async def initialize(self) -> None:
@@ -64,11 +67,20 @@ class BotManager:
         self,
         config: BotConfig,
         strategy_cls: type[Strategy],
-        ctx: StrategyContext,
+        ctx: StrategyContext | None = None,
     ) -> Bot:
-        """봇 생성. 전략 클래스와 StrategyContext를 직접 주입받는다."""
+        """봇 생성.
+
+        ctx가 주입되면 그대로 사용하고, None이면 context_factory로 자동 생성한다.
+        """
         if config.bot_id in self._bots:
             raise BotError(f"Bot already exists: {config.bot_id}")
+
+        if ctx is None:
+            if self._context_factory is None:
+                msg = "ctx 또는 context_factory 중 하나는 필수입니다"
+                raise BotError(msg)
+            ctx = self._context_factory.create(config)
 
         bot = Bot(
             config=config,
@@ -101,6 +113,15 @@ class BotManager:
             await bot.stop()
 
         self._unregister_bot_events(bot)
+
+        # Paper 봇 PaperExecutor 등록 해제
+        if (
+            self._context_factory
+            and self._context_factory._paper_executor
+            and bot.config.bot_type == "paper"
+        ):
+            self._context_factory._paper_executor.unregister_bot(bot_id)
+
         del self._bots[bot_id]
         await self._db.execute("DELETE FROM bots WHERE bot_id = ?", (bot_id,))
         logger.info("봇 삭제: %s", bot_id)

--- a/src/ante/bot/providers/__init__.py
+++ b/src/ante/bot/providers/__init__.py
@@ -1,0 +1,12 @@
+"""Bot Provider 구현체 — live/paper 봇용 DataProvider, PortfolioView, OrderView."""
+
+from ante.bot.providers.live import LiveOrderView, LivePortfolioView
+from ante.bot.providers.paper import PaperExecutor, PaperOrderView, PaperPortfolioView
+
+__all__ = [
+    "LiveOrderView",
+    "LivePortfolioView",
+    "PaperExecutor",
+    "PaperOrderView",
+    "PaperPortfolioView",
+]

--- a/src/ante/bot/providers/live.py
+++ b/src/ante/bot/providers/live.py
@@ -1,0 +1,70 @@
+"""Live 봇용 Provider 구현체.
+
+실제 시스템 모듈(Treasury, Trade, Broker)을 경유하여
+계좌 잔고·포지션·미체결 주문을 조회한다.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from ante.strategy.base import OrderView, PortfolioView
+
+if TYPE_CHECKING:
+    from ante.broker.order_registry import OrderRegistry
+    from ante.trade.position import PositionHistory
+    from ante.treasury.treasury import Treasury
+
+logger = logging.getLogger(__name__)
+
+
+class LivePortfolioView(PortfolioView):
+    """Live 봇용 PortfolioView. Treasury(잔고) + Trade(포지션) 경유."""
+
+    def __init__(
+        self,
+        treasury: Treasury,
+        position_history: PositionHistory,
+    ) -> None:
+        self._treasury = treasury
+        self._position_history = position_history
+
+    def get_positions(self, bot_id: str) -> dict[str, Any]:
+        """현재 보유 포지션 조회 (인메모리 캐시)."""
+        snapshots = self._position_history.get_positions_sync(bot_id)
+        return {
+            s.symbol: {
+                "symbol": s.symbol,
+                "quantity": s.quantity,
+                "avg_entry_price": s.avg_entry_price,
+                "realized_pnl": s.realized_pnl,
+            }
+            for s in snapshots
+        }
+
+    def get_balance(self, bot_id: str) -> dict[str, float]:
+        """봇 할당 자금 현황 조회 (인메모리 캐시)."""
+        budget = self._treasury.get_budget_sync(bot_id)
+        if budget is None:
+            return {"allocated": 0.0, "available": 0.0, "reserved": 0.0}
+        return {
+            "allocated": budget.allocated,
+            "available": budget.available,
+            "reserved": budget.reserved,
+        }
+
+
+class LiveOrderView(OrderView):
+    """Live 봇용 OrderView. Broker OrderRegistry에서 미체결 주문 조회."""
+
+    def __init__(self, order_registry: OrderRegistry) -> None:
+        self._registry = order_registry
+
+    def get_open_orders(self, bot_id: str) -> list[dict[str, Any]]:
+        """미체결 주문 목록 조회.
+
+        OrderRegistry는 DB 기반이므로 동기 조회가 제한적이다.
+        현재는 빈 목록을 반환하며, 실시간 주문 추적은 Phase 2에서 구현.
+        """
+        return []

--- a/src/ante/bot/providers/paper.py
+++ b/src/ante/bot/providers/paper.py
@@ -1,0 +1,257 @@
+"""Paper 봇용 Provider 구현체 + PaperExecutor.
+
+인메모리 가상 자금/포지션으로 실제 계좌 영향 없이 전략을 검증한다.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from ante.strategy.base import OrderView, PortfolioView
+
+if TYPE_CHECKING:
+    from ante.eventbus.bus import EventBus
+    from ante.gateway.gateway import APIGateway
+
+logger = logging.getLogger(__name__)
+
+
+class PaperPortfolioView(PortfolioView):
+    """Paper 봇용 PortfolioView. 인메모리 가상 잔고/포지션 관리."""
+
+    def __init__(self, bot_id: str, initial_balance: float) -> None:
+        self._bot_id = bot_id
+        self._initial_balance = initial_balance
+        self._balance = initial_balance
+        self._reserved: float = 0.0
+        self._positions: dict[str, dict[str, Any]] = {}
+        self._pending_orders: dict[str, dict[str, Any]] = {}
+
+    def get_positions(self, bot_id: str) -> dict[str, Any]:
+        """현재 보유 포지션 조회."""
+        return {
+            symbol: dict(pos)
+            for symbol, pos in self._positions.items()
+            if pos["quantity"] > 0
+        }
+
+    def get_balance(self, bot_id: str) -> dict[str, float]:
+        """가상 자금 현황 조회."""
+        return {
+            "allocated": self._initial_balance,
+            "available": self._balance - self._reserved,
+            "reserved": self._reserved,
+        }
+
+    def apply_fill(
+        self,
+        symbol: str,
+        side: str,
+        quantity: float,
+        price: float,
+        commission: float,
+    ) -> None:
+        """가상 체결 결과를 포지션/잔고에 반영."""
+        pos = self._positions.get(
+            symbol,
+            {
+                "symbol": symbol,
+                "quantity": 0.0,
+                "avg_entry_price": 0.0,
+                "realized_pnl": 0.0,
+            },
+        )
+
+        if side == "buy":
+            total_cost = pos["avg_entry_price"] * pos["quantity"]
+            new_cost = price * quantity
+            new_qty = pos["quantity"] + quantity
+            new_avg = (total_cost + new_cost) / new_qty if new_qty > 0 else 0.0
+
+            pos["quantity"] = new_qty
+            pos["avg_entry_price"] = new_avg
+            self._balance -= price * quantity + commission
+
+        elif side == "sell":
+            pnl = (price - pos["avg_entry_price"]) * quantity - commission
+            new_qty = pos["quantity"] - quantity
+
+            pos["quantity"] = max(new_qty, 0.0)
+            if new_qty <= 0:
+                pos["avg_entry_price"] = 0.0
+            pos["realized_pnl"] += pnl
+            self._balance += price * quantity - commission
+
+        self._positions[symbol] = pos
+
+    def check_balance(self, amount: float) -> bool:
+        """잔고 충분 여부 확인."""
+        return (self._balance - self._reserved) >= amount
+
+    def reserve(self, order_id: str, amount: float) -> None:
+        """주문용 자금 예약."""
+        self._reserved += amount
+        self._pending_orders[order_id] = {"amount": amount}
+
+    def release_reservation(self, order_id: str) -> None:
+        """예약 해제."""
+        order = self._pending_orders.pop(order_id, None)
+        if order:
+            self._reserved -= order["amount"]
+
+
+class PaperOrderView(OrderView):
+    """Paper 봇용 OrderView. PaperPortfolioView의 미체결 주문 추적."""
+
+    def __init__(self, portfolio: PaperPortfolioView) -> None:
+        self._portfolio = portfolio
+
+    def get_open_orders(self, bot_id: str) -> list[dict[str, Any]]:
+        """미체결 주문 목록 조회."""
+        return [
+            {"order_id": oid, **info}
+            for oid, info in self._portfolio._pending_orders.items()
+        ]
+
+
+class PaperExecutor:
+    """Paper 봇의 주문을 가상 체결하는 실행기.
+
+    EventBus에서 OrderRequestEvent를 구독하여 paper 봇의 주문만 처리한다.
+    즉시 가상 체결 후 OrderFilledEvent를 발행한다.
+    """
+
+    def __init__(
+        self,
+        eventbus: EventBus,
+        gateway: APIGateway | None = None,
+        commission_rate: float = 0.00015,
+        slippage_rate: float = 0.0,
+    ) -> None:
+        self._eventbus = eventbus
+        self._gateway = gateway
+        self._commission_rate = commission_rate
+        self._slippage_rate = slippage_rate
+        self._portfolios: dict[str, PaperPortfolioView] = {}
+        self._bot_configs: dict[str, Any] = {}
+
+    def register_bot(self, bot_id: str, portfolio: PaperPortfolioView) -> None:
+        """Paper 봇의 PortfolioView 등록."""
+        self._portfolios[bot_id] = portfolio
+        logger.info("PaperExecutor: 봇 등록 %s", bot_id)
+
+    def unregister_bot(self, bot_id: str) -> None:
+        """Paper 봇 등록 해제."""
+        self._portfolios.pop(bot_id, None)
+        logger.info("PaperExecutor: 봇 해제 %s", bot_id)
+
+    def subscribe(self) -> None:
+        """EventBus에 OrderRequestEvent 구독."""
+        from ante.eventbus.events import OrderRequestEvent
+
+        self._eventbus.subscribe(OrderRequestEvent, self._on_order_request, priority=50)
+        logger.info("PaperExecutor 구독 완료")
+
+    async def _on_order_request(self, event: object) -> None:
+        """OrderRequestEvent 처리. paper 봇의 주문만 처리."""
+        from ante.eventbus.events import (
+            OrderFilledEvent,
+            OrderRejectedEvent,
+            OrderRequestEvent,
+        )
+
+        if not isinstance(event, OrderRequestEvent):
+            return
+
+        portfolio = self._portfolios.get(event.bot_id)
+        if portfolio is None:
+            return  # live 봇의 주문 → 무시 (APIGateway가 처리)
+
+        order_id = str(uuid.uuid4())
+        symbol = event.symbol
+        side = event.side
+        quantity = event.quantity
+        order_type = event.order_type
+
+        # 체결가 계산
+        if order_type == "limit" and event.price is not None:
+            fill_price = event.price
+        else:
+            # market 주문: 현재가 기반 + 슬리피지
+            if self._gateway:
+                try:
+                    current_price = await self._gateway.get_current_price(symbol)
+                except Exception:
+                    logger.warning("현재가 조회 실패: %s, 기본가 사용", symbol)
+                    current_price = event.price or 0.0
+            else:
+                current_price = event.price or 0.0
+
+            if self._slippage_rate > 0:
+                if side == "buy":
+                    fill_price = current_price * (1 + self._slippage_rate)
+                else:
+                    fill_price = current_price * (1 - self._slippage_rate)
+            else:
+                fill_price = current_price
+
+        # 수수료 계산
+        trade_amount = fill_price * quantity
+        commission = trade_amount * self._commission_rate
+
+        # 잔고 확인 (매수 시)
+        if side == "buy":
+            total_cost = trade_amount + commission
+            if not portfolio.check_balance(total_cost):
+                await self._eventbus.publish(
+                    OrderRejectedEvent(
+                        order_id=order_id,
+                        bot_id=event.bot_id,
+                        strategy_id=event.strategy_id,
+                        symbol=symbol,
+                        side=side,
+                        quantity=quantity,
+                        order_type=order_type,
+                        reason="잔고 부족 (paper)",
+                    )
+                )
+                logger.info(
+                    "Paper 주문 거부 (잔고 부족): %s %s %s qty=%s",
+                    event.bot_id,
+                    side,
+                    symbol,
+                    quantity,
+                )
+                return
+
+        # 가상 체결: 포지션/잔고 업데이트
+        portfolio.apply_fill(symbol, side, quantity, fill_price, commission)
+
+        # OrderFilledEvent 발행
+        await self._eventbus.publish(
+            OrderFilledEvent(
+                order_id=order_id,
+                broker_order_id=f"paper-{order_id[:8]}",
+                bot_id=event.bot_id,
+                strategy_id=event.strategy_id,
+                symbol=symbol,
+                side=side,
+                quantity=quantity,
+                price=fill_price,
+                commission=commission,
+                order_type=order_type,
+                timestamp=datetime.now(UTC),
+            )
+        )
+        logger.info(
+            "Paper 체결: %s %s %s qty=%s price=%s commission=%s",
+            event.bot_id,
+            side,
+            symbol,
+            quantity,
+            fill_price,
+            commission,
+        )

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -138,10 +138,36 @@ async def main() -> None:
     )
     logger.info("Trade 모듈 초기화 완료")
 
-    # ── 10. BotManager ───────────────────────────────
-    from ante.bot import BotManager
+    # ── 10. BotManager + StrategyContextFactory ──────
+    from ante.bot import BotManager, StrategyContextFactory
+    from ante.bot.providers.live import LiveOrderView, LivePortfolioView
+    from ante.bot.providers.paper import PaperExecutor
 
-    bot_manager = BotManager(eventbus=eventbus, db=db)
+    # PaperExecutor (paper 봇이 존재할 때 가상 체결 처리)
+    paper_executor = PaperExecutor(
+        eventbus=eventbus,
+        gateway=None,  # APIGateway 연결 후 설정
+        commission_rate=commission_rate,
+    )
+    paper_executor.subscribe()
+
+    # Live 프로바이더
+    live_portfolio = LivePortfolioView(
+        treasury=treasury,
+        position_history=position_history,
+    )
+    live_order_view = LiveOrderView(order_registry=None)  # Broker 연결 후 설정
+
+    # StrategyContextFactory
+
+    # DataProvider는 APIGateway 연결 후 설정 (11단계)
+    context_factory: StrategyContextFactory | None = None
+
+    bot_manager = BotManager(
+        eventbus=eventbus,
+        db=db,
+        context_factory=context_factory,  # APIGateway 연결 후 갱신
+    )
     await bot_manager.initialize()
     logger.info("BotManager 초기화 완료")
 
@@ -168,6 +194,24 @@ async def main() -> None:
         api_gateway = APIGateway(broker=broker, eventbus=eventbus)
         await api_gateway.start()
         logger.info("APIGateway 시작 완료")
+
+    # ── 11.5. StrategyContextFactory 완성 ─────────────
+    from ante.gateway.data_provider import LiveDataProvider
+
+    data_provider: LiveDataProvider | None = None
+    if api_gateway:
+        data_provider = LiveDataProvider(gateway=api_gateway)
+        paper_executor._gateway = api_gateway
+
+    if data_provider:
+        context_factory = StrategyContextFactory(
+            data_provider=data_provider,
+            live_portfolio=live_portfolio,
+            live_order_view=live_order_view,
+            paper_executor=paper_executor,
+        )
+        bot_manager._context_factory = context_factory
+        logger.info("StrategyContextFactory 설정 완료")
 
     # ── 12. Data Pipeline ────────────────────────────
     from ante.data import DataCatalog, DataCollector, ParquetStore

--- a/src/ante/trade/position.py
+++ b/src/ante/trade/position.py
@@ -47,12 +47,29 @@ class PositionHistory:
 
     def __init__(self, db: Database) -> None:
         self._db = db
+        self._position_cache: dict[str, dict[str, PositionSnapshot]] = {}
 
     async def initialize(self) -> None:
-        """스키마 생성 + 마이그레이션."""
+        """스키마 생성 + 마이그레이션 + 캐시 워밍."""
         await self._db.execute_script(POSITION_SCHEMA)
         await self._migrate_exchange_column()
+        await self._warm_cache()
         logger.info("PositionHistory 초기화 완료")
+
+    async def _warm_cache(self) -> None:
+        """DB에서 전체 포지션을 읽어 인메모리 캐시에 적재."""
+        rows = await self._db.fetch_all("SELECT * FROM positions WHERE quantity > 0")
+        self._position_cache.clear()
+        for row in rows:
+            snapshot = self._row_to_snapshot(row)
+            self._position_cache.setdefault(snapshot.bot_id, {})[snapshot.symbol] = (
+                snapshot
+            )
+
+    def get_positions_sync(self, bot_id: str) -> list[PositionSnapshot]:
+        """봇의 현재 포지션 동기 조회 (인메모리 캐시). PortfolioView용."""
+        bot_positions = self._position_cache.get(bot_id, {})
+        return list(bot_positions.values())
 
     async def _migrate_exchange_column(self) -> None:
         """exchange 컬럼 마이그레이션 (v0.2)."""
@@ -235,6 +252,34 @@ class PositionHistory:
                 realized_pnl_delta,
             ),
         )
+        # 인메모리 캐시 갱신
+        self._update_cache(
+            bot_id, symbol, quantity, avg_entry_price, realized_pnl_delta
+        )
+
+    def _update_cache(
+        self,
+        bot_id: str,
+        symbol: str,
+        quantity: float,
+        avg_entry_price: float,
+        realized_pnl_delta: float = 0.0,
+    ) -> None:
+        """인메모리 포지션 캐시 갱신."""
+        bot_cache = self._position_cache.setdefault(bot_id, {})
+        existing = bot_cache.get(symbol)
+        prev_pnl = existing.realized_pnl if existing else 0.0
+
+        if quantity > 0:
+            bot_cache[symbol] = PositionSnapshot(
+                bot_id=bot_id,
+                symbol=symbol,
+                quantity=quantity,
+                avg_entry_price=avg_entry_price,
+                realized_pnl=prev_pnl + realized_pnl_delta,
+            )
+        else:
+            bot_cache.pop(symbol, None)
 
     async def _save_history(
         self,

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -117,6 +117,10 @@ class Treasury:
         """봇의 예산 상태 조회."""
         return self._budgets.get(bot_id)
 
+    def get_budget_sync(self, bot_id: str) -> BotBudget | None:
+        """봇의 예산 상태 동기 조회 (인메모리). PortfolioView용."""
+        return self._budgets.get(bot_id)
+
     # ── 예산 할당/회수 ──────────────────────────────
 
     async def allocate(self, bot_id: str, amount: float) -> bool:

--- a/tests/unit/test_bot_providers.py
+++ b/tests/unit/test_bot_providers.py
@@ -1,0 +1,762 @@
+"""Bot Provider + StrategyContextFactory 단위 테스트."""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.bot.config import BotConfig
+from ante.bot.context_factory import StrategyContextFactory
+from ante.bot.providers.live import LiveOrderView, LivePortfolioView
+from ante.bot.providers.paper import PaperExecutor, PaperOrderView, PaperPortfolioView
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import (
+    OrderFilledEvent,
+    OrderRejectedEvent,
+    OrderRequestEvent,
+)
+from ante.strategy.base import DataProvider
+from ante.strategy.context import StrategyContext
+from ante.trade.position import PositionHistory
+from ante.treasury.treasury import Treasury
+
+# ── Fake/Stub 구현체 ─────────────────────────────
+
+
+class FakeDataProvider(DataProvider):
+    async def get_ohlcv(self, symbol, timeframe="1d", limit=100):
+        return [{"close": 50000.0}]
+
+    async def get_current_price(self, symbol):
+        return 50000.0
+
+    async def get_indicator(self, symbol, indicator, params=None):
+        return {}
+
+
+# ── Fixtures ─────────────────────────────────────
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    await database.close()
+
+
+# ── US-1: LivePortfolioView / LiveOrderView ──────
+
+
+class TestLivePortfolioView:
+    async def test_get_positions_empty(self, db, eventbus):
+        """봇에 포지션이 없으면 빈 dict 반환."""
+        treasury = Treasury(db=db, eventbus=eventbus)
+        await treasury.initialize()
+        position_history = PositionHistory(db=db)
+        await position_history.initialize()
+
+        view = LivePortfolioView(treasury=treasury, position_history=position_history)
+        assert view.get_positions("bot1") == {}
+
+    async def test_get_positions_with_data(self, db, eventbus):
+        """포지션이 있으면 심볼별 dict 반환."""
+        treasury = Treasury(db=db, eventbus=eventbus)
+        await treasury.initialize()
+        position_history = PositionHistory(db=db)
+        await position_history.initialize()
+
+        # 포지션 삽입
+        from ante.trade.models import TradeRecord, TradeStatus
+
+        record = TradeRecord(
+            trade_id="t1",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            price=50000.0,
+            status=TradeStatus.FILLED,
+            order_type="market",
+        )
+        await position_history.on_trade(record)
+
+        view = LivePortfolioView(treasury=treasury, position_history=position_history)
+        positions = view.get_positions("bot1")
+        assert "005930" in positions
+        assert positions["005930"]["quantity"] == 10.0
+        assert positions["005930"]["avg_entry_price"] == 50000.0
+
+    async def test_get_balance_no_budget(self, db, eventbus):
+        """예산 미할당 시 0 반환."""
+        treasury = Treasury(db=db, eventbus=eventbus)
+        await treasury.initialize()
+        position_history = PositionHistory(db=db)
+        await position_history.initialize()
+
+        view = LivePortfolioView(treasury=treasury, position_history=position_history)
+        balance = view.get_balance("bot1")
+        assert balance["allocated"] == 0.0
+        assert balance["available"] == 0.0
+
+    async def test_get_balance_with_budget(self, db, eventbus):
+        """예산 할당 시 잔고 반환."""
+        treasury = Treasury(db=db, eventbus=eventbus)
+        await treasury.initialize()
+        await treasury.set_account_balance(10_000_000.0)
+        await treasury.allocate("bot1", 1_000_000.0)
+
+        position_history = PositionHistory(db=db)
+        await position_history.initialize()
+
+        view = LivePortfolioView(treasury=treasury, position_history=position_history)
+        balance = view.get_balance("bot1")
+        assert balance["allocated"] == 1_000_000.0
+        assert balance["available"] == 1_000_000.0
+
+
+class TestLiveOrderView:
+    def test_get_open_orders_empty(self):
+        """미체결 주문 없으면 빈 목록."""
+        view = LiveOrderView(order_registry=None)
+        assert view.get_open_orders("bot1") == []
+
+
+# ── US-2: PaperPortfolioView / PaperOrderView ───
+
+
+class TestPaperPortfolioView:
+    def test_initial_balance(self):
+        """초기 잔고 확인."""
+        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        balance = pv.get_balance("paper1")
+        assert balance["allocated"] == 10_000_000.0
+        assert balance["available"] == 10_000_000.0
+        assert balance["reserved"] == 0.0
+
+    def test_empty_positions(self):
+        """초기 포지션 없음."""
+        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        assert pv.get_positions("paper1") == {}
+
+    def test_apply_fill_buy(self):
+        """매수 체결 시 포지션/잔고 갱신."""
+        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        pv.apply_fill("005930", "buy", 10.0, 50000.0, commission=75.0)
+
+        positions = pv.get_positions("paper1")
+        assert positions["005930"]["quantity"] == 10.0
+        assert positions["005930"]["avg_entry_price"] == 50000.0
+
+        balance = pv.get_balance("paper1")
+        assert balance["available"] == 10_000_000.0 - 500000.0 - 75.0
+
+    def test_apply_fill_sell(self):
+        """매도 체결 시 포지션/잔고 갱신."""
+        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        pv.apply_fill("005930", "buy", 10.0, 50000.0, commission=75.0)
+        pv.apply_fill("005930", "sell", 10.0, 55000.0, commission=82.5)
+
+        positions = pv.get_positions("paper1")
+        # 수량 0이면 포지션에서 제외
+        assert "005930" not in positions
+
+    def test_check_balance_sufficient(self):
+        """잔고 충분 확인."""
+        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        assert pv.check_balance(5_000_000.0) is True
+
+    def test_check_balance_insufficient(self):
+        """잔고 부족 확인."""
+        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        assert pv.check_balance(15_000_000.0) is False
+
+    def test_reserve_and_release(self):
+        """자금 예약/해제."""
+        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        pv.reserve("ord1", 500_000.0)
+
+        balance = pv.get_balance("paper1")
+        assert balance["reserved"] == 500_000.0
+        assert balance["available"] == 9_500_000.0
+
+        pv.release_reservation("ord1")
+        balance = pv.get_balance("paper1")
+        assert balance["reserved"] == 0.0
+
+
+class TestPaperOrderView:
+    def test_empty_orders(self):
+        """미체결 주문 없으면 빈 목록."""
+        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        ov = PaperOrderView(portfolio=pv)
+        assert ov.get_open_orders("paper1") == []
+
+    def test_pending_orders_tracked(self):
+        """예약된 주문이 미체결 목록에 나타남."""
+        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        pv.reserve("ord1", 500_000.0)
+
+        ov = PaperOrderView(portfolio=pv)
+        orders = ov.get_open_orders("paper1")
+        assert len(orders) == 1
+        assert orders[0]["order_id"] == "ord1"
+
+
+# ── US-3: PaperExecutor ─────────────────────────
+
+
+class TestPaperExecutor:
+    async def test_paper_fill_buy(self, eventbus):
+        """Paper 봇의 매수 주문 → 가상 체결."""
+        executor = PaperExecutor(eventbus=eventbus, commission_rate=0.00015)
+
+        portfolio = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        executor.register_bot("paper1", portfolio)
+        executor.subscribe()
+
+        filled = []
+        eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
+
+        await eventbus.publish(
+            OrderRequestEvent(
+                bot_id="paper1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                order_type="limit",
+                price=50000.0,
+            )
+        )
+
+        assert len(filled) == 1
+        assert filled[0].bot_id == "paper1"
+        assert filled[0].symbol == "005930"
+        assert filled[0].quantity == 10.0
+        assert filled[0].price == 50000.0
+        assert filled[0].commission == 50000.0 * 10.0 * 0.00015
+
+        # 포지션 반영 확인
+        positions = portfolio.get_positions("paper1")
+        assert positions["005930"]["quantity"] == 10.0
+
+    async def test_paper_fill_sell(self, eventbus):
+        """Paper 봇의 매도 주문 → 가상 체결."""
+        executor = PaperExecutor(eventbus=eventbus, commission_rate=0.00015)
+        portfolio = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        executor.register_bot("paper1", portfolio)
+        executor.subscribe()
+
+        # 먼저 매수
+        await eventbus.publish(
+            OrderRequestEvent(
+                bot_id="paper1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                order_type="limit",
+                price=50000.0,
+            )
+        )
+
+        filled = []
+        eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
+
+        # 매도
+        await eventbus.publish(
+            OrderRequestEvent(
+                bot_id="paper1",
+                strategy_id="s1",
+                symbol="005930",
+                side="sell",
+                quantity=10.0,
+                order_type="limit",
+                price=55000.0,
+            )
+        )
+
+        # 첫 번째는 매수 체결, 마지막이 매도 체결
+        sell_fill = filled[-1]
+        assert sell_fill.side == "sell"
+        assert sell_fill.price == 55000.0
+
+    async def test_paper_buy_insufficient_balance(self, eventbus):
+        """잔고 부족 시 OrderRejectedEvent 발행."""
+        executor = PaperExecutor(eventbus=eventbus)
+        portfolio = PaperPortfolioView(bot_id="paper1", initial_balance=100.0)
+        executor.register_bot("paper1", portfolio)
+        executor.subscribe()
+
+        rejected = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+
+        await eventbus.publish(
+            OrderRequestEvent(
+                bot_id="paper1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                order_type="limit",
+                price=50000.0,
+            )
+        )
+
+        assert len(rejected) == 1
+        assert "잔고 부족" in rejected[0].reason
+
+    async def test_ignores_live_bot(self, eventbus):
+        """live 봇의 주문은 무시."""
+        executor = PaperExecutor(eventbus=eventbus)
+        executor.subscribe()
+
+        filled = []
+        eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
+
+        await eventbus.publish(
+            OrderRequestEvent(
+                bot_id="live_bot",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                order_type="market",
+                price=50000.0,
+            )
+        )
+
+        assert len(filled) == 0
+
+    async def test_commission_calculation(self, eventbus):
+        """수수료 계산 검증."""
+        executor = PaperExecutor(
+            eventbus=eventbus,
+            commission_rate=0.001,  # 0.1%
+        )
+        portfolio = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        executor.register_bot("paper1", portfolio)
+        executor.subscribe()
+
+        filled = []
+        eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
+
+        await eventbus.publish(
+            OrderRequestEvent(
+                bot_id="paper1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=100.0,
+                order_type="limit",
+                price=50000.0,
+            )
+        )
+
+        assert filled[0].commission == 50000.0 * 100.0 * 0.001
+
+    async def test_slippage_buy(self, eventbus):
+        """매수 슬리피지: 체결가 = 현재가 × (1 + slippage_rate)."""
+        executor = PaperExecutor(eventbus=eventbus, slippage_rate=0.001)
+        portfolio = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        executor.register_bot("paper1", portfolio)
+        executor.subscribe()
+
+        filled = []
+        eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
+
+        await eventbus.publish(
+            OrderRequestEvent(
+                bot_id="paper1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                order_type="market",
+                price=50000.0,  # current price fallback
+            )
+        )
+
+        expected_price = 50000.0 * 1.001
+        assert filled[0].price == pytest.approx(expected_price)
+
+    async def test_slippage_sell(self, eventbus):
+        """매도 슬리피지: 체결가 = 현재가 × (1 - slippage_rate)."""
+        executor = PaperExecutor(eventbus=eventbus, slippage_rate=0.001)
+        portfolio = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        # 먼저 포지션 만들기
+        portfolio.apply_fill("005930", "buy", 10.0, 50000.0, 0.0)
+        executor.register_bot("paper1", portfolio)
+        executor.subscribe()
+
+        filled = []
+        eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
+
+        await eventbus.publish(
+            OrderRequestEvent(
+                bot_id="paper1",
+                strategy_id="s1",
+                symbol="005930",
+                side="sell",
+                quantity=10.0,
+                order_type="market",
+                price=50000.0,
+            )
+        )
+
+        expected_price = 50000.0 * 0.999
+        assert filled[0].price == pytest.approx(expected_price)
+
+    async def test_limit_order_no_slippage(self, eventbus):
+        """지정가 주문: 슬리피지 없이 지정가 그대로 체결."""
+        executor = PaperExecutor(
+            eventbus=eventbus,
+            slippage_rate=0.01,  # 1% 슬리피지 설정해도
+        )
+        portfolio = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        executor.register_bot("paper1", portfolio)
+        executor.subscribe()
+
+        filled = []
+        eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
+
+        await eventbus.publish(
+            OrderRequestEvent(
+                bot_id="paper1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                order_type="limit",
+                price=50000.0,
+            )
+        )
+
+        assert filled[0].price == 50000.0  # 지정가 그대로
+
+    async def test_unregister_bot(self, eventbus):
+        """봇 등록 해제 후 주문 무시."""
+        executor = PaperExecutor(eventbus=eventbus)
+        portfolio = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        executor.register_bot("paper1", portfolio)
+        executor.subscribe()
+
+        executor.unregister_bot("paper1")
+
+        filled = []
+        eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
+
+        await eventbus.publish(
+            OrderRequestEvent(
+                bot_id="paper1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                order_type="limit",
+                price=50000.0,
+            )
+        )
+
+        assert len(filled) == 0
+
+
+# ── US-4: StrategyContextFactory ─────────────────
+
+
+class TestStrategyContextFactory:
+    def test_create_paper_context(self, eventbus):
+        """Paper 봇 StrategyContext 생성."""
+        executor = PaperExecutor(eventbus=eventbus)
+        factory = StrategyContextFactory(
+            data_provider=FakeDataProvider(),
+            paper_executor=executor,
+        )
+
+        config = BotConfig(
+            bot_id="paper1",
+            strategy_id="s1",
+            bot_type="paper",
+            paper_initial_balance=5_000_000.0,
+        )
+        ctx = factory.create(config)
+
+        assert isinstance(ctx, StrategyContext)
+        assert ctx.bot_id == "paper1"
+
+        # Paper 봇이 PaperExecutor에 등록되었는지 확인
+        assert "paper1" in executor._portfolios
+
+        # 초기 잔고 확인
+        balance = ctx.get_balance()
+        assert balance["allocated"] == 5_000_000.0
+
+    def test_create_live_context(self, eventbus):
+        """Live 봇 StrategyContext 생성."""
+        from ante.bot.providers.live import LiveOrderView, LivePortfolioView
+
+        # 가짜 live providers
+        class FakeLivePortfolio(LivePortfolioView):
+            def __init__(self):
+                pass
+
+            def get_positions(self, bot_id):
+                return {}
+
+            def get_balance(self, bot_id):
+                return {"allocated": 0.0, "available": 0.0, "reserved": 0.0}
+
+        class FakeLiveOrders(LiveOrderView):
+            def __init__(self):
+                pass
+
+            def get_open_orders(self, bot_id):
+                return []
+
+        factory = StrategyContextFactory(
+            data_provider=FakeDataProvider(),
+            live_portfolio=FakeLivePortfolio(),
+            live_order_view=FakeLiveOrders(),
+        )
+
+        config = BotConfig(bot_id="live1", strategy_id="s1", bot_type="live")
+        ctx = factory.create(config)
+
+        assert isinstance(ctx, StrategyContext)
+        assert ctx.bot_id == "live1"
+
+    def test_live_without_providers_raises(self, eventbus):
+        """Live providers 미설정 시 에러."""
+        factory = StrategyContextFactory(data_provider=FakeDataProvider())
+        config = BotConfig(bot_id="live1", strategy_id="s1", bot_type="live")
+
+        with pytest.raises(ValueError, match="Provider"):
+            factory.create(config)
+
+
+# ── US-5: BotManager + Factory 통합 ─────────────
+
+
+class TestBotManagerWithFactory:
+    @pytest.fixture
+    async def db(self, tmp_path):
+        database = Database(str(tmp_path / "test.db"))
+        await database.connect()
+        yield database
+        await database.close()
+
+    async def test_create_bot_with_factory(self, eventbus, db):
+        """Factory를 통한 봇 생성 (ctx 미지정)."""
+        from ante.bot import BotManager, StrategyContextFactory
+        from ante.strategy.base import Strategy, StrategyMeta
+
+        class SimpleStrategy(Strategy):
+            meta = StrategyMeta(name="simple", version="1.0.0", description="test")
+
+            async def on_step(self, context):
+                return []
+
+        executor = PaperExecutor(eventbus=eventbus)
+        factory = StrategyContextFactory(
+            data_provider=FakeDataProvider(),
+            paper_executor=executor,
+        )
+        manager = BotManager(eventbus=eventbus, db=db, context_factory=factory)
+        await manager.initialize()
+
+        config = BotConfig(
+            bot_id="paper1",
+            strategy_id="s1",
+            bot_type="paper",
+            paper_initial_balance=5_000_000.0,
+        )
+        bot = await manager.create_bot(config, SimpleStrategy)
+
+        assert bot.bot_id == "paper1"
+        assert "paper1" in executor._portfolios
+
+    async def test_create_bot_with_explicit_ctx(self, eventbus, db):
+        """기존 방식: ctx 직접 주입."""
+        from ante.bot import BotManager
+        from ante.strategy.base import Strategy, StrategyMeta
+
+        class SimpleStrategy(Strategy):
+            meta = StrategyMeta(name="simple", version="1.0.0", description="test")
+
+            async def on_step(self, context):
+                return []
+
+        manager = BotManager(eventbus=eventbus, db=db)
+        await manager.initialize()
+
+        ctx = StrategyContext(
+            bot_id="bot1",
+            data_provider=FakeDataProvider(),
+            portfolio=PaperPortfolioView(bot_id="bot1", initial_balance=1_000_000.0),
+            order_view=PaperOrderView(
+                PaperPortfolioView(bot_id="bot1", initial_balance=1_000_000.0)
+            ),
+        )
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        bot = await manager.create_bot(config, SimpleStrategy, ctx)
+        assert bot.bot_id == "bot1"
+
+    async def test_create_bot_no_ctx_no_factory_raises(self, eventbus, db):
+        """ctx도 factory도 없으면 에러."""
+        from ante.bot import BotError, BotManager
+        from ante.strategy.base import Strategy, StrategyMeta
+
+        class SimpleStrategy(Strategy):
+            meta = StrategyMeta(name="simple", version="1.0.0", description="test")
+
+            async def on_step(self, context):
+                return []
+
+        manager = BotManager(eventbus=eventbus, db=db)
+        await manager.initialize()
+
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        with pytest.raises(BotError, match="factory"):
+            await manager.create_bot(config, SimpleStrategy)
+
+    async def test_remove_paper_bot_unregisters(self, eventbus, db):
+        """Paper 봇 삭제 시 PaperExecutor에서 등록 해제."""
+        from ante.bot import BotManager, StrategyContextFactory
+        from ante.strategy.base import Strategy, StrategyMeta
+
+        class SimpleStrategy(Strategy):
+            meta = StrategyMeta(name="simple", version="1.0.0", description="test")
+
+            async def on_step(self, context):
+                return []
+
+        executor = PaperExecutor(eventbus=eventbus)
+        factory = StrategyContextFactory(
+            data_provider=FakeDataProvider(),
+            paper_executor=executor,
+        )
+        manager = BotManager(eventbus=eventbus, db=db, context_factory=factory)
+        await manager.initialize()
+
+        config = BotConfig(bot_id="paper1", strategy_id="s1", bot_type="paper")
+        await manager.create_bot(config, SimpleStrategy)
+        assert "paper1" in executor._portfolios
+
+        await manager.remove_bot("paper1")
+        assert "paper1" not in executor._portfolios
+
+
+# ── PositionHistory 캐시 테스트 ──────────────────
+
+
+class TestPositionHistoryCache:
+    @pytest.fixture
+    async def db(self, tmp_path):
+        database = Database(str(tmp_path / "test.db"))
+        await database.connect()
+        yield database
+        await database.close()
+
+    async def test_sync_positions_after_trade(self, db):
+        """체결 후 동기 캐시에 포지션 반영."""
+        ph = PositionHistory(db=db)
+        await ph.initialize()
+
+        from ante.trade.models import TradeRecord, TradeStatus
+
+        record = TradeRecord(
+            trade_id="t1",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            price=50000.0,
+            status=TradeStatus.FILLED,
+            order_type="market",
+        )
+        await ph.on_trade(record)
+
+        positions = ph.get_positions_sync("bot1")
+        assert len(positions) == 1
+        assert positions[0].symbol == "005930"
+        assert positions[0].quantity == 10.0
+
+    async def test_sync_positions_empty(self, db):
+        """포지션 없으면 빈 목록."""
+        ph = PositionHistory(db=db)
+        await ph.initialize()
+
+        positions = ph.get_positions_sync("bot1")
+        assert positions == []
+
+    async def test_cache_warm_on_init(self, db):
+        """초기화 시 DB에서 캐시 워밍."""
+        ph1 = PositionHistory(db=db)
+        await ph1.initialize()
+
+        from ante.trade.models import TradeRecord, TradeStatus
+
+        record = TradeRecord(
+            trade_id="t1",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            price=50000.0,
+            status=TradeStatus.FILLED,
+            order_type="market",
+        )
+        await ph1.on_trade(record)
+
+        # 새 인스턴스로 다시 초기화 → 캐시 워밍
+        ph2 = PositionHistory(db=db)
+        await ph2.initialize()
+
+        positions = ph2.get_positions_sync("bot1")
+        assert len(positions) == 1
+        assert positions[0].quantity == 10.0
+
+    async def test_cache_updates_on_sell(self, db):
+        """매도 후 포지션이 0이면 캐시에서 제거."""
+        ph = PositionHistory(db=db)
+        await ph.initialize()
+
+        from ante.trade.models import TradeRecord, TradeStatus
+
+        buy = TradeRecord(
+            trade_id="t1",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            price=50000.0,
+            status=TradeStatus.FILLED,
+            order_type="market",
+        )
+        await ph.on_trade(buy)
+
+        sell = TradeRecord(
+            trade_id="t2",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            price=55000.0,
+            status=TradeStatus.FILLED,
+            order_type="market",
+        )
+        await ph.on_trade(sell)
+
+        positions = ph.get_positions_sync("bot1")
+        assert positions == []


### PR DESCRIPTION
## Summary
Closes #47

- **US-1 (Live Providers)**: `LivePortfolioView`, `LiveOrderView` — Treasury/PositionHistory를 sync ABC로 래핑
- **US-2 (Paper Providers)**: `PaperPortfolioView`, `PaperOrderView` — 인메모리 가상 잔고/포지션 관리
- **US-3 (PaperExecutor)**: OrderRequestEvent 구독 → 가상 체결(수수료/슬리피지 포함) → OrderFilledEvent 발행
- **US-4 (StrategyContextFactory)**: bot_type(live/paper) 기반 StrategyContext 자동 조립
- **US-5 (BotManager 통합)**: Factory 주입 + 기존 명시적 ctx 주입 하위 호환 유지
- **인프라**: PositionHistory/Treasury에 sync 캐시 레이어 추가, main.py Composition Root 배선

## Test plan
- [x] LivePortfolioView: 빈 포지션, 데이터 있는 포지션, 잔고 조회 (4 tests)
- [x] PaperPortfolioView: 초기 잔고, 매수/매도 체결, 잔고 확인, 예약/해제 (7 tests)
- [x] PaperExecutor: 매수/매도 체결, 잔고 부족 거절, live 봇 무시, 수수료, 슬리피지 (9 tests)
- [x] StrategyContextFactory: paper/live 컨텍스트 생성, 프로바이더 미설정 예외 (3 tests)
- [x] BotManager 통합: factory 사용, 명시적 ctx, 에러 케이스, paper 봇 삭제 시 해제 (4 tests)
- [x] PositionHistory 캐시: 거래 후 동기화, 초기화 시 워밍, 매도 시 제거 (4 tests)
- [x] 전체 607 테스트 통과, 0 실패

🤖 Generated with [Claude Code](https://claude.com/claude-code)