### PR TITLE
feat: 수수료율 기반 체결 수수료 계산 체계

### DIFF
--- a/src/ante/bot/providers/paper.py
+++ b/src/ante/bot/providers/paper.py
@@ -10,6 +10,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from ante.broker.models import CommissionInfo
 from ante.strategy.base import OrderView, PortfolioView
 
 if TYPE_CHECKING:
@@ -129,11 +130,15 @@ class PaperExecutor:
         eventbus: EventBus,
         gateway: APIGateway | None = None,
         commission_rate: float = 0.00015,
+        sell_tax_rate: float = 0.0023,
         slippage_rate: float = 0.0,
     ) -> None:
         self._eventbus = eventbus
         self._gateway = gateway
-        self._commission_rate = commission_rate
+        self._commission_info = CommissionInfo(
+            commission_rate=commission_rate,
+            sell_tax_rate=sell_tax_rate,
+        )
         self._slippage_rate = slippage_rate
         self._portfolios: dict[str, PaperPortfolioView] = {}
         self._bot_configs: dict[str, Any] = {}
@@ -200,7 +205,7 @@ class PaperExecutor:
 
         # 수수료 계산
         trade_amount = fill_price * quantity
-        commission = trade_amount * self._commission_rate
+        commission = self._commission_info.calculate(side, trade_amount)
 
         # 잔고 확인 (매수 시)
         if side == "buy":

--- a/src/ante/broker/__init__.py
+++ b/src/ante/broker/__init__.py
@@ -9,10 +9,12 @@ from ante.broker.exceptions import (
     RateLimitError,
 )
 from ante.broker.kis import KISAdapter
+from ante.broker.models import CommissionInfo
 from ante.broker.order_registry import OrderRegistry
 
 __all__ = [
     "BrokerAdapter",
+    "CommissionInfo",
     "KISAdapter",
     "OrderRegistry",
     "BrokerError",

--- a/src/ante/broker/base.py
+++ b/src/ante/broker/base.py
@@ -7,7 +7,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ante.broker.models import CommissionInfo
 
 
 class BrokerAdapter(ABC):
@@ -137,6 +140,13 @@ class BrokerAdapter(ABC):
               "quantity": float, "filled_quantity": float,
               "price": float, "status": str, "timestamp": str}, ...]
         """
+        ...
+
+    # ── 수수료 ────────────────────────────────────────
+
+    @abstractmethod
+    def get_commission_info(self) -> CommissionInfo:
+        """증권사별 수수료율 정보 반환."""
         ...
 
     # ── 헬퍼 메서드 ─────────────────────────────────

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -18,6 +18,7 @@ from ante.broker.exceptions import (
     AuthenticationError,
     OrderNotFoundError,
 )
+from ante.broker.models import CommissionInfo
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,8 @@ class KISAdapter(BrokerAdapter):
         self.app_secret: str = config["app_secret"]
         self.account_no: str = config["account_no"]
         self.is_paper: bool = config.get("is_paper", False)
+        self._commission_rate: float = config.get("commission_rate", 0.00015)
+        self._sell_tax_rate: float = config.get("sell_tax_rate", 0.0023)
 
         # API 엔드포인트
         if self.is_paper:
@@ -414,6 +417,15 @@ class KISAdapter(BrokerAdapter):
         """실시간 주문 체결 스트리밍. WebSocket 연동 Phase에서 구현."""
         raise NotImplementedError("실시간 주문 스트리밍은 추후 구현")
         yield {}  # type: ignore[misc]
+
+    # ── 수수료 ────────────────────────────────────────
+
+    def get_commission_info(self) -> CommissionInfo:
+        """KIS 수수료율 정보 반환."""
+        return CommissionInfo(
+            commission_rate=self._commission_rate,
+            sell_tax_rate=self._sell_tax_rate,
+        )
 
     # ── 대사용 조회 ────────────────────────────────
 

--- a/src/ante/broker/models.py
+++ b/src/ante/broker/models.py
@@ -1,0 +1,27 @@
+"""Broker 데이터 모델."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CommissionInfo:
+    """증권사별 수수료율 정보.
+
+    commission_rate: 매매 수수료율 (예: 0.00015 = 0.015%)
+    sell_tax_rate: 매도 세금율 (증권거래세 + 농특세, 예: 0.0023 = 0.23%)
+    """
+
+    commission_rate: float = 0.00015
+    sell_tax_rate: float = 0.0023
+
+    def calculate(self, side: str, filled_value: float) -> float:
+        """체결 금액 기반 수수료 계산.
+
+        매수: filled_value × commission_rate
+        매도: filled_value × (commission_rate + sell_tax_rate)
+        """
+        if side == "sell":
+            return filled_value * (self.commission_rate + self.sell_tax_rate)
+        return filled_value * self.commission_rate

--- a/src/ante/config/defaults.py
+++ b/src/ante/config/defaults.py
@@ -11,4 +11,7 @@ DEFAULTS: dict[str, object] = {
     "web.port": 8000,
     "eventbus.history_size": 1000,
     "instrument.default_exchange": "KRX",
+    "broker.commission_rate": 0.00015,
+    "broker.sell_tax_rate": 0.0023,
+    "treasury.sync_interval_seconds": 300,
 }

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -109,8 +109,14 @@ async def main() -> None:
     # ── 8. Treasury ──────────────────────────────────
     from ante.treasury import Treasury
 
-    commission_rate = config.get("treasury.commission_rate", 0.00015)
-    treasury = Treasury(db=db, eventbus=eventbus, commission_rate=commission_rate)
+    commission_rate = config.get("broker.commission_rate", 0.00015)
+    sell_tax_rate = config.get("broker.sell_tax_rate", 0.0023)
+    treasury = Treasury(
+        db=db,
+        eventbus=eventbus,
+        commission_rate=commission_rate,
+        sell_tax_rate=sell_tax_rate,
+    )
     await treasury.initialize()
     logger.info("Treasury 초기화 완료")
 
@@ -148,6 +154,7 @@ async def main() -> None:
         eventbus=eventbus,
         gateway=None,  # APIGateway 연결 후 설정
         commission_rate=commission_rate,
+        sell_tax_rate=sell_tax_rate,
     )
     paper_executor.subscribe()
 

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -56,10 +56,12 @@ class Treasury:
         db: Database,
         eventbus: EventBus,
         commission_rate: float = 0.00015,
+        sell_tax_rate: float = 0.0023,
     ) -> None:
         self._db = db
         self._eventbus = eventbus
         self._commission_rate = commission_rate
+        self._sell_tax_rate = sell_tax_rate
 
         self._account_balance: float = 0.0
         self._purchasable_amount: float = 0.0
@@ -116,6 +118,26 @@ class Treasury:
     @property
     def unallocated(self) -> float:
         return self._unallocated
+
+    @property
+    def commission_rate(self) -> float:
+        return self._commission_rate
+
+    @property
+    def sell_tax_rate(self) -> float:
+        return self._sell_tax_rate
+
+    def update_commission_rates(
+        self, commission_rate: float, sell_tax_rate: float
+    ) -> None:
+        """수수료율 업데이트 (DynamicConfig 변경 시 호출)."""
+        self._commission_rate = commission_rate
+        self._sell_tax_rate = sell_tax_rate
+        logger.info(
+            "수수료율 갱신: commission=%s, sell_tax=%s",
+            commission_rate,
+            sell_tax_rate,
+        )
 
     # ── 예산 조회 ───────────────────────────────────
 

--- a/tests/integration/test_e2e_flow.py
+++ b/tests/integration/test_e2e_flow.py
@@ -119,6 +119,11 @@ class MockBrokerAdapter(BrokerAdapter):
     ) -> list[dict[str, Any]]:
         return list(self._orders.values())
 
+    def get_commission_info(self) -> Any:
+        from ante.broker.models import CommissionInfo
+
+        return CommissionInfo()
+
 
 class AutoFillSimulator:
     """OrderSubmittedEvent를 수신하면 즉시 OrderFilledEvent를 발행하는 시뮬레이터.

--- a/tests/unit/test_broker.py
+++ b/tests/unit/test_broker.py
@@ -82,6 +82,7 @@ class TestBrokerAdapterABC:
             async def get_order_history(
                 self, from_date: str | None = None, to_date: str | None = None
             ) -> list[dict[str, Any]]: ...
+            def get_commission_info(self) -> Any: ...
 
         broker = DummyBroker({})
         assert broker.normalize_symbol("5930") == "005930"
@@ -121,6 +122,7 @@ class TestBrokerAdapterABC:
             async def get_order_history(
                 self, from_date: str | None = None, to_date: str | None = None
             ) -> list[dict[str, Any]]: ...
+            def get_commission_info(self) -> Any: ...
 
         cfg = {"key": "value"}
         broker = MinBroker(cfg)

--- a/tests/unit/test_commission.py
+++ b/tests/unit/test_commission.py
@@ -1,0 +1,278 @@
+"""수수료 계산 체계 테스트."""
+
+import pytest
+
+from ante.broker.models import CommissionInfo
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import OrderFilledEvent
+from ante.treasury import Treasury
+
+# ── US-1: CommissionInfo 모델 ─────────────────────
+
+
+class TestCommissionInfo:
+    def test_defaults(self):
+        """기본 수수료율."""
+        info = CommissionInfo()
+        assert info.commission_rate == 0.00015
+        assert info.sell_tax_rate == 0.0023
+
+    def test_custom_rates(self):
+        """커스텀 수수료율."""
+        info = CommissionInfo(commission_rate=0.0001, sell_tax_rate=0.0018)
+        assert info.commission_rate == 0.0001
+        assert info.sell_tax_rate == 0.0018
+
+    def test_frozen(self):
+        """불변 객체."""
+        info = CommissionInfo()
+        with pytest.raises(AttributeError):
+            info.commission_rate = 0.001  # type: ignore[misc]
+
+
+class TestCommissionCalculation:
+    def test_buy_commission(self):
+        """매수 수수료: filled_value × commission_rate."""
+        info = CommissionInfo(commission_rate=0.00015, sell_tax_rate=0.0023)
+        commission = info.calculate("buy", 1_000_000.0)
+        assert commission == pytest.approx(150.0)
+
+    def test_sell_commission_includes_tax(self):
+        """매도 수수료: filled_value × (commission_rate + sell_tax_rate)."""
+        info = CommissionInfo(commission_rate=0.00015, sell_tax_rate=0.0023)
+        commission = info.calculate("sell", 1_000_000.0)
+        expected = 1_000_000.0 * (0.00015 + 0.0023)
+        assert commission == pytest.approx(expected)
+
+    def test_sell_commission_higher_than_buy(self):
+        """매도 수수료가 매수보다 높다."""
+        info = CommissionInfo()
+        buy_fee = info.calculate("buy", 1_000_000.0)
+        sell_fee = info.calculate("sell", 1_000_000.0)
+        assert sell_fee > buy_fee
+
+    def test_zero_amount(self):
+        """0원 체결 → 수수료 0."""
+        info = CommissionInfo()
+        assert info.calculate("buy", 0.0) == 0.0
+        assert info.calculate("sell", 0.0) == 0.0
+
+    def test_kosdaq_tax_rate(self):
+        """코스닥 세율 적용 (0.0018)."""
+        info = CommissionInfo(commission_rate=0.00015, sell_tax_rate=0.0018)
+        commission = info.calculate("sell", 1_000_000.0)
+        expected = 1_000_000.0 * (0.00015 + 0.0018)
+        assert commission == pytest.approx(expected)
+
+
+# ── US-1: KISAdapter.get_commission_info ──────────
+
+
+class TestKISCommissionInfo:
+    def test_kis_default_commission(self):
+        """KISAdapter 기본 수수료율."""
+        from ante.broker.kis import KISAdapter
+
+        adapter = KISAdapter.__new__(KISAdapter)
+        adapter._commission_rate = 0.00015
+        adapter._sell_tax_rate = 0.0023
+
+        info = adapter.get_commission_info()
+        assert info.commission_rate == 0.00015
+        assert info.sell_tax_rate == 0.0023
+
+    def test_kis_custom_commission_from_config(self):
+        """KISAdapter config에서 수수료율 읽기."""
+        from ante.broker.kis import KISAdapter
+
+        adapter = KISAdapter.__new__(KISAdapter)
+        adapter._commission_rate = 0.0001
+        adapter._sell_tax_rate = 0.0018
+
+        info = adapter.get_commission_info()
+        assert info.commission_rate == 0.0001
+        assert info.sell_tax_rate == 0.0018
+
+
+# ── US-2: PaperExecutor 매도 세금 반영 ────────────
+
+
+class TestPaperExecutorCommission:
+    async def test_buy_commission(self):
+        """PaperExecutor 매수 수수료 = commission_rate만 적용."""
+        from ante.bot.providers.paper import PaperExecutor, PaperPortfolioView
+
+        eventbus = EventBus()
+        executor = PaperExecutor(
+            eventbus=eventbus,
+            commission_rate=0.00015,
+            sell_tax_rate=0.0023,
+        )
+
+        portfolio = PaperPortfolioView(bot_id="bot1", initial_balance=10_000_000.0)
+        executor.register_bot("bot1", portfolio)
+        executor.subscribe()
+
+        received: list[OrderFilledEvent] = []
+        eventbus.subscribe(OrderFilledEvent, lambda e: received.append(e))
+
+        from ante.eventbus.events import OrderRequestEvent
+
+        await eventbus.publish(
+            OrderRequestEvent(
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                order_type="limit",
+                price=50_000.0,
+            )
+        )
+
+        assert len(received) == 1
+        filled_value = 50_000.0 * 10.0
+        expected_commission = filled_value * 0.00015
+        assert received[0].commission == pytest.approx(expected_commission)
+
+    async def test_sell_commission_includes_tax(self):
+        """PaperExecutor 매도 수수료 = commission_rate + sell_tax_rate."""
+        from ante.bot.providers.paper import PaperExecutor, PaperPortfolioView
+
+        eventbus = EventBus()
+        executor = PaperExecutor(
+            eventbus=eventbus,
+            commission_rate=0.00015,
+            sell_tax_rate=0.0023,
+        )
+
+        portfolio = PaperPortfolioView(bot_id="bot1", initial_balance=10_000_000.0)
+        # 먼저 보유 포지션 설정
+        portfolio._positions["005930"] = {
+            "quantity": 100.0,
+            "avg_entry_price": 50_000.0,
+            "realized_pnl": 0.0,
+        }
+        executor.register_bot("bot1", portfolio)
+        executor.subscribe()
+
+        received: list[OrderFilledEvent] = []
+        eventbus.subscribe(OrderFilledEvent, lambda e: received.append(e))
+
+        from ante.eventbus.events import OrderRequestEvent
+
+        await eventbus.publish(
+            OrderRequestEvent(
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="sell",
+                quantity=10.0,
+                order_type="limit",
+                price=55_000.0,
+            )
+        )
+
+        assert len(received) == 1
+        filled_value = 55_000.0 * 10.0
+        expected_commission = filled_value * (0.00015 + 0.0023)
+        assert received[0].commission == pytest.approx(expected_commission)
+
+
+# ── US-3: 설정 기본값 ────────────────────────────
+
+
+class TestCommissionDefaults:
+    def test_defaults_include_commission_rate(self):
+        """config/defaults.py에 broker.commission_rate 포함."""
+        from ante.config.defaults import DEFAULTS
+
+        assert "broker.commission_rate" in DEFAULTS
+        assert DEFAULTS["broker.commission_rate"] == 0.00015
+
+    def test_defaults_include_sell_tax_rate(self):
+        """config/defaults.py에 broker.sell_tax_rate 포함."""
+        from ante.config.defaults import DEFAULTS
+
+        assert "broker.sell_tax_rate" in DEFAULTS
+        assert DEFAULTS["broker.sell_tax_rate"] == 0.0023
+
+
+# ── US-4: Treasury 수수료 추정 통합 ──────────────
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+class TestTreasuryCommission:
+    async def test_treasury_accepts_sell_tax_rate(self, db, eventbus):
+        """Treasury가 sell_tax_rate 파라미터를 수용."""
+        t = Treasury(
+            db=db,
+            eventbus=eventbus,
+            commission_rate=0.00015,
+            sell_tax_rate=0.0023,
+        )
+        await t.initialize()
+        assert t.commission_rate == 0.00015
+        assert t.sell_tax_rate == 0.0023
+
+    async def test_treasury_default_sell_tax_rate(self, db, eventbus):
+        """Treasury 기본 sell_tax_rate = 0.0023."""
+        t = Treasury(db=db, eventbus=eventbus)
+        await t.initialize()
+        assert t.sell_tax_rate == 0.0023
+
+    async def test_update_commission_rates(self, db, eventbus):
+        """수수료율 동적 업데이트."""
+        t = Treasury(db=db, eventbus=eventbus)
+        await t.initialize()
+
+        t.update_commission_rates(0.0001, 0.0018)
+        assert t.commission_rate == 0.0001
+        assert t.sell_tax_rate == 0.0018
+
+    async def test_buy_reservation_uses_commission_rate(self, db, eventbus):
+        """매수 예약 시 commission_rate 사용."""
+        from ante.eventbus.events import OrderApprovedEvent, OrderValidatedEvent
+
+        t = Treasury(
+            db=db,
+            eventbus=eventbus,
+            commission_rate=0.001,  # 높은 수수료율로 테스트
+            sell_tax_rate=0.0023,
+        )
+        await t.initialize()
+        await t.set_account_balance(10_000_000.0)
+        await t.allocate("bot1", 5_000_000.0)
+
+        received = []
+        eventbus.subscribe(OrderApprovedEvent, lambda e: received.append(e))
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=50_000.0,
+                order_type="market",
+            )
+        )
+
+        assert len(received) == 1
+        # reserved_amount = 10*50000 * (1 + 0.001) = 500,500
+        assert received[0].reserved_amount == pytest.approx(500_500.0)


### PR DESCRIPTION
Closes #50

## Summary
- **US-1**: `CommissionInfo` frozen dataclass + `BrokerAdapter.get_commission_info()` 추상 메서드 추가
- **US-2**: `PaperExecutor`가 매도 시 증권거래세(`sell_tax_rate`) 반영하도록 변경
- **US-3**: `config/defaults.py`에 `broker.commission_rate`(0.00015), `broker.sell_tax_rate`(0.0023) 기본값 추가
- **US-4**: `Treasury`에 `sell_tax_rate` 파라미터 및 `update_commission_rates()` 동적 업데이트 지원

## Changes
- `src/ante/broker/models.py` — CommissionInfo dataclass (calculate 메서드 포함)
- `src/ante/broker/base.py` — BrokerAdapter ABC에 get_commission_info() 추가
- `src/ante/broker/kis.py` — KISAdapter에 수수료율 config 읽기 + get_commission_info() 구현
- `src/ante/bot/providers/paper.py` — PaperExecutor sell_tax_rate 지원
- `src/ante/treasury/treasury.py` — sell_tax_rate, update_commission_rates()
- `src/ante/config/defaults.py` — 브로커 수수료 기본값
- `src/ante/main.py` — composition root에서 수수료율 주입

## Test plan
- [x] CommissionInfo 모델 테스트 (기본값, 커스텀, frozen)
- [x] 매수/매도 수수료 계산 테스트 (매도 > 매수, 0원, 코스닥 세율)
- [x] KISAdapter 수수료 정보 테스트
- [x] PaperExecutor 매수/매도 수수료 테스트
- [x] config defaults 포함 테스트
- [x] Treasury sell_tax_rate 수용/기본값/동적 업데이트/매수 예약 테스트
- [x] 전체 테스트 스위트 646개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)