### PR TITLE
feat: 봇 중지 시 미체결 예약 자금 자동 해제

### DIFF
--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -73,7 +73,9 @@ class Treasury:
         self._external_eval_amount: float = 0.0
         self._budgets: dict[str, BotBudget] = {}
         self._unallocated: float = 0.0
-        self._reservations: dict[str, float] = {}
+        self._reservations: dict[
+            str, tuple[str, float]
+        ] = {}  # order_id → (bot_id, amount)
         self._sync_task: asyncio.Task[None] | None = None
 
     async def initialize(self) -> None:
@@ -86,6 +88,7 @@ class Treasury:
     def _subscribe_events(self) -> None:
         """EventBus 이벤트 구독."""
         from ante.eventbus.events import (
+            BotStoppedEvent,
             OrderCancelledEvent,
             OrderFailedEvent,
             OrderFilledEvent,
@@ -100,6 +103,7 @@ class Treasury:
             OrderCancelledEvent, self._on_order_cancelled, priority=80
         )
         self._eventbus.subscribe(OrderFailedEvent, self._on_order_failed, priority=80)
+        self._eventbus.subscribe(BotStoppedEvent, self._on_bot_stopped, priority=80)
 
     # ── 계좌 잔고 ───────────────────────────────────
 
@@ -206,7 +210,7 @@ class Treasury:
         budget.available -= amount
         budget.reserved += amount
         budget.last_updated = datetime.now(UTC)
-        self._reservations[order_id] = amount
+        self._reservations[order_id] = (bot_id, amount)
 
         await self._save_budget(budget)
         return True
@@ -214,7 +218,8 @@ class Treasury:
     async def release_reservation(self, bot_id: str, order_id: str) -> None:
         """주문 취소/실패 시 예약 해제."""
         budget = self._budgets.get(bot_id)
-        amount = self._reservations.pop(order_id, 0.0)
+        entry = self._reservations.pop(order_id, None)
+        amount = entry[1] if entry else 0.0
         if not budget or amount <= 0:
             return
 
@@ -223,6 +228,16 @@ class Treasury:
         budget.last_updated = datetime.now(UTC)
 
         await self._save_budget(budget)
+
+    def get_reservations(self, bot_id: str) -> dict[str, float]:
+        """특정 봇의 미체결 예약 내역 조회.
+
+        Returns:
+            {order_id: amount, ...}
+        """
+        return {
+            oid: amt for oid, (bid, amt) in self._reservations.items() if bid == bot_id
+        }
 
     # ── 이벤트 핸들러 ───────────────────────────────
 
@@ -296,7 +311,8 @@ class Treasury:
         commission = event.commission
 
         if event.side == "buy":
-            reserved_amount = self._reservations.pop(event.order_id, 0.0)
+            entry = self._reservations.pop(event.order_id, None)
+            reserved_amount = entry[1] if entry else 0.0
             actual_cost = fill_value + commission
             budget.reserved = max(0.0, budget.reserved - reserved_amount)
             budget.spent += actual_cost
@@ -334,6 +350,43 @@ class Treasury:
         if not isinstance(event, OrderFailedEvent):
             return
         await self.release_reservation(event.bot_id, event.order_id)
+
+    async def _on_bot_stopped(self, event: object) -> None:
+        """봇 중지 시 해당 봇의 모든 예약 자금 일괄 해제."""
+        from ante.eventbus.events import BotStoppedEvent
+
+        if not isinstance(event, BotStoppedEvent):
+            return
+
+        bot_id = event.bot_id
+        pending = self.get_reservations(bot_id)
+        if not pending:
+            return
+
+        total_released = 0.0
+        for order_id, amount in pending.items():
+            self._reservations.pop(order_id, None)
+            total_released += amount
+
+        budget = self._budgets.get(bot_id)
+        if budget:
+            budget.reserved = max(0.0, budget.reserved - total_released)
+            budget.available += total_released
+            budget.last_updated = datetime.now(UTC)
+            await self._save_budget(budget)
+
+        await self._log_transaction(
+            bot_id=bot_id,
+            tx_type="bot_stopped_release",
+            amount=total_released,
+            description=f"{len(pending)}건 예약 해제",
+        )
+        logger.info(
+            "봇 중지 예약 해제: %s — %d건, %s원",
+            bot_id,
+            len(pending),
+            f"{total_released:,.0f}",
+        )
 
     # ── 잔고 동기화 ────────────────────────────────
 

--- a/tests/unit/test_bot_stop_release.py
+++ b/tests/unit/test_bot_stop_release.py
@@ -1,0 +1,162 @@
+"""봇 중지 시 미체결 예약 자금 자동 해제 테스트."""
+
+import pytest
+
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import BotStoppedEvent
+from ante.treasury import Treasury
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+async def treasury(db, eventbus):
+    t = Treasury(db=db, eventbus=eventbus)
+    await t.initialize()
+    await t.set_account_balance(10_000_000.0)
+    await t.allocate("bot1", 5_000_000.0)
+    await t.allocate("bot2", 3_000_000.0)
+    return t
+
+
+# ── US-2: 봇별 예약 내역 조회 ──────────────────────
+
+
+class TestGetReservations:
+    async def test_empty_reservations(self, treasury):
+        """예약 없는 봇 → 빈 dict."""
+        result = treasury.get_reservations("bot1")
+        assert result == {}
+
+    async def test_single_reservation(self, treasury):
+        """단일 예약."""
+        await treasury.reserve_for_order("bot1", "ord1", 100_000.0)
+        result = treasury.get_reservations("bot1")
+        assert result == {"ord1": 100_000.0}
+
+    async def test_multiple_reservations(self, treasury):
+        """복수 예약."""
+        await treasury.reserve_for_order("bot1", "ord1", 100_000.0)
+        await treasury.reserve_for_order("bot1", "ord2", 200_000.0)
+        result = treasury.get_reservations("bot1")
+        assert result == {"ord1": 100_000.0, "ord2": 200_000.0}
+
+    async def test_filters_by_bot_id(self, treasury):
+        """다른 봇의 예약은 필터링."""
+        await treasury.reserve_for_order("bot1", "ord1", 100_000.0)
+        await treasury.reserve_for_order("bot2", "ord2", 200_000.0)
+        assert treasury.get_reservations("bot1") == {"ord1": 100_000.0}
+        assert treasury.get_reservations("bot2") == {"ord2": 200_000.0}
+
+    async def test_reservation_removed_after_release(self, treasury):
+        """해제 후 조회 결과에서 제거."""
+        await treasury.reserve_for_order("bot1", "ord1", 100_000.0)
+        await treasury.release_reservation("bot1", "ord1")
+        assert treasury.get_reservations("bot1") == {}
+
+
+# ── US-1: 봇 중지 시 예약 자금 일괄 해제 ────────────
+
+
+class TestBotStopRelease:
+    async def test_bot_stopped_releases_all_reservations(self, treasury, eventbus):
+        """BotStoppedEvent → 해당 봇 예약 전부 해제."""
+        await treasury.reserve_for_order("bot1", "ord1", 100_000.0)
+        await treasury.reserve_for_order("bot1", "ord2", 200_000.0)
+
+        budget_before = await treasury.get_budget("bot1")
+        available_before = budget_before.available
+
+        await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
+
+        budget_after = await treasury.get_budget("bot1")
+        assert budget_after.reserved == 0.0
+        assert budget_after.available == pytest.approx(available_before + 300_000.0)
+        assert treasury.get_reservations("bot1") == {}
+
+    async def test_bot_stopped_does_not_affect_other_bots(self, treasury, eventbus):
+        """다른 봇의 예약은 영향 없음."""
+        await treasury.reserve_for_order("bot1", "ord1", 100_000.0)
+        await treasury.reserve_for_order("bot2", "ord2", 200_000.0)
+
+        await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
+
+        assert treasury.get_reservations("bot2") == {"ord2": 200_000.0}
+        budget2 = await treasury.get_budget("bot2")
+        assert budget2.reserved == 200_000.0
+
+    async def test_bot_stopped_no_reservations_noop(self, treasury, eventbus):
+        """예약 없는 봇 중지 → 아무 변화 없음."""
+        budget_before = await treasury.get_budget("bot1")
+
+        await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
+
+        budget_after = await treasury.get_budget("bot1")
+        assert budget_after.available == budget_before.available
+        assert budget_after.reserved == budget_before.reserved
+
+    async def test_bot_stopped_logs_transaction(self, treasury, eventbus, db):
+        """해제 시 거래 이력에 bot_stopped_release 기록."""
+        await treasury.reserve_for_order("bot1", "ord1", 100_000.0)
+
+        await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
+
+        rows = await db.fetch_all(
+            "SELECT * FROM treasury_transactions "
+            "WHERE transaction_type = 'bot_stopped_release'"
+        )
+        assert len(rows) == 1
+        assert rows[0]["bot_id"] == "bot1"
+        assert rows[0]["amount"] == pytest.approx(100_000.0)
+        assert "1건" in rows[0]["description"]
+
+    async def test_bot_stopped_releases_correct_total(self, treasury, eventbus):
+        """여러 예약 해제 시 총 금액이 정확."""
+        await treasury.reserve_for_order("bot1", "ord1", 150_000.0)
+        await treasury.reserve_for_order("bot1", "ord2", 250_000.0)
+        await treasury.reserve_for_order("bot1", "ord3", 100_000.0)
+
+        await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
+
+        budget = await treasury.get_budget("bot1")
+        assert budget.reserved == 0.0
+        # available should have all 500k returned
+        assert budget.available == pytest.approx(5_000_000.0 - 500_000.0 + 500_000.0)
+
+    async def test_unknown_bot_stopped_no_error(self, treasury, eventbus):
+        """존재하지 않는 봇 중지 → 에러 없이 무시."""
+        await eventbus.publish(BotStoppedEvent(bot_id="unknown_bot"))
+        # 에러 없이 통과
+
+
+# ── 기존 예약/해제 호환성 ──────────────────────────
+
+
+class TestReservationCompatibility:
+    async def test_reserve_and_release_still_works(self, treasury):
+        """기존 reserve/release 정상 동작."""
+        await treasury.reserve_for_order("bot1", "ord1", 100_000.0)
+        budget = await treasury.get_budget("bot1")
+        assert budget.reserved == 100_000.0
+
+        await treasury.release_reservation("bot1", "ord1")
+        budget = await treasury.get_budget("bot1")
+        assert budget.reserved == 0.0
+
+    async def test_nonexistent_order_release_noop(self, treasury):
+        """존재하지 않는 주문 해제 → 무시."""
+        await treasury.release_reservation("bot1", "nonexistent")
+        budget = await treasury.get_budget("bot1")
+        assert budget.available == 5_000_000.0


### PR DESCRIPTION
Closes #55

## Summary
- **US-1**: Treasury가 `BotStoppedEvent` 구독 → 해당 봇의 모든 미체결 예약 자금 일괄 해제, `bot_stopped_release` 거래 이력 기록
- **US-2**: `_reservations` 구조를 `order_id → (bot_id, amount)` 튜플로 변경, `get_reservations(bot_id)` 메서드 추가

## Changes
- `src/ante/treasury/treasury.py` — 예약 구조 변경, BotStoppedEvent 핸들러, get_reservations()

## Test plan
- [x] 빈 예약 조회 / 단일·복수 예약 조회 / 봇별 필터링
- [x] 봇 중지 시 전체 예약 해제 + available 복원
- [x] 다른 봇 예약 미영향
- [x] 예약 없는 봇 중지 → noop
- [x] 거래 이력에 bot_stopped_release 기록
- [x] 존재하지 않는 봇 중지 → 에러 없음
- [x] 기존 reserve/release 호환성 유지
- [x] 전체 테스트 691개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)