### PR TITLE
feat: add detailed backtest performance metrics (#58)

### DIFF
--- a/src/ante/backtest/__init__.py
+++ b/src/ante/backtest/__init__.py
@@ -7,6 +7,7 @@ from ante.backtest.exceptions import (
     BacktestError,
 )
 from ante.backtest.executor import BacktestExecutor
+from ante.backtest.metrics import calculate_metrics
 from ante.backtest.result import BacktestResult, BacktestTrade
 from ante.backtest.service import BacktestService
 
@@ -17,6 +18,7 @@ __all__ = [
     "BacktestError",
     "BacktestExecutor",
     "BacktestResult",
+    "calculate_metrics",
     "BacktestService",
     "BacktestTrade",
 ]

--- a/src/ante/backtest/executor.py
+++ b/src/ante/backtest/executor.py
@@ -164,16 +164,25 @@ class BacktestExecutor:
 
     def _calculate_metrics(self) -> dict:
         """성과 지표 계산."""
+        from ante.backtest.metrics import calculate_metrics
+
         if not self._trades:
             return {}
 
-        return {
-            "total_trades": len(self._trades),
-            "buy_trades": sum(1 for t in self._trades if t.side == "buy"),
-            "sell_trades": sum(1 for t in self._trades if t.side == "sell"),
-            "total_commission": sum(t.commission for t in self._trades),
-            "total_slippage": sum(t.slippage for t in self._trades),
-        }
+        final_equity = self._calculate_equity()
+        metrics = calculate_metrics(
+            trades=self._trades,
+            equity_curve=self._equity_curve,
+            initial_balance=self._initial_balance,
+            final_balance=final_equity,
+        )
+
+        # 기존 호환 필드 추가
+        metrics["buy_trades"] = sum(1 for t in self._trades if t.side == "buy")
+        metrics["sell_trades"] = sum(1 for t in self._trades if t.side == "sell")
+        metrics["total_slippage"] = round(sum(t.slippage for t in self._trades), 2)
+
+        return metrics
 
     def get_positions(self, bot_id: str) -> dict[str, Any]:
         """PortfolioView 인터페이스."""

--- a/src/ante/backtest/metrics.py
+++ b/src/ante/backtest/metrics.py
@@ -1,0 +1,204 @@
+"""백테스트 성과 지표 계산 유틸리티."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+def calculate_metrics(
+    trades: list[Any],
+    equity_curve: list[dict],
+    initial_balance: float,
+    final_balance: float,
+) -> dict[str, Any]:
+    """백테스트 결과에서 상세 성과 지표를 계산한다.
+
+    Args:
+        trades: BacktestTrade 리스트
+        equity_curve: [{"timestamp": str, "equity": float}, ...] 리스트
+        initial_balance: 초기 자금
+        final_balance: 최종 자산
+
+    Returns:
+        성과 지표 dict
+    """
+    metrics: dict[str, Any] = {}
+
+    # ── 수익률 ────────────────────────────────────────
+    total_return = (
+        (final_balance - initial_balance) / initial_balance * 100
+        if initial_balance > 0
+        else 0.0
+    )
+    metrics["total_return"] = round(total_return, 4)
+
+    # 연환산 수익률
+    metrics["annual_return"] = round(_annual_return(equity_curve, total_return), 4)
+
+    # ── Equity Curve 기반 지표 ────────────────────────
+    equities = [e["equity"] for e in equity_curve] if equity_curve else []
+
+    sharpe = _sharpe_ratio(equities)
+    metrics["sharpe_ratio"] = round(sharpe, 4) if sharpe is not None else None
+
+    mdd, mdd_duration = _max_drawdown(equities)
+    metrics["max_drawdown"] = round(mdd, 4)
+    metrics["max_drawdown_duration"] = mdd_duration
+
+    # ── 거래 기반 지표 ────────────────────────────────
+    sell_trades = [t for t in trades if t.side == "sell"]
+
+    # 매도 거래별 손익 추정 (간이: 동일 종목 buy-sell 매칭)
+    pnl_list = _estimate_trade_pnl(trades)
+
+    winning = [p for p in pnl_list if p > 0]
+    losing = [p for p in pnl_list if p < 0]
+
+    total_trades = len(sell_trades)
+    winning_trades = len(winning)
+    losing_trades = len(losing)
+
+    total_profit = sum(winning) if winning else 0.0
+    total_loss = abs(sum(losing)) if losing else 0.0
+    total_commission = sum(t.commission for t in trades)
+
+    metrics["total_trades"] = total_trades
+    metrics["winning_trades"] = winning_trades
+    metrics["losing_trades"] = losing_trades
+    metrics["win_rate"] = (
+        round(winning_trades / total_trades * 100, 2) if total_trades > 0 else 0.0
+    )
+    metrics["profit_factor"] = (
+        round(total_profit / total_loss, 4)
+        if total_loss > 0
+        else float("inf")
+        if total_profit > 0
+        else 0.0
+    )
+    metrics["avg_profit"] = (
+        round(total_profit / winning_trades, 2) if winning_trades > 0 else 0.0
+    )
+    metrics["avg_loss"] = (
+        round(total_loss / losing_trades, 2) if losing_trades > 0 else 0.0
+    )
+    metrics["total_commission"] = round(total_commission, 2)
+
+    return metrics
+
+
+def _annual_return(equity_curve: list[dict], total_return: float) -> float:
+    """연환산 수익률 계산."""
+    if len(equity_curve) < 2:
+        return total_return
+
+    days = len(equity_curve)
+    if days <= 0:
+        return total_return
+
+    # (1 + r) ^ (252/days) - 1
+    r = total_return / 100
+    if r <= -1:
+        return -100.0
+
+    annual = ((1 + r) ** (252 / days) - 1) * 100
+    return annual
+
+
+def _sharpe_ratio(equities: list[float]) -> float | None:
+    """Sharpe ratio (일간 수익률 기준, 무위험 이자율 0)."""
+    if len(equities) < 2:
+        return None
+
+    daily_returns: list[float] = []
+    for i in range(1, len(equities)):
+        if equities[i - 1] > 0:
+            daily_returns.append((equities[i] - equities[i - 1]) / equities[i - 1])
+
+    if len(daily_returns) < 2:
+        return None
+
+    mean_r = sum(daily_returns) / len(daily_returns)
+    variance = sum((r - mean_r) ** 2 for r in daily_returns) / (len(daily_returns) - 1)
+    std_r = math.sqrt(variance)
+
+    if std_r == 0:
+        return None
+
+    return (mean_r / std_r) * math.sqrt(252)
+
+
+def _max_drawdown(
+    equities: list[float],
+) -> tuple[float, int]:
+    """최대 낙폭(%) 및 MDD 지속 기간(일).
+
+    Returns:
+        (max_drawdown_pct, max_drawdown_duration_days)
+    """
+    if not equities:
+        return 0.0, 0
+
+    peak = equities[0]
+    max_dd = 0.0
+    max_dd_duration = 0
+    current_dd_start = 0
+    in_drawdown = False
+
+    for i, equity in enumerate(equities):
+        if equity >= peak:
+            if in_drawdown:
+                duration = i - current_dd_start
+                if duration > max_dd_duration:
+                    max_dd_duration = duration
+                in_drawdown = False
+            peak = equity
+        else:
+            if not in_drawdown:
+                current_dd_start = i
+                in_drawdown = True
+            dd = (peak - equity) / peak * 100 if peak > 0 else 0.0
+            if dd > max_dd:
+                max_dd = dd
+
+    # 끝까지 drawdown 상태인 경우
+    if in_drawdown:
+        duration = len(equities) - current_dd_start
+        if duration > max_dd_duration:
+            max_dd_duration = duration
+
+    return max_dd, max_dd_duration
+
+
+def _estimate_trade_pnl(trades: list[Any]) -> list[float]:
+    """거래 리스트에서 매도별 손익을 추정.
+
+    FIFO 방식: 종목별 buy 평균 단가 → sell 시 손익 계산.
+    """
+    # 종목별 buy 평균 단가 추적
+    positions: dict[str, dict[str, float]] = {}
+    pnl_list: list[float] = []
+
+    for trade in trades:
+        symbol = trade.symbol
+        if trade.side == "buy":
+            if symbol not in positions:
+                positions[symbol] = {"quantity": 0, "total_cost": 0.0}
+            pos = positions[symbol]
+            pos["quantity"] += trade.quantity
+            pos["total_cost"] += trade.price * trade.quantity
+        elif trade.side == "sell":
+            pos = positions.get(symbol)
+            if pos and pos["quantity"] > 0:
+                avg_cost = pos["total_cost"] / pos["quantity"]
+                pnl = (trade.price - avg_cost) * trade.quantity
+                pnl -= trade.commission
+                pnl_list.append(pnl)
+
+                sell_qty = min(trade.quantity, pos["quantity"])
+                pos["total_cost"] -= avg_cost * sell_qty
+                pos["quantity"] -= sell_qty
+                if pos["quantity"] <= 0:
+                    del positions[symbol]
+
+    return pnl_list

--- a/src/ante/backtest/result.py
+++ b/src/ante/backtest/result.py
@@ -46,6 +46,7 @@ class BacktestResult:
             "total_return_pct": round(self.total_return, 2),
             "total_trades": len(self.trades),
             "metrics": self.metrics,
+            "equity_curve": self.equity_curve,
             "trades": [
                 {
                     "timestamp": str(t.timestamp),

--- a/src/ante/cli/commands/backtest.py
+++ b/src/ante/cli/commands/backtest.py
@@ -54,6 +54,8 @@ def run(
         service = BacktestService(data_path=data_path)
         result = asyncio.run(service.run(config))
         result_dict = result.to_dict()
+        metrics = result_dict.get("metrics", {})
+
         fmt.output(
             result_dict,
             "Strategy: {strategy}\n"
@@ -62,6 +64,48 @@ def run(
             "Trades: {total_trades}\n"
             "Final Balance: {final_balance:,.0f}",
         )
+
+        if metrics:
+            metric_rows = _format_metrics(metrics)
+            fmt.table(metric_rows, ["지표", "값"])
+
     except Exception as e:
         fmt.error(str(e), code="BACKTEST_ERROR")
         raise SystemExit(1) from e
+
+
+def _format_metrics(metrics: dict) -> list[dict[str, str]]:
+    """metrics dict를 CLI 테이블 행으로 변환."""
+    labels = {
+        "total_return": ("총 수익률", "%"),
+        "annual_return": ("연환산 수익률", "%"),
+        "sharpe_ratio": ("Sharpe Ratio", ""),
+        "max_drawdown": ("최대 낙폭 (MDD)", "%"),
+        "max_drawdown_duration": ("MDD 지속 기간", "일"),
+        "total_trades": ("총 거래 횟수", ""),
+        "winning_trades": ("승리 거래", ""),
+        "losing_trades": ("패배 거래", ""),
+        "win_rate": ("승률", "%"),
+        "profit_factor": ("Profit Factor", ""),
+        "avg_profit": ("평균 수익", "원"),
+        "avg_loss": ("평균 손실", "원"),
+        "total_commission": ("총 수수료", "원"),
+    }
+    rows = []
+    for key, (label, unit) in labels.items():
+        value = metrics.get(key)
+        if value is None:
+            formatted = "N/A"
+        elif isinstance(value, float):
+            if value == float("inf"):
+                formatted = "∞"
+            else:
+                formatted = f"{value:,.4f}" if unit == "" else f"{value:,.2f}"
+            if unit:
+                formatted += unit
+        else:
+            formatted = str(value)
+            if unit:
+                formatted += unit
+        rows.append({"지표": label, "값": formatted})
+    return rows

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -407,9 +407,12 @@ class TestBacktestExecutor:
             slippage_rate=0.0,
         )
         result = await executor.run()
-        assert result.metrics["total_trades"] == 2
+        assert result.metrics["total_trades"] == 1  # 매도 기준 거래 횟수
         assert result.metrics["buy_trades"] == 1
         assert result.metrics["sell_trades"] == 1
+        assert "sharpe_ratio" in result.metrics
+        assert "max_drawdown" in result.metrics
+        assert "win_rate" in result.metrics
 
     async def test_metrics_empty_for_no_trades(self, data_provider):
         data_provider.reset()

--- a/tests/unit/test_backtest_metrics.py
+++ b/tests/unit/test_backtest_metrics.py
@@ -1,0 +1,366 @@
+"""백테스트 성과 지표 계산 테스트."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+import pytest
+
+from ante.backtest.metrics import (
+    _annual_return,
+    _estimate_trade_pnl,
+    _max_drawdown,
+    _sharpe_ratio,
+    calculate_metrics,
+)
+
+
+@dataclass(frozen=True)
+class FakeTrade:
+    """테스트용 거래 데이터."""
+
+    timestamp: datetime
+    symbol: str
+    side: str
+    quantity: float
+    price: float
+    commission: float
+    slippage: float = 0.0
+    reason: str = ""
+
+
+# ── calculate_metrics 통합 ────────────────────────
+
+
+class TestCalculateMetrics:
+    def test_empty_trades(self):
+        """거래 없으면 기본값."""
+        metrics = calculate_metrics(
+            trades=[],
+            equity_curve=[],
+            initial_balance=10_000_000,
+            final_balance=10_000_000,
+        )
+        assert metrics["total_return"] == 0.0
+        assert metrics["total_trades"] == 0
+        assert metrics["win_rate"] == 0.0
+
+    def test_profitable_trades(self):
+        """수익 거래 지표 계산."""
+        trades = [
+            FakeTrade(
+                datetime(2024, 1, 1),
+                "005930",
+                "buy",
+                10,
+                70000,
+                105,
+            ),
+            FakeTrade(
+                datetime(2024, 1, 10),
+                "005930",
+                "sell",
+                10,
+                75000,
+                112.5,
+            ),
+        ]
+        equity_curve = [
+            {"timestamp": "2024-01-01", "equity": 10_000_000},
+            {"timestamp": "2024-01-10", "equity": 10_049_782},
+        ]
+
+        metrics = calculate_metrics(
+            trades=trades,
+            equity_curve=equity_curve,
+            initial_balance=10_000_000,
+            final_balance=10_049_782,
+        )
+
+        assert metrics["total_trades"] == 1  # sell 1건
+        assert metrics["winning_trades"] == 1
+        assert metrics["losing_trades"] == 0
+        assert metrics["win_rate"] == 100.0
+        assert metrics["total_return"] > 0
+        assert metrics["total_commission"] > 0
+
+    def test_losing_trades(self):
+        """손실 거래 지표."""
+        trades = [
+            FakeTrade(
+                datetime(2024, 1, 1),
+                "005930",
+                "buy",
+                10,
+                70000,
+                105,
+            ),
+            FakeTrade(
+                datetime(2024, 1, 10),
+                "005930",
+                "sell",
+                10,
+                65000,
+                97.5,
+            ),
+        ]
+        equity_curve = [
+            {"timestamp": "2024-01-01", "equity": 10_000_000},
+            {"timestamp": "2024-01-10", "equity": 9_949_797},
+        ]
+
+        metrics = calculate_metrics(
+            trades=trades,
+            equity_curve=equity_curve,
+            initial_balance=10_000_000,
+            final_balance=9_949_797,
+        )
+
+        assert metrics["total_trades"] == 1
+        assert metrics["winning_trades"] == 0
+        assert metrics["losing_trades"] == 1
+        assert metrics["win_rate"] == 0.0
+        assert metrics["total_return"] < 0
+
+    def test_mixed_trades(self):
+        """승패 혼합 거래."""
+        trades = [
+            FakeTrade(datetime(2024, 1, 1), "A", "buy", 10, 100, 1.5),
+            FakeTrade(datetime(2024, 1, 5), "A", "sell", 10, 110, 1.65),
+            FakeTrade(datetime(2024, 1, 10), "B", "buy", 10, 200, 3.0),
+            FakeTrade(datetime(2024, 1, 15), "B", "sell", 10, 190, 2.85),
+        ]
+        equity_curve = [
+            {"timestamp": "2024-01-01", "equity": 10000},
+            {"timestamp": "2024-01-05", "equity": 10097},
+            {"timestamp": "2024-01-10", "equity": 10097},
+            {"timestamp": "2024-01-15", "equity": 9991},
+        ]
+
+        metrics = calculate_metrics(
+            trades=trades,
+            equity_curve=equity_curve,
+            initial_balance=10000,
+            final_balance=9991,
+        )
+
+        assert metrics["total_trades"] == 2
+        assert metrics["winning_trades"] == 1
+        assert metrics["losing_trades"] == 1
+        assert metrics["win_rate"] == 50.0
+        assert metrics["profit_factor"] > 0
+
+    def test_profit_factor_no_loss(self):
+        """손실 없을 때 profit_factor = inf."""
+        trades = [
+            FakeTrade(datetime(2024, 1, 1), "A", "buy", 10, 100, 0),
+            FakeTrade(datetime(2024, 1, 5), "A", "sell", 10, 110, 0),
+        ]
+        equity_curve = [
+            {"timestamp": "2024-01-01", "equity": 10000},
+            {"timestamp": "2024-01-05", "equity": 10100},
+        ]
+
+        metrics = calculate_metrics(
+            trades=trades,
+            equity_curve=equity_curve,
+            initial_balance=10000,
+            final_balance=10100,
+        )
+
+        assert metrics["profit_factor"] == float("inf")
+
+
+# ── Sharpe Ratio ────────────────────────────────
+
+
+class TestSharpeRatio:
+    def test_insufficient_data(self):
+        """데이터 부족 시 None."""
+        assert _sharpe_ratio([100]) is None
+        assert _sharpe_ratio([]) is None
+
+    def test_constant_equity(self):
+        """변동 없으면 None (std=0)."""
+        assert _sharpe_ratio([100, 100, 100]) is None
+
+    def test_positive_returns(self):
+        """양의 수익률."""
+        # 매일 1% 상승
+        equities = [100 * (1.01**i) for i in range(30)]
+        sharpe = _sharpe_ratio(equities)
+        assert sharpe is not None
+        assert sharpe > 0
+
+    def test_volatile_returns(self):
+        """변동성 높은 수익률 → 낮은 Sharpe."""
+        equities = []
+        v = 100.0
+        for i in range(30):
+            v *= 1.02 if i % 2 == 0 else 0.98
+            equities.append(v)
+        sharpe = _sharpe_ratio(equities)
+        assert sharpe is not None
+
+
+# ── Maximum Drawdown ────────────────────────────
+
+
+class TestMaxDrawdown:
+    def test_no_drawdown(self):
+        """항상 상승 → MDD=0."""
+        equities = [100, 110, 120, 130]
+        mdd, duration = _max_drawdown(equities)
+        assert mdd == 0.0
+        assert duration == 0
+
+    def test_simple_drawdown(self):
+        """단순 하락 → MDD 계산."""
+        equities = [100, 110, 100, 95, 105]
+        mdd, duration = _max_drawdown(equities)
+        # peak=110, lowest=95, dd = (110-95)/110 * 100 = 13.636%
+        assert abs(mdd - 13.6364) < 0.1
+        assert duration > 0
+
+    def test_empty_equities(self):
+        """빈 리스트."""
+        mdd, duration = _max_drawdown([])
+        assert mdd == 0.0
+        assert duration == 0
+
+    def test_drawdown_at_end(self):
+        """끝까지 하락 상태."""
+        equities = [100, 110, 105, 100, 90]
+        mdd, duration = _max_drawdown(equities)
+        # peak=110, lowest=90, dd = 18.18%
+        assert mdd > 18.0
+        assert duration > 0
+
+
+# ── Annual Return ──────────────────────────────
+
+
+class TestAnnualReturn:
+    def test_short_period(self):
+        """데이터 부족 시 total_return 반환."""
+        result = _annual_return([{"equity": 100}], 10.0)
+        assert result == 10.0
+
+    def test_one_year(self):
+        """252일 (1년) → annual_return ≈ total_return."""
+        curve = [{"equity": 100 + i} for i in range(252)]
+        result = _annual_return(curve, 10.0)
+        assert abs(result - 10.0) < 0.5
+
+
+# ── Trade PnL Estimation ──────────────────────
+
+
+class TestEstimateTradePnl:
+    def test_profitable_trade(self):
+        """수익 거래 PnL."""
+        trades = [
+            FakeTrade(datetime(2024, 1, 1), "A", "buy", 10, 100, 0),
+            FakeTrade(datetime(2024, 1, 5), "A", "sell", 10, 110, 1.0),
+        ]
+        pnl = _estimate_trade_pnl(trades)
+        assert len(pnl) == 1
+        # (110 - 100) * 10 - 1.0 = 99.0
+        assert pnl[0] == pytest.approx(99.0)
+
+    def test_losing_trade(self):
+        """손실 거래 PnL."""
+        trades = [
+            FakeTrade(datetime(2024, 1, 1), "A", "buy", 10, 100, 0),
+            FakeTrade(datetime(2024, 1, 5), "A", "sell", 10, 90, 1.0),
+        ]
+        pnl = _estimate_trade_pnl(trades)
+        assert len(pnl) == 1
+        # (90 - 100) * 10 - 1.0 = -101.0
+        assert pnl[0] == pytest.approx(-101.0)
+
+    def test_no_sell_trades(self):
+        """매도 없으면 빈 리스트."""
+        trades = [
+            FakeTrade(datetime(2024, 1, 1), "A", "buy", 10, 100, 0),
+        ]
+        pnl = _estimate_trade_pnl(trades)
+        assert pnl == []
+
+    def test_multiple_symbols(self):
+        """다종목 거래."""
+        trades = [
+            FakeTrade(datetime(2024, 1, 1), "A", "buy", 10, 100, 0),
+            FakeTrade(datetime(2024, 1, 2), "B", "buy", 5, 200, 0),
+            FakeTrade(datetime(2024, 1, 3), "A", "sell", 10, 110, 0),
+            FakeTrade(datetime(2024, 1, 4), "B", "sell", 5, 190, 0),
+        ]
+        pnl = _estimate_trade_pnl(trades)
+        assert len(pnl) == 2
+        assert pnl[0] == pytest.approx(100.0)  # A: (110-100)*10
+        assert pnl[1] == pytest.approx(-50.0)  # B: (190-200)*5
+
+
+# ── CLI 지표 표시 ──────────────────────────────
+
+
+class TestCLIFormatMetrics:
+    def test_format_metrics_function_exists(self):
+        """_format_metrics 함수 존재 확인."""
+        from ante.cli.commands.backtest import _format_metrics
+
+        metrics = {
+            "total_return": 10.5,
+            "sharpe_ratio": 1.23,
+            "max_drawdown": 5.0,
+            "total_trades": 20,
+            "win_rate": 60.0,
+        }
+        rows = _format_metrics(metrics)
+        assert isinstance(rows, list)
+        assert len(rows) > 0
+        assert all("지표" in r and "값" in r for r in rows)
+
+    def test_format_none_value(self):
+        """None 값은 N/A로 표시."""
+        from ante.cli.commands.backtest import _format_metrics
+
+        metrics = {"sharpe_ratio": None}
+        rows = _format_metrics(metrics)
+        sharpe_row = [r for r in rows if r["지표"] == "Sharpe Ratio"][0]
+        assert sharpe_row["값"] == "N/A"
+
+    def test_format_inf_value(self):
+        """inf 값은 ∞로 표시."""
+        from ante.cli.commands.backtest import _format_metrics
+
+        metrics = {"profit_factor": float("inf")}
+        rows = _format_metrics(metrics)
+        pf_row = [r for r in rows if r["지표"] == "Profit Factor"][0]
+        assert pf_row["값"] == "∞"
+
+
+# ── BacktestResult.to_dict ──────────────────────
+
+
+class TestBacktestResultToDict:
+    def test_to_dict_includes_equity_curve(self):
+        """to_dict에 equity_curve 포함."""
+        from ante.backtest.result import BacktestResult
+
+        result = BacktestResult(
+            strategy_name="test",
+            strategy_version="1.0",
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+            initial_balance=10_000_000,
+            final_balance=10_500_000,
+            total_return=5.0,
+            equity_curve=[{"timestamp": "2024-01-01", "equity": 10_000_000}],
+            metrics={"total_return": 5.0},
+        )
+        d = result.to_dict()
+        assert "equity_curve" in d
+        assert len(d["equity_curve"]) == 1
+        assert "metrics" in d


### PR DESCRIPTION
## Summary
- **US-1**: `backtest/metrics.py` 신규 모듈 — `calculate_metrics()`로 13종 성과 지표 자동 산출 (Sharpe ratio, MDD, MDD 지속기간, 연환산수익률, 승률, profit factor, 평균수익/손실 등). FIFO 기반 매도별 PnL 추정. `BacktestExecutor`에서 자동 호출, `BacktestResult.to_dict()`에 equity_curve 포함
- **US-2**: CLI `ante backtest run` 결과에 성과 지표 테이블 표시. None→N/A, inf→∞ 포맷팅. `--format json` 시 전체 metrics dict 포함

Closes #58

## Test plan
- [x] 빈 거래 기본값 (1 test)
- [x] 수익/손실/혼합 거래 지표 계산 (3 tests)
- [x] profit_factor 무손실 시 inf (1 test)
- [x] Sharpe ratio: 데이터 부족, 무변동, 양/음 수익률 (4 tests)
- [x] MDD: 무하락, 단순하락, 빈 데이터, 끝까지 하락 (4 tests)
- [x] 연환산 수익률 (2 tests)
- [x] FIFO PnL 추정: 수익/손실/매도없음/다종목 (4 tests)
- [x] CLI _format_metrics, None→N/A, inf→∞ (3 tests)
- [x] BacktestResult.to_dict equity_curve 포함 (1 test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)