### PR TITLE
feat: RFC 7807 에러 응답 표준화

### DIFF
--- a/src/ante/web/app.py
+++ b/src/ante/web/app.py
@@ -42,4 +42,8 @@ def create_app(**services: Any) -> FastAPI:
     app.include_router(report_router, prefix="/api/reports", tags=["reports"])
     app.include_router(data_router, prefix="/api/data", tags=["data"])
 
+    from ante.web.errors import register_exception_handlers
+
+    register_exception_handlers(app)
+
     return app

--- a/src/ante/web/errors.py
+++ b/src/ante/web/errors.py
@@ -1,0 +1,103 @@
+"""RFC 7807 에러 처리 — exception handler 및 에러 유형 카탈로그."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from ante.web.schemas import ErrorResponse
+
+logger = logging.getLogger(__name__)
+
+# 에러 유형 카탈로그: HTTP 상태 코드 → (type URI, default title)
+ERROR_CATALOG: dict[int, tuple[str, str]] = {
+    400: ("/errors/validation", "Bad Request"),
+    401: ("/errors/unauthorized", "Unauthorized"),
+    403: ("/errors/forbidden", "Forbidden"),
+    404: ("/errors/not-found", "Not Found"),
+    409: ("/errors/conflict", "Conflict"),
+    422: ("/errors/validation", "Validation Error"),
+    500: ("/errors/internal", "Internal Server Error"),
+    503: ("/errors/internal", "Service Unavailable"),
+}
+
+PROBLEM_JSON = "application/problem+json"
+
+
+def _build_error(status: int, detail: str, instance: str = "") -> ErrorResponse:
+    """상태 코드에 맞는 RFC 7807 에러 응답 생성."""
+    error_type, title = ERROR_CATALOG.get(status, ("/errors/internal", "Error"))
+    return ErrorResponse(
+        type=error_type,
+        title=title,
+        detail=detail,
+        status=status,
+        instance=instance,
+    )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """FastAPI 앱에 RFC 7807 exception handler 등록."""
+
+    @app.exception_handler(StarletteHTTPException)
+    async def http_exception_handler(
+        request: Request, exc: StarletteHTTPException
+    ) -> JSONResponse:
+        error = _build_error(
+            status=exc.status_code,
+            detail=str(exc.detail),
+            instance=request.url.path,
+        )
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=error.model_dump(),
+            media_type=PROBLEM_JSON,
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(
+        request: Request, exc: RequestValidationError
+    ) -> JSONResponse:
+        error = _build_error(
+            status=422,
+            detail=str(exc.errors()),
+            instance=request.url.path,
+        )
+        return JSONResponse(
+            status_code=422,
+            content=error.model_dump(),
+            media_type=PROBLEM_JSON,
+        )
+
+    @app.exception_handler(ValueError)
+    async def value_error_handler(request: Request, exc: ValueError) -> JSONResponse:
+        error = _build_error(
+            status=400,
+            detail=str(exc),
+            instance=request.url.path,
+        )
+        return JSONResponse(
+            status_code=400,
+            content=error.model_dump(),
+            media_type=PROBLEM_JSON,
+        )
+
+    @app.exception_handler(Exception)
+    async def unhandled_exception_handler(
+        request: Request, exc: Exception
+    ) -> JSONResponse:
+        logger.exception("처리되지 않은 예외: %s", request.url.path)
+        error = _build_error(
+            status=500,
+            detail="An unexpected error occurred.",
+            instance=request.url.path,
+        )
+        return JSONResponse(
+            status_code=500,
+            content=error.model_dump(),
+            media_type=PROBLEM_JSON,
+        )

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -13,10 +13,13 @@ class StatusResponse(BaseModel):
 
 
 class ErrorResponse(BaseModel):
-    """에러 응답."""
+    """RFC 7807 Problem Details 에러 응답."""
 
-    detail: str
-    code: str = ""
+    type: str = "/errors/internal"
+    title: str = "Internal Server Error"
+    detail: str = ""
+    status: int = 500
+    instance: str = ""
 
 
 class ReportSubmitRequest(BaseModel):

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -80,6 +80,9 @@ class TestStrategy(Strategy):
             json={},
         )
         assert resp.status_code == 400
+        data = resp.json()
+        assert data["type"] == "/errors/validation"
+        assert data["status"] == 400
 
     def test_validate_nonexistent_file(self, client):
         resp = client.post(
@@ -87,6 +90,9 @@ class TestStrategy(Strategy):
             json={"path": "/nonexistent.py"},
         )
         assert resp.status_code == 404
+        data = resp.json()
+        assert data["type"] == "/errors/not-found"
+        assert data["status"] == 404
 
 
 # ── Data 라우트 테스트 ────────────────────────────
@@ -151,10 +157,96 @@ class TestReportRoutes:
     def test_list_no_store(self, client):
         resp = client.get("/api/reports")
         assert resp.status_code == 503
+        data = resp.json()
+        assert data["type"] == "/errors/internal"
+        assert data["status"] == 503
 
     def test_submit_no_store(self, client):
         resp = client.post("/api/reports", json={"test": True})
         assert resp.status_code == 503
+        data = resp.json()
+        assert data["type"] == "/errors/internal"
+
+
+# ── RFC 7807 에러 응답 테스트 ────────────────────────
+
+
+class TestRFC7807ErrorResponse:
+    def test_404_returns_problem_json(self, client):
+        resp = client.get("/api/nonexistent")
+        assert resp.status_code == 404
+        assert resp.headers["content-type"] == "application/problem+json"
+        data = resp.json()
+        assert data["type"] == "/errors/not-found"
+        assert data["title"] == "Not Found"
+        assert data["status"] == 404
+        assert data["instance"] == "/api/nonexistent"
+
+    def test_http_exception_returns_rfc7807(self, client):
+        resp = client.post("/api/strategies/validate", json={})
+        assert resp.status_code == 400
+        assert resp.headers["content-type"] == "application/problem+json"
+        data = resp.json()
+        assert data["type"] == "/errors/validation"
+        assert data["title"] == "Bad Request"
+        assert data["status"] == 400
+        assert "detail" in data
+        assert "instance" in data
+
+    def test_503_returns_rfc7807(self, client):
+        resp = client.get("/api/reports")
+        assert resp.status_code == 503
+        assert resp.headers["content-type"] == "application/problem+json"
+        data = resp.json()
+        assert data["status"] == 503
+
+    def test_error_response_schema(self):
+        from ante.web.schemas import ErrorResponse
+
+        error = ErrorResponse(
+            type="/errors/not-found",
+            title="Not Found",
+            detail="Bot xyz not found",
+            status=404,
+            instance="/api/bots/xyz",
+        )
+        d = error.model_dump()
+        assert d["type"] == "/errors/not-found"
+        assert d["title"] == "Not Found"
+        assert d["detail"] == "Bot xyz not found"
+        assert d["status"] == 404
+        assert d["instance"] == "/api/bots/xyz"
+
+    def test_error_catalog_coverage(self):
+        from ante.web.errors import ERROR_CATALOG
+
+        required_types = {
+            "/errors/not-found",
+            "/errors/validation",
+            "/errors/unauthorized",
+            "/errors/forbidden",
+            "/errors/conflict",
+            "/errors/internal",
+        }
+        actual_types = {t for t, _ in ERROR_CATALOG.values()}
+        assert required_types == actual_types
+
+    def test_value_error_returns_400(self, app, client):
+        from fastapi import APIRouter
+
+        test_router = APIRouter()
+
+        @test_router.get("/test-value-error")
+        async def raise_value_error():
+            raise ValueError("invalid input")
+
+        app.include_router(test_router, prefix="/api")
+        resp = client.get("/api/test-value-error")
+        assert resp.status_code == 400
+        assert resp.headers["content-type"] == "application/problem+json"
+        data = resp.json()
+        assert data["type"] == "/errors/validation"
+        assert data["detail"] == "invalid input"
 
 
 # ── App Factory 테스트 ────────────────────────────


### PR DESCRIPTION
## Summary
- `ErrorResponse` 스키마를 RFC 7807 Problem Details 형식으로 확장 (type, title, detail, status, instance)
- 6가지 에러 유형 카탈로그 정의 (not-found, validation, unauthorized, forbidden, conflict, internal)
- FastAPI exception handler로 모든 예외를 `application/problem+json` 형식으로 변환

## Test plan
- [x] 404/400/503 에러 응답이 RFC 7807 형식인지 검증
- [x] Content-Type이 `application/problem+json`인지 검증
- [x] 에러 카탈로그 커버리지 검증
- [x] ValueError → 400 변환 검증
- [x] 기존 24개 테스트 + 신규 6개 = 전체 811개 테스트 통과

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)