### PR TITLE
feat: CLI 라이브 커맨드 (system/bot/trade/treasury/rule/broker)

### DIFF
--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -1,0 +1,240 @@
+"""ante bot — 봇 생명주기 관리 커맨드."""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+from ante.cli.main import get_formatter
+from ante.cli.middleware import require_auth, require_scope
+
+
+@click.group()
+def bot() -> None:
+    """봇 생성·시작·중지·조회."""
+
+
+def _run(coro):  # noqa: ANN001, ANN202
+    return asyncio.run(coro)
+
+
+async def _create_services():  # noqa: ANN202
+    from ante.bot.manager import BotManager
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+    db = Database("db/ante.db")
+    await db.connect()
+    eventbus = EventBus()
+    manager = BotManager(eventbus=eventbus, db=db)
+    await manager.initialize()
+    return db, eventbus, manager
+
+
+@bot.command("list")
+@click.pass_context
+@require_auth
+@require_scope("bot:read")
+def bot_list(ctx: click.Context) -> None:
+    """봇 목록 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _run_list() -> list[dict]:
+        db, _, _ = await _create_services()
+        try:
+            rows = await db.fetch_all(
+                "SELECT bot_id, strategy_id, bot_type, status, created_at FROM bots"
+            )
+            return [dict(r) for r in rows]
+        finally:
+            await db.close()
+
+    result = _run(_run_list())
+
+    if not result:
+        fmt.output({"message": "등록된 봇이 없습니다.", "bots": []})
+        return
+
+    if fmt.is_json:
+        fmt.output({"bots": result})
+    else:
+        fmt.table(
+            result,
+            ["bot_id", "strategy_id", "bot_type", "status", "created_at"],
+        )
+
+
+@bot.command("info")
+@click.argument("bot_id")
+@click.pass_context
+@require_auth
+@require_scope("bot:read")
+def bot_info(ctx: click.Context, bot_id: str) -> None:
+    """봇 상세 정보 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _run_info() -> dict | None:
+        db, _, _ = await _create_services()
+        try:
+            row = await db.fetch_one("SELECT * FROM bots WHERE bot_id = ?", (bot_id,))
+            return dict(row) if row else None
+        finally:
+            await db.close()
+
+    result = _run(_run_info())
+
+    if not result:
+        fmt.error(f"봇을 찾을 수 없습니다: {bot_id}")
+        return
+
+    if fmt.is_json:
+        fmt.output(result)
+    else:
+        click.echo(f"  Bot ID    : {result['bot_id']}")
+        click.echo(f"  전략      : {result['strategy_id']}")
+        click.echo(f"  타입      : {result['bot_type']}")
+        click.echo(f"  상태      : {result['status']}")
+        click.echo(f"  생성일    : {result['created_at']}")
+
+
+@bot.command("create")
+@click.option("--strategy", required=True, help="전략 ID")
+@click.option(
+    "--type",
+    "bot_type",
+    type=click.Choice(["live", "paper"]),
+    default="live",
+    help="봇 타입",
+)
+@click.option("--interval", default=60, help="실행 주기 (초)")
+@click.option("--symbols", default="", help="대상 종목 (쉼표 구분)")
+@click.option("--id", "bot_id", default="", help="봇 ID (미지정 시 자동 생성)")
+@click.pass_context
+@require_auth
+@require_scope("bot:admin")
+def bot_create(
+    ctx: click.Context,
+    strategy: str,
+    bot_type: str,
+    interval: int,
+    symbols: str,
+    bot_id: str,
+) -> None:
+    """봇 생성."""
+    fmt = get_formatter(ctx)
+
+    async def _run_create() -> dict:
+        import json
+        from uuid import uuid4
+
+        db, _, _ = await _create_services()
+        try:
+            bid = bot_id or f"bot-{uuid4().hex[:8]}"
+            symbol_list = [s.strip() for s in symbols.split(",") if s.strip()] or None
+            config_dict = {
+                "bot_id": bid,
+                "strategy_id": strategy,
+                "bot_type": bot_type,
+                "interval_seconds": interval,
+                "symbols": symbol_list,
+            }
+            await db.execute(
+                """INSERT INTO bots (bot_id, strategy_id, bot_type, config_json)
+                   VALUES (?, ?, ?, ?)""",
+                (bid, strategy, bot_type, json.dumps(config_dict)),
+            )
+            return config_dict
+        finally:
+            await db.close()
+
+    try:
+        result = _run(_run_create())
+    except Exception as e:
+        fmt.error(str(e))
+        return
+
+    fmt.success(f"봇 생성 완료: {result['bot_id']}", result)
+
+
+@bot.command("remove")
+@click.argument("bot_id")
+@click.confirmation_option(prompt="봇을 삭제합니다. 계속하시겠습니까?")
+@click.pass_context
+@require_auth
+@require_scope("bot:admin")
+def bot_remove(ctx: click.Context, bot_id: str) -> None:
+    """봇 삭제."""
+    fmt = get_formatter(ctx)
+
+    async def _run_remove() -> bool:
+        db, _, _ = await _create_services()
+        try:
+            row = await db.fetch_one(
+                "SELECT bot_id FROM bots WHERE bot_id = ?", (bot_id,)
+            )
+            if not row:
+                return False
+            await db.execute("DELETE FROM bots WHERE bot_id = ?", (bot_id,))
+            return True
+        finally:
+            await db.close()
+
+    if not _run(_run_remove()):
+        fmt.error(f"봇을 찾을 수 없습니다: {bot_id}")
+        return
+
+    fmt.success(f"봇 삭제 완료: {bot_id}")
+
+
+@bot.command("positions")
+@click.argument("bot_id")
+@click.pass_context
+@require_auth
+@require_scope("bot:read")
+def bot_positions(ctx: click.Context, bot_id: str) -> None:
+    """봇 보유 포지션 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _run_positions() -> list[dict]:
+        from ante.core.database import Database
+        from ante.eventbus.bus import EventBus
+        from ante.trade.performance import PerformanceTracker
+        from ante.trade.position import PositionHistory
+        from ante.trade.recorder import TradeRecorder
+        from ante.trade.service import TradeService
+
+        db = Database("db/ante.db")
+        await db.connect()
+        try:
+            eventbus = EventBus()
+            recorder = TradeRecorder(db, eventbus)
+            await recorder.initialize()
+            position_history = PositionHistory(db, eventbus)
+            await position_history.initialize()
+            performance = PerformanceTracker(db)
+            await performance.initialize()
+            service = TradeService(recorder, position_history, performance)
+            positions = await service.get_positions(bot_id)
+            return [
+                {
+                    "symbol": p.symbol,
+                    "quantity": p.quantity,
+                    "avg_entry_price": p.avg_entry_price,
+                    "realized_pnl": p.realized_pnl,
+                }
+                for p in positions
+            ]
+        finally:
+            await db.close()
+
+    result = _run(_run_positions())
+
+    if not result:
+        fmt.output({"message": "보유 포지션 없음", "positions": []})
+        return
+
+    if fmt.is_json:
+        fmt.output({"positions": result})
+    else:
+        fmt.table(result, ["symbol", "quantity", "avg_entry_price", "realized_pnl"])

--- a/src/ante/cli/commands/broker.py
+++ b/src/ante/cli/commands/broker.py
@@ -1,0 +1,221 @@
+"""ante broker — 증권사 계좌 조회 커맨드."""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+from ante.cli.main import get_formatter
+from ante.cli.middleware import require_auth, require_scope
+
+
+@click.group()
+def broker() -> None:
+    """증권사 계좌 정보 조회."""
+
+
+def _run(coro):  # noqa: ANN001, ANN202
+    return asyncio.run(coro)
+
+
+async def _create_broker():  # noqa: ANN202
+    from ante.config.config import Config
+
+    config = Config.load()
+    broker_config = config.get("broker") or {}
+    if not isinstance(broker_config, dict):
+        broker_config = {}
+    broker_type = broker_config.get("type", "kis")
+
+    if broker_type == "kis":
+        from ante.broker.kis import KISAdapter
+
+        adapter = KISAdapter(broker_config)
+        await adapter.connect()
+        return adapter
+    else:
+        msg = f"지원하지 않는 브로커: {broker_type}"
+        raise ValueError(msg)
+
+
+@broker.command()
+@click.pass_context
+@require_auth
+@require_scope("broker:read")
+def status(ctx: click.Context) -> None:
+    """증권사 연결 상태 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _run_status() -> dict:
+        try:
+            adapter = await _create_broker()
+            healthy = await adapter.health_check()
+            return {
+                "connected": adapter.is_connected,
+                "healthy": healthy,
+                "exchange": adapter.exchange,
+            }
+        except Exception as e:
+            return {
+                "connected": False,
+                "healthy": False,
+                "error": str(e),
+            }
+
+    result = _run(_run_status())
+
+    if fmt.is_json:
+        fmt.output(result)
+    else:
+        click.echo(
+            f"  연결 상태  : {'연결됨' if result.get('connected') else '미연결'}"
+        )
+        click.echo(f"  건강 상태  : {'정상' if result.get('healthy') else '이상'}")
+        if result.get("exchange"):
+            click.echo(f"  거래소     : {result['exchange']}")
+        if result.get("error"):
+            click.echo(f"  오류       : {result['error']}")
+
+
+@broker.command()
+@click.pass_context
+@require_auth
+@require_scope("broker:read")
+def balance(ctx: click.Context) -> None:
+    """증권사 계좌 잔고 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _run_balance() -> dict:
+        adapter = await _create_broker()
+        try:
+            return await adapter.get_account_balance()
+        finally:
+            await adapter.disconnect()
+
+    try:
+        result = _run(_run_balance())
+    except Exception as e:
+        fmt.error(str(e))
+        return
+
+    if fmt.is_json:
+        fmt.output(result)
+    else:
+        for key, value in result.items():
+            if isinstance(value, float):
+                click.echo(f"  {key:20s}: {value:>15,.0f}")
+            else:
+                click.echo(f"  {key:20s}: {value}")
+
+
+@broker.command()
+@click.pass_context
+@require_auth
+@require_scope("broker:read")
+def positions(ctx: click.Context) -> None:
+    """증권사 보유 종목 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _run_positions() -> list[dict]:
+        adapter = await _create_broker()
+        try:
+            return await adapter.get_positions()
+        finally:
+            await adapter.disconnect()
+
+    try:
+        result = _run(_run_positions())
+    except Exception as e:
+        fmt.error(str(e))
+        return
+
+    if not result:
+        fmt.output({"message": "보유 종목 없음", "positions": []})
+        return
+
+    if fmt.is_json:
+        fmt.output({"positions": result})
+    else:
+        columns = ["symbol", "quantity", "avg_price", "eval_amount"]
+        fmt.table(result, columns)
+
+
+@broker.command()
+@click.pass_context
+@require_auth
+@require_scope("broker:read")
+def reconcile(ctx: click.Context) -> None:
+    """내부 데이터와 증권사 데이터 대사."""
+    fmt = get_formatter(ctx)
+
+    async def _run_reconcile() -> dict:
+        from ante.core.database import Database
+        from ante.eventbus.bus import EventBus
+        from ante.trade.performance import PerformanceTracker
+        from ante.trade.position import PositionHistory
+        from ante.trade.recorder import TradeRecorder
+        from ante.trade.service import TradeService
+
+        adapter = await _create_broker()
+        db = Database("db/ante.db")
+        await db.connect()
+        try:
+            eventbus = EventBus()
+            recorder = TradeRecorder(db, eventbus)
+            await recorder.initialize()
+            position_history = PositionHistory(db, eventbus)
+            await position_history.initialize()
+            performance = PerformanceTracker(db)
+            await performance.initialize()
+            trade_service = TradeService(recorder, position_history, performance)
+
+            broker_positions = await adapter.get_account_positions()
+            internal_positions = await trade_service.get_all_positions()
+
+            broker_map = {p["symbol"]: p for p in broker_positions}
+            internal_map = {p.symbol: p for p in internal_positions}
+
+            all_symbols = set(broker_map.keys()) | set(internal_map.keys())
+            discrepancies = []
+            for symbol in sorted(all_symbols):
+                bp = broker_map.get(symbol)
+                ip = internal_map.get(symbol)
+                broker_qty = float(bp.get("quantity", 0)) if bp else 0.0
+                internal_qty = ip.quantity if ip else 0.0
+                if broker_qty != internal_qty:
+                    discrepancies.append(
+                        {
+                            "symbol": symbol,
+                            "broker_qty": broker_qty,
+                            "internal_qty": internal_qty,
+                            "diff": broker_qty - internal_qty,
+                        }
+                    )
+
+            return {
+                "total_symbols": len(all_symbols),
+                "discrepancies": discrepancies,
+                "match": len(discrepancies) == 0,
+            }
+        finally:
+            await adapter.disconnect()
+            await db.close()
+
+    try:
+        result = _run(_run_reconcile())
+    except Exception as e:
+        fmt.error(str(e))
+        return
+
+    if fmt.is_json:
+        fmt.output(result)
+    else:
+        click.echo(f"  총 종목 수     : {result['total_symbols']}")
+        click.echo(f"  대사 결과      : {'일치' if result['match'] else '불일치'}")
+        if result["discrepancies"]:
+            click.echo("  불일치 종목:")
+            fmt.table(
+                result["discrepancies"],
+                ["symbol", "broker_qty", "internal_qty", "diff"],
+            )

--- a/src/ante/cli/commands/rule.py
+++ b/src/ante/cli/commands/rule.py
@@ -1,0 +1,231 @@
+"""ante rule — 거래 룰 조회/관리 커맨드."""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+from ante.cli.main import get_formatter
+from ante.cli.middleware import require_auth, require_scope
+
+
+@click.group()
+def rule() -> None:
+    """거래 룰 조회·관리."""
+
+
+def _run(coro):  # noqa: ANN001, ANN202
+    return asyncio.run(coro)
+
+
+async def _create_rule_engine():  # noqa: ANN202
+    from ante.config.system_state import SystemState
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+    from ante.rule.engine import RuleEngine
+
+    db = Database("db/ante.db")
+    await db.connect()
+    eventbus = EventBus()
+    system_state = SystemState(db, eventbus)
+    await system_state.initialize()
+    engine = RuleEngine(eventbus, system_state)
+    return engine, db
+
+
+def _load_rules_from_config(engine) -> None:  # noqa: ANN001
+    """설정 파일에서 룰을 로딩."""
+    from ante.config.config import Config
+
+    config = Config.load()
+    global_rules = config.get("rules.global")
+    if isinstance(global_rules, list):
+        engine.load_rules_from_config(global_rules)
+
+    strategy_rules = config.get("rules.strategy")
+    if isinstance(strategy_rules, dict):
+        for strategy_id, rules in strategy_rules.items():
+            engine.load_strategy_rules_from_config(strategy_id, rules)
+
+
+def _collect_rules(engine) -> list[dict]:  # noqa: ANN001
+    """엔진에서 전체 룰 목록 수집."""
+    rules = []
+    for r in engine._global_rules:
+        rules.append(
+            {
+                "rule_id": r.rule_id,
+                "name": r.name,
+                "scope": "global",
+                "enabled": r.enabled,
+                "priority": r.priority,
+                "description": r.description,
+            }
+        )
+    for strategy_id, strategy_rules in engine._strategy_rules.items():
+        for r in strategy_rules:
+            rules.append(
+                {
+                    "rule_id": r.rule_id,
+                    "name": r.name,
+                    "scope": f"strategy:{strategy_id}",
+                    "enabled": r.enabled,
+                    "priority": r.priority,
+                    "description": r.description,
+                }
+            )
+    return rules
+
+
+@rule.command("list")
+@click.option(
+    "--scope",
+    "scope_filter",
+    type=click.Choice(["global", "strategy"]),
+    default=None,
+    help="룰 범위 필터",
+)
+@click.pass_context
+@require_auth
+@require_scope("rule:read")
+def rule_list(ctx: click.Context, scope_filter: str | None) -> None:
+    """룰 목록 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _run_list() -> list[dict]:
+        engine, db = await _create_rule_engine()
+        try:
+            try:
+                _load_rules_from_config(engine)
+            except Exception:
+                pass
+            rules = _collect_rules(engine)
+            if scope_filter:
+                rules = [
+                    r
+                    for r in rules
+                    if (scope_filter == "global" and r["scope"] == "global")
+                    or (
+                        scope_filter == "strategy"
+                        and r["scope"].startswith("strategy:")
+                    )
+                ]
+            return rules
+        finally:
+            await db.close()
+
+    result = _run(_run_list())
+
+    if not result:
+        fmt.output({"message": "등록된 룰이 없습니다.", "rules": []})
+        return
+
+    if fmt.is_json:
+        fmt.output({"rules": result})
+    else:
+        fmt.table(result, ["rule_id", "name", "scope", "enabled", "priority"])
+
+
+@rule.command("info")
+@click.argument("rule_id")
+@click.pass_context
+@require_auth
+@require_scope("rule:read")
+def rule_info(ctx: click.Context, rule_id: str) -> None:
+    """룰 상세 정보 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _run_info() -> dict | None:
+        engine, db = await _create_rule_engine()
+        try:
+            try:
+                _load_rules_from_config(engine)
+            except Exception:
+                pass
+            rules = _collect_rules(engine)
+            return next((r for r in rules if r["rule_id"] == rule_id), None)
+        finally:
+            await db.close()
+
+    result = _run(_run_info())
+
+    if not result:
+        fmt.error(f"룰을 찾을 수 없습니다: {rule_id}")
+        return
+
+    if fmt.is_json:
+        fmt.output(result)
+    else:
+        for key, value in result.items():
+            click.echo(f"  {key:15s}: {value}")
+
+
+@rule.command("enable")
+@click.argument("rule_id")
+@click.pass_context
+@require_auth
+@require_scope("rule:admin")
+def rule_enable(ctx: click.Context, rule_id: str) -> None:
+    """룰 활성화."""
+    fmt = get_formatter(ctx)
+
+    async def _run_enable() -> bool:
+        engine, db = await _create_rule_engine()
+        try:
+            try:
+                _load_rules_from_config(engine)
+            except Exception:
+                pass
+            for r in engine._global_rules:
+                if r.rule_id == rule_id:
+                    r.enabled = True
+                    return True
+            for rules in engine._strategy_rules.values():
+                for r in rules:
+                    if r.rule_id == rule_id:
+                        r.enabled = True
+                        return True
+            return False
+        finally:
+            await db.close()
+
+    if _run(_run_enable()):
+        fmt.success(f"룰 활성화 완료: {rule_id}")
+    else:
+        fmt.error(f"룰을 찾을 수 없습니다: {rule_id}")
+
+
+@rule.command("disable")
+@click.argument("rule_id")
+@click.pass_context
+@require_auth
+@require_scope("rule:admin")
+def rule_disable(ctx: click.Context, rule_id: str) -> None:
+    """룰 비활성화."""
+    fmt = get_formatter(ctx)
+
+    async def _run_disable() -> bool:
+        engine, db = await _create_rule_engine()
+        try:
+            try:
+                _load_rules_from_config(engine)
+            except Exception:
+                pass
+            for r in engine._global_rules:
+                if r.rule_id == rule_id:
+                    r.enabled = False
+                    return True
+            for rules in engine._strategy_rules.values():
+                for r in rules:
+                    if r.rule_id == rule_id:
+                        r.enabled = False
+                        return True
+            return False
+        finally:
+            await db.close()
+
+    if _run(_run_disable()):
+        fmt.success(f"룰 비활성화 완료: {rule_id}")
+    else:
+        fmt.error(f"룰을 찾을 수 없습니다: {rule_id}")

--- a/src/ante/cli/commands/system.py
+++ b/src/ante/cli/commands/system.py
@@ -1,0 +1,117 @@
+"""ante system — 시스템 제어 커맨드."""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+from ante.cli.main import get_formatter
+from ante.cli.middleware import get_member_id, require_auth, require_scope
+
+
+@click.group()
+def system() -> None:
+    """시스템 시작·중지·상태 확인."""
+
+
+def _run(coro):  # noqa: ANN001, ANN202
+    return asyncio.run(coro)
+
+
+async def _create_services():  # noqa: ANN202
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+    db = Database("db/ante.db")
+    await db.connect()
+    eventbus = EventBus()
+    return db, eventbus
+
+
+@system.command()
+@click.pass_context
+@require_auth
+@require_scope("system:read")
+def status(ctx: click.Context) -> None:
+    """시스템 상태 표시."""
+    fmt = get_formatter(ctx)
+
+    async def _run_status() -> dict:
+        from ante.config.system_state import SystemState
+
+        db, eventbus = await _create_services()
+        try:
+            state = SystemState(db, eventbus)
+            await state.initialize()
+
+            # 봇 수 조회
+            row = await db.fetch_one("SELECT count(*) as cnt FROM bots")
+            bot_count = row["cnt"] if row else 0
+
+            return {
+                "trading_state": state.trading_state.value,
+                "bot_count": bot_count,
+            }
+        finally:
+            await db.close()
+
+    result = _run(_run_status())
+
+    if fmt.is_json:
+        fmt.output(result)
+    else:
+        click.echo(f"  거래 상태  : {result['trading_state']}")
+        click.echo(f"  봇 수     : {result['bot_count']}")
+
+
+@system.command()
+@click.option("--reason", default="", help="사유")
+@click.pass_context
+@require_auth
+@require_scope("system:admin")
+def halt(ctx: click.Context, reason: str) -> None:
+    """킬 스위치 발동 (전체 거래 중지)."""
+    fmt = get_formatter(ctx)
+    actor = get_member_id(ctx)
+
+    async def _run_halt() -> dict:
+        from ante.config.system_state import SystemState, TradingState
+
+        db, eventbus = await _create_services()
+        try:
+            state = SystemState(db, eventbus)
+            await state.initialize()
+            await state.set_state(TradingState.HALTED, reason=reason, changed_by=actor)
+            return {"trading_state": state.trading_state.value}
+        finally:
+            await db.close()
+
+    result = _run(_run_halt())
+    fmt.success("시스템 HALTED — 전체 거래 중지", result)
+
+
+@system.command()
+@click.option("--reason", default="", help="사유")
+@click.pass_context
+@require_auth
+@require_scope("system:admin")
+def activate(ctx: click.Context, reason: str) -> None:
+    """킬 스위치 해제 (거래 재개)."""
+    fmt = get_formatter(ctx)
+    actor = get_member_id(ctx)
+
+    async def _run_activate() -> dict:
+        from ante.config.system_state import SystemState, TradingState
+
+        db, eventbus = await _create_services()
+        try:
+            state = SystemState(db, eventbus)
+            await state.initialize()
+            await state.set_state(TradingState.ACTIVE, reason=reason, changed_by=actor)
+            return {"trading_state": state.trading_state.value}
+        finally:
+            await db.close()
+
+    result = _run(_run_activate())
+    fmt.success("시스템 ACTIVE — 거래 재개", result)

--- a/src/ante/cli/commands/trade.py
+++ b/src/ante/cli/commands/trade.py
@@ -1,0 +1,133 @@
+"""ante trade — 거래 내역 조회 커맨드."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+
+import click
+
+from ante.cli.main import get_formatter
+from ante.cli.middleware import require_auth, require_scope
+
+
+@click.group()
+def trade() -> None:
+    """거래 내역 조회."""
+
+
+def _run(coro):  # noqa: ANN001, ANN202
+    return asyncio.run(coro)
+
+
+async def _create_trade_service():  # noqa: ANN202
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+    from ante.trade.performance import PerformanceTracker
+    from ante.trade.position import PositionHistory
+    from ante.trade.recorder import TradeRecorder
+    from ante.trade.service import TradeService
+
+    db = Database("db/ante.db")
+    await db.connect()
+    eventbus = EventBus()
+    recorder = TradeRecorder(db, eventbus)
+    await recorder.initialize()
+    position_history = PositionHistory(db, eventbus)
+    await position_history.initialize()
+    performance = PerformanceTracker(db)
+    await performance.initialize()
+    service = TradeService(recorder, position_history, performance)
+    return service, db
+
+
+@trade.command("list")
+@click.option("--bot", "bot_id", default=None, help="봇 ID 필터")
+@click.option("--from", "from_date", default=None, help="시작일 (YYYY-MM-DD)")
+@click.option("--to", "to_date", default=None, help="종료일 (YYYY-MM-DD)")
+@click.option("--limit", default=50, help="최대 조회 수")
+@click.pass_context
+@require_auth
+@require_scope("trade:read")
+def trade_list(
+    ctx: click.Context,
+    bot_id: str | None,
+    from_date: str | None,
+    to_date: str | None,
+    limit: int,
+) -> None:
+    """거래 목록 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _run_list() -> list[dict]:
+        service, db = await _create_trade_service()
+        try:
+            fd = datetime.fromisoformat(from_date) if from_date else None
+            td = datetime.fromisoformat(to_date) if to_date else None
+            trades = await service.get_trades(
+                bot_id=bot_id, from_date=fd, to_date=td, limit=limit
+            )
+            return [
+                {
+                    "trade_id": str(t.trade_id),
+                    "bot_id": t.bot_id,
+                    "symbol": t.symbol,
+                    "side": t.side,
+                    "quantity": t.quantity,
+                    "price": t.price,
+                    "status": t.status,
+                    "timestamp": str(t.timestamp) if t.timestamp else "",
+                }
+                for t in trades
+            ]
+        finally:
+            await db.close()
+
+    result = _run(_run_list())
+
+    if not result:
+        fmt.output({"message": "거래 내역 없음", "trades": []})
+        return
+
+    if fmt.is_json:
+        fmt.output({"trades": result})
+    else:
+        fmt.table(
+            result,
+            ["trade_id", "bot_id", "symbol", "side", "quantity", "price", "status"],
+        )
+
+
+@trade.command("info")
+@click.argument("trade_id")
+@click.pass_context
+@require_auth
+@require_scope("trade:read")
+def trade_info(ctx: click.Context, trade_id: str) -> None:
+    """거래 상세 정보 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _run_info() -> dict | None:
+        from ante.core.database import Database
+
+        db = Database("db/ante.db")
+        await db.connect()
+        try:
+            row = await db.fetch_one(
+                "SELECT * FROM trades WHERE trade_id = ?", (trade_id,)
+            )
+            return dict(row) if row else None
+        finally:
+            await db.close()
+
+    result = _run(_run_info())
+
+    if not result:
+        fmt.error(f"거래를 찾을 수 없습니다: {trade_id}")
+        return
+
+    if fmt.is_json:
+        fmt.output(result)
+    else:
+        for key, value in result.items():
+            click.echo(f"  {key:15s}: {value}")

--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -1,0 +1,120 @@
+"""ante treasury — 자금 현황 조회/관리 커맨드."""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+from ante.cli.main import get_formatter
+from ante.cli.middleware import require_auth, require_scope
+
+
+@click.group()
+def treasury() -> None:
+    """자금 현황 조회·관리."""
+
+
+def _run(coro):  # noqa: ANN001, ANN202
+    return asyncio.run(coro)
+
+
+async def _create_treasury():  # noqa: ANN202
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+    from ante.treasury.treasury import Treasury
+
+    db = Database("db/ante.db")
+    await db.connect()
+    eventbus = EventBus()
+    t = Treasury(db, eventbus)
+    await t.initialize()
+    return t, db
+
+
+@treasury.command()
+@click.pass_context
+@require_auth
+@require_scope("treasury:read")
+def status(ctx: click.Context) -> None:
+    """자금 현황 요약."""
+    fmt = get_formatter(ctx)
+
+    async def _run_status() -> dict:
+        t, db = await _create_treasury()
+        try:
+            return t.get_summary()
+        finally:
+            await db.close()
+
+    result = _run(_run_status())
+
+    if fmt.is_json:
+        fmt.output(result)
+    else:
+        click.echo(f"  계좌 잔고      : {result['account_balance']:>15,.0f}")
+        click.echo(f"  매수 가능      : {result['purchasable_amount']:>15,.0f}")
+        click.echo(f"  총 평가액      : {result['total_evaluation']:>15,.0f}")
+        click.echo(f"  총 손익        : {result['total_profit_loss']:>15,.0f}")
+        click.echo(f"  총 할당        : {result['total_allocated']:>15,.0f}")
+        click.echo(f"  총 예약        : {result['total_reserved']:>15,.0f}")
+        click.echo(f"  미할당         : {result['unallocated']:>15,.0f}")
+        click.echo(f"  봇 수          : {result['bot_count']:>15d}")
+
+
+@treasury.command()
+@click.argument("bot_id")
+@click.argument("amount", type=float)
+@click.pass_context
+@require_auth
+@require_scope("treasury:admin")
+def allocate(ctx: click.Context, bot_id: str, amount: float) -> None:
+    """봇에 예산 할당."""
+    fmt = get_formatter(ctx)
+
+    async def _run_allocate() -> bool:
+        t, db = await _create_treasury()
+        try:
+            return await t.allocate(bot_id, amount)
+        finally:
+            await db.close()
+
+    success = _run(_run_allocate())
+
+    if success:
+        fmt.success(
+            f"예산 할당 완료: {bot_id} ← {amount:,.0f}원",
+            {"bot_id": bot_id, "amount": amount},
+        )
+    else:
+        fmt.error(
+            f"예산 할당 실패: 미할당 자금 부족 또는 금액 오류 (요청: {amount:,.0f}원)"
+        )
+
+
+@treasury.command()
+@click.argument("bot_id")
+@click.argument("amount", type=float)
+@click.pass_context
+@require_auth
+@require_scope("treasury:admin")
+def deallocate(ctx: click.Context, bot_id: str, amount: float) -> None:
+    """봇 예산 회수."""
+    fmt = get_formatter(ctx)
+
+    async def _run_deallocate() -> bool:
+        t, db = await _create_treasury()
+        try:
+            return await t.deallocate(bot_id, amount)
+        finally:
+            await db.close()
+
+    success = _run(_run_deallocate())
+
+    if success:
+        fmt.success(
+            f"예산 회수 완료: {bot_id} → {amount:,.0f}원",
+            {"bot_id": bot_id, "amount": amount},
+        )
+    else:
+        fmt.error(f"예산 회수 실패: 가용 예산 부족 (요청: {amount:,.0f}원)")

--- a/src/ante/cli/main.py
+++ b/src/ante/cli/main.py
@@ -34,14 +34,22 @@ def get_formatter(ctx: click.Context) -> OutputFormatter:
 # 서브커맨드 등록
 from ante.cli.commands.approval import approval  # noqa: E402
 from ante.cli.commands.backtest import backtest  # noqa: E402
+from ante.cli.commands.bot import bot  # noqa: E402
+from ante.cli.commands.broker import broker  # noqa: E402
 from ante.cli.commands.data import data  # noqa: E402
 from ante.cli.commands.instrument import instrument  # noqa: E402
 from ante.cli.commands.member import member  # noqa: E402
 from ante.cli.commands.notification import notification  # noqa: E402
 from ante.cli.commands.report import report  # noqa: E402
+from ante.cli.commands.rule import rule  # noqa: E402
 from ante.cli.commands.strategy import strategy  # noqa: E402
+from ante.cli.commands.system import system  # noqa: E402
+from ante.cli.commands.trade import trade  # noqa: E402
+from ante.cli.commands.treasury import treasury  # noqa: E402
 
 cli.add_command(approval)
+cli.add_command(bot)
+cli.add_command(broker)
 cli.add_command(strategy)
 cli.add_command(data)
 cli.add_command(backtest)
@@ -49,3 +57,7 @@ cli.add_command(report)
 cli.add_command(instrument)
 cli.add_command(member)
 cli.add_command(notification)
+cli.add_command(rule)
+cli.add_command(system)
+cli.add_command(trade)
+cli.add_command(treasury)

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -1,0 +1,419 @@
+"""CLI 라이브 커맨드(system/bot/trade/treasury/rule/broker) 단위 테스트."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner():
+    """인증된 상태의 CliRunner."""
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+# ── system 커맨드 ──────────────────────────────────
+
+
+class TestSystemCommands:
+    def _mock_system_state(self, trading_state_value="active"):
+        from ante.config.system_state import TradingState
+
+        mock_state = AsyncMock()
+        mock_state.trading_state = TradingState(trading_state_value)
+        mock_state.initialize = AsyncMock()
+        mock_state.set_state = AsyncMock()
+        return mock_state
+
+    def test_system_status(self, runner):
+        with patch("ante.cli.commands.system._create_services") as mock_svc:
+            mock_db = AsyncMock()
+            mock_db.fetch_one = AsyncMock(return_value={"cnt": 3})
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_db, MagicMock())
+
+            with patch(
+                "ante.config.system_state.SystemState",
+                return_value=self._mock_system_state("active"),
+            ):
+                result = runner.invoke(cli, ["system", "status"])
+                assert result.exit_code == 0
+                assert "active" in result.output
+
+    def test_system_status_json(self, runner):
+        with patch("ante.cli.commands.system._create_services") as mock_svc:
+            mock_db = AsyncMock()
+            mock_db.fetch_one = AsyncMock(return_value={"cnt": 2})
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_db, MagicMock())
+
+            with patch(
+                "ante.config.system_state.SystemState",
+                return_value=self._mock_system_state("active"),
+            ):
+                result = runner.invoke(cli, ["--format", "json", "system", "status"])
+                assert result.exit_code == 0
+                data = json.loads(result.output)
+                assert data["trading_state"] == "active"
+                assert data["bot_count"] == 2
+
+    def test_system_halt(self, runner):
+        with patch("ante.cli.commands.system._create_services") as mock_svc:
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_db, MagicMock())
+
+            mock_state = self._mock_system_state("halted")
+            with patch(
+                "ante.config.system_state.SystemState",
+                return_value=mock_state,
+            ):
+                result = runner.invoke(cli, ["system", "halt", "--reason", "test halt"])
+                assert result.exit_code == 0
+                assert "HALTED" in result.output
+
+    def test_system_activate(self, runner):
+        with patch("ante.cli.commands.system._create_services") as mock_svc:
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_db, MagicMock())
+
+            mock_state = self._mock_system_state("active")
+            with patch(
+                "ante.config.system_state.SystemState",
+                return_value=mock_state,
+            ):
+                result = runner.invoke(cli, ["system", "activate"])
+                assert result.exit_code == 0
+                assert "ACTIVE" in result.output
+
+
+# ── bot 커맨드 ─────────────────────────────────────
+
+
+class TestBotCommands:
+    def test_bot_list_empty(self, runner):
+        with patch("ante.cli.commands.bot._create_services") as mock_svc:
+            mock_db = AsyncMock()
+            mock_db.fetch_all = AsyncMock(return_value=[])
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_db, MagicMock(), MagicMock())
+
+            result = runner.invoke(cli, ["bot", "list"])
+            assert result.exit_code == 0
+
+    def test_bot_list_with_data(self, runner):
+        with patch("ante.cli.commands.bot._create_services") as mock_svc:
+            mock_db = AsyncMock()
+            mock_db.fetch_all = AsyncMock(
+                return_value=[
+                    {
+                        "bot_id": "bot-1",
+                        "strategy_id": "stg-1",
+                        "bot_type": "paper",
+                        "status": "created",
+                        "created_at": "2026-01-01",
+                    }
+                ]
+            )
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_db, MagicMock(), MagicMock())
+
+            result = runner.invoke(cli, ["--format", "json", "bot", "list"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert len(data["bots"]) == 1
+            assert data["bots"][0]["bot_id"] == "bot-1"
+
+    def test_bot_info_not_found(self, runner):
+        with patch("ante.cli.commands.bot._create_services") as mock_svc:
+            mock_db = AsyncMock()
+            mock_db.fetch_one = AsyncMock(return_value=None)
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_db, MagicMock(), MagicMock())
+
+            result = runner.invoke(cli, ["bot", "info", "nonexistent"])
+            assert result.exit_code == 0
+            assert "찾을 수 없습니다" in result.output
+
+    def test_bot_info_found(self, runner):
+        with patch("ante.cli.commands.bot._create_services") as mock_svc:
+            mock_db = AsyncMock()
+            mock_db.fetch_one = AsyncMock(
+                return_value={
+                    "bot_id": "bot-1",
+                    "strategy_id": "stg-1",
+                    "bot_type": "live",
+                    "status": "running",
+                    "created_at": "2026-01-01",
+                    "config_json": "{}",
+                    "auto_start": 0,
+                    "updated_at": "2026-01-01",
+                }
+            )
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_db, MagicMock(), MagicMock())
+
+            result = runner.invoke(cli, ["bot", "info", "bot-1"])
+            assert result.exit_code == 0
+            assert "bot-1" in result.output
+
+    def test_bot_create(self, runner):
+        with patch("ante.cli.commands.bot._create_services") as mock_svc:
+            mock_db = AsyncMock()
+            mock_db.execute = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_db, MagicMock(), MagicMock())
+
+            result = runner.invoke(
+                cli,
+                ["bot", "create", "--strategy", "stg-1", "--type", "paper"],
+            )
+            assert result.exit_code == 0
+            assert "생성 완료" in result.output
+
+
+# ── trade 커맨드 ────────────────────────────────────
+
+
+class TestTradeCommands:
+    def test_trade_list_empty(self, runner):
+        with patch("ante.cli.commands.trade._create_trade_service") as mock_svc:
+            mock_service = AsyncMock()
+            mock_service.get_trades = AsyncMock(return_value=[])
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_service, mock_db)
+
+            result = runner.invoke(cli, ["trade", "list"])
+            assert result.exit_code == 0
+
+    def test_trade_info_not_found(self, runner):
+        with patch("ante.core.database.Database") as mock_db_cls:
+            mock_db = AsyncMock()
+            mock_db.connect = AsyncMock()
+            mock_db.fetch_one = AsyncMock(return_value=None)
+            mock_db.close = AsyncMock()
+            mock_db_cls.return_value = mock_db
+
+            result = runner.invoke(cli, ["trade", "info", "fake-id"])
+            assert result.exit_code == 0
+            assert "찾을 수 없습니다" in result.output
+
+
+# ── treasury 커맨드 ──────────────────────────────────
+
+
+class TestTreasuryCommands:
+    def test_treasury_status(self, runner):
+        with patch("ante.cli.commands.treasury._create_treasury") as mock_svc:
+            mock_treasury = MagicMock()
+            mock_treasury.get_summary.return_value = {
+                "account_balance": 10000000.0,
+                "purchasable_amount": 8000000.0,
+                "total_evaluation": 12000000.0,
+                "total_profit_loss": 200000.0,
+                "total_allocated": 5000000.0,
+                "total_reserved": 100000.0,
+                "unallocated": 5000000.0,
+                "bot_count": 2,
+            }
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_treasury, mock_db)
+
+            result = runner.invoke(cli, ["treasury", "status"])
+            assert result.exit_code == 0
+            assert "10,000,000" in result.output
+
+    def test_treasury_status_json(self, runner):
+        with patch("ante.cli.commands.treasury._create_treasury") as mock_svc:
+            mock_treasury = MagicMock()
+            mock_treasury.get_summary.return_value = {
+                "account_balance": 10000000.0,
+                "purchasable_amount": 8000000.0,
+                "total_evaluation": 12000000.0,
+                "total_profit_loss": 200000.0,
+                "total_allocated": 5000000.0,
+                "total_reserved": 100000.0,
+                "unallocated": 5000000.0,
+                "bot_count": 2,
+            }
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_treasury, mock_db)
+
+            result = runner.invoke(cli, ["--format", "json", "treasury", "status"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["account_balance"] == 10000000.0
+
+    def test_treasury_allocate_success(self, runner):
+        with patch("ante.cli.commands.treasury._create_treasury") as mock_svc:
+            mock_treasury = AsyncMock()
+            mock_treasury.allocate = AsyncMock(return_value=True)
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_treasury, mock_db)
+
+            result = runner.invoke(cli, ["treasury", "allocate", "bot-1", "1000000"])
+            assert result.exit_code == 0
+            assert "할당 완료" in result.output
+
+    def test_treasury_allocate_fail(self, runner):
+        with patch("ante.cli.commands.treasury._create_treasury") as mock_svc:
+            mock_treasury = AsyncMock()
+            mock_treasury.allocate = AsyncMock(return_value=False)
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_treasury, mock_db)
+
+            result = runner.invoke(cli, ["treasury", "allocate", "bot-1", "999999999"])
+            assert result.exit_code == 0
+            assert "실패" in result.output
+
+    def test_treasury_deallocate_success(self, runner):
+        with patch("ante.cli.commands.treasury._create_treasury") as mock_svc:
+            mock_treasury = AsyncMock()
+            mock_treasury.deallocate = AsyncMock(return_value=True)
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_treasury, mock_db)
+
+            result = runner.invoke(cli, ["treasury", "deallocate", "bot-1", "500000"])
+            assert result.exit_code == 0
+            assert "회수 완료" in result.output
+
+
+# ── rule 커맨드 ─────────────────────────────────────
+
+
+class TestRuleCommands:
+    def test_rule_list_empty(self, runner):
+        with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
+            mock_engine = MagicMock()
+            mock_engine._global_rules = []
+            mock_engine._strategy_rules = {}
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_engine, mock_db)
+
+            with patch("ante.cli.commands.rule._load_rules_from_config"):
+                result = runner.invoke(cli, ["rule", "list"])
+                assert result.exit_code == 0
+
+    def test_rule_list_with_rules(self, runner):
+        with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
+            mock_rule = MagicMock()
+            mock_rule.rule_id = "daily_loss"
+            mock_rule.name = "Daily Loss Limit"
+            mock_rule.enabled = True
+            mock_rule.priority = 0
+            mock_rule.description = "Daily loss limit rule"
+
+            mock_engine = MagicMock()
+            mock_engine._global_rules = [mock_rule]
+            mock_engine._strategy_rules = {}
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_engine, mock_db)
+
+            with patch("ante.cli.commands.rule._load_rules_from_config"):
+                result = runner.invoke(cli, ["--format", "json", "rule", "list"])
+                assert result.exit_code == 0
+                data = json.loads(result.output)
+                assert len(data["rules"]) == 1
+                assert data["rules"][0]["rule_id"] == "daily_loss"
+
+    def test_rule_info_not_found(self, runner):
+        with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
+            mock_engine = MagicMock()
+            mock_engine._global_rules = []
+            mock_engine._strategy_rules = {}
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_engine, mock_db)
+
+            with patch("ante.cli.commands.rule._load_rules_from_config"):
+                result = runner.invoke(cli, ["rule", "info", "nonexistent"])
+                assert result.exit_code == 0
+                assert "찾을 수 없습니다" in result.output
+
+
+# ── broker 커맨드 ───────────────────────────────────
+
+
+class TestBrokerCommands:
+    def test_broker_status_connected(self, runner):
+        with patch("ante.cli.commands.broker._create_broker") as mock_create:
+            mock_adapter = AsyncMock()
+            mock_adapter.is_connected = True
+            mock_adapter.health_check = AsyncMock(return_value=True)
+            mock_adapter.exchange = "KRX"
+            mock_create.return_value = mock_adapter
+
+            result = runner.invoke(cli, ["broker", "status"])
+            assert result.exit_code == 0
+            assert "연결됨" in result.output
+
+    def test_broker_status_error(self, runner):
+        with patch("ante.cli.commands.broker._create_broker") as mock_create:
+            mock_create.side_effect = Exception("connection failed")
+
+            result = runner.invoke(cli, ["broker", "status"])
+            assert result.exit_code == 0
+            assert "미연결" in result.output
+
+    def test_broker_balance(self, runner):
+        with patch("ante.cli.commands.broker._create_broker") as mock_create:
+            mock_adapter = AsyncMock()
+            mock_adapter.get_account_balance = AsyncMock(
+                return_value={"cash": 10000000.0, "total_assets": 15000000.0}
+            )
+            mock_adapter.disconnect = AsyncMock()
+            mock_create.return_value = mock_adapter
+
+            result = runner.invoke(cli, ["--format", "json", "broker", "balance"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["cash"] == 10000000.0
+
+    def test_broker_positions_empty(self, runner):
+        with patch("ante.cli.commands.broker._create_broker") as mock_create:
+            mock_adapter = AsyncMock()
+            mock_adapter.get_positions = AsyncMock(return_value=[])
+            mock_adapter.disconnect = AsyncMock()
+            mock_create.return_value = mock_adapter
+
+            result = runner.invoke(cli, ["broker", "positions"])
+            assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- 6개 CLI 커맨드 그룹 구현: `system`, `bot`, `trade`, `treasury`, `rule`, `broker`
- 각 커맨드는 DB 직접 조회 방식으로 시스템 상태를 확인하고 관리
- 모든 커맨드 `--format json` 지원

## Test plan
- [x] system: status/halt/activate 테스트 (4개)
- [x] bot: list/info/create 테스트 (5개)
- [x] trade: list/info 테스트 (2개)
- [x] treasury: status/allocate/deallocate 테스트 (5개)
- [x] rule: list/info 테스트 (3개)
- [x] broker: status/balance/positions 테스트 (4개)
- [x] 전체 834개 테스트 통과

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)