### PR TITLE
feat: CLI 설정 조회/변경 커맨드 (ante config get/set)

### DIFF
--- a/src/ante/cli/commands/config.py
+++ b/src/ante/cli/commands/config.py
@@ -1,0 +1,178 @@
+"""ante config — 설정 조회/변경 커맨드."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import click
+
+from ante.cli.main import get_formatter
+from ante.cli.middleware import get_member_id, require_auth, require_scope
+
+
+@click.group()
+def config() -> None:
+    """설정 조회·변경."""
+
+
+def _run(coro):  # noqa: ANN001, ANN202
+    return asyncio.run(coro)
+
+
+async def _create_services():  # noqa: ANN202
+    from ante.config.config import Config
+    from ante.config.dynamic import DynamicConfigService
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+    db = Database("db/ante.db")
+    await db.connect()
+    eventbus = EventBus()
+    static_config = Config.load()
+    dynamic = DynamicConfigService(db, eventbus)
+    await dynamic.initialize()
+    return static_config, dynamic, db
+
+
+@config.command("get")
+@click.argument("key", required=False, default=None)
+@click.pass_context
+@require_auth
+@require_scope("config:read")
+def config_get(ctx: click.Context, key: str | None) -> None:
+    """설정 조회. 키 없이 호출하면 전체 목록."""
+    fmt = get_formatter(ctx)
+
+    async def _run_get() -> dict | list[dict]:
+        static_config, dynamic, db = await _create_services()
+        try:
+            if key is not None:
+                # 동적 설정 먼저 확인
+                if await dynamic.exists(key):
+                    value = await dynamic.get(key)
+                    return {"key": key, "value": value, "source": "dynamic"}
+                # 정적 설정 확인
+                static_value = static_config.get(key)
+                if static_value is not None:
+                    return {"key": key, "value": static_value, "source": "static"}
+                return {"key": key, "value": None, "source": "not_found"}
+            else:
+                # 전체 목록
+                results: list[dict] = []
+
+                # 정적 설정 (defaults + system.toml)
+                from ante.config.defaults import DEFAULTS
+
+                for k, v in sorted(DEFAULTS.items()):
+                    static_val = static_config.get(k, v)
+                    results.append(
+                        {
+                            "key": k,
+                            "value": static_val,
+                            "source": "static",
+                        }
+                    )
+
+                # 동적 설정
+                rows = await db.fetch_all(
+                    "SELECT key, value, category FROM dynamic_config ORDER BY key"
+                )
+                for row in rows:
+                    results.append(
+                        {
+                            "key": row["key"],
+                            "value": json.loads(row["value"]),
+                            "source": "dynamic",
+                        }
+                    )
+
+                return results
+        finally:
+            await db.close()
+
+    result = _run(_run_get())
+
+    if isinstance(result, dict):
+        if result["source"] == "not_found":
+            fmt.error(f"설정을 찾을 수 없습니다: {result['key']}")
+            return
+        if fmt.is_json:
+            fmt.output(result)
+        else:
+            click.echo(
+                f"  {result['key']} = {result['value']} (source: {result['source']})"
+            )
+    else:
+        if fmt.is_json:
+            fmt.output({"configs": result})
+        else:
+            if not result:
+                click.echo("  (설정 없음)")
+                return
+            for item in result:
+                click.echo(
+                    f"  {item['key']:40s} = {str(item['value']):20s} ({item['source']})"
+                )
+
+
+@config.command("set")
+@click.argument("key")
+@click.argument("value")
+@click.pass_context
+@require_auth
+@require_scope("config:write")
+def config_set(ctx: click.Context, key: str, value: str) -> None:
+    """동적 설정 변경. 정적 설정은 변경 불가."""
+    fmt = get_formatter(ctx)
+    actor = get_member_id(ctx)
+
+    async def _run_set() -> dict:
+        from ante.config.defaults import DEFAULTS
+
+        static_config, dynamic, db = await _create_services()
+        try:
+            # 정적 설정 키인지 확인
+            if key in DEFAULTS or static_config.get(key) is not None:
+                if not await dynamic.exists(key):
+                    return {
+                        "success": False,
+                        "error": (
+                            f"'{key}'는 정적 설정입니다. "
+                            "config/system.toml을 직접 수정해 주세요."
+                        ),
+                    }
+
+            # 값 파싱 (JSON 시도, 실패하면 문자열)
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError:
+                parsed = value
+
+            # 카테고리 추론
+            category = key.split(".")[0] if "." in key else "general"
+
+            await dynamic.set(key, parsed, category)
+            return {
+                "success": True,
+                "key": key,
+                "value": parsed,
+                "category": category,
+                "changed_by": actor,
+            }
+        finally:
+            await db.close()
+
+    result = _run(_run_set())
+
+    if not result["success"]:
+        fmt.error(result["error"])
+        return
+
+    if fmt.is_json:
+        fmt.output(result)
+    else:
+        fmt.success(
+            f"설정 변경 완료: {result['key']} = {result['value']}",
+            result,
+        )

--- a/src/ante/cli/main.py
+++ b/src/ante/cli/main.py
@@ -36,6 +36,7 @@ from ante.cli.commands.approval import approval  # noqa: E402
 from ante.cli.commands.backtest import backtest  # noqa: E402
 from ante.cli.commands.bot import bot  # noqa: E402
 from ante.cli.commands.broker import broker  # noqa: E402
+from ante.cli.commands.config import config  # noqa: E402
 from ante.cli.commands.data import data  # noqa: E402
 from ante.cli.commands.instrument import instrument  # noqa: E402
 from ante.cli.commands.member import member  # noqa: E402
@@ -50,6 +51,7 @@ from ante.cli.commands.treasury import treasury  # noqa: E402
 cli.add_command(approval)
 cli.add_command(bot)
 cli.add_command(broker)
+cli.add_command(config)
 cli.add_command(strategy)
 cli.add_command(data)
 cli.add_command(backtest)

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -1,0 +1,189 @@
+"""CLI config 커맨드 단위 테스트."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+class TestConfigGet:
+    def test_get_specific_key_static(self, runner):
+        with patch("ante.cli.commands.config._create_services") as mock_svc:
+            mock_config = MagicMock()
+            mock_config.get.return_value = "INFO"
+            mock_dynamic = AsyncMock()
+            mock_dynamic.exists = AsyncMock(return_value=False)
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_config, mock_dynamic, mock_db)
+
+            result = runner.invoke(cli, ["config", "get", "system.log_level"])
+            assert result.exit_code == 0
+            assert "INFO" in result.output
+            assert "static" in result.output
+
+    def test_get_specific_key_dynamic(self, runner):
+        with patch("ante.cli.commands.config._create_services") as mock_svc:
+            mock_config = MagicMock()
+            mock_dynamic = AsyncMock()
+            mock_dynamic.exists = AsyncMock(return_value=True)
+            mock_dynamic.get = AsyncMock(return_value=42)
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_config, mock_dynamic, mock_db)
+
+            result = runner.invoke(cli, ["config", "get", "custom.key"])
+            assert result.exit_code == 0
+            assert "42" in result.output
+            assert "dynamic" in result.output
+
+    def test_get_not_found(self, runner):
+        with patch("ante.cli.commands.config._create_services") as mock_svc:
+            mock_config = MagicMock()
+            mock_config.get.return_value = None
+            mock_dynamic = AsyncMock()
+            mock_dynamic.exists = AsyncMock(return_value=False)
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_config, mock_dynamic, mock_db)
+
+            result = runner.invoke(cli, ["config", "get", "nonexistent.key"])
+            assert result.exit_code == 0
+            assert "찾을 수 없습니다" in result.output
+
+    def test_get_all_json(self, runner):
+        with patch("ante.cli.commands.config._create_services") as mock_svc:
+            mock_config = MagicMock()
+            mock_config.get.side_effect = lambda k, d=None: d
+            mock_dynamic = AsyncMock()
+            mock_db = AsyncMock()
+            mock_db.fetch_all = AsyncMock(return_value=[])
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_config, mock_dynamic, mock_db)
+
+            result = runner.invoke(cli, ["--format", "json", "config", "get"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert "configs" in data
+            assert len(data["configs"]) > 0
+
+    def test_get_specific_key_json(self, runner):
+        with patch("ante.cli.commands.config._create_services") as mock_svc:
+            mock_config = MagicMock()
+            mock_dynamic = AsyncMock()
+            mock_dynamic.exists = AsyncMock(return_value=True)
+            mock_dynamic.get = AsyncMock(return_value="DEBUG")
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_config, mock_dynamic, mock_db)
+
+            result = runner.invoke(
+                cli, ["--format", "json", "config", "get", "system.log_level"]
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["key"] == "system.log_level"
+            assert data["value"] == "DEBUG"
+            assert data["source"] == "dynamic"
+
+
+class TestConfigSet:
+    def test_set_dynamic_key(self, runner):
+        with patch("ante.cli.commands.config._create_services") as mock_svc:
+            mock_config = MagicMock()
+            mock_config.get.return_value = None
+            mock_dynamic = AsyncMock()
+            mock_dynamic.exists = AsyncMock(return_value=False)
+            mock_dynamic.set = AsyncMock()
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_config, mock_dynamic, mock_db)
+
+            result = runner.invoke(cli, ["config", "set", "custom.key", "hello"])
+            assert result.exit_code == 0
+            assert "변경 완료" in result.output
+
+    def test_set_static_key_rejected(self, runner):
+        with patch("ante.cli.commands.config._create_services") as mock_svc:
+            mock_config = MagicMock()
+            mock_config.get.return_value = "INFO"
+            mock_dynamic = AsyncMock()
+            mock_dynamic.exists = AsyncMock(return_value=False)
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_config, mock_dynamic, mock_db)
+
+            result = runner.invoke(cli, ["config", "set", "system.log_level", "DEBUG"])
+            assert result.exit_code == 0
+            assert "정적 설정" in result.output
+
+    def test_set_json_value(self, runner):
+        with patch("ante.cli.commands.config._create_services") as mock_svc:
+            mock_config = MagicMock()
+            mock_config.get.return_value = None
+            mock_dynamic = AsyncMock()
+            mock_dynamic.exists = AsyncMock(return_value=False)
+            mock_dynamic.set = AsyncMock()
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_config, mock_dynamic, mock_db)
+
+            result = runner.invoke(cli, ["config", "set", "custom.count", "42"])
+            assert result.exit_code == 0
+            assert "변경 완료" in result.output
+
+    def test_set_json_format(self, runner):
+        with patch("ante.cli.commands.config._create_services") as mock_svc:
+            mock_config = MagicMock()
+            mock_config.get.return_value = None
+            mock_dynamic = AsyncMock()
+            mock_dynamic.exists = AsyncMock(return_value=False)
+            mock_dynamic.set = AsyncMock()
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_config, mock_dynamic, mock_db)
+
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "config", "set", "custom.flag", "true"],
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["success"] is True
+            assert data["key"] == "custom.flag"
+            assert data["value"] is True


### PR DESCRIPTION
## Summary
- `ante config get [key]` — 정적/동적 설정 조회 (출처 구분)
- `ante config set <key> <value>` — 동적 설정 변경 (정적 설정 변경 거부)
- JSON 값 자동 파싱, `--format json` 지원

## Test plan
- [x] config get/set 9개 테스트 통과
- [x] 전체 843개 테스트 통과

Closes #72

Generated with [Claude Code](https://claude.com/claude-code)