### PR TITLE
feat: 일별/월별 성과 집계 (#73)

### DIFF
--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -94,3 +94,70 @@ def report_list(ctx: click.Context, status: str | None, db_path: str) -> None:
     except Exception as e:
         fmt.error(str(e), code="REPORT_ERROR")
         raise SystemExit(1) from e
+
+
+@report.command("performance")
+@click.option(
+    "--period",
+    type=click.Choice(["daily", "monthly"]),
+    default="daily",
+    help="집계 기간 (daily 또는 monthly)",
+)
+@click.option("--bot-id", default=None, help="봇 ID 필터")
+@click.option("--start", default=None, help="시작일 (YYYY-MM-DD, daily 전용)")
+@click.option("--end", default=None, help="종료일 (YYYY-MM-DD, daily 전용)")
+@click.option("--year", default=None, type=int, help="연도 필터 (monthly 전용)")
+@click.pass_context
+@require_auth
+@require_scope("report:read")
+def report_performance(
+    ctx: click.Context,
+    period: str,
+    bot_id: str | None,
+    start: str | None,
+    end: str | None,
+    year: int | None,
+) -> None:
+    """기간별 성과 집계 조회."""
+    from dataclasses import asdict
+
+    fmt = get_formatter(ctx)
+
+    async def _run_performance() -> list[dict]:
+        from ante.core.database import Database
+        from ante.trade.performance import PerformanceTracker
+
+        db = Database("db/ante.db")
+        await db.connect()
+        try:
+            tracker = PerformanceTracker(db)
+            if period == "daily":
+                summaries = await tracker.get_daily_summary(
+                    bot_id=bot_id,
+                    start_date=start,
+                    end_date=end,
+                )
+            else:
+                summaries = await tracker.get_monthly_summary(
+                    bot_id=bot_id,
+                    year=year,
+                )
+            return [asdict(s) for s in summaries]
+        finally:
+            await db.close()
+
+    result = asyncio.run(_run_performance())
+
+    if not result:
+        fmt.output({"message": "집계 데이터가 없습니다.", "summaries": []})
+        return
+
+    if fmt.is_json:
+        fmt.output({"period": period, "summaries": result})
+    else:
+        if period == "daily":
+            fmt.table(result, ["date", "realized_pnl", "trade_count", "win_rate"])
+        else:
+            fmt.table(
+                result, ["year", "month", "realized_pnl", "trade_count", "win_rate"]
+            )

--- a/src/ante/trade/__init__.py
+++ b/src/ante/trade/__init__.py
@@ -1,6 +1,8 @@
 """Trade 모듈 — 거래 기록, 포지션 추적, 성과 산출."""
 
 from ante.trade.models import (
+    DailySummary,
+    MonthlySummary,
     PerformanceMetrics,
     PositionSnapshot,
     TradeRecord,
@@ -13,6 +15,8 @@ from ante.trade.recorder import TradeRecorder
 from ante.trade.service import TradeService
 
 __all__ = [
+    "DailySummary",
+    "MonthlySummary",
     "PerformanceMetrics",
     "PerformanceTracker",
     "PositionHistory",

--- a/src/ante/trade/models.py
+++ b/src/ante/trade/models.py
@@ -58,6 +58,27 @@ class PositionSnapshot:
     exchange: str = "KRX"
 
 
+@dataclass(frozen=True)
+class DailySummary:
+    """일별 성과 집계."""
+
+    date: str
+    realized_pnl: float
+    trade_count: int
+    win_rate: float
+
+
+@dataclass(frozen=True)
+class MonthlySummary:
+    """월별 성과 집계."""
+
+    year: int
+    month: int
+    realized_pnl: float
+    trade_count: int
+    win_rate: float
+
+
 @dataclass
 class PerformanceMetrics:
     """봇/전략 성과 지표."""

--- a/src/ante/trade/performance.py
+++ b/src/ante/trade/performance.py
@@ -7,7 +7,13 @@ import statistics
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from ante.trade.models import PerformanceMetrics, TradeRecord, TradeStatus
+from ante.trade.models import (
+    DailySummary,
+    MonthlySummary,
+    PerformanceMetrics,
+    TradeRecord,
+    TradeStatus,
+)
 
 if TYPE_CHECKING:
     from ante.core.database import Database
@@ -77,6 +83,129 @@ class PerformanceTracker:
             last_trade_at=trades[-1].timestamp,
             active_days=len({t.timestamp.date() for t in trades if t.timestamp}),
         )
+
+    async def get_daily_summary(
+        self,
+        bot_id: str | None = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
+    ) -> list[DailySummary]:
+        """일별 성과 집계.
+
+        Args:
+            bot_id: 봇 ID 필터 (None이면 전체)
+            start_date: 시작일 (YYYY-MM-DD)
+            end_date: 종료일 (YYYY-MM-DD)
+        """
+        conditions: list[str] = [
+            "t.status = ?",
+            "t.side = 'sell'",
+        ]
+        params: list[Any] = [TradeStatus.FILLED.value]
+
+        if bot_id:
+            conditions.append("t.bot_id = ?")
+            params.append(bot_id)
+        if start_date:
+            conditions.append("date(t.timestamp) >= ?")
+            params.append(start_date)
+        if end_date:
+            conditions.append("date(t.timestamp) <= ?")
+            params.append(end_date)
+
+        where = " AND ".join(conditions)
+        query = f"""
+            SELECT
+                date(t.timestamp) AS trade_date,
+                COALESCE(SUM(ph.pnl), 0.0) AS realized_pnl,
+                COUNT(*) AS trade_count,
+                SUM(CASE WHEN ph.pnl > 0 THEN 1 ELSE 0 END) AS win_count
+            FROM trades t
+            LEFT JOIN position_history ph
+                ON ph.bot_id = t.bot_id
+                AND ph.symbol = t.symbol
+                AND ph.action = 'sell'
+                AND ph.price = t.price
+                AND ph.quantity = t.quantity
+            WHERE {where}
+            GROUP BY trade_date
+            ORDER BY trade_date ASC
+        """
+
+        rows = await self._db.fetch_all(query, tuple(params))
+        return [
+            DailySummary(
+                date=row["trade_date"],
+                realized_pnl=float(row["realized_pnl"]),
+                trade_count=int(row["trade_count"]),
+                win_rate=(
+                    int(row["win_count"]) / int(row["trade_count"])
+                    if int(row["trade_count"]) > 0
+                    else 0.0
+                ),
+            )
+            for row in rows
+        ]
+
+    async def get_monthly_summary(
+        self,
+        bot_id: str | None = None,
+        year: int | None = None,
+    ) -> list[MonthlySummary]:
+        """월별 성과 집계.
+
+        Args:
+            bot_id: 봇 ID 필터 (None이면 전체)
+            year: 연도 필터 (None이면 전체)
+        """
+        conditions: list[str] = [
+            "t.status = ?",
+            "t.side = 'sell'",
+        ]
+        params: list[Any] = [TradeStatus.FILLED.value]
+
+        if bot_id:
+            conditions.append("t.bot_id = ?")
+            params.append(bot_id)
+        if year:
+            conditions.append("strftime('%Y', t.timestamp) = ?")
+            params.append(str(year))
+
+        where = " AND ".join(conditions)
+        query = f"""
+            SELECT
+                CAST(strftime('%Y', t.timestamp) AS INTEGER) AS yr,
+                CAST(strftime('%m', t.timestamp) AS INTEGER) AS mo,
+                COALESCE(SUM(ph.pnl), 0.0) AS realized_pnl,
+                COUNT(*) AS trade_count,
+                SUM(CASE WHEN ph.pnl > 0 THEN 1 ELSE 0 END) AS win_count
+            FROM trades t
+            LEFT JOIN position_history ph
+                ON ph.bot_id = t.bot_id
+                AND ph.symbol = t.symbol
+                AND ph.action = 'sell'
+                AND ph.price = t.price
+                AND ph.quantity = t.quantity
+            WHERE {where}
+            GROUP BY yr, mo
+            ORDER BY yr ASC, mo ASC
+        """
+
+        rows = await self._db.fetch_all(query, tuple(params))
+        return [
+            MonthlySummary(
+                year=int(row["yr"]),
+                month=int(row["mo"]),
+                realized_pnl=float(row["realized_pnl"]),
+                trade_count=int(row["trade_count"]),
+                win_rate=(
+                    int(row["win_count"]) / int(row["trade_count"])
+                    if int(row["trade_count"]) > 0
+                    else 0.0
+                ),
+            )
+            for row in rows
+        ]
 
     @staticmethod
     def _calculate_mdd(pnl_list: list[float]) -> tuple[float, float]:

--- a/tests/unit/test_performance_summary.py
+++ b/tests/unit/test_performance_summary.py
@@ -1,0 +1,274 @@
+"""일별/월별 성과 집계 단위 테스트."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+from ante.trade.models import DailySummary, MonthlySummary
+from ante.trade.performance import PerformanceTracker
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+class TestGetDailySummary:
+    @pytest.mark.asyncio
+    async def test_daily_summary_basic(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(
+            return_value=[
+                {
+                    "trade_date": "2026-03-10",
+                    "realized_pnl": 15000.0,
+                    "trade_count": 3,
+                    "win_count": 2,
+                },
+                {
+                    "trade_date": "2026-03-11",
+                    "realized_pnl": -5000.0,
+                    "trade_count": 2,
+                    "win_count": 0,
+                },
+            ]
+        )
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_daily_summary()
+
+        assert len(result) == 2
+        assert isinstance(result[0], DailySummary)
+        assert result[0].date == "2026-03-10"
+        assert result[0].realized_pnl == 15000.0
+        assert result[0].trade_count == 3
+        assert result[0].win_rate == pytest.approx(2 / 3)
+        assert result[1].win_rate == 0.0
+
+    @pytest.mark.asyncio
+    async def test_daily_summary_with_bot_filter(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_daily_summary(bot_id="bot-1")
+
+        assert result == []
+        call_args = db.fetch_all.call_args
+        query = call_args[0][0]
+        params = call_args[0][1]
+        assert "t.bot_id = ?" in query
+        assert "bot-1" in params
+
+    @pytest.mark.asyncio
+    async def test_daily_summary_with_date_range(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        await tracker.get_daily_summary(start_date="2026-03-01", end_date="2026-03-31")
+
+        call_args = db.fetch_all.call_args
+        query = call_args[0][0]
+        params = call_args[0][1]
+        assert "date(t.timestamp) >= ?" in query
+        assert "date(t.timestamp) <= ?" in query
+        assert "2026-03-01" in params
+        assert "2026-03-31" in params
+
+    @pytest.mark.asyncio
+    async def test_daily_summary_empty(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_daily_summary()
+
+        assert result == []
+
+
+class TestGetMonthlySummary:
+    @pytest.mark.asyncio
+    async def test_monthly_summary_basic(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(
+            return_value=[
+                {
+                    "yr": 2026,
+                    "mo": 1,
+                    "realized_pnl": 50000.0,
+                    "trade_count": 10,
+                    "win_count": 7,
+                },
+                {
+                    "yr": 2026,
+                    "mo": 2,
+                    "realized_pnl": -20000.0,
+                    "trade_count": 8,
+                    "win_count": 3,
+                },
+            ]
+        )
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_monthly_summary()
+
+        assert len(result) == 2
+        assert isinstance(result[0], MonthlySummary)
+        assert result[0].year == 2026
+        assert result[0].month == 1
+        assert result[0].realized_pnl == 50000.0
+        assert result[0].trade_count == 10
+        assert result[0].win_rate == pytest.approx(0.7)
+
+    @pytest.mark.asyncio
+    async def test_monthly_summary_with_year_filter(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        await tracker.get_monthly_summary(year=2026)
+
+        call_args = db.fetch_all.call_args
+        query = call_args[0][0]
+        params = call_args[0][1]
+        assert "strftime('%Y', t.timestamp) = ?" in query
+        assert "2026" in params
+
+    @pytest.mark.asyncio
+    async def test_monthly_summary_with_bot_filter(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        await tracker.get_monthly_summary(bot_id="bot-1")
+
+        call_args = db.fetch_all.call_args
+        query = call_args[0][0]
+        params = call_args[0][1]
+        assert "t.bot_id = ?" in query
+        assert "bot-1" in params
+
+    @pytest.mark.asyncio
+    async def test_monthly_summary_empty(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_monthly_summary()
+
+        assert result == []
+
+
+class TestReportPerformanceCLI:
+    def test_daily_performance_text(self, runner):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            mock_run.return_value = [
+                {
+                    "date": "2026-03-10",
+                    "realized_pnl": 15000.0,
+                    "trade_count": 3,
+                    "win_rate": 0.67,
+                }
+            ]
+            result = runner.invoke(cli, ["report", "performance", "--period", "daily"])
+            assert result.exit_code == 0
+            assert "2026-03-10" in result.output
+
+    def test_monthly_performance_json(self, runner):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            mock_run.return_value = [
+                {
+                    "year": 2026,
+                    "month": 3,
+                    "realized_pnl": 50000.0,
+                    "trade_count": 10,
+                    "win_rate": 0.7,
+                }
+            ]
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "report", "performance", "--period", "monthly"],
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["period"] == "monthly"
+            assert len(data["summaries"]) == 1
+            assert data["summaries"][0]["year"] == 2026
+
+    def test_performance_empty(self, runner):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            mock_run.return_value = []
+            result = runner.invoke(cli, ["report", "performance"])
+            assert result.exit_code == 0
+            assert "없습니다" in result.output
+
+    def test_daily_with_bot_filter(self, runner):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            mock_run.return_value = [
+                {
+                    "date": "2026-03-10",
+                    "realized_pnl": 5000.0,
+                    "trade_count": 1,
+                    "win_rate": 1.0,
+                }
+            ]
+            result = runner.invoke(
+                cli,
+                ["report", "performance", "--bot-id", "bot-1"],
+            )
+            assert result.exit_code == 0
+
+    def test_monthly_with_year_filter(self, runner):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            mock_run.return_value = [
+                {
+                    "year": 2025,
+                    "month": 12,
+                    "realized_pnl": 100000.0,
+                    "trade_count": 20,
+                    "win_rate": 0.6,
+                }
+            ]
+            result = runner.invoke(
+                cli,
+                [
+                    "report",
+                    "performance",
+                    "--period",
+                    "monthly",
+                    "--year",
+                    "2025",
+                ],
+            )
+            assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- `PerformanceTracker`에 `get_daily_summary()`, `get_monthly_summary()` 메서드 추가
- `DailySummary`, `MonthlySummary` 데이터 모델 추가
- CLI 커맨드 `ante report performance --period daily|monthly [--bot-id] [--start] [--end] [--year]` 구현

## Test plan
- [x] 일별 집계 기본 동작 테스트 (4건)
- [x] 월별 집계 기본 동작 테스트 (4건)
- [x] CLI 커맨드 테스트 (5건: text/json 출력, 빈 결과, 필터)
- [x] ruff check + format 통과
- [x] 전체 테스트 856건 통과

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)