### PR TITLE
feat: Parquet 파일 무결성 검증 및 복구 (#74)

### DIFF
--- a/src/ante/cli/commands/data.py
+++ b/src/ante/cli/commands/data.py
@@ -130,3 +130,80 @@ def inject(
         f"Injected {count} rows for {symbol}/{timeframe}",
         {"count": count, "symbol": symbol, "timeframe": timeframe},
     )
+
+
+@data.command("validate")
+@click.option("--symbol", default=None, help="검증할 종목 코드 (미지정 시 전체)")
+@click.option("--timeframe", default="1d", help="타임프레임")
+@click.option(
+    "--fix", is_flag=True, default=False, help="손상 파일을 .corrupted로 이동"
+)
+@click.option("--data-path", default="data/", help="데이터 디렉토리 경로")
+@click.pass_context
+@require_auth
+@require_scope("data:read")
+def validate(
+    ctx: click.Context,
+    symbol: str | None,
+    timeframe: str,
+    fix: bool,
+    data_path: str,
+) -> None:
+    """Parquet 파일 무결성 검증."""
+    import asyncio
+
+    from ante.data.store import ParquetStore
+
+    fmt = get_formatter(ctx)
+    store = ParquetStore(base_path=data_path)
+
+    if symbol:
+        symbols = [symbol]
+    else:
+        symbols = store.list_symbols(timeframe)
+
+    if not symbols:
+        fmt.output({"message": "검증할 데이터가 없습니다.", "results": []})
+        return
+
+    async def _validate() -> list[dict]:
+        results = []
+        for sym in symbols:
+            result = await store.validate(sym, timeframe, fix=fix)
+            results.append(result)
+        return results
+
+    results = asyncio.run(_validate())
+
+    total_files = sum(r["total"] for r in results)
+    total_valid = sum(r["valid"] for r in results)
+    total_corrupted = sum(r["corrupted"] for r in results)
+
+    if fmt.is_json:
+        fmt.output(
+            {
+                "results": results,
+                "summary": {
+                    "total_files": total_files,
+                    "valid": total_valid,
+                    "corrupted": total_corrupted,
+                    "fixed": fix and total_corrupted > 0,
+                },
+            }
+        )
+    else:
+        for r in results:
+            if r["corrupted"] > 0:
+                click.echo(
+                    f"  {r['symbol']}/{r['timeframe']}: "
+                    f"{r['total']}개 중 {r['corrupted']}개 손상"
+                )
+                for cf in r["corrupted_files"]:
+                    click.echo(f"    → {cf}")
+        click.echo()
+        click.echo(
+            f"  검증 완료: 전체 {total_files}개 / "
+            f"정상 {total_valid}개 / 손상 {total_corrupted}개"
+        )
+        if fix and total_corrupted > 0:
+            click.echo("  손상 파일을 .corrupted로 이동 완료")

--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -148,6 +148,54 @@ class ParquetStore:
                 usage[tf_dir.name] = size
         return usage
 
+    async def validate(
+        self,
+        symbol: str,
+        timeframe: str,
+        fix: bool = False,
+    ) -> dict:
+        """Parquet 파일 무결성 검증.
+
+        Args:
+            symbol: 종목 코드
+            timeframe: 타임프레임
+            fix: True이면 손상 파일을 .corrupted 확장자로 이동
+
+        Returns:
+            {"symbol": str, "timeframe": str, "total": int,
+             "valid": int, "corrupted": int, "corrupted_files": list[str]}
+        """
+        path = self._base / "ohlcv" / timeframe / symbol
+        result: dict = {
+            "symbol": symbol,
+            "timeframe": timeframe,
+            "total": 0,
+            "valid": 0,
+            "corrupted": 0,
+            "corrupted_files": [],
+        }
+
+        if not path.exists():
+            return result
+
+        files = sorted(path.glob("*.parquet"))
+        result["total"] = len(files)
+
+        for f in files:
+            try:
+                pl.read_parquet(f)
+                result["valid"] += 1
+            except Exception:
+                logger.warning("손상된 Parquet 파일 발견: %s", f)
+                result["corrupted"] += 1
+                result["corrupted_files"].append(str(f))
+                if fix:
+                    corrupted_path = f.with_suffix(".corrupted")
+                    f.rename(corrupted_path)
+                    logger.info("손상 파일 이동: %s → %s", f, corrupted_path)
+
+        return result
+
     def delete_file(self, symbol: str, timeframe: str, month: str) -> bool:
         """특정 Parquet 파일 삭제. 성공 여부 반환."""
         filepath = self._base / "ohlcv" / timeframe / symbol / f"{month}.parquet"

--- a/tests/unit/test_parquet_validation.py
+++ b/tests/unit/test_parquet_validation.py
@@ -1,0 +1,208 @@
+"""Parquet 파일 무결성 검증 단위 테스트."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import polars as pl
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.data.store import ParquetStore
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+@pytest.fixture
+def tmp_store(tmp_path):
+    """임시 디렉토리 기반 ParquetStore."""
+    return ParquetStore(base_path=tmp_path)
+
+
+def _create_valid_parquet(path: Path) -> None:
+    """유효한 Parquet 파일 생성."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df = pl.DataFrame({"timestamp": ["2026-01-01"], "close": [100.0]})
+    df.write_parquet(str(path))
+
+
+def _create_corrupted_parquet(path: Path) -> None:
+    """손상된 Parquet 파일 생성."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"NOT_A_PARQUET_FILE")
+
+
+class TestParquetValidate:
+    @pytest.mark.asyncio
+    async def test_validate_all_valid(self, tmp_store, tmp_path):
+        _create_valid_parquet(tmp_path / "ohlcv" / "1d" / "005930" / "2026-01.parquet")
+        _create_valid_parquet(tmp_path / "ohlcv" / "1d" / "005930" / "2026-02.parquet")
+
+        result = await tmp_store.validate("005930", "1d")
+
+        assert result["total"] == 2
+        assert result["valid"] == 2
+        assert result["corrupted"] == 0
+        assert result["corrupted_files"] == []
+
+    @pytest.mark.asyncio
+    async def test_validate_corrupted_file(self, tmp_store, tmp_path):
+        _create_valid_parquet(tmp_path / "ohlcv" / "1d" / "005930" / "2026-01.parquet")
+        _create_corrupted_parquet(
+            tmp_path / "ohlcv" / "1d" / "005930" / "2026-02.parquet"
+        )
+
+        result = await tmp_store.validate("005930", "1d")
+
+        assert result["total"] == 2
+        assert result["valid"] == 1
+        assert result["corrupted"] == 1
+        assert len(result["corrupted_files"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_validate_fix_moves_corrupted(self, tmp_store, tmp_path):
+        corrupted_path = tmp_path / "ohlcv" / "1d" / "005930" / "2026-02.parquet"
+        _create_corrupted_parquet(corrupted_path)
+
+        result = await tmp_store.validate("005930", "1d", fix=True)
+
+        assert result["corrupted"] == 1
+        assert not corrupted_path.exists()
+        assert corrupted_path.with_suffix(".corrupted").exists()
+
+    @pytest.mark.asyncio
+    async def test_validate_no_data(self, tmp_store):
+        result = await tmp_store.validate("NONE", "1d")
+
+        assert result["total"] == 0
+        assert result["valid"] == 0
+        assert result["corrupted"] == 0
+
+    @pytest.mark.asyncio
+    async def test_validate_empty_directory(self, tmp_store, tmp_path):
+        (tmp_path / "ohlcv" / "1d" / "005930").mkdir(parents=True)
+
+        result = await tmp_store.validate("005930", "1d")
+
+        assert result["total"] == 0
+
+
+class TestValidateCLI:
+    def test_validate_specific_symbol(self, runner):
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = [
+                {
+                    "symbol": "005930",
+                    "timeframe": "1d",
+                    "total": 3,
+                    "valid": 3,
+                    "corrupted": 0,
+                    "corrupted_files": [],
+                }
+            ]
+            result = runner.invoke(cli, ["data", "validate", "--symbol", "005930"])
+            assert result.exit_code == 0
+            assert "정상 3개" in result.output
+
+    def test_validate_with_corrupted(self, runner):
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = [
+                {
+                    "symbol": "005930",
+                    "timeframe": "1d",
+                    "total": 3,
+                    "valid": 2,
+                    "corrupted": 1,
+                    "corrupted_files": ["/data/ohlcv/1d/005930/2026-01.parquet"],
+                }
+            ]
+            result = runner.invoke(cli, ["data", "validate", "--symbol", "005930"])
+            assert result.exit_code == 0
+            assert "손상 1개" in result.output
+
+    def test_validate_json_output(self, runner):
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = [
+                {
+                    "symbol": "005930",
+                    "timeframe": "1d",
+                    "total": 2,
+                    "valid": 2,
+                    "corrupted": 0,
+                    "corrupted_files": [],
+                }
+            ]
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "data", "validate", "--symbol", "005930"],
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["summary"]["total_files"] == 2
+            assert data["summary"]["valid"] == 2
+
+    def test_validate_no_data(self, runner):
+        with patch("ante.data.store.ParquetStore.list_symbols") as mock_list:
+            mock_list.return_value = []
+            result = runner.invoke(cli, ["data", "validate"])
+            assert result.exit_code == 0
+            assert "없습니다" in result.output
+
+    def test_validate_all_symbols(self, runner):
+        with (
+            patch("asyncio.run") as mock_run,
+            patch("ante.data.store.ParquetStore.list_symbols") as mock_list,
+        ):
+            mock_list.return_value = ["005930", "000660"]
+            mock_run.return_value = [
+                {
+                    "symbol": "005930",
+                    "timeframe": "1d",
+                    "total": 2,
+                    "valid": 2,
+                    "corrupted": 0,
+                    "corrupted_files": [],
+                },
+                {
+                    "symbol": "000660",
+                    "timeframe": "1d",
+                    "total": 1,
+                    "valid": 1,
+                    "corrupted": 0,
+                    "corrupted_files": [],
+                },
+            ]
+            result = runner.invoke(cli, ["data", "validate"])
+            assert result.exit_code == 0
+            assert "전체 3개" in result.output


### PR DESCRIPTION
## Summary
- `ParquetStore.validate(symbol, timeframe, fix)` 메서드 추가 — 파일별 읽기 시도로 무결성 검증
- `--fix` 옵션 시 손상 파일을 `.corrupted` 확장자로 이동
- CLI 커맨드 `ante data validate [--symbol] [--timeframe] [--fix]` 구현

## Test plan
- [x] ParquetStore.validate 단위 테스트 (5건: 정상, 손상, fix, 빈 데이터)
- [x] CLI 커맨드 테스트 (5건: 특정 심볼, 손상 출력, JSON, 빈 데이터, 전체 심볼)
- [x] ruff check + format 통과
- [x] 전체 테스트 866건 통과

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)