### PR TITLE
feat: 백테스트 완료 시 리포트 초안 자동 생성 (#75)

### DIFF
--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -161,3 +161,60 @@ def report_performance(
             fmt.table(
                 result, ["year", "month", "realized_pnl", "trade_count", "win_rate"]
             )
+
+
+@report.command("view")
+@click.argument("report_id")
+@click.option("--db-path", default="db/ante.db", help="DB 경로")
+@click.pass_context
+@require_auth
+@require_scope("report:read")
+def report_view(ctx: click.Context, report_id: str, db_path: str) -> None:
+    """리포트 상세 조회."""
+    from ante.report import ReportStore
+
+    fmt = get_formatter(ctx)
+
+    async def _view() -> dict | None:
+        from ante.core.database import Database
+
+        db = Database(db_path)
+        await db.connect()
+        try:
+            store = ReportStore(db)
+            await store.initialize()
+            r = await store.get(report_id)
+            if not r:
+                return None
+            return {
+                "report_id": r.report_id,
+                "strategy": f"{r.strategy_name} v{r.strategy_version}",
+                "status": r.status.value,
+                "submitted_at": str(r.submitted_at),
+                "submitted_by": r.submitted_by,
+                "backtest_period": r.backtest_period,
+                "total_return_pct": r.total_return_pct,
+                "total_trades": r.total_trades,
+                "sharpe_ratio": r.sharpe_ratio,
+                "max_drawdown_pct": r.max_drawdown_pct,
+                "win_rate": r.win_rate,
+                "summary": r.summary,
+                "rationale": r.rationale,
+                "risks": r.risks,
+                "recommendations": r.recommendations,
+            }
+        finally:
+            await db.close()
+
+    result = asyncio.run(_view())
+
+    if not result:
+        fmt.error(f"리포트를 찾을 수 없습니다: {report_id}")
+        return
+
+    if fmt.is_json:
+        fmt.output(result)
+    else:
+        for key, value in result.items():
+            if value is not None and value != "":
+                click.echo(f"  {key:20s}: {value}")

--- a/src/ante/report/__init__.py
+++ b/src/ante/report/__init__.py
@@ -1,11 +1,13 @@
 """Report Store — 전략 검증 리포트 저장·관리."""
 
+from ante.report.draft import ReportDraftGenerator
 from ante.report.feedback import PerformanceFeedback
 from ante.report.models import ReportStatus, StrategyReport
 from ante.report.store import ReportStore
 
 __all__ = [
     "PerformanceFeedback",
+    "ReportDraftGenerator",
     "ReportStatus",
     "ReportStore",
     "StrategyReport",

--- a/src/ante/report/draft.py
+++ b/src/ante/report/draft.py
@@ -1,0 +1,133 @@
+"""리포트 초안 자동 생성 — 백테스트 완료 시 draft 리포트 생성."""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from ante.report.models import ReportStatus, StrategyReport
+
+if TYPE_CHECKING:
+    from ante.eventbus.bus import EventBus
+    from ante.report.store import ReportStore
+
+logger = logging.getLogger(__name__)
+
+
+class ReportDraftGenerator:
+    """백테스트 결과로부터 리포트 초안을 생성."""
+
+    def __init__(self, report_store: ReportStore, eventbus: EventBus) -> None:
+        self._store = report_store
+        self._eventbus = eventbus
+
+    async def initialize(self) -> None:
+        """EventBus에 핸들러 등록."""
+        from ante.eventbus.events import BacktestCompleteEvent
+
+        self._eventbus.subscribe(BacktestCompleteEvent, self._on_backtest_complete)
+        logger.info("ReportDraftGenerator 초기화 완료")
+
+    async def _on_backtest_complete(self, event: object) -> None:
+        """백테스트 완료 이벤트 핸들러."""
+        from ante.eventbus.events import BacktestCompleteEvent
+
+        if not isinstance(event, BacktestCompleteEvent):
+            return
+
+        if event.status != "completed":
+            logger.debug("백테스트 실패/취소, 초안 생성 스킵: %s", event.backtest_id)
+            return
+
+        try:
+            result_data = self._load_result(event.result_path)
+            if not result_data:
+                logger.warning("백테스트 결과 로드 실패: %s", event.result_path)
+                return
+
+            report = self.generate_draft(result_data, event.strategy_id)
+            await self._store.submit(report)
+
+            from ante.eventbus.events import NotificationEvent
+
+            await self._eventbus.publish(
+                NotificationEvent(
+                    level="info",
+                    message=f"백테스트 리포트 초안 생성: {report.report_id}",
+                    detail=(
+                        f"전략: {report.strategy_name}, "
+                        f"수익률: {report.total_return_pct}%"
+                    ),
+                    metadata={"report_id": report.report_id},
+                )
+            )
+            logger.info("리포트 초안 생성 완료: %s", report.report_id)
+        except Exception:
+            logger.exception("리포트 초안 생성 실패: %s", event.backtest_id)
+
+    @staticmethod
+    def _load_result(result_path: str) -> dict | None:
+        """결과 파일 로드."""
+        if not result_path:
+            return None
+        try:
+            from pathlib import Path
+
+            path = Path(result_path)
+            if not path.exists():
+                return None
+            return json.loads(path.read_text())
+        except Exception:
+            logger.exception("결과 파일 읽기 실패: %s", result_path)
+            return None
+
+    @staticmethod
+    def generate_draft(
+        result_data: dict,
+        strategy_id: str = "",
+    ) -> StrategyReport:
+        """백테스트 결과 딕셔너리로부터 리포트 초안 생성."""
+        metrics = result_data.get("metrics", {})
+        strategy = result_data.get("strategy", strategy_id or "unknown")
+
+        # 전략 이름/버전 파싱 (format: "name_v1.0.0")
+        if "_v" in strategy:
+            name, version = strategy.rsplit("_v", 1)
+        else:
+            name = strategy
+            version = "0.0.0"
+
+        period = result_data.get("period", "")
+        total_return = result_data.get("total_return_pct", 0.0)
+        total_trades = result_data.get("total_trades", 0)
+        sharpe = metrics.get("sharpe_ratio")
+        mdd = metrics.get("max_drawdown")
+        win_rate = metrics.get("win_rate")
+
+        summary = (
+            f"백테스트 자동 생성 초안. "
+            f"기간: {period}, "
+            f"수익률: {total_return}%, "
+            f"거래: {total_trades}건"
+        )
+
+        return StrategyReport(
+            report_id=str(uuid.uuid4()),
+            strategy_name=name,
+            strategy_version=version,
+            strategy_path="",
+            status=ReportStatus.DRAFT,
+            submitted_at=datetime.now(tz=UTC),
+            submitted_by="system",
+            backtest_period=period,
+            total_return_pct=total_return,
+            total_trades=total_trades,
+            sharpe_ratio=sharpe,
+            max_drawdown_pct=mdd,
+            win_rate=win_rate,
+            summary=summary,
+            detail_json=json.dumps(result_data, default=str),
+        )

--- a/src/ante/report/models.py
+++ b/src/ante/report/models.py
@@ -10,6 +10,7 @@ from enum import StrEnum
 class ReportStatus(StrEnum):
     """리포트 상태."""
 
+    DRAFT = "draft"
     SUBMITTED = "submitted"
     REVIEWED = "reviewed"
     ADOPTED = "adopted"

--- a/tests/unit/test_report_draft.py
+++ b/tests/unit/test_report_draft.py
@@ -1,0 +1,248 @@
+"""백테스트 리포트 초안 자동 생성 단위 테스트."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.eventbus.events import BacktestCompleteEvent, NotificationEvent
+from ante.member.models import Member, MemberRole, MemberType
+from ante.report.draft import ReportDraftGenerator
+from ante.report.models import ReportStatus
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+_SAMPLE_RESULT = {
+    "strategy": "momentum_v1.0.0",
+    "period": "2025-01 ~ 2025-12",
+    "initial_balance": 10_000_000,
+    "final_balance": 11_500_000,
+    "total_return_pct": 15.0,
+    "total_trades": 42,
+    "metrics": {
+        "sharpe_ratio": 1.2,
+        "max_drawdown": -8.5,
+        "win_rate": 0.58,
+        "profit_factor": 1.8,
+    },
+    "trades": [],
+    "equity_curve": [],
+}
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+class TestGenerateDraft:
+    def test_generate_draft_basic(self):
+        report = ReportDraftGenerator.generate_draft(_SAMPLE_RESULT)
+
+        assert report.status == ReportStatus.DRAFT
+        assert report.strategy_name == "momentum"
+        assert report.strategy_version == "1.0.0"
+        assert report.total_return_pct == 15.0
+        assert report.total_trades == 42
+        assert report.sharpe_ratio == 1.2
+        assert report.max_drawdown_pct == -8.5
+        assert report.win_rate == 0.58
+        assert report.submitted_by == "system"
+        assert "15.0%" in report.summary
+        assert "42건" in report.summary
+
+    def test_generate_draft_no_version(self):
+        data = {**_SAMPLE_RESULT, "strategy": "simple_strategy"}
+        report = ReportDraftGenerator.generate_draft(data)
+
+        assert report.strategy_name == "simple_strategy"
+        assert report.strategy_version == "0.0.0"
+
+    def test_generate_draft_missing_metrics(self):
+        data = {
+            "strategy": "test_v1.0.0",
+            "period": "2025-01 ~ 2025-06",
+            "total_return_pct": 5.0,
+            "total_trades": 10,
+            "metrics": {},
+        }
+        report = ReportDraftGenerator.generate_draft(data)
+
+        assert report.sharpe_ratio is None
+        assert report.max_drawdown_pct is None
+        assert report.win_rate is None
+
+    def test_generate_draft_detail_json(self):
+        report = ReportDraftGenerator.generate_draft(_SAMPLE_RESULT)
+        detail = json.loads(report.detail_json)
+
+        assert detail["total_return_pct"] == 15.0
+        assert detail["metrics"]["sharpe_ratio"] == 1.2
+
+
+class TestOnBacktestComplete:
+    @pytest.mark.asyncio
+    async def test_event_handler_creates_draft(self, tmp_path):
+        result_file = tmp_path / "result.json"
+        result_file.write_text(json.dumps(_SAMPLE_RESULT))
+
+        mock_store = AsyncMock()
+        mock_store.submit = AsyncMock(return_value="report-123")
+        mock_eventbus = AsyncMock()
+        mock_eventbus.subscribe = MagicMock()
+        mock_eventbus.publish = AsyncMock()
+
+        generator = ReportDraftGenerator(mock_store, mock_eventbus)
+
+        event = BacktestCompleteEvent(
+            backtest_id="bt-1",
+            strategy_id="momentum_v1.0.0",
+            status="completed",
+            result_path=str(result_file),
+        )
+
+        await generator._on_backtest_complete(event)
+
+        mock_store.submit.assert_called_once()
+        submitted_report = mock_store.submit.call_args[0][0]
+        assert submitted_report.status == ReportStatus.DRAFT
+        assert submitted_report.total_return_pct == 15.0
+
+        # NotificationEvent 발행 확인
+        mock_eventbus.publish.assert_called_once()
+        notification = mock_eventbus.publish.call_args[0][0]
+        assert isinstance(notification, NotificationEvent)
+        assert "초안 생성" in notification.message
+
+    @pytest.mark.asyncio
+    async def test_event_handler_skips_failed_backtest(self):
+        mock_store = AsyncMock()
+        mock_eventbus = AsyncMock()
+        mock_eventbus.subscribe = MagicMock()
+
+        generator = ReportDraftGenerator(mock_store, mock_eventbus)
+
+        event = BacktestCompleteEvent(
+            backtest_id="bt-2",
+            strategy_id="test",
+            status="failed",
+            error_message="out of memory",
+        )
+
+        await generator._on_backtest_complete(event)
+
+        mock_store.submit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_event_handler_handles_missing_result(self):
+        mock_store = AsyncMock()
+        mock_eventbus = AsyncMock()
+        mock_eventbus.subscribe = MagicMock()
+
+        generator = ReportDraftGenerator(mock_store, mock_eventbus)
+
+        event = BacktestCompleteEvent(
+            backtest_id="bt-3",
+            strategy_id="test",
+            status="completed",
+            result_path="/nonexistent/path.json",
+        )
+
+        await generator._on_backtest_complete(event)
+
+        mock_store.submit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_initialize_subscribes_to_event(self):
+        mock_store = AsyncMock()
+        mock_eventbus = MagicMock()
+        mock_eventbus.subscribe = MagicMock()
+
+        generator = ReportDraftGenerator(mock_store, mock_eventbus)
+        await generator.initialize()
+
+        mock_eventbus.subscribe.assert_called_once()
+
+
+class TestReportViewCLI:
+    def test_view_existing_report(self, runner):
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = {
+                "report_id": "rpt-1",
+                "strategy": "momentum v1.0.0",
+                "status": "draft",
+                "submitted_at": "2026-03-13",
+                "submitted_by": "system",
+                "backtest_period": "2025-01 ~ 2025-12",
+                "total_return_pct": 15.0,
+                "total_trades": 42,
+                "sharpe_ratio": 1.2,
+                "max_drawdown_pct": -8.5,
+                "win_rate": 0.58,
+                "summary": "백테스트 자동 생성 초안",
+                "rationale": "",
+                "risks": "",
+                "recommendations": "",
+            }
+            result = runner.invoke(cli, ["report", "view", "rpt-1"])
+            assert result.exit_code == 0
+            assert "rpt-1" in result.output
+            assert "draft" in result.output
+
+    def test_view_not_found(self, runner):
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = None
+            result = runner.invoke(cli, ["report", "view", "nonexistent"])
+            assert result.exit_code == 0
+            assert "찾을 수 없습니다" in result.output
+
+    def test_view_json_format(self, runner):
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = {
+                "report_id": "rpt-1",
+                "strategy": "momentum v1.0.0",
+                "status": "draft",
+                "submitted_at": "2026-03-13",
+                "submitted_by": "system",
+                "backtest_period": "2025-01 ~ 2025-12",
+                "total_return_pct": 15.0,
+                "total_trades": 42,
+                "sharpe_ratio": 1.2,
+                "max_drawdown_pct": -8.5,
+                "win_rate": 0.58,
+                "summary": "초안",
+                "rationale": "",
+                "risks": "",
+                "recommendations": "",
+            }
+            result = runner.invoke(cli, ["--format", "json", "report", "view", "rpt-1"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["report_id"] == "rpt-1"
+            assert data["status"] == "draft"


### PR DESCRIPTION
## Summary
- `ReportDraftGenerator` 추가 — `BacktestCompleteEvent` 구독하여 draft 리포트 자동 생성
- `ReportStatus.DRAFT` 상태 추가
- `ante report view <id>` CLI 커맨드로 리포트 상세 조회 지원
- 초안 생성 시 `NotificationEvent` 발행

## Test plan
- [x] generate_draft 단위 테스트 (4건: 기본, 버전 없음, 지표 없음, detail_json)
- [x] 이벤트 핸들러 테스트 (4건: 정상 생성, 실패 스킵, 결과 없음, 구독 등록)
- [x] CLI report view 테스트 (3건: 조회, 없음, JSON)
- [x] ruff check + format 통과
- [x] 전체 테스트 877건 통과

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)