### PR TITLE
feat: ante bot create 전략 파라미터 오버라이드 (#76)

### DIFF
--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -98,6 +98,21 @@ def bot_info(ctx: click.Context, bot_id: str) -> None:
         click.echo(f"  생성일    : {result['created_at']}")
 
 
+def _parse_param(value: str) -> tuple[str, object]:
+    """key=value 형식의 파라미터 파싱. 값은 JSON 파싱 시도."""
+    import json as _json
+
+    if "=" not in value:
+        msg = f"잘못된 파라미터 형식: '{value}' (key=value 형태로 지정)"
+        raise click.BadParameter(msg)
+    key, raw = value.split("=", 1)
+    try:
+        parsed = _json.loads(raw)
+    except _json.JSONDecodeError:
+        parsed = raw
+    return key.strip(), parsed
+
+
 @bot.command("create")
 @click.option("--strategy", required=True, help="전략 ID")
 @click.option(
@@ -110,6 +125,12 @@ def bot_info(ctx: click.Context, bot_id: str) -> None:
 @click.option("--interval", default=60, help="실행 주기 (초)")
 @click.option("--symbols", default="", help="대상 종목 (쉼표 구분)")
 @click.option("--id", "bot_id", default="", help="봇 ID (미지정 시 자동 생성)")
+@click.option(
+    "--param",
+    "params",
+    multiple=True,
+    help="전략 파라미터 오버라이드 (key=value, 복수 지정 가능)",
+)
 @click.pass_context
 @require_auth
 @require_scope("bot:admin")
@@ -120,9 +141,20 @@ def bot_create(
     interval: int,
     symbols: str,
     bot_id: str,
+    params: tuple[str, ...],
 ) -> None:
     """봇 생성."""
     fmt = get_formatter(ctx)
+
+    # 파라미터 파싱
+    param_dict: dict = {}
+    for p in params:
+        try:
+            key, value = _parse_param(p)
+            param_dict[key] = value
+        except click.BadParameter as e:
+            fmt.error(str(e))
+            return
 
     async def _run_create() -> dict:
         import json
@@ -132,13 +164,15 @@ def bot_create(
         try:
             bid = bot_id or f"bot-{uuid4().hex[:8]}"
             symbol_list = [s.strip() for s in symbols.split(",") if s.strip()] or None
-            config_dict = {
+            config_dict: dict = {
                 "bot_id": bid,
                 "strategy_id": strategy,
                 "bot_type": bot_type,
                 "interval_seconds": interval,
                 "symbols": symbol_list,
             }
+            if param_dict:
+                config_dict["params"] = param_dict
             await db.execute(
                 """INSERT INTO bots (bot_id, strategy_id, bot_type, config_json)
                    VALUES (?, ?, ?, ?)""",

--- a/tests/unit/test_bot_create_params.py
+++ b/tests/unit/test_bot_create_params.py
@@ -1,0 +1,164 @@
+"""봇 생성 시 전략 파라미터 오버라이드 테스트."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.commands.bot import _parse_param
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+class TestParseParam:
+    def test_string_value(self):
+        key, value = _parse_param("name=hello")
+        assert key == "name"
+        assert value == "hello"
+
+    def test_numeric_value(self):
+        key, value = _parse_param("lookback=20")
+        assert key == "lookback"
+        assert value == 20
+
+    def test_float_value(self):
+        key, value = _parse_param("threshold=0.5")
+        assert key == "threshold"
+        assert value == 0.5
+
+    def test_boolean_value(self):
+        key, value = _parse_param("enabled=true")
+        assert key == "enabled"
+        assert value is True
+
+    def test_value_with_equals(self):
+        key, value = _parse_param("expr=a=b")
+        assert key == "expr"
+        assert value == "a=b"
+
+    def test_invalid_format(self):
+        import click
+
+        with pytest.raises(click.BadParameter):
+            _parse_param("invalidformat")
+
+
+class TestBotCreateWithParams:
+    def test_create_with_params(self, runner):
+        with patch("ante.cli.commands.bot._create_services") as mock_svc:
+            mock_db = AsyncMock()
+            mock_db.execute = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_db, MagicMock(), MagicMock())
+
+            result = runner.invoke(
+                cli,
+                [
+                    "bot",
+                    "create",
+                    "--strategy",
+                    "stg-1",
+                    "--param",
+                    "lookback=20",
+                    "--param",
+                    "threshold=0.5",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "생성 완료" in result.output
+
+            # DB에 저장된 config_json에 params 포함 확인
+            call_args = mock_db.execute.call_args[0]
+            config_json = call_args[1][3]
+            config = json.loads(config_json)
+            assert config["params"]["lookback"] == 20
+            assert config["params"]["threshold"] == 0.5
+
+    def test_create_without_params(self, runner):
+        with patch("ante.cli.commands.bot._create_services") as mock_svc:
+            mock_db = AsyncMock()
+            mock_db.execute = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_db, MagicMock(), MagicMock())
+
+            result = runner.invoke(
+                cli,
+                ["bot", "create", "--strategy", "stg-1"],
+            )
+            assert result.exit_code == 0
+
+            # params 키가 없어야 함
+            call_args = mock_db.execute.call_args[0]
+            config_json = call_args[1][3]
+            config = json.loads(config_json)
+            assert "params" not in config
+
+    def test_create_invalid_param_format(self, runner):
+        result = runner.invoke(
+            cli,
+            [
+                "bot",
+                "create",
+                "--strategy",
+                "stg-1",
+                "--param",
+                "invalidformat",
+            ],
+        )
+        assert "잘못된 파라미터 형식" in result.output
+
+    def test_create_with_json_output(self, runner):
+        with patch("ante.cli.commands.bot._create_services") as mock_svc:
+            mock_db = AsyncMock()
+            mock_db.execute = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_db, MagicMock(), MagicMock())
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "bot",
+                    "create",
+                    "--strategy",
+                    "stg-1",
+                    "--param",
+                    "window=30",
+                ],
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["params"]["window"] == 30


### PR DESCRIPTION
## Summary
- `ante bot create`에 `--param key=value` 옵션 추가 (복수 지정 가능)
- 값은 JSON 파싱 시도 (숫자, boolean 등 자동 변환)
- 잘못된 형식 시 에러 메시지 출력
- `--param` 미지정 시 기존 동작 유지

## Test plan
- [x] _parse_param 단위 테스트 (6건: string, int, float, bool, equals 포함, 잘못된 형식)
- [x] CLI 통합 테스트 (4건: params 포함 생성, params 없이 생성, 잘못된 형식, JSON 출력)
- [x] ruff check + format 통과
- [x] 전체 테스트 887건 통과

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)