### PR TITLE
feat: 백테스트 실행 시 진행률 표시 (#77)

### DIFF
--- a/src/ante/backtest/executor.py
+++ b/src/ante/backtest/executor.py
@@ -41,8 +41,17 @@ class BacktestExecutor:
         self._trades: list[BacktestTrade] = []
         self._equity_curve: list[dict] = []
 
-    async def run(self) -> BacktestResult:
-        """백테스트 실행."""
+    async def run(
+        self,
+        progress_callback: Any | None = None,
+    ) -> BacktestResult:
+        """백테스트 실행.
+
+        Args:
+            progress_callback: (current_step, total_steps)를 받는 콜백.
+        """
+        total_steps = self._data.get_total_steps()
+
         ctx = BacktestStrategyContext(
             bot_id="backtest",
             data_provider=self._data,
@@ -77,6 +86,8 @@ class BacktestExecutor:
                 }
             )
             step += 1
+            if progress_callback:
+                progress_callback(step, total_steps)
 
         strategy.on_stop()
 

--- a/src/ante/backtest/service.py
+++ b/src/ante/backtest/service.py
@@ -28,7 +28,11 @@ class BacktestService:
         self._data_path = data_path
         self._running: dict[str, asyncio.Task] = {}
 
-    async def run(self, config: dict[str, Any]) -> BacktestResult:
+    async def run(
+        self,
+        config: dict[str, Any],
+        progress_callback: Any | None = None,
+    ) -> BacktestResult:
         """백테스트를 in-process로 실행."""
         self._validate_config(config)
 
@@ -56,7 +60,7 @@ class BacktestService:
             slippage_rate=config.get("slippage_rate", 0.001),
         )
 
-        return await executor.run()
+        return await executor.run(progress_callback=progress_callback)
 
     async def run_subprocess(self, config: dict[str, Any]) -> dict:
         """백테스트를 subprocess로 격리 실행 (D-004)."""

--- a/src/ante/cli/commands/backtest.py
+++ b/src/ante/cli/commands/backtest.py
@@ -52,7 +52,31 @@ def run(
 
     try:
         service = BacktestService(data_path=data_path)
-        result = asyncio.run(service.run(config))
+        show_progress = not fmt.is_json
+
+        progress_bar = None
+
+        def _progress_callback(current: int, total: int) -> None:
+            nonlocal progress_bar
+            if not show_progress:
+                return
+            if progress_bar is None and total > 0:
+                progress_bar = click.progressbar(
+                    length=total,
+                    label="백테스트 진행",
+                    show_percent=True,
+                    show_pos=True,
+                )
+                progress_bar.__enter__()
+            if progress_bar is not None:
+                progress_bar.update(1)
+
+        result = asyncio.run(service.run(config, progress_callback=_progress_callback))
+
+        if progress_bar is not None:
+            progress_bar.__exit__(None, None, None)
+            click.echo()
+
         result_dict = result.to_dict()
         metrics = result_dict.get("metrics", {})
 

--- a/tests/unit/test_backtest_progress.py
+++ b/tests/unit/test_backtest_progress.py
@@ -1,0 +1,118 @@
+"""백테스트 진행률 표시 단위 테스트."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ante.backtest.executor import BacktestExecutor
+
+
+class TestProgressCallback:
+    @pytest.mark.asyncio
+    async def test_callback_called_each_step(self):
+        """진행률 콜백이 매 스텝 호출된다."""
+        from datetime import datetime
+
+        mock_strategy_cls = MagicMock()
+        mock_strategy = MagicMock()
+        mock_strategy.on_start = MagicMock()
+        mock_strategy.on_stop = MagicMock()
+        mock_strategy.on_step = AsyncMock(return_value=[])
+        mock_meta = MagicMock()
+        mock_meta.name = "test"
+        mock_meta.version = "1.0"
+        mock_strategy.meta = mock_meta
+        mock_strategy_cls.return_value = mock_strategy
+
+        mock_data = MagicMock()
+        mock_data.get_total_steps.return_value = 3
+        mock_data.advance = MagicMock(side_effect=[True, True, True, False])
+        mock_data.get_current_timestamp.return_value = datetime(2025, 1, 1)
+        mock_data.start = "2025-01-01"
+        mock_data.end = "2025-12-31"
+
+        progress_calls = []
+
+        def callback(current: int, total: int) -> None:
+            progress_calls.append((current, total))
+
+        executor = BacktestExecutor(
+            strategy_cls=mock_strategy_cls,
+            data_provider=mock_data,
+        )
+        await executor.run(progress_callback=callback)
+
+        assert len(progress_calls) == 3
+        assert progress_calls[0] == (1, 3)
+        assert progress_calls[1] == (2, 3)
+        assert progress_calls[2] == (3, 3)
+
+    @pytest.mark.asyncio
+    async def test_no_callback_works(self):
+        """콜백 없이도 정상 동작한다."""
+        from datetime import datetime
+
+        mock_strategy_cls = MagicMock()
+        mock_strategy = MagicMock()
+        mock_strategy.on_start = MagicMock()
+        mock_strategy.on_stop = MagicMock()
+        mock_strategy.on_step = AsyncMock(return_value=[])
+        mock_meta = MagicMock()
+        mock_meta.name = "test"
+        mock_meta.version = "1.0"
+        mock_strategy.meta = mock_meta
+        mock_strategy_cls.return_value = mock_strategy
+
+        mock_data = MagicMock()
+        mock_data.get_total_steps.return_value = 2
+        mock_data.advance = MagicMock(side_effect=[True, True, False])
+        mock_data.get_current_timestamp.return_value = datetime(2025, 1, 1)
+        mock_data.start = "2025-01-01"
+        mock_data.end = "2025-12-31"
+
+        executor = BacktestExecutor(
+            strategy_cls=mock_strategy_cls,
+            data_provider=mock_data,
+        )
+        result = await executor.run()
+
+        assert result is not None
+        assert result.strategy_name == "test"
+
+
+class TestBacktestServiceProgress:
+    @pytest.mark.asyncio
+    async def test_service_passes_callback(self):
+        """BacktestService가 progress_callback을 전달한다."""
+        with (
+            patch("ante.backtest.service.StrategyLoader.load") as mock_load,
+            patch("ante.backtest.service.BacktestDataProvider") as mock_dp_cls,
+            patch("ante.backtest.service.BacktestExecutor") as mock_exec_cls,
+        ):
+            mock_load.return_value = MagicMock()
+            mock_dp = AsyncMock()
+            mock_dp.load = AsyncMock(return_value=100)
+            mock_dp_cls.return_value = mock_dp
+
+            mock_exec = AsyncMock()
+            mock_result = MagicMock()
+            mock_exec.run = AsyncMock(return_value=mock_result)
+            mock_exec_cls.return_value = mock_exec
+
+            from ante.backtest.service import BacktestService
+
+            service = BacktestService()
+            cb = MagicMock()
+            config = {
+                "strategy_path": "test.py",
+                "start_date": "2025-01-01",
+                "end_date": "2025-12-31",
+                "symbols": ["005930"],
+            }
+            await service.run(config, progress_callback=cb)
+
+            mock_exec.run.assert_called_once_with(
+                progress_callback=cb,
+            )


### PR DESCRIPTION
## Summary
- `BacktestExecutor.run()`에 `progress_callback` 파라미터 추가
- `BacktestService.run()`에서 콜백 전달 지원
- CLI에서 `click.progressbar`로 진행률 바 표시
- `--format json` 모드에서는 진행률 미표시

## Test plan
- [x] progress_callback 매 스텝 호출 테스트
- [x] 콜백 없이 정상 동작 테스트
- [x] BacktestService → Executor 콜백 전달 테스트
- [x] ruff check + format 통과
- [x] 전체 테스트 890건 통과

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)