### PR TITLE
feat: 알림 중복 방지 (#78)

### DIFF
--- a/src/ante/notification/service.py
+++ b/src/ante/notification/service.py
@@ -35,6 +35,9 @@ CREATE INDEX IF NOT EXISTS idx_notification_history_level
 """
 
 
+_SUPPRESSED = object()  # 중복 억제 센티널
+
+
 class NotificationService:
     """알림 라우팅 및 필터링 서비스."""
 
@@ -47,6 +50,7 @@ class NotificationService:
         quiet_end: time | None = None,
         instrument_service: InstrumentService | None = None,
         db: Database | None = None,
+        dedup_window: float = 60.0,
     ) -> None:
         self._adapter = adapter
         self._eventbus = eventbus
@@ -55,6 +59,9 @@ class NotificationService:
         self._quiet_end = quiet_end
         self._instrument_service = instrument_service
         self._db = db
+        self._dedup_window = dedup_window
+        # {dedup_key: (last_sent_timestamp, suppressed_count)}
+        self._dedup_cache: dict[str, tuple[float, int]] = {}
 
     async def initialize(self) -> None:
         """notification_history 테이블 스키마 생성."""
@@ -98,6 +105,46 @@ class NotificationService:
             priority=0,
         )
 
+    def _make_dedup_key(self, level: NotificationLevel, message: str) -> str:
+        """중복 방지 키 생성: level + message_hash."""
+        import hashlib
+
+        msg_hash = hashlib.md5(  # noqa: S324
+            message.encode()
+        ).hexdigest()[:12]
+        return f"{level}:{msg_hash}"
+
+    def _check_dedup(self, level: NotificationLevel, message: str) -> str | object:
+        """중복 여부 확인.
+
+        Returns:
+            _SUPPRESSED: 억제 (발송 안 함)
+            "": 발송 허용 (부기 없음)
+            "(N건 억제됨)": 발송 허용 + 이전 억제 건수 부기
+        """
+        import time as time_mod
+
+        if level == NotificationLevel.CRITICAL:
+            return ""
+
+        key = self._make_dedup_key(level, message)
+        now = time_mod.monotonic()
+
+        if key in self._dedup_cache:
+            last_sent, suppressed = self._dedup_cache[key]
+            if now - last_sent < self._dedup_window:
+                self._dedup_cache[key] = (last_sent, suppressed + 1)
+                return _SUPPRESSED
+
+        # 발송 허용
+        suffix = ""
+        if key in self._dedup_cache:
+            _, suppressed = self._dedup_cache[key]
+            if suppressed > 0:
+                suffix = f" ({suppressed}건 억제됨)"
+        self._dedup_cache[key] = (now, 0)
+        return suffix
+
     async def _send_and_record(
         self,
         level: NotificationLevel,
@@ -108,6 +155,14 @@ class NotificationService:
         bot_id: str = "",
     ) -> bool:
         """send() 호출 후 이력 기록."""
+        dedup_result = self._check_dedup(level, message)
+        if dedup_result is _SUPPRESSED:
+            logger.debug("알림 억제 (중복): %s", message[:50])
+            return False
+
+        if dedup_result:
+            message = message + dedup_result
+
         success = False
         error_message = ""
         try:
@@ -138,6 +193,14 @@ class NotificationService:
         bot_id: str = "",
     ) -> bool:
         """send_rich() 호출 후 이력 기록."""
+        dedup_result = self._check_dedup(level, body or title)
+        if dedup_result is _SUPPRESSED:
+            logger.debug("알림 억제 (중복): %s", (body or title)[:50])
+            return False
+
+        if dedup_result:
+            body = (body or "") + dedup_result
+
         success = False
         error_message = ""
         try:

--- a/tests/unit/test_notification_dedup.py
+++ b/tests/unit/test_notification_dedup.py
@@ -1,0 +1,149 @@
+"""알림 중복 방지 단위 테스트."""
+
+from __future__ import annotations
+
+import time as time_mod
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.notification.base import NotificationLevel
+from ante.notification.service import NotificationService
+
+
+@pytest.fixture
+def service():
+    adapter = AsyncMock()
+    adapter.send = AsyncMock(return_value=True)
+    adapter.send_rich = AsyncMock(return_value=True)
+    eventbus = MagicMock()
+    eventbus.subscribe = MagicMock()
+    return NotificationService(
+        adapter=adapter,
+        eventbus=eventbus,
+        dedup_window=1.0,
+    )
+
+
+class TestDedupBasic:
+    @pytest.mark.asyncio
+    async def test_first_send_passes(self, service):
+        """첫 발송은 정상 통과."""
+        result = await service._send_and_record(
+            NotificationLevel.INFO,
+            "테스트 메시지",
+        )
+        assert result is True
+        service._adapter.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_suppressed(self, service):
+        """동일 메시지 재발송 억제."""
+        await service._send_and_record(
+            NotificationLevel.INFO,
+            "테스트 메시지",
+        )
+        result = await service._send_and_record(
+            NotificationLevel.INFO,
+            "테스트 메시지",
+        )
+        assert result is False
+        assert service._adapter.send.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_different_message_not_suppressed(self, service):
+        """다른 메시지는 억제 안 함."""
+        await service._send_and_record(NotificationLevel.INFO, "메시지 A")
+        result = await service._send_and_record(NotificationLevel.INFO, "메시지 B")
+        assert result is True
+        assert service._adapter.send.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_critical_never_suppressed(self, service):
+        """CRITICAL 레벨은 항상 발송."""
+        await service._send_and_record(
+            NotificationLevel.CRITICAL,
+            "긴급 알림",
+        )
+        result = await service._send_and_record(
+            NotificationLevel.CRITICAL,
+            "긴급 알림",
+        )
+        assert result is True
+        assert service._adapter.send.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_after_window_sends_again(self, service):
+        """dedup_window 경과 후 재발송 허용."""
+        service._dedup_window = 0.1
+
+        await service._send_and_record(
+            NotificationLevel.INFO,
+            "테스트 메시지",
+        )
+
+        time_mod.sleep(0.15)
+
+        result = await service._send_and_record(
+            NotificationLevel.INFO,
+            "테스트 메시지",
+        )
+        assert result is True
+        assert service._adapter.send.call_count == 2
+
+
+class TestDedupSuffix:
+    @pytest.mark.asyncio
+    async def test_suppressed_count_appended(self, service):
+        """억제 후 재발송 시 억제 건수 부기."""
+        service._dedup_window = 0.1
+
+        # 첫 발송
+        await service._send_and_record(NotificationLevel.INFO, "반복 알림")
+        # 억제 2건
+        await service._send_and_record(NotificationLevel.INFO, "반복 알림")
+        await service._send_and_record(NotificationLevel.INFO, "반복 알림")
+
+        time_mod.sleep(0.15)
+
+        # window 후 재발송 — 억제 건수 부기
+        await service._send_and_record(NotificationLevel.INFO, "반복 알림")
+
+        assert service._adapter.send.call_count == 2
+        last_call = service._adapter.send.call_args_list[-1]
+        sent_message = last_call[0][1]
+        assert "(2건 억제됨)" in sent_message
+
+
+class TestDedupRichSend:
+    @pytest.mark.asyncio
+    async def test_rich_send_dedup(self, service):
+        """send_rich도 중복 방지 동작."""
+        await service._send_rich_and_record(
+            NotificationLevel.WARNING,
+            "제목",
+            "본문 내용",
+        )
+        result = await service._send_rich_and_record(
+            NotificationLevel.WARNING,
+            "제목",
+            "본문 내용",
+        )
+        assert result is False
+        assert service._adapter.send_rich.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_rich_critical_not_suppressed(self, service):
+        """send_rich에서도 CRITICAL은 억제 안 함."""
+        await service._send_rich_and_record(
+            NotificationLevel.CRITICAL,
+            "긴급",
+            "긴급 상세",
+        )
+        result = await service._send_rich_and_record(
+            NotificationLevel.CRITICAL,
+            "긴급",
+            "긴급 상세",
+        )
+        assert result is True
+        assert service._adapter.send_rich.call_count == 2


### PR DESCRIPTION
## Summary
- `NotificationService`에 `dedup_window` 파라미터 추가 (기본 60초)
- 동일 메시지(level + message_hash) dedup_window 내 재발송 억제
- CRITICAL 레벨은 중복 방지 미적용 (항상 발송)
- 억제 후 재발송 시 "(N건 억제됨)" 부기

## Test plan
- [x] 기본 동작 테스트 (5건: 첫 발송, 중복 억제, 다른 메시지, CRITICAL, window 경과)
- [x] 억제 건수 부기 테스트 (1건)
- [x] send_rich 중복 방지 테스트 (2건)
- [x] ruff check + format 통과
- [x] 전체 테스트 898건 통과

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)