### PR TITLE
feat: 종목 데이터 CSV/JSON import CLI (#79)

### DIFF
--- a/src/ante/cli/commands/instrument.py
+++ b/src/ante/cli/commands/instrument.py
@@ -226,3 +226,115 @@ def search(
         return
 
     fmt.table(results, ["symbol", "exchange", "name", "name_en", "type"])
+
+
+@instrument.command("import")
+@click.argument("file_path", type=click.Path(exists=True))
+@click.option("--dry-run", is_flag=True, help="실제 저장 없이 미리보기")
+@click.option("--db-path", default="db/ante.db", help="DB 경로")
+@click.pass_context
+@require_auth
+@require_scope("data:write")
+def instrument_import(
+    ctx: click.Context,
+    file_path: str,
+    dry_run: bool,
+    db_path: str,
+) -> None:
+    """CSV/JSON 파일에서 종목 데이터 import."""
+    import json
+    from pathlib import Path
+
+    from ante.instrument.models import Instrument
+
+    fmt = get_formatter(ctx)
+    path = Path(file_path)
+    ext = path.suffix.lower()
+
+    # 파일 읽기
+    try:
+        if ext == ".csv":
+            import csv
+
+            with open(path, newline="", encoding="utf-8") as f:
+                reader = csv.DictReader(f)
+                records = list(reader)
+        elif ext == ".json":
+            with open(path, encoding="utf-8") as f:
+                records = json.load(f)
+                if not isinstance(records, list):
+                    fmt.error("JSON 파일은 배열 형태여야 합니다.")
+                    return
+        else:
+            fmt.error(f"지원하지 않는 파일 형식: {ext} (csv 또는 json만 지원)")
+            return
+    except Exception as e:
+        fmt.error(f"파일 읽기 실패: {e}")
+        return
+
+    if not records:
+        fmt.error("파일에 데이터가 없습니다.")
+        return
+
+    # 필수 컬럼 확인
+    first = records[0]
+    if "symbol" not in first or "exchange" not in first:
+        fmt.error("필수 컬럼 누락: symbol, exchange가 필요합니다.")
+        return
+
+    instruments = [
+        Instrument(
+            symbol=r["symbol"],
+            exchange=r["exchange"],
+            name=r.get("name", ""),
+            name_en=r.get("name_en", ""),
+            instrument_type=r.get("instrument_type", ""),
+            listed=str(r.get("listed", "true")).lower() in ("true", "1", "yes", "y"),
+        )
+        for r in records
+    ]
+
+    if dry_run:
+        preview = [
+            {
+                "symbol": inst.symbol,
+                "exchange": inst.exchange,
+                "name": inst.name,
+                "type": inst.instrument_type,
+            }
+            for inst in instruments[:10]
+        ]
+        if fmt.is_json:
+            fmt.output(
+                {
+                    "dry_run": True,
+                    "total": len(instruments),
+                    "preview": preview,
+                }
+            )
+        else:
+            click.echo(f"  미리보기 ({len(instruments)}건 중 상위 {len(preview)}건):")
+            fmt.table(
+                preview,
+                ["symbol", "exchange", "name", "type"],
+            )
+        return
+
+    async def _import() -> int:
+        from ante.core.database import Database
+        from ante.instrument.service import InstrumentService
+
+        db = Database(db_path)
+        await db.connect()
+        try:
+            svc = InstrumentService(db)
+            await svc.initialize()
+            return await svc.bulk_upsert(instruments)
+        finally:
+            await db.close()
+
+    count = asyncio.run(_import())
+    fmt.success(
+        f"종목 import 완료: {count}건",
+        {"count": count, "file": str(path)},
+    )

--- a/tests/unit/test_instrument_import.py
+++ b/tests/unit/test_instrument_import.py
@@ -1,0 +1,154 @@
+"""종목 데이터 import CLI 단위 테스트."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+class TestInstrumentImportCSV:
+    def test_import_csv(self, runner, tmp_path):
+        csv_file = tmp_path / "instruments.csv"
+        csv_file.write_text(
+            "symbol,exchange,name,instrument_type\n"
+            "005930,KRX,삼성전자,stock\n"
+            "000660,KRX,SK하이닉스,stock\n"
+        )
+
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = 2
+            result = runner.invoke(
+                cli,
+                ["instrument", "import", str(csv_file)],
+            )
+            assert result.exit_code == 0
+            assert "2건" in result.output
+
+    def test_import_csv_dry_run(self, runner, tmp_path):
+        csv_file = tmp_path / "instruments.csv"
+        csv_file.write_text("symbol,exchange,name\n005930,KRX,삼성전자\n")
+
+        result = runner.invoke(
+            cli,
+            ["instrument", "import", str(csv_file), "--dry-run"],
+        )
+        assert result.exit_code == 0
+        assert "미리보기" in result.output
+        assert "005930" in result.output
+
+
+class TestInstrumentImportJSON:
+    def test_import_json(self, runner, tmp_path):
+        json_file = tmp_path / "instruments.json"
+        data = [
+            {"symbol": "005930", "exchange": "KRX", "name": "삼성전자"},
+            {"symbol": "000660", "exchange": "KRX", "name": "SK하이닉스"},
+        ]
+        json_file.write_text(json.dumps(data))
+
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = 2
+            result = runner.invoke(
+                cli,
+                ["instrument", "import", str(json_file)],
+            )
+            assert result.exit_code == 0
+            assert "2건" in result.output
+
+    def test_import_json_dry_run_format(self, runner, tmp_path):
+        json_file = tmp_path / "instruments.json"
+        data = [{"symbol": "005930", "exchange": "KRX"}]
+        json_file.write_text(json.dumps(data))
+
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "instrument",
+                "import",
+                str(json_file),
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert output["dry_run"] is True
+        assert output["total"] == 1
+
+
+class TestInstrumentImportErrors:
+    def test_unsupported_extension(self, runner, tmp_path):
+        xml_file = tmp_path / "instruments.xml"
+        xml_file.write_text("<data/>")
+
+        result = runner.invoke(
+            cli,
+            ["instrument", "import", str(xml_file)],
+        )
+        assert "지원하지 않는 파일 형식" in result.output
+
+    def test_missing_required_columns(self, runner, tmp_path):
+        csv_file = tmp_path / "bad.csv"
+        csv_file.write_text("name,type\nSamsung,stock\n")
+
+        result = runner.invoke(
+            cli,
+            ["instrument", "import", str(csv_file)],
+        )
+        assert "필수 컬럼 누락" in result.output
+
+    def test_empty_file(self, runner, tmp_path):
+        csv_file = tmp_path / "empty.csv"
+        csv_file.write_text("symbol,exchange\n")
+
+        result = runner.invoke(
+            cli,
+            ["instrument", "import", str(csv_file)],
+        )
+        assert "데이터가 없습니다" in result.output
+
+    def test_json_not_array(self, runner, tmp_path):
+        json_file = tmp_path / "bad.json"
+        json_file.write_text('{"symbol": "005930"}')
+
+        result = runner.invoke(
+            cli,
+            ["instrument", "import", str(json_file)],
+        )
+        assert "배열 형태" in result.output


### PR DESCRIPTION
## Summary
- CSV/JSON 파일에서 종목 데이터를 읽어 DB에 bulk upsert하는 `instrument import` 커맨드 추가
- `--dry-run` 미리보기, 파일 형식 자동 감지, 필수 컬럼(symbol, exchange) 검증
- 에러 케이스 처리: 미지원 확장자, 필수 컬럼 누락, 빈 파일, 비배열 JSON

Closes #79

## Test plan
- [x] CSV import 정상 동작 테스트
- [x] CSV dry-run 미리보기 테스트
- [x] JSON import 정상 동작 테스트
- [x] JSON dry-run + format json 테스트
- [x] 미지원 파일 형식 에러 테스트
- [x] 필수 컬럼 누락 에러 테스트
- [x] 빈 파일 에러 테스트
- [x] JSON 비배열 에러 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)