### PR TITLE
feat: --listed-only 옵션으로 상장 종목 필터 (#80)

### DIFF
--- a/src/ante/cli/commands/instrument.py
+++ b/src/ante/cli/commands/instrument.py
@@ -20,6 +20,7 @@ def instrument() -> None:
 @click.option(
     "--type", "inst_type", default=None, help="종목 유형 필터 (stock, etf, etn 등)"
 )
+@click.option("--listed-only", is_flag=True, help="상장 종목만 표시")
 @click.option("--db-path", default="db/ante.db", help="DB 경로")
 @click.pass_context
 @require_auth
@@ -28,6 +29,7 @@ def instrument_list(
     ctx: click.Context,
     exchange: str,
     inst_type: str | None,
+    listed_only: bool,
     db_path: str,
 ) -> None:
     """등록된 종목 목록 조회."""
@@ -49,6 +51,9 @@ def instrument_list(
             if inst_type:
                 query += " AND instrument_type = ?"
                 params.append(inst_type)
+
+            if listed_only:
+                query += " AND listed = 1"
 
             query += " ORDER BY symbol"
             rows = await db.fetch_all(query, tuple(params))
@@ -183,6 +188,7 @@ def sync(
 @instrument.command()
 @click.argument("keyword")
 @click.option("--limit", default=20, help="최대 결과 수")
+@click.option("--listed-only", is_flag=True, help="상장 종목만 검색")
 @click.option("--db-path", default="db/ante.db", help="DB 경로")
 @click.pass_context
 @require_auth
@@ -191,6 +197,7 @@ def search(
     ctx: click.Context,
     keyword: str,
     limit: int,
+    listed_only: bool,
     db_path: str,
 ) -> None:
     """키워드로 종목 검색 (종목코드, 한글명, 영문명)."""
@@ -205,7 +212,11 @@ def search(
         try:
             svc = InstrumentService(db)
             await svc.initialize()
-            instruments = await svc.search(keyword, limit=limit)
+            instruments = await svc.search(
+                keyword,
+                limit=limit,
+                listed_only=listed_only,
+            )
             return [
                 {
                     "symbol": inst.symbol,

--- a/src/ante/instrument/service.py
+++ b/src/ante/instrument/service.py
@@ -62,15 +62,27 @@ class InstrumentService:
         inst = self._cache.get((symbol, exchange))
         return inst.name if inst and inst.name else symbol
 
-    async def search(self, keyword: str, limit: int = 20) -> list[Instrument]:
+    async def search(
+        self,
+        keyword: str,
+        limit: int = 20,
+        listed_only: bool = False,
+    ) -> list[Instrument]:
         """키워드로 종목 검색 (name, name_en, symbol LIKE)."""
         pattern = f"%{keyword}%"
-        rows = await self._db.fetch_all(
+        query = (
             "SELECT * FROM instruments "
-            "WHERE name LIKE ? OR name_en LIKE ? OR symbol LIKE ? "
-            "LIMIT ?",
-            (pattern, pattern, pattern, limit),
+            "WHERE (name LIKE ? OR name_en LIKE ? OR symbol LIKE ?)"
         )
+        params: list[object] = [pattern, pattern, pattern]
+
+        if listed_only:
+            query += " AND listed = 1"
+
+        query += " LIMIT ?"
+        params.append(limit)
+
+        rows = await self._db.fetch_all(query, tuple(params))
         return [self._row_to_instrument(row) for row in rows]
 
     async def bulk_upsert(self, instruments: list[Instrument]) -> int:

--- a/tests/unit/test_listed_only.py
+++ b/tests/unit/test_listed_only.py
@@ -1,0 +1,194 @@
+"""listed_only 필터 단위 테스트."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.instrument.service import InstrumentService
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+class TestInstrumentServiceListedOnly:
+    @pytest.mark.asyncio
+    async def test_search_default_returns_all(self):
+        """기본 검색은 모든 종목 반환."""
+        db = AsyncMock()
+        db.execute_script = AsyncMock()
+        db.fetch_all = AsyncMock(
+            side_effect=[
+                [],  # _warm_cache
+                [
+                    {
+                        "symbol": "005930",
+                        "exchange": "KRX",
+                        "name": "삼성전자",
+                        "name_en": "Samsung",
+                        "instrument_type": "stock",
+                        "logo_url": "",
+                        "listed": 1,
+                        "updated_at": "",
+                    },
+                    {
+                        "symbol": "000000",
+                        "exchange": "KRX",
+                        "name": "폐지종목",
+                        "name_en": "Delisted",
+                        "instrument_type": "stock",
+                        "logo_url": "",
+                        "listed": 0,
+                        "updated_at": "",
+                    },
+                ],
+            ]
+        )
+
+        svc = InstrumentService(db)
+        await svc.initialize()
+        results = await svc.search("종목")
+
+        assert len(results) == 2
+        # listed_only=False이므로 listed 필터 없어야 함
+        call_args = db.fetch_all.call_args_list[-1]
+        assert "AND listed = 1" not in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_search_listed_only_filters(self):
+        """listed_only=True이면 상장 종목만 검색."""
+        db = AsyncMock()
+        db.execute_script = AsyncMock()
+        db.fetch_all = AsyncMock(
+            side_effect=[
+                [],  # _warm_cache
+                [
+                    {
+                        "symbol": "005930",
+                        "exchange": "KRX",
+                        "name": "삼성전자",
+                        "name_en": "Samsung",
+                        "instrument_type": "stock",
+                        "logo_url": "",
+                        "listed": 1,
+                        "updated_at": "",
+                    },
+                ],
+            ]
+        )
+
+        svc = InstrumentService(db)
+        await svc.initialize()
+        results = await svc.search("삼성", listed_only=True)
+
+        assert len(results) == 1
+        call_args = db.fetch_all.call_args_list[-1]
+        assert "AND listed = 1" in call_args[0][0]
+
+
+class TestListCLIListedOnly:
+    def test_list_without_listed_only(self, runner):
+        """기본 list는 모든 종목 표시."""
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = [
+                {
+                    "symbol": "005930",
+                    "name": "삼성전자",
+                    "name_en": "Samsung",
+                    "type": "stock",
+                    "listed": "Y",
+                },
+                {
+                    "symbol": "000000",
+                    "name": "폐지종목",
+                    "name_en": "Delisted",
+                    "type": "stock",
+                    "listed": "N",
+                },
+            ]
+            result = runner.invoke(cli, ["instrument", "list"])
+            assert result.exit_code == 0
+            assert "005930" in result.output
+            assert "000000" in result.output
+
+    def test_list_with_listed_only(self, runner):
+        """--listed-only 시 상장 종목만 표시."""
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = [
+                {
+                    "symbol": "005930",
+                    "name": "삼성전자",
+                    "name_en": "Samsung",
+                    "type": "stock",
+                    "listed": "Y",
+                },
+            ]
+            result = runner.invoke(cli, ["instrument", "list", "--listed-only"])
+            assert result.exit_code == 0
+            assert "005930" in result.output
+
+
+class TestSearchCLIListedOnly:
+    def test_search_without_listed_only(self, runner):
+        """기본 search는 모든 종목 검색."""
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = [
+                {
+                    "symbol": "005930",
+                    "exchange": "KRX",
+                    "name": "삼성전자",
+                    "name_en": "Samsung",
+                    "type": "stock",
+                },
+            ]
+            result = runner.invoke(cli, ["instrument", "search", "삼성"])
+            assert result.exit_code == 0
+            assert "005930" in result.output
+
+    def test_search_with_listed_only(self, runner):
+        """--listed-only 시 상장 종목만 검색."""
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = [
+                {
+                    "symbol": "005930",
+                    "exchange": "KRX",
+                    "name": "삼성전자",
+                    "name_en": "Samsung",
+                    "type": "stock",
+                },
+            ]
+            result = runner.invoke(
+                cli, ["instrument", "search", "--listed-only", "삼성"]
+            )
+            assert result.exit_code == 0
+            assert "005930" in result.output


### PR DESCRIPTION
## Summary
- `instrument list --listed-only` — listed=True인 종목만 표시
- `instrument search --listed-only <keyword>` — 상장 종목만 검색
- `InstrumentService.search()에 listed_only` 파라미터 추가
- 기본값은 모든 종목 표시 (하위 호환 유지)

Closes #80

## Test plan
- [x] InstrumentService.search() 기본 호출 시 모든 종목 반환
- [x] InstrumentService.search(listed_only=True) 시 listed=1 필터 적용
- [x] CLI instrument list 기본 동작
- [x] CLI instrument list --listed-only 동작
- [x] CLI instrument search 기본 동작
- [x] CLI instrument search --listed-only 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)