### PR TITLE
feat: InstrumentService 캐시 TTL 갱신 주기 설정 (#81)

### DIFF
--- a/src/ante/config/defaults.py
+++ b/src/ante/config/defaults.py
@@ -11,6 +11,7 @@ DEFAULTS: dict[str, object] = {
     "web.port": 8000,
     "eventbus.history_size": 1000,
     "instrument.default_exchange": "KRX",
+    "instrument.cache_ttl_seconds": 3600,
     "broker.commission_rate": 0.00015,
     "broker.sell_tax_rate": 0.0023,
     "broker.retry.max_retries_order": 3,

--- a/src/ante/instrument/service.py
+++ b/src/ante/instrument/service.py
@@ -35,9 +35,11 @@ class InstrumentService:
     한국 상장 종목 ~2,500개 수준이므로 전체 메모리 적재가 합리적.
     """
 
-    def __init__(self, db: Database) -> None:
+    def __init__(self, db: Database, cache_ttl_seconds: float = 3600.0) -> None:
         self._db = db
         self._cache: dict[tuple[str, str], Instrument] = {}
+        self._cache_ttl = cache_ttl_seconds
+        self._cache_loaded_at: float = 0.0
 
     async def initialize(self) -> None:
         """스키마 생성 + 캐시 워밍."""
@@ -47,14 +49,33 @@ class InstrumentService:
 
     async def _warm_cache(self) -> None:
         """DB 전체 로드 → 메모리 캐시."""
+        import time as time_mod
+
         rows = await self._db.fetch_all("SELECT * FROM instruments")
         self._cache = {
             (row["symbol"], row["exchange"]): self._row_to_instrument(row)
             for row in rows
         }
+        self._cache_loaded_at = time_mod.monotonic()
+
+    def _is_cache_expired(self) -> bool:
+        """캐시 TTL 초과 여부."""
+        import time as time_mod
+
+        if self._cache_loaded_at == 0.0:
+            return True
+        return (time_mod.monotonic() - self._cache_loaded_at) > self._cache_ttl
+
+    async def _ensure_cache(self) -> None:
+        """캐시 TTL 초과 시 재로드."""
+        if self._is_cache_expired():
+            logger.info("캐시 TTL 만료, 재로드 시작")
+            await self._warm_cache()
+            logger.info("캐시 재로드 완료 (%d건)", len(self._cache))
 
     async def get(self, symbol: str, exchange: str = "KRX") -> Instrument | None:
-        """(symbol, exchange) 조회. 캐시 우선."""
+        """(symbol, exchange) 조회. 캐시 TTL 체크."""
+        await self._ensure_cache()
         return self._cache.get((symbol, exchange))
 
     def get_name(self, symbol: str, exchange: str = "KRX") -> str:

--- a/tests/unit/test_instrument_cache_ttl.py
+++ b/tests/unit/test_instrument_cache_ttl.py
@@ -1,0 +1,128 @@
+"""InstrumentService 캐시 TTL 단위 테스트."""
+
+from __future__ import annotations
+
+import time as time_mod
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ante.instrument.service import InstrumentService
+
+
+def _make_row(symbol: str = "005930", exchange: str = "KRX") -> dict:
+    return {
+        "symbol": symbol,
+        "exchange": exchange,
+        "name": "삼성전자",
+        "name_en": "Samsung",
+        "instrument_type": "stock",
+        "logo_url": "",
+        "listed": 1,
+        "updated_at": "",
+    }
+
+
+class TestCacheTTL:
+    @pytest.mark.asyncio
+    async def test_default_ttl(self):
+        """기본 TTL은 3600초."""
+        db = AsyncMock()
+        svc = InstrumentService(db)
+        assert svc._cache_ttl == 3600.0
+
+    @pytest.mark.asyncio
+    async def test_custom_ttl(self):
+        """커스텀 TTL 설정."""
+        db = AsyncMock()
+        svc = InstrumentService(db, cache_ttl_seconds=120.0)
+        assert svc._cache_ttl == 120.0
+
+    @pytest.mark.asyncio
+    async def test_cache_not_expired_within_ttl(self):
+        """TTL 내에서는 캐시 재로드하지 않음."""
+        db = AsyncMock()
+        db.execute_script = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[_make_row()])
+
+        svc = InstrumentService(db, cache_ttl_seconds=3600.0)
+        await svc.initialize()
+
+        # initialize에서 1회 fetch
+        assert db.fetch_all.call_count == 1
+
+        # get() 호출 — TTL 내이므로 재로드 안 함
+        result = await svc.get("005930")
+        assert result is not None
+        assert result.symbol == "005930"
+        assert db.fetch_all.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_cache_expired_triggers_reload(self):
+        """TTL 초과 시 캐시 재로드."""
+        db = AsyncMock()
+        db.execute_script = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[_make_row()])
+
+        svc = InstrumentService(db, cache_ttl_seconds=0.1)
+        await svc.initialize()
+
+        assert db.fetch_all.call_count == 1
+
+        # TTL 초과 대기
+        time_mod.sleep(0.15)
+
+        # get() 호출 — TTL 만료로 재로드
+        await svc.get("005930")
+        assert db.fetch_all.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_cache_reload_updates_data(self):
+        """캐시 재로드 시 새 데이터 반영."""
+        db = AsyncMock()
+        db.execute_script = AsyncMock()
+
+        row_v1 = _make_row()
+        row_v1["name"] = "삼성전자(구)"
+        row_v2 = _make_row()
+        row_v2["name"] = "삼성전자(신)"
+
+        db.fetch_all = AsyncMock(side_effect=[[row_v1], [row_v2]])
+
+        svc = InstrumentService(db, cache_ttl_seconds=0.1)
+        await svc.initialize()
+
+        result = await svc.get("005930")
+        assert result is not None
+        assert result.name == "삼성전자(구)"
+
+        time_mod.sleep(0.15)
+
+        result = await svc.get("005930")
+        assert result is not None
+        assert result.name == "삼성전자(신)"
+
+    @pytest.mark.asyncio
+    async def test_bulk_upsert_resets_cache_timestamp(self):
+        """bulk_upsert 후에도 캐시 타임스탬프 유지 (upsert는 개별 갱신)."""
+        db = AsyncMock()
+        db.execute_script = AsyncMock()
+        db.execute = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        svc = InstrumentService(db, cache_ttl_seconds=3600.0)
+        await svc.initialize()
+
+        from ante.instrument.models import Instrument
+
+        inst = Instrument(
+            symbol="005930",
+            exchange="KRX",
+            name="삼성전자",
+        )
+        await svc.bulk_upsert([inst])
+
+        # 캐시에 직접 추가됨
+        result = await svc.get("005930")
+        assert result is not None
+        assert result.symbol == "005930"


### PR DESCRIPTION
## Summary
- `InstrumentService.get()` 호출 시 캐시 TTL 체크, 만료 시 DB 자동 재로드
- `cache_ttl_seconds` 생성자 파라미터 추가 (기본 3600초)
- `defaults.py`에 `instrument.cache_ttl_seconds: 3600` 설정 추가

Closes #81

## Test plan
- [x] 기본 TTL 3600초 확인
- [x] 커스텀 TTL 설정 확인
- [x] TTL 내에서 캐시 재로드 안 함
- [x] TTL 초과 시 캐시 재로드 트리거
- [x] 캐시 재로드 시 새 데이터 반영
- [x] bulk_upsert 후 캐시 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)