### PR TITLE
feat: Web API cursor 기반 페이지네이션 (#82)

### DIFF
--- a/src/ante/web/app.py
+++ b/src/ante/web/app.py
@@ -32,15 +32,25 @@ def create_app(**services: Any) -> FastAPI:
     for name, service in services.items():
         setattr(app.state, name, service)
 
+    from ante.web.routes.bots import router as bots_router
     from ante.web.routes.data import router as data_router
+    from ante.web.routes.notifications import router as notifications_router
     from ante.web.routes.reports import router as report_router
     from ante.web.routes.strategies import router as strategy_router
     from ante.web.routes.system import router as system_router
+    from ante.web.routes.trades import router as trades_router
 
     app.include_router(system_router, prefix="/api/system", tags=["system"])
     app.include_router(strategy_router, prefix="/api/strategies", tags=["strategies"])
     app.include_router(report_router, prefix="/api/reports", tags=["reports"])
     app.include_router(data_router, prefix="/api/data", tags=["data"])
+    app.include_router(trades_router, prefix="/api/trades", tags=["trades"])
+    app.include_router(bots_router, prefix="/api/bots", tags=["bots"])
+    app.include_router(
+        notifications_router,
+        prefix="/api/notifications",
+        tags=["notifications"],
+    )
 
     from ante.web.errors import register_exception_handlers
 

--- a/src/ante/web/pagination.py
+++ b/src/ante/web/pagination.py
@@ -1,0 +1,54 @@
+"""Cursor 기반 페이지네이션 유틸리티."""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+
+def encode_cursor(value: str) -> str:
+    """값을 opaque cursor 문자열로 인코딩."""
+    return base64.urlsafe_b64encode(value.encode()).decode()
+
+
+def decode_cursor(cursor: str) -> str:
+    """Opaque cursor를 원래 값으로 디코딩."""
+    return base64.urlsafe_b64decode(cursor.encode()).decode()
+
+
+def paginate(
+    items: list[dict[str, Any]],
+    *,
+    cursor_field: str,
+    limit: int,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    """리스트에 cursor 기반 페이지네이션 적용.
+
+    Args:
+        items: 전체 항목 (cursor_field 기준 정렬 필요).
+        cursor_field: cursor로 사용할 필드 이름.
+        limit: 반환할 최대 항목 수.
+        cursor: 이전 페이지의 next_cursor 값.
+
+    Returns:
+        {"items": [...], "next_cursor": "..." | None}
+    """
+    if cursor:
+        decoded = decode_cursor(cursor)
+        filtered = []
+        found = False
+        for item in items:
+            if found:
+                filtered.append(item)
+            elif str(item[cursor_field]) == decoded:
+                found = True
+        items = filtered
+
+    page = items[:limit]
+    next_cursor = None
+    if len(items) > limit:
+        last = page[-1]
+        next_cursor = encode_cursor(str(last[cursor_field]))
+
+    return {"items": page, "next_cursor": next_cursor}

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -1,0 +1,25 @@
+"""봇 관리 API."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+router = APIRouter()
+
+
+@router.get("")
+async def list_bots(
+    request: Request,
+    limit: int = 20,
+    cursor: str | None = None,
+) -> dict:
+    """봇 목록 조회 (cursor 기반 페이지네이션)."""
+    from ante.web.pagination import paginate
+
+    bot_manager = getattr(request.app.state, "bot_manager", None)
+    if bot_manager is None:
+        raise HTTPException(status_code=503, detail="Bot manager not available")
+
+    bots = bot_manager.list_bots()
+    result = paginate(bots, cursor_field="bot_id", limit=limit, cursor=cursor)
+    return {"bots": result["items"], "next_cursor": result["next_cursor"]}

--- a/src/ante/web/routes/notifications.py
+++ b/src/ante/web/routes/notifications.py
@@ -1,0 +1,43 @@
+"""알림 이력 API."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+router = APIRouter()
+
+
+@router.get("")
+async def list_notifications(
+    request: Request,
+    level: str | None = None,
+    limit: int = 20,
+    cursor: str | None = None,
+) -> dict:
+    """알림 이력 조회 (cursor 기반 페이지네이션)."""
+    from ante.web.pagination import paginate
+
+    notification_service = getattr(request.app.state, "notification_service", None)
+    if notification_service is None:
+        raise HTTPException(
+            status_code=503, detail="Notification service not available"
+        )
+
+    rows = await notification_service.get_history(level=level, limit=limit + 1)
+    items = [
+        {
+            "id": str(r["id"]),
+            "level": r["level"],
+            "title": r["title"],
+            "message": r["message"],
+            "success": bool(r["success"]),
+            "created_at": r["created_at"],
+        }
+        for r in rows
+    ]
+
+    result = paginate(items, cursor_field="id", limit=limit, cursor=cursor)
+    return {
+        "notifications": result["items"],
+        "next_cursor": result["next_cursor"],
+    }

--- a/src/ante/web/routes/reports.py
+++ b/src/ante/web/routes/reports.py
@@ -36,21 +36,25 @@ async def list_reports(
     request: Request,
     status: str | None = None,
     limit: int = 20,
+    cursor: str | None = None,
 ) -> dict:
-    """리포트 목록 조회."""
+    """리포트 목록 조회 (cursor 기반 페이지네이션)."""
+    from ante.web.pagination import paginate
+
     report_store = getattr(request.app.state, "report_store", None)
     if report_store is None:
         raise HTTPException(status_code=503, detail="Report store not available")
 
     reports = await report_store.list_reports(status=status)
-    return {
-        "reports": [
-            {
-                "report_id": r.report_id,
-                "strategy": r.strategy_name,
-                "status": r.status.value,
-                "submitted_at": str(r.submitted_at),
-            }
-            for r in reports[:limit]
-        ]
-    }
+    items = [
+        {
+            "report_id": r.report_id,
+            "strategy": r.strategy_name,
+            "status": r.status.value,
+            "submitted_at": str(r.submitted_at),
+        }
+        for r in reports
+    ]
+
+    result = paginate(items, cursor_field="report_id", limit=limit, cursor=cursor)
+    return {"reports": result["items"], "next_cursor": result["next_cursor"]}

--- a/src/ante/web/routes/trades.py
+++ b/src/ante/web/routes/trades.py
@@ -1,0 +1,45 @@
+"""거래 기록 API."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+router = APIRouter()
+
+
+@router.get("")
+async def list_trades(
+    request: Request,
+    bot_id: str | None = None,
+    symbol: str | None = None,
+    limit: int = 20,
+    cursor: str | None = None,
+) -> dict:
+    """거래 기록 목록 조회 (cursor 기반 페이지네이션)."""
+    from ante.web.pagination import paginate
+
+    trade_service = getattr(request.app.state, "trade_service", None)
+    if trade_service is None:
+        raise HTTPException(status_code=503, detail="Trade service not available")
+
+    trades = await trade_service.get_trades(
+        bot_id=bot_id,
+        symbol=symbol,
+        limit=limit + 1,
+    )
+    items = [
+        {
+            "trade_id": t.trade_id,
+            "bot_id": t.bot_id,
+            "symbol": t.symbol,
+            "side": t.side,
+            "quantity": t.quantity,
+            "price": t.price,
+            "status": t.status.value if hasattr(t.status, "value") else str(t.status),
+            "created_at": str(t.created_at),
+        }
+        for t in trades
+    ]
+
+    result = paginate(items, cursor_field="trade_id", limit=limit, cursor=cursor)
+    return {"trades": result["items"], "next_cursor": result["next_cursor"]}

--- a/tests/unit/test_api_pagination.py
+++ b/tests/unit/test_api_pagination.py
@@ -1,0 +1,184 @@
+"""Web API 페이지네이션 단위 테스트."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from ante.web.app import create_app
+from ante.web.pagination import decode_cursor, encode_cursor, paginate
+
+
+class TestPaginationUtil:
+    def test_encode_decode_roundtrip(self):
+        """cursor 인코딩/디코딩 왕복."""
+        original = "report-123"
+        cursor = encode_cursor(original)
+        assert decode_cursor(cursor) == original
+
+    def test_paginate_first_page(self):
+        """첫 페이지 반환."""
+        items = [{"id": str(i)} for i in range(5)]
+        result = paginate(items, cursor_field="id", limit=3)
+        assert len(result["items"]) == 3
+        assert result["next_cursor"] is not None
+
+    def test_paginate_last_page(self):
+        """마지막 페이지면 next_cursor=None."""
+        items = [{"id": str(i)} for i in range(3)]
+        result = paginate(items, cursor_field="id", limit=5)
+        assert len(result["items"]) == 3
+        assert result["next_cursor"] is None
+
+    def test_paginate_with_cursor(self):
+        """cursor 이후 항목 반환."""
+        items = [{"id": str(i)} for i in range(5)]
+        cursor = encode_cursor("1")
+        result = paginate(items, cursor_field="id", limit=2, cursor=cursor)
+        assert len(result["items"]) == 2
+        assert result["items"][0]["id"] == "2"
+        assert result["items"][1]["id"] == "3"
+        assert result["next_cursor"] is not None
+
+    def test_paginate_cursor_at_end(self):
+        """cursor가 마지막 항목이면 빈 결과."""
+        items = [{"id": str(i)} for i in range(3)]
+        cursor = encode_cursor("2")
+        result = paginate(items, cursor_field="id", limit=10, cursor=cursor)
+        assert len(result["items"]) == 0
+        assert result["next_cursor"] is None
+
+    def test_paginate_empty_list(self):
+        """빈 리스트."""
+        result = paginate([], cursor_field="id", limit=10)
+        assert len(result["items"]) == 0
+        assert result["next_cursor"] is None
+
+
+class TestReportsEndpointPagination:
+    @pytest.mark.asyncio
+    async def test_reports_returns_next_cursor(self):
+        """리포트 목록에 next_cursor 포함."""
+        mock_store = AsyncMock()
+        reports = []
+        for i in range(5):
+            r = MagicMock()
+            r.report_id = f"rpt-{i}"
+            r.strategy_name = "test"
+            r.status.value = "submitted"
+            r.submitted_at = "2025-01-01"
+            reports.append(r)
+        mock_store.list_reports = AsyncMock(return_value=reports)
+
+        app = create_app(report_store=mock_store)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/api/reports?limit=3")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data["reports"]) == 3
+            assert data["next_cursor"] is not None
+
+    @pytest.mark.asyncio
+    async def test_reports_no_cursor_when_all_fit(self):
+        """전체 결과가 limit 이내면 next_cursor=null."""
+        mock_store = AsyncMock()
+        r = MagicMock()
+        r.report_id = "rpt-0"
+        r.strategy_name = "test"
+        r.status.value = "submitted"
+        r.submitted_at = "2025-01-01"
+        mock_store.list_reports = AsyncMock(return_value=[r])
+
+        app = create_app(report_store=mock_store)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/api/reports?limit=20")
+            data = resp.json()
+            assert data["next_cursor"] is None
+
+
+class TestBotsEndpointPagination:
+    @pytest.mark.asyncio
+    async def test_bots_pagination(self):
+        """봇 목록 페이지네이션."""
+        mock_manager = MagicMock()
+        bots = [{"bot_id": f"bot-{i}", "status": "running"} for i in range(5)]
+        mock_manager.list_bots.return_value = bots
+
+        app = create_app(bot_manager=mock_manager)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/api/bots?limit=3")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data["bots"]) == 3
+            assert data["next_cursor"] is not None
+
+    @pytest.mark.asyncio
+    async def test_bots_service_unavailable(self):
+        """봇 매니저 없으면 503."""
+        app = create_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/api/bots")
+            assert resp.status_code == 503
+
+
+class TestTradesEndpointPagination:
+    @pytest.mark.asyncio
+    async def test_trades_pagination(self):
+        """거래 기록 페이지네이션."""
+        mock_service = AsyncMock()
+        trades = []
+        for i in range(5):
+            t = MagicMock()
+            t.trade_id = f"trd-{i}"
+            t.bot_id = "bot-1"
+            t.symbol = "005930"
+            t.side = "buy"
+            t.quantity = 10
+            t.price = 70000
+            t.status.value = "filled"
+            t.created_at = "2025-01-01"
+            trades.append(t)
+        mock_service.get_trades = AsyncMock(return_value=trades)
+
+        app = create_app(trade_service=mock_service)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/api/trades?limit=3")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data["trades"]) == 3
+            assert data["next_cursor"] is not None
+
+
+class TestNotificationsEndpointPagination:
+    @pytest.mark.asyncio
+    async def test_notifications_pagination(self):
+        """알림 이력 페이지네이션."""
+        mock_service = AsyncMock()
+        rows = [
+            {
+                "id": i,
+                "level": "INFO",
+                "title": "",
+                "message": f"msg-{i}",
+                "success": 1,
+                "created_at": "2025-01-01",
+            }
+            for i in range(5)
+        ]
+        mock_service.get_history = AsyncMock(return_value=rows)
+
+        app = create_app(notification_service=mock_service)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/api/notifications?limit=3")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data["notifications"]) == 3
+            assert data["next_cursor"] is not None

--- a/tests/unit/test_api_pagination.py
+++ b/tests/unit/test_api_pagination.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-from fastapi.testclient import TestClient
+import pytest
 
-from ante.web.app import create_app
 from ante.web.pagination import decode_cursor, encode_cursor, paginate
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402
 
 
 class TestPaginationUtil:

--- a/tests/unit/test_api_pagination.py
+++ b/tests/unit/test_api_pagination.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-from httpx import ASGITransport, AsyncClient
+from fastapi.testclient import TestClient
 
 from ante.web.app import create_app
 from ante.web.pagination import decode_cursor, encode_cursor, paginate
@@ -58,8 +57,7 @@ class TestPaginationUtil:
 
 
 class TestReportsEndpointPagination:
-    @pytest.mark.asyncio
-    async def test_reports_returns_next_cursor(self):
+    def test_reports_returns_next_cursor(self):
         """리포트 목록에 next_cursor 포함."""
         mock_store = AsyncMock()
         reports = []
@@ -73,16 +71,14 @@ class TestReportsEndpointPagination:
         mock_store.list_reports = AsyncMock(return_value=reports)
 
         app = create_app(report_store=mock_store)
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as ac:
-            resp = await ac.get("/api/reports?limit=3")
-            assert resp.status_code == 200
-            data = resp.json()
-            assert len(data["reports"]) == 3
-            assert data["next_cursor"] is not None
+        client = TestClient(app)
+        resp = client.get("/api/reports?limit=3")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["reports"]) == 3
+        assert data["next_cursor"] is not None
 
-    @pytest.mark.asyncio
-    async def test_reports_no_cursor_when_all_fit(self):
+    def test_reports_no_cursor_when_all_fit(self):
         """전체 결과가 limit 이내면 next_cursor=null."""
         mock_store = AsyncMock()
         r = MagicMock()
@@ -93,43 +89,37 @@ class TestReportsEndpointPagination:
         mock_store.list_reports = AsyncMock(return_value=[r])
 
         app = create_app(report_store=mock_store)
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as ac:
-            resp = await ac.get("/api/reports?limit=20")
-            data = resp.json()
-            assert data["next_cursor"] is None
+        client = TestClient(app)
+        resp = client.get("/api/reports?limit=20")
+        data = resp.json()
+        assert data["next_cursor"] is None
 
 
 class TestBotsEndpointPagination:
-    @pytest.mark.asyncio
-    async def test_bots_pagination(self):
+    def test_bots_pagination(self):
         """봇 목록 페이지네이션."""
         mock_manager = MagicMock()
         bots = [{"bot_id": f"bot-{i}", "status": "running"} for i in range(5)]
         mock_manager.list_bots.return_value = bots
 
         app = create_app(bot_manager=mock_manager)
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as ac:
-            resp = await ac.get("/api/bots?limit=3")
-            assert resp.status_code == 200
-            data = resp.json()
-            assert len(data["bots"]) == 3
-            assert data["next_cursor"] is not None
+        client = TestClient(app)
+        resp = client.get("/api/bots?limit=3")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["bots"]) == 3
+        assert data["next_cursor"] is not None
 
-    @pytest.mark.asyncio
-    async def test_bots_service_unavailable(self):
+    def test_bots_service_unavailable(self):
         """봇 매니저 없으면 503."""
         app = create_app()
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as ac:
-            resp = await ac.get("/api/bots")
-            assert resp.status_code == 503
+        client = TestClient(app)
+        resp = client.get("/api/bots")
+        assert resp.status_code == 503
 
 
 class TestTradesEndpointPagination:
-    @pytest.mark.asyncio
-    async def test_trades_pagination(self):
+    def test_trades_pagination(self):
         """거래 기록 페이지네이션."""
         mock_service = AsyncMock()
         trades = []
@@ -147,18 +137,16 @@ class TestTradesEndpointPagination:
         mock_service.get_trades = AsyncMock(return_value=trades)
 
         app = create_app(trade_service=mock_service)
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as ac:
-            resp = await ac.get("/api/trades?limit=3")
-            assert resp.status_code == 200
-            data = resp.json()
-            assert len(data["trades"]) == 3
-            assert data["next_cursor"] is not None
+        client = TestClient(app)
+        resp = client.get("/api/trades?limit=3")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["trades"]) == 3
+        assert data["next_cursor"] is not None
 
 
 class TestNotificationsEndpointPagination:
-    @pytest.mark.asyncio
-    async def test_notifications_pagination(self):
+    def test_notifications_pagination(self):
         """알림 이력 페이지네이션."""
         mock_service = AsyncMock()
         rows = [
@@ -175,10 +163,9 @@ class TestNotificationsEndpointPagination:
         mock_service.get_history = AsyncMock(return_value=rows)
 
         app = create_app(notification_service=mock_service)
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as ac:
-            resp = await ac.get("/api/notifications?limit=3")
-            assert resp.status_code == 200
-            data = resp.json()
-            assert len(data["notifications"]) == 3
-            assert data["next_cursor"] is not None
+        client = TestClient(app)
+        resp = client.get("/api/notifications?limit=3")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["notifications"]) == 3
+        assert data["next_cursor"] is not None


### PR DESCRIPTION
## Summary
- 리스트 엔드포인트에 `cursor` + `limit` 파라미터 추가 (opaque base64 인코딩)
- 응답에 `next_cursor` 포함, 마지막 페이지면 `null`
- 대상 엔드포인트: `GET /api/trades`, `GET /api/reports`, `GET /api/bots`, `GET /api/notifications`
- 공통 `paginate()` 유틸리티 모듈 추가

Closes #82

## Test plan
- [x] cursor 인코딩/디코딩 왕복 테스트
- [x] 첫 페이지 반환 + next_cursor 존재
- [x] 마지막 페이지 next_cursor=null
- [x] cursor 이후 항목 반환
- [x] cursor가 마지막이면 빈 결과
- [x] 빈 리스트 처리
- [x] Reports 엔드포인트 페이지네이션
- [x] Bots 엔드포인트 페이지네이션
- [x] Trades 엔드포인트 페이지네이션
- [x] Notifications 엔드포인트 페이지네이션
- [x] 서비스 미등록 시 503 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)