### PR TITLE
feat: API 토큰 만료 정책 (TTL + 자동 갱신) (#83)

### DIFF
--- a/src/ante/config/defaults.py
+++ b/src/ante/config/defaults.py
@@ -10,6 +10,7 @@ DEFAULTS: dict[str, object] = {
     "web.host": "0.0.0.0",
     "web.port": 8000,
     "eventbus.history_size": 1000,
+    "member.token_ttl_days": 90,
     "instrument.default_exchange": "KRX",
     "instrument.cache_ttl_seconds": 3600,
     "broker.commission_rate": 0.00015,

--- a/src/ante/member/models.py
+++ b/src/ante/member/models.py
@@ -49,3 +49,4 @@ class Member:
     last_active_at: str = ""
     suspended_at: str = ""
     revoked_at: str = ""
+    token_expires_at: str = ""

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -52,6 +52,9 @@ CREATE INDEX IF NOT EXISTS idx_members_org ON members(org);
 """
 
 _EMOJI_MIGRATION = "ALTER TABLE members ADD COLUMN emoji TEXT NOT NULL DEFAULT ''"
+_TOKEN_EXPIRES_MIGRATION = (
+    "ALTER TABLE members ADD COLUMN token_expires_at TEXT DEFAULT ''"
+)
 
 # 단일 이모지(grapheme cluster) 검증 패턴
 # 기본 이모지 1개 + 선택적 modifier/ZWJ sequence
@@ -140,6 +143,7 @@ def _row_to_member(row: dict) -> Member:
         last_active_at=row.get("last_active_at", ""),
         suspended_at=row.get("suspended_at", ""),
         revoked_at=row.get("revoked_at", ""),
+        token_expires_at=row.get("token_expires_at", ""),
     )
 
 
@@ -148,20 +152,34 @@ def _now() -> str:
     return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
 
 
+def _token_expires_at(ttl_days: int) -> str:
+    """TTL 일수 기준 토큰 만료 시각."""
+    from datetime import timedelta
+
+    return (datetime.now(UTC) + timedelta(days=ttl_days)).strftime("%Y-%m-%d %H:%M:%S")
+
+
 class MemberService:
     """멤버 등록·인증·관리 서비스."""
 
-    def __init__(self, db: Database, eventbus: EventBus) -> None:
+    def __init__(
+        self,
+        db: Database,
+        eventbus: EventBus,
+        token_ttl_days: int = 90,
+    ) -> None:
         self._db = db
         self._eventbus = eventbus
+        self._token_ttl_days = token_ttl_days
 
     async def initialize(self) -> None:
-        """스키마 생성 + emoji 컬럼 마이그레이션."""
+        """스키마 생성 + 컬럼 마이그레이션."""
         await self._db.execute_script(MEMBER_SCHEMA)
-        try:
-            await self._db.execute(_EMOJI_MIGRATION)
-        except Exception:  # noqa: BLE001
-            pass  # 컬럼이 이미 존재하면 무시
+        for migration in (_EMOJI_MIGRATION, _TOKEN_EXPIRES_MIGRATION):
+            try:
+                await self._db.execute(migration)
+            except Exception:  # noqa: BLE001
+                pass  # 컬럼이 이미 존재하면 무시
         logger.info("MemberService 초기화 완료")
 
     # ── emoji 관리 ──────────────────────────────────────
@@ -327,6 +345,7 @@ class MemberService:
 
         token = generate_token(member_type)
         now = _now()
+        expires_at = _token_expires_at(self._token_ttl_days)
         scopes = scopes or []
 
         member = Member(
@@ -341,14 +360,15 @@ class MemberService:
             token_hash=hash_token(token),
             created_at=now,
             created_by=registered_by,
+            token_expires_at=expires_at,
         )
 
         await self._db.execute(
             """INSERT INTO members
                (member_id, type, role, org, name, emoji, status, scopes,
                 token_hash, password_hash, recovery_key_hash,
-                created_at, created_by)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                created_at, created_by, token_expires_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 member.member_id,
                 member.type,
@@ -363,6 +383,7 @@ class MemberService:
                 member.recovery_key_hash,
                 member.created_at,
                 member.created_by,
+                member.token_expires_at,
             ),
         )
 
@@ -415,6 +436,28 @@ class MemberService:
             )
             msg = f"비활성 멤버: {member.status}"
             raise PermissionError(msg)
+
+        # 토큰 만료 체크
+        if member.token_expires_at:
+            expires = datetime.strptime(  # noqa: DTZ007
+                member.token_expires_at, "%Y-%m-%d %H:%M:%S"
+            )
+            now = datetime.now(UTC).replace(tzinfo=None)
+            if now > expires:
+                await self._publish_auth_failed(member.member_id, "토큰 만료")
+                msg = (
+                    "토큰이 만료되었습니다. 'ante member rotate-token'으로 갱신하세요."
+                )
+                raise PermissionError(msg)
+
+            from datetime import timedelta
+
+            if now > expires - timedelta(days=7):
+                logger.warning(
+                    "토큰 만료 임박: %s (만료: %s)",
+                    member.member_id,
+                    member.token_expires_at,
+                )
 
         return member
 
@@ -561,20 +604,23 @@ class MemberService:
     async def rotate_token(
         self, member_id: str, rotated_by: str = ""
     ) -> tuple[Member, str]:
-        """토큰 재발급. 기존 토큰 즉시 무효화."""
+        """토큰 재발급. 기존 토큰 즉시 무효화. 새 TTL 적용."""
         member = await self._get_or_raise(member_id)
         self._assert_active(member, "rotate_token")
 
         token = generate_token(member.type)
         t_hash = hash_token(token)
+        expires_at = _token_expires_at(self._token_ttl_days)
 
         await self._db.execute(
-            "UPDATE members SET token_hash = ? WHERE member_id = ?",
-            (t_hash, member_id),
+            "UPDATE members SET token_hash = ?, token_expires_at = ? "
+            "WHERE member_id = ?",
+            (t_hash, expires_at, member_id),
         )
 
         logger.info("토큰 재발급: %s (by %s)", member_id, rotated_by)
         member.token_hash = t_hash
+        member.token_expires_at = expires_at
         return member, token
 
     # ── 패스워드 관리 ──────────────────────────────────

--- a/tests/unit/test_token_expiry.py
+++ b/tests/unit/test_token_expiry.py
@@ -1,0 +1,195 @@
+"""토큰 만료 정책 단위 테스트."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.member.auth import generate_token, hash_token
+from ante.member.models import MemberStatus, MemberType
+from ante.member.service import MemberService, _token_expires_at
+
+
+def _make_member_row(
+    *,
+    member_id: str = "test-agent",
+    member_type: str = MemberType.AGENT,
+    token: str | None = None,
+    status: str = MemberStatus.ACTIVE,
+    token_expires_at: str = "",
+) -> dict:
+    if token is None:
+        token = generate_token(member_type)
+    return {
+        "member_id": member_id,
+        "type": member_type,
+        "role": "default",
+        "org": "default",
+        "name": "Test",
+        "emoji": "",
+        "status": status,
+        "scopes": "[]",
+        "token_hash": hash_token(token),
+        "password_hash": "",
+        "recovery_key_hash": "",
+        "created_at": "2025-01-01 00:00:00",
+        "created_by": "system",
+        "last_active_at": "",
+        "suspended_at": "",
+        "revoked_at": "",
+        "token_expires_at": token_expires_at,
+    }
+
+
+class TestTokenExpiresAtHelper:
+    def test_returns_future_date(self):
+        """만료 시각이 미래."""
+        result = _token_expires_at(90)
+        expires = datetime.strptime(result, "%Y-%m-%d %H:%M:%S")  # noqa: DTZ007
+        now = datetime.now(UTC).replace(tzinfo=None)
+        assert expires > now
+
+    def test_ttl_days_applied(self):
+        """TTL 일수가 반영됨."""
+        result = _token_expires_at(30)
+        expires = datetime.strptime(result, "%Y-%m-%d %H:%M:%S")  # noqa: DTZ007
+        now = datetime.now(UTC).replace(tzinfo=None)
+        diff = expires - now
+        assert 29 <= diff.days <= 30
+
+
+class TestTokenExpiryOnAuth:
+    @pytest.mark.asyncio
+    async def test_valid_token_not_expired(self):
+        """만료되지 않은 토큰은 인증 성공."""
+        token = generate_token(MemberType.AGENT)
+        future = (datetime.now(UTC) + timedelta(days=30)).strftime("%Y-%m-%d %H:%M:%S")
+        row = _make_member_row(token=token, token_expires_at=future)
+
+        db = AsyncMock()
+        db.fetch_one = AsyncMock(return_value=row)
+        eventbus = MagicMock()
+        eventbus.publish = AsyncMock()
+
+        svc = MemberService(db, eventbus)
+        member = await svc.authenticate(token)
+        assert member.member_id == "test-agent"
+
+    @pytest.mark.asyncio
+    async def test_expired_token_raises(self):
+        """만료된 토큰은 PermissionError."""
+        token = generate_token(MemberType.AGENT)
+        past = (datetime.now(UTC) - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
+        row = _make_member_row(token=token, token_expires_at=past)
+
+        db = AsyncMock()
+        db.fetch_one = AsyncMock(return_value=row)
+        eventbus = MagicMock()
+        eventbus.publish = AsyncMock()
+
+        svc = MemberService(db, eventbus)
+        with pytest.raises(PermissionError, match="만료"):
+            await svc.authenticate(token)
+
+    @pytest.mark.asyncio
+    async def test_no_expiry_field_ok(self):
+        """token_expires_at이 빈 문자열이면 만료 체크 스킵."""
+        token = generate_token(MemberType.AGENT)
+        row = _make_member_row(token=token, token_expires_at="")
+
+        db = AsyncMock()
+        db.fetch_one = AsyncMock(return_value=row)
+        eventbus = MagicMock()
+        eventbus.publish = AsyncMock()
+
+        svc = MemberService(db, eventbus)
+        member = await svc.authenticate(token)
+        assert member.member_id == "test-agent"
+
+    @pytest.mark.asyncio
+    async def test_warning_logged_near_expiry(self, caplog):
+        """만료 7일 전 경고 로그."""
+        import logging
+
+        token = generate_token(MemberType.AGENT)
+        near = (datetime.now(UTC) + timedelta(days=3)).strftime("%Y-%m-%d %H:%M:%S")
+        row = _make_member_row(token=token, token_expires_at=near)
+
+        db = AsyncMock()
+        db.fetch_one = AsyncMock(return_value=row)
+        eventbus = MagicMock()
+        eventbus.publish = AsyncMock()
+
+        svc = MemberService(db, eventbus)
+        with caplog.at_level(logging.WARNING, logger="ante.member.service"):
+            member = await svc.authenticate(token)
+            assert member is not None
+            assert "만료 임박" in caplog.text
+
+
+class TestTokenExpiryOnRotate:
+    @pytest.mark.asyncio
+    async def test_rotate_sets_new_expiry(self):
+        """토큰 재발급 시 새 만료 시각 설정."""
+        row = _make_member_row()
+
+        db = AsyncMock()
+        db.fetch_one = AsyncMock(return_value=row)
+        db.execute = AsyncMock()
+        eventbus = MagicMock()
+        eventbus.publish = AsyncMock()
+
+        svc = MemberService(db, eventbus, token_ttl_days=30)
+        member, new_token = await svc.rotate_token("test-agent", "admin")
+
+        assert member.token_expires_at != ""
+        expires = datetime.strptime(  # noqa: DTZ007
+            member.token_expires_at, "%Y-%m-%d %H:%M:%S"
+        )
+        now = datetime.now(UTC).replace(tzinfo=None)
+        diff = expires - now
+        assert 29 <= diff.days <= 30
+
+
+class TestTokenExpiryOnRegister:
+    @pytest.mark.asyncio
+    async def test_register_sets_expiry(self):
+        """멤버 등록 시 토큰 만료 시각 설정."""
+        db = AsyncMock()
+        db.fetch_one = AsyncMock(return_value=None)
+        db.execute = AsyncMock()
+        eventbus = MagicMock()
+        eventbus.publish = AsyncMock()
+
+        svc = MemberService(db, eventbus, token_ttl_days=60)
+        member, token = await svc.register(
+            member_id="new-agent",
+            member_type=MemberType.AGENT,
+            registered_by="admin",
+        )
+
+        assert member.token_expires_at != ""
+        expires = datetime.strptime(  # noqa: DTZ007
+            member.token_expires_at, "%Y-%m-%d %H:%M:%S"
+        )
+        now = datetime.now(UTC).replace(tzinfo=None)
+        diff = expires - now
+        assert 59 <= diff.days <= 60
+
+
+class TestDefaultTTL:
+    def test_default_ttl_90_days(self):
+        """기본 TTL은 90일."""
+        db = AsyncMock()
+        eventbus = MagicMock()
+        svc = MemberService(db, eventbus)
+        assert svc._token_ttl_days == 90
+
+    def test_custom_ttl(self):
+        """커스텀 TTL 설정."""
+        db = AsyncMock()
+        eventbus = MagicMock()
+        svc = MemberService(db, eventbus, token_ttl_days=30)
+        assert svc._token_ttl_days == 30


### PR DESCRIPTION
## Summary
- 토큰 생성/재발급 시 `token_expires_at` 만료 시각 기록 (기본 90일)
- 인증 미들웨어에서 만료 체크 → 만료 시 PermissionError + 안내 메시지
- 만료 7일 전 경고 로그 출력
- `members` 테이블에 `token_expires_at` 컬럼 자동 마이그레이션
- `defaults.py`에 `member.token_ttl_days: 90` 설정 추가
- 기존 토큰(token_expires_at 빈 문자열)은 만료 체크 스킵 (하위 호환)

Closes #83

## Test plan
- [x] _token_expires_at() 미래 날짜 반환
- [x] TTL 일수 정확히 반영
- [x] 유효한 토큰 인증 성공
- [x] 만료된 토큰 PermissionError
- [x] token_expires_at 빈 문자열 시 만료 체크 스킵
- [x] 만료 7일 전 경고 로그
- [x] rotate_token() 시 새 만료 시각 설정
- [x] register() 시 만료 시각 설정
- [x] 기본 TTL 90일
- [x] 커스텀 TTL 설정

🤖 Generated with [Claude Code](https://claude.com/claude-code)