### PR TITLE
feat: add stop order emulation and KIS WebSocket client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "click>=8.1",
     "fastapi>=0.115",
     "uvicorn>=0.34",
+    "websockets>=13.0",
 ]
 
 [project.optional-dependencies]

--- a/src/ante/broker/__init__.py
+++ b/src/ante/broker/__init__.py
@@ -11,6 +11,7 @@ from ante.broker.exceptions import (
     RateLimitError,
 )
 from ante.broker.kis import KISAdapter
+from ante.broker.kis_stream import KISStreamClient
 from ante.broker.models import CommissionInfo
 from ante.broker.order_registry import OrderRegistry
 
@@ -21,6 +22,7 @@ __all__ = [
     "CircuitState",
     "CommissionInfo",
     "KISAdapter",
+    "KISStreamClient",
     "OrderRegistry",
     "BrokerError",
     "AuthenticationError",

--- a/src/ante/broker/kis_stream.py
+++ b/src/ante/broker/kis_stream.py
@@ -1,0 +1,414 @@
+"""KIS WebSocket 실시간 스트리밍 클라이언트.
+
+KIS Open API WebSocket을 통해 실시간 시세(H0STCNT0)와
+체결 통보(H0STCNI0)를 수신한다.
+실행 시 websockets 패키지가 필요하다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import Callable, Coroutine
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ante.eventbus.bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+# KIS WebSocket 채널
+CHANNEL_PRICE = "H0STCNT0"  # 실시간 시세
+CHANNEL_EXECUTION = "H0STCNI0"  # 실시간 체결 통보
+
+# 최대 구독 종목 수
+MAX_SUBSCRIPTIONS = 40
+
+# 재연결 설정
+DEFAULT_RECONNECT_DELAY = 1.0
+DEFAULT_MAX_RECONNECT_DELAY = 60.0
+DEFAULT_PING_INTERVAL = 30.0
+
+
+PriceCallback = Callable[[str, float], Coroutine[Any, Any, None]]
+ExecutionCallback = Callable[[dict[str, Any]], Coroutine[Any, Any, None]]
+
+
+class KISStreamClient:
+    """KIS WebSocket 실시간 스트리밍 클라이언트.
+
+    - 실시간 시세 수신 (H0STCNT0)
+    - 실시간 체결 통보 수신 (H0STCNI0)
+    - 자동 재연결
+    - 최대 40종목 구독 제한
+    """
+
+    def __init__(
+        self,
+        websocket_url: str,
+        app_key: str,
+        app_secret: str,
+        approval_key: str | None = None,
+        eventbus: EventBus | None = None,
+        ping_interval: float = DEFAULT_PING_INTERVAL,
+    ) -> None:
+        self._url = websocket_url
+        self._app_key = app_key
+        self._app_secret = app_secret
+        self._approval_key = approval_key
+        self._eventbus = eventbus
+        self._ping_interval = ping_interval
+
+        self._ws: Any = None
+        self._running = False
+        self._recv_task: asyncio.Task[None] | None = None
+        self._subscribed_symbols: set[str] = set()
+
+        # 콜백
+        self._price_callbacks: list[PriceCallback] = []
+        self._execution_callbacks: list[ExecutionCallback] = []
+
+        # 재연결 상태
+        self._reconnect_delay = DEFAULT_RECONNECT_DELAY
+
+    @property
+    def is_connected(self) -> bool:
+        """WebSocket 연결 상태."""
+        return self._ws is not None and self._running
+
+    @property
+    def subscribed_symbols(self) -> set[str]:
+        """현재 구독 중인 종목."""
+        return set(self._subscribed_symbols)
+
+    def on_price(self, callback: PriceCallback) -> None:
+        """시세 콜백 등록."""
+        self._price_callbacks.append(callback)
+
+    def on_execution(self, callback: ExecutionCallback) -> None:
+        """체결 통보 콜백 등록."""
+        self._execution_callbacks.append(callback)
+
+    async def connect(self) -> None:
+        """WebSocket 연결 및 수신 루프 시작."""
+        if self._running:
+            logger.warning("KIS WebSocket 이미 연결됨")
+            return
+
+        if not self._approval_key:
+            self._approval_key = await self._get_approval_key()
+
+        self._running = True
+        self._recv_task = asyncio.create_task(
+            self._connection_loop(), name="kis-stream"
+        )
+        logger.info("KIS WebSocket 연결 시작: %s", self._url)
+
+    async def disconnect(self) -> None:
+        """WebSocket 연결 해제."""
+        self._running = False
+
+        if self._recv_task and not self._recv_task.done():
+            self._recv_task.cancel()
+            try:
+                await self._recv_task
+            except asyncio.CancelledError:
+                pass
+            self._recv_task = None
+
+        await self._close_ws()
+        self._subscribed_symbols.clear()
+        logger.info("KIS WebSocket 연결 해제")
+
+    async def subscribe(self, symbol: str) -> bool:
+        """종목 시세 구독."""
+        if symbol in self._subscribed_symbols:
+            return True
+
+        if len(self._subscribed_symbols) >= MAX_SUBSCRIPTIONS:
+            logger.warning(
+                "최대 구독 한도 초과 (%d/%d): %s",
+                len(self._subscribed_symbols),
+                MAX_SUBSCRIPTIONS,
+                symbol,
+            )
+            return False
+
+        if self._ws:
+            await self._send_subscribe(symbol, CHANNEL_PRICE, "1")
+            self._subscribed_symbols.add(symbol)
+            logger.info("종목 구독: %s (총 %d)", symbol, len(self._subscribed_symbols))
+            return True
+
+        # 연결 전이면 목록에만 추가 (연결 후 자동 구독)
+        self._subscribed_symbols.add(symbol)
+        return True
+
+    async def unsubscribe(self, symbol: str) -> None:
+        """종목 시세 구독 해제."""
+        if symbol not in self._subscribed_symbols:
+            return
+
+        if self._ws:
+            await self._send_subscribe(symbol, CHANNEL_PRICE, "2")
+
+        self._subscribed_symbols.discard(symbol)
+        logger.info("종목 구독 해제: %s", symbol)
+
+    async def subscribe_execution(self) -> None:
+        """체결 통보 구독."""
+        if self._ws:
+            msg = {
+                "header": {
+                    "approval_key": self._approval_key,
+                    "custtype": "P",
+                    "tr_type": "1",
+                    "content-type": "utf-8",
+                },
+                "body": {
+                    "input": {
+                        "tr_id": CHANNEL_EXECUTION,
+                        "tr_key": "",
+                    }
+                },
+            }
+            await self._ws.send(json.dumps(msg))
+            logger.info("체결 통보 구독 시작")
+
+    # ── 내부 메서드 ──────────────────────────────────
+
+    async def _connection_loop(self) -> None:
+        """WebSocket 연결 유지 루프 (자동 재연결)."""
+        while self._running:
+            try:
+                await self._connect_and_recv()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                if not self._running:
+                    break
+                logger.warning(
+                    "KIS WebSocket 연결 끊김, %.1f초 후 재연결",
+                    self._reconnect_delay,
+                    exc_info=True,
+                )
+                await self._publish_disconnected("connection_lost")
+                await asyncio.sleep(self._reconnect_delay)
+                self._reconnect_delay = min(
+                    self._reconnect_delay * 2, DEFAULT_MAX_RECONNECT_DELAY
+                )
+
+    async def _connect_and_recv(self) -> None:
+        """WebSocket 연결 후 메시지 수신."""
+        try:
+            import websockets
+        except ImportError as e:
+            raise ImportError(
+                "websockets 패키지가 필요합니다: pip install websockets"
+            ) from e
+
+        async with websockets.connect(
+            self._url,
+            ping_interval=self._ping_interval,
+        ) as ws:
+            self._ws = ws
+            self._reconnect_delay = DEFAULT_RECONNECT_DELAY
+            logger.info("KIS WebSocket 연결 완료")
+            await self._publish_connected()
+
+            # 기존 구독 복구
+            await self._resubscribe_all()
+
+            # 수신 루프
+            async for message in ws:
+                if not self._running:
+                    break
+                try:
+                    await self._handle_message(message)
+                except Exception:
+                    logger.exception("WebSocket 메시지 처리 오류")
+
+        self._ws = None
+
+    async def _resubscribe_all(self) -> None:
+        """재연결 후 기존 구독 복구."""
+        symbols = list(self._subscribed_symbols)
+        for symbol in symbols:
+            await self._send_subscribe(symbol, CHANNEL_PRICE, "1")
+            await asyncio.sleep(0.1)  # rate limit 방지
+
+    async def _send_subscribe(self, symbol: str, tr_id: str, tr_type: str) -> None:
+        """구독/해제 메시지 전송."""
+        if not self._ws:
+            return
+
+        msg = {
+            "header": {
+                "approval_key": self._approval_key,
+                "custtype": "P",
+                "tr_type": tr_type,  # 1: 구독, 2: 해제
+                "content-type": "utf-8",
+            },
+            "body": {
+                "input": {
+                    "tr_id": tr_id,
+                    "tr_key": symbol,
+                }
+            },
+        }
+        await self._ws.send(json.dumps(msg))
+
+    async def _handle_message(self, raw: str | bytes) -> None:
+        """수신 메시지 분류 및 처리."""
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+
+        # JSON 응답 (구독 확인 등)
+        if raw.startswith("{"):
+            data = json.loads(raw)
+            header = data.get("header", {})
+            tr_id = header.get("tr_id", "")
+            if tr_id == CHANNEL_EXECUTION:
+                await self._handle_execution_json(data)
+            return
+
+        # 파이프 구분 데이터 (실시간 시세)
+        await self._handle_pipe_data(raw)
+
+    async def _handle_pipe_data(self, raw: str) -> None:
+        """파이프(|) 구분 실시간 시세 데이터 처리.
+
+        KIS WebSocket 시세 데이터 형식:
+        0|H0STCNT0|004|005930^...^현재가^...
+        """
+        parts = raw.split("|")
+        if len(parts) < 4:
+            return
+
+        tr_id = parts[1]
+        if tr_id == CHANNEL_PRICE:
+            await self._handle_price_data(parts[3])
+        elif tr_id == CHANNEL_EXECUTION:
+            await self._handle_execution_data(parts[3])
+
+    async def _handle_price_data(self, data_str: str) -> None:
+        """실시간 시세 데이터 파싱 및 콜백 호출.
+
+        H0STCNT0 응답 필드 (^로 구분):
+        [0]: 종목코드, [1]: 시각, ..., [2]: 현재가
+        """
+        fields = data_str.split("^")
+        if len(fields) < 3:
+            return
+
+        symbol = fields[0]
+        try:
+            price = float(fields[2])
+        except (ValueError, IndexError):
+            return
+
+        for callback in self._price_callbacks:
+            try:
+                await callback(symbol, price)
+            except Exception:
+                logger.exception("시세 콜백 오류: %s", symbol)
+
+    async def _handle_execution_data(self, data_str: str) -> None:
+        """실시간 체결 통보 데이터 파싱."""
+        fields = data_str.split("^")
+        if len(fields) < 10:
+            return
+
+        execution = {
+            "symbol": fields[0],
+            "order_id": fields[1],
+            "side": "buy" if fields[4] == "02" else "sell",
+            "quantity": float(fields[5]) if fields[5] else 0.0,
+            "price": float(fields[6]) if fields[6] else 0.0,
+            "timestamp": datetime.now(UTC),
+        }
+
+        for callback in self._execution_callbacks:
+            try:
+                await callback(execution)
+            except Exception:
+                logger.exception("체결 통보 콜백 오류")
+
+    async def _handle_execution_json(self, data: dict[str, Any]) -> None:
+        """JSON 형식 체결 통보 처리."""
+        body = data.get("body", {})
+        output = body.get("output", {})
+        if not output:
+            return
+
+        execution = {
+            "symbol": output.get("pdno", ""),
+            "order_id": output.get("odno", ""),
+            "side": "buy" if output.get("sll_buy_dvsn_cd") == "02" else "sell",
+            "quantity": float(output.get("ccld_qty", 0)),
+            "price": float(output.get("ccld_pric", 0)),
+            "timestamp": datetime.now(UTC),
+        }
+
+        for callback in self._execution_callbacks:
+            try:
+                await callback(execution)
+            except Exception:
+                logger.exception("체결 통보 콜백 오류")
+
+    async def _get_approval_key(self) -> str:
+        """WebSocket 접속키 발급."""
+        try:
+            import aiohttp
+        except ImportError as e:
+            raise ImportError("aiohttp 패키지가 필요합니다: pip install aiohttp") from e
+
+        # WebSocket URL에서 REST URL 유추
+        if "21000" in self._url:
+            rest_url = "https://openapivts.koreainvestment.com:29443"
+        else:
+            rest_url = "https://openapi.koreainvestment.com:9443"
+
+        url = f"{rest_url}/oauth2/Approval"
+        data = {
+            "grant_type": "client_credentials",
+            "appkey": self._app_key,
+            "secretkey": self._app_secret,
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=data) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    raise RuntimeError(f"WebSocket 접속키 발급 실패: {text}")
+                result = await resp.json()
+                return result["approval_key"]
+
+    async def _close_ws(self) -> None:
+        """WebSocket 연결 닫기."""
+        if self._ws:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+            self._ws = None
+
+    async def _publish_connected(self) -> None:
+        """연결 이벤트 발행."""
+        if self._eventbus:
+            from ante.eventbus.events import StreamConnectedEvent
+
+            await self._eventbus.publish(
+                StreamConnectedEvent(broker="kis", url=self._url)
+            )
+
+    async def _publish_disconnected(self, reason: str) -> None:
+        """연결 해제 이벤트 발행."""
+        if self._eventbus:
+            from ante.eventbus.events import StreamDisconnectedEvent
+
+            await self._eventbus.publish(
+                StreamDisconnectedEvent(broker="kis", reason=reason)
+            )

--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -425,3 +425,65 @@ class OrderCancelFailedEvent(Event):
     bot_id: str = ""
     strategy_id: str = ""
     error_message: str = ""
+
+
+# ── Stop Order 이벤트 ──────────────────────────────
+
+
+@dataclass(frozen=True)
+class StopOrderRegisteredEvent(Event):
+    """StopOrderManager → EventBus: 스탑 주문 등록."""
+
+    stop_order_id: str = ""
+    bot_id: str = ""
+    strategy_id: str = ""
+    symbol: str = ""
+    side: str = ""
+    quantity: float = 0.0
+    order_type: str = ""
+    stop_price: float = 0.0
+    limit_price: float | None = None
+
+
+@dataclass(frozen=True)
+class StopOrderTriggeredEvent(Event):
+    """StopOrderManager → EventBus: 스탑 주문 트리거."""
+
+    stop_order_id: str = ""
+    bot_id: str = ""
+    strategy_id: str = ""
+    symbol: str = ""
+    side: str = ""
+    quantity: float = 0.0
+    trigger_price: float = 0.0
+    converted_order_type: str = ""
+
+
+@dataclass(frozen=True)
+class StopOrderExpiredEvent(Event):
+    """StopOrderManager → EventBus: 스탑 주문 만료 (세션 종료)."""
+
+    stop_order_id: str = ""
+    bot_id: str = ""
+    strategy_id: str = ""
+    symbol: str = ""
+    reason: str = ""
+
+
+# ── 실시간 스트림 이벤트 ─────────────────────────────
+
+
+@dataclass(frozen=True)
+class StreamConnectedEvent(Event):
+    """KISStreamClient → EventBus: WebSocket 연결 성공."""
+
+    broker: str = ""
+    url: str = ""
+
+
+@dataclass(frozen=True)
+class StreamDisconnectedEvent(Event):
+    """KISStreamClient → EventBus: WebSocket 연결 해제."""
+
+    broker: str = ""
+    reason: str = ""

--- a/src/ante/gateway/__init__.py
+++ b/src/ante/gateway/__init__.py
@@ -5,6 +5,7 @@ from ante.gateway.data_provider import LiveDataProvider
 from ante.gateway.gateway import APIGateway
 from ante.gateway.queue import APIRequest, RequestPriority, RequestQueue
 from ante.gateway.rate_limiter import RateLimitConfig, RateLimiter
+from ante.gateway.stop_order import StopOrderManager
 
 __all__ = [
     "APIGateway",
@@ -15,4 +16,5 @@ __all__ = [
     "RequestQueue",
     "RequestPriority",
     "APIRequest",
+    "StopOrderManager",
 ]

--- a/src/ante/gateway/gateway.py
+++ b/src/ante/gateway/gateway.py
@@ -21,6 +21,7 @@ class APIGateway:
     - Rate limit 준수
     - 응답 캐시 (시세, 잔고 등)
     - EventBus 이벤트 기반 주문 처리
+    - Stop order 라우팅 (StopOrderManager 연동)
     """
 
     def __init__(
@@ -28,6 +29,7 @@ class APIGateway:
         broker: BrokerAdapter,
         eventbus: EventBus,
         rate_config: RateLimitConfig | None = None,
+        stop_order_manager: Any | None = None,
     ) -> None:
         self._broker = broker
         self._eventbus = eventbus
@@ -36,6 +38,7 @@ class APIGateway:
         )
         self._cache = ResponseCache()
         self._running = False
+        self._stop_order_manager = stop_order_manager
 
     async def start(self) -> None:
         """이벤트 구독 시작."""
@@ -138,7 +141,10 @@ class APIGateway:
     # ── EventBus 핸들러 ──────────────────────────────
 
     async def _on_order_approved(self, event: object) -> None:
-        """Treasury 자금 확보 완료 → 증권사에 주문 제출."""
+        """Treasury 자금 확보 완료 → 증권사에 주문 제출.
+
+        stop/stop_limit 주문은 StopOrderManager로 라우팅한다.
+        """
         from ante.eventbus.events import (
             OrderApprovedEvent,
             OrderFailedEvent,
@@ -147,6 +153,40 @@ class APIGateway:
 
         if not isinstance(event, OrderApprovedEvent):
             return
+
+        # stop/stop_limit → StopOrderManager로 라우팅
+        if event.order_type in ("stop", "stop_limit") and self._stop_order_manager:
+            try:
+                await self._stop_order_manager.register(
+                    order_id=event.order_id,
+                    bot_id=event.bot_id,
+                    strategy_id=event.strategy_id,
+                    symbol=event.symbol,
+                    side=event.side,
+                    quantity=event.quantity,
+                    order_type=event.order_type,
+                    stop_price=event.stop_price or 0.0,
+                    limit_price=event.price,
+                    exchange=event.exchange,
+                )
+                return
+            except Exception as e:
+                logger.error("스탑 주문 등록 실패: %s — %s", event.order_id, e)
+                await self._eventbus.publish(
+                    OrderFailedEvent(
+                        order_id=event.order_id,
+                        bot_id=event.bot_id,
+                        strategy_id=event.strategy_id,
+                        symbol=event.symbol,
+                        side=event.side,
+                        quantity=event.quantity,
+                        price=event.price or 0.0,
+                        order_type=event.order_type,
+                        error_message=str(e),
+                        exchange=event.exchange,
+                    )
+                )
+                return
 
         try:
             broker_order_id = await self.submit_order(

--- a/src/ante/gateway/stop_order.py
+++ b/src/ante/gateway/stop_order.py
@@ -1,0 +1,285 @@
+"""StopOrderManager — 스탑 주문 에뮬레이션.
+
+KRX는 네이티브 스탑 주문을 지원하지 않으므로,
+실시간 시세를 모니터링하여 트리거 조건 충족 시
+시장가/지정가 주문으로 변환하여 기존 주문 흐름에 주입한다.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+if TYPE_CHECKING:
+    from ante.eventbus.bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+# 거래 세션 시간 (한국 시간 기준, UTC+9)
+REGULAR_SESSION_START = (0, 0)  # 09:00 KST = 00:00 UTC
+REGULAR_SESSION_END = (6, 30)  # 15:30 KST = 06:30 UTC
+EXTENDED_SESSION_START = (23, 30)  # 08:30 KST (전일 23:30 UTC)
+EXTENDED_SESSION_END = (9, 0)  # 18:00 KST = 09:00 UTC
+
+
+@dataclass
+class StopOrder:
+    """스탑 주문 내부 표현."""
+
+    stop_order_id: str
+    order_id: str
+    bot_id: str
+    strategy_id: str
+    symbol: str
+    side: str
+    quantity: float
+    order_type: str  # "stop" | "stop_limit"
+    stop_price: float
+    limit_price: float | None
+    trading_session: str  # "regular" | "extended"
+    registered_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    triggered: bool = False
+    expired: bool = False
+    exchange: str = "KRX"
+
+
+class StopOrderManager:
+    """스탑 주문 에뮬레이션 매니저.
+
+    - 스탑 주문 등록/취소/조회
+    - 실시간 시세 기반 트리거 판단
+    - 세션 종료 시 미트리거 주문 만료
+    """
+
+    def __init__(self, eventbus: EventBus) -> None:
+        self._eventbus = eventbus
+        self._orders: dict[str, StopOrder] = {}
+        self._running = False
+
+    @property
+    def active_orders(self) -> list[StopOrder]:
+        """활성 스탑 주문 목록."""
+        return [o for o in self._orders.values() if not o.triggered and not o.expired]
+
+    @property
+    def monitored_symbols(self) -> set[str]:
+        """모니터링 대상 종목."""
+        return {o.symbol for o in self.active_orders}
+
+    async def start(self) -> None:
+        """매니저 시작."""
+        self._running = True
+        logger.info("StopOrderManager 시작")
+
+    async def stop(self) -> None:
+        """매니저 중지. 활성 주문 모두 만료 처리."""
+        self._running = False
+        for order in self.active_orders:
+            await self._expire_order(order, "manager_stopped")
+        logger.info("StopOrderManager 중지")
+
+    async def register(
+        self,
+        order_id: str,
+        bot_id: str,
+        strategy_id: str,
+        symbol: str,
+        side: str,
+        quantity: float,
+        order_type: str,
+        stop_price: float,
+        limit_price: float | None = None,
+        trading_session: str = "regular",
+        exchange: str = "KRX",
+    ) -> str:
+        """스탑 주문 등록.
+
+        Returns:
+            stop_order_id
+        """
+        stop_order_id = f"stop-{uuid4().hex[:12]}"
+
+        order = StopOrder(
+            stop_order_id=stop_order_id,
+            order_id=order_id,
+            bot_id=bot_id,
+            strategy_id=strategy_id,
+            symbol=symbol,
+            side=side,
+            quantity=quantity,
+            order_type=order_type,
+            stop_price=stop_price,
+            limit_price=limit_price,
+            trading_session=trading_session,
+            exchange=exchange,
+        )
+        self._orders[stop_order_id] = order
+
+        logger.info(
+            "스탑 주문 등록: %s %s %s stop=%.0f",
+            stop_order_id,
+            side,
+            symbol,
+            stop_price,
+        )
+
+        from ante.eventbus.events import StopOrderRegisteredEvent
+
+        await self._eventbus.publish(
+            StopOrderRegisteredEvent(
+                stop_order_id=stop_order_id,
+                bot_id=bot_id,
+                strategy_id=strategy_id,
+                symbol=symbol,
+                side=side,
+                quantity=quantity,
+                order_type=order_type,
+                stop_price=stop_price,
+                limit_price=limit_price,
+            )
+        )
+
+        return stop_order_id
+
+    async def cancel(self, stop_order_id: str) -> bool:
+        """스탑 주문 취소."""
+        order = self._orders.get(stop_order_id)
+        if not order or order.triggered or order.expired:
+            return False
+
+        order.expired = True
+        del self._orders[stop_order_id]
+        logger.info("스탑 주문 취소: %s", stop_order_id)
+        return True
+
+    def get_order(self, stop_order_id: str) -> StopOrder | None:
+        """스탑 주문 조회."""
+        return self._orders.get(stop_order_id)
+
+    def get_orders_for_bot(self, bot_id: str) -> list[StopOrder]:
+        """봇의 활성 스탑 주문 목록."""
+        return [o for o in self.active_orders if o.bot_id == bot_id]
+
+    async def on_price_update(self, symbol: str, price: float) -> None:
+        """실시간 시세 수신 시 트리거 판단.
+
+        매수 스탑: 현재가 >= stop_price → 트리거
+        매도 스탑: 현재가 <= stop_price → 트리거
+        """
+        if not self._running:
+            return
+
+        active_for_symbol = [
+            o
+            for o in self.active_orders
+            if o.symbol == symbol and self._is_in_session(o)
+        ]
+
+        for order in active_for_symbol:
+            if self._should_trigger(order, price):
+                await self._trigger_order(order, price)
+
+    async def check_session_expiry(self) -> None:
+        """세션 종료 시 미트리거 주문 만료 처리."""
+        for order in self.active_orders:
+            if not self._is_in_session(order):
+                await self._expire_order(order, "session_ended")
+
+    def _should_trigger(self, order: StopOrder, price: float) -> bool:
+        """트리거 조건 판단."""
+        if order.side == "buy":
+            return price >= order.stop_price
+        else:  # sell
+            return price <= order.stop_price
+
+    def _is_in_session(self, order: StopOrder) -> bool:
+        """현재 시각이 주문의 거래 세션 시간 내인지 확인."""
+        now = datetime.now(UTC)
+        hour, minute = now.hour, now.minute
+        current_minutes = hour * 60 + minute
+
+        if order.trading_session == "extended":
+            # 확장 세션: 08:30-18:00 KST (23:30-09:00 UTC, 자정 걸침)
+            start = EXTENDED_SESSION_START[0] * 60 + EXTENDED_SESSION_START[1]
+            end = EXTENDED_SESSION_END[0] * 60 + EXTENDED_SESSION_END[1]
+            if start > end:  # 자정 걸침
+                return current_minutes >= start or current_minutes < end
+            return start <= current_minutes < end
+        else:
+            # 정규 세션: 09:00-15:30 KST (00:00-06:30 UTC)
+            start = REGULAR_SESSION_START[0] * 60 + REGULAR_SESSION_START[1]
+            end = REGULAR_SESSION_END[0] * 60 + REGULAR_SESSION_END[1]
+            return start <= current_minutes < end
+
+    async def _trigger_order(self, order: StopOrder, trigger_price: float) -> None:
+        """스탑 주문 트리거 → 시장가/지정가 주문으로 변환."""
+        order.triggered = True
+
+        # stop → market, stop_limit → limit
+        converted_type = "limit" if order.order_type == "stop_limit" else "market"
+        converted_price = order.limit_price if converted_type == "limit" else None
+
+        logger.info(
+            "스탑 주문 트리거: %s %s %s trigger=%.0f → %s",
+            order.stop_order_id,
+            order.side,
+            order.symbol,
+            trigger_price,
+            converted_type,
+        )
+
+        from ante.eventbus.events import OrderRequestEvent, StopOrderTriggeredEvent
+
+        # 트리거 이벤트 발행
+        await self._eventbus.publish(
+            StopOrderTriggeredEvent(
+                stop_order_id=order.stop_order_id,
+                bot_id=order.bot_id,
+                strategy_id=order.strategy_id,
+                symbol=order.symbol,
+                side=order.side,
+                quantity=order.quantity,
+                trigger_price=trigger_price,
+                converted_order_type=converted_type,
+            )
+        )
+
+        # 변환된 주문을 기존 흐름에 주입
+        await self._eventbus.publish(
+            OrderRequestEvent(
+                bot_id=order.bot_id,
+                strategy_id=order.strategy_id,
+                symbol=order.symbol,
+                side=order.side,
+                quantity=order.quantity,
+                order_type=converted_type,
+                price=converted_price,
+                reason=f"stop_triggered: {order.stop_order_id}",
+                exchange=order.exchange,
+            )
+        )
+
+    async def _expire_order(self, order: StopOrder, reason: str) -> None:
+        """스탑 주문 만료 처리."""
+        order.expired = True
+
+        logger.info(
+            "스탑 주문 만료: %s (%s)",
+            order.stop_order_id,
+            reason,
+        )
+
+        from ante.eventbus.events import StopOrderExpiredEvent
+
+        await self._eventbus.publish(
+            StopOrderExpiredEvent(
+                stop_order_id=order.stop_order_id,
+                bot_id=order.bot_id,
+                strategy_id=order.strategy_id,
+                symbol=order.symbol,
+                reason=reason,
+            )
+        )

--- a/src/ante/strategy/base.py
+++ b/src/ante/strategy/base.py
@@ -40,6 +40,7 @@ class Signal:
     price: float | None = None
     stop_price: float | None = None
     reason: str = ""
+    trading_session: str = "regular"  # "regular" | "extended"
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_gateway_stop_routing.py
+++ b/tests/unit/test_gateway_stop_routing.py
@@ -1,0 +1,205 @@
+"""APIGateway stop order 라우팅 테스트."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.eventbus.events import (
+    OrderApprovedEvent,
+    OrderFailedEvent,
+    OrderSubmittedEvent,
+)
+from ante.gateway.gateway import APIGateway
+
+
+@pytest.fixture
+def broker() -> MagicMock:
+    """BrokerAdapter mock."""
+    b = MagicMock()
+    b.place_order = AsyncMock(return_value="BRK-001")
+    return b
+
+
+@pytest.fixture
+def eventbus() -> MagicMock:
+    """EventBus mock."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    bus.subscribe = MagicMock()
+    return bus
+
+
+@pytest.fixture
+def stop_manager(eventbus: MagicMock) -> MagicMock:
+    """StopOrderManager mock."""
+    mgr = MagicMock()
+    mgr.register = AsyncMock(return_value="stop-abc123")
+    return mgr
+
+
+@pytest.fixture
+def gateway(
+    broker: MagicMock, eventbus: MagicMock, stop_manager: MagicMock
+) -> APIGateway:
+    """APIGateway with StopOrderManager."""
+    return APIGateway(
+        broker=broker,
+        eventbus=eventbus,
+        stop_order_manager=stop_manager,
+    )
+
+
+@pytest.fixture
+def gateway_no_stop(broker: MagicMock, eventbus: MagicMock) -> APIGateway:
+    """APIGateway without StopOrderManager."""
+    return APIGateway(broker=broker, eventbus=eventbus)
+
+
+class TestStopOrderRouting:
+    """Stop order 라우팅 테스트."""
+
+    async def test_stop_order_routed_to_manager(
+        self,
+        gateway: APIGateway,
+        stop_manager: MagicMock,
+        broker: MagicMock,
+        eventbus: MagicMock,
+    ) -> None:
+        """stop 주문은 StopOrderManager로 라우팅."""
+        event = OrderApprovedEvent(
+            order_id="ord-001",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop",
+            stop_price=49000.0,
+            price=None,
+            exchange="KRX",
+        )
+
+        await gateway._on_order_approved(event)
+
+        # StopOrderManager.register 호출
+        stop_manager.register.assert_called_once_with(
+            order_id="ord-001",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop",
+            stop_price=49000.0,
+            limit_price=None,
+            exchange="KRX",
+        )
+
+        # broker.place_order는 호출 안 됨
+        broker.place_order.assert_not_called()
+
+    async def test_stop_limit_routed_to_manager(
+        self,
+        gateway: APIGateway,
+        stop_manager: MagicMock,
+    ) -> None:
+        """stop_limit 주문도 StopOrderManager로 라우팅."""
+        event = OrderApprovedEvent(
+            order_id="ord-002",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="buy",
+            quantity=5.0,
+            order_type="stop_limit",
+            stop_price=51000.0,
+            price=51500.0,
+            exchange="KRX",
+        )
+
+        await gateway._on_order_approved(event)
+
+        stop_manager.register.assert_called_once()
+        call_kwargs = stop_manager.register.call_args[1]
+        assert call_kwargs["limit_price"] == 51500.0
+
+    async def test_market_order_goes_to_broker(
+        self,
+        gateway: APIGateway,
+        stop_manager: MagicMock,
+        broker: MagicMock,
+        eventbus: MagicMock,
+    ) -> None:
+        """일반 market 주문은 broker로 직접 전달."""
+        event = OrderApprovedEvent(
+            order_id="ord-003",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            order_type="market",
+            exchange="KRX",
+        )
+
+        await gateway._on_order_approved(event)
+
+        broker.place_order.assert_called_once()
+        stop_manager.register.assert_not_called()
+        eventbus.publish.assert_called_once()
+        submitted = eventbus.publish.call_args[0][0]
+        assert isinstance(submitted, OrderSubmittedEvent)
+
+    async def test_stop_order_register_failure(
+        self,
+        gateway: APIGateway,
+        stop_manager: MagicMock,
+        eventbus: MagicMock,
+    ) -> None:
+        """StopOrderManager 등록 실패 시 OrderFailedEvent 발행."""
+        stop_manager.register = AsyncMock(side_effect=RuntimeError("test error"))
+
+        event = OrderApprovedEvent(
+            order_id="ord-004",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop",
+            stop_price=49000.0,
+            exchange="KRX",
+        )
+
+        await gateway._on_order_approved(event)
+
+        eventbus.publish.assert_called_once()
+        failed = eventbus.publish.call_args[0][0]
+        assert isinstance(failed, OrderFailedEvent)
+        assert "test error" in failed.error_message
+
+    async def test_stop_order_without_manager(
+        self,
+        gateway_no_stop: APIGateway,
+        broker: MagicMock,
+        eventbus: MagicMock,
+    ) -> None:
+        """StopOrderManager 미설정 시 broker에 전달 (기존 동작)."""
+        event = OrderApprovedEvent(
+            order_id="ord-005",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop",
+            stop_price=49000.0,
+            exchange="KRX",
+        )
+
+        await gateway_no_stop._on_order_approved(event)
+
+        # stop_order_manager가 없으므로 broker에 직접 전달 시도
+        broker.place_order.assert_called_once()

--- a/tests/unit/test_kis_stream.py
+++ b/tests/unit/test_kis_stream.py
@@ -1,0 +1,201 @@
+"""KISStreamClient 단위 테스트."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.broker.kis_stream import (
+    CHANNEL_EXECUTION,
+    CHANNEL_PRICE,
+    MAX_SUBSCRIPTIONS,
+    KISStreamClient,
+)
+
+
+@pytest.fixture
+def eventbus() -> MagicMock:
+    """EventBus mock."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    return bus
+
+
+@pytest.fixture
+def stream_client(eventbus: MagicMock) -> KISStreamClient:
+    """KISStreamClient 인스턴스."""
+    return KISStreamClient(
+        websocket_url="ws://ops.koreainvestment.com:21000",
+        app_key="test_key",
+        app_secret="test_secret",
+        approval_key="test_approval",
+        eventbus=eventbus,
+    )
+
+
+class TestKISStreamClientInit:
+    """초기화 테스트."""
+
+    def test_init_paper(self, stream_client: KISStreamClient) -> None:
+        assert stream_client._url == "ws://ops.koreainvestment.com:21000"
+        assert not stream_client.is_connected
+        assert len(stream_client.subscribed_symbols) == 0
+
+    def test_init_real(self, eventbus: MagicMock) -> None:
+        client = KISStreamClient(
+            websocket_url="ws://ops.koreainvestment.com:31000",
+            app_key="key",
+            app_secret="secret",
+            approval_key="approval",
+            eventbus=eventbus,
+        )
+        assert client._url == "ws://ops.koreainvestment.com:31000"
+
+
+class TestSubscription:
+    """구독 관련 테스트."""
+
+    async def test_subscribe_before_connect(
+        self, stream_client: KISStreamClient
+    ) -> None:
+        """연결 전 구독은 목록에만 추가."""
+        result = await stream_client.subscribe("005930")
+        assert result is True
+        assert "005930" in stream_client.subscribed_symbols
+
+    async def test_subscribe_duplicate(self, stream_client: KISStreamClient) -> None:
+        """중복 구독은 무시."""
+        await stream_client.subscribe("005930")
+        result = await stream_client.subscribe("005930")
+        assert result is True
+        assert len(stream_client.subscribed_symbols) == 1
+
+    async def test_subscribe_max_limit(self, stream_client: KISStreamClient) -> None:
+        """최대 구독 한도 초과 시 False 반환."""
+        for i in range(MAX_SUBSCRIPTIONS):
+            await stream_client.subscribe(f"{i:06d}")
+        result = await stream_client.subscribe("999999")
+        assert result is False
+        assert len(stream_client.subscribed_symbols) == MAX_SUBSCRIPTIONS
+
+    async def test_unsubscribe(self, stream_client: KISStreamClient) -> None:
+        """구독 해제."""
+        await stream_client.subscribe("005930")
+        await stream_client.unsubscribe("005930")
+        assert "005930" not in stream_client.subscribed_symbols
+
+    async def test_unsubscribe_not_subscribed(
+        self, stream_client: KISStreamClient
+    ) -> None:
+        """미구독 종목 해제는 무시."""
+        await stream_client.unsubscribe("999999")  # 에러 없이 통과
+
+
+class TestMessageHandling:
+    """메시지 처리 테스트."""
+
+    async def test_handle_price_data(self, stream_client: KISStreamClient) -> None:
+        """실시간 시세 데이터 처리."""
+        received: list[tuple[str, float]] = []
+
+        async def on_price(symbol: str, price: float) -> None:
+            received.append((symbol, price))
+
+        stream_client.on_price(on_price)
+
+        # 파이프 구분 시세 데이터
+        raw = f"0|{CHANNEL_PRICE}|004|005930^143000^50000^500"
+        await stream_client._handle_message(raw)
+
+        assert len(received) == 1
+        assert received[0] == ("005930", 50000.0)
+
+    async def test_handle_price_data_invalid(
+        self, stream_client: KISStreamClient
+    ) -> None:
+        """잘못된 시세 데이터는 무시."""
+        received: list[tuple[str, float]] = []
+
+        async def on_price(symbol: str, price: float) -> None:
+            received.append((symbol, price))
+
+        stream_client.on_price(on_price)
+
+        # 필드 부족
+        raw = f"0|{CHANNEL_PRICE}|004|005930"
+        await stream_client._handle_message(raw)
+        assert len(received) == 0
+
+    async def test_handle_execution_data(self, stream_client: KISStreamClient) -> None:
+        """실시간 체결 통보 처리."""
+        received: list[dict] = []
+
+        async def on_exec(data: dict) -> None:
+            received.append(data)
+
+        stream_client.on_execution(on_exec)
+
+        # 파이프 구분 체결 데이터
+        fields = ["005930", "ORD001", "", "", "02", "10", "50000", "", "", "", ""]
+        raw = f"0|{CHANNEL_EXECUTION}|004|" + "^".join(fields)
+        await stream_client._handle_message(raw)
+
+        assert len(received) == 1
+        assert received[0]["symbol"] == "005930"
+        assert received[0]["side"] == "buy"
+        assert received[0]["quantity"] == 10.0
+
+    async def test_handle_json_message(self, stream_client: KISStreamClient) -> None:
+        """JSON 구독 확인 메시지 처리 (에러 없이)."""
+        import json
+
+        msg = json.dumps(
+            {
+                "header": {"tr_id": "H0STCNT0", "tr_key": "005930"},
+                "body": {"msg1": "SUBSCRIBE SUCCESS"},
+            }
+        )
+        # JSON 메시지 (구독 확인 등) — 에러 없이 처리
+        await stream_client._handle_message(msg)
+
+    async def test_price_callback_error_isolated(
+        self, stream_client: KISStreamClient
+    ) -> None:
+        """콜백 오류가 다른 콜백에 영향 주지 않음."""
+        received: list[tuple[str, float]] = []
+
+        async def bad_callback(symbol: str, price: float) -> None:
+            raise ValueError("test error")
+
+        async def good_callback(symbol: str, price: float) -> None:
+            received.append((symbol, price))
+
+        stream_client.on_price(bad_callback)
+        stream_client.on_price(good_callback)
+
+        raw = f"0|{CHANNEL_PRICE}|004|005930^143000^50000^500"
+        await stream_client._handle_message(raw)
+
+        assert len(received) == 1
+
+
+class TestDisconnect:
+    """연결 해제 테스트."""
+
+    async def test_disconnect_clears_state(
+        self, stream_client: KISStreamClient
+    ) -> None:
+        """disconnect 시 구독 목록 초기화."""
+        await stream_client.subscribe("005930")
+        await stream_client.disconnect()
+        assert len(stream_client.subscribed_symbols) == 0
+        assert not stream_client.is_connected
+
+    async def test_disconnect_publishes_event(
+        self, stream_client: KISStreamClient, eventbus: MagicMock
+    ) -> None:
+        """disconnect 후 이벤트 발행 안 함 (clean disconnect)."""
+        await stream_client.disconnect()
+        # clean disconnect에서는 disconnected 이벤트를 발행하지 않음
+        # (connection_lost일 때만 발행)

--- a/tests/unit/test_stop_order.py
+++ b/tests/unit/test_stop_order.py
@@ -1,0 +1,349 @@
+"""StopOrderManager 단위 테스트."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.eventbus.events import (
+    OrderRequestEvent,
+    StopOrderExpiredEvent,
+    StopOrderRegisteredEvent,
+    StopOrderTriggeredEvent,
+)
+from ante.gateway.stop_order import StopOrderManager
+
+
+@pytest.fixture
+def eventbus() -> MagicMock:
+    """EventBus mock."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    return bus
+
+
+@pytest.fixture
+def manager(eventbus: MagicMock) -> StopOrderManager:
+    """StopOrderManager 인스턴스."""
+    return StopOrderManager(eventbus)
+
+
+class TestRegister:
+    """스탑 주문 등록 테스트."""
+
+    async def test_register_stop_order(
+        self, manager: StopOrderManager, eventbus: MagicMock
+    ) -> None:
+        """스탑 주문 등록."""
+        stop_id = await manager.register(
+            order_id="ord-001",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop",
+            stop_price=49000.0,
+        )
+
+        assert stop_id.startswith("stop-")
+        assert len(manager.active_orders) == 1
+        assert "005930" in manager.monitored_symbols
+
+        # 이벤트 발행 확인
+        eventbus.publish.assert_called_once()
+        event = eventbus.publish.call_args[0][0]
+        assert isinstance(event, StopOrderRegisteredEvent)
+        assert event.stop_price == 49000.0
+
+    async def test_register_stop_limit_order(
+        self, manager: StopOrderManager, eventbus: MagicMock
+    ) -> None:
+        """스탑 리밋 주문 등록."""
+        stop_id = await manager.register(
+            order_id="ord-002",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="buy",
+            quantity=5.0,
+            order_type="stop_limit",
+            stop_price=51000.0,
+            limit_price=51500.0,
+        )
+
+        order = manager.get_order(stop_id)
+        assert order is not None
+        assert order.order_type == "stop_limit"
+        assert order.limit_price == 51500.0
+
+
+class TestTrigger:
+    """트리거 판단 테스트."""
+
+    async def test_sell_stop_triggered(
+        self, manager: StopOrderManager, eventbus: MagicMock
+    ) -> None:
+        """매도 스탑: 현재가 <= stop_price 시 트리거."""
+        await manager.start()
+
+        await manager.register(
+            order_id="ord-001",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop",
+            stop_price=49000.0,
+        )
+
+        eventbus.publish.reset_mock()
+
+        # 가격이 stop_price 이하로 하락
+        await manager.on_price_update("005930", 48500.0)
+
+        # StopOrderTriggeredEvent + OrderRequestEvent 발행
+        assert eventbus.publish.call_count == 2
+
+        triggered_event = eventbus.publish.call_args_list[0][0][0]
+        assert isinstance(triggered_event, StopOrderTriggeredEvent)
+        assert triggered_event.trigger_price == 48500.0
+        assert triggered_event.converted_order_type == "market"
+
+        order_event = eventbus.publish.call_args_list[1][0][0]
+        assert isinstance(order_event, OrderRequestEvent)
+        assert order_event.order_type == "market"
+        assert order_event.side == "sell"
+
+    async def test_buy_stop_triggered(
+        self, manager: StopOrderManager, eventbus: MagicMock
+    ) -> None:
+        """매수 스탑: 현재가 >= stop_price 시 트리거."""
+        await manager.start()
+
+        await manager.register(
+            order_id="ord-002",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="buy",
+            quantity=5.0,
+            order_type="stop",
+            stop_price=51000.0,
+        )
+
+        eventbus.publish.reset_mock()
+        await manager.on_price_update("005930", 51500.0)
+
+        assert eventbus.publish.call_count == 2
+        triggered_event = eventbus.publish.call_args_list[0][0][0]
+        assert isinstance(triggered_event, StopOrderTriggeredEvent)
+
+    async def test_stop_limit_converts_to_limit(
+        self, manager: StopOrderManager, eventbus: MagicMock
+    ) -> None:
+        """stop_limit → limit 변환."""
+        await manager.start()
+
+        await manager.register(
+            order_id="ord-003",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="buy",
+            quantity=5.0,
+            order_type="stop_limit",
+            stop_price=51000.0,
+            limit_price=51500.0,
+        )
+
+        eventbus.publish.reset_mock()
+        await manager.on_price_update("005930", 51000.0)
+
+        order_event = eventbus.publish.call_args_list[1][0][0]
+        assert isinstance(order_event, OrderRequestEvent)
+        assert order_event.order_type == "limit"
+        assert order_event.price == 51500.0
+
+    async def test_not_triggered_below_threshold(
+        self, manager: StopOrderManager, eventbus: MagicMock
+    ) -> None:
+        """트리거 조건 미충족 시 주문 유지."""
+        await manager.start()
+
+        await manager.register(
+            order_id="ord-004",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop",
+            stop_price=49000.0,
+        )
+
+        eventbus.publish.reset_mock()
+        await manager.on_price_update("005930", 50000.0)  # > stop_price
+
+        # 트리거 안 됨
+        assert eventbus.publish.call_count == 0
+        assert len(manager.active_orders) == 1
+
+    async def test_different_symbol_ignored(
+        self, manager: StopOrderManager, eventbus: MagicMock
+    ) -> None:
+        """다른 종목 시세는 무시."""
+        await manager.start()
+
+        await manager.register(
+            order_id="ord-005",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop",
+            stop_price=49000.0,
+        )
+
+        eventbus.publish.reset_mock()
+        await manager.on_price_update("000660", 48000.0)
+
+        assert eventbus.publish.call_count == 0
+
+    async def test_not_running_ignores_price(
+        self, manager: StopOrderManager, eventbus: MagicMock
+    ) -> None:
+        """매니저 미시작 상태에서 시세 무시."""
+        await manager.register(
+            order_id="ord-006",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop",
+            stop_price=49000.0,
+        )
+
+        eventbus.publish.reset_mock()
+        await manager.on_price_update("005930", 48000.0)
+
+        # running=False이므로 무시
+        assert eventbus.publish.call_count == 0
+
+
+class TestCancel:
+    """스탑 주문 취소 테스트."""
+
+    async def test_cancel_active_order(
+        self, manager: StopOrderManager, eventbus: MagicMock
+    ) -> None:
+        """활성 주문 취소."""
+        stop_id = await manager.register(
+            order_id="ord-001",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop",
+            stop_price=49000.0,
+        )
+
+        result = await manager.cancel(stop_id)
+        assert result is True
+        assert len(manager.active_orders) == 0
+
+    async def test_cancel_nonexistent(self, manager: StopOrderManager) -> None:
+        """존재하지 않는 주문 취소."""
+        result = await manager.cancel("stop-nonexistent")
+        assert result is False
+
+
+class TestExpiry:
+    """세션 종료 만료 테스트."""
+
+    async def test_stop_expires_all_on_stop(
+        self, manager: StopOrderManager, eventbus: MagicMock
+    ) -> None:
+        """매니저 중지 시 모든 주문 만료."""
+        await manager.start()
+
+        await manager.register(
+            order_id="ord-001",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop",
+            stop_price=49000.0,
+        )
+
+        eventbus.publish.reset_mock()
+        await manager.stop()
+
+        # StopOrderExpiredEvent 발행
+        assert eventbus.publish.call_count == 1
+        event = eventbus.publish.call_args[0][0]
+        assert isinstance(event, StopOrderExpiredEvent)
+        assert event.reason == "manager_stopped"
+
+
+class TestBotOrders:
+    """봇별 주문 조회 테스트."""
+
+    async def test_get_orders_for_bot(
+        self, manager: StopOrderManager, eventbus: MagicMock
+    ) -> None:
+        """봇별 활성 주문 필터링."""
+        await manager.register(
+            order_id="ord-001",
+            bot_id="bot-001",
+            strategy_id="stg-001",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop",
+            stop_price=49000.0,
+        )
+        await manager.register(
+            order_id="ord-002",
+            bot_id="bot-002",
+            strategy_id="stg-002",
+            symbol="000660",
+            side="buy",
+            quantity=5.0,
+            order_type="stop",
+            stop_price=100000.0,
+        )
+
+        bot1_orders = manager.get_orders_for_bot("bot-001")
+        assert len(bot1_orders) == 1
+        assert bot1_orders[0].symbol == "005930"
+
+
+class TestSignalTradingSession:
+    """Signal trading_session 필드 테스트."""
+
+    def test_signal_default_session(self) -> None:
+        """Signal 기본 trading_session은 regular."""
+        from ante.strategy.base import Signal
+
+        sig = Signal(symbol="005930", side="buy", quantity=10)
+        assert sig.trading_session == "regular"
+
+    def test_signal_extended_session(self) -> None:
+        """Signal extended session 설정."""
+        from ante.strategy.base import Signal
+
+        sig = Signal(
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            trading_session="extended",
+        )
+        assert sig.trading_session == "extended"


### PR DESCRIPTION
## Summary
- KISStreamClient: KIS WebSocket 실시간 스트리밍 (시세 H0STCNT0, 체결통보 H0STCNI0, 자동 재연결)
- StopOrderManager: 스탑/스탑리밋 주문 에뮬레이션 (실시간 시세 기반 트리거, 세션 만료)
- APIGateway: stop/stop_limit 주문을 StopOrderManager로 라우팅
- Signal에 `trading_session` 필드 추가 ("regular" | "extended")
- 5개 신규 이벤트: StopOrderRegistered/Triggered/Expired, StreamConnected/Disconnected
- `websockets>=13.0` 의존성 추가

## Test plan
- [x] KISStreamClient 14개 테스트 (구독, 메시지 처리, 콜백 격리)
- [x] StopOrderManager 14개 테스트 (등록, 매수/매도 트리거, 취소, 만료)
- [x] APIGateway 라우팅 5개 테스트 (stop→manager, market→broker, 실패 처리)
- [x] Signal trading_session 필드 2개 테스트
- [x] ruff check + format 통과
- [x] 전체 973 테스트 통과

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)