### PR TITLE
feat: add accepts_external_signals flag to StrategyMeta

### DIFF
--- a/src/ante/bot/bot.py
+++ b/src/ante/bot/bot.py
@@ -199,6 +199,39 @@ class Bot:
         if update:
             await self.strategy.on_order_update(update)
 
+    async def on_external_signal(self, event: object) -> None:
+        """외부 시그널 수신 → 전략의 on_data()로 전달.
+
+        accepts_external_signals=False인 전략은 시그널을 무시한다.
+        """
+        from ante.eventbus.events import ExternalSignalEvent
+
+        if not isinstance(event, ExternalSignalEvent):
+            return
+        if not self.strategy or event.bot_id != self.bot_id:
+            return
+
+        if not self.strategy.meta.accepts_external_signals:
+            logger.warning(
+                "외부 시그널 거부: 봇 %s 전략 %s — accepts_external_signals=False",
+                self.bot_id,
+                self.strategy.meta.name,
+            )
+            return
+
+        follow_up = await self.strategy.on_data(
+            {
+                "signal_id": event.signal_id,
+                "symbol": event.symbol,
+                "action": event.action,
+                "reason": event.reason,
+                "confidence": event.confidence,
+                "metadata": event.metadata,
+                "timestamp": event.timestamp,
+            }
+        )
+        await self._publish_signals(follow_up or [])
+
     async def _publish_signals(self, signals: list[Signal]) -> None:
         """Signal → OrderRequestEvent 변환 + EventBus 발행."""
         from ante.eventbus.events import OrderRequestEvent

--- a/src/ante/strategy/base.py
+++ b/src/ante/strategy/base.py
@@ -24,6 +24,7 @@ class StrategyMeta:
     symbols: list[str] | None = None
     timeframe: str = "1d"
     exchange: str = "KRX"
+    accepts_external_signals: bool = False
 
 
 # ── 시그널 / 주문 액션 ────────────────────────────

--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -71,6 +71,15 @@ class StrategyValidator:
             if not self._has_method(cls, "on_step"):
                 errors.append("Missing required method: on_step()")
 
+            # accepts_external_signals=True인 전략에 on_data() 구현 여부 경고
+            if self._has_accepts_external_signals(cls) and not self._has_method(
+                cls, "on_data"
+            ):
+                warnings.append(
+                    "Strategy has accepts_external_signals=True but does not "
+                    "implement on_data() — external signals will use default handler"
+                )
+
         # 4. 금지 모듈 import
         forbidden = self._find_forbidden_imports(tree)
         for module in forbidden:
@@ -115,6 +124,25 @@ class StrategyValidator:
             if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
                 if node.name == name:
                     return True
+        return False
+
+    def _has_accepts_external_signals(self, cls: ast.ClassDef) -> bool:
+        """meta에 accepts_external_signals=True 설정 여부 탐지."""
+        for node in cls.body:
+            # meta = StrategyMeta(..., accepts_external_signals=True)
+            if isinstance(node, ast.Assign | ast.AnnAssign):
+                target = (
+                    node.targets[0] if isinstance(node, ast.Assign) else node.target
+                )
+                if not isinstance(target, ast.Name) or target.id != "meta":
+                    continue
+                value = node.value
+                if isinstance(value, ast.Call):
+                    for kw in value.keywords:
+                        if kw.arg == "accepts_external_signals" and isinstance(
+                            kw.value, ast.Constant
+                        ):
+                            return bool(kw.value.value)
         return False
 
     def _find_forbidden_imports(self, tree: ast.Module) -> list[str]:

--- a/tests/unit/test_external_signals.py
+++ b/tests/unit/test_external_signals.py
@@ -1,0 +1,251 @@
+"""accepts_external_signals 플래그 및 외부 시그널 수신 테스트."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from ante.eventbus.events import ExternalSignalEvent
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+from ante.strategy.validator import StrategyValidator
+
+# ── US-1: StrategyMeta accepts_external_signals ──────────
+
+
+class TestStrategyMetaFlag:
+    """StrategyMeta accepts_external_signals 필드 테스트."""
+
+    def test_default_false(self) -> None:
+        """기본값은 False."""
+        meta = StrategyMeta(name="test", version="1.0.0", description="test")
+        assert meta.accepts_external_signals is False
+
+    def test_set_true(self) -> None:
+        """True로 설정 가능."""
+        meta = StrategyMeta(
+            name="test",
+            version="1.0.0",
+            description="test",
+            accepts_external_signals=True,
+        )
+        assert meta.accepts_external_signals is True
+
+    def test_backward_compatible(self) -> None:
+        """기존 전략 코드에 영향 없음."""
+        meta = StrategyMeta(
+            name="old_strategy",
+            version="1.0.0",
+            description="legacy",
+            author="human",
+            symbols=["005930"],
+            timeframe="1d",
+        )
+        assert meta.accepts_external_signals is False
+
+
+class TestValidatorExternalSignals:
+    """StrategyValidator accepts_external_signals 경고 테스트."""
+
+    def _write_strategy(self, code: str) -> Path:
+        f = tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False)
+        f.write(code)
+        f.close()
+        return Path(f.name)
+
+    def test_no_warning_without_flag(self) -> None:
+        """accepts_external_signals 없으면 경고 없음."""
+        path = self._write_strategy(
+            """
+from ante.strategy.base import Strategy, StrategyMeta, Signal
+
+class MyStrategy(Strategy):
+    meta = StrategyMeta(name="test", version="1.0", description="test")
+
+    async def on_step(self, context):
+        return []
+"""
+        )
+        result = StrategyValidator().validate(path)
+        assert result.valid
+        assert not any("accepts_external_signals" in w for w in result.warnings)
+
+    def test_warning_with_flag_no_on_data(self) -> None:
+        """accepts_external_signals=True + on_data() 미구현 시 경고."""
+        path = self._write_strategy(
+            """
+from ante.strategy.base import Strategy, StrategyMeta, Signal
+
+class MyStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0", description="test",
+        accepts_external_signals=True,
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        )
+        result = StrategyValidator().validate(path)
+        assert result.valid
+        assert any("accepts_external_signals" in w for w in result.warnings)
+        assert any("on_data" in w for w in result.warnings)
+
+    def test_no_warning_with_flag_and_on_data(self) -> None:
+        """accepts_external_signals=True + on_data() 구현 시 경고 없음."""
+        path = self._write_strategy(
+            """
+from ante.strategy.base import Strategy, StrategyMeta, Signal
+
+class MyStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0", description="test",
+        accepts_external_signals=True,
+    )
+
+    async def on_step(self, context):
+        return []
+
+    async def on_data(self, data):
+        return []
+"""
+        )
+        result = StrategyValidator().validate(path)
+        assert result.valid
+        assert not any("accepts_external_signals" in w for w in result.warnings)
+
+
+# ── US-2: Bot.on_external_signal() ──────────────────────
+
+
+class _InhouseStrategy(Strategy):
+    """accepts_external_signals=False 전략."""
+
+    meta = StrategyMeta(name="inhouse", version="1.0.0", description="inhouse strategy")
+
+    async def on_step(self, context: dict) -> list[Signal]:
+        return []
+
+
+class _OutsourcedStrategy(Strategy):
+    """accepts_external_signals=True 전략."""
+
+    meta = StrategyMeta(
+        name="outsourced",
+        version="1.0.0",
+        description="outsourced strategy",
+        accepts_external_signals=True,
+    )
+
+    async def on_step(self, context: dict) -> list[Signal]:
+        return []
+
+    async def on_data(self, data: dict) -> list[Signal]:
+        return [
+            Signal(
+                symbol=data["symbol"],
+                side=data["action"],
+                quantity=1.0,
+                reason=data.get("reason", "external"),
+            )
+        ]
+
+
+def _make_bot(strategy_cls: type[Strategy]) -> MagicMock:
+    """Bot 인스턴스를 만들되 필요한 속성을 mock으로 설정."""
+    from ante.bot.bot import Bot
+
+    config = MagicMock()
+    config.bot_id = "bot-001"
+    config.strategy_id = "stg-001"
+    config.exchange = "KRX"
+
+    ctx = MagicMock()
+    ctx.get_positions.return_value = {}
+    ctx.get_balance.return_value = {"available": 1000000.0}
+
+    eventbus = MagicMock()
+    eventbus.publish = AsyncMock()
+
+    bot = Bot(config=config, strategy_cls=strategy_cls, ctx=ctx, eventbus=eventbus)
+    bot.strategy = strategy_cls(ctx=ctx)
+
+    return bot
+
+
+class TestBotExternalSignal:
+    """Bot.on_external_signal() 테스트."""
+
+    async def test_reject_when_not_accepting(self) -> None:
+        """accepts_external_signals=False 시 시그널 무시."""
+        bot = _make_bot(_InhouseStrategy)
+
+        event = ExternalSignalEvent(
+            bot_id="bot-001",
+            signal_id="sig-001",
+            symbol="005930",
+            action="buy",
+            reason="test",
+            confidence=0.9,
+        )
+
+        await bot.on_external_signal(event)
+
+        # EventBus에 OrderRequestEvent 발행되지 않음
+        bot._eventbus.publish.assert_not_called()
+
+    async def test_accept_and_forward(self) -> None:
+        """accepts_external_signals=True 시 on_data() 호출 및 시그널 발행."""
+        bot = _make_bot(_OutsourcedStrategy)
+
+        event = ExternalSignalEvent(
+            bot_id="bot-001",
+            signal_id="sig-001",
+            symbol="005930",
+            action="buy",
+            reason="external signal",
+            confidence=0.95,
+        )
+
+        await bot.on_external_signal(event)
+
+        # on_data() → Signal → OrderRequestEvent 발행
+        bot._eventbus.publish.assert_called_once()
+        published = bot._eventbus.publish.call_args[0][0]
+        assert published.symbol == "005930"
+        assert published.side == "buy"
+
+    async def test_ignore_wrong_bot_id(self) -> None:
+        """다른 봇의 시그널은 무시."""
+        bot = _make_bot(_OutsourcedStrategy)
+
+        event = ExternalSignalEvent(
+            bot_id="bot-999",  # 다른 봇
+            signal_id="sig-001",
+            symbol="005930",
+            action="buy",
+        )
+
+        await bot.on_external_signal(event)
+        bot._eventbus.publish.assert_not_called()
+
+    async def test_ignore_non_event(self) -> None:
+        """ExternalSignalEvent가 아닌 이벤트 무시."""
+        bot = _make_bot(_OutsourcedStrategy)
+        await bot.on_external_signal("not an event")
+        bot._eventbus.publish.assert_not_called()
+
+    async def test_ignore_when_no_strategy(self) -> None:
+        """전략이 없을 때 무시."""
+        bot = _make_bot(_OutsourcedStrategy)
+        bot.strategy = None
+
+        event = ExternalSignalEvent(
+            bot_id="bot-001",
+            signal_id="sig-001",
+            symbol="005930",
+            action="buy",
+        )
+
+        await bot.on_external_signal(event)
+        bot._eventbus.publish.assert_not_called()

--- a/tests/unit/test_stop_order.py
+++ b/tests/unit/test_stop_order.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: F811
 
 import pytest
 
@@ -82,8 +82,9 @@ class TestRegister:
 class TestTrigger:
     """트리거 판단 테스트."""
 
+    @patch.object(StopOrderManager, "_is_in_session", return_value=True)
     async def test_sell_stop_triggered(
-        self, manager: StopOrderManager, eventbus: MagicMock
+        self, _mock_session: MagicMock, manager: StopOrderManager, eventbus: MagicMock
     ) -> None:
         """매도 스탑: 현재가 <= stop_price 시 트리거."""
         await manager.start()
@@ -117,8 +118,9 @@ class TestTrigger:
         assert order_event.order_type == "market"
         assert order_event.side == "sell"
 
+    @patch.object(StopOrderManager, "_is_in_session", return_value=True)
     async def test_buy_stop_triggered(
-        self, manager: StopOrderManager, eventbus: MagicMock
+        self, _mock_session: MagicMock, manager: StopOrderManager, eventbus: MagicMock
     ) -> None:
         """매수 스탑: 현재가 >= stop_price 시 트리거."""
         await manager.start()
@@ -141,8 +143,9 @@ class TestTrigger:
         triggered_event = eventbus.publish.call_args_list[0][0][0]
         assert isinstance(triggered_event, StopOrderTriggeredEvent)
 
+    @patch.object(StopOrderManager, "_is_in_session", return_value=True)
     async def test_stop_limit_converts_to_limit(
-        self, manager: StopOrderManager, eventbus: MagicMock
+        self, _mock_session: MagicMock, manager: StopOrderManager, eventbus: MagicMock
     ) -> None:
         """stop_limit → limit 변환."""
         await manager.start()


### PR DESCRIPTION
## Summary
- StrategyMeta에 `accepts_external_signals: bool = False` 필드 추가 — 기존 전략 하위호환
- StrategyValidator: `accepts_external_signals=True`인데 `on_data()` 미구현 시 경고 출력
- Bot.on_external_signal(): 플래그 확인 후 `on_data()`로 전달, False면 경고 로그 후 무시
- 이전 이슈(#62) 스탑 주문 테스트 세션 체크 패치 (타임존 무관 테스트)

## Test plan
- [x] StrategyMeta 기본값 False, True 설정, 하위호환성 (3개)
- [x] StrategyValidator 경고 발생/미발생 (3개)
- [x] Bot.on_external_signal() 거부/수락/잘못된 봇/비이벤트/전략없음 (5개)
- [x] 전체 984 테스트 통과

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)