### PR TITLE
feat: add SignalKeyManager for bot signal key management

### DIFF
--- a/src/ante/bot/__init__.py
+++ b/src/ante/bot/__init__.py
@@ -5,6 +5,7 @@ from ante.bot.config import BotConfig, BotStatus
 from ante.bot.context_factory import StrategyContextFactory
 from ante.bot.exceptions import BotError
 from ante.bot.manager import BotManager
+from ante.bot.signal_key import SignalKeyManager
 
 __all__ = [
     "Bot",
@@ -12,5 +13,6 @@ __all__ = [
     "BotError",
     "BotManager",
     "BotStatus",
+    "SignalKeyManager",
     "StrategyContextFactory",
 ]

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -13,6 +13,7 @@ from ante.bot.exceptions import BotError
 
 if TYPE_CHECKING:
     from ante.bot.context_factory import StrategyContextFactory
+    from ante.bot.signal_key import SignalKeyManager  # noqa: F811
     from ante.core.database import Database
     from ante.eventbus.bus import EventBus
     from ante.strategy.base import Strategy
@@ -42,10 +43,12 @@ class BotManager:
         eventbus: EventBus,
         db: Database,
         context_factory: StrategyContextFactory | None = None,
+        signal_key_manager: SignalKeyManager | None = None,
     ) -> None:
         self._eventbus = eventbus
         self._db = db
         self._context_factory = context_factory
+        self._signal_key_manager = signal_key_manager
         self._bots: dict[str, Bot] = {}
         self._restart_counts: dict[str, int] = {}
         self._restart_tasks: dict[str, asyncio.Task[None]] = {}
@@ -101,6 +104,19 @@ class BotManager:
         self._bots[config.bot_id] = bot
         await self._save_bot_config(config)
 
+        # accepts_external_signals=True이면 시그널 키 자동 발급
+        if (
+            self._signal_key_manager
+            and hasattr(strategy_cls, "meta")
+            and getattr(strategy_cls.meta, "accepts_external_signals", False)
+        ):
+            signal_key = await self._signal_key_manager.generate(config.bot_id)
+            logger.info(
+                "시그널 키 자동 발급: bot=%s key=%s...",
+                config.bot_id,
+                signal_key[:8],
+            )
+
         logger.info("봇 생성: %s (전략: %s)", config.bot_id, config.strategy_id)
         return bot
 
@@ -129,6 +145,10 @@ class BotManager:
             and bot.config.bot_type == "paper"
         ):
             self._context_factory._paper_executor.unregister_bot(bot_id)
+
+        # 시그널 키 폐기
+        if self._signal_key_manager:
+            await self._signal_key_manager.revoke(bot_id)
 
         del self._bots[bot_id]
         await self._db.execute("DELETE FROM bots WHERE bot_id = ?", (bot_id,))
@@ -298,6 +318,19 @@ class BotManager:
                 last_error=last_error,
             )
         )
+
+    async def get_signal_key(self, bot_id: str) -> str | None:
+        """봇의 시그널 키 조회."""
+        if not self._signal_key_manager:
+            return None
+        return await self._signal_key_manager.get_key(bot_id)
+
+    async def rotate_signal_key(self, bot_id: str) -> str:
+        """시그널 키 재발급."""
+        if not self._signal_key_manager:
+            raise BotError("SignalKeyManager가 설정되지 않았습니다")
+        self._get_bot(bot_id)  # 존재 확인
+        return await self._signal_key_manager.rotate(bot_id)
 
     def get_restart_count(self, bot_id: str) -> int:
         """봇의 현재 재시작 시도 횟수."""

--- a/src/ante/bot/signal_key.py
+++ b/src/ante/bot/signal_key.py
@@ -1,0 +1,88 @@
+"""SignalKeyManager — 봇별 시그널 키 발급/관리."""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+
+logger = logging.getLogger(__name__)
+
+SIGNAL_KEY_SCHEMA = """
+CREATE TABLE IF NOT EXISTS signal_keys (
+    key_id       TEXT PRIMARY KEY,
+    bot_id       TEXT NOT NULL UNIQUE,
+    created_at   TEXT DEFAULT (datetime('now'))
+);
+"""
+
+# 키 형식: sk_ + 32자 hex (128-bit entropy)
+_KEY_PREFIX = "sk_"
+_KEY_BYTES = 16
+
+
+class SignalKeyManager:
+    """봇별 시그널 키 발급/조회/재발급/폐기."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    async def initialize(self) -> None:
+        """signal_keys 테이블 생성."""
+        await self._db.execute_script(SIGNAL_KEY_SCHEMA)
+
+    async def generate(self, bot_id: str) -> str:
+        """시그널 키 발급. 이미 존재하면 기존 키 반환."""
+        existing = await self.get_key(bot_id)
+        if existing:
+            return existing
+
+        key = _KEY_PREFIX + secrets.token_hex(_KEY_BYTES)
+        await self._db.execute(
+            "INSERT INTO signal_keys (key_id, bot_id) VALUES (?, ?)",
+            (key, bot_id),
+        )
+        logger.info("시그널 키 발급: bot=%s", bot_id)
+        return key
+
+    async def get_key(self, bot_id: str) -> str | None:
+        """봇의 시그널 키 조회."""
+        row = await self._db.fetch_one(
+            "SELECT key_id FROM signal_keys WHERE bot_id = ?",
+            (bot_id,),
+        )
+        return row["key_id"] if row else None
+
+    async def rotate(self, bot_id: str) -> str:
+        """기존 키 폐기 + 새 키 발급."""
+        await self.revoke(bot_id)
+        new_key = _KEY_PREFIX + secrets.token_hex(_KEY_BYTES)
+        await self._db.execute(
+            "INSERT INTO signal_keys (key_id, bot_id) VALUES (?, ?)",
+            (new_key, bot_id),
+        )
+        logger.info("시그널 키 재발급: bot=%s", bot_id)
+        return new_key
+
+    async def revoke(self, bot_id: str) -> bool:
+        """시그널 키 폐기."""
+        existing = await self.get_key(bot_id)
+        if not existing:
+            return False
+        await self._db.execute(
+            "DELETE FROM signal_keys WHERE bot_id = ?",
+            (bot_id,),
+        )
+        logger.info("시그널 키 폐기: bot=%s", bot_id)
+        return True
+
+    async def validate_key(self, key: str) -> str | None:
+        """키 유효성 검증. 유효하면 bot_id 반환."""
+        row = await self._db.fetch_one(
+            "SELECT bot_id FROM signal_keys WHERE key_id = ?",
+            (key,),
+        )
+        return row["bot_id"] if row else None

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -221,6 +221,55 @@ def bot_remove(ctx: click.Context, bot_id: str) -> None:
     fmt.success(f"봇 삭제 완료: {bot_id}")
 
 
+@bot.command("signal-key")
+@click.argument("bot_id")
+@click.option("--rotate", is_flag=True, help="기존 키 폐기 + 새 키 발급")
+@click.pass_context
+@require_auth
+@require_scope("bot:admin")
+def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
+    """봇 시그널 키 조회 또는 재발급."""
+    fmt = get_formatter(ctx)
+
+    async def _run_signal_key() -> dict:
+        from ante.bot.signal_key import SignalKeyManager
+
+        db, _, _ = await _create_services()
+        try:
+            skm = SignalKeyManager(db)
+            await skm.initialize()
+
+            if rotate:
+                new_key = await skm.rotate(bot_id)
+                return {"bot_id": bot_id, "signal_key": new_key, "rotated": True}
+
+            key = await skm.get_key(bot_id)
+            if not key:
+                return {"bot_id": bot_id, "signal_key": None}
+            return {"bot_id": bot_id, "signal_key": key}
+        finally:
+            await db.close()
+
+    try:
+        result = _run(_run_signal_key())
+    except Exception as e:
+        fmt.error(str(e))
+        return
+
+    if result.get("signal_key") is None:
+        fmt.error(f"시그널 키가 없습니다: {bot_id}")
+        return
+
+    if result.get("rotated"):
+        fmt.success(f"시그널 키 재발급 완료: {bot_id}", result)
+    else:
+        if fmt.is_json:
+            fmt.output(result)
+        else:
+            click.echo(f"  Bot ID     : {result['bot_id']}")
+            click.echo(f"  Signal Key : {result['signal_key']}")
+
+
 @bot.command("positions")
 @click.argument("bot_id")
 @click.pass_context

--- a/tests/unit/test_signal_key.py
+++ b/tests/unit/test_signal_key.py
@@ -1,0 +1,295 @@
+"""SignalKeyManager 및 BotManager 시그널 키 연동 테스트."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.bot.signal_key import SignalKeyManager
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+# ── SignalKeyManager 단독 테스트 ─────────────────────
+
+
+@pytest.fixture
+def db() -> MagicMock:
+    """Database mock."""
+    mock_db = MagicMock()
+    mock_db.execute = AsyncMock()
+    mock_db.execute_script = AsyncMock()
+    mock_db.fetch_one = AsyncMock(return_value=None)
+    mock_db.fetch_all = AsyncMock(return_value=[])
+    return mock_db
+
+
+@pytest.fixture
+def skm(db: MagicMock) -> SignalKeyManager:
+    """SignalKeyManager 인스턴스."""
+    return SignalKeyManager(db)
+
+
+class TestSignalKeyGenerate:
+    """키 발급 테스트."""
+
+    async def test_generate_key_format(self, skm: SignalKeyManager) -> None:
+        """발급된 키가 sk_ 접두사 + hex 형식."""
+        key = await skm.generate("bot-001")
+        assert key.startswith("sk_")
+        assert len(key) == 3 + 32  # "sk_" + 32 hex chars
+
+    async def test_generate_unique_keys(self, skm: SignalKeyManager) -> None:
+        """매번 고유한 키 발급."""
+        key1 = await skm.generate("bot-001")
+        # Reset mock to simulate no existing key
+        skm._db.fetch_one = AsyncMock(return_value=None)
+        key2 = await skm.generate("bot-002")
+        assert key1 != key2
+
+    async def test_generate_returns_existing(
+        self, skm: SignalKeyManager, db: MagicMock
+    ) -> None:
+        """이미 키가 있으면 기존 키 반환."""
+        db.fetch_one = AsyncMock(return_value={"key_id": "sk_existing123"})
+        key = await skm.generate("bot-001")
+        assert key == "sk_existing123"
+        # INSERT 호출 안 됨
+        db.execute.assert_not_called()
+
+    async def test_generate_saves_to_db(
+        self, skm: SignalKeyManager, db: MagicMock
+    ) -> None:
+        """키 발급 시 DB에 저장."""
+        key = await skm.generate("bot-001")
+        db.execute.assert_called_once()
+        call_args = db.execute.call_args
+        assert "INSERT INTO signal_keys" in call_args[0][0]
+        assert call_args[0][1] == (key, "bot-001")
+
+
+class TestSignalKeyGet:
+    """키 조회 테스트."""
+
+    async def test_get_existing_key(self, skm: SignalKeyManager, db: MagicMock) -> None:
+        """존재하는 키 조회."""
+        db.fetch_one = AsyncMock(return_value={"key_id": "sk_abc123"})
+        key = await skm.get_key("bot-001")
+        assert key == "sk_abc123"
+
+    async def test_get_nonexistent_key(self, skm: SignalKeyManager) -> None:
+        """없는 키 조회 시 None."""
+        key = await skm.get_key("bot-999")
+        assert key is None
+
+
+class TestSignalKeyRotate:
+    """키 재발급 테스트."""
+
+    async def test_rotate_generates_new_key(
+        self, skm: SignalKeyManager, db: MagicMock
+    ) -> None:
+        """재발급 시 새 키 반환."""
+        db.fetch_one = AsyncMock(return_value={"key_id": "sk_old"})
+        new_key = await skm.rotate("bot-001")
+        assert new_key.startswith("sk_")
+        assert new_key != "sk_old"
+
+    async def test_rotate_deletes_old_key(
+        self, skm: SignalKeyManager, db: MagicMock
+    ) -> None:
+        """재발급 시 기존 키 삭제."""
+        db.fetch_one = AsyncMock(return_value={"key_id": "sk_old"})
+        await skm.rotate("bot-001")
+        # DELETE + INSERT 호출
+        assert db.execute.call_count == 2
+        delete_call = db.execute.call_args_list[0]
+        assert "DELETE FROM signal_keys" in delete_call[0][0]
+
+
+class TestSignalKeyRevoke:
+    """키 폐기 테스트."""
+
+    async def test_revoke_existing(self, skm: SignalKeyManager, db: MagicMock) -> None:
+        """존재하는 키 폐기."""
+        db.fetch_one = AsyncMock(return_value={"key_id": "sk_abc"})
+        result = await skm.revoke("bot-001")
+        assert result is True
+        db.execute.assert_called_once()
+
+    async def test_revoke_nonexistent(self, skm: SignalKeyManager) -> None:
+        """없는 키 폐기 시 False."""
+        result = await skm.revoke("bot-999")
+        assert result is False
+
+
+class TestSignalKeyValidate:
+    """키 검증 테스트."""
+
+    async def test_validate_valid_key(
+        self, skm: SignalKeyManager, db: MagicMock
+    ) -> None:
+        """유효한 키 → bot_id 반환."""
+        db.fetch_one = AsyncMock(return_value={"bot_id": "bot-001"})
+        bot_id = await skm.validate_key("sk_valid123")
+        assert bot_id == "bot-001"
+
+    async def test_validate_invalid_key(self, skm: SignalKeyManager) -> None:
+        """무효한 키 → None."""
+        bot_id = await skm.validate_key("sk_invalid")
+        assert bot_id is None
+
+
+# ── BotManager 연동 테스트 ──────────────────────────
+
+
+class _AcceptingStrategy(Strategy):
+    """accepts_external_signals=True 전략."""
+
+    meta = StrategyMeta(
+        name="accepting",
+        version="1.0.0",
+        description="accepts signals",
+        accepts_external_signals=True,
+    )
+
+    async def on_step(self, context: dict) -> list[Signal]:
+        return []
+
+
+class _NormalStrategy(Strategy):
+    """accepts_external_signals=False 전략."""
+
+    meta = StrategyMeta(
+        name="normal",
+        version="1.0.0",
+        description="normal strategy",
+    )
+
+    async def on_step(self, context: dict) -> list[Signal]:
+        return []
+
+
+class TestBotManagerSignalKey:
+    """BotManager 시그널 키 연동."""
+
+    async def test_create_bot_auto_generates_key(self) -> None:
+        """accepts_external_signals=True 전략 봇 생성 시 키 자동 발급."""
+        from ante.bot.config import BotConfig
+        from ante.bot.manager import BotManager
+
+        db = MagicMock()
+        db.execute = AsyncMock()
+        db.execute_script = AsyncMock()
+        eventbus = MagicMock()
+        eventbus.subscribe = MagicMock()
+
+        skm = MagicMock()
+        skm.generate = AsyncMock(return_value="sk_auto123")
+
+        manager = BotManager(eventbus=eventbus, db=db, signal_key_manager=skm)
+
+        ctx = MagicMock()
+        config = BotConfig(bot_id="bot-001", strategy_id="accepting")
+
+        await manager.create_bot(config, _AcceptingStrategy, ctx=ctx)
+
+        skm.generate.assert_called_once_with("bot-001")
+
+    async def test_create_bot_no_key_for_normal(self) -> None:
+        """accepts_external_signals=False 전략은 키 미발급."""
+        from ante.bot.config import BotConfig
+        from ante.bot.manager import BotManager
+
+        db = MagicMock()
+        db.execute = AsyncMock()
+        db.execute_script = AsyncMock()
+        eventbus = MagicMock()
+        eventbus.subscribe = MagicMock()
+
+        skm = MagicMock()
+        skm.generate = AsyncMock()
+
+        manager = BotManager(eventbus=eventbus, db=db, signal_key_manager=skm)
+
+        ctx = MagicMock()
+        config = BotConfig(bot_id="bot-002", strategy_id="normal")
+
+        await manager.create_bot(config, _NormalStrategy, ctx=ctx)
+
+        skm.generate.assert_not_called()
+
+    async def test_remove_bot_revokes_key(self) -> None:
+        """봇 삭제 시 시그널 키 폐기."""
+        from ante.bot.config import BotConfig
+        from ante.bot.manager import BotManager
+
+        db = MagicMock()
+        db.execute = AsyncMock()
+        db.execute_script = AsyncMock()
+        eventbus = MagicMock()
+        eventbus.subscribe = MagicMock()
+        eventbus.unsubscribe = MagicMock()
+        eventbus.publish = AsyncMock()
+
+        skm = MagicMock()
+        skm.generate = AsyncMock(return_value="sk_test")
+        skm.revoke = AsyncMock(return_value=True)
+
+        manager = BotManager(eventbus=eventbus, db=db, signal_key_manager=skm)
+
+        ctx = MagicMock()
+        config = BotConfig(bot_id="bot-003", strategy_id="accepting")
+        await manager.create_bot(config, _AcceptingStrategy, ctx=ctx)
+
+        await manager.remove_bot("bot-003")
+
+        skm.revoke.assert_called_once_with("bot-003")
+
+    async def test_rotate_signal_key(self) -> None:
+        """시그널 키 재발급."""
+        from ante.bot.config import BotConfig
+        from ante.bot.manager import BotManager
+
+        db = MagicMock()
+        db.execute = AsyncMock()
+        db.execute_script = AsyncMock()
+        eventbus = MagicMock()
+        eventbus.subscribe = MagicMock()
+
+        skm = MagicMock()
+        skm.generate = AsyncMock(return_value="sk_old")
+        skm.rotate = AsyncMock(return_value="sk_new123")
+
+        manager = BotManager(eventbus=eventbus, db=db, signal_key_manager=skm)
+
+        ctx = MagicMock()
+        config = BotConfig(bot_id="bot-004", strategy_id="accepting")
+        await manager.create_bot(config, _AcceptingStrategy, ctx=ctx)
+
+        new_key = await manager.rotate_signal_key("bot-004")
+        assert new_key == "sk_new123"
+        skm.rotate.assert_called_once_with("bot-004")
+
+    async def test_get_signal_key(self) -> None:
+        """시그널 키 조회."""
+        from ante.bot.config import BotConfig
+        from ante.bot.manager import BotManager
+
+        db = MagicMock()
+        db.execute = AsyncMock()
+        db.execute_script = AsyncMock()
+        eventbus = MagicMock()
+        eventbus.subscribe = MagicMock()
+
+        skm = MagicMock()
+        skm.generate = AsyncMock(return_value="sk_test")
+        skm.get_key = AsyncMock(return_value="sk_test")
+
+        manager = BotManager(eventbus=eventbus, db=db, signal_key_manager=skm)
+
+        ctx = MagicMock()
+        config = BotConfig(bot_id="bot-005", strategy_id="accepting")
+        await manager.create_bot(config, _AcceptingStrategy, ctx=ctx)
+
+        key = await manager.get_signal_key("bot-005")
+        assert key == "sk_test"


### PR DESCRIPTION
## Summary
- `SignalKeyManager`: 시그널 키 발급(`sk_` + 128-bit hex)/조회/재발급/폐기/검증
- `BotManager.create_bot()`: `accepts_external_signals=True` 전략 봇 생성 시 키 자동 발급
- `BotManager.remove_bot()`: 봇 삭제 시 키 자동 폐기
- `BotManager.rotate_signal_key()` / `get_signal_key()` 메서드 추가
- CLI: `ante bot signal-key <bot_id> [--rotate]` 커맨드 추가
- SQLite `signal_keys` 테이블 스키마

## Test plan
- [x] SignalKeyManager: generate(4), get(2), rotate(2), revoke(2), validate(2) — 12개
- [x] BotManager 연동: 자동발급, 미발급, 삭제시폐기, rotate, 조회 — 5개
- [x] 전체 1001 테스트 통과

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)