### PR TITLE
feat: enforce forbidden builtins and top-level code restrictions

### DIFF
--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -38,6 +38,8 @@ class StrategyValidator:
         "pathlib",
     }
 
+    FORBIDDEN_BUILTINS: set[str] = {"eval", "exec", "compile", "__import__"}
+
     def validate(self, filepath: Path) -> ValidationResult:
         """전략 파일 정적 검증."""
         errors: list[str] = []
@@ -85,7 +87,13 @@ class StrategyValidator:
         for module in forbidden:
             errors.append(f"Forbidden import: {module}")
 
-        # 5. 위험 패턴 경고
+        # 5. 금지된 내장 함수 호출 (에러)
+        errors.extend(self._find_forbidden_builtins(tree))
+
+        # 6. 금지된 최상위 코드 (에러)
+        errors.extend(self._find_forbidden_toplevel(tree))
+
+        # 7. 위험 패턴 경고
         warnings.extend(self._find_dangerous_patterns(tree))
 
         return ValidationResult(
@@ -161,21 +169,60 @@ class StrategyValidator:
                         found.append(node.module)
         return found
 
+    def _find_forbidden_builtins(self, tree: ast.Module) -> list[str]:
+        """금지된 내장 함수 호출 탐지 (에러)."""
+        errors: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                if node.func.id in self.FORBIDDEN_BUILTINS:
+                    errors.append(
+                        f"Forbidden built-in call: "
+                        f"{node.func.id}() at line {node.lineno}"
+                    )
+        return errors
+
+    def _find_forbidden_toplevel(self, tree: ast.Module) -> list[str]:
+        """금지된 최상위 코드 탐지 (에러)."""
+        errors: list[str] = []
+        for node in tree.body:
+            if isinstance(node, ast.Import | ast.ImportFrom):
+                continue
+            if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            if isinstance(node, ast.Pass):
+                continue
+            if isinstance(node, ast.If):
+                continue
+            # 모듈 docstring (문자열 리터럴 Expr)
+            if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
+                continue
+            # 리터럴 상수 할당
+            if isinstance(node, ast.Assign | ast.AnnAssign):
+                value = node.value
+                if value is not None and not self._contains_call(value):
+                    continue
+                if value is None:
+                    # 타입 어노테이션만 있는 경우 (x: int)
+                    continue
+            errors.append(
+                f"Forbidden top-level code at line {node.lineno}: {type(node).__name__}"
+            )
+        return errors
+
+    def _contains_call(self, node: ast.AST) -> bool:
+        """AST 서브트리에 함수 호출이 포함되어 있는지 확인."""
+        if isinstance(node, ast.Call):
+            return True
+        for child in ast.walk(node):
+            if isinstance(child, ast.Call):
+                return True
+        return False
+
     def _find_dangerous_patterns(self, tree: ast.Module) -> list[str]:
         """위험 패턴 탐지 (경고 수준)."""
         warnings: list[str] = []
         for node in ast.walk(tree):
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-                if node.func.id in (
-                    "eval",
-                    "exec",
-                    "compile",
-                    "__import__",
-                ):
-                    warnings.append(
-                        f"Dangerous built-in call: "
-                        f"{node.func.id}() at line {node.lineno}"
-                    )
-                elif node.func.id == "open":
+                if node.func.id == "open":
                     warnings.append(f"File access via open() at line {node.lineno}")
         return warnings

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -263,8 +263,8 @@ class TestStrategy(Strategy):
         assert not result.valid
         assert any("subprocess" in e for e in result.errors)
 
-    def test_dangerous_eval_warning(self, validator, tmp_path):
-        """eval 호출은 경고."""
+    def test_forbidden_eval_error(self, validator, tmp_path):
+        """eval 호출은 에러."""
         code = """
 class TestStrategy(Strategy):
     meta = None
@@ -273,8 +273,103 @@ class TestStrategy(Strategy):
         return []
 """
         result = validator.validate(self._write_strategy(tmp_path, code))
-        assert len(result.warnings) > 0
-        assert any("eval" in w for w in result.warnings)
+        assert not result.valid
+        assert any("eval" in e for e in result.errors)
+
+    def test_forbidden_exec_error(self, validator, tmp_path):
+        """exec 호출은 에러."""
+        code = """
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        exec("x = 1")
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("exec" in e for e in result.errors)
+
+    def test_forbidden_compile_error(self, validator, tmp_path):
+        """compile 호출은 에러."""
+        code = """
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        compile("x = 1", "<string>", "exec")
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("compile" in e for e in result.errors)
+
+    def test_forbidden_dunder_import_error(self, validator, tmp_path):
+        """__import__ 호출은 에러."""
+        code = """
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        __import__("os")
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("__import__" in e for e in result.errors)
+
+    def test_forbidden_toplevel_function_call_assign(self, validator, tmp_path):
+        """최상위 함수 호출 할당은 에러."""
+        code = """
+data = load_model("path/to/model")
+
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("top-level" in e.lower() for e in result.errors)
+
+    def test_forbidden_toplevel_standalone_call(self, validator, tmp_path):
+        """최상위 독립 표현식(함수 호출)은 에러."""
+        code = """
+print("hello")
+
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("top-level" in e.lower() for e in result.errors)
+
+    def test_toplevel_literal_assign_allowed(self, validator, tmp_path):
+        """최상위 리터럴 상수 할당은 허용."""
+        code = """
+X = [1, 2, 3]
+Y = "hello"
+
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        # 리터럴 할당은 top-level 에러가 아님
+        assert not any("top-level" in e.lower() for e in result.errors)
+
+    def test_toplevel_docstring_allowed(self, validator, tmp_path):
+        """모듈 docstring은 허용."""
+        code = '''
+"""This is a strategy module."""
+
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        return []
+'''
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not any("top-level" in e.lower() for e in result.errors)
 
     def test_open_warning(self, validator, tmp_path):
         """open 호출은 경고."""


### PR DESCRIPTION
## Summary
- **US-1**: `eval`/`exec`/`compile`/`__import__` 호출을 경고에서 **에러**로 승격. `FORBIDDEN_BUILTINS` 집합 + `_find_forbidden_builtins()` 메서드 추가
- **US-2**: 최상위(module-level) 함수 호출 코드 차단. `_find_forbidden_toplevel()` + `_contains_call()` 헬퍼 추가. 허용: import, class/def, 리터럴 할당, if, pass, docstring
- **US-3**: AGENT.md는 gitignore 대상이므로 로컬에서 별도 관리

Closes #105

## Test plan
- [x] eval 호출 → 에러 (기존 경고 테스트를 에러로 변경)
- [x] exec 호출 → 에러
- [x] compile 호출 → 에러
- [x] __import__ 호출 → 에러
- [x] 최상위 함수 호출 할당 (`data = load_model(...)`) → 에러
- [x] 최상위 독립 표현식 (`print("hello")`) → 에러
- [x] 리터럴 상수 할당 → 통과
- [x] 모듈 docstring → 통과
- [x] 전체 테스트 스위트 통과 (1031 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)