### PR TITLE
feat: add ctx.load_file(), promote open() to error, expand forbidden modules

### DIFF
--- a/src/ante/strategy/__init__.py
+++ b/src/ante/strategy/__init__.py
@@ -12,6 +12,7 @@ from ante.strategy.base import (
 from ante.strategy.context import StrategyContext
 from ante.strategy.exceptions import (
     StrategyError,
+    StrategyFileAccessError,
     StrategyLoadError,
     StrategyValidationError,
 )
@@ -28,6 +29,7 @@ __all__ = [
     "Strategy",
     "StrategyContext",
     "StrategyError",
+    "StrategyFileAccessError",
     "StrategyLoadError",
     "StrategyLoader",
     "StrategyMeta",

--- a/src/ante/strategy/context.py
+++ b/src/ante/strategy/context.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any
 
 from ante.strategy.base import DataProvider, OrderAction, OrderView, PortfolioView
+from ante.strategy.exceptions import StrategyFileAccessError
+
+logger = logging.getLogger(__name__)
+
+# strategies/ 디렉토리 기준 경로 (프로젝트 루트 기준)
+_STRATEGIES_ROOT = Path("strategies")
 
 
 class StrategyContext:
@@ -18,6 +25,7 @@ class StrategyContext:
         portfolio: PortfolioView,
         order_view: OrderView,
         logger: logging.Logger | None = None,
+        strategies_dir: Path | None = None,
     ) -> None:
         self.bot_id = bot_id
         self._data = data_provider
@@ -25,6 +33,9 @@ class StrategyContext:
         self._orders = order_view
         self._log = logger or logging.getLogger(f"ante.strategy.{bot_id}")
         self._pending_actions: list[OrderAction] = []
+        self._strategies_dir = (
+            strategies_dir.resolve() if strategies_dir else _STRATEGIES_ROOT.resolve()
+        )
 
     # ── 데이터 조회 ──
 
@@ -95,6 +106,42 @@ class StrategyContext:
         actions = self._pending_actions.copy()
         self._pending_actions.clear()
         return actions
+
+    # ── 파일 접근 ──
+
+    def _resolve_strategy_path(self, path: str) -> Path:
+        """전략 파일 경로를 검증하고 절대 경로로 변환."""
+        # 절대 경로 차단
+        if Path(path).is_absolute():
+            raise StrategyFileAccessError(f"Absolute paths are not allowed: {path}")
+
+        # 경로 탈출 시도 차단
+        resolved = (self._strategies_dir / path).resolve()
+        if not resolved.is_relative_to(self._strategies_dir):
+            raise StrategyFileAccessError(f"Path escapes strategies directory: {path}")
+
+        return resolved
+
+    def load_file(self, path: str) -> bytes:
+        """전략 전용 파일 읽기 (바이너리).
+
+        strategies/ 하위 경로만 허용. 경로 탈출 시도 차단.
+        """
+        resolved = self._resolve_strategy_path(path)
+
+        if not resolved.exists():
+            raise StrategyFileAccessError(f"File not found: {path}")
+
+        self._log.info("[%s] Loading file: %s", self.bot_id, path)
+        return resolved.read_bytes()
+
+    def load_text(self, path: str, encoding: str = "utf-8") -> str:
+        """전략 전용 파일 읽기 (텍스트).
+
+        strategies/ 하위 경로만 허용. 경로 탈출 시도 차단.
+        """
+        data = self.load_file(path)
+        return data.decode(encoding)
 
     # ── 로깅 ──
 

--- a/src/ante/strategy/exceptions.py
+++ b/src/ante/strategy/exceptions.py
@@ -17,3 +17,9 @@ class StrategyValidationError(StrategyError):
     """전략 검증 실패."""
 
     pass
+
+
+class StrategyFileAccessError(StrategyError):
+    """전략 파일 접근 오류."""
+
+    pass

--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -36,9 +36,24 @@ class StrategyValidator:
         "ctypes",
         "pickle",
         "pathlib",
+        "multiprocessing",
+        "threading",
+        "signal",
+        "io",
+        "tempfile",
+        "glob",
+        "builtins",
     }
 
-    FORBIDDEN_BUILTINS: set[str] = {"eval", "exec", "compile", "__import__"}
+    FORBIDDEN_BUILTINS: set[str] = {
+        "eval",
+        "exec",
+        "compile",
+        "__import__",
+        "globals",
+        "locals",
+        "open",
+    }
 
     def validate(self, filepath: Path) -> ValidationResult:
         """전략 파일 정적 검증."""
@@ -221,8 +236,5 @@ class StrategyValidator:
     def _find_dangerous_patterns(self, tree: ast.Module) -> list[str]:
         """위험 패턴 탐지 (경고 수준)."""
         warnings: list[str] = []
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-                if node.func.id == "open":
-                    warnings.append(f"File access via open() at line {node.lineno}")
+        # open()은 FORBIDDEN_BUILTINS로 승격되어 에러로 처리됨
         return warnings

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -18,7 +18,11 @@ from ante.strategy import (
     StrategyStatus,
     StrategyValidator,
 )
-from ante.strategy.exceptions import StrategyError, StrategyLoadError
+from ante.strategy.exceptions import (
+    StrategyError,
+    StrategyFileAccessError,
+    StrategyLoadError,
+)
 
 # ── Test fixtures ─────────────────────────────────
 
@@ -170,6 +174,68 @@ class TestStrategyContext:
         ctx.cancel_order("ord1")
         ctx._drain_actions()
         assert ctx._drain_actions() == []
+
+
+# ── StrategyContext.load_file / load_text ────────
+
+
+class TestStrategyContextFileAccess:
+    @pytest.fixture
+    def strategies_dir(self, tmp_path):
+        d = tmp_path / "strategies"
+        d.mkdir()
+        return d
+
+    @pytest.fixture
+    def ctx(self, strategies_dir):
+        return StrategyContext(
+            bot_id="bot1",
+            data_provider=FakeDataProvider(),
+            portfolio=FakePortfolioView(),
+            order_view=FakeOrderView(),
+            strategies_dir=strategies_dir,
+        )
+
+    def test_load_file_success(self, ctx, strategies_dir):
+        """strategies/ 하위 파일을 읽는다."""
+        (strategies_dir / "data.bin").write_bytes(b"\x00\x01\x02")
+        result = ctx.load_file("data.bin")
+        assert result == b"\x00\x01\x02"
+
+    def test_load_text_success(self, ctx, strategies_dir):
+        """strategies/ 하위 텍스트 파일을 읽는다."""
+        (strategies_dir / "config.txt").write_text("hello", encoding="utf-8")
+        result = ctx.load_text("config.txt")
+        assert result == "hello"
+
+    def test_load_file_subdirectory(self, ctx, strategies_dir):
+        """strategies/ 하위 디렉토리의 파일을 읽는다."""
+        sub = strategies_dir / "sub"
+        sub.mkdir()
+        (sub / "data.csv").write_text("a,b,c")
+        result = ctx.load_text("sub/data.csv")
+        assert result == "a,b,c"
+
+    def test_load_file_absolute_path_rejected(self, ctx):
+        """절대 경로는 차단된다."""
+        with pytest.raises(StrategyFileAccessError, match="Absolute paths"):
+            ctx.load_file("/etc/passwd")
+
+    def test_load_file_path_escape_rejected(self, ctx):
+        """경로 탈출 시도는 차단된다."""
+        with pytest.raises(StrategyFileAccessError, match="escapes"):
+            ctx.load_file("../../etc/passwd")
+
+    def test_load_file_not_found(self, ctx):
+        """파일 미존재 시 명확한 에러."""
+        with pytest.raises(StrategyFileAccessError, match="File not found"):
+            ctx.load_file("nonexistent.txt")
+
+    def test_load_text_encoding(self, ctx, strategies_dir):
+        """인코딩 지정이 동작한다."""
+        (strategies_dir / "kr.txt").write_text("한글", encoding="euc-kr")
+        result = ctx.load_text("kr.txt", encoding="euc-kr")
+        assert result == "한글"
 
 
 # ── StrategyValidator ─────────────────────────────
@@ -371,8 +437,8 @@ class TestStrategy(Strategy):
         result = validator.validate(self._write_strategy(tmp_path, code))
         assert not any("top-level" in e.lower() for e in result.errors)
 
-    def test_open_warning(self, validator, tmp_path):
-        """open 호출은 경고."""
+    def test_open_error(self, validator, tmp_path):
+        """open 호출은 에러."""
         code = """
 class TestStrategy(Strategy):
     meta = None
@@ -381,8 +447,60 @@ class TestStrategy(Strategy):
         return []
 """
         result = validator.validate(self._write_strategy(tmp_path, code))
-        assert len(result.warnings) > 0
-        assert any("open" in w for w in result.warnings)
+        assert not result.valid
+        assert any("open" in e for e in result.errors)
+
+    def test_forbidden_globals_error(self, validator, tmp_path):
+        """globals 호출은 에러."""
+        code = """
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        globals()
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("globals" in e for e in result.errors)
+
+    def test_forbidden_locals_error(self, validator, tmp_path):
+        """locals 호출은 에러."""
+        code = """
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        locals()
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("locals" in e for e in result.errors)
+
+    @pytest.mark.parametrize(
+        "module",
+        [
+            "multiprocessing",
+            "threading",
+            "signal",
+            "io",
+            "tempfile",
+            "glob",
+            "builtins",
+        ],
+    )
+    def test_forbidden_module_import(self, validator, tmp_path, module):
+        """새로 추가된 금지 모듈 import 시 실패."""
+        code = f"""
+import {module}
+
+class TestStrategy(Strategy):
+    meta = None
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any(module in e for e in result.errors)
 
     def test_multiple_strategy_classes(self, validator, tmp_path):
         """복수 Strategy 클래스는 실패."""


### PR DESCRIPTION
## Summary
- `StrategyContext`에 `load_file(path) -> bytes`, `load_text(path, encoding) -> str` 메서드 추가 (strategies/ 하위 경로만 허용, 경로 탈출 차단, 읽기 전용)
- `open()`을 경고에서 에러로 승격 (`FORBIDDEN_BUILTINS`에 추가, `_find_dangerous_patterns()`에서 제거)
- `FORBIDDEN_BUILTINS`에 `globals`, `locals` 추가
- `FORBIDDEN_MODULES`에 `multiprocessing`, `threading`, `signal`, `io`, `tempfile`, `glob`, `builtins` 추가
- `StrategyFileAccessError` 예외 클래스 추가

## Test plan
- [x] `load_file()` 정상 파일 읽기 테스트
- [x] `load_text()` 텍스트 파일 읽기 + 인코딩 테스트
- [x] 절대 경로 차단 테스트
- [x] 경로 탈출(`../`) 차단 테스트
- [x] 파일 미존재 에러 테스트
- [x] `open()` 에러 승격 테스트 (기존 warning 테스트 → error 테스트로 변경)
- [x] `globals()`, `locals()` 에러 테스트
- [x] 7개 신규 금지 모듈 parametrize 테스트
- [x] 전체 1047 테스트 통과

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)