### PR TITLE
feat: enforce single-bot-per-strategy policy

### DIFF
--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -87,6 +87,19 @@ class BotManager:
         if config.bot_id in self._bots:
             raise BotError(f"Bot already exists: {config.bot_id}")
 
+        # 1전략 1봇 정책: 실행 중인 봇이 사용 중인 전략 중복 차단
+        active_statuses = {BotStatus.RUNNING, BotStatus.STOPPING}
+        for existing_bot in self._bots.values():
+            if (
+                existing_bot.config.strategy_id == config.strategy_id
+                and existing_bot.status in active_statuses
+            ):
+                raise BotError(
+                    f"전략 '{config.strategy_id}'은(는) 이미 봇 "
+                    f"'{existing_bot.bot_id}'에서 사용 중입니다. "
+                    f"파라미터가 다른 전략은 별도 파일로 작성하세요."
+                )
+
         if ctx is None:
             if self._context_factory is None:
                 msg = "ctx 또는 context_factory 중 하나는 필수입니다"

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -471,7 +471,7 @@ class TestBotManager:
             )
             config = BotConfig(
                 bot_id=f"bot{i}",
-                strategy_id="s1",
+                strategy_id=f"s{i}",
                 interval_seconds=999,
             )
             await manager.create_bot(config, SimpleStrategy, ctx)
@@ -519,6 +519,78 @@ class TestBotManager:
         """존재하지 않는 봇 시작 시 에러."""
         with pytest.raises(BotError, match="not found"):
             await manager.start_bot("nonexistent")
+
+    async def test_single_bot_per_strategy_running(self, manager, eventbus):
+        """실행 중인 봇의 전략으로 새 봇 생성 시 에러."""
+        ctx1 = StrategyContext(
+            bot_id="bot1",
+            data_provider=FakeDataProvider(),
+            portfolio=FakePortfolioView(),
+            order_view=FakeOrderView(),
+        )
+        ctx2 = StrategyContext(
+            bot_id="bot2",
+            data_provider=FakeDataProvider(),
+            portfolio=FakePortfolioView(),
+            order_view=FakeOrderView(),
+        )
+        config1 = BotConfig(bot_id="bot1", strategy_id="same_stg", interval_seconds=999)
+        config2 = BotConfig(bot_id="bot2", strategy_id="same_stg", interval_seconds=999)
+        await manager.create_bot(config1, SimpleStrategy, ctx1)
+        await manager.start_bot("bot1")
+
+        with pytest.raises(BotError, match="이미 봇"):
+            await manager.create_bot(config2, SimpleStrategy, ctx2)
+
+        await manager.stop_bot("bot1")
+
+    async def test_single_bot_per_strategy_stopped_reuse(self, manager, eventbus):
+        """중지된 봇의 전략은 재사용 가능."""
+        ctx1 = StrategyContext(
+            bot_id="bot1",
+            data_provider=FakeDataProvider(),
+            portfolio=FakePortfolioView(),
+            order_view=FakeOrderView(),
+        )
+        ctx2 = StrategyContext(
+            bot_id="bot2",
+            data_provider=FakeDataProvider(),
+            portfolio=FakePortfolioView(),
+            order_view=FakeOrderView(),
+        )
+        config1 = BotConfig(bot_id="bot1", strategy_id="same_stg", interval_seconds=999)
+        config2 = BotConfig(bot_id="bot2", strategy_id="same_stg", interval_seconds=999)
+        await manager.create_bot(config1, SimpleStrategy, ctx1)
+        await manager.start_bot("bot1")
+        await manager.stop_bot("bot1")
+
+        # stopped 상태이므로 같은 전략으로 생성 가능
+        bot2 = await manager.create_bot(config2, SimpleStrategy, ctx2)
+        assert bot2.status == BotStatus.CREATED
+
+    async def test_single_bot_per_strategy_different_strategy(self, manager, eventbus):
+        """다른 전략이면 봇 생성 정상."""
+        ctx1 = StrategyContext(
+            bot_id="bot1",
+            data_provider=FakeDataProvider(),
+            portfolio=FakePortfolioView(),
+            order_view=FakeOrderView(),
+        )
+        ctx2 = StrategyContext(
+            bot_id="bot2",
+            data_provider=FakeDataProvider(),
+            portfolio=FakePortfolioView(),
+            order_view=FakeOrderView(),
+        )
+        config1 = BotConfig(bot_id="bot1", strategy_id="stg_a", interval_seconds=999)
+        config2 = BotConfig(bot_id="bot2", strategy_id="stg_b", interval_seconds=999)
+        await manager.create_bot(config1, SimpleStrategy, ctx1)
+        await manager.start_bot("bot1")
+
+        bot2 = await manager.create_bot(config2, SimpleStrategy, ctx2)
+        assert bot2.status == BotStatus.CREATED
+
+        await manager.stop_bot("bot1")
 
     async def test_bot_config_persisted(self, manager, eventbus, ctx, db):
         """봇 설정이 DB에 저장됨."""


### PR DESCRIPTION
## Summary
- `BotManager.create_bot()`에 1전략 1봇 정책 적용: RUNNING/STOPPING 상태 봇이 사용 중인 전략으로 새 봇 생성 시 에러 반환
- stopped/error 상태 봇의 전략은 재사용 허용
- 에러 메시지에 충돌 봇 ID와 안내 문구 포함

## Test plan
- [x] 실행 중인 봇의 전략으로 새 봇 생성 시 BotError 발생
- [x] stopped 상태 봇의 전략은 재사용 가능
- [x] 다른 전략이면 봇 생성 정상
- [x] 기존 25개 봇 테스트 전체 통과
- [x] 전체 1059개 테스트 통과

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)