### PR TITLE
feat: migrate log_level to DynamicConfigService

### DIFF
--- a/src/ante/config/dynamic.py
+++ b/src/ante/config/dynamic.py
@@ -95,9 +95,38 @@ class DynamicConfigService:
         )
         return {row["key"]: json.loads(row["value"]) for row in rows}
 
+    async def register_default(self, key: str, value: Any, category: str) -> None:
+        """기본값 등록. 이미 값이 존재하면 무시한다."""
+        if not await self.exists(key):
+            json_value = json.dumps(value)
+            await self._db.execute(
+                "INSERT OR IGNORE INTO dynamic_config"
+                " (key, value, category, updated_at)"
+                " VALUES (?, ?, ?, datetime('now'))",
+                (key, json_value, category),
+            )
+            logger.info("동적 설정 기본값 등록: %s = %s", key, value)
+
     async def exists(self, key: str) -> bool:
         """설정 존재 여부 확인."""
         row = await self._db.fetch_one(
             "SELECT 1 FROM dynamic_config WHERE key = ?", (key,)
         )
         return row is not None
+
+
+_VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+
+
+def _on_log_level_changed(event: Any) -> None:
+    """system.log_level 변경 시 루트 로거 레벨을 동적으로 갱신한다."""
+    if event.key != "system.log_level":
+        return
+
+    new_level = json.loads(event.new_value).upper()
+    if new_level not in _VALID_LOG_LEVELS:
+        logger.warning("유효하지 않은 log_level: %s — 무시", new_level)
+        return
+
+    logging.getLogger().setLevel(getattr(logging, new_level))
+    logger.info("루트 로거 레벨 변경: %s", new_level)

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -73,6 +73,15 @@ async def main() -> None:
     # ── 5. DynamicConfigService ──────────────────────
     dynamic_config = DynamicConfigService(db=db, eventbus=eventbus)
     await dynamic_config.initialize()
+
+    # log_level 동적 설정: 기본값 등록 + 변경 구독
+    from ante.config.dynamic import _on_log_level_changed
+    from ante.eventbus.events import ConfigChangedEvent
+
+    await dynamic_config.register_default(
+        "system.log_level", log_level, category="system"
+    )
+    eventbus.subscribe(ConfigChangedEvent, _on_log_level_changed)
     logger.info("DynamicConfigService 초기화 완료")
 
     # ── 5.5. MemberService ─────────────────────────────

--- a/tests/unit/test_dynamic_log_level.py
+++ b/tests/unit/test_dynamic_log_level.py
@@ -1,0 +1,114 @@
+"""동적 log_level 변경 단위 테스트."""
+
+import json
+import logging
+
+import pytest
+
+from ante.config.dynamic import DynamicConfigService, _on_log_level_changed
+from ante.core import Database
+from ante.eventbus.bus import EventBus
+from ante.eventbus.events import ConfigChangedEvent
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+async def service(db, eventbus):
+    svc = DynamicConfigService(db=db, eventbus=eventbus)
+    await svc.initialize()
+    return svc
+
+
+# ── register_default 테스트 ────────────────────────
+
+
+async def test_register_default_inserts_when_missing(service):
+    """키가 없으면 기본값을 등록한다."""
+    await service.register_default("system.log_level", "INFO", category="system")
+    assert await service.get("system.log_level") == "INFO"
+
+
+async def test_register_default_skips_when_existing(service):
+    """이미 값이 있으면 기본값을 무시한다."""
+    await service.set("system.log_level", "DEBUG", category="system")
+    await service.register_default("system.log_level", "INFO", category="system")
+    assert await service.get("system.log_level") == "DEBUG"
+
+
+# ── _on_log_level_changed 핸들러 테스트 ────────────
+
+
+def test_log_level_changed_updates_root_logger():
+    """system.log_level 변경 시 루트 로거 레벨이 갱신된다."""
+    original = logging.getLogger().level
+
+    event = ConfigChangedEvent(
+        category="system",
+        key="system.log_level",
+        old_value=json.dumps("INFO"),
+        new_value=json.dumps("DEBUG"),
+    )
+    _on_log_level_changed(event)
+
+    assert logging.getLogger().level == logging.DEBUG
+
+    # 원복
+    logging.getLogger().setLevel(original)
+
+
+def test_log_level_changed_ignores_other_keys():
+    """system.log_level이 아닌 키 변경은 무시한다."""
+    original = logging.getLogger().level
+
+    event = ConfigChangedEvent(
+        category="system",
+        key="system.other_setting",
+        old_value=json.dumps("old"),
+        new_value=json.dumps("new"),
+    )
+    _on_log_level_changed(event)
+
+    assert logging.getLogger().level == original
+
+
+def test_log_level_changed_ignores_invalid_level():
+    """유효하지 않은 로그 레벨은 무시한다."""
+    logging.getLogger().setLevel(logging.INFO)
+
+    event = ConfigChangedEvent(
+        category="system",
+        key="system.log_level",
+        old_value=json.dumps("INFO"),
+        new_value=json.dumps("INVALID_LEVEL"),
+    )
+    _on_log_level_changed(event)
+
+    assert logging.getLogger().level == logging.INFO
+
+
+# ── EventBus 통합 테스트 ───────────────────────────
+
+
+async def test_eventbus_integration(service, eventbus):
+    """DynamicConfigService.set()으로 log_level 변경 시 루트 로거가 갱신된다."""
+    original = logging.getLogger().level
+    eventbus.subscribe(ConfigChangedEvent, _on_log_level_changed)
+
+    await service.set("system.log_level", "WARNING", category="system")
+
+    assert logging.getLogger().level == logging.WARNING
+
+    # 원복
+    logging.getLogger().setLevel(original)


### PR DESCRIPTION
## Summary
- `DynamicConfigService.register_default()` 메서드 추가 (기본값 등록, 기존 값 있으면 무시)
- `_on_log_level_changed()` 핸들러: `ConfigChangedEvent` 구독하여 루트 로거 레벨 동적 갱신
- `main.py`에서 시작 시 `system.log_level` 기본값 등록 + 변경 이벤트 구독
- 유효하지 않은 로그 레벨은 무시 (안전 처리)

## Test plan
- [x] register_default: 키 없으면 등록
- [x] register_default: 기존 값 있으면 무시
- [x] 로그 레벨 변경 시 루트 로거 갱신
- [x] 다른 키 변경은 무시
- [x] 유효하지 않은 레벨 무시
- [x] EventBus 통합 테스트
- [x] 전체 1065개 테스트 통과

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)