### PR TITLE
feat: 전략 파일 스냅샷 복사 — 봇 실행 중 원본 보호

### DIFF
--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ante.bot.bot import Bot
@@ -18,6 +19,7 @@ if TYPE_CHECKING:
     from ante.eventbus.bus import EventBus
     from ante.strategy.base import Strategy
     from ante.strategy.context import StrategyContext
+    from ante.strategy.snapshot import StrategySnapshot
 
 logger = logging.getLogger(__name__)
 
@@ -44,20 +46,26 @@ class BotManager:
         db: Database,
         context_factory: StrategyContextFactory | None = None,
         signal_key_manager: SignalKeyManager | None = None,
+        snapshot: StrategySnapshot | None = None,
     ) -> None:
         self._eventbus = eventbus
         self._db = db
         self._context_factory = context_factory
         self._signal_key_manager = signal_key_manager
+        self._snapshot = snapshot
         self._bots: dict[str, Bot] = {}
         self._restart_counts: dict[str, int] = {}
         self._restart_tasks: dict[str, asyncio.Task[None]] = {}
         self._restart_reset_tasks: dict[str, asyncio.Task[None]] = {}
 
     async def initialize(self) -> None:
-        """스키마 생성 + EventBus 구독."""
+        """스키마 생성 + EventBus 구독 + 잔존 스냅샷 정리."""
         await self._db.execute_script(BOT_SCHEMA)
         self._subscribe_events()
+        if self._snapshot:
+            cleaned = self._snapshot.cleanup_all()
+            if cleaned:
+                logger.info("잔존 전략 스냅샷 %d건 정리", cleaned)
         logger.info("BotManager 초기화 완료")
 
     def _subscribe_events(self) -> None:
@@ -79,10 +87,12 @@ class BotManager:
         config: BotConfig,
         strategy_cls: type[Strategy],
         ctx: StrategyContext | None = None,
+        source_path: Path | None = None,
     ) -> Bot:
         """봇 생성.
 
         ctx가 주입되면 그대로 사용하고, None이면 context_factory로 자동 생성한다.
+        source_path가 주어지면 전략 파일을 스냅샷으로 복사하여 보호한다.
         """
         if config.bot_id in self._bots:
             raise BotError(f"Bot already exists: {config.bot_id}")
@@ -99,6 +109,18 @@ class BotManager:
                     f"'{existing_bot.bot_id}'에서 사용 중입니다. "
                     f"파라미터가 다른 전략은 별도 파일로 작성하세요."
                 )
+
+        # 전략 파일 스냅샷 생성
+        if self._snapshot and source_path:
+            from ante.strategy.loader import StrategyLoader
+
+            snapshot_path = self._snapshot.create(config.bot_id, source_path)
+            strategy_cls = StrategyLoader.load(snapshot_path)
+            logger.info(
+                "스냅샷에서 전략 로드: %s → %s",
+                source_path,
+                snapshot_path,
+            )
 
         if ctx is None:
             if self._context_factory is None:
@@ -162,6 +184,10 @@ class BotManager:
         # 시그널 키 폐기
         if self._signal_key_manager:
             await self._signal_key_manager.revoke(bot_id)
+
+        # 전략 스냅샷 정리
+        if self._snapshot:
+            self._snapshot.cleanup(bot_id)
 
         del self._bots[bot_id]
         await self._db.execute("DELETE FROM bots WHERE bot_id = ?", (bot_id,))

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -179,10 +179,16 @@ async def main() -> None:
     # DataProvider는 APIGateway 연결 후 설정 (11단계)
     context_factory: StrategyContextFactory | None = None
 
+    from ante.strategy.snapshot import StrategySnapshot
+
+    strategies_dir = Path(config.get("strategy.dir", "strategies"))
+    strategy_snapshot = StrategySnapshot(strategies_dir)
+
     bot_manager = BotManager(
         eventbus=eventbus,
         db=db,
         context_factory=context_factory,  # APIGateway 연결 후 갱신
+        snapshot=strategy_snapshot,
     )
     await bot_manager.initialize()
     logger.info("BotManager 초기화 완료")

--- a/src/ante/strategy/__init__.py
+++ b/src/ante/strategy/__init__.py
@@ -18,6 +18,7 @@ from ante.strategy.exceptions import (
 )
 from ante.strategy.loader import StrategyLoader
 from ante.strategy.registry import StrategyRecord, StrategyRegistry, StrategyStatus
+from ante.strategy.snapshot import StrategySnapshot
 from ante.strategy.validator import StrategyValidator, ValidationResult
 
 __all__ = [
@@ -35,6 +36,7 @@ __all__ = [
     "StrategyMeta",
     "StrategyRecord",
     "StrategyRegistry",
+    "StrategySnapshot",
     "StrategyStatus",
     "StrategyValidationError",
     "StrategyValidator",

--- a/src/ante/strategy/snapshot.py
+++ b/src/ante/strategy/snapshot.py
@@ -1,0 +1,77 @@
+"""StrategySnapshot — 전략 파일 스냅샷 생성/정리."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# strategies/.running/{bot_id}/ 하위에 스냅샷 저장
+_RUNNING_DIR_NAME = ".running"
+
+
+class StrategySnapshot:
+    """전략 파일 스냅샷 관리.
+
+    봇 시작 시 원본 전략 파일을 .running/{bot_id}/ 디렉토리에 복사하고,
+    봇 종료 시 정리한다. 원본 파일 수정으로부터 실행 중 코드를 보호한다.
+    """
+
+    def __init__(self, strategies_dir: Path) -> None:
+        self._strategies_dir = strategies_dir
+        self._running_dir = strategies_dir / _RUNNING_DIR_NAME
+
+    def create(self, bot_id: str, source_path: Path) -> Path:
+        """전략 파일을 스냅샷 디렉토리에 복사.
+
+        Args:
+            bot_id: 봇 식별자
+            source_path: 원본 전략 파일 경로
+
+        Returns:
+            스냅샷 파일 경로
+        """
+        bot_dir = self._running_dir / bot_id
+        bot_dir.mkdir(parents=True, exist_ok=True)
+
+        snapshot_path = bot_dir / source_path.name
+        shutil.copy2(source_path, snapshot_path)
+
+        logger.info("전략 스냅샷 생성: %s → %s", source_path, snapshot_path)
+        return snapshot_path
+
+    def cleanup(self, bot_id: str) -> None:
+        """봇의 스냅샷 디렉토리 삭제."""
+        bot_dir = self._running_dir / bot_id
+        if bot_dir.exists():
+            shutil.rmtree(bot_dir)
+            logger.info("전략 스냅샷 정리: %s", bot_dir)
+
+    def cleanup_all(self) -> int:
+        """잔존 스냅샷 전체 정리. 시스템 시작 시 호출.
+
+        Returns:
+            정리된 봇 디렉토리 수
+        """
+        if not self._running_dir.exists():
+            return 0
+
+        count = 0
+        for bot_dir in self._running_dir.iterdir():
+            if bot_dir.is_dir():
+                shutil.rmtree(bot_dir)
+                logger.info("잔존 스냅샷 정리: %s", bot_dir)
+                count += 1
+
+        return count
+
+    def get_snapshot_path(self, bot_id: str) -> Path | None:
+        """봇의 스냅샷 파일 경로 반환. 없으면 None."""
+        bot_dir = self._running_dir / bot_id
+        if not bot_dir.exists():
+            return None
+
+        py_files = list(bot_dir.glob("*.py"))
+        return py_files[0] if py_files else None

--- a/tests/unit/test_strategy_snapshot.py
+++ b/tests/unit/test_strategy_snapshot.py
@@ -1,0 +1,114 @@
+"""StrategySnapshot 단위 테스트."""
+
+import pytest
+
+from ante.strategy.snapshot import StrategySnapshot
+
+
+@pytest.fixture
+def strategies_dir(tmp_path):
+    """임시 strategies 디렉토리."""
+    d = tmp_path / "strategies"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def snapshot(strategies_dir):
+    return StrategySnapshot(strategies_dir)
+
+
+@pytest.fixture
+def strategy_file(strategies_dir):
+    """테스트용 전략 파일."""
+    f = strategies_dir / "my_strategy.py"
+    f.write_text("class MyStrategy: pass\n")
+    return f
+
+
+def test_create_copies_file(snapshot, strategy_file):
+    """스냅샷 생성 시 파일이 복사된다."""
+    result = snapshot.create("bot-1", strategy_file)
+
+    assert result.exists()
+    assert result.name == "my_strategy.py"
+    assert result.read_text() == strategy_file.read_text()
+    assert ".running" in str(result)
+    assert "bot-1" in str(result)
+
+
+def test_create_preserves_original(snapshot, strategy_file):
+    """스냅샷 생성 후 원본은 그대로 유지된다."""
+    snapshot.create("bot-1", strategy_file)
+    assert strategy_file.exists()
+    assert strategy_file.read_text() == "class MyStrategy: pass\n"
+
+
+def test_snapshot_isolated_from_original_change(snapshot, strategy_file):
+    """스냅샷 생성 후 원본 수정이 스냅샷에 영향 주지 않음."""
+    snapshot_path = snapshot.create("bot-1", strategy_file)
+
+    # 원본 수정
+    strategy_file.write_text("class ModifiedStrategy: pass\n")
+
+    assert snapshot_path.read_text() == "class MyStrategy: pass\n"
+
+
+def test_cleanup_removes_bot_dir(snapshot, strategy_file):
+    """cleanup 시 봇의 스냅샷 디렉토리가 삭제된다."""
+    snapshot_path = snapshot.create("bot-1", strategy_file)
+    bot_dir = snapshot_path.parent
+
+    snapshot.cleanup("bot-1")
+
+    assert not bot_dir.exists()
+
+
+def test_cleanup_nonexistent_bot(snapshot):
+    """존재하지 않는 봇 cleanup은 에러 없이 통과."""
+    snapshot.cleanup("nonexistent")  # 에러 없이 통과
+
+
+def test_cleanup_all(snapshot, strategy_file):
+    """cleanup_all은 모든 봇 스냅샷을 정리한다."""
+    snapshot.create("bot-1", strategy_file)
+    snapshot.create("bot-2", strategy_file)
+
+    count = snapshot.cleanup_all()
+
+    assert count == 2
+    running_dir = snapshot._running_dir
+    # .running 디렉토리 자체는 남아있지만 하위 봇 디렉토리는 없음
+    remaining = list(running_dir.iterdir()) if running_dir.exists() else []
+    assert len(remaining) == 0
+
+
+def test_cleanup_all_empty(snapshot):
+    """스냅샷이 없으면 cleanup_all은 0 반환."""
+    count = snapshot.cleanup_all()
+    assert count == 0
+
+
+def test_get_snapshot_path(snapshot, strategy_file):
+    """스냅샷 경로 조회."""
+    expected = snapshot.create("bot-1", strategy_file)
+    result = snapshot.get_snapshot_path("bot-1")
+    assert result == expected
+
+
+def test_get_snapshot_path_nonexistent(snapshot):
+    """존재하지 않는 봇은 None 반환."""
+    assert snapshot.get_snapshot_path("nonexistent") is None
+
+
+def test_multiple_bots_isolated(snapshot, strategy_file):
+    """서로 다른 봇의 스냅샷은 독립적이다."""
+    path1 = snapshot.create("bot-1", strategy_file)
+    path2 = snapshot.create("bot-2", strategy_file)
+
+    assert path1 != path2
+    assert path1.parent != path2.parent
+
+    snapshot.cleanup("bot-1")
+    assert not path1.exists()
+    assert path2.exists()


### PR DESCRIPTION
## Summary
- `StrategySnapshot` 클래스 구현: `strategies/.running/{bot_id}/`에 전략 파일 스냅샷 복사
- `BotManager.create_bot()`에 `source_path` 파라미터 추가, 스냅샷에서 전략 로드
- 봇 삭제 시 스냅샷 자동 정리, 시스템 시작 시 잔존 스냅샷 전체 정리
- `main.py`에서 `StrategySnapshot`을 `BotManager`에 주입

## Test plan
- [x] 스냅샷 복사/정리/전체정리 단위 테스트 10건
- [x] 원본 변경이 스냅샷에 영향 없음 검증
- [x] 봇 간 스냅샷 독립성 검증
- [x] 전체 테스트 스위트 1075건 통과

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)