### PR TITLE
feat: StrategyContext에 get_trade_history() API 추가

### DIFF
--- a/src/ante/bot/context_factory.py
+++ b/src/ante/bot/context_factory.py
@@ -10,7 +10,11 @@ from ante.bot.providers.paper import PaperExecutor, PaperOrderView, PaperPortfol
 from ante.strategy.context import StrategyContext
 
 if TYPE_CHECKING:
-    from ante.bot.providers.live import LiveOrderView, LivePortfolioView
+    from ante.bot.providers.live import (
+        LiveOrderView,
+        LivePortfolioView,
+        LiveTradeHistoryView,
+    )
     from ante.strategy.base import DataProvider
 
 logger = logging.getLogger(__name__)
@@ -28,11 +32,13 @@ class StrategyContextFactory:
         live_portfolio: LivePortfolioView | None = None,
         live_order_view: LiveOrderView | None = None,
         paper_executor: PaperExecutor | None = None,
+        live_trade_history: LiveTradeHistoryView | None = None,
     ) -> None:
         self._data_provider = data_provider
         self._live_portfolio = live_portfolio
         self._live_order_view = live_order_view
         self._paper_executor = paper_executor
+        self._live_trade_history = live_trade_history
 
     def create(self, config: BotConfig) -> StrategyContext:
         """BotConfig 기반으로 적절한 StrategyContext 생성."""
@@ -51,6 +57,7 @@ class StrategyContextFactory:
             data_provider=self._data_provider,
             portfolio=self._live_portfolio,
             order_view=self._live_order_view,
+            trade_history=self._live_trade_history,
         )
         logger.info("Live StrategyContext 생성: %s", config.bot_id)
         return ctx

--- a/src/ante/bot/providers/live.py
+++ b/src/ante/bot/providers/live.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from ante.strategy.base import OrderView, PortfolioView
+from ante.strategy.base import OrderView, PortfolioView, TradeHistoryView
 
 if TYPE_CHECKING:
     from ante.broker.order_registry import OrderRegistry
     from ante.trade.position import PositionHistory
+    from ante.trade.recorder import TradeRecorder
     from ante.treasury.treasury import Treasury
 
 logger = logging.getLogger(__name__)
@@ -68,3 +69,36 @@ class LiveOrderView(OrderView):
         현재는 빈 목록을 반환하며, 실시간 주문 추적은 Phase 2에서 구현.
         """
         return []
+
+
+class LiveTradeHistoryView(TradeHistoryView):
+    """Live 봇용 TradeHistoryView. TradeRecorder에서 거래 이력 조회."""
+
+    def __init__(self, trade_recorder: TradeRecorder) -> None:
+        self._recorder = trade_recorder
+
+    async def get_trade_history(
+        self,
+        bot_id: str,
+        symbol: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """봇의 거래 이력 조회."""
+        records = await self._recorder.get_trades(
+            bot_id=bot_id, symbol=symbol, limit=limit
+        )
+        return [
+            {
+                "trade_id": r.trade_id,
+                "symbol": r.symbol,
+                "side": r.side,
+                "quantity": r.quantity,
+                "price": r.price,
+                "status": r.status.value,
+                "order_type": r.order_type,
+                "reason": r.reason,
+                "commission": r.commission,
+                "timestamp": r.timestamp.isoformat(),
+            }
+            for r in records
+        ]

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -242,12 +242,17 @@ async def main() -> None:
         data_provider = LiveDataProvider(gateway=api_gateway)
         paper_executor._gateway = api_gateway
 
+    from ante.bot.providers.live import LiveTradeHistoryView
+
+    live_trade_history = LiveTradeHistoryView(trade_recorder=trade_recorder)
+
     if data_provider:
         context_factory = StrategyContextFactory(
             data_provider=data_provider,
             live_portfolio=live_portfolio,
             live_order_view=live_order_view,
             paper_executor=paper_executor,
+            live_trade_history=live_trade_history,
         )
         bot_manager._context_factory = context_factory
         logger.info("StrategyContextFactory 설정 완료")

--- a/src/ante/strategy/__init__.py
+++ b/src/ante/strategy/__init__.py
@@ -8,6 +8,7 @@ from ante.strategy.base import (
     Signal,
     Strategy,
     StrategyMeta,
+    TradeHistoryView,
 )
 from ante.strategy.context import StrategyContext
 from ante.strategy.exceptions import (
@@ -37,6 +38,7 @@ __all__ = [
     "StrategyRegistry",
     "StrategyStatus",
     "StrategyValidationError",
+    "TradeHistoryView",
     "StrategyValidator",
     "ValidationResult",
 ]

--- a/src/ante/strategy/base.py
+++ b/src/ante/strategy/base.py
@@ -110,6 +110,20 @@ class OrderView(ABC):
         ...
 
 
+class TradeHistoryView(ABC):
+    """거래 이력 읽기 전용 인터페이스."""
+
+    @abstractmethod
+    async def get_trade_history(
+        self,
+        bot_id: str,
+        symbol: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """봇의 거래 이력 조회. 최신순 반환."""
+        ...
+
+
 # ── Strategy ABC ──────────────────────────────────
 
 

--- a/src/ante/strategy/context.py
+++ b/src/ante/strategy/context.py
@@ -6,7 +6,13 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from ante.strategy.base import DataProvider, OrderAction, OrderView, PortfolioView
+from ante.strategy.base import (
+    DataProvider,
+    OrderAction,
+    OrderView,
+    PortfolioView,
+    TradeHistoryView,
+)
 from ante.strategy.exceptions import StrategyFileAccessError
 
 logger = logging.getLogger(__name__)
@@ -24,6 +30,7 @@ class StrategyContext:
         data_provider: DataProvider,
         portfolio: PortfolioView,
         order_view: OrderView,
+        trade_history: TradeHistoryView | None = None,
         logger: logging.Logger | None = None,
         strategies_dir: Path | None = None,
     ) -> None:
@@ -31,6 +38,7 @@ class StrategyContext:
         self._data = data_provider
         self._portfolio = portfolio
         self._orders = order_view
+        self._trade_history = trade_history
         self._log = logger or logging.getLogger(f"ante.strategy.{bot_id}")
         self._pending_actions: list[OrderAction] = []
         self._strategies_dir = (
@@ -70,6 +78,20 @@ class StrategyContext:
     def get_balance(self) -> dict[str, float]:
         """봇 할당 자금 현황 조회."""
         return self._portfolio.get_balance(self.bot_id)
+
+    # ── 거래 이력 ──
+
+    async def get_trade_history(
+        self,
+        symbol: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """봇의 거래 이력 조회. 최신순 반환."""
+        if self._trade_history is None:
+            return []
+        return await self._trade_history.get_trade_history(
+            self.bot_id, symbol=symbol, limit=limit
+        )
 
     # ── 주문 관리 ──
 

--- a/tests/unit/test_trade_history_view.py
+++ b/tests/unit/test_trade_history_view.py
@@ -1,0 +1,119 @@
+"""StrategyContext.get_trade_history() 테스트."""
+
+import pytest
+
+from ante.strategy.base import (
+    DataProvider,
+    OrderView,
+    PortfolioView,
+    TradeHistoryView,
+)
+from ante.strategy.context import StrategyContext
+
+
+class FakeDataProvider(DataProvider):
+    async def get_ohlcv(self, symbol, timeframe="1d", limit=100):
+        return []
+
+    async def get_current_price(self, symbol):
+        return 0.0
+
+    async def get_indicator(self, symbol, indicator, params=None):
+        return {}
+
+
+class FakePortfolio(PortfolioView):
+    def get_positions(self, bot_id):
+        return {}
+
+    def get_balance(self, bot_id):
+        return {"allocated": 0.0, "available": 0.0}
+
+
+class FakeOrderView(OrderView):
+    def get_open_orders(self, bot_id):
+        return []
+
+
+class FakeTradeHistory(TradeHistoryView):
+    def __init__(self, trades=None):
+        self._trades = trades or []
+
+    async def get_trade_history(self, bot_id, symbol=None, limit=50):
+        result = [t for t in self._trades if t["bot_id"] == bot_id]
+        if symbol:
+            result = [t for t in result if t["symbol"] == symbol]
+        return result[:limit]
+
+
+@pytest.fixture
+def trades():
+    return [
+        {
+            "bot_id": "bot-1",
+            "trade_id": "t1",
+            "symbol": "005930",
+            "side": "buy",
+            "quantity": 10.0,
+            "price": 70000.0,
+        },
+        {
+            "bot_id": "bot-1",
+            "trade_id": "t2",
+            "symbol": "035720",
+            "side": "buy",
+            "quantity": 5.0,
+            "price": 50000.0,
+        },
+        {
+            "bot_id": "bot-2",
+            "trade_id": "t3",
+            "symbol": "005930",
+            "side": "sell",
+            "quantity": 3.0,
+            "price": 72000.0,
+        },
+    ]
+
+
+@pytest.fixture
+def ctx(trades):
+    return StrategyContext(
+        bot_id="bot-1",
+        data_provider=FakeDataProvider(),
+        portfolio=FakePortfolio(),
+        order_view=FakeOrderView(),
+        trade_history=FakeTradeHistory(trades),
+    )
+
+
+async def test_get_trade_history(ctx):
+    """봇의 거래 이력을 조회한다."""
+    result = await ctx.get_trade_history()
+    assert len(result) == 2
+    assert all(t["bot_id"] == "bot-1" for t in result)
+
+
+async def test_get_trade_history_filter_symbol(ctx):
+    """symbol 필터가 동작한다."""
+    result = await ctx.get_trade_history(symbol="005930")
+    assert len(result) == 1
+    assert result[0]["symbol"] == "005930"
+
+
+async def test_get_trade_history_limit(ctx):
+    """limit이 반환 건수를 제한한다."""
+    result = await ctx.get_trade_history(limit=1)
+    assert len(result) == 1
+
+
+async def test_get_trade_history_no_provider():
+    """trade_history 미주입 시 빈 리스트 반환."""
+    ctx = StrategyContext(
+        bot_id="bot-1",
+        data_provider=FakeDataProvider(),
+        portfolio=FakePortfolio(),
+        order_view=FakeOrderView(),
+    )
+    result = await ctx.get_trade_history()
+    assert result == []


### PR DESCRIPTION
## Summary
- `TradeHistoryView` ABC 추가: 전략이 자신의 과거 거래 이력을 조회할 수 있는 읽기 전용 인터페이스
- `StrategyContext.get_trade_history(symbol, limit)` 메서드 추가
- `LiveTradeHistoryView` 구현체: `TradeRecorder.get_trades()` 래핑
- `StrategyContextFactory` + `main.py`에서 주입 파이프라인 완성

## Test plan
- [x] 거래 이력 조회 테스트 (봇별 필터링)
- [x] symbol 필터 동작 검증
- [x] limit 제한 검증
- [x] trade_history 미주입 시 빈 리스트 반환 (안전한 폴백)
- [x] 전체 테스트 스위트 1077건 통과

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)