### PR TITLE
feat: OrderModifyEvent 룰 검증 추가

### DIFF
--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -55,6 +55,22 @@ class OrderModifyEvent(Event):
     bot_id: str = ""
     strategy_id: str = ""
     order_id: str = ""
+    symbol: str = ""
+    side: str = ""
+    quantity: float = 0.0
+    price: float | None = None
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class OrderModifyRejectedEvent(Event):
+    """RuleEngine → EventBus: 주문 정정 룰 위반으로 거부."""
+
+    order_id: str = ""
+    bot_id: str = ""
+    strategy_id: str = ""
+    symbol: str = ""
+    side: str = ""
     quantity: float = 0.0
     price: float | None = None
     reason: str = ""

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -61,11 +61,16 @@ class RuleEngine:
 
     async def start(self) -> None:
         """EventBus 구독 등록."""
-        from ante.eventbus.events import ConfigChangedEvent, OrderRequestEvent
+        from ante.eventbus.events import (
+            ConfigChangedEvent,
+            OrderModifyEvent,
+            OrderRequestEvent,
+        )
 
         self._eventbus.subscribe(
             OrderRequestEvent, self._on_order_request, priority=100
         )
+        self._eventbus.subscribe(OrderModifyEvent, self._on_order_modify, priority=100)
         self._eventbus.subscribe(ConfigChangedEvent, self._on_config_changed)
         logger.info("RuleEngine 시작")
 
@@ -312,6 +317,72 @@ class RuleEngine:
                     reason="Critical rule violation",
                     changed_by="rule_engine",
                 )
+
+    async def _on_order_modify(self, event: object) -> None:
+        """OrderModifyEvent 수신 시 룰 평가. 위반 시 거부 이벤트 발행."""
+        from ante.eventbus.events import (
+            OrderModifyEvent,
+            OrderModifyRejectedEvent,
+        )
+
+        if not isinstance(event, OrderModifyEvent):
+            return
+
+        context = RuleContext(
+            bot_id=event.bot_id,
+            strategy_id=event.strategy_id,
+            symbol=event.symbol,
+            side=event.side,
+            quantity=event.quantity,
+            order_type="limit" if event.price else "market",
+            price=event.price,
+            current_price=event.price or 0.0,
+            system_status=self._system_state.trading_state.value,
+        )
+
+        try:
+            result = self.evaluate(context)
+
+            if result.overall_result in (
+                RuleResult.BLOCK,
+                RuleResult.REJECT,
+            ):
+                logger.warning(
+                    "주문 정정 거부: order=%s bot=%s — %s",
+                    event.order_id,
+                    event.bot_id,
+                    result.rejection_reason,
+                )
+                await self._eventbus.publish(
+                    OrderModifyRejectedEvent(
+                        order_id=event.order_id,
+                        bot_id=event.bot_id,
+                        strategy_id=event.strategy_id,
+                        symbol=event.symbol,
+                        side=event.side,
+                        quantity=event.quantity,
+                        price=event.price,
+                        reason=result.rejection_reason,
+                    )
+                )
+                # 거부 시 이벤트 소비 — 후속 핸들러(Gateway)에 전달 방지
+                if hasattr(event, "_consumed"):
+                    object.__setattr__(event, "_consumed", True)
+
+        except Exception:
+            logger.exception("주문 정정 룰 평가 실패: %s", event.order_id)
+            await self._eventbus.publish(
+                OrderModifyRejectedEvent(
+                    order_id=event.order_id,
+                    bot_id=event.bot_id,
+                    strategy_id=event.strategy_id,
+                    symbol=event.symbol,
+                    side=event.side,
+                    quantity=event.quantity,
+                    price=event.price,
+                    reason="Rule evaluation error",
+                )
+            )
 
     async def _on_config_changed(self, event: object) -> None:
         """설정 변경 시 룰 재로딩 트리거."""

--- a/tests/unit/test_rule_modify.py
+++ b/tests/unit/test_rule_modify.py
@@ -1,0 +1,160 @@
+"""OrderModifyEvent 룰 검증 테스트."""
+
+import pytest
+
+from ante.config.system_state import SystemState
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import OrderModifyEvent, OrderModifyRejectedEvent
+from ante.rule import RuleEngine
+from ante.rule.base import Rule, RuleAction, RuleContext, RuleEvaluation, RuleResult
+
+
+class AlwaysRejectRule(Rule):
+    """테스트용: 항상 REJECT하는 룰."""
+
+    def evaluate(self, context: RuleContext) -> RuleEvaluation:
+        return RuleEvaluation(
+            rule_id=self.rule_id,
+            rule_name=self.name,
+            result=RuleResult.REJECT,
+            action=RuleAction.NOTIFY,
+            message="Always reject for testing",
+        )
+
+
+class AlwaysPassRule(Rule):
+    """테스트용: 항상 PASS하는 룰."""
+
+    def evaluate(self, context: RuleContext) -> RuleEvaluation:
+        return RuleEvaluation(
+            rule_id=self.rule_id,
+            rule_name=self.name,
+            result=RuleResult.PASS,
+            action=RuleAction.LOG,
+            message="Always pass",
+        )
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+async def system_state(db):
+    state = SystemState(db=db, eventbus=EventBus())
+    await state.initialize()
+    return state
+
+
+@pytest.fixture
+async def engine(system_state):
+    eventbus = EventBus()
+    engine = RuleEngine(eventbus=eventbus, system_state=system_state)
+    await engine.start()
+    return engine
+
+
+def _make_modify_event(**kwargs):
+    defaults = {
+        "bot_id": "bot1",
+        "strategy_id": "s1",
+        "order_id": "ord-1",
+        "symbol": "005930",
+        "side": "buy",
+        "quantity": 10.0,
+        "price": 50000.0,
+    }
+    defaults.update(kwargs)
+    return OrderModifyEvent(**defaults)
+
+
+async def test_modify_passes_when_no_rules(engine):
+    """룰이 없으면 정정 요청이 통과한다."""
+    received = []
+    engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+    await engine._on_order_modify(_make_modify_event())
+    assert len(received) == 0
+
+
+async def test_modify_rejected_by_global_rule(engine):
+    """전역 룰 위반 시 정정이 거부된다."""
+    received = []
+    engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    engine.add_global_rule(AlwaysRejectRule("reject", {"type": "test"}))
+    await engine._on_order_modify(_make_modify_event())
+
+    assert len(received) == 1
+    assert received[0].order_id == "ord-1"
+    assert received[0].reason == "Always reject for testing"
+
+
+async def test_modify_passes_with_pass_rule(engine):
+    """룰 통과 시 거부 이벤트가 발행되지 않는다."""
+    received = []
+    engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    engine.add_global_rule(AlwaysPassRule("pass", {"type": "test"}))
+    await engine._on_order_modify(_make_modify_event())
+
+    assert len(received) == 0
+
+
+async def test_modify_rejected_event_has_correct_fields(engine):
+    """거부 이벤트에 올바른 필드가 포함된다."""
+    received = []
+    engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    engine.add_global_rule(AlwaysRejectRule("reject", {"type": "test"}))
+
+    event = _make_modify_event(
+        bot_id="bot1",
+        strategy_id="strat1",
+        order_id="ord-99",
+        symbol="005930",
+        side="buy",
+        quantity=5.0,
+        price=70000.0,
+    )
+    await engine._on_order_modify(event)
+
+    assert len(received) == 1
+    rejected = received[0]
+    assert rejected.bot_id == "bot1"
+    assert rejected.strategy_id == "strat1"
+    assert rejected.order_id == "ord-99"
+    assert rejected.symbol == "005930"
+    assert rejected.side == "buy"
+    assert rejected.quantity == 5.0
+    assert rejected.price == 70000.0
+
+
+async def test_strategy_specific_rule_applied_to_modify(engine):
+    """전략별 룰도 정정 요청에 적용된다."""
+    received = []
+    engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    engine.add_strategy_rule("strat1", AlwaysRejectRule("reject", {"type": "test"}))
+
+    event = _make_modify_event(strategy_id="strat1")
+    await engine._on_order_modify(event)
+
+    assert len(received) == 1
+
+
+async def test_other_strategy_rule_not_applied(engine):
+    """다른 전략의 룰은 적용되지 않는다."""
+    received = []
+    engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    engine.add_strategy_rule("strat2", AlwaysRejectRule("reject", {"type": "test"}))
+
+    event = _make_modify_event(strategy_id="strat1")
+    await engine._on_order_modify(event)
+
+    assert len(received) == 0


### PR DESCRIPTION
## Summary
- 주문 정정(OrderModifyEvent)에도 전역/전략별 룰 검증을 적용
- OrderModifyRejectedEvent 신규 이벤트 타입 추가
- RuleEngine에 _on_order_modify 핸들러 구현

## Test plan
- [x] 룰 없을 때 정정 통과
- [x] 전역 룰 위반 시 거부 이벤트 발행
- [x] 전략별 룰 적용 확인
- [x] 거부 이벤트 필드 검증
- [x] 다른 전략의 룰 미적용 확인

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)