### PR TITLE
feat: TA-Lib 기반 기술 지표 편의 API 추가

### DIFF
--- a/scripts/install-talib.sh
+++ b/scripts/install-talib.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# TA-Lib C 라이브러리 + Python 바인딩 설치 스크립트.
+# 사용법: bash scripts/install-talib.sh
+set -euo pipefail
+
+TALIB_VERSION="0.4.0"
+TALIB_URL="https://sourceforge.net/projects/ta-lib/files/ta-lib/${TALIB_VERSION}/ta-lib-${TALIB_VERSION}-src.tar.gz"
+
+echo "=== TA-Lib C 라이브러리 설치 ==="
+
+OS="$(uname -s)"
+case "${OS}" in
+    Darwin)
+        echo "[macOS] Homebrew로 설치합니다."
+        if command -v brew &>/dev/null; then
+            brew install ta-lib
+        else
+            echo "ERROR: Homebrew가 설치되어 있지 않습니다."
+            echo "  https://brew.sh 에서 설치 후 다시 실행하세요."
+            exit 1
+        fi
+        ;;
+    Linux)
+        echo "[Linux] 소스에서 빌드합니다."
+        # 빌드 도구 확인
+        if ! command -v gcc &>/dev/null; then
+            echo "gcc를 설치합니다..."
+            if command -v apt-get &>/dev/null; then
+                sudo apt-get update && sudo apt-get install -y build-essential wget
+            elif command -v yum &>/dev/null; then
+                sudo yum groupinstall -y "Development Tools" && sudo yum install -y wget
+            else
+                echo "ERROR: 패키지 매니저를 찾을 수 없습니다. gcc를 수동 설치하세요."
+                exit 1
+            fi
+        fi
+
+        TMPDIR="$(mktemp -d)"
+        echo "소스 다운로드: ${TALIB_URL}"
+        wget -q -O "${TMPDIR}/ta-lib.tar.gz" "${TALIB_URL}"
+        tar -xzf "${TMPDIR}/ta-lib.tar.gz" -C "${TMPDIR}"
+        cd "${TMPDIR}/ta-lib"
+        ./configure --prefix=/usr/local
+        make -j"$(nproc)"
+        sudo make install
+        sudo ldconfig
+        rm -rf "${TMPDIR}"
+        echo "C 라이브러리 설치 완료 (/usr/local/lib)"
+        ;;
+    *)
+        echo "ERROR: 지원하지 않는 OS: ${OS}"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "=== Python 바인딩 설치 ==="
+pip install TA-Lib
+echo ""
+echo "=== 설치 검증 ==="
+python -c "import talib; print(f'TA-Lib {talib.__version__} 설치 완료')"
+echo "완료!"

--- a/src/ante/strategy/__init__.py
+++ b/src/ante/strategy/__init__.py
@@ -16,12 +16,14 @@ from ante.strategy.exceptions import (
     StrategyLoadError,
     StrategyValidationError,
 )
+from ante.strategy.indicators import IndicatorCalculator
 from ante.strategy.loader import StrategyLoader
 from ante.strategy.registry import StrategyRecord, StrategyRegistry, StrategyStatus
 from ante.strategy.validator import StrategyValidator, ValidationResult
 
 __all__ = [
     "DataProvider",
+    "IndicatorCalculator",
     "OrderAction",
     "OrderView",
     "PortfolioView",

--- a/src/ante/strategy/context.py
+++ b/src/ante/strategy/context.py
@@ -57,8 +57,29 @@ class StrategyContext:
         symbol: str,
         indicator: str,
         params: dict[str, Any] | None = None,
-    ) -> Any:
-        """기술 지표 데이터 조회."""
+    ) -> dict[str, Any]:
+        """기술 지표 계산.
+
+        TA-Lib 설치 시 OHLCV 데이터를 가져와 지표를 계산한다.
+        미설치 시 DataProvider 구현체에 위임한다.
+
+        Args:
+            symbol: 종목 코드.
+            indicator: 지표 이름 (예: "sma", "rsi", "macd").
+            params: TA-Lib 파라미터 오버라이드 (예: {"timeperiod": 50}).
+
+        Returns:
+            지표 결과 딕셔너리. 키는 지표명, 값은 numpy 배열 또는 리스트.
+        """
+        from ante.strategy.indicators import (
+            IndicatorCalculator,
+            ohlcv_to_numpy,
+        )
+
+        if IndicatorCalculator.is_available():
+            ohlcv_data = await self._data.get_ohlcv(symbol, limit=500)
+            arrays = ohlcv_to_numpy(ohlcv_data)
+            return IndicatorCalculator.compute(indicator, arrays, **(params or {}))
         return await self._data.get_indicator(symbol, indicator, params)
 
     # ── 포트폴리오 조회 ──

--- a/src/ante/strategy/indicators.py
+++ b/src/ante/strategy/indicators.py
@@ -1,0 +1,202 @@
+"""TA-Lib 기반 기술 지표 계산기.
+
+TA-Lib 선택 의존성 — 미설치 시 ImportError를 명확히 안내한다.
+지원 지표: SMA, EMA, RSI, MACD, Bollinger Bands, ATR, Stochastic,
+           ADX, CCI, OBV, WMA, DEMA, TEMA, WILLR, MFI (15종).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+try:
+    import numpy as np
+    import talib
+
+    TALIB_AVAILABLE = True
+except ImportError:
+    np = None  # type: ignore[assignment]
+    talib = None  # type: ignore[assignment]
+    TALIB_AVAILABLE = False
+
+# 지표별 TA-Lib 함수명, 입력 타입, 기본 파라미터
+INDICATOR_REGISTRY: dict[str, dict[str, Any]] = {
+    "sma": {"func": "SMA", "input": "close", "params": {"timeperiod": 20}},
+    "ema": {"func": "EMA", "input": "close", "params": {"timeperiod": 20}},
+    "rsi": {"func": "RSI", "input": "close", "params": {"timeperiod": 14}},
+    "macd": {
+        "func": "MACD",
+        "input": "close",
+        "params": {"fastperiod": 12, "slowperiod": 26, "signalperiod": 9},
+    },
+    "bbands": {
+        "func": "BBANDS",
+        "input": "close",
+        "params": {"timeperiod": 20, "nbdevup": 2.0, "nbdevdn": 2.0},
+    },
+    "atr": {"func": "ATR", "input": "hlc", "params": {"timeperiod": 14}},
+    "stoch": {
+        "func": "STOCH",
+        "input": "hlc",
+        "params": {
+            "fastk_period": 14,
+            "slowk_period": 3,
+            "slowd_period": 3,
+        },
+    },
+    "adx": {"func": "ADX", "input": "hlc", "params": {"timeperiod": 14}},
+    "cci": {"func": "CCI", "input": "hlc", "params": {"timeperiod": 14}},
+    "obv": {"func": "OBV", "input": "close_volume", "params": {}},
+    "wma": {"func": "WMA", "input": "close", "params": {"timeperiod": 20}},
+    "dema": {"func": "DEMA", "input": "close", "params": {"timeperiod": 20}},
+    "tema": {"func": "TEMA", "input": "close", "params": {"timeperiod": 20}},
+    "willr": {"func": "WILLR", "input": "hlc", "params": {"timeperiod": 14}},
+    "mfi": {"func": "MFI", "input": "hlcv", "params": {"timeperiod": 14}},
+}
+
+# 다중 출력 지표의 결과 키 매핑
+_MULTI_OUTPUT: dict[str, list[str]] = {
+    "macd": ["macd", "signal", "hist"],
+    "bbands": ["upper", "middle", "lower"],
+    "stoch": ["slowk", "slowd"],
+}
+
+
+class IndicatorCalculator:
+    """TA-Lib 래핑 기술 지표 계산기.
+
+    사용법::
+
+        calc = IndicatorCalculator()
+        result = calc.compute("sma", ohlcv, timeperiod=50)
+        # result == {"sma": np.ndarray}
+    """
+
+    @staticmethod
+    def is_available() -> bool:
+        """TA-Lib 설치 여부."""
+        return TALIB_AVAILABLE
+
+    @staticmethod
+    def supported_indicators() -> list[str]:
+        """지원 지표 이름 목록."""
+        return sorted(INDICATOR_REGISTRY.keys())
+
+    @staticmethod
+    def compute(
+        name: str,
+        ohlcv: dict[str, np.ndarray],
+        **params: Any,
+    ) -> dict[str, np.ndarray]:
+        """지표 계산.
+
+        Args:
+            name: 지표 이름 (예: "sma", "rsi", "macd").
+            ohlcv: OHLCV numpy 배열 딕셔너리.
+                   키: "open", "high", "low", "close", "volume".
+            **params: TA-Lib 파라미터 오버라이드.
+
+        Returns:
+            결과 키 → numpy 배열 딕셔너리.
+            단일 출력: ``{"sma": array}``.
+            다중 출력: ``{"macd": array, "signal": array, "hist": array}``.
+
+        Raises:
+            ImportError: TA-Lib 미설치.
+            ValueError: 미지원 지표 또는 필수 입력 누락.
+        """
+        if not TALIB_AVAILABLE:
+            raise ImportError(
+                "TA-Lib is not installed. "
+                "Run 'scripts/install-talib.sh' to install the C library, "
+                "then 'pip install TA-Lib'."
+            )
+
+        name_lower = name.lower()
+        if name_lower not in INDICATOR_REGISTRY:
+            supported = ", ".join(sorted(INDICATOR_REGISTRY.keys()))
+            raise ValueError(f"Unknown indicator: {name}. Supported: {supported}")
+
+        spec = INDICATOR_REGISTRY[name_lower]
+        func = getattr(talib, spec["func"])
+        merged_params = {**spec["params"], **params}
+
+        input_type = spec["input"]
+        if input_type == "close":
+            result = func(ohlcv["close"], **merged_params)
+        elif input_type == "hlc":
+            result = func(ohlcv["high"], ohlcv["low"], ohlcv["close"], **merged_params)
+        elif input_type == "close_volume":
+            result = func(
+                ohlcv["close"],
+                ohlcv["volume"].astype(float),
+                **merged_params,
+            )
+        elif input_type == "hlcv":
+            result = func(
+                ohlcv["high"],
+                ohlcv["low"],
+                ohlcv["close"],
+                ohlcv["volume"].astype(float),
+                **merged_params,
+            )
+        else:
+            raise ValueError(f"Unknown input type: {input_type}")
+
+        # 결과 포맷팅
+        if name_lower in _MULTI_OUTPUT:
+            keys = _MULTI_OUTPUT[name_lower]
+            return dict(zip(keys, result))
+        if isinstance(result, tuple):
+            return {f"{name_lower}_{i}": r for i, r in enumerate(result)}
+        return {name_lower: result}
+
+
+def ohlcv_to_numpy(data: Any) -> dict[str, Any]:
+    """OHLCV 데이터를 numpy 배열 딕셔너리로 변환.
+
+    지원 입력 형식:
+    - polars DataFrame (columns: open, high, low, close, volume)
+    - list[dict] (각 dict에 open, high, low, close, volume 키)
+
+    Returns:
+        {"open": array, "high": array, "low": array,
+         "close": array, "volume": array}
+
+    Raises:
+        ImportError: numpy 미설치.
+        ValueError: 변환 불가한 데이터 형식 또는 빈 데이터.
+    """
+    if np is None:
+        raise ImportError(
+            "numpy is required for indicator computation. "
+            "Install TA-Lib: scripts/install-talib.sh"
+        )
+
+    try:
+        import polars as pl
+
+        if isinstance(data, pl.DataFrame):
+            return {
+                col: data[col].to_numpy().astype(float)
+                for col in ("open", "high", "low", "close", "volume")
+                if col in data.columns
+            }
+    except ImportError:
+        pass
+
+    if isinstance(data, list):
+        if not data:
+            raise ValueError("Empty OHLCV data")
+        arrays: dict[str, Any] = {}
+        for col in ("open", "high", "low", "close", "volume"):
+            arrays[col] = np.array([float(row.get(col, 0.0)) for row in data])
+        return arrays
+
+    raise ValueError(
+        f"Unsupported OHLCV data type: {type(data).__name__}. "
+        "Expected polars DataFrame or list[dict]."
+    )

--- a/tests/unit/test_indicators.py
+++ b/tests/unit/test_indicators.py
@@ -60,9 +60,8 @@ def test_registry_input_types_valid():
     """레지스트리 input 타입이 유효한 값이다."""
     valid_types = {"close", "hlc", "close_volume", "hlcv"}
     for name, spec in INDICATOR_REGISTRY.items():
-        assert (
-            spec["input"] in valid_types
-        ), f"{name} has invalid input type: {spec['input']}"
+        msg = f"{name} has invalid input type: {spec['input']}"
+        assert spec["input"] in valid_types, msg
 
 
 # ── ohlcv_to_numpy ──

--- a/tests/unit/test_indicators.py
+++ b/tests/unit/test_indicators.py
@@ -1,0 +1,166 @@
+"""IndicatorCalculator 단위 테스트."""
+
+import polars as pl
+import pytest
+
+from ante.strategy.indicators import (
+    INDICATOR_REGISTRY,
+    TALIB_AVAILABLE,
+    IndicatorCalculator,
+    ohlcv_to_numpy,
+)
+
+# ── IndicatorCalculator ──
+
+
+def test_supported_indicators_returns_all_registered():
+    """지원 지표 목록이 레지스트리와 일치한다."""
+    supported = IndicatorCalculator.supported_indicators()
+    assert set(supported) == set(INDICATOR_REGISTRY.keys())
+    assert len(supported) >= 15
+
+
+def test_supported_indicators_sorted():
+    """지원 지표 목록이 정렬되어 있다."""
+    supported = IndicatorCalculator.supported_indicators()
+    assert supported == sorted(supported)
+
+
+def test_is_available_matches_import():
+    """is_available()이 실제 import 상태와 일치한다."""
+    assert IndicatorCalculator.is_available() == TALIB_AVAILABLE
+
+
+def test_registry_has_required_indicators():
+    """대표 10종 지표가 레지스트리에 포함되어 있다."""
+    required = {
+        "sma",
+        "ema",
+        "rsi",
+        "macd",
+        "bbands",
+        "atr",
+        "stoch",
+        "adx",
+        "cci",
+        "obv",
+    }
+    assert required.issubset(set(INDICATOR_REGISTRY.keys()))
+
+
+def test_registry_entries_have_required_keys():
+    """레지스트리 각 항목에 func, input, params 키가 존재한다."""
+    for name, spec in INDICATOR_REGISTRY.items():
+        assert "func" in spec, f"{name} missing 'func'"
+        assert "input" in spec, f"{name} missing 'input'"
+        assert "params" in spec, f"{name} missing 'params'"
+
+
+def test_registry_input_types_valid():
+    """레지스트리 input 타입이 유효한 값이다."""
+    valid_types = {"close", "hlc", "close_volume", "hlcv"}
+    for name, spec in INDICATOR_REGISTRY.items():
+        assert (
+            spec["input"] in valid_types
+        ), f"{name} has invalid input type: {spec['input']}"
+
+
+# ── ohlcv_to_numpy ──
+
+
+@pytest.mark.skipif(not TALIB_AVAILABLE, reason="numpy/TA-Lib not installed")
+def test_ohlcv_from_list_of_dicts():
+    """list[dict] → numpy 변환이 정상 동작한다."""
+    import numpy as np_
+
+    data = [
+        {"open": 100, "high": 110, "low": 90, "close": 105, "volume": 1000},
+        {"open": 105, "high": 115, "low": 95, "close": 110, "volume": 1200},
+    ]
+    result = ohlcv_to_numpy(data)
+    assert set(result.keys()) == {"open", "high", "low", "close", "volume"}
+    np_.testing.assert_array_equal(result["close"], [105.0, 110.0])
+    np_.testing.assert_array_equal(result["volume"], [1000.0, 1200.0])
+
+
+@pytest.mark.skipif(not TALIB_AVAILABLE, reason="numpy/TA-Lib not installed")
+def test_ohlcv_from_polars_dataframe():
+    """polars DataFrame → numpy 변환이 정상 동작한다."""
+    import numpy as np_
+
+    df = pl.DataFrame(
+        {
+            "open": [100.0, 105.0],
+            "high": [110.0, 115.0],
+            "low": [90.0, 95.0],
+            "close": [105.0, 110.0],
+            "volume": [1000.0, 1200.0],
+        }
+    )
+    result = ohlcv_to_numpy(df)
+    assert set(result.keys()) == {"open", "high", "low", "close", "volume"}
+    np_.testing.assert_array_equal(result["close"], [105.0, 110.0])
+
+
+@pytest.mark.skipif(not TALIB_AVAILABLE, reason="numpy/TA-Lib not installed")
+def test_ohlcv_empty_list_raises():
+    """빈 리스트는 ValueError를 발생시킨다."""
+    with pytest.raises(ValueError, match="Empty OHLCV data"):
+        ohlcv_to_numpy([])
+
+
+def test_ohlcv_without_numpy_raises_import_error():
+    """numpy 미설치 시 ImportError를 발생시킨다."""
+    if TALIB_AVAILABLE:
+        pytest.skip("numpy is installed")
+    with pytest.raises(ImportError, match="numpy is required"):
+        ohlcv_to_numpy([{"close": 1.0}])
+
+
+def test_compute_without_talib_raises_import_error():
+    """TA-Lib 미설치 시 compute()가 ImportError를 발생시킨다."""
+    if TALIB_AVAILABLE:
+        pytest.skip("TA-Lib is installed")
+    with pytest.raises(ImportError, match="TA-Lib is not installed"):
+        IndicatorCalculator.compute("sma", {"close": []})
+
+
+# ── StrategyContext.get_indicator fallback ──
+
+
+async def test_context_get_indicator_fallback_without_talib():
+    """TA-Lib 미설치 시 DataProvider에 위임한다."""
+    if TALIB_AVAILABLE:
+        pytest.skip("TA-Lib is installed")
+
+    class FakeDataProvider:
+        async def get_ohlcv(self, symbol, timeframe="1d", limit=100):
+            return []
+
+        async def get_current_price(self, symbol):
+            return 50000.0
+
+        async def get_indicator(self, symbol, indicator, params=None):
+            return {"fallback": True}
+
+    class FakePortfolio:
+        def get_positions(self, bot_id):
+            return {}
+
+        def get_balance(self, bot_id):
+            return {}
+
+    class FakeOrderView:
+        def get_open_orders(self, bot_id):
+            return []
+
+    from ante.strategy.context import StrategyContext
+
+    ctx = StrategyContext(
+        bot_id="test-bot",
+        data_provider=FakeDataProvider(),  # type: ignore[arg-type]
+        portfolio=FakePortfolio(),  # type: ignore[arg-type]
+        order_view=FakeOrderView(),  # type: ignore[arg-type]
+    )
+    result = await ctx.get_indicator("005930", "sma")
+    assert result == {"fallback": True}


### PR DESCRIPTION
## Summary
- `IndicatorCalculator`로 TA-Lib 래핑, 15종 대표 지표 지원 (SMA, EMA, RSI, MACD, BBands, ATR, Stochastic, ADX, CCI, OBV, WMA, DEMA, TEMA, WILLR, MFI)
- `StrategyContext.get_indicator()`가 TA-Lib 설치 시 자동 계산, 미설치 시 DataProvider 폴백
- macOS/Linux 플랫폼별 TA-Lib C 라이브러리 설치 스크립트 제공

## Test plan
- [x] 지표 레지스트리 15종 완비 검증
- [x] 레지스트리 항목 구조 검증 (func, input, params)
- [x] TA-Lib 미설치 시 ImportError 안내
- [x] numpy 미설치 시 ohlcv_to_numpy ImportError 안내
- [x] StrategyContext 폴백 동작 검증
- [x] 전체 테스트 스위트 통과 (1082 passed, 3 skipped)

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)