### PR TITLE
feat: DataNormalizer 소스별 Normalizer 클래스 패턴 구현

### DIFF
--- a/src/ante/data/__init__.py
+++ b/src/ante/data/__init__.py
@@ -3,20 +3,34 @@
 from ante.data.catalog import DataCatalog
 from ante.data.collector import DataCollector
 from ante.data.injector import DataInjector
-from ante.data.normalizer import DataNormalizer
+from ante.data.normalizer import (
+    BaseNormalizer,
+    DataNormalizer,
+    DefaultNormalizer,
+    KISNormalizer,
+    YahooNormalizer,
+    get_normalizer,
+    register_normalizer,
+)
 from ante.data.retention import RetentionPolicy
 from ante.data.schemas import OHLCV_COLUMNS, OHLCV_SCHEMA, TICK_SCHEMA, TIMEFRAMES
 from ante.data.store import ParquetStore
 
 __all__ = [
+    "BaseNormalizer",
     "DataCatalog",
     "DataCollector",
     "DataInjector",
     "DataNormalizer",
+    "DefaultNormalizer",
+    "KISNormalizer",
     "OHLCV_COLUMNS",
     "OHLCV_SCHEMA",
     "ParquetStore",
     "RetentionPolicy",
     "TICK_SCHEMA",
     "TIMEFRAMES",
+    "YahooNormalizer",
+    "get_normalizer",
+    "register_normalizer",
 ]

--- a/src/ante/data/normalizer.py
+++ b/src/ante/data/normalizer.py
@@ -1,8 +1,13 @@
-"""Data Pipeline — 다양한 소스의 데이터를 통일된 스키마로 정규화."""
+"""Data Pipeline — 다양한 소스의 데이터를 통일된 스키마로 정규화.
+
+소스별 Normalizer 클래스 패턴: BaseNormalizer ABC를 상속하여
+각 데이터 소스(KIS, Yahoo 등)마다 정규화 로직을 캡슐화한다.
+"""
 
 from __future__ import annotations
 
 import logging
+from abc import ABC, abstractmethod
 
 import polars as pl
 
@@ -10,40 +15,180 @@ from ante.data.schemas import OHLCV_COLUMNS
 
 logger = logging.getLogger(__name__)
 
-# 소스별 컬럼 매핑 규칙
+
+class BaseNormalizer(ABC):
+    """데이터 정규화 인터페이스.
+
+    모든 소스별 Normalizer가 구현해야 하는 ABC.
+    """
+
+    @property
+    @abstractmethod
+    def source_name(self) -> str:
+        """데이터 소스 식별자 (예: 'kis', 'yahoo')."""
+        ...
+
+    @property
+    @abstractmethod
+    def column_mapping(self) -> dict[str, str]:
+        """소스 컬럼명 → OHLCV 표준 컬럼명 매핑."""
+        ...
+
+    def normalize(self, df: pl.DataFrame) -> pl.DataFrame:
+        """DataFrame을 OHLCV 스키마로 정규화.
+
+        Args:
+            df: 원본 DataFrame.
+
+        Returns:
+            OHLCV 스키마에 맞춰 정규화된 DataFrame.
+        """
+        # 컬럼 이름 매핑
+        rename_map = {
+            src: dst for src, dst in self.column_mapping.items() if src in df.columns
+        }
+        if rename_map:
+            df = df.rename(rename_map)
+
+        # 소스별 추가 변환 (서브클래스 오버라이드 가능)
+        df = self.transform(df)
+
+        # timestamp 정규화
+        df = _normalize_timestamp(df)
+
+        # 숫자 컬럼 타입 변환
+        for col in ("open", "high", "low", "close"):
+            if col in df.columns:
+                df = df.with_columns(pl.col(col).cast(pl.Float64))
+        if "volume" in df.columns:
+            df = df.with_columns(pl.col("volume").cast(pl.Int64))
+
+        # source 컬럼
+        if "source" not in df.columns:
+            df = df.with_columns(pl.lit(self.source_name).alias("source"))
+
+        # symbol 컬럼 (호출자가 채움)
+        if "symbol" not in df.columns:
+            df = df.with_columns(pl.lit("").alias("symbol"))
+
+        # 스키마 컬럼만 선택
+        available = [c for c in OHLCV_COLUMNS if c in df.columns]
+        return df.select(available).sort("timestamp")
+
+    def transform(self, df: pl.DataFrame) -> pl.DataFrame:
+        """소스별 추가 변환 훅. 기본은 무변환."""
+        return df
+
+
+class KISNormalizer(BaseNormalizer):
+    """한국투자증권(KIS) API 응답 정규화."""
+
+    @property
+    def source_name(self) -> str:
+        return "kis"
+
+    @property
+    def column_mapping(self) -> dict[str, str]:
+        return {
+            "stck_bsop_date": "date",
+            "stck_clpr": "close",
+            "stck_oprc": "open",
+            "stck_hgpr": "high",
+            "stck_lwpr": "low",
+            "acml_vol": "volume",
+        }
+
+    def transform(self, df: pl.DataFrame) -> pl.DataFrame:
+        """KIS date 컬럼을 timestamp로 변환."""
+        if "date" in df.columns and "timestamp" not in df.columns:
+            df = df.rename({"date": "timestamp"})
+        return df
+
+
+class YahooNormalizer(BaseNormalizer):
+    """Yahoo Finance 데이터 정규화."""
+
+    @property
+    def source_name(self) -> str:
+        return "yahoo"
+
+    @property
+    def column_mapping(self) -> dict[str, str]:
+        return {
+            "Date": "timestamp",
+            "Open": "open",
+            "High": "high",
+            "Low": "low",
+            "Close": "close",
+            "Volume": "volume",
+        }
+
+
+class DefaultNormalizer(BaseNormalizer):
+    """범용 정규화. 일반적인 컬럼명(date, datetime 등)을 매핑."""
+
+    @property
+    def source_name(self) -> str:
+        return "external"
+
+    @property
+    def column_mapping(self) -> dict[str, str]:
+        return {
+            "date": "timestamp",
+            "datetime": "timestamp",
+            "time": "timestamp",
+            "open": "open",
+            "high": "high",
+            "low": "low",
+            "close": "close",
+            "volume": "volume",
+            "vol": "volume",
+        }
+
+
+# ── Normalizer 레지스트리 ────────────────────────────
+
+NORMALIZER_REGISTRY: dict[str, type[BaseNormalizer]] = {
+    "kis": KISNormalizer,
+    "yahoo": YahooNormalizer,
+    "default": DefaultNormalizer,
+    "external": DefaultNormalizer,
+}
+
+
+def get_normalizer(source: str) -> BaseNormalizer:
+    """소스명으로 Normalizer 인스턴스를 조회.
+
+    Args:
+        source: 데이터 소스 식별자 (예: "kis", "yahoo", "external").
+
+    Returns:
+        해당 소스의 Normalizer 인스턴스. 미등록 시 DefaultNormalizer.
+    """
+    cls = NORMALIZER_REGISTRY.get(source, DefaultNormalizer)
+    return cls()
+
+
+def register_normalizer(source: str, cls: type[BaseNormalizer]) -> None:
+    """커스텀 Normalizer를 레지스트리에 등록.
+
+    새 거래소 추가 시 이 함수로 등록하면 DataNormalizer가 자동 인식.
+    """
+    NORMALIZER_REGISTRY[source] = cls
+
+
+# ── 하위 호환 DataNormalizer 파사드 ──────────────────
+
+# 기존 COLUMN_MAPPINGS 유지 (하위 호환)
 COLUMN_MAPPINGS: dict[str, dict[str, str]] = {
-    "kis": {
-        "stck_bsop_date": "date",
-        "stck_clpr": "close",
-        "stck_oprc": "open",
-        "stck_hgpr": "high",
-        "stck_lwpr": "low",
-        "acml_vol": "volume",
-    },
-    "yahoo": {
-        "Date": "timestamp",
-        "Open": "open",
-        "High": "high",
-        "Low": "low",
-        "Close": "close",
-        "Volume": "volume",
-    },
-    "default": {
-        "date": "timestamp",
-        "datetime": "timestamp",
-        "time": "timestamp",
-        "open": "open",
-        "high": "high",
-        "low": "low",
-        "close": "close",
-        "volume": "volume",
-        "vol": "volume",
-    },
+    "kis": KISNormalizer().column_mapping,
+    "yahoo": YahooNormalizer().column_mapping,
+    "default": DefaultNormalizer().column_mapping,
 }
 
 
 class DataNormalizer:
-    """다양한 소스의 DataFrame을 OHLCV 공통 스키마로 정규화."""
+    """하위 호환 파사드. 내부적으로 소스별 Normalizer에 위임."""
 
     def normalize(
         self,
@@ -54,67 +199,47 @@ class DataNormalizer:
         """DataFrame을 OHLCV 스키마로 정규화.
 
         Args:
-            df: 원본 DataFrame
-            source: 데이터 소스 식별자 ("kis", "yahoo", "external" 등)
-            format_hint: 소스별 컬럼 매핑 힌트. None이면 자동 감지.
+            df: 원본 DataFrame.
+            source: 데이터 소스 식별자.
+            format_hint: 소스별 컬럼 매핑 힌트. None이면 source 사용.
 
         Returns:
             OHLCV 스키마에 맞춰 정규화된 DataFrame.
         """
-        mapping_key = format_hint or source
-        mapping = COLUMN_MAPPINGS.get(mapping_key, COLUMN_MAPPINGS["default"])
+        has_source = "source" in df.columns
+        key = format_hint or source
+        normalizer = get_normalizer(key)
+        result = normalizer.normalize(df)
+        # source 값: 원본에 없었을 때만 source 파라미터로 덮어쓰기
+        if not has_source and "source" in result.columns:
+            result = result.with_columns(pl.lit(source).alias("source"))
+        return result
 
-        # 컬럼 이름 매핑 적용
-        rename_map: dict[str, str] = {}
-        for src_col, dst_col in mapping.items():
-            if src_col in df.columns:
-                rename_map[src_col] = dst_col
-
-        if rename_map:
-            df = df.rename(rename_map)
-
-        # timestamp 컬럼 처리
-        df = self._normalize_timestamp(df)
-
-        # 숫자 컬럼 타입 변환
-        for col in ["open", "high", "low", "close"]:
-            if col in df.columns:
-                df = df.with_columns(pl.col(col).cast(pl.Float64))
-
-        if "volume" in df.columns:
-            df = df.with_columns(pl.col("volume").cast(pl.Int64))
-
-        # source 컬럼 추가
-        if "source" not in df.columns:
-            df = df.with_columns(pl.lit(source).alias("source"))
-
-        # symbol 컬럼 없으면 빈 문자열 (호출자가 채움)
-        if "symbol" not in df.columns:
-            df = df.with_columns(pl.lit("").alias("symbol"))
-
-        # 필요한 컬럼만 선택 (존재하는 것만)
-        available = [c for c in OHLCV_COLUMNS if c in df.columns]
-        df = df.select(available)
-
-        return df.sort("timestamp")
-
-    def _normalize_timestamp(self, df: pl.DataFrame) -> pl.DataFrame:
+    @staticmethod
+    def _normalize_timestamp(df: pl.DataFrame) -> pl.DataFrame:
         """timestamp 컬럼을 Datetime[ns]로 정규화."""
-        if "timestamp" not in df.columns:
-            raise ValueError("DataFrame에 timestamp 컬럼이 없습니다.")
+        return _normalize_timestamp(df)
 
-        ts_dtype = df["timestamp"].dtype
-        if ts_dtype == pl.Utf8:
-            # 문자열 → datetime 변환 시도
-            df = df.with_columns(pl.col("timestamp").str.to_datetime(time_zone="UTC"))
-        elif ts_dtype == pl.Date:
-            df = df.with_columns(
-                pl.col("timestamp").cast(pl.Datetime("ns")).dt.replace_time_zone("UTC")
-            )
-        elif isinstance(ts_dtype, pl.Datetime):
-            if ts_dtype.time_zone is None:
-                df = df.with_columns(pl.col("timestamp").dt.replace_time_zone("UTC"))
-        else:
-            raise ValueError(f"지원하지 않는 timestamp 타입: {ts_dtype}")
 
-        return df
+# ── 공통 유틸 ────────────────────────────────────────
+
+
+def _normalize_timestamp(df: pl.DataFrame) -> pl.DataFrame:
+    """timestamp 컬럼을 Datetime[ns, UTC]로 정규화."""
+    if "timestamp" not in df.columns:
+        raise ValueError("DataFrame에 timestamp 컬럼이 없습니다.")
+
+    ts_dtype = df["timestamp"].dtype
+    if ts_dtype == pl.Utf8:
+        df = df.with_columns(pl.col("timestamp").str.to_datetime(time_zone="UTC"))
+    elif ts_dtype == pl.Date:
+        df = df.with_columns(
+            pl.col("timestamp").cast(pl.Datetime("ns")).dt.replace_time_zone("UTC")
+        )
+    elif isinstance(ts_dtype, pl.Datetime):
+        if ts_dtype.time_zone is None:
+            df = df.with_columns(pl.col("timestamp").dt.replace_time_zone("UTC"))
+    else:
+        raise ValueError(f"지원하지 않는 timestamp 타입: {ts_dtype}")
+
+    return df

--- a/tests/unit/test_normalizer_classes.py
+++ b/tests/unit/test_normalizer_classes.py
@@ -1,0 +1,200 @@
+"""소스별 Normalizer 클래스 패턴 테스트."""
+
+import polars as pl
+import pytest
+
+from ante.data.normalizer import (
+    BaseNormalizer,
+    DefaultNormalizer,
+    KISNormalizer,
+    YahooNormalizer,
+    get_normalizer,
+    register_normalizer,
+)
+
+# ── BaseNormalizer ABC ──
+
+
+def test_base_normalizer_is_abstract():
+    """BaseNormalizer는 직접 인스턴스화할 수 없다."""
+    with pytest.raises(TypeError):
+        BaseNormalizer()  # type: ignore[abstract]
+
+
+# ── KISNormalizer ──
+
+
+class TestKISNormalizer:
+    @pytest.fixture
+    def normalizer(self):
+        return KISNormalizer()
+
+    def test_source_name(self, normalizer):
+        assert normalizer.source_name == "kis"
+
+    def test_column_mapping_keys(self, normalizer):
+        mapping = normalizer.column_mapping
+        assert "stck_oprc" in mapping
+        assert "stck_hgpr" in mapping
+        assert "stck_lwpr" in mapping
+        assert "stck_clpr" in mapping
+        assert "acml_vol" in mapping
+
+    def test_normalize_kis_format(self, normalizer):
+        """KIS API 응답 형식이 OHLCV 스키마로 정규화된다."""
+        df = pl.DataFrame(
+            {
+                "stck_bsop_date": ["2026-03-01T09:00:00"],
+                "stck_oprc": [50000],
+                "stck_hgpr": [50100],
+                "stck_lwpr": [49900],
+                "stck_clpr": [50050],
+                "acml_vol": [1000],
+            }
+        )
+        result = normalizer.normalize(df)
+        assert "timestamp" in result.columns
+        assert "open" in result.columns
+        assert "high" in result.columns
+        assert "low" in result.columns
+        assert "close" in result.columns
+        assert "volume" in result.columns
+        assert result["source"][0] == "kis"
+
+    def test_normalize_kis_numeric_types(self, normalizer):
+        """KIS 데이터의 가격은 Float64, 거래량은 Int64로 변환된다."""
+        df = pl.DataFrame(
+            {
+                "stck_bsop_date": ["2026-03-01T09:00:00"],
+                "stck_oprc": [50000],
+                "stck_hgpr": [50100],
+                "stck_lwpr": [49900],
+                "stck_clpr": [50050],
+                "acml_vol": [1000],
+            }
+        )
+        result = normalizer.normalize(df)
+        assert result["open"].dtype == pl.Float64
+        assert result["volume"].dtype == pl.Int64
+
+
+# ── YahooNormalizer ──
+
+
+class TestYahooNormalizer:
+    @pytest.fixture
+    def normalizer(self):
+        return YahooNormalizer()
+
+    def test_source_name(self, normalizer):
+        assert normalizer.source_name == "yahoo"
+
+    def test_normalize_yahoo_format(self, normalizer):
+        """Yahoo Finance 형식이 정규화된다."""
+        df = pl.DataFrame(
+            {
+                "Date": ["2026-03-01T09:00:00", "2026-03-02T09:00:00"],
+                "Open": [50000, 50100],
+                "High": [50100, 50200],
+                "Low": [49900, 50000],
+                "Close": [50050, 50150],
+                "Volume": [1000, 1100],
+            }
+        )
+        result = normalizer.normalize(df)
+        assert len(result) == 2
+        assert "timestamp" in result.columns
+        assert result["source"][0] == "yahoo"
+
+
+# ── DefaultNormalizer ──
+
+
+class TestDefaultNormalizer:
+    @pytest.fixture
+    def normalizer(self):
+        return DefaultNormalizer()
+
+    def test_source_name(self, normalizer):
+        assert normalizer.source_name == "external"
+
+    def test_normalize_with_date_column(self, normalizer):
+        """'date' 컬럼이 'timestamp'로 매핑된다."""
+        df = pl.DataFrame(
+            {
+                "date": ["2026-03-01T09:00:00"],
+                "open": [50000.0],
+                "high": [50100.0],
+                "low": [49900.0],
+                "close": [50050.0],
+                "volume": [1000],
+            }
+        )
+        result = normalizer.normalize(df)
+        assert "timestamp" in result.columns
+
+    def test_normalize_with_vol_column(self, normalizer):
+        """'vol' 컬럼이 'volume'으로 매핑된다."""
+        df = pl.DataFrame(
+            {
+                "timestamp": ["2026-03-01T09:00:00"],
+                "open": [50000.0],
+                "high": [50100.0],
+                "low": [49900.0],
+                "close": [50050.0],
+                "vol": [1000],
+            }
+        )
+        result = normalizer.normalize(df)
+        assert "volume" in result.columns
+
+
+# ── 레지스트리 ──
+
+
+def test_get_normalizer_kis():
+    """get_normalizer('kis')가 KISNormalizer를 반환한다."""
+    n = get_normalizer("kis")
+    assert isinstance(n, KISNormalizer)
+
+
+def test_get_normalizer_yahoo():
+    n = get_normalizer("yahoo")
+    assert isinstance(n, YahooNormalizer)
+
+
+def test_get_normalizer_default():
+    n = get_normalizer("external")
+    assert isinstance(n, DefaultNormalizer)
+
+
+def test_get_normalizer_unknown_returns_default():
+    """미등록 소스는 DefaultNormalizer로 폴백한다."""
+    n = get_normalizer("unknown_source")
+    assert isinstance(n, DefaultNormalizer)
+
+
+def test_register_custom_normalizer():
+    """커스텀 Normalizer를 레지스트리에 등록할 수 있다."""
+
+    class CustomNormalizer(BaseNormalizer):
+        @property
+        def source_name(self) -> str:
+            return "custom"
+
+        @property
+        def column_mapping(self) -> dict[str, str]:
+            return {"price": "close"}
+
+    register_normalizer("custom", CustomNormalizer)
+    n = get_normalizer("custom")
+    assert isinstance(n, CustomNormalizer)
+    assert n.source_name == "custom"
+
+
+def test_no_timestamp_raises():
+    """timestamp 컬럼 없이 정규화하면 ValueError."""
+    n = DefaultNormalizer()
+    df = pl.DataFrame({"open": [50000.0], "close": [50050.0]})
+    with pytest.raises(ValueError, match="timestamp"):
+        n.normalize(df)


### PR DESCRIPTION
## Summary
- BaseNormalizer ABC 도입으로 소스별 정규화 로직 캡슐화
- KISNormalizer, YahooNormalizer, DefaultNormalizer 구현
- get_normalizer()/register_normalizer() 레지스트리로 확장 용이
- 기존 DataNormalizer를 하위 호환 파사드로 유지

## Test plan
- [x] BaseNormalizer ABC 직접 인스턴스화 불가 확인
- [x] KIS/Yahoo/Default 각 Normalizer 정규화 검증
- [x] 레지스트리 조회 및 커스텀 Normalizer 등록
- [x] 기존 DataNormalizer 7개 테스트 하위 호환 통과
- [x] 전체 테스트 스위트 1089 passed

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)