### PR TITLE
feat: systemd/launchd 서비스 파일 제공 (데몬 모드)

### DIFF
--- a/deploy/ante.service
+++ b/deploy/ante.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Ante AI-Native Trading Engine
+Documentation=https://github.com/joshua-jingu-lee/ante
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ante
+Group=ante
+WorkingDirectory=/opt/ante
+ExecStart=/opt/ante/.venv/bin/python -m ante.main
+Restart=on-failure
+RestartSec=10
+TimeoutStopSec=30
+
+# 환경 변수
+EnvironmentFile=-/opt/ante/.env
+
+# 보안 강화
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/opt/ante/db /opt/ante/data /opt/ante/logs
+PrivateTmp=true
+
+# 로깅 (journald)
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=ante
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/com.ante.plist
+++ b/deploy/com.ante.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ante</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/ante/.venv/bin/python</string>
+        <string>-m</string>
+        <string>ante.main</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/opt/ante</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>/opt/ante/logs/ante.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/opt/ante/logs/ante.err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>ANTE_HOME</key>
+        <string>/opt/ante</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Ante 시스템 서비스 설치 스크립트.
+# Linux (systemd) 또는 macOS (launchd)를 자동 감지하여 설치한다.
+# 사용법: sudo bash scripts/install-service.sh
+set -euo pipefail
+
+ANTE_HOME="${ANTE_HOME:-/opt/ante}"
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "=== Ante 서비스 설치 ==="
+echo "ANTE_HOME: ${ANTE_HOME}"
+
+OS="$(uname -s)"
+case "${OS}" in
+    Linux)
+        echo "[Linux] systemd 서비스를 설치합니다."
+
+        # ante 사용자 생성 (없으면)
+        if ! id -u ante &>/dev/null; then
+            echo "ante 사용자 생성..."
+            useradd --system --home-dir "${ANTE_HOME}" --shell /usr/sbin/nologin ante
+        fi
+
+        # 디렉토리 준비
+        mkdir -p "${ANTE_HOME}"/{db,data,logs}
+        chown -R ante:ante "${ANTE_HOME}"
+
+        # 서비스 파일 복사
+        cp "${SCRIPT_DIR}/deploy/ante.service" /etc/systemd/system/ante.service
+
+        # 경로 치환 (ANTE_HOME이 기본값과 다를 때)
+        if [ "${ANTE_HOME}" != "/opt/ante" ]; then
+            sed -i "s|/opt/ante|${ANTE_HOME}|g" /etc/systemd/system/ante.service
+        fi
+
+        # systemd 등록
+        systemctl daemon-reload
+        systemctl enable ante.service
+        systemctl start ante.service
+
+        echo ""
+        echo "=== 설치 완료 ==="
+        echo "상태 확인: systemctl status ante"
+        echo "로그 확인: journalctl -u ante -f"
+        ;;
+
+    Darwin)
+        echo "[macOS] launchd 서비스를 설치합니다."
+
+        # 디렉토리 준비
+        mkdir -p "${ANTE_HOME}"/{db,data,logs}
+
+        # plist 복사
+        PLIST_DST="${HOME}/Library/LaunchAgents/com.ante.plist"
+        cp "${SCRIPT_DIR}/deploy/com.ante.plist" "${PLIST_DST}"
+
+        # 경로 치환
+        if [ "${ANTE_HOME}" != "/opt/ante" ]; then
+            sed -i '' "s|/opt/ante|${ANTE_HOME}|g" "${PLIST_DST}"
+        fi
+
+        # launchd 등록
+        launchctl load "${PLIST_DST}"
+
+        echo ""
+        echo "=== 설치 완료 ==="
+        echo "상태 확인: launchctl list | grep ante"
+        echo "로그 확인: tail -f ${ANTE_HOME}/logs/ante.out.log"
+        ;;
+
+    *)
+        echo "ERROR: 지원하지 않는 OS: ${OS}"
+        exit 1
+        ;;
+esac

--- a/scripts/uninstall-service.sh
+++ b/scripts/uninstall-service.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Ante 시스템 서비스 제거 스크립트.
+# 사용법: sudo bash scripts/uninstall-service.sh
+set -euo pipefail
+
+echo "=== Ante 서비스 제거 ==="
+
+OS="$(uname -s)"
+case "${OS}" in
+    Linux)
+        echo "[Linux] systemd 서비스를 제거합니다."
+
+        if systemctl is-active --quiet ante.service 2>/dev/null; then
+            systemctl stop ante.service
+            echo "서비스 중지 완료"
+        fi
+
+        if systemctl is-enabled --quiet ante.service 2>/dev/null; then
+            systemctl disable ante.service
+            echo "자동 시작 비활성화"
+        fi
+
+        if [ -f /etc/systemd/system/ante.service ]; then
+            rm /etc/systemd/system/ante.service
+            systemctl daemon-reload
+            echo "서비스 파일 제거 완료"
+        fi
+
+        echo ""
+        echo "=== 제거 완료 ==="
+        echo "데이터 디렉토리(/opt/ante)는 보존됩니다."
+        echo "완전 삭제: rm -rf /opt/ante && userdel ante"
+        ;;
+
+    Darwin)
+        echo "[macOS] launchd 서비스를 제거합니다."
+
+        PLIST="${HOME}/Library/LaunchAgents/com.ante.plist"
+        if [ -f "${PLIST}" ]; then
+            launchctl unload "${PLIST}" 2>/dev/null || true
+            rm "${PLIST}"
+            echo "서비스 제거 완료"
+        else
+            echo "서비스 파일이 없습니다: ${PLIST}"
+        fi
+
+        echo ""
+        echo "=== 제거 완료 ==="
+        echo "데이터 디렉토리(/opt/ante)는 보존됩니다."
+        ;;
+
+    *)
+        echo "ERROR: 지원하지 않는 OS: ${OS}"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Linux systemd 유닛 파일 (`deploy/ante.service`) — 자동 재시작, 보안 강화, journald 로깅
- macOS launchd plist (`deploy/com.ante.plist`) — KeepAlive, 로그 파일 분리
- 설치/제거 스크립트 (`scripts/install-service.sh`, `scripts/uninstall-service.sh`)

## Test plan
- [x] systemd 서비스 파일 문법 검증 (유닛 섹션 완비)
- [x] launchd plist XML 구조 확인
- [x] 설치 스크립트 OS 분기 로직 확인
- [x] 전체 테스트 스위트 영향 없음 (1073 passed)

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)