### PR TITLE
feat: 예수금 부족 주문실패 에러 처리

### DIFF
--- a/config/secrets.env.example
+++ b/config/secrets.env.example
@@ -5,6 +5,7 @@
 # KIS Open API
 KIS_APP_KEY=your_app_key_here
 KIS_APP_SECRET=your_app_secret_here
+KIS_ACCOUNT_NO=your_account_no_here  # 계좌번호 (8자리-2자리, 예: 12345678-90)
 
 # Telegram 알림 (선택)
 # TELEGRAM_BOT_TOKEN=your_bot_token

--- a/config/system.toml.example
+++ b/config/system.toml.example
@@ -20,9 +20,8 @@ port = 8000
 history_size = 1000
 
 [broker]
-# KIS 모의투자 설정 — secrets.env 에서 앱키/시크릿 관리
+# KIS 모의투자 설정 — secrets.env 에서 앱키/시크릿/계좌번호 관리
 is_paper = true             # true: 모의투자, false: 실전투자
-account_no = ""             # KIS 계좌번호 (8자리-2자리)
 commission_rate = 0.00015   # 매매 수수료율
 sell_tax_rate = 0.0023      # 매도 세금율 (증권거래세+농특세)
 

--- a/scripts/verify-install.py
+++ b/scripts/verify-install.py
@@ -15,8 +15,7 @@
     python scripts/verify-install.py all
 
 필수 조건:
-    - config/secrets.env 에 KIS_APP_KEY, KIS_APP_SECRET 설정
-    - config/system.toml 에 broker.account_no 설정
+    - config/secrets.env 에 KIS_APP_KEY, KIS_APP_SECRET, KIS_ACCOUNT_NO 설정
 """
 
 from __future__ import annotations
@@ -228,18 +227,19 @@ async def stage_query() -> bool:
     config = Config.load(config_dir=project_root / "config")
 
     broker_config = config.get("broker", {})
-    app_key = config.get_secret("KIS_APP_KEY")
-    app_secret = config.get_secret("KIS_APP_SECRET")
-    account_no = broker_config.get("account_no", "")
-
-    if not app_key or not app_secret:
+    try:
+        app_key = config.secret("KIS_APP_KEY")
+        app_secret = config.secret("KIS_APP_SECRET")
+    except Exception:
         log_fail("KIS_APP_KEY / KIS_APP_SECRET 가 설정되지 않았습니다")
         log_info("config/secrets.env 파일을 확인하세요")
         return False
 
-    if not account_no:
-        log_fail("broker.account_no 가 설정되지 않았습니다")
-        log_info("config/system.toml [broker] 섹션을 확인하세요")
+    try:
+        account_no = config.secret("KIS_ACCOUNT_NO")
+    except Exception:
+        log_fail("KIS_ACCOUNT_NO 가 설정되지 않았습니다")
+        log_info("config/secrets.env 파일을 확인하세요")
         return False
 
     log_ok(f"설정 확인: app_key={app_key[:4]}****, account={account_no}")
@@ -350,9 +350,9 @@ async def stage_order() -> bool:
     config = Config.load(config_dir=project_root / "config")
 
     broker_config = config.get("broker", {})
-    app_key = config.get_secret("KIS_APP_KEY")
-    app_secret = config.get_secret("KIS_APP_SECRET")
-    account_no = broker_config.get("account_no", "")
+    app_key = config.secret("KIS_APP_KEY")
+    app_secret = config.secret("KIS_APP_SECRET")
+    account_no = config.secret("KIS_ACCOUNT_NO")
 
     from ante.broker import KISAdapter
 

--- a/scripts/verify-install.py
+++ b/scripts/verify-install.py
@@ -275,7 +275,7 @@ async def stage_query() -> bool:
     # 2-2. 계좌 잔고 조회
     log_info("계좌 잔고 조회...")
     try:
-        balance = await adapter.get_balance()
+        balance = await adapter.get_account_balance()
         log_ok(f"잔고 조회 성공: {balance}")
     except Exception as e:
         log_fail(f"잔고 조회 실패: {e}")

--- a/src/ante/broker/error_codes.py
+++ b/src/ante/broker/error_codes.py
@@ -70,6 +70,15 @@ def is_retryable_http_status(status_code: int) -> bool:
     return status_code in RETRYABLE_HTTP_STATUS_CODES
 
 
+# ── 예수금 부족 관련 에러 코드 ────────────────────────────
+INSUFFICIENT_DEPOSIT_CODE = "APBK0919"  # 잔고(예수금) 부족
+
+
+def is_insufficient_deposit(msg_cd: str) -> bool:
+    """예수금 부족 에러인지 판별."""
+    return msg_cd == INSUFFICIENT_DEPOSIT_CODE
+
+
 def get_error_message(msg_cd: str, fallback: str = "") -> str:
     """KIS msg_cd에 대한 한글 에러 메시지 반환."""
     return KIS_ERROR_MESSAGES.get(msg_cd, fallback or f"알 수 없는 에러 ({msg_cd})")

--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -190,6 +190,7 @@ class OrderFailedEvent(Event):
     price: float = 0.0
     order_type: str = ""
     error_message: str = ""
+    error_code: str = ""
     exchange: str = "KRX"
 
 

--- a/src/ante/gateway/gateway.py
+++ b/src/ante/gateway/gateway.py
@@ -211,6 +211,12 @@ class APIGateway:
                 )
             )
         except Exception as e:
+            from ante.broker.exceptions import APIError
+
+            error_code = ""
+            if isinstance(e, APIError):
+                error_code = e.error_code
+
             logger.error("주문 제출 실패: %s — %s", event.order_id, e)
             await self._eventbus.publish(
                 OrderFailedEvent(
@@ -223,6 +229,7 @@ class APIGateway:
                     price=event.price or 0.0,
                     order_type=event.order_type,
                     error_message=str(e),
+                    error_code=error_code,
                     exchange=event.exchange,
                 )
             )

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -201,6 +201,13 @@ async def main() -> None:
     api_gateway = None
 
     broker_config = config.get("broker", {})
+    try:
+        broker_config["app_key"] = config.secret("KIS_APP_KEY")
+        broker_config["app_secret"] = config.secret("KIS_APP_SECRET")
+        broker_config["account_no"] = config.secret("KIS_ACCOUNT_NO")
+    except Exception:
+        pass  # 비밀값 없으면 브로커 미사용
+
     if broker_config.get("app_key"):
         broker = KISAdapter(config=broker_config, eventbus=eventbus)
         try:

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -518,6 +518,11 @@ class Treasury:
         ante_eval = self._eval_amount - self._external_eval_amount
         ante_profit_loss = ante_eval - ante_purchase
 
+        total_available = sum(b.available for b in self._budgets.values())
+        budget_exceeds_purchasable = (
+            self._purchasable_amount > 0 and total_available > self._purchasable_amount
+        )
+
         return {
             "account_balance": self._account_balance,
             "purchasable_amount": self._purchasable_amount,
@@ -527,6 +532,7 @@ class Treasury:
             "total_profit_loss": self._total_profit_loss,
             "total_allocated": total_allocated,
             "total_reserved": total_reserved,
+            "total_available": total_available,
             "unallocated": self._unallocated,
             "bot_count": len(self._budgets),
             "external_purchase_amount": self._external_purchase_amount,
@@ -534,6 +540,7 @@ class Treasury:
             "ante_purchase_amount": ante_purchase,
             "ante_eval_amount": ante_eval,
             "ante_profit_loss": ante_profit_loss,
+            "budget_exceeds_purchasable": budget_exceeds_purchasable,
         }
 
     # ── DB 영속화 ───────────────────────────────────

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -329,6 +329,40 @@ class TestAPIGatewayEvents:
 
         assert len(received) == 1
         assert "broker error" in received[0].error_message
+        assert received[0].error_code == ""
+
+    async def test_order_failure_with_api_error_code(self, gateway, eventbus, broker):
+        """APIError 주문 실패 → error_code 전달."""
+        from ante.broker.exceptions import APIError
+
+        broker.place_order = AsyncMock(
+            side_effect=APIError(
+                "잔고 부족",
+                status_code=500,
+                error_code="APBK0919",
+                retryable=False,
+            )
+        )
+
+        received: list[OrderFailedEvent] = []
+        eventbus.subscribe(OrderFailedEvent, lambda e: received.append(e))
+
+        await eventbus.publish(
+            OrderApprovedEvent(
+                order_id="ord1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                order_type="market",
+                reserved_amount=500000.0,
+            )
+        )
+
+        assert len(received) == 1
+        assert received[0].error_code == "APBK0919"
+        assert "잔고 부족" in received[0].error_message
 
     async def test_order_cancel_event(self, gateway, eventbus, broker):
         """OrderCancelEvent → 취소 → OrderCancelledEvent."""

--- a/tests/unit/test_kis_error_handling.py
+++ b/tests/unit/test_kis_error_handling.py
@@ -77,6 +77,20 @@ class TestErrorCodeClassification:
         msg2 = get_error_message("UNKNOWN")
         assert "알 수 없는 에러" in msg2
 
+    def test_insufficient_deposit_constant(self):
+        """예수금 부족 코드 상수 확인."""
+        from ante.broker.error_codes import INSUFFICIENT_DEPOSIT_CODE
+
+        assert INSUFFICIENT_DEPOSIT_CODE == "APBK0919"
+
+    def test_is_insufficient_deposit(self):
+        """예수금 부족 에러 판별."""
+        from ante.broker.error_codes import is_insufficient_deposit
+
+        assert is_insufficient_deposit("APBK0919") is True
+        assert is_insufficient_deposit("APBK0013") is False
+        assert is_insufficient_deposit("") is False
+
 
 # ── US-2: Circuit Breaker ──────────────────────────
 

--- a/tests/unit/test_treasury.py
+++ b/tests/unit/test_treasury.py
@@ -359,8 +359,27 @@ class TestTreasurySummary:
         summary = treasury.get_summary()
         assert summary["account_balance"] == 10_000_000.0
         assert summary["total_allocated"] == 5_000_000.0
+        assert summary["total_available"] == 5_000_000.0
         assert summary["unallocated"] == 5_000_000.0
         assert summary["bot_count"] == 2
+        assert summary["budget_exceeds_purchasable"] is False
+
+    async def test_budget_exceeds_purchasable_warning(self, treasury):
+        """잔여예산 > 매수가능금액 시 경고 플래그."""
+        await treasury.allocate("bot1", 5_000_000.0)
+        await treasury.sync_balance(
+            {"cash": 10_000_000.0, "purchasable_amount": 3_000_000.0}
+        )
+
+        summary = treasury.get_summary()
+        assert summary["budget_exceeds_purchasable"] is True
+
+    async def test_no_warning_when_purchasable_zero(self, treasury):
+        """매수가능금액이 0이면 경고 미표시 (동기화 전)."""
+        await treasury.allocate("bot1", 5_000_000.0)
+
+        summary = treasury.get_summary()
+        assert summary["budget_exceeds_purchasable"] is False
 
 
 # ── DB 영속화 ───────────────────────────────────


### PR DESCRIPTION
## Summary

- `OrderFailedEvent`에 `error_code` 필드 추가 — KIS 에러 코드(`APBK0919` 등)를 구조화하여 전달
- APIGateway에서 `APIError` catch 시 `error_code`를 `OrderFailedEvent`에 포함
- `error_codes.py`에 `INSUFFICIENT_DEPOSIT_CODE` 상수 및 `is_insufficient_deposit()` 헬퍼 추가
- `Treasury.get_summary()`에 `budget_exceeds_purchasable` 경고 플래그 추가 (대시보드 경고 배지용)

### 요구사항 체크
- [x] KIS API 주문 응답에서 예수금 부족 에러 코드 식별 → 명확한 에러 이벤트로 변환
- [x] `OrderFailedEvent`에 실패 사유(`error_code`) 포함
- [x] Treasury 예약 자금 자동 해제 (기존 `_on_order_failed` 핸들러 — 변경 없이 동작)
- [x] 잔여예산 > 매수가능금액 경고 데이터 제공 (`budget_exceeds_purchasable`)
- [ ] 대시보드 UI 경고 배지 — 목업 존재, 프론트엔드 구현은 후속 이슈

## Test plan
- [x] APIError 주문 실패 시 error_code 전달 확인
- [x] 일반 Exception 실패 시 error_code 빈 문자열 확인
- [x] `is_insufficient_deposit()` 판별 함수 테스트
- [x] `INSUFFICIENT_DEPOSIT_CODE` 상수 확인
- [x] 잔여예산 > 매수가능금액 경고 플래그 테스트
- [x] 매수가능금액 0일 때 경고 미표시 테스트
- [x] 전체 테스트 1133 passed

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)