### PR TITLE
feat: 멤버 범용 감사 로그(Audit Log) 테이블 신설

### DIFF
--- a/src/ante/audit/__init__.py
+++ b/src/ante/audit/__init__.py
@@ -1,0 +1,5 @@
+"""Audit — 감사 로그 기록 및 조회."""
+
+from ante.audit.logger import AuditLogger
+
+__all__ = ["AuditLogger"]

--- a/src/ante/audit/logger.py
+++ b/src/ante/audit/logger.py
@@ -1,0 +1,104 @@
+"""감사 로그 서비스."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from ante.core.database import Database
+
+logger = logging.getLogger(__name__)
+
+AUDIT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS audit_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    member_id   TEXT NOT NULL,
+    action      TEXT NOT NULL,
+    resource    TEXT NOT NULL DEFAULT '',
+    detail      TEXT DEFAULT '',
+    ip          TEXT DEFAULT '',
+    created_at  TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_audit_member ON audit_log(member_id);
+CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_log(action);
+CREATE INDEX IF NOT EXISTS idx_audit_created ON audit_log(created_at);
+"""
+
+
+class AuditLogger:
+    """멤버 액션 감사 로그 기록 및 조회."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    async def initialize(self) -> None:
+        """audit_log 테이블 생성."""
+        await self._db.execute_script(AUDIT_SCHEMA)
+        logger.info("AuditLogger 초기화 완료")
+
+    async def log(
+        self,
+        *,
+        member_id: str,
+        action: str,
+        resource: str = "",
+        detail: str = "",
+        ip: str = "",
+    ) -> None:
+        """감사 로그 기록."""
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+        await self._db.execute(
+            """INSERT INTO audit_log
+               (member_id, action, resource, detail, ip, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (member_id, action, resource, detail, ip, now),
+        )
+        logger.debug("감사 로그: %s %s %s", member_id, action, resource)
+
+    async def query(
+        self,
+        *,
+        member_id: str | None = None,
+        action: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict]:
+        """감사 로그 조회. 최신순."""
+        conditions: list[str] = []
+        params: list[str | int] = []
+
+        if member_id:
+            conditions.append("member_id = ?")
+            params.append(member_id)
+        if action:
+            conditions.append("action LIKE ?")
+            params.append(f"{action}%")
+
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        sql = f"""SELECT id, member_id, action, resource, detail, ip, created_at
+                  FROM audit_log {where}
+                  ORDER BY id DESC LIMIT ? OFFSET ?"""
+        params.extend([limit, offset])
+        return await self._db.fetch_all(sql, tuple(params))
+
+    async def count(
+        self,
+        *,
+        member_id: str | None = None,
+        action: str | None = None,
+    ) -> int:
+        """감사 로그 건수 조회."""
+        conditions: list[str] = []
+        params: list[str] = []
+
+        if member_id:
+            conditions.append("member_id = ?")
+            params.append(member_id)
+        if action:
+            conditions.append("action LIKE ?")
+            params.append(f"{action}%")
+
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        sql = f"SELECT COUNT(*) as cnt FROM audit_log {where}"
+        row = await self._db.fetch_one(sql, tuple(params))
+        return row["cnt"] if row else 0

--- a/src/ante/cli/commands/audit.py
+++ b/src/ante/cli/commands/audit.py
@@ -1,0 +1,70 @@
+"""ante audit — 감사 로그 조회 커맨드."""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+from ante.cli.main import get_formatter
+from ante.cli.middleware import require_auth, require_scope
+
+
+@click.group()
+def audit() -> None:
+    """감사 로그 조회."""
+
+
+def _run(coro):  # noqa: ANN001, ANN202
+    return asyncio.run(coro)
+
+
+@audit.command("list")
+@click.option("--member", "member_id", default=None, help="멤버 ID 필터")
+@click.option("--action", default=None, help="액션 필터 (prefix 매칭)")
+@click.option("--limit", default=20, type=click.IntRange(1, 200), help="조회 건수")
+@click.option("--offset", default=0, type=int, help="오프셋")
+@click.pass_context
+@require_auth
+@require_scope("audit:read")
+def audit_list(
+    ctx: click.Context,
+    member_id: str | None,
+    action: str | None,
+    limit: int,
+    offset: int,
+) -> None:
+    """감사 로그 목록 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _run_list() -> list[dict]:
+        from ante.audit import AuditLogger
+        from ante.core.database import Database
+
+        db = Database("db/ante.db")
+        await db.connect()
+        try:
+            audit_logger = AuditLogger(db)
+            await audit_logger.initialize()
+            return await audit_logger.query(
+                member_id=member_id,
+                action=action,
+                limit=limit,
+                offset=offset,
+            )
+        finally:
+            await db.close()
+
+    result = _run(_run_list())
+
+    if not result:
+        fmt.output({"message": "감사 로그가 없습니다.", "logs": []})
+        return
+
+    if fmt.is_json:
+        fmt.output({"logs": result})
+    else:
+        fmt.table(
+            result,
+            ["id", "member_id", "action", "resource", "created_at"],
+        )

--- a/src/ante/cli/main.py
+++ b/src/ante/cli/main.py
@@ -33,6 +33,7 @@ def get_formatter(ctx: click.Context) -> OutputFormatter:
 
 # 서브커맨드 등록
 from ante.cli.commands.approval import approval  # noqa: E402
+from ante.cli.commands.audit import audit  # noqa: E402
 from ante.cli.commands.backtest import backtest  # noqa: E402
 from ante.cli.commands.bot import bot  # noqa: E402
 from ante.cli.commands.broker import broker  # noqa: E402
@@ -49,6 +50,7 @@ from ante.cli.commands.system import system  # noqa: E402
 from ante.cli.commands.trade import trade  # noqa: E402
 from ante.cli.commands.treasury import treasury  # noqa: E402
 
+cli.add_command(audit)
 cli.add_command(approval)
 cli.add_command(bot)
 cli.add_command(broker)

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -84,14 +84,21 @@ async def main() -> None:
     eventbus.subscribe(ConfigChangedEvent, _on_log_level_changed)
     logger.info("DynamicConfigService 초기화 완료")
 
-    # ── 5.5. MemberService ─────────────────────────────
+    # ── 5.5. AuditLogger ────────────────────────────────
+    from ante.audit import AuditLogger
+
+    audit_logger = AuditLogger(db=db)
+    await audit_logger.initialize()
+    logger.info("AuditLogger 초기화 완료")
+
+    # ── 5.6. MemberService ─────────────────────────────
     from ante.member import MemberService
 
     member_service = MemberService(db=db, eventbus=eventbus)
     await member_service.initialize()
     logger.info("MemberService 초기화 완료")
 
-    # ── 5.6. InstrumentService ─────────────────────────
+    # ── 5.7. InstrumentService ─────────────────────────
     from ante.instrument import InstrumentService
 
     instrument_service = InstrumentService(db=db)
@@ -396,6 +403,7 @@ async def main() -> None:
             report_store=report_store,
             data_catalog=data_catalog,
             data_store=parquet_store,
+            audit_logger=audit_logger,
         )
 
         import uvicorn

--- a/src/ante/web/app.py
+++ b/src/ante/web/app.py
@@ -32,6 +32,7 @@ def create_app(**services: Any) -> FastAPI:
     for name, service in services.items():
         setattr(app.state, name, service)
 
+    from ante.web.routes.audit import router as audit_router
     from ante.web.routes.bots import router as bots_router
     from ante.web.routes.data import router as data_router
     from ante.web.routes.notifications import router as notifications_router
@@ -41,6 +42,7 @@ def create_app(**services: Any) -> FastAPI:
     from ante.web.routes.trades import router as trades_router
     from ante.web.routes.treasury import router as treasury_router
 
+    app.include_router(audit_router, prefix="/api/audit", tags=["audit"])
     app.include_router(system_router, prefix="/api/system", tags=["system"])
     app.include_router(strategy_router, prefix="/api/strategies", tags=["strategies"])
     app.include_router(report_router, prefix="/api/reports", tags=["reports"])

--- a/src/ante/web/routes/audit.py
+++ b/src/ante/web/routes/audit.py
@@ -1,0 +1,30 @@
+"""감사 로그 API."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+router = APIRouter()
+
+
+@router.get("")
+async def list_audit_logs(
+    request: Request,
+    member_id: str | None = None,
+    action: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict:
+    """감사 로그 조회."""
+    audit_logger = getattr(request.app.state, "audit_logger", None)
+    if audit_logger is None:
+        raise HTTPException(status_code=503, detail="Audit logger not available")
+
+    logs = await audit_logger.query(
+        member_id=member_id,
+        action=action,
+        limit=limit,
+        offset=offset,
+    )
+    total = await audit_logger.count(member_id=member_id, action=action)
+    return {"logs": logs, "total": total}

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -1,0 +1,156 @@
+"""감사 로그(AuditLogger) 단위 테스트."""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.audit import AuditLogger
+from ante.core.database import Database
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """임시 파일 DB."""
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+async def audit_logger(db: Database) -> AuditLogger:
+    """AuditLogger 인스턴스."""
+    al = AuditLogger(db=db)
+    await al.initialize()
+    return al
+
+
+# ── 기록 ─────────────────────────────────────────
+
+
+class TestAuditLog:
+    """감사 로그 기록 테스트."""
+
+    async def test_log_and_query(self, audit_logger: AuditLogger) -> None:
+        """로그 기록 후 조회."""
+        await audit_logger.log(
+            member_id="agent-01",
+            action="bot.create",
+            resource="bot:bot-momentum-01",
+            detail='{"strategy": "momentum_v1"}',
+        )
+        logs = await audit_logger.query()
+        assert len(logs) == 1
+        assert logs[0]["member_id"] == "agent-01"
+        assert logs[0]["action"] == "bot.create"
+        assert logs[0]["resource"] == "bot:bot-momentum-01"
+
+    async def test_log_multiple(self, audit_logger: AuditLogger) -> None:
+        """여러 건 기록 후 최신순 조회."""
+        await audit_logger.log(member_id="user-01", action="auth.login")
+        await audit_logger.log(member_id="user-01", action="bot.create")
+        await audit_logger.log(member_id="agent-01", action="report.submitted")
+
+        logs = await audit_logger.query()
+        assert len(logs) == 3
+        # 최신순 (id DESC)
+        assert logs[0]["action"] == "report.submitted"
+        assert logs[2]["action"] == "auth.login"
+
+    async def test_log_with_ip(self, audit_logger: AuditLogger) -> None:
+        """IP 주소 포함 기록."""
+        await audit_logger.log(
+            member_id="user-01",
+            action="auth.login",
+            ip="127.0.0.1",
+        )
+        logs = await audit_logger.query()
+        assert logs[0]["ip"] == "127.0.0.1"
+
+
+# ── 필터 조회 ────────────────────────────────────
+
+
+class TestAuditQuery:
+    """감사 로그 필터 조회 테스트."""
+
+    async def test_filter_by_member(self, audit_logger: AuditLogger) -> None:
+        """member_id로 필터링."""
+        await audit_logger.log(member_id="user-01", action="auth.login")
+        await audit_logger.log(member_id="agent-01", action="bot.create")
+
+        logs = await audit_logger.query(member_id="agent-01")
+        assert len(logs) == 1
+        assert logs[0]["member_id"] == "agent-01"
+
+    async def test_filter_by_action_prefix(self, audit_logger: AuditLogger) -> None:
+        """action prefix로 필터링."""
+        await audit_logger.log(member_id="user-01", action="auth.login")
+        await audit_logger.log(member_id="user-01", action="auth.failed")
+        await audit_logger.log(member_id="user-01", action="bot.create")
+
+        logs = await audit_logger.query(action="auth")
+        assert len(logs) == 2
+
+    async def test_filter_combined(self, audit_logger: AuditLogger) -> None:
+        """member_id + action 복합 필터."""
+        await audit_logger.log(member_id="user-01", action="auth.login")
+        await audit_logger.log(member_id="agent-01", action="auth.login")
+        await audit_logger.log(member_id="agent-01", action="bot.create")
+
+        logs = await audit_logger.query(member_id="agent-01", action="auth")
+        assert len(logs) == 1
+        assert logs[0]["member_id"] == "agent-01"
+        assert logs[0]["action"] == "auth.login"
+
+    async def test_limit_and_offset(self, audit_logger: AuditLogger) -> None:
+        """페이지네이션 (limit, offset)."""
+        for i in range(10):
+            await audit_logger.log(member_id="user-01", action=f"action.{i}")
+
+        page1 = await audit_logger.query(limit=3, offset=0)
+        assert len(page1) == 3
+
+        page2 = await audit_logger.query(limit=3, offset=3)
+        assert len(page2) == 3
+        assert page1[0]["id"] != page2[0]["id"]
+
+
+# ── 건수 조회 ────────────────────────────────────
+
+
+class TestAuditCount:
+    """감사 로그 건수 조회."""
+
+    async def test_count_all(self, audit_logger: AuditLogger) -> None:
+        """전체 건수."""
+        for _ in range(5):
+            await audit_logger.log(member_id="user-01", action="auth.login")
+        assert await audit_logger.count() == 5
+
+    async def test_count_filtered(self, audit_logger: AuditLogger) -> None:
+        """필터 건수."""
+        await audit_logger.log(member_id="user-01", action="auth.login")
+        await audit_logger.log(member_id="agent-01", action="bot.create")
+
+        assert await audit_logger.count(member_id="user-01") == 1
+        assert await audit_logger.count(action="bot") == 1
+
+    async def test_count_empty(self, audit_logger: AuditLogger) -> None:
+        """빈 테이블."""
+        assert await audit_logger.count() == 0
+
+
+# ── 스키마 멱등성 ────────────────────────────────
+
+
+class TestAuditInit:
+    """초기화 멱등성."""
+
+    async def test_initialize_idempotent(self, db: Database) -> None:
+        """initialize()를 여러 번 호출해도 안전."""
+        al = AuditLogger(db=db)
+        await al.initialize()
+        await al.initialize()
+        await al.log(member_id="test", action="test.action")
+        assert await al.count() == 1


### PR DESCRIPTION
## Summary
- `AuditLogger` 서비스 클래스 신설 (`src/ante/audit/`) — `log()`, `query()`, `count()` 메서드
- `audit_log` 테이블 스키마 (member_id, action, resource, detail, ip, created_at)
- Web API: `GET /api/audit` — member_id, action 필터 + limit/offset 페이지네이션
- CLI: `ante audit list` — `--member`, `--action`, `--limit`, `--offset` 옵션
- Composition Root (`main.py`)에 AuditLogger 초기화 및 Web 서비스 주입

Closes #144

## Test plan
- [x] 로그 기록 및 조회 (단건/복수건)
- [x] member_id, action prefix 필터링
- [x] 복합 필터 (member + action)
- [x] limit/offset 페이지네이션
- [x] 건수 조회 (전체/필터/빈 테이블)
- [x] 스키마 초기화 멱등성
- [x] 전체 테스트 1153 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)