### PR TITLE
refactor: BotConfig에서 symbols 필드 제거

### DIFF
--- a/src/ante/bot/config.py
+++ b/src/ante/bot/config.py
@@ -29,7 +29,6 @@ class BotConfig:
     strategy_id: str
     bot_type: str = "live"
     interval_seconds: int = 60
-    symbols: list[str] | None = None
     paper_initial_balance: float = 10_000_000.0
     exchange: str = "KRX"
     auto_restart: bool = True

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -432,7 +432,6 @@ class BotManager:
             "strategy_id": config.strategy_id,
             "bot_type": config.bot_type,
             "interval_seconds": config.interval_seconds,
-            "symbols": config.symbols,
             "paper_initial_balance": config.paper_initial_balance,
         }
         await self._db.execute(

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -128,7 +128,6 @@ def _parse_param(value: str) -> tuple[str, object]:
     type=click.IntRange(10, 3600),
     help="실행 주기 (초, 10-3600)",
 )
-@click.option("--symbols", default="", help="대상 종목 (쉼표 구분)")
 @click.option("--id", "bot_id", default="", help="봇 ID (미지정 시 자동 생성)")
 @click.option(
     "--param",
@@ -144,7 +143,6 @@ def bot_create(
     strategy: str,
     bot_type: str,
     interval: int,
-    symbols: str,
     bot_id: str,
     params: tuple[str, ...],
 ) -> None:
@@ -168,13 +166,11 @@ def bot_create(
         db, _, _ = await _create_services()
         try:
             bid = bot_id or f"bot-{uuid4().hex[:8]}"
-            symbol_list = [s.strip() for s in symbols.split(",") if s.strip()] or None
             config_dict: dict = {
                 "bot_id": bid,
                 "strategy_id": strategy,
                 "bot_type": bot_type,
                 "interval_seconds": interval,
-                "symbols": symbol_list,
             }
             if param_dict:
                 config_dict["params"] = param_dict

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -14,7 +14,6 @@ class BotCreateRequest(BaseModel):
     strategy_id: str
     bot_type: str = "live"
     interval_seconds: int = Field(default=60, ge=10, le=3600)
-    symbols: list[str] | None = None
 
 
 class BotUpdateRequest(BaseModel):


### PR DESCRIPTION
## Summary
- `BotConfig.symbols` 필드 제거
- CLI `bot create --symbols` 옵션 제거
- Web API `BotCreateRequest.symbols` 필드 제거
- `BotManager._save_bot_config()`에서 symbols 직렬화 제거

종목 선정은 전략의 핵심 판단 영역이므로, 시스템이 아닌 전략에 전권 위임 (설계 철학 준수).

Closes #137

## Test plan
- [x] 전체 테스트 1147 passed (기존 테스트 영향 없음)
- [x] ruff lint/format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)