### PR TITLE
feat: Strategy.get_param_schema() 메서드 추가

### DIFF
--- a/src/ante/strategy/base.py
+++ b/src/ante/strategy/base.py
@@ -175,3 +175,7 @@ class Strategy(ABC):
     def get_params(self) -> dict[str, Any]:
         """백테스트 최적화 파라미터 반환."""
         return {}
+
+    def get_param_schema(self) -> dict[str, str]:
+        """파라미터 설명 반환. {파라미터명: 설명} 형식."""
+        return {}

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -121,6 +121,43 @@ class TestStrategyABC:
         result = await s.on_data({})
         assert result == []
 
+    def test_default_get_param_schema_returns_empty(self):
+        """get_param_schema 기본 구현은 빈 dict 반환."""
+
+        class S(Strategy):
+            meta = StrategyMeta(name="x", version="1.0.0", description="x")
+
+            async def on_step(self, context):
+                return []
+
+        s = S(ctx=None)
+        assert s.get_param_schema() == {}
+
+    def test_get_param_schema_with_descriptions(self):
+        """전략이 파라미터 설명을 제공할 수 있다."""
+
+        class S(Strategy):
+            meta = StrategyMeta(name="x", version="1.0.0", description="x")
+
+            async def on_step(self, context):
+                return []
+
+            def get_params(self):
+                return {"lookback": 20, "atr_mul": 2.5}
+
+            def get_param_schema(self):
+                return {
+                    "lookback": "고점 탐색 기간 (일)",
+                    "atr_mul": "ATR 배수",
+                }
+
+        s = S(ctx=None)
+        schema = s.get_param_schema()
+        assert schema["lookback"] == "고점 탐색 기간 (일)"
+        assert schema["atr_mul"] == "ATR 배수"
+        # params와 schema 키가 일치
+        assert set(s.get_params().keys()) == set(schema.keys())
+
 
 # ── StrategyContext ────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `Strategy` ABC에 `get_param_schema() -> dict[str, str]` 메서드 추가
- 전략이 파라미터의 설명을 `{키: 설명}` 형태로 제공 가능
- 기본 구현은 빈 dict 반환 (기존 전략 호환성 유지)
- 대시보드에서 `get_params()` 값 + `get_param_schema()` 설명을 함께 렌더링 가능

Closes #147

## Test plan
- [x] 기본 구현 빈 dict 반환 테스트
- [x] 전략이 설명을 오버라이드하여 제공하는 테스트
- [x] params 키와 schema 키 일치 검증
- [x] 전체 테스트 1160 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)