### PR TITLE
feat: 외부 거래 포지션 불일치 감지 및 자동 보정

### DIFF
--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -304,6 +304,17 @@ class BacktestCompleteEvent(Event):
 
 
 @dataclass(frozen=True)
+class PositionMismatchEvent(Event):
+    """포지션 불일치 감지."""
+
+    bot_id: str = ""
+    symbol: str = ""
+    internal_qty: float = 0.0
+    broker_qty: float = 0.0
+    reason: str = ""
+
+
+@dataclass(frozen=True)
 class ReconcileEvent(Event):
     """Reconciler → EventBus: 대사 보정 완료."""
 

--- a/src/ante/notification/service.py
+++ b/src/ante/notification/service.py
@@ -78,6 +78,7 @@ class NotificationService:
             NotificationEvent,
             OrderCancelFailedEvent,
             OrderFilledEvent,
+            PositionMismatchEvent,
             TradingStateChangedEvent,
         )
 
@@ -102,6 +103,11 @@ class NotificationService:
         self._eventbus.subscribe(
             CircuitBreakerEvent,
             self._on_circuit_breaker,
+            priority=0,
+        )
+        self._eventbus.subscribe(
+            PositionMismatchEvent,
+            self._on_position_mismatch,
             priority=0,
         )
 
@@ -300,6 +306,26 @@ class NotificationService:
                 metadata=event.metadata or None,
                 event_type="NotificationEvent",
             )
+
+    async def _on_position_mismatch(self, event: object) -> None:
+        """포지션 불일치 감지 알림 (critical)."""
+        from ante.eventbus.events import PositionMismatchEvent
+
+        if not isinstance(event, PositionMismatchEvent):
+            return
+
+        msg = (
+            f"포지션 불일치 [{event.bot_id}] {event.symbol}: "
+            f"내부={event.internal_qty:.0f}주, "
+            f"브로커={event.broker_qty:.0f}주 "
+            f"({event.reason})"
+        )
+        await self._send_and_record(
+            NotificationLevel.CRITICAL,
+            msg,
+            event_type="PositionMismatchEvent",
+            bot_id=event.bot_id,
+        )
 
     async def _on_bot_error(self, event: object) -> None:
         """봇 에러 자동 알림."""

--- a/src/ante/trade/__init__.py
+++ b/src/ante/trade/__init__.py
@@ -11,6 +11,7 @@ from ante.trade.models import (
 )
 from ante.trade.performance import PerformanceTracker
 from ante.trade.position import PositionHistory
+from ante.trade.reconciler import PositionReconciler
 from ante.trade.recorder import TradeRecorder
 from ante.trade.service import TradeService
 
@@ -20,6 +21,7 @@ __all__ = [
     "PerformanceMetrics",
     "PerformanceTracker",
     "PositionHistory",
+    "PositionReconciler",
     "PositionSnapshot",
     "TradeRecord",
     "TradeRecorder",

--- a/src/ante/trade/reconciler.py
+++ b/src/ante/trade/reconciler.py
@@ -1,0 +1,130 @@
+"""포지션 정합성 검증 및 자동 보정."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ante.eventbus.bus import EventBus
+    from ante.trade.service import TradeService
+
+logger = logging.getLogger(__name__)
+
+
+class PositionReconciler:
+    """브로커 실제 포지션과 내부 포지션의 불일치를 감지하고 보정한다."""
+
+    def __init__(
+        self,
+        trade_service: TradeService,
+        eventbus: EventBus,
+    ) -> None:
+        self._trade_service = trade_service
+        self._eventbus = eventbus
+
+    async def reconcile(
+        self,
+        bot_id: str,
+        broker_positions: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """봇의 내부 포지션과 브로커 포지션을 대조하여 보정.
+
+        Args:
+            bot_id: 대상 봇 ID.
+            broker_positions: 브로커 실제 보유.
+                [{"symbol": str, "quantity": float, "avg_price": float}, ...]
+
+        Returns:
+            보정 내역 리스트. 불일치가 없으면 빈 리스트.
+        """
+        from ante.eventbus.events import (
+            PositionMismatchEvent,
+            ReconcileEvent,
+        )
+
+        internal = await self._trade_service.get_positions(bot_id)
+        internal_map: dict[str, dict[str, float]] = {
+            p.symbol: {
+                "quantity": p.quantity,
+                "avg_price": p.avg_entry_price,
+            }
+            for p in internal
+            if p.quantity > 0
+        }
+
+        broker_map: dict[str, dict[str, float]] = {
+            p["symbol"]: {
+                "quantity": p["quantity"],
+                "avg_price": p.get("avg_price", 0.0),
+            }
+            for p in broker_positions
+            if p["quantity"] > 0
+        }
+
+        corrections: list[dict[str, Any]] = []
+
+        # 내부에는 있지만 브로커에 없거나 수량 불일치
+        all_symbols = set(internal_map.keys()) | set(broker_map.keys())
+
+        for symbol in all_symbols:
+            i_qty = internal_map.get(symbol, {}).get("quantity", 0.0)
+            b_qty = broker_map.get(symbol, {}).get("quantity", 0.0)
+            b_avg = broker_map.get(symbol, {}).get("avg_price", 0.0)
+
+            if i_qty == b_qty:
+                continue
+
+            # 불일치 감지
+            if b_qty == 0 and i_qty > 0:
+                reason = "외부 청산"
+            elif b_qty < i_qty:
+                reason = "외부 일부 매도"
+            elif b_qty > i_qty:
+                reason = "외부 매수"
+            else:
+                reason = "수량 불일치"
+
+            logger.warning(
+                "포지션 불일치 [%s] %s: 내부=%.2f, 브로커=%.2f → %s",
+                bot_id,
+                symbol,
+                i_qty,
+                b_qty,
+                reason,
+            )
+
+            await self._eventbus.publish(
+                PositionMismatchEvent(
+                    bot_id=bot_id,
+                    symbol=symbol,
+                    internal_qty=i_qty,
+                    broker_qty=b_qty,
+                    reason=reason,
+                )
+            )
+
+            correction = await self._trade_service.correct_position(
+                bot_id=bot_id,
+                symbol=symbol,
+                quantity=b_qty,
+                avg_price=b_avg if b_avg > 0 else None,
+                reason=reason,
+            )
+            corrections.append(correction)
+
+        if corrections:
+            logger.info(
+                "포지션 보정 완료 [%s]: %d건",
+                bot_id,
+                len(corrections),
+            )
+            await self._eventbus.publish(
+                ReconcileEvent(
+                    bot_id=bot_id,
+                    discrepancy_count=len(corrections),
+                    corrections=corrections,
+                )
+            )
+
+        return corrections

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -1,0 +1,198 @@
+"""PositionReconciler 단위 테스트."""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.core.database import Database
+from ante.eventbus.bus import EventBus
+from ante.eventbus.events import PositionMismatchEvent, ReconcileEvent
+from ante.trade.performance import PerformanceTracker
+from ante.trade.position import PositionHistory
+from ante.trade.reconciler import PositionReconciler
+from ante.trade.recorder import TradeRecorder
+from ante.trade.service import TradeService
+
+# ── Fixtures ─────────────────────────────────────────
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+async def position_history(db):
+    ph = PositionHistory(db)
+    await ph.initialize()
+    return ph
+
+
+@pytest.fixture
+async def recorder(db, position_history):
+    rec = TradeRecorder(db, position_history)
+    await rec.initialize()
+    return rec
+
+
+@pytest.fixture
+async def service(recorder, position_history):
+    perf = PerformanceTracker(recorder._db)
+    return TradeService(recorder, position_history, perf)
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+def reconciler(service, eventbus):
+    return PositionReconciler(trade_service=service, eventbus=eventbus)
+
+
+async def _set_position(position_history, bot_id, symbol, qty, avg_price):
+    """테스트용 포지션 설정."""
+    await position_history.force_update(
+        bot_id=bot_id,
+        symbol=symbol,
+        quantity=qty,
+        avg_entry_price=avg_price,
+    )
+
+
+# ── 시나리오 1: 전량 외부 매도 ─────────────────────
+
+
+class TestFullExternalSell:
+    async def test_full_sell_detected_and_corrected(
+        self, reconciler, position_history, eventbus
+    ):
+        """내부 50주, 브로커 0주 → 포지션 0주로 보정."""
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+
+        mismatch_events: list = []
+        reconcile_events: list = []
+        eventbus.subscribe(PositionMismatchEvent, lambda e: mismatch_events.append(e))
+        eventbus.subscribe(ReconcileEvent, lambda e: reconcile_events.append(e))
+
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[],  # 브로커에 없음
+        )
+
+        assert len(corrections) == 1
+        assert corrections[0]["old_quantity"] == 50
+        assert corrections[0]["new_quantity"] == 0
+        assert corrections[0]["reason"] == "외부 청산"
+
+        # 이벤트 발행 확인
+        assert len(mismatch_events) == 1
+        assert mismatch_events[0].symbol == "005930"
+        assert mismatch_events[0].internal_qty == 50
+        assert mismatch_events[0].broker_qty == 0
+
+        assert len(reconcile_events) == 1
+        assert reconcile_events[0].discrepancy_count == 1
+
+        # 포지션 실제로 0주로 변경됨
+        pos = await position_history.get_current("bot-1", "005930")
+        assert pos["quantity"] == 0
+
+
+# ── 시나리오 2: 일부 외부 매도 ─────────────────────
+
+
+class TestPartialExternalSell:
+    async def test_partial_sell_corrected(self, reconciler, position_history):
+        """내부 50주, 브로커 30주 → 30주로 보정."""
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "005930", "quantity": 30, "avg_price": 50000},
+            ],
+        )
+
+        assert len(corrections) == 1
+        assert corrections[0]["old_quantity"] == 50
+        assert corrections[0]["new_quantity"] == 30
+        assert corrections[0]["reason"] == "외부 일부 매도"
+
+
+# ── 시나리오 3: 불일치 없음 ────────────────────────
+
+
+class TestNoMismatch:
+    async def test_no_correction_when_matched(
+        self, reconciler, position_history, eventbus
+    ):
+        """포지션 일치 시 보정 없음."""
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+
+        reconcile_events: list = []
+        eventbus.subscribe(ReconcileEvent, lambda e: reconcile_events.append(e))
+
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "005930", "quantity": 50, "avg_price": 50000},
+            ],
+        )
+
+        assert corrections == []
+        assert len(reconcile_events) == 0
+
+    async def test_no_correction_both_empty(self, reconciler):
+        """내부/브로커 모두 빈 포지션."""
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[],
+        )
+        assert corrections == []
+
+
+# ── 시나리오 4: 외부 매수 ──────────────────────────
+
+
+class TestExternalBuy:
+    async def test_external_buy_detected(self, reconciler, position_history):
+        """내부 0주, 브로커 20주 → 외부 매수로 보정."""
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "005930", "quantity": 20, "avg_price": 55000},
+            ],
+        )
+
+        assert len(corrections) == 1
+        assert corrections[0]["new_quantity"] == 20
+        assert corrections[0]["reason"] == "외부 매수"
+
+
+# ── 시나리오 5: 복수 종목 불일치 ───────────────────
+
+
+class TestMultipleSymbols:
+    async def test_multiple_corrections(self, reconciler, position_history, eventbus):
+        """여러 종목 동시 불일치."""
+        await _set_position(position_history, "bot-1", "005930", 50, 50000)
+        await _set_position(position_history, "bot-1", "000660", 30, 80000)
+
+        mismatch_events: list = []
+        eventbus.subscribe(PositionMismatchEvent, lambda e: mismatch_events.append(e))
+
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[
+                {"symbol": "005930", "quantity": 0, "avg_price": 0},
+                # 000660 은 브로커에 없음
+            ],
+        )
+
+        assert len(corrections) == 2
+        assert len(mismatch_events) == 2


### PR DESCRIPTION
## Summary
- `PositionReconciler` 서비스 클래스 신설 (`src/ante/trade/reconciler.py`)
  - 브로커 실제 포지션과 내부 포지션 비교
  - 불일치 감지 시 `TradeService.correct_position()` 호출하여 자동 보정
  - 보정 사유 분류: 외부 청산 / 외부 일부 매도 / 외부 매수
- `PositionMismatchEvent` 이벤트 추가 (bot_id, symbol, 내부/브로커 수량, 사유)
- `NotificationService`에 포지션 불일치 CRITICAL 알림 구독 추가
- Trade 모듈 export에 `PositionReconciler` 추가

Closes #142

## Test plan
- [x] 전량 외부 매도 감지 + 보정 (50→0)
- [x] 일부 외부 매도 감지 + 보정 (50→30)
- [x] 포지션 일치 시 보정 없음
- [x] 양쪽 모두 빈 포지션 (no-op)
- [x] 외부 매수 감지 (0→20)
- [x] 복수 종목 동시 불일치 보정
- [x] PositionMismatchEvent / ReconcileEvent 발행 확인
- [x] 전체 테스트 1164 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)