### PR TITLE
feat: BotConfig에 name 필드 추가

### DIFF
--- a/src/ante/bot/bot.py
+++ b/src/ante/bot/bot.py
@@ -337,6 +337,7 @@ class Bot:
         """봇 상태 정보 반환."""
         return {
             "bot_id": self.bot_id,
+            "name": self.config.name,
             "status": self.status.value,
             "bot_type": self.config.bot_type,
             "strategy_id": self.config.strategy_id,

--- a/src/ante/bot/config.py
+++ b/src/ante/bot/config.py
@@ -27,6 +27,7 @@ class BotConfig:
 
     bot_id: str
     strategy_id: str
+    name: str = ""
     bot_type: str = "live"
     interval_seconds: int = 60
     paper_initial_balance: float = 10_000_000.0

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 BOT_SCHEMA = """
 CREATE TABLE IF NOT EXISTS bots (
     bot_id       TEXT PRIMARY KEY,
+    name         TEXT NOT NULL DEFAULT '',
     strategy_id  TEXT NOT NULL,
     bot_type     TEXT NOT NULL DEFAULT 'live',
     config_json  TEXT NOT NULL,
@@ -429,6 +430,7 @@ class BotManager:
         """봇 설정 DB 저장."""
         config_dict = {
             "bot_id": config.bot_id,
+            "name": config.name,
             "strategy_id": config.strategy_id,
             "bot_type": config.bot_type,
             "interval_seconds": config.interval_seconds,
@@ -436,13 +438,15 @@ class BotManager:
         }
         await self._db.execute(
             """INSERT INTO bots
-               (bot_id, strategy_id, bot_type, config_json)
-               VALUES (?, ?, ?, ?)
+               (bot_id, name, strategy_id, bot_type, config_json)
+               VALUES (?, ?, ?, ?, ?)
                ON CONFLICT(bot_id) DO UPDATE SET
+                 name = excluded.name,
                  config_json = excluded.config_json,
                  updated_at = datetime('now')""",
             (
                 config.bot_id,
+                config.name,
                 config.strategy_id,
                 config.bot_type,
                 json.dumps(config_dict),

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -44,7 +44,8 @@ def bot_list(ctx: click.Context) -> None:
         db, _, _ = await _create_services()
         try:
             rows = await db.fetch_all(
-                "SELECT bot_id, strategy_id, bot_type, status, created_at FROM bots"
+                "SELECT bot_id, name, strategy_id, bot_type, status, created_at"
+                " FROM bots"
             )
             return [dict(r) for r in rows]
         finally:
@@ -61,7 +62,7 @@ def bot_list(ctx: click.Context) -> None:
     else:
         fmt.table(
             result,
-            ["bot_id", "strategy_id", "bot_type", "status", "created_at"],
+            ["bot_id", "name", "strategy_id", "bot_type", "status", "created_at"],
         )
 
 
@@ -92,6 +93,7 @@ def bot_info(ctx: click.Context, bot_id: str) -> None:
         fmt.output(result)
     else:
         click.echo(f"  Bot ID    : {result['bot_id']}")
+        click.echo(f"  이름      : {result['name']}")
         click.echo(f"  전략      : {result['strategy_id']}")
         click.echo(f"  타입      : {result['bot_type']}")
         click.echo(f"  상태      : {result['status']}")
@@ -114,6 +116,7 @@ def _parse_param(value: str) -> tuple[str, object]:
 
 
 @bot.command("create")
+@click.option("--name", required=True, help="봇 이름")
 @click.option("--strategy", required=True, help="전략 ID")
 @click.option(
     "--type",
@@ -140,6 +143,7 @@ def _parse_param(value: str) -> tuple[str, object]:
 @require_scope("bot:admin")
 def bot_create(
     ctx: click.Context,
+    name: str,
     strategy: str,
     bot_type: str,
     interval: int,
@@ -168,6 +172,7 @@ def bot_create(
             bid = bot_id or f"bot-{uuid4().hex[:8]}"
             config_dict: dict = {
                 "bot_id": bid,
+                "name": name,
                 "strategy_id": strategy,
                 "bot_type": bot_type,
                 "interval_seconds": interval,
@@ -175,9 +180,10 @@ def bot_create(
             if param_dict:
                 config_dict["params"] = param_dict
             await db.execute(
-                """INSERT INTO bots (bot_id, strategy_id, bot_type, config_json)
-                   VALUES (?, ?, ?, ?)""",
-                (bid, strategy, bot_type, json.dumps(config_dict)),
+                """INSERT INTO bots
+                   (bot_id, name, strategy_id, bot_type, config_json)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (bid, name, strategy, bot_type, json.dumps(config_dict)),
             )
             return config_dict
         finally:

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -11,6 +11,7 @@ router = APIRouter()
 class BotCreateRequest(BaseModel):
     """봇 생성 요청."""
 
+    name: str
     strategy_id: str
     bot_type: str = "live"
     interval_seconds: int = Field(default=60, ge=10, le=3600)

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -144,8 +144,14 @@ class TestBotConfig:
     def test_defaults(self):
         """BotConfig 기본값."""
         c = BotConfig(bot_id="b1", strategy_id="s1")
+        assert c.name == ""
         assert c.bot_type == "live"
         assert c.interval_seconds == 60
+
+    def test_name_field(self):
+        """BotConfig name 필드 설정."""
+        c = BotConfig(bot_id="b1", strategy_id="s1", name="테스트 봇")
+        assert c.name == "테스트 봇"
 
     def test_bot_status_values(self):
         """BotStatus 값."""
@@ -434,7 +440,25 @@ class TestBot:
         )
         info = bot.get_info()
         assert info["bot_id"] == "bot1"
+        assert info["name"] == ""
         assert info["status"] == "created"
+
+    def test_get_info_with_name(self, eventbus, ctx):
+        """이름이 설정된 봇의 정보 반환."""
+        config = BotConfig(
+            bot_id="bot1",
+            strategy_id="s1",
+            name="모멘텀 봇",
+            interval_seconds=10,
+        )
+        bot = Bot(
+            config=config,
+            strategy_cls=SimpleStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        info = bot.get_info()
+        assert info["name"] == "모멘텀 봇"
 
 
 # ── BotManager ───────────────────────────────────
@@ -625,3 +649,12 @@ class TestBotManager:
         row = await db.fetch_one("SELECT * FROM bots WHERE bot_id = 'bot1'")
         assert row is not None
         assert row["strategy_id"] == "s1"
+
+    async def test_bot_name_persisted(self, manager, eventbus, ctx, db):
+        """봇 이름이 DB에 저장됨."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", name="모멘텀 봇")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        row = await db.fetch_one("SELECT * FROM bots WHERE bot_id = 'bot1'")
+        assert row is not None
+        assert row["name"] == "모멘텀 봇"

--- a/tests/unit/test_bot_create_params.py
+++ b/tests/unit/test_bot_create_params.py
@@ -88,6 +88,8 @@ class TestBotCreateWithParams:
                 [
                     "bot",
                     "create",
+                    "--name",
+                    "테스트봇",
                     "--strategy",
                     "stg-1",
                     "--param",
@@ -101,7 +103,7 @@ class TestBotCreateWithParams:
 
             # DB에 저장된 config_json에 params 포함 확인
             call_args = mock_db.execute.call_args[0]
-            config_json = call_args[1][3]
+            config_json = call_args[1][4]
             config = json.loads(config_json)
             assert config["params"]["lookback"] == 20
             assert config["params"]["threshold"] == 0.5
@@ -115,13 +117,13 @@ class TestBotCreateWithParams:
 
             result = runner.invoke(
                 cli,
-                ["bot", "create", "--strategy", "stg-1"],
+                ["bot", "create", "--name", "테스트봇", "--strategy", "stg-1"],
             )
             assert result.exit_code == 0
 
             # params 키가 없어야 함
             call_args = mock_db.execute.call_args[0]
-            config_json = call_args[1][3]
+            config_json = call_args[1][4]
             config = json.loads(config_json)
             assert "params" not in config
 
@@ -131,6 +133,8 @@ class TestBotCreateWithParams:
             [
                 "bot",
                 "create",
+                "--name",
+                "테스트봇",
                 "--strategy",
                 "stg-1",
                 "--param",
@@ -153,6 +157,8 @@ class TestBotCreateWithParams:
                     "json",
                     "bot",
                     "create",
+                    "--name",
+                    "테스트봇",
                     "--strategy",
                     "stg-1",
                     "--param",

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -139,6 +139,7 @@ class TestBotCommands:
                 return_value=[
                     {
                         "bot_id": "bot-1",
+                        "name": "테스트봇",
                         "strategy_id": "stg-1",
                         "bot_type": "paper",
                         "status": "created",
@@ -172,6 +173,7 @@ class TestBotCommands:
             mock_db.fetch_one = AsyncMock(
                 return_value={
                     "bot_id": "bot-1",
+                    "name": "테스트봇",
                     "strategy_id": "stg-1",
                     "bot_type": "live",
                     "status": "running",
@@ -197,7 +199,16 @@ class TestBotCommands:
 
             result = runner.invoke(
                 cli,
-                ["bot", "create", "--strategy", "stg-1", "--type", "paper"],
+                [
+                    "bot",
+                    "create",
+                    "--name",
+                    "테스트봇",
+                    "--strategy",
+                    "stg-1",
+                    "--type",
+                    "paper",
+                ],
             )
             assert result.exit_code == 0
             assert "생성 완료" in result.output


### PR DESCRIPTION
## Summary
- `BotConfig` 데이터클래스에 `name: str = ""` 필드 추가
- DB `bots` 테이블 스키마에 `name TEXT NOT NULL DEFAULT ''` 컬럼 추가
- `BotManager._save_bot_config()`에서 name을 DB에 저장
- `Bot.get_info()`에 name 포함
- CLI `bot create`에 `--name` 필수 옵션 추가, `bot list`/`bot info` 출력에 name 표시
- Web API `BotCreateRequest`에 `name` 필드 추가

## Test plan
- [x] BotConfig name 기본값 테스트
- [x] BotConfig name 설정 테스트
- [x] Bot.get_info()에 name 포함 확인
- [x] BotManager DB 저장 시 name 포함 확인
- [x] CLI bot create --name 필수 옵션 동작 확인
- [x] 기존 전체 테스트 통과 (1169 passed)

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)