### PR TITLE
fix: Config.get_secret() → Config.secret() 메서드명 수정

### DIFF
--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -343,8 +343,8 @@ async def main() -> None:
     )
 
     notification_service = None
-    telegram_token = config.get_secret("TELEGRAM_BOT_TOKEN")
-    telegram_chat_id = config.get_secret("TELEGRAM_CHAT_ID")
+    telegram_token = config.secret("TELEGRAM_BOT_TOKEN")
+    telegram_chat_id = config.secret("TELEGRAM_CHAT_ID")
 
     if telegram_token and telegram_chat_id:
         adapter = TelegramAdapter(bot_token=telegram_token, chat_id=telegram_chat_id)


### PR DESCRIPTION
## Summary
- `main.py`에서 `config.get_secret()` → `config.secret()`으로 수정
- `Config` 클래스에 존재하지 않는 `get_secret` 메서드를 호출하던 버그 수정
- 텔레그램 설정이 있는 환경에서 시스템 시작 시 `AttributeError` 방지

## Test plan
- [x] ruff lint 통과
- [x] 전체 테스트 1166개 통과

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)