### PR TITLE
feat: Bot 소프트 딜리트 정책 도입 및 DELETED 상태 추가

### DIFF
--- a/src/ante/bot/config.py
+++ b/src/ante/bot/config.py
@@ -14,6 +14,7 @@ class BotStatus(StrEnum):
     STOPPING = "stopping"
     STOPPED = "stopped"
     ERROR = "error"
+    DELETED = "deleted"
 
 
 # 실행 간격 제한

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -166,8 +166,8 @@ class BotManager:
         bot = self._get_bot(bot_id)
         await bot.stop()
 
-    async def remove_bot(self, bot_id: str) -> None:
-        """봇 삭제. 실행 중이면 먼저 중지."""
+    async def delete_bot(self, bot_id: str) -> None:
+        """봇 소프트 딜리트. 실행 중이면 먼저 중지."""
         bot = self._get_bot(bot_id)
         if bot.status == BotStatus.RUNNING:
             await bot.stop()
@@ -190,9 +190,18 @@ class BotManager:
         if self._snapshot:
             self._snapshot.cleanup(bot_id)
 
+        bot.status = BotStatus.DELETED
         del self._bots[bot_id]
-        await self._db.execute("DELETE FROM bots WHERE bot_id = ?", (bot_id,))
-        logger.info("봇 삭제: %s", bot_id)
+        await self._db.execute(
+            "UPDATE bots SET status = 'deleted', updated_at = datetime('now')"
+            " WHERE bot_id = ?",
+            (bot_id,),
+        )
+        logger.info("봇 삭제 (soft delete): %s", bot_id)
+
+    async def remove_bot(self, bot_id: str) -> None:
+        """봇 삭제. delete_bot()의 별칭 (하위 호환)."""
+        await self.delete_bot(bot_id)
 
     async def stop_all(self) -> None:
         """모든 봇 중지."""

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -45,7 +45,7 @@ def bot_list(ctx: click.Context) -> None:
         try:
             rows = await db.fetch_all(
                 "SELECT bot_id, name, strategy_id, bot_type, status, created_at"
-                " FROM bots"
+                " FROM bots WHERE status != 'deleted'"
             )
             return [dict(r) for r in rows]
         finally:
@@ -212,11 +212,16 @@ def bot_remove(ctx: click.Context, bot_id: str) -> None:
         db, _, _ = await _create_services()
         try:
             row = await db.fetch_one(
-                "SELECT bot_id FROM bots WHERE bot_id = ?", (bot_id,)
+                "SELECT bot_id FROM bots WHERE bot_id = ? AND status != 'deleted'",
+                (bot_id,),
             )
             if not row:
                 return False
-            await db.execute("DELETE FROM bots WHERE bot_id = ?", (bot_id,))
+            await db.execute(
+                "UPDATE bots SET status = 'deleted', updated_at = datetime('now')"
+                " WHERE bot_id = ?",
+                (bot_id,),
+            )
             return True
         finally:
             await db.close()

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -158,6 +158,7 @@ class TestBotConfig:
         assert BotStatus.CREATED == "created"
         assert BotStatus.RUNNING == "running"
         assert BotStatus.ERROR == "error"
+        assert BotStatus.DELETED == "deleted"
 
     def test_interval_min_valid(self):
         """최소 간격 10초 허용."""
@@ -503,11 +504,38 @@ class TestBotManager:
         assert manager.get_bot("bot1").status == BotStatus.STOPPED
 
     async def test_remove_bot(self, manager, eventbus, ctx):
-        """봇 삭제."""
+        """봇 삭제 (하위 호환 — remove_bot은 delete_bot 별칭)."""
         config = BotConfig(bot_id="bot1", strategy_id="s1")
         await manager.create_bot(config, SimpleStrategy, ctx)
         await manager.remove_bot("bot1")
         assert manager.get_bot("bot1") is None
+
+    async def test_delete_bot_soft_delete(self, manager, eventbus, ctx, db):
+        """delete_bot은 DB 레코드를 삭제하지 않고 status를 deleted로 변경."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.delete_bot("bot1")
+
+        # 메모리에서는 제거
+        assert manager.get_bot("bot1") is None
+
+        # DB에는 레코드가 남아있고 status가 deleted
+        row = await db.fetch_one("SELECT * FROM bots WHERE bot_id = 'bot1'")
+        assert row is not None
+        assert row["status"] == "deleted"
+
+    async def test_delete_bot_stops_running(self, manager, eventbus, ctx, db):
+        """실행 중인 봇 삭제 시 먼저 중지 후 deleted 처리."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+        assert manager.get_bot("bot1").status == BotStatus.RUNNING
+
+        await manager.delete_bot("bot1")
+        assert manager.get_bot("bot1") is None
+
+        row = await db.fetch_one("SELECT * FROM bots WHERE bot_id = 'bot1'")
+        assert row["status"] == "deleted"
 
     async def test_stop_all(self, manager, eventbus):
         """전체 봇 중지."""


### PR DESCRIPTION
## Summary
- `BotStatus`에 `DELETED = "deleted"` 추가
- `remove_bot()` → `delete_bot()`으로 변경 (소프트 딜리트: `UPDATE status = 'deleted'`)
  - `remove_bot()`은 하위 호환 별칭으로 유지
- CLI `bot list` 쿼리에 `WHERE status != 'deleted'` 필터 추가
- CLI `bot remove`도 DB DELETE 대신 소프트 딜리트 수행
- 거래 이력 보존, 포지션 고아 방지, 성과 피드백 연속성 확보

## Test plan
- [x] BotStatus.DELETED 값 확인
- [x] delete_bot() 소프트 딜리트 — DB 레코드 보존 + status='deleted' 확인
- [x] delete_bot() 실행 중 봇 → 중지 후 삭제 확인
- [x] remove_bot() 하위 호환 동작 확인
- [x] 전체 테스트 1171개 통과

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)