### PR TITLE
feat: 알림 메시지 템플릿 상수 모듈 분리

### DIFF
--- a/src/ante/notification/service.py
+++ b/src/ante/notification/service.py
@@ -7,6 +7,15 @@ from datetime import time
 from typing import TYPE_CHECKING
 
 from ante.notification.base import NotificationAdapter, NotificationLevel
+from ante.notification.templates import (
+    BOT_ERROR,
+    CIRCUIT_BREAKER,
+    ORDER_CANCEL_FAILED,
+    ORDER_FILLED,
+    POSITION_MISMATCH,
+    RESTART_EXHAUSTED,
+    TRADING_STATE_CHANGED,
+)
 
 if TYPE_CHECKING:
     from ante.core.database import Database
@@ -314,11 +323,12 @@ class NotificationService:
         if not isinstance(event, PositionMismatchEvent):
             return
 
-        msg = (
-            f"포지션 불일치 [{event.bot_id}] {event.symbol}: "
-            f"내부={event.internal_qty:.0f}주, "
-            f"브로커={event.broker_qty:.0f}주 "
-            f"({event.reason})"
+        msg = POSITION_MISMATCH.format(
+            bot_id=event.bot_id,
+            symbol=event.symbol,
+            internal_qty=event.internal_qty,
+            broker_qty=event.broker_qty,
+            reason=event.reason,
         )
         await self._send_and_record(
             NotificationLevel.CRITICAL,
@@ -334,9 +344,13 @@ class NotificationService:
         if not isinstance(event, BotErrorEvent):
             return
 
+        msg = BOT_ERROR.format(
+            bot_id=event.bot_id,
+            error_message=event.error_message,
+        )
         await self._send_and_record(
             NotificationLevel.ERROR,
-            f"봇 에러 [{event.bot_id}]: {event.error_message}",
+            msg,
             event_type="BotErrorEvent",
             bot_id=event.bot_id,
         )
@@ -357,10 +371,16 @@ class NotificationService:
             if name != event.symbol:
                 display = f"{event.symbol}({name})"
 
+        msg = ORDER_FILLED.format(
+            bot_id=event.bot_id,
+            display=display,
+            side=event.side,
+            quantity=event.quantity,
+            price=event.price,
+        )
         await self._send_and_record(
             NotificationLevel.INFO,
-            f"체결 [{event.bot_id}] {display} "
-            f"{event.side} {event.quantity}주 @ {event.price:,.0f}원",
+            msg,
             event_type="OrderFilledEvent",
             bot_id=event.bot_id,
         )
@@ -372,9 +392,14 @@ class NotificationService:
         if not isinstance(event, TradingStateChangedEvent):
             return
 
+        msg = TRADING_STATE_CHANGED.format(
+            old_state=event.old_state,
+            new_state=event.new_state,
+            reason=event.reason,
+        )
         await self._send_and_record(
             NotificationLevel.CRITICAL,
-            f"거래 상태 변경: {event.old_state} → {event.new_state} ({event.reason})",
+            msg,
             event_type="TradingStateChangedEvent",
         )
 
@@ -385,10 +410,14 @@ class NotificationService:
         if not isinstance(event, BotRestartExhaustedEvent):
             return
 
+        msg = RESTART_EXHAUSTED.format(
+            bot_id=event.bot_id,
+            restart_attempts=event.restart_attempts,
+            last_error=event.last_error,
+        )
         await self._send_and_record(
             NotificationLevel.ERROR,
-            f"봇 재시작 한도 소진 [{event.bot_id}] "
-            f"{event.restart_attempts}회 시도: {event.last_error}",
+            msg,
             event_type="BotRestartExhaustedEvent",
             bot_id=event.bot_id,
         )
@@ -400,9 +429,10 @@ class NotificationService:
         if not isinstance(event, OrderCancelFailedEvent):
             return
 
-        msg = (
-            f"주문 취소 실패 [{event.bot_id}] "
-            f"주문={event.order_id}: {event.error_message}"
+        msg = ORDER_CANCEL_FAILED.format(
+            bot_id=event.bot_id,
+            order_id=event.order_id,
+            error_message=event.error_message,
         )
         await self._send_and_record(
             NotificationLevel.ERROR,
@@ -422,10 +452,15 @@ class NotificationService:
         if event.new_state == "open":
             level = NotificationLevel.ERROR
 
+        msg = CIRCUIT_BREAKER.format(
+            broker=event.broker,
+            old_state=event.old_state,
+            new_state=event.new_state,
+            reason=event.reason,
+        )
         await self._send_and_record(
             level,
-            f"Circuit Breaker [{event.broker}] "
-            f"{event.old_state} → {event.new_state} ({event.reason})",
+            msg,
             event_type="CircuitBreakerEvent",
         )
 

--- a/src/ante/notification/templates.py
+++ b/src/ante/notification/templates.py
@@ -1,0 +1,43 @@
+"""알림 메시지 템플릿 상수.
+
+모든 알림 메시지의 서식과 텍스트를 한곳에서 관리한다.
+각 상수는 str.format() 호환 포맷 문자열이다.
+"""
+
+# ── CRITICAL ──────────────────────────────────
+
+TRADING_STATE_CHANGED = (
+    "🚨 *거래 상태 변경*\n{old_state} → *{new_state}*\n사유: {reason}"
+)
+
+POSITION_MISMATCH = (
+    "🚨 *포지션 불일치*\n"
+    "봇: `{bot_id}` · 종목: `{symbol}`\n"
+    "내부: {internal_qty:.0f}주 · 브로커: {broker_qty:.0f}주\n"
+    "사유: {reason}"
+)
+
+# ── ERROR ─────────────────────────────────────
+
+BOT_ERROR = "❌ *봇 에러*\n봇: `{bot_id}`\n{error_message}"
+
+RESTART_EXHAUSTED = (
+    "❌ *봇 재시작 한도 소진*\n봇: `{bot_id}` · {restart_attempts}회 시도\n{last_error}"
+)
+
+ORDER_CANCEL_FAILED = (
+    "❌ *주문 취소 실패*\n봇: `{bot_id}` · 주문: `{order_id}`\n{error_message}"
+)
+
+CIRCUIT_BREAKER = (
+    "❌ *Circuit Breaker*\n브로커: `{broker}`\n{old_state} → *{new_state}* ({reason})"
+)
+
+# ── INFO ──────────────────────────────────────
+
+ORDER_FILLED = (
+    "📈 *체결 완료*\n"
+    "봇: `{bot_id}`\n"
+    "종목: *{display}*\n"
+    "{side} {quantity}주 @ {price:,.0f}원"
+)

--- a/tests/unit/test_notification_templates.py
+++ b/tests/unit/test_notification_templates.py
@@ -1,0 +1,86 @@
+"""알림 메시지 템플릿 테스트."""
+
+from ante.notification.templates import (
+    BOT_ERROR,
+    CIRCUIT_BREAKER,
+    ORDER_CANCEL_FAILED,
+    ORDER_FILLED,
+    POSITION_MISMATCH,
+    RESTART_EXHAUSTED,
+    TRADING_STATE_CHANGED,
+)
+
+
+class TestTemplateFormat:
+    """각 템플릿이 올바른 변수로 포맷되는지 확인."""
+
+    def test_trading_state_changed(self):
+        result = TRADING_STATE_CHANGED.format(
+            old_state="active",
+            new_state="halted",
+            reason="일일 손실 한도",
+        )
+        assert "active" in result
+        assert "halted" in result
+        assert "일일 손실 한도" in result
+
+    def test_position_mismatch(self):
+        result = POSITION_MISMATCH.format(
+            bot_id="bot1",
+            symbol="005930",
+            internal_qty=100,
+            broker_qty=50,
+            reason="외부 일부 매도",
+        )
+        assert "bot1" in result
+        assert "005930" in result
+        assert "100" in result
+        assert "50" in result
+
+    def test_bot_error(self):
+        result = BOT_ERROR.format(
+            bot_id="bot1",
+            error_message="Connection timeout",
+        )
+        assert "bot1" in result
+        assert "Connection timeout" in result
+
+    def test_restart_exhausted(self):
+        result = RESTART_EXHAUSTED.format(
+            bot_id="bot1",
+            restart_attempts=3,
+            last_error="timeout",
+        )
+        assert "bot1" in result
+        assert "3" in result
+
+    def test_order_cancel_failed(self):
+        result = ORDER_CANCEL_FAILED.format(
+            bot_id="bot1",
+            order_id="ord-123",
+            error_message="시장 마감",
+        )
+        assert "bot1" in result
+        assert "ord-123" in result
+
+    def test_circuit_breaker(self):
+        result = CIRCUIT_BREAKER.format(
+            broker="KIS",
+            old_state="closed",
+            new_state="open",
+            reason="연속 오류",
+        )
+        assert "KIS" in result
+        assert "open" in result
+
+    def test_order_filled(self):
+        result = ORDER_FILLED.format(
+            bot_id="bot1",
+            display="005930(삼성전자)",
+            side="buy",
+            quantity=100,
+            price=72000,
+        )
+        assert "bot1" in result
+        assert "005930(삼성전자)" in result
+        assert "72,000" in result


### PR DESCRIPTION
## Summary
- `src/ante/notification/templates.py` 신설: 7개 알림 메시지를 `str.format()` 상수로 중앙 관리
  - CRITICAL: `TRADING_STATE_CHANGED`, `POSITION_MISMATCH`
  - ERROR: `BOT_ERROR`, `RESTART_EXHAUSTED`, `ORDER_CANCEL_FAILED`, `CIRCUIT_BREAKER`
  - INFO: `ORDER_FILLED`
- `NotificationService` 핸들러의 인라인 f-string을 `templates.X.format()` 호출로 교체
- 텔레그램 Markdown 서식(이모지, 볼드, 코드블록) 적용
- 이벤트 핸들러 로직과 메시지 표현의 관심사 분리

## Test plan
- [x] 7개 템플릿 모두 올바른 변수로 포맷되는지 확인
- [x] 기존 NotificationService 테스트 전체 통과
- [x] 전체 테스트 1176개 통과

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)