### PR TITLE
feat: Config 경로 탐색 우선순위 도입 및 ante init 명령 추가

### DIFF
--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -1,0 +1,85 @@
+"""ante init — 설정 디렉토리 초기화."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from ante.cli.main import get_formatter
+
+SYSTEM_TOML_TEMPLATE = """\
+# Ante 시스템 설정
+
+[system]
+log_level = "INFO"
+timezone = "Asia/Seoul"
+
+[db]
+path = "db/ante.db"
+
+[web]
+host = "0.0.0.0"
+port = 8000
+"""
+
+SECRETS_ENV_TEMPLATE = """\
+# Ante 비밀값 설정
+# 환경변수가 이 파일보다 우선합니다.
+
+# KIS 증권 API
+# KIS_APP_KEY=
+# KIS_APP_SECRET=
+# KIS_ACCOUNT_NO=
+
+# 텔레그램 알림 (선택)
+# TELEGRAM_BOT_TOKEN=
+# TELEGRAM_CHAT_ID=
+"""
+
+
+@click.command("init")
+@click.option(
+    "--dir",
+    "target_dir",
+    type=click.Path(),
+    default=None,
+    help="설정 디렉토리 경로 (기본: ~/.config/ante/)",
+)
+@click.pass_context
+def init(ctx: click.Context, target_dir: str | None) -> None:
+    """설정 디렉토리 및 기본 설정 파일 생성."""
+    fmt = get_formatter(ctx)
+
+    config_path = Path(target_dir) if target_dir else Path.home() / ".config" / "ante"
+
+    if config_path.exists():
+        existing = []
+        if (config_path / "system.toml").exists():
+            existing.append("system.toml")
+        if (config_path / "secrets.env").exists():
+            existing.append("secrets.env")
+        if existing:
+            fmt.error(
+                f"설정 디렉토리가 이미 존재합니다: {config_path}\n"
+                f"  기존 파일: {', '.join(existing)}"
+            )
+            return
+
+    config_path.mkdir(parents=True, exist_ok=True)
+
+    system_toml = config_path / "system.toml"
+    if not system_toml.exists():
+        system_toml.write_text(SYSTEM_TOML_TEMPLATE)
+
+    secrets_env = config_path / "secrets.env"
+    if not secrets_env.exists():
+        secrets_env.write_text(SECRETS_ENV_TEMPLATE)
+
+    fmt.success(
+        f"설정 초기화 완료: {config_path}",
+        {
+            "config_dir": str(config_path),
+            "files": ["system.toml", "secrets.env"],
+        },
+    )

--- a/src/ante/cli/main.py
+++ b/src/ante/cli/main.py
@@ -16,13 +16,25 @@ from ante.cli.middleware import authenticate_member
     default="text",
     help="출력 형식 (text 또는 json)",
 )
+@click.option(
+    "--config-dir",
+    "config_dir",
+    type=click.Path(exists=False),
+    default=None,
+    envvar="ANTE_CONFIG_DIR",
+    help="설정 디렉토리 경로 (기본: ~/.config/ante/ 또는 ./config/)",
+)
 @click.version_option(version="0.1.0", prog_name="ante")
 @click.pass_context
-def cli(ctx: click.Context, output_format: str) -> None:
+def cli(ctx: click.Context, output_format: str, config_dir: str | None) -> None:
     """Ante — AI-Native Trading Engine CLI."""
     ctx.ensure_object(dict)
     ctx.obj["format"] = output_format
     ctx.obj["formatter"] = OutputFormatter(output_format)
+    if config_dir:
+        from pathlib import Path
+
+        ctx.obj["config_dir"] = Path(config_dir)
     authenticate_member(ctx)
 
 
@@ -39,6 +51,7 @@ from ante.cli.commands.bot import bot  # noqa: E402
 from ante.cli.commands.broker import broker  # noqa: E402
 from ante.cli.commands.config import config  # noqa: E402
 from ante.cli.commands.data import data  # noqa: E402
+from ante.cli.commands.init import init  # noqa: E402
 from ante.cli.commands.instrument import instrument  # noqa: E402
 from ante.cli.commands.member import member  # noqa: E402
 from ante.cli.commands.notification import notification  # noqa: E402
@@ -52,6 +65,7 @@ from ante.cli.commands.treasury import treasury  # noqa: E402
 
 cli.add_command(audit)
 cli.add_command(approval)
+cli.add_command(init)
 cli.add_command(bot)
 cli.add_command(broker)
 cli.add_command(config)

--- a/src/ante/config/__init__.py
+++ b/src/ante/config/__init__.py
@@ -1,6 +1,6 @@
 """Config — 설정 관리."""
 
-from ante.config.config import Config
+from ante.config.config import Config, resolve_config_dir
 from ante.config.defaults import DEFAULTS
 from ante.config.dynamic import DynamicConfigService
 from ante.config.exceptions import ConfigError
@@ -13,4 +13,5 @@ __all__ = [
     "DynamicConfigService",
     "SystemState",
     "TradingState",
+    "resolve_config_dir",
 ]

--- a/src/ante/config/config.py
+++ b/src/ante/config/config.py
@@ -62,6 +62,26 @@ def _nested_get(data: dict[str, Any], key: str, default: Any = None) -> Any:
     return current
 
 
+def resolve_config_dir(override: Path | None = None) -> Path:
+    """설정 디렉토리 탐색.
+
+    우선순위: override 인자 > ANTE_CONFIG_DIR 환경변수
+              > ~/.config/ante/ > ./config/
+    """
+    if override is not None:
+        return override
+
+    env_dir = os.environ.get("ANTE_CONFIG_DIR")
+    if env_dir:
+        return Path(env_dir)
+
+    user_dir = Path.home() / ".config" / "ante"
+    if user_dir.exists():
+        return user_dir
+
+    return Path("config")
+
+
 class Config:
     """Ante 통합 설정 접근 인터페이스.
 
@@ -74,10 +94,14 @@ class Config:
         self._secrets = secrets
 
     @classmethod
-    def load(cls, config_dir: Path = Path("config")) -> Config:
-        """설정 파일 로드 및 Config 인스턴스 생성."""
-        static = _load_toml(config_dir / "system.toml")
-        secrets = _load_dotenv(config_dir / "secrets.env")
+    def load(cls, config_dir: Path | None = None) -> Config:
+        """설정 파일 로드 및 Config 인스턴스 생성.
+
+        config_dir이 None이면 resolve_config_dir()로 자동 탐색.
+        """
+        resolved = resolve_config_dir(config_dir)
+        static = _load_toml(resolved / "system.toml")
+        secrets = _load_dotenv(resolved / "secrets.env")
         return cls(static=static, secrets=secrets)
 
     def get(self, key: str, default: Any = None) -> Any:

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -39,7 +39,7 @@ async def main() -> None:
     종료 순서: 역순 (상위 소비자부터 정리)
     """
     # ── 1. Config ────────────────────────────────────
-    config = Config.load(config_dir=Path("config"))
+    config = Config.load()
     config.validate()
 
     log_level = config.get("system.log_level", "INFO")

--- a/tests/unit/test_config_path.py
+++ b/tests/unit/test_config_path.py
@@ -1,0 +1,138 @@
+"""Config 경로 탐색 및 ante init 테스트."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.config.config import resolve_config_dir
+from ante.member.models import Member, MemberRole, MemberType
+
+# ── resolve_config_dir ──────────────────────────
+
+
+class TestResolveConfigDir:
+    def test_override_takes_priority(self, tmp_path: Path) -> None:
+        """명시적 override가 최우선."""
+        result = resolve_config_dir(override=tmp_path)
+        assert result == tmp_path
+
+    def test_env_var_second_priority(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """ANTE_CONFIG_DIR 환경변수가 두 번째 우선순위."""
+        env_path = tmp_path / "env_config"
+        env_path.mkdir()
+        monkeypatch.setenv("ANTE_CONFIG_DIR", str(env_path))
+        result = resolve_config_dir()
+        assert result == env_path
+
+    def test_user_config_dir_third(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """~/.config/ante/ 가 세 번째 우선순위."""
+        monkeypatch.delenv("ANTE_CONFIG_DIR", raising=False)
+        user_dir = tmp_path / ".config" / "ante"
+        user_dir.mkdir(parents=True)
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = resolve_config_dir()
+        assert result == user_dir
+
+    def test_fallback_to_local(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """다른 경로가 없으면 ./config/ 폴백."""
+        monkeypatch.delenv("ANTE_CONFIG_DIR", raising=False)
+        with patch.object(Path, "home", return_value=Path("/nonexistent")):
+            result = resolve_config_dir()
+        assert result == Path("config")
+
+    def test_env_var_overrides_user_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """환경변수가 ~/.config/ante/ 보다 우선."""
+        env_path = tmp_path / "env"
+        env_path.mkdir()
+        monkeypatch.setenv("ANTE_CONFIG_DIR", str(env_path))
+
+        user_dir = tmp_path / ".config" / "ante"
+        user_dir.mkdir(parents=True)
+
+        result = resolve_config_dir()
+        assert result == env_path
+
+
+# ── Config.load() with resolve ──────────────────
+
+
+class TestConfigLoadResolve:
+    def test_load_none_uses_resolve(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Config.load()에 인자 없으면 resolve_config_dir() 사용."""
+        from ante.config import Config
+
+        monkeypatch.setenv("ANTE_CONFIG_DIR", str(tmp_path))
+        toml = tmp_path / "system.toml"
+        toml.write_text('[system]\nlog_level = "TRACE"\n')
+
+        config = Config.load()
+        assert config.get("system.log_level") == "TRACE"
+
+
+# ── ante init ───────────────────────────────────
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+class TestInitCommand:
+    @pytest.fixture
+    def runner(self):
+        r = CliRunner()
+        original_invoke = r.invoke
+
+        def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+            with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+                def _set_member(ctx):
+                    ctx.obj = ctx.obj or {}
+                    ctx.obj["member"] = _MOCK_MASTER
+
+                mock_auth.side_effect = _set_member
+                return original_invoke(cli_cmd, args, **kwargs)
+
+        r.invoke = _invoke_with_auth
+        return r
+
+    def test_init_creates_files(self, runner, tmp_path: Path) -> None:
+        """ante init이 설정 파일을 생성한다."""
+        target = tmp_path / "new_config"
+        result = runner.invoke(cli, ["init", "--dir", str(target)])
+        assert result.exit_code == 0
+        assert "초기화 완료" in result.output
+        assert (target / "system.toml").exists()
+        assert (target / "secrets.env").exists()
+
+    def test_init_blocks_existing(self, runner, tmp_path: Path) -> None:
+        """이미 설정 파일이 있으면 에러."""
+        target = tmp_path / "existing"
+        target.mkdir()
+        (target / "system.toml").write_text("existing")
+
+        result = runner.invoke(cli, ["init", "--dir", str(target)])
+        assert "이미 존재합니다" in result.output
+
+    def test_init_default_dir(self, runner, tmp_path: Path) -> None:
+        """--dir 미지정 시 ~/.config/ante/ 사용."""
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = runner.invoke(cli, ["init"])
+        assert result.exit_code == 0
+        assert (tmp_path / ".config" / "ante" / "system.toml").exists()


### PR DESCRIPTION
## Summary
- `resolve_config_dir()` 함수 추가: 설정 디렉토리 탐색 우선순위 도입
  - CLI `--config-dir` 인자 > `ANTE_CONFIG_DIR` 환경변수 > `~/.config/ante/` > `./config/`
- `Config.load()`가 인자 없이 호출 시 `resolve_config_dir()` 자동 사용
- CLI 루트 그룹에 `--config-dir` 글로벌 옵션 추가
- `ante init` 명령 추가: 설정 디렉토리에 `system.toml`, `secrets.env` 초기 생성
- `main.py`의 하드코딩된 `Path("config")` 제거

## Test plan
- [x] resolve_config_dir: override 최우선
- [x] resolve_config_dir: ANTE_CONFIG_DIR 환경변수 두 번째
- [x] resolve_config_dir: ~/.config/ante/ 세 번째
- [x] resolve_config_dir: ./config/ 폴백
- [x] resolve_config_dir: 환경변수가 user dir보다 우선
- [x] Config.load() None 인자 시 resolve 사용
- [x] ante init 파일 생성
- [x] ante init 기존 파일 있으면 에러
- [x] ante init --dir 미지정 시 기본 경로
- [x] 전체 테스트 1187개 통과

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)