### PR TITLE
fix: 종목 마스터 API를 KIS 공식 마스터 파일 방식으로 교체

### DIFF
--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -657,27 +657,62 @@ class KISAdapter(BrokerAdapter):
 
         return instruments
 
+    # 마스터 파일 다운로드 설정 (KIS 공식 방식)
+    _MASTER_FILES: dict[str, dict[str, str | int]] = {
+        "J": {
+            "url": "https://new.real.download.dws.co.kr/common/master/kospi_code.mst.zip",
+            "filename": "kospi_code.mst",
+            "tail_len": 228,
+        },
+        "Q": {
+            "url": "https://new.real.download.dws.co.kr/common/master/kosdaq_code.mst.zip",
+            "filename": "kosdaq_code.mst",
+            "tail_len": 222,
+        },
+    }
+
     async def _fetch_stock_list(self, mrkt_code: str) -> list[dict[str, Any]]:
-        """시장 코드별 종목 목록 조회 (페이징 처리)."""
-        tr_id = "CTPF1702R"
-        url = (
-            f"{self.base_url}"
-            "/uapi/domestic-stock/v1/quotations/inquire-search-stock-info"
-        )
-        all_items: list[dict[str, Any]] = []
+        """KIS 마스터 파일 다운로드로 종목 목록 조회.
 
-        params = {
-            "PRDT_TYPE_CD": "300",
-            "PDNO": "",
-            "PRDT_GRP_CD": "",
-            "STTL_CYCL_CD": "",
-            "MKT_ID_CD": mrkt_code,
-        }
-        result = await self._request("GET", url, tr_id, params=params)
-        items = result.get("output2", [])
-        all_items.extend(items)
+        기존 CTPF1702R API가 404를 반환하여, KIS 공식 마스터 파일
+        다운로드 방식으로 대체 (koreainvestment/open-trading-api 참조).
+        """
+        import io
+        import zipfile
 
-        return all_items
+        config = self._MASTER_FILES.get(mrkt_code)
+        if config is None:
+            raise ValueError(f"지원하지 않는 시장 코드: {mrkt_code}")
+
+        url = str(config["url"])
+        filename = str(config["filename"])
+        tail_len = int(config["tail_len"])
+
+        async with self._session.get(url) as resp:
+            resp.raise_for_status()
+            zip_data = await resp.read()
+
+        with zipfile.ZipFile(io.BytesIO(zip_data)) as zf:
+            raw = zf.read(filename)
+
+        items: list[dict[str, Any]] = []
+        for line in raw.decode("cp949").splitlines():
+            if not line.strip():
+                continue
+            part1 = line[: len(line) - tail_len]
+            short_code = part1[0:9].strip()
+            name = part1[21:].strip()
+
+            if len(short_code) == 6 and short_code.isdigit():
+                items.append(
+                    {
+                        "std_pdno": short_code,
+                        "prdt_name": name,
+                        "prdt_eng_name": "",
+                    }
+                )
+
+        return items
 
     @staticmethod
     def _classify_instrument_type(symbol: str, name: str, market: str) -> str:

--- a/tests/unit/test_instrument_sync.py
+++ b/tests/unit/test_instrument_sync.py
@@ -289,3 +289,121 @@ class TestDelistingHandling:
         samsung = await instrument_service.get("005930")
         assert samsung is not None
         assert samsung.listed is True
+
+
+# ── _fetch_stock_list 마스터 파일 파싱 ──────────
+
+
+def _build_master_zip(
+    filename: str, tail_len: int, rows: list[tuple[str, str, str]]
+) -> bytes:
+    """테스트용 KIS 마스터 파일 zip 생성.
+
+    rows: [(short_code, std_code, name), ...]
+    """
+    import io
+    import zipfile
+
+    lines = []
+    for short_code, std_code, name in rows:
+        part1 = f"{short_code:<9}{std_code:<12}{name}"
+        part2 = "0" * tail_len
+        lines.append(part1 + part2)
+
+    content = "\n".join(lines).encode("cp949")
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(filename, content)
+    return buf.getvalue()
+
+
+class TestFetchStockListMaster:
+    async def test_parse_kospi_master_file(self):
+        """KOSPI 마스터 파일에서 종목 코드/이름 추출."""
+        config = {
+            "app_key": "test",
+            "app_secret": "test",
+            "account_no": "1234567890",
+            "is_paper": True,
+        }
+        adapter = KISAdapter(config=config)
+
+        zip_data = _build_master_zip(
+            "kospi_code.mst",
+            228,
+            [
+                ("005930", "KR7005930003", "삼성전자"),
+                ("069500", "KR7069500007", "KODEX 200"),
+            ],
+        )
+
+        mock_resp = AsyncMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.read = AsyncMock(return_value=zip_data)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=_AsyncCtx(mock_resp))
+        adapter._session = mock_session
+
+        result = await adapter._fetch_stock_list("J")
+        assert len(result) == 2
+        assert result[0]["std_pdno"] == "005930"
+        assert result[0]["prdt_name"] == "삼성전자"
+        assert result[1]["std_pdno"] == "069500"
+        assert result[1]["prdt_name"] == "KODEX 200"
+
+    async def test_parse_kosdaq_master_file(self):
+        """KOSDAQ 마스터 파일 파싱."""
+        config = {
+            "app_key": "test",
+            "app_secret": "test",
+            "account_no": "1234567890",
+            "is_paper": True,
+        }
+        adapter = KISAdapter(config=config)
+
+        zip_data = _build_master_zip(
+            "kosdaq_code.mst",
+            222,
+            [("035720", "KR7035720002", "카카오")],
+        )
+
+        mock_resp = AsyncMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.read = AsyncMock(return_value=zip_data)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=_AsyncCtx(mock_resp))
+        adapter._session = mock_session
+
+        result = await adapter._fetch_stock_list("Q")
+        assert len(result) == 1
+        assert result[0]["std_pdno"] == "035720"
+        assert result[0]["prdt_name"] == "카카오"
+
+    async def test_invalid_market_code_raises(self):
+        """지원하지 않는 시장 코드 시 ValueError."""
+        config = {
+            "app_key": "test",
+            "app_secret": "test",
+            "account_no": "1234567890",
+            "is_paper": True,
+        }
+        adapter = KISAdapter(config=config)
+
+        with pytest.raises(ValueError, match="지원하지 않는 시장 코드"):
+            await adapter._fetch_stock_list("X")
+
+
+class _AsyncCtx:
+    """async context manager mock helper."""
+
+    def __init__(self, value: object) -> None:
+        self._value = value
+
+    async def __aenter__(self) -> object:
+        return self._value
+
+    async def __aexit__(self, *args: object) -> None:
+        pass


### PR DESCRIPTION
## Summary
- CTPF1702R API 엔드포인트가 404를 반환하는 문제 해결
- KIS 공식 마스터 파일(kospi_code.mst, kosdaq_code.mst) 다운로드 방식으로 교체
- 인증 불필요한 공개 URL에서 zip 다운로드 → cp949 디코딩 → 종목 파싱

## Test plan
- [x] 기존 14개 테스트 통과 확인
- [x] 마스터 파일 파싱 테스트 3개 추가 (KOSPI/KOSDAQ 파싱, 잘못된 시장코드)
- [x] ruff check + ruff format 통과
- [x] 전체 테스트 1183 passed

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)