### PR TITLE
feat: 대시보드 프론트엔드 구현 (Phase F-1 ~ F-4)

### DIFF
--- a/frontend/public/logo-a.svg
+++ b/frontend/public/logo-a.svg
@@ -1,0 +1,110 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <defs>
+    <!-- 회로 트레이스 그라데이션 -->
+    <linearGradient id="traceGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3B82F6" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#3B82F6" stop-opacity="0.8"/>
+    </linearGradient>
+    <!-- 코어 글로우 -->
+    <radialGradient id="coreGlow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#60A5FA"/>
+      <stop offset="70%" stop-color="#3B82F6"/>
+      <stop offset="100%" stop-color="#2563EB"/>
+    </radialGradient>
+    <!-- 외곽 링 글로우 -->
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="1.5" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- 배경 원 (칩 기판) -->
+  <circle cx="60" cy="60" r="52" fill="#1a1a2e" stroke="#2a2a4a" stroke-width="1.5"/>
+
+  <!-- 외곽 회로 트레이스 링 -->
+  <circle cx="60" cy="60" r="46" fill="none" stroke="url(#traceGrad)" stroke-width="0.8" stroke-dasharray="4 6" opacity="0.6">
+    <animateTransform attributeName="transform" type="rotate" from="0 60 60" to="360 60 60" dur="60s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- 회로 트레이스 (상하좌우 핀) -->
+  <g stroke="#3B82F6" stroke-width="1.2" stroke-linecap="round" opacity="0">
+    <!-- 상단 핀 -->
+    <line x1="48" y1="8" x2="48" y2="18"/>
+    <line x1="60" y1="5" x2="60" y2="15"/>
+    <line x1="72" y1="8" x2="72" y2="18"/>
+    <!-- 하단 핀 -->
+    <line x1="48" y1="112" x2="48" y2="102"/>
+    <line x1="60" y1="115" x2="60" y2="105"/>
+    <line x1="72" y1="112" x2="72" y2="102"/>
+    <!-- 좌측 핀 -->
+    <line x1="8" y1="48" x2="18" y2="48"/>
+    <line x1="5" y1="60" x2="15" y2="60"/>
+    <line x1="8" y1="72" x2="18" y2="72"/>
+    <!-- 우측 핀 -->
+    <line x1="112" y1="48" x2="102" y2="48"/>
+    <line x1="115" y1="60" x2="105" y2="60"/>
+    <line x1="112" y1="72" x2="102" y2="72"/>
+    <animate attributeName="opacity" values="0;0.7;0" dur="3s" repeatCount="indefinite"/>
+  </g>
+
+  <!-- 핀 끝 노드 (발광 점) -->
+  <g fill="#60A5FA" opacity="0">
+    <circle cx="48" cy="8" r="1.5"/><circle cx="60" cy="5" r="1.5"/><circle cx="72" cy="8" r="1.5"/>
+    <circle cx="48" cy="112" r="1.5"/><circle cx="60" cy="115" r="1.5"/><circle cx="72" cy="112" r="1.5"/>
+    <circle cx="8" cy="48" r="1.5"/><circle cx="5" cy="60" r="1.5"/><circle cx="8" cy="72" r="1.5"/>
+    <circle cx="112" cy="48" r="1.5"/><circle cx="115" cy="60" r="1.5"/><circle cx="112" cy="72" r="1.5"/>
+    <animate attributeName="opacity" values="0;1;0" dur="3s" repeatCount="indefinite"/>
+  </g>
+
+  <!-- 내부 회로 트레이스 패턴 -->
+  <g stroke="#3B82F6" stroke-width="0.6" fill="none" opacity="0.25">
+    <!-- 대각선 트레이스 -->
+    <path d="M36 36 L28 28"/>
+    <path d="M84 36 L92 28"/>
+    <path d="M36 84 L28 92"/>
+    <path d="M84 84 L92 92"/>
+    <!-- 내부 연결선 -->
+    <path d="M42 38 L38 38 L38 42"/>
+    <path d="M78 38 L82 38 L82 42"/>
+    <path d="M42 82 L38 82 L38 78"/>
+    <path d="M78 82 L82 82 L82 78"/>
+  </g>
+
+  <!-- 중간 링 -->
+  <circle cx="60" cy="60" r="34" fill="none" stroke="#3B82F6" stroke-width="0.6" opacity="0.3"/>
+
+  <!-- 내부 회로 링 (역회전) -->
+  <circle cx="60" cy="60" r="28" fill="none" stroke="#3B82F6" stroke-width="0.5" stroke-dasharray="2 8" opacity="0.4">
+    <animateTransform attributeName="transform" type="rotate" from="360 60 60" to="0 60 60" dur="40s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- 코어 (중앙 칩 다이) -->
+  <rect x="40" y="40" width="40" height="40" rx="4" fill="#1e1e3a" stroke="#3B82F6" stroke-width="1" opacity="0.8"/>
+
+  <!-- 코어 내부 글로우 -->
+  <rect x="43" y="43" width="34" height="34" rx="2" fill="url(#coreGlow)" opacity="0.15">
+    <animate attributeName="opacity" values="0.1;0.25;0.1" dur="4s" repeatCount="indefinite"/>
+  </rect>
+
+  <!-- A 글리프 -->
+  <g filter="url(#glow)">
+    <text x="60" y="79" text-anchor="middle" font-family="'SF Pro Display', 'Inter', system-ui, sans-serif" font-size="58" font-weight="900" fill="#E2E8F0" letter-spacing="-1">A</text>
+  </g>
+
+  <!-- 코어 코너 노드 -->
+  <g fill="#60A5FA">
+    <circle cx="40" cy="40" r="1.5" opacity="0.6"/>
+    <circle cx="80" cy="40" r="1.5" opacity="0.6"/>
+    <circle cx="40" cy="80" r="1.5" opacity="0.6"/>
+    <circle cx="80" cy="80" r="1.5" opacity="0.6"/>
+  </g>
+
+  <!-- 펄스 링 (코어에서 확산) -->
+  <circle cx="60" cy="60" r="20" fill="none" stroke="#3B82F6" stroke-width="1" opacity="0">
+    <animate attributeName="r" values="20;48" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.6;0" dur="3s" repeatCount="indefinite"/>
+  </circle>
+</svg>

--- a/frontend/public/logo-e.svg
+++ b/frontend/public/logo-e.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <defs>
+    <linearGradient id="traceGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#F59E0B" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#F59E0B" stop-opacity="0.8"/>
+    </linearGradient>
+    <radialGradient id="coreGlow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#FDE68A"/>
+      <stop offset="70%" stop-color="#F59E0B"/>
+      <stop offset="100%" stop-color="#D97706"/>
+    </radialGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="1.5" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <circle cx="60" cy="60" r="52" fill="#1a1a2e" stroke="#2a2a4a" stroke-width="1.5"/>
+
+  <circle cx="60" cy="60" r="46" fill="none" stroke="url(#traceGrad)" stroke-width="0.8" stroke-dasharray="4 6" opacity="0.6">
+    <animateTransform attributeName="transform" type="rotate" from="0 60 60" to="360 60 60" dur="65s" repeatCount="indefinite"/>
+  </circle>
+
+  <g stroke="#F59E0B" stroke-width="1.2" stroke-linecap="round" opacity="0">
+    <line x1="48" y1="8" x2="48" y2="18"/><line x1="60" y1="5" x2="60" y2="15"/><line x1="72" y1="8" x2="72" y2="18"/>
+    <line x1="48" y1="112" x2="48" y2="102"/><line x1="60" y1="115" x2="60" y2="105"/><line x1="72" y1="112" x2="72" y2="102"/>
+    <line x1="8" y1="48" x2="18" y2="48"/><line x1="5" y1="60" x2="15" y2="60"/><line x1="8" y1="72" x2="18" y2="72"/>
+    <line x1="112" y1="48" x2="102" y2="48"/><line x1="115" y1="60" x2="105" y2="60"/><line x1="112" y1="72" x2="102" y2="72"/>
+    <animate attributeName="opacity" values="0;0.7;0" dur="2.5s" repeatCount="indefinite"/>
+  </g>
+
+  <g fill="#FDE68A" opacity="0">
+    <circle cx="48" cy="8" r="1.5"/><circle cx="60" cy="5" r="1.5"/><circle cx="72" cy="8" r="1.5"/>
+    <circle cx="48" cy="112" r="1.5"/><circle cx="60" cy="115" r="1.5"/><circle cx="72" cy="112" r="1.5"/>
+    <circle cx="8" cy="48" r="1.5"/><circle cx="5" cy="60" r="1.5"/><circle cx="8" cy="72" r="1.5"/>
+    <circle cx="112" cy="48" r="1.5"/><circle cx="115" cy="60" r="1.5"/><circle cx="112" cy="72" r="1.5"/>
+    <animate attributeName="opacity" values="0;1;0" dur="2.5s" repeatCount="indefinite"/>
+  </g>
+
+  <g stroke="#F59E0B" stroke-width="0.6" fill="none" opacity="0.25">
+    <path d="M36 36 L28 28"/><path d="M84 36 L92 28"/><path d="M36 84 L28 92"/><path d="M84 84 L92 92"/>
+    <path d="M42 38 L38 38 L38 42"/><path d="M78 38 L82 38 L82 42"/><path d="M42 82 L38 82 L38 78"/><path d="M78 82 L82 82 L82 78"/>
+  </g>
+
+  <circle cx="60" cy="60" r="34" fill="none" stroke="#F59E0B" stroke-width="0.6" opacity="0.3"/>
+
+  <circle cx="60" cy="60" r="28" fill="none" stroke="#F59E0B" stroke-width="0.5" stroke-dasharray="2 8" opacity="0.4">
+    <animateTransform attributeName="transform" type="rotate" from="360 60 60" to="0 60 60" dur="38s" repeatCount="indefinite"/>
+  </circle>
+
+  <rect x="40" y="40" width="40" height="40" rx="4" fill="#1e1e3a" stroke="#F59E0B" stroke-width="1" opacity="0.8"/>
+
+  <rect x="43" y="43" width="34" height="34" rx="2" fill="url(#coreGlow)" opacity="0.15">
+    <animate attributeName="opacity" values="0.1;0.25;0.1" dur="3.5s" repeatCount="indefinite"/>
+  </rect>
+
+  <g filter="url(#glow)">
+    <text x="60" y="79" text-anchor="middle" font-family="'SF Pro Display', 'Inter', system-ui, sans-serif" font-size="58" font-weight="900" fill="#E2E8F0" letter-spacing="-1">E</text>
+  </g>
+
+  <g fill="#FDE68A">
+    <circle cx="40" cy="40" r="1.5" opacity="0.6"/><circle cx="80" cy="40" r="1.5" opacity="0.6"/>
+    <circle cx="40" cy="80" r="1.5" opacity="0.6"/><circle cx="80" cy="80" r="1.5" opacity="0.6"/>
+  </g>
+
+  <circle cx="60" cy="60" r="20" fill="none" stroke="#F59E0B" stroke-width="1" opacity="0">
+    <animate attributeName="r" values="20;48" dur="2.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.6;0" dur="2.5s" repeatCount="indefinite"/>
+  </circle>
+</svg>

--- a/frontend/public/logo-n.svg
+++ b/frontend/public/logo-n.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <defs>
+    <linearGradient id="traceGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#14B8A6" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#14B8A6" stop-opacity="0.8"/>
+    </linearGradient>
+    <radialGradient id="coreGlow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#5EEAD4"/>
+      <stop offset="70%" stop-color="#14B8A6"/>
+      <stop offset="100%" stop-color="#0D9488"/>
+    </radialGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="1.5" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <circle cx="60" cy="60" r="52" fill="#1a1a2e" stroke="#2a2a4a" stroke-width="1.5"/>
+
+  <circle cx="60" cy="60" r="46" fill="none" stroke="url(#traceGrad)" stroke-width="0.8" stroke-dasharray="4 6" opacity="0.6">
+    <animateTransform attributeName="transform" type="rotate" from="0 60 60" to="360 60 60" dur="55s" repeatCount="indefinite"/>
+  </circle>
+
+  <g stroke="#14B8A6" stroke-width="1.2" stroke-linecap="round" opacity="0">
+    <line x1="48" y1="8" x2="48" y2="18"/><line x1="60" y1="5" x2="60" y2="15"/><line x1="72" y1="8" x2="72" y2="18"/>
+    <line x1="48" y1="112" x2="48" y2="102"/><line x1="60" y1="115" x2="60" y2="105"/><line x1="72" y1="112" x2="72" y2="102"/>
+    <line x1="8" y1="48" x2="18" y2="48"/><line x1="5" y1="60" x2="15" y2="60"/><line x1="8" y1="72" x2="18" y2="72"/>
+    <line x1="112" y1="48" x2="102" y2="48"/><line x1="115" y1="60" x2="105" y2="60"/><line x1="112" y1="72" x2="102" y2="72"/>
+    <animate attributeName="opacity" values="0;0.7;0" dur="3.5s" repeatCount="indefinite"/>
+  </g>
+
+  <g fill="#5EEAD4" opacity="0">
+    <circle cx="48" cy="8" r="1.5"/><circle cx="60" cy="5" r="1.5"/><circle cx="72" cy="8" r="1.5"/>
+    <circle cx="48" cy="112" r="1.5"/><circle cx="60" cy="115" r="1.5"/><circle cx="72" cy="112" r="1.5"/>
+    <circle cx="8" cy="48" r="1.5"/><circle cx="5" cy="60" r="1.5"/><circle cx="8" cy="72" r="1.5"/>
+    <circle cx="112" cy="48" r="1.5"/><circle cx="115" cy="60" r="1.5"/><circle cx="112" cy="72" r="1.5"/>
+    <animate attributeName="opacity" values="0;1;0" dur="3.5s" repeatCount="indefinite"/>
+  </g>
+
+  <g stroke="#14B8A6" stroke-width="0.6" fill="none" opacity="0.25">
+    <path d="M36 36 L28 28"/><path d="M84 36 L92 28"/><path d="M36 84 L28 92"/><path d="M84 84 L92 92"/>
+    <path d="M42 38 L38 38 L38 42"/><path d="M78 38 L82 38 L82 42"/><path d="M42 82 L38 82 L38 78"/><path d="M78 82 L82 82 L82 78"/>
+  </g>
+
+  <circle cx="60" cy="60" r="34" fill="none" stroke="#14B8A6" stroke-width="0.6" opacity="0.3"/>
+
+  <circle cx="60" cy="60" r="28" fill="none" stroke="#14B8A6" stroke-width="0.5" stroke-dasharray="2 8" opacity="0.4">
+    <animateTransform attributeName="transform" type="rotate" from="360 60 60" to="0 60 60" dur="35s" repeatCount="indefinite"/>
+  </circle>
+
+  <rect x="40" y="40" width="40" height="40" rx="4" fill="#1e1e3a" stroke="#14B8A6" stroke-width="1" opacity="0.8"/>
+
+  <rect x="43" y="43" width="34" height="34" rx="2" fill="url(#coreGlow)" opacity="0.15">
+    <animate attributeName="opacity" values="0.1;0.25;0.1" dur="4.5s" repeatCount="indefinite"/>
+  </rect>
+
+  <g filter="url(#glow)">
+    <text x="60" y="79" text-anchor="middle" font-family="'SF Pro Display', 'Inter', system-ui, sans-serif" font-size="58" font-weight="900" fill="#E2E8F0" letter-spacing="-1">N</text>
+  </g>
+
+  <g fill="#5EEAD4">
+    <circle cx="40" cy="40" r="1.5" opacity="0.6"/><circle cx="80" cy="40" r="1.5" opacity="0.6"/>
+    <circle cx="40" cy="80" r="1.5" opacity="0.6"/><circle cx="80" cy="80" r="1.5" opacity="0.6"/>
+  </g>
+
+  <circle cx="60" cy="60" r="20" fill="none" stroke="#14B8A6" stroke-width="1" opacity="0">
+    <animate attributeName="r" values="20;48" dur="3.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.6;0" dur="3.5s" repeatCount="indefinite"/>
+  </circle>
+</svg>

--- a/frontend/public/logo-t.svg
+++ b/frontend/public/logo-t.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <defs>
+    <linearGradient id="traceGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#8B5CF6" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#8B5CF6" stop-opacity="0.8"/>
+    </linearGradient>
+    <radialGradient id="coreGlow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#C4B5FD"/>
+      <stop offset="70%" stop-color="#8B5CF6"/>
+      <stop offset="100%" stop-color="#7C3AED"/>
+    </radialGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="1.5" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <circle cx="60" cy="60" r="52" fill="#1a1a2e" stroke="#2a2a4a" stroke-width="1.5"/>
+
+  <circle cx="60" cy="60" r="46" fill="none" stroke="url(#traceGrad)" stroke-width="0.8" stroke-dasharray="4 6" opacity="0.6">
+    <animateTransform attributeName="transform" type="rotate" from="0 60 60" to="360 60 60" dur="50s" repeatCount="indefinite"/>
+  </circle>
+
+  <g stroke="#8B5CF6" stroke-width="1.2" stroke-linecap="round" opacity="0">
+    <line x1="48" y1="8" x2="48" y2="18"/><line x1="60" y1="5" x2="60" y2="15"/><line x1="72" y1="8" x2="72" y2="18"/>
+    <line x1="48" y1="112" x2="48" y2="102"/><line x1="60" y1="115" x2="60" y2="105"/><line x1="72" y1="112" x2="72" y2="102"/>
+    <line x1="8" y1="48" x2="18" y2="48"/><line x1="5" y1="60" x2="15" y2="60"/><line x1="8" y1="72" x2="18" y2="72"/>
+    <line x1="112" y1="48" x2="102" y2="48"/><line x1="115" y1="60" x2="105" y2="60"/><line x1="112" y1="72" x2="102" y2="72"/>
+    <animate attributeName="opacity" values="0;0.7;0" dur="4s" repeatCount="indefinite"/>
+  </g>
+
+  <g fill="#C4B5FD" opacity="0">
+    <circle cx="48" cy="8" r="1.5"/><circle cx="60" cy="5" r="1.5"/><circle cx="72" cy="8" r="1.5"/>
+    <circle cx="48" cy="112" r="1.5"/><circle cx="60" cy="115" r="1.5"/><circle cx="72" cy="112" r="1.5"/>
+    <circle cx="8" cy="48" r="1.5"/><circle cx="5" cy="60" r="1.5"/><circle cx="8" cy="72" r="1.5"/>
+    <circle cx="112" cy="48" r="1.5"/><circle cx="115" cy="60" r="1.5"/><circle cx="112" cy="72" r="1.5"/>
+    <animate attributeName="opacity" values="0;1;0" dur="4s" repeatCount="indefinite"/>
+  </g>
+
+  <g stroke="#8B5CF6" stroke-width="0.6" fill="none" opacity="0.25">
+    <path d="M36 36 L28 28"/><path d="M84 36 L92 28"/><path d="M36 84 L28 92"/><path d="M84 84 L92 92"/>
+    <path d="M42 38 L38 38 L38 42"/><path d="M78 38 L82 38 L82 42"/><path d="M42 82 L38 82 L38 78"/><path d="M78 82 L82 82 L82 78"/>
+  </g>
+
+  <circle cx="60" cy="60" r="34" fill="none" stroke="#8B5CF6" stroke-width="0.6" opacity="0.3"/>
+
+  <circle cx="60" cy="60" r="28" fill="none" stroke="#8B5CF6" stroke-width="0.5" stroke-dasharray="2 8" opacity="0.4">
+    <animateTransform attributeName="transform" type="rotate" from="360 60 60" to="0 60 60" dur="45s" repeatCount="indefinite"/>
+  </circle>
+
+  <rect x="40" y="40" width="40" height="40" rx="4" fill="#1e1e3a" stroke="#8B5CF6" stroke-width="1" opacity="0.8"/>
+
+  <rect x="43" y="43" width="34" height="34" rx="2" fill="url(#coreGlow)" opacity="0.15">
+    <animate attributeName="opacity" values="0.1;0.25;0.1" dur="5s" repeatCount="indefinite"/>
+  </rect>
+
+  <g filter="url(#glow)">
+    <text x="60" y="79" text-anchor="middle" font-family="'SF Pro Display', 'Inter', system-ui, sans-serif" font-size="58" font-weight="900" fill="#E2E8F0" letter-spacing="-1">T</text>
+  </g>
+
+  <g fill="#C4B5FD">
+    <circle cx="40" cy="40" r="1.5" opacity="0.6"/><circle cx="80" cy="40" r="1.5" opacity="0.6"/>
+    <circle cx="40" cy="80" r="1.5" opacity="0.6"/><circle cx="80" cy="80" r="1.5" opacity="0.6"/>
+  </g>
+
+  <circle cx="60" cy="60" r="20" fill="none" stroke="#8B5CF6" stroke-width="1" opacity="0">
+    <animate attributeName="r" values="20;48" dur="4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.6;0" dur="4s" repeatCount="indefinite"/>
+  </circle>
+</svg>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,21 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import ProtectedRoute from './components/auth/ProtectedRoute'
+import Layout from './components/layout/Layout'
+import Login from './pages/Login'
+import Dashboard from './pages/Dashboard'
+import Approvals from './pages/Approvals'
+import ApprovalDetail from './pages/ApprovalDetail'
+import Treasury from './pages/Treasury'
+import TreasuryHistory from './pages/TreasuryHistory'
+import Strategies from './pages/Strategies'
+import StrategyDetail from './pages/StrategyDetail'
+import Bots from './pages/Bots'
+import BotDetail from './pages/BotDetail'
+import BacktestData from './pages/BacktestData'
+import Agents from './pages/Agents'
+import AgentDetail from './pages/AgentDetail'
+import Settings from './pages/Settings'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -10,36 +26,34 @@ const queryClient = new QueryClient({
   },
 })
 
-function DashboardPlaceholder() {
-  return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-50">
-      <div className="text-center">
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">Ante Dashboard</h1>
-        <p className="text-gray-500">AI-Native Trading Engine</p>
-      </div>
-    </div>
-  )
-}
-
-function LoginPlaceholder() {
-  return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-50">
-      <div className="text-center">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">Login</h1>
-        <p className="text-gray-500">로그인 페이지 (구현 예정)</p>
-      </div>
-    </div>
-  )
-}
-
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <Routes>
-          <Route path="/login" element={<LoginPlaceholder />} />
-          <Route path="/dashboard" element={<DashboardPlaceholder />} />
-          <Route path="*" element={<Navigate to="/dashboard" replace />} />
+          <Route path="/login" element={<Login />} />
+          <Route
+            element={
+              <ProtectedRoute>
+                <Layout />
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<Dashboard />} />
+            <Route path="approvals" element={<Approvals />} />
+            <Route path="approvals/:id" element={<ApprovalDetail />} />
+            <Route path="treasury" element={<Treasury />} />
+            <Route path="treasury/history" element={<TreasuryHistory />} />
+            <Route path="strategies" element={<Strategies />} />
+            <Route path="strategies/:id" element={<StrategyDetail />} />
+            <Route path="bots" element={<Bots />} />
+            <Route path="bots/:id" element={<BotDetail />} />
+            <Route path="backtest-data" element={<BacktestData />} />
+            <Route path="agents" element={<Agents />} />
+            <Route path="agents/:id" element={<AgentDetail />} />
+            <Route path="settings" element={<Settings />} />
+          </Route>
+          <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </BrowserRouter>
     </QueryClientProvider>

--- a/frontend/src/api/approvals.ts
+++ b/frontend/src/api/approvals.ts
@@ -1,0 +1,37 @@
+import client from './client'
+import type { Approval, ApprovalDetail, ApprovalStatus, ApprovalType } from '../types/approval'
+
+interface ApprovalsParams {
+  status?: ApprovalStatus | 'all'
+  type?: ApprovalType | 'all'
+  offset?: number
+  limit?: number
+}
+
+interface ApprovalsResponse {
+  items: Approval[]
+  total: number
+}
+
+export async function getApprovals(params: ApprovalsParams): Promise<ApprovalsResponse> {
+  const query: Record<string, string | number> = {}
+  if (params.status && params.status !== 'all') query.status = params.status
+  if (params.type && params.type !== 'all') query.type = params.type
+  if (params.offset) query.offset = params.offset
+  if (params.limit) query.limit = params.limit
+  const res = await client.get('/api/approvals', { params: query })
+  return res.data
+}
+
+export async function getApprovalDetail(id: number): Promise<ApprovalDetail> {
+  const res = await client.get(`/api/approvals/${id}`)
+  return res.data
+}
+
+export async function updateApprovalStatus(
+  id: number,
+  status: 'approved' | 'rejected',
+  memo?: string,
+): Promise<void> {
+  await client.patch(`/api/approvals/${id}/status`, { status, memo })
+}

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,16 @@
+import client from './client'
+import type { LoginRequest, LoginResponse, User } from '../types/auth'
+
+export async function login(data: LoginRequest): Promise<LoginResponse> {
+  const res = await client.post('/api/auth/login', data)
+  return res.data
+}
+
+export async function logout(): Promise<void> {
+  await client.post('/api/auth/logout')
+}
+
+export async function getMe(): Promise<User> {
+  const res = await client.get('/api/auth/me')
+  return res.data
+}

--- a/frontend/src/api/bots.ts
+++ b/frontend/src/api/bots.ts
@@ -1,0 +1,29 @@
+import client from './client'
+import type { Bot, BotDetail, BotCreateRequest } from '../types/bot'
+
+export async function getBots(): Promise<{ items: Bot[] }> {
+  const res = await client.get('/api/bots')
+  return res.data
+}
+
+export async function getBotDetail(botId: string): Promise<BotDetail> {
+  const res = await client.get(`/api/bots/${botId}`)
+  return res.data
+}
+
+export async function createBot(data: BotCreateRequest): Promise<Bot> {
+  const res = await client.post('/api/bots', data)
+  return res.data
+}
+
+export async function startBot(botId: string): Promise<void> {
+  await client.post(`/api/bots/${botId}/start`)
+}
+
+export async function stopBot(botId: string): Promise<void> {
+  await client.post(`/api/bots/${botId}/stop`)
+}
+
+export async function deleteBot(botId: string): Promise<void> {
+  await client.delete(`/api/bots/${botId}`)
+}

--- a/frontend/src/api/data.ts
+++ b/frontend/src/api/data.ts
@@ -1,0 +1,34 @@
+import client from './client'
+
+export interface Dataset {
+  id: number
+  symbol: string
+  timeframe: string
+  start_date: string
+  end_date: string
+  row_count: number
+}
+
+export interface StorageInfo {
+  total_size_bytes: number
+  dataset_count: number
+}
+
+export async function getDatasets(params?: {
+  symbol?: string
+  timeframe?: string
+  offset?: number
+  limit?: number
+}): Promise<{ items: Dataset[]; total: number }> {
+  const res = await client.get('/api/data/datasets', { params })
+  return res.data
+}
+
+export async function getStorageInfo(): Promise<StorageInfo> {
+  const res = await client.get('/api/data/storage')
+  return res.data
+}
+
+export async function deleteDataset(id: number): Promise<void> {
+  await client.delete(`/api/data/datasets/${id}`)
+}

--- a/frontend/src/api/members.ts
+++ b/frontend/src/api/members.ts
@@ -1,0 +1,42 @@
+import client from './client'
+import type { Member, MemberDetail, MemberCreateRequest } from '../types/member'
+
+export async function getMembers(params?: {
+  type?: string
+  org?: string
+  status?: string
+}): Promise<Member[]> {
+  const res = await client.get('/api/members', { params })
+  return res.data
+}
+
+export async function getMemberDetail(id: string): Promise<MemberDetail> {
+  const res = await client.get(`/api/members/${id}`)
+  return res.data
+}
+
+export async function createMember(data: MemberCreateRequest): Promise<{ token: string }> {
+  const res = await client.post('/api/members', data)
+  return res.data
+}
+
+export async function suspendMember(id: string): Promise<void> {
+  await client.post(`/api/members/${id}/suspend`)
+}
+
+export async function reactivateMember(id: string): Promise<void> {
+  await client.post(`/api/members/${id}/reactivate`)
+}
+
+export async function revokeMember(id: string): Promise<void> {
+  await client.post(`/api/members/${id}/revoke`)
+}
+
+export async function rotateToken(id: string): Promise<{ token: string }> {
+  const res = await client.post(`/api/members/${id}/rotate-token`)
+  return res.data
+}
+
+export async function updateScopes(id: string, scopes: string[]): Promise<void> {
+  await client.put(`/api/members/${id}/scopes`, { scopes })
+}

--- a/frontend/src/api/portfolio.ts
+++ b/frontend/src/api/portfolio.ts
@@ -1,0 +1,12 @@
+import client from './client'
+import type { PortfolioValue, PortfolioHistoryPoint, Period } from '../types/portfolio'
+
+export async function getPortfolioValue(): Promise<PortfolioValue> {
+  const res = await client.get('/api/portfolio/value')
+  return res.data
+}
+
+export async function getPortfolioHistory(period: Period): Promise<PortfolioHistoryPoint[]> {
+  const res = await client.get('/api/portfolio/history', { params: { period } })
+  return res.data
+}

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -1,0 +1,25 @@
+import client from './client'
+import type { Strategy, StrategyDetail, StrategyPerformance, Trade } from '../types/strategy'
+
+export async function getStrategies(): Promise<Strategy[]> {
+  const res = await client.get('/api/strategies')
+  return res.data
+}
+
+export async function getStrategyDetail(id: number): Promise<StrategyDetail> {
+  const res = await client.get(`/api/strategies/${id}`)
+  return res.data
+}
+
+export async function getStrategyPerformance(id: number): Promise<StrategyPerformance> {
+  const res = await client.get(`/api/strategies/${id}/performance`)
+  return res.data
+}
+
+export async function getStrategyTrades(
+  id: number,
+  params?: { cursor?: number; limit?: number },
+): Promise<{ items: Trade[]; next_cursor?: number }> {
+  const res = await client.get(`/api/strategies/${id}/trades`, { params })
+  return res.data
+}

--- a/frontend/src/api/system.ts
+++ b/frontend/src/api/system.ts
@@ -1,0 +1,20 @@
+import client from './client'
+import type { SystemStatus, DynamicConfig } from '../types/system'
+
+export async function getSystemStatus(): Promise<SystemStatus> {
+  const res = await client.get('/api/system/status')
+  return res.data
+}
+
+export async function setKillSwitch(enabled: boolean): Promise<void> {
+  await client.post('/api/system/kill-switch', { enabled })
+}
+
+export async function getConfigs(): Promise<DynamicConfig[]> {
+  const res = await client.get('/api/config')
+  return res.data
+}
+
+export async function updateConfig(key: string, value: string): Promise<void> {
+  await client.put(`/api/config/${encodeURIComponent(key)}`, { value })
+}

--- a/frontend/src/api/treasury.ts
+++ b/frontend/src/api/treasury.ts
@@ -1,0 +1,28 @@
+import client from './client'
+import type { TreasurySummary, BotBudget, TreasuryTransaction } from '../types/treasury'
+
+export async function getTreasurySummary(): Promise<TreasurySummary> {
+  const res = await client.get('/api/treasury')
+  return res.data
+}
+
+export async function getBotBudgets(): Promise<BotBudget[]> {
+  const res = await client.get('/api/treasury/budgets')
+  return res.data
+}
+
+export async function allocateBudget(botId: string, amount: number): Promise<void> {
+  await client.post(`/api/treasury/bots/${botId}/allocate`, { amount })
+}
+
+export async function deallocateBudget(botId: string, amount: number): Promise<void> {
+  await client.post(`/api/treasury/bots/${botId}/deallocate`, { amount })
+}
+
+export async function getTreasuryHistory(params: {
+  offset?: number
+  limit?: number
+}): Promise<{ items: TreasuryTransaction[]; total: number }> {
+  const res = await client.get('/api/audit', { params: { ...params, category: 'treasury' } })
+  return res.data
+}

--- a/frontend/src/components/agents/AgentRegisterForm.tsx
+++ b/frontend/src/components/agents/AgentRegisterForm.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+import { useCreateMember } from '../../hooks/useMembers'
+import { ALL_SCOPES } from '../../types/member'
+
+interface AgentRegisterFormProps {
+  onClose: () => void
+  onTokenCreated: (token: string) => void
+}
+
+export default function AgentRegisterForm({ onClose, onTokenCreated }: AgentRegisterFormProps) {
+  const [memberId, setMemberId] = useState('')
+  const [name, setName] = useState('')
+  const [org, setOrg] = useState('')
+  const [scopes, setScopes] = useState<string[]>([])
+  const createMember = useCreateMember()
+
+  const toggleScope = (scope: string) => {
+    setScopes((prev) => prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope])
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    createMember.mutate(
+      { member_id: memberId, name, org, scopes },
+      { onSuccess: (data) => onTokenCreated(data.token) },
+    )
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+      <div className="bg-surface border border-border rounded-lg p-6 w-[480px] max-h-[90vh] overflow-y-auto">
+        <h2 className="text-[18px] font-bold mb-5">에이전트 등록</h2>
+        <form onSubmit={handleSubmit}>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">Agent ID</label>
+            <input value={memberId} onChange={(e) => setMemberId(e.target.value)} placeholder="agent-research-01" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
+          </div>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">이름</label>
+            <input value={name} onChange={(e) => setName(e.target.value)} placeholder="리서치 에이전트" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
+          </div>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">소속 (org)</label>
+            <input value={org} onChange={(e) => setOrg(e.target.value)} placeholder="research" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
+          </div>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-2">권한 범위</label>
+            <div className="grid grid-cols-2 gap-2">
+              {ALL_SCOPES.map((scope) => (
+                <label key={scope} className="flex items-center gap-2 text-[13px] cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={scopes.includes(scope)}
+                    onChange={() => toggleScope(scope)}
+                    className="accent-primary"
+                  />
+                  <span className="font-mono text-[12px]">{scope}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+          <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
+            <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
+            <button type="submit" disabled={createMember.isPending} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50">등록</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/agents/AgentTable.tsx
+++ b/frontend/src/components/agents/AgentTable.tsx
@@ -1,0 +1,69 @@
+import { useNavigate } from 'react-router-dom'
+import StatusBadge from '../common/StatusBadge'
+import { formatDateTime } from '../../utils/formatters'
+import { MEMBER_STATUS_LABELS } from '../../utils/constants'
+import type { Member, MemberStatus } from '../../types/member'
+
+const STATUS_VARIANT: Record<MemberStatus, string> = {
+  active: 'positive', suspended: 'warning', revoked: 'negative',
+}
+
+interface AgentTableProps {
+  items: Member[]
+  onSuspend: (id: string) => void
+  onReactivate: (id: string) => void
+  onRevoke: (id: string) => void
+}
+
+export default function AgentTable({ items, onSuspend, onReactivate, onRevoke }: AgentTableProps) {
+  const navigate = useNavigate()
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">ID</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">이름</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">소속</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">상태</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">마지막 활동</th>
+            <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.length === 0 ? (
+            <tr><td colSpan={6} className="px-3 py-8 text-center text-text-muted text-[13px]">등록된 에이전트가 없습니다</td></tr>
+          ) : (
+            items.map((m) => (
+              <tr key={m.member_id} onClick={() => navigate(`/agents/${m.member_id}`)} className="hover:bg-surface-hover cursor-pointer">
+                <td className="px-3 py-3 border-b border-border text-[13px] font-mono font-medium">{m.member_id}</td>
+                <td className="px-3 py-3 border-b border-border text-[13px]">{m.name}</td>
+                <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{m.org}</td>
+                <td className="px-3 py-3 border-b border-border text-[13px]">
+                  <StatusBadge variant={STATUS_VARIANT[m.status] as 'positive'}>{MEMBER_STATUS_LABELS[m.status]}</StatusBadge>
+                </td>
+                <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">
+                  {m.last_active_at ? formatDateTime(m.last_active_at) : '-'}
+                </td>
+                <td className="px-3 py-3 border-b border-border text-[13px] text-right">
+                  <div className="flex gap-2 justify-end" onClick={(e) => e.stopPropagation()}>
+                    {m.status === 'active' && (
+                      <button onClick={() => onSuspend(m.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-warning border border-border cursor-pointer hover:bg-warning-bg">정지</button>
+                    )}
+                    {m.status === 'suspended' && (
+                      <button onClick={() => onReactivate(m.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">재활성화</button>
+                    )}
+                    {m.status !== 'revoked' && (
+                      <button onClick={() => onRevoke(m.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-negative border border-border cursor-pointer hover:bg-negative-bg">폐기</button>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/approvals/ApprovalFilters.tsx
+++ b/frontend/src/components/approvals/ApprovalFilters.tsx
@@ -1,0 +1,52 @@
+import type { ApprovalStatus, ApprovalType } from '../../types/approval'
+
+const STATUS_OPTIONS: { key: ApprovalStatus | 'all'; label: string }[] = [
+  { key: 'all', label: '전체' },
+  { key: 'pending', label: '대기' },
+  { key: 'approved', label: '승인' },
+  { key: 'rejected', label: '거부' },
+]
+
+const TYPE_OPTIONS: { key: ApprovalType | 'all'; label: string }[] = [
+  { key: 'all', label: '전체' },
+  { key: 'strategy_report', label: '전략 리포트' },
+  { key: 'budget_allocation', label: '예산 할당' },
+  { key: 'live_switch', label: '실전 전환' },
+  { key: 'risk_alert', label: '위험 알림' },
+]
+
+interface ApprovalFiltersProps {
+  status: ApprovalStatus | 'all'
+  type: ApprovalType | 'all'
+  onStatusChange: (s: ApprovalStatus | 'all') => void
+  onTypeChange: (t: ApprovalType | 'all') => void
+}
+
+export default function ApprovalFilters({ status, type, onStatusChange, onTypeChange }: ApprovalFiltersProps) {
+  return (
+    <div className="flex items-center gap-3 mb-4 flex-wrap">
+      <div className="flex gap-1 bg-bg rounded-lg p-0.5">
+        {STATUS_OPTIONS.map((opt) => (
+          <button
+            key={opt.key}
+            onClick={() => onStatusChange(opt.key)}
+            className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
+              status === opt.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
+            }`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+      <select
+        value={type}
+        onChange={(e) => onTypeChange(e.target.value as ApprovalType | 'all')}
+        className="bg-bg border border-border rounded-lg px-3 py-1.5 text-text text-[13px] cursor-pointer"
+      >
+        {TYPE_OPTIONS.map((opt) => (
+          <option key={opt.key} value={opt.key}>{opt.label}</option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/frontend/src/components/approvals/ApprovalTable.tsx
+++ b/frontend/src/components/approvals/ApprovalTable.tsx
@@ -1,0 +1,68 @@
+import { useNavigate } from 'react-router-dom'
+import StatusBadge from '../common/StatusBadge'
+import { formatDateTime } from '../../utils/formatters'
+import type { Approval, ApprovalStatus, ApprovalType } from '../../types/approval'
+import { APPROVAL_STATUS_LABELS } from '../../utils/constants'
+
+const TYPE_BADGE: Record<ApprovalType, { label: string; variant: string }> = {
+  strategy_report: { label: '전략 리포트', variant: 'info' },
+  budget_allocation: { label: '예산 할당', variant: 'primary' },
+  live_switch: { label: '실전 전환', variant: 'warning' },
+  risk_alert: { label: '위험 알림', variant: 'negative' },
+}
+
+const STATUS_VARIANT: Record<ApprovalStatus, string> = {
+  pending: 'warning',
+  approved: 'positive',
+  rejected: 'negative',
+}
+
+export default function ApprovalTable({ items }: { items: Approval[] }) {
+  const navigate = useNavigate()
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">유형</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">제목</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">요청자</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">요청일</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">상태</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.length === 0 ? (
+            <tr>
+              <td colSpan={5} className="px-3 py-8 text-center text-text-muted text-[13px]">결재 항목이 없습니다</td>
+            </tr>
+          ) : (
+            items.map((item) => {
+              const typeInfo = TYPE_BADGE[item.type] || { label: item.type, variant: 'muted' }
+              return (
+                <tr
+                  key={item.id}
+                  onClick={() => navigate(`/approvals/${item.id}`)}
+                  className="hover:bg-surface-hover cursor-pointer"
+                >
+                  <td className="px-3 py-3 border-b border-border text-[13px]">
+                    <StatusBadge variant={typeInfo.variant as 'info'}>{typeInfo.label}</StatusBadge>
+                  </td>
+                  <td className="px-3 py-3 border-b border-border text-[13px]">{item.title}</td>
+                  <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{item.requester}</td>
+                  <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{formatDateTime(item.requested_at)}</td>
+                  <td className="px-3 py-3 border-b border-border text-[13px]">
+                    <StatusBadge variant={STATUS_VARIANT[item.status] as 'warning'}>
+                      {APPROVAL_STATUS_LABELS[item.status] || item.status}
+                    </StatusBadge>
+                  </td>
+                </tr>
+              )
+            })
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/approvals/BacktestMetrics.tsx
+++ b/frontend/src/components/approvals/BacktestMetrics.tsx
@@ -1,0 +1,31 @@
+import HintTooltip from '../common/HintTooltip'
+import { formatPercent, formatNumber } from '../../utils/formatters'
+import type { BacktestMetrics as Metrics } from '../../types/approval'
+
+const METRIC_DEFS: { key: keyof Metrics; label: string; hint: string; format: (v: number) => string }[] = [
+  { key: 'sharpe_ratio', label: '샤프 비율', hint: '위험 대비 수익 효율. 높을수록 안정적인 수익', format: (v) => v.toFixed(2) },
+  { key: 'max_drawdown', label: '최대 낙폭 (MDD)', hint: '고점 대비 최대 하락 폭', format: (v) => formatPercent(v) },
+  { key: 'win_rate', label: '승률', hint: '수익 거래 비율', format: (v) => formatPercent(v) },
+  { key: 'profit_factor', label: '수익 팩터', hint: '총 이익 / 총 손실. 1 이상이면 수익', format: (v) => v.toFixed(2) },
+  { key: 'total_trades', label: '총 거래 수', hint: '백테스트 기간 중 총 거래 횟수', format: (v) => formatNumber(v) },
+  { key: 'total_return', label: '총 수익률', hint: '백테스트 기간 총 수익률', format: (v) => formatPercent(v) },
+]
+
+export default function BacktestMetricsPanel({ metrics }: { metrics: Metrics }) {
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+      <h3 className="text-[15px] font-semibold mb-4">성과 지표</h3>
+      <div className="grid grid-cols-3 gap-4">
+        {METRIC_DEFS.map((def) => (
+          <div key={def.key} className="bg-bg rounded-lg p-4">
+            <div className="text-[12px] text-text-muted mb-1">
+              {def.label}
+              <HintTooltip text={def.hint} />
+            </div>
+            <div className="text-[20px] font-bold">{def.format(metrics[def.key])}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/approvals/ReviewControls.tsx
+++ b/frontend/src/components/approvals/ReviewControls.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+import { useUpdateApprovalStatus } from '../../hooks/useApprovals'
+
+export default function ReviewControls({ approvalId, isPending }: { approvalId: number; isPending: boolean }) {
+  const [memo, setMemo] = useState('')
+  const updateStatus = useUpdateApprovalStatus()
+
+  if (!isPending) return null
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+      <h3 className="text-[15px] font-semibold mb-3">결재</h3>
+      <textarea
+        value={memo}
+        onChange={(e) => setMemo(e.target.value)}
+        placeholder="메모 (선택)"
+        rows={3}
+        className="w-full bg-bg border border-border rounded-lg p-3 text-text text-[14px] placeholder:text-text-muted focus:outline-none focus:border-primary resize-vertical mb-3"
+      />
+      <div className="flex gap-2">
+        <button
+          onClick={() => updateStatus.mutate({ id: approvalId, status: 'approved', memo: memo || undefined })}
+          disabled={updateStatus.isPending}
+          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover disabled:opacity-50"
+        >
+          승인
+        </button>
+        <button
+          onClick={() => updateStatus.mutate({ id: approvalId, status: 'rejected', memo: memo || undefined })}
+          disabled={updateStatus.isPending}
+          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative-hover disabled:opacity-50"
+        >
+          거부
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react'
+import { useLogin } from '../../hooks/useAuth'
+
+export default function LoginForm() {
+  const [memberId, setMemberId] = useState('')
+  const [password, setPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const loginMutation = useLogin()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    loginMutation.mutate({ member_id: memberId, password })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="text-left">
+      {loginMutation.isError && (
+        <div className="bg-negative-bg text-negative px-3.5 py-2.5 rounded-lg text-[13px] mb-4">
+          ID 또는 패스워드가 올바르지 않습니다.
+        </div>
+      )}
+
+      <div className="mb-4">
+        <label className="block text-[12px] font-semibold text-text-muted mb-1.5">
+          Member ID
+        </label>
+        <input
+          type="text"
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          placeholder="owner"
+          autoFocus
+          className="w-full bg-bg border border-border rounded-lg py-3 px-3.5 text-text text-[14px] placeholder:text-text-muted focus:outline-none focus:border-primary"
+        />
+      </div>
+
+      <div className="mb-4">
+        <label className="block text-[12px] font-semibold text-text-muted mb-1.5">
+          패스워드
+        </label>
+        <div className="relative">
+          <input
+            type={showPassword ? 'text' : 'password'}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="패스워드를 입력하세요"
+            className="w-full bg-bg border border-border rounded-lg py-3 px-3.5 text-text text-[14px] placeholder:text-text-muted focus:outline-none focus:border-primary"
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 bg-transparent border-none text-text-muted cursor-pointer text-[14px]"
+            title="패스워드 표시"
+          >
+            {showPassword ? '🙈' : '👁'}
+          </button>
+        </div>
+      </div>
+
+      <button
+        type="submit"
+        disabled={loginMutation.isPending || !memberId || !password}
+        className="w-full py-3 bg-primary text-white rounded-lg text-[14px] font-semibold mt-2 hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer border-none"
+      >
+        {loginMutation.isPending ? '로그인 중...' : '로그인'}
+      </button>
+    </form>
+  )
+}

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,17 @@
+import { Navigate } from 'react-router-dom'
+import { useUser } from '../../hooks/useAuth'
+import LoadingSpinner from '../common/LoadingSpinner'
+
+export default function ProtectedRoute({ children }: { children: React.ReactNode }) {
+  const { data: user, isLoading, isError } = useUser()
+
+  if (isLoading) {
+    return <LoadingSpinner className="min-h-screen" />
+  }
+
+  if (isError || !user) {
+    return <Navigate to="/login" replace />
+  }
+
+  return <>{children}</>
+}

--- a/frontend/src/components/bots/BotCreateForm.tsx
+++ b/frontend/src/components/bots/BotCreateForm.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react'
+import { useCreateBot } from '../../hooks/useBots'
+import type { BotMode } from '../../types/bot'
+
+interface BotCreateFormProps {
+  onClose: () => void
+}
+
+export default function BotCreateForm({ onClose }: BotCreateFormProps) {
+  const [botId, setBotId] = useState('')
+  const [strategyName, setStrategyName] = useState('')
+  const [mode, setMode] = useState<BotMode>('paper')
+  const [interval, setInterval] = useState('60')
+  const [budget, setBudget] = useState('')
+  const [symbols, setSymbols] = useState('')
+  const createBot = useCreateBot()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    createBot.mutate(
+      {
+        bot_id: botId,
+        strategy_name: strategyName,
+        mode,
+        interval_seconds: Number(interval),
+        budget: Number(budget),
+        symbols: symbols.split(',').map((s) => s.trim()).filter(Boolean),
+      },
+      { onSuccess: onClose },
+    )
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+      <div className="bg-surface border border-border rounded-lg p-6 w-[480px] max-h-[90vh] overflow-y-auto">
+        <h2 className="text-[18px] font-bold mb-5">봇 생성</h2>
+        <form onSubmit={handleSubmit}>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">봇 ID</label>
+            <input value={botId} onChange={(e) => setBotId(e.target.value)} placeholder="bot-momentum-01" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
+          </div>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">전략</label>
+            <input value={strategyName} onChange={(e) => setStrategyName(e.target.value)} placeholder="전략명" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
+          </div>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">봇 유형</label>
+            <div className="flex gap-2">
+              <button type="button" onClick={() => setMode('paper')} className={`flex-1 py-2 rounded-lg text-[13px] font-medium border cursor-pointer ${mode === 'paper' ? 'bg-primary text-white border-primary' : 'bg-transparent text-text-muted border-border hover:bg-surface-hover'}`}>모의투자</button>
+              <button type="button" onClick={() => setMode('live')} className={`flex-1 py-2 rounded-lg text-[13px] font-medium border cursor-pointer ${mode === 'live' ? 'bg-warning text-black border-warning' : 'bg-transparent text-text-muted border-border hover:bg-surface-hover'}`}>실전투자</button>
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">실행 간격 (초)</label>
+            <input type="number" value={interval} onChange={(e) => setInterval(e.target.value)} className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" />
+          </div>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">예산 (원)</label>
+            <input type="number" value={budget} onChange={(e) => setBudget(e.target.value)} placeholder="5000000" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
+          </div>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">대상 종목 (콤마 구분)</label>
+            <input value={symbols} onChange={(e) => setSymbols(e.target.value)} placeholder="005930, 035420" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" />
+            <div className="text-[11px] text-text-muted mt-1">선택사항</div>
+          </div>
+          <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
+            <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
+            <button type="submit" disabled={createBot.isPending} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50">생성</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/bots/BotTable.tsx
+++ b/frontend/src/components/bots/BotTable.tsx
@@ -1,0 +1,65 @@
+import { useNavigate } from 'react-router-dom'
+import StatusBadge from '../common/StatusBadge'
+import { BOT_STATUS_LABELS } from '../../utils/constants'
+import type { Bot, BotStatus } from '../../types/bot'
+
+const STATUS_VARIANT: Record<BotStatus, string> = {
+  created: 'muted', running: 'positive', stopping: 'warning', stopped: 'muted', error: 'negative', deleted: 'muted',
+}
+
+interface BotTableProps {
+  items: Bot[]
+  onStart: (id: string) => void
+  onStop: (id: string) => void
+  onDelete: (id: string) => void
+}
+
+export default function BotTable({ items, onStart, onStop, onDelete }: BotTableProps) {
+  const navigate = useNavigate()
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">ID</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">전략</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">상태</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">유형</th>
+            <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.length === 0 ? (
+            <tr><td colSpan={5} className="px-3 py-8 text-center text-text-muted text-[13px]">등록된 봇이 없습니다</td></tr>
+          ) : (
+            items.map((bot) => (
+              <tr key={bot.bot_id} onClick={() => navigate(`/bots/${bot.bot_id}`)} className="hover:bg-surface-hover cursor-pointer">
+                <td className="px-3 py-3 border-b border-border text-[13px] font-mono font-medium">{bot.bot_id}</td>
+                <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{bot.strategy_name || '-'}</td>
+                <td className="px-3 py-3 border-b border-border text-[13px]">
+                  <StatusBadge variant={STATUS_VARIANT[bot.status] as 'positive'}>{BOT_STATUS_LABELS[bot.status] || bot.status}</StatusBadge>
+                </td>
+                <td className="px-3 py-3 border-b border-border text-[13px]">
+                  <StatusBadge variant={bot.mode === 'live' ? 'warning' : 'info'}>
+                    {bot.mode === 'live' ? '실전' : '모의'}
+                  </StatusBadge>
+                </td>
+                <td className="px-3 py-3 border-b border-border text-[13px] text-right">
+                  <div className="flex gap-2 justify-end" onClick={(e) => e.stopPropagation()}>
+                    {bot.status === 'stopped' || bot.status === 'created' ? (
+                      <button onClick={() => onStart(bot.bot_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">시작</button>
+                    ) : bot.status === 'running' ? (
+                      <button onClick={() => onStop(bot.bot_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">중지</button>
+                    ) : null}
+                    <button onClick={() => onDelete(bot.bot_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-negative border border-border cursor-pointer hover:bg-negative-bg">삭제</button>
+                  </div>
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/common/DataTable.tsx
+++ b/frontend/src/components/common/DataTable.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from 'react'
+
+export interface Column<T> {
+  key: string
+  header: string
+  render: (item: T) => ReactNode
+  align?: 'left' | 'right'
+}
+
+interface DataTableProps<T> {
+  columns: Column<T>[]
+  data: T[]
+  onRowClick?: (item: T) => void
+  emptyMessage?: string
+}
+
+export default function DataTable<T>({ columns, data, onRowClick, emptyMessage = '데이터가 없습니다' }: DataTableProps<T>) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            {columns.map((col) => (
+              <th
+                key={col.key}
+                className={`text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border ${col.align === 'right' ? 'text-right' : ''}`}
+              >
+                {col.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.length === 0 ? (
+            <tr>
+              <td colSpan={columns.length} className="px-3 py-8 text-center text-text-muted text-[13px]">
+                {emptyMessage}
+              </td>
+            </tr>
+          ) : (
+            data.map((item, i) => (
+              <tr
+                key={i}
+                onClick={() => onRowClick?.(item)}
+                className={`hover:bg-surface-hover ${onRowClick ? 'cursor-pointer' : ''}`}
+              >
+                {columns.map((col) => (
+                  <td
+                    key={col.key}
+                    className={`px-3 py-3 border-b border-border text-[13px] last:border-b-0 ${col.align === 'right' ? 'text-right' : ''}`}
+                  >
+                    {col.render(item)}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/common/HintTooltip.tsx
+++ b/frontend/src/components/common/HintTooltip.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+
+export default function HintTooltip({ text }: { text: string }) {
+  const [show, setShow] = useState(false)
+
+  return (
+    <span
+      className="relative inline-flex items-center ml-1 cursor-help"
+      onMouseEnter={() => setShow(true)}
+      onMouseLeave={() => setShow(false)}
+    >
+      <span className="w-4 h-4 rounded-full bg-[rgba(139,143,163,0.15)] text-text-muted text-[10px] font-bold flex items-center justify-center">
+        ?
+      </span>
+      {show && (
+        <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-surface border border-border rounded-lg text-[12px] text-text-muted whitespace-nowrap z-50 shadow-lg">
+          {text}
+        </span>
+      )}
+    </span>
+  )
+}

--- a/frontend/src/components/common/LoadingSpinner.tsx
+++ b/frontend/src/components/common/LoadingSpinner.tsx
@@ -1,0 +1,7 @@
+export default function LoadingSpinner({ className = '' }: { className?: string }) {
+  return (
+    <div className={`flex items-center justify-center py-12 ${className}`}>
+      <div className="w-8 h-8 border-2 border-border border-t-primary rounded-full animate-spin" />
+    </div>
+  )
+}

--- a/frontend/src/components/common/Pagination.tsx
+++ b/frontend/src/components/common/Pagination.tsx
@@ -1,0 +1,37 @@
+interface PaginationProps {
+  total: number
+  offset: number
+  limit: number
+  onPageChange: (offset: number) => void
+}
+
+export default function Pagination({ total, offset, limit, onPageChange }: PaginationProps) {
+  const start = offset + 1
+  const end = Math.min(offset + limit, total)
+  const hasPrev = offset > 0
+  const hasNext = offset + limit < total
+
+  return (
+    <div className="flex items-center justify-between pt-4 text-[13px]">
+      <span className="text-text-muted">
+        {total}건 중 {start}-{end}
+      </span>
+      <div className="flex gap-2">
+        <button
+          onClick={() => onPageChange(Math.max(0, offset - limit))}
+          disabled={!hasPrev}
+          className="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-border bg-transparent text-text-muted hover:bg-surface-hover hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          이전
+        </button>
+        <button
+          onClick={() => onPageChange(offset + limit)}
+          disabled={!hasNext}
+          className="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-border bg-transparent text-text-muted hover:bg-surface-hover hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          다음
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/common/StatusBadge.tsx
+++ b/frontend/src/components/common/StatusBadge.tsx
@@ -1,0 +1,21 @@
+const VARIANT_CLASSES: Record<string, string> = {
+  positive: 'bg-positive-bg text-positive',
+  negative: 'bg-negative-bg text-negative',
+  warning: 'bg-warning-bg text-warning',
+  info: 'bg-info-bg text-info',
+  muted: 'bg-[rgba(139,143,163,0.15)] text-text-muted',
+  primary: 'bg-positive-bg text-primary',
+}
+
+interface StatusBadgeProps {
+  variant: keyof typeof VARIANT_CLASSES
+  children: React.ReactNode
+}
+
+export default function StatusBadge({ variant, children }: StatusBadgeProps) {
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-[10px] text-[11px] font-semibold ${VARIANT_CLASSES[variant] || VARIANT_CLASSES.muted}`}>
+      {children}
+    </span>
+  )
+}

--- a/frontend/src/components/dashboard/PendingApprovals.tsx
+++ b/frontend/src/components/dashboard/PendingApprovals.tsx
@@ -1,0 +1,99 @@
+import { Link } from 'react-router-dom'
+import { useApprovals, useUpdateApprovalStatus } from '../../hooks/useApprovals'
+import { formatDateTime } from '../../utils/formatters'
+import StatusBadge from '../common/StatusBadge'
+import LoadingSpinner from '../common/LoadingSpinner'
+import type { Approval, ApprovalType } from '../../types/approval'
+
+const TYPE_LABELS: Record<ApprovalType, { label: string; variant: string }> = {
+  strategy_report: { label: '전략 리포트', variant: 'info' },
+  budget_allocation: { label: '예산 할당', variant: 'primary' },
+  live_switch: { label: '실전 전환', variant: 'warning' },
+  risk_alert: { label: '위험 알림', variant: 'negative' },
+}
+
+export default function PendingApprovals() {
+  const { data, isLoading } = useApprovals({ status: 'pending', limit: 5 })
+  const updateStatus = useUpdateApprovalStatus()
+
+  const items = data?.items ?? []
+  const total = data?.total ?? 0
+
+  const handleAction = (id: number, status: 'approved' | 'rejected') => {
+    updateStatus.mutate({ id, status })
+  }
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-4">
+          <span className="text-[15px] font-semibold">승인 대기</span>
+          {total > 0 && (
+            <StatusBadge variant="negative">{total}건</StatusBadge>
+          )}
+        </div>
+        <Link
+          to="/approvals"
+          className="px-2.5 py-1.5 text-[12px] text-text-muted bg-transparent rounded-lg hover:bg-surface-hover hover:text-text no-underline"
+        >
+          전체 보기 →
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <LoadingSpinner />
+      ) : items.length === 0 ? (
+        <div className="py-8 text-center text-text-muted text-[13px]">승인 대기 건이 없습니다</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr>
+                <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">유형</th>
+                <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">제목</th>
+                <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">요청일</th>
+                <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item: Approval) => {
+                const typeInfo = TYPE_LABELS[item.type] || { label: item.type, variant: 'muted' }
+                return (
+                  <tr key={item.id} className="hover:bg-surface-hover">
+                    <td className="px-3 py-3 border-b border-border text-[13px]">
+                      <StatusBadge variant={typeInfo.variant as 'info'}>{typeInfo.label}</StatusBadge>
+                    </td>
+                    <td className="px-3 py-3 border-b border-border text-[13px]">
+                      <Link to={`/approvals/${item.id}`} className="text-primary no-underline hover:underline">
+                        {item.title}
+                      </Link>
+                    </td>
+                    <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">
+                      {formatDateTime(item.requested_at)}
+                    </td>
+                    <td className="px-3 py-3 border-b border-border text-[13px] text-right">
+                      <div className="flex gap-2 justify-end">
+                        <button
+                          onClick={() => handleAction(item.id, 'approved')}
+                          className="px-2.5 py-1 rounded-lg text-[12px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover"
+                        >
+                          승인
+                        </button>
+                        <button
+                          onClick={() => handleAction(item.id, 'rejected')}
+                          className="px-2.5 py-1 rounded-lg text-[12px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover hover:text-text"
+                        >
+                          거부
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/dashboard/PortfolioChart.tsx
+++ b/frontend/src/components/dashboard/PortfolioChart.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react'
+import { usePortfolioValue, usePortfolioHistory } from '../../hooks/usePortfolio'
+import { formatKRW, formatPercent } from '../../utils/formatters'
+import type { Period } from '../../types/portfolio'
+import LoadingSpinner from '../common/LoadingSpinner'
+
+const PERIODS: { key: Period; label: string }[] = [
+  { key: '1d', label: '1일' },
+  { key: '1w', label: '1주' },
+  { key: '1m', label: '1개월' },
+  { key: '3m', label: '3개월' },
+  { key: 'all', label: '전체' },
+]
+
+export default function PortfolioChart() {
+  const [period, setPeriod] = useState<Period>('1w')
+  const { data: value, isLoading: valueLoading } = usePortfolioValue()
+  const { data: history, isLoading: historyLoading } = usePortfolioHistory(period)
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          {valueLoading ? (
+            <div className="h-10 w-48 bg-surface-hover rounded animate-pulse" />
+          ) : (
+            <>
+              <div className="text-[32px] font-bold">{formatKRW(value?.total_value ?? 0)}</div>
+              <div className="mt-1">
+                <span
+                  className={`text-[14px] font-semibold ${
+                    (value?.daily_pnl ?? 0) >= 0 ? 'text-positive' : 'text-negative'
+                  }`}
+                >
+                  {(value?.daily_pnl ?? 0) >= 0 ? '+' : ''}
+                  {formatKRW(value?.daily_pnl ?? 0)} ({formatPercent((value?.daily_pnl_pct ?? 0) / 100)})
+                </span>
+                <span className="text-text-muted text-[12px] ml-2">오늘</span>
+              </div>
+            </>
+          )}
+        </div>
+        <div className="flex gap-1">
+          {PERIODS.map((p) => (
+            <button
+              key={p.key}
+              onClick={() => setPeriod(p.key)}
+              className={`px-3 py-1 rounded text-[12px] font-medium border-none cursor-pointer ${
+                period === p.key
+                  ? 'bg-primary text-white'
+                  : 'bg-transparent text-text-muted hover:text-text'
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {historyLoading ? (
+        <LoadingSpinner />
+      ) : history && history.length > 0 ? (
+        <div className="h-[280px] bg-bg border border-dashed border-border rounded-lg flex items-center justify-center text-text-muted text-[13px]">
+          📈 자산 추이 차트 (TradingView Area Chart) — {history.length}개 데이터 포인트
+        </div>
+      ) : (
+        <div className="h-[280px] bg-bg border border-dashed border-border rounded-lg flex items-center justify-center text-text-muted text-[13px]">
+          📈 자산 추이 차트 (TradingView Area Chart)
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,0 +1,111 @@
+import { useState, useRef, useEffect } from 'react'
+import { useLocation, useNavigate, Link } from 'react-router-dom'
+import { useUser, useLogout } from '../../hooks/useAuth'
+import { useSystemStatus } from '../../hooks/useSystemStatus'
+
+const PAGE_TITLES: Record<string, string> = {
+  '/': '대시보드',
+  '/approvals': '결재함',
+  '/treasury': '자금관리',
+  '/treasury/history': '자금 거래 이력',
+  '/strategies': '전략과 성과',
+  '/bots': '봇 관리',
+  '/backtest-data': '백테스트 데이터',
+  '/agents': '에이전트 관리',
+  '/settings': '설정',
+}
+
+function getPageTitle(pathname: string): string {
+  if (PAGE_TITLES[pathname]) return PAGE_TITLES[pathname]
+  if (pathname.startsWith('/approvals/')) return '결재 상세'
+  if (pathname.startsWith('/strategies/')) return '전략 상세'
+  if (pathname.startsWith('/bots/')) return '봇 상세'
+  if (pathname.startsWith('/agents/')) return '에이전트 상세'
+  return '대시보드'
+}
+
+function isDetailPage(pathname: string): boolean {
+  return /^\/(approvals|strategies|bots|agents)\/[^/]+/.test(pathname) || pathname === '/treasury/history'
+}
+
+export default function Header() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const { data: user } = useUser()
+  const { data: systemStatus } = useSystemStatus()
+  const logoutMutation = useLogout()
+  const [menuOpen, setMenuOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  const title = getPageTitle(location.pathname)
+  const showBack = isDetailPage(location.pathname)
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  return (
+    <header className="fixed top-0 left-sidebar right-0 h-header bg-surface border-b border-border flex items-center justify-between px-6 z-[100]">
+      <div className="flex items-center gap-4">
+        {showBack && (
+          <button
+            onClick={() => navigate(-1)}
+            className="bg-transparent border-none text-text-muted cursor-pointer text-[18px] p-1.5 rounded hover:text-text hover:bg-surface-hover"
+          >
+            ←
+          </button>
+        )}
+        <h1 className="text-[16px] font-semibold">{title}</h1>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <div className="flex items-center gap-1.5 text-[12px] text-text-muted">
+          <span
+            className={`w-2 h-2 rounded-full ${
+              systemStatus?.trading_status === 'ACTIVE' ? 'bg-positive' : 'bg-negative'
+            }`}
+          />
+          {systemStatus?.trading_status ?? '...'}
+        </div>
+
+        <div ref={menuRef} className="relative">
+          <button
+            onClick={() => setMenuOpen(!menuOpen)}
+            className="flex items-center gap-2 px-2.5 py-1 rounded-lg cursor-pointer text-[13px] text-text-muted bg-transparent border-none hover:bg-surface-hover hover:text-text"
+          >
+            <span className="text-[22px] leading-none mt-0.5">🦁</span>
+            <span>{user?.member_id ?? '...'} · {user?.role === 'master' ? '대표' : user?.role}</span>
+          </button>
+
+          {menuOpen && (
+            <div className="absolute top-[calc(100%+6px)] right-0 bg-surface border border-border rounded-lg shadow-[0_8px_24px_rgba(0,0,0,0.3)] min-w-[200px] z-[200] py-3">
+              <div className="px-4 pb-3 border-b border-border text-[12px] text-text-muted">
+                <div className="font-medium text-text">{user?.name}</div>
+                <div>{user?.org}</div>
+              </div>
+              <Link
+                to="/settings"
+                onClick={() => setMenuOpen(false)}
+                className="block px-4 py-2 text-[13px] text-text no-underline hover:bg-surface-hover"
+              >
+                설정
+              </Link>
+              <button
+                onClick={() => { setMenuOpen(false); logoutMutation.mutate() }}
+                className="block w-full text-left px-4 py-2 text-[13px] text-negative bg-transparent border-none cursor-pointer hover:bg-surface-hover"
+              >
+                로그아웃
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,0 +1,15 @@
+import { Outlet } from 'react-router-dom'
+import Sidebar from './Sidebar'
+import Header from './Header'
+
+export default function Layout() {
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <Header />
+      <main className="ml-sidebar mt-header p-6 flex-1 min-h-[calc(100vh-var(--spacing-header))]">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,0 +1,57 @@
+import { NavLink } from 'react-router-dom'
+import { useApprovals } from '../../hooks/useApprovals'
+
+const NAV_ITEMS = [
+  { path: '/', icon: '⭐', label: '대시보드' },
+  { path: '/approvals', icon: '📋', label: '결재함', showBadge: true },
+  { path: '/treasury', icon: '💰', label: '자금관리' },
+  { path: '/strategies', icon: '📈', label: '전략과 성과' },
+  { path: '/bots', icon: '🤖', label: '봇 관리' },
+  { path: '/backtest-data', icon: '📁', label: '백테스트 데이터' },
+  { path: '/agents', icon: '🧑‍💼', label: '에이전트 관리' },
+]
+
+export default function Sidebar() {
+  const { data: approvals } = useApprovals({ status: 'pending', limit: 0 })
+  const pendingCount = approvals?.total ?? 0
+
+  return (
+    <aside className="fixed top-0 left-0 w-sidebar h-screen bg-surface border-r border-border flex flex-col z-[101]">
+      <div className="h-header flex items-center justify-center gap-0 px-5 border-b border-border">
+        <img src="/logo-a.svg" alt="A" className="w-8 h-8" />
+        <img src="/logo-n.svg" alt="N" className="w-8 h-8" />
+        <img src="/logo-t.svg" alt="T" className="w-8 h-8" />
+        <img src="/logo-e.svg" alt="E" className="w-8 h-8" />
+      </div>
+
+      <nav className="flex-1 py-3 px-2 flex flex-col gap-0.5">
+        {NAV_ITEMS.map((item) => (
+          <NavLink
+            key={item.path}
+            to={item.path}
+            end={item.path === '/'}
+            className={({ isActive }) =>
+              `flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-[15px] font-medium no-underline transition-colors ${
+                isActive
+                  ? 'bg-primary text-white'
+                  : 'text-text-muted hover:bg-surface-hover hover:text-text'
+              }`
+            }
+          >
+            <span className="text-[16px] w-5 text-center">{item.icon}</span>
+            <span>{item.label}</span>
+            {item.showBadge && pendingCount > 0 && (
+              <span className="ml-auto bg-negative text-white text-[11px] px-1.5 py-0 rounded-[10px] font-semibold">
+                {pendingCount}
+              </span>
+            )}
+          </NavLink>
+        ))}
+      </nav>
+
+      <div className="px-4 py-3 text-[11px] text-text-muted border-t border-border">
+        Ante v0.1.0 · <a href="https://opensource.org/licenses/MIT" className="text-text-muted hover:text-text no-underline">MIT</a>
+      </div>
+    </aside>
+  )
+}

--- a/frontend/src/components/strategies/PerformancePanel.tsx
+++ b/frontend/src/components/strategies/PerformancePanel.tsx
@@ -1,0 +1,31 @@
+import HintTooltip from '../common/HintTooltip'
+import { formatPercent, formatNumber, formatKRW } from '../../utils/formatters'
+import type { StrategyPerformance } from '../../types/strategy'
+
+export default function PerformancePanel({ perf }: { perf: StrategyPerformance }) {
+  const metrics = [
+    { label: '총 거래 수', value: formatNumber(perf.total_trades), hint: '전체 거래 횟수' },
+    { label: '승률', value: formatPercent(perf.win_rate), hint: '수익 거래 비율' },
+    { label: '수익 팩터', value: perf.profit_factor.toFixed(2), hint: '총 이익 / 총 손실' },
+    { label: '최대 낙폭', value: formatPercent(perf.max_drawdown), hint: '고점 대비 최대 하락 폭' },
+    { label: '실현 손익', value: formatKRW(perf.realized_pnl), hint: '확정된 거래 손익 합계' },
+    { label: '샤프 비율', value: perf.sharpe_ratio.toFixed(2), hint: '위험 대비 수익 효율' },
+  ]
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+      <h3 className="text-[15px] font-semibold mb-4">성과 지표</h3>
+      <div className="grid grid-cols-3 gap-4">
+        {metrics.map((m) => (
+          <div key={m.label} className="bg-bg rounded-lg p-4">
+            <div className="text-[12px] text-text-muted mb-1">
+              {m.label}
+              <HintTooltip text={m.hint} />
+            </div>
+            <div className="text-[20px] font-bold">{m.value}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/strategies/StrategyTable.tsx
+++ b/frontend/src/components/strategies/StrategyTable.tsx
@@ -1,0 +1,55 @@
+import { useNavigate } from 'react-router-dom'
+import StatusBadge from '../common/StatusBadge'
+import { formatPercent } from '../../utils/formatters'
+import { STRATEGY_STATUS_LABELS } from '../../utils/constants'
+import type { Strategy, StrategyStatus } from '../../types/strategy'
+
+const STATUS_VARIANT: Record<StrategyStatus, string> = {
+  active: 'positive',
+  registered: 'info',
+  inactive: 'muted',
+  archived: 'muted',
+}
+
+export default function StrategyTable({ items }: { items: Strategy[] }) {
+  const navigate = useNavigate()
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">전략명</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">버전</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">상태</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">실행 봇</th>
+            <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">누적 수익률</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.length === 0 ? (
+            <tr><td colSpan={5} className="px-3 py-8 text-center text-text-muted text-[13px]">등록된 전략이 없습니다</td></tr>
+          ) : (
+            items.map((s) => (
+              <tr key={s.id} onClick={() => navigate(`/strategies/${s.id}`)} className="hover:bg-surface-hover cursor-pointer">
+                <td className="px-3 py-3 border-b border-border text-[13px] font-medium">{s.name}</td>
+                <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{s.version}</td>
+                <td className="px-3 py-3 border-b border-border text-[13px]">
+                  <StatusBadge variant={STATUS_VARIANT[s.status] as 'positive'}>{STRATEGY_STATUS_LABELS[s.status] || s.status}</StatusBadge>
+                </td>
+                <td className="px-3 py-3 border-b border-border text-[13px] font-mono text-text-muted">{s.bot_id || '-'}</td>
+                <td className="px-3 py-3 border-b border-border text-[13px] text-right">
+                  {s.cumulative_return != null ? (
+                    <span className={s.cumulative_return >= 0 ? 'text-positive' : 'text-negative'}>
+                      {formatPercent(s.cumulative_return / 100)}
+                    </span>
+                  ) : '-'}
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/treasury/AccountSummary.tsx
+++ b/frontend/src/components/treasury/AccountSummary.tsx
@@ -1,0 +1,22 @@
+import { formatKRW } from '../../utils/formatters'
+import type { TreasurySummary } from '../../types/treasury'
+
+export default function AccountSummary({ summary }: { summary: TreasurySummary }) {
+  const stats = [
+    { label: '총 잔고', value: formatKRW(summary.total_balance) },
+    { label: '할당됨', value: formatKRW(summary.allocated) },
+    { label: '미할당', value: formatKRW(summary.unallocated) },
+    { label: '예약됨', value: formatKRW(summary.reserved) },
+  ]
+
+  return (
+    <div className="grid grid-cols-4 gap-4 mb-6">
+      {stats.map((s) => (
+        <div key={s.label} className="bg-surface border border-border rounded-lg px-5 py-4">
+          <div className="text-[12px] text-text-muted mb-1">{s.label}</div>
+          <div className="text-[24px] font-bold">{s.value}</div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/treasury/AllocationForm.tsx
+++ b/frontend/src/components/treasury/AllocationForm.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+import { useAllocateBudget, useDeallocateBudget } from '../../hooks/useTreasury'
+
+export default function AllocationForm({ botIds }: { botIds: string[] }) {
+  const [botId, setBotId] = useState(botIds[0] ?? '')
+  const [amount, setAmount] = useState('')
+  const allocate = useAllocateBudget()
+  const deallocate = useDeallocateBudget()
+
+  const handleAction = (action: 'allocate' | 'deallocate') => {
+    const numAmount = Number(amount)
+    if (!botId || !numAmount) return
+    if (action === 'allocate') {
+      allocate.mutate({ botId, amount: numAmount }, { onSuccess: () => setAmount('') })
+    } else {
+      deallocate.mutate({ botId, amount: numAmount }, { onSuccess: () => setAmount('') })
+    }
+  }
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5">
+      <h3 className="text-[15px] font-semibold mb-4">할당 / 회수</h3>
+      <div className="flex gap-3 items-end">
+        <div className="flex-1">
+          <label className="block text-[12px] font-semibold text-text-muted mb-1.5">봇</label>
+          <select
+            value={botId}
+            onChange={(e) => setBotId(e.target.value)}
+            className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px]"
+          >
+            {botIds.map((id) => (
+              <option key={id} value={id}>{id}</option>
+            ))}
+          </select>
+        </div>
+        <div className="flex-1">
+          <label className="block text-[12px] font-semibold text-text-muted mb-1.5">금액 (원)</label>
+          <input
+            type="number"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            placeholder="0"
+            className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] placeholder:text-text-muted focus:outline-none focus:border-primary"
+          />
+        </div>
+        <button
+          onClick={() => handleAction('allocate')}
+          disabled={!botId || !amount}
+          className="px-4 py-2.5 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover disabled:opacity-50"
+        >
+          할당
+        </button>
+        <button
+          onClick={() => handleAction('deallocate')}
+          disabled={!botId || !amount}
+          className="px-4 py-2.5 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover hover:text-text disabled:opacity-50"
+        >
+          회수
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/treasury/BudgetTable.tsx
+++ b/frontend/src/components/treasury/BudgetTable.tsx
@@ -1,0 +1,38 @@
+import { formatKRW } from '../../utils/formatters'
+import type { BotBudget } from '../../types/treasury'
+
+export default function BudgetTable({ budgets }: { budgets: BotBudget[] }) {
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+      <h3 className="text-[15px] font-semibold mb-4">봇별 예산</h3>
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr>
+              <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">봇 ID</th>
+              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">할당액</th>
+              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">가용액</th>
+              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">예약액</th>
+              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">사용액</th>
+            </tr>
+          </thead>
+          <tbody>
+            {budgets.length === 0 ? (
+              <tr><td colSpan={5} className="px-3 py-8 text-center text-text-muted text-[13px]">할당된 봇이 없습니다</td></tr>
+            ) : (
+              budgets.map((b) => (
+                <tr key={b.bot_id} className="hover:bg-surface-hover">
+                  <td className="px-3 py-3 border-b border-border text-[13px] font-mono">{b.bot_id}</td>
+                  <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.allocated)}</td>
+                  <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.available)}</td>
+                  <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.reserved)}</td>
+                  <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.used)}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useApprovals.ts
+++ b/frontend/src/hooks/useApprovals.ts
@@ -1,0 +1,34 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getApprovals, getApprovalDetail, updateApprovalStatus } from '../api/approvals'
+import type { ApprovalStatus, ApprovalType } from '../types/approval'
+
+export function useApprovals(params: {
+  status?: ApprovalStatus | 'all'
+  type?: ApprovalType | 'all'
+  offset?: number
+  limit?: number
+}) {
+  return useQuery({
+    queryKey: ['approvals', params],
+    queryFn: () => getApprovals(params),
+  })
+}
+
+export function useApprovalDetail(id: number) {
+  return useQuery({
+    queryKey: ['approvals', id],
+    queryFn: () => getApprovalDetail(id),
+    enabled: id > 0,
+  })
+}
+
+export function useUpdateApprovalStatus() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, status, memo }: { id: number; status: 'approved' | 'rejected'; memo?: string }) =>
+      updateApprovalStatus(id, status, memo),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['approvals'] })
+    },
+  })
+}

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,39 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { login, logout, getMe } from '../api/auth'
+import type { LoginRequest } from '../types/auth'
+
+export function useUser() {
+  return useQuery({
+    queryKey: ['auth', 'me'],
+    queryFn: getMe,
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+export function useLogin() {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+
+  return useMutation({
+    mutationFn: (data: LoginRequest) => login(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['auth', 'me'] })
+      navigate('/', { replace: true })
+    },
+  })
+}
+
+export function useLogout() {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      queryClient.clear()
+      navigate('/login', { replace: true })
+    },
+  })
+}

--- a/frontend/src/hooks/useBots.ts
+++ b/frontend/src/hooks/useBots.ts
@@ -1,0 +1,44 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getBots, getBotDetail, createBot, startBot, stopBot, deleteBot } from '../api/bots'
+import type { BotCreateRequest } from '../types/bot'
+
+export function useBots() {
+  return useQuery({
+    queryKey: ['bots'],
+    queryFn: getBots,
+  })
+}
+
+export function useBotDetail(botId: string) {
+  return useQuery({
+    queryKey: ['bots', botId],
+    queryFn: () => getBotDetail(botId),
+    enabled: !!botId,
+  })
+}
+
+export function useCreateBot() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: BotCreateRequest) => createBot(data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['bots'] }),
+  })
+}
+
+export function useBotControl() {
+  const queryClient = useQueryClient()
+  return {
+    start: useMutation({
+      mutationFn: startBot,
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ['bots'] }),
+    }),
+    stop: useMutation({
+      mutationFn: stopBot,
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ['bots'] }),
+    }),
+    remove: useMutation({
+      mutationFn: deleteBot,
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ['bots'] }),
+    }),
+  }
+}

--- a/frontend/src/hooks/useMembers.ts
+++ b/frontend/src/hooks/useMembers.ts
@@ -1,0 +1,51 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getMembers, getMemberDetail, createMember, suspendMember, reactivateMember, revokeMember, rotateToken, updateScopes } from '../api/members'
+import type { MemberCreateRequest } from '../types/member'
+
+export function useMembers(params?: { type?: string; org?: string; status?: string }) {
+  return useQuery({
+    queryKey: ['members', params],
+    queryFn: () => getMembers(params),
+  })
+}
+
+export function useMemberDetail(id: string) {
+  return useQuery({
+    queryKey: ['members', id],
+    queryFn: () => getMemberDetail(id),
+    enabled: !!id,
+  })
+}
+
+export function useCreateMember() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: MemberCreateRequest) => createMember(data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['members'] }),
+  })
+}
+
+export function useMemberControl() {
+  const queryClient = useQueryClient()
+  return {
+    suspend: useMutation({
+      mutationFn: suspendMember,
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ['members'] }),
+    }),
+    reactivate: useMutation({
+      mutationFn: reactivateMember,
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ['members'] }),
+    }),
+    revoke: useMutation({
+      mutationFn: revokeMember,
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ['members'] }),
+    }),
+    rotateToken: useMutation({
+      mutationFn: rotateToken,
+    }),
+    updateScopes: useMutation({
+      mutationFn: ({ id, scopes }: { id: string; scopes: string[] }) => updateScopes(id, scopes),
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ['members'] }),
+    }),
+  }
+}

--- a/frontend/src/hooks/usePortfolio.ts
+++ b/frontend/src/hooks/usePortfolio.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+import { getPortfolioValue, getPortfolioHistory } from '../api/portfolio'
+import type { Period } from '../types/portfolio'
+
+export function usePortfolioValue() {
+  return useQuery({
+    queryKey: ['portfolio', 'value'],
+    queryFn: getPortfolioValue,
+    staleTime: 30_000,
+  })
+}
+
+export function usePortfolioHistory(period: Period) {
+  return useQuery({
+    queryKey: ['portfolio', 'history', period],
+    queryFn: () => getPortfolioHistory(period),
+    staleTime: 60_000,
+  })
+}

--- a/frontend/src/hooks/useStrategies.ts
+++ b/frontend/src/hooks/useStrategies.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query'
+import { getStrategies, getStrategyDetail, getStrategyPerformance, getStrategyTrades } from '../api/strategies'
+
+export function useStrategies() {
+  return useQuery({
+    queryKey: ['strategies'],
+    queryFn: getStrategies,
+  })
+}
+
+export function useStrategyDetail(id: number) {
+  return useQuery({
+    queryKey: ['strategies', id],
+    queryFn: () => getStrategyDetail(id),
+    enabled: id > 0,
+  })
+}
+
+export function useStrategyPerformance(id: number) {
+  return useQuery({
+    queryKey: ['strategies', id, 'performance'],
+    queryFn: () => getStrategyPerformance(id),
+    enabled: id > 0,
+  })
+}
+
+export function useStrategyTrades(id: number, cursor?: number) {
+  return useQuery({
+    queryKey: ['strategies', id, 'trades', cursor],
+    queryFn: () => getStrategyTrades(id, { cursor, limit: 100 }),
+    enabled: id > 0,
+  })
+}

--- a/frontend/src/hooks/useSystemStatus.ts
+++ b/frontend/src/hooks/useSystemStatus.ts
@@ -1,0 +1,33 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getSystemStatus, setKillSwitch, getConfigs, updateConfig } from '../api/system'
+
+export function useSystemStatus() {
+  return useQuery({
+    queryKey: ['system', 'status'],
+    queryFn: getSystemStatus,
+    refetchInterval: 30_000,
+  })
+}
+
+export function useKillSwitch() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: setKillSwitch,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['system'] }),
+  })
+}
+
+export function useConfigs() {
+  return useQuery({
+    queryKey: ['config'],
+    queryFn: getConfigs,
+  })
+}
+
+export function useUpdateConfig() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ key, value }: { key: string; value: string }) => updateConfig(key, value),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['config'] }),
+  })
+}

--- a/frontend/src/hooks/useTreasury.ts
+++ b/frontend/src/hooks/useTreasury.ts
@@ -1,0 +1,43 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getTreasurySummary, getBotBudgets, allocateBudget, deallocateBudget, getTreasuryHistory } from '../api/treasury'
+
+export function useTreasurySummary() {
+  return useQuery({
+    queryKey: ['treasury', 'summary'],
+    queryFn: getTreasurySummary,
+  })
+}
+
+export function useBotBudgets() {
+  return useQuery({
+    queryKey: ['treasury', 'budgets'],
+    queryFn: getBotBudgets,
+  })
+}
+
+export function useAllocateBudget() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ botId, amount }: { botId: string; amount: number }) => allocateBudget(botId, amount),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['treasury'] })
+    },
+  })
+}
+
+export function useDeallocateBudget() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ botId, amount }: { botId: string; amount: number }) => deallocateBudget(botId, amount),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['treasury'] })
+    },
+  })
+}
+
+export function useTreasuryHistory(offset = 0, limit = 20) {
+  return useQuery({
+    queryKey: ['treasury', 'history', offset, limit],
+    queryFn: () => getTreasuryHistory({ offset, limit }),
+  })
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,12 +1,52 @@
 @import "tailwindcss";
 
+@theme {
+  --color-bg: #0b0b10;
+  --color-surface: #141419;
+  --color-surface-hover: #1e1e25;
+  --color-border: #2a2a35;
+  --color-text: #e1e4ea;
+  --color-text-muted: #8b8fa3;
+
+  --color-positive: #1E8EFF;
+  --color-positive-hover: #0A7AEE;
+  --color-positive-bg: rgba(30, 142, 255, 0.12);
+  --color-negative: #E85830;
+  --color-negative-hover: #D04820;
+  --color-negative-bg: rgba(232, 88, 48, 0.12);
+  --color-warning: #F0A030;
+  --color-warning-bg: rgba(240, 160, 48, 0.12);
+  --color-accent: #F5C518;
+  --color-accent-bg: rgba(245, 197, 24, 0.10);
+  --color-info: #a78bfa;
+  --color-info-bg: rgba(167, 139, 250, 0.10);
+  --color-primary: #1E8EFF;
+  --color-primary-hover: #0A7AEE;
+
+  --spacing-sidebar: 220px;
+  --spacing-header: 56px;
+}
+
 body {
   margin: 0;
-  font-family: system-ui, -apple-system, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 14px;
+  line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 #root {
   min-height: 100vh;
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
 }

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -1,0 +1,148 @@
+import { useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { useMemberDetail, useMemberControl } from '../hooks/useMembers'
+import StatusBadge from '../components/common/StatusBadge'
+import LoadingSpinner from '../components/common/LoadingSpinner'
+import { formatDateTime } from '../utils/formatters'
+import { MEMBER_STATUS_LABELS } from '../utils/constants'
+import { ALL_SCOPES, type MemberStatus } from '../types/member'
+
+const STATUS_VARIANT: Record<MemberStatus, string> = {
+  active: 'positive', suspended: 'warning', revoked: 'negative',
+}
+
+export default function AgentDetail() {
+  const { id } = useParams<{ id: string }>()
+  const { data: member, isLoading } = useMemberDetail(id!)
+  const { suspend, reactivate, revoke, rotateToken, updateScopes } = useMemberControl()
+  const [newToken, setNewToken] = useState<string | null>(null)
+  const [editingScopes, setEditingScopes] = useState(false)
+  const [scopesDraft, setScopesDraft] = useState<string[]>([])
+
+  if (isLoading) return <LoadingSpinner />
+  if (!member) return <div className="text-text-muted text-center py-12">에이전트를 찾을 수 없습니다</div>
+
+  const startEditScopes = () => {
+    setScopesDraft([...member.scopes])
+    setEditingScopes(true)
+  }
+
+  const handleRotateToken = () => {
+    if (!confirm('기존 토큰이 즉시 무효화됩니다. 계속하시겠습니까?')) return
+    rotateToken.mutateAsync(member.member_id).then((data) => setNewToken(data.token))
+  }
+
+  return (
+    <>
+      {/* 헤더 */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h2 className="text-[20px] font-bold">{member.name}</h2>
+          <div className="flex gap-3 items-center mt-1">
+            <span className="text-text-muted font-mono text-[13px]">{member.member_id}</span>
+            <span className="text-text-muted text-[13px]">{member.org}</span>
+            <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>
+              {MEMBER_STATUS_LABELS[member.status]}
+            </StatusBadge>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          {member.status === 'active' && (
+            <button onClick={() => suspend.mutate(member.member_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-warning border border-border cursor-pointer hover:bg-warning-bg">정지</button>
+          )}
+          {member.status === 'suspended' && (
+            <button onClick={() => reactivate.mutate(member.member_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">재활성화</button>
+          )}
+          {member.status !== 'revoked' && (
+            <button onClick={() => { if (confirm('영구 폐기하시겠습니까?')) revoke.mutate(member.member_id) }} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-negative border border-border cursor-pointer hover:bg-negative-bg">폐기</button>
+          )}
+        </div>
+      </div>
+
+      {/* 토큰 관리 */}
+      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-[15px] font-semibold">토큰 관리</h3>
+          <button
+            onClick={handleRotateToken}
+            disabled={member.status === 'revoked'}
+            className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover disabled:opacity-40"
+          >
+            토큰 재발급
+          </button>
+        </div>
+        <p className="text-[12px] text-warning">기존 토큰이 즉시 무효화됩니다</p>
+      </div>
+
+      {/* 권한 범위 */}
+      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-[15px] font-semibold">권한 범위</h3>
+          {!editingScopes ? (
+            <button onClick={startEditScopes} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">편집</button>
+          ) : (
+            <div className="flex gap-2">
+              <button onClick={() => { updateScopes.mutate({ id: member.member_id, scopes: scopesDraft }); setEditingScopes(false) }} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">저장</button>
+              <button onClick={() => setEditingScopes(false)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
+            </div>
+          )}
+        </div>
+        {editingScopes ? (
+          <div className="grid grid-cols-2 gap-2">
+            {ALL_SCOPES.map((scope) => (
+              <label key={scope} className="flex items-center gap-2 text-[13px] cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={scopesDraft.includes(scope)}
+                  onChange={() => setScopesDraft((prev) => prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope])}
+                  className="accent-primary"
+                />
+                <span className="font-mono text-[12px]">{scope}</span>
+              </label>
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-1.5">
+            {member.scopes.map((s) => (
+              <span key={s} className="px-2 py-0.5 bg-positive-bg text-primary rounded text-[11px] font-medium font-mono">{s}</span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* 활동 정보 */}
+      <div className="bg-surface border border-border rounded-lg p-5">
+        <h3 className="text-[15px] font-semibold mb-3">활동 정보</h3>
+        <div className="space-y-2">
+          <div className="flex justify-between py-2 border-b border-border text-[13px]">
+            <span className="text-text-muted">생성일</span>
+            <span>{formatDateTime(member.created_at)}</span>
+          </div>
+          <div className="flex justify-between py-2 border-b border-border text-[13px]">
+            <span className="text-text-muted">생성자</span>
+            <span>{member.created_by || '-'}</span>
+          </div>
+          <div className="flex justify-between py-2 text-[13px]">
+            <span className="text-text-muted">마지막 활동</span>
+            <span>{member.last_active_at ? formatDateTime(member.last_active_at) : '-'}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* 토큰 표시 모달 */}
+      {newToken && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+          <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
+            <h3 className="text-[18px] font-bold mb-4">새 토큰 발급 완료</h3>
+            <p className="text-[13px] text-warning mb-3">이 토큰은 다시 확인할 수 없습니다.</p>
+            <div className="bg-bg border border-border rounded-lg p-3 font-mono text-[12px] break-all mb-4">{newToken}</div>
+            <div className="flex justify-end gap-2">
+              <button onClick={() => navigator.clipboard.writeText(newToken)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">복사</button>
+              <button onClick={() => setNewToken(null)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">닫기</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import { useMembers, useMemberControl } from '../hooks/useMembers'
+import AgentTable from '../components/agents/AgentTable'
+import AgentRegisterForm from '../components/agents/AgentRegisterForm'
+import LoadingSpinner from '../components/common/LoadingSpinner'
+import type { MemberStatus } from '../types/member'
+
+const STATUS_FILTERS: { key: MemberStatus | 'all'; label: string }[] = [
+  { key: 'all', label: '전체' },
+  { key: 'active', label: 'active' },
+  { key: 'suspended', label: 'suspended' },
+  { key: 'revoked', label: 'revoked' },
+]
+
+export default function Agents() {
+  const [statusFilter, setStatusFilter] = useState<MemberStatus | 'all'>('all')
+  const [showRegister, setShowRegister] = useState(false)
+  const [createdToken, setCreatedToken] = useState<string | null>(null)
+
+  const { data: members, isLoading } = useMembers({
+    type: 'agent',
+    status: statusFilter === 'all' ? undefined : statusFilter,
+  })
+  const { suspend, reactivate, revoke } = useMemberControl()
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex gap-1 bg-bg rounded-lg p-0.5">
+          {STATUS_FILTERS.map((f) => (
+            <button
+              key={f.key}
+              onClick={() => setStatusFilter(f.key)}
+              className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
+                statusFilter === f.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={() => setShowRegister(true)}
+          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
+        >
+          에이전트 등록
+        </button>
+      </div>
+
+      <div className="bg-surface border border-border rounded-lg p-5">
+        {isLoading ? (
+          <LoadingSpinner />
+        ) : (
+          <AgentTable
+            items={members ?? []}
+            onSuspend={(id) => suspend.mutate(id)}
+            onReactivate={(id) => reactivate.mutate(id)}
+            onRevoke={(id) => { if (confirm('이 에이전트를 영구 폐기하시겠습니까?')) revoke.mutate(id) }}
+          />
+        )}
+      </div>
+
+      {showRegister && (
+        <AgentRegisterForm
+          onClose={() => setShowRegister(false)}
+          onTokenCreated={(token) => { setShowRegister(false); setCreatedToken(token) }}
+        />
+      )}
+
+      {/* 토큰 표시 모달 */}
+      {createdToken && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+          <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
+            <h3 className="text-[18px] font-bold mb-4">에이전트 토큰 발급 완료</h3>
+            <p className="text-[13px] text-warning mb-3">이 토큰은 다시 확인할 수 없습니다. 반드시 복사해 두세요.</p>
+            <div className="bg-bg border border-border rounded-lg p-3 font-mono text-[12px] break-all mb-4">
+              {createdToken}
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => navigator.clipboard.writeText(createdToken)}
+                className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
+              >
+                복사
+              </button>
+              <button
+                onClick={() => setCreatedToken(null)}
+                className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover"
+              >
+                닫기
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/frontend/src/pages/ApprovalDetail.tsx
+++ b/frontend/src/pages/ApprovalDetail.tsx
@@ -1,0 +1,140 @@
+import { useParams } from 'react-router-dom'
+import { useApprovalDetail } from '../hooks/useApprovals'
+import ReviewControls from '../components/approvals/ReviewControls'
+import BacktestMetricsPanel from '../components/approvals/BacktestMetrics'
+import StatusBadge from '../components/common/StatusBadge'
+import LoadingSpinner from '../components/common/LoadingSpinner'
+import { formatDate } from '../utils/formatters'
+import { APPROVAL_STATUS_LABELS } from '../utils/constants'
+import type { ApprovalStatus } from '../types/approval'
+
+const STATUS_VARIANT: Record<ApprovalStatus, string> = {
+  pending: 'warning',
+  approved: 'positive',
+  rejected: 'negative',
+}
+
+export default function ApprovalDetail() {
+  const { id } = useParams<{ id: string }>()
+  const { data: approval, isLoading } = useApprovalDetail(Number(id))
+
+  if (isLoading) return <LoadingSpinner />
+  if (!approval) return <div className="text-text-muted text-center py-12">결재 항목을 찾을 수 없습니다</div>
+
+  const detail = approval.detail
+  const isPending = approval.status === 'pending'
+
+  return (
+    <>
+      {/* 결재 영역 */}
+      <ReviewControls approvalId={approval.id} isPending={isPending} />
+
+      {/* Agent 분석 */}
+      {detail && (
+        <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+          <h3 className="text-[15px] font-semibold mb-3">Agent 분석</h3>
+          <div className="space-y-4 text-[13px]">
+            <div>
+              <div className="text-text-muted text-[12px] font-semibold mb-1">요약</div>
+              <p>{detail.agent_summary}</p>
+            </div>
+            <div>
+              <div className="text-text-muted text-[12px] font-semibold mb-1">근거</div>
+              <p>{detail.agent_rationale}</p>
+            </div>
+            <div>
+              <div className="text-text-muted text-[12px] font-semibold mb-1">리스크</div>
+              <p>{detail.agent_risks}</p>
+            </div>
+            <div>
+              <div className="text-text-muted text-[12px] font-semibold mb-1">권장 사항</div>
+              <p>{detail.agent_recommendation}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 전략 정보 + 백테스트 요약 */}
+      <div className="grid grid-cols-2 gap-4 mb-6">
+        <div className="bg-surface border border-border rounded-lg p-5">
+          <h3 className="text-[15px] font-semibold mb-3">전략 정보</h3>
+          <div className="space-y-2">
+            <div className="flex justify-between py-2 border-b border-border text-[13px]">
+              <span className="text-text-muted">제목</span>
+              <span>{approval.title}</span>
+            </div>
+            <div className="flex justify-between py-2 border-b border-border text-[13px]">
+              <span className="text-text-muted">요청자</span>
+              <span>{approval.requester}</span>
+            </div>
+            <div className="flex justify-between py-2 border-b border-border text-[13px]">
+              <span className="text-text-muted">상태</span>
+              <StatusBadge variant={STATUS_VARIANT[approval.status] as 'warning'}>
+                {APPROVAL_STATUS_LABELS[approval.status]}
+              </StatusBadge>
+            </div>
+            {detail && (
+              <>
+                <div className="flex justify-between py-2 border-b border-border text-[13px]">
+                  <span className="text-text-muted">전략명</span>
+                  <span>{detail.strategy_name}</span>
+                </div>
+                <div className="flex justify-between py-2 text-[13px]">
+                  <span className="text-text-muted">버전</span>
+                  <span>{detail.strategy_version}</span>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        {detail && (
+          <div className="bg-surface border border-border rounded-lg p-5">
+            <h3 className="text-[15px] font-semibold mb-3">백테스트 요약</h3>
+            <div className="space-y-2">
+              <div className="flex justify-between py-2 border-b border-border text-[13px]">
+                <span className="text-text-muted">시작일</span>
+                <span>{formatDate(detail.backtest_start)}</span>
+              </div>
+              <div className="flex justify-between py-2 border-b border-border text-[13px]">
+                <span className="text-text-muted">종료일</span>
+                <span>{formatDate(detail.backtest_end)}</span>
+              </div>
+              <div className="flex justify-between py-2 border-b border-border text-[13px]">
+                <span className="text-text-muted">총 거래</span>
+                <span>{detail.metrics.total_trades}회</span>
+              </div>
+              <div className="flex justify-between py-2 text-[13px]">
+                <span className="text-text-muted">총 수익률</span>
+                <span className={detail.metrics.total_return >= 0 ? 'text-positive' : 'text-negative'}>
+                  {(detail.metrics.total_return * 100).toFixed(2)}%
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 성과 지표 */}
+      {detail && <BacktestMetricsPanel metrics={detail.metrics} />}
+
+      {/* 차트 */}
+      {detail && (
+        <div className="grid grid-cols-2 gap-4">
+          <div className="bg-surface border border-border rounded-lg p-5">
+            <h3 className="text-[15px] font-semibold mb-3">자산 추이</h3>
+            <div className="h-[200px] bg-bg border border-dashed border-border rounded-lg flex items-center justify-center text-text-muted text-[13px]">
+              📈 에쿼티 커브 (Area Chart)
+            </div>
+          </div>
+          <div className="bg-surface border border-border rounded-lg p-5">
+            <h3 className="text-[15px] font-semibold mb-3">드로우다운</h3>
+            <div className="h-[200px] bg-bg border border-dashed border-border rounded-lg flex items-center justify-center text-text-muted text-[13px]">
+              📉 드로우다운 (Area Chart)
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/frontend/src/pages/Approvals.tsx
+++ b/frontend/src/pages/Approvals.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { useApprovals } from '../hooks/useApprovals'
+import ApprovalFilters from '../components/approvals/ApprovalFilters'
+import ApprovalTable from '../components/approvals/ApprovalTable'
+import Pagination from '../components/common/Pagination'
+import LoadingSpinner from '../components/common/LoadingSpinner'
+import type { ApprovalStatus, ApprovalType } from '../types/approval'
+
+const LIMIT = 20
+
+export default function Approvals() {
+  const [status, setStatus] = useState<ApprovalStatus | 'all'>('all')
+  const [type, setType] = useState<ApprovalType | 'all'>('all')
+  const [offset, setOffset] = useState(0)
+
+  const { data, isLoading } = useApprovals({ status, type, offset, limit: LIMIT })
+
+  return (
+    <>
+      <ApprovalFilters
+        status={status}
+        type={type}
+        onStatusChange={(s) => { setStatus(s); setOffset(0) }}
+        onTypeChange={(t) => { setType(t); setOffset(0) }}
+      />
+      <div className="bg-surface border border-border rounded-lg p-5">
+        {isLoading ? (
+          <LoadingSpinner />
+        ) : (
+          <>
+            <ApprovalTable items={data?.items ?? []} />
+            {(data?.total ?? 0) > LIMIT && (
+              <Pagination
+                total={data?.total ?? 0}
+                offset={offset}
+                limit={LIMIT}
+                onPageChange={setOffset}
+              />
+            )}
+          </>
+        )}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -1,0 +1,155 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getDatasets, getStorageInfo, deleteDataset } from '../api/data'
+import { formatNumber, formatDate } from '../utils/formatters'
+import Pagination from '../components/common/Pagination'
+import LoadingSpinner from '../components/common/LoadingSpinner'
+
+const LIMIT = 15
+const TF_OPTIONS = ['all', '1d', '1h', '1m'] as const
+
+export default function BacktestData() {
+  const [search, setSearch] = useState('')
+  const [timeframe, setTimeframe] = useState<string>('all')
+  const [offset, setOffset] = useState(0)
+  const [deleteTarget, setDeleteTarget] = useState<{ id: number; symbol: string; timeframe: string } | null>(null)
+  const queryClient = useQueryClient()
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['datasets', search, timeframe, offset],
+    queryFn: () =>
+      getDatasets({
+        symbol: search || undefined,
+        timeframe: timeframe === 'all' ? undefined : timeframe,
+        offset,
+        limit: LIMIT,
+      }),
+  })
+
+  const { data: storage } = useQuery({
+    queryKey: ['storage'],
+    queryFn: getStorageInfo,
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteDataset,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['datasets'] })
+      queryClient.invalidateQueries({ queryKey: ['storage'] })
+      setDeleteTarget(null)
+    },
+  })
+
+  return (
+    <>
+      {/* 안내 배너 */}
+      <div className="bg-info-bg border border-[rgba(167,139,250,0.2)] rounded-lg px-4 py-3 mb-4 text-[13px] text-info">
+        데이터 수집은 Agent에게 요청하거나 CLI(<code className="bg-bg px-1.5 py-0.5 rounded text-[12px]">ante data collect</code>)를 사용하세요
+      </div>
+
+      {/* 필터 */}
+      <div className="flex items-center gap-3 mb-4">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => { setSearch(e.target.value); setOffset(0) }}
+          placeholder="종목 검색..."
+          className="bg-bg border border-border rounded-lg px-3 py-1.5 text-text text-[13px] w-60 placeholder:text-text-muted focus:outline-none focus:border-primary"
+        />
+        <div className="flex gap-1 bg-bg rounded-lg p-0.5">
+          {TF_OPTIONS.map((tf) => (
+            <button
+              key={tf}
+              onClick={() => { setTimeframe(tf); setOffset(0) }}
+              className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
+                timeframe === tf ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
+              }`}
+            >
+              {tf === 'all' ? '전체' : tf}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 테이블 */}
+      <div className="bg-surface border border-border rounded-lg p-5">
+        {isLoading ? (
+          <LoadingSpinner />
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr>
+                    <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">종목</th>
+                    <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">타임프레임</th>
+                    <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">시작일</th>
+                    <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">종료일</th>
+                    <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">행 수</th>
+                    <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(data?.items ?? []).length === 0 ? (
+                    <tr><td colSpan={6} className="px-3 py-8 text-center text-text-muted text-[13px]">데이터셋이 없습니다</td></tr>
+                  ) : (
+                    (data?.items ?? []).map((ds) => (
+                      <tr key={ds.id} className="hover:bg-surface-hover">
+                        <td className="px-3 py-3 border-b border-border text-[13px] font-mono font-medium">{ds.symbol}</td>
+                        <td className="px-3 py-3 border-b border-border text-[13px]">{ds.timeframe}</td>
+                        <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{formatDate(ds.start_date)}</td>
+                        <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{formatDate(ds.end_date)}</td>
+                        <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatNumber(ds.row_count)}</td>
+                        <td className="px-3 py-3 border-b border-border text-[13px] text-right">
+                          <button
+                            onClick={() => setDeleteTarget({ id: ds.id, symbol: ds.symbol, timeframe: ds.timeframe })}
+                            className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-negative border border-border cursor-pointer hover:bg-negative-bg"
+                          >
+                            삭제
+                          </button>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="flex items-center justify-between pt-4">
+              <span className="text-[12px] text-text-muted">
+                총 {formatNumber(data?.total ?? 0)}건
+                {storage && ` · ${(storage.total_size_bytes / 1024 / 1024).toFixed(1)} MB`}
+              </span>
+              {(data?.total ?? 0) > LIMIT && (
+                <Pagination total={data?.total ?? 0} offset={offset} limit={LIMIT} onPageChange={setOffset} />
+              )}
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* 삭제 확인 모달 */}
+      {deleteTarget && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+          <div className="bg-surface border border-border rounded-lg p-6 w-[400px]">
+            <h3 className="text-[18px] font-bold mb-4">데이터셋 삭제</h3>
+            <p className="text-[13px] mb-2">
+              <span className="font-mono font-medium">{deleteTarget.symbol}</span> ({deleteTarget.timeframe}) 데이터를 삭제하시겠습니까?
+            </p>
+            <p className="text-[12px] text-warning mb-4">사용 중인 백테스트가 있을 수 있습니다.</p>
+            <div className="flex justify-end gap-2 pt-4 border-t border-border">
+              <button onClick={() => setDeleteTarget(null)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
+              <button
+                onClick={() => deleteMutation.mutate(deleteTarget.id)}
+                disabled={deleteMutation.isPending}
+                className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative-hover disabled:opacity-50"
+              >
+                삭제
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/frontend/src/pages/BotDetail.tsx
+++ b/frontend/src/pages/BotDetail.tsx
@@ -1,0 +1,94 @@
+import { useParams, Link } from 'react-router-dom'
+import { useBotDetail, useBotControl } from '../hooks/useBots'
+import StatusBadge from '../components/common/StatusBadge'
+import LoadingSpinner from '../components/common/LoadingSpinner'
+import { formatKRW, formatDateTime } from '../utils/formatters'
+import { BOT_STATUS_LABELS } from '../utils/constants'
+import type { BotStatus } from '../types/bot'
+
+const STATUS_VARIANT: Record<BotStatus, string> = {
+  created: 'muted', running: 'positive', stopping: 'warning', stopped: 'muted', error: 'negative', deleted: 'muted',
+}
+
+export default function BotDetail() {
+  const { id } = useParams<{ id: string }>()
+  const { data: bot, isLoading } = useBotDetail(id!)
+  const { start, stop } = useBotControl()
+
+  if (isLoading) return <LoadingSpinner />
+  if (!bot) return <div className="text-text-muted text-center py-12">봇을 찾을 수 없습니다</div>
+
+  const canStart = bot.status === 'stopped' || bot.status === 'created'
+  const canStop = bot.status === 'running'
+
+  return (
+    <>
+      {/* 헤더 */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h2 className="text-[20px] font-bold">{bot.bot_id}</h2>
+          <div className="flex gap-3 items-center mt-1">
+            <StatusBadge variant={STATUS_VARIANT[bot.status] as 'positive'}>
+              {BOT_STATUS_LABELS[bot.status]}
+            </StatusBadge>
+            <StatusBadge variant={bot.mode === 'live' ? 'warning' : 'info'}>
+              {bot.mode === 'live' ? '실전' : '모의'}
+            </StatusBadge>
+            {bot.strategy_name && (
+              <Link to="/strategies" className="text-primary text-[13px] no-underline hover:underline">
+                {bot.strategy_name}
+              </Link>
+            )}
+          </div>
+        </div>
+        <div className="flex gap-2">
+          {canStart && (
+            <button onClick={() => start.mutate(bot.bot_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">시작</button>
+          )}
+          {canStop && (
+            <button onClick={() => stop.mutate(bot.bot_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">중지</button>
+          )}
+        </div>
+      </div>
+
+      {/* 설정 */}
+      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+        <h3 className="text-[15px] font-semibold mb-3">실행 설정</h3>
+        <div className="space-y-2">
+          <div className="flex justify-between py-2 border-b border-border text-[13px]">
+            <span className="text-text-muted">실행 간격</span>
+            <span>{bot.interval_seconds}초</span>
+          </div>
+          <div className="flex justify-between py-2 border-b border-border text-[13px]">
+            <span className="text-text-muted">대상 종목</span>
+            <span className="font-mono">{bot.symbols?.length ? bot.symbols.join(', ') : '-'}</span>
+          </div>
+          <div className="flex justify-between py-2 text-[13px]">
+            <span className="text-text-muted">할당 예산</span>
+            <span>{formatKRW(bot.allocated_budget)}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* 실행 로그 */}
+      <div className="bg-surface border border-border rounded-lg p-5">
+        <h3 className="text-[15px] font-semibold mb-3">실행 로그</h3>
+        {(bot.logs ?? []).length === 0 ? (
+          <div className="py-4 text-text-muted text-[13px] text-center">로그가 없습니다</div>
+        ) : (
+          <div className="space-y-0">
+            {bot.logs.map((log, i) => (
+              <div key={i} className="flex gap-3 py-2 border-b border-border text-[13px]">
+                <span className="text-text-muted font-mono text-[12px] whitespace-nowrap">{formatDateTime(log.timestamp)}</span>
+                <StatusBadge variant={log.success ? 'positive' : 'negative'}>
+                  {log.success ? '성공' : '실패'}
+                </StatusBadge>
+                {log.message && <span className="text-text-muted">{log.message}</span>}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/pages/Bots.tsx
+++ b/frontend/src/pages/Bots.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react'
+import { useBots, useBotControl } from '../hooks/useBots'
+import BotTable from '../components/bots/BotTable'
+import BotCreateForm from '../components/bots/BotCreateForm'
+import LoadingSpinner from '../components/common/LoadingSpinner'
+import type { BotStatus } from '../types/bot'
+
+const STATUS_FILTERS: { key: BotStatus | 'all'; label: string }[] = [
+  { key: 'all', label: '전체' },
+  { key: 'running', label: '실행 중' },
+  { key: 'stopped', label: '중지됨' },
+  { key: 'error', label: '오류' },
+]
+
+export default function Bots() {
+  const [statusFilter, setStatusFilter] = useState<BotStatus | 'all'>('all')
+  const [showCreate, setShowCreate] = useState(false)
+  const { data, isLoading } = useBots()
+  const { start, stop, remove } = useBotControl()
+
+  const items = (data?.items ?? []).filter(
+    (b) => statusFilter === 'all' || b.status === statusFilter,
+  )
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex gap-1 bg-bg rounded-lg p-0.5">
+          {STATUS_FILTERS.map((f) => (
+            <button
+              key={f.key}
+              onClick={() => setStatusFilter(f.key)}
+              className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
+                statusFilter === f.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={() => setShowCreate(true)}
+          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
+        >
+          봇 생성
+        </button>
+      </div>
+
+      <div className="bg-surface border border-border rounded-lg p-5">
+        {isLoading ? (
+          <LoadingSpinner />
+        ) : (
+          <BotTable
+            items={items}
+            onStart={(id) => start.mutate(id)}
+            onStop={(id) => stop.mutate(id)}
+            onDelete={(id) => { if (confirm('이 봇을 삭제하시겠습니까?')) remove.mutate(id) }}
+          />
+        )}
+      </div>
+
+      {showCreate && <BotCreateForm onClose={() => setShowCreate(false)} />}
+    </>
+  )
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,11 @@
+import PortfolioChart from '../components/dashboard/PortfolioChart'
+import PendingApprovals from '../components/dashboard/PendingApprovals'
+
+export default function Dashboard() {
+  return (
+    <>
+      <PortfolioChart />
+      <PendingApprovals />
+    </>
+  )
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,26 @@
+import { Navigate } from 'react-router-dom'
+import { useUser } from '../hooks/useAuth'
+import LoginForm from '../components/auth/LoginForm'
+
+export default function Login() {
+  const { data: user, isLoading } = useUser()
+
+  if (!isLoading && user) {
+    return <Navigate to="/" replace />
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-bg">
+      <div className="bg-surface border border-border rounded-lg p-10 w-[400px] text-center">
+        <div className="flex items-center justify-center gap-0 mb-1">
+          <img src="/logo-a.svg" alt="A" className="w-14 h-14" />
+          <img src="/logo-n.svg" alt="N" className="w-14 h-14" />
+          <img src="/logo-t.svg" alt="T" className="w-14 h-14" />
+          <img src="/logo-e.svg" alt="E" className="w-14 h-14" />
+        </div>
+        <div className="text-[13px] text-text-muted mb-8">AI-Native Trading Engine</div>
+        <LoginForm />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,0 +1,172 @@
+import { useState } from 'react'
+import { useSystemStatus, useKillSwitch, useConfigs, useUpdateConfig } from '../hooks/useSystemStatus'
+import LoadingSpinner from '../components/common/LoadingSpinner'
+
+function formatUptime(seconds: number): string {
+  const d = Math.floor(seconds / 86400)
+  const h = Math.floor((seconds % 86400) / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  if (d > 0) return `${d}일 ${h}시간 ${m}분`
+  if (h > 0) return `${h}시간 ${m}분`
+  return `${m}분`
+}
+
+const CONFIG_HINTS: Record<string, string> = {
+  'risk.max_mdd_pct': '고점 대비 N% 하락 시 정지',
+  'risk.max_position_pct': '총 자산의 N%까지 한 종목 보유 가능',
+  'risk.max_daily_loss_pct': '당일 손실 N% 초과 시 당일 거래 중지',
+}
+
+export default function Settings() {
+  const { data: status, isLoading: statusLoading } = useSystemStatus()
+  const killSwitch = useKillSwitch()
+  const { data: configs, isLoading: configLoading } = useConfigs()
+  const updateConfig = useUpdateConfig()
+  const [editingKey, setEditingKey] = useState<string | null>(null)
+  const [editValue, setEditValue] = useState('')
+  const [showKillConfirm, setShowKillConfirm] = useState(false)
+
+  if (statusLoading) return <LoadingSpinner />
+
+  const isActive = status?.trading_status === 'ACTIVE'
+
+  const handleKillSwitch = () => {
+    if (isActive) {
+      setShowKillConfirm(true)
+    } else {
+      killSwitch.mutate(false)
+    }
+  }
+
+  const confirmKill = () => {
+    killSwitch.mutate(true)
+    setShowKillConfirm(false)
+  }
+
+  const startEdit = (key: string, value: string) => {
+    setEditingKey(key)
+    setEditValue(value)
+  }
+
+  const saveEdit = () => {
+    if (editingKey) {
+      updateConfig.mutate({ key: editingKey, value: editValue })
+      setEditingKey(null)
+    }
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-6">
+      {/* 좌측 — 시스템 상태 */}
+      <div className="space-y-6">
+        <div className="bg-surface border border-border rounded-lg p-5">
+          <h3 className="text-[15px] font-semibold mb-4">시스템 상태</h3>
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-[13px]">거래 상태</div>
+                <span className={`inline-flex items-center px-2 py-0.5 rounded-[10px] text-[11px] font-semibold mt-1 ${isActive ? 'bg-positive-bg text-positive' : 'bg-negative-bg text-negative'}`}>
+                  {isActive ? 'ACTIVE' : 'HALTED'}
+                </span>
+              </div>
+              <button
+                onClick={handleKillSwitch}
+                className={`relative w-10 h-[22px] rounded-[11px] border-none cursor-pointer transition-colors ${isActive ? 'bg-positive' : 'bg-border'}`}
+              >
+                <span className={`absolute top-[2px] w-[18px] h-[18px] bg-white rounded-full transition-transform ${isActive ? 'left-[20px]' : 'left-[2px]'}`} />
+              </button>
+            </div>
+            <div className="flex justify-between py-2 border-t border-border text-[13px]">
+              <span className="text-text-muted">시스템 업타임</span>
+              <span>{status ? formatUptime(status.uptime_seconds) : '-'}</span>
+            </div>
+            <div className="flex justify-between py-2 border-t border-border text-[13px]">
+              <span className="text-text-muted">실행 중 봇</span>
+              <span>{status?.running_bots ?? 0}개</span>
+            </div>
+            <div className="flex justify-between py-2 border-t border-border text-[13px]">
+              <span className="text-text-muted">버전</span>
+              <span className="font-mono">{status?.version ?? '-'}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 우측 — 거래소 연결 */}
+      <div className="space-y-6">
+        <div className="bg-surface border border-border rounded-lg p-5">
+          <h3 className="text-[15px] font-semibold mb-4">거래소 연결</h3>
+          <div className="space-y-2">
+            <div className="flex justify-between py-2 border-b border-border text-[13px]">
+              <span className="text-text-muted">한국투자증권 API</span>
+              <span className="flex items-center gap-1.5">
+                <span className="w-2 h-2 rounded-full bg-positive" />
+                연결됨
+              </span>
+            </div>
+            <div className="flex justify-between py-2 text-[13px]">
+              <span className="text-text-muted">모드</span>
+              <span>모의투자</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 하단 — 거래 설정 (전체 폭) */}
+      <div className="col-span-2">
+        <div className="bg-surface border border-border rounded-lg p-5">
+          <h3 className="text-[15px] font-semibold mb-4">거래 설정</h3>
+          {configLoading ? (
+            <LoadingSpinner />
+          ) : (
+            <div className="space-y-0">
+              {(configs ?? []).map((cfg) => (
+                <div key={cfg.key} className="flex items-center justify-between py-3 border-b border-border last:border-b-0">
+                  <div>
+                    <div className="text-[13px] font-mono">{cfg.key}</div>
+                    <div className="text-[11px] text-text-muted mt-0.5">
+                      {CONFIG_HINTS[cfg.key] || cfg.description || ''}
+                    </div>
+                  </div>
+                  {editingKey === cfg.key ? (
+                    <div className="flex gap-2 items-center">
+                      <input
+                        value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)}
+                        className="w-24 bg-bg border border-border rounded px-2 py-1 text-text text-[13px] focus:outline-none focus:border-primary"
+                        autoFocus
+                      />
+                      <button onClick={saveEdit} className="px-2.5 py-1 rounded text-[12px] bg-primary text-white border-none cursor-pointer">저장</button>
+                      <button onClick={() => setEditingKey(null)} className="px-2.5 py-1 rounded text-[12px] bg-transparent text-text-muted border border-border cursor-pointer">취소</button>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() => startEdit(cfg.key, cfg.value)}
+                      className="text-[13px] font-mono text-text bg-transparent border-none cursor-pointer hover:text-primary"
+                    >
+                      {cfg.value}
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Kill Switch 확인 모달 */}
+      {showKillConfirm && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+          <div className="bg-surface border border-border rounded-lg p-6 w-[400px]">
+            <h3 className="text-[18px] font-bold mb-4">거래 중지 확인</h3>
+            <p className="text-[13px] text-negative mb-4">전체 거래가 중단됩니다. 모든 실행 중인 봇이 정지됩니다.</p>
+            <div className="flex justify-end gap-2 pt-4 border-t border-border">
+              <button onClick={() => setShowKillConfirm(false)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
+              <button onClick={confirmKill} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative-hover">중지</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Strategies.tsx
+++ b/frontend/src/pages/Strategies.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+import { useStrategies } from '../hooks/useStrategies'
+import StrategyTable from '../components/strategies/StrategyTable'
+import LoadingSpinner from '../components/common/LoadingSpinner'
+import type { StrategyStatus } from '../types/strategy'
+
+const STATUS_FILTERS: { key: StrategyStatus | 'all'; label: string }[] = [
+  { key: 'all', label: '전체' },
+  { key: 'active', label: '운용중' },
+  { key: 'registered', label: '대기' },
+  { key: 'inactive', label: '중지' },
+]
+
+export default function Strategies() {
+  const [statusFilter, setStatusFilter] = useState<StrategyStatus | 'all'>('all')
+  const { data: strategies, isLoading } = useStrategies()
+
+  const filtered = (strategies ?? []).filter(
+    (s) => statusFilter === 'all' || s.status === statusFilter,
+  )
+
+  return (
+    <>
+      <div className="flex gap-1 bg-bg rounded-lg p-0.5 mb-4 w-fit">
+        {STATUS_FILTERS.map((f) => (
+          <button
+            key={f.key}
+            onClick={() => setStatusFilter(f.key)}
+            className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
+              statusFilter === f.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
+            }`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+      <div className="bg-surface border border-border rounded-lg p-5">
+        {isLoading ? <LoadingSpinner /> : <StrategyTable items={filtered} />}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/pages/StrategyDetail.tsx
+++ b/frontend/src/pages/StrategyDetail.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { useStrategyDetail, useStrategyPerformance, useStrategyTrades } from '../hooks/useStrategies'
+import PerformancePanel from '../components/strategies/PerformancePanel'
+import StatusBadge from '../components/common/StatusBadge'
+import LoadingSpinner from '../components/common/LoadingSpinner'
+import { formatKRW, formatDateTime } from '../utils/formatters'
+import { STRATEGY_STATUS_LABELS } from '../utils/constants'
+import type { StrategyStatus } from '../types/strategy'
+
+const STATUS_VARIANT: Record<StrategyStatus, string> = {
+  active: 'positive', registered: 'info', inactive: 'muted', archived: 'muted',
+}
+
+type Tab = 'performance' | 'trades'
+
+export default function StrategyDetail() {
+  const { id } = useParams<{ id: string }>()
+  const numId = Number(id)
+  const [tab, setTab] = useState<Tab>('performance')
+
+  const { data: strategy, isLoading } = useStrategyDetail(numId)
+  const { data: performance } = useStrategyPerformance(numId)
+  const { data: tradesData } = useStrategyTrades(numId)
+
+  if (isLoading) return <LoadingSpinner />
+  if (!strategy) return <div className="text-text-muted text-center py-12">전략을 찾을 수 없습니다</div>
+
+  return (
+    <>
+      {/* 헤더 */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h2 className="text-[20px] font-bold">{strategy.name}</h2>
+          <div className="flex gap-3 items-center mt-1">
+            <span className="text-text-muted text-[13px]">v{strategy.version}</span>
+            <StatusBadge variant={STATUS_VARIANT[strategy.status] as 'positive'}>
+              {STRATEGY_STATUS_LABELS[strategy.status]}
+            </StatusBadge>
+            {strategy.bot_id && (
+              <Link to={`/bots/${strategy.bot_id}`} className="text-primary text-[13px] no-underline hover:underline">
+                {strategy.bot_id}
+              </Link>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* 에쿼티 커브 */}
+      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+        <h3 className="text-[15px] font-semibold mb-3">자산 추이</h3>
+        <div className="h-[280px] bg-bg border border-dashed border-border rounded-lg flex items-center justify-center text-text-muted text-[13px]">
+          📈 에쿼티 커브 (TradingView Area Chart)
+        </div>
+      </div>
+
+      {/* 성과 지표 */}
+      {performance && <PerformancePanel perf={performance} />}
+
+      {/* 탭 */}
+      <div className="flex gap-1 bg-bg rounded-lg p-0.5 mb-4 w-fit">
+        <button
+          onClick={() => setTab('performance')}
+          className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${tab === 'performance' ? 'bg-surface text-text' : 'bg-transparent text-text-muted'}`}
+        >
+          파라미터
+        </button>
+        <button
+          onClick={() => setTab('trades')}
+          className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${tab === 'trades' ? 'bg-surface text-text' : 'bg-transparent text-text-muted'}`}
+        >
+          거래 내역
+        </button>
+      </div>
+
+      {tab === 'performance' && strategy.params && (
+        <div className="bg-surface border border-border rounded-lg p-5">
+          <h3 className="text-[15px] font-semibold mb-3">전략 파라미터</h3>
+          <div className="space-y-2">
+            {Object.entries(strategy.params).map(([key, value]) => (
+              <div key={key} className="flex justify-between py-2 border-b border-border text-[13px]">
+                <span className="text-text-muted font-mono">{key}</span>
+                <span>{String(value)}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {tab === 'trades' && (
+        <div className="bg-surface border border-border rounded-lg p-5">
+          <h3 className="text-[15px] font-semibold mb-3">거래 내역</h3>
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse">
+              <thead>
+                <tr>
+                  <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">종목</th>
+                  <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">방향</th>
+                  <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">수량</th>
+                  <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">가격</th>
+                  <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">손익</th>
+                  <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">체결일</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(tradesData?.items ?? []).length === 0 ? (
+                  <tr><td colSpan={6} className="px-3 py-8 text-center text-text-muted text-[13px]">거래 내역이 없습니다</td></tr>
+                ) : (
+                  (tradesData?.items ?? []).map((t) => (
+                    <tr key={t.id} className="hover:bg-surface-hover">
+                      <td className="px-3 py-3 border-b border-border text-[13px] font-mono">{t.symbol}</td>
+                      <td className="px-3 py-3 border-b border-border text-[13px]">
+                        <StatusBadge variant={t.side === 'buy' ? 'positive' : 'negative'}>
+                          {t.side === 'buy' ? '매수' : '매도'}
+                        </StatusBadge>
+                      </td>
+                      <td className="px-3 py-3 border-b border-border text-[13px] text-right">{t.quantity}</td>
+                      <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(t.price)}</td>
+                      <td className="px-3 py-3 border-b border-border text-[13px] text-right">
+                        {t.pnl != null ? (
+                          <span className={t.pnl >= 0 ? 'text-positive' : 'text-negative'}>{formatKRW(t.pnl)}</span>
+                        ) : '-'}
+                      </td>
+                      <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{formatDateTime(t.executed_at)}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/frontend/src/pages/Treasury.tsx
+++ b/frontend/src/pages/Treasury.tsx
@@ -1,0 +1,31 @@
+import { Link } from 'react-router-dom'
+import { useTreasurySummary, useBotBudgets } from '../hooks/useTreasury'
+import AccountSummary from '../components/treasury/AccountSummary'
+import BudgetTable from '../components/treasury/BudgetTable'
+import AllocationForm from '../components/treasury/AllocationForm'
+import LoadingSpinner from '../components/common/LoadingSpinner'
+
+export default function Treasury() {
+  const { data: summary, isLoading: summaryLoading } = useTreasurySummary()
+  const { data: budgets, isLoading: budgetsLoading } = useBotBudgets()
+
+  if (summaryLoading || budgetsLoading) return <LoadingSpinner />
+
+  const botIds = (budgets ?? []).map((b) => b.bot_id)
+
+  return (
+    <>
+      {summary && <AccountSummary summary={summary} />}
+      <BudgetTable budgets={budgets ?? []} />
+      {botIds.length > 0 && <AllocationForm botIds={botIds} />}
+      <div className="mt-4">
+        <Link
+          to="/treasury/history"
+          className="text-[13px] text-primary no-underline hover:underline"
+        >
+          거래 이력 보기 →
+        </Link>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/pages/TreasuryHistory.tsx
+++ b/frontend/src/pages/TreasuryHistory.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react'
+import { useTreasuryHistory } from '../hooks/useTreasury'
+import { formatKRW, formatDateTime } from '../utils/formatters'
+import Pagination from '../components/common/Pagination'
+import LoadingSpinner from '../components/common/LoadingSpinner'
+
+const LIMIT = 20
+
+export default function TreasuryHistory() {
+  const [offset, setOffset] = useState(0)
+  const { data, isLoading } = useTreasuryHistory(offset, LIMIT)
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5">
+      <h3 className="text-[15px] font-semibold mb-4">자금 거래 이력</h3>
+      {isLoading ? (
+        <LoadingSpinner />
+      ) : (
+        <>
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse">
+              <thead>
+                <tr>
+                  <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">유형</th>
+                  <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">봇 ID</th>
+                  <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">금액</th>
+                  <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">설명</th>
+                  <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">일시</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(data?.items ?? []).length === 0 ? (
+                  <tr><td colSpan={5} className="px-3 py-8 text-center text-text-muted text-[13px]">이력이 없습니다</td></tr>
+                ) : (
+                  (data?.items ?? []).map((tx) => (
+                    <tr key={tx.id} className="hover:bg-surface-hover">
+                      <td className="px-3 py-3 border-b border-border text-[13px]">{tx.type}</td>
+                      <td className="px-3 py-3 border-b border-border text-[13px] font-mono">{tx.bot_id || '-'}</td>
+                      <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(tx.amount)}</td>
+                      <td className="px-3 py-3 border-b border-border text-[13px]">{tx.description}</td>
+                      <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{formatDateTime(tx.created_at)}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+          {(data?.total ?? 0) > LIMIT && (
+            <Pagination total={data?.total ?? 0} offset={offset} limit={LIMIT} onPageChange={setOffset} />
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/types/approval.ts
+++ b/frontend/src/types/approval.ts
@@ -1,0 +1,43 @@
+export type ApprovalStatus = 'pending' | 'approved' | 'rejected'
+export type ApprovalType = 'strategy_report' | 'budget_allocation' | 'live_switch' | 'risk_alert'
+
+export interface Approval {
+  id: number
+  type: ApprovalType
+  title: string
+  requester: string
+  requested_at: string
+  status: ApprovalStatus
+  reference_id?: number
+  memo?: string
+  resolved_at?: string
+  resolved_by?: string
+}
+
+export interface ApprovalDetail extends Approval {
+  detail?: StrategyReportDetail
+}
+
+export interface StrategyReportDetail {
+  strategy_name: string
+  strategy_version: string
+  agent_summary: string
+  agent_rationale: string
+  agent_risks: string
+  agent_recommendation: string
+  backtest_start: string
+  backtest_end: string
+  metrics: BacktestMetrics
+  equity_curve: { date: string; value: number }[]
+  drawdown: { date: string; value: number }[]
+}
+
+export interface BacktestMetrics {
+  sharpe_ratio: number
+  max_drawdown: number
+  win_rate: number
+  profit_factor: number
+  total_trades: number
+  total_return: number
+  annual_return: number
+}

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,0 +1,19 @@
+export interface LoginRequest {
+  member_id: string
+  password: string
+}
+
+export interface User {
+  member_id: string
+  name: string
+  role: string
+  type: string
+  org: string
+  scopes: string[]
+}
+
+export interface LoginResponse {
+  member_id: string
+  name: string
+  role: string
+}

--- a/frontend/src/types/bot.ts
+++ b/frontend/src/types/bot.ts
@@ -1,0 +1,32 @@
+export type BotStatus = 'created' | 'running' | 'stopping' | 'stopped' | 'error' | 'deleted'
+export type BotMode = 'live' | 'paper'
+
+export interface Bot {
+  bot_id: string
+  strategy_name?: string
+  status: BotStatus
+  mode: BotMode
+  created_at: string
+}
+
+export interface BotDetail extends Bot {
+  interval_seconds: number
+  symbols: string[]
+  allocated_budget: number
+  logs: BotLog[]
+}
+
+export interface BotLog {
+  timestamp: string
+  success: boolean
+  message?: string
+}
+
+export interface BotCreateRequest {
+  bot_id: string
+  strategy_name: string
+  mode: BotMode
+  interval_seconds: number
+  budget: number
+  symbols: string[]
+}

--- a/frontend/src/types/member.ts
+++ b/frontend/src/types/member.ts
@@ -1,0 +1,36 @@
+export type MemberStatus = 'active' | 'suspended' | 'revoked'
+export type MemberType = 'human' | 'agent'
+
+export interface Member {
+  member_id: string
+  name: string
+  type: MemberType
+  org: string
+  status: MemberStatus
+  last_active_at?: string
+  created_at: string
+}
+
+export interface MemberDetail extends Member {
+  scopes: string[]
+  created_by?: string
+}
+
+export interface MemberCreateRequest {
+  member_id: string
+  name: string
+  org: string
+  scopes: string[]
+}
+
+export const ALL_SCOPES = [
+  'strategy:read',
+  'strategy:write',
+  'report:write',
+  'approval:create',
+  'approval:review',
+  'bot:read',
+  'data:read',
+  'data:write',
+  'backtest:run',
+] as const

--- a/frontend/src/types/portfolio.ts
+++ b/frontend/src/types/portfolio.ts
@@ -1,0 +1,15 @@
+export interface PortfolioValue {
+  total_value: number
+  total_cost: number
+  total_pnl: number
+  total_pnl_pct: number
+  daily_pnl: number
+  daily_pnl_pct: number
+}
+
+export interface PortfolioHistoryPoint {
+  date: string
+  value: number
+}
+
+export type Period = '1d' | '1w' | '1m' | '3m' | 'all'

--- a/frontend/src/types/strategy.ts
+++ b/frontend/src/types/strategy.ts
@@ -1,0 +1,38 @@
+export type StrategyStatus = 'registered' | 'active' | 'inactive' | 'archived'
+
+export interface Strategy {
+  id: number
+  name: string
+  version: string
+  status: StrategyStatus
+  bot_id?: string
+  cumulative_return?: number
+  created_at: string
+}
+
+export interface StrategyDetail extends Strategy {
+  description?: string
+  params?: Record<string, unknown>
+}
+
+export interface StrategyPerformance {
+  total_trades: number
+  win_rate: number
+  profit_factor: number
+  max_drawdown: number
+  realized_pnl: number
+  sharpe_ratio: number
+  equity_curve: { date: string; value: number }[]
+}
+
+export interface Trade {
+  id: number
+  strategy_id: number
+  bot_id: string
+  symbol: string
+  side: 'buy' | 'sell'
+  quantity: number
+  price: number
+  executed_at: string
+  pnl?: number
+}

--- a/frontend/src/types/system.ts
+++ b/frontend/src/types/system.ts
@@ -1,0 +1,18 @@
+export interface SystemStatus {
+  trading_status: 'ACTIVE' | 'HALTED'
+  uptime_seconds: number
+  running_bots: number
+  version: string
+}
+
+export interface BrokerStatus {
+  connected: boolean
+  mode: 'live' | 'paper'
+  token_expires_at?: string
+}
+
+export interface DynamicConfig {
+  key: string
+  value: string
+  description?: string
+}

--- a/frontend/src/types/treasury.ts
+++ b/frontend/src/types/treasury.ts
@@ -1,0 +1,23 @@
+export interface TreasurySummary {
+  total_balance: number
+  allocated: number
+  unallocated: number
+  reserved: number
+}
+
+export interface BotBudget {
+  bot_id: string
+  allocated: number
+  available: number
+  reserved: number
+  used: number
+}
+
+export interface TreasuryTransaction {
+  id: number
+  type: 'allocate' | 'deallocate' | 'trade' | 'deposit' | 'withdrawal'
+  bot_id?: string
+  amount: number
+  description: string
+  created_at: string
+}


### PR DESCRIPTION
## Summary
- 대시보드 프론트엔드 전체 구현 (13개 이슈, 12개 커밋)
- Bloomberg 다크 테마 기반 UI, React 18 + TypeScript + Tailwind CSS v4
- 모든 페이지 API 연동 준비 완료 (React Query 훅 + Axios 클라이언트)

## 구현된 이슈
| 이슈 | 페이지 |
|------|--------|
| #160 | 로그인 (Member ID + 패스워드, ProtectedRoute) |
| #161 | 레이아웃 (Sidebar + Header + 라우팅) |
| #164 | 대시보드 메인 (자산 추이 + 승인 대기) |
| #165 | 결재함 목록 (상태/유형 필터 + 페이지네이션) |
| #166 | 결재 상세 (Agent 분석 + 성과 지표 + 차트) |
| #169 | 자금 관리 (계좌 요약 + 봇별 예산 + 할당/회수) |
| #170 | 전략 목록 (상태 필터) |
| #171 | 전략 상세 (에쿼티 커브 + 성과 + 거래 탭) |
| #174 | 봇 관리 (목록 + 생성 모달 + 상세) |
| #175 | 백테스트 데이터 (검색 + 삭제 + 페이지네이션) |
| #178 | 에이전트 관리 (목록 + 등록 + 상세 + 토큰) |
| #179 | 설정 (Kill Switch + 거래소 + 동적 설정) |

## 남은 작업 (#180)
- [ ] TradingView Lightweight Charts 실제 연동
- [ ] 에러 바운더리 추가
- [ ] 반응형 레이아웃
- [ ] FastAPI 정적 파일 서빙 설정
- [ ] 프론트엔드 CI (ESLint + TypeScript + build)

## Test plan
- [ ] `npm run build` 빌드 성공 확인 (완료)
- [ ] `npx tsc -b` 타입 체크 통과 확인 (완료)
- [ ] 각 페이지 라우팅 정상 동작 확인
- [ ] API 연동 후 데이터 표시 확인

Closes #160, Closes #161, Closes #164, Closes #165, Closes #166
Closes #169, Closes #170, Closes #171, Closes #174, Closes #175
Closes #178, Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)