### PR TITLE
feat: 대시보드 마무리 (에러 핸들링 + 반응형 + 빌드 서빙)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import ErrorBoundary from './components/common/ErrorBoundary'
+import ToastContainer from './components/common/Toast'
 import ProtectedRoute from './components/auth/ProtectedRoute'
 import Layout from './components/layout/Layout'
 import Login from './pages/Login'
@@ -16,6 +18,7 @@ import BacktestData from './pages/BacktestData'
 import Agents from './pages/Agents'
 import AgentDetail from './pages/AgentDetail'
 import Settings from './pages/Settings'
+import NotFound from './pages/NotFound'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -28,34 +31,38 @@ const queryClient = new QueryClient({
 
 export default function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route
-            element={
-              <ProtectedRoute>
-                <Layout />
-              </ProtectedRoute>
-            }
-          >
-            <Route index element={<Dashboard />} />
-            <Route path="approvals" element={<Approvals />} />
-            <Route path="approvals/:id" element={<ApprovalDetail />} />
-            <Route path="treasury" element={<Treasury />} />
-            <Route path="treasury/history" element={<TreasuryHistory />} />
-            <Route path="strategies" element={<Strategies />} />
-            <Route path="strategies/:id" element={<StrategyDetail />} />
-            <Route path="bots" element={<Bots />} />
-            <Route path="bots/:id" element={<BotDetail />} />
-            <Route path="backtest-data" element={<BacktestData />} />
-            <Route path="agents" element={<Agents />} />
-            <Route path="agents/:id" element={<AgentDetail />} />
-            <Route path="settings" element={<Settings />} />
-          </Route>
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
-      </BrowserRouter>
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <ToastContainer />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/login" element={<Login />} />
+            <Route
+              element={
+                <ProtectedRoute>
+                  <Layout />
+                </ProtectedRoute>
+              }
+            >
+              <Route index element={<Dashboard />} />
+              <Route path="approvals" element={<Approvals />} />
+              <Route path="approvals/:id" element={<ApprovalDetail />} />
+              <Route path="treasury" element={<Treasury />} />
+              <Route path="treasury/history" element={<TreasuryHistory />} />
+              <Route path="strategies" element={<Strategies />} />
+              <Route path="strategies/:id" element={<StrategyDetail />} />
+              <Route path="bots" element={<Bots />} />
+              <Route path="bots/:id" element={<BotDetail />} />
+              <Route path="backtest-data" element={<BacktestData />} />
+              <Route path="agents" element={<Agents />} />
+              <Route path="agents/:id" element={<AgentDetail />} />
+              <Route path="settings" element={<Settings />} />
+              <Route path="*" element={<NotFound />} />
+            </Route>
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </QueryClientProvider>
+    </ErrorBoundary>
   )
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { showToast } from '../components/common/Toast'
 
 const client = axios.create({
   baseURL: import.meta.env.VITE_API_URL || '',
@@ -13,7 +14,16 @@ client.interceptors.response.use(
   (error) => {
     if (error.response?.status === 401) {
       window.location.href = '/login'
+      return Promise.reject(error)
     }
+
+    const data = error.response?.data
+    if (data?.detail) {
+      showToast(data.detail, 'error')
+    } else if (!error.response) {
+      showToast('서버에 연결할 수 없습니다', 'error')
+    }
+
     return Promise.reject(error)
   },
 )

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,52 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+  error: Error | null
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex items-center justify-center min-h-screen bg-bg">
+          <div className="text-center max-w-md px-6">
+            <div className="text-[48px] mb-4">💥</div>
+            <h1 className="text-[20px] font-semibold mb-2">예기치 않은 오류가 발생했습니다</h1>
+            <p className="text-text-muted text-[14px] mb-6">
+              {this.state.error?.message || '알 수 없는 오류'}
+            </p>
+            <button
+              onClick={() => {
+                this.setState({ hasError: false, error: null })
+                window.location.href = '/'
+              }}
+              className="px-4 py-2 bg-primary text-white rounded-lg border-none cursor-pointer text-[14px] hover:bg-primary-hover"
+            >
+              대시보드로 돌아가기
+            </button>
+          </div>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/frontend/src/components/common/ServiceUnavailable.tsx
+++ b/frontend/src/components/common/ServiceUnavailable.tsx
@@ -1,0 +1,19 @@
+export default function ServiceUnavailable() {
+  return (
+    <div className="flex items-center justify-center py-16">
+      <div className="text-center">
+        <div className="text-[48px] mb-4">🔌</div>
+        <h2 className="text-[18px] font-semibold mb-2">서비스에 연결할 수 없습니다</h2>
+        <p className="text-text-muted text-[14px] mb-6">
+          서버가 응답하지 않습니다. 잠시 후 다시 시도해 주세요.
+        </p>
+        <button
+          onClick={() => window.location.reload()}
+          className="px-4 py-2 bg-primary text-white rounded-lg border-none cursor-pointer text-[14px] hover:bg-primary-hover"
+        >
+          새로고침
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/common/Skeleton.tsx
+++ b/frontend/src/components/common/Skeleton.tsx
@@ -1,0 +1,59 @@
+export function Skeleton({ className = '' }: { className?: string }) {
+  return (
+    <div
+      className={`bg-surface-hover rounded animate-pulse ${className}`}
+    />
+  )
+}
+
+export function TableSkeleton({ rows = 5, cols = 4 }: { rows?: number; cols?: number }) {
+  return (
+    <div className="border border-border rounded-lg overflow-hidden">
+      <div className="flex gap-4 px-4 py-3 border-b border-border">
+        {Array.from({ length: cols }).map((_, i) => (
+          <Skeleton key={i} className="h-4 flex-1" />
+        ))}
+      </div>
+      {Array.from({ length: rows }).map((_, r) => (
+        <div key={r} className="flex gap-4 px-4 py-3 border-b border-border last:border-b-0">
+          {Array.from({ length: cols }).map((_, c) => (
+            <Skeleton key={c} className="h-4 flex-1" />
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function ChartSkeleton({ className = '' }: { className?: string }) {
+  return (
+    <div className={`border border-border rounded-lg p-4 ${className}`}>
+      <Skeleton className="h-5 w-32 mb-4" />
+      <Skeleton className="h-48 w-full" />
+    </div>
+  )
+}
+
+export function CardSkeleton() {
+  return (
+    <div className="border border-border rounded-lg p-4">
+      <Skeleton className="h-4 w-24 mb-3" />
+      <Skeleton className="h-8 w-32" />
+    </div>
+  )
+}
+
+export function PageSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <CardSkeleton />
+        <CardSkeleton />
+        <CardSkeleton />
+        <CardSkeleton />
+      </div>
+      <ChartSkeleton />
+      <TableSkeleton />
+    </div>
+  )
+}

--- a/frontend/src/components/common/Toast.tsx
+++ b/frontend/src/components/common/Toast.tsx
@@ -1,0 +1,83 @@
+import { useState, useEffect, useCallback, useSyncExternalStore } from 'react'
+
+interface ToastItem {
+  id: number
+  message: string
+  type: 'error' | 'success' | 'warning'
+}
+
+let toastId = 0
+let toasts: ToastItem[] = []
+const listeners = new Set<() => void>()
+
+function notify() {
+  listeners.forEach((l) => l())
+}
+
+export function showToast(message: string, type: ToastItem['type'] = 'error') {
+  const id = ++toastId
+  toasts = [...toasts, { id, message, type }]
+  notify()
+  setTimeout(() => {
+    toasts = toasts.filter((t) => t.id !== id)
+    notify()
+  }, 5000)
+}
+
+function useToasts() {
+  return useSyncExternalStore(
+    (cb) => {
+      listeners.add(cb)
+      return () => listeners.delete(cb)
+    },
+    () => toasts,
+  )
+}
+
+export default function ToastContainer() {
+  const items = useToasts()
+
+  const dismiss = useCallback((id: number) => {
+    toasts = toasts.filter((t) => t.id !== id)
+    notify()
+  }, [])
+
+  if (items.length === 0) return null
+
+  return (
+    <div className="fixed top-4 right-4 z-[9999] flex flex-col gap-2 max-w-[400px]">
+      {items.map((toast) => (
+        <ToastMessage key={toast.id} toast={toast} onDismiss={dismiss} />
+      ))}
+    </div>
+  )
+}
+
+function ToastMessage({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id: number) => void }) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    requestAnimationFrame(() => setVisible(true))
+  }, [])
+
+  const bgColor =
+    toast.type === 'error'
+      ? 'bg-negative-bg border-negative'
+      : toast.type === 'warning'
+        ? 'bg-warning-bg border-warning'
+        : 'bg-positive-bg border-positive'
+
+  return (
+    <div
+      className={`${bgColor} border rounded-lg px-4 py-3 text-[13px] text-text shadow-[0_4px_12px_rgba(0,0,0,0.3)] flex items-start gap-2 transition-all duration-200 ${visible ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-4'}`}
+    >
+      <span className="flex-1 break-words">{toast.message}</span>
+      <button
+        onClick={() => onDismiss(toast.id)}
+        className="bg-transparent border-none text-text-muted cursor-pointer text-[16px] p-0 leading-none hover:text-text"
+      >
+        x
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/dashboard/PendingApprovals.tsx
+++ b/frontend/src/components/dashboard/PendingApprovals.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom'
 import { useApprovals, useUpdateApprovalStatus } from '../../hooks/useApprovals'
 import { formatDateTime } from '../../utils/formatters'
 import StatusBadge from '../common/StatusBadge'
-import LoadingSpinner from '../common/LoadingSpinner'
+import { TableSkeleton } from '../common/Skeleton'
 import type { Approval, ApprovalType } from '../../types/approval'
 
 const TYPE_LABELS: Record<ApprovalType, { label: string; variant: string }> = {
@@ -41,7 +41,7 @@ export default function PendingApprovals() {
       </div>
 
       {isLoading ? (
-        <LoadingSpinner />
+        <TableSkeleton rows={3} cols={4} />
       ) : items.length === 0 ? (
         <div className="py-8 text-center text-text-muted text-[13px]">승인 대기 건이 없습니다</div>
       ) : (

--- a/frontend/src/components/dashboard/PortfolioChart.tsx
+++ b/frontend/src/components/dashboard/PortfolioChart.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { usePortfolioValue, usePortfolioHistory } from '../../hooks/usePortfolio'
 import { formatKRW, formatPercent } from '../../utils/formatters'
 import type { Period } from '../../types/portfolio'
-import LoadingSpinner from '../common/LoadingSpinner'
+import { ChartSkeleton } from '../common/Skeleton'
 
 const PERIODS: { key: Period; label: string }[] = [
   { key: '1d', label: '1일' },
@@ -58,7 +58,7 @@ export default function PortfolioChart() {
       </div>
 
       {historyLoading ? (
-        <LoadingSpinner />
+        <ChartSkeleton />
       ) : history && history.length > 0 ? (
         <div className="h-[280px] bg-bg border border-dashed border-border rounded-lg flex items-center justify-center text-text-muted text-[13px]">
           📈 자산 추이 차트 (TradingView Area Chart) — {history.length}개 데이터 포인트

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -51,8 +51,8 @@ export default function Header() {
   }, [])
 
   return (
-    <header className="fixed top-0 left-sidebar right-0 h-header bg-surface border-b border-border flex items-center justify-between px-6 z-[100]">
-      <div className="flex items-center gap-4">
+    <header className="fixed top-0 left-0 md:left-sidebar right-0 h-header bg-surface border-b border-border flex items-center justify-between px-4 md:px-6 z-[100]">
+      <div className="flex items-center gap-4 ml-10 md:ml-0">
         {showBack && (
           <button
             onClick={() => navigate(-1)}
@@ -64,8 +64,8 @@ export default function Header() {
         <h1 className="text-[16px] font-semibold">{title}</h1>
       </div>
 
-      <div className="flex items-center gap-4">
-        <div className="flex items-center gap-1.5 text-[12px] text-text-muted">
+      <div className="flex items-center gap-2 md:gap-4">
+        <div className="hidden sm:flex items-center gap-1.5 text-[12px] text-text-muted">
           <span
             className={`w-2 h-2 rounded-full ${
               systemStatus?.trading_status === 'ACTIVE' ? 'bg-positive' : 'bg-negative'
@@ -80,7 +80,7 @@ export default function Header() {
             className="flex items-center gap-2 px-2.5 py-1 rounded-lg cursor-pointer text-[13px] text-text-muted bg-transparent border-none hover:bg-surface-hover hover:text-text"
           >
             <span className="text-[22px] leading-none mt-0.5">🦁</span>
-            <span>{user?.member_id ?? '...'} · {user?.role === 'master' ? '대표' : user?.role}</span>
+            <span className="hidden sm:inline">{user?.member_id ?? '...'} · {user?.role === 'master' ? '대표' : user?.role}</span>
           </button>
 
           {menuOpen && (

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -7,7 +7,7 @@ export default function Layout() {
     <div className="flex min-h-screen">
       <Sidebar />
       <Header />
-      <main className="ml-sidebar mt-header p-6 flex-1 min-h-[calc(100vh-var(--spacing-header))]">
+      <main className="ml-0 md:ml-sidebar mt-header p-4 md:p-6 flex-1 min-h-[calc(100vh-var(--spacing-header))]">
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import { useApprovals } from '../../hooks/useApprovals'
 
@@ -14,44 +15,72 @@ const NAV_ITEMS = [
 export default function Sidebar() {
   const { data: approvals } = useApprovals({ status: 'pending', limit: 0 })
   const pendingCount = approvals?.total ?? 0
+  const [mobileOpen, setMobileOpen] = useState(false)
 
   return (
-    <aside className="fixed top-0 left-0 w-sidebar h-screen bg-surface border-r border-border flex flex-col z-[101]">
-      <div className="h-header flex items-center justify-center gap-0 px-5 border-b border-border">
-        <img src="/logo-a.svg" alt="A" className="w-8 h-8" />
-        <img src="/logo-n.svg" alt="N" className="w-8 h-8" />
-        <img src="/logo-t.svg" alt="T" className="w-8 h-8" />
-        <img src="/logo-e.svg" alt="E" className="w-8 h-8" />
-      </div>
+    <>
+      {/* 모바일 햄버거 버튼 */}
+      <button
+        onClick={() => setMobileOpen(true)}
+        className="fixed top-3 left-3 z-[102] p-2 rounded-lg bg-surface border border-border cursor-pointer text-text md:hidden"
+        aria-label="메뉴 열기"
+      >
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <path d="M3 5h14M3 10h14M3 15h14" />
+        </svg>
+      </button>
 
-      <nav className="flex-1 py-3 px-2 flex flex-col gap-0.5">
-        {NAV_ITEMS.map((item) => (
-          <NavLink
-            key={item.path}
-            to={item.path}
-            end={item.path === '/'}
-            className={({ isActive }) =>
-              `flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-[15px] font-medium no-underline transition-colors ${
-                isActive
-                  ? 'bg-primary text-white'
-                  : 'text-text-muted hover:bg-surface-hover hover:text-text'
-              }`
-            }
-          >
-            <span className="text-[16px] w-5 text-center">{item.icon}</span>
-            <span>{item.label}</span>
-            {item.showBadge && pendingCount > 0 && (
-              <span className="ml-auto bg-negative text-white text-[11px] px-1.5 py-0 rounded-[10px] font-semibold">
-                {pendingCount}
-              </span>
-            )}
-          </NavLink>
-        ))}
-      </nav>
+      {/* 모바일 오버레이 */}
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 z-[100] md:hidden"
+          onClick={() => setMobileOpen(false)}
+        />
+      )}
 
-      <div className="px-4 py-3 text-[11px] text-text-muted border-t border-border">
-        Ante v0.1.0 · <a href="https://opensource.org/licenses/MIT" className="text-text-muted hover:text-text no-underline">MIT</a>
-      </div>
-    </aside>
+      {/* 사이드바 */}
+      <aside
+        className={`fixed top-0 left-0 w-sidebar h-screen bg-surface border-r border-border flex flex-col z-[101] transition-transform duration-200 ${
+          mobileOpen ? 'translate-x-0' : '-translate-x-full'
+        } md:translate-x-0`}
+      >
+        <div className="h-header flex items-center justify-center gap-0 px-5 border-b border-border">
+          <img src="/logo-a.svg" alt="A" className="w-8 h-8" />
+          <img src="/logo-n.svg" alt="N" className="w-8 h-8" />
+          <img src="/logo-t.svg" alt="T" className="w-8 h-8" />
+          <img src="/logo-e.svg" alt="E" className="w-8 h-8" />
+        </div>
+
+        <nav className="flex-1 py-3 px-2 flex flex-col gap-0.5">
+          {NAV_ITEMS.map((item) => (
+            <NavLink
+              key={item.path}
+              to={item.path}
+              end={item.path === '/'}
+              onClick={() => setMobileOpen(false)}
+              className={({ isActive }) =>
+                `flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-[15px] font-medium no-underline transition-colors ${
+                  isActive
+                    ? 'bg-primary text-white'
+                    : 'text-text-muted hover:bg-surface-hover hover:text-text'
+                }`
+              }
+            >
+              <span className="text-[16px] w-5 text-center">{item.icon}</span>
+              <span>{item.label}</span>
+              {item.showBadge && pendingCount > 0 && (
+                <span className="ml-auto bg-negative text-white text-[11px] px-1.5 py-0 rounded-[10px] font-semibold">
+                  {pendingCount}
+                </span>
+              )}
+            </NavLink>
+          ))}
+        </nav>
+
+        <div className="px-4 py-3 text-[11px] text-text-muted border-t border-border">
+          Ante v0.1.0 · <a href="https://opensource.org/licenses/MIT" className="text-text-muted hover:text-text no-underline">MIT</a>
+        </div>
+      </aside>
+    </>
   )
 }

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { useMemberDetail, useMemberControl } from '../hooks/useMembers'
 import StatusBadge from '../components/common/StatusBadge'
-import LoadingSpinner from '../components/common/LoadingSpinner'
+import { PageSkeleton } from '../components/common/Skeleton'
 import { formatDateTime } from '../utils/formatters'
 import { MEMBER_STATUS_LABELS } from '../utils/constants'
 import { ALL_SCOPES, type MemberStatus } from '../types/member'
@@ -19,7 +19,7 @@ export default function AgentDetail() {
   const [editingScopes, setEditingScopes] = useState(false)
   const [scopesDraft, setScopesDraft] = useState<string[]>([])
 
-  if (isLoading) return <LoadingSpinner />
+  if (isLoading) return <PageSkeleton />
   if (!member) return <div className="text-text-muted text-center py-12">에이전트를 찾을 수 없습니다</div>
 
   const startEditScopes = () => {

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useMembers, useMemberControl } from '../hooks/useMembers'
 import AgentTable from '../components/agents/AgentTable'
 import AgentRegisterForm from '../components/agents/AgentRegisterForm'
-import LoadingSpinner from '../components/common/LoadingSpinner'
+import { TableSkeleton } from '../components/common/Skeleton'
 import type { MemberStatus } from '../types/member'
 
 const STATUS_FILTERS: { key: MemberStatus | 'all'; label: string }[] = [
@@ -49,7 +49,7 @@ export default function Agents() {
 
       <div className="bg-surface border border-border rounded-lg p-5">
         {isLoading ? (
-          <LoadingSpinner />
+          <TableSkeleton rows={5} cols={5} />
         ) : (
           <AgentTable
             items={members ?? []}

--- a/frontend/src/pages/ApprovalDetail.tsx
+++ b/frontend/src/pages/ApprovalDetail.tsx
@@ -3,7 +3,7 @@ import { useApprovalDetail } from '../hooks/useApprovals'
 import ReviewControls from '../components/approvals/ReviewControls'
 import BacktestMetricsPanel from '../components/approvals/BacktestMetrics'
 import StatusBadge from '../components/common/StatusBadge'
-import LoadingSpinner from '../components/common/LoadingSpinner'
+import { PageSkeleton } from '../components/common/Skeleton'
 import { formatDate } from '../utils/formatters'
 import { APPROVAL_STATUS_LABELS } from '../utils/constants'
 import type { ApprovalStatus } from '../types/approval'
@@ -18,7 +18,7 @@ export default function ApprovalDetail() {
   const { id } = useParams<{ id: string }>()
   const { data: approval, isLoading } = useApprovalDetail(Number(id))
 
-  if (isLoading) return <LoadingSpinner />
+  if (isLoading) return <PageSkeleton />
   if (!approval) return <div className="text-text-muted text-center py-12">결재 항목을 찾을 수 없습니다</div>
 
   const detail = approval.detail
@@ -55,7 +55,7 @@ export default function ApprovalDetail() {
       )}
 
       {/* 전략 정보 + 백테스트 요약 */}
-      <div className="grid grid-cols-2 gap-4 mb-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
         <div className="bg-surface border border-border rounded-lg p-5">
           <h3 className="text-[15px] font-semibold mb-3">전략 정보</h3>
           <div className="space-y-2">
@@ -120,7 +120,7 @@ export default function ApprovalDetail() {
 
       {/* 차트 */}
       {detail && (
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div className="bg-surface border border-border rounded-lg p-5">
             <h3 className="text-[15px] font-semibold mb-3">자산 추이</h3>
             <div className="h-[200px] bg-bg border border-dashed border-border rounded-lg flex items-center justify-center text-text-muted text-[13px]">

--- a/frontend/src/pages/Approvals.tsx
+++ b/frontend/src/pages/Approvals.tsx
@@ -3,7 +3,7 @@ import { useApprovals } from '../hooks/useApprovals'
 import ApprovalFilters from '../components/approvals/ApprovalFilters'
 import ApprovalTable from '../components/approvals/ApprovalTable'
 import Pagination from '../components/common/Pagination'
-import LoadingSpinner from '../components/common/LoadingSpinner'
+import { TableSkeleton } from '../components/common/Skeleton'
 import type { ApprovalStatus, ApprovalType } from '../types/approval'
 
 const LIMIT = 20
@@ -25,7 +25,7 @@ export default function Approvals() {
       />
       <div className="bg-surface border border-border rounded-lg p-5">
         {isLoading ? (
-          <LoadingSpinner />
+          <TableSkeleton rows={5} cols={5} />
         ) : (
           <>
             <ApprovalTable items={data?.items ?? []} />

--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getDatasets, getStorageInfo, deleteDataset } from '../api/data'
 import { formatNumber, formatDate } from '../utils/formatters'
 import Pagination from '../components/common/Pagination'
-import LoadingSpinner from '../components/common/LoadingSpinner'
+import { TableSkeleton } from '../components/common/Skeleton'
 
 const LIMIT = 15
 const TF_OPTIONS = ['all', '1d', '1h', '1m'] as const
@@ -74,7 +74,7 @@ export default function BacktestData() {
       {/* 테이블 */}
       <div className="bg-surface border border-border rounded-lg p-5">
         {isLoading ? (
-          <LoadingSpinner />
+          <TableSkeleton rows={5} cols={6} />
         ) : (
           <>
             <div className="overflow-x-auto">

--- a/frontend/src/pages/BotDetail.tsx
+++ b/frontend/src/pages/BotDetail.tsx
@@ -1,7 +1,7 @@
 import { useParams, Link } from 'react-router-dom'
 import { useBotDetail, useBotControl } from '../hooks/useBots'
 import StatusBadge from '../components/common/StatusBadge'
-import LoadingSpinner from '../components/common/LoadingSpinner'
+import { PageSkeleton } from '../components/common/Skeleton'
 import { formatKRW, formatDateTime } from '../utils/formatters'
 import { BOT_STATUS_LABELS } from '../utils/constants'
 import type { BotStatus } from '../types/bot'
@@ -15,7 +15,7 @@ export default function BotDetail() {
   const { data: bot, isLoading } = useBotDetail(id!)
   const { start, stop } = useBotControl()
 
-  if (isLoading) return <LoadingSpinner />
+  if (isLoading) return <PageSkeleton />
   if (!bot) return <div className="text-text-muted text-center py-12">봇을 찾을 수 없습니다</div>
 
   const canStart = bot.status === 'stopped' || bot.status === 'created'

--- a/frontend/src/pages/Bots.tsx
+++ b/frontend/src/pages/Bots.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useBots, useBotControl } from '../hooks/useBots'
 import BotTable from '../components/bots/BotTable'
 import BotCreateForm from '../components/bots/BotCreateForm'
-import LoadingSpinner from '../components/common/LoadingSpinner'
+import { TableSkeleton } from '../components/common/Skeleton'
 import type { BotStatus } from '../types/bot'
 
 const STATUS_FILTERS: { key: BotStatus | 'all'; label: string }[] = [
@@ -48,7 +48,7 @@ export default function Bots() {
 
       <div className="bg-surface border border-border rounded-lg p-5">
         {isLoading ? (
-          <LoadingSpinner />
+          <TableSkeleton rows={5} cols={4} />
         ) : (
           <BotTable
             items={items}

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,0 +1,21 @@
+import { Link } from 'react-router-dom'
+
+export default function NotFound() {
+  return (
+    <div className="flex items-center justify-center min-h-[calc(100vh-var(--spacing-header)-48px)]">
+      <div className="text-center">
+        <div className="text-[64px] font-bold text-text-muted mb-2">404</div>
+        <h1 className="text-[18px] font-semibold mb-2">페이지를 찾을 수 없습니다</h1>
+        <p className="text-text-muted text-[14px] mb-6">
+          요청하신 페이지가 존재하지 않거나 이동되었습니다.
+        </p>
+        <Link
+          to="/"
+          className="inline-block px-4 py-2 bg-primary text-white rounded-lg no-underline text-[14px] hover:bg-primary-hover"
+        >
+          대시보드로 돌아가기
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useSystemStatus, useKillSwitch, useConfigs, useUpdateConfig } from '../hooks/useSystemStatus'
-import LoadingSpinner from '../components/common/LoadingSpinner'
+import { PageSkeleton, TableSkeleton } from '../components/common/Skeleton'
 
 function formatUptime(seconds: number): string {
   const d = Math.floor(seconds / 86400)
@@ -26,7 +26,7 @@ export default function Settings() {
   const [editValue, setEditValue] = useState('')
   const [showKillConfirm, setShowKillConfirm] = useState(false)
 
-  if (statusLoading) return <LoadingSpinner />
+  if (statusLoading) return <PageSkeleton />
 
   const isActive = status?.trading_status === 'ACTIVE'
 
@@ -56,7 +56,7 @@ export default function Settings() {
   }
 
   return (
-    <div className="grid grid-cols-2 gap-6">
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
       {/* 좌측 — 시스템 상태 */}
       <div className="space-y-6">
         <div className="bg-surface border border-border rounded-lg p-5">
@@ -113,11 +113,11 @@ export default function Settings() {
       </div>
 
       {/* 하단 — 거래 설정 (전체 폭) */}
-      <div className="col-span-2">
+      <div className="col-span-1 md:col-span-2">
         <div className="bg-surface border border-border rounded-lg p-5">
           <h3 className="text-[15px] font-semibold mb-4">거래 설정</h3>
           {configLoading ? (
-            <LoadingSpinner />
+            <TableSkeleton rows={3} cols={2} />
           ) : (
             <div className="space-y-0">
               {(configs ?? []).map((cfg) => (

--- a/frontend/src/pages/Strategies.tsx
+++ b/frontend/src/pages/Strategies.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useStrategies } from '../hooks/useStrategies'
 import StrategyTable from '../components/strategies/StrategyTable'
-import LoadingSpinner from '../components/common/LoadingSpinner'
+import { TableSkeleton } from '../components/common/Skeleton'
 import type { StrategyStatus } from '../types/strategy'
 
 const STATUS_FILTERS: { key: StrategyStatus | 'all'; label: string }[] = [
@@ -35,7 +35,7 @@ export default function Strategies() {
         ))}
       </div>
       <div className="bg-surface border border-border rounded-lg p-5">
-        {isLoading ? <LoadingSpinner /> : <StrategyTable items={filtered} />}
+        {isLoading ? <TableSkeleton rows={5} cols={5} /> : <StrategyTable items={filtered} />}
       </div>
     </>
   )

--- a/frontend/src/pages/StrategyDetail.tsx
+++ b/frontend/src/pages/StrategyDetail.tsx
@@ -3,7 +3,7 @@ import { useParams, Link } from 'react-router-dom'
 import { useStrategyDetail, useStrategyPerformance, useStrategyTrades } from '../hooks/useStrategies'
 import PerformancePanel from '../components/strategies/PerformancePanel'
 import StatusBadge from '../components/common/StatusBadge'
-import LoadingSpinner from '../components/common/LoadingSpinner'
+import { PageSkeleton } from '../components/common/Skeleton'
 import { formatKRW, formatDateTime } from '../utils/formatters'
 import { STRATEGY_STATUS_LABELS } from '../utils/constants'
 import type { StrategyStatus } from '../types/strategy'
@@ -23,7 +23,7 @@ export default function StrategyDetail() {
   const { data: performance } = useStrategyPerformance(numId)
   const { data: tradesData } = useStrategyTrades(numId)
 
-  if (isLoading) return <LoadingSpinner />
+  if (isLoading) return <PageSkeleton />
   if (!strategy) return <div className="text-text-muted text-center py-12">전략을 찾을 수 없습니다</div>
 
   return (

--- a/frontend/src/pages/Treasury.tsx
+++ b/frontend/src/pages/Treasury.tsx
@@ -3,13 +3,13 @@ import { useTreasurySummary, useBotBudgets } from '../hooks/useTreasury'
 import AccountSummary from '../components/treasury/AccountSummary'
 import BudgetTable from '../components/treasury/BudgetTable'
 import AllocationForm from '../components/treasury/AllocationForm'
-import LoadingSpinner from '../components/common/LoadingSpinner'
+import { PageSkeleton } from '../components/common/Skeleton'
 
 export default function Treasury() {
   const { data: summary, isLoading: summaryLoading } = useTreasurySummary()
   const { data: budgets, isLoading: budgetsLoading } = useBotBudgets()
 
-  if (summaryLoading || budgetsLoading) return <LoadingSpinner />
+  if (summaryLoading || budgetsLoading) return <PageSkeleton />
 
   const botIds = (budgets ?? []).map((b) => b.bot_id)
 

--- a/frontend/src/pages/TreasuryHistory.tsx
+++ b/frontend/src/pages/TreasuryHistory.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useTreasuryHistory } from '../hooks/useTreasury'
 import { formatKRW, formatDateTime } from '../utils/formatters'
 import Pagination from '../components/common/Pagination'
-import LoadingSpinner from '../components/common/LoadingSpinner'
+import { TableSkeleton } from '../components/common/Skeleton'
 
 const LIMIT = 20
 
@@ -14,7 +14,7 @@ export default function TreasuryHistory() {
     <div className="bg-surface border border-border rounded-lg p-5">
       <h3 className="text-[15px] font-semibold mb-4">자금 거래 이력</h3>
       {isLoading ? (
-        <LoadingSpinner />
+        <TableSkeleton rows={5} cols={5} />
       ) : (
         <>
           <div className="overflow-x-auto">

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,4 +12,18 @@ export default defineConfig({
       },
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          react: ['react', 'react-dom'],
+          router: ['react-router-dom'],
+          query: ['@tanstack/react-query'],
+        },
+      },
+    },
+    target: 'es2020',
+    sourcemap: false,
+    chunkSizeWarningLimit: 500,
+  },
 })

--- a/src/ante/web/app.py
+++ b/src/ante/web/app.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+import logging
+from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+
+logger = logging.getLogger(__name__)
+
+# frontend/dist/ 위치: 프로젝트 루트 기준
+_FRONTEND_DIR = Path(__file__).resolve().parents[3] / "frontend" / "dist"
 
 
 def create_app(**services: Any) -> FastAPI:
@@ -70,4 +78,55 @@ def create_app(**services: Any) -> FastAPI:
 
     register_exception_handlers(app)
 
+    # 프론트엔드 정적 파일 서빙 (빌드 결과물이 존재할 때만)
+    _mount_frontend(app)
+
     return app
+
+
+def _mount_frontend(app: FastAPI) -> None:
+    """frontend/dist/ 정적 파일 서빙 + SPA fallback 설정."""
+    frontend_dir = _FRONTEND_DIR
+    index_html = frontend_dir / "index.html"
+
+    if not frontend_dir.is_dir() or not index_html.is_file():
+        logger.info("프론트엔드 빌드 없음 (%s) — 정적 파일 서빙 비활성화", frontend_dir)
+        return
+
+    logger.info("프론트엔드 정적 파일 서빙: %s", frontend_dir)
+
+    # /assets/* 빌드 산출물 서빙 (Vite 번들)
+    assets_dir = frontend_dir / "assets"
+    if assets_dir.is_dir():
+        app.mount(
+            "/assets",
+            StaticFiles(directory=str(assets_dir)),
+            name="frontend-assets",
+        )
+
+    # SPA fallback middleware: /api 외 404 → index.html
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.requests import Request as StarletteRequest
+    from starlette.responses import Response
+
+    class SPAFallbackMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request: StarletteRequest, call_next: Any) -> Response:
+            response = await call_next(request)
+            path = request.url.path
+
+            # API 경로는 그대로 반환
+            if path.startswith("/api"):
+                return response
+
+            # 404인 비-API 요청: 정적 파일이 있으면 반환, 없으면 index.html
+            if response.status_code == 404:
+                file_path = frontend_dir / path.lstrip("/")
+                if file_path.is_file():
+                    from fastapi.responses import FileResponse
+
+                    return FileResponse(str(file_path))
+                return FileResponse(str(index_html))
+
+            return response
+
+    app.add_middleware(SPAFallbackMiddleware)


### PR DESCRIPTION
## Summary

- **에러 핸들링**: 전역 ErrorBoundary, API 에러 토스트 (RFC 7807 detail), 404 페이지, 503 상태 컴포넌트
- **로딩 상태 통일**: LoadingSpinner → Skeleton UI (TableSkeleton, ChartSkeleton, PageSkeleton) 전면 교체
- **반응형 디자인**: 모바일 햄버거 메뉴 (md 브레이크포인트), 2열 그리드 → 1열 반응형, 헤더 컴팩트화
- **빌드 + 서빙**: Vite 코드 스플리팅 (react/router/query 분리), FastAPI SPA fallback middleware

## 변경 파일

| 영역 | 파일 | 내용 |
|------|------|------|
| 에러 | `ErrorBoundary.tsx`, `Toast.tsx`, `NotFound.tsx`, `ServiceUnavailable.tsx` | 신규 컴포넌트 |
| 에러 | `api/client.ts` | RFC 7807 detail 토스트 표시 |
| 로딩 | `Skeleton.tsx` | Table/Chart/Card/Page 스켈레톤 |
| 로딩 | 12개 페이지 | LoadingSpinner → Skeleton 교체 |
| 반응형 | `Sidebar.tsx` | 모바일 햄버거 메뉴 + 오버레이 |
| 반응형 | `Layout.tsx`, `Header.tsx` | 반응형 마진/패딩 |
| 반응형 | `ApprovalDetail.tsx`, `Settings.tsx` | 2열 → 1열 반응형 그리드 |
| 빌드 | `vite.config.ts` | manualChunks 코드 스플리팅 |
| 서빙 | `src/ante/web/app.py` | SPA fallback middleware + /assets 정적 파일 |

## Test plan

- [x] TypeScript 타입 체크 통과
- [x] ruff lint + format 통과
- [x] pytest 전체 1271 passed, 0 failed
- [ ] CI 통과 확인

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)