### PR TITLE
feat(broker): Mock Broker Adapter 구현

### DIFF
--- a/src/ante/broker/__init__.py
+++ b/src/ante/broker/__init__.py
@@ -12,6 +12,7 @@ from ante.broker.exceptions import (
 )
 from ante.broker.kis import KISAdapter
 from ante.broker.kis_stream import KISStreamClient
+from ante.broker.mock import MockBrokerAdapter
 from ante.broker.models import CommissionInfo
 from ante.broker.order_registry import OrderRegistry
 
@@ -23,6 +24,7 @@ __all__ = [
     "CommissionInfo",
     "KISAdapter",
     "KISStreamClient",
+    "MockBrokerAdapter",
     "OrderRegistry",
     "BrokerError",
     "AuthenticationError",

--- a/src/ante/broker/mock.py
+++ b/src/ante/broker/mock.py
@@ -1,0 +1,358 @@
+"""Mock Broker Adapter — E2E 테스트용 가상 브로커.
+
+외부 API 없이 주문 → 체결 → 잔고 변동 흐름을 시뮬레이션한다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+from ante.broker.base import BrokerAdapter
+from ante.broker.exceptions import BrokerError, OrderNotFoundError
+from ante.broker.models import CommissionInfo
+
+logger = logging.getLogger(__name__)
+
+
+# ── 시뮬레이션 모드 ─────────────────────────────────────
+
+
+class FillMode(StrEnum):
+    """체결 시뮬레이션 모드."""
+
+    IMMEDIATE = "immediate"  # 즉시 전량 체결
+    PARTIAL = "partial"  # 부분 체결
+    DELAYED = "delayed"  # 지연 체결
+    REJECT = "reject"  # 주문 거부
+
+
+@dataclass
+class MockPosition:
+    """메모리 기반 가상 포지션."""
+
+    symbol: str
+    quantity: float
+    avg_price: float
+
+
+@dataclass
+class MockOrder:
+    """Mock 주문 기록."""
+
+    order_id: str
+    symbol: str
+    side: str
+    quantity: float
+    filled_quantity: float
+    price: float
+    order_type: str
+    status: str  # "pending" | "filled" | "partially_filled" | "cancelled" | "rejected"
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+class MockBrokerAdapter(BrokerAdapter):
+    """E2E 테스트용 가상 브로커 어댑터.
+
+    설정 옵션:
+        fill_mode: "immediate" | "partial" | "delayed" | "reject"
+        partial_fill_ratio: 부분 체결 비율 (0.0~1.0, 기본 0.5)
+        delay_seconds: 지연 체결 시 대기 시간 (기본 0.1)
+        initial_cash: 초기 현금 (기본 100_000_000)
+        default_price: 종목 기본 현재가 (기본 50_000)
+        prices: 종목별 현재가 딕셔너리 (예: {"005930": 70000})
+    """
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        config.setdefault("exchange", "KRX")
+        super().__init__(config)
+
+        self._fill_mode = FillMode(config.get("fill_mode", "immediate"))
+        self._partial_fill_ratio: float = config.get("partial_fill_ratio", 0.5)
+        self._delay_seconds: float = config.get("delay_seconds", 0.1)
+
+        # 가상 잔고
+        self._cash: float = config.get("initial_cash", 100_000_000.0)
+        self._positions: dict[str, MockPosition] = {}
+        self._orders: dict[str, MockOrder] = {}
+
+        # 종목별 현재가
+        self._prices: dict[str, float] = config.get("prices", {})
+        self._default_price: float = config.get("default_price", 50_000.0)
+
+        self._commission = CommissionInfo(
+            commission_rate=config.get("commission_rate", 0.00015),
+            sell_tax_rate=config.get("sell_tax_rate", 0.0023),
+        )
+
+    # ── 연결 ──────────────────────────────────────────
+
+    async def connect(self) -> None:
+        """Mock 연결 (항상 성공)."""
+        self.is_connected = True
+        logger.info("Mock Broker 연결됨")
+
+    async def disconnect(self) -> None:
+        """Mock 연결 해제."""
+        self.is_connected = False
+        logger.info("Mock Broker 연결 해제")
+
+    # ── 조회 ──────────────────────────────────────────
+
+    async def get_account_balance(self) -> dict[str, float]:
+        """가상 계좌 잔고 조회."""
+        total_stock_value = sum(
+            pos.quantity * self._get_price(pos.symbol)
+            for pos in self._positions.values()
+        )
+        return {
+            "cash": self._cash,
+            "total_assets": self._cash + total_stock_value,
+            "stock_value": total_stock_value,
+        }
+
+    async def get_positions(self) -> list[dict[str, Any]]:
+        """보유 포지션 조회."""
+        return [
+            {
+                "symbol": pos.symbol,
+                "quantity": pos.quantity,
+                "avg_price": pos.avg_price,
+                "current_price": self._get_price(pos.symbol),
+                "pnl": (self._get_price(pos.symbol) - pos.avg_price) * pos.quantity,
+            }
+            for pos in self._positions.values()
+            if pos.quantity > 0
+        ]
+
+    async def get_current_price(self, symbol: str) -> float:
+        """현재가 조회."""
+        return self._get_price(symbol)
+
+    # ── 주문 ──────────────────────────────────────────
+
+    async def place_order(
+        self,
+        symbol: str,
+        side: str,
+        quantity: float,
+        order_type: str = "market",
+        price: float | None = None,
+        stop_price: float | None = None,
+    ) -> str:
+        """주문 접수 및 시뮬레이션 체결."""
+        if self._fill_mode == FillMode.REJECT:
+            msg = f"Mock 주문 거부: {symbol} {side} {quantity}"
+            raise BrokerError(msg)
+
+        order_id = str(uuid.uuid4())[:8]
+        exec_price = price if price is not None else self._get_price(symbol)
+
+        order = MockOrder(
+            order_id=order_id,
+            symbol=symbol,
+            side=side,
+            quantity=quantity,
+            filled_quantity=0.0,
+            price=exec_price,
+            order_type=order_type,
+            status="pending",
+        )
+        self._orders[order_id] = order
+
+        if self._fill_mode == FillMode.DELAYED:
+            await asyncio.sleep(self._delay_seconds)
+
+        fill_qty = self._calculate_fill_quantity(quantity)
+        self._execute_fill(order, fill_qty, exec_price)
+
+        logger.info(
+            "Mock 주문 체결: %s %s %s qty=%.1f filled=%.1f @ %.0f",
+            order_id,
+            side,
+            symbol,
+            quantity,
+            fill_qty,
+            exec_price,
+        )
+        return order_id
+
+    async def cancel_order(self, order_id: str) -> bool:
+        """주문 취소."""
+        order = self._orders.get(order_id)
+        if order is None:
+            raise OrderNotFoundError(f"주문을 찾을 수 없음: {order_id}")
+        if order.status in ("filled", "cancelled", "rejected"):
+            return False
+        order.status = "cancelled"
+        return True
+
+    async def get_order_status(self, order_id: str) -> dict[str, Any]:
+        """주문 상태 조회."""
+        order = self._orders.get(order_id)
+        if order is None:
+            raise OrderNotFoundError(f"주문을 찾을 수 없음: {order_id}")
+        return {
+            "order_id": order.order_id,
+            "symbol": order.symbol,
+            "side": order.side,
+            "quantity": order.quantity,
+            "filled_quantity": order.filled_quantity,
+            "price": order.price,
+            "order_type": order.order_type,
+            "status": order.status,
+            "created_at": order.created_at.isoformat(),
+        }
+
+    async def get_pending_orders(self) -> list[dict[str, Any]]:
+        """미체결 주문 목록."""
+        results = []
+        for order in self._orders.values():
+            if order.status in ("pending", "partially_filled"):
+                results.append(await self.get_order_status(order.order_id))
+        return results
+
+    # ── 실시간 스트리밍 (stub) ────────────────────────
+
+    async def realtime_price_stream(
+        self, symbols: list[str]
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Mock 실시간 가격 스트리밍 (단일 스냅샷 후 종료)."""
+        for symbol in symbols:
+            yield {
+                "symbol": symbol,
+                "price": self._get_price(symbol),
+                "timestamp": datetime.now(UTC).isoformat(),
+            }
+
+    async def realtime_order_stream(self) -> AsyncIterator[dict[str, Any]]:
+        """Mock 실시간 주문 체결 스트리밍 (체결된 주문 반환 후 종료)."""
+        for order in self._orders.values():
+            if order.status in ("filled", "partially_filled"):
+                yield await self.get_order_status(order.order_id)
+
+    # ── 대사(Reconciliation) 조회 ─────────────────────
+
+    async def get_account_positions(self) -> list[dict[str, Any]]:
+        """증권사 실제 보유 잔고 (대사용)."""
+        return await self.get_positions()
+
+    async def get_order_history(
+        self,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """주문/체결 이력 조회."""
+        results = []
+        for order in self._orders.values():
+            results.append(
+                {
+                    "order_id": order.order_id,
+                    "symbol": order.symbol,
+                    "side": order.side,
+                    "quantity": order.quantity,
+                    "filled_quantity": order.filled_quantity,
+                    "price": order.price,
+                    "status": order.status,
+                    "timestamp": order.created_at.isoformat(),
+                }
+            )
+        return results
+
+    # ── 종목 마스터 ───────────────────────────────────
+
+    async def get_instruments(self, exchange: str = "KRX") -> list[dict[str, Any]]:
+        """Mock 종목 마스터."""
+        return [
+            {
+                "symbol": "005930",
+                "name": "삼성전자",
+                "name_en": "Samsung Electronics",
+                "instrument_type": "stock",
+                "listed": True,
+            },
+            {
+                "symbol": "000660",
+                "name": "SK하이닉스",
+                "name_en": "SK Hynix",
+                "instrument_type": "stock",
+                "listed": True,
+            },
+        ]
+
+    # ── 수수료 ────────────────────────────────────────
+
+    def get_commission_info(self) -> CommissionInfo:
+        """수수료율 정보."""
+        return self._commission
+
+    # ── 내부 헬퍼 ─────────────────────────────────────
+
+    def _get_price(self, symbol: str) -> float:
+        """종목 현재가 반환."""
+        return self._prices.get(symbol, self._default_price)
+
+    def set_price(self, symbol: str, price: float) -> None:
+        """테스트용: 종목 현재가 설정."""
+        self._prices[symbol] = price
+
+    def set_fill_mode(self, mode: FillMode) -> None:
+        """테스트용: 체결 모드 변경."""
+        self._fill_mode = mode
+
+    def _calculate_fill_quantity(self, quantity: float) -> float:
+        """체결 모드에 따른 체결 수량 계산."""
+        if self._fill_mode == FillMode.PARTIAL:
+            return quantity * self._partial_fill_ratio
+        return quantity  # IMMEDIATE, DELAYED
+
+    def _execute_fill(
+        self, order: MockOrder, fill_qty: float, exec_price: float
+    ) -> None:
+        """체결 처리: 잔고 및 포지션 업데이트."""
+        order.filled_quantity = fill_qty
+        filled_value = fill_qty * exec_price
+        commission = self._commission.calculate(order.side, filled_value)
+
+        if order.side == "buy":
+            self._cash -= filled_value + commission
+            self._update_position_buy(order.symbol, fill_qty, exec_price)
+        else:  # sell
+            self._cash += filled_value - commission
+            self._update_position_sell(order.symbol, fill_qty)
+
+        if fill_qty >= order.quantity:
+            order.status = "filled"
+        else:
+            order.status = "partially_filled"
+
+    def _update_position_buy(self, symbol: str, quantity: float, price: float) -> None:
+        """매수 시 포지션 업데이트."""
+        pos = self._positions.get(symbol)
+        if pos is None:
+            self._positions[symbol] = MockPosition(
+                symbol=symbol, quantity=quantity, avg_price=price
+            )
+        else:
+            total_qty = pos.quantity + quantity
+            pos.avg_price = (
+                pos.avg_price * pos.quantity + price * quantity
+            ) / total_qty
+            pos.quantity = total_qty
+
+    def _update_position_sell(self, symbol: str, quantity: float) -> None:
+        """매도 시 포지션 업데이트."""
+        pos = self._positions.get(symbol)
+        if pos is None:
+            msg = f"매도할 포지션 없음: {symbol}"
+            raise BrokerError(msg)
+        if pos.quantity < quantity:
+            msg = f"보유 수량 부족: {symbol} (보유: {pos.quantity}, 매도: {quantity})"
+            raise BrokerError(msg)
+        pos.quantity -= quantity

--- a/src/ante/cli/commands/broker.py
+++ b/src/ante/cli/commands/broker.py
@@ -34,6 +34,12 @@ async def _create_broker():  # noqa: ANN202
         adapter = KISAdapter(broker_config)
         await adapter.connect()
         return adapter
+    elif broker_type == "mock":
+        from ante.broker.mock import MockBrokerAdapter
+
+        adapter = MockBrokerAdapter(broker_config)
+        await adapter.connect()
+        return adapter
     else:
         msg = f"지원하지 않는 브로커: {broker_type}"
         raise ValueError(msg)

--- a/tests/unit/test_mock_broker.py
+++ b/tests/unit/test_mock_broker.py
@@ -1,0 +1,322 @@
+"""MockBrokerAdapter 단위 테스트."""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.broker.exceptions import BrokerError, OrderNotFoundError
+from ante.broker.mock import FillMode, MockBrokerAdapter
+
+
+@pytest.fixture
+def broker() -> MockBrokerAdapter:
+    """기본 설정의 MockBrokerAdapter."""
+    return MockBrokerAdapter({"initial_cash": 10_000_000, "default_price": 50_000})
+
+
+@pytest.fixture
+def partial_broker() -> MockBrokerAdapter:
+    """부분 체결 모드 브로커."""
+    return MockBrokerAdapter(
+        {
+            "fill_mode": "partial",
+            "partial_fill_ratio": 0.5,
+            "initial_cash": 10_000_000,
+            "default_price": 50_000,
+        }
+    )
+
+
+@pytest.fixture
+def delayed_broker() -> MockBrokerAdapter:
+    """지연 체결 모드 브로커."""
+    return MockBrokerAdapter(
+        {
+            "fill_mode": "delayed",
+            "delay_seconds": 0.01,
+            "initial_cash": 10_000_000,
+            "default_price": 50_000,
+        }
+    )
+
+
+@pytest.fixture
+def reject_broker() -> MockBrokerAdapter:
+    """주문 거부 모드 브로커."""
+    return MockBrokerAdapter({"fill_mode": "reject"})
+
+
+# ── 연결 ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_connect_disconnect(broker: MockBrokerAdapter) -> None:
+    """connect/disconnect 시 is_connected 상태가 변경된다."""
+    assert not broker.is_connected
+    await broker.connect()
+    assert broker.is_connected
+    await broker.disconnect()
+    assert not broker.is_connected
+
+
+# ── 즉시 체결 (IMMEDIATE) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_immediate_buy_order(broker: MockBrokerAdapter) -> None:
+    """즉시 체결 모드에서 매수 주문이 전량 체결된다."""
+    order_id = await broker.place_order("005930", "buy", 10)
+
+    status = await broker.get_order_status(order_id)
+    assert status["status"] == "filled"
+    assert status["filled_quantity"] == 10
+    assert status["symbol"] == "005930"
+    assert status["side"] == "buy"
+
+
+@pytest.mark.asyncio
+async def test_immediate_buy_updates_balance(broker: MockBrokerAdapter) -> None:
+    """매수 후 현금이 감소하고 포지션이 생성된다."""
+    initial_balance = await broker.get_account_balance()
+    initial_cash = initial_balance["cash"]
+
+    await broker.place_order("005930", "buy", 10)
+
+    balance = await broker.get_account_balance()
+    assert balance["cash"] < initial_cash
+
+    positions = await broker.get_positions()
+    assert len(positions) == 1
+    assert positions[0]["symbol"] == "005930"
+    assert positions[0]["quantity"] == 10
+
+
+@pytest.mark.asyncio
+async def test_immediate_sell_order(broker: MockBrokerAdapter) -> None:
+    """매수 후 매도 시 포지션이 감소하고 현금이 증가한다."""
+    await broker.place_order("005930", "buy", 10)
+    cash_after_buy = (await broker.get_account_balance())["cash"]
+
+    await broker.place_order("005930", "sell", 5)
+
+    balance = await broker.get_account_balance()
+    assert balance["cash"] > cash_after_buy
+
+    positions = await broker.get_positions()
+    assert positions[0]["quantity"] == 5
+
+
+@pytest.mark.asyncio
+async def test_sell_without_position_raises(broker: MockBrokerAdapter) -> None:
+    """포지션 없이 매도 시 BrokerError가 발생한다."""
+    with pytest.raises(BrokerError, match="매도할 포지션 없음"):
+        await broker.place_order("005930", "sell", 10)
+
+
+@pytest.mark.asyncio
+async def test_sell_exceeding_quantity_raises(broker: MockBrokerAdapter) -> None:
+    """보유 수량 초과 매도 시 BrokerError가 발생한다."""
+    await broker.place_order("005930", "buy", 5)
+    with pytest.raises(BrokerError, match="보유 수량 부족"):
+        await broker.place_order("005930", "sell", 10)
+
+
+# ── 부분 체결 (PARTIAL) ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_partial_fill(partial_broker: MockBrokerAdapter) -> None:
+    """부분 체결 모드에서 설정 비율만큼만 체결된다."""
+    order_id = await partial_broker.place_order("005930", "buy", 10)
+
+    status = await partial_broker.get_order_status(order_id)
+    assert status["status"] == "partially_filled"
+    assert status["filled_quantity"] == 5.0  # 10 * 0.5
+
+
+@pytest.mark.asyncio
+async def test_partial_fill_position(partial_broker: MockBrokerAdapter) -> None:
+    """부분 체결 시 체결된 수량만 포지션에 반영된다."""
+    await partial_broker.place_order("005930", "buy", 10)
+
+    positions = await partial_broker.get_positions()
+    assert positions[0]["quantity"] == 5.0
+
+
+# ── 지연 체결 (DELAYED) ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delayed_fill(delayed_broker: MockBrokerAdapter) -> None:
+    """지연 체결 모드에서도 최종적으로 전량 체결된다."""
+    order_id = await delayed_broker.place_order("005930", "buy", 10)
+
+    status = await delayed_broker.get_order_status(order_id)
+    assert status["status"] == "filled"
+    assert status["filled_quantity"] == 10
+
+
+# ── 주문 거부 (REJECT) ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reject_mode(reject_broker: MockBrokerAdapter) -> None:
+    """주문 거부 모드에서 BrokerError가 발생한다."""
+    with pytest.raises(BrokerError, match="Mock 주문 거부"):
+        await reject_broker.place_order("005930", "buy", 10)
+
+
+# ── 주문 관리 ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_order(partial_broker: MockBrokerAdapter) -> None:
+    """부분 체결된 주문을 취소할 수 있다."""
+    order_id = await partial_broker.place_order("005930", "buy", 10)
+
+    result = await partial_broker.cancel_order(order_id)
+    assert result is True
+
+    status = await partial_broker.get_order_status(order_id)
+    assert status["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_cancel_filled_order_returns_false(broker: MockBrokerAdapter) -> None:
+    """이미 체결된 주문 취소 시 False를 반환한다."""
+    order_id = await broker.place_order("005930", "buy", 10)
+
+    result = await broker.cancel_order(order_id)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_nonexistent_order_raises(broker: MockBrokerAdapter) -> None:
+    """존재하지 않는 주문 취소 시 OrderNotFoundError가 발생한다."""
+    with pytest.raises(OrderNotFoundError):
+        await broker.cancel_order("nonexistent")
+
+
+@pytest.mark.asyncio
+async def test_get_pending_orders(partial_broker: MockBrokerAdapter) -> None:
+    """미체결 주문 목록을 조회할 수 있다."""
+    await partial_broker.place_order("005930", "buy", 10)
+    await partial_broker.place_order("000660", "buy", 5)
+
+    pending = await partial_broker.get_pending_orders()
+    assert len(pending) == 2
+
+
+# ── 잔고 조회 ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_initial_balance(broker: MockBrokerAdapter) -> None:
+    """초기 잔고가 설정 값과 일치한다."""
+    balance = await broker.get_account_balance()
+    assert balance["cash"] == 10_000_000
+    assert balance["total_assets"] == 10_000_000
+    assert balance["stock_value"] == 0
+
+
+@pytest.mark.asyncio
+async def test_balance_after_trades(broker: MockBrokerAdapter) -> None:
+    """매매 후 total_assets가 수수료만큼 감소한다."""
+    initial = await broker.get_account_balance()
+
+    await broker.place_order("005930", "buy", 10)
+    after = await broker.get_account_balance()
+
+    # stock_value = 10 * 50000 = 500000
+    assert after["stock_value"] == 500_000
+    # total_assets는 수수료만큼 초기보다 감소
+    assert after["total_assets"] < initial["total_assets"]
+
+
+# ── 가격 설정 ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_custom_price(broker: MockBrokerAdapter) -> None:
+    """종목별 현재가를 설정할 수 있다."""
+    broker.set_price("005930", 70_000)
+    price = await broker.get_current_price("005930")
+    assert price == 70_000
+
+
+@pytest.mark.asyncio
+async def test_default_price() -> None:
+    """prices 딕셔너리에 없는 종목은 default_price를 반환한다."""
+    b = MockBrokerAdapter({"default_price": 30_000})
+    assert await b.get_current_price("999999") == 30_000
+
+
+# ── 체결 모드 동적 변경 ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_set_fill_mode(broker: MockBrokerAdapter) -> None:
+    """테스트 중 체결 모드를 동적으로 변경할 수 있다."""
+    broker.set_fill_mode(FillMode.PARTIAL)
+    order_id = await broker.place_order("005930", "buy", 10)
+    status = await broker.get_order_status(order_id)
+    assert status["status"] == "partially_filled"
+
+
+# ── 기타 조회 ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_instruments(broker: MockBrokerAdapter) -> None:
+    """종목 마스터 데이터를 반환한다."""
+    instruments = await broker.get_instruments()
+    assert len(instruments) >= 1
+    assert instruments[0]["symbol"] == "005930"
+
+
+@pytest.mark.asyncio
+async def test_get_commission_info(broker: MockBrokerAdapter) -> None:
+    """수수료 정보를 반환한다."""
+    info = broker.get_commission_info()
+    assert info.commission_rate == 0.00015
+    assert info.sell_tax_rate == 0.0023
+
+
+@pytest.mark.asyncio
+async def test_order_history(broker: MockBrokerAdapter) -> None:
+    """주문 이력을 조회할 수 있다."""
+    await broker.place_order("005930", "buy", 10)
+    await broker.place_order("000660", "buy", 5)
+
+    history = await broker.get_order_history()
+    assert len(history) == 2
+
+
+@pytest.mark.asyncio
+async def test_health_check(broker: MockBrokerAdapter) -> None:
+    """health_check가 True를 반환한다."""
+    assert await broker.health_check() is True
+
+
+@pytest.mark.asyncio
+async def test_realtime_price_stream(broker: MockBrokerAdapter) -> None:
+    """실시간 가격 스트리밍이 종목 데이터를 반환한다."""
+    items = []
+    async for item in broker.realtime_price_stream(["005930", "000660"]):
+        items.append(item)
+    assert len(items) == 2
+    assert items[0]["symbol"] == "005930"
+
+
+@pytest.mark.asyncio
+async def test_multiple_buys_avg_price(broker: MockBrokerAdapter) -> None:
+    """동일 종목 추가 매수 시 평균단가가 올바르게 계산된다."""
+    broker.set_price("005930", 50_000)
+    await broker.place_order("005930", "buy", 10, price=50_000)
+
+    broker.set_price("005930", 60_000)
+    await broker.place_order("005930", "buy", 10, price=60_000)
+
+    positions = await broker.get_positions()
+    assert positions[0]["quantity"] == 20
+    assert positions[0]["avg_price"] == 55_000  # (50000*10 + 60000*10) / 20


### PR DESCRIPTION
## Summary
- E2E 테스트용 `MockBrokerAdapter` 구현 (`src/ante/broker/mock.py`)
- 4가지 체결 모드 지원: 즉시(immediate), 부분(partial), 지연(delayed), 거부(reject)
- 메모리 기반 가상 잔고/포지션 관리, 수수료 계산 포함
- Config에서 `broker.type = "mock"` 설정으로 Mock Broker 로드 지원
- 25개 단위 테스트 작성 (전체 1296개 테스트 통과)

Closes #196

## 변경 파일
| 파일 | 설명 |
|------|------|
| `src/ante/broker/mock.py` | MockBrokerAdapter 신규 생성 |
| `src/ante/broker/__init__.py` | MockBrokerAdapter export 추가 |
| `src/ante/cli/commands/broker.py` | broker type "mock" 분기 로딩 |
| `tests/unit/test_mock_broker.py` | 25개 단위 테스트 |

## 유저스토리 체크리스트
- [x] `broker.type = "mock"` 설정으로 Mock Broker 로드
- [x] 주문 요청 시 즉시 체결 응답 반환
- [x] 부분 체결, 지연 체결, 주문 실패 시뮬레이션
- [x] 잔고 조회 시 메모리 기반 가상 잔고 반환

## Test plan
- [x] 즉시 체결 매수/매도 테스트
- [x] 부분 체결 수량 및 포지션 검증
- [x] 지연 체결 동작 확인
- [x] 주문 거부 모드 BrokerError 발생 확인
- [x] 잔고/포지션/주문 관리 통합 검증
- [x] 전체 테스트 스위트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)