### PR TITLE
feat(e2e): docker-compose.test.yml E2E 테스트 환경

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,45 @@
+# E2E 테스트 전용 Dockerfile
+# 프로덕션 Dockerfile과 달리 테스트 코드 + 시드 데이터를 포함한다.
+
+# Stage 1: 프론트엔드 빌드
+FROM node:20-alpine AS frontend-build
+WORKDIR /build
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ ./
+RUN npm run build
+
+# Stage 2: Python 런타임 (테스트용)
+FROM python:3.12-slim AS runtime
+WORKDIR /app
+
+# 시스템 의존성
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python 패키지 설치
+COPY pyproject.toml ./
+COPY src/ src/
+
+# 프론트엔드 빌드 산출물
+COPY --from=frontend-build /build/dist src/ante/web/static
+
+RUN pip install --no-cache-dir .
+
+# 테스트 코드 + 시드 데이터 (프로덕션에는 없는 부분)
+COPY tests/ tests/
+
+# 런타임 디렉토리
+RUN mkdir -p config data db
+
+# 테스트 전용 설정 파일
+COPY config/system.test.toml config/system.toml
+
+# 시드 + 시작 스크립트
+COPY scripts/e2e-entrypoint.sh /app/e2e-entrypoint.sh
+RUN chmod +x /app/e2e-entrypoint.sh
+
+EXPOSE 8000
+
+ENTRYPOINT ["/app/e2e-entrypoint.sh"]

--- a/config/system.test.toml
+++ b/config/system.test.toml
@@ -1,0 +1,31 @@
+# Ante E2E 테스트 전용 설정
+# docker-compose.test.yml에서 사용한다.
+
+[system]
+log_level = "DEBUG"
+timezone = "Asia/Seoul"
+
+[db]
+path = "db/ante.db"
+
+[data]
+path = "data/"
+
+[web]
+enabled = true
+host = "0.0.0.0"
+port = 8000
+
+[eventbus]
+history_size = 1000
+
+[broker]
+type = "mock"
+fill_mode = "immediate"
+initial_cash = 100000000.0
+default_price = 50000.0
+commission_rate = 0.00015
+sell_tax_rate = 0.0023
+
+[treasury]
+sync_interval_seconds = 60

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,33 @@
+# E2E 테스트 전용 Docker Compose
+#
+# 사용법:
+#   docker compose -f docker-compose.test.yml up --build     # 테스트 환경 기동
+#   docker compose -f docker-compose.test.yml down -v         # 완전 정리 (볼륨 포함)
+#
+# CI에서:
+#   docker compose -f docker-compose.test.yml up --build -d   # 백그라운드 기동
+#   # ... E2E 테스트 실행 ...
+#   docker compose -f docker-compose.test.yml down -v         # 정리
+
+services:
+  ante-test:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    ports:
+      - "8000:8000"
+    environment:
+      - ANTE_CONFIG_DIR=/app/config
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/system/health')"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+    volumes:
+      - e2e-data:/app/data
+      - e2e-db:/app/db
+
+volumes:
+  e2e-data:
+  e2e-db:

--- a/scripts/e2e-entrypoint.sh
+++ b/scripts/e2e-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# E2E 테스트 환경 엔트리포인트
+# 1. 시드 데이터 주입
+# 2. Ante 서버 시작
+set -e
+
+echo "[e2e] 시드 데이터 주입 시작..."
+python -c "
+import asyncio
+from tests.fixtures.seed.seeder import inject_seed_data
+result = asyncio.run(inject_seed_data('db/ante.db', 'data/'))
+print(f'[e2e] 시드 데이터 주입 완료: {result}')
+"
+
+echo "[e2e] Ante 서버 시작..."
+exec python -m ante.main

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -208,30 +208,45 @@ async def main() -> None:
     logger.info("BotManager 초기화 완료")
 
     # ── 11. Broker + APIGateway ──────────────────────
-    from ante.broker import KISAdapter
     from ante.gateway import APIGateway
 
     broker = None
     api_gateway = None
 
     broker_config = config.get("broker", {})
-    try:
-        broker_config["app_key"] = config.secret("KIS_APP_KEY")
-        broker_config["app_secret"] = config.secret("KIS_APP_SECRET")
-        broker_config["account_no"] = config.secret("KIS_ACCOUNT_NO")
-    except Exception:
-        pass  # 비밀값 없으면 브로커 미사용
+    broker_type = (
+        broker_config.get("type", "kis") if isinstance(broker_config, dict) else "kis"
+    )
 
-    if broker_config.get("app_key"):
-        broker = KISAdapter(config=broker_config, eventbus=eventbus)
+    if broker_type == "mock":
+        from ante.broker.mock import MockBrokerAdapter
+
+        broker = MockBrokerAdapter(
+            broker_config if isinstance(broker_config, dict) else {}
+        )
+        await broker.connect()
+        logger.info("MockBrokerAdapter 연결 완료")
+    else:
+        from ante.broker import KISAdapter
+
         try:
-            await broker.connect()
-            logger.info(
-                "KISAdapter 연결 완료 (paper=%s)", broker_config.get("is_paper", True)
-            )
+            broker_config["app_key"] = config.secret("KIS_APP_KEY")
+            broker_config["app_secret"] = config.secret("KIS_APP_SECRET")
+            broker_config["account_no"] = config.secret("KIS_ACCOUNT_NO")
         except Exception:
-            logger.warning("KISAdapter 연결 실패 — 브로커 없이 시작", exc_info=True)
-            broker = None
+            pass  # 비밀값 없으면 브로커 미사용
+
+        if broker_config.get("app_key"):
+            broker = KISAdapter(config=broker_config, eventbus=eventbus)
+            try:
+                await broker.connect()
+                logger.info(
+                    "KISAdapter 연결 완료 (paper=%s)",
+                    broker_config.get("is_paper", True),
+                )
+            except Exception:
+                logger.warning("KISAdapter 연결 실패 — 브로커 없이 시작", exc_info=True)
+                broker = None
 
     if broker:
         api_gateway = APIGateway(broker=broker, eventbus=eventbus)


### PR DESCRIPTION
## Summary
- E2E 테스트 전용 Docker Compose 환경 구성
- `Dockerfile.test`: 테스트 코드 + 시드 데이터 포함 이미지 (프로덕션과 분리)
- `config/system.test.toml`: Mock Broker + web enabled 테스트 설정
- `scripts/e2e-entrypoint.sh`: 시드 데이터 자동 주입 후 서버 시작
- `main.py`: `broker.type = "mock"` 설정 시 MockBrokerAdapter 자동 로딩

Closes #198

## 사용법
```bash
# 테스트 환경 기동
docker compose -f docker-compose.test.yml up --build

# 정리 (볼륨 포함)
docker compose -f docker-compose.test.yml down -v
```

## 유저스토리 체크리스트
- [x] `docker compose -f docker-compose.test.yml up`으로 테스트 환경 구성
- [x] Mock Broker + web.enabled=true + 시드 데이터 자동 적용
- [x] `docker compose down -v`로 완전 정리
- [x] CI에서도 동일한 환경으로 E2E 테스트 실행 가능

## Test plan
- [x] main.py broker type 분기 로직 기존 테스트 통과 (1271 passed)
- [ ] Docker 이미지 빌드 검증 (CI)
- [ ] 헬스체크 엔드포인트 정상 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)