### PR TITLE
fix(frontend): 전략 상세 성과 데이터 빈 상태 메시지 추가

### DIFF
--- a/frontend/src/components/strategies/PerformancePanel.tsx
+++ b/frontend/src/components/strategies/PerformancePanel.tsx
@@ -2,7 +2,20 @@ import HintTooltip from '../common/HintTooltip'
 import { formatPercent, formatNumber, formatKRW } from '../../utils/formatters'
 import type { StrategyPerformance } from '../../types/strategy'
 
-export default function PerformancePanel({ perf }: { perf: StrategyPerformance }) {
+export default function PerformancePanel({ perf }: { perf: StrategyPerformance | null | undefined }) {
+  const isEmpty = !perf || perf.total_trades === 0
+
+  if (isEmpty) {
+    return (
+      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+        <h3 className="text-[15px] font-semibold mb-4">성과 지표</h3>
+        <div className="py-8 text-center text-text-muted text-[13px]">
+          아직 성과 데이터가 없습니다
+        </div>
+      </div>
+    )
+  }
+
   const metrics = [
     { label: '총 거래 수', value: formatNumber(perf.total_trades), hint: '전체 거래 횟수' },
     { label: '승률', value: formatPercent(perf.win_rate), hint: '수익 거래 비율' },

--- a/frontend/src/pages/StrategyDetail.tsx
+++ b/frontend/src/pages/StrategyDetail.tsx
@@ -49,13 +49,19 @@ export default function StrategyDetail() {
       {/* 에쿼티 커브 */}
       <div className="bg-surface border border-border rounded-lg p-5 mb-6">
         <h3 className="text-[15px] font-semibold mb-3">자산 추이</h3>
-        <div className="h-[280px] bg-bg border border-dashed border-border rounded-lg flex items-center justify-center text-text-muted text-[13px]">
-          📈 에쿼티 커브 (TradingView Area Chart)
-        </div>
+        {!performance || performance.total_trades === 0 ? (
+          <div className="py-8 text-center text-text-muted text-[13px]">
+            아직 자산 추이 데이터가 없습니다
+          </div>
+        ) : (
+          <div className="h-[280px] bg-bg border border-dashed border-border rounded-lg flex items-center justify-center text-text-muted text-[13px]">
+            📈 에쿼티 커브 (TradingView Area Chart)
+          </div>
+        )}
       </div>
 
       {/* 성과 지표 */}
-      {performance && <PerformancePanel perf={performance} />}
+      <PerformancePanel perf={performance} />
 
       {/* 탭 */}
       <div className="flex gap-1 bg-bg rounded-lg p-0.5 mb-4 w-fit">


### PR DESCRIPTION
## Summary
- 성과 데이터가 없는 전략에서 PerformancePanel이 사라지는 대신 빈 상태 메시지 표시
- 에쿼티 커브 섹션에도 데이터 없을 때 빈 상태 안내 추가
- 기존 성과 데이터가 있는 전략은 동작 변경 없음

Closes #204

## 변경 내용
| 파일 | 변경 |
|------|------|
| `PerformancePanel.tsx` | `perf`가 null/undefined/total_trades=0일 때 "아직 성과 데이터가 없습니다" 메시지 |
| `StrategyDetail.tsx` | 에쿼티 커브 빈 상태 메시지 + PerformancePanel 항상 렌더링 |

## 수용 조건
- [x] `performance`가 null/undefined이거나 `total_trades === 0`일 때 빈 상태 메시지 표시
- [x] 에쿼티 커브 섹션에 데이터 없을 때 빈 상태 메시지 표시
- [x] 기존 성과 데이터가 있는 전략은 기존대로 동작

## Test plan
- [x] 백엔드 테스트 영향 없음 (1298 passed)
- [ ] 성과 데이터 없는 전략 페이지에서 빈 상태 메시지 확인
- [ ] 성과 데이터 있는 전략 페이지에서 기존 카드 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)