### PR TITLE
fix: 봇 관리 페이지 카드 레이아웃 및 섹션 구분

### DIFF
--- a/frontend/src/components/bots/BotCard.tsx
+++ b/frontend/src/components/bots/BotCard.tsx
@@ -1,0 +1,80 @@
+import { useNavigate } from 'react-router-dom'
+import StatusBadge from '../common/StatusBadge'
+import { BOT_STATUS_LABELS } from '../../utils/constants'
+import type { Bot, BotStatus } from '../../types/bot'
+
+const STATUS_VARIANT: Record<BotStatus, string> = {
+  created: 'muted', running: 'positive', stopping: 'warning', stopped: 'muted', error: 'negative', deleted: 'muted',
+}
+
+interface BotCardProps {
+  bot: Bot
+  onStart: (id: string) => void
+  onStop: (id: string) => void
+  onDelete: (id: string) => void
+}
+
+function BotIcon({ status }: { status: BotStatus }) {
+  const bgClass = status === 'running'
+    ? 'bg-positive-bg text-positive'
+    : status === 'error'
+      ? 'bg-negative-bg text-negative'
+      : 'bg-bg text-text-muted'
+
+  return (
+    <div className={`w-[72px] h-[72px] rounded-full flex items-center justify-center shrink-0 ${bgClass}`}>
+      <svg viewBox="0 0 24 24" className="w-12 h-12 fill-current">
+        <circle cx="12" cy="2" r="1.5" />
+        <line x1="12" y1="3.5" x2="12" y2="6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        <rect x="4" y="6" width="16" height="12" rx="3" ry="3" />
+        <circle cx="9" cy="12" r="2" className="fill-surface" />
+        <circle cx="15" cy="12" r="2" className="fill-surface" />
+        <rect x="8" y="20" width="3" height="3" rx="1" />
+        <rect x="13" y="20" width="3" height="3" rx="1" />
+      </svg>
+    </div>
+  )
+}
+
+export default function BotCard({ bot, onStart, onStop, onDelete }: BotCardProps) {
+  const navigate = useNavigate()
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5 flex gap-4 items-start">
+      <BotIcon status={bot.status} />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-[15px] font-semibold">{bot.name || bot.bot_id}</span>
+          <StatusBadge variant={STATUS_VARIANT[bot.status] as 'positive'}>{BOT_STATUS_LABELS[bot.status] || bot.status}</StatusBadge>
+        </div>
+        <div className="text-[13px] text-text-muted mb-3">
+          <a onClick={() => navigate(`/bots/${bot.bot_id}`)} className="hover:text-primary cursor-pointer">{bot.bot_id}</a>
+        </div>
+        <div className="flex flex-col gap-1.5 text-[13px] text-text-muted mb-4">
+          <div className="flex justify-between">
+            <span>전략</span>
+            <span>{bot.strategy_name ? <a onClick={() => navigate(`/strategies/${bot.strategy_name}`)} className="text-primary hover:underline cursor-pointer">{bot.strategy_name}</a> : '-'}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>모드</span>
+            <StatusBadge variant={bot.mode === 'live' ? 'warning' : 'info'}>{bot.mode === 'live' ? '실전' : '모의'}</StatusBadge>
+          </div>
+        </div>
+        <div className="flex gap-2 justify-end">
+          {(bot.status === 'stopped' || bot.status === 'created') && (
+            <>
+              <button onClick={() => onStart(bot.bot_id)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">시작</button>
+              <button onClick={() => onDelete(bot.bot_id)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-negative border-none cursor-pointer hover:underline">삭제</button>
+            </>
+          )}
+          {bot.status === 'running' && (
+            <button onClick={() => onStop(bot.bot_id)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-negative border border-negative cursor-pointer hover:bg-negative-bg">중지</button>
+          )}
+          {bot.status === 'error' && (
+            <button onClick={() => onDelete(bot.bot_id)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-negative border-none cursor-pointer hover:underline">삭제</button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/bots/BotCreateForm.tsx
+++ b/frontend/src/components/bots/BotCreateForm.tsx
@@ -8,6 +8,7 @@ interface BotCreateFormProps {
 
 export default function BotCreateForm({ onClose }: BotCreateFormProps) {
   const [botId, setBotId] = useState('')
+  const [name, setName] = useState('')
   const [strategyName, setStrategyName] = useState('')
   const [mode, setMode] = useState<BotMode>('paper')
   const [interval, setInterval] = useState('60')
@@ -20,6 +21,7 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
     createBot.mutate(
       {
         bot_id: botId,
+        name,
         strategy_name: strategyName,
         mode,
         interval_seconds: Number(interval),
@@ -35,6 +37,11 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
       <div className="bg-surface border border-border rounded-lg p-6 w-[480px] max-h-[90vh] overflow-y-auto">
         <h2 className="text-[18px] font-bold mb-5">봇 생성</h2>
         <form onSubmit={handleSubmit}>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">이름</label>
+            <input value={name} onChange={(e) => setName(e.target.value)} placeholder="모멘텀 돌파 봇" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" />
+            <div className="text-[11px] text-text-muted mt-1">대시보드에 표시되는 이름</div>
+          </div>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">봇 ID</label>
             <input value={botId} onChange={(e) => setBotId(e.target.value)} placeholder="bot-momentum-01" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />

--- a/frontend/src/pages/BotDetail.tsx
+++ b/frontend/src/pages/BotDetail.tsx
@@ -26,7 +26,10 @@ export default function BotDetail() {
       {/* 헤더 */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h2 className="text-[20px] font-bold">{bot.bot_id}</h2>
+          <h2 className="text-[20px] font-bold">
+            {bot.name || bot.bot_id}
+            {bot.name && <span className="ml-2 text-[14px] font-normal text-text-muted font-mono">{bot.bot_id}</span>}
+          </h2>
           <div className="flex gap-3 items-center mt-1">
             <StatusBadge variant={STATUS_VARIANT[bot.status] as 'positive'}>
               {BOT_STATUS_LABELS[bot.status]}

--- a/frontend/src/pages/Bots.tsx
+++ b/frontend/src/pages/Bots.tsx
@@ -1,63 +1,75 @@
 import { useState } from 'react'
 import { useBots, useBotControl } from '../hooks/useBots'
-import BotTable from '../components/bots/BotTable'
+import BotCard from '../components/bots/BotCard'
 import BotCreateForm from '../components/bots/BotCreateForm'
 import { TableSkeleton } from '../components/common/Skeleton'
-import type { BotStatus } from '../types/bot'
-
-const STATUS_FILTERS: { key: BotStatus | 'all'; label: string }[] = [
-  { key: 'all', label: '전체' },
-  { key: 'running', label: '실행 중' },
-  { key: 'stopped', label: '중지됨' },
-  { key: 'error', label: '오류' },
-]
 
 export default function Bots() {
-  const [statusFilter, setStatusFilter] = useState<BotStatus | 'all'>('all')
   const [showCreate, setShowCreate] = useState(false)
   const { data, isLoading } = useBots()
   const { start, stop, remove } = useBotControl()
 
-  const items = (data?.items ?? []).filter(
-    (b) => statusFilter === 'all' || b.status === statusFilter,
-  )
+  const allBots = data?.items ?? []
+  const runningBots = allBots.filter((b) => b.status === 'running')
+  const inactiveBots = allBots.filter((b) => b.status !== 'running' && b.status !== 'deleted')
+
+  const handleDelete = (id: string) => {
+    if (confirm('이 봇을 삭제하시겠습니까?')) remove.mutate(id)
+  }
 
   return (
     <>
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex gap-1 bg-bg rounded-lg p-0.5">
-          {STATUS_FILTERS.map((f) => (
+      {isLoading ? (
+        <TableSkeleton rows={3} cols={3} />
+      ) : (
+        <>
+          {/* 실행 중 섹션 */}
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-2 text-[15px] font-semibold text-text-muted">
+              실행 중
+              <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded-full">{runningBots.length}</span>
+            </div>
             <button
-              key={f.key}
-              onClick={() => setStatusFilter(f.key)}
-              className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
-                statusFilter === f.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
-              }`}
+              onClick={() => setShowCreate(true)}
+              className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
             >
-              {f.label}
+              봇 생성
             </button>
-          ))}
-        </div>
-        <button
-          onClick={() => setShowCreate(true)}
-          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
-        >
-          봇 생성
-        </button>
-      </div>
+          </div>
 
-      <div className="bg-surface border border-border rounded-lg p-5">
-        {isLoading ? (
-          <TableSkeleton rows={5} cols={4} />
-        ) : (
-          <BotTable
-            items={items}
-            onStart={(id) => start.mutate(id)}
-            onStop={(id) => stop.mutate(id)}
-            onDelete={(id) => { if (confirm('이 봇을 삭제하시겠습니까?')) remove.mutate(id) }}
-          />
-        )}
-      </div>
+          <div className="mb-8">
+            {runningBots.length === 0 ? (
+              <div className="text-[13px] text-text-muted py-8 text-center">실행 중인 봇이 없습니다</div>
+            ) : (
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4">
+                {runningBots.map((bot) => (
+                  <BotCard key={bot.bot_id} bot={bot} onStart={(id) => start.mutate(id)} onStop={(id) => stop.mutate(id)} onDelete={handleDelete} />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* 비활성 섹션 */}
+          <div className="mb-4">
+            <div className="flex items-center gap-2 text-[15px] font-semibold text-text-muted">
+              비활성
+              <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded-full">{inactiveBots.length}</span>
+            </div>
+          </div>
+
+          <div className="mb-8">
+            {inactiveBots.length === 0 ? (
+              <div className="text-[13px] text-text-muted py-8 text-center">비활성 봇이 없습니다</div>
+            ) : (
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4">
+                {inactiveBots.map((bot) => (
+                  <BotCard key={bot.bot_id} bot={bot} onStart={(id) => start.mutate(id)} onStop={(id) => stop.mutate(id)} onDelete={handleDelete} />
+                ))}
+              </div>
+            )}
+          </div>
+        </>
+      )}
 
       {showCreate && <BotCreateForm onClose={() => setShowCreate(false)} />}
     </>

--- a/frontend/src/types/bot.ts
+++ b/frontend/src/types/bot.ts
@@ -3,6 +3,7 @@ export type BotMode = 'live' | 'paper'
 
 export interface Bot {
   bot_id: string
+  name: string
   strategy_name?: string
   status: BotStatus
   mode: BotMode
@@ -24,6 +25,7 @@ export interface BotLog {
 
 export interface BotCreateRequest {
   bot_id: string
+  name: string
   strategy_name: string
   mode: BotMode
   interval_seconds: number


### PR DESCRIPTION
## Summary
- 봇 목록을 테이블에서 카드 그리드 레이아웃으로 변경 (목업 기준)
- "실행 중 (N)" / "비활성 (N)" 섹션으로 봇 그룹핑
- BotCard 컴포넌트 생성 (로봇 아이콘, 전략/모드 메타, 상태별 액션 버튼)
- Bot 타입에 name 필드 추가, 생성 폼/상세 헤더에 반영 (#207 내용 포함)

Closes #209

## Test plan
- [ ] 봇 목록에서 "실행 중"/"비활성" 섹션 구분 확인
- [ ] 카드에 봇 이름, ID, 전략, 모드, 상태 뱃지, 액션 버튼 표시 확인
- [ ] running 봇: "중지" 버튼만, stopped/created: "시작"+"삭제", error: "삭제"만
- [ ] 카드 클릭(ID 링크)으로 봇 상세 페이지 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)