### PR TITLE
fix: 전략 목록에 제출자 컬럼 및 페이지네이션 추가

### DIFF
--- a/frontend/src/components/strategies/StrategyTable.tsx
+++ b/frontend/src/components/strategies/StrategyTable.tsx
@@ -21,6 +21,7 @@ export default function StrategyTable({ items }: { items: Strategy[] }) {
           <tr>
             <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">전략명</th>
             <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">버전</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">제출자</th>
             <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">상태</th>
             <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">실행 봇</th>
             <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">누적 수익률</th>
@@ -28,12 +29,13 @@ export default function StrategyTable({ items }: { items: Strategy[] }) {
         </thead>
         <tbody>
           {items.length === 0 ? (
-            <tr><td colSpan={5} className="px-3 py-8 text-center text-text-muted text-[13px]">등록된 전략이 없습니다</td></tr>
+            <tr><td colSpan={6} className="px-3 py-8 text-center text-text-muted text-[13px]">등록된 전략이 없습니다</td></tr>
           ) : (
             items.map((s) => (
               <tr key={s.id} onClick={() => navigate(`/strategies/${s.id}`)} className="hover:bg-surface-hover cursor-pointer">
                 <td className="px-3 py-3 border-b border-border text-[13px] font-medium">{s.name}</td>
                 <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{s.version}</td>
+                <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{s.author || '-'}</td>
                 <td className="px-3 py-3 border-b border-border text-[13px]">
                   <StatusBadge variant={STATUS_VARIANT[s.status] as 'positive'}>{STRATEGY_STATUS_LABELS[s.status] || s.status}</StatusBadge>
                 </td>

--- a/frontend/src/pages/Strategies.tsx
+++ b/frontend/src/pages/Strategies.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useStrategies } from '../hooks/useStrategies'
 import StrategyTable from '../components/strategies/StrategyTable'
+import Pagination from '../components/common/Pagination'
 import { TableSkeleton } from '../components/common/Skeleton'
 import type { StrategyStatus } from '../types/strategy'
 
@@ -11,13 +12,23 @@ const STATUS_FILTERS: { key: StrategyStatus | 'all'; label: string }[] = [
   { key: 'inactive', label: '중지' },
 ]
 
+const PAGE_SIZE = 5
+
 export default function Strategies() {
   const [statusFilter, setStatusFilter] = useState<StrategyStatus | 'all'>('all')
+  const [offset, setOffset] = useState(0)
   const { data: strategies, isLoading } = useStrategies()
 
   const filtered = (strategies ?? []).filter(
     (s) => statusFilter === 'all' || s.status === statusFilter,
   )
+
+  const paged = filtered.slice(offset, offset + PAGE_SIZE)
+
+  const handleFilterChange = (key: StrategyStatus | 'all') => {
+    setStatusFilter(key)
+    setOffset(0)
+  }
 
   return (
     <>
@@ -25,7 +36,7 @@ export default function Strategies() {
         {STATUS_FILTERS.map((f) => (
           <button
             key={f.key}
-            onClick={() => setStatusFilter(f.key)}
+            onClick={() => handleFilterChange(f.key)}
             className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
               statusFilter === f.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
             }`}
@@ -35,7 +46,16 @@ export default function Strategies() {
         ))}
       </div>
       <div className="bg-surface border border-border rounded-lg p-5">
-        {isLoading ? <TableSkeleton rows={5} cols={5} /> : <StrategyTable items={filtered} />}
+        {isLoading ? (
+          <TableSkeleton rows={5} cols={6} />
+        ) : (
+          <>
+            <StrategyTable items={paged} />
+            {filtered.length > PAGE_SIZE && (
+              <Pagination total={filtered.length} offset={offset} limit={PAGE_SIZE} onPageChange={setOffset} />
+            )}
+          </>
+        )}
       </div>
     </>
   )

--- a/frontend/src/types/strategy.ts
+++ b/frontend/src/types/strategy.ts
@@ -5,6 +5,7 @@ export interface Strategy {
   name: string
   version: string
   status: StrategyStatus
+  author?: string
   bot_id?: string
   cumulative_return?: number
   created_at: string

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -67,6 +67,7 @@ async def list_strategies(
                 "status": r.status.value
                 if hasattr(r.status, "value")
                 else str(r.status),
+                "author": r.author,
                 "bot_id": bot_info["bot_id"] if bot_info else None,
                 "bot_status": bot_info["status"] if bot_info else None,
             }


### PR DESCRIPTION
## Summary
- 백엔드 전략 리스트 API 응답에 `author` 필드 추가
- 전략 테이블에 "제출자" 컬럼 추가 (목업 기준 버전과 상태 사이)
- 클라이언트 사이드 페이지네이션 추가 (5건 단위, "N건 중 1-5" + 이전/다음)
- 필터 변경 시 페이지를 첫 페이지로 리셋

Closes #210

## Test plan
- [ ] 전략 목록에 "제출자" 컬럼이 표시되는지 확인
- [ ] 5건 초과 시 페이지네이션 UI 표시 확인
- [ ] 필터 변경 시 페이지 리셋 확인
- [ ] 백엔드 테스트 전체 통과 확인 (1305 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)