### PR TITLE
fix: 결재함 목업 대비 UI 괴리 개선

### DIFF
--- a/frontend/src/components/approvals/ApprovalFilters.tsx
+++ b/frontend/src/components/approvals/ApprovalFilters.tsx
@@ -1,4 +1,4 @@
-import type { ApprovalStatus, ApprovalType } from '../../types/approval'
+import type { ApprovalStatus, ApprovalType, Approval } from '../../types/approval'
 
 const STATUS_OPTIONS: { key: ApprovalStatus | 'all'; label: string }[] = [
   { key: 'all', label: '전체' },
@@ -8,7 +8,7 @@ const STATUS_OPTIONS: { key: ApprovalStatus | 'all'; label: string }[] = [
 ]
 
 const TYPE_OPTIONS: { key: ApprovalType | 'all'; label: string }[] = [
-  { key: 'all', label: '전체' },
+  { key: 'all', label: '전체 유형' },
   { key: 'strategy_report', label: '전략 리포트' },
   { key: 'budget_allocation', label: '예산 할당' },
   { key: 'live_switch', label: '실전 전환' },
@@ -18,35 +18,62 @@ const TYPE_OPTIONS: { key: ApprovalType | 'all'; label: string }[] = [
 interface ApprovalFiltersProps {
   status: ApprovalStatus | 'all'
   type: ApprovalType | 'all'
+  search: string
+  items?: Approval[]
   onStatusChange: (s: ApprovalStatus | 'all') => void
   onTypeChange: (t: ApprovalType | 'all') => void
+  onSearchChange: (q: string) => void
 }
 
-export default function ApprovalFilters({ status, type, onStatusChange, onTypeChange }: ApprovalFiltersProps) {
+export default function ApprovalFilters({ status, type, search, items, onStatusChange, onTypeChange, onSearchChange }: ApprovalFiltersProps) {
+  const counts: Record<string, number> = { all: 0, pending: 0, approved: 0, rejected: 0 }
+  for (const item of items ?? []) {
+    counts.all++
+    if (item.status in counts) counts[item.status]++
+  }
+
   return (
-    <div className="flex items-center gap-3 mb-4 flex-wrap">
-      <div className="flex gap-1 bg-bg rounded-lg p-0.5">
-        {STATUS_OPTIONS.map((opt) => (
-          <button
-            key={opt.key}
-            onClick={() => onStatusChange(opt.key)}
-            className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
-              status === opt.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
-            }`}
-          >
-            {opt.label}
-          </button>
-        ))}
+    <div className="space-y-3 mb-4">
+      <div className="flex items-center gap-3 flex-wrap">
+        <div className="flex gap-1 bg-bg rounded-lg p-0.5">
+          {STATUS_OPTIONS.map((opt) => (
+            <button
+              key={opt.key}
+              onClick={() => onStatusChange(opt.key)}
+              className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
+                status === opt.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
+              }`}
+            >
+              {opt.label}
+              {counts[opt.key] > 0 && (
+                <span className="ml-1 bg-border text-text text-[11px] px-1.5 py-0.5 rounded-full">{counts[opt.key]}</span>
+              )}
+            </button>
+          ))}
+        </div>
       </div>
-      <select
-        value={type}
-        onChange={(e) => onTypeChange(e.target.value as ApprovalType | 'all')}
-        className="bg-bg border border-border rounded-lg px-3 py-1.5 text-text text-[13px] cursor-pointer"
-      >
-        {TYPE_OPTIONS.map((opt) => (
-          <option key={opt.key} value={opt.key}>{opt.label}</option>
-        ))}
-      </select>
+      <div className="flex items-center gap-3 flex-wrap">
+        <div className="flex gap-1 bg-bg rounded-lg p-0.5">
+          {TYPE_OPTIONS.map((opt) => (
+            <button
+              key={opt.key}
+              onClick={() => onTypeChange(opt.key)}
+              className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
+                type === opt.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="제목, 전략명 검색..."
+          className="bg-bg border border-border rounded-lg px-3 py-1.5 text-text text-[13px] w-[240px] focus:outline-none focus:border-primary"
+        />
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/approvals/ApprovalTable.tsx
+++ b/frontend/src/components/approvals/ApprovalTable.tsx
@@ -29,13 +29,14 @@ export default function ApprovalTable({ items }: { items: Approval[] }) {
             <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">제목</th>
             <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">요청자</th>
             <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">요청일</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">처리일</th>
             <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">상태</th>
           </tr>
         </thead>
         <tbody>
           {items.length === 0 ? (
             <tr>
-              <td colSpan={5} className="px-3 py-8 text-center text-text-muted text-[13px]">결재 항목이 없습니다</td>
+              <td colSpan={6} className="px-3 py-8 text-center text-text-muted text-[13px]">결재 항목이 없습니다</td>
             </tr>
           ) : (
             items.map((item) => {
@@ -52,6 +53,7 @@ export default function ApprovalTable({ items }: { items: Approval[] }) {
                   <td className="px-3 py-3 border-b border-border text-[13px]">{item.title}</td>
                   <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{item.requester}</td>
                   <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{formatDateTime(item.requested_at)}</td>
+                  <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{item.resolved_at ? formatDateTime(item.resolved_at) : '-'}</td>
                   <td className="px-3 py-3 border-b border-border text-[13px]">
                     <StatusBadge variant={STATUS_VARIANT[item.status] as 'warning'}>
                       {APPROVAL_STATUS_LABELS[item.status] || item.status}

--- a/frontend/src/pages/ApprovalDetail.tsx
+++ b/frontend/src/pages/ApprovalDetail.tsx
@@ -4,14 +4,21 @@ import ReviewControls from '../components/approvals/ReviewControls'
 import BacktestMetricsPanel from '../components/approvals/BacktestMetrics'
 import StatusBadge from '../components/common/StatusBadge'
 import { PageSkeleton } from '../components/common/Skeleton'
-import { formatDate } from '../utils/formatters'
+import { formatDate, formatDateTime } from '../utils/formatters'
 import { APPROVAL_STATUS_LABELS } from '../utils/constants'
-import type { ApprovalStatus } from '../types/approval'
+import type { ApprovalStatus, ApprovalType } from '../types/approval'
 
 const STATUS_VARIANT: Record<ApprovalStatus, string> = {
   pending: 'warning',
   approved: 'positive',
   rejected: 'negative',
+}
+
+const TYPE_BADGE: Record<ApprovalType, { label: string; variant: string }> = {
+  strategy_report: { label: '전략 리포트', variant: 'info' },
+  budget_allocation: { label: '예산 할당', variant: 'primary' },
+  live_switch: { label: '실전 전환', variant: 'warning' },
+  risk_alert: { label: '위험 알림', variant: 'negative' },
 }
 
 export default function ApprovalDetail() {
@@ -23,9 +30,24 @@ export default function ApprovalDetail() {
 
   const detail = approval.detail
   const isPending = approval.status === 'pending'
+  const typeInfo = TYPE_BADGE[approval.type] || { label: approval.type, variant: 'muted' }
 
   return (
     <>
+      {/* 상세 헤더 */}
+      <div className="mb-6">
+        <h2 className="text-[20px] font-bold mb-2">{approval.title}</h2>
+        <div className="flex items-center gap-3 flex-wrap">
+          <StatusBadge variant={typeInfo.variant as 'info'}>{typeInfo.label}</StatusBadge>
+          <StatusBadge variant={STATUS_VARIANT[approval.status] as 'warning'}>
+            {APPROVAL_STATUS_LABELS[approval.status]}
+          </StatusBadge>
+          <span className="text-[13px] text-text-muted">
+            요청: {approval.requester} | {formatDateTime(approval.requested_at)}
+          </span>
+        </div>
+      </div>
+
       {/* 결재 영역 */}
       <ReviewControls approvalId={approval.id} isPending={isPending} />
 
@@ -59,31 +81,27 @@ export default function ApprovalDetail() {
         <div className="bg-surface border border-border rounded-lg p-5">
           <h3 className="text-[15px] font-semibold mb-3">전략 정보</h3>
           <div className="space-y-2">
-            <div className="flex justify-between py-2 border-b border-border text-[13px]">
-              <span className="text-text-muted">제목</span>
-              <span>{approval.title}</span>
-            </div>
-            <div className="flex justify-between py-2 border-b border-border text-[13px]">
-              <span className="text-text-muted">요청자</span>
-              <span>{approval.requester}</span>
-            </div>
-            <div className="flex justify-between py-2 border-b border-border text-[13px]">
-              <span className="text-text-muted">상태</span>
-              <StatusBadge variant={STATUS_VARIANT[approval.status] as 'warning'}>
-                {APPROVAL_STATUS_LABELS[approval.status]}
-              </StatusBadge>
-            </div>
             {detail && (
               <>
                 <div className="flex justify-between py-2 border-b border-border text-[13px]">
                   <span className="text-text-muted">전략명</span>
                   <span>{detail.strategy_name}</span>
                 </div>
-                <div className="flex justify-between py-2 text-[13px]">
+                <div className="flex justify-between py-2 border-b border-border text-[13px]">
                   <span className="text-text-muted">버전</span>
                   <span>{detail.strategy_version}</span>
                 </div>
               </>
+            )}
+            <div className="flex justify-between py-2 border-b border-border text-[13px]">
+              <span className="text-text-muted">작성자</span>
+              <span>{approval.requester}</span>
+            </div>
+            {detail && detail.filepath && (
+              <div className="flex justify-between py-2 text-[13px]">
+                <span className="text-text-muted">파일 경로</span>
+                <span className="font-mono text-[12px]">{detail.filepath}</span>
+              </div>
             )}
           </div>
         </div>
@@ -93,22 +111,26 @@ export default function ApprovalDetail() {
             <h3 className="text-[15px] font-semibold mb-3">백테스트 요약</h3>
             <div className="space-y-2">
               <div className="flex justify-between py-2 border-b border-border text-[13px]">
-                <span className="text-text-muted">시작일</span>
-                <span>{formatDate(detail.backtest_start)}</span>
+                <span className="text-text-muted">기간</span>
+                <span>{formatDate(detail.backtest_start)} ~ {formatDate(detail.backtest_end)}</span>
               </div>
               <div className="flex justify-between py-2 border-b border-border text-[13px]">
-                <span className="text-text-muted">종료일</span>
-                <span>{formatDate(detail.backtest_end)}</span>
+                <span className="text-text-muted">초기 자산</span>
+                <span>{detail.initial_capital != null ? `${detail.initial_capital.toLocaleString()}원` : '-'}</span>
               </div>
               <div className="flex justify-between py-2 border-b border-border text-[13px]">
-                <span className="text-text-muted">총 거래</span>
-                <span>{detail.metrics.total_trades}회</span>
+                <span className="text-text-muted">최종 자산</span>
+                <span>{detail.final_capital != null ? `${detail.final_capital.toLocaleString()}원` : '-'}</span>
               </div>
-              <div className="flex justify-between py-2 text-[13px]">
-                <span className="text-text-muted">총 수익률</span>
+              <div className="flex justify-between py-2 border-b border-border text-[13px]">
+                <span className="text-text-muted">수익률</span>
                 <span className={detail.metrics.total_return >= 0 ? 'text-positive' : 'text-negative'}>
                   {(detail.metrics.total_return * 100).toFixed(2)}%
                 </span>
+              </div>
+              <div className="flex justify-between py-2 text-[13px]">
+                <span className="text-text-muted">거래 수</span>
+                <span>{detail.metrics.total_trades}회</span>
               </div>
             </div>
           </div>
@@ -124,13 +146,13 @@ export default function ApprovalDetail() {
           <div className="bg-surface border border-border rounded-lg p-5">
             <h3 className="text-[15px] font-semibold mb-3">자산 추이</h3>
             <div className="h-[200px] bg-bg border border-dashed border-border rounded-lg flex items-center justify-center text-text-muted text-[13px]">
-              📈 에쿼티 커브 (Area Chart)
+              에쿼티 커브 (Area Chart)
             </div>
           </div>
           <div className="bg-surface border border-border rounded-lg p-5">
             <h3 className="text-[15px] font-semibold mb-3">드로우다운</h3>
             <div className="h-[200px] bg-bg border border-dashed border-border rounded-lg flex items-center justify-center text-text-muted text-[13px]">
-              📉 드로우다운 (Area Chart)
+              드로우다운 (Area Chart)
             </div>
           </div>
         </div>

--- a/frontend/src/pages/Approvals.tsx
+++ b/frontend/src/pages/Approvals.tsx
@@ -11,24 +11,33 @@ const LIMIT = 20
 export default function Approvals() {
   const [status, setStatus] = useState<ApprovalStatus | 'all'>('all')
   const [type, setType] = useState<ApprovalType | 'all'>('all')
+  const [search, setSearch] = useState('')
   const [offset, setOffset] = useState(0)
 
   const { data, isLoading } = useApprovals({ status, type, offset, limit: LIMIT })
+
+  const allItems = data?.items ?? []
+  const filtered = search
+    ? allItems.filter((item) => item.title.toLowerCase().includes(search.toLowerCase()))
+    : allItems
 
   return (
     <>
       <ApprovalFilters
         status={status}
         type={type}
+        search={search}
+        items={allItems}
         onStatusChange={(s) => { setStatus(s); setOffset(0) }}
         onTypeChange={(t) => { setType(t); setOffset(0) }}
+        onSearchChange={(q) => { setSearch(q); setOffset(0) }}
       />
       <div className="bg-surface border border-border rounded-lg p-5">
         {isLoading ? (
-          <TableSkeleton rows={5} cols={5} />
+          <TableSkeleton rows={5} cols={6} />
         ) : (
           <>
-            <ApprovalTable items={data?.items ?? []} />
+            <ApprovalTable items={filtered} />
             {(data?.total ?? 0) > LIMIT && (
               <Pagination
                 total={data?.total ?? 0}

--- a/frontend/src/types/approval.ts
+++ b/frontend/src/types/approval.ts
@@ -21,12 +21,15 @@ export interface ApprovalDetail extends Approval {
 export interface StrategyReportDetail {
   strategy_name: string
   strategy_version: string
+  filepath?: string
   agent_summary: string
   agent_rationale: string
   agent_risks: string
   agent_recommendation: string
   backtest_start: string
   backtest_end: string
+  initial_capital?: number
+  final_capital?: number
   metrics: BacktestMetrics
   equity_curve: { date: string; value: number }[]
   drawdown: { date: string; value: number }[]


### PR DESCRIPTION
## Summary
- 상태 필터 탭에 건수 뱃지 표시
- 유형 필터를 드롭다운에서 탭 버튼으로 변경
- 검색 입력 필드 추가 (제목 기준)
- 테이블에 "처리일" 컬럼 추가
- 결재 상세 헤더 섹션 추가 (제목, 유형/상태 뱃지, 요청자)
- 백테스트 요약에 초기 자산, 최종 자산 추가
- 전략 정보에 파일 경로 추가

Closes #213

## Test plan
- [ ] 상태 탭에 건수 뱃지 표시 확인
- [ ] 유형 탭 버튼 전환 확인
- [ ] 검색 필드 동작 확인
- [ ] 처리일 컬럼 표시 확인
- [ ] 결재 상세 헤더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)