### PR TITLE
fix: 멤버 관리 UI를 목업 기준으로 개선

### DIFF
--- a/frontend/src/components/agents/MemberCard.tsx
+++ b/frontend/src/components/agents/MemberCard.tsx
@@ -1,0 +1,61 @@
+import { useNavigate } from 'react-router-dom'
+import StatusBadge from '../common/StatusBadge'
+import { MEMBER_STATUS_LABELS } from '../../utils/constants'
+import type { Member, MemberStatus } from '../../types/member'
+
+const STATUS_VARIANT: Record<MemberStatus, string> = {
+  active: 'positive', suspended: 'warning', revoked: 'negative',
+}
+
+interface MemberCardProps {
+  member: Member
+  onSuspend?: (id: string) => void
+  onReactivate?: (id: string) => void
+  onRevoke?: (id: string) => void
+}
+
+export default function MemberCard({ member, onSuspend, onReactivate, onRevoke }: MemberCardProps) {
+  const navigate = useNavigate()
+
+  return (
+    <div
+      onClick={() => navigate(`/agents/${member.member_id}`)}
+      className="bg-surface border border-border rounded-lg p-5 flex gap-4 items-start cursor-pointer hover:border-primary/50 transition-colors"
+    >
+      <div className="w-[56px] h-[56px] rounded-full bg-bg flex items-center justify-center text-[28px] shrink-0">
+        {member.emoji || (member.type === 'human' ? '👤' : '🤖')}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-[15px] font-semibold">{member.name}</span>
+          <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>{MEMBER_STATUS_LABELS[member.status]}</StatusBadge>
+        </div>
+        <div className="text-[13px] text-text-muted font-mono mb-2">{member.member_id}</div>
+        <div className="text-[12px] text-text-muted mb-3">소속: {member.org}</div>
+        {member.scopes && member.scopes.length > 0 && (
+          <div className="flex flex-wrap gap-1 mb-3">
+            {member.scopes.slice(0, 4).map((scope) => (
+              <span key={scope} className="bg-bg text-text-muted text-[11px] px-2 py-0.5 rounded">{scope}</span>
+            ))}
+            {member.scopes.length > 4 && (
+              <span className="text-text-muted text-[11px]">+{member.scopes.length - 4}</span>
+            )}
+          </div>
+        )}
+        {(onSuspend || onReactivate || onRevoke) && (
+          <div className="flex gap-2 justify-end" onClick={(e) => e.stopPropagation()}>
+            {member.status === 'active' && onSuspend && (
+              <button onClick={() => onSuspend(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-warning border border-border cursor-pointer hover:bg-warning-bg">정지</button>
+            )}
+            {member.status === 'suspended' && onReactivate && (
+              <button onClick={() => onReactivate(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">재활성화</button>
+            )}
+            {member.status !== 'revoked' && onRevoke && (
+              <button onClick={() => onRevoke(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-negative border border-border cursor-pointer hover:bg-negative-bg">폐기</button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -9,7 +9,7 @@ const NAV_ITEMS = [
   { path: '/strategies', icon: '📈', label: '전략과 성과' },
   { path: '/bots', icon: '🤖', label: '봇 관리' },
   { path: '/backtest-data', icon: '📁', label: '백테스트 데이터' },
-  { path: '/agents', icon: '🧑‍💼', label: '에이전트 관리' },
+  { path: '/agents', icon: '🧑‍💼', label: '멤버 관리' },
 ]
 
 export default function Sidebar() {

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -36,14 +36,19 @@ export default function AgentDetail() {
     <>
       {/* 헤더 */}
       <div className="flex items-center justify-between mb-6">
-        <div>
-          <h2 className="text-[20px] font-bold">{member.name}</h2>
-          <div className="flex gap-3 items-center mt-1">
-            <span className="text-text-muted font-mono text-[13px]">{member.member_id}</span>
-            <span className="text-text-muted text-[13px]">{member.org}</span>
-            <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>
-              {MEMBER_STATUS_LABELS[member.status]}
-            </StatusBadge>
+        <div className="flex items-center gap-4">
+          <div className="w-[56px] h-[56px] rounded-full bg-surface border border-border flex items-center justify-center text-[28px] shrink-0">
+            {member.emoji || (member.type === 'human' ? '👤' : '🤖')}
+          </div>
+          <div>
+            <h2 className="text-[20px] font-bold font-mono">{member.member_id}</h2>
+            <div className="flex gap-3 items-center mt-1">
+              <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded">{member.org}</span>
+              <span className="text-text-muted text-[13px]">{member.name}</span>
+              <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>
+                {MEMBER_STATUS_LABELS[member.status]}
+              </StatusBadge>
+            </div>
           </div>
         </div>
         <div className="flex gap-2">
@@ -59,6 +64,31 @@ export default function AgentDetail() {
         </div>
       </div>
 
+      {/* 기본 정보 카드 */}
+      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+        <h3 className="text-[15px] font-semibold mb-3">기본 정보</h3>
+        <div className="grid grid-cols-2 gap-x-8 gap-y-2">
+          <div className="flex justify-between py-2 border-b border-border text-[13px]">
+            <span className="text-text-muted">Agent ID</span>
+            <span className="font-mono">{member.member_id}</span>
+          </div>
+          <div className="flex justify-between py-2 border-b border-border text-[13px]">
+            <span className="text-text-muted">이름</span>
+            <span>{member.name}</span>
+          </div>
+          <div className="flex justify-between py-2 border-b border-border text-[13px]">
+            <span className="text-text-muted">소속</span>
+            <span>{member.org}</span>
+          </div>
+          <div className="flex justify-between py-2 border-b border-border text-[13px]">
+            <span className="text-text-muted">상태</span>
+            <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>
+              {MEMBER_STATUS_LABELS[member.status]}
+            </StatusBadge>
+          </div>
+        </div>
+      </div>
+
       {/* 토큰 관리 */}
       <div className="bg-surface border border-border rounded-lg p-5 mb-6">
         <div className="flex items-center justify-between mb-3">
@@ -71,6 +101,12 @@ export default function AgentDetail() {
             토큰 재발급
           </button>
         </div>
+        {member.token_prefix && (
+          <div className="flex justify-between py-2 border-b border-border text-[13px] mb-3">
+            <span className="text-text-muted">토큰 접두어</span>
+            <span className="font-mono">{member.token_prefix}****</span>
+          </div>
+        )}
         <p className="text-[12px] text-warning">기존 토큰이 즉시 무효화됩니다</p>
       </div>
 
@@ -122,6 +158,12 @@ export default function AgentDetail() {
             <span className="text-text-muted">생성자</span>
             <span>{member.created_by || '-'}</span>
           </div>
+          {member.suspended_at && (
+            <div className="flex justify-between py-2 border-b border-border text-[13px]">
+              <span className="text-text-muted">정지 시각</span>
+              <span>{formatDateTime(member.suspended_at)}</span>
+            </div>
+          )}
           <div className="flex justify-between py-2 text-[13px]">
             <span className="text-text-muted">마지막 활동</span>
             <span>{member.last_active_at ? formatDateTime(member.last_active_at) : '-'}</span>

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -1,64 +1,97 @@
 import { useState } from 'react'
 import { useMembers, useMemberControl } from '../hooks/useMembers'
-import AgentTable from '../components/agents/AgentTable'
+import MemberCard from '../components/agents/MemberCard'
 import AgentRegisterForm from '../components/agents/AgentRegisterForm'
 import { TableSkeleton } from '../components/common/Skeleton'
-import type { MemberStatus } from '../types/member'
-
-const STATUS_FILTERS: { key: MemberStatus | 'all'; label: string }[] = [
-  { key: 'all', label: '전체' },
-  { key: 'active', label: 'active' },
-  { key: 'suspended', label: 'suspended' },
-  { key: 'revoked', label: 'revoked' },
-]
 
 export default function Agents() {
-  const [statusFilter, setStatusFilter] = useState<MemberStatus | 'all'>('all')
+  const [orgFilter, setOrgFilter] = useState<string>('all')
   const [showRegister, setShowRegister] = useState(false)
   const [createdToken, setCreatedToken] = useState<string | null>(null)
 
-  const { data: members, isLoading } = useMembers({
-    type: 'agent',
-    status: statusFilter === 'all' ? undefined : statusFilter,
-  })
+  const { data: allMembers, isLoading } = useMembers({})
+  const { data: humanMembers } = useMembers({ type: 'human' })
+  const { data: agentMembers } = useMembers({ type: 'agent' })
   const { suspend, reactivate, revoke } = useMemberControl()
+
+  const humans = humanMembers ?? []
+  const agents = agentMembers ?? []
+
+  // 소속 목록 추출
+  const allItems = allMembers ?? []
+  const orgs = Array.from(new Set(allItems.map((m) => m.org).filter(Boolean)))
+
+  const filterByOrg = (items: typeof allItems) =>
+    orgFilter === 'all' ? items : items.filter((m) => m.org === orgFilter)
 
   return (
     <>
       <div className="flex items-center justify-between mb-4">
-        <div className="flex gap-1 bg-bg rounded-lg p-0.5">
-          {STATUS_FILTERS.map((f) => (
-            <button
-              key={f.key}
-              onClick={() => setStatusFilter(f.key)}
-              className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
-                statusFilter === f.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
-              }`}
-            >
-              {f.label}
-            </button>
-          ))}
+        <div className="flex items-center gap-3">
+          <select
+            value={orgFilter}
+            onChange={(e) => setOrgFilter(e.target.value)}
+            className="bg-bg border border-border rounded-lg px-3 py-1.5 text-text text-[13px] cursor-pointer"
+          >
+            <option value="all">전체 소속</option>
+            {orgs.map((org) => (
+              <option key={org} value={org}>{org}</option>
+            ))}
+          </select>
         </div>
         <button
           onClick={() => setShowRegister(true)}
           className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
         >
-          에이전트 등록
+          멤버 등록
         </button>
       </div>
 
-      <div className="bg-surface border border-border rounded-lg p-5">
-        {isLoading ? (
-          <TableSkeleton rows={5} cols={5} />
-        ) : (
-          <AgentTable
-            items={members ?? []}
-            onSuspend={(id) => suspend.mutate(id)}
-            onReactivate={(id) => reactivate.mutate(id)}
-            onRevoke={(id) => { if (confirm('이 에이전트를 영구 폐기하시겠습니까?')) revoke.mutate(id) }}
-          />
-        )}
-      </div>
+      {isLoading ? (
+        <TableSkeleton rows={3} cols={3} />
+      ) : (
+        <>
+          {/* Human 멤버 섹션 */}
+          <div className="mb-8">
+            <div className="flex items-center gap-2 text-[15px] font-semibold text-text-muted mb-4">
+              Human 멤버
+              <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded-full">{filterByOrg(humans).length}</span>
+            </div>
+            {filterByOrg(humans).length === 0 ? (
+              <div className="text-[13px] text-text-muted py-6 text-center">Human 멤버가 없습니다</div>
+            ) : (
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4">
+                {filterByOrg(humans).map((m) => (
+                  <MemberCard key={m.member_id} member={m} />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Agent 멤버 섹션 */}
+          <div className="mb-8">
+            <div className="flex items-center gap-2 text-[15px] font-semibold text-text-muted mb-4">
+              Agent 멤버
+              <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded-full">{filterByOrg(agents).length}</span>
+            </div>
+            {filterByOrg(agents).length === 0 ? (
+              <div className="text-[13px] text-text-muted py-6 text-center">Agent 멤버가 없습니다</div>
+            ) : (
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4">
+                {filterByOrg(agents).map((m) => (
+                  <MemberCard
+                    key={m.member_id}
+                    member={m}
+                    onSuspend={(id) => suspend.mutate(id)}
+                    onReactivate={(id) => reactivate.mutate(id)}
+                    onRevoke={(id) => { if (confirm('이 에이전트를 영구 폐기하시겠습니까?')) revoke.mutate(id) }}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </>
+      )}
 
       {showRegister && (
         <AgentRegisterForm
@@ -67,7 +100,6 @@ export default function Agents() {
         />
       )}
 
-      {/* 토큰 표시 모달 */}
       {createdToken && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
           <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
@@ -77,18 +109,8 @@ export default function Agents() {
               {createdToken}
             </div>
             <div className="flex justify-end gap-2">
-              <button
-                onClick={() => navigator.clipboard.writeText(createdToken)}
-                className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
-              >
-                복사
-              </button>
-              <button
-                onClick={() => setCreatedToken(null)}
-                className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover"
-              >
-                닫기
-              </button>
+              <button onClick={() => navigator.clipboard.writeText(createdToken)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">복사</button>
+              <button onClick={() => setCreatedToken(null)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">닫기</button>
             </div>
           </div>
         </div>

--- a/frontend/src/types/member.ts
+++ b/frontend/src/types/member.ts
@@ -6,7 +6,9 @@ export interface Member {
   name: string
   type: MemberType
   org: string
+  emoji?: string
   status: MemberStatus
+  scopes?: string[]
   last_active_at?: string
   created_at: string
 }
@@ -14,6 +16,8 @@ export interface Member {
 export interface MemberDetail extends Member {
   scopes: string[]
   created_by?: string
+  token_prefix?: string
+  suspended_at?: string
 }
 
 export interface MemberCreateRequest {


### PR DESCRIPTION
## Summary
- 사이드바 라벨 "에이전트 관리" → "멤버 관리" 변경
- 테이블 → 카드 레이아웃 전환 (MemberCard 컴포넌트 신규)
- Human/Agent 섹션 분리, 소속 필터 드롭다운, 아바타 이모지 + 스코프 태그 표시
- 상세 페이지: agent_id 타이틀, 기본 정보 카드, 토큰 접두어 마스킹, 정지 시각 필드 추가

Closes #214

## Test plan
- [ ] 멤버 목록에서 Human/Agent 섹션 분리 확인
- [ ] 카드에 이모지, 스코프 태그 표시 확인
- [ ] 소속 필터 드롭다운 동작 확인
- [ ] 상세 페이지에서 agent_id가 타이틀인지 확인
- [ ] 토큰 접두어 마스킹 (ante_ak_****) 표시 확인
- [ ] 정지 시각 필드 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)