### PR TITLE
fix: 자금관리 UI를 목업 기준으로 전면 개선

### DIFF
--- a/frontend/src/api/treasury.ts
+++ b/frontend/src/api/treasury.ts
@@ -8,7 +8,7 @@ export async function getTreasurySummary(): Promise<TreasurySummary> {
 
 export async function getBotBudgets(): Promise<BotBudget[]> {
   const res = await client.get('/api/treasury/budgets')
-  return res.data
+  return res.data.budgets ?? res.data
 }
 
 export async function allocateBudget(botId: string, amount: number): Promise<void> {
@@ -19,10 +19,12 @@ export async function deallocateBudget(botId: string, amount: number): Promise<v
   await client.post(`/api/treasury/bots/${botId}/deallocate`, { amount })
 }
 
-export async function getTreasuryHistory(params: {
+export async function getTreasuryTransactions(params: {
   offset?: number
   limit?: number
+  type?: string
+  bot_id?: string
 }): Promise<{ items: TreasuryTransaction[]; total: number }> {
-  const res = await client.get('/api/audit', { params: { ...params, category: 'treasury' } })
+  const res = await client.get('/api/treasury/transactions', { params })
   return res.data
 }

--- a/frontend/src/components/treasury/AccountSummary.tsx
+++ b/frontend/src/components/treasury/AccountSummary.tsx
@@ -1,22 +1,48 @@
-import { formatKRW } from '../../utils/formatters'
+import { formatKRW, formatPercent } from '../../utils/formatters'
 import type { TreasurySummary } from '../../types/treasury'
 
 export default function AccountSummary({ summary }: { summary: TreasurySummary }) {
-  const stats = [
-    { label: '총 잔고', value: formatKRW(summary.total_balance) },
-    { label: '할당됨', value: formatKRW(summary.allocated) },
-    { label: '미할당', value: formatKRW(summary.unallocated) },
-    { label: '예약됨', value: formatKRW(summary.reserved) },
-  ]
+  const profitColor = summary.total_profit_loss >= 0 ? 'text-positive' : 'text-negative'
+  const profitPercent = summary.total_evaluation > 0
+    ? summary.total_profit_loss / (summary.total_evaluation - summary.total_profit_loss)
+    : 0
 
   return (
-    <div className="grid grid-cols-4 gap-4 mb-6">
-      {stats.map((s) => (
-        <div key={s.label} className="bg-surface border border-border rounded-lg px-5 py-4">
-          <div className="text-[12px] text-text-muted mb-1">{s.label}</div>
-          <div className="text-[24px] font-bold">{s.value}</div>
+    <div className="bg-surface border border-border rounded-lg overflow-hidden mb-6">
+      {/* KIS 헤더 */}
+      <div className="flex items-center gap-4 px-5 py-3 border-b border-border">
+        <div className="flex items-center gap-2">
+          <span className="bg-primary text-white text-[11px] font-bold px-2 py-0.5 rounded">KIS</span>
+          <span className="text-[14px] font-semibold">한국투자증권</span>
         </div>
-      ))}
+        <div className="ml-auto flex items-center gap-4 text-[13px] text-text-muted">
+          <span>수수료 {(summary.commission_rate * 100).toFixed(3)}%</span>
+          <span>매도세 {(summary.sell_tax_rate * 100).toFixed(2)}%</span>
+        </div>
+      </div>
+
+      {/* 4개 통계 */}
+      <div className="grid grid-cols-4">
+        <div className="px-5 py-4">
+          <div className="text-[12px] text-text-muted mb-1">총 자산 평가</div>
+          <div className="text-[22px] font-bold">{formatKRW(summary.total_evaluation)}</div>
+        </div>
+        <div className="px-5 py-4">
+          <div className="text-[12px] text-text-muted mb-1">총 손익</div>
+          <div className={`text-[22px] font-bold ${profitColor}`}>{formatKRW(summary.total_profit_loss)}</div>
+          {profitPercent !== 0 && (
+            <div className={`text-[13px] ${profitColor}`}>({formatPercent(profitPercent)})</div>
+          )}
+        </div>
+        <div className="px-5 py-4">
+          <div className="text-[12px] text-text-muted mb-1">예수금</div>
+          <div className="text-[22px] font-bold text-text-muted">{formatKRW(summary.account_balance)}</div>
+        </div>
+        <div className="px-5 py-4">
+          <div className="text-[12px] text-text-muted mb-1">매수가능금액</div>
+          <div className="text-[22px] font-bold text-text-muted">{formatKRW(summary.purchasable_amount)}</div>
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/treasury/AllocationForm.tsx
+++ b/frontend/src/components/treasury/AllocationForm.tsx
@@ -1,63 +1,122 @@
 import { useState } from 'react'
 import { useAllocateBudget, useDeallocateBudget } from '../../hooks/useTreasury'
+import { formatKRW } from '../../utils/formatters'
+import type { BotBudget } from '../../types/treasury'
 
-export default function AllocationForm({ botIds }: { botIds: string[] }) {
-  const [botId, setBotId] = useState(botIds[0] ?? '')
+interface AllocationFormProps {
+  budgets: BotBudget[]
+}
+
+export default function AllocationForm({ budgets }: AllocationFormProps) {
+  const [botId, setBotId] = useState(budgets[0]?.bot_id ?? '')
   const [amount, setAmount] = useState('')
+  const [confirmAction, setConfirmAction] = useState<{ action: 'allocate' | 'deallocate'; botId: string; amount: number } | null>(null)
   const allocate = useAllocateBudget()
   const deallocate = useDeallocateBudget()
 
-  const handleAction = (action: 'allocate' | 'deallocate') => {
-    const numAmount = Number(amount)
-    if (!botId || !numAmount) return
+  const selectedBudget = budgets.find((b) => b.bot_id === botId)
+  const numAmount = Number(amount)
+
+  const handleSubmit = () => {
+    if (!confirmAction) return
+    const { action, botId: bid, amount: amt } = confirmAction
     if (action === 'allocate') {
-      allocate.mutate({ botId, amount: numAmount }, { onSuccess: () => setAmount('') })
+      allocate.mutate({ botId: bid, amount: amt }, { onSuccess: () => { setAmount(''); setConfirmAction(null) } })
     } else {
-      deallocate.mutate({ botId, amount: numAmount }, { onSuccess: () => setAmount('') })
+      deallocate.mutate({ botId: bid, amount: amt }, { onSuccess: () => { setAmount(''); setConfirmAction(null) } })
     }
   }
 
   return (
-    <div className="bg-surface border border-border rounded-lg p-5">
-      <h3 className="text-[15px] font-semibold mb-4">할당 / 회수</h3>
-      <div className="flex gap-3 items-end">
-        <div className="flex-1">
-          <label className="block text-[12px] font-semibold text-text-muted mb-1.5">봇</label>
-          <select
-            value={botId}
-            onChange={(e) => setBotId(e.target.value)}
-            className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px]"
-          >
-            {botIds.map((id) => (
-              <option key={id} value={id}>{id}</option>
-            ))}
-          </select>
+    <>
+      <div className="bg-surface border border-border rounded-lg p-5">
+        <h3 className="text-[15px] font-semibold mb-2">Bot 예산 관리</h3>
+        <div className="text-[12px] text-text-muted mb-4">예산 변경은 Bot이 중지된 상태에서만 가능합니다.</div>
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">Bot 선택</label>
+            <select
+              value={botId}
+              onChange={(e) => setBotId(e.target.value)}
+              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px]"
+            >
+              {budgets.map((b) => (
+                <option key={b.bot_id} value={b.bot_id}>{b.bot_id}</option>
+              ))}
+            </select>
+          </div>
+
+          {selectedBudget && (
+            <div>
+              <label className="block text-[12px] font-semibold text-text-muted mb-1.5">현재 배정예산</label>
+              <div className="text-[15px] font-semibold">{formatKRW(selectedBudget.allocated)}</div>
+            </div>
+          )}
+
+          <div>
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">금액 (원)</label>
+            <input
+              type="number"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              placeholder="0"
+              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] placeholder:text-text-muted focus:outline-none focus:border-primary"
+            />
+          </div>
+
+          <div className="flex gap-2">
+            <button
+              onClick={() => numAmount > 0 && botId && setConfirmAction({ action: 'allocate', botId, amount: numAmount })}
+              disabled={!botId || !numAmount}
+              className="flex-1 px-4 py-2.5 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover disabled:opacity-50"
+            >
+              할당
+            </button>
+            <button
+              onClick={() => numAmount > 0 && botId && setConfirmAction({ action: 'deallocate', botId, amount: numAmount })}
+              disabled={!botId || !numAmount}
+              className="flex-1 px-4 py-2.5 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover hover:text-text disabled:opacity-50"
+            >
+              회수
+            </button>
+          </div>
         </div>
-        <div className="flex-1">
-          <label className="block text-[12px] font-semibold text-text-muted mb-1.5">금액 (원)</label>
-          <input
-            type="number"
-            value={amount}
-            onChange={(e) => setAmount(e.target.value)}
-            placeholder="0"
-            className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] placeholder:text-text-muted focus:outline-none focus:border-primary"
-          />
-        </div>
-        <button
-          onClick={() => handleAction('allocate')}
-          disabled={!botId || !amount}
-          className="px-4 py-2.5 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover disabled:opacity-50"
-        >
-          할당
-        </button>
-        <button
-          onClick={() => handleAction('deallocate')}
-          disabled={!botId || !amount}
-          className="px-4 py-2.5 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover hover:text-text disabled:opacity-50"
-        >
-          회수
-        </button>
       </div>
-    </div>
+
+      {/* 확인 모달 */}
+      {confirmAction && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+          <div className="bg-surface border border-border rounded-lg p-6 w-[420px]">
+            <h3 className="text-[16px] font-bold mb-3">
+              예산 {confirmAction.action === 'allocate' ? '할당' : '회수'} 확인
+            </h3>
+            <div className="text-[13px] text-text-muted mb-4">아래 내용으로 예산을 변경합니다.</div>
+            <div className="bg-bg border border-border rounded-lg p-4 mb-4 space-y-2">
+              <div className="flex justify-between text-[13px]">
+                <span className="text-text-muted">Bot</span>
+                <span className="font-semibold font-mono">{confirmAction.botId}</span>
+              </div>
+              {selectedBudget && (
+                <div className="flex justify-between text-[13px]">
+                  <span className="text-text-muted">현재 예산</span>
+                  <span>{formatKRW(selectedBudget.allocated)}</span>
+                </div>
+              )}
+              <div className="flex justify-between text-[13px]">
+                <span className="text-text-muted">{confirmAction.action === 'allocate' ? '할당' : '회수'} 금액</span>
+                <span className={`font-semibold ${confirmAction.action === 'allocate' ? 'text-positive' : 'text-negative'}`}>
+                  {confirmAction.action === 'allocate' ? '+' : '-'}{formatKRW(confirmAction.amount)}
+                </span>
+              </div>
+            </div>
+            <div className="flex justify-end gap-2">
+              <button onClick={() => setConfirmAction(null)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
+              <button onClick={handleSubmit} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">변경 확인</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   )
 }

--- a/frontend/src/components/treasury/AnteSummary.tsx
+++ b/frontend/src/components/treasury/AnteSummary.tsx
@@ -1,0 +1,68 @@
+import { formatKRW, formatPercent } from '../../utils/formatters'
+import type { TreasurySummary } from '../../types/treasury'
+
+export default function AnteSummary({ summary }: { summary: TreasurySummary }) {
+  const anteProfitColor = summary.ante_profit_loss >= 0 ? 'text-positive' : 'text-negative'
+  const anteProfitPercent = summary.ante_purchase_amount > 0
+    ? summary.ante_profit_loss / summary.ante_purchase_amount
+    : 0
+
+  const holdingProfitColor = (summary.ante_eval_amount - summary.ante_purchase_amount) >= 0 ? 'text-positive' : 'text-negative'
+
+  return (
+    <div className="bg-surface border border-border rounded-lg overflow-hidden mb-6">
+      {/* Ante 헤더 */}
+      <div className="flex items-center gap-4 px-5 py-3 border-b border-border">
+        <div className="flex items-center gap-2">
+          <span className="bg-positive text-white text-[11px] font-bold px-2 py-0.5 rounded">Ante</span>
+          <span className="text-[14px] font-semibold">관리 자금</span>
+        </div>
+        <span className="text-[13px] text-text-muted">Bot {summary.bot_count}개 운용 중</span>
+        {summary.budget_exceeds_purchasable && (
+          <div className="ml-auto flex items-center gap-1.5 bg-warning-bg text-warning px-3 py-1 rounded text-[12px]">
+            ⚠ 잔여예산이 매수가능금액을 초과합니다
+          </div>
+        )}
+      </div>
+
+      {/* 상단 4개 */}
+      <div className="grid grid-cols-4 border-b border-border">
+        <div className="px-5 py-4">
+          <div className="text-[12px] text-text-muted mb-1">Ante 관리자산 평가</div>
+          <div className="text-[22px] font-bold">{formatKRW(summary.ante_eval_amount)}</div>
+        </div>
+        <div className="px-5 py-4">
+          <div className="text-[12px] text-text-muted mb-1">Ante 관리자산 손익</div>
+          <div className={`text-[22px] font-bold ${anteProfitColor}`}>{formatKRW(summary.ante_profit_loss)}</div>
+          {anteProfitPercent !== 0 && (
+            <div className={`text-[13px] ${anteProfitColor}`}>({formatPercent(anteProfitPercent)})</div>
+          )}
+        </div>
+        <div className="px-5 py-4">
+          <div className="text-[12px] text-text-muted mb-1">Bot 배정예산</div>
+          <div className="text-[22px] font-bold text-text-muted">{formatKRW(summary.total_allocated)}</div>
+        </div>
+        <div className="px-5 py-4">
+          <div className="text-[12px] text-text-muted mb-1">잔여예산</div>
+          <div className="text-[22px] font-bold text-text-muted">{formatKRW(summary.total_available)}</div>
+        </div>
+      </div>
+
+      {/* 하단 3개 */}
+      <div className="grid grid-cols-4">
+        <div className="px-5 py-4">
+          <div className="text-[12px] text-text-muted mb-1">보유종목 평가금액</div>
+          <div className="text-[22px] font-bold">{formatKRW(summary.ante_eval_amount)}</div>
+        </div>
+        <div className="px-5 py-4">
+          <div className="text-[12px] text-text-muted mb-1">보유종목 손익</div>
+          <div className={`text-[22px] font-bold ${holdingProfitColor}`}>{formatKRW(summary.ante_profit_loss)}</div>
+        </div>
+        <div className="px-5 py-4">
+          <div className="text-[12px] text-text-muted mb-1">체결대기 자금</div>
+          <div className="text-[22px] font-bold text-text-muted">{formatKRW(summary.total_reserved)}</div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/treasury/BudgetTable.tsx
+++ b/frontend/src/components/treasury/BudgetTable.tsx
@@ -1,34 +1,48 @@
-import { formatKRW } from '../../utils/formatters'
+import { Link } from 'react-router-dom'
+import { formatKRW, formatPercent } from '../../utils/formatters'
 import type { BotBudget } from '../../types/treasury'
 
 export default function BudgetTable({ budgets }: { budgets: BotBudget[] }) {
   return (
     <div className="bg-surface border border-border rounded-lg p-5 mb-6">
-      <h3 className="text-[15px] font-semibold mb-4">봇별 예산</h3>
+      <h3 className="text-[15px] font-semibold mb-4">Bot당 예산</h3>
       <div className="overflow-x-auto">
         <table className="w-full border-collapse">
           <thead>
             <tr>
-              <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">봇 ID</th>
-              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">할당액</th>
-              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">가용액</th>
-              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">예약액</th>
-              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">사용액</th>
+              <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">Bot ID</th>
+              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">배정예산</th>
+              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">사용예산</th>
+              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">잔여예산</th>
+              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">체결대기</th>
+              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">회수금</th>
+              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">손익</th>
+              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">예산 수익률</th>
             </tr>
           </thead>
           <tbody>
             {budgets.length === 0 ? (
-              <tr><td colSpan={5} className="px-3 py-8 text-center text-text-muted text-[13px]">할당된 봇이 없습니다</td></tr>
+              <tr><td colSpan={8} className="px-3 py-8 text-center text-text-muted text-[13px]">할당된 봇이 없습니다</td></tr>
             ) : (
-              budgets.map((b) => (
-                <tr key={b.bot_id} className="hover:bg-surface-hover">
-                  <td className="px-3 py-3 border-b border-border text-[13px] font-mono">{b.bot_id}</td>
-                  <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.allocated)}</td>
-                  <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.available)}</td>
-                  <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.reserved)}</td>
-                  <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.used)}</td>
-                </tr>
-              ))
+              budgets.map((b) => {
+                const pnl = b.returned - b.spent
+                const pnlColor = pnl >= 0 ? 'text-positive' : 'text-negative'
+                const budgetRoi = b.allocated > 0 ? pnl / b.allocated : 0
+                return (
+                  <tr key={b.bot_id} className="hover:bg-surface-hover">
+                    <td className="px-3 py-3 border-b border-border text-[13px]">
+                      <Link to={`/bots/${b.bot_id}`} className="text-primary no-underline hover:underline font-mono">{b.bot_id}</Link>
+                    </td>
+                    <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.allocated)}</td>
+                    <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.spent)}</td>
+                    <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.available)}</td>
+                    <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.reserved)}</td>
+                    <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.returned)}</td>
+                    <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${pnlColor}`}>{formatKRW(pnl)}</td>
+                    <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${pnlColor}`}>{formatPercent(budgetRoi)}</td>
+                  </tr>
+                )
+              })
             )}
           </tbody>
         </table>

--- a/frontend/src/components/treasury/RecentTransactions.tsx
+++ b/frontend/src/components/treasury/RecentTransactions.tsx
@@ -1,0 +1,53 @@
+import { Link } from 'react-router-dom'
+import { useTreasuryTransactions } from '../../hooks/useTreasury'
+import { formatKRW, formatDateTime } from '../../utils/formatters'
+import { TRANSACTION_TYPE_LABELS, TRANSACTION_TYPE_VARIANT } from '../../utils/constants'
+import StatusBadge from '../common/StatusBadge'
+
+export default function RecentTransactions() {
+  const { data } = useTreasuryTransactions({ limit: 5 })
+  const items = data?.items ?? []
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-[15px] font-semibold">최근 자금 변동</h3>
+        <Link to="/treasury/history" className="text-[13px] text-primary no-underline hover:underline">전체 보기 →</Link>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr>
+              <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">시각</th>
+              <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">유형</th>
+              <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">Bot</th>
+              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">금액</th>
+              <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">비고</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.length === 0 ? (
+              <tr><td colSpan={5} className="px-3 py-8 text-center text-text-muted text-[13px]">변동 이력이 없습니다</td></tr>
+            ) : (
+              items.map((tx) => (
+                <tr key={tx.id} className="hover:bg-surface-hover">
+                  <td className="px-3 py-3 border-b border-border text-[13px] font-mono text-text-muted">{formatDateTime(tx.created_at)}</td>
+                  <td className="px-3 py-3 border-b border-border text-[13px]">
+                    <StatusBadge variant={TRANSACTION_TYPE_VARIANT[tx.type] ?? 'default'}>
+                      {TRANSACTION_TYPE_LABELS[tx.type] ?? tx.type}
+                    </StatusBadge>
+                  </td>
+                  <td className="px-3 py-3 border-b border-border text-[13px] font-mono">{tx.bot_id || '-'}</td>
+                  <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${tx.type === 'allocate' ? 'text-positive' : tx.type === 'deallocate' ? 'text-negative' : ''}`}>
+                    {tx.type === 'allocate' ? '+' : ''}{formatKRW(tx.amount)}
+                  </td>
+                  <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{tx.description}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useTreasury.ts
+++ b/frontend/src/hooks/useTreasury.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getTreasurySummary, getBotBudgets, allocateBudget, deallocateBudget, getTreasuryHistory } from '../api/treasury'
+import { getTreasurySummary, getBotBudgets, allocateBudget, deallocateBudget, getTreasuryTransactions } from '../api/treasury'
 
 export function useTreasurySummary() {
   return useQuery({
@@ -35,9 +35,14 @@ export function useDeallocateBudget() {
   })
 }
 
-export function useTreasuryHistory(offset = 0, limit = 20) {
+export function useTreasuryTransactions(params: {
+  offset?: number
+  limit?: number
+  type?: string
+  bot_id?: string
+}) {
   return useQuery({
-    queryKey: ['treasury', 'history', offset, limit],
-    queryFn: () => getTreasuryHistory({ offset, limit }),
+    queryKey: ['treasury', 'transactions', params],
+    queryFn: () => getTreasuryTransactions(params),
   })
 }

--- a/frontend/src/pages/Treasury.tsx
+++ b/frontend/src/pages/Treasury.tsx
@@ -1,8 +1,9 @@
-import { Link } from 'react-router-dom'
 import { useTreasurySummary, useBotBudgets } from '../hooks/useTreasury'
 import AccountSummary from '../components/treasury/AccountSummary'
+import AnteSummary from '../components/treasury/AnteSummary'
 import BudgetTable from '../components/treasury/BudgetTable'
 import AllocationForm from '../components/treasury/AllocationForm'
+import RecentTransactions from '../components/treasury/RecentTransactions'
 import { PageSkeleton } from '../components/common/Skeleton'
 
 export default function Treasury() {
@@ -11,21 +12,26 @@ export default function Treasury() {
 
   if (summaryLoading || budgetsLoading) return <PageSkeleton />
 
-  const botIds = (budgets ?? []).map((b) => b.bot_id)
-
   return (
     <>
       {summary && <AccountSummary summary={summary} />}
-      <BudgetTable budgets={budgets ?? []} />
-      {botIds.length > 0 && <AllocationForm botIds={botIds} />}
-      <div className="mt-4">
-        <Link
-          to="/treasury/history"
-          className="text-[13px] text-primary no-underline hover:underline"
-        >
-          거래 이력 보기 →
-        </Link>
+      {summary && <AnteSummary summary={summary} />}
+
+      <div className="grid grid-cols-[1fr_1fr] gap-6 mb-6">
+        {/* 파이 차트 자리 */}
+        <div className="bg-surface border border-border rounded-lg p-5">
+          <h3 className="text-[15px] font-semibold mb-4">Bot 예산 비중</h3>
+          <div className="flex items-center justify-center h-[240px] text-text-muted text-[13px] border border-dashed border-border rounded-lg">
+            📊 파이 차트 — Bot별 예산 비중
+          </div>
+        </div>
+
+        {/* 예산 관리 폼 */}
+        {(budgets ?? []).length > 0 && <AllocationForm budgets={budgets ?? []} />}
       </div>
+
+      <BudgetTable budgets={budgets ?? []} />
+      <RecentTransactions />
     </>
   )
 }

--- a/frontend/src/pages/TreasuryHistory.tsx
+++ b/frontend/src/pages/TreasuryHistory.tsx
@@ -1,55 +1,114 @@
 import { useState } from 'react'
-import { useTreasuryHistory } from '../hooks/useTreasury'
+import { useTreasuryTransactions, useBotBudgets } from '../hooks/useTreasury'
 import { formatKRW, formatDateTime } from '../utils/formatters'
+import { TRANSACTION_TYPE_LABELS, TRANSACTION_TYPE_VARIANT } from '../utils/constants'
+import StatusBadge from '../components/common/StatusBadge'
 import Pagination from '../components/common/Pagination'
 import { TableSkeleton } from '../components/common/Skeleton'
 
 const LIMIT = 20
+const TYPE_TABS = [
+  { value: '', label: '전체' },
+  { value: 'allocate', label: '할당' },
+  { value: 'deallocate', label: '회수' },
+  { value: 'fill', label: '체결' },
+]
 
 export default function TreasuryHistory() {
+  const [typeFilter, setTypeFilter] = useState('')
+  const [botFilter, setBotFilter] = useState('')
   const [offset, setOffset] = useState(0)
-  const { data, isLoading } = useTreasuryHistory(offset, LIMIT)
+
+  const { data: budgets } = useBotBudgets()
+  const botIds = (budgets ?? []).map((b) => b.bot_id)
+
+  const { data, isLoading } = useTreasuryTransactions({
+    offset,
+    limit: LIMIT,
+    type: typeFilter || undefined,
+    bot_id: botFilter || undefined,
+  })
+
+  const handleTypeChange = (t: string) => { setTypeFilter(t); setOffset(0) }
+  const handleBotChange = (b: string) => { setBotFilter(b); setOffset(0) }
 
   return (
-    <div className="bg-surface border border-border rounded-lg p-5">
-      <h3 className="text-[15px] font-semibold mb-4">자금 거래 이력</h3>
-      {isLoading ? (
-        <TableSkeleton rows={5} cols={5} />
-      ) : (
-        <>
-          <div className="overflow-x-auto">
-            <table className="w-full border-collapse">
-              <thead>
-                <tr>
-                  <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">유형</th>
-                  <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">봇 ID</th>
-                  <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">금액</th>
-                  <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">설명</th>
-                  <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">일시</th>
-                </tr>
-              </thead>
-              <tbody>
-                {(data?.items ?? []).length === 0 ? (
-                  <tr><td colSpan={5} className="px-3 py-8 text-center text-text-muted text-[13px]">이력이 없습니다</td></tr>
-                ) : (
-                  (data?.items ?? []).map((tx) => (
-                    <tr key={tx.id} className="hover:bg-surface-hover">
-                      <td className="px-3 py-3 border-b border-border text-[13px]">{tx.type}</td>
-                      <td className="px-3 py-3 border-b border-border text-[13px] font-mono">{tx.bot_id || '-'}</td>
-                      <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(tx.amount)}</td>
-                      <td className="px-3 py-3 border-b border-border text-[13px]">{tx.description}</td>
-                      <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{formatDateTime(tx.created_at)}</td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
-          {(data?.total ?? 0) > LIMIT && (
-            <Pagination total={data?.total ?? 0} offset={offset} limit={LIMIT} onPageChange={setOffset} />
-          )}
-        </>
-      )}
-    </div>
+    <>
+      {/* 필터 */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex gap-1">
+          {TYPE_TABS.map((tab) => (
+            <button
+              key={tab.value}
+              onClick={() => handleTypeChange(tab.value)}
+              className={`px-3 py-1.5 rounded-lg text-[13px] font-medium border-none cursor-pointer transition-colors ${
+                typeFilter === tab.value
+                  ? 'bg-primary text-white'
+                  : 'bg-transparent text-text-muted hover:bg-surface-hover hover:text-text'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <select
+          value={botFilter}
+          onChange={(e) => handleBotChange(e.target.value)}
+          className="bg-bg border border-border rounded-lg px-3 py-1.5 text-text text-[13px] cursor-pointer"
+        >
+          <option value="">전체 Bot</option>
+          {botIds.map((id) => (
+            <option key={id} value={id}>{id}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* 이력 테이블 */}
+      <div className="bg-surface border border-border rounded-lg p-5">
+        {isLoading ? (
+          <TableSkeleton rows={5} cols={5} />
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr>
+                    <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">시각</th>
+                    <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">유형</th>
+                    <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">Bot</th>
+                    <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">금액</th>
+                    <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">비고</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(data?.items ?? []).length === 0 ? (
+                    <tr><td colSpan={5} className="px-3 py-8 text-center text-text-muted text-[13px]">이력이 없습니다</td></tr>
+                  ) : (
+                    (data?.items ?? []).map((tx) => (
+                      <tr key={tx.id} className="hover:bg-surface-hover">
+                        <td className="px-3 py-3 border-b border-border text-[13px] font-mono text-text-muted">{formatDateTime(tx.created_at)}</td>
+                        <td className="px-3 py-3 border-b border-border text-[13px]">
+                          <StatusBadge variant={TRANSACTION_TYPE_VARIANT[tx.type] ?? 'muted'}>
+                            {TRANSACTION_TYPE_LABELS[tx.type] ?? tx.type}
+                          </StatusBadge>
+                        </td>
+                        <td className="px-3 py-3 border-b border-border text-[13px] font-mono">{tx.bot_id || '-'}</td>
+                        <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${tx.type === 'allocate' ? 'text-positive' : tx.type === 'deallocate' ? 'text-negative' : ''}`}>
+                          {tx.type === 'allocate' ? '+' : ''}{formatKRW(tx.amount)}
+                        </td>
+                        <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{tx.description}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+            {(data?.total ?? 0) > LIMIT && (
+              <Pagination total={data?.total ?? 0} offset={offset} limit={LIMIT} onPageChange={setOffset} />
+            )}
+          </>
+        )}
+      </div>
+    </>
   )
 }

--- a/frontend/src/types/treasury.ts
+++ b/frontend/src/types/treasury.ts
@@ -1,8 +1,21 @@
 export interface TreasurySummary {
-  total_balance: number
-  allocated: number
+  // KIS 계좌
+  account_balance: number
+  purchasable_amount: number
+  total_evaluation: number
+  total_profit_loss: number
+  commission_rate: number
+  sell_tax_rate: number
+  // Ante 관리자산
+  total_allocated: number
+  total_reserved: number
+  total_available: number
   unallocated: number
-  reserved: number
+  bot_count: number
+  ante_purchase_amount: number
+  ante_eval_amount: number
+  ante_profit_loss: number
+  budget_exceeds_purchasable: boolean
 }
 
 export interface BotBudget {
@@ -10,12 +23,15 @@ export interface BotBudget {
   allocated: number
   available: number
   reserved: number
-  used: number
+  spent: number
+  returned: number
 }
+
+export type TransactionType = 'allocate' | 'deallocate' | 'fill' | 'bot_stopped_release'
 
 export interface TreasuryTransaction {
   id: number
-  type: 'allocate' | 'deallocate' | 'trade' | 'deposit' | 'withdrawal'
+  type: TransactionType
   bot_id?: string
   amount: number
   description: string

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -32,3 +32,19 @@ export const MEMBER_STATUS_LABELS: Record<string, string> = {
   suspended: '정지',
   revoked: '폐기',
 }
+
+/** 자금 변동 유형 라벨 */
+export const TRANSACTION_TYPE_LABELS: Record<string, string> = {
+  allocate: '할당',
+  deallocate: '회수',
+  fill: '체결',
+  bot_stopped_release: '예약해제',
+}
+
+/** 자금 변동 유형 뱃지 색상 */
+export const TRANSACTION_TYPE_VARIANT: Record<string, string> = {
+  allocate: 'positive',
+  deallocate: 'warning',
+  fill: 'primary',
+  bot_stopped_release: 'default',
+}

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -26,7 +26,64 @@ async def get_summary(request: Request) -> dict:
     treasury = getattr(request.app.state, "treasury", None)
     if treasury is None:
         raise HTTPException(status_code=503, detail="Treasury not available")
-    return treasury.get_summary()
+    summary = treasury.get_summary()
+    summary["commission_rate"] = getattr(treasury, "commission_rate", 0.00015)
+    summary["sell_tax_rate"] = getattr(treasury, "sell_tax_rate", 0.0023)
+    return summary
+
+
+@router.get("/transactions")
+async def list_transactions(
+    request: Request,
+    type: str | None = None,
+    bot_id: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict:
+    """자금 변동 이력 조회."""
+    treasury = getattr(request.app.state, "treasury", None)
+    if treasury is None:
+        raise HTTPException(status_code=503, detail="Treasury not available")
+
+    db = getattr(treasury, "_db", None)
+    if db is None:
+        return {"items": [], "total": 0}
+
+    where_clauses: list[str] = []
+    params: list[str | int] = []
+
+    if type:
+        where_clauses.append("transaction_type = ?")
+        params.append(type)
+    if bot_id:
+        where_clauses.append("bot_id = ?")
+        params.append(bot_id)
+
+    where_sql = (" WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+
+    count_row = await db.fetch_one(
+        f"SELECT COUNT(*) as cnt FROM treasury_transactions{where_sql}",
+        tuple(params),
+    )
+    total = count_row["cnt"] if count_row else 0
+
+    query = (
+        f"SELECT * FROM treasury_transactions{where_sql}"
+        " ORDER BY created_at DESC LIMIT ? OFFSET ?"
+    )
+    rows = await db.fetch_all(query, (*params, limit, offset))
+    items = [
+        {
+            "id": r["id"],
+            "type": r["transaction_type"],
+            "bot_id": r["bot_id"],
+            "amount": r["amount"],
+            "description": r["description"],
+            "created_at": r["created_at"],
+        }
+        for r in rows
+    ]
+    return {"items": items, "total": total}
 
 
 @router.post("/bots/{bot_id}/allocate")


### PR DESCRIPTION
## Summary
- KIS 계좌 요약 카드 + Ante 관리자산 요약 섹션 구현
- Bot 예산 테이블 확장 (손익/수익률), 파이 차트 플레이스홀더
- 예산 관리 폼에 현재 예산 + 확인 모달 추가
- 최근 자금 변동 인라인 테이블, 이력 페이지 필터/뱃지 개선
- 백엔드 `GET /api/treasury/transactions` 엔드포인트 추가

Closes #215

## Test plan
- [ ] KIS 계좌 요약 카드에 수수료율, 통계 4개 표시 확인
- [ ] Ante 관리자산 요약 7개 통계 + 불일치 경고 배너 확인
- [ ] Bot 예산 테이블 8개 컬럼 확인
- [ ] 예산 관리 폼 현재 예산 표시 + 확인 모달 동작 확인
- [ ] 최근 자금 변동 테이블 + 전체 보기 링크 확인
- [ ] 이력 페이지 유형/Bot 필터 동작 확인
- [ ] 이력 테이블 시각 첫 번째 + 유형 뱃지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)