### PR TITLE
feat(#231): 봇 상세 예산 카드·보유종목 테이블 데이터 연동

### DIFF
--- a/frontend/src/pages/BotDetail.tsx
+++ b/frontend/src/pages/BotDetail.tsx
@@ -3,7 +3,7 @@ import { useParams, Link } from 'react-router-dom'
 import { useBotDetail, useBotControl } from '../hooks/useBots'
 import StatusBadge from '../components/common/StatusBadge'
 import { PageSkeleton } from '../components/common/Skeleton'
-import { formatKRW, formatDateTime } from '../utils/formatters'
+import { formatKRW, formatDateTime, formatPercent } from '../utils/formatters'
 import { BOT_STATUS_LABELS } from '../utils/constants'
 import type { BotStatus, BotDetail as BotDetailType } from '../types/bot'
 
@@ -117,20 +117,20 @@ export default function BotDetail() {
           <h3 className="text-[15px] font-semibold mb-3">예산</h3>
           <div className="space-y-2">
             <div className="flex justify-between py-1.5 text-[13px]">
-              <span className="text-text-muted">배정 금액</span>
-              <span>{formatKRW(bot.allocated_budget)}</span>
+              <span className="text-text-muted">배정금액</span>
+              <span>{formatKRW(bot.budget?.allocated ?? bot.allocated_budget)}</span>
             </div>
             <div className="flex justify-between py-1.5 text-[13px]">
-              <span className="text-text-muted">매수 금액</span>
-              <span>-</span>
+              <span className="text-text-muted">매수금액</span>
+              <span>{bot.budget ? formatKRW(bot.budget.spent) : '-'}</span>
             </div>
             <div className="flex justify-between py-1.5 text-[13px]">
-              <span className="text-text-muted">체결 대기</span>
-              <span>-</span>
+              <span className="text-text-muted">체결대기</span>
+              <span>{bot.budget ? formatKRW(bot.budget.reserved) : '-'}</span>
             </div>
             <div className="flex justify-between py-1.5 text-[13px]">
-              <span className="text-text-muted">잔여 예산</span>
-              <span>-</span>
+              <span className="text-text-muted">잔여예산</span>
+              <span>{bot.budget ? formatKRW(bot.budget.available) : '-'}</span>
             </div>
           </div>
         </div>
@@ -151,10 +151,42 @@ export default function BotDetail() {
                 <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">평가금액</th>
                 <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">미실현 손익</th>
                 <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">수익률</th>
+                <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">실현 손익</th>
               </tr>
             </thead>
             <tbody>
-              <tr><td colSpan={8} className="px-3 py-6 text-center text-text-muted text-[13px]">보유 종목이 없습니다</td></tr>
+              {(!bot.positions || bot.positions.length === 0) ? (
+                <tr><td colSpan={9} className="px-3 py-6 text-center text-text-muted text-[13px]">보유 종목이 없습니다</td></tr>
+              ) : (
+                bot.positions.map((pos) => {
+                  const isClosed = pos.quantity === 0
+                  const cost = isClosed ? 0 : pos.quantity * pos.avg_entry_price
+                  const evalAmount = isClosed ? 0 : pos.quantity * (pos.current_price ?? pos.avg_entry_price)
+                  const unrealizedPnl = isClosed ? 0 : evalAmount - cost
+                  const returnRate = isClosed ? 0 : cost > 0 ? unrealizedPnl / cost : 0
+                  const pnlColor = (v: number) => v > 0 ? 'text-positive' : v < 0 ? 'text-negative' : 'text-text-muted'
+
+                  return (
+                    <tr key={pos.symbol} className="border-b border-border">
+                      <td className="px-3 py-2 text-[13px]">{pos.symbol}</td>
+                      <td className="text-right px-3 py-2 text-[13px]">{pos.quantity}</td>
+                      <td className="text-right px-3 py-2 text-[13px]">{isClosed ? '—' : formatKRW(pos.avg_entry_price)}</td>
+                      <td className="text-right px-3 py-2 text-[13px]">{isClosed ? '—' : formatKRW(pos.current_price ?? pos.avg_entry_price)}</td>
+                      <td className="text-right px-3 py-2 text-[13px]">{isClosed ? '—' : formatKRW(cost)}</td>
+                      <td className="text-right px-3 py-2 text-[13px]">{isClosed ? '—' : formatKRW(evalAmount)}</td>
+                      <td className={`text-right px-3 py-2 text-[13px] ${isClosed ? 'text-text-muted' : pnlColor(unrealizedPnl)}`}>
+                        {isClosed ? '—' : formatKRW(unrealizedPnl)}
+                      </td>
+                      <td className={`text-right px-3 py-2 text-[13px] ${isClosed ? 'text-text-muted' : pnlColor(returnRate)}`}>
+                        {isClosed ? '—' : formatPercent(returnRate)}
+                      </td>
+                      <td className={`text-right px-3 py-2 text-[13px] ${pnlColor(pos.realized_pnl)}`}>
+                        {formatKRW(pos.realized_pnl)}
+                      </td>
+                    </tr>
+                  )
+                })
+              )}
             </tbody>
           </table>
         </div>

--- a/frontend/src/types/bot.ts
+++ b/frontend/src/types/bot.ts
@@ -17,12 +17,29 @@ export interface BotStrategy {
   description: string
 }
 
+export interface BotBudgetDetail {
+  allocated: number
+  spent: number
+  reserved: number
+  available: number
+}
+
+export interface BotPosition {
+  symbol: string
+  quantity: number
+  avg_entry_price: number
+  current_price?: number
+  realized_pnl: number
+}
+
 export interface BotDetail extends Bot {
   interval_seconds: number
   symbols: string[]
   allocated_budget: number
   logs: BotLog[]
   strategy?: BotStrategy
+  budget?: BotBudgetDetail
+  positions?: BotPosition[]
 }
 
 export interface BotLog {

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -107,6 +107,34 @@ async def get_bot(request: Request, bot_id: str) -> dict:
                 "description": record.description,
             }
 
+    # 예산 정보 추가
+    treasury = getattr(request.app.state, "treasury", None)
+    if treasury is not None:
+        budget = await treasury.get_budget(bot_id)
+        if budget:
+            info["budget"] = {
+                "allocated": budget.allocated,
+                "spent": budget.spent,
+                "reserved": budget.reserved,
+                "available": budget.available,
+            }
+
+    # 포지션 정보 추가
+    trade_service = getattr(request.app.state, "trade_service", None)
+    if trade_service is not None:
+        positions = await trade_service.get_positions(
+            bot_id=bot_id, include_closed=True
+        )
+        info["positions"] = [
+            {
+                "symbol": p.symbol,
+                "quantity": p.quantity,
+                "avg_entry_price": p.avg_entry_price,
+                "realized_pnl": p.realized_pnl,
+            }
+            for p in positions
+        ]
+
     return {"bot": info}
 
 

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -79,14 +79,92 @@ class FakeBotManager:
             del self._bots[bot_id]
 
 
+class FakeBotBudget:
+    """테스트용 BotBudget stub."""
+
+    def __init__(
+        self,
+        bot_id: str,
+        allocated: float = 0.0,
+        spent: float = 0.0,
+        reserved: float = 0.0,
+        available: float = 0.0,
+    ) -> None:
+        self.bot_id = bot_id
+        self.allocated = allocated
+        self.spent = spent
+        self.reserved = reserved
+        self.available = available
+
+
+class FakeTreasury:
+    """테스트용 Treasury stub."""
+
+    def __init__(self) -> None:
+        self._budgets: dict[str, FakeBotBudget] = {}
+
+    async def get_budget(self, bot_id: str) -> FakeBotBudget | None:
+        return self._budgets.get(bot_id)
+
+
+class FakePositionSnapshot:
+    """테스트용 PositionSnapshot stub."""
+
+    def __init__(
+        self,
+        bot_id: str,
+        symbol: str,
+        quantity: float,
+        avg_entry_price: float,
+        realized_pnl: float = 0.0,
+    ) -> None:
+        self.bot_id = bot_id
+        self.symbol = symbol
+        self.quantity = quantity
+        self.avg_entry_price = avg_entry_price
+        self.realized_pnl = realized_pnl
+
+
+class FakeTradeService:
+    """테스트용 TradeService stub."""
+
+    def __init__(self) -> None:
+        self._positions: dict[str, list[FakePositionSnapshot]] = {}
+
+    async def get_positions(
+        self, bot_id: str, include_closed: bool = False
+    ) -> list[FakePositionSnapshot]:
+        return self._positions.get(bot_id, [])
+
+
 @pytest.fixture
 def bot_manager():
     return FakeBotManager()
 
 
 @pytest.fixture
+def treasury():
+    return FakeTreasury()
+
+
+@pytest.fixture
+def trade_service():
+    return FakeTradeService()
+
+
+@pytest.fixture
 def client(bot_manager):
     app = create_app(bot_manager=bot_manager)
+    return TestClient(app)
+
+
+@pytest.fixture
+def client_with_services(bot_manager, treasury, trade_service):
+    app = create_app(
+        bot_manager=bot_manager,
+        treasury=treasury,
+        trade_service=trade_service,
+    )
     return TestClient(app)
 
 
@@ -158,6 +236,68 @@ class TestDeleteBot:
         """존재하지 않는 봇 삭제 → 404."""
         resp = client.delete("/api/bots/nonexistent")
         assert resp.status_code == 404
+
+
+class TestGetBotWithBudget:
+    def test_budget_included(self, client_with_services, bot_manager, treasury):
+        """봇 상세 조회 시 예산 정보 포함."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1")
+        treasury._budgets["bot-1"] = FakeBotBudget(
+            bot_id="bot-1",
+            allocated=15_000_000,
+            spent=5_000_000,
+            reserved=1_500_000,
+            available=8_500_000,
+        )
+        resp = client_with_services.get("/api/bots/bot-1")
+        assert resp.status_code == 200
+        budget = resp.json()["bot"]["budget"]
+        assert budget["allocated"] == 15_000_000
+        assert budget["spent"] == 5_000_000
+        assert budget["reserved"] == 1_500_000
+        assert budget["available"] == 8_500_000
+
+    def test_no_budget(self, client_with_services, bot_manager):
+        """예산 미할당 봇은 budget 필드 없음."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1")
+        resp = client_with_services.get("/api/bots/bot-1")
+        assert resp.status_code == 200
+        assert "budget" not in resp.json()["bot"]
+
+
+class TestGetBotWithPositions:
+    def test_positions_included(self, client_with_services, bot_manager, trade_service):
+        """봇 상세 조회 시 포지션 정보 포함."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1")
+        trade_service._positions["bot-1"] = [
+            FakePositionSnapshot("bot-1", "005930", 50, 72300.0, 0.0),
+            FakePositionSnapshot("bot-1", "035420", 15, 210000.0, 0.0),
+            FakePositionSnapshot("bot-1", "035720", 0, 0.0, 45000.0),
+        ]
+        resp = client_with_services.get("/api/bots/bot-1")
+        assert resp.status_code == 200
+        positions = resp.json()["bot"]["positions"]
+        assert len(positions) == 3
+        assert positions[0]["symbol"] == "005930"
+        assert positions[0]["quantity"] == 50
+        assert positions[0]["avg_entry_price"] == 72300.0
+        # 청산 완료 종목
+        assert positions[2]["quantity"] == 0
+        assert positions[2]["realized_pnl"] == 45000.0
+
+    def test_no_positions(self, client_with_services, bot_manager, trade_service):
+        """포지션 없는 봇은 빈 배열."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1")
+        resp = client_with_services.get("/api/bots/bot-1")
+        assert resp.status_code == 200
+        assert resp.json()["bot"]["positions"] == []
+
+    def test_no_trade_service(self, client, bot_manager):
+        """trade_service 없으면 positions 필드 없음."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1")
+        resp = client.get("/api/bots/bot-1")
+        assert resp.status_code == 200
+        assert "positions" not in resp.json()["bot"]
 
 
 class TestBotLifecycle:


### PR DESCRIPTION
## Summary
- API `GET /api/bots/{bot_id}` 응답에 `budget`(배정·매수·체결대기·잔여) 및 `positions`(종목·수량·평균단가·실현손익) 필드 추가
- `BotDetail` 타입에 `BotBudgetDetail`, `BotPosition` 인터페이스 추가
- 예산 카드에 실제 값 바인딩, 보유종목 테이블 9열(실현 손익 추가) 구현, 청산 완료 종목 "—" 표시 처리
- 예산/포지션 API 응답 검증 테스트 5개 추가

Closes #231

## Test plan
- [x] `test_bot_api.py` — 16개 테스트 통과 (신규 5개 포함)
- [x] 전체 테스트 스위트 1310 passed
- [x] TypeScript 타입 체크 통과
- [x] ruff lint/format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)