### PR TITLE
feat(#238): 멤버 관리 상태 필터 탭 및 소속 필터 위치 수정

### DIFF
--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -3,9 +3,18 @@ import { useMembers, useMemberControl } from '../hooks/useMembers'
 import MemberCard from '../components/agents/MemberCard'
 import AgentRegisterForm from '../components/agents/AgentRegisterForm'
 import { TableSkeleton } from '../components/common/Skeleton'
+import type { MemberStatus } from '../types/member'
+
+const STATUS_TABS: { label: string; value: MemberStatus | 'all' }[] = [
+  { label: '전체', value: 'all' },
+  { label: 'active', value: 'active' },
+  { label: 'suspended', value: 'suspended' },
+  { label: 'revoked', value: 'revoked' },
+]
 
 export default function Agents() {
   const [orgFilter, setOrgFilter] = useState<string>('all')
+  const [statusFilter, setStatusFilter] = useState<MemberStatus | 'all'>('all')
   const [showRegister, setShowRegister] = useState(false)
   const [createdToken, setCreatedToken] = useState<string | null>(null)
 
@@ -24,29 +33,16 @@ export default function Agents() {
   const filterByOrg = (items: typeof allItems) =>
     orgFilter === 'all' ? items : items.filter((m) => m.org === orgFilter)
 
+  const filterAgents = (items: typeof allItems) => {
+    let filtered = filterByOrg(items)
+    if (statusFilter !== 'all') {
+      filtered = filtered.filter((m) => m.status === statusFilter)
+    }
+    return filtered
+  }
+
   return (
     <>
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center gap-3">
-          <select
-            value={orgFilter}
-            onChange={(e) => setOrgFilter(e.target.value)}
-            className="bg-bg border border-border rounded-lg px-3 py-1.5 text-text text-[13px] cursor-pointer"
-          >
-            <option value="all">전체 소속</option>
-            {orgs.map((org) => (
-              <option key={org} value={org}>{org}</option>
-            ))}
-          </select>
-        </div>
-        <button
-          onClick={() => setShowRegister(true)}
-          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
-        >
-          멤버 등록
-        </button>
-      </div>
-
       {isLoading ? (
         <TableSkeleton rows={3} cols={3} />
       ) : (
@@ -55,13 +51,13 @@ export default function Agents() {
           <div className="mb-8">
             <div className="flex items-center gap-2 text-[15px] font-semibold text-text-muted mb-4">
               Human 멤버
-              <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded-full">{filterByOrg(humans).length}</span>
+              <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded-full">{humans.length}</span>
             </div>
-            {filterByOrg(humans).length === 0 ? (
+            {humans.length === 0 ? (
               <div className="text-[13px] text-text-muted py-6 text-center">Human 멤버가 없습니다</div>
             ) : (
               <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4">
-                {filterByOrg(humans).map((m) => (
+                {humans.map((m) => (
                   <MemberCard key={m.member_id} member={m} />
                 ))}
               </div>
@@ -72,13 +68,51 @@ export default function Agents() {
           <div className="mb-8">
             <div className="flex items-center gap-2 text-[15px] font-semibold text-text-muted mb-4">
               Agent 멤버
-              <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded-full">{filterByOrg(agents).length}</span>
+              <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded-full">{agents.length}</span>
+              <div className="ml-auto">
+                <button
+                  onClick={() => setShowRegister(true)}
+                  className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
+                >
+                  + 에이전트 등록
+                </button>
+              </div>
             </div>
-            {filterByOrg(agents).length === 0 ? (
+
+            {/* 필터 영역: 상태 탭 + 소속 셀렉트 */}
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex gap-1">
+                {STATUS_TABS.map((tab) => (
+                  <button
+                    key={tab.value}
+                    onClick={() => setStatusFilter(tab.value)}
+                    className={`px-3 py-1.5 rounded-lg text-[13px] font-medium border cursor-pointer transition-colors ${
+                      statusFilter === tab.value
+                        ? 'bg-primary text-white border-primary'
+                        : 'bg-transparent text-text-muted border-border hover:bg-surface-hover'
+                    }`}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
+              <select
+                value={orgFilter}
+                onChange={(e) => setOrgFilter(e.target.value)}
+                className="bg-bg border border-border rounded-lg px-3 py-1.5 text-text text-[13px] cursor-pointer"
+              >
+                <option value="all">전체 소속</option>
+                {orgs.map((org) => (
+                  <option key={org} value={org}>{org}</option>
+                ))}
+              </select>
+            </div>
+
+            {filterAgents(agents).length === 0 ? (
               <div className="text-[13px] text-text-muted py-6 text-center">Agent 멤버가 없습니다</div>
             ) : (
               <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4">
-                {filterByOrg(agents).map((m) => (
+                {filterAgents(agents).map((m) => (
                   <MemberCard
                     key={m.member_id}
                     member={m}


### PR DESCRIPTION
## Summary
- Agent 섹션에 상태 필터 탭 4개(전체/active/suspended/revoked) 추가, "전체" 기본 선택
- 소속 드롭다운을 상단에서 Agent 섹션 필터 영역 내로 이동
- 상태 + 소속 복합 필터 동작 구현
- 등록 버튼 라벨을 "+ 에이전트 등록"으로 목업과 일치시킴

Closes #238

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] ESLint 통과
- [ ] E2E 시나리오 flow-member-management.md 섹션 6, 10, 11 수동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)