### PR TITLE
feat(#244): 설정 HALTED 정지 시각·사유 및 금액 단위 토글

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -83,6 +83,13 @@ export default function Settings() {
             <div className="flex items-center justify-between py-3">
               <div>
                 <div className="text-[13px] text-negative font-semibold">거래가 정지되었습니다</div>
+                {(status?.halt_time || status?.halt_reason) && (
+                  <div className="text-[12px] text-text-muted mt-1">
+                    {status.halt_time && `정지 시각: ${status.halt_time}`}
+                    {status.halt_time && status.halt_reason && ' · '}
+                    {status.halt_reason && `사유: ${status.halt_reason}`}
+                  </div>
+                )}
               </div>
               <button
                 onClick={handleActivate}
@@ -169,6 +176,25 @@ export default function Settings() {
       <div className="bg-surface border border-border rounded-lg p-5">
         <h3 className="text-[15px] font-semibold mb-4">표시 및 알림</h3>
         <div className="space-y-0">
+          {/* 금액 단위 위치 토글 */}
+          <div className="flex items-center justify-between py-3 border-b border-border">
+            <div>
+              <div className="text-[13px] font-medium">금액 단위 위치</div>
+              <div className="text-[12px] text-text-muted mt-0.5">금액 표시 시 통화 단위(원)의 위치를 설정합니다</div>
+            </div>
+            <div className="flex gap-2">
+              <CurrencyFormatButton
+                label="₩ 1,000,000"
+                active={getConfigValue('display.currency_position') === 'prefix'}
+                onClick={() => updateConfig.mutate({ key: 'display.currency_position', value: 'prefix' })}
+              />
+              <CurrencyFormatButton
+                label="1,000,000 원"
+                active={getConfigValue('display.currency_position') !== 'prefix'}
+                onClick={() => updateConfig.mutate({ key: 'display.currency_position', value: 'suffix' })}
+              />
+            </div>
+          </div>
           {DISPLAY_CONFIGS.map((cfg) => (
             <div key={cfg.key} className="flex items-center justify-between py-3 border-b border-border last:border-b-0">
               <div>
@@ -236,5 +262,20 @@ export default function Settings() {
         </div>
       )}
     </>
+  )
+}
+
+function CurrencyFormatButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-3 py-1.5 rounded-lg text-[13px] font-medium border cursor-pointer transition-colors ${
+        active
+          ? 'bg-primary text-white border-primary'
+          : 'bg-transparent text-text-muted border-border hover:bg-surface-hover'
+      }`}
+    >
+      {label}
+    </button>
   )
 }

--- a/frontend/src/types/system.ts
+++ b/frontend/src/types/system.ts
@@ -3,6 +3,8 @@ export interface SystemStatus {
   uptime_seconds: number
   running_bots: number
   version: string
+  halt_time?: string
+  halt_reason?: string
 }
 
 export interface BrokerStatus {

--- a/src/ante/web/routes/system.py
+++ b/src/ante/web/routes/system.py
@@ -16,12 +16,38 @@ class KillSwitchRequest(BaseModel):
 
 
 @router.get("/status")
-async def get_system_status() -> dict:
+async def get_system_status(request: Request) -> dict:
     """시스템 상태 조회."""
-    return {
+    result: dict = {
         "status": "running",
         "version": "0.1.0",
     }
+
+    system_state = getattr(request.app.state, "system_state", None)
+    if system_state is not None:
+        result["trading_status"] = system_state.trading_state.value.upper()
+
+        # HALTED 상태이면 최근 halt 이력에서 시각·사유를 가져옴
+        if system_state.trading_state.value == "halted":
+            halt_info = await _get_last_halt_info(system_state)
+            if halt_info:
+                result["halt_time"] = halt_info.get("created_at")
+                result["halt_reason"] = halt_info.get("reason", "")
+
+    return result
+
+
+async def _get_last_halt_info(system_state: object) -> dict | None:
+    """system_state_history에서 마지막 HALTED 전환 정보를 가져온다."""
+    db = getattr(system_state, "_db", None)
+    if db is None:
+        return None
+    row = await db.fetch_one(
+        "SELECT reason, changed_by, created_at FROM system_state_history"
+        " WHERE new_state = 'halted'"
+        " ORDER BY id DESC LIMIT 1"
+    )
+    return dict(row) if row else None
 
 
 @router.get("/health")


### PR DESCRIPTION
## Summary
- API `GET /api/system/status`에 HALTED 시 `halt_time`, `halt_reason` 필드 추가
- HALTED 상태에서 "정지 시각 · 사유" 회색 텍스트 표시
- 표시 및 알림 섹션에 금액 단위 위치 토글 버튼 2개 추가 (`₩ 1,000,000` / `1,000,000 원`)

Closes #244

## Test plan
- [x] 전체 테스트 스위트 1305 passed
- [x] TypeScript 타입 체크 통과
- [x] ruff lint/format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)