### PR TITLE
fix(#243): 백테스트 데이터 삭제 모달 목업 불일치 수정

### DIFF
--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -13,7 +13,7 @@ export default function BacktestData() {
   const [search, setSearch] = useState('')
   const [timeframe, setTimeframe] = useState<string>('all')
   const [offset, setOffset] = useState(0)
-  const [deleteTarget, setDeleteTarget] = useState<{ id: number; symbol: string; timeframe: string } | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<{ id: number; symbol: string; timeframe: string; start_date: string; end_date: string; row_count: number } | null>(null)
   const queryClient = useQueryClient()
 
   const { data, isLoading } = useQuery({
@@ -103,7 +103,7 @@ export default function BacktestData() {
                         <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatNumber(ds.row_count)}</td>
                         <td className="px-3 py-3 border-b border-border text-[13px] text-right">
                           <button
-                            onClick={() => setDeleteTarget({ id: ds.id, symbol: ds.symbol, timeframe: ds.timeframe })}
+                            onClick={() => setDeleteTarget({ id: ds.id, symbol: ds.symbol, timeframe: ds.timeframe, start_date: ds.start_date, end_date: ds.end_date, row_count: ds.row_count })}
                             className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-negative border border-border cursor-pointer hover:bg-negative-bg"
                           >
                             삭제
@@ -138,11 +138,15 @@ export default function BacktestData() {
       {deleteTarget && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
           <div className="bg-surface border border-border rounded-lg p-6 w-[400px]">
-            <h3 className="text-[18px] font-bold mb-4">데이터셋 삭제</h3>
-            <p className="text-[13px] mb-2">
-              <span className="font-mono font-medium">{deleteTarget.symbol}</span> ({TF_LABELS[deleteTarget.timeframe] ?? deleteTarget.timeframe}) 데이터를 삭제하시겠습니까?
-            </p>
-            <p className="text-[12px] text-warning mb-4">사용 중인 백테스트가 있을 수 있습니다.</p>
+            <h3 className="text-[18px] font-bold mb-4 text-negative">데이터셋 삭제</h3>
+            <div className="mb-4 text-[13px] text-text-muted">
+              <strong className="text-text">{deleteTarget.symbol} — {TF_LABELS[deleteTarget.timeframe] ?? deleteTarget.timeframe}</strong><br />
+              기간: {formatDate(deleteTarget.start_date)} ~ {formatDate(deleteTarget.end_date)} · {formatNumber(deleteTarget.row_count)}건<br /><br />
+              삭제된 데이터는 복구할 수 없습니다.
+            </div>
+            <div className="bg-warning-bg text-warning px-3.5 py-2.5 rounded text-[12px] mb-4">
+              ⚠ 이 데이터를 사용 중인 백테스트가 있을 수 있습니다.
+            </div>
             <div className="flex justify-end gap-2 pt-4 border-t border-border">
               <button onClick={() => setDeleteTarget(null)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
               <button


### PR DESCRIPTION
## Summary
- 삭제 모달 타이틀 "데이터셋 삭제"에 빨간색(`text-negative`) 스타일 적용
- 삭제 대상의 상세 정보(종목명 — 타임프레임, 기간, 건수) 표시
- "삭제된 데이터는 복구할 수 없습니다." 경고 문구 추가
- 노란색 배경의 경고 배너 "⚠ 이 데이터를 사용 중인 백테스트가 있을 수 있습니다." 추가

## Test plan
- [ ] 백테스트 데이터 페이지에서 삭제 버튼 클릭 시 모달 확인
- [ ] 모달 타이틀이 빨간색으로 표시되는지 확인
- [ ] 종목명, 타임프레임, 기간, 건수가 올바르게 표시되는지 확인
- [ ] 경고 문구 및 노란색 배너가 목업과 일치하는지 확인

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)