### PR TITLE
fix(#241): 백테스트 데이터 카드 레이아웃·배너·필터 목업 불일치 수정

### DIFF
--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getDatasets, getStorageInfo, deleteDataset } from '../api/data'
 import { formatNumber, formatDate } from '../utils/formatters'
@@ -15,6 +15,17 @@ export default function BacktestData() {
   const [offset, setOffset] = useState(0)
   const [deleteTarget, setDeleteTarget] = useState<{ id: number; symbol: string; timeframe: string } | null>(null)
   const queryClient = useQueryClient()
+
+  /* 자동완성용: 전체 데이터셋에서 고유 종목 목록 추출 */
+  const { data: allDatasets } = useQuery({
+    queryKey: ['datasets-all-symbols'],
+    queryFn: () => getDatasets({ limit: 1000 }),
+  })
+
+  const symbolOptions = useMemo(() => {
+    if (!allDatasets?.items) return []
+    return [...new Set(allDatasets.items.map((ds) => ds.symbol))]
+  }, [allDatasets])
 
   const { data, isLoading } = useQuery({
     queryKey: ['datasets', search, timeframe, offset],
@@ -45,35 +56,40 @@ export default function BacktestData() {
     <>
       {/* 안내 배너 */}
       <div className="bg-info-bg border border-[rgba(167,139,250,0.2)] rounded-lg px-4 py-3 mb-4 text-[13px] text-info">
-        데이터 수집은 Agent에게 요청하거나 CLI(<code className="bg-bg px-1.5 py-0.5 rounded text-[12px]">ante data collect</code>)를 사용하세요
+        {'\u{1f4a1}'} 데이터 수집은 Agent에게 요청하거나 CLI(<code className="bg-bg px-1.5 py-0.5 rounded text-[12px]">ante data collect</code>)를 사용하세요.
       </div>
 
-      {/* 필터 */}
-      <div className="flex items-center gap-3 mb-4">
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => { setSearch(e.target.value); setOffset(0) }}
-          placeholder="종목 검색..."
-          className="bg-bg border border-border rounded-lg px-3 py-1.5 text-text text-[13px] w-60 placeholder:text-text-muted focus:outline-none focus:border-primary"
-        />
-        <div className="flex gap-1 bg-bg rounded-lg p-0.5">
-          {TF_OPTIONS.map((tf) => (
-            <button
-              key={tf}
-              onClick={() => { setTimeframe(tf); setOffset(0) }}
-              className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
-                timeframe === tf ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
-              }`}
-            >
-              {tf === 'all' ? '전체' : TF_LABELS[tf] ?? tf}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {/* 테이블 */}
+      {/* 데이터셋 카드 */}
       <div className="bg-surface border border-border rounded-lg p-5">
+        {/* 카드 헤더: 타이틀 + 필터를 한 줄 배치 */}
+        <div className="flex items-center justify-between mb-4">
+          <span className="text-[15px] font-semibold text-text">데이터셋</span>
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => { setSearch(e.target.value); setOffset(0) }}
+              list="symbol-list"
+              placeholder="종목 검색"
+              className="bg-bg border border-border rounded px-2 py-1 text-text text-[13px] w-40 placeholder:text-text-muted focus:outline-none focus:border-primary"
+            />
+            <datalist id="symbol-list">
+              {symbolOptions.map((sym) => (
+                <option key={sym} value={sym} />
+              ))}
+            </datalist>
+            <select
+              value={timeframe}
+              onChange={(e) => { setTimeframe(e.target.value); setOffset(0) }}
+              className="bg-bg border border-border rounded px-2 py-1 text-text text-[13px] cursor-pointer focus:outline-none focus:border-primary"
+            >
+              <option value="all">전체 타임프레임</option>
+              {TF_OPTIONS.filter((tf) => tf !== 'all').map((tf) => (
+                <option key={tf} value={tf}>{TF_LABELS[tf] ?? tf}</option>
+              ))}
+            </select>
+          </div>
+        </div>
         {isLoading ? (
           <TableSkeleton rows={5} cols={6} />
         ) : (


### PR DESCRIPTION
## Summary
- 필터(종목 검색 + 타임프레임 셀렉트)를 카드 헤더 안으로 이동하여 타이틀과 한 줄로 배치
- 안내 배너에 💡 이모지를 추가하고 문구를 목업과 일치시킴
- 종목 검색 input에 `datalist` 자동완성 추가 (API에서 고유 종목 목록 동적 추출)
- 타임프레임 필터를 버튼 그룹에서 `<select>` 드롭다운으로 변경

## 목업 대비 변경사항
| 항목 | 변경 전 | 변경 후 (목업 일치) |
|------|---------|-------------------|
| 필터 위치 | 카드 밖 독립 영역 | 카드 헤더 내 타이틀 우측 |
| 배너 텍스트 | 이모지 없음 | 💡 이모지 포함 |
| 종목 검색 | 일반 input | datalist 자동완성 |
| 타임프레임 | 버튼 그룹 | select 드롭다운 |

## Test plan
- [ ] 백테스트 데이터 페이지에서 카드 헤더에 "데이터셋" 타이틀과 필터가 한 줄로 표시되는지 확인
- [ ] 안내 배너에 💡 이모지와 올바른 문구가 표시되는지 확인
- [ ] 종목 검색 입력 시 자동완성 목록이 나타나는지 확인
- [ ] 타임프레임 드롭다운 선택이 정상 동작하는지 확인
- [ ] `npx tsc --noEmit` 통과 확인

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)