### PR TITLE
fix(#237): 멤버 관리 라우트·타이틀·라벨 목업 불일치 수정

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,8 +54,8 @@ export default function App() {
               <Route path="bots" element={<Bots />} />
               <Route path="bots/:id" element={<BotDetail />} />
               <Route path="backtest-data" element={<BacktestData />} />
-              <Route path="agents" element={<Agents />} />
-              <Route path="agents/:id" element={<AgentDetail />} />
+              <Route path="members" element={<Agents />} />
+              <Route path="members/:id" element={<AgentDetail />} />
               <Route path="settings" element={<Settings />} />
               <Route path="*" element={<NotFound />} />
             </Route>

--- a/frontend/src/components/agents/AgentTable.tsx
+++ b/frontend/src/components/agents/AgentTable.tsx
@@ -36,7 +36,7 @@ export default function AgentTable({ items, onSuspend, onReactivate, onRevoke }:
             <tr><td colSpan={6} className="px-3 py-8 text-center text-text-muted text-[13px]">등록된 에이전트가 없습니다</td></tr>
           ) : (
             items.map((m) => (
-              <tr key={m.member_id} onClick={() => navigate(`/agents/${m.member_id}`)} className="hover:bg-surface-hover cursor-pointer">
+              <tr key={m.member_id} onClick={() => navigate(`/members/${m.member_id}`)} className="hover:bg-surface-hover cursor-pointer">
                 <td className="px-3 py-3 border-b border-border text-[13px] font-mono font-medium">{m.member_id}</td>
                 <td className="px-3 py-3 border-b border-border text-[13px]">{m.name}</td>
                 <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{m.org}</td>

--- a/frontend/src/components/agents/MemberCard.tsx
+++ b/frontend/src/components/agents/MemberCard.tsx
@@ -19,7 +19,7 @@ export default function MemberCard({ member, onSuspend, onReactivate, onRevoke }
 
   return (
     <div
-      onClick={() => navigate(`/agents/${member.member_id}`)}
+      onClick={() => navigate(`/members/${member.member_id}`)}
       className="bg-surface border border-border rounded-lg p-5 flex gap-4 items-start cursor-pointer hover:border-primary/50 transition-colors"
     >
       <div className="w-[56px] h-[56px] rounded-full bg-bg flex items-center justify-center text-[28px] shrink-0">

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -11,7 +11,7 @@ const PAGE_TITLES: Record<string, string> = {
   '/strategies': '전략과 성과',
   '/bots': '봇 관리',
   '/backtest-data': '백테스트 데이터',
-  '/agents': '에이전트 관리',
+  '/members': '멤버 관리',
   '/settings': '설정',
 }
 
@@ -20,12 +20,12 @@ function getPageTitle(pathname: string): string {
   if (pathname.startsWith('/approvals/')) return '결재 상세'
   if (pathname.startsWith('/strategies/')) return '전략 상세'
   if (pathname.startsWith('/bots/')) return '봇 상세'
-  if (pathname.startsWith('/agents/')) return '에이전트 상세'
+  if (pathname.startsWith('/members/')) return '멤버 상세'
   return '대시보드'
 }
 
 function isDetailPage(pathname: string): boolean {
-  return /^\/(approvals|strategies|bots|agents)\/[^/]+/.test(pathname) || pathname === '/treasury/history'
+  return /^\/(approvals|strategies|bots|members)\/[^/]+/.test(pathname) || pathname === '/treasury/history'
 }
 
 export default function Header() {

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -9,7 +9,7 @@ const NAV_ITEMS = [
   { path: '/strategies', icon: '📈', label: '전략과 성과' },
   { path: '/bots', icon: '🤖', label: '봇 관리' },
   { path: '/backtest-data', icon: '📁', label: '백테스트 데이터' },
-  { path: '/agents', icon: '🧑‍💼', label: '멤버 관리' },
+  { path: '/members', icon: '🧑‍💼', label: '멤버 관리' },
 ]
 
 export default function Sidebar() {

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -43,7 +43,7 @@ export default function Agents() {
           onClick={() => setShowRegister(true)}
           className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
         >
-          멤버 등록
+          + 에이전트 등록
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- 라우트 경로를 `/agents` → `/members`, `/agents/:id` → `/members/:id`로 변경
- Header 페이지 타이틀을 목업 기준으로 수정 (`에이전트 관리` → `멤버 관리`, `에이전트 상세` → `멤버 상세`)
- Agent 섹션 등록 버튼 라벨을 `멤버 등록` → `+ 에이전트 등록`으로 목업에 맞게 수정
- 사이드바, MemberCard, AgentTable의 navigate 경로를 `/members`로 통일

## Test plan
- [ ] 사이드바에서 '멤버 관리' 클릭 시 `/members` 경로로 이동 확인
- [ ] 멤버 카드/테이블 행 클릭 시 `/members/{id}` 경로로 이동 확인
- [ ] 페이지 헤더에 '멤버 관리' 타이틀 표시 확인
- [ ] 상세 페이지 헤더에 '멤버 상세' 타이틀 및 뒤로가기 버튼 표시 확인
- [ ] Agent 섹션에서 '+ 에이전트 등록' 버튼 라벨 확인
- [ ] TypeScript 타입 체크 통과 확인 (`tsc --noEmit`)

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)