### PR TITLE
feat(#234): Bot당 예산 테이블 보강 — 보유종목 데이터 연동

### DIFF
--- a/frontend/src/components/treasury/BudgetTable.tsx
+++ b/frontend/src/components/treasury/BudgetTable.tsx
@@ -15,19 +15,20 @@ export default function BudgetTable({ budgets }: { budgets: BotBudget[] }) {
               <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">사용예산</th>
               <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">잔여예산</th>
               <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">체결대기</th>
-              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">회수금</th>
-              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">손익</th>
+              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">보유종목 평가금액</th>
+              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">보유종목 손익</th>
+              <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">종목 수익률</th>
               <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">예산 수익률</th>
             </tr>
           </thead>
           <tbody>
             {budgets.length === 0 ? (
-              <tr><td colSpan={8} className="px-3 py-8 text-center text-text-muted text-[13px]">할당된 봇이 없습니다</td></tr>
+              <tr><td colSpan={9} className="px-3 py-8 text-center text-text-muted text-[13px]">할당된 봇이 없습니다</td></tr>
             ) : (
               budgets.map((b) => {
-                const pnl = b.returned - b.spent
-                const pnlColor = pnl >= 0 ? 'text-positive' : 'text-negative'
-                const budgetRoi = b.allocated > 0 ? pnl / b.allocated : 0
+                const pnlColor = b.position_pnl >= 0 ? 'text-positive' : 'text-negative'
+                const budgetRoi = b.allocated > 0 ? b.position_pnl / b.allocated : 0
+                const budgetRoiColor = budgetRoi >= 0 ? 'text-positive' : 'text-negative'
                 return (
                   <tr key={b.bot_id} className="hover:bg-surface-hover">
                     <td className="px-3 py-3 border-b border-border text-[13px]">
@@ -37,9 +38,10 @@ export default function BudgetTable({ budgets }: { budgets: BotBudget[] }) {
                     <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.spent)}</td>
                     <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.available)}</td>
                     <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.reserved)}</td>
-                    <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.returned)}</td>
-                    <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${pnlColor}`}>{formatKRW(pnl)}</td>
-                    <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${pnlColor}`}>{formatPercent(budgetRoi)}</td>
+                    <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatKRW(b.eval_amount)}</td>
+                    <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${pnlColor}`}>{formatKRW(b.position_pnl)}</td>
+                    <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${pnlColor}`}>{formatPercent(b.position_return)}</td>
+                    <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${budgetRoiColor}`}>{formatPercent(budgetRoi)}</td>
                   </tr>
                 )
               })

--- a/frontend/src/types/treasury.ts
+++ b/frontend/src/types/treasury.ts
@@ -25,6 +25,9 @@ export interface BotBudget {
   reserved: number
   spent: number
   returned: number
+  eval_amount: number
+  position_pnl: number
+  position_return: number
 }
 
 export type TransactionType = 'allocate' | 'deallocate' | 'fill' | 'bot_stopped_release'


### PR DESCRIPTION
## Summary
- `BotBudget` 타입에 `eval_amount`, `position_pnl`, `position_return` 필드 추가
- `BudgetTable` 컬럼 재구성: 기존 회수금/손익 컬럼 제거, 보유종목 평가금액/보유종목 손익/종목 수익률 컬럼 추가
- 목업(`docs/dashboard/mockups/treasury.html` L148-203) 레이아웃에 맞춰 9개 컬럼으로 재배치

## 변경 파일
- `frontend/src/types/treasury.ts` — `BotBudget` 인터페이스에 포지션 관련 필드 3개 추가
- `frontend/src/components/treasury/BudgetTable.tsx` — 테이블 컬럼 재구성 및 포지션 데이터 표시

## Test plan
- [ ] `npx tsc --noEmit` 타입 체크 통과 확인
- [ ] Treasury 페이지에서 Bot당 예산 테이블 렌더링 확인
- [ ] 보유종목 평가금액, 보유종목 손익, 종목 수익률 컬럼 정상 표시 확인
- [ ] 손익 양수/음수에 따른 색상(text-positive/text-negative) 적용 확인
- [ ] E2E 시나리오 `flow-treasury.md` 14번 항목 검증

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)