### PR TITLE
fix(#240): 멤버 관리 revoked 스타일 및 상세 브레드크럼 추가

### DIFF
--- a/frontend/src/components/agents/MemberCard.tsx
+++ b/frontend/src/components/agents/MemberCard.tsx
@@ -17,12 +17,14 @@ interface MemberCardProps {
 export default function MemberCard({ member, onSuspend, onReactivate, onRevoke }: MemberCardProps) {
   const navigate = useNavigate()
 
+  const isRevoked = member.status === 'revoked'
+
   return (
     <div
       onClick={() => navigate(`/agents/${member.member_id}`)}
-      className="bg-surface border border-border rounded-lg p-5 flex gap-4 items-start cursor-pointer hover:border-primary/50 transition-colors"
+      className={`bg-surface border border-border rounded-lg p-5 flex gap-4 items-start cursor-pointer hover:border-primary/50 transition-colors${isRevoked ? ' opacity-50' : ''}`}
     >
-      <div className="w-[56px] h-[56px] rounded-full bg-bg flex items-center justify-center text-[28px] shrink-0">
+      <div className={`w-[56px] h-[56px] rounded-full bg-bg flex items-center justify-center text-[28px] shrink-0${isRevoked ? ' blur-[2px]' : ''}`}>
         {member.emoji || (member.type === 'human' ? '👤' : '🤖')}
       </div>
       <div className="flex-1 min-w-0">
@@ -42,7 +44,7 @@ export default function MemberCard({ member, onSuspend, onReactivate, onRevoke }
             )}
           </div>
         )}
-        {(onSuspend || onReactivate || onRevoke) && (
+        {!isRevoked && (onSuspend || onReactivate || onRevoke) && (
           <div className="flex gap-2 justify-end" onClick={(e) => e.stopPropagation()}>
             {member.status === 'active' && onSuspend && (
               <button onClick={() => onSuspend(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-warning border border-border cursor-pointer hover:bg-warning-bg">정지</button>

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, Link } from 'react-router-dom'
 import { useMemberDetail, useMemberControl } from '../hooks/useMembers'
 import StatusBadge from '../components/common/StatusBadge'
 import { PageSkeleton } from '../components/common/Skeleton'
@@ -34,6 +34,11 @@ export default function AgentDetail() {
 
   return (
     <>
+      {/* 브레드크럼 */}
+      <Link to="/agents" className="inline-flex items-center gap-1 text-[13px] text-text-muted hover:text-text mb-4 no-underline">
+        ← 에이전트 관리
+      </Link>
+
       {/* 헤더 */}
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center gap-4">


### PR DESCRIPTION
## Summary
- MemberCard: revoked 상태 카드에 `opacity: 0.5` 적용 및 아바타 blur 처리
- MemberCard: revoked 멤버의 액션 버튼(정지/재활성화/폐기) 숨김
- AgentDetail: 상세 페이지 상단에 "← 에이전트 관리" 브레드크럼 링크 추가

Closes #240

## Test plan
- [ ] 멤버 목록에서 revoked 상태 카드가 반투명(opacity 0.5)으로 표시되는지 확인
- [ ] revoked 카드의 아바타에 blur 효과가 적용되는지 확인
- [ ] revoked 카드에 액션 버튼이 표시되지 않는지 확인
- [ ] 에이전트 상세 페이지에서 "← 에이전트 관리" 링크가 보이는지 확인
- [ ] 해당 링크 클릭 시 `/agents` 페이지로 이동하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)