### PR TITLE
feat(#230): 봇 중지/삭제 모달 구현

### DIFF
--- a/frontend/src/components/bots/BotDeleteModal.tsx
+++ b/frontend/src/components/bots/BotDeleteModal.tsx
@@ -1,0 +1,164 @@
+import { useState } from 'react'
+import type { Bot } from '../../types/bot'
+
+interface Position {
+  symbol: string
+  quantity: number
+  avg_price: number
+  current_price: number
+}
+
+export type DeleteOption = 'force_liquidate' | 'manual_liquidate'
+
+interface BotDeleteModalProps {
+  bot: Bot
+  positions?: Position[]
+  onConfirm: (option?: DeleteOption) => void
+  onClose: () => void
+  isPending?: boolean
+}
+
+export default function BotDeleteModal({ bot, positions = [], onConfirm, onClose, isPending }: BotDeleteModalProps) {
+  const hasPositions = positions.length > 0
+  const [deleteOption, setDeleteOption] = useState<DeleteOption>('force_liquidate')
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]" onClick={onClose}>
+      <div className="bg-surface border border-border rounded-lg p-6 w-[480px] max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+        <h2 className="text-[18px] font-bold mb-5">봇 삭제</h2>
+
+        {/* 보유종목 있음 경고 배너 */}
+        {hasPositions && (
+          <div className="flex items-start gap-2 bg-negative/10 border border-negative/30 rounded-lg px-4 py-3 mb-4">
+            <span className="text-negative text-[16px] mt-0.5">&#9888;</span>
+            <div className="text-[13px] text-negative">
+              <span className="font-semibold">보유 종목 {positions.length}개가 있습니다</span>
+              <p className="mt-1 text-negative/80">삭제 전 포지션 처리 방법을 선택하세요.</p>
+            </div>
+          </div>
+        )}
+
+        {/* 보유종목 없음 안내 */}
+        {!hasPositions && (
+          <div className="flex items-start gap-2 bg-primary/10 border border-primary/30 rounded-lg px-4 py-3 mb-4">
+            <span className="text-primary text-[16px] mt-0.5">&#8505;</span>
+            <div className="text-[13px] text-text-muted">
+              거래 이력과 성과 기록은 보존됩니다.
+            </div>
+          </div>
+        )}
+
+        {/* Bot 정보 */}
+        <div className="bg-bg rounded-lg p-4 mb-4">
+          <div className="space-y-2 text-[13px]">
+            <div className="flex justify-between">
+              <span className="text-text-muted">봇 이름</span>
+              <span className="font-medium">{bot.name || bot.bot_id}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-text-muted">봇 ID</span>
+              <span className="font-mono text-[12px]">{bot.bot_id}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-text-muted">보유 종목</span>
+              <span>{hasPositions ? `${positions.length}개` : '없음'}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* 포지션 처리 옵션 (보유종목 있을 때만) */}
+        {hasPositions && (
+          <div className="mb-4">
+            <h3 className="text-[13px] font-semibold text-text-muted mb-3">포지션 처리 방법</h3>
+            <div className="space-y-2">
+              <label
+                className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                  deleteOption === 'force_liquidate'
+                    ? 'border-primary bg-primary/5'
+                    : 'border-border hover:bg-surface-hover'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="deleteOption"
+                  checked={deleteOption === 'force_liquidate'}
+                  onChange={() => setDeleteOption('force_liquidate')}
+                  className="mt-0.5 accent-primary"
+                />
+                <div>
+                  <div className="text-[13px] font-medium">강제 청산 후 삭제</div>
+                  <div className="text-[12px] text-text-muted mt-0.5">
+                    모든 보유 종목을 시장가로 즉시 매도한 뒤 봇을 삭제합니다.
+                  </div>
+                </div>
+              </label>
+              <label
+                className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                  deleteOption === 'manual_liquidate'
+                    ? 'border-primary bg-primary/5'
+                    : 'border-border hover:bg-surface-hover'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="deleteOption"
+                  checked={deleteOption === 'manual_liquidate'}
+                  onChange={() => setDeleteOption('manual_liquidate')}
+                  className="mt-0.5 accent-primary"
+                />
+                <div>
+                  <div className="text-[13px] font-medium">직접 청산</div>
+                  <div className="text-[12px] text-text-muted mt-0.5">
+                    봇을 중지 상태로 전환합니다. 보유 종목을 직접 청산한 뒤 다시 삭제하세요.
+                  </div>
+                </div>
+              </label>
+            </div>
+
+            {/* 보유종목 테이블 */}
+            <div className="mt-4">
+              <h3 className="text-[13px] font-semibold text-text-muted mb-2">보유 종목</h3>
+              <div className="overflow-x-auto">
+                <table className="w-full border-collapse text-[12px]">
+                  <thead>
+                    <tr>
+                      <th className="text-left px-2 py-1.5 font-semibold text-text-muted border-b border-border">종목</th>
+                      <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">수량</th>
+                      <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">평균단가</th>
+                      <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">현재가</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {positions.map((pos) => (
+                      <tr key={pos.symbol}>
+                        <td className="px-2 py-1.5 font-mono border-b border-border/50">{pos.symbol}</td>
+                        <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.quantity.toLocaleString()}</td>
+                        <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.avg_price.toLocaleString()}원</td>
+                        <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.current_price.toLocaleString()}원</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* 버튼 */}
+        <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
+          <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(hasPositions ? deleteOption : undefined)}
+            disabled={isPending}
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative/80 disabled:opacity-50"
+          >
+            {isPending ? '삭제 중...' : hasPositions && deleteOption === 'manual_liquidate' ? '중지로 전환' : '삭제'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/bots/BotStopModal.tsx
+++ b/frontend/src/components/bots/BotStopModal.tsx
@@ -1,0 +1,141 @@
+import type { Bot } from '../../types/bot'
+
+interface Position {
+  symbol: string
+  quantity: number
+  avg_price: number
+  current_price: number
+}
+
+interface PendingOrder {
+  symbol: string
+  side: 'buy' | 'sell'
+  quantity: number
+  price: number
+}
+
+interface BotStopModalProps {
+  bot: Bot
+  positions?: Position[]
+  pendingOrders?: PendingOrder[]
+  onConfirm: () => void
+  onClose: () => void
+  isPending?: boolean
+}
+
+export default function BotStopModal({ bot, positions = [], pendingOrders = [], onConfirm, onClose, isPending }: BotStopModalProps) {
+  const hasPositions = positions.length > 0
+  const hasPendingOrders = pendingOrders.length > 0
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]" onClick={onClose}>
+      <div className="bg-surface border border-border rounded-lg p-6 w-[480px] max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+        <h2 className="text-[18px] font-bold mb-5">봇 중지</h2>
+
+        {/* 보유종목 있음 경고 배너 */}
+        {hasPositions && (
+          <div className="flex items-start gap-2 bg-warning/10 border border-warning/30 rounded-lg px-4 py-3 mb-4">
+            <span className="text-warning text-[16px] mt-0.5">&#9888;</span>
+            <div className="text-[13px] text-warning">
+              <span className="font-semibold">보유 종목 {positions.length}개가 유지됩니다</span>
+              <p className="mt-1 text-warning/80">봇을 중지해도 보유 종목은 자동으로 매도되지 않습니다. 필요 시 수동으로 청산하세요.</p>
+            </div>
+          </div>
+        )}
+
+        {/* Bot 정보 */}
+        <div className="bg-bg rounded-lg p-4 mb-4">
+          <div className="space-y-2 text-[13px]">
+            <div className="flex justify-between">
+              <span className="text-text-muted">봇 이름</span>
+              <span className="font-medium">{bot.name || bot.bot_id}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-text-muted">봇 ID</span>
+              <span className="font-mono text-[12px]">{bot.bot_id}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-text-muted">보유 종목</span>
+              <span>{hasPositions ? `${positions.length}개` : '없음'}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* 보유종목 테이블 */}
+        {hasPositions && (
+          <div className="mb-4">
+            <h3 className="text-[13px] font-semibold text-text-muted mb-2">보유 종목</h3>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse text-[12px]">
+                <thead>
+                  <tr>
+                    <th className="text-left px-2 py-1.5 font-semibold text-text-muted border-b border-border">종목</th>
+                    <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">수량</th>
+                    <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">평균단가</th>
+                    <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">현재가</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {positions.map((pos) => (
+                    <tr key={pos.symbol}>
+                      <td className="px-2 py-1.5 font-mono border-b border-border/50">{pos.symbol}</td>
+                      <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.quantity.toLocaleString()}</td>
+                      <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.avg_price.toLocaleString()}원</td>
+                      <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.current_price.toLocaleString()}원</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {/* 체결 대기 */}
+        {hasPendingOrders && (
+          <div className="mb-4">
+            <h3 className="text-[13px] font-semibold text-text-muted mb-2">체결 대기</h3>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse text-[12px]">
+                <thead>
+                  <tr>
+                    <th className="text-left px-2 py-1.5 font-semibold text-text-muted border-b border-border">종목</th>
+                    <th className="text-center px-2 py-1.5 font-semibold text-text-muted border-b border-border">유형</th>
+                    <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">수량</th>
+                    <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">주문가</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pendingOrders.map((order, i) => (
+                    <tr key={`${order.symbol}-${i}`}>
+                      <td className="px-2 py-1.5 font-mono border-b border-border/50">{order.symbol}</td>
+                      <td className={`text-center px-2 py-1.5 border-b border-border/50 ${order.side === 'buy' ? 'text-positive' : 'text-negative'}`}>
+                        {order.side === 'buy' ? '매수' : '매도'}
+                      </td>
+                      <td className="text-right px-2 py-1.5 border-b border-border/50">{order.quantity.toLocaleString()}</td>
+                      <td className="text-right px-2 py-1.5 border-b border-border/50">{order.price.toLocaleString()}원</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {/* 버튼 */}
+        <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
+          <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isPending}
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative/80 disabled:opacity-50"
+          >
+            {isPending ? '중지 중...' : '중지'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/BotDetail.tsx
+++ b/frontend/src/pages/BotDetail.tsx
@@ -3,6 +3,7 @@ import { useParams, Link } from 'react-router-dom'
 import { useBotDetail, useBotControl } from '../hooks/useBots'
 import StatusBadge from '../components/common/StatusBadge'
 import { PageSkeleton } from '../components/common/Skeleton'
+import BotStopModal from '../components/bots/BotStopModal'
 import { formatKRW, formatDateTime } from '../utils/formatters'
 import { BOT_STATUS_LABELS } from '../utils/constants'
 import type { BotStatus, BotDetail as BotDetailType } from '../types/bot'
@@ -16,6 +17,7 @@ export default function BotDetail() {
   const { data: bot, isLoading } = useBotDetail(id!)
   const { start, stop } = useBotControl()
   const [showEditModal, setShowEditModal] = useState(false)
+  const [showStopModal, setShowStopModal] = useState(false)
 
   if (isLoading) return <PageSkeleton />
   if (!bot) return <div className="text-text-muted text-center py-12">봇을 찾을 수 없습니다</div>
@@ -55,7 +57,7 @@ export default function BotDetail() {
             <button onClick={() => start.mutate(bot.bot_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">시작</button>
           )}
           {canStop && (
-            <button onClick={() => stop.mutate(bot.bot_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">중지</button>
+            <button onClick={() => setShowStopModal(true)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">중지</button>
           )}
         </div>
       </div>
@@ -184,6 +186,18 @@ export default function BotDetail() {
           </div>
         )}
       </div>
+
+      {/* 중지 확인 모달 */}
+      {showStopModal && (
+        <BotStopModal
+          bot={bot}
+          onConfirm={() => {
+            stop.mutate(bot.bot_id, { onSuccess: () => setShowStopModal(false) })
+          }}
+          onClose={() => setShowStopModal(false)}
+          isPending={stop.isPending}
+        />
+      )}
 
       {/* 설정 수정 모달 */}
       {showEditModal && <BotEditModal bot={bot} onClose={() => setShowEditModal(false)} />}

--- a/frontend/src/pages/Bots.tsx
+++ b/frontend/src/pages/Bots.tsx
@@ -2,10 +2,15 @@ import { useState } from 'react'
 import { useBots, useBotControl } from '../hooks/useBots'
 import BotCard from '../components/bots/BotCard'
 import BotCreateForm from '../components/bots/BotCreateForm'
+import BotStopModal from '../components/bots/BotStopModal'
+import BotDeleteModal from '../components/bots/BotDeleteModal'
 import { TableSkeleton } from '../components/common/Skeleton'
+import type { Bot } from '../types/bot'
 
 export default function Bots() {
   const [showCreate, setShowCreate] = useState(false)
+  const [stopTarget, setStopTarget] = useState<Bot | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<Bot | null>(null)
   const { data, isLoading } = useBots()
   const { start, stop, remove } = useBotControl()
 
@@ -13,8 +18,26 @@ export default function Bots() {
   const runningBots = allBots.filter((b) => b.status === 'running')
   const inactiveBots = allBots.filter((b) => b.status !== 'running' && b.status !== 'deleted')
 
-  const handleDelete = (id: string) => {
-    if (confirm('이 봇을 삭제하시겠습니까?')) remove.mutate(id)
+  const handleStopClick = (id: string) => {
+    const bot = allBots.find((b) => b.bot_id === id)
+    if (bot) setStopTarget(bot)
+  }
+
+  const handleDeleteClick = (id: string) => {
+    const bot = allBots.find((b) => b.bot_id === id)
+    if (bot) setDeleteTarget(bot)
+  }
+
+  const handleStopConfirm = () => {
+    if (stopTarget) {
+      stop.mutate(stopTarget.bot_id, { onSuccess: () => setStopTarget(null) })
+    }
+  }
+
+  const handleDeleteConfirm = () => {
+    if (deleteTarget) {
+      remove.mutate(deleteTarget.bot_id, { onSuccess: () => setDeleteTarget(null) })
+    }
   }
 
   return (
@@ -43,7 +66,7 @@ export default function Bots() {
             ) : (
               <div className="grid grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4">
                 {runningBots.map((bot) => (
-                  <BotCard key={bot.bot_id} bot={bot} onStart={(id) => start.mutate(id)} onStop={(id) => stop.mutate(id)} onDelete={handleDelete} />
+                  <BotCard key={bot.bot_id} bot={bot} onStart={(id) => start.mutate(id)} onStop={handleStopClick} onDelete={handleDeleteClick} />
                 ))}
               </div>
             )}
@@ -63,7 +86,7 @@ export default function Bots() {
             ) : (
               <div className="grid grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4">
                 {inactiveBots.map((bot) => (
-                  <BotCard key={bot.bot_id} bot={bot} onStart={(id) => start.mutate(id)} onStop={(id) => stop.mutate(id)} onDelete={handleDelete} />
+                  <BotCard key={bot.bot_id} bot={bot} onStart={(id) => start.mutate(id)} onStop={handleStopClick} onDelete={handleDeleteClick} />
                 ))}
               </div>
             )}
@@ -72,6 +95,24 @@ export default function Bots() {
       )}
 
       {showCreate && <BotCreateForm onClose={() => setShowCreate(false)} />}
+
+      {stopTarget && (
+        <BotStopModal
+          bot={stopTarget}
+          onConfirm={handleStopConfirm}
+          onClose={() => setStopTarget(null)}
+          isPending={stop.isPending}
+        />
+      )}
+
+      {deleteTarget && (
+        <BotDeleteModal
+          bot={deleteTarget}
+          onConfirm={handleDeleteConfirm}
+          onClose={() => setDeleteTarget(null)}
+          isPending={remove.isPending}
+        />
+      )}
     </>
   )
 }


### PR DESCRIPTION
## Summary
- 봇 중지/삭제 시 `confirm()` 대신 전용 모달 컴포넌트로 교체
- **BotStopModal**: 보유종목 유무에 따라 경고 배너 및 종목/체결대기 테이블 분기 표시
- **BotDeleteModal**: 보유종목 있을 때 "강제 청산 후 삭제" / "직접 청산" 라디오 옵션 제공, 없을 때 "거래 이력 보존" 안내 표시
- `Bots.tsx`(목록)와 `BotDetail.tsx`(상세) 양쪽에 모달 통합

## Test plan
- [ ] 실행 중인 봇 카드에서 "중지" 클릭 → BotStopModal 표시 확인
- [ ] 보유종목 없는 봇 중지 모달에서 "보유 종목: 없음" 표시 확인
- [ ] 보유종목 있는 봇 중지 모달에서 경고 배너 + 종목 테이블 표시 확인
- [ ] 비활성 봇 카드에서 "삭제" 클릭 → BotDeleteModal 표시 확인
- [ ] 보유종목 없는 봇 삭제 모달에서 "거래 이력과 성과 기록은 보존됩니다" 안내 확인
- [ ] 보유종목 있는 봇 삭제 모달에서 라디오 옵션 2개 표시 및 선택 동작 확인
- [ ] BotDetail 페이지 "중지" 버튼 → BotStopModal 표시 확인
- [ ] 모달 외부 클릭 및 취소 버튼으로 모달 닫힘 확인

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)