### PR TITLE
fix(#242): 백테스트 데이터 페이지네이션·용량 정보 레이아웃 수정

### DIFF
--- a/frontend/src/components/common/Pagination.tsx
+++ b/frontend/src/components/common/Pagination.tsx
@@ -22,14 +22,14 @@ export default function Pagination({ total, offset, limit, onPageChange }: Pagin
           disabled={!hasPrev}
           className="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-border bg-transparent text-text-muted hover:bg-surface-hover hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          이전
+          ← 이전
         </button>
         <button
           onClick={() => onPageChange(offset + limit)}
           disabled={!hasNext}
           className="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-border bg-transparent text-text-muted hover:bg-surface-hover hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          다음
+          다음 →
         </button>
       </div>
     </div>

--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getDatasets, getStorageInfo, deleteDataset } from '../api/data'
 import { formatNumber, formatDate } from '../utils/formatters'
-import Pagination from '../components/common/Pagination'
 import { TableSkeleton } from '../components/common/Skeleton'
 
 const LIMIT = 15
@@ -116,9 +115,10 @@ export default function BacktestData() {
               </table>
             </div>
 
-            <div className="flex items-center justify-between pt-4">
-              <span className="text-[12px] text-text-muted">
+            <div className="flex items-center justify-between pt-4 text-[13px] text-text-muted">
+              <span>
                 총 {formatNumber(data?.total ?? 0)}건
+                {(data?.total ?? 0) > 0 && ` 중 ${offset + 1}-${Math.min(offset + LIMIT, data?.total ?? 0)}`}
                 {storage && ` · 전체 ${storage.total_mb >= 1024 ? `${(storage.total_mb / 1024).toFixed(1)} GB` : `${storage.total_mb.toFixed(1)} MB`}`}
                 {storage?.by_timeframe && Object.keys(storage.by_timeframe).length > 0 && (
                   <> ({Object.entries(storage.by_timeframe).map(([tf, bytes], i) => (
@@ -127,7 +127,22 @@ export default function BacktestData() {
                 )}
               </span>
               {(data?.total ?? 0) > LIMIT && (
-                <Pagination total={data?.total ?? 0} offset={offset} limit={LIMIT} onPageChange={setOffset} />
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => setOffset(Math.max(0, offset - LIMIT))}
+                    disabled={offset <= 0}
+                    className="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-border bg-transparent text-text-muted hover:bg-surface-hover hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    ← 이전
+                  </button>
+                  <button
+                    onClick={() => setOffset(offset + LIMIT)}
+                    disabled={offset + LIMIT >= (data?.total ?? 0)}
+                    className="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-border bg-transparent text-text-muted hover:bg-surface-hover hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    다음 →
+                  </button>
+                </div>
               )}
             </div>
           </>


### PR DESCRIPTION
## Summary
- 백테스트 데이터 테이블 하단의 건수·페이지 범위·용량 정보를 한 줄 레이아웃(flex, justify-between)으로 통합
- 페이지네이션 버튼 라벨에 화살표 추가: `← 이전`, `다음 →`
- `Pagination` 공통 컴포넌트에도 화살표 라벨 반영 (다른 페이지에도 적용)

## Test plan
- [ ] 백테스트 데이터 페이지에서 하단 정보가 한 줄로 표시되는지 확인
- [ ] 좌측: "총 N건 중 X-Y · 전체 X.X GB (타임프레임별 용량)" 형식 확인
- [ ] 우측: "← 이전" / "다음 →" 버튼 표시 및 동작 확인
- [ ] 첫 페이지에서 "← 이전" 버튼 비활성화 확인
- [ ] 마지막 페이지에서 "다음 →" 버튼 비활성화 확인
- [ ] 다른 페이지(전략, 자금이력, 승인)의 Pagination 화살표 표시 확인

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)