### PR TITLE
feat(#235): Bot 예산 비중 파이 차트 구현

### DIFF
--- a/frontend/src/components/treasury/BudgetPieChart.tsx
+++ b/frontend/src/components/treasury/BudgetPieChart.tsx
@@ -1,0 +1,107 @@
+import type { BotBudget } from '../../types/treasury'
+import { formatKRW } from '../../utils/formatters'
+
+const COLORS = [
+  '#1E8EFF', // positive (blue)
+  '#F5C518', // accent (gold)
+  '#a78bfa', // info (purple)
+  '#E85830', // negative (orange-red)
+  '#F0A030', // warning (amber)
+  '#34d399', // emerald
+  '#f472b6', // pink
+  '#60a5fa', // light blue
+]
+
+interface Props {
+  budgets: BotBudget[]
+}
+
+export default function BudgetPieChart({ budgets }: Props) {
+  const allocatedBudgets = budgets.filter((b) => b.allocated > 0)
+
+  if (allocatedBudgets.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-[240px] text-text-muted text-[13px] border border-dashed border-border rounded-lg">
+        할당된 예산이 없습니다
+      </div>
+    )
+  }
+
+  const total = allocatedBudgets.reduce((sum, b) => sum + b.allocated, 0)
+
+  // Build pie slices using SVG arc paths
+  const slices: { botId: string; percentage: number; color: string; startAngle: number; endAngle: number }[] = []
+  let currentAngle = -90 // Start from top
+
+  allocatedBudgets.forEach((b, i) => {
+    const percentage = (b.allocated / total) * 100
+    const angle = (b.allocated / total) * 360
+    slices.push({
+      botId: b.bot_id,
+      percentage,
+      color: COLORS[i % COLORS.length],
+      startAngle: currentAngle,
+      endAngle: currentAngle + angle,
+    })
+    currentAngle += angle
+  })
+
+  return (
+    <div className="flex items-center gap-6 h-[240px]">
+      {/* SVG Pie Chart */}
+      <div className="flex-shrink-0">
+        <svg width="180" height="180" viewBox="-1 -1 2 2" style={{ transform: 'rotate(-90deg)' }}>
+          {slices.map((slice) => {
+            if (slice.percentage >= 99.99) {
+              // Full circle
+              return (
+                <circle key={slice.botId} r="1" fill={slice.color} />
+              )
+            }
+
+            const startRad = ((slice.startAngle + 90) * Math.PI) / 180
+            const endRad = ((slice.endAngle + 90) * Math.PI) / 180
+
+            const x1 = Math.cos(startRad)
+            const y1 = Math.sin(startRad)
+            const x2 = Math.cos(endRad)
+            const y2 = Math.sin(endRad)
+
+            const largeArc = slice.endAngle - slice.startAngle > 180 ? 1 : 0
+
+            const d = [
+              `M 0 0`,
+              `L ${x1} ${y1}`,
+              `A 1 1 0 ${largeArc} 1 ${x2} ${y2}`,
+              `Z`,
+            ].join(' ')
+
+            return <path key={slice.botId} d={d} fill={slice.color} />
+          })}
+        </svg>
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-col gap-2 overflow-y-auto max-h-[220px] min-w-0">
+        {slices.map((slice) => {
+          const budget = allocatedBudgets.find((b) => b.bot_id === slice.botId)!
+          return (
+            <div key={slice.botId} className="flex items-center gap-2 text-[13px]">
+              <span
+                className="w-3 h-3 rounded-sm flex-shrink-0"
+                style={{ backgroundColor: slice.color }}
+              />
+              <span className="text-text truncate">{slice.botId}</span>
+              <span className="text-text-muted ml-auto flex-shrink-0">
+                {slice.percentage.toFixed(1)}%
+              </span>
+              <span className="text-text-muted flex-shrink-0">
+                ({formatKRW(budget.allocated)})
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Treasury.tsx
+++ b/frontend/src/pages/Treasury.tsx
@@ -1,6 +1,7 @@
 import { useTreasurySummary, useBotBudgets } from '../hooks/useTreasury'
 import AccountSummary from '../components/treasury/AccountSummary'
 import AnteSummary from '../components/treasury/AnteSummary'
+import BudgetPieChart from '../components/treasury/BudgetPieChart'
 import BudgetTable from '../components/treasury/BudgetTable'
 import AllocationForm from '../components/treasury/AllocationForm'
 import RecentTransactions from '../components/treasury/RecentTransactions'
@@ -18,12 +19,10 @@ export default function Treasury() {
       {summary && <AnteSummary summary={summary} />}
 
       <div className="grid grid-cols-[1fr_1fr] gap-6 mb-6">
-        {/* 파이 차트 자리 */}
+        {/* 파이 차트 */}
         <div className="bg-surface border border-border rounded-lg p-5">
           <h3 className="text-[15px] font-semibold mb-4">Bot 예산 비중</h3>
-          <div className="flex items-center justify-center h-[240px] text-text-muted text-[13px] border border-dashed border-border rounded-lg">
-            📊 파이 차트 — Bot별 예산 비중
-          </div>
+          <BudgetPieChart budgets={budgets ?? []} />
         </div>
 
         {/* 예산 관리 폼 */}


### PR DESCRIPTION
## Summary
- `BotBudget[].allocated` 값을 기반으로 Bot별 예산 할당 비율을 시각적으로 보여주는 SVG 파이 차트 구현
- 외부 차트 라이브러리 없이 순수 SVG path/arc로 구현하여 의존성 추가 없음
- 프로젝트 테마 색상(positive, accent, info 등)을 활용한 일관된 디자인

## 변경 사항
- `frontend/src/components/treasury/BudgetPieChart.tsx` — 신규 파이 차트 컴포넌트
- `frontend/src/pages/Treasury.tsx` — placeholder를 BudgetPieChart로 교체

## Test plan
- [ ] Treasury 페이지에서 파이 차트가 정상 렌더링되는지 확인
- [ ] Bot 예산이 없을 때 "할당된 예산이 없습니다" 메시지 표시 확인
- [ ] Bot이 1개일 때 전체 원이 그려지는지 확인
- [ ] Bot이 여러 개일 때 비율이 정확히 나뉘는지 확인
- [ ] 범례에 Bot 이름, 퍼센트, 금액이 표시되는지 확인

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)