### PR TITLE
feat(#228): 봇 카드 UI 개선 — 로봇 아이콘 애니메이션, 실행간격 표시

### DIFF
--- a/frontend/src/components/bots/BotCard.tsx
+++ b/frontend/src/components/bots/BotCard.tsx
@@ -15,20 +15,38 @@ interface BotCardProps {
 }
 
 function BotIcon({ status }: { status: BotStatus }) {
-  const bgClass = status === 'running'
+  const isRunning = status === 'running'
+  const bgClass = isRunning
     ? 'bg-positive-bg text-positive'
     : status === 'error'
       ? 'bg-negative-bg text-negative'
       : 'bg-bg text-text-muted'
 
   return (
-    <div className={`w-[72px] h-[72px] rounded-full flex items-center justify-center shrink-0 ${bgClass}`}>
+    <div
+      className={`w-[72px] h-[72px] rounded-full flex items-center justify-center shrink-0 ${bgClass}`}
+      style={isRunning ? { animation: 'border-glow 1.5s ease-in-out infinite' } : undefined}
+    >
       <svg viewBox="0 0 24 24" className="w-12 h-12 fill-current">
-        <circle cx="12" cy="2" r="1.5" />
-        <line x1="12" y1="3.5" x2="12" y2="6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        <circle
+          cx="12" cy="2" r="1.5"
+          style={isRunning ? { animation: 'antenna-pulse 1.2s ease-in-out infinite', fill: '#fff' } : undefined}
+        />
+        <line
+          x1="12" y1="3.5" x2="12" y2="6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"
+          style={isRunning ? { animation: 'antenna-pulse 1.2s ease-in-out infinite' } : undefined}
+        />
         <rect x="4" y="6" width="16" height="12" rx="3" ry="3" />
-        <circle cx="9" cy="12" r="2" className="fill-surface" />
-        <circle cx="15" cy="12" r="2" className="fill-surface" />
+        <circle
+          cx="9" cy="12" r="2"
+          className={isRunning ? '' : 'fill-surface'}
+          style={isRunning ? { animation: 'eye-glow 1.5s ease-in-out infinite' } : undefined}
+        />
+        <circle
+          cx="15" cy="12" r="2"
+          className={isRunning ? '' : 'fill-surface'}
+          style={isRunning ? { animation: 'eye-glow 1.5s ease-in-out infinite' } : undefined}
+        />
         <rect x="8" y="20" width="3" height="3" rx="1" />
         <rect x="13" y="20" width="3" height="3" rx="1" />
       </svg>
@@ -59,6 +77,12 @@ export default function BotCard({ bot, onStart, onStop, onDelete }: BotCardProps
             <span>모드</span>
             <StatusBadge variant={bot.mode === 'live' ? 'warning' : 'info'}>{bot.mode === 'live' ? '실전' : '모의'}</StatusBadge>
           </div>
+          {bot.interval_seconds != null && (
+            <div className="flex justify-between">
+              <span>실행 간격</span>
+              <span>{bot.interval_seconds}초</span>
+            </div>
+          )}
         </div>
         <div className="flex gap-2 justify-end">
           {(bot.status === 'stopped' || bot.status === 'created') && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -50,3 +50,19 @@ a {
 a:hover {
   text-decoration: underline;
 }
+
+/* Bot icon running animations */
+@keyframes border-glow {
+  0%, 100% { box-shadow: inset 0 0 2px rgba(255, 255, 255, 0.1); }
+  50% { box-shadow: inset 0 0 12px rgba(255, 255, 255, 0.3); }
+}
+
+@keyframes antenna-pulse {
+  0%, 100% { opacity: 0.3; filter: drop-shadow(0 0 0px #fff); }
+  50% { opacity: 1; filter: drop-shadow(0 0 8px #fff); }
+}
+
+@keyframes eye-glow {
+  0%, 100% { fill: var(--color-surface); filter: drop-shadow(0 0 0px #fff); }
+  50% { fill: #fff; filter: drop-shadow(0 0 6px #fff); }
+}

--- a/frontend/src/types/bot.ts
+++ b/frontend/src/types/bot.ts
@@ -7,6 +7,7 @@ export interface Bot {
   strategy_name?: string
   status: BotStatus
   mode: BotMode
+  interval_seconds?: number
   created_at: string
 }
 


### PR DESCRIPTION
## Summary
- running 상태 봇의 로봇 아이콘에 glow 애니메이션 3종 적용 (border-glow, antenna-pulse, eye-glow)
- 봇 카드에 실행 간격(interval_seconds) 표시 행 추가
- `Bot` 타입에 `interval_seconds?` 필드 추가 (백엔드 list API에서 이미 반환 중)

## 변경 파일
- `frontend/src/index.css` — @keyframes 애니메이션 정의
- `frontend/src/components/bots/BotCard.tsx` — BotIcon 애니메이션 적용, 실행 간격 표시
- `frontend/src/types/bot.ts` — Bot 인터페이스에 interval_seconds 추가

## Test plan
- [ ] 봇 목록 페이지에서 running 상태 봇 아이콘에 glow 애니메이션이 표시되는지 확인
- [ ] stopped/created/error 상태 봇에는 애니메이션이 적용되지 않는지 확인
- [ ] 봇 카드에 실행 간격이 "60초" 형식으로 표시되는지 확인
- [ ] `npx tsc --noEmit` 통과 확인

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)