### PR TITLE
fix: 결재 유형 enum 백엔드/스펙 불일치 수정

### DIFF
--- a/frontend/src/api/approvals.ts
+++ b/frontend/src/api/approvals.ts
@@ -23,13 +23,13 @@ export async function getApprovals(params: ApprovalsParams): Promise<ApprovalsRe
   return res.data
 }
 
-export async function getApprovalDetail(id: number): Promise<ApprovalDetail> {
+export async function getApprovalDetail(id: string): Promise<ApprovalDetail> {
   const res = await client.get(`/api/approvals/${id}`)
   return res.data
 }
 
 export async function updateApprovalStatus(
-  id: number,
+  id: string,
   status: 'approved' | 'rejected',
   memo?: string,
 ): Promise<void> {

--- a/frontend/src/components/approvals/ApprovalFilters.tsx
+++ b/frontend/src/components/approvals/ApprovalFilters.tsx
@@ -9,10 +9,11 @@ const STATUS_OPTIONS: { key: ApprovalStatus | 'all'; label: string }[] = [
 
 const TYPE_OPTIONS: { key: ApprovalType | 'all'; label: string }[] = [
   { key: 'all', label: '전체 유형' },
-  { key: 'strategy_report', label: '전략 리포트' },
-  { key: 'budget_allocation', label: '예산 할당' },
-  { key: 'live_switch', label: '실전 전환' },
-  { key: 'risk_alert', label: '위험 알림' },
+  { key: 'strategy_adopt', label: '전략 채택' },
+  { key: 'budget_change', label: '예산 변경' },
+  { key: 'bot_create', label: '봇 생성' },
+  { key: 'bot_stop', label: '봇 중지' },
+  { key: 'rule_change', label: '규칙 변경' },
 ]
 
 interface ApprovalFiltersProps {

--- a/frontend/src/components/approvals/ApprovalTable.tsx
+++ b/frontend/src/components/approvals/ApprovalTable.tsx
@@ -5,10 +5,11 @@ import type { Approval, ApprovalStatus, ApprovalType } from '../../types/approva
 import { APPROVAL_STATUS_LABELS } from '../../utils/constants'
 
 const TYPE_BADGE: Record<ApprovalType, { label: string; variant: string }> = {
-  strategy_report: { label: '전략 리포트', variant: 'info' },
-  budget_allocation: { label: '예산 할당', variant: 'primary' },
-  live_switch: { label: '실전 전환', variant: 'warning' },
-  risk_alert: { label: '위험 알림', variant: 'negative' },
+  strategy_adopt: { label: '전략 채택', variant: 'info' },
+  budget_change: { label: '예산 변경', variant: 'primary' },
+  bot_create: { label: '봇 생성', variant: 'positive' },
+  bot_stop: { label: '봇 중지', variant: 'warning' },
+  rule_change: { label: '규칙 변경', variant: 'negative' },
 }
 
 const STATUS_VARIANT: Record<ApprovalStatus, string> = {

--- a/frontend/src/components/approvals/ReviewControls.tsx
+++ b/frontend/src/components/approvals/ReviewControls.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useUpdateApprovalStatus } from '../../hooks/useApprovals'
 
-export default function ReviewControls({ approvalId, isPending }: { approvalId: number; isPending: boolean }) {
+export default function ReviewControls({ approvalId, isPending }: { approvalId: string; isPending: boolean }) {
   const [memo, setMemo] = useState('')
   const updateStatus = useUpdateApprovalStatus()
 

--- a/frontend/src/components/dashboard/PendingApprovals.tsx
+++ b/frontend/src/components/dashboard/PendingApprovals.tsx
@@ -6,10 +6,11 @@ import { TableSkeleton } from '../common/Skeleton'
 import type { Approval, ApprovalType } from '../../types/approval'
 
 const TYPE_LABELS: Record<ApprovalType, { label: string; variant: string }> = {
-  strategy_report: { label: '전략 리포트', variant: 'info' },
-  budget_allocation: { label: '예산 할당', variant: 'primary' },
-  live_switch: { label: '실전 전환', variant: 'warning' },
-  risk_alert: { label: '위험 알림', variant: 'negative' },
+  strategy_adopt: { label: '전략 채택', variant: 'info' },
+  budget_change: { label: '예산 변경', variant: 'primary' },
+  bot_create: { label: '봇 생성', variant: 'positive' },
+  bot_stop: { label: '봇 중지', variant: 'warning' },
+  rule_change: { label: '규칙 변경', variant: 'negative' },
 }
 
 export default function PendingApprovals() {
@@ -19,7 +20,7 @@ export default function PendingApprovals() {
   const items = data?.items ?? []
   const total = data?.total ?? 0
 
-  const handleAction = (id: number, status: 'approved' | 'rejected') => {
+  const handleAction = (id: string, status: 'approved' | 'rejected') => {
     updateStatus.mutate({ id, status })
   }
 

--- a/frontend/src/hooks/useApprovals.ts
+++ b/frontend/src/hooks/useApprovals.ts
@@ -14,18 +14,18 @@ export function useApprovals(params: {
   })
 }
 
-export function useApprovalDetail(id: number) {
+export function useApprovalDetail(id: string) {
   return useQuery({
     queryKey: ['approvals', id],
     queryFn: () => getApprovalDetail(id),
-    enabled: id > 0,
+    enabled: !!id,
   })
 }
 
 export function useUpdateApprovalStatus() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: ({ id, status, memo }: { id: number; status: 'approved' | 'rejected'; memo?: string }) =>
+    mutationFn: ({ id, status, memo }: { id: string; status: 'approved' | 'rejected'; memo?: string }) =>
       updateApprovalStatus(id, status, memo),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['approvals'] })

--- a/frontend/src/pages/ApprovalDetail.tsx
+++ b/frontend/src/pages/ApprovalDetail.tsx
@@ -1,10 +1,9 @@
 import { useParams } from 'react-router-dom'
 import { useApprovalDetail } from '../hooks/useApprovals'
 import ReviewControls from '../components/approvals/ReviewControls'
-import BacktestMetricsPanel from '../components/approvals/BacktestMetrics'
 import StatusBadge from '../components/common/StatusBadge'
 import { PageSkeleton } from '../components/common/Skeleton'
-import { formatDate, formatDateTime } from '../utils/formatters'
+import { formatDateTime } from '../utils/formatters'
 import { APPROVAL_STATUS_LABELS } from '../utils/constants'
 import type { ApprovalStatus, ApprovalType } from '../types/approval'
 
@@ -15,20 +14,20 @@ const STATUS_VARIANT: Record<ApprovalStatus, string> = {
 }
 
 const TYPE_BADGE: Record<ApprovalType, { label: string; variant: string }> = {
-  strategy_report: { label: '전략 리포트', variant: 'info' },
-  budget_allocation: { label: '예산 할당', variant: 'primary' },
-  live_switch: { label: '실전 전환', variant: 'warning' },
-  risk_alert: { label: '위험 알림', variant: 'negative' },
+  strategy_adopt: { label: '전략 채택', variant: 'info' },
+  budget_change: { label: '예산 변경', variant: 'primary' },
+  bot_create: { label: '봇 생성', variant: 'positive' },
+  bot_stop: { label: '봇 중지', variant: 'warning' },
+  rule_change: { label: '규칙 변경', variant: 'negative' },
 }
 
 export default function ApprovalDetail() {
   const { id } = useParams<{ id: string }>()
-  const { data: approval, isLoading } = useApprovalDetail(Number(id))
+  const { data: approval, isLoading } = useApprovalDetail(id ?? '')
 
   if (isLoading) return <PageSkeleton />
   if (!approval) return <div className="text-text-muted text-center py-12">결재 항목을 찾을 수 없습니다</div>
 
-  const detail = approval.detail
   const isPending = approval.status === 'pending'
   const typeInfo = TYPE_BADGE[approval.type] || { label: approval.type, variant: 'muted' }
 
@@ -48,115 +47,52 @@ export default function ApprovalDetail() {
         </div>
       </div>
 
-      {/* 결재 영역 */}
-      <ReviewControls approvalId={approval.id} isPending={isPending} />
-
-      {/* Agent 분석 */}
-      {detail && (
-        <div className="bg-surface border border-border rounded-lg p-5 mb-6">
-          <h3 className="text-[15px] font-semibold mb-3">Agent 분석</h3>
-          <div className="space-y-4 text-[13px]">
-            <div>
-              <div className="text-text-muted text-[12px] font-semibold mb-1">요약</div>
-              <p>{detail.agent_summary}</p>
-            </div>
-            <div>
-              <div className="text-text-muted text-[12px] font-semibold mb-1">근거</div>
-              <p>{detail.agent_rationale}</p>
-            </div>
-            <div>
-              <div className="text-text-muted text-[12px] font-semibold mb-1">리스크</div>
-              <p>{detail.agent_risks}</p>
-            </div>
-            <div>
-              <div className="text-text-muted text-[12px] font-semibold mb-1">권장 사항</div>
-              <p>{detail.agent_recommendation}</p>
-            </div>
-          </div>
+      {/* 거부 사유 배너 */}
+      {approval.reject_reason && (
+        <div className="bg-negative/10 border border-negative/30 rounded-lg p-4 mb-6 text-[13px] text-negative">
+          <span className="font-semibold">거부 사유:</span> {approval.reject_reason}
         </div>
       )}
 
-      {/* 전략 정보 + 백테스트 요약 */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
-        <div className="bg-surface border border-border rounded-lg p-5">
-          <h3 className="text-[15px] font-semibold mb-3">전략 정보</h3>
-          <div className="space-y-2">
-            {detail && (
-              <>
-                <div className="flex justify-between py-2 border-b border-border text-[13px]">
-                  <span className="text-text-muted">전략명</span>
-                  <span>{detail.strategy_name}</span>
-                </div>
-                <div className="flex justify-between py-2 border-b border-border text-[13px]">
-                  <span className="text-text-muted">버전</span>
-                  <span>{detail.strategy_version}</span>
-                </div>
-              </>
-            )}
+      {/* 결재 정보 */}
+      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+        <h3 className="text-[15px] font-semibold mb-3">결재 정보</h3>
+        <div className="space-y-2">
+          <div className="flex justify-between py-2 border-b border-border text-[13px]">
+            <span className="text-text-muted">유형</span>
+            <span>{typeInfo.label}</span>
+          </div>
+          <div className="flex justify-between py-2 border-b border-border text-[13px]">
+            <span className="text-text-muted">요청자</span>
+            <span>{approval.requester}</span>
+          </div>
+          <div className="flex justify-between py-2 border-b border-border text-[13px]">
+            <span className="text-text-muted">요청일</span>
+            <span>{formatDateTime(approval.requested_at)}</span>
+          </div>
+          {approval.expires_at && (
             <div className="flex justify-between py-2 border-b border-border text-[13px]">
-              <span className="text-text-muted">작성자</span>
-              <span>{approval.requester}</span>
+              <span className="text-text-muted">만료일</span>
+              <span>{formatDateTime(approval.expires_at)}</span>
             </div>
-            {detail && detail.filepath && (
-              <div className="flex justify-between py-2 text-[13px]">
-                <span className="text-text-muted">파일 경로</span>
-                <span className="font-mono text-[12px]">{detail.filepath}</span>
-              </div>
-            )}
-          </div>
+          )}
+          {approval.resolved_at && (
+            <div className="flex justify-between py-2 border-b border-border text-[13px]">
+              <span className="text-text-muted">처리일</span>
+              <span>{formatDateTime(approval.resolved_at)}</span>
+            </div>
+          )}
+          {approval.resolved_by && (
+            <div className="flex justify-between py-2 text-[13px]">
+              <span className="text-text-muted">처리자</span>
+              <span>{approval.resolved_by}</span>
+            </div>
+          )}
         </div>
-
-        {detail && (
-          <div className="bg-surface border border-border rounded-lg p-5">
-            <h3 className="text-[15px] font-semibold mb-3">백테스트 요약</h3>
-            <div className="space-y-2">
-              <div className="flex justify-between py-2 border-b border-border text-[13px]">
-                <span className="text-text-muted">기간</span>
-                <span>{formatDate(detail.backtest_start)} ~ {formatDate(detail.backtest_end)}</span>
-              </div>
-              <div className="flex justify-between py-2 border-b border-border text-[13px]">
-                <span className="text-text-muted">초기 자산</span>
-                <span>{detail.initial_capital != null ? `${detail.initial_capital.toLocaleString()}원` : '-'}</span>
-              </div>
-              <div className="flex justify-between py-2 border-b border-border text-[13px]">
-                <span className="text-text-muted">최종 자산</span>
-                <span>{detail.final_capital != null ? `${detail.final_capital.toLocaleString()}원` : '-'}</span>
-              </div>
-              <div className="flex justify-between py-2 border-b border-border text-[13px]">
-                <span className="text-text-muted">수익률</span>
-                <span className={detail.metrics.total_return >= 0 ? 'text-positive' : 'text-negative'}>
-                  {(detail.metrics.total_return * 100).toFixed(2)}%
-                </span>
-              </div>
-              <div className="flex justify-between py-2 text-[13px]">
-                <span className="text-text-muted">거래 수</span>
-                <span>{detail.metrics.total_trades}회</span>
-              </div>
-            </div>
-          </div>
-        )}
       </div>
 
-      {/* 성과 지표 */}
-      {detail && <BacktestMetricsPanel metrics={detail.metrics} />}
-
-      {/* 차트 */}
-      {detail && (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="bg-surface border border-border rounded-lg p-5">
-            <h3 className="text-[15px] font-semibold mb-3">자산 추이</h3>
-            <div className="h-[200px] bg-bg border border-dashed border-border rounded-lg flex items-center justify-center text-text-muted text-[13px]">
-              에쿼티 커브 (Area Chart)
-            </div>
-          </div>
-          <div className="bg-surface border border-border rounded-lg p-5">
-            <h3 className="text-[15px] font-semibold mb-3">드로우다운</h3>
-            <div className="h-[200px] bg-bg border border-dashed border-border rounded-lg flex items-center justify-center text-text-muted text-[13px]">
-              드로우다운 (Area Chart)
-            </div>
-          </div>
-        </div>
-      )}
+      {/* 결재 영역 */}
+      <ReviewControls approvalId={approval.id} isPending={isPending} />
     </>
   )
 }

--- a/frontend/src/types/approval.ts
+++ b/frontend/src/types/approval.ts
@@ -1,46 +1,37 @@
 export type ApprovalStatus = 'pending' | 'approved' | 'rejected'
-export type ApprovalType = 'strategy_report' | 'budget_allocation' | 'live_switch' | 'risk_alert'
+export type ApprovalType = 'strategy_adopt' | 'budget_change' | 'bot_create' | 'bot_stop' | 'rule_change'
+
+export interface ApprovalReview {
+  reviewer: string
+  result: 'pass' | 'warn' | 'fail'
+  detail: string
+  reviewed_at: string
+}
+
+export interface ApprovalHistoryEntry {
+  action: string
+  actor: string
+  at: string
+  detail?: string
+}
 
 export interface Approval {
-  id: number
+  id: string
   type: ApprovalType
   title: string
   requester: string
   requested_at: string
   status: ApprovalStatus
-  reference_id?: number
+  reference_id?: string
   memo?: string
   resolved_at?: string
   resolved_by?: string
+  body?: string
+  params?: Record<string, unknown>
+  reviews?: ApprovalReview[]
+  history?: ApprovalHistoryEntry[]
+  expires_at?: string
+  reject_reason?: string
 }
 
-export interface ApprovalDetail extends Approval {
-  detail?: StrategyReportDetail
-}
-
-export interface StrategyReportDetail {
-  strategy_name: string
-  strategy_version: string
-  filepath?: string
-  agent_summary: string
-  agent_rationale: string
-  agent_risks: string
-  agent_recommendation: string
-  backtest_start: string
-  backtest_end: string
-  initial_capital?: number
-  final_capital?: number
-  metrics: BacktestMetrics
-  equity_curve: { date: string; value: number }[]
-  drawdown: { date: string; value: number }[]
-}
-
-export interface BacktestMetrics {
-  sharpe_ratio: number
-  max_drawdown: number
-  win_rate: number
-  profit_factor: number
-  total_trades: number
-  total_return: number
-  annual_return: number
-}
+export type ApprovalDetail = Approval


### PR DESCRIPTION
## Summary
- `ApprovalType`을 백엔드/스펙 기준 5개 유형(`strategy_adopt`, `budget_change`, `bot_create`, `bot_stop`, `rule_change`)으로 수정
- `Approval.id` 타입을 `number` → `string`으로 변경 (백엔드 UUID 정합성)
- `Approval` 타입에 누락 필드 추가 (`body`, `params`, `reviews`, `history`, `expires_at`, `reject_reason`)
- `ApprovalDetail`을 `Approval` alias로 변경하여 strategy_report 전용 구조 제거

## 변경 파일
- `types/approval.ts` — 타입 정의 전면 수정
- `ApprovalFilters.tsx` — 유형 필터 옵션 5개로 변경
- `ApprovalTable.tsx` — 유형 뱃지 매핑 수정
- `ApprovalDetail.tsx` — 유형 뱃지 수정, id string 반영, strategy 전용 UI 제거
- `PendingApprovals.tsx` — 유형 라벨 매핑 수정
- `ReviewControls.tsx` — id 타입 string 반영
- `useApprovals.ts`, `api/approvals.ts` — id 타입 string 반영

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] 프론트엔드 빌드 성공
- [x] 백엔드 approval 테스트 48개 통과

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)