### PR TITLE
feat: 결재함 목록 필터 및 컬럼 목업 반영

### DIFF
--- a/frontend/src/components/approvals/ApprovalFilters.tsx
+++ b/frontend/src/components/approvals/ApprovalFilters.tsx
@@ -20,61 +20,49 @@ interface ApprovalFiltersProps {
   status: ApprovalStatus | 'all'
   type: ApprovalType | 'all'
   search: string
-  items?: Approval[]
+  pendingCount: number
   onStatusChange: (s: ApprovalStatus | 'all') => void
   onTypeChange: (t: ApprovalType | 'all') => void
   onSearchChange: (q: string) => void
 }
 
-export default function ApprovalFilters({ status, type, search, items, onStatusChange, onTypeChange, onSearchChange }: ApprovalFiltersProps) {
-  const counts: Record<string, number> = { all: 0, pending: 0, approved: 0, rejected: 0 }
-  for (const item of items ?? []) {
-    counts.all++
-    if (item.status in counts) counts[item.status]++
-  }
-
+export default function ApprovalFilters({ status, type, search, pendingCount, onStatusChange, onTypeChange, onSearchChange }: ApprovalFiltersProps) {
   return (
-    <div className="space-y-3 mb-4">
-      <div className="flex items-center gap-3 flex-wrap">
-        <div className="flex gap-1 bg-bg rounded-lg p-0.5">
-          {STATUS_OPTIONS.map((opt) => (
-            <button
-              key={opt.key}
-              onClick={() => onStatusChange(opt.key)}
-              className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
-                status === opt.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
-              }`}
-            >
-              {opt.label}
-              {counts[opt.key] > 0 && (
-                <span className="ml-1 bg-border text-text text-[11px] px-1.5 py-0.5 rounded-full">{counts[opt.key]}</span>
-              )}
-            </button>
-          ))}
-        </div>
+    <div className="flex items-center gap-3 flex-wrap mb-4">
+      <div className="flex gap-1 bg-bg rounded-lg p-0.5">
+        {STATUS_OPTIONS.map((opt) => (
+          <button
+            key={opt.key}
+            onClick={() => onStatusChange(opt.key)}
+            className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
+              status === opt.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
+            }`}
+          >
+            {opt.label}
+            {opt.key === 'pending' && pendingCount > 0 && (
+              <span className="ml-1 bg-border text-text text-[11px] px-1.5 py-0.5 rounded-full">
+                {pendingCount}
+              </span>
+            )}
+          </button>
+        ))}
       </div>
-      <div className="flex items-center gap-3 flex-wrap">
-        <div className="flex gap-1 bg-bg rounded-lg p-0.5">
-          {TYPE_OPTIONS.map((opt) => (
-            <button
-              key={opt.key}
-              onClick={() => onTypeChange(opt.key)}
-              className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
-                type === opt.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
-              }`}
-            >
-              {opt.label}
-            </button>
-          ))}
-        </div>
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => onSearchChange(e.target.value)}
-          placeholder="제목, 전략명 검색..."
-          className="bg-bg border border-border rounded-lg px-3 py-1.5 text-text text-[13px] w-[240px] focus:outline-none focus:border-primary"
-        />
-      </div>
+      <select
+        value={type}
+        onChange={(e) => onTypeChange(e.target.value as ApprovalType | 'all')}
+        className="bg-bg border border-border rounded-lg px-3 py-1.5 text-text text-[13px] min-w-[140px] focus:outline-none focus:border-primary cursor-pointer"
+      >
+        {TYPE_OPTIONS.map((opt) => (
+          <option key={opt.key} value={opt.key}>{opt.label}</option>
+        ))}
+      </select>
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => onSearchChange(e.target.value)}
+        placeholder="제목, 전략명 검색..."
+        className="bg-bg border border-border rounded-lg px-3 py-1.5 text-text text-[13px] w-[240px] focus:outline-none focus:border-primary"
+      />
     </div>
   )
 }

--- a/frontend/src/components/approvals/ApprovalTable.tsx
+++ b/frontend/src/components/approvals/ApprovalTable.tsx
@@ -4,12 +4,12 @@ import { formatDateTime } from '../../utils/formatters'
 import type { Approval, ApprovalStatus, ApprovalType } from '../../types/approval'
 import { APPROVAL_STATUS_LABELS } from '../../utils/constants'
 
-const TYPE_BADGE: Record<ApprovalType, { label: string; variant: string }> = {
-  strategy_adopt: { label: '전략 채택', variant: 'info' },
-  budget_change: { label: '예산 변경', variant: 'primary' },
-  bot_create: { label: '봇 생성', variant: 'positive' },
-  bot_stop: { label: '봇 중지', variant: 'warning' },
-  rule_change: { label: '규칙 변경', variant: 'negative' },
+const TYPE_LABEL: Record<ApprovalType, string> = {
+  strategy_adopt: '전략 채택',
+  budget_change: '예산 변경',
+  bot_create: '봇 생성',
+  bot_stop: '봇 중지',
+  rule_change: '규칙 변경',
 }
 
 const STATUS_VARIANT: Record<ApprovalStatus, string> = {
@@ -30,8 +30,8 @@ export default function ApprovalTable({ items }: { items: Approval[] }) {
             <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">제목</th>
             <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">요청자</th>
             <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">요청일</th>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">처리일</th>
             <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">상태</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">처리일</th>
           </tr>
         </thead>
         <tbody>
@@ -40,29 +40,26 @@ export default function ApprovalTable({ items }: { items: Approval[] }) {
               <td colSpan={6} className="px-3 py-8 text-center text-text-muted text-[13px]">결재 항목이 없습니다</td>
             </tr>
           ) : (
-            items.map((item) => {
-              const typeInfo = TYPE_BADGE[item.type] || { label: item.type, variant: 'muted' }
-              return (
+            items.map((item) => (
                 <tr
                   key={item.id}
                   onClick={() => navigate(`/approvals/${item.id}`)}
                   className="hover:bg-surface-hover cursor-pointer"
                 >
                   <td className="px-3 py-3 border-b border-border text-[13px]">
-                    <StatusBadge variant={typeInfo.variant as 'info'}>{typeInfo.label}</StatusBadge>
+                    <StatusBadge variant="muted">{TYPE_LABEL[item.type] || item.type}</StatusBadge>
                   </td>
                   <td className="px-3 py-3 border-b border-border text-[13px]">{item.title}</td>
                   <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{item.requester}</td>
                   <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{formatDateTime(item.requested_at)}</td>
-                  <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{item.resolved_at ? formatDateTime(item.resolved_at) : '-'}</td>
                   <td className="px-3 py-3 border-b border-border text-[13px]">
                     <StatusBadge variant={STATUS_VARIANT[item.status] as 'warning'}>
                       {APPROVAL_STATUS_LABELS[item.status] || item.status}
                     </StatusBadge>
                   </td>
+                  <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{item.resolved_at ? formatDateTime(item.resolved_at) : '-'}</td>
                 </tr>
-              )
-            })
+              ))
           )}
         </tbody>
       </table>

--- a/frontend/src/pages/Approvals.tsx
+++ b/frontend/src/pages/Approvals.tsx
@@ -15,6 +15,7 @@ export default function Approvals() {
   const [offset, setOffset] = useState(0)
 
   const { data, isLoading } = useApprovals({ status, type, offset, limit: LIMIT })
+  const pendingQuery = useApprovals({ status: 'pending', limit: 0 })
 
   const allItems = data?.items ?? []
   const filtered = search
@@ -27,7 +28,7 @@ export default function Approvals() {
         status={status}
         type={type}
         search={search}
-        items={allItems}
+        pendingCount={pendingQuery.data?.total ?? 0}
         onStatusChange={(s) => { setStatus(s); setOffset(0) }}
         onTypeChange={(t) => { setType(t); setOffset(0) }}
         onSearchChange={(q) => { setSearch(q); setOffset(0) }}


### PR DESCRIPTION
## Summary
- 유형 필터를 탭 버튼에서 셀렉트 박스로 변경하여 목업과 일치
- 상태 탭에 대기 건수를 API 연동으로 표시
- 테이블 컬럼 순서를 목업 기준으로 재배치 (상태 → 처리일 순)
- 유형 뱃지 색상을 muted로 통일 (목업 기준)

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] 프론트엔드 빌드 성공
- [x] 백엔드 전체 테스트 1310 passed

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)