### PR TITLE
feat: 결재 상세 공통 레이아웃 및 유형별 실행 내용

### DIFF
--- a/frontend/src/components/approvals/ExecutionContent.tsx
+++ b/frontend/src/components/approvals/ExecutionContent.tsx
@@ -1,0 +1,150 @@
+import type { ApprovalType } from '../../types/approval'
+
+interface ExecutionContentProps {
+  type: ApprovalType
+  params?: Record<string, unknown>
+}
+
+const INFO_BANNERS: Record<ApprovalType, { text: string; variant: 'info' | 'warning' }> = {
+  strategy_adopt: { text: '승인 시 해당 전략이 채택(registered) 상태로 전환됩니다.', variant: 'info' },
+  budget_change: { text: '승인 시 Treasury에서 예산이 즉시 재배분됩니다.', variant: 'info' },
+  bot_create: { text: '승인 시 BotManager에서 봇이 즉시 생성됩니다.', variant: 'info' },
+  bot_stop: { text: '승인 시 해당 봇의 거래가 즉시 중지됩니다.', variant: 'warning' },
+  rule_change: { text: '승인 시 RuleEngine에서 해당 봇의 규칙이 즉시 갱신됩니다.', variant: 'info' },
+}
+
+function InfoBanner({ type }: { type: ApprovalType }) {
+  const banner = INFO_BANNERS[type]
+  if (!banner) return null
+
+  const isWarning = banner.variant === 'warning'
+  return (
+    <div className={`${isWarning ? 'bg-warning/10 text-warning' : 'bg-info/10 text-info'} p-3 rounded text-[12px] mb-4`}>
+      {isWarning ? '\u26A0' : '\uD83D\uDCA1'} {banner.text}
+    </div>
+  )
+}
+
+function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex justify-between py-2 border-b border-border text-[13px]">
+      <span className="text-text-muted">{label}</span>
+      <span>{value}</span>
+    </div>
+  )
+}
+
+function formatCurrency(value: unknown): string {
+  const num = Number(value)
+  if (isNaN(num)) return String(value ?? '-')
+  return `${num.toLocaleString()}원`
+}
+
+function StrategyAdoptContent({ params }: { params: Record<string, unknown> }) {
+  return (
+    <>
+      <InfoRow label="대상 전략" value={<span className="font-mono text-[12px]">{String(params.strategy_name ?? '-')}</span>} />
+      <InfoRow label="버전" value={String(params.version ?? '-')} />
+    </>
+  )
+}
+
+function BudgetChangeContent({ params }: { params: Record<string, unknown> }) {
+  const current = Number(params.current_budget ?? 0)
+  const requested = Number(params.requested_budget ?? 0)
+  const diff = requested - current
+  const pct = current > 0 ? ((diff / current) * 100).toFixed(0) : '-'
+  const sign = diff >= 0 ? '+' : ''
+
+  return (
+    <>
+      <InfoRow label="대상 봇" value={<span className="font-mono text-[12px]">{String(params.bot_id ?? '-')}</span>} />
+      <InfoRow label="현재 예산" value={formatCurrency(current)} />
+      <InfoRow label="요청 예산" value={formatCurrency(requested)} />
+      <InfoRow label="변경폭" value={`${sign}${formatCurrency(diff)} (${sign}${pct}%)`} />
+    </>
+  )
+}
+
+function BotCreateContent({ params }: { params: Record<string, unknown> }) {
+  return (
+    <>
+      <InfoRow label="전략명" value={<span className="font-mono text-[12px]">{String(params.strategy_name ?? '-')}</span>} />
+      <InfoRow label="배정 예산" value={formatCurrency(params.budget)} />
+      <InfoRow label="거래 모드" value={String(params.trade_mode ?? '-')} />
+    </>
+  )
+}
+
+function BotStopContent({ params }: { params: Record<string, unknown> }) {
+  return (
+    <>
+      <InfoRow label="대상 봇" value={<span className="font-mono text-[12px]">{String(params.bot_id ?? '-')}</span>} />
+      <InfoRow label="중지 사유" value={String(params.reason ?? '-')} />
+    </>
+  )
+}
+
+function RuleChangeContent({ params }: { params: Record<string, unknown> }) {
+  const rules = (params.rules ?? []) as Array<{
+    name: string
+    current_value: string | number
+    requested_value: string | number
+  }>
+
+  return (
+    <>
+      <InfoRow label="대상 봇" value={<span className="font-mono text-[12px]">{String(params.bot_id ?? '-')}</span>} />
+      {rules.length > 0 && (
+        <div className="mt-3">
+          <div className="text-[12px] font-semibold text-text-muted mb-2">변경 규칙</div>
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse">
+              <thead>
+                <tr>
+                  <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">규칙</th>
+                  <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">현재 값</th>
+                  <th className="text-center px-2 py-2 text-[12px] text-text-muted border-b border-border">&rarr;</th>
+                  <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">요청 값</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rules.map((rule) => (
+                  <tr key={rule.name}>
+                    <td className="px-3 py-2 border-b border-border text-[13px] font-mono">{rule.name}</td>
+                    <td className="px-3 py-2 border-b border-border text-[13px]">{String(rule.current_value)}</td>
+                    <td className="text-center px-2 py-2 border-b border-border text-[13px] text-text-muted">&rarr;</td>
+                    <td className="px-3 py-2 border-b border-border text-[13px]">{String(rule.requested_value)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+const CONTENT_COMPONENTS: Record<ApprovalType, React.FC<{ params: Record<string, unknown> }>> = {
+  strategy_adopt: StrategyAdoptContent,
+  budget_change: BudgetChangeContent,
+  bot_create: BotCreateContent,
+  bot_stop: BotStopContent,
+  rule_change: RuleChangeContent,
+}
+
+export default function ExecutionContent({ type, params }: ExecutionContentProps) {
+  const ContentComponent = CONTENT_COMPONENTS[type]
+  if (!ContentComponent || !params) return null
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+      <h3 className="text-[15px] font-semibold mb-3">실행 내용</h3>
+      <InfoBanner type={type} />
+      <div className="space-y-0">
+        <ContentComponent params={params} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/approvals/ReviewControls.tsx
+++ b/frontend/src/components/approvals/ReviewControls.tsx
@@ -1,38 +1,26 @@
-import { useState } from 'react'
 import { useUpdateApprovalStatus } from '../../hooks/useApprovals'
 
 export default function ReviewControls({ approvalId, isPending }: { approvalId: string; isPending: boolean }) {
-  const [memo, setMemo] = useState('')
   const updateStatus = useUpdateApprovalStatus()
 
   if (!isPending) return null
 
   return (
-    <div className="bg-surface border border-border rounded-lg p-5 mb-6">
-      <h3 className="text-[15px] font-semibold mb-3">결재</h3>
-      <textarea
-        value={memo}
-        onChange={(e) => setMemo(e.target.value)}
-        placeholder="메모 (선택)"
-        rows={3}
-        className="w-full bg-bg border border-border rounded-lg p-3 text-text text-[14px] placeholder:text-text-muted focus:outline-none focus:border-primary resize-vertical mb-3"
-      />
-      <div className="flex gap-2">
-        <button
-          onClick={() => updateStatus.mutate({ id: approvalId, status: 'approved', memo: memo || undefined })}
-          disabled={updateStatus.isPending}
-          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover disabled:opacity-50"
-        >
-          승인
-        </button>
-        <button
-          onClick={() => updateStatus.mutate({ id: approvalId, status: 'rejected', memo: memo || undefined })}
-          disabled={updateStatus.isPending}
-          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative-hover disabled:opacity-50"
-        >
-          거부
-        </button>
-      </div>
+    <div className="flex gap-2">
+      <button
+        onClick={() => updateStatus.mutate({ id: approvalId, status: 'rejected' })}
+        disabled={updateStatus.isPending}
+        className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text border border-border cursor-pointer hover:bg-surface-hover disabled:opacity-50"
+      >
+        거부
+      </button>
+      <button
+        onClick={() => updateStatus.mutate({ id: approvalId, status: 'approved' })}
+        disabled={updateStatus.isPending}
+        className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover disabled:opacity-50"
+      >
+        승인
+      </button>
     </div>
   )
 }

--- a/frontend/src/pages/ApprovalDetail.tsx
+++ b/frontend/src/pages/ApprovalDetail.tsx
@@ -1,11 +1,12 @@
-import { useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
 import { useApprovalDetail } from '../hooks/useApprovals'
 import ReviewControls from '../components/approvals/ReviewControls'
+import ExecutionContent from '../components/approvals/ExecutionContent'
 import StatusBadge from '../components/common/StatusBadge'
 import { PageSkeleton } from '../components/common/Skeleton'
 import { formatDateTime } from '../utils/formatters'
 import { APPROVAL_STATUS_LABELS } from '../utils/constants'
-import type { ApprovalStatus, ApprovalType } from '../types/approval'
+import type { Approval, ApprovalStatus, ApprovalType, ApprovalReview, ApprovalHistoryEntry } from '../types/approval'
 
 const STATUS_VARIANT: Record<ApprovalStatus, string> = {
   pending: 'warning',
@@ -13,14 +14,137 @@ const STATUS_VARIANT: Record<ApprovalStatus, string> = {
   rejected: 'negative',
 }
 
-const TYPE_BADGE: Record<ApprovalType, { label: string; variant: string }> = {
-  strategy_adopt: { label: '전략 채택', variant: 'info' },
-  budget_change: { label: '예산 변경', variant: 'primary' },
-  bot_create: { label: '봇 생성', variant: 'positive' },
-  bot_stop: { label: '봇 중지', variant: 'warning' },
-  rule_change: { label: '규칙 변경', variant: 'negative' },
+const TYPE_LABEL: Record<ApprovalType, string> = {
+  strategy_adopt: '전략 채택',
+  budget_change: '예산 변경',
+  bot_create: '봇 생성',
+  bot_stop: '봇 중지',
+  rule_change: '규칙 변경',
 }
 
+const REVIEW_RESULT_VARIANT: Record<string, string> = {
+  pass: 'positive',
+  warn: 'warning',
+  fail: 'negative',
+}
+
+const ACTOR_COLOR: Record<string, string> = {
+  user: 'text-positive',
+  rule_engine: 'text-text-muted',
+  treasury: 'text-text-muted',
+}
+
+function getActorColor(actor: string): string {
+  if (actor in ACTOR_COLOR) return ACTOR_COLOR[actor]
+  if (actor.startsWith('agent:')) return 'text-primary'
+  return 'text-text-muted'
+}
+
+/* ── 결재 정보 카드 ── */
+function ApprovalInfoCard({ approval }: { approval: Approval }) {
+  const typeLabel = TYPE_LABEL[approval.type] || approval.type
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5">
+      <h3 className="text-[15px] font-semibold mb-3">결재 정보</h3>
+      <div className="space-y-0">
+        <InfoRow label="요청자" value={approval.requester} />
+        <InfoRow label="유형" value={typeLabel} />
+        <InfoRow label="상태" value={
+          <StatusBadge variant={STATUS_VARIANT[approval.status] as 'warning'}>
+            {APPROVAL_STATUS_LABELS[approval.status]}
+          </StatusBadge>
+        } />
+        <InfoRow label="요청일" value={formatDateTime(approval.requested_at)} />
+        {approval.expires_at && <InfoRow label="만료일" value={formatDateTime(approval.expires_at)} />}
+        {approval.resolved_at && <InfoRow label="처리일" value={formatDateTime(approval.resolved_at)} />}
+        {approval.resolved_by && <InfoRow label="처리자" value={approval.resolved_by} />}
+        {approval.reference_id && (
+          <InfoRow label="참조 리포트" value={
+            <Link to={`/reports/${approval.reference_id}`} className="text-primary no-underline hover:underline font-mono text-[12px]">
+              {approval.reference_id}
+            </Link>
+          } />
+        )}
+      </div>
+    </div>
+  )
+}
+
+/* ── 검토 의견 카드 ── */
+function ReviewsCard({ reviews }: { reviews: ApprovalReview[] }) {
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5">
+      <h3 className="text-[15px] font-semibold mb-3">검토 의견</h3>
+      {reviews.length === 0 ? (
+        <div className="text-[13px] text-text-muted py-4 text-center">검토 의견이 없습니다</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr>
+                <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">검증 주체</th>
+                <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">결과</th>
+                <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">상세</th>
+                <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">검증 시각</th>
+              </tr>
+            </thead>
+            <tbody>
+              {reviews.map((r, i) => (
+                <tr key={i}>
+                  <td className="px-3 py-2.5 border-b border-border text-[13px] font-mono">{r.reviewer}</td>
+                  <td className="px-3 py-2.5 border-b border-border text-[13px]">
+                    <StatusBadge variant={(REVIEW_RESULT_VARIANT[r.result] ?? 'muted') as 'positive'}>
+                      {r.result}
+                    </StatusBadge>
+                  </td>
+                  <td className="px-3 py-2.5 border-b border-border text-[12px] text-text-muted max-w-[300px]">{r.detail}</td>
+                  <td className="px-3 py-2.5 border-b border-border text-[13px] text-text-muted whitespace-nowrap">{formatDateTime(r.reviewed_at)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* ── 감사 이력 카드 ── */
+function AuditHistoryCard({ history }: { history: ApprovalHistoryEntry[] }) {
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5">
+      <h3 className="text-[15px] font-semibold mb-3">감사 이력</h3>
+      {history.length === 0 ? (
+        <div className="text-[13px] text-text-muted py-4 text-center">이력이 없습니다</div>
+      ) : (
+        <div className="space-y-0">
+          {history.map((entry, i) => (
+            <div key={i} className="flex items-start gap-4 py-2.5 border-b border-border last:border-b-0">
+              <span className="text-[12px] text-text-muted whitespace-nowrap min-w-[130px]">{formatDateTime(entry.at)}</span>
+              <span className="text-[13px]">
+                <span className={`font-mono ${getActorColor(entry.actor)}`}>{entry.actor}</span>
+                {' — '}
+                {entry.detail || entry.action}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* ── 공통 InfoRow ── */
+function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex justify-between py-2 border-b border-border last:border-b-0 text-[13px]">
+      <span className="text-text-muted">{label}</span>
+      <span>{value}</span>
+    </div>
+  )
+}
+
+/* ── 메인 페이지 ── */
 export default function ApprovalDetail() {
   const { id } = useParams<{ id: string }>()
   const { data: approval, isLoading } = useApprovalDetail(id ?? '')
@@ -29,70 +153,41 @@ export default function ApprovalDetail() {
   if (!approval) return <div className="text-text-muted text-center py-12">결재 항목을 찾을 수 없습니다</div>
 
   const isPending = approval.status === 'pending'
-  const typeInfo = TYPE_BADGE[approval.type] || { label: approval.type, variant: 'muted' }
 
   return (
     <>
       {/* 상세 헤더 */}
-      <div className="mb-6">
-        <h2 className="text-[20px] font-bold mb-2">{approval.title}</h2>
-        <div className="flex items-center gap-3 flex-wrap">
-          <StatusBadge variant={typeInfo.variant as 'info'}>{typeInfo.label}</StatusBadge>
-          <StatusBadge variant={STATUS_VARIANT[approval.status] as 'warning'}>
-            {APPROVAL_STATUS_LABELS[approval.status]}
-          </StatusBadge>
-          <span className="text-[13px] text-text-muted">
-            요청: {approval.requester} | {formatDateTime(approval.requested_at)}
-          </span>
-        </div>
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-[20px] font-bold">{approval.title}</h2>
+        {isPending && <ReviewControls approvalId={approval.id} isPending={isPending} />}
       </div>
 
       {/* 거부 사유 배너 */}
       {approval.reject_reason && (
-        <div className="bg-negative/10 border border-negative/30 rounded-lg p-4 mb-6 text-[13px] text-negative">
-          <span className="font-semibold">거부 사유:</span> {approval.reject_reason}
+        <div className="bg-negative/10 border border-negative/30 rounded-lg p-4 mb-6 text-[13px]">
+          <div className="font-semibold text-negative mb-1">거부 사유</div>
+          <div className="text-text-muted">{approval.reject_reason}</div>
         </div>
       )}
 
-      {/* 결재 정보 */}
-      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
-        <h3 className="text-[15px] font-semibold mb-3">결재 정보</h3>
-        <div className="space-y-2">
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">유형</span>
-            <span>{typeInfo.label}</span>
-          </div>
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">요청자</span>
-            <span>{approval.requester}</span>
-          </div>
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">요청일</span>
-            <span>{formatDateTime(approval.requested_at)}</span>
-          </div>
-          {approval.expires_at && (
-            <div className="flex justify-between py-2 border-b border-border text-[13px]">
-              <span className="text-text-muted">만료일</span>
-              <span>{formatDateTime(approval.expires_at)}</span>
-            </div>
-          )}
-          {approval.resolved_at && (
-            <div className="flex justify-between py-2 border-b border-border text-[13px]">
-              <span className="text-text-muted">처리일</span>
-              <span>{formatDateTime(approval.resolved_at)}</span>
-            </div>
-          )}
-          {approval.resolved_by && (
-            <div className="flex justify-between py-2 text-[13px]">
-              <span className="text-text-muted">처리자</span>
-              <span>{approval.resolved_by}</span>
-            </div>
-          )}
-        </div>
+      {/* 1행: 결재 정보 | 검토 의견 (2열) */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+        <ApprovalInfoCard approval={approval} />
+        <ReviewsCard reviews={approval.reviews ?? []} />
       </div>
 
-      {/* 결재 영역 */}
-      <ReviewControls approvalId={approval.id} isPending={isPending} />
+      {/* 2행: 본문 (placeholder — #268에서 마크다운 렌더링 구현) */}
+      {approval.body && (
+        <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+          <div className="text-[13px] text-text-muted whitespace-pre-wrap leading-relaxed">{approval.body}</div>
+        </div>
+      )}
+
+      {/* 3행: 실행 내용 */}
+      <ExecutionContent type={approval.type} params={approval.params} />
+
+      {/* 4행: 감사 이력 */}
+      <AuditHistoryCard history={approval.history ?? []} />
     </>
   )
 }


### PR DESCRIPTION
## Summary
- 목업 기준 5개 섹션 레이아웃 구현: 결재 정보 | 검토 의견 (2열) → 본문 → 실행 내용 → 감사 이력
- 5개 유형별 실행 내용 동적 렌더링 (ExecutionContent 컴포넌트)
- 거부 사유 배너, 참조 리포트 링크, 만료일/처리일/처리자 표시
- ReviewControls를 헤더 인라인 버튼으로 변경

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] 프론트엔드 빌드 성공

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)