### PR TITLE
feat: 결재 승인/거부 확인 모달

### DIFF
--- a/frontend/src/components/approvals/ReviewControls.tsx
+++ b/frontend/src/components/approvals/ReviewControls.tsx
@@ -1,26 +1,115 @@
+import { useState } from 'react'
 import { useUpdateApprovalStatus } from '../../hooks/useApprovals'
+import Modal from '../common/Modal'
+import type { ApprovalReview } from '../../types/approval'
 
-export default function ReviewControls({ approvalId, isPending }: { approvalId: string; isPending: boolean }) {
+interface ReviewControlsProps {
+  approvalId: string
+  isPending: boolean
+  title: string
+  reviews?: ApprovalReview[]
+}
+
+export default function ReviewControls({ approvalId, isPending, title, reviews }: ReviewControlsProps) {
+  const [showApprove, setShowApprove] = useState(false)
+  const [showReject, setShowReject] = useState(false)
+  const [rejectReason, setRejectReason] = useState('')
   const updateStatus = useUpdateApprovalStatus()
 
   if (!isPending) return null
 
+  const hasWarnings = reviews?.some((r) => r.result === 'warn' || r.result === 'fail') ?? false
+
+  const handleApprove = () => {
+    updateStatus.mutate({ id: approvalId, status: 'approved' }, {
+      onSuccess: () => setShowApprove(false),
+    })
+  }
+
+  const handleReject = () => {
+    if (!rejectReason.trim()) return
+    updateStatus.mutate({ id: approvalId, status: 'rejected', memo: rejectReason.trim() }, {
+      onSuccess: () => { setShowReject(false); setRejectReason('') },
+    })
+  }
+
   return (
-    <div className="flex gap-2">
-      <button
-        onClick={() => updateStatus.mutate({ id: approvalId, status: 'rejected' })}
-        disabled={updateStatus.isPending}
-        className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text border border-border cursor-pointer hover:bg-surface-hover disabled:opacity-50"
-      >
-        거부
-      </button>
-      <button
-        onClick={() => updateStatus.mutate({ id: approvalId, status: 'approved' })}
-        disabled={updateStatus.isPending}
-        className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover disabled:opacity-50"
-      >
-        승인
-      </button>
-    </div>
+    <>
+      <div className="flex gap-2">
+        <button
+          onClick={() => setShowReject(true)}
+          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text border border-border cursor-pointer hover:bg-surface-hover"
+        >
+          거부
+        </button>
+        <button
+          onClick={() => setShowApprove(true)}
+          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover"
+        >
+          승인
+        </button>
+      </div>
+
+      {/* 승인 확인 모달 */}
+      <Modal open={showApprove} onClose={() => setShowApprove(false)}>
+        <div className="text-[16px] font-semibold text-positive mb-4">결재 승인</div>
+        <div className="text-[13px] text-text-muted mb-4">
+          <strong className="text-text">{title}</strong>을 승인하시겠습니까?
+        </div>
+        {hasWarnings && (
+          <div className="bg-warning/10 text-warning p-3 rounded text-[12px] mb-4">
+            {'\u26A0'} 검토 의견에 <strong>warn</strong> 또는 <strong>fail</strong> 결과가 포함되어 있습니다. 검증 내용을 확인하세요.
+          </div>
+        )}
+        <div className="flex justify-end gap-2 mt-4">
+          <button
+            onClick={() => setShowApprove(false)}
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text border border-border cursor-pointer hover:bg-surface-hover"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleApprove}
+            disabled={updateStatus.isPending}
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover disabled:opacity-50"
+          >
+            승인
+          </button>
+        </div>
+      </Modal>
+
+      {/* 거부 확인 모달 */}
+      <Modal open={showReject} onClose={() => setShowReject(false)}>
+        <div className="text-[16px] font-semibold text-negative mb-4">결재 거부</div>
+        <div className="text-[13px] text-text-muted mb-4">
+          <strong className="text-text">{title}</strong>을 거부하시겠습니까?
+        </div>
+        <div className="mb-4">
+          <label className="block text-[12px] font-semibold text-text-muted mb-1.5">거부 사유</label>
+          <input
+            type="text"
+            value={rejectReason}
+            onChange={(e) => setRejectReason(e.target.value)}
+            placeholder="예: 변동성 구간 추가 검증 필요"
+            className="w-full bg-bg border border-border rounded-lg px-3 py-2 text-text text-[13px] focus:outline-none focus:border-primary"
+          />
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={() => setShowReject(false)}
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text border border-border cursor-pointer hover:bg-surface-hover"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleReject}
+            disabled={updateStatus.isPending || !rejectReason.trim()}
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative-hover disabled:opacity-50"
+          >
+            거부
+          </button>
+        </div>
+      </Modal>
+    </>
   )
 }

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react'
+
+interface ModalProps {
+  open: boolean
+  onClose: () => void
+  children: React.ReactNode
+}
+
+export default function Modal({ open, onClose, children }: ModalProps) {
+  const overlayRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={(e) => { if (e.target === overlayRef.current) onClose() }}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    >
+      <div className="bg-surface border border-border rounded-lg p-6 w-full max-w-[440px] shadow-lg">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/ApprovalDetail.tsx
+++ b/frontend/src/pages/ApprovalDetail.tsx
@@ -160,7 +160,7 @@ export default function ApprovalDetail() {
       {/* 상세 헤더 */}
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-[20px] font-bold">{approval.title}</h2>
-        {isPending && <ReviewControls approvalId={approval.id} isPending={isPending} />}
+        {isPending && <ReviewControls approvalId={approval.id} isPending={isPending} title={approval.title} reviews={approval.reviews} />}
       </div>
 
       {/* 거부 사유 배너 */}


### PR DESCRIPTION
## Summary
- 승인 확인 모달: 요청 제목 + warn/fail 검토 의견 경고 배너
- 거부 확인 모달: 거부 사유 입력 필드 (필수, reject_reason으로 API 전달)
- 공용 Modal 컴포넌트 추가 (ESC 키, 오버레이 클릭으로 닫기)
- 처리 완료(approved/rejected) 상태에서는 버튼 미표시

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] 프론트엔드 빌드 성공

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)