### PR TITLE
feat: 리포트 상세 페이지 및 API 엔드포인트

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import BotDetail from './pages/BotDetail'
 import BacktestData from './pages/BacktestData'
 import Agents from './pages/Agents'
 import AgentDetail from './pages/AgentDetail'
+import ReportDetail from './pages/ReportDetail'
 import Settings from './pages/Settings'
 import NotFound from './pages/NotFound'
 
@@ -53,6 +54,7 @@ export default function App() {
               <Route path="strategies/:id" element={<StrategyDetail />} />
               <Route path="bots" element={<Bots />} />
               <Route path="bots/:id" element={<BotDetail />} />
+              <Route path="reports/:id" element={<ReportDetail />} />
               <Route path="backtest-data" element={<BacktestData />} />
               <Route path="members" element={<Agents />} />
               <Route path="members/:id" element={<AgentDetail />} />

--- a/frontend/src/api/reports.ts
+++ b/frontend/src/api/reports.ts
@@ -1,0 +1,7 @@
+import client from './client'
+import type { ReportDetail } from '../types/report'
+
+export async function getReportDetail(id: string): Promise<ReportDetail> {
+  const res = await client.get(`/api/reports/${id}`)
+  return res.data
+}

--- a/frontend/src/hooks/useReports.ts
+++ b/frontend/src/hooks/useReports.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+import { getReportDetail } from '../api/reports'
+
+export function useReportDetail(id: string) {
+  return useQuery({
+    queryKey: ['reports', id],
+    queryFn: () => getReportDetail(id),
+    enabled: !!id,
+  })
+}

--- a/frontend/src/pages/ReportDetail.tsx
+++ b/frontend/src/pages/ReportDetail.tsx
@@ -1,0 +1,209 @@
+import { Link, useParams } from 'react-router-dom'
+import { useReportDetail } from '../hooks/useReports'
+import StatusBadge from '../components/common/StatusBadge'
+import { PageSkeleton } from '../components/common/Skeleton'
+import { formatDateTime } from '../utils/formatters'
+import type { ReportDetail as ReportDetailType, ReportStatus } from '../types/report'
+
+const STATUS_BADGE: Record<ReportStatus, { label: string; variant: string }> = {
+  draft: { label: '초안', variant: 'muted' },
+  submitted: { label: '제출됨', variant: 'warning' },
+  reviewed: { label: '검토됨', variant: 'info' },
+  adopted: { label: '채택됨', variant: 'positive' },
+  rejected: { label: '거부됨', variant: 'negative' },
+  archived: { label: '보관됨', variant: 'muted' },
+}
+
+function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex justify-between py-2 border-b border-border last:border-b-0 text-[13px]">
+      <span className="text-text-muted">{label}</span>
+      <span>{value}</span>
+    </div>
+  )
+}
+
+function formatCurrency(value: number | null | undefined): string {
+  if (value == null) return '-'
+  return `${value.toLocaleString()}원`
+}
+
+function formatPct(value: number | null | undefined, sign = false): string {
+  if (value == null) return '-'
+  const prefix = sign && value > 0 ? '+' : ''
+  return `${prefix}${value.toFixed(1)}%`
+}
+
+/* ── 리포트 정보 카드 ── */
+function ReportInfoCard({ report }: { report: ReportDetailType }) {
+  const status = STATUS_BADGE[report.status] || { label: report.status, variant: 'muted' }
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5">
+      <h3 className="text-[15px] font-semibold mb-3">리포트 정보</h3>
+      <InfoRow label="리포트 ID" value={<span className="font-mono text-[12px]">{report.report_id}</span>} />
+      <InfoRow label="전략명" value={<span className="font-mono text-[12px]">{report.strategy_name}</span>} />
+      <InfoRow label="버전" value={report.strategy_version} />
+      <InfoRow label="상태" value={<StatusBadge variant={status.variant as 'info'}>{status.label}</StatusBadge>} />
+      <InfoRow label="수행자" value={report.submitted_by} />
+      <InfoRow label="수행일" value={formatDateTime(report.submitted_at)} />
+      <InfoRow label="백테스트 기간" value={report.backtest_period || '-'} />
+    </div>
+  )
+}
+
+/* ── 백테스트 성과 카드 ── */
+function PerformanceCard({ report }: { report: ReportDetailType }) {
+  const initialBalance = report.initial_balance ?? 0
+  const returnAmount = initialBalance * (report.total_return_pct / 100)
+  const mddAmount = initialBalance * ((report.max_drawdown_pct ?? 0) / 100)
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5">
+      <h3 className="text-[15px] font-semibold mb-3">백테스트 성과</h3>
+      <InfoRow
+        label="누적 수익률"
+        value={
+          <span className={`font-semibold ${report.total_return_pct >= 0 ? 'text-positive' : 'text-negative'}`}>
+            {formatPct(report.total_return_pct, true)} ({returnAmount >= 0 ? '+' : ''}{formatCurrency(Math.round(returnAmount))})
+          </span>
+        }
+      />
+      <InfoRow label="총 거래 수" value={`${report.total_trades}회`} />
+      <InfoRow label="승률" value={formatPct(report.win_rate)} />
+      <InfoRow label="수익 팩터" value={report.metrics?.profit_factor?.toFixed(2) ?? '-'} />
+      <InfoRow label="샤프 비율" value={report.sharpe_ratio?.toFixed(2) ?? '-'} />
+      <InfoRow
+        label="최대 낙폭"
+        value={
+          <span className="font-semibold text-negative">
+            {formatPct(report.max_drawdown_pct)} ({formatCurrency(Math.round(mddAmount))})
+          </span>
+        }
+      />
+      <InfoRow label="평균 수익" value={<span className="text-positive">{formatCurrency(report.metrics?.avg_profit ? Math.round(report.metrics.avg_profit) : null)}</span>} />
+      <InfoRow label="평균 손실" value={<span className="text-negative">{formatCurrency(report.metrics?.avg_loss ? Math.round(report.metrics.avg_loss) : null)}</span>} />
+      <InfoRow label="수수료 합계" value={<span className="text-text-muted">{formatCurrency(report.metrics?.total_commission ? Math.round(report.metrics.total_commission) : null)}</span>} />
+      <InfoRow label="활성 거래일" value={report.metrics?.active_days ? `${report.metrics.active_days}일` : '-'} />
+    </div>
+  )
+}
+
+/* ── 백테스트 데이터 카드 ── */
+function BacktestDataCard({ report }: { report: ReportDetailType }) {
+  const symbols = report.symbols ?? []
+  const visible = symbols.slice(0, 3)
+  const remaining = symbols.length - 3
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5">
+      <h3 className="text-[15px] font-semibold mb-3">백테스트 데이터</h3>
+      <InfoRow label="초기 자금" value={formatCurrency(report.initial_balance)} />
+      {symbols.length > 0 && (
+        <div className="mt-3 overflow-x-auto">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr>
+                <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">종목</th>
+                <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">타임프레임</th>
+                <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">기간</th>
+                <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">행 수</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((s) => (
+                <tr key={s.symbol}>
+                  <td className="px-3 py-2 border-b border-border text-[13px]">{s.name} ({s.symbol})</td>
+                  <td className="px-3 py-2 border-b border-border text-[13px]">{s.timeframe}</td>
+                  <td className="px-3 py-2 border-b border-border text-[13px]">{s.period}</td>
+                  <td className="px-3 py-2 border-b border-border text-[13px] text-right">{s.rows.toLocaleString()}</td>
+                </tr>
+              ))}
+              {remaining > 0 && (
+                <tr>
+                  <td colSpan={4} className="px-3 py-2 text-center text-[12px] text-text-muted">
+                    외 {remaining}종목 · <Link to="/backtest-data" className="text-primary no-underline hover:underline">백테스트 데이터 관리</Link>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* ── 메인 페이지 ── */
+export default function ReportDetail() {
+  const { id } = useParams<{ id: string }>()
+  const { data: report, isLoading } = useReportDetail(id ?? '')
+
+  if (isLoading) return <PageSkeleton />
+  if (!report) return <div className="text-text-muted text-center py-12">리포트를 찾을 수 없습니다</div>
+
+  return (
+    <>
+      {/* 헤더 */}
+      <div className="mb-6">
+        <h2 className="text-[20px] font-bold">{report.strategy_name} {report.strategy_version} 검증 리포트</h2>
+      </div>
+
+      {/* 1행: 리포트 정보 | 백테스트 성과 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+        <ReportInfoCard report={report} />
+        <PerformanceCard report={report} />
+      </div>
+
+      {/* 2행: 백테스트 데이터 */}
+      <div className="mb-6">
+        <BacktestDataCard report={report} />
+      </div>
+
+      {/* 3행: 자산 곡선 차트 (플레이스홀더) */}
+      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+        <h3 className="text-[15px] font-semibold mb-3">자산 곡선</h3>
+        <div className="h-[240px] bg-bg-elevated rounded flex items-center justify-center text-text-muted text-[13px]">
+          equity_curve 차트 영역 (detail_json.equity_curve 데이터 기반)
+        </div>
+      </div>
+
+      {/* 4행: 전략 요약 | 리스크 분석 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="bg-surface border border-border rounded-lg p-5">
+          <h3 className="text-[15px] font-semibold mb-3">전략 요약</h3>
+          <div className="text-[13px] text-text-muted leading-relaxed space-y-3">
+            {report.summary && (
+              <div>
+                <div className="text-text font-semibold mb-1">요약</div>
+                <p>{report.summary}</p>
+              </div>
+            )}
+            {report.rationale && (
+              <div>
+                <div className="text-text font-semibold mb-1">근거</div>
+                <p>{report.rationale}</p>
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="bg-surface border border-border rounded-lg p-5">
+          <h3 className="text-[15px] font-semibold mb-3">리스크 분석</h3>
+          <div className="text-[13px] text-text-muted leading-relaxed space-y-3">
+            {report.risks && (
+              <div>
+                <div className="text-text font-semibold mb-1">위험 요소</div>
+                <p>{report.risks}</p>
+              </div>
+            )}
+            {report.recommendations && (
+              <div>
+                <div className="text-text font-semibold mb-1">권장 사항</div>
+                <p>{report.recommendations}</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/types/report.ts
+++ b/frontend/src/types/report.ts
@@ -1,0 +1,36 @@
+export type ReportStatus = 'draft' | 'submitted' | 'reviewed' | 'adopted' | 'rejected' | 'archived'
+
+export interface ReportSymbol {
+  symbol: string
+  name: string
+  timeframe: string
+  period: string
+  rows: number
+}
+
+export interface ReportDetail {
+  report_id: string
+  strategy_name: string
+  strategy_version: string
+  strategy_path: string
+  status: ReportStatus
+  submitted_at: string
+  submitted_by: string
+  backtest_period: string
+  total_return_pct: number
+  total_trades: number
+  sharpe_ratio: number | null
+  max_drawdown_pct: number | null
+  win_rate: number | null
+  summary: string
+  rationale: string
+  risks: string
+  recommendations: string
+  equity_curve: { date: string; value: number }[]
+  metrics: Record<string, number>
+  initial_balance: number | null
+  final_balance: number | null
+  symbols: ReportSymbol[]
+  user_notes: string
+  reviewed_at: string | null
+}

--- a/src/ante/web/routes/reports.py
+++ b/src/ante/web/routes/reports.py
@@ -31,6 +31,52 @@ async def submit_report(request: Request, body: dict) -> dict:
     }
 
 
+@router.get("/{report_id}")
+async def report_view(request: Request, report_id: str) -> dict:
+    """리포트 단건 조회."""
+    import json
+
+    report_store = getattr(request.app.state, "report_store", None)
+    if report_store is None:
+        raise HTTPException(status_code=503, detail="Report store not available")
+
+    report = await report_store.get(report_id)
+    if report is None:
+        raise HTTPException(status_code=404, detail="리포트를 찾을 수 없습니다")
+
+    try:
+        detail = json.loads(report.detail_json)
+    except (json.JSONDecodeError, TypeError):
+        detail = {}
+
+    return {
+        "report_id": report.report_id,
+        "strategy_name": report.strategy_name,
+        "strategy_version": report.strategy_version,
+        "strategy_path": report.strategy_path,
+        "status": report.status.value,
+        "submitted_at": str(report.submitted_at),
+        "submitted_by": report.submitted_by,
+        "backtest_period": report.backtest_period,
+        "total_return_pct": report.total_return_pct,
+        "total_trades": report.total_trades,
+        "sharpe_ratio": report.sharpe_ratio,
+        "max_drawdown_pct": report.max_drawdown_pct,
+        "win_rate": report.win_rate,
+        "summary": report.summary,
+        "rationale": report.rationale,
+        "risks": report.risks,
+        "recommendations": report.recommendations,
+        "equity_curve": detail.get("equity_curve", []),
+        "metrics": detail.get("metrics", {}),
+        "initial_balance": detail.get("initial_balance"),
+        "final_balance": detail.get("final_balance"),
+        "symbols": detail.get("symbols", []),
+        "user_notes": report.user_notes,
+        "reviewed_at": str(report.reviewed_at) if report.reviewed_at else None,
+    }
+
+
 @router.get("")
 async def list_reports(
     request: Request,

--- a/tests/unit/test_report_api.py
+++ b/tests/unit/test_report_api.py
@@ -1,0 +1,148 @@
+"""리포트 API 테스트."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.report.models import ReportStatus, StrategyReport  # noqa: E402
+from ante.web.app import create_app  # noqa: E402
+
+
+@pytest.fixture
+async def db(tmp_path):
+    from ante.core import Database
+
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+async def report_store(db):
+    from ante.report.store import ReportStore
+
+    store = ReportStore(db)
+    await store.initialize()
+    return store
+
+
+@pytest.fixture
+def app(report_store):
+    return create_app(report_store=report_store)
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+@pytest.fixture
+async def sample_report(report_store):
+    """테스트용 리포트 생성."""
+    report = StrategyReport(
+        report_id="rpt-test-001",
+        strategy_name="momentum_breakout_v2",
+        strategy_version="v2.0",
+        strategy_path="/strategies/momentum_breakout_v2.py",
+        status=ReportStatus.SUBMITTED,
+        submitted_at=datetime(2026, 3, 13, 9, 20, tzinfo=UTC),
+        submitted_by="strategy-dev-01",
+        backtest_period="2024-01 ~ 2026-03",
+        total_return_pct=42.3,
+        total_trades=127,
+        sharpe_ratio=1.72,
+        max_drawdown_pct=-6.8,
+        win_rate=62.2,
+        summary="모멘텀 돌파 전략 요약",
+        rationale="거래량 필터 추가",
+        risks="변동성 구간 MDD 증가",
+        recommendations="모의투자 1개월 검증 후 실전 전환",
+        detail_json=json.dumps(
+            {
+                "equity_curve": [
+                    {"date": "2024-01-02", "value": 10000000},
+                    {"date": "2024-06-30", "value": 12500000},
+                ],
+                "metrics": {
+                    "sharpe_ratio": 1.72,
+                    "max_drawdown": -6.8,
+                    "win_rate": 62.2,
+                    "profit_factor": 1.85,
+                },
+                "initial_balance": 10000000,
+                "final_balance": 14230000,
+                "symbols": [
+                    {
+                        "symbol": "005930",
+                        "name": "삼성전자",
+                        "timeframe": "1일",
+                        "period": "2024-01-02 ~ 2026-03-12",
+                        "rows": 543,
+                    },
+                    {
+                        "symbol": "000660",
+                        "name": "SK하이닉스",
+                        "timeframe": "1일",
+                        "period": "2024-01-02 ~ 2026-03-12",
+                        "rows": 543,
+                    },
+                ],
+            }
+        ),
+    )
+    await report_store.submit(report)
+    return report
+
+
+class TestGetReport:
+    """GET /api/reports/{report_id} 테스트."""
+
+    def test_get_existing(self, client, sample_report):
+        res = client.get(f"/api/reports/{sample_report.report_id}")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["report_id"] == sample_report.report_id
+        assert data["strategy_name"] == "momentum_breakout_v2"
+        assert data["strategy_version"] == "v2.0"
+        assert data["total_return_pct"] == 42.3
+        assert data["total_trades"] == 127
+        assert data["sharpe_ratio"] == 1.72
+        assert data["summary"] == "모멘텀 돌파 전략 요약"
+
+    def test_get_equity_curve(self, client, sample_report):
+        res = client.get(f"/api/reports/{sample_report.report_id}")
+        data = res.json()
+        assert len(data["equity_curve"]) == 2
+        assert data["equity_curve"][0]["date"] == "2024-01-02"
+        assert data["equity_curve"][0]["value"] == 10000000
+
+    def test_get_metrics(self, client, sample_report):
+        res = client.get(f"/api/reports/{sample_report.report_id}")
+        data = res.json()
+        assert data["metrics"]["profit_factor"] == 1.85
+        assert data["initial_balance"] == 10000000
+        assert data["final_balance"] == 14230000
+
+    def test_get_symbols(self, client, sample_report):
+        res = client.get(f"/api/reports/{sample_report.report_id}")
+        data = res.json()
+        assert len(data["symbols"]) == 2
+        assert data["symbols"][0]["symbol"] == "005930"
+
+    def test_get_nonexistent(self, client):
+        res = client.get("/api/reports/nonexistent-id")
+        assert res.status_code == 404
+
+    def test_get_agent_commentary(self, client, sample_report):
+        res = client.get(f"/api/reports/{sample_report.report_id}")
+        data = res.json()
+        assert data["risks"] == "변동성 구간 MDD 증가"
+        assert data["recommendations"] == "모의투자 1개월 검증 후 실전 전환"


### PR DESCRIPTION
## Summary
- `GET /api/reports/{report_id}` 백엔드 엔드포인트 추가 (detail_json 파싱 포함)
- 리포트 상세 프론트엔드 페이지 구현 (4행 레이아웃: 리포트 정보 | 성과 → 데이터 → 차트 → 요약 | 리스크)
- 백테스트 성과 10개 지표, 데이터 테이블 (상위 3종목 + 요약행), 차트 플레이스홀더
- `/reports/:id` 라우트 추가, 결재 상세 참조 리포트 링크 연결
- API 테스트 6개 추가

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] 프론트엔드 빌드 성공
- [x] 리포트 API 테스트 6개 통과
- [x] 기존 리포트 테스트 16개 통과

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)