### PR TITLE
refactor: OHLCV_SCHEMA에 amount 필드 추가

### DIFF
--- a/src/ante/data/normalizer.py
+++ b/src/ante/data/normalizer.py
@@ -62,6 +62,12 @@ class BaseNormalizer(ABC):
                 df = df.with_columns(pl.col(col).cast(pl.Float64))
         if "volume" in df.columns:
             df = df.with_columns(pl.col("volume").cast(pl.Int64))
+        if "amount" in df.columns:
+            df = df.with_columns(pl.col("amount").cast(pl.Int64))
+
+        # amount 컬럼 (없으면 null로 채움)
+        if "amount" not in df.columns:
+            df = df.with_columns(pl.lit(None).cast(pl.Int64).alias("amount"))
 
         # source 컬럼
         if "source" not in df.columns:

--- a/src/ante/data/schemas.py
+++ b/src/ante/data/schemas.py
@@ -13,6 +13,7 @@ OHLCV_SCHEMA: dict[str, type[pl.DataType]] = {
     "low": pl.Float64,
     "close": pl.Float64,
     "volume": pl.Int64,
+    "amount": pl.Int64,
     "source": pl.Utf8,
 }
 

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -75,7 +75,8 @@ class TestSchemas:
         assert "timestamp" in OHLCV_COLUMNS
         assert "symbol" in OHLCV_COLUMNS
         assert "close" in OHLCV_COLUMNS
-        assert len(OHLCV_COLUMNS) == 8
+        assert "amount" in OHLCV_COLUMNS
+        assert len(OHLCV_COLUMNS) == 9
 
     def test_timeframes(self):
         assert "1m" in TIMEFRAMES
@@ -322,6 +323,41 @@ class TestDataNormalizer:
         )
         result = normalizer.normalize(df)
         assert isinstance(result["timestamp"].dtype, pl.Datetime)
+
+    def test_normalize_fills_amount_null_when_missing(self, normalizer):
+        """amount 컬럼이 없는 소스 데이터는 null로 채워진다."""
+        df = pl.DataFrame(
+            {
+                "timestamp": ["2026-03-01T09:00:00"],
+                "open": [50000.0],
+                "high": [50100.0],
+                "low": [49900.0],
+                "close": [50050.0],
+                "volume": [1000],
+            }
+        )
+        result = normalizer.normalize(df)
+        assert "amount" in result.columns
+        assert result["amount"].dtype == pl.Int64
+        assert result["amount"][0] is None
+
+    def test_normalize_preserves_amount_when_present(self, normalizer):
+        """amount 컬럼이 있는 소스 데이터는 값이 유지된다."""
+        df = pl.DataFrame(
+            {
+                "timestamp": ["2026-03-01T09:00:00"],
+                "open": [50000.0],
+                "high": [50100.0],
+                "low": [49900.0],
+                "close": [50050.0],
+                "volume": [1000],
+                "amount": [5000000],
+            }
+        )
+        result = normalizer.normalize(df)
+        assert "amount" in result.columns
+        assert result["amount"][0] == 5000000
+        assert result["amount"].dtype == pl.Int64
 
     def test_normalize_casts_numeric_types(self, normalizer):
         df = pl.DataFrame(


### PR DESCRIPTION
## Summary
- `OHLCV_SCHEMA`에 `amount`(pl.Int64) 필드 추가 (volume 뒤, source 앞)
- `BaseNormalizer.normalize()`에 amount 캐스팅 + 누락 시 null 채움 로직 추가
- 기존 Normalizer(KIS, Yahoo, Default)는 amount 매핑이 없으므로 자동 null 처리

## Test plan
- [x] `OHLCV_COLUMNS`에 amount 포함, 길이 9 확인
- [x] amount 누락 소스 → null 채움 검증
- [x] amount 존재 소스 → 값 유지 검증
- [x] 기존 테스트 49건 + 전체 1311건 통과

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)