### PR TITLE
feat: FUNDAMENTAL_SCHEMA 정의 추가

### DIFF
--- a/src/ante/data/__init__.py
+++ b/src/ante/data/__init__.py
@@ -13,7 +13,14 @@ from ante.data.normalizer import (
     register_normalizer,
 )
 from ante.data.retention import RetentionPolicy
-from ante.data.schemas import OHLCV_COLUMNS, OHLCV_SCHEMA, TICK_SCHEMA, TIMEFRAMES
+from ante.data.schemas import (
+    FUNDAMENTAL_COLUMNS,
+    FUNDAMENTAL_SCHEMA,
+    OHLCV_COLUMNS,
+    OHLCV_SCHEMA,
+    TICK_SCHEMA,
+    TIMEFRAMES,
+)
 from ante.data.store import ParquetStore
 
 __all__ = [
@@ -23,6 +30,8 @@ __all__ = [
     "DataInjector",
     "DataNormalizer",
     "DefaultNormalizer",
+    "FUNDAMENTAL_COLUMNS",
+    "FUNDAMENTAL_SCHEMA",
     "KISNormalizer",
     "OHLCV_COLUMNS",
     "OHLCV_SCHEMA",

--- a/src/ante/data/schemas.py
+++ b/src/ante/data/schemas.py
@@ -27,6 +27,30 @@ TICK_SCHEMA: dict[str, type[pl.DataType]] = {
     "side": pl.Utf8,
 }
 
+# 재무 데이터 스키마 (DART, data.go.kr 등)
+FUNDAMENTAL_SCHEMA: dict[str, type[pl.DataType]] = {
+    "date": pl.Date,
+    "symbol": pl.Utf8,
+    "market_cap": pl.Int64,
+    "shares_listed": pl.Int64,
+    "shares_outstanding": pl.Int64,
+    "foreign_ratio": pl.Float64,
+    "foreign_shares": pl.Int64,
+    "per": pl.Float64,
+    "pbr": pl.Float64,
+    "eps": pl.Float64,
+    "bps": pl.Float64,
+    "roe": pl.Float64,
+    "debt_to_equity": pl.Float64,
+    "revenue": pl.Int64,
+    "net_income": pl.Int64,
+    "div_yield": pl.Float64,
+    "dps": pl.Float64,
+    "source": pl.Utf8,
+}
+
+FUNDAMENTAL_COLUMNS: list[str] = list(FUNDAMENTAL_SCHEMA.keys())
+
 # 지원되는 타임프레임
 TIMEFRAMES: list[str] = ["1m", "5m", "15m", "1h", "1d"]
 
@@ -43,4 +67,13 @@ def validate_ohlcv(df: pl.DataFrame) -> bool:
         "volume",
         "source",
     }
+    return required.issubset(set(df.columns))
+
+
+def validate_fundamental(df: pl.DataFrame) -> bool:
+    """FUNDAMENTAL DataFrame이 스키마에 부합하는지 검증.
+
+    필수 필드: date, symbol, source만 필수. 나머지는 null 허용.
+    """
+    required = {"date", "symbol", "source"}
     return required.issubset(set(df.columns))

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -13,7 +13,14 @@ from ante.data.collector import DataCollector
 from ante.data.injector import DataInjector
 from ante.data.normalizer import DataNormalizer
 from ante.data.retention import RetentionPolicy
-from ante.data.schemas import OHLCV_COLUMNS, TIMEFRAMES, validate_ohlcv
+from ante.data.schemas import (
+    FUNDAMENTAL_COLUMNS,
+    FUNDAMENTAL_SCHEMA,
+    OHLCV_COLUMNS,
+    TIMEFRAMES,
+    validate_fundamental,
+    validate_ohlcv,
+)
 from ante.data.store import ParquetStore
 
 # ── Fixtures ─────────────────────────────────────────
@@ -88,6 +95,39 @@ class TestSchemas:
     def test_validate_ohlcv_missing_column(self):
         df = _make_ohlcv_df().drop("volume")
         assert validate_ohlcv(df) is False
+
+    def test_fundamental_schema_field_count(self):
+        assert len(FUNDAMENTAL_SCHEMA) == 18
+
+    def test_fundamental_columns_list(self):
+        assert "date" in FUNDAMENTAL_COLUMNS
+        assert "symbol" in FUNDAMENTAL_COLUMNS
+        assert "market_cap" in FUNDAMENTAL_COLUMNS
+        assert "per" in FUNDAMENTAL_COLUMNS
+        assert "source" in FUNDAMENTAL_COLUMNS
+        assert len(FUNDAMENTAL_COLUMNS) == 18
+
+    def test_fundamental_schema_types(self):
+        assert FUNDAMENTAL_SCHEMA["date"] == pl.Date
+        assert FUNDAMENTAL_SCHEMA["symbol"] == pl.Utf8
+        assert FUNDAMENTAL_SCHEMA["market_cap"] == pl.Int64
+        assert FUNDAMENTAL_SCHEMA["per"] == pl.Float64
+        assert FUNDAMENTAL_SCHEMA["source"] == pl.Utf8
+
+    def test_validate_fundamental_valid(self):
+        df = pl.DataFrame(
+            {
+                "date": [datetime(2026, 3, 1).date()],
+                "symbol": ["005930"],
+                "source": ["dart"],
+                "market_cap": [None],
+            }
+        )
+        assert validate_fundamental(df) is True
+
+    def test_validate_fundamental_missing_required(self):
+        df = pl.DataFrame({"date": [datetime(2026, 3, 1).date()], "symbol": ["005930"]})
+        assert validate_fundamental(df) is False
 
 
 # ── store.py 테스트 ─────────────────────────────────


### PR DESCRIPTION
## Summary
- `FUNDAMENTAL_SCHEMA` (18필드: date, symbol, market_cap, per, pbr 등) 및 `FUNDAMENTAL_COLUMNS` 추가
- `validate_fundamental()` 함수 추가 (필수: date, symbol, source)
- `__init__.py`에 export 추가

## Test plan
- [x] FUNDAMENTAL_SCHEMA 필드 수 18 확인
- [x] FUNDAMENTAL_COLUMNS 주요 필드 포함 확인
- [x] 타입 검증 (Date, Utf8, Int64, Float64)
- [x] validate_fundamental 유효/무효 케이스 검증
- [x] 전체 52건 통과

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)