### PR TITLE
refactor: ParquetStore에 data_type 파라미터 추가

### DIFF
--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -9,9 +9,16 @@ import polars as pl
 
 logger = logging.getLogger(__name__)
 
+# data_type별 시간 컬럼명
+_TIME_COLUMN: dict[str, str] = {
+    "ohlcv": "timestamp",
+    "fundamental": "date",
+    "tick": "timestamp",
+}
+
 
 class ParquetStore:
-    """Parquet 파일 관리. OHLCV 데이터의 읽기/쓰기/파티셔닝 담당."""
+    """Parquet 파일 관리. 다양한 데이터 타입의 읽기/쓰기/파티셔닝 담당."""
 
     def __init__(
         self, base_path: str | Path = "data/", compression: str = "snappy"
@@ -23,6 +30,24 @@ class ParquetStore:
     def base_path(self) -> Path:
         return self._base
 
+    def _resolve_path(
+        self, symbol: str, timeframe: str, data_type: str = "ohlcv"
+    ) -> Path:
+        """data_type에 따라 저장 경로를 결정.
+
+        - ohlcv: {base}/ohlcv/{timeframe}/{symbol}/
+        - fundamental: {base}/fundamental/krx/{symbol}/
+        - tick: {base}/tick/krx/{symbol}/
+        """
+        if data_type == "ohlcv":
+            return self._base / "ohlcv" / timeframe / symbol
+        elif data_type == "fundamental":
+            return self._base / "fundamental" / "krx" / symbol
+        elif data_type == "tick":
+            return self._base / "tick" / "krx" / symbol
+        else:
+            return self._base / data_type / timeframe / symbol
+
     async def read(
         self,
         symbol: str,
@@ -30,8 +55,9 @@ class ParquetStore:
         start: str | None = None,
         end: str | None = None,
         limit: int | None = None,
+        data_type: str = "ohlcv",
     ) -> pl.DataFrame:
-        """Parquet에서 OHLCV 데이터 읽기.
+        """Parquet에서 데이터 읽기.
 
         Args:
             symbol: 종목 코드
@@ -39,8 +65,9 @@ class ParquetStore:
             start: 시작 시간 (ISO 형식, inclusive)
             end: 종료 시간 (ISO 형식, inclusive)
             limit: 최근 N건만 반환
+            data_type: 데이터 타입 (ohlcv, fundamental, tick)
         """
-        path = self._base / "ohlcv" / timeframe / symbol
+        path = self._resolve_path(symbol, timeframe, data_type)
         if not path.exists():
             return pl.DataFrame()
 
@@ -60,92 +87,131 @@ class ParquetStore:
             return pl.DataFrame()
 
         df = pl.concat(dfs)
+        time_col = _TIME_COLUMN.get(data_type, "timestamp")
 
-        if start:
+        if start and time_col in df.columns:
             df = df.filter(
-                pl.col("timestamp") >= pl.lit(start).str.to_datetime(time_zone="UTC")
+                pl.col(time_col) >= pl.lit(start).str.to_datetime(time_zone="UTC")
             )
-        if end:
+        if end and time_col in df.columns:
             df = df.filter(
-                pl.col("timestamp") <= pl.lit(end).str.to_datetime(time_zone="UTC")
+                pl.col(time_col) <= pl.lit(end).str.to_datetime(time_zone="UTC")
             )
 
-        df = df.sort("timestamp")
+        if time_col in df.columns:
+            df = df.sort(time_col)
 
         if limit:
             df = df.tail(limit)
 
         return df
 
-    async def write(self, symbol: str, timeframe: str, data: pl.DataFrame) -> None:
+    async def write(
+        self,
+        symbol: str,
+        timeframe: str,
+        data: pl.DataFrame,
+        data_type: str = "ohlcv",
+    ) -> None:
         """데이터를 Parquet에 기록. 월별 파티셔닝, 중복 제거(merge)."""
         if data.is_empty():
             return
 
-        path = self._base / "ohlcv" / timeframe / symbol
+        path = self._resolve_path(symbol, timeframe, data_type)
         path.mkdir(parents=True, exist_ok=True)
 
+        time_col = _TIME_COLUMN.get(data_type, "timestamp")
+
         # 월별 파티셔닝
-        month_col = data["timestamp"].dt.strftime("%Y-%m")
+        if time_col in data.columns:
+            if data[time_col].dtype == pl.Date:
+                month_col = data[time_col].cast(pl.Utf8).str.slice(0, 7)
+            else:
+                month_col = data[time_col].dt.strftime("%Y-%m")
+        else:
+            month_col = pl.Series(["unknown"] * len(data))
+
         data_with_month = data.with_columns(month_col.alias("_month"))
 
         for month_val in data_with_month["_month"].unique().to_list():
             group = data_with_month.filter(pl.col("_month") == month_val).drop("_month")
             filepath = path / f"{month_val}.parquet"
 
+            unique_col = time_col if time_col in group.columns else None
+
             if filepath.exists():
                 try:
                     existing = pl.read_parquet(filepath)
-                    merged = (
-                        pl.concat([existing, group])
-                        .unique(subset=["timestamp"])
-                        .sort("timestamp")
-                    )
+                    merged = pl.concat([existing, group])
+                    if unique_col:
+                        merged = merged.unique(subset=[unique_col]).sort(unique_col)
                     merged.write_parquet(str(filepath), compression=self._compression)
                 except Exception:
                     logger.warning(
                         "Failed to merge with existing file: %s, overwriting", filepath
                     )
-                    group.sort("timestamp").write_parquet(
-                        str(filepath), compression=self._compression
-                    )
+                    if unique_col and unique_col in group.columns:
+                        group = group.sort(unique_col)
+                    group.write_parquet(str(filepath), compression=self._compression)
             else:
-                group.sort("timestamp").write_parquet(
-                    str(filepath), compression=self._compression
-                )
+                if unique_col and unique_col in group.columns:
+                    group = group.sort(unique_col)
+                group.write_parquet(str(filepath), compression=self._compression)
 
         logger.debug("Wrote %d rows for %s/%s", len(data), symbol, timeframe)
 
-    async def append(self, symbol: str, timeframe: str, rows: list[dict]) -> None:
+    async def append(
+        self,
+        symbol: str,
+        timeframe: str,
+        rows: list[dict],
+        data_type: str = "ohlcv",
+    ) -> None:
         """버퍼 데이터를 기존 Parquet에 추가."""
         df = pl.DataFrame(rows)
-        await self.write(symbol, timeframe, df)
+        await self.write(symbol, timeframe, df, data_type=data_type)
 
-    def list_symbols(self, timeframe: str = "1d") -> list[str]:
+    def list_symbols(
+        self, timeframe: str = "1d", data_type: str = "ohlcv"
+    ) -> list[str]:
         """보유 데이터의 종목 목록."""
-        path = self._base / "ohlcv" / timeframe
+        if data_type == "ohlcv":
+            path = self._base / "ohlcv" / timeframe
+        elif data_type in ("fundamental", "tick"):
+            path = self._base / data_type / "krx"
+        else:
+            path = self._base / data_type / timeframe
         if not path.exists():
             return []
         return sorted([d.name for d in path.iterdir() if d.is_dir()])
 
-    def get_date_range(self, symbol: str, timeframe: str) -> tuple[str, str] | None:
+    def get_date_range(
+        self, symbol: str, timeframe: str, data_type: str = "ohlcv"
+    ) -> tuple[str, str] | None:
         """종목의 데이터 기간 조회. (첫 파일 stem, 마지막 파일 stem) 반환."""
-        path = self._base / "ohlcv" / timeframe / symbol
+        path = self._resolve_path(symbol, timeframe, data_type)
         files = sorted(path.glob("*.parquet")) if path.exists() else []
         if not files:
             return None
         return files[0].stem, files[-1].stem
 
     def get_storage_usage(self) -> dict[str, int]:
-        """저장 용량 현황 (바이트). timeframe별 합산."""
+        """저장 용량 현황 (바이트). 데이터 타입/타임프레임별 합산."""
         usage: dict[str, int] = {}
+        # ohlcv: timeframe별
         ohlcv_path = self._base / "ohlcv"
-        if not ohlcv_path.exists():
-            return usage
-        for tf_dir in ohlcv_path.iterdir():
-            if tf_dir.is_dir():
-                size = sum(f.stat().st_size for f in tf_dir.rglob("*.parquet"))
-                usage[tf_dir.name] = size
+        if ohlcv_path.exists():
+            for tf_dir in ohlcv_path.iterdir():
+                if tf_dir.is_dir():
+                    size = sum(f.stat().st_size for f in tf_dir.rglob("*.parquet"))
+                    usage[tf_dir.name] = size
+        # fundamental, tick
+        for dtype in ("fundamental", "tick"):
+            dtype_path = self._base / dtype
+            if dtype_path.exists():
+                size = sum(f.stat().st_size for f in dtype_path.rglob("*.parquet"))
+                if size > 0:
+                    usage[dtype] = size
         return usage
 
     async def validate(
@@ -153,6 +219,7 @@ class ParquetStore:
         symbol: str,
         timeframe: str,
         fix: bool = False,
+        data_type: str = "ohlcv",
     ) -> dict:
         """Parquet 파일 무결성 검증.
 
@@ -160,12 +227,13 @@ class ParquetStore:
             symbol: 종목 코드
             timeframe: 타임프레임
             fix: True이면 손상 파일을 .corrupted 확장자로 이동
+            data_type: 데이터 타입 (ohlcv, fundamental, tick)
 
         Returns:
             {"symbol": str, "timeframe": str, "total": int,
              "valid": int, "corrupted": int, "corrupted_files": list[str]}
         """
-        path = self._base / "ohlcv" / timeframe / symbol
+        path = self._resolve_path(symbol, timeframe, data_type)
         result: dict = {
             "symbol": symbol,
             "timeframe": timeframe,
@@ -196,9 +264,12 @@ class ParquetStore:
 
         return result
 
-    def delete_file(self, symbol: str, timeframe: str, month: str) -> bool:
+    def delete_file(
+        self, symbol: str, timeframe: str, month: str, data_type: str = "ohlcv"
+    ) -> bool:
         """특정 Parquet 파일 삭제. 성공 여부 반환."""
-        filepath = self._base / "ohlcv" / timeframe / symbol / f"{month}.parquet"
+        path = self._resolve_path(symbol, timeframe, data_type)
+        filepath = path / f"{month}.parquet"
         if filepath.exists():
             filepath.unlink()
             logger.info("Deleted parquet file: %s", filepath)

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -235,6 +235,79 @@ class TestParquetStore:
         assert march_file.exists()
         assert april_file.exists()
 
+    async def test_fundamental_write_and_read(self, store):
+        """fundamental 데이터 타입으로 write/read."""
+        from datetime import date
+
+        df = pl.DataFrame(
+            {
+                "date": [date(2026, 3, 1), date(2026, 3, 2)],
+                "symbol": ["005930", "005930"],
+                "market_cap": [500000000000, 510000000000],
+                "per": [12.5, 12.8],
+                "source": ["dart", "dart"],
+            }
+        )
+        await store.write("005930", "", df, data_type="fundamental")
+        result = await store.read("005930", "", data_type="fundamental")
+        assert len(result) == 2
+        assert result["market_cap"][0] == 500000000000
+
+    async def test_fundamental_path_structure(self, store, data_dir):
+        """fundamental은 {base}/fundamental/krx/{symbol}/ 경로."""
+        from datetime import date
+
+        df = pl.DataFrame(
+            {
+                "date": [date(2026, 3, 1)],
+                "symbol": ["005930"],
+                "source": ["dart"],
+            }
+        )
+        await store.write("005930", "", df, data_type="fundamental")
+        path = data_dir / "fundamental" / "krx" / "005930"
+        assert path.exists()
+        assert list(path.glob("*.parquet"))
+
+    async def test_list_symbols_fundamental(self, store):
+        """fundamental data_type의 종목 목록."""
+        from datetime import date
+
+        df = pl.DataFrame(
+            {
+                "date": [date(2026, 3, 1)],
+                "symbol": ["005930"],
+                "source": ["dart"],
+            }
+        )
+        await store.write("005930", "", df, data_type="fundamental")
+        symbols = store.list_symbols(data_type="fundamental")
+        assert symbols == ["005930"]
+
+    async def test_storage_usage_includes_fundamental(self, store):
+        """get_storage_usage가 fundamental 용량도 포함."""
+        from datetime import date
+
+        await store.write("005930", "1d", _make_ohlcv_df())
+        df = pl.DataFrame(
+            {
+                "date": [date(2026, 3, 1)],
+                "symbol": ["005930"],
+                "source": ["dart"],
+            }
+        )
+        await store.write("005930", "", df, data_type="fundamental")
+        usage = store.get_storage_usage()
+        assert "1d" in usage
+        assert "fundamental" in usage
+
+    async def test_ohlcv_default_backward_compat(self, store):
+        """data_type 미지정 시 기존 OHLCV 동작 유지."""
+        df = _make_ohlcv_df()
+        await store.write("005930", "1m", df)
+        result = await store.read("005930", "1m")
+        assert len(result) == 5
+
 
 # ── normalizer.py 테스트 ─────────────────────────────
 


### PR DESCRIPTION
## Summary
- `_resolve_path()` 메서드로 ohlcv/fundamental/tick 경로 분리
- 모든 주요 메서드에 `data_type="ohlcv"` 기본값 파라미터 추가 (하위 호환)
- `get_storage_usage()`에 fundamental/tick 디렉토리 스캔 추가
- fundamental의 `date`(pl.Date) 컬럼 기반 월별 파티셔닝 지원

## Test plan
- [x] fundamental write/read 검증
- [x] fundamental 경로 구조 (`{base}/fundamental/krx/{symbol}/`) 확인
- [x] fundamental 종목 목록 조회
- [x] storage usage에 fundamental 포함 확인
- [x] data_type 미지정 시 OHLCV 하위 호환 확인
- [x] 기존 테스트 52건 전체 통과

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)