### PR TITLE
refactor: RetentionPolicy 보존 기간 스펙 반영

### DIFF
--- a/src/ante/data/retention.py
+++ b/src/ante/data/retention.py
@@ -14,14 +14,16 @@ class RetentionPolicy:
     """데이터 보존 정책 — 오래된 데이터 삭제로 용량 관리.
 
     타임프레임별로 보존 기간을 설정하고, 초과된 데이터를 자동 삭제한다.
+    -1은 무기한 보존을 의미한다.
     """
 
     DEFAULT_RETENTION: dict[str, int] = {
-        "1m": 90,  # 1분봉: 90일
-        "5m": 180,  # 5분봉: 180일
-        "15m": 365,  # 15분봉: 1년
-        "1h": 365,  # 1시간봉: 1년
+        "1m": 365,  # 1분봉: 365일
+        "5m": 365,  # 5분봉: 365일
+        "15m": 365,  # 15분봉: 365일
+        "1h": 365,  # 1시간봉: 365일
         "1d": 3650,  # 일봉: 10년
+        "fundamental": -1,  # 재무데이터: 무기한
     }
 
     def __init__(
@@ -51,6 +53,10 @@ class RetentionPolicy:
         deleted: dict[str, int] = {}
 
         for tf, max_days in self._retention.items():
+            # -1이면 무기한 보존 → 스킵
+            if max_days < 0:
+                continue
+
             count = 0
             symbols = self._store.list_symbols(tf)
 

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -531,8 +531,10 @@ class TestDataCatalog:
 class TestRetentionPolicy:
     def test_default_retention_days(self, store):
         policy = RetentionPolicy(store)
-        assert policy.retention_days["1m"] == 90
+        assert policy.retention_days["1m"] == 365
+        assert policy.retention_days["5m"] == 365
         assert policy.retention_days["1d"] == 3650
+        assert policy.retention_days["fundamental"] == -1
 
     def test_custom_retention_days(self, store):
         custom = {"1m": 30, "1d": 100}
@@ -563,6 +565,16 @@ class TestRetentionPolicy:
         deleted = await policy.enforce(now=now)
 
         # 2026-03 데이터는 15일 전이므로 삭제 안 됨
+        assert deleted == {}
+        result = await store.read("005930", "1m")
+        assert len(result) == 5
+
+    async def test_enforce_skips_negative_retention(self, store):
+        """보존 기간이 -1(무기한)이면 삭제하지 않는다."""
+        await store.write("005930", "1m", _make_ohlcv_df())
+        policy = RetentionPolicy(store, retention_days={"1m": -1})
+        now = datetime(2099, 1, 1, tzinfo=UTC)
+        deleted = await policy.enforce(now=now)
         assert deleted == {}
         result = await store.read("005930", "1m")
         assert len(result) == 5


### PR DESCRIPTION
## Summary
- `DEFAULT_RETENTION` 값을 스펙에 맞게 수정 (1m/5m: 90→365일)
- `fundamental: -1` (무기한 보존) 추가
- `enforce()`에서 `-1`인 데이터 타입은 삭제 스킵

## Test plan
- [x] 기본 보존 기간 값 검증 (1m=365, 5m=365, fundamental=-1)
- [x] -1(무기한) 보존 시 삭제 스킵 확인
- [x] 기존 테스트 6건 통과

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)