### PR TITLE
feat(feed): 체크포인트 + 스케줄러 구현

### DIFF
--- a/src/ante/feed/pipeline/checkpoint.py
+++ b/src/ante/feed/pipeline/checkpoint.py
@@ -6,7 +6,10 @@
 
 from __future__ import annotations
 
+import json
 import logging
+import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -34,7 +37,16 @@ class Checkpoint:
             source: 소스 이름 (예: 'data_go_kr', 'dart').
             data_type: 데이터 유형 (예: 'ohlcv', 'fundamental').
         """
-        ...
+        self._feed_dir = feed_dir
+        self._source = source
+        self._data_type = data_type
+        self._checkpoint_dir = feed_dir / CHECKPOINT_DIR
+        self._file_path = self._checkpoint_dir / f"{source}_{data_type}.json"
+
+    @property
+    def file_path(self) -> Path:
+        """체크포인트 파일 경로를 반환한다."""
+        return self._file_path
 
     def load(self) -> dict | None:
         """체크포인트를 로드한다.
@@ -42,7 +54,29 @@ class Checkpoint:
         Returns:
             체크포인트 딕셔너리. 파일이 없으면 None.
         """
-        ...
+        if not self._file_path.exists():
+            logger.debug(
+                "체크포인트 파일 없음: %s",
+                self._file_path,
+            )
+            return None
+
+        try:
+            data: dict = json.loads(self._file_path.read_text(encoding="utf-8"))
+            logger.debug(
+                "체크포인트 로드: source=%s, data_type=%s, last_date=%s",
+                data.get("source"),
+                data.get("data_type"),
+                data.get("last_date"),
+            )
+            return data
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning(
+                "체크포인트 파일 읽기 실패: %s (%s)",
+                self._file_path,
+                exc,
+            )
+            return None
 
     def save(self, last_date: str) -> None:
         """체크포인트를 원자적으로 저장한다.
@@ -52,7 +86,35 @@ class Checkpoint:
         Args:
             last_date: 마지막으로 성공한 날짜 (YYYY-MM-DD).
         """
-        ...
+        self._checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+        data = {
+            "source": self._source,
+            "data_type": self._data_type,
+            "last_date": last_date,
+            "updated_at": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+
+        # write-then-rename 패턴으로 원자성 보장
+        fd, tmp_path = tempfile.mkstemp(
+            dir=self._checkpoint_dir,
+            suffix=".tmp",
+        )
+        try:
+            with open(fd, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2, ensure_ascii=False)
+            Path(tmp_path).replace(self._file_path)
+        except BaseException:
+            # 실패 시 임시 파일 정리
+            Path(tmp_path).unlink(missing_ok=True)
+            raise
+
+        logger.info(
+            "체크포인트 저장: source=%s, data_type=%s, last_date=%s",
+            self._source,
+            self._data_type,
+            last_date,
+        )
 
     def get_last_date(self) -> str | None:
         """마지막 수집 날짜를 반환한다.
@@ -60,4 +122,7 @@ class Checkpoint:
         Returns:
             마지막 수집 날짜 (YYYY-MM-DD). 체크포인트가 없으면 None.
         """
-        ...
+        checkpoint = self.load()
+        if checkpoint is None:
+            return None
+        return checkpoint.get("last_date")

--- a/src/ante/feed/pipeline/scheduler.py
+++ b/src/ante/feed/pipeline/scheduler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterator
-from datetime import date
+from datetime import date, timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,33 @@ def generate_backfill_dates(
     Yields:
         날짜 문자열 (YYYY-MM-DD), 오름차순.
     """
-    ...
+    start_date = date.fromisoformat(start)
+    end_date = date.fromisoformat(end) if end else date.today()
+
+    # 체크포인트가 있으면 그 다음 날부터 시작
+    if last_checkpoint:
+        checkpoint_date = date.fromisoformat(last_checkpoint)
+        effective_start = checkpoint_date + timedelta(days=1)
+        if effective_start > start_date:
+            start_date = effective_start
+        logger.info(
+            "체크포인트 이후부터 재개: checkpoint=%s, start=%s",
+            last_checkpoint,
+            start_date.isoformat(),
+        )
+
+    if start_date > end_date:
+        logger.debug(
+            "시작일이 종료일 이후: start=%s, end=%s",
+            start_date.isoformat(),
+            end_date.isoformat(),
+        )
+        return
+
+    current = start_date
+    while current <= end_date:
+        yield current.isoformat()
+        current += timedelta(days=1)
 
 
 def generate_daily_date(reference: date | None = None) -> str:
@@ -39,7 +65,9 @@ def generate_daily_date(reference: date | None = None) -> str:
     Returns:
         전일 날짜 문자열 (YYYY-MM-DD).
     """
-    ...
+    ref = reference or date.today()
+    yesterday = ref - timedelta(days=1)
+    return yesterday.isoformat()
 
 
 def is_business_day(target: str) -> bool:
@@ -53,4 +81,6 @@ def is_business_day(target: str) -> bool:
     Returns:
         영업일이면 True.
     """
-    ...
+    d = date.fromisoformat(target)
+    # weekday(): 0=월, 1=화, ..., 4=금, 5=토, 6=일
+    return d.weekday() < 5

--- a/tests/unit/feed/test_checkpoint.py
+++ b/tests/unit/feed/test_checkpoint.py
@@ -1,0 +1,157 @@
+"""Checkpoint 모듈 단위 테스트."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ante.feed.pipeline.checkpoint import CHECKPOINT_DIR, Checkpoint
+
+
+@pytest.fixture
+def feed_dir(tmp_path: Path) -> Path:
+    """임시 .feed 디렉토리를 생성한다."""
+    d = tmp_path / ".feed"
+    d.mkdir()
+    return d
+
+
+class TestCheckpointInit:
+    """Checkpoint 초기화 테스트."""
+
+    def test_file_path_format(self, feed_dir: Path) -> None:
+        """체크포인트 파일 경로가 {source}_{data_type}.json 형식이다."""
+        cp = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        expected = feed_dir / CHECKPOINT_DIR / "data_go_kr_ohlcv.json"
+        assert cp.file_path == expected
+
+    def test_different_source_data_type(self, feed_dir: Path) -> None:
+        """소스와 데이터 유형이 다르면 다른 파일 경로를 가진다."""
+        cp1 = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        cp2 = Checkpoint(feed_dir, "dart", "fundamental")
+        assert cp1.file_path != cp2.file_path
+
+
+class TestCheckpointSaveLoad:
+    """체크포인트 저장/로드 테스트."""
+
+    def test_save_creates_file(self, feed_dir: Path) -> None:
+        """save()는 체크포인트 파일을 생성한다."""
+        cp = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        cp.save("2024-06-15")
+        assert cp.file_path.exists()
+
+    def test_save_creates_checkpoint_dir(self, feed_dir: Path) -> None:
+        """save()는 checkpoints 디렉토리가 없으면 생성한다."""
+        cp = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        cp.save("2024-06-15")
+        assert (feed_dir / CHECKPOINT_DIR).is_dir()
+
+    def test_save_and_load_roundtrip(self, feed_dir: Path) -> None:
+        """저장한 체크포인트를 로드하면 동일한 데이터를 반환한다."""
+        cp = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        cp.save("2024-06-15")
+
+        data = cp.load()
+        assert data is not None
+        assert data["source"] == "data_go_kr"
+        assert data["data_type"] == "ohlcv"
+        assert data["last_date"] == "2024-06-15"
+        assert "updated_at" in data
+
+    def test_save_overwrites_previous(self, feed_dir: Path) -> None:
+        """같은 소스/타입에 대해 다시 save()하면 덮어쓴다."""
+        cp = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        cp.save("2024-06-15")
+        cp.save("2024-06-20")
+
+        data = cp.load()
+        assert data is not None
+        assert data["last_date"] == "2024-06-20"
+
+    def test_save_idempotent(self, feed_dir: Path) -> None:
+        """같은 날짜로 여러 번 저장해도 안전하다."""
+        cp = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        cp.save("2024-06-15")
+        cp.save("2024-06-15")
+
+        data = cp.load()
+        assert data is not None
+        assert data["last_date"] == "2024-06-15"
+
+    def test_save_json_format(self, feed_dir: Path) -> None:
+        """저장된 파일이 유효한 JSON이다."""
+        cp = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        cp.save("2024-06-15")
+
+        raw = cp.file_path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+        assert isinstance(data, dict)
+
+
+class TestCheckpointMissing:
+    """체크포인트 미존재 시 기본 동작 테스트."""
+
+    def test_load_returns_none_when_no_file(self, feed_dir: Path) -> None:
+        """파일이 없으면 load()는 None을 반환한다."""
+        cp = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        assert cp.load() is None
+
+    def test_get_last_date_returns_none_when_no_file(self, feed_dir: Path) -> None:
+        """파일이 없으면 get_last_date()는 None을 반환한다."""
+        cp = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        assert cp.get_last_date() is None
+
+    def test_load_returns_none_for_corrupted_file(self, feed_dir: Path) -> None:
+        """파일이 손상되면 load()는 None을 반환한다."""
+        cp = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        cp_dir = feed_dir / CHECKPOINT_DIR
+        cp_dir.mkdir(parents=True, exist_ok=True)
+        cp.file_path.write_text("not valid json", encoding="utf-8")
+
+        assert cp.load() is None
+
+
+class TestCheckpointGetLastDate:
+    """get_last_date() 테스트."""
+
+    def test_returns_last_date(self, feed_dir: Path) -> None:
+        """저장된 체크포인트의 last_date를 반환한다."""
+        cp = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        cp.save("2024-06-15")
+        assert cp.get_last_date() == "2024-06-15"
+
+    def test_returns_updated_date_after_resave(self, feed_dir: Path) -> None:
+        """재저장 후 get_last_date()는 새 날짜를 반환한다."""
+        cp = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        cp.save("2024-06-15")
+        cp.save("2024-07-01")
+        assert cp.get_last_date() == "2024-07-01"
+
+
+class TestCheckpointConcurrentAccess:
+    """동시 접근 안전성 테스트."""
+
+    def test_atomic_write_no_partial_file(self, feed_dir: Path) -> None:
+        """write-then-rename 패턴으로 임시 파일이 남지 않는다."""
+        cp = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        cp.save("2024-06-15")
+
+        cp_dir = feed_dir / CHECKPOINT_DIR
+        tmp_files = list(cp_dir.glob("*.tmp"))
+        assert tmp_files == []
+
+    def test_multiple_instances_same_target(self, feed_dir: Path) -> None:
+        """같은 소스/타입의 Checkpoint 인스턴스 여러 개가 동시 사용 가능하다."""
+        cp1 = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        cp2 = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+
+        cp1.save("2024-06-15")
+        data = cp2.load()
+        assert data is not None
+        assert data["last_date"] == "2024-06-15"
+
+        cp2.save("2024-06-20")
+        assert cp1.get_last_date() == "2024-06-20"

--- a/tests/unit/feed/test_scheduler.py
+++ b/tests/unit/feed/test_scheduler.py
@@ -1,0 +1,172 @@
+"""Scheduler 모듈 단위 테스트."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from ante.feed.pipeline.scheduler import (
+    generate_backfill_dates,
+    generate_daily_date,
+    is_business_day,
+)
+
+
+class TestGenerateBackfillDates:
+    """backfill 날짜 범위 생성 테스트."""
+
+    def test_basic_range(self) -> None:
+        """시작~종료 범위의 모든 날짜를 생성한다."""
+        dates = list(generate_backfill_dates("2024-01-01", "2024-01-05"))
+        assert dates == [
+            "2024-01-01",
+            "2024-01-02",
+            "2024-01-03",
+            "2024-01-04",
+            "2024-01-05",
+        ]
+
+    def test_single_day_range(self) -> None:
+        """시작과 종료가 같으면 1일만 생성한다."""
+        dates = list(generate_backfill_dates("2024-01-01", "2024-01-01"))
+        assert dates == ["2024-01-01"]
+
+    def test_empty_when_start_after_end(self) -> None:
+        """시작이 종료보다 크면 빈 결과를 반환한다."""
+        dates = list(generate_backfill_dates("2024-01-10", "2024-01-05"))
+        assert dates == []
+
+    def test_end_defaults_to_today(self) -> None:
+        """end가 None이면 오늘까지 생성한다."""
+        today = date.today().isoformat()
+        dates = list(generate_backfill_dates(today))
+        assert dates == [today]
+
+    def test_includes_weekends(self) -> None:
+        """영업일 필터링 없이 주말도 포함한다."""
+        # 2024-01-06 = 토요일, 2024-01-07 = 일요일
+        dates = list(generate_backfill_dates("2024-01-05", "2024-01-08"))
+        assert "2024-01-06" in dates
+        assert "2024-01-07" in dates
+
+
+class TestBackfillWithCheckpoint:
+    """체크포인트를 사용한 backfill 재개 테스트."""
+
+    def test_resume_from_checkpoint(self) -> None:
+        """체크포인트 다음 날부터 시작한다."""
+        dates = list(
+            generate_backfill_dates(
+                "2024-01-01",
+                "2024-01-05",
+                last_checkpoint="2024-01-03",
+            )
+        )
+        assert dates == ["2024-01-04", "2024-01-05"]
+
+    def test_checkpoint_at_end_returns_empty(self) -> None:
+        """체크포인트가 종료일과 같으면 빈 결과를 반환한다."""
+        dates = list(
+            generate_backfill_dates(
+                "2024-01-01",
+                "2024-01-05",
+                last_checkpoint="2024-01-05",
+            )
+        )
+        assert dates == []
+
+    def test_checkpoint_after_end_returns_empty(self) -> None:
+        """체크포인트가 종료일 이후면 빈 결과를 반환한다."""
+        dates = list(
+            generate_backfill_dates(
+                "2024-01-01",
+                "2024-01-05",
+                last_checkpoint="2024-01-10",
+            )
+        )
+        assert dates == []
+
+    def test_checkpoint_before_start(self) -> None:
+        """체크포인트가 시작일 이전이면 시작일부터 생성한다."""
+        dates = list(
+            generate_backfill_dates(
+                "2024-01-05",
+                "2024-01-07",
+                last_checkpoint="2024-01-02",
+            )
+        )
+        assert dates == ["2024-01-05", "2024-01-06", "2024-01-07"]
+
+    def test_checkpoint_none_starts_from_begin(self) -> None:
+        """체크포인트가 None이면 시작일부터 생성한다."""
+        dates = list(
+            generate_backfill_dates(
+                "2024-01-01",
+                "2024-01-03",
+                last_checkpoint=None,
+            )
+        )
+        assert dates == ["2024-01-01", "2024-01-02", "2024-01-03"]
+
+
+class TestGenerateDailyDate:
+    """daily 수집 날짜 생성 테스트."""
+
+    def test_returns_yesterday(self) -> None:
+        """기준일의 전일을 반환한다."""
+        result = generate_daily_date(date(2024, 3, 15))
+        assert result == "2024-03-14"
+
+    def test_returns_yesterday_across_month(self) -> None:
+        """월 경계를 넘어도 정확한 전일을 반환한다."""
+        result = generate_daily_date(date(2024, 3, 1))
+        assert result == "2024-02-29"  # 2024년은 윤년
+
+    def test_returns_yesterday_across_year(self) -> None:
+        """연도 경계를 넘어도 정확한 전일을 반환한다."""
+        result = generate_daily_date(date(2024, 1, 1))
+        assert result == "2023-12-31"
+
+    def test_default_reference_is_today(self) -> None:
+        """기준일 미지정 시 오늘 기준으로 전일을 반환한다."""
+        from datetime import timedelta
+
+        expected = (date.today() - timedelta(days=1)).isoformat()
+        assert generate_daily_date() == expected
+
+    def test_return_format_is_iso(self) -> None:
+        """반환값은 YYYY-MM-DD 형식이다."""
+        result = generate_daily_date(date(2024, 6, 15))
+        assert len(result) == 10
+        assert result[4] == "-"
+        assert result[7] == "-"
+
+
+class TestIsBusinessDay:
+    """영업일 판별 테스트."""
+
+    def test_monday_is_business_day(self) -> None:
+        """월요일은 영업일이다."""
+        assert is_business_day("2024-01-01") is True  # 월요일
+
+    def test_friday_is_business_day(self) -> None:
+        """금요일은 영업일이다."""
+        assert is_business_day("2024-01-05") is True  # 금요일
+
+    def test_saturday_is_not_business_day(self) -> None:
+        """토요일은 영업일이 아니다."""
+        assert is_business_day("2024-01-06") is False  # 토요일
+
+    def test_sunday_is_not_business_day(self) -> None:
+        """일요일은 영업일이 아니다."""
+        assert is_business_day("2024-01-07") is False  # 일요일
+
+    def test_all_weekdays(self) -> None:
+        """월~금은 모두 영업일이다."""
+        # 2024-01-01(월) ~ 2024-01-05(금)
+        for day in range(1, 6):
+            assert is_business_day(f"2024-01-0{day}") is True
+
+    def test_weekend_pair(self) -> None:
+        """토~일은 모두 비영업일이다."""
+        assert is_business_day("2024-01-06") is False
+        assert is_business_day("2024-01-07") is False


### PR DESCRIPTION
## Summary
- **Checkpoint**: JSON 기반 체크포인트 저장/복원 구현. write-then-rename 패턴으로 원자성 보장, 손상 파일 graceful 처리
- **Scheduler**: backfill 날짜 범위 생성(체크포인트 재개 지원), daily 전일 날짜 반환, 영업일(월~금) 판별 함수 구현
- 단위 테스트 36건 전체 통과 (checkpoint 15건, scheduler 21건)

Closes #293

## Test plan
- [x] `pytest tests/unit/feed/test_checkpoint.py -v` — save/load, 미존재 기본값, 동시 접근 안전성
- [x] `pytest tests/unit/feed/test_scheduler.py -v` — 날짜 범위 생성, 체크포인트 재개, daily, 영업일

🤖 Generated with [Claude Code](https://claude.com/claude-code)