### PR TITLE
feat(data): DataGoKrNormalizer 구현

### DIFF
--- a/src/ante/data/__init__.py
+++ b/src/ante/data/__init__.py
@@ -4,6 +4,7 @@ from ante.data.collector import DataCollector
 from ante.data.injector import DataInjector
 from ante.data.normalizer import (
     BaseNormalizer,
+    DataGoKrNormalizer,
     DataNormalizer,
     DefaultNormalizer,
     KISNormalizer,
@@ -25,6 +26,7 @@ from ante.data.store import ParquetStore
 __all__ = [
     "BaseNormalizer",
     "DataCollector",
+    "DataGoKrNormalizer",
     "DataInjector",
     "DataNormalizer",
     "DefaultNormalizer",

--- a/src/ante/data/normalizer.py
+++ b/src/ante/data/normalizer.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod
 
 import polars as pl
 
-from ante.data.schemas import OHLCV_COLUMNS
+from ante.data.schemas import FUNDAMENTAL_COLUMNS, OHLCV_COLUMNS
 
 logger = logging.getLogger(__name__)
 
@@ -152,6 +152,107 @@ class DefaultNormalizer(BaseNormalizer):
         }
 
 
+class DataGoKrNormalizer(BaseNormalizer):
+    """data.go.kr 주식시세 API 응답 정규화.
+
+    동일한 API 응답에서 OHLCV와 FUNDAMENTAL 두 스키마를 각각 추출한다.
+    모든 API 응답 값이 문자열이므로 숫자 타입 변환을 수행한다.
+    """
+
+    # OHLCV 컬럼 매핑
+    _OHLCV_MAPPING: dict[str, str] = {
+        "basDt": "timestamp",
+        "srtnCd": "symbol",
+        "mkp": "open",
+        "hipr": "high",
+        "lopr": "low",
+        "clpr": "close",
+        "trqu": "volume",
+        "trPrc": "amount",
+    }
+
+    # FUNDAMENTAL 컬럼 매핑
+    _FUNDAMENTAL_MAPPING: dict[str, str] = {
+        "basDt": "date",
+        "srtnCd": "symbol",
+        "mrktTotAmt": "market_cap",
+        "lstgStCnt": "shares_listed",
+    }
+
+    @property
+    def source_name(self) -> str:
+        return "data_go_kr"
+
+    @property
+    def column_mapping(self) -> dict[str, str]:
+        return self._OHLCV_MAPPING
+
+    def transform(self, df: pl.DataFrame) -> pl.DataFrame:
+        """data.go.kr 문자열 값을 숫자로 변환."""
+        # 숫자 컬럼: 문자열 → 숫자 변환
+        for col in ("open", "high", "low", "close"):
+            if col in df.columns and df[col].dtype == pl.Utf8:
+                df = df.with_columns(pl.col(col).cast(pl.Float64))
+        for col in ("volume", "amount"):
+            if col in df.columns and df[col].dtype == pl.Utf8:
+                df = df.with_columns(pl.col(col).cast(pl.Int64))
+
+        # timestamp: YYYYMMDD 문자열 → Date → Datetime 변환
+        if "timestamp" in df.columns and df["timestamp"].dtype == pl.Utf8:
+            df = df.with_columns(
+                pl.col("timestamp").str.to_date("%Y%m%d").cast(pl.Datetime("ns"))
+            )
+        return df
+
+    def normalize_ohlcv(self, df: pl.DataFrame) -> pl.DataFrame:
+        """data.go.kr 응답을 OHLCV_SCHEMA DataFrame으로 정규화.
+
+        Args:
+            df: data.go.kr API 원본 응답 DataFrame (모든 값이 문자열).
+
+        Returns:
+            OHLCV_SCHEMA에 맞춘 DataFrame.
+        """
+        return self.normalize(df)
+
+    def normalize_fundamental(self, df: pl.DataFrame) -> pl.DataFrame:
+        """data.go.kr 응답을 FUNDAMENTAL_SCHEMA 부분 DataFrame으로 정규화.
+
+        Args:
+            df: data.go.kr API 원본 응답 DataFrame (모든 값이 문자열).
+
+        Returns:
+            FUNDAMENTAL_SCHEMA 부분 필드
+            (date, symbol, market_cap, shares_listed, source).
+        """
+        # 컬럼 매핑
+        rename_map = {
+            src: dst
+            for src, dst in self._FUNDAMENTAL_MAPPING.items()
+            if src in df.columns
+        }
+        if rename_map:
+            df = df.rename(rename_map)
+
+        # date: YYYYMMDD 문자열 → Date 변환
+        if "date" in df.columns and df["date"].dtype == pl.Utf8:
+            df = df.with_columns(pl.col("date").str.to_date("%Y%m%d"))
+
+        # 숫자 컬럼 변환
+        if "market_cap" in df.columns and df["market_cap"].dtype == pl.Utf8:
+            df = df.with_columns(pl.col("market_cap").cast(pl.Int64))
+        if "shares_listed" in df.columns and df["shares_listed"].dtype == pl.Utf8:
+            df = df.with_columns(pl.col("shares_listed").cast(pl.Int64))
+
+        # source 컬럼
+        if "source" not in df.columns:
+            df = df.with_columns(pl.lit(self.source_name).alias("source"))
+
+        # FUNDAMENTAL_SCHEMA 컬럼만 선택
+        available = [c for c in FUNDAMENTAL_COLUMNS if c in df.columns]
+        return df.select(available)
+
+
 # ── Normalizer 레지스트리 ────────────────────────────
 
 NORMALIZER_REGISTRY: dict[str, type[BaseNormalizer]] = {
@@ -159,6 +260,7 @@ NORMALIZER_REGISTRY: dict[str, type[BaseNormalizer]] = {
     "yahoo": YahooNormalizer,
     "default": DefaultNormalizer,
     "external": DefaultNormalizer,
+    "data_go_kr": DataGoKrNormalizer,
 }
 
 

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -10,7 +10,9 @@ import pytest
 
 from ante.data.collector import DataCollector
 from ante.data.injector import DataInjector
-from ante.data.normalizer import DataNormalizer
+from ante.data.normalizer import (
+    DataNormalizer,
+)
 from ante.data.retention import RetentionPolicy
 from ante.data.schemas import (
     FUNDAMENTAL_COLUMNS,
@@ -480,6 +482,153 @@ class TestDataNormalizer:
         result = normalizer.normalize(df)
         assert result["open"].dtype == pl.Float64
         assert result["volume"].dtype == pl.Int64
+
+
+# ── DataGoKrNormalizer 테스트 ─────────────────────────
+
+
+class TestDataGoKrNormalizer:
+    """data.go.kr API 응답 정규화 테스트."""
+
+    @pytest.fixture
+    def dgk_normalizer(self):
+        from ante.data.normalizer import DataGoKrNormalizer
+
+        return DataGoKrNormalizer()
+
+    @pytest.fixture
+    def sample_df(self):
+        """data.go.kr API 응답 샘플 (모든 값이 문자열)."""
+        return pl.DataFrame(
+            {
+                "basDt": ["20260301", "20260302"],
+                "srtnCd": ["005930", "005930"],
+                "mkp": ["50000", "50500"],
+                "hipr": ["51000", "51500"],
+                "lopr": ["49500", "50000"],
+                "clpr": ["50500", "51000"],
+                "trqu": ["1000000", "1200000"],
+                "trPrc": ["50500000000", "61200000000"],
+                "mrktTotAmt": ["300000000000000", "305000000000000"],
+                "lstgStCnt": ["5969782550", "5969782550"],
+            }
+        )
+
+    def test_source_name(self, dgk_normalizer):
+        assert dgk_normalizer.source_name == "data_go_kr"
+
+    def test_registry_lookup(self):
+        from ante.data.normalizer import get_normalizer
+
+        n = get_normalizer("data_go_kr")
+        assert n.source_name == "data_go_kr"
+
+    def test_normalize_ohlcv(self, dgk_normalizer, sample_df):
+        result = dgk_normalizer.normalize_ohlcv(sample_df)
+
+        assert "timestamp" in result.columns
+        assert "symbol" in result.columns
+        assert "open" in result.columns
+        assert "close" in result.columns
+        assert "volume" in result.columns
+        assert "amount" in result.columns
+        assert "source" in result.columns
+
+        assert result["open"].dtype == pl.Float64
+        assert result["close"].dtype == pl.Float64
+        assert result["volume"].dtype == pl.Int64
+        assert result["amount"].dtype == pl.Int64
+        assert isinstance(result["timestamp"].dtype, pl.Datetime)
+        assert result["source"][0] == "data_go_kr"
+
+        assert result["open"][0] == 50000.0
+        assert result["close"][0] == 50500.0
+        assert result["volume"][0] == 1000000
+        assert result["amount"][0] == 50500000000
+        assert result["symbol"][0] == "005930"
+
+    def test_normalize_ohlcv_sorts_by_timestamp(self, dgk_normalizer):
+        df = pl.DataFrame(
+            {
+                "basDt": ["20260302", "20260301"],
+                "srtnCd": ["005930", "005930"],
+                "mkp": ["50500", "50000"],
+                "hipr": ["51500", "51000"],
+                "lopr": ["50000", "49500"],
+                "clpr": ["51000", "50500"],
+                "trqu": ["1200000", "1000000"],
+                "trPrc": ["61200000000", "50500000000"],
+            }
+        )
+        result = dgk_normalizer.normalize_ohlcv(df)
+        assert result["open"][0] == 50000.0
+
+    def test_normalize_fundamental(self, dgk_normalizer, sample_df):
+        result = dgk_normalizer.normalize_fundamental(sample_df)
+
+        assert "date" in result.columns
+        assert "symbol" in result.columns
+        assert "market_cap" in result.columns
+        assert "shares_listed" in result.columns
+        assert "source" in result.columns
+
+        assert result["date"].dtype == pl.Date
+        assert result["market_cap"].dtype == pl.Int64
+        assert result["shares_listed"].dtype == pl.Int64
+
+        assert result["symbol"][0] == "005930"
+        assert result["market_cap"][0] == 300000000000000
+        assert result["shares_listed"][0] == 5969782550
+        assert result["source"][0] == "data_go_kr"
+
+    def test_normalize_fundamental_date_parsing(self, dgk_normalizer, sample_df):
+        result = dgk_normalizer.normalize_fundamental(sample_df)
+        from datetime import date
+
+        assert result["date"][0] == date(2026, 3, 1)
+        assert result["date"][1] == date(2026, 3, 2)
+
+    def test_normalize_ohlcv_timestamp_parsing(self, dgk_normalizer):
+        """YYYYMMDD 문자열이 Datetime으로 변환되는지 확인."""
+        df = pl.DataFrame(
+            {
+                "basDt": ["20260315"],
+                "srtnCd": ["005930"],
+                "mkp": ["50000"],
+                "hipr": ["51000"],
+                "lopr": ["49500"],
+                "clpr": ["50500"],
+                "trqu": ["1000000"],
+                "trPrc": ["50500000000"],
+            }
+        )
+        result = dgk_normalizer.normalize_ohlcv(df)
+        ts = result["timestamp"][0]
+        assert ts.year == 2026
+        assert ts.month == 3
+        assert ts.day == 15
+
+    def test_normalize_fundamental_excludes_ohlcv_columns(
+        self, dgk_normalizer, sample_df
+    ):
+        """fundamental 결과에 OHLCV 전용 컬럼이 포함되지 않아야 한다."""
+        result = dgk_normalizer.normalize_fundamental(sample_df)
+        for col in ("open", "high", "low", "close", "volume", "amount", "timestamp"):
+            assert col not in result.columns
+
+    def test_normalize_ohlcv_via_base_normalize(self, dgk_normalizer, sample_df):
+        """BaseNormalizer.normalize()를 직접 호출해도 OHLCV 결과가 동일."""
+        result = dgk_normalizer.normalize(sample_df)
+        assert "timestamp" in result.columns
+        assert "close" in result.columns
+        assert result["source"][0] == "data_go_kr"
+
+    def test_export_from_package(self):
+        """ante.data 패키지에서 DataGoKrNormalizer를 임포트할 수 있어야 한다."""
+        from ante.data import DataGoKrNormalizer
+
+        n = DataGoKrNormalizer()
+        assert n.source_name == "data_go_kr"
 
 
 # ── collector.py 테스트 ─────────────────────────────


### PR DESCRIPTION
## Summary
- `DataGoKrNormalizer` 클래스 추가: data.go.kr 주식시세 API 응답을 dual-schema(OHLCV/FUNDAMENTAL)로 정규화
- `normalize_ohlcv(df)`: basDt→timestamp, mkp→open, clpr→close, trqu→volume, trPrc→amount 등 OHLCV 매핑 + 문자열→숫자 변환
- `normalize_fundamental(df)`: basDt→date, srtnCd→symbol, mrktTotAmt→market_cap, lstgStCnt→shares_listed 매핑
- NORMALIZER_REGISTRY에 `"data_go_kr"` 등록, `__init__.py` 패키지 export 추가
- 10건의 단위 테스트 추가 (전체 64건 통과)

## Test plan
- [x] `pytest tests/unit/test_data_pipeline.py -v` — 64건 전체 통과
- [x] `ruff check` / `ruff format` 통과

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)