### PR TITLE
feat(data): DARTNormalizer 구현

### DIFF
--- a/src/ante/data/__init__.py
+++ b/src/ante/data/__init__.py
@@ -4,6 +4,7 @@ from ante.data.collector import DataCollector
 from ante.data.injector import DataInjector
 from ante.data.normalizer import (
     BaseNormalizer,
+    DARTNormalizer,
     DataGoKrNormalizer,
     DataNormalizer,
     DefaultNormalizer,
@@ -25,6 +26,7 @@ from ante.data.store import ParquetStore
 
 __all__ = [
     "BaseNormalizer",
+    "DARTNormalizer",
     "DataCollector",
     "DataGoKrNormalizer",
     "DataInjector",

--- a/src/ante/data/normalizer.py
+++ b/src/ante/data/normalizer.py
@@ -253,6 +253,229 @@ class DataGoKrNormalizer(BaseNormalizer):
         return df.select(available)
 
 
+# ── DART 재무제표 Normalizer ─────────────────────────
+
+# DART 계정과목명 → FUNDAMENTAL_SCHEMA 필드 매핑
+_DART_ACCOUNT_MAP: dict[str, str] = {
+    "매출액": "revenue",
+    "수익(매출액)": "revenue",
+    "당기순이익": "net_income",
+    "당기순이익(손실)": "net_income",
+    "자본총계": "total_equity",
+    "부채총계": "total_debt",
+    "자산총계": "total_assets",
+}
+
+# DART reprt_code → (분기, 월) 매핑
+_REPRT_CODE_MAP: dict[str, tuple[str, int]] = {
+    "11013": ("1Q", 3),
+    "11012": ("semi", 6),
+    "11014": ("3Q", 9),
+    "11011": ("annual", 12),
+}
+
+
+class DARTNormalizer:
+    """DART API 재무제표 응답을 FUNDAMENTAL_SCHEMA로 정규화.
+
+    DART 응답은 계정과목별 행(row-per-account) 구조이므로
+    종목별 컬럼 구조로 피벗 변환한다.
+
+    파생 지표(PER/PBR/EPS/BPS/ROE/부채비율)는 계산하지 않는다.
+    이들은 orchestrator가 data.go.kr 데이터와 결합하여 계산한다.
+    """
+
+    @property
+    def source_name(self) -> str:
+        """데이터 소스 식별자."""
+        return "dart"
+
+    def normalize(
+        self,
+        df: pl.DataFrame,
+        corp_code_map: dict[str, str],
+    ) -> pl.DataFrame:
+        """DART 재무제표 DataFrame을 정규화.
+
+        Args:
+            df: DART API 원본 응답 DataFrame.
+                필수 컬럼: corp_code, account_nm,
+                thstrm_amount, fs_div, reprt_code, bsns_year
+            corp_code_map: corp_code -> symbol 매핑
+                (예: {"00126380": "005930"}).
+
+        Returns:
+            FUNDAMENTAL_SCHEMA 부분 컬럼을 가진 DataFrame.
+            포함: date, symbol, revenue, net_income,
+            total_equity, total_debt, total_assets, source.
+        """
+        from ante.data.schemas import FUNDAMENTAL_COLUMNS
+
+        empty_schema = {
+            "date": pl.Date,
+            "symbol": pl.Utf8,
+            "source": pl.Utf8,
+        }
+
+        if df.is_empty():
+            return pl.DataFrame(schema=empty_schema)
+
+        required_cols = {
+            "corp_code",
+            "account_nm",
+            "thstrm_amount",
+            "fs_div",
+            "reprt_code",
+            "bsns_year",
+        }
+        missing = required_cols - set(df.columns)
+        if missing:
+            msg = f"DART DataFrame에 필수 컬럼이 없습니다: {missing}"
+            raise ValueError(msg)
+
+        # 매핑 대상 계정과목만 필터링
+        target_accounts = list(_DART_ACCOUNT_MAP.keys())
+        df = df.filter(pl.col("account_nm").is_in(target_accounts))
+
+        if df.is_empty():
+            return pl.DataFrame(schema=empty_schema)
+
+        # CFS(연결재무제표) 우선, OFS(개별재무제표) 폴백
+        df = self._select_fs_div(df)
+
+        # corp_code → symbol 매핑
+        df = df.with_columns(
+            pl.col("corp_code")
+            .replace_strict(corp_code_map, default=None)
+            .alias("symbol")
+        )
+        # 매핑 실패 행 제거
+        df = df.filter(pl.col("symbol").is_not_null())
+
+        if df.is_empty():
+            return pl.DataFrame(schema=empty_schema)
+
+        # reprt_code + bsns_year → date 변환
+        df = self._convert_report_date(df)
+
+        # thstrm_amount 콤마 제거 + 숫자 변환
+        df = df.with_columns(
+            pl.col("thstrm_amount")
+            .cast(pl.Utf8)
+            .str.replace_all(",", "")
+            .cast(pl.Int64, strict=False)
+            .alias("amount_value")
+        )
+
+        # 계정과목명 → 필드명 매핑
+        df = df.with_columns(
+            pl.col("account_nm")
+            .replace_strict(_DART_ACCOUNT_MAP, default=None)
+            .alias("field_name")
+        )
+        df = df.filter(pl.col("field_name").is_not_null())
+
+        if df.is_empty():
+            return pl.DataFrame(schema=empty_schema)
+
+        # 피벗: 행(계정과목별) → 열(종목별 필드)
+        pivoted = df.pivot(
+            on="field_name",
+            index=["symbol", "date"],
+            values="amount_value",
+            aggregate_function="first",
+        )
+
+        # source 컬럼 추가
+        pivoted = pivoted.with_columns(pl.lit("dart").alias("source"))
+
+        # 출력 컬럼 선택
+        fundamental_cols = set(FUNDAMENTAL_COLUMNS)
+        extra_cols = {
+            "total_equity",
+            "total_debt",
+            "total_assets",
+        }
+        select_cols: list[str] = [
+            col
+            for col in pivoted.columns
+            if col in fundamental_cols or col in extra_cols
+        ]
+
+        result = pivoted.select(select_cols)
+
+        # 숫자 컬럼 타입 강제
+        int_fields = {
+            "revenue",
+            "net_income",
+            "total_equity",
+            "total_debt",
+            "total_assets",
+        }
+        for col in int_fields:
+            if col in result.columns:
+                result = result.with_columns(pl.col(col).cast(pl.Int64, strict=False))
+
+        return result.sort("symbol", "date")
+
+    def _select_fs_div(self, df: pl.DataFrame) -> pl.DataFrame:
+        """CFS(연결) 우선, 없으면 OFS(개별) 폴백.
+
+        corp_code + reprt_code 기준으로 CFS 데이터가 있으면
+        CFS만, CFS가 없는 조합은 OFS를 사용한다.
+        """
+        cfs = df.filter(pl.col("fs_div") == "CFS")
+        ofs = df.filter(pl.col("fs_div") == "OFS")
+
+        if cfs.is_empty():
+            return ofs
+        if ofs.is_empty():
+            return cfs
+
+        # CFS가 있는 (corp_code, reprt_code) 조합
+        cfs_keys = cfs.select("corp_code", "reprt_code").unique()
+
+        # OFS 중 CFS가 없는 조합만 추출
+        ofs_fallback = ofs.join(
+            cfs_keys,
+            on=["corp_code", "reprt_code"],
+            how="anti",
+        )
+
+        return pl.concat([cfs, ofs_fallback])
+
+    def _convert_report_date(self, df: pl.DataFrame) -> pl.DataFrame:
+        """reprt_code + bsns_year → date 컬럼 변환.
+
+        reprt_code 매핑:
+        - 11013 → 1Q (3월 말)
+        - 11012 → semi (6월 말)
+        - 11014 → 3Q (9월 말)
+        - 11011 → annual (12월 말)
+        """
+        from calendar import monthrange
+        from datetime import date as date_cls
+
+        def _to_date(reprt_code: str, bsns_year: str) -> date_cls | None:
+            mapping = _REPRT_CODE_MAP.get(reprt_code)
+            if mapping is None:
+                return None
+            _, month = mapping
+            year = int(bsns_year)
+            day = monthrange(year, month)[1]
+            return date_cls(year, month, day)
+
+        dates: list[date_cls | None] = []
+        for rc, by in zip(
+            df["reprt_code"].to_list(),
+            df["bsns_year"].to_list(),
+        ):
+            dates.append(_to_date(str(rc), str(by)))
+
+        df = df.with_columns(pl.Series("date", dates, dtype=pl.Date))
+        return df.filter(pl.col("date").is_not_null())
+
+
 # ── Normalizer 레지스트리 ────────────────────────────
 
 NORMALIZER_REGISTRY: dict[str, type[BaseNormalizer]] = {
@@ -261,6 +484,11 @@ NORMALIZER_REGISTRY: dict[str, type[BaseNormalizer]] = {
     "default": DefaultNormalizer,
     "external": DefaultNormalizer,
     "data_go_kr": DataGoKrNormalizer,
+}
+
+# DARTNormalizer는 BaseNormalizer(OHLCV)와 다른 스키마이므로 별도 등록
+DART_NORMALIZER_REGISTRY: dict[str, type[DARTNormalizer]] = {
+    "dart": DARTNormalizer,
 }
 
 

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -836,3 +836,268 @@ class TestRetentionPolicy:
         policy = RetentionPolicy(store)
         deleted = await policy.enforce()
         assert deleted == {}
+
+
+# ── DARTNormalizer 테스트 ─────────────────────────────
+
+
+def _make_dart_df(
+    corp_codes: list[str] | None = None,
+    accounts: list[str] | None = None,
+    amounts: list[str] | None = None,
+    fs_divs: list[str] | None = None,
+    reprt_codes: list[str] | None = None,
+    bsns_years: list[str] | None = None,
+) -> pl.DataFrame:
+    """테스트용 DART API 응답 DataFrame 생성."""
+    if corp_codes is None:
+        corp_codes = ["00126380"] * 5
+    if accounts is None:
+        accounts = [
+            "매출액",
+            "당기순이익",
+            "자본총계",
+            "부채총계",
+            "자산총계",
+        ]
+    if amounts is None:
+        amounts = [
+            "1,000,000",
+            "200,000",
+            "500,000",
+            "300,000",
+            "800,000",
+        ]
+    if fs_divs is None:
+        fs_divs = ["CFS"] * 5
+    if reprt_codes is None:
+        reprt_codes = ["11011"] * 5
+    if bsns_years is None:
+        bsns_years = ["2025"] * 5
+
+    return pl.DataFrame(
+        {
+            "corp_code": corp_codes,
+            "account_nm": accounts,
+            "thstrm_amount": amounts,
+            "fs_div": fs_divs,
+            "reprt_code": reprt_codes,
+            "bsns_year": bsns_years,
+        }
+    )
+
+
+class TestDARTNormalizer:
+    """DARTNormalizer 단위 테스트."""
+
+    @pytest.fixture
+    def dart_normalizer(self):
+        from ante.data.normalizer import DARTNormalizer
+
+        return DARTNormalizer()
+
+    @pytest.fixture
+    def corp_code_map(self) -> dict[str, str]:
+        return {
+            "00126380": "005930",
+            "00164742": "000660",
+        }
+
+    def test_source_name(self, dart_normalizer):
+        assert dart_normalizer.source_name == "dart"
+
+    def test_normalize_basic(self, dart_normalizer, corp_code_map):
+        """기본 정규화: 5개 계정과목 -> 피벗된 1행."""
+        df = _make_dart_df()
+        result = dart_normalizer.normalize(df, corp_code_map)
+
+        assert len(result) == 1
+        assert "symbol" in result.columns
+        assert "date" in result.columns
+        assert "source" in result.columns
+        assert result["symbol"][0] == "005930"
+        assert result["source"][0] == "dart"
+        assert result["revenue"][0] == 1_000_000
+        assert result["net_income"][0] == 200_000
+        assert result["total_equity"][0] == 500_000
+        assert result["total_debt"][0] == 300_000
+        assert result["total_assets"][0] == 800_000
+
+    def test_normalize_comma_removal(self, dart_normalizer, corp_code_map):
+        """thstrm_amount 콤마 제거 후 숫자 변환."""
+        df = _make_dart_df(amounts=["1,234,567,890"] * 5)
+        result = dart_normalizer.normalize(df, corp_code_map)
+        assert result["revenue"][0] == 1_234_567_890
+
+    def test_normalize_reprt_code_1q(self, dart_normalizer, corp_code_map):
+        """reprt_code 11013 -> 1Q (3월 말)."""
+        from datetime import date
+
+        df = _make_dart_df(
+            reprt_codes=["11013"] * 5,
+            bsns_years=["2025"] * 5,
+        )
+        result = dart_normalizer.normalize(df, corp_code_map)
+        assert result["date"][0] == date(2025, 3, 31)
+
+    def test_normalize_reprt_code_semi(self, dart_normalizer, corp_code_map):
+        """reprt_code 11012 -> semi (6월 말)."""
+        from datetime import date
+
+        df = _make_dart_df(
+            reprt_codes=["11012"] * 5,
+            bsns_years=["2025"] * 5,
+        )
+        result = dart_normalizer.normalize(df, corp_code_map)
+        assert result["date"][0] == date(2025, 6, 30)
+
+    def test_normalize_reprt_code_3q(self, dart_normalizer, corp_code_map):
+        """reprt_code 11014 -> 3Q (9월 말)."""
+        from datetime import date
+
+        df = _make_dart_df(
+            reprt_codes=["11014"] * 5,
+            bsns_years=["2025"] * 5,
+        )
+        result = dart_normalizer.normalize(df, corp_code_map)
+        assert result["date"][0] == date(2025, 9, 30)
+
+    def test_normalize_reprt_code_annual(self, dart_normalizer, corp_code_map):
+        """reprt_code 11011 -> annual (12월 말)."""
+        from datetime import date
+
+        df = _make_dart_df(
+            reprt_codes=["11011"] * 5,
+            bsns_years=["2025"] * 5,
+        )
+        result = dart_normalizer.normalize(df, corp_code_map)
+        assert result["date"][0] == date(2025, 12, 31)
+
+    def test_normalize_cfs_priority(self, dart_normalizer, corp_code_map):
+        """CFS 우선: CFS/OFS 둘 다 있으면 CFS만 사용."""
+        df = pl.DataFrame(
+            {
+                "corp_code": ["00126380"] * 2,
+                "account_nm": ["매출액", "매출액"],
+                "thstrm_amount": ["1,000,000", "500,000"],
+                "fs_div": ["CFS", "OFS"],
+                "reprt_code": ["11011", "11011"],
+                "bsns_year": ["2025", "2025"],
+            }
+        )
+        result = dart_normalizer.normalize(df, corp_code_map)
+        assert result["revenue"][0] == 1_000_000
+
+    def test_normalize_ofs_fallback(self, dart_normalizer, corp_code_map):
+        """OFS 폴백: CFS가 없으면 OFS 사용."""
+        df = _make_dart_df(fs_divs=["OFS"] * 5)
+        result = dart_normalizer.normalize(df, corp_code_map)
+        assert len(result) == 1
+        assert result["revenue"][0] == 1_000_000
+
+    def test_normalize_empty_df(self, dart_normalizer, corp_code_map):
+        """빈 DataFrame 입력 시 빈 결과."""
+        df = pl.DataFrame(
+            schema={
+                "corp_code": pl.Utf8,
+                "account_nm": pl.Utf8,
+                "thstrm_amount": pl.Utf8,
+                "fs_div": pl.Utf8,
+                "reprt_code": pl.Utf8,
+                "bsns_year": pl.Utf8,
+            }
+        )
+        result = dart_normalizer.normalize(df, corp_code_map)
+        assert result.is_empty()
+
+    def test_normalize_missing_columns_raises(self, dart_normalizer, corp_code_map):
+        """필수 컬럼 누락 시 ValueError."""
+        df = pl.DataFrame(
+            {
+                "corp_code": ["00126380"],
+                "account_nm": ["매출액"],
+            }
+        )
+        with pytest.raises(ValueError, match="필수 컬럼"):
+            dart_normalizer.normalize(df, corp_code_map)
+
+    def test_normalize_unknown_corp_code_filtered(self, dart_normalizer):
+        """매핑되지 않는 corp_code는 필터링."""
+        df = _make_dart_df(corp_codes=["99999999"] * 5)
+        result = dart_normalizer.normalize(df, {"00126380": "005930"})
+        assert result.is_empty()
+
+    def test_normalize_alternative_account_names(self, dart_normalizer, corp_code_map):
+        """대체 계정과목명 매핑."""
+        df = _make_dart_df(
+            accounts=[
+                "수익(매출액)",
+                "당기순이익(손실)",
+                "자본총계",
+                "부채총계",
+                "자산총계",
+            ]
+        )
+        result = dart_normalizer.normalize(df, corp_code_map)
+        assert result["revenue"][0] == 1_000_000
+        assert result["net_income"][0] == 200_000
+
+    def test_normalize_multi_symbol(self, dart_normalizer, corp_code_map):
+        """여러 종목 동시 정규화."""
+        df = pl.DataFrame(
+            {
+                "corp_code": [
+                    "00126380",
+                    "00126380",
+                    "00164742",
+                    "00164742",
+                ],
+                "account_nm": [
+                    "매출액",
+                    "당기순이익",
+                    "매출액",
+                    "당기순이익",
+                ],
+                "thstrm_amount": [
+                    "1,000,000",
+                    "200,000",
+                    "500,000",
+                    "100,000",
+                ],
+                "fs_div": ["CFS"] * 4,
+                "reprt_code": ["11011"] * 4,
+                "bsns_year": ["2025"] * 4,
+            }
+        )
+        result = dart_normalizer.normalize(df, corp_code_map)
+        assert len(result) == 2
+        symbols = result["symbol"].to_list()
+        assert symbols == ["000660", "005930"]
+
+    def test_normalize_unrecognized_account_filtered(
+        self, dart_normalizer, corp_code_map
+    ):
+        """인식되지 않는 계정과목은 무시."""
+        df = _make_dart_df(
+            accounts=[
+                "매출액",
+                "당기순이익",
+                "영업이익",
+                "미지의계정",
+                "자산총계",
+            ],
+        )
+        result = dart_normalizer.normalize(df, corp_code_map)
+        assert "revenue" in result.columns
+        assert "net_income" in result.columns
+        assert "total_assets" in result.columns
+
+    def test_dart_in_registry(self):
+        """DARTNormalizer가 DART_NORMALIZER_REGISTRY에 등록."""
+        from ante.data.normalizer import (
+            DART_NORMALIZER_REGISTRY,
+            DARTNormalizer,
+        )
+
+        assert "dart" in DART_NORMALIZER_REGISTRY
+        assert DART_NORMALIZER_REGISTRY["dart"] is DARTNormalizer


### PR DESCRIPTION
## Summary
- DART API 재무제표 응답을 FUNDAMENTAL_SCHEMA로 정규화하는 `DARTNormalizer` 클래스 구현
- 계정과목별 행(row-per-account) 구조를 종목별 컬럼 구조로 피벗 변환
- CFS(연결재무제표) 우선, OFS(개별재무제표) 폴백 로직 포함

## Changes
- `src/ante/data/normalizer.py`: `DARTNormalizer` 클래스 추가, `DART_NORMALIZER_REGISTRY` 등록
- `src/ante/data/__init__.py`: `DARTNormalizer` export 추가
- `tests/unit/test_data_pipeline.py`: `TestDARTNormalizer` 16건 테스트 추가 (전체 70건 통과)

## Key Features
- 계정과목 매핑: 매출액/수익(매출액) → revenue, 당기순이익/당기순이익(손실) → net_income, 자본총계/부채총계/자산총계
- `reprt_code` → date 변환 (11013→1Q/3월, 11012→반기/6월, 11014→3Q/9월, 11011→연간/12월)
- `thstrm_amount` 콤마 제거 + Int64 변환
- `corp_code` → symbol 매핑 (외부 매핑 테이블 주입)
- 파생 지표(PER/PBR/EPS/BPS/ROE/부채비율)는 계산하지 않음 (orchestrator 책임)

## Test plan
- [x] 기본 정규화 (5개 계정과목 → 피벗된 1행)
- [x] 콤마 제거 및 숫자 변환
- [x] 4개 reprt_code 각각의 date 변환
- [x] CFS 우선 / OFS 폴백
- [x] 빈 DataFrame / 필수 컬럼 누락 / 미매핑 corp_code
- [x] 대체 계정과목명 / 다중 종목 / 미인식 계정 필터링
- [x] DART_NORMALIZER_REGISTRY 등록 확인

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)