### PR TITLE
feat(feed): 4계층 데이터 검증 구현

### DIFF
--- a/src/ante/feed/models/__init__.py
+++ b/src/ante/feed/models/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from ante.feed.models.result import CollectionResult
+from ante.feed.models.result import CollectionResult, ValidationResult
 
-__all__ = ["CollectionResult"]
+__all__ = ["CollectionResult", "ValidationResult"]

--- a/src/ante/feed/models/result.py
+++ b/src/ante/feed/models/result.py
@@ -6,6 +6,41 @@ from dataclasses import dataclass, field
 
 
 @dataclass
+class ValidationResult:
+    """4계층 데이터 검증 결과를 담는 데이터클래스.
+
+    각 검증 계층(전송/구문/스키마/비즈니스)이 생성하며,
+    경고와 오류를 분리하여 보고한다.
+    """
+
+    passed: bool
+    """검증 통과 여부. errors가 비어있으면 True."""
+
+    warnings: list[str] = field(default_factory=list)
+    """경고 메시지 목록 (비즈니스 규칙 위반 등, 저장은 허용)."""
+
+    errors: list[str] = field(default_factory=list)
+    """오류 메시지 목록 (스키마 위반 등, 저장 불가)."""
+
+    def merge(self, other: ValidationResult) -> ValidationResult:
+        """다른 ValidationResult를 병합하여 새 결과를 반환한다.
+
+        Args:
+            other: 병합할 검증 결과.
+
+        Returns:
+            병합된 검증 결과. errors가 하나라도 있으면 passed=False.
+        """
+        merged_warnings = self.warnings + other.warnings
+        merged_errors = self.errors + other.errors
+        return ValidationResult(
+            passed=len(merged_errors) == 0,
+            warnings=merged_warnings,
+            errors=merged_errors,
+        )
+
+
+@dataclass
 class CollectionResult:
     """수집 작업의 집계 결과를 담는 데이터클래스.
 

--- a/src/ante/feed/transform/validate.py
+++ b/src/ante/feed/transform/validate.py
@@ -9,24 +9,14 @@
 
 from __future__ import annotations
 
+import json
 import logging
+from datetime import datetime
 from typing import Any
 
+from ante.feed.models.result import ValidationResult
+
 logger = logging.getLogger(__name__)
-
-
-class ValidationResult:
-    """검증 결과를 담는 클래스."""
-
-    def __init__(self, passed: bool, warnings: list[str], errors: list[str]) -> None:
-        """ValidationResult를 초기화한다.
-
-        Args:
-            passed: 검증 통과 여부.
-            warnings: 경고 메시지 목록 (비즈니스 규칙 위반 등).
-            errors: 오류 메시지 목록 (스키마 위반 등).
-        """
-        ...
 
 
 def validate_transport(
@@ -44,7 +34,20 @@ def validate_transport(
     Returns:
         검증 결과.
     """
-    ...
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if not (200 <= status_code < 300):
+        errors.append(f"HTTP 상태 코드 오류: {status_code}")
+
+    if content_length is not None and content_length == 0:
+        errors.append("응답 본문이 비어있음 (Content-Length: 0)")
+
+    return ValidationResult(
+        passed=len(errors) == 0,
+        warnings=warnings,
+        errors=errors,
+    )
 
 
 def validate_syntax(raw: Any) -> ValidationResult:
@@ -53,16 +56,46 @@ def validate_syntax(raw: Any) -> ValidationResult:
     JSON 파싱 가능 여부와 인코딩 정상 여부를 확인한다.
 
     Args:
-        raw: 원시 응답 데이터.
+        raw: 원시 응답 데이터. str이면 JSON 파싱을 시도하고,
+             dict/list면 이미 파싱된 것으로 간주한다.
 
     Returns:
         검증 결과.
     """
-    ...
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if raw is None:
+        errors.append("응답 데이터가 None")
+        return ValidationResult(passed=False, warnings=warnings, errors=errors)
+
+    if isinstance(raw, bytes):
+        try:
+            raw = raw.decode("utf-8")
+        except UnicodeDecodeError as e:
+            errors.append(f"인코딩 오류: {e}")
+            return ValidationResult(passed=False, warnings=warnings, errors=errors)
+
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, ValueError) as e:
+            errors.append(f"JSON 파싱 오류: {e}")
+            return ValidationResult(passed=False, warnings=warnings, errors=errors)
+        if not isinstance(parsed, (dict, list)):
+            errors.append(f"예상치 못한 JSON 타입: {type(parsed).__name__}")
+    elif not isinstance(raw, (dict, list)):
+        errors.append(f"지원하지 않는 데이터 타입: {type(raw).__name__}")
+
+    return ValidationResult(
+        passed=len(errors) == 0,
+        warnings=warnings,
+        errors=errors,
+    )
 
 
 def validate_schema(
-    records: list[dict],
+    records: list[dict[str, Any]],
     required_fields: list[str],
 ) -> ValidationResult:
     """스키마 계층 검증.
@@ -76,30 +109,208 @@ def validate_schema(
     Returns:
         검증 결과.
     """
-    ...
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if not records:
+        warnings.append("레코드가 비어있음")
+        return ValidationResult(passed=True, warnings=warnings, errors=errors)
+
+    # 첫 레코드 기준으로 필수 필드 존재 여부 확인
+    first_record_keys = set(records[0].keys())
+    missing_fields = set(required_fields) - first_record_keys
+    if missing_fields:
+        errors.append(f"필수 필드 누락: {sorted(missing_fields)}")
+
+    # 숫자 필드 타입 변환 가능 여부 확인
+    numeric_fields = {"open", "high", "low", "close", "volume", "amount"}
+    check_fields = numeric_fields & first_record_keys
+
+    for i, record in enumerate(records):
+        for field_name in check_fields:
+            value = record.get(field_name)
+            if value is None:
+                continue
+            if isinstance(value, (int, float)):
+                continue
+            try:
+                float(value)
+            except (ValueError, TypeError):
+                errors.append(
+                    f"레코드 {i}: 필드 '{field_name}' 값 '{value}'를 숫자로 변환 불가"
+                )
+
+    return ValidationResult(
+        passed=len(errors) == 0,
+        warnings=warnings,
+        errors=errors,
+    )
 
 
-def validate_business(records: list[dict]) -> ValidationResult:
+def validate_business(records: list[dict[str, Any]]) -> ValidationResult:
     """비즈니스 계층 검증.
 
-    low <= open/close <= high, volume >= 0, 시계열 갭 등을 확인한다.
+    OHLCV 비즈니스 규칙과 시계열 연속성을 확인한다.
     실패 시 경고 로그를 남기고 저장은 허용한다.
+
+    검증 규칙:
+    - price > 0 (open, high, low, close)
+    - volume >= 0
+    - low <= close <= high
+    - low <= open <= high
+    - 시계열 갭 감지 (날짜 중복, 순서 역전)
 
     Args:
         records: 검증할 OHLCV 레코드 목록.
 
     Returns:
-        검증 결과 (경고 포함 가능).
+        검증 결과 (경고 포함 가능, 비즈니스 규칙 위반은 경고로 분류).
     """
-    ...
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if not records:
+        return ValidationResult(passed=True, warnings=warnings, errors=errors)
+
+    for i, record in enumerate(records):
+        symbol = record.get("symbol", f"record_{i}")
+
+        # 가격 양수 검증
+        for price_field in ("open", "high", "low", "close"):
+            value = record.get(price_field)
+            if value is None:
+                continue
+            try:
+                price = float(value)
+            except (ValueError, TypeError):
+                continue  # 스키마 검증에서 이미 잡힘
+            if price <= 0:
+                warnings.append(f"{symbol}: {price_field} <= 0 ({price_field}={price})")
+
+        # 거래량 >= 0 검증
+        volume_val = record.get("volume")
+        if volume_val is not None:
+            try:
+                vol = int(float(str(volume_val)))
+            except (ValueError, TypeError):
+                pass
+            else:
+                if vol < 0:
+                    warnings.append(f"{symbol}: volume < 0 (volume={vol})")
+
+        # OHLC 관계 검증: low <= open/close <= high
+        try:
+            o = float(record["open"]) if "open" in record else None
+            h = float(record["high"]) if "high" in record else None
+            low_val = float(record["low"]) if "low" in record else None
+            c = float(record["close"]) if "close" in record else None
+        except (ValueError, TypeError):
+            continue  # 숫자 변환 실패는 스키마 계층에서 처리
+
+        if all(v is not None for v in (o, h, low_val, c)):
+            if low_val > c:
+                warnings.append(f"{symbol}: low > close (low={low_val}, close={c})")
+            if c > h:
+                warnings.append(f"{symbol}: close > high (close={c}, high={h})")
+            if low_val > o:
+                warnings.append(f"{symbol}: low > open (low={low_val}, open={o})")
+            if o > h:
+                warnings.append(f"{symbol}: open > high (open={o}, high={h})")
+
+    # 시계열 연속성 검증 (날짜 중복 및 순서)
+    _validate_time_series(records, warnings)
+
+    if warnings:
+        for w in warnings:
+            logger.warning("비즈니스 검증 경고: %s", w)
+
+    return ValidationResult(
+        passed=True,  # 비즈니스 규칙 위반은 경고이므로 passed=True
+        warnings=warnings,
+        errors=errors,
+    )
+
+
+def _validate_time_series(records: list[dict[str, Any]], warnings: list[str]) -> None:
+    """시계열 연속성을 검증한다.
+
+    날짜 중복과 순서 역전을 감지한다.
+
+    Args:
+        records: 검증할 레코드 목록.
+        warnings: 경고를 추가할 목록.
+    """
+    # timestamp 또는 date 필드로 시계열 확인
+    date_field = "timestamp" if "timestamp" in records[0] else "date"
+    if date_field not in records[0]:
+        return
+
+    # 심볼별로 그룹핑하여 검증
+    by_symbol: dict[str, list[str]] = {}
+    for record in records:
+        symbol = record.get("symbol", "unknown")
+        date_val = record.get(date_field)
+        if date_val is not None:
+            by_symbol.setdefault(symbol, []).append(str(date_val))
+
+    for symbol, dates in by_symbol.items():
+        # 중복 검사
+        seen: set[str] = set()
+        duplicates: list[str] = []
+        for d in dates:
+            if d in seen:
+                duplicates.append(d)
+            seen.add(d)
+
+        if duplicates:
+            warnings.append(f"{symbol}: 중복 날짜 감지: {duplicates}")
+
+        # 순서 검증 (파싱 가능한 날짜에 대해서만)
+        parsed_dates: list[tuple[datetime, str]] = []
+        for d in dates:
+            dt = _try_parse_date(d)
+            if dt is not None:
+                parsed_dates.append((dt, d))
+
+        for j in range(1, len(parsed_dates)):
+            if parsed_dates[j][0] < parsed_dates[j - 1][0]:
+                warnings.append(
+                    f"{symbol}: 날짜 순서 역전 감지: "
+                    f"{parsed_dates[j - 1][1]} -> {parsed_dates[j][1]}"
+                )
+
+
+def _try_parse_date(value: str) -> datetime | None:
+    """날짜 문자열을 파싱 시도한다.
+
+    Args:
+        value: 날짜 문자열.
+
+    Returns:
+        파싱된 datetime 또는 None.
+    """
+    for fmt in (
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%d",
+        "%Y%m%d",
+    ):
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    return None
 
 
 def validate_all(
-    records: list[dict],
+    records: list[dict[str, Any]],
     required_fields: list[str],
     status_code: int = 200,
 ) -> ValidationResult:
     """4계층 검증을 순서대로 실행한다.
+
+    각 계층에서 오류가 발생하면 다음 계층으로 진행하지 않고
+    해당 시점까지의 결과를 반환한다.
 
     Args:
         records: 검증할 레코드 목록.
@@ -109,4 +320,22 @@ def validate_all(
     Returns:
         통합 검증 결과.
     """
-    ...
+    # 1. 전송 계층
+    transport_result = validate_transport(status_code)
+    if not transport_result.passed:
+        return transport_result
+
+    # 2. 구문 계층 (records가 이미 파싱된 상태이므로 list 검증)
+    syntax_result = validate_syntax(records)
+    if not syntax_result.passed:
+        return transport_result.merge(syntax_result)
+
+    # 3. 스키마 계층
+    schema_result = validate_schema(records, required_fields)
+    merged = transport_result.merge(syntax_result).merge(schema_result)
+    if not merged.passed:
+        return merged
+
+    # 4. 비즈니스 계층
+    business_result = validate_business(records)
+    return merged.merge(business_result)

--- a/tests/unit/feed/test_validate.py
+++ b/tests/unit/feed/test_validate.py
@@ -1,0 +1,374 @@
+"""4계층 데이터 검증 모듈 테스트.
+
+각 검증 계층별 테스트와 통합 검증(validate_all) 테스트를 포함한다.
+"""
+
+from __future__ import annotations
+
+import json
+
+from ante.feed.models.result import ValidationResult
+from ante.feed.transform.validate import (
+    validate_all,
+    validate_business,
+    validate_schema,
+    validate_syntax,
+    validate_transport,
+)
+
+# ---------------------------------------------------------------------------
+# 헬퍼
+# ---------------------------------------------------------------------------
+
+
+def _make_ohlcv_record(
+    symbol: str = "005930",
+    timestamp: str = "2024-01-02",
+    open_: float = 100.0,
+    high: float = 110.0,
+    low: float = 90.0,
+    close: float = 105.0,
+    volume: int = 1000,
+    amount: int = 100000,
+    source: str = "data_go_kr",
+) -> dict:
+    """OHLCV 테스트 레코드를 생성한다."""
+    return {
+        "timestamp": timestamp,
+        "symbol": symbol,
+        "open": open_,
+        "high": high,
+        "low": low,
+        "close": close,
+        "volume": volume,
+        "amount": amount,
+        "source": source,
+    }
+
+
+OHLCV_REQUIRED_FIELDS = [
+    "timestamp",
+    "symbol",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "source",
+]
+
+
+# ===========================================================================
+# 1. 전송 계층 (validate_transport)
+# ===========================================================================
+
+
+class TestValidateTransport:
+    """전송 계층 검증 테스트."""
+
+    def test_success_200(self) -> None:
+        result = validate_transport(200)
+        assert result.passed is True
+        assert result.errors == []
+
+    def test_success_with_content_length(self) -> None:
+        result = validate_transport(200, content_length=1024)
+        assert result.passed is True
+
+    def test_fail_4xx(self) -> None:
+        result = validate_transport(404)
+        assert result.passed is False
+        assert len(result.errors) == 1
+        assert "404" in result.errors[0]
+
+    def test_fail_5xx(self) -> None:
+        result = validate_transport(500)
+        assert result.passed is False
+
+    def test_fail_empty_content(self) -> None:
+        result = validate_transport(200, content_length=0)
+        assert result.passed is False
+        assert "비어있음" in result.errors[0]
+
+    def test_none_content_length_skipped(self) -> None:
+        result = validate_transport(200, content_length=None)
+        assert result.passed is True
+
+
+# ===========================================================================
+# 2. 구문 계층 (validate_syntax)
+# ===========================================================================
+
+
+class TestValidateSyntax:
+    """구문 계층 검증 테스트."""
+
+    def test_valid_json_string(self) -> None:
+        raw = json.dumps([{"key": "value"}])
+        result = validate_syntax(raw)
+        assert result.passed is True
+
+    def test_valid_dict(self) -> None:
+        result = validate_syntax({"key": "value"})
+        assert result.passed is True
+
+    def test_valid_list(self) -> None:
+        result = validate_syntax([{"key": "value"}])
+        assert result.passed is True
+
+    def test_none_input(self) -> None:
+        result = validate_syntax(None)
+        assert result.passed is False
+        assert "None" in result.errors[0]
+
+    def test_invalid_json(self) -> None:
+        result = validate_syntax("{not valid json")
+        assert result.passed is False
+        assert "JSON" in result.errors[0]
+
+    def test_invalid_bytes_encoding(self) -> None:
+        result = validate_syntax(b"\x80\x81\x82")
+        assert result.passed is False
+        assert "인코딩" in result.errors[0]
+
+    def test_valid_bytes(self) -> None:
+        raw = json.dumps({"key": "value"}).encode("utf-8")
+        result = validate_syntax(raw)
+        assert result.passed is True
+
+    def test_unsupported_type(self) -> None:
+        result = validate_syntax(12345)
+        assert result.passed is False
+        assert "타입" in result.errors[0]
+
+    def test_json_primitive_not_dict_or_list(self) -> None:
+        result = validate_syntax('"just a string"')
+        assert result.passed is False
+        assert "타입" in result.errors[0]
+
+
+# ===========================================================================
+# 3. 스키마 계층 (validate_schema)
+# ===========================================================================
+
+
+class TestValidateSchema:
+    """스키마 계층 검증 테스트."""
+
+    def test_valid_records(self) -> None:
+        records = [_make_ohlcv_record()]
+        result = validate_schema(records, OHLCV_REQUIRED_FIELDS)
+        assert result.passed is True
+        assert result.errors == []
+
+    def test_empty_records(self) -> None:
+        result = validate_schema([], OHLCV_REQUIRED_FIELDS)
+        assert result.passed is True
+        assert "비어있음" in result.warnings[0]
+
+    def test_missing_required_field(self) -> None:
+        record = _make_ohlcv_record()
+        del record["close"]
+        result = validate_schema([record], OHLCV_REQUIRED_FIELDS)
+        assert result.passed is False
+        assert "close" in result.errors[0]
+
+    def test_multiple_missing_fields(self) -> None:
+        record = {"symbol": "005930", "source": "test"}
+        result = validate_schema([record], OHLCV_REQUIRED_FIELDS)
+        assert result.passed is False
+
+    def test_numeric_conversion_failure(self) -> None:
+        record = _make_ohlcv_record()
+        record["open"] = "not_a_number"
+        result = validate_schema([record], OHLCV_REQUIRED_FIELDS)
+        assert result.passed is False
+        assert "변환 불가" in result.errors[0]
+
+    def test_string_numeric_values_ok(self) -> None:
+        """문자열 숫자 (API 원시 응답 형태)도 통과해야 한다."""
+        record = _make_ohlcv_record()
+        record["open"] = "100.0"
+        record["volume"] = "5000"
+        result = validate_schema([record], OHLCV_REQUIRED_FIELDS)
+        assert result.passed is True
+
+    def test_none_numeric_values_ok(self) -> None:
+        """None 값은 검사를 건너뛴다."""
+        record = _make_ohlcv_record()
+        record["amount"] = None
+        result = validate_schema([record], OHLCV_REQUIRED_FIELDS)
+        assert result.passed is True
+
+
+# ===========================================================================
+# 4. 비즈니스 계층 (validate_business)
+# ===========================================================================
+
+
+class TestValidateBusiness:
+    """비즈니스 계층 검증 테스트."""
+
+    def test_valid_ohlcv(self) -> None:
+        records = [_make_ohlcv_record()]
+        result = validate_business(records)
+        assert result.passed is True
+        assert result.warnings == []
+
+    def test_empty_records(self) -> None:
+        result = validate_business([])
+        assert result.passed is True
+
+    def test_negative_price(self) -> None:
+        record = _make_ohlcv_record(open_=-10.0)
+        result = validate_business([record])
+        assert result.passed is True  # 비즈니스 규칙 위반은 경고
+        assert any("open <= 0" in w for w in result.warnings)
+
+    def test_zero_price(self) -> None:
+        record = _make_ohlcv_record(close=0.0)
+        result = validate_business([record])
+        assert any("close <= 0" in w for w in result.warnings)
+
+    def test_negative_volume(self) -> None:
+        record = _make_ohlcv_record(volume=-100)
+        result = validate_business([record])
+        assert any("volume < 0" in w for w in result.warnings)
+
+    def test_low_greater_than_close(self) -> None:
+        record = _make_ohlcv_record(low=110.0, close=100.0, high=120.0, open_=115.0)
+        result = validate_business([record])
+        assert any("low > close" in w for w in result.warnings)
+
+    def test_close_greater_than_high(self) -> None:
+        record = _make_ohlcv_record(close=130.0, high=120.0, low=90.0)
+        result = validate_business([record])
+        assert any("close > high" in w for w in result.warnings)
+
+    def test_open_greater_than_high(self) -> None:
+        record = _make_ohlcv_record(open_=130.0, high=120.0, low=90.0)
+        result = validate_business([record])
+        assert any("open > high" in w for w in result.warnings)
+
+    def test_low_greater_than_open(self) -> None:
+        record = _make_ohlcv_record(low=110.0, open_=100.0, high=120.0, close=115.0)
+        result = validate_business([record])
+        assert any("low > open" in w for w in result.warnings)
+
+    def test_duplicate_dates(self) -> None:
+        records = [
+            _make_ohlcv_record(timestamp="2024-01-02"),
+            _make_ohlcv_record(timestamp="2024-01-02"),
+        ]
+        result = validate_business(records)
+        assert any("중복" in w for w in result.warnings)
+
+    def test_date_order_reversal(self) -> None:
+        records = [
+            _make_ohlcv_record(timestamp="2024-01-03"),
+            _make_ohlcv_record(timestamp="2024-01-02"),
+        ]
+        result = validate_business(records)
+        assert any("역전" in w for w in result.warnings)
+
+    def test_multiple_symbols_independent(self) -> None:
+        """심볼이 다르면 시계열 검증이 독립적으로 수행된다."""
+        records = [
+            _make_ohlcv_record(symbol="005930", timestamp="2024-01-03"),
+            _make_ohlcv_record(symbol="000660", timestamp="2024-01-02"),
+        ]
+        result = validate_business(records)
+        # 다른 심볼이므로 역전 경고가 없어야 함
+        assert not any("역전" in w for w in result.warnings)
+
+    def test_business_violations_are_warnings_not_errors(self) -> None:
+        """비즈니스 규칙 위반은 경고이며 passed=True이다."""
+        record = _make_ohlcv_record(
+            low=200.0,
+            close=100.0,
+            high=90.0,
+            open_=-5.0,
+            volume=-1,
+        )
+        result = validate_business([record])
+        assert result.passed is True
+        assert len(result.warnings) > 0
+        assert result.errors == []
+
+
+# ===========================================================================
+# 5. 통합 검증 (validate_all)
+# ===========================================================================
+
+
+class TestValidateAll:
+    """통합 검증 테스트."""
+
+    def test_all_pass(self) -> None:
+        records = [_make_ohlcv_record()]
+        result = validate_all(records, OHLCV_REQUIRED_FIELDS, status_code=200)
+        assert result.passed is True
+        assert result.errors == []
+
+    def test_transport_failure_stops_pipeline(self) -> None:
+        records = [_make_ohlcv_record()]
+        result = validate_all(records, OHLCV_REQUIRED_FIELDS, status_code=500)
+        assert result.passed is False
+
+    def test_schema_failure_stops_pipeline(self) -> None:
+        record = _make_ohlcv_record()
+        del record["close"]
+        result = validate_all([record], OHLCV_REQUIRED_FIELDS, status_code=200)
+        assert result.passed is False
+        assert any("close" in e for e in result.errors)
+
+    def test_business_warnings_propagate(self) -> None:
+        record = _make_ohlcv_record(low=200.0, close=100.0, high=300.0, open_=150.0)
+        result = validate_all([record], OHLCV_REQUIRED_FIELDS, status_code=200)
+        assert result.passed is True
+        assert len(result.warnings) > 0
+
+    def test_default_status_code(self) -> None:
+        records = [_make_ohlcv_record()]
+        result = validate_all(records, OHLCV_REQUIRED_FIELDS)
+        assert result.passed is True
+
+
+# ===========================================================================
+# 6. ValidationResult 모델
+# ===========================================================================
+
+
+class TestValidationResult:
+    """ValidationResult 데이터클래스 테스트."""
+
+    def test_creation(self) -> None:
+        result = ValidationResult(passed=True, warnings=[], errors=[])
+        assert result.passed is True
+
+    def test_merge_both_passed(self) -> None:
+        a = ValidationResult(passed=True, warnings=["w1"], errors=[])
+        b = ValidationResult(passed=True, warnings=["w2"], errors=[])
+        merged = a.merge(b)
+        assert merged.passed is True
+        assert merged.warnings == ["w1", "w2"]
+        assert merged.errors == []
+
+    def test_merge_one_failed(self) -> None:
+        a = ValidationResult(passed=True, warnings=[], errors=[])
+        b = ValidationResult(passed=False, warnings=[], errors=["e1"])
+        merged = a.merge(b)
+        assert merged.passed is False
+        assert merged.errors == ["e1"]
+
+    def test_merge_both_failed(self) -> None:
+        a = ValidationResult(passed=False, warnings=[], errors=["e1"])
+        b = ValidationResult(passed=False, warnings=[], errors=["e2"])
+        merged = a.merge(b)
+        assert merged.passed is False
+        assert merged.errors == ["e1", "e2"]
+
+    def test_default_factory(self) -> None:
+        result = ValidationResult(passed=True)
+        assert result.warnings == []
+        assert result.errors == []


### PR DESCRIPTION
## Summary
- DataFeed ETL 파이프라인의 4계층 데이터 검증 시스템 구현 (전송/구문/스키마/비즈니스)
- `ValidationResult` dataclass 추가 (`merge()` 메서드로 계층별 결과 병합)
- 비즈니스 규칙 위반은 경고(warning)로 분류하여 저장 허용, 스키마 위반은 오류(error)로 차단

## Changes
- `src/ante/feed/transform/validate.py`: 스텁에서 전체 구현으로 전환 (5개 공개 함수 + 2개 내부 헬퍼)
- `src/ante/feed/models/result.py`: `ValidationResult` dataclass 추가
- `src/ante/feed/models/__init__.py`: `ValidationResult` export 추가
- `tests/unit/feed/test_validate.py`: 45건 단위 테스트 (계층별 + 통합 + 모델)

## Test plan
- [x] `pytest tests/unit/feed/test_validate.py -v` — 45건 전체 통과
- [x] `pytest tests/unit/ -x` — 기존 1397건 테스트 회귀 없음
- [x] `ruff check` + `ruff format` 통과

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)