### PR TITLE
feat(feed): 리포트 생성기 구현

### DIFF
--- a/src/ante/feed/report/__init__.py
+++ b/src/ante/feed/report/__init__.py
@@ -1,3 +1,7 @@
 """ante.feed.report — 수집 리포트 생성."""
 
 from __future__ import annotations
+
+from ante.feed.report.generator import ReportGenerator
+
+__all__ = ["ReportGenerator"]

--- a/src/ante/feed/report/generator.py
+++ b/src/ante/feed/report/generator.py
@@ -6,12 +6,11 @@ CollectionResult를 JSON 파일로 변환하여 .feed/reports/ 에 저장한다.
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from ante.feed.models.result import CollectionResult
+from ante.feed.models.result import CollectionResult
 
 logger = logging.getLogger(__name__)
 
@@ -27,20 +26,66 @@ class ReportGenerator:
         Args:
             feed_dir: .feed 디렉토리 경로.
         """
-        ...
+        self._feed_dir = feed_dir
 
-    def generate(self, result: CollectionResult) -> Path:
-        """CollectionResult를 JSON 파일로 저장한다.
-
-        파일명: {YYYY-MM-DD}-{mode}.json (started_at 기준)
+    def generate(self, result: CollectionResult) -> dict:
+        """CollectionResult를 리포트 dict로 변환한다.
 
         Args:
             result: 수집 결과 객체.
 
         Returns:
+            리포트 JSON 구조를 담은 dict.
+        """
+        report: dict = {
+            "mode": result.mode,
+            "started_at": result.started_at,
+            "finished_at": result.finished_at,
+            "duration_seconds": result.duration_seconds,
+            "target_date": result.target_date,
+            "summary": {
+                "symbols_total": result.symbols_total,
+                "symbols_success": result.symbols_success,
+                "symbols_failed": result.symbols_failed,
+                "rows_written": result.rows_written,
+                "data_types": list(result.data_types),
+            },
+            "failures": list(result.failures),
+            "warnings": list(result.warnings),
+            "config_errors": list(result.config_errors),
+        }
+        return report
+
+    def save(self, data_path: Path, report: dict, mode: str) -> Path:
+        """리포트를 JSON 파일로 저장한다.
+
+        경로: {data_path}/.feed/reports/{YYYY-MM-DD}-{mode}.json
+        날짜는 report의 started_at에서 추출한다.
+
+        Args:
+            data_path: 데이터 루트 디렉토리.
+            report: generate()가 반환한 리포트 dict.
+            mode: 수집 모드 ('daily' 또는 'backfill').
+
+        Returns:
             저장된 리포트 파일 경로.
         """
-        ...
+        started_at = report["started_at"]
+        date_str = started_at[:10]
+
+        reports_dir = data_path / ".feed" / REPORTS_DIR
+        reports_dir.mkdir(parents=True, exist_ok=True)
+
+        filename = f"{date_str}-{mode}.json"
+        file_path = reports_dir / filename
+
+        file_path.write_text(
+            json.dumps(report, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+        logger.info("리포트 저장 완료: %s", file_path)
+        return file_path
 
     def list_reports(self, limit: int = 10) -> list[Path]:
         """최근 리포트 목록을 반환한다.
@@ -51,4 +96,9 @@ class ReportGenerator:
         Returns:
             리포트 파일 경로 목록.
         """
-        ...
+        reports_dir = self._feed_dir / REPORTS_DIR
+        if not reports_dir.exists():
+            return []
+
+        files = sorted(reports_dir.glob("*.json"), reverse=True)
+        return files[:limit]

--- a/tests/unit/feed/test_report.py
+++ b/tests/unit/feed/test_report.py
@@ -1,0 +1,340 @@
+"""리포트 생성기 단위 테스트."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ante.feed.models.result import CollectionResult
+from ante.feed.report.generator import REPORTS_DIR, ReportGenerator
+
+
+@pytest.fixture
+def feed_dir(tmp_path: Path) -> Path:
+    """임시 .feed 디렉토리를 생성한다."""
+    d = tmp_path / ".feed"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def data_path(tmp_path: Path) -> Path:
+    """임시 데이터 루트 디렉토리를 반환한다."""
+    return tmp_path
+
+
+@pytest.fixture
+def sample_result() -> CollectionResult:
+    """테스트용 CollectionResult를 생성한다."""
+    return CollectionResult(
+        mode="daily",
+        started_at="2026-03-17T16:00:12Z",
+        finished_at="2026-03-17T16:05:34Z",
+        duration_seconds=322.0,
+        target_date="2026-03-16",
+        symbols_total=2487,
+        symbols_success=2485,
+        symbols_failed=2,
+        rows_written=2485,
+        data_types=["ohlcv", "fundamental"],
+        failures=[
+            {
+                "symbol": "003920",
+                "date": "2026-03-16",
+                "source": "data_go_kr",
+                "reason": "API 타임아웃",
+                "retries": 3,
+            },
+        ],
+        warnings=[
+            {
+                "symbol": "005930",
+                "date": "2026-03-16",
+                "type": "business_rule",
+                "message": "전일 대비 가격 변동 30% 초과",
+            },
+        ],
+        config_errors=[
+            {
+                "key": "ANTE_DART_API_KEY",
+                "message": "API 키 미설정",
+            },
+        ],
+    )
+
+
+@pytest.fixture
+def empty_result() -> CollectionResult:
+    """failures/warnings/config_errors가 비어있는 CollectionResult."""
+    return CollectionResult(
+        mode="backfill",
+        started_at="2026-03-15T10:00:00Z",
+        finished_at="2026-03-15T10:30:00Z",
+        duration_seconds=1800.0,
+        target_date="2026-03-14",
+        symbols_total=100,
+        symbols_success=100,
+        symbols_failed=0,
+        rows_written=100,
+        data_types=["ohlcv"],
+    )
+
+
+class TestReportGenerate:
+    """generate() 메서드 테스트."""
+
+    def test_returns_dict(
+        self, feed_dir: Path, sample_result: CollectionResult
+    ) -> None:
+        """generate()는 dict를 반환한다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(sample_result)
+        assert isinstance(report, dict)
+
+    def test_top_level_keys(
+        self, feed_dir: Path, sample_result: CollectionResult
+    ) -> None:
+        """리포트에 필수 최상위 키가 존재한다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(sample_result)
+
+        required_keys = {
+            "mode",
+            "started_at",
+            "finished_at",
+            "duration_seconds",
+            "target_date",
+            "summary",
+            "failures",
+            "warnings",
+            "config_errors",
+        }
+        assert required_keys <= set(report.keys())
+
+    def test_mode_value(self, feed_dir: Path, sample_result: CollectionResult) -> None:
+        """mode 필드가 CollectionResult의 값과 일치한다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(sample_result)
+        assert report["mode"] == "daily"
+
+    def test_summary_structure(
+        self, feed_dir: Path, sample_result: CollectionResult
+    ) -> None:
+        """summary에 필수 키가 모두 포함된다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(sample_result)
+        summary = report["summary"]
+
+        assert summary["symbols_total"] == 2487
+        assert summary["symbols_success"] == 2485
+        assert summary["symbols_failed"] == 2
+        assert summary["rows_written"] == 2485
+        assert summary["data_types"] == ["ohlcv", "fundamental"]
+
+    def test_failures_type(
+        self, feed_dir: Path, sample_result: CollectionResult
+    ) -> None:
+        """failures는 list이다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(sample_result)
+        assert isinstance(report["failures"], list)
+        assert len(report["failures"]) == 1
+
+    def test_warnings_type(
+        self, feed_dir: Path, sample_result: CollectionResult
+    ) -> None:
+        """warnings는 list이다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(sample_result)
+        assert isinstance(report["warnings"], list)
+        assert len(report["warnings"]) == 1
+
+    def test_config_errors_type(
+        self, feed_dir: Path, sample_result: CollectionResult
+    ) -> None:
+        """config_errors는 list이다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(sample_result)
+        assert isinstance(report["config_errors"], list)
+        assert len(report["config_errors"]) == 1
+
+
+class TestReportGenerateEmpty:
+    """빈 결과 처리 테스트."""
+
+    def test_empty_failures(
+        self, feed_dir: Path, empty_result: CollectionResult
+    ) -> None:
+        """failures가 빈 배열일 때 정상 생성된다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(empty_result)
+        assert report["failures"] == []
+
+    def test_empty_warnings(
+        self, feed_dir: Path, empty_result: CollectionResult
+    ) -> None:
+        """warnings가 빈 배열일 때 정상 생성된다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(empty_result)
+        assert report["warnings"] == []
+
+    def test_empty_config_errors(
+        self, feed_dir: Path, empty_result: CollectionResult
+    ) -> None:
+        """config_errors가 빈 배열일 때 정상 생성된다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(empty_result)
+        assert report["config_errors"] == []
+
+    def test_empty_result_has_all_keys(
+        self, feed_dir: Path, empty_result: CollectionResult
+    ) -> None:
+        """빈 결과에도 모든 필수 키가 존재한다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(empty_result)
+        required_keys = {
+            "mode",
+            "started_at",
+            "finished_at",
+            "duration_seconds",
+            "target_date",
+            "summary",
+            "failures",
+            "warnings",
+            "config_errors",
+        }
+        assert required_keys <= set(report.keys())
+
+
+class TestReportSave:
+    """save() 메서드 테스트."""
+
+    def test_creates_file(
+        self,
+        feed_dir: Path,
+        data_path: Path,
+        sample_result: CollectionResult,
+    ) -> None:
+        """save()는 JSON 파일을 생성한다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(sample_result)
+        path = gen.save(data_path, report, "daily")
+        assert path.exists()
+
+    def test_file_path_pattern(
+        self,
+        feed_dir: Path,
+        data_path: Path,
+        sample_result: CollectionResult,
+    ) -> None:
+        """파일 경로가 {YYYY-MM-DD}-{mode}.json 패턴이다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(sample_result)
+        path = gen.save(data_path, report, "daily")
+
+        assert path.name == "2026-03-17-daily.json"
+        assert path.parent == data_path / ".feed" / REPORTS_DIR
+
+    def test_file_is_valid_json(
+        self,
+        feed_dir: Path,
+        data_path: Path,
+        sample_result: CollectionResult,
+    ) -> None:
+        """저장된 파일이 유효한 JSON이다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(sample_result)
+        path = gen.save(data_path, report, "daily")
+
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+        assert isinstance(data, dict)
+        assert data["mode"] == "daily"
+
+    def test_creates_reports_dir(
+        self,
+        feed_dir: Path,
+        data_path: Path,
+        sample_result: CollectionResult,
+    ) -> None:
+        """reports 디렉토리가 없으면 자동 생성한다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(sample_result)
+        gen.save(data_path, report, "daily")
+
+        assert (data_path / ".feed" / REPORTS_DIR).is_dir()
+
+    def test_backfill_mode_filename(
+        self,
+        feed_dir: Path,
+        data_path: Path,
+        empty_result: CollectionResult,
+    ) -> None:
+        """backfill 모드일 때 파일명에 backfill이 포함된다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(empty_result)
+        path = gen.save(data_path, report, "backfill")
+
+        assert path.name == "2026-03-15-backfill.json"
+
+    def test_saved_content_matches_report(
+        self,
+        feed_dir: Path,
+        data_path: Path,
+        sample_result: CollectionResult,
+    ) -> None:
+        """저장된 JSON 내용이 generate()의 반환값과 일치한다."""
+        gen = ReportGenerator(feed_dir)
+        report = gen.generate(sample_result)
+        path = gen.save(data_path, report, "daily")
+
+        raw = path.read_text(encoding="utf-8")
+        saved = json.loads(raw)
+        assert saved == report
+
+
+class TestReportListReports:
+    """list_reports() 메서드 테스트."""
+
+    def test_empty_when_no_reports(self, feed_dir: Path) -> None:
+        """리포트가 없으면 빈 리스트를 반환한다."""
+        gen = ReportGenerator(feed_dir)
+        assert gen.list_reports() == []
+
+    def test_returns_existing_reports(self, feed_dir: Path) -> None:
+        """저장된 리포트 파일 목록을 반환한다."""
+        reports_dir = feed_dir / REPORTS_DIR
+        reports_dir.mkdir()
+        (reports_dir / "2026-03-15-daily.json").write_text("{}", encoding="utf-8")
+        (reports_dir / "2026-03-16-daily.json").write_text("{}", encoding="utf-8")
+
+        gen = ReportGenerator(feed_dir)
+        reports = gen.list_reports()
+        assert len(reports) == 2
+
+    def test_limit_parameter(self, feed_dir: Path) -> None:
+        """limit 파라미터가 반환 개수를 제한한다."""
+        reports_dir = feed_dir / REPORTS_DIR
+        reports_dir.mkdir()
+        for i in range(5):
+            (reports_dir / f"2026-03-{10 + i:02d}-daily.json").write_text(
+                "{}", encoding="utf-8"
+            )
+
+        gen = ReportGenerator(feed_dir)
+        reports = gen.list_reports(limit=3)
+        assert len(reports) == 3
+
+    def test_sorted_reverse(self, feed_dir: Path) -> None:
+        """최신 순으로 정렬된다."""
+        reports_dir = feed_dir / REPORTS_DIR
+        reports_dir.mkdir()
+        (reports_dir / "2026-03-10-daily.json").write_text("{}", encoding="utf-8")
+        (reports_dir / "2026-03-15-daily.json").write_text("{}", encoding="utf-8")
+
+        gen = ReportGenerator(feed_dir)
+        reports = gen.list_reports()
+        assert reports[0].name == "2026-03-15-daily.json"
+        assert reports[1].name == "2026-03-10-daily.json"


### PR DESCRIPTION
## Summary
- `ReportGenerator` 클래스 구현: `CollectionResult`를 JSON 리포트로 변환·저장
- `generate()`: CollectionResult → dict 변환 (mode, summary, failures, warnings, config_errors 포함)
- `save()`: `{data}/.feed/reports/{YYYY-MM-DD}-{mode}.json` 경로에 JSON 파일 저장
- `list_reports()`: 최근 리포트 파일 목록 조회 (최신 순 정렬)

## Test plan
- [x] 리포트 생성: CollectionResult → dict 변환 검증 (7건)
- [x] 빈 결과 처리: failures/warnings/config_errors 빈 배열 정상 생성 (4건)
- [x] 파일 저장: 경로 패턴, JSON 유효성, 디렉토리 자동 생성 검증 (6건)
- [x] 목록 조회: 빈 목록, 정렬, limit 파라미터 검증 (4건)
- [x] 전체 21건 테스트 통과 (`pytest tests/unit/feed/test_report.py -v`)

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)