### PR TITLE
feat(feed): data.go.kr 소스 어댑터 구현

### DIFF
--- a/src/ante/feed/sources/__init__.py
+++ b/src/ante/feed/sources/__init__.py
@@ -1,3 +1,20 @@
 """ante.feed.sources — 데이터 소스 어댑터."""
 
 from __future__ import annotations
+
+from ante.feed.sources.base import DataSource, RateLimiter
+from ante.feed.sources.data_go_kr import (
+    CriticalApiError,
+    DailyLimitExceededError,
+    DataGoKrError,
+    DataGoKrSource,
+)
+
+__all__ = [
+    "CriticalApiError",
+    "DailyLimitExceededError",
+    "DataGoKrError",
+    "DataGoKrSource",
+    "DataSource",
+    "RateLimiter",
+]

--- a/src/ante/feed/sources/base.py
+++ b/src/ante/feed/sources/base.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
@@ -19,7 +21,7 @@ class DataSource(Protocol):
     orchestrator는 이 프로토콜을 통해 소스를 다룬다.
     """
 
-    def fetch(self, date: str, **kwargs: Any) -> list[dict]:
+    async def fetch(self, date: str, **kwargs: Any) -> list[dict]:
         """지정된 날짜의 데이터를 수집한다.
 
         Args:
@@ -46,15 +48,32 @@ class RateLimiter:
             tps_limit: 초당 허용 트랜잭션 수.
             daily_limit: 일일 최대 호출 수.
         """
-        ...
+        self._rate = tps_limit
+        self._burst = int(tps_limit)
+        self._tokens = float(self._burst)
+        self._last_refill = time.monotonic()
+        self._lock = asyncio.Lock()
+        self._daily_limit = daily_limit
+        self._daily_count = 0
 
-    def acquire(self) -> None:
+    async def acquire(self) -> None:
         """토큰 하나를 소비한다. 필요 시 대기한다."""
-        ...
+        async with self._lock:
+            now = time.monotonic()
+            elapsed = now - self._last_refill
+            self._tokens = min(self._burst, self._tokens + elapsed * self._rate)
+            self._last_refill = now
+
+            if self._tokens < 1:
+                wait_time = (1 - self._tokens) / self._rate
+                await asyncio.sleep(wait_time)
+                self._tokens = 0
+            else:
+                self._tokens -= 1
 
     def increment_daily(self) -> None:
         """일일 호출 카운터를 1 증가시킨다."""
-        ...
+        self._daily_count += 1
 
     def is_daily_limit_reached(self, threshold: float = 0.9) -> bool:
         """일일 한도의 threshold 비율에 도달했는지 확인한다.
@@ -65,8 +84,13 @@ class RateLimiter:
         Returns:
             한도에 도달하면 True.
         """
-        ...
+        return self._daily_count >= int(self._daily_limit * threshold)
 
     def reset_daily(self) -> None:
         """일일 카운터를 초기화한다 (자정 후 호출)."""
-        ...
+        self._daily_count = 0
+
+    @property
+    def daily_count(self) -> int:
+        """현재 일일 호출 수."""
+        return self._daily_count

--- a/src/ante/feed/sources/data_go_kr.py
+++ b/src/ante/feed/sources/data_go_kr.py
@@ -1,0 +1,356 @@
+"""data.go.kr 주식시세 API 소스 어댑터.
+
+getStockPriceInfo 단일 호출로 OHLCV + 거래대금 + 시가총액 + 상장주식수를 동시 확보.
+날짜별 전종목 조회 방식을 사용하며, 페이지네이션과 에러 코드 처리를 담당한다.
+
+API 레퍼런스: docs/references/dashboard/data-go-kr-stock-price-api.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from enum import StrEnum
+from typing import Any
+
+import aiohttp
+
+from ante.feed.sources.base import RateLimiter
+
+logger = logging.getLogger(__name__)
+
+# ── API 상수 (API 스펙 종속, 하드코딩) ─────────────────────
+
+BASE_URL = (
+    "https://apis.data.go.kr/1160100/service"
+    "/GetStockSecuritiesInfoService/getStockPriceInfo"
+)
+TPS_LIMIT = 25.0  # 실제 30 tps, 여유분 확보
+DAILY_LIMIT = 10_000
+NUM_OF_ROWS = 1000
+REQUEST_TIMEOUT = 30  # 초
+
+
+# ── 에러 분류 ──────────────────────────────────────────────
+
+
+class ErrorAction(StrEnum):
+    """API 에러 코드에 따른 행동 분류."""
+
+    OK = "ok"
+    RETRY = "retry"
+    SKIP = "skip"
+    DAILY_LIMIT = "daily_limit"
+    CRITICAL = "critical"
+
+
+# data.go.kr resultCode → 행동 매핑
+_ERROR_CODE_MAP: dict[str, ErrorAction] = {
+    "00": ErrorAction.OK,
+    "01": ErrorAction.RETRY,  # APPLICATION_ERROR
+    "10": ErrorAction.SKIP,  # INVALID_REQUEST_PARAMETER_ERROR
+    "12": ErrorAction.SKIP,  # NO_OPENAPI_SERVICE_ERROR
+    "20": ErrorAction.SKIP,  # SERVICE_ACCESS_DENIED_ERROR
+    "22": ErrorAction.DAILY_LIMIT,  # LIMITED_NUMBER_OF_SERVICE_REQUESTS_EXCEEDS_ERROR
+    "30": ErrorAction.CRITICAL,  # SERVICE_KEY_IS_NOT_REGISTERED_ERROR
+    "31": ErrorAction.CRITICAL,  # DEADLINE_HAS_EXPIRED_ERROR
+    "32": ErrorAction.SKIP,  # UNREGISTERED_IP_ERROR
+    "99": ErrorAction.RETRY,  # UNKNOWN_ERROR
+}
+
+
+def classify_error(result_code: str) -> ErrorAction:
+    """resultCode를 행동으로 분류한다."""
+    return _ERROR_CODE_MAP.get(result_code, ErrorAction.RETRY)
+
+
+# ── 예외 ──────────────────────────────────────────────────
+
+
+class DataGoKrError(Exception):
+    """data.go.kr API 에러 기본 예외."""
+
+    pass
+
+
+class DailyLimitExceededError(DataGoKrError):
+    """일일 호출 한도 초과."""
+
+    pass
+
+
+class CriticalApiError(DataGoKrError):
+    """서비스키 미등록/만료 등 복구 불가능 에러."""
+
+    pass
+
+
+# ── DataGoKrSource ────────────────────────────────────────
+
+
+class DataGoKrSource:
+    """data.go.kr 주식시세 API 소스 어댑터.
+
+    fetch_by_date(date)로 해당 날짜 전 종목 데이터를 수집한다.
+    페이지네이션, Rate Limiting, 에러 코드 처리를 담당한다.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        rate_limiter: RateLimiter | None = None,
+        session: aiohttp.ClientSession | None = None,
+        *,
+        max_retries: int = 3,
+        base_url: str = BASE_URL,
+    ) -> None:
+        """DataGoKrSource를 초기화한다.
+
+        Args:
+            api_key: data.go.kr 공공데이터포털 서비스키 (디코딩된 원본).
+            rate_limiter: Rate Limiter 인스턴스. None이면 기본값 생성.
+            session: aiohttp 세션. None이면 fetch 시 생성.
+            max_retries: 최대 재시도 횟수.
+            base_url: API 엔드포인트 URL.
+        """
+        self._api_key = api_key
+        self._rate_limiter = rate_limiter or RateLimiter(
+            tps_limit=TPS_LIMIT, daily_limit=DAILY_LIMIT
+        )
+        self._session = session
+        self._max_retries = max_retries
+        self._base_url = base_url
+
+    @property
+    def rate_limiter(self) -> RateLimiter:
+        """Rate Limiter 인스턴스."""
+        return self._rate_limiter
+
+    async def fetch(self, date: str, **kwargs: Any) -> list[dict]:
+        """DataSource 프로토콜 구현. fetch_by_date에 위임한다.
+
+        Args:
+            date: 수집 대상 날짜 (YYYY-MM-DD 형식).
+            **kwargs: 미사용.
+
+        Returns:
+            수집된 레코드 딕셔너리 목록.
+        """
+        return await self.fetch_by_date(date)
+
+    async def fetch_by_date(self, date: str) -> list[dict]:
+        """해당 날짜 전 종목 데이터를 수집한다.
+
+        날짜별 전종목 조회 방식으로 페이지네이션을 처리한다.
+        1일 = ~2,400건 (KOSPI+KOSDAQ) → 약 3페이지 (numOfRows=1000).
+
+        Args:
+            date: 수집 대상 날짜 (YYYY-MM-DD 형식).
+
+        Returns:
+            수집된 레코드 딕셔너리 목록.
+
+        Raises:
+            DailyLimitExceededError: 일일 한도 초과 시.
+            CriticalApiError: 서비스키 미등록/만료 등 복구 불가능 에러.
+        """
+        # YYYY-MM-DD → YYYYMMDD (API 요청 형식)
+        bas_dt = date.replace("-", "")
+        all_items: list[dict] = []
+        page_no = 1
+
+        own_session = self._session is None
+        session = self._session or aiohttp.ClientSession()
+
+        try:
+            while True:
+                # 일일 한도 확인
+                if self._rate_limiter.is_daily_limit_reached():
+                    msg = (
+                        f"일일 한도 90% 도달 "
+                        f"({self._rate_limiter.daily_count}/{DAILY_LIMIT})"
+                    )
+                    logger.critical(msg)
+                    raise DailyLimitExceededError(msg)
+
+                items, total_count = await self._fetch_page(session, bas_dt, page_no)
+                all_items.extend(items)
+
+                logger.debug(
+                    "data.go.kr 수집: date=%s page=%d items=%d total=%d",
+                    date,
+                    page_no,
+                    len(items),
+                    total_count,
+                )
+
+                # 페이지네이션 종료 조건
+                if len(all_items) >= total_count or len(items) == 0:
+                    break
+
+                page_no += 1
+        finally:
+            if own_session:
+                await session.close()
+
+        logger.info("data.go.kr 수집 완료: date=%s records=%d", date, len(all_items))
+        return all_items
+
+    async def _fetch_page(
+        self,
+        session: aiohttp.ClientSession,
+        bas_dt: str,
+        page_no: int,
+    ) -> tuple[list[dict], int]:
+        """단일 페이지를 조회한다.
+
+        Args:
+            session: aiohttp 세션.
+            bas_dt: 기준일자 (YYYYMMDD).
+            page_no: 페이지 번호.
+
+        Returns:
+            (item 목록, totalCount) 튜플.
+
+        Raises:
+            DailyLimitExceededError: 일일 한도 초과 에러 코드.
+            CriticalApiError: 복구 불가능 에러 코드.
+            DataGoKrError: 재시도 소진 후 최종 실패.
+        """
+        params = {
+            "serviceKey": self._api_key,
+            "numOfRows": str(NUM_OF_ROWS),
+            "pageNo": str(page_no),
+            "resultType": "json",
+            "basDt": bas_dt,
+        }
+
+        last_error: Exception | None = None
+
+        for attempt in range(self._max_retries):
+            await self._rate_limiter.acquire()
+
+            try:
+                data = await asyncio.wait_for(
+                    self._do_request(session, params),
+                    timeout=REQUEST_TIMEOUT,
+                )
+                self._rate_limiter.increment_daily()
+            except (TimeoutError, aiohttp.ClientError) as exc:
+                last_error = exc
+                delay = self._backoff_delay(attempt)
+                logger.warning(
+                    "data.go.kr 요청 실패 (attempt=%d/%d): %s. %.1f초 후 재시도",
+                    attempt + 1,
+                    self._max_retries,
+                    exc,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+                continue
+
+            # HTTP 200이지만 body에 에러 코드가 있을 수 있음
+            result_code, result_msg = self._extract_result_code(data)
+            action = classify_error(result_code)
+
+            if action == ErrorAction.OK:
+                return self._extract_items(data)
+
+            if action == ErrorAction.DAILY_LIMIT:
+                msg = f"일일 한도 초과: {result_msg}"
+                logger.critical(msg)
+                raise DailyLimitExceededError(msg)
+
+            if action == ErrorAction.CRITICAL:
+                msg = f"복구 불가능 에러 (code={result_code}): {result_msg}"
+                logger.critical(msg)
+                raise CriticalApiError(msg)
+
+            if action == ErrorAction.SKIP:
+                msg = f"재시도 불가 에러 (code={result_code}): {result_msg}"
+                logger.error(msg)
+                raise DataGoKrError(msg)
+
+            # RETRY
+            last_error = DataGoKrError(f"API 에러 (code={result_code}): {result_msg}")
+            if attempt < self._max_retries - 1:
+                delay = self._backoff_delay(attempt)
+                logger.warning(
+                    "data.go.kr API 에러 (attempt=%d/%d, code=%s):"
+                    " %s. %.1f초 후 재시도",
+                    attempt + 1,
+                    self._max_retries,
+                    result_code,
+                    result_msg,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+        # 재시도 소진
+        msg = f"data.go.kr 요청 최종 실패: basDt={bas_dt}, pageNo={page_no}"
+        logger.error(msg)
+        raise DataGoKrError(msg) from last_error
+
+    async def _do_request(
+        self,
+        session: aiohttp.ClientSession,
+        params: dict[str, str],
+    ) -> dict:
+        """HTTP GET 요청을 보내고 JSON 응답을 반환한다."""
+        async with session.get(self._base_url, params=params) as resp:
+            resp.raise_for_status()
+            return await resp.json(content_type=None)
+
+    @staticmethod
+    def _extract_result_code(data: dict) -> tuple[str, str]:
+        """응답에서 resultCode와 resultMsg를 추출한다.
+
+        Args:
+            data: JSON 응답 딕셔너리.
+
+        Returns:
+            (resultCode, resultMsg) 튜플.
+        """
+        header = data.get("response", {}).get("header", {})
+        result_code = str(header.get("resultCode", "99"))
+        result_msg = str(header.get("resultMsg", "UNKNOWN"))
+        return result_code, result_msg
+
+    @staticmethod
+    def _extract_items(data: dict) -> tuple[list[dict], int]:
+        """응답에서 item 목록과 totalCount를 추출한다.
+
+        Args:
+            data: JSON 응답 딕셔너리.
+
+        Returns:
+            (item 목록, totalCount) 튜플.
+        """
+        body = data.get("response", {}).get("body", {})
+        total_count = int(body.get("totalCount", 0))
+        items_wrapper = body.get("items", {})
+
+        if not items_wrapper:
+            return [], total_count
+
+        items = items_wrapper.get("item", [])
+        # 단일 item인 경우 list로 감싸기
+        if isinstance(items, dict):
+            items = [items]
+
+        return items, total_count
+
+    @staticmethod
+    def _backoff_delay(attempt: int, base: float = 1.0, cap: float = 60.0) -> float:
+        """Exponential Backoff + Full Jitter 대기 시간을 계산한다.
+
+        Args:
+            attempt: 현재 시도 인덱스 (0-based).
+            base: 기본 대기 시간 (초).
+            cap: 최대 대기 시간 (초).
+
+        Returns:
+            대기 시간 (초).
+        """
+        return random.uniform(0, min(cap, base * (2**attempt)))

--- a/tests/unit/feed/test_data_go_kr.py
+++ b/tests/unit/feed/test_data_go_kr.py
@@ -1,0 +1,491 @@
+"""data.go.kr 소스 어댑터 유닛 테스트."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ante.feed.sources.base import RateLimiter
+from ante.feed.sources.data_go_kr import (
+    CriticalApiError,
+    DailyLimitExceededError,
+    DataGoKrError,
+    DataGoKrSource,
+    ErrorAction,
+    classify_error,
+)
+
+# ── 테스트 헬퍼 ──────────────────────────────────────────────
+
+
+def _make_response(
+    items: list[dict],
+    total_count: int | None = None,
+    result_code: str = "00",
+    result_msg: str = "NORMAL SERVICE.",
+) -> dict:
+    """data.go.kr API mock 응답을 생성한다."""
+    if total_count is None:
+        total_count = len(items)
+    return {
+        "response": {
+            "header": {
+                "resultCode": result_code,
+                "resultMsg": result_msg,
+            },
+            "body": {
+                "numOfRows": 1000,
+                "pageNo": 1,
+                "totalCount": total_count,
+                "items": {"item": items},
+            },
+        }
+    }
+
+
+def _make_item(
+    bas_dt: str = "20240301",
+    srtn_cd: str = "005930",
+    itms_nm: str = "삼성전자",
+    mrkt_ctg: str = "KOSPI",
+    mkp: str = "71000",
+    hipr: str = "72000",
+    lopr: str = "70500",
+    clpr: str = "71500",
+    trqu: str = "15000000",
+    tr_prc: str = "1072500000000",
+    lstg_st_cnt: str = "5969782550",
+    mrkt_tot_amt: str = "426839412325000",
+) -> dict:
+    """data.go.kr API mock item을 생성한다."""
+    return {
+        "basDt": bas_dt,
+        "srtnCd": srtn_cd,
+        "isinCd": "KR7005930003",
+        "itmsNm": itms_nm,
+        "mrktCtg": mrkt_ctg,
+        "clpr": clpr,
+        "vs": "500",
+        "fltRt": "0.70",
+        "mkp": mkp,
+        "hipr": hipr,
+        "lopr": lopr,
+        "trqu": trqu,
+        "trPrc": tr_prc,
+        "lstgStCnt": lstg_st_cnt,
+        "mrktTotAmt": mrkt_tot_amt,
+    }
+
+
+@pytest.fixture
+def rate_limiter() -> RateLimiter:
+    """RateLimiter 인스턴스."""
+    return RateLimiter(tps_limit=25.0, daily_limit=10_000)
+
+
+@pytest.fixture
+def source(rate_limiter: RateLimiter) -> DataGoKrSource:
+    """DataGoKrSource 인스턴스."""
+    return DataGoKrSource(
+        api_key="test-api-key",
+        rate_limiter=rate_limiter,
+        max_retries=2,
+    )
+
+
+# ── classify_error ───────────────────────────────────────────
+
+
+class TestClassifyError:
+    """에러 코드 분류 테스트."""
+
+    def test_normal_service(self) -> None:
+        """00은 OK로 분류한다."""
+        assert classify_error("00") == ErrorAction.OK
+
+    def test_invalid_parameter(self) -> None:
+        """10은 SKIP으로 분류한다."""
+        assert classify_error("10") == ErrorAction.SKIP
+
+    def test_daily_limit_exceeded(self) -> None:
+        """22는 DAILY_LIMIT으로 분류한다."""
+        assert classify_error("22") == ErrorAction.DAILY_LIMIT
+
+    def test_service_key_not_registered(self) -> None:
+        """30은 CRITICAL로 분류한다."""
+        assert classify_error("30") == ErrorAction.CRITICAL
+
+    def test_deadline_expired(self) -> None:
+        """31은 CRITICAL로 분류한다."""
+        assert classify_error("31") == ErrorAction.CRITICAL
+
+    def test_unknown_error(self) -> None:
+        """99는 RETRY로 분류한다."""
+        assert classify_error("99") == ErrorAction.RETRY
+
+    def test_unmapped_code_defaults_to_retry(self) -> None:
+        """매핑되지 않은 코드는 RETRY로 분류한다."""
+        assert classify_error("55") == ErrorAction.RETRY
+
+
+# ── _extract_result_code ─────────────────────────────────────
+
+
+class TestExtractResultCode:
+    """응답 resultCode 추출 테스트."""
+
+    def test_normal_response(self) -> None:
+        """정상 응답에서 resultCode를 추출한다."""
+        data = _make_response([_make_item()])
+        code, msg = DataGoKrSource._extract_result_code(data)
+        assert code == "00"
+        assert msg == "NORMAL SERVICE."
+
+    def test_error_response(self) -> None:
+        """에러 응답에서 resultCode를 추출한다."""
+        data = _make_response([], result_code="30", result_msg="KEY_ERROR")
+        code, msg = DataGoKrSource._extract_result_code(data)
+        assert code == "30"
+        assert msg == "KEY_ERROR"
+
+    def test_missing_header(self) -> None:
+        """헤더가 없으면 기본값 99/UNKNOWN을 반환한다."""
+        code, msg = DataGoKrSource._extract_result_code({})
+        assert code == "99"
+        assert msg == "UNKNOWN"
+
+
+# ── _extract_items ───────────────────────────────────────────
+
+
+class TestExtractItems:
+    """응답 item 목록 추출 테스트."""
+
+    def test_multiple_items(self) -> None:
+        """여러 item을 추출한다."""
+        items_data = [_make_item(srtn_cd="005930"), _make_item(srtn_cd="000660")]
+        data = _make_response(items_data, total_count=2)
+        items, total = DataGoKrSource._extract_items(data)
+        assert len(items) == 2
+        assert total == 2
+
+    def test_single_item_as_dict(self) -> None:
+        """단일 item이 dict로 올 경우 list로 감싼다."""
+        single_item = _make_item()
+        data = {
+            "response": {
+                "header": {"resultCode": "00", "resultMsg": "OK"},
+                "body": {
+                    "totalCount": 1,
+                    "items": {"item": single_item},
+                },
+            }
+        }
+        items, total = DataGoKrSource._extract_items(data)
+        assert len(items) == 1
+        assert total == 1
+
+    def test_empty_items(self) -> None:
+        """items가 비어있으면 빈 리스트를 반환한다."""
+        data = {
+            "response": {
+                "header": {"resultCode": "00", "resultMsg": "OK"},
+                "body": {
+                    "totalCount": 0,
+                    "items": {},
+                },
+            }
+        }
+        items, total = DataGoKrSource._extract_items(data)
+        assert items == []
+        assert total == 0
+
+    def test_no_body(self) -> None:
+        """body가 없으면 빈 리스트를 반환한다."""
+        data = {"response": {"header": {"resultCode": "00"}}}
+        items, total = DataGoKrSource._extract_items(data)
+        assert items == []
+        assert total == 0
+
+
+# ── _backoff_delay ───────────────────────────────────────────
+
+
+class TestBackoffDelay:
+    """Exponential Backoff + Full Jitter 테스트."""
+
+    def test_attempt_0_bounded(self) -> None:
+        """attempt=0일 때 0~1초 사이 값을 반환한다."""
+        for _ in range(100):
+            delay = DataGoKrSource._backoff_delay(0, base=1.0, cap=60.0)
+            assert 0 <= delay <= 1.0
+
+    def test_attempt_increases_bound(self) -> None:
+        """attempt가 증가하면 상한이 증가한다."""
+        # attempt=3 → max bound = min(60, 1*2^3) = 8.0
+        for _ in range(100):
+            delay = DataGoKrSource._backoff_delay(3, base=1.0, cap=60.0)
+            assert 0 <= delay <= 8.0
+
+    def test_cap_limits_delay(self) -> None:
+        """cap 이상의 값을 반환하지 않는다."""
+        for _ in range(100):
+            delay = DataGoKrSource._backoff_delay(10, base=1.0, cap=5.0)
+            assert 0 <= delay <= 5.0
+
+
+# ── RateLimiter ──────────────────────────────────────────────
+
+
+class TestRateLimiter:
+    """RateLimiter 유닛 테스트."""
+
+    def test_daily_count_starts_zero(self, rate_limiter: RateLimiter) -> None:
+        """초기 일일 카운터는 0이다."""
+        assert rate_limiter.daily_count == 0
+
+    def test_increment_daily(self, rate_limiter: RateLimiter) -> None:
+        """increment_daily는 카운터를 1 증가시킨다."""
+        rate_limiter.increment_daily()
+        assert rate_limiter.daily_count == 1
+
+    def test_daily_limit_not_reached_initially(self, rate_limiter: RateLimiter) -> None:
+        """초기 상태에서 한도에 도달하지 않았다."""
+        assert not rate_limiter.is_daily_limit_reached()
+
+    def test_daily_limit_reached_at_threshold(self) -> None:
+        """90% 도달 시 True를 반환한다."""
+        rl = RateLimiter(tps_limit=10.0, daily_limit=100)
+        for _ in range(90):
+            rl.increment_daily()
+        assert rl.is_daily_limit_reached()
+
+    def test_daily_limit_custom_threshold(self) -> None:
+        """커스텀 threshold로 판별한다."""
+        rl = RateLimiter(tps_limit=10.0, daily_limit=100)
+        for _ in range(50):
+            rl.increment_daily()
+        assert rl.is_daily_limit_reached(threshold=0.5)
+        assert not rl.is_daily_limit_reached(threshold=0.6)
+
+    def test_reset_daily(self) -> None:
+        """reset_daily는 카운터를 0으로 초기화한다."""
+        rl = RateLimiter(tps_limit=10.0, daily_limit=100)
+        for _ in range(50):
+            rl.increment_daily()
+        rl.reset_daily()
+        assert rl.daily_count == 0
+
+    @pytest.mark.asyncio
+    async def test_acquire_decrements_tokens(self) -> None:
+        """acquire는 토큰을 소비한다."""
+        rl = RateLimiter(tps_limit=10.0, daily_limit=100)
+        # 여러 번 acquire해도 에러 없이 동작한다
+        for _ in range(5):
+            await rl.acquire()
+
+
+# ── fetch_by_date ────────────────────────────────────────────
+
+
+class TestFetchByDate:
+    """fetch_by_date 통합 테스트 (mock HTTP)."""
+
+    @pytest.mark.asyncio
+    async def test_single_page(self, source: DataGoKrSource) -> None:
+        """단일 페이지 응답을 정상 처리한다."""
+        items = [_make_item(srtn_cd=f"00{i:04d}") for i in range(3)]
+        response = _make_response(items, total_count=3)
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            result = await source.fetch_by_date("2024-03-01")
+
+        assert len(result) == 3
+        assert result[0]["srtnCd"] == "000000"
+
+    @pytest.mark.asyncio
+    async def test_pagination(self, source: DataGoKrSource) -> None:
+        """여러 페이지를 순회하여 전체 데이터를 수집한다."""
+        page1_items = [_make_item(srtn_cd=f"00{i:04d}") for i in range(1000)]
+        page1 = _make_response(page1_items, total_count=1500)
+
+        page2_items = [_make_item(srtn_cd=f"01{i:04d}") for i in range(500)]
+        page2 = _make_response(page2_items, total_count=1500)
+
+        call_count = 0
+
+        async def mock_request(session, params):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return page1
+            return page2
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            result = await source.fetch_by_date("2024-03-01")
+
+        assert len(result) == 1500
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_date(self, source: DataGoKrSource) -> None:
+        """데이터가 없는 날짜는 빈 리스트를 반환한다."""
+        response = _make_response([], total_count=0)
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            result = await source.fetch_by_date("2024-01-01")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_daily_limit_raises(self, source: DataGoKrSource) -> None:
+        """일일 한도 도달 시 DailyLimitExceededError를 발생시킨다."""
+        # 한도의 90% 도달 상태 설정
+        for _ in range(9000):
+            source.rate_limiter.increment_daily()
+
+        with pytest.raises(DailyLimitExceededError):
+            await source.fetch_by_date("2024-03-01")
+
+    @pytest.mark.asyncio
+    async def test_critical_error_raises(self, source: DataGoKrSource) -> None:
+        """서비스키 미등록 에러 시 CriticalApiError를 발생시킨다."""
+        response = _make_response(
+            [],
+            result_code="30",
+            result_msg="SERVICE_KEY_IS_NOT_REGISTERED_ERROR",
+        )
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            with pytest.raises(CriticalApiError):
+                await source.fetch_by_date("2024-03-01")
+
+    @pytest.mark.asyncio
+    async def test_skip_error_raises(self, source: DataGoKrSource) -> None:
+        """재시도 불가 에러 시 DataGoKrError를 발생시킨다."""
+        response = _make_response(
+            [],
+            result_code="10",
+            result_msg="INVALID_REQUEST_PARAMETER_ERROR",
+        )
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            with pytest.raises(DataGoKrError):
+                await source.fetch_by_date("2024-03-01")
+
+    @pytest.mark.asyncio
+    async def test_retry_then_success(self, source: DataGoKrSource) -> None:
+        """재시도 가능 에러 후 성공하면 데이터를 반환한다."""
+        error_response = _make_response(
+            [],
+            result_code="99",
+            result_msg="UNKNOWN_ERROR",
+        )
+        success_response = _make_response([_make_item()], total_count=1)
+
+        call_count = 0
+
+        async def mock_request(session, params):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return error_response
+            return success_response
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                result = await source.fetch_by_date("2024-03-01")
+
+        assert len(result) == 1
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retry_exhausted_raises(self, source: DataGoKrSource) -> None:
+        """재시도 소진 시 DataGoKrError를 발생시킨다."""
+        error_response = _make_response(
+            [],
+            result_code="99",
+            result_msg="UNKNOWN_ERROR",
+        )
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=error_response
+        ):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DataGoKrError, match="최종 실패"):
+                    await source.fetch_by_date("2024-03-01")
+
+    @pytest.mark.asyncio
+    async def test_network_error_retries(self, source: DataGoKrSource) -> None:
+        """네트워크 에러 시 재시도 후 성공하면 데이터를 반환한다."""
+        import aiohttp
+
+        success_response = _make_response([_make_item()], total_count=1)
+        call_count = 0
+
+        async def mock_request(session, params):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise aiohttp.ClientConnectionError("Connection refused")
+            return success_response
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                result = await source.fetch_by_date("2024-03-01")
+
+        assert len(result) == 1
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_daily_limit_error_code_raises(self, source: DataGoKrSource) -> None:
+        """API 에러 코드 22(일일 한도 초과) 시 DailyLimitExceededError를 발생시킨다."""
+        response = _make_response(
+            [],
+            result_code="22",
+            result_msg="LIMITED_NUMBER_OF_SERVICE_REQUESTS_EXCEEDS_ERROR",
+        )
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            with pytest.raises(DailyLimitExceededError):
+                await source.fetch_by_date("2024-03-01")
+
+    @pytest.mark.asyncio
+    async def test_fetch_delegates_to_fetch_by_date(
+        self, source: DataGoKrSource
+    ) -> None:
+        """fetch()는 fetch_by_date()에 위임한다."""
+        response = _make_response([_make_item()], total_count=1)
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            result = await source.fetch("2024-03-01")
+
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_date_format_conversion(self, source: DataGoKrSource) -> None:
+        """YYYY-MM-DD 형식을 YYYYMMDD로 변환하여 요청한다."""
+        response = _make_response([_make_item()], total_count=1)
+        captured_params: list[dict] = []
+
+        async def mock_request(session, params):
+            captured_params.append(params)
+            return response
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            await source.fetch_by_date("2024-03-01")
+
+        assert captured_params[0]["basDt"] == "20240301"


### PR DESCRIPTION
## Summary
- `DataGoKrSource` 클래스 구현: 날짜별 전 종목 OHLCV + fundamental 데이터 수집
- `RateLimiter` Token Bucket 구현체 완성 (기존 스텁 → 실제 구현)
- 에러 코드 분류 (OK/RETRY/SKIP/DAILY_LIMIT/CRITICAL), 페이지네이션, Exponential Backoff + Full Jitter 재시도

## Changes
- `src/ante/feed/sources/base.py`: DataSource Protocol (async fetch), RateLimiter 구현 (토큰 버킷 + 일일 한도)
- `src/ante/feed/sources/data_go_kr.py`: DataGoKrSource, ErrorAction, 에러 코드 매핑, 예외 클래스
- `src/ante/feed/sources/__init__.py`: public API re-export
- `tests/unit/feed/test_data_go_kr.py`: 36건 테스트 (에러 분류, 응답 파싱, 페이지네이션, Rate Limiting, 재시도, 네트워크 에러)

## Test plan
- [x] `pytest tests/unit/feed/test_data_go_kr.py -v` — 36건 전체 통과
- [x] `pytest tests/unit/feed/ -v` — 기존 119건 포함 155건 전체 통과
- [x] `ruff check` / `ruff format` 통과

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)