### PR TITLE
feat(feed): DART 소스 어댑터 구현

### DIFF
--- a/src/ante/feed/sources/__init__.py
+++ b/src/ante/feed/sources/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ante.feed.sources.base import DataSource, RateLimiter
+from ante.feed.sources.dart import DARTError, DARTSource
 from ante.feed.sources.data_go_kr import (
     CriticalApiError,
     DailyLimitExceededError,
@@ -12,6 +13,8 @@ from ante.feed.sources.data_go_kr import (
 
 __all__ = [
     "CriticalApiError",
+    "DARTError",
+    "DARTSource",
     "DailyLimitExceededError",
     "DataGoKrError",
     "DataGoKrSource",

--- a/src/ante/feed/sources/dart.py
+++ b/src/ante/feed/sources/dart.py
@@ -1,0 +1,543 @@
+"""DART OpenAPI 소스 어댑터.
+
+DART API에서 상장기업 재무제표(매출, 순이익, 자본총계 등)를 수집한다.
+고유번호(corp_code) 매핑, 다중회사 배치 호출(fnlttMultiAcnt),
+Rate Limiting, 에러 코드 처리를 담당한다.
+
+API 레퍼런스: docs/references/dashboard/dart-openapi.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import logging
+import random
+import zipfile
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree
+
+import aiohttp
+
+from ante.feed.sources.base import RateLimiter
+
+logger = logging.getLogger(__name__)
+
+# -- API 상수 (API 스펙 종속, 하드코딩) --------------------------------
+
+BASE_URL = "https://opendart.fss.or.kr/api"
+TPS_LIMIT = 10.0  # 보수적 설정
+DAILY_LIMIT = 20_000
+BATCH_SIZE = 100  # fnlttMultiAcnt 최대 100개 회사
+REQUEST_TIMEOUT = 60  # 다중회사 응답이 커질 수 있으므로 넉넉하게
+
+# 보고서 코드 매핑
+REPRT_CODES: dict[str, str] = {
+    "11013": "1분기보고서",
+    "11012": "반기보고서",
+    "11014": "3분기보고서",
+    "11011": "사업보고서",
+}
+
+
+# -- 에러 분류 ---------------------------------------------------------
+
+
+class ErrorAction(StrEnum):
+    """DART API 에러 코드에 따른 행동 분류."""
+
+    OK = "ok"
+    NO_DATA = "no_data"
+    RETRY = "retry"
+    SKIP = "skip"
+    DAILY_LIMIT = "daily_limit"
+    CRITICAL = "critical"
+
+
+_ERROR_CODE_MAP: dict[str, ErrorAction] = {
+    "000": ErrorAction.OK,
+    "010": ErrorAction.CRITICAL,  # 등록되지 않은 키
+    "011": ErrorAction.CRITICAL,  # 사용할 수 없는 키
+    "012": ErrorAction.CRITICAL,  # 접근할 수 없는 IP
+    "013": ErrorAction.NO_DATA,  # 조회된 데이터 없음
+    "014": ErrorAction.SKIP,  # 파일 존재하지 않음
+    "020": ErrorAction.DAILY_LIMIT,  # 요청 제한 초과
+    "021": ErrorAction.SKIP,  # 조회 가능 회사 개수 초과 (구현 버그)
+    "100": ErrorAction.SKIP,  # 부적절한 필드 값
+    "101": ErrorAction.SKIP,  # 부적절한 접근
+    "800": ErrorAction.RETRY,  # 시스템 점검 중
+    "900": ErrorAction.RETRY,  # 정의되지 않은 오류
+    "901": ErrorAction.CRITICAL,  # 개인정보 보유기간 만료
+}
+
+
+def classify_error(status: str) -> ErrorAction:
+    """DART status 코드를 행동으로 분류한다."""
+    return _ERROR_CODE_MAP.get(status, ErrorAction.RETRY)
+
+
+# -- 예외 --------------------------------------------------------------
+
+
+class DARTError(Exception):
+    """DART API 에러 기본 예외."""
+
+    pass
+
+
+class DailyLimitExceededError(DARTError):
+    """일일 호출 한도 초과."""
+
+    pass
+
+
+class CriticalApiError(DARTError):
+    """키 미등록/만료 등 복구 불가능 에러."""
+
+    pass
+
+
+# -- DARTSource --------------------------------------------------------
+
+
+class DARTSource:
+    """DART OpenAPI 소스 어댑터.
+
+    fetch_corp_codes()로 고유번호 매핑을 확보한 후,
+    fetch_financial()로 다중회사 재무제표를 배치 수집한다.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        rate_limiter: RateLimiter | None = None,
+        session: aiohttp.ClientSession | None = None,
+        *,
+        max_retries: int = 3,
+        base_url: str = BASE_URL,
+    ) -> None:
+        """DARTSource를 초기화한다.
+
+        Args:
+            api_key: DART OpenAPI 인증키 (40자리).
+            rate_limiter: Rate Limiter 인스턴스. None이면 기본값 생성.
+            session: aiohttp 세션. None이면 호출 시 생성.
+            max_retries: 최대 재시도 횟수.
+            base_url: API 기본 URL.
+        """
+        self._api_key = api_key
+        self._rate_limiter = rate_limiter or RateLimiter(
+            tps_limit=TPS_LIMIT, daily_limit=DAILY_LIMIT
+        )
+        self._session = session
+        self._max_retries = max_retries
+        self._base_url = base_url
+
+    @property
+    def rate_limiter(self) -> RateLimiter:
+        """Rate Limiter 인스턴스."""
+        return self._rate_limiter
+
+    async def fetch(self, date: str, **kwargs: Any) -> list[dict]:
+        """DataSource 프로토콜 구현.
+
+        DART는 날짜별 수집이 아니라 연도+분기별 수집이므로,
+        kwargs에서 corp_codes, year, reprt_code를 받아 fetch_financial에 위임한다.
+
+        Args:
+            date: 미사용 (프로토콜 호환).
+            **kwargs: corp_codes, year, reprt_code.
+
+        Returns:
+            수집된 레코드 딕셔너리 목록.
+        """
+        corp_codes = kwargs.get("corp_codes", [])
+        year = kwargs.get("year", "")
+        reprt_code = kwargs.get("reprt_code", "")
+        if not corp_codes or not year or not reprt_code:
+            return []
+        return await self.fetch_financial(corp_codes, year, reprt_code)
+
+    async def fetch_corp_codes(
+        self,
+        save_path: Path | None = None,
+    ) -> dict[str, str]:
+        """DART 고유번호 ZIP을 다운로드하고 파싱한다.
+
+        ZIP 내 XML에서 상장사(stock_code 비어있지 않은)만 추출하여
+        corp_code -> stock_code 매핑을 반환한다.
+
+        Args:
+            save_path: 매핑 결과를 저장할 JSON 파일 경로.
+                None이면 저장하지 않고 딕셔너리만 반환.
+
+        Returns:
+            corp_code -> stock_code 매핑 딕셔너리.
+                예: {"00126380": "005930", ...}
+
+        Raises:
+            DailyLimitExceededError: 일일 한도 초과 시.
+            CriticalApiError: 인증키 에러 시.
+            DARTError: 다운로드 실패 시.
+        """
+        if self._rate_limiter.is_daily_limit_reached():
+            msg = f"일일 한도 90% 도달 ({self._rate_limiter.daily_count}/{DAILY_LIMIT})"
+            logger.critical(msg)
+            raise DailyLimitExceededError(msg)
+
+        url = f"{self._base_url}/corpCode.xml"
+        params = {"crtfc_key": self._api_key}
+
+        own_session = self._session is None
+        session = self._session or aiohttp.ClientSession()
+
+        try:
+            zip_bytes = await self._download_corp_code_zip(session, url, params)
+        finally:
+            if own_session:
+                await session.close()
+
+        self._rate_limiter.increment_daily()
+
+        # ZIP 해제 및 XML 파싱
+        corp_code_map = self._parse_corp_code_zip(zip_bytes)
+
+        logger.info(
+            "DART 고유번호 수집 완료: 상장사 %d개",
+            len(corp_code_map),
+        )
+
+        # 파일 저장
+        if save_path is not None:
+            save_path.parent.mkdir(parents=True, exist_ok=True)
+            save_path.write_text(
+                json.dumps(corp_code_map, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            logger.info("고유번호 매핑 저장: %s", save_path)
+
+        return corp_code_map
+
+    async def fetch_financial(
+        self,
+        corp_codes: list[str],
+        year: str,
+        reprt_code: str,
+    ) -> list[dict]:
+        """다중회사 주요계정(fnlttMultiAcnt) API를 배치 호출한다.
+
+        corp_codes를 100개씩 나누어 호출하며,
+        Rate Limiting과 에러 코드 처리를 수행한다.
+
+        Args:
+            corp_codes: DART 고유번호 목록.
+            year: 사업연도 (4자리, 예: "2024").
+            reprt_code: 보고서 코드 (11013/11012/11014/11011).
+
+        Returns:
+            수집된 재무제표 레코드 딕셔너리 목록.
+
+        Raises:
+            DailyLimitExceededError: 일일 한도 초과 시.
+            CriticalApiError: 인증키 에러 시.
+        """
+        all_items: list[dict] = []
+
+        own_session = self._session is None
+        session = self._session or aiohttp.ClientSession()
+
+        try:
+            # 100개씩 배치 분할
+            for batch_start in range(0, len(corp_codes), BATCH_SIZE):
+                batch = corp_codes[batch_start : batch_start + BATCH_SIZE]
+
+                if self._rate_limiter.is_daily_limit_reached():
+                    msg = (
+                        f"일일 한도 90% 도달 "
+                        f"({self._rate_limiter.daily_count}/{DAILY_LIMIT})"
+                    )
+                    logger.critical(msg)
+                    raise DailyLimitExceededError(msg)
+
+                items = await self._fetch_multi_acnt(session, batch, year, reprt_code)
+                all_items.extend(items)
+
+                logger.debug(
+                    "DART 배치 수집: year=%s reprt=%s batch=%d~%d items=%d",
+                    year,
+                    reprt_code,
+                    batch_start,
+                    batch_start + len(batch),
+                    len(items),
+                )
+        finally:
+            if own_session:
+                await session.close()
+
+        reprt_name = REPRT_CODES.get(reprt_code, reprt_code)
+        logger.info(
+            "DART 재무제표 수집 완료: year=%s reprt=%s(%s) records=%d",
+            year,
+            reprt_code,
+            reprt_name,
+            len(all_items),
+        )
+        return all_items
+
+    # -- 내부 메서드 ---------------------------------------------------
+
+    async def _download_corp_code_zip(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+        params: dict[str, str],
+    ) -> bytes:
+        """고유번호 ZIP 파일을 다운로드한다.
+
+        Returns:
+            ZIP 파일 바이트.
+
+        Raises:
+            DARTError: 다운로드 실패 시.
+            CriticalApiError: JSON 에러 응답 시.
+        """
+        last_error: Exception | None = None
+
+        for attempt in range(self._max_retries):
+            await self._rate_limiter.acquire()
+
+            try:
+                async with asyncio.timeout(REQUEST_TIMEOUT):
+                    async with session.get(url, params=params) as resp:
+                        content_type = resp.content_type or ""
+
+                        # ZIP 바이너리 응답
+                        if "zip" in content_type or "octet-stream" in content_type:
+                            return await resp.read()
+
+                        # JSON 에러 응답 (키 오류 등)
+                        if "json" in content_type or "text" in content_type:
+                            body = await resp.text()
+                            try:
+                                data = json.loads(body)
+                                status = str(data.get("status", "900"))
+                                message = str(data.get("message", ""))
+                            except json.JSONDecodeError:
+                                status = "900"
+                                message = body[:200]
+
+                            action = classify_error(status)
+
+                            if action == ErrorAction.CRITICAL:
+                                msg = f"DART 인증 에러 (status={status}): {message}"
+                                logger.critical(msg)
+                                raise CriticalApiError(msg)
+                            if action == ErrorAction.DAILY_LIMIT:
+                                msg = f"DART 일일 한도 초과: {message}"
+                                logger.critical(msg)
+                                raise DailyLimitExceededError(msg)
+
+                            last_error = DARTError(
+                                f"DART 에러 (status={status}): {message}"
+                            )
+                        else:
+                            resp.raise_for_status()
+                            return await resp.read()
+
+            except (TimeoutError, aiohttp.ClientError) as exc:
+                last_error = exc
+
+            if attempt < self._max_retries - 1:
+                delay = self._backoff_delay(attempt)
+                logger.warning(
+                    "DART corpCode 다운로드 실패 (attempt=%d/%d): %s. %.1f초 후 재시도",
+                    attempt + 1,
+                    self._max_retries,
+                    last_error,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+        msg = "DART 고유번호 ZIP 다운로드 최종 실패"
+        logger.error(msg)
+        raise DARTError(msg) from last_error
+
+    @staticmethod
+    def _parse_corp_code_zip(zip_bytes: bytes) -> dict[str, str]:
+        """ZIP 바이트에서 corp_code -> stock_code 매핑을 추출한다.
+
+        stock_code가 비어있는 비상장사는 필터링한다.
+
+        Args:
+            zip_bytes: corpCode.xml ZIP 파일 바이트.
+
+        Returns:
+            corp_code -> stock_code 매핑.
+        """
+        corp_code_map: dict[str, str] = {}
+
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            # ZIP 내 첫 번째 파일(XML) 읽기
+            xml_name = zf.namelist()[0]
+            with zf.open(xml_name) as xml_file:
+                tree = ElementTree.parse(xml_file)
+                root = tree.getroot()
+
+                for elem in root.iter("list"):
+                    corp_code = elem.findtext("corp_code", "").strip()
+                    stock_code = elem.findtext("stock_code", "").strip()
+
+                    # 비상장사 필터링 (stock_code가 비어있거나 공백)
+                    if corp_code and stock_code:
+                        corp_code_map[corp_code] = stock_code
+
+        return corp_code_map
+
+    async def _fetch_multi_acnt(
+        self,
+        session: aiohttp.ClientSession,
+        corp_codes: list[str],
+        year: str,
+        reprt_code: str,
+    ) -> list[dict]:
+        """fnlttMultiAcnt API를 호출한다.
+
+        Args:
+            session: aiohttp 세션.
+            corp_codes: 고유번호 목록 (최대 100개).
+            year: 사업연도.
+            reprt_code: 보고서 코드.
+
+        Returns:
+            재무제표 레코드 목록.
+
+        Raises:
+            DailyLimitExceededError: 일일 한도 초과 에러 코드.
+            CriticalApiError: 인증키 에러 코드.
+            DARTError: 재시도 소진 후 최종 실패.
+        """
+        url = f"{self._base_url}/fnlttMultiAcnt.json"
+        params = {
+            "crtfc_key": self._api_key,
+            "corp_code": ",".join(corp_codes),
+            "bsns_year": year,
+            "reprt_code": reprt_code,
+        }
+
+        last_error: Exception | None = None
+
+        for attempt in range(self._max_retries):
+            await self._rate_limiter.acquire()
+
+            try:
+                data = await asyncio.wait_for(
+                    self._do_request(session, url, params),
+                    timeout=REQUEST_TIMEOUT,
+                )
+                self._rate_limiter.increment_daily()
+            except (TimeoutError, aiohttp.ClientError) as exc:
+                last_error = exc
+                delay = self._backoff_delay(attempt)
+                logger.warning(
+                    "DART fnlttMultiAcnt 요청 실패 "
+                    "(attempt=%d/%d): %s. %.1f초 후 재시도",
+                    attempt + 1,
+                    self._max_retries,
+                    exc,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+                continue
+
+            # 에러 코드 처리
+            status = str(data.get("status", "900"))
+            message = str(data.get("message", ""))
+            action = classify_error(status)
+
+            if action == ErrorAction.OK:
+                return self._extract_list(data)
+
+            if action == ErrorAction.NO_DATA:
+                logger.debug(
+                    "DART 데이터 없음: year=%s reprt=%s corps=%d",
+                    year,
+                    reprt_code,
+                    len(corp_codes),
+                )
+                return []
+
+            if action == ErrorAction.DAILY_LIMIT:
+                msg = f"DART 일일 한도 초과: {message}"
+                logger.critical(msg)
+                raise DailyLimitExceededError(msg)
+
+            if action == ErrorAction.CRITICAL:
+                msg = f"DART 복구 불가능 에러 (status={status}): {message}"
+                logger.critical(msg)
+                raise CriticalApiError(msg)
+
+            if action == ErrorAction.SKIP:
+                msg = f"DART 재시도 불가 에러 (status={status}): {message}"
+                logger.error(msg)
+                raise DARTError(msg)
+
+            # RETRY
+            last_error = DARTError(f"DART API 에러 (status={status}): {message}")
+            if attempt < self._max_retries - 1:
+                delay = self._backoff_delay(attempt)
+                logger.warning(
+                    "DART API 에러 (attempt=%d/%d, status=%s): %s. %.1f초 후 재시도",
+                    attempt + 1,
+                    self._max_retries,
+                    status,
+                    message,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+        msg = f"DART fnlttMultiAcnt 요청 최종 실패: year={year}, reprt={reprt_code}"
+        logger.error(msg)
+        raise DARTError(msg) from last_error
+
+    async def _do_request(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+        params: dict[str, str],
+    ) -> dict:
+        """HTTP GET 요청을 보내고 JSON 응답을 반환한다."""
+        async with session.get(url, params=params) as resp:
+            resp.raise_for_status()
+            return await resp.json(content_type=None)
+
+    @staticmethod
+    def _extract_list(data: dict) -> list[dict]:
+        """DART 응답에서 list 배열을 추출한다.
+
+        Args:
+            data: JSON 응답 딕셔너리.
+
+        Returns:
+            재무제표 레코드 목록.
+        """
+        items = data.get("list", [])
+        if isinstance(items, dict):
+            items = [items]
+        return items
+
+    @staticmethod
+    def _backoff_delay(attempt: int, base: float = 1.0, cap: float = 60.0) -> float:
+        """Exponential Backoff + Full Jitter 대기 시간을 계산한다.
+
+        Args:
+            attempt: 현재 시도 인덱스 (0-based).
+            base: 기본 대기 시간 (초).
+            cap: 최대 대기 시간 (초).
+
+        Returns:
+            대기 시간 (초).
+        """
+        return random.uniform(0, min(cap, base * (2**attempt)))

--- a/tests/unit/feed/test_dart.py
+++ b/tests/unit/feed/test_dart.py
@@ -1,0 +1,538 @@
+"""DART 소스 어댑터 유닛 테스트."""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from unittest.mock import AsyncMock, patch
+from xml.etree.ElementTree import Element, SubElement, tostring
+
+import pytest
+
+from ante.feed.sources.base import RateLimiter
+from ante.feed.sources.dart import (
+    CriticalApiError,
+    DailyLimitExceededError,
+    DARTError,
+    DARTSource,
+    ErrorAction,
+    classify_error,
+)
+
+# -- 테스트 헬퍼 --------------------------------------------------------
+
+
+def _make_corp_code_zip(entries: list[dict[str, str]]) -> bytes:
+    """corp_code ZIP 파일 바이트를 생성한다.
+
+    Args:
+        entries: [{"corp_code": "...", "corp_name": "...", "stock_code": "..."}, ...]
+    """
+    root = Element("result")
+    for entry in entries:
+        item = SubElement(root, "list")
+        for key, value in entry.items():
+            child = SubElement(item, key)
+            child.text = value
+
+    xml_bytes = tostring(root, encoding="utf-8", xml_declaration=True)
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("CORPCODE.xml", xml_bytes)
+    return buf.getvalue()
+
+
+def _make_financial_response(
+    items: list[dict],
+    status: str = "000",
+    message: str = "정상",
+) -> dict:
+    """DART fnlttMultiAcnt mock 응답을 생성한다."""
+    return {
+        "status": status,
+        "message": message,
+        "list": items,
+    }
+
+
+def _make_financial_item(
+    corp_code: str = "00126380",
+    stock_code: str = "005930",
+    bsns_year: str = "2024",
+    reprt_code: str = "11011",
+    account_nm: str = "당기순이익",
+    fs_div: str = "CFS",
+    sj_div: str = "IS",
+    thstrm_amount: str = "50,000,000,000",
+) -> dict:
+    """DART 재무제표 mock item을 생성한다."""
+    return {
+        "rcept_no": "20250315000001",
+        "corp_code": corp_code,
+        "stock_code": stock_code,
+        "bsns_year": bsns_year,
+        "reprt_code": reprt_code,
+        "account_nm": account_nm,
+        "fs_div": fs_div,
+        "fs_nm": "연결재무제표" if fs_div == "CFS" else "재무제표",
+        "sj_div": sj_div,
+        "sj_nm": "손익계산서" if sj_div == "IS" else "재무상태표",
+        "thstrm_nm": "제 56 기",
+        "thstrm_dt": "2024.12.31",
+        "thstrm_amount": thstrm_amount,
+        "thstrm_add_amount": "",
+        "frmtrm_nm": "제 55 기",
+        "frmtrm_dt": "2023.12.31",
+        "frmtrm_amount": "40,000,000,000",
+        "frmtrm_add_amount": "",
+        "ord": "1",
+        "currency": "KRW",
+    }
+
+
+@pytest.fixture
+def rate_limiter() -> RateLimiter:
+    """RateLimiter 인스턴스."""
+    return RateLimiter(tps_limit=10.0, daily_limit=20_000)
+
+
+@pytest.fixture
+def source(rate_limiter: RateLimiter) -> DARTSource:
+    """DARTSource 인스턴스."""
+    return DARTSource(
+        api_key="test-dart-api-key-0123456789abcdef01",
+        rate_limiter=rate_limiter,
+        max_retries=2,
+    )
+
+
+# -- classify_error ----------------------------------------------------
+
+
+class TestClassifyError:
+    """DART 에러 코드 분류 테스트."""
+
+    def test_normal(self) -> None:
+        """000은 OK로 분류한다."""
+        assert classify_error("000") == ErrorAction.OK
+
+    def test_unregistered_key(self) -> None:
+        """010은 CRITICAL로 분류한다."""
+        assert classify_error("010") == ErrorAction.CRITICAL
+
+    def test_no_data(self) -> None:
+        """013은 NO_DATA로 분류한다."""
+        assert classify_error("013") == ErrorAction.NO_DATA
+
+    def test_daily_limit(self) -> None:
+        """020은 DAILY_LIMIT으로 분류한다."""
+        assert classify_error("020") == ErrorAction.DAILY_LIMIT
+
+    def test_excess_companies(self) -> None:
+        """021은 SKIP으로 분류한다."""
+        assert classify_error("021") == ErrorAction.SKIP
+
+    def test_invalid_field(self) -> None:
+        """100은 SKIP으로 분류한다."""
+        assert classify_error("100") == ErrorAction.SKIP
+
+    def test_system_maintenance(self) -> None:
+        """800은 RETRY로 분류한다."""
+        assert classify_error("800") == ErrorAction.RETRY
+
+    def test_undefined_error(self) -> None:
+        """900은 RETRY로 분류한다."""
+        assert classify_error("900") == ErrorAction.RETRY
+
+    def test_expired_account(self) -> None:
+        """901은 CRITICAL로 분류한다."""
+        assert classify_error("901") == ErrorAction.CRITICAL
+
+    def test_unmapped_code_defaults_to_retry(self) -> None:
+        """매핑되지 않은 코드는 RETRY로 분류한다."""
+        assert classify_error("999") == ErrorAction.RETRY
+
+
+# -- _parse_corp_code_zip ----------------------------------------------
+
+
+class TestParseCorpCodeZip:
+    """corp_code ZIP 파싱 테스트."""
+
+    def test_parse_listed_companies(self) -> None:
+        """상장사만 추출한다."""
+        entries = [
+            {
+                "corp_code": "00126380",
+                "corp_name": "삼성전자",
+                "stock_code": "005930",
+                "modify_date": "20240101",
+            },
+            {
+                "corp_code": "00999999",
+                "corp_name": "비상장회사",
+                "stock_code": "",
+                "modify_date": "20240101",
+            },
+            {
+                "corp_code": "00126400",
+                "corp_name": "SK하이닉스",
+                "stock_code": "000660",
+                "modify_date": "20240101",
+            },
+        ]
+        zip_bytes = _make_corp_code_zip(entries)
+        result = DARTSource._parse_corp_code_zip(zip_bytes)
+
+        assert len(result) == 2
+        assert result["00126380"] == "005930"
+        assert result["00126400"] == "000660"
+        assert "00999999" not in result
+
+    def test_parse_empty_zip(self) -> None:
+        """항목이 없으면 빈 딕셔너리를 반환한다."""
+        zip_bytes = _make_corp_code_zip([])
+        result = DARTSource._parse_corp_code_zip(zip_bytes)
+        assert result == {}
+
+    def test_parse_all_unlisted(self) -> None:
+        """모두 비상장사이면 빈 딕셔너리를 반환한다."""
+        entries = [
+            {
+                "corp_code": "00999999",
+                "corp_name": "비상장A",
+                "stock_code": "",
+                "modify_date": "20240101",
+            },
+            {
+                "corp_code": "00999998",
+                "corp_name": "비상장B",
+                "stock_code": "  ",
+                "modify_date": "20240101",
+            },
+        ]
+        zip_bytes = _make_corp_code_zip(entries)
+        result = DARTSource._parse_corp_code_zip(zip_bytes)
+        assert result == {}
+
+
+# -- _extract_list -----------------------------------------------------
+
+
+class TestExtractList:
+    """DART 응답 list 추출 테스트."""
+
+    def test_multiple_items(self) -> None:
+        """여러 item을 추출한다."""
+        data = _make_financial_response(
+            [_make_financial_item(), _make_financial_item(corp_code="00126400")]
+        )
+        items = DARTSource._extract_list(data)
+        assert len(items) == 2
+
+    def test_single_item_as_dict(self) -> None:
+        """단일 item이 dict로 올 경우 list로 감싼다."""
+        data = {"status": "000", "message": "정상", "list": _make_financial_item()}
+        items = DARTSource._extract_list(data)
+        assert len(items) == 1
+
+    def test_empty_list(self) -> None:
+        """list가 비어있으면 빈 리스트를 반환한다."""
+        data = {"status": "000", "message": "정상", "list": []}
+        items = DARTSource._extract_list(data)
+        assert items == []
+
+    def test_no_list_key(self) -> None:
+        """list 키가 없으면 빈 리스트를 반환한다."""
+        data = {"status": "013", "message": "조회된 데이터 없음"}
+        items = DARTSource._extract_list(data)
+        assert items == []
+
+
+# -- _backoff_delay ----------------------------------------------------
+
+
+class TestBackoffDelay:
+    """Exponential Backoff + Full Jitter 테스트."""
+
+    def test_attempt_0_bounded(self) -> None:
+        """attempt=0일 때 0~1초 사이 값을 반환한다."""
+        for _ in range(100):
+            delay = DARTSource._backoff_delay(0, base=1.0, cap=60.0)
+            assert 0 <= delay <= 1.0
+
+    def test_cap_limits_delay(self) -> None:
+        """cap 이상의 값을 반환하지 않는다."""
+        for _ in range(100):
+            delay = DARTSource._backoff_delay(10, base=1.0, cap=5.0)
+            assert 0 <= delay <= 5.0
+
+
+# -- fetch_corp_codes --------------------------------------------------
+
+
+class TestFetchCorpCodes:
+    """fetch_corp_codes 테스트 (mock HTTP)."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, source: DARTSource) -> None:
+        """정상적으로 고유번호 매핑을 반환한다."""
+        entries = [
+            {
+                "corp_code": "00126380",
+                "corp_name": "삼성전자",
+                "stock_code": "005930",
+                "modify_date": "20240101",
+            },
+        ]
+        zip_bytes = _make_corp_code_zip(entries)
+
+        with patch.object(
+            source,
+            "_download_corp_code_zip",
+            new_callable=AsyncMock,
+            return_value=zip_bytes,
+        ):
+            result = await source.fetch_corp_codes()
+
+        assert result == {"00126380": "005930"}
+
+    @pytest.mark.asyncio
+    async def test_saves_to_file(self, source: DARTSource, tmp_path) -> None:
+        """save_path가 주어지면 JSON 파일로 저장한다."""
+        entries = [
+            {
+                "corp_code": "00126380",
+                "corp_name": "삼성전자",
+                "stock_code": "005930",
+                "modify_date": "20240101",
+            },
+        ]
+        zip_bytes = _make_corp_code_zip(entries)
+        save_path = tmp_path / "dart_corp_codes.json"
+
+        with patch.object(
+            source,
+            "_download_corp_code_zip",
+            new_callable=AsyncMock,
+            return_value=zip_bytes,
+        ):
+            result = await source.fetch_corp_codes(save_path=save_path)
+
+        assert save_path.exists()
+        saved = json.loads(save_path.read_text(encoding="utf-8"))
+        assert saved == {"00126380": "005930"}
+        assert result == saved
+
+    @pytest.mark.asyncio
+    async def test_daily_limit_raises(self, source: DARTSource) -> None:
+        """일일 한도 도달 시 DailyLimitExceededError를 발생시킨다."""
+        for _ in range(18000):
+            source.rate_limiter.increment_daily()
+
+        with pytest.raises(DailyLimitExceededError):
+            await source.fetch_corp_codes()
+
+
+# -- fetch_financial ---------------------------------------------------
+
+
+class TestFetchFinancial:
+    """fetch_financial 테스트 (mock HTTP)."""
+
+    @pytest.mark.asyncio
+    async def test_single_batch(self, source: DARTSource) -> None:
+        """100개 이하 corp_codes는 단일 배치로 처리한다."""
+        items = [
+            _make_financial_item(corp_code="00126380", account_nm="당기순이익"),
+            _make_financial_item(corp_code="00126380", account_nm="자본총계"),
+        ]
+        response = _make_financial_response(items)
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            result = await source.fetch_financial(["00126380"], "2024", "11011")
+
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_multi_batch(self, source: DARTSource) -> None:
+        """100개 초과 corp_codes는 여러 배치로 나누어 처리한다."""
+        corp_codes = [f"{i:08d}" for i in range(150)]
+        response = _make_financial_response([_make_financial_item()])
+
+        call_count = 0
+
+        async def mock_request(session, url, params):
+            nonlocal call_count
+            call_count += 1
+            return response
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            await source.fetch_financial(corp_codes, "2024", "11011")
+
+        # 150개 = 100 + 50 → 2 배치
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_data_returns_empty(self, source: DARTSource) -> None:
+        """데이터 없음(013) 응답 시 빈 리스트를 반환한다."""
+        response = {"status": "013", "message": "조회된 데이터 없음"}
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            result = await source.fetch_financial(["00126380"], "2024", "11013")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_critical_error_raises(self, source: DARTSource) -> None:
+        """인증키 에러(010) 시 CriticalApiError를 발생시킨다."""
+        response = {"status": "010", "message": "등록되지 않은 키"}
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            with pytest.raises(CriticalApiError):
+                await source.fetch_financial(["00126380"], "2024", "11011")
+
+    @pytest.mark.asyncio
+    async def test_daily_limit_error_raises(self, source: DARTSource) -> None:
+        """일일 한도 초과(020) 시 DailyLimitExceededError를 발생시킨다."""
+        response = {"status": "020", "message": "요청 제한 초과"}
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            with pytest.raises(DailyLimitExceededError):
+                await source.fetch_financial(["00126380"], "2024", "11011")
+
+    @pytest.mark.asyncio
+    async def test_skip_error_raises(self, source: DARTSource) -> None:
+        """재시도 불가 에러(100) 시 DARTError를 발생시킨다."""
+        response = {"status": "100", "message": "부적절한 필드 값"}
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            with pytest.raises(DARTError):
+                await source.fetch_financial(["00126380"], "2024", "11011")
+
+    @pytest.mark.asyncio
+    async def test_retry_then_success(self, source: DARTSource) -> None:
+        """재시도 가능 에러 후 성공하면 데이터를 반환한다."""
+        error_response = {"status": "800", "message": "시스템 점검 중"}
+        success_response = _make_financial_response([_make_financial_item()])
+
+        call_count = 0
+
+        async def mock_request(session, url, params):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return error_response
+            return success_response
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                result = await source.fetch_financial(["00126380"], "2024", "11011")
+
+        assert len(result) == 1
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retry_exhausted_raises(self, source: DARTSource) -> None:
+        """재시도 소진 시 DARTError를 발생시킨다."""
+        error_response = {"status": "900", "message": "정의되지 않은 오류"}
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=error_response
+        ):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                with pytest.raises(DARTError, match="최종 실패"):
+                    await source.fetch_financial(["00126380"], "2024", "11011")
+
+    @pytest.mark.asyncio
+    async def test_network_error_retries(self, source: DARTSource) -> None:
+        """네트워크 에러 시 재시도 후 성공하면 데이터를 반환한다."""
+        import aiohttp
+
+        success_response = _make_financial_response([_make_financial_item()])
+        call_count = 0
+
+        async def mock_request(session, url, params):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise aiohttp.ClientConnectionError("Connection refused")
+            return success_response
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with patch.object(source, "_backoff_delay", return_value=0.0):
+                result = await source.fetch_financial(["00126380"], "2024", "11011")
+
+        assert len(result) == 1
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_daily_limit_mid_batch_raises(self, source: DARTSource) -> None:
+        """배치 처리 중 일일 한도 도달 시 DailyLimitExceededError를 발생시킨다."""
+        corp_codes = [f"{i:08d}" for i in range(150)]
+        response = _make_financial_response([_make_financial_item()])
+
+        call_count = 0
+
+        async def mock_request(session, url, params):
+            nonlocal call_count
+            call_count += 1
+            # 첫 번째 배치 후 한도 90% 도달 설정
+            for _ in range(18000):
+                source.rate_limiter.increment_daily()
+            return response
+
+        with patch.object(source, "_do_request", side_effect=mock_request):
+            with pytest.raises(DailyLimitExceededError):
+                await source.fetch_financial(corp_codes, "2024", "11011")
+
+        # 첫 번째 배치만 실행됨
+        assert call_count == 1
+
+
+# -- fetch (DataSource 프로토콜) ----------------------------------------
+
+
+class TestFetch:
+    """DataSource 프로토콜 fetch() 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_fetch_financial(self, source: DARTSource) -> None:
+        """fetch()는 kwargs를 fetch_financial에 전달한다."""
+        response = _make_financial_response([_make_financial_item()])
+
+        with patch.object(
+            source, "_do_request", new_callable=AsyncMock, return_value=response
+        ):
+            result = await source.fetch(
+                "2024-12-31",
+                corp_codes=["00126380"],
+                year="2024",
+                reprt_code="11011",
+            )
+
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_missing_kwargs_returns_empty(self, source: DARTSource) -> None:
+        """필수 kwargs가 없으면 빈 리스트를 반환한다."""
+        result = await source.fetch("2024-12-31")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_partial_kwargs_returns_empty(self, source: DARTSource) -> None:
+        """일부 kwargs만 있으면 빈 리스트를 반환한다."""
+        result = await source.fetch("2024-12-31", corp_codes=["00126380"])
+        assert result == []


### PR DESCRIPTION
## Summary
- DARTSource 클래스 구현: 고유번호 ZIP 다운로드/파싱(`fetch_corp_codes`), 다중회사 재무제표 배치 수집(`fetch_financial`, 100개씩 `fnlttMultiAcnt` API 호출)
- DART 에러 코드 분류(000~901), Rate Limiting(20,000건/일), Exponential Backoff 재시도
- `ante.feed.sources.__init__.py`에 `DARTSource`, `DARTError` export 추가

## Test plan
- [x] `pytest tests/unit/feed/test_dart.py -v` — 35건 전체 통과
- [x] `ruff check` / `ruff format` 통과
- [x] 전체 유닛 테스트 1551건 통과 (기존 테스트 미파손)

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)