### PR TITLE
feat(feed): Orchestrator 구현 — backfill/daily ETL 흐름

### DIFF
--- a/src/ante/feed/pipeline/__init__.py
+++ b/src/ante/feed/pipeline/__init__.py
@@ -1,3 +1,19 @@
 """ante.feed.pipeline — ETL 오케스트레이션."""
 
 from __future__ import annotations
+
+from ante.feed.pipeline.checkpoint import Checkpoint
+from ante.feed.pipeline.orchestrator import FeedOrchestrator
+from ante.feed.pipeline.scheduler import (
+    generate_backfill_dates,
+    generate_daily_date,
+    is_business_day,
+)
+
+__all__ = [
+    "Checkpoint",
+    "FeedOrchestrator",
+    "generate_backfill_dates",
+    "generate_daily_date",
+    "is_business_day",
+]

--- a/src/ante/feed/pipeline/orchestrator.py
+++ b/src/ante/feed/pipeline/orchestrator.py
@@ -1,78 +1,910 @@
-"""ETL 오케스트레이션 모듈.
+"""FeedOrchestrator — backfill/daily ETL 파이프라인 오케스트레이션.
 
-Extract → Transform → Load 흐름과 가드/한도 관리를 담당한다.
+소스 어댑터(data.go.kr, DART)에서 데이터를 수집하고,
+Normalizer로 정규화, Validator로 검증, ParquetStore로 저장한다.
+파생 지표(PER/PBR/EPS/BPS/ROE/부채비율) 계산도 이 모듈에서 수행한다.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+import os
+from datetime import UTC, date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
 
-if TYPE_CHECKING:
-    from ante.feed.config import FeedConfig
-    from ante.feed.models.result import CollectionResult
+import polars as pl
+
+from ante.data.normalizer import DARTNormalizer, DataGoKrNormalizer
+from ante.data.store import ParquetStore
+from ante.feed.models.result import CollectionResult
+from ante.feed.pipeline.checkpoint import Checkpoint
+from ante.feed.pipeline.scheduler import (
+    generate_backfill_dates,
+    generate_daily_date,
+)
+from ante.feed.report.generator import ReportGenerator
+from ante.feed.sources.dart import (
+    CriticalApiError as DARTCriticalError,
+)
+from ante.feed.sources.dart import (
+    DailyLimitExceededError as DARTDailyLimitError,
+)
+from ante.feed.sources.dart import DARTSource
+from ante.feed.sources.data_go_kr import (
+    CriticalApiError as DataGoKrCriticalError,
+)
+from ante.feed.sources.data_go_kr import (
+    DailyLimitExceededError as DataGoKrDailyLimitError,
+)
+from ante.feed.sources.data_go_kr import DataGoKrSource
+from ante.feed.transform.validate import validate_all
 
 logger = logging.getLogger(__name__)
+
+# 기본 설정 상수
+DEFAULT_BACKFILL_SINCE = "2015-01-01"
+LOCK_FILE = "lock"
+
+# DART 보고서 코드 (분기별)
+REPRT_CODES = ["11013", "11012", "11014", "11011"]
+
+# OHLCV 필수 검증 필드
+OHLCV_REQUIRED_FIELDS = [
+    "timestamp",
+    "symbol",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+]
 
 
 class FeedOrchestrator:
     """DataFeed ETL 오케스트레이터.
 
-    날짜별 루프를 실행하며 Extract → Transform → Load 흐름을 조율한다.
+    backfill과 daily 두 모드를 지원하며,
+    data.go.kr + DART 데이터를 수집/정규화/검증/저장한다.
 
     책임:
       - 방어 가드(blocked_days, blocked_hours) 적용
       - 일일 한도 확인 및 도달 시 체크포인트 저장 후 종료
       - 소스별 수집 실패 스킵 및 집계
+      - 파생 지표(PER/PBR/EPS/BPS/ROE/부채비율) 계산
+      - lock 파일로 동시 실행 방지
       - CollectionResult 생성
     """
 
-    def __init__(self, config: FeedConfig) -> None:
+    def __init__(
+        self,
+        data_go_kr_source: DataGoKrSource | None = None,
+        dart_source: DARTSource | None = None,
+        store: ParquetStore | None = None,
+        data_go_kr_normalizer: DataGoKrNormalizer | None = None,
+        dart_normalizer: DARTNormalizer | None = None,
+        report_generator: ReportGenerator | None = None,
+    ) -> None:
         """FeedOrchestrator를 초기화한다.
 
         Args:
-            config: DataFeed 설정 객체.
+            data_go_kr_source: data.go.kr 소스 어댑터.
+            dart_source: DART 소스 어댑터.
+            store: ParquetStore 인스턴스.
+            data_go_kr_normalizer: data.go.kr 정규화기.
+            dart_normalizer: DART 정규화기.
+            report_generator: 리포트 생성기.
         """
-        ...
+        self._data_go_kr_source = data_go_kr_source
+        self._dart_source = dart_source
+        self._store = store
+        self._data_go_kr_normalizer = data_go_kr_normalizer or DataGoKrNormalizer()
+        self._dart_normalizer = dart_normalizer or DARTNormalizer()
+        self._report_generator = report_generator
 
-    def run_backfill(self) -> CollectionResult:
-        """Backfill을 1회 실행한다.
+    async def run_backfill(
+        self,
+        data_path: Path,
+        config: dict[str, Any],
+    ) -> CollectionResult:
+        """과거 데이터 대량 수집 (backfill 모드).
 
-        backfill_since 이후 데이터를 일일 한도 내에서 수집한다.
-        완료 또는 한도 도달 시 체크포인트를 저장하고 CollectionResult를 반환한다.
-
-        Returns:
-            수집 결과.
-        """
-        ...
-
-    def run_daily(self) -> CollectionResult:
-        """Daily 수집을 1회 실행한다.
-
-        전일 데이터를 수집하고 CollectionResult를 반환한다.
-
-        Returns:
-            수집 결과.
-        """
-        ...
-
-    def _is_guarded(self) -> bool:
-        """현재 시각이 가드 조건에 해당하는지 확인한다.
-
-        blocked_days와 blocked_hours(pause_during_trading이 true일 때)를 확인한다.
-
-        Returns:
-            가드 조건에 해당하면 True.
-        """
-        ...
-
-    def _etl_one_day(self, date: str) -> dict:
-        """하루치 데이터를 ETL 처리한다.
+        1. 체크포인트 로드 -> 날짜 범위 생성
+        2. 날짜별: data.go.kr fetch -> normalize -> validate -> store
+        3. 분기별: DART fetch -> normalize -> validate -> store
+        4. 파생 지표 계산
+        5. 체크포인트 저장, 리포트 생성
 
         Args:
-            date: 처리할 날짜 (YYYY-MM-DD).
+            data_path: Ante 데이터 저장소 루트 경로.
+            config: 설정 딕셔너리 (schedule, guard 섹션 포함).
 
         Returns:
-            처리 결과 딕셔너리 (symbols_success, symbols_failed, rows_written 등).
+            수집 결과 CollectionResult.
         """
-        ...
+        feed_dir = data_path / ".feed"
+        started_at = datetime.now(tz=UTC)
+
+        # lock 파일 확인/생성
+        if not self._acquire_lock(feed_dir):
+            return self._make_result(
+                "backfill",
+                started_at,
+                config_errors=[{"error": "다른 수집 프로세스가 이미 실행 중"}],
+            )
+
+        try:
+            return await self._run_backfill_inner(
+                data_path, config, feed_dir, started_at
+            )
+        finally:
+            self._release_lock(feed_dir)
+
+    async def _run_backfill_inner(
+        self,
+        data_path: Path,
+        config: dict[str, Any],
+        feed_dir: Path,
+        started_at: datetime,
+    ) -> CollectionResult:
+        """Backfill 내부 구현."""
+        schedule = config.get("schedule", {})
+        backfill_since = schedule.get("backfill_since", DEFAULT_BACKFILL_SINCE)
+
+        # 체크포인트 로드
+        ohlcv_checkpoint = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        dart_checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
+
+        last_ohlcv_date = ohlcv_checkpoint.get_last_date()
+
+        # 날짜 범위 생성
+        dates = list(
+            generate_backfill_dates(
+                start=backfill_since,
+                last_checkpoint=last_ohlcv_date,
+            )
+        )
+
+        if not dates:
+            logger.info("Backfill: 수집할 날짜 없음 (이미 완료)")
+            return self._make_result("backfill", started_at)
+
+        # 결과 집계 변수
+        failures: list[dict] = []
+        warnings: list[dict] = []
+        config_errors: list[dict] = []
+        total_symbols: set[str] = set()
+        success_symbols: set[str] = set()
+        rows_written = 0
+        data_types: set[str] = set()
+
+        # 소스 누락 확인
+        if self._data_go_kr_source is None:
+            config_errors.append(
+                {
+                    "error": "data.go.kr API 키 미설정",
+                    "source": "data_go_kr",
+                }
+            )
+        if self._dart_source is None:
+            config_errors.append(
+                {
+                    "error": "DART API 키 미설정",
+                    "source": "dart",
+                }
+            )
+
+        store = self._store or ParquetStore(base_path=data_path)
+
+        # --- data.go.kr 날짜별 수집 ---
+        if self._data_go_kr_source is not None:
+            for target_date in dates:
+                # 방어 가드 체크
+                if self._is_blocked(config, target_date):
+                    logger.debug("방어 가드: %s 스킵", target_date)
+                    continue
+
+                try:
+                    written, syms, warns = await self._collect_data_go_kr_date(
+                        target_date, store
+                    )
+                    rows_written += written
+                    total_symbols.update(syms)
+                    success_symbols.update(syms)
+                    if warns:
+                        warnings.extend(warns)
+                    if written > 0:
+                        data_types.add("ohlcv")
+                        data_types.add("fundamental")
+
+                    # 날짜별 체크포인트 갱신
+                    ohlcv_checkpoint.save(target_date)
+
+                except (DataGoKrDailyLimitError, DataGoKrCriticalError) as exc:
+                    logger.critical("data.go.kr 수집 중단: %s", exc)
+                    config_errors.append(
+                        {
+                            "error": str(exc),
+                            "source": "data_go_kr",
+                        }
+                    )
+                    break
+                except Exception as exc:
+                    logger.error("data.go.kr 수집 실패: date=%s, %s", target_date, exc)
+                    failures.append(
+                        {
+                            "date": target_date,
+                            "source": "data_go_kr",
+                            "reason": str(exc),
+                        }
+                    )
+
+        # --- DART 분기별 수집 ---
+        if self._dart_source is not None:
+            try:
+                dart_written, dart_syms, dart_warns = await self._collect_dart(
+                    data_path, feed_dir, dart_checkpoint, config
+                )
+                rows_written += dart_written
+                total_symbols.update(dart_syms)
+                success_symbols.update(dart_syms)
+                if dart_warns:
+                    warnings.extend(dart_warns)
+                if dart_written > 0:
+                    data_types.add("fundamental")
+            except (DARTDailyLimitError, DARTCriticalError) as exc:
+                logger.critical("DART 수집 중단: %s", exc)
+                config_errors.append(
+                    {
+                        "error": str(exc),
+                        "source": "dart",
+                    }
+                )
+            except Exception as exc:
+                logger.error("DART 수집 실패: %s", exc)
+                failures.append(
+                    {
+                        "source": "dart",
+                        "reason": str(exc),
+                    }
+                )
+
+        # --- 파생 지표 계산 ---
+        if "fundamental" in data_types and success_symbols:
+            try:
+                derived_written = await self._compute_derived_indicators(
+                    store, list(success_symbols)
+                )
+                rows_written += derived_written
+            except Exception as exc:
+                logger.error("파생 지표 계산 실패: %s", exc)
+                warnings.append(
+                    {
+                        "type": "derived_indicators",
+                        "message": f"파생 지표 계산 실패: {exc}",
+                    }
+                )
+
+        # 실패 종목 집계
+        failed_symbols = total_symbols - success_symbols
+
+        # 리포트 생성
+        result = self._make_result(
+            mode="backfill",
+            started_at=started_at,
+            symbols_total=len(total_symbols),
+            symbols_success=len(success_symbols),
+            symbols_failed=len(failed_symbols),
+            rows_written=rows_written,
+            data_types=sorted(data_types),
+            failures=failures,
+            warnings=warnings,
+            config_errors=config_errors,
+        )
+
+        self._save_report(data_path, feed_dir, result, "backfill")
+
+        return result
+
+    async def run_daily(
+        self,
+        data_path: Path,
+        config: dict[str, Any],
+    ) -> CollectionResult:
+        """일별 증분 수집 (daily 모드).
+
+        어제 1일치 데이터를 수집한다. backfill과 동일한 ETL 흐름.
+
+        Args:
+            data_path: Ante 데이터 저장소 루트 경로.
+            config: 설정 딕셔너리.
+
+        Returns:
+            수집 결과 CollectionResult.
+        """
+        feed_dir = data_path / ".feed"
+        started_at = datetime.now(tz=UTC)
+
+        # lock 파일 확인/생성
+        if not self._acquire_lock(feed_dir):
+            return self._make_result(
+                "daily",
+                started_at,
+                config_errors=[{"error": "다른 수집 프로세스가 이미 실행 중"}],
+            )
+
+        try:
+            return await self._run_daily_inner(data_path, config, feed_dir, started_at)
+        finally:
+            self._release_lock(feed_dir)
+
+    async def _run_daily_inner(
+        self,
+        data_path: Path,
+        config: dict[str, Any],
+        feed_dir: Path,
+        started_at: datetime,
+    ) -> CollectionResult:
+        """Daily 내부 구현."""
+        target_date = generate_daily_date()
+
+        # 방어 가드
+        if self._is_blocked(config, target_date):
+            logger.info("Daily: 방어 가드에 의해 스킵 (date=%s)", target_date)
+            return self._make_result(
+                "daily",
+                started_at,
+                target_date=target_date,
+            )
+
+        failures: list[dict] = []
+        warnings: list[dict] = []
+        config_errors: list[dict] = []
+        total_symbols: set[str] = set()
+        success_symbols: set[str] = set()
+        rows_written = 0
+        data_types: set[str] = set()
+
+        store = self._store or ParquetStore(base_path=data_path)
+
+        # data.go.kr 수집
+        if self._data_go_kr_source is not None:
+            try:
+                written, syms, warns = await self._collect_data_go_kr_date(
+                    target_date, store
+                )
+                rows_written += written
+                total_symbols.update(syms)
+                success_symbols.update(syms)
+                if warns:
+                    warnings.extend(warns)
+                if written > 0:
+                    data_types.add("ohlcv")
+                    data_types.add("fundamental")
+            except (DataGoKrDailyLimitError, DataGoKrCriticalError) as exc:
+                config_errors.append(
+                    {
+                        "error": str(exc),
+                        "source": "data_go_kr",
+                    }
+                )
+            except Exception as exc:
+                failures.append(
+                    {
+                        "date": target_date,
+                        "source": "data_go_kr",
+                        "reason": str(exc),
+                    }
+                )
+        else:
+            config_errors.append(
+                {
+                    "error": "data.go.kr API 키 미설정",
+                    "source": "data_go_kr",
+                }
+            )
+
+        # DART 수집 (daily에서는 현재 분기 기준)
+        if self._dart_source is not None:
+            dart_checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
+            try:
+                dart_written, dart_syms, dart_warns = await self._collect_dart(
+                    data_path, feed_dir, dart_checkpoint, config
+                )
+                rows_written += dart_written
+                total_symbols.update(dart_syms)
+                success_symbols.update(dart_syms)
+                if dart_warns:
+                    warnings.extend(dart_warns)
+                if dart_written > 0:
+                    data_types.add("fundamental")
+            except (DARTDailyLimitError, DARTCriticalError) as exc:
+                config_errors.append(
+                    {
+                        "error": str(exc),
+                        "source": "dart",
+                    }
+                )
+            except Exception as exc:
+                failures.append(
+                    {
+                        "source": "dart",
+                        "reason": str(exc),
+                    }
+                )
+        else:
+            config_errors.append(
+                {
+                    "error": "DART API 키 미설정",
+                    "source": "dart",
+                }
+            )
+
+        # 파생 지표 계산
+        if "fundamental" in data_types and success_symbols:
+            try:
+                derived_written = await self._compute_derived_indicators(
+                    store, list(success_symbols)
+                )
+                rows_written += derived_written
+            except Exception as exc:
+                warnings.append(
+                    {
+                        "type": "derived_indicators",
+                        "message": f"파생 지표 계산 실패: {exc}",
+                    }
+                )
+
+        failed_symbols = total_symbols - success_symbols
+
+        result = self._make_result(
+            mode="daily",
+            started_at=started_at,
+            target_date=target_date,
+            symbols_total=len(total_symbols),
+            symbols_success=len(success_symbols),
+            symbols_failed=len(failed_symbols),
+            rows_written=rows_written,
+            data_types=sorted(data_types),
+            failures=failures,
+            warnings=warnings,
+            config_errors=config_errors,
+        )
+
+        self._save_report(data_path, feed_dir, result, "daily")
+
+        return result
+
+    # ── data.go.kr 수집 ───────────────────────────────────
+
+    async def _collect_data_go_kr_date(
+        self,
+        target_date: str,
+        store: ParquetStore,
+    ) -> tuple[int, set[str], list[dict]]:
+        """data.go.kr에서 특정 날짜 전종목 데이터를 수집한다.
+
+        Returns:
+            (기록 행 수, 수집된 심볼 집합, 경고 목록).
+        """
+        assert self._data_go_kr_source is not None
+
+        # API 호출
+        raw_items = await self._data_go_kr_source.fetch(target_date)
+        if not raw_items:
+            logger.debug("data.go.kr: date=%s 데이터 없음", target_date)
+            return 0, set(), []
+
+        # 검증
+        validation = validate_all(
+            raw_items,
+            OHLCV_REQUIRED_FIELDS,
+        )
+        warns: list[dict] = []
+        if validation.warnings:
+            for w in validation.warnings:
+                warns.append(
+                    {
+                        "date": target_date,
+                        "source": "data_go_kr",
+                        "type": "business_rule",
+                        "message": w,
+                    }
+                )
+
+        # DataFrame 변환
+        df = pl.DataFrame(raw_items)
+
+        # 중복 제거
+        if "srtnCd" in df.columns and "basDt" in df.columns:
+            df = df.unique(subset=["srtnCd", "basDt"])
+
+        # OHLCV 정규화 + 저장
+        ohlcv_df = self._data_go_kr_normalizer.normalize_ohlcv(df)
+        rows_written = 0
+        symbols: set[str] = set()
+
+        if not ohlcv_df.is_empty() and "symbol" in ohlcv_df.columns:
+            symbol_list = ohlcv_df["symbol"].unique().to_list()
+            for sym in symbol_list:
+                sym_df = ohlcv_df.filter(pl.col("symbol") == sym)
+                await store.write(sym, "1d", sym_df, data_type="ohlcv")
+                rows_written += len(sym_df)
+                symbols.add(sym)
+
+        # FUNDAMENTAL 정규화 + 저장
+        fundamental_df = self._data_go_kr_normalizer.normalize_fundamental(df)
+        if not fundamental_df.is_empty() and "symbol" in fundamental_df.columns:
+            fund_symbols = fundamental_df["symbol"].unique().to_list()
+            for sym in fund_symbols:
+                sym_df = fundamental_df.filter(pl.col("symbol") == sym)
+                await store.write(sym, "krx", sym_df, data_type="fundamental")
+                rows_written += len(sym_df)
+                symbols.add(sym)
+
+        logger.info(
+            "data.go.kr 수집 완료: date=%s symbols=%d rows=%d",
+            target_date,
+            len(symbols),
+            rows_written,
+        )
+
+        return rows_written, symbols, warns
+
+    # ── DART 수집 ─────────────────────────────────────────
+
+    async def _collect_dart(
+        self,
+        data_path: Path,
+        feed_dir: Path,
+        checkpoint: Checkpoint,
+        config: dict[str, Any],
+    ) -> tuple[int, set[str], list[dict]]:
+        """DART에서 재무제표를 분기별로 수집한다.
+
+        Returns:
+            (기록 행 수, 수집된 심볼 집합, 경고 목록).
+        """
+        assert self._dart_source is not None
+
+        store = self._store or ParquetStore(base_path=data_path)
+
+        # corp_code 매핑 로드 또는 다운로드
+        corp_codes_path = feed_dir / "dart_corp_codes.json"
+        corp_code_map = await self._dart_source.fetch_corp_codes(
+            save_path=corp_codes_path
+        )
+
+        if not corp_code_map:
+            logger.warning("DART: 고유번호 매핑이 비어있음")
+            return 0, set(), []
+
+        corp_codes_list = list(corp_code_map.keys())
+
+        # 수집 연도/분기 범위 결정
+        schedule = config.get("schedule", {})
+        backfill_since = schedule.get("backfill_since", DEFAULT_BACKFILL_SINCE)
+        start_year = int(backfill_since[:4])
+        end_year = date.today().year
+
+        last_checkpoint = checkpoint.get_last_date()
+
+        rows_written = 0
+        symbols: set[str] = set()
+        warns: list[dict] = []
+
+        for year in range(start_year, end_year + 1):
+            for reprt_code in REPRT_CODES:
+                # 체크포인트 기반 스킵
+                quarter_key = f"{year}-{reprt_code}"
+                if last_checkpoint and quarter_key <= last_checkpoint:
+                    continue
+
+                try:
+                    raw_items = await self._dart_source.fetch_financial(
+                        corp_codes_list, str(year), reprt_code
+                    )
+                except (DARTDailyLimitError, DARTCriticalError):
+                    raise
+                except Exception as exc:
+                    logger.warning(
+                        "DART 수집 실패: year=%s reprt=%s: %s",
+                        year,
+                        reprt_code,
+                        exc,
+                    )
+                    warns.append(
+                        {
+                            "source": "dart",
+                            "year": str(year),
+                            "reprt_code": reprt_code,
+                            "message": str(exc),
+                        }
+                    )
+                    continue
+
+                if not raw_items:
+                    continue
+
+                # DataFrame 변환 + 정규화
+                df = pl.DataFrame(raw_items)
+                normalized = self._dart_normalizer.normalize(df, corp_code_map)
+
+                if normalized.is_empty():
+                    continue
+
+                # 심볼별 저장
+                if "symbol" in normalized.columns:
+                    sym_list = normalized["symbol"].unique().to_list()
+                    for sym in sym_list:
+                        sym_df = normalized.filter(pl.col("symbol") == sym)
+                        await store.write(sym, "krx", sym_df, data_type="fundamental")
+                        rows_written += len(sym_df)
+                        symbols.add(sym)
+
+                # 분기별 체크포인트 갱신
+                checkpoint.save(quarter_key)
+
+        logger.info(
+            "DART 수집 완료: symbols=%d rows=%d",
+            len(symbols),
+            rows_written,
+        )
+
+        return rows_written, symbols, warns
+
+    # ── 파생 지표 계산 ────────────────────────────────────
+
+    async def _compute_derived_indicators(
+        self,
+        store: ParquetStore,
+        symbols: list[str],
+    ) -> int:
+        """PER/PBR/EPS/BPS/ROE/부채비율을 계산하여 fundamental에 merge한다.
+
+        계산 공식:
+        - PER = 시가총액 / 당기순이익
+        - PBR = 시가총액 / 자본총계
+        - EPS = 당기순이익 / 상장주식수
+        - BPS = 자본총계 / 상장주식수
+        - ROE = 당기순이익 / 자본총계
+        - 부채비율 = 부채총계 / 자본총계
+
+        Args:
+            store: ParquetStore 인스턴스.
+            symbols: 대상 심볼 목록.
+
+        Returns:
+            갱신된 행 수.
+        """
+        rows_updated = 0
+
+        for sym in symbols:
+            try:
+                fundamental = await store.read(sym, "krx", data_type="fundamental")
+            except Exception:
+                continue
+
+            if fundamental.is_empty():
+                continue
+
+            # 필수 컬럼 존재 확인
+            cols = set(fundamental.columns)
+            has_market_cap = "market_cap" in cols
+            has_shares = "shares_listed" in cols
+            has_net_income = "net_income" in cols
+            has_equity = "total_equity" in cols
+            has_debt = "total_debt" in cols
+
+            exprs: list[pl.Expr] = []
+
+            # PER = 시가총액 / 당기순이익
+            if has_market_cap and has_net_income:
+                exprs.append(
+                    pl.when(pl.col("net_income") != 0)
+                    .then(
+                        pl.col("market_cap").cast(pl.Float64)
+                        / pl.col("net_income").cast(pl.Float64)
+                    )
+                    .otherwise(None)
+                    .alias("per")
+                )
+
+            # PBR = 시가총액 / 자본총계
+            if has_market_cap and has_equity:
+                exprs.append(
+                    pl.when(pl.col("total_equity") != 0)
+                    .then(
+                        pl.col("market_cap").cast(pl.Float64)
+                        / pl.col("total_equity").cast(pl.Float64)
+                    )
+                    .otherwise(None)
+                    .alias("pbr")
+                )
+
+            # EPS = 당기순이익 / 상장주식수
+            if has_net_income and has_shares:
+                exprs.append(
+                    pl.when(pl.col("shares_listed") != 0)
+                    .then(
+                        pl.col("net_income").cast(pl.Float64)
+                        / pl.col("shares_listed").cast(pl.Float64)
+                    )
+                    .otherwise(None)
+                    .alias("eps")
+                )
+
+            # BPS = 자본총계 / 상장주식수
+            if has_equity and has_shares:
+                exprs.append(
+                    pl.when(pl.col("shares_listed") != 0)
+                    .then(
+                        pl.col("total_equity").cast(pl.Float64)
+                        / pl.col("shares_listed").cast(pl.Float64)
+                    )
+                    .otherwise(None)
+                    .alias("bps")
+                )
+
+            # ROE = 당기순이익 / 자본총계
+            if has_net_income and has_equity:
+                exprs.append(
+                    pl.when(pl.col("total_equity") != 0)
+                    .then(
+                        pl.col("net_income").cast(pl.Float64)
+                        / pl.col("total_equity").cast(pl.Float64)
+                    )
+                    .otherwise(None)
+                    .alias("roe")
+                )
+
+            # 부채비율 = 부채총계 / 자본총계
+            if has_debt and has_equity:
+                exprs.append(
+                    pl.when(pl.col("total_equity") != 0)
+                    .then(
+                        pl.col("total_debt").cast(pl.Float64)
+                        / pl.col("total_equity").cast(pl.Float64)
+                    )
+                    .otherwise(None)
+                    .alias("debt_to_equity")
+                )
+
+            if not exprs:
+                continue
+
+            updated = fundamental.with_columns(exprs)
+            await store.write(sym, "krx", updated, data_type="fundamental")
+            rows_updated += len(updated)
+
+        logger.info(
+            "파생 지표 계산 완료: symbols=%d rows=%d",
+            len(symbols),
+            rows_updated,
+        )
+        return rows_updated
+
+    # ── 방어 가드 ─────────────────────────────────────────
+
+    @staticmethod
+    def _is_blocked(config: dict[str, Any], target_date: str) -> bool:
+        """방어 가드 조건을 확인한다.
+
+        Args:
+            config: 설정 딕셔너리 (guard 섹션).
+            target_date: 확인할 날짜 (YYYY-MM-DD).
+
+        Returns:
+            차단되면 True.
+        """
+        guard = config.get("guard", {})
+
+        # blocked_days 확인
+        blocked_days = guard.get("blocked_days", [])
+        if blocked_days:
+            d = date.fromisoformat(target_date)
+            day_names = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+            current_day = day_names[d.weekday()]
+            if current_day in [bd.lower() for bd in blocked_days]:
+                return True
+
+        # blocked_hours 확인 (현재 시각 기준)
+        pause_during_trading = guard.get("pause_during_trading", False)
+        blocked_hours = guard.get("blocked_hours", [])
+
+        if pause_during_trading and blocked_hours:
+            kst = timezone(timedelta(hours=9))
+            now_kst = datetime.now(tz=kst)
+            current_hour_min = now_kst.strftime("%H:%M")
+
+            for window in blocked_hours:
+                if "-" in window:
+                    start_time, end_time = window.split("-")
+                    if start_time.strip() <= current_hour_min <= end_time.strip():
+                        return True
+
+        return False
+
+    # ── Lock 파일 관리 ────────────────────────────────────
+
+    @staticmethod
+    def _acquire_lock(feed_dir: Path) -> bool:
+        """Lock 파일을 생성하여 동시 실행을 방지한다.
+
+        Args:
+            feed_dir: .feed 디렉토리 경로.
+
+        Returns:
+            lock 획득 성공 시 True.
+        """
+        lock_path = feed_dir / LOCK_FILE
+        feed_dir.mkdir(parents=True, exist_ok=True)
+
+        if lock_path.exists():
+            try:
+                pid = int(lock_path.read_text().strip())
+                # 프로세스 존재 여부 확인
+                os.kill(pid, 0)
+                logger.error("다른 수집 프로세스가 실행 중 (PID=%d)", pid)
+                return False
+            except (ValueError, ProcessLookupError, PermissionError, OSError):
+                # 프로세스 없음 (비정상 종료) -> lock 파일 제거 후 진행
+                logger.warning("비정상 lock 파일 감지, 제거 후 진행")
+                lock_path.unlink(missing_ok=True)
+
+        lock_path.write_text(str(os.getpid()))
+        return True
+
+    @staticmethod
+    def _release_lock(feed_dir: Path) -> None:
+        """Lock 파일을 제거한다."""
+        lock_path = feed_dir / LOCK_FILE
+        lock_path.unlink(missing_ok=True)
+
+    # ── 유틸리티 ──────────────────────────────────────────
+
+    @staticmethod
+    def _make_result(
+        mode: str,
+        started_at: datetime,
+        target_date: str | None = None,
+        symbols_total: int = 0,
+        symbols_success: int = 0,
+        symbols_failed: int = 0,
+        rows_written: int = 0,
+        data_types: list[str] | None = None,
+        failures: list[dict] | None = None,
+        warnings: list[dict] | None = None,
+        config_errors: list[dict] | None = None,
+    ) -> CollectionResult:
+        """CollectionResult를 생성한다."""
+        finished_at = datetime.now(tz=UTC)
+        duration = (finished_at - started_at).total_seconds()
+
+        return CollectionResult(
+            mode=mode,
+            started_at=started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            finished_at=finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            duration_seconds=duration,
+            target_date=target_date,
+            symbols_total=symbols_total,
+            symbols_success=symbols_success,
+            symbols_failed=symbols_failed,
+            rows_written=rows_written,
+            data_types=data_types or [],
+            failures=failures or [],
+            warnings=warnings or [],
+            config_errors=config_errors or [],
+        )
+
+    def _save_report(
+        self,
+        data_path: Path,
+        feed_dir: Path,
+        result: CollectionResult,
+        mode: str,
+    ) -> None:
+        """리포트를 생성하고 저장한다."""
+        generator = self._report_generator or ReportGenerator(feed_dir)
+        report = generator.generate(result)
+        generator.save(data_path, report, mode)

--- a/tests/unit/feed/test_orchestrator.py
+++ b/tests/unit/feed/test_orchestrator.py
@@ -1,0 +1,664 @@
+"""FeedOrchestrator 단위 테스트.
+
+mock 소스로 전체 ETL 흐름, 체크포인트 재개, 에러 처리, 파생 지표 계산을 검증한다.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import polars as pl
+import pytest
+
+from ante.data.store import ParquetStore
+from ante.feed.models.result import CollectionResult
+from ante.feed.pipeline.orchestrator import FeedOrchestrator
+from ante.feed.sources.dart import (
+    DailyLimitExceededError as DARTDailyLimitError,
+)
+from ante.feed.sources.data_go_kr import (
+    CriticalApiError as DataGoKrCriticalError,
+)
+from ante.feed.sources.data_go_kr import (
+    DailyLimitExceededError as DataGoKrDailyLimitError,
+)
+
+# ── Fixtures ─────────────────────────────────────────────
+
+
+def _make_data_go_kr_records(
+    date_str: str = "20240101",
+    symbols: list[str] | None = None,
+) -> list[dict]:
+    """data.go.kr 응답 형식의 mock 레코드를 생성한다."""
+    syms = symbols or ["005930", "000660"]
+    records = []
+    for sym in syms:
+        records.append(
+            {
+                "basDt": date_str,
+                "srtnCd": sym,
+                "itmsNm": f"종목{sym}",
+                "mrktCtg": "KOSPI",
+                "mkp": "70000",
+                "hipr": "72000",
+                "lopr": "69000",
+                "clpr": "71000",
+                "trqu": "10000000",
+                "trPrc": "710000000000",
+                "lstgStCnt": "5969782550",
+                "mrktTotAmt": "423814400050000",
+            }
+        )
+    return records
+
+
+def _make_dart_records(
+    corp_code: str = "00126380",
+    year: str = "2024",
+    reprt_code: str = "11011",
+) -> list[dict]:
+    """DART 재무제표 응답 형식의 mock 레코드를 생성한다."""
+    return [
+        {
+            "corp_code": corp_code,
+            "account_nm": "당기순이익",
+            "thstrm_amount": "50,000,000,000",
+            "fs_div": "CFS",
+            "reprt_code": reprt_code,
+            "bsns_year": year,
+            "sj_div": "IS",
+        },
+        {
+            "corp_code": corp_code,
+            "account_nm": "자본총계",
+            "thstrm_amount": "300,000,000,000",
+            "fs_div": "CFS",
+            "reprt_code": reprt_code,
+            "bsns_year": year,
+            "sj_div": "BS",
+        },
+        {
+            "corp_code": corp_code,
+            "account_nm": "부채총계",
+            "thstrm_amount": "100,000,000,000",
+            "fs_div": "CFS",
+            "reprt_code": reprt_code,
+            "bsns_year": year,
+            "sj_div": "BS",
+        },
+        {
+            "corp_code": corp_code,
+            "account_nm": "매출액",
+            "thstrm_amount": "200,000,000,000",
+            "fs_div": "CFS",
+            "reprt_code": reprt_code,
+            "bsns_year": year,
+            "sj_div": "IS",
+        },
+    ]
+
+
+@pytest.fixture
+def tmp_data_path(tmp_path: Path) -> Path:
+    """테스트용 데이터 디렉토리."""
+    data_path = tmp_path / "data"
+    data_path.mkdir()
+    feed_dir = data_path / ".feed"
+    feed_dir.mkdir()
+    (feed_dir / "checkpoints").mkdir()
+    (feed_dir / "reports").mkdir()
+    return data_path
+
+
+@pytest.fixture
+def mock_data_go_kr_source() -> AsyncMock:
+    """data.go.kr 소스 mock."""
+    source = AsyncMock()
+    source.fetch = AsyncMock(return_value=_make_data_go_kr_records())
+    source.rate_limiter = MagicMock()
+    source.rate_limiter.is_daily_limit_reached.return_value = False
+    return source
+
+
+@pytest.fixture
+def mock_dart_source() -> AsyncMock:
+    """DART 소스 mock."""
+    source = AsyncMock()
+    source.fetch_corp_codes = AsyncMock(
+        return_value={"00126380": "005930", "00164742": "000660"}
+    )
+    source.fetch_financial = AsyncMock(return_value=_make_dart_records())
+    source.rate_limiter = MagicMock()
+    source.rate_limiter.is_daily_limit_reached.return_value = False
+    return source
+
+
+@pytest.fixture
+def basic_config() -> dict:
+    """기본 설정."""
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+    return {
+        "schedule": {
+            "backfill_since": yesterday,
+        },
+        "guard": {
+            "blocked_days": [],
+            "blocked_hours": [],
+            "pause_during_trading": False,
+        },
+    }
+
+
+# ── Backfill 테스트 ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_backfill_basic_flow(
+    tmp_data_path: Path,
+    mock_data_go_kr_source: AsyncMock,
+    basic_config: dict,
+) -> None:
+    """Backfill 기본 ETL 흐름이 정상 동작한다."""
+    store = ParquetStore(base_path=tmp_data_path)
+    orchestrator = FeedOrchestrator(
+        data_go_kr_source=mock_data_go_kr_source,
+        store=store,
+    )
+
+    result = await orchestrator.run_backfill(tmp_data_path, basic_config)
+
+    assert isinstance(result, CollectionResult)
+    assert result.mode == "backfill"
+    assert result.rows_written > 0
+    assert "ohlcv" in result.data_types
+
+
+@pytest.mark.asyncio
+async def test_backfill_no_sources(
+    tmp_data_path: Path,
+    basic_config: dict,
+) -> None:
+    """소스가 없으면 config_errors를 보고한다."""
+    orchestrator = FeedOrchestrator()
+
+    result = await orchestrator.run_backfill(tmp_data_path, basic_config)
+
+    assert result.mode == "backfill"
+    assert len(result.config_errors) >= 1
+    sources = [e.get("source") for e in result.config_errors]
+    assert "data_go_kr" in sources
+
+
+@pytest.mark.asyncio
+async def test_backfill_checkpoint_resume(
+    tmp_data_path: Path,
+    mock_data_go_kr_source: AsyncMock,
+) -> None:
+    """체크포인트가 있으면 그 이후부터 수집을 재개한다."""
+    # 어제-2일부터 시작, 어제-1일까지 체크포인트 저장
+    two_days_ago = (date.today() - timedelta(days=2)).isoformat()
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+
+    config = {
+        "schedule": {"backfill_since": two_days_ago},
+        "guard": {
+            "blocked_days": [],
+            "blocked_hours": [],
+            "pause_during_trading": False,
+        },
+    }
+
+    # 첫 번째 체크포인트를 수동 저장
+    from ante.feed.pipeline.checkpoint import Checkpoint
+
+    cp = Checkpoint(tmp_data_path / ".feed", "data_go_kr", "ohlcv")
+    cp.save(yesterday)
+
+    store = ParquetStore(base_path=tmp_data_path)
+    orchestrator = FeedOrchestrator(
+        data_go_kr_source=mock_data_go_kr_source,
+        store=store,
+    )
+
+    result = await orchestrator.run_backfill(tmp_data_path, config)
+
+    # 체크포인트 이후 날짜만 수집 시도 (오늘)
+    assert result.mode == "backfill"
+
+
+@pytest.mark.asyncio
+async def test_backfill_daily_limit_stops(
+    tmp_data_path: Path,
+    basic_config: dict,
+) -> None:
+    """data.go.kr 일일 한도 초과 시 수집을 중단하고 결과를 반환한다."""
+    source = AsyncMock()
+    source.fetch = AsyncMock(side_effect=DataGoKrDailyLimitError("일일 한도 초과"))
+
+    store = ParquetStore(base_path=tmp_data_path)
+    orchestrator = FeedOrchestrator(
+        data_go_kr_source=source,
+        store=store,
+    )
+
+    result = await orchestrator.run_backfill(tmp_data_path, basic_config)
+
+    assert result.mode == "backfill"
+    assert any("data_go_kr" in str(e) for e in result.config_errors)
+
+
+@pytest.mark.asyncio
+async def test_backfill_critical_error_stops(
+    tmp_data_path: Path,
+    basic_config: dict,
+) -> None:
+    """data.go.kr Critical 에러 시 수집을 중단한다."""
+    source = AsyncMock()
+    source.fetch = AsyncMock(side_effect=DataGoKrCriticalError("서비스키 만료"))
+
+    store = ParquetStore(base_path=tmp_data_path)
+    orchestrator = FeedOrchestrator(
+        data_go_kr_source=source,
+        store=store,
+    )
+
+    result = await orchestrator.run_backfill(tmp_data_path, basic_config)
+
+    assert any("data_go_kr" in str(e) for e in result.config_errors)
+
+
+@pytest.mark.asyncio
+async def test_backfill_fetch_error_skips_date(
+    tmp_data_path: Path,
+    basic_config: dict,
+) -> None:
+    """일반 에러 시 해당 날짜를 스킵하고 failures에 기록한다."""
+    source = AsyncMock()
+    source.fetch = AsyncMock(side_effect=RuntimeError("네트워크 오류"))
+
+    store = ParquetStore(base_path=tmp_data_path)
+    orchestrator = FeedOrchestrator(
+        data_go_kr_source=source,
+        store=store,
+    )
+
+    result = await orchestrator.run_backfill(tmp_data_path, basic_config)
+
+    assert len(result.failures) > 0
+    assert result.failures[0]["source"] == "data_go_kr"
+
+
+# ── Daily 테스트 ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_daily_basic_flow(
+    tmp_data_path: Path,
+    mock_data_go_kr_source: AsyncMock,
+    basic_config: dict,
+) -> None:
+    """Daily 기본 ETL 흐름이 정상 동작한다."""
+    store = ParquetStore(base_path=tmp_data_path)
+    orchestrator = FeedOrchestrator(
+        data_go_kr_source=mock_data_go_kr_source,
+        store=store,
+    )
+
+    result = await orchestrator.run_daily(tmp_data_path, basic_config)
+
+    assert isinstance(result, CollectionResult)
+    assert result.mode == "daily"
+    assert result.target_date is not None
+    assert result.rows_written > 0
+
+
+@pytest.mark.asyncio
+async def test_daily_no_sources(
+    tmp_data_path: Path,
+    basic_config: dict,
+) -> None:
+    """Daily에서 소스 없으면 config_errors 보고."""
+    orchestrator = FeedOrchestrator()
+
+    result = await orchestrator.run_daily(tmp_data_path, basic_config)
+
+    assert result.mode == "daily"
+    assert len(result.config_errors) >= 1
+
+
+# ── 방어 가드 테스트 ─────────────────────────────────────
+
+
+def test_is_blocked_by_day() -> None:
+    """blocked_days에 해당하면 True를 반환한다."""
+    # 2024-01-01은 월요일 (mon)
+    config = {"guard": {"blocked_days": ["mon"]}}
+    assert FeedOrchestrator._is_blocked(config, "2024-01-01") is True
+
+
+def test_is_not_blocked_by_day() -> None:
+    """blocked_days에 해당하지 않으면 False."""
+    config = {"guard": {"blocked_days": ["sat", "sun"]}}
+    assert FeedOrchestrator._is_blocked(config, "2024-01-01") is False
+
+
+def test_is_blocked_empty_guard() -> None:
+    """guard 설정이 없으면 차단되지 않는다."""
+    config: dict = {}
+    assert FeedOrchestrator._is_blocked(config, "2024-01-01") is False
+
+
+# ── Lock 파일 테스트 ─────────────────────────────────────
+
+
+def test_acquire_and_release_lock(tmp_path: Path) -> None:
+    """Lock 획득 후 해제가 정상 동작한다."""
+    feed_dir = tmp_path / ".feed"
+    feed_dir.mkdir()
+
+    assert FeedOrchestrator._acquire_lock(feed_dir) is True
+    assert (feed_dir / "lock").exists()
+
+    FeedOrchestrator._release_lock(feed_dir)
+    assert not (feed_dir / "lock").exists()
+
+
+def test_acquire_lock_stale(tmp_path: Path) -> None:
+    """비정상 종료된 lock 파일은 제거 후 획득한다."""
+    feed_dir = tmp_path / ".feed"
+    feed_dir.mkdir()
+
+    # 존재하지 않는 PID로 lock 파일 생성
+    (feed_dir / "lock").write_text("999999999")
+
+    assert FeedOrchestrator._acquire_lock(feed_dir) is True
+
+
+@pytest.mark.asyncio
+async def test_concurrent_run_blocked(
+    tmp_data_path: Path,
+    basic_config: dict,
+) -> None:
+    """동시 실행 시 두 번째 실행이 차단된다."""
+    feed_dir = tmp_data_path / ".feed"
+    import os
+
+    # 현재 프로세스 PID로 lock 파일 생성 (실행 중인 것처럼)
+    (feed_dir / "lock").write_text(str(os.getpid()))
+
+    orchestrator = FeedOrchestrator()
+    result = await orchestrator.run_backfill(tmp_data_path, basic_config)
+
+    assert any("실행 중" in str(e) for e in result.config_errors)
+
+    # lock 파일 정리
+    (feed_dir / "lock").unlink(missing_ok=True)
+
+
+# ── 파생 지표 계산 테스트 ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_compute_derived_indicators(tmp_data_path: Path) -> None:
+    """PER/PBR/EPS/BPS/ROE/부채비율이 올바르게 계산된다."""
+    store = ParquetStore(base_path=tmp_data_path)
+
+    # fundamental 데이터 준비
+    fundamental_df = pl.DataFrame(
+        {
+            "date": [date(2024, 12, 31)],
+            "symbol": ["005930"],
+            "market_cap": [400_000_000_000_000],
+            "shares_listed": [5_969_782_550],
+            "net_income": [50_000_000_000_000],
+            "total_equity": [300_000_000_000_000],
+            "total_debt": [100_000_000_000_000],
+            "source": ["test"],
+        }
+    )
+
+    await store.write("005930", "krx", fundamental_df, data_type="fundamental")
+
+    orchestrator = FeedOrchestrator(store=store)
+    rows = await orchestrator._compute_derived_indicators(store, ["005930"])
+
+    assert rows > 0
+
+    # 결과 읽기
+    result = await store.read("005930", "krx", data_type="fundamental")
+    assert not result.is_empty()
+
+    row = result.row(0, named=True)
+
+    # PER = 시가총액 / 순이익
+    expected_per = 400_000_000_000_000 / 50_000_000_000_000
+    assert abs(row["per"] - expected_per) < 0.01
+
+    # PBR = 시가총액 / 자본총계
+    expected_pbr = 400_000_000_000_000 / 300_000_000_000_000
+    assert abs(row["pbr"] - expected_pbr) < 0.01
+
+    # EPS = 순이익 / 상장주식수
+    expected_eps = 50_000_000_000_000 / 5_969_782_550
+    assert abs(row["eps"] - expected_eps) < 1.0
+
+    # BPS = 자본총계 / 상장주식수
+    expected_bps = 300_000_000_000_000 / 5_969_782_550
+    assert abs(row["bps"] - expected_bps) < 1.0
+
+    # ROE = 순이익 / 자본총계
+    expected_roe = 50_000_000_000_000 / 300_000_000_000_000
+    assert abs(row["roe"] - expected_roe) < 0.0001
+
+    # 부채비율 = 부채총계 / 자본총계
+    expected_dte = 100_000_000_000_000 / 300_000_000_000_000
+    assert abs(row["debt_to_equity"] - expected_dte) < 0.0001
+
+
+@pytest.mark.asyncio
+async def test_compute_derived_zero_division(tmp_data_path: Path) -> None:
+    """분모가 0이면 파생 지표가 None이 된다."""
+    store = ParquetStore(base_path=tmp_data_path)
+
+    fundamental_df = pl.DataFrame(
+        {
+            "date": [date(2024, 12, 31)],
+            "symbol": ["005930"],
+            "market_cap": [400_000_000_000_000],
+            "shares_listed": [0],  # 0으로 나누기
+            "net_income": [0],  # 0으로 나누기
+            "total_equity": [0],  # 0으로 나누기
+            "total_debt": [100_000_000_000_000],
+            "source": ["test"],
+        }
+    )
+
+    await store.write("005930", "krx", fundamental_df, data_type="fundamental")
+
+    orchestrator = FeedOrchestrator(store=store)
+    await orchestrator._compute_derived_indicators(store, ["005930"])
+
+    result = await store.read("005930", "krx", data_type="fundamental")
+    row = result.row(0, named=True)
+
+    # 분모 0이면 None
+    assert row["per"] is None
+    assert row["pbr"] is None
+    assert row["eps"] is None
+    assert row["bps"] is None
+    assert row["roe"] is None
+    assert row["debt_to_equity"] is None
+
+
+@pytest.mark.asyncio
+async def test_compute_derived_missing_columns(tmp_data_path: Path) -> None:
+    """필수 컬럼이 없으면 해당 지표를 건너뛴다."""
+    store = ParquetStore(base_path=tmp_data_path)
+
+    # market_cap만 있고 net_income 등이 없는 경우
+    fundamental_df = pl.DataFrame(
+        {
+            "date": [date(2024, 12, 31)],
+            "symbol": ["005930"],
+            "market_cap": [400_000_000_000_000],
+            "shares_listed": [5_969_782_550],
+            "source": ["test"],
+        }
+    )
+
+    await store.write("005930", "krx", fundamental_df, data_type="fundamental")
+
+    orchestrator = FeedOrchestrator(store=store)
+    # 에러 없이 실행되어야 함
+    rows = await orchestrator._compute_derived_indicators(store, ["005930"])
+    assert rows >= 0
+
+
+# ── DART 수집 테스트 ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_backfill_with_dart(
+    tmp_data_path: Path,
+    mock_data_go_kr_source: AsyncMock,
+    mock_dart_source: AsyncMock,
+) -> None:
+    """Backfill에서 DART 수집이 함께 동작한다."""
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+    config = {
+        "schedule": {"backfill_since": yesterday},
+        "guard": {
+            "blocked_days": [],
+            "blocked_hours": [],
+            "pause_during_trading": False,
+        },
+    }
+
+    store = ParquetStore(base_path=tmp_data_path)
+    orchestrator = FeedOrchestrator(
+        data_go_kr_source=mock_data_go_kr_source,
+        dart_source=mock_dart_source,
+        store=store,
+    )
+
+    result = await orchestrator.run_backfill(tmp_data_path, config)
+
+    assert result.mode == "backfill"
+    assert "fundamental" in result.data_types
+
+
+@pytest.mark.asyncio
+async def test_dart_daily_limit_handled(
+    tmp_data_path: Path,
+    mock_data_go_kr_source: AsyncMock,
+    basic_config: dict,
+) -> None:
+    """DART 일일 한도 초과 시 config_errors에 기록한다."""
+    dart_source = AsyncMock()
+    dart_source.fetch_corp_codes = AsyncMock(
+        side_effect=DARTDailyLimitError("DART 일일 한도 초과")
+    )
+
+    store = ParquetStore(base_path=tmp_data_path)
+    orchestrator = FeedOrchestrator(
+        data_go_kr_source=mock_data_go_kr_source,
+        dart_source=dart_source,
+        store=store,
+    )
+
+    result = await orchestrator.run_backfill(tmp_data_path, basic_config)
+
+    assert any("dart" in str(e).lower() for e in result.config_errors)
+
+
+# ── 리포트 생성 테스트 ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_report_generated(
+    tmp_data_path: Path,
+    mock_data_go_kr_source: AsyncMock,
+    basic_config: dict,
+) -> None:
+    """수집 완료 후 리포트 파일이 생성된다."""
+    store = ParquetStore(base_path=tmp_data_path)
+    orchestrator = FeedOrchestrator(
+        data_go_kr_source=mock_data_go_kr_source,
+        store=store,
+    )
+
+    await orchestrator.run_backfill(tmp_data_path, basic_config)
+
+    reports_dir = tmp_data_path / ".feed" / "reports"
+    report_files = list(reports_dir.glob("*.json"))
+    assert len(report_files) >= 1
+
+
+@pytest.mark.asyncio
+async def test_daily_report_generated(
+    tmp_data_path: Path,
+    mock_data_go_kr_source: AsyncMock,
+    basic_config: dict,
+) -> None:
+    """Daily 수집 후 리포트 파일이 생성된다."""
+    store = ParquetStore(base_path=tmp_data_path)
+    orchestrator = FeedOrchestrator(
+        data_go_kr_source=mock_data_go_kr_source,
+        store=store,
+    )
+
+    await orchestrator.run_daily(tmp_data_path, basic_config)
+
+    reports_dir = tmp_data_path / ".feed" / "reports"
+    report_files = list(reports_dir.glob("*.json"))
+    assert len(report_files) >= 1
+
+
+# ── 데이터 저장 검증 ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ohlcv_written_to_store(
+    tmp_data_path: Path,
+    mock_data_go_kr_source: AsyncMock,
+    basic_config: dict,
+) -> None:
+    """OHLCV 데이터가 ParquetStore에 올바르게 저장된다."""
+    store = ParquetStore(base_path=tmp_data_path)
+    orchestrator = FeedOrchestrator(
+        data_go_kr_source=mock_data_go_kr_source,
+        store=store,
+    )
+
+    await orchestrator.run_daily(tmp_data_path, basic_config)
+
+    # 심볼 디렉토리 확인
+    ohlcv_path = tmp_data_path / "ohlcv" / "1d"
+    if ohlcv_path.exists():
+        symbol_dirs = list(ohlcv_path.iterdir())
+        assert len(symbol_dirs) > 0
+
+
+@pytest.mark.asyncio
+async def test_fundamental_written_to_store(
+    tmp_data_path: Path,
+    mock_data_go_kr_source: AsyncMock,
+    basic_config: dict,
+) -> None:
+    """FUNDAMENTAL 데이터가 ParquetStore에 올바르게 저장된다."""
+    store = ParquetStore(base_path=tmp_data_path)
+    orchestrator = FeedOrchestrator(
+        data_go_kr_source=mock_data_go_kr_source,
+        store=store,
+    )
+
+    await orchestrator.run_daily(tmp_data_path, basic_config)
+
+    # fundamental 디렉토리 확인
+    fund_path = tmp_data_path / "fundamental" / "krx"
+    if fund_path.exists():
+        symbol_dirs = list(fund_path.iterdir())
+        assert len(symbol_dirs) > 0


### PR DESCRIPTION
## Summary
- FeedOrchestrator 클래스 구현: `run_backfill()`, `run_daily()` 메서드로 과거 대량 수집 및 일별 증분 수집 지원
- data.go.kr + DART 데이터를 결합한 파생 지표 계산 (PER/PBR/EPS/BPS/ROE/부채비율)
- 방어 가드(blocked_days/blocked_hours), lock 파일 동시 실행 방지, 체크포인트 기반 중단/재개, 일일 API 한도 안전 중단

## Changes
- `src/ante/feed/pipeline/orchestrator.py`: FeedOrchestrator 전체 구현 (스텁 -> 완전 구현)
- `src/ante/feed/pipeline/__init__.py`: public API re-export 추가
- `tests/unit/feed/test_orchestrator.py`: 단위 테스트 23건 (ETL 흐름, 체크포인트, 에러 처리, 파생 지표, 방어 가드, lock)

## Test plan
- [x] `pytest tests/unit/feed/test_orchestrator.py -v` — 23건 전체 통과
- [x] `pytest tests/unit/ -v` — 기존 1574건 전체 통과 (깨진 테스트 없음)
- [x] `ruff check` + `ruff format` 통과

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)