### PR TITLE
fix(dashboard): 레이아웃 목업 충실도 개선 (#332)

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -79,22 +79,21 @@ export default function Header() {
             onClick={() => setMenuOpen(!menuOpen)}
             className="flex items-center gap-2 px-2.5 py-1 rounded-lg cursor-pointer text-[13px] text-text-muted bg-transparent border-none hover:bg-surface-hover hover:text-text"
           >
-            <span className="text-[22px] leading-none mt-0.5">🦁</span>
+            <span className="text-[22px] leading-none mt-0.5">{user?.emoji || '🦁'}</span>
             <span className="hidden sm:inline">{user?.member_id ?? '...'} · {user?.role === 'master' ? '대표' : user?.role}</span>
           </button>
 
           {menuOpen && (
             <div className="absolute top-[calc(100%+6px)] right-0 bg-surface border border-border rounded-lg shadow-[0_8px_24px_rgba(0,0,0,0.3)] min-w-[200px] z-[200] py-3">
               <div className="px-4 pb-3 border-b border-border text-[12px] text-text-muted">
-                <div className="font-medium text-text">{user?.name}</div>
-                <div>{user?.org}</div>
+                {user?.login_at ? `접속: ${user.login_at.slice(0, 16)}` : ''}
               </div>
               <Link
                 to="/settings"
                 onClick={() => setMenuOpen(false)}
                 className="block px-4 py-2 text-[13px] text-text no-underline hover:bg-surface-hover"
               >
-                설정
+                ⚙️ 설정
               </Link>
               <button
                 onClick={() => { setMenuOpen(false); logoutMutation.mutate() }}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -69,7 +69,7 @@ export default function Sidebar() {
               <span className="text-[16px] w-5 text-center">{item.icon}</span>
               <span>{item.label}</span>
               {item.showBadge && pendingCount > 0 && (
-                <span className="ml-auto bg-negative text-white text-[11px] px-1.5 py-0 rounded-[10px] font-semibold">
+                <span className="ml-auto bg-negative text-white text-[11px] px-1.5 py-px rounded-[10px] font-semibold">
                   {pendingCount}
                 </span>
               )}

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -10,6 +10,8 @@ export interface User {
   type: string
   org: string
   scopes: string[]
+  emoji: string
+  login_at: string
 }
 
 export interface LoginResponse {

--- a/src/ante/web/routes/auth.py
+++ b/src/ante/web/routes/auth.py
@@ -102,4 +102,5 @@ async def me(
         type=member.type,
         emoji=member.emoji,
         role=member.role,
+        login_at=session.get("created_at", ""),
     )

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -66,3 +66,4 @@ class MeResponse(BaseModel):
     type: str
     emoji: str = ""
     role: str = ""
+    login_at: str = ""


### PR DESCRIPTION
Closes #332

## Summary
- Header 드롭다운에 접속 시간(`login_at`) 표시, 설정 링크에 ⚙️ 이모지 추가
- Header 사용자 아바타를 `user.emoji` 필드에서 동적으로 가져오도록 변경
- Sidebar nav-badge 패딩을 목업과 정확히 일치(`py-px`)
- Backend `/api/auth/me` 응답에 `login_at` 필드 추가 (세션 생성 시각)
- Frontend `User` 타입에 `emoji`, `login_at` 필드 추가

## Test plan
- [x] ruff check / ruff format 통과
- [x] pytest 1587 passed, 3 skipped (기존 테스트 영향 없음)
- [ ] 브라우저에서 사이드바/헤더/드롭다운 레이아웃이 목업과 일치하는지 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)