### PR TITLE
fix(dashboard): 로그인 페이지 목업 충실도 개선

### DIFF
--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -52,7 +52,7 @@ export default function LoginForm() {
             className="absolute right-3 top-1/2 -translate-y-1/2 bg-transparent border-none text-text-muted cursor-pointer text-[14px]"
             title="패스워드 표시"
           >
-            {showPassword ? '🙈' : '👁'}
+            {'\u{1F441}'}
           </button>
         </div>
       </div>
@@ -60,7 +60,7 @@ export default function LoginForm() {
       <button
         type="submit"
         disabled={loginMutation.isPending || !memberId || !password}
-        className="w-full py-3 bg-primary text-white rounded-lg text-[14px] font-semibold mt-2 hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer border-none"
+        className="w-full inline-flex items-center justify-center py-3 bg-primary text-white rounded-lg text-[14px] font-semibold mt-2 hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer border-none transition-colors duration-150"
       >
         {loginMutation.isPending ? '로그인 중...' : '로그인'}
       </button>


### PR DESCRIPTION
## Summary
- 로그인 버튼에 `inline-flex items-center justify-center`와 `transition-colors duration-150` 추가하여 목업의 `.btn` 기본 스타일(중앙 정렬, 호버 전환 애니메이션)과 일치시킴
- 패스워드 토글 아이콘을 목업과 동일한 단일 eye 문자(U+1F441)로 통일 (기존: 상태별 다른 이모지)

## Test plan
- [x] TypeScript 컴파일 오류 없음 (`tsc --noEmit`)
- [x] 전체 테스트 통과 (1587 passed)
- [ ] 브라우저에서 로그인 화면이 목업(`docs/dashboard/mockups/login.html`)과 동일한 레이아웃으로 렌더링되는지 확인
- [ ] 로그인 버튼 호버 시 배경색 전환 애니메이션 확인
- [ ] 패스워드 토글 버튼 동작 확인

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)