### PR TITLE
feat(dashboard): 결재함 목록 + 상세 5종 목업 충실도 개선

### DIFF
--- a/frontend/src/components/approvals/ApprovalFilters.tsx
+++ b/frontend/src/components/approvals/ApprovalFilters.tsx
@@ -38,12 +38,9 @@ export default function ApprovalFilters({ status, type, search, pendingCount, on
               status === opt.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
             }`}
           >
-            {opt.label}
-            {opt.key === 'pending' && pendingCount > 0 && (
-              <span className="ml-1 bg-border text-text text-[11px] px-1.5 py-0.5 rounded-full">
-                {pendingCount}
-              </span>
-            )}
+            {opt.key === 'pending' && pendingCount > 0
+              ? `${opt.label} (${pendingCount})`
+              : opt.label}
           </button>
         ))}
       </div>

--- a/frontend/src/components/approvals/ApprovalTable.tsx
+++ b/frontend/src/components/approvals/ApprovalTable.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import StatusBadge from '../common/StatusBadge'
 import { formatDateTime } from '../../utils/formatters'
 import type { Approval, ApprovalStatus, ApprovalType } from '../../types/approval'
@@ -19,19 +19,17 @@ const STATUS_VARIANT: Record<ApprovalStatus, string> = {
 }
 
 export default function ApprovalTable({ items }: { items: Approval[] }) {
-  const navigate = useNavigate()
-
   return (
     <div className="overflow-x-auto">
       <table className="w-full border-collapse">
         <thead>
           <tr>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">유형</th>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">제목</th>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">요청자</th>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">요청일</th>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">상태</th>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">처리일</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">유형</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">제목</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">요청자</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">요청일</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">상태</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">처리일</th>
           </tr>
         </thead>
         <tbody>
@@ -43,14 +41,19 @@ export default function ApprovalTable({ items }: { items: Approval[] }) {
             items.map((item) => (
                 <tr
                   key={item.id}
-                  onClick={() => navigate(`/approvals/${item.id}`)}
-                  className="hover:bg-surface-hover cursor-pointer"
+                  className="hover:bg-surface-hover"
                 >
                   <td className="px-3 py-3 border-b border-border text-[13px]">
                     <StatusBadge variant="muted">{TYPE_LABEL[item.type] || item.type}</StatusBadge>
                   </td>
-                  <td className="px-3 py-3 border-b border-border text-[13px]">{item.title}</td>
-                  <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{item.requester}</td>
+                  <td className="px-3 py-3 border-b border-border text-[13px]">
+                    <Link to={`/approvals/${item.id}`} className="text-primary no-underline hover:underline">
+                      {item.title}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-3 border-b border-border text-[13px]">
+                    <span className="text-primary">{item.requester}</span>
+                  </td>
                   <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{formatDateTime(item.requested_at)}</td>
                   <td className="px-3 py-3 border-b border-border text-[13px]">
                     <StatusBadge variant={STATUS_VARIANT[item.status] as 'warning'}>

--- a/frontend/src/components/approvals/ExecutionContent.tsx
+++ b/frontend/src/components/approvals/ExecutionContent.tsx
@@ -1,3 +1,4 @@
+import StatusBadge from '../common/StatusBadge'
 import type { ApprovalType } from '../../types/approval'
 
 interface ExecutionContentProps {
@@ -5,11 +6,11 @@ interface ExecutionContentProps {
   params?: Record<string, unknown>
 }
 
-const INFO_BANNERS: Record<ApprovalType, { text: string; variant: 'info' | 'warning' }> = {
+const INFO_BANNERS: Record<ApprovalType, { text: string; variant: 'info' | 'negative' }> = {
   strategy_adopt: { text: '승인 시 해당 전략이 채택(registered) 상태로 전환됩니다.', variant: 'info' },
   budget_change: { text: '승인 시 Treasury에서 예산이 즉시 재배분됩니다.', variant: 'info' },
   bot_create: { text: '승인 시 BotManager에서 봇이 즉시 생성됩니다.', variant: 'info' },
-  bot_stop: { text: '승인 시 해당 봇의 거래가 즉시 중지됩니다.', variant: 'warning' },
+  bot_stop: { text: '승인 시 해당 봇의 거래가 즉시 중지됩니다.', variant: 'negative' },
   rule_change: { text: '승인 시 RuleEngine에서 해당 봇의 규칙이 즉시 갱신됩니다.', variant: 'info' },
 }
 
@@ -17,18 +18,18 @@ function InfoBanner({ type }: { type: ApprovalType }) {
   const banner = INFO_BANNERS[type]
   if (!banner) return null
 
-  const isWarning = banner.variant === 'warning'
+  const isNegative = banner.variant === 'negative'
   return (
-    <div className={`${isWarning ? 'bg-warning/10 text-warning' : 'bg-info/10 text-info'} p-3 rounded text-[12px] mb-4`}>
-      {isWarning ? '\u26A0' : '\uD83D\uDCA1'} {banner.text}
+    <div className={`${isNegative ? 'bg-negative/10 text-negative' : 'bg-info/10 text-info'} p-3 rounded text-[12px] mb-4`}>
+      {isNegative ? '\u26A0' : '\uD83D\uDCA1'} {banner.text}
     </div>
   )
 }
 
 function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
   return (
-    <div className="flex justify-between py-2 border-b border-border text-[13px]">
-      <span className="text-text-muted">{label}</span>
+    <div className="flex justify-between py-2 border-b border-border last:border-b-0 text-[13px]">
+      <span className="text-text-muted min-w-[80px]">{label}</span>
       <span>{value}</span>
     </div>
   )
@@ -43,7 +44,9 @@ function formatCurrency(value: unknown): string {
 function StrategyAdoptContent({ params }: { params: Record<string, unknown> }) {
   return (
     <>
-      <InfoRow label="대상 전략" value={<span className="font-mono text-[12px]">{String(params.strategy_name ?? '-')}</span>} />
+      <InfoRow label="대상 전략" value={
+        <span className="font-mono text-[12px] text-primary">{String(params.strategy_name ?? '-')}</span>
+      } />
       <InfoRow label="버전" value={String(params.version ?? '-')} />
     </>
   )
@@ -55,23 +58,37 @@ function BudgetChangeContent({ params }: { params: Record<string, unknown> }) {
   const diff = requested - current
   const pct = current > 0 ? ((diff / current) * 100).toFixed(0) : '-'
   const sign = diff >= 0 ? '+' : ''
+  const colorClass = diff >= 0 ? 'text-positive' : 'text-negative'
 
   return (
     <>
-      <InfoRow label="대상 봇" value={<span className="font-mono text-[12px]">{String(params.bot_id ?? '-')}</span>} />
+      <InfoRow label="대상 봇" value={
+        <span className="font-mono text-[12px] text-primary">{String(params.bot_id ?? '-')}</span>
+      } />
       <InfoRow label="현재 예산" value={formatCurrency(current)} />
-      <InfoRow label="요청 예산" value={formatCurrency(requested)} />
-      <InfoRow label="변경폭" value={`${sign}${formatCurrency(diff)} (${sign}${pct}%)`} />
+      <InfoRow label="요청 예산" value={
+        <span className={`${colorClass} font-semibold`}>{formatCurrency(requested)}</span>
+      } />
+      <InfoRow label="변경폭" value={
+        <span className={colorClass}>{sign}{formatCurrency(diff)} ({sign}{pct}%)</span>
+      } />
     </>
   )
 }
 
 function BotCreateContent({ params }: { params: Record<string, unknown> }) {
+  const tradeMode = String(params.trade_mode ?? '-')
+  const isMock = tradeMode === 'mock' || tradeMode === '모의투자'
+
   return (
     <>
       <InfoRow label="전략명" value={<span className="font-mono text-[12px]">{String(params.strategy_name ?? '-')}</span>} />
       <InfoRow label="배정 예산" value={formatCurrency(params.budget)} />
-      <InfoRow label="거래 모드" value={String(params.trade_mode ?? '-')} />
+      <InfoRow label="거래 모드" value={
+        isMock
+          ? <StatusBadge variant="warning">모의투자</StatusBadge>
+          : <StatusBadge variant="positive">실전투자</StatusBadge>
+      } />
     </>
   )
 }
@@ -79,7 +96,9 @@ function BotCreateContent({ params }: { params: Record<string, unknown> }) {
 function BotStopContent({ params }: { params: Record<string, unknown> }) {
   return (
     <>
-      <InfoRow label="대상 봇" value={<span className="font-mono text-[12px]">{String(params.bot_id ?? '-')}</span>} />
+      <InfoRow label="대상 봇" value={
+        <span className="font-mono text-[12px] text-primary">{String(params.bot_id ?? '-')}</span>
+      } />
       <InfoRow label="중지 사유" value={String(params.reason ?? '-')} />
     </>
   )
@@ -94,7 +113,9 @@ function RuleChangeContent({ params }: { params: Record<string, unknown> }) {
 
   return (
     <>
-      <InfoRow label="대상 봇" value={<span className="font-mono text-[12px]">{String(params.bot_id ?? '-')}</span>} />
+      <InfoRow label="대상 봇" value={
+        <span className="font-mono text-[12px] text-primary">{String(params.bot_id ?? '-')}</span>
+      } />
       {rules.length > 0 && (
         <div className="mt-3">
           <div className="text-[12px] font-semibold text-text-muted mb-2">변경 규칙</div>
@@ -114,7 +135,7 @@ function RuleChangeContent({ params }: { params: Record<string, unknown> }) {
                     <td className="px-3 py-2 border-b border-border text-[13px] font-mono">{rule.name}</td>
                     <td className="px-3 py-2 border-b border-border text-[13px]">{String(rule.current_value)}</td>
                     <td className="text-center px-2 py-2 border-b border-border text-[13px] text-text-muted">&rarr;</td>
-                    <td className="px-3 py-2 border-b border-border text-[13px]">{String(rule.requested_value)}</td>
+                    <td className="px-3 py-2 border-b border-border text-[13px] text-warning font-semibold">{String(rule.requested_value)}</td>
                   </tr>
                 ))}
               </tbody>
@@ -140,7 +161,7 @@ export default function ExecutionContent({ type, params }: ExecutionContentProps
 
   return (
     <div className="bg-surface border border-border rounded-lg p-5 mb-6">
-      <h3 className="text-[15px] font-semibold mb-3">실행 내용</h3>
+      <h3 className="text-[15px] font-semibold mb-4">실행 내용</h3>
       <InfoBanner type={type} />
       <div className="space-y-0">
         <ContentComponent params={params} />

--- a/frontend/src/components/approvals/ReviewControls.tsx
+++ b/frontend/src/components/approvals/ReviewControls.tsx
@@ -1,16 +1,64 @@
 import { useState } from 'react'
 import { useUpdateApprovalStatus } from '../../hooks/useApprovals'
 import Modal from '../common/Modal'
-import type { ApprovalReview } from '../../types/approval'
+import StatusBadge from '../common/StatusBadge'
+import type { ApprovalReview, ApprovalType } from '../../types/approval'
+
+const APPROVE_ACTION_TEXT: Record<ApprovalType, string> = {
+  strategy_adopt: '전략이 채택 상태로 전환됩니다.',
+  budget_change: 'Treasury에서 예산이 즉시 재배분됩니다.',
+  bot_create: 'BotManager에서 봇이 즉시 생성됩니다.',
+  bot_stop: '해당 봇의 거래가 즉시 중지됩니다.',
+  rule_change: 'RuleEngine에서 해당 봇의 규칙이 즉시 갱신됩니다.',
+}
 
 interface ReviewControlsProps {
   approvalId: string
   isPending: boolean
   title: string
   reviews?: ApprovalReview[]
+  type?: ApprovalType
+  params?: Record<string, unknown>
 }
 
-export default function ReviewControls({ approvalId, isPending, title, reviews }: ReviewControlsProps) {
+function formatCurrency(value: unknown): string {
+  const num = Number(value)
+  if (isNaN(num)) return String(value ?? '-')
+  return `${num.toLocaleString()}원`
+}
+
+function ApproveModalSummary({ type, params }: { type?: ApprovalType; params?: Record<string, unknown> }) {
+  if (!type || !params) return null
+
+  if (type === 'bot_create') {
+    const tradeMode = String(params.trade_mode ?? '')
+    const isMock = tradeMode === 'mock' || tradeMode === '모의투자'
+    return (
+      <div className="text-[13px] text-text-muted mb-4">
+        전략: <span className="font-mono">{String(params.strategy_name ?? '-')}</span>
+        {' · '}예산: {formatCurrency(params.budget)}
+        {' · '}모드: {isMock
+          ? <StatusBadge variant="warning">모의투자</StatusBadge>
+          : <StatusBadge variant="positive">실전투자</StatusBadge>}
+      </div>
+    )
+  }
+
+  if (type === 'budget_change') {
+    const current = Number(params.current_budget ?? 0)
+    const requested = Number(params.requested_budget ?? 0)
+    const diff = requested - current
+    return (
+      <div className="text-[13px] text-text-muted mb-4">
+        예산: {formatCurrency(current)} → <strong className="text-positive">{formatCurrency(requested)}</strong> ({diff >= 0 ? '+' : ''}{formatCurrency(diff)})
+      </div>
+    )
+  }
+
+  return null
+}
+
+export default function ReviewControls({ approvalId, isPending, title, reviews, type, params }: ReviewControlsProps) {
   const [showApprove, setShowApprove] = useState(false)
   const [showReject, setShowReject] = useState(false)
   const [rejectReason, setRejectReason] = useState('')
@@ -56,6 +104,12 @@ export default function ReviewControls({ approvalId, isPending, title, reviews }
         <div className="text-[13px] text-text-muted mb-4">
           <strong className="text-text">{title}</strong>을 승인하시겠습니까?
         </div>
+        <ApproveModalSummary type={type} params={params} />
+        {type && (
+          <div className="bg-info/10 text-info p-3 rounded text-[12px] mb-4">
+            {'\uD83D\uDCA1'} 승인 시 <strong>{APPROVE_ACTION_TEXT[type]}</strong>
+          </div>
+        )}
         {hasWarnings && (
           <div className="bg-warning/10 text-warning p-3 rounded text-[12px] mb-4">
             {'\u26A0'} 검토 의견에 <strong>warn</strong> 또는 <strong>fail</strong> 결과가 포함되어 있습니다. 검증 내용을 확인하세요.

--- a/frontend/src/pages/ApprovalDetail.tsx
+++ b/frontend/src/pages/ApprovalDetail.tsx
@@ -29,14 +29,13 @@ const REVIEW_RESULT_VARIANT: Record<string, string> = {
   fail: 'negative',
 }
 
-const ACTOR_COLOR: Record<string, string> = {
-  user: 'text-positive',
-  rule_engine: 'text-text-muted',
-  treasury: 'text-text-muted',
-}
-
-function getActorColor(actor: string): string {
-  if (actor in ACTOR_COLOR) return ACTOR_COLOR[actor]
+function getActorColor(actor: string, action?: string): string {
+  if (actor === 'user') {
+    if (action === 'approved' || action === 'approve') return 'text-positive'
+    if (action === 'rejected' || action === 'reject') return 'text-negative'
+    return 'text-positive'
+  }
+  if (actor === 'rule_engine' || actor === 'treasury') return 'text-text-muted'
   if (actor.startsWith('agent:')) return 'text-primary'
   return 'text-text-muted'
 }
@@ -46,9 +45,11 @@ function ApprovalInfoCard({ approval }: { approval: Approval }) {
   const typeLabel = TYPE_LABEL[approval.type] || approval.type
   return (
     <div className="bg-surface border border-border rounded-lg p-5">
-      <h3 className="text-[15px] font-semibold mb-3">결재 정보</h3>
+      <h3 className="text-[15px] font-semibold mb-4">결재 정보</h3>
       <div className="space-y-0">
-        <InfoRow label="요청자" value={approval.requester} />
+        <InfoRow label="요청자" value={
+          <span className="text-primary">{approval.requester}</span>
+        } />
         <InfoRow label="유형" value={typeLabel} />
         <InfoRow label="상태" value={
           <StatusBadge variant={STATUS_VARIANT[approval.status] as 'warning'}>
@@ -56,7 +57,9 @@ function ApprovalInfoCard({ approval }: { approval: Approval }) {
           </StatusBadge>
         } />
         <InfoRow label="요청일" value={formatDateTime(approval.requested_at)} />
-        {approval.expires_at && <InfoRow label="만료일" value={formatDateTime(approval.expires_at)} />}
+        {approval.status === 'pending' && approval.expires_at && (
+          <InfoRow label="만료일" value={formatDateTime(approval.expires_at)} />
+        )}
         {approval.resolved_at && <InfoRow label="처리일" value={formatDateTime(approval.resolved_at)} />}
         {approval.resolved_by && <InfoRow label="처리자" value={approval.resolved_by} />}
         {approval.reference_id && (
@@ -75,7 +78,7 @@ function ApprovalInfoCard({ approval }: { approval: Approval }) {
 function ReviewsCard({ reviews }: { reviews: ApprovalReview[] }) {
   return (
     <div className="bg-surface border border-border rounded-lg p-5">
-      <h3 className="text-[15px] font-semibold mb-3">검토 의견</h3>
+      <h3 className="text-[15px] font-semibold mb-4">검토 의견</h3>
       {reviews.length === 0 ? (
         <div className="text-[13px] text-text-muted py-4 text-center">검토 의견이 없습니다</div>
       ) : (
@@ -114,7 +117,7 @@ function ReviewsCard({ reviews }: { reviews: ApprovalReview[] }) {
 function AuditHistoryCard({ history }: { history: ApprovalHistoryEntry[] }) {
   return (
     <div className="bg-surface border border-border rounded-lg p-5">
-      <h3 className="text-[15px] font-semibold mb-3">감사 이력</h3>
+      <h3 className="text-[15px] font-semibold mb-4">감사 이력</h3>
       {history.length === 0 ? (
         <div className="text-[13px] text-text-muted py-4 text-center">이력이 없습니다</div>
       ) : (
@@ -123,7 +126,7 @@ function AuditHistoryCard({ history }: { history: ApprovalHistoryEntry[] }) {
             <div key={i} className="flex items-start gap-4 py-2.5 border-b border-border last:border-b-0">
               <span className="text-[12px] text-text-muted whitespace-nowrap min-w-[130px]">{formatDateTime(entry.at)}</span>
               <span className="text-[13px]">
-                <span className={`font-mono ${getActorColor(entry.actor)}`}>{entry.actor}</span>
+                <span className={`font-mono ${getActorColor(entry.actor, entry.action)}`}>{entry.actor}</span>
                 {' — '}
                 {entry.detail || entry.action}
               </span>
@@ -139,7 +142,7 @@ function AuditHistoryCard({ history }: { history: ApprovalHistoryEntry[] }) {
 function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div className="flex justify-between py-2 border-b border-border last:border-b-0 text-[13px]">
-      <span className="text-text-muted">{label}</span>
+      <span className="text-text-muted min-w-[80px]">{label}</span>
       <span>{value}</span>
     </div>
   )
@@ -160,14 +163,17 @@ export default function ApprovalDetail() {
       {/* 상세 헤더 */}
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-[20px] font-bold">{approval.title}</h2>
-        {isPending && <ReviewControls approvalId={approval.id} isPending={isPending} title={approval.title} reviews={approval.reviews} />}
+        {isPending && <ReviewControls approvalId={approval.id} isPending={isPending} title={approval.title} reviews={approval.reviews} type={approval.type} params={approval.params} />}
       </div>
 
       {/* 거부 사유 배너 */}
-      {approval.reject_reason && (
-        <div className="bg-negative/10 border border-negative/30 rounded-lg p-4 mb-6 text-[13px]">
-          <div className="font-semibold text-negative mb-1">거부 사유</div>
-          <div className="text-text-muted">{approval.reject_reason}</div>
+      {approval.status === 'rejected' && approval.reject_reason && (
+        <div className="bg-negative/10 text-negative rounded-lg px-[18px] py-[14px] mb-6 flex items-start gap-2.5 text-[13px]">
+          <span className="text-[16px] leading-none mt-0.5">{'\u2715'}</span>
+          <div>
+            <div className="font-semibold mb-1">거부 사유</div>
+            <div className="text-[12px]">{approval.reject_reason}</div>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
Closes #335

- 결재함 목록: 필터 탭 카운트 표기 개선, 테이블 제목을 Link 컴포넌트로 변경, 헤더 스타일 목업 일치
- 결재 상세 5종(전략 채택/예산 변경/봇 생성/봇 중지/규칙 변경): 거부 사유 배너, 실행 내용 색상/배지, 감사 이력 actor 색상, 승인 모달 유형별 요약 정보 등 목업 충실도 전면 개선
- 공통: 카드 제목 간격, InfoRow 라벨 최소폭, 대상 봇/전략 링크 색상 통일

## Changes
- `ApprovalFilters.tsx`: 대기 탭 카운트를 괄호 표기로 변경
- `ApprovalTable.tsx`: 제목을 Link로, 요청자 primary 색상, 헤더 uppercase 제거
- `ApprovalDetail.tsx`: 거부 배너 X 아이콘 레이아웃, 요청자 링크, actor 색상 분기
- `ExecutionContent.tsx`: bot_stop negative 배너, budget 색상 강조, bot_create 모드 배지, rule_change 요청값 warning
- `ReviewControls.tsx`: 승인 모달에 유형별 실행 안내 + 요약 정보 추가

## Test plan
- [ ] 결재 목록 페이지에서 필터 탭, 테이블 렌더링 확인
- [ ] 전략 채택 상세: 결재 정보, 검토 의견, 본문, 실행 내용, 감사 이력, 승인/거부 모달
- [ ] 예산 변경 상세: 요청 예산 색상 강조, 변경폭 표시
- [ ] 봇 생성 상세: 거래 모드 배지, 승인 모달 요약
- [ ] 봇 중지 상세: negative 배너, 승인 완료 시 액션 버튼 미표시
- [ ] 규칙 변경 상세: 거부 상태 배너, 요청값 warning 색상, 감사 이력 거부 actor 색상

🤖 Generated with [Claude Code](https://claude.com/claude-code)