### PR TITLE
fix(dashboard): 승인 대기 카드 목업 충실도 개선

### DIFF
--- a/frontend/src/components/dashboard/PendingApprovals.tsx
+++ b/frontend/src/components/dashboard/PendingApprovals.tsx
@@ -3,9 +3,14 @@ import { useApprovals, useUpdateApprovalStatus } from '../../hooks/useApprovals'
 import { formatDateTime } from '../../utils/formatters'
 import StatusBadge from '../common/StatusBadge'
 import { TableSkeleton } from '../common/Skeleton'
-import type { Approval, ApprovalType } from '../../types/approval'
+import type { Approval } from '../../types/approval'
 
-const TYPE_LABELS: Record<ApprovalType, { label: string; variant: string }> = {
+const TYPE_LABELS: Record<string, { label: string; variant: string }> = {
+  strategy_report: { label: '전략 리포트', variant: 'info' },
+  budget_allocate: { label: '예산 할당', variant: 'primary' },
+  live_switch: { label: '실전 전환', variant: 'warning' },
+  risk_alert: { label: '위험 알림', variant: 'negative' },
+  // 레거시 타입 호환
   strategy_adopt: { label: '전략 채택', variant: 'info' },
   budget_change: { label: '예산 변경', variant: 'primary' },
   bot_create: { label: '봇 생성', variant: 'positive' },
@@ -57,22 +62,24 @@ export default function PendingApprovals() {
               </tr>
             </thead>
             <tbody>
-              {items.map((item: Approval) => {
+              {items.map((item: Approval, idx: number) => {
                 const typeInfo = TYPE_LABELS[item.type] || { label: item.type, variant: 'muted' }
+                const isLast = idx === items.length - 1
+                const borderCls = isLast ? '' : 'border-b border-border'
                 return (
                   <tr key={item.id} className="hover:bg-surface-hover">
-                    <td className="px-3 py-3 border-b border-border text-[13px]">
+                    <td className={`px-3 py-3 text-[13px] ${borderCls}`}>
                       <StatusBadge variant={typeInfo.variant as 'info'}>{typeInfo.label}</StatusBadge>
                     </td>
-                    <td className="px-3 py-3 border-b border-border text-[13px]">
+                    <td className={`px-3 py-3 text-[13px] ${borderCls}`}>
                       <Link to={`/approvals/${item.id}`} className="text-primary no-underline hover:underline">
                         {item.title}
                       </Link>
                     </td>
-                    <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">
+                    <td className={`px-3 py-3 text-[13px] text-text-muted ${borderCls}`}>
                       {formatDateTime(item.requested_at)}
                     </td>
-                    <td className="px-3 py-3 border-b border-border text-[13px] text-right">
+                    <td className={`px-3 py-3 text-[13px] text-right ${borderCls}`}>
                       <div className="flex gap-2 justify-end">
                         <button
                           onClick={() => handleAction(item.id, 'approved')}

--- a/frontend/src/types/approval.ts
+++ b/frontend/src/types/approval.ts
@@ -1,5 +1,14 @@
 export type ApprovalStatus = 'pending' | 'approved' | 'rejected'
-export type ApprovalType = 'strategy_adopt' | 'budget_change' | 'bot_create' | 'bot_stop' | 'rule_change'
+export type ApprovalType =
+  | 'strategy_report'
+  | 'budget_allocate'
+  | 'live_switch'
+  | 'risk_alert'
+  | 'strategy_adopt'
+  | 'budget_change'
+  | 'bot_create'
+  | 'bot_stop'
+  | 'rule_change'
 
 export interface ApprovalReview {
   reviewer: string


### PR DESCRIPTION
## Summary
- 목업 HTML(`docs/dashboard/mockups/dashboard.html`)과 현재 대시보드 구현을 비교하여 차이점 수정
- 승인 대기 카드의 결재 유형 레이블/배지를 목업 기준(전략 리포트, 예산 할당, 실전 전환, 위험 알림)에 맞게 추가
- `ApprovalType`에 `architecture.md` §3.3에 정의된 4개 타입(`strategy_report`, `budget_allocate`, `live_switch`, `risk_alert`) 반영
- 테이블 마지막 행 하단 border 제거로 목업 스타일 일치
- 기존 타입은 레거시 호환 유지

Closes #334

## Test plan
- [x] `pytest tests/ --ignore=tests/e2e` 전체 통과 (1587 passed)
- [ ] 브라우저에서 대시보드 페이지 열어 승인 대기 카드 렌더링 확인
- [ ] 각 결재 유형별 배지 색상이 목업과 일치하는지 확인
- [ ] 마지막 행 하단 border가 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)