### PR TITLE
목업 충실도: 에이전트 관리 (목록 + 상세)

### DIFF
--- a/frontend/src/components/agents/AgentRegisterForm.tsx
+++ b/frontend/src/components/agents/AgentRegisterForm.tsx
@@ -1,18 +1,25 @@
 import { useState } from 'react'
-import { useCreateMember } from '../../hooks/useMembers'
+import { useCreateMember, useMembers } from '../../hooks/useMembers'
 import { ALL_SCOPES } from '../../types/member'
+
+const DEFAULT_ORGS = ['default', 'strategy-lab', 'risk', 'treasury', 'operations']
 
 interface AgentRegisterFormProps {
   onClose: () => void
-  onTokenCreated: (token: string) => void
+  onTokenCreated: (agentId: string, token: string) => void
 }
 
 export default function AgentRegisterForm({ onClose, onTokenCreated }: AgentRegisterFormProps) {
   const [memberId, setMemberId] = useState('')
   const [name, setName] = useState('')
-  const [org, setOrg] = useState('')
+  const [org, setOrg] = useState('default')
   const [scopes, setScopes] = useState<string[]>([])
   const createMember = useCreateMember()
+
+  // 기존 소속 목록에서 동적으로 추출, 기본값과 병합
+  const { data: allMembers } = useMembers({})
+  const existingOrgs = Array.from(new Set((allMembers ?? []).map((m) => m.org).filter(Boolean)))
+  const orgOptions = Array.from(new Set([...DEFAULT_ORGS, ...existingOrgs]))
 
   const toggleScope = (scope: string) => {
     setScopes((prev) => prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope])
@@ -22,7 +29,7 @@ export default function AgentRegisterForm({ onClose, onTokenCreated }: AgentRegi
     e.preventDefault()
     createMember.mutate(
       { member_id: memberId, name, org, scopes },
-      { onSuccess: (data) => onTokenCreated(data.token) },
+      { onSuccess: (data) => onTokenCreated(memberId, data.token) },
     )
   }
 
@@ -33,18 +40,27 @@ export default function AgentRegisterForm({ onClose, onTokenCreated }: AgentRegi
         <form onSubmit={handleSubmit}>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">Agent ID</label>
-            <input value={memberId} onChange={(e) => setMemberId(e.target.value)} placeholder="agent-research-01" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
+            <input value={memberId} onChange={(e) => setMemberId(e.target.value)} placeholder="strategy-dev-03" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
+            <div className="text-[12px] text-text-muted mt-1">영문, 숫자, 하이픈만 사용 가능</div>
           </div>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">이름</label>
-            <input value={name} onChange={(e) => setName(e.target.value)} placeholder="리서치 에이전트" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
+            <input value={name} onChange={(e) => setName(e.target.value)} placeholder="전략 리서치 3호" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
           </div>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">소속 (org)</label>
-            <input value={org} onChange={(e) => setOrg(e.target.value)} placeholder="research" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
+            <select
+              value={org}
+              onChange={(e) => setOrg(e.target.value)}
+              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary cursor-pointer"
+            >
+              {orgOptions.map((o) => (
+                <option key={o} value={o}>{o}</option>
+              ))}
+            </select>
           </div>
           <div className="mb-4">
-            <label className="block text-[12px] font-semibold text-text-muted mb-2">권한 범위</label>
+            <label className="block text-[12px] font-semibold text-text-muted mb-2">권한 범위 (Scopes)</label>
             <div className="grid grid-cols-2 gap-2">
               {ALL_SCOPES.map((scope) => (
                 <label key={scope} className="flex items-center gap-2 text-[13px] cursor-pointer">

--- a/frontend/src/components/agents/MemberCard.tsx
+++ b/frontend/src/components/agents/MemberCard.tsx
@@ -33,68 +33,114 @@ export default function MemberCard({ member, onSuspend, onReactivate, onRevoke, 
   const role = member.role ?? (isOwner ? 'owner' : undefined)
 
   const isRevoked = member.status === 'revoked'
+  const isHuman = member.type === 'human'
+  const isAgent = member.type === 'agent'
+
+  const avatarColorClass = isHuman
+    ? 'bg-info-bg text-info'
+    : 'bg-positive-bg text-positive'
 
   return (
     <div
-      onClick={() => navigate(`/members/${member.member_id}`)}
-      className={`bg-surface border border-border rounded-lg p-5 flex gap-4 items-start cursor-pointer hover:border-primary/50 transition-colors${isRevoked ? ' opacity-50' : ''}`}
+      onClick={() => isAgent ? navigate(`/members/${member.member_id}`) : undefined}
+      className={`bg-surface border border-border rounded-lg p-5 flex gap-5 transition-colors${isRevoked ? ' opacity-50' : ''}${isAgent ? ' cursor-pointer hover:border-primary/50' : ''}`}
     >
-      <div className="relative shrink-0">
-        {role === 'owner' && (
-          <div className="absolute -top-3 left-1/2 -translate-x-1/2 text-[16px] leading-none">
+      {/* 프로필 아바타 */}
+      <div className="relative shrink-0 flex items-start justify-center">
+        {isOwner && (
+          <div className="absolute -top-[13px] left-1/2 -translate-x-1/2 text-[16px] leading-none">
             {'👑'}
           </div>
         )}
-        <div className={`w-[56px] h-[56px] rounded-full bg-bg flex items-center justify-center text-[28px]${isRevoked ? ' blur-[2px]' : ''}`}>
-          {member.emoji || (member.type === 'human' ? '👤' : '🤖')}
+        <div className={`w-[72px] h-[72px] rounded-full flex items-center justify-center text-[45px] shrink-0 transition-transform hover:scale-[1.15] hover:-rotate-[8deg] cursor-default ${avatarColorClass}${isRevoked ? ' opacity-50' : ''}`}>
+          {member.emoji || (isHuman ? '👤' : '🤖')}
         </div>
       </div>
+
+      {/* 카드 본문 */}
       <div className="flex-1 min-w-0">
-        <div className="flex items-center justify-between mb-1">
-          <div className="flex items-center gap-2">
-            <span className="text-[15px] font-semibold">{member.name}</span>
-            {role && (
-              <span className={`text-[11px] font-medium px-1.5 py-0.5 rounded ${ROLE_BADGE_STYLE[role]}`}>
-                {ROLE_LABELS[role]}
-              </span>
-            )}
+        {/* 헤더: ID + 역할/상태 뱃지 */}
+        <div className="flex items-center justify-between mb-[10px]">
+          <div>
+            <div className="text-[15px] font-semibold">{member.member_id}</div>
+            <div className="text-[13px] text-text-muted">{member.name}</div>
           </div>
-          <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>{MEMBER_STATUS_LABELS[member.status]}</StatusBadge>
+          {isHuman && role ? (
+            <span className={`text-[11px] font-medium px-1.5 py-0.5 rounded ${ROLE_BADGE_STYLE[role]}`}>
+              {ROLE_LABELS[role]}
+            </span>
+          ) : (
+            <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>
+              {MEMBER_STATUS_LABELS[member.status]}
+            </StatusBadge>
+          )}
         </div>
-        <div className="text-[13px] text-text-muted font-mono mb-2">{member.member_id}</div>
-        <div className="text-[12px] text-text-muted mb-3">소속: {member.org}</div>
-        {member.scopes && member.scopes.length > 0 && (
-          <div className="flex flex-wrap gap-1 mb-3">
-            {member.scopes.slice(0, 4).map((scope) => (
-              <span key={scope} className="bg-bg text-text-muted text-[11px] px-2 py-0.5 rounded">{scope}</span>
+
+        {/* 메타 정보 */}
+        <div className="flex flex-col gap-1.5 text-[13px] text-text-muted mb-4">
+          {isHuman ? (
+            <>
+              <div className="flex justify-between">
+                <span className="text-text-muted">상태</span>
+                <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>
+                  {MEMBER_STATUS_LABELS[member.status]}
+                </StatusBadge>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-text-muted">소속</span>
+                <span>{member.org}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-text-muted">마지막 활동</span>
+                <span>{member.last_active_at || '-'}</span>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="flex justify-between">
+                <span className="text-text-muted">소속</span>
+                <StatusBadge variant="muted">{member.org}</StatusBadge>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-text-muted">마지막 활동</span>
+                <span>{member.last_active_at || '-'}</span>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* 스코프 태그 (에이전트만) */}
+        {isAgent && member.scopes && member.scopes.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {member.scopes.map((scope) => (
+              <span key={scope} className="text-[11px] px-1.5 py-[1px] rounded-sm bg-bg border border-border text-text-muted">{scope}</span>
             ))}
-            {member.scopes.length > 4 && (
-              <span className="text-text-muted text-[11px]">+{member.scopes.length - 4}</span>
-            )}
           </div>
         )}
+
         {/* Human 멤버 액션 버튼 */}
-        {!isRevoked && member.type === 'human' && (onSuspend || onChangePassword) && (
+        {!isRevoked && isHuman && (onSuspend || onChangePassword) && (
           <div className="flex gap-2 justify-end" onClick={(e) => e.stopPropagation()}>
             {!isOwner && member.status === 'active' && onSuspend && (
-              <button onClick={() => onSuspend(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-warning border border-border cursor-pointer hover:bg-warning-bg">정지</button>
+              <button onClick={() => onSuspend(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">정지</button>
             )}
             {onChangePassword && (
               <button onClick={() => onChangePassword(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">비밀번호 변경</button>
             )}
           </div>
         )}
+
         {/* Agent 멤버 액션 버튼 */}
-        {!isRevoked && member.type === 'agent' && (onSuspend || onReactivate || onRevoke) && (
-          <div className="flex gap-2 justify-end" onClick={(e) => e.stopPropagation()}>
+        {!isRevoked && isAgent && (onSuspend || onReactivate || onRevoke) && (
+          <div className="flex gap-2 justify-end mt-3" onClick={(e) => e.stopPropagation()}>
             {member.status === 'active' && onSuspend && (
-              <button onClick={() => onSuspend(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-warning border border-border cursor-pointer hover:bg-warning-bg">정지</button>
+              <button onClick={() => onSuspend(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">정지</button>
             )}
             {member.status === 'suspended' && onReactivate && (
               <button onClick={() => onReactivate(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">재활성화</button>
             )}
-            {member.status !== 'revoked' && onRevoke && (
-              <button onClick={() => onRevoke(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-negative border border-border cursor-pointer hover:bg-negative-bg">폐기</button>
+            {onRevoke && (
+              <button onClick={() => onRevoke(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-negative border-none cursor-pointer hover:bg-negative-bg">폐기</button>
             )}
           </div>
         )}

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -34,157 +34,164 @@ export default function AgentDetail() {
 
   return (
     <>
-      {/* 브레드크럼 */}
-      <Link to="/agents" className="inline-flex items-center gap-1 text-[13px] text-text-muted hover:text-text mb-4 no-underline">
-        ← 에이전트 관리
-      </Link>
-
-      {/* 헤더 */}
-      <div className="flex items-center justify-between mb-6">
-        <div className="flex items-center gap-4">
-          <div className="w-[56px] h-[56px] rounded-full bg-surface border border-border flex items-center justify-center text-[28px] shrink-0">
-            {member.emoji || (member.type === 'human' ? '👤' : '🤖')}
+      {/* 에이전트 정보 헤더 — 목업 detail-header 기준 */}
+      <div className="flex items-center justify-between mb-6 pb-4 border-b border-border">
+        <div>
+          <h2 className="text-[20px] font-bold font-mono mb-1">{member.member_id}</h2>
+          <div className="flex gap-2 items-center">
+            <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>
+              {MEMBER_STATUS_LABELS[member.status]}
+            </StatusBadge>
+            <StatusBadge variant="muted">{member.org}</StatusBadge>
+            <span className="text-text-muted text-[13px]">{member.name}</span>
           </div>
-          <div>
-            <h2 className="text-[20px] font-bold font-mono">{member.member_id}</h2>
-            <div className="flex gap-3 items-center mt-1">
-              <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded">{member.org}</span>
-              <span className="text-text-muted text-[13px]">{member.name}</span>
+        </div>
+        <div className="flex gap-2">
+          {member.status === 'active' && (
+            <button onClick={() => suspend.mutate(member.member_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">정지</button>
+          )}
+          {member.status === 'suspended' && (
+            <button onClick={() => reactivate.mutate(member.member_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">재활성화</button>
+          )}
+          {member.status !== 'revoked' && (
+            <button onClick={() => { if (confirm('영구 폐기하시겠습니까?')) revoke.mutate(member.member_id) }} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative-hover">폐기</button>
+          )}
+        </div>
+      </div>
+
+      {/* 기본 정보 + 활동 정보 — 목업 detail-grid 기준 (2열) */}
+      <div className="grid grid-cols-2 gap-6 mb-6">
+        {/* 기본 정보 */}
+        <div className="bg-surface border border-border rounded-lg p-5">
+          <h3 className="text-[15px] font-semibold mb-4">기본 정보</h3>
+          <div className="space-y-0">
+            <div className="flex justify-between py-2.5 border-b border-border text-[13px]">
+              <span className="text-text-muted">Agent ID</span>
+              <span className="font-mono">{member.member_id}</span>
+            </div>
+            <div className="flex justify-between py-2.5 border-b border-border text-[13px]">
+              <span className="text-text-muted">이름</span>
+              <span>{member.name}</span>
+            </div>
+            <div className="flex justify-between py-2.5 border-b border-border text-[13px]">
+              <span className="text-text-muted">소속</span>
+              <span>{member.org}</span>
+            </div>
+            <div className="flex justify-between py-2.5 text-[13px]">
+              <span className="text-text-muted">상태</span>
               <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>
                 {MEMBER_STATUS_LABELS[member.status]}
               </StatusBadge>
             </div>
           </div>
         </div>
-        <div className="flex gap-2">
-          {member.status === 'active' && (
-            <button onClick={() => suspend.mutate(member.member_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-warning border border-border cursor-pointer hover:bg-warning-bg">정지</button>
-          )}
-          {member.status === 'suspended' && (
-            <button onClick={() => reactivate.mutate(member.member_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">재활성화</button>
-          )}
-          {member.status !== 'revoked' && (
-            <button onClick={() => { if (confirm('영구 폐기하시겠습니까?')) revoke.mutate(member.member_id) }} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-negative border border-border cursor-pointer hover:bg-negative-bg">폐기</button>
-          )}
-        </div>
-      </div>
 
-      {/* 기본 정보 카드 */}
-      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
-        <h3 className="text-[15px] font-semibold mb-3">기본 정보</h3>
-        <div className="grid grid-cols-2 gap-x-8 gap-y-2">
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">Agent ID</span>
-            <span className="font-mono">{member.member_id}</span>
-          </div>
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">이름</span>
-            <span>{member.name}</span>
-          </div>
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">소속</span>
-            <span>{member.org}</span>
-          </div>
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">상태</span>
-            <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>
-              {MEMBER_STATUS_LABELS[member.status]}
-            </StatusBadge>
+        {/* 활동 정보 */}
+        <div className="bg-surface border border-border rounded-lg p-5">
+          <h3 className="text-[15px] font-semibold mb-4">활동 정보</h3>
+          <div className="space-y-0">
+            <div className="flex justify-between py-2.5 border-b border-border text-[13px]">
+              <span className="text-text-muted">생성일</span>
+              <span>{formatDateTime(member.created_at)}</span>
+            </div>
+            <div className="flex justify-between py-2.5 border-b border-border text-[13px]">
+              <span className="text-text-muted">생성자</span>
+              <span>{member.created_by || '-'}</span>
+            </div>
+            <div className="flex justify-between py-2.5 border-b border-border text-[13px]">
+              <span className="text-text-muted">마지막 활동</span>
+              <span>{member.last_active_at ? formatDateTime(member.last_active_at) : '-'}</span>
+            </div>
+            <div className="flex justify-between py-2.5 text-[13px]">
+              <span className="text-text-muted">정지 시각</span>
+              <span className={member.suspended_at ? '' : 'text-text-muted'}>{member.suspended_at ? formatDateTime(member.suspended_at) : '-'}</span>
+            </div>
           </div>
         </div>
       </div>
 
-      {/* 토큰 관리 */}
+      {/* 토큰 관리 — 목업 기준 */}
       <div className="bg-surface border border-border rounded-lg p-5 mb-6">
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center justify-between">
           <h3 className="text-[15px] font-semibold">토큰 관리</h3>
+        </div>
+        <div className="flex items-center gap-4 mt-3">
+          <div className="flex-1">
+            {member.token_prefix && (
+              <div className="flex justify-between py-2.5 border-b border-border text-[13px]">
+                <span className="text-text-muted">토큰 접두어</span>
+                <span className="font-mono">{member.token_prefix}****</span>
+              </div>
+            )}
+          </div>
           <button
             onClick={handleRotateToken}
             disabled={member.status === 'revoked'}
-            className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover disabled:opacity-40"
+            className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover disabled:opacity-40 shrink-0"
           >
             토큰 재발급
           </button>
         </div>
-        {member.token_prefix && (
-          <div className="flex justify-between py-2 border-b border-border text-[13px] mb-3">
-            <span className="text-text-muted">토큰 접두어</span>
-            <span className="font-mono">{member.token_prefix}****</span>
-          </div>
-        )}
-        <p className="text-[12px] text-warning">기존 토큰이 즉시 무효화됩니다</p>
+        <p className="text-[12px] text-warning mt-2">{'⚠'} 토큰 재발급 시 기존 토큰이 즉시 무효화됩니다.</p>
       </div>
 
-      {/* 권한 범위 */}
-      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
-        <div className="flex items-center justify-between mb-3">
-          <h3 className="text-[15px] font-semibold">권한 범위</h3>
+      {/* 권한 범위 (Scopes) — 목업 기준 */}
+      <div className="bg-surface border border-border rounded-lg p-5">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-[15px] font-semibold">권한 범위 (Scopes)</h3>
           {!editingScopes ? (
             <button onClick={startEditScopes} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">편집</button>
-          ) : (
+          ) : null}
+        </div>
+
+        {/* 현재 scope 표시 */}
+        <div className="flex flex-wrap gap-1 mb-4">
+          {member.scopes.map((s) => (
+            <span key={s} className="text-[11px] px-1.5 py-[1px] rounded-sm bg-bg border border-border text-text-muted font-mono">{s}</span>
+          ))}
+        </div>
+
+        {/* scope 편집 (토글) */}
+        {editingScopes && (
+          <div className="border-t border-border pt-4">
+            <div className="grid grid-cols-2 gap-2 mb-4">
+              {ALL_SCOPES.map((scope) => (
+                <label key={scope} className="flex items-center gap-2 text-[13px] cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={scopesDraft.includes(scope)}
+                    onChange={() => setScopesDraft((prev) => prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope])}
+                    className="accent-primary"
+                  />
+                  <span className="font-mono text-[12px]">{scope}</span>
+                </label>
+              ))}
+            </div>
             <div className="flex gap-2">
               <button onClick={() => { updateScopes.mutate({ id: member.member_id, scopes: scopesDraft }); setEditingScopes(false) }} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">저장</button>
               <button onClick={() => setEditingScopes(false)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
             </div>
-          )}
-        </div>
-        {editingScopes ? (
-          <div className="grid grid-cols-2 gap-2">
-            {ALL_SCOPES.map((scope) => (
-              <label key={scope} className="flex items-center gap-2 text-[13px] cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={scopesDraft.includes(scope)}
-                  onChange={() => setScopesDraft((prev) => prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope])}
-                  className="accent-primary"
-                />
-                <span className="font-mono text-[12px]">{scope}</span>
-              </label>
-            ))}
-          </div>
-        ) : (
-          <div className="flex flex-wrap gap-1.5">
-            {member.scopes.map((s) => (
-              <span key={s} className="px-2 py-0.5 bg-positive-bg text-primary rounded text-[11px] font-medium font-mono">{s}</span>
-            ))}
           </div>
         )}
-      </div>
-
-      {/* 활동 정보 */}
-      <div className="bg-surface border border-border rounded-lg p-5">
-        <h3 className="text-[15px] font-semibold mb-3">활동 정보</h3>
-        <div className="space-y-2">
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">생성일</span>
-            <span>{formatDateTime(member.created_at)}</span>
-          </div>
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">생성자</span>
-            <span>{member.created_by || '-'}</span>
-          </div>
-          {member.suspended_at && (
-            <div className="flex justify-between py-2 border-b border-border text-[13px]">
-              <span className="text-text-muted">정지 시각</span>
-              <span>{formatDateTime(member.suspended_at)}</span>
-            </div>
-          )}
-          <div className="flex justify-between py-2 text-[13px]">
-            <span className="text-text-muted">마지막 활동</span>
-            <span>{member.last_active_at ? formatDateTime(member.last_active_at) : '-'}</span>
-          </div>
-        </div>
       </div>
 
       {/* 토큰 표시 모달 */}
       {newToken && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
-          <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
-            <h3 className="text-[18px] font-bold mb-4">새 토큰 발급 완료</h3>
-            <p className="text-[13px] text-warning mb-3">이 토큰은 다시 확인할 수 없습니다.</p>
-            <div className="bg-bg border border-border rounded-lg p-3 font-mono text-[12px] break-all mb-4">{newToken}</div>
-            <div className="flex justify-end gap-2">
-              <button onClick={() => navigator.clipboard.writeText(newToken)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">복사</button>
+          <div className="bg-surface border border-border rounded-lg p-6 w-[480px] text-center">
+            <h3 className="text-[18px] font-bold mb-4 text-positive">{'✓'} 새 토큰 발급 완료</h3>
+
+            <div className="my-5">
+              <div className="text-[12px] font-semibold text-text-muted">발급된 토큰</div>
+              <div className="bg-bg border border-border rounded-lg p-3.5 font-mono text-[13px] break-all text-left mt-2">{newToken}</div>
+            </div>
+
+            <div className="bg-warning-bg text-warning p-3 rounded-lg text-[13px] mb-5 text-left">
+              {'⚠'} 이 토큰은 다시 표시되지 않습니다. 안전한 곳에 복사해 두세요.
+            </div>
+
+            <div className="flex justify-center gap-2">
+              <button onClick={() => navigator.clipboard.writeText(newToken)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">토큰 복사</button>
               <button onClick={() => setNewToken(null)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">닫기</button>
             </div>
           </div>

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -16,7 +16,7 @@ export default function Agents() {
   const [orgFilter, setOrgFilter] = useState<string>('all')
   const [statusFilter, setStatusFilter] = useState<MemberStatus | 'all'>('all')
   const [showRegister, setShowRegister] = useState(false)
-  const [createdToken, setCreatedToken] = useState<string | null>(null)
+  const [createdToken, setCreatedToken] = useState<{ agentId: string; token: string } | null>(null)
 
   const { data: allMembers, isLoading } = useMembers({})
   const { data: humanMembers } = useMembers({ type: 'human' })
@@ -50,13 +50,13 @@ export default function Agents() {
           {/* Human 멤버 섹션 */}
           <div className="mb-8">
             <div className="flex items-center gap-2 text-[15px] font-semibold text-text-muted mb-4">
-              Human 멤버
+              {'👤'} Human 멤버
               <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded-full">{humans.length}</span>
             </div>
             {humans.length === 0 ? (
               <div className="text-[13px] text-text-muted py-6 text-center">Human 멤버가 없습니다</div>
             ) : (
-              <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4">
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4">
                 {filterByOrg(humans).map((m) => (
                   <MemberCard
                     key={m.member_id}
@@ -72,7 +72,7 @@ export default function Agents() {
           {/* Agent 멤버 섹션 */}
           <div className="mb-8">
             <div className="flex items-center gap-2 text-[15px] font-semibold text-text-muted mb-4">
-              Agent 멤버
+              {'☯'} Agent 멤버
               <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded-full">{agents.length}</span>
               <div className="ml-auto">
                 <button
@@ -116,7 +116,7 @@ export default function Agents() {
             {filterAgents(agents).length === 0 ? (
               <div className="text-[13px] text-text-muted py-6 text-center">Agent 멤버가 없습니다</div>
             ) : (
-              <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4">
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4">
                 {filterAgents(agents).map((m) => (
                   <MemberCard
                     key={m.member_id}
@@ -135,21 +135,45 @@ export default function Agents() {
       {showRegister && (
         <AgentRegisterForm
           onClose={() => setShowRegister(false)}
-          onTokenCreated={(token) => { setShowRegister(false); setCreatedToken(token) }}
+          onTokenCreated={(agentId, token) => { setShowRegister(false); setCreatedToken({ agentId, token }) }}
         />
       )}
 
+      {/* 토큰 표시 모달 — 목업 tokenModal 기준 */}
       {createdToken && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
-          <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
-            <h3 className="text-[18px] font-bold mb-4">에이전트 토큰 발급 완료</h3>
-            <p className="text-[13px] text-warning mb-3">이 토큰은 다시 확인할 수 없습니다. 반드시 복사해 두세요.</p>
-            <div className="bg-bg border border-border rounded-lg p-3 font-mono text-[12px] break-all mb-4">
-              {createdToken}
+          <div className="bg-surface border border-border rounded-lg p-6 w-[480px] text-center">
+            <h3 className="text-[18px] font-bold mb-4 text-positive">{'✓'} 에이전트 등록 완료</h3>
+
+            <div className="mb-2">
+              <div className="text-[12px] font-semibold text-text-muted">Agent ID</div>
+              <div className="text-[16px] font-semibold">{createdToken.agentId}</div>
             </div>
-            <div className="flex justify-end gap-2">
-              <button onClick={() => navigator.clipboard.writeText(createdToken)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">복사</button>
-              <button onClick={() => setCreatedToken(null)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">닫기</button>
+
+            <div className="my-5">
+              <div className="text-[12px] font-semibold text-text-muted">발급된 토큰</div>
+              <div className="bg-bg border border-border rounded-lg p-3.5 font-mono text-[13px] break-all text-left mt-2">
+                {createdToken.token}
+              </div>
+            </div>
+
+            <div className="bg-warning-bg text-warning p-3 rounded-lg text-[13px] mb-5 text-left">
+              {'⚠'} 이 토큰은 다시 표시되지 않습니다. 안전한 곳에 복사해 두세요.
+            </div>
+
+            <div className="flex justify-center gap-2">
+              <button
+                onClick={() => navigator.clipboard.writeText(createdToken.token)}
+                className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
+              >
+                토큰 복사
+              </button>
+              <button
+                onClick={() => setCreatedToken(null)}
+                className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover"
+              >
+                닫기
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- 에이전트 목록/상세 페이지를 목업 HTML(`agents.html`, `agent-detail.html`) 기준으로 디자인 충실도 개선
- MemberCard: 아바타 크기(72px), 색상 배경, ID 우선 표시, 메타 행 레이아웃, 스코프 전체 표시
- AgentDetail: 기본 정보+활동 정보 2열 그리드, 토큰/스코프 섹션 목업 레이아웃 반영
- AgentRegisterForm: 소속을 드롭다운으로 변경, 토큰 모달 목업 기준 재구성

## Test plan
- [x] TypeScript 컴파일 에러 없음 (`tsc --noEmit`)
- [x] 백엔드 테스트 1587 passed
- [ ] 브라우저에서 에이전트 목록 페이지가 목업과 동일한 레이아웃으로 렌더링되는지 확인
- [ ] 브라우저에서 에이전트 상세 페이지가 목업과 일치하는지 확인
- [ ] 에이전트 등록 모달에서 소속 드롭다운 정상 동작 확인
- [ ] 토큰 발급 완료 모달 레이아웃 확인

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)