### PR TITLE
목업 충실도: 자금관리 (메인 + 변동이력)

### DIFF
--- a/frontend/src/components/treasury/AllocationForm.tsx
+++ b/frontend/src/components/treasury/AllocationForm.tsx
@@ -10,22 +10,26 @@ interface AllocationFormProps {
 export default function AllocationForm({ budgets }: AllocationFormProps) {
   const [botId, setBotId] = useState(budgets[0]?.bot_id ?? '')
   const [amount, setAmount] = useState('')
-  const [confirmAction, setConfirmAction] = useState<{ action: 'allocate' | 'deallocate'; botId: string; amount: number } | null>(null)
+  const [showConfirm, setShowConfirm] = useState(false)
   const allocate = useAllocateBudget()
   const deallocate = useDeallocateBudget()
 
   const selectedBudget = budgets.find((b) => b.bot_id === botId)
-  const numAmount = Number(amount)
+  const numAmount = Number(amount.replace(/,/g, ''))
 
   const handleSubmit = () => {
-    if (!confirmAction) return
-    const { action, botId: bid, amount: amt } = confirmAction
-    if (action === 'allocate') {
-      allocate.mutate({ botId: bid, amount: amt }, { onSuccess: () => { setAmount(''); setConfirmAction(null) } })
+    if (!selectedBudget || !numAmount) return
+    const diff = numAmount - selectedBudget.allocated
+    if (diff > 0) {
+      allocate.mutate({ botId, amount: diff }, { onSuccess: () => { setAmount(''); setShowConfirm(false) } })
+    } else if (diff < 0) {
+      deallocate.mutate({ botId, amount: Math.abs(diff) }, { onSuccess: () => { setAmount(''); setShowConfirm(false) } })
     } else {
-      deallocate.mutate({ botId: bid, amount: amt }, { onSuccess: () => { setAmount(''); setConfirmAction(null) } })
+      setShowConfirm(false)
     }
   }
+
+  const diff = selectedBudget ? numAmount - selectedBudget.allocated : 0
 
   return (
     <>
@@ -39,7 +43,7 @@ export default function AllocationForm({ budgets }: AllocationFormProps) {
             <select
               value={botId}
               onChange={(e) => setBotId(e.target.value)}
-              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px]"
+              className="w-full bg-bg border border-border rounded-lg px-3 py-2 text-text text-[14px] h-[38px]"
             >
               {budgets.map((b) => (
                 <option key={b.bot_id} value={b.bot_id}>{b.bot_id}</option>
@@ -50,68 +54,59 @@ export default function AllocationForm({ budgets }: AllocationFormProps) {
           {selectedBudget && (
             <div>
               <label className="block text-[12px] font-semibold text-text-muted mb-1.5">현재 배정예산</label>
-              <div className="text-[15px] font-semibold">{formatKRW(selectedBudget.allocated)}</div>
+              <div className="text-[15px] font-semibold mb-2">{formatKRW(selectedBudget.allocated)}</div>
             </div>
           )}
 
           <div>
-            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">금액 (원)</label>
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">변경할 예산 (원)</label>
             <input
-              type="number"
+              type="text"
               value={amount}
               onChange={(e) => setAmount(e.target.value)}
-              placeholder="0"
+              placeholder={selectedBudget ? new Intl.NumberFormat('ko-KR').format(selectedBudget.allocated) : '0'}
               className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] placeholder:text-text-muted focus:outline-none focus:border-primary"
             />
           </div>
 
-          <div className="flex gap-2">
-            <button
-              onClick={() => numAmount > 0 && botId && setConfirmAction({ action: 'allocate', botId, amount: numAmount })}
-              disabled={!botId || !numAmount}
-              className="flex-1 px-4 py-2.5 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover disabled:opacity-50"
-            >
-              할당
-            </button>
-            <button
-              onClick={() => numAmount > 0 && botId && setConfirmAction({ action: 'deallocate', botId, amount: numAmount })}
-              disabled={!botId || !numAmount}
-              className="flex-1 px-4 py-2.5 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover hover:text-text disabled:opacity-50"
-            >
-              회수
-            </button>
-          </div>
+          <button
+            onClick={() => numAmount > 0 && botId && setShowConfirm(true)}
+            disabled={!botId || !numAmount}
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50"
+          >
+            예산 변경
+          </button>
         </div>
       </div>
 
-      {/* 확인 모달 */}
-      {confirmAction && (
+      {/* 예산 변경 확인 모달 */}
+      {showConfirm && selectedBudget && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
-          <div className="bg-surface border border-border rounded-lg p-6 w-[420px]">
-            <h3 className="text-[16px] font-bold mb-3">
-              예산 {confirmAction.action === 'allocate' ? '할당' : '회수'} 확인
-            </h3>
+          <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
+            <h3 className="text-[18px] font-bold mb-5">예산 변경 확인</h3>
             <div className="text-[13px] text-text-muted mb-4">아래 내용으로 예산을 변경합니다.</div>
             <div className="bg-bg border border-border rounded-lg p-4 mb-4 space-y-2">
               <div className="flex justify-between text-[13px]">
                 <span className="text-text-muted">Bot</span>
-                <span className="font-semibold font-mono">{confirmAction.botId}</span>
+                <span className="font-semibold">{botId}</span>
               </div>
-              {selectedBudget && (
-                <div className="flex justify-between text-[13px]">
-                  <span className="text-text-muted">현재 예산</span>
-                  <span>{formatKRW(selectedBudget.allocated)}</span>
-                </div>
-              )}
               <div className="flex justify-between text-[13px]">
-                <span className="text-text-muted">{confirmAction.action === 'allocate' ? '할당' : '회수'} 금액</span>
-                <span className={`font-semibold ${confirmAction.action === 'allocate' ? 'text-positive' : 'text-negative'}`}>
-                  {confirmAction.action === 'allocate' ? '+' : '-'}{formatKRW(confirmAction.amount)}
+                <span className="text-text-muted">현재 예산</span>
+                <span>{formatKRW(selectedBudget.allocated)}</span>
+              </div>
+              <div className="flex justify-between text-[13px]">
+                <span className="text-text-muted">변경 예산</span>
+                <span className="font-semibold">{formatKRW(numAmount)}</span>
+              </div>
+              <div className="flex justify-between text-[13px] border-t border-border pt-2">
+                <span className="text-text-muted">차액</span>
+                <span className={`font-semibold ${diff >= 0 ? 'text-positive' : 'text-negative'}`}>
+                  {diff >= 0 ? '+' : ''}{formatKRW(diff)}
                 </span>
               </div>
             </div>
-            <div className="flex justify-end gap-2">
-              <button onClick={() => setConfirmAction(null)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
+            <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
+              <button onClick={() => setShowConfirm(false)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
               <button onClick={handleSubmit} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">변경 확인</button>
             </div>
           </div>

--- a/frontend/src/components/treasury/AnteSummary.tsx
+++ b/frontend/src/components/treasury/AnteSummary.tsx
@@ -7,7 +7,11 @@ export default function AnteSummary({ summary }: { summary: TreasurySummary }) {
     ? summary.ante_profit_loss / summary.ante_purchase_amount
     : 0
 
-  const holdingProfitColor = (summary.ante_eval_amount - summary.ante_purchase_amount) >= 0 ? 'text-positive' : 'text-negative'
+  const holdingPnl = summary.ante_eval_amount - summary.ante_purchase_amount
+  const holdingProfitColor = holdingPnl >= 0 ? 'text-positive' : 'text-negative'
+  const holdingProfitPercent = summary.ante_purchase_amount > 0
+    ? holdingPnl / summary.ante_purchase_amount
+    : 0
 
   return (
     <div className="bg-surface border border-border rounded-lg overflow-hidden mb-6">
@@ -56,7 +60,10 @@ export default function AnteSummary({ summary }: { summary: TreasurySummary }) {
         </div>
         <div className="px-5 py-4">
           <div className="text-[12px] text-text-muted mb-1">보유종목 손익</div>
-          <div className={`text-[22px] font-bold ${holdingProfitColor}`}>{formatKRW(summary.ante_profit_loss)}</div>
+          <div className={`text-[22px] font-bold ${holdingProfitColor}`}>{formatKRW(holdingPnl)}</div>
+          {holdingProfitPercent !== 0 && (
+            <div className={`text-[13px] ${holdingProfitColor}`}>({formatPercent(holdingProfitPercent)})</div>
+          )}
         </div>
         <div className="px-5 py-4">
           <div className="text-[12px] text-text-muted mb-1">체결대기 자금</div>

--- a/frontend/src/components/treasury/RecentTransactions.tsx
+++ b/frontend/src/components/treasury/RecentTransactions.tsx
@@ -33,13 +33,13 @@ export default function RecentTransactions() {
                 <tr key={tx.id} className="hover:bg-surface-hover">
                   <td className="px-3 py-3 border-b border-border text-[13px] font-mono text-text-muted">{formatDateTime(tx.created_at)}</td>
                   <td className="px-3 py-3 border-b border-border text-[13px]">
-                    <StatusBadge variant={TRANSACTION_TYPE_VARIANT[tx.type] ?? 'default'}>
+                    <StatusBadge variant={TRANSACTION_TYPE_VARIANT[tx.type] ?? 'muted'}>
                       {TRANSACTION_TYPE_LABELS[tx.type] ?? tx.type}
                     </StatusBadge>
                   </td>
                   <td className="px-3 py-3 border-b border-border text-[13px] font-mono">{tx.bot_id || '-'}</td>
-                  <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${tx.type === 'allocate' ? 'text-positive' : tx.type === 'deallocate' ? 'text-negative' : ''}`}>
-                    {tx.type === 'allocate' ? '+' : ''}{formatKRW(tx.amount)}
+                  <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${tx.amount >= 0 ? 'text-positive' : 'text-negative'}`}>
+                    {tx.amount > 0 ? '+' : ''}{formatKRW(tx.amount)}
                   </td>
                   <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{tx.description}</td>
                 </tr>

--- a/frontend/src/pages/TreasuryHistory.tsx
+++ b/frontend/src/pages/TreasuryHistory.tsx
@@ -35,16 +35,16 @@ export default function TreasuryHistory() {
   return (
     <>
       {/* 필터 */}
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex gap-1">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="flex gap-1 bg-bg rounded-lg p-[3px]">
           {TYPE_TABS.map((tab) => (
             <button
               key={tab.value}
               onClick={() => handleTypeChange(tab.value)}
-              className={`px-3 py-1.5 rounded-lg text-[13px] font-medium border-none cursor-pointer transition-colors ${
+              className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer transition-colors ${
                 typeFilter === tab.value
-                  ? 'bg-primary text-white'
-                  : 'bg-transparent text-text-muted hover:bg-surface-hover hover:text-text'
+                  ? 'bg-surface text-text'
+                  : 'bg-transparent text-text-muted hover:text-text'
               }`}
             >
               {tab.label}
@@ -93,8 +93,8 @@ export default function TreasuryHistory() {
                           </StatusBadge>
                         </td>
                         <td className="px-3 py-3 border-b border-border text-[13px] font-mono">{tx.bot_id || '-'}</td>
-                        <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${tx.type === 'allocate' ? 'text-positive' : tx.type === 'deallocate' ? 'text-negative' : ''}`}>
-                          {tx.type === 'allocate' ? '+' : ''}{formatKRW(tx.amount)}
+                        <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${tx.amount >= 0 ? 'text-positive' : 'text-negative'}`}>
+                          {tx.amount > 0 ? '+' : ''}{formatKRW(tx.amount)}
                         </td>
                         <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{tx.description}</td>
                       </tr>

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -1,10 +1,9 @@
-/** 원화 포맷 (예: 1,000,000원) */
+/** 원화 포맷 (예: 1,000,000 원) — 목업 기준 "숫자 원" 형식 */
 export function formatKRW(value: number): string {
-  return new Intl.NumberFormat('ko-KR', {
-    style: 'currency',
-    currency: 'KRW',
+  const formatted = new Intl.NumberFormat('ko-KR', {
     maximumFractionDigits: 0,
   }).format(value)
+  return `${formatted} 원`
 }
 
 /** 퍼센트 포맷 (예: +1.23%) */


### PR DESCRIPTION
## Summary

- `formatKRW` 출력 형식을 목업 기준 "숫자 원"으로 변경 (기존: "₩숫자")
- AllocationForm을 단일 "예산 변경" 버튼 + 변경/차액 표시 모달로 목업에 맞게 재구성
- AnteSummary 하단 보유종목 손익에 수익률 퍼센트 표시 추가
- TreasuryHistory 필터 탭을 세그먼트 컨트롤 스타일로 변경 (목업 filter-tabs 패턴)
- 거래 금액 부호 표시를 type 기반이 아닌 amount 값 기반으로 통일

Closes #336

## Test plan

- [x] pytest 1587 passed (backend 회귀 없음)
- [ ] 자금관리 메인 페이지가 목업(`treasury.html`)과 동일한 레이아웃으로 렌더링되는지 확인
- [ ] 변동이력 페이지가 목업(`treasury-history.html`)과 일치하는지 확인
- [ ] 금액 포맷이 "숫자 원" 형식으로 표시되는지 확인
- [ ] 예산 변경 모달에서 현재 예산/변경 예산/차액이 올바르게 표시되는지 확인
- [ ] 필터 탭 스타일이 세그먼트 컨트롤로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)