### PR TITLE
fix(dashboard): 봇 관리 페이지 목업 충실도 개선

### DIFF
--- a/frontend/src/components/bots/BotCard.tsx
+++ b/frontend/src/components/bots/BotCard.tsx
@@ -75,7 +75,7 @@ export default function BotCard({ bot, onStart, onStop, onDelete }: BotCardProps
           </div>
           <div className="flex justify-between">
             <span>모드</span>
-            <StatusBadge variant={bot.mode === 'live' ? 'warning' : 'info'}>{bot.mode === 'live' ? '실전' : '모의'}</StatusBadge>
+            <StatusBadge variant={bot.mode === 'live' ? 'primary' : 'warning'}>{bot.mode === 'live' ? '실전' : '모의'}</StatusBadge>
           </div>
           {bot.interval_seconds != null && (
             <div className="flex justify-between">
@@ -85,7 +85,7 @@ export default function BotCard({ bot, onStart, onStop, onDelete }: BotCardProps
           )}
         </div>
         <div className="flex gap-2 justify-end">
-          {(bot.status === 'stopped' || bot.status === 'created') && (
+          {(bot.status === 'stopped' || bot.status === 'created' || bot.status === 'error') && (
             <>
               <button onClick={() => onStart(bot.bot_id)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">시작</button>
               <button onClick={() => onDelete(bot.bot_id)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-negative border-none cursor-pointer hover:underline">삭제</button>
@@ -93,9 +93,6 @@ export default function BotCard({ bot, onStart, onStop, onDelete }: BotCardProps
           )}
           {bot.status === 'running' && (
             <button onClick={() => onStop(bot.bot_id)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-negative border border-negative cursor-pointer hover:bg-negative-bg">중지</button>
-          )}
-          {bot.status === 'error' && (
-            <button onClick={() => onDelete(bot.bot_id)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-negative border-none cursor-pointer hover:underline">삭제</button>
           )}
         </div>
       </div>

--- a/frontend/src/components/bots/BotCreateForm.tsx
+++ b/frontend/src/components/bots/BotCreateForm.tsx
@@ -18,7 +18,6 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
   const [mode, setMode] = useState<BotMode>('paper')
   const [interval, setInterval] = useState('60')
   const [budget, setBudget] = useState('')
-  const [symbols, setSymbols] = useState('')
   const [botIdError, setBotIdError] = useState('')
   const createBot = useCreateBot()
   const { data: strategies } = useStrategies()
@@ -50,8 +49,8 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
         strategy_name: strategyName,
         mode,
         interval_seconds: Number(interval),
-        budget: Number(budget),
-        symbols: symbols.split(',').map((s) => s.trim()).filter(Boolean),
+        budget: Number(budget.replace(/,/g, '')),
+        symbols: [],
       },
       { onSuccess: onClose },
     )
@@ -64,7 +63,7 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
         <form onSubmit={handleSubmit}>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">Bot ID</label>
-            <input value={botId} onChange={(e) => handleBotIdChange(e.target.value)} placeholder="bot-momentum-01" className={`w-full bg-bg border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary ${botIdError ? 'border-negative' : 'border-border'}`} required />
+            <input value={botId} onChange={(e) => handleBotIdChange(e.target.value)} placeholder="my-bot-01" className={`w-full bg-bg border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary ${botIdError ? 'border-negative' : 'border-border'}`} required />
             {botIdError ? (
               <div className="text-[11px] text-negative mt-1">{botIdError}</div>
             ) : (
@@ -87,9 +86,9 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
           </div>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">봇 유형</label>
-            <div className="flex gap-2">
-              <button type="button" onClick={() => setMode('paper')} className={`flex-1 py-2 rounded-lg text-[13px] font-medium border cursor-pointer ${mode === 'paper' ? 'bg-primary text-white border-primary' : 'bg-transparent text-text-muted border-border hover:bg-surface-hover'}`}>모의투자</button>
-              <button type="button" onClick={() => setMode('live')} className={`flex-1 py-2 rounded-lg text-[13px] font-medium border cursor-pointer ${mode === 'live' ? 'bg-warning text-black border-warning' : 'bg-transparent text-text-muted border-border hover:bg-surface-hover'}`}>실전투자</button>
+            <div className="inline-flex rounded-lg border border-border overflow-hidden">
+              <button type="button" onClick={() => setMode('paper')} className={`px-4 py-2 text-[13px] font-medium border-none cursor-pointer ${mode === 'paper' ? 'bg-primary text-white' : 'bg-transparent text-text-muted hover:bg-surface-hover'}`}>모의투자</button>
+              <button type="button" onClick={() => setMode('live')} className={`px-4 py-2 text-[13px] font-medium border-none cursor-pointer ${mode === 'live' ? 'bg-primary text-white' : 'bg-transparent text-text-muted hover:bg-surface-hover'}`}>실전투자</button>
             </div>
           </div>
           <div className="mb-4">
@@ -99,13 +98,8 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
           </div>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">배정예산 (원)</label>
-            <input type="number" value={budget} onChange={(e) => setBudget(e.target.value)} placeholder="5000000" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
-            <div className="text-[11px] text-text-muted mt-1">잔여예산: {formatNumber(remainingBudget)}원</div>
-          </div>
-          <div className="mb-4">
-            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">대상 종목 (콤마 구분)</label>
-            <input value={symbols} onChange={(e) => setSymbols(e.target.value)} placeholder="005930, 035420" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" />
-            <div className="text-[11px] text-text-muted mt-1">선택사항</div>
+            <input type="text" value={budget} onChange={(e) => setBudget(e.target.value)} placeholder="5,000,000" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
+            <div className="text-[11px] text-text-muted mt-1">잔여예산: {formatNumber(remainingBudget)} 원</div>
           </div>
           <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
             <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>

--- a/frontend/src/components/bots/BotDeleteModal.tsx
+++ b/frontend/src/components/bots/BotDeleteModal.tsx
@@ -1,151 +1,83 @@
 import { useState } from 'react'
 import type { Bot } from '../../types/bot'
 
-interface Position {
-  symbol: string
-  quantity: number
-  avg_price: number
-  current_price: number
-}
-
 export type DeleteOption = 'force_liquidate' | 'manual_liquidate'
 
 interface BotDeleteModalProps {
-  bot: Bot
-  positions?: Position[]
+  bot: Bot & {
+    positions?: { symbol: string; quantity: number }[]
+  }
   onConfirm: (option?: DeleteOption) => void
   onClose: () => void
   isPending?: boolean
 }
 
-export default function BotDeleteModal({ bot, positions = [], onConfirm, onClose, isPending }: BotDeleteModalProps) {
+export default function BotDeleteModal({ bot, onConfirm, onClose, isPending }: BotDeleteModalProps) {
+  const positions = bot.positions?.filter((p) => p.quantity > 0) ?? []
   const hasPositions = positions.length > 0
-  const [deleteOption, setDeleteOption] = useState<DeleteOption>('force_liquidate')
+  const [deleteOption, setDeleteOption] = useState<DeleteOption>('manual_liquidate')
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]" onClick={onClose}>
       <div className="bg-surface border border-border rounded-lg p-6 w-[480px] max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
-        <h2 className="text-[18px] font-bold mb-5">봇 삭제</h2>
+        <h2 className="text-[18px] font-bold mb-4 text-negative">Bot 삭제</h2>
 
-        {/* 보유종목 있음 경고 배너 */}
-        {hasPositions && (
-          <div className="flex items-start gap-2 bg-negative/10 border border-negative/30 rounded-lg px-4 py-3 mb-4">
-            <span className="text-negative text-[16px] mt-0.5">&#9888;</span>
-            <div className="text-[13px] text-negative">
-              <span className="font-semibold">보유 종목 {positions.length}개가 있습니다</span>
-              <p className="mt-1 text-negative/80">삭제 전 포지션 처리 방법을 선택하세요.</p>
-            </div>
-          </div>
-        )}
-
-        {/* 보유종목 없음 안내 */}
-        {!hasPositions && (
-          <div className="flex items-start gap-2 bg-primary/10 border border-primary/30 rounded-lg px-4 py-3 mb-4">
-            <span className="text-primary text-[16px] mt-0.5">&#8505;</span>
-            <div className="text-[13px] text-text-muted">
-              거래 이력과 성과 기록은 보존됩니다.
-            </div>
-          </div>
-        )}
+        <div className="text-[13px] text-text-muted mb-4">
+          {hasPositions
+            ? '보유 종목이 있습니다. 삭제 전 포지션 처리 방법을 선택해주세요.'
+            : <>Bot을 삭제하면 더 이상 실행할 수 없습니다.<br />거래 이력과 성과 기록은 보존됩니다.</>
+          }
+        </div>
 
         {/* Bot 정보 */}
-        <div className="bg-bg rounded-lg p-4 mb-4">
-          <div className="space-y-2 text-[13px]">
-            <div className="flex justify-between">
-              <span className="text-text-muted">봇 이름</span>
-              <span className="font-medium">{bot.name || bot.bot_id}</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-text-muted">봇 ID</span>
-              <span className="font-mono text-[12px]">{bot.bot_id}</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-text-muted">보유 종목</span>
-              <span>{hasPositions ? `${positions.length}개` : '없음'}</span>
-            </div>
+        <div className="bg-bg border border-border rounded-lg p-3.5 mb-4">
+          <div className="flex justify-between mb-2 text-[13px]">
+            <span className="text-text-muted">Bot</span>
+            <span>
+              <span className="font-semibold">{bot.name || bot.bot_id}</span>
+              {bot.name && <span className="font-normal text-text-muted ml-1">{bot.bot_id}</span>}
+            </span>
+          </div>
+          <div className="flex justify-between text-[13px]">
+            <span className="text-text-muted">보유 종목</span>
+            <span>{hasPositions ? `${positions.length}종목` : '없음'}</span>
           </div>
         </div>
 
         {/* 포지션 처리 옵션 (보유종목 있을 때만) */}
         {hasPositions && (
-          <div className="mb-4">
-            <h3 className="text-[13px] font-semibold text-text-muted mb-3">포지션 처리 방법</h3>
-            <div className="space-y-2">
-              <label
-                className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
-                  deleteOption === 'force_liquidate'
-                    ? 'border-primary bg-primary/5'
-                    : 'border-border hover:bg-surface-hover'
-                }`}
-              >
-                <input
-                  type="radio"
-                  name="deleteOption"
-                  checked={deleteOption === 'force_liquidate'}
-                  onChange={() => setDeleteOption('force_liquidate')}
-                  className="mt-0.5 accent-primary"
-                />
-                <div>
-                  <div className="text-[13px] font-medium">강제 청산 후 삭제</div>
-                  <div className="text-[12px] text-text-muted mt-0.5">
-                    모든 보유 종목을 시장가로 즉시 매도한 뒤 봇을 삭제합니다.
-                  </div>
-                </div>
-              </label>
-              <label
-                className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
-                  deleteOption === 'manual_liquidate'
-                    ? 'border-primary bg-primary/5'
-                    : 'border-border hover:bg-surface-hover'
-                }`}
-              >
-                <input
-                  type="radio"
-                  name="deleteOption"
-                  checked={deleteOption === 'manual_liquidate'}
-                  onChange={() => setDeleteOption('manual_liquidate')}
-                  className="mt-0.5 accent-primary"
-                />
-                <div>
-                  <div className="text-[13px] font-medium">직접 청산</div>
-                  <div className="text-[12px] text-text-muted mt-0.5">
-                    봇을 중지 상태로 전환합니다. 보유 종목을 직접 청산한 뒤 다시 삭제하세요.
-                  </div>
-                </div>
-              </label>
-            </div>
-
-            {/* 보유종목 테이블 */}
-            <div className="mt-4">
-              <h3 className="text-[13px] font-semibold text-text-muted mb-2">보유 종목</h3>
-              <div className="overflow-x-auto">
-                <table className="w-full border-collapse text-[12px]">
-                  <thead>
-                    <tr>
-                      <th className="text-left px-2 py-1.5 font-semibold text-text-muted border-b border-border">종목</th>
-                      <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">수량</th>
-                      <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">평균단가</th>
-                      <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">현재가</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {positions.map((pos) => (
-                      <tr key={pos.symbol}>
-                        <td className="px-2 py-1.5 font-mono border-b border-border/50">{pos.symbol}</td>
-                        <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.quantity.toLocaleString()}</td>
-                        <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.avg_price.toLocaleString()}원</td>
-                        <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.current_price.toLocaleString()}원</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+          <div className="flex flex-col gap-2 mb-4">
+            <label className="flex items-start gap-2.5 p-3 border border-border rounded-lg cursor-pointer hover:bg-surface-hover">
+              <input
+                type="radio"
+                name="deleteOption"
+                checked={deleteOption === 'force_liquidate'}
+                onChange={() => setDeleteOption('force_liquidate')}
+                className="mt-0.5"
+              />
+              <div>
+                <div className="text-[13px] font-medium">강제 청산 후 삭제</div>
+                <div className="text-[12px] text-text-muted">보유 종목을 전량 시장가 매도한 후 Bot을 삭제합니다</div>
               </div>
-            </div>
+            </label>
+            <label className="flex items-start gap-2.5 p-3 border border-border rounded-lg cursor-pointer hover:bg-surface-hover">
+              <input
+                type="radio"
+                name="deleteOption"
+                checked={deleteOption === 'manual_liquidate'}
+                onChange={() => setDeleteOption('manual_liquidate')}
+                className="mt-0.5"
+              />
+              <div>
+                <div className="text-[13px] font-medium">직접 청산</div>
+                <div className="text-[12px] text-text-muted">보유 종목을 먼저 청산한 후 삭제할 수 있습니다</div>
+              </div>
+            </label>
           </div>
         )}
 
         {/* 버튼 */}
-        <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
+        <div className="flex justify-end gap-2 pt-4 border-t border-border">
           <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">
             취소
           </button>
@@ -155,7 +87,7 @@ export default function BotDeleteModal({ bot, positions = [], onConfirm, onClose
             disabled={isPending}
             className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative/80 disabled:opacity-50"
           >
-            {isPending ? '삭제 중...' : hasPositions && deleteOption === 'manual_liquidate' ? '중지로 전환' : '삭제'}
+            {isPending ? '삭제 중...' : '삭제'}
           </button>
         </div>
       </div>

--- a/frontend/src/components/bots/BotStopModal.tsx
+++ b/frontend/src/components/bots/BotStopModal.tsx
@@ -1,128 +1,62 @@
 import type { Bot } from '../../types/bot'
-
-interface Position {
-  symbol: string
-  quantity: number
-  avg_price: number
-  current_price: number
-}
-
-interface PendingOrder {
-  symbol: string
-  side: 'buy' | 'sell'
-  quantity: number
-  price: number
-}
+import { formatKRW } from '../../utils/formatters'
 
 interface BotStopModalProps {
-  bot: Bot
-  positions?: Position[]
-  pendingOrders?: PendingOrder[]
+  bot: Bot & {
+    positions?: { symbol: string; quantity: number }[]
+    budget?: { reserved: number }
+  }
   onConfirm: () => void
   onClose: () => void
   isPending?: boolean
 }
 
-export default function BotStopModal({ bot, positions = [], pendingOrders = [], onConfirm, onClose, isPending }: BotStopModalProps) {
+export default function BotStopModal({ bot, onConfirm, onClose, isPending }: BotStopModalProps) {
+  const positions = bot.positions?.filter((p) => p.quantity > 0) ?? []
   const hasPositions = positions.length > 0
-  const hasPendingOrders = pendingOrders.length > 0
+  const positionNames = positions.map((p) => p.symbol).join(', ')
+  const reserved = bot.budget?.reserved ?? 0
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]" onClick={onClose}>
       <div className="bg-surface border border-border rounded-lg p-6 w-[480px] max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
-        <h2 className="text-[18px] font-bold mb-5">봇 중지</h2>
+        <h2 className="text-[18px] font-bold mb-4 text-negative">Bot 중지</h2>
+
+        <div className="text-[13px] text-text-muted mb-4">
+          Bot을 중지하면 현재 실행 중인 전략 사이클이 완료된 후 중지됩니다.<br />
+          미체결 주문은 취소되지 않습니다.
+        </div>
 
         {/* 보유종목 있음 경고 배너 */}
         {hasPositions && (
-          <div className="flex items-start gap-2 bg-warning/10 border border-warning/30 rounded-lg px-4 py-3 mb-4">
-            <span className="text-warning text-[16px] mt-0.5">&#9888;</span>
-            <div className="text-[13px] text-warning">
-              <span className="font-semibold">보유 종목 {positions.length}개가 유지됩니다</span>
-              <p className="mt-1 text-warning/80">봇을 중지해도 보유 종목은 자동으로 매도되지 않습니다. 필요 시 수동으로 청산하세요.</p>
-            </div>
+          <div className="bg-warning-bg text-warning px-3.5 py-2.5 rounded text-[12px] mb-4">
+            &#9888; 보유 종목 {positions.length}개가 유지됩니다. 중지 후 포지션을 직접 관리해야 합니다.
           </div>
         )}
 
         {/* Bot 정보 */}
-        <div className="bg-bg rounded-lg p-4 mb-4">
-          <div className="space-y-2 text-[13px]">
-            <div className="flex justify-between">
-              <span className="text-text-muted">봇 이름</span>
-              <span className="font-medium">{bot.name || bot.bot_id}</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-text-muted">봇 ID</span>
-              <span className="font-mono text-[12px]">{bot.bot_id}</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-text-muted">보유 종목</span>
-              <span>{hasPositions ? `${positions.length}개` : '없음'}</span>
-            </div>
+        <div className="bg-bg border border-border rounded-lg p-3.5 mb-4">
+          <div className="flex justify-between mb-2 text-[13px]">
+            <span className="text-text-muted">Bot</span>
+            <span>
+              <span className="font-semibold">{bot.name || bot.bot_id}</span>
+              {bot.name && <span className="font-normal text-text-muted ml-1">{bot.bot_id}</span>}
+            </span>
           </div>
+          <div className="flex justify-between mb-2 text-[13px]">
+            <span className="text-text-muted">보유 종목</span>
+            <span>{hasPositions ? `${positions.length}종목 (${positionNames})` : '없음'}</span>
+          </div>
+          {(hasPositions || reserved > 0) && (
+            <div className="flex justify-between text-[13px]">
+              <span className="text-text-muted">체결대기</span>
+              <span>{formatKRW(reserved)}</span>
+            </div>
+          )}
         </div>
 
-        {/* 보유종목 테이블 */}
-        {hasPositions && (
-          <div className="mb-4">
-            <h3 className="text-[13px] font-semibold text-text-muted mb-2">보유 종목</h3>
-            <div className="overflow-x-auto">
-              <table className="w-full border-collapse text-[12px]">
-                <thead>
-                  <tr>
-                    <th className="text-left px-2 py-1.5 font-semibold text-text-muted border-b border-border">종목</th>
-                    <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">수량</th>
-                    <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">평균단가</th>
-                    <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">현재가</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {positions.map((pos) => (
-                    <tr key={pos.symbol}>
-                      <td className="px-2 py-1.5 font-mono border-b border-border/50">{pos.symbol}</td>
-                      <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.quantity.toLocaleString()}</td>
-                      <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.avg_price.toLocaleString()}원</td>
-                      <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.current_price.toLocaleString()}원</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        )}
-
-        {/* 체결 대기 */}
-        {hasPendingOrders && (
-          <div className="mb-4">
-            <h3 className="text-[13px] font-semibold text-text-muted mb-2">체결 대기</h3>
-            <div className="overflow-x-auto">
-              <table className="w-full border-collapse text-[12px]">
-                <thead>
-                  <tr>
-                    <th className="text-left px-2 py-1.5 font-semibold text-text-muted border-b border-border">종목</th>
-                    <th className="text-center px-2 py-1.5 font-semibold text-text-muted border-b border-border">유형</th>
-                    <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">수량</th>
-                    <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">주문가</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {pendingOrders.map((order, i) => (
-                    <tr key={`${order.symbol}-${i}`}>
-                      <td className="px-2 py-1.5 font-mono border-b border-border/50">{order.symbol}</td>
-                      <td className={`text-center px-2 py-1.5 border-b border-border/50 ${order.side === 'buy' ? 'text-positive' : 'text-negative'}`}>
-                        {order.side === 'buy' ? '매수' : '매도'}
-                      </td>
-                      <td className="text-right px-2 py-1.5 border-b border-border/50">{order.quantity.toLocaleString()}</td>
-                      <td className="text-right px-2 py-1.5 border-b border-border/50">{order.price.toLocaleString()}원</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        )}
-
         {/* 버튼 */}
-        <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
+        <div className="flex justify-end gap-2 pt-4 border-t border-border">
           <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">
             취소
           </button>
@@ -132,7 +66,7 @@ export default function BotStopModal({ bot, positions = [], pendingOrders = [], 
             disabled={isPending}
             className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative/80 disabled:opacity-50"
           >
-            {isPending ? '중지 중...' : '중지'}
+            {isPending ? '중지 중...' : '중지 확인'}
           </button>
         </div>
       </div>

--- a/frontend/src/pages/BotDetail.tsx
+++ b/frontend/src/pages/BotDetail.tsx
@@ -27,13 +27,11 @@ export default function BotDetail() {
   const canStart = bot.status === 'stopped' || bot.status === 'created'
   const canStop = bot.status === 'running'
   const canEdit = bot.status === 'stopped' || bot.status === 'created'
-  const isStopped = bot.status === 'stopped'
-
   return (
     <>
       {/* 뒤로가기 링크 */}
       <div className="mb-4">
-        <Link to="/bots" className="text-text-muted text-[13px] no-underline hover:text-text hover:underline">
+        <Link to="/bots" className="inline-flex items-center text-text-muted text-[13px] no-underline px-2 py-1 rounded hover:bg-surface-hover hover:text-text">
           &larr; 봇 관리
         </Link>
       </div>
@@ -43,34 +41,18 @@ export default function BotDetail() {
         <div>
           <h2 className="text-[20px] font-bold flex items-center gap-2">
             {bot.name || bot.bot_id}
-            {bot.name && <span className="text-[14px] font-normal text-text-muted font-mono">{bot.bot_id}</span>}
-            {isStopped && (
-              <StatusBadge variant="warning">중지</StatusBadge>
-            )}
+            {bot.name && <span className="text-[16px] font-normal text-text-muted">{bot.bot_id}</span>}
           </h2>
-          <div className="flex gap-3 items-center mt-1">
-            <StatusBadge variant={STATUS_VARIANT[bot.status] as 'positive'}>
-              {BOT_STATUS_LABELS[bot.status]}
-            </StatusBadge>
-            <StatusBadge variant={bot.mode === 'live' ? 'warning' : 'info'}>
-              {bot.mode === 'live' ? '실전' : '모의'}
-            </StatusBadge>
-            {bot.strategy_name && (
-              <Link to="/strategies" className="text-primary text-[13px] no-underline hover:underline">
-                {bot.strategy_name}
-              </Link>
-            )}
-          </div>
         </div>
         <div className="flex gap-2">
           {canEdit && (
             <button onClick={() => setShowEditModal(true)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">설정 수정</button>
           )}
           {canStart && (
-            <button onClick={() => start.mutate(bot.bot_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">시작</button>
+            <button onClick={() => start.mutate(bot.bot_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">시작</button>
           )}
           {canStop && (
-            <button onClick={() => setShowStopModal(true)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">중지</button>
+            <button onClick={() => setShowStopModal(true)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-negative border border-negative cursor-pointer hover:bg-negative-bg">중지</button>
           )}
         </div>
       </div>
@@ -83,7 +65,7 @@ export default function BotDetail() {
           <div className="space-y-2">
             <div className="flex justify-between py-1.5 text-[13px]">
               <span className="text-text-muted">전략명</span>
-              <span>{bot.strategy?.name || bot.strategy_name || '-'}</span>
+              <span>{bot.strategy?.name || bot.strategy_name ? <Link to="/strategies" className="text-primary no-underline hover:underline">{bot.strategy?.name || bot.strategy_name}</Link> : '-'}</span>
             </div>
             <div className="flex justify-between py-1.5 text-[13px]">
               <span className="text-text-muted">버전</span>
@@ -95,7 +77,7 @@ export default function BotDetail() {
             </div>
             <div className="flex justify-between py-1.5 text-[13px]">
               <span className="text-text-muted">설명</span>
-              <span className="text-right max-w-[60%]">{bot.strategy?.description || '-'}</span>
+              <span className="text-right max-w-[60%] text-[12px] text-text-muted">{bot.strategy?.description || '-'}</span>
             </div>
           </div>
         </div>
@@ -106,7 +88,7 @@ export default function BotDetail() {
           <div className="space-y-2">
             <div className="flex justify-between py-1.5 text-[13px]">
               <span className="text-text-muted">모드</span>
-              <StatusBadge variant={bot.mode === 'live' ? 'warning' : 'info'}>
+              <StatusBadge variant={bot.mode === 'live' ? 'primary' : 'warning'}>
                 {bot.mode === 'live' ? '실전' : '모의'}
               </StatusBadge>
             </div>
@@ -119,10 +101,6 @@ export default function BotDetail() {
             <div className="flex justify-between py-1.5 text-[13px]">
               <span className="text-text-muted">실행 간격</span>
               <span>{bot.interval_seconds}초</span>
-            </div>
-            <div className="flex justify-between py-1.5 text-[13px]">
-              <span className="text-text-muted">대상 종목</span>
-              <span className="font-mono">{bot.symbols?.length ? bot.symbols.join(', ') : '-'}</span>
             </div>
           </div>
         </div>
@@ -212,7 +190,7 @@ export default function BotDetail() {
         <div className="flex items-center justify-between mb-3">
           <h3 className="text-[15px] font-semibold">실행 로그</h3>
           {(bot.logs ?? []).length > 0 && (
-            <span className="text-[12px] text-primary cursor-pointer hover:underline">전체 보기</span>
+            <span className="text-[13px] text-primary cursor-pointer hover:underline">전체 보기 &rarr;</span>
           )}
         </div>
         {(bot.logs ?? []).length === 0 ? (
@@ -225,7 +203,7 @@ export default function BotDetail() {
                 <StatusBadge variant={log.success ? 'positive' : 'negative'}>
                   {log.success ? '성공' : '실패'}
                 </StatusBadge>
-                {log.message && <span className="text-text-muted">{log.message}</span>}
+                {log.message && <span className={log.success ? '' : 'text-negative'}>{log.message}</span>}
               </div>
             ))}
           </div>

--- a/frontend/src/pages/Bots.tsx
+++ b/frontend/src/pages/Bots.tsx
@@ -56,7 +56,7 @@ export default function Bots() {
               onClick={() => setShowCreate(true)}
               className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
             >
-              봇 생성
+              + 봇 생성
             </button>
           </div>
 


### PR DESCRIPTION
## Summary

- 봇 목록, 봇 상세(운영 중), 봇 상세(정지) 페이지를 목업 HTML과 일치하도록 수정
- BotStopModal/BotDeleteModal을 목업의 간결한 레이아웃으로 재작성
- BotCard 오류 상태 봇 액션 버튼, 모드 뱃지 색상, BotDetail 헤더/로그 스타일 등 세부 디자인 수정
- BotCreateForm에서 목업에 없는 대상 종목 필드 제거

## 변경 파일

- `frontend/src/pages/Bots.tsx` — 봇 생성 버튼 텍스트
- `frontend/src/pages/BotDetail.tsx` — 헤더 간소화, 중지 버튼 스타일, 실행 설정 행 정리, 로그 스타일
- `frontend/src/components/bots/BotCard.tsx` — 오류 봇 액션, 모드 뱃지 색상
- `frontend/src/components/bots/BotStopModal.tsx` — 목업 일치 재작성
- `frontend/src/components/bots/BotDeleteModal.tsx` — 목업 일치 재작성
- `frontend/src/components/bots/BotCreateForm.tsx` — 대상 종목 필드 제거, 토글 스타일

## Test plan

- [x] TypeScript 타입 체크 통과 (`npx tsc --noEmit`)
- [x] ESLint 통과
- [x] 백엔드 테스트 1587 passed
- [ ] 브라우저에서 봇 목록 페이지가 목업과 동일한 레이아웃으로 렌더링되는지 확인
- [ ] 운영 중 봇 상세가 목업과 일치하는지 확인
- [ ] 정지 봇 상세가 목업과 일치하는지 확인
- [ ] 중지/삭제 모달이 목업과 일치하는지 확인

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)