### PR TITLE
feat(dashboard): 성과 분석·거래 내역 페이지 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,8 @@ import BotDetail from './pages/BotDetail'
 import BacktestData from './pages/BacktestData'
 import Agents from './pages/Agents'
 import AgentDetail from './pages/AgentDetail'
+import Performance from './pages/Performance'
+import Trades from './pages/Trades'
 import ReportDetail from './pages/ReportDetail'
 import Settings from './pages/Settings'
 import NotFound from './pages/NotFound'
@@ -52,6 +54,8 @@ export default function App() {
               <Route path="treasury/history" element={<TreasuryHistory />} />
               <Route path="strategies" element={<Strategies />} />
               <Route path="strategies/:id" element={<StrategyDetail />} />
+              <Route path="strategies/:id/performance" element={<Performance />} />
+              <Route path="strategies/:id/trades" element={<Trades />} />
               <Route path="bots" element={<Bots />} />
               <Route path="bots/:id" element={<BotDetail />} />
               <Route path="reports/:id" element={<ReportDetail />} />

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -1,5 +1,5 @@
 import client from './client'
-import type { Strategy, StrategyDetail, StrategyPerformance, Trade, DailySummary, MonthlySummary } from '../types/strategy'
+import type { Strategy, StrategyDetail, StrategyPerformance, Trade, DailySummary, MonthlySummary, WeeklySummary } from '../types/strategy'
 
 export async function getStrategies(): Promise<Strategy[]> {
   const res = await client.get('/api/strategies')
@@ -29,7 +29,20 @@ export async function getStrategyDailySummary(id: string): Promise<DailySummary[
   return res.data.items
 }
 
+export async function getStrategyWeeklySummary(id: string): Promise<WeeklySummary[]> {
+  const res = await client.get(`/api/strategies/${id}/weekly-summary`)
+  return res.data.items
+}
+
 export async function getStrategyMonthlySummary(id: string): Promise<MonthlySummary[]> {
   const res = await client.get(`/api/strategies/${id}/monthly-summary`)
   return res.data.items
+}
+
+export async function getStrategyTradesPaginated(
+  id: string,
+  params?: { offset?: number; limit?: number; side?: string; start_date?: string; end_date?: string },
+): Promise<{ items: Trade[]; total: number }> {
+  const res = await client.get(`/api/strategies/${id}/trades`, { params })
+  return { items: res.data.trades ?? [], total: res.data.total ?? 0 }
 }

--- a/frontend/src/hooks/useStrategies.ts
+++ b/frontend/src/hooks/useStrategies.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { getStrategies, getStrategyDetail, getStrategyPerformance, getStrategyTrades, getStrategyDailySummary, getStrategyMonthlySummary } from '../api/strategies'
+import { getStrategies, getStrategyDetail, getStrategyPerformance, getStrategyTrades, getStrategyDailySummary, getStrategyWeeklySummary, getStrategyMonthlySummary, getStrategyTradesPaginated } from '../api/strategies'
 
 export function useStrategies() {
   return useQuery({
@@ -40,10 +40,29 @@ export function useStrategyDailySummary(id: string) {
   })
 }
 
+export function useStrategyWeeklySummary(id: string) {
+  return useQuery({
+    queryKey: ['strategies', id, 'weekly-summary'],
+    queryFn: () => getStrategyWeeklySummary(id),
+    enabled: !!id,
+  })
+}
+
 export function useStrategyMonthlySummary(id: string) {
   return useQuery({
     queryKey: ['strategies', id, 'monthly-summary'],
     queryFn: () => getStrategyMonthlySummary(id),
+    enabled: !!id,
+  })
+}
+
+export function useStrategyTradesPaginated(
+  id: string,
+  params?: { offset?: number; limit?: number; side?: string; start_date?: string; end_date?: string },
+) {
+  return useQuery({
+    queryKey: ['strategies', id, 'trades-paginated', params],
+    queryFn: () => getStrategyTradesPaginated(id, params),
     enabled: !!id,
   })
 }

--- a/frontend/src/pages/Performance.tsx
+++ b/frontend/src/pages/Performance.tsx
@@ -1,0 +1,262 @@
+import { useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { useStrategyPerformance, useStrategyDailySummary, useStrategyWeeklySummary, useStrategyMonthlySummary } from '../hooks/useStrategies'
+import { PageSkeleton } from '../components/common/Skeleton'
+import Pagination from '../components/common/Pagination'
+import { formatKRW, formatPercent } from '../utils/formatters'
+import type { DailySummary, WeeklySummary, MonthlySummary } from '../types/strategy'
+
+type PeriodTab = 'daily' | 'weekly' | 'monthly'
+
+const DAILY_PAGE_SIZE = 20
+const WEEKLY_PAGE_SIZE = 20
+const MONTHLY_PAGE_SIZE = 20
+
+function StatCard({ label, value, colorClass }: { label: string; value: string; colorClass?: string }) {
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5">
+      <div className="text-[12px] text-text-muted mb-1">{label}</div>
+      <div className={`text-[20px] font-bold ${colorClass ?? ''}`}>{value}</div>
+    </div>
+  )
+}
+
+function DailyTable({ items, offset }: { items: DailySummary[]; offset: number }) {
+  const page = items.slice(offset, offset + DAILY_PAGE_SIZE)
+
+  if (page.length === 0) {
+    return <div className="py-8 text-center text-text-muted text-[13px]">데이터가 없습니다</div>
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">일자</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">거래 수</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">승률</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">실현 손익</th>
+          </tr>
+        </thead>
+        <tbody>
+          {page.map((d) => (
+            <tr key={d.date} className="hover:bg-surface-hover">
+              <td className="px-3 py-2.5 border-b border-border text-[13px]">{d.date}</td>
+              <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{d.trade_count}</td>
+              <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{formatPercent(d.win_rate)}</td>
+              <td className={`px-3 py-2.5 border-b border-border text-[13px] text-right ${d.realized_pnl >= 0 ? 'text-positive' : 'text-negative'}`}>
+                {formatKRW(d.realized_pnl)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function WeeklyTable({ items, offset }: { items: WeeklySummary[]; offset: number }) {
+  const page = items.slice(offset, offset + WEEKLY_PAGE_SIZE)
+
+  if (page.length === 0) {
+    return <div className="py-8 text-center text-text-muted text-[13px]">데이터가 없습니다</div>
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">주간</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">거래 수</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">승률</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">실현 손익</th>
+          </tr>
+        </thead>
+        <tbody>
+          {page.map((w) => (
+            <tr key={w.week_start} className="hover:bg-surface-hover">
+              <td className="px-3 py-2.5 border-b border-border text-[13px]">{w.week_start} ~ {w.week_end.slice(5)}</td>
+              <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{w.trade_count}</td>
+              <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{formatPercent(w.win_rate)}</td>
+              <td className={`px-3 py-2.5 border-b border-border text-[13px] text-right ${w.realized_pnl >= 0 ? 'text-positive' : 'text-negative'}`}>
+                {formatKRW(w.realized_pnl)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function MonthlyTable({ items, offset }: { items: MonthlySummary[]; offset: number }) {
+  const page = items.slice(offset, offset + MONTHLY_PAGE_SIZE)
+
+  if (page.length === 0) {
+    return <div className="py-8 text-center text-text-muted text-[13px]">데이터가 없습니다</div>
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">월</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">거래 수</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">승률</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">실현 손익</th>
+          </tr>
+        </thead>
+        <tbody>
+          {page.map((m) => (
+            <tr key={`${m.year}-${m.month}`} className="hover:bg-surface-hover">
+              <td className="px-3 py-2.5 border-b border-border text-[13px]">{m.year}-{String(m.month).padStart(2, '0')}</td>
+              <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{m.trade_count}</td>
+              <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{formatPercent(m.win_rate)}</td>
+              <td className={`px-3 py-2.5 border-b border-border text-[13px] text-right ${m.realized_pnl >= 0 ? 'text-positive' : 'text-negative'}`}>
+                {formatKRW(m.realized_pnl)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default function Performance() {
+  const { id = '' } = useParams<{ id: string }>()
+  const [tab, setTab] = useState<PeriodTab>('monthly')
+  const [dailyOffset, setDailyOffset] = useState(0)
+  const [weeklyOffset, setWeeklyOffset] = useState(0)
+  const [monthlyOffset, setMonthlyOffset] = useState(0)
+
+  const { data: performance, isLoading } = useStrategyPerformance(id)
+  const { data: dailyData } = useStrategyDailySummary(id)
+  const { data: weeklyData } = useStrategyWeeklySummary(id)
+  const { data: monthlyData } = useStrategyMonthlySummary(id)
+
+  if (isLoading) return <PageSkeleton />
+
+  const daily = (dailyData ?? []).slice().reverse()
+  const weekly = (weeklyData ?? []).slice().reverse()
+  const monthly = (monthlyData ?? []).slice().reverse()
+
+  const tabConfig: { key: PeriodTab; label: string }[] = [
+    { key: 'daily', label: '일별' },
+    { key: 'weekly', label: '주별' },
+    { key: 'monthly', label: '월별' },
+  ]
+
+  const totalPnl = performance?.realized_pnl ?? 0
+  const totalTrades = performance?.total_trades ?? 0
+  const winRate = performance?.win_rate ?? 0
+  const profitFactor = performance?.profit_factor
+
+  return (
+    <>
+      {/* 헤더 */}
+      <div className="flex items-center gap-3 mb-6">
+        <Link
+          to={`/strategies/${id}`}
+          className="text-[13px] text-text-muted no-underline hover:text-text"
+        >
+          &larr; 전략 상세
+        </Link>
+        <h2 className="text-[20px] font-bold">기간별 성과</h2>
+      </div>
+
+      {/* 필터 바 */}
+      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+        <div className="flex items-center gap-4 flex-wrap">
+          <div>
+            <label className="text-[12px] text-text-muted block mb-1">기간</label>
+            <div className="flex gap-1 bg-bg rounded-lg p-0.5">
+              {tabConfig.map(({ key, label }) => (
+                <button
+                  key={key}
+                  onClick={() => setTab(key)}
+                  className={`px-3 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
+                    tab === key
+                      ? 'bg-surface text-text'
+                      : 'bg-transparent text-text-muted'
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 요약 카드 */}
+      <div className="grid grid-cols-4 gap-4 mb-6">
+        <StatCard
+          label="조회 기간 실현 손익"
+          value={formatKRW(totalPnl)}
+          colorClass={totalPnl >= 0 ? 'text-positive' : 'text-negative'}
+        />
+        <StatCard label="총 거래 수" value={String(totalTrades)} />
+        <StatCard label="승률" value={formatPercent(winRate)} />
+        <StatCard
+          label="수익 팩터"
+          value={profitFactor == null ? '-' : profitFactor === Infinity ? '∞' : profitFactor.toFixed(2)}
+        />
+      </div>
+
+      {/* 기간별 성과 테이블 */}
+      <div className="bg-surface border border-border rounded-lg p-5">
+        <h3 className="text-[15px] font-semibold mb-4">
+          {tab === 'daily' && '일별 성과'}
+          {tab === 'weekly' && '주별 성과'}
+          {tab === 'monthly' && '월별 성과'}
+        </h3>
+
+        {tab === 'daily' && (
+          <>
+            <DailyTable items={daily} offset={dailyOffset} />
+            {daily.length > DAILY_PAGE_SIZE && (
+              <Pagination
+                total={daily.length}
+                offset={dailyOffset}
+                limit={DAILY_PAGE_SIZE}
+                onPageChange={setDailyOffset}
+              />
+            )}
+          </>
+        )}
+
+        {tab === 'weekly' && (
+          <>
+            <WeeklyTable items={weekly} offset={weeklyOffset} />
+            {weekly.length > WEEKLY_PAGE_SIZE && (
+              <Pagination
+                total={weekly.length}
+                offset={weeklyOffset}
+                limit={WEEKLY_PAGE_SIZE}
+                onPageChange={setWeeklyOffset}
+              />
+            )}
+          </>
+        )}
+
+        {tab === 'monthly' && (
+          <>
+            <MonthlyTable items={monthly} offset={monthlyOffset} />
+            {monthly.length > MONTHLY_PAGE_SIZE && (
+              <Pagination
+                total={monthly.length}
+                offset={monthlyOffset}
+                limit={MONTHLY_PAGE_SIZE}
+                onPageChange={setMonthlyOffset}
+              />
+            )}
+          </>
+        )}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/pages/StrategyDetail.tsx
+++ b/frontend/src/pages/StrategyDetail.tsx
@@ -116,46 +116,60 @@ export default function StrategyDetail() {
       {/* 2열 그리드: 기간별 성과 + 최근 거래 */}
       <div className="grid grid-cols-2 gap-6">
         {/* 좌: 기간별 성과 */}
-        <PeriodPerformance daily={dailySummary} monthly={monthlySummary} />
+        <div>
+          <PeriodPerformance daily={dailySummary} monthly={monthlySummary} />
+          <div className="mt-2 text-right">
+            <Link to={`/strategies/${id}/performance`} className="text-[13px] text-primary no-underline hover:underline">
+              기간별 성과 더보기 &rarr;
+            </Link>
+          </div>
+        </div>
 
         {/* 우: 최근 거래 */}
-        <div className="bg-surface border border-border rounded-lg p-5">
-          <h3 className="text-[15px] font-semibold mb-4">최근 거래</h3>
-          <div className="overflow-x-auto">
-            <table className="w-full border-collapse">
-              <thead>
-                <tr>
-                  <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">종목</th>
-                  <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">방향</th>
-                  <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">가격</th>
-                  <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">손익</th>
-                  <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">체결일</th>
-                </tr>
-              </thead>
-              <tbody>
-                {(tradesData?.items ?? []).length === 0 ? (
-                  <tr><td colSpan={5} className="px-3 py-8 text-center text-text-muted text-[13px]">거래 내역이 없습니다</td></tr>
-                ) : (
-                  (tradesData?.items ?? []).slice(0, 10).map((t) => (
-                    <tr key={t.id} className="hover:bg-surface-hover">
-                      <td className="px-3 py-2.5 border-b border-border text-[13px] font-mono">{t.symbol}</td>
-                      <td className="px-3 py-2.5 border-b border-border text-[13px]">
-                        <StatusBadge variant={t.side === 'buy' ? 'positive' : 'negative'}>
-                          {t.side === 'buy' ? '매수' : '매도'}
-                        </StatusBadge>
-                      </td>
-                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{formatKRW(t.price)}</td>
-                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">
-                        {t.pnl != null ? (
-                          <span className={t.pnl >= 0 ? 'text-positive' : 'text-negative'}>{formatKRW(t.pnl)}</span>
-                        ) : '-'}
-                      </td>
-                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-text-muted">{formatDateTime(t.executed_at)}</td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
+        <div>
+          <div className="bg-surface border border-border rounded-lg p-5">
+            <h3 className="text-[15px] font-semibold mb-4">최근 거래</h3>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr>
+                    <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">종목</th>
+                    <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">방향</th>
+                    <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">가격</th>
+                    <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">손익</th>
+                    <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">체결일</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(tradesData?.items ?? []).length === 0 ? (
+                    <tr><td colSpan={5} className="px-3 py-8 text-center text-text-muted text-[13px]">거래 내역이 없습니다</td></tr>
+                  ) : (
+                    (tradesData?.items ?? []).slice(0, 10).map((t) => (
+                      <tr key={t.id} className="hover:bg-surface-hover">
+                        <td className="px-3 py-2.5 border-b border-border text-[13px] font-mono">{t.symbol}</td>
+                        <td className="px-3 py-2.5 border-b border-border text-[13px]">
+                          <StatusBadge variant={t.side === 'buy' ? 'negative' : 'positive'}>
+                            {t.side === 'buy' ? '매수' : '매도'}
+                          </StatusBadge>
+                        </td>
+                        <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{formatKRW(t.price)}</td>
+                        <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">
+                          {t.pnl != null ? (
+                            <span className={t.pnl >= 0 ? 'text-positive' : 'text-negative'}>{formatKRW(t.pnl)}</span>
+                          ) : '-'}
+                        </td>
+                        <td className="px-3 py-2.5 border-b border-border text-[13px] text-text-muted">{formatDateTime(t.executed_at)}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div className="mt-2 text-right">
+            <Link to={`/strategies/${id}/trades`} className="text-[13px] text-primary no-underline hover:underline">
+              거래 내역 더보기 &rarr;
+            </Link>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/Trades.tsx
+++ b/frontend/src/pages/Trades.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { useStrategyTradesPaginated } from '../hooks/useStrategies'
+import { PageSkeleton } from '../components/common/Skeleton'
+import StatusBadge from '../components/common/StatusBadge'
+import Pagination from '../components/common/Pagination'
+import { formatKRW, formatDateTime } from '../utils/formatters'
+
+const PAGE_SIZE = 15
+
+export default function Trades() {
+  const { id = '' } = useParams<{ id: string }>()
+  const [offset, setOffset] = useState(0)
+  const [sideFilter, setSideFilter] = useState<string>('')
+
+  const { data, isLoading } = useStrategyTradesPaginated(id, {
+    offset,
+    limit: PAGE_SIZE,
+    side: sideFilter || undefined,
+  })
+
+  if (isLoading && !data) return <PageSkeleton />
+
+  const trades = data?.items ?? []
+  const total = data?.total ?? 0
+
+  return (
+    <>
+      {/* 헤더 */}
+      <div className="flex items-center gap-3 mb-6">
+        <Link
+          to={`/strategies/${id}`}
+          className="text-[13px] text-text-muted no-underline hover:text-text"
+        >
+          &larr; 전략 상세
+        </Link>
+        <h2 className="text-[20px] font-bold">거래 내역</h2>
+      </div>
+
+      {/* 필터 바 */}
+      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+        <div className="flex items-center gap-4 flex-wrap">
+          <div>
+            <label className="text-[12px] text-text-muted block mb-1">매매</label>
+            <select
+              value={sideFilter}
+              onChange={(e) => {
+                setSideFilter(e.target.value)
+                setOffset(0)
+              }}
+              className="h-8 px-3 rounded-lg border border-border bg-bg text-[13px] text-text"
+            >
+              <option value="">전체</option>
+              <option value="buy">매수</option>
+              <option value="sell">매도</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {/* 거래 테이블 */}
+      <div className="bg-surface border border-border rounded-lg p-5">
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr>
+                <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">시각</th>
+                <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">종목</th>
+                <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">매매</th>
+                <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">수량</th>
+                <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">단가</th>
+                <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">금액</th>
+                <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">수수료</th>
+                <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">손익</th>
+              </tr>
+            </thead>
+            <tbody>
+              {trades.length === 0 ? (
+                <tr>
+                  <td colSpan={8} className="px-3 py-8 text-center text-text-muted text-[13px]">
+                    거래 내역이 없습니다
+                  </td>
+                </tr>
+              ) : (
+                trades.map((t) => {
+                  const amount = t.quantity * t.price
+                  const displayName = t.symbol_name
+                    ? `${t.symbol_name} (${t.symbol})`
+                    : t.symbol
+
+                  return (
+                    <tr key={t.id} className="hover:bg-surface-hover">
+                      <td className="px-3 py-2.5 border-b border-border text-[13px] font-mono">
+                        {formatDateTime(t.executed_at)}
+                      </td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px]">
+                        {displayName}
+                      </td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px]">
+                        <StatusBadge variant={t.side === 'buy' ? 'negative' : 'positive'}>
+                          {t.side === 'buy' ? '매수' : '매도'}
+                        </StatusBadge>
+                      </td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">
+                        {t.quantity.toLocaleString()}
+                      </td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">
+                        {formatKRW(t.price)}
+                      </td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">
+                        {formatKRW(amount)}
+                      </td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right text-text-muted">
+                        {t.commission != null ? formatKRW(t.commission) : '-'}
+                      </td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">
+                        {t.pnl != null ? (
+                          <span className={t.pnl >= 0 ? 'text-positive' : 'text-negative'}>
+                            {formatKRW(t.pnl)}
+                          </span>
+                        ) : (
+                          <span className="text-text-muted">&mdash;</span>
+                        )}
+                      </td>
+                    </tr>
+                  )
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {total > PAGE_SIZE && (
+          <Pagination
+            total={total}
+            offset={offset}
+            limit={PAGE_SIZE}
+            onPageChange={setOffset}
+          />
+        )}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/types/strategy.ts
+++ b/frontend/src/types/strategy.ts
@@ -50,14 +50,24 @@ export interface MonthlySummary {
   win_rate: number
 }
 
+export interface WeeklySummary {
+  week_start: string
+  week_end: string
+  realized_pnl: number
+  trade_count: number
+  win_rate: number
+}
+
 export interface Trade {
   id: number
   strategy_id: number
   bot_id: string
   symbol: string
+  symbol_name?: string
   side: 'buy' | 'sell'
   quantity: number
   price: number
   executed_at: string
   pnl?: number
+  commission?: number
 }


### PR DESCRIPTION
## Summary

- 목업 HTML(`performance.html`, `trades.html`)에 맞춰 **기간별 성과 분석** 페이지와 **거래 내역** 페이지를 신규 구현
- 성과 분석: 일별/주별/월별 탭 전환, 요약 카드(실현 손익·거래 수·승률·수익 팩터), 페이지네이션 포함
- 거래 내역: 전체 컬럼(시각/종목/매매/수량/단가/금액/수수료/손익) 구현, 매매 필터·페이지네이션 포함
- 전략 상세(`StrategyDetail`)에서 성과/거래 더보기 링크 추가, 매수/매도 배지 색상 목업 일치

Closes #341

## Test plan

- [ ] `/strategies/:id/performance` 접속 시 기간별 성과 페이지 렌더링 확인
- [ ] 일별/주별/월별 탭 전환이 정상 동작하는지 확인
- [ ] 요약 카드 4종이 목업과 동일한 레이아웃으로 표시되는지 확인
- [ ] `/strategies/:id/trades` 접속 시 거래 내역 페이지 렌더링 확인
- [ ] 매매 필터(전체/매수/매도)가 정상 동작하는지 확인
- [ ] 페이지네이션이 정상 동작하는지 확인
- [ ] 전략 상세에서 "기간별 성과 더보기", "거래 내역 더보기" 링크가 올바른 페이지로 이동하는지 확인
- [ ] TypeScript 타입 체크 통과 (`tsc --noEmit`)
- [ ] ESLint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)