### PR TITLE
epic/#331: 프론트엔드 목업 충실도 개선

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,8 @@ import BotDetail from './pages/BotDetail'
 import BacktestData from './pages/BacktestData'
 import Agents from './pages/Agents'
 import AgentDetail from './pages/AgentDetail'
+import Performance from './pages/Performance'
+import Trades from './pages/Trades'
 import ReportDetail from './pages/ReportDetail'
 import Settings from './pages/Settings'
 import NotFound from './pages/NotFound'
@@ -52,6 +54,8 @@ export default function App() {
               <Route path="treasury/history" element={<TreasuryHistory />} />
               <Route path="strategies" element={<Strategies />} />
               <Route path="strategies/:id" element={<StrategyDetail />} />
+              <Route path="strategies/:id/performance" element={<Performance />} />
+              <Route path="strategies/:id/trades" element={<Trades />} />
               <Route path="bots" element={<Bots />} />
               <Route path="bots/:id" element={<BotDetail />} />
               <Route path="reports/:id" element={<ReportDetail />} />

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -1,5 +1,5 @@
 import client from './client'
-import type { Strategy, StrategyDetail, StrategyPerformance, Trade, DailySummary, MonthlySummary } from '../types/strategy'
+import type { Strategy, StrategyDetail, StrategyPerformance, Trade, DailySummary, WeeklySummary, MonthlySummary } from '../types/strategy'
 
 export async function getStrategies(): Promise<Strategy[]> {
   const res = await client.get('/api/strategies')
@@ -26,6 +26,11 @@ export async function getStrategyTrades(
 
 export async function getStrategyDailySummary(id: string): Promise<DailySummary[]> {
   const res = await client.get(`/api/strategies/${id}/daily-summary`)
+  return res.data.items
+}
+
+export async function getStrategyWeeklySummary(id: string): Promise<WeeklySummary[]> {
+  const res = await client.get(`/api/strategies/${id}/weekly-summary`)
   return res.data.items
 }
 

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -1,5 +1,5 @@
 import client from './client'
-import type { Strategy, StrategyDetail, StrategyPerformance, Trade, DailySummary, MonthlySummary } from '../types/strategy'
+import type { Strategy, StrategyDetail, StrategyPerformance, Trade, DailySummary, MonthlySummary, WeeklySummary } from '../types/strategy'
 
 export async function getStrategies(): Promise<Strategy[]> {
   const res = await client.get('/api/strategies')
@@ -29,7 +29,20 @@ export async function getStrategyDailySummary(id: string): Promise<DailySummary[
   return res.data.items
 }
 
+export async function getStrategyWeeklySummary(id: string): Promise<WeeklySummary[]> {
+  const res = await client.get(`/api/strategies/${id}/weekly-summary`)
+  return res.data.items
+}
+
 export async function getStrategyMonthlySummary(id: string): Promise<MonthlySummary[]> {
   const res = await client.get(`/api/strategies/${id}/monthly-summary`)
   return res.data.items
+}
+
+export async function getStrategyTradesPaginated(
+  id: string,
+  params?: { offset?: number; limit?: number; side?: string; start_date?: string; end_date?: string },
+): Promise<{ items: Trade[]; total: number }> {
+  const res = await client.get(`/api/strategies/${id}/trades`, { params })
+  return { items: res.data.trades ?? [], total: res.data.total ?? 0 }
 }

--- a/frontend/src/components/agents/AgentRegisterForm.tsx
+++ b/frontend/src/components/agents/AgentRegisterForm.tsx
@@ -1,18 +1,25 @@
 import { useState } from 'react'
-import { useCreateMember } from '../../hooks/useMembers'
+import { useCreateMember, useMembers } from '../../hooks/useMembers'
 import { ALL_SCOPES } from '../../types/member'
+
+const DEFAULT_ORGS = ['default', 'strategy-lab', 'risk', 'treasury', 'operations']
 
 interface AgentRegisterFormProps {
   onClose: () => void
-  onTokenCreated: (token: string) => void
+  onTokenCreated: (agentId: string, token: string) => void
 }
 
 export default function AgentRegisterForm({ onClose, onTokenCreated }: AgentRegisterFormProps) {
   const [memberId, setMemberId] = useState('')
   const [name, setName] = useState('')
-  const [org, setOrg] = useState('')
+  const [org, setOrg] = useState('default')
   const [scopes, setScopes] = useState<string[]>([])
   const createMember = useCreateMember()
+
+  // 기존 소속 목록에서 동적으로 추출, 기본값과 병합
+  const { data: allMembers } = useMembers({})
+  const existingOrgs = Array.from(new Set((allMembers ?? []).map((m) => m.org).filter(Boolean)))
+  const orgOptions = Array.from(new Set([...DEFAULT_ORGS, ...existingOrgs]))
 
   const toggleScope = (scope: string) => {
     setScopes((prev) => prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope])
@@ -22,7 +29,7 @@ export default function AgentRegisterForm({ onClose, onTokenCreated }: AgentRegi
     e.preventDefault()
     createMember.mutate(
       { member_id: memberId, name, org, scopes },
-      { onSuccess: (data) => onTokenCreated(data.token) },
+      { onSuccess: (data) => onTokenCreated(memberId, data.token) },
     )
   }
 
@@ -33,18 +40,27 @@ export default function AgentRegisterForm({ onClose, onTokenCreated }: AgentRegi
         <form onSubmit={handleSubmit}>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">Agent ID</label>
-            <input value={memberId} onChange={(e) => setMemberId(e.target.value)} placeholder="agent-research-01" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
+            <input value={memberId} onChange={(e) => setMemberId(e.target.value)} placeholder="strategy-dev-03" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
+            <div className="text-[12px] text-text-muted mt-1">영문, 숫자, 하이픈만 사용 가능</div>
           </div>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">이름</label>
-            <input value={name} onChange={(e) => setName(e.target.value)} placeholder="리서치 에이전트" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
+            <input value={name} onChange={(e) => setName(e.target.value)} placeholder="전략 리서치 3호" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
           </div>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">소속 (org)</label>
-            <input value={org} onChange={(e) => setOrg(e.target.value)} placeholder="research" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
+            <select
+              value={org}
+              onChange={(e) => setOrg(e.target.value)}
+              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary cursor-pointer"
+            >
+              {orgOptions.map((o) => (
+                <option key={o} value={o}>{o}</option>
+              ))}
+            </select>
           </div>
           <div className="mb-4">
-            <label className="block text-[12px] font-semibold text-text-muted mb-2">권한 범위</label>
+            <label className="block text-[12px] font-semibold text-text-muted mb-2">권한 범위 (Scopes)</label>
             <div className="grid grid-cols-2 gap-2">
               {ALL_SCOPES.map((scope) => (
                 <label key={scope} className="flex items-center gap-2 text-[13px] cursor-pointer">

--- a/frontend/src/components/agents/MemberCard.tsx
+++ b/frontend/src/components/agents/MemberCard.tsx
@@ -33,68 +33,114 @@ export default function MemberCard({ member, onSuspend, onReactivate, onRevoke, 
   const role = member.role ?? (isOwner ? 'owner' : undefined)
 
   const isRevoked = member.status === 'revoked'
+  const isHuman = member.type === 'human'
+  const isAgent = member.type === 'agent'
+
+  const avatarColorClass = isHuman
+    ? 'bg-info-bg text-info'
+    : 'bg-positive-bg text-positive'
 
   return (
     <div
-      onClick={() => navigate(`/members/${member.member_id}`)}
-      className={`bg-surface border border-border rounded-lg p-5 flex gap-4 items-start cursor-pointer hover:border-primary/50 transition-colors${isRevoked ? ' opacity-50' : ''}`}
+      onClick={() => isAgent ? navigate(`/members/${member.member_id}`) : undefined}
+      className={`bg-surface border border-border rounded-lg p-5 flex gap-5 transition-colors${isRevoked ? ' opacity-50' : ''}${isAgent ? ' cursor-pointer hover:border-primary/50' : ''}`}
     >
-      <div className="relative shrink-0">
-        {role === 'owner' && (
-          <div className="absolute -top-3 left-1/2 -translate-x-1/2 text-[16px] leading-none">
+      {/* 프로필 아바타 */}
+      <div className="relative shrink-0 flex items-start justify-center">
+        {isOwner && (
+          <div className="absolute -top-[13px] left-1/2 -translate-x-1/2 text-[16px] leading-none">
             {'👑'}
           </div>
         )}
-        <div className={`w-[56px] h-[56px] rounded-full bg-bg flex items-center justify-center text-[28px]${isRevoked ? ' blur-[2px]' : ''}`}>
-          {member.emoji || (member.type === 'human' ? '👤' : '🤖')}
+        <div className={`w-[72px] h-[72px] rounded-full flex items-center justify-center text-[45px] shrink-0 transition-transform hover:scale-[1.15] hover:-rotate-[8deg] cursor-default ${avatarColorClass}${isRevoked ? ' opacity-50' : ''}`}>
+          {member.emoji || (isHuman ? '👤' : '🤖')}
         </div>
       </div>
+
+      {/* 카드 본문 */}
       <div className="flex-1 min-w-0">
-        <div className="flex items-center justify-between mb-1">
-          <div className="flex items-center gap-2">
-            <span className="text-[15px] font-semibold">{member.name}</span>
-            {role && (
-              <span className={`text-[11px] font-medium px-1.5 py-0.5 rounded ${ROLE_BADGE_STYLE[role]}`}>
-                {ROLE_LABELS[role]}
-              </span>
-            )}
+        {/* 헤더: ID + 역할/상태 뱃지 */}
+        <div className="flex items-center justify-between mb-[10px]">
+          <div>
+            <div className="text-[15px] font-semibold">{member.member_id}</div>
+            <div className="text-[13px] text-text-muted">{member.name}</div>
           </div>
-          <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>{MEMBER_STATUS_LABELS[member.status]}</StatusBadge>
+          {isHuman && role ? (
+            <span className={`text-[11px] font-medium px-1.5 py-0.5 rounded ${ROLE_BADGE_STYLE[role]}`}>
+              {ROLE_LABELS[role]}
+            </span>
+          ) : (
+            <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>
+              {MEMBER_STATUS_LABELS[member.status]}
+            </StatusBadge>
+          )}
         </div>
-        <div className="text-[13px] text-text-muted font-mono mb-2">{member.member_id}</div>
-        <div className="text-[12px] text-text-muted mb-3">소속: {member.org}</div>
-        {member.scopes && member.scopes.length > 0 && (
-          <div className="flex flex-wrap gap-1 mb-3">
-            {member.scopes.slice(0, 4).map((scope) => (
-              <span key={scope} className="bg-bg text-text-muted text-[11px] px-2 py-0.5 rounded">{scope}</span>
+
+        {/* 메타 정보 */}
+        <div className="flex flex-col gap-1.5 text-[13px] text-text-muted mb-4">
+          {isHuman ? (
+            <>
+              <div className="flex justify-between">
+                <span className="text-text-muted">상태</span>
+                <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>
+                  {MEMBER_STATUS_LABELS[member.status]}
+                </StatusBadge>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-text-muted">소속</span>
+                <span>{member.org}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-text-muted">마지막 활동</span>
+                <span>{member.last_active_at || '-'}</span>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="flex justify-between">
+                <span className="text-text-muted">소속</span>
+                <StatusBadge variant="muted">{member.org}</StatusBadge>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-text-muted">마지막 활동</span>
+                <span>{member.last_active_at || '-'}</span>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* 스코프 태그 (에이전트만) */}
+        {isAgent && member.scopes && member.scopes.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {member.scopes.map((scope) => (
+              <span key={scope} className="text-[11px] px-1.5 py-[1px] rounded-sm bg-bg border border-border text-text-muted">{scope}</span>
             ))}
-            {member.scopes.length > 4 && (
-              <span className="text-text-muted text-[11px]">+{member.scopes.length - 4}</span>
-            )}
           </div>
         )}
+
         {/* Human 멤버 액션 버튼 */}
-        {!isRevoked && member.type === 'human' && (onSuspend || onChangePassword) && (
+        {!isRevoked && isHuman && (onSuspend || onChangePassword) && (
           <div className="flex gap-2 justify-end" onClick={(e) => e.stopPropagation()}>
             {!isOwner && member.status === 'active' && onSuspend && (
-              <button onClick={() => onSuspend(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-warning border border-border cursor-pointer hover:bg-warning-bg">정지</button>
+              <button onClick={() => onSuspend(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">정지</button>
             )}
             {onChangePassword && (
               <button onClick={() => onChangePassword(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">비밀번호 변경</button>
             )}
           </div>
         )}
+
         {/* Agent 멤버 액션 버튼 */}
-        {!isRevoked && member.type === 'agent' && (onSuspend || onReactivate || onRevoke) && (
-          <div className="flex gap-2 justify-end" onClick={(e) => e.stopPropagation()}>
+        {!isRevoked && isAgent && (onSuspend || onReactivate || onRevoke) && (
+          <div className="flex gap-2 justify-end mt-3" onClick={(e) => e.stopPropagation()}>
             {member.status === 'active' && onSuspend && (
-              <button onClick={() => onSuspend(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-warning border border-border cursor-pointer hover:bg-warning-bg">정지</button>
+              <button onClick={() => onSuspend(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">정지</button>
             )}
             {member.status === 'suspended' && onReactivate && (
               <button onClick={() => onReactivate(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">재활성화</button>
             )}
-            {member.status !== 'revoked' && onRevoke && (
-              <button onClick={() => onRevoke(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-negative border border-border cursor-pointer hover:bg-negative-bg">폐기</button>
+            {onRevoke && (
+              <button onClick={() => onRevoke(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-negative border-none cursor-pointer hover:bg-negative-bg">폐기</button>
             )}
           </div>
         )}

--- a/frontend/src/components/approvals/ApprovalFilters.tsx
+++ b/frontend/src/components/approvals/ApprovalFilters.tsx
@@ -38,12 +38,9 @@ export default function ApprovalFilters({ status, type, search, pendingCount, on
               status === opt.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
             }`}
           >
-            {opt.label}
-            {opt.key === 'pending' && pendingCount > 0 && (
-              <span className="ml-1 bg-border text-text text-[11px] px-1.5 py-0.5 rounded-full">
-                {pendingCount}
-              </span>
-            )}
+            {opt.key === 'pending' && pendingCount > 0
+              ? `${opt.label} (${pendingCount})`
+              : opt.label}
           </button>
         ))}
       </div>

--- a/frontend/src/components/approvals/ApprovalTable.tsx
+++ b/frontend/src/components/approvals/ApprovalTable.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import StatusBadge from '../common/StatusBadge'
 import { formatDateTime } from '../../utils/formatters'
 import type { Approval, ApprovalStatus, ApprovalType } from '../../types/approval'
@@ -19,19 +19,17 @@ const STATUS_VARIANT: Record<ApprovalStatus, string> = {
 }
 
 export default function ApprovalTable({ items }: { items: Approval[] }) {
-  const navigate = useNavigate()
-
   return (
     <div className="overflow-x-auto">
       <table className="w-full border-collapse">
         <thead>
           <tr>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">유형</th>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">제목</th>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">요청자</th>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">요청일</th>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">상태</th>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">처리일</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">유형</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">제목</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">요청자</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">요청일</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">상태</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">처리일</th>
           </tr>
         </thead>
         <tbody>
@@ -43,14 +41,19 @@ export default function ApprovalTable({ items }: { items: Approval[] }) {
             items.map((item) => (
                 <tr
                   key={item.id}
-                  onClick={() => navigate(`/approvals/${item.id}`)}
-                  className="hover:bg-surface-hover cursor-pointer"
+                  className="hover:bg-surface-hover"
                 >
                   <td className="px-3 py-3 border-b border-border text-[13px]">
                     <StatusBadge variant="muted">{TYPE_LABEL[item.type] || item.type}</StatusBadge>
                   </td>
-                  <td className="px-3 py-3 border-b border-border text-[13px]">{item.title}</td>
-                  <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{item.requester}</td>
+                  <td className="px-3 py-3 border-b border-border text-[13px]">
+                    <Link to={`/approvals/${item.id}`} className="text-primary no-underline hover:underline">
+                      {item.title}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-3 border-b border-border text-[13px]">
+                    <span className="text-primary">{item.requester}</span>
+                  </td>
                   <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{formatDateTime(item.requested_at)}</td>
                   <td className="px-3 py-3 border-b border-border text-[13px]">
                     <StatusBadge variant={STATUS_VARIANT[item.status] as 'warning'}>

--- a/frontend/src/components/approvals/ExecutionContent.tsx
+++ b/frontend/src/components/approvals/ExecutionContent.tsx
@@ -1,3 +1,4 @@
+import StatusBadge from '../common/StatusBadge'
 import type { ApprovalType } from '../../types/approval'
 
 interface ExecutionContentProps {
@@ -5,11 +6,11 @@ interface ExecutionContentProps {
   params?: Record<string, unknown>
 }
 
-const INFO_BANNERS: Record<ApprovalType, { text: string; variant: 'info' | 'warning' }> = {
+const INFO_BANNERS: Record<ApprovalType, { text: string; variant: 'info' | 'negative' }> = {
   strategy_adopt: { text: '승인 시 해당 전략이 채택(registered) 상태로 전환됩니다.', variant: 'info' },
   budget_change: { text: '승인 시 Treasury에서 예산이 즉시 재배분됩니다.', variant: 'info' },
   bot_create: { text: '승인 시 BotManager에서 봇이 즉시 생성됩니다.', variant: 'info' },
-  bot_stop: { text: '승인 시 해당 봇의 거래가 즉시 중지됩니다.', variant: 'warning' },
+  bot_stop: { text: '승인 시 해당 봇의 거래가 즉시 중지됩니다.', variant: 'negative' },
   rule_change: { text: '승인 시 RuleEngine에서 해당 봇의 규칙이 즉시 갱신됩니다.', variant: 'info' },
 }
 
@@ -17,18 +18,18 @@ function InfoBanner({ type }: { type: ApprovalType }) {
   const banner = INFO_BANNERS[type]
   if (!banner) return null
 
-  const isWarning = banner.variant === 'warning'
+  const isNegative = banner.variant === 'negative'
   return (
-    <div className={`${isWarning ? 'bg-warning/10 text-warning' : 'bg-info/10 text-info'} p-3 rounded text-[12px] mb-4`}>
-      {isWarning ? '\u26A0' : '\uD83D\uDCA1'} {banner.text}
+    <div className={`${isNegative ? 'bg-negative/10 text-negative' : 'bg-info/10 text-info'} p-3 rounded text-[12px] mb-4`}>
+      {isNegative ? '\u26A0' : '\uD83D\uDCA1'} {banner.text}
     </div>
   )
 }
 
 function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
   return (
-    <div className="flex justify-between py-2 border-b border-border text-[13px]">
-      <span className="text-text-muted">{label}</span>
+    <div className="flex justify-between py-2 border-b border-border last:border-b-0 text-[13px]">
+      <span className="text-text-muted min-w-[80px]">{label}</span>
       <span>{value}</span>
     </div>
   )
@@ -43,7 +44,9 @@ function formatCurrency(value: unknown): string {
 function StrategyAdoptContent({ params }: { params: Record<string, unknown> }) {
   return (
     <>
-      <InfoRow label="대상 전략" value={<span className="font-mono text-[12px]">{String(params.strategy_name ?? '-')}</span>} />
+      <InfoRow label="대상 전략" value={
+        <span className="font-mono text-[12px] text-primary">{String(params.strategy_name ?? '-')}</span>
+      } />
       <InfoRow label="버전" value={String(params.version ?? '-')} />
     </>
   )
@@ -55,23 +58,37 @@ function BudgetChangeContent({ params }: { params: Record<string, unknown> }) {
   const diff = requested - current
   const pct = current > 0 ? ((diff / current) * 100).toFixed(0) : '-'
   const sign = diff >= 0 ? '+' : ''
+  const colorClass = diff >= 0 ? 'text-positive' : 'text-negative'
 
   return (
     <>
-      <InfoRow label="대상 봇" value={<span className="font-mono text-[12px]">{String(params.bot_id ?? '-')}</span>} />
+      <InfoRow label="대상 봇" value={
+        <span className="font-mono text-[12px] text-primary">{String(params.bot_id ?? '-')}</span>
+      } />
       <InfoRow label="현재 예산" value={formatCurrency(current)} />
-      <InfoRow label="요청 예산" value={formatCurrency(requested)} />
-      <InfoRow label="변경폭" value={`${sign}${formatCurrency(diff)} (${sign}${pct}%)`} />
+      <InfoRow label="요청 예산" value={
+        <span className={`${colorClass} font-semibold`}>{formatCurrency(requested)}</span>
+      } />
+      <InfoRow label="변경폭" value={
+        <span className={colorClass}>{sign}{formatCurrency(diff)} ({sign}{pct}%)</span>
+      } />
     </>
   )
 }
 
 function BotCreateContent({ params }: { params: Record<string, unknown> }) {
+  const tradeMode = String(params.trade_mode ?? '-')
+  const isMock = tradeMode === 'mock' || tradeMode === '모의투자'
+
   return (
     <>
       <InfoRow label="전략명" value={<span className="font-mono text-[12px]">{String(params.strategy_name ?? '-')}</span>} />
       <InfoRow label="배정 예산" value={formatCurrency(params.budget)} />
-      <InfoRow label="거래 모드" value={String(params.trade_mode ?? '-')} />
+      <InfoRow label="거래 모드" value={
+        isMock
+          ? <StatusBadge variant="warning">모의투자</StatusBadge>
+          : <StatusBadge variant="positive">실전투자</StatusBadge>
+      } />
     </>
   )
 }
@@ -79,7 +96,9 @@ function BotCreateContent({ params }: { params: Record<string, unknown> }) {
 function BotStopContent({ params }: { params: Record<string, unknown> }) {
   return (
     <>
-      <InfoRow label="대상 봇" value={<span className="font-mono text-[12px]">{String(params.bot_id ?? '-')}</span>} />
+      <InfoRow label="대상 봇" value={
+        <span className="font-mono text-[12px] text-primary">{String(params.bot_id ?? '-')}</span>
+      } />
       <InfoRow label="중지 사유" value={String(params.reason ?? '-')} />
     </>
   )
@@ -94,7 +113,9 @@ function RuleChangeContent({ params }: { params: Record<string, unknown> }) {
 
   return (
     <>
-      <InfoRow label="대상 봇" value={<span className="font-mono text-[12px]">{String(params.bot_id ?? '-')}</span>} />
+      <InfoRow label="대상 봇" value={
+        <span className="font-mono text-[12px] text-primary">{String(params.bot_id ?? '-')}</span>
+      } />
       {rules.length > 0 && (
         <div className="mt-3">
           <div className="text-[12px] font-semibold text-text-muted mb-2">변경 규칙</div>
@@ -114,7 +135,7 @@ function RuleChangeContent({ params }: { params: Record<string, unknown> }) {
                     <td className="px-3 py-2 border-b border-border text-[13px] font-mono">{rule.name}</td>
                     <td className="px-3 py-2 border-b border-border text-[13px]">{String(rule.current_value)}</td>
                     <td className="text-center px-2 py-2 border-b border-border text-[13px] text-text-muted">&rarr;</td>
-                    <td className="px-3 py-2 border-b border-border text-[13px]">{String(rule.requested_value)}</td>
+                    <td className="px-3 py-2 border-b border-border text-[13px] text-warning font-semibold">{String(rule.requested_value)}</td>
                   </tr>
                 ))}
               </tbody>
@@ -140,7 +161,7 @@ export default function ExecutionContent({ type, params }: ExecutionContentProps
 
   return (
     <div className="bg-surface border border-border rounded-lg p-5 mb-6">
-      <h3 className="text-[15px] font-semibold mb-3">실행 내용</h3>
+      <h3 className="text-[15px] font-semibold mb-4">실행 내용</h3>
       <InfoBanner type={type} />
       <div className="space-y-0">
         <ContentComponent params={params} />

--- a/frontend/src/components/approvals/ReviewControls.tsx
+++ b/frontend/src/components/approvals/ReviewControls.tsx
@@ -1,16 +1,64 @@
 import { useState } from 'react'
 import { useUpdateApprovalStatus } from '../../hooks/useApprovals'
 import Modal from '../common/Modal'
-import type { ApprovalReview } from '../../types/approval'
+import StatusBadge from '../common/StatusBadge'
+import type { ApprovalReview, ApprovalType } from '../../types/approval'
+
+const APPROVE_ACTION_TEXT: Record<ApprovalType, string> = {
+  strategy_adopt: '전략이 채택 상태로 전환됩니다.',
+  budget_change: 'Treasury에서 예산이 즉시 재배분됩니다.',
+  bot_create: 'BotManager에서 봇이 즉시 생성됩니다.',
+  bot_stop: '해당 봇의 거래가 즉시 중지됩니다.',
+  rule_change: 'RuleEngine에서 해당 봇의 규칙이 즉시 갱신됩니다.',
+}
 
 interface ReviewControlsProps {
   approvalId: string
   isPending: boolean
   title: string
   reviews?: ApprovalReview[]
+  type?: ApprovalType
+  params?: Record<string, unknown>
 }
 
-export default function ReviewControls({ approvalId, isPending, title, reviews }: ReviewControlsProps) {
+function formatCurrency(value: unknown): string {
+  const num = Number(value)
+  if (isNaN(num)) return String(value ?? '-')
+  return `${num.toLocaleString()}원`
+}
+
+function ApproveModalSummary({ type, params }: { type?: ApprovalType; params?: Record<string, unknown> }) {
+  if (!type || !params) return null
+
+  if (type === 'bot_create') {
+    const tradeMode = String(params.trade_mode ?? '')
+    const isMock = tradeMode === 'mock' || tradeMode === '모의투자'
+    return (
+      <div className="text-[13px] text-text-muted mb-4">
+        전략: <span className="font-mono">{String(params.strategy_name ?? '-')}</span>
+        {' · '}예산: {formatCurrency(params.budget)}
+        {' · '}모드: {isMock
+          ? <StatusBadge variant="warning">모의투자</StatusBadge>
+          : <StatusBadge variant="positive">실전투자</StatusBadge>}
+      </div>
+    )
+  }
+
+  if (type === 'budget_change') {
+    const current = Number(params.current_budget ?? 0)
+    const requested = Number(params.requested_budget ?? 0)
+    const diff = requested - current
+    return (
+      <div className="text-[13px] text-text-muted mb-4">
+        예산: {formatCurrency(current)} → <strong className="text-positive">{formatCurrency(requested)}</strong> ({diff >= 0 ? '+' : ''}{formatCurrency(diff)})
+      </div>
+    )
+  }
+
+  return null
+}
+
+export default function ReviewControls({ approvalId, isPending, title, reviews, type, params }: ReviewControlsProps) {
   const [showApprove, setShowApprove] = useState(false)
   const [showReject, setShowReject] = useState(false)
   const [rejectReason, setRejectReason] = useState('')
@@ -56,6 +104,12 @@ export default function ReviewControls({ approvalId, isPending, title, reviews }
         <div className="text-[13px] text-text-muted mb-4">
           <strong className="text-text">{title}</strong>을 승인하시겠습니까?
         </div>
+        <ApproveModalSummary type={type} params={params} />
+        {type && (
+          <div className="bg-info/10 text-info p-3 rounded text-[12px] mb-4">
+            {'\uD83D\uDCA1'} 승인 시 <strong>{APPROVE_ACTION_TEXT[type]}</strong>
+          </div>
+        )}
         {hasWarnings && (
           <div className="bg-warning/10 text-warning p-3 rounded text-[12px] mb-4">
             {'\u26A0'} 검토 의견에 <strong>warn</strong> 또는 <strong>fail</strong> 결과가 포함되어 있습니다. 검증 내용을 확인하세요.

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -52,7 +52,7 @@ export default function LoginForm() {
             className="absolute right-3 top-1/2 -translate-y-1/2 bg-transparent border-none text-text-muted cursor-pointer text-[14px]"
             title="패스워드 표시"
           >
-            {showPassword ? '🙈' : '👁'}
+            {'\u{1F441}'}
           </button>
         </div>
       </div>
@@ -60,7 +60,7 @@ export default function LoginForm() {
       <button
         type="submit"
         disabled={loginMutation.isPending || !memberId || !password}
-        className="w-full py-3 bg-primary text-white rounded-lg text-[14px] font-semibold mt-2 hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer border-none"
+        className="w-full inline-flex items-center justify-center py-3 bg-primary text-white rounded-lg text-[14px] font-semibold mt-2 hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer border-none transition-colors duration-150"
       >
         {loginMutation.isPending ? '로그인 중...' : '로그인'}
       </button>

--- a/frontend/src/components/bots/BotCard.tsx
+++ b/frontend/src/components/bots/BotCard.tsx
@@ -75,7 +75,7 @@ export default function BotCard({ bot, onStart, onStop, onDelete }: BotCardProps
           </div>
           <div className="flex justify-between">
             <span>모드</span>
-            <StatusBadge variant={bot.mode === 'live' ? 'warning' : 'info'}>{bot.mode === 'live' ? '실전' : '모의'}</StatusBadge>
+            <StatusBadge variant={bot.mode === 'live' ? 'primary' : 'warning'}>{bot.mode === 'live' ? '실전' : '모의'}</StatusBadge>
           </div>
           {bot.interval_seconds != null && (
             <div className="flex justify-between">
@@ -85,7 +85,7 @@ export default function BotCard({ bot, onStart, onStop, onDelete }: BotCardProps
           )}
         </div>
         <div className="flex gap-2 justify-end">
-          {(bot.status === 'stopped' || bot.status === 'created') && (
+          {(bot.status === 'stopped' || bot.status === 'created' || bot.status === 'error') && (
             <>
               <button onClick={() => onStart(bot.bot_id)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">시작</button>
               <button onClick={() => onDelete(bot.bot_id)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-negative border-none cursor-pointer hover:underline">삭제</button>
@@ -93,9 +93,6 @@ export default function BotCard({ bot, onStart, onStop, onDelete }: BotCardProps
           )}
           {bot.status === 'running' && (
             <button onClick={() => onStop(bot.bot_id)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-negative border border-negative cursor-pointer hover:bg-negative-bg">중지</button>
-          )}
-          {bot.status === 'error' && (
-            <button onClick={() => onDelete(bot.bot_id)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-negative border-none cursor-pointer hover:underline">삭제</button>
           )}
         </div>
       </div>

--- a/frontend/src/components/bots/BotCreateForm.tsx
+++ b/frontend/src/components/bots/BotCreateForm.tsx
@@ -18,7 +18,6 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
   const [mode, setMode] = useState<BotMode>('paper')
   const [interval, setInterval] = useState('60')
   const [budget, setBudget] = useState('')
-  const [symbols, setSymbols] = useState('')
   const [botIdError, setBotIdError] = useState('')
   const createBot = useCreateBot()
   const { data: strategies } = useStrategies()
@@ -50,8 +49,8 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
         strategy_name: strategyName,
         mode,
         interval_seconds: Number(interval),
-        budget: Number(budget),
-        symbols: symbols.split(',').map((s) => s.trim()).filter(Boolean),
+        budget: Number(budget.replace(/,/g, '')),
+        symbols: [],
       },
       { onSuccess: onClose },
     )
@@ -64,7 +63,7 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
         <form onSubmit={handleSubmit}>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">Bot ID</label>
-            <input value={botId} onChange={(e) => handleBotIdChange(e.target.value)} placeholder="bot-momentum-01" className={`w-full bg-bg border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary ${botIdError ? 'border-negative' : 'border-border'}`} required />
+            <input value={botId} onChange={(e) => handleBotIdChange(e.target.value)} placeholder="my-bot-01" className={`w-full bg-bg border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary ${botIdError ? 'border-negative' : 'border-border'}`} required />
             {botIdError ? (
               <div className="text-[11px] text-negative mt-1">{botIdError}</div>
             ) : (
@@ -87,9 +86,9 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
           </div>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">봇 유형</label>
-            <div className="flex gap-2">
-              <button type="button" onClick={() => setMode('paper')} className={`flex-1 py-2 rounded-lg text-[13px] font-medium border cursor-pointer ${mode === 'paper' ? 'bg-primary text-white border-primary' : 'bg-transparent text-text-muted border-border hover:bg-surface-hover'}`}>모의투자</button>
-              <button type="button" onClick={() => setMode('live')} className={`flex-1 py-2 rounded-lg text-[13px] font-medium border cursor-pointer ${mode === 'live' ? 'bg-warning text-black border-warning' : 'bg-transparent text-text-muted border-border hover:bg-surface-hover'}`}>실전투자</button>
+            <div className="inline-flex rounded-lg border border-border overflow-hidden">
+              <button type="button" onClick={() => setMode('paper')} className={`px-4 py-2 text-[13px] font-medium border-none cursor-pointer ${mode === 'paper' ? 'bg-primary text-white' : 'bg-transparent text-text-muted hover:bg-surface-hover'}`}>모의투자</button>
+              <button type="button" onClick={() => setMode('live')} className={`px-4 py-2 text-[13px] font-medium border-none cursor-pointer ${mode === 'live' ? 'bg-primary text-white' : 'bg-transparent text-text-muted hover:bg-surface-hover'}`}>실전투자</button>
             </div>
           </div>
           <div className="mb-4">
@@ -99,13 +98,8 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
           </div>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">배정예산 (원)</label>
-            <input type="number" value={budget} onChange={(e) => setBudget(e.target.value)} placeholder="5000000" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
-            <div className="text-[11px] text-text-muted mt-1">잔여예산: {formatNumber(remainingBudget)}원</div>
-          </div>
-          <div className="mb-4">
-            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">대상 종목 (콤마 구분)</label>
-            <input value={symbols} onChange={(e) => setSymbols(e.target.value)} placeholder="005930, 035420" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" />
-            <div className="text-[11px] text-text-muted mt-1">선택사항</div>
+            <input type="text" value={budget} onChange={(e) => setBudget(e.target.value)} placeholder="5,000,000" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
+            <div className="text-[11px] text-text-muted mt-1">잔여예산: {formatNumber(remainingBudget)} 원</div>
           </div>
           <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
             <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>

--- a/frontend/src/components/bots/BotDeleteModal.tsx
+++ b/frontend/src/components/bots/BotDeleteModal.tsx
@@ -1,151 +1,83 @@
 import { useState } from 'react'
 import type { Bot } from '../../types/bot'
 
-interface Position {
-  symbol: string
-  quantity: number
-  avg_price: number
-  current_price: number
-}
-
 export type DeleteOption = 'force_liquidate' | 'manual_liquidate'
 
 interface BotDeleteModalProps {
-  bot: Bot
-  positions?: Position[]
+  bot: Bot & {
+    positions?: { symbol: string; quantity: number }[]
+  }
   onConfirm: (option?: DeleteOption) => void
   onClose: () => void
   isPending?: boolean
 }
 
-export default function BotDeleteModal({ bot, positions = [], onConfirm, onClose, isPending }: BotDeleteModalProps) {
+export default function BotDeleteModal({ bot, onConfirm, onClose, isPending }: BotDeleteModalProps) {
+  const positions = bot.positions?.filter((p) => p.quantity > 0) ?? []
   const hasPositions = positions.length > 0
-  const [deleteOption, setDeleteOption] = useState<DeleteOption>('force_liquidate')
+  const [deleteOption, setDeleteOption] = useState<DeleteOption>('manual_liquidate')
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]" onClick={onClose}>
       <div className="bg-surface border border-border rounded-lg p-6 w-[480px] max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
-        <h2 className="text-[18px] font-bold mb-5">봇 삭제</h2>
+        <h2 className="text-[18px] font-bold mb-4 text-negative">Bot 삭제</h2>
 
-        {/* 보유종목 있음 경고 배너 */}
-        {hasPositions && (
-          <div className="flex items-start gap-2 bg-negative/10 border border-negative/30 rounded-lg px-4 py-3 mb-4">
-            <span className="text-negative text-[16px] mt-0.5">&#9888;</span>
-            <div className="text-[13px] text-negative">
-              <span className="font-semibold">보유 종목 {positions.length}개가 있습니다</span>
-              <p className="mt-1 text-negative/80">삭제 전 포지션 처리 방법을 선택하세요.</p>
-            </div>
-          </div>
-        )}
-
-        {/* 보유종목 없음 안내 */}
-        {!hasPositions && (
-          <div className="flex items-start gap-2 bg-primary/10 border border-primary/30 rounded-lg px-4 py-3 mb-4">
-            <span className="text-primary text-[16px] mt-0.5">&#8505;</span>
-            <div className="text-[13px] text-text-muted">
-              거래 이력과 성과 기록은 보존됩니다.
-            </div>
-          </div>
-        )}
+        <div className="text-[13px] text-text-muted mb-4">
+          {hasPositions
+            ? '보유 종목이 있습니다. 삭제 전 포지션 처리 방법을 선택해주세요.'
+            : <>Bot을 삭제하면 더 이상 실행할 수 없습니다.<br />거래 이력과 성과 기록은 보존됩니다.</>
+          }
+        </div>
 
         {/* Bot 정보 */}
-        <div className="bg-bg rounded-lg p-4 mb-4">
-          <div className="space-y-2 text-[13px]">
-            <div className="flex justify-between">
-              <span className="text-text-muted">봇 이름</span>
-              <span className="font-medium">{bot.name || bot.bot_id}</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-text-muted">봇 ID</span>
-              <span className="font-mono text-[12px]">{bot.bot_id}</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-text-muted">보유 종목</span>
-              <span>{hasPositions ? `${positions.length}개` : '없음'}</span>
-            </div>
+        <div className="bg-bg border border-border rounded-lg p-3.5 mb-4">
+          <div className="flex justify-between mb-2 text-[13px]">
+            <span className="text-text-muted">Bot</span>
+            <span>
+              <span className="font-semibold">{bot.name || bot.bot_id}</span>
+              {bot.name && <span className="font-normal text-text-muted ml-1">{bot.bot_id}</span>}
+            </span>
+          </div>
+          <div className="flex justify-between text-[13px]">
+            <span className="text-text-muted">보유 종목</span>
+            <span>{hasPositions ? `${positions.length}종목` : '없음'}</span>
           </div>
         </div>
 
         {/* 포지션 처리 옵션 (보유종목 있을 때만) */}
         {hasPositions && (
-          <div className="mb-4">
-            <h3 className="text-[13px] font-semibold text-text-muted mb-3">포지션 처리 방법</h3>
-            <div className="space-y-2">
-              <label
-                className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
-                  deleteOption === 'force_liquidate'
-                    ? 'border-primary bg-primary/5'
-                    : 'border-border hover:bg-surface-hover'
-                }`}
-              >
-                <input
-                  type="radio"
-                  name="deleteOption"
-                  checked={deleteOption === 'force_liquidate'}
-                  onChange={() => setDeleteOption('force_liquidate')}
-                  className="mt-0.5 accent-primary"
-                />
-                <div>
-                  <div className="text-[13px] font-medium">강제 청산 후 삭제</div>
-                  <div className="text-[12px] text-text-muted mt-0.5">
-                    모든 보유 종목을 시장가로 즉시 매도한 뒤 봇을 삭제합니다.
-                  </div>
-                </div>
-              </label>
-              <label
-                className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
-                  deleteOption === 'manual_liquidate'
-                    ? 'border-primary bg-primary/5'
-                    : 'border-border hover:bg-surface-hover'
-                }`}
-              >
-                <input
-                  type="radio"
-                  name="deleteOption"
-                  checked={deleteOption === 'manual_liquidate'}
-                  onChange={() => setDeleteOption('manual_liquidate')}
-                  className="mt-0.5 accent-primary"
-                />
-                <div>
-                  <div className="text-[13px] font-medium">직접 청산</div>
-                  <div className="text-[12px] text-text-muted mt-0.5">
-                    봇을 중지 상태로 전환합니다. 보유 종목을 직접 청산한 뒤 다시 삭제하세요.
-                  </div>
-                </div>
-              </label>
-            </div>
-
-            {/* 보유종목 테이블 */}
-            <div className="mt-4">
-              <h3 className="text-[13px] font-semibold text-text-muted mb-2">보유 종목</h3>
-              <div className="overflow-x-auto">
-                <table className="w-full border-collapse text-[12px]">
-                  <thead>
-                    <tr>
-                      <th className="text-left px-2 py-1.5 font-semibold text-text-muted border-b border-border">종목</th>
-                      <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">수량</th>
-                      <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">평균단가</th>
-                      <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">현재가</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {positions.map((pos) => (
-                      <tr key={pos.symbol}>
-                        <td className="px-2 py-1.5 font-mono border-b border-border/50">{pos.symbol}</td>
-                        <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.quantity.toLocaleString()}</td>
-                        <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.avg_price.toLocaleString()}원</td>
-                        <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.current_price.toLocaleString()}원</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+          <div className="flex flex-col gap-2 mb-4">
+            <label className="flex items-start gap-2.5 p-3 border border-border rounded-lg cursor-pointer hover:bg-surface-hover">
+              <input
+                type="radio"
+                name="deleteOption"
+                checked={deleteOption === 'force_liquidate'}
+                onChange={() => setDeleteOption('force_liquidate')}
+                className="mt-0.5"
+              />
+              <div>
+                <div className="text-[13px] font-medium">강제 청산 후 삭제</div>
+                <div className="text-[12px] text-text-muted">보유 종목을 전량 시장가 매도한 후 Bot을 삭제합니다</div>
               </div>
-            </div>
+            </label>
+            <label className="flex items-start gap-2.5 p-3 border border-border rounded-lg cursor-pointer hover:bg-surface-hover">
+              <input
+                type="radio"
+                name="deleteOption"
+                checked={deleteOption === 'manual_liquidate'}
+                onChange={() => setDeleteOption('manual_liquidate')}
+                className="mt-0.5"
+              />
+              <div>
+                <div className="text-[13px] font-medium">직접 청산</div>
+                <div className="text-[12px] text-text-muted">보유 종목을 먼저 청산한 후 삭제할 수 있습니다</div>
+              </div>
+            </label>
           </div>
         )}
 
         {/* 버튼 */}
-        <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
+        <div className="flex justify-end gap-2 pt-4 border-t border-border">
           <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">
             취소
           </button>
@@ -155,7 +87,7 @@ export default function BotDeleteModal({ bot, positions = [], onConfirm, onClose
             disabled={isPending}
             className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative/80 disabled:opacity-50"
           >
-            {isPending ? '삭제 중...' : hasPositions && deleteOption === 'manual_liquidate' ? '중지로 전환' : '삭제'}
+            {isPending ? '삭제 중...' : '삭제'}
           </button>
         </div>
       </div>

--- a/frontend/src/components/bots/BotStopModal.tsx
+++ b/frontend/src/components/bots/BotStopModal.tsx
@@ -1,128 +1,62 @@
 import type { Bot } from '../../types/bot'
-
-interface Position {
-  symbol: string
-  quantity: number
-  avg_price: number
-  current_price: number
-}
-
-interface PendingOrder {
-  symbol: string
-  side: 'buy' | 'sell'
-  quantity: number
-  price: number
-}
+import { formatKRW } from '../../utils/formatters'
 
 interface BotStopModalProps {
-  bot: Bot
-  positions?: Position[]
-  pendingOrders?: PendingOrder[]
+  bot: Bot & {
+    positions?: { symbol: string; quantity: number }[]
+    budget?: { reserved: number }
+  }
   onConfirm: () => void
   onClose: () => void
   isPending?: boolean
 }
 
-export default function BotStopModal({ bot, positions = [], pendingOrders = [], onConfirm, onClose, isPending }: BotStopModalProps) {
+export default function BotStopModal({ bot, onConfirm, onClose, isPending }: BotStopModalProps) {
+  const positions = bot.positions?.filter((p) => p.quantity > 0) ?? []
   const hasPositions = positions.length > 0
-  const hasPendingOrders = pendingOrders.length > 0
+  const positionNames = positions.map((p) => p.symbol).join(', ')
+  const reserved = bot.budget?.reserved ?? 0
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]" onClick={onClose}>
       <div className="bg-surface border border-border rounded-lg p-6 w-[480px] max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
-        <h2 className="text-[18px] font-bold mb-5">봇 중지</h2>
+        <h2 className="text-[18px] font-bold mb-4 text-negative">Bot 중지</h2>
+
+        <div className="text-[13px] text-text-muted mb-4">
+          Bot을 중지하면 현재 실행 중인 전략 사이클이 완료된 후 중지됩니다.<br />
+          미체결 주문은 취소되지 않습니다.
+        </div>
 
         {/* 보유종목 있음 경고 배너 */}
         {hasPositions && (
-          <div className="flex items-start gap-2 bg-warning/10 border border-warning/30 rounded-lg px-4 py-3 mb-4">
-            <span className="text-warning text-[16px] mt-0.5">&#9888;</span>
-            <div className="text-[13px] text-warning">
-              <span className="font-semibold">보유 종목 {positions.length}개가 유지됩니다</span>
-              <p className="mt-1 text-warning/80">봇을 중지해도 보유 종목은 자동으로 매도되지 않습니다. 필요 시 수동으로 청산하세요.</p>
-            </div>
+          <div className="bg-warning-bg text-warning px-3.5 py-2.5 rounded text-[12px] mb-4">
+            &#9888; 보유 종목 {positions.length}개가 유지됩니다. 중지 후 포지션을 직접 관리해야 합니다.
           </div>
         )}
 
         {/* Bot 정보 */}
-        <div className="bg-bg rounded-lg p-4 mb-4">
-          <div className="space-y-2 text-[13px]">
-            <div className="flex justify-between">
-              <span className="text-text-muted">봇 이름</span>
-              <span className="font-medium">{bot.name || bot.bot_id}</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-text-muted">봇 ID</span>
-              <span className="font-mono text-[12px]">{bot.bot_id}</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-text-muted">보유 종목</span>
-              <span>{hasPositions ? `${positions.length}개` : '없음'}</span>
-            </div>
+        <div className="bg-bg border border-border rounded-lg p-3.5 mb-4">
+          <div className="flex justify-between mb-2 text-[13px]">
+            <span className="text-text-muted">Bot</span>
+            <span>
+              <span className="font-semibold">{bot.name || bot.bot_id}</span>
+              {bot.name && <span className="font-normal text-text-muted ml-1">{bot.bot_id}</span>}
+            </span>
           </div>
+          <div className="flex justify-between mb-2 text-[13px]">
+            <span className="text-text-muted">보유 종목</span>
+            <span>{hasPositions ? `${positions.length}종목 (${positionNames})` : '없음'}</span>
+          </div>
+          {(hasPositions || reserved > 0) && (
+            <div className="flex justify-between text-[13px]">
+              <span className="text-text-muted">체결대기</span>
+              <span>{formatKRW(reserved)}</span>
+            </div>
+          )}
         </div>
 
-        {/* 보유종목 테이블 */}
-        {hasPositions && (
-          <div className="mb-4">
-            <h3 className="text-[13px] font-semibold text-text-muted mb-2">보유 종목</h3>
-            <div className="overflow-x-auto">
-              <table className="w-full border-collapse text-[12px]">
-                <thead>
-                  <tr>
-                    <th className="text-left px-2 py-1.5 font-semibold text-text-muted border-b border-border">종목</th>
-                    <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">수량</th>
-                    <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">평균단가</th>
-                    <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">현재가</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {positions.map((pos) => (
-                    <tr key={pos.symbol}>
-                      <td className="px-2 py-1.5 font-mono border-b border-border/50">{pos.symbol}</td>
-                      <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.quantity.toLocaleString()}</td>
-                      <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.avg_price.toLocaleString()}원</td>
-                      <td className="text-right px-2 py-1.5 border-b border-border/50">{pos.current_price.toLocaleString()}원</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        )}
-
-        {/* 체결 대기 */}
-        {hasPendingOrders && (
-          <div className="mb-4">
-            <h3 className="text-[13px] font-semibold text-text-muted mb-2">체결 대기</h3>
-            <div className="overflow-x-auto">
-              <table className="w-full border-collapse text-[12px]">
-                <thead>
-                  <tr>
-                    <th className="text-left px-2 py-1.5 font-semibold text-text-muted border-b border-border">종목</th>
-                    <th className="text-center px-2 py-1.5 font-semibold text-text-muted border-b border-border">유형</th>
-                    <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">수량</th>
-                    <th className="text-right px-2 py-1.5 font-semibold text-text-muted border-b border-border">주문가</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {pendingOrders.map((order, i) => (
-                    <tr key={`${order.symbol}-${i}`}>
-                      <td className="px-2 py-1.5 font-mono border-b border-border/50">{order.symbol}</td>
-                      <td className={`text-center px-2 py-1.5 border-b border-border/50 ${order.side === 'buy' ? 'text-positive' : 'text-negative'}`}>
-                        {order.side === 'buy' ? '매수' : '매도'}
-                      </td>
-                      <td className="text-right px-2 py-1.5 border-b border-border/50">{order.quantity.toLocaleString()}</td>
-                      <td className="text-right px-2 py-1.5 border-b border-border/50">{order.price.toLocaleString()}원</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        )}
-
         {/* 버튼 */}
-        <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
+        <div className="flex justify-end gap-2 pt-4 border-t border-border">
           <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">
             취소
           </button>
@@ -132,7 +66,7 @@ export default function BotStopModal({ bot, positions = [], pendingOrders = [], 
             disabled={isPending}
             className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative/80 disabled:opacity-50"
           >
-            {isPending ? '중지 중...' : '중지'}
+            {isPending ? '중지 중...' : '중지 확인'}
           </button>
         </div>
       </div>

--- a/frontend/src/components/dashboard/PendingApprovals.tsx
+++ b/frontend/src/components/dashboard/PendingApprovals.tsx
@@ -3,9 +3,14 @@ import { useApprovals, useUpdateApprovalStatus } from '../../hooks/useApprovals'
 import { formatDateTime } from '../../utils/formatters'
 import StatusBadge from '../common/StatusBadge'
 import { TableSkeleton } from '../common/Skeleton'
-import type { Approval, ApprovalType } from '../../types/approval'
+import type { Approval } from '../../types/approval'
 
-const TYPE_LABELS: Record<ApprovalType, { label: string; variant: string }> = {
+const TYPE_LABELS: Record<string, { label: string; variant: string }> = {
+  strategy_report: { label: '전략 리포트', variant: 'info' },
+  budget_allocate: { label: '예산 할당', variant: 'primary' },
+  live_switch: { label: '실전 전환', variant: 'warning' },
+  risk_alert: { label: '위험 알림', variant: 'negative' },
+  // 레거시 타입 호환
   strategy_adopt: { label: '전략 채택', variant: 'info' },
   budget_change: { label: '예산 변경', variant: 'primary' },
   bot_create: { label: '봇 생성', variant: 'positive' },
@@ -57,22 +62,24 @@ export default function PendingApprovals() {
               </tr>
             </thead>
             <tbody>
-              {items.map((item: Approval) => {
+              {items.map((item: Approval, idx: number) => {
                 const typeInfo = TYPE_LABELS[item.type] || { label: item.type, variant: 'muted' }
+                const isLast = idx === items.length - 1
+                const borderCls = isLast ? '' : 'border-b border-border'
                 return (
                   <tr key={item.id} className="hover:bg-surface-hover">
-                    <td className="px-3 py-3 border-b border-border text-[13px]">
+                    <td className={`px-3 py-3 text-[13px] ${borderCls}`}>
                       <StatusBadge variant={typeInfo.variant as 'info'}>{typeInfo.label}</StatusBadge>
                     </td>
-                    <td className="px-3 py-3 border-b border-border text-[13px]">
+                    <td className={`px-3 py-3 text-[13px] ${borderCls}`}>
                       <Link to={`/approvals/${item.id}`} className="text-primary no-underline hover:underline">
                         {item.title}
                       </Link>
                     </td>
-                    <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">
+                    <td className={`px-3 py-3 text-[13px] text-text-muted ${borderCls}`}>
                       {formatDateTime(item.requested_at)}
                     </td>
-                    <td className="px-3 py-3 border-b border-border text-[13px] text-right">
+                    <td className={`px-3 py-3 text-[13px] text-right ${borderCls}`}>
                       <div className="flex gap-2 justify-end">
                         <button
                           onClick={() => handleAction(item.id, 'approved')}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -79,22 +79,21 @@ export default function Header() {
             onClick={() => setMenuOpen(!menuOpen)}
             className="flex items-center gap-2 px-2.5 py-1 rounded-lg cursor-pointer text-[13px] text-text-muted bg-transparent border-none hover:bg-surface-hover hover:text-text"
           >
-            <span className="text-[22px] leading-none mt-0.5">🦁</span>
+            <span className="text-[22px] leading-none mt-0.5">{user?.emoji || '🦁'}</span>
             <span className="hidden sm:inline">{user?.member_id ?? '...'} · {user?.role === 'master' ? '대표' : user?.role}</span>
           </button>
 
           {menuOpen && (
             <div className="absolute top-[calc(100%+6px)] right-0 bg-surface border border-border rounded-lg shadow-[0_8px_24px_rgba(0,0,0,0.3)] min-w-[200px] z-[200] py-3">
               <div className="px-4 pb-3 border-b border-border text-[12px] text-text-muted">
-                <div className="font-medium text-text">{user?.name}</div>
-                <div>{user?.org}</div>
+                {user?.login_at ? `접속: ${user.login_at.slice(0, 16)}` : ''}
               </div>
               <Link
                 to="/settings"
                 onClick={() => setMenuOpen(false)}
                 className="block px-4 py-2 text-[13px] text-text no-underline hover:bg-surface-hover"
               >
-                설정
+                ⚙️ 설정
               </Link>
               <button
                 onClick={() => { setMenuOpen(false); logoutMutation.mutate() }}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -69,7 +69,7 @@ export default function Sidebar() {
               <span className="text-[16px] w-5 text-center">{item.icon}</span>
               <span>{item.label}</span>
               {item.showBadge && pendingCount > 0 && (
-                <span className="ml-auto bg-negative text-white text-[11px] px-1.5 py-0 rounded-[10px] font-semibold">
+                <span className="ml-auto bg-negative text-white text-[11px] px-1.5 py-px rounded-[10px] font-semibold">
                   {pendingCount}
                 </span>
               )}

--- a/frontend/src/components/strategies/PerformancePanel.tsx
+++ b/frontend/src/components/strategies/PerformancePanel.tsx
@@ -2,49 +2,89 @@ import HintTooltip from '../common/HintTooltip'
 import { formatPercent, formatNumber, formatKRW } from '../../utils/formatters'
 import type { StrategyPerformance } from '../../types/strategy'
 
+interface StatItem {
+  label: string
+  value: string
+  hint: string
+  color?: string
+  sub?: string
+  subColor?: string
+}
+
 export default function PerformancePanel({ perf }: { perf: StrategyPerformance | null | undefined }) {
   const isEmpty = !perf || perf.total_trades === 0
 
   if (isEmpty) {
     return (
-      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
-        <h3 className="text-[15px] font-semibold mb-4">성과 지표</h3>
-        <div className="py-8 text-center text-text-muted text-[13px]">
-          아직 성과 데이터가 없습니다
+      <div className="mb-6">
+        <div className="bg-surface border border-border rounded-lg p-5">
+          <div className="py-8 text-center text-text-muted text-[13px]">
+            아직 성과 데이터가 없습니다
+          </div>
         </div>
       </div>
     )
   }
 
-  const metrics = [
-    { label: '순손익', value: formatKRW(perf.net_pnl), hint: '총 손익 - 수수료', color: perf.net_pnl >= 0 ? 'text-positive' : 'text-negative' },
+  const row1: StatItem[] = [
+    {
+      label: '순손익',
+      value: formatKRW(perf.net_pnl),
+      hint: '실현 손익 + 미실현 손익의 합계',
+      color: perf.net_pnl >= 0 ? 'text-positive' : 'text-negative',
+      sub: perf.net_pnl !== 0 ? `(${perf.net_pnl >= 0 ? '+' : ''}${formatPercent(perf.win_rate).replace(/^[+-]/, perf.net_pnl >= 0 ? '+' : '-')})` : undefined,
+      subColor: perf.net_pnl >= 0 ? 'text-positive' : 'text-negative',
+    },
     { label: '총 거래 수', value: formatNumber(perf.total_trades), hint: '전체 거래 횟수' },
-    { label: '승률', value: formatPercent(perf.win_rate), hint: '수익 거래 비율' },
-    { label: '활성 거래일', value: `${perf.active_days}일`, hint: '실제 거래가 발생한 날 수' },
-    { label: '수익 팩터', value: perf.profit_factor == null ? '-' : perf.profit_factor === Infinity ? '∞' : perf.profit_factor.toFixed(2), hint: '총 이익 / 총 손실' },
-    { label: '샤프 비율', value: perf.sharpe_ratio != null ? perf.sharpe_ratio.toFixed(2) : '-', hint: '위험 대비 수익 효율' },
-    { label: 'MDD', value: formatPercent(perf.max_drawdown), hint: '고점 대비 최대 하락 폭' },
-    { label: '수수료 합계', value: formatKRW(perf.total_commission), hint: '총 거래 수수료' },
-    { label: '평균 수익', value: formatKRW(perf.avg_profit), hint: '수익 거래의 평균 이익' },
-    { label: '평균 손실', value: formatKRW(perf.avg_loss), hint: '손실 거래의 평균 손실', color: perf.avg_loss > 0 ? 'text-negative' : undefined },
-    { label: '실현 손익', value: formatKRW(perf.total_pnl), hint: '수수료 차감 전 확정 손익', color: perf.total_pnl >= 0 ? 'text-positive' : 'text-negative' },
-    { label: '미실현 손익', value: '-', hint: '현재 보유 포지션 기준 (추후 지원)' },
+    { label: '승률', value: formatPercent(perf.win_rate), hint: '수익을 낸 거래 수 / 전체 거래 수' },
+    { label: '활성 거래일', value: `${perf.active_days}일`, hint: '실제 매매가 발생한 날의 수' },
+  ]
+
+  const row2: StatItem[] = [
+    { label: '수익 팩터', value: perf.profit_factor == null ? '-' : perf.profit_factor === Infinity ? '∞' : perf.profit_factor.toFixed(2), hint: '총 수익 / 총 손실. 1 이상이면 수익 우위' },
+    { label: 'Sharpe Ratio', value: perf.sharpe_ratio != null ? perf.sharpe_ratio.toFixed(2) : '-', hint: '위험 대비 수익 효율. 높을수록 안정적인 수익' },
+    {
+      label: 'MDD',
+      value: formatPercent(perf.max_drawdown),
+      hint: '최대 낙폭. 고점 대비 가장 크게 떨어진 비율',
+      color: 'text-negative',
+      sub: perf.max_drawdown_amount ? `(${formatKRW(-Math.abs(perf.max_drawdown_amount))})` : undefined,
+      subColor: 'text-negative',
+    },
+    { label: '수수료 합계', value: formatKRW(perf.total_commission), hint: '총 거래 수수료', color: 'text-text-muted' },
+  ]
+
+  const row3: StatItem[] = [
+    { label: '평균 수익', value: formatKRW(perf.avg_profit), hint: '수익 거래의 평균 이익 금액', color: 'text-positive' },
+    { label: '평균 손실', value: formatKRW(perf.avg_loss), hint: '손실 거래의 평균 손실 금액', color: 'text-negative' },
+    { label: '실현 손익', value: formatKRW(perf.realized_pnl), hint: '매도 완료된 거래의 확정 손익', color: perf.realized_pnl >= 0 ? 'text-positive' : 'text-negative' },
+    { label: '미실현 손익', value: '-', hint: '보유 중인 종목의 평가 손익 (미확정)' },
   ]
 
   return (
-    <div className="bg-surface border border-border rounded-lg p-5 mb-6">
-      <h3 className="text-[15px] font-semibold mb-4">성과 지표</h3>
-      <div className="grid grid-cols-4 gap-4">
-        {metrics.map((m) => (
-          <div key={m.label} className="bg-bg rounded-lg p-4">
-            <div className="text-[12px] text-text-muted mb-1">
-              {m.label}
-              <HintTooltip text={m.hint} />
-            </div>
-            <div className={`text-[20px] font-bold ${m.color ?? ''}`}>{m.value}</div>
+    <div className="mb-6">
+      <StatsRow items={row1} />
+      <StatsRow items={row2} />
+      <StatsRow items={row3} last />
+    </div>
+  )
+}
+
+function StatsRow({ items, last }: { items: StatItem[]; last?: boolean }) {
+  return (
+    <div className={`grid grid-cols-4 gap-4 ${last ? '' : 'mb-4'}`}>
+      {items.map((m) => (
+        <div key={m.label} className="bg-surface border border-border rounded-lg p-4">
+          <div className="text-[12px] text-text-muted mb-1">
+            {m.label}
+            <HintTooltip text={m.hint} />
           </div>
-        ))}
-      </div>
+          <div className={`text-[20px] font-bold ${m.color ?? ''}`}>{m.value}</div>
+          {m.sub && (
+            <div className={`text-[13px] mt-[-4px] ${m.subColor ?? 'text-text-muted'}`}>{m.sub}</div>
+          )}
+        </div>
+      ))}
     </div>
   )
 }

--- a/frontend/src/components/strategies/PeriodPerformance.tsx
+++ b/frontend/src/components/strategies/PeriodPerformance.tsx
@@ -1,33 +1,45 @@
 import { useState } from 'react'
 import { formatKRW, formatPercent } from '../../utils/formatters'
-import type { DailySummary, MonthlySummary } from '../../types/strategy'
+import type { DailySummary, WeeklySummary, MonthlySummary } from '../../types/strategy'
 
-type PeriodTab = 'daily' | 'monthly'
+type PeriodTab = 'daily' | 'weekly' | 'monthly'
 
 interface PeriodPerformanceProps {
   daily: DailySummary[] | undefined
+  weekly: WeeklySummary[] | undefined
   monthly: MonthlySummary[] | undefined
+  strategyId?: string
 }
 
-export default function PeriodPerformance({ daily, monthly }: PeriodPerformanceProps) {
-  const [tab, setTab] = useState<PeriodTab>('daily')
+export default function PeriodPerformance({ daily, weekly, monthly, strategyId }: PeriodPerformanceProps) {
+  const [tab, setTab] = useState<PeriodTab>('monthly')
+
+  const tabBtn = (key: PeriodTab, label: string) => (
+    <button
+      onClick={() => setTab(key)}
+      className={`px-3 py-1 rounded text-[12px] font-medium border-none cursor-pointer ${tab === key ? 'bg-surface text-text' : 'bg-transparent text-text-muted'}`}
+    >
+      {label}
+    </button>
+  )
 
   return (
     <div className="bg-surface border border-border rounded-lg p-5">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-[15px] font-semibold">기간별 성과</h3>
-        <div className="flex gap-1 bg-bg rounded-lg p-0.5">
-          <button onClick={() => setTab('daily')} className={`px-3 py-1 rounded text-[12px] font-medium border-none cursor-pointer ${tab === 'daily' ? 'bg-surface text-text' : 'bg-transparent text-text-muted'}`}>일별</button>
-          <button onClick={() => setTab('monthly')} className={`px-3 py-1 rounded text-[12px] font-medium border-none cursor-pointer ${tab === 'monthly' ? 'bg-surface text-text' : 'bg-transparent text-text-muted'}`}>월별</button>
-        </div>
+        {strategyId && (
+          <span className="text-[13px] text-primary cursor-pointer hover:underline">더 보기 &rarr;</span>
+        )}
+      </div>
+      <div className="flex gap-1 bg-bg rounded-lg p-0.5 w-fit mb-4">
+        {tabBtn('daily', '일별')}
+        {tabBtn('weekly', '주별')}
+        {tabBtn('monthly', '월별')}
       </div>
 
-      {tab === 'daily' && (
-        <DailyTable items={daily ?? []} />
-      )}
-      {tab === 'monthly' && (
-        <MonthlyTable items={monthly ?? []} />
-      )}
+      {tab === 'daily' && <DailyTable items={daily ?? []} />}
+      {tab === 'weekly' && <WeeklyTable items={weekly ?? []} />}
+      {tab === 'monthly' && <MonthlyTable items={monthly ?? []} />}
     </div>
   )
 }
@@ -35,26 +47,57 @@ export default function PeriodPerformance({ daily, monthly }: PeriodPerformanceP
 function DailyTable({ items }: { items: DailySummary[] }) {
   if (items.length === 0) return <div className="py-4 text-text-muted text-[13px] text-center">데이터가 없습니다</div>
 
-  const recent = items.slice(-10).reverse()
+  const recent = items.slice(-12).reverse()
 
   return (
     <div className="overflow-x-auto">
       <table className="w-full border-collapse">
         <thead>
           <tr>
-            <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">날짜</th>
-            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">손익</th>
-            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">거래수</th>
+            <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">일자</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">거래 수</th>
             <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">승률</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">실현 손익</th>
           </tr>
         </thead>
         <tbody>
           {recent.map((d) => (
             <tr key={d.date} className="hover:bg-surface-hover">
               <td className="px-3 py-2.5 border-b border-border text-[13px]">{d.date}</td>
-              <td className={`px-3 py-2.5 border-b border-border text-[13px] text-right ${d.realized_pnl >= 0 ? 'text-positive' : 'text-negative'}`}>{formatKRW(d.realized_pnl)}</td>
               <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{d.trade_count}</td>
               <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{formatPercent(d.win_rate)}</td>
+              <td className={`px-3 py-2.5 border-b border-border text-[13px] text-right ${d.realized_pnl >= 0 ? 'text-positive' : 'text-negative'}`}>{formatKRW(d.realized_pnl)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function WeeklyTable({ items }: { items: WeeklySummary[] }) {
+  if (items.length === 0) return <div className="py-4 text-text-muted text-[13px] text-center">데이터가 없습니다</div>
+
+  const recent = items.slice(-12).reverse()
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">주간</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">거래 수</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">승률</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">실현 손익</th>
+          </tr>
+        </thead>
+        <tbody>
+          {recent.map((w) => (
+            <tr key={w.week_label} className="hover:bg-surface-hover">
+              <td className="px-3 py-2.5 border-b border-border text-[13px]">{w.week_label}</td>
+              <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{w.trade_count}</td>
+              <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{formatPercent(w.win_rate)}</td>
+              <td className={`px-3 py-2.5 border-b border-border text-[13px] text-right ${w.realized_pnl >= 0 ? 'text-positive' : 'text-negative'}`}>{formatKRW(w.realized_pnl)}</td>
             </tr>
           ))}
         </tbody>
@@ -73,19 +116,19 @@ function MonthlyTable({ items }: { items: MonthlySummary[] }) {
       <table className="w-full border-collapse">
         <thead>
           <tr>
-            <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">기간</th>
-            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">손익</th>
-            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">거래수</th>
+            <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">월</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">거래 수</th>
             <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">승률</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">실현 손익</th>
           </tr>
         </thead>
         <tbody>
           {recent.map((m) => (
             <tr key={`${m.year}-${m.month}`} className="hover:bg-surface-hover">
-              <td className="px-3 py-2.5 border-b border-border text-[13px]">{m.year}년 {m.month}월</td>
-              <td className={`px-3 py-2.5 border-b border-border text-[13px] text-right ${m.realized_pnl >= 0 ? 'text-positive' : 'text-negative'}`}>{formatKRW(m.realized_pnl)}</td>
+              <td className="px-3 py-2.5 border-b border-border text-[13px]">{m.year}-{String(m.month).padStart(2, '0')}</td>
               <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{m.trade_count}</td>
               <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{formatPercent(m.win_rate)}</td>
+              <td className={`px-3 py-2.5 border-b border-border text-[13px] text-right ${m.realized_pnl >= 0 ? 'text-positive' : 'text-negative'}`}>{formatKRW(m.realized_pnl)}</td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/components/strategies/StrategyTable.tsx
+++ b/frontend/src/components/strategies/StrategyTable.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import StatusBadge from '../common/StatusBadge'
 import { formatPercent } from '../../utils/formatters'
 import { STRATEGY_STATUS_LABELS } from '../../utils/constants'
@@ -6,25 +6,23 @@ import type { Strategy, StrategyStatus } from '../../types/strategy'
 
 const STATUS_VARIANT: Record<StrategyStatus, string> = {
   active: 'positive',
-  registered: 'info',
+  registered: 'warning',
   inactive: 'muted',
   archived: 'muted',
 }
 
 export default function StrategyTable({ items }: { items: Strategy[] }) {
-  const navigate = useNavigate()
-
   return (
     <div className="overflow-x-auto">
       <table className="w-full border-collapse">
         <thead>
           <tr>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">전략명</th>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">버전</th>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">제출자</th>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">상태</th>
-            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">실행 봇</th>
-            <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">누적 수익률</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">전략명</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">버전</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">제출자</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">상태</th>
+            <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">실행 봇</th>
+            <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">누적 수익률</th>
           </tr>
         </thead>
         <tbody>
@@ -32,20 +30,36 @@ export default function StrategyTable({ items }: { items: Strategy[] }) {
             <tr><td colSpan={6} className="px-3 py-8 text-center text-text-muted text-[13px]">등록된 전략이 없습니다</td></tr>
           ) : (
             items.map((s) => (
-              <tr key={s.id} onClick={() => navigate(`/strategies/${s.id}`)} className="hover:bg-surface-hover cursor-pointer">
-                <td className="px-3 py-3 border-b border-border text-[13px] font-medium">{s.name}</td>
-                <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{s.version}</td>
-                <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{s.author || '-'}</td>
+              <tr key={s.id} className="hover:bg-surface-hover">
+                <td className="px-3 py-3 border-b border-border text-[13px] font-medium">
+                  <Link to={`/strategies/${s.id}`} className="text-text no-underline hover:underline">{s.name}</Link>
+                </td>
+                <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">v{s.version}</td>
+                <td className="px-3 py-3 border-b border-border text-[13px]">
+                  {s.author ? (
+                    <span>{s.author} {s.author_id && <span className="text-text-muted font-normal">{s.author_id}</span>}</span>
+                  ) : (
+                    <span className="text-text-muted">-</span>
+                  )}
+                </td>
                 <td className="px-3 py-3 border-b border-border text-[13px]">
                   <StatusBadge variant={STATUS_VARIANT[s.status] as 'positive'}>{STRATEGY_STATUS_LABELS[s.status] || s.status}</StatusBadge>
                 </td>
-                <td className="px-3 py-3 border-b border-border text-[13px] font-mono text-text-muted">{s.bot_id || '-'}</td>
+                <td className="px-3 py-3 border-b border-border text-[13px]">
+                  {s.bot_id ? (
+                    <Link to={`/bots/${s.bot_id}`} className="text-text font-mono no-underline hover:underline">{s.bot_id}</Link>
+                  ) : (
+                    <span className="text-text-muted">-</span>
+                  )}
+                </td>
                 <td className="px-3 py-3 border-b border-border text-[13px] text-right">
                   {s.cumulative_return != null ? (
-                    <span className={s.cumulative_return >= 0 ? 'text-positive' : 'text-negative'}>
+                    <span className={`font-bold ${s.cumulative_return >= 0 ? 'text-positive' : 'text-negative'}`}>
                       {formatPercent(s.cumulative_return / 100)}
                     </span>
-                  ) : '-'}
+                  ) : (
+                    <span className="text-text-muted">-</span>
+                  )}
                 </td>
               </tr>
             ))

--- a/frontend/src/components/treasury/AllocationForm.tsx
+++ b/frontend/src/components/treasury/AllocationForm.tsx
@@ -10,22 +10,26 @@ interface AllocationFormProps {
 export default function AllocationForm({ budgets }: AllocationFormProps) {
   const [botId, setBotId] = useState(budgets[0]?.bot_id ?? '')
   const [amount, setAmount] = useState('')
-  const [confirmAction, setConfirmAction] = useState<{ action: 'allocate' | 'deallocate'; botId: string; amount: number } | null>(null)
+  const [showConfirm, setShowConfirm] = useState(false)
   const allocate = useAllocateBudget()
   const deallocate = useDeallocateBudget()
 
   const selectedBudget = budgets.find((b) => b.bot_id === botId)
-  const numAmount = Number(amount)
+  const numAmount = Number(amount.replace(/,/g, ''))
 
   const handleSubmit = () => {
-    if (!confirmAction) return
-    const { action, botId: bid, amount: amt } = confirmAction
-    if (action === 'allocate') {
-      allocate.mutate({ botId: bid, amount: amt }, { onSuccess: () => { setAmount(''); setConfirmAction(null) } })
+    if (!selectedBudget || !numAmount) return
+    const diff = numAmount - selectedBudget.allocated
+    if (diff > 0) {
+      allocate.mutate({ botId, amount: diff }, { onSuccess: () => { setAmount(''); setShowConfirm(false) } })
+    } else if (diff < 0) {
+      deallocate.mutate({ botId, amount: Math.abs(diff) }, { onSuccess: () => { setAmount(''); setShowConfirm(false) } })
     } else {
-      deallocate.mutate({ botId: bid, amount: amt }, { onSuccess: () => { setAmount(''); setConfirmAction(null) } })
+      setShowConfirm(false)
     }
   }
+
+  const diff = selectedBudget ? numAmount - selectedBudget.allocated : 0
 
   return (
     <>
@@ -39,7 +43,7 @@ export default function AllocationForm({ budgets }: AllocationFormProps) {
             <select
               value={botId}
               onChange={(e) => setBotId(e.target.value)}
-              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px]"
+              className="w-full bg-bg border border-border rounded-lg px-3 py-2 text-text text-[14px] h-[38px]"
             >
               {budgets.map((b) => (
                 <option key={b.bot_id} value={b.bot_id}>{b.bot_id}</option>
@@ -50,68 +54,59 @@ export default function AllocationForm({ budgets }: AllocationFormProps) {
           {selectedBudget && (
             <div>
               <label className="block text-[12px] font-semibold text-text-muted mb-1.5">현재 배정예산</label>
-              <div className="text-[15px] font-semibold">{formatKRW(selectedBudget.allocated)}</div>
+              <div className="text-[15px] font-semibold mb-2">{formatKRW(selectedBudget.allocated)}</div>
             </div>
           )}
 
           <div>
-            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">금액 (원)</label>
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">변경할 예산 (원)</label>
             <input
-              type="number"
+              type="text"
               value={amount}
               onChange={(e) => setAmount(e.target.value)}
-              placeholder="0"
+              placeholder={selectedBudget ? new Intl.NumberFormat('ko-KR').format(selectedBudget.allocated) : '0'}
               className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] placeholder:text-text-muted focus:outline-none focus:border-primary"
             />
           </div>
 
-          <div className="flex gap-2">
-            <button
-              onClick={() => numAmount > 0 && botId && setConfirmAction({ action: 'allocate', botId, amount: numAmount })}
-              disabled={!botId || !numAmount}
-              className="flex-1 px-4 py-2.5 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover disabled:opacity-50"
-            >
-              할당
-            </button>
-            <button
-              onClick={() => numAmount > 0 && botId && setConfirmAction({ action: 'deallocate', botId, amount: numAmount })}
-              disabled={!botId || !numAmount}
-              className="flex-1 px-4 py-2.5 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover hover:text-text disabled:opacity-50"
-            >
-              회수
-            </button>
-          </div>
+          <button
+            onClick={() => numAmount > 0 && botId && setShowConfirm(true)}
+            disabled={!botId || !numAmount}
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50"
+          >
+            예산 변경
+          </button>
         </div>
       </div>
 
-      {/* 확인 모달 */}
-      {confirmAction && (
+      {/* 예산 변경 확인 모달 */}
+      {showConfirm && selectedBudget && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
-          <div className="bg-surface border border-border rounded-lg p-6 w-[420px]">
-            <h3 className="text-[16px] font-bold mb-3">
-              예산 {confirmAction.action === 'allocate' ? '할당' : '회수'} 확인
-            </h3>
+          <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
+            <h3 className="text-[18px] font-bold mb-5">예산 변경 확인</h3>
             <div className="text-[13px] text-text-muted mb-4">아래 내용으로 예산을 변경합니다.</div>
             <div className="bg-bg border border-border rounded-lg p-4 mb-4 space-y-2">
               <div className="flex justify-between text-[13px]">
                 <span className="text-text-muted">Bot</span>
-                <span className="font-semibold font-mono">{confirmAction.botId}</span>
+                <span className="font-semibold">{botId}</span>
               </div>
-              {selectedBudget && (
-                <div className="flex justify-between text-[13px]">
-                  <span className="text-text-muted">현재 예산</span>
-                  <span>{formatKRW(selectedBudget.allocated)}</span>
-                </div>
-              )}
               <div className="flex justify-between text-[13px]">
-                <span className="text-text-muted">{confirmAction.action === 'allocate' ? '할당' : '회수'} 금액</span>
-                <span className={`font-semibold ${confirmAction.action === 'allocate' ? 'text-positive' : 'text-negative'}`}>
-                  {confirmAction.action === 'allocate' ? '+' : '-'}{formatKRW(confirmAction.amount)}
+                <span className="text-text-muted">현재 예산</span>
+                <span>{formatKRW(selectedBudget.allocated)}</span>
+              </div>
+              <div className="flex justify-between text-[13px]">
+                <span className="text-text-muted">변경 예산</span>
+                <span className="font-semibold">{formatKRW(numAmount)}</span>
+              </div>
+              <div className="flex justify-between text-[13px] border-t border-border pt-2">
+                <span className="text-text-muted">차액</span>
+                <span className={`font-semibold ${diff >= 0 ? 'text-positive' : 'text-negative'}`}>
+                  {diff >= 0 ? '+' : ''}{formatKRW(diff)}
                 </span>
               </div>
             </div>
-            <div className="flex justify-end gap-2">
-              <button onClick={() => setConfirmAction(null)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
+            <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
+              <button onClick={() => setShowConfirm(false)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
               <button onClick={handleSubmit} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">변경 확인</button>
             </div>
           </div>

--- a/frontend/src/components/treasury/AnteSummary.tsx
+++ b/frontend/src/components/treasury/AnteSummary.tsx
@@ -7,7 +7,11 @@ export default function AnteSummary({ summary }: { summary: TreasurySummary }) {
     ? summary.ante_profit_loss / summary.ante_purchase_amount
     : 0
 
-  const holdingProfitColor = (summary.ante_eval_amount - summary.ante_purchase_amount) >= 0 ? 'text-positive' : 'text-negative'
+  const holdingPnl = summary.ante_eval_amount - summary.ante_purchase_amount
+  const holdingProfitColor = holdingPnl >= 0 ? 'text-positive' : 'text-negative'
+  const holdingProfitPercent = summary.ante_purchase_amount > 0
+    ? holdingPnl / summary.ante_purchase_amount
+    : 0
 
   return (
     <div className="bg-surface border border-border rounded-lg overflow-hidden mb-6">
@@ -56,7 +60,10 @@ export default function AnteSummary({ summary }: { summary: TreasurySummary }) {
         </div>
         <div className="px-5 py-4">
           <div className="text-[12px] text-text-muted mb-1">보유종목 손익</div>
-          <div className={`text-[22px] font-bold ${holdingProfitColor}`}>{formatKRW(summary.ante_profit_loss)}</div>
+          <div className={`text-[22px] font-bold ${holdingProfitColor}`}>{formatKRW(holdingPnl)}</div>
+          {holdingProfitPercent !== 0 && (
+            <div className={`text-[13px] ${holdingProfitColor}`}>({formatPercent(holdingProfitPercent)})</div>
+          )}
         </div>
         <div className="px-5 py-4">
           <div className="text-[12px] text-text-muted mb-1">체결대기 자금</div>

--- a/frontend/src/components/treasury/RecentTransactions.tsx
+++ b/frontend/src/components/treasury/RecentTransactions.tsx
@@ -33,13 +33,13 @@ export default function RecentTransactions() {
                 <tr key={tx.id} className="hover:bg-surface-hover">
                   <td className="px-3 py-3 border-b border-border text-[13px] font-mono text-text-muted">{formatDateTime(tx.created_at)}</td>
                   <td className="px-3 py-3 border-b border-border text-[13px]">
-                    <StatusBadge variant={TRANSACTION_TYPE_VARIANT[tx.type] ?? 'default'}>
+                    <StatusBadge variant={TRANSACTION_TYPE_VARIANT[tx.type] ?? 'muted'}>
                       {TRANSACTION_TYPE_LABELS[tx.type] ?? tx.type}
                     </StatusBadge>
                   </td>
                   <td className="px-3 py-3 border-b border-border text-[13px] font-mono">{tx.bot_id || '-'}</td>
-                  <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${tx.type === 'allocate' ? 'text-positive' : tx.type === 'deallocate' ? 'text-negative' : ''}`}>
-                    {tx.type === 'allocate' ? '+' : ''}{formatKRW(tx.amount)}
+                  <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${tx.amount >= 0 ? 'text-positive' : 'text-negative'}`}>
+                    {tx.amount > 0 ? '+' : ''}{formatKRW(tx.amount)}
                   </td>
                   <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{tx.description}</td>
                 </tr>

--- a/frontend/src/hooks/useStrategies.ts
+++ b/frontend/src/hooks/useStrategies.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { getStrategies, getStrategyDetail, getStrategyPerformance, getStrategyTrades, getStrategyDailySummary, getStrategyMonthlySummary } from '../api/strategies'
+import { getStrategies, getStrategyDetail, getStrategyPerformance, getStrategyTrades, getStrategyDailySummary, getStrategyWeeklySummary, getStrategyMonthlySummary, getStrategyTradesPaginated } from '../api/strategies'
 
 export function useStrategies() {
   return useQuery({
@@ -40,10 +40,29 @@ export function useStrategyDailySummary(id: string) {
   })
 }
 
+export function useStrategyWeeklySummary(id: string) {
+  return useQuery({
+    queryKey: ['strategies', id, 'weekly-summary'],
+    queryFn: () => getStrategyWeeklySummary(id),
+    enabled: !!id,
+  })
+}
+
 export function useStrategyMonthlySummary(id: string) {
   return useQuery({
     queryKey: ['strategies', id, 'monthly-summary'],
     queryFn: () => getStrategyMonthlySummary(id),
+    enabled: !!id,
+  })
+}
+
+export function useStrategyTradesPaginated(
+  id: string,
+  params?: { offset?: number; limit?: number; side?: string; start_date?: string; end_date?: string },
+) {
+  return useQuery({
+    queryKey: ['strategies', id, 'trades-paginated', params],
+    queryFn: () => getStrategyTradesPaginated(id, params),
     enabled: !!id,
   })
 }

--- a/frontend/src/hooks/useStrategies.ts
+++ b/frontend/src/hooks/useStrategies.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { getStrategies, getStrategyDetail, getStrategyPerformance, getStrategyTrades, getStrategyDailySummary, getStrategyMonthlySummary } from '../api/strategies'
+import { getStrategies, getStrategyDetail, getStrategyPerformance, getStrategyTrades, getStrategyDailySummary, getStrategyWeeklySummary, getStrategyMonthlySummary } from '../api/strategies'
 
 export function useStrategies() {
   return useQuery({
@@ -36,6 +36,14 @@ export function useStrategyDailySummary(id: string) {
   return useQuery({
     queryKey: ['strategies', id, 'daily-summary'],
     queryFn: () => getStrategyDailySummary(id),
+    enabled: !!id,
+  })
+}
+
+export function useStrategyWeeklySummary(id: string) {
+  return useQuery({
+    queryKey: ['strategies', id, 'weekly-summary'],
+    queryFn: () => getStrategyWeeklySummary(id),
     enabled: !!id,
   })
 }

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -34,157 +34,164 @@ export default function AgentDetail() {
 
   return (
     <>
-      {/* 브레드크럼 */}
-      <Link to="/agents" className="inline-flex items-center gap-1 text-[13px] text-text-muted hover:text-text mb-4 no-underline">
-        ← 에이전트 관리
-      </Link>
-
-      {/* 헤더 */}
-      <div className="flex items-center justify-between mb-6">
-        <div className="flex items-center gap-4">
-          <div className="w-[56px] h-[56px] rounded-full bg-surface border border-border flex items-center justify-center text-[28px] shrink-0">
-            {member.emoji || (member.type === 'human' ? '👤' : '🤖')}
+      {/* 에이전트 정보 헤더 — 목업 detail-header 기준 */}
+      <div className="flex items-center justify-between mb-6 pb-4 border-b border-border">
+        <div>
+          <h2 className="text-[20px] font-bold font-mono mb-1">{member.member_id}</h2>
+          <div className="flex gap-2 items-center">
+            <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>
+              {MEMBER_STATUS_LABELS[member.status]}
+            </StatusBadge>
+            <StatusBadge variant="muted">{member.org}</StatusBadge>
+            <span className="text-text-muted text-[13px]">{member.name}</span>
           </div>
-          <div>
-            <h2 className="text-[20px] font-bold font-mono">{member.member_id}</h2>
-            <div className="flex gap-3 items-center mt-1">
-              <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded">{member.org}</span>
-              <span className="text-text-muted text-[13px]">{member.name}</span>
+        </div>
+        <div className="flex gap-2">
+          {member.status === 'active' && (
+            <button onClick={() => suspend.mutate(member.member_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">정지</button>
+          )}
+          {member.status === 'suspended' && (
+            <button onClick={() => reactivate.mutate(member.member_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">재활성화</button>
+          )}
+          {member.status !== 'revoked' && (
+            <button onClick={() => { if (confirm('영구 폐기하시겠습니까?')) revoke.mutate(member.member_id) }} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative-hover">폐기</button>
+          )}
+        </div>
+      </div>
+
+      {/* 기본 정보 + 활동 정보 — 목업 detail-grid 기준 (2열) */}
+      <div className="grid grid-cols-2 gap-6 mb-6">
+        {/* 기본 정보 */}
+        <div className="bg-surface border border-border rounded-lg p-5">
+          <h3 className="text-[15px] font-semibold mb-4">기본 정보</h3>
+          <div className="space-y-0">
+            <div className="flex justify-between py-2.5 border-b border-border text-[13px]">
+              <span className="text-text-muted">Agent ID</span>
+              <span className="font-mono">{member.member_id}</span>
+            </div>
+            <div className="flex justify-between py-2.5 border-b border-border text-[13px]">
+              <span className="text-text-muted">이름</span>
+              <span>{member.name}</span>
+            </div>
+            <div className="flex justify-between py-2.5 border-b border-border text-[13px]">
+              <span className="text-text-muted">소속</span>
+              <span>{member.org}</span>
+            </div>
+            <div className="flex justify-between py-2.5 text-[13px]">
+              <span className="text-text-muted">상태</span>
               <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>
                 {MEMBER_STATUS_LABELS[member.status]}
               </StatusBadge>
             </div>
           </div>
         </div>
-        <div className="flex gap-2">
-          {member.status === 'active' && (
-            <button onClick={() => suspend.mutate(member.member_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-warning border border-border cursor-pointer hover:bg-warning-bg">정지</button>
-          )}
-          {member.status === 'suspended' && (
-            <button onClick={() => reactivate.mutate(member.member_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">재활성화</button>
-          )}
-          {member.status !== 'revoked' && (
-            <button onClick={() => { if (confirm('영구 폐기하시겠습니까?')) revoke.mutate(member.member_id) }} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-negative border border-border cursor-pointer hover:bg-negative-bg">폐기</button>
-          )}
-        </div>
-      </div>
 
-      {/* 기본 정보 카드 */}
-      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
-        <h3 className="text-[15px] font-semibold mb-3">기본 정보</h3>
-        <div className="grid grid-cols-2 gap-x-8 gap-y-2">
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">Agent ID</span>
-            <span className="font-mono">{member.member_id}</span>
-          </div>
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">이름</span>
-            <span>{member.name}</span>
-          </div>
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">소속</span>
-            <span>{member.org}</span>
-          </div>
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">상태</span>
-            <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>
-              {MEMBER_STATUS_LABELS[member.status]}
-            </StatusBadge>
+        {/* 활동 정보 */}
+        <div className="bg-surface border border-border rounded-lg p-5">
+          <h3 className="text-[15px] font-semibold mb-4">활동 정보</h3>
+          <div className="space-y-0">
+            <div className="flex justify-between py-2.5 border-b border-border text-[13px]">
+              <span className="text-text-muted">생성일</span>
+              <span>{formatDateTime(member.created_at)}</span>
+            </div>
+            <div className="flex justify-between py-2.5 border-b border-border text-[13px]">
+              <span className="text-text-muted">생성자</span>
+              <span>{member.created_by || '-'}</span>
+            </div>
+            <div className="flex justify-between py-2.5 border-b border-border text-[13px]">
+              <span className="text-text-muted">마지막 활동</span>
+              <span>{member.last_active_at ? formatDateTime(member.last_active_at) : '-'}</span>
+            </div>
+            <div className="flex justify-between py-2.5 text-[13px]">
+              <span className="text-text-muted">정지 시각</span>
+              <span className={member.suspended_at ? '' : 'text-text-muted'}>{member.suspended_at ? formatDateTime(member.suspended_at) : '-'}</span>
+            </div>
           </div>
         </div>
       </div>
 
-      {/* 토큰 관리 */}
+      {/* 토큰 관리 — 목업 기준 */}
       <div className="bg-surface border border-border rounded-lg p-5 mb-6">
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center justify-between">
           <h3 className="text-[15px] font-semibold">토큰 관리</h3>
+        </div>
+        <div className="flex items-center gap-4 mt-3">
+          <div className="flex-1">
+            {member.token_prefix && (
+              <div className="flex justify-between py-2.5 border-b border-border text-[13px]">
+                <span className="text-text-muted">토큰 접두어</span>
+                <span className="font-mono">{member.token_prefix}****</span>
+              </div>
+            )}
+          </div>
           <button
             onClick={handleRotateToken}
             disabled={member.status === 'revoked'}
-            className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover disabled:opacity-40"
+            className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover disabled:opacity-40 shrink-0"
           >
             토큰 재발급
           </button>
         </div>
-        {member.token_prefix && (
-          <div className="flex justify-between py-2 border-b border-border text-[13px] mb-3">
-            <span className="text-text-muted">토큰 접두어</span>
-            <span className="font-mono">{member.token_prefix}****</span>
-          </div>
-        )}
-        <p className="text-[12px] text-warning">기존 토큰이 즉시 무효화됩니다</p>
+        <p className="text-[12px] text-warning mt-2">{'⚠'} 토큰 재발급 시 기존 토큰이 즉시 무효화됩니다.</p>
       </div>
 
-      {/* 권한 범위 */}
-      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
-        <div className="flex items-center justify-between mb-3">
-          <h3 className="text-[15px] font-semibold">권한 범위</h3>
+      {/* 권한 범위 (Scopes) — 목업 기준 */}
+      <div className="bg-surface border border-border rounded-lg p-5">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-[15px] font-semibold">권한 범위 (Scopes)</h3>
           {!editingScopes ? (
             <button onClick={startEditScopes} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">편집</button>
-          ) : (
+          ) : null}
+        </div>
+
+        {/* 현재 scope 표시 */}
+        <div className="flex flex-wrap gap-1 mb-4">
+          {member.scopes.map((s) => (
+            <span key={s} className="text-[11px] px-1.5 py-[1px] rounded-sm bg-bg border border-border text-text-muted font-mono">{s}</span>
+          ))}
+        </div>
+
+        {/* scope 편집 (토글) */}
+        {editingScopes && (
+          <div className="border-t border-border pt-4">
+            <div className="grid grid-cols-2 gap-2 mb-4">
+              {ALL_SCOPES.map((scope) => (
+                <label key={scope} className="flex items-center gap-2 text-[13px] cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={scopesDraft.includes(scope)}
+                    onChange={() => setScopesDraft((prev) => prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope])}
+                    className="accent-primary"
+                  />
+                  <span className="font-mono text-[12px]">{scope}</span>
+                </label>
+              ))}
+            </div>
             <div className="flex gap-2">
               <button onClick={() => { updateScopes.mutate({ id: member.member_id, scopes: scopesDraft }); setEditingScopes(false) }} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">저장</button>
               <button onClick={() => setEditingScopes(false)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
             </div>
-          )}
-        </div>
-        {editingScopes ? (
-          <div className="grid grid-cols-2 gap-2">
-            {ALL_SCOPES.map((scope) => (
-              <label key={scope} className="flex items-center gap-2 text-[13px] cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={scopesDraft.includes(scope)}
-                  onChange={() => setScopesDraft((prev) => prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope])}
-                  className="accent-primary"
-                />
-                <span className="font-mono text-[12px]">{scope}</span>
-              </label>
-            ))}
-          </div>
-        ) : (
-          <div className="flex flex-wrap gap-1.5">
-            {member.scopes.map((s) => (
-              <span key={s} className="px-2 py-0.5 bg-positive-bg text-primary rounded text-[11px] font-medium font-mono">{s}</span>
-            ))}
           </div>
         )}
-      </div>
-
-      {/* 활동 정보 */}
-      <div className="bg-surface border border-border rounded-lg p-5">
-        <h3 className="text-[15px] font-semibold mb-3">활동 정보</h3>
-        <div className="space-y-2">
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">생성일</span>
-            <span>{formatDateTime(member.created_at)}</span>
-          </div>
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">생성자</span>
-            <span>{member.created_by || '-'}</span>
-          </div>
-          {member.suspended_at && (
-            <div className="flex justify-between py-2 border-b border-border text-[13px]">
-              <span className="text-text-muted">정지 시각</span>
-              <span>{formatDateTime(member.suspended_at)}</span>
-            </div>
-          )}
-          <div className="flex justify-between py-2 text-[13px]">
-            <span className="text-text-muted">마지막 활동</span>
-            <span>{member.last_active_at ? formatDateTime(member.last_active_at) : '-'}</span>
-          </div>
-        </div>
       </div>
 
       {/* 토큰 표시 모달 */}
       {newToken && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
-          <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
-            <h3 className="text-[18px] font-bold mb-4">새 토큰 발급 완료</h3>
-            <p className="text-[13px] text-warning mb-3">이 토큰은 다시 확인할 수 없습니다.</p>
-            <div className="bg-bg border border-border rounded-lg p-3 font-mono text-[12px] break-all mb-4">{newToken}</div>
-            <div className="flex justify-end gap-2">
-              <button onClick={() => navigator.clipboard.writeText(newToken)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">복사</button>
+          <div className="bg-surface border border-border rounded-lg p-6 w-[480px] text-center">
+            <h3 className="text-[18px] font-bold mb-4 text-positive">{'✓'} 새 토큰 발급 완료</h3>
+
+            <div className="my-5">
+              <div className="text-[12px] font-semibold text-text-muted">발급된 토큰</div>
+              <div className="bg-bg border border-border rounded-lg p-3.5 font-mono text-[13px] break-all text-left mt-2">{newToken}</div>
+            </div>
+
+            <div className="bg-warning-bg text-warning p-3 rounded-lg text-[13px] mb-5 text-left">
+              {'⚠'} 이 토큰은 다시 표시되지 않습니다. 안전한 곳에 복사해 두세요.
+            </div>
+
+            <div className="flex justify-center gap-2">
+              <button onClick={() => navigator.clipboard.writeText(newToken)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">토큰 복사</button>
               <button onClick={() => setNewToken(null)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">닫기</button>
             </div>
           </div>

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -16,7 +16,7 @@ export default function Agents() {
   const [orgFilter, setOrgFilter] = useState<string>('all')
   const [statusFilter, setStatusFilter] = useState<MemberStatus | 'all'>('all')
   const [showRegister, setShowRegister] = useState(false)
-  const [createdToken, setCreatedToken] = useState<string | null>(null)
+  const [createdToken, setCreatedToken] = useState<{ agentId: string; token: string } | null>(null)
 
   const { data: allMembers, isLoading } = useMembers({})
   const { data: humanMembers } = useMembers({ type: 'human' })
@@ -50,13 +50,13 @@ export default function Agents() {
           {/* Human 멤버 섹션 */}
           <div className="mb-8">
             <div className="flex items-center gap-2 text-[15px] font-semibold text-text-muted mb-4">
-              Human 멤버
+              {'👤'} Human 멤버
               <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded-full">{humans.length}</span>
             </div>
             {humans.length === 0 ? (
               <div className="text-[13px] text-text-muted py-6 text-center">Human 멤버가 없습니다</div>
             ) : (
-              <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4">
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4">
                 {filterByOrg(humans).map((m) => (
                   <MemberCard
                     key={m.member_id}
@@ -72,7 +72,7 @@ export default function Agents() {
           {/* Agent 멤버 섹션 */}
           <div className="mb-8">
             <div className="flex items-center gap-2 text-[15px] font-semibold text-text-muted mb-4">
-              Agent 멤버
+              {'☯'} Agent 멤버
               <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded-full">{agents.length}</span>
               <div className="ml-auto">
                 <button
@@ -116,7 +116,7 @@ export default function Agents() {
             {filterAgents(agents).length === 0 ? (
               <div className="text-[13px] text-text-muted py-6 text-center">Agent 멤버가 없습니다</div>
             ) : (
-              <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4">
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4">
                 {filterAgents(agents).map((m) => (
                   <MemberCard
                     key={m.member_id}
@@ -135,21 +135,45 @@ export default function Agents() {
       {showRegister && (
         <AgentRegisterForm
           onClose={() => setShowRegister(false)}
-          onTokenCreated={(token) => { setShowRegister(false); setCreatedToken(token) }}
+          onTokenCreated={(agentId, token) => { setShowRegister(false); setCreatedToken({ agentId, token }) }}
         />
       )}
 
+      {/* 토큰 표시 모달 — 목업 tokenModal 기준 */}
       {createdToken && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
-          <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
-            <h3 className="text-[18px] font-bold mb-4">에이전트 토큰 발급 완료</h3>
-            <p className="text-[13px] text-warning mb-3">이 토큰은 다시 확인할 수 없습니다. 반드시 복사해 두세요.</p>
-            <div className="bg-bg border border-border rounded-lg p-3 font-mono text-[12px] break-all mb-4">
-              {createdToken}
+          <div className="bg-surface border border-border rounded-lg p-6 w-[480px] text-center">
+            <h3 className="text-[18px] font-bold mb-4 text-positive">{'✓'} 에이전트 등록 완료</h3>
+
+            <div className="mb-2">
+              <div className="text-[12px] font-semibold text-text-muted">Agent ID</div>
+              <div className="text-[16px] font-semibold">{createdToken.agentId}</div>
             </div>
-            <div className="flex justify-end gap-2">
-              <button onClick={() => navigator.clipboard.writeText(createdToken)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">복사</button>
-              <button onClick={() => setCreatedToken(null)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">닫기</button>
+
+            <div className="my-5">
+              <div className="text-[12px] font-semibold text-text-muted">발급된 토큰</div>
+              <div className="bg-bg border border-border rounded-lg p-3.5 font-mono text-[13px] break-all text-left mt-2">
+                {createdToken.token}
+              </div>
+            </div>
+
+            <div className="bg-warning-bg text-warning p-3 rounded-lg text-[13px] mb-5 text-left">
+              {'⚠'} 이 토큰은 다시 표시되지 않습니다. 안전한 곳에 복사해 두세요.
+            </div>
+
+            <div className="flex justify-center gap-2">
+              <button
+                onClick={() => navigator.clipboard.writeText(createdToken.token)}
+                className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
+              >
+                토큰 복사
+              </button>
+              <button
+                onClick={() => setCreatedToken(null)}
+                className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover"
+              >
+                닫기
+              </button>
             </div>
           </div>
         </div>

--- a/frontend/src/pages/ApprovalDetail.tsx
+++ b/frontend/src/pages/ApprovalDetail.tsx
@@ -29,14 +29,13 @@ const REVIEW_RESULT_VARIANT: Record<string, string> = {
   fail: 'negative',
 }
 
-const ACTOR_COLOR: Record<string, string> = {
-  user: 'text-positive',
-  rule_engine: 'text-text-muted',
-  treasury: 'text-text-muted',
-}
-
-function getActorColor(actor: string): string {
-  if (actor in ACTOR_COLOR) return ACTOR_COLOR[actor]
+function getActorColor(actor: string, action?: string): string {
+  if (actor === 'user') {
+    if (action === 'approved' || action === 'approve') return 'text-positive'
+    if (action === 'rejected' || action === 'reject') return 'text-negative'
+    return 'text-positive'
+  }
+  if (actor === 'rule_engine' || actor === 'treasury') return 'text-text-muted'
   if (actor.startsWith('agent:')) return 'text-primary'
   return 'text-text-muted'
 }
@@ -46,9 +45,11 @@ function ApprovalInfoCard({ approval }: { approval: Approval }) {
   const typeLabel = TYPE_LABEL[approval.type] || approval.type
   return (
     <div className="bg-surface border border-border rounded-lg p-5">
-      <h3 className="text-[15px] font-semibold mb-3">결재 정보</h3>
+      <h3 className="text-[15px] font-semibold mb-4">결재 정보</h3>
       <div className="space-y-0">
-        <InfoRow label="요청자" value={approval.requester} />
+        <InfoRow label="요청자" value={
+          <span className="text-primary">{approval.requester}</span>
+        } />
         <InfoRow label="유형" value={typeLabel} />
         <InfoRow label="상태" value={
           <StatusBadge variant={STATUS_VARIANT[approval.status] as 'warning'}>
@@ -56,7 +57,9 @@ function ApprovalInfoCard({ approval }: { approval: Approval }) {
           </StatusBadge>
         } />
         <InfoRow label="요청일" value={formatDateTime(approval.requested_at)} />
-        {approval.expires_at && <InfoRow label="만료일" value={formatDateTime(approval.expires_at)} />}
+        {approval.status === 'pending' && approval.expires_at && (
+          <InfoRow label="만료일" value={formatDateTime(approval.expires_at)} />
+        )}
         {approval.resolved_at && <InfoRow label="처리일" value={formatDateTime(approval.resolved_at)} />}
         {approval.resolved_by && <InfoRow label="처리자" value={approval.resolved_by} />}
         {approval.reference_id && (
@@ -75,7 +78,7 @@ function ApprovalInfoCard({ approval }: { approval: Approval }) {
 function ReviewsCard({ reviews }: { reviews: ApprovalReview[] }) {
   return (
     <div className="bg-surface border border-border rounded-lg p-5">
-      <h3 className="text-[15px] font-semibold mb-3">검토 의견</h3>
+      <h3 className="text-[15px] font-semibold mb-4">검토 의견</h3>
       {reviews.length === 0 ? (
         <div className="text-[13px] text-text-muted py-4 text-center">검토 의견이 없습니다</div>
       ) : (
@@ -114,7 +117,7 @@ function ReviewsCard({ reviews }: { reviews: ApprovalReview[] }) {
 function AuditHistoryCard({ history }: { history: ApprovalHistoryEntry[] }) {
   return (
     <div className="bg-surface border border-border rounded-lg p-5">
-      <h3 className="text-[15px] font-semibold mb-3">감사 이력</h3>
+      <h3 className="text-[15px] font-semibold mb-4">감사 이력</h3>
       {history.length === 0 ? (
         <div className="text-[13px] text-text-muted py-4 text-center">이력이 없습니다</div>
       ) : (
@@ -123,7 +126,7 @@ function AuditHistoryCard({ history }: { history: ApprovalHistoryEntry[] }) {
             <div key={i} className="flex items-start gap-4 py-2.5 border-b border-border last:border-b-0">
               <span className="text-[12px] text-text-muted whitespace-nowrap min-w-[130px]">{formatDateTime(entry.at)}</span>
               <span className="text-[13px]">
-                <span className={`font-mono ${getActorColor(entry.actor)}`}>{entry.actor}</span>
+                <span className={`font-mono ${getActorColor(entry.actor, entry.action)}`}>{entry.actor}</span>
                 {' — '}
                 {entry.detail || entry.action}
               </span>
@@ -139,7 +142,7 @@ function AuditHistoryCard({ history }: { history: ApprovalHistoryEntry[] }) {
 function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div className="flex justify-between py-2 border-b border-border last:border-b-0 text-[13px]">
-      <span className="text-text-muted">{label}</span>
+      <span className="text-text-muted min-w-[80px]">{label}</span>
       <span>{value}</span>
     </div>
   )
@@ -160,14 +163,17 @@ export default function ApprovalDetail() {
       {/* 상세 헤더 */}
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-[20px] font-bold">{approval.title}</h2>
-        {isPending && <ReviewControls approvalId={approval.id} isPending={isPending} title={approval.title} reviews={approval.reviews} />}
+        {isPending && <ReviewControls approvalId={approval.id} isPending={isPending} title={approval.title} reviews={approval.reviews} type={approval.type} params={approval.params} />}
       </div>
 
       {/* 거부 사유 배너 */}
-      {approval.reject_reason && (
-        <div className="bg-negative/10 border border-negative/30 rounded-lg p-4 mb-6 text-[13px]">
-          <div className="font-semibold text-negative mb-1">거부 사유</div>
-          <div className="text-text-muted">{approval.reject_reason}</div>
+      {approval.status === 'rejected' && approval.reject_reason && (
+        <div className="bg-negative/10 text-negative rounded-lg px-[18px] py-[14px] mb-6 flex items-start gap-2.5 text-[13px]">
+          <span className="text-[16px] leading-none mt-0.5">{'\u2715'}</span>
+          <div>
+            <div className="font-semibold mb-1">거부 사유</div>
+            <div className="text-[12px]">{approval.reject_reason}</div>
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -54,8 +54,8 @@ export default function BacktestData() {
   return (
     <>
       {/* 안내 배너 */}
-      <div className="bg-info-bg border border-[rgba(167,139,250,0.2)] rounded-lg px-4 py-3 mb-4 text-[13px] text-info">
-        {'\u{1f4a1}'} 데이터 수집은 Agent에게 요청하거나 CLI(<code className="bg-bg px-1.5 py-0.5 rounded text-[12px]">ante data collect</code>)를 사용하세요.
+      <div className="bg-info-bg rounded px-3.5 py-2.5 mb-4 text-[12px] text-info">
+        {'\u{1f4a1}'} 데이터 수집은 Agent에게 요청하거나 CLI(<code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante data collect</code>)를 사용하세요.
       </div>
 
       {/* 데이터셋 카드 */}
@@ -109,29 +109,33 @@ export default function BacktestData() {
                   {(data?.items ?? []).length === 0 ? (
                     <tr><td colSpan={6} className="px-3 py-8 text-center text-text-muted text-[13px]">데이터셋이 없습니다</td></tr>
                   ) : (
-                    (data?.items ?? []).map((ds) => (
+                    (data?.items ?? []).map((ds, idx, arr) => {
+                      const isLast = idx === arr.length - 1
+                      const borderCls = isLast ? '' : 'border-b border-border'
+                      return (
                       <tr key={ds.id} className="hover:bg-surface-hover">
-                        <td className="px-3 py-3 border-b border-border text-[13px] font-mono font-medium">{ds.symbol}</td>
-                        <td className="px-3 py-3 border-b border-border text-[13px]">{TF_LABELS[ds.timeframe] ?? ds.timeframe}</td>
-                        <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{formatDate(ds.start_date)}</td>
-                        <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{formatDate(ds.end_date)}</td>
-                        <td className="px-3 py-3 border-b border-border text-[13px] text-right">{formatNumber(ds.row_count)}</td>
-                        <td className="px-3 py-3 border-b border-border text-[13px] text-right">
+                        <td className={`px-3 py-3 ${borderCls} text-[13px] font-mono font-medium`}>{ds.symbol}</td>
+                        <td className={`px-3 py-3 ${borderCls} text-[13px]`}>{TF_LABELS[ds.timeframe] ?? ds.timeframe}</td>
+                        <td className={`px-3 py-3 ${borderCls} text-[13px] text-text-muted`}>{formatDate(ds.start_date)}</td>
+                        <td className={`px-3 py-3 ${borderCls} text-[13px] text-text-muted`}>{formatDate(ds.end_date)}</td>
+                        <td className={`px-3 py-3 ${borderCls} text-[13px] text-right`}>{formatNumber(ds.row_count)}</td>
+                        <td className={`px-3 py-3 ${borderCls} text-[13px] text-right`}>
                           <button
                             onClick={() => setDeleteTarget({ id: ds.id, symbol: ds.symbol, timeframe: ds.timeframe, start_date: ds.start_date, end_date: ds.end_date, row_count: ds.row_count })}
-                            className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-negative border border-border cursor-pointer hover:bg-negative-bg"
+                            className="px-2.5 py-1 rounded text-[12px] bg-transparent text-negative border border-border cursor-pointer hover:bg-surface-hover hover:text-text"
                           >
                             삭제
                           </button>
                         </td>
                       </tr>
-                    ))
+                      )
+                    })
                   )}
                 </tbody>
               </table>
             </div>
 
-            <div className="flex items-center justify-between pt-4 text-[13px] text-text-muted">
+            <div className="flex items-center justify-between pt-3 text-[13px] text-text-muted">
               <span>
                 총 {formatNumber(data?.total ?? 0)}건
                 {(data?.total ?? 0) > 0 && ` 중 ${offset + 1}-${Math.min(offset + LIMIT, data?.total ?? 0)}`}
@@ -142,24 +146,22 @@ export default function BacktestData() {
                   ))})</>
                 )}
               </span>
-              {(data?.total ?? 0) > LIMIT && (
-                <div className="flex items-center gap-2">
-                  <button
-                    onClick={() => setOffset(Math.max(0, offset - LIMIT))}
-                    disabled={offset <= 0}
-                    className="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-border bg-transparent text-text-muted hover:bg-surface-hover hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
-                  >
-                    ← 이전
-                  </button>
-                  <button
-                    onClick={() => setOffset(offset + LIMIT)}
-                    disabled={offset + LIMIT >= (data?.total ?? 0)}
-                    className="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-border bg-transparent text-text-muted hover:bg-surface-hover hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
-                  >
-                    다음 →
-                  </button>
-                </div>
-              )}
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={() => setOffset(Math.max(0, offset - LIMIT))}
+                  disabled={offset <= 0}
+                  className="px-2.5 py-1 rounded text-[12px] font-medium border border-border bg-transparent text-text-muted hover:bg-surface-hover hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  &larr; 이전
+                </button>
+                <button
+                  onClick={() => setOffset(offset + LIMIT)}
+                  disabled={offset + LIMIT >= (data?.total ?? 0)}
+                  className="px-2.5 py-1 rounded text-[12px] font-medium border border-border bg-transparent text-text-muted hover:bg-surface-hover hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  다음 &rarr;
+                </button>
+              </div>
             </div>
           </>
         )}
@@ -168,8 +170,8 @@ export default function BacktestData() {
       {/* 삭제 확인 모달 */}
       {deleteTarget && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
-          <div className="bg-surface border border-border rounded-lg p-6 w-[400px]">
-            <h3 className="text-[18px] font-bold mb-4 text-negative">데이터셋 삭제</h3>
+          <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
+            <h3 className="text-[18px] font-bold mb-5 text-negative">데이터셋 삭제</h3>
             <div className="mb-4 text-[13px] text-text-muted">
               <strong className="text-text">{deleteTarget.symbol} — {TF_LABELS[deleteTarget.timeframe] ?? deleteTarget.timeframe}</strong><br />
               기간: {formatDate(deleteTarget.start_date)} ~ {formatDate(deleteTarget.end_date)} · {formatNumber(deleteTarget.row_count)}건<br /><br />
@@ -178,12 +180,12 @@ export default function BacktestData() {
             <div className="bg-warning-bg text-warning px-3.5 py-2.5 rounded text-[12px] mb-4">
               ⚠ 이 데이터를 사용 중인 백테스트가 있을 수 있습니다.
             </div>
-            <div className="flex justify-end gap-2 pt-4 border-t border-border">
-              <button onClick={() => setDeleteTarget(null)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
+            <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
+              <button onClick={() => setDeleteTarget(null)} className="px-4 py-2 rounded text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover hover:text-text">취소</button>
               <button
                 onClick={() => deleteMutation.mutate(deleteTarget.id)}
                 disabled={deleteMutation.isPending}
-                className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative-hover disabled:opacity-50"
+                className="px-4 py-2 rounded text-[13px] font-medium bg-negative text-white border border-negative cursor-pointer hover:bg-negative-hover disabled:opacity-50"
               >
                 삭제
               </button>

--- a/frontend/src/pages/BotDetail.tsx
+++ b/frontend/src/pages/BotDetail.tsx
@@ -27,13 +27,11 @@ export default function BotDetail() {
   const canStart = bot.status === 'stopped' || bot.status === 'created'
   const canStop = bot.status === 'running'
   const canEdit = bot.status === 'stopped' || bot.status === 'created'
-  const isStopped = bot.status === 'stopped'
-
   return (
     <>
       {/* 뒤로가기 링크 */}
       <div className="mb-4">
-        <Link to="/bots" className="text-text-muted text-[13px] no-underline hover:text-text hover:underline">
+        <Link to="/bots" className="inline-flex items-center text-text-muted text-[13px] no-underline px-2 py-1 rounded hover:bg-surface-hover hover:text-text">
           &larr; 봇 관리
         </Link>
       </div>
@@ -43,34 +41,18 @@ export default function BotDetail() {
         <div>
           <h2 className="text-[20px] font-bold flex items-center gap-2">
             {bot.name || bot.bot_id}
-            {bot.name && <span className="text-[14px] font-normal text-text-muted font-mono">{bot.bot_id}</span>}
-            {isStopped && (
-              <StatusBadge variant="warning">중지</StatusBadge>
-            )}
+            {bot.name && <span className="text-[16px] font-normal text-text-muted">{bot.bot_id}</span>}
           </h2>
-          <div className="flex gap-3 items-center mt-1">
-            <StatusBadge variant={STATUS_VARIANT[bot.status] as 'positive'}>
-              {BOT_STATUS_LABELS[bot.status]}
-            </StatusBadge>
-            <StatusBadge variant={bot.mode === 'live' ? 'warning' : 'info'}>
-              {bot.mode === 'live' ? '실전' : '모의'}
-            </StatusBadge>
-            {bot.strategy_name && (
-              <Link to="/strategies" className="text-primary text-[13px] no-underline hover:underline">
-                {bot.strategy_name}
-              </Link>
-            )}
-          </div>
         </div>
         <div className="flex gap-2">
           {canEdit && (
             <button onClick={() => setShowEditModal(true)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">설정 수정</button>
           )}
           {canStart && (
-            <button onClick={() => start.mutate(bot.bot_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">시작</button>
+            <button onClick={() => start.mutate(bot.bot_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">시작</button>
           )}
           {canStop && (
-            <button onClick={() => setShowStopModal(true)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">중지</button>
+            <button onClick={() => setShowStopModal(true)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-negative border border-negative cursor-pointer hover:bg-negative-bg">중지</button>
           )}
         </div>
       </div>
@@ -83,7 +65,7 @@ export default function BotDetail() {
           <div className="space-y-2">
             <div className="flex justify-between py-1.5 text-[13px]">
               <span className="text-text-muted">전략명</span>
-              <span>{bot.strategy?.name || bot.strategy_name || '-'}</span>
+              <span>{bot.strategy?.name || bot.strategy_name ? <Link to="/strategies" className="text-primary no-underline hover:underline">{bot.strategy?.name || bot.strategy_name}</Link> : '-'}</span>
             </div>
             <div className="flex justify-between py-1.5 text-[13px]">
               <span className="text-text-muted">버전</span>
@@ -95,7 +77,7 @@ export default function BotDetail() {
             </div>
             <div className="flex justify-between py-1.5 text-[13px]">
               <span className="text-text-muted">설명</span>
-              <span className="text-right max-w-[60%]">{bot.strategy?.description || '-'}</span>
+              <span className="text-right max-w-[60%] text-[12px] text-text-muted">{bot.strategy?.description || '-'}</span>
             </div>
           </div>
         </div>
@@ -106,7 +88,7 @@ export default function BotDetail() {
           <div className="space-y-2">
             <div className="flex justify-between py-1.5 text-[13px]">
               <span className="text-text-muted">모드</span>
-              <StatusBadge variant={bot.mode === 'live' ? 'warning' : 'info'}>
+              <StatusBadge variant={bot.mode === 'live' ? 'primary' : 'warning'}>
                 {bot.mode === 'live' ? '실전' : '모의'}
               </StatusBadge>
             </div>
@@ -119,10 +101,6 @@ export default function BotDetail() {
             <div className="flex justify-between py-1.5 text-[13px]">
               <span className="text-text-muted">실행 간격</span>
               <span>{bot.interval_seconds}초</span>
-            </div>
-            <div className="flex justify-between py-1.5 text-[13px]">
-              <span className="text-text-muted">대상 종목</span>
-              <span className="font-mono">{bot.symbols?.length ? bot.symbols.join(', ') : '-'}</span>
             </div>
           </div>
         </div>
@@ -212,7 +190,7 @@ export default function BotDetail() {
         <div className="flex items-center justify-between mb-3">
           <h3 className="text-[15px] font-semibold">실행 로그</h3>
           {(bot.logs ?? []).length > 0 && (
-            <span className="text-[12px] text-primary cursor-pointer hover:underline">전체 보기</span>
+            <span className="text-[13px] text-primary cursor-pointer hover:underline">전체 보기 &rarr;</span>
           )}
         </div>
         {(bot.logs ?? []).length === 0 ? (
@@ -225,7 +203,7 @@ export default function BotDetail() {
                 <StatusBadge variant={log.success ? 'positive' : 'negative'}>
                   {log.success ? '성공' : '실패'}
                 </StatusBadge>
-                {log.message && <span className="text-text-muted">{log.message}</span>}
+                {log.message && <span className={log.success ? '' : 'text-negative'}>{log.message}</span>}
               </div>
             ))}
           </div>

--- a/frontend/src/pages/Bots.tsx
+++ b/frontend/src/pages/Bots.tsx
@@ -56,7 +56,7 @@ export default function Bots() {
               onClick={() => setShowCreate(true)}
               className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
             >
-              봇 생성
+              + 봇 생성
             </button>
           </div>
 

--- a/frontend/src/pages/Performance.tsx
+++ b/frontend/src/pages/Performance.tsx
@@ -1,0 +1,262 @@
+import { useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { useStrategyPerformance, useStrategyDailySummary, useStrategyWeeklySummary, useStrategyMonthlySummary } from '../hooks/useStrategies'
+import { PageSkeleton } from '../components/common/Skeleton'
+import Pagination from '../components/common/Pagination'
+import { formatKRW, formatPercent } from '../utils/formatters'
+import type { DailySummary, WeeklySummary, MonthlySummary } from '../types/strategy'
+
+type PeriodTab = 'daily' | 'weekly' | 'monthly'
+
+const DAILY_PAGE_SIZE = 20
+const WEEKLY_PAGE_SIZE = 20
+const MONTHLY_PAGE_SIZE = 20
+
+function StatCard({ label, value, colorClass }: { label: string; value: string; colorClass?: string }) {
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5">
+      <div className="text-[12px] text-text-muted mb-1">{label}</div>
+      <div className={`text-[20px] font-bold ${colorClass ?? ''}`}>{value}</div>
+    </div>
+  )
+}
+
+function DailyTable({ items, offset }: { items: DailySummary[]; offset: number }) {
+  const page = items.slice(offset, offset + DAILY_PAGE_SIZE)
+
+  if (page.length === 0) {
+    return <div className="py-8 text-center text-text-muted text-[13px]">데이터가 없습니다</div>
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">일자</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">거래 수</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">승률</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">실현 손익</th>
+          </tr>
+        </thead>
+        <tbody>
+          {page.map((d) => (
+            <tr key={d.date} className="hover:bg-surface-hover">
+              <td className="px-3 py-2.5 border-b border-border text-[13px]">{d.date}</td>
+              <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{d.trade_count}</td>
+              <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{formatPercent(d.win_rate)}</td>
+              <td className={`px-3 py-2.5 border-b border-border text-[13px] text-right ${d.realized_pnl >= 0 ? 'text-positive' : 'text-negative'}`}>
+                {formatKRW(d.realized_pnl)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function WeeklyTable({ items, offset }: { items: WeeklySummary[]; offset: number }) {
+  const page = items.slice(offset, offset + WEEKLY_PAGE_SIZE)
+
+  if (page.length === 0) {
+    return <div className="py-8 text-center text-text-muted text-[13px]">데이터가 없습니다</div>
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">주간</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">거래 수</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">승률</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">실현 손익</th>
+          </tr>
+        </thead>
+        <tbody>
+          {page.map((w) => (
+            <tr key={w.week_start} className="hover:bg-surface-hover">
+              <td className="px-3 py-2.5 border-b border-border text-[13px]">{w.week_start} ~ {w.week_end.slice(5)}</td>
+              <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{w.trade_count}</td>
+              <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{formatPercent(w.win_rate)}</td>
+              <td className={`px-3 py-2.5 border-b border-border text-[13px] text-right ${w.realized_pnl >= 0 ? 'text-positive' : 'text-negative'}`}>
+                {formatKRW(w.realized_pnl)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function MonthlyTable({ items, offset }: { items: MonthlySummary[]; offset: number }) {
+  const page = items.slice(offset, offset + MONTHLY_PAGE_SIZE)
+
+  if (page.length === 0) {
+    return <div className="py-8 text-center text-text-muted text-[13px]">데이터가 없습니다</div>
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">월</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">거래 수</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">승률</th>
+            <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">실현 손익</th>
+          </tr>
+        </thead>
+        <tbody>
+          {page.map((m) => (
+            <tr key={`${m.year}-${m.month}`} className="hover:bg-surface-hover">
+              <td className="px-3 py-2.5 border-b border-border text-[13px]">{m.year}-{String(m.month).padStart(2, '0')}</td>
+              <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{m.trade_count}</td>
+              <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{formatPercent(m.win_rate)}</td>
+              <td className={`px-3 py-2.5 border-b border-border text-[13px] text-right ${m.realized_pnl >= 0 ? 'text-positive' : 'text-negative'}`}>
+                {formatKRW(m.realized_pnl)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default function Performance() {
+  const { id = '' } = useParams<{ id: string }>()
+  const [tab, setTab] = useState<PeriodTab>('monthly')
+  const [dailyOffset, setDailyOffset] = useState(0)
+  const [weeklyOffset, setWeeklyOffset] = useState(0)
+  const [monthlyOffset, setMonthlyOffset] = useState(0)
+
+  const { data: performance, isLoading } = useStrategyPerformance(id)
+  const { data: dailyData } = useStrategyDailySummary(id)
+  const { data: weeklyData } = useStrategyWeeklySummary(id)
+  const { data: monthlyData } = useStrategyMonthlySummary(id)
+
+  if (isLoading) return <PageSkeleton />
+
+  const daily = (dailyData ?? []).slice().reverse()
+  const weekly = (weeklyData ?? []).slice().reverse()
+  const monthly = (monthlyData ?? []).slice().reverse()
+
+  const tabConfig: { key: PeriodTab; label: string }[] = [
+    { key: 'daily', label: '일별' },
+    { key: 'weekly', label: '주별' },
+    { key: 'monthly', label: '월별' },
+  ]
+
+  const totalPnl = performance?.realized_pnl ?? 0
+  const totalTrades = performance?.total_trades ?? 0
+  const winRate = performance?.win_rate ?? 0
+  const profitFactor = performance?.profit_factor
+
+  return (
+    <>
+      {/* 헤더 */}
+      <div className="flex items-center gap-3 mb-6">
+        <Link
+          to={`/strategies/${id}`}
+          className="text-[13px] text-text-muted no-underline hover:text-text"
+        >
+          &larr; 전략 상세
+        </Link>
+        <h2 className="text-[20px] font-bold">기간별 성과</h2>
+      </div>
+
+      {/* 필터 바 */}
+      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+        <div className="flex items-center gap-4 flex-wrap">
+          <div>
+            <label className="text-[12px] text-text-muted block mb-1">기간</label>
+            <div className="flex gap-1 bg-bg rounded-lg p-0.5">
+              {tabConfig.map(({ key, label }) => (
+                <button
+                  key={key}
+                  onClick={() => setTab(key)}
+                  className={`px-3 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
+                    tab === key
+                      ? 'bg-surface text-text'
+                      : 'bg-transparent text-text-muted'
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 요약 카드 */}
+      <div className="grid grid-cols-4 gap-4 mb-6">
+        <StatCard
+          label="조회 기간 실현 손익"
+          value={formatKRW(totalPnl)}
+          colorClass={totalPnl >= 0 ? 'text-positive' : 'text-negative'}
+        />
+        <StatCard label="총 거래 수" value={String(totalTrades)} />
+        <StatCard label="승률" value={formatPercent(winRate)} />
+        <StatCard
+          label="수익 팩터"
+          value={profitFactor == null ? '-' : profitFactor === Infinity ? '∞' : profitFactor.toFixed(2)}
+        />
+      </div>
+
+      {/* 기간별 성과 테이블 */}
+      <div className="bg-surface border border-border rounded-lg p-5">
+        <h3 className="text-[15px] font-semibold mb-4">
+          {tab === 'daily' && '일별 성과'}
+          {tab === 'weekly' && '주별 성과'}
+          {tab === 'monthly' && '월별 성과'}
+        </h3>
+
+        {tab === 'daily' && (
+          <>
+            <DailyTable items={daily} offset={dailyOffset} />
+            {daily.length > DAILY_PAGE_SIZE && (
+              <Pagination
+                total={daily.length}
+                offset={dailyOffset}
+                limit={DAILY_PAGE_SIZE}
+                onPageChange={setDailyOffset}
+              />
+            )}
+          </>
+        )}
+
+        {tab === 'weekly' && (
+          <>
+            <WeeklyTable items={weekly} offset={weeklyOffset} />
+            {weekly.length > WEEKLY_PAGE_SIZE && (
+              <Pagination
+                total={weekly.length}
+                offset={weeklyOffset}
+                limit={WEEKLY_PAGE_SIZE}
+                onPageChange={setWeeklyOffset}
+              />
+            )}
+          </>
+        )}
+
+        {tab === 'monthly' && (
+          <>
+            <MonthlyTable items={monthly} offset={monthlyOffset} />
+            {monthly.length > MONTHLY_PAGE_SIZE && (
+              <Pagination
+                total={monthly.length}
+                offset={monthlyOffset}
+                limit={MONTHLY_PAGE_SIZE}
+                onPageChange={setMonthlyOffset}
+              />
+            )}
+          </>
+        )}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -18,8 +18,8 @@ const TRADING_CONFIGS = [
 
 /** 표시 및 알림 설정 */
 const DISPLAY_CONFIGS = [
-  { key: 'system.log_level', label: '시스템 로그 수준', desc: '로그 출력 상세도', type: 'select' as const, options: ['DEBUG', 'INFO', 'WARNING', 'ERROR'] },
-  { key: 'notification.telegram_level', label: '텔레그램 알림 수준', desc: '알림 발송 기준', type: 'select' as const, options: ['all', 'important', 'critical', 'off'] },
+  { key: 'system.log_level', label: '시스템 로그 수준', desc: 'system.log_level · 로그 출력 상세도', type: 'select' as const, options: ['DEBUG', 'INFO', 'WARNING', 'ERROR'] },
+  { key: 'notification.telegram_level', label: '텔레그램 알림 수준', desc: 'notification.telegram_level · 알림 발송 기준', type: 'select' as const, options: ['all', 'important', 'critical', 'off'] },
   { key: 'notification.fill_alert', label: '체결 알림', desc: '매수/매도 체결 시 즉시 알림', type: 'toggle' as const },
   { key: 'notification.daily_report', label: '일일 리포트', desc: '매일 장 마감 후 수익 요약 리포트', type: 'toggle' as const },
 ]
@@ -62,7 +62,7 @@ export default function Settings() {
 
   return (
     <>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
         {/* 시스템 상태 */}
         <div className="bg-surface border border-border rounded-lg p-5">
           <h3 className="text-[15px] font-semibold mb-4">시스템 상태</h3>
@@ -101,20 +101,20 @@ export default function Settings() {
         {/* 거래소 연결 */}
         <div className="bg-surface border border-border rounded-lg p-5">
           <h3 className="text-[15px] font-semibold mb-4">거래소 연결</h3>
-          <div className="space-y-0">
-            <div className="flex justify-between py-2.5 border-b border-border text-[13px]">
+          <div>
+            <div className="flex justify-between py-2 border-b border-border text-[13px]">
               <span className="text-text-muted">이름</span>
               <span>한국투자증권</span>
             </div>
-            <div className="flex justify-between py-2.5 border-b border-border text-[13px]">
+            <div className="flex justify-between py-2 border-b border-border text-[13px]">
               <span className="text-text-muted">거래 모드</span>
               <span className="inline-flex items-center px-2 py-0.5 rounded-[10px] text-[11px] font-semibold bg-primary/15 text-primary">
-                {getConfigValue('broker.mode') || '모의투자'}
+                {getConfigValue('broker.mode') || '실전'}
               </span>
             </div>
-            <div className="flex justify-between py-2.5 text-[13px]">
+            <div className="flex justify-between py-2 text-[13px]">
               <span className="text-text-muted">계좌번호</span>
-              <span className="font-mono">{getConfigValue('broker.account_no') || '-'}</span>
+              <span className="font-mono text-[12px]">{getConfigValue('broker.account_no') || '-'}</span>
             </div>
           </div>
         </div>
@@ -128,8 +128,8 @@ export default function Settings() {
             <thead>
               <tr>
                 <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">설정</th>
-                <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border w-[160px]">값</th>
-                <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border w-[60px]"></th>
+                <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">값</th>
+                <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border"></th>
               </tr>
             </thead>
             <tbody>
@@ -143,12 +143,17 @@ export default function Settings() {
                     <input
                       value={getRowValue(cfg.key)}
                       onChange={(e) => setRowValue(cfg.key, e.target.value)}
-                      className="w-full bg-bg border border-border rounded px-2 py-1 text-text text-[13px] font-mono focus:outline-none focus:border-primary"
+                      className="w-[120px] bg-bg border border-border rounded px-2 py-1 text-text text-[13px] focus:outline-none focus:border-primary"
                       onKeyDown={(e) => e.key === 'Enter' && saveRow(cfg.key)}
                     />
                   </td>
                   <td className="px-3 py-3 border-b border-border text-right">
-                    <button onClick={() => saveRow(cfg.key)} className="px-2 py-1 rounded text-[11px] bg-primary text-white border-none cursor-pointer">저장</button>
+                    <button
+                      onClick={() => saveRow(cfg.key)}
+                      className="px-2.5 py-1 rounded text-[12px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover hover:text-text"
+                    >
+                      저장
+                    </button>
                   </td>
                 </tr>
               ))}
@@ -160,16 +165,16 @@ export default function Settings() {
       {/* 표시 및 알림 */}
       <div className="bg-surface border border-border rounded-lg p-5">
         <h3 className="text-[15px] font-semibold mb-4">표시 및 알림</h3>
-        <div className="space-y-0">
+        <div>
           {/* 금액 단위 위치 토글 */}
-          <div className="flex items-center justify-between py-3 border-b border-border">
+          <div className="flex items-center justify-between py-2 border-b border-border">
             <div>
               <div className="text-[13px] font-medium">금액 단위 위치</div>
               <div className="text-[12px] text-text-muted mt-0.5">금액 표시 시 통화 단위(원)의 위치를 설정합니다</div>
             </div>
             <div className="flex gap-2">
               <CurrencyFormatButton
-                label="₩ 1,000,000"
+                label={'\u20A9 1,000,000'}
                 active={getConfigValue('display.currency_position') === 'prefix'}
                 onClick={() => updateConfig.mutate({ key: 'display.currency_position', value: 'prefix' })}
               />
@@ -180,8 +185,13 @@ export default function Settings() {
               />
             </div>
           </div>
-          {DISPLAY_CONFIGS.map((cfg) => (
-            <div key={cfg.key} className="flex items-center justify-between py-3 border-b border-border last:border-b-0">
+          {DISPLAY_CONFIGS.map((cfg, idx) => (
+            <div
+              key={cfg.key}
+              className={`flex items-center justify-between py-2 ${
+                idx < DISPLAY_CONFIGS.length - 1 ? 'border-b border-border' : ''
+              }`}
+            >
               <div>
                 <div className="text-[13px] font-medium">{cfg.label}</div>
                 <div className="text-[12px] text-text-muted mt-0.5">{cfg.desc}</div>
@@ -220,8 +230,8 @@ export default function Settings() {
       {/* 비상 거래 정지 모달 */}
       {showHaltModal && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
-          <div className="bg-surface border border-border rounded-lg p-6 w-[440px]">
-            <h3 className="text-[18px] font-bold text-negative mb-4">비상 거래 정지</h3>
+          <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
+            <h3 className="text-[18px] font-bold text-negative mb-5">비상 거래 정지</h3>
             <p className="text-[13px] text-text-muted mb-4">
               모든 봇의 거래가 즉시 중단됩니다.<br />
               실행 중인 사이클이 완료된 후 정지되며, 보유 포지션은 유지됩니다.
@@ -236,10 +246,10 @@ export default function Settings() {
                 className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] placeholder:text-text-muted focus:outline-none focus:border-primary"
               />
             </div>
-            <div className="bg-warning-bg text-warning px-3 py-2.5 rounded text-[12px] mb-4">
+            <div className="bg-warning-bg text-warning px-3.5 py-2.5 rounded text-[12px] mb-4">
               ⚠ 이 작업은 실행 중인 모든 봇에 영향을 줍니다.
             </div>
-            <div className="flex justify-end gap-2 pt-4 border-t border-border">
+            <div className="flex justify-end gap-2 pt-4 border-t border-border mt-6">
               <button onClick={() => { setShowHaltModal(false); setHaltReason('') }} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
               <button onClick={handleHalt} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative-hover">거래 정지 확인</button>
             </div>
@@ -254,7 +264,7 @@ function CurrencyFormatButton({ label, active, onClick }: { label: string; activ
   return (
     <button
       onClick={onClick}
-      className={`px-3 py-1.5 rounded-lg text-[13px] font-medium border cursor-pointer transition-colors ${
+      className={`px-2.5 py-1 rounded-lg text-[12px] font-medium border cursor-pointer transition-colors ${
         active
           ? 'bg-primary text-white border-primary'
           : 'bg-transparent text-text-muted border-border hover:bg-surface-hover'

--- a/frontend/src/pages/StrategyDetail.tsx
+++ b/frontend/src/pages/StrategyDetail.tsx
@@ -1,28 +1,33 @@
 import { useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
-import { useStrategyDetail, useStrategyPerformance, useStrategyTrades, useStrategyDailySummary, useStrategyMonthlySummary } from '../hooks/useStrategies'
+import { useStrategyDetail, useStrategyPerformance, useStrategyTrades, useStrategyDailySummary, useStrategyWeeklySummary, useStrategyMonthlySummary } from '../hooks/useStrategies'
 import PerformancePanel from '../components/strategies/PerformancePanel'
 import PeriodPerformance from '../components/strategies/PeriodPerformance'
 import StatusBadge from '../components/common/StatusBadge'
 import { PageSkeleton } from '../components/common/Skeleton'
-import { formatKRW, formatDateTime } from '../utils/formatters'
+import { formatNumber } from '../utils/formatters'
 import { STRATEGY_STATUS_LABELS } from '../utils/constants'
-import type { StrategyStatus } from '../types/strategy'
+import type { StrategyStatus, StrategyParam } from '../types/strategy'
 
 const STATUS_VARIANT: Record<StrategyStatus, string> = {
-  active: 'positive', registered: 'info', inactive: 'muted', archived: 'muted',
+  active: 'positive', registered: 'warning', inactive: 'muted', archived: 'muted',
 }
 
 type EquityCurvePeriod = '1w' | '1m' | '3m' | 'all'
 
+function isStrategyParam(v: unknown): v is StrategyParam {
+  return typeof v === 'object' && v !== null && 'value' in v
+}
+
 export default function StrategyDetail() {
   const { id = '' } = useParams<{ id: string }>()
-  const [equityPeriod, setEquityPeriod] = useState<EquityCurvePeriod>('all')
+  const [equityPeriod, setEquityPeriod] = useState<EquityCurvePeriod>('1m')
 
   const { data: strategy, isLoading } = useStrategyDetail(id)
   const { data: performance } = useStrategyPerformance(id)
   const { data: tradesData } = useStrategyTrades(id)
   const { data: dailySummary } = useStrategyDailySummary(id)
+  const { data: weeklySummary } = useStrategyWeeklySummary(id)
   const { data: monthlySummary } = useStrategyMonthlySummary(id)
 
   if (isLoading) return <PageSkeleton />
@@ -30,63 +35,96 @@ export default function StrategyDetail() {
 
   return (
     <>
-      {/* 헤더 */}
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h2 className="text-[20px] font-bold">{strategy.name}</h2>
-          <div className="flex gap-3 items-center mt-1">
-            <span className="text-text-muted text-[13px]">v{strategy.version}</span>
-            <StatusBadge variant={STATUS_VARIANT[strategy.status] as 'positive'}>
-              {STRATEGY_STATUS_LABELS[strategy.status]}
-            </StatusBadge>
-            {strategy.bot_id && (
-              <span className="text-[13px] text-text-muted">
+      {/* 전략 정보 헤더 */}
+      <div className="mb-6">
+        <h2 className="text-[20px] font-bold">{strategy.name}</h2>
+        <div className="flex gap-3 items-center mt-1">
+          <StatusBadge variant={STATUS_VARIANT[strategy.status] as 'positive'}>
+            {STRATEGY_STATUS_LABELS[strategy.status]}
+          </StatusBadge>
+          <span className="text-text-muted text-[13px]">v{strategy.version}</span>
+          {strategy.bot_id && (
+            <>
+              <span className="text-text-muted text-[13px]">|</span>
+              <span className="text-[13px]">
                 실행 봇:{' '}
-                <Link to={`/bots/${strategy.bot_id}`} className="text-primary no-underline hover:underline">
+                <Link to={`/bots/${strategy.bot_id}`} className="text-text no-underline hover:underline">
                   {strategy.bot_id}
                 </Link>
               </span>
-            )}
-          </div>
-        </div>
-      </div>
-
-      {/* 전략 정보 카드 */}
-      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
-        <h3 className="text-[15px] font-semibold mb-3">전략 정보</h3>
-        <div className="space-y-2">
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">제출자</span>
-            <span>{strategy.author || '-'}</span>
-          </div>
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">버전</span>
-            <span>v{strategy.version}</span>
-          </div>
-          <div className="flex justify-between py-2 border-b border-border text-[13px]">
-            <span className="text-text-muted">설명</span>
-            <span>{strategy.description || '-'}</span>
-          </div>
-          {strategy.params && Object.keys(strategy.params).length > 0 && (
-            <div className="pt-2 text-[13px]">
-              <span className="text-text-muted block mb-2">파라미터</span>
-              <div className="bg-bg rounded-lg p-3 space-y-1">
-                {Object.entries(strategy.params).map(([key, value]) => (
-                  <div key={key} className="flex justify-between">
-                    <span className="text-text-muted font-mono text-[12px]">{key}</span>
-                    <span className="text-[12px]">{String(value)}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
+            </>
           )}
         </div>
       </div>
 
-      {/* 에쿼티 커브 */}
+      {/* 전략 개요: 2열 그리드 (전략 정보 + 전략 파라미터) */}
+      <div className="grid grid-cols-2 gap-4 mb-6">
+        {/* 전략 정보 */}
+        <div className="bg-surface border border-border rounded-lg p-5">
+          <h3 className="text-[15px] font-semibold mb-4">전략 정보</h3>
+          <div className="flex justify-between py-2 border-b border-border text-[13px]">
+            <span className="text-text-muted">제출자</span>
+            <span>
+              {strategy.author ? (
+                <>{strategy.author} {strategy.author_id && <span className="text-text-muted font-normal">{strategy.author_id}</span>}</>
+              ) : '-'}
+            </span>
+          </div>
+          <div className="flex justify-between py-2 border-b border-border text-[13px]">
+            <span className="text-text-muted">버전</span>
+            <span>{strategy.version}</span>
+          </div>
+          <div className="flex justify-between py-2 border-b border-border text-[13px]">
+            <span className="text-text-muted">설명</span>
+            <span className="text-[12px] text-text-muted">{strategy.description || '-'}</span>
+          </div>
+          {strategy.rationale && (
+            <div className="mt-3">
+              <div className="text-[12px] text-text-muted font-semibold mb-1">투자 근거</div>
+              <div className="text-[12px] text-text-muted leading-relaxed whitespace-pre-line">{strategy.rationale}</div>
+            </div>
+          )}
+          {strategy.risks && (
+            <div className="mt-3 pt-3 border-t border-border">
+              <div className="text-[12px] text-text-muted font-semibold mb-1">리스크</div>
+              <div className="text-[12px] text-text-muted leading-relaxed whitespace-pre-line">{strategy.risks}</div>
+            </div>
+          )}
+        </div>
+
+        {/* 전략 파라미터 */}
+        <div className="bg-surface border border-border rounded-lg p-5">
+          <h3 className="text-[15px] font-semibold mb-4">전략 파라미터</h3>
+          {strategy.params && Object.keys(strategy.params).length > 0 ? (
+            <div className="space-y-0">
+              {Object.entries(strategy.params).map(([key, raw]) => {
+                const param = isStrategyParam(raw) ? raw : { value: raw }
+                return (
+                  <div key={key} className="flex justify-between py-2 border-b border-border text-[13px]">
+                    <span className="text-text-muted">{key}</span>
+                    <span>
+                      <span className="font-mono">{String(param.value)}</span>
+                      {param.description && (
+                        <span className="text-text-muted text-[11px] ml-2">{param.description}</span>
+                      )}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <div className="py-4 text-text-muted text-[13px] text-center">파라미터가 없습니다</div>
+          )}
+        </div>
+      </div>
+
+      {/* 전략 성과 섹션 제목 */}
+      <h3 className="text-[16px] font-semibold mb-4">전략 성과</h3>
+
+      {/* 자산 추이 (Equity Curve) */}
       <div className="bg-surface border border-border rounded-lg p-5 mb-6">
         <div className="flex items-center justify-between mb-3">
-          <h3 className="text-[15px] font-semibold">자산 추이</h3>
+          <h3 className="text-[15px] font-semibold">자산 추이 (Equity Curve)</h3>
           <div className="flex gap-1 bg-bg rounded-lg p-0.5">
             {([['1w', '1주'], ['1m', '1개월'], ['3m', '3개월'], ['all', '전체']] as const).map(([key, label]) => (
               <button
@@ -104,8 +142,8 @@ export default function StrategyDetail() {
             아직 자산 추이 데이터가 없습니다
           </div>
         ) : (
-          <div className="h-[280px] bg-bg border border-dashed border-border rounded-lg flex items-center justify-center text-text-muted text-[13px]">
-            에쿼티 커브 (TradingView Area Chart)
+          <div className="h-[240px] bg-bg border border-dashed border-border rounded-lg flex items-center justify-center text-text-muted text-[13px]">
+            Equity Curve — 전략 자산 가치 변화
           </div>
         )}
       </div>
@@ -114,43 +152,50 @@ export default function StrategyDetail() {
       <PerformancePanel perf={performance} />
 
       {/* 2열 그리드: 기간별 성과 + 최근 거래 */}
-      <div className="grid grid-cols-2 gap-6">
+      <div className="grid grid-cols-2 gap-4">
         {/* 좌: 기간별 성과 */}
-        <PeriodPerformance daily={dailySummary} monthly={monthlySummary} />
+        <PeriodPerformance daily={dailySummary} weekly={weeklySummary} monthly={monthlySummary} strategyId={id} />
 
         {/* 우: 최근 거래 */}
         <div className="bg-surface border border-border rounded-lg p-5">
-          <h3 className="text-[15px] font-semibold mb-4">최근 거래</h3>
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-[15px] font-semibold">최근 거래</h3>
+            <span className="text-[13px] text-primary cursor-pointer hover:underline">전체 보기 &rarr;</span>
+          </div>
           <div className="overflow-x-auto">
             <table className="w-full border-collapse">
               <thead>
                 <tr>
+                  <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">시각</th>
                   <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">종목</th>
-                  <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">방향</th>
-                  <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">가격</th>
+                  <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">매매</th>
+                  <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">수량</th>
+                  <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">단가</th>
                   <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">손익</th>
-                  <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">체결일</th>
                 </tr>
               </thead>
               <tbody>
                 {(tradesData?.items ?? []).length === 0 ? (
-                  <tr><td colSpan={5} className="px-3 py-8 text-center text-text-muted text-[13px]">거래 내역이 없습니다</td></tr>
+                  <tr><td colSpan={6} className="px-3 py-8 text-center text-text-muted text-[13px]">거래 내역이 없습니다</td></tr>
                 ) : (
-                  (tradesData?.items ?? []).slice(0, 10).map((t) => (
+                  (tradesData?.items ?? []).slice(0, 12).map((t) => (
                     <tr key={t.id} className="hover:bg-surface-hover">
-                      <td className="px-3 py-2.5 border-b border-border text-[13px] font-mono">{t.symbol}</td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px] font-mono text-text-muted">{formatShortDateTime(t.executed_at)}</td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px]">{t.symbol}</td>
                       <td className="px-3 py-2.5 border-b border-border text-[13px]">
-                        <StatusBadge variant={t.side === 'buy' ? 'positive' : 'negative'}>
+                        <StatusBadge variant={t.side === 'buy' ? 'negative' : 'positive'}>
                           {t.side === 'buy' ? '매수' : '매도'}
                         </StatusBadge>
                       </td>
-                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{formatKRW(t.price)}</td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{formatNumber(t.quantity)}</td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{formatNumber(t.price)}</td>
                       <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">
                         {t.pnl != null ? (
-                          <span className={t.pnl >= 0 ? 'text-positive' : 'text-negative'}>{formatKRW(t.pnl)}</span>
-                        ) : '-'}
+                          <span className={t.pnl >= 0 ? 'text-positive' : 'text-negative'}>{formatNumber(t.pnl)}</span>
+                        ) : (
+                          <span className="text-text-muted">—</span>
+                        )}
                       </td>
-                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-text-muted">{formatDateTime(t.executed_at)}</td>
                     </tr>
                   ))
                 )}
@@ -161,4 +206,16 @@ export default function StrategyDetail() {
       </div>
     </>
   )
+}
+
+/** MM-DD HH:mm 형식의 짧은 날짜 시간 */
+function formatShortDateTime(dateStr: string | undefined | null): string {
+  if (!dateStr) return '-'
+  const d = new Date(dateStr.replace(' ', 'T'))
+  if (isNaN(d.getTime())) return '-'
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  const hh = String(d.getHours()).padStart(2, '0')
+  const min = String(d.getMinutes()).padStart(2, '0')
+  return `${mm}-${dd} ${hh}:${min}`
 }

--- a/frontend/src/pages/StrategyDetail.tsx
+++ b/frontend/src/pages/StrategyDetail.tsx
@@ -116,46 +116,60 @@ export default function StrategyDetail() {
       {/* 2열 그리드: 기간별 성과 + 최근 거래 */}
       <div className="grid grid-cols-2 gap-6">
         {/* 좌: 기간별 성과 */}
-        <PeriodPerformance daily={dailySummary} monthly={monthlySummary} />
+        <div>
+          <PeriodPerformance daily={dailySummary} monthly={monthlySummary} />
+          <div className="mt-2 text-right">
+            <Link to={`/strategies/${id}/performance`} className="text-[13px] text-primary no-underline hover:underline">
+              기간별 성과 더보기 &rarr;
+            </Link>
+          </div>
+        </div>
 
         {/* 우: 최근 거래 */}
-        <div className="bg-surface border border-border rounded-lg p-5">
-          <h3 className="text-[15px] font-semibold mb-4">최근 거래</h3>
-          <div className="overflow-x-auto">
-            <table className="w-full border-collapse">
-              <thead>
-                <tr>
-                  <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">종목</th>
-                  <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">방향</th>
-                  <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">가격</th>
-                  <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">손익</th>
-                  <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">체결일</th>
-                </tr>
-              </thead>
-              <tbody>
-                {(tradesData?.items ?? []).length === 0 ? (
-                  <tr><td colSpan={5} className="px-3 py-8 text-center text-text-muted text-[13px]">거래 내역이 없습니다</td></tr>
-                ) : (
-                  (tradesData?.items ?? []).slice(0, 10).map((t) => (
-                    <tr key={t.id} className="hover:bg-surface-hover">
-                      <td className="px-3 py-2.5 border-b border-border text-[13px] font-mono">{t.symbol}</td>
-                      <td className="px-3 py-2.5 border-b border-border text-[13px]">
-                        <StatusBadge variant={t.side === 'buy' ? 'positive' : 'negative'}>
-                          {t.side === 'buy' ? '매수' : '매도'}
-                        </StatusBadge>
-                      </td>
-                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{formatKRW(t.price)}</td>
-                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">
-                        {t.pnl != null ? (
-                          <span className={t.pnl >= 0 ? 'text-positive' : 'text-negative'}>{formatKRW(t.pnl)}</span>
-                        ) : '-'}
-                      </td>
-                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-text-muted">{formatDateTime(t.executed_at)}</td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
+        <div>
+          <div className="bg-surface border border-border rounded-lg p-5">
+            <h3 className="text-[15px] font-semibold mb-4">최근 거래</h3>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr>
+                    <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">종목</th>
+                    <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">방향</th>
+                    <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">가격</th>
+                    <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">손익</th>
+                    <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">체결일</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(tradesData?.items ?? []).length === 0 ? (
+                    <tr><td colSpan={5} className="px-3 py-8 text-center text-text-muted text-[13px]">거래 내역이 없습니다</td></tr>
+                  ) : (
+                    (tradesData?.items ?? []).slice(0, 10).map((t) => (
+                      <tr key={t.id} className="hover:bg-surface-hover">
+                        <td className="px-3 py-2.5 border-b border-border text-[13px] font-mono">{t.symbol}</td>
+                        <td className="px-3 py-2.5 border-b border-border text-[13px]">
+                          <StatusBadge variant={t.side === 'buy' ? 'negative' : 'positive'}>
+                            {t.side === 'buy' ? '매수' : '매도'}
+                          </StatusBadge>
+                        </td>
+                        <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">{formatKRW(t.price)}</td>
+                        <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">
+                          {t.pnl != null ? (
+                            <span className={t.pnl >= 0 ? 'text-positive' : 'text-negative'}>{formatKRW(t.pnl)}</span>
+                          ) : '-'}
+                        </td>
+                        <td className="px-3 py-2.5 border-b border-border text-[13px] text-text-muted">{formatDateTime(t.executed_at)}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div className="mt-2 text-right">
+            <Link to={`/strategies/${id}/trades`} className="text-[13px] text-primary no-underline hover:underline">
+              거래 내역 더보기 &rarr;
+            </Link>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/Trades.tsx
+++ b/frontend/src/pages/Trades.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { useStrategyTradesPaginated } from '../hooks/useStrategies'
+import { PageSkeleton } from '../components/common/Skeleton'
+import StatusBadge from '../components/common/StatusBadge'
+import Pagination from '../components/common/Pagination'
+import { formatKRW, formatDateTime } from '../utils/formatters'
+
+const PAGE_SIZE = 15
+
+export default function Trades() {
+  const { id = '' } = useParams<{ id: string }>()
+  const [offset, setOffset] = useState(0)
+  const [sideFilter, setSideFilter] = useState<string>('')
+
+  const { data, isLoading } = useStrategyTradesPaginated(id, {
+    offset,
+    limit: PAGE_SIZE,
+    side: sideFilter || undefined,
+  })
+
+  if (isLoading && !data) return <PageSkeleton />
+
+  const trades = data?.items ?? []
+  const total = data?.total ?? 0
+
+  return (
+    <>
+      {/* 헤더 */}
+      <div className="flex items-center gap-3 mb-6">
+        <Link
+          to={`/strategies/${id}`}
+          className="text-[13px] text-text-muted no-underline hover:text-text"
+        >
+          &larr; 전략 상세
+        </Link>
+        <h2 className="text-[20px] font-bold">거래 내역</h2>
+      </div>
+
+      {/* 필터 바 */}
+      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+        <div className="flex items-center gap-4 flex-wrap">
+          <div>
+            <label className="text-[12px] text-text-muted block mb-1">매매</label>
+            <select
+              value={sideFilter}
+              onChange={(e) => {
+                setSideFilter(e.target.value)
+                setOffset(0)
+              }}
+              className="h-8 px-3 rounded-lg border border-border bg-bg text-[13px] text-text"
+            >
+              <option value="">전체</option>
+              <option value="buy">매수</option>
+              <option value="sell">매도</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {/* 거래 테이블 */}
+      <div className="bg-surface border border-border rounded-lg p-5">
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr>
+                <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">시각</th>
+                <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">종목</th>
+                <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">매매</th>
+                <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">수량</th>
+                <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">단가</th>
+                <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">금액</th>
+                <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">수수료</th>
+                <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">손익</th>
+              </tr>
+            </thead>
+            <tbody>
+              {trades.length === 0 ? (
+                <tr>
+                  <td colSpan={8} className="px-3 py-8 text-center text-text-muted text-[13px]">
+                    거래 내역이 없습니다
+                  </td>
+                </tr>
+              ) : (
+                trades.map((t) => {
+                  const amount = t.quantity * t.price
+                  const displayName = t.symbol_name
+                    ? `${t.symbol_name} (${t.symbol})`
+                    : t.symbol
+
+                  return (
+                    <tr key={t.id} className="hover:bg-surface-hover">
+                      <td className="px-3 py-2.5 border-b border-border text-[13px] font-mono">
+                        {formatDateTime(t.executed_at)}
+                      </td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px]">
+                        {displayName}
+                      </td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px]">
+                        <StatusBadge variant={t.side === 'buy' ? 'negative' : 'positive'}>
+                          {t.side === 'buy' ? '매수' : '매도'}
+                        </StatusBadge>
+                      </td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">
+                        {t.quantity.toLocaleString()}
+                      </td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">
+                        {formatKRW(t.price)}
+                      </td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">
+                        {formatKRW(amount)}
+                      </td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right text-text-muted">
+                        {t.commission != null ? formatKRW(t.commission) : '-'}
+                      </td>
+                      <td className="px-3 py-2.5 border-b border-border text-[13px] text-right">
+                        {t.pnl != null ? (
+                          <span className={t.pnl >= 0 ? 'text-positive' : 'text-negative'}>
+                            {formatKRW(t.pnl)}
+                          </span>
+                        ) : (
+                          <span className="text-text-muted">&mdash;</span>
+                        )}
+                      </td>
+                    </tr>
+                  )
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {total > PAGE_SIZE && (
+          <Pagination
+            total={total}
+            offset={offset}
+            limit={PAGE_SIZE}
+            onPageChange={setOffset}
+          />
+        )}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/pages/TreasuryHistory.tsx
+++ b/frontend/src/pages/TreasuryHistory.tsx
@@ -35,16 +35,16 @@ export default function TreasuryHistory() {
   return (
     <>
       {/* 필터 */}
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex gap-1">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="flex gap-1 bg-bg rounded-lg p-[3px]">
           {TYPE_TABS.map((tab) => (
             <button
               key={tab.value}
               onClick={() => handleTypeChange(tab.value)}
-              className={`px-3 py-1.5 rounded-lg text-[13px] font-medium border-none cursor-pointer transition-colors ${
+              className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer transition-colors ${
                 typeFilter === tab.value
-                  ? 'bg-primary text-white'
-                  : 'bg-transparent text-text-muted hover:bg-surface-hover hover:text-text'
+                  ? 'bg-surface text-text'
+                  : 'bg-transparent text-text-muted hover:text-text'
               }`}
             >
               {tab.label}
@@ -93,8 +93,8 @@ export default function TreasuryHistory() {
                           </StatusBadge>
                         </td>
                         <td className="px-3 py-3 border-b border-border text-[13px] font-mono">{tx.bot_id || '-'}</td>
-                        <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${tx.type === 'allocate' ? 'text-positive' : tx.type === 'deallocate' ? 'text-negative' : ''}`}>
-                          {tx.type === 'allocate' ? '+' : ''}{formatKRW(tx.amount)}
+                        <td className={`px-3 py-3 border-b border-border text-[13px] text-right ${tx.amount >= 0 ? 'text-positive' : 'text-negative'}`}>
+                          {tx.amount > 0 ? '+' : ''}{formatKRW(tx.amount)}
                         </td>
                         <td className="px-3 py-3 border-b border-border text-[13px] text-text-muted">{tx.description}</td>
                       </tr>

--- a/frontend/src/types/approval.ts
+++ b/frontend/src/types/approval.ts
@@ -1,5 +1,14 @@
 export type ApprovalStatus = 'pending' | 'approved' | 'rejected'
-export type ApprovalType = 'strategy_adopt' | 'budget_change' | 'bot_create' | 'bot_stop' | 'rule_change'
+export type ApprovalType =
+  | 'strategy_report'
+  | 'budget_allocate'
+  | 'live_switch'
+  | 'risk_alert'
+  | 'strategy_adopt'
+  | 'budget_change'
+  | 'bot_create'
+  | 'bot_stop'
+  | 'rule_change'
 
 export interface ApprovalReview {
   reviewer: string

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -10,6 +10,8 @@ export interface User {
   type: string
   org: string
   scopes: string[]
+  emoji: string
+  login_at: string
 }
 
 export interface LoginResponse {

--- a/frontend/src/types/strategy.ts
+++ b/frontend/src/types/strategy.ts
@@ -50,14 +50,24 @@ export interface MonthlySummary {
   win_rate: number
 }
 
+export interface WeeklySummary {
+  week_start: string
+  week_end: string
+  realized_pnl: number
+  trade_count: number
+  win_rate: number
+}
+
 export interface Trade {
   id: number
   strategy_id: number
   bot_id: string
   symbol: string
+  symbol_name?: string
   side: 'buy' | 'sell'
   quantity: number
   price: number
   executed_at: string
   pnl?: number
+  commission?: number
 }

--- a/frontend/src/types/strategy.ts
+++ b/frontend/src/types/strategy.ts
@@ -6,6 +6,7 @@ export interface Strategy {
   version: string
   status: StrategyStatus
   author?: string
+  author_id?: string
   bot_id?: string
   cumulative_return?: number
   created_at: string
@@ -13,7 +14,21 @@ export interface Strategy {
 
 export interface StrategyDetail extends Strategy {
   description?: string
-  params?: Record<string, unknown>
+  rationale?: string
+  risks?: string
+  params?: Record<string, StrategyParam | unknown>
+}
+
+export interface StrategyParam {
+  value: unknown
+  description?: string
+}
+
+export interface WeeklySummary {
+  week_label: string
+  realized_pnl: number
+  trade_count: number
+  win_rate: number
 }
 
 export interface StrategyPerformance {

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -13,9 +13,9 @@ export const BOT_STATUS_LABELS: Record<string, string> = {
 
 /** 전략 상태 라벨 */
 export const STRATEGY_STATUS_LABELS: Record<string, string> = {
-  registered: '등록됨',
-  active: '활성',
-  inactive: '비활성',
+  registered: '대기',
+  active: '운용중',
+  inactive: '중지',
   archived: '보관됨',
 }
 

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -1,10 +1,9 @@
-/** 원화 포맷 (예: 1,000,000원) */
+/** 원화 포맷 (예: 1,000,000 원) — 목업 기준 "숫자 원" 형식 */
 export function formatKRW(value: number): string {
-  return new Intl.NumberFormat('ko-KR', {
-    style: 'currency',
-    currency: 'KRW',
+  const formatted = new Intl.NumberFormat('ko-KR', {
     maximumFractionDigits: 0,
   }).format(value)
+  return `${formatted} 원`
 }
 
 /** 퍼센트 포맷 (예: +1.23%) */

--- a/src/ante/web/routes/auth.py
+++ b/src/ante/web/routes/auth.py
@@ -102,4 +102,5 @@ async def me(
         type=member.type,
         emoji=member.emoji,
         role=member.role,
+        login_at=session.get("created_at", ""),
     )

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -66,3 +66,4 @@ class MeResponse(BaseModel):
     type: str
     emoji: str = ""
     role: str = ""
+    login_at: str = ""


### PR DESCRIPTION
Closes #331

## Summary
프론트엔드 전체 페이지를 `docs/dashboard/mockups/` HTML 목업 기준으로 재점검하여 디자인 충실도를 높였습니다.

### 하위 이슈 (11건 완료)
- #332 레이아웃 (사이드바·헤더·본문) — PR #344
- #333 로그인 페이지 — PR #345
- #334 대시보드 페이지 — PR #348
- #335 결재함 (목록+상세 5종) — PR #347
- #336 자금관리 (메인+변동이력) — PR #352
- #337 전략과 성과 (목록+상세) — PR #351
- #338 봇 관리 (목록+상세+정지상세) — PR #353
- #339 백테스트 데이터 — PR #350
- #340 에이전트 관리 (목록+상세) — PR #349
- #341 성과 분석 (성과+리포트+거래내역) — PR #354
- #342 설정 — PR #346

### 주요 변경
- 41개 파일 변경, 2개 신규 페이지 추가 (Performance, Trades)
- 백엔드: `/api/auth/me` 응답에 `login_at` 필드 추가
- 프론트엔드: 색상, 간격, 레이아웃, 테이블 컬럼, 모달, 배지 등 목업 CSS와 정밀 일치

## Test plan
- [x] pytest 1587 passed, 3 skipped (에픽 브랜치 통합 후 전체 테스트)
- [x] ruff check / ruff format 통과
- [ ] 브라우저에서 각 페이지별 목업 HTML과 시각 비교 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)