### PR TITLE
epic/300: DataStore 스펙 정합성 + DataFeed 후속 과업 완료

### DIFF
--- a/src/ante/data/retention.py
+++ b/src/ante/data/retention.py
@@ -9,6 +9,23 @@ from ante.data.store import ParquetStore
 
 logger = logging.getLogger(__name__)
 
+# OHLCV 타임프레임 집합 — retention key가 여기 속하면 data_type="ohlcv"
+_OHLCV_TIMEFRAMES: frozenset[str] = frozenset({"1m", "5m", "15m", "1h", "1d"})
+
+
+def _resolve_data_type(key: str) -> tuple[str, str]:
+    """retention key를 (data_type, timeframe) 튜플로 변환.
+
+    Args:
+        key: retention 딕셔너리의 키 (예: "1m", "fundamental")
+
+    Returns:
+        (data_type, timeframe) — 예: ("ohlcv", "1m"), ("fundamental", "")
+    """
+    if key in _OHLCV_TIMEFRAMES:
+        return ("ohlcv", key)
+    return (key, "")
+
 
 class RetentionPolicy:
     """데이터 보존 정책 — 오래된 데이터 삭제로 용량 관리.
@@ -52,21 +69,24 @@ class RetentionPolicy:
 
         deleted: dict[str, int] = {}
 
-        for tf, max_days in self._retention.items():
+        for key, max_days in self._retention.items():
             # -1이면 무기한 보존 → 스킵
             if max_days < 0:
                 continue
 
+            data_type, timeframe = _resolve_data_type(key)
             count = 0
-            symbols = self._store.list_symbols(tf)
+            symbols = self._store.list_symbols(timeframe, data_type=data_type)
 
             for symbol in symbols:
-                date_range = self._store.get_date_range(symbol, tf)
+                date_range = self._store.get_date_range(
+                    symbol, timeframe, data_type=data_type
+                )
                 if not date_range:
                     continue
 
-                # Parquet 파일 순회
-                path = self._store.base_path / "ohlcv" / tf / symbol
+                # ParquetStore._resolve_path()로 경로 결정
+                path = self._store._resolve_path(symbol, timeframe, data_type)
                 if not path.exists():
                     continue
 
@@ -80,14 +100,16 @@ class RetentionPolicy:
                         age_days = (now - file_month_end).days
 
                         if age_days > max_days:
-                            if self._store.delete_file(symbol, tf, month_str):
+                            if self._store.delete_file(
+                                symbol, timeframe, month_str, data_type=data_type
+                            ):
                                 count += 1
                     except (ValueError, IndexError):
                         logger.warning("Invalid parquet filename: %s", parquet_file)
                         continue
 
             if count > 0:
-                deleted[tf] = count
-                logger.info("Retention: deleted %d files for timeframe %s", count, tf)
+                deleted[key] = count
+                logger.info("Retention: deleted %d files for %s", count, key)
 
         return deleted

--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -131,6 +131,334 @@ def config_check(ctx: click.Context, data_path: str) -> None:
         click.echo()
 
 
+# ── run 서브그룹 ──────────────────────────────────────────────────────────────
+
+
+@feed.group("run")
+def feed_run() -> None:
+    """수집을 1회 실행한다 (backfill / daily)."""
+
+
+def _build_orchestrator(  # noqa: ANN001, ANN201
+    cfg,  # FeedConfig
+):  # -> FeedOrchestrator
+    """FeedConfig의 API 키를 기반으로 FeedOrchestrator를 조립한다."""
+    from ante.feed.pipeline.orchestrator import FeedOrchestrator
+    from ante.feed.sources.dart import DARTSource
+    from ante.feed.sources.data_go_kr import DataGoKrSource
+
+    api_keys = cfg.load_api_keys()
+
+    data_go_kr_source = None
+    dart_source = None
+
+    datagokr_key = api_keys.get("ANTE_DATAGOKR_API_KEY")
+    if datagokr_key:
+        data_go_kr_source = DataGoKrSource(api_key=datagokr_key)
+
+    dart_key = api_keys.get("ANTE_DART_API_KEY")
+    if dart_key:
+        dart_source = DARTSource(api_key=dart_key)
+
+    return FeedOrchestrator(
+        data_go_kr_source=data_go_kr_source,
+        dart_source=dart_source,
+    )
+
+
+def _ensure_initialized(  # noqa: ANN001, ANN201
+    cfg,  # FeedConfig
+    fmt,  # OutputFormatter
+    data_path: str,
+) -> bool:
+    """초기화 상태를 확인하고 미초기화 시 에러를 출력한다."""
+    if not cfg.is_initialized():
+        fmt.error(
+            f"DataFeed가 초기화되지 않았습니다. 먼저 실행: ante feed init {data_path}",
+            "NOT_INITIALIZED",
+        )
+        return False
+    return True
+
+
+@feed_run.command("backfill")
+@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option(
+    "--since", default=None, help="수집 시작일 (YYYY-MM-DD, config 기본값 오버라이드)"
+)
+@click.option("--until", default=None, help="수집 종료일 (YYYY-MM-DD, 기본값: 오늘)")
+@click.pass_context
+@require_auth
+@require_scope("data:write")
+def run_backfill(
+    ctx: click.Context,
+    data_path: str,
+    since: str | None,
+    until: str | None,
+) -> None:
+    """과거 데이터를 1회 수집한다 (backfill)."""
+    import asyncio
+    from pathlib import Path
+
+    from ante.feed.config import FeedConfig
+
+    fmt = get_formatter(ctx)
+    cfg = FeedConfig(data_path)
+
+    if not _ensure_initialized(cfg, fmt, data_path):
+        raise SystemExit(1)
+
+    config = cfg.load_config()
+
+    # CLI 옵션으로 schedule 오버라이드
+    if since is not None:
+        config.setdefault("schedule", {})["backfill_since"] = since  # type: ignore[union-attr]
+
+    orchestrator = _build_orchestrator(cfg)
+
+    result = asyncio.run(
+        orchestrator.run_backfill(
+            data_path=Path(data_path),
+            config=config,
+        )
+    )
+
+    if fmt.is_json:
+        fmt.output(
+            {
+                "mode": result.mode,
+                "symbols_total": result.symbols_total,
+                "symbols_success": result.symbols_success,
+                "symbols_failed": result.symbols_failed,
+                "rows_written": result.rows_written,
+                "data_types": result.data_types,
+                "duration_seconds": result.duration_seconds,
+                "config_errors": result.config_errors,
+            }
+        )
+    else:
+        click.echo()
+        click.echo(
+            f"Backfill 완료: {result.symbols_success}/{result.symbols_total} 종목 성공"
+        )
+        click.echo(f"  기록: {result.rows_written} rows")
+        click.echo(f"  데이터: {', '.join(result.data_types) or '없음'}")
+        click.echo(f"  소요: {result.duration_seconds:.1f}초")
+        if result.config_errors:
+            click.echo()
+            for err in result.config_errors:
+                click.echo(f"  [경고] {err.get('error', err)}")
+        click.echo()
+
+
+@feed_run.command("daily")
+@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option(
+    "--date", "target_date", default=None, help="수집 대상일 (YYYY-MM-DD, 기본값: 어제)"
+)
+@click.pass_context
+@require_auth
+@require_scope("data:write")
+def run_daily(
+    ctx: click.Context,
+    data_path: str,
+    target_date: str | None,
+) -> None:
+    """어제(또는 지정일) 데이터를 1회 수집한다 (daily)."""
+    import asyncio
+    from pathlib import Path
+
+    from ante.feed.config import FeedConfig
+
+    fmt = get_formatter(ctx)
+    cfg = FeedConfig(data_path)
+
+    if not _ensure_initialized(cfg, fmt, data_path):
+        raise SystemExit(1)
+
+    config = cfg.load_config()
+
+    orchestrator = _build_orchestrator(cfg)
+
+    # --date 옵션이 있으면 generate_daily_date를 패치
+    if target_date is not None:
+        import ante.feed.pipeline.scheduler as _sched
+
+        _original_generate = _sched.generate_daily_date
+
+        def _override(reference: object = None) -> str:
+            return target_date  # type: ignore[return-value]
+
+        _sched.generate_daily_date = _override  # type: ignore[assignment]
+        try:
+            result = asyncio.run(
+                orchestrator.run_daily(
+                    data_path=Path(data_path),
+                    config=config,
+                )
+            )
+        finally:
+            _sched.generate_daily_date = _original_generate
+    else:
+        result = asyncio.run(
+            orchestrator.run_daily(
+                data_path=Path(data_path),
+                config=config,
+            )
+        )
+
+    if fmt.is_json:
+        fmt.output(
+            {
+                "mode": result.mode,
+                "target_date": result.target_date,
+                "symbols_total": result.symbols_total,
+                "symbols_success": result.symbols_success,
+                "symbols_failed": result.symbols_failed,
+                "rows_written": result.rows_written,
+                "data_types": result.data_types,
+                "duration_seconds": result.duration_seconds,
+                "config_errors": result.config_errors,
+            }
+        )
+    else:
+        click.echo()
+        click.echo(
+            f"Daily 수집 완료 ({result.target_date}): "
+            f"{result.symbols_success}/{result.symbols_total} 종목 성공"
+        )
+        click.echo(f"  기록: {result.rows_written} rows")
+        click.echo(f"  데이터: {', '.join(result.data_types) or '없음'}")
+        click.echo(f"  소요: {result.duration_seconds:.1f}초")
+        if result.config_errors:
+            click.echo()
+            for err in result.config_errors:
+                click.echo(f"  [경고] {err.get('error', err)}")
+        click.echo()
+
+
+# ── start (상주 스케줄러) ─────────────────────────────────────────────────────
+
+
+@feed.command("start")
+@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.pass_context
+@require_auth
+@require_scope("data:write")
+def feed_start(ctx: click.Context, data_path: str) -> None:
+    """내장 스케줄러로 backfill/daily를 자동 실행하는 상주 프로세스를 시작한다."""
+    import asyncio
+    import signal
+    from datetime import datetime, timedelta, timezone
+    from pathlib import Path
+
+    from ante.feed.config import FeedConfig
+
+    fmt = get_formatter(ctx)
+    cfg = FeedConfig(data_path)
+
+    if not _ensure_initialized(cfg, fmt, data_path):
+        raise SystemExit(1)
+
+    config = cfg.load_config()
+    schedule = config.get("schedule", {})
+    daily_at = (
+        schedule.get("daily_at", "16:00") if isinstance(schedule, dict) else "16:00"
+    )
+    backfill_at = (
+        schedule.get("backfill_at", "01:00") if isinstance(schedule, dict) else "01:00"
+    )
+
+    orchestrator = _build_orchestrator(cfg)
+
+    kst = timezone(timedelta(hours=9))
+
+    async def _scheduler_loop() -> None:
+        """스케줄 루프: daily_at / backfill_at 시각에 수집 실행."""
+        stop_event = asyncio.Event()
+        loop = asyncio.get_running_loop()
+
+        def _handle_signal() -> None:
+            logger.info("종료 시그널 수신, 스케줄러 중지...")
+            stop_event.set()
+
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            loop.add_signal_handler(sig, _handle_signal)
+
+        logger.info(
+            "DataFeed 스케줄러 시작 (daily_at=%s, backfill_at=%s)",
+            daily_at,
+            backfill_at,
+        )
+        click.echo(
+            f"DataFeed 스케줄러 시작 (daily_at={daily_at}, backfill_at={backfill_at})"
+        )
+        click.echo("종료하려면 Ctrl+C 또는 SIGTERM을 보내세요.")
+
+        daily_ran_today = False
+        backfill_ran_today = False
+        last_date = ""
+
+        while not stop_event.is_set():
+            now = datetime.now(tz=kst)
+            current_time = now.strftime("%H:%M")
+            current_date_str = now.strftime("%Y-%m-%d")
+
+            # 날짜가 바뀌면 플래그 초기화
+            if last_date and last_date != current_date_str:
+                daily_ran_today = False
+                backfill_ran_today = False
+            last_date = current_date_str
+
+            # daily 실행
+            if not daily_ran_today and current_time >= str(daily_at):
+                logger.info("Daily 수집 시작 (%s)", current_date_str)
+                try:
+                    result = await orchestrator.run_daily(
+                        data_path=Path(data_path),
+                        config=config,
+                    )
+                    click.echo(
+                        f"[{current_date_str}] Daily 완료: "
+                        f"{result.symbols_success}/{result.symbols_total} 종목, "
+                        f"{result.rows_written} rows"
+                    )
+                except Exception as exc:
+                    logger.error("Daily 수집 실패: %s", exc)
+                daily_ran_today = True
+
+            # backfill 실행
+            if not backfill_ran_today and current_time >= str(backfill_at):
+                logger.info("Backfill 수집 시작 (%s)", current_date_str)
+                try:
+                    result = await orchestrator.run_backfill(
+                        data_path=Path(data_path),
+                        config=config,
+                    )
+                    click.echo(
+                        f"[{current_date_str}] Backfill 완료: "
+                        f"{result.symbols_success}/{result.symbols_total} 종목, "
+                        f"{result.rows_written} rows"
+                    )
+                except Exception as exc:
+                    logger.error("Backfill 수집 실패: %s", exc)
+                backfill_ran_today = True
+
+            # 60초 대기 (stop_event 감시)
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=60.0)
+            except TimeoutError:
+                pass
+
+        logger.info("DataFeed 스케줄러 종료")
+        click.echo("DataFeed 스케줄러 종료")
+
+    try:
+        asyncio.run(_scheduler_loop())
+    except KeyboardInterrupt:
+        click.echo("\nDataFeed 스케줄러 종료")
+
+
 # ── init ─────────────────────────────────────────────────────────────────────
 
 

--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import logging
+import pathlib
+from typing import TYPE_CHECKING
 
 import click
 
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
+
+if TYPE_CHECKING:
+    from ante.feed.report.generator import ReportGenerator
 
 logger = logging.getLogger(__name__)
 
@@ -167,7 +172,9 @@ def feed_init(ctx: click.Context, data_path: str) -> None:
 @require_scope("data:read")
 def feed_status(ctx: click.Context, data_path: str) -> None:
     """수집 상태를 조회한다."""
+
     from ante.feed.config import FeedConfig
+    from ante.feed.report.generator import ReportGenerator
 
     fmt = get_formatter(ctx)
     cfg = FeedConfig(data_path)
@@ -180,11 +187,118 @@ def feed_status(ctx: click.Context, data_path: str) -> None:
             click.echo(f"초기화: ante feed init {data_path}")
         return
 
+    # 1. 체크포인트 로드
+    checkpoints = _load_checkpoints(cfg.feed_dir)
+
+    # 2. 최근 리포트 1건 로드
+    report_gen = ReportGenerator(cfg.feed_dir)
+    latest_report = _load_latest_report(report_gen)
+
+    # 3. API 키 상태 확인
+    api_keys = cfg.check_api_keys()
+
     if fmt.is_json:
-        fmt.output({"initialized": True, "feed_dir": str(cfg.feed_dir)})
+        fmt.output(
+            {
+                "initialized": True,
+                "feed_dir": str(cfg.feed_dir),
+                "checkpoints": checkpoints,
+                "latest_report": latest_report,
+                "api_keys": api_keys,
+            }
+        )
     else:
-        click.echo(f"DataFeed 초기화됨: {cfg.feed_dir}")
-        click.echo("(상세 상태 조회는 Phase 2에서 구현 예정)")
+        click.echo()
+        click.echo(f"DataFeed Status ({cfg.feed_dir})")
+        click.echo("══════════════════════════════════════════════════")
+
+        # 체크포인트 섹션
+        click.echo()
+        click.echo("Checkpoints")
+        click.echo("──────────────────────────────────────────────────")
+        if checkpoints:
+            for cp in checkpoints:
+                click.echo(
+                    f"  {cp['source']}/{cp['data_type']:<16}"
+                    f" last_date: {cp['last_date']}"
+                    f"  (updated: {cp['updated_at']})"
+                )
+        else:
+            click.echo("  (체크포인트 없음 — 아직 수집을 실행하지 않았습니다)")
+
+        # 최근 리포트 섹션
+        click.echo()
+        click.echo("Latest Report")
+        click.echo("──────────────────────────────────────────────────")
+        if latest_report:
+            summary = latest_report.get("summary", {})
+            click.echo(f"  mode: {latest_report.get('mode', '?')}")
+            click.echo(f"  date: {latest_report.get('target_date', '?')}")
+            click.echo(
+                f"  result: {summary.get('symbols_success', 0)} success"
+                f" / {summary.get('symbols_failed', 0)} failed"
+                f" / {len(latest_report.get('warnings', []))} warnings"
+            )
+            click.echo(f"  rows: {summary.get('rows_written', 0)}")
+        else:
+            click.echo("  (리포트 없음 — 아직 수집을 실행하지 않았습니다)")
+
+        # API 키 섹션
+        click.echo()
+        click.echo("API Keys")
+        click.echo("──────────────────────────────────────────────────")
+        for entry in api_keys:
+            if entry["set"]:
+                source_info = f"(source: {entry['source']})"
+                click.echo(f"  {entry['key']:<30} ✓ 설정됨 {source_info}")
+            else:
+                click.echo(f"  {entry['key']:<30} ✗ 미설정")
+
+        click.echo()
+
+
+def _load_checkpoints(feed_dir: pathlib.Path) -> list[dict[str, str]]:
+    """체크포인트 디렉토리에서 모든 체크포인트를 로드한다."""
+    import json
+
+    from ante.feed.pipeline.checkpoint import CHECKPOINT_DIR
+
+    checkpoint_dir = feed_dir / CHECKPOINT_DIR
+    if not checkpoint_dir.exists():
+        return []
+
+    results: list[dict[str, str]] = []
+    for cp_file in sorted(checkpoint_dir.glob("*.json")):
+        try:
+            data: dict[str, str] = json.loads(cp_file.read_text(encoding="utf-8"))
+            results.append(
+                {
+                    "source": data.get("source", "?"),
+                    "data_type": data.get("data_type", "?"),
+                    "last_date": data.get("last_date", "?"),
+                    "updated_at": data.get("updated_at", "?"),
+                }
+            )
+        except (json.JSONDecodeError, OSError):
+            logger.warning("체크포인트 파일 읽기 실패: %s", cp_file)
+    return results
+
+
+def _load_latest_report(
+    report_gen: ReportGenerator,
+) -> dict | None:
+    """최근 리포트 1건을 로드한다."""
+    import json
+
+    reports = report_gen.list_reports(limit=1)
+    if not reports:
+        return None
+
+    try:
+        return json.loads(reports[0].read_text(encoding="utf-8"))  # type: ignore[no-any-return]
+    except (json.JSONDecodeError, OSError):
+        logger.warning("리포트 파일 읽기 실패: %s", reports[0])
+        return None
 
 
 # ── inject ───────────────────────────────────────────────────────────────────

--- a/src/ante/feed/config.py
+++ b/src/ante/feed/config.py
@@ -69,6 +69,19 @@ class FeedConfig:
         """DataFeed가 초기화되어 있는지 확인한다."""
         return self.config_path.exists()
 
+    def load_config(self) -> dict[str, object]:
+        """config.toml을 읽어 딕셔너리로 반환한다.
+
+        Returns:
+            설정 딕셔너리. 파일이 없으면 빈 딕셔너리.
+        """
+        import tomllib
+
+        if not self.config_path.exists():
+            return {}
+        with self.config_path.open("rb") as f:
+            return tomllib.load(f)
+
     def init(self) -> list[str]:
         """피드 디렉토리를 초기화한다. 생성된 경로 목록을 반환한다."""
         created = []

--- a/tests/unit/feed/test_cli_run.py
+++ b/tests/unit/feed/test_cli_run.py
@@ -1,0 +1,417 @@
+"""ante feed run/start CLI 커맨드 테스트.
+
+mock orchestrator로 CLI invocation을 검증한다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.feed.models.result import CollectionResult
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+_EMPTY_RESULT = CollectionResult(
+    mode="backfill",
+    started_at="2026-03-18T00:00:00Z",
+    finished_at="2026-03-18T00:00:01Z",
+    duration_seconds=1.0,
+    symbols_total=0,
+    symbols_success=0,
+    symbols_failed=0,
+    rows_written=0,
+    data_types=[],
+    failures=[],
+    warnings=[],
+    config_errors=[],
+)
+
+_DAILY_RESULT = CollectionResult(
+    mode="daily",
+    started_at="2026-03-18T00:00:00Z",
+    finished_at="2026-03-18T00:00:02Z",
+    duration_seconds=2.0,
+    target_date="2026-03-17",
+    symbols_total=100,
+    symbols_success=98,
+    symbols_failed=2,
+    rows_written=500,
+    data_types=["ohlcv", "fundamental"],
+    failures=[],
+    warnings=[],
+    config_errors=[],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """인증된 상태의 CliRunner."""
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # type: ignore[no-untyped-def]
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx: object) -> None:
+                import click
+
+                ctx = click.get_current_context()
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+@pytest.fixture
+def initialized_data_path(tmp_path: Path) -> str:
+    """초기화된 데이터 디렉토리 경로."""
+    data_dir = tmp_path / "data"
+    feed_dir = data_dir / ".feed"
+    feed_dir.mkdir(parents=True)
+
+    # config.toml 생성
+    config_toml = feed_dir / "config.toml"
+    config_toml.write_text(
+        "[schedule]\n"
+        'daily_at = "16:00"\n'
+        'backfill_at = "01:00"\n'
+        'backfill_since = "2024-01-01"\n'
+        "\n"
+        "[guard]\n"
+        "blocked_days = []\n"
+        'blocked_hours = ["09:00-15:30"]\n'
+        "pause_during_trading = true\n"
+    )
+
+    # checkpoints, reports 디렉토리 생성
+    (feed_dir / "checkpoints").mkdir()
+    (feed_dir / "reports").mkdir()
+
+    return str(data_dir)
+
+
+@pytest.fixture
+def uninitialized_data_path(tmp_path: Path) -> str:
+    """초기화되지 않은 데이터 디렉토리 경로."""
+    return str(tmp_path / "data")
+
+
+# ── ante feed run backfill ───────────────────────────────────────────────
+
+
+class TestRunBackfill:
+    def test_exit_code_zero(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """backfill이 정상 실행되면 exit code 0."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                ["feed", "run", "backfill", "--data-path", initialized_data_path],
+                catch_exceptions=False,
+            )
+            assert result.exit_code == 0
+
+    def test_calls_orchestrator_run_backfill(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """FeedOrchestrator.run_backfill이 호출된다."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_RESULT)
+            mock_build.return_value = mock_orch
+
+            runner.invoke(
+                cli,
+                ["feed", "run", "backfill", "--data-path", initialized_data_path],
+                catch_exceptions=False,
+            )
+
+            mock_orch.run_backfill.assert_awaited_once()
+
+    def test_output_contains_result_summary(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """출력에 결과 요약이 포함된다."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                ["feed", "run", "backfill", "--data-path", initialized_data_path],
+                catch_exceptions=False,
+            )
+
+            assert "Backfill" in result.output
+
+    def test_since_option_overrides_config(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """--since 옵션이 config의 backfill_since를 오버라이드한다."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_RESULT)
+            mock_build.return_value = mock_orch
+
+            runner.invoke(
+                cli,
+                [
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                    "--since",
+                    "2020-01-01",
+                ],
+                catch_exceptions=False,
+            )
+
+            call_args = mock_orch.run_backfill.call_args
+            config = call_args.kwargs["config"]
+            assert config["schedule"]["backfill_since"] == "2020-01-01"
+
+    def test_not_initialized_error(
+        self, runner: CliRunner, uninitialized_data_path: str
+    ) -> None:
+        """초기화되지 않은 상태에서 실행하면 에러."""
+        result = runner.invoke(
+            cli,
+            ["feed", "run", "backfill", "--data-path", uninitialized_data_path],
+        )
+        assert result.exit_code != 0
+
+    def test_json_output(self, runner: CliRunner, initialized_data_path: str) -> None:
+        """--format json 출력이 올바르다."""
+        import json
+
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                ],
+                catch_exceptions=False,
+            )
+
+            data = json.loads(result.output)
+            assert data["mode"] == "backfill"
+            assert "rows_written" in data
+
+
+# ── ante feed run daily ──────────────────────────────────────────────────
+
+
+class TestRunDaily:
+    def test_exit_code_zero(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """daily가 정상 실행되면 exit code 0."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_daily = AsyncMock(return_value=_DAILY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                ["feed", "run", "daily", "--data-path", initialized_data_path],
+                catch_exceptions=False,
+            )
+            assert result.exit_code == 0
+
+    def test_calls_orchestrator_run_daily(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """FeedOrchestrator.run_daily가 호출된다."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_daily = AsyncMock(return_value=_DAILY_RESULT)
+            mock_build.return_value = mock_orch
+
+            runner.invoke(
+                cli,
+                ["feed", "run", "daily", "--data-path", initialized_data_path],
+                catch_exceptions=False,
+            )
+
+            mock_orch.run_daily.assert_awaited_once()
+
+    def test_output_contains_daily_summary(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """출력에 Daily 수집 결과가 포함된다."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_daily = AsyncMock(return_value=_DAILY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                ["feed", "run", "daily", "--data-path", initialized_data_path],
+                catch_exceptions=False,
+            )
+
+            assert "Daily" in result.output
+            assert "98/100" in result.output
+
+    def test_date_option(self, runner: CliRunner, initialized_data_path: str) -> None:
+        """--date 옵션으로 수집 대상일을 지정할 수 있다."""
+        custom_result = CollectionResult(
+            mode="daily",
+            started_at="2026-03-18T00:00:00Z",
+            finished_at="2026-03-18T00:00:01Z",
+            duration_seconds=1.0,
+            target_date="2026-01-15",
+        )
+
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_daily = AsyncMock(return_value=custom_result)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "feed",
+                    "run",
+                    "daily",
+                    "--data-path",
+                    initialized_data_path,
+                    "--date",
+                    "2026-01-15",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 0
+
+    def test_not_initialized_error(
+        self, runner: CliRunner, uninitialized_data_path: str
+    ) -> None:
+        """초기화되지 않은 상태에서 실행하면 에러."""
+        result = runner.invoke(
+            cli,
+            ["feed", "run", "daily", "--data-path", uninitialized_data_path],
+        )
+        assert result.exit_code != 0
+
+    def test_json_output(self, runner: CliRunner, initialized_data_path: str) -> None:
+        """--format json 출력이 올바르다."""
+        import json
+
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_daily = AsyncMock(return_value=_DAILY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "feed",
+                    "run",
+                    "daily",
+                    "--data-path",
+                    initialized_data_path,
+                ],
+                catch_exceptions=False,
+            )
+
+            data = json.loads(result.output)
+            assert data["mode"] == "daily"
+            assert data["target_date"] == "2026-03-17"
+            assert data["symbols_success"] == 98
+
+
+# ── ante feed start ──────────────────────────────────────────────────────
+
+
+class TestFeedStart:
+    def test_not_initialized_error(
+        self, runner: CliRunner, uninitialized_data_path: str
+    ) -> None:
+        """초기화되지 않은 상태에서 실행하면 에러."""
+        result = runner.invoke(
+            cli,
+            ["feed", "start", "--data-path", uninitialized_data_path],
+        )
+        assert result.exit_code != 0
+
+    def test_help_shows_description(self, runner: CliRunner) -> None:
+        """--help에 상주 프로세스 설명이 포함된다."""
+        result = runner.invoke(
+            cli,
+            ["feed", "start", "--help"],
+        )
+        assert result.exit_code == 0
+        assert "스케줄러" in result.output
+
+
+# ── ante feed run --help ─────────────────────────────────────────────────
+
+
+class TestRunHelp:
+    def test_run_group_help(self, runner: CliRunner) -> None:
+        """feed run --help에 backfill/daily 서브커맨드가 표시된다."""
+        result = runner.invoke(
+            cli,
+            ["feed", "run", "--help"],
+        )
+        assert result.exit_code == 0
+        assert "backfill" in result.output
+        assert "daily" in result.output
+
+    def test_backfill_help(self, runner: CliRunner) -> None:
+        """feed run backfill --help에 옵션이 표시된다."""
+        result = runner.invoke(
+            cli,
+            ["feed", "run", "backfill", "--help"],
+        )
+        assert result.exit_code == 0
+        assert "--since" in result.output
+        assert "--data-path" in result.output
+
+    def test_daily_help(self, runner: CliRunner) -> None:
+        """feed run daily --help에 옵션이 표시된다."""
+        result = runner.invoke(
+            cli,
+            ["feed", "run", "daily", "--help"],
+        )
+        assert result.exit_code == 0
+        assert "--date" in result.output
+        assert "--data-path" in result.output

--- a/tests/unit/feed/test_cli_status.py
+++ b/tests/unit/feed/test_cli_status.py
@@ -1,0 +1,263 @@
+"""ante feed status CLI 커맨드 테스트."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """인증된 상태의 CliRunner."""
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # type: ignore[no-untyped-def]
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx: object) -> None:
+                import click
+
+                ctx = click.get_current_context()
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+@pytest.fixture
+def data_path(tmp_path: Path) -> str:
+    """임시 데이터 디렉토리 경로 (문자열)."""
+    return str(tmp_path / "data")
+
+
+def _init_feed(data_path: str) -> None:
+    """피드 디렉토리를 초기화한다."""
+    from ante.feed.config import FeedConfig
+
+    cfg = FeedConfig(data_path)
+    cfg.init()
+
+
+def _invoke_status(runner: CliRunner, data_path: str, fmt: str = "text") -> object:
+    """feed status 커맨드를 실행한다."""
+    args = ["feed", "status", "--data-path", data_path]
+    if fmt == "json":
+        args = ["--format", "json"] + args
+    return runner.invoke(cli, args, catch_exceptions=False)
+
+
+class TestFeedStatusNotInitialized:
+    """초기화되지 않은 상태에서의 feed status."""
+
+    def test_shows_not_initialized(self, runner: CliRunner, data_path: str) -> None:
+        result = _invoke_status(runner, data_path)
+        assert "초기화되지 않았습니다" in result.output
+
+    def test_shows_init_command(self, runner: CliRunner, data_path: str) -> None:
+        result = _invoke_status(runner, data_path)
+        assert "ante feed init" in result.output
+
+    def test_json_not_initialized(self, runner: CliRunner, data_path: str) -> None:
+        result = _invoke_status(runner, data_path, fmt="json")
+        data = json.loads(result.output)
+        assert data["initialized"] is False
+
+
+class TestFeedStatusInitialized:
+    """초기화된 상태에서의 feed status (체크포인트/리포트 없음)."""
+
+    def test_shows_empty_checkpoints(self, runner: CliRunner, data_path: str) -> None:
+        _init_feed(data_path)
+        result = _invoke_status(runner, data_path)
+        assert "체크포인트 없음" in result.output
+
+    def test_shows_empty_reports(self, runner: CliRunner, data_path: str) -> None:
+        _init_feed(data_path)
+        result = _invoke_status(runner, data_path)
+        assert "리포트 없음" in result.output
+
+    def test_shows_api_keys_section(self, runner: CliRunner, data_path: str) -> None:
+        _init_feed(data_path)
+        result = _invoke_status(runner, data_path)
+        assert "API Keys" in result.output
+        assert "ANTE_DATAGOKR_API_KEY" in result.output
+        assert "ANTE_DART_API_KEY" in result.output
+
+    def test_shows_unset_api_keys(self, runner: CliRunner, data_path: str) -> None:
+        _init_feed(data_path)
+        result = _invoke_status(runner, data_path)
+        assert "미설정" in result.output
+
+    def test_exit_code_zero(self, runner: CliRunner, data_path: str) -> None:
+        _init_feed(data_path)
+        result = _invoke_status(runner, data_path)
+        assert result.exit_code == 0
+
+
+class TestFeedStatusWithCheckpoints:
+    """체크포인트가 있는 상태에서의 feed status."""
+
+    def test_shows_checkpoint_info(self, runner: CliRunner, data_path: str) -> None:
+        _init_feed(data_path)
+        _create_checkpoint(data_path, "data_go_kr", "ohlcv", "2026-03-15")
+        result = _invoke_status(runner, data_path)
+        assert "data_go_kr" in result.output
+        assert "ohlcv" in result.output
+        assert "2026-03-15" in result.output
+
+    def test_shows_multiple_checkpoints(
+        self, runner: CliRunner, data_path: str
+    ) -> None:
+        _init_feed(data_path)
+        _create_checkpoint(data_path, "data_go_kr", "ohlcv", "2026-03-15")
+        _create_checkpoint(data_path, "dart", "fundamental", "2026-03-10")
+        result = _invoke_status(runner, data_path)
+        assert "data_go_kr" in result.output
+        assert "dart" in result.output
+
+    def test_json_contains_checkpoints(self, runner: CliRunner, data_path: str) -> None:
+        _init_feed(data_path)
+        _create_checkpoint(data_path, "data_go_kr", "ohlcv", "2026-03-15")
+        result = _invoke_status(runner, data_path, fmt="json")
+        data = json.loads(result.output)
+        assert data["initialized"] is True
+        assert len(data["checkpoints"]) == 1
+        assert data["checkpoints"][0]["source"] == "data_go_kr"
+        assert data["checkpoints"][0]["last_date"] == "2026-03-15"
+
+
+class TestFeedStatusWithReport:
+    """리포트가 있는 상태에서의 feed status."""
+
+    def test_shows_report_summary(self, runner: CliRunner, data_path: str) -> None:
+        _init_feed(data_path)
+        _create_report(data_path, mode="daily", target_date="2026-03-16")
+        result = _invoke_status(runner, data_path)
+        assert "daily" in result.output
+        assert "2026-03-16" in result.output
+        assert "success" in result.output
+
+    def test_shows_report_failure_count(
+        self, runner: CliRunner, data_path: str
+    ) -> None:
+        _init_feed(data_path)
+        _create_report(
+            data_path, mode="daily", target_date="2026-03-16", failed=2, warnings=3
+        )
+        result = _invoke_status(runner, data_path)
+        assert "2 failed" in result.output
+        assert "3 warnings" in result.output
+
+    def test_json_contains_report(self, runner: CliRunner, data_path: str) -> None:
+        _init_feed(data_path)
+        _create_report(data_path, mode="daily", target_date="2026-03-16")
+        result = _invoke_status(runner, data_path, fmt="json")
+        data = json.loads(result.output)
+        assert data["latest_report"] is not None
+        assert data["latest_report"]["mode"] == "daily"
+        assert data["latest_report"]["summary"]["symbols_success"] == 2485
+
+
+class TestFeedStatusApiKeys:
+    """API 키 상태 표시."""
+
+    def test_shows_set_api_key(self, runner: CliRunner, data_path: str) -> None:
+        _init_feed(data_path)
+        from ante.feed.config import FeedConfig
+
+        cfg = FeedConfig(data_path)
+        cfg.set_api_key("ANTE_DATAGOKR_API_KEY", "test_key_value_123")
+        result = _invoke_status(runner, data_path)
+        assert "설정됨" in result.output
+
+    def test_json_api_keys(self, runner: CliRunner, data_path: str) -> None:
+        _init_feed(data_path)
+        result = _invoke_status(runner, data_path, fmt="json")
+        data = json.loads(result.output)
+        assert len(data["api_keys"]) == 2
+        for key_info in data["api_keys"]:
+            assert "key" in key_info
+            assert "set" in key_info
+
+
+# ── 헬퍼 ────────────────────────────────────────────────────────────────────
+
+
+def _create_checkpoint(
+    data_path: str, source: str, data_type: str, last_date: str
+) -> None:
+    """테스트용 체크포인트 파일을 생성한다."""
+    cp_dir = Path(data_path) / ".feed" / "checkpoints"
+    cp_dir.mkdir(parents=True, exist_ok=True)
+    cp_file = cp_dir / f"{source}_{data_type}.json"
+    cp_file.write_text(
+        json.dumps(
+            {
+                "source": source,
+                "data_type": data_type,
+                "last_date": last_date,
+                "updated_at": "2026-03-17T01:23:45Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _create_report(
+    data_path: str,
+    *,
+    mode: str = "daily",
+    target_date: str = "2026-03-16",
+    success: int = 2485,
+    failed: int = 0,
+    warnings: int = 0,
+) -> None:
+    """테스트용 리포트 파일을 생성한다."""
+    reports_dir = Path(data_path) / ".feed" / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    report = {
+        "mode": mode,
+        "started_at": f"{target_date}T16:00:12Z",
+        "finished_at": f"{target_date}T16:05:34Z",
+        "duration_seconds": 322,
+        "target_date": target_date,
+        "summary": {
+            "symbols_total": success + failed,
+            "symbols_success": success,
+            "symbols_failed": failed,
+            "rows_written": success,
+            "data_types": ["ohlcv", "fundamental"],
+        },
+        "failures": [{"symbol": f"00{i:04d}", "reason": "test"} for i in range(failed)],
+        "warnings": [
+            {"symbol": f"00{i:04d}", "message": "test warning"} for i in range(warnings)
+        ],
+        "config_errors": [],
+    }
+    filename = f"{target_date}-{mode}.json"
+    (reports_dir / filename).write_text(
+        json.dumps(report, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -800,6 +800,36 @@ class TestRetentionPolicy:
         deleted = await policy.enforce()
         assert deleted == {}
 
+    async def test_enforce_fundamental_path_resolution(self, store, data_dir):
+        """fundamental data_type이 _resolve_path 경로를 사용하여 삭제."""
+        from datetime import date
+
+        df = pl.DataFrame(
+            {
+                "date": [date(2024, 1, 15), date(2024, 2, 15)],
+                "symbol": ["005930", "005930"],
+                "market_cap": [300000000000000, 305000000000000],
+                "source": ["dart", "dart"],
+            }
+        )
+        await store.write("005930", "", df, data_type="fundamental")
+
+        # fundamental/krx/005930/ 경로에 파일이 생성되었는지 확인
+        fundamental_path = data_dir / "fundamental" / "krx" / "005930"
+        assert fundamental_path.exists()
+        assert len(list(fundamental_path.glob("*.parquet"))) == 2
+
+        # fundamental 보존 기간을 0일로 설정 → 오래된 데이터 삭제 대상
+        policy = RetentionPolicy(store, retention_days={"fundamental": 0})
+        now = datetime(2026, 6, 1, tzinfo=UTC)
+        deleted = await policy.enforce(now=now)
+
+        assert "fundamental" in deleted
+        assert deleted["fundamental"] == 2
+
+        result = await store.read("005930", "", data_type="fundamental")
+        assert result.is_empty()
+
 
 # ── DARTNormalizer 테스트 ─────────────────────────────
 


### PR DESCRIPTION
## Summary
에픽 #300의 미완료 후속 과업 3건을 구현하여 에픽을 완성한다.

- **#328** RetentionPolicy.enforce()에서 _resolve_path() 활용 (리팩터링)
- **#329** `ante feed run backfill/daily`, `ante feed start` CLI 커맨드 구현
- **#330** `ante feed status` 상세 구현 (체크포인트, 리포트, API 키 상태)

## 검증
- unit 테스트 1614건 통과 (신규 34건 포함)
- ruff check + format 통과

Closes #300