### PR TITLE
fix(dashboard): 사이드바 목업 충실도 미세 조정

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -9,7 +9,7 @@ const NAV_ITEMS = [
   { path: '/strategies', icon: '📈', label: '전략과 성과' },
   { path: '/bots', icon: '🤖', label: '봇 관리' },
   { path: '/backtest-data', icon: '📁', label: '백테스트 데이터' },
-  { path: '/members', icon: '🧑‍💼', label: '멤버 관리' },
+  { path: '/agents', icon: '🧑‍💼', label: '에이전트 관리' },
 ]
 
 export default function Sidebar() {
@@ -51,7 +51,7 @@ export default function Sidebar() {
           <img src="/logo-e.svg" alt="E" className="w-8 h-8" />
         </div>
 
-        <nav className="flex-1 py-3 px-2 flex flex-col gap-0.5">
+        <nav className="flex-1 py-3 px-2 flex flex-col gap-[2px]">
           {NAV_ITEMS.map((item) => (
             <NavLink
               key={item.path}
@@ -59,15 +59,15 @@ export default function Sidebar() {
               end={item.path === '/'}
               onClick={() => setMobileOpen(false)}
               className={({ isActive }) =>
-                `flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-[15px] font-medium no-underline transition-colors ${
+                `flex items-center gap-[10px] px-3 py-[10px] rounded-lg text-[15px] font-medium no-underline transition-colors ${
                   isActive
-                    ? 'bg-primary text-white'
+                    ? 'bg-primary !text-white'
                     : 'text-text-muted hover:bg-surface-hover hover:text-text'
                 }`
               }
             >
               <span className="text-[16px] w-5 text-center">{item.icon}</span>
-              <span>{item.label}</span>
+              <span className="leading-none">{item.label}</span>
               {item.showBadge && pendingCount > 0 && (
                 <span className="ml-auto bg-negative text-white text-[11px] px-1.5 py-px rounded-[10px] font-semibold">
                   {pendingCount}


### PR DESCRIPTION
## Summary
- active 상태에서 텍스트가 배경색에 묻히는 문제 수정 (`!text-white` 강제 적용)
- 아이콘-텍스트 간격을 목업 CSS(`gap: 10px; padding: 10px 12px`)와 일치
- nav 항목 간격을 `gap-[2px]`로 목업과 일치
- "멤버 관리" → "에이전트 관리"로 메뉴 항목 변경

Closes #360