### PR TITLE
fix(dashboard): 사이드바 버전을 pyproject.toml에서 빌드 타임 주입

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -78,7 +78,7 @@ export default function Sidebar() {
         </nav>
 
         <div className="px-4 py-3 text-[11px] text-text-muted border-t border-border">
-          Ante v0.1.0 · <a href="https://opensource.org/licenses/MIT" className="text-text-muted hover:text-text no-underline">MIT</a>
+          Ante v{__APP_VERSION__} · <a href="https://opensource.org/licenses/MIT" className="text-text-muted hover:text-text no-underline">MIT</a>
         </div>
       </aside>
     </>

--- a/frontend/src/globals.d.ts
+++ b/frontend/src/globals.d.ts
@@ -1,0 +1,1 @@
+declare const __APP_VERSION__: string

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,20 @@
+import fs from 'fs'
+import path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+function getVersion(): string {
+  const pyproject = fs.readFileSync(path.resolve(__dirname, '../pyproject.toml'), 'utf-8')
+  const match = pyproject.match(/^version\s*=\s*"(.+)"/m)
+  return match ? match[1] : '0.0.0'
+}
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    __APP_VERSION__: JSON.stringify(getVersion()),
+  },
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
## Summary
- `vite.config.ts`에서 `pyproject.toml`의 version을 읽어 `__APP_VERSION__`으로 define
- `Sidebar.tsx`의 하드코딩 `v0.1.0`을 `__APP_VERSION__` 참조로 변경
- 릴리즈 시 프론트엔드 버전이 자동으로 동기화됨

Closes #362