### PR TITLE
feat(data): fundamental 데이터 유형 지원 추가 (#365)

### DIFF
--- a/frontend/src/api/data.ts
+++ b/frontend/src/api/data.ts
@@ -1,9 +1,12 @@
 import client from './client'
 
+export type DataType = 'ohlcv' | 'fundamental'
+
 export interface Dataset {
   id: number
   symbol: string
   timeframe: string
+  data_type: DataType
   start_date: string
   end_date: string
   row_count: number
@@ -18,6 +21,7 @@ export interface StorageInfo {
 export async function getDatasets(params?: {
   symbol?: string
   timeframe?: string
+  data_type?: DataType
   offset?: number
   limit?: number
 }): Promise<{ items: Dataset[]; total: number }> {
@@ -30,6 +34,6 @@ export async function getStorageInfo(): Promise<StorageInfo> {
   return res.data
 }
 
-export async function deleteDataset(id: number): Promise<void> {
-  await client.delete(`/api/data/datasets/${id}`)
+export async function deleteDataset(id: number, data_type?: DataType): Promise<void> {
+  await client.delete(`/api/data/datasets/${id}`, { params: { data_type } })
 }

--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getDatasets, getStorageInfo, deleteDataset } from '../api/data'
+import type { DataType } from '../api/data'
 import { formatNumber, formatDate } from '../utils/formatters'
 import { TableSkeleton } from '../components/common/Skeleton'
 
@@ -8,17 +9,23 @@ const LIMIT = 15
 const TF_OPTIONS = ['all', '1d', '1h', '1m'] as const
 const TF_LABELS: Record<string, string> = { '1d': '1일', '1h': '1시간', '1m': '1분' }
 
+const DATA_TYPE_OPTIONS: { value: DataType; label: string }[] = [
+  { value: 'ohlcv', label: 'OHLCV (시세)' },
+  { value: 'fundamental', label: 'Fundamental (재무)' },
+]
+
 export default function BacktestData() {
   const [search, setSearch] = useState('')
+  const [dataType, setDataType] = useState<DataType>('ohlcv')
   const [timeframe, setTimeframe] = useState<string>('all')
   const [offset, setOffset] = useState(0)
-  const [deleteTarget, setDeleteTarget] = useState<{ id: number; symbol: string; timeframe: string; start_date: string; end_date: string; row_count: number } | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<{ id: number; symbol: string; timeframe: string; data_type: DataType; start_date: string; end_date: string; row_count: number } | null>(null)
   const queryClient = useQueryClient()
 
   /* 자동완성용: 전체 데이터셋에서 고유 종목 목록 추출 */
   const { data: allDatasets } = useQuery({
-    queryKey: ['datasets-all-symbols'],
-    queryFn: () => getDatasets({ limit: 1000 }),
+    queryKey: ['datasets-all-symbols', dataType],
+    queryFn: () => getDatasets({ data_type: dataType, limit: 1000 }),
   })
 
   const symbolOptions = useMemo(() => {
@@ -27,11 +34,12 @@ export default function BacktestData() {
   }, [allDatasets])
 
   const { data, isLoading } = useQuery({
-    queryKey: ['datasets', search, timeframe, offset],
+    queryKey: ['datasets', search, dataType, timeframe, offset],
     queryFn: () =>
       getDatasets({
         symbol: search || undefined,
-        timeframe: timeframe === 'all' ? undefined : timeframe,
+        data_type: dataType,
+        timeframe: dataType === 'ohlcv' && timeframe !== 'all' ? timeframe : undefined,
         offset,
         limit: LIMIT,
       }),
@@ -43,13 +51,16 @@ export default function BacktestData() {
   })
 
   const deleteMutation = useMutation({
-    mutationFn: deleteDataset,
+    mutationFn: (target: { id: number; data_type: DataType }) => deleteDataset(target.id, target.data_type),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['datasets'] })
+      queryClient.invalidateQueries({ queryKey: ['datasets-all-symbols'] })
       queryClient.invalidateQueries({ queryKey: ['storage'] })
       setDeleteTarget(null)
     },
   })
+
+  const isFundamental = dataType === 'fundamental'
 
   return (
     <>
@@ -78,19 +89,30 @@ export default function BacktestData() {
               ))}
             </datalist>
             <select
-              value={timeframe}
-              onChange={(e) => { setTimeframe(e.target.value); setOffset(0) }}
+              value={dataType}
+              onChange={(e) => { setDataType(e.target.value as DataType); setTimeframe('all'); setOffset(0) }}
               className="bg-bg border border-border rounded px-2 py-1 text-text text-[13px] cursor-pointer focus:outline-none focus:border-primary"
             >
-              <option value="all">전체 타임프레임</option>
-              {TF_OPTIONS.filter((tf) => tf !== 'all').map((tf) => (
-                <option key={tf} value={tf}>{TF_LABELS[tf] ?? tf}</option>
+              {DATA_TYPE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
               ))}
             </select>
+            {!isFundamental && (
+              <select
+                value={timeframe}
+                onChange={(e) => { setTimeframe(e.target.value); setOffset(0) }}
+                className="bg-bg border border-border rounded px-2 py-1 text-text text-[13px] cursor-pointer focus:outline-none focus:border-primary"
+              >
+                <option value="all">전체 타임프레임</option>
+                {TF_OPTIONS.filter((tf) => tf !== 'all').map((tf) => (
+                  <option key={tf} value={tf}>{TF_LABELS[tf] ?? tf}</option>
+                ))}
+              </select>
+            )}
           </div>
         </div>
         {isLoading ? (
-          <TableSkeleton rows={5} cols={6} />
+          <TableSkeleton rows={5} cols={isFundamental ? 5 : 6} />
         ) : (
           <>
             <div className="overflow-x-auto">
@@ -98,7 +120,9 @@ export default function BacktestData() {
                 <thead>
                   <tr>
                     <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">종목</th>
-                    <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">타임프레임</th>
+                    {!isFundamental && (
+                      <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">타임프레임</th>
+                    )}
                     <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">시작일</th>
                     <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">종료일</th>
                     <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">행 수</th>
@@ -107,7 +131,7 @@ export default function BacktestData() {
                 </thead>
                 <tbody>
                   {(data?.items ?? []).length === 0 ? (
-                    <tr><td colSpan={6} className="px-3 py-8 text-center text-text-muted text-[13px]">데이터셋이 없습니다</td></tr>
+                    <tr><td colSpan={isFundamental ? 5 : 6} className="px-3 py-8 text-center text-text-muted text-[13px]">데이터셋이 없습니다</td></tr>
                   ) : (
                     (data?.items ?? []).map((ds, idx, arr) => {
                       const isLast = idx === arr.length - 1
@@ -115,13 +139,15 @@ export default function BacktestData() {
                       return (
                       <tr key={ds.id} className="hover:bg-surface-hover">
                         <td className={`px-3 py-3 ${borderCls} text-[13px] font-mono font-medium`}>{ds.symbol}</td>
-                        <td className={`px-3 py-3 ${borderCls} text-[13px]`}>{TF_LABELS[ds.timeframe] ?? ds.timeframe}</td>
+                        {!isFundamental && (
+                          <td className={`px-3 py-3 ${borderCls} text-[13px]`}>{TF_LABELS[ds.timeframe] ?? ds.timeframe}</td>
+                        )}
                         <td className={`px-3 py-3 ${borderCls} text-[13px] text-text-muted`}>{formatDate(ds.start_date)}</td>
                         <td className={`px-3 py-3 ${borderCls} text-[13px] text-text-muted`}>{formatDate(ds.end_date)}</td>
                         <td className={`px-3 py-3 ${borderCls} text-[13px] text-right`}>{formatNumber(ds.row_count)}</td>
                         <td className={`px-3 py-3 ${borderCls} text-[13px] text-right`}>
                           <button
-                            onClick={() => setDeleteTarget({ id: ds.id, symbol: ds.symbol, timeframe: ds.timeframe, start_date: ds.start_date, end_date: ds.end_date, row_count: ds.row_count })}
+                            onClick={() => setDeleteTarget({ id: ds.id, symbol: ds.symbol, timeframe: ds.timeframe, data_type: ds.data_type, start_date: ds.start_date, end_date: ds.end_date, row_count: ds.row_count })}
                             className="px-2.5 py-1 rounded text-[12px] bg-transparent text-negative border border-border cursor-pointer hover:bg-surface-hover hover:text-text"
                           >
                             삭제
@@ -142,7 +168,7 @@ export default function BacktestData() {
                 {storage && ` · 전체 ${storage.total_mb >= 1024 ? `${(storage.total_mb / 1024).toFixed(1)} GB` : `${storage.total_mb.toFixed(1)} MB`}`}
                 {storage?.by_timeframe && Object.keys(storage.by_timeframe).length > 0 && (
                   <> ({Object.entries(storage.by_timeframe).map(([tf, bytes], i) => (
-                    <span key={tf}>{i > 0 && ' · '}{TF_LABELS[tf] ?? tf}봉 {(bytes / 1024 / 1024).toFixed(0)} MB</span>
+                    <span key={tf}>{i > 0 && ' · '}{TF_LABELS[tf] ?? tf} {(bytes / 1024 / 1024).toFixed(0)} MB</span>
                   ))})</>
                 )}
               </span>
@@ -173,17 +199,20 @@ export default function BacktestData() {
           <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
             <h3 className="text-[18px] font-bold mb-5 text-negative">데이터셋 삭제</h3>
             <div className="mb-4 text-[13px] text-text-muted">
-              <strong className="text-text">{deleteTarget.symbol} — {TF_LABELS[deleteTarget.timeframe] ?? deleteTarget.timeframe}</strong><br />
+              <strong className="text-text">
+                {deleteTarget.symbol}
+                {deleteTarget.data_type === 'fundamental' ? ' — Fundamental' : ` — ${TF_LABELS[deleteTarget.timeframe] ?? deleteTarget.timeframe}`}
+              </strong><br />
               기간: {formatDate(deleteTarget.start_date)} ~ {formatDate(deleteTarget.end_date)} · {formatNumber(deleteTarget.row_count)}건<br /><br />
               삭제된 데이터는 복구할 수 없습니다.
             </div>
             <div className="bg-warning-bg text-warning px-3.5 py-2.5 rounded text-[12px] mb-4">
-              ⚠ 이 데이터를 사용 중인 백테스트가 있을 수 있습니다.
+              이 데이터를 사용 중인 백테스트가 있을 수 있습니다.
             </div>
             <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
               <button onClick={() => setDeleteTarget(null)} className="px-4 py-2 rounded text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover hover:text-text">취소</button>
               <button
-                onClick={() => deleteMutation.mutate(deleteTarget.id)}
+                onClick={() => deleteMutation.mutate({ id: deleteTarget.id, data_type: deleteTarget.data_type })}
                 disabled={deleteMutation.isPending}
                 className="px-4 py-2 rounded text-[13px] font-medium bg-negative text-white border border-negative cursor-pointer hover:bg-negative-hover disabled:opacity-50"
               >

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -4,39 +4,75 @@ from __future__ import annotations
 
 import shutil
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 
 router = APIRouter()
 
+# 지원하는 데이터 유형
+DATA_TYPES = ["ohlcv", "fundamental"]
+
 
 @router.get("/datasets")
-async def list_datasets(request: Request) -> dict:
-    """보유 데이터셋 목록."""
+async def list_datasets(
+    request: Request,
+    data_type: str = Query("ohlcv", description="데이터 유형 (ohlcv, fundamental)"),
+) -> dict:
+    """보유 데이터셋 목록.
+
+    data_type에 따라 해당 유형의 데이터셋만 반환한다.
+    - ohlcv: 타임프레임별 OHLCV 시세 데이터
+    - fundamental: 재무 데이터 (타임프레임 없음, 'krx' 고정)
+    """
     store = getattr(request.app.state, "data_store", None)
     if store is None:
-        return {"datasets": []}
-
-    from ante.data.schemas import TIMEFRAMES
+        return {"datasets": [], "data_type": data_type}
 
     datasets = []
-    for tf in TIMEFRAMES:
-        symbols = store.list_symbols(tf)
+
+    if data_type == "fundamental":
+        symbols = store.list_symbols(data_type="fundamental")
         for symbol in symbols:
-            date_range = store.get_date_range(symbol, tf)
+            date_range = store.get_date_range(symbol, "", data_type="fundamental")
             datasets.append(
                 {
                     "symbol": symbol,
-                    "timeframe": tf,
+                    "timeframe": "",
+                    "data_type": "fundamental",
                     "start": date_range[0] if date_range else None,
                     "end": date_range[1] if date_range else None,
                 }
             )
-    return {"datasets": datasets}
+    else:
+        from ante.data.schemas import TIMEFRAMES
+
+        for tf in TIMEFRAMES:
+            symbols = store.list_symbols(tf)
+            for symbol in symbols:
+                date_range = store.get_date_range(symbol, tf)
+                datasets.append(
+                    {
+                        "symbol": symbol,
+                        "timeframe": tf,
+                        "data_type": "ohlcv",
+                        "start": date_range[0] if date_range else None,
+                        "end": date_range[1] if date_range else None,
+                    }
+                )
+
+    return {"datasets": datasets, "data_type": data_type}
 
 
 @router.get("/schema")
-async def get_data_schema(request: Request) -> dict:
-    """OHLCV 데이터 스키마."""
+async def get_data_schema(
+    request: Request,
+    data_type: str = Query("ohlcv", description="데이터 유형 (ohlcv, fundamental)"),
+) -> dict:
+    """데이터 스키마 조회. data_type에 따라 해당 스키마를 반환."""
+    if data_type == "fundamental":
+        from ante.data.schemas import FUNDAMENTAL_SCHEMA
+
+        return {k: str(v) for k, v in FUNDAMENTAL_SCHEMA.items()}
+
     from ante.data.schemas import OHLCV_SCHEMA
 
     return {k: str(v) for k, v in OHLCV_SCHEMA.items()}
@@ -60,10 +96,15 @@ async def get_storage_summary(request: Request) -> dict:
 
 
 @router.delete("/datasets/{dataset_id}", status_code=204)
-async def delete_dataset(request: Request, dataset_id: str) -> None:
+async def delete_dataset(
+    request: Request,
+    dataset_id: str,
+    data_type: str = Query("ohlcv", description="데이터 유형 (ohlcv, fundamental)"),
+) -> None:
     """데이터셋 삭제.
 
     dataset_id 형식: "{symbol}__{timeframe}" (예: "005930__1d")
+    fundamental의 경우: "{symbol}__fundamental" (예: "005930__fundamental")
     """
     from fastapi import HTTPException
 
@@ -79,7 +120,12 @@ async def delete_dataset(request: Request, dataset_id: str) -> None:
         )
 
     symbol, timeframe = parts
-    path = store.base_path / "ohlcv" / timeframe / symbol
+
+    if data_type == "fundamental":
+        path = store._resolve_path(symbol, "", data_type="fundamental")
+    else:
+        path = store.base_path / "ohlcv" / timeframe / symbol
+
     if not path.exists():
         raise HTTPException(status_code=404, detail="데이터셋을 찾을 수 없습니다")
     shutil.rmtree(path)

--- a/tests/unit/test_dataset_delete_api.py
+++ b/tests/unit/test_dataset_delete_api.py
@@ -38,6 +38,21 @@ def _make_ohlcv_df() -> pl.DataFrame:
     )
 
 
+def _make_fundamental_df() -> pl.DataFrame:
+    from datetime import date
+
+    return pl.DataFrame(
+        {
+            "date": [date(2026, 3, 1), date(2026, 3, 2)],
+            "symbol": ["005930", "005930"],
+            "market_cap": [400_000_000_000, 401_000_000_000],
+            "per": [12.5, 12.6],
+            "pbr": [1.2, 1.3],
+            "source": ["test", "test"],
+        }
+    )
+
+
 @pytest.fixture
 def store(tmp_path):
     return ParquetStore(base_path=tmp_path / "data")
@@ -73,3 +88,49 @@ class TestDeleteDataset:
         resp = client.get("/api/data/datasets")
         assert resp.status_code == 200
         assert resp.json()["datasets"] == []
+
+
+class TestFundamentalDatasets:
+    """fundamental 데이터 유형 API 테스트."""
+
+    async def test_list_fundamental_datasets(self, client, store):
+        """fundamental 데이터셋 목록 조회."""
+        await store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        resp = client.get("/api/data/datasets", params={"data_type": "fundamental"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data_type"] == "fundamental"
+        assert len(body["datasets"]) == 1
+        ds = body["datasets"][0]
+        assert ds["symbol"] == "005930"
+        assert ds["data_type"] == "fundamental"
+
+    async def test_list_ohlcv_excludes_fundamental(self, client, store):
+        """OHLCV 조회 시 fundamental 데이터가 포함되지 않음."""
+        await store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        resp = client.get("/api/data/datasets", params={"data_type": "ohlcv"})
+        assert resp.status_code == 200
+        assert resp.json()["datasets"] == []
+
+    async def test_delete_fundamental_dataset(self, client, store):
+        """fundamental 데이터셋 삭제."""
+        await store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        resp = client.delete(
+            "/api/data/datasets/005930__fundamental",
+            params={"data_type": "fundamental"},
+        )
+        assert resp.status_code == 204
+
+        # 삭제 후 목록에서 제거 확인
+        resp = client.get("/api/data/datasets", params={"data_type": "fundamental"})
+        assert resp.json()["datasets"] == []
+
+    def test_schema_fundamental(self, client):
+        """fundamental 스키마 조회."""
+        resp = client.get("/api/data/schema", params={"data_type": "fundamental"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "date" in data
+        assert "per" in data
+        assert "pbr" in data
+        assert "market_cap" in data

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -102,13 +102,30 @@ class TestDataRoutes:
     def test_datasets_no_catalog(self, client):
         resp = client.get("/api/data/datasets")
         assert resp.status_code == 200
-        assert resp.json()["datasets"] == []
+        body = resp.json()
+        assert body["datasets"] == []
+        assert body["data_type"] == "ohlcv"
+
+    def test_datasets_no_catalog_fundamental(self, client):
+        resp = client.get("/api/data/datasets", params={"data_type": "fundamental"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["datasets"] == []
+        assert body["data_type"] == "fundamental"
 
     def test_schema_no_catalog(self, client):
         resp = client.get("/api/data/schema")
         assert resp.status_code == 200
         data = resp.json()
         assert "timestamp" in data
+
+    def test_schema_fundamental(self, client):
+        resp = client.get("/api/data/schema", params={"data_type": "fundamental"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "date" in data
+        assert "per" in data
+        assert "pbr" in data
 
     def test_storage_no_catalog(self, client):
         resp = client.get("/api/data/storage")
@@ -126,6 +143,36 @@ class TestDataRoutes:
         resp = client.get("/api/data/datasets")
         assert resp.status_code == 200
         assert isinstance(resp.json()["datasets"], list)
+
+    def test_datasets_with_store_data_type_ohlcv(self, tmp_path):
+        """data_type=ohlcv 파라미터로 OHLCV 데이터셋만 반환."""
+        from ante.data.store import ParquetStore
+
+        store = ParquetStore(base_path=tmp_path / "data")
+        app = create_app(data_store=store)
+        client = TestClient(app)
+
+        resp = client.get("/api/data/datasets", params={"data_type": "ohlcv"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data_type"] == "ohlcv"
+        for ds in body["datasets"]:
+            assert ds["data_type"] == "ohlcv"
+
+    def test_datasets_with_store_data_type_fundamental(self, tmp_path):
+        """data_type=fundamental 파라미터로 fundamental 데이터셋만 반환."""
+        from ante.data.store import ParquetStore
+
+        store = ParquetStore(base_path=tmp_path / "data")
+        app = create_app(data_store=store)
+        client = TestClient(app)
+
+        resp = client.get("/api/data/datasets", params={"data_type": "fundamental"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data_type"] == "fundamental"
+        for ds in body["datasets"]:
+            assert ds["data_type"] == "fundamental"
 
     def test_storage_with_store(self, tmp_path):
         from ante.data.store import ParquetStore


### PR DESCRIPTION
## Summary

- 백엔드 `list_datasets`, `get_data_schema`, `delete_dataset` API에 `data_type` 쿼리 파라미터 추가 (ohlcv/fundamental)
- 프론트엔드 백테스트 데이터 페이지에 데이터 유형 필터 드롭다운 추가, fundamental 선택 시 타임프레임 필터 숨김
- fundamental 데이터셋 목록 조회/삭제/스키마 조회 단위 테스트 추가

## Test plan

- [x] `pytest tests/ -v --ignore=tests/e2e` 전체 통과 (1629 passed)
- [ ] 프론트엔드에서 OHLCV/Fundamental 필터 전환 확인
- [ ] fundamental 데이터셋 삭제 동작 확인

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)