### PR TITLE
fix(dashboard): 에이전트 등록 시 member_type 필드 누락 수정

### DIFF
--- a/frontend/src/components/agents/AgentRegisterForm.tsx
+++ b/frontend/src/components/agents/AgentRegisterForm.tsx
@@ -28,7 +28,7 @@ export default function AgentRegisterForm({ onClose, onTokenCreated }: AgentRegi
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     createMember.mutate(
-      { member_id: memberId, name, org, scopes },
+      { member_id: memberId, member_type: 'agent', name, org, scopes },
       { onSuccess: (data) => onTokenCreated(memberId, data.token) },
     )
   }

--- a/frontend/src/types/member.ts
+++ b/frontend/src/types/member.ts
@@ -24,6 +24,7 @@ export interface MemberDetail extends Member {
 
 export interface MemberCreateRequest {
   member_id: string
+  member_type: MemberType
   name: string
   org: string
   scopes: string[]


### PR DESCRIPTION
## Summary
- `MemberCreateRequest` 타입에 `member_type: MemberType` 필드 추가
- `AgentRegisterForm`에서 `member_type: 'agent'`를 자동 설정하여 백엔드 422 에러 해결

Closes #370

## Test plan
- [x] TypeScript 타입 체크 통과 (`tsc --noEmit`)
- [x] pytest 전체 통과 (1621 passed)
- [ ] Docker 테스트 모드에서 에이전트 등록 폼 제출 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)