### PR TITLE
fix: 설정 페이지 display.currency_position 미등록 에러 해결

### DIFF
--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -81,6 +81,9 @@ async def main() -> None:
     await dynamic_config.register_default(
         "system.log_level", log_level, category="system"
     )
+    await dynamic_config.register_default(
+        "display.currency_position", "suffix", category="display"
+    )
     eventbus.subscribe(ConfigChangedEvent, _on_log_level_changed)
     logger.info("DynamicConfigService 초기화 완료")
 

--- a/tests/fixtures/seed/scenarios/action-settings.sql
+++ b/tests/fixtures/seed/scenarios/action-settings.sql
@@ -5,7 +5,7 @@
 -- _base.sql 의 trading_state = 'active' 를 그대로 유지한다.
 -- (INSERT OR IGNORE 이므로 별도 override 불필요)
 
--- ── 동적 설정 (10개) ──────────────────────────────────
+-- ── 동적 설정 (11개) ──────────────────────────────────
 -- 값은 DynamicConfigService와 동일하게 JSON 인코딩하여 저장한다.
 INSERT INTO dynamic_config (key, value, category, updated_at)
 VALUES ('risk.max_mdd_pct', '"15.0"', 'risk', datetime('now', '-7 days'));
@@ -38,6 +38,9 @@ INSERT INTO dynamic_config (key, value, category, updated_at)
 VALUES ('broker.sell_tax_rate', '"0.23"', 'broker', datetime('now', '-7 days'));
 
 -- ── 표시·알림 설정 ────────────────────────────────────
+INSERT INTO dynamic_config (key, value, category, updated_at)
+VALUES ('display.currency_position', '"suffix"', 'display', datetime('now', '-7 days'));
+
 INSERT INTO dynamic_config (key, value, category, updated_at)
 VALUES ('notification.fill_alert', '"true"', 'notification', datetime('now', '-7 days'));
 

--- a/tests/fixtures/seed/scenarios/settings.sql
+++ b/tests/fixtures/seed/scenarios/settings.sql
@@ -7,7 +7,7 @@ UPDATE system_state SET value = 'halted' WHERE key = 'trading_state';
 INSERT INTO system_state_history (old_state, new_state, reason, changed_by)
 VALUES ('active', 'halted', '설정 페이지 테스트용 거래 정지', 'test-seed');
 
--- ── 동적 설정 (10개) ────────────────────────────────
+-- ── 동적 설정 (11개) ────────────────────────────────
 INSERT INTO dynamic_config (key, value, category, updated_at) VALUES ('risk.max_mdd_pct', '15.0', 'risk', datetime('now', '-7 days'));
 INSERT INTO dynamic_config (key, value, category, updated_at) VALUES ('risk.max_position_pct', '30.0', 'risk', datetime('now', '-7 days'));
 INSERT INTO dynamic_config (key, value, category, updated_at) VALUES ('rule.daily_loss_limit', '5.0', 'rule', datetime('now', '-7 days'));
@@ -18,6 +18,7 @@ INSERT INTO dynamic_config (key, value, category, updated_at) VALUES ('rule.allo
 INSERT INTO dynamic_config (key, value, category, updated_at) VALUES ('bot.default_interval_sec', '60', 'bot', datetime('now', '-7 days'));
 INSERT INTO dynamic_config (key, value, category, updated_at) VALUES ('broker.commission_rate', '0.015', 'broker', datetime('now', '-7 days'));
 INSERT INTO dynamic_config (key, value, category, updated_at) VALUES ('broker.sell_tax_rate', '0.23', 'broker', datetime('now', '-7 days'));
+INSERT INTO dynamic_config (key, value, category, updated_at) VALUES ('display.currency_position', '"suffix"', 'display', datetime('now', '-7 days'));
 
 -- ── 설정 변경 이력 ──────────────────────────────────
 INSERT INTO dynamic_config_history (key, old_value, new_value, changed_by, changed_at)


### PR DESCRIPTION
## Summary
- 설정 페이지에서 `display.currency_position` 키가 백엔드 dynamic_config에 등록되지 않아 PUT 요청 시 404 에러가 발생하는 문제를 수정
- `main.py` DynamicConfigService 초기화 시 `display.currency_position` 기본값(`"suffix"`)을 `register_default`로 등록
- E2E 시드 SQL(`action-settings.sql`, `settings.sql`)에 해당 설정 키 추가

Closes #371

## Test plan
- [x] 기존 유닛/통합 테스트 전체 통과 확인 (1621 passed)
- [ ] Docker 테스트 모드에서 settings 시나리오 주입 후 설정 페이지 진입 시 에러 없음 확인
- [ ] 금액 단위 위치 토글(prefix/suffix) 클릭 시 정상 저장 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)