### PR TITLE
fix(dashboard): 멤버 관리 비밀번호 변경 기능 구현

### DIFF
--- a/frontend/src/api/members.ts
+++ b/frontend/src/api/members.ts
@@ -37,6 +37,10 @@ export async function rotateToken(id: string): Promise<{ token: string }> {
   return res.data
 }
 
+export async function changePassword(id: string, oldPassword: string, newPassword: string): Promise<void> {
+  await client.patch(`/api/members/${id}/password`, { old_password: oldPassword, new_password: newPassword })
+}
+
 export async function updateScopes(id: string, scopes: string[]): Promise<void> {
   await client.put(`/api/members/${id}/scopes`, { scopes })
 }

--- a/frontend/src/components/agents/ChangePasswordModal.tsx
+++ b/frontend/src/components/agents/ChangePasswordModal.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react'
+import { useMemberControl } from '../../hooks/useMembers'
+
+interface ChangePasswordModalProps {
+  memberId: string
+  onClose: () => void
+}
+
+export default function ChangePasswordModal({ memberId, onClose }: ChangePasswordModalProps) {
+  const [oldPassword, setOldPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState(false)
+
+  const { changePassword } = useMemberControl()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    if (newPassword.length < 4) {
+      setError('새 비밀번호는 최소 4자 이상이어야 합니다')
+      return
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError('새 비밀번호가 일치하지 않습니다')
+      return
+    }
+
+    changePassword.mutate(
+      { id: memberId, oldPassword, newPassword },
+      {
+        onSuccess: () => setSuccess(true),
+        onError: (err) => {
+          const message = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+            ?? '비밀번호 변경에 실패했습니다'
+          setError(message)
+        },
+      },
+    )
+  }
+
+  if (success) {
+    return (
+      <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+        <div className="bg-surface border border-border rounded-lg p-6 w-[400px] text-center">
+          <h3 className="text-[18px] font-bold mb-4 text-positive">비밀번호 변경 완료</h3>
+          <p className="text-[13px] text-text-muted mb-5">
+            <span className="font-semibold text-text">{memberId}</span>의 비밀번호가 변경되었습니다.
+          </p>
+          <button
+            onClick={onClose}
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+      <div className="bg-surface border border-border rounded-lg p-6 w-[400px]">
+        <h2 className="text-[18px] font-bold mb-5">비밀번호 변경</h2>
+        <p className="text-[13px] text-text-muted mb-4">
+          <span className="font-semibold text-text">{memberId}</span>
+        </p>
+        <form onSubmit={handleSubmit}>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">현재 비밀번호</label>
+            <input
+              type="password"
+              value={oldPassword}
+              onChange={(e) => setOldPassword(e.target.value)}
+              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary"
+              required
+              autoFocus
+            />
+          </div>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">새 비밀번호</label>
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary"
+              required
+            />
+          </div>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">새 비밀번호 확인</label>
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary"
+              required
+            />
+          </div>
+          {error && (
+            <div className="text-[13px] text-negative mb-4">{error}</div>
+          )}
+          <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={changePassword.isPending}
+              className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50"
+            >
+              {changePassword.isPending ? '변경 중...' : '변경'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useMembers.ts
+++ b/frontend/src/hooks/useMembers.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getMembers, getMemberDetail, createMember, suspendMember, reactivateMember, revokeMember, rotateToken, updateScopes } from '../api/members'
+import { getMembers, getMemberDetail, createMember, suspendMember, reactivateMember, revokeMember, rotateToken, changePassword, updateScopes } from '../api/members'
 import type { MemberCreateRequest } from '../types/member'
 
 export function useMembers(params?: { type?: string; org?: string; status?: string }) {
@@ -42,6 +42,10 @@ export function useMemberControl() {
     }),
     rotateToken: useMutation({
       mutationFn: rotateToken,
+    }),
+    changePassword: useMutation({
+      mutationFn: ({ id, oldPassword, newPassword }: { id: string; oldPassword: string; newPassword: string }) =>
+        changePassword(id, oldPassword, newPassword),
     }),
     updateScopes: useMutation({
       mutationFn: ({ id, scopes }: { id: string; scopes: string[] }) => updateScopes(id, scopes),

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useMembers, useMemberControl } from '../hooks/useMembers'
 import MemberCard from '../components/agents/MemberCard'
 import AgentRegisterForm from '../components/agents/AgentRegisterForm'
+import ChangePasswordModal from '../components/agents/ChangePasswordModal'
 import { TableSkeleton } from '../components/common/Skeleton'
 import type { MemberStatus } from '../types/member'
 
@@ -17,6 +18,7 @@ export default function Agents() {
   const [statusFilter, setStatusFilter] = useState<MemberStatus | 'all'>('all')
   const [showRegister, setShowRegister] = useState(false)
   const [createdToken, setCreatedToken] = useState<{ agentId: string; token: string } | null>(null)
+  const [passwordTarget, setPasswordTarget] = useState<string | null>(null)
 
   const { data: allMembers, isLoading } = useMembers({})
   const { data: humanMembers } = useMembers({ type: 'human' })
@@ -62,7 +64,7 @@ export default function Agents() {
                     key={m.member_id}
                     member={m}
                     onSuspend={m.member_id !== 'owner' ? (id) => suspend.mutate(id) : undefined}
-                    onChangePassword={() => {/* TODO: 비밀번호 변경 모달 연결 */}}
+                    onChangePassword={(id) => setPasswordTarget(id)}
                   />
                 ))}
               </div>
@@ -136,6 +138,13 @@ export default function Agents() {
         <AgentRegisterForm
           onClose={() => setShowRegister(false)}
           onTokenCreated={(agentId, token) => { setShowRegister(false); setCreatedToken({ agentId, token }) }}
+        />
+      )}
+
+      {passwordTarget && (
+        <ChangePasswordModal
+          memberId={passwordTarget}
+          onClose={() => setPasswordTarget(null)}
         />
       )}
 

--- a/src/ante/web/routes/members.py
+++ b/src/ante/web/routes/members.py
@@ -21,6 +21,13 @@ class MemberCreateRequest(BaseModel):
     scopes: list[str] = []
 
 
+class PasswordChangeRequest(BaseModel):
+    """비밀번호 변경 요청."""
+
+    old_password: str
+    new_password: str
+
+
 class ScopesUpdateRequest(BaseModel):
     """권한 범위 변경 요청."""
 
@@ -134,6 +141,21 @@ async def rotate_token(request: Request, member_id: str) -> dict:
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
     return {"member": asdict(member), "token": token}
+
+
+@router.patch("/{member_id}/password")
+async def change_password(
+    request: Request, member_id: str, body: PasswordChangeRequest
+) -> dict:
+    """비밀번호 변경 (human 멤버 전용)."""
+    svc = _get_member_service(request)
+    try:
+        await svc.change_password(member_id, body.old_password, body.new_password)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e)) from e
+    return {"ok": True}
 
 
 @router.put("/{member_id}/scopes")

--- a/tests/unit/test_member_api.py
+++ b/tests/unit/test_member_api.py
@@ -121,6 +121,18 @@ class FakeMemberService:
         self._token_counter += 1
         return member, f"ante_ak_{self._token_counter}"
 
+    async def change_password(
+        self, member_id: str, old_password: str, new_password: str
+    ) -> None:
+        member = self._members.get(member_id)
+        if member is None:
+            raise ValueError(f"멤버를 찾을 수 없습니다: {member_id}")
+        if member.type != "human":
+            raise PermissionError("human 멤버만 비밀번호를 변경할 수 있습니다")
+        if member.password_hash and member.password_hash != old_password:
+            raise PermissionError("현재 패스워드가 일치하지 않습니다")
+        member.password_hash = new_password
+
     async def update_scopes(
         self, member_id: str, scopes: list[str], updated_by: str = ""
     ) -> FakeMember:
@@ -260,6 +272,50 @@ class TestTokenManagement:
         """존재하지 않는 멤버 → 404."""
         resp = client.post("/api/members/nonexistent/rotate-token")
         assert resp.status_code == 404
+
+
+class TestChangePassword:
+    def test_change_password_success(self, client, member_service):
+        """비밀번호 변경 성공."""
+        member_service._members["user-01"] = FakeMember(
+            member_id="user-01", type="human", password_hash="old123"
+        )
+        resp = client.patch(
+            "/api/members/user-01/password",
+            json={"old_password": "old123", "new_password": "new456"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+    def test_change_password_wrong_old(self, client, member_service):
+        """기존 비밀번호 불일치 → 403."""
+        member_service._members["user-01"] = FakeMember(
+            member_id="user-01", type="human", password_hash="old123"
+        )
+        resp = client.patch(
+            "/api/members/user-01/password",
+            json={"old_password": "wrong", "new_password": "new456"},
+        )
+        assert resp.status_code == 403
+
+    def test_change_password_nonexistent(self, client):
+        """존재하지 않는 멤버 → 404."""
+        resp = client.patch(
+            "/api/members/nonexistent/password",
+            json={"old_password": "old", "new_password": "new"},
+        )
+        assert resp.status_code == 404
+
+    def test_change_password_agent_forbidden(self, client, member_service):
+        """agent 멤버 비밀번호 변경 → 403."""
+        member_service._members["agent-01"] = FakeMember(
+            member_id="agent-01", type="agent"
+        )
+        resp = client.patch(
+            "/api/members/agent-01/password",
+            json={"old_password": "old", "new_password": "new"},
+        )
+        assert resp.status_code == 403
 
 
 class TestScopesUpdate:


### PR DESCRIPTION
## Summary
- 백엔드 `PATCH /api/members/{id}/password` 엔드포인트 추가 (기존 `MemberService.change_password()` 연동)
- 프론트엔드 `ChangePasswordModal` 컴포넌트 신규 구현 (현재/새/확인 3필드, 유효성 검증, 에러/성공 상태 처리)
- `Agents.tsx` 페이지의 TODO 스텁을 모달 연결로 교체

Closes #369

## Test plan
- [x] `test_member_api.py` — 비밀번호 변경 성공, 기존 비밀번호 불일치(403), 존재하지 않는 멤버(404), agent 멤버 변경 시도(403) 4건 추가
- [x] 기존 17개 테스트 포함 전체 1625 테스트 통과
- [x] TypeScript 타입 체크 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)