### PR TITLE
fix(api): 전략 상세 페이지 weekly-summary API 404 해소

### DIFF
--- a/frontend/src/types/strategy.ts
+++ b/frontend/src/types/strategy.ts
@@ -24,13 +24,6 @@ export interface StrategyParam {
   description?: string
 }
 
-export interface WeeklySummary {
-  week_label: string
-  realized_pnl: number
-  trade_count: number
-  win_rate: number
-}
-
 export interface StrategyPerformance {
   total_trades: number
   winning_trades: number
@@ -68,6 +61,7 @@ export interface MonthlySummary {
 export interface WeeklySummary {
   week_start: string
   week_end: string
+  week_label: string
   realized_pnl: number
   trade_count: number
   win_rate: number

--- a/src/ante/trade/__init__.py
+++ b/src/ante/trade/__init__.py
@@ -8,6 +8,7 @@ from ante.trade.models import (
     TradeRecord,
     TradeStatus,
     TradeType,
+    WeeklySummary,
 )
 from ante.trade.performance import PerformanceTracker
 from ante.trade.position import PositionHistory
@@ -18,6 +19,7 @@ from ante.trade.service import TradeService
 __all__ = [
     "DailySummary",
     "MonthlySummary",
+    "WeeklySummary",
     "PerformanceMetrics",
     "PerformanceTracker",
     "PositionHistory",

--- a/src/ante/trade/models.py
+++ b/src/ante/trade/models.py
@@ -69,6 +69,22 @@ class DailySummary:
 
 
 @dataclass(frozen=True)
+class WeeklySummary:
+    """주별 성과 집계."""
+
+    week_start: str
+    week_end: str
+    realized_pnl: float
+    trade_count: int
+    win_rate: float
+
+    @property
+    def week_label(self) -> str:
+        """주간 라벨 (MM-DD ~ MM-DD 형식)."""
+        return f"{self.week_start[5:]} ~ {self.week_end[5:]}"
+
+
+@dataclass(frozen=True)
 class MonthlySummary:
     """월별 성과 집계."""
 

--- a/src/ante/trade/performance.py
+++ b/src/ante/trade/performance.py
@@ -13,6 +13,7 @@ from ante.trade.models import (
     PerformanceMetrics,
     TradeRecord,
     TradeStatus,
+    WeeklySummary,
 )
 
 if TYPE_CHECKING:
@@ -136,6 +137,63 @@ class PerformanceTracker:
         return [
             DailySummary(
                 date=row["trade_date"],
+                realized_pnl=float(row["realized_pnl"]),
+                trade_count=int(row["trade_count"]),
+                win_rate=(
+                    int(row["win_count"]) / int(row["trade_count"])
+                    if int(row["trade_count"]) > 0
+                    else 0.0
+                ),
+            )
+            for row in rows
+        ]
+
+    async def get_weekly_summary(
+        self,
+        bot_id: str | None = None,
+    ) -> list[WeeklySummary]:
+        """주별 성과 집계.
+
+        ISO 주 단위(월요일 시작)로 거래를 그룹화하여 집계한다.
+
+        Args:
+            bot_id: 봇 ID 필터 (None이면 전체)
+        """
+        conditions: list[str] = [
+            "t.status = ?",
+            "t.side = 'sell'",
+        ]
+        params: list[Any] = [TradeStatus.FILLED.value]
+
+        if bot_id:
+            conditions.append("t.bot_id = ?")
+            params.append(bot_id)
+
+        where = " AND ".join(conditions)
+        query = f"""
+            SELECT
+                date(t.timestamp, 'weekday 0', '-6 days') AS week_start,
+                date(t.timestamp, 'weekday 0') AS week_end,
+                COALESCE(SUM(ph.pnl), 0.0) AS realized_pnl,
+                COUNT(*) AS trade_count,
+                SUM(CASE WHEN ph.pnl > 0 THEN 1 ELSE 0 END) AS win_count
+            FROM trades t
+            LEFT JOIN position_history ph
+                ON ph.bot_id = t.bot_id
+                AND ph.symbol = t.symbol
+                AND ph.action = 'sell'
+                AND ph.price = t.price
+                AND ph.quantity = t.quantity
+            WHERE {where}
+            GROUP BY week_start
+            ORDER BY week_start ASC
+        """
+
+        rows = await self._db.fetch_all(query, tuple(params))
+        return [
+            WeeklySummary(
+                week_start=row["week_start"],
+                week_end=row["week_end"],
                 realized_pnl=float(row["realized_pnl"]),
                 trade_count=int(row["trade_count"]),
                 win_rate=(

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -190,6 +190,52 @@ async def get_strategy_daily_summary(
     }
 
 
+@router.get("/{strategy_id}/weekly-summary")
+async def get_strategy_weekly_summary(
+    request: Request,
+    strategy_id: str,
+) -> dict:
+    """전략 주별 성과 집계."""
+    registry = getattr(request.app.state, "strategy_registry", None)
+    if registry is None:
+        raise HTTPException(status_code=503, detail="Strategy registry not available")
+
+    record = await registry.get(strategy_id)
+    if not record:
+        raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
+
+    db = getattr(request.app.state, "db", None)
+    if db is None:
+        raise HTTPException(status_code=503, detail="Database not available")
+
+    from ante.trade.performance import PerformanceTracker
+
+    tracker = PerformanceTracker(db)
+
+    bot_id = None
+    bot_manager = getattr(request.app.state, "bot_manager", None)
+    if bot_manager is not None:
+        for b in bot_manager.list_bots():
+            if b.get("strategy_id") == strategy_id:
+                bot_id = b["bot_id"]
+                break
+
+    summaries = await tracker.get_weekly_summary(bot_id=bot_id)
+    return {
+        "items": [
+            {
+                "week_start": s.week_start,
+                "week_end": s.week_end,
+                "week_label": s.week_label,
+                "realized_pnl": s.realized_pnl,
+                "trade_count": s.trade_count,
+                "win_rate": s.win_rate,
+            }
+            for s in summaries
+        ]
+    }
+
+
 @router.get("/{strategy_id}/monthly-summary")
 async def get_strategy_monthly_summary(
     request: Request,

--- a/tests/unit/test_performance_summary.py
+++ b/tests/unit/test_performance_summary.py
@@ -1,4 +1,4 @@
-"""일별/월별 성과 집계 단위 테스트."""
+"""일별/주별/월별 성과 집계 단위 테스트."""
 
 from __future__ import annotations
 
@@ -115,6 +115,83 @@ class TestGetDailySummary:
         result = await tracker.get_daily_summary()
 
         assert result == []
+
+
+class TestGetWeeklySummary:
+    @pytest.mark.asyncio
+    async def test_weekly_summary_basic(self):
+        from ante.trade.models import WeeklySummary
+
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(
+            return_value=[
+                {
+                    "week_start": "2026-03-09",
+                    "week_end": "2026-03-15",
+                    "realized_pnl": 30000.0,
+                    "trade_count": 5,
+                    "win_count": 3,
+                },
+                {
+                    "week_start": "2026-03-16",
+                    "week_end": "2026-03-22",
+                    "realized_pnl": -10000.0,
+                    "trade_count": 4,
+                    "win_count": 1,
+                },
+            ]
+        )
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_weekly_summary()
+
+        assert len(result) == 2
+        assert isinstance(result[0], WeeklySummary)
+        assert result[0].week_start == "2026-03-09"
+        assert result[0].week_end == "2026-03-15"
+        assert result[0].realized_pnl == 30000.0
+        assert result[0].trade_count == 5
+        assert result[0].win_rate == pytest.approx(3 / 5)
+        assert result[0].week_label == "03-09 ~ 03-15"
+        assert result[1].win_rate == pytest.approx(1 / 4)
+
+    @pytest.mark.asyncio
+    async def test_weekly_summary_with_bot_filter(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_weekly_summary(bot_id="bot-1")
+
+        assert result == []
+        call_args = db.fetch_all.call_args
+        query = call_args[0][0]
+        params = call_args[0][1]
+        assert "t.bot_id = ?" in query
+        assert "bot-1" in params
+
+    @pytest.mark.asyncio
+    async def test_weekly_summary_empty(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_weekly_summary()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_weekly_summary_query_groups_by_week(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        await tracker.get_weekly_summary()
+
+        call_args = db.fetch_all.call_args
+        query = call_args[0][0]
+        assert "week_start" in query
+        assert "GROUP BY week_start" in query
 
 
 class TestGetMonthlySummary:


### PR DESCRIPTION
## Summary
- 백엔드에 `GET /api/strategies/{id}/weekly-summary` 엔드포인트를 구현하여 프론트엔드 전략 상세 페이지 진입 시 발생하던 404 에러를 해결
- `WeeklySummary` 모델, `PerformanceTracker.get_weekly_summary()` 메서드, API 라우트 추가
- 프론트엔드 `WeeklySummary` 타입 중복 정의를 하나로 통합하고 `week_label` 필드 추가

## Test plan
- [x] `TestGetWeeklySummary` 단위 테스트 4건 통과 확인
- [x] 기존 전체 테스트 스위트 1625건 통과 확인 (regression 없음)
- [x] ruff lint/format 통과
- [ ] Docker 테스트 모드에서 전략 상세 페이지 진입 시 404 에러 미발생 확인

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)