### PR TITLE
feat(dashboard): Feed 상태 및 API 키 현황 UI 추가

### DIFF
--- a/frontend/src/api/data.ts
+++ b/frontend/src/api/data.ts
@@ -1,4 +1,5 @@
 import client from './client'
+import type { FeedStatus } from '../types/feed'
 
 export interface Dataset {
   id: number
@@ -32,4 +33,9 @@ export async function getStorageInfo(): Promise<StorageInfo> {
 
 export async function deleteDataset(id: number): Promise<void> {
   await client.delete(`/api/data/datasets/${id}`)
+}
+
+export async function getFeedStatus(): Promise<FeedStatus> {
+  const res = await client.get('/api/data/feed-status')
+  return res.data
 }

--- a/frontend/src/components/data/ApiKeyStatusPanel.tsx
+++ b/frontend/src/components/data/ApiKeyStatusPanel.tsx
@@ -1,0 +1,75 @@
+import { useFeedStatus } from '../../hooks/useFeed'
+import StatusBadge from '../common/StatusBadge'
+import { Skeleton } from '../common/Skeleton'
+
+const KEY_LABELS: Record<string, { name: string; desc: string }> = {
+  ANTE_DATAGOKR_API_KEY: {
+    name: 'data.go.kr',
+    desc: '공공데이터포털 서비스키',
+  },
+  ANTE_DART_API_KEY: {
+    name: 'DART',
+    desc: '금융감독원 OpenAPI 인증키',
+  },
+}
+
+export default function ApiKeyStatusPanel() {
+  const { data: feedStatus, isLoading } = useFeedStatus()
+
+  if (isLoading) {
+    return (
+      <div className="bg-surface border border-border rounded-lg p-5">
+        <Skeleton className="h-5 w-40 mb-4" />
+        <Skeleton className="h-16 w-full" />
+      </div>
+    )
+  }
+
+  if (!feedStatus) return null
+
+  const { api_keys } = feedStatus
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5">
+      <h3 className="text-[15px] font-semibold mb-4">외부 데이터 API 키</h3>
+      <div>
+        {api_keys.map((apiKey, idx) => {
+          const label = KEY_LABELS[apiKey.key]
+          const isLast = idx === api_keys.length - 1
+          return (
+            <div
+              key={apiKey.key}
+              className={`flex items-center justify-between py-2.5 ${
+                !isLast ? 'border-b border-border' : ''
+              }`}
+            >
+              <div>
+                <div className="text-[13px] font-medium">
+                  {label?.name ?? apiKey.key}
+                </div>
+                <div className="text-[12px] text-text-muted mt-0.5">
+                  {label?.desc ?? apiKey.key}
+                  {apiKey.set && apiKey.source && (
+                    <span className="ml-1.5 text-[11px]">
+                      (source: {apiKey.source})
+                    </span>
+                  )}
+                </div>
+              </div>
+              {apiKey.set ? (
+                <StatusBadge variant="positive">설정됨</StatusBadge>
+              ) : (
+                <StatusBadge variant="warning">미설정</StatusBadge>
+              )}
+            </div>
+          )
+        })}
+      </div>
+      {api_keys.some((k) => !k.set) && (
+        <div className="bg-info-bg rounded px-3.5 py-2.5 mt-3 text-[12px] text-info">
+          API 키 설정: <code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante feed config set {'<KEY>'} {'<VALUE>'}</code>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/data/FeedStatusPanel.tsx
+++ b/frontend/src/components/data/FeedStatusPanel.tsx
@@ -1,0 +1,143 @@
+import { useFeedStatus } from '../../hooks/useFeed'
+import { formatDateTime, formatNumber } from '../../utils/formatters'
+import StatusBadge from '../common/StatusBadge'
+import { Skeleton } from '../common/Skeleton'
+import type { FeedCheckpoint, FeedReport } from '../../types/feed'
+
+const SOURCE_LABELS: Record<string, string> = {
+  data_go_kr: 'data.go.kr',
+  dart: 'DART',
+  pykrx: 'pykrx',
+}
+
+const DATA_TYPE_LABELS: Record<string, string> = {
+  ohlcv: 'OHLCV (시세)',
+  fundamental: '재무제표',
+  flow: '수급',
+  event: '기업 이벤트',
+}
+
+const MODE_LABELS: Record<string, string> = {
+  daily: '일일 수집',
+  backfill: '백필',
+}
+
+export default function FeedStatusPanel() {
+  const { data: feedStatus, isLoading } = useFeedStatus()
+
+  if (isLoading) {
+    return (
+      <div className="bg-surface border border-border rounded-lg p-5 mb-4">
+        <Skeleton className="h-5 w-40 mb-4" />
+        <Skeleton className="h-20 w-full" />
+      </div>
+    )
+  }
+
+  if (!feedStatus) return null
+
+  const { initialized, checkpoints, recent_reports } = feedStatus
+  const latestReport = recent_reports.length > 0 ? recent_reports[0] : null
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5 mb-4">
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-[15px] font-semibold text-text">Feed 파이프라인</span>
+        {initialized ? (
+          <StatusBadge variant="positive">활성</StatusBadge>
+        ) : (
+          <StatusBadge variant="muted">미초기화</StatusBadge>
+        )}
+      </div>
+
+      {!initialized ? (
+        <div className="text-[13px] text-text-muted">
+          Feed가 초기화되지 않았습니다. <code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante feed init</code> 명령으로 초기화하세요.
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {/* 최근 실행 결과 */}
+          {latestReport && <LatestReportCard report={latestReport} />}
+
+          {/* 소스별 체크포인트 현황 */}
+          {checkpoints.length > 0 && (
+            <div>
+              <h4 className="text-[13px] font-semibold text-text-muted mb-2">소스별 수집 현황</h4>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                {checkpoints.map((cp) => (
+                  <CheckpointCard key={`${cp.source}_${cp.data_type}`} checkpoint={cp} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {checkpoints.length === 0 && !latestReport && (
+            <div className="text-[13px] text-text-muted">
+              아직 수집이 실행되지 않았습니다. <code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante feed run daily</code> 또는 <code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante feed run backfill</code> 명령으로 수집을 시작하세요.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function LatestReportCard({ report }: { report: FeedReport }) {
+  const isSuccess = report.summary.symbols_failed === 0
+  const hasWarnings = report.failures.length > 0 || report.warnings.length > 0
+
+  return (
+    <div>
+      <h4 className="text-[13px] font-semibold text-text-muted mb-2">마지막 실행</h4>
+      <div className="bg-bg rounded-lg border border-border p-3">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2">
+            <span className="text-[13px] font-medium text-text">
+              {MODE_LABELS[report.mode] ?? report.mode}
+            </span>
+            {isSuccess ? (
+              <StatusBadge variant="positive">성공</StatusBadge>
+            ) : hasWarnings ? (
+              <StatusBadge variant="warning">일부 실패</StatusBadge>
+            ) : (
+              <StatusBadge variant="negative">실패</StatusBadge>
+            )}
+          </div>
+          <span className="text-[12px] text-text-muted">
+            {formatDateTime(report.finished_at)}
+          </span>
+        </div>
+        <div className="flex items-center gap-4 text-[12px] text-text-muted">
+          <span>대상: {report.target_date}</span>
+          <span>종목: {formatNumber(report.summary.symbols_success)}/{formatNumber(report.summary.symbols_total)}</span>
+          <span>기록: {formatNumber(report.summary.rows_written)}행</span>
+          <span>소요: {report.duration_seconds}초</span>
+        </div>
+        {report.summary.symbols_failed > 0 && (
+          <div className="mt-2 text-[12px] text-warning">
+            {report.summary.symbols_failed}개 종목 수집 실패
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function CheckpointCard({ checkpoint }: { checkpoint: FeedCheckpoint }) {
+  return (
+    <div className="bg-bg rounded-lg border border-border p-3">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-[13px] font-medium text-text">
+          {SOURCE_LABELS[checkpoint.source] ?? checkpoint.source}
+        </span>
+        <span className="text-[11px] text-text-muted">
+          {DATA_TYPE_LABELS[checkpoint.data_type] ?? checkpoint.data_type}
+        </span>
+      </div>
+      <div className="text-[12px] text-text-muted">
+        <span>마지막 수집: {checkpoint.last_date}</span>
+        <span className="ml-3">갱신: {formatDateTime(checkpoint.updated_at)}</span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useFeed.ts
+++ b/frontend/src/hooks/useFeed.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+import { getFeedStatus } from '../api/data'
+
+export function useFeedStatus() {
+  return useQuery({
+    queryKey: ['data', 'feed-status'],
+    queryFn: getFeedStatus,
+    refetchInterval: 60_000,
+  })
+}

--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getDatasets, getStorageInfo, deleteDataset } from '../api/data'
 import { formatNumber, formatDate } from '../utils/formatters'
 import { TableSkeleton } from '../components/common/Skeleton'
+import FeedStatusPanel from '../components/data/FeedStatusPanel'
 
 const LIMIT = 15
 const TF_OPTIONS = ['all', '1d', '1h', '1m'] as const
@@ -57,6 +58,9 @@ export default function BacktestData() {
       <div className="bg-info-bg rounded px-3.5 py-2.5 mb-4 text-[12px] text-info">
         {'\u{1f4a1}'} 데이터 수집은 Agent에게 요청하거나 CLI(<code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante data collect</code>)를 사용하세요.
       </div>
+
+      {/* Feed 파이프라인 상태 (BD-6) */}
+      <FeedStatusPanel />
 
       {/* 데이터셋 카드 */}
       <div className="bg-surface border border-border rounded-lg p-5">

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useSystemStatus, useKillSwitch, useConfigs, useUpdateConfig } from '../hooks/useSystemStatus'
 import { PageSkeleton } from '../components/common/Skeleton'
+import ApiKeyStatusPanel from '../components/data/ApiKeyStatusPanel'
 
 /** 거래 설정 고정 항목 */
 const TRADING_CONFIGS = [
@@ -118,6 +119,11 @@ export default function Settings() {
             </div>
           </div>
         </div>
+      </div>
+
+      {/* 외부 데이터 API 키 상태 (BD-7) */}
+      <div className="mb-6">
+        <ApiKeyStatusPanel />
       </div>
 
       {/* 거래 설정 */}

--- a/frontend/src/types/feed.ts
+++ b/frontend/src/types/feed.ts
@@ -1,0 +1,50 @@
+export interface FeedCheckpoint {
+  source: string
+  data_type: string
+  last_date: string
+  updated_at: string
+}
+
+export interface FeedReportSummary {
+  symbols_total: number
+  symbols_success: number
+  symbols_failed: number
+  rows_written: number
+  data_types: string[]
+}
+
+export interface FeedReport {
+  mode: string
+  started_at: string
+  finished_at: string
+  duration_seconds: number
+  target_date: string
+  summary: FeedReportSummary
+  failures: Array<{
+    symbol: string
+    date: string
+    source: string
+    reason: string
+    retries: number
+  }>
+  warnings: Array<{
+    symbol: string
+    date: string
+    type: string
+    message: string
+  }>
+  config_errors: string[]
+}
+
+export interface FeedApiKeyStatus {
+  key: string
+  set: boolean
+  source: string
+}
+
+export interface FeedStatus {
+  initialized: boolean
+  checkpoints: FeedCheckpoint[]
+  recent_reports: FeedReport[]
+  api_keys: FeedApiKeyStatus[]
+}

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 import shutil
 
 from fastapi import APIRouter, Request
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -83,3 +86,67 @@ async def delete_dataset(request: Request, dataset_id: str) -> None:
     if not path.exists():
         raise HTTPException(status_code=404, detail="데이터셋을 찾을 수 없습니다")
     shutil.rmtree(path)
+
+
+@router.get("/feed-status")
+async def get_feed_status(request: Request) -> dict:
+    """Feed 파이프라인 상태 조회.
+
+    Feed 초기화 여부, 소스별 체크포인트 현황, 최근 리포트 요약,
+    API 키 설정 상태를 반환한다.
+    """
+    import json
+    from pathlib import Path
+
+    store = getattr(request.app.state, "data_store", None)
+    data_path: Path | None = getattr(store, "base_path", None) if store else None
+
+    result: dict = {
+        "initialized": False,
+        "checkpoints": [],
+        "recent_reports": [],
+        "api_keys": [],
+    }
+
+    if data_path is None:
+        return result
+
+    try:
+        from ante.feed.config import FeedConfig
+
+        config = FeedConfig(data_path)
+        result["initialized"] = config.is_initialized()
+
+        if not result["initialized"]:
+            # 미초기화 상태에서도 API 키 상태는 반환
+            result["api_keys"] = config.check_api_keys()
+            return result
+
+        # 체크포인트 현황
+        checkpoint_dir = config.feed_dir / "checkpoints"
+        if checkpoint_dir.exists():
+            for cp_file in sorted(checkpoint_dir.glob("*.json")):
+                try:
+                    cp_data = json.loads(cp_file.read_text(encoding="utf-8"))
+                    result["checkpoints"].append(cp_data)
+                except (json.JSONDecodeError, OSError):
+                    logger.warning("체크포인트 파일 읽기 실패: %s", cp_file)
+
+        # 최근 리포트 (최대 5개)
+        reports_dir = config.feed_dir / "reports"
+        if reports_dir.exists():
+            report_files = sorted(reports_dir.glob("*.json"), reverse=True)[:5]
+            for rpt_file in report_files:
+                try:
+                    rpt_data = json.loads(rpt_file.read_text(encoding="utf-8"))
+                    result["recent_reports"].append(rpt_data)
+                except (json.JSONDecodeError, OSError):
+                    logger.warning("리포트 파일 읽기 실패: %s", rpt_file)
+
+        # API 키 상태
+        result["api_keys"] = config.check_api_keys()
+
+    except Exception:
+        logger.exception("Feed 상태 조회 실패")
+
+    return result

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -139,6 +139,92 @@ class TestDataRoutes:
         data = resp.json()
         assert "total_mb" in data
 
+    def test_feed_status_no_store(self, client):
+        resp = client.get("/api/data/feed-status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["initialized"] is False
+        assert data["checkpoints"] == []
+        assert data["recent_reports"] == []
+        assert data["api_keys"] == []
+
+    def test_feed_status_not_initialized(self, tmp_path):
+        from ante.data.store import ParquetStore
+
+        store = ParquetStore(base_path=tmp_path / "data")
+        app = create_app(data_store=store)
+        client = TestClient(app)
+
+        resp = client.get("/api/data/feed-status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["initialized"] is False
+        assert isinstance(data["api_keys"], list)
+
+    def test_feed_status_initialized(self, tmp_path):
+        import json
+
+        from ante.data.store import ParquetStore
+        from ante.feed.config import FeedConfig
+
+        data_path = tmp_path / "data"
+        store = ParquetStore(base_path=data_path)
+        config = FeedConfig(data_path)
+        config.init()
+
+        # 체크포인트 생성
+        cp_dir = config.feed_dir / "checkpoints"
+        cp_dir.mkdir(parents=True, exist_ok=True)
+        (cp_dir / "data_go_kr_ohlcv.json").write_text(
+            json.dumps(
+                {
+                    "source": "data_go_kr",
+                    "data_type": "ohlcv",
+                    "last_date": "2026-03-17",
+                    "updated_at": "2026-03-17T16:00:00Z",
+                }
+            )
+        )
+
+        # 리포트 생성
+        rpt_dir = config.feed_dir / "reports"
+        rpt_dir.mkdir(parents=True, exist_ok=True)
+        (rpt_dir / "2026-03-17-daily.json").write_text(
+            json.dumps(
+                {
+                    "mode": "daily",
+                    "started_at": "2026-03-17T16:00:12Z",
+                    "finished_at": "2026-03-17T16:05:34Z",
+                    "duration_seconds": 322,
+                    "target_date": "2026-03-16",
+                    "summary": {
+                        "symbols_total": 2487,
+                        "symbols_success": 2485,
+                        "symbols_failed": 2,
+                        "rows_written": 2485,
+                        "data_types": ["ohlcv", "fundamental"],
+                    },
+                    "failures": [],
+                    "warnings": [],
+                    "config_errors": [],
+                }
+            )
+        )
+
+        app = create_app(data_store=store)
+        client = TestClient(app)
+
+        resp = client.get("/api/data/feed-status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["initialized"] is True
+        assert len(data["checkpoints"]) == 1
+        assert data["checkpoints"][0]["source"] == "data_go_kr"
+        assert data["checkpoints"][0]["last_date"] == "2026-03-17"
+        assert len(data["recent_reports"]) == 1
+        assert data["recent_reports"][0]["mode"] == "daily"
+        assert isinstance(data["api_keys"], list)
+
 
 # ── Report 라우트 테스트 ────────────────────────
 


### PR DESCRIPTION
## Summary

- **BD-6**: 백테스트 데이터 페이지에 Feed 파이프라인 상태 패널 추가 (초기화 여부, 마지막 실행 결과, 소스별 체크포인트 현황)
- **BD-7**: 설정 페이지에 외부 데이터 API 키(data.go.kr, DART) 상태 패널 추가
- **백엔드**: `GET /api/data/feed-status` 엔드포인트 신규 추가 — FeedConfig를 통해 Feed 상태 일괄 조회

Closes #367

## 변경 파일

| 파일 | 설명 |
|------|------|
| `src/ante/web/routes/data.py` | feed-status API 엔드포인트 추가 |
| `frontend/src/types/feed.ts` | Feed 관련 TypeScript 타입 정의 |
| `frontend/src/api/data.ts` | getFeedStatus API 함수 추가 |
| `frontend/src/hooks/useFeed.ts` | useFeedStatus React Query 훅 |
| `frontend/src/components/data/FeedStatusPanel.tsx` | Feed 파이프라인 상태 패널 (BD-6) |
| `frontend/src/components/data/ApiKeyStatusPanel.tsx` | API 키 상태 패널 (BD-7) |
| `frontend/src/pages/BacktestData.tsx` | FeedStatusPanel 통합 |
| `frontend/src/pages/Settings.tsx` | ApiKeyStatusPanel 통합 |
| `tests/unit/test_web_api.py` | feed-status 엔드포인트 테스트 3건 추가 |

## Test plan

- [x] `pytest tests/ --ignore=tests/e2e` — 1624 passed
- [x] TypeScript 타입 체크 통과
- [x] Vite 빌드 성공
- [ ] Feed 미초기화 상태에서 "미초기화" 배지 및 안내 문구 표시 확인
- [ ] Feed 초기화 후 체크포인트/리포트 데이터 표시 확인
- [ ] 설정 페이지에서 API 키 설정/미설정 상태 배지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)