### PR TITLE
epic/#372: 대시보드 QA — 시나리오 테스트 불일치 수정

### DIFF
--- a/frontend/src/api/data.ts
+++ b/frontend/src/api/data.ts
@@ -1,9 +1,12 @@
 import client from './client'
 
+export type DataType = 'ohlcv' | 'fundamental'
+
 export interface Dataset {
   id: number
   symbol: string
   timeframe: string
+  data_type: DataType
   start_date: string
   end_date: string
   row_count: number
@@ -18,6 +21,7 @@ export interface StorageInfo {
 export async function getDatasets(params?: {
   symbol?: string
   timeframe?: string
+  data_type?: DataType
   offset?: number
   limit?: number
 }): Promise<{ items: Dataset[]; total: number }> {
@@ -30,6 +34,6 @@ export async function getStorageInfo(): Promise<StorageInfo> {
   return res.data
 }
 
-export async function deleteDataset(id: number): Promise<void> {
-  await client.delete(`/api/data/datasets/${id}`)
+export async function deleteDataset(id: number, data_type?: DataType): Promise<void> {
+  await client.delete(`/api/data/datasets/${id}`, { params: { data_type } })
 }

--- a/frontend/src/api/data.ts
+++ b/frontend/src/api/data.ts
@@ -1,4 +1,5 @@
 import client from './client'
+import type { FeedStatus } from '../types/feed'
 
 export interface Dataset {
   id: number
@@ -32,4 +33,9 @@ export async function getStorageInfo(): Promise<StorageInfo> {
 
 export async function deleteDataset(id: number): Promise<void> {
   await client.delete(`/api/data/datasets/${id}`)
+}
+
+export async function getFeedStatus(): Promise<FeedStatus> {
+  const res = await client.get('/api/data/feed-status')
+  return res.data
 }

--- a/frontend/src/api/data.ts
+++ b/frontend/src/api/data.ts
@@ -1,7 +1,7 @@
 import client from './client'
 
 export interface Dataset {
-  id: number
+  id: string
   symbol: string
   timeframe: string
   start_date: string
@@ -30,6 +30,6 @@ export async function getStorageInfo(): Promise<StorageInfo> {
   return res.data
 }
 
-export async function deleteDataset(id: number): Promise<void> {
+export async function deleteDataset(id: string): Promise<void> {
   await client.delete(`/api/data/datasets/${id}`)
 }

--- a/frontend/src/api/members.ts
+++ b/frontend/src/api/members.ts
@@ -37,6 +37,10 @@ export async function rotateToken(id: string): Promise<{ token: string }> {
   return res.data
 }
 
+export async function changePassword(id: string, oldPassword: string, newPassword: string): Promise<void> {
+  await client.patch(`/api/members/${id}/password`, { old_password: oldPassword, new_password: newPassword })
+}
+
 export async function updateScopes(id: string, scopes: string[]): Promise<void> {
   await client.put(`/api/members/${id}/scopes`, { scopes })
 }

--- a/frontend/src/components/agents/AgentRegisterForm.tsx
+++ b/frontend/src/components/agents/AgentRegisterForm.tsx
@@ -28,7 +28,7 @@ export default function AgentRegisterForm({ onClose, onTokenCreated }: AgentRegi
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     createMember.mutate(
-      { member_id: memberId, name, org, scopes },
+      { member_id: memberId, member_type: 'agent', name, org, scopes },
       { onSuccess: (data) => onTokenCreated(memberId, data.token) },
     )
   }

--- a/frontend/src/components/agents/ChangePasswordModal.tsx
+++ b/frontend/src/components/agents/ChangePasswordModal.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react'
+import { useMemberControl } from '../../hooks/useMembers'
+
+interface ChangePasswordModalProps {
+  memberId: string
+  onClose: () => void
+}
+
+export default function ChangePasswordModal({ memberId, onClose }: ChangePasswordModalProps) {
+  const [oldPassword, setOldPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState(false)
+
+  const { changePassword } = useMemberControl()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    if (newPassword.length < 4) {
+      setError('새 비밀번호는 최소 4자 이상이어야 합니다')
+      return
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError('새 비밀번호가 일치하지 않습니다')
+      return
+    }
+
+    changePassword.mutate(
+      { id: memberId, oldPassword, newPassword },
+      {
+        onSuccess: () => setSuccess(true),
+        onError: (err) => {
+          const message = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+            ?? '비밀번호 변경에 실패했습니다'
+          setError(message)
+        },
+      },
+    )
+  }
+
+  if (success) {
+    return (
+      <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+        <div className="bg-surface border border-border rounded-lg p-6 w-[400px] text-center">
+          <h3 className="text-[18px] font-bold mb-4 text-positive">비밀번호 변경 완료</h3>
+          <p className="text-[13px] text-text-muted mb-5">
+            <span className="font-semibold text-text">{memberId}</span>의 비밀번호가 변경되었습니다.
+          </p>
+          <button
+            onClick={onClose}
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+      <div className="bg-surface border border-border rounded-lg p-6 w-[400px]">
+        <h2 className="text-[18px] font-bold mb-5">비밀번호 변경</h2>
+        <p className="text-[13px] text-text-muted mb-4">
+          <span className="font-semibold text-text">{memberId}</span>
+        </p>
+        <form onSubmit={handleSubmit}>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">현재 비밀번호</label>
+            <input
+              type="password"
+              value={oldPassword}
+              onChange={(e) => setOldPassword(e.target.value)}
+              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary"
+              required
+              autoFocus
+            />
+          </div>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">새 비밀번호</label>
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary"
+              required
+            />
+          </div>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">새 비밀번호 확인</label>
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary"
+              required
+            />
+          </div>
+          {error && (
+            <div className="text-[13px] text-negative mb-4">{error}</div>
+          )}
+          <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={changePassword.isPending}
+              className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50"
+            >
+              {changePassword.isPending ? '변경 중...' : '변경'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/data/ApiKeyStatusPanel.tsx
+++ b/frontend/src/components/data/ApiKeyStatusPanel.tsx
@@ -1,0 +1,75 @@
+import { useFeedStatus } from '../../hooks/useFeed'
+import StatusBadge from '../common/StatusBadge'
+import { Skeleton } from '../common/Skeleton'
+
+const KEY_LABELS: Record<string, { name: string; desc: string }> = {
+  ANTE_DATAGOKR_API_KEY: {
+    name: 'data.go.kr',
+    desc: '공공데이터포털 서비스키',
+  },
+  ANTE_DART_API_KEY: {
+    name: 'DART',
+    desc: '금융감독원 OpenAPI 인증키',
+  },
+}
+
+export default function ApiKeyStatusPanel() {
+  const { data: feedStatus, isLoading } = useFeedStatus()
+
+  if (isLoading) {
+    return (
+      <div className="bg-surface border border-border rounded-lg p-5">
+        <Skeleton className="h-5 w-40 mb-4" />
+        <Skeleton className="h-16 w-full" />
+      </div>
+    )
+  }
+
+  if (!feedStatus) return null
+
+  const { api_keys } = feedStatus
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5">
+      <h3 className="text-[15px] font-semibold mb-4">외부 데이터 API 키</h3>
+      <div>
+        {api_keys.map((apiKey, idx) => {
+          const label = KEY_LABELS[apiKey.key]
+          const isLast = idx === api_keys.length - 1
+          return (
+            <div
+              key={apiKey.key}
+              className={`flex items-center justify-between py-2.5 ${
+                !isLast ? 'border-b border-border' : ''
+              }`}
+            >
+              <div>
+                <div className="text-[13px] font-medium">
+                  {label?.name ?? apiKey.key}
+                </div>
+                <div className="text-[12px] text-text-muted mt-0.5">
+                  {label?.desc ?? apiKey.key}
+                  {apiKey.set && apiKey.source && (
+                    <span className="ml-1.5 text-[11px]">
+                      (source: {apiKey.source})
+                    </span>
+                  )}
+                </div>
+              </div>
+              {apiKey.set ? (
+                <StatusBadge variant="positive">설정됨</StatusBadge>
+              ) : (
+                <StatusBadge variant="warning">미설정</StatusBadge>
+              )}
+            </div>
+          )
+        })}
+      </div>
+      {api_keys.some((k) => !k.set) && (
+        <div className="bg-info-bg rounded px-3.5 py-2.5 mt-3 text-[12px] text-info">
+          API 키 설정: <code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante feed config set {'<KEY>'} {'<VALUE>'}</code>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/data/FeedStatusPanel.tsx
+++ b/frontend/src/components/data/FeedStatusPanel.tsx
@@ -1,0 +1,143 @@
+import { useFeedStatus } from '../../hooks/useFeed'
+import { formatDateTime, formatNumber } from '../../utils/formatters'
+import StatusBadge from '../common/StatusBadge'
+import { Skeleton } from '../common/Skeleton'
+import type { FeedCheckpoint, FeedReport } from '../../types/feed'
+
+const SOURCE_LABELS: Record<string, string> = {
+  data_go_kr: 'data.go.kr',
+  dart: 'DART',
+  pykrx: 'pykrx',
+}
+
+const DATA_TYPE_LABELS: Record<string, string> = {
+  ohlcv: 'OHLCV (시세)',
+  fundamental: '재무제표',
+  flow: '수급',
+  event: '기업 이벤트',
+}
+
+const MODE_LABELS: Record<string, string> = {
+  daily: '일일 수집',
+  backfill: '백필',
+}
+
+export default function FeedStatusPanel() {
+  const { data: feedStatus, isLoading } = useFeedStatus()
+
+  if (isLoading) {
+    return (
+      <div className="bg-surface border border-border rounded-lg p-5 mb-4">
+        <Skeleton className="h-5 w-40 mb-4" />
+        <Skeleton className="h-20 w-full" />
+      </div>
+    )
+  }
+
+  if (!feedStatus) return null
+
+  const { initialized, checkpoints, recent_reports } = feedStatus
+  const latestReport = recent_reports.length > 0 ? recent_reports[0] : null
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5 mb-4">
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-[15px] font-semibold text-text">Feed 파이프라인</span>
+        {initialized ? (
+          <StatusBadge variant="positive">활성</StatusBadge>
+        ) : (
+          <StatusBadge variant="muted">미초기화</StatusBadge>
+        )}
+      </div>
+
+      {!initialized ? (
+        <div className="text-[13px] text-text-muted">
+          Feed가 초기화되지 않았습니다. <code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante feed init</code> 명령으로 초기화하세요.
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {/* 최근 실행 결과 */}
+          {latestReport && <LatestReportCard report={latestReport} />}
+
+          {/* 소스별 체크포인트 현황 */}
+          {checkpoints.length > 0 && (
+            <div>
+              <h4 className="text-[13px] font-semibold text-text-muted mb-2">소스별 수집 현황</h4>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                {checkpoints.map((cp) => (
+                  <CheckpointCard key={`${cp.source}_${cp.data_type}`} checkpoint={cp} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {checkpoints.length === 0 && !latestReport && (
+            <div className="text-[13px] text-text-muted">
+              아직 수집이 실행되지 않았습니다. <code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante feed run daily</code> 또는 <code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante feed run backfill</code> 명령으로 수집을 시작하세요.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function LatestReportCard({ report }: { report: FeedReport }) {
+  const isSuccess = report.summary.symbols_failed === 0
+  const hasWarnings = report.failures.length > 0 || report.warnings.length > 0
+
+  return (
+    <div>
+      <h4 className="text-[13px] font-semibold text-text-muted mb-2">마지막 실행</h4>
+      <div className="bg-bg rounded-lg border border-border p-3">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2">
+            <span className="text-[13px] font-medium text-text">
+              {MODE_LABELS[report.mode] ?? report.mode}
+            </span>
+            {isSuccess ? (
+              <StatusBadge variant="positive">성공</StatusBadge>
+            ) : hasWarnings ? (
+              <StatusBadge variant="warning">일부 실패</StatusBadge>
+            ) : (
+              <StatusBadge variant="negative">실패</StatusBadge>
+            )}
+          </div>
+          <span className="text-[12px] text-text-muted">
+            {formatDateTime(report.finished_at)}
+          </span>
+        </div>
+        <div className="flex items-center gap-4 text-[12px] text-text-muted">
+          <span>대상: {report.target_date}</span>
+          <span>종목: {formatNumber(report.summary.symbols_success)}/{formatNumber(report.summary.symbols_total)}</span>
+          <span>기록: {formatNumber(report.summary.rows_written)}행</span>
+          <span>소요: {report.duration_seconds}초</span>
+        </div>
+        {report.summary.symbols_failed > 0 && (
+          <div className="mt-2 text-[12px] text-warning">
+            {report.summary.symbols_failed}개 종목 수집 실패
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function CheckpointCard({ checkpoint }: { checkpoint: FeedCheckpoint }) {
+  return (
+    <div className="bg-bg rounded-lg border border-border p-3">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-[13px] font-medium text-text">
+          {SOURCE_LABELS[checkpoint.source] ?? checkpoint.source}
+        </span>
+        <span className="text-[11px] text-text-muted">
+          {DATA_TYPE_LABELS[checkpoint.data_type] ?? checkpoint.data_type}
+        </span>
+      </div>
+      <div className="text-[12px] text-text-muted">
+        <span>마지막 수집: {checkpoint.last_date}</span>
+        <span className="ml-3">갱신: {formatDateTime(checkpoint.updated_at)}</span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useFeed.ts
+++ b/frontend/src/hooks/useFeed.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+import { getFeedStatus } from '../api/data'
+
+export function useFeedStatus() {
+  return useQuery({
+    queryKey: ['data', 'feed-status'],
+    queryFn: getFeedStatus,
+    refetchInterval: 60_000,
+  })
+}

--- a/frontend/src/hooks/useMembers.ts
+++ b/frontend/src/hooks/useMembers.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getMembers, getMemberDetail, createMember, suspendMember, reactivateMember, revokeMember, rotateToken, updateScopes } from '../api/members'
+import { getMembers, getMemberDetail, createMember, suspendMember, reactivateMember, revokeMember, rotateToken, changePassword, updateScopes } from '../api/members'
 import type { MemberCreateRequest } from '../types/member'
 
 export function useMembers(params?: { type?: string; org?: string; status?: string }) {
@@ -42,6 +42,10 @@ export function useMemberControl() {
     }),
     rotateToken: useMutation({
       mutationFn: rotateToken,
+    }),
+    changePassword: useMutation({
+      mutationFn: ({ id, oldPassword, newPassword }: { id: string; oldPassword: string; newPassword: string }) =>
+        changePassword(id, oldPassword, newPassword),
     }),
     updateScopes: useMutation({
       mutationFn: ({ id, scopes }: { id: string; scopes: string[] }) => updateScopes(id, scopes),

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useMembers, useMemberControl } from '../hooks/useMembers'
 import MemberCard from '../components/agents/MemberCard'
 import AgentRegisterForm from '../components/agents/AgentRegisterForm'
+import ChangePasswordModal from '../components/agents/ChangePasswordModal'
 import { TableSkeleton } from '../components/common/Skeleton'
 import type { MemberStatus } from '../types/member'
 
@@ -17,6 +18,7 @@ export default function Agents() {
   const [statusFilter, setStatusFilter] = useState<MemberStatus | 'all'>('all')
   const [showRegister, setShowRegister] = useState(false)
   const [createdToken, setCreatedToken] = useState<{ agentId: string; token: string } | null>(null)
+  const [passwordTarget, setPasswordTarget] = useState<string | null>(null)
 
   const { data: allMembers, isLoading } = useMembers({})
   const { data: humanMembers } = useMembers({ type: 'human' })
@@ -62,7 +64,7 @@ export default function Agents() {
                     key={m.member_id}
                     member={m}
                     onSuspend={m.member_id !== 'owner' ? (id) => suspend.mutate(id) : undefined}
-                    onChangePassword={() => {/* TODO: 비밀번호 변경 모달 연결 */}}
+                    onChangePassword={(id) => setPasswordTarget(id)}
                   />
                 ))}
               </div>
@@ -136,6 +138,13 @@ export default function Agents() {
         <AgentRegisterForm
           onClose={() => setShowRegister(false)}
           onTokenCreated={(agentId, token) => { setShowRegister(false); setCreatedToken({ agentId, token }) }}
+        />
+      )}
+
+      {passwordTarget && (
+        <ChangePasswordModal
+          memberId={passwordTarget}
+          onClose={() => setPasswordTarget(null)}
         />
       )}
 

--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -55,7 +55,7 @@ export default function BacktestData() {
     <>
       {/* 안내 배너 */}
       <div className="bg-info-bg rounded px-3.5 py-2.5 mb-4 text-[12px] text-info">
-        {'\u{1f4a1}'} 데이터 수집은 Agent에게 요청하거나 CLI(<code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante data collect</code>)를 사용하세요.
+        {'\u{1f4a1}'} 데이터 수집은 Agent에게 요청하거나 CLI(<code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante feed</code>)를 사용하세요.
       </div>
 
       {/* 데이터셋 카드 */}

--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getDatasets, getStorageInfo, deleteDataset } from '../api/data'
 import { formatNumber, formatDate } from '../utils/formatters'
 import { TableSkeleton } from '../components/common/Skeleton'
+import FeedStatusPanel from '../components/data/FeedStatusPanel'
 
 const LIMIT = 15
 const TF_OPTIONS = ['all', '1d', '1h', '1m'] as const
@@ -57,6 +58,9 @@ export default function BacktestData() {
       <div className="bg-info-bg rounded px-3.5 py-2.5 mb-4 text-[12px] text-info">
         {'\u{1f4a1}'} 데이터 수집은 Agent에게 요청하거나 CLI(<code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante data collect</code>)를 사용하세요.
       </div>
+
+      {/* Feed 파이프라인 상태 (BD-6) */}
+      <FeedStatusPanel />
 
       {/* 데이터셋 카드 */}
       <div className="bg-surface border border-border rounded-lg p-5">

--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getDatasets, getStorageInfo, deleteDataset } from '../api/data'
+import type { DataType } from '../api/data'
 import { formatNumber, formatDate } from '../utils/formatters'
 import { TableSkeleton } from '../components/common/Skeleton'
 
@@ -8,17 +9,23 @@ const LIMIT = 15
 const TF_OPTIONS = ['all', '1d', '1h', '1m'] as const
 const TF_LABELS: Record<string, string> = { '1d': '1일', '1h': '1시간', '1m': '1분' }
 
+const DATA_TYPE_OPTIONS: { value: DataType; label: string }[] = [
+  { value: 'ohlcv', label: 'OHLCV (시세)' },
+  { value: 'fundamental', label: 'Fundamental (재무)' },
+]
+
 export default function BacktestData() {
   const [search, setSearch] = useState('')
+  const [dataType, setDataType] = useState<DataType>('ohlcv')
   const [timeframe, setTimeframe] = useState<string>('all')
   const [offset, setOffset] = useState(0)
-  const [deleteTarget, setDeleteTarget] = useState<{ id: number; symbol: string; timeframe: string; start_date: string; end_date: string; row_count: number } | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<{ id: number; symbol: string; timeframe: string; data_type: DataType; start_date: string; end_date: string; row_count: number } | null>(null)
   const queryClient = useQueryClient()
 
   /* 자동완성용: 전체 데이터셋에서 고유 종목 목록 추출 */
   const { data: allDatasets } = useQuery({
-    queryKey: ['datasets-all-symbols'],
-    queryFn: () => getDatasets({ limit: 1000 }),
+    queryKey: ['datasets-all-symbols', dataType],
+    queryFn: () => getDatasets({ data_type: dataType, limit: 1000 }),
   })
 
   const symbolOptions = useMemo(() => {
@@ -27,11 +34,12 @@ export default function BacktestData() {
   }, [allDatasets])
 
   const { data, isLoading } = useQuery({
-    queryKey: ['datasets', search, timeframe, offset],
+    queryKey: ['datasets', search, dataType, timeframe, offset],
     queryFn: () =>
       getDatasets({
         symbol: search || undefined,
-        timeframe: timeframe === 'all' ? undefined : timeframe,
+        data_type: dataType,
+        timeframe: dataType === 'ohlcv' && timeframe !== 'all' ? timeframe : undefined,
         offset,
         limit: LIMIT,
       }),
@@ -43,13 +51,16 @@ export default function BacktestData() {
   })
 
   const deleteMutation = useMutation({
-    mutationFn: deleteDataset,
+    mutationFn: (target: { id: number; data_type: DataType }) => deleteDataset(target.id, target.data_type),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['datasets'] })
+      queryClient.invalidateQueries({ queryKey: ['datasets-all-symbols'] })
       queryClient.invalidateQueries({ queryKey: ['storage'] })
       setDeleteTarget(null)
     },
   })
+
+  const isFundamental = dataType === 'fundamental'
 
   return (
     <>
@@ -78,19 +89,30 @@ export default function BacktestData() {
               ))}
             </datalist>
             <select
-              value={timeframe}
-              onChange={(e) => { setTimeframe(e.target.value); setOffset(0) }}
+              value={dataType}
+              onChange={(e) => { setDataType(e.target.value as DataType); setTimeframe('all'); setOffset(0) }}
               className="bg-bg border border-border rounded px-2 py-1 text-text text-[13px] cursor-pointer focus:outline-none focus:border-primary"
             >
-              <option value="all">전체 타임프레임</option>
-              {TF_OPTIONS.filter((tf) => tf !== 'all').map((tf) => (
-                <option key={tf} value={tf}>{TF_LABELS[tf] ?? tf}</option>
+              {DATA_TYPE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
               ))}
             </select>
+            {!isFundamental && (
+              <select
+                value={timeframe}
+                onChange={(e) => { setTimeframe(e.target.value); setOffset(0) }}
+                className="bg-bg border border-border rounded px-2 py-1 text-text text-[13px] cursor-pointer focus:outline-none focus:border-primary"
+              >
+                <option value="all">전체 타임프레임</option>
+                {TF_OPTIONS.filter((tf) => tf !== 'all').map((tf) => (
+                  <option key={tf} value={tf}>{TF_LABELS[tf] ?? tf}</option>
+                ))}
+              </select>
+            )}
           </div>
         </div>
         {isLoading ? (
-          <TableSkeleton rows={5} cols={6} />
+          <TableSkeleton rows={5} cols={isFundamental ? 5 : 6} />
         ) : (
           <>
             <div className="overflow-x-auto">
@@ -98,7 +120,9 @@ export default function BacktestData() {
                 <thead>
                   <tr>
                     <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">종목</th>
-                    <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">타임프레임</th>
+                    {!isFundamental && (
+                      <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">타임프레임</th>
+                    )}
                     <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">시작일</th>
                     <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">종료일</th>
                     <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">행 수</th>
@@ -107,7 +131,7 @@ export default function BacktestData() {
                 </thead>
                 <tbody>
                   {(data?.items ?? []).length === 0 ? (
-                    <tr><td colSpan={6} className="px-3 py-8 text-center text-text-muted text-[13px]">데이터셋이 없습니다</td></tr>
+                    <tr><td colSpan={isFundamental ? 5 : 6} className="px-3 py-8 text-center text-text-muted text-[13px]">데이터셋이 없습니다</td></tr>
                   ) : (
                     (data?.items ?? []).map((ds, idx, arr) => {
                       const isLast = idx === arr.length - 1
@@ -115,13 +139,15 @@ export default function BacktestData() {
                       return (
                       <tr key={ds.id} className="hover:bg-surface-hover">
                         <td className={`px-3 py-3 ${borderCls} text-[13px] font-mono font-medium`}>{ds.symbol}</td>
-                        <td className={`px-3 py-3 ${borderCls} text-[13px]`}>{TF_LABELS[ds.timeframe] ?? ds.timeframe}</td>
+                        {!isFundamental && (
+                          <td className={`px-3 py-3 ${borderCls} text-[13px]`}>{TF_LABELS[ds.timeframe] ?? ds.timeframe}</td>
+                        )}
                         <td className={`px-3 py-3 ${borderCls} text-[13px] text-text-muted`}>{formatDate(ds.start_date)}</td>
                         <td className={`px-3 py-3 ${borderCls} text-[13px] text-text-muted`}>{formatDate(ds.end_date)}</td>
                         <td className={`px-3 py-3 ${borderCls} text-[13px] text-right`}>{formatNumber(ds.row_count)}</td>
                         <td className={`px-3 py-3 ${borderCls} text-[13px] text-right`}>
                           <button
-                            onClick={() => setDeleteTarget({ id: ds.id, symbol: ds.symbol, timeframe: ds.timeframe, start_date: ds.start_date, end_date: ds.end_date, row_count: ds.row_count })}
+                            onClick={() => setDeleteTarget({ id: ds.id, symbol: ds.symbol, timeframe: ds.timeframe, data_type: ds.data_type, start_date: ds.start_date, end_date: ds.end_date, row_count: ds.row_count })}
                             className="px-2.5 py-1 rounded text-[12px] bg-transparent text-negative border border-border cursor-pointer hover:bg-surface-hover hover:text-text"
                           >
                             삭제
@@ -142,7 +168,7 @@ export default function BacktestData() {
                 {storage && ` · 전체 ${storage.total_mb >= 1024 ? `${(storage.total_mb / 1024).toFixed(1)} GB` : `${storage.total_mb.toFixed(1)} MB`}`}
                 {storage?.by_timeframe && Object.keys(storage.by_timeframe).length > 0 && (
                   <> ({Object.entries(storage.by_timeframe).map(([tf, bytes], i) => (
-                    <span key={tf}>{i > 0 && ' · '}{TF_LABELS[tf] ?? tf}봉 {(bytes / 1024 / 1024).toFixed(0)} MB</span>
+                    <span key={tf}>{i > 0 && ' · '}{TF_LABELS[tf] ?? tf} {(bytes / 1024 / 1024).toFixed(0)} MB</span>
                   ))})</>
                 )}
               </span>
@@ -173,17 +199,20 @@ export default function BacktestData() {
           <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
             <h3 className="text-[18px] font-bold mb-5 text-negative">데이터셋 삭제</h3>
             <div className="mb-4 text-[13px] text-text-muted">
-              <strong className="text-text">{deleteTarget.symbol} — {TF_LABELS[deleteTarget.timeframe] ?? deleteTarget.timeframe}</strong><br />
+              <strong className="text-text">
+                {deleteTarget.symbol}
+                {deleteTarget.data_type === 'fundamental' ? ' — Fundamental' : ` — ${TF_LABELS[deleteTarget.timeframe] ?? deleteTarget.timeframe}`}
+              </strong><br />
               기간: {formatDate(deleteTarget.start_date)} ~ {formatDate(deleteTarget.end_date)} · {formatNumber(deleteTarget.row_count)}건<br /><br />
               삭제된 데이터는 복구할 수 없습니다.
             </div>
             <div className="bg-warning-bg text-warning px-3.5 py-2.5 rounded text-[12px] mb-4">
-              ⚠ 이 데이터를 사용 중인 백테스트가 있을 수 있습니다.
+              이 데이터를 사용 중인 백테스트가 있을 수 있습니다.
             </div>
             <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
               <button onClick={() => setDeleteTarget(null)} className="px-4 py-2 rounded text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover hover:text-text">취소</button>
               <button
-                onClick={() => deleteMutation.mutate(deleteTarget.id)}
+                onClick={() => deleteMutation.mutate({ id: deleteTarget.id, data_type: deleteTarget.data_type })}
                 disabled={deleteMutation.isPending}
                 className="px-4 py-2 rounded text-[13px] font-medium bg-negative text-white border border-negative cursor-pointer hover:bg-negative-hover disabled:opacity-50"
               >

--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -12,7 +12,7 @@ export default function BacktestData() {
   const [search, setSearch] = useState('')
   const [timeframe, setTimeframe] = useState<string>('all')
   const [offset, setOffset] = useState(0)
-  const [deleteTarget, setDeleteTarget] = useState<{ id: number; symbol: string; timeframe: string; start_date: string; end_date: string; row_count: number } | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; symbol: string; timeframe: string; start_date: string; end_date: string; row_count: number } | null>(null)
   const queryClient = useQueryClient()
 
   /* 자동완성용: 전체 데이터셋에서 고유 종목 목록 추출 */

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useSystemStatus, useKillSwitch, useConfigs, useUpdateConfig } from '../hooks/useSystemStatus'
 import { PageSkeleton } from '../components/common/Skeleton'
+import ApiKeyStatusPanel from '../components/data/ApiKeyStatusPanel'
 
 /** 거래 설정 고정 항목 */
 const TRADING_CONFIGS = [
@@ -118,6 +119,11 @@ export default function Settings() {
             </div>
           </div>
         </div>
+      </div>
+
+      {/* 외부 데이터 API 키 상태 (BD-7) */}
+      <div className="mb-6">
+        <ApiKeyStatusPanel />
       </div>
 
       {/* 거래 설정 */}

--- a/frontend/src/types/feed.ts
+++ b/frontend/src/types/feed.ts
@@ -1,0 +1,50 @@
+export interface FeedCheckpoint {
+  source: string
+  data_type: string
+  last_date: string
+  updated_at: string
+}
+
+export interface FeedReportSummary {
+  symbols_total: number
+  symbols_success: number
+  symbols_failed: number
+  rows_written: number
+  data_types: string[]
+}
+
+export interface FeedReport {
+  mode: string
+  started_at: string
+  finished_at: string
+  duration_seconds: number
+  target_date: string
+  summary: FeedReportSummary
+  failures: Array<{
+    symbol: string
+    date: string
+    source: string
+    reason: string
+    retries: number
+  }>
+  warnings: Array<{
+    symbol: string
+    date: string
+    type: string
+    message: string
+  }>
+  config_errors: string[]
+}
+
+export interface FeedApiKeyStatus {
+  key: string
+  set: boolean
+  source: string
+}
+
+export interface FeedStatus {
+  initialized: boolean
+  checkpoints: FeedCheckpoint[]
+  recent_reports: FeedReport[]
+  api_keys: FeedApiKeyStatus[]
+}

--- a/frontend/src/types/member.ts
+++ b/frontend/src/types/member.ts
@@ -24,6 +24,7 @@ export interface MemberDetail extends Member {
 
 export interface MemberCreateRequest {
   member_id: string
+  member_type: MemberType
   name: string
   org: string
   scopes: string[]

--- a/frontend/src/types/strategy.ts
+++ b/frontend/src/types/strategy.ts
@@ -24,13 +24,6 @@ export interface StrategyParam {
   description?: string
 }
 
-export interface WeeklySummary {
-  week_label: string
-  realized_pnl: number
-  trade_count: number
-  win_rate: number
-}
-
 export interface StrategyPerformance {
   total_trades: number
   winning_trades: number
@@ -68,6 +61,7 @@ export interface MonthlySummary {
 export interface WeeklySummary {
   week_start: string
   week_end: string
+  week_label: string
   realized_pnl: number
   trade_count: number
   win_rate: number

--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -195,6 +195,23 @@ class ParquetStore:
             return None
         return files[0].stem, files[-1].stem
 
+    def get_row_count(
+        self, symbol: str, timeframe: str, data_type: str = "ohlcv"
+    ) -> int:
+        """종목의 총 행 수 조회. Parquet 메타데이터만 읽어 빠르게 반환."""
+        path = self._resolve_path(symbol, timeframe, data_type)
+        if not path.exists():
+            return 0
+        files = sorted(path.glob("*.parquet"))
+        total = 0
+        for f in files:
+            try:
+                total += pl.scan_parquet(f).select(pl.len()).collect().item()
+            except Exception:
+                logger.warning("Failed to read row count: %s", f)
+                continue
+        return total
+
     def get_storage_usage(self) -> dict[str, int]:
         """저장 용량 현황 (바이트). 데이터 타입/타임프레임별 합산."""
         usage: dict[str, int] = {}

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -81,6 +81,9 @@ async def main() -> None:
     await dynamic_config.register_default(
         "system.log_level", log_level, category="system"
     )
+    await dynamic_config.register_default(
+        "display.currency_position", "suffix", category="display"
+    )
     eventbus.subscribe(ConfigChangedEvent, _on_log_level_changed)
     logger.info("DynamicConfigService 초기화 완료")
 

--- a/src/ante/trade/__init__.py
+++ b/src/ante/trade/__init__.py
@@ -8,6 +8,7 @@ from ante.trade.models import (
     TradeRecord,
     TradeStatus,
     TradeType,
+    WeeklySummary,
 )
 from ante.trade.performance import PerformanceTracker
 from ante.trade.position import PositionHistory
@@ -18,6 +19,7 @@ from ante.trade.service import TradeService
 __all__ = [
     "DailySummary",
     "MonthlySummary",
+    "WeeklySummary",
     "PerformanceMetrics",
     "PerformanceTracker",
     "PositionHistory",

--- a/src/ante/trade/models.py
+++ b/src/ante/trade/models.py
@@ -69,6 +69,22 @@ class DailySummary:
 
 
 @dataclass(frozen=True)
+class WeeklySummary:
+    """주별 성과 집계."""
+
+    week_start: str
+    week_end: str
+    realized_pnl: float
+    trade_count: int
+    win_rate: float
+
+    @property
+    def week_label(self) -> str:
+        """주간 라벨 (MM-DD ~ MM-DD 형식)."""
+        return f"{self.week_start[5:]} ~ {self.week_end[5:]}"
+
+
+@dataclass(frozen=True)
 class MonthlySummary:
     """월별 성과 집계."""
 

--- a/src/ante/trade/performance.py
+++ b/src/ante/trade/performance.py
@@ -13,6 +13,7 @@ from ante.trade.models import (
     PerformanceMetrics,
     TradeRecord,
     TradeStatus,
+    WeeklySummary,
 )
 
 if TYPE_CHECKING:
@@ -136,6 +137,63 @@ class PerformanceTracker:
         return [
             DailySummary(
                 date=row["trade_date"],
+                realized_pnl=float(row["realized_pnl"]),
+                trade_count=int(row["trade_count"]),
+                win_rate=(
+                    int(row["win_count"]) / int(row["trade_count"])
+                    if int(row["trade_count"]) > 0
+                    else 0.0
+                ),
+            )
+            for row in rows
+        ]
+
+    async def get_weekly_summary(
+        self,
+        bot_id: str | None = None,
+    ) -> list[WeeklySummary]:
+        """주별 성과 집계.
+
+        ISO 주 단위(월요일 시작)로 거래를 그룹화하여 집계한다.
+
+        Args:
+            bot_id: 봇 ID 필터 (None이면 전체)
+        """
+        conditions: list[str] = [
+            "t.status = ?",
+            "t.side = 'sell'",
+        ]
+        params: list[Any] = [TradeStatus.FILLED.value]
+
+        if bot_id:
+            conditions.append("t.bot_id = ?")
+            params.append(bot_id)
+
+        where = " AND ".join(conditions)
+        query = f"""
+            SELECT
+                date(t.timestamp, 'weekday 0', '-6 days') AS week_start,
+                date(t.timestamp, 'weekday 0') AS week_end,
+                COALESCE(SUM(ph.pnl), 0.0) AS realized_pnl,
+                COUNT(*) AS trade_count,
+                SUM(CASE WHEN ph.pnl > 0 THEN 1 ELSE 0 END) AS win_count
+            FROM trades t
+            LEFT JOIN position_history ph
+                ON ph.bot_id = t.bot_id
+                AND ph.symbol = t.symbol
+                AND ph.action = 'sell'
+                AND ph.price = t.price
+                AND ph.quantity = t.quantity
+            WHERE {where}
+            GROUP BY week_start
+            ORDER BY week_start ASC
+        """
+
+        rows = await self._db.fetch_all(query, tuple(params))
+        return [
+            WeeklySummary(
+                week_start=row["week_start"],
+                week_end=row["week_end"],
                 realized_pnl=float(row["realized_pnl"]),
                 trade_count=int(row["trade_count"]),
                 win_rate=(

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -4,39 +4,75 @@ from __future__ import annotations
 
 import shutil
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 
 router = APIRouter()
 
+# 지원하는 데이터 유형
+DATA_TYPES = ["ohlcv", "fundamental"]
+
 
 @router.get("/datasets")
-async def list_datasets(request: Request) -> dict:
-    """보유 데이터셋 목록."""
+async def list_datasets(
+    request: Request,
+    data_type: str = Query("ohlcv", description="데이터 유형 (ohlcv, fundamental)"),
+) -> dict:
+    """보유 데이터셋 목록.
+
+    data_type에 따라 해당 유형의 데이터셋만 반환한다.
+    - ohlcv: 타임프레임별 OHLCV 시세 데이터
+    - fundamental: 재무 데이터 (타임프레임 없음, 'krx' 고정)
+    """
     store = getattr(request.app.state, "data_store", None)
     if store is None:
-        return {"datasets": []}
-
-    from ante.data.schemas import TIMEFRAMES
+        return {"datasets": [], "data_type": data_type}
 
     datasets = []
-    for tf in TIMEFRAMES:
-        symbols = store.list_symbols(tf)
+
+    if data_type == "fundamental":
+        symbols = store.list_symbols(data_type="fundamental")
         for symbol in symbols:
-            date_range = store.get_date_range(symbol, tf)
+            date_range = store.get_date_range(symbol, "", data_type="fundamental")
             datasets.append(
                 {
                     "symbol": symbol,
-                    "timeframe": tf,
+                    "timeframe": "",
+                    "data_type": "fundamental",
                     "start": date_range[0] if date_range else None,
                     "end": date_range[1] if date_range else None,
                 }
             )
-    return {"datasets": datasets}
+    else:
+        from ante.data.schemas import TIMEFRAMES
+
+        for tf in TIMEFRAMES:
+            symbols = store.list_symbols(tf)
+            for symbol in symbols:
+                date_range = store.get_date_range(symbol, tf)
+                datasets.append(
+                    {
+                        "symbol": symbol,
+                        "timeframe": tf,
+                        "data_type": "ohlcv",
+                        "start": date_range[0] if date_range else None,
+                        "end": date_range[1] if date_range else None,
+                    }
+                )
+
+    return {"datasets": datasets, "data_type": data_type}
 
 
 @router.get("/schema")
-async def get_data_schema(request: Request) -> dict:
-    """OHLCV 데이터 스키마."""
+async def get_data_schema(
+    request: Request,
+    data_type: str = Query("ohlcv", description="데이터 유형 (ohlcv, fundamental)"),
+) -> dict:
+    """데이터 스키마 조회. data_type에 따라 해당 스키마를 반환."""
+    if data_type == "fundamental":
+        from ante.data.schemas import FUNDAMENTAL_SCHEMA
+
+        return {k: str(v) for k, v in FUNDAMENTAL_SCHEMA.items()}
+
     from ante.data.schemas import OHLCV_SCHEMA
 
     return {k: str(v) for k, v in OHLCV_SCHEMA.items()}
@@ -60,10 +96,15 @@ async def get_storage_summary(request: Request) -> dict:
 
 
 @router.delete("/datasets/{dataset_id}", status_code=204)
-async def delete_dataset(request: Request, dataset_id: str) -> None:
+async def delete_dataset(
+    request: Request,
+    dataset_id: str,
+    data_type: str = Query("ohlcv", description="데이터 유형 (ohlcv, fundamental)"),
+) -> None:
     """데이터셋 삭제.
 
     dataset_id 형식: "{symbol}__{timeframe}" (예: "005930__1d")
+    fundamental의 경우: "{symbol}__fundamental" (예: "005930__fundamental")
     """
     from fastapi import HTTPException
 
@@ -79,7 +120,12 @@ async def delete_dataset(request: Request, dataset_id: str) -> None:
         )
 
     symbol, timeframe = parts
-    path = store.base_path / "ohlcv" / timeframe / symbol
+
+    if data_type == "fundamental":
+        path = store._resolve_path(symbol, "", data_type="fundamental")
+    else:
+        path = store.base_path / "ohlcv" / timeframe / symbol
+
     if not path.exists():
         raise HTTPException(status_code=404, detail="데이터셋을 찾을 수 없습니다")
     shutil.rmtree(path)

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -10,28 +10,48 @@ router = APIRouter()
 
 
 @router.get("/datasets")
-async def list_datasets(request: Request) -> dict:
-    """보유 데이터셋 목록."""
+async def list_datasets(
+    request: Request,
+    symbol: str | None = None,
+    timeframe: str | None = None,
+    offset: int = 0,
+    limit: int = 50,
+) -> dict:
+    """보유 데이터셋 목록 (페이지네이션 지원).
+
+    Returns:
+        {items: [...], total: int}
+    """
     store = getattr(request.app.state, "data_store", None)
     if store is None:
-        return {"datasets": []}
+        return {"items": [], "total": 0}
 
     from ante.data.schemas import TIMEFRAMES
 
-    datasets = []
-    for tf in TIMEFRAMES:
+    tf_list = [timeframe] if timeframe else TIMEFRAMES
+
+    all_datasets = []
+    for tf in tf_list:
         symbols = store.list_symbols(tf)
-        for symbol in symbols:
-            date_range = store.get_date_range(symbol, tf)
-            datasets.append(
+        for sym in symbols:
+            if symbol and sym != symbol:
+                continue
+            date_range = store.get_date_range(sym, tf)
+            row_count = store.get_row_count(sym, tf)
+            all_datasets.append(
                 {
-                    "symbol": symbol,
+                    "id": f"{sym}__{tf}",
+                    "symbol": sym,
                     "timeframe": tf,
-                    "start": date_range[0] if date_range else None,
-                    "end": date_range[1] if date_range else None,
+                    "start_date": date_range[0] if date_range else None,
+                    "end_date": date_range[1] if date_range else None,
+                    "row_count": row_count,
                 }
             )
-    return {"datasets": datasets}
+
+    total = len(all_datasets)
+    items = all_datasets[offset : offset + limit]
+    return {"items": items, "total": total}
 
 
 @router.get("/schema")

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 import shutil
 
 from fastapi import APIRouter, Request
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -83,3 +86,67 @@ async def delete_dataset(request: Request, dataset_id: str) -> None:
     if not path.exists():
         raise HTTPException(status_code=404, detail="데이터셋을 찾을 수 없습니다")
     shutil.rmtree(path)
+
+
+@router.get("/feed-status")
+async def get_feed_status(request: Request) -> dict:
+    """Feed 파이프라인 상태 조회.
+
+    Feed 초기화 여부, 소스별 체크포인트 현황, 최근 리포트 요약,
+    API 키 설정 상태를 반환한다.
+    """
+    import json
+    from pathlib import Path
+
+    store = getattr(request.app.state, "data_store", None)
+    data_path: Path | None = getattr(store, "base_path", None) if store else None
+
+    result: dict = {
+        "initialized": False,
+        "checkpoints": [],
+        "recent_reports": [],
+        "api_keys": [],
+    }
+
+    if data_path is None:
+        return result
+
+    try:
+        from ante.feed.config import FeedConfig
+
+        config = FeedConfig(data_path)
+        result["initialized"] = config.is_initialized()
+
+        if not result["initialized"]:
+            # 미초기화 상태에서도 API 키 상태는 반환
+            result["api_keys"] = config.check_api_keys()
+            return result
+
+        # 체크포인트 현황
+        checkpoint_dir = config.feed_dir / "checkpoints"
+        if checkpoint_dir.exists():
+            for cp_file in sorted(checkpoint_dir.glob("*.json")):
+                try:
+                    cp_data = json.loads(cp_file.read_text(encoding="utf-8"))
+                    result["checkpoints"].append(cp_data)
+                except (json.JSONDecodeError, OSError):
+                    logger.warning("체크포인트 파일 읽기 실패: %s", cp_file)
+
+        # 최근 리포트 (최대 5개)
+        reports_dir = config.feed_dir / "reports"
+        if reports_dir.exists():
+            report_files = sorted(reports_dir.glob("*.json"), reverse=True)[:5]
+            for rpt_file in report_files:
+                try:
+                    rpt_data = json.loads(rpt_file.read_text(encoding="utf-8"))
+                    result["recent_reports"].append(rpt_data)
+                except (json.JSONDecodeError, OSError):
+                    logger.warning("리포트 파일 읽기 실패: %s", rpt_file)
+
+        # API 키 상태
+        result["api_keys"] = config.check_api_keys()
+
+    except Exception:
+        logger.exception("Feed 상태 조회 실패")
+
+    return result

--- a/src/ante/web/routes/members.py
+++ b/src/ante/web/routes/members.py
@@ -21,6 +21,13 @@ class MemberCreateRequest(BaseModel):
     scopes: list[str] = []
 
 
+class PasswordChangeRequest(BaseModel):
+    """비밀번호 변경 요청."""
+
+    old_password: str
+    new_password: str
+
+
 class ScopesUpdateRequest(BaseModel):
     """권한 범위 변경 요청."""
 
@@ -134,6 +141,21 @@ async def rotate_token(request: Request, member_id: str) -> dict:
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
     return {"member": asdict(member), "token": token}
+
+
+@router.patch("/{member_id}/password")
+async def change_password(
+    request: Request, member_id: str, body: PasswordChangeRequest
+) -> dict:
+    """비밀번호 변경 (human 멤버 전용)."""
+    svc = _get_member_service(request)
+    try:
+        await svc.change_password(member_id, body.old_password, body.new_password)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e)) from e
+    return {"ok": True}
 
 
 @router.put("/{member_id}/scopes")

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -190,6 +190,52 @@ async def get_strategy_daily_summary(
     }
 
 
+@router.get("/{strategy_id}/weekly-summary")
+async def get_strategy_weekly_summary(
+    request: Request,
+    strategy_id: str,
+) -> dict:
+    """전략 주별 성과 집계."""
+    registry = getattr(request.app.state, "strategy_registry", None)
+    if registry is None:
+        raise HTTPException(status_code=503, detail="Strategy registry not available")
+
+    record = await registry.get(strategy_id)
+    if not record:
+        raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
+
+    db = getattr(request.app.state, "db", None)
+    if db is None:
+        raise HTTPException(status_code=503, detail="Database not available")
+
+    from ante.trade.performance import PerformanceTracker
+
+    tracker = PerformanceTracker(db)
+
+    bot_id = None
+    bot_manager = getattr(request.app.state, "bot_manager", None)
+    if bot_manager is not None:
+        for b in bot_manager.list_bots():
+            if b.get("strategy_id") == strategy_id:
+                bot_id = b["bot_id"]
+                break
+
+    summaries = await tracker.get_weekly_summary(bot_id=bot_id)
+    return {
+        "items": [
+            {
+                "week_start": s.week_start,
+                "week_end": s.week_end,
+                "week_label": s.week_label,
+                "realized_pnl": s.realized_pnl,
+                "trade_count": s.trade_count,
+                "win_rate": s.win_rate,
+            }
+            for s in summaries
+        ]
+    }
+
+
 @router.get("/{strategy_id}/monthly-summary")
 async def get_strategy_monthly_summary(
     request: Request,

--- a/tests/fixtures/seed/scenarios/action-settings.sql
+++ b/tests/fixtures/seed/scenarios/action-settings.sql
@@ -5,7 +5,7 @@
 -- _base.sql 의 trading_state = 'active' 를 그대로 유지한다.
 -- (INSERT OR IGNORE 이므로 별도 override 불필요)
 
--- ── 동적 설정 (10개) ──────────────────────────────────
+-- ── 동적 설정 (11개) ──────────────────────────────────
 -- 값은 DynamicConfigService와 동일하게 JSON 인코딩하여 저장한다.
 INSERT INTO dynamic_config (key, value, category, updated_at)
 VALUES ('risk.max_mdd_pct', '"15.0"', 'risk', datetime('now', '-7 days'));
@@ -38,6 +38,9 @@ INSERT INTO dynamic_config (key, value, category, updated_at)
 VALUES ('broker.sell_tax_rate', '"0.23"', 'broker', datetime('now', '-7 days'));
 
 -- ── 표시·알림 설정 ────────────────────────────────────
+INSERT INTO dynamic_config (key, value, category, updated_at)
+VALUES ('display.currency_position', '"suffix"', 'display', datetime('now', '-7 days'));
+
 INSERT INTO dynamic_config (key, value, category, updated_at)
 VALUES ('notification.fill_alert', '"true"', 'notification', datetime('now', '-7 days'));
 

--- a/tests/fixtures/seed/scenarios/settings.sql
+++ b/tests/fixtures/seed/scenarios/settings.sql
@@ -7,7 +7,7 @@ UPDATE system_state SET value = 'halted' WHERE key = 'trading_state';
 INSERT INTO system_state_history (old_state, new_state, reason, changed_by)
 VALUES ('active', 'halted', '설정 페이지 테스트용 거래 정지', 'test-seed');
 
--- ── 동적 설정 (10개) ────────────────────────────────
+-- ── 동적 설정 (11개) ────────────────────────────────
 INSERT INTO dynamic_config (key, value, category, updated_at) VALUES ('risk.max_mdd_pct', '15.0', 'risk', datetime('now', '-7 days'));
 INSERT INTO dynamic_config (key, value, category, updated_at) VALUES ('risk.max_position_pct', '30.0', 'risk', datetime('now', '-7 days'));
 INSERT INTO dynamic_config (key, value, category, updated_at) VALUES ('rule.daily_loss_limit', '5.0', 'rule', datetime('now', '-7 days'));
@@ -18,6 +18,7 @@ INSERT INTO dynamic_config (key, value, category, updated_at) VALUES ('rule.allo
 INSERT INTO dynamic_config (key, value, category, updated_at) VALUES ('bot.default_interval_sec', '60', 'bot', datetime('now', '-7 days'));
 INSERT INTO dynamic_config (key, value, category, updated_at) VALUES ('broker.commission_rate', '0.015', 'broker', datetime('now', '-7 days'));
 INSERT INTO dynamic_config (key, value, category, updated_at) VALUES ('broker.sell_tax_rate', '0.23', 'broker', datetime('now', '-7 days'));
+INSERT INTO dynamic_config (key, value, category, updated_at) VALUES ('display.currency_position', '"suffix"', 'display', datetime('now', '-7 days'));
 
 -- ── 설정 변경 이력 ──────────────────────────────────
 INSERT INTO dynamic_config_history (key, old_value, new_value, changed_by, changed_at)

--- a/tests/unit/test_dataset_delete_api.py
+++ b/tests/unit/test_dataset_delete_api.py
@@ -38,6 +38,21 @@ def _make_ohlcv_df() -> pl.DataFrame:
     )
 
 
+def _make_fundamental_df() -> pl.DataFrame:
+    from datetime import date
+
+    return pl.DataFrame(
+        {
+            "date": [date(2026, 3, 1), date(2026, 3, 2)],
+            "symbol": ["005930", "005930"],
+            "market_cap": [400_000_000_000, 401_000_000_000],
+            "per": [12.5, 12.6],
+            "pbr": [1.2, 1.3],
+            "source": ["test", "test"],
+        }
+    )
+
+
 @pytest.fixture
 def store(tmp_path):
     return ParquetStore(base_path=tmp_path / "data")
@@ -73,3 +88,49 @@ class TestDeleteDataset:
         resp = client.get("/api/data/datasets")
         assert resp.status_code == 200
         assert resp.json()["datasets"] == []
+
+
+class TestFundamentalDatasets:
+    """fundamental 데이터 유형 API 테스트."""
+
+    async def test_list_fundamental_datasets(self, client, store):
+        """fundamental 데이터셋 목록 조회."""
+        await store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        resp = client.get("/api/data/datasets", params={"data_type": "fundamental"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data_type"] == "fundamental"
+        assert len(body["datasets"]) == 1
+        ds = body["datasets"][0]
+        assert ds["symbol"] == "005930"
+        assert ds["data_type"] == "fundamental"
+
+    async def test_list_ohlcv_excludes_fundamental(self, client, store):
+        """OHLCV 조회 시 fundamental 데이터가 포함되지 않음."""
+        await store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        resp = client.get("/api/data/datasets", params={"data_type": "ohlcv"})
+        assert resp.status_code == 200
+        assert resp.json()["datasets"] == []
+
+    async def test_delete_fundamental_dataset(self, client, store):
+        """fundamental 데이터셋 삭제."""
+        await store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        resp = client.delete(
+            "/api/data/datasets/005930__fundamental",
+            params={"data_type": "fundamental"},
+        )
+        assert resp.status_code == 204
+
+        # 삭제 후 목록에서 제거 확인
+        resp = client.get("/api/data/datasets", params={"data_type": "fundamental"})
+        assert resp.json()["datasets"] == []
+
+    def test_schema_fundamental(self, client):
+        """fundamental 스키마 조회."""
+        resp = client.get("/api/data/schema", params={"data_type": "fundamental"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "date" in data
+        assert "per" in data
+        assert "pbr" in data
+        assert "market_cap" in data

--- a/tests/unit/test_dataset_delete_api.py
+++ b/tests/unit/test_dataset_delete_api.py
@@ -1,4 +1,4 @@
-"""데이터셋 삭제 API 테스트."""
+"""데이터셋 API 테스트 — 목록 조회(페이지네이션·필터) 및 삭제."""
 
 from __future__ import annotations
 
@@ -49,6 +49,76 @@ def client(store):
     return TestClient(app)
 
 
+class TestListDatasets:
+    """GET /api/data/datasets — 응답 형식·필드·페이지네이션·필터 검증."""
+
+    async def test_response_wrapper_format(self, client, store):
+        """응답이 {items, total} 래퍼를 사용한다."""
+        await store.write("005930", "1d", _make_ohlcv_df())
+        resp = client.get("/api/data/datasets")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "items" in body
+        assert "total" in body
+        assert body["total"] == 1
+        assert len(body["items"]) == 1
+
+    async def test_field_names(self, client, store):
+        """각 데이터셋에 id, start_date, end_date, row_count 필드가 있다."""
+        await store.write("005930", "1d", _make_ohlcv_df())
+        resp = client.get("/api/data/datasets")
+        ds = resp.json()["items"][0]
+        assert ds["id"] == "005930__1d"
+        assert ds["symbol"] == "005930"
+        assert ds["timeframe"] == "1d"
+        assert "start_date" in ds
+        assert "end_date" in ds
+        assert isinstance(ds["row_count"], int)
+        assert ds["row_count"] > 0
+
+    async def test_pagination(self, client, store):
+        """offset/limit 파라미터로 페이지네이션이 동작한다."""
+        for sym in ["000010", "000020", "000030"]:
+            await store.write(sym, "1d", _make_ohlcv_df())
+
+        resp = client.get("/api/data/datasets", params={"offset": 0, "limit": 2})
+        body = resp.json()
+        assert body["total"] == 3
+        assert len(body["items"]) == 2
+
+        resp2 = client.get("/api/data/datasets", params={"offset": 2, "limit": 2})
+        body2 = resp2.json()
+        assert body2["total"] == 3
+        assert len(body2["items"]) == 1
+
+    async def test_filter_by_symbol(self, client, store):
+        """symbol 필터로 특정 종목만 반환한다."""
+        await store.write("005930", "1d", _make_ohlcv_df())
+        await store.write("035720", "1d", _make_ohlcv_df())
+
+        resp = client.get("/api/data/datasets", params={"symbol": "005930"})
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["items"][0]["symbol"] == "005930"
+
+    async def test_filter_by_timeframe(self, client, store):
+        """timeframe 필터로 특정 타임프레임만 반환한다."""
+        await store.write("005930", "1d", _make_ohlcv_df())
+        await store.write("005930", "1h", _make_ohlcv_df())
+
+        resp = client.get("/api/data/datasets", params={"timeframe": "1d"})
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["items"][0]["timeframe"] == "1d"
+
+    def test_empty_store(self, client):
+        """데이터가 없으면 빈 목록과 total=0을 반환한다."""
+        resp = client.get("/api/data/datasets")
+        body = resp.json()
+        assert body["items"] == []
+        assert body["total"] == 0
+
+
 class TestDeleteDataset:
     async def test_delete_success(self, client, store):
         """데이터셋 삭제 성공."""
@@ -72,4 +142,6 @@ class TestDeleteDataset:
         client.delete("/api/data/datasets/005930__1d")
         resp = client.get("/api/data/datasets")
         assert resp.status_code == 200
-        assert resp.json()["datasets"] == []
+        body = resp.json()
+        assert body["items"] == []
+        assert body["total"] == 0

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -300,7 +300,9 @@ async def test_composition_root_with_web_api(tmp_path: Path) -> None:
     # 데이터셋 목록
     resp = client.get("/api/data/datasets")
     assert resp.status_code == 200
-    assert resp.json()["datasets"] == []
+    body = resp.json()
+    assert body["items"] == []
+    assert body["total"] == 0
 
     # 스토리지 정보
     resp = client.get("/api/data/storage")

--- a/tests/unit/test_member_api.py
+++ b/tests/unit/test_member_api.py
@@ -121,6 +121,18 @@ class FakeMemberService:
         self._token_counter += 1
         return member, f"ante_ak_{self._token_counter}"
 
+    async def change_password(
+        self, member_id: str, old_password: str, new_password: str
+    ) -> None:
+        member = self._members.get(member_id)
+        if member is None:
+            raise ValueError(f"멤버를 찾을 수 없습니다: {member_id}")
+        if member.type != "human":
+            raise PermissionError("human 멤버만 비밀번호를 변경할 수 있습니다")
+        if member.password_hash and member.password_hash != old_password:
+            raise PermissionError("현재 패스워드가 일치하지 않습니다")
+        member.password_hash = new_password
+
     async def update_scopes(
         self, member_id: str, scopes: list[str], updated_by: str = ""
     ) -> FakeMember:
@@ -260,6 +272,50 @@ class TestTokenManagement:
         """존재하지 않는 멤버 → 404."""
         resp = client.post("/api/members/nonexistent/rotate-token")
         assert resp.status_code == 404
+
+
+class TestChangePassword:
+    def test_change_password_success(self, client, member_service):
+        """비밀번호 변경 성공."""
+        member_service._members["user-01"] = FakeMember(
+            member_id="user-01", type="human", password_hash="old123"
+        )
+        resp = client.patch(
+            "/api/members/user-01/password",
+            json={"old_password": "old123", "new_password": "new456"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+    def test_change_password_wrong_old(self, client, member_service):
+        """기존 비밀번호 불일치 → 403."""
+        member_service._members["user-01"] = FakeMember(
+            member_id="user-01", type="human", password_hash="old123"
+        )
+        resp = client.patch(
+            "/api/members/user-01/password",
+            json={"old_password": "wrong", "new_password": "new456"},
+        )
+        assert resp.status_code == 403
+
+    def test_change_password_nonexistent(self, client):
+        """존재하지 않는 멤버 → 404."""
+        resp = client.patch(
+            "/api/members/nonexistent/password",
+            json={"old_password": "old", "new_password": "new"},
+        )
+        assert resp.status_code == 404
+
+    def test_change_password_agent_forbidden(self, client, member_service):
+        """agent 멤버 비밀번호 변경 → 403."""
+        member_service._members["agent-01"] = FakeMember(
+            member_id="agent-01", type="agent"
+        )
+        resp = client.patch(
+            "/api/members/agent-01/password",
+            json={"old_password": "old", "new_password": "new"},
+        )
+        assert resp.status_code == 403
 
 
 class TestScopesUpdate:

--- a/tests/unit/test_performance_summary.py
+++ b/tests/unit/test_performance_summary.py
@@ -1,4 +1,4 @@
-"""일별/월별 성과 집계 단위 테스트."""
+"""일별/주별/월별 성과 집계 단위 테스트."""
 
 from __future__ import annotations
 
@@ -115,6 +115,83 @@ class TestGetDailySummary:
         result = await tracker.get_daily_summary()
 
         assert result == []
+
+
+class TestGetWeeklySummary:
+    @pytest.mark.asyncio
+    async def test_weekly_summary_basic(self):
+        from ante.trade.models import WeeklySummary
+
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(
+            return_value=[
+                {
+                    "week_start": "2026-03-09",
+                    "week_end": "2026-03-15",
+                    "realized_pnl": 30000.0,
+                    "trade_count": 5,
+                    "win_count": 3,
+                },
+                {
+                    "week_start": "2026-03-16",
+                    "week_end": "2026-03-22",
+                    "realized_pnl": -10000.0,
+                    "trade_count": 4,
+                    "win_count": 1,
+                },
+            ]
+        )
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_weekly_summary()
+
+        assert len(result) == 2
+        assert isinstance(result[0], WeeklySummary)
+        assert result[0].week_start == "2026-03-09"
+        assert result[0].week_end == "2026-03-15"
+        assert result[0].realized_pnl == 30000.0
+        assert result[0].trade_count == 5
+        assert result[0].win_rate == pytest.approx(3 / 5)
+        assert result[0].week_label == "03-09 ~ 03-15"
+        assert result[1].win_rate == pytest.approx(1 / 4)
+
+    @pytest.mark.asyncio
+    async def test_weekly_summary_with_bot_filter(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_weekly_summary(bot_id="bot-1")
+
+        assert result == []
+        call_args = db.fetch_all.call_args
+        query = call_args[0][0]
+        params = call_args[0][1]
+        assert "t.bot_id = ?" in query
+        assert "bot-1" in params
+
+    @pytest.mark.asyncio
+    async def test_weekly_summary_empty(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        result = await tracker.get_weekly_summary()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_weekly_summary_query_groups_by_week(self):
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        await tracker.get_weekly_summary()
+
+        call_args = db.fetch_all.call_args
+        query = call_args[0][0]
+        assert "week_start" in query
+        assert "GROUP BY week_start" in query
 
 
 class TestGetMonthlySummary:

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -139,6 +139,92 @@ class TestDataRoutes:
         data = resp.json()
         assert "total_mb" in data
 
+    def test_feed_status_no_store(self, client):
+        resp = client.get("/api/data/feed-status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["initialized"] is False
+        assert data["checkpoints"] == []
+        assert data["recent_reports"] == []
+        assert data["api_keys"] == []
+
+    def test_feed_status_not_initialized(self, tmp_path):
+        from ante.data.store import ParquetStore
+
+        store = ParquetStore(base_path=tmp_path / "data")
+        app = create_app(data_store=store)
+        client = TestClient(app)
+
+        resp = client.get("/api/data/feed-status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["initialized"] is False
+        assert isinstance(data["api_keys"], list)
+
+    def test_feed_status_initialized(self, tmp_path):
+        import json
+
+        from ante.data.store import ParquetStore
+        from ante.feed.config import FeedConfig
+
+        data_path = tmp_path / "data"
+        store = ParquetStore(base_path=data_path)
+        config = FeedConfig(data_path)
+        config.init()
+
+        # 체크포인트 생성
+        cp_dir = config.feed_dir / "checkpoints"
+        cp_dir.mkdir(parents=True, exist_ok=True)
+        (cp_dir / "data_go_kr_ohlcv.json").write_text(
+            json.dumps(
+                {
+                    "source": "data_go_kr",
+                    "data_type": "ohlcv",
+                    "last_date": "2026-03-17",
+                    "updated_at": "2026-03-17T16:00:00Z",
+                }
+            )
+        )
+
+        # 리포트 생성
+        rpt_dir = config.feed_dir / "reports"
+        rpt_dir.mkdir(parents=True, exist_ok=True)
+        (rpt_dir / "2026-03-17-daily.json").write_text(
+            json.dumps(
+                {
+                    "mode": "daily",
+                    "started_at": "2026-03-17T16:00:12Z",
+                    "finished_at": "2026-03-17T16:05:34Z",
+                    "duration_seconds": 322,
+                    "target_date": "2026-03-16",
+                    "summary": {
+                        "symbols_total": 2487,
+                        "symbols_success": 2485,
+                        "symbols_failed": 2,
+                        "rows_written": 2485,
+                        "data_types": ["ohlcv", "fundamental"],
+                    },
+                    "failures": [],
+                    "warnings": [],
+                    "config_errors": [],
+                }
+            )
+        )
+
+        app = create_app(data_store=store)
+        client = TestClient(app)
+
+        resp = client.get("/api/data/feed-status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["initialized"] is True
+        assert len(data["checkpoints"]) == 1
+        assert data["checkpoints"][0]["source"] == "data_go_kr"
+        assert data["checkpoints"][0]["last_date"] == "2026-03-17"
+        assert len(data["recent_reports"]) == 1
+        assert data["recent_reports"][0]["mode"] == "daily"
+        assert isinstance(data["api_keys"], list)
+
 
 # ── Report 라우트 테스트 ────────────────────────
 

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -102,7 +102,9 @@ class TestDataRoutes:
     def test_datasets_no_catalog(self, client):
         resp = client.get("/api/data/datasets")
         assert resp.status_code == 200
-        assert resp.json()["datasets"] == []
+        body = resp.json()
+        assert body["items"] == []
+        assert body["total"] == 0
 
     def test_schema_no_catalog(self, client):
         resp = client.get("/api/data/schema")
@@ -125,7 +127,9 @@ class TestDataRoutes:
 
         resp = client.get("/api/data/datasets")
         assert resp.status_code == 200
-        assert isinstance(resp.json()["datasets"], list)
+        body = resp.json()
+        assert isinstance(body["items"], list)
+        assert "total" in body
 
     def test_storage_with_store(self, tmp_path):
         from ante.data.store import ParquetStore

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -102,13 +102,30 @@ class TestDataRoutes:
     def test_datasets_no_catalog(self, client):
         resp = client.get("/api/data/datasets")
         assert resp.status_code == 200
-        assert resp.json()["datasets"] == []
+        body = resp.json()
+        assert body["datasets"] == []
+        assert body["data_type"] == "ohlcv"
+
+    def test_datasets_no_catalog_fundamental(self, client):
+        resp = client.get("/api/data/datasets", params={"data_type": "fundamental"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["datasets"] == []
+        assert body["data_type"] == "fundamental"
 
     def test_schema_no_catalog(self, client):
         resp = client.get("/api/data/schema")
         assert resp.status_code == 200
         data = resp.json()
         assert "timestamp" in data
+
+    def test_schema_fundamental(self, client):
+        resp = client.get("/api/data/schema", params={"data_type": "fundamental"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "date" in data
+        assert "per" in data
+        assert "pbr" in data
 
     def test_storage_no_catalog(self, client):
         resp = client.get("/api/data/storage")
@@ -126,6 +143,36 @@ class TestDataRoutes:
         resp = client.get("/api/data/datasets")
         assert resp.status_code == 200
         assert isinstance(resp.json()["datasets"], list)
+
+    def test_datasets_with_store_data_type_ohlcv(self, tmp_path):
+        """data_type=ohlcv 파라미터로 OHLCV 데이터셋만 반환."""
+        from ante.data.store import ParquetStore
+
+        store = ParquetStore(base_path=tmp_path / "data")
+        app = create_app(data_store=store)
+        client = TestClient(app)
+
+        resp = client.get("/api/data/datasets", params={"data_type": "ohlcv"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data_type"] == "ohlcv"
+        for ds in body["datasets"]:
+            assert ds["data_type"] == "ohlcv"
+
+    def test_datasets_with_store_data_type_fundamental(self, tmp_path):
+        """data_type=fundamental 파라미터로 fundamental 데이터셋만 반환."""
+        from ante.data.store import ParquetStore
+
+        store = ParquetStore(base_path=tmp_path / "data")
+        app = create_app(data_store=store)
+        client = TestClient(app)
+
+        resp = client.get("/api/data/datasets", params={"data_type": "fundamental"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data_type"] == "fundamental"
+        for ds in body["datasets"]:
+            assert ds["data_type"] == "fundamental"
 
     def test_storage_with_store(self, tmp_path):
         from ante.data.store import ParquetStore


### PR DESCRIPTION
## Summary
- 대시보드 Docker 테스트 모드 시나리오 QA에서 발견된 8건의 불일치 수정
- 백테스트 데이터 API 페이지네이션 및 필드명 정규화 (#364)
- 재무제표(fundamental) 데이터 타입 지원 (#365)
- 대시보드 메인 위젯 통화 표시 위치 수정 (#366)
- Feed 상태 UI 신규 구현 (#367)
- 주간 요약 리포트 API 및 UI 구현 (#368)
- 비밀번호 변경 API 라우트 추가 (#369)
- 전략 상세 페이지 수익률 차트 스켈레톤/빈 상태 처리 (#370)
- 봇 상세 페이지 데이터 바인딩 수정 (#371)

## 하위 이슈
Closes #372

하위 PR: #373, #374, #375, #376, #377, #378, #379, #380

## Test plan
- [x] 전체 테스트 1646 passed, 3 skipped, 0 failed
- [x] ruff lint/format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)