### PR TITLE
feat(broker): 브로커 메타정보 동적 표출

### DIFF
--- a/frontend/src/components/treasury/AccountSummary.tsx
+++ b/frontend/src/components/treasury/AccountSummary.tsx
@@ -14,11 +14,14 @@ export default function AccountSummary({ summary }: { summary: TreasurySummary }
 
   return (
     <div className="bg-surface border border-border rounded-lg overflow-hidden mb-6">
-      {/* KIS 헤더 */}
+      {/* 브로커 헤더 */}
       <div className="flex items-center gap-4 px-5 py-3 border-b border-border">
         <div className="flex items-center gap-2">
-          <span className="bg-primary text-white text-[11px] font-bold px-2 py-0.5 rounded">KIS</span>
-          <span className="text-[14px] font-semibold">한국투자증권</span>
+          <span className="bg-primary text-white text-[11px] font-bold px-2 py-0.5 rounded">{summary.broker_short_name || 'KIS'}</span>
+          <span className="text-[14px] font-semibold">{summary.broker_name || '한국투자증권'}</span>
+          {summary.exchange && (
+            <span className="text-[11px] text-text-muted border border-border px-1.5 py-0.5 rounded">{summary.exchange}</span>
+          )}
         </div>
         {summary.account_number && (
           <span className="text-[13px] font-mono">{summary.account_number}</span>

--- a/frontend/src/types/treasury.ts
+++ b/frontend/src/types/treasury.ts
@@ -6,6 +6,11 @@ export interface TreasurySummary {
   total_profit_loss: number
   commission_rate: number
   sell_tax_rate: number
+  // 브로커 메타정보
+  broker_id: string
+  broker_name: string
+  broker_short_name: string
+  exchange: string
   // KIS 계좌 헤더
   account_number: string
   is_demo_trading: boolean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "pytest-cov>=6.0",
     "ruff>=0.8",
     "mypy>=1.13",
+    "httpx>=0.27",
 ]
 e2e = [
     "pytest>=8.0",

--- a/src/ante/broker/base.py
+++ b/src/ante/broker/base.py
@@ -16,6 +16,11 @@ if TYPE_CHECKING:
 class BrokerAdapter(ABC):
     """증권사 API 어댑터 추상 기본 클래스."""
 
+    # 서브클래스에서 오버라이드하는 브로커 메타정보
+    broker_id: str = "unknown"
+    broker_name: str = "Unknown Broker"
+    broker_short_name: str = "UNK"
+
     def __init__(self, config: dict[str, Any]) -> None:
         self.config = config
         self.is_connected: bool = False

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -70,6 +70,10 @@ _AUTH_PATH = "/oauth2/tokenP"
 class KISAdapter(BrokerAdapter):
     """한국투자증권 Open API 어댑터."""
 
+    broker_id: str = "kis"
+    broker_name: str = "한국투자증권"
+    broker_short_name: str = "KIS"
+
     def __init__(
         self,
         config: dict[str, Any],

--- a/src/ante/broker/mock.py
+++ b/src/ante/broker/mock.py
@@ -69,6 +69,10 @@ class MockBrokerAdapter(BrokerAdapter):
         prices: 종목별 현재가 딕셔너리 (예: {"005930": 70000})
     """
 
+    broker_id: str = "mock"
+    broker_name: str = "모의 브로커"
+    broker_short_name: str = "MOCK"
+
     def __init__(self, config: dict[str, Any]) -> None:
         config.setdefault("exchange", "KRX")
         super().__init__(config)

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -435,6 +435,7 @@ async def main() -> None:
             bot_manager=bot_manager,
             trade_service=trade_service,
             treasury=treasury,
+            broker=broker,
             report_store=report_store,
             data_store=parquet_store,
             audit_logger=audit_logger,

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -30,6 +30,14 @@ async def get_summary(request: Request) -> dict:
     summary["commission_rate"] = getattr(treasury, "commission_rate", 0.00015)
     summary["sell_tax_rate"] = getattr(treasury, "sell_tax_rate", 0.0023)
 
+    # 브로커 메타정보
+    broker = getattr(request.app.state, "broker", None)
+    if broker is not None:
+        summary["broker_id"] = broker.broker_id
+        summary["broker_name"] = broker.broker_name
+        summary["broker_short_name"] = broker.broker_short_name
+        summary["exchange"] = broker.exchange
+
     # KIS 계좌 헤더 정보
     config = getattr(request.app.state, "config", None)
     if config is not None:

--- a/tests/unit/test_broker_meta_api.py
+++ b/tests/unit/test_broker_meta_api.py
@@ -1,0 +1,89 @@
+"""브로커 메타정보 API 테스트."""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from ante.broker.base import BrokerAdapter
+from ante.broker.mock import MockBrokerAdapter
+from ante.web.app import create_app
+
+
+class FakeTreasury:
+    """Treasury stub."""
+
+    commission_rate: float = 0.00015
+    sell_tax_rate: float = 0.0023
+    last_synced_at = None
+
+    def get_summary(self) -> dict:
+        return {
+            "account_balance": 10_000_000,
+            "purchasable_amount": 10_000_000,
+            "total_evaluation": 10_000_000,
+            "total_profit_loss": 0,
+            "total_allocated": 0,
+            "total_reserved": 0,
+            "total_available": 10_000_000,
+            "unallocated": 10_000_000,
+            "bot_count": 0,
+        }
+
+
+class TestBrokerMetaInTreasury:
+    """GET /api/treasury 응답에 브로커 메타정보가 포함된다."""
+
+    @pytest.fixture
+    def client_with_broker(self) -> TestClient:
+        broker = MockBrokerAdapter({"exchange": "KRX"})
+        app = create_app(treasury=FakeTreasury(), broker=broker)
+        return TestClient(app)
+
+    @pytest.fixture
+    def client_without_broker(self) -> TestClient:
+        app = create_app(treasury=FakeTreasury())
+        return TestClient(app)
+
+    def test_broker_meta_fields_present(self, client_with_broker: TestClient) -> None:
+        """브로커가 있으면 메타정보 4개 필드가 응답에 포함된다."""
+        resp = client_with_broker.get("/api/treasury")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["broker_id"] == "mock"
+        assert body["broker_name"] == "모의 브로커"
+        assert body["broker_short_name"] == "MOCK"
+        assert body["exchange"] == "KRX"
+
+    def test_no_broker_no_meta(self, client_without_broker: TestClient) -> None:
+        """브로커가 없으면 메타정보 필드가 응답에 없다."""
+        resp = client_without_broker.get("/api/treasury")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "broker_id" not in body
+        assert "broker_name" not in body
+
+
+class TestBrokerAdapterMetaDefaults:
+    """BrokerAdapter 클래스 레벨 메타정보 기본값."""
+
+    def test_base_defaults(self) -> None:
+        """BrokerAdapter 기본 메타정보 값이 정의되어 있다."""
+        assert BrokerAdapter.broker_id == "unknown"
+        assert BrokerAdapter.broker_name == "Unknown Broker"
+        assert BrokerAdapter.broker_short_name == "UNK"
+
+    def test_mock_broker_meta(self) -> None:
+        """MockBrokerAdapter 메타정보가 올바르다."""
+        adapter = MockBrokerAdapter({"exchange": "KRX"})
+        assert adapter.broker_id == "mock"
+        assert adapter.broker_name == "모의 브로커"
+        assert adapter.broker_short_name == "MOCK"
+
+    def test_kis_adapter_meta(self) -> None:
+        """KISAdapter 메타정보가 올바르다 (클래스 속성)."""
+        from ante.broker.kis import KISAdapter
+
+        assert KISAdapter.broker_id == "kis"
+        assert KISAdapter.broker_name == "한국투자증권"
+        assert KISAdapter.broker_short_name == "KIS"


### PR DESCRIPTION
## Summary
Closes #381

- `BrokerAdapter`에 `broker_id`, `broker_name`, `broker_short_name` 클래스 속성 추가
- `KISAdapter`: kis / 한국투자증권 / KIS, `MockBrokerAdapter`: mock / 모의 브로커 / MOCK
- `GET /api/treasury` 응답에 `broker_id`, `broker_name`, `broker_short_name`, `exchange` 포함
- `AccountSummary.tsx` 하드코딩("KIS", "한국투자증권") 제거 → API 데이터 바인딩
- 거래소(exchange) 배지도 헤더에 표시

## Test plan
- [x] 브로커 메타정보 API 응답 검증 (broker 있을 때 / 없을 때)
- [x] BrokerAdapter / MockBrokerAdapter / KISAdapter 클래스 속성 검증
- [x] 전체 테스트 1651 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)