### PR TITLE
feat(cli): Click introspection 기반 CLI 레퍼런스 자동 생성

### DIFF
--- a/scripts/generate_cli_reference.py
+++ b/scripts/generate_cli_reference.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Click introspection 기반 CLI 레퍼런스 문서 자동 생성.
+
+ante CLI의 Click 명령어 트리를 순회하며 docs/generated/cli-reference.md를 생성한다.
+SSOT: Click 데코레이터 → cli-reference.md (자동 생성)
+
+사용법:
+    python scripts/generate_cli_reference.py
+    python scripts/generate_cli_reference.py --output docs/generated/cli-reference.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import TextIO
+
+import click
+
+
+def get_cli() -> click.Group:
+    """ante CLI 루트 그룹을 가져온다."""
+    from ante.cli.main import cli
+
+    return cli
+
+
+# ── Click introspection helpers ──────────────────────────────────────────────
+
+
+def _collect_commands(
+    group: click.Group,
+    prefix: str = "",
+) -> list[tuple[str, click.BaseCommand]]:
+    """명령어 트리를 DFS로 순회하여 (full_name, command) 쌍을 수집한다."""
+    results: list[tuple[str, click.BaseCommand]] = []
+    ctx = click.Context(group, info_name=prefix or group.name or "ante")
+
+    for name in sorted(group.list_commands(ctx)):
+        cmd = group.get_command(ctx, name)
+        if cmd is None:
+            continue
+
+        full_name = f"{prefix} {name}".strip() if prefix else name
+
+        if isinstance(cmd, click.Group):
+            # 그룹 자체도 기록 (설명 포함)
+            results.append((full_name, cmd))
+            # 하위 명령어 재귀 수집
+            results.extend(_collect_commands(cmd, full_name))
+        else:
+            results.append((full_name, cmd))
+
+    return results
+
+
+def _get_params(cmd: click.BaseCommand) -> list[click.Parameter]:
+    """명령어의 파라미터 목록을 반환한다 (help 옵션 제외)."""
+    return [
+        p for p in cmd.params if not (isinstance(p, click.Option) and p.name == "help")
+    ]
+
+
+def _format_param_type(param: click.Parameter) -> str:
+    """파라미터 타입을 문자열로 포맷팅한다."""
+    if isinstance(param.type, click.Choice):
+        return " / ".join(param.type.choices)
+    if isinstance(param.type, click.IntRange):
+        parts = []
+        if param.type.min is not None:
+            parts.append(str(param.type.min))
+        else:
+            parts.append("")
+        if param.type.max is not None:
+            parts.append(str(param.type.max))
+        else:
+            parts.append("")
+        return f"INT ({parts[0]}~{parts[1]})"
+    if isinstance(param.type, click.Path):
+        return "PATH"
+    type_name = param.type.name.upper() if hasattr(param.type, "name") else "TEXT"
+    return type_name
+
+
+def _format_default(param: click.Parameter) -> str:
+    """기본값을 문자열로 포맷팅한다."""
+    if param.default is None:
+        return "\u2014"
+    if isinstance(param.default, bool):
+        return "false" if not param.default else "true"
+    if isinstance(param.default, tuple) and len(param.default) == 0:
+        return "\u2014"
+    return str(param.default)
+
+
+def _is_required(param: click.Parameter) -> str:
+    """필수 여부를 O/- 로 반환한다."""
+    if isinstance(param, click.Argument):
+        return "O" if param.required else "-"
+    if isinstance(param, click.Option):
+        return "O" if param.required else "-"
+    return "-"
+
+
+def _param_display_name(param: click.Parameter) -> str:
+    """파라미터의 표시 이름을 반환한다."""
+    if isinstance(param, click.Argument):
+        human = param.human_readable_name.upper()
+        return f"`<{human}>`"
+    if isinstance(param, click.Option):
+        opts = param.opts + param.secondary_opts
+        return ", ".join(f"`{o}`" for o in opts)
+    return f"`{param.name}`"
+
+
+# ── Markdown generation ──────────────────────────────────────────────────────
+
+
+def _write_header(out: TextIO) -> None:
+    """문서 헤더를 출력한다."""
+    kst = timezone(timedelta(hours=9))
+    today = datetime.now(tz=kst).strftime("%Y-%m-%d")
+    out.write("# Ante CLI Reference\n\n")
+    out.write(
+        "> 이 문서는 `scripts/generate_cli_reference.py`에 의해 "
+        "Click introspection으로 자동 생성됩니다.\n"
+    )
+    out.write("> 직접 수정하지 마세요. CLI 코드 변경 후 스크립트를 재실행하세요.\n")
+    out.write(f">\n> 마지막 갱신: {today}\n\n")
+
+
+def _write_global_options(out: TextIO, cli: click.Group) -> None:
+    """글로벌 옵션 섹션을 출력한다."""
+    out.write("## 글로벌 옵션\n\n")
+    out.write("```bash\nante [OPTIONS] <command>\n```\n\n")
+
+    params = _get_params(cli)
+    if params:
+        out.write("| 옵션 | 타입 | 기본값 | 설명 |\n")
+        out.write("|------|------|--------|------|\n")
+        for p in params:
+            name = _param_display_name(p)
+            ptype = _format_param_type(p)
+            default = _format_default(p)
+            desc = p.help or ""
+            out.write(f"| {name} | {ptype} | {default} | {desc} |\n")
+        out.write("\n")
+
+    out.write("---\n\n")
+
+
+def _write_summary_table(
+    out: TextIO,
+    commands: list[tuple[str, click.BaseCommand]],
+) -> None:
+    """명령어 요약 테이블을 출력한다."""
+    out.write("## 명령어 요약\n\n")
+    out.write("| 명령 | 설명 |\n")
+    out.write("|------|------|\n")
+
+    for full_name, cmd in commands:
+        # 그룹 자체는 요약 테이블에 표시하되 하위 명령어가 있으면 별도 표시
+        help_text = ""
+        if cmd.help:
+            # 첫 줄만 사용
+            help_text = cmd.help.strip().split("\n")[0]
+
+        out.write(f"| `ante {full_name}` | {help_text} |\n")
+
+    out.write("\n---\n\n")
+
+
+def _write_command_detail(
+    out: TextIO,
+    full_name: str,
+    cmd: click.BaseCommand,
+) -> None:
+    """개별 명령어 상세 정보를 출력한다."""
+    # 그룹이면서 직접 실행 불가한 경우 상세를 생략
+    if isinstance(cmd, click.Group):
+        return
+
+    out.write(f"### ante {full_name}\n\n")
+
+    # 설명
+    if cmd.help:
+        out.write(f"{cmd.help.strip()}\n\n")
+
+    params = _get_params(cmd)
+    arguments = [p for p in params if isinstance(p, click.Argument)]
+    options = [p for p in params if isinstance(p, click.Option)]
+
+    # 사용법
+    usage_parts = [f"ante {full_name}"]
+    for arg in arguments:
+        usage_parts.append(f"<{arg.human_readable_name.upper()}>")
+    if options:
+        usage_parts.append("[OPTIONS]")
+    out.write(f"```bash\n{' '.join(usage_parts)}\n```\n\n")
+
+    # Arguments 테이블
+    if arguments:
+        out.write("**Arguments:**\n\n")
+        out.write("| 인자 | 필수 | 설명 |\n")
+        out.write("|------|------|------|\n")
+        for arg in arguments:
+            name = _param_display_name(arg)
+            req = _is_required(arg)
+            desc = getattr(arg, "help", "") or ""
+            out.write(f"| {name} | {req} | {desc} |\n")
+        out.write("\n")
+
+    # Options 테이블
+    if options:
+        out.write("**Options:**\n\n")
+        out.write("| 옵션 | 필수 | 타입 | 기본값 | 설명 |\n")
+        out.write("|------|------|------|--------|------|\n")
+        for opt in options:
+            name = _param_display_name(opt)
+            req = _is_required(opt)
+            ptype = _format_param_type(opt)
+            default = _format_default(opt)
+            desc = opt.help or ""
+            out.write(f"| {name} | {req} | {ptype} | {default} | {desc} |\n")
+        out.write("\n")
+
+    out.write("\n")
+
+
+def _group_by_top_level(
+    commands: list[tuple[str, click.BaseCommand]],
+) -> dict[str, list[tuple[str, click.BaseCommand]]]:
+    """명령어를 최상위 그룹 기준으로 분류한다."""
+    groups: dict[str, list[tuple[str, click.BaseCommand]]] = {}
+    for full_name, cmd in commands:
+        top = full_name.split()[0]
+        groups.setdefault(top, []).append((full_name, cmd))
+    return groups
+
+
+def generate_cli_reference(out: TextIO) -> int:
+    """CLI 레퍼런스 문서를 생성하고 서브커맨드 수를 반환한다."""
+    cli = get_cli()
+
+    commands = _collect_commands(cli)
+    leaf_commands = [(n, c) for n, c in commands if not isinstance(c, click.Group)]
+
+    _write_header(out)
+    _write_global_options(out, cli)
+    _write_summary_table(out, leaf_commands)
+
+    # 그룹별 상세
+    grouped = _group_by_top_level(commands)
+    for group_name in sorted(grouped):
+        items = grouped[group_name]
+        # 그룹 설명 찾기
+        group_cmd = None
+        for _, cmd in items:
+            if isinstance(cmd, click.Group):
+                group_cmd = cmd
+                break
+
+        group_help = ""
+        if group_cmd and group_cmd.help:
+            group_help = f" \u2014 {group_cmd.help.strip().split(chr(10))[0]}"
+
+        out.write(f"## {group_name}{group_help}\n\n")
+
+        for full_name, cmd in items:
+            _write_command_detail(out, full_name, cmd)
+
+        out.write("---\n\n")
+
+    return len(leaf_commands)
+
+
+# ── CLI entrypoint ───────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    """스크립트 진입점."""
+    parser = argparse.ArgumentParser(
+        description="Click introspection 기반 CLI 레퍼런스 문서 자동 생성",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default="docs/generated/cli-reference.md",
+        help="출력 파일 경로 (기본: docs/generated/cli-reference.md)",
+    )
+    parser.add_argument(
+        "--stdout",
+        action="store_true",
+        help="파일 대신 stdout으로 출력",
+    )
+    args = parser.parse_args()
+
+    if args.stdout:
+        count = generate_cli_reference(sys.stdout)
+        print(f"\n<!-- {count} subcommands documented -->", file=sys.stderr)
+    else:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with output_path.open("w", encoding="utf-8") as f:
+            count = generate_cli_reference(f)
+
+        print(f"Generated {output_path} ({count} subcommands)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_generate_cli_reference.py
+++ b/tests/unit/test_generate_cli_reference.py
@@ -1,0 +1,236 @@
+"""scripts/generate_cli_reference.py 동작 검증 테스트."""
+
+from __future__ import annotations
+
+import io
+
+import click
+
+# ── 헬퍼 함수 테스트 ─────────────────────────────────────────────────────────
+
+
+class TestCollectCommands:
+    """_collect_commands가 Click 명령어 트리를 올바르게 순회하는지 검증."""
+
+    def test_collects_leaf_commands(self) -> None:
+        """리프 명령어가 수집된다."""
+        from scripts.generate_cli_reference import _collect_commands
+
+        @click.group()
+        def root() -> None:
+            pass
+
+        @root.command()
+        def sub() -> None:
+            """서브커맨드."""
+
+        result = _collect_commands(root)
+        names = [name for name, _ in result]
+        assert "sub" in names
+
+    def test_collects_nested_commands(self) -> None:
+        """중첩 그룹의 명령어가 수집된다."""
+        from scripts.generate_cli_reference import _collect_commands
+
+        @click.group()
+        def root() -> None:
+            pass
+
+        @root.group()
+        def grp() -> None:
+            """그룹."""
+
+        @grp.command()
+        def leaf() -> None:
+            """리프."""
+
+        result = _collect_commands(root)
+        names = [name for name, _ in result]
+        assert "grp leaf" in names
+
+    def test_groups_are_included(self) -> None:
+        """그룹 자체도 결과에 포함된다."""
+        from scripts.generate_cli_reference import _collect_commands
+
+        @click.group()
+        def root() -> None:
+            pass
+
+        @root.group()
+        def grp() -> None:
+            """그룹."""
+
+        @grp.command()
+        def leaf() -> None:
+            """리프."""
+
+        result = _collect_commands(root)
+        names = [name for name, _ in result]
+        assert "grp" in names
+
+
+class TestFormatParamType:
+    """_format_param_type가 파라미터 타입을 올바르게 포맷팅하는지 검증."""
+
+    def test_choice_type(self) -> None:
+        from scripts.generate_cli_reference import _format_param_type
+
+        param = click.Option(["--fmt"], type=click.Choice(["text", "json"]))
+        assert _format_param_type(param) == "text / json"
+
+    def test_int_range_type(self) -> None:
+        from scripts.generate_cli_reference import _format_param_type
+
+        param = click.Option(["--n"], type=click.IntRange(1, 100))
+        result = _format_param_type(param)
+        assert "1" in result
+        assert "100" in result
+
+    def test_path_type(self) -> None:
+        from scripts.generate_cli_reference import _format_param_type
+
+        param = click.Option(["--path"], type=click.Path())
+        assert _format_param_type(param) == "PATH"
+
+    def test_string_type(self) -> None:
+        from scripts.generate_cli_reference import _format_param_type
+
+        param = click.Option(["--name"], type=click.STRING)
+        result = _format_param_type(param)
+        assert result == "TEXT"
+
+
+class TestFormatDefault:
+    """_format_default가 기본값을 올바르게 포맷팅하는지 검증."""
+
+    def test_none_default(self) -> None:
+        from scripts.generate_cli_reference import _format_default
+
+        param = click.Option(["--x"], default=None)
+        assert _format_default(param) == "\u2014"
+
+    def test_bool_false_default(self) -> None:
+        from scripts.generate_cli_reference import _format_default
+
+        param = click.Option(["--x"], is_flag=True, default=False)
+        assert _format_default(param) == "false"
+
+    def test_string_default(self) -> None:
+        from scripts.generate_cli_reference import _format_default
+
+        param = click.Option(["--x"], default="hello")
+        assert _format_default(param) == "hello"
+
+    def test_empty_tuple_default(self) -> None:
+        from scripts.generate_cli_reference import _format_default
+
+        param = click.Option(["--x"], multiple=True)
+        assert _format_default(param) == "\u2014"
+
+
+class TestGetParams:
+    """_get_params가 help 옵션을 제외하는지 검증."""
+
+    def test_excludes_help(self) -> None:
+        from scripts.generate_cli_reference import _get_params
+
+        @click.command()
+        @click.option("--name", help="이름")
+        def cmd(name: str) -> None:
+            pass
+
+        params = _get_params(cmd)
+        names = [p.name for p in params]
+        assert "name" in names
+        assert "help" not in names
+
+
+# ── 전체 생성 테스트 ─────────────────────────────────────────────────────────
+
+
+class TestGenerateCliReference:
+    """generate_cli_reference가 ante CLI에서 올바른 문서를 생성하는지 검증."""
+
+    def test_generates_markdown(self) -> None:
+        """마크다운 문서가 생성된다."""
+        from scripts.generate_cli_reference import generate_cli_reference
+
+        buf = io.StringIO()
+        count = generate_cli_reference(buf)
+        content = buf.getvalue()
+
+        assert content.startswith("# Ante CLI Reference")
+        assert count > 0
+
+    def test_subcommand_count_at_least_60(self) -> None:
+        """60개 이상의 서브커맨드가 문서화된다."""
+        from scripts.generate_cli_reference import generate_cli_reference
+
+        buf = io.StringIO()
+        count = generate_cli_reference(buf)
+
+        assert count >= 60, f"서브커맨드 {count}개 — 60개 이상 필요"
+
+    def test_contains_summary_table(self) -> None:
+        """명령어 요약 테이블이 포함된다."""
+        from scripts.generate_cli_reference import generate_cli_reference
+
+        buf = io.StringIO()
+        generate_cli_reference(buf)
+        content = buf.getvalue()
+
+        assert "## 명령어 요약" in content
+        assert "| 명령 | 설명 |" in content
+
+    def test_contains_global_options(self) -> None:
+        """글로벌 옵션 섹션이 포함된다."""
+        from scripts.generate_cli_reference import generate_cli_reference
+
+        buf = io.StringIO()
+        generate_cli_reference(buf)
+        content = buf.getvalue()
+
+        assert "## 글로벌 옵션" in content
+        assert "`--format`" in content
+
+    def test_contains_known_commands(self) -> None:
+        """알려진 명령어들이 문서에 포함된다."""
+        from scripts.generate_cli_reference import generate_cli_reference
+
+        buf = io.StringIO()
+        generate_cli_reference(buf)
+        content = buf.getvalue()
+
+        expected_commands = [
+            "ante bot create",
+            "ante bot list",
+            "ante member bootstrap",
+            "ante strategy validate",
+            "ante system halt",
+            "ante trade list",
+            "ante feed init",
+        ]
+        for cmd in expected_commands:
+            assert cmd in content, f"'{cmd}'가 문서에 없음"
+
+    def test_auto_generation_notice(self) -> None:
+        """자동 생성 안내 문구가 포함된다."""
+        from scripts.generate_cli_reference import generate_cli_reference
+
+        buf = io.StringIO()
+        generate_cli_reference(buf)
+        content = buf.getvalue()
+
+        assert "자동 생성" in content
+        assert "직접 수정하지 마세요" in content
+
+    def test_options_have_details(self) -> None:
+        """옵션이 있는 명령어에 옵션 테이블이 포함된다."""
+        from scripts.generate_cli_reference import generate_cli_reference
+
+        buf = io.StringIO()
+        generate_cli_reference(buf)
+        content = buf.getvalue()
+
+        # bot create는 --name, --strategy 등 옵션이 많음
+        assert "**Options:**" in content


### PR DESCRIPTION
## Summary
- Click introspection API로 CLI 명령어 트리를 순회하여 `docs/generated/cli-reference.md`를 자동 생성하는 `scripts/generate_cli_reference.py` 추가
- 72개 서브커맨드의 이름, 설명, 파라미터, 옵션, 기본값을 포함하는 Markdown 문서 생성
- 헬퍼 함수 및 전체 생성 로직을 검증하는 단위 테스트 19개 추가 (모두 통과)

## 변경 파일
- `scripts/generate_cli_reference.py` — Click introspection 기반 CLI 레퍼런스 생성기
- `tests/unit/test_generate_cli_reference.py` — 생성기 동작 검증 테스트

## 완료 조건 충족
- [x] CLI 명령어 추가/수정 시 스크립트 실행만으로 cli-reference.md가 최신 상태로 갱신됨
- [x] 생성된 문서에 72개(60+) 서브커맨드의 이름, 설명, 파라미터, 옵션이 포함됨
- [x] /sync-specs 3단계에 CLI 레퍼런스 갱신 추가 — `.claude/skills/sync-specs.md`는 gitignore 대상이므로 별도 수동 갱신 필요

## Test plan
- [x] `python scripts/generate_cli_reference.py` 실행 시 72개 서브커맨드 문서 생성 확인
- [x] `pytest tests/unit/test_generate_cli_reference.py -v` 19개 테스트 통과
- [x] `pytest tests/unit/ -v` 전체 1663개 테스트 통과
- [x] `ruff check` + `ruff format` 통과

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)