### PR TITLE
feat(web): 전 엔드포인트 response_model 추가 및 OpenAPI 스키마 정비

### DIFF
--- a/src/ante/web/routes/approvals.py
+++ b/src/ante/web/routes/approvals.py
@@ -8,6 +8,12 @@ from dataclasses import asdict
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel
 
+from ante.web.schemas import (
+    ApprovalDetailResponse,
+    ApprovalListResponse,
+    ApprovalUpdateResponse,
+)
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
@@ -20,7 +26,7 @@ class ApprovalStatusUpdate(BaseModel):
     memo: str = ""
 
 
-@router.get("")
+@router.get("", response_model=ApprovalListResponse)
 async def list_approvals(
     request: Request,
     status: str | None = Query(default=None),
@@ -41,7 +47,7 @@ async def list_approvals(
     }
 
 
-@router.get("/{approval_id}")
+@router.get("/{approval_id}", response_model=ApprovalDetailResponse)
 async def get_approval(request: Request, approval_id: str) -> dict:
     """결재 상세 조회."""
     approval_service = request.app.state.approval_service
@@ -64,7 +70,7 @@ async def get_approval(request: Request, approval_id: str) -> dict:
     return result
 
 
-@router.patch("/{approval_id}/status")
+@router.patch("/{approval_id}/status", response_model=ApprovalUpdateResponse)
 async def update_approval_status(
     request: Request,
     approval_id: str,

--- a/src/ante/web/routes/audit.py
+++ b/src/ante/web/routes/audit.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Request
 
+from ante.web.schemas import AuditLogListResponse
+
 router = APIRouter()
 
 
-@router.get("")
+@router.get("", response_model=AuditLogListResponse)
 async def list_audit_logs(
     request: Request,
     member_id: str | None = None,

--- a/src/ante/web/routes/auth.py
+++ b/src/ante/web/routes/auth.py
@@ -6,7 +6,7 @@ import logging
 
 from fastapi import APIRouter, Cookie, HTTPException, Request, Response
 
-from ante.web.schemas import LoginRequest, LoginResponse, MeResponse
+from ante.web.schemas import LoginRequest, LoginResponse, LogoutResponse, MeResponse
 
 logger = logging.getLogger(__name__)
 
@@ -16,11 +16,11 @@ COOKIE_NAME = "ante_session"
 COOKIE_MAX_AGE = 86400  # 24시간
 
 
-@router.post("/login")
+@router.post("/login", response_model=LoginResponse)
 async def login(
     body: LoginRequest, request: Request, response: Response
 ) -> LoginResponse:
-    """패스워드 로그인 → 세션 쿠키 발급."""
+    """패스워드 로그인 -> 세션 쿠키 발급."""
     member_service = request.app.state.member_service
     session_service = request.app.state.session_service
 
@@ -60,7 +60,7 @@ async def login(
     )
 
 
-@router.post("/logout")
+@router.post("/logout", response_model=LogoutResponse)
 async def logout(
     request: Request,
     response: Response,
@@ -75,7 +75,7 @@ async def logout(
     return {"ok": True}
 
 
-@router.get("/me")
+@router.get("/me", response_model=MeResponse)
 async def me(
     request: Request,
     ante_session: str | None = Cookie(default=None),

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from ante.web.schemas import BotDetailResponse, BotListResponse
+
 router = APIRouter()
 
 
@@ -18,7 +20,7 @@ class BotCreateRequest(BaseModel):
     interval_seconds: int = Field(default=60, ge=10, le=3600)
 
 
-@router.get("")
+@router.get("", response_model=BotListResponse)
 async def list_bots(
     request: Request,
     limit: int = 20,
@@ -36,7 +38,7 @@ async def list_bots(
     return {"bots": result["items"], "next_cursor": result["next_cursor"]}
 
 
-@router.post("", status_code=201)
+@router.post("", status_code=201, response_model=BotDetailResponse)
 async def create_bot(request: Request, body: BotCreateRequest) -> dict:
     """봇 생성."""
     from pathlib import Path
@@ -82,7 +84,7 @@ async def create_bot(request: Request, body: BotCreateRequest) -> dict:
     return {"bot": bot.get_info()}
 
 
-@router.get("/{bot_id}")
+@router.get("/{bot_id}", response_model=BotDetailResponse)
 async def get_bot(request: Request, bot_id: str) -> dict:
     """봇 상세 조회."""
     bot_manager = getattr(request.app.state, "bot_manager", None)
@@ -138,7 +140,7 @@ async def get_bot(request: Request, bot_id: str) -> dict:
     return {"bot": info}
 
 
-@router.post("/{bot_id}/start")
+@router.post("/{bot_id}/start", response_model=BotDetailResponse)
 async def start_bot(request: Request, bot_id: str) -> dict:
     """봇 시작."""
     from ante.bot.exceptions import BotError
@@ -159,7 +161,7 @@ async def start_bot(request: Request, bot_id: str) -> dict:
     return {"bot": bot.get_info()}
 
 
-@router.post("/{bot_id}/stop")
+@router.post("/{bot_id}/stop", response_model=BotDetailResponse)
 async def stop_bot(request: Request, bot_id: str) -> dict:
     """봇 중지."""
     from ante.bot.exceptions import BotError

--- a/src/ante/web/routes/config.py
+++ b/src/ante/web/routes/config.py
@@ -7,6 +7,8 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+from ante.web.schemas import ConfigListResponse, ConfigUpdateResponse
+
 router = APIRouter()
 
 
@@ -17,7 +19,7 @@ class ConfigUpdateRequest(BaseModel):
     category: str = ""
 
 
-@router.get("")
+@router.get("", response_model=ConfigListResponse)
 async def list_configs(request: Request) -> dict:
     """동적 설정 전체 조회."""
     config_service = getattr(request.app.state, "dynamic_config", None)
@@ -28,7 +30,7 @@ async def list_configs(request: Request) -> dict:
     return {"configs": configs}
 
 
-@router.put("/{key:path}")
+@router.put("/{key:path}", response_model=ConfigUpdateResponse)
 async def update_config(request: Request, key: str, body: ConfigUpdateRequest) -> dict:
     """동적 설정 값 변경."""
     config_service = getattr(request.app.state, "dynamic_config", None)
@@ -40,7 +42,7 @@ async def update_config(request: Request, key: str, body: ConfigUpdateRequest) -
 
     old_value = await config_service.get(key)
 
-    # category: 요청에 없으면 key에서 추출 (예: "risk.max_mdd" → "risk")
+    # category: 요청에 없으면 key에서 추출 (예: "risk.max_mdd" -> "risk")
     category = body.category or key.split(".")[0]
 
     await config_service.set(key, body.value, category=category, changed_by="dashboard")

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -7,6 +7,12 @@ import shutil
 
 from fastapi import APIRouter, Query, Request
 
+from ante.web.schemas import (
+    DatasetListResponse,
+    FeedStatusResponse,
+    StorageSummaryResponse,
+)
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
@@ -15,7 +21,7 @@ router = APIRouter()
 DATA_TYPES = ["ohlcv", "fundamental"]
 
 
-@router.get("/datasets")
+@router.get("/datasets", response_model=DatasetListResponse)
 async def list_datasets(
     request: Request,
     symbol: str | None = None,
@@ -97,7 +103,7 @@ async def get_data_schema(
     return {k: str(v) for k, v in OHLCV_SCHEMA.items()}
 
 
-@router.get("/storage")
+@router.get("/storage", response_model=StorageSummaryResponse)
 async def get_storage_summary(request: Request) -> dict:
     """저장 용량 현황."""
     store = getattr(request.app.state, "data_store", None)
@@ -150,7 +156,7 @@ async def delete_dataset(
     shutil.rmtree(path)
 
 
-@router.get("/feed-status")
+@router.get("/feed-status", response_model=FeedStatusResponse)
 async def get_feed_status(request: Request) -> dict:
     """Feed 파이프라인 상태 조회.
 

--- a/src/ante/web/routes/members.py
+++ b/src/ante/web/routes/members.py
@@ -7,6 +7,15 @@ from dataclasses import asdict
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel
 
+from ante.web.schemas import (
+    MemberCreateResponse,
+    MemberDetailResponse,
+    MemberListResponse,
+    MemberScopesResponse,
+    MemberTokenResponse,
+    OkResponse,
+)
+
 router = APIRouter()
 
 
@@ -41,7 +50,7 @@ def _get_member_service(request: Request):
     return svc
 
 
-@router.get("")
+@router.get("", response_model=MemberListResponse)
 async def list_members(
     request: Request,
     type: str | None = Query(default=None),
@@ -58,7 +67,7 @@ async def list_members(
     return {"members": [asdict(m) for m in members], "total": len(members)}
 
 
-@router.post("", status_code=201)
+@router.post("", status_code=201, response_model=MemberCreateResponse)
 async def create_member(request: Request, body: MemberCreateRequest) -> dict:
     """멤버 등록. 토큰 1회 반환."""
     svc = _get_member_service(request)
@@ -81,7 +90,7 @@ async def create_member(request: Request, body: MemberCreateRequest) -> dict:
     return {"member": asdict(member), "token": token}
 
 
-@router.get("/{member_id}")
+@router.get("/{member_id}", response_model=MemberDetailResponse)
 async def get_member(request: Request, member_id: str) -> dict:
     """멤버 상세 조회."""
     svc = _get_member_service(request)
@@ -91,7 +100,7 @@ async def get_member(request: Request, member_id: str) -> dict:
     return {"member": asdict(member)}
 
 
-@router.post("/{member_id}/suspend")
+@router.post("/{member_id}/suspend", response_model=MemberDetailResponse)
 async def suspend_member(request: Request, member_id: str) -> dict:
     """멤버 일시 정지."""
     svc = _get_member_service(request)
@@ -104,7 +113,7 @@ async def suspend_member(request: Request, member_id: str) -> dict:
     return {"member": asdict(member)}
 
 
-@router.post("/{member_id}/reactivate")
+@router.post("/{member_id}/reactivate", response_model=MemberDetailResponse)
 async def reactivate_member(request: Request, member_id: str) -> dict:
     """멤버 재활성화."""
     svc = _get_member_service(request)
@@ -117,7 +126,7 @@ async def reactivate_member(request: Request, member_id: str) -> dict:
     return {"member": asdict(member)}
 
 
-@router.post("/{member_id}/revoke")
+@router.post("/{member_id}/revoke", response_model=MemberDetailResponse)
 async def revoke_member(request: Request, member_id: str) -> dict:
     """멤버 영구 폐기."""
     svc = _get_member_service(request)
@@ -130,7 +139,7 @@ async def revoke_member(request: Request, member_id: str) -> dict:
     return {"member": asdict(member)}
 
 
-@router.post("/{member_id}/rotate-token")
+@router.post("/{member_id}/rotate-token", response_model=MemberTokenResponse)
 async def rotate_token(request: Request, member_id: str) -> dict:
     """토큰 재발급."""
     svc = _get_member_service(request)
@@ -143,7 +152,7 @@ async def rotate_token(request: Request, member_id: str) -> dict:
     return {"member": asdict(member), "token": token}
 
 
-@router.patch("/{member_id}/password")
+@router.patch("/{member_id}/password", response_model=OkResponse)
 async def change_password(
     request: Request, member_id: str, body: PasswordChangeRequest
 ) -> dict:
@@ -158,7 +167,7 @@ async def change_password(
     return {"ok": True}
 
 
-@router.put("/{member_id}/scopes")
+@router.put("/{member_id}/scopes", response_model=MemberScopesResponse)
 async def update_scopes(
     request: Request, member_id: str, body: ScopesUpdateRequest
 ) -> dict:

--- a/src/ante/web/routes/notifications.py
+++ b/src/ante/web/routes/notifications.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Request
 
+from ante.web.schemas import NotificationListResponse
+
 router = APIRouter()
 
 
-@router.get("")
+@router.get("", response_model=NotificationListResponse)
 async def list_notifications(
     request: Request,
     level: str | None = None,

--- a/src/ante/web/routes/portfolio.py
+++ b/src/ante/web/routes/portfolio.py
@@ -7,12 +7,14 @@ from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Query, Request
 
+from ante.web.schemas import PortfolioHistoryResponse, PortfolioValueResponse
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 
-@router.get("/value")
+@router.get("/value", response_model=PortfolioValueResponse)
 async def portfolio_value(request: Request) -> dict:
     """총 자산 가치 + 오늘 손익."""
     treasury = request.app.state.treasury
@@ -30,7 +32,7 @@ async def portfolio_value(request: Request) -> dict:
     }
 
 
-# 기간 → 일수 매핑
+# 기간 -> 일수 매핑
 _PERIOD_DAYS = {
     "1d": 1,
     "1w": 7,
@@ -40,7 +42,7 @@ _PERIOD_DAYS = {
 }
 
 
-@router.get("/history")
+@router.get("/history", response_model=PortfolioHistoryResponse)
 async def portfolio_history(
     request: Request,
     period: str = Query(default="1m", pattern="^(1d|1w|1m|3m|all)$"),

--- a/src/ante/web/routes/reports.py
+++ b/src/ante/web/routes/reports.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Request
 
+from ante.web.schemas import (
+    ReportDetailResponse,
+    ReportListResponse,
+    ReportSubmitResponse,
+)
+
 router = APIRouter()
 
 
@@ -16,7 +22,7 @@ async def get_report_schema() -> dict:
     return store.get_schema()
 
 
-@router.post("", status_code=201)
+@router.post("", status_code=201, response_model=ReportSubmitResponse)
 async def submit_report(request: Request, body: dict) -> dict:
     """리포트 제출."""
     report_store = getattr(request.app.state, "report_store", None)
@@ -31,7 +37,7 @@ async def submit_report(request: Request, body: dict) -> dict:
     }
 
 
-@router.get("/{report_id}")
+@router.get("/{report_id}", response_model=ReportDetailResponse)
 async def report_view(request: Request, report_id: str) -> dict:
     """리포트 단건 조회."""
     import json
@@ -77,7 +83,7 @@ async def report_view(request: Request, report_id: str) -> dict:
     }
 
 
-@router.get("")
+@router.get("", response_model=ReportListResponse)
 async def list_reports(
     request: Request,
     status: str | None = None,

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -7,10 +7,21 @@ from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Query, Request
 
+from ante.web.schemas import (
+    DailySummaryResponse,
+    MonthlySummaryResponse,
+    StrategyDetailResponse,
+    StrategyListResponse,
+    StrategyPerformanceResponse,
+    StrategyTradesResponse,
+    StrategyValidateResponse,
+    WeeklySummaryResponse,
+)
+
 router = APIRouter()
 
 
-@router.post("/validate")
+@router.post("/validate", response_model=StrategyValidateResponse)
 async def validate_strategy(body: dict) -> dict:
     """전략 파일 정적 검증.
 
@@ -36,7 +47,7 @@ async def validate_strategy(body: dict) -> dict:
     }
 
 
-@router.get("")
+@router.get("", response_model=StrategyListResponse)
 async def list_strategies(
     request: Request,
     status: str | None = Query(default=None),
@@ -76,7 +87,7 @@ async def list_strategies(
     return {"strategies": strategies}
 
 
-@router.get("/{strategy_id}")
+@router.get("/{strategy_id}", response_model=StrategyDetailResponse)
 async def get_strategy(request: Request, strategy_id: str) -> dict:
     """전략 상세 조회."""
     registry = getattr(request.app.state, "strategy_registry", None)
@@ -103,7 +114,7 @@ async def get_strategy(request: Request, strategy_id: str) -> dict:
     return {"strategy": strategy_dict, "bot": bot_info}
 
 
-@router.get("/{strategy_id}/performance")
+@router.get("/{strategy_id}/performance", response_model=StrategyPerformanceResponse)
 async def get_strategy_performance(request: Request, strategy_id: str) -> dict:
     """전략 성과 지표 조회."""
     registry = getattr(request.app.state, "strategy_registry", None)
@@ -145,7 +156,7 @@ async def get_strategy_performance(request: Request, strategy_id: str) -> dict:
     return result
 
 
-@router.get("/{strategy_id}/daily-summary")
+@router.get("/{strategy_id}/daily-summary", response_model=DailySummaryResponse)
 async def get_strategy_daily_summary(
     request: Request,
     strategy_id: str,
@@ -190,7 +201,7 @@ async def get_strategy_daily_summary(
     }
 
 
-@router.get("/{strategy_id}/weekly-summary")
+@router.get("/{strategy_id}/weekly-summary", response_model=WeeklySummaryResponse)
 async def get_strategy_weekly_summary(
     request: Request,
     strategy_id: str,
@@ -236,7 +247,7 @@ async def get_strategy_weekly_summary(
     }
 
 
-@router.get("/{strategy_id}/monthly-summary")
+@router.get("/{strategy_id}/monthly-summary", response_model=MonthlySummaryResponse)
 async def get_strategy_monthly_summary(
     request: Request,
     strategy_id: str,
@@ -281,7 +292,7 @@ async def get_strategy_monthly_summary(
     }
 
 
-@router.get("/{strategy_id}/trades")
+@router.get("/{strategy_id}/trades", response_model=StrategyTradesResponse)
 async def get_strategy_trades(
     request: Request,
     strategy_id: str,

--- a/src/ante/web/routes/system.py
+++ b/src/ante/web/routes/system.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+from ante.web.schemas import HealthResponse, KillSwitchResponse, StatusResponse
+
 router = APIRouter()
 
 
@@ -15,7 +17,7 @@ class KillSwitchRequest(BaseModel):
     reason: str = ""
 
 
-@router.get("/status")
+@router.get("/status", response_model=StatusResponse)
 async def get_system_status(request: Request) -> dict:
     """시스템 상태 조회."""
     result: dict = {
@@ -50,13 +52,13 @@ async def _get_last_halt_info(system_state: object) -> dict | None:
     return dict(row) if row else None
 
 
-@router.get("/health")
+@router.get("/health", response_model=HealthResponse)
 async def health_check() -> dict:
     """헬스체크."""
     return {"ok": True}
 
 
-@router.post("/kill-switch")
+@router.post("/kill-switch", response_model=KillSwitchResponse)
 async def kill_switch(request: Request, body: KillSwitchRequest) -> dict:
     """킬 스위치 제어 (halt/activate)."""
     from datetime import UTC, datetime

--- a/src/ante/web/routes/test_seed.py
+++ b/src/ante/web/routes/test_seed.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Query, Request
 
+from ante.web.schemas import SeedResetResponse
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
@@ -20,7 +22,7 @@ def _find_scenarios_dir() -> Path:
     """시나리오 SQL 디렉토리를 탐색한다.
 
     pip install로 site-packages에 설치된 경우 __file__ 기준 경로가 맞지 않으므로,
-    환경변수 → CWD → __file__ 순서로 탐색한다.
+    환경변수 -> CWD -> __file__ 순서로 탐색한다.
     """
     import os
 
@@ -54,7 +56,7 @@ SCENARIOS_DIR = _find_scenarios_dir()
 BASE_SQL = SCENARIOS_DIR / "_base.sql"
 
 
-@router.post("/reset")
+@router.post("/reset", response_model=SeedResetResponse)
 async def reset_seed(
     request: Request,
     scenario: str = Query(..., description="시나리오 이름 (예: login-dashboard)"),

--- a/src/ante/web/routes/trades.py
+++ b/src/ante/web/routes/trades.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Request
 
+from ante.web.schemas import TradeListResponse
+
 router = APIRouter()
 
 
-@router.get("")
+@router.get("", response_model=TradeListResponse)
 async def list_trades(
     request: Request,
     bot_id: str | None = None,

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+from ante.web.schemas import (
+    BalanceSetResponse,
+    BudgetListResponse,
+    BudgetOperationResponse,
+    TransactionListResponse,
+    TreasurySummaryResponse,
+)
+
 router = APIRouter()
 
 
@@ -20,7 +28,9 @@ class BalanceSetRequest(BaseModel):
     balance: float
 
 
-@router.get("")
+@router.get(
+    "", response_model=TreasurySummaryResponse, response_model_exclude_none=True
+)
 async def get_summary(request: Request) -> dict:
     """자금 현황 요약."""
     treasury = getattr(request.app.state, "treasury", None)
@@ -43,7 +53,7 @@ async def get_summary(request: Request) -> dict:
     if config is not None:
         try:
             account_no = config.secret("KIS_ACCOUNT_NO")
-            # "1234567801" → "12345678-01" 포맷 변환
+            # "1234567801" -> "12345678-01" 포맷 변환
             if account_no and len(account_no) == 10:
                 summary["account_no"] = f"{account_no[:8]}-{account_no[8:]}"
             elif account_no:
@@ -61,7 +71,7 @@ async def get_summary(request: Request) -> dict:
     return summary
 
 
-@router.get("/transactions")
+@router.get("/transactions", response_model=TransactionListResponse)
 async def list_transactions(
     request: Request,
     type: str | None = None,
@@ -115,7 +125,7 @@ async def list_transactions(
     return {"items": items, "total": total}
 
 
-@router.post("/bots/{bot_id}/allocate")
+@router.post("/bots/{bot_id}/allocate", response_model=BudgetOperationResponse)
 async def allocate(request: Request, bot_id: str, body: BudgetChangeRequest) -> dict:
     """봇에 예산 할당."""
     from ante.treasury.exceptions import BotNotStoppedError
@@ -146,7 +156,7 @@ async def allocate(request: Request, bot_id: str, body: BudgetChangeRequest) -> 
     }
 
 
-@router.post("/bots/{bot_id}/deallocate")
+@router.post("/bots/{bot_id}/deallocate", response_model=BudgetOperationResponse)
 async def deallocate(request: Request, bot_id: str, body: BudgetChangeRequest) -> dict:
     """봇 예산 회수."""
     from ante.treasury.exceptions import BotNotStoppedError
@@ -174,7 +184,7 @@ async def deallocate(request: Request, bot_id: str, body: BudgetChangeRequest) -
     }
 
 
-@router.get("/budgets")
+@router.get("/budgets", response_model=BudgetListResponse)
 async def list_budgets(request: Request) -> dict:
     """봇별 예산 목록 조회."""
     from dataclasses import asdict
@@ -187,7 +197,7 @@ async def list_budgets(request: Request) -> dict:
     return {"budgets": [asdict(b) for b in budgets]}
 
 
-@router.post("/balance")
+@router.post("/balance", response_model=BalanceSetResponse)
 async def set_balance(request: Request, body: BalanceSetRequest) -> dict:
     """계좌 총 잔고 수동 설정."""
     from datetime import UTC, datetime

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -2,14 +2,9 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from typing import Any
 
-
-class StatusResponse(BaseModel):
-    """시스템 상태 응답."""
-
-    status: str
-    version: str = "0.1.0"
+from pydantic import BaseModel, ConfigDict
 
 
 class ErrorResponse(BaseModel):
@@ -22,22 +17,30 @@ class ErrorResponse(BaseModel):
     instance: str = ""
 
 
-class ReportSubmitRequest(BaseModel):
-    """리포트 제출 요청."""
-
-    strategy_name: str
-    strategy_version: str
-    backtest_result: dict
-    summary: str = ""
-    recommendation: str = ""
+# ── 시스템 ──────────────────────────────────────────────
 
 
-class DataInjectRequest(BaseModel):
-    """데이터 주입 요청 (JSON body)."""
+class StatusResponse(BaseModel):
+    """시스템 상태 응답."""
 
-    symbol: str
-    timeframe: str = "1d"
-    source: str = "external"
+    status: str
+    version: str = "0.1.0"
+    trading_status: str | None = None
+    halt_time: str | None = None
+    halt_reason: str | None = None
+
+
+class HealthResponse(BaseModel):
+    """헬스체크 응답."""
+
+    ok: bool
+
+
+class KillSwitchResponse(BaseModel):
+    """킬 스위치 제어 응답."""
+
+    status: str
+    changed_at: str
 
 
 # ── 인증 ──────────────────────────────────────────────
@@ -58,6 +61,12 @@ class LoginResponse(BaseModel):
     type: str
 
 
+class LogoutResponse(BaseModel):
+    """로그아웃 응답."""
+
+    ok: bool
+
+
 class MeResponse(BaseModel):
     """현재 사용자 정보 응답."""
 
@@ -67,3 +76,507 @@ class MeResponse(BaseModel):
     emoji: str = ""
     role: str = ""
     login_at: str = ""
+
+
+# ── 봇 ──────────────────────────────────────────────
+
+
+class BotListResponse(BaseModel):
+    """봇 목록 응답."""
+
+    bots: list[dict[str, Any]]
+    next_cursor: str | None = None
+
+
+class BotDetailResponse(BaseModel):
+    """봇 상세/생성/시작/중지 응답."""
+
+    bot: dict[str, Any]
+
+
+# ── 전략 ──────────────────────────────────────────────
+
+
+class StrategyValidateResponse(BaseModel):
+    """전략 검증 응답."""
+
+    valid: bool
+    errors: list[str] = []
+    warnings: list[str] = []
+
+
+class StrategyListItem(BaseModel):
+    """전략 목록 아이템."""
+
+    id: str
+    name: str
+    version: str
+    status: str
+    author: str
+    bot_id: str | None = None
+    bot_status: str | None = None
+
+
+class StrategyListResponse(BaseModel):
+    """전략 목록 응답."""
+
+    strategies: list[StrategyListItem]
+
+
+class StrategyDetailResponse(BaseModel):
+    """전략 상세 응답."""
+
+    strategy: dict[str, Any]
+    bot: dict[str, Any] | None = None
+
+
+class EquityCurvePoint(BaseModel):
+    """에쿼티 커브 포인트."""
+
+    date: str
+    value: float
+
+
+class StrategyPerformanceResponse(BaseModel):
+    """전략 성과 지표 응답."""
+
+    total_trades: int = 0
+    winning_trades: int = 0
+    losing_trades: int = 0
+    win_rate: float = 0.0
+    total_pnl: float = 0.0
+    avg_pnl: float = 0.0
+    max_drawdown: float = 0.0
+    profit_factor: float = 0.0
+    sharpe_ratio: float = 0.0
+    equity_curve: list[dict[str, Any]] = []
+
+    model_config = ConfigDict(extra="allow")  #
+
+
+class DailySummaryItem(BaseModel):
+    """일별 성과 집계 아이템."""
+
+    date: str
+    realized_pnl: float
+    trade_count: int
+    win_rate: float
+
+
+class DailySummaryResponse(BaseModel):
+    """일별 성과 집계 응답."""
+
+    items: list[DailySummaryItem]
+
+
+class WeeklySummaryItem(BaseModel):
+    """주별 성과 집계 아이템."""
+
+    week_start: str
+    week_end: str
+    week_label: str
+    realized_pnl: float
+    trade_count: int
+    win_rate: float
+
+
+class WeeklySummaryResponse(BaseModel):
+    """주별 성과 집계 응답."""
+
+    items: list[WeeklySummaryItem]
+
+
+class MonthlySummaryItem(BaseModel):
+    """월별 성과 집계 아이템."""
+
+    year: int
+    month: int
+    realized_pnl: float
+    trade_count: int
+    win_rate: float
+
+
+class MonthlySummaryResponse(BaseModel):
+    """월별 성과 집계 응답."""
+
+    items: list[MonthlySummaryItem]
+
+
+class StrategyTradeItem(BaseModel):
+    """전략 거래 아이템."""
+
+    trade_id: str
+    bot_id: str
+    symbol: str
+    side: str
+    quantity: float
+    price: float
+    status: str
+    timestamp: str
+
+
+class StrategyTradesResponse(BaseModel):
+    """전략 거래 내역 응답."""
+
+    trades: list[StrategyTradeItem]
+    next_cursor: str | None = None
+
+
+# ── Treasury ──────────────────────────────────────────────
+
+
+class TreasurySummaryResponse(BaseModel):
+    """자금 현황 요약 응답."""
+
+    total_balance: float = 0.0
+    unallocated: float = 0.0
+    total_allocated: float = 0.0
+    total_evaluation: float = 0.0
+    total_profit_loss: float = 0.0
+    commission_rate: float = 0.00015
+    sell_tax_rate: float = 0.0023
+    broker_id: str | None = None
+    broker_name: str | None = None
+    broker_short_name: str | None = None
+    exchange: str | None = None
+    account_no: str | None = None
+    is_virtual: bool | None = None
+    synced_at: str | None = None
+
+    model_config = ConfigDict(extra="allow")  #
+
+
+class TransactionItem(BaseModel):
+    """자금 변동 이력 아이템."""
+
+    id: int
+    type: str
+    bot_id: str | None = None
+    amount: float
+    description: str = ""
+    created_at: str
+
+
+class TransactionListResponse(BaseModel):
+    """자금 변동 이력 응답."""
+
+    items: list[TransactionItem]
+    total: int
+
+
+class BudgetOperationResponse(BaseModel):
+    """예산 할당/회수 응답."""
+
+    bot_id: str
+    allocated: float
+    available: float
+
+
+class BudgetListResponse(BaseModel):
+    """예산 목록 응답."""
+
+    budgets: list[dict[str, Any]]
+
+
+class BalanceSetResponse(BaseModel):
+    """잔고 설정 응답."""
+
+    total_balance: float
+    updated_at: str
+
+
+# ── 리포트 ──────────────────────────────────────────────
+
+
+class ReportSubmitRequest(BaseModel):
+    """리포트 제출 요청."""
+
+    strategy_name: str
+    strategy_version: str
+    backtest_result: dict
+    summary: str = ""
+    recommendation: str = ""
+
+
+class ReportSubmitResponse(BaseModel):
+    """리포트 제출 응답."""
+
+    report_id: str
+    strategy: str
+    status: str
+
+
+class ReportDetailResponse(BaseModel):
+    """리포트 상세 응답."""
+
+    report_id: str
+    strategy_name: str
+    strategy_version: str
+    strategy_path: str = ""
+    status: str
+    submitted_at: str
+    submitted_by: str = ""
+    backtest_period: str | None = None
+    total_return_pct: float | None = None
+    total_trades: int | None = None
+    sharpe_ratio: float | None = None
+    max_drawdown_pct: float | None = None
+    win_rate: float | None = None
+    summary: str = ""
+    rationale: str = ""
+    risks: str = ""
+    recommendations: str = ""
+    equity_curve: list[dict[str, Any]] = []
+    metrics: dict[str, Any] = {}
+    initial_balance: float | None = None
+    final_balance: float | None = None
+    symbols: list[str | dict[str, Any]] = []
+    user_notes: str = ""
+    reviewed_at: str | None = None
+
+
+class ReportListItem(BaseModel):
+    """리포트 목록 아이템."""
+
+    report_id: str
+    strategy: str
+    status: str
+    submitted_at: str
+
+
+class ReportListResponse(BaseModel):
+    """리포트 목록 응답."""
+
+    reports: list[ReportListItem]
+    next_cursor: str | None = None
+
+
+class ReportSchemaResponse(BaseModel):
+    """리포트 스키마 응답."""
+
+    model_config = ConfigDict(extra="allow")  #
+
+
+# ── 데이터 ──────────────────────────────────────────────
+
+
+class DataInjectRequest(BaseModel):
+    """데이터 주입 요청 (JSON body)."""
+
+    symbol: str
+    timeframe: str = "1d"
+    source: str = "external"
+
+
+class DatasetItem(BaseModel):
+    """데이터셋 아이템."""
+
+    id: str
+    symbol: str
+    timeframe: str
+    data_type: str
+    start_date: str | None = None
+    end_date: str | None = None
+    row_count: int = 0
+
+
+class DatasetListResponse(BaseModel):
+    """데이터셋 목록 응답."""
+
+    items: list[DatasetItem]
+    total: int
+
+
+class DataSchemaResponse(BaseModel):
+    """데이터 스키마 응답 (동적 키-값)."""
+
+    model_config = ConfigDict(extra="allow")  #
+
+
+class StorageSummaryResponse(BaseModel):
+    """저장 용량 현황 응답."""
+
+    total_bytes: int
+    total_mb: float
+    by_timeframe: dict[str, float]
+
+
+class FeedStatusResponse(BaseModel):
+    """Feed 파이프라인 상태 응답."""
+
+    initialized: bool = False
+    checkpoints: list[dict[str, Any]] = []
+    recent_reports: list[dict[str, Any]] = []
+    api_keys: list[dict[str, Any]] = []
+
+
+# ── 멤버 ──────────────────────────────────────────────
+
+
+class MemberListResponse(BaseModel):
+    """멤버 목록 응답."""
+
+    members: list[dict[str, Any]]
+    total: int
+
+
+class MemberDetailResponse(BaseModel):
+    """멤버 상세 응답."""
+
+    member: dict[str, Any]
+
+
+class MemberCreateResponse(BaseModel):
+    """멤버 생성 응답 (토큰 포함)."""
+
+    member: dict[str, Any]
+    token: str
+
+
+class MemberTokenResponse(BaseModel):
+    """토큰 재발급 응답."""
+
+    member: dict[str, Any]
+    token: str
+
+
+class OkResponse(BaseModel):
+    """단순 성공 응답."""
+
+    ok: bool
+
+
+class MemberScopesResponse(BaseModel):
+    """권한 범위 변경 응답."""
+
+    member: dict[str, Any]
+
+
+# ── 거래 ──────────────────────────────────────────────
+
+
+class TradeItem(BaseModel):
+    """거래 기록 아이템."""
+
+    trade_id: str
+    bot_id: str
+    symbol: str
+    side: str
+    quantity: float
+    price: float
+    status: str
+    created_at: str
+
+
+class TradeListResponse(BaseModel):
+    """거래 기록 목록 응답."""
+
+    trades: list[TradeItem]
+    next_cursor: str | None = None
+
+
+# ── 결재 ──────────────────────────────────────────────
+
+
+class ApprovalListResponse(BaseModel):
+    """결재 목록 응답."""
+
+    approvals: list[dict[str, Any]]
+    total: int
+
+
+class ApprovalDetailResponse(BaseModel):
+    """결재 상세 응답."""
+
+    approval: dict[str, Any]
+    report_detail: dict[str, Any] | None = None
+
+
+class ApprovalUpdateResponse(BaseModel):
+    """결재 상태 변경 응답."""
+
+    approval: dict[str, Any]
+
+
+# ── 설정 ──────────────────────────────────────────────
+
+
+class ConfigListResponse(BaseModel):
+    """동적 설정 목록 응답."""
+
+    configs: list[dict[str, Any]]
+
+
+class ConfigUpdateResponse(BaseModel):
+    """설정 변경 응답."""
+
+    key: str
+    old_value: Any = None
+    new_value: Any = None
+
+
+# ── 포트폴리오 ──────────────────────────────────────────────
+
+
+class PortfolioValueResponse(BaseModel):
+    """총 자산 가치 응답."""
+
+    total_value: float
+    daily_pnl: float
+    daily_pnl_pct: float
+    updated_at: str
+
+
+class PortfolioHistoryPoint(BaseModel):
+    """자산 추이 데이터 포인트."""
+
+    date: str
+    value: float
+
+
+class PortfolioHistoryResponse(BaseModel):
+    """기간별 자산 추이 응답."""
+
+    data: list[PortfolioHistoryPoint]
+    period: str
+
+
+# ── 감사 로그 ──────────────────────────────────────────────
+
+
+class AuditLogListResponse(BaseModel):
+    """감사 로그 목록 응답."""
+
+    logs: list[dict[str, Any]]
+    total: int
+
+
+# ── 알림 ──────────────────────────────────────────────
+
+
+class NotificationItem(BaseModel):
+    """알림 이력 아이템."""
+
+    id: str
+    level: str
+    title: str
+    message: str
+    success: bool
+    created_at: str
+
+
+class NotificationListResponse(BaseModel):
+    """알림 이력 목록 응답."""
+
+    notifications: list[NotificationItem]
+    next_cursor: str | None = None
+
+
+# ── 테스트 시드 ──────────────────────────────────────────────
+
+
+class SeedResetResponse(BaseModel):
+    """시드 리셋 응답."""
+
+    ok: bool
+    scenario: str

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -405,3 +405,138 @@ class TestAppFactory:
         assert resp.status_code == 200
         data = resp.json()
         assert data["info"]["title"] == "Ante"
+
+
+# ── response_model 커버리지 테스트 ────────────────────────
+
+
+class TestResponseModelCoverage:
+    """모든 엔드포인트에 response_model이 설정되어 있는지 검증."""
+
+    # response_model 면제 대상 (동적 스키마를 반환하는 엔드포인트)
+    _EXEMPT_PATHS = {
+        "/api/reports/schema",
+        "/api/data/schema",
+    }
+
+    def test_all_endpoints_have_response_model(self, app):
+        """204를 제외한 모든 API 엔드포인트에 response_model이 설정되어야 한다."""
+        missing = []
+        for route in app.routes:
+            if not hasattr(route, "methods"):
+                continue
+            path = getattr(route, "path", "")
+            if not path.startswith("/api"):
+                continue
+            if path in self._EXEMPT_PATHS:
+                continue
+            # 204 응답(삭제)은 response_model 불필요
+            status_code = getattr(route, "status_code", None) or 200
+            if status_code == 204:
+                continue
+            response_model = getattr(route, "response_model", None)
+            if response_model is None:
+                methods = getattr(route, "methods", set())
+                missing.append(f"{','.join(methods)} {path}")
+
+        assert missing == [], "response_model 누락 엔드포인트:\n" + "\n".join(
+            f"  - {m}" for m in missing
+        )
+
+    def test_openapi_schema_has_response_schemas(self, client):
+        """OpenAPI 스키마에서 모든 엔드포인트에 응답 스키마가 존재."""
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        openapi = resp.json()
+        paths = openapi.get("paths", {})
+
+        missing = []
+        for path, methods in paths.items():
+            if not path.startswith("/api"):
+                continue
+            if path in self._EXEMPT_PATHS:
+                continue
+            for method, spec in methods.items():
+                if method in ("options", "head"):
+                    continue
+                responses = spec.get("responses", {})
+                # 204 응답은 스키마 불필요
+                if "204" in responses and len(responses) <= 2:
+                    continue
+                # 200 또는 201에 content schema가 있어야 함
+                success_codes = [c for c in ("200", "201") if c in responses]
+                if not success_codes:
+                    continue
+                for code in success_codes:
+                    content = responses[code].get("content", {})
+                    json_schema = content.get("application/json", {}).get("schema")
+                    if json_schema is None:
+                        missing.append(f"{method.upper()} {path} ({code})")
+
+        assert missing == [], "OpenAPI 응답 스키마 누락:\n" + "\n".join(
+            f"  - {m}" for m in missing
+        )
+
+    def test_response_model_validates_status_response(self, client):
+        """StatusResponse 모델이 실제 응답과 일치하는지 검증."""
+        from ante.web.schemas import StatusResponse
+
+        resp = client.get("/api/system/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        # Pydantic 모델로 파싱 가능해야 함
+        model = StatusResponse(**data)
+        assert model.status == "running"
+
+    def test_response_model_validates_health_response(self, client):
+        """HealthResponse 모델이 실제 응답과 일치하는지 검증."""
+        from ante.web.schemas import HealthResponse
+
+        resp = client.get("/api/system/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        model = HealthResponse(**data)
+        assert model.ok is True
+
+    def test_response_model_validates_strategy_validate(self, client, tmp_path):
+        """StrategyValidateResponse 모델이 실제 응답과 일치하는지 검증."""
+        from ante.web.schemas import StrategyValidateResponse
+
+        path = tmp_path / "test.py"
+        path.write_text("import os\nprint('not a strategy')")
+
+        resp = client.post("/api/strategies/validate", json={"path": str(path)})
+        assert resp.status_code == 200
+        data = resp.json()
+        model = StrategyValidateResponse(**data)
+        assert model.valid is False
+
+    def test_response_model_validates_dataset_list(self, client):
+        """DatasetListResponse 모델이 실제 응답과 일치하는지 검증."""
+        from ante.web.schemas import DatasetListResponse
+
+        resp = client.get("/api/data/datasets")
+        assert resp.status_code == 200
+        data = resp.json()
+        model = DatasetListResponse(**data)
+        assert model.total == 0
+
+    def test_response_model_validates_storage_summary(self, client):
+        """StorageSummaryResponse 모델이 실제 응답과 일치하는지 검증."""
+        from ante.web.schemas import StorageSummaryResponse
+
+        resp = client.get("/api/data/storage")
+        assert resp.status_code == 200
+        data = resp.json()
+        model = StorageSummaryResponse(**data)
+        assert model.total_bytes == 0
+
+    def test_response_model_validates_feed_status(self, client):
+        """FeedStatusResponse 모델이 실제 응답과 일치하는지 검증."""
+        from ante.web.schemas import FeedStatusResponse
+
+        resp = client.get("/api/data/feed-status")
+        assert resp.status_code == 200
+        data = resp.json()
+        model = FeedStatusResponse(**data)
+        assert model.initialized is False


### PR DESCRIPTION
## Summary
- `schemas.py`에 도메인별 Pydantic 응답 모델 50+개 정의 (시스템, 인증, 봇, 전략, Treasury, 리포트, 데이터, 멤버, 거래, 결재, 설정, 포트폴리오, 감사 로그, 알림, 테스트 시드)
- 15개 라우터의 모든 엔드포인트에 `response_model` 파라미터 적용
- `/openapi.json`에서 모든 엔드포인트의 요청/응답 스키마가 완전히 표현됨
- 응답 구조 변경 시 FastAPI가 런타임 `ResponseValidationError`를 발생시킴

## 변경 파일
- `src/ante/web/schemas.py` — 응답 모델 50+개 추가
- `src/ante/web/routes/*.py` — 15개 라우터에 response_model 적용
- `tests/unit/test_web_api.py` — response_model 커버리지 테스트 8개 추가

## 설계 결정
- 204 응답(삭제)과 동적 스키마 엔드포인트(`data/schema`, `reports/schema`)는 response_model 면제
- Treasury summary에 `response_model_exclude_none=True` 적용 (broker 미설정 시 필드 미노출)
- Pydantic V2 `ConfigDict(extra="allow")` 사용 (deprecation 경고 해소)

## Test plan
- [x] 기존 단위 테스트 1652개 전체 통과
- [x] response_model 커버리지 테스트 — 모든 API 엔드포인트에 response_model 설정 확인
- [x] OpenAPI 스키마 검증 — 모든 엔드포인트에 응답 스키마 존재 확인
- [x] 실제 응답 Pydantic 파싱 검증 (StatusResponse, HealthResponse, StrategyValidateResponse, DatasetListResponse, StorageSummaryResponse, FeedStatusResponse)
- [x] ruff check + format 통과

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)