### PR TITLE
fix(scripts): Click 8.2+ Sentinel.UNSET 호환성 수정 (#399)

### DIFF
--- a/scripts/generate_cli_reference.py
+++ b/scripts/generate_cli_reference.py
@@ -92,7 +92,11 @@ def _format_default(param: click.Parameter) -> str:
         return "false" if not param.default else "true"
     if isinstance(param.default, tuple) and len(param.default) == 0:
         return "\u2014"
-    return str(param.default)
+    # Click 8.2+ 에서 multiple=True 옵션의 기본값이 Sentinel.UNSET일 수 있음
+    default_str = str(param.default)
+    if "UNSET" in default_str or "Sentinel" in default_str:
+        return "\u2014"
+    return default_str
 
 
 def _is_required(param: click.Parameter) -> str:


### PR DESCRIPTION
## Summary
- `scripts/generate_cli_reference.py`의 `_format_default` 함수에서 Click 8.2+ `Sentinel.UNSET` 기본값 처리 호환성 수정
- `multiple=True` 옵션의 기본값이 빈 튜플 대신 `Sentinel.UNSET`으로 변경된 것에 대응
- 기존 19개 CLI 레퍼런스 생성 테스트 전체 통과

## Test plan
- [x] `tests/unit/test_generate_cli_reference.py` 19/19 통과
- [x] 전체 단위 테스트 1671 passed

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)