### PR TITLE
fix: asyncio.CancelledError 미재발생 버그 수정

### DIFF
--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -351,7 +351,7 @@ class BotManager:
         try:
             await asyncio.sleep(bot.config.restart_cooldown_seconds)
         except asyncio.CancelledError:
-            return
+            raise
 
         if bot.status != BotStatus.ERROR:
             return
@@ -389,7 +389,7 @@ class BotManager:
         try:
             await asyncio.sleep(seconds)
         except asyncio.CancelledError:
-            return
+            raise
 
         bot = self._bots.get(bot_id)
         if bot and bot.status == BotStatus.RUNNING:

--- a/src/ante/bot/signal_channel.py
+++ b/src/ante/bot/signal_channel.py
@@ -69,7 +69,7 @@ class SignalChannel:
                     break
                 await self._handle_line(line.decode("utf-8").strip())
             except asyncio.CancelledError:
-                break
+                raise
             except Exception:
                 logger.exception("채널 메시지 처리 오류")
 

--- a/src/ante/data/collector.py
+++ b/src/ante/data/collector.py
@@ -127,7 +127,7 @@ class DataCollector:
             try:
                 await asyncio.sleep(self._collect_interval)
             except asyncio.CancelledError:
-                break
+                raise
 
     async def _flush_loop(self) -> None:
         """주기적 버퍼 flush."""
@@ -135,7 +135,7 @@ class DataCollector:
             try:
                 await asyncio.sleep(self._flush_interval)
             except asyncio.CancelledError:
-                break
+                raise
             await self.flush_all()
 
     async def _flush(self, key: str) -> None:

--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -83,7 +83,7 @@ class TelegramCommandReceiver:
                 for update in updates:
                     await self._handle_update(update)
             except asyncio.CancelledError:
-                break
+                raise
             except Exception:
                 logger.warning("텔레그램 폴링 실패, 다음 주기에 재시도", exc_info=True)
 


### PR DESCRIPTION
## Summary

- `asyncio.CancelledError`를 catch 후 `break`/`return`으로 삼키던 6건을 `raise`로 변경하여 취소 신호가 정상 전파되도록 수정
- 셧다운 시 프로세스 hang 및 리소스 누수 방지

### 수정 파일 (6건)
| 파일 | 메서드 | 변경 |
|------|--------|------|
| `data/collector.py:129` | `_collect_loop` | `break` → `raise` |
| `data/collector.py:137` | `_flush_loop` | `break` → `raise` |
| `bot/signal_channel.py:71` | `run` | `break` → `raise` |
| `notification/telegram_receiver.py:85` | `_poll_loop` | `break` → `raise` |
| `bot/manager.py:353` | `_restart_after_cooldown` | `return` → `raise` |
| `bot/manager.py:391` | `_reset_restart_count_after` | `return` → `raise` |

### 제외 사유 (5건)
나머지 5건(`treasury.py:470`, `bot.py:80`, `main.py:493`, `kis_stream.py:117`, `telegram_receiver.py:71`)은 `task.cancel()` + `await task` 패턴으로, 호출자가 의도적으로 취소를 발생시키고 대기하는 구조이므로 `asyncio-patterns.md` §2의 정규 패턴에 따라 `pass`가 올바릅니다.

## Test plan
- [x] `ruff check` 통과
- [x] `ruff format` 통과
- [x] `pytest tests/` 전체 테스트 통과 (1750 passed, 3 skipped)

Refs #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)