### PR TITLE
refactor: main.py Composition Root 분리

### DIFF
--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1,12 +1,16 @@
 """Ante - AI-Native Trading Engine entrypoint.
 
 Composition Root: 모든 모듈을 조립하고 시스템을 부팅한다.
+각 _init_*() 함수가 독립적 초기화 단위를 담당하고,
+main()은 조율만 수행한다.
 """
 
 import asyncio
 import logging
 import signal
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from ante.config import Config, DynamicConfigService, SystemState
 from ante.core import Database
@@ -15,131 +19,151 @@ from ante.eventbus import EventBus, EventHistoryStore
 logger = logging.getLogger(__name__)
 
 
-async def main() -> None:
-    """Main asyncio entrypoint.
+@dataclass
+class Services:
+    """초기화된 서비스 인스턴스를 전달하는 컨테이너."""
 
-    초기화 순서 (architecture.md 참조):
-    1. Config + Logging
-    2. Database
-    3. EventBus + EventHistoryStore
-    4. SystemState (킬 스위치)
-    5. DynamicConfigService
-    6. StrategyRegistry
-    7. RuleEngine
-    8. Treasury
-    9. Trade (Recorder, PositionHistory, PerformanceTracker, Service)
-    10. BotManager
-    11. Broker (KISAdapter) + APIGateway
-    12. Data Pipeline (ParquetStore, DataCollector)
-    13. BacktestService
-    14. ReportStore
-    15. NotificationService
-    16. Web API (FastAPI)
+    config: Any = None
+    db: Database | None = None
+    eventbus: EventBus | None = None
+    event_history: EventHistoryStore | None = None
+    system_state: SystemState | None = None
+    dynamic_config: DynamicConfigService | None = None
+    audit_logger: Any = None
+    member_service: Any = None
+    instrument_service: Any = None
+    strategy_registry: Any = None
+    rule_engine: Any = None
+    treasury: Any = None
+    trade_recorder: Any = None
+    position_history: Any = None
+    performance_tracker: Any = None
+    trade_service: Any = None
+    bot_manager: Any = None
+    paper_executor: Any = None
+    live_portfolio: Any = None
+    live_order_view: Any = None
+    strategy_snapshot: Any = None
+    broker: Any = None
+    api_gateway: Any = None
+    data_provider: Any = None
+    parquet_store: Any = None
+    data_collector: Any = None
+    backtest_service: Any = None
+    report_store: Any = None
+    approval_service: Any = None
+    notification_service: Any = None
+    telegram_receiver: Any = None
+    web_task: asyncio.Task | None = None  # type: ignore[type-arg]
+    commission_rate: float = 0.00015
+    sell_tax_rate: float = 0.0023
+    _cleanup_tasks: list[str] = field(default_factory=list)
 
-    종료 순서: 역순 (상위 소비자부터 정리)
-    """
-    # ── 1. Config ────────────────────────────────────
-    config = Config.load()
-    config.validate()
 
-    log_level = config.get("system.log_level", "INFO")
+async def _init_core(s: Services) -> None:
+    """Config, Database, EventBus, SystemState, DynamicConfig 초기화."""
+    # Config
+    s.config = Config.load()
+    s.config.validate()
+
+    log_level = s.config.get("system.log_level", "INFO")
     logging.basicConfig(
         level=getattr(logging, log_level),
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
     logger.info("Ante 시작")
 
-    # ── 2. Database ──────────────────────────────────
-    db_path = config.get("db.path", "db/ante.db")
+    # Database
+    db_path = s.config.get("db.path", "db/ante.db")
     Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-    db = Database(db_path)
-    await db.connect()
+    s.db = Database(db_path)
+    await s.db.connect()
     logger.info("Database 연결 완료: %s", db_path)
 
-    # ── 3. EventBus ──────────────────────────────────
-    history_size = config.get("eventbus.history_size", 1000)
-    eventbus = EventBus(history_size=history_size)
-
-    event_history = EventHistoryStore(db=db)
-    await event_history.initialize()
-    eventbus.use(event_history.record)
+    # EventBus + EventHistoryStore
+    history_size = s.config.get("eventbus.history_size", 1000)
+    s.eventbus = EventBus(history_size=history_size)
+    s.event_history = EventHistoryStore(db=s.db)
+    await s.event_history.initialize()
+    s.eventbus.use(s.event_history.record)
     logger.info("EventBus 초기화 완료 (history_size=%d)", history_size)
 
-    # ── 4. SystemState (킬 스위치) ───────────────────
-    system_state = SystemState(db=db, eventbus=eventbus)
-    await system_state.initialize()
-    logger.info("SystemState 초기화 완료: %s", system_state.trading_state)
+    # SystemState (킬 스위치)
+    s.system_state = SystemState(db=s.db, eventbus=s.eventbus)
+    await s.system_state.initialize()
+    logger.info("SystemState 초기화 완료: %s", s.system_state.trading_state)
 
-    # ── 5. DynamicConfigService ──────────────────────
-    dynamic_config = DynamicConfigService(db=db, eventbus=eventbus)
-    await dynamic_config.initialize()
+    # DynamicConfigService
+    s.dynamic_config = DynamicConfigService(db=s.db, eventbus=s.eventbus)
+    await s.dynamic_config.initialize()
 
-    # log_level 동적 설정: 기본값 등록 + 변경 구독
     from ante.config.dynamic import _on_log_level_changed
     from ante.eventbus.events import ConfigChangedEvent
 
-    await dynamic_config.register_default(
+    await s.dynamic_config.register_default(
         "system.log_level", log_level, category="system"
     )
-    await dynamic_config.register_default(
+    await s.dynamic_config.register_default(
         "display.currency_position", "suffix", category="display"
     )
-    eventbus.subscribe(ConfigChangedEvent, _on_log_level_changed)
+    s.eventbus.subscribe(ConfigChangedEvent, _on_log_level_changed)
     logger.info("DynamicConfigService 초기화 완료")
 
-    # ── 5.5. AuditLogger ────────────────────────────────
+
+async def _init_services(s: Services) -> None:
+    """AuditLogger, MemberService, InstrumentService 초기화."""
     from ante.audit import AuditLogger
 
-    audit_logger = AuditLogger(db=db)
-    await audit_logger.initialize()
+    s.audit_logger = AuditLogger(db=s.db)
+    await s.audit_logger.initialize()
     logger.info("AuditLogger 초기화 완료")
 
-    # ── 5.6. MemberService ─────────────────────────────
     from ante.member import MemberService
 
-    member_service = MemberService(db=db, eventbus=eventbus)
-    await member_service.initialize()
+    s.member_service = MemberService(db=s.db, eventbus=s.eventbus)
+    await s.member_service.initialize()
     logger.info("MemberService 초기화 완료")
 
-    # ── 5.7. InstrumentService ─────────────────────────
     from ante.instrument import InstrumentService
 
-    instrument_service = InstrumentService(db=db)
-    await instrument_service.initialize()
+    s.instrument_service = InstrumentService(db=s.db)
+    await s.instrument_service.initialize()
 
-    # ── 6. StrategyRegistry ──────────────────────────
+
+async def _init_trading(s: Services) -> None:
+    """StrategyRegistry, RuleEngine, Treasury, Trade, BotManager 초기화."""
     from ante.strategy import StrategyRegistry
 
-    strategy_registry = StrategyRegistry(db=db)
-    await strategy_registry.initialize()
+    s.strategy_registry = StrategyRegistry(db=s.db)
+    await s.strategy_registry.initialize()
     logger.info("StrategyRegistry 초기화 완료")
 
-    # ── 7. RuleEngine ────────────────────────────────
+    # RuleEngine
     from ante.rule import RuleEngine
 
-    rule_engine = RuleEngine(eventbus=eventbus, system_state=system_state)
-    await rule_engine.start()
+    s.rule_engine = RuleEngine(eventbus=s.eventbus, system_state=s.system_state)
+    await s.rule_engine.start()
 
-    rule_configs = config.get("rules.global", [])
+    rule_configs = s.config.get("rules.global", [])
     if rule_configs:
-        rule_engine.load_rules_from_config(rule_configs)
+        s.rule_engine.load_rules_from_config(rule_configs)
     logger.info("RuleEngine 초기화 완료")
 
-    # ── 8. Treasury ──────────────────────────────────
+    # Treasury
     from ante.treasury import Treasury
 
-    commission_rate = config.get("broker.commission_rate", 0.00015)
-    sell_tax_rate = config.get("broker.sell_tax_rate", 0.0023)
-    treasury = Treasury(
-        db=db,
-        eventbus=eventbus,
-        commission_rate=commission_rate,
-        sell_tax_rate=sell_tax_rate,
+    s.commission_rate = s.config.get("broker.commission_rate", 0.00015)
+    s.sell_tax_rate = s.config.get("broker.sell_tax_rate", 0.0023)
+    s.treasury = Treasury(
+        db=s.db,
+        eventbus=s.eventbus,
+        commission_rate=s.commission_rate,
+        sell_tax_rate=s.sell_tax_rate,
     )
-    await treasury.initialize()
+    await s.treasury.initialize()
     logger.info("Treasury 초기화 완료")
 
-    # ── 9. Trade ─────────────────────────────────────
+    # Trade
     from ante.trade import (
         PerformanceTracker,
         PositionHistory,
@@ -147,76 +171,76 @@ async def main() -> None:
         TradeService,
     )
 
-    position_history = PositionHistory(db=db)
-    await position_history.initialize()
+    s.position_history = PositionHistory(db=s.db)
+    await s.position_history.initialize()
 
-    trade_recorder = TradeRecorder(db=db, position_history=position_history)
-    await trade_recorder.initialize()
-    trade_recorder.subscribe(eventbus)
+    s.trade_recorder = TradeRecorder(db=s.db, position_history=s.position_history)
+    await s.trade_recorder.initialize()
+    s.trade_recorder.subscribe(s.eventbus)
 
-    performance_tracker = PerformanceTracker(db=db)
+    s.performance_tracker = PerformanceTracker(db=s.db)
 
-    trade_service = TradeService(
-        recorder=trade_recorder,
-        position_history=position_history,
-        performance=performance_tracker,
+    s.trade_service = TradeService(
+        recorder=s.trade_recorder,
+        position_history=s.position_history,
+        performance=s.performance_tracker,
     )
     logger.info("Trade 모듈 초기화 완료")
 
-    # ── 10. BotManager + StrategyContextFactory ──────
-    from ante.bot import BotManager, StrategyContextFactory
+    # BotManager + StrategyContextFactory
+    from ante.bot import BotManager, StrategyContextFactory  # noqa: F401
     from ante.bot.providers.live import LiveOrderView, LivePortfolioView
     from ante.bot.providers.paper import PaperExecutor
-
-    # PaperExecutor (paper 봇이 존재할 때 가상 체결 처리)
-    paper_executor = PaperExecutor(
-        eventbus=eventbus,
-        gateway=None,  # APIGateway 연결 후 설정
-        commission_rate=commission_rate,
-        sell_tax_rate=sell_tax_rate,
-    )
-    paper_executor.subscribe()
-
-    # Live 프로바이더
-    live_portfolio = LivePortfolioView(
-        treasury=treasury,
-        position_history=position_history,
-    )
-    live_order_view = LiveOrderView(order_registry=None)  # Broker 연결 후 설정
-
-    # StrategyContextFactory
-
-    # DataProvider는 APIGateway 연결 후 설정 (11단계)
-    context_factory: StrategyContextFactory | None = None
-
     from ante.strategy.snapshot import StrategySnapshot
 
-    strategies_dir = Path(config.get("strategy.dir", "strategies"))
-    strategy_snapshot = StrategySnapshot(strategies_dir)
-
-    bot_manager = BotManager(
-        eventbus=eventbus,
-        db=db,
-        context_factory=context_factory,  # APIGateway 연결 후 갱신
-        snapshot=strategy_snapshot,
+    s.paper_executor = PaperExecutor(
+        eventbus=s.eventbus,
+        gateway=None,  # APIGateway 연결 후 설정
+        commission_rate=s.commission_rate,
+        sell_tax_rate=s.sell_tax_rate,
     )
-    await bot_manager.initialize()
+    s.paper_executor.subscribe()
+
+    s.live_portfolio = LivePortfolioView(
+        treasury=s.treasury,
+        position_history=s.position_history,
+    )
+    s.live_order_view = LiveOrderView(order_registry=None)  # Broker 연결 후 설정
+
+    strategies_dir = Path(s.config.get("strategy.dir", "strategies"))
+    s.strategy_snapshot = StrategySnapshot(strategies_dir)
+
+    s.bot_manager = BotManager(
+        eventbus=s.eventbus,
+        db=s.db,
+        context_factory=None,  # APIGateway 연결 후 갱신
+        snapshot=s.strategy_snapshot,
+    )
+    await s.bot_manager.initialize()
 
     # Treasury에 봇 상태 확인 콜백 연결
     def _get_bot_status(bot_id: str) -> str:
-        bot = bot_manager.get_bot(bot_id)
+        bot = s.bot_manager.get_bot(bot_id)
         return bot.status if bot else ""
 
-    treasury.set_bot_status_checker(_get_bot_status)
+    s.treasury.set_bot_status_checker(_get_bot_status)
     logger.info("BotManager 초기화 완료")
 
-    # ── 11. Broker + APIGateway ──────────────────────
+    # Broker + APIGateway
+    await _init_broker(s)
+
+    # StrategyContextFactory 완성 (Broker 연결 이후)
+    await _init_context_factory(s)
+
+    # Treasury 잔고 동기화 (Broker 연결 이후)
+    await _init_treasury_sync(s)
+
+
+async def _init_broker(s: Services) -> None:
+    """Broker, APIGateway 연결 및 종목 마스터 동기화."""
     from ante.gateway import APIGateway
 
-    broker = None
-    api_gateway = None
-
-    broker_config = config.get("broker", {})
+    broker_config = s.config.get("broker", {})
     broker_type = (
         broker_config.get("type", "kis") if isinstance(broker_config, dict) else "kis"
     )
@@ -224,42 +248,42 @@ async def main() -> None:
     if broker_type == "mock":
         from ante.broker.mock import MockBrokerAdapter
 
-        broker = MockBrokerAdapter(
+        s.broker = MockBrokerAdapter(
             broker_config if isinstance(broker_config, dict) else {}
         )
-        await broker.connect()
+        await s.broker.connect()
         logger.info("MockBrokerAdapter 연결 완료")
     else:
         from ante.broker import KISAdapter
 
         try:
-            broker_config["app_key"] = config.secret("KIS_APP_KEY")
-            broker_config["app_secret"] = config.secret("KIS_APP_SECRET")
-            broker_config["account_no"] = config.secret("KIS_ACCOUNT_NO")
+            broker_config["app_key"] = s.config.secret("KIS_APP_KEY")
+            broker_config["app_secret"] = s.config.secret("KIS_APP_SECRET")
+            broker_config["account_no"] = s.config.secret("KIS_ACCOUNT_NO")
         except Exception:
             pass  # 비밀값 없으면 브로커 미사용
 
         if broker_config.get("app_key"):
-            broker = KISAdapter(config=broker_config, eventbus=eventbus)
+            s.broker = KISAdapter(config=broker_config, eventbus=s.eventbus)
             try:
-                await broker.connect()
+                await s.broker.connect()
                 logger.info(
                     "KISAdapter 연결 완료 (paper=%s)",
                     broker_config.get("is_paper", True),
                 )
             except Exception:
                 logger.warning("KISAdapter 연결 실패 — 브로커 없이 시작", exc_info=True)
-                broker = None
+                s.broker = None
 
-    if broker:
-        api_gateway = APIGateway(broker=broker, eventbus=eventbus)
-        await api_gateway.start()
+    if s.broker:
+        s.api_gateway = APIGateway(broker=s.broker, eventbus=s.eventbus)
+        await s.api_gateway.start()
         logger.info("APIGateway 시작 완료")
 
-    # ── 11.1. 종목 마스터 동기화 ───────────────────────
-    if broker:
+    # 종목 마스터 동기화
+    if s.broker:
         try:
-            raw_instruments = await broker.get_instruments()
+            raw_instruments = await s.broker.get_instruments()
             if raw_instruments:
                 from ante.instrument.models import Instrument
 
@@ -274,196 +298,201 @@ async def main() -> None:
                     )
                     for item in raw_instruments
                 ]
-                count = await instrument_service.bulk_upsert(instruments_to_upsert)
+                count = await s.instrument_service.bulk_upsert(instruments_to_upsert)
                 logger.info("종목 동기화 완료: %d건 갱신", count)
         except Exception:
             logger.warning("종목 동기화 실패 — 기존 캐시 데이터로 운영", exc_info=True)
 
-    # ── 11.5. StrategyContextFactory 완성 ─────────────
+
+async def _init_context_factory(s: Services) -> None:
+    """StrategyContextFactory 완성 (Broker/APIGateway 연결 이후)."""
+    from ante.bot import StrategyContextFactory
+    from ante.bot.providers.live import LiveTradeHistoryView
     from ante.gateway.data_provider import LiveDataProvider
 
-    data_provider: LiveDataProvider | None = None
-    if api_gateway:
-        data_provider = LiveDataProvider(gateway=api_gateway)
-        paper_executor._gateway = api_gateway
+    if s.api_gateway:
+        s.data_provider = LiveDataProvider(gateway=s.api_gateway)
+        s.paper_executor._gateway = s.api_gateway
 
-    from ante.bot.providers.live import LiveTradeHistoryView
+    live_trade_history = LiveTradeHistoryView(trade_recorder=s.trade_recorder)
 
-    live_trade_history = LiveTradeHistoryView(trade_recorder=trade_recorder)
-
-    if data_provider:
+    if s.data_provider:
         context_factory = StrategyContextFactory(
-            data_provider=data_provider,
-            live_portfolio=live_portfolio,
-            live_order_view=live_order_view,
-            paper_executor=paper_executor,
+            data_provider=s.data_provider,
+            live_portfolio=s.live_portfolio,
+            live_order_view=s.live_order_view,
+            paper_executor=s.paper_executor,
             live_trade_history=live_trade_history,
         )
-        bot_manager._context_factory = context_factory
+        s.bot_manager._context_factory = context_factory
         logger.info("StrategyContextFactory 설정 완료")
 
-    # ── 11.6. Treasury 잔고 동기화 ────────────────────
-    if broker:
-        # KIS 계좌 메타 정보 전달
-        account_no = getattr(broker, "account_no", "")
-        is_paper = getattr(broker, "is_paper", False)
-        formatted_account = (
-            f"{account_no[:8]}-{account_no[8:]}"
-            if len(account_no) >= 10
-            else account_no
-        )
-        treasury.set_account_info(
-            account_number=formatted_account,
-            is_demo_trading=is_paper,
-        )
 
-        sync_interval = config.get("treasury.sync_interval_seconds", 300)
-        await treasury.start_sync(
-            broker=broker,
-            position_history=position_history,
-            interval_seconds=sync_interval,
-        )
-        logger.info("Treasury 잔고 동기화 시작 (주기: %d초)", sync_interval)
+async def _init_treasury_sync(s: Services) -> None:
+    """Treasury 잔고 동기화 시작 (Broker 연결 이후)."""
+    if not s.broker:
+        return
 
-    # ── 12. Data Pipeline ────────────────────────────
+    account_no = getattr(s.broker, "account_no", "")
+    is_paper = getattr(s.broker, "is_paper", False)
+    formatted_account = (
+        f"{account_no[:8]}-{account_no[8:]}" if len(account_no) >= 10 else account_no
+    )
+    s.treasury.set_account_info(
+        account_number=formatted_account,
+        is_demo_trading=is_paper,
+    )
+
+    sync_interval = s.config.get("treasury.sync_interval_seconds", 300)
+    await s.treasury.start_sync(
+        broker=s.broker,
+        position_history=s.position_history,
+        interval_seconds=sync_interval,
+    )
+    logger.info("Treasury 잔고 동기화 시작 (주기: %d초)", sync_interval)
+
+
+async def _init_feed(s: Services) -> None:
+    """Data Pipeline, BacktestService, ReportStore, ApprovalService 초기화."""
     from ante.data import DataCollector, ParquetStore
 
-    data_path = config.get("data.path", "data/")
+    data_path = s.config.get("data.path", "data/")
     Path(data_path).mkdir(parents=True, exist_ok=True)
-    parquet_store = ParquetStore(base_path=Path(data_path))
+    s.parquet_store = ParquetStore(base_path=Path(data_path))
 
-    data_collector = None
-    if api_gateway:
-        data_collector = DataCollector(store=parquet_store, eventbus=eventbus)  # noqa: F841
+    if s.api_gateway:
+        s.data_collector = DataCollector(store=s.parquet_store, eventbus=s.eventbus)
     logger.info("Data Pipeline 초기화 완료: %s", data_path)
 
-    # ── 13. BacktestService ──────────────────────────
+    # BacktestService
     from ante.backtest import BacktestService
 
-    backtest_service = BacktestService(data_path=data_path)  # noqa: F841
+    s.backtest_service = BacktestService(data_path=data_path)
     logger.info("BacktestService 초기화 완료")
 
-    # ── 14. ReportStore ──────────────────────────────
+    # ReportStore
     from ante.report import ReportStore
 
-    report_store = ReportStore(db=db)
-    await report_store.initialize()
+    s.report_store = ReportStore(db=s.db)
+    await s.report_store.initialize()
     logger.info("ReportStore 초기화 완료")
 
-    # ── 14.5. ApprovalService ──────────────────────────
+    # ApprovalService
     from ante.approval import ApprovalService
 
     approval_executors: dict = {
-        "strategy_adopt": lambda params: report_store.update_status(
+        "strategy_adopt": lambda params: s.report_store.update_status(
             params["report_id"], "adopted"
         ),
-        "bot_stop": lambda params: bot_manager.stop_bot(params["bot_id"]),
+        "bot_stop": lambda params: s.bot_manager.stop_bot(params["bot_id"]),
     }
-    approval_service = ApprovalService(  # noqa: F841
-        db=db, eventbus=eventbus, executors=approval_executors
+    s.approval_service = ApprovalService(
+        db=s.db, eventbus=s.eventbus, executors=approval_executors
     )
-    await approval_service.initialize()
+    await s.approval_service.initialize()
     logger.info("ApprovalService 초기화 완료")
 
-    # ── 15. NotificationService ──────────────────────
+
+async def _init_notification(s: Services) -> None:
+    """NotificationService, TelegramCommandReceiver 초기화."""
     from ante.notification import (
         NotificationLevel,
         NotificationService,
         TelegramAdapter,
     )
 
-    notification_service = None
-    telegram_token = config.secret("TELEGRAM_BOT_TOKEN")
-    telegram_chat_id = config.secret("TELEGRAM_CHAT_ID")
+    telegram_token = s.config.secret("TELEGRAM_BOT_TOKEN")
+    telegram_chat_id = s.config.secret("TELEGRAM_CHAT_ID")
 
-    if telegram_token and telegram_chat_id:
-        adapter = TelegramAdapter(bot_token=telegram_token, chat_id=telegram_chat_id)
-        min_level_str = config.get("notification.min_level", "info")
-        notification_service = NotificationService(
-            adapter=adapter,
-            eventbus=eventbus,
-            min_level=NotificationLevel(min_level_str),
-            instrument_service=instrument_service,
-            db=db,
-        )
-        await notification_service.initialize()
-        notification_service.subscribe()
-        logger.info("NotificationService 초기화 완료 (Telegram)")
-    else:
+    if not (telegram_token and telegram_chat_id):
         logger.info("NotificationService 건너뜀 — Telegram 설정 없음")
+        return
 
-    # ── 15.5. TelegramCommandReceiver ─────────────────
-    telegram_receiver = None
-    if telegram_token and telegram_chat_id:
-        from ante.notification import TelegramCommandReceiver
+    adapter = TelegramAdapter(bot_token=telegram_token, chat_id=telegram_chat_id)
+    min_level_str = s.config.get("notification.min_level", "info")
+    s.notification_service = NotificationService(
+        adapter=adapter,
+        eventbus=s.eventbus,
+        min_level=NotificationLevel(min_level_str),
+        instrument_service=s.instrument_service,
+        db=s.db,
+    )
+    await s.notification_service.initialize()
+    s.notification_service.subscribe()
+    logger.info("NotificationService 초기화 완료 (Telegram)")
 
-        allowed_ids_raw = config.get("telegram.command.allowed_user_ids", [])
-        allowed_user_ids = (
-            [int(uid) for uid in allowed_ids_raw] if allowed_ids_raw else []
+    # TelegramCommandReceiver
+    from ante.notification import TelegramCommandReceiver
+
+    allowed_ids_raw = s.config.get("telegram.command.allowed_user_ids", [])
+    allowed_user_ids = [int(uid) for uid in allowed_ids_raw] if allowed_ids_raw else []
+
+    if allowed_user_ids:
+        s.telegram_receiver = TelegramCommandReceiver(
+            adapter=adapter,
+            allowed_user_ids=allowed_user_ids,
+            polling_interval=s.config.get("telegram.command.polling_interval", 3.0),
+            confirm_timeout=s.config.get("telegram.command.confirm_timeout", 30.0),
+            bot_manager=s.bot_manager,
+            treasury=s.treasury,
+            system_state=s.system_state,
         )
+        s.telegram_receiver.start()
+        logger.info("TelegramCommandReceiver 시작")
+    else:
+        logger.info("TelegramCommandReceiver 건너뜀 — allowed_user_ids 비어있음")
 
-        if allowed_user_ids:
-            telegram_receiver = TelegramCommandReceiver(
-                adapter=adapter,
-                allowed_user_ids=allowed_user_ids,
-                polling_interval=config.get("telegram.command.polling_interval", 3.0),
-                confirm_timeout=config.get("telegram.command.confirm_timeout", 30.0),
-                bot_manager=bot_manager,
-                treasury=treasury,
-                system_state=system_state,
-            )
-            telegram_receiver.start()
-            logger.info("TelegramCommandReceiver 시작")
-        else:
-            logger.info("TelegramCommandReceiver 건너뜀 — allowed_user_ids 비어있음")
 
-    # ── 16. Web API ──────────────────────────────────
-    web_task = None
-    web_enabled = config.get("web.enabled", False)
+async def _init_web(s: Services) -> None:
+    """FastAPI 앱 생성 및 uvicorn 서버 시작."""
+    web_enabled = s.config.get("web.enabled", False)
+    if not web_enabled:
+        return
 
-    if web_enabled:
-        from ante.web.app import create_app
-        from ante.web.session import SessionService
+    from ante.web.app import create_app
+    from ante.web.session import SessionService
 
-        session_service = SessionService(db=db)
-        await session_service.initialize()
+    session_service = SessionService(db=s.db)
+    await session_service.initialize()
 
-        app = create_app(
-            config=config,
-            db=db,
-            eventbus=eventbus,
-            bot_manager=bot_manager,
-            trade_service=trade_service,
-            treasury=treasury,
-            broker=broker,
-            report_store=report_store,
-            data_store=parquet_store,
-            audit_logger=audit_logger,
-            member_service=member_service,
-            session_service=session_service,
-            strategy_registry=strategy_registry,
-            dynamic_config=dynamic_config,
-            approval_service=approval_service,
-            system_state=system_state,
-        )
+    app = create_app(
+        config=s.config,
+        db=s.db,
+        eventbus=s.eventbus,
+        bot_manager=s.bot_manager,
+        trade_service=s.trade_service,
+        treasury=s.treasury,
+        broker=s.broker,
+        report_store=s.report_store,
+        data_store=s.parquet_store,
+        audit_logger=s.audit_logger,
+        member_service=s.member_service,
+        session_service=session_service,
+        strategy_registry=s.strategy_registry,
+        dynamic_config=s.dynamic_config,
+        approval_service=s.approval_service,
+        system_state=s.system_state,
+    )
 
-        import uvicorn
+    import uvicorn
 
-        uv_config = uvicorn.Config(
-            app,
-            host=config.get("web.host", "0.0.0.0"),
-            port=config.get("web.port", 8000),
-            log_level="info",
-        )
-        server = uvicorn.Server(uv_config)
-        web_task = asyncio.create_task(server.serve(), name="web-api")
-        logger.info(
-            "Web API 시작: http://%s:%d",
-            uv_config.host,
-            uv_config.port,
-        )
+    uv_config = uvicorn.Config(
+        app,
+        host=s.config.get("web.host", "0.0.0.0"),
+        port=s.config.get("web.port", 8000),
+        log_level="info",
+    )
+    server = uvicorn.Server(uv_config)
+    s.web_task = asyncio.create_task(server.serve(), name="web-api")
+    logger.info(
+        "Web API 시작: http://%s:%d",
+        uv_config.host,
+        uv_config.port,
+    )
 
-    # ── Graceful Shutdown ────────────────────────────
+
+async def _run(s: Services) -> None:
+    """시그널 대기 및 Graceful Shutdown."""
     shutdown_event = asyncio.Event()
 
     def _signal_handler() -> None:
@@ -477,43 +506,64 @@ async def main() -> None:
     logger.info("Ante 준비 완료 — 종료 시그널 대기 중")
     await shutdown_event.wait()
 
-    # ── 종료 정리 (역순) ─────────────────────────────
+    await _shutdown(s)
+
+
+async def _shutdown(s: Services) -> None:
+    """종료 정리 (역순)."""
     logger.info("Ante 종료 시작")
 
-    # 15.5 TelegramCommandReceiver
-    if telegram_receiver:
-        await telegram_receiver.stop()
+    if s.telegram_receiver:
+        await s.telegram_receiver.stop()
         logger.info("TelegramCommandReceiver 종료")
 
-    # 16. Web API
-    if web_task and not web_task.done():
-        web_task.cancel()
+    if s.web_task and not s.web_task.done():
+        s.web_task.cancel()
         try:
-            await web_task
+            await s.web_task
         except asyncio.CancelledError:
             pass
         logger.info("Web API 종료")
 
-    # 10.5 Treasury 잔고 동기화 중지
-    await treasury.stop_sync()
+    await s.treasury.stop_sync()
 
-    # 10. BotManager (봇 먼저 중지)
-    await bot_manager.stop_all()
+    await s.bot_manager.stop_all()
     logger.info("BotManager 종료 — 모든 봇 중지")
 
-    # 11. APIGateway
-    if api_gateway:
-        await api_gateway.stop()
+    if s.api_gateway:
+        await s.api_gateway.stop()
         logger.info("APIGateway 종료")
 
-    # 11. Broker
-    if broker:
-        await broker.disconnect()
+    if s.broker:
+        await s.broker.disconnect()
         logger.info("Broker 연결 해제")
 
-    # 2. Database (최종)
-    await db.close()
+    await s.db.close()
     logger.info("Ante 종료 완료")
+
+
+async def main() -> None:
+    """Main asyncio entrypoint.
+
+    초기화 순서 (architecture.md 참조):
+    1. Core: Config, Database, EventBus, SystemState, DynamicConfig
+    2. Services: AuditLogger, MemberService, InstrumentService
+    3. Trading: Strategy, Rule, Treasury, Trade, Bot, Broker, Gateway
+    4. Feed: DataPipeline, Backtest, Report, Approval
+    5. Notification: Telegram
+    6. Web: FastAPI + uvicorn
+
+    종료 순서: 역순 (상위 소비자부터 정리)
+    """
+    s = Services()
+
+    await _init_core(s)
+    await _init_services(s)
+    await _init_trading(s)
+    await _init_feed(s)
+    await _init_notification(s)
+    await _init_web(s)
+    await _run(s)
 
 
 if __name__ == "__main__":

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -246,62 +246,79 @@ async def _init_broker(s: Services) -> None:
     )
 
     if broker_type == "mock":
-        from ante.broker.mock import MockBrokerAdapter
-
-        s.broker = MockBrokerAdapter(
-            broker_config if isinstance(broker_config, dict) else {}
-        )
-        await s.broker.connect()
-        logger.info("MockBrokerAdapter 연결 완료")
+        await _connect_mock_broker(s, broker_config)
     else:
-        from ante.broker import KISAdapter
-
-        try:
-            broker_config["app_key"] = s.config.secret("KIS_APP_KEY")
-            broker_config["app_secret"] = s.config.secret("KIS_APP_SECRET")
-            broker_config["account_no"] = s.config.secret("KIS_ACCOUNT_NO")
-        except Exception:
-            pass  # 비밀값 없으면 브로커 미사용
-
-        if broker_config.get("app_key"):
-            s.broker = KISAdapter(config=broker_config, eventbus=s.eventbus)
-            try:
-                await s.broker.connect()
-                logger.info(
-                    "KISAdapter 연결 완료 (paper=%s)",
-                    broker_config.get("is_paper", True),
-                )
-            except Exception:
-                logger.warning("KISAdapter 연결 실패 — 브로커 없이 시작", exc_info=True)
-                s.broker = None
+        await _connect_kis_broker(s, broker_config)
 
     if s.broker:
         s.api_gateway = APIGateway(broker=s.broker, eventbus=s.eventbus)
         await s.api_gateway.start()
         logger.info("APIGateway 시작 완료")
 
-    # 종목 마스터 동기화
     if s.broker:
-        try:
-            raw_instruments = await s.broker.get_instruments()
-            if raw_instruments:
-                from ante.instrument.models import Instrument
+        await _sync_instruments(s)
 
-                instruments_to_upsert = [
-                    Instrument(
-                        symbol=item["symbol"],
-                        exchange="KRX",
-                        name=item.get("name", ""),
-                        name_en=item.get("name_en", ""),
-                        instrument_type=item.get("instrument_type", ""),
-                        listed=item.get("listed", True),
-                    )
-                    for item in raw_instruments
-                ]
-                count = await s.instrument_service.bulk_upsert(instruments_to_upsert)
-                logger.info("종목 동기화 완료: %d건 갱신", count)
-        except Exception:
-            logger.warning("종목 동기화 실패 — 기존 캐시 데이터로 운영", exc_info=True)
+
+async def _connect_mock_broker(s: Services, broker_config: dict) -> None:
+    """MockBrokerAdapter 연결."""
+    from ante.broker.mock import MockBrokerAdapter
+
+    s.broker = MockBrokerAdapter(
+        broker_config if isinstance(broker_config, dict) else {}
+    )
+    await s.broker.connect()
+    logger.info("MockBrokerAdapter 연결 완료")
+
+
+async def _connect_kis_broker(s: Services, broker_config: dict) -> None:
+    """KISAdapter 연결 (비밀값 없으면 건너뜀)."""
+    from ante.broker import KISAdapter
+
+    try:
+        broker_config["app_key"] = s.config.secret("KIS_APP_KEY")
+        broker_config["app_secret"] = s.config.secret("KIS_APP_SECRET")
+        broker_config["account_no"] = s.config.secret("KIS_ACCOUNT_NO")
+    except Exception:
+        return  # 비밀값 없으면 브로커 미사용
+
+    if not broker_config.get("app_key"):
+        return
+
+    s.broker = KISAdapter(config=broker_config, eventbus=s.eventbus)
+    try:
+        await s.broker.connect()
+        logger.info(
+            "KISAdapter 연결 완료 (paper=%s)",
+            broker_config.get("is_paper", True),
+        )
+    except Exception:
+        logger.warning("KISAdapter 연결 실패 — 브로커 없이 시작", exc_info=True)
+        s.broker = None
+
+
+async def _sync_instruments(s: Services) -> None:
+    """종목 마스터 동기화."""
+    try:
+        raw_instruments = await s.broker.get_instruments()
+        if not raw_instruments:
+            return
+        from ante.instrument.models import Instrument
+
+        instruments_to_upsert = [
+            Instrument(
+                symbol=item["symbol"],
+                exchange="KRX",
+                name=item.get("name", ""),
+                name_en=item.get("name_en", ""),
+                instrument_type=item.get("instrument_type", ""),
+                listed=item.get("listed", True),
+            )
+            for item in raw_instruments
+        ]
+        count = await s.instrument_service.bulk_upsert(instruments_to_upsert)
+        logger.info("종목 동기화 완료: %d건 갱신", count)
+    except Exception:
+        logger.warning("종목 동기화 실패 — 기존 캐시 데이터로 운영", exc_info=True)
 
 
 async def _init_context_factory(s: Services) -> None:


### PR DESCRIPTION
## Summary
- `main()` 499줄 God Method를 `Services` 데이터클래스 + 7개 초기화 함수로 분해
- `_init_core()`, `_init_services()`, `_init_trading()`, `_init_feed()`, `_init_notification()`, `_init_web()`, `_run()` 각각 독립 호출 가능
- `main()` 22줄로 축소 (목표 50줄 이하 달성)
- 기존 초기화 순서 및 Graceful Shutdown 역순 로직 완전 보존

## Test plan
- [x] `tests/unit/test_main.py` 5개 테스트 전체 통과
- [x] 전체 단위/통합 테스트 1727개 통과 (3 skipped)
- [x] `ruff check` + `ruff format` 통과
- [x] `main()` 함수 50줄 이하 확인 (22줄)
- [x] 각 초기화 함수 중첩 깊이 3단계 이하 확인

Refs #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)