### PR TITLE
refactor(feed): feed/cli.py 스케줄러 루프 분리

### DIFF
--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -205,6 +205,7 @@ def run_backfill(
     import asyncio
     from pathlib import Path
 
+    from ante.feed.cli_output import format_backfill_result
     from ante.feed.config import FeedConfig
 
     fmt = get_formatter(ctx)
@@ -228,32 +229,7 @@ def run_backfill(
         )
     )
 
-    if fmt.is_json:
-        fmt.output(
-            {
-                "mode": result.mode,
-                "symbols_total": result.symbols_total,
-                "symbols_success": result.symbols_success,
-                "symbols_failed": result.symbols_failed,
-                "rows_written": result.rows_written,
-                "data_types": result.data_types,
-                "duration_seconds": result.duration_seconds,
-                "config_errors": result.config_errors,
-            }
-        )
-    else:
-        click.echo()
-        click.echo(
-            f"Backfill 완료: {result.symbols_success}/{result.symbols_total} 종목 성공"
-        )
-        click.echo(f"  기록: {result.rows_written} rows")
-        click.echo(f"  데이터: {', '.join(result.data_types) or '없음'}")
-        click.echo(f"  소요: {result.duration_seconds:.1f}초")
-        if result.config_errors:
-            click.echo()
-            for err in result.config_errors:
-                click.echo(f"  [경고] {err.get('error', err)}")
-        click.echo()
+    format_backfill_result(result, fmt)
 
 
 @feed_run.command("daily")
@@ -273,6 +249,7 @@ def run_daily(
     import asyncio
     from pathlib import Path
 
+    from ante.feed.cli_output import format_daily_result
     from ante.feed.config import FeedConfig
 
     fmt = get_formatter(ctx)
@@ -312,34 +289,7 @@ def run_daily(
             )
         )
 
-    if fmt.is_json:
-        fmt.output(
-            {
-                "mode": result.mode,
-                "target_date": result.target_date,
-                "symbols_total": result.symbols_total,
-                "symbols_success": result.symbols_success,
-                "symbols_failed": result.symbols_failed,
-                "rows_written": result.rows_written,
-                "data_types": result.data_types,
-                "duration_seconds": result.duration_seconds,
-                "config_errors": result.config_errors,
-            }
-        )
-    else:
-        click.echo()
-        click.echo(
-            f"Daily 수집 완료 ({result.target_date}): "
-            f"{result.symbols_success}/{result.symbols_total} 종목 성공"
-        )
-        click.echo(f"  기록: {result.rows_written} rows")
-        click.echo(f"  데이터: {', '.join(result.data_types) or '없음'}")
-        click.echo(f"  소요: {result.duration_seconds:.1f}초")
-        if result.config_errors:
-            click.echo()
-            for err in result.config_errors:
-                click.echo(f"  [경고] {err.get('error', err)}")
-        click.echo()
+    format_daily_result(result, fmt)
 
 
 # ── start (상주 스케줄러) ─────────────────────────────────────────────────────
@@ -353,10 +303,8 @@ def run_daily(
 def feed_start(ctx: click.Context, data_path: str) -> None:
     """내장 스케줄러로 backfill/daily를 자동 실행하는 상주 프로세스를 시작한다."""
     import asyncio
-    import signal
-    from datetime import datetime, timedelta, timezone
-    from pathlib import Path
 
+    from ante.feed.cli_scheduler import run_scheduler_loop
     from ante.feed.config import FeedConfig
 
     fmt = get_formatter(ctx)
@@ -376,90 +324,16 @@ def feed_start(ctx: click.Context, data_path: str) -> None:
 
     orchestrator = _build_orchestrator(cfg)
 
-    kst = timezone(timedelta(hours=9))
-
-    async def _scheduler_loop() -> None:
-        """스케줄 루프: daily_at / backfill_at 시각에 수집 실행."""
-        stop_event = asyncio.Event()
-        loop = asyncio.get_running_loop()
-
-        def _handle_signal() -> None:
-            logger.info("종료 시그널 수신, 스케줄러 중지...")
-            stop_event.set()
-
-        for sig in (signal.SIGTERM, signal.SIGINT):
-            loop.add_signal_handler(sig, _handle_signal)
-
-        logger.info(
-            "DataFeed 스케줄러 시작 (daily_at=%s, backfill_at=%s)",
-            daily_at,
-            backfill_at,
-        )
-        click.echo(
-            f"DataFeed 스케줄러 시작 (daily_at={daily_at}, backfill_at={backfill_at})"
-        )
-        click.echo("종료하려면 Ctrl+C 또는 SIGTERM을 보내세요.")
-
-        daily_ran_today = False
-        backfill_ran_today = False
-        last_date = ""
-
-        while not stop_event.is_set():
-            now = datetime.now(tz=kst)
-            current_time = now.strftime("%H:%M")
-            current_date_str = now.strftime("%Y-%m-%d")
-
-            # 날짜가 바뀌면 플래그 초기화
-            if last_date and last_date != current_date_str:
-                daily_ran_today = False
-                backfill_ran_today = False
-            last_date = current_date_str
-
-            # daily 실행
-            if not daily_ran_today and current_time >= str(daily_at):
-                logger.info("Daily 수집 시작 (%s)", current_date_str)
-                try:
-                    result = await orchestrator.run_daily(
-                        data_path=Path(data_path),
-                        config=config,
-                    )
-                    click.echo(
-                        f"[{current_date_str}] Daily 완료: "
-                        f"{result.symbols_success}/{result.symbols_total} 종목, "
-                        f"{result.rows_written} rows"
-                    )
-                except Exception as exc:
-                    logger.error("Daily 수집 실패: %s", exc)
-                daily_ran_today = True
-
-            # backfill 실행
-            if not backfill_ran_today and current_time >= str(backfill_at):
-                logger.info("Backfill 수집 시작 (%s)", current_date_str)
-                try:
-                    result = await orchestrator.run_backfill(
-                        data_path=Path(data_path),
-                        config=config,
-                    )
-                    click.echo(
-                        f"[{current_date_str}] Backfill 완료: "
-                        f"{result.symbols_success}/{result.symbols_total} 종목, "
-                        f"{result.rows_written} rows"
-                    )
-                except Exception as exc:
-                    logger.error("Backfill 수집 실패: %s", exc)
-                backfill_ran_today = True
-
-            # 60초 대기 (stop_event 감시)
-            try:
-                await asyncio.wait_for(stop_event.wait(), timeout=60.0)
-            except TimeoutError:
-                pass
-
-        logger.info("DataFeed 스케줄러 종료")
-        click.echo("DataFeed 스케줄러 종료")
-
     try:
-        asyncio.run(_scheduler_loop())
+        asyncio.run(
+            run_scheduler_loop(
+                orchestrator=orchestrator,
+                data_path=data_path,
+                config=config,
+                daily_at=daily_at,
+                backfill_at=backfill_at,
+            )
+        )
     except KeyboardInterrupt:
         click.echo("\nDataFeed 스케줄러 종료")
 
@@ -536,53 +410,73 @@ def feed_status(ctx: click.Context, data_path: str) -> None:
             }
         )
     else:
-        click.echo()
-        click.echo(f"DataFeed Status ({cfg.feed_dir})")
-        click.echo("══════════════════════════════════════════════════")
+        _echo_status_text(cfg, checkpoints, latest_report, api_keys)
 
-        # 체크포인트 섹션
-        click.echo()
-        click.echo("Checkpoints")
-        click.echo("──────────────────────────────────────────────────")
-        if checkpoints:
-            for cp in checkpoints:
-                click.echo(
-                    f"  {cp['source']}/{cp['data_type']:<16}"
-                    f" last_date: {cp['last_date']}"
-                    f"  (updated: {cp['updated_at']})"
-                )
-        else:
-            click.echo("  (체크포인트 없음 — 아직 수집을 실행하지 않았습니다)")
 
-        # 최근 리포트 섹션
-        click.echo()
-        click.echo("Latest Report")
-        click.echo("──────────────────────────────────────────────────")
-        if latest_report:
-            summary = latest_report.get("summary", {})
-            click.echo(f"  mode: {latest_report.get('mode', '?')}")
-            click.echo(f"  date: {latest_report.get('target_date', '?')}")
+def _echo_status_text(
+    cfg: object,  # FeedConfig
+    checkpoints: list[dict[str, str]],
+    latest_report: dict | None,
+    api_keys: list[dict],
+) -> None:
+    """feed status의 텍스트 출력을 수행한다."""
+    click.echo()
+    click.echo(f"DataFeed Status ({cfg.feed_dir})")  # type: ignore[attr-defined]
+    click.echo("══════════════════════════════════════════════════")
+
+    _echo_checkpoints_section(checkpoints)
+    _echo_report_section(latest_report)
+    _echo_api_keys_section(api_keys)
+
+    click.echo()
+
+
+def _echo_checkpoints_section(checkpoints: list[dict[str, str]]) -> None:
+    """체크포인트 섹션을 출력한다."""
+    click.echo()
+    click.echo("Checkpoints")
+    click.echo("──────────────────────────────────────────────────")
+    if checkpoints:
+        for cp in checkpoints:
             click.echo(
-                f"  result: {summary.get('symbols_success', 0)} success"
-                f" / {summary.get('symbols_failed', 0)} failed"
-                f" / {len(latest_report.get('warnings', []))} warnings"
+                f"  {cp['source']}/{cp['data_type']:<16}"
+                f" last_date: {cp['last_date']}"
+                f"  (updated: {cp['updated_at']})"
             )
-            click.echo(f"  rows: {summary.get('rows_written', 0)}")
+    else:
+        click.echo("  (체크포인트 없음 — 아직 수집을 실행하지 않았습니다)")
+
+
+def _echo_report_section(latest_report: dict | None) -> None:
+    """최근 리포트 섹션을 출력한다."""
+    click.echo()
+    click.echo("Latest Report")
+    click.echo("──────────────────────────────────────────────────")
+    if latest_report:
+        summary = latest_report.get("summary", {})
+        click.echo(f"  mode: {latest_report.get('mode', '?')}")
+        click.echo(f"  date: {latest_report.get('target_date', '?')}")
+        click.echo(
+            f"  result: {summary.get('symbols_success', 0)} success"
+            f" / {summary.get('symbols_failed', 0)} failed"
+            f" / {len(latest_report.get('warnings', []))} warnings"
+        )
+        click.echo(f"  rows: {summary.get('rows_written', 0)}")
+    else:
+        click.echo("  (리포트 없음 — 아직 수집을 실행하지 않았습니다)")
+
+
+def _echo_api_keys_section(api_keys: list[dict]) -> None:
+    """API 키 섹션을 출력한다."""
+    click.echo()
+    click.echo("API Keys")
+    click.echo("──────────────────────────────────────────────────")
+    for entry in api_keys:
+        if entry["set"]:
+            source_info = f"(source: {entry['source']})"
+            click.echo(f"  {entry['key']:<30} ✓ 설정됨 {source_info}")
         else:
-            click.echo("  (리포트 없음 — 아직 수집을 실행하지 않았습니다)")
-
-        # API 키 섹션
-        click.echo()
-        click.echo("API Keys")
-        click.echo("──────────────────────────────────────────────────")
-        for entry in api_keys:
-            if entry["set"]:
-                source_info = f"(source: {entry['source']})"
-                click.echo(f"  {entry['key']:<30} ✓ 설정됨 {source_info}")
-            else:
-                click.echo(f"  {entry['key']:<30} ✗ 미설정")
-
-        click.echo()
+            click.echo(f"  {entry['key']:<30} ✗ 미설정")
 
 
 def _load_checkpoints(feed_dir: pathlib.Path) -> list[dict[str, str]]:

--- a/src/ante/feed/cli_output.py
+++ b/src/ante/feed/cli_output.py
@@ -1,0 +1,95 @@
+"""ante feed CLI — 결과 출력 포매터.
+
+CLI 서브커맨드들이 공유하는 CollectionResult 출력 로직을 분리한 모듈이다.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import click
+
+if TYPE_CHECKING:
+    from ante.feed.models.result import CollectionResult
+
+
+def format_backfill_result(
+    result: CollectionResult,
+    fmt: Any,  # OutputFormatter  # noqa: ANN401
+) -> None:
+    """Backfill 결과를 text 또는 JSON으로 출력한다."""
+    if fmt.is_json:
+        fmt.output(_backfill_result_dict(result))
+    else:
+        _echo_backfill_text(result)
+
+
+def format_daily_result(
+    result: CollectionResult,
+    fmt: Any,  # OutputFormatter  # noqa: ANN401
+) -> None:
+    """Daily 결과를 text 또는 JSON으로 출력한다."""
+    if fmt.is_json:
+        fmt.output(_daily_result_dict(result))
+    else:
+        _echo_daily_text(result)
+
+
+def _backfill_result_dict(result: CollectionResult) -> dict[str, Any]:
+    """Backfill 결과를 JSON 직렬화용 dict로 변환한다."""
+    return {
+        "mode": result.mode,
+        "symbols_total": result.symbols_total,
+        "symbols_success": result.symbols_success,
+        "symbols_failed": result.symbols_failed,
+        "rows_written": result.rows_written,
+        "data_types": result.data_types,
+        "duration_seconds": result.duration_seconds,
+        "config_errors": result.config_errors,
+    }
+
+
+def _daily_result_dict(result: CollectionResult) -> dict[str, Any]:
+    """Daily 결과를 JSON 직렬화용 dict로 변환한다."""
+    return {
+        "mode": result.mode,
+        "target_date": result.target_date,
+        "symbols_total": result.symbols_total,
+        "symbols_success": result.symbols_success,
+        "symbols_failed": result.symbols_failed,
+        "rows_written": result.rows_written,
+        "data_types": result.data_types,
+        "duration_seconds": result.duration_seconds,
+        "config_errors": result.config_errors,
+    }
+
+
+def _echo_backfill_text(result: CollectionResult) -> None:
+    """Backfill 결과를 사람이 읽기 좋은 텍스트로 출력한다."""
+    click.echo()
+    click.echo(
+        f"Backfill 완료: {result.symbols_success}/{result.symbols_total} 종목 성공"
+    )
+    _echo_common_stats(result)
+
+
+def _echo_daily_text(result: CollectionResult) -> None:
+    """Daily 결과를 사람이 읽기 좋은 텍스트로 출력한다."""
+    click.echo()
+    click.echo(
+        f"Daily 수집 완료 ({result.target_date}): "
+        f"{result.symbols_success}/{result.symbols_total} 종목 성공"
+    )
+    _echo_common_stats(result)
+
+
+def _echo_common_stats(result: CollectionResult) -> None:
+    """공통 통계 항목(rows, data_types, 소요시간, 경고)을 출력한다."""
+    click.echo(f"  기록: {result.rows_written} rows")
+    click.echo(f"  데이터: {', '.join(result.data_types) or '없음'}")
+    click.echo(f"  소요: {result.duration_seconds:.1f}초")
+    if result.config_errors:
+        click.echo()
+        for err in result.config_errors:
+            click.echo(f"  [경고] {err.get('error', err)}")
+    click.echo()

--- a/src/ante/feed/cli_scheduler.py
+++ b/src/ante/feed/cli_scheduler.py
@@ -1,0 +1,134 @@
+"""ante feed start — 상주 스케줄러 루프.
+
+feed_start CLI 커맨드에서 사용하는 스케줄러 루프를 분리한 모듈이다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import click
+
+logger = logging.getLogger(__name__)
+
+KST = timezone(timedelta(hours=9))
+
+
+async def run_scheduler_loop(
+    orchestrator: Any,  # FeedOrchestrator  # noqa: ANN401
+    data_path: str,
+    config: dict[str, Any],
+    daily_at: str,
+    backfill_at: str,
+) -> None:
+    """스케줄 루프: daily_at / backfill_at 시각에 수집을 실행한다."""
+    stop_event = _setup_signal_handlers()
+
+    logger.info(
+        "DataFeed 스케줄러 시작 (daily_at=%s, backfill_at=%s)",
+        daily_at,
+        backfill_at,
+    )
+    click.echo(
+        f"DataFeed 스케줄러 시작 (daily_at={daily_at}, backfill_at={backfill_at})"
+    )
+    click.echo("종료하려면 Ctrl+C 또는 SIGTERM을 보내세요.")
+
+    daily_ran_today = False
+    backfill_ran_today = False
+    last_date = ""
+
+    while not stop_event.is_set():
+        now = datetime.now(tz=KST)
+        current_time = now.strftime("%H:%M")
+        current_date = now.strftime("%Y-%m-%d")
+
+        if last_date and last_date != current_date:
+            daily_ran_today = False
+            backfill_ran_today = False
+        last_date = current_date
+
+        if not daily_ran_today and current_time >= str(daily_at):
+            await _run_daily_job(orchestrator, data_path, config, current_date)
+            daily_ran_today = True
+
+        if not backfill_ran_today and current_time >= str(backfill_at):
+            await _run_backfill_job(orchestrator, data_path, config, current_date)
+            backfill_ran_today = True
+
+        await _wait_or_stop(stop_event, timeout=60.0)
+
+    logger.info("DataFeed 스케줄러 종료")
+    click.echo("DataFeed 스케줄러 종료")
+
+
+def _setup_signal_handlers() -> asyncio.Event:
+    """SIGTERM/SIGINT 시그널 핸들러를 등록하고 stop_event를 반환한다."""
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def _handle_signal() -> None:
+        logger.info("종료 시그널 수신, 스케줄러 중지...")
+        stop_event.set()
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _handle_signal)
+
+    return stop_event
+
+
+async def _run_daily_job(
+    orchestrator: Any,  # noqa: ANN401
+    data_path: str,
+    config: dict[str, Any],
+    current_date: str,
+) -> None:
+    """Daily 수집 작업을 1회 실행한다."""
+    logger.info("Daily 수집 시작 (%s)", current_date)
+    try:
+        result = await orchestrator.run_daily(
+            data_path=Path(data_path),
+            config=config,
+        )
+        click.echo(
+            f"[{current_date}] Daily 완료: "
+            f"{result.symbols_success}/{result.symbols_total} 종목, "
+            f"{result.rows_written} rows"
+        )
+    except Exception as exc:
+        logger.error("Daily 수집 실패: %s", exc)
+
+
+async def _run_backfill_job(
+    orchestrator: Any,  # noqa: ANN401
+    data_path: str,
+    config: dict[str, Any],
+    current_date: str,
+) -> None:
+    """Backfill 수집 작업을 1회 실행한다."""
+    logger.info("Backfill 수집 시작 (%s)", current_date)
+    try:
+        result = await orchestrator.run_backfill(
+            data_path=Path(data_path),
+            config=config,
+        )
+        click.echo(
+            f"[{current_date}] Backfill 완료: "
+            f"{result.symbols_success}/{result.symbols_total} 종목, "
+            f"{result.rows_written} rows"
+        )
+    except Exception as exc:
+        logger.error("Backfill 수집 실패: %s", exc)
+
+
+async def _wait_or_stop(stop_event: asyncio.Event, *, timeout: float) -> None:
+    """stop_event 또는 timeout까지 대기한다."""
+    try:
+        await asyncio.wait_for(stop_event.wait(), timeout=timeout)
+    except TimeoutError:
+        pass


### PR DESCRIPTION
## Summary
- `_scheduler_loop()` 내부 로직을 `cli_scheduler.py` 독립 모듈로 추출하여 46줄 이하로 축소
- daily/backfill job 실행 로직을 독립 async 함수(`_run_daily_job`, `_run_backfill_job`)로 분리
- `CollectionResult` 출력 포맷팅을 `cli_output.py`로 추출하여 `run_backfill`/`run_daily` 커맨드의 중복 제거
- `feed_status` 텍스트 출력을 섹션별 함수(`_echo_checkpoints_section`, `_echo_report_section`, `_echo_api_keys_section`)로 분리
- 모든 함수 중첩 3단계 이하 유지

Refs #414

## Test plan
- [x] `ruff check` 및 `ruff format` 통과
- [x] 기존 CLI 테스트 40건 전체 통과 (test_cli_init, test_cli_run, test_cli_status)
- [x] 전체 유닛 테스트 1720건 통과
- [x] `run_scheduler_loop()` 46줄 이하 확인
- [x] 외부 인터페이스(CLI 사용법) 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)