### PR TITLE
refactor: MemberService 관심사 분리

### DIFF
--- a/src/ante/member/__init__.py
+++ b/src/ante/member/__init__.py
@@ -1,6 +1,18 @@
 """Member — 멤버 등록·인증·관리."""
 
+from ante.member.auth_service import AuthService
 from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+from ante.member.recovery_key_manager import RecoveryKeyManager
 from ante.member.service import MemberService
+from ante.member.token_manager import TokenManager
 
-__all__ = ["Member", "MemberRole", "MemberService", "MemberStatus", "MemberType"]
+__all__ = [
+    "AuthService",
+    "Member",
+    "MemberRole",
+    "MemberService",
+    "MemberStatus",
+    "MemberType",
+    "RecoveryKeyManager",
+    "TokenManager",
+]

--- a/src/ante/member/auth_service.py
+++ b/src/ante/member/auth_service.py
@@ -1,0 +1,119 @@
+"""AuthService — 멤버 인증 (토큰·패스워드)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ante.member.auth import get_token_type, hash_token, verify_password
+from ante.member.models import Member, MemberStatus, MemberType
+from ante.member.token_manager import TokenManager
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+
+class AuthService:
+    """토큰·패스워드 기반 멤버 인증."""
+
+    def __init__(
+        self,
+        db: Database,
+        eventbus: EventBus,
+        token_manager: TokenManager,
+        get_member: object,
+    ) -> None:
+        self._db = db
+        self._eventbus = eventbus
+        self._token_manager = token_manager
+        # get_member는 MemberService.get을 주입받음
+        self._get_member = get_member
+
+    async def authenticate(self, token: str) -> Member:
+        """토큰으로 멤버 인증. 접두어 기반 타입 강제."""
+        token_type = get_token_type(token)
+        if token_type is None:
+            await self._publish_auth_failed("", "유효하지 않은 토큰 형식")
+            msg = "유효하지 않은 토큰 형식"
+            raise PermissionError(msg)
+
+        t_hash = hash_token(token)
+        row = await self._db.fetch_one(
+            "SELECT * FROM members WHERE token_hash = ?",
+            (t_hash,),
+        )
+        if not row:
+            await self._publish_auth_failed("", "토큰과 일치하는 멤버 없음")
+            msg = "인증 실패"
+            raise PermissionError(msg)
+
+        from ante.member.service import _row_to_member
+
+        member = _row_to_member(row)
+
+        if member.type != token_type:
+            await self._publish_auth_failed(
+                member.member_id, "토큰 접두어와 멤버 타입 불일치"
+            )
+            msg = f"{token_type} key로 {member.type} 멤버 인증 불가"
+            raise PermissionError(msg)
+
+        if member.status != MemberStatus.ACTIVE:
+            await self._publish_auth_failed(
+                member.member_id, f"비활성 멤버: {member.status}"
+            )
+            msg = f"비활성 멤버: {member.status}"
+            raise PermissionError(msg)
+
+        # 토큰 만료 체크
+        expiry_status = TokenManager.check_token_expiry(member)
+        if expiry_status == "expired":
+            await self._publish_auth_failed(member.member_id, "토큰 만료")
+            msg = "토큰이 만료되었습니다. 'ante member rotate-token'으로 갱신하세요."
+            raise PermissionError(msg)
+        if expiry_status == "expiring_soon":
+            logger.warning(
+                "토큰 만료 임박: %s (만료: %s)",
+                member.member_id,
+                member.token_expires_at,
+            )
+
+        return member
+
+    async def authenticate_password(self, member_id: str, password: str) -> Member:
+        """패스워드 인증 (human 대시보드 로그인)."""
+        member = await self._get_member(member_id)
+        if not member:
+            await self._publish_auth_failed(member_id, "존재하지 않는 멤버")
+            msg = "인증 실패"
+            raise PermissionError(msg)
+
+        if member.type != MemberType.HUMAN:
+            await self._publish_auth_failed(member_id, "human 전용 인증")
+            msg = "패스워드 인증은 human 멤버만 가능합니다"
+            raise PermissionError(msg)
+
+        if member.status != MemberStatus.ACTIVE:
+            await self._publish_auth_failed(member_id, f"비활성 멤버: {member.status}")
+            msg = f"비활성 멤버: {member.status}"
+            raise PermissionError(msg)
+
+        if not member.password_hash or not verify_password(
+            password, member.password_hash
+        ):
+            await self._publish_auth_failed(member_id, "패스워드 불일치")
+            msg = "인증 실패"
+            raise PermissionError(msg)
+
+        return member
+
+    async def _publish_auth_failed(self, member_id: str, reason: str) -> None:
+        """인증 실패 이벤트 발행."""
+        from ante.eventbus.events import MemberAuthFailedEvent
+
+        await self._eventbus.publish(
+            MemberAuthFailedEvent(member_id=member_id, reason=reason)
+        )

--- a/src/ante/member/recovery_key_manager.py
+++ b/src/ante/member/recovery_key_manager.py
@@ -1,0 +1,112 @@
+"""RecoveryKeyManager — 복구 키·패스워드 관리."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ante.member.auth import (
+    generate_recovery_key,
+    hash_password,
+    hash_recovery_key,
+    verify_password,
+    verify_recovery_key,
+)
+from ante.member.models import Member, MemberStatus, MemberType
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+
+class RecoveryKeyManager:
+    """복구 키 생성·검증·폐기 및 패스워드 관리."""
+
+    def __init__(
+        self,
+        db: Database,
+        eventbus: EventBus,
+    ) -> None:
+        self._db = db
+        self._eventbus = eventbus
+
+    async def change_password(
+        self, member: Member, old_password: str, new_password: str
+    ) -> None:
+        """패스워드 변경 (human만)."""
+        self._assert_human(member, "change_password")
+        self._assert_active(member, "change_password")
+
+        if not member.password_hash or not verify_password(
+            old_password, member.password_hash
+        ):
+            msg = "현재 패스워드가 일치하지 않습니다"
+            raise PermissionError(msg)
+
+        await self._db.execute(
+            "UPDATE members SET password_hash = ? WHERE member_id = ?",
+            (hash_password(new_password), member.member_id),
+        )
+        logger.info("패스워드 변경 완료: %s", member.member_id)
+
+    async def reset_password(
+        self, member: Member, recovery_key: str, new_password: str
+    ) -> None:
+        """recovery key로 패스워드 리셋 (human만)."""
+        self._assert_human(member, "reset_password")
+
+        if not member.recovery_key_hash or not verify_recovery_key(
+            recovery_key, member.recovery_key_hash
+        ):
+            await self._publish_auth_failed(member.member_id, "recovery key 불일치")
+            msg = "유효하지 않은 recovery key"
+            raise PermissionError(msg)
+
+        await self._db.execute(
+            "UPDATE members SET password_hash = ? WHERE member_id = ?",
+            (hash_password(new_password), member.member_id),
+        )
+        logger.info("패스워드 리셋 완료 (recovery key): %s", member.member_id)
+
+    async def regenerate_recovery_key(self, member: Member, password: str) -> str:
+        """복구 키 재발급. 현재 패스워드 확인 필수."""
+        self._assert_human(member, "regenerate_recovery_key")
+        self._assert_active(member, "regenerate_recovery_key")
+
+        if not member.password_hash or not verify_password(
+            password, member.password_hash
+        ):
+            msg = "현재 패스워드가 일치하지 않습니다"
+            raise PermissionError(msg)
+
+        recovery_key = generate_recovery_key()
+        await self._db.execute(
+            "UPDATE members SET recovery_key_hash = ? WHERE member_id = ?",
+            (hash_recovery_key(recovery_key), member.member_id),
+        )
+        logger.info("Recovery key 재발급 완료: %s", member.member_id)
+        return recovery_key
+
+    async def _publish_auth_failed(self, member_id: str, reason: str) -> None:
+        """인증 실패 이벤트 발행."""
+        from ante.eventbus.events import MemberAuthFailedEvent
+
+        await self._eventbus.publish(
+            MemberAuthFailedEvent(member_id=member_id, reason=reason)
+        )
+
+    @staticmethod
+    def _assert_human(member: Member, action: str) -> None:
+        """human 전용 검증."""
+        if member.type != MemberType.HUMAN:
+            msg = f"{action}은(는) human 멤버만 가능합니다"
+            raise PermissionError(msg)
+
+    @staticmethod
+    def _assert_active(member: Member, action: str) -> None:
+        """활성 상태 검증."""
+        if member.status != MemberStatus.ACTIVE:
+            msg = f"비활성 멤버는 {action}할 수 없습니다 (현재: {member.status})"
+            raise PermissionError(msg)

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -1,25 +1,25 @@
-"""MemberService — 멤버 등록·인증·관리."""
+"""MemberService — 멤버 등록·조회·상태 관리."""
 
 from __future__ import annotations
 
 import json
 import logging
-import random
 import re
+import secrets
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from ante.member.auth import (
     generate_recovery_key,
-    generate_token,
-    get_token_type,
     hash_password,
     hash_recovery_key,
-    hash_token,
-    verify_password,
-    verify_recovery_key,
 )
+from ante.member.auth_service import AuthService
 from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+from ante.member.recovery_key_manager import RecoveryKeyManager
+from ante.member.token_manager import TokenManager, _token_expires_at
+
+__all__ = ["MemberService", "ANIMAL_EMOJI_POOL", "MEMBER_SCHEMA", "_token_expires_at"]
 
 if TYPE_CHECKING:
     from ante.core.database import Database
@@ -82,41 +82,41 @@ _EMOJI_RE = re.compile(
 )
 
 ANIMAL_EMOJI_POOL: list[str] = [
-    "🐶",
-    "🐱",
-    "🐻",
-    "🦊",
-    "🐼",
-    "🐨",
-    "🦁",
-    "🐯",
-    "🐸",
-    "🐵",
-    "🦄",
-    "🐳",
-    "🐙",
-    "🦉",
-    "🦋",
-    "🐧",
-    "🐺",
-    "🦈",
-    "🐝",
-    "🦜",
-    "🐢",
-    "🐬",
-    "🦅",
-    "🐲",
-    "🐴",
-    "🦩",
-    "🐿",
-    "🦔",
-    "🦇",
-    "🐞",
-    "🦀",
-    "🐘",
-    "🦒",
-    "🦘",
-    "🐊",
+    "\U0001f436",
+    "\U0001f431",
+    "\U0001f43b",
+    "\U0001f98a",
+    "\U0001f43c",
+    "\U0001f428",
+    "\U0001f981",
+    "\U0001f42f",
+    "\U0001f438",
+    "\U0001f435",
+    "\U0001f984",
+    "\U0001f433",
+    "\U0001f419",
+    "\U0001f989",
+    "\U0001f98b",
+    "\U0001f427",
+    "\U0001f43a",
+    "\U0001f988",
+    "\U0001f41d",
+    "\U0001f99c",
+    "\U0001f422",
+    "\U0001f42c",
+    "\U0001f985",
+    "\U0001f432",
+    "\U0001f434",
+    "\U0001f9a9",
+    "\U0001f43f",
+    "\U0001f994",
+    "\U0001f987",
+    "\U0001f41e",
+    "\U0001f980",
+    "\U0001f418",
+    "\U0001f992",
+    "\U0001f998",
+    "\U0001f40a",
 ]
 
 
@@ -153,15 +153,12 @@ def _now() -> str:
     return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
 
 
-def _token_expires_at(ttl_days: int) -> str:
-    """TTL 일수 기준 토큰 만료 시각."""
-    from datetime import timedelta
-
-    return (datetime.now(UTC) + timedelta(days=ttl_days)).strftime("%Y-%m-%d %H:%M:%S")
-
-
 class MemberService:
-    """멤버 등록·인증·관리 서비스."""
+    """멤버 등록·조회·상태 관리 서비스.
+
+    인증은 AuthService, 토큰은 TokenManager,
+    복구키·패스워드는 RecoveryKeyManager에 위임한다.
+    """
 
     def __init__(
         self,
@@ -172,6 +169,16 @@ class MemberService:
         self._db = db
         self._eventbus = eventbus
         self._token_ttl_days = token_ttl_days
+
+        # 하위 매니저 조립
+        self._token_manager = TokenManager(db, token_ttl_days)
+        self._auth_service = AuthService(
+            db=db,
+            eventbus=eventbus,
+            token_manager=self._token_manager,
+            get_member=self.get,
+        )
+        self._recovery_key_manager = RecoveryKeyManager(db=db, eventbus=eventbus)
 
     async def initialize(self) -> None:
         """스키마 생성 + 컬럼 마이그레이션."""
@@ -196,7 +203,7 @@ class MemberService:
         available = [e for e in ANIMAL_EMOJI_POOL if e not in used]
         if not available:
             return ""
-        return random.choice(available)  # noqa: S311
+        return secrets.choice(available)
 
     async def _validate_emoji_unique(
         self, emoji: str, exclude_member_id: str = ""
@@ -344,9 +351,8 @@ class MemberService:
             self._validate_emoji_format(emoji)
             await self._validate_emoji_unique(emoji)
 
-        token = generate_token(member_type)
+        token, t_hash, expires_at = self._token_manager.create_token(member_type)
         now = _now()
-        expires_at = _token_expires_at(self._token_ttl_days)
         scopes = scopes or []
 
         member = Member(
@@ -358,7 +364,7 @@ class MemberService:
             emoji=emoji,
             status=MemberStatus.ACTIVE,
             scopes=scopes,
-            token_hash=hash_token(token),
+            token_hash=t_hash,
             created_at=now,
             created_by=registered_by,
             token_expires_at=expires_at,
@@ -402,92 +408,15 @@ class MemberService:
         logger.info("멤버 등록 완료: %s (type=%s)", member.member_id, member.type)
         return member, token
 
-    # ── 인증 ───────────────────────────────────────────
+    # ── 인증 (AuthService 위임) ────────────────────────
 
     async def authenticate(self, token: str) -> Member:
-        """토큰으로 멤버 인증. 접두어 기반 타입 강제."""
-        token_type = get_token_type(token)
-        if token_type is None:
-            await self._publish_auth_failed("", "유효하지 않은 토큰 형식")
-            msg = "유효하지 않은 토큰 형식"
-            raise PermissionError(msg)
-
-        t_hash = hash_token(token)
-        row = await self._db.fetch_one(
-            "SELECT * FROM members WHERE token_hash = ?",
-            (t_hash,),
-        )
-        if not row:
-            await self._publish_auth_failed("", "토큰과 일치하는 멤버 없음")
-            msg = "인증 실패"
-            raise PermissionError(msg)
-
-        member = _row_to_member(row)
-
-        if member.type != token_type:
-            await self._publish_auth_failed(
-                member.member_id, "토큰 접두어와 멤버 타입 불일치"
-            )
-            msg = f"{token_type} key로 {member.type} 멤버 인증 불가"
-            raise PermissionError(msg)
-
-        if member.status != MemberStatus.ACTIVE:
-            await self._publish_auth_failed(
-                member.member_id, f"비활성 멤버: {member.status}"
-            )
-            msg = f"비활성 멤버: {member.status}"
-            raise PermissionError(msg)
-
-        # 토큰 만료 체크
-        if member.token_expires_at:
-            expires = datetime.strptime(  # noqa: DTZ007
-                member.token_expires_at, "%Y-%m-%d %H:%M:%S"
-            )
-            now = datetime.now(UTC).replace(tzinfo=None)
-            if now > expires:
-                await self._publish_auth_failed(member.member_id, "토큰 만료")
-                msg = (
-                    "토큰이 만료되었습니다. 'ante member rotate-token'으로 갱신하세요."
-                )
-                raise PermissionError(msg)
-
-            from datetime import timedelta
-
-            if now > expires - timedelta(days=7):
-                logger.warning(
-                    "토큰 만료 임박: %s (만료: %s)",
-                    member.member_id,
-                    member.token_expires_at,
-                )
-
-        return member
+        """토큰으로 멤버 인증."""
+        return await self._auth_service.authenticate(token)
 
     async def authenticate_password(self, member_id: str, password: str) -> Member:
         """패스워드 인증 (human 대시보드 로그인)."""
-        member = await self.get(member_id)
-        if not member:
-            await self._publish_auth_failed(member_id, "존재하지 않는 멤버")
-            msg = "인증 실패"
-            raise PermissionError(msg)
-
-        if member.type != MemberType.HUMAN:
-            await self._publish_auth_failed(member_id, "human 전용 인증")
-            msg = "패스워드 인증은 human 멤버만 가능합니다"
-            raise PermissionError(msg)
-
-        if member.status != MemberStatus.ACTIVE:
-            await self._publish_auth_failed(member_id, f"비활성 멤버: {member.status}")
-            msg = f"비활성 멤버: {member.status}"
-            raise PermissionError(msg)
-
-        if not member.password_hash or not verify_password(
-            password, member.password_hash
-        ):
-            await self._publish_auth_failed(member_id, "패스워드 불일치")
-            msg = "인증 실패"
-            raise PermissionError(msg)
-
-        return member
+        return await self._auth_service.authenticate_password(member_id, password)
 
     # ── 조회 ───────────────────────────────────────────
 
@@ -600,91 +529,41 @@ class MemberService:
         member.revoked_at = now
         return member
 
-    # ── 토큰 관리 ──────────────────────────────────────
+    # ── 토큰 관리 (TokenManager 위임) ──────────────────
 
     async def rotate_token(
         self, member_id: str, rotated_by: str = ""
     ) -> tuple[Member, str]:
-        """토큰 재발급. 기존 토큰 즉시 무효화. 새 TTL 적용."""
+        """토큰 재발급. 기존 토큰 즉시 무효화."""
         member = await self._get_or_raise(member_id)
-        self._assert_active(member, "rotate_token")
+        return await self._token_manager.rotate_token(member, rotated_by)
 
-        token = generate_token(member.type)
-        t_hash = hash_token(token)
-        expires_at = _token_expires_at(self._token_ttl_days)
-
-        await self._db.execute(
-            "UPDATE members SET token_hash = ?, token_expires_at = ? "
-            "WHERE member_id = ?",
-            (t_hash, expires_at, member_id),
-        )
-
-        logger.info("토큰 재발급: %s (by %s)", member_id, rotated_by)
-        member.token_hash = t_hash
-        member.token_expires_at = expires_at
-        return member, token
-
-    # ── 패스워드 관리 ──────────────────────────────────
+    # ── 패스워드·복구키 관리 (RecoveryKeyManager 위임) ─
 
     async def change_password(
         self, member_id: str, old_password: str, new_password: str
     ) -> None:
         """패스워드 변경 (human만)."""
         member = await self._get_or_raise(member_id)
-        self._assert_human(member, "change_password")
-        self._assert_active(member, "change_password")
-
-        if not member.password_hash or not verify_password(
-            old_password, member.password_hash
-        ):
-            msg = "현재 패스워드가 일치하지 않습니다"
-            raise PermissionError(msg)
-
-        await self._db.execute(
-            "UPDATE members SET password_hash = ? WHERE member_id = ?",
-            (hash_password(new_password), member_id),
+        await self._recovery_key_manager.change_password(
+            member, old_password, new_password
         )
-        logger.info("패스워드 변경 완료: %s", member_id)
 
     async def reset_password(
         self, member_id: str, recovery_key: str, new_password: str
     ) -> None:
         """recovery key로 패스워드 리셋 (human만)."""
         member = await self._get_or_raise(member_id)
-        self._assert_human(member, "reset_password")
-
-        if not member.recovery_key_hash or not verify_recovery_key(
-            recovery_key, member.recovery_key_hash
-        ):
-            await self._publish_auth_failed(member_id, "recovery key 불일치")
-            msg = "유효하지 않은 recovery key"
-            raise PermissionError(msg)
-
-        await self._db.execute(
-            "UPDATE members SET password_hash = ? WHERE member_id = ?",
-            (hash_password(new_password), member_id),
+        await self._recovery_key_manager.reset_password(
+            member, recovery_key, new_password
         )
-        logger.info("패스워드 리셋 완료 (recovery key): %s", member_id)
 
     async def regenerate_recovery_key(self, member_id: str, password: str) -> str:
-        """복구 키 재발급. 현재 패스워드 확인 필수."""
+        """복구 키 재발급."""
         member = await self._get_or_raise(member_id)
-        self._assert_human(member, "regenerate_recovery_key")
-        self._assert_active(member, "regenerate_recovery_key")
-
-        if not member.password_hash or not verify_password(
-            password, member.password_hash
-        ):
-            msg = "현재 패스워드가 일치하지 않습니다"
-            raise PermissionError(msg)
-
-        recovery_key = generate_recovery_key()
-        await self._db.execute(
-            "UPDATE members SET recovery_key_hash = ? WHERE member_id = ?",
-            (hash_recovery_key(recovery_key), member_id),
+        return await self._recovery_key_manager.regenerate_recovery_key(
+            member, password
         )
-        logger.info("Recovery key 재발급 완료: %s", member_id)
-        return recovery_key
 
     # ── 권한 관리 ──────────────────────────────────────
 
@@ -723,14 +602,6 @@ class MemberService:
             raise ValueError(msg)
         return member
 
-    async def _publish_auth_failed(self, member_id: str, reason: str) -> None:
-        """인증 실패 이벤트 발행."""
-        from ante.eventbus.events import MemberAuthFailedEvent
-
-        await self._eventbus.publish(
-            MemberAuthFailedEvent(member_id=member_id, reason=reason)
-        )
-
     @staticmethod
     def _assert_type_role(member_type: str, role: str) -> None:
         """타입-역할 불변식 검증."""
@@ -753,13 +624,6 @@ class MemberService:
         """활성 상태 검증."""
         if member.status != MemberStatus.ACTIVE:
             msg = f"비활성 멤버는 {action}할 수 없습니다 (현재: {member.status})"
-            raise PermissionError(msg)
-
-    @staticmethod
-    def _assert_human(member: Member, action: str) -> None:
-        """human 전용 검증."""
-        if member.type != MemberType.HUMAN:
-            msg = f"{action}은(는) human 멤버만 가능합니다"
             raise PermissionError(msg)
 
     @staticmethod

--- a/src/ante/member/token_manager.py
+++ b/src/ante/member/token_manager.py
@@ -1,0 +1,84 @@
+"""TokenManager — 토큰 생성·갱신·만료 관리."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from ante.member.auth import generate_token, hash_token
+from ante.member.models import Member, MemberStatus
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+
+logger = logging.getLogger(__name__)
+
+
+def _token_expires_at(ttl_days: int) -> str:
+    """TTL 일수 기준 토큰 만료 시각."""
+    return (datetime.now(UTC) + timedelta(days=ttl_days)).strftime("%Y-%m-%d %H:%M:%S")
+
+
+class TokenManager:
+    """토큰 생성·갱신·만료 관리."""
+
+    def __init__(self, db: Database, token_ttl_days: int = 90) -> None:
+        self._db = db
+        self._token_ttl_days = token_ttl_days
+
+    @property
+    def token_ttl_days(self) -> int:
+        """토큰 TTL 일수."""
+        return self._token_ttl_days
+
+    def create_token(self, member_type: str) -> tuple[str, str, str]:
+        """새 토큰 생성. (raw_token, token_hash, expires_at) 반환."""
+        token = generate_token(member_type)
+        t_hash = hash_token(token)
+        expires_at = _token_expires_at(self._token_ttl_days)
+        return token, t_hash, expires_at
+
+    async def rotate_token(
+        self, member: Member, rotated_by: str = ""
+    ) -> tuple[Member, str]:
+        """토큰 재발급. 기존 토큰 즉시 무효화. 새 TTL 적용."""
+        if member.status != MemberStatus.ACTIVE:
+            msg = f"비활성 멤버는 rotate_token할 수 없습니다 (현재: {member.status})"
+            raise PermissionError(msg)
+
+        token, t_hash, expires_at = self.create_token(member.type)
+
+        await self._db.execute(
+            "UPDATE members SET token_hash = ?, token_expires_at = ? "
+            "WHERE member_id = ?",
+            (t_hash, expires_at, member.member_id),
+        )
+
+        logger.info("토큰 재발급: %s (by %s)", member.member_id, rotated_by)
+        member.token_hash = t_hash
+        member.token_expires_at = expires_at
+        return member, token
+
+    @staticmethod
+    def check_token_expiry(member: Member) -> str | None:
+        """토큰 만료 상태 확인.
+
+        Returns:
+            None — 정상
+            "expired" — 만료됨
+            "expiring_soon" — 7일 이내 만료 임박
+        """
+        if not member.token_expires_at:
+            return None
+
+        expires = datetime.strptime(  # noqa: DTZ007
+            member.token_expires_at, "%Y-%m-%d %H:%M:%S"
+        )
+        now = datetime.now(UTC).replace(tzinfo=None)
+
+        if now > expires:
+            return "expired"
+        if now > expires - timedelta(days=7):
+            return "expiring_soon"
+        return None


### PR DESCRIPTION
## Summary

- 773줄 4개 책임이 혼합된 `MemberService`를 단일 책임 클래스로 분해
  - `AuthService`: 토큰·패스워드 기반 멤버 인증
  - `TokenManager`: 토큰 생성·갱신·만료 관리
  - `RecoveryKeyManager`: 복구 키 생성·검증·폐기 및 패스워드 관리
  - `MemberService`: 등록·조회·상태 관리만 담당 (위임 패턴으로 기존 API 유지)
- Security Hotspot 수정: `random.choice` → `secrets.choice` (CSPRNG)
- 기존 외부 인터페이스(MemberService public API) 완전 유지

Refs #415

## Test plan

- [x] 기존 unit 테스트 106건 전체 통과 (test_member, test_token_expiry, test_session_auth, test_member_api)
- [x] 전체 테스트 스위트 1727건 통과 (3 skipped, 0 failed)
- [x] `ruff check` / `ruff format` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)