### PR TITLE
fix: 부동소수점 비교 버그 수정 및 데드 코드 확인

### DIFF
--- a/src/ante/instrument/service.py
+++ b/src/ante/instrument/service.py
@@ -60,9 +60,10 @@ class InstrumentService:
 
     def _is_cache_expired(self) -> bool:
         """캐시 TTL 초과 여부."""
+        import math
         import time as time_mod
 
-        if self._cache_loaded_at == 0.0:
+        if math.isclose(self._cache_loaded_at, 0.0, abs_tol=1e-9):
             return True
         return (time_mod.monotonic() - self._cache_loaded_at) > self._cache_ttl
 


### PR DESCRIPTION
## Summary
- `instrument/service.py:65`의 부동소수점 동등 비교(`== 0.0`)를 `math.isclose(abs_tol=1e-9)`로 교체 (SonarQube S1244)
- `broker/kis.py` 데드 코드(S1763, 625/630줄)는 #410에서 이미 수정 완료 확인 → 스킵

## Test plan
- [x] `ruff check` 통과
- [x] `ruff format` 통과
- [x] `pytest tests/` 전체 1727건 통과 (e2e 제외)

Refs #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)