### PR TITLE
refactor: 불필요한 async 함수 정리

### DIFF
--- a/src/ante/backtest/data_provider.py
+++ b/src/ante/backtest/data_provider.py
@@ -21,6 +21,8 @@ class BacktestDataProvider(DataProvider):
     """백테스트용 DataProvider. 과거 데이터를 시간순으로 제공.
 
     미래 데이터 참조를 방지하기 위해 current_idx까지만 노출한다.
+
+    Note: DataProvider 인터페이스 준수를 위해 get_ohlcv 등은 async def를 유지한다.
     """
 
     def __init__(
@@ -47,10 +49,10 @@ class BacktestDataProvider(DataProvider):
     def end(self) -> str:
         return self._end
 
-    async def load(self, symbol: str, timeframe: str) -> int:
+    def load(self, symbol: str, timeframe: str) -> int:
         """데이터를 캐시에 로드. 로드된 행 수 반환."""
         key = f"{symbol}:{timeframe}"
-        df = await self._store.read(symbol, timeframe, start=self._start, end=self._end)
+        df = self._store.read(symbol, timeframe, start=self._start, end=self._end)
         self._cache[key] = df
         return len(df)
 
@@ -63,7 +65,7 @@ class BacktestDataProvider(DataProvider):
         """현재 시점까지의 OHLCV 데이터 반환."""
         key = f"{symbol}:{timeframe}"
         if key not in self._cache:
-            await self.load(symbol, timeframe)
+            self.load(symbol, timeframe)
 
         df = self._cache[key]
         visible = df.head(self._current_idx + 1)

--- a/src/ante/backtest/service.py
+++ b/src/ante/backtest/service.py
@@ -50,7 +50,7 @@ class BacktestService:
         symbols = config.get("symbols", [])
         timeframe = config.get("timeframe", "1d")
         for symbol in symbols:
-            await data_provider.load(symbol, timeframe)
+            data_provider.load(symbol, timeframe)
 
         executor = BacktestExecutor(
             strategy_cls=strategy_cls,

--- a/src/ante/bot/signal_channel.py
+++ b/src/ante/bot/signal_channel.py
@@ -190,7 +190,10 @@ class SignalChannel:
             self._eventbus.unsubscribe(evt, self._on_order_update)
 
     async def _on_fill(self, event: object) -> None:
-        """체결 이벤트 → 외부 전달."""
+        """체결 이벤트 → 외부 전달.
+
+        Note: EventBus 핸들러 — isawaitable 패턴을 위해 async def 유지.
+        """
         from ante.eventbus.events import OrderFilledEvent
 
         if not isinstance(event, OrderFilledEvent):
@@ -212,7 +215,10 @@ class SignalChannel:
         )
 
     async def _on_order_update(self, event: object) -> None:
-        """주문 상태 변경 → 외부 전달."""
+        """주문 상태 변경 → 외부 전달.
+
+        Note: EventBus 핸들러 — isawaitable 패턴을 위해 async def 유지.
+        """
         bot_id = getattr(event, "bot_id", None)
         if bot_id != self._bot.bot_id:
             return

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -659,6 +659,7 @@ class KISAdapter(BrokerAdapter):
         return orders
 
     # ── 실시간 스트리밍 (구현 예정) ────────────────
+    # BrokerAdapter 인터페이스 준수를 위해 async def 유지
 
     async def realtime_price_stream(
         self, symbols: list[str]

--- a/src/ante/broker/mock.py
+++ b/src/ante/broker/mock.py
@@ -60,6 +60,9 @@ class MockOrder:
 class MockBrokerAdapter(BrokerAdapter):
     """E2E 테스트용 가상 브로커 어댑터.
 
+    Note: BrokerAdapter 인터페이스 준수를 위해 async def를 유지한다.
+    내부적으로 await를 사용하지 않지만, 호출부에서 await로 사용된다.
+
     설정 옵션:
         fill_mode: "immediate" | "partial" | "delayed" | "reject"
         partial_fill_ratio: 부분 체결 비율 (0.0~1.0, 기본 0.5)

--- a/src/ante/cli/commands/data.py
+++ b/src/ante/cli/commands/data.py
@@ -124,7 +124,6 @@ def validate(
     data_path: str,
 ) -> None:
     """Parquet 파일 무결성 검증."""
-    import asyncio
 
     from ante.data.store import ParquetStore
 
@@ -140,14 +139,10 @@ def validate(
         fmt.output({"message": "검증할 데이터가 없습니다.", "results": []})
         return
 
-    async def _validate() -> list[dict]:
-        results = []
-        for sym in symbols:
-            result = await store.validate(sym, timeframe, fix=fix)
-            results.append(result)
-        return results
-
-    results = asyncio.run(_validate())
+    results = []
+    for sym in symbols:
+        result = store.validate(sym, timeframe, fix=fix)
+        results.append(result)
 
     total_files = sum(r["total"] for r in results)
     total_valid = sum(r["valid"] for r in results)

--- a/src/ante/data/collector.py
+++ b/src/ante/data/collector.py
@@ -56,7 +56,7 @@ class DataCollector:
         """데이터 수집 콜백 설정. 시그니처: async (symbol, tf) -> list[dict]."""
         self._data_callback = callback
 
-    async def start(self, symbols: list[str], timeframes: list[str]) -> None:
+    def start(self, symbols: list[str], timeframes: list[str]) -> None:
         """데이터 수집 시작."""
         if self._running:
             logger.warning("DataCollector is already running")
@@ -73,7 +73,7 @@ class DataCollector:
             timeframes,
         )
 
-    async def stop(self) -> None:
+    def stop(self) -> None:
         """데이터 수집 중지. 남은 버퍼를 flush."""
         self._running = False
         if self._collect_task:
@@ -84,10 +84,10 @@ class DataCollector:
             self._flush_task = None
 
         # 남은 데이터 flush
-        await self.flush_all()
+        self.flush_all()
         logger.info("DataCollector stopped")
 
-    async def add_data(self, symbol: str, timeframe: str, row: dict) -> None:
+    def add_data(self, symbol: str, timeframe: str, row: dict) -> None:
         """외부에서 직접 데이터를 추가 (이벤트 기반 수집 시 사용)."""
         key = f"{symbol}:{timeframe}"
         if key not in self._buffer:
@@ -95,15 +95,15 @@ class DataCollector:
         self._buffer[key].append(row)
 
         if len(self._buffer[key]) >= self._buffer_size:
-            await self._flush(key)
+            self._flush(key)
 
-    async def flush_all(self) -> int:
+    def flush_all(self) -> int:
         """모든 버퍼 데이터를 Parquet에 flush. flush된 총 건수 반환."""
         total = 0
         for key in list(self._buffer.keys()):
             if self._buffer[key]:
                 count = len(self._buffer[key])
-                await self._flush(key)
+                self._flush(key)
                 total += count
         return total
 
@@ -116,7 +116,7 @@ class DataCollector:
                         try:
                             rows = await self._data_callback(symbol, tf)
                             for row in rows:
-                                await self.add_data(symbol, tf, row)
+                                self.add_data(symbol, tf, row)
                         except Exception as e:
                             logger.warning(
                                 "Data collection failed for %s/%s: %s",
@@ -136,16 +136,16 @@ class DataCollector:
                 await asyncio.sleep(self._flush_interval)
             except asyncio.CancelledError:
                 raise
-            await self.flush_all()
+            self.flush_all()
 
-    async def _flush(self, key: str) -> None:
+    def _flush(self, key: str) -> None:
         """버퍼의 데이터를 Parquet에 적재."""
         rows = self._buffer.pop(key, [])
         if not rows:
             return
         symbol, tf = key.split(":")
         try:
-            await self._store.append(symbol, tf, rows)
+            self._store.append(symbol, tf, rows)
             logger.debug("Flushed %d rows for %s/%s", len(rows), symbol, tf)
         except Exception as e:
             logger.error("Failed to flush data for %s/%s: %s", symbol, tf, e)

--- a/src/ante/data/retention.py
+++ b/src/ante/data/retention.py
@@ -55,7 +55,7 @@ class RetentionPolicy:
     def retention_days(self) -> dict[str, int]:
         return self._retention
 
-    async def enforce(self, now: datetime | None = None) -> dict[str, int]:
+    def enforce(self, now: datetime | None = None) -> dict[str, int]:
         """보존 정책 적용. 삭제된 파일 수를 timeframe별로 반환.
 
         Args:

--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -48,7 +48,7 @@ class ParquetStore:
         else:
             return self._base / data_type / timeframe / symbol
 
-    async def read(
+    def read(
         self,
         symbol: str,
         timeframe: str,
@@ -106,7 +106,7 @@ class ParquetStore:
 
         return df
 
-    async def write(
+    def write(
         self,
         symbol: str,
         timeframe: str,
@@ -160,7 +160,7 @@ class ParquetStore:
 
         logger.debug("Wrote %d rows for %s/%s", len(data), symbol, timeframe)
 
-    async def append(
+    def append(
         self,
         symbol: str,
         timeframe: str,
@@ -169,7 +169,7 @@ class ParquetStore:
     ) -> None:
         """버퍼 데이터를 기존 Parquet에 추가."""
         df = pl.DataFrame(rows)
-        await self.write(symbol, timeframe, df, data_type=data_type)
+        self.write(symbol, timeframe, df, data_type=data_type)
 
     def list_symbols(
         self, timeframe: str = "1d", data_type: str = "ohlcv"
@@ -231,7 +231,7 @@ class ParquetStore:
                     usage[dtype] = size
         return usage
 
-    async def validate(
+    def validate(
         self,
         symbol: str,
         timeframe: str,

--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -544,7 +544,6 @@ def feed_inject(
     data_path: str,
 ) -> None:
     """외부 CSV 파일에서 과거 데이터를 수동 주입한다."""
-    import asyncio
     from pathlib import Path as _Path
 
     from ante.data.normalizer import DataNormalizer
@@ -559,13 +558,11 @@ def feed_inject(
     injector = FeedInjector(store=store, normalizer=normalizer)
 
     try:
-        count = asyncio.run(
-            injector.inject_csv(
-                filepath,
-                symbol=symbol,
-                timeframe=timeframe,
-                source=source,
-            )
+        count = injector.inject_csv(
+            filepath,
+            symbol=symbol,
+            timeframe=timeframe,
+            source=source,
         )
     except FileNotFoundError as e:
         fmt.error(str(e), "FILE_NOT_FOUND")

--- a/src/ante/feed/injector.py
+++ b/src/ante/feed/injector.py
@@ -38,7 +38,7 @@ class FeedInjector:
         self._store = store
         self._normalizer = normalizer
 
-    async def inject_csv(
+    def inject_csv(
         self,
         path: str | Path,
         symbol: str,
@@ -80,7 +80,7 @@ class FeedInjector:
         # 4계층 검증 (스키마 + 비즈니스)
         self._validate(normalized)
 
-        await self._store.write(symbol, timeframe, normalized)
+        self._store.write(symbol, timeframe, normalized)
         logger.info(
             "CSV 주입 완료: %d행, %s → %s/%s",
             len(normalized),
@@ -90,7 +90,7 @@ class FeedInjector:
         )
         return len(normalized)
 
-    async def inject_dataframe(
+    def inject_dataframe(
         self,
         df: pl.DataFrame,
         symbol: str,
@@ -122,7 +122,7 @@ class FeedInjector:
         # 4계층 검증 (스키마 + 비즈니스)
         self._validate(df)
 
-        await self._store.write(symbol, timeframe, df)
+        self._store.write(symbol, timeframe, df)
         logger.info("DataFrame 주입 완료: %d행, %s/%s", len(df), symbol, timeframe)
         return len(df)
 

--- a/src/ante/feed/pipeline/backfill_runner.py
+++ b/src/ante/feed/pipeline/backfill_runner.py
@@ -89,7 +89,7 @@ class BackfillRunner:
             store,
             ctx,
         )
-        await self._compute_indicators(store, ctx)
+        self._compute_indicators(store, ctx)
 
         return ctx.to_result("backfill", started_at)
 
@@ -220,7 +220,7 @@ class BackfillRunner:
                 }
             )
 
-    async def _compute_indicators(
+    def _compute_indicators(
         self,
         store: ParquetStore,
         ctx: _RunContext,
@@ -232,7 +232,7 @@ class BackfillRunner:
             return
 
         try:
-            written = await self._indicator.compute(
+            written = self._indicator.compute(
                 store,
                 list(ctx.success_symbols),
             )

--- a/src/ante/feed/pipeline/daily_runner.py
+++ b/src/ante/feed/pipeline/daily_runner.py
@@ -75,7 +75,7 @@ class DailyRunner:
             store,
             ctx,
         )
-        await self._compute_indicators(store, ctx)
+        self._compute_indicators(store, ctx)
 
         return ctx.to_result("daily", started_at, target_date=target_date)
 
@@ -164,7 +164,7 @@ class DailyRunner:
                 }
             )
 
-    async def _compute_indicators(
+    def _compute_indicators(
         self,
         store: ParquetStore,
         ctx: _RunContext,
@@ -176,7 +176,7 @@ class DailyRunner:
             return
 
         try:
-            written = await self._indicator.compute(
+            written = self._indicator.compute(
                 store,
                 list(ctx.success_symbols),
             )

--- a/src/ante/feed/pipeline/dart_collector.py
+++ b/src/ante/feed/pipeline/dart_collector.py
@@ -170,13 +170,13 @@ class DARTCollector:
         if not raw_items:
             return 0, set()
 
-        return await self._normalize_and_store(
+        return self._normalize_and_store(
             raw_items,
             corp_code_map,
             store,
         )
 
-    async def _normalize_and_store(
+    def _normalize_and_store(
         self,
         raw_items: list[dict],
         corp_code_map: dict[str, str],
@@ -193,7 +193,7 @@ class DARTCollector:
         symbols: set[str] = set()
         for sym in normalized["symbol"].unique().to_list():
             sym_df = normalized.filter(pl.col("symbol") == sym)
-            await store.write(sym, "krx", sym_df, data_type="fundamental")
+            store.write(sym, "krx", sym_df, data_type="fundamental")
             rows += len(sym_df)
             symbols.add(sym)
 

--- a/src/ante/feed/pipeline/data_go_kr_collector.py
+++ b/src/ante/feed/pipeline/data_go_kr_collector.py
@@ -58,7 +58,7 @@ class DataGoKrCollector:
         df = pl.DataFrame(raw_items)
         df = self._deduplicate(df)
 
-        rows_written, symbols = await self._normalize_and_store(
+        rows_written, symbols = self._normalize_and_store(
             df,
             store,
             target_date,
@@ -92,7 +92,7 @@ class DataGoKrCollector:
             return df.unique(subset=["srtnCd", "basDt"])
         return df
 
-    async def _normalize_and_store(
+    def _normalize_and_store(
         self,
         df: pl.DataFrame,
         store: ParquetStore,
@@ -102,8 +102,8 @@ class DataGoKrCollector:
         rows_written = 0
         symbols: set[str] = set()
 
-        rows_written += await self._store_ohlcv(df, store, symbols)
-        rows_written += await self._store_fundamental(df, store, symbols)
+        rows_written += self._store_ohlcv(df, store, symbols)
+        rows_written += self._store_fundamental(df, store, symbols)
 
         logger.info(
             "data.go.kr 수집 완료: date=%s symbols=%d rows=%d",
@@ -113,7 +113,7 @@ class DataGoKrCollector:
         )
         return rows_written, symbols
 
-    async def _store_ohlcv(
+    def _store_ohlcv(
         self,
         df: pl.DataFrame,
         store: ParquetStore,
@@ -127,12 +127,12 @@ class DataGoKrCollector:
         rows = 0
         for sym in ohlcv_df["symbol"].unique().to_list():
             sym_df = ohlcv_df.filter(pl.col("symbol") == sym)
-            await store.write(sym, "1d", sym_df, data_type="ohlcv")
+            store.write(sym, "1d", sym_df, data_type="ohlcv")
             rows += len(sym_df)
             symbols.add(sym)
         return rows
 
-    async def _store_fundamental(
+    def _store_fundamental(
         self,
         df: pl.DataFrame,
         store: ParquetStore,
@@ -146,7 +146,7 @@ class DataGoKrCollector:
         rows = 0
         for sym in fund_df["symbol"].unique().to_list():
             sym_df = fund_df.filter(pl.col("symbol") == sym)
-            await store.write(sym, "krx", sym_df, data_type="fundamental")
+            store.write(sym, "krx", sym_df, data_type="fundamental")
             rows += len(sym_df)
             symbols.add(sym)
         return rows

--- a/src/ante/feed/pipeline/indicator_calculator.py
+++ b/src/ante/feed/pipeline/indicator_calculator.py
@@ -23,7 +23,7 @@ class IndicatorCalculator:
     - 부채비율 = 부채총계 / 자본총계
     """
 
-    async def compute(
+    def compute(
         self,
         store: ParquetStore,
         symbols: list[str],
@@ -36,7 +36,7 @@ class IndicatorCalculator:
         rows_updated = 0
 
         for sym in symbols:
-            updated = await self._compute_symbol(store, sym)
+            updated = self._compute_symbol(store, sym)
             rows_updated += updated
 
         logger.info(
@@ -46,14 +46,14 @@ class IndicatorCalculator:
         )
         return rows_updated
 
-    async def _compute_symbol(
+    def _compute_symbol(
         self,
         store: ParquetStore,
         sym: str,
     ) -> int:
         """단일 심볼의 파생 지표를 계산한다."""
         try:
-            fundamental = await store.read(sym, "krx", data_type="fundamental")
+            fundamental = store.read(sym, "krx", data_type="fundamental")
         except Exception:
             return 0
 
@@ -65,7 +65,7 @@ class IndicatorCalculator:
             return 0
 
         updated = fundamental.with_columns(exprs)
-        await store.write(sym, "krx", updated, data_type="fundamental")
+        store.write(sym, "krx", updated, data_type="fundamental")
         return len(updated)
 
     @staticmethod

--- a/src/ante/gateway/data_provider.py
+++ b/src/ante/gateway/data_provider.py
@@ -11,7 +11,10 @@ if TYPE_CHECKING:
 
 
 class LiveDataProvider(DataProvider):
-    """라이브 모드 DataProvider. APIGateway 경유로 캐시 활용."""
+    """라이브 모드 DataProvider. APIGateway 경유로 캐시 활용.
+
+    Note: DataProvider 인터페이스 준수를 위해 async def를 유지한다.
+    """
 
     def __init__(self, gateway: APIGateway) -> None:
         self._gateway = gateway

--- a/src/ante/gateway/gateway.py
+++ b/src/ante/gateway/gateway.py
@@ -40,13 +40,13 @@ class APIGateway:
         self._running = False
         self._stop_order_manager = stop_order_manager
 
-    async def start(self) -> None:
+    def start(self) -> None:
         """이벤트 구독 시작."""
         self._subscribe_events()
         self._running = True
         logger.info("APIGateway 시작")
 
-    async def stop(self) -> None:
+    def stop(self) -> None:
         """중지."""
         self._running = False
         logger.info("APIGateway 중지")
@@ -271,7 +271,10 @@ class APIGateway:
             )
 
     async def _on_order_modify(self, event: object) -> None:
-        """주문 정정 요청 → 로깅만 (정정은 추후 구현)."""
+        """주문 정정 요청 → 로깅만 (정정은 추후 구현).
+
+        Note: EventBus 핸들러 — isawaitable 패턴을 위해 async def 유지.
+        """
         from ante.eventbus.events import OrderModifyEvent
 
         if not isinstance(event, OrderModifyEvent):
@@ -279,7 +282,10 @@ class APIGateway:
         logger.warning("주문 정정은 추후 구현: %s", event.order_id)
 
     async def _on_order_filled(self, event: object) -> None:
-        """체결 시 관련 캐시 무효화."""
+        """체결 시 관련 캐시 무효화.
+
+        Note: EventBus 핸들러 — isawaitable 패턴을 위해 async def 유지.
+        """
         from ante.eventbus.events import OrderFilledEvent
 
         if not isinstance(event, OrderFilledEvent):

--- a/src/ante/gateway/stop_order.py
+++ b/src/ante/gateway/stop_order.py
@@ -69,7 +69,7 @@ class StopOrderManager:
         """모니터링 대상 종목."""
         return {o.symbol for o in self.active_orders}
 
-    async def start(self) -> None:
+    def start(self) -> None:
         """매니저 시작."""
         self._running = True
         logger.info("StopOrderManager 시작")
@@ -144,7 +144,7 @@ class StopOrderManager:
 
         return stop_order_id
 
-    async def cancel(self, stop_order_id: str) -> bool:
+    def cancel(self, stop_order_id: str) -> bool:
         """스탑 주문 취소."""
         order = self._orders.get(stop_order_id)
         if not order or order.triggered or order.expired:

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -142,7 +142,7 @@ async def _init_trading(s: Services) -> None:
     from ante.rule import RuleEngine
 
     s.rule_engine = RuleEngine(eventbus=s.eventbus, system_state=s.system_state)
-    await s.rule_engine.start()
+    s.rule_engine.start()
 
     rule_configs = s.config.get("rules.global", [])
     if rule_configs:
@@ -230,10 +230,10 @@ async def _init_trading(s: Services) -> None:
     await _init_broker(s)
 
     # StrategyContextFactory 완성 (Broker 연결 이후)
-    await _init_context_factory(s)
+    _init_context_factory(s)
 
     # Treasury 잔고 동기화 (Broker 연결 이후)
-    await _init_treasury_sync(s)
+    _init_treasury_sync(s)
 
 
 async def _init_broker(s: Services) -> None:
@@ -252,7 +252,7 @@ async def _init_broker(s: Services) -> None:
 
     if s.broker:
         s.api_gateway = APIGateway(broker=s.broker, eventbus=s.eventbus)
-        await s.api_gateway.start()
+        s.api_gateway.start()
         logger.info("APIGateway 시작 완료")
 
     if s.broker:
@@ -321,7 +321,7 @@ async def _sync_instruments(s: Services) -> None:
         logger.warning("종목 동기화 실패 — 기존 캐시 데이터로 운영", exc_info=True)
 
 
-async def _init_context_factory(s: Services) -> None:
+def _init_context_factory(s: Services) -> None:
     """StrategyContextFactory 완성 (Broker/APIGateway 연결 이후)."""
     from ante.bot import StrategyContextFactory
     from ante.bot.providers.live import LiveTradeHistoryView
@@ -345,7 +345,7 @@ async def _init_context_factory(s: Services) -> None:
         logger.info("StrategyContextFactory 설정 완료")
 
 
-async def _init_treasury_sync(s: Services) -> None:
+def _init_treasury_sync(s: Services) -> None:
     """Treasury 잔고 동기화 시작 (Broker 연결 이후)."""
     if not s.broker:
         return
@@ -361,7 +361,7 @@ async def _init_treasury_sync(s: Services) -> None:
     )
 
     sync_interval = s.config.get("treasury.sync_interval_seconds", 300)
-    await s.treasury.start_sync(
+    s.treasury.start_sync(
         broker=s.broker,
         position_history=s.position_history,
         interval_seconds=sync_interval,
@@ -548,7 +548,7 @@ async def _shutdown(s: Services) -> None:
     logger.info("BotManager 종료 — 모든 봇 중지")
 
     if s.api_gateway:
-        await s.api_gateway.stop()
+        s.api_gateway.stop()
         logger.info("APIGateway 종료")
 
     if s.broker:

--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time as time_mod
+from inspect import isawaitable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -188,7 +189,10 @@ class TelegramCommandReceiver:
 
         handler = handlers.get(command)
         if handler:
-            return await handler(args)
+            result = handler(args)
+            if isawaitable(result):
+                return await result
+            return result
 
         return "알 수 없는 명령입니다. /help를 입력해 주세요."
 
@@ -232,7 +236,7 @@ class TelegramCommandReceiver:
 
     # ── 명령 핸들러 ─────────────────────────────────
 
-    async def _cmd_help(self, args: list[str]) -> str:
+    def _cmd_help(self, args: list[str]) -> str:
         """사용 가능한 명령어 목록."""
         return (
             "사용 가능한 명령어:\n"
@@ -245,7 +249,7 @@ class TelegramCommandReceiver:
             "/help — 이 도움말"
         )
 
-    async def _cmd_status(self, args: list[str]) -> str:
+    def _cmd_status(self, args: list[str]) -> str:
         """시스템 상태 요약."""
         parts = []
 
@@ -263,7 +267,7 @@ class TelegramCommandReceiver:
 
         return "\n".join(parts)
 
-    async def _cmd_bots(self, args: list[str]) -> str:
+    def _cmd_bots(self, args: list[str]) -> str:
         """봇 목록."""
         if not self._bot_manager:
             return "BotManager가 연결되지 않았습니다."
@@ -281,7 +285,7 @@ class TelegramCommandReceiver:
 
         return "봇 목록:\n" + "\n".join(lines)
 
-    async def _cmd_balance(self, args: list[str]) -> str:
+    def _cmd_balance(self, args: list[str]) -> str:
         """자금 현황."""
         if not self._treasury:
             return "Treasury가 연결되지 않았습니다."

--- a/src/ante/report/draft.py
+++ b/src/ante/report/draft.py
@@ -24,7 +24,7 @@ class ReportDraftGenerator:
         self._store = report_store
         self._eventbus = eventbus
 
-    async def initialize(self) -> None:
+    def initialize(self) -> None:
         """EventBus에 핸들러 등록."""
         from ante.eventbus.events import BacktestCompleteEvent
 

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -59,7 +59,7 @@ class RuleEngine:
         self._global_rules: list[Rule] = []
         self._strategy_rules: dict[str, list[Rule]] = {}
 
-    async def start(self) -> None:
+    def start(self) -> None:
         """EventBus 구독 등록."""
         from ante.eventbus.events import (
             ConfigChangedEvent,
@@ -385,7 +385,10 @@ class RuleEngine:
             )
 
     async def _on_config_changed(self, event: object) -> None:
-        """설정 변경 시 룰 재로딩 트리거."""
+        """설정 변경 시 룰 재로딩 트리거.
+
+        Note: EventBus 핸들러 — isawaitable 패턴을 위해 async def 유지.
+        """
         from ante.eventbus.events import ConfigChangedEvent
 
         if not isinstance(event, ConfigChangedEvent):

--- a/src/ante/strategy/base.py
+++ b/src/ante/strategy/base.py
@@ -151,6 +151,7 @@ class Strategy(ABC):
         ...
 
     # ── 이벤트 핸들러 (선택) ──
+    # 서브클래스에서 override하여 async 작업을 수행할 수 있으므로 async def 유지
 
     async def on_fill(self, fill: dict[str, Any]) -> list[Signal]:
         """주문 체결 통보."""

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -184,12 +184,12 @@ class Treasury:
 
     # ── 예산 조회 ───────────────────────────────────
 
-    async def get_available(self, bot_id: str) -> float:
+    def get_available(self, bot_id: str) -> float:
         """봇의 가용 예산 조회."""
         budget = self._budgets.get(bot_id)
         return budget.available if budget else 0.0
 
-    async def get_budget(self, bot_id: str) -> BotBudget | None:
+    def get_budget(self, bot_id: str) -> BotBudget | None:
         """봇의 예산 상태 조회."""
         return self._budgets.get(bot_id)
 
@@ -316,7 +316,7 @@ class Treasury:
                 event.bot_id, event.order_id, total_reserve
             )
             if not success:
-                available = await self.get_available(event.bot_id)
+                available = self.get_available(event.bot_id)
                 await self._eventbus.publish(
                     OrderRejectedEvent(
                         order_id=event.order_id,
@@ -444,7 +444,7 @@ class Treasury:
 
     # ── 잔고 동기화 ────────────────────────────────
 
-    async def start_sync(
+    def start_sync(
         self,
         broker: BrokerAdapter,
         position_history: PositionHistory,

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -112,7 +112,7 @@ async def get_bot(request: Request, bot_id: str) -> dict:
     # 예산 정보 추가
     treasury = getattr(request.app.state, "treasury", None)
     if treasury is not None:
-        budget = await treasury.get_budget(bot_id)
+        budget = treasury.get_budget(bot_id)
         if budget:
             info["budget"] = {
                 "allocated": budget.allocated,

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -148,7 +148,7 @@ async def allocate(request: Request, bot_id: str, body: BudgetChangeRequest) -> 
             ),
         )
 
-    budget = await treasury.get_budget(bot_id)
+    budget = treasury.get_budget(bot_id)
     return {
         "bot_id": bot_id,
         "allocated": budget.allocated if budget else 0.0,
@@ -176,7 +176,7 @@ async def deallocate(request: Request, bot_id: str, body: BudgetChangeRequest) -
             detail=f"예산 회수 실패: 가용 예산 부족 (요청: {body.amount:,.0f}원)",
         )
 
-    budget = await treasury.get_budget(bot_id)
+    budget = treasury.get_budget(bot_id)
     return {
         "bot_id": bot_id,
         "allocated": budget.allocated if budget else 0.0,

--- a/tests/integration/test_e2e_flow.py
+++ b/tests/integration/test_e2e_flow.py
@@ -267,7 +267,7 @@ async def system(tmp_path: Path):
 
     # RuleEngine
     rule_engine = RuleEngine(eventbus=eventbus, system_state=system_state)
-    await rule_engine.start()
+    rule_engine.start()
 
     # Treasury
     treasury = Treasury(db=db, eventbus=eventbus, commission_rate=0.00015)
@@ -293,7 +293,7 @@ async def system(tmp_path: Path):
     # MockBroker + APIGateway
     broker = MockBrokerAdapter()
     api_gateway = APIGateway(broker=broker, eventbus=eventbus)
-    await api_gateway.start()
+    api_gateway.start()
 
     # AutoFill 시뮬레이터
     auto_fill = AutoFillSimulator(eventbus=eventbus, broker=broker)
@@ -324,7 +324,7 @@ async def system(tmp_path: Path):
 
     # Teardown
     await bot_manager.stop_all()
-    await api_gateway.stop()
+    api_gateway.stop()
     await db.close()
 
 
@@ -434,7 +434,7 @@ class TestE2EBacktest:
                 "volume": [1000.0] * 20,
             }
         )
-        await store.write("005930", "1d", df)
+        store.write("005930", "1d", df)
 
         # 전략 파일
         filepath = _write_test_strategy(tmp_path)
@@ -616,7 +616,7 @@ class TestE2EOrderFlow:
         assert positions[0].quantity == 10.0
 
         # 6. Treasury 자금 변동 확인
-        budget = await treasury.get_budget(bot_id)
+        budget = treasury.get_budget(bot_id)
         assert budget is not None
         assert budget.spent > 0
 
@@ -757,7 +757,7 @@ class TestE2EFullPipeline:
                 "volume": [1000.0] * 20,
             }
         )
-        await store.write("005930", "1d", df)
+        store.write("005930", "1d", df)
 
         bt_service = BacktestService(data_path=str(data_path))
         bt_result = await bt_service.run(

--- a/tests/unit/feed/test_injector.py
+++ b/tests/unit/feed/test_injector.py
@@ -84,23 +84,23 @@ class TestFeedInjectorCSV:
             "2026-03-01T09:01:00,50100,50200,50000,50150,1100\n"
         )
 
-        count = await injector.inject_csv(csv_path, "005930", "1m")
+        count = injector.inject_csv(csv_path, "005930", "1m")
         assert count == 2
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) == 2
 
     async def test_inject_csv_not_found(self, injector):
         """존재하지 않는 CSV 파일은 FileNotFoundError."""
         with pytest.raises(FileNotFoundError):
-            await injector.inject_csv("/nonexistent.csv", "005930", "1m")
+            injector.inject_csv("/nonexistent.csv", "005930", "1m")
 
     async def test_inject_csv_empty(self, injector, tmp_path):
         """빈 CSV 파일은 0행 반환."""
         csv_path = tmp_path / "empty.csv"
         csv_path.write_text("date,open,high,low,close,volume\n")
 
-        count = await injector.inject_csv(csv_path, "005930", "1d")
+        count = injector.inject_csv(csv_path, "005930", "1d")
         assert count == 0
 
     async def test_inject_csv_default_timeframe(self, injector, store, tmp_path):
@@ -111,10 +111,10 @@ class TestFeedInjectorCSV:
             "2026-03-01T00:00:00,50000,50100,49900,50050,1000\n"
         )
 
-        count = await injector.inject_csv(csv_path, "005930")
+        count = injector.inject_csv(csv_path, "005930")
         assert count == 1
 
-        result = await store.read("005930", "1d")
+        result = store.read("005930", "1d")
         assert len(result) == 1
 
 
@@ -127,15 +127,15 @@ class TestFeedInjectorDataFrame:
     async def test_inject_dataframe(self, injector, store):
         """DataFrame을 직접 주입한다."""
         df = _make_ohlcv_df(n=3)
-        count = await injector.inject_dataframe(df, "005930", "1m")
+        count = injector.inject_dataframe(df, "005930", "1m")
         assert count == 3
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) == 3
 
     async def test_inject_empty_dataframe(self, injector):
         """빈 DataFrame은 0행 반환."""
-        count = await injector.inject_dataframe(pl.DataFrame(), "005930", "1m")
+        count = injector.inject_dataframe(pl.DataFrame(), "005930", "1m")
         assert count == 0
 
     async def test_inject_dataframe_adds_symbol(self, injector, store):
@@ -157,16 +157,16 @@ class TestFeedInjectorDataFrame:
                 "source": ["test"] * 3,
             }
         )
-        count = await injector.inject_dataframe(df, "005930", "1m")
+        count = injector.inject_dataframe(df, "005930", "1m")
         assert count == 3
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert result["symbol"][0] == "005930"
 
     async def test_inject_dataframe_adds_source(self, injector, store):
         """source 컬럼이 없는 DataFrame에 source를 추가한다."""
         df = _make_ohlcv_df(n=2).drop("source")
-        count = await injector.inject_dataframe(df, "005930", "1m", source="custom")
+        count = injector.inject_dataframe(df, "005930", "1m", source="custom")
         assert count == 2
 
 
@@ -179,7 +179,7 @@ class TestFeedInjectorValidation:
     async def test_schema_validation_passes(self, injector, store):
         """올바른 스키마의 DataFrame은 검증을 통과한다."""
         df = _make_ohlcv_df(n=2)
-        count = await injector.inject_dataframe(df, "005930", "1m")
+        count = injector.inject_dataframe(df, "005930", "1m")
         assert count == 2
 
     async def test_business_validation_warnings_allow_storage(self, injector, store):
@@ -197,8 +197,8 @@ class TestFeedInjectorValidation:
                 "source": ["test"],
             }
         )
-        count = await injector.inject_dataframe(df, "005930", "1m")
+        count = injector.inject_dataframe(df, "005930", "1m")
         assert count == 1
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) == 1

--- a/tests/unit/feed/test_orchestrator.py
+++ b/tests/unit/feed/test_orchestrator.py
@@ -421,15 +421,15 @@ async def test_compute_derived_indicators(tmp_data_path: Path) -> None:
         }
     )
 
-    await store.write("005930", "krx", fundamental_df, data_type="fundamental")
+    store.write("005930", "krx", fundamental_df, data_type="fundamental")
 
     calculator = IndicatorCalculator()
-    rows = await calculator.compute(store, ["005930"])
+    rows = calculator.compute(store, ["005930"])
 
     assert rows > 0
 
     # 결과 읽기
-    result = await store.read("005930", "krx", data_type="fundamental")
+    result = store.read("005930", "krx", data_type="fundamental")
     assert not result.is_empty()
 
     row = result.row(0, named=True)
@@ -477,12 +477,12 @@ async def test_compute_derived_zero_division(tmp_data_path: Path) -> None:
         }
     )
 
-    await store.write("005930", "krx", fundamental_df, data_type="fundamental")
+    store.write("005930", "krx", fundamental_df, data_type="fundamental")
 
     calculator = IndicatorCalculator()
-    await calculator.compute(store, ["005930"])
+    calculator.compute(store, ["005930"])
 
-    result = await store.read("005930", "krx", data_type="fundamental")
+    result = store.read("005930", "krx", data_type="fundamental")
     row = result.row(0, named=True)
 
     # 분모 0이면 None
@@ -510,11 +510,11 @@ async def test_compute_derived_missing_columns(tmp_data_path: Path) -> None:
         }
     )
 
-    await store.write("005930", "krx", fundamental_df, data_type="fundamental")
+    store.write("005930", "krx", fundamental_df, data_type="fundamental")
 
     calculator = IndicatorCalculator()
     # 에러 없이 실행되어야 함
-    rows = await calculator.compute(store, ["005930"])
+    rows = calculator.compute(store, ["005930"])
     assert rows >= 0
 
 

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -123,7 +123,7 @@ def store(data_dir):
 async def loaded_store(store):
     """데이터가 미리 적재된 store."""
     df = _make_ohlcv_df()
-    await store.write("005930", "1d", df)
+    store.write("005930", "1d", df)
     return store
 
 
@@ -134,7 +134,7 @@ async def data_provider(loaded_store):
         start_date="2026-01-01",
         end_date="2026-12-31",
     )
-    await provider.load("005930", "1d")
+    provider.load("005930", "1d")
     return provider
 
 

--- a/tests/unit/test_backtest_progress.py
+++ b/tests/unit/test_backtest_progress.py
@@ -93,7 +93,7 @@ class TestBacktestServiceProgress:
         ):
             mock_load.return_value = MagicMock()
             mock_dp = AsyncMock()
-            mock_dp.load = AsyncMock(return_value=100)
+            mock_dp.load = MagicMock(return_value=100)
             mock_dp_cls.return_value = mock_dp
 
             mock_exec = AsyncMock()

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -103,7 +103,7 @@ class FakeTreasury:
     def __init__(self) -> None:
         self._budgets: dict[str, FakeBotBudget] = {}
 
-    async def get_budget(self, bot_id: str) -> FakeBotBudget | None:
+    def get_budget(self, bot_id: str) -> FakeBotBudget | None:
         return self._budgets.get(bot_id)
 
 

--- a/tests/unit/test_bot_stop_release.py
+++ b/tests/unit/test_bot_stop_release.py
@@ -76,12 +76,12 @@ class TestBotStopRelease:
         await treasury.reserve_for_order("bot1", "ord1", 100_000.0)
         await treasury.reserve_for_order("bot1", "ord2", 200_000.0)
 
-        budget_before = await treasury.get_budget("bot1")
+        budget_before = treasury.get_budget("bot1")
         available_before = budget_before.available
 
         await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
 
-        budget_after = await treasury.get_budget("bot1")
+        budget_after = treasury.get_budget("bot1")
         assert budget_after.reserved == 0.0
         assert budget_after.available == pytest.approx(available_before + 300_000.0)
         assert treasury.get_reservations("bot1") == {}
@@ -94,16 +94,16 @@ class TestBotStopRelease:
         await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
 
         assert treasury.get_reservations("bot2") == {"ord2": 200_000.0}
-        budget2 = await treasury.get_budget("bot2")
+        budget2 = treasury.get_budget("bot2")
         assert budget2.reserved == 200_000.0
 
     async def test_bot_stopped_no_reservations_noop(self, treasury, eventbus):
         """예약 없는 봇 중지 → 아무 변화 없음."""
-        budget_before = await treasury.get_budget("bot1")
+        budget_before = treasury.get_budget("bot1")
 
         await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
 
-        budget_after = await treasury.get_budget("bot1")
+        budget_after = treasury.get_budget("bot1")
         assert budget_after.available == budget_before.available
         assert budget_after.reserved == budget_before.reserved
 
@@ -130,7 +130,7 @@ class TestBotStopRelease:
 
         await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
 
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget.reserved == 0.0
         # available should have all 500k returned
         assert budget.available == pytest.approx(5_000_000.0 - 500_000.0 + 500_000.0)
@@ -148,15 +148,15 @@ class TestReservationCompatibility:
     async def test_reserve_and_release_still_works(self, treasury):
         """기존 reserve/release 정상 동작."""
         await treasury.reserve_for_order("bot1", "ord1", 100_000.0)
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget.reserved == 100_000.0
 
         await treasury.release_reservation("bot1", "ord1")
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget.reserved == 0.0
 
     async def test_nonexistent_order_release_noop(self, treasury):
         """존재하지 않는 주문 해제 → 무시."""
         await treasury.release_reservation("bot1", "nonexistent")
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget.available == 5_000_000.0

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -132,19 +132,19 @@ class TestSchemas:
 class TestParquetStore:
     async def test_write_and_read(self, store):
         df = _make_ohlcv_df()
-        await store.write("005930", "1m", df)
+        store.write("005930", "1m", df)
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) == 5
         assert result["symbol"][0] == "005930"
 
     async def test_read_empty(self, store):
-        result = await store.read("999999", "1d")
+        result = store.read("999999", "1d")
         assert result.is_empty()
 
     async def test_write_creates_partitioned_files(self, store, data_dir):
         df = _make_ohlcv_df()
-        await store.write("005930", "1m", df)
+        store.write("005930", "1m", df)
 
         parquet_path = data_dir / "ohlcv" / "1m" / "005930" / "2026-03.parquet"
         assert parquet_path.exists()
@@ -152,17 +152,17 @@ class TestParquetStore:
     async def test_write_merge_dedup(self, store):
         """같은 timestamp 데이터를 두 번 쓰면 중복 제거."""
         df = _make_ohlcv_df(n=3)
-        await store.write("005930", "1m", df)
-        await store.write("005930", "1m", df)
+        store.write("005930", "1m", df)
+        store.write("005930", "1m", df)
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) == 3  # 중복 제거됨
 
     async def test_read_with_time_filter(self, store):
         df = _make_ohlcv_df(n=10, start="2026-03-01T09:00:00")
-        await store.write("005930", "1m", df)
+        store.write("005930", "1m", df)
 
-        result = await store.read(
+        result = store.read(
             "005930",
             "1m",
             start="2026-03-01T09:03:00",
@@ -172,9 +172,9 @@ class TestParquetStore:
 
     async def test_read_with_limit(self, store):
         df = _make_ohlcv_df(n=10)
-        await store.write("005930", "1m", df)
+        store.write("005930", "1m", df)
 
-        result = await store.read("005930", "1m", limit=3)
+        result = store.read("005930", "1m", limit=3)
         assert len(result) == 3
 
     async def test_append(self, store):
@@ -190,13 +190,13 @@ class TestParquetStore:
                 "source": "test",
             }
         ]
-        await store.append("005930", "1m", rows)
-        result = await store.read("005930", "1m")
+        store.append("005930", "1m", rows)
+        result = store.read("005930", "1m")
         assert len(result) == 1
 
     async def test_list_symbols(self, store):
-        await store.write("005930", "1d", _make_ohlcv_df("005930"))
-        await store.write("000660", "1d", _make_ohlcv_df("000660"))
+        store.write("005930", "1d", _make_ohlcv_df("005930"))
+        store.write("000660", "1d", _make_ohlcv_df("000660"))
 
         symbols = store.list_symbols("1d")
         assert symbols == ["000660", "005930"]
@@ -205,7 +205,7 @@ class TestParquetStore:
         assert store.list_symbols("1d") == []
 
     async def test_get_date_range(self, store):
-        await store.write("005930", "1m", _make_ohlcv_df())
+        store.write("005930", "1m", _make_ohlcv_df())
         result = store.get_date_range("005930", "1m")
         assert result is not None
         assert result == ("2026-03", "2026-03")
@@ -214,15 +214,15 @@ class TestParquetStore:
         assert store.get_date_range("999999", "1m") is None
 
     async def test_get_storage_usage(self, store):
-        await store.write("005930", "1d", _make_ohlcv_df())
+        store.write("005930", "1d", _make_ohlcv_df())
         usage = store.get_storage_usage()
         assert "1d" in usage
         assert usage["1d"] > 0
 
     async def test_delete_file(self, store):
-        await store.write("005930", "1m", _make_ohlcv_df())
+        store.write("005930", "1m", _make_ohlcv_df())
         assert store.delete_file("005930", "1m", "2026-03") is True
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert result.is_empty()
 
     async def test_delete_file_nonexistent(self, store):
@@ -230,8 +230,8 @@ class TestParquetStore:
 
     async def test_write_empty_df(self, store):
         empty = pl.DataFrame()
-        await store.write("005930", "1m", empty)
-        result = await store.read("005930", "1m")
+        store.write("005930", "1m", empty)
+        result = store.read("005930", "1m")
         assert result.is_empty()
 
     async def test_multi_month_partitioning(self, store, data_dir):
@@ -264,7 +264,7 @@ class TestParquetStore:
                 "source": ["test"] * n,
             }
         )
-        await store.write("005930", "1m", df)
+        store.write("005930", "1m", df)
 
         march_file = data_dir / "ohlcv" / "1m" / "005930" / "2026-03.parquet"
         april_file = data_dir / "ohlcv" / "1m" / "005930" / "2026-04.parquet"
@@ -284,8 +284,8 @@ class TestParquetStore:
                 "source": ["dart", "dart"],
             }
         )
-        await store.write("005930", "", df, data_type="fundamental")
-        result = await store.read("005930", "", data_type="fundamental")
+        store.write("005930", "", df, data_type="fundamental")
+        result = store.read("005930", "", data_type="fundamental")
         assert len(result) == 2
         assert result["market_cap"][0] == 500000000000
 
@@ -300,7 +300,7 @@ class TestParquetStore:
                 "source": ["dart"],
             }
         )
-        await store.write("005930", "", df, data_type="fundamental")
+        store.write("005930", "", df, data_type="fundamental")
         path = data_dir / "fundamental" / "krx" / "005930"
         assert path.exists()
         assert list(path.glob("*.parquet"))
@@ -316,7 +316,7 @@ class TestParquetStore:
                 "source": ["dart"],
             }
         )
-        await store.write("005930", "", df, data_type="fundamental")
+        store.write("005930", "", df, data_type="fundamental")
         symbols = store.list_symbols(data_type="fundamental")
         assert symbols == ["005930"]
 
@@ -324,7 +324,7 @@ class TestParquetStore:
         """get_storage_usage가 fundamental 용량도 포함."""
         from datetime import date
 
-        await store.write("005930", "1d", _make_ohlcv_df())
+        store.write("005930", "1d", _make_ohlcv_df())
         df = pl.DataFrame(
             {
                 "date": [date(2026, 3, 1)],
@@ -332,7 +332,7 @@ class TestParquetStore:
                 "source": ["dart"],
             }
         )
-        await store.write("005930", "", df, data_type="fundamental")
+        store.write("005930", "", df, data_type="fundamental")
         usage = store.get_storage_usage()
         assert "1d" in usage
         assert "fundamental" in usage
@@ -340,8 +340,8 @@ class TestParquetStore:
     async def test_ohlcv_default_backward_compat(self, store):
         """data_type 미지정 시 기존 OHLCV 동작 유지."""
         df = _make_ohlcv_df()
-        await store.write("005930", "1m", df)
-        result = await store.read("005930", "1m")
+        store.write("005930", "1m", df)
+        result = store.read("005930", "1m")
         assert len(result) == 5
 
 
@@ -650,10 +650,10 @@ class TestDataCollector:
             "volume": 1000,
             "source": "test",
         }
-        await collector.add_data("005930", "1m", row)
+        collector.add_data("005930", "1m", row)
         assert len(collector.buffer["005930:1m"]) == 1
 
-        flushed = await collector.flush_all()
+        flushed = collector.flush_all()
         assert flushed == 1
         assert "005930:1m" not in collector.buffer
 
@@ -674,12 +674,12 @@ class TestDataCollector:
                 "volume": 1000,
                 "source": "test",
             }
-            await collector.add_data("005930", "1m", row)
+            collector.add_data("005930", "1m", row)
 
         # buffer_size=2이므로 자동 flush됨
         assert "005930:1m" not in collector.buffer
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) == 2
 
     async def test_start_and_stop(self, store):
@@ -688,11 +688,11 @@ class TestDataCollector:
         eventbus = AsyncMock()
         collector = DataCollector(store=store, eventbus=eventbus, collect_interval=0.05)
 
-        await collector.start(["005930"], ["1m"])
+        collector.start(["005930"], ["1m"])
         assert collector.running is True
 
         await asyncio.sleep(0.02)
-        await collector.stop()
+        collector.stop()
         assert collector.running is False
 
     async def test_start_twice_ignored(self, store):
@@ -701,11 +701,11 @@ class TestDataCollector:
         eventbus = AsyncMock()
         collector = DataCollector(store=store, eventbus=eventbus)
 
-        await collector.start(["005930"], ["1m"])
-        await collector.start(["005930"], ["1m"])  # 두 번째 호출은 무시
+        collector.start(["005930"], ["1m"])
+        collector.start(["005930"], ["1m"])  # 두 번째 호출은 무시
         assert collector.running is True
 
-        await collector.stop()
+        collector.stop()
 
     async def test_data_callback(self, store):
         from unittest.mock import AsyncMock
@@ -733,11 +733,11 @@ class TestDataCollector:
             ]
 
         collector.set_data_callback(mock_callback)
-        await collector.start(["005930"], ["1m"])
+        collector.start(["005930"], ["1m"])
         await asyncio.sleep(0.1)
-        await collector.stop()
+        collector.stop()
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) >= 1
 
 
@@ -759,45 +759,45 @@ class TestRetentionPolicy:
 
     async def test_enforce_deletes_old_data(self, store):
         """보존 기간 초과 데이터 삭제."""
-        await store.write("005930", "1m", _make_ohlcv_df())
+        store.write("005930", "1m", _make_ohlcv_df())
 
         # 1분봉 보존 기간을 0일로 설정 → 모든 데이터 삭제 대상
         policy = RetentionPolicy(store, retention_days={"1m": 0})
         now = datetime(2026, 6, 1, tzinfo=UTC)
-        deleted = await policy.enforce(now=now)
+        deleted = policy.enforce(now=now)
 
         assert "1m" in deleted
         assert deleted["1m"] >= 1
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert result.is_empty()
 
     async def test_enforce_keeps_recent_data(self, store):
         """보존 기간 내 데이터는 유지."""
-        await store.write("005930", "1m", _make_ohlcv_df())
+        store.write("005930", "1m", _make_ohlcv_df())
 
         policy = RetentionPolicy(store, retention_days={"1m": 365})
         now = datetime(2026, 3, 15, tzinfo=UTC)
-        deleted = await policy.enforce(now=now)
+        deleted = policy.enforce(now=now)
 
         # 2026-03 데이터는 15일 전이므로 삭제 안 됨
         assert deleted == {}
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) == 5
 
     async def test_enforce_skips_negative_retention(self, store):
         """보존 기간이 -1(무기한)이면 삭제하지 않는다."""
-        await store.write("005930", "1m", _make_ohlcv_df())
+        store.write("005930", "1m", _make_ohlcv_df())
         policy = RetentionPolicy(store, retention_days={"1m": -1})
         now = datetime(2099, 1, 1, tzinfo=UTC)
-        deleted = await policy.enforce(now=now)
+        deleted = policy.enforce(now=now)
         assert deleted == {}
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) == 5
 
     async def test_enforce_empty_store(self, store):
         policy = RetentionPolicy(store)
-        deleted = await policy.enforce()
+        deleted = policy.enforce()
         assert deleted == {}
 
     async def test_enforce_fundamental_path_resolution(self, store, data_dir):
@@ -812,7 +812,7 @@ class TestRetentionPolicy:
                 "source": ["dart", "dart"],
             }
         )
-        await store.write("005930", "", df, data_type="fundamental")
+        store.write("005930", "", df, data_type="fundamental")
 
         # fundamental/krx/005930/ 경로에 파일이 생성되었는지 확인
         fundamental_path = data_dir / "fundamental" / "krx" / "005930"
@@ -822,12 +822,12 @@ class TestRetentionPolicy:
         # fundamental 보존 기간을 0일로 설정 → 오래된 데이터 삭제 대상
         policy = RetentionPolicy(store, retention_days={"fundamental": 0})
         now = datetime(2026, 6, 1, tzinfo=UTC)
-        deleted = await policy.enforce(now=now)
+        deleted = policy.enforce(now=now)
 
         assert "fundamental" in deleted
         assert deleted["fundamental"] == 2
 
-        result = await store.read("005930", "", data_type="fundamental")
+        result = store.read("005930", "", data_type="fundamental")
         assert result.is_empty()
 
 

--- a/tests/unit/test_dataset_delete_api.py
+++ b/tests/unit/test_dataset_delete_api.py
@@ -69,7 +69,7 @@ class TestListDatasets:
 
     async def test_response_wrapper_format(self, client, store):
         """응답이 {items, total} 래퍼를 사용한다."""
-        await store.write("005930", "1d", _make_ohlcv_df())
+        store.write("005930", "1d", _make_ohlcv_df())
         resp = client.get("/api/data/datasets")
         assert resp.status_code == 200
         body = resp.json()
@@ -80,7 +80,7 @@ class TestListDatasets:
 
     async def test_field_names(self, client, store):
         """각 데이터셋에 id, start_date, end_date, row_count 필드가 있다."""
-        await store.write("005930", "1d", _make_ohlcv_df())
+        store.write("005930", "1d", _make_ohlcv_df())
         resp = client.get("/api/data/datasets")
         ds = resp.json()["items"][0]
         assert ds["id"] == "005930__1d"
@@ -94,7 +94,7 @@ class TestListDatasets:
     async def test_pagination(self, client, store):
         """offset/limit 파라미터로 페이지네이션이 동작한다."""
         for sym in ["000010", "000020", "000030"]:
-            await store.write(sym, "1d", _make_ohlcv_df())
+            store.write(sym, "1d", _make_ohlcv_df())
 
         resp = client.get("/api/data/datasets", params={"offset": 0, "limit": 2})
         body = resp.json()
@@ -108,8 +108,8 @@ class TestListDatasets:
 
     async def test_filter_by_symbol(self, client, store):
         """symbol 필터로 특정 종목만 반환한다."""
-        await store.write("005930", "1d", _make_ohlcv_df())
-        await store.write("035720", "1d", _make_ohlcv_df())
+        store.write("005930", "1d", _make_ohlcv_df())
+        store.write("035720", "1d", _make_ohlcv_df())
 
         resp = client.get("/api/data/datasets", params={"symbol": "005930"})
         body = resp.json()
@@ -118,8 +118,8 @@ class TestListDatasets:
 
     async def test_filter_by_timeframe(self, client, store):
         """timeframe 필터로 특정 타임프레임만 반환한다."""
-        await store.write("005930", "1d", _make_ohlcv_df())
-        await store.write("005930", "1h", _make_ohlcv_df())
+        store.write("005930", "1d", _make_ohlcv_df())
+        store.write("005930", "1h", _make_ohlcv_df())
 
         resp = client.get("/api/data/datasets", params={"timeframe": "1d"})
         body = resp.json()
@@ -137,7 +137,7 @@ class TestListDatasets:
 class TestDeleteDataset:
     async def test_delete_success(self, client, store):
         """데이터셋 삭제 성공."""
-        await store.write("005930", "1d", _make_ohlcv_df())
+        store.write("005930", "1d", _make_ohlcv_df())
         resp = client.delete("/api/data/datasets/005930__1d")
         assert resp.status_code == 204
 
@@ -153,7 +153,7 @@ class TestDeleteDataset:
 
     async def test_datasets_empty_after_delete(self, client, store):
         """삭제 후 목록에서 제거 확인."""
-        await store.write("005930", "1d", _make_ohlcv_df())
+        store.write("005930", "1d", _make_ohlcv_df())
         client.delete("/api/data/datasets/005930__1d")
         resp = client.get("/api/data/datasets")
         assert resp.status_code == 200
@@ -167,7 +167,7 @@ class TestFundamentalDatasets:
 
     async def test_list_fundamental_datasets(self, client, store):
         """fundamental 데이터셋 목록 조회."""
-        await store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
         resp = client.get("/api/data/datasets", params={"data_type": "fundamental"})
         assert resp.status_code == 200
         body = resp.json()
@@ -178,14 +178,14 @@ class TestFundamentalDatasets:
 
     async def test_list_ohlcv_excludes_fundamental(self, client, store):
         """OHLCV 조회 시 fundamental 데이터가 포함되지 않음."""
-        await store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
         resp = client.get("/api/data/datasets", params={"data_type": "ohlcv"})
         assert resp.status_code == 200
         assert resp.json()["items"] == []
 
     async def test_delete_fundamental_dataset(self, client, store):
         """fundamental 데이터셋 삭제."""
-        await store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
         resp = client.delete(
             "/api/data/datasets/005930__fundamental",
             params={"data_type": "fundamental"},

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -215,7 +215,7 @@ class TestAPIGateway:
             eventbus=eventbus,
             rate_config=RateLimitConfig(max_requests=100, window_seconds=60),
         )
-        await gw.start()
+        gw.start()
         return gw
 
     async def test_get_current_price(self, gateway, broker):
@@ -281,7 +281,7 @@ class TestAPIGatewayEvents:
             eventbus=eventbus,
             rate_config=RateLimitConfig(max_requests=100, window_seconds=60),
         )
-        await gw.start()
+        gw.start()
         return gw
 
     async def test_order_approved_submits(self, gateway, eventbus, broker):

--- a/tests/unit/test_kis_error_handling.py
+++ b/tests/unit/test_kis_error_handling.py
@@ -353,7 +353,7 @@ class TestGatewayCancelFailed:
         mock_broker.cancel_order = AsyncMock(side_effect=Exception("network error"))
 
         gw = APIGateway(broker=mock_broker, eventbus=eventbus)
-        await gw.start()
+        gw.start()
 
         received: list[OrderCancelFailedEvent] = []
         eventbus.subscribe(OrderCancelFailedEvent, lambda e: received.append(e))

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -132,7 +132,7 @@ async def test_composition_root_all_modules(tmp_path: Path) -> None:
     from ante.rule import RuleEngine
 
     rule_engine = RuleEngine(eventbus=eventbus, system_state=system_state)
-    await rule_engine.start()
+    rule_engine.start()
 
     # 8. Treasury
     from ante.treasury import Treasury

--- a/tests/unit/test_parquet_validation.py
+++ b/tests/unit/test_parquet_validation.py
@@ -69,7 +69,7 @@ class TestParquetValidate:
         _create_valid_parquet(tmp_path / "ohlcv" / "1d" / "005930" / "2026-01.parquet")
         _create_valid_parquet(tmp_path / "ohlcv" / "1d" / "005930" / "2026-02.parquet")
 
-        result = await tmp_store.validate("005930", "1d")
+        result = tmp_store.validate("005930", "1d")
 
         assert result["total"] == 2
         assert result["valid"] == 2
@@ -83,7 +83,7 @@ class TestParquetValidate:
             tmp_path / "ohlcv" / "1d" / "005930" / "2026-02.parquet"
         )
 
-        result = await tmp_store.validate("005930", "1d")
+        result = tmp_store.validate("005930", "1d")
 
         assert result["total"] == 2
         assert result["valid"] == 1
@@ -95,7 +95,7 @@ class TestParquetValidate:
         corrupted_path = tmp_path / "ohlcv" / "1d" / "005930" / "2026-02.parquet"
         _create_corrupted_parquet(corrupted_path)
 
-        result = await tmp_store.validate("005930", "1d", fix=True)
+        result = tmp_store.validate("005930", "1d", fix=True)
 
         assert result["corrupted"] == 1
         assert not corrupted_path.exists()
@@ -103,7 +103,7 @@ class TestParquetValidate:
 
     @pytest.mark.asyncio
     async def test_validate_no_data(self, tmp_store):
-        result = await tmp_store.validate("NONE", "1d")
+        result = tmp_store.validate("NONE", "1d")
 
         assert result["total"] == 0
         assert result["valid"] == 0
@@ -113,56 +113,50 @@ class TestParquetValidate:
     async def test_validate_empty_directory(self, tmp_store, tmp_path):
         (tmp_path / "ohlcv" / "1d" / "005930").mkdir(parents=True)
 
-        result = await tmp_store.validate("005930", "1d")
+        result = tmp_store.validate("005930", "1d")
 
         assert result["total"] == 0
 
 
 class TestValidateCLI:
     def test_validate_specific_symbol(self, runner):
-        with patch("asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "symbol": "005930",
-                    "timeframe": "1d",
-                    "total": 3,
-                    "valid": 3,
-                    "corrupted": 0,
-                    "corrupted_files": [],
-                }
-            ]
+        with patch("ante.data.store.ParquetStore.validate") as mock_validate:
+            mock_validate.return_value = {
+                "symbol": "005930",
+                "timeframe": "1d",
+                "total": 3,
+                "valid": 3,
+                "corrupted": 0,
+                "corrupted_files": [],
+            }
             result = runner.invoke(cli, ["data", "validate", "--symbol", "005930"])
             assert result.exit_code == 0
             assert "정상 3개" in result.output
 
     def test_validate_with_corrupted(self, runner):
-        with patch("asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "symbol": "005930",
-                    "timeframe": "1d",
-                    "total": 3,
-                    "valid": 2,
-                    "corrupted": 1,
-                    "corrupted_files": ["/data/ohlcv/1d/005930/2026-01.parquet"],
-                }
-            ]
+        with patch("ante.data.store.ParquetStore.validate") as mock_validate:
+            mock_validate.return_value = {
+                "symbol": "005930",
+                "timeframe": "1d",
+                "total": 3,
+                "valid": 2,
+                "corrupted": 1,
+                "corrupted_files": ["/data/ohlcv/1d/005930/2026-01.parquet"],
+            }
             result = runner.invoke(cli, ["data", "validate", "--symbol", "005930"])
             assert result.exit_code == 0
             assert "손상 1개" in result.output
 
     def test_validate_json_output(self, runner):
-        with patch("asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "symbol": "005930",
-                    "timeframe": "1d",
-                    "total": 2,
-                    "valid": 2,
-                    "corrupted": 0,
-                    "corrupted_files": [],
-                }
-            ]
+        with patch("ante.data.store.ParquetStore.validate") as mock_validate:
+            mock_validate.return_value = {
+                "symbol": "005930",
+                "timeframe": "1d",
+                "total": 2,
+                "valid": 2,
+                "corrupted": 0,
+                "corrupted_files": [],
+            }
             result = runner.invoke(
                 cli,
                 ["--format", "json", "data", "validate", "--symbol", "005930"],
@@ -181,11 +175,11 @@ class TestValidateCLI:
 
     def test_validate_all_symbols(self, runner):
         with (
-            patch("asyncio.run") as mock_run,
+            patch("ante.data.store.ParquetStore.validate") as mock_validate,
             patch("ante.data.store.ParquetStore.list_symbols") as mock_list,
         ):
             mock_list.return_value = ["005930", "000660"]
-            mock_run.return_value = [
+            mock_validate.side_effect = [
                 {
                     "symbol": "005930",
                     "timeframe": "1d",

--- a/tests/unit/test_report_draft.py
+++ b/tests/unit/test_report_draft.py
@@ -185,7 +185,7 @@ class TestOnBacktestComplete:
         mock_eventbus.subscribe = MagicMock()
 
         generator = ReportDraftGenerator(mock_store, mock_eventbus)
-        await generator.initialize()
+        generator.initialize()
 
         mock_eventbus.subscribe.assert_called_once()
 

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -473,7 +473,7 @@ class TestRuleEngineEventBus:
     @pytest.fixture
     async def engine(self, eventbus, system_state):
         engine = RuleEngine(eventbus=eventbus, system_state=system_state)
-        await engine.start()
+        engine.start()
         return engine
 
     async def test_order_validated_on_pass(self, engine, eventbus):

--- a/tests/unit/test_rule_modify.py
+++ b/tests/unit/test_rule_modify.py
@@ -55,7 +55,7 @@ async def system_state(db):
 async def engine(system_state):
     eventbus = EventBus()
     engine = RuleEngine(eventbus=eventbus, system_state=system_state)
-    await engine.start()
+    engine.start()
     return engine
 
 

--- a/tests/unit/test_stop_order.py
+++ b/tests/unit/test_stop_order.py
@@ -87,7 +87,7 @@ class TestTrigger:
         self, _mock_session: MagicMock, manager: StopOrderManager, eventbus: MagicMock
     ) -> None:
         """매도 스탑: 현재가 <= stop_price 시 트리거."""
-        await manager.start()
+        manager.start()
 
         await manager.register(
             order_id="ord-001",
@@ -123,7 +123,7 @@ class TestTrigger:
         self, _mock_session: MagicMock, manager: StopOrderManager, eventbus: MagicMock
     ) -> None:
         """매수 스탑: 현재가 >= stop_price 시 트리거."""
-        await manager.start()
+        manager.start()
 
         await manager.register(
             order_id="ord-002",
@@ -148,7 +148,7 @@ class TestTrigger:
         self, _mock_session: MagicMock, manager: StopOrderManager, eventbus: MagicMock
     ) -> None:
         """stop_limit → limit 변환."""
-        await manager.start()
+        manager.start()
 
         await manager.register(
             order_id="ord-003",
@@ -174,7 +174,7 @@ class TestTrigger:
         self, manager: StopOrderManager, eventbus: MagicMock
     ) -> None:
         """트리거 조건 미충족 시 주문 유지."""
-        await manager.start()
+        manager.start()
 
         await manager.register(
             order_id="ord-004",
@@ -198,7 +198,7 @@ class TestTrigger:
         self, manager: StopOrderManager, eventbus: MagicMock
     ) -> None:
         """다른 종목 시세는 무시."""
-        await manager.start()
+        manager.start()
 
         await manager.register(
             order_id="ord-005",
@@ -256,13 +256,13 @@ class TestCancel:
             stop_price=49000.0,
         )
 
-        result = await manager.cancel(stop_id)
+        result = manager.cancel(stop_id)
         assert result is True
         assert len(manager.active_orders) == 0
 
     async def test_cancel_nonexistent(self, manager: StopOrderManager) -> None:
         """존재하지 않는 주문 취소."""
-        result = await manager.cancel("stop-nonexistent")
+        result = manager.cancel("stop-nonexistent")
         assert result is False
 
 
@@ -273,7 +273,7 @@ class TestExpiry:
         self, manager: StopOrderManager, eventbus: MagicMock
     ) -> None:
         """매니저 중지 시 모든 주문 만료."""
-        await manager.start()
+        manager.start()
 
         await manager.register(
             order_id="ord-001",

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -117,53 +117,53 @@ class TestCommands:
     """명령 핸들러 테스트."""
 
     async def test_help(self, receiver):
-        result = await receiver._cmd_help([])
+        result = receiver._cmd_help([])
         assert "/status" in result
         assert "/halt" in result
         assert "/help" in result
 
     async def test_status(self, receiver):
-        result = await receiver._cmd_status([])
+        result = receiver._cmd_status([])
         assert "거래 상태" in result
         assert "active" in result
         assert "봇" in result
 
     async def test_status_no_manager(self, receiver):
         receiver._bot_manager = None
-        result = await receiver._cmd_status([])
+        result = receiver._cmd_status([])
         assert "거래 상태" in result
 
     async def test_status_no_state(self, receiver):
         receiver._system_state = None
         receiver._bot_manager = None
-        result = await receiver._cmd_status([])
+        result = receiver._cmd_status([])
         assert "조회할 수 없습니다" in result
 
     async def test_bots(self, receiver):
-        result = await receiver._cmd_bots([])
+        result = receiver._cmd_bots([])
         assert "봇 목록" in result
         assert "bot-1" in result
         assert "bot-2" in result
 
     async def test_bots_no_manager(self, receiver):
         receiver._bot_manager = None
-        result = await receiver._cmd_bots([])
+        result = receiver._cmd_bots([])
         assert "연결되지 않았습니다" in result
 
     async def test_bots_empty(self, receiver):
         receiver._bot_manager.list_bots.return_value = []
-        result = await receiver._cmd_bots([])
+        result = receiver._cmd_bots([])
         assert "없습니다" in result
 
     async def test_balance(self, receiver):
-        result = await receiver._cmd_balance([])
+        result = receiver._cmd_balance([])
         assert "계좌 잔고" in result
         assert "10,000,000" in result
         assert "할당" in result
 
     async def test_balance_no_treasury(self, receiver):
         receiver._treasury = None
-        result = await receiver._cmd_balance([])
+        result = receiver._cmd_balance([])
         assert "연결되지 않았습니다" in result
 
     async def test_unknown_command(self, receiver):

--- a/tests/unit/test_treasury.py
+++ b/tests/unit/test_treasury.py
@@ -81,7 +81,7 @@ class TestAllocation:
         """예산 할당."""
         result = await treasury.allocate("bot1", 1_000_000.0)
         assert result is True
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.allocated == 1_000_000.0
         assert budget.available == 1_000_000.0
@@ -101,7 +101,7 @@ class TestAllocation:
         await treasury.allocate("bot1", 1_000_000.0)
         result = await treasury.deallocate("bot1", 500_000.0)
         assert result is True
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.allocated == 500_000.0
         assert budget.available == 500_000.0
@@ -123,7 +123,7 @@ class TestAllocation:
         """동일 봇에 추가 할당."""
         await treasury.allocate("bot1", 500_000.0)
         await treasury.allocate("bot1", 300_000.0)
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.allocated == 800_000.0
         assert budget.available == 800_000.0
@@ -227,7 +227,7 @@ class TestReservation:
         await treasury.allocate("bot1", 1_000_000.0)
         result = await treasury.reserve_for_order("bot1", "ord1", 500_000.0)
         assert result is True
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.available == 500_000.0
         assert budget.reserved == 500_000.0
@@ -243,7 +243,7 @@ class TestReservation:
         await treasury.allocate("bot1", 1_000_000.0)
         await treasury.reserve_for_order("bot1", "ord1", 500_000.0)
         await treasury.release_reservation("bot1", "ord1")
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.available == 1_000_000.0
         assert budget.reserved == 0.0
@@ -252,7 +252,7 @@ class TestReservation:
         """존재하지 않는 주문 해제는 무시."""
         await treasury.allocate("bot1", 1_000_000.0)
         await treasury.release_reservation("bot1", "unknown_ord")
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.available == 1_000_000.0
 
@@ -285,7 +285,7 @@ class TestTreasuryEvents:
         assert received[0].order_id == "ord1"
         assert received[0].reserved_amount > 0
 
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.reserved > 0
         assert budget.available < 1_000_000.0
@@ -356,7 +356,7 @@ class TestTreasuryEvents:
             )
         )
 
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.reserved == 0.0
         assert budget.spent == 500_075.0  # 500,000 + 75
@@ -382,7 +382,7 @@ class TestTreasuryEvents:
             )
         )
 
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         expected_proceeds = 550_000.0 - 82.5
         assert budget.returned == expected_proceeds
@@ -406,7 +406,7 @@ class TestTreasuryEvents:
             )
         )
 
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.available == 1_000_000.0
         assert budget.reserved == 0.0
@@ -430,7 +430,7 @@ class TestTreasuryEvents:
             )
         )
 
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.available == 1_000_000.0
         assert budget.reserved == 0.0
@@ -488,7 +488,7 @@ class TestTreasuryPersistence:
 
         assert t2.account_balance == 5_000_000.0
         assert t2.unallocated == 3_000_000.0
-        budget = await t2.get_budget("bot1")
+        budget = t2.get_budget("bot1")
         assert budget is not None
         assert budget.allocated == 2_000_000.0
         assert budget.available == 2_000_000.0

--- a/tests/unit/test_treasury_sync.py
+++ b/tests/unit/test_treasury_sync.py
@@ -183,7 +183,7 @@ class TestSyncLoop:
         broker = FakeBroker()
         pos_history = FakePositionHistory()
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=1)
+        treasury.start_sync(broker, pos_history, interval_seconds=1)
         assert treasury._sync_task is not None
         assert not treasury._sync_task.done()
 
@@ -198,7 +198,7 @@ class TestSyncLoop:
         broker = FakeBroker()
         pos_history = FakePositionHistory()
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 
@@ -213,7 +213,7 @@ class TestSyncLoop:
         broker = FailingBroker()
         pos_history = FakePositionHistory()
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 
@@ -227,7 +227,7 @@ class TestSyncLoop:
         broker = FakeBroker()
         pos_history = FakePositionHistory()
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 
@@ -240,10 +240,10 @@ class TestSyncLoop:
         broker = FakeBroker()
         pos_history = FakePositionHistory()
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         task1 = treasury._sync_task
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         assert treasury._sync_task is task1  # 같은 태스크
 
         await treasury.stop_sync()
@@ -286,7 +286,7 @@ class TestExternalPositions:
             ]
         )
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 
@@ -316,7 +316,7 @@ class TestExternalPositions:
             ]
         )
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 
@@ -337,7 +337,7 @@ class TestExternalPositions:
         )
         pos_history = FakePositionHistory(positions=[])
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 
@@ -358,7 +358,7 @@ class TestExternalPositions:
         )
         pos_history = FakePositionHistory(positions=[])
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 
@@ -386,7 +386,7 @@ class TestExternalPositions:
         )
         pos_history = FakePositionHistory(positions=[])
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 


### PR DESCRIPTION
## Summary

- `async def`로 선언되었으나 내부에서 `await`를 사용하지 않는 함수 25개를 `def`로 전환
- 호출부의 `await` 제거 및 테스트 코드 동기화
- 인터페이스/이벤트 핸들러 등 의도적 유지가 필요한 24건에 주석으로 사유 명시

## Test plan

- [x] `ruff check` 통과
- [x] `ruff format` 통과
- [x] `pytest tests/` 전체 1750건 통과 (e2e 제외, playwright 미설치)

Refs #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)