### PR TITLE
refactor: 문자열 리터럴 상수 추출

### DIFF
--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -8,6 +8,9 @@ import click
 
 from ante.cli.main import get_formatter
 
+_SYSTEM_TOML_FILENAME = "system.toml"
+_SECRETS_ENV_FILENAME = "secrets.env"
+
 SYSTEM_TOML_TEMPLATE = """\
 # Ante 시스템 설정
 
@@ -61,10 +64,10 @@ def init(ctx: click.Context, target_dir: str | None, seed: bool) -> None:
 
     if config_path.exists():
         existing = []
-        if (config_path / "system.toml").exists():
-            existing.append("system.toml")
-        if (config_path / "secrets.env").exists():
-            existing.append("secrets.env")
+        if (config_path / _SYSTEM_TOML_FILENAME).exists():
+            existing.append(_SYSTEM_TOML_FILENAME)
+        if (config_path / _SECRETS_ENV_FILENAME).exists():
+            existing.append(_SECRETS_ENV_FILENAME)
         if existing and not seed:
             fmt.error(
                 f"설정 디렉토리가 이미 존재합니다: {config_path}\n"
@@ -74,15 +77,15 @@ def init(ctx: click.Context, target_dir: str | None, seed: bool) -> None:
 
     config_path.mkdir(parents=True, exist_ok=True)
 
-    system_toml = config_path / "system.toml"
+    system_toml = config_path / _SYSTEM_TOML_FILENAME
     if not system_toml.exists():
         system_toml.write_text(SYSTEM_TOML_TEMPLATE)
 
-    secrets_env = config_path / "secrets.env"
+    secrets_env = config_path / _SECRETS_ENV_FILENAME
     if not secrets_env.exists():
         secrets_env.write_text(SECRETS_ENV_TEMPLATE)
 
-    created_files = ["system.toml", "secrets.env"]
+    created_files = [_SYSTEM_TOML_FILENAME, _SECRETS_ENV_FILENAME]
 
     if seed:
         import asyncio

--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -16,6 +16,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_DATA_PATH = "data/"
+_DATA_PATH_HELP = "데이터 저장소 경로"
+_SCOPE_DATA_WRITE = "data:write"
+_SCOPE_DATA_READ = "data:read"
+_SEPARATOR = "──────────────────────────────────────────────────"
+
 _API_KEY_GUIDE = """\
 ──────────────────────────────────────────────────
 API 키 설정이 필요합니다.
@@ -56,10 +62,10 @@ def feed_config() -> None:
 @feed_config.command("set")
 @click.argument("key")
 @click.argument("value")
-@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
-@require_scope("data:write")
+@require_scope(_SCOPE_DATA_WRITE)
 def config_set(ctx: click.Context, key: str, value: str, data_path: str) -> None:
     """API 키를 .feed/.env 파일에 저장한다."""
     from ante.feed.config import API_KEYS, FeedConfig
@@ -81,10 +87,10 @@ def config_set(ctx: click.Context, key: str, value: str, data_path: str) -> None
 
 
 @feed_config.command("list")
-@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
-@require_scope("data:read")
+@require_scope(_SCOPE_DATA_READ)
 def config_list(ctx: click.Context, data_path: str) -> None:
     """등록된 API 키 목록을 마스킹하여 표시한다."""
     from ante.feed.config import FeedConfig
@@ -104,10 +110,10 @@ def config_list(ctx: click.Context, data_path: str) -> None:
 
 
 @feed_config.command("check")
-@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
-@require_scope("data:read")
+@require_scope(_SCOPE_DATA_READ)
 def config_check(ctx: click.Context, data_path: str) -> None:
     """API 키 존재 여부를 확인한다."""
     from ante.feed.config import FeedConfig
@@ -121,7 +127,7 @@ def config_check(ctx: click.Context, data_path: str) -> None:
     else:
         click.echo()
         click.echo("API Key Status")
-        click.echo("──────────────────────────────────────────────────")
+        click.echo(_SEPARATOR)
         all_set = True
         for entry in statuses:
             if entry["set"]:
@@ -130,7 +136,7 @@ def config_check(ctx: click.Context, data_path: str) -> None:
             else:
                 click.echo(f"  {entry['key']:<30} ✗ 미설정")
                 all_set = False
-        click.echo("──────────────────────────────────────────────────")
+        click.echo(_SEPARATOR)
         if not all_set:
             click.echo("설정: ante feed config set <KEY> <VALUE>")
         click.echo()
@@ -187,14 +193,14 @@ def _ensure_initialized(  # noqa: ANN001, ANN201
 
 
 @feed_run.command("backfill")
-@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
 @click.option(
     "--since", default=None, help="수집 시작일 (YYYY-MM-DD, config 기본값 오버라이드)"
 )
 @click.option("--until", default=None, help="수집 종료일 (YYYY-MM-DD, 기본값: 오늘)")
 @click.pass_context
 @require_auth
-@require_scope("data:write")
+@require_scope(_SCOPE_DATA_WRITE)
 def run_backfill(
     ctx: click.Context,
     data_path: str,
@@ -233,13 +239,13 @@ def run_backfill(
 
 
 @feed_run.command("daily")
-@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
 @click.option(
     "--date", "target_date", default=None, help="수집 대상일 (YYYY-MM-DD, 기본값: 어제)"
 )
 @click.pass_context
 @require_auth
-@require_scope("data:write")
+@require_scope(_SCOPE_DATA_WRITE)
 def run_daily(
     ctx: click.Context,
     data_path: str,
@@ -296,10 +302,10 @@ def run_daily(
 
 
 @feed.command("start")
-@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
-@require_scope("data:write")
+@require_scope(_SCOPE_DATA_WRITE)
 def feed_start(ctx: click.Context, data_path: str) -> None:
     """내장 스케줄러로 backfill/daily를 자동 실행하는 상주 프로세스를 시작한다."""
     import asyncio
@@ -342,10 +348,10 @@ def feed_start(ctx: click.Context, data_path: str) -> None:
 
 
 @feed.command("init")
-@click.argument("data_path", default="data/")
+@click.argument("data_path", default=_DEFAULT_DATA_PATH)
 @click.pass_context
 @require_auth
-@require_scope("data:write")
+@require_scope(_SCOPE_DATA_WRITE)
 def feed_init(ctx: click.Context, data_path: str) -> None:
     """DataFeed 운영 디렉토리를 초기화한다."""
     from ante.feed.config import FeedConfig
@@ -368,10 +374,10 @@ def feed_init(ctx: click.Context, data_path: str) -> None:
 
 
 @feed.command("status")
-@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
-@require_scope("data:read")
+@require_scope(_SCOPE_DATA_READ)
 def feed_status(ctx: click.Context, data_path: str) -> None:
     """수집 상태를 조회한다."""
 
@@ -422,7 +428,7 @@ def _echo_status_text(
     """feed status의 텍스트 출력을 수행한다."""
     click.echo()
     click.echo(f"DataFeed Status ({cfg.feed_dir})")  # type: ignore[attr-defined]
-    click.echo("══════════════════════════════════════════════════")
+    click.echo("═" * 50)
 
     _echo_checkpoints_section(checkpoints)
     _echo_report_section(latest_report)
@@ -435,7 +441,7 @@ def _echo_checkpoints_section(checkpoints: list[dict[str, str]]) -> None:
     """체크포인트 섹션을 출력한다."""
     click.echo()
     click.echo("Checkpoints")
-    click.echo("──────────────────────────────────────────────────")
+    click.echo(_SEPARATOR)
     if checkpoints:
         for cp in checkpoints:
             click.echo(
@@ -451,7 +457,7 @@ def _echo_report_section(latest_report: dict | None) -> None:
     """최근 리포트 섹션을 출력한다."""
     click.echo()
     click.echo("Latest Report")
-    click.echo("──────────────────────────────────────────────────")
+    click.echo(_SEPARATOR)
     if latest_report:
         summary = latest_report.get("summary", {})
         click.echo(f"  mode: {latest_report.get('mode', '?')}")
@@ -470,7 +476,7 @@ def _echo_api_keys_section(api_keys: list[dict]) -> None:
     """API 키 섹션을 출력한다."""
     click.echo()
     click.echo("API Keys")
-    click.echo("──────────────────────────────────────────────────")
+    click.echo(_SEPARATOR)
     for entry in api_keys:
         if entry["set"]:
             source_info = f"(source: {entry['source']})"
@@ -531,10 +537,10 @@ def _load_latest_report(
 @click.option("--symbol", required=True, help="종목 코드 (6자리)")
 @click.option("--timeframe", default="1d", help="타임프레임 (기본값: 1d)")
 @click.option("--source", default="external", help="데이터 소스 식별자")
-@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
-@require_scope("data:write")
+@require_scope(_SCOPE_DATA_WRITE)
 def feed_inject(
     ctx: click.Context,
     path: str,

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_ORG = "default"
+
 MEMBER_SCHEMA = """
 CREATE TABLE IF NOT EXISTS members (
     member_id          TEXT PRIMARY KEY,
@@ -131,7 +133,7 @@ def _row_to_member(row: dict) -> Member:
         member_id=row["member_id"],
         type=row["type"],
         role=row["role"],
-        org=row.get("org", "default"),
+        org=row.get("org", _DEFAULT_ORG),
         name=row.get("name", ""),
         emoji=row.get("emoji", ""),
         status=row.get("status", MemberStatus.ACTIVE),
@@ -275,7 +277,7 @@ class MemberService:
             member_id=member_id,
             type=MemberType.HUMAN,
             role=MemberRole.MASTER,
-            org="default",
+            org=_DEFAULT_ORG,
             name=name or member_id,
             emoji=emoji,
             status=MemberStatus.ACTIVE,
@@ -331,7 +333,7 @@ class MemberService:
         member_id: str,
         member_type: str,
         role: str = MemberRole.DEFAULT,
-        org: str = "default",
+        org: str = _DEFAULT_ORG,
         name: str = "",
         emoji: str | None = None,
         scopes: list[str] | None = None,

--- a/src/ante/trade/performance.py
+++ b/src/ante/trade/performance.py
@@ -21,6 +21,17 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# SQL query fragments reused in daily/weekly/monthly summary methods
+_COND_STATUS_FILLED = "t.status = ?"
+_COND_SIDE_SELL = "t.side = 'sell'"
+_COND_BOT_ID = "t.bot_id = ?"
+_JOIN_POSITION_HISTORY = """LEFT JOIN position_history ph
+                ON ph.bot_id = t.bot_id
+                AND ph.symbol = t.symbol
+                AND ph.action = 'sell'
+                AND ph.price = t.price
+                AND ph.quantity = t.quantity"""
+
 
 class PerformanceTracker:
     """봇/전략의 성과 지표를 조회 시 계산."""
@@ -99,13 +110,13 @@ class PerformanceTracker:
             end_date: 종료일 (YYYY-MM-DD)
         """
         conditions: list[str] = [
-            "t.status = ?",
-            "t.side = 'sell'",
+            _COND_STATUS_FILLED,
+            _COND_SIDE_SELL,
         ]
         params: list[Any] = [TradeStatus.FILLED.value]
 
         if bot_id:
-            conditions.append("t.bot_id = ?")
+            conditions.append(_COND_BOT_ID)
             params.append(bot_id)
         if start_date:
             conditions.append("date(t.timestamp) >= ?")
@@ -122,12 +133,7 @@ class PerformanceTracker:
                 COUNT(*) AS trade_count,
                 SUM(CASE WHEN ph.pnl > 0 THEN 1 ELSE 0 END) AS win_count
             FROM trades t
-            LEFT JOIN position_history ph
-                ON ph.bot_id = t.bot_id
-                AND ph.symbol = t.symbol
-                AND ph.action = 'sell'
-                AND ph.price = t.price
-                AND ph.quantity = t.quantity
+            {_JOIN_POSITION_HISTORY}
             WHERE {where}
             GROUP BY trade_date
             ORDER BY trade_date ASC
@@ -160,13 +166,13 @@ class PerformanceTracker:
             bot_id: 봇 ID 필터 (None이면 전체)
         """
         conditions: list[str] = [
-            "t.status = ?",
-            "t.side = 'sell'",
+            _COND_STATUS_FILLED,
+            _COND_SIDE_SELL,
         ]
         params: list[Any] = [TradeStatus.FILLED.value]
 
         if bot_id:
-            conditions.append("t.bot_id = ?")
+            conditions.append(_COND_BOT_ID)
             params.append(bot_id)
 
         where = " AND ".join(conditions)
@@ -178,12 +184,7 @@ class PerformanceTracker:
                 COUNT(*) AS trade_count,
                 SUM(CASE WHEN ph.pnl > 0 THEN 1 ELSE 0 END) AS win_count
             FROM trades t
-            LEFT JOIN position_history ph
-                ON ph.bot_id = t.bot_id
-                AND ph.symbol = t.symbol
-                AND ph.action = 'sell'
-                AND ph.price = t.price
-                AND ph.quantity = t.quantity
+            {_JOIN_POSITION_HISTORY}
             WHERE {where}
             GROUP BY week_start
             ORDER BY week_start ASC
@@ -217,13 +218,13 @@ class PerformanceTracker:
             year: 연도 필터 (None이면 전체)
         """
         conditions: list[str] = [
-            "t.status = ?",
-            "t.side = 'sell'",
+            _COND_STATUS_FILLED,
+            _COND_SIDE_SELL,
         ]
         params: list[Any] = [TradeStatus.FILLED.value]
 
         if bot_id:
-            conditions.append("t.bot_id = ?")
+            conditions.append(_COND_BOT_ID)
             params.append(bot_id)
         if year:
             conditions.append("strftime('%Y', t.timestamp) = ?")
@@ -238,12 +239,7 @@ class PerformanceTracker:
                 COUNT(*) AS trade_count,
                 SUM(CASE WHEN ph.pnl > 0 THEN 1 ELSE 0 END) AS win_count
             FROM trades t
-            LEFT JOIN position_history ph
-                ON ph.bot_id = t.bot_id
-                AND ph.symbol = t.symbol
-                AND ph.action = 'sell'
-                AND ph.price = t.price
-                AND ph.quantity = t.quantity
+            {_JOIN_POSITION_HISTORY}
             WHERE {where}
             GROUP BY yr, mo
             ORDER BY yr ASC, mo ASC

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -18,6 +18,8 @@ from ante.web.schemas import BotDetailResponse, BotListResponse
 
 router = APIRouter()
 
+_BOT_NOT_FOUND = "봇을 찾을 수 없습니다"
+
 
 class BotCreateRequest(BaseModel):
     """봇 생성 요청."""
@@ -96,7 +98,7 @@ async def get_bot(
     """봇 상세 조회."""
     bot = bot_manager.get_bot(bot_id)
     if bot is None:
-        raise HTTPException(status_code=404, detail="봇을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_BOT_NOT_FOUND)
 
     info = bot.get_info()
 
@@ -150,7 +152,7 @@ async def start_bot(
 
     bot = bot_manager.get_bot(bot_id)
     if bot is None:
-        raise HTTPException(status_code=404, detail="봇을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_BOT_NOT_FOUND)
 
     try:
         await bot_manager.start_bot(bot_id)
@@ -170,7 +172,7 @@ async def stop_bot(
 
     bot = bot_manager.get_bot(bot_id)
     if bot is None:
-        raise HTTPException(status_code=404, detail="봇을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_BOT_NOT_FOUND)
 
     try:
         await bot_manager.stop_bot(bot_id)
@@ -190,7 +192,7 @@ async def delete_bot(
 
     bot = bot_manager.get_bot(bot_id)
     if bot is None:
-        raise HTTPException(status_code=404, detail="봇을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_BOT_NOT_FOUND)
 
     try:
         await bot_manager.delete_bot(bot_id)

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -28,6 +28,8 @@ from ante.web.schemas import (
 
 router = APIRouter()
 
+_STRATEGY_NOT_FOUND = "전략을 찾을 수 없습니다"
+
 
 @router.post("/validate", response_model=StrategyValidateResponse)
 async def validate_strategy(body: dict) -> dict:
@@ -100,7 +102,7 @@ async def get_strategy(
     """전략 상세 조회."""
     record = await registry.get(strategy_id)
     if not record:
-        raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
 
     strategy_dict = asdict(record)
     strategy_dict["status"] = (
@@ -128,7 +130,7 @@ async def get_strategy_performance(
     """전략 성과 지표 조회."""
     record = await registry.get(strategy_id)
     if not record:
-        raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
 
     from ante.trade.performance import PerformanceTracker
 
@@ -165,7 +167,7 @@ async def get_strategy_daily_summary(
     """전략 일별 성과 집계."""
     record = await registry.get(strategy_id)
     if not record:
-        raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
 
     from ante.trade.performance import PerformanceTracker
 
@@ -203,7 +205,7 @@ async def get_strategy_weekly_summary(
     """전략 주별 성과 집계."""
     record = await registry.get(strategy_id)
     if not record:
-        raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
 
     from ante.trade.performance import PerformanceTracker
 
@@ -242,7 +244,7 @@ async def get_strategy_monthly_summary(
     """전략 월별 성과 집계."""
     record = await registry.get(strategy_id)
     if not record:
-        raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
 
     from ante.trade.performance import PerformanceTracker
 
@@ -283,7 +285,7 @@ async def get_strategy_trades(
 
     record = await registry.get(strategy_id)
     if not record:
-        raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
 
     trades = await trade_service.get_trades(
         strategy_id=strategy_id,


### PR DESCRIPTION
## Summary

- 6개 파일에서 3회 이상 반복되는 하드코딩 문자열을 모듈 수준 상수로 추출
- SonarQube S1192 CRITICAL 이슈 해소
- 전체 테스트 1750건 통과 확인

## 변경 파일

| 파일 | 추출된 상수 |
|------|-----------|
| `cli/commands/init.py` | `_SYSTEM_TOML_FILENAME`, `_SECRETS_ENV_FILENAME` |
| `feed/cli.py` | `_DEFAULT_DATA_PATH`, `_DATA_PATH_HELP`, `_SCOPE_DATA_WRITE`, `_SCOPE_DATA_READ`, `_SEPARATOR` |
| `web/routes/bots.py` | `_BOT_NOT_FOUND` |
| `web/routes/strategies.py` | `_STRATEGY_NOT_FOUND` |
| `member/service.py` | `_DEFAULT_ORG` |
| `trade/performance.py` | `_COND_STATUS_FILLED`, `_COND_SIDE_SELL`, `_COND_BOT_ID`, `_JOIN_POSITION_HISTORY` |

## Test plan

- [x] `ruff check` 통과
- [x] `ruff format` 통과
- [x] `pytest tests/unit tests/integration` 전체 1750건 통과

Refs #416