### PR TITLE
docs: HTTPException 응답 문서화

### DIFF
--- a/src/ante/web/routes/approvals.py
+++ b/src/ante/web/routes/approvals.py
@@ -28,7 +28,11 @@ class ApprovalStatusUpdate(BaseModel):
     memo: str = ""
 
 
-@router.get("", response_model=ApprovalListResponse)
+@router.get(
+    "",
+    response_model=ApprovalListResponse,
+    responses={503: {"description": "Approval service not available"}},
+)
 async def list_approvals(
     approval_service: Annotated[Any, Depends(get_approval_service)],
     status: str | None = Query(default=None),
@@ -47,7 +51,14 @@ async def list_approvals(
     }
 
 
-@router.get("/{approval_id}", response_model=ApprovalDetailResponse)
+@router.get(
+    "/{approval_id}",
+    response_model=ApprovalDetailResponse,
+    responses={
+        404: {"description": "Approval not found"},
+        503: {"description": "Approval service not available"},
+    },
+)
 async def get_approval(
     approval_id: str,
     approval_service: Annotated[Any, Depends(get_approval_service)],
@@ -71,7 +82,15 @@ async def get_approval(
     return result
 
 
-@router.patch("/{approval_id}/status", response_model=ApprovalUpdateResponse)
+@router.patch(
+    "/{approval_id}/status",
+    response_model=ApprovalUpdateResponse,
+    responses={
+        400: {"description": "Invalid status value"},
+        404: {"description": "Approval not found"},
+        503: {"description": "Approval service not available"},
+    },
+)
 async def update_approval_status(
     approval_id: str,
     body: ApprovalStatusUpdate,

--- a/src/ante/web/routes/audit.py
+++ b/src/ante/web/routes/audit.py
@@ -12,7 +12,11 @@ from ante.web.schemas import AuditLogListResponse
 router = APIRouter()
 
 
-@router.get("", response_model=AuditLogListResponse)
+@router.get(
+    "",
+    response_model=AuditLogListResponse,
+    responses={503: {"description": "Audit logger not available"}},
+)
 async def list_audit_logs(
     audit_logger: Annotated[Any, Depends(get_audit_logger)],
     member_id: str | None = None,

--- a/src/ante/web/routes/auth.py
+++ b/src/ante/web/routes/auth.py
@@ -18,7 +18,14 @@ COOKIE_NAME = "ante_session"
 COOKIE_MAX_AGE = 86400  # 24시간
 
 
-@router.post("/login", response_model=LoginResponse)
+@router.post(
+    "/login",
+    response_model=LoginResponse,
+    responses={
+        401: {"description": "Invalid credentials"},
+        503: {"description": "Member or session service not available"},
+    },
+)
 async def login(
     body: LoginRequest,
     request: Request,
@@ -63,7 +70,11 @@ async def login(
     )
 
 
-@router.post("/logout", response_model=LogoutResponse)
+@router.post(
+    "/logout",
+    response_model=LogoutResponse,
+    responses={503: {"description": "Session service not available"}},
+)
 async def logout(
     response: Response,
     session_service: Annotated[Any, Depends(get_session_service)],
@@ -77,7 +88,14 @@ async def logout(
     return {"ok": True}
 
 
-@router.get("/me", response_model=MeResponse)
+@router.get(
+    "/me",
+    response_model=MeResponse,
+    responses={
+        401: {"description": "Not authenticated or session expired"},
+        503: {"description": "Member or session service not available"},
+    },
+)
 async def me(
     member_service: Annotated[Any, Depends(get_member_service)],
     session_service: Annotated[Any, Depends(get_session_service)],

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -29,7 +29,11 @@ class BotCreateRequest(BaseModel):
     interval_seconds: int = Field(default=60, ge=10, le=3600)
 
 
-@router.get("", response_model=BotListResponse)
+@router.get(
+    "",
+    response_model=BotListResponse,
+    responses={503: {"description": "Bot manager not available"}},
+)
 async def list_bots(
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     limit: int = 20,
@@ -43,7 +47,17 @@ async def list_bots(
     return {"bots": result["items"], "next_cursor": result["next_cursor"]}
 
 
-@router.post("", status_code=201, response_model=BotDetailResponse)
+@router.post(
+    "",
+    status_code=201,
+    response_model=BotDetailResponse,
+    responses={
+        400: {"description": "Strategy loading failed"},
+        404: {"description": "Strategy not found"},
+        409: {"description": "Bot already exists or conflict"},
+        503: {"description": "Bot manager or strategy registry not available"},
+    },
+)
 async def create_bot(
     body: BotCreateRequest,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
@@ -85,7 +99,14 @@ async def create_bot(
     return {"bot": bot.get_info()}
 
 
-@router.get("/{bot_id}", response_model=BotDetailResponse)
+@router.get(
+    "/{bot_id}",
+    response_model=BotDetailResponse,
+    responses={
+        404: {"description": "Bot not found"},
+        503: {"description": "Bot manager not available"},
+    },
+)
 async def get_bot(
     bot_id: str,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
@@ -140,7 +161,15 @@ async def get_bot(
     return {"bot": info}
 
 
-@router.post("/{bot_id}/start", response_model=BotDetailResponse)
+@router.post(
+    "/{bot_id}/start",
+    response_model=BotDetailResponse,
+    responses={
+        404: {"description": "Bot not found"},
+        409: {"description": "Bot state conflict"},
+        503: {"description": "Bot manager not available"},
+    },
+)
 async def start_bot(
     bot_id: str,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
@@ -160,7 +189,15 @@ async def start_bot(
     return {"bot": bot.get_info()}
 
 
-@router.post("/{bot_id}/stop", response_model=BotDetailResponse)
+@router.post(
+    "/{bot_id}/stop",
+    response_model=BotDetailResponse,
+    responses={
+        404: {"description": "Bot not found"},
+        409: {"description": "Bot state conflict"},
+        503: {"description": "Bot manager not available"},
+    },
+)
 async def stop_bot(
     bot_id: str,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
@@ -180,7 +217,15 @@ async def stop_bot(
     return {"bot": bot.get_info()}
 
 
-@router.delete("/{bot_id}", status_code=204)
+@router.delete(
+    "/{bot_id}",
+    status_code=204,
+    responses={
+        404: {"description": "Bot not found"},
+        409: {"description": "Bot state conflict"},
+        503: {"description": "Bot manager not available"},
+    },
+)
 async def delete_bot(
     bot_id: str,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],

--- a/src/ante/web/routes/config.py
+++ b/src/ante/web/routes/config.py
@@ -20,7 +20,11 @@ class ConfigUpdateRequest(BaseModel):
     category: str = ""
 
 
-@router.get("", response_model=ConfigListResponse)
+@router.get(
+    "",
+    response_model=ConfigListResponse,
+    responses={503: {"description": "Config service not available"}},
+)
 async def list_configs(
     config_service: Annotated[Any, Depends(get_dynamic_config)],
 ) -> dict:
@@ -29,7 +33,14 @@ async def list_configs(
     return {"configs": configs}
 
 
-@router.put("/{key:path}", response_model=ConfigUpdateResponse)
+@router.put(
+    "/{key:path}",
+    response_model=ConfigUpdateResponse,
+    responses={
+        404: {"description": "Config key not found"},
+        503: {"description": "Config service not available"},
+    },
+)
 async def update_config(
     key: str,
     body: ConfigUpdateRequest,

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -122,7 +122,15 @@ async def get_storage_summary(
     }
 
 
-@router.delete("/datasets/{dataset_id}", status_code=204)
+@router.delete(
+    "/datasets/{dataset_id}",
+    status_code=204,
+    responses={
+        400: {"description": "Invalid dataset_id format"},
+        404: {"description": "Dataset not found"},
+        503: {"description": "Data store not available"},
+    },
+)
 async def delete_dataset(
     dataset_id: str,
     store: Annotated[Any | None, Depends(get_data_store)],

--- a/src/ante/web/routes/members.py
+++ b/src/ante/web/routes/members.py
@@ -45,7 +45,11 @@ class ScopesUpdateRequest(BaseModel):
     scopes: list[str]
 
 
-@router.get("", response_model=MemberListResponse)
+@router.get(
+    "",
+    response_model=MemberListResponse,
+    responses={503: {"description": "Member service not available"}},
+)
 async def list_members(
     svc: Annotated[Any, Depends(get_member_service)],
     type: str | None = Query(default=None),
@@ -61,7 +65,16 @@ async def list_members(
     return {"members": [asdict(m) for m in members], "total": len(members)}
 
 
-@router.post("", status_code=201, response_model=MemberCreateResponse)
+@router.post(
+    "",
+    status_code=201,
+    response_model=MemberCreateResponse,
+    responses={
+        400: {"description": "Invalid member data"},
+        403: {"description": "Permission denied"},
+        503: {"description": "Member service not available"},
+    },
+)
 async def create_member(
     body: MemberCreateRequest,
     svc: Annotated[Any, Depends(get_member_service)],
@@ -85,7 +98,14 @@ async def create_member(
     return {"member": asdict(member), "token": token}
 
 
-@router.get("/{member_id}", response_model=MemberDetailResponse)
+@router.get(
+    "/{member_id}",
+    response_model=MemberDetailResponse,
+    responses={
+        404: {"description": "Member not found"},
+        503: {"description": "Member service not available"},
+    },
+)
 async def get_member(
     member_id: str,
     svc: Annotated[Any, Depends(get_member_service)],
@@ -97,7 +117,15 @@ async def get_member(
     return {"member": asdict(member)}
 
 
-@router.post("/{member_id}/suspend", response_model=MemberDetailResponse)
+@router.post(
+    "/{member_id}/suspend",
+    response_model=MemberDetailResponse,
+    responses={
+        403: {"description": "Permission denied"},
+        404: {"description": "Member not found"},
+        503: {"description": "Member service not available"},
+    },
+)
 async def suspend_member(
     member_id: str,
     svc: Annotated[Any, Depends(get_member_service)],
@@ -112,7 +140,15 @@ async def suspend_member(
     return {"member": asdict(member)}
 
 
-@router.post("/{member_id}/reactivate", response_model=MemberDetailResponse)
+@router.post(
+    "/{member_id}/reactivate",
+    response_model=MemberDetailResponse,
+    responses={
+        403: {"description": "Permission denied"},
+        404: {"description": "Member not found"},
+        503: {"description": "Member service not available"},
+    },
+)
 async def reactivate_member(
     member_id: str,
     svc: Annotated[Any, Depends(get_member_service)],
@@ -127,7 +163,15 @@ async def reactivate_member(
     return {"member": asdict(member)}
 
 
-@router.post("/{member_id}/revoke", response_model=MemberDetailResponse)
+@router.post(
+    "/{member_id}/revoke",
+    response_model=MemberDetailResponse,
+    responses={
+        403: {"description": "Permission denied"},
+        404: {"description": "Member not found"},
+        503: {"description": "Member service not available"},
+    },
+)
 async def revoke_member(
     member_id: str,
     svc: Annotated[Any, Depends(get_member_service)],
@@ -142,7 +186,15 @@ async def revoke_member(
     return {"member": asdict(member)}
 
 
-@router.post("/{member_id}/rotate-token", response_model=MemberTokenResponse)
+@router.post(
+    "/{member_id}/rotate-token",
+    response_model=MemberTokenResponse,
+    responses={
+        403: {"description": "Permission denied"},
+        404: {"description": "Member not found"},
+        503: {"description": "Member service not available"},
+    },
+)
 async def rotate_token(
     member_id: str,
     svc: Annotated[Any, Depends(get_member_service)],
@@ -157,7 +209,15 @@ async def rotate_token(
     return {"member": asdict(member), "token": token}
 
 
-@router.patch("/{member_id}/password", response_model=OkResponse)
+@router.patch(
+    "/{member_id}/password",
+    response_model=OkResponse,
+    responses={
+        403: {"description": "Permission denied"},
+        404: {"description": "Member not found"},
+        503: {"description": "Member service not available"},
+    },
+)
 async def change_password(
     member_id: str,
     body: PasswordChangeRequest,
@@ -173,7 +233,15 @@ async def change_password(
     return {"ok": True}
 
 
-@router.put("/{member_id}/scopes", response_model=MemberScopesResponse)
+@router.put(
+    "/{member_id}/scopes",
+    response_model=MemberScopesResponse,
+    responses={
+        403: {"description": "Permission denied"},
+        404: {"description": "Member not found"},
+        503: {"description": "Member service not available"},
+    },
+)
 async def update_scopes(
     member_id: str,
     body: ScopesUpdateRequest,

--- a/src/ante/web/routes/notifications.py
+++ b/src/ante/web/routes/notifications.py
@@ -12,7 +12,11 @@ from ante.web.schemas import NotificationListResponse
 router = APIRouter()
 
 
-@router.get("", response_model=NotificationListResponse)
+@router.get(
+    "",
+    response_model=NotificationListResponse,
+    responses={503: {"description": "Notification service not available"}},
+)
 async def list_notifications(
     notification_service: Annotated[Any, Depends(get_notification_service)],
     level: str | None = None,

--- a/src/ante/web/routes/portfolio.py
+++ b/src/ante/web/routes/portfolio.py
@@ -16,7 +16,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/value", response_model=PortfolioValueResponse)
+@router.get(
+    "/value",
+    response_model=PortfolioValueResponse,
+    responses={503: {"description": "Treasury not available"}},
+)
 async def portfolio_value(
     treasury: Annotated[Any, Depends(get_treasury)],
 ) -> dict:
@@ -44,7 +48,13 @@ _PERIOD_DAYS = {
 }
 
 
-@router.get("/history", response_model=PortfolioHistoryResponse)
+@router.get(
+    "/history",
+    response_model=PortfolioHistoryResponse,
+    responses={
+        503: {"description": "Trade service or bot manager not available"},
+    },
+)
 async def portfolio_history(
     trade_service: Annotated[Any, Depends(get_trade_service)],
     bot_manager: Annotated[Any, Depends(get_bot_manager)],

--- a/src/ante/web/routes/reports.py
+++ b/src/ante/web/routes/reports.py
@@ -26,7 +26,12 @@ async def get_report_schema() -> dict:
     return store.get_schema()
 
 
-@router.post("", status_code=201, response_model=ReportSubmitResponse)
+@router.post(
+    "",
+    status_code=201,
+    response_model=ReportSubmitResponse,
+    responses={503: {"description": "Report store not available"}},
+)
 async def submit_report(
     body: dict,
     report_store: Annotated[Any, Depends(get_report_store)],
@@ -40,7 +45,14 @@ async def submit_report(
     }
 
 
-@router.get("/{report_id}", response_model=ReportDetailResponse)
+@router.get(
+    "/{report_id}",
+    response_model=ReportDetailResponse,
+    responses={
+        404: {"description": "Report not found"},
+        503: {"description": "Report store not available"},
+    },
+)
 async def report_view(
     report_id: str,
     report_store: Annotated[Any, Depends(get_report_store)],
@@ -85,7 +97,11 @@ async def report_view(
     }
 
 
-@router.get("", response_model=ReportListResponse)
+@router.get(
+    "",
+    response_model=ReportListResponse,
+    responses={503: {"description": "Report store not available"}},
+)
 async def list_reports(
     report_store: Annotated[Any, Depends(get_report_store)],
     status: str | None = None,

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -29,7 +29,14 @@ from ante.web.schemas import (
 router = APIRouter()
 
 
-@router.post("/validate", response_model=StrategyValidateResponse)
+@router.post(
+    "/validate",
+    response_model=StrategyValidateResponse,
+    responses={
+        400: {"description": "Path is required"},
+        404: {"description": "Strategy file not found"},
+    },
+)
 async def validate_strategy(body: dict) -> dict:
     """전략 파일 정적 검증.
 
@@ -55,7 +62,11 @@ async def validate_strategy(body: dict) -> dict:
     }
 
 
-@router.get("", response_model=StrategyListResponse)
+@router.get(
+    "",
+    response_model=StrategyListResponse,
+    responses={503: {"description": "Strategy registry not available"}},
+)
 async def list_strategies(
     registry: Annotated[Any, Depends(get_strategy_registry)],
     bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
@@ -91,7 +102,14 @@ async def list_strategies(
     return {"strategies": strategies}
 
 
-@router.get("/{strategy_id}", response_model=StrategyDetailResponse)
+@router.get(
+    "/{strategy_id}",
+    response_model=StrategyDetailResponse,
+    responses={
+        404: {"description": "Strategy not found"},
+        503: {"description": "Strategy registry not available"},
+    },
+)
 async def get_strategy(
     strategy_id: str,
     registry: Annotated[Any, Depends(get_strategy_registry)],
@@ -117,7 +135,14 @@ async def get_strategy(
     return {"strategy": strategy_dict, "bot": bot_info}
 
 
-@router.get("/{strategy_id}/performance", response_model=StrategyPerformanceResponse)
+@router.get(
+    "/{strategy_id}/performance",
+    response_model=StrategyPerformanceResponse,
+    responses={
+        404: {"description": "Strategy not found"},
+        503: {"description": "Strategy registry or database not available"},
+    },
+)
 async def get_strategy_performance(
     strategy_id: str,
     registry: Annotated[Any, Depends(get_strategy_registry)],
@@ -155,7 +180,14 @@ async def get_strategy_performance(
     return result
 
 
-@router.get("/{strategy_id}/daily-summary", response_model=DailySummaryResponse)
+@router.get(
+    "/{strategy_id}/daily-summary",
+    response_model=DailySummaryResponse,
+    responses={
+        404: {"description": "Strategy not found"},
+        503: {"description": "Strategy registry or database not available"},
+    },
+)
 async def get_strategy_daily_summary(
     strategy_id: str,
     registry: Annotated[Any, Depends(get_strategy_registry)],
@@ -193,7 +225,14 @@ async def get_strategy_daily_summary(
     }
 
 
-@router.get("/{strategy_id}/weekly-summary", response_model=WeeklySummaryResponse)
+@router.get(
+    "/{strategy_id}/weekly-summary",
+    response_model=WeeklySummaryResponse,
+    responses={
+        404: {"description": "Strategy not found"},
+        503: {"description": "Strategy registry or database not available"},
+    },
+)
 async def get_strategy_weekly_summary(
     strategy_id: str,
     registry: Annotated[Any, Depends(get_strategy_registry)],
@@ -232,7 +271,14 @@ async def get_strategy_weekly_summary(
     }
 
 
-@router.get("/{strategy_id}/monthly-summary", response_model=MonthlySummaryResponse)
+@router.get(
+    "/{strategy_id}/monthly-summary",
+    response_model=MonthlySummaryResponse,
+    responses={
+        404: {"description": "Strategy not found"},
+        503: {"description": "Strategy registry or database not available"},
+    },
+)
 async def get_strategy_monthly_summary(
     strategy_id: str,
     registry: Annotated[Any, Depends(get_strategy_registry)],
@@ -270,7 +316,14 @@ async def get_strategy_monthly_summary(
     }
 
 
-@router.get("/{strategy_id}/trades", response_model=StrategyTradesResponse)
+@router.get(
+    "/{strategy_id}/trades",
+    response_model=StrategyTradesResponse,
+    responses={
+        404: {"description": "Strategy not found"},
+        503: {"description": "Strategy registry or trade service not available"},
+    },
+)
 async def get_strategy_trades(
     strategy_id: str,
     registry: Annotated[Any, Depends(get_strategy_registry)],

--- a/src/ante/web/routes/system.py
+++ b/src/ante/web/routes/system.py
@@ -62,7 +62,14 @@ async def health_check() -> dict:
     return {"ok": True}
 
 
-@router.post("/kill-switch", response_model=KillSwitchResponse)
+@router.post(
+    "/kill-switch",
+    response_model=KillSwitchResponse,
+    responses={
+        400: {"description": "Invalid action value"},
+        503: {"description": "System state not available"},
+    },
+)
 async def kill_switch(
     body: KillSwitchRequest,
     system_state: Annotated[Any, Depends(get_system_state)],

--- a/src/ante/web/routes/test_seed.py
+++ b/src/ante/web/routes/test_seed.py
@@ -63,7 +63,14 @@ SCENARIOS_DIR = _find_scenarios_dir()
 BASE_SQL = SCENARIOS_DIR / "_base.sql"
 
 
-@router.post("/reset", response_model=SeedResetResponse)
+@router.post(
+    "/reset",
+    response_model=SeedResetResponse,
+    responses={
+        400: {"description": "Scenario not found"},
+        503: {"description": "Database not available"},
+    },
+)
 async def reset_seed(
     db: Annotated[Any, Depends(get_db)],
     system_state: Annotated[Any | None, Depends(get_system_state_optional)],

--- a/src/ante/web/routes/trades.py
+++ b/src/ante/web/routes/trades.py
@@ -12,7 +12,11 @@ from ante.web.schemas import TradeListResponse
 router = APIRouter()
 
 
-@router.get("", response_model=TradeListResponse)
+@router.get(
+    "",
+    response_model=TradeListResponse,
+    responses={503: {"description": "Trade service not available"}},
+)
 async def list_trades(
     trade_service: Annotated[Any, Depends(get_trade_service)],
     bot_id: str | None = None,

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -32,7 +32,10 @@ class BalanceSetRequest(BaseModel):
 
 
 @router.get(
-    "", response_model=TreasurySummaryResponse, response_model_exclude_none=True
+    "",
+    response_model=TreasurySummaryResponse,
+    response_model_exclude_none=True,
+    responses={503: {"description": "Treasury not available"}},
 )
 async def get_summary(
     treasury: Annotated[Any, Depends(get_treasury)],
@@ -73,7 +76,11 @@ async def get_summary(
     return summary
 
 
-@router.get("/transactions", response_model=TransactionListResponse)
+@router.get(
+    "/transactions",
+    response_model=TransactionListResponse,
+    responses={503: {"description": "Treasury not available"}},
+)
 async def list_transactions(
     treasury: Annotated[Any, Depends(get_treasury)],
     type: str | None = None,
@@ -123,7 +130,15 @@ async def list_transactions(
     return {"items": items, "total": total}
 
 
-@router.post("/bots/{bot_id}/allocate", response_model=BudgetOperationResponse)
+@router.post(
+    "/bots/{bot_id}/allocate",
+    response_model=BudgetOperationResponse,
+    responses={
+        400: {"description": "Insufficient funds or invalid amount"},
+        409: {"description": "Bot not stopped"},
+        503: {"description": "Treasury not available"},
+    },
+)
 async def allocate(
     bot_id: str,
     body: BudgetChangeRequest,
@@ -154,7 +169,15 @@ async def allocate(
     }
 
 
-@router.post("/bots/{bot_id}/deallocate", response_model=BudgetOperationResponse)
+@router.post(
+    "/bots/{bot_id}/deallocate",
+    response_model=BudgetOperationResponse,
+    responses={
+        400: {"description": "Insufficient available budget"},
+        409: {"description": "Bot not stopped"},
+        503: {"description": "Treasury not available"},
+    },
+)
 async def deallocate(
     bot_id: str,
     body: BudgetChangeRequest,
@@ -182,7 +205,11 @@ async def deallocate(
     }
 
 
-@router.get("/budgets", response_model=BudgetListResponse)
+@router.get(
+    "/budgets",
+    response_model=BudgetListResponse,
+    responses={503: {"description": "Treasury not available"}},
+)
 async def list_budgets(
     treasury: Annotated[Any, Depends(get_treasury)],
 ) -> dict:
@@ -193,7 +220,11 @@ async def list_budgets(
     return {"budgets": [asdict(b) for b in budgets]}
 
 
-@router.post("/balance", response_model=BalanceSetResponse)
+@router.post(
+    "/balance",
+    response_model=BalanceSetResponse,
+    responses={503: {"description": "Treasury not available"}},
+)
 async def set_balance(
     body: BalanceSetRequest,
     treasury: Annotated[Any, Depends(get_treasury)],


### PR DESCRIPTION
## Summary
- 모든 라우트 데코레이터에 `responses` 파라미터를 추가하여 HTTPException 에러 응답을 OpenAPI 스펙에 문서화
- 15개 라우트 파일, 총 46개 엔드포인트에 대해 400/401/403/404/409/503 에러 응답 정의
- `deps.py`의 필수 의존성(503)과 각 핸들러 내부의 HTTPException을 모두 반영

## Test plan
- [x] `ruff check` 통과
- [x] `ruff format` 통과
- [x] `pytest tests/ --ignore=tests/e2e` 전체 1750 passed, 3 skipped

Refs #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)