### PR TITLE
epic/406: 코드 퀄리티 개선 및 리팩토링

### DIFF
--- a/src/ante/backtest/data_provider.py
+++ b/src/ante/backtest/data_provider.py
@@ -21,6 +21,8 @@ class BacktestDataProvider(DataProvider):
     """백테스트용 DataProvider. 과거 데이터를 시간순으로 제공.
 
     미래 데이터 참조를 방지하기 위해 current_idx까지만 노출한다.
+
+    Note: DataProvider 인터페이스 준수를 위해 get_ohlcv 등은 async def를 유지한다.
     """
 
     def __init__(
@@ -47,10 +49,10 @@ class BacktestDataProvider(DataProvider):
     def end(self) -> str:
         return self._end
 
-    async def load(self, symbol: str, timeframe: str) -> int:
+    def load(self, symbol: str, timeframe: str) -> int:
         """데이터를 캐시에 로드. 로드된 행 수 반환."""
         key = f"{symbol}:{timeframe}"
-        df = await self._store.read(symbol, timeframe, start=self._start, end=self._end)
+        df = self._store.read(symbol, timeframe, start=self._start, end=self._end)
         self._cache[key] = df
         return len(df)
 
@@ -63,7 +65,7 @@ class BacktestDataProvider(DataProvider):
         """현재 시점까지의 OHLCV 데이터 반환."""
         key = f"{symbol}:{timeframe}"
         if key not in self._cache:
-            await self.load(symbol, timeframe)
+            self.load(symbol, timeframe)
 
         df = self._cache[key]
         visible = df.head(self._current_idx + 1)

--- a/src/ante/backtest/service.py
+++ b/src/ante/backtest/service.py
@@ -50,7 +50,7 @@ class BacktestService:
         symbols = config.get("symbols", [])
         timeframe = config.get("timeframe", "1d")
         for symbol in symbols:
-            await data_provider.load(symbol, timeframe)
+            data_provider.load(symbol, timeframe)
 
         executor = BacktestExecutor(
             strategy_cls=strategy_cls,

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -351,7 +351,7 @@ class BotManager:
         try:
             await asyncio.sleep(bot.config.restart_cooldown_seconds)
         except asyncio.CancelledError:
-            return
+            raise
 
         if bot.status != BotStatus.ERROR:
             return
@@ -389,7 +389,7 @@ class BotManager:
         try:
             await asyncio.sleep(seconds)
         except asyncio.CancelledError:
-            return
+            raise
 
         bot = self._bots.get(bot_id)
         if bot and bot.status == BotStatus.RUNNING:

--- a/src/ante/bot/signal_channel.py
+++ b/src/ante/bot/signal_channel.py
@@ -190,7 +190,10 @@ class SignalChannel:
             self._eventbus.unsubscribe(evt, self._on_order_update)
 
     async def _on_fill(self, event: object) -> None:
-        """체결 이벤트 → 외부 전달."""
+        """체결 이벤트 → 외부 전달.
+
+        Note: EventBus 핸들러 — isawaitable 패턴을 위해 async def 유지.
+        """
         from ante.eventbus.events import OrderFilledEvent
 
         if not isinstance(event, OrderFilledEvent):
@@ -212,7 +215,10 @@ class SignalChannel:
         )
 
     async def _on_order_update(self, event: object) -> None:
-        """주문 상태 변경 → 외부 전달."""
+        """주문 상태 변경 → 외부 전달.
+
+        Note: EventBus 핸들러 — isawaitable 패턴을 위해 async def 유지.
+        """
         bot_id = getattr(event, "bot_id", None)
         if bot_id != self._bot.bot_id:
             return

--- a/src/ante/bot/signal_channel.py
+++ b/src/ante/bot/signal_channel.py
@@ -69,7 +69,7 @@ class SignalChannel:
                     break
                 await self._handle_line(line.decode("utf-8").strip())
             except asyncio.CancelledError:
-                break
+                raise
             except Exception:
                 logger.exception("채널 메시지 처리 오류")
 

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -67,6 +67,94 @@ _ORDER_TR_IDS = frozenset(
 _AUTH_PATH = "/oauth2/tokenP"
 
 
+class KISErrorClassifier:
+    """KIS API 에러를 분류하여 재시도/즉시실패/서킷브레이크를 결정한다."""
+
+    @staticmethod
+    def classify(error: Exception) -> tuple[bool, bool]:
+        """에러를 분류하여 (retryable, record_cb_failure) 튜플을 반환한다.
+
+        Returns:
+            retryable: 재시도 가능 여부
+            record_cb_failure: circuit breaker에 실패 기록 여부
+        """
+        if isinstance(error, (CircuitOpenError, AuthenticationError)):
+            return False, False
+        if isinstance(error, TimeoutError):
+            return True, True
+        if isinstance(error, (ConnectionError, OSError)):
+            return True, True
+        if isinstance(error, RateLimitError):
+            return True, True
+        if isinstance(error, APIError):
+            if not error.retryable:
+                return False, False
+            return True, True
+        # 알 수 없는 에러는 재시도하지 않음
+        return False, False
+
+    @staticmethod
+    def to_api_error(error: Exception, timeout: float) -> Exception:
+        """네트워크/타임아웃 에러를 APIError로 래핑한다."""
+        if isinstance(error, TimeoutError):
+            return APIError(f"타임아웃 ({timeout:.0f}초 초과)", retryable=True)
+        if isinstance(error, (ConnectionError, OSError)):
+            return APIError(str(error), retryable=True)
+        return error
+
+    @staticmethod
+    def log_label(error: Exception) -> str:
+        """에러 종류별 로그 라벨 반환."""
+        if isinstance(error, TimeoutError):
+            return "API 타임아웃"
+        if isinstance(error, (ConnectionError, OSError)):
+            return "네트워크 오류"
+        if isinstance(error, RateLimitError):
+            return "Rate limit"
+        return "API 오류"
+
+
+class KISRetryHandler:
+    """지수 백오프 기반 재시도 전략을 관리한다."""
+
+    def __init__(self, backoff_base: float = DEFAULT_BACKOFF_BASE) -> None:
+        self._backoff_base = backoff_base
+
+    def backoff_delay(self, attempt: int) -> float:
+        """attempt 번째 시도의 백오프 대기 시간(초)."""
+        return self._backoff_base * (2**attempt)
+
+    def should_retry(self, attempt: int, max_retries: int) -> bool:
+        """재시도 여부 결정."""
+        return attempt < max_retries
+
+    async def wait_and_log(
+        self,
+        attempt: int,
+        max_retries: int,
+        tr_id: str,
+        error: Exception,
+    ) -> None:
+        """백오프 대기 후 로그를 남긴다."""
+        wait = self.backoff_delay(attempt)
+        label = KISErrorClassifier.log_label(error)
+        detail = (
+            f": {error}"
+            if not isinstance(error, (TimeoutError, RateLimitError))
+            else ""
+        )
+        logger.warning(
+            "%s [%s] 재시도 %d/%d (%.1f초 후)%s",
+            label,
+            tr_id,
+            attempt + 1,
+            max_retries,
+            wait,
+            detail,
+        )
+        await asyncio.sleep(wait)
+
+
 class KISAdapter(BrokerAdapter):
     """한국투자증권 Open API 어댑터."""
 
@@ -141,6 +229,9 @@ class KISAdapter(BrokerAdapter):
             eventbus=eventbus,
             name="kis",
         )
+
+        # ── 재시도 핸들러 ─────────────────────────────
+        self._retry_handler = KISRetryHandler(backoff_base=self._backoff_base)
 
     @property
     def circuit_breaker(self) -> CircuitBreaker:
@@ -281,111 +372,63 @@ class KISAdapter(BrokerAdapter):
         params: dict[str, str] | None = None,
         json_data: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """API 요청 공통 래퍼 (circuit breaker + 재시도 + 타임아웃)."""
-        # [1] Circuit Breaker 확인
-        self._circuit_breaker.check()
+        """API 요청 공통 래퍼 (circuit breaker + 재시도 + 타임아웃).
 
+        조율만 담당하며, 에러 분류는 KISErrorClassifier,
+        재시도 전략은 KISRetryHandler에 위임한다.
+        """
+        self._circuit_breaker.check()
         await self._ensure_authenticated()
         await self._rate_limit_wait()
 
         max_retries = self._get_max_retries(url, tr_id)
-        timeout = self._timeout_query
-        if tr_id in _ORDER_TR_IDS:
-            timeout = self._timeout_order
-
+        timeout = self._timeout_order if tr_id in _ORDER_TR_IDS else self._timeout_query
         headers = self._get_headers(tr_id)
         last_error: Exception | None = None
 
         for attempt in range(max_retries + 1):
             try:
-                # [2] API 호출 (타임아웃 적용)
-                async with asyncio.timeout(timeout):
-                    if method == "GET":
-                        async with self._session.get(
-                            url, headers=headers, params=params
-                        ) as resp:
-                            result = await self._handle_response(resp)
-                    else:
-                        async with self._session.post(
-                            url, headers=headers, json=json_data
-                        ) as resp:
-                            result = await self._handle_response(resp)
-
-                # 성공
+                result = await self._send_http(
+                    method, url, headers, params, json_data, timeout
+                )
                 self._circuit_breaker.record_success()
                 return result
-
-            except CircuitOpenError:
-                raise
-            except TimeoutError:
-                last_error = APIError(
-                    f"타임아웃 ({timeout:.0f}초 초과)",
-                    retryable=True,
-                )
-                self._circuit_breaker.record_failure()
-                if attempt < max_retries:
-                    wait = self._backoff_base * (2**attempt)
-                    logger.warning(
-                        "API 타임아웃 [%s] 재시도 %d/%d (%.1f초 후)",
-                        tr_id,
-                        attempt + 1,
-                        max_retries,
-                        wait,
-                    )
-                    await asyncio.sleep(wait)
-                    continue
-            except (ConnectionError, OSError) as e:
-                last_error = APIError(str(e), retryable=True)
-                self._circuit_breaker.record_failure()
-                if attempt < max_retries:
-                    wait = self._backoff_base * (2**attempt)
-                    logger.warning(
-                        "네트워크 오류 [%s] 재시도 %d/%d (%.1f초 후): %s",
-                        tr_id,
-                        attempt + 1,
-                        max_retries,
-                        wait,
-                        e,
-                    )
-                    await asyncio.sleep(wait)
-                    continue
-            except RateLimitError as e:
-                last_error = e
-                self._circuit_breaker.record_failure()
-                if attempt < max_retries:
-                    wait = self._backoff_base * (2**attempt)
-                    logger.warning(
-                        "Rate limit [%s] 재시도 %d/%d (%.1f초 후)",
-                        tr_id,
-                        attempt + 1,
-                        max_retries,
-                        wait,
-                    )
-                    await asyncio.sleep(wait)
-                    continue
-            except APIError as e:
-                last_error = e
-                if not e.retryable:
-                    # permanent 에러 → 즉시 실패 (circuit breaker에 기록하지 않음)
+            except Exception as e:
+                retryable, record_failure = KISErrorClassifier.classify(e)
+                if not retryable:
                     raise
-                self._circuit_breaker.record_failure()
-                if attempt < max_retries:
-                    wait = self._backoff_base * (2**attempt)
-                    logger.warning(
-                        "API 오류 [%s] 재시도 %d/%d (%.1f초 후): %s",
-                        tr_id,
-                        attempt + 1,
-                        max_retries,
-                        wait,
-                        e,
+                last_error = KISErrorClassifier.to_api_error(e, timeout)
+                if record_failure:
+                    self._circuit_breaker.record_failure()
+                if self._retry_handler.should_retry(attempt, max_retries):
+                    await self._retry_handler.wait_and_log(
+                        attempt, max_retries, tr_id, e
                     )
-                    await asyncio.sleep(wait)
                     continue
-            except AuthenticationError:
-                raise
 
-        # 모든 재시도 소진
         raise last_error  # type: ignore[misc]
+
+    async def _send_http(
+        self,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        params: dict[str, str] | None,
+        json_data: dict[str, Any] | None,
+        timeout: float,
+    ) -> dict[str, Any]:
+        """단일 HTTP 요청 실행 (타임아웃 적용)."""
+        async with asyncio.timeout(timeout):
+            if method == "GET":
+                async with self._session.get(
+                    url, headers=headers, params=params
+                ) as resp:
+                    return await self._handle_response(resp)
+            else:
+                async with self._session.post(
+                    url, headers=headers, json=json_data
+                ) as resp:
+                    return await self._handle_response(resp)
 
     # ── 계좌 정보 조회 ─────────────────────────────
 
@@ -622,12 +665,14 @@ class KISAdapter(BrokerAdapter):
     ) -> AsyncIterator[dict[str, Any]]:
         """실시간 가격 스트리밍. WebSocket 연동 Phase에서 구현."""
         raise NotImplementedError("실시간 가격 스트리밍은 추후 구현")
-        yield {}  # type: ignore[misc]
+        # AsyncIterator 시그니처 충족을 위한 yield (도달 불가)
+        yield  # pragma: no cover
 
     async def realtime_order_stream(self) -> AsyncIterator[dict[str, Any]]:
         """실시간 주문 체결 스트리밍. WebSocket 연동 Phase에서 구현."""
         raise NotImplementedError("실시간 주문 스트리밍은 추후 구현")
-        yield {}  # type: ignore[misc]
+        # AsyncIterator 시그니처 충족을 위한 yield (도달 불가)
+        yield  # pragma: no cover
 
     # ── 종목 마스터 ────────────────────────────────────
 

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -659,6 +659,7 @@ class KISAdapter(BrokerAdapter):
         return orders
 
     # ── 실시간 스트리밍 (구현 예정) ────────────────
+    # BrokerAdapter 인터페이스 준수를 위해 async def 유지
 
     async def realtime_price_stream(
         self, symbols: list[str]

--- a/src/ante/broker/mock.py
+++ b/src/ante/broker/mock.py
@@ -60,6 +60,9 @@ class MockOrder:
 class MockBrokerAdapter(BrokerAdapter):
     """E2E 테스트용 가상 브로커 어댑터.
 
+    Note: BrokerAdapter 인터페이스 준수를 위해 async def를 유지한다.
+    내부적으로 await를 사용하지 않지만, 호출부에서 await로 사용된다.
+
     설정 옵션:
         fill_mode: "immediate" | "partial" | "delayed" | "reject"
         partial_fill_ratio: 부분 체결 비율 (0.0~1.0, 기본 0.5)

--- a/src/ante/cli/commands/data.py
+++ b/src/ante/cli/commands/data.py
@@ -124,7 +124,6 @@ def validate(
     data_path: str,
 ) -> None:
     """Parquet 파일 무결성 검증."""
-    import asyncio
 
     from ante.data.store import ParquetStore
 
@@ -140,14 +139,10 @@ def validate(
         fmt.output({"message": "검증할 데이터가 없습니다.", "results": []})
         return
 
-    async def _validate() -> list[dict]:
-        results = []
-        for sym in symbols:
-            result = await store.validate(sym, timeframe, fix=fix)
-            results.append(result)
-        return results
-
-    results = asyncio.run(_validate())
+    results = []
+    for sym in symbols:
+        result = store.validate(sym, timeframe, fix=fix)
+        results.append(result)
 
     total_files = sum(r["total"] for r in results)
     total_valid = sum(r["valid"] for r in results)

--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -8,6 +8,9 @@ import click
 
 from ante.cli.main import get_formatter
 
+_SYSTEM_TOML_FILENAME = "system.toml"
+_SECRETS_ENV_FILENAME = "secrets.env"
+
 SYSTEM_TOML_TEMPLATE = """\
 # Ante 시스템 설정
 
@@ -61,10 +64,10 @@ def init(ctx: click.Context, target_dir: str | None, seed: bool) -> None:
 
     if config_path.exists():
         existing = []
-        if (config_path / "system.toml").exists():
-            existing.append("system.toml")
-        if (config_path / "secrets.env").exists():
-            existing.append("secrets.env")
+        if (config_path / _SYSTEM_TOML_FILENAME).exists():
+            existing.append(_SYSTEM_TOML_FILENAME)
+        if (config_path / _SECRETS_ENV_FILENAME).exists():
+            existing.append(_SECRETS_ENV_FILENAME)
         if existing and not seed:
             fmt.error(
                 f"설정 디렉토리가 이미 존재합니다: {config_path}\n"
@@ -74,15 +77,15 @@ def init(ctx: click.Context, target_dir: str | None, seed: bool) -> None:
 
     config_path.mkdir(parents=True, exist_ok=True)
 
-    system_toml = config_path / "system.toml"
+    system_toml = config_path / _SYSTEM_TOML_FILENAME
     if not system_toml.exists():
         system_toml.write_text(SYSTEM_TOML_TEMPLATE)
 
-    secrets_env = config_path / "secrets.env"
+    secrets_env = config_path / _SECRETS_ENV_FILENAME
     if not secrets_env.exists():
         secrets_env.write_text(SECRETS_ENV_TEMPLATE)
 
-    created_files = ["system.toml", "secrets.env"]
+    created_files = [_SYSTEM_TOML_FILENAME, _SECRETS_ENV_FILENAME]
 
     if seed:
         import asyncio

--- a/src/ante/data/collector.py
+++ b/src/ante/data/collector.py
@@ -127,7 +127,7 @@ class DataCollector:
             try:
                 await asyncio.sleep(self._collect_interval)
             except asyncio.CancelledError:
-                break
+                raise
 
     async def _flush_loop(self) -> None:
         """주기적 버퍼 flush."""
@@ -135,7 +135,7 @@ class DataCollector:
             try:
                 await asyncio.sleep(self._flush_interval)
             except asyncio.CancelledError:
-                break
+                raise
             await self.flush_all()
 
     async def _flush(self, key: str) -> None:

--- a/src/ante/data/collector.py
+++ b/src/ante/data/collector.py
@@ -56,7 +56,7 @@ class DataCollector:
         """데이터 수집 콜백 설정. 시그니처: async (symbol, tf) -> list[dict]."""
         self._data_callback = callback
 
-    async def start(self, symbols: list[str], timeframes: list[str]) -> None:
+    def start(self, symbols: list[str], timeframes: list[str]) -> None:
         """데이터 수집 시작."""
         if self._running:
             logger.warning("DataCollector is already running")
@@ -73,7 +73,7 @@ class DataCollector:
             timeframes,
         )
 
-    async def stop(self) -> None:
+    def stop(self) -> None:
         """데이터 수집 중지. 남은 버퍼를 flush."""
         self._running = False
         if self._collect_task:
@@ -84,10 +84,10 @@ class DataCollector:
             self._flush_task = None
 
         # 남은 데이터 flush
-        await self.flush_all()
+        self.flush_all()
         logger.info("DataCollector stopped")
 
-    async def add_data(self, symbol: str, timeframe: str, row: dict) -> None:
+    def add_data(self, symbol: str, timeframe: str, row: dict) -> None:
         """외부에서 직접 데이터를 추가 (이벤트 기반 수집 시 사용)."""
         key = f"{symbol}:{timeframe}"
         if key not in self._buffer:
@@ -95,15 +95,15 @@ class DataCollector:
         self._buffer[key].append(row)
 
         if len(self._buffer[key]) >= self._buffer_size:
-            await self._flush(key)
+            self._flush(key)
 
-    async def flush_all(self) -> int:
+    def flush_all(self) -> int:
         """모든 버퍼 데이터를 Parquet에 flush. flush된 총 건수 반환."""
         total = 0
         for key in list(self._buffer.keys()):
             if self._buffer[key]:
                 count = len(self._buffer[key])
-                await self._flush(key)
+                self._flush(key)
                 total += count
         return total
 
@@ -116,7 +116,7 @@ class DataCollector:
                         try:
                             rows = await self._data_callback(symbol, tf)
                             for row in rows:
-                                await self.add_data(symbol, tf, row)
+                                self.add_data(symbol, tf, row)
                         except Exception as e:
                             logger.warning(
                                 "Data collection failed for %s/%s: %s",
@@ -136,16 +136,16 @@ class DataCollector:
                 await asyncio.sleep(self._flush_interval)
             except asyncio.CancelledError:
                 raise
-            await self.flush_all()
+            self.flush_all()
 
-    async def _flush(self, key: str) -> None:
+    def _flush(self, key: str) -> None:
         """버퍼의 데이터를 Parquet에 적재."""
         rows = self._buffer.pop(key, [])
         if not rows:
             return
         symbol, tf = key.split(":")
         try:
-            await self._store.append(symbol, tf, rows)
+            self._store.append(symbol, tf, rows)
             logger.debug("Flushed %d rows for %s/%s", len(rows), symbol, tf)
         except Exception as e:
             logger.error("Failed to flush data for %s/%s: %s", symbol, tf, e)

--- a/src/ante/data/retention.py
+++ b/src/ante/data/retention.py
@@ -55,7 +55,7 @@ class RetentionPolicy:
     def retention_days(self) -> dict[str, int]:
         return self._retention
 
-    async def enforce(self, now: datetime | None = None) -> dict[str, int]:
+    def enforce(self, now: datetime | None = None) -> dict[str, int]:
         """보존 정책 적용. 삭제된 파일 수를 timeframe별로 반환.
 
         Args:

--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -48,7 +48,7 @@ class ParquetStore:
         else:
             return self._base / data_type / timeframe / symbol
 
-    async def read(
+    def read(
         self,
         symbol: str,
         timeframe: str,
@@ -106,7 +106,7 @@ class ParquetStore:
 
         return df
 
-    async def write(
+    def write(
         self,
         symbol: str,
         timeframe: str,
@@ -160,7 +160,7 @@ class ParquetStore:
 
         logger.debug("Wrote %d rows for %s/%s", len(data), symbol, timeframe)
 
-    async def append(
+    def append(
         self,
         symbol: str,
         timeframe: str,
@@ -169,7 +169,7 @@ class ParquetStore:
     ) -> None:
         """버퍼 데이터를 기존 Parquet에 추가."""
         df = pl.DataFrame(rows)
-        await self.write(symbol, timeframe, df, data_type=data_type)
+        self.write(symbol, timeframe, df, data_type=data_type)
 
     def list_symbols(
         self, timeframe: str = "1d", data_type: str = "ohlcv"
@@ -231,7 +231,7 @@ class ParquetStore:
                     usage[dtype] = size
         return usage
 
-    async def validate(
+    def validate(
         self,
         symbol: str,
         timeframe: str,

--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -16,6 +16,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_DATA_PATH = "data/"
+_DATA_PATH_HELP = "데이터 저장소 경로"
+_SCOPE_DATA_WRITE = "data:write"
+_SCOPE_DATA_READ = "data:read"
+_SEPARATOR = "──────────────────────────────────────────────────"
+
 _API_KEY_GUIDE = """\
 ──────────────────────────────────────────────────
 API 키 설정이 필요합니다.
@@ -56,10 +62,10 @@ def feed_config() -> None:
 @feed_config.command("set")
 @click.argument("key")
 @click.argument("value")
-@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
-@require_scope("data:write")
+@require_scope(_SCOPE_DATA_WRITE)
 def config_set(ctx: click.Context, key: str, value: str, data_path: str) -> None:
     """API 키를 .feed/.env 파일에 저장한다."""
     from ante.feed.config import API_KEYS, FeedConfig
@@ -81,10 +87,10 @@ def config_set(ctx: click.Context, key: str, value: str, data_path: str) -> None
 
 
 @feed_config.command("list")
-@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
-@require_scope("data:read")
+@require_scope(_SCOPE_DATA_READ)
 def config_list(ctx: click.Context, data_path: str) -> None:
     """등록된 API 키 목록을 마스킹하여 표시한다."""
     from ante.feed.config import FeedConfig
@@ -104,10 +110,10 @@ def config_list(ctx: click.Context, data_path: str) -> None:
 
 
 @feed_config.command("check")
-@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
-@require_scope("data:read")
+@require_scope(_SCOPE_DATA_READ)
 def config_check(ctx: click.Context, data_path: str) -> None:
     """API 키 존재 여부를 확인한다."""
     from ante.feed.config import FeedConfig
@@ -121,7 +127,7 @@ def config_check(ctx: click.Context, data_path: str) -> None:
     else:
         click.echo()
         click.echo("API Key Status")
-        click.echo("──────────────────────────────────────────────────")
+        click.echo(_SEPARATOR)
         all_set = True
         for entry in statuses:
             if entry["set"]:
@@ -130,7 +136,7 @@ def config_check(ctx: click.Context, data_path: str) -> None:
             else:
                 click.echo(f"  {entry['key']:<30} ✗ 미설정")
                 all_set = False
-        click.echo("──────────────────────────────────────────────────")
+        click.echo(_SEPARATOR)
         if not all_set:
             click.echo("설정: ante feed config set <KEY> <VALUE>")
         click.echo()
@@ -187,14 +193,14 @@ def _ensure_initialized(  # noqa: ANN001, ANN201
 
 
 @feed_run.command("backfill")
-@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
 @click.option(
     "--since", default=None, help="수집 시작일 (YYYY-MM-DD, config 기본값 오버라이드)"
 )
 @click.option("--until", default=None, help="수집 종료일 (YYYY-MM-DD, 기본값: 오늘)")
 @click.pass_context
 @require_auth
-@require_scope("data:write")
+@require_scope(_SCOPE_DATA_WRITE)
 def run_backfill(
     ctx: click.Context,
     data_path: str,
@@ -233,13 +239,13 @@ def run_backfill(
 
 
 @feed_run.command("daily")
-@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
 @click.option(
     "--date", "target_date", default=None, help="수집 대상일 (YYYY-MM-DD, 기본값: 어제)"
 )
 @click.pass_context
 @require_auth
-@require_scope("data:write")
+@require_scope(_SCOPE_DATA_WRITE)
 def run_daily(
     ctx: click.Context,
     data_path: str,
@@ -296,10 +302,10 @@ def run_daily(
 
 
 @feed.command("start")
-@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
-@require_scope("data:write")
+@require_scope(_SCOPE_DATA_WRITE)
 def feed_start(ctx: click.Context, data_path: str) -> None:
     """내장 스케줄러로 backfill/daily를 자동 실행하는 상주 프로세스를 시작한다."""
     import asyncio
@@ -342,10 +348,10 @@ def feed_start(ctx: click.Context, data_path: str) -> None:
 
 
 @feed.command("init")
-@click.argument("data_path", default="data/")
+@click.argument("data_path", default=_DEFAULT_DATA_PATH)
 @click.pass_context
 @require_auth
-@require_scope("data:write")
+@require_scope(_SCOPE_DATA_WRITE)
 def feed_init(ctx: click.Context, data_path: str) -> None:
     """DataFeed 운영 디렉토리를 초기화한다."""
     from ante.feed.config import FeedConfig
@@ -368,10 +374,10 @@ def feed_init(ctx: click.Context, data_path: str) -> None:
 
 
 @feed.command("status")
-@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
-@require_scope("data:read")
+@require_scope(_SCOPE_DATA_READ)
 def feed_status(ctx: click.Context, data_path: str) -> None:
     """수집 상태를 조회한다."""
 
@@ -422,7 +428,7 @@ def _echo_status_text(
     """feed status의 텍스트 출력을 수행한다."""
     click.echo()
     click.echo(f"DataFeed Status ({cfg.feed_dir})")  # type: ignore[attr-defined]
-    click.echo("══════════════════════════════════════════════════")
+    click.echo("═" * 50)
 
     _echo_checkpoints_section(checkpoints)
     _echo_report_section(latest_report)
@@ -435,7 +441,7 @@ def _echo_checkpoints_section(checkpoints: list[dict[str, str]]) -> None:
     """체크포인트 섹션을 출력한다."""
     click.echo()
     click.echo("Checkpoints")
-    click.echo("──────────────────────────────────────────────────")
+    click.echo(_SEPARATOR)
     if checkpoints:
         for cp in checkpoints:
             click.echo(
@@ -451,7 +457,7 @@ def _echo_report_section(latest_report: dict | None) -> None:
     """최근 리포트 섹션을 출력한다."""
     click.echo()
     click.echo("Latest Report")
-    click.echo("──────────────────────────────────────────────────")
+    click.echo(_SEPARATOR)
     if latest_report:
         summary = latest_report.get("summary", {})
         click.echo(f"  mode: {latest_report.get('mode', '?')}")
@@ -470,7 +476,7 @@ def _echo_api_keys_section(api_keys: list[dict]) -> None:
     """API 키 섹션을 출력한다."""
     click.echo()
     click.echo("API Keys")
-    click.echo("──────────────────────────────────────────────────")
+    click.echo(_SEPARATOR)
     for entry in api_keys:
         if entry["set"]:
             source_info = f"(source: {entry['source']})"
@@ -531,10 +537,10 @@ def _load_latest_report(
 @click.option("--symbol", required=True, help="종목 코드 (6자리)")
 @click.option("--timeframe", default="1d", help="타임프레임 (기본값: 1d)")
 @click.option("--source", default="external", help="데이터 소스 식별자")
-@click.option("--data-path", default="data/", help="데이터 저장소 경로")
+@click.option("--data-path", default=_DEFAULT_DATA_PATH, help=_DATA_PATH_HELP)
 @click.pass_context
 @require_auth
-@require_scope("data:write")
+@require_scope(_SCOPE_DATA_WRITE)
 def feed_inject(
     ctx: click.Context,
     path: str,

--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -544,7 +544,6 @@ def feed_inject(
     data_path: str,
 ) -> None:
     """외부 CSV 파일에서 과거 데이터를 수동 주입한다."""
-    import asyncio
     from pathlib import Path as _Path
 
     from ante.data.normalizer import DataNormalizer
@@ -559,13 +558,11 @@ def feed_inject(
     injector = FeedInjector(store=store, normalizer=normalizer)
 
     try:
-        count = asyncio.run(
-            injector.inject_csv(
-                filepath,
-                symbol=symbol,
-                timeframe=timeframe,
-                source=source,
-            )
+        count = injector.inject_csv(
+            filepath,
+            symbol=symbol,
+            timeframe=timeframe,
+            source=source,
         )
     except FileNotFoundError as e:
         fmt.error(str(e), "FILE_NOT_FOUND")

--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -205,6 +205,7 @@ def run_backfill(
     import asyncio
     from pathlib import Path
 
+    from ante.feed.cli_output import format_backfill_result
     from ante.feed.config import FeedConfig
 
     fmt = get_formatter(ctx)
@@ -228,32 +229,7 @@ def run_backfill(
         )
     )
 
-    if fmt.is_json:
-        fmt.output(
-            {
-                "mode": result.mode,
-                "symbols_total": result.symbols_total,
-                "symbols_success": result.symbols_success,
-                "symbols_failed": result.symbols_failed,
-                "rows_written": result.rows_written,
-                "data_types": result.data_types,
-                "duration_seconds": result.duration_seconds,
-                "config_errors": result.config_errors,
-            }
-        )
-    else:
-        click.echo()
-        click.echo(
-            f"Backfill 완료: {result.symbols_success}/{result.symbols_total} 종목 성공"
-        )
-        click.echo(f"  기록: {result.rows_written} rows")
-        click.echo(f"  데이터: {', '.join(result.data_types) or '없음'}")
-        click.echo(f"  소요: {result.duration_seconds:.1f}초")
-        if result.config_errors:
-            click.echo()
-            for err in result.config_errors:
-                click.echo(f"  [경고] {err.get('error', err)}")
-        click.echo()
+    format_backfill_result(result, fmt)
 
 
 @feed_run.command("daily")
@@ -273,6 +249,7 @@ def run_daily(
     import asyncio
     from pathlib import Path
 
+    from ante.feed.cli_output import format_daily_result
     from ante.feed.config import FeedConfig
 
     fmt = get_formatter(ctx)
@@ -312,34 +289,7 @@ def run_daily(
             )
         )
 
-    if fmt.is_json:
-        fmt.output(
-            {
-                "mode": result.mode,
-                "target_date": result.target_date,
-                "symbols_total": result.symbols_total,
-                "symbols_success": result.symbols_success,
-                "symbols_failed": result.symbols_failed,
-                "rows_written": result.rows_written,
-                "data_types": result.data_types,
-                "duration_seconds": result.duration_seconds,
-                "config_errors": result.config_errors,
-            }
-        )
-    else:
-        click.echo()
-        click.echo(
-            f"Daily 수집 완료 ({result.target_date}): "
-            f"{result.symbols_success}/{result.symbols_total} 종목 성공"
-        )
-        click.echo(f"  기록: {result.rows_written} rows")
-        click.echo(f"  데이터: {', '.join(result.data_types) or '없음'}")
-        click.echo(f"  소요: {result.duration_seconds:.1f}초")
-        if result.config_errors:
-            click.echo()
-            for err in result.config_errors:
-                click.echo(f"  [경고] {err.get('error', err)}")
-        click.echo()
+    format_daily_result(result, fmt)
 
 
 # ── start (상주 스케줄러) ─────────────────────────────────────────────────────
@@ -353,10 +303,8 @@ def run_daily(
 def feed_start(ctx: click.Context, data_path: str) -> None:
     """내장 스케줄러로 backfill/daily를 자동 실행하는 상주 프로세스를 시작한다."""
     import asyncio
-    import signal
-    from datetime import datetime, timedelta, timezone
-    from pathlib import Path
 
+    from ante.feed.cli_scheduler import run_scheduler_loop
     from ante.feed.config import FeedConfig
 
     fmt = get_formatter(ctx)
@@ -376,90 +324,16 @@ def feed_start(ctx: click.Context, data_path: str) -> None:
 
     orchestrator = _build_orchestrator(cfg)
 
-    kst = timezone(timedelta(hours=9))
-
-    async def _scheduler_loop() -> None:
-        """스케줄 루프: daily_at / backfill_at 시각에 수집 실행."""
-        stop_event = asyncio.Event()
-        loop = asyncio.get_running_loop()
-
-        def _handle_signal() -> None:
-            logger.info("종료 시그널 수신, 스케줄러 중지...")
-            stop_event.set()
-
-        for sig in (signal.SIGTERM, signal.SIGINT):
-            loop.add_signal_handler(sig, _handle_signal)
-
-        logger.info(
-            "DataFeed 스케줄러 시작 (daily_at=%s, backfill_at=%s)",
-            daily_at,
-            backfill_at,
-        )
-        click.echo(
-            f"DataFeed 스케줄러 시작 (daily_at={daily_at}, backfill_at={backfill_at})"
-        )
-        click.echo("종료하려면 Ctrl+C 또는 SIGTERM을 보내세요.")
-
-        daily_ran_today = False
-        backfill_ran_today = False
-        last_date = ""
-
-        while not stop_event.is_set():
-            now = datetime.now(tz=kst)
-            current_time = now.strftime("%H:%M")
-            current_date_str = now.strftime("%Y-%m-%d")
-
-            # 날짜가 바뀌면 플래그 초기화
-            if last_date and last_date != current_date_str:
-                daily_ran_today = False
-                backfill_ran_today = False
-            last_date = current_date_str
-
-            # daily 실행
-            if not daily_ran_today and current_time >= str(daily_at):
-                logger.info("Daily 수집 시작 (%s)", current_date_str)
-                try:
-                    result = await orchestrator.run_daily(
-                        data_path=Path(data_path),
-                        config=config,
-                    )
-                    click.echo(
-                        f"[{current_date_str}] Daily 완료: "
-                        f"{result.symbols_success}/{result.symbols_total} 종목, "
-                        f"{result.rows_written} rows"
-                    )
-                except Exception as exc:
-                    logger.error("Daily 수집 실패: %s", exc)
-                daily_ran_today = True
-
-            # backfill 실행
-            if not backfill_ran_today and current_time >= str(backfill_at):
-                logger.info("Backfill 수집 시작 (%s)", current_date_str)
-                try:
-                    result = await orchestrator.run_backfill(
-                        data_path=Path(data_path),
-                        config=config,
-                    )
-                    click.echo(
-                        f"[{current_date_str}] Backfill 완료: "
-                        f"{result.symbols_success}/{result.symbols_total} 종목, "
-                        f"{result.rows_written} rows"
-                    )
-                except Exception as exc:
-                    logger.error("Backfill 수집 실패: %s", exc)
-                backfill_ran_today = True
-
-            # 60초 대기 (stop_event 감시)
-            try:
-                await asyncio.wait_for(stop_event.wait(), timeout=60.0)
-            except TimeoutError:
-                pass
-
-        logger.info("DataFeed 스케줄러 종료")
-        click.echo("DataFeed 스케줄러 종료")
-
     try:
-        asyncio.run(_scheduler_loop())
+        asyncio.run(
+            run_scheduler_loop(
+                orchestrator=orchestrator,
+                data_path=data_path,
+                config=config,
+                daily_at=daily_at,
+                backfill_at=backfill_at,
+            )
+        )
     except KeyboardInterrupt:
         click.echo("\nDataFeed 스케줄러 종료")
 
@@ -536,53 +410,73 @@ def feed_status(ctx: click.Context, data_path: str) -> None:
             }
         )
     else:
-        click.echo()
-        click.echo(f"DataFeed Status ({cfg.feed_dir})")
-        click.echo("══════════════════════════════════════════════════")
+        _echo_status_text(cfg, checkpoints, latest_report, api_keys)
 
-        # 체크포인트 섹션
-        click.echo()
-        click.echo("Checkpoints")
-        click.echo("──────────────────────────────────────────────────")
-        if checkpoints:
-            for cp in checkpoints:
-                click.echo(
-                    f"  {cp['source']}/{cp['data_type']:<16}"
-                    f" last_date: {cp['last_date']}"
-                    f"  (updated: {cp['updated_at']})"
-                )
-        else:
-            click.echo("  (체크포인트 없음 — 아직 수집을 실행하지 않았습니다)")
 
-        # 최근 리포트 섹션
-        click.echo()
-        click.echo("Latest Report")
-        click.echo("──────────────────────────────────────────────────")
-        if latest_report:
-            summary = latest_report.get("summary", {})
-            click.echo(f"  mode: {latest_report.get('mode', '?')}")
-            click.echo(f"  date: {latest_report.get('target_date', '?')}")
+def _echo_status_text(
+    cfg: object,  # FeedConfig
+    checkpoints: list[dict[str, str]],
+    latest_report: dict | None,
+    api_keys: list[dict],
+) -> None:
+    """feed status의 텍스트 출력을 수행한다."""
+    click.echo()
+    click.echo(f"DataFeed Status ({cfg.feed_dir})")  # type: ignore[attr-defined]
+    click.echo("══════════════════════════════════════════════════")
+
+    _echo_checkpoints_section(checkpoints)
+    _echo_report_section(latest_report)
+    _echo_api_keys_section(api_keys)
+
+    click.echo()
+
+
+def _echo_checkpoints_section(checkpoints: list[dict[str, str]]) -> None:
+    """체크포인트 섹션을 출력한다."""
+    click.echo()
+    click.echo("Checkpoints")
+    click.echo("──────────────────────────────────────────────────")
+    if checkpoints:
+        for cp in checkpoints:
             click.echo(
-                f"  result: {summary.get('symbols_success', 0)} success"
-                f" / {summary.get('symbols_failed', 0)} failed"
-                f" / {len(latest_report.get('warnings', []))} warnings"
+                f"  {cp['source']}/{cp['data_type']:<16}"
+                f" last_date: {cp['last_date']}"
+                f"  (updated: {cp['updated_at']})"
             )
-            click.echo(f"  rows: {summary.get('rows_written', 0)}")
+    else:
+        click.echo("  (체크포인트 없음 — 아직 수집을 실행하지 않았습니다)")
+
+
+def _echo_report_section(latest_report: dict | None) -> None:
+    """최근 리포트 섹션을 출력한다."""
+    click.echo()
+    click.echo("Latest Report")
+    click.echo("──────────────────────────────────────────────────")
+    if latest_report:
+        summary = latest_report.get("summary", {})
+        click.echo(f"  mode: {latest_report.get('mode', '?')}")
+        click.echo(f"  date: {latest_report.get('target_date', '?')}")
+        click.echo(
+            f"  result: {summary.get('symbols_success', 0)} success"
+            f" / {summary.get('symbols_failed', 0)} failed"
+            f" / {len(latest_report.get('warnings', []))} warnings"
+        )
+        click.echo(f"  rows: {summary.get('rows_written', 0)}")
+    else:
+        click.echo("  (리포트 없음 — 아직 수집을 실행하지 않았습니다)")
+
+
+def _echo_api_keys_section(api_keys: list[dict]) -> None:
+    """API 키 섹션을 출력한다."""
+    click.echo()
+    click.echo("API Keys")
+    click.echo("──────────────────────────────────────────────────")
+    for entry in api_keys:
+        if entry["set"]:
+            source_info = f"(source: {entry['source']})"
+            click.echo(f"  {entry['key']:<30} ✓ 설정됨 {source_info}")
         else:
-            click.echo("  (리포트 없음 — 아직 수집을 실행하지 않았습니다)")
-
-        # API 키 섹션
-        click.echo()
-        click.echo("API Keys")
-        click.echo("──────────────────────────────────────────────────")
-        for entry in api_keys:
-            if entry["set"]:
-                source_info = f"(source: {entry['source']})"
-                click.echo(f"  {entry['key']:<30} ✓ 설정됨 {source_info}")
-            else:
-                click.echo(f"  {entry['key']:<30} ✗ 미설정")
-
-        click.echo()
+            click.echo(f"  {entry['key']:<30} ✗ 미설정")
 
 
 def _load_checkpoints(feed_dir: pathlib.Path) -> list[dict[str, str]]:

--- a/src/ante/feed/cli_output.py
+++ b/src/ante/feed/cli_output.py
@@ -1,0 +1,95 @@
+"""ante feed CLI — 결과 출력 포매터.
+
+CLI 서브커맨드들이 공유하는 CollectionResult 출력 로직을 분리한 모듈이다.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import click
+
+if TYPE_CHECKING:
+    from ante.feed.models.result import CollectionResult
+
+
+def format_backfill_result(
+    result: CollectionResult,
+    fmt: Any,  # OutputFormatter  # noqa: ANN401
+) -> None:
+    """Backfill 결과를 text 또는 JSON으로 출력한다."""
+    if fmt.is_json:
+        fmt.output(_backfill_result_dict(result))
+    else:
+        _echo_backfill_text(result)
+
+
+def format_daily_result(
+    result: CollectionResult,
+    fmt: Any,  # OutputFormatter  # noqa: ANN401
+) -> None:
+    """Daily 결과를 text 또는 JSON으로 출력한다."""
+    if fmt.is_json:
+        fmt.output(_daily_result_dict(result))
+    else:
+        _echo_daily_text(result)
+
+
+def _backfill_result_dict(result: CollectionResult) -> dict[str, Any]:
+    """Backfill 결과를 JSON 직렬화용 dict로 변환한다."""
+    return {
+        "mode": result.mode,
+        "symbols_total": result.symbols_total,
+        "symbols_success": result.symbols_success,
+        "symbols_failed": result.symbols_failed,
+        "rows_written": result.rows_written,
+        "data_types": result.data_types,
+        "duration_seconds": result.duration_seconds,
+        "config_errors": result.config_errors,
+    }
+
+
+def _daily_result_dict(result: CollectionResult) -> dict[str, Any]:
+    """Daily 결과를 JSON 직렬화용 dict로 변환한다."""
+    return {
+        "mode": result.mode,
+        "target_date": result.target_date,
+        "symbols_total": result.symbols_total,
+        "symbols_success": result.symbols_success,
+        "symbols_failed": result.symbols_failed,
+        "rows_written": result.rows_written,
+        "data_types": result.data_types,
+        "duration_seconds": result.duration_seconds,
+        "config_errors": result.config_errors,
+    }
+
+
+def _echo_backfill_text(result: CollectionResult) -> None:
+    """Backfill 결과를 사람이 읽기 좋은 텍스트로 출력한다."""
+    click.echo()
+    click.echo(
+        f"Backfill 완료: {result.symbols_success}/{result.symbols_total} 종목 성공"
+    )
+    _echo_common_stats(result)
+
+
+def _echo_daily_text(result: CollectionResult) -> None:
+    """Daily 결과를 사람이 읽기 좋은 텍스트로 출력한다."""
+    click.echo()
+    click.echo(
+        f"Daily 수집 완료 ({result.target_date}): "
+        f"{result.symbols_success}/{result.symbols_total} 종목 성공"
+    )
+    _echo_common_stats(result)
+
+
+def _echo_common_stats(result: CollectionResult) -> None:
+    """공통 통계 항목(rows, data_types, 소요시간, 경고)을 출력한다."""
+    click.echo(f"  기록: {result.rows_written} rows")
+    click.echo(f"  데이터: {', '.join(result.data_types) or '없음'}")
+    click.echo(f"  소요: {result.duration_seconds:.1f}초")
+    if result.config_errors:
+        click.echo()
+        for err in result.config_errors:
+            click.echo(f"  [경고] {err.get('error', err)}")
+    click.echo()

--- a/src/ante/feed/cli_scheduler.py
+++ b/src/ante/feed/cli_scheduler.py
@@ -1,0 +1,134 @@
+"""ante feed start — 상주 스케줄러 루프.
+
+feed_start CLI 커맨드에서 사용하는 스케줄러 루프를 분리한 모듈이다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import click
+
+logger = logging.getLogger(__name__)
+
+KST = timezone(timedelta(hours=9))
+
+
+async def run_scheduler_loop(
+    orchestrator: Any,  # FeedOrchestrator  # noqa: ANN401
+    data_path: str,
+    config: dict[str, Any],
+    daily_at: str,
+    backfill_at: str,
+) -> None:
+    """스케줄 루프: daily_at / backfill_at 시각에 수집을 실행한다."""
+    stop_event = _setup_signal_handlers()
+
+    logger.info(
+        "DataFeed 스케줄러 시작 (daily_at=%s, backfill_at=%s)",
+        daily_at,
+        backfill_at,
+    )
+    click.echo(
+        f"DataFeed 스케줄러 시작 (daily_at={daily_at}, backfill_at={backfill_at})"
+    )
+    click.echo("종료하려면 Ctrl+C 또는 SIGTERM을 보내세요.")
+
+    daily_ran_today = False
+    backfill_ran_today = False
+    last_date = ""
+
+    while not stop_event.is_set():
+        now = datetime.now(tz=KST)
+        current_time = now.strftime("%H:%M")
+        current_date = now.strftime("%Y-%m-%d")
+
+        if last_date and last_date != current_date:
+            daily_ran_today = False
+            backfill_ran_today = False
+        last_date = current_date
+
+        if not daily_ran_today and current_time >= str(daily_at):
+            await _run_daily_job(orchestrator, data_path, config, current_date)
+            daily_ran_today = True
+
+        if not backfill_ran_today and current_time >= str(backfill_at):
+            await _run_backfill_job(orchestrator, data_path, config, current_date)
+            backfill_ran_today = True
+
+        await _wait_or_stop(stop_event, timeout=60.0)
+
+    logger.info("DataFeed 스케줄러 종료")
+    click.echo("DataFeed 스케줄러 종료")
+
+
+def _setup_signal_handlers() -> asyncio.Event:
+    """SIGTERM/SIGINT 시그널 핸들러를 등록하고 stop_event를 반환한다."""
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def _handle_signal() -> None:
+        logger.info("종료 시그널 수신, 스케줄러 중지...")
+        stop_event.set()
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _handle_signal)
+
+    return stop_event
+
+
+async def _run_daily_job(
+    orchestrator: Any,  # noqa: ANN401
+    data_path: str,
+    config: dict[str, Any],
+    current_date: str,
+) -> None:
+    """Daily 수집 작업을 1회 실행한다."""
+    logger.info("Daily 수집 시작 (%s)", current_date)
+    try:
+        result = await orchestrator.run_daily(
+            data_path=Path(data_path),
+            config=config,
+        )
+        click.echo(
+            f"[{current_date}] Daily 완료: "
+            f"{result.symbols_success}/{result.symbols_total} 종목, "
+            f"{result.rows_written} rows"
+        )
+    except Exception as exc:
+        logger.error("Daily 수집 실패: %s", exc)
+
+
+async def _run_backfill_job(
+    orchestrator: Any,  # noqa: ANN401
+    data_path: str,
+    config: dict[str, Any],
+    current_date: str,
+) -> None:
+    """Backfill 수집 작업을 1회 실행한다."""
+    logger.info("Backfill 수집 시작 (%s)", current_date)
+    try:
+        result = await orchestrator.run_backfill(
+            data_path=Path(data_path),
+            config=config,
+        )
+        click.echo(
+            f"[{current_date}] Backfill 완료: "
+            f"{result.symbols_success}/{result.symbols_total} 종목, "
+            f"{result.rows_written} rows"
+        )
+    except Exception as exc:
+        logger.error("Backfill 수집 실패: %s", exc)
+
+
+async def _wait_or_stop(stop_event: asyncio.Event, *, timeout: float) -> None:
+    """stop_event 또는 timeout까지 대기한다."""
+    try:
+        await asyncio.wait_for(stop_event.wait(), timeout=timeout)
+    except TimeoutError:
+        pass

--- a/src/ante/feed/injector.py
+++ b/src/ante/feed/injector.py
@@ -38,7 +38,7 @@ class FeedInjector:
         self._store = store
         self._normalizer = normalizer
 
-    async def inject_csv(
+    def inject_csv(
         self,
         path: str | Path,
         symbol: str,
@@ -80,7 +80,7 @@ class FeedInjector:
         # 4계층 검증 (스키마 + 비즈니스)
         self._validate(normalized)
 
-        await self._store.write(symbol, timeframe, normalized)
+        self._store.write(symbol, timeframe, normalized)
         logger.info(
             "CSV 주입 완료: %d행, %s → %s/%s",
             len(normalized),
@@ -90,7 +90,7 @@ class FeedInjector:
         )
         return len(normalized)
 
-    async def inject_dataframe(
+    def inject_dataframe(
         self,
         df: pl.DataFrame,
         symbol: str,
@@ -122,7 +122,7 @@ class FeedInjector:
         # 4계층 검증 (스키마 + 비즈니스)
         self._validate(df)
 
-        await self._store.write(symbol, timeframe, df)
+        self._store.write(symbol, timeframe, df)
         logger.info("DataFrame 주입 완료: %d행, %s/%s", len(df), symbol, timeframe)
         return len(df)
 

--- a/src/ante/feed/pipeline/backfill_runner.py
+++ b/src/ante/feed/pipeline/backfill_runner.py
@@ -89,7 +89,7 @@ class BackfillRunner:
             store,
             ctx,
         )
-        await self._compute_indicators(store, ctx)
+        self._compute_indicators(store, ctx)
 
         return ctx.to_result("backfill", started_at)
 
@@ -220,7 +220,7 @@ class BackfillRunner:
                 }
             )
 
-    async def _compute_indicators(
+    def _compute_indicators(
         self,
         store: ParquetStore,
         ctx: _RunContext,
@@ -232,7 +232,7 @@ class BackfillRunner:
             return
 
         try:
-            written = await self._indicator.compute(
+            written = self._indicator.compute(
                 store,
                 list(ctx.success_symbols),
             )

--- a/src/ante/feed/pipeline/backfill_runner.py
+++ b/src/ante/feed/pipeline/backfill_runner.py
@@ -1,0 +1,329 @@
+"""BackfillRunner — 과거 데이터 대량 수집 (backfill 모드)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from ante.data.store import ParquetStore
+from ante.feed.models.result import CollectionResult
+from ante.feed.pipeline.checkpoint import Checkpoint
+from ante.feed.pipeline.dart_collector import DARTCollector
+from ante.feed.pipeline.data_go_kr_collector import DataGoKrCollector
+from ante.feed.pipeline.indicator_calculator import IndicatorCalculator
+from ante.feed.pipeline.scheduler import generate_backfill_dates
+from ante.feed.sources.dart import (
+    CriticalApiError as DARTCriticalError,
+)
+from ante.feed.sources.dart import (
+    DailyLimitExceededError as DARTDailyLimitError,
+)
+from ante.feed.sources.data_go_kr import (
+    CriticalApiError as DataGoKrCriticalError,
+)
+from ante.feed.sources.data_go_kr import (
+    DailyLimitExceededError as DataGoKrDailyLimitError,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BACKFILL_SINCE = "2015-01-01"
+
+
+class BackfillRunner:
+    """Backfill 모드 ETL 실행기.
+
+    체크포인트 기반으로 날짜 범위를 생성하고,
+    DataGoKrCollector + DARTCollector + IndicatorCalculator를 순서대로 실행한다.
+    """
+
+    def __init__(
+        self,
+        data_go_kr_collector: DataGoKrCollector | None = None,
+        dart_collector: DARTCollector | None = None,
+        indicator_calculator: IndicatorCalculator | None = None,
+        store: ParquetStore | None = None,
+    ) -> None:
+        self._data_go_kr = data_go_kr_collector
+        self._dart = dart_collector
+        self._indicator = indicator_calculator or IndicatorCalculator()
+        self._store = store
+
+    async def run(
+        self,
+        data_path: Path,
+        config: dict[str, Any],
+        feed_dir: Path,
+        started_at: datetime,
+        is_blocked: Any,
+    ) -> CollectionResult:
+        """Backfill 내부 구현. data.go.kr + DART 수집 후 지표 계산."""
+        ctx = _RunContext()
+        store = self._store or ParquetStore(base_path=data_path)
+
+        dates = self._resolve_dates(config, feed_dir)
+        if not dates:
+            logger.info("Backfill: 수집할 날짜 없음 (이미 완료)")
+            return _make_result("backfill", started_at)
+
+        self._check_sources(ctx)
+
+        ohlcv_checkpoint = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        dart_checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
+
+        await self._collect_data_go_kr(
+            dates,
+            config,
+            store,
+            ohlcv_checkpoint,
+            ctx,
+            is_blocked,
+        )
+        await self._collect_dart(
+            data_path,
+            feed_dir,
+            dart_checkpoint,
+            config,
+            store,
+            ctx,
+        )
+        await self._compute_indicators(store, ctx)
+
+        return ctx.to_result("backfill", started_at)
+
+    @staticmethod
+    def _resolve_dates(
+        config: dict[str, Any],
+        feed_dir: Path,
+    ) -> list[str]:
+        """체크포인트 기반으로 backfill 날짜 목록을 생성한다."""
+        schedule = config.get("schedule", {})
+        backfill_since = schedule.get("backfill_since", DEFAULT_BACKFILL_SINCE)
+        ohlcv_checkpoint = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
+        last_date = ohlcv_checkpoint.get_last_date()
+
+        return list(
+            generate_backfill_dates(
+                start=backfill_since,
+                last_checkpoint=last_date,
+            )
+        )
+
+    def _check_sources(self, ctx: _RunContext) -> None:
+        """소스 누락을 확인하여 config_errors에 기록한다."""
+        if self._data_go_kr is None:
+            ctx.config_errors.append(
+                {
+                    "error": "data.go.kr API 키 미설정",
+                    "source": "data_go_kr",
+                }
+            )
+        if self._dart is None:
+            ctx.config_errors.append(
+                {
+                    "error": "DART API 키 미설정",
+                    "source": "dart",
+                }
+            )
+
+    async def _collect_data_go_kr(
+        self,
+        dates: list[str],
+        config: dict[str, Any],
+        store: ParquetStore,
+        checkpoint: Checkpoint,
+        ctx: _RunContext,
+        is_blocked: Any,
+    ) -> None:
+        """data.go.kr 날짜별 수집을 실행한다."""
+        if self._data_go_kr is None:
+            return
+
+        for target_date in dates:
+            if is_blocked(config, target_date):
+                logger.debug("방어 가드: %s 스킵", target_date)
+                continue
+
+            try:
+                written, syms, warns = await self._data_go_kr.collect(
+                    target_date,
+                    store,
+                )
+                ctx.add_success(written, syms, warns)
+                if written > 0:
+                    ctx.data_types.update(["ohlcv", "fundamental"])
+                checkpoint.save(target_date)
+
+            except (DataGoKrDailyLimitError, DataGoKrCriticalError) as exc:
+                logger.critical("data.go.kr 수집 중단: %s", exc)
+                ctx.config_errors.append(
+                    {
+                        "error": str(exc),
+                        "source": "data_go_kr",
+                    }
+                )
+                break
+            except Exception as exc:
+                logger.error(
+                    "data.go.kr 수집 실패: date=%s, %s",
+                    target_date,
+                    exc,
+                )
+                ctx.failures.append(
+                    {
+                        "date": target_date,
+                        "source": "data_go_kr",
+                        "reason": str(exc),
+                    }
+                )
+
+    async def _collect_dart(
+        self,
+        data_path: Path,
+        feed_dir: Path,
+        checkpoint: Checkpoint,
+        config: dict[str, Any],
+        store: ParquetStore,
+        ctx: _RunContext,
+    ) -> None:
+        """DART 분기별 수집을 실행한다."""
+        if self._dart is None:
+            return
+
+        try:
+            written, syms, warns = await self._dart.collect(
+                data_path,
+                feed_dir,
+                checkpoint,
+                config,
+                store,
+            )
+            ctx.add_success(written, syms, warns)
+            if written > 0:
+                ctx.data_types.add("fundamental")
+        except (DARTDailyLimitError, DARTCriticalError) as exc:
+            logger.critical("DART 수집 중단: %s", exc)
+            ctx.config_errors.append(
+                {
+                    "error": str(exc),
+                    "source": "dart",
+                }
+            )
+        except Exception as exc:
+            logger.error("DART 수집 실패: %s", exc)
+            ctx.failures.append(
+                {
+                    "source": "dart",
+                    "reason": str(exc),
+                }
+            )
+
+    async def _compute_indicators(
+        self,
+        store: ParquetStore,
+        ctx: _RunContext,
+    ) -> None:
+        """파생 지표를 계산한다."""
+        if "fundamental" not in ctx.data_types:
+            return
+        if not ctx.success_symbols:
+            return
+
+        try:
+            written = await self._indicator.compute(
+                store,
+                list(ctx.success_symbols),
+            )
+            ctx.rows_written += written
+        except Exception as exc:
+            logger.error("파생 지표 계산 실패: %s", exc)
+            ctx.warnings.append(
+                {
+                    "type": "derived_indicators",
+                    "message": f"파생 지표 계산 실패: {exc}",
+                }
+            )
+
+
+class _RunContext:
+    """수집 실행 중 결과를 집계하는 컨텍스트."""
+
+    def __init__(self) -> None:
+        self.failures: list[dict] = []
+        self.warnings: list[dict] = []
+        self.config_errors: list[dict] = []
+        self.total_symbols: set[str] = set()
+        self.success_symbols: set[str] = set()
+        self.rows_written: int = 0
+        self.data_types: set[str] = set()
+
+    def add_success(
+        self,
+        written: int,
+        syms: set[str],
+        warns: list[dict],
+    ) -> None:
+        """성공 결과를 집계한다."""
+        self.rows_written += written
+        self.total_symbols.update(syms)
+        self.success_symbols.update(syms)
+        if warns:
+            self.warnings.extend(warns)
+
+    def to_result(
+        self,
+        mode: str,
+        started_at: datetime,
+        target_date: str | None = None,
+    ) -> CollectionResult:
+        """집계 결과를 CollectionResult로 변환한다."""
+        failed = self.total_symbols - self.success_symbols
+        return _make_result(
+            mode=mode,
+            started_at=started_at,
+            target_date=target_date,
+            symbols_total=len(self.total_symbols),
+            symbols_success=len(self.success_symbols),
+            symbols_failed=len(failed),
+            rows_written=self.rows_written,
+            data_types=sorted(self.data_types),
+            failures=self.failures,
+            warnings=self.warnings,
+            config_errors=self.config_errors,
+        )
+
+
+def _make_result(
+    mode: str,
+    started_at: datetime,
+    target_date: str | None = None,
+    symbols_total: int = 0,
+    symbols_success: int = 0,
+    symbols_failed: int = 0,
+    rows_written: int = 0,
+    data_types: list[str] | None = None,
+    failures: list[dict] | None = None,
+    warnings: list[dict] | None = None,
+    config_errors: list[dict] | None = None,
+) -> CollectionResult:
+    """CollectionResult를 생성한다."""
+    finished_at = datetime.now(tz=UTC)
+    duration = (finished_at - started_at).total_seconds()
+
+    return CollectionResult(
+        mode=mode,
+        started_at=started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        finished_at=finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        duration_seconds=duration,
+        target_date=target_date,
+        symbols_total=symbols_total,
+        symbols_success=symbols_success,
+        symbols_failed=symbols_failed,
+        rows_written=rows_written,
+        data_types=data_types or [],
+        failures=failures or [],
+        warnings=warnings or [],
+        config_errors=config_errors or [],
+    )

--- a/src/ante/feed/pipeline/daily_runner.py
+++ b/src/ante/feed/pipeline/daily_runner.py
@@ -1,0 +1,190 @@
+"""DailyRunner — 일별 증분 수집 (daily 모드)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ante.data.store import ParquetStore
+from ante.feed.models.result import CollectionResult
+from ante.feed.pipeline.backfill_runner import _make_result, _RunContext
+from ante.feed.pipeline.checkpoint import Checkpoint
+from ante.feed.pipeline.dart_collector import DARTCollector
+from ante.feed.pipeline.data_go_kr_collector import DataGoKrCollector
+from ante.feed.pipeline.indicator_calculator import IndicatorCalculator
+from ante.feed.pipeline.scheduler import generate_daily_date
+from ante.feed.sources.dart import (
+    CriticalApiError as DARTCriticalError,
+)
+from ante.feed.sources.dart import (
+    DailyLimitExceededError as DARTDailyLimitError,
+)
+from ante.feed.sources.data_go_kr import (
+    CriticalApiError as DataGoKrCriticalError,
+)
+from ante.feed.sources.data_go_kr import (
+    DailyLimitExceededError as DataGoKrDailyLimitError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DailyRunner:
+    """Daily 모드 ETL 실행기.
+
+    어제 1일치 데이터를 수집한다. backfill과 동일한 ETL 흐름.
+    """
+
+    def __init__(
+        self,
+        data_go_kr_collector: DataGoKrCollector | None = None,
+        dart_collector: DARTCollector | None = None,
+        indicator_calculator: IndicatorCalculator | None = None,
+        store: ParquetStore | None = None,
+    ) -> None:
+        self._data_go_kr = data_go_kr_collector
+        self._dart = dart_collector
+        self._indicator = indicator_calculator or IndicatorCalculator()
+        self._store = store
+
+    async def run(
+        self,
+        data_path: Path,
+        config: dict[str, Any],
+        feed_dir: Path,
+        started_at: datetime,
+        is_blocked: Any,
+    ) -> CollectionResult:
+        """Daily 내부 구현."""
+        target_date = generate_daily_date()
+
+        if is_blocked(config, target_date):
+            logger.info("Daily: 방어 가드에 의해 스킵 (date=%s)", target_date)
+            return _make_result("daily", started_at, target_date=target_date)
+
+        ctx = _RunContext()
+        store = self._store or ParquetStore(base_path=data_path)
+
+        await self._collect_data_go_kr(target_date, store, ctx)
+        await self._collect_dart(
+            data_path,
+            feed_dir,
+            config,
+            store,
+            ctx,
+        )
+        await self._compute_indicators(store, ctx)
+
+        return ctx.to_result("daily", started_at, target_date=target_date)
+
+    async def _collect_data_go_kr(
+        self,
+        target_date: str,
+        store: ParquetStore,
+        ctx: _RunContext,
+    ) -> None:
+        """data.go.kr 일별 수집을 실행한다."""
+        if self._data_go_kr is None:
+            ctx.config_errors.append(
+                {
+                    "error": "data.go.kr API 키 미설정",
+                    "source": "data_go_kr",
+                }
+            )
+            return
+
+        try:
+            written, syms, warns = await self._data_go_kr.collect(
+                target_date,
+                store,
+            )
+            ctx.add_success(written, syms, warns)
+            if written > 0:
+                ctx.data_types.update(["ohlcv", "fundamental"])
+        except (DataGoKrDailyLimitError, DataGoKrCriticalError) as exc:
+            ctx.config_errors.append(
+                {
+                    "error": str(exc),
+                    "source": "data_go_kr",
+                }
+            )
+        except Exception as exc:
+            ctx.failures.append(
+                {
+                    "date": target_date,
+                    "source": "data_go_kr",
+                    "reason": str(exc),
+                }
+            )
+
+    async def _collect_dart(
+        self,
+        data_path: Path,
+        feed_dir: Path,
+        config: dict[str, Any],
+        store: ParquetStore,
+        ctx: _RunContext,
+    ) -> None:
+        """DART 일별 수집을 실행한다."""
+        if self._dart is None:
+            ctx.config_errors.append(
+                {
+                    "error": "DART API 키 미설정",
+                    "source": "dart",
+                }
+            )
+            return
+
+        checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
+        try:
+            written, syms, warns = await self._dart.collect(
+                data_path,
+                feed_dir,
+                checkpoint,
+                config,
+                store,
+            )
+            ctx.add_success(written, syms, warns)
+            if written > 0:
+                ctx.data_types.add("fundamental")
+        except (DARTDailyLimitError, DARTCriticalError) as exc:
+            ctx.config_errors.append(
+                {
+                    "error": str(exc),
+                    "source": "dart",
+                }
+            )
+        except Exception as exc:
+            ctx.failures.append(
+                {
+                    "source": "dart",
+                    "reason": str(exc),
+                }
+            )
+
+    async def _compute_indicators(
+        self,
+        store: ParquetStore,
+        ctx: _RunContext,
+    ) -> None:
+        """파생 지표를 계산한다."""
+        if "fundamental" not in ctx.data_types:
+            return
+        if not ctx.success_symbols:
+            return
+
+        try:
+            written = await self._indicator.compute(
+                store,
+                list(ctx.success_symbols),
+            )
+            ctx.rows_written += written
+        except Exception as exc:
+            ctx.warnings.append(
+                {
+                    "type": "derived_indicators",
+                    "message": f"파생 지표 계산 실패: {exc}",
+                }
+            )

--- a/src/ante/feed/pipeline/daily_runner.py
+++ b/src/ante/feed/pipeline/daily_runner.py
@@ -75,7 +75,7 @@ class DailyRunner:
             store,
             ctx,
         )
-        await self._compute_indicators(store, ctx)
+        self._compute_indicators(store, ctx)
 
         return ctx.to_result("daily", started_at, target_date=target_date)
 
@@ -164,7 +164,7 @@ class DailyRunner:
                 }
             )
 
-    async def _compute_indicators(
+    def _compute_indicators(
         self,
         store: ParquetStore,
         ctx: _RunContext,
@@ -176,7 +176,7 @@ class DailyRunner:
             return
 
         try:
-            written = await self._indicator.compute(
+            written = self._indicator.compute(
                 store,
                 list(ctx.success_symbols),
             )

--- a/src/ante/feed/pipeline/dart_collector.py
+++ b/src/ante/feed/pipeline/dart_collector.py
@@ -170,13 +170,13 @@ class DARTCollector:
         if not raw_items:
             return 0, set()
 
-        return await self._normalize_and_store(
+        return self._normalize_and_store(
             raw_items,
             corp_code_map,
             store,
         )
 
-    async def _normalize_and_store(
+    def _normalize_and_store(
         self,
         raw_items: list[dict],
         corp_code_map: dict[str, str],
@@ -193,7 +193,7 @@ class DARTCollector:
         symbols: set[str] = set()
         for sym in normalized["symbol"].unique().to_list():
             sym_df = normalized.filter(pl.col("symbol") == sym)
-            await store.write(sym, "krx", sym_df, data_type="fundamental")
+            store.write(sym, "krx", sym_df, data_type="fundamental")
             rows += len(sym_df)
             symbols.add(sym)
 

--- a/src/ante/feed/pipeline/dart_collector.py
+++ b/src/ante/feed/pipeline/dart_collector.py
@@ -1,0 +1,200 @@
+"""DARTCollector — DART 재무제표 분기별 수집."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+from ante.data.normalizer import DARTNormalizer
+from ante.data.store import ParquetStore
+from ante.feed.pipeline.checkpoint import Checkpoint
+from ante.feed.sources.dart import (
+    CriticalApiError as DARTCriticalError,
+)
+from ante.feed.sources.dart import (
+    DailyLimitExceededError as DARTDailyLimitError,
+)
+
+logger = logging.getLogger(__name__)
+
+# DART 보고서 코드 (분기별)
+REPRT_CODES = ["11013", "11012", "11014", "11011"]
+
+# 기본 설정 상수
+DEFAULT_BACKFILL_SINCE = "2015-01-01"
+
+
+class DARTCollector:
+    """DART에서 재무제표를 분기별로 수집한다.
+
+    책임: corp_code 매핑 로드 -> 연도/분기 순회 -> 정규화 -> 저장.
+    """
+
+    def __init__(
+        self,
+        source: Any,
+        normalizer: DARTNormalizer | None = None,
+    ) -> None:
+        self._source = source
+        self._normalizer = normalizer or DARTNormalizer()
+
+    async def collect(
+        self,
+        data_path: Path,
+        feed_dir: Path,
+        checkpoint: Checkpoint,
+        config: dict[str, Any],
+        store: ParquetStore,
+    ) -> tuple[int, set[str], list[dict]]:
+        """DART 재무제표를 분기별로 수집한다.
+
+        Returns:
+            (기록 행 수, 수집된 심볼 집합, 경고 목록).
+        """
+        corp_code_map = await self._load_corp_codes(feed_dir)
+        if not corp_code_map:
+            logger.warning("DART: 고유번호 매핑이 비어있음")
+            return 0, set(), []
+
+        start_year, end_year = self._resolve_year_range(config)
+        last_checkpoint = checkpoint.get_last_date()
+
+        return await self._collect_quarters(
+            corp_code_map,
+            store,
+            checkpoint,
+            start_year,
+            end_year,
+            last_checkpoint,
+        )
+
+    async def _load_corp_codes(
+        self,
+        feed_dir: Path,
+    ) -> dict[str, str]:
+        """고유번호 매핑을 로드하거나 다운로드한다."""
+        corp_codes_path = feed_dir / "dart_corp_codes.json"
+        return await self._source.fetch_corp_codes(save_path=corp_codes_path)
+
+    @staticmethod
+    def _resolve_year_range(
+        config: dict[str, Any],
+    ) -> tuple[int, int]:
+        """설정에서 수집 연도 범위를 결정한다."""
+        from datetime import date
+
+        schedule = config.get("schedule", {})
+        backfill_since = schedule.get("backfill_since", DEFAULT_BACKFILL_SINCE)
+        start_year = int(backfill_since[:4])
+        end_year = date.today().year
+        return start_year, end_year
+
+    async def _collect_quarters(
+        self,
+        corp_code_map: dict[str, str],
+        store: ParquetStore,
+        checkpoint: Checkpoint,
+        start_year: int,
+        end_year: int,
+        last_checkpoint: str | None,
+    ) -> tuple[int, set[str], list[dict]]:
+        """연도/분기를 순회하며 재무제표를 수집한다."""
+        corp_codes_list = list(corp_code_map.keys())
+        rows_written = 0
+        symbols: set[str] = set()
+        warns: list[dict] = []
+
+        for year in range(start_year, end_year + 1):
+            for reprt_code in REPRT_CODES:
+                quarter_key = f"{year}-{reprt_code}"
+                if last_checkpoint and quarter_key <= last_checkpoint:
+                    continue
+
+                written, syms = await self._fetch_quarter(
+                    corp_codes_list,
+                    corp_code_map,
+                    store,
+                    year,
+                    reprt_code,
+                    warns,
+                )
+                rows_written += written
+                symbols.update(syms)
+                checkpoint.save(quarter_key)
+
+        logger.info(
+            "DART 수집 완료: symbols=%d rows=%d",
+            len(symbols),
+            rows_written,
+        )
+        return rows_written, symbols, warns
+
+    async def _fetch_quarter(
+        self,
+        corp_codes_list: list[str],
+        corp_code_map: dict[str, str],
+        store: ParquetStore,
+        year: int,
+        reprt_code: str,
+        warns: list[dict],
+    ) -> tuple[int, set[str]]:
+        """단일 분기 재무제표를 수집/정규화/저장한다."""
+        try:
+            raw_items = await self._source.fetch_financial(
+                corp_codes_list,
+                str(year),
+                reprt_code,
+            )
+        except (DARTDailyLimitError, DARTCriticalError):
+            raise
+        except Exception as exc:
+            logger.warning(
+                "DART 수집 실패: year=%s reprt=%s: %s",
+                year,
+                reprt_code,
+                exc,
+            )
+            warns.append(
+                {
+                    "source": "dart",
+                    "year": str(year),
+                    "reprt_code": reprt_code,
+                    "message": str(exc),
+                }
+            )
+            return 0, set()
+
+        if not raw_items:
+            return 0, set()
+
+        return await self._normalize_and_store(
+            raw_items,
+            corp_code_map,
+            store,
+        )
+
+    async def _normalize_and_store(
+        self,
+        raw_items: list[dict],
+        corp_code_map: dict[str, str],
+        store: ParquetStore,
+    ) -> tuple[int, set[str]]:
+        """raw 데이터를 정규화하고 심볼별로 저장한다."""
+        df = pl.DataFrame(raw_items)
+        normalized = self._normalizer.normalize(df, corp_code_map)
+
+        if normalized.is_empty() or "symbol" not in normalized.columns:
+            return 0, set()
+
+        rows = 0
+        symbols: set[str] = set()
+        for sym in normalized["symbol"].unique().to_list():
+            sym_df = normalized.filter(pl.col("symbol") == sym)
+            await store.write(sym, "krx", sym_df, data_type="fundamental")
+            rows += len(sym_df)
+            symbols.add(sym)
+
+        return rows, symbols

--- a/src/ante/feed/pipeline/data_go_kr_collector.py
+++ b/src/ante/feed/pipeline/data_go_kr_collector.py
@@ -1,0 +1,152 @@
+"""DataGoKrCollector — data.go.kr 전종목 일별 수집."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import polars as pl
+
+from ante.data.normalizer import DataGoKrNormalizer
+from ante.data.store import ParquetStore
+from ante.feed.transform.validate import validate_all
+
+logger = logging.getLogger(__name__)
+
+# OHLCV 필수 검증 필드
+OHLCV_REQUIRED_FIELDS = [
+    "timestamp",
+    "symbol",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+]
+
+
+class DataGoKrCollector:
+    """data.go.kr에서 특정 날짜 전종목 데이터를 수집한다.
+
+    책임: API 호출 -> 검증 -> 정규화 -> 심볼별 저장.
+    """
+
+    def __init__(
+        self,
+        source: Any,
+        normalizer: DataGoKrNormalizer | None = None,
+    ) -> None:
+        self._source = source
+        self._normalizer = normalizer or DataGoKrNormalizer()
+
+    async def collect(
+        self,
+        target_date: str,
+        store: ParquetStore,
+    ) -> tuple[int, set[str], list[dict]]:
+        """특정 날짜의 전종목 데이터를 수집한다.
+
+        Returns:
+            (기록 행 수, 수집된 심볼 집합, 경고 목록).
+        """
+        raw_items = await self._source.fetch(target_date)
+        if not raw_items:
+            logger.debug("data.go.kr: date=%s 데이터 없음", target_date)
+            return 0, set(), []
+
+        warns = self._validate(raw_items, target_date)
+        df = pl.DataFrame(raw_items)
+        df = self._deduplicate(df)
+
+        rows_written, symbols = await self._normalize_and_store(
+            df,
+            store,
+            target_date,
+        )
+
+        return rows_written, symbols, warns
+
+    @staticmethod
+    def _validate(
+        raw_items: list[dict],
+        target_date: str,
+    ) -> list[dict]:
+        """데이터를 검증하고 경고 목록을 반환한다."""
+        validation = validate_all(raw_items, OHLCV_REQUIRED_FIELDS)
+        warns: list[dict] = []
+        for w in validation.warnings:
+            warns.append(
+                {
+                    "date": target_date,
+                    "source": "data_go_kr",
+                    "type": "business_rule",
+                    "message": w,
+                }
+            )
+        return warns
+
+    @staticmethod
+    def _deduplicate(df: pl.DataFrame) -> pl.DataFrame:
+        """srtnCd + basDt 기준 중복을 제거한다."""
+        if "srtnCd" in df.columns and "basDt" in df.columns:
+            return df.unique(subset=["srtnCd", "basDt"])
+        return df
+
+    async def _normalize_and_store(
+        self,
+        df: pl.DataFrame,
+        store: ParquetStore,
+        target_date: str,
+    ) -> tuple[int, set[str]]:
+        """OHLCV와 fundamental을 정규화하고 저장한다."""
+        rows_written = 0
+        symbols: set[str] = set()
+
+        rows_written += await self._store_ohlcv(df, store, symbols)
+        rows_written += await self._store_fundamental(df, store, symbols)
+
+        logger.info(
+            "data.go.kr 수집 완료: date=%s symbols=%d rows=%d",
+            target_date,
+            len(symbols),
+            rows_written,
+        )
+        return rows_written, symbols
+
+    async def _store_ohlcv(
+        self,
+        df: pl.DataFrame,
+        store: ParquetStore,
+        symbols: set[str],
+    ) -> int:
+        """OHLCV 데이터를 정규화하여 심볼별로 저장한다."""
+        ohlcv_df = self._normalizer.normalize_ohlcv(df)
+        if ohlcv_df.is_empty() or "symbol" not in ohlcv_df.columns:
+            return 0
+
+        rows = 0
+        for sym in ohlcv_df["symbol"].unique().to_list():
+            sym_df = ohlcv_df.filter(pl.col("symbol") == sym)
+            await store.write(sym, "1d", sym_df, data_type="ohlcv")
+            rows += len(sym_df)
+            symbols.add(sym)
+        return rows
+
+    async def _store_fundamental(
+        self,
+        df: pl.DataFrame,
+        store: ParquetStore,
+        symbols: set[str],
+    ) -> int:
+        """fundamental 데이터를 정규화하여 심볼별로 저장한다."""
+        fund_df = self._normalizer.normalize_fundamental(df)
+        if fund_df.is_empty() or "symbol" not in fund_df.columns:
+            return 0
+
+        rows = 0
+        for sym in fund_df["symbol"].unique().to_list():
+            sym_df = fund_df.filter(pl.col("symbol") == sym)
+            await store.write(sym, "krx", sym_df, data_type="fundamental")
+            rows += len(sym_df)
+            symbols.add(sym)
+        return rows

--- a/src/ante/feed/pipeline/data_go_kr_collector.py
+++ b/src/ante/feed/pipeline/data_go_kr_collector.py
@@ -58,7 +58,7 @@ class DataGoKrCollector:
         df = pl.DataFrame(raw_items)
         df = self._deduplicate(df)
 
-        rows_written, symbols = await self._normalize_and_store(
+        rows_written, symbols = self._normalize_and_store(
             df,
             store,
             target_date,
@@ -92,7 +92,7 @@ class DataGoKrCollector:
             return df.unique(subset=["srtnCd", "basDt"])
         return df
 
-    async def _normalize_and_store(
+    def _normalize_and_store(
         self,
         df: pl.DataFrame,
         store: ParquetStore,
@@ -102,8 +102,8 @@ class DataGoKrCollector:
         rows_written = 0
         symbols: set[str] = set()
 
-        rows_written += await self._store_ohlcv(df, store, symbols)
-        rows_written += await self._store_fundamental(df, store, symbols)
+        rows_written += self._store_ohlcv(df, store, symbols)
+        rows_written += self._store_fundamental(df, store, symbols)
 
         logger.info(
             "data.go.kr 수집 완료: date=%s symbols=%d rows=%d",
@@ -113,7 +113,7 @@ class DataGoKrCollector:
         )
         return rows_written, symbols
 
-    async def _store_ohlcv(
+    def _store_ohlcv(
         self,
         df: pl.DataFrame,
         store: ParquetStore,
@@ -127,12 +127,12 @@ class DataGoKrCollector:
         rows = 0
         for sym in ohlcv_df["symbol"].unique().to_list():
             sym_df = ohlcv_df.filter(pl.col("symbol") == sym)
-            await store.write(sym, "1d", sym_df, data_type="ohlcv")
+            store.write(sym, "1d", sym_df, data_type="ohlcv")
             rows += len(sym_df)
             symbols.add(sym)
         return rows
 
-    async def _store_fundamental(
+    def _store_fundamental(
         self,
         df: pl.DataFrame,
         store: ParquetStore,
@@ -146,7 +146,7 @@ class DataGoKrCollector:
         rows = 0
         for sym in fund_df["symbol"].unique().to_list():
             sym_df = fund_df.filter(pl.col("symbol") == sym)
-            await store.write(sym, "krx", sym_df, data_type="fundamental")
+            store.write(sym, "krx", sym_df, data_type="fundamental")
             rows += len(sym_df)
             symbols.add(sym)
         return rows

--- a/src/ante/feed/pipeline/indicator_calculator.py
+++ b/src/ante/feed/pipeline/indicator_calculator.py
@@ -23,7 +23,7 @@ class IndicatorCalculator:
     - 부채비율 = 부채총계 / 자본총계
     """
 
-    async def compute(
+    def compute(
         self,
         store: ParquetStore,
         symbols: list[str],
@@ -36,7 +36,7 @@ class IndicatorCalculator:
         rows_updated = 0
 
         for sym in symbols:
-            updated = await self._compute_symbol(store, sym)
+            updated = self._compute_symbol(store, sym)
             rows_updated += updated
 
         logger.info(
@@ -46,14 +46,14 @@ class IndicatorCalculator:
         )
         return rows_updated
 
-    async def _compute_symbol(
+    def _compute_symbol(
         self,
         store: ParquetStore,
         sym: str,
     ) -> int:
         """단일 심볼의 파생 지표를 계산한다."""
         try:
-            fundamental = await store.read(sym, "krx", data_type="fundamental")
+            fundamental = store.read(sym, "krx", data_type="fundamental")
         except Exception:
             return 0
 
@@ -65,7 +65,7 @@ class IndicatorCalculator:
             return 0
 
         updated = fundamental.with_columns(exprs)
-        await store.write(sym, "krx", updated, data_type="fundamental")
+        store.write(sym, "krx", updated, data_type="fundamental")
         return len(updated)
 
     @staticmethod

--- a/src/ante/feed/pipeline/indicator_calculator.py
+++ b/src/ante/feed/pipeline/indicator_calculator.py
@@ -1,0 +1,116 @@
+"""IndicatorCalculator — PER/PBR/EPS/BPS/ROE/부채비율 파생 지표 계산."""
+
+from __future__ import annotations
+
+import logging
+
+import polars as pl
+
+from ante.data.store import ParquetStore
+
+logger = logging.getLogger(__name__)
+
+
+class IndicatorCalculator:
+    """fundamental 데이터로부터 파생 투자 지표를 계산한다.
+
+    계산 공식:
+    - PER = 시가총액 / 당기순이익
+    - PBR = 시가총액 / 자본총계
+    - EPS = 당기순이익 / 상장주식수
+    - BPS = 자본총계 / 상장주식수
+    - ROE = 당기순이익 / 자본총계
+    - 부채비율 = 부채총계 / 자본총계
+    """
+
+    async def compute(
+        self,
+        store: ParquetStore,
+        symbols: list[str],
+    ) -> int:
+        """심볼 목록에 대해 파생 지표를 계산하여 저장한다.
+
+        Returns:
+            갱신된 행 수.
+        """
+        rows_updated = 0
+
+        for sym in symbols:
+            updated = await self._compute_symbol(store, sym)
+            rows_updated += updated
+
+        logger.info(
+            "파생 지표 계산 완료: symbols=%d rows=%d",
+            len(symbols),
+            rows_updated,
+        )
+        return rows_updated
+
+    async def _compute_symbol(
+        self,
+        store: ParquetStore,
+        sym: str,
+    ) -> int:
+        """단일 심볼의 파생 지표를 계산한다."""
+        try:
+            fundamental = await store.read(sym, "krx", data_type="fundamental")
+        except Exception:
+            return 0
+
+        if fundamental.is_empty():
+            return 0
+
+        exprs = self._build_expressions(set(fundamental.columns))
+        if not exprs:
+            return 0
+
+        updated = fundamental.with_columns(exprs)
+        await store.write(sym, "krx", updated, data_type="fundamental")
+        return len(updated)
+
+    @staticmethod
+    def _build_expressions(cols: set[str]) -> list[pl.Expr]:
+        """사용 가능한 컬럼에 따라 지표 계산 표현식을 생성한다."""
+        has_market_cap = "market_cap" in cols
+        has_shares = "shares_listed" in cols
+        has_net_income = "net_income" in cols
+        has_equity = "total_equity" in cols
+        has_debt = "total_debt" in cols
+
+        exprs: list[pl.Expr] = []
+
+        if has_market_cap and has_net_income:
+            exprs.append(_ratio_expr("market_cap", "net_income", "per"))
+
+        if has_market_cap and has_equity:
+            exprs.append(_ratio_expr("market_cap", "total_equity", "pbr"))
+
+        if has_net_income and has_shares:
+            exprs.append(_ratio_expr("net_income", "shares_listed", "eps"))
+
+        if has_equity and has_shares:
+            exprs.append(_ratio_expr("total_equity", "shares_listed", "bps"))
+
+        if has_net_income and has_equity:
+            exprs.append(_ratio_expr("net_income", "total_equity", "roe"))
+
+        if has_debt and has_equity:
+            exprs.append(
+                _ratio_expr("total_debt", "total_equity", "debt_to_equity"),
+            )
+
+        return exprs
+
+
+def _ratio_expr(
+    numerator: str,
+    denominator: str,
+    alias: str,
+) -> pl.Expr:
+    """분모가 0이면 None을 반환하는 나눗셈 표현식."""
+    return (
+        pl.when(pl.col(denominator) != 0)
+        .then(pl.col(numerator).cast(pl.Float64) / pl.col(denominator).cast(pl.Float64))
+        .otherwise(None)
+        .alias(alias)
+    )

--- a/src/ante/feed/pipeline/orchestrator.py
+++ b/src/ante/feed/pipeline/orchestrator.py
@@ -1,8 +1,7 @@
 """FeedOrchestrator — backfill/daily ETL 파이프라인 오케스트레이션.
 
-소스 어댑터(data.go.kr, DART)에서 데이터를 수집하고,
-Normalizer로 정규화, Validator로 검증, ParquetStore로 저장한다.
-파생 지표(PER/PBR/EPS/BPS/ROE/부채비율) 계산도 이 모듈에서 수행한다.
+수집/정규화/지표 계산은 전담 클래스에 위임하고,
+lock 관리, 방어 가드, 리포트 생성만 담당한다.
 """
 
 from __future__ import annotations
@@ -13,68 +12,25 @@ from datetime import UTC, date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-import polars as pl
-
 from ante.data.normalizer import DARTNormalizer, DataGoKrNormalizer
 from ante.data.store import ParquetStore
 from ante.feed.models.result import CollectionResult
-from ante.feed.pipeline.checkpoint import Checkpoint
-from ante.feed.pipeline.scheduler import (
-    generate_backfill_dates,
-    generate_daily_date,
-)
+from ante.feed.pipeline.backfill_runner import BackfillRunner, _make_result
+from ante.feed.pipeline.daily_runner import DailyRunner
+from ante.feed.pipeline.dart_collector import DARTCollector
+from ante.feed.pipeline.data_go_kr_collector import DataGoKrCollector
+from ante.feed.pipeline.indicator_calculator import IndicatorCalculator
 from ante.feed.report.generator import ReportGenerator
-from ante.feed.sources.dart import (
-    CriticalApiError as DARTCriticalError,
-)
-from ante.feed.sources.dart import (
-    DailyLimitExceededError as DARTDailyLimitError,
-)
 from ante.feed.sources.dart import DARTSource
-from ante.feed.sources.data_go_kr import (
-    CriticalApiError as DataGoKrCriticalError,
-)
-from ante.feed.sources.data_go_kr import (
-    DailyLimitExceededError as DataGoKrDailyLimitError,
-)
 from ante.feed.sources.data_go_kr import DataGoKrSource
-from ante.feed.transform.validate import validate_all
 
 logger = logging.getLogger(__name__)
 
-# 기본 설정 상수
-DEFAULT_BACKFILL_SINCE = "2015-01-01"
 LOCK_FILE = "lock"
-
-# DART 보고서 코드 (분기별)
-REPRT_CODES = ["11013", "11012", "11014", "11011"]
-
-# OHLCV 필수 검증 필드
-OHLCV_REQUIRED_FIELDS = [
-    "timestamp",
-    "symbol",
-    "open",
-    "high",
-    "low",
-    "close",
-    "volume",
-]
 
 
 class FeedOrchestrator:
-    """DataFeed ETL 오케스트레이터.
-
-    backfill과 daily 두 모드를 지원하며,
-    data.go.kr + DART 데이터를 수집/정규화/검증/저장한다.
-
-    책임:
-      - 방어 가드(blocked_days, blocked_hours) 적용
-      - 일일 한도 확인 및 도달 시 체크포인트 저장 후 종료
-      - 소스별 수집 실패 스킵 및 집계
-      - 파생 지표(PER/PBR/EPS/BPS/ROE/부채비율) 계산
-      - lock 파일로 동시 실행 방지
-      - CollectionResult 생성
-    """
+    """DataFeed ETL 오케스트레이터 (lock/가드/리포트만 담당)."""
 
     def __init__(
         self,
@@ -85,721 +41,98 @@ class FeedOrchestrator:
         dart_normalizer: DARTNormalizer | None = None,
         report_generator: ReportGenerator | None = None,
     ) -> None:
-        """FeedOrchestrator를 초기화한다.
-
-        Args:
-            data_go_kr_source: data.go.kr 소스 어댑터.
-            dart_source: DART 소스 어댑터.
-            store: ParquetStore 인스턴스.
-            data_go_kr_normalizer: data.go.kr 정규화기.
-            dart_normalizer: DART 정규화기.
-            report_generator: 리포트 생성기.
-        """
-        self._data_go_kr_source = data_go_kr_source
-        self._dart_source = dart_source
         self._store = store
-        self._data_go_kr_normalizer = data_go_kr_normalizer or DataGoKrNormalizer()
-        self._dart_normalizer = dart_normalizer or DARTNormalizer()
         self._report_generator = report_generator
+
+        # 하위 컬렉터 조립
+        data_go_kr_collector = (
+            DataGoKrCollector(data_go_kr_source, data_go_kr_normalizer)
+            if data_go_kr_source
+            else None
+        )
+        dart_collector = (
+            DARTCollector(dart_source, dart_normalizer) if dart_source else None
+        )
+        indicator = IndicatorCalculator()
+
+        self._backfill_runner = BackfillRunner(
+            data_go_kr_collector=data_go_kr_collector,
+            dart_collector=dart_collector,
+            indicator_calculator=indicator,
+            store=store,
+        )
+        self._daily_runner = DailyRunner(
+            data_go_kr_collector=data_go_kr_collector,
+            dart_collector=dart_collector,
+            indicator_calculator=indicator,
+            store=store,
+        )
 
     async def run_backfill(
         self,
         data_path: Path,
         config: dict[str, Any],
     ) -> CollectionResult:
-        """과거 데이터 대량 수집 (backfill 모드).
-
-        1. 체크포인트 로드 -> 날짜 범위 생성
-        2. 날짜별: data.go.kr fetch -> normalize -> validate -> store
-        3. 분기별: DART fetch -> normalize -> validate -> store
-        4. 파생 지표 계산
-        5. 체크포인트 저장, 리포트 생성
-
-        Args:
-            data_path: Ante 데이터 저장소 루트 경로.
-            config: 설정 딕셔너리 (schedule, guard 섹션 포함).
-
-        Returns:
-            수집 결과 CollectionResult.
-        """
+        """과거 데이터 대량 수집 (backfill 모드)."""
         feed_dir = data_path / ".feed"
         started_at = datetime.now(tz=UTC)
 
-        # lock 파일 확인/생성
         if not self._acquire_lock(feed_dir):
-            return self._make_result(
+            return _make_result(
                 "backfill",
                 started_at,
                 config_errors=[{"error": "다른 수집 프로세스가 이미 실행 중"}],
             )
 
         try:
-            return await self._run_backfill_inner(
-                data_path, config, feed_dir, started_at
+            result = await self._backfill_runner.run(
+                data_path,
+                config,
+                feed_dir,
+                started_at,
+                self._is_blocked,
             )
+            self._save_report(data_path, feed_dir, result, "backfill")
+            return result
         finally:
             self._release_lock(feed_dir)
-
-    async def _run_backfill_inner(
-        self,
-        data_path: Path,
-        config: dict[str, Any],
-        feed_dir: Path,
-        started_at: datetime,
-    ) -> CollectionResult:
-        """Backfill 내부 구현."""
-        schedule = config.get("schedule", {})
-        backfill_since = schedule.get("backfill_since", DEFAULT_BACKFILL_SINCE)
-
-        # 체크포인트 로드
-        ohlcv_checkpoint = Checkpoint(feed_dir, "data_go_kr", "ohlcv")
-        dart_checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
-
-        last_ohlcv_date = ohlcv_checkpoint.get_last_date()
-
-        # 날짜 범위 생성
-        dates = list(
-            generate_backfill_dates(
-                start=backfill_since,
-                last_checkpoint=last_ohlcv_date,
-            )
-        )
-
-        if not dates:
-            logger.info("Backfill: 수집할 날짜 없음 (이미 완료)")
-            return self._make_result("backfill", started_at)
-
-        # 결과 집계 변수
-        failures: list[dict] = []
-        warnings: list[dict] = []
-        config_errors: list[dict] = []
-        total_symbols: set[str] = set()
-        success_symbols: set[str] = set()
-        rows_written = 0
-        data_types: set[str] = set()
-
-        # 소스 누락 확인
-        if self._data_go_kr_source is None:
-            config_errors.append(
-                {
-                    "error": "data.go.kr API 키 미설정",
-                    "source": "data_go_kr",
-                }
-            )
-        if self._dart_source is None:
-            config_errors.append(
-                {
-                    "error": "DART API 키 미설정",
-                    "source": "dart",
-                }
-            )
-
-        store = self._store or ParquetStore(base_path=data_path)
-
-        # --- data.go.kr 날짜별 수집 ---
-        if self._data_go_kr_source is not None:
-            for target_date in dates:
-                # 방어 가드 체크
-                if self._is_blocked(config, target_date):
-                    logger.debug("방어 가드: %s 스킵", target_date)
-                    continue
-
-                try:
-                    written, syms, warns = await self._collect_data_go_kr_date(
-                        target_date, store
-                    )
-                    rows_written += written
-                    total_symbols.update(syms)
-                    success_symbols.update(syms)
-                    if warns:
-                        warnings.extend(warns)
-                    if written > 0:
-                        data_types.add("ohlcv")
-                        data_types.add("fundamental")
-
-                    # 날짜별 체크포인트 갱신
-                    ohlcv_checkpoint.save(target_date)
-
-                except (DataGoKrDailyLimitError, DataGoKrCriticalError) as exc:
-                    logger.critical("data.go.kr 수집 중단: %s", exc)
-                    config_errors.append(
-                        {
-                            "error": str(exc),
-                            "source": "data_go_kr",
-                        }
-                    )
-                    break
-                except Exception as exc:
-                    logger.error("data.go.kr 수집 실패: date=%s, %s", target_date, exc)
-                    failures.append(
-                        {
-                            "date": target_date,
-                            "source": "data_go_kr",
-                            "reason": str(exc),
-                        }
-                    )
-
-        # --- DART 분기별 수집 ---
-        if self._dart_source is not None:
-            try:
-                dart_written, dart_syms, dart_warns = await self._collect_dart(
-                    data_path, feed_dir, dart_checkpoint, config
-                )
-                rows_written += dart_written
-                total_symbols.update(dart_syms)
-                success_symbols.update(dart_syms)
-                if dart_warns:
-                    warnings.extend(dart_warns)
-                if dart_written > 0:
-                    data_types.add("fundamental")
-            except (DARTDailyLimitError, DARTCriticalError) as exc:
-                logger.critical("DART 수집 중단: %s", exc)
-                config_errors.append(
-                    {
-                        "error": str(exc),
-                        "source": "dart",
-                    }
-                )
-            except Exception as exc:
-                logger.error("DART 수집 실패: %s", exc)
-                failures.append(
-                    {
-                        "source": "dart",
-                        "reason": str(exc),
-                    }
-                )
-
-        # --- 파생 지표 계산 ---
-        if "fundamental" in data_types and success_symbols:
-            try:
-                derived_written = await self._compute_derived_indicators(
-                    store, list(success_symbols)
-                )
-                rows_written += derived_written
-            except Exception as exc:
-                logger.error("파생 지표 계산 실패: %s", exc)
-                warnings.append(
-                    {
-                        "type": "derived_indicators",
-                        "message": f"파생 지표 계산 실패: {exc}",
-                    }
-                )
-
-        # 실패 종목 집계
-        failed_symbols = total_symbols - success_symbols
-
-        # 리포트 생성
-        result = self._make_result(
-            mode="backfill",
-            started_at=started_at,
-            symbols_total=len(total_symbols),
-            symbols_success=len(success_symbols),
-            symbols_failed=len(failed_symbols),
-            rows_written=rows_written,
-            data_types=sorted(data_types),
-            failures=failures,
-            warnings=warnings,
-            config_errors=config_errors,
-        )
-
-        self._save_report(data_path, feed_dir, result, "backfill")
-
-        return result
 
     async def run_daily(
         self,
         data_path: Path,
         config: dict[str, Any],
     ) -> CollectionResult:
-        """일별 증분 수집 (daily 모드).
-
-        어제 1일치 데이터를 수집한다. backfill과 동일한 ETL 흐름.
-
-        Args:
-            data_path: Ante 데이터 저장소 루트 경로.
-            config: 설정 딕셔너리.
-
-        Returns:
-            수집 결과 CollectionResult.
-        """
+        """일별 증분 수집 (daily 모드)."""
         feed_dir = data_path / ".feed"
         started_at = datetime.now(tz=UTC)
 
-        # lock 파일 확인/생성
         if not self._acquire_lock(feed_dir):
-            return self._make_result(
+            return _make_result(
                 "daily",
                 started_at,
                 config_errors=[{"error": "다른 수집 프로세스가 이미 실행 중"}],
             )
 
         try:
-            return await self._run_daily_inner(data_path, config, feed_dir, started_at)
+            result = await self._daily_runner.run(
+                data_path,
+                config,
+                feed_dir,
+                started_at,
+                self._is_blocked,
+            )
+            self._save_report(data_path, feed_dir, result, "daily")
+            return result
         finally:
             self._release_lock(feed_dir)
-
-    async def _run_daily_inner(
-        self,
-        data_path: Path,
-        config: dict[str, Any],
-        feed_dir: Path,
-        started_at: datetime,
-    ) -> CollectionResult:
-        """Daily 내부 구현."""
-        target_date = generate_daily_date()
-
-        # 방어 가드
-        if self._is_blocked(config, target_date):
-            logger.info("Daily: 방어 가드에 의해 스킵 (date=%s)", target_date)
-            return self._make_result(
-                "daily",
-                started_at,
-                target_date=target_date,
-            )
-
-        failures: list[dict] = []
-        warnings: list[dict] = []
-        config_errors: list[dict] = []
-        total_symbols: set[str] = set()
-        success_symbols: set[str] = set()
-        rows_written = 0
-        data_types: set[str] = set()
-
-        store = self._store or ParquetStore(base_path=data_path)
-
-        # data.go.kr 수집
-        if self._data_go_kr_source is not None:
-            try:
-                written, syms, warns = await self._collect_data_go_kr_date(
-                    target_date, store
-                )
-                rows_written += written
-                total_symbols.update(syms)
-                success_symbols.update(syms)
-                if warns:
-                    warnings.extend(warns)
-                if written > 0:
-                    data_types.add("ohlcv")
-                    data_types.add("fundamental")
-            except (DataGoKrDailyLimitError, DataGoKrCriticalError) as exc:
-                config_errors.append(
-                    {
-                        "error": str(exc),
-                        "source": "data_go_kr",
-                    }
-                )
-            except Exception as exc:
-                failures.append(
-                    {
-                        "date": target_date,
-                        "source": "data_go_kr",
-                        "reason": str(exc),
-                    }
-                )
-        else:
-            config_errors.append(
-                {
-                    "error": "data.go.kr API 키 미설정",
-                    "source": "data_go_kr",
-                }
-            )
-
-        # DART 수집 (daily에서는 현재 분기 기준)
-        if self._dart_source is not None:
-            dart_checkpoint = Checkpoint(feed_dir, "dart", "fundamental")
-            try:
-                dart_written, dart_syms, dart_warns = await self._collect_dart(
-                    data_path, feed_dir, dart_checkpoint, config
-                )
-                rows_written += dart_written
-                total_symbols.update(dart_syms)
-                success_symbols.update(dart_syms)
-                if dart_warns:
-                    warnings.extend(dart_warns)
-                if dart_written > 0:
-                    data_types.add("fundamental")
-            except (DARTDailyLimitError, DARTCriticalError) as exc:
-                config_errors.append(
-                    {
-                        "error": str(exc),
-                        "source": "dart",
-                    }
-                )
-            except Exception as exc:
-                failures.append(
-                    {
-                        "source": "dart",
-                        "reason": str(exc),
-                    }
-                )
-        else:
-            config_errors.append(
-                {
-                    "error": "DART API 키 미설정",
-                    "source": "dart",
-                }
-            )
-
-        # 파생 지표 계산
-        if "fundamental" in data_types and success_symbols:
-            try:
-                derived_written = await self._compute_derived_indicators(
-                    store, list(success_symbols)
-                )
-                rows_written += derived_written
-            except Exception as exc:
-                warnings.append(
-                    {
-                        "type": "derived_indicators",
-                        "message": f"파생 지표 계산 실패: {exc}",
-                    }
-                )
-
-        failed_symbols = total_symbols - success_symbols
-
-        result = self._make_result(
-            mode="daily",
-            started_at=started_at,
-            target_date=target_date,
-            symbols_total=len(total_symbols),
-            symbols_success=len(success_symbols),
-            symbols_failed=len(failed_symbols),
-            rows_written=rows_written,
-            data_types=sorted(data_types),
-            failures=failures,
-            warnings=warnings,
-            config_errors=config_errors,
-        )
-
-        self._save_report(data_path, feed_dir, result, "daily")
-
-        return result
-
-    # ── data.go.kr 수집 ───────────────────────────────────
-
-    async def _collect_data_go_kr_date(
-        self,
-        target_date: str,
-        store: ParquetStore,
-    ) -> tuple[int, set[str], list[dict]]:
-        """data.go.kr에서 특정 날짜 전종목 데이터를 수집한다.
-
-        Returns:
-            (기록 행 수, 수집된 심볼 집합, 경고 목록).
-        """
-        assert self._data_go_kr_source is not None
-
-        # API 호출
-        raw_items = await self._data_go_kr_source.fetch(target_date)
-        if not raw_items:
-            logger.debug("data.go.kr: date=%s 데이터 없음", target_date)
-            return 0, set(), []
-
-        # 검증
-        validation = validate_all(
-            raw_items,
-            OHLCV_REQUIRED_FIELDS,
-        )
-        warns: list[dict] = []
-        if validation.warnings:
-            for w in validation.warnings:
-                warns.append(
-                    {
-                        "date": target_date,
-                        "source": "data_go_kr",
-                        "type": "business_rule",
-                        "message": w,
-                    }
-                )
-
-        # DataFrame 변환
-        df = pl.DataFrame(raw_items)
-
-        # 중복 제거
-        if "srtnCd" in df.columns and "basDt" in df.columns:
-            df = df.unique(subset=["srtnCd", "basDt"])
-
-        # OHLCV 정규화 + 저장
-        ohlcv_df = self._data_go_kr_normalizer.normalize_ohlcv(df)
-        rows_written = 0
-        symbols: set[str] = set()
-
-        if not ohlcv_df.is_empty() and "symbol" in ohlcv_df.columns:
-            symbol_list = ohlcv_df["symbol"].unique().to_list()
-            for sym in symbol_list:
-                sym_df = ohlcv_df.filter(pl.col("symbol") == sym)
-                await store.write(sym, "1d", sym_df, data_type="ohlcv")
-                rows_written += len(sym_df)
-                symbols.add(sym)
-
-        # FUNDAMENTAL 정규화 + 저장
-        fundamental_df = self._data_go_kr_normalizer.normalize_fundamental(df)
-        if not fundamental_df.is_empty() and "symbol" in fundamental_df.columns:
-            fund_symbols = fundamental_df["symbol"].unique().to_list()
-            for sym in fund_symbols:
-                sym_df = fundamental_df.filter(pl.col("symbol") == sym)
-                await store.write(sym, "krx", sym_df, data_type="fundamental")
-                rows_written += len(sym_df)
-                symbols.add(sym)
-
-        logger.info(
-            "data.go.kr 수집 완료: date=%s symbols=%d rows=%d",
-            target_date,
-            len(symbols),
-            rows_written,
-        )
-
-        return rows_written, symbols, warns
-
-    # ── DART 수집 ─────────────────────────────────────────
-
-    async def _collect_dart(
-        self,
-        data_path: Path,
-        feed_dir: Path,
-        checkpoint: Checkpoint,
-        config: dict[str, Any],
-    ) -> tuple[int, set[str], list[dict]]:
-        """DART에서 재무제표를 분기별로 수집한다.
-
-        Returns:
-            (기록 행 수, 수집된 심볼 집합, 경고 목록).
-        """
-        assert self._dart_source is not None
-
-        store = self._store or ParquetStore(base_path=data_path)
-
-        # corp_code 매핑 로드 또는 다운로드
-        corp_codes_path = feed_dir / "dart_corp_codes.json"
-        corp_code_map = await self._dart_source.fetch_corp_codes(
-            save_path=corp_codes_path
-        )
-
-        if not corp_code_map:
-            logger.warning("DART: 고유번호 매핑이 비어있음")
-            return 0, set(), []
-
-        corp_codes_list = list(corp_code_map.keys())
-
-        # 수집 연도/분기 범위 결정
-        schedule = config.get("schedule", {})
-        backfill_since = schedule.get("backfill_since", DEFAULT_BACKFILL_SINCE)
-        start_year = int(backfill_since[:4])
-        end_year = date.today().year
-
-        last_checkpoint = checkpoint.get_last_date()
-
-        rows_written = 0
-        symbols: set[str] = set()
-        warns: list[dict] = []
-
-        for year in range(start_year, end_year + 1):
-            for reprt_code in REPRT_CODES:
-                # 체크포인트 기반 스킵
-                quarter_key = f"{year}-{reprt_code}"
-                if last_checkpoint and quarter_key <= last_checkpoint:
-                    continue
-
-                try:
-                    raw_items = await self._dart_source.fetch_financial(
-                        corp_codes_list, str(year), reprt_code
-                    )
-                except (DARTDailyLimitError, DARTCriticalError):
-                    raise
-                except Exception as exc:
-                    logger.warning(
-                        "DART 수집 실패: year=%s reprt=%s: %s",
-                        year,
-                        reprt_code,
-                        exc,
-                    )
-                    warns.append(
-                        {
-                            "source": "dart",
-                            "year": str(year),
-                            "reprt_code": reprt_code,
-                            "message": str(exc),
-                        }
-                    )
-                    continue
-
-                if not raw_items:
-                    continue
-
-                # DataFrame 변환 + 정규화
-                df = pl.DataFrame(raw_items)
-                normalized = self._dart_normalizer.normalize(df, corp_code_map)
-
-                if normalized.is_empty():
-                    continue
-
-                # 심볼별 저장
-                if "symbol" in normalized.columns:
-                    sym_list = normalized["symbol"].unique().to_list()
-                    for sym in sym_list:
-                        sym_df = normalized.filter(pl.col("symbol") == sym)
-                        await store.write(sym, "krx", sym_df, data_type="fundamental")
-                        rows_written += len(sym_df)
-                        symbols.add(sym)
-
-                # 분기별 체크포인트 갱신
-                checkpoint.save(quarter_key)
-
-        logger.info(
-            "DART 수집 완료: symbols=%d rows=%d",
-            len(symbols),
-            rows_written,
-        )
-
-        return rows_written, symbols, warns
-
-    # ── 파생 지표 계산 ────────────────────────────────────
-
-    async def _compute_derived_indicators(
-        self,
-        store: ParquetStore,
-        symbols: list[str],
-    ) -> int:
-        """PER/PBR/EPS/BPS/ROE/부채비율을 계산하여 fundamental에 merge한다.
-
-        계산 공식:
-        - PER = 시가총액 / 당기순이익
-        - PBR = 시가총액 / 자본총계
-        - EPS = 당기순이익 / 상장주식수
-        - BPS = 자본총계 / 상장주식수
-        - ROE = 당기순이익 / 자본총계
-        - 부채비율 = 부채총계 / 자본총계
-
-        Args:
-            store: ParquetStore 인스턴스.
-            symbols: 대상 심볼 목록.
-
-        Returns:
-            갱신된 행 수.
-        """
-        rows_updated = 0
-
-        for sym in symbols:
-            try:
-                fundamental = await store.read(sym, "krx", data_type="fundamental")
-            except Exception:
-                continue
-
-            if fundamental.is_empty():
-                continue
-
-            # 필수 컬럼 존재 확인
-            cols = set(fundamental.columns)
-            has_market_cap = "market_cap" in cols
-            has_shares = "shares_listed" in cols
-            has_net_income = "net_income" in cols
-            has_equity = "total_equity" in cols
-            has_debt = "total_debt" in cols
-
-            exprs: list[pl.Expr] = []
-
-            # PER = 시가총액 / 당기순이익
-            if has_market_cap and has_net_income:
-                exprs.append(
-                    pl.when(pl.col("net_income") != 0)
-                    .then(
-                        pl.col("market_cap").cast(pl.Float64)
-                        / pl.col("net_income").cast(pl.Float64)
-                    )
-                    .otherwise(None)
-                    .alias("per")
-                )
-
-            # PBR = 시가총액 / 자본총계
-            if has_market_cap and has_equity:
-                exprs.append(
-                    pl.when(pl.col("total_equity") != 0)
-                    .then(
-                        pl.col("market_cap").cast(pl.Float64)
-                        / pl.col("total_equity").cast(pl.Float64)
-                    )
-                    .otherwise(None)
-                    .alias("pbr")
-                )
-
-            # EPS = 당기순이익 / 상장주식수
-            if has_net_income and has_shares:
-                exprs.append(
-                    pl.when(pl.col("shares_listed") != 0)
-                    .then(
-                        pl.col("net_income").cast(pl.Float64)
-                        / pl.col("shares_listed").cast(pl.Float64)
-                    )
-                    .otherwise(None)
-                    .alias("eps")
-                )
-
-            # BPS = 자본총계 / 상장주식수
-            if has_equity and has_shares:
-                exprs.append(
-                    pl.when(pl.col("shares_listed") != 0)
-                    .then(
-                        pl.col("total_equity").cast(pl.Float64)
-                        / pl.col("shares_listed").cast(pl.Float64)
-                    )
-                    .otherwise(None)
-                    .alias("bps")
-                )
-
-            # ROE = 당기순이익 / 자본총계
-            if has_net_income and has_equity:
-                exprs.append(
-                    pl.when(pl.col("total_equity") != 0)
-                    .then(
-                        pl.col("net_income").cast(pl.Float64)
-                        / pl.col("total_equity").cast(pl.Float64)
-                    )
-                    .otherwise(None)
-                    .alias("roe")
-                )
-
-            # 부채비율 = 부채총계 / 자본총계
-            if has_debt and has_equity:
-                exprs.append(
-                    pl.when(pl.col("total_equity") != 0)
-                    .then(
-                        pl.col("total_debt").cast(pl.Float64)
-                        / pl.col("total_equity").cast(pl.Float64)
-                    )
-                    .otherwise(None)
-                    .alias("debt_to_equity")
-                )
-
-            if not exprs:
-                continue
-
-            updated = fundamental.with_columns(exprs)
-            await store.write(sym, "krx", updated, data_type="fundamental")
-            rows_updated += len(updated)
-
-        logger.info(
-            "파생 지표 계산 완료: symbols=%d rows=%d",
-            len(symbols),
-            rows_updated,
-        )
-        return rows_updated
 
     # ── 방어 가드 ─────────────────────────────────────────
 
     @staticmethod
     def _is_blocked(config: dict[str, Any], target_date: str) -> bool:
-        """방어 가드 조건을 확인한다.
-
-        Args:
-            config: 설정 딕셔너리 (guard 섹션).
-            target_date: 확인할 날짜 (YYYY-MM-DD).
-
-        Returns:
-            차단되면 True.
-        """
+        """방어 가드 조건을 확인한다."""
         guard = config.get("guard", {})
 
-        # blocked_days 확인
         blocked_days = guard.get("blocked_days", [])
         if blocked_days:
             d = date.fromisoformat(target_date)
@@ -808,7 +141,6 @@ class FeedOrchestrator:
             if current_day in [bd.lower() for bd in blocked_days]:
                 return True
 
-        # blocked_hours 확인 (현재 시각 기준)
         pause_during_trading = guard.get("pause_during_trading", False)
         blocked_hours = guard.get("blocked_hours", [])
 
@@ -829,26 +161,17 @@ class FeedOrchestrator:
 
     @staticmethod
     def _acquire_lock(feed_dir: Path) -> bool:
-        """Lock 파일을 생성하여 동시 실행을 방지한다.
-
-        Args:
-            feed_dir: .feed 디렉토리 경로.
-
-        Returns:
-            lock 획득 성공 시 True.
-        """
+        """Lock 파일을 생성하여 동시 실행을 방지한다."""
         lock_path = feed_dir / LOCK_FILE
         feed_dir.mkdir(parents=True, exist_ok=True)
 
         if lock_path.exists():
             try:
                 pid = int(lock_path.read_text().strip())
-                # 프로세스 존재 여부 확인
                 os.kill(pid, 0)
                 logger.error("다른 수집 프로세스가 실행 중 (PID=%d)", pid)
                 return False
             except (ValueError, ProcessLookupError, PermissionError, OSError):
-                # 프로세스 없음 (비정상 종료) -> lock 파일 제거 후 진행
                 logger.warning("비정상 lock 파일 감지, 제거 후 진행")
                 lock_path.unlink(missing_ok=True)
 
@@ -861,41 +184,7 @@ class FeedOrchestrator:
         lock_path = feed_dir / LOCK_FILE
         lock_path.unlink(missing_ok=True)
 
-    # ── 유틸리티 ──────────────────────────────────────────
-
-    @staticmethod
-    def _make_result(
-        mode: str,
-        started_at: datetime,
-        target_date: str | None = None,
-        symbols_total: int = 0,
-        symbols_success: int = 0,
-        symbols_failed: int = 0,
-        rows_written: int = 0,
-        data_types: list[str] | None = None,
-        failures: list[dict] | None = None,
-        warnings: list[dict] | None = None,
-        config_errors: list[dict] | None = None,
-    ) -> CollectionResult:
-        """CollectionResult를 생성한다."""
-        finished_at = datetime.now(tz=UTC)
-        duration = (finished_at - started_at).total_seconds()
-
-        return CollectionResult(
-            mode=mode,
-            started_at=started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            finished_at=finished_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            duration_seconds=duration,
-            target_date=target_date,
-            symbols_total=symbols_total,
-            symbols_success=symbols_success,
-            symbols_failed=symbols_failed,
-            rows_written=rows_written,
-            data_types=data_types or [],
-            failures=failures or [],
-            warnings=warnings or [],
-            config_errors=config_errors or [],
-        )
+    # ── 리포트 ────────────────────────────────────────────
 
     def _save_report(
         self,

--- a/src/ante/feed/transform/validate.py
+++ b/src/ante/feed/transform/validate.py
@@ -166,58 +166,17 @@ def validate_business(records: list[dict[str, Any]]) -> ValidationResult:
     Returns:
         검증 결과 (경고 포함 가능, 비즈니스 규칙 위반은 경고로 분류).
     """
-    errors: list[str] = []
     warnings: list[str] = []
 
     if not records:
-        return ValidationResult(passed=True, warnings=warnings, errors=errors)
+        return ValidationResult(passed=True, warnings=warnings, errors=[])
 
     for i, record in enumerate(records):
         symbol = record.get("symbol", f"record_{i}")
+        _check_positive_prices(record, symbol, warnings)
+        _check_volume_non_negative(record, symbol, warnings)
+        _check_ohlc_relationship(record, symbol, warnings)
 
-        # 가격 양수 검증
-        for price_field in ("open", "high", "low", "close"):
-            value = record.get(price_field)
-            if value is None:
-                continue
-            try:
-                price = float(value)
-            except (ValueError, TypeError):
-                continue  # 스키마 검증에서 이미 잡힘
-            if price <= 0:
-                warnings.append(f"{symbol}: {price_field} <= 0 ({price_field}={price})")
-
-        # 거래량 >= 0 검증
-        volume_val = record.get("volume")
-        if volume_val is not None:
-            try:
-                vol = int(float(str(volume_val)))
-            except (ValueError, TypeError):
-                pass
-            else:
-                if vol < 0:
-                    warnings.append(f"{symbol}: volume < 0 (volume={vol})")
-
-        # OHLC 관계 검증: low <= open/close <= high
-        try:
-            o = float(record["open"]) if "open" in record else None
-            h = float(record["high"]) if "high" in record else None
-            low_val = float(record["low"]) if "low" in record else None
-            c = float(record["close"]) if "close" in record else None
-        except (ValueError, TypeError):
-            continue  # 숫자 변환 실패는 스키마 계층에서 처리
-
-        if all(v is not None for v in (o, h, low_val, c)):
-            if low_val > c:
-                warnings.append(f"{symbol}: low > close (low={low_val}, close={c})")
-            if c > h:
-                warnings.append(f"{symbol}: close > high (close={c}, high={h})")
-            if low_val > o:
-                warnings.append(f"{symbol}: low > open (low={low_val}, open={o})")
-            if o > h:
-                warnings.append(f"{symbol}: open > high (open={o}, high={h})")
-
-    # 시계열 연속성 검증 (날짜 중복 및 순서)
     _validate_time_series(records, warnings)
 
     if warnings:
@@ -227,8 +186,88 @@ def validate_business(records: list[dict[str, Any]]) -> ValidationResult:
     return ValidationResult(
         passed=True,  # 비즈니스 규칙 위반은 경고이므로 passed=True
         warnings=warnings,
-        errors=errors,
+        errors=[],
     )
+
+
+def _check_positive_prices(
+    record: dict[str, Any],
+    symbol: str,
+    warnings: list[str],
+) -> None:
+    """가격 필드가 양수인지 검증한다.
+
+    Args:
+        record: 검증할 레코드.
+        symbol: 심볼 식별자 (경고 메시지용).
+        warnings: 경고를 추가할 목록.
+    """
+    for price_field in ("open", "high", "low", "close"):
+        value = record.get(price_field)
+        if value is None:
+            continue
+        try:
+            price = float(value)
+        except (ValueError, TypeError):
+            continue  # 스키마 검증에서 이미 잡힘
+        if price <= 0:
+            warnings.append(f"{symbol}: {price_field} <= 0 ({price_field}={price})")
+
+
+def _check_volume_non_negative(
+    record: dict[str, Any],
+    symbol: str,
+    warnings: list[str],
+) -> None:
+    """거래량이 0 이상인지 검증한다.
+
+    Args:
+        record: 검증할 레코드.
+        symbol: 심볼 식별자 (경고 메시지용).
+        warnings: 경고를 추가할 목록.
+    """
+    volume_val = record.get("volume")
+    if volume_val is None:
+        return
+    try:
+        vol = int(float(str(volume_val)))
+    except (ValueError, TypeError):
+        return
+    if vol < 0:
+        warnings.append(f"{symbol}: volume < 0 (volume={vol})")
+
+
+def _check_ohlc_relationship(
+    record: dict[str, Any],
+    symbol: str,
+    warnings: list[str],
+) -> None:
+    """OHLC 관계(low <= open/close <= high)를 검증한다.
+
+    Args:
+        record: 검증할 레코드.
+        symbol: 심볼 식별자 (경고 메시지용).
+        warnings: 경고를 추가할 목록.
+    """
+    try:
+        o = float(record["open"]) if "open" in record else None
+        h = float(record["high"]) if "high" in record else None
+        low_val = float(record["low"]) if "low" in record else None
+        c = float(record["close"]) if "close" in record else None
+    except (ValueError, TypeError):
+        return  # 숫자 변환 실패는 스키마 계층에서 처리
+
+    if not all(v is not None for v in (o, h, low_val, c)):
+        return
+
+    if low_val > c:
+        warnings.append(f"{symbol}: low > close (low={low_val}, close={c})")
+    if c > h:
+        warnings.append(f"{symbol}: close > high (close={c}, high={h})")
+    if low_val > o:
+        warnings.append(f"{symbol}: low > open (low={low_val}, open={o})")
+    if o > h:
+        warnings.append(f"{symbol}: open > high (open={o}, high={h})")
 
 
 def _validate_time_series(records: list[dict[str, Any]], warnings: list[str]) -> None:
@@ -254,30 +293,57 @@ def _validate_time_series(records: list[dict[str, Any]], warnings: list[str]) ->
             by_symbol.setdefault(symbol, []).append(str(date_val))
 
     for symbol, dates in by_symbol.items():
-        # 중복 검사
-        seen: set[str] = set()
-        duplicates: list[str] = []
-        for d in dates:
-            if d in seen:
-                duplicates.append(d)
-            seen.add(d)
+        _check_duplicate_dates(symbol, dates, warnings)
+        _check_date_order(symbol, dates, warnings)
 
-        if duplicates:
-            warnings.append(f"{symbol}: 중복 날짜 감지: {duplicates}")
 
-        # 순서 검증 (파싱 가능한 날짜에 대해서만)
-        parsed_dates: list[tuple[datetime, str]] = []
-        for d in dates:
-            dt = _try_parse_date(d)
-            if dt is not None:
-                parsed_dates.append((dt, d))
+def _check_duplicate_dates(
+    symbol: str,
+    dates: list[str],
+    warnings: list[str],
+) -> None:
+    """날짜 중복을 검사한다.
 
-        for j in range(1, len(parsed_dates)):
-            if parsed_dates[j][0] < parsed_dates[j - 1][0]:
-                warnings.append(
-                    f"{symbol}: 날짜 순서 역전 감지: "
-                    f"{parsed_dates[j - 1][1]} -> {parsed_dates[j][1]}"
-                )
+    Args:
+        symbol: 심볼 식별자.
+        dates: 날짜 문자열 목록.
+        warnings: 경고를 추가할 목록.
+    """
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for d in dates:
+        if d in seen:
+            duplicates.append(d)
+        seen.add(d)
+
+    if duplicates:
+        warnings.append(f"{symbol}: 중복 날짜 감지: {duplicates}")
+
+
+def _check_date_order(
+    symbol: str,
+    dates: list[str],
+    warnings: list[str],
+) -> None:
+    """날짜 순서 역전을 검사한다.
+
+    Args:
+        symbol: 심볼 식별자.
+        dates: 날짜 문자열 목록.
+        warnings: 경고를 추가할 목록.
+    """
+    parsed_dates: list[tuple[datetime, str]] = []
+    for d in dates:
+        dt = _try_parse_date(d)
+        if dt is not None:
+            parsed_dates.append((dt, d))
+
+    for j in range(1, len(parsed_dates)):
+        if parsed_dates[j][0] < parsed_dates[j - 1][0]:
+            warnings.append(
+                f"{symbol}: 날짜 순서 역전 감지: "
+                f"{parsed_dates[j - 1][1]} -> {parsed_dates[j][1]}"
+            )
 
 
 def _try_parse_date(value: str) -> datetime | None:

--- a/src/ante/gateway/data_provider.py
+++ b/src/ante/gateway/data_provider.py
@@ -11,7 +11,10 @@ if TYPE_CHECKING:
 
 
 class LiveDataProvider(DataProvider):
-    """라이브 모드 DataProvider. APIGateway 경유로 캐시 활용."""
+    """라이브 모드 DataProvider. APIGateway 경유로 캐시 활용.
+
+    Note: DataProvider 인터페이스 준수를 위해 async def를 유지한다.
+    """
 
     def __init__(self, gateway: APIGateway) -> None:
         self._gateway = gateway

--- a/src/ante/gateway/gateway.py
+++ b/src/ante/gateway/gateway.py
@@ -40,13 +40,13 @@ class APIGateway:
         self._running = False
         self._stop_order_manager = stop_order_manager
 
-    async def start(self) -> None:
+    def start(self) -> None:
         """이벤트 구독 시작."""
         self._subscribe_events()
         self._running = True
         logger.info("APIGateway 시작")
 
-    async def stop(self) -> None:
+    def stop(self) -> None:
         """중지."""
         self._running = False
         logger.info("APIGateway 중지")
@@ -271,7 +271,10 @@ class APIGateway:
             )
 
     async def _on_order_modify(self, event: object) -> None:
-        """주문 정정 요청 → 로깅만 (정정은 추후 구현)."""
+        """주문 정정 요청 → 로깅만 (정정은 추후 구현).
+
+        Note: EventBus 핸들러 — isawaitable 패턴을 위해 async def 유지.
+        """
         from ante.eventbus.events import OrderModifyEvent
 
         if not isinstance(event, OrderModifyEvent):
@@ -279,7 +282,10 @@ class APIGateway:
         logger.warning("주문 정정은 추후 구현: %s", event.order_id)
 
     async def _on_order_filled(self, event: object) -> None:
-        """체결 시 관련 캐시 무효화."""
+        """체결 시 관련 캐시 무효화.
+
+        Note: EventBus 핸들러 — isawaitable 패턴을 위해 async def 유지.
+        """
         from ante.eventbus.events import OrderFilledEvent
 
         if not isinstance(event, OrderFilledEvent):

--- a/src/ante/gateway/stop_order.py
+++ b/src/ante/gateway/stop_order.py
@@ -69,7 +69,7 @@ class StopOrderManager:
         """모니터링 대상 종목."""
         return {o.symbol for o in self.active_orders}
 
-    async def start(self) -> None:
+    def start(self) -> None:
         """매니저 시작."""
         self._running = True
         logger.info("StopOrderManager 시작")
@@ -144,7 +144,7 @@ class StopOrderManager:
 
         return stop_order_id
 
-    async def cancel(self, stop_order_id: str) -> bool:
+    def cancel(self, stop_order_id: str) -> bool:
         """스탑 주문 취소."""
         order = self._orders.get(stop_order_id)
         if not order or order.triggered or order.expired:

--- a/src/ante/instrument/service.py
+++ b/src/ante/instrument/service.py
@@ -60,9 +60,10 @@ class InstrumentService:
 
     def _is_cache_expired(self) -> bool:
         """캐시 TTL 초과 여부."""
+        import math
         import time as time_mod
 
-        if self._cache_loaded_at == 0.0:
+        if math.isclose(self._cache_loaded_at, 0.0, abs_tol=1e-9):
             return True
         return (time_mod.monotonic() - self._cache_loaded_at) > self._cache_ttl
 

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -142,7 +142,7 @@ async def _init_trading(s: Services) -> None:
     from ante.rule import RuleEngine
 
     s.rule_engine = RuleEngine(eventbus=s.eventbus, system_state=s.system_state)
-    await s.rule_engine.start()
+    s.rule_engine.start()
 
     rule_configs = s.config.get("rules.global", [])
     if rule_configs:
@@ -230,10 +230,10 @@ async def _init_trading(s: Services) -> None:
     await _init_broker(s)
 
     # StrategyContextFactory 완성 (Broker 연결 이후)
-    await _init_context_factory(s)
+    _init_context_factory(s)
 
     # Treasury 잔고 동기화 (Broker 연결 이후)
-    await _init_treasury_sync(s)
+    _init_treasury_sync(s)
 
 
 async def _init_broker(s: Services) -> None:
@@ -252,7 +252,7 @@ async def _init_broker(s: Services) -> None:
 
     if s.broker:
         s.api_gateway = APIGateway(broker=s.broker, eventbus=s.eventbus)
-        await s.api_gateway.start()
+        s.api_gateway.start()
         logger.info("APIGateway 시작 완료")
 
     if s.broker:
@@ -321,7 +321,7 @@ async def _sync_instruments(s: Services) -> None:
         logger.warning("종목 동기화 실패 — 기존 캐시 데이터로 운영", exc_info=True)
 
 
-async def _init_context_factory(s: Services) -> None:
+def _init_context_factory(s: Services) -> None:
     """StrategyContextFactory 완성 (Broker/APIGateway 연결 이후)."""
     from ante.bot import StrategyContextFactory
     from ante.bot.providers.live import LiveTradeHistoryView
@@ -345,7 +345,7 @@ async def _init_context_factory(s: Services) -> None:
         logger.info("StrategyContextFactory 설정 완료")
 
 
-async def _init_treasury_sync(s: Services) -> None:
+def _init_treasury_sync(s: Services) -> None:
     """Treasury 잔고 동기화 시작 (Broker 연결 이후)."""
     if not s.broker:
         return
@@ -361,7 +361,7 @@ async def _init_treasury_sync(s: Services) -> None:
     )
 
     sync_interval = s.config.get("treasury.sync_interval_seconds", 300)
-    await s.treasury.start_sync(
+    s.treasury.start_sync(
         broker=s.broker,
         position_history=s.position_history,
         interval_seconds=sync_interval,
@@ -548,7 +548,7 @@ async def _shutdown(s: Services) -> None:
     logger.info("BotManager 종료 — 모든 봇 중지")
 
     if s.api_gateway:
-        await s.api_gateway.stop()
+        s.api_gateway.stop()
         logger.info("APIGateway 종료")
 
     if s.broker:

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1,12 +1,16 @@
 """Ante - AI-Native Trading Engine entrypoint.
 
 Composition Root: 모든 모듈을 조립하고 시스템을 부팅한다.
+각 _init_*() 함수가 독립적 초기화 단위를 담당하고,
+main()은 조율만 수행한다.
 """
 
 import asyncio
 import logging
 import signal
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from ante.config import Config, DynamicConfigService, SystemState
 from ante.core import Database
@@ -15,131 +19,151 @@ from ante.eventbus import EventBus, EventHistoryStore
 logger = logging.getLogger(__name__)
 
 
-async def main() -> None:
-    """Main asyncio entrypoint.
+@dataclass
+class Services:
+    """초기화된 서비스 인스턴스를 전달하는 컨테이너."""
 
-    초기화 순서 (architecture.md 참조):
-    1. Config + Logging
-    2. Database
-    3. EventBus + EventHistoryStore
-    4. SystemState (킬 스위치)
-    5. DynamicConfigService
-    6. StrategyRegistry
-    7. RuleEngine
-    8. Treasury
-    9. Trade (Recorder, PositionHistory, PerformanceTracker, Service)
-    10. BotManager
-    11. Broker (KISAdapter) + APIGateway
-    12. Data Pipeline (ParquetStore, DataCollector)
-    13. BacktestService
-    14. ReportStore
-    15. NotificationService
-    16. Web API (FastAPI)
+    config: Any = None
+    db: Database | None = None
+    eventbus: EventBus | None = None
+    event_history: EventHistoryStore | None = None
+    system_state: SystemState | None = None
+    dynamic_config: DynamicConfigService | None = None
+    audit_logger: Any = None
+    member_service: Any = None
+    instrument_service: Any = None
+    strategy_registry: Any = None
+    rule_engine: Any = None
+    treasury: Any = None
+    trade_recorder: Any = None
+    position_history: Any = None
+    performance_tracker: Any = None
+    trade_service: Any = None
+    bot_manager: Any = None
+    paper_executor: Any = None
+    live_portfolio: Any = None
+    live_order_view: Any = None
+    strategy_snapshot: Any = None
+    broker: Any = None
+    api_gateway: Any = None
+    data_provider: Any = None
+    parquet_store: Any = None
+    data_collector: Any = None
+    backtest_service: Any = None
+    report_store: Any = None
+    approval_service: Any = None
+    notification_service: Any = None
+    telegram_receiver: Any = None
+    web_task: asyncio.Task | None = None  # type: ignore[type-arg]
+    commission_rate: float = 0.00015
+    sell_tax_rate: float = 0.0023
+    _cleanup_tasks: list[str] = field(default_factory=list)
 
-    종료 순서: 역순 (상위 소비자부터 정리)
-    """
-    # ── 1. Config ────────────────────────────────────
-    config = Config.load()
-    config.validate()
 
-    log_level = config.get("system.log_level", "INFO")
+async def _init_core(s: Services) -> None:
+    """Config, Database, EventBus, SystemState, DynamicConfig 초기화."""
+    # Config
+    s.config = Config.load()
+    s.config.validate()
+
+    log_level = s.config.get("system.log_level", "INFO")
     logging.basicConfig(
         level=getattr(logging, log_level),
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
     logger.info("Ante 시작")
 
-    # ── 2. Database ──────────────────────────────────
-    db_path = config.get("db.path", "db/ante.db")
+    # Database
+    db_path = s.config.get("db.path", "db/ante.db")
     Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-    db = Database(db_path)
-    await db.connect()
+    s.db = Database(db_path)
+    await s.db.connect()
     logger.info("Database 연결 완료: %s", db_path)
 
-    # ── 3. EventBus ──────────────────────────────────
-    history_size = config.get("eventbus.history_size", 1000)
-    eventbus = EventBus(history_size=history_size)
-
-    event_history = EventHistoryStore(db=db)
-    await event_history.initialize()
-    eventbus.use(event_history.record)
+    # EventBus + EventHistoryStore
+    history_size = s.config.get("eventbus.history_size", 1000)
+    s.eventbus = EventBus(history_size=history_size)
+    s.event_history = EventHistoryStore(db=s.db)
+    await s.event_history.initialize()
+    s.eventbus.use(s.event_history.record)
     logger.info("EventBus 초기화 완료 (history_size=%d)", history_size)
 
-    # ── 4. SystemState (킬 스위치) ───────────────────
-    system_state = SystemState(db=db, eventbus=eventbus)
-    await system_state.initialize()
-    logger.info("SystemState 초기화 완료: %s", system_state.trading_state)
+    # SystemState (킬 스위치)
+    s.system_state = SystemState(db=s.db, eventbus=s.eventbus)
+    await s.system_state.initialize()
+    logger.info("SystemState 초기화 완료: %s", s.system_state.trading_state)
 
-    # ── 5. DynamicConfigService ──────────────────────
-    dynamic_config = DynamicConfigService(db=db, eventbus=eventbus)
-    await dynamic_config.initialize()
+    # DynamicConfigService
+    s.dynamic_config = DynamicConfigService(db=s.db, eventbus=s.eventbus)
+    await s.dynamic_config.initialize()
 
-    # log_level 동적 설정: 기본값 등록 + 변경 구독
     from ante.config.dynamic import _on_log_level_changed
     from ante.eventbus.events import ConfigChangedEvent
 
-    await dynamic_config.register_default(
+    await s.dynamic_config.register_default(
         "system.log_level", log_level, category="system"
     )
-    await dynamic_config.register_default(
+    await s.dynamic_config.register_default(
         "display.currency_position", "suffix", category="display"
     )
-    eventbus.subscribe(ConfigChangedEvent, _on_log_level_changed)
+    s.eventbus.subscribe(ConfigChangedEvent, _on_log_level_changed)
     logger.info("DynamicConfigService 초기화 완료")
 
-    # ── 5.5. AuditLogger ────────────────────────────────
+
+async def _init_services(s: Services) -> None:
+    """AuditLogger, MemberService, InstrumentService 초기화."""
     from ante.audit import AuditLogger
 
-    audit_logger = AuditLogger(db=db)
-    await audit_logger.initialize()
+    s.audit_logger = AuditLogger(db=s.db)
+    await s.audit_logger.initialize()
     logger.info("AuditLogger 초기화 완료")
 
-    # ── 5.6. MemberService ─────────────────────────────
     from ante.member import MemberService
 
-    member_service = MemberService(db=db, eventbus=eventbus)
-    await member_service.initialize()
+    s.member_service = MemberService(db=s.db, eventbus=s.eventbus)
+    await s.member_service.initialize()
     logger.info("MemberService 초기화 완료")
 
-    # ── 5.7. InstrumentService ─────────────────────────
     from ante.instrument import InstrumentService
 
-    instrument_service = InstrumentService(db=db)
-    await instrument_service.initialize()
+    s.instrument_service = InstrumentService(db=s.db)
+    await s.instrument_service.initialize()
 
-    # ── 6. StrategyRegistry ──────────────────────────
+
+async def _init_trading(s: Services) -> None:
+    """StrategyRegistry, RuleEngine, Treasury, Trade, BotManager 초기화."""
     from ante.strategy import StrategyRegistry
 
-    strategy_registry = StrategyRegistry(db=db)
-    await strategy_registry.initialize()
+    s.strategy_registry = StrategyRegistry(db=s.db)
+    await s.strategy_registry.initialize()
     logger.info("StrategyRegistry 초기화 완료")
 
-    # ── 7. RuleEngine ────────────────────────────────
+    # RuleEngine
     from ante.rule import RuleEngine
 
-    rule_engine = RuleEngine(eventbus=eventbus, system_state=system_state)
-    await rule_engine.start()
+    s.rule_engine = RuleEngine(eventbus=s.eventbus, system_state=s.system_state)
+    await s.rule_engine.start()
 
-    rule_configs = config.get("rules.global", [])
+    rule_configs = s.config.get("rules.global", [])
     if rule_configs:
-        rule_engine.load_rules_from_config(rule_configs)
+        s.rule_engine.load_rules_from_config(rule_configs)
     logger.info("RuleEngine 초기화 완료")
 
-    # ── 8. Treasury ──────────────────────────────────
+    # Treasury
     from ante.treasury import Treasury
 
-    commission_rate = config.get("broker.commission_rate", 0.00015)
-    sell_tax_rate = config.get("broker.sell_tax_rate", 0.0023)
-    treasury = Treasury(
-        db=db,
-        eventbus=eventbus,
-        commission_rate=commission_rate,
-        sell_tax_rate=sell_tax_rate,
+    s.commission_rate = s.config.get("broker.commission_rate", 0.00015)
+    s.sell_tax_rate = s.config.get("broker.sell_tax_rate", 0.0023)
+    s.treasury = Treasury(
+        db=s.db,
+        eventbus=s.eventbus,
+        commission_rate=s.commission_rate,
+        sell_tax_rate=s.sell_tax_rate,
     )
-    await treasury.initialize()
+    await s.treasury.initialize()
     logger.info("Treasury 초기화 완료")
 
-    # ── 9. Trade ─────────────────────────────────────
+    # Trade
     from ante.trade import (
         PerformanceTracker,
         PositionHistory,
@@ -147,323 +171,345 @@ async def main() -> None:
         TradeService,
     )
 
-    position_history = PositionHistory(db=db)
-    await position_history.initialize()
+    s.position_history = PositionHistory(db=s.db)
+    await s.position_history.initialize()
 
-    trade_recorder = TradeRecorder(db=db, position_history=position_history)
-    await trade_recorder.initialize()
-    trade_recorder.subscribe(eventbus)
+    s.trade_recorder = TradeRecorder(db=s.db, position_history=s.position_history)
+    await s.trade_recorder.initialize()
+    s.trade_recorder.subscribe(s.eventbus)
 
-    performance_tracker = PerformanceTracker(db=db)
+    s.performance_tracker = PerformanceTracker(db=s.db)
 
-    trade_service = TradeService(
-        recorder=trade_recorder,
-        position_history=position_history,
-        performance=performance_tracker,
+    s.trade_service = TradeService(
+        recorder=s.trade_recorder,
+        position_history=s.position_history,
+        performance=s.performance_tracker,
     )
     logger.info("Trade 모듈 초기화 완료")
 
-    # ── 10. BotManager + StrategyContextFactory ──────
-    from ante.bot import BotManager, StrategyContextFactory
+    # BotManager + StrategyContextFactory
+    from ante.bot import BotManager, StrategyContextFactory  # noqa: F401
     from ante.bot.providers.live import LiveOrderView, LivePortfolioView
     from ante.bot.providers.paper import PaperExecutor
-
-    # PaperExecutor (paper 봇이 존재할 때 가상 체결 처리)
-    paper_executor = PaperExecutor(
-        eventbus=eventbus,
-        gateway=None,  # APIGateway 연결 후 설정
-        commission_rate=commission_rate,
-        sell_tax_rate=sell_tax_rate,
-    )
-    paper_executor.subscribe()
-
-    # Live 프로바이더
-    live_portfolio = LivePortfolioView(
-        treasury=treasury,
-        position_history=position_history,
-    )
-    live_order_view = LiveOrderView(order_registry=None)  # Broker 연결 후 설정
-
-    # StrategyContextFactory
-
-    # DataProvider는 APIGateway 연결 후 설정 (11단계)
-    context_factory: StrategyContextFactory | None = None
-
     from ante.strategy.snapshot import StrategySnapshot
 
-    strategies_dir = Path(config.get("strategy.dir", "strategies"))
-    strategy_snapshot = StrategySnapshot(strategies_dir)
-
-    bot_manager = BotManager(
-        eventbus=eventbus,
-        db=db,
-        context_factory=context_factory,  # APIGateway 연결 후 갱신
-        snapshot=strategy_snapshot,
+    s.paper_executor = PaperExecutor(
+        eventbus=s.eventbus,
+        gateway=None,  # APIGateway 연결 후 설정
+        commission_rate=s.commission_rate,
+        sell_tax_rate=s.sell_tax_rate,
     )
-    await bot_manager.initialize()
+    s.paper_executor.subscribe()
+
+    s.live_portfolio = LivePortfolioView(
+        treasury=s.treasury,
+        position_history=s.position_history,
+    )
+    s.live_order_view = LiveOrderView(order_registry=None)  # Broker 연결 후 설정
+
+    strategies_dir = Path(s.config.get("strategy.dir", "strategies"))
+    s.strategy_snapshot = StrategySnapshot(strategies_dir)
+
+    s.bot_manager = BotManager(
+        eventbus=s.eventbus,
+        db=s.db,
+        context_factory=None,  # APIGateway 연결 후 갱신
+        snapshot=s.strategy_snapshot,
+    )
+    await s.bot_manager.initialize()
 
     # Treasury에 봇 상태 확인 콜백 연결
     def _get_bot_status(bot_id: str) -> str:
-        bot = bot_manager.get_bot(bot_id)
+        bot = s.bot_manager.get_bot(bot_id)
         return bot.status if bot else ""
 
-    treasury.set_bot_status_checker(_get_bot_status)
+    s.treasury.set_bot_status_checker(_get_bot_status)
     logger.info("BotManager 초기화 완료")
 
-    # ── 11. Broker + APIGateway ──────────────────────
+    # Broker + APIGateway
+    await _init_broker(s)
+
+    # StrategyContextFactory 완성 (Broker 연결 이후)
+    await _init_context_factory(s)
+
+    # Treasury 잔고 동기화 (Broker 연결 이후)
+    await _init_treasury_sync(s)
+
+
+async def _init_broker(s: Services) -> None:
+    """Broker, APIGateway 연결 및 종목 마스터 동기화."""
     from ante.gateway import APIGateway
 
-    broker = None
-    api_gateway = None
-
-    broker_config = config.get("broker", {})
+    broker_config = s.config.get("broker", {})
     broker_type = (
         broker_config.get("type", "kis") if isinstance(broker_config, dict) else "kis"
     )
 
     if broker_type == "mock":
-        from ante.broker.mock import MockBrokerAdapter
-
-        broker = MockBrokerAdapter(
-            broker_config if isinstance(broker_config, dict) else {}
-        )
-        await broker.connect()
-        logger.info("MockBrokerAdapter 연결 완료")
+        await _connect_mock_broker(s, broker_config)
     else:
-        from ante.broker import KISAdapter
+        await _connect_kis_broker(s, broker_config)
 
-        try:
-            broker_config["app_key"] = config.secret("KIS_APP_KEY")
-            broker_config["app_secret"] = config.secret("KIS_APP_SECRET")
-            broker_config["account_no"] = config.secret("KIS_ACCOUNT_NO")
-        except Exception:
-            pass  # 비밀값 없으면 브로커 미사용
-
-        if broker_config.get("app_key"):
-            broker = KISAdapter(config=broker_config, eventbus=eventbus)
-            try:
-                await broker.connect()
-                logger.info(
-                    "KISAdapter 연결 완료 (paper=%s)",
-                    broker_config.get("is_paper", True),
-                )
-            except Exception:
-                logger.warning("KISAdapter 연결 실패 — 브로커 없이 시작", exc_info=True)
-                broker = None
-
-    if broker:
-        api_gateway = APIGateway(broker=broker, eventbus=eventbus)
-        await api_gateway.start()
+    if s.broker:
+        s.api_gateway = APIGateway(broker=s.broker, eventbus=s.eventbus)
+        await s.api_gateway.start()
         logger.info("APIGateway 시작 완료")
 
-    # ── 11.1. 종목 마스터 동기화 ───────────────────────
-    if broker:
-        try:
-            raw_instruments = await broker.get_instruments()
-            if raw_instruments:
-                from ante.instrument.models import Instrument
+    if s.broker:
+        await _sync_instruments(s)
 
-                instruments_to_upsert = [
-                    Instrument(
-                        symbol=item["symbol"],
-                        exchange="KRX",
-                        name=item.get("name", ""),
-                        name_en=item.get("name_en", ""),
-                        instrument_type=item.get("instrument_type", ""),
-                        listed=item.get("listed", True),
-                    )
-                    for item in raw_instruments
-                ]
-                count = await instrument_service.bulk_upsert(instruments_to_upsert)
-                logger.info("종목 동기화 완료: %d건 갱신", count)
-        except Exception:
-            logger.warning("종목 동기화 실패 — 기존 캐시 데이터로 운영", exc_info=True)
 
-    # ── 11.5. StrategyContextFactory 완성 ─────────────
+async def _connect_mock_broker(s: Services, broker_config: dict) -> None:
+    """MockBrokerAdapter 연결."""
+    from ante.broker.mock import MockBrokerAdapter
+
+    s.broker = MockBrokerAdapter(
+        broker_config if isinstance(broker_config, dict) else {}
+    )
+    await s.broker.connect()
+    logger.info("MockBrokerAdapter 연결 완료")
+
+
+async def _connect_kis_broker(s: Services, broker_config: dict) -> None:
+    """KISAdapter 연결 (비밀값 없으면 건너뜀)."""
+    from ante.broker import KISAdapter
+
+    try:
+        broker_config["app_key"] = s.config.secret("KIS_APP_KEY")
+        broker_config["app_secret"] = s.config.secret("KIS_APP_SECRET")
+        broker_config["account_no"] = s.config.secret("KIS_ACCOUNT_NO")
+    except Exception:
+        return  # 비밀값 없으면 브로커 미사용
+
+    if not broker_config.get("app_key"):
+        return
+
+    s.broker = KISAdapter(config=broker_config, eventbus=s.eventbus)
+    try:
+        await s.broker.connect()
+        logger.info(
+            "KISAdapter 연결 완료 (paper=%s)",
+            broker_config.get("is_paper", True),
+        )
+    except Exception:
+        logger.warning("KISAdapter 연결 실패 — 브로커 없이 시작", exc_info=True)
+        s.broker = None
+
+
+async def _sync_instruments(s: Services) -> None:
+    """종목 마스터 동기화."""
+    try:
+        raw_instruments = await s.broker.get_instruments()
+        if not raw_instruments:
+            return
+        from ante.instrument.models import Instrument
+
+        instruments_to_upsert = [
+            Instrument(
+                symbol=item["symbol"],
+                exchange="KRX",
+                name=item.get("name", ""),
+                name_en=item.get("name_en", ""),
+                instrument_type=item.get("instrument_type", ""),
+                listed=item.get("listed", True),
+            )
+            for item in raw_instruments
+        ]
+        count = await s.instrument_service.bulk_upsert(instruments_to_upsert)
+        logger.info("종목 동기화 완료: %d건 갱신", count)
+    except Exception:
+        logger.warning("종목 동기화 실패 — 기존 캐시 데이터로 운영", exc_info=True)
+
+
+async def _init_context_factory(s: Services) -> None:
+    """StrategyContextFactory 완성 (Broker/APIGateway 연결 이후)."""
+    from ante.bot import StrategyContextFactory
+    from ante.bot.providers.live import LiveTradeHistoryView
     from ante.gateway.data_provider import LiveDataProvider
 
-    data_provider: LiveDataProvider | None = None
-    if api_gateway:
-        data_provider = LiveDataProvider(gateway=api_gateway)
-        paper_executor._gateway = api_gateway
+    if s.api_gateway:
+        s.data_provider = LiveDataProvider(gateway=s.api_gateway)
+        s.paper_executor._gateway = s.api_gateway
 
-    from ante.bot.providers.live import LiveTradeHistoryView
+    live_trade_history = LiveTradeHistoryView(trade_recorder=s.trade_recorder)
 
-    live_trade_history = LiveTradeHistoryView(trade_recorder=trade_recorder)
-
-    if data_provider:
+    if s.data_provider:
         context_factory = StrategyContextFactory(
-            data_provider=data_provider,
-            live_portfolio=live_portfolio,
-            live_order_view=live_order_view,
-            paper_executor=paper_executor,
+            data_provider=s.data_provider,
+            live_portfolio=s.live_portfolio,
+            live_order_view=s.live_order_view,
+            paper_executor=s.paper_executor,
             live_trade_history=live_trade_history,
         )
-        bot_manager._context_factory = context_factory
+        s.bot_manager._context_factory = context_factory
         logger.info("StrategyContextFactory 설정 완료")
 
-    # ── 11.6. Treasury 잔고 동기화 ────────────────────
-    if broker:
-        # KIS 계좌 메타 정보 전달
-        account_no = getattr(broker, "account_no", "")
-        is_paper = getattr(broker, "is_paper", False)
-        formatted_account = (
-            f"{account_no[:8]}-{account_no[8:]}"
-            if len(account_no) >= 10
-            else account_no
-        )
-        treasury.set_account_info(
-            account_number=formatted_account,
-            is_demo_trading=is_paper,
-        )
 
-        sync_interval = config.get("treasury.sync_interval_seconds", 300)
-        await treasury.start_sync(
-            broker=broker,
-            position_history=position_history,
-            interval_seconds=sync_interval,
-        )
-        logger.info("Treasury 잔고 동기화 시작 (주기: %d초)", sync_interval)
+async def _init_treasury_sync(s: Services) -> None:
+    """Treasury 잔고 동기화 시작 (Broker 연결 이후)."""
+    if not s.broker:
+        return
 
-    # ── 12. Data Pipeline ────────────────────────────
+    account_no = getattr(s.broker, "account_no", "")
+    is_paper = getattr(s.broker, "is_paper", False)
+    formatted_account = (
+        f"{account_no[:8]}-{account_no[8:]}" if len(account_no) >= 10 else account_no
+    )
+    s.treasury.set_account_info(
+        account_number=formatted_account,
+        is_demo_trading=is_paper,
+    )
+
+    sync_interval = s.config.get("treasury.sync_interval_seconds", 300)
+    await s.treasury.start_sync(
+        broker=s.broker,
+        position_history=s.position_history,
+        interval_seconds=sync_interval,
+    )
+    logger.info("Treasury 잔고 동기화 시작 (주기: %d초)", sync_interval)
+
+
+async def _init_feed(s: Services) -> None:
+    """Data Pipeline, BacktestService, ReportStore, ApprovalService 초기화."""
     from ante.data import DataCollector, ParquetStore
 
-    data_path = config.get("data.path", "data/")
+    data_path = s.config.get("data.path", "data/")
     Path(data_path).mkdir(parents=True, exist_ok=True)
-    parquet_store = ParquetStore(base_path=Path(data_path))
+    s.parquet_store = ParquetStore(base_path=Path(data_path))
 
-    data_collector = None
-    if api_gateway:
-        data_collector = DataCollector(store=parquet_store, eventbus=eventbus)  # noqa: F841
+    if s.api_gateway:
+        s.data_collector = DataCollector(store=s.parquet_store, eventbus=s.eventbus)
     logger.info("Data Pipeline 초기화 완료: %s", data_path)
 
-    # ── 13. BacktestService ──────────────────────────
+    # BacktestService
     from ante.backtest import BacktestService
 
-    backtest_service = BacktestService(data_path=data_path)  # noqa: F841
+    s.backtest_service = BacktestService(data_path=data_path)
     logger.info("BacktestService 초기화 완료")
 
-    # ── 14. ReportStore ──────────────────────────────
+    # ReportStore
     from ante.report import ReportStore
 
-    report_store = ReportStore(db=db)
-    await report_store.initialize()
+    s.report_store = ReportStore(db=s.db)
+    await s.report_store.initialize()
     logger.info("ReportStore 초기화 완료")
 
-    # ── 14.5. ApprovalService ──────────────────────────
+    # ApprovalService
     from ante.approval import ApprovalService
 
     approval_executors: dict = {
-        "strategy_adopt": lambda params: report_store.update_status(
+        "strategy_adopt": lambda params: s.report_store.update_status(
             params["report_id"], "adopted"
         ),
-        "bot_stop": lambda params: bot_manager.stop_bot(params["bot_id"]),
+        "bot_stop": lambda params: s.bot_manager.stop_bot(params["bot_id"]),
     }
-    approval_service = ApprovalService(  # noqa: F841
-        db=db, eventbus=eventbus, executors=approval_executors
+    s.approval_service = ApprovalService(
+        db=s.db, eventbus=s.eventbus, executors=approval_executors
     )
-    await approval_service.initialize()
+    await s.approval_service.initialize()
     logger.info("ApprovalService 초기화 완료")
 
-    # ── 15. NotificationService ──────────────────────
+
+async def _init_notification(s: Services) -> None:
+    """NotificationService, TelegramCommandReceiver 초기화."""
     from ante.notification import (
         NotificationLevel,
         NotificationService,
         TelegramAdapter,
     )
 
-    notification_service = None
-    telegram_token = config.secret("TELEGRAM_BOT_TOKEN")
-    telegram_chat_id = config.secret("TELEGRAM_CHAT_ID")
+    telegram_token = s.config.secret("TELEGRAM_BOT_TOKEN")
+    telegram_chat_id = s.config.secret("TELEGRAM_CHAT_ID")
 
-    if telegram_token and telegram_chat_id:
-        adapter = TelegramAdapter(bot_token=telegram_token, chat_id=telegram_chat_id)
-        min_level_str = config.get("notification.min_level", "info")
-        notification_service = NotificationService(
-            adapter=adapter,
-            eventbus=eventbus,
-            min_level=NotificationLevel(min_level_str),
-            instrument_service=instrument_service,
-            db=db,
-        )
-        await notification_service.initialize()
-        notification_service.subscribe()
-        logger.info("NotificationService 초기화 완료 (Telegram)")
-    else:
+    if not (telegram_token and telegram_chat_id):
         logger.info("NotificationService 건너뜀 — Telegram 설정 없음")
+        return
 
-    # ── 15.5. TelegramCommandReceiver ─────────────────
-    telegram_receiver = None
-    if telegram_token and telegram_chat_id:
-        from ante.notification import TelegramCommandReceiver
+    adapter = TelegramAdapter(bot_token=telegram_token, chat_id=telegram_chat_id)
+    min_level_str = s.config.get("notification.min_level", "info")
+    s.notification_service = NotificationService(
+        adapter=adapter,
+        eventbus=s.eventbus,
+        min_level=NotificationLevel(min_level_str),
+        instrument_service=s.instrument_service,
+        db=s.db,
+    )
+    await s.notification_service.initialize()
+    s.notification_service.subscribe()
+    logger.info("NotificationService 초기화 완료 (Telegram)")
 
-        allowed_ids_raw = config.get("telegram.command.allowed_user_ids", [])
-        allowed_user_ids = (
-            [int(uid) for uid in allowed_ids_raw] if allowed_ids_raw else []
+    # TelegramCommandReceiver
+    from ante.notification import TelegramCommandReceiver
+
+    allowed_ids_raw = s.config.get("telegram.command.allowed_user_ids", [])
+    allowed_user_ids = [int(uid) for uid in allowed_ids_raw] if allowed_ids_raw else []
+
+    if allowed_user_ids:
+        s.telegram_receiver = TelegramCommandReceiver(
+            adapter=adapter,
+            allowed_user_ids=allowed_user_ids,
+            polling_interval=s.config.get("telegram.command.polling_interval", 3.0),
+            confirm_timeout=s.config.get("telegram.command.confirm_timeout", 30.0),
+            bot_manager=s.bot_manager,
+            treasury=s.treasury,
+            system_state=s.system_state,
         )
+        s.telegram_receiver.start()
+        logger.info("TelegramCommandReceiver 시작")
+    else:
+        logger.info("TelegramCommandReceiver 건너뜀 — allowed_user_ids 비어있음")
 
-        if allowed_user_ids:
-            telegram_receiver = TelegramCommandReceiver(
-                adapter=adapter,
-                allowed_user_ids=allowed_user_ids,
-                polling_interval=config.get("telegram.command.polling_interval", 3.0),
-                confirm_timeout=config.get("telegram.command.confirm_timeout", 30.0),
-                bot_manager=bot_manager,
-                treasury=treasury,
-                system_state=system_state,
-            )
-            telegram_receiver.start()
-            logger.info("TelegramCommandReceiver 시작")
-        else:
-            logger.info("TelegramCommandReceiver 건너뜀 — allowed_user_ids 비어있음")
 
-    # ── 16. Web API ──────────────────────────────────
-    web_task = None
-    web_enabled = config.get("web.enabled", False)
+async def _init_web(s: Services) -> None:
+    """FastAPI 앱 생성 및 uvicorn 서버 시작."""
+    web_enabled = s.config.get("web.enabled", False)
+    if not web_enabled:
+        return
 
-    if web_enabled:
-        from ante.web.app import create_app
-        from ante.web.session import SessionService
+    from ante.web.app import create_app
+    from ante.web.session import SessionService
 
-        session_service = SessionService(db=db)
-        await session_service.initialize()
+    session_service = SessionService(db=s.db)
+    await session_service.initialize()
 
-        app = create_app(
-            config=config,
-            db=db,
-            eventbus=eventbus,
-            bot_manager=bot_manager,
-            trade_service=trade_service,
-            treasury=treasury,
-            broker=broker,
-            report_store=report_store,
-            data_store=parquet_store,
-            audit_logger=audit_logger,
-            member_service=member_service,
-            session_service=session_service,
-            strategy_registry=strategy_registry,
-            dynamic_config=dynamic_config,
-            approval_service=approval_service,
-            system_state=system_state,
-        )
+    app = create_app(
+        config=s.config,
+        db=s.db,
+        eventbus=s.eventbus,
+        bot_manager=s.bot_manager,
+        trade_service=s.trade_service,
+        treasury=s.treasury,
+        broker=s.broker,
+        report_store=s.report_store,
+        data_store=s.parquet_store,
+        audit_logger=s.audit_logger,
+        member_service=s.member_service,
+        session_service=session_service,
+        strategy_registry=s.strategy_registry,
+        dynamic_config=s.dynamic_config,
+        approval_service=s.approval_service,
+        system_state=s.system_state,
+    )
 
-        import uvicorn
+    import uvicorn
 
-        uv_config = uvicorn.Config(
-            app,
-            host=config.get("web.host", "0.0.0.0"),
-            port=config.get("web.port", 8000),
-            log_level="info",
-        )
-        server = uvicorn.Server(uv_config)
-        web_task = asyncio.create_task(server.serve(), name="web-api")
-        logger.info(
-            "Web API 시작: http://%s:%d",
-            uv_config.host,
-            uv_config.port,
-        )
+    uv_config = uvicorn.Config(
+        app,
+        host=s.config.get("web.host", "0.0.0.0"),
+        port=s.config.get("web.port", 8000),
+        log_level="info",
+    )
+    server = uvicorn.Server(uv_config)
+    s.web_task = asyncio.create_task(server.serve(), name="web-api")
+    logger.info(
+        "Web API 시작: http://%s:%d",
+        uv_config.host,
+        uv_config.port,
+    )
 
-    # ── Graceful Shutdown ────────────────────────────
+
+async def _run(s: Services) -> None:
+    """시그널 대기 및 Graceful Shutdown."""
     shutdown_event = asyncio.Event()
 
     def _signal_handler() -> None:
@@ -477,43 +523,64 @@ async def main() -> None:
     logger.info("Ante 준비 완료 — 종료 시그널 대기 중")
     await shutdown_event.wait()
 
-    # ── 종료 정리 (역순) ─────────────────────────────
+    await _shutdown(s)
+
+
+async def _shutdown(s: Services) -> None:
+    """종료 정리 (역순)."""
     logger.info("Ante 종료 시작")
 
-    # 15.5 TelegramCommandReceiver
-    if telegram_receiver:
-        await telegram_receiver.stop()
+    if s.telegram_receiver:
+        await s.telegram_receiver.stop()
         logger.info("TelegramCommandReceiver 종료")
 
-    # 16. Web API
-    if web_task and not web_task.done():
-        web_task.cancel()
+    if s.web_task and not s.web_task.done():
+        s.web_task.cancel()
         try:
-            await web_task
+            await s.web_task
         except asyncio.CancelledError:
             pass
         logger.info("Web API 종료")
 
-    # 10.5 Treasury 잔고 동기화 중지
-    await treasury.stop_sync()
+    await s.treasury.stop_sync()
 
-    # 10. BotManager (봇 먼저 중지)
-    await bot_manager.stop_all()
+    await s.bot_manager.stop_all()
     logger.info("BotManager 종료 — 모든 봇 중지")
 
-    # 11. APIGateway
-    if api_gateway:
-        await api_gateway.stop()
+    if s.api_gateway:
+        await s.api_gateway.stop()
         logger.info("APIGateway 종료")
 
-    # 11. Broker
-    if broker:
-        await broker.disconnect()
+    if s.broker:
+        await s.broker.disconnect()
         logger.info("Broker 연결 해제")
 
-    # 2. Database (최종)
-    await db.close()
+    await s.db.close()
     logger.info("Ante 종료 완료")
+
+
+async def main() -> None:
+    """Main asyncio entrypoint.
+
+    초기화 순서 (architecture.md 참조):
+    1. Core: Config, Database, EventBus, SystemState, DynamicConfig
+    2. Services: AuditLogger, MemberService, InstrumentService
+    3. Trading: Strategy, Rule, Treasury, Trade, Bot, Broker, Gateway
+    4. Feed: DataPipeline, Backtest, Report, Approval
+    5. Notification: Telegram
+    6. Web: FastAPI + uvicorn
+
+    종료 순서: 역순 (상위 소비자부터 정리)
+    """
+    s = Services()
+
+    await _init_core(s)
+    await _init_services(s)
+    await _init_trading(s)
+    await _init_feed(s)
+    await _init_notification(s)
+    await _init_web(s)
+    await _run(s)
 
 
 if __name__ == "__main__":

--- a/src/ante/member/__init__.py
+++ b/src/ante/member/__init__.py
@@ -1,6 +1,18 @@
 """Member — 멤버 등록·인증·관리."""
 
+from ante.member.auth_service import AuthService
 from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+from ante.member.recovery_key_manager import RecoveryKeyManager
 from ante.member.service import MemberService
+from ante.member.token_manager import TokenManager
 
-__all__ = ["Member", "MemberRole", "MemberService", "MemberStatus", "MemberType"]
+__all__ = [
+    "AuthService",
+    "Member",
+    "MemberRole",
+    "MemberService",
+    "MemberStatus",
+    "MemberType",
+    "RecoveryKeyManager",
+    "TokenManager",
+]

--- a/src/ante/member/auth_service.py
+++ b/src/ante/member/auth_service.py
@@ -1,0 +1,119 @@
+"""AuthService — 멤버 인증 (토큰·패스워드)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ante.member.auth import get_token_type, hash_token, verify_password
+from ante.member.models import Member, MemberStatus, MemberType
+from ante.member.token_manager import TokenManager
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+
+class AuthService:
+    """토큰·패스워드 기반 멤버 인증."""
+
+    def __init__(
+        self,
+        db: Database,
+        eventbus: EventBus,
+        token_manager: TokenManager,
+        get_member: object,
+    ) -> None:
+        self._db = db
+        self._eventbus = eventbus
+        self._token_manager = token_manager
+        # get_member는 MemberService.get을 주입받음
+        self._get_member = get_member
+
+    async def authenticate(self, token: str) -> Member:
+        """토큰으로 멤버 인증. 접두어 기반 타입 강제."""
+        token_type = get_token_type(token)
+        if token_type is None:
+            await self._publish_auth_failed("", "유효하지 않은 토큰 형식")
+            msg = "유효하지 않은 토큰 형식"
+            raise PermissionError(msg)
+
+        t_hash = hash_token(token)
+        row = await self._db.fetch_one(
+            "SELECT * FROM members WHERE token_hash = ?",
+            (t_hash,),
+        )
+        if not row:
+            await self._publish_auth_failed("", "토큰과 일치하는 멤버 없음")
+            msg = "인증 실패"
+            raise PermissionError(msg)
+
+        from ante.member.service import _row_to_member
+
+        member = _row_to_member(row)
+
+        if member.type != token_type:
+            await self._publish_auth_failed(
+                member.member_id, "토큰 접두어와 멤버 타입 불일치"
+            )
+            msg = f"{token_type} key로 {member.type} 멤버 인증 불가"
+            raise PermissionError(msg)
+
+        if member.status != MemberStatus.ACTIVE:
+            await self._publish_auth_failed(
+                member.member_id, f"비활성 멤버: {member.status}"
+            )
+            msg = f"비활성 멤버: {member.status}"
+            raise PermissionError(msg)
+
+        # 토큰 만료 체크
+        expiry_status = TokenManager.check_token_expiry(member)
+        if expiry_status == "expired":
+            await self._publish_auth_failed(member.member_id, "토큰 만료")
+            msg = "토큰이 만료되었습니다. 'ante member rotate-token'으로 갱신하세요."
+            raise PermissionError(msg)
+        if expiry_status == "expiring_soon":
+            logger.warning(
+                "토큰 만료 임박: %s (만료: %s)",
+                member.member_id,
+                member.token_expires_at,
+            )
+
+        return member
+
+    async def authenticate_password(self, member_id: str, password: str) -> Member:
+        """패스워드 인증 (human 대시보드 로그인)."""
+        member = await self._get_member(member_id)
+        if not member:
+            await self._publish_auth_failed(member_id, "존재하지 않는 멤버")
+            msg = "인증 실패"
+            raise PermissionError(msg)
+
+        if member.type != MemberType.HUMAN:
+            await self._publish_auth_failed(member_id, "human 전용 인증")
+            msg = "패스워드 인증은 human 멤버만 가능합니다"
+            raise PermissionError(msg)
+
+        if member.status != MemberStatus.ACTIVE:
+            await self._publish_auth_failed(member_id, f"비활성 멤버: {member.status}")
+            msg = f"비활성 멤버: {member.status}"
+            raise PermissionError(msg)
+
+        if not member.password_hash or not verify_password(
+            password, member.password_hash
+        ):
+            await self._publish_auth_failed(member_id, "패스워드 불일치")
+            msg = "인증 실패"
+            raise PermissionError(msg)
+
+        return member
+
+    async def _publish_auth_failed(self, member_id: str, reason: str) -> None:
+        """인증 실패 이벤트 발행."""
+        from ante.eventbus.events import MemberAuthFailedEvent
+
+        await self._eventbus.publish(
+            MemberAuthFailedEvent(member_id=member_id, reason=reason)
+        )

--- a/src/ante/member/recovery_key_manager.py
+++ b/src/ante/member/recovery_key_manager.py
@@ -1,0 +1,112 @@
+"""RecoveryKeyManager — 복구 키·패스워드 관리."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ante.member.auth import (
+    generate_recovery_key,
+    hash_password,
+    hash_recovery_key,
+    verify_password,
+    verify_recovery_key,
+)
+from ante.member.models import Member, MemberStatus, MemberType
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+
+class RecoveryKeyManager:
+    """복구 키 생성·검증·폐기 및 패스워드 관리."""
+
+    def __init__(
+        self,
+        db: Database,
+        eventbus: EventBus,
+    ) -> None:
+        self._db = db
+        self._eventbus = eventbus
+
+    async def change_password(
+        self, member: Member, old_password: str, new_password: str
+    ) -> None:
+        """패스워드 변경 (human만)."""
+        self._assert_human(member, "change_password")
+        self._assert_active(member, "change_password")
+
+        if not member.password_hash or not verify_password(
+            old_password, member.password_hash
+        ):
+            msg = "현재 패스워드가 일치하지 않습니다"
+            raise PermissionError(msg)
+
+        await self._db.execute(
+            "UPDATE members SET password_hash = ? WHERE member_id = ?",
+            (hash_password(new_password), member.member_id),
+        )
+        logger.info("패스워드 변경 완료: %s", member.member_id)
+
+    async def reset_password(
+        self, member: Member, recovery_key: str, new_password: str
+    ) -> None:
+        """recovery key로 패스워드 리셋 (human만)."""
+        self._assert_human(member, "reset_password")
+
+        if not member.recovery_key_hash or not verify_recovery_key(
+            recovery_key, member.recovery_key_hash
+        ):
+            await self._publish_auth_failed(member.member_id, "recovery key 불일치")
+            msg = "유효하지 않은 recovery key"
+            raise PermissionError(msg)
+
+        await self._db.execute(
+            "UPDATE members SET password_hash = ? WHERE member_id = ?",
+            (hash_password(new_password), member.member_id),
+        )
+        logger.info("패스워드 리셋 완료 (recovery key): %s", member.member_id)
+
+    async def regenerate_recovery_key(self, member: Member, password: str) -> str:
+        """복구 키 재발급. 현재 패스워드 확인 필수."""
+        self._assert_human(member, "regenerate_recovery_key")
+        self._assert_active(member, "regenerate_recovery_key")
+
+        if not member.password_hash or not verify_password(
+            password, member.password_hash
+        ):
+            msg = "현재 패스워드가 일치하지 않습니다"
+            raise PermissionError(msg)
+
+        recovery_key = generate_recovery_key()
+        await self._db.execute(
+            "UPDATE members SET recovery_key_hash = ? WHERE member_id = ?",
+            (hash_recovery_key(recovery_key), member.member_id),
+        )
+        logger.info("Recovery key 재발급 완료: %s", member.member_id)
+        return recovery_key
+
+    async def _publish_auth_failed(self, member_id: str, reason: str) -> None:
+        """인증 실패 이벤트 발행."""
+        from ante.eventbus.events import MemberAuthFailedEvent
+
+        await self._eventbus.publish(
+            MemberAuthFailedEvent(member_id=member_id, reason=reason)
+        )
+
+    @staticmethod
+    def _assert_human(member: Member, action: str) -> None:
+        """human 전용 검증."""
+        if member.type != MemberType.HUMAN:
+            msg = f"{action}은(는) human 멤버만 가능합니다"
+            raise PermissionError(msg)
+
+    @staticmethod
+    def _assert_active(member: Member, action: str) -> None:
+        """활성 상태 검증."""
+        if member.status != MemberStatus.ACTIVE:
+            msg = f"비활성 멤버는 {action}할 수 없습니다 (현재: {member.status})"
+            raise PermissionError(msg)

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_ORG = "default"
+
 MEMBER_SCHEMA = """
 CREATE TABLE IF NOT EXISTS members (
     member_id          TEXT PRIMARY KEY,
@@ -131,7 +133,7 @@ def _row_to_member(row: dict) -> Member:
         member_id=row["member_id"],
         type=row["type"],
         role=row["role"],
-        org=row.get("org", "default"),
+        org=row.get("org", _DEFAULT_ORG),
         name=row.get("name", ""),
         emoji=row.get("emoji", ""),
         status=row.get("status", MemberStatus.ACTIVE),
@@ -275,7 +277,7 @@ class MemberService:
             member_id=member_id,
             type=MemberType.HUMAN,
             role=MemberRole.MASTER,
-            org="default",
+            org=_DEFAULT_ORG,
             name=name or member_id,
             emoji=emoji,
             status=MemberStatus.ACTIVE,
@@ -331,7 +333,7 @@ class MemberService:
         member_id: str,
         member_type: str,
         role: str = MemberRole.DEFAULT,
-        org: str = "default",
+        org: str = _DEFAULT_ORG,
         name: str = "",
         emoji: str | None = None,
         scopes: list[str] | None = None,

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -1,25 +1,25 @@
-"""MemberService — 멤버 등록·인증·관리."""
+"""MemberService — 멤버 등록·조회·상태 관리."""
 
 from __future__ import annotations
 
 import json
 import logging
-import random
 import re
+import secrets
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from ante.member.auth import (
     generate_recovery_key,
-    generate_token,
-    get_token_type,
     hash_password,
     hash_recovery_key,
-    hash_token,
-    verify_password,
-    verify_recovery_key,
 )
+from ante.member.auth_service import AuthService
 from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+from ante.member.recovery_key_manager import RecoveryKeyManager
+from ante.member.token_manager import TokenManager, _token_expires_at
+
+__all__ = ["MemberService", "ANIMAL_EMOJI_POOL", "MEMBER_SCHEMA", "_token_expires_at"]
 
 if TYPE_CHECKING:
     from ante.core.database import Database
@@ -82,41 +82,41 @@ _EMOJI_RE = re.compile(
 )
 
 ANIMAL_EMOJI_POOL: list[str] = [
-    "🐶",
-    "🐱",
-    "🐻",
-    "🦊",
-    "🐼",
-    "🐨",
-    "🦁",
-    "🐯",
-    "🐸",
-    "🐵",
-    "🦄",
-    "🐳",
-    "🐙",
-    "🦉",
-    "🦋",
-    "🐧",
-    "🐺",
-    "🦈",
-    "🐝",
-    "🦜",
-    "🐢",
-    "🐬",
-    "🦅",
-    "🐲",
-    "🐴",
-    "🦩",
-    "🐿",
-    "🦔",
-    "🦇",
-    "🐞",
-    "🦀",
-    "🐘",
-    "🦒",
-    "🦘",
-    "🐊",
+    "\U0001f436",
+    "\U0001f431",
+    "\U0001f43b",
+    "\U0001f98a",
+    "\U0001f43c",
+    "\U0001f428",
+    "\U0001f981",
+    "\U0001f42f",
+    "\U0001f438",
+    "\U0001f435",
+    "\U0001f984",
+    "\U0001f433",
+    "\U0001f419",
+    "\U0001f989",
+    "\U0001f98b",
+    "\U0001f427",
+    "\U0001f43a",
+    "\U0001f988",
+    "\U0001f41d",
+    "\U0001f99c",
+    "\U0001f422",
+    "\U0001f42c",
+    "\U0001f985",
+    "\U0001f432",
+    "\U0001f434",
+    "\U0001f9a9",
+    "\U0001f43f",
+    "\U0001f994",
+    "\U0001f987",
+    "\U0001f41e",
+    "\U0001f980",
+    "\U0001f418",
+    "\U0001f992",
+    "\U0001f998",
+    "\U0001f40a",
 ]
 
 
@@ -153,15 +153,12 @@ def _now() -> str:
     return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
 
 
-def _token_expires_at(ttl_days: int) -> str:
-    """TTL 일수 기준 토큰 만료 시각."""
-    from datetime import timedelta
-
-    return (datetime.now(UTC) + timedelta(days=ttl_days)).strftime("%Y-%m-%d %H:%M:%S")
-
-
 class MemberService:
-    """멤버 등록·인증·관리 서비스."""
+    """멤버 등록·조회·상태 관리 서비스.
+
+    인증은 AuthService, 토큰은 TokenManager,
+    복구키·패스워드는 RecoveryKeyManager에 위임한다.
+    """
 
     def __init__(
         self,
@@ -172,6 +169,16 @@ class MemberService:
         self._db = db
         self._eventbus = eventbus
         self._token_ttl_days = token_ttl_days
+
+        # 하위 매니저 조립
+        self._token_manager = TokenManager(db, token_ttl_days)
+        self._auth_service = AuthService(
+            db=db,
+            eventbus=eventbus,
+            token_manager=self._token_manager,
+            get_member=self.get,
+        )
+        self._recovery_key_manager = RecoveryKeyManager(db=db, eventbus=eventbus)
 
     async def initialize(self) -> None:
         """스키마 생성 + 컬럼 마이그레이션."""
@@ -196,7 +203,7 @@ class MemberService:
         available = [e for e in ANIMAL_EMOJI_POOL if e not in used]
         if not available:
             return ""
-        return random.choice(available)  # noqa: S311
+        return secrets.choice(available)
 
     async def _validate_emoji_unique(
         self, emoji: str, exclude_member_id: str = ""
@@ -344,9 +351,8 @@ class MemberService:
             self._validate_emoji_format(emoji)
             await self._validate_emoji_unique(emoji)
 
-        token = generate_token(member_type)
+        token, t_hash, expires_at = self._token_manager.create_token(member_type)
         now = _now()
-        expires_at = _token_expires_at(self._token_ttl_days)
         scopes = scopes or []
 
         member = Member(
@@ -358,7 +364,7 @@ class MemberService:
             emoji=emoji,
             status=MemberStatus.ACTIVE,
             scopes=scopes,
-            token_hash=hash_token(token),
+            token_hash=t_hash,
             created_at=now,
             created_by=registered_by,
             token_expires_at=expires_at,
@@ -402,92 +408,15 @@ class MemberService:
         logger.info("멤버 등록 완료: %s (type=%s)", member.member_id, member.type)
         return member, token
 
-    # ── 인증 ───────────────────────────────────────────
+    # ── 인증 (AuthService 위임) ────────────────────────
 
     async def authenticate(self, token: str) -> Member:
-        """토큰으로 멤버 인증. 접두어 기반 타입 강제."""
-        token_type = get_token_type(token)
-        if token_type is None:
-            await self._publish_auth_failed("", "유효하지 않은 토큰 형식")
-            msg = "유효하지 않은 토큰 형식"
-            raise PermissionError(msg)
-
-        t_hash = hash_token(token)
-        row = await self._db.fetch_one(
-            "SELECT * FROM members WHERE token_hash = ?",
-            (t_hash,),
-        )
-        if not row:
-            await self._publish_auth_failed("", "토큰과 일치하는 멤버 없음")
-            msg = "인증 실패"
-            raise PermissionError(msg)
-
-        member = _row_to_member(row)
-
-        if member.type != token_type:
-            await self._publish_auth_failed(
-                member.member_id, "토큰 접두어와 멤버 타입 불일치"
-            )
-            msg = f"{token_type} key로 {member.type} 멤버 인증 불가"
-            raise PermissionError(msg)
-
-        if member.status != MemberStatus.ACTIVE:
-            await self._publish_auth_failed(
-                member.member_id, f"비활성 멤버: {member.status}"
-            )
-            msg = f"비활성 멤버: {member.status}"
-            raise PermissionError(msg)
-
-        # 토큰 만료 체크
-        if member.token_expires_at:
-            expires = datetime.strptime(  # noqa: DTZ007
-                member.token_expires_at, "%Y-%m-%d %H:%M:%S"
-            )
-            now = datetime.now(UTC).replace(tzinfo=None)
-            if now > expires:
-                await self._publish_auth_failed(member.member_id, "토큰 만료")
-                msg = (
-                    "토큰이 만료되었습니다. 'ante member rotate-token'으로 갱신하세요."
-                )
-                raise PermissionError(msg)
-
-            from datetime import timedelta
-
-            if now > expires - timedelta(days=7):
-                logger.warning(
-                    "토큰 만료 임박: %s (만료: %s)",
-                    member.member_id,
-                    member.token_expires_at,
-                )
-
-        return member
+        """토큰으로 멤버 인증."""
+        return await self._auth_service.authenticate(token)
 
     async def authenticate_password(self, member_id: str, password: str) -> Member:
         """패스워드 인증 (human 대시보드 로그인)."""
-        member = await self.get(member_id)
-        if not member:
-            await self._publish_auth_failed(member_id, "존재하지 않는 멤버")
-            msg = "인증 실패"
-            raise PermissionError(msg)
-
-        if member.type != MemberType.HUMAN:
-            await self._publish_auth_failed(member_id, "human 전용 인증")
-            msg = "패스워드 인증은 human 멤버만 가능합니다"
-            raise PermissionError(msg)
-
-        if member.status != MemberStatus.ACTIVE:
-            await self._publish_auth_failed(member_id, f"비활성 멤버: {member.status}")
-            msg = f"비활성 멤버: {member.status}"
-            raise PermissionError(msg)
-
-        if not member.password_hash or not verify_password(
-            password, member.password_hash
-        ):
-            await self._publish_auth_failed(member_id, "패스워드 불일치")
-            msg = "인증 실패"
-            raise PermissionError(msg)
-
-        return member
+        return await self._auth_service.authenticate_password(member_id, password)
 
     # ── 조회 ───────────────────────────────────────────
 
@@ -600,91 +529,41 @@ class MemberService:
         member.revoked_at = now
         return member
 
-    # ── 토큰 관리 ──────────────────────────────────────
+    # ── 토큰 관리 (TokenManager 위임) ──────────────────
 
     async def rotate_token(
         self, member_id: str, rotated_by: str = ""
     ) -> tuple[Member, str]:
-        """토큰 재발급. 기존 토큰 즉시 무효화. 새 TTL 적용."""
+        """토큰 재발급. 기존 토큰 즉시 무효화."""
         member = await self._get_or_raise(member_id)
-        self._assert_active(member, "rotate_token")
+        return await self._token_manager.rotate_token(member, rotated_by)
 
-        token = generate_token(member.type)
-        t_hash = hash_token(token)
-        expires_at = _token_expires_at(self._token_ttl_days)
-
-        await self._db.execute(
-            "UPDATE members SET token_hash = ?, token_expires_at = ? "
-            "WHERE member_id = ?",
-            (t_hash, expires_at, member_id),
-        )
-
-        logger.info("토큰 재발급: %s (by %s)", member_id, rotated_by)
-        member.token_hash = t_hash
-        member.token_expires_at = expires_at
-        return member, token
-
-    # ── 패스워드 관리 ──────────────────────────────────
+    # ── 패스워드·복구키 관리 (RecoveryKeyManager 위임) ─
 
     async def change_password(
         self, member_id: str, old_password: str, new_password: str
     ) -> None:
         """패스워드 변경 (human만)."""
         member = await self._get_or_raise(member_id)
-        self._assert_human(member, "change_password")
-        self._assert_active(member, "change_password")
-
-        if not member.password_hash or not verify_password(
-            old_password, member.password_hash
-        ):
-            msg = "현재 패스워드가 일치하지 않습니다"
-            raise PermissionError(msg)
-
-        await self._db.execute(
-            "UPDATE members SET password_hash = ? WHERE member_id = ?",
-            (hash_password(new_password), member_id),
+        await self._recovery_key_manager.change_password(
+            member, old_password, new_password
         )
-        logger.info("패스워드 변경 완료: %s", member_id)
 
     async def reset_password(
         self, member_id: str, recovery_key: str, new_password: str
     ) -> None:
         """recovery key로 패스워드 리셋 (human만)."""
         member = await self._get_or_raise(member_id)
-        self._assert_human(member, "reset_password")
-
-        if not member.recovery_key_hash or not verify_recovery_key(
-            recovery_key, member.recovery_key_hash
-        ):
-            await self._publish_auth_failed(member_id, "recovery key 불일치")
-            msg = "유효하지 않은 recovery key"
-            raise PermissionError(msg)
-
-        await self._db.execute(
-            "UPDATE members SET password_hash = ? WHERE member_id = ?",
-            (hash_password(new_password), member_id),
+        await self._recovery_key_manager.reset_password(
+            member, recovery_key, new_password
         )
-        logger.info("패스워드 리셋 완료 (recovery key): %s", member_id)
 
     async def regenerate_recovery_key(self, member_id: str, password: str) -> str:
-        """복구 키 재발급. 현재 패스워드 확인 필수."""
+        """복구 키 재발급."""
         member = await self._get_or_raise(member_id)
-        self._assert_human(member, "regenerate_recovery_key")
-        self._assert_active(member, "regenerate_recovery_key")
-
-        if not member.password_hash or not verify_password(
-            password, member.password_hash
-        ):
-            msg = "현재 패스워드가 일치하지 않습니다"
-            raise PermissionError(msg)
-
-        recovery_key = generate_recovery_key()
-        await self._db.execute(
-            "UPDATE members SET recovery_key_hash = ? WHERE member_id = ?",
-            (hash_recovery_key(recovery_key), member_id),
+        return await self._recovery_key_manager.regenerate_recovery_key(
+            member, password
         )
-        logger.info("Recovery key 재발급 완료: %s", member_id)
-        return recovery_key
 
     # ── 권한 관리 ──────────────────────────────────────
 
@@ -723,14 +602,6 @@ class MemberService:
             raise ValueError(msg)
         return member
 
-    async def _publish_auth_failed(self, member_id: str, reason: str) -> None:
-        """인증 실패 이벤트 발행."""
-        from ante.eventbus.events import MemberAuthFailedEvent
-
-        await self._eventbus.publish(
-            MemberAuthFailedEvent(member_id=member_id, reason=reason)
-        )
-
     @staticmethod
     def _assert_type_role(member_type: str, role: str) -> None:
         """타입-역할 불변식 검증."""
@@ -753,13 +624,6 @@ class MemberService:
         """활성 상태 검증."""
         if member.status != MemberStatus.ACTIVE:
             msg = f"비활성 멤버는 {action}할 수 없습니다 (현재: {member.status})"
-            raise PermissionError(msg)
-
-    @staticmethod
-    def _assert_human(member: Member, action: str) -> None:
-        """human 전용 검증."""
-        if member.type != MemberType.HUMAN:
-            msg = f"{action}은(는) human 멤버만 가능합니다"
             raise PermissionError(msg)
 
     @staticmethod

--- a/src/ante/member/token_manager.py
+++ b/src/ante/member/token_manager.py
@@ -1,0 +1,84 @@
+"""TokenManager — 토큰 생성·갱신·만료 관리."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from ante.member.auth import generate_token, hash_token
+from ante.member.models import Member, MemberStatus
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+
+logger = logging.getLogger(__name__)
+
+
+def _token_expires_at(ttl_days: int) -> str:
+    """TTL 일수 기준 토큰 만료 시각."""
+    return (datetime.now(UTC) + timedelta(days=ttl_days)).strftime("%Y-%m-%d %H:%M:%S")
+
+
+class TokenManager:
+    """토큰 생성·갱신·만료 관리."""
+
+    def __init__(self, db: Database, token_ttl_days: int = 90) -> None:
+        self._db = db
+        self._token_ttl_days = token_ttl_days
+
+    @property
+    def token_ttl_days(self) -> int:
+        """토큰 TTL 일수."""
+        return self._token_ttl_days
+
+    def create_token(self, member_type: str) -> tuple[str, str, str]:
+        """새 토큰 생성. (raw_token, token_hash, expires_at) 반환."""
+        token = generate_token(member_type)
+        t_hash = hash_token(token)
+        expires_at = _token_expires_at(self._token_ttl_days)
+        return token, t_hash, expires_at
+
+    async def rotate_token(
+        self, member: Member, rotated_by: str = ""
+    ) -> tuple[Member, str]:
+        """토큰 재발급. 기존 토큰 즉시 무효화. 새 TTL 적용."""
+        if member.status != MemberStatus.ACTIVE:
+            msg = f"비활성 멤버는 rotate_token할 수 없습니다 (현재: {member.status})"
+            raise PermissionError(msg)
+
+        token, t_hash, expires_at = self.create_token(member.type)
+
+        await self._db.execute(
+            "UPDATE members SET token_hash = ?, token_expires_at = ? "
+            "WHERE member_id = ?",
+            (t_hash, expires_at, member.member_id),
+        )
+
+        logger.info("토큰 재발급: %s (by %s)", member.member_id, rotated_by)
+        member.token_hash = t_hash
+        member.token_expires_at = expires_at
+        return member, token
+
+    @staticmethod
+    def check_token_expiry(member: Member) -> str | None:
+        """토큰 만료 상태 확인.
+
+        Returns:
+            None — 정상
+            "expired" — 만료됨
+            "expiring_soon" — 7일 이내 만료 임박
+        """
+        if not member.token_expires_at:
+            return None
+
+        expires = datetime.strptime(  # noqa: DTZ007
+            member.token_expires_at, "%Y-%m-%d %H:%M:%S"
+        )
+        now = datetime.now(UTC).replace(tzinfo=None)
+
+        if now > expires:
+            return "expired"
+        if now > expires - timedelta(days=7):
+            return "expiring_soon"
+        return None

--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -83,7 +83,7 @@ class TelegramCommandReceiver:
                 for update in updates:
                     await self._handle_update(update)
             except asyncio.CancelledError:
-                break
+                raise
             except Exception:
                 logger.warning("텔레그램 폴링 실패, 다음 주기에 재시도", exc_info=True)
 

--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time as time_mod
+from inspect import isawaitable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -188,7 +189,10 @@ class TelegramCommandReceiver:
 
         handler = handlers.get(command)
         if handler:
-            return await handler(args)
+            result = handler(args)
+            if isawaitable(result):
+                return await result
+            return result
 
         return "알 수 없는 명령입니다. /help를 입력해 주세요."
 
@@ -232,7 +236,7 @@ class TelegramCommandReceiver:
 
     # ── 명령 핸들러 ─────────────────────────────────
 
-    async def _cmd_help(self, args: list[str]) -> str:
+    def _cmd_help(self, args: list[str]) -> str:
         """사용 가능한 명령어 목록."""
         return (
             "사용 가능한 명령어:\n"
@@ -245,7 +249,7 @@ class TelegramCommandReceiver:
             "/help — 이 도움말"
         )
 
-    async def _cmd_status(self, args: list[str]) -> str:
+    def _cmd_status(self, args: list[str]) -> str:
         """시스템 상태 요약."""
         parts = []
 
@@ -263,7 +267,7 @@ class TelegramCommandReceiver:
 
         return "\n".join(parts)
 
-    async def _cmd_bots(self, args: list[str]) -> str:
+    def _cmd_bots(self, args: list[str]) -> str:
         """봇 목록."""
         if not self._bot_manager:
             return "BotManager가 연결되지 않았습니다."
@@ -281,7 +285,7 @@ class TelegramCommandReceiver:
 
         return "봇 목록:\n" + "\n".join(lines)
 
-    async def _cmd_balance(self, args: list[str]) -> str:
+    def _cmd_balance(self, args: list[str]) -> str:
         """자금 현황."""
         if not self._treasury:
             return "Treasury가 연결되지 않았습니다."

--- a/src/ante/report/draft.py
+++ b/src/ante/report/draft.py
@@ -24,7 +24,7 @@ class ReportDraftGenerator:
         self._store = report_store
         self._eventbus = eventbus
 
-    async def initialize(self) -> None:
+    def initialize(self) -> None:
         """EventBus에 핸들러 등록."""
         from ante.eventbus.events import BacktestCompleteEvent
 

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -59,7 +59,7 @@ class RuleEngine:
         self._global_rules: list[Rule] = []
         self._strategy_rules: dict[str, list[Rule]] = {}
 
-    async def start(self) -> None:
+    def start(self) -> None:
         """EventBus 구독 등록."""
         from ante.eventbus.events import (
             ConfigChangedEvent,
@@ -385,7 +385,10 @@ class RuleEngine:
             )
 
     async def _on_config_changed(self, event: object) -> None:
-        """설정 변경 시 룰 재로딩 트리거."""
+        """설정 변경 시 룰 재로딩 트리거.
+
+        Note: EventBus 핸들러 — isawaitable 패턴을 위해 async def 유지.
+        """
         from ante.eventbus.events import ConfigChangedEvent
 
         if not isinstance(event, ConfigChangedEvent):

--- a/src/ante/strategy/base.py
+++ b/src/ante/strategy/base.py
@@ -151,6 +151,7 @@ class Strategy(ABC):
         ...
 
     # ── 이벤트 핸들러 (선택) ──
+    # 서브클래스에서 override하여 async 작업을 수행할 수 있으므로 async def 유지
 
     async def on_fill(self, fill: dict[str, Any]) -> list[Signal]:
         """주문 체결 통보."""

--- a/src/ante/trade/performance.py
+++ b/src/ante/trade/performance.py
@@ -21,6 +21,17 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# SQL query fragments reused in daily/weekly/monthly summary methods
+_COND_STATUS_FILLED = "t.status = ?"
+_COND_SIDE_SELL = "t.side = 'sell'"
+_COND_BOT_ID = "t.bot_id = ?"
+_JOIN_POSITION_HISTORY = """LEFT JOIN position_history ph
+                ON ph.bot_id = t.bot_id
+                AND ph.symbol = t.symbol
+                AND ph.action = 'sell'
+                AND ph.price = t.price
+                AND ph.quantity = t.quantity"""
+
 
 class PerformanceTracker:
     """봇/전략의 성과 지표를 조회 시 계산."""
@@ -99,13 +110,13 @@ class PerformanceTracker:
             end_date: 종료일 (YYYY-MM-DD)
         """
         conditions: list[str] = [
-            "t.status = ?",
-            "t.side = 'sell'",
+            _COND_STATUS_FILLED,
+            _COND_SIDE_SELL,
         ]
         params: list[Any] = [TradeStatus.FILLED.value]
 
         if bot_id:
-            conditions.append("t.bot_id = ?")
+            conditions.append(_COND_BOT_ID)
             params.append(bot_id)
         if start_date:
             conditions.append("date(t.timestamp) >= ?")
@@ -122,12 +133,7 @@ class PerformanceTracker:
                 COUNT(*) AS trade_count,
                 SUM(CASE WHEN ph.pnl > 0 THEN 1 ELSE 0 END) AS win_count
             FROM trades t
-            LEFT JOIN position_history ph
-                ON ph.bot_id = t.bot_id
-                AND ph.symbol = t.symbol
-                AND ph.action = 'sell'
-                AND ph.price = t.price
-                AND ph.quantity = t.quantity
+            {_JOIN_POSITION_HISTORY}
             WHERE {where}
             GROUP BY trade_date
             ORDER BY trade_date ASC
@@ -160,13 +166,13 @@ class PerformanceTracker:
             bot_id: 봇 ID 필터 (None이면 전체)
         """
         conditions: list[str] = [
-            "t.status = ?",
-            "t.side = 'sell'",
+            _COND_STATUS_FILLED,
+            _COND_SIDE_SELL,
         ]
         params: list[Any] = [TradeStatus.FILLED.value]
 
         if bot_id:
-            conditions.append("t.bot_id = ?")
+            conditions.append(_COND_BOT_ID)
             params.append(bot_id)
 
         where = " AND ".join(conditions)
@@ -178,12 +184,7 @@ class PerformanceTracker:
                 COUNT(*) AS trade_count,
                 SUM(CASE WHEN ph.pnl > 0 THEN 1 ELSE 0 END) AS win_count
             FROM trades t
-            LEFT JOIN position_history ph
-                ON ph.bot_id = t.bot_id
-                AND ph.symbol = t.symbol
-                AND ph.action = 'sell'
-                AND ph.price = t.price
-                AND ph.quantity = t.quantity
+            {_JOIN_POSITION_HISTORY}
             WHERE {where}
             GROUP BY week_start
             ORDER BY week_start ASC
@@ -217,13 +218,13 @@ class PerformanceTracker:
             year: 연도 필터 (None이면 전체)
         """
         conditions: list[str] = [
-            "t.status = ?",
-            "t.side = 'sell'",
+            _COND_STATUS_FILLED,
+            _COND_SIDE_SELL,
         ]
         params: list[Any] = [TradeStatus.FILLED.value]
 
         if bot_id:
-            conditions.append("t.bot_id = ?")
+            conditions.append(_COND_BOT_ID)
             params.append(bot_id)
         if year:
             conditions.append("strftime('%Y', t.timestamp) = ?")
@@ -238,12 +239,7 @@ class PerformanceTracker:
                 COUNT(*) AS trade_count,
                 SUM(CASE WHEN ph.pnl > 0 THEN 1 ELSE 0 END) AS win_count
             FROM trades t
-            LEFT JOIN position_history ph
-                ON ph.bot_id = t.bot_id
-                AND ph.symbol = t.symbol
-                AND ph.action = 'sell'
-                AND ph.price = t.price
-                AND ph.quantity = t.quantity
+            {_JOIN_POSITION_HISTORY}
             WHERE {where}
             GROUP BY yr, mo
             ORDER BY yr ASC, mo ASC

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -184,12 +184,12 @@ class Treasury:
 
     # ── 예산 조회 ───────────────────────────────────
 
-    async def get_available(self, bot_id: str) -> float:
+    def get_available(self, bot_id: str) -> float:
         """봇의 가용 예산 조회."""
         budget = self._budgets.get(bot_id)
         return budget.available if budget else 0.0
 
-    async def get_budget(self, bot_id: str) -> BotBudget | None:
+    def get_budget(self, bot_id: str) -> BotBudget | None:
         """봇의 예산 상태 조회."""
         return self._budgets.get(bot_id)
 
@@ -316,7 +316,7 @@ class Treasury:
                 event.bot_id, event.order_id, total_reserve
             )
             if not success:
-                available = await self.get_available(event.bot_id)
+                available = self.get_available(event.bot_id)
                 await self._eventbus.publish(
                     OrderRejectedEvent(
                         order_id=event.order_id,
@@ -444,7 +444,7 @@ class Treasury:
 
     # ── 잔고 동기화 ────────────────────────────────
 
-    async def start_sync(
+    def start_sync(
         self,
         broker: BrokerAdapter,
         position_history: PositionHistory,

--- a/src/ante/web/deps.py
+++ b/src/ante/web/deps.py
@@ -1,0 +1,170 @@
+"""Web API 공통 의존성 함수.
+
+모든 라우트 핸들러는 getattr(request.app.state, ...) 대신
+이 모듈의 의존성 함수를 Annotated[Type, Depends(...)] 형태로 사용한다.
+
+필수 의존성: 서비스가 없으면 HTTPException 503을 발생시킨다.
+선택적 의존성: 서비스가 없으면 None을 반환한다.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException, Request
+
+# ── 필수 의존성 ─────────────────────────────────────────
+
+
+def get_approval_service(request: Request) -> Any:
+    """결재 서비스 (필수)."""
+    svc = getattr(request.app.state, "approval_service", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Approval service not available")
+    return svc
+
+
+def get_audit_logger(request: Request) -> Any:
+    """감사 로거 (필수)."""
+    svc = getattr(request.app.state, "audit_logger", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Audit logger not available")
+    return svc
+
+
+def get_bot_manager(request: Request) -> Any:
+    """봇 매니저 (필수)."""
+    svc = getattr(request.app.state, "bot_manager", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Bot manager not available")
+    return svc
+
+
+def get_strategy_registry(request: Request) -> Any:
+    """전략 레지스트리 (필수)."""
+    svc = getattr(request.app.state, "strategy_registry", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Strategy registry not available")
+    return svc
+
+
+def get_treasury(request: Request) -> Any:
+    """자금 관리 (필수)."""
+    svc = getattr(request.app.state, "treasury", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Treasury not available")
+    return svc
+
+
+def get_trade_service(request: Request) -> Any:
+    """거래 서비스 (필수)."""
+    svc = getattr(request.app.state, "trade_service", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Trade service not available")
+    return svc
+
+
+def get_report_store(request: Request) -> Any:
+    """리포트 저장소 (필수)."""
+    svc = getattr(request.app.state, "report_store", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Report store not available")
+    return svc
+
+
+def get_dynamic_config(request: Request) -> Any:
+    """동적 설정 서비스 (필수)."""
+    svc = getattr(request.app.state, "dynamic_config", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Config service not available")
+    return svc
+
+
+def get_system_state(request: Request) -> Any:
+    """시스템 상태 (필수)."""
+    svc = getattr(request.app.state, "system_state", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="System state not available")
+    return svc
+
+
+def get_notification_service(request: Request) -> Any:
+    """알림 서비스 (필수)."""
+    svc = getattr(request.app.state, "notification_service", None)
+    if svc is None:
+        raise HTTPException(
+            status_code=503, detail="Notification service not available"
+        )
+    return svc
+
+
+def get_member_service(request: Request) -> Any:
+    """멤버 서비스 (필수)."""
+    svc = getattr(request.app.state, "member_service", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Member service not available")
+    return svc
+
+
+def get_session_service(request: Request) -> Any:
+    """세션 서비스 (필수)."""
+    svc = getattr(request.app.state, "session_service", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Session service not available")
+    return svc
+
+
+def get_db(request: Request) -> Any:
+    """데이터베이스 (필수)."""
+    db = getattr(request.app.state, "db", None)
+    if db is None:
+        raise HTTPException(status_code=503, detail="Database not available")
+    return db
+
+
+# ── 선택적 의존성 ───────────────────────────────────────
+
+
+def get_data_store(request: Request) -> Any | None:
+    """데이터 저장소 (선택적). 없으면 None."""
+    return getattr(request.app.state, "data_store", None)
+
+
+def get_bot_manager_optional(request: Request) -> Any | None:
+    """봇 매니저 (선택적). 없으면 None."""
+    return getattr(request.app.state, "bot_manager", None)
+
+
+def get_strategy_registry_optional(request: Request) -> Any | None:
+    """전략 레지스트리 (선택적). 없으면 None."""
+    return getattr(request.app.state, "strategy_registry", None)
+
+
+def get_treasury_optional(request: Request) -> Any | None:
+    """자금 관리 (선택적). 없으면 None."""
+    return getattr(request.app.state, "treasury", None)
+
+
+def get_trade_service_optional(request: Request) -> Any | None:
+    """거래 서비스 (선택적). 없으면 None."""
+    return getattr(request.app.state, "trade_service", None)
+
+
+def get_report_store_optional(request: Request) -> Any | None:
+    """리포트 저장소 (선택적). 없으면 None."""
+    return getattr(request.app.state, "report_store", None)
+
+
+def get_system_state_optional(request: Request) -> Any | None:
+    """시스템 상태 (선택적). 없으면 None."""
+    return getattr(request.app.state, "system_state", None)
+
+
+def get_config(request: Request) -> Any | None:
+    """앱 설정 (선택적). 없으면 None."""
+    return getattr(request.app.state, "config", None)
+
+
+def get_broker(request: Request) -> Any | None:
+    """브로커 (선택적). 없으면 None."""
+    return getattr(request.app.state, "broker", None)

--- a/src/ante/web/routes/approvals.py
+++ b/src/ante/web/routes/approvals.py
@@ -28,7 +28,11 @@ class ApprovalStatusUpdate(BaseModel):
     memo: str = ""
 
 
-@router.get("", response_model=ApprovalListResponse)
+@router.get(
+    "",
+    response_model=ApprovalListResponse,
+    responses={503: {"description": "Approval service not available"}},
+)
 async def list_approvals(
     approval_service: Annotated[Any, Depends(get_approval_service)],
     status: str | None = Query(default=None),
@@ -47,7 +51,14 @@ async def list_approvals(
     }
 
 
-@router.get("/{approval_id}", response_model=ApprovalDetailResponse)
+@router.get(
+    "/{approval_id}",
+    response_model=ApprovalDetailResponse,
+    responses={
+        404: {"description": "Approval not found"},
+        503: {"description": "Approval service not available"},
+    },
+)
 async def get_approval(
     approval_id: str,
     approval_service: Annotated[Any, Depends(get_approval_service)],
@@ -71,7 +82,15 @@ async def get_approval(
     return result
 
 
-@router.patch("/{approval_id}/status", response_model=ApprovalUpdateResponse)
+@router.patch(
+    "/{approval_id}/status",
+    response_model=ApprovalUpdateResponse,
+    responses={
+        400: {"description": "Invalid status value"},
+        404: {"description": "Approval not found"},
+        503: {"description": "Approval service not available"},
+    },
+)
 async def update_approval_status(
     approval_id: str,
     body: ApprovalStatusUpdate,

--- a/src/ante/web/routes/approvals.py
+++ b/src/ante/web/routes/approvals.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import asdict
+from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
+from ante.web.deps import get_approval_service, get_report_store_optional
 from ante.web.schemas import (
     ApprovalDetailResponse,
     ApprovalListResponse,
@@ -28,15 +30,13 @@ class ApprovalStatusUpdate(BaseModel):
 
 @router.get("", response_model=ApprovalListResponse)
 async def list_approvals(
-    request: Request,
+    approval_service: Annotated[Any, Depends(get_approval_service)],
     status: str | None = Query(default=None),
     type: str | None = Query(default=None),
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=20, ge=1, le=100),
 ) -> dict:
     """결재 목록 조회."""
-    approval_service = request.app.state.approval_service
-
     approvals = await approval_service.list(
         status=status, type=type, limit=limit, offset=offset
     )
@@ -48,10 +48,12 @@ async def list_approvals(
 
 
 @router.get("/{approval_id}", response_model=ApprovalDetailResponse)
-async def get_approval(request: Request, approval_id: str) -> dict:
+async def get_approval(
+    approval_id: str,
+    approval_service: Annotated[Any, Depends(get_approval_service)],
+    report_store: Annotated[Any | None, Depends(get_report_store_optional)],
+) -> dict:
     """결재 상세 조회."""
-    approval_service = request.app.state.approval_service
-
     approval = await approval_service.get(approval_id)
     if not approval:
         raise HTTPException(status_code=404, detail="결재 요청을 찾을 수 없습니다")
@@ -59,8 +61,7 @@ async def get_approval(request: Request, approval_id: str) -> dict:
     result: dict = {"approval": asdict(approval)}
 
     # 전략 리포트 유형이면 report_detail 포함
-    if approval.reference_id and hasattr(request.app.state, "report_store"):
-        report_store = request.app.state.report_store
+    if approval.reference_id and report_store is not None:
         report = await report_store.get(approval.reference_id)
         if report:
             result["report_detail"] = (
@@ -72,13 +73,11 @@ async def get_approval(request: Request, approval_id: str) -> dict:
 
 @router.patch("/{approval_id}/status", response_model=ApprovalUpdateResponse)
 async def update_approval_status(
-    request: Request,
     approval_id: str,
     body: ApprovalStatusUpdate,
+    approval_service: Annotated[Any, Depends(get_approval_service)],
 ) -> dict:
     """결재 승인/거부 처리."""
-    approval_service = request.app.state.approval_service
-
     try:
         if body.status == "approved":
             approval = await approval_service.approve(

--- a/src/ante/web/routes/audit.py
+++ b/src/ante/web/routes/audit.py
@@ -12,7 +12,11 @@ from ante.web.schemas import AuditLogListResponse
 router = APIRouter()
 
 
-@router.get("", response_model=AuditLogListResponse)
+@router.get(
+    "",
+    response_model=AuditLogListResponse,
+    responses={503: {"description": "Audit logger not available"}},
+)
 async def list_audit_logs(
     audit_logger: Annotated[Any, Depends(get_audit_logger)],
     member_id: str | None = None,

--- a/src/ante/web/routes/audit.py
+++ b/src/ante/web/routes/audit.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Request
+from typing import Annotated, Any
 
+from fastapi import APIRouter, Depends
+
+from ante.web.deps import get_audit_logger
 from ante.web.schemas import AuditLogListResponse
 
 router = APIRouter()
@@ -11,17 +14,13 @@ router = APIRouter()
 
 @router.get("", response_model=AuditLogListResponse)
 async def list_audit_logs(
-    request: Request,
+    audit_logger: Annotated[Any, Depends(get_audit_logger)],
     member_id: str | None = None,
     action: str | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> dict:
     """감사 로그 조회."""
-    audit_logger = getattr(request.app.state, "audit_logger", None)
-    if audit_logger is None:
-        raise HTTPException(status_code=503, detail="Audit logger not available")
-
     logs = await audit_logger.query(
         member_id=member_id,
         action=action,

--- a/src/ante/web/routes/auth.py
+++ b/src/ante/web/routes/auth.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import logging
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Cookie, HTTPException, Request, Response
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response
 
+from ante.web.deps import get_member_service, get_session_service
 from ante.web.schemas import LoginRequest, LoginResponse, LogoutResponse, MeResponse
 
 logger = logging.getLogger(__name__)
@@ -18,12 +20,13 @@ COOKIE_MAX_AGE = 86400  # 24시간
 
 @router.post("/login", response_model=LoginResponse)
 async def login(
-    body: LoginRequest, request: Request, response: Response
+    body: LoginRequest,
+    request: Request,
+    response: Response,
+    member_service: Annotated[Any, Depends(get_member_service)],
+    session_service: Annotated[Any, Depends(get_session_service)],
 ) -> LoginResponse:
     """패스워드 로그인 -> 세션 쿠키 발급."""
-    member_service = request.app.state.member_service
-    session_service = request.app.state.session_service
-
     try:
         member = await member_service.authenticate_password(
             body.member_id, body.password
@@ -62,13 +65,12 @@ async def login(
 
 @router.post("/logout", response_model=LogoutResponse)
 async def logout(
-    request: Request,
     response: Response,
+    session_service: Annotated[Any, Depends(get_session_service)],
     ante_session: str | None = Cookie(default=None),
 ) -> dict:
     """로그아웃 — 세션 삭제 + 쿠키 제거."""
     if ante_session:
-        session_service = request.app.state.session_service
         await session_service.delete(ante_session)
 
     response.delete_cookie(key=COOKIE_NAME)
@@ -77,19 +79,18 @@ async def logout(
 
 @router.get("/me", response_model=MeResponse)
 async def me(
-    request: Request,
+    member_service: Annotated[Any, Depends(get_member_service)],
+    session_service: Annotated[Any, Depends(get_session_service)],
     ante_session: str | None = Cookie(default=None),
 ) -> MeResponse:
     """현재 로그인 사용자 정보."""
     if not ante_session:
         raise HTTPException(status_code=401, detail="인증이 필요합니다")
 
-    session_service = request.app.state.session_service
     session = await session_service.validate(ante_session)
     if not session:
         raise HTTPException(status_code=401, detail="세션이 만료되었습니다")
 
-    member_service = request.app.state.member_service
     member = await member_service.get(session["member_id"])
     if not member:
         raise HTTPException(status_code=401, detail="사용자를 찾을 수 없습니다")

--- a/src/ante/web/routes/auth.py
+++ b/src/ante/web/routes/auth.py
@@ -18,7 +18,14 @@ COOKIE_NAME = "ante_session"
 COOKIE_MAX_AGE = 86400  # 24시간
 
 
-@router.post("/login", response_model=LoginResponse)
+@router.post(
+    "/login",
+    response_model=LoginResponse,
+    responses={
+        401: {"description": "Invalid credentials"},
+        503: {"description": "Member or session service not available"},
+    },
+)
 async def login(
     body: LoginRequest,
     request: Request,
@@ -63,7 +70,11 @@ async def login(
     )
 
 
-@router.post("/logout", response_model=LogoutResponse)
+@router.post(
+    "/logout",
+    response_model=LogoutResponse,
+    responses={503: {"description": "Session service not available"}},
+)
 async def logout(
     response: Response,
     session_service: Annotated[Any, Depends(get_session_service)],
@@ -77,7 +88,14 @@ async def logout(
     return {"ok": True}
 
 
-@router.get("/me", response_model=MeResponse)
+@router.get(
+    "/me",
+    response_model=MeResponse,
+    responses={
+        401: {"description": "Not authenticated or session expired"},
+        503: {"description": "Member or session service not available"},
+    },
+)
 async def me(
     member_service: Annotated[Any, Depends(get_member_service)],
     session_service: Annotated[Any, Depends(get_session_service)],

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -31,7 +31,11 @@ class BotCreateRequest(BaseModel):
     interval_seconds: int = Field(default=60, ge=10, le=3600)
 
 
-@router.get("", response_model=BotListResponse)
+@router.get(
+    "",
+    response_model=BotListResponse,
+    responses={503: {"description": "Bot manager not available"}},
+)
 async def list_bots(
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     limit: int = 20,
@@ -45,7 +49,17 @@ async def list_bots(
     return {"bots": result["items"], "next_cursor": result["next_cursor"]}
 
 
-@router.post("", status_code=201, response_model=BotDetailResponse)
+@router.post(
+    "",
+    status_code=201,
+    response_model=BotDetailResponse,
+    responses={
+        400: {"description": "Strategy loading failed"},
+        404: {"description": "Strategy not found"},
+        409: {"description": "Bot already exists or conflict"},
+        503: {"description": "Bot manager or strategy registry not available"},
+    },
+)
 async def create_bot(
     body: BotCreateRequest,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
@@ -87,7 +101,14 @@ async def create_bot(
     return {"bot": bot.get_info()}
 
 
-@router.get("/{bot_id}", response_model=BotDetailResponse)
+@router.get(
+    "/{bot_id}",
+    response_model=BotDetailResponse,
+    responses={
+        404: {"description": "Bot not found"},
+        503: {"description": "Bot manager not available"},
+    },
+)
 async def get_bot(
     bot_id: str,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
@@ -142,7 +163,15 @@ async def get_bot(
     return {"bot": info}
 
 
-@router.post("/{bot_id}/start", response_model=BotDetailResponse)
+@router.post(
+    "/{bot_id}/start",
+    response_model=BotDetailResponse,
+    responses={
+        404: {"description": "Bot not found"},
+        409: {"description": "Bot state conflict"},
+        503: {"description": "Bot manager not available"},
+    },
+)
 async def start_bot(
     bot_id: str,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
@@ -162,7 +191,15 @@ async def start_bot(
     return {"bot": bot.get_info()}
 
 
-@router.post("/{bot_id}/stop", response_model=BotDetailResponse)
+@router.post(
+    "/{bot_id}/stop",
+    response_model=BotDetailResponse,
+    responses={
+        404: {"description": "Bot not found"},
+        409: {"description": "Bot state conflict"},
+        503: {"description": "Bot manager not available"},
+    },
+)
 async def stop_bot(
     bot_id: str,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
@@ -182,7 +219,15 @@ async def stop_bot(
     return {"bot": bot.get_info()}
 
 
-@router.delete("/{bot_id}", status_code=204)
+@router.delete(
+    "/{bot_id}",
+    status_code=204,
+    responses={
+        404: {"description": "Bot not found"},
+        409: {"description": "Bot state conflict"},
+        503: {"description": "Bot manager not available"},
+    },
+)
 async def delete_bot(
     bot_id: str,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -113,7 +113,7 @@ async def get_bot(
 
     # 예산 정보 추가
     if treasury is not None:
-        budget = await treasury.get_budget(bot_id)
+        budget = treasury.get_budget(bot_id)
         if budget:
             info["budget"] = {
                 "allocated": budget.allocated,

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -18,6 +18,8 @@ from ante.web.schemas import BotDetailResponse, BotListResponse
 
 router = APIRouter()
 
+_BOT_NOT_FOUND = "봇을 찾을 수 없습니다"
+
 
 class BotCreateRequest(BaseModel):
     """봇 생성 요청."""
@@ -96,7 +98,7 @@ async def get_bot(
     """봇 상세 조회."""
     bot = bot_manager.get_bot(bot_id)
     if bot is None:
-        raise HTTPException(status_code=404, detail="봇을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_BOT_NOT_FOUND)
 
     info = bot.get_info()
 
@@ -150,7 +152,7 @@ async def start_bot(
 
     bot = bot_manager.get_bot(bot_id)
     if bot is None:
-        raise HTTPException(status_code=404, detail="봇을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_BOT_NOT_FOUND)
 
     try:
         await bot_manager.start_bot(bot_id)
@@ -170,7 +172,7 @@ async def stop_bot(
 
     bot = bot_manager.get_bot(bot_id)
     if bot is None:
-        raise HTTPException(status_code=404, detail="봇을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_BOT_NOT_FOUND)
 
     try:
         await bot_manager.stop_bot(bot_id)
@@ -190,7 +192,7 @@ async def delete_bot(
 
     bot = bot_manager.get_bot(bot_id)
     if bot is None:
-        raise HTTPException(status_code=404, detail="봇을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_BOT_NOT_FOUND)
 
     try:
         await bot_manager.delete_bot(bot_id)

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Request
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
+from ante.web.deps import (
+    get_bot_manager,
+    get_strategy_registry,
+    get_strategy_registry_optional,
+    get_trade_service_optional,
+    get_treasury_optional,
+)
 from ante.web.schemas import BotDetailResponse, BotListResponse
 
 router = APIRouter()
@@ -22,16 +31,12 @@ class BotCreateRequest(BaseModel):
 
 @router.get("", response_model=BotListResponse)
 async def list_bots(
-    request: Request,
+    bot_manager: Annotated[Any, Depends(get_bot_manager)],
     limit: int = 20,
     cursor: str | None = None,
 ) -> dict:
     """봇 목록 조회 (cursor 기반 페이지네이션)."""
     from ante.web.pagination import paginate
-
-    bot_manager = getattr(request.app.state, "bot_manager", None)
-    if bot_manager is None:
-        raise HTTPException(status_code=503, detail="Bot manager not available")
 
     bots = bot_manager.list_bots()
     result = paginate(bots, cursor_field="bot_id", limit=limit, cursor=cursor)
@@ -39,21 +44,17 @@ async def list_bots(
 
 
 @router.post("", status_code=201, response_model=BotDetailResponse)
-async def create_bot(request: Request, body: BotCreateRequest) -> dict:
+async def create_bot(
+    body: BotCreateRequest,
+    bot_manager: Annotated[Any, Depends(get_bot_manager)],
+    registry: Annotated[Any, Depends(get_strategy_registry)],
+) -> dict:
     """봇 생성."""
     from pathlib import Path
 
     from ante.bot.config import BotConfig
     from ante.bot.exceptions import BotError
     from ante.strategy.loader import StrategyLoader
-
-    bot_manager = getattr(request.app.state, "bot_manager", None)
-    if bot_manager is None:
-        raise HTTPException(status_code=503, detail="Bot manager not available")
-
-    registry = getattr(request.app.state, "strategy_registry", None)
-    if registry is None:
-        raise HTTPException(status_code=503, detail="Strategy registry not available")
 
     record = await registry.get(body.strategy_id)
     if not record:
@@ -85,12 +86,14 @@ async def create_bot(request: Request, body: BotCreateRequest) -> dict:
 
 
 @router.get("/{bot_id}", response_model=BotDetailResponse)
-async def get_bot(request: Request, bot_id: str) -> dict:
+async def get_bot(
+    bot_id: str,
+    bot_manager: Annotated[Any, Depends(get_bot_manager)],
+    registry: Annotated[Any | None, Depends(get_strategy_registry_optional)],
+    treasury: Annotated[Any | None, Depends(get_treasury_optional)],
+    trade_service: Annotated[Any | None, Depends(get_trade_service_optional)],
+) -> dict:
     """봇 상세 조회."""
-    bot_manager = getattr(request.app.state, "bot_manager", None)
-    if bot_manager is None:
-        raise HTTPException(status_code=503, detail="Bot manager not available")
-
     bot = bot_manager.get_bot(bot_id)
     if bot is None:
         raise HTTPException(status_code=404, detail="봇을 찾을 수 없습니다")
@@ -98,7 +101,6 @@ async def get_bot(request: Request, bot_id: str) -> dict:
     info = bot.get_info()
 
     # 전략 정보 추가
-    registry = getattr(request.app.state, "strategy_registry", None)
     if registry is not None:
         record = await registry.get(info.get("strategy_id", ""))
         if record:
@@ -110,7 +112,6 @@ async def get_bot(request: Request, bot_id: str) -> dict:
             }
 
     # 예산 정보 추가
-    treasury = getattr(request.app.state, "treasury", None)
     if treasury is not None:
         budget = await treasury.get_budget(bot_id)
         if budget:
@@ -122,7 +123,6 @@ async def get_bot(request: Request, bot_id: str) -> dict:
             }
 
     # 포지션 정보 추가
-    trade_service = getattr(request.app.state, "trade_service", None)
     if trade_service is not None:
         positions = await trade_service.get_positions(
             bot_id=bot_id, include_closed=True
@@ -141,13 +141,12 @@ async def get_bot(request: Request, bot_id: str) -> dict:
 
 
 @router.post("/{bot_id}/start", response_model=BotDetailResponse)
-async def start_bot(request: Request, bot_id: str) -> dict:
+async def start_bot(
+    bot_id: str,
+    bot_manager: Annotated[Any, Depends(get_bot_manager)],
+) -> dict:
     """봇 시작."""
     from ante.bot.exceptions import BotError
-
-    bot_manager = getattr(request.app.state, "bot_manager", None)
-    if bot_manager is None:
-        raise HTTPException(status_code=503, detail="Bot manager not available")
 
     bot = bot_manager.get_bot(bot_id)
     if bot is None:
@@ -162,13 +161,12 @@ async def start_bot(request: Request, bot_id: str) -> dict:
 
 
 @router.post("/{bot_id}/stop", response_model=BotDetailResponse)
-async def stop_bot(request: Request, bot_id: str) -> dict:
+async def stop_bot(
+    bot_id: str,
+    bot_manager: Annotated[Any, Depends(get_bot_manager)],
+) -> dict:
     """봇 중지."""
     from ante.bot.exceptions import BotError
-
-    bot_manager = getattr(request.app.state, "bot_manager", None)
-    if bot_manager is None:
-        raise HTTPException(status_code=503, detail="Bot manager not available")
 
     bot = bot_manager.get_bot(bot_id)
     if bot is None:
@@ -183,13 +181,12 @@ async def stop_bot(request: Request, bot_id: str) -> dict:
 
 
 @router.delete("/{bot_id}", status_code=204)
-async def delete_bot(request: Request, bot_id: str) -> None:
+async def delete_bot(
+    bot_id: str,
+    bot_manager: Annotated[Any, Depends(get_bot_manager)],
+) -> None:
     """봇 삭제."""
     from ante.bot.exceptions import BotError
-
-    bot_manager = getattr(request.app.state, "bot_manager", None)
-    if bot_manager is None:
-        raise HTTPException(status_code=503, detail="Bot manager not available")
 
     bot = bot_manager.get_bot(bot_id)
     if bot is None:

--- a/src/ante/web/routes/config.py
+++ b/src/ante/web/routes/config.py
@@ -20,7 +20,11 @@ class ConfigUpdateRequest(BaseModel):
     category: str = ""
 
 
-@router.get("", response_model=ConfigListResponse)
+@router.get(
+    "",
+    response_model=ConfigListResponse,
+    responses={503: {"description": "Config service not available"}},
+)
 async def list_configs(
     config_service: Annotated[Any, Depends(get_dynamic_config)],
 ) -> dict:
@@ -29,7 +33,14 @@ async def list_configs(
     return {"configs": configs}
 
 
-@router.put("/{key:path}", response_model=ConfigUpdateResponse)
+@router.put(
+    "/{key:path}",
+    response_model=ConfigUpdateResponse,
+    responses={
+        404: {"description": "Config key not found"},
+        503: {"description": "Config service not available"},
+    },
+)
 async def update_config(
     key: str,
     body: ConfigUpdateRequest,

--- a/src/ante/web/routes/config.py
+++ b/src/ante/web/routes/config.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from ante.web.deps import get_dynamic_config
 from ante.web.schemas import ConfigListResponse, ConfigUpdateResponse
 
 router = APIRouter()
@@ -20,23 +21,21 @@ class ConfigUpdateRequest(BaseModel):
 
 
 @router.get("", response_model=ConfigListResponse)
-async def list_configs(request: Request) -> dict:
+async def list_configs(
+    config_service: Annotated[Any, Depends(get_dynamic_config)],
+) -> dict:
     """동적 설정 전체 조회."""
-    config_service = getattr(request.app.state, "dynamic_config", None)
-    if config_service is None:
-        raise HTTPException(status_code=503, detail="Config service not available")
-
     configs = await config_service.get_all()
     return {"configs": configs}
 
 
 @router.put("/{key:path}", response_model=ConfigUpdateResponse)
-async def update_config(request: Request, key: str, body: ConfigUpdateRequest) -> dict:
+async def update_config(
+    key: str,
+    body: ConfigUpdateRequest,
+    config_service: Annotated[Any, Depends(get_dynamic_config)],
+) -> dict:
     """동적 설정 값 변경."""
-    config_service = getattr(request.app.state, "dynamic_config", None)
-    if config_service is None:
-        raise HTTPException(status_code=503, detail="Config service not available")
-
     if not await config_service.exists(key):
         raise HTTPException(status_code=404, detail=f"설정을 찾을 수 없습니다: {key}")
 

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import logging
 import shutil
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query
 
+from ante.web.deps import get_data_store
 from ante.web.schemas import (
     DataSchemaResponse,
     DatasetListResponse,
@@ -24,7 +26,7 @@ DATA_TYPES = ["ohlcv", "fundamental"]
 
 @router.get("/datasets", response_model=DatasetListResponse)
 async def list_datasets(
-    request: Request,
+    store: Annotated[Any | None, Depends(get_data_store)],
     symbol: str | None = None,
     timeframe: str | None = None,
     data_type: str = Query("ohlcv", description="데이터 유형 (ohlcv, fundamental)"),
@@ -37,7 +39,6 @@ async def list_datasets(
     Returns:
         {items: [...], total: int}
     """
-    store = getattr(request.app.state, "data_store", None)
     if store is None:
         return {"items": [], "total": 0}
 
@@ -90,7 +91,6 @@ async def list_datasets(
 
 @router.get("/schema", response_model=DataSchemaResponse)
 async def get_data_schema(
-    request: Request,
     data_type: str = Query("ohlcv", description="데이터 유형 (ohlcv, fundamental)"),
 ) -> dict:
     """데이터 스키마 조회. data_type에 따라 해당 스키마를 반환."""
@@ -105,9 +105,10 @@ async def get_data_schema(
 
 
 @router.get("/storage", response_model=StorageSummaryResponse)
-async def get_storage_summary(request: Request) -> dict:
+async def get_storage_summary(
+    store: Annotated[Any | None, Depends(get_data_store)],
+) -> dict:
     """저장 용량 현황."""
-    store = getattr(request.app.state, "data_store", None)
     if store is None:
         return {"total_bytes": 0, "total_mb": 0.0, "by_timeframe": {}}
     usage = store.get_storage_usage()
@@ -123,8 +124,8 @@ async def get_storage_summary(request: Request) -> dict:
 
 @router.delete("/datasets/{dataset_id}", status_code=204)
 async def delete_dataset(
-    request: Request,
     dataset_id: str,
+    store: Annotated[Any | None, Depends(get_data_store)],
     data_type: str = Query("ohlcv", description="데이터 유형 (ohlcv, fundamental)"),
 ) -> None:
     """데이터셋 삭제.
@@ -132,9 +133,6 @@ async def delete_dataset(
     dataset_id 형식: "{symbol}__{timeframe}" (예: "005930__1d")
     fundamental의 경우: "{symbol}__fundamental" (예: "005930__fundamental")
     """
-    from fastapi import HTTPException
-
-    store = getattr(request.app.state, "data_store", None)
     if store is None:
         raise HTTPException(status_code=503, detail="Data store not available")
 
@@ -158,7 +156,9 @@ async def delete_dataset(
 
 
 @router.get("/feed-status", response_model=FeedStatusResponse)
-async def get_feed_status(request: Request) -> dict:
+async def get_feed_status(
+    store: Annotated[Any | None, Depends(get_data_store)],
+) -> dict:
     """Feed 파이프라인 상태 조회.
 
     Feed 초기화 여부, 소스별 체크포인트 현황, 최근 리포트 요약,
@@ -167,7 +167,6 @@ async def get_feed_status(request: Request) -> dict:
     import json
     from pathlib import Path
 
-    store = getattr(request.app.state, "data_store", None)
     data_path: Path | None = getattr(store, "base_path", None) if store else None
 
     result: dict = {

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -122,7 +122,15 @@ async def get_storage_summary(
     }
 
 
-@router.delete("/datasets/{dataset_id}", status_code=204)
+@router.delete(
+    "/datasets/{dataset_id}",
+    status_code=204,
+    responses={
+        400: {"description": "Invalid dataset_id format"},
+        404: {"description": "Dataset not found"},
+        503: {"description": "Data store not available"},
+    },
+)
 async def delete_dataset(
     dataset_id: str,
     store: Annotated[Any | None, Depends(get_data_store)],

--- a/src/ante/web/routes/members.py
+++ b/src/ante/web/routes/members.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import asdict
+from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
+from ante.web.deps import get_member_service
 from ante.web.schemas import (
     MemberCreateResponse,
     MemberDetailResponse,
@@ -43,16 +45,9 @@ class ScopesUpdateRequest(BaseModel):
     scopes: list[str]
 
 
-def _get_member_service(request: Request):
-    svc = getattr(request.app.state, "member_service", None)
-    if svc is None:
-        raise HTTPException(status_code=503, detail="Member service not available")
-    return svc
-
-
 @router.get("", response_model=MemberListResponse)
 async def list_members(
-    request: Request,
+    svc: Annotated[Any, Depends(get_member_service)],
     type: str | None = Query(default=None),
     org: str | None = Query(default=None),
     status: str | None = Query(default=None),
@@ -60,7 +55,6 @@ async def list_members(
     offset: int = Query(default=0, ge=0),
 ) -> dict:
     """멤버 목록 조회."""
-    svc = _get_member_service(request)
     members = await svc.list(
         member_type=type, org=org, status=status, limit=limit, offset=offset
     )
@@ -68,10 +62,11 @@ async def list_members(
 
 
 @router.post("", status_code=201, response_model=MemberCreateResponse)
-async def create_member(request: Request, body: MemberCreateRequest) -> dict:
+async def create_member(
+    body: MemberCreateRequest,
+    svc: Annotated[Any, Depends(get_member_service)],
+) -> dict:
     """멤버 등록. 토큰 1회 반환."""
-    svc = _get_member_service(request)
-
     try:
         member, token = await svc.register(
             member_id=body.member_id,
@@ -91,9 +86,11 @@ async def create_member(request: Request, body: MemberCreateRequest) -> dict:
 
 
 @router.get("/{member_id}", response_model=MemberDetailResponse)
-async def get_member(request: Request, member_id: str) -> dict:
+async def get_member(
+    member_id: str,
+    svc: Annotated[Any, Depends(get_member_service)],
+) -> dict:
     """멤버 상세 조회."""
-    svc = _get_member_service(request)
     member = await svc.get(member_id)
     if member is None:
         raise HTTPException(status_code=404, detail="멤버를 찾을 수 없습니다")
@@ -101,9 +98,11 @@ async def get_member(request: Request, member_id: str) -> dict:
 
 
 @router.post("/{member_id}/suspend", response_model=MemberDetailResponse)
-async def suspend_member(request: Request, member_id: str) -> dict:
+async def suspend_member(
+    member_id: str,
+    svc: Annotated[Any, Depends(get_member_service)],
+) -> dict:
     """멤버 일시 정지."""
-    svc = _get_member_service(request)
     try:
         member = await svc.suspend(member_id, suspended_by="dashboard")
     except ValueError as e:
@@ -114,9 +113,11 @@ async def suspend_member(request: Request, member_id: str) -> dict:
 
 
 @router.post("/{member_id}/reactivate", response_model=MemberDetailResponse)
-async def reactivate_member(request: Request, member_id: str) -> dict:
+async def reactivate_member(
+    member_id: str,
+    svc: Annotated[Any, Depends(get_member_service)],
+) -> dict:
     """멤버 재활성화."""
-    svc = _get_member_service(request)
     try:
         member = await svc.reactivate(member_id, reactivated_by="dashboard")
     except ValueError as e:
@@ -127,9 +128,11 @@ async def reactivate_member(request: Request, member_id: str) -> dict:
 
 
 @router.post("/{member_id}/revoke", response_model=MemberDetailResponse)
-async def revoke_member(request: Request, member_id: str) -> dict:
+async def revoke_member(
+    member_id: str,
+    svc: Annotated[Any, Depends(get_member_service)],
+) -> dict:
     """멤버 영구 폐기."""
-    svc = _get_member_service(request)
     try:
         member = await svc.revoke(member_id, revoked_by="dashboard")
     except ValueError as e:
@@ -140,9 +143,11 @@ async def revoke_member(request: Request, member_id: str) -> dict:
 
 
 @router.post("/{member_id}/rotate-token", response_model=MemberTokenResponse)
-async def rotate_token(request: Request, member_id: str) -> dict:
+async def rotate_token(
+    member_id: str,
+    svc: Annotated[Any, Depends(get_member_service)],
+) -> dict:
     """토큰 재발급."""
-    svc = _get_member_service(request)
     try:
         member, token = await svc.rotate_token(member_id, rotated_by="dashboard")
     except ValueError as e:
@@ -154,10 +159,11 @@ async def rotate_token(request: Request, member_id: str) -> dict:
 
 @router.patch("/{member_id}/password", response_model=OkResponse)
 async def change_password(
-    request: Request, member_id: str, body: PasswordChangeRequest
+    member_id: str,
+    body: PasswordChangeRequest,
+    svc: Annotated[Any, Depends(get_member_service)],
 ) -> dict:
     """비밀번호 변경 (human 멤버 전용)."""
-    svc = _get_member_service(request)
     try:
         await svc.change_password(member_id, body.old_password, body.new_password)
     except ValueError as e:
@@ -169,10 +175,11 @@ async def change_password(
 
 @router.put("/{member_id}/scopes", response_model=MemberScopesResponse)
 async def update_scopes(
-    request: Request, member_id: str, body: ScopesUpdateRequest
+    member_id: str,
+    body: ScopesUpdateRequest,
+    svc: Annotated[Any, Depends(get_member_service)],
 ) -> dict:
     """권한 범위 변경."""
-    svc = _get_member_service(request)
     try:
         member = await svc.update_scopes(member_id, body.scopes, updated_by="dashboard")
     except ValueError as e:

--- a/src/ante/web/routes/members.py
+++ b/src/ante/web/routes/members.py
@@ -45,7 +45,11 @@ class ScopesUpdateRequest(BaseModel):
     scopes: list[str]
 
 
-@router.get("", response_model=MemberListResponse)
+@router.get(
+    "",
+    response_model=MemberListResponse,
+    responses={503: {"description": "Member service not available"}},
+)
 async def list_members(
     svc: Annotated[Any, Depends(get_member_service)],
     type: str | None = Query(default=None),
@@ -61,7 +65,16 @@ async def list_members(
     return {"members": [asdict(m) for m in members], "total": len(members)}
 
 
-@router.post("", status_code=201, response_model=MemberCreateResponse)
+@router.post(
+    "",
+    status_code=201,
+    response_model=MemberCreateResponse,
+    responses={
+        400: {"description": "Invalid member data"},
+        403: {"description": "Permission denied"},
+        503: {"description": "Member service not available"},
+    },
+)
 async def create_member(
     body: MemberCreateRequest,
     svc: Annotated[Any, Depends(get_member_service)],
@@ -85,7 +98,14 @@ async def create_member(
     return {"member": asdict(member), "token": token}
 
 
-@router.get("/{member_id}", response_model=MemberDetailResponse)
+@router.get(
+    "/{member_id}",
+    response_model=MemberDetailResponse,
+    responses={
+        404: {"description": "Member not found"},
+        503: {"description": "Member service not available"},
+    },
+)
 async def get_member(
     member_id: str,
     svc: Annotated[Any, Depends(get_member_service)],
@@ -97,7 +117,15 @@ async def get_member(
     return {"member": asdict(member)}
 
 
-@router.post("/{member_id}/suspend", response_model=MemberDetailResponse)
+@router.post(
+    "/{member_id}/suspend",
+    response_model=MemberDetailResponse,
+    responses={
+        403: {"description": "Permission denied"},
+        404: {"description": "Member not found"},
+        503: {"description": "Member service not available"},
+    },
+)
 async def suspend_member(
     member_id: str,
     svc: Annotated[Any, Depends(get_member_service)],
@@ -112,7 +140,15 @@ async def suspend_member(
     return {"member": asdict(member)}
 
 
-@router.post("/{member_id}/reactivate", response_model=MemberDetailResponse)
+@router.post(
+    "/{member_id}/reactivate",
+    response_model=MemberDetailResponse,
+    responses={
+        403: {"description": "Permission denied"},
+        404: {"description": "Member not found"},
+        503: {"description": "Member service not available"},
+    },
+)
 async def reactivate_member(
     member_id: str,
     svc: Annotated[Any, Depends(get_member_service)],
@@ -127,7 +163,15 @@ async def reactivate_member(
     return {"member": asdict(member)}
 
 
-@router.post("/{member_id}/revoke", response_model=MemberDetailResponse)
+@router.post(
+    "/{member_id}/revoke",
+    response_model=MemberDetailResponse,
+    responses={
+        403: {"description": "Permission denied"},
+        404: {"description": "Member not found"},
+        503: {"description": "Member service not available"},
+    },
+)
 async def revoke_member(
     member_id: str,
     svc: Annotated[Any, Depends(get_member_service)],
@@ -142,7 +186,15 @@ async def revoke_member(
     return {"member": asdict(member)}
 
 
-@router.post("/{member_id}/rotate-token", response_model=MemberTokenResponse)
+@router.post(
+    "/{member_id}/rotate-token",
+    response_model=MemberTokenResponse,
+    responses={
+        403: {"description": "Permission denied"},
+        404: {"description": "Member not found"},
+        503: {"description": "Member service not available"},
+    },
+)
 async def rotate_token(
     member_id: str,
     svc: Annotated[Any, Depends(get_member_service)],
@@ -157,7 +209,15 @@ async def rotate_token(
     return {"member": asdict(member), "token": token}
 
 
-@router.patch("/{member_id}/password", response_model=OkResponse)
+@router.patch(
+    "/{member_id}/password",
+    response_model=OkResponse,
+    responses={
+        403: {"description": "Permission denied"},
+        404: {"description": "Member not found"},
+        503: {"description": "Member service not available"},
+    },
+)
 async def change_password(
     member_id: str,
     body: PasswordChangeRequest,
@@ -173,7 +233,15 @@ async def change_password(
     return {"ok": True}
 
 
-@router.put("/{member_id}/scopes", response_model=MemberScopesResponse)
+@router.put(
+    "/{member_id}/scopes",
+    response_model=MemberScopesResponse,
+    responses={
+        403: {"description": "Permission denied"},
+        404: {"description": "Member not found"},
+        503: {"description": "Member service not available"},
+    },
+)
 async def update_scopes(
     member_id: str,
     body: ScopesUpdateRequest,

--- a/src/ante/web/routes/notifications.py
+++ b/src/ante/web/routes/notifications.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Request
+from typing import Annotated, Any
 
+from fastapi import APIRouter, Depends
+
+from ante.web.deps import get_notification_service
 from ante.web.schemas import NotificationListResponse
 
 router = APIRouter()
@@ -11,19 +14,13 @@ router = APIRouter()
 
 @router.get("", response_model=NotificationListResponse)
 async def list_notifications(
-    request: Request,
+    notification_service: Annotated[Any, Depends(get_notification_service)],
     level: str | None = None,
     limit: int = 20,
     cursor: str | None = None,
 ) -> dict:
     """알림 이력 조회 (cursor 기반 페이지네이션)."""
     from ante.web.pagination import paginate
-
-    notification_service = getattr(request.app.state, "notification_service", None)
-    if notification_service is None:
-        raise HTTPException(
-            status_code=503, detail="Notification service not available"
-        )
 
     rows = await notification_service.get_history(level=level, limit=limit + 1)
     items = [

--- a/src/ante/web/routes/notifications.py
+++ b/src/ante/web/routes/notifications.py
@@ -12,7 +12,11 @@ from ante.web.schemas import NotificationListResponse
 router = APIRouter()
 
 
-@router.get("", response_model=NotificationListResponse)
+@router.get(
+    "",
+    response_model=NotificationListResponse,
+    responses={503: {"description": "Notification service not available"}},
+)
 async def list_notifications(
     notification_service: Annotated[Any, Depends(get_notification_service)],
     level: str | None = None,

--- a/src/ante/web/routes/portfolio.py
+++ b/src/ante/web/routes/portfolio.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime, timedelta
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, Depends, Query
 
+from ante.web.deps import get_bot_manager, get_trade_service, get_treasury
 from ante.web.schemas import PortfolioHistoryResponse, PortfolioValueResponse
 
 logger = logging.getLogger(__name__)
@@ -15,10 +17,10 @@ router = APIRouter()
 
 
 @router.get("/value", response_model=PortfolioValueResponse)
-async def portfolio_value(request: Request) -> dict:
+async def portfolio_value(
+    treasury: Annotated[Any, Depends(get_treasury)],
+) -> dict:
     """총 자산 가치 + 오늘 손익."""
-    treasury = request.app.state.treasury
-
     summary = treasury.get_summary()
     total_value = summary["total_evaluation"]
     daily_pnl = summary["total_profit_loss"]
@@ -44,13 +46,11 @@ _PERIOD_DAYS = {
 
 @router.get("/history", response_model=PortfolioHistoryResponse)
 async def portfolio_history(
-    request: Request,
+    trade_service: Annotated[Any, Depends(get_trade_service)],
+    bot_manager: Annotated[Any, Depends(get_bot_manager)],
     period: str = Query(default="1m", pattern="^(1d|1w|1m|3m|all)$"),
 ) -> dict:
     """기간별 자산 추이."""
-    trade_service = request.app.state.trade_service
-    bot_manager = request.app.state.bot_manager
-
     # 모든 봇의 equity curve를 합산
     from ante.report.feedback import PerformanceFeedback
 

--- a/src/ante/web/routes/portfolio.py
+++ b/src/ante/web/routes/portfolio.py
@@ -16,7 +16,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/value", response_model=PortfolioValueResponse)
+@router.get(
+    "/value",
+    response_model=PortfolioValueResponse,
+    responses={503: {"description": "Treasury not available"}},
+)
 async def portfolio_value(
     treasury: Annotated[Any, Depends(get_treasury)],
 ) -> dict:
@@ -44,7 +48,13 @@ _PERIOD_DAYS = {
 }
 
 
-@router.get("/history", response_model=PortfolioHistoryResponse)
+@router.get(
+    "/history",
+    response_model=PortfolioHistoryResponse,
+    responses={
+        503: {"description": "Trade service or bot manager not available"},
+    },
+)
 async def portfolio_history(
     trade_service: Annotated[Any, Depends(get_trade_service)],
     bot_manager: Annotated[Any, Depends(get_bot_manager)],

--- a/src/ante/web/routes/reports.py
+++ b/src/ante/web/routes/reports.py
@@ -26,7 +26,12 @@ async def get_report_schema() -> dict:
     return store.get_schema()
 
 
-@router.post("", status_code=201, response_model=ReportSubmitResponse)
+@router.post(
+    "",
+    status_code=201,
+    response_model=ReportSubmitResponse,
+    responses={503: {"description": "Report store not available"}},
+)
 async def submit_report(
     body: dict,
     report_store: Annotated[Any, Depends(get_report_store)],
@@ -40,7 +45,14 @@ async def submit_report(
     }
 
 
-@router.get("/{report_id}", response_model=ReportDetailResponse)
+@router.get(
+    "/{report_id}",
+    response_model=ReportDetailResponse,
+    responses={
+        404: {"description": "Report not found"},
+        503: {"description": "Report store not available"},
+    },
+)
 async def report_view(
     report_id: str,
     report_store: Annotated[Any, Depends(get_report_store)],
@@ -85,7 +97,11 @@ async def report_view(
     }
 
 
-@router.get("", response_model=ReportListResponse)
+@router.get(
+    "",
+    response_model=ReportListResponse,
+    responses={503: {"description": "Report store not available"}},
+)
 async def list_reports(
     report_store: Annotated[Any, Depends(get_report_store)],
     status: str | None = None,

--- a/src/ante/web/routes/reports.py
+++ b/src/ante/web/routes/reports.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Request
+from typing import Annotated, Any
 
+from fastapi import APIRouter, Depends, HTTPException
+
+from ante.web.deps import get_report_store
 from ante.web.schemas import (
     ReportDetailResponse,
     ReportListResponse,
@@ -24,12 +27,11 @@ async def get_report_schema() -> dict:
 
 
 @router.post("", status_code=201, response_model=ReportSubmitResponse)
-async def submit_report(request: Request, body: dict) -> dict:
+async def submit_report(
+    body: dict,
+    report_store: Annotated[Any, Depends(get_report_store)],
+) -> dict:
     """리포트 제출."""
-    report_store = getattr(request.app.state, "report_store", None)
-    if report_store is None:
-        raise HTTPException(status_code=503, detail="Report store not available")
-
     report = await report_store.submit(body)
     return {
         "report_id": report.report_id,
@@ -39,13 +41,12 @@ async def submit_report(request: Request, body: dict) -> dict:
 
 
 @router.get("/{report_id}", response_model=ReportDetailResponse)
-async def report_view(request: Request, report_id: str) -> dict:
+async def report_view(
+    report_id: str,
+    report_store: Annotated[Any, Depends(get_report_store)],
+) -> dict:
     """리포트 단건 조회."""
     import json
-
-    report_store = getattr(request.app.state, "report_store", None)
-    if report_store is None:
-        raise HTTPException(status_code=503, detail="Report store not available")
 
     report = await report_store.get(report_id)
     if report is None:
@@ -86,17 +87,13 @@ async def report_view(request: Request, report_id: str) -> dict:
 
 @router.get("", response_model=ReportListResponse)
 async def list_reports(
-    request: Request,
+    report_store: Annotated[Any, Depends(get_report_store)],
     status: str | None = None,
     limit: int = 20,
     cursor: str | None = None,
 ) -> dict:
     """리포트 목록 조회 (cursor 기반 페이지네이션)."""
     from ante.web.pagination import paginate
-
-    report_store = getattr(request.app.state, "report_store", None)
-    if report_store is None:
-        raise HTTPException(status_code=503, detail="Report store not available")
 
     reports = await report_store.list_reports(status=status)
     items = [

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -4,9 +4,17 @@ from __future__ import annotations
 
 from dataclasses import asdict
 from pathlib import Path
+from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query
 
+from ante.web.deps import (
+    get_bot_manager_optional,
+    get_db,
+    get_strategy_registry,
+    get_trade_service,
+    get_trade_service_optional,
+)
 from ante.web.schemas import (
     DailySummaryResponse,
     MonthlySummaryResponse,
@@ -49,17 +57,13 @@ async def validate_strategy(body: dict) -> dict:
 
 @router.get("", response_model=StrategyListResponse)
 async def list_strategies(
-    request: Request,
+    registry: Annotated[Any, Depends(get_strategy_registry)],
+    bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
     status: str | None = Query(default=None),
 ) -> dict:
     """전략 목록 조회."""
-    registry = getattr(request.app.state, "strategy_registry", None)
-    if registry is None:
-        raise HTTPException(status_code=503, detail="Strategy registry not available")
-
     records = await registry.list_strategies(status=status)
 
-    bot_manager = getattr(request.app.state, "bot_manager", None)
     bots_by_strategy: dict[str, dict] = {}
     if bot_manager is not None:
         for bot_info in bot_manager.list_bots():
@@ -88,12 +92,12 @@ async def list_strategies(
 
 
 @router.get("/{strategy_id}", response_model=StrategyDetailResponse)
-async def get_strategy(request: Request, strategy_id: str) -> dict:
+async def get_strategy(
+    strategy_id: str,
+    registry: Annotated[Any, Depends(get_strategy_registry)],
+    bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
+) -> dict:
     """전략 상세 조회."""
-    registry = getattr(request.app.state, "strategy_registry", None)
-    if registry is None:
-        raise HTTPException(status_code=503, detail="Strategy registry not available")
-
     record = await registry.get(strategy_id)
     if not record:
         raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
@@ -104,7 +108,6 @@ async def get_strategy(request: Request, strategy_id: str) -> dict:
     )
 
     bot_info = None
-    bot_manager = getattr(request.app.state, "bot_manager", None)
     if bot_manager is not None:
         for b in bot_manager.list_bots():
             if b.get("strategy_id") == strategy_id:
@@ -115,19 +118,17 @@ async def get_strategy(request: Request, strategy_id: str) -> dict:
 
 
 @router.get("/{strategy_id}/performance", response_model=StrategyPerformanceResponse)
-async def get_strategy_performance(request: Request, strategy_id: str) -> dict:
+async def get_strategy_performance(
+    strategy_id: str,
+    registry: Annotated[Any, Depends(get_strategy_registry)],
+    db: Annotated[Any, Depends(get_db)],
+    bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
+    trade_service: Annotated[Any | None, Depends(get_trade_service_optional)],
+) -> dict:
     """전략 성과 지표 조회."""
-    registry = getattr(request.app.state, "strategy_registry", None)
-    if registry is None:
-        raise HTTPException(status_code=503, detail="Strategy registry not available")
-
     record = await registry.get(strategy_id)
     if not record:
         raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
-
-    db = getattr(request.app.state, "db", None)
-    if db is None:
-        raise HTTPException(status_code=503, detail="Database not available")
 
     from ante.trade.performance import PerformanceTracker
 
@@ -138,8 +139,6 @@ async def get_strategy_performance(request: Request, strategy_id: str) -> dict:
 
     # equity curve: bot_id가 있으면 추가
     equity_curve: list[dict] = []
-    bot_manager = getattr(request.app.state, "bot_manager", None)
-    trade_service = getattr(request.app.state, "trade_service", None)
     if bot_manager is not None and trade_service is not None:
         for b in bot_manager.list_bots():
             if b.get("strategy_id") == strategy_id:
@@ -158,21 +157,15 @@ async def get_strategy_performance(request: Request, strategy_id: str) -> dict:
 
 @router.get("/{strategy_id}/daily-summary", response_model=DailySummaryResponse)
 async def get_strategy_daily_summary(
-    request: Request,
     strategy_id: str,
+    registry: Annotated[Any, Depends(get_strategy_registry)],
+    db: Annotated[Any, Depends(get_db)],
+    bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
 ) -> dict:
     """전략 일별 성과 집계."""
-    registry = getattr(request.app.state, "strategy_registry", None)
-    if registry is None:
-        raise HTTPException(status_code=503, detail="Strategy registry not available")
-
     record = await registry.get(strategy_id)
     if not record:
         raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
-
-    db = getattr(request.app.state, "db", None)
-    if db is None:
-        raise HTTPException(status_code=503, detail="Database not available")
 
     from ante.trade.performance import PerformanceTracker
 
@@ -180,7 +173,6 @@ async def get_strategy_daily_summary(
 
     # strategy에 연결된 bot_id 찾기
     bot_id = None
-    bot_manager = getattr(request.app.state, "bot_manager", None)
     if bot_manager is not None:
         for b in bot_manager.list_bots():
             if b.get("strategy_id") == strategy_id:
@@ -203,28 +195,21 @@ async def get_strategy_daily_summary(
 
 @router.get("/{strategy_id}/weekly-summary", response_model=WeeklySummaryResponse)
 async def get_strategy_weekly_summary(
-    request: Request,
     strategy_id: str,
+    registry: Annotated[Any, Depends(get_strategy_registry)],
+    db: Annotated[Any, Depends(get_db)],
+    bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
 ) -> dict:
     """전략 주별 성과 집계."""
-    registry = getattr(request.app.state, "strategy_registry", None)
-    if registry is None:
-        raise HTTPException(status_code=503, detail="Strategy registry not available")
-
     record = await registry.get(strategy_id)
     if not record:
         raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
-
-    db = getattr(request.app.state, "db", None)
-    if db is None:
-        raise HTTPException(status_code=503, detail="Database not available")
 
     from ante.trade.performance import PerformanceTracker
 
     tracker = PerformanceTracker(db)
 
     bot_id = None
-    bot_manager = getattr(request.app.state, "bot_manager", None)
     if bot_manager is not None:
         for b in bot_manager.list_bots():
             if b.get("strategy_id") == strategy_id:
@@ -249,28 +234,21 @@ async def get_strategy_weekly_summary(
 
 @router.get("/{strategy_id}/monthly-summary", response_model=MonthlySummaryResponse)
 async def get_strategy_monthly_summary(
-    request: Request,
     strategy_id: str,
+    registry: Annotated[Any, Depends(get_strategy_registry)],
+    db: Annotated[Any, Depends(get_db)],
+    bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
 ) -> dict:
     """전략 월별 성과 집계."""
-    registry = getattr(request.app.state, "strategy_registry", None)
-    if registry is None:
-        raise HTTPException(status_code=503, detail="Strategy registry not available")
-
     record = await registry.get(strategy_id)
     if not record:
         raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
-
-    db = getattr(request.app.state, "db", None)
-    if db is None:
-        raise HTTPException(status_code=503, detail="Database not available")
 
     from ante.trade.performance import PerformanceTracker
 
     tracker = PerformanceTracker(db)
 
     bot_id = None
-    bot_manager = getattr(request.app.state, "bot_manager", None)
     if bot_manager is not None:
         for b in bot_manager.list_bots():
             if b.get("strategy_id") == strategy_id:
@@ -294,25 +272,18 @@ async def get_strategy_monthly_summary(
 
 @router.get("/{strategy_id}/trades", response_model=StrategyTradesResponse)
 async def get_strategy_trades(
-    request: Request,
     strategy_id: str,
+    registry: Annotated[Any, Depends(get_strategy_registry)],
+    trade_service: Annotated[Any, Depends(get_trade_service)],
     limit: int = Query(default=20, ge=1, le=100),
     cursor: str | None = Query(default=None),
 ) -> dict:
     """전략 거래 내역 조회 (cursor 기반 페이지네이션)."""
     from ante.web.pagination import paginate
 
-    registry = getattr(request.app.state, "strategy_registry", None)
-    if registry is None:
-        raise HTTPException(status_code=503, detail="Strategy registry not available")
-
     record = await registry.get(strategy_id)
     if not record:
         raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
-
-    trade_service = getattr(request.app.state, "trade_service", None)
-    if trade_service is None:
-        raise HTTPException(status_code=503, detail="Trade service not available")
 
     trades = await trade_service.get_trades(
         strategy_id=strategy_id,

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -28,6 +28,8 @@ from ante.web.schemas import (
 
 router = APIRouter()
 
+_STRATEGY_NOT_FOUND = "전략을 찾을 수 없습니다"
+
 
 @router.post("/validate", response_model=StrategyValidateResponse)
 async def validate_strategy(body: dict) -> dict:
@@ -100,7 +102,7 @@ async def get_strategy(
     """전략 상세 조회."""
     record = await registry.get(strategy_id)
     if not record:
-        raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
 
     strategy_dict = asdict(record)
     strategy_dict["status"] = (
@@ -128,7 +130,7 @@ async def get_strategy_performance(
     """전략 성과 지표 조회."""
     record = await registry.get(strategy_id)
     if not record:
-        raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
 
     from ante.trade.performance import PerformanceTracker
 
@@ -165,7 +167,7 @@ async def get_strategy_daily_summary(
     """전략 일별 성과 집계."""
     record = await registry.get(strategy_id)
     if not record:
-        raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
 
     from ante.trade.performance import PerformanceTracker
 
@@ -203,7 +205,7 @@ async def get_strategy_weekly_summary(
     """전략 주별 성과 집계."""
     record = await registry.get(strategy_id)
     if not record:
-        raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
 
     from ante.trade.performance import PerformanceTracker
 
@@ -242,7 +244,7 @@ async def get_strategy_monthly_summary(
     """전략 월별 성과 집계."""
     record = await registry.get(strategy_id)
     if not record:
-        raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
 
     from ante.trade.performance import PerformanceTracker
 
@@ -283,7 +285,7 @@ async def get_strategy_trades(
 
     record = await registry.get(strategy_id)
     if not record:
-        raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다")
+        raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
 
     trades = await trade_service.get_trades(
         strategy_id=strategy_id,

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -31,7 +31,14 @@ router = APIRouter()
 _STRATEGY_NOT_FOUND = "전략을 찾을 수 없습니다"
 
 
-@router.post("/validate", response_model=StrategyValidateResponse)
+@router.post(
+    "/validate",
+    response_model=StrategyValidateResponse,
+    responses={
+        400: {"description": "Path is required"},
+        404: {"description": "Strategy file not found"},
+    },
+)
 async def validate_strategy(body: dict) -> dict:
     """전략 파일 정적 검증.
 
@@ -57,7 +64,11 @@ async def validate_strategy(body: dict) -> dict:
     }
 
 
-@router.get("", response_model=StrategyListResponse)
+@router.get(
+    "",
+    response_model=StrategyListResponse,
+    responses={503: {"description": "Strategy registry not available"}},
+)
 async def list_strategies(
     registry: Annotated[Any, Depends(get_strategy_registry)],
     bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
@@ -93,7 +104,14 @@ async def list_strategies(
     return {"strategies": strategies}
 
 
-@router.get("/{strategy_id}", response_model=StrategyDetailResponse)
+@router.get(
+    "/{strategy_id}",
+    response_model=StrategyDetailResponse,
+    responses={
+        404: {"description": "Strategy not found"},
+        503: {"description": "Strategy registry not available"},
+    },
+)
 async def get_strategy(
     strategy_id: str,
     registry: Annotated[Any, Depends(get_strategy_registry)],
@@ -119,7 +137,14 @@ async def get_strategy(
     return {"strategy": strategy_dict, "bot": bot_info}
 
 
-@router.get("/{strategy_id}/performance", response_model=StrategyPerformanceResponse)
+@router.get(
+    "/{strategy_id}/performance",
+    response_model=StrategyPerformanceResponse,
+    responses={
+        404: {"description": "Strategy not found"},
+        503: {"description": "Strategy registry or database not available"},
+    },
+)
 async def get_strategy_performance(
     strategy_id: str,
     registry: Annotated[Any, Depends(get_strategy_registry)],
@@ -157,7 +182,14 @@ async def get_strategy_performance(
     return result
 
 
-@router.get("/{strategy_id}/daily-summary", response_model=DailySummaryResponse)
+@router.get(
+    "/{strategy_id}/daily-summary",
+    response_model=DailySummaryResponse,
+    responses={
+        404: {"description": "Strategy not found"},
+        503: {"description": "Strategy registry or database not available"},
+    },
+)
 async def get_strategy_daily_summary(
     strategy_id: str,
     registry: Annotated[Any, Depends(get_strategy_registry)],
@@ -195,7 +227,14 @@ async def get_strategy_daily_summary(
     }
 
 
-@router.get("/{strategy_id}/weekly-summary", response_model=WeeklySummaryResponse)
+@router.get(
+    "/{strategy_id}/weekly-summary",
+    response_model=WeeklySummaryResponse,
+    responses={
+        404: {"description": "Strategy not found"},
+        503: {"description": "Strategy registry or database not available"},
+    },
+)
 async def get_strategy_weekly_summary(
     strategy_id: str,
     registry: Annotated[Any, Depends(get_strategy_registry)],
@@ -234,7 +273,14 @@ async def get_strategy_weekly_summary(
     }
 
 
-@router.get("/{strategy_id}/monthly-summary", response_model=MonthlySummaryResponse)
+@router.get(
+    "/{strategy_id}/monthly-summary",
+    response_model=MonthlySummaryResponse,
+    responses={
+        404: {"description": "Strategy not found"},
+        503: {"description": "Strategy registry or database not available"},
+    },
+)
 async def get_strategy_monthly_summary(
     strategy_id: str,
     registry: Annotated[Any, Depends(get_strategy_registry)],
@@ -272,7 +318,14 @@ async def get_strategy_monthly_summary(
     }
 
 
-@router.get("/{strategy_id}/trades", response_model=StrategyTradesResponse)
+@router.get(
+    "/{strategy_id}/trades",
+    response_model=StrategyTradesResponse,
+    responses={
+        404: {"description": "Strategy not found"},
+        503: {"description": "Strategy registry or trade service not available"},
+    },
+)
 async def get_strategy_trades(
     strategy_id: str,
     registry: Annotated[Any, Depends(get_strategy_registry)],

--- a/src/ante/web/routes/system.py
+++ b/src/ante/web/routes/system.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Request
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from ante.web.deps import get_system_state, get_system_state_optional
 from ante.web.schemas import HealthResponse, KillSwitchResponse, StatusResponse
 
 router = APIRouter()
@@ -18,14 +21,15 @@ class KillSwitchRequest(BaseModel):
 
 
 @router.get("/status", response_model=StatusResponse)
-async def get_system_status(request: Request) -> dict:
+async def get_system_status(
+    system_state: Annotated[Any | None, Depends(get_system_state_optional)],
+) -> dict:
     """시스템 상태 조회."""
     result: dict = {
         "status": "running",
         "version": "0.1.0",
     }
 
-    system_state = getattr(request.app.state, "system_state", None)
     if system_state is not None:
         result["trading_status"] = system_state.trading_state.value.upper()
 
@@ -59,15 +63,14 @@ async def health_check() -> dict:
 
 
 @router.post("/kill-switch", response_model=KillSwitchResponse)
-async def kill_switch(request: Request, body: KillSwitchRequest) -> dict:
+async def kill_switch(
+    body: KillSwitchRequest,
+    system_state: Annotated[Any, Depends(get_system_state)],
+) -> dict:
     """킬 스위치 제어 (halt/activate)."""
     from datetime import UTC, datetime
 
     from ante.config.system_state import TradingState
-
-    system_state = getattr(request.app.state, "system_state", None)
-    if system_state is None:
-        raise HTTPException(status_code=503, detail="System state not available")
 
     if body.action == "halt":
         target = TradingState.HALTED

--- a/src/ante/web/routes/system.py
+++ b/src/ante/web/routes/system.py
@@ -62,7 +62,14 @@ async def health_check() -> dict:
     return {"ok": True}
 
 
-@router.post("/kill-switch", response_model=KillSwitchResponse)
+@router.post(
+    "/kill-switch",
+    response_model=KillSwitchResponse,
+    responses={
+        400: {"description": "Invalid action value"},
+        503: {"description": "System state not available"},
+    },
+)
 async def kill_switch(
     body: KillSwitchRequest,
     system_state: Annotated[Any, Depends(get_system_state)],

--- a/src/ante/web/routes/test_seed.py
+++ b/src/ante/web/routes/test_seed.py
@@ -63,7 +63,14 @@ SCENARIOS_DIR = _find_scenarios_dir()
 BASE_SQL = SCENARIOS_DIR / "_base.sql"
 
 
-@router.post("/reset", response_model=SeedResetResponse)
+@router.post(
+    "/reset",
+    response_model=SeedResetResponse,
+    responses={
+        400: {"description": "Scenario not found"},
+        503: {"description": "Database not available"},
+    },
+)
 async def reset_seed(
     db: Annotated[Any, Depends(get_db)],
     system_state: Annotated[Any | None, Depends(get_system_state_optional)],

--- a/src/ante/web/routes/test_seed.py
+++ b/src/ante/web/routes/test_seed.py
@@ -8,9 +8,16 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query
 
+from ante.web.deps import (
+    get_bot_manager_optional,
+    get_db,
+    get_system_state_optional,
+    get_treasury_optional,
+)
 from ante.web.schemas import SeedResetResponse
 
 logger = logging.getLogger(__name__)
@@ -58,7 +65,10 @@ BASE_SQL = SCENARIOS_DIR / "_base.sql"
 
 @router.post("/reset", response_model=SeedResetResponse)
 async def reset_seed(
-    request: Request,
+    db: Annotated[Any, Depends(get_db)],
+    system_state: Annotated[Any | None, Depends(get_system_state_optional)],
+    bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
+    treasury: Annotated[Any | None, Depends(get_treasury_optional)],
     scenario: str = Query(..., description="시나리오 이름 (예: login-dashboard)"),
 ) -> dict:
     """DB를 초기화하고 시나리오별 시드 데이터를 주입한다.
@@ -74,8 +84,6 @@ async def reset_seed(
             status_code=400,
             detail=f"시나리오를 찾을 수 없습니다: {scenario}",
         )
-
-    db = request.app.state.db
 
     # 1. 모든 테이블 DROP
     rows = await db.fetch_all(
@@ -99,25 +107,26 @@ async def reset_seed(
     await db.execute_script(scenario_content)
 
     # 5. 메모리 기반 매니저 리로드
-    await _reload_managers(request)
+    await _reload_managers(system_state, bot_manager, treasury)
 
     logger.info("시드 리셋 완료: scenario=%s", scenario)
     return {"ok": True, "scenario": scenario}
 
 
-async def _reload_managers(request: Request) -> None:
+async def _reload_managers(
+    system_state: Any | None,
+    bot_manager: Any | None,
+    treasury: Any | None,
+) -> None:
     """시딩 후 메모리 기반 매니저들을 DB에서 리로드한다."""
     # SystemState (인메모리 trading_state 동기화)
-    system_state = getattr(request.app.state, "system_state", None)
     if system_state is not None and hasattr(system_state, "_load_from_db"):
         await system_state._load_from_db()  # noqa: SLF001
 
     # BotManager
-    bot_manager = getattr(request.app.state, "bot_manager", None)
     if bot_manager is not None:
         await bot_manager.load_from_db()
 
     # Treasury (budget 리로드)
-    treasury = getattr(request.app.state, "treasury", None)
     if treasury is not None and hasattr(treasury, "load_from_db"):
         await treasury.load_from_db()

--- a/src/ante/web/routes/trades.py
+++ b/src/ante/web/routes/trades.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Request
+from typing import Annotated, Any
 
+from fastapi import APIRouter, Depends
+
+from ante.web.deps import get_trade_service
 from ante.web.schemas import TradeListResponse
 
 router = APIRouter()
@@ -11,7 +14,7 @@ router = APIRouter()
 
 @router.get("", response_model=TradeListResponse)
 async def list_trades(
-    request: Request,
+    trade_service: Annotated[Any, Depends(get_trade_service)],
     bot_id: str | None = None,
     symbol: str | None = None,
     limit: int = 20,
@@ -19,10 +22,6 @@ async def list_trades(
 ) -> dict:
     """거래 기록 목록 조회 (cursor 기반 페이지네이션)."""
     from ante.web.pagination import paginate
-
-    trade_service = getattr(request.app.state, "trade_service", None)
-    if trade_service is None:
-        raise HTTPException(status_code=503, detail="Trade service not available")
 
     trades = await trade_service.get_trades(
         bot_id=bot_id,

--- a/src/ante/web/routes/trades.py
+++ b/src/ante/web/routes/trades.py
@@ -12,7 +12,11 @@ from ante.web.schemas import TradeListResponse
 router = APIRouter()
 
 
-@router.get("", response_model=TradeListResponse)
+@router.get(
+    "",
+    response_model=TradeListResponse,
+    responses={503: {"description": "Trade service not available"}},
+)
 async def list_trades(
     trade_service: Annotated[Any, Depends(get_trade_service)],
     bot_id: str | None = None,

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Request
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from ante.web.deps import get_broker, get_config, get_treasury
 from ante.web.schemas import (
     BalanceSetResponse,
     BudgetListResponse,
@@ -31,17 +34,17 @@ class BalanceSetRequest(BaseModel):
 @router.get(
     "", response_model=TreasurySummaryResponse, response_model_exclude_none=True
 )
-async def get_summary(request: Request) -> dict:
+async def get_summary(
+    treasury: Annotated[Any, Depends(get_treasury)],
+    broker: Annotated[Any | None, Depends(get_broker)],
+    config: Annotated[Any | None, Depends(get_config)],
+) -> dict:
     """자금 현황 요약."""
-    treasury = getattr(request.app.state, "treasury", None)
-    if treasury is None:
-        raise HTTPException(status_code=503, detail="Treasury not available")
     summary = treasury.get_summary()
     summary["commission_rate"] = getattr(treasury, "commission_rate", 0.00015)
     summary["sell_tax_rate"] = getattr(treasury, "sell_tax_rate", 0.0023)
 
     # 브로커 메타정보
-    broker = getattr(request.app.state, "broker", None)
     if broker is not None:
         summary["broker_id"] = broker.broker_id
         summary["broker_name"] = broker.broker_name
@@ -49,7 +52,6 @@ async def get_summary(request: Request) -> dict:
         summary["exchange"] = broker.exchange
 
     # KIS 계좌 헤더 정보
-    config = getattr(request.app.state, "config", None)
     if config is not None:
         try:
             account_no = config.secret("KIS_ACCOUNT_NO")
@@ -73,17 +75,13 @@ async def get_summary(request: Request) -> dict:
 
 @router.get("/transactions", response_model=TransactionListResponse)
 async def list_transactions(
-    request: Request,
+    treasury: Annotated[Any, Depends(get_treasury)],
     type: str | None = None,
     bot_id: str | None = None,
     limit: int = 20,
     offset: int = 0,
 ) -> dict:
     """자금 변동 이력 조회."""
-    treasury = getattr(request.app.state, "treasury", None)
-    if treasury is None:
-        raise HTTPException(status_code=503, detail="Treasury not available")
-
     db = getattr(treasury, "_db", None)
     if db is None:
         return {"items": [], "total": 0}
@@ -126,13 +124,13 @@ async def list_transactions(
 
 
 @router.post("/bots/{bot_id}/allocate", response_model=BudgetOperationResponse)
-async def allocate(request: Request, bot_id: str, body: BudgetChangeRequest) -> dict:
+async def allocate(
+    bot_id: str,
+    body: BudgetChangeRequest,
+    treasury: Annotated[Any, Depends(get_treasury)],
+) -> dict:
     """봇에 예산 할당."""
     from ante.treasury.exceptions import BotNotStoppedError
-
-    treasury = getattr(request.app.state, "treasury", None)
-    if treasury is None:
-        raise HTTPException(status_code=503, detail="Treasury not available")
 
     try:
         success = await treasury.allocate(bot_id, body.amount)
@@ -157,13 +155,13 @@ async def allocate(request: Request, bot_id: str, body: BudgetChangeRequest) -> 
 
 
 @router.post("/bots/{bot_id}/deallocate", response_model=BudgetOperationResponse)
-async def deallocate(request: Request, bot_id: str, body: BudgetChangeRequest) -> dict:
+async def deallocate(
+    bot_id: str,
+    body: BudgetChangeRequest,
+    treasury: Annotated[Any, Depends(get_treasury)],
+) -> dict:
     """봇 예산 회수."""
     from ante.treasury.exceptions import BotNotStoppedError
-
-    treasury = getattr(request.app.state, "treasury", None)
-    if treasury is None:
-        raise HTTPException(status_code=503, detail="Treasury not available")
 
     try:
         success = await treasury.deallocate(bot_id, body.amount)
@@ -185,26 +183,23 @@ async def deallocate(request: Request, bot_id: str, body: BudgetChangeRequest) -
 
 
 @router.get("/budgets", response_model=BudgetListResponse)
-async def list_budgets(request: Request) -> dict:
+async def list_budgets(
+    treasury: Annotated[Any, Depends(get_treasury)],
+) -> dict:
     """봇별 예산 목록 조회."""
     from dataclasses import asdict
-
-    treasury = getattr(request.app.state, "treasury", None)
-    if treasury is None:
-        raise HTTPException(status_code=503, detail="Treasury not available")
 
     budgets = treasury.list_budgets()
     return {"budgets": [asdict(b) for b in budgets]}
 
 
 @router.post("/balance", response_model=BalanceSetResponse)
-async def set_balance(request: Request, body: BalanceSetRequest) -> dict:
+async def set_balance(
+    body: BalanceSetRequest,
+    treasury: Annotated[Any, Depends(get_treasury)],
+) -> dict:
     """계좌 총 잔고 수동 설정."""
     from datetime import UTC, datetime
-
-    treasury = getattr(request.app.state, "treasury", None)
-    if treasury is None:
-        raise HTTPException(status_code=503, detail="Treasury not available")
 
     await treasury.set_account_balance(body.balance)
     return {

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -146,7 +146,7 @@ async def allocate(
             ),
         )
 
-    budget = await treasury.get_budget(bot_id)
+    budget = treasury.get_budget(bot_id)
     return {
         "bot_id": bot_id,
         "allocated": budget.allocated if budget else 0.0,
@@ -174,7 +174,7 @@ async def deallocate(
             detail=f"예산 회수 실패: 가용 예산 부족 (요청: {body.amount:,.0f}원)",
         )
 
-    budget = await treasury.get_budget(bot_id)
+    budget = treasury.get_budget(bot_id)
     return {
         "bot_id": bot_id,
         "allocated": budget.allocated if budget else 0.0,

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -32,7 +32,10 @@ class BalanceSetRequest(BaseModel):
 
 
 @router.get(
-    "", response_model=TreasurySummaryResponse, response_model_exclude_none=True
+    "",
+    response_model=TreasurySummaryResponse,
+    response_model_exclude_none=True,
+    responses={503: {"description": "Treasury not available"}},
 )
 async def get_summary(
     treasury: Annotated[Any, Depends(get_treasury)],
@@ -73,7 +76,11 @@ async def get_summary(
     return summary
 
 
-@router.get("/transactions", response_model=TransactionListResponse)
+@router.get(
+    "/transactions",
+    response_model=TransactionListResponse,
+    responses={503: {"description": "Treasury not available"}},
+)
 async def list_transactions(
     treasury: Annotated[Any, Depends(get_treasury)],
     type: str | None = None,
@@ -123,7 +130,15 @@ async def list_transactions(
     return {"items": items, "total": total}
 
 
-@router.post("/bots/{bot_id}/allocate", response_model=BudgetOperationResponse)
+@router.post(
+    "/bots/{bot_id}/allocate",
+    response_model=BudgetOperationResponse,
+    responses={
+        400: {"description": "Insufficient funds or invalid amount"},
+        409: {"description": "Bot not stopped"},
+        503: {"description": "Treasury not available"},
+    },
+)
 async def allocate(
     bot_id: str,
     body: BudgetChangeRequest,
@@ -154,7 +169,15 @@ async def allocate(
     }
 
 
-@router.post("/bots/{bot_id}/deallocate", response_model=BudgetOperationResponse)
+@router.post(
+    "/bots/{bot_id}/deallocate",
+    response_model=BudgetOperationResponse,
+    responses={
+        400: {"description": "Insufficient available budget"},
+        409: {"description": "Bot not stopped"},
+        503: {"description": "Treasury not available"},
+    },
+)
 async def deallocate(
     bot_id: str,
     body: BudgetChangeRequest,
@@ -182,7 +205,11 @@ async def deallocate(
     }
 
 
-@router.get("/budgets", response_model=BudgetListResponse)
+@router.get(
+    "/budgets",
+    response_model=BudgetListResponse,
+    responses={503: {"description": "Treasury not available"}},
+)
 async def list_budgets(
     treasury: Annotated[Any, Depends(get_treasury)],
 ) -> dict:
@@ -193,7 +220,11 @@ async def list_budgets(
     return {"budgets": [asdict(b) for b in budgets]}
 
 
-@router.post("/balance", response_model=BalanceSetResponse)
+@router.post(
+    "/balance",
+    response_model=BalanceSetResponse,
+    responses={503: {"description": "Treasury not available"}},
+)
 async def set_balance(
     body: BalanceSetRequest,
     treasury: Annotated[Any, Depends(get_treasury)],

--- a/tests/integration/test_e2e_flow.py
+++ b/tests/integration/test_e2e_flow.py
@@ -267,7 +267,7 @@ async def system(tmp_path: Path):
 
     # RuleEngine
     rule_engine = RuleEngine(eventbus=eventbus, system_state=system_state)
-    await rule_engine.start()
+    rule_engine.start()
 
     # Treasury
     treasury = Treasury(db=db, eventbus=eventbus, commission_rate=0.00015)
@@ -293,7 +293,7 @@ async def system(tmp_path: Path):
     # MockBroker + APIGateway
     broker = MockBrokerAdapter()
     api_gateway = APIGateway(broker=broker, eventbus=eventbus)
-    await api_gateway.start()
+    api_gateway.start()
 
     # AutoFill 시뮬레이터
     auto_fill = AutoFillSimulator(eventbus=eventbus, broker=broker)
@@ -324,7 +324,7 @@ async def system(tmp_path: Path):
 
     # Teardown
     await bot_manager.stop_all()
-    await api_gateway.stop()
+    api_gateway.stop()
     await db.close()
 
 
@@ -434,7 +434,7 @@ class TestE2EBacktest:
                 "volume": [1000.0] * 20,
             }
         )
-        await store.write("005930", "1d", df)
+        store.write("005930", "1d", df)
 
         # 전략 파일
         filepath = _write_test_strategy(tmp_path)
@@ -616,7 +616,7 @@ class TestE2EOrderFlow:
         assert positions[0].quantity == 10.0
 
         # 6. Treasury 자금 변동 확인
-        budget = await treasury.get_budget(bot_id)
+        budget = treasury.get_budget(bot_id)
         assert budget is not None
         assert budget.spent > 0
 
@@ -757,7 +757,7 @@ class TestE2EFullPipeline:
                 "volume": [1000.0] * 20,
             }
         )
-        await store.write("005930", "1d", df)
+        store.write("005930", "1d", df)
 
         bt_service = BacktestService(data_path=str(data_path))
         bt_result = await bt_service.run(

--- a/tests/unit/feed/test_injector.py
+++ b/tests/unit/feed/test_injector.py
@@ -84,23 +84,23 @@ class TestFeedInjectorCSV:
             "2026-03-01T09:01:00,50100,50200,50000,50150,1100\n"
         )
 
-        count = await injector.inject_csv(csv_path, "005930", "1m")
+        count = injector.inject_csv(csv_path, "005930", "1m")
         assert count == 2
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) == 2
 
     async def test_inject_csv_not_found(self, injector):
         """존재하지 않는 CSV 파일은 FileNotFoundError."""
         with pytest.raises(FileNotFoundError):
-            await injector.inject_csv("/nonexistent.csv", "005930", "1m")
+            injector.inject_csv("/nonexistent.csv", "005930", "1m")
 
     async def test_inject_csv_empty(self, injector, tmp_path):
         """빈 CSV 파일은 0행 반환."""
         csv_path = tmp_path / "empty.csv"
         csv_path.write_text("date,open,high,low,close,volume\n")
 
-        count = await injector.inject_csv(csv_path, "005930", "1d")
+        count = injector.inject_csv(csv_path, "005930", "1d")
         assert count == 0
 
     async def test_inject_csv_default_timeframe(self, injector, store, tmp_path):
@@ -111,10 +111,10 @@ class TestFeedInjectorCSV:
             "2026-03-01T00:00:00,50000,50100,49900,50050,1000\n"
         )
 
-        count = await injector.inject_csv(csv_path, "005930")
+        count = injector.inject_csv(csv_path, "005930")
         assert count == 1
 
-        result = await store.read("005930", "1d")
+        result = store.read("005930", "1d")
         assert len(result) == 1
 
 
@@ -127,15 +127,15 @@ class TestFeedInjectorDataFrame:
     async def test_inject_dataframe(self, injector, store):
         """DataFrame을 직접 주입한다."""
         df = _make_ohlcv_df(n=3)
-        count = await injector.inject_dataframe(df, "005930", "1m")
+        count = injector.inject_dataframe(df, "005930", "1m")
         assert count == 3
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) == 3
 
     async def test_inject_empty_dataframe(self, injector):
         """빈 DataFrame은 0행 반환."""
-        count = await injector.inject_dataframe(pl.DataFrame(), "005930", "1m")
+        count = injector.inject_dataframe(pl.DataFrame(), "005930", "1m")
         assert count == 0
 
     async def test_inject_dataframe_adds_symbol(self, injector, store):
@@ -157,16 +157,16 @@ class TestFeedInjectorDataFrame:
                 "source": ["test"] * 3,
             }
         )
-        count = await injector.inject_dataframe(df, "005930", "1m")
+        count = injector.inject_dataframe(df, "005930", "1m")
         assert count == 3
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert result["symbol"][0] == "005930"
 
     async def test_inject_dataframe_adds_source(self, injector, store):
         """source 컬럼이 없는 DataFrame에 source를 추가한다."""
         df = _make_ohlcv_df(n=2).drop("source")
-        count = await injector.inject_dataframe(df, "005930", "1m", source="custom")
+        count = injector.inject_dataframe(df, "005930", "1m", source="custom")
         assert count == 2
 
 
@@ -179,7 +179,7 @@ class TestFeedInjectorValidation:
     async def test_schema_validation_passes(self, injector, store):
         """올바른 스키마의 DataFrame은 검증을 통과한다."""
         df = _make_ohlcv_df(n=2)
-        count = await injector.inject_dataframe(df, "005930", "1m")
+        count = injector.inject_dataframe(df, "005930", "1m")
         assert count == 2
 
     async def test_business_validation_warnings_allow_storage(self, injector, store):
@@ -197,8 +197,8 @@ class TestFeedInjectorValidation:
                 "source": ["test"],
             }
         )
-        count = await injector.inject_dataframe(df, "005930", "1m")
+        count = injector.inject_dataframe(df, "005930", "1m")
         assert count == 1
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) == 1

--- a/tests/unit/feed/test_orchestrator.py
+++ b/tests/unit/feed/test_orchestrator.py
@@ -14,6 +14,7 @@ import pytest
 
 from ante.data.store import ParquetStore
 from ante.feed.models.result import CollectionResult
+from ante.feed.pipeline.indicator_calculator import IndicatorCalculator
 from ante.feed.pipeline.orchestrator import FeedOrchestrator
 from ante.feed.sources.dart import (
     DailyLimitExceededError as DARTDailyLimitError,
@@ -422,8 +423,8 @@ async def test_compute_derived_indicators(tmp_data_path: Path) -> None:
 
     await store.write("005930", "krx", fundamental_df, data_type="fundamental")
 
-    orchestrator = FeedOrchestrator(store=store)
-    rows = await orchestrator._compute_derived_indicators(store, ["005930"])
+    calculator = IndicatorCalculator()
+    rows = await calculator.compute(store, ["005930"])
 
     assert rows > 0
 
@@ -478,8 +479,8 @@ async def test_compute_derived_zero_division(tmp_data_path: Path) -> None:
 
     await store.write("005930", "krx", fundamental_df, data_type="fundamental")
 
-    orchestrator = FeedOrchestrator(store=store)
-    await orchestrator._compute_derived_indicators(store, ["005930"])
+    calculator = IndicatorCalculator()
+    await calculator.compute(store, ["005930"])
 
     result = await store.read("005930", "krx", data_type="fundamental")
     row = result.row(0, named=True)
@@ -511,9 +512,9 @@ async def test_compute_derived_missing_columns(tmp_data_path: Path) -> None:
 
     await store.write("005930", "krx", fundamental_df, data_type="fundamental")
 
-    orchestrator = FeedOrchestrator(store=store)
+    calculator = IndicatorCalculator()
     # 에러 없이 실행되어야 함
-    rows = await orchestrator._compute_derived_indicators(store, ["005930"])
+    rows = await calculator.compute(store, ["005930"])
     assert rows >= 0
 
 

--- a/tests/unit/feed/test_orchestrator.py
+++ b/tests/unit/feed/test_orchestrator.py
@@ -421,15 +421,15 @@ async def test_compute_derived_indicators(tmp_data_path: Path) -> None:
         }
     )
 
-    await store.write("005930", "krx", fundamental_df, data_type="fundamental")
+    store.write("005930", "krx", fundamental_df, data_type="fundamental")
 
     calculator = IndicatorCalculator()
-    rows = await calculator.compute(store, ["005930"])
+    rows = calculator.compute(store, ["005930"])
 
     assert rows > 0
 
     # 결과 읽기
-    result = await store.read("005930", "krx", data_type="fundamental")
+    result = store.read("005930", "krx", data_type="fundamental")
     assert not result.is_empty()
 
     row = result.row(0, named=True)
@@ -477,12 +477,12 @@ async def test_compute_derived_zero_division(tmp_data_path: Path) -> None:
         }
     )
 
-    await store.write("005930", "krx", fundamental_df, data_type="fundamental")
+    store.write("005930", "krx", fundamental_df, data_type="fundamental")
 
     calculator = IndicatorCalculator()
-    await calculator.compute(store, ["005930"])
+    calculator.compute(store, ["005930"])
 
-    result = await store.read("005930", "krx", data_type="fundamental")
+    result = store.read("005930", "krx", data_type="fundamental")
     row = result.row(0, named=True)
 
     # 분모 0이면 None
@@ -510,11 +510,11 @@ async def test_compute_derived_missing_columns(tmp_data_path: Path) -> None:
         }
     )
 
-    await store.write("005930", "krx", fundamental_df, data_type="fundamental")
+    store.write("005930", "krx", fundamental_df, data_type="fundamental")
 
     calculator = IndicatorCalculator()
     # 에러 없이 실행되어야 함
-    rows = await calculator.compute(store, ["005930"])
+    rows = calculator.compute(store, ["005930"])
     assert rows >= 0
 
 

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -123,7 +123,7 @@ def store(data_dir):
 async def loaded_store(store):
     """데이터가 미리 적재된 store."""
     df = _make_ohlcv_df()
-    await store.write("005930", "1d", df)
+    store.write("005930", "1d", df)
     return store
 
 
@@ -134,7 +134,7 @@ async def data_provider(loaded_store):
         start_date="2026-01-01",
         end_date="2026-12-31",
     )
-    await provider.load("005930", "1d")
+    provider.load("005930", "1d")
     return provider
 
 

--- a/tests/unit/test_backtest_progress.py
+++ b/tests/unit/test_backtest_progress.py
@@ -93,7 +93,7 @@ class TestBacktestServiceProgress:
         ):
             mock_load.return_value = MagicMock()
             mock_dp = AsyncMock()
-            mock_dp.load = AsyncMock(return_value=100)
+            mock_dp.load = MagicMock(return_value=100)
             mock_dp_cls.return_value = mock_dp
 
             mock_exec = AsyncMock()

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -103,7 +103,7 @@ class FakeTreasury:
     def __init__(self) -> None:
         self._budgets: dict[str, FakeBotBudget] = {}
 
-    async def get_budget(self, bot_id: str) -> FakeBotBudget | None:
+    def get_budget(self, bot_id: str) -> FakeBotBudget | None:
         return self._budgets.get(bot_id)
 
 

--- a/tests/unit/test_bot_stop_release.py
+++ b/tests/unit/test_bot_stop_release.py
@@ -76,12 +76,12 @@ class TestBotStopRelease:
         await treasury.reserve_for_order("bot1", "ord1", 100_000.0)
         await treasury.reserve_for_order("bot1", "ord2", 200_000.0)
 
-        budget_before = await treasury.get_budget("bot1")
+        budget_before = treasury.get_budget("bot1")
         available_before = budget_before.available
 
         await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
 
-        budget_after = await treasury.get_budget("bot1")
+        budget_after = treasury.get_budget("bot1")
         assert budget_after.reserved == 0.0
         assert budget_after.available == pytest.approx(available_before + 300_000.0)
         assert treasury.get_reservations("bot1") == {}
@@ -94,16 +94,16 @@ class TestBotStopRelease:
         await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
 
         assert treasury.get_reservations("bot2") == {"ord2": 200_000.0}
-        budget2 = await treasury.get_budget("bot2")
+        budget2 = treasury.get_budget("bot2")
         assert budget2.reserved == 200_000.0
 
     async def test_bot_stopped_no_reservations_noop(self, treasury, eventbus):
         """예약 없는 봇 중지 → 아무 변화 없음."""
-        budget_before = await treasury.get_budget("bot1")
+        budget_before = treasury.get_budget("bot1")
 
         await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
 
-        budget_after = await treasury.get_budget("bot1")
+        budget_after = treasury.get_budget("bot1")
         assert budget_after.available == budget_before.available
         assert budget_after.reserved == budget_before.reserved
 
@@ -130,7 +130,7 @@ class TestBotStopRelease:
 
         await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
 
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget.reserved == 0.0
         # available should have all 500k returned
         assert budget.available == pytest.approx(5_000_000.0 - 500_000.0 + 500_000.0)
@@ -148,15 +148,15 @@ class TestReservationCompatibility:
     async def test_reserve_and_release_still_works(self, treasury):
         """기존 reserve/release 정상 동작."""
         await treasury.reserve_for_order("bot1", "ord1", 100_000.0)
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget.reserved == 100_000.0
 
         await treasury.release_reservation("bot1", "ord1")
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget.reserved == 0.0
 
     async def test_nonexistent_order_release_noop(self, treasury):
         """존재하지 않는 주문 해제 → 무시."""
         await treasury.release_reservation("bot1", "nonexistent")
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget.available == 5_000_000.0

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -132,19 +132,19 @@ class TestSchemas:
 class TestParquetStore:
     async def test_write_and_read(self, store):
         df = _make_ohlcv_df()
-        await store.write("005930", "1m", df)
+        store.write("005930", "1m", df)
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) == 5
         assert result["symbol"][0] == "005930"
 
     async def test_read_empty(self, store):
-        result = await store.read("999999", "1d")
+        result = store.read("999999", "1d")
         assert result.is_empty()
 
     async def test_write_creates_partitioned_files(self, store, data_dir):
         df = _make_ohlcv_df()
-        await store.write("005930", "1m", df)
+        store.write("005930", "1m", df)
 
         parquet_path = data_dir / "ohlcv" / "1m" / "005930" / "2026-03.parquet"
         assert parquet_path.exists()
@@ -152,17 +152,17 @@ class TestParquetStore:
     async def test_write_merge_dedup(self, store):
         """같은 timestamp 데이터를 두 번 쓰면 중복 제거."""
         df = _make_ohlcv_df(n=3)
-        await store.write("005930", "1m", df)
-        await store.write("005930", "1m", df)
+        store.write("005930", "1m", df)
+        store.write("005930", "1m", df)
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) == 3  # 중복 제거됨
 
     async def test_read_with_time_filter(self, store):
         df = _make_ohlcv_df(n=10, start="2026-03-01T09:00:00")
-        await store.write("005930", "1m", df)
+        store.write("005930", "1m", df)
 
-        result = await store.read(
+        result = store.read(
             "005930",
             "1m",
             start="2026-03-01T09:03:00",
@@ -172,9 +172,9 @@ class TestParquetStore:
 
     async def test_read_with_limit(self, store):
         df = _make_ohlcv_df(n=10)
-        await store.write("005930", "1m", df)
+        store.write("005930", "1m", df)
 
-        result = await store.read("005930", "1m", limit=3)
+        result = store.read("005930", "1m", limit=3)
         assert len(result) == 3
 
     async def test_append(self, store):
@@ -190,13 +190,13 @@ class TestParquetStore:
                 "source": "test",
             }
         ]
-        await store.append("005930", "1m", rows)
-        result = await store.read("005930", "1m")
+        store.append("005930", "1m", rows)
+        result = store.read("005930", "1m")
         assert len(result) == 1
 
     async def test_list_symbols(self, store):
-        await store.write("005930", "1d", _make_ohlcv_df("005930"))
-        await store.write("000660", "1d", _make_ohlcv_df("000660"))
+        store.write("005930", "1d", _make_ohlcv_df("005930"))
+        store.write("000660", "1d", _make_ohlcv_df("000660"))
 
         symbols = store.list_symbols("1d")
         assert symbols == ["000660", "005930"]
@@ -205,7 +205,7 @@ class TestParquetStore:
         assert store.list_symbols("1d") == []
 
     async def test_get_date_range(self, store):
-        await store.write("005930", "1m", _make_ohlcv_df())
+        store.write("005930", "1m", _make_ohlcv_df())
         result = store.get_date_range("005930", "1m")
         assert result is not None
         assert result == ("2026-03", "2026-03")
@@ -214,15 +214,15 @@ class TestParquetStore:
         assert store.get_date_range("999999", "1m") is None
 
     async def test_get_storage_usage(self, store):
-        await store.write("005930", "1d", _make_ohlcv_df())
+        store.write("005930", "1d", _make_ohlcv_df())
         usage = store.get_storage_usage()
         assert "1d" in usage
         assert usage["1d"] > 0
 
     async def test_delete_file(self, store):
-        await store.write("005930", "1m", _make_ohlcv_df())
+        store.write("005930", "1m", _make_ohlcv_df())
         assert store.delete_file("005930", "1m", "2026-03") is True
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert result.is_empty()
 
     async def test_delete_file_nonexistent(self, store):
@@ -230,8 +230,8 @@ class TestParquetStore:
 
     async def test_write_empty_df(self, store):
         empty = pl.DataFrame()
-        await store.write("005930", "1m", empty)
-        result = await store.read("005930", "1m")
+        store.write("005930", "1m", empty)
+        result = store.read("005930", "1m")
         assert result.is_empty()
 
     async def test_multi_month_partitioning(self, store, data_dir):
@@ -264,7 +264,7 @@ class TestParquetStore:
                 "source": ["test"] * n,
             }
         )
-        await store.write("005930", "1m", df)
+        store.write("005930", "1m", df)
 
         march_file = data_dir / "ohlcv" / "1m" / "005930" / "2026-03.parquet"
         april_file = data_dir / "ohlcv" / "1m" / "005930" / "2026-04.parquet"
@@ -284,8 +284,8 @@ class TestParquetStore:
                 "source": ["dart", "dart"],
             }
         )
-        await store.write("005930", "", df, data_type="fundamental")
-        result = await store.read("005930", "", data_type="fundamental")
+        store.write("005930", "", df, data_type="fundamental")
+        result = store.read("005930", "", data_type="fundamental")
         assert len(result) == 2
         assert result["market_cap"][0] == 500000000000
 
@@ -300,7 +300,7 @@ class TestParquetStore:
                 "source": ["dart"],
             }
         )
-        await store.write("005930", "", df, data_type="fundamental")
+        store.write("005930", "", df, data_type="fundamental")
         path = data_dir / "fundamental" / "krx" / "005930"
         assert path.exists()
         assert list(path.glob("*.parquet"))
@@ -316,7 +316,7 @@ class TestParquetStore:
                 "source": ["dart"],
             }
         )
-        await store.write("005930", "", df, data_type="fundamental")
+        store.write("005930", "", df, data_type="fundamental")
         symbols = store.list_symbols(data_type="fundamental")
         assert symbols == ["005930"]
 
@@ -324,7 +324,7 @@ class TestParquetStore:
         """get_storage_usage가 fundamental 용량도 포함."""
         from datetime import date
 
-        await store.write("005930", "1d", _make_ohlcv_df())
+        store.write("005930", "1d", _make_ohlcv_df())
         df = pl.DataFrame(
             {
                 "date": [date(2026, 3, 1)],
@@ -332,7 +332,7 @@ class TestParquetStore:
                 "source": ["dart"],
             }
         )
-        await store.write("005930", "", df, data_type="fundamental")
+        store.write("005930", "", df, data_type="fundamental")
         usage = store.get_storage_usage()
         assert "1d" in usage
         assert "fundamental" in usage
@@ -340,8 +340,8 @@ class TestParquetStore:
     async def test_ohlcv_default_backward_compat(self, store):
         """data_type 미지정 시 기존 OHLCV 동작 유지."""
         df = _make_ohlcv_df()
-        await store.write("005930", "1m", df)
-        result = await store.read("005930", "1m")
+        store.write("005930", "1m", df)
+        result = store.read("005930", "1m")
         assert len(result) == 5
 
 
@@ -650,10 +650,10 @@ class TestDataCollector:
             "volume": 1000,
             "source": "test",
         }
-        await collector.add_data("005930", "1m", row)
+        collector.add_data("005930", "1m", row)
         assert len(collector.buffer["005930:1m"]) == 1
 
-        flushed = await collector.flush_all()
+        flushed = collector.flush_all()
         assert flushed == 1
         assert "005930:1m" not in collector.buffer
 
@@ -674,12 +674,12 @@ class TestDataCollector:
                 "volume": 1000,
                 "source": "test",
             }
-            await collector.add_data("005930", "1m", row)
+            collector.add_data("005930", "1m", row)
 
         # buffer_size=2이므로 자동 flush됨
         assert "005930:1m" not in collector.buffer
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) == 2
 
     async def test_start_and_stop(self, store):
@@ -688,11 +688,11 @@ class TestDataCollector:
         eventbus = AsyncMock()
         collector = DataCollector(store=store, eventbus=eventbus, collect_interval=0.05)
 
-        await collector.start(["005930"], ["1m"])
+        collector.start(["005930"], ["1m"])
         assert collector.running is True
 
         await asyncio.sleep(0.02)
-        await collector.stop()
+        collector.stop()
         assert collector.running is False
 
     async def test_start_twice_ignored(self, store):
@@ -701,11 +701,11 @@ class TestDataCollector:
         eventbus = AsyncMock()
         collector = DataCollector(store=store, eventbus=eventbus)
 
-        await collector.start(["005930"], ["1m"])
-        await collector.start(["005930"], ["1m"])  # 두 번째 호출은 무시
+        collector.start(["005930"], ["1m"])
+        collector.start(["005930"], ["1m"])  # 두 번째 호출은 무시
         assert collector.running is True
 
-        await collector.stop()
+        collector.stop()
 
     async def test_data_callback(self, store):
         from unittest.mock import AsyncMock
@@ -733,11 +733,11 @@ class TestDataCollector:
             ]
 
         collector.set_data_callback(mock_callback)
-        await collector.start(["005930"], ["1m"])
+        collector.start(["005930"], ["1m"])
         await asyncio.sleep(0.1)
-        await collector.stop()
+        collector.stop()
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) >= 1
 
 
@@ -759,45 +759,45 @@ class TestRetentionPolicy:
 
     async def test_enforce_deletes_old_data(self, store):
         """보존 기간 초과 데이터 삭제."""
-        await store.write("005930", "1m", _make_ohlcv_df())
+        store.write("005930", "1m", _make_ohlcv_df())
 
         # 1분봉 보존 기간을 0일로 설정 → 모든 데이터 삭제 대상
         policy = RetentionPolicy(store, retention_days={"1m": 0})
         now = datetime(2026, 6, 1, tzinfo=UTC)
-        deleted = await policy.enforce(now=now)
+        deleted = policy.enforce(now=now)
 
         assert "1m" in deleted
         assert deleted["1m"] >= 1
 
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert result.is_empty()
 
     async def test_enforce_keeps_recent_data(self, store):
         """보존 기간 내 데이터는 유지."""
-        await store.write("005930", "1m", _make_ohlcv_df())
+        store.write("005930", "1m", _make_ohlcv_df())
 
         policy = RetentionPolicy(store, retention_days={"1m": 365})
         now = datetime(2026, 3, 15, tzinfo=UTC)
-        deleted = await policy.enforce(now=now)
+        deleted = policy.enforce(now=now)
 
         # 2026-03 데이터는 15일 전이므로 삭제 안 됨
         assert deleted == {}
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) == 5
 
     async def test_enforce_skips_negative_retention(self, store):
         """보존 기간이 -1(무기한)이면 삭제하지 않는다."""
-        await store.write("005930", "1m", _make_ohlcv_df())
+        store.write("005930", "1m", _make_ohlcv_df())
         policy = RetentionPolicy(store, retention_days={"1m": -1})
         now = datetime(2099, 1, 1, tzinfo=UTC)
-        deleted = await policy.enforce(now=now)
+        deleted = policy.enforce(now=now)
         assert deleted == {}
-        result = await store.read("005930", "1m")
+        result = store.read("005930", "1m")
         assert len(result) == 5
 
     async def test_enforce_empty_store(self, store):
         policy = RetentionPolicy(store)
-        deleted = await policy.enforce()
+        deleted = policy.enforce()
         assert deleted == {}
 
     async def test_enforce_fundamental_path_resolution(self, store, data_dir):
@@ -812,7 +812,7 @@ class TestRetentionPolicy:
                 "source": ["dart", "dart"],
             }
         )
-        await store.write("005930", "", df, data_type="fundamental")
+        store.write("005930", "", df, data_type="fundamental")
 
         # fundamental/krx/005930/ 경로에 파일이 생성되었는지 확인
         fundamental_path = data_dir / "fundamental" / "krx" / "005930"
@@ -822,12 +822,12 @@ class TestRetentionPolicy:
         # fundamental 보존 기간을 0일로 설정 → 오래된 데이터 삭제 대상
         policy = RetentionPolicy(store, retention_days={"fundamental": 0})
         now = datetime(2026, 6, 1, tzinfo=UTC)
-        deleted = await policy.enforce(now=now)
+        deleted = policy.enforce(now=now)
 
         assert "fundamental" in deleted
         assert deleted["fundamental"] == 2
 
-        result = await store.read("005930", "", data_type="fundamental")
+        result = store.read("005930", "", data_type="fundamental")
         assert result.is_empty()
 
 

--- a/tests/unit/test_dataset_delete_api.py
+++ b/tests/unit/test_dataset_delete_api.py
@@ -69,7 +69,7 @@ class TestListDatasets:
 
     async def test_response_wrapper_format(self, client, store):
         """응답이 {items, total} 래퍼를 사용한다."""
-        await store.write("005930", "1d", _make_ohlcv_df())
+        store.write("005930", "1d", _make_ohlcv_df())
         resp = client.get("/api/data/datasets")
         assert resp.status_code == 200
         body = resp.json()
@@ -80,7 +80,7 @@ class TestListDatasets:
 
     async def test_field_names(self, client, store):
         """각 데이터셋에 id, start_date, end_date, row_count 필드가 있다."""
-        await store.write("005930", "1d", _make_ohlcv_df())
+        store.write("005930", "1d", _make_ohlcv_df())
         resp = client.get("/api/data/datasets")
         ds = resp.json()["items"][0]
         assert ds["id"] == "005930__1d"
@@ -94,7 +94,7 @@ class TestListDatasets:
     async def test_pagination(self, client, store):
         """offset/limit 파라미터로 페이지네이션이 동작한다."""
         for sym in ["000010", "000020", "000030"]:
-            await store.write(sym, "1d", _make_ohlcv_df())
+            store.write(sym, "1d", _make_ohlcv_df())
 
         resp = client.get("/api/data/datasets", params={"offset": 0, "limit": 2})
         body = resp.json()
@@ -108,8 +108,8 @@ class TestListDatasets:
 
     async def test_filter_by_symbol(self, client, store):
         """symbol 필터로 특정 종목만 반환한다."""
-        await store.write("005930", "1d", _make_ohlcv_df())
-        await store.write("035720", "1d", _make_ohlcv_df())
+        store.write("005930", "1d", _make_ohlcv_df())
+        store.write("035720", "1d", _make_ohlcv_df())
 
         resp = client.get("/api/data/datasets", params={"symbol": "005930"})
         body = resp.json()
@@ -118,8 +118,8 @@ class TestListDatasets:
 
     async def test_filter_by_timeframe(self, client, store):
         """timeframe 필터로 특정 타임프레임만 반환한다."""
-        await store.write("005930", "1d", _make_ohlcv_df())
-        await store.write("005930", "1h", _make_ohlcv_df())
+        store.write("005930", "1d", _make_ohlcv_df())
+        store.write("005930", "1h", _make_ohlcv_df())
 
         resp = client.get("/api/data/datasets", params={"timeframe": "1d"})
         body = resp.json()
@@ -137,7 +137,7 @@ class TestListDatasets:
 class TestDeleteDataset:
     async def test_delete_success(self, client, store):
         """데이터셋 삭제 성공."""
-        await store.write("005930", "1d", _make_ohlcv_df())
+        store.write("005930", "1d", _make_ohlcv_df())
         resp = client.delete("/api/data/datasets/005930__1d")
         assert resp.status_code == 204
 
@@ -153,7 +153,7 @@ class TestDeleteDataset:
 
     async def test_datasets_empty_after_delete(self, client, store):
         """삭제 후 목록에서 제거 확인."""
-        await store.write("005930", "1d", _make_ohlcv_df())
+        store.write("005930", "1d", _make_ohlcv_df())
         client.delete("/api/data/datasets/005930__1d")
         resp = client.get("/api/data/datasets")
         assert resp.status_code == 200
@@ -167,7 +167,7 @@ class TestFundamentalDatasets:
 
     async def test_list_fundamental_datasets(self, client, store):
         """fundamental 데이터셋 목록 조회."""
-        await store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
         resp = client.get("/api/data/datasets", params={"data_type": "fundamental"})
         assert resp.status_code == 200
         body = resp.json()
@@ -178,14 +178,14 @@ class TestFundamentalDatasets:
 
     async def test_list_ohlcv_excludes_fundamental(self, client, store):
         """OHLCV 조회 시 fundamental 데이터가 포함되지 않음."""
-        await store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
         resp = client.get("/api/data/datasets", params={"data_type": "ohlcv"})
         assert resp.status_code == 200
         assert resp.json()["items"] == []
 
     async def test_delete_fundamental_dataset(self, client, store):
         """fundamental 데이터셋 삭제."""
-        await store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
         resp = client.delete(
             "/api/data/datasets/005930__fundamental",
             params={"data_type": "fundamental"},

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -215,7 +215,7 @@ class TestAPIGateway:
             eventbus=eventbus,
             rate_config=RateLimitConfig(max_requests=100, window_seconds=60),
         )
-        await gw.start()
+        gw.start()
         return gw
 
     async def test_get_current_price(self, gateway, broker):
@@ -281,7 +281,7 @@ class TestAPIGatewayEvents:
             eventbus=eventbus,
             rate_config=RateLimitConfig(max_requests=100, window_seconds=60),
         )
-        await gw.start()
+        gw.start()
         return gw
 
     async def test_order_approved_submits(self, gateway, eventbus, broker):

--- a/tests/unit/test_kis_error_handling.py
+++ b/tests/unit/test_kis_error_handling.py
@@ -353,7 +353,7 @@ class TestGatewayCancelFailed:
         mock_broker.cancel_order = AsyncMock(side_effect=Exception("network error"))
 
         gw = APIGateway(broker=mock_broker, eventbus=eventbus)
-        await gw.start()
+        gw.start()
 
         received: list[OrderCancelFailedEvent] = []
         eventbus.subscribe(OrderCancelFailedEvent, lambda e: received.append(e))

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -132,7 +132,7 @@ async def test_composition_root_all_modules(tmp_path: Path) -> None:
     from ante.rule import RuleEngine
 
     rule_engine = RuleEngine(eventbus=eventbus, system_state=system_state)
-    await rule_engine.start()
+    rule_engine.start()
 
     # 8. Treasury
     from ante.treasury import Treasury

--- a/tests/unit/test_parquet_validation.py
+++ b/tests/unit/test_parquet_validation.py
@@ -69,7 +69,7 @@ class TestParquetValidate:
         _create_valid_parquet(tmp_path / "ohlcv" / "1d" / "005930" / "2026-01.parquet")
         _create_valid_parquet(tmp_path / "ohlcv" / "1d" / "005930" / "2026-02.parquet")
 
-        result = await tmp_store.validate("005930", "1d")
+        result = tmp_store.validate("005930", "1d")
 
         assert result["total"] == 2
         assert result["valid"] == 2
@@ -83,7 +83,7 @@ class TestParquetValidate:
             tmp_path / "ohlcv" / "1d" / "005930" / "2026-02.parquet"
         )
 
-        result = await tmp_store.validate("005930", "1d")
+        result = tmp_store.validate("005930", "1d")
 
         assert result["total"] == 2
         assert result["valid"] == 1
@@ -95,7 +95,7 @@ class TestParquetValidate:
         corrupted_path = tmp_path / "ohlcv" / "1d" / "005930" / "2026-02.parquet"
         _create_corrupted_parquet(corrupted_path)
 
-        result = await tmp_store.validate("005930", "1d", fix=True)
+        result = tmp_store.validate("005930", "1d", fix=True)
 
         assert result["corrupted"] == 1
         assert not corrupted_path.exists()
@@ -103,7 +103,7 @@ class TestParquetValidate:
 
     @pytest.mark.asyncio
     async def test_validate_no_data(self, tmp_store):
-        result = await tmp_store.validate("NONE", "1d")
+        result = tmp_store.validate("NONE", "1d")
 
         assert result["total"] == 0
         assert result["valid"] == 0
@@ -113,56 +113,50 @@ class TestParquetValidate:
     async def test_validate_empty_directory(self, tmp_store, tmp_path):
         (tmp_path / "ohlcv" / "1d" / "005930").mkdir(parents=True)
 
-        result = await tmp_store.validate("005930", "1d")
+        result = tmp_store.validate("005930", "1d")
 
         assert result["total"] == 0
 
 
 class TestValidateCLI:
     def test_validate_specific_symbol(self, runner):
-        with patch("asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "symbol": "005930",
-                    "timeframe": "1d",
-                    "total": 3,
-                    "valid": 3,
-                    "corrupted": 0,
-                    "corrupted_files": [],
-                }
-            ]
+        with patch("ante.data.store.ParquetStore.validate") as mock_validate:
+            mock_validate.return_value = {
+                "symbol": "005930",
+                "timeframe": "1d",
+                "total": 3,
+                "valid": 3,
+                "corrupted": 0,
+                "corrupted_files": [],
+            }
             result = runner.invoke(cli, ["data", "validate", "--symbol", "005930"])
             assert result.exit_code == 0
             assert "정상 3개" in result.output
 
     def test_validate_with_corrupted(self, runner):
-        with patch("asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "symbol": "005930",
-                    "timeframe": "1d",
-                    "total": 3,
-                    "valid": 2,
-                    "corrupted": 1,
-                    "corrupted_files": ["/data/ohlcv/1d/005930/2026-01.parquet"],
-                }
-            ]
+        with patch("ante.data.store.ParquetStore.validate") as mock_validate:
+            mock_validate.return_value = {
+                "symbol": "005930",
+                "timeframe": "1d",
+                "total": 3,
+                "valid": 2,
+                "corrupted": 1,
+                "corrupted_files": ["/data/ohlcv/1d/005930/2026-01.parquet"],
+            }
             result = runner.invoke(cli, ["data", "validate", "--symbol", "005930"])
             assert result.exit_code == 0
             assert "손상 1개" in result.output
 
     def test_validate_json_output(self, runner):
-        with patch("asyncio.run") as mock_run:
-            mock_run.return_value = [
-                {
-                    "symbol": "005930",
-                    "timeframe": "1d",
-                    "total": 2,
-                    "valid": 2,
-                    "corrupted": 0,
-                    "corrupted_files": [],
-                }
-            ]
+        with patch("ante.data.store.ParquetStore.validate") as mock_validate:
+            mock_validate.return_value = {
+                "symbol": "005930",
+                "timeframe": "1d",
+                "total": 2,
+                "valid": 2,
+                "corrupted": 0,
+                "corrupted_files": [],
+            }
             result = runner.invoke(
                 cli,
                 ["--format", "json", "data", "validate", "--symbol", "005930"],
@@ -181,11 +175,11 @@ class TestValidateCLI:
 
     def test_validate_all_symbols(self, runner):
         with (
-            patch("asyncio.run") as mock_run,
+            patch("ante.data.store.ParquetStore.validate") as mock_validate,
             patch("ante.data.store.ParquetStore.list_symbols") as mock_list,
         ):
             mock_list.return_value = ["005930", "000660"]
-            mock_run.return_value = [
+            mock_validate.side_effect = [
                 {
                     "symbol": "005930",
                     "timeframe": "1d",

--- a/tests/unit/test_report_draft.py
+++ b/tests/unit/test_report_draft.py
@@ -185,7 +185,7 @@ class TestOnBacktestComplete:
         mock_eventbus.subscribe = MagicMock()
 
         generator = ReportDraftGenerator(mock_store, mock_eventbus)
-        await generator.initialize()
+        generator.initialize()
 
         mock_eventbus.subscribe.assert_called_once()
 

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -473,7 +473,7 @@ class TestRuleEngineEventBus:
     @pytest.fixture
     async def engine(self, eventbus, system_state):
         engine = RuleEngine(eventbus=eventbus, system_state=system_state)
-        await engine.start()
+        engine.start()
         return engine
 
     async def test_order_validated_on_pass(self, engine, eventbus):

--- a/tests/unit/test_rule_modify.py
+++ b/tests/unit/test_rule_modify.py
@@ -55,7 +55,7 @@ async def system_state(db):
 async def engine(system_state):
     eventbus = EventBus()
     engine = RuleEngine(eventbus=eventbus, system_state=system_state)
-    await engine.start()
+    engine.start()
     return engine
 
 

--- a/tests/unit/test_stop_order.py
+++ b/tests/unit/test_stop_order.py
@@ -87,7 +87,7 @@ class TestTrigger:
         self, _mock_session: MagicMock, manager: StopOrderManager, eventbus: MagicMock
     ) -> None:
         """매도 스탑: 현재가 <= stop_price 시 트리거."""
-        await manager.start()
+        manager.start()
 
         await manager.register(
             order_id="ord-001",
@@ -123,7 +123,7 @@ class TestTrigger:
         self, _mock_session: MagicMock, manager: StopOrderManager, eventbus: MagicMock
     ) -> None:
         """매수 스탑: 현재가 >= stop_price 시 트리거."""
-        await manager.start()
+        manager.start()
 
         await manager.register(
             order_id="ord-002",
@@ -148,7 +148,7 @@ class TestTrigger:
         self, _mock_session: MagicMock, manager: StopOrderManager, eventbus: MagicMock
     ) -> None:
         """stop_limit → limit 변환."""
-        await manager.start()
+        manager.start()
 
         await manager.register(
             order_id="ord-003",
@@ -174,7 +174,7 @@ class TestTrigger:
         self, manager: StopOrderManager, eventbus: MagicMock
     ) -> None:
         """트리거 조건 미충족 시 주문 유지."""
-        await manager.start()
+        manager.start()
 
         await manager.register(
             order_id="ord-004",
@@ -198,7 +198,7 @@ class TestTrigger:
         self, manager: StopOrderManager, eventbus: MagicMock
     ) -> None:
         """다른 종목 시세는 무시."""
-        await manager.start()
+        manager.start()
 
         await manager.register(
             order_id="ord-005",
@@ -256,13 +256,13 @@ class TestCancel:
             stop_price=49000.0,
         )
 
-        result = await manager.cancel(stop_id)
+        result = manager.cancel(stop_id)
         assert result is True
         assert len(manager.active_orders) == 0
 
     async def test_cancel_nonexistent(self, manager: StopOrderManager) -> None:
         """존재하지 않는 주문 취소."""
-        result = await manager.cancel("stop-nonexistent")
+        result = manager.cancel("stop-nonexistent")
         assert result is False
 
 
@@ -273,7 +273,7 @@ class TestExpiry:
         self, manager: StopOrderManager, eventbus: MagicMock
     ) -> None:
         """매니저 중지 시 모든 주문 만료."""
-        await manager.start()
+        manager.start()
 
         await manager.register(
             order_id="ord-001",

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -117,53 +117,53 @@ class TestCommands:
     """명령 핸들러 테스트."""
 
     async def test_help(self, receiver):
-        result = await receiver._cmd_help([])
+        result = receiver._cmd_help([])
         assert "/status" in result
         assert "/halt" in result
         assert "/help" in result
 
     async def test_status(self, receiver):
-        result = await receiver._cmd_status([])
+        result = receiver._cmd_status([])
         assert "거래 상태" in result
         assert "active" in result
         assert "봇" in result
 
     async def test_status_no_manager(self, receiver):
         receiver._bot_manager = None
-        result = await receiver._cmd_status([])
+        result = receiver._cmd_status([])
         assert "거래 상태" in result
 
     async def test_status_no_state(self, receiver):
         receiver._system_state = None
         receiver._bot_manager = None
-        result = await receiver._cmd_status([])
+        result = receiver._cmd_status([])
         assert "조회할 수 없습니다" in result
 
     async def test_bots(self, receiver):
-        result = await receiver._cmd_bots([])
+        result = receiver._cmd_bots([])
         assert "봇 목록" in result
         assert "bot-1" in result
         assert "bot-2" in result
 
     async def test_bots_no_manager(self, receiver):
         receiver._bot_manager = None
-        result = await receiver._cmd_bots([])
+        result = receiver._cmd_bots([])
         assert "연결되지 않았습니다" in result
 
     async def test_bots_empty(self, receiver):
         receiver._bot_manager.list_bots.return_value = []
-        result = await receiver._cmd_bots([])
+        result = receiver._cmd_bots([])
         assert "없습니다" in result
 
     async def test_balance(self, receiver):
-        result = await receiver._cmd_balance([])
+        result = receiver._cmd_balance([])
         assert "계좌 잔고" in result
         assert "10,000,000" in result
         assert "할당" in result
 
     async def test_balance_no_treasury(self, receiver):
         receiver._treasury = None
-        result = await receiver._cmd_balance([])
+        result = receiver._cmd_balance([])
         assert "연결되지 않았습니다" in result
 
     async def test_unknown_command(self, receiver):

--- a/tests/unit/test_treasury.py
+++ b/tests/unit/test_treasury.py
@@ -81,7 +81,7 @@ class TestAllocation:
         """예산 할당."""
         result = await treasury.allocate("bot1", 1_000_000.0)
         assert result is True
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.allocated == 1_000_000.0
         assert budget.available == 1_000_000.0
@@ -101,7 +101,7 @@ class TestAllocation:
         await treasury.allocate("bot1", 1_000_000.0)
         result = await treasury.deallocate("bot1", 500_000.0)
         assert result is True
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.allocated == 500_000.0
         assert budget.available == 500_000.0
@@ -123,7 +123,7 @@ class TestAllocation:
         """동일 봇에 추가 할당."""
         await treasury.allocate("bot1", 500_000.0)
         await treasury.allocate("bot1", 300_000.0)
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.allocated == 800_000.0
         assert budget.available == 800_000.0
@@ -227,7 +227,7 @@ class TestReservation:
         await treasury.allocate("bot1", 1_000_000.0)
         result = await treasury.reserve_for_order("bot1", "ord1", 500_000.0)
         assert result is True
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.available == 500_000.0
         assert budget.reserved == 500_000.0
@@ -243,7 +243,7 @@ class TestReservation:
         await treasury.allocate("bot1", 1_000_000.0)
         await treasury.reserve_for_order("bot1", "ord1", 500_000.0)
         await treasury.release_reservation("bot1", "ord1")
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.available == 1_000_000.0
         assert budget.reserved == 0.0
@@ -252,7 +252,7 @@ class TestReservation:
         """존재하지 않는 주문 해제는 무시."""
         await treasury.allocate("bot1", 1_000_000.0)
         await treasury.release_reservation("bot1", "unknown_ord")
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.available == 1_000_000.0
 
@@ -285,7 +285,7 @@ class TestTreasuryEvents:
         assert received[0].order_id == "ord1"
         assert received[0].reserved_amount > 0
 
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.reserved > 0
         assert budget.available < 1_000_000.0
@@ -356,7 +356,7 @@ class TestTreasuryEvents:
             )
         )
 
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.reserved == 0.0
         assert budget.spent == 500_075.0  # 500,000 + 75
@@ -382,7 +382,7 @@ class TestTreasuryEvents:
             )
         )
 
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         expected_proceeds = 550_000.0 - 82.5
         assert budget.returned == expected_proceeds
@@ -406,7 +406,7 @@ class TestTreasuryEvents:
             )
         )
 
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.available == 1_000_000.0
         assert budget.reserved == 0.0
@@ -430,7 +430,7 @@ class TestTreasuryEvents:
             )
         )
 
-        budget = await treasury.get_budget("bot1")
+        budget = treasury.get_budget("bot1")
         assert budget is not None
         assert budget.available == 1_000_000.0
         assert budget.reserved == 0.0
@@ -488,7 +488,7 @@ class TestTreasuryPersistence:
 
         assert t2.account_balance == 5_000_000.0
         assert t2.unallocated == 3_000_000.0
-        budget = await t2.get_budget("bot1")
+        budget = t2.get_budget("bot1")
         assert budget is not None
         assert budget.allocated == 2_000_000.0
         assert budget.available == 2_000_000.0

--- a/tests/unit/test_treasury_sync.py
+++ b/tests/unit/test_treasury_sync.py
@@ -183,7 +183,7 @@ class TestSyncLoop:
         broker = FakeBroker()
         pos_history = FakePositionHistory()
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=1)
+        treasury.start_sync(broker, pos_history, interval_seconds=1)
         assert treasury._sync_task is not None
         assert not treasury._sync_task.done()
 
@@ -198,7 +198,7 @@ class TestSyncLoop:
         broker = FakeBroker()
         pos_history = FakePositionHistory()
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 
@@ -213,7 +213,7 @@ class TestSyncLoop:
         broker = FailingBroker()
         pos_history = FakePositionHistory()
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 
@@ -227,7 +227,7 @@ class TestSyncLoop:
         broker = FakeBroker()
         pos_history = FakePositionHistory()
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 
@@ -240,10 +240,10 @@ class TestSyncLoop:
         broker = FakeBroker()
         pos_history = FakePositionHistory()
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         task1 = treasury._sync_task
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         assert treasury._sync_task is task1  # 같은 태스크
 
         await treasury.stop_sync()
@@ -286,7 +286,7 @@ class TestExternalPositions:
             ]
         )
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 
@@ -316,7 +316,7 @@ class TestExternalPositions:
             ]
         )
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 
@@ -337,7 +337,7 @@ class TestExternalPositions:
         )
         pos_history = FakePositionHistory(positions=[])
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 
@@ -358,7 +358,7 @@ class TestExternalPositions:
         )
         pos_history = FakePositionHistory(positions=[])
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 
@@ -386,7 +386,7 @@ class TestExternalPositions:
         )
         pos_history = FakePositionHistory(positions=[])
 
-        await treasury.start_sync(broker, pos_history, interval_seconds=100)
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 


### PR DESCRIPTION
Refs #406

## 개요

수동 정적 분석 + SonarQube 분석 결과를 기반으로 한 코드 퀄리티 개선 에픽.
모든 변경은 순수 리팩토링 — 외부 동작(기능) 그대로 유지, 내부 구조만 개선.

## 하위 이슈 (13개, 모두 완료)

### P0 — 긴급
- #407 ✅ asyncio.CancelledError 미재발생 버그 수정 (6건 수정, 5건 정상 확인)
- #408 ✅ main.py Composition Root 분리 (499줄 → 22줄)
- #409 ✅ FeedOrchestrator God Class 분해 (910줄 → 6개 클래스)
- #410 ✅ KIS 어댑터 _request() 관심사 분리 (116줄 → 30줄)

### P1 — 높음
- #411 ✅ Web 라우트 의존성 주입 전환 (getattr 68회 → Depends)
- #412 ✅ FastAPI Annotated 타입 힌트 전환
- #413 ✅ feed/transform/validate.py 복잡도 개선 (CC 50 → ~5)
- #414 ✅ feed/cli.py 스케줄러 루프 분리 (319줄 → 46줄)

### P2 — 중간
- #415 ✅ MemberService 관심사 분리 (773줄 → 4개 클래스)
- #416 ✅ 문자열 리터럴 상수 추출 (6개 파일, 12개 상수)
- #417 ✅ 부동소수점 비교 버그 수정 (math.isclose 적용)
- #418 ✅ 불필요한 async 함수 정리 (25건+ 전환)

### P3 — 낮음
- #419 ✅ HTTPException 응답 문서화 (46개 엔드포인트)

## 테스트
- 1750 passed, 3 skipped (e2e 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)