### PR TITLE
feat: TestBrokerAdapter — 개발/검증용 테스트 브로커 구현

### DIFF
--- a/src/ante/broker/__init__.py
+++ b/src/ante/broker/__init__.py
@@ -15,6 +15,7 @@ from ante.broker.kis_stream import KISStreamClient
 from ante.broker.mock import MockBrokerAdapter
 from ante.broker.models import CommissionInfo
 from ante.broker.order_registry import OrderRegistry
+from ante.broker.test import TestBrokerAdapter
 
 __all__ = [
     "BrokerAdapter",
@@ -26,6 +27,7 @@ __all__ = [
     "KISStreamClient",
     "MockBrokerAdapter",
     "OrderRegistry",
+    "TestBrokerAdapter",
     "BrokerError",
     "AuthenticationError",
     "APIError",

--- a/src/ante/broker/test.py
+++ b/src/ante/broker/test.py
@@ -1,20 +1,39 @@
-"""PriceSimulator — GBM 기반 가격 시뮬레이션 엔진.
+"""TestBrokerAdapter 및 PriceSimulator — 개발/검증용 테스트 브로커.
 
-Test 브로커에서 사용할 현실적 가격 변동 엔진.
-시드 생성기의 GBM 로직을 재활용하되, 틱 단위(초 단위) 변동을 지원한다.
+KIS 실전 API 없이도 시스템 전체 흐름을 검증할 수 있는 테스트 브로커.
+GBM 기반 가격 시뮬레이션, 현실적 체결(슬리피지/부분 체결),
+인메모리 잔고/포지션 관리를 지원한다.
+MockBrokerAdapter(E2E용)와는 목적이 다르며 유지한다.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import math
 import random
-from dataclasses import dataclass
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from ante.broker.base import BrokerAdapter
+from ante.broker.exceptions import BrokerError, OrderNotFoundError
+from ante.broker.models import CommissionInfo
 
 logger = logging.getLogger(__name__)
 
 # KRX 하루 거래 시간: 09:00~15:30 = 6.5시간 = 23,400초
 KRX_TRADING_SECONDS = 23_400
+
+# ── 슬리피지/부분 체결 기본값 ────────────────────────────────
+_SLIPPAGE_MIN = 0.001  # 0.1%
+_SLIPPAGE_MAX = 0.003  # 0.3%
+_PARTIAL_FILL_THRESHOLD = 100  # 이 수량 이상이면 부분 체결 확률 적용
+_PARTIAL_FILL_PROBABILITY = 0.3  # 부분 체결 발생 확률
+_PARTIAL_FILL_RATIO_MIN = 0.3
+_PARTIAL_FILL_RATIO_MAX = 0.9
 
 
 @dataclass(frozen=True)
@@ -154,3 +173,422 @@ class PriceSimulator:
     def presets(self) -> dict[str, StockPreset]:
         """종목 프리셋 조회."""
         return dict(self._presets)
+
+
+# ── TestBrokerAdapter 내부 모델 ──────────────────────────────
+
+
+@dataclass
+class _TestPosition:
+    """인메모리 가상 포지션."""
+
+    symbol: str
+    quantity: float
+    avg_price: float
+
+
+@dataclass
+class _TestOrder:
+    """인메모리 주문 기록."""
+
+    order_id: str
+    symbol: str
+    side: str
+    quantity: float
+    filled_quantity: float
+    price: float
+    order_type: str
+    status: str  # "pending" | "filled" | "partially_filled" | "cancelled"
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+# ── TestBrokerAdapter ────────────────────────────────────────
+
+
+class TestBrokerAdapter(BrokerAdapter):
+    """개발/검증용 테스트 브로커 어댑터.
+
+    KIS와 동일한 BrokerAdapter 인터페이스로 현실적인 시뮬레이션 데이터를 반환한다.
+    PriceSimulator(GBM) 기반 가격 변동, 슬리피지/부분 체결 시뮬레이션,
+    인메모리 잔고/포지션/주문 이력 관리를 제공한다.
+
+    설정 옵션:
+        seed: 시뮬레이션 시드 (기본 42, 재현 가능)
+        initial_cash: 초기 현금 (기본 100_000_000)
+        tick_interval: 스트리밍 가격 변동 간격 초 (기본 1.0)
+    """
+
+    broker_id: str = "test"
+    broker_name: str = "테스트 브로커"
+    broker_short_name: str = "TEST"
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        config.setdefault("exchange", "KRX")
+        super().__init__(config)
+
+        self._seed: int = config.get("seed", 42)
+        self._initial_cash: float = config.get("initial_cash", 100_000_000.0)
+        self._tick_interval: float = config.get("tick_interval", 1.0)
+
+        # 시뮬레이터
+        self._simulator = PriceSimulator(seed=self._seed)
+        self._rng = random.Random(self._seed)
+
+        # 인메모리 상태
+        self._cash: float = self._initial_cash
+        self._positions: dict[str, _TestPosition] = {}
+        self._orders: dict[str, _TestOrder] = {}
+
+        # 수수료 (KIS 동일)
+        self._commission = CommissionInfo(
+            commission_rate=config.get("commission_rate", 0.00015),
+            sell_tax_rate=config.get("sell_tax_rate", 0.0023),
+        )
+
+    # ── 연결 ──────────────────────────────────────────────
+
+    async def connect(self) -> None:
+        """Test 브로커 연결 (항상 성공)."""
+        self.is_connected = True
+        logger.info(
+            "Test Broker 연결됨 (seed=%d, cash=%.0f)",
+            self._seed,
+            self._cash,
+        )
+
+    async def disconnect(self) -> None:
+        """Test 브로커 연결 해제."""
+        self.is_connected = False
+        logger.info("Test Broker 연결 해제")
+
+    # ── 시세 조회 ─────────────────────────────────────────
+
+    async def get_current_price(self, symbol: str) -> float:
+        """현재가 조회 — 매 호출마다 GBM 변동 적용."""
+        return self._simulator.tick(symbol)
+
+    # ── 계좌/포지션 ───────────────────────────────────────
+
+    async def get_account_balance(self) -> dict[str, float]:
+        """가상 계좌 잔고 조회."""
+        total_stock_value = sum(
+            pos.quantity * self._simulator.get_price(pos.symbol)
+            for pos in self._positions.values()
+        )
+        return {
+            "cash": self._cash,
+            "total_assets": self._cash + total_stock_value,
+            "stock_value": total_stock_value,
+        }
+
+    async def get_positions(self) -> list[dict[str, Any]]:
+        """보유 포지션 조회 — 현재 시뮬레이션 가격으로 평가손익 계산."""
+        return [
+            {
+                "symbol": pos.symbol,
+                "quantity": pos.quantity,
+                "avg_price": pos.avg_price,
+                "current_price": self._simulator.get_price(pos.symbol),
+                "pnl": (self._simulator.get_price(pos.symbol) - pos.avg_price)
+                * pos.quantity,
+            }
+            for pos in self._positions.values()
+            if pos.quantity > 0
+        ]
+
+    async def get_account_positions(self) -> list[dict[str, Any]]:
+        """증권사 실제 보유 잔고 (대사용) — get_positions() 위임."""
+        return await self.get_positions()
+
+    # ── 주문/체결 ─────────────────────────────────────────
+
+    async def place_order(
+        self,
+        symbol: str,
+        side: str,
+        quantity: float,
+        order_type: str = "market",
+        price: float | None = None,
+        stop_price: float | None = None,
+    ) -> str:
+        """주문 접수 및 체결 시뮬레이션.
+
+        시장가: 현재 시뮬레이션가 +/- 슬리피지로 즉시 체결.
+        지정가: 지정가와 현재가를 비교하여 체결 가능 시 체결.
+        대량 주문 시 부분 체결 확률 적용.
+        """
+        if symbol not in self._simulator.symbols:
+            msg = f"등록되지 않은 종목: {symbol}"
+            raise BrokerError(msg)
+
+        order_id = str(uuid.uuid4())[:8]
+        current_price = self._simulator.get_price(symbol)
+
+        # 체결 가격 결정
+        if order_type == "limit" and price is not None:
+            # 지정가: 매수 시 현재가 <= 지정가여야 체결, 매도 시 현재가 >= 지정가
+            if side == "buy" and current_price > price:
+                # 지정가 미도달 → 미체결 보류
+                order = _TestOrder(
+                    order_id=order_id,
+                    symbol=symbol,
+                    side=side,
+                    quantity=quantity,
+                    filled_quantity=0.0,
+                    price=price,
+                    order_type=order_type,
+                    status="pending",
+                )
+                self._orders[order_id] = order
+                logger.info(
+                    "Test 지정가 미체결: %s %s %s qty=%.1f @ %.0f (현재=%.0f)",
+                    order_id,
+                    side,
+                    symbol,
+                    quantity,
+                    price,
+                    current_price,
+                )
+                return order_id
+            if side == "sell" and current_price < price:
+                order = _TestOrder(
+                    order_id=order_id,
+                    symbol=symbol,
+                    side=side,
+                    quantity=quantity,
+                    filled_quantity=0.0,
+                    price=price,
+                    order_type=order_type,
+                    status="pending",
+                )
+                self._orders[order_id] = order
+                logger.info(
+                    "Test 지정가 미체결: %s %s %s qty=%.1f @ %.0f (현재=%.0f)",
+                    order_id,
+                    side,
+                    symbol,
+                    quantity,
+                    price,
+                    current_price,
+                )
+                return order_id
+            exec_price = tick_round(price)
+        else:
+            # 시장가: 슬리피지 적용
+            exec_price = self._apply_slippage(current_price, side)
+
+        # 체결 수량 결정 (부분 체결 확률)
+        fill_qty = self._calculate_fill_quantity(quantity)
+
+        # 잔고 검증
+        if side == "buy":
+            required = fill_qty * exec_price
+            if required > self._cash:
+                msg = f"자금 부족: 필요 {required:.0f}, 보유 {self._cash:.0f}"
+                raise BrokerError(msg)
+        elif side == "sell":
+            pos = self._positions.get(symbol)
+            if pos is None or pos.quantity < fill_qty:
+                available = pos.quantity if pos else 0.0
+                msg = f"보유 수량 부족: {symbol} (보유: {available}, 매도: {fill_qty})"
+                raise BrokerError(msg)
+
+        # 주문 생성
+        order = _TestOrder(
+            order_id=order_id,
+            symbol=symbol,
+            side=side,
+            quantity=quantity,
+            filled_quantity=0.0,
+            price=exec_price,
+            order_type=order_type,
+            status="pending",
+        )
+        self._orders[order_id] = order
+
+        # 체결 실행
+        self._execute_fill(order, fill_qty, exec_price)
+
+        logger.info(
+            "Test 주문 체결: %s %s %s qty=%.1f filled=%.1f @ %.0f",
+            order_id,
+            side,
+            symbol,
+            quantity,
+            fill_qty,
+            exec_price,
+        )
+        return order_id
+
+    async def cancel_order(self, order_id: str) -> bool:
+        """미체결 주문 취소."""
+        order = self._orders.get(order_id)
+        if order is None:
+            raise OrderNotFoundError(f"주문을 찾을 수 없음: {order_id}")
+        if order.status in ("filled", "cancelled"):
+            return False
+        order.status = "cancelled"
+        return True
+
+    async def get_order_status(self, order_id: str) -> dict[str, Any]:
+        """주문 상태 조회."""
+        order = self._orders.get(order_id)
+        if order is None:
+            raise OrderNotFoundError(f"주문을 찾을 수 없음: {order_id}")
+        return {
+            "order_id": order.order_id,
+            "symbol": order.symbol,
+            "side": order.side,
+            "quantity": order.quantity,
+            "filled_quantity": order.filled_quantity,
+            "price": order.price,
+            "order_type": order.order_type,
+            "status": order.status,
+            "created_at": order.created_at.isoformat(),
+        }
+
+    async def get_pending_orders(self) -> list[dict[str, Any]]:
+        """미체결 주문 목록."""
+        results = []
+        for order in self._orders.values():
+            if order.status in ("pending", "partially_filled"):
+                results.append(await self.get_order_status(order.order_id))
+        return results
+
+    # ── 실시간 스트리밍 ───────────────────────────────────
+
+    async def realtime_price_stream(
+        self, symbols: list[str]
+    ) -> AsyncIterator[dict[str, Any]]:
+        """1초 간격 가격 변동 스트림.
+
+        매 인터벌마다 각 종목의 tick()을 호출하여 GBM 변동이 적용된
+        가격을 yield한다. 연결이 끊기면 스트림이 종료된다.
+        """
+        while self.is_connected:
+            for symbol in symbols:
+                price = self._simulator.tick(symbol)
+                yield {
+                    "symbol": symbol,
+                    "price": price,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                }
+            await asyncio.sleep(self._tick_interval)
+
+    async def realtime_order_stream(self) -> AsyncIterator[dict[str, Any]]:
+        """실시간 주문 체결 스트리밍 — 체결된 주문 반환 후 종료."""
+        for order in self._orders.values():
+            if order.status in ("filled", "partially_filled"):
+                yield await self.get_order_status(order.order_id)
+
+    # ── 이력/마스터 ───────────────────────────────────────
+
+    async def get_order_history(
+        self,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """주문/체결 이력 조회."""
+        results = []
+        for order in self._orders.values():
+            results.append(
+                {
+                    "order_id": order.order_id,
+                    "symbol": order.symbol,
+                    "side": order.side,
+                    "quantity": order.quantity,
+                    "filled_quantity": order.filled_quantity,
+                    "price": order.price,
+                    "status": order.status,
+                    "timestamp": order.created_at.isoformat(),
+                }
+            )
+        return results
+
+    async def get_instruments(self, exchange: str = "KRX") -> list[dict[str, Any]]:
+        """가상 종목 프리셋 목록 반환 (6종)."""
+        return [
+            {
+                "symbol": preset.symbol,
+                "name": preset.name,
+                "name_en": "",
+                "instrument_type": "stock",
+                "listed": True,
+            }
+            for preset in self._simulator.presets.values()
+        ]
+
+    # ── 수수료 ────────────────────────────────────────────
+
+    def get_commission_info(self) -> CommissionInfo:
+        """수수료율 정보 (KIS 동일: 0.015%, 매도세 0.23%)."""
+        return self._commission
+
+    # ── 내부 헬퍼 ─────────────────────────────────────────
+
+    def _apply_slippage(self, price: float, side: str) -> float:
+        """슬리피지 적용 — 매수 +0.1~0.3%, 매도 -0.1~0.3%."""
+        slippage_rate = self._rng.uniform(_SLIPPAGE_MIN, _SLIPPAGE_MAX)
+        if side == "buy":
+            slipped = price * (1 + slippage_rate)
+        else:
+            slipped = price * (1 - slippage_rate)
+        return tick_round(slipped)
+
+    def _calculate_fill_quantity(self, quantity: float) -> float:
+        """부분 체결 수량 계산.
+
+        대량 주문(>= 100주) 시 30% 확률로 부분 체결 발생.
+        """
+        if quantity >= _PARTIAL_FILL_THRESHOLD:
+            if self._rng.random() < _PARTIAL_FILL_PROBABILITY:
+                ratio = self._rng.uniform(
+                    _PARTIAL_FILL_RATIO_MIN, _PARTIAL_FILL_RATIO_MAX
+                )
+                return float(max(1, int(quantity * ratio)))
+        return quantity
+
+    def _execute_fill(
+        self, order: _TestOrder, fill_qty: float, exec_price: float
+    ) -> None:
+        """체결 처리: 잔고 및 포지션 업데이트."""
+        order.filled_quantity = fill_qty
+        filled_value = fill_qty * exec_price
+        commission = self._commission.calculate(order.side, filled_value)
+
+        if order.side == "buy":
+            self._cash -= filled_value + commission
+            self._update_position_buy(order.symbol, fill_qty, exec_price)
+        else:  # sell
+            self._cash += filled_value - commission
+            self._update_position_sell(order.symbol, fill_qty)
+
+        if fill_qty >= order.quantity:
+            order.status = "filled"
+        else:
+            order.status = "partially_filled"
+
+    def _update_position_buy(self, symbol: str, quantity: float, price: float) -> None:
+        """매수 시 포지션 업데이트."""
+        pos = self._positions.get(symbol)
+        if pos is None:
+            self._positions[symbol] = _TestPosition(
+                symbol=symbol, quantity=quantity, avg_price=price
+            )
+        else:
+            total_qty = pos.quantity + quantity
+            pos.avg_price = (
+                pos.avg_price * pos.quantity + price * quantity
+            ) / total_qty
+            pos.quantity = total_qty
+
+    def _update_position_sell(self, symbol: str, quantity: float) -> None:
+        """매도 시 포지션 업데이트."""
+        pos = self._positions.get(symbol)
+        if pos is None:
+            msg = f"매도할 포지션 없음: {symbol}"
+            raise BrokerError(msg)
+        if pos.quantity < quantity:
+            msg = f"보유 수량 부족: {symbol} (보유: {pos.quantity}, 매도: {quantity})"
+            raise BrokerError(msg)
+        pos.quantity -= quantity

--- a/tests/unit/test_test_broker.py
+++ b/tests/unit/test_test_broker.py
@@ -1,0 +1,498 @@
+"""TestBrokerAdapter 단위 테스트.
+
+연결/시세/주문/체결/잔고/포지션/스트리밍/종목마스터/수수료 검증.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ante.broker.exceptions import BrokerError, OrderNotFoundError
+from ante.broker.models import CommissionInfo
+from ante.broker.test import TestBrokerAdapter, tick_round
+
+# ── Fixture ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def broker() -> TestBrokerAdapter:
+    """기본 설정의 TestBrokerAdapter 인스턴스."""
+    return TestBrokerAdapter({"seed": 42, "initial_cash": 100_000_000})
+
+
+@pytest.fixture
+async def connected_broker(broker: TestBrokerAdapter) -> TestBrokerAdapter:
+    """연결된 TestBrokerAdapter 인스턴스."""
+    await broker.connect()
+    return broker
+
+
+# ── 연결/해제 ────────────────────────────────────────────────
+
+
+class TestConnection:
+    """연결/해제 동작 검증."""
+
+    @pytest.mark.asyncio
+    async def test_connect(self, broker: TestBrokerAdapter) -> None:
+        """connect() 후 is_connected가 True."""
+        assert broker.is_connected is False
+        await broker.connect()
+        assert broker.is_connected is True
+
+    @pytest.mark.asyncio
+    async def test_disconnect(self, connected_broker: TestBrokerAdapter) -> None:
+        """disconnect() 후 is_connected가 False."""
+        await connected_broker.disconnect()
+        assert connected_broker.is_connected is False
+
+    def test_broker_metadata(self, broker: TestBrokerAdapter) -> None:
+        """브로커 메타정보가 올바르다."""
+        assert broker.broker_id == "test"
+        assert broker.broker_name == "테스트 브로커"
+        assert broker.broker_short_name == "TEST"
+
+
+# ── 시세 조회 ────────────────────────────────────────────────
+
+
+class TestCurrentPrice:
+    """get_current_price() 동작 검증."""
+
+    @pytest.mark.asyncio
+    async def test_returns_positive_price(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """현재가가 양수이다."""
+        price = await connected_broker.get_current_price("000001")
+        assert price > 0
+
+    @pytest.mark.asyncio
+    async def test_price_changes_on_each_call(self) -> None:
+        """매 호출마다 가격이 변동될 수 있다 (GBM 적용)."""
+        from ante.broker.test import PriceSimulator, StockPreset
+
+        # 저가 종목(호가 1원)으로 변동이 반올림에 묻히지 않게 함
+        custom = {"T01": StockPreset("T01", "테스트", 1_000, 0.03)}
+        broker = TestBrokerAdapter({"seed": 42, "initial_cash": 1_000_000})
+        broker._simulator = PriceSimulator(presets=custom, seed=42)
+        await broker.connect()
+        prices = [await broker.get_current_price("T01") for _ in range(50)]
+        assert len(set(prices)) > 1
+
+    @pytest.mark.asyncio
+    async def test_unknown_symbol_raises(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """등록되지 않은 종목 조회 시 KeyError."""
+        with pytest.raises(KeyError, match="등록되지 않은 종목"):
+            await connected_broker.get_current_price("999999")
+
+    @pytest.mark.asyncio
+    async def test_price_conforms_to_tick_size(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """반환 가격이 KRX 호가 단위에 맞다."""
+        for _ in range(100):
+            price = await connected_broker.get_current_price("000001")
+            assert price == tick_round(price)
+
+
+# ── 계좌/포지션 ──────────────────────────────────────────────
+
+
+class TestAccountBalance:
+    """get_account_balance() 동작 검증."""
+
+    @pytest.mark.asyncio
+    async def test_initial_balance(self, connected_broker: TestBrokerAdapter) -> None:
+        """초기 잔고가 설정값과 일치한다."""
+        balance = await connected_broker.get_account_balance()
+        assert balance["cash"] == 100_000_000
+        assert balance["total_assets"] == 100_000_000
+        assert balance["stock_value"] == 0
+
+    @pytest.mark.asyncio
+    async def test_balance_after_buy(self, connected_broker: TestBrokerAdapter) -> None:
+        """매수 후 현금이 감소하고 stock_value가 증가한다."""
+        await connected_broker.place_order("000001", "buy", 10)
+        balance = await connected_broker.get_account_balance()
+        assert balance["cash"] < 100_000_000
+        assert balance["stock_value"] > 0
+
+
+class TestPositions:
+    """get_positions() / get_account_positions() 동작 검증."""
+
+    @pytest.mark.asyncio
+    async def test_no_positions_initially(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """초기에는 포지션이 없다."""
+        positions = await connected_broker.get_positions()
+        assert positions == []
+
+    @pytest.mark.asyncio
+    async def test_position_after_buy(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """매수 후 포지션이 생성된다."""
+        await connected_broker.place_order("000001", "buy", 10)
+        positions = await connected_broker.get_positions()
+        assert len(positions) == 1
+        assert positions[0]["symbol"] == "000001"
+        assert positions[0]["quantity"] == 10
+
+    @pytest.mark.asyncio
+    async def test_account_positions_delegates(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """get_account_positions()이 get_positions()와 동일 결과를 반환한다."""
+        await connected_broker.place_order("000001", "buy", 5)
+        positions = await connected_broker.get_positions()
+        account_positions = await connected_broker.get_account_positions()
+        assert positions == account_positions
+
+
+# ── 주문/체결 ────────────────────────────────────────────────
+
+
+class TestPlaceOrder:
+    """place_order() 동작 검증."""
+
+    @pytest.mark.asyncio
+    async def test_market_buy_returns_order_id(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """시장가 매수가 주문 ID를 반환한다."""
+        order_id = await connected_broker.place_order("000001", "buy", 10)
+        assert isinstance(order_id, str)
+        assert len(order_id) > 0
+
+    @pytest.mark.asyncio
+    async def test_market_buy_updates_cash(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """시장가 매수 후 현금이 감소한다."""
+        initial_balance = await connected_broker.get_account_balance()
+        await connected_broker.place_order("000001", "buy", 10)
+        after_balance = await connected_broker.get_account_balance()
+        assert after_balance["cash"] < initial_balance["cash"]
+
+    @pytest.mark.asyncio
+    async def test_market_sell(self, connected_broker: TestBrokerAdapter) -> None:
+        """매수 후 매도가 정상 동작한다."""
+        await connected_broker.place_order("000001", "buy", 10)
+        order_id = await connected_broker.place_order("000001", "sell", 5)
+        positions = await connected_broker.get_positions()
+        assert positions[0]["quantity"] == 5
+        status = await connected_broker.get_order_status(order_id)
+        assert status["side"] == "sell"
+
+    @pytest.mark.asyncio
+    async def test_sell_without_position_raises(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """포지션 없이 매도 시 BrokerError."""
+        with pytest.raises(BrokerError, match="보유 수량 부족"):
+            await connected_broker.place_order("000001", "sell", 10)
+
+    @pytest.mark.asyncio
+    async def test_buy_insufficient_cash_raises(
+        self,
+    ) -> None:
+        """자금 부족 시 BrokerError."""
+        broker = TestBrokerAdapter({"seed": 42, "initial_cash": 1.0})
+        await broker.connect()
+        with pytest.raises(BrokerError, match="자금 부족"):
+            await broker.place_order("000001", "buy", 100)
+
+    @pytest.mark.asyncio
+    async def test_unknown_symbol_raises(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """등록되지 않은 종목 주문 시 BrokerError."""
+        with pytest.raises(BrokerError, match="등록되지 않은 종목"):
+            await connected_broker.place_order("999999", "buy", 10)
+
+    @pytest.mark.asyncio
+    async def test_slippage_applied_on_market_order(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """시장가 주문에 슬리피지가 적용된다."""
+        # 동일 시드로 여러 번 주문하면 체결가가 현재가와 약간 다를 수 있다
+        order_id = await connected_broker.place_order("000001", "buy", 10)
+        status = await connected_broker.get_order_status(order_id)
+        # 체결가가 호가 단위에 맞는지만 확인 (슬리피지 적용 여부는 확률적)
+        assert status["price"] == tick_round(status["price"])
+
+
+class TestLimitOrder:
+    """지정가 주문 동작 검증."""
+
+    @pytest.mark.asyncio
+    async def test_limit_buy_unfillable(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """지정가 매수 — 현재가보다 낮은 가격이면 미체결."""
+        # 현재가보다 훨씬 낮은 지정가
+        order_id = await connected_broker.place_order(
+            "000001", "buy", 10, order_type="limit", price=1_000.0
+        )
+        status = await connected_broker.get_order_status(order_id)
+        assert status["status"] == "pending"
+        assert status["filled_quantity"] == 0
+
+    @pytest.mark.asyncio
+    async def test_limit_buy_fillable(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """지정가 매수 — 현재가 이상이면 체결."""
+        order_id = await connected_broker.place_order(
+            "000001", "buy", 10, order_type="limit", price=999_999.0
+        )
+        status = await connected_broker.get_order_status(order_id)
+        assert status["status"] in ("filled", "partially_filled")
+
+    @pytest.mark.asyncio
+    async def test_limit_sell_unfillable(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """지정가 매도 — 현재가보다 높은 가격이면 미체결."""
+        await connected_broker.place_order("000001", "buy", 10)
+        order_id = await connected_broker.place_order(
+            "000001", "sell", 5, order_type="limit", price=999_999.0
+        )
+        status = await connected_broker.get_order_status(order_id)
+        assert status["status"] == "pending"
+
+
+class TestCancelOrder:
+    """cancel_order() 동작 검증."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_pending_order(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """미체결 주문 취소 성공."""
+        order_id = await connected_broker.place_order(
+            "000001", "buy", 10, order_type="limit", price=1_000.0
+        )
+        result = await connected_broker.cancel_order(order_id)
+        assert result is True
+        status = await connected_broker.get_order_status(order_id)
+        assert status["status"] == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_cancel_filled_order_fails(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """체결된 주문 취소 실패."""
+        order_id = await connected_broker.place_order("000001", "buy", 10)
+        status = await connected_broker.get_order_status(order_id)
+        if status["status"] == "filled":
+            result = await connected_broker.cancel_order(order_id)
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_cancel_nonexistent_order_raises(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """존재하지 않는 주문 취소 시 OrderNotFoundError."""
+        with pytest.raises(OrderNotFoundError):
+            await connected_broker.cancel_order("nonexistent")
+
+
+# ── 주문 상태/이력 ───────────────────────────────────────────
+
+
+class TestOrderStatus:
+    """get_order_status() / get_pending_orders() / get_order_history() 검증."""
+
+    @pytest.mark.asyncio
+    async def test_order_status_fields(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """주문 상태에 필수 필드가 포함된다."""
+        order_id = await connected_broker.place_order("000001", "buy", 10)
+        status = await connected_broker.get_order_status(order_id)
+        required_fields = {
+            "order_id",
+            "symbol",
+            "side",
+            "quantity",
+            "filled_quantity",
+            "price",
+            "order_type",
+            "status",
+            "created_at",
+        }
+        assert required_fields.issubset(status.keys())
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_order_raises(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """존재하지 않는 주문 조회 시 OrderNotFoundError."""
+        with pytest.raises(OrderNotFoundError):
+            await connected_broker.get_order_status("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_pending_orders_list(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """미체결 주문이 pending_orders에 포함된다."""
+        await connected_broker.place_order(
+            "000001", "buy", 10, order_type="limit", price=1_000.0
+        )
+        pending = await connected_broker.get_pending_orders()
+        assert len(pending) >= 1
+        assert pending[0]["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_order_history(self, connected_broker: TestBrokerAdapter) -> None:
+        """주문 이력에 모든 주문이 포함된다."""
+        await connected_broker.place_order("000001", "buy", 10)
+        await connected_broker.place_order(
+            "000002", "buy", 5, order_type="limit", price=1_000.0
+        )
+        history = await connected_broker.get_order_history()
+        assert len(history) == 2
+
+
+# ── 스트리밍 ─────────────────────────────────────────────────
+
+
+class TestStreaming:
+    """realtime_price_stream() / realtime_order_stream() 검증."""
+
+    @pytest.mark.asyncio
+    async def test_price_stream_yields_data(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """가격 스트림이 데이터를 yield한다."""
+        # tick_interval을 짧게 설정
+        connected_broker._tick_interval = 0.01
+
+        items: list[dict] = []
+        async for item in connected_broker.realtime_price_stream(["000001", "000002"]):
+            items.append(item)
+            if len(items) >= 4:  # 2종목 x 2라운드
+                await connected_broker.disconnect()  # 스트림 종료
+
+        assert len(items) >= 4
+        assert all("symbol" in item for item in items)
+        assert all("price" in item for item in items)
+        assert all("timestamp" in item for item in items)
+
+    @pytest.mark.asyncio
+    async def test_price_stream_stops_on_disconnect(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """disconnect 후 스트림이 종료된다."""
+        connected_broker._tick_interval = 0.01
+
+        async def disconnect_after(delay: float) -> None:
+            await asyncio.sleep(delay)
+            await connected_broker.disconnect()
+
+        task = asyncio.create_task(disconnect_after(0.05))
+        count = 0
+        async for _ in connected_broker.realtime_price_stream(["000001"]):
+            count += 1
+        await task
+        assert count > 0  # 최소 한 번은 yield해야 함
+
+    @pytest.mark.asyncio
+    async def test_order_stream_returns_filled_orders(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """주문 스트림이 체결 주문을 반환한다."""
+        await connected_broker.place_order("000001", "buy", 10)
+        items = []
+        async for item in connected_broker.realtime_order_stream():
+            items.append(item)
+        assert len(items) >= 1
+
+
+# ── 종목 마스터 ──────────────────────────────────────────────
+
+
+class TestInstruments:
+    """get_instruments() 검증."""
+
+    @pytest.mark.asyncio
+    async def test_returns_six_instruments(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """6종의 가상 종목이 반환된다."""
+        instruments = await connected_broker.get_instruments()
+        assert len(instruments) == 6
+
+    @pytest.mark.asyncio
+    async def test_instrument_fields(self, connected_broker: TestBrokerAdapter) -> None:
+        """종목 정보에 필수 필드가 포함된다."""
+        instruments = await connected_broker.get_instruments()
+        required_fields = {"symbol", "name", "name_en", "instrument_type", "listed"}
+        for inst in instruments:
+            assert required_fields.issubset(inst.keys())
+            assert inst["instrument_type"] == "stock"
+            assert inst["listed"] is True
+
+
+# ── 수수료 ───────────────────────────────────────────────────
+
+
+class TestCommission:
+    """get_commission_info() 검증."""
+
+    def test_returns_commission_info(self, broker: TestBrokerAdapter) -> None:
+        """CommissionInfo 인스턴스를 반환한다."""
+        info = broker.get_commission_info()
+        assert isinstance(info, CommissionInfo)
+
+    def test_default_rates(self, broker: TestBrokerAdapter) -> None:
+        """KIS 동일 수수료율이 설정된다."""
+        info = broker.get_commission_info()
+        assert info.commission_rate == 0.00015
+        assert info.sell_tax_rate == 0.0023
+
+
+# ── 시드 재현성 ──────────────────────────────────────────────
+
+
+class TestSeedReproducibility:
+    """동일 시드로 동일한 체결 결과 재현 검증."""
+
+    @pytest.mark.asyncio
+    async def test_same_seed_same_prices(self) -> None:
+        """동일 시드의 두 브로커가 동일한 가격 시퀀스를 반환한다."""
+        b1 = TestBrokerAdapter({"seed": 42})
+        b2 = TestBrokerAdapter({"seed": 42})
+        await b1.connect()
+        await b2.connect()
+
+        prices1 = [await b1.get_current_price("000001") for _ in range(20)]
+        prices2 = [await b2.get_current_price("000001") for _ in range(20)]
+        assert prices1 == prices2
+
+
+# ── BrokerAdapter 인터페이스 준수 ────────────────────────────
+
+
+class TestBrokerAdapterInterface:
+    """BrokerAdapter ABC 전체 메서드 구현 검증."""
+
+    def test_is_broker_adapter(self, broker: TestBrokerAdapter) -> None:
+        """TestBrokerAdapter가 BrokerAdapter의 인스턴스이다."""
+        from ante.broker.base import BrokerAdapter
+
+        assert isinstance(broker, BrokerAdapter)
+
+    def test_all_abstract_methods_implemented(self) -> None:
+        """모든 추상 메서드가 구현되었다 (인스턴스 생성 가능 = ABC 충족)."""
+        # ABC를 모두 구현하지 않으면 인스턴스 생성 시 TypeError
+        broker = TestBrokerAdapter({"seed": 1})
+        assert broker is not None


### PR DESCRIPTION
## Summary

- BrokerAdapter ABC 18개 추상 메서드를 모두 구현한 TestBrokerAdapter 추가
- PriceSimulator(GBM) 기반 시세 조회: 매 호출마다 현실적 가격 변동 적용
- 체결 시뮬레이션: 시장가 슬리피지(0.1~0.3%), 대량 주문 부분 체결(30% 확률), 지정가 미도달 시 미체결
- 인메모리 잔고/포지션/주문 이력 관리 (수수료 적용: KIS 동일 0.015%, 매도세 0.23%)
- `realtime_price_stream()`: 1초 간격 연속 가격 변동 스트림
- `get_instruments()`: 가상 종목 프리셋 6종 반환
- `__init__.py`에 TestBrokerAdapter export 추가

## Test plan

- [x] 연결/해제 동작 검증
- [x] GBM 기반 시세 변동 확인 (저가 종목으로 호가 단위 반올림 영향 배제)
- [x] 시장가/지정가 주문 및 체결 시뮬레이션 검증
- [x] 잔고/포지션 업데이트 검증 (매수→현금 감소, 매도→수량 감소)
- [x] 미체결 주문 취소, 주문 상태 조회, 이력 조회
- [x] 실시간 가격 스트림 yield 및 disconnect 시 종료
- [x] 종목 마스터/수수료 정보 반환
- [x] BrokerAdapter ABC 인터페이스 준수 확인
- [x] 시드 재현성 검증
- [x] 에러 경로: 미등록 종목, 자금 부족, 보유 수량 부족, 존재하지 않는 주문
- [x] ruff check/format 통과
- [x] 전체 테스트 1819 passed (기존 테스트 무영향)

Refs #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)