### PR TITLE
epic/429: Test 브로커 구현 및 KIS ↔ Test 전환 지원

### DIFF
--- a/config/system.toml.example
+++ b/config/system.toml.example
@@ -20,10 +20,19 @@ port = 8000
 history_size = 1000
 
 [broker]
-# KIS 모의투자 설정 — secrets.env 에서 앱키/시크릿/계좌번호 관리
+type = "kis"                # "kis" | "test" | "mock"
+# KIS: secrets.env 에서 앱키/시크릿/계좌번호 관리
+# Test: KIS 시크릿 없이 시뮬레이션 구동 (broker.test 섹션 참조)
+# Mock: E2E 테스트 자동화 전용
 is_paper = true             # true: 모의투자, false: 실전투자
 commission_rate = 0.00015   # 매매 수수료율
 sell_tax_rate = 0.0023      # 매도 세금율 (증권거래세+농특세)
+
+# Test 브로커 전용 설정 (type = "test" 일 때만 사용)
+[broker.test]
+seed = 42                   # 재현 가능한 시뮬레이션 시드
+initial_cash = 100000000    # 초기 자금 (1억)
+tick_interval = 1.0         # 가격 변동 간격 (초)
 
 [treasury]
 sync_interval_seconds = 300 # 잔고 동기화 주기 (초)

--- a/src/ante/broker/__init__.py
+++ b/src/ante/broker/__init__.py
@@ -15,6 +15,7 @@ from ante.broker.kis_stream import KISStreamClient
 from ante.broker.mock import MockBrokerAdapter
 from ante.broker.models import CommissionInfo
 from ante.broker.order_registry import OrderRegistry
+from ante.broker.test import TestBrokerAdapter
 
 __all__ = [
     "BrokerAdapter",
@@ -26,6 +27,7 @@ __all__ = [
     "KISStreamClient",
     "MockBrokerAdapter",
     "OrderRegistry",
+    "TestBrokerAdapter",
     "BrokerError",
     "AuthenticationError",
     "APIError",

--- a/src/ante/broker/test.py
+++ b/src/ante/broker/test.py
@@ -1,0 +1,156 @@
+"""PriceSimulator — GBM 기반 가격 시뮬레이션 엔진.
+
+Test 브로커에서 사용할 현실적 가격 변동 엔진.
+시드 생성기의 GBM 로직을 재활용하되, 틱 단위(초 단위) 변동을 지원한다.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import random
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# KRX 하루 거래 시간: 09:00~15:30 = 6.5시간 = 23,400초
+KRX_TRADING_SECONDS = 23_400
+
+
+@dataclass(frozen=True)
+class StockPreset:
+    """가상 종목 프리셋."""
+
+    symbol: str
+    name: str
+    base_price: float
+    daily_vol: float  # 일별 변동성 (0.018 = 1.8%)
+
+
+# 가상 종목 프리셋 6종
+VIRTUAL_STOCK_PRESETS: dict[str, StockPreset] = {
+    "000001": StockPreset("000001", "알파전자", 72_000, 0.018),
+    "000002": StockPreset("000002", "베타반도체", 160_000, 0.025),
+    "000003": StockPreset("000003", "감마소프트", 210_000, 0.022),
+    "000004": StockPreset("000004", "델타플랫폼", 48_000, 0.028),
+    "000005": StockPreset("000005", "엡실론모터스", 230_000, 0.015),
+    "000006": StockPreset("000006", "제타에너지", 390_000, 0.020),
+}
+
+
+def _tick_size(price: float) -> int:
+    """KRX 호가 단위 반환."""
+    if price < 2_000:
+        return 1
+    if price < 5_000:
+        return 5
+    if price < 20_000:
+        return 10
+    if price < 50_000:
+        return 50
+    if price < 200_000:
+        return 100
+    if price < 500_000:
+        return 500
+    return 1_000
+
+
+def tick_round(price: float) -> float:
+    """KRX 호가 단위로 반올림."""
+    tick = _tick_size(price)
+    return float(round(price / tick) * tick)
+
+
+class PriceSimulator:
+    """GBM 기반 실시간 가격 시뮬레이션 엔진.
+
+    시드 생성기의 GBM 로직을 재활용하되, 일봉이 아닌 틱(초) 단위
+    변동을 지원한다.
+
+    일변동성 → 초단위 스케일링:
+        σ_tick = σ_daily / √(KRX 거래초수)
+
+    동일 시드로 초기화하면 동일한 가격 시퀀스를 재현할 수 있다.
+    """
+
+    def __init__(
+        self,
+        presets: dict[str, StockPreset] | None = None,
+        seed: int = 42,
+    ) -> None:
+        self._presets = presets or VIRTUAL_STOCK_PRESETS
+        self._seed = seed
+        self._rng = random.Random(seed)
+        self._prices: dict[str, float] = {}
+        self._tick_vols: dict[str, float] = {}
+        self._initialize()
+
+    def _initialize(self) -> None:
+        """프리셋 기반 초기 가격 및 틱 변동성 설정."""
+        sqrt_trading_seconds = math.sqrt(KRX_TRADING_SECONDS)
+        for symbol, preset in self._presets.items():
+            self._prices[symbol] = tick_round(preset.base_price)
+            self._tick_vols[symbol] = preset.daily_vol / sqrt_trading_seconds
+        logger.info(
+            "PriceSimulator 초기화: %d종목, seed=%d",
+            len(self._presets),
+            self._seed,
+        )
+
+    def tick(self, symbol: str) -> float:
+        """한 틱(초 단위) 진행 — GBM 변동 적용 후 현재가 반환.
+
+        Args:
+            symbol: 종목코드.
+
+        Returns:
+            호가 단위로 반올림된 현재가.
+
+        Raises:
+            KeyError: 등록되지 않은 종목코드.
+        """
+        if symbol not in self._prices:
+            msg = f"등록되지 않은 종목: {symbol}"
+            raise KeyError(msg)
+
+        current = self._prices[symbol]
+        sigma = self._tick_vols[symbol]
+
+        # GBM: dS = S * σ * dW  (drift ≈ 0 for tick-level)
+        z = self._rng.gauss(0, 1)
+        log_return = sigma * z
+        new_price = current * math.exp(log_return)
+
+        # 최소 가격 보장 (1 호가 단위 이상)
+        new_price = max(new_price, _tick_size(new_price))
+
+        rounded = tick_round(new_price)
+        self._prices[symbol] = rounded
+        return rounded
+
+    def get_price(self, symbol: str) -> float:
+        """현재가 조회 (tick 진행 없이).
+
+        Args:
+            symbol: 종목코드.
+
+        Returns:
+            현재가.
+
+        Raises:
+            KeyError: 등록되지 않은 종목코드.
+        """
+        if symbol not in self._prices:
+            msg = f"등록되지 않은 종목: {symbol}"
+            raise KeyError(msg)
+        return self._prices[symbol]
+
+    @property
+    def symbols(self) -> list[str]:
+        """등록된 종목코드 목록."""
+        return list(self._presets.keys())
+
+    @property
+    def presets(self) -> dict[str, StockPreset]:
+        """종목 프리셋 조회."""
+        return dict(self._presets)

--- a/src/ante/broker/test.py
+++ b/src/ante/broker/test.py
@@ -1,20 +1,39 @@
-"""PriceSimulator — GBM 기반 가격 시뮬레이션 엔진.
+"""TestBrokerAdapter 및 PriceSimulator — 개발/검증용 테스트 브로커.
 
-Test 브로커에서 사용할 현실적 가격 변동 엔진.
-시드 생성기의 GBM 로직을 재활용하되, 틱 단위(초 단위) 변동을 지원한다.
+KIS 실전 API 없이도 시스템 전체 흐름을 검증할 수 있는 테스트 브로커.
+GBM 기반 가격 시뮬레이션, 현실적 체결(슬리피지/부분 체결),
+인메모리 잔고/포지션 관리를 지원한다.
+MockBrokerAdapter(E2E용)와는 목적이 다르며 유지한다.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import math
 import random
-from dataclasses import dataclass
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from ante.broker.base import BrokerAdapter
+from ante.broker.exceptions import BrokerError, OrderNotFoundError
+from ante.broker.models import CommissionInfo
 
 logger = logging.getLogger(__name__)
 
 # KRX 하루 거래 시간: 09:00~15:30 = 6.5시간 = 23,400초
 KRX_TRADING_SECONDS = 23_400
+
+# ── 슬리피지/부분 체결 기본값 ────────────────────────────────
+_SLIPPAGE_MIN = 0.001  # 0.1%
+_SLIPPAGE_MAX = 0.003  # 0.3%
+_PARTIAL_FILL_THRESHOLD = 100  # 이 수량 이상이면 부분 체결 확률 적용
+_PARTIAL_FILL_PROBABILITY = 0.3  # 부분 체결 발생 확률
+_PARTIAL_FILL_RATIO_MIN = 0.3
+_PARTIAL_FILL_RATIO_MAX = 0.9
 
 
 @dataclass(frozen=True)
@@ -154,3 +173,422 @@ class PriceSimulator:
     def presets(self) -> dict[str, StockPreset]:
         """종목 프리셋 조회."""
         return dict(self._presets)
+
+
+# ── TestBrokerAdapter 내부 모델 ──────────────────────────────
+
+
+@dataclass
+class _TestPosition:
+    """인메모리 가상 포지션."""
+
+    symbol: str
+    quantity: float
+    avg_price: float
+
+
+@dataclass
+class _TestOrder:
+    """인메모리 주문 기록."""
+
+    order_id: str
+    symbol: str
+    side: str
+    quantity: float
+    filled_quantity: float
+    price: float
+    order_type: str
+    status: str  # "pending" | "filled" | "partially_filled" | "cancelled"
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+# ── TestBrokerAdapter ────────────────────────────────────────
+
+
+class TestBrokerAdapter(BrokerAdapter):
+    """개발/검증용 테스트 브로커 어댑터.
+
+    KIS와 동일한 BrokerAdapter 인터페이스로 현실적인 시뮬레이션 데이터를 반환한다.
+    PriceSimulator(GBM) 기반 가격 변동, 슬리피지/부분 체결 시뮬레이션,
+    인메모리 잔고/포지션/주문 이력 관리를 제공한다.
+
+    설정 옵션:
+        seed: 시뮬레이션 시드 (기본 42, 재현 가능)
+        initial_cash: 초기 현금 (기본 100_000_000)
+        tick_interval: 스트리밍 가격 변동 간격 초 (기본 1.0)
+    """
+
+    broker_id: str = "test"
+    broker_name: str = "테스트 브로커"
+    broker_short_name: str = "TEST"
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        config.setdefault("exchange", "KRX")
+        super().__init__(config)
+
+        self._seed: int = config.get("seed", 42)
+        self._initial_cash: float = config.get("initial_cash", 100_000_000.0)
+        self._tick_interval: float = config.get("tick_interval", 1.0)
+
+        # 시뮬레이터
+        self._simulator = PriceSimulator(seed=self._seed)
+        self._rng = random.Random(self._seed)
+
+        # 인메모리 상태
+        self._cash: float = self._initial_cash
+        self._positions: dict[str, _TestPosition] = {}
+        self._orders: dict[str, _TestOrder] = {}
+
+        # 수수료 (KIS 동일)
+        self._commission = CommissionInfo(
+            commission_rate=config.get("commission_rate", 0.00015),
+            sell_tax_rate=config.get("sell_tax_rate", 0.0023),
+        )
+
+    # ── 연결 ──────────────────────────────────────────────
+
+    async def connect(self) -> None:
+        """Test 브로커 연결 (항상 성공)."""
+        self.is_connected = True
+        logger.info(
+            "Test Broker 연결됨 (seed=%d, cash=%.0f)",
+            self._seed,
+            self._cash,
+        )
+
+    async def disconnect(self) -> None:
+        """Test 브로커 연결 해제."""
+        self.is_connected = False
+        logger.info("Test Broker 연결 해제")
+
+    # ── 시세 조회 ─────────────────────────────────────────
+
+    async def get_current_price(self, symbol: str) -> float:
+        """현재가 조회 — 매 호출마다 GBM 변동 적용."""
+        return self._simulator.tick(symbol)
+
+    # ── 계좌/포지션 ───────────────────────────────────────
+
+    async def get_account_balance(self) -> dict[str, float]:
+        """가상 계좌 잔고 조회."""
+        total_stock_value = sum(
+            pos.quantity * self._simulator.get_price(pos.symbol)
+            for pos in self._positions.values()
+        )
+        return {
+            "cash": self._cash,
+            "total_assets": self._cash + total_stock_value,
+            "stock_value": total_stock_value,
+        }
+
+    async def get_positions(self) -> list[dict[str, Any]]:
+        """보유 포지션 조회 — 현재 시뮬레이션 가격으로 평가손익 계산."""
+        return [
+            {
+                "symbol": pos.symbol,
+                "quantity": pos.quantity,
+                "avg_price": pos.avg_price,
+                "current_price": self._simulator.get_price(pos.symbol),
+                "pnl": (self._simulator.get_price(pos.symbol) - pos.avg_price)
+                * pos.quantity,
+            }
+            for pos in self._positions.values()
+            if pos.quantity > 0
+        ]
+
+    async def get_account_positions(self) -> list[dict[str, Any]]:
+        """증권사 실제 보유 잔고 (대사용) — get_positions() 위임."""
+        return await self.get_positions()
+
+    # ── 주문/체결 ─────────────────────────────────────────
+
+    async def place_order(
+        self,
+        symbol: str,
+        side: str,
+        quantity: float,
+        order_type: str = "market",
+        price: float | None = None,
+        stop_price: float | None = None,
+    ) -> str:
+        """주문 접수 및 체결 시뮬레이션.
+
+        시장가: 현재 시뮬레이션가 +/- 슬리피지로 즉시 체결.
+        지정가: 지정가와 현재가를 비교하여 체결 가능 시 체결.
+        대량 주문 시 부분 체결 확률 적용.
+        """
+        if symbol not in self._simulator.symbols:
+            msg = f"등록되지 않은 종목: {symbol}"
+            raise BrokerError(msg)
+
+        order_id = str(uuid.uuid4())[:8]
+        current_price = self._simulator.get_price(symbol)
+
+        # 체결 가격 결정
+        if order_type == "limit" and price is not None:
+            # 지정가: 매수 시 현재가 <= 지정가여야 체결, 매도 시 현재가 >= 지정가
+            if side == "buy" and current_price > price:
+                # 지정가 미도달 → 미체결 보류
+                order = _TestOrder(
+                    order_id=order_id,
+                    symbol=symbol,
+                    side=side,
+                    quantity=quantity,
+                    filled_quantity=0.0,
+                    price=price,
+                    order_type=order_type,
+                    status="pending",
+                )
+                self._orders[order_id] = order
+                logger.info(
+                    "Test 지정가 미체결: %s %s %s qty=%.1f @ %.0f (현재=%.0f)",
+                    order_id,
+                    side,
+                    symbol,
+                    quantity,
+                    price,
+                    current_price,
+                )
+                return order_id
+            if side == "sell" and current_price < price:
+                order = _TestOrder(
+                    order_id=order_id,
+                    symbol=symbol,
+                    side=side,
+                    quantity=quantity,
+                    filled_quantity=0.0,
+                    price=price,
+                    order_type=order_type,
+                    status="pending",
+                )
+                self._orders[order_id] = order
+                logger.info(
+                    "Test 지정가 미체결: %s %s %s qty=%.1f @ %.0f (현재=%.0f)",
+                    order_id,
+                    side,
+                    symbol,
+                    quantity,
+                    price,
+                    current_price,
+                )
+                return order_id
+            exec_price = tick_round(price)
+        else:
+            # 시장가: 슬리피지 적용
+            exec_price = self._apply_slippage(current_price, side)
+
+        # 체결 수량 결정 (부분 체결 확률)
+        fill_qty = self._calculate_fill_quantity(quantity)
+
+        # 잔고 검증
+        if side == "buy":
+            required = fill_qty * exec_price
+            if required > self._cash:
+                msg = f"자금 부족: 필요 {required:.0f}, 보유 {self._cash:.0f}"
+                raise BrokerError(msg)
+        elif side == "sell":
+            pos = self._positions.get(symbol)
+            if pos is None or pos.quantity < fill_qty:
+                available = pos.quantity if pos else 0.0
+                msg = f"보유 수량 부족: {symbol} (보유: {available}, 매도: {fill_qty})"
+                raise BrokerError(msg)
+
+        # 주문 생성
+        order = _TestOrder(
+            order_id=order_id,
+            symbol=symbol,
+            side=side,
+            quantity=quantity,
+            filled_quantity=0.0,
+            price=exec_price,
+            order_type=order_type,
+            status="pending",
+        )
+        self._orders[order_id] = order
+
+        # 체결 실행
+        self._execute_fill(order, fill_qty, exec_price)
+
+        logger.info(
+            "Test 주문 체결: %s %s %s qty=%.1f filled=%.1f @ %.0f",
+            order_id,
+            side,
+            symbol,
+            quantity,
+            fill_qty,
+            exec_price,
+        )
+        return order_id
+
+    async def cancel_order(self, order_id: str) -> bool:
+        """미체결 주문 취소."""
+        order = self._orders.get(order_id)
+        if order is None:
+            raise OrderNotFoundError(f"주문을 찾을 수 없음: {order_id}")
+        if order.status in ("filled", "cancelled"):
+            return False
+        order.status = "cancelled"
+        return True
+
+    async def get_order_status(self, order_id: str) -> dict[str, Any]:
+        """주문 상태 조회."""
+        order = self._orders.get(order_id)
+        if order is None:
+            raise OrderNotFoundError(f"주문을 찾을 수 없음: {order_id}")
+        return {
+            "order_id": order.order_id,
+            "symbol": order.symbol,
+            "side": order.side,
+            "quantity": order.quantity,
+            "filled_quantity": order.filled_quantity,
+            "price": order.price,
+            "order_type": order.order_type,
+            "status": order.status,
+            "created_at": order.created_at.isoformat(),
+        }
+
+    async def get_pending_orders(self) -> list[dict[str, Any]]:
+        """미체결 주문 목록."""
+        results = []
+        for order in self._orders.values():
+            if order.status in ("pending", "partially_filled"):
+                results.append(await self.get_order_status(order.order_id))
+        return results
+
+    # ── 실시간 스트리밍 ───────────────────────────────────
+
+    async def realtime_price_stream(
+        self, symbols: list[str]
+    ) -> AsyncIterator[dict[str, Any]]:
+        """1초 간격 가격 변동 스트림.
+
+        매 인터벌마다 각 종목의 tick()을 호출하여 GBM 변동이 적용된
+        가격을 yield한다. 연결이 끊기면 스트림이 종료된다.
+        """
+        while self.is_connected:
+            for symbol in symbols:
+                price = self._simulator.tick(symbol)
+                yield {
+                    "symbol": symbol,
+                    "price": price,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                }
+            await asyncio.sleep(self._tick_interval)
+
+    async def realtime_order_stream(self) -> AsyncIterator[dict[str, Any]]:
+        """실시간 주문 체결 스트리밍 — 체결된 주문 반환 후 종료."""
+        for order in self._orders.values():
+            if order.status in ("filled", "partially_filled"):
+                yield await self.get_order_status(order.order_id)
+
+    # ── 이력/마스터 ───────────────────────────────────────
+
+    async def get_order_history(
+        self,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """주문/체결 이력 조회."""
+        results = []
+        for order in self._orders.values():
+            results.append(
+                {
+                    "order_id": order.order_id,
+                    "symbol": order.symbol,
+                    "side": order.side,
+                    "quantity": order.quantity,
+                    "filled_quantity": order.filled_quantity,
+                    "price": order.price,
+                    "status": order.status,
+                    "timestamp": order.created_at.isoformat(),
+                }
+            )
+        return results
+
+    async def get_instruments(self, exchange: str = "KRX") -> list[dict[str, Any]]:
+        """가상 종목 프리셋 목록 반환 (6종)."""
+        return [
+            {
+                "symbol": preset.symbol,
+                "name": preset.name,
+                "name_en": "",
+                "instrument_type": "stock",
+                "listed": True,
+            }
+            for preset in self._simulator.presets.values()
+        ]
+
+    # ── 수수료 ────────────────────────────────────────────
+
+    def get_commission_info(self) -> CommissionInfo:
+        """수수료율 정보 (KIS 동일: 0.015%, 매도세 0.23%)."""
+        return self._commission
+
+    # ── 내부 헬퍼 ─────────────────────────────────────────
+
+    def _apply_slippage(self, price: float, side: str) -> float:
+        """슬리피지 적용 — 매수 +0.1~0.3%, 매도 -0.1~0.3%."""
+        slippage_rate = self._rng.uniform(_SLIPPAGE_MIN, _SLIPPAGE_MAX)
+        if side == "buy":
+            slipped = price * (1 + slippage_rate)
+        else:
+            slipped = price * (1 - slippage_rate)
+        return tick_round(slipped)
+
+    def _calculate_fill_quantity(self, quantity: float) -> float:
+        """부분 체결 수량 계산.
+
+        대량 주문(>= 100주) 시 30% 확률로 부분 체결 발생.
+        """
+        if quantity >= _PARTIAL_FILL_THRESHOLD:
+            if self._rng.random() < _PARTIAL_FILL_PROBABILITY:
+                ratio = self._rng.uniform(
+                    _PARTIAL_FILL_RATIO_MIN, _PARTIAL_FILL_RATIO_MAX
+                )
+                return float(max(1, int(quantity * ratio)))
+        return quantity
+
+    def _execute_fill(
+        self, order: _TestOrder, fill_qty: float, exec_price: float
+    ) -> None:
+        """체결 처리: 잔고 및 포지션 업데이트."""
+        order.filled_quantity = fill_qty
+        filled_value = fill_qty * exec_price
+        commission = self._commission.calculate(order.side, filled_value)
+
+        if order.side == "buy":
+            self._cash -= filled_value + commission
+            self._update_position_buy(order.symbol, fill_qty, exec_price)
+        else:  # sell
+            self._cash += filled_value - commission
+            self._update_position_sell(order.symbol, fill_qty)
+
+        if fill_qty >= order.quantity:
+            order.status = "filled"
+        else:
+            order.status = "partially_filled"
+
+    def _update_position_buy(self, symbol: str, quantity: float, price: float) -> None:
+        """매수 시 포지션 업데이트."""
+        pos = self._positions.get(symbol)
+        if pos is None:
+            self._positions[symbol] = _TestPosition(
+                symbol=symbol, quantity=quantity, avg_price=price
+            )
+        else:
+            total_qty = pos.quantity + quantity
+            pos.avg_price = (
+                pos.avg_price * pos.quantity + price * quantity
+            ) / total_qty
+            pos.quantity = total_qty
+
+    def _update_position_sell(self, symbol: str, quantity: float) -> None:
+        """매도 시 포지션 업데이트."""
+        pos = self._positions.get(symbol)
+        if pos is None:
+            msg = f"매도할 포지션 없음: {symbol}"
+            raise BrokerError(msg)
+        if pos.quantity < quantity:
+            msg = f"보유 수량 부족: {symbol} (보유: {pos.quantity}, 매도: {quantity})"
+            raise BrokerError(msg)
+        pos.quantity -= quantity

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -229,6 +229,19 @@ async def main() -> None:
         )
         await broker.connect()
         logger.info("MockBrokerAdapter 연결 완료")
+    elif broker_type == "test":
+        from ante.broker import TestBrokerAdapter
+
+        test_config = (
+            broker_config.get("test", {}) if isinstance(broker_config, dict) else {}
+        )
+        merged = {
+            **(broker_config if isinstance(broker_config, dict) else {}),
+            **test_config,
+        }
+        broker = TestBrokerAdapter(merged)
+        await broker.connect()
+        logger.info("TestBrokerAdapter 연결 완료 (seed=%s)", merged.get("seed", 42))
     else:
         from ante.broker import KISAdapter
 

--- a/tests/unit/test_broker_type_switch.py
+++ b/tests/unit/test_broker_type_switch.py
@@ -1,0 +1,236 @@
+"""broker.type 설정 기반 KIS <-> Test 브로커 전환 통합 테스트.
+
+main.py의 브로커 초기화 분기가 설정에 따라 올바른 어댑터를 생성하는지 검증한다.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ante.broker.base import BrokerAdapter
+from ante.broker.mock import MockBrokerAdapter
+from ante.broker.test import TestBrokerAdapter
+
+
+def _make_config(broker_type: str, **extra: object) -> MagicMock:
+    """테스트용 Config 객체를 생성한다."""
+    broker_section: dict = {
+        "type": broker_type,
+        "is_paper": True,
+        "commission_rate": 0.00015,
+        "sell_tax_rate": 0.0023,
+        **extra,
+    }
+
+    config = MagicMock()
+    config.get.side_effect = lambda key, default=None: (
+        broker_section if key == "broker" else default
+    )
+    config.secret.return_value = None
+    config.validate.return_value = None
+    return config
+
+
+async def _create_broker_from_config(
+    broker_config: dict,
+) -> BrokerAdapter | None:
+    """main.py의 브로커 초기화 분기 로직을 재현한다.
+
+    main.py에서 발췌한 핵심 분기만 격리 테스트한다.
+    """
+    broker_type = (
+        broker_config.get("type", "kis") if isinstance(broker_config, dict) else "kis"
+    )
+
+    if broker_type == "mock":
+        broker = MockBrokerAdapter(
+            broker_config if isinstance(broker_config, dict) else {}
+        )
+        await broker.connect()
+        return broker
+    elif broker_type == "test":
+        test_config = (
+            broker_config.get("test", {}) if isinstance(broker_config, dict) else {}
+        )
+        merged = {
+            **(broker_config if isinstance(broker_config, dict) else {}),
+            **test_config,
+        }
+        broker = TestBrokerAdapter(merged)
+        await broker.connect()
+        return broker
+    else:
+        # KIS 분기 — 시크릿 없으면 None
+        return None
+
+
+# ── 전환 분기 검증 ──────────────────────────────────────────────
+
+
+class TestBrokerTypeSwitch:
+    """broker.type 설정에 따른 브로커 인스턴스 생성 검증."""
+
+    @pytest.mark.asyncio
+    async def test_type_test_creates_test_broker(self) -> None:
+        """type = 'test'이면 TestBrokerAdapter가 생성된다."""
+        broker_config = {
+            "type": "test",
+            "commission_rate": 0.00015,
+            "sell_tax_rate": 0.0023,
+            "test": {"seed": 42, "initial_cash": 50_000_000},
+        }
+        broker = await _create_broker_from_config(broker_config)
+        assert isinstance(broker, TestBrokerAdapter)
+        assert broker.is_connected is True
+        await broker.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_type_mock_creates_mock_broker(self) -> None:
+        """type = 'mock'이면 MockBrokerAdapter가 생성된다."""
+        broker_config = {"type": "mock"}
+        broker = await _create_broker_from_config(broker_config)
+        assert isinstance(broker, MockBrokerAdapter)
+        assert broker.is_connected is True
+        await broker.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_type_kis_without_secrets_returns_none(self) -> None:
+        """type = 'kis'이고 시크릿이 없으면 None."""
+        broker_config = {"type": "kis"}
+        broker = await _create_broker_from_config(broker_config)
+        assert broker is None
+
+    @pytest.mark.asyncio
+    async def test_default_type_is_kis(self) -> None:
+        """type 미지정 시 기본값 'kis'로 동작한다."""
+        broker_config = {}
+        broker = await _create_broker_from_config(broker_config)
+        assert broker is None  # KIS 시크릿 없으면 None
+
+
+class TestTestBrokerConfigMerge:
+    """[broker.test] 섹션이 브로커 설정에 올바르게 병합되는지 검증."""
+
+    @pytest.mark.asyncio
+    async def test_test_section_overrides_defaults(self) -> None:
+        """[broker.test] 설정이 기본 seed/initial_cash를 오버라이드한다."""
+        broker_config = {
+            "type": "test",
+            "commission_rate": 0.00015,
+            "sell_tax_rate": 0.0023,
+            "test": {
+                "seed": 99,
+                "initial_cash": 50_000_000,
+                "tick_interval": 0.5,
+            },
+        }
+        broker = await _create_broker_from_config(broker_config)
+        assert isinstance(broker, TestBrokerAdapter)
+        assert broker._seed == 99
+        assert broker._initial_cash == 50_000_000
+        assert broker._tick_interval == 0.5
+        await broker.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_commission_rates_propagated(self) -> None:
+        """broker 섹션의 수수료율이 TestBrokerAdapter에 전달된다."""
+        broker_config = {
+            "type": "test",
+            "commission_rate": 0.0002,
+            "sell_tax_rate": 0.003,
+            "test": {"seed": 42},
+        }
+        broker = await _create_broker_from_config(broker_config)
+        assert isinstance(broker, TestBrokerAdapter)
+        info = broker.get_commission_info()
+        assert info.commission_rate == 0.0002
+        assert info.sell_tax_rate == 0.003
+        await broker.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_empty_test_section_uses_defaults(self) -> None:
+        """[broker.test] 미지정 시 기본값으로 동작한다."""
+        broker_config = {"type": "test"}
+        broker = await _create_broker_from_config(broker_config)
+        assert isinstance(broker, TestBrokerAdapter)
+        assert broker._seed == 42
+        assert broker._initial_cash == 100_000_000.0
+        await broker.disconnect()
+
+
+class TestBrokerAdapterInterfaceConsistency:
+    """KIS <-> Test 전환 시 인터페이스 일관성 검증."""
+
+    @pytest.mark.asyncio
+    async def test_test_broker_is_broker_adapter(self) -> None:
+        """TestBrokerAdapter가 BrokerAdapter 인터페이스를 구현한다."""
+        broker = TestBrokerAdapter({"seed": 1})
+        assert isinstance(broker, BrokerAdapter)
+
+    @pytest.mark.asyncio
+    async def test_test_broker_full_cycle(self) -> None:
+        """Test 브로커로 조회/매수/매도/이력 전체 흐름이 동작한다."""
+        broker_config = {
+            "type": "test",
+            "test": {"seed": 42, "initial_cash": 100_000_000},
+        }
+        broker = await _create_broker_from_config(broker_config)
+        assert isinstance(broker, TestBrokerAdapter)
+
+        # 잔고 조회
+        balance = await broker.get_account_balance()
+        assert balance["cash"] == 100_000_000
+
+        # 시세 조회
+        price = await broker.get_current_price("000001")
+        assert price > 0
+
+        # 매수
+        order_id = await broker.place_order("000001", "buy", 10)
+        assert order_id
+
+        # 포지션 확인
+        positions = await broker.get_positions()
+        assert len(positions) == 1
+
+        # 매도
+        sell_id = await broker.place_order("000001", "sell", 5)
+        assert sell_id
+
+        # 이력
+        history = await broker.get_order_history()
+        assert len(history) == 2
+
+        # 종목 마스터
+        instruments = await broker.get_instruments()
+        assert len(instruments) == 6
+
+        await broker.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_switch_test_to_test_independent(self) -> None:
+        """서로 다른 Test 브로커 인스턴스가 독립적이다."""
+        b1 = await _create_broker_from_config(
+            {"type": "test", "test": {"seed": 1, "initial_cash": 10_000_000}}
+        )
+        b2 = await _create_broker_from_config(
+            {"type": "test", "test": {"seed": 2, "initial_cash": 50_000_000}}
+        )
+
+        assert isinstance(b1, TestBrokerAdapter)
+        assert isinstance(b2, TestBrokerAdapter)
+
+        bal1 = await b1.get_account_balance()
+        bal2 = await b2.get_account_balance()
+        assert bal1["cash"] == 10_000_000
+        assert bal2["cash"] == 50_000_000
+
+        # b1에서 매수해도 b2에 영향 없음
+        await b1.place_order("000001", "buy", 5)
+        assert len(await b1.get_positions()) == 1
+        assert len(await b2.get_positions()) == 0
+
+        await b1.disconnect()
+        await b2.disconnect()

--- a/tests/unit/test_price_simulator.py
+++ b/tests/unit/test_price_simulator.py
@@ -1,0 +1,211 @@
+"""PriceSimulator 단위 테스트.
+
+시드 재현성, 가격 범위, KRX 호가 단위(tick size) 검증.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.broker.test import (
+    VIRTUAL_STOCK_PRESETS,
+    PriceSimulator,
+    StockPreset,
+    _tick_size,
+    tick_round,
+)
+
+# ── tick_round / tick_size 검증 ─────────────────────────────
+
+
+class TestTickRound:
+    """KRX 호가 단위 반올림 검증."""
+
+    @pytest.mark.parametrize(
+        ("price", "expected_tick"),
+        [
+            (1_500, 1),
+            (3_000, 5),
+            (10_000, 10),
+            (30_000, 50),
+            (72_000, 100),
+            (250_000, 500),
+            (600_000, 1_000),
+        ],
+    )
+    def test_tick_size_by_price_range(self, price: float, expected_tick: int) -> None:
+        """가격 구간별 호가 단위가 올바르다."""
+        assert _tick_size(price) == expected_tick
+
+    @pytest.mark.parametrize(
+        ("price", "expected"),
+        [
+            # 100원 단위 (50,000~200,000)
+            (72_051, 72_100),
+            (72_049, 72_000),
+            (72_150, 72_200),  # 정확히 .5 → banker's rounding (짝수)
+            # 500원 단위 (200,000~500,000)
+            (390_300, 390_500),
+            (390_249, 390_000),
+            # 50원 단위 (20,000~50,000)
+            (48_026, 48_050),
+            (48_024, 48_000),
+            # 10원 단위 (5,000~20,000)
+            (10_006, 10_010),
+            (10_004, 10_000),
+        ],
+    )
+    def test_tick_round_values(self, price: float, expected: float) -> None:
+        """호가 단위 반올림이 정확하다."""
+        assert tick_round(price) == expected
+
+
+# ── PriceSimulator 기본 동작 ────────────────────────────────
+
+
+class TestPriceSimulatorBasic:
+    """PriceSimulator 기본 동작 검증."""
+
+    def test_default_presets(self) -> None:
+        """기본 프리셋 6종으로 초기화된다."""
+        sim = PriceSimulator()
+        assert len(sim.symbols) == 6
+        assert set(sim.symbols) == set(VIRTUAL_STOCK_PRESETS.keys())
+
+    def test_custom_presets(self) -> None:
+        """커스텀 프리셋으로 초기화할 수 있다."""
+        custom = {
+            "999999": StockPreset("999999", "테스트종목", 100_000, 0.02),
+        }
+        sim = PriceSimulator(presets=custom)
+        assert sim.symbols == ["999999"]
+        assert sim.get_price("999999") == 100_000
+
+    def test_initial_price_matches_preset(self) -> None:
+        """초기 가격이 프리셋 기준가를 호가 단위로 반올림한 값이다."""
+        sim = PriceSimulator()
+        for symbol, preset in VIRTUAL_STOCK_PRESETS.items():
+            assert sim.get_price(symbol) == tick_round(preset.base_price)
+
+    def test_tick_returns_float(self) -> None:
+        """tick()은 float를 반환한다."""
+        sim = PriceSimulator()
+        price = sim.tick("000001")
+        assert isinstance(price, float)
+
+    def test_tick_updates_price(self) -> None:
+        """tick() 호출 후 get_price()가 갱신된 값을 반환한다."""
+        sim = PriceSimulator()
+        new_price = sim.tick("000001")
+        assert sim.get_price("000001") == new_price
+
+    def test_unknown_symbol_tick_raises(self) -> None:
+        """등록되지 않은 종목으로 tick() 호출 시 KeyError."""
+        sim = PriceSimulator()
+        with pytest.raises(KeyError, match="등록되지 않은 종목"):
+            sim.tick("999999")
+
+    def test_unknown_symbol_get_price_raises(self) -> None:
+        """등록되지 않은 종목으로 get_price() 호출 시 KeyError."""
+        sim = PriceSimulator()
+        with pytest.raises(KeyError, match="등록되지 않은 종목"):
+            sim.get_price("999999")
+
+
+# ── 시드 재현성 ─────────────────────────────────────────────
+
+
+class TestSeedReproducibility:
+    """동일 시드 → 동일 가격 시퀀스 재현성 검증."""
+
+    def test_same_seed_same_sequence(self) -> None:
+        """동일 시드로 초기화하면 동일한 가격 시퀀스를 생성한다."""
+        seq1 = self._generate_sequence(seed=42, ticks=100)
+        seq2 = self._generate_sequence(seed=42, ticks=100)
+        assert seq1 == seq2
+
+    def test_different_seed_different_sequence(self) -> None:
+        """다른 시드로 초기화하면 다른 가격 시퀀스를 생성한다."""
+        # 낮은 가격대(호가 단위 1원)를 사용하여 변동이 반올림에 묻히지 않게 함
+        preset = {"T01": StockPreset("T01", "테스트", 1_000, 0.03)}
+        seq1 = self._generate_sequence_with_preset(preset, seed=42, ticks=100)
+        seq2 = self._generate_sequence_with_preset(preset, seed=99, ticks=100)
+        assert seq1 != seq2
+
+    def test_reproducibility_across_symbols(self) -> None:
+        """여러 종목을 교차 호출해도 시드 재현성이 유지된다."""
+        symbols = ["000001", "000002", "000003"]
+
+        def run(seed: int) -> list[float]:
+            sim = PriceSimulator(seed=seed)
+            prices = []
+            for _ in range(20):
+                for s in symbols:
+                    prices.append(sim.tick(s))
+            return prices
+
+        assert run(42) == run(42)
+
+    @staticmethod
+    def _generate_sequence(seed: int, ticks: int) -> list[float]:
+        sim = PriceSimulator(seed=seed)
+        return [sim.tick("000001") for _ in range(ticks)]
+
+    @staticmethod
+    def _generate_sequence_with_preset(
+        presets: dict[str, StockPreset], seed: int, ticks: int
+    ) -> list[float]:
+        sim = PriceSimulator(presets=presets, seed=seed)
+        symbol = next(iter(presets))
+        return [sim.tick(symbol) for _ in range(ticks)]
+
+
+# ── 가격 범위 및 호가 단위 검증 ─────────────────────────────
+
+
+class TestPriceProperties:
+    """가격 변동 특성 검증."""
+
+    def test_prices_remain_positive(self) -> None:
+        """1000틱 진행 후에도 가격이 양수를 유지한다."""
+        sim = PriceSimulator(seed=12345)
+        for symbol in sim.symbols:
+            for _ in range(1000):
+                price = sim.tick(symbol)
+                assert price > 0, f"{symbol} 가격이 0 이하: {price}"
+
+    def test_prices_conform_to_tick_size(self) -> None:
+        """모든 가격이 KRX 호가 단위의 정수배이다."""
+        sim = PriceSimulator(seed=42)
+        for symbol in sim.symbols:
+            for _ in range(500):
+                price = sim.tick(symbol)
+                tick = _tick_size(price)
+                remainder = price % tick
+                assert remainder == 0, (
+                    f"{symbol}: {price}는 호가단위 {tick}의 배수가 아님"
+                )
+
+    def test_price_changes_are_small_per_tick(self) -> None:
+        """틱 단위 변동폭이 일변동성보다 훨씬 작다."""
+        sim = PriceSimulator(seed=42)
+        symbol = "000001"
+        prev = sim.get_price(symbol)
+        max_return = 0.0
+        for _ in range(1000):
+            curr = sim.tick(symbol)
+            if prev > 0:
+                ret = abs(curr - prev) / prev
+                max_return = max(max_return, ret)
+            prev = curr
+        # 틱 단위 최대 수익률은 일변동성(1.8%)의 일부여야 함
+        # σ_tick ≈ 0.018 / √23400 ≈ 0.000118, 3σ ≈ 0.00035
+        # 호가 단위 반올림 효과를 고려하여 넉넉하게 1%로 설정
+        assert max_return < 0.01, f"틱 최대 변동률 {max_return:.6f}이 1%를 초과"
+
+    def test_presets_property_returns_copy(self) -> None:
+        """presets 프로퍼티가 내부 상태의 복사본을 반환한다."""
+        sim = PriceSimulator()
+        presets = sim.presets
+        presets.pop("000001")
+        assert "000001" in sim.presets

--- a/tests/unit/test_test_broker.py
+++ b/tests/unit/test_test_broker.py
@@ -1,0 +1,498 @@
+"""TestBrokerAdapter 단위 테스트.
+
+연결/시세/주문/체결/잔고/포지션/스트리밍/종목마스터/수수료 검증.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ante.broker.exceptions import BrokerError, OrderNotFoundError
+from ante.broker.models import CommissionInfo
+from ante.broker.test import TestBrokerAdapter, tick_round
+
+# ── Fixture ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def broker() -> TestBrokerAdapter:
+    """기본 설정의 TestBrokerAdapter 인스턴스."""
+    return TestBrokerAdapter({"seed": 42, "initial_cash": 100_000_000})
+
+
+@pytest.fixture
+async def connected_broker(broker: TestBrokerAdapter) -> TestBrokerAdapter:
+    """연결된 TestBrokerAdapter 인스턴스."""
+    await broker.connect()
+    return broker
+
+
+# ── 연결/해제 ────────────────────────────────────────────────
+
+
+class TestConnection:
+    """연결/해제 동작 검증."""
+
+    @pytest.mark.asyncio
+    async def test_connect(self, broker: TestBrokerAdapter) -> None:
+        """connect() 후 is_connected가 True."""
+        assert broker.is_connected is False
+        await broker.connect()
+        assert broker.is_connected is True
+
+    @pytest.mark.asyncio
+    async def test_disconnect(self, connected_broker: TestBrokerAdapter) -> None:
+        """disconnect() 후 is_connected가 False."""
+        await connected_broker.disconnect()
+        assert connected_broker.is_connected is False
+
+    def test_broker_metadata(self, broker: TestBrokerAdapter) -> None:
+        """브로커 메타정보가 올바르다."""
+        assert broker.broker_id == "test"
+        assert broker.broker_name == "테스트 브로커"
+        assert broker.broker_short_name == "TEST"
+
+
+# ── 시세 조회 ────────────────────────────────────────────────
+
+
+class TestCurrentPrice:
+    """get_current_price() 동작 검증."""
+
+    @pytest.mark.asyncio
+    async def test_returns_positive_price(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """현재가가 양수이다."""
+        price = await connected_broker.get_current_price("000001")
+        assert price > 0
+
+    @pytest.mark.asyncio
+    async def test_price_changes_on_each_call(self) -> None:
+        """매 호출마다 가격이 변동될 수 있다 (GBM 적용)."""
+        from ante.broker.test import PriceSimulator, StockPreset
+
+        # 저가 종목(호가 1원)으로 변동이 반올림에 묻히지 않게 함
+        custom = {"T01": StockPreset("T01", "테스트", 1_000, 0.03)}
+        broker = TestBrokerAdapter({"seed": 42, "initial_cash": 1_000_000})
+        broker._simulator = PriceSimulator(presets=custom, seed=42)
+        await broker.connect()
+        prices = [await broker.get_current_price("T01") for _ in range(50)]
+        assert len(set(prices)) > 1
+
+    @pytest.mark.asyncio
+    async def test_unknown_symbol_raises(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """등록되지 않은 종목 조회 시 KeyError."""
+        with pytest.raises(KeyError, match="등록되지 않은 종목"):
+            await connected_broker.get_current_price("999999")
+
+    @pytest.mark.asyncio
+    async def test_price_conforms_to_tick_size(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """반환 가격이 KRX 호가 단위에 맞다."""
+        for _ in range(100):
+            price = await connected_broker.get_current_price("000001")
+            assert price == tick_round(price)
+
+
+# ── 계좌/포지션 ──────────────────────────────────────────────
+
+
+class TestAccountBalance:
+    """get_account_balance() 동작 검증."""
+
+    @pytest.mark.asyncio
+    async def test_initial_balance(self, connected_broker: TestBrokerAdapter) -> None:
+        """초기 잔고가 설정값과 일치한다."""
+        balance = await connected_broker.get_account_balance()
+        assert balance["cash"] == 100_000_000
+        assert balance["total_assets"] == 100_000_000
+        assert balance["stock_value"] == 0
+
+    @pytest.mark.asyncio
+    async def test_balance_after_buy(self, connected_broker: TestBrokerAdapter) -> None:
+        """매수 후 현금이 감소하고 stock_value가 증가한다."""
+        await connected_broker.place_order("000001", "buy", 10)
+        balance = await connected_broker.get_account_balance()
+        assert balance["cash"] < 100_000_000
+        assert balance["stock_value"] > 0
+
+
+class TestPositions:
+    """get_positions() / get_account_positions() 동작 검증."""
+
+    @pytest.mark.asyncio
+    async def test_no_positions_initially(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """초기에는 포지션이 없다."""
+        positions = await connected_broker.get_positions()
+        assert positions == []
+
+    @pytest.mark.asyncio
+    async def test_position_after_buy(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """매수 후 포지션이 생성된다."""
+        await connected_broker.place_order("000001", "buy", 10)
+        positions = await connected_broker.get_positions()
+        assert len(positions) == 1
+        assert positions[0]["symbol"] == "000001"
+        assert positions[0]["quantity"] == 10
+
+    @pytest.mark.asyncio
+    async def test_account_positions_delegates(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """get_account_positions()이 get_positions()와 동일 결과를 반환한다."""
+        await connected_broker.place_order("000001", "buy", 5)
+        positions = await connected_broker.get_positions()
+        account_positions = await connected_broker.get_account_positions()
+        assert positions == account_positions
+
+
+# ── 주문/체결 ────────────────────────────────────────────────
+
+
+class TestPlaceOrder:
+    """place_order() 동작 검증."""
+
+    @pytest.mark.asyncio
+    async def test_market_buy_returns_order_id(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """시장가 매수가 주문 ID를 반환한다."""
+        order_id = await connected_broker.place_order("000001", "buy", 10)
+        assert isinstance(order_id, str)
+        assert len(order_id) > 0
+
+    @pytest.mark.asyncio
+    async def test_market_buy_updates_cash(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """시장가 매수 후 현금이 감소한다."""
+        initial_balance = await connected_broker.get_account_balance()
+        await connected_broker.place_order("000001", "buy", 10)
+        after_balance = await connected_broker.get_account_balance()
+        assert after_balance["cash"] < initial_balance["cash"]
+
+    @pytest.mark.asyncio
+    async def test_market_sell(self, connected_broker: TestBrokerAdapter) -> None:
+        """매수 후 매도가 정상 동작한다."""
+        await connected_broker.place_order("000001", "buy", 10)
+        order_id = await connected_broker.place_order("000001", "sell", 5)
+        positions = await connected_broker.get_positions()
+        assert positions[0]["quantity"] == 5
+        status = await connected_broker.get_order_status(order_id)
+        assert status["side"] == "sell"
+
+    @pytest.mark.asyncio
+    async def test_sell_without_position_raises(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """포지션 없이 매도 시 BrokerError."""
+        with pytest.raises(BrokerError, match="보유 수량 부족"):
+            await connected_broker.place_order("000001", "sell", 10)
+
+    @pytest.mark.asyncio
+    async def test_buy_insufficient_cash_raises(
+        self,
+    ) -> None:
+        """자금 부족 시 BrokerError."""
+        broker = TestBrokerAdapter({"seed": 42, "initial_cash": 1.0})
+        await broker.connect()
+        with pytest.raises(BrokerError, match="자금 부족"):
+            await broker.place_order("000001", "buy", 100)
+
+    @pytest.mark.asyncio
+    async def test_unknown_symbol_raises(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """등록되지 않은 종목 주문 시 BrokerError."""
+        with pytest.raises(BrokerError, match="등록되지 않은 종목"):
+            await connected_broker.place_order("999999", "buy", 10)
+
+    @pytest.mark.asyncio
+    async def test_slippage_applied_on_market_order(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """시장가 주문에 슬리피지가 적용된다."""
+        # 동일 시드로 여러 번 주문하면 체결가가 현재가와 약간 다를 수 있다
+        order_id = await connected_broker.place_order("000001", "buy", 10)
+        status = await connected_broker.get_order_status(order_id)
+        # 체결가가 호가 단위에 맞는지만 확인 (슬리피지 적용 여부는 확률적)
+        assert status["price"] == tick_round(status["price"])
+
+
+class TestLimitOrder:
+    """지정가 주문 동작 검증."""
+
+    @pytest.mark.asyncio
+    async def test_limit_buy_unfillable(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """지정가 매수 — 현재가보다 낮은 가격이면 미체결."""
+        # 현재가보다 훨씬 낮은 지정가
+        order_id = await connected_broker.place_order(
+            "000001", "buy", 10, order_type="limit", price=1_000.0
+        )
+        status = await connected_broker.get_order_status(order_id)
+        assert status["status"] == "pending"
+        assert status["filled_quantity"] == 0
+
+    @pytest.mark.asyncio
+    async def test_limit_buy_fillable(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """지정가 매수 — 현재가 이상이면 체결."""
+        order_id = await connected_broker.place_order(
+            "000001", "buy", 10, order_type="limit", price=999_999.0
+        )
+        status = await connected_broker.get_order_status(order_id)
+        assert status["status"] in ("filled", "partially_filled")
+
+    @pytest.mark.asyncio
+    async def test_limit_sell_unfillable(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """지정가 매도 — 현재가보다 높은 가격이면 미체결."""
+        await connected_broker.place_order("000001", "buy", 10)
+        order_id = await connected_broker.place_order(
+            "000001", "sell", 5, order_type="limit", price=999_999.0
+        )
+        status = await connected_broker.get_order_status(order_id)
+        assert status["status"] == "pending"
+
+
+class TestCancelOrder:
+    """cancel_order() 동작 검증."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_pending_order(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """미체결 주문 취소 성공."""
+        order_id = await connected_broker.place_order(
+            "000001", "buy", 10, order_type="limit", price=1_000.0
+        )
+        result = await connected_broker.cancel_order(order_id)
+        assert result is True
+        status = await connected_broker.get_order_status(order_id)
+        assert status["status"] == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_cancel_filled_order_fails(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """체결된 주문 취소 실패."""
+        order_id = await connected_broker.place_order("000001", "buy", 10)
+        status = await connected_broker.get_order_status(order_id)
+        if status["status"] == "filled":
+            result = await connected_broker.cancel_order(order_id)
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_cancel_nonexistent_order_raises(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """존재하지 않는 주문 취소 시 OrderNotFoundError."""
+        with pytest.raises(OrderNotFoundError):
+            await connected_broker.cancel_order("nonexistent")
+
+
+# ── 주문 상태/이력 ───────────────────────────────────────────
+
+
+class TestOrderStatus:
+    """get_order_status() / get_pending_orders() / get_order_history() 검증."""
+
+    @pytest.mark.asyncio
+    async def test_order_status_fields(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """주문 상태에 필수 필드가 포함된다."""
+        order_id = await connected_broker.place_order("000001", "buy", 10)
+        status = await connected_broker.get_order_status(order_id)
+        required_fields = {
+            "order_id",
+            "symbol",
+            "side",
+            "quantity",
+            "filled_quantity",
+            "price",
+            "order_type",
+            "status",
+            "created_at",
+        }
+        assert required_fields.issubset(status.keys())
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_order_raises(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """존재하지 않는 주문 조회 시 OrderNotFoundError."""
+        with pytest.raises(OrderNotFoundError):
+            await connected_broker.get_order_status("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_pending_orders_list(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """미체결 주문이 pending_orders에 포함된다."""
+        await connected_broker.place_order(
+            "000001", "buy", 10, order_type="limit", price=1_000.0
+        )
+        pending = await connected_broker.get_pending_orders()
+        assert len(pending) >= 1
+        assert pending[0]["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_order_history(self, connected_broker: TestBrokerAdapter) -> None:
+        """주문 이력에 모든 주문이 포함된다."""
+        await connected_broker.place_order("000001", "buy", 10)
+        await connected_broker.place_order(
+            "000002", "buy", 5, order_type="limit", price=1_000.0
+        )
+        history = await connected_broker.get_order_history()
+        assert len(history) == 2
+
+
+# ── 스트리밍 ─────────────────────────────────────────────────
+
+
+class TestStreaming:
+    """realtime_price_stream() / realtime_order_stream() 검증."""
+
+    @pytest.mark.asyncio
+    async def test_price_stream_yields_data(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """가격 스트림이 데이터를 yield한다."""
+        # tick_interval을 짧게 설정
+        connected_broker._tick_interval = 0.01
+
+        items: list[dict] = []
+        async for item in connected_broker.realtime_price_stream(["000001", "000002"]):
+            items.append(item)
+            if len(items) >= 4:  # 2종목 x 2라운드
+                await connected_broker.disconnect()  # 스트림 종료
+
+        assert len(items) >= 4
+        assert all("symbol" in item for item in items)
+        assert all("price" in item for item in items)
+        assert all("timestamp" in item for item in items)
+
+    @pytest.mark.asyncio
+    async def test_price_stream_stops_on_disconnect(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """disconnect 후 스트림이 종료된다."""
+        connected_broker._tick_interval = 0.01
+
+        async def disconnect_after(delay: float) -> None:
+            await asyncio.sleep(delay)
+            await connected_broker.disconnect()
+
+        task = asyncio.create_task(disconnect_after(0.05))
+        count = 0
+        async for _ in connected_broker.realtime_price_stream(["000001"]):
+            count += 1
+        await task
+        assert count > 0  # 최소 한 번은 yield해야 함
+
+    @pytest.mark.asyncio
+    async def test_order_stream_returns_filled_orders(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """주문 스트림이 체결 주문을 반환한다."""
+        await connected_broker.place_order("000001", "buy", 10)
+        items = []
+        async for item in connected_broker.realtime_order_stream():
+            items.append(item)
+        assert len(items) >= 1
+
+
+# ── 종목 마스터 ──────────────────────────────────────────────
+
+
+class TestInstruments:
+    """get_instruments() 검증."""
+
+    @pytest.mark.asyncio
+    async def test_returns_six_instruments(
+        self, connected_broker: TestBrokerAdapter
+    ) -> None:
+        """6종의 가상 종목이 반환된다."""
+        instruments = await connected_broker.get_instruments()
+        assert len(instruments) == 6
+
+    @pytest.mark.asyncio
+    async def test_instrument_fields(self, connected_broker: TestBrokerAdapter) -> None:
+        """종목 정보에 필수 필드가 포함된다."""
+        instruments = await connected_broker.get_instruments()
+        required_fields = {"symbol", "name", "name_en", "instrument_type", "listed"}
+        for inst in instruments:
+            assert required_fields.issubset(inst.keys())
+            assert inst["instrument_type"] == "stock"
+            assert inst["listed"] is True
+
+
+# ── 수수료 ───────────────────────────────────────────────────
+
+
+class TestCommission:
+    """get_commission_info() 검증."""
+
+    def test_returns_commission_info(self, broker: TestBrokerAdapter) -> None:
+        """CommissionInfo 인스턴스를 반환한다."""
+        info = broker.get_commission_info()
+        assert isinstance(info, CommissionInfo)
+
+    def test_default_rates(self, broker: TestBrokerAdapter) -> None:
+        """KIS 동일 수수료율이 설정된다."""
+        info = broker.get_commission_info()
+        assert info.commission_rate == 0.00015
+        assert info.sell_tax_rate == 0.0023
+
+
+# ── 시드 재현성 ──────────────────────────────────────────────
+
+
+class TestSeedReproducibility:
+    """동일 시드로 동일한 체결 결과 재현 검증."""
+
+    @pytest.mark.asyncio
+    async def test_same_seed_same_prices(self) -> None:
+        """동일 시드의 두 브로커가 동일한 가격 시퀀스를 반환한다."""
+        b1 = TestBrokerAdapter({"seed": 42})
+        b2 = TestBrokerAdapter({"seed": 42})
+        await b1.connect()
+        await b2.connect()
+
+        prices1 = [await b1.get_current_price("000001") for _ in range(20)]
+        prices2 = [await b2.get_current_price("000001") for _ in range(20)]
+        assert prices1 == prices2
+
+
+# ── BrokerAdapter 인터페이스 준수 ────────────────────────────
+
+
+class TestBrokerAdapterInterface:
+    """BrokerAdapter ABC 전체 메서드 구현 검증."""
+
+    def test_is_broker_adapter(self, broker: TestBrokerAdapter) -> None:
+        """TestBrokerAdapter가 BrokerAdapter의 인스턴스이다."""
+        from ante.broker.base import BrokerAdapter
+
+        assert isinstance(broker, BrokerAdapter)
+
+    def test_all_abstract_methods_implemented(self) -> None:
+        """모든 추상 메서드가 구현되었다 (인스턴스 생성 가능 = ABC 충족)."""
+        # ABC를 모두 구현하지 않으면 인스턴스 생성 시 TypeError
+        broker = TestBrokerAdapter({"seed": 1})
+        assert broker is not None


### PR DESCRIPTION
Refs #429

## 개요

KIS 실전 API 없이도 시스템 전체 흐름을 검증할 수 있는 Test 브로커 구현.
GBM 기반 현실적 가격 시뮬레이션, 슬리피지/부분체결, 설정 기반 전환을 지원.

## 하위 이슈 (3개, 모두 완료)

- #425 ✅ PriceSimulator — GBM 기반 가격 시뮬레이션 엔진 (가상 종목 6종, 시드 재현성, KRX 호가 단위)
- #426 ✅ TestBrokerAdapter — BrokerAdapter ABC 18개 메서드 전체 구현 (슬리피지, 부분체결, 실시간 스트림)
- #427 ✅ broker.type 설정 기반 KIS ↔ Test 전환 (system.toml 설정, main.py 분기)

## 테스트
- 1829 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)