### PR TITLE
feat: Treasury.update_budget() 및 RuleEngine.update_rules() 구현

### DIFF
--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from ante.rule.base import (
@@ -52,9 +53,11 @@ class RuleEngine:
         self,
         eventbus: EventBus,
         system_state: SystemState,
+        bot_strategy_resolver: Callable[[str], str | None] | None = None,
     ) -> None:
         self._eventbus = eventbus
         self._system_state = system_state
+        self._bot_strategy_resolver = bot_strategy_resolver
 
         self._global_rules: list[Rule] = []
         self._strategy_rules: dict[str, list[Rule]] = {}
@@ -87,6 +90,43 @@ class RuleEngine:
             self._strategy_rules[strategy_id] = []
         self._strategy_rules[strategy_id].append(rule)
         self._strategy_rules[strategy_id].sort(key=lambda r: r.priority)
+
+    def set_bot_strategy_resolver(self, resolver: Callable[[str], str | None]) -> None:
+        """봇 ID → 전략 ID 변환 콜백 설정 (초기화 후 BotManager 연결 시 호출)."""
+        self._bot_strategy_resolver = resolver
+
+    def update_rules(self, bot_id: str, rules: list[dict[str, Any]]) -> None:
+        """봇의 거래 규칙을 갱신.
+
+        bot_id에 연결된 strategy_id를 조회한 뒤
+        load_strategy_rules_from_config(strategy_id, rules)로 기존 룰을 교체한다.
+
+        Args:
+            bot_id: 대상 봇 ID.
+            rules: 새 룰 설정 리스트.
+
+        Raises:
+            RuleError: resolver 미설정 또는 strategy_id 조회 실패.
+        """
+        from ante.rule.exceptions import RuleError
+
+        if not self._bot_strategy_resolver:
+            raise RuleError(
+                "bot_strategy_resolver가 설정되지 않았습니다. "
+                "set_bot_strategy_resolver()를 먼저 호출하세요."
+            )
+
+        strategy_id = self._bot_strategy_resolver(bot_id)
+        if not strategy_id:
+            raise RuleError(f"봇 '{bot_id}'에 연결된 전략을 찾을 수 없습니다.")
+
+        self.load_strategy_rules_from_config(strategy_id, rules)
+        logger.info(
+            "룰 갱신: bot=%s, strategy=%s, 룰 %d건",
+            bot_id,
+            strategy_id,
+            len(rules),
+        )
 
     def clear_rules(self) -> None:
         """모든 룰 제거."""

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -251,6 +251,64 @@ class Treasury:
         logger.info("예산 회수: %s ← %s", bot_id, amount)
         return True
 
+    async def update_budget(self, bot_id: str, target_amount: float) -> None:
+        """봇의 예산을 목표 금액으로 변경.
+
+        현재 할당액과 목표 금액의 차이를 계산하여 allocate/deallocate를 호출한다.
+        미할당 잔액이 부족하면 InsufficientFundsError를 발생시킨다.
+
+        Args:
+            bot_id: 대상 봇 ID.
+            target_amount: 목표 할당 금액.
+
+        Raises:
+            InsufficientFundsError: 증액 시 미할당 잔액 부족.
+            BotNotStoppedError: 봇이 운용 중인 경우.
+            ValueError: 목표 금액이 음수인 경우.
+        """
+        from ante.treasury.exceptions import InsufficientFundsError
+
+        if target_amount < 0:
+            raise ValueError(f"목표 금액은 0 이상이어야 합니다: {target_amount}")
+
+        budget = self._budgets.get(bot_id)
+        current = budget.allocated if budget else 0.0
+        diff = target_amount - current
+
+        if diff == 0:
+            return
+
+        if diff > 0:
+            # 증액
+            if self._unallocated < diff:
+                raise InsufficientFundsError(
+                    f"미할당 잔액 부족: 필요 {diff:,.0f}, 가용 {self._unallocated:,.0f}"
+                )
+            result = await self.allocate(bot_id, diff)
+            if not result:
+                raise InsufficientFundsError(
+                    f"예산 할당 실패: bot_id={bot_id}, amount={diff}"
+                )
+        else:
+            # 감액
+            decrease = abs(diff)
+            result = await self.deallocate(bot_id, decrease)
+            if not result:
+                available = budget.available if budget else 0.0
+                raise InsufficientFundsError(
+                    f"예산 회수 실패: 회수 요청 {decrease:,.0f}, "
+                    f"가용 예산 {available:,.0f}"
+                )
+
+        logger.info(
+            "예산 변경: %s — %s → %s (차이: %s%s)",
+            bot_id,
+            f"{current:,.0f}",
+            f"{target_amount:,.0f}",
+            "+" if diff > 0 else "",
+            f"{diff:,.0f}",
+        )
+
     # ── 주문 자금 예약/해제 ─────────────────────────
 
     async def reserve_for_order(

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -530,3 +530,185 @@ class TestRuleEngineEventBus:
 
         assert len(received) == 1
         assert "Trading not allowed" in received[0].reason
+
+
+# ── RuleEngine.update_rules ──────────────────────
+
+
+class TestRuleEngineUpdateRules:
+    """RuleEngine.update_rules() 단위 테스트."""
+
+    @pytest.fixture
+    async def db(self, tmp_path):
+        database = Database(str(tmp_path / "test.db"))
+        await database.connect()
+        yield database
+        await database.close()
+
+    @pytest.fixture
+    def eventbus(self):
+        return EventBus()
+
+    @pytest.fixture
+    async def system_state(self, db, eventbus):
+        from ante.config.system_state import SystemState
+
+        state = SystemState(db=db, eventbus=eventbus)
+        await state.initialize()
+        return state
+
+    @pytest.fixture
+    def bot_strategies(self):
+        """bot_id → strategy_id 매핑."""
+        return {"bot1": "momentum_v1", "bot2": "mean_revert_v1"}
+
+    @pytest.fixture
+    def engine(self, eventbus, system_state, bot_strategies):
+        return RuleEngine(
+            eventbus=eventbus,
+            system_state=system_state,
+            bot_strategy_resolver=lambda bid: bot_strategies.get(bid),
+        )
+
+    def test_update_rules_replaces_strategy_rules(self, engine):
+        """update_rules는 해당 전략의 기존 룰을 교체한다."""
+        # 기존 룰 설정
+        engine.add_strategy_rule(
+            "momentum_v1",
+            PositionSizeRule("old_ps", {"max_position_percent": 0.10}),
+        )
+        assert len(engine._strategy_rules["momentum_v1"]) == 1
+
+        # update_rules로 교체
+        new_rules = [
+            {
+                "type": "position_size",
+                "id": "new_ps",
+                "max_position_percent": 0.20,
+                "max_position_amount": 500000.0,
+            },
+            {
+                "type": "trade_frequency",
+                "id": "new_freq",
+                "max_trades_per_hour": 10,
+            },
+        ]
+        engine.update_rules("bot1", new_rules)
+
+        assert len(engine._strategy_rules["momentum_v1"]) == 2
+        rule_ids = [r.rule_id for r in engine._strategy_rules["momentum_v1"]]
+        assert "new_ps" in rule_ids
+        assert "new_freq" in rule_ids
+        assert "old_ps" not in rule_ids
+
+    def test_update_rules_no_resolver_raises(self, eventbus, system_state):
+        """resolver 미설정 시 RuleError."""
+        from ante.rule.exceptions import RuleError
+
+        engine = RuleEngine(eventbus=eventbus, system_state=system_state)
+        with pytest.raises(RuleError, match="bot_strategy_resolver"):
+            engine.update_rules("bot1", [])
+
+    def test_update_rules_unknown_bot_raises(self, engine):
+        """존재하지 않는 봇이면 RuleError."""
+        from ante.rule.exceptions import RuleError
+
+        with pytest.raises(RuleError, match="전략을 찾을 수 없습니다"):
+            engine.update_rules("nonexistent", [])
+
+    def test_update_rules_empty_list(self, engine):
+        """빈 룰 리스트로 갱신하면 기존 룰이 모두 제거된다."""
+        engine.add_strategy_rule(
+            "momentum_v1",
+            PositionSizeRule("ps", {"max_position_percent": 0.10}),
+        )
+        engine.update_rules("bot1", [])
+        assert engine._strategy_rules["momentum_v1"] == []
+
+    def test_update_rules_does_not_affect_other_strategies(self, engine):
+        """다른 전략의 룰에 영향 없음."""
+        engine.add_strategy_rule(
+            "momentum_v1",
+            PositionSizeRule("ps1", {"max_position_percent": 0.10}),
+        )
+        engine.add_strategy_rule(
+            "mean_revert_v1",
+            TradeFrequencyRule("freq1", {"max_trades_per_hour": 5}),
+        )
+
+        engine.update_rules(
+            "bot1",
+            [
+                {
+                    "type": "trade_frequency",
+                    "id": "new_freq",
+                    "max_trades_per_hour": 20,
+                },
+            ],
+        )
+
+        # bot1의 전략(momentum_v1) 룰은 교체됨
+        assert len(engine._strategy_rules["momentum_v1"]) == 1
+        assert engine._strategy_rules["momentum_v1"][0].rule_id == "new_freq"
+
+        # bot2의 전략(mean_revert_v1) 룰은 그대로
+        assert len(engine._strategy_rules["mean_revert_v1"]) == 1
+        assert engine._strategy_rules["mean_revert_v1"][0].rule_id == "freq1"
+
+    def test_set_bot_strategy_resolver(self, eventbus, system_state):
+        """set_bot_strategy_resolver로 resolver를 나중에 설정할 수 있다."""
+        engine = RuleEngine(eventbus=eventbus, system_state=system_state)
+        engine.set_bot_strategy_resolver(lambda bid: "strat_a" if bid == "b1" else None)
+
+        engine.update_rules(
+            "b1",
+            [
+                {"type": "position_size", "id": "ps", "max_position_percent": 0.15},
+            ],
+        )
+        assert "strat_a" in engine._strategy_rules
+        assert len(engine._strategy_rules["strat_a"]) == 1
+
+    def test_update_rules_evaluate_with_new_rules(self, engine):
+        """갱신된 룰이 실제 평가에 반영된다."""
+        # 느슨한 룰
+        engine.update_rules(
+            "bot1",
+            [
+                {
+                    "type": "position_size",
+                    "id": "ps",
+                    "max_position_percent": 1.0,
+                    "max_position_amount": 10_000_000.0,
+                },
+            ],
+        )
+
+        context = RuleContext(
+            bot_id="bot1",
+            strategy_id="momentum_v1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            order_type="market",
+            current_price=50000.0,
+            available_balance=1_000_000.0,
+            system_status="active",
+        )
+        result = engine.evaluate(context)
+        assert result.overall_result == RuleResult.PASS
+
+        # 타이트한 룰로 교체
+        engine.update_rules(
+            "bot1",
+            [
+                {
+                    "type": "position_size",
+                    "id": "ps_tight",
+                    "max_position_percent": 0.01,
+                    "max_position_amount": 10_000.0,
+                },
+            ],
+        )
+        result = engine.evaluate(context)
+        assert result.overall_result == RuleResult.REJECT

--- a/tests/unit/test_treasury.py
+++ b/tests/unit/test_treasury.py
@@ -492,3 +492,91 @@ class TestTreasuryPersistence:
         assert budget is not None
         assert budget.allocated == 2_000_000.0
         assert budget.available == 2_000_000.0
+
+
+# ── update_budget ─────────────────────────────
+
+
+class TestUpdateBudget:
+    """Treasury.update_budget() 단위 테스트."""
+
+    async def test_increase_budget(self, treasury):
+        """기존 봇의 예산 증액."""
+        await treasury.allocate("bot1", 2_000_000.0)
+        await treasury.update_budget("bot1", 5_000_000.0)
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 5_000_000.0
+        assert budget.available == 5_000_000.0
+        assert treasury.unallocated == 5_000_000.0
+
+    async def test_decrease_budget(self, treasury):
+        """기존 봇의 예산 감액."""
+        await treasury.allocate("bot1", 5_000_000.0)
+        await treasury.update_budget("bot1", 3_000_000.0)
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 3_000_000.0
+        assert budget.available == 3_000_000.0
+        assert treasury.unallocated == 7_000_000.0
+
+    async def test_new_bot_budget(self, treasury):
+        """예산이 없는 봇에 최초 할당."""
+        await treasury.update_budget("new_bot", 3_000_000.0)
+
+        budget = treasury.get_budget("new_bot")
+        assert budget is not None
+        assert budget.allocated == 3_000_000.0
+        assert budget.available == 3_000_000.0
+        assert treasury.unallocated == 7_000_000.0
+
+    async def test_same_amount_noop(self, treasury):
+        """동일 금액이면 변경 없음."""
+        await treasury.allocate("bot1", 3_000_000.0)
+        await treasury.update_budget("bot1", 3_000_000.0)
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 3_000_000.0
+
+    async def test_increase_insufficient_funds(self, treasury):
+        """증액 시 미할당 잔액 부족이면 InsufficientFundsError."""
+        from ante.treasury.exceptions import InsufficientFundsError
+
+        await treasury.allocate("bot1", 8_000_000.0)
+        with pytest.raises(InsufficientFundsError, match="미할당 잔액 부족"):
+            await treasury.update_budget("bot1", 15_000_000.0)
+
+        # 원래 상태 유지
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 8_000_000.0
+
+    async def test_decrease_exceeds_available(self, treasury):
+        """감액 시 가용 예산 부족이면 InsufficientFundsError."""
+        from ante.treasury.exceptions import InsufficientFundsError
+
+        await treasury.allocate("bot1", 5_000_000.0)
+        # 자금 예약으로 available을 줄임
+        await treasury.reserve_for_order("bot1", "ord1", 4_000_000.0)
+
+        with pytest.raises(InsufficientFundsError, match="예산 회수 실패"):
+            await treasury.update_budget("bot1", 0.0)
+
+    async def test_negative_target_raises(self, treasury):
+        """목표 금액이 음수면 ValueError."""
+        with pytest.raises(ValueError, match="0 이상"):
+            await treasury.update_budget("bot1", -100.0)
+
+    async def test_set_to_zero(self, treasury):
+        """예산을 0으로 설정."""
+        await treasury.allocate("bot1", 3_000_000.0)
+        await treasury.update_budget("bot1", 0.0)
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 0.0
+        assert budget.available == 0.0
+        assert treasury.unallocated == 10_000_000.0


### PR DESCRIPTION
## Summary
- `Treasury.update_budget(bot_id, target_amount)`: 현재 할당액과 목표 금액 차이를 계산하여 allocate/deallocate 호출. 미할당 잔액 부족 시 `InsufficientFundsError` 발생
- `RuleEngine.update_rules(bot_id, rules)`: `bot_strategy_resolver` 콜백으로 bot_id → strategy_id 조회 후 `load_strategy_rules_from_config()`로 기존 전략별 룰 교체
- 단위 테스트 15건 추가 (update_budget 8건, update_rules 7건)

Refs #445

## Test plan
- [x] `Treasury.update_budget()` 증액/감액/최초할당/동일금액/잔액부족/가용부족/음수/0설정 테스트
- [x] `RuleEngine.update_rules()` 룰교체/resolver미설정/봇미존재/빈리스트/타전략무영향/resolver후설정/평가반영 테스트
- [x] 기존 1867건 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)