### PR TITLE
epic/447: 결재 executor 전체 등록

### DIFF
--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -209,6 +209,69 @@ class BotManager:
         logger.info("봇 생성: %s (전략: %s)", config.bot_id, config.strategy_id)
         return bot
 
+    async def assign_strategy(self, bot_id: str, strategy_id: str) -> None:
+        """봇에 전략 배정.
+
+        running 상태이면 중지 후 전략을 교체하고 재시작한다.
+        stopped/created 상태이면 전략 ID만 교체한다.
+        """
+        bot = self._get_bot(bot_id)
+        was_running = bot.status == BotStatus.RUNNING
+
+        if was_running:
+            await bot.stop()
+
+        bot.config.strategy_id = strategy_id
+        await self._update_bot_strategy(bot_id, strategy_id)
+
+        if was_running:
+            await bot.start()
+
+        logger.info(
+            "전략 배정: bot=%s strategy=%s (재시작=%s)",
+            bot_id,
+            strategy_id,
+            was_running,
+        )
+
+    async def change_strategy(self, bot_id: str, strategy_id: str) -> None:
+        """중지 상태 봇의 전략 교체.
+
+        running 상태이면 예외를 발생시킨다.
+        stopped/created/error 상태에서만 전략 ID를 교체한다.
+        """
+        bot = self._get_bot(bot_id)
+        if bot.status == BotStatus.RUNNING:
+            raise BotError(
+                f"실행 중인 봇의 전략은 변경할 수 없습니다: {bot_id}. "
+                f"assign_strategy()를 사용하거나 먼저 봇을 중지하세요."
+            )
+
+        bot.config.strategy_id = strategy_id
+        await self._update_bot_strategy(bot_id, strategy_id)
+
+        logger.info("전략 교체: bot=%s strategy=%s", bot_id, strategy_id)
+
+    async def resume_bot(self, bot_id: str) -> None:
+        """중지/에러 상태 봇 재시작.
+
+        에러 카운터를 리셋하고 봇을 시작한다.
+        running 상태이면 예외를 발생시킨다.
+        """
+        bot = self._get_bot(bot_id)
+        if bot.status == BotStatus.RUNNING:
+            raise BotError(f"이미 실행 중인 봇입니다: {bot_id}")
+
+        if bot.status not in (BotStatus.STOPPED, BotStatus.ERROR):
+            raise BotError(f"재개할 수 없는 상태입니다: {bot_id} (현재: {bot.status})")
+
+        # 에러 카운터 리셋
+        self._restart_counts.pop(bot_id, None)
+        bot.error_message = None
+
+        await bot.start()
+        logger.info("봇 재개: %s", bot_id)
+
     async def start_bot(self, bot_id: str) -> None:
         """봇 시작."""
         bot = self._get_bot(bot_id)
@@ -487,6 +550,14 @@ class BotManager:
             self._eventbus.unsubscribe(event_type, bot.on_order_update)
 
     # ── DB ───────────────────────────────────────────
+
+    async def _update_bot_strategy(self, bot_id: str, strategy_id: str) -> None:
+        """봇의 전략 ID를 DB에 갱신."""
+        await self._db.execute(
+            "UPDATE bots SET strategy_id = ?, updated_at = datetime('now')"
+            " WHERE bot_id = ?",
+            (strategy_id, bot_id),
+        )
 
     async def _save_bot_config(self, config: BotConfig) -> None:
         """봇 설정 DB 저장."""

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -415,11 +415,33 @@ async def _init_feed(s: Services) -> None:
     # ApprovalService
     from ante.approval import ApprovalService
 
+    async def _exec_rule_change(params: dict) -> None:
+        s.rule_engine.update_rules(params["bot_id"], params["rules"])
+
     approval_executors: dict = {
+        # 전략 관련
         "strategy_adopt": lambda params: s.report_store.update_status(
             params["report_id"], "adopted"
         ),
+        "strategy_retire": lambda params: s.report_store.update_status(
+            params["report_id"], "retired"
+        ),
+        # 봇 생명주기
+        "bot_create": lambda params: s.bot_manager.create_bot(**params),
+        "bot_assign_strategy": lambda params: s.bot_manager.assign_strategy(
+            params["bot_id"], params["strategy_id"]
+        ),
+        "bot_change_strategy": lambda params: s.bot_manager.change_strategy(
+            params["bot_id"], params["strategy_id"]
+        ),
         "bot_stop": lambda params: s.bot_manager.stop_bot(params["bot_id"]),
+        "bot_resume": lambda params: s.bot_manager.resume_bot(params["bot_id"]),
+        "bot_delete": lambda params: s.bot_manager.delete_bot(params["bot_id"]),
+        # 자금·규칙
+        "budget_change": lambda params: s.treasury.update_budget(
+            params["bot_id"], params["amount"]
+        ),
+        "rule_change": _exec_rule_change,
     }
     s.approval_service = ApprovalService(
         db=s.db, eventbus=s.eventbus, executors=approval_executors

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from ante.rule.base import (
@@ -52,9 +53,11 @@ class RuleEngine:
         self,
         eventbus: EventBus,
         system_state: SystemState,
+        bot_strategy_resolver: Callable[[str], str | None] | None = None,
     ) -> None:
         self._eventbus = eventbus
         self._system_state = system_state
+        self._bot_strategy_resolver = bot_strategy_resolver
 
         self._global_rules: list[Rule] = []
         self._strategy_rules: dict[str, list[Rule]] = {}
@@ -87,6 +90,43 @@ class RuleEngine:
             self._strategy_rules[strategy_id] = []
         self._strategy_rules[strategy_id].append(rule)
         self._strategy_rules[strategy_id].sort(key=lambda r: r.priority)
+
+    def set_bot_strategy_resolver(self, resolver: Callable[[str], str | None]) -> None:
+        """봇 ID → 전략 ID 변환 콜백 설정 (초기화 후 BotManager 연결 시 호출)."""
+        self._bot_strategy_resolver = resolver
+
+    def update_rules(self, bot_id: str, rules: list[dict[str, Any]]) -> None:
+        """봇의 거래 규칙을 갱신.
+
+        bot_id에 연결된 strategy_id를 조회한 뒤
+        load_strategy_rules_from_config(strategy_id, rules)로 기존 룰을 교체한다.
+
+        Args:
+            bot_id: 대상 봇 ID.
+            rules: 새 룰 설정 리스트.
+
+        Raises:
+            RuleError: resolver 미설정 또는 strategy_id 조회 실패.
+        """
+        from ante.rule.exceptions import RuleError
+
+        if not self._bot_strategy_resolver:
+            raise RuleError(
+                "bot_strategy_resolver가 설정되지 않았습니다. "
+                "set_bot_strategy_resolver()를 먼저 호출하세요."
+            )
+
+        strategy_id = self._bot_strategy_resolver(bot_id)
+        if not strategy_id:
+            raise RuleError(f"봇 '{bot_id}'에 연결된 전략을 찾을 수 없습니다.")
+
+        self.load_strategy_rules_from_config(strategy_id, rules)
+        logger.info(
+            "룰 갱신: bot=%s, strategy=%s, 룰 %d건",
+            bot_id,
+            strategy_id,
+            len(rules),
+        )
 
     def clear_rules(self) -> None:
         """모든 룰 제거."""

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -251,6 +251,64 @@ class Treasury:
         logger.info("예산 회수: %s ← %s", bot_id, amount)
         return True
 
+    async def update_budget(self, bot_id: str, target_amount: float) -> None:
+        """봇의 예산을 목표 금액으로 변경.
+
+        현재 할당액과 목표 금액의 차이를 계산하여 allocate/deallocate를 호출한다.
+        미할당 잔액이 부족하면 InsufficientFundsError를 발생시킨다.
+
+        Args:
+            bot_id: 대상 봇 ID.
+            target_amount: 목표 할당 금액.
+
+        Raises:
+            InsufficientFundsError: 증액 시 미할당 잔액 부족.
+            BotNotStoppedError: 봇이 운용 중인 경우.
+            ValueError: 목표 금액이 음수인 경우.
+        """
+        from ante.treasury.exceptions import InsufficientFundsError
+
+        if target_amount < 0:
+            raise ValueError(f"목표 금액은 0 이상이어야 합니다: {target_amount}")
+
+        budget = self._budgets.get(bot_id)
+        current = budget.allocated if budget else 0.0
+        diff = target_amount - current
+
+        if diff == 0:
+            return
+
+        if diff > 0:
+            # 증액
+            if self._unallocated < diff:
+                raise InsufficientFundsError(
+                    f"미할당 잔액 부족: 필요 {diff:,.0f}, 가용 {self._unallocated:,.0f}"
+                )
+            result = await self.allocate(bot_id, diff)
+            if not result:
+                raise InsufficientFundsError(
+                    f"예산 할당 실패: bot_id={bot_id}, amount={diff}"
+                )
+        else:
+            # 감액
+            decrease = abs(diff)
+            result = await self.deallocate(bot_id, decrease)
+            if not result:
+                available = budget.available if budget else 0.0
+                raise InsufficientFundsError(
+                    f"예산 회수 실패: 회수 요청 {decrease:,.0f}, "
+                    f"가용 예산 {available:,.0f}"
+                )
+
+        logger.info(
+            "예산 변경: %s — %s → %s (차이: %s%s)",
+            bot_id,
+            f"{current:,.0f}",
+            f"{target_amount:,.0f}",
+            "+" if diff > 0 else "",
+            f"{diff:,.0f}",
+        )
+
     # ── 주문 자금 예약/해제 ─────────────────────────
 
     async def reserve_for_order(

--- a/tests/unit/test_approval_executors.py
+++ b/tests/unit/test_approval_executors.py
@@ -1,0 +1,279 @@
+"""결재 유형별 executor 등록 및 승인→실행 테스트.
+
+Refs #446: 8건 executor 신규 등록 검증.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.approval.service import ApprovalService
+from ante.core.database import Database
+from ante.eventbus.bus import EventBus
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """테스트용 SQLite DB."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    return db
+
+
+@pytest.fixture
+async def eventbus():
+    return EventBus()
+
+
+def _build_executors() -> tuple[dict, dict]:
+    """mock executor dict와 mock 서비스 객체를 생성.
+
+    Returns:
+        (executors dict, mocks dict) — mocks에서 호출 검증 가능.
+    """
+    report_store = MagicMock()
+    report_store.update_status = AsyncMock()
+
+    bot_manager = MagicMock()
+    bot_manager.create_bot = AsyncMock()
+    bot_manager.assign_strategy = AsyncMock()
+    bot_manager.change_strategy = AsyncMock()
+    bot_manager.stop_bot = AsyncMock()
+    bot_manager.resume_bot = AsyncMock()
+    bot_manager.delete_bot = AsyncMock()
+
+    treasury = MagicMock()
+    treasury.update_budget = AsyncMock()
+
+    rule_engine = MagicMock()
+    rule_engine.update_rules = MagicMock()  # sync
+
+    async def _exec_rule_change(params: dict) -> None:
+        rule_engine.update_rules(params["bot_id"], params["rules"])
+
+    executors = {
+        "strategy_adopt": lambda params: report_store.update_status(
+            params["report_id"], "adopted"
+        ),
+        "strategy_retire": lambda params: report_store.update_status(
+            params["report_id"], "retired"
+        ),
+        "bot_create": lambda params: bot_manager.create_bot(**params),
+        "bot_assign_strategy": lambda params: bot_manager.assign_strategy(
+            params["bot_id"], params["strategy_id"]
+        ),
+        "bot_change_strategy": lambda params: bot_manager.change_strategy(
+            params["bot_id"], params["strategy_id"]
+        ),
+        "bot_stop": lambda params: bot_manager.stop_bot(params["bot_id"]),
+        "bot_resume": lambda params: bot_manager.resume_bot(params["bot_id"]),
+        "bot_delete": lambda params: bot_manager.delete_bot(params["bot_id"]),
+        "budget_change": lambda params: treasury.update_budget(
+            params["bot_id"], params["amount"]
+        ),
+        "rule_change": _exec_rule_change,
+    }
+
+    mocks = {
+        "report_store": report_store,
+        "bot_manager": bot_manager,
+        "treasury": treasury,
+        "rule_engine": rule_engine,
+    }
+    return executors, mocks
+
+
+@pytest.fixture
+async def service_with_executors(db, eventbus):
+    """모든 executor가 등록된 ApprovalService."""
+    executors, mocks = _build_executors()
+    svc = ApprovalService(db=db, eventbus=eventbus, executors=executors)
+    await svc.initialize()
+    return svc, mocks
+
+
+class TestStrategyAdoptExecutor:
+    """strategy_adopt executor 테스트."""
+
+    async def test_approve_calls_update_status_adopted(self, service_with_executors):
+        svc, mocks = service_with_executors
+        req = await svc.create(
+            type="strategy_adopt",
+            requester="agent",
+            title="전략 채택",
+            params={"report_id": "rpt-001", "strategy_name": "momentum"},
+        )
+        await svc.approve(req.id)
+        mocks["report_store"].update_status.assert_awaited_once_with(
+            "rpt-001", "adopted"
+        )
+
+
+class TestStrategyRetireExecutor:
+    """strategy_retire executor 테스트."""
+
+    async def test_approve_calls_update_status_retired(self, service_with_executors):
+        svc, mocks = service_with_executors
+        req = await svc.create(
+            type="strategy_retire",
+            requester="agent",
+            title="전략 폐기",
+            params={"report_id": "rpt-002", "strategy_name": "mean_revert"},
+        )
+        await svc.approve(req.id)
+        mocks["report_store"].update_status.assert_awaited_once_with(
+            "rpt-002", "retired"
+        )
+
+
+class TestBotCreateExecutor:
+    """bot_create executor 테스트."""
+
+    async def test_approve_calls_create_bot(self, service_with_executors):
+        svc, mocks = service_with_executors
+        params = {
+            "strategy_name": "momentum",
+            "budget": 10000000,
+            "mode": "paper",
+        }
+        req = await svc.create(
+            type="bot_create",
+            requester="agent",
+            title="봇 생성",
+            params=params,
+        )
+        await svc.approve(req.id)
+        mocks["bot_manager"].create_bot.assert_awaited_once_with(**params)
+
+
+class TestBotAssignStrategyExecutor:
+    """bot_assign_strategy executor 테스트."""
+
+    async def test_approve_calls_assign_strategy(self, service_with_executors):
+        svc, mocks = service_with_executors
+        req = await svc.create(
+            type="bot_assign_strategy",
+            requester="agent",
+            title="전략 배정",
+            params={"bot_id": "bot-1", "strategy_id": "strat-1"},
+        )
+        await svc.approve(req.id)
+        mocks["bot_manager"].assign_strategy.assert_awaited_once_with(
+            "bot-1", "strat-1"
+        )
+
+
+class TestBotChangeStrategyExecutor:
+    """bot_change_strategy executor 테스트."""
+
+    async def test_approve_calls_change_strategy(self, service_with_executors):
+        svc, mocks = service_with_executors
+        req = await svc.create(
+            type="bot_change_strategy",
+            requester="agent",
+            title="전략 변경",
+            params={"bot_id": "bot-1", "strategy_id": "strat-2"},
+        )
+        await svc.approve(req.id)
+        mocks["bot_manager"].change_strategy.assert_awaited_once_with(
+            "bot-1", "strat-2"
+        )
+
+
+class TestBotStopExecutor:
+    """bot_stop executor 테스트."""
+
+    async def test_approve_calls_stop_bot(self, service_with_executors):
+        svc, mocks = service_with_executors
+        req = await svc.create(
+            type="bot_stop",
+            requester="agent",
+            title="봇 중지",
+            params={"bot_id": "bot-1", "reason": "손실 누적"},
+        )
+        await svc.approve(req.id)
+        mocks["bot_manager"].stop_bot.assert_awaited_once_with("bot-1")
+
+
+class TestBotResumeExecutor:
+    """bot_resume executor 테스트."""
+
+    async def test_approve_calls_resume_bot(self, service_with_executors):
+        svc, mocks = service_with_executors
+        req = await svc.create(
+            type="bot_resume",
+            requester="agent",
+            title="봇 재개",
+            params={"bot_id": "bot-1", "reason": "에러 해소"},
+        )
+        await svc.approve(req.id)
+        mocks["bot_manager"].resume_bot.assert_awaited_once_with("bot-1")
+
+
+class TestBotDeleteExecutor:
+    """bot_delete executor 테스트."""
+
+    async def test_approve_calls_delete_bot(self, service_with_executors):
+        svc, mocks = service_with_executors
+        req = await svc.create(
+            type="bot_delete",
+            requester="agent",
+            title="봇 삭제",
+            params={"bot_id": "bot-1", "reason": "전략 폐기"},
+        )
+        await svc.approve(req.id)
+        mocks["bot_manager"].delete_bot.assert_awaited_once_with("bot-1")
+
+
+class TestBudgetChangeExecutor:
+    """budget_change executor 테스트."""
+
+    async def test_approve_calls_update_budget(self, service_with_executors):
+        svc, mocks = service_with_executors
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="예산 변경",
+            params={"bot_id": "bot-1", "amount": 25000000, "current": 10000000},
+        )
+        await svc.approve(req.id)
+        mocks["treasury"].update_budget.assert_awaited_once_with("bot-1", 25000000)
+
+
+class TestRuleChangeExecutor:
+    """rule_change executor 테스트."""
+
+    async def test_approve_calls_update_rules(self, service_with_executors):
+        svc, mocks = service_with_executors
+        rules = [{"type": "max_position_pct", "value": 0.2}]
+        req = await svc.create(
+            type="rule_change",
+            requester="agent",
+            title="규칙 변경",
+            params={"bot_id": "bot-1", "rules": rules},
+        )
+        await svc.approve(req.id)
+        mocks["rule_engine"].update_rules.assert_called_once_with("bot-1", rules)
+
+
+class TestAllExecutorsRegistered:
+    """모든 결재 유형에 executor가 등록되어 있는지 확인."""
+
+    def test_all_types_have_executor(self):
+        """10개 결재 유형 모두 executor가 등록되어 있다."""
+        executors, _ = _build_executors()
+        expected_types = {
+            "strategy_adopt",
+            "strategy_retire",
+            "bot_create",
+            "bot_assign_strategy",
+            "bot_change_strategy",
+            "bot_stop",
+            "bot_resume",
+            "bot_delete",
+            "budget_change",
+            "rule_change",
+        }
+        assert set(executors.keys()) == expected_types

--- a/tests/unit/test_bot_manager_methods.py
+++ b/tests/unit/test_bot_manager_methods.py
@@ -1,0 +1,276 @@
+"""BotManager 전략 배정/변경/재개 메서드 단위 테스트.
+
+Refs #444
+"""
+
+import asyncio
+
+import pytest
+
+from ante.bot import BotConfig, BotError, BotManager, BotStatus
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.strategy import (
+    DataProvider,
+    OrderView,
+    PortfolioView,
+    Strategy,
+    StrategyContext,
+    StrategyMeta,
+)
+
+# ── Fake 구현체 ──────────────────────────────────
+
+
+class FakeDataProvider(DataProvider):
+    async def get_ohlcv(self, symbol, timeframe="1d", limit=100):
+        return [{"close": 100.0}]
+
+    async def get_current_price(self, symbol):
+        return 100.0
+
+    async def get_indicator(self, symbol, indicator, params=None):
+        return {}
+
+
+class FakePortfolioView(PortfolioView):
+    def get_positions(self, bot_id):
+        return {}
+
+    def get_balance(self, bot_id):
+        return {"total": 1000000.0, "available": 500000.0}
+
+
+class FakeOrderView(OrderView):
+    def get_open_orders(self, bot_id):
+        return []
+
+
+class SimpleStrategy(Strategy):
+    meta = StrategyMeta(name="simple", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+
+
+# ── Fixtures ─────────────────────────────────────
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+def ctx():
+    return StrategyContext(
+        bot_id="bot1",
+        data_provider=FakeDataProvider(),
+        portfolio=FakePortfolioView(),
+        order_view=FakeOrderView(),
+    )
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    try:
+        await asyncio.wait_for(database.close(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+@pytest.fixture
+async def manager(eventbus, db):
+    m = BotManager(eventbus=eventbus, db=db)
+    await m.initialize()
+    yield m
+    for bot in list(m._bots.values()):
+        if bot._task and not bot._task.done():
+            bot._task.cancel()
+    try:
+        await asyncio.wait_for(m.stop_all(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+# ── assign_strategy ──────────────────────────────
+
+
+class TestAssignStrategy:
+    async def test_assign_to_stopped_bot(self, manager, ctx):
+        """중지 상태 봇에 전략 배정."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        await manager.assign_strategy("bot1", "s2")
+
+        bot = manager.get_bot("bot1")
+        assert bot.config.strategy_id == "s2"
+
+    async def test_assign_to_running_bot_restarts(self, manager, ctx):
+        """running 봇에 전략 배정 시 중지 후 재시작."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+        assert manager.get_bot("bot1").status == BotStatus.RUNNING
+
+        await manager.assign_strategy("bot1", "s2")
+
+        bot = manager.get_bot("bot1")
+        assert bot.config.strategy_id == "s2"
+        assert bot.status == BotStatus.RUNNING
+
+    async def test_assign_updates_db(self, manager, ctx, db):
+        """전략 배정 시 DB에 strategy_id가 갱신된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        await manager.assign_strategy("bot1", "s2")
+
+        row = await db.fetch_one("SELECT strategy_id FROM bots WHERE bot_id = 'bot1'")
+        assert row["strategy_id"] == "s2"
+
+    async def test_assign_not_found_raises(self, manager):
+        """존재하지 않는 봇이면 예외."""
+        with pytest.raises(BotError, match="not found"):
+            await manager.assign_strategy("nonexistent", "s1")
+
+    async def test_assign_to_created_bot(self, manager, ctx):
+        """created 상태 봇에 전략 배정."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        assert manager.get_bot("bot1").status == BotStatus.CREATED
+
+        await manager.assign_strategy("bot1", "s2")
+
+        assert manager.get_bot("bot1").config.strategy_id == "s2"
+
+
+# ── change_strategy ──────────────────────────────
+
+
+class TestChangeStrategy:
+    async def test_change_stopped_bot(self, manager, ctx):
+        """중지 상태 봇의 전략 교체."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+        await manager.stop_bot("bot1")
+        assert manager.get_bot("bot1").status == BotStatus.STOPPED
+
+        await manager.change_strategy("bot1", "s2")
+
+        assert manager.get_bot("bot1").config.strategy_id == "s2"
+
+    async def test_change_running_raises(self, manager, ctx):
+        """running 봇 전략 변경 시 예외."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+
+        with pytest.raises(BotError, match="실행 중인 봇"):
+            await manager.change_strategy("bot1", "s2")
+
+    async def test_change_updates_db(self, manager, ctx, db):
+        """전략 교체 시 DB에 strategy_id가 갱신된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        await manager.change_strategy("bot1", "s2")
+
+        row = await db.fetch_one("SELECT strategy_id FROM bots WHERE bot_id = 'bot1'")
+        assert row["strategy_id"] == "s2"
+
+    async def test_change_not_found_raises(self, manager):
+        """존재하지 않는 봇이면 예외."""
+        with pytest.raises(BotError, match="not found"):
+            await manager.change_strategy("nonexistent", "s1")
+
+    async def test_change_created_bot(self, manager, ctx):
+        """created 상태 봇의 전략 교체 가능."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        await manager.change_strategy("bot1", "s2")
+
+        assert manager.get_bot("bot1").config.strategy_id == "s2"
+
+    async def test_change_error_bot(self, manager, ctx):
+        """error 상태 봇의 전략 교체 가능."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        # 수동으로 error 상태 설정
+        manager.get_bot("bot1").status = BotStatus.ERROR
+
+        await manager.change_strategy("bot1", "s2")
+
+        assert manager.get_bot("bot1").config.strategy_id == "s2"
+
+
+# ── resume_bot ───────────────────────────────────
+
+
+class TestResumeBot:
+    async def test_resume_stopped_bot(self, manager, ctx):
+        """stopped 봇 재시작."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+        await manager.stop_bot("bot1")
+        assert manager.get_bot("bot1").status == BotStatus.STOPPED
+
+        await manager.resume_bot("bot1")
+
+        assert manager.get_bot("bot1").status == BotStatus.RUNNING
+
+    async def test_resume_error_bot(self, manager, ctx):
+        """error 봇 재시작."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        # 수동으로 error 상태 설정
+        bot = manager.get_bot("bot1")
+        bot.status = BotStatus.ERROR
+        bot.error_message = "some error"
+
+        await manager.resume_bot("bot1")
+
+        assert bot.status == BotStatus.RUNNING
+        assert bot.error_message is None
+
+    async def test_resume_resets_error_counter(self, manager, ctx):
+        """재개 시 에러 카운터가 리셋된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        bot = manager.get_bot("bot1")
+        bot.status = BotStatus.ERROR
+        manager._restart_counts["bot1"] = 3
+
+        await manager.resume_bot("bot1")
+
+        assert manager.get_restart_count("bot1") == 0
+
+    async def test_resume_running_raises(self, manager, ctx):
+        """running 봇 재개 시 예외."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+
+        with pytest.raises(BotError, match="이미 실행 중"):
+            await manager.resume_bot("bot1")
+
+    async def test_resume_created_raises(self, manager, ctx):
+        """created 상태 봇 재개 시 예외."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        assert manager.get_bot("bot1").status == BotStatus.CREATED
+
+        with pytest.raises(BotError, match="재개할 수 없는 상태"):
+            await manager.resume_bot("bot1")
+
+    async def test_resume_not_found_raises(self, manager):
+        """존재하지 않는 봇 재개 시 예외."""
+        with pytest.raises(BotError, match="not found"):
+            await manager.resume_bot("nonexistent")

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -530,3 +530,185 @@ class TestRuleEngineEventBus:
 
         assert len(received) == 1
         assert "Trading not allowed" in received[0].reason
+
+
+# ── RuleEngine.update_rules ──────────────────────
+
+
+class TestRuleEngineUpdateRules:
+    """RuleEngine.update_rules() 단위 테스트."""
+
+    @pytest.fixture
+    async def db(self, tmp_path):
+        database = Database(str(tmp_path / "test.db"))
+        await database.connect()
+        yield database
+        await database.close()
+
+    @pytest.fixture
+    def eventbus(self):
+        return EventBus()
+
+    @pytest.fixture
+    async def system_state(self, db, eventbus):
+        from ante.config.system_state import SystemState
+
+        state = SystemState(db=db, eventbus=eventbus)
+        await state.initialize()
+        return state
+
+    @pytest.fixture
+    def bot_strategies(self):
+        """bot_id → strategy_id 매핑."""
+        return {"bot1": "momentum_v1", "bot2": "mean_revert_v1"}
+
+    @pytest.fixture
+    def engine(self, eventbus, system_state, bot_strategies):
+        return RuleEngine(
+            eventbus=eventbus,
+            system_state=system_state,
+            bot_strategy_resolver=lambda bid: bot_strategies.get(bid),
+        )
+
+    def test_update_rules_replaces_strategy_rules(self, engine):
+        """update_rules는 해당 전략의 기존 룰을 교체한다."""
+        # 기존 룰 설정
+        engine.add_strategy_rule(
+            "momentum_v1",
+            PositionSizeRule("old_ps", {"max_position_percent": 0.10}),
+        )
+        assert len(engine._strategy_rules["momentum_v1"]) == 1
+
+        # update_rules로 교체
+        new_rules = [
+            {
+                "type": "position_size",
+                "id": "new_ps",
+                "max_position_percent": 0.20,
+                "max_position_amount": 500000.0,
+            },
+            {
+                "type": "trade_frequency",
+                "id": "new_freq",
+                "max_trades_per_hour": 10,
+            },
+        ]
+        engine.update_rules("bot1", new_rules)
+
+        assert len(engine._strategy_rules["momentum_v1"]) == 2
+        rule_ids = [r.rule_id for r in engine._strategy_rules["momentum_v1"]]
+        assert "new_ps" in rule_ids
+        assert "new_freq" in rule_ids
+        assert "old_ps" not in rule_ids
+
+    def test_update_rules_no_resolver_raises(self, eventbus, system_state):
+        """resolver 미설정 시 RuleError."""
+        from ante.rule.exceptions import RuleError
+
+        engine = RuleEngine(eventbus=eventbus, system_state=system_state)
+        with pytest.raises(RuleError, match="bot_strategy_resolver"):
+            engine.update_rules("bot1", [])
+
+    def test_update_rules_unknown_bot_raises(self, engine):
+        """존재하지 않는 봇이면 RuleError."""
+        from ante.rule.exceptions import RuleError
+
+        with pytest.raises(RuleError, match="전략을 찾을 수 없습니다"):
+            engine.update_rules("nonexistent", [])
+
+    def test_update_rules_empty_list(self, engine):
+        """빈 룰 리스트로 갱신하면 기존 룰이 모두 제거된다."""
+        engine.add_strategy_rule(
+            "momentum_v1",
+            PositionSizeRule("ps", {"max_position_percent": 0.10}),
+        )
+        engine.update_rules("bot1", [])
+        assert engine._strategy_rules["momentum_v1"] == []
+
+    def test_update_rules_does_not_affect_other_strategies(self, engine):
+        """다른 전략의 룰에 영향 없음."""
+        engine.add_strategy_rule(
+            "momentum_v1",
+            PositionSizeRule("ps1", {"max_position_percent": 0.10}),
+        )
+        engine.add_strategy_rule(
+            "mean_revert_v1",
+            TradeFrequencyRule("freq1", {"max_trades_per_hour": 5}),
+        )
+
+        engine.update_rules(
+            "bot1",
+            [
+                {
+                    "type": "trade_frequency",
+                    "id": "new_freq",
+                    "max_trades_per_hour": 20,
+                },
+            ],
+        )
+
+        # bot1의 전략(momentum_v1) 룰은 교체됨
+        assert len(engine._strategy_rules["momentum_v1"]) == 1
+        assert engine._strategy_rules["momentum_v1"][0].rule_id == "new_freq"
+
+        # bot2의 전략(mean_revert_v1) 룰은 그대로
+        assert len(engine._strategy_rules["mean_revert_v1"]) == 1
+        assert engine._strategy_rules["mean_revert_v1"][0].rule_id == "freq1"
+
+    def test_set_bot_strategy_resolver(self, eventbus, system_state):
+        """set_bot_strategy_resolver로 resolver를 나중에 설정할 수 있다."""
+        engine = RuleEngine(eventbus=eventbus, system_state=system_state)
+        engine.set_bot_strategy_resolver(lambda bid: "strat_a" if bid == "b1" else None)
+
+        engine.update_rules(
+            "b1",
+            [
+                {"type": "position_size", "id": "ps", "max_position_percent": 0.15},
+            ],
+        )
+        assert "strat_a" in engine._strategy_rules
+        assert len(engine._strategy_rules["strat_a"]) == 1
+
+    def test_update_rules_evaluate_with_new_rules(self, engine):
+        """갱신된 룰이 실제 평가에 반영된다."""
+        # 느슨한 룰
+        engine.update_rules(
+            "bot1",
+            [
+                {
+                    "type": "position_size",
+                    "id": "ps",
+                    "max_position_percent": 1.0,
+                    "max_position_amount": 10_000_000.0,
+                },
+            ],
+        )
+
+        context = RuleContext(
+            bot_id="bot1",
+            strategy_id="momentum_v1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            order_type="market",
+            current_price=50000.0,
+            available_balance=1_000_000.0,
+            system_status="active",
+        )
+        result = engine.evaluate(context)
+        assert result.overall_result == RuleResult.PASS
+
+        # 타이트한 룰로 교체
+        engine.update_rules(
+            "bot1",
+            [
+                {
+                    "type": "position_size",
+                    "id": "ps_tight",
+                    "max_position_percent": 0.01,
+                    "max_position_amount": 10_000.0,
+                },
+            ],
+        )
+        result = engine.evaluate(context)
+        assert result.overall_result == RuleResult.REJECT

--- a/tests/unit/test_treasury.py
+++ b/tests/unit/test_treasury.py
@@ -492,3 +492,91 @@ class TestTreasuryPersistence:
         assert budget is not None
         assert budget.allocated == 2_000_000.0
         assert budget.available == 2_000_000.0
+
+
+# ── update_budget ─────────────────────────────
+
+
+class TestUpdateBudget:
+    """Treasury.update_budget() 단위 테스트."""
+
+    async def test_increase_budget(self, treasury):
+        """기존 봇의 예산 증액."""
+        await treasury.allocate("bot1", 2_000_000.0)
+        await treasury.update_budget("bot1", 5_000_000.0)
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 5_000_000.0
+        assert budget.available == 5_000_000.0
+        assert treasury.unallocated == 5_000_000.0
+
+    async def test_decrease_budget(self, treasury):
+        """기존 봇의 예산 감액."""
+        await treasury.allocate("bot1", 5_000_000.0)
+        await treasury.update_budget("bot1", 3_000_000.0)
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 3_000_000.0
+        assert budget.available == 3_000_000.0
+        assert treasury.unallocated == 7_000_000.0
+
+    async def test_new_bot_budget(self, treasury):
+        """예산이 없는 봇에 최초 할당."""
+        await treasury.update_budget("new_bot", 3_000_000.0)
+
+        budget = treasury.get_budget("new_bot")
+        assert budget is not None
+        assert budget.allocated == 3_000_000.0
+        assert budget.available == 3_000_000.0
+        assert treasury.unallocated == 7_000_000.0
+
+    async def test_same_amount_noop(self, treasury):
+        """동일 금액이면 변경 없음."""
+        await treasury.allocate("bot1", 3_000_000.0)
+        await treasury.update_budget("bot1", 3_000_000.0)
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 3_000_000.0
+
+    async def test_increase_insufficient_funds(self, treasury):
+        """증액 시 미할당 잔액 부족이면 InsufficientFundsError."""
+        from ante.treasury.exceptions import InsufficientFundsError
+
+        await treasury.allocate("bot1", 8_000_000.0)
+        with pytest.raises(InsufficientFundsError, match="미할당 잔액 부족"):
+            await treasury.update_budget("bot1", 15_000_000.0)
+
+        # 원래 상태 유지
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 8_000_000.0
+
+    async def test_decrease_exceeds_available(self, treasury):
+        """감액 시 가용 예산 부족이면 InsufficientFundsError."""
+        from ante.treasury.exceptions import InsufficientFundsError
+
+        await treasury.allocate("bot1", 5_000_000.0)
+        # 자금 예약으로 available을 줄임
+        await treasury.reserve_for_order("bot1", "ord1", 4_000_000.0)
+
+        with pytest.raises(InsufficientFundsError, match="예산 회수 실패"):
+            await treasury.update_budget("bot1", 0.0)
+
+    async def test_negative_target_raises(self, treasury):
+        """목표 금액이 음수면 ValueError."""
+        with pytest.raises(ValueError, match="0 이상"):
+            await treasury.update_budget("bot1", -100.0)
+
+    async def test_set_to_zero(self, treasury):
+        """예산을 0으로 설정."""
+        await treasury.allocate("bot1", 3_000_000.0)
+        await treasury.update_budget("bot1", 0.0)
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 0.0
+        assert budget.available == 0.0
+        assert treasury.unallocated == 10_000_000.0


### PR DESCRIPTION
Refs #447

## 개요

결재 시스템의 executor 전체 등록. 기존 2건(strategy_adopt, bot_stop)에 8건 추가하여 총 10개 결재 유형이 승인 시 자동 실행.

## 하위 이슈 (3개, 모두 완료)

- #444 ✅ BotManager 전략 배정/변경/재개 메서드 구현 (assign_strategy, change_strategy, resume_bot)
- #445 ✅ Treasury.update_budget() 및 RuleEngine.update_rules() 구현
- #446 ✅ 결재 executor 8건 등록 (strategy_retire, budget_change, bot_create/assign/change/delete/resume, rule_change)

## 테스트
- 1895 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)