### PR TITLE
feat: 결재 전결(자동 승인) 구현

### DIFF
--- a/config/system.toml.example
+++ b/config/system.toml.example
@@ -36,3 +36,14 @@ tick_interval = 1.0         # 가격 변동 간격 (초)
 
 [treasury]
 sync_interval_seconds = 300 # 잔고 동기화 주기 (초)
+
+# 결재 전결 (자동 승인) 설정
+# ⚠️ 잘못된 설정은 의도하지 않은 거래·자금 변동으로 이어질 수 있으므로 신중하게 사용
+[approval.auto_approve]
+enabled = false                  # 전결 기능 전체 on/off (기본: false)
+
+# 유형별 전결 규칙 (enabled = true일 때만 적용)
+[approval.auto_approve.rules]
+bot_stop = true                  # 봇 중지는 항상 자동 승인
+bot_create_paper = true          # 모의투자 봇 생성은 자동 승인
+budget_change_max = 5000000      # 예산 변경 500만원 이하 자동 승인 (0이면 비활성)

--- a/src/ante/approval/__init__.py
+++ b/src/ante/approval/__init__.py
@@ -1,5 +1,6 @@
 """Approval — AI Agent 결재 체계."""
 
+from ante.approval.auto_approve import AutoApproveConfig, AutoApproveEvaluator
 from ante.approval.models import ApprovalRequest, ApprovalStatus, ApprovalType
 from ante.approval.service import ApprovalService
 
@@ -8,4 +9,6 @@ __all__ = [
     "ApprovalService",
     "ApprovalStatus",
     "ApprovalType",
+    "AutoApproveConfig",
+    "AutoApproveEvaluator",
 ]

--- a/src/ante/approval/auto_approve.py
+++ b/src/ante/approval/auto_approve.py
@@ -1,0 +1,83 @@
+"""AutoApproveEvaluator — 결재 전결(자동 승인) 규칙 평가기."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+# 전결 대상에서 제외되는 유형
+EXCLUDED_TYPES: frozenset[str] = frozenset({"strategy_adopt", "strategy_retire"})
+
+
+@dataclass(frozen=True)
+class AutoApproveConfig:
+    """전결 설정.
+
+    system.toml의 [approval.auto_approve] 섹션에 대응한다.
+    """
+
+    enabled: bool = False
+    bot_stop: bool = True
+    bot_create_paper: bool = True
+    budget_change_max: float = 5_000_000
+
+    @classmethod
+    def from_dict(cls, data: dict) -> AutoApproveConfig:
+        """dict에서 AutoApproveConfig 생성.
+
+        Config.get("approval.auto_approve", {}) 결과를 받는다.
+        """
+        rules = data.get("rules", {})
+        return cls(
+            enabled=bool(data.get("enabled", False)),
+            bot_stop=bool(rules.get("bot_stop", True)),
+            bot_create_paper=bool(rules.get("bot_create_paper", True)),
+            budget_change_max=float(rules.get("budget_change_max", 5_000_000)),
+        )
+
+
+@dataclass
+class AutoApproveEvaluator:
+    """결재 전결 규칙 평가기.
+
+    ApprovalService.create() 호출 시, 요청 유형과 파라미터를 기반으로
+    자동 승인 여부를 판단한다.
+    """
+
+    config: AutoApproveConfig = field(default_factory=AutoApproveConfig)
+
+    def should_auto_approve(self, type: str, params: dict | None = None) -> bool:
+        """전결 조건 평가.
+
+        Args:
+            type: 결재 요청 유형 (예: "bot_stop", "budget_change")
+            params: 유형별 실행 파라미터
+
+        Returns:
+            True이면 자동 승인 대상.
+        """
+        if not self.config.enabled:
+            return False
+
+        if type in EXCLUDED_TYPES:
+            return False
+
+        params = params or {}
+
+        if type == "bot_stop" and self.config.bot_stop:
+            return True
+
+        if type == "bot_create" and self.config.bot_create_paper:
+            if params.get("mode") == "paper":
+                return True
+
+        if type == "budget_change" and self.config.budget_change_max > 0:
+            amount = params.get("amount", 0)
+            current = params.get("current", 0)
+            change = abs(float(amount) - float(current))
+            if change <= self.config.budget_change_max:
+                return True
+
+        return False

--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
+from ante.approval.auto_approve import AutoApproveEvaluator
 from ante.approval.models import ApprovalRequest, ApprovalStatus
 
 if TYPE_CHECKING:
@@ -49,10 +50,12 @@ class ApprovalService:
         db: Database,
         eventbus: EventBus,
         executors: dict[str, Callable[..., Awaitable]] | None = None,
+        auto_approve_evaluator: AutoApproveEvaluator | None = None,
     ) -> None:
         self._db = db
         self._eventbus = eventbus
         self._executors = executors or {}
+        self._auto_approve = auto_approve_evaluator or AutoApproveEvaluator()
 
     async def initialize(self) -> None:
         """스키마 생성."""
@@ -98,11 +101,30 @@ class ApprovalService:
             created_at=now,
         )
 
+        # 전결 평가
+        auto_approved = self._auto_approve.should_auto_approve(type, params)
+
+        if auto_approved:
+            # 즉시 승인 처리: status를 APPROVED로 설정
+            request.status = ApprovalStatus.APPROVED
+            request.resolved_at = now
+            request.resolved_by = "system:auto_approve"
+            request.history.append(
+                {
+                    "action": "approved",
+                    "actor": "system:auto_approve",
+                    "at": now,
+                    "detail": "전결 규칙에 의한 자동 승인",
+                }
+            )
+
+        # DB INSERT (auto_approved이면 approved 상태로 저장)
         await self._db.execute(
             """INSERT INTO approvals
                (id, type, status, requester, title, body, params,
-                reviews, history, reference_id, expires_at, created_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                reviews, history, reference_id, expires_at, created_at,
+                resolved_at, resolved_by)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 request.id,
                 request.type,
@@ -116,14 +138,17 @@ class ApprovalService:
                 request.reference_id,
                 request.expires_at,
                 request.created_at,
+                request.resolved_at,
+                request.resolved_by,
             ),
         )
 
         logger.info(
-            "결재 요청 생성: %s (%s) by %s",
+            "결재 요청 생성: %s (%s) by %s%s",
             request.id,
             request.type,
             request.requester,
+            " [자동 승인]" if auto_approved else "",
         )
 
         # ApprovalCreatedEvent 발행
@@ -135,8 +160,33 @@ class ApprovalService:
                 approval_type=request.type,
                 requester=request.requester,
                 title=request.title,
+                auto_approved=auto_approved,
             )
         )
+
+        # 전결 시 executor 즉시 실행
+        if auto_approved:
+            executor = self._executors.get(request.type)
+            if executor:
+                try:
+                    await executor(request.params)
+                    logger.info("전결 실행 완료: %s (%s)", request.id, request.type)
+                except Exception:
+                    logger.exception(
+                        "전결 실행 실패: %s (%s)", request.id, request.type
+                    )
+
+            # ApprovalResolvedEvent 발행
+            from ante.eventbus.events import ApprovalResolvedEvent
+
+            await self._eventbus.publish(
+                ApprovalResolvedEvent(
+                    approval_id=request.id,
+                    approval_type=request.type,
+                    resolution=ApprovalStatus.APPROVED,
+                    resolved_by="system:auto_approve",
+                )
+            )
 
         return request
 

--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -365,6 +365,7 @@ class ApprovalCreatedEvent(Event):
     approval_type: str = ""
     requester: str = ""
     title: str = ""
+    auto_approved: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -414,6 +414,7 @@ async def _init_feed(s: Services) -> None:
 
     # ApprovalService
     from ante.approval import ApprovalService
+    from ante.approval.auto_approve import AutoApproveConfig, AutoApproveEvaluator
 
     async def _exec_rule_change(params: dict) -> None:
         s.rule_engine.update_rules(params["bot_id"], params["rules"])
@@ -443,8 +444,21 @@ async def _init_feed(s: Services) -> None:
         ),
         "rule_change": _exec_rule_change,
     }
+
+    # 전결 설정 로딩
+    auto_approve_raw = s.config.get("approval.auto_approve", {})
+    auto_approve_config = AutoApproveConfig.from_dict(
+        auto_approve_raw if isinstance(auto_approve_raw, dict) else {}
+    )
+    auto_approve_evaluator = AutoApproveEvaluator(config=auto_approve_config)
+    if auto_approve_config.enabled:
+        logger.info("전결 기능 활성화")
+
     s.approval_service = ApprovalService(
-        db=s.db, eventbus=s.eventbus, executors=approval_executors
+        db=s.db,
+        eventbus=s.eventbus,
+        executors=approval_executors,
+        auto_approve_evaluator=auto_approve_evaluator,
     )
     await s.approval_service.initialize()
     logger.info("ApprovalService 초기화 완료")

--- a/tests/unit/test_auto_approve.py
+++ b/tests/unit/test_auto_approve.py
@@ -1,0 +1,433 @@
+"""AutoApproveEvaluator 및 전결 연동 단위 테스트."""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.approval.auto_approve import (
+    EXCLUDED_TYPES,
+    AutoApproveConfig,
+    AutoApproveEvaluator,
+)
+from ante.approval.models import ApprovalStatus
+from ante.approval.service import ApprovalService
+from ante.core.database import Database
+from ante.eventbus.bus import EventBus
+from ante.eventbus.events import ApprovalCreatedEvent, ApprovalResolvedEvent
+
+# ── Fixtures ─────────────────────────────────────────
+
+
+@pytest.fixture
+def enabled_config() -> AutoApproveConfig:
+    """전결 활성화 설정."""
+    return AutoApproveConfig(
+        enabled=True,
+        bot_stop=True,
+        bot_create_paper=True,
+        budget_change_max=5_000_000,
+    )
+
+
+@pytest.fixture
+def disabled_config() -> AutoApproveConfig:
+    """전결 비활성화 설정."""
+    return AutoApproveConfig(enabled=False)
+
+
+@pytest.fixture
+def evaluator(enabled_config: AutoApproveConfig) -> AutoApproveEvaluator:
+    return AutoApproveEvaluator(config=enabled_config)
+
+
+@pytest.fixture
+def disabled_evaluator(disabled_config: AutoApproveConfig) -> AutoApproveEvaluator:
+    return AutoApproveEvaluator(config=disabled_config)
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """테스트용 SQLite DB."""
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    return database
+
+
+@pytest.fixture
+async def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+async def service_with_auto_approve(db, eventbus, enabled_config):
+    """전결 활성화된 ApprovalService."""
+    executed = []
+
+    async def mock_executor(params: dict) -> None:
+        executed.append(params)
+
+    evaluator = AutoApproveEvaluator(config=enabled_config)
+    svc = ApprovalService(
+        db=db,
+        eventbus=eventbus,
+        executors={"bot_stop": mock_executor, "bot_create": mock_executor},
+        auto_approve_evaluator=evaluator,
+    )
+    await svc.initialize()
+    return svc, executed
+
+
+@pytest.fixture
+async def service_without_auto_approve(db, eventbus):
+    """전결 비활성화된 ApprovalService (기본)."""
+    svc = ApprovalService(db=db, eventbus=eventbus)
+    await svc.initialize()
+    return svc
+
+
+# ── AutoApproveConfig ────────────────────────────────
+
+
+class TestAutoApproveConfig:
+    def test_default_config(self):
+        """기본 설정: 비활성화."""
+        config = AutoApproveConfig()
+        assert config.enabled is False
+        assert config.bot_stop is True
+        assert config.bot_create_paper is True
+        assert config.budget_change_max == 5_000_000
+
+    def test_from_dict(self):
+        """dict에서 설정 생성."""
+        data = {
+            "enabled": True,
+            "rules": {
+                "bot_stop": True,
+                "bot_create_paper": False,
+                "budget_change_max": 3000000,
+            },
+        }
+        config = AutoApproveConfig.from_dict(data)
+        assert config.enabled is True
+        assert config.bot_stop is True
+        assert config.bot_create_paper is False
+        assert config.budget_change_max == 3_000_000
+
+    def test_from_dict_empty(self):
+        """빈 dict에서 기본값 적용."""
+        config = AutoApproveConfig.from_dict({})
+        assert config.enabled is False
+        assert config.bot_stop is True
+
+    def test_from_dict_missing_rules(self):
+        """rules 키 없이 enabled만 있는 경우."""
+        config = AutoApproveConfig.from_dict({"enabled": True})
+        assert config.enabled is True
+        assert config.bot_stop is True
+        assert config.budget_change_max == 5_000_000
+
+
+# ── AutoApproveEvaluator ─────────────────────────────
+
+
+class TestAutoApproveEvaluator:
+    def test_disabled_returns_false(self, disabled_evaluator):
+        """비활성화 시 항상 False."""
+        assert disabled_evaluator.should_auto_approve("bot_stop") is False
+        assert disabled_evaluator.should_auto_approve("budget_change") is False
+
+    def test_bot_stop_auto_approved(self, evaluator):
+        """bot_stop은 자동 승인."""
+        assert evaluator.should_auto_approve("bot_stop", {"bot_id": "bot-1"}) is True
+
+    def test_bot_create_paper_auto_approved(self, evaluator):
+        """모의투자 봇 생성은 자동 승인."""
+        assert (
+            evaluator.should_auto_approve(
+                "bot_create", {"mode": "paper", "strategy_name": "test"}
+            )
+            is True
+        )
+
+    def test_bot_create_live_not_auto_approved(self, evaluator):
+        """실전투자 봇 생성은 자동 승인 안 됨."""
+        assert (
+            evaluator.should_auto_approve(
+                "bot_create", {"mode": "live", "strategy_name": "test"}
+            )
+            is False
+        )
+
+    def test_bot_create_no_mode_not_auto_approved(self, evaluator):
+        """mode 없는 봇 생성은 자동 승인 안 됨."""
+        assert (
+            evaluator.should_auto_approve("bot_create", {"strategy_name": "test"})
+            is False
+        )
+
+    def test_budget_change_within_limit(self, evaluator):
+        """예산 변경이 한도 이내이면 자동 승인."""
+        assert (
+            evaluator.should_auto_approve(
+                "budget_change",
+                {"bot_id": "bot-1", "amount": 15000000, "current": 10000000},
+            )
+            is True
+        )
+
+    def test_budget_change_at_limit(self, evaluator):
+        """예산 변경이 정확히 한도이면 자동 승인."""
+        assert (
+            evaluator.should_auto_approve(
+                "budget_change",
+                {"bot_id": "bot-1", "amount": 15000000, "current": 10000000},
+            )
+            is True
+        )
+
+    def test_budget_change_over_limit(self, evaluator):
+        """예산 변경이 한도 초과이면 자동 승인 안 됨."""
+        assert (
+            evaluator.should_auto_approve(
+                "budget_change",
+                {"bot_id": "bot-1", "amount": 20000000, "current": 10000000},
+            )
+            is False
+        )
+
+    def test_budget_change_decrease_within_limit(self, evaluator):
+        """예산 감액도 변경액 기준으로 평가."""
+        assert (
+            evaluator.should_auto_approve(
+                "budget_change",
+                {"bot_id": "bot-1", "amount": 7000000, "current": 10000000},
+            )
+            is True
+        )
+
+    def test_strategy_adopt_excluded(self, evaluator):
+        """strategy_adopt는 전결 대상에서 제외."""
+        assert (
+            evaluator.should_auto_approve(
+                "strategy_adopt", {"strategy_name": "test", "report_id": "r1"}
+            )
+            is False
+        )
+
+    def test_strategy_retire_excluded(self, evaluator):
+        """strategy_retire는 전결 대상에서 제외."""
+        assert (
+            evaluator.should_auto_approve(
+                "strategy_retire", {"strategy_name": "test", "report_id": "r1"}
+            )
+            is False
+        )
+
+    def test_excluded_types_constant(self):
+        """제외 유형 상수 확인."""
+        assert "strategy_adopt" in EXCLUDED_TYPES
+        assert "strategy_retire" in EXCLUDED_TYPES
+
+    def test_unknown_type_not_auto_approved(self, evaluator):
+        """알 수 없는 유형은 자동 승인 안 됨."""
+        assert evaluator.should_auto_approve("unknown_type") is False
+
+    def test_rule_change_not_auto_approved(self, evaluator):
+        """rule_change는 전결 규칙에 없으므로 자동 승인 안 됨."""
+        assert (
+            evaluator.should_auto_approve("rule_change", {"bot_id": "bot-1"}) is False
+        )
+
+    def test_bot_stop_disabled_in_config(self):
+        """bot_stop 규칙이 비활성화된 경우."""
+        config = AutoApproveConfig(enabled=True, bot_stop=False)
+        ev = AutoApproveEvaluator(config=config)
+        assert ev.should_auto_approve("bot_stop", {"bot_id": "bot-1"}) is False
+
+    def test_budget_change_max_zero_disables(self):
+        """budget_change_max가 0이면 예산 변경 전결 비활성화."""
+        config = AutoApproveConfig(enabled=True, budget_change_max=0)
+        ev = AutoApproveEvaluator(config=config)
+        assert (
+            ev.should_auto_approve(
+                "budget_change",
+                {"bot_id": "bot-1", "amount": 10000000, "current": 10000000},
+            )
+            is False
+        )
+
+
+# ── ApprovalService 전결 연동 ─────────────────────────
+
+
+class TestServiceAutoApprove:
+    async def test_auto_approve_creates_approved_request(
+        self, service_with_auto_approve
+    ):
+        """전결 조건 충족 시 approved 상태로 생성."""
+        svc, _executed = service_with_auto_approve
+        req = await svc.create(
+            type="bot_stop",
+            requester="agent:dev",
+            title="봇 중지 요청",
+            params={"bot_id": "bot-1"},
+        )
+
+        assert req.status == ApprovalStatus.APPROVED
+        assert req.resolved_by == "system:auto_approve"
+        assert req.resolved_at != ""
+        # history: created + approved
+        assert len(req.history) == 2
+        assert req.history[0]["action"] == "created"
+        assert req.history[1]["action"] == "approved"
+        assert req.history[1]["actor"] == "system:auto_approve"
+
+    async def test_auto_approve_executes_handler(self, service_with_auto_approve):
+        """전결 시 executor가 실행된다."""
+        svc, executed = service_with_auto_approve
+        await svc.create(
+            type="bot_stop",
+            requester="agent:dev",
+            title="봇 중지 요청",
+            params={"bot_id": "bot-1"},
+        )
+
+        assert len(executed) == 1
+        assert executed[0]["bot_id"] == "bot-1"
+
+    async def test_auto_approve_publishes_created_event_with_flag(
+        self, service_with_auto_approve, eventbus
+    ):
+        """전결 시 ApprovalCreatedEvent에 auto_approved=True."""
+        svc, _executed = service_with_auto_approve
+        received = []
+
+        async def handler(event: object) -> None:
+            if isinstance(event, ApprovalCreatedEvent):
+                received.append(event)
+
+        eventbus.subscribe(ApprovalCreatedEvent, handler)
+
+        await svc.create(
+            type="bot_stop",
+            requester="agent:dev",
+            title="봇 중지 요청",
+            params={"bot_id": "bot-1"},
+        )
+
+        assert len(received) == 1
+        assert received[0].auto_approved is True
+
+    async def test_auto_approve_publishes_resolved_event(
+        self, service_with_auto_approve, eventbus
+    ):
+        """전결 시 ApprovalResolvedEvent도 발행된다."""
+        svc, _executed = service_with_auto_approve
+        received = []
+
+        async def handler(event: object) -> None:
+            if isinstance(event, ApprovalResolvedEvent):
+                received.append(event)
+
+        eventbus.subscribe(ApprovalResolvedEvent, handler)
+
+        await svc.create(
+            type="bot_stop",
+            requester="agent:dev",
+            title="봇 중지 요청",
+            params={"bot_id": "bot-1"},
+        )
+
+        assert len(received) == 1
+        assert received[0].resolution == "approved"
+        assert received[0].resolved_by == "system:auto_approve"
+
+    async def test_non_matching_request_stays_pending(self, service_with_auto_approve):
+        """전결 조건 미충족 시 pending 상태 유지."""
+        svc, executed = service_with_auto_approve
+        req = await svc.create(
+            type="budget_change",
+            requester="agent:dev",
+            title="예산 대폭 증액",
+            params={"bot_id": "bot-1", "amount": 100000000, "current": 10000000},
+        )
+
+        assert req.status == ApprovalStatus.PENDING
+        assert req.resolved_by == ""
+        assert len(executed) == 0
+
+    async def test_disabled_auto_approve_stays_pending(
+        self, service_without_auto_approve
+    ):
+        """전결 비활성화 시 항상 pending."""
+        svc = service_without_auto_approve
+        req = await svc.create(
+            type="bot_stop",
+            requester="agent:dev",
+            title="봇 중지 요청",
+            params={"bot_id": "bot-1"},
+        )
+
+        assert req.status == ApprovalStatus.PENDING
+
+    async def test_auto_approve_persisted_in_db(self, service_with_auto_approve):
+        """전결 결과가 DB에 영속화."""
+        svc, _executed = service_with_auto_approve
+        req = await svc.create(
+            type="bot_stop",
+            requester="agent:dev",
+            title="봇 중지 요청",
+            params={"bot_id": "bot-1"},
+        )
+
+        fetched = await svc.get(req.id)
+        assert fetched is not None
+        assert fetched.status == "approved"
+        assert fetched.resolved_by == "system:auto_approve"
+        assert len(fetched.history) == 2
+
+    async def test_created_event_auto_approved_false_for_normal(
+        self, service_without_auto_approve, eventbus
+    ):
+        """일반 요청의 ApprovalCreatedEvent에 auto_approved=False."""
+        svc = service_without_auto_approve
+        received = []
+
+        async def handler(event: object) -> None:
+            if isinstance(event, ApprovalCreatedEvent):
+                received.append(event)
+
+        eventbus.subscribe(ApprovalCreatedEvent, handler)
+
+        await svc.create(
+            type="bot_stop",
+            requester="agent:dev",
+            title="봇 중지 요청",
+        )
+
+        assert len(received) == 1
+        assert received[0].auto_approved is False
+
+    async def test_strategy_adopt_never_auto_approved(self, service_with_auto_approve):
+        """strategy_adopt는 전결 활성화되어도 자동 승인 안 됨."""
+        svc, _executed = service_with_auto_approve
+        req = await svc.create(
+            type="strategy_adopt",
+            requester="agent:dev",
+            title="전략 채택 요청",
+            params={"strategy_name": "test", "report_id": "r1"},
+        )
+
+        assert req.status == ApprovalStatus.PENDING
+
+    async def test_strategy_retire_never_auto_approved(self, service_with_auto_approve):
+        """strategy_retire는 전결 활성화되어도 자동 승인 안 됨."""
+        svc, _executed = service_with_auto_approve
+        req = await svc.create(
+            type="strategy_retire",
+            requester="agent:dev",
+            title="전략 폐기 요청",
+            params={"strategy_name": "test", "report_id": "r1"},
+        )
+
+        assert req.status == ApprovalStatus.PENDING


### PR DESCRIPTION
## Summary
- `AutoApproveEvaluator` 클래스 신규 구현: 전결 규칙 평가기 (`bot_stop`, `bot_create_paper`, `budget_change_max`)
- `ApprovalService.create()`에 전결 분기 추가: 조건 충족 시 즉시 approve + executor 실행
- `ApprovalCreatedEvent`에 `auto_approved` 플래그 추가, 감사 이력에 `system:auto_approve` 액터 기록
- `strategy_adopt`, `strategy_retire`는 전결 대상에서 제외
- `config/system.toml.example`에 `[approval.auto_approve]` 섹션 추가
- `main.py`에서 config 로딩 및 evaluator 주입

## Test plan
- [x] AutoApproveConfig 기본값 및 from_dict 변환 테스트
- [x] AutoApproveEvaluator 유형별 규칙 평가 테스트 (bot_stop, bot_create_paper, budget_change)
- [x] strategy_adopt, strategy_retire 전결 제외 테스트
- [x] ApprovalService 전결 분기: approved 상태 생성, executor 실행, 이벤트 발행
- [x] 전결 비활성화 시 pending 유지 테스트
- [x] DB 영속화 확인
- [x] 전체 테스트 스위트 1925건 통과

Refs #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)