### PR TITLE
feat(approval): 결재 사전 검증(validator) 구현

### DIFF
--- a/src/ante/approval/__init__.py
+++ b/src/ante/approval/__init__.py
@@ -1,7 +1,13 @@
 """Approval — AI Agent 결재 체계."""
 
 from ante.approval.auto_approve import AutoApproveConfig, AutoApproveEvaluator
-from ante.approval.models import ApprovalRequest, ApprovalStatus, ApprovalType
+from ante.approval.models import (
+    ApprovalRequest,
+    ApprovalStatus,
+    ApprovalType,
+    ApprovalValidationError,
+    ValidationResult,
+)
 from ante.approval.service import ApprovalService
 
 __all__ = [
@@ -9,6 +15,8 @@ __all__ = [
     "ApprovalService",
     "ApprovalStatus",
     "ApprovalType",
+    "ApprovalValidationError",
     "AutoApproveConfig",
     "AutoApproveEvaluator",
+    "ValidationResult",
 ]

--- a/src/ante/approval/models.py
+++ b/src/ante/approval/models.py
@@ -21,9 +21,14 @@ class ApprovalType(StrEnum):
     """결재 유형."""
 
     STRATEGY_ADOPT = "strategy_adopt"
-    BUDGET_CHANGE = "budget_change"
+    STRATEGY_RETIRE = "strategy_retire"
     BOT_CREATE = "bot_create"
+    BOT_ASSIGN_STRATEGY = "bot_assign_strategy"
+    BOT_CHANGE_STRATEGY = "bot_change_strategy"
     BOT_STOP = "bot_stop"
+    BOT_RESUME = "bot_resume"
+    BOT_DELETE = "bot_delete"
+    BUDGET_CHANGE = "budget_change"
     RULE_CHANGE = "rule_change"
 
 
@@ -46,3 +51,26 @@ class ApprovalRequest:
     resolved_at: str = ""
     resolved_by: str = ""
     reject_reason: str = ""
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """사전 검증 결과.
+
+    grade:
+        - "fail": 논리적으로 실행 불가능 — 요청 생성 차단
+        - "warn": 판단 여지 있음 — 경고를 reviews에 첨부
+        - "pass": 검증 통과
+    """
+
+    grade: str
+    detail: str
+    reviewer: str
+
+
+class ApprovalValidationError(Exception):
+    """사전 검증 실패 — 요청 생성 차단."""
+
+    def __init__(self, detail: str) -> None:
+        self.detail = detail
+        super().__init__(detail)

--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -9,7 +9,12 @@ from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from ante.approval.auto_approve import AutoApproveEvaluator
-from ante.approval.models import ApprovalRequest, ApprovalStatus
+from ante.approval.models import (
+    ApprovalRequest,
+    ApprovalStatus,
+    ApprovalValidationError,
+    ValidationResult,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -50,11 +55,13 @@ class ApprovalService:
         db: Database,
         eventbus: EventBus,
         executors: dict[str, Callable[..., Awaitable]] | None = None,
+        validators: dict[str, Callable[..., list[ValidationResult]]] | None = None,
         auto_approve_evaluator: AutoApproveEvaluator | None = None,
     ) -> None:
         self._db = db
         self._eventbus = eventbus
         self._executors = executors or {}
+        self._validators = validators or {}
         self._auto_approve = auto_approve_evaluator or AutoApproveEvaluator()
 
     async def initialize(self) -> None:
@@ -77,6 +84,30 @@ class ApprovalService:
         now = datetime.now(UTC).isoformat()
         params = params or {}
 
+        # 사전 검증 (validator)
+        reviews: list[dict] = []
+        validator = self._validators.get(type)
+        if validator:
+            results = validator(params)
+            for r in results:
+                if r.grade == "fail":
+                    logger.info(
+                        "사전 검증 실패 (%s): %s — %s",
+                        type,
+                        r.reviewer,
+                        r.detail,
+                    )
+                    raise ApprovalValidationError(r.detail)
+                if r.grade == "warn":
+                    reviews.append(
+                        {
+                            "reviewer": r.reviewer,
+                            "result": "warn",
+                            "detail": r.detail,
+                            "reviewed_at": now,
+                        }
+                    )
+
         history = [
             {
                 "action": "created",
@@ -94,7 +125,7 @@ class ApprovalService:
             title=title,
             body=body,
             params=params,
-            reviews=[],
+            reviews=reviews,
             history=history,
             reference_id=reference_id,
             expires_at=expires_at,

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -415,6 +415,7 @@ async def _init_feed(s: Services) -> None:
     # ApprovalService
     from ante.approval import ApprovalService
     from ante.approval.auto_approve import AutoApproveConfig, AutoApproveEvaluator
+    from ante.approval.models import ValidationResult
 
     async def _exec_rule_change(params: dict) -> None:
         s.rule_engine.update_rules(params["bot_id"], params["rules"])
@@ -445,6 +446,139 @@ async def _init_feed(s: Services) -> None:
         "rule_change": _exec_rule_change,
     }
 
+    # 사전 검증 validator 정의
+    from ante.bot.config import BotStatus
+
+    def _validate_strategy_retire(params: dict) -> list[ValidationResult]:
+        """전략 폐기 사전 검증: 사용 중인 봇 존재 여부."""
+        strategy_id = params.get("strategy_id", "")
+        bots = [
+            b for b in s.bot_manager.list_bots() if b.get("strategy_id") == strategy_id
+        ]
+        if bots:
+            return [
+                ValidationResult(
+                    "fail",
+                    f"전략을 사용 중인 봇 {len(bots)}개 존재",
+                    "system:bot_manager",
+                )
+            ]
+        return [ValidationResult("pass", "", "system:bot_manager")]
+
+    def _validate_bot_create(params: dict) -> list[ValidationResult]:
+        """봇 생성 사전 검증: 전략 adopted 상태, 동일 봇 미존재."""
+        results: list[ValidationResult] = []
+        bot_id = params.get("bot_id", "")
+        if bot_id and s.bot_manager.get_bot(bot_id):
+            results.append(
+                ValidationResult(
+                    "fail",
+                    f"동일 ID의 봇이 이미 존재: {bot_id}",
+                    "system:bot_manager",
+                )
+            )
+        strategy_id = params.get("strategy_id", "")
+        if strategy_id:
+            # strategy_id로 리포트 확인은 비동기 — 동기 호출 불가이므로
+            # 이 검증은 executor 2단계 검증에 위임
+            pass
+        return results or [ValidationResult("pass", "", "system:bot_manager")]
+
+    def _validate_bot_delete(params: dict) -> list[ValidationResult]:
+        """봇 삭제 사전 검증: stopped 상태, 보유 포지션 없음."""
+        results: list[ValidationResult] = []
+        bot_id = params.get("bot_id", "")
+        bot = s.bot_manager.get_bot(bot_id)
+        if not bot:
+            return [
+                ValidationResult("fail", "봇이 존재하지 않음", "system:bot_manager")
+            ]
+        if bot.status != BotStatus.STOPPED:
+            results.append(
+                ValidationResult(
+                    "fail",
+                    f"봇이 {bot.status} 상태 (stopped 필요)",
+                    "system:bot_manager",
+                )
+            )
+        positions = s.position_history.get_positions_sync(bot_id)
+        if positions:
+            results.append(
+                ValidationResult(
+                    "fail",
+                    f"보유 포지션 {len(positions)}건 존재",
+                    "system:trade",
+                )
+            )
+        return results or [ValidationResult("pass", "", "system:bot_manager")]
+
+    def _validate_bot_change_strategy(params: dict) -> list[ValidationResult]:
+        """봇 전략 변경 사전 검증: stopped 상태 확인."""
+        bot_id = params.get("bot_id", "")
+        bot = s.bot_manager.get_bot(bot_id)
+        if not bot:
+            return [
+                ValidationResult("fail", "봇이 존재하지 않음", "system:bot_manager")
+            ]
+        if bot.status != BotStatus.STOPPED:
+            return [
+                ValidationResult(
+                    "fail",
+                    f"봇이 {bot.status} 상태 (stopped 필요)",
+                    "system:bot_manager",
+                )
+            ]
+        return [ValidationResult("pass", "", "system:bot_manager")]
+
+    def _validate_bot_assign_strategy(params: dict) -> list[ValidationResult]:
+        """봇 전략 배정 사전 검증: 전략 adopted 상태 확인."""
+        # 전략 상태 확인은 비동기 조회가 필요하므로 executor 2단계에 위임
+        return [ValidationResult("pass", "", "system:report_store")]
+
+    def _validate_bot_resume(params: dict) -> list[ValidationResult]:
+        """봇 재개 사전 검증: stopped/error 상태 확인."""
+        bot_id = params.get("bot_id", "")
+        bot = s.bot_manager.get_bot(bot_id)
+        if not bot:
+            return [
+                ValidationResult("fail", "봇이 존재하지 않음", "system:bot_manager")
+            ]
+        if bot.status not in (BotStatus.STOPPED, BotStatus.ERROR):
+            return [
+                ValidationResult(
+                    "fail",
+                    f"봇이 {bot.status} 상태 (stopped/error 필요)",
+                    "system:bot_manager",
+                )
+            ]
+        return [ValidationResult("pass", "", "system:bot_manager")]
+
+    def _validate_budget_change(params: dict) -> list[ValidationResult]:
+        """예산 변경 사전 검증: 미할당 잔액 충분 여부 (warn)."""
+        amount = float(params.get("amount", 0))
+        current = float(params.get("current", 0))
+        amount_diff = amount - current
+        if amount_diff > 0 and amount_diff > s.treasury.unallocated:
+            return [
+                ValidationResult(
+                    "warn",
+                    f"미할당 잔액({s.treasury.unallocated:,.0f}원) "
+                    f"< 증액분({amount_diff:,.0f}원)",
+                    "system:treasury",
+                )
+            ]
+        return [ValidationResult("pass", "", "system:treasury")]
+
+    approval_validators: dict = {
+        "strategy_retire": _validate_strategy_retire,
+        "bot_create": _validate_bot_create,
+        "bot_delete": _validate_bot_delete,
+        "bot_change_strategy": _validate_bot_change_strategy,
+        "bot_assign_strategy": _validate_bot_assign_strategy,
+        "bot_resume": _validate_bot_resume,
+        "budget_change": _validate_budget_change,
+    }
+
     # 전결 설정 로딩
     auto_approve_raw = s.config.get("approval.auto_approve", {})
     auto_approve_config = AutoApproveConfig.from_dict(
@@ -458,6 +592,7 @@ async def _init_feed(s: Services) -> None:
         db=s.db,
         eventbus=s.eventbus,
         executors=approval_executors,
+        validators=approval_validators,
         auto_approve_evaluator=auto_approve_evaluator,
     )
     await s.approval_service.initialize()

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -6,7 +6,13 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from ante.approval.models import ApprovalRequest, ApprovalStatus, ApprovalType
+from ante.approval.models import (
+    ApprovalRequest,
+    ApprovalStatus,
+    ApprovalType,
+    ApprovalValidationError,
+    ValidationResult,
+)
 from ante.approval.service import ApprovalService
 from ante.core.database import Database
 from ante.eventbus.bus import EventBus
@@ -547,3 +553,197 @@ class TestEvents:
         )
         assert event.resolution == "approved"
         assert event.event_id is not None
+
+
+# ── 사전 검증 Validator (US-8) ────────────────────────
+
+
+class TestValidator:
+    """사전 검증(validator) 단위 테스트."""
+
+    async def test_fail_blocks_creation(self, db, eventbus):
+        """fail 등급 검증 결과 시 요청 생성이 차단된다."""
+
+        def fail_validator(params: dict) -> list[ValidationResult]:
+            return [ValidationResult("fail", "봇이 running 상태", "system:bot_manager")]
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            validators={"bot_delete": fail_validator},
+        )
+        await svc.initialize()
+
+        with pytest.raises(ApprovalValidationError, match="봇이 running 상태"):
+            await svc.create(
+                type="bot_delete",
+                requester="agent",
+                title="봇 삭제 요청",
+                params={"bot_id": "bot-1"},
+            )
+
+        # DB에 요청이 생성되지 않았는지 확인
+        all_requests = await svc.list()
+        assert len(all_requests) == 0
+
+    async def test_warn_attaches_review(self, db, eventbus):
+        """warn 등급 검증 결과 시 요청은 생성되고 reviews에 경고가 첨부된다."""
+
+        def warn_validator(params: dict) -> list[ValidationResult]:
+            return [
+                ValidationResult(
+                    "warn",
+                    "미할당 잔액 부족",
+                    "system:treasury",
+                )
+            ]
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            validators={"budget_change": warn_validator},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="예산 증액",
+            params={"bot_id": "bot-1", "amount": 50000000, "current": 10000000},
+        )
+
+        assert req.status == "pending"
+        assert len(req.reviews) == 1
+        assert req.reviews[0]["result"] == "warn"
+        assert req.reviews[0]["reviewer"] == "system:treasury"
+        assert "미할당 잔액 부족" in req.reviews[0]["detail"]
+
+    async def test_pass_creates_normally(self, db, eventbus):
+        """pass 등급 검증 결과 시 요청이 정상 생성된다."""
+
+        def pass_validator(params: dict) -> list[ValidationResult]:
+            return [ValidationResult("pass", "", "system:bot_manager")]
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            validators={"bot_delete": pass_validator},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="bot_delete",
+            requester="agent",
+            title="봇 삭제",
+            params={"bot_id": "bot-1"},
+        )
+
+        assert req.status == "pending"
+        assert len(req.reviews) == 0
+
+    async def test_no_validator_creates_normally(self, service):
+        """validator가 등록되지 않은 유형은 정상 생성된다."""
+        req = await service.create(
+            type="rule_change",
+            requester="agent",
+            title="규칙 변경",
+            params={"bot_id": "bot-1", "rules": {}},
+        )
+        assert req.status == "pending"
+
+    async def test_multiple_results_first_fail_blocks(self, db, eventbus):
+        """복수 검증 결과 중 첫 번째 fail이 생성을 차단한다."""
+
+        def multi_validator(params: dict) -> list[ValidationResult]:
+            return [
+                ValidationResult("fail", "봇이 running 상태", "system:bot_manager"),
+                ValidationResult("fail", "보유 포지션 존재", "system:trade"),
+            ]
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            validators={"bot_delete": multi_validator},
+        )
+        await svc.initialize()
+
+        with pytest.raises(ApprovalValidationError, match="봇이 running 상태"):
+            await svc.create(
+                type="bot_delete",
+                requester="agent",
+                title="봇 삭제",
+                params={"bot_id": "bot-1"},
+            )
+
+    async def test_warn_persisted_to_db(self, db, eventbus):
+        """warn reviews가 DB에 영속화된다."""
+
+        def warn_validator(params: dict) -> list[ValidationResult]:
+            return [ValidationResult("warn", "잔액 주의", "system:treasury")]
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            validators={"budget_change": warn_validator},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="예산 변경",
+            params={"bot_id": "bot-1", "amount": 20000000, "current": 10000000},
+        )
+
+        fetched = await svc.get(req.id)
+        assert fetched is not None
+        assert len(fetched.reviews) == 1
+        assert fetched.reviews[0]["result"] == "warn"
+
+    async def test_warn_with_reviewed_at(self, db, eventbus):
+        """warn review에 reviewed_at 시각이 포함된다."""
+
+        def warn_validator(params: dict) -> list[ValidationResult]:
+            return [ValidationResult("warn", "잔액 부족", "system:treasury")]
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            validators={"budget_change": warn_validator},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="예산 변경",
+            params={"bot_id": "bot-1", "amount": 20000000},
+        )
+
+        assert "reviewed_at" in req.reviews[0]
+        assert req.reviews[0]["reviewed_at"] != ""
+
+
+# ── 모델 추가분 (US-9) ──────────────────────────────
+
+
+class TestValidationModels:
+    def test_validation_result_frozen(self):
+        """ValidationResult는 불변이다."""
+        result = ValidationResult("fail", "테스트", "system:test")
+        with pytest.raises(AttributeError):
+            result.grade = "pass"  # type: ignore[misc]
+
+    def test_approval_validation_error(self):
+        """ApprovalValidationError에 detail 속성이 있다."""
+        error = ApprovalValidationError("검증 실패")
+        assert error.detail == "검증 실패"
+        assert str(error) == "검증 실패"
+
+    def test_approval_type_new_values(self):
+        """새로 추가된 ApprovalType 값."""
+        assert ApprovalType.STRATEGY_RETIRE == "strategy_retire"
+        assert ApprovalType.BOT_ASSIGN_STRATEGY == "bot_assign_strategy"
+        assert ApprovalType.BOT_CHANGE_STRATEGY == "bot_change_strategy"
+        assert ApprovalType.BOT_RESUME == "bot_resume"
+        assert ApprovalType.BOT_DELETE == "bot_delete"


### PR DESCRIPTION
## Summary
- `create()` 시점에 유형별 validator를 실행하여 fail 시 요청 생성 차단, warn 시 reviews에 경고 첨부
- `ValidationResult` 모델 및 `ApprovalValidationError` 예외 정의
- 유형별 validator 7건 `main.py`에 등록 (`strategy_retire`, `bot_create`, `bot_delete`, `bot_change_strategy`, `bot_assign_strategy`, `bot_resume`, `budget_change`)
- `ApprovalType` enum에 누락된 유형 5개 추가 (`STRATEGY_RETIRE`, `BOT_ASSIGN_STRATEGY`, `BOT_CHANGE_STRATEGY`, `BOT_RESUME`, `BOT_DELETE`)

## Test plan
- [x] fail 등급 검증 → 요청 생성 차단 확인
- [x] warn 등급 검증 → reviews 첨부 + 요청 생성 확인
- [x] pass 등급 검증 → 정상 생성 확인
- [x] validator 미등록 유형 → 정상 생성 확인
- [x] 복수 검증 결과 중 첫 번째 fail이 차단하는지 확인
- [x] warn reviews가 DB에 영속화되는지 확인
- [x] ValidationResult frozen 불변성 확인
- [x] 기존 테스트 전체 통과 (48/48)

Refs #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)