### PR TITLE
feat(approval): 결재 실행 실패 상태(EXECUTION_FAILED) 구현

### DIFF
--- a/src/ante/approval/models.py
+++ b/src/ante/approval/models.py
@@ -11,6 +11,7 @@ class ApprovalStatus(StrEnum):
 
     PENDING = "pending"
     APPROVED = "approved"
+    EXECUTION_FAILED = "execution_failed"
     REJECTED = "rejected"
     ON_HOLD = "on_hold"
     EXPIRED = "expired"

--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -170,8 +170,42 @@ class ApprovalService:
             if executor:
                 try:
                     await executor(request.params)
+                    request.history.append(
+                        {
+                            "action": "executed",
+                            "actor": "system:auto_approve",
+                            "at": now,
+                            "detail": "",
+                        }
+                    )
+                    await self._db.execute(
+                        """UPDATE approvals SET history = ? WHERE id = ?""",
+                        (
+                            json.dumps(request.history, ensure_ascii=False),
+                            request.id,
+                        ),
+                    )
                     logger.info("전결 실행 완료: %s (%s)", request.id, request.type)
-                except Exception:
+                except Exception as exc:
+                    request.status = ApprovalStatus.EXECUTION_FAILED
+                    request.history.append(
+                        {
+                            "action": "execution_failed",
+                            "actor": "system:auto_approve",
+                            "at": now,
+                            "detail": str(exc),
+                        }
+                    )
+                    await self._db.execute(
+                        """UPDATE approvals
+                           SET status = ?, history = ?
+                           WHERE id = ?""",
+                        (
+                            ApprovalStatus.EXECUTION_FAILED,
+                            json.dumps(request.history, ensure_ascii=False),
+                            request.id,
+                        ),
+                    )
                     logger.exception(
                         "전결 실행 실패: %s (%s)", request.id, request.type
                     )
@@ -183,7 +217,7 @@ class ApprovalService:
                 ApprovalResolvedEvent(
                     approval_id=request.id,
                     approval_type=request.type,
-                    resolution=ApprovalStatus.APPROVED,
+                    resolution=request.status,
                     resolved_by="system:auto_approve",
                 )
             )
@@ -201,8 +235,12 @@ class ApprovalService:
             msg = f"결재 요청을 찾을 수 없음: {id}"
             raise ValueError(msg)
 
-        if request.status != ApprovalStatus.PENDING:
-            msg = f"pending 상태에서만 승인 가능 (현재: {request.status})"
+        approvable = (ApprovalStatus.PENDING, ApprovalStatus.EXECUTION_FAILED)
+        if request.status not in approvable:
+            msg = (
+                "pending/execution_failed 상태에서만 승인 가능"
+                f" (현재: {request.status})"
+            )
             raise ValueError(msg)
 
         now = datetime.now(UTC).isoformat()
@@ -235,9 +273,42 @@ class ApprovalService:
         if executor:
             try:
                 await executor(request.params)
+                request.history.append(
+                    {
+                        "action": "executed",
+                        "actor": resolved_by,
+                        "at": now,
+                        "detail": "",
+                    }
+                )
                 logger.info("결재 실행 완료: %s (%s)", id, request.type)
-            except Exception:
+            except Exception as exc:
+                request.status = ApprovalStatus.EXECUTION_FAILED
+                request.history.append(
+                    {
+                        "action": "execution_failed",
+                        "actor": resolved_by,
+                        "at": now,
+                        "detail": str(exc),
+                    }
+                )
+                await self._db.execute(
+                    """UPDATE approvals
+                       SET status = ?, history = ?
+                       WHERE id = ?""",
+                    (
+                        ApprovalStatus.EXECUTION_FAILED,
+                        json.dumps(request.history, ensure_ascii=False),
+                        id,
+                    ),
+                )
                 logger.exception("결재 실행 실패: %s (%s)", id, request.type)
+            else:
+                # 실행 성공 시 history만 갱신
+                await self._db.execute(
+                    """UPDATE approvals SET history = ? WHERE id = ?""",
+                    (json.dumps(request.history, ensure_ascii=False), id),
+                )
 
         # ApprovalResolvedEvent 발행
         from ante.eventbus.events import ApprovalResolvedEvent
@@ -246,7 +317,7 @@ class ApprovalService:
             ApprovalResolvedEvent(
                 approval_id=id,
                 approval_type=request.type,
-                resolution=ApprovalStatus.APPROVED,
+                resolution=request.status,
                 resolved_by=resolved_by,
             )
         )
@@ -265,8 +336,12 @@ class ApprovalService:
             msg = f"결재 요청을 찾을 수 없음: {id}"
             raise ValueError(msg)
 
-        if request.status != ApprovalStatus.PENDING:
-            msg = f"pending 상태에서만 거절 가능 (현재: {request.status})"
+        rejectable = (ApprovalStatus.PENDING, ApprovalStatus.EXECUTION_FAILED)
+        if request.status not in rejectable:
+            msg = (
+                "pending/execution_failed 상태에서만 거절 가능"
+                f" (현재: {request.status})"
+            )
             raise ValueError(msg)
 
         now = datetime.now(UTC).isoformat()
@@ -329,8 +404,16 @@ class ApprovalService:
             msg = f"본인 요청만 철회 가능 (요청자: {request.requester})"
             raise ValueError(msg)
 
-        if request.status not in (ApprovalStatus.PENDING, ApprovalStatus.ON_HOLD):
-            msg = f"pending/on_hold 상태에서만 철회 가능 (현재: {request.status})"
+        cancellable = (
+            ApprovalStatus.PENDING,
+            ApprovalStatus.ON_HOLD,
+            ApprovalStatus.EXECUTION_FAILED,
+        )
+        if request.status not in cancellable:
+            msg = (
+                "pending/on_hold/execution_failed 상태에서만 철회 가능"
+                f" (현재: {request.status})"
+            )
             raise ValueError(msg)
 
         now = datetime.now(UTC).isoformat()
@@ -378,8 +461,12 @@ class ApprovalService:
             msg = f"결재 요청을 찾을 수 없음: {id}"
             raise ValueError(msg)
 
-        if request.status != ApprovalStatus.PENDING:
-            msg = f"pending 상태에서만 보류 가능 (현재: {request.status})"
+        holdable = (ApprovalStatus.PENDING, ApprovalStatus.EXECUTION_FAILED)
+        if request.status not in holdable:
+            msg = (
+                "pending/execution_failed 상태에서만 보류 가능"
+                f" (현재: {request.status})"
+            )
             raise ValueError(msg)
 
         now = datetime.now(UTC).isoformat()

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -43,6 +43,7 @@ class TestModels:
         """ApprovalStatus 값."""
         assert ApprovalStatus.PENDING == "pending"
         assert ApprovalStatus.APPROVED == "approved"
+        assert ApprovalStatus.EXECUTION_FAILED == "execution_failed"
         assert ApprovalStatus.REJECTED == "rejected"
         assert ApprovalStatus.ON_HOLD == "on_hold"
         assert ApprovalStatus.EXPIRED == "expired"
@@ -260,13 +261,15 @@ class TestResolve:
         assert received[0].resolution == "approved"
 
     async def test_approve_non_pending_fails(self, service):
-        """pending이 아닌 상태에서 승인 시 에러."""
+        """pending/execution_failed이 아닌 상태에서 승인 시 에러."""
         req = await service.create(
             type="budget_change", requester="agent", title="테스트"
         )
         await service.approve(req.id)
 
-        with pytest.raises(ValueError, match="pending 상태에서만 승인 가능"):
+        with pytest.raises(
+            ValueError, match="pending/execution_failed 상태에서만 승인 가능"
+        ):
             await service.approve(req.id)
 
     async def test_reject(self, service):
@@ -281,13 +284,15 @@ class TestResolve:
         assert any(h["action"] == "rejected" for h in rejected.history)
 
     async def test_reject_non_pending_fails(self, service):
-        """pending이 아닌 상태에서 거절 시 에러."""
+        """pending/execution_failed이 아닌 상태에서 거절 시 에러."""
         req = await service.create(
             type="budget_change", requester="agent", title="테스트"
         )
         await service.reject(req.id)
 
-        with pytest.raises(ValueError, match="pending 상태에서만 거절 가능"):
+        with pytest.raises(
+            ValueError, match="pending/execution_failed 상태에서만 거절 가능"
+        ):
             await service.reject(req.id)
 
     async def test_hold_and_resume(self, service):
@@ -305,13 +310,15 @@ class TestResolve:
         assert any(h["action"] == "resumed" for h in resumed.history)
 
     async def test_hold_non_pending_fails(self, service):
-        """pending이 아닌 상태에서 보류 시 에러."""
+        """pending/execution_failed이 아닌 상태에서 보류 시 에러."""
         req = await service.create(
             type="budget_change", requester="agent", title="테스트"
         )
         await service.approve(req.id)
 
-        with pytest.raises(ValueError, match="pending 상태에서만 보류 가능"):
+        with pytest.raises(
+            ValueError, match="pending/execution_failed 상태에서만 보류 가능"
+        ):
             await service.hold(req.id)
 
     async def test_resume_non_hold_fails(self, service):
@@ -364,7 +371,10 @@ class TestCancel:
         )
         await service.approve(req.id)
 
-        with pytest.raises(ValueError, match="pending/on_hold 상태에서만 철회 가능"):
+        with pytest.raises(
+            ValueError,
+            match="pending/on_hold/execution_failed 상태에서만 철회 가능",
+        ):
             await service.cancel(req.id, requester="agent:dev")
 
     async def test_cancel_publishes_event(self, service, eventbus):
@@ -547,3 +557,233 @@ class TestEvents:
         )
         assert event.resolution == "approved"
         assert event.event_id is not None
+
+
+# ── 실행 실패 (US-8: EXECUTION_FAILED) ──────────────
+
+
+class TestExecutionFailed:
+    async def test_executor_failure_transitions_to_execution_failed(self, db, eventbus):
+        """executor 실패 시 execution_failed 상태로 전환."""
+
+        async def failing_executor(params: dict) -> None:
+            msg = "잔액 부족"
+            raise RuntimeError(msg)
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"budget_change": failing_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="실행 실패 테스트",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        result = await svc.approve(req.id)
+
+        assert result.status == "execution_failed"
+        assert any(h["action"] == "execution_failed" for h in result.history)
+        # 에러 메시지가 history에 기록
+        failed_entry = next(
+            h for h in result.history if h["action"] == "execution_failed"
+        )
+        assert "잔액 부족" in failed_entry["detail"]
+
+    async def test_execution_failed_persisted_in_db(self, db, eventbus):
+        """execution_failed 상태가 DB에 영속화."""
+
+        async def failing_executor(params: dict) -> None:
+            msg = "봇 미존재"
+            raise RuntimeError(msg)
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"bot_stop": failing_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="bot_stop",
+            requester="agent",
+            title="영속화 테스트",
+            params={"bot_id": "bot-1"},
+        )
+        await svc.approve(req.id)
+
+        fetched = await svc.get(req.id)
+        assert fetched is not None
+        assert fetched.status == "execution_failed"
+        assert any(h["action"] == "execution_failed" for h in fetched.history)
+
+    async def test_reapprove_after_execution_failed(self, db, eventbus):
+        """execution_failed 상태에서 재승인 → executor 재실행."""
+        call_count = 0
+
+        async def flaky_executor(params: dict) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                msg = "일시적 오류"
+                raise RuntimeError(msg)
+            # 두 번째 호출은 성공
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"budget_change": flaky_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="재승인 테스트",
+            params={"bot_id": "bot-1", "amount": 10000000},
+        )
+        failed = await svc.approve(req.id)
+        assert failed.status == "execution_failed"
+
+        # 재승인
+        success = await svc.approve(req.id)
+        assert success.status == "approved"
+        assert call_count == 2
+        assert any(h["action"] == "executed" for h in success.history)
+
+    async def test_reject_after_execution_failed(self, db, eventbus):
+        """execution_failed 상태에서 거절 가능."""
+
+        async def failing_executor(params: dict) -> None:
+            msg = "실패"
+            raise RuntimeError(msg)
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"budget_change": failing_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="거절 테스트",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        await svc.approve(req.id)
+        rejected = await svc.reject(req.id, reject_reason="원인 해소 불가")
+
+        assert rejected.status == "rejected"
+        assert rejected.reject_reason == "원인 해소 불가"
+
+    async def test_hold_after_execution_failed(self, db, eventbus):
+        """execution_failed 상태에서 보류 가능."""
+
+        async def failing_executor(params: dict) -> None:
+            msg = "실패"
+            raise RuntimeError(msg)
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"budget_change": failing_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="보류 테스트",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        await svc.approve(req.id)
+        held = await svc.hold(req.id)
+
+        assert held.status == "on_hold"
+
+    async def test_cancel_after_execution_failed(self, db, eventbus):
+        """execution_failed 상태에서 철회 가능."""
+
+        async def failing_executor(params: dict) -> None:
+            msg = "실패"
+            raise RuntimeError(msg)
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"budget_change": failing_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent:dev",
+            title="철회 테스트",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        await svc.approve(req.id)
+        cancelled = await svc.cancel(req.id, requester="agent:dev")
+
+        assert cancelled.status == "cancelled"
+
+    async def test_execution_failed_publishes_event(self, db, eventbus):
+        """executor 실패 시 ApprovalResolvedEvent에 execution_failed resolution."""
+        received = []
+
+        async def handler(event: object) -> None:
+            if isinstance(event, ApprovalResolvedEvent):
+                received.append(event)
+
+        eventbus.subscribe(ApprovalResolvedEvent, handler)
+
+        async def failing_executor(params: dict) -> None:
+            msg = "실패"
+            raise RuntimeError(msg)
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"budget_change": failing_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="이벤트 테스트",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        await svc.approve(req.id)
+
+        assert len(received) == 1
+        assert received[0].resolution == "execution_failed"
+
+    async def test_list_filter_execution_failed(self, db, eventbus):
+        """execution_failed 상태 필터 조회."""
+
+        async def failing_executor(params: dict) -> None:
+            msg = "실패"
+            raise RuntimeError(msg)
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"budget_change": failing_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="필터 테스트",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        await svc.approve(req.id)
+
+        failed_list = await svc.list(status="execution_failed")
+        assert len(failed_list) == 1
+        assert failed_list[0].status == "execution_failed"

--- a/tests/unit/test_auto_approve.py
+++ b/tests/unit/test_auto_approve.py
@@ -276,11 +276,12 @@ class TestServiceAutoApprove:
         assert req.status == ApprovalStatus.APPROVED
         assert req.resolved_by == "system:auto_approve"
         assert req.resolved_at != ""
-        # history: created + approved
-        assert len(req.history) == 2
+        # history: created + approved + executed
+        assert len(req.history) == 3
         assert req.history[0]["action"] == "created"
         assert req.history[1]["action"] == "approved"
         assert req.history[1]["actor"] == "system:auto_approve"
+        assert req.history[2]["action"] == "executed"
 
     async def test_auto_approve_executes_handler(self, service_with_auto_approve):
         """전결 시 executor가 실행된다."""
@@ -384,7 +385,7 @@ class TestServiceAutoApprove:
         assert fetched is not None
         assert fetched.status == "approved"
         assert fetched.resolved_by == "system:auto_approve"
-        assert len(fetched.history) == 2
+        assert len(fetched.history) == 3
 
     async def test_created_event_auto_approved_false_for_normal(
         self, service_without_auto_approve, eventbus


### PR DESCRIPTION
## Summary
- `ApprovalStatus.EXECUTION_FAILED` 상태 추가 — executor 실행 실패 시 명시적 상태 전환
- `approve()` 메서드에서 executor 예외 발생 시 `execution_failed`로 전환 + 에러 메시지 history 기록
- `approve()`, `reject()`, `hold()`, `cancel()` 메서드가 `execution_failed` 상태를 입력으로 허용
- 전결(auto-approve) 경로에도 동일한 실패 처리 적용
- 단위 테스트 8건 추가: 상태 전환, DB 영속화, 재승인, 거절/보류/철회 전이, 이벤트 발행, 필터 조회

## Test plan
- [x] executor 실패 → `execution_failed` 전환 확인
- [x] `execution_failed` → 재승인(`approve`) 전이 확인
- [x] `execution_failed` → 거절(`reject`) 전이 확인
- [x] `execution_failed` → 보류(`hold`) 전이 확인
- [x] `execution_failed` → 철회(`cancel`) 전이 확인
- [x] 에러 메시지가 history에 기록되는지 확인
- [x] DB에 `execution_failed` 상태가 영속화되는지 확인
- [x] `ApprovalResolvedEvent`에 `execution_failed` resolution 전달 확인

Refs #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)