### PR TITLE
feat: Telegram 결재 연동 — 인라인 버튼 + 명령어

### DIFF
--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -667,6 +667,7 @@ async def _init_notification(s: Services) -> None:
             bot_manager=s.bot_manager,
             treasury=s.treasury,
             system_state=s.system_state,
+            approval_service=s.approval_service,
         )
         s.telegram_receiver.start()
         logger.info("TelegramCommandReceiver 시작")

--- a/src/ante/notification/service.py
+++ b/src/ante/notification/service.py
@@ -120,6 +120,19 @@ class NotificationService:
             priority=0,
         )
 
+        from ante.eventbus.events import ApprovalCreatedEvent, ApprovalResolvedEvent
+
+        self._eventbus.subscribe(
+            ApprovalCreatedEvent,
+            self._on_approval_created,
+            priority=0,
+        )
+        self._eventbus.subscribe(
+            ApprovalResolvedEvent,
+            self._on_approval_resolved,
+            priority=0,
+        )
+
     def _make_dedup_key(self, level: NotificationLevel, message: str) -> str:
         """중복 방지 키 생성: level + message_hash."""
         import hashlib
@@ -462,6 +475,89 @@ class NotificationService:
             level,
             msg,
             event_type="CircuitBreakerEvent",
+        )
+
+    async def _on_approval_created(self, event: object) -> None:
+        """결재 요청 생성 알림 (인라인 버튼 포함)."""
+        from ante.eventbus.events import ApprovalCreatedEvent
+        from ante.notification.templates import APPROVAL_CREATED
+
+        if not isinstance(event, ApprovalCreatedEvent):
+            return
+
+        prefix = "[자동 승인] 📋 " if event.auto_approved else "📋 "
+        msg = APPROVAL_CREATED.format(
+            prefix=prefix,
+            approval_type=event.approval_type,
+            title=event.title,
+            requester=event.requester,
+            approval_id=event.approval_id,
+        )
+
+        # 자동 승인이 아닌 경우 인라인 버튼 포함 발송 시도
+        if not event.auto_approved:
+            from ante.notification.telegram import TelegramAdapter
+
+            if isinstance(self._adapter, TelegramAdapter):
+                buttons = [
+                    [
+                        {
+                            "text": "\u2705 승인",
+                            "callback_data": f"approve:{event.approval_id}",
+                        },
+                        {
+                            "text": "\u274c 거절",
+                            "callback_data": f"reject:{event.approval_id}",
+                        },
+                    ]
+                ]
+                success = False
+                error_message = ""
+                try:
+                    success = await self._adapter.send_with_buttons(
+                        NotificationLevel.INFO, msg, buttons
+                    )
+                except Exception as e:
+                    error_message = str(e)
+                    logger.warning("결재 알림 발송 실패: %s", e)
+
+                await self._record_history(
+                    level=NotificationLevel.INFO,
+                    title="결재 요청",
+                    message=msg,
+                    success=success,
+                    error_message=error_message,
+                    event_type="ApprovalCreatedEvent",
+                )
+                return
+
+        # 자동 승인 또는 TelegramAdapter가 아닌 경우 일반 발송
+        await self._send_and_record(
+            NotificationLevel.INFO,
+            msg,
+            title="결재 요청",
+            event_type="ApprovalCreatedEvent",
+        )
+
+    async def _on_approval_resolved(self, event: object) -> None:
+        """결재 처리 완료 알림."""
+        from ante.eventbus.events import ApprovalResolvedEvent
+        from ante.notification.templates import APPROVAL_RESOLVED
+
+        if not isinstance(event, ApprovalResolvedEvent):
+            return
+
+        msg = APPROVAL_RESOLVED.format(
+            approval_type=event.approval_type,
+            resolution=event.resolution,
+            resolved_by=event.resolved_by,
+            approval_id=event.approval_id,
+        )
+        await self._send_and_record(
+            NotificationLevel.INFO,
+            msg,
+            title="결재 처리 완료",
+            event_type="ApprovalResolvedEvent",
         )
 
     def _should_send(self, level: NotificationLevel) -> bool:

--- a/src/ante/notification/telegram.py
+++ b/src/ante/notification/telegram.py
@@ -46,7 +46,59 @@ class TelegramAdapter(NotificationAdapter):
         text = "\n".join(parts)
         return await self._send_message(text, parse_mode="Markdown")
 
-    async def _send_message(self, text: str, parse_mode: str = "") -> bool:
+    async def send_with_buttons(
+        self,
+        level: NotificationLevel,
+        message: str,
+        buttons: list[list[dict]],
+    ) -> bool:
+        """인라인 버튼이 포함된 알림 발송.
+
+        Args:
+            level: 알림 레벨.
+            message: 메시지 본문.
+            buttons: 인라인 키보드 버튼 행 목록.
+                [[{"text": "승인", "callback_data": "approve:id"}, ...], ...]
+        """
+        emoji = LEVEL_EMOJI.get(level, "\U0001f4cc")
+        text = f"{emoji} {message}"
+        reply_markup = {
+            "inline_keyboard": buttons,
+        }
+        return await self._send_message(
+            text, parse_mode="Markdown", reply_markup=reply_markup
+        )
+
+    async def answer_callback_query(
+        self,
+        callback_query_id: str,
+        text: str = "",
+    ) -> bool:
+        """answerCallbackQuery API 호출 (버튼 로딩 해제)."""
+        try:
+            import aiohttp
+        except ImportError:
+            return False
+
+        url = f"{self._api_base}/answerCallbackQuery"
+        payload: dict = {"callback_query_id": callback_query_id}
+        if text:
+            payload["text"] = text
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, json=payload) as resp:
+                    return resp.status == 200
+        except Exception as e:
+            logger.warning("answerCallbackQuery 오류: %s", e)
+            return False
+
+    async def _send_message(
+        self,
+        text: str,
+        parse_mode: str = "",
+        reply_markup: dict | None = None,
+    ) -> bool:
         """텔레그램 sendMessage API 호출."""
         try:
             import aiohttp
@@ -63,6 +115,8 @@ class TelegramAdapter(NotificationAdapter):
         }
         if parse_mode:
             payload["parse_mode"] = parse_mode
+        if reply_markup:
+            payload["reply_markup"] = reply_markup
 
         try:
             async with aiohttp.ClientSession() as session:

--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -9,6 +9,7 @@ from inspect import isawaitable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from ante.approval.service import ApprovalService
     from ante.bot.manager import BotManager
     from ante.config.system_state import SystemState
     from ante.notification.telegram import TelegramAdapter
@@ -33,6 +34,7 @@ class TelegramCommandReceiver:
         bot_manager: BotManager | None = None,
         treasury: Treasury | None = None,
         system_state: SystemState | None = None,
+        approval_service: ApprovalService | None = None,
     ) -> None:
         self._adapter = adapter
         self._allowed_user_ids = set(allowed_user_ids or [])
@@ -41,6 +43,7 @@ class TelegramCommandReceiver:
         self._bot_manager = bot_manager
         self._treasury = treasury
         self._system_state = system_state
+        self._approval_service = approval_service
 
         self._offset: int = 0
         self._task: asyncio.Task[None] | None = None
@@ -125,6 +128,11 @@ class TelegramCommandReceiver:
 
     async def _handle_update(self, update: dict[str, Any]) -> None:
         """개별 업데이트 처리."""
+        # callback_query (인라인 버튼) 처리
+        if "callback_query" in update:
+            await self._handle_callback_query(update["callback_query"])
+            return
+
         message = update.get("message")
         if not message:
             return
@@ -156,6 +164,58 @@ class TelegramCommandReceiver:
         if reply:
             await self._reply(chat_id, reply)
 
+    async def _handle_callback_query(self, callback_query: dict[str, Any]) -> None:
+        """인라인 버튼 콜백 처리 (결재 승인/거절)."""
+        callback_id = callback_query.get("id", "")
+        user = callback_query.get("from", {})
+        user_id = user.get("id", 0)
+        chat_id = callback_query.get("message", {}).get("chat", {}).get("id")
+        data = callback_query.get("data", "")
+
+        if not self._is_authorized(user_id):
+            logger.warning("미인가 콜백 시도: user_id=%d, data=%s", user_id, data)
+            await self._adapter.answer_callback_query(callback_id, "권한이 없습니다.")
+            return
+
+        if not self._approval_service:
+            await self._adapter.answer_callback_query(
+                callback_id, "ApprovalService가 연결되지 않았습니다."
+            )
+            return
+
+        # data 형식: "approve:{id}" 또는 "reject:{id}"
+        if ":" not in data:
+            await self._adapter.answer_callback_query(callback_id, "잘못된 요청입니다.")
+            return
+
+        action, approval_id = data.split(":", 1)
+
+        try:
+            if action == "approve":
+                await self._approval_service.approve(
+                    approval_id, resolved_by="telegram"
+                )
+                result_msg = f"결재 승인 완료: {approval_id}"
+            elif action == "reject":
+                await self._approval_service.reject(
+                    approval_id, resolved_by="telegram", reject_reason="사용자 거절"
+                )
+                result_msg = f"결재 거절 완료: {approval_id}"
+            else:
+                await self._adapter.answer_callback_query(
+                    callback_id, "알 수 없는 동작입니다."
+                )
+                return
+        except ValueError as e:
+            result_msg = f"처리 실패: {e}"
+        except Exception:
+            logger.exception("콜백 결재 처리 오류: %s", data)
+            result_msg = "처리 중 오류가 발생했습니다."
+
+        await self._adapter.answer_callback_query(callback_id, result_msg)
+        if chat_id:
+            await self._reply(chat_id, result_msg)
+
     def _is_authorized(self, user_id: int) -> bool:
         """화이트리스트 인증 확인."""
         return user_id in self._allowed_user_ids
@@ -185,6 +245,8 @@ class TelegramCommandReceiver:
             "bots": self._cmd_bots,
             "balance": self._cmd_balance,
             "activate": self._cmd_activate,
+            "approve": self._cmd_approve,
+            "reject": self._cmd_reject,
         }
 
         handler = handlers.get(command)
@@ -246,6 +308,8 @@ class TelegramCommandReceiver:
             "/halt [reason] — 전체 거래 중지 (확인 필요)\n"
             "/activate — 거래 재개\n"
             "/stop <bot_id> — 특정 봇 중지 (확인 필요)\n"
+            "/approve <id> — 결재 승인\n"
+            "/reject <id> [reason] — 결재 거절\n"
             "/help — 이 도움말"
         )
 
@@ -301,6 +365,43 @@ class TelegramCommandReceiver:
             f"할당: {allocated:,.0f}원 ({bot_count}개 봇)\n"
             f"미할당: {unallocated:,.0f}원"
         )
+
+    async def _cmd_approve(self, args: list[str]) -> str:
+        """결재 승인. /approve <id>"""
+        if not self._approval_service:
+            return "ApprovalService가 연결되지 않았습니다."
+        if not args:
+            return "결재 ID를 지정해 주세요. 예: /approve abc123"
+
+        approval_id = args[0]
+        try:
+            await self._approval_service.approve(approval_id, resolved_by="telegram")
+            return f"결재 승인 완료: {approval_id}"
+        except ValueError as e:
+            return f"승인 실패: {e}"
+        except Exception:
+            logger.exception("결재 승인 오류: %s", approval_id)
+            return "승인 처리 중 오류가 발생했습니다."
+
+    async def _cmd_reject(self, args: list[str]) -> str:
+        """결재 거절. /reject <id> [reason]"""
+        if not self._approval_service:
+            return "ApprovalService가 연결되지 않았습니다."
+        if not args:
+            return "결재 ID를 지정해 주세요. 예: /reject abc123 사유"
+
+        approval_id = args[0]
+        reason = " ".join(args[1:]) if len(args) > 1 else "사용자 거절"
+        try:
+            await self._approval_service.reject(
+                approval_id, resolved_by="telegram", reject_reason=reason
+            )
+            return f"결재 거절 완료: {approval_id} (사유: {reason})"
+        except ValueError as e:
+            return f"거절 실패: {e}"
+        except Exception:
+            logger.exception("결재 거절 오류: %s", approval_id)
+            return "거절 처리 중 오류가 발생했습니다."
 
     async def _cmd_halt(self, args: list[str]) -> str:
         """전체 거래 중지."""

--- a/src/ante/notification/templates.py
+++ b/src/ante/notification/templates.py
@@ -41,3 +41,21 @@ ORDER_FILLED = (
     "종목: *{display}*\n"
     "{side} {quantity}주 @ {price:,.0f}원"
 )
+
+# ── 결재 (Approval) ──────────────────────────
+
+APPROVAL_CREATED = (
+    "{prefix}*결재 요청*\n"
+    "유형: `{approval_type}`\n"
+    "제목: {title}\n"
+    "요청자: `{requester}`\n"
+    "ID: `{approval_id}`"
+)
+
+APPROVAL_RESOLVED = (
+    "📋 *결재 처리 완료*\n"
+    "유형: `{approval_type}`\n"
+    "결과: *{resolution}*\n"
+    "처리자: `{resolved_by}`\n"
+    "ID: `{approval_id}`"
+)

--- a/tests/unit/test_telegram_approval.py
+++ b/tests/unit/test_telegram_approval.py
@@ -1,0 +1,462 @@
+"""텔레그램 결재 연동 테스트.
+
+TelegramAdapter.send_with_buttons(), TelegramCommandReceiver 콜백/명령어,
+NotificationService의 ApprovalEvent 구독을 검증한다.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ante.core.database import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import ApprovalCreatedEvent, ApprovalResolvedEvent
+from ante.notification.base import NotificationLevel
+from ante.notification.service import NOTIFICATION_HISTORY_SCHEMA, NotificationService
+from ante.notification.telegram import TelegramAdapter
+from ante.notification.telegram_receiver import TelegramCommandReceiver
+
+# ── Fixtures ──────────────────────────────────────
+
+
+@pytest.fixture
+def adapter():
+    """TelegramAdapter mock."""
+    mock = MagicMock(spec=TelegramAdapter)
+    mock._api_base = "https://api.telegram.org/botTEST"
+    mock._bot_token = "TEST"
+    mock._chat_id = "123"
+    mock.send = AsyncMock(return_value=True)
+    mock.send_rich = AsyncMock(return_value=True)
+    mock.send_with_buttons = AsyncMock(return_value=True)
+    mock.answer_callback_query = AsyncMock(return_value=True)
+    return mock
+
+
+@pytest.fixture
+def approval_service():
+    """ApprovalService mock."""
+    mock = MagicMock()
+    mock.approve = AsyncMock()
+    mock.reject = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def receiver(adapter, approval_service):
+    """approval_service가 주입된 TelegramCommandReceiver."""
+    return TelegramCommandReceiver(
+        adapter=adapter,
+        allowed_user_ids=[12345],
+        approval_service=approval_service,
+    )
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """테스트용 DB."""
+    _db = Database(str(tmp_path / "test.db"))
+    await _db.connect()
+    yield _db
+    await _db.close()
+
+
+# ── TelegramAdapter.send_with_buttons ─────────────
+
+
+class TestSendWithButtons:
+    """send_with_buttons() 단위 테스트."""
+
+    async def test_send_with_buttons_calls_api(self):
+        """send_with_buttons가 reply_markup과 함께 _send_message를 호출한다."""
+        adapter = TelegramAdapter(bot_token="TEST", chat_id="123")
+        adapter._send_message = AsyncMock(return_value=True)
+
+        buttons = [[{"text": "승인", "callback_data": "approve:abc"}]]
+        result = await adapter.send_with_buttons(
+            NotificationLevel.INFO, "테스트 메시지", buttons
+        )
+
+        assert result is True
+        adapter._send_message.assert_called_once()
+        call_kwargs = adapter._send_message.call_args
+        assert call_kwargs[1]["reply_markup"] == {"inline_keyboard": buttons}
+
+    async def test_send_with_buttons_includes_emoji(self):
+        """send_with_buttons가 레벨 이모지를 포함한다."""
+        adapter = TelegramAdapter(bot_token="TEST", chat_id="123")
+        adapter._send_message = AsyncMock(return_value=True)
+
+        await adapter.send_with_buttons(
+            NotificationLevel.INFO,
+            "테스트",
+            [[{"text": "OK", "callback_data": "ok"}]],
+        )
+
+        text_arg = adapter._send_message.call_args[0][0]
+        assert "\u2139\ufe0f" in text_arg  # INFO 이모지
+
+
+class TestAnswerCallbackQuery:
+    """answer_callback_query() 단위 테스트."""
+
+    async def test_answer_callback_query_success(self):
+        """answerCallbackQuery API 호출 성공."""
+        adapter = TelegramAdapter(bot_token="TEST", chat_id="123")
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await adapter.answer_callback_query("cb123", "완료")
+
+        assert result is True
+
+
+# ── Callback Query 처리 ──────────────────────────
+
+
+class TestCallbackQuery:
+    """인라인 버튼 콜백 처리 테스트."""
+
+    async def test_approve_callback(self, receiver, approval_service):
+        """approve 콜백이 ApprovalService.approve()를 호출한다."""
+        update = {
+            "callback_query": {
+                "id": "cb1",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "approve:abc123",
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
+
+        approval_service.approve.assert_called_once_with(
+            "abc123", resolved_by="telegram"
+        )
+
+    async def test_reject_callback(self, receiver, approval_service):
+        """reject 콜백이 ApprovalService.reject()를 호출한다."""
+        update = {
+            "callback_query": {
+                "id": "cb2",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "reject:abc123",
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
+
+        approval_service.reject.assert_called_once_with(
+            "abc123", resolved_by="telegram", reject_reason="사용자 거절"
+        )
+
+    async def test_callback_unauthorized(self, receiver, adapter):
+        """미인가 사용자의 콜백은 거부된다."""
+        update = {
+            "callback_query": {
+                "id": "cb3",
+                "from": {"id": 99999},
+                "message": {"chat": {"id": 100}},
+                "data": "approve:abc123",
+            }
+        }
+        await receiver._handle_update(update)
+        adapter.answer_callback_query.assert_called_once()
+        assert "권한" in adapter.answer_callback_query.call_args[0][1]
+
+    async def test_callback_invalid_data(self, receiver, adapter):
+        """잘못된 callback_data 형식 처리."""
+        update = {
+            "callback_query": {
+                "id": "cb4",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "invalid",
+            }
+        }
+        await receiver._handle_update(update)
+        adapter.answer_callback_query.assert_called_once()
+        assert "잘못된" in adapter.answer_callback_query.call_args[0][1]
+
+    async def test_callback_unknown_action(self, receiver, adapter):
+        """알 수 없는 action 처리."""
+        update = {
+            "callback_query": {
+                "id": "cb5",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "hold:abc123",
+            }
+        }
+        await receiver._handle_update(update)
+        adapter.answer_callback_query.assert_called()
+        assert "알 수 없는" in adapter.answer_callback_query.call_args[0][1]
+
+    async def test_callback_approve_error(self, receiver, approval_service, adapter):
+        """approve 실패 시 에러 메시지를 반환한다."""
+        approval_service.approve.side_effect = ValueError("pending 상태가 아님")
+        update = {
+            "callback_query": {
+                "id": "cb6",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "approve:abc123",
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
+        adapter.answer_callback_query.assert_called_once()
+        assert "실패" in adapter.answer_callback_query.call_args[0][1]
+
+    async def test_callback_no_approval_service(self, adapter):
+        """approval_service 없으면 안내 메시지."""
+        r = TelegramCommandReceiver(
+            adapter=adapter, allowed_user_ids=[12345], approval_service=None
+        )
+        update = {
+            "callback_query": {
+                "id": "cb7",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "approve:abc123",
+            }
+        }
+        await r._handle_update(update)
+        adapter.answer_callback_query.assert_called_once()
+        assert "ApprovalService" in adapter.answer_callback_query.call_args[0][1]
+
+    async def test_callback_sends_reply(self, receiver, adapter, approval_service):
+        """콜백 처리 후 결과 메시지를 chat에 발송한다."""
+        update = {
+            "callback_query": {
+                "id": "cb8",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "approve:abc123",
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
+        receiver._reply.assert_called_once()
+        assert "승인 완료" in receiver._reply.call_args[0][1]
+
+
+# ── /approve, /reject 명령어 ─────────────────────
+
+
+class TestApproveRejectCommands:
+    """텍스트 명령어 /approve, /reject 테스트."""
+
+    async def test_approve_command(self, receiver, approval_service):
+        """/approve <id> 명령이 ApprovalService.approve()를 호출한다."""
+        result = await receiver._cmd_approve(["abc123"])
+        assert "승인 완료" in result
+        approval_service.approve.assert_called_once_with(
+            "abc123", resolved_by="telegram"
+        )
+
+    async def test_approve_no_args(self, receiver):
+        """/approve 인자 없으면 안내 메시지."""
+        result = await receiver._cmd_approve([])
+        assert "ID를 지정" in result
+
+    async def test_approve_no_service(self, adapter):
+        """approval_service 없으면 안내 메시지."""
+        r = TelegramCommandReceiver(
+            adapter=adapter, allowed_user_ids=[12345], approval_service=None
+        )
+        result = await r._cmd_approve(["abc123"])
+        assert "연결되지 않았습니다" in result
+
+    async def test_approve_error(self, receiver, approval_service):
+        """approve 실패 시 에러 메시지."""
+        approval_service.approve.side_effect = ValueError("찾을 수 없음")
+        result = await receiver._cmd_approve(["abc123"])
+        assert "실패" in result
+
+    async def test_reject_command(self, receiver, approval_service):
+        """/reject <id> [reason] 명령이 reject를 호출한다."""
+        result = await receiver._cmd_reject(["abc123", "리스크", "과다"])
+        assert "거절 완료" in result
+        approval_service.reject.assert_called_once_with(
+            "abc123", resolved_by="telegram", reject_reason="리스크 과다"
+        )
+
+    async def test_reject_default_reason(self, receiver, approval_service):
+        """/reject <id> 사유 미지정 시 기본 사유."""
+        await receiver._cmd_reject(["abc123"])
+        approval_service.reject.assert_called_once_with(
+            "abc123", resolved_by="telegram", reject_reason="사용자 거절"
+        )
+
+    async def test_reject_no_args(self, receiver):
+        """/reject 인자 없으면 안내 메시지."""
+        result = await receiver._cmd_reject([])
+        assert "ID를 지정" in result
+
+    async def test_reject_no_service(self, adapter):
+        """approval_service 없으면 안내 메시지."""
+        r = TelegramCommandReceiver(
+            adapter=adapter, allowed_user_ids=[12345], approval_service=None
+        )
+        result = await r._cmd_reject(["abc123"])
+        assert "연결되지 않았습니다" in result
+
+    async def test_reject_error(self, receiver, approval_service):
+        """reject 실패 시 에러 메시지."""
+        approval_service.reject.side_effect = ValueError("이미 처리됨")
+        result = await receiver._cmd_reject(["abc123"])
+        assert "실패" in result
+
+    async def test_help_includes_approval_commands(self, receiver):
+        """/help에 /approve, /reject 명령이 포함된다."""
+        result = receiver._cmd_help([])
+        assert "/approve" in result
+        assert "/reject" in result
+
+    async def test_execute_approve(self, receiver, approval_service):
+        """_execute를 통해 /approve가 라우팅된다."""
+        result = await receiver._execute("approve", ["abc123"], 12345, 100)
+        assert "승인 완료" in result
+
+    async def test_execute_reject(self, receiver, approval_service):
+        """_execute를 통해 /reject가 라우팅된다."""
+        result = await receiver._execute("reject", ["abc123"], 12345, 100)
+        assert "거절 완료" in result
+
+
+# ── NotificationService 결재 이벤트 구독 ─────────
+
+
+class TestNotificationApprovalEvents:
+    """NotificationService의 ApprovalEvent 구독 테스트."""
+
+    async def test_approval_created_with_buttons(self, adapter, eventbus, db):
+        """ApprovalCreatedEvent가 인라인 버튼 메시지를 발송한다."""
+        await db.execute_script(NOTIFICATION_HISTORY_SCHEMA)
+
+        svc = NotificationService(
+            adapter=adapter,
+            eventbus=eventbus,
+            db=db,
+        )
+        await svc.initialize()
+        svc.subscribe()
+
+        event = ApprovalCreatedEvent(
+            approval_id="test-id",
+            approval_type="budget_change",
+            requester="agent",
+            title="예산 증액",
+            auto_approved=False,
+        )
+        await eventbus.publish(event)
+
+        # TelegramAdapter이므로 send_with_buttons 호출
+        adapter.send_with_buttons.assert_called_once()
+        call_args = adapter.send_with_buttons.call_args
+        assert call_args[0][0] == NotificationLevel.INFO
+        assert "결재 요청" in call_args[0][1]
+        assert "예산 증액" in call_args[0][1]
+        # 버튼 확인
+        buttons = call_args[0][2]
+        assert len(buttons) == 1
+        assert buttons[0][0]["callback_data"] == "approve:test-id"
+        assert buttons[0][1]["callback_data"] == "reject:test-id"
+
+    async def test_approval_created_auto_approved(self, adapter, eventbus, db):
+        """자동 승인 시 [자동 승인] 접두사가 포함된다."""
+        await db.execute_script(NOTIFICATION_HISTORY_SCHEMA)
+
+        svc = NotificationService(
+            adapter=adapter,
+            eventbus=eventbus,
+            db=db,
+        )
+        await svc.initialize()
+        svc.subscribe()
+
+        event = ApprovalCreatedEvent(
+            approval_id="test-auto",
+            approval_type="bot_stop",
+            requester="agent",
+            title="봇 중지",
+            auto_approved=True,
+        )
+        await eventbus.publish(event)
+
+        # 자동 승인이므로 send_with_buttons가 아닌 일반 send 호출
+        adapter.send_with_buttons.assert_not_called()
+        adapter.send.assert_called_once()
+        msg = adapter.send.call_args[0][1]
+        assert "[자동 승인]" in msg
+
+    async def test_approval_resolved_event(self, adapter, eventbus, db):
+        """ApprovalResolvedEvent가 결과 메시지를 발송한다."""
+        await db.execute_script(NOTIFICATION_HISTORY_SCHEMA)
+
+        svc = NotificationService(
+            adapter=adapter,
+            eventbus=eventbus,
+            db=db,
+        )
+        await svc.initialize()
+        svc.subscribe()
+
+        event = ApprovalResolvedEvent(
+            approval_id="test-id",
+            approval_type="budget_change",
+            resolution="approved",
+            resolved_by="telegram",
+        )
+        await eventbus.publish(event)
+
+        adapter.send.assert_called_once()
+        msg = adapter.send.call_args[0][1]
+        assert "처리 완료" in msg
+        assert "approved" in msg
+
+    async def test_approval_created_non_telegram_adapter(self, eventbus, db):
+        """TelegramAdapter가 아닌 경우 일반 send로 발송한다."""
+        await db.execute_script(NOTIFICATION_HISTORY_SCHEMA)
+
+        mock_adapter = MagicMock()
+        mock_adapter.send = AsyncMock(return_value=True)
+        mock_adapter.send_rich = AsyncMock(return_value=True)
+
+        svc = NotificationService(
+            adapter=mock_adapter,
+            eventbus=eventbus,
+            db=db,
+        )
+        await svc.initialize()
+        svc.subscribe()
+
+        event = ApprovalCreatedEvent(
+            approval_id="test-id",
+            approval_type="budget_change",
+            requester="agent",
+            title="예산 증액",
+            auto_approved=False,
+        )
+        await eventbus.publish(event)
+
+        # TelegramAdapter가 아니므로 일반 send 호출
+        mock_adapter.send.assert_called_once()


### PR DESCRIPTION
## Summary
- `TelegramAdapter`에 `send_with_buttons()`, `answer_callback_query()` 메서드 추가
- `NotificationService`에 `ApprovalCreatedEvent`/`ApprovalResolvedEvent` 구독 및 핸들러 구현 — 결재 생성 시 인라인 버튼(승인/거절) 포함 메시지 발송, 결재 처리 완료 시 결과 알림
- `TelegramCommandReceiver`에 `callback_query` 처리(인라인 버튼 탭), `/approve <id>`, `/reject <id> [reason]` 텍스트 명령어 추가
- `main.py`에서 `TelegramCommandReceiver` 생성 시 `approval_service` 주입
- 자동 승인 시 "[자동 승인]" 접두사 표시

## Test plan
- [x] `send_with_buttons()` 단위 테스트 (reply_markup 전달 확인)
- [x] `answer_callback_query()` API 호출 테스트
- [x] 인라인 버튼 콜백: 승인/거절/미인가/잘못된 데이터/에러 처리
- [x] `/approve`, `/reject` 텍스트 명령어: 정상/인자 없음/서비스 없음/에러
- [x] `NotificationService` — `ApprovalCreatedEvent` 인라인 버튼 발송, 자동 승인 접두사, 비-Telegram 어댑터 폴백
- [x] `NotificationService` — `ApprovalResolvedEvent` 결과 알림

Refs #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)