### PR TITLE
epic/465: 결재(Approval) 모듈 완성

### DIFF
--- a/src/ante/approval/__init__.py
+++ b/src/ante/approval/__init__.py
@@ -1,7 +1,13 @@
 """Approval — AI Agent 결재 체계."""
 
 from ante.approval.auto_approve import AutoApproveConfig, AutoApproveEvaluator
-from ante.approval.models import ApprovalRequest, ApprovalStatus, ApprovalType
+from ante.approval.models import (
+    ApprovalRequest,
+    ApprovalStatus,
+    ApprovalType,
+    ApprovalValidationError,
+    ValidationResult,
+)
 from ante.approval.service import ApprovalService
 
 __all__ = [
@@ -9,6 +15,8 @@ __all__ = [
     "ApprovalService",
     "ApprovalStatus",
     "ApprovalType",
+    "ApprovalValidationError",
     "AutoApproveConfig",
     "AutoApproveEvaluator",
+    "ValidationResult",
 ]

--- a/src/ante/approval/models.py
+++ b/src/ante/approval/models.py
@@ -21,9 +21,14 @@ class ApprovalType(StrEnum):
     """결재 유형."""
 
     STRATEGY_ADOPT = "strategy_adopt"
-    BUDGET_CHANGE = "budget_change"
+    STRATEGY_RETIRE = "strategy_retire"
     BOT_CREATE = "bot_create"
+    BOT_ASSIGN_STRATEGY = "bot_assign_strategy"
+    BOT_CHANGE_STRATEGY = "bot_change_strategy"
     BOT_STOP = "bot_stop"
+    BOT_RESUME = "bot_resume"
+    BOT_DELETE = "bot_delete"
+    BUDGET_CHANGE = "budget_change"
     RULE_CHANGE = "rule_change"
 
 
@@ -46,3 +51,26 @@ class ApprovalRequest:
     resolved_at: str = ""
     resolved_by: str = ""
     reject_reason: str = ""
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """사전 검증 결과.
+
+    grade:
+        - "fail": 논리적으로 실행 불가능 — 요청 생성 차단
+        - "warn": 판단 여지 있음 — 경고를 reviews에 첨부
+        - "pass": 검증 통과
+    """
+
+    grade: str
+    detail: str
+    reviewer: str
+
+
+class ApprovalValidationError(Exception):
+    """사전 검증 실패 — 요청 생성 차단."""
+
+    def __init__(self, detail: str) -> None:
+        self.detail = detail
+        super().__init__(detail)

--- a/src/ante/approval/models.py
+++ b/src/ante/approval/models.py
@@ -11,6 +11,7 @@ class ApprovalStatus(StrEnum):
 
     PENDING = "pending"
     APPROVED = "approved"
+    EXECUTION_FAILED = "execution_failed"
     REJECTED = "rejected"
     ON_HOLD = "on_hold"
     EXPIRED = "expired"

--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -420,6 +420,122 @@ class ApprovalService:
 
         return request
 
+    async def reopen(
+        self,
+        id: str,
+        requester: str,
+        body: str | None = None,
+        params: dict | None = None,
+    ) -> ApprovalRequest:
+        """거절된 요청을 수정하여 재상신 (rejected → pending).
+
+        body와 params를 갱신할 수 있다. None이면 기존 값 유지.
+        본인 요청만 reopen 가능. 사전 검증(validator)을 재실행한다.
+        """
+        request = await self.get(id)
+        if not request:
+            msg = f"결재 요청을 찾을 수 없음: {id}"
+            raise ValueError(msg)
+
+        # 상태 검증: rejected만 허용
+        if request.status != ApprovalStatus.REJECTED:
+            msg = f"rejected 상태에서만 reopen 가능 (현재: {request.status})"
+            raise ValueError(msg)
+
+        # 권한 검증: 본인 요청만 reopen 가능
+        if request.requester != requester:
+            msg = f"본인 요청만 reopen 가능 (요청자: {request.requester})"
+            raise ValueError(msg)
+
+        # body/params 갱신 (None이면 기존 값 유지)
+        if body is not None:
+            request.body = body
+        if params is not None:
+            request.params = params
+
+        # 사전 검증(validator) 재실행
+        now = datetime.now(UTC).isoformat()
+        validator = self._validators.get(request.type)
+        if validator:
+            results = validator(request.params)
+            for r in results:
+                if r.grade == "fail":
+                    logger.info(
+                        "reopen 사전 검증 실패 (%s): %s — %s",
+                        request.type,
+                        r.reviewer,
+                        r.detail,
+                    )
+                    raise ApprovalValidationError(r.detail)
+                if r.grade == "warn":
+                    request.reviews.append(
+                        {
+                            "reviewer": r.reviewer,
+                            "result": "warn",
+                            "detail": r.detail,
+                            "reviewed_at": now,
+                        }
+                    )
+
+        # 상태 전환 + 이력 기록
+        request.status = ApprovalStatus.PENDING
+        request.reject_reason = ""
+        request.resolved_at = ""
+        request.resolved_by = ""
+
+        detail_parts: list[str] = []
+        if body is not None:
+            detail_parts.append("body 수정")
+        if params is not None:
+            detail_parts.append("params 수정")
+        detail = ", ".join(detail_parts) + " 후 재상신" if detail_parts else "재상신"
+
+        request.history.append(
+            {
+                "action": "reopened",
+                "actor": requester,
+                "at": now,
+                "detail": detail,
+            }
+        )
+
+        # DB 업데이트
+        await self._db.execute(
+            """UPDATE approvals
+               SET status = ?, body = ?, params = ?, reviews = ?,
+                   history = ?, reject_reason = ?,
+                   resolved_at = ?, resolved_by = ?
+               WHERE id = ?""",
+            (
+                ApprovalStatus.PENDING,
+                request.body,
+                json.dumps(request.params, ensure_ascii=False),
+                json.dumps(request.reviews, ensure_ascii=False),
+                json.dumps(request.history, ensure_ascii=False),
+                "",
+                "",
+                "",
+                id,
+            ),
+        )
+
+        logger.info("결재 재상신: %s by %s", id, requester)
+
+        # ApprovalCreatedEvent 재발행 (알림 재발송)
+        from ante.eventbus.events import ApprovalCreatedEvent
+
+        await self._eventbus.publish(
+            ApprovalCreatedEvent(
+                approval_id=request.id,
+                approval_type=request.type,
+                requester=request.requester,
+                title=request.title,
+                auto_approved=False,
+            )
+        )
+
+        return request
+
     async def cancel(
         self,
         id: str,

--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -201,8 +201,42 @@ class ApprovalService:
             if executor:
                 try:
                     await executor(request.params)
+                    request.history.append(
+                        {
+                            "action": "executed",
+                            "actor": "system:auto_approve",
+                            "at": now,
+                            "detail": "",
+                        }
+                    )
+                    await self._db.execute(
+                        """UPDATE approvals SET history = ? WHERE id = ?""",
+                        (
+                            json.dumps(request.history, ensure_ascii=False),
+                            request.id,
+                        ),
+                    )
                     logger.info("전결 실행 완료: %s (%s)", request.id, request.type)
-                except Exception:
+                except Exception as exc:
+                    request.status = ApprovalStatus.EXECUTION_FAILED
+                    request.history.append(
+                        {
+                            "action": "execution_failed",
+                            "actor": "system:auto_approve",
+                            "at": now,
+                            "detail": str(exc),
+                        }
+                    )
+                    await self._db.execute(
+                        """UPDATE approvals
+                           SET status = ?, history = ?
+                           WHERE id = ?""",
+                        (
+                            ApprovalStatus.EXECUTION_FAILED,
+                            json.dumps(request.history, ensure_ascii=False),
+                            request.id,
+                        ),
+                    )
                     logger.exception(
                         "전결 실행 실패: %s (%s)", request.id, request.type
                     )
@@ -214,7 +248,7 @@ class ApprovalService:
                 ApprovalResolvedEvent(
                     approval_id=request.id,
                     approval_type=request.type,
-                    resolution=ApprovalStatus.APPROVED,
+                    resolution=request.status,
                     resolved_by="system:auto_approve",
                 )
             )
@@ -232,8 +266,12 @@ class ApprovalService:
             msg = f"결재 요청을 찾을 수 없음: {id}"
             raise ValueError(msg)
 
-        if request.status != ApprovalStatus.PENDING:
-            msg = f"pending 상태에서만 승인 가능 (현재: {request.status})"
+        approvable = (ApprovalStatus.PENDING, ApprovalStatus.EXECUTION_FAILED)
+        if request.status not in approvable:
+            msg = (
+                "pending/execution_failed 상태에서만 승인 가능"
+                f" (현재: {request.status})"
+            )
             raise ValueError(msg)
 
         now = datetime.now(UTC).isoformat()
@@ -266,9 +304,42 @@ class ApprovalService:
         if executor:
             try:
                 await executor(request.params)
+                request.history.append(
+                    {
+                        "action": "executed",
+                        "actor": resolved_by,
+                        "at": now,
+                        "detail": "",
+                    }
+                )
                 logger.info("결재 실행 완료: %s (%s)", id, request.type)
-            except Exception:
+            except Exception as exc:
+                request.status = ApprovalStatus.EXECUTION_FAILED
+                request.history.append(
+                    {
+                        "action": "execution_failed",
+                        "actor": resolved_by,
+                        "at": now,
+                        "detail": str(exc),
+                    }
+                )
+                await self._db.execute(
+                    """UPDATE approvals
+                       SET status = ?, history = ?
+                       WHERE id = ?""",
+                    (
+                        ApprovalStatus.EXECUTION_FAILED,
+                        json.dumps(request.history, ensure_ascii=False),
+                        id,
+                    ),
+                )
                 logger.exception("결재 실행 실패: %s (%s)", id, request.type)
+            else:
+                # 실행 성공 시 history만 갱신
+                await self._db.execute(
+                    """UPDATE approvals SET history = ? WHERE id = ?""",
+                    (json.dumps(request.history, ensure_ascii=False), id),
+                )
 
         # ApprovalResolvedEvent 발행
         from ante.eventbus.events import ApprovalResolvedEvent
@@ -277,7 +348,7 @@ class ApprovalService:
             ApprovalResolvedEvent(
                 approval_id=id,
                 approval_type=request.type,
-                resolution=ApprovalStatus.APPROVED,
+                resolution=request.status,
                 resolved_by=resolved_by,
             )
         )
@@ -296,8 +367,12 @@ class ApprovalService:
             msg = f"결재 요청을 찾을 수 없음: {id}"
             raise ValueError(msg)
 
-        if request.status != ApprovalStatus.PENDING:
-            msg = f"pending 상태에서만 거절 가능 (현재: {request.status})"
+        rejectable = (ApprovalStatus.PENDING, ApprovalStatus.EXECUTION_FAILED)
+        if request.status not in rejectable:
+            msg = (
+                "pending/execution_failed 상태에서만 거절 가능"
+                f" (현재: {request.status})"
+            )
             raise ValueError(msg)
 
         now = datetime.now(UTC).isoformat()
@@ -360,8 +435,16 @@ class ApprovalService:
             msg = f"본인 요청만 철회 가능 (요청자: {request.requester})"
             raise ValueError(msg)
 
-        if request.status not in (ApprovalStatus.PENDING, ApprovalStatus.ON_HOLD):
-            msg = f"pending/on_hold 상태에서만 철회 가능 (현재: {request.status})"
+        cancellable = (
+            ApprovalStatus.PENDING,
+            ApprovalStatus.ON_HOLD,
+            ApprovalStatus.EXECUTION_FAILED,
+        )
+        if request.status not in cancellable:
+            msg = (
+                "pending/on_hold/execution_failed 상태에서만 철회 가능"
+                f" (현재: {request.status})"
+            )
             raise ValueError(msg)
 
         now = datetime.now(UTC).isoformat()
@@ -409,8 +492,12 @@ class ApprovalService:
             msg = f"결재 요청을 찾을 수 없음: {id}"
             raise ValueError(msg)
 
-        if request.status != ApprovalStatus.PENDING:
-            msg = f"pending 상태에서만 보류 가능 (현재: {request.status})"
+        holdable = (ApprovalStatus.PENDING, ApprovalStatus.EXECUTION_FAILED)
+        if request.status not in holdable:
+            msg = (
+                "pending/execution_failed 상태에서만 보류 가능"
+                f" (현재: {request.status})"
+            )
             raise ValueError(msg)
 
         now = datetime.now(UTC).isoformat()

--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -9,7 +9,12 @@ from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from ante.approval.auto_approve import AutoApproveEvaluator
-from ante.approval.models import ApprovalRequest, ApprovalStatus
+from ante.approval.models import (
+    ApprovalRequest,
+    ApprovalStatus,
+    ApprovalValidationError,
+    ValidationResult,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -50,11 +55,13 @@ class ApprovalService:
         db: Database,
         eventbus: EventBus,
         executors: dict[str, Callable[..., Awaitable]] | None = None,
+        validators: dict[str, Callable[..., list[ValidationResult]]] | None = None,
         auto_approve_evaluator: AutoApproveEvaluator | None = None,
     ) -> None:
         self._db = db
         self._eventbus = eventbus
         self._executors = executors or {}
+        self._validators = validators or {}
         self._auto_approve = auto_approve_evaluator or AutoApproveEvaluator()
 
     async def initialize(self) -> None:
@@ -77,6 +84,30 @@ class ApprovalService:
         now = datetime.now(UTC).isoformat()
         params = params or {}
 
+        # 사전 검증 (validator)
+        reviews: list[dict] = []
+        validator = self._validators.get(type)
+        if validator:
+            results = validator(params)
+            for r in results:
+                if r.grade == "fail":
+                    logger.info(
+                        "사전 검증 실패 (%s): %s — %s",
+                        type,
+                        r.reviewer,
+                        r.detail,
+                    )
+                    raise ApprovalValidationError(r.detail)
+                if r.grade == "warn":
+                    reviews.append(
+                        {
+                            "reviewer": r.reviewer,
+                            "result": "warn",
+                            "detail": r.detail,
+                            "reviewed_at": now,
+                        }
+                    )
+
         history = [
             {
                 "action": "created",
@@ -94,7 +125,7 @@ class ApprovalService:
             title=title,
             body=body,
             params=params,
-            reviews=[],
+            reviews=reviews,
             history=history,
             reference_id=reference_id,
             expires_at=expires_at,

--- a/src/ante/cli/commands/approval.py
+++ b/src/ante/cli/commands/approval.py
@@ -241,6 +241,71 @@ def review(
         raise SystemExit(1) from e
 
 
+@approval.command("reopen")
+@click.argument("id")
+@click.option("--body", default=None, help="수정할 본문 (미지정 시 기존 값 유지)")
+@click.option(
+    "--params",
+    "params_json",
+    default=None,
+    help="수정할 파라미터 (JSON, 미지정 시 기존 값 유지)",
+)
+@click.option("--db-path", default="db/ante.db", help="DB 경로")
+@click.pass_context
+@require_auth
+@require_scope("approval:write")
+def reopen(
+    ctx: click.Context,
+    id: str,
+    body: str | None,
+    params_json: str | None,
+    db_path: str,
+) -> None:
+    """거절된 결재 재상신."""
+    fmt = get_formatter(ctx)
+    requester = get_member_id(ctx)
+
+    params = None
+    if params_json is not None:
+        try:
+            params = json.loads(params_json)
+        except json.JSONDecodeError as e:
+            fmt.error(f"잘못된 JSON 형식: {e}", code="INVALID_JSON")
+            raise SystemExit(1) from e
+
+    async def _reopen() -> dict:
+        from ante.approval import ApprovalService
+        from ante.core.database import Database
+        from ante.eventbus.bus import EventBus
+
+        db = Database(db_path)
+        await db.connect()
+        eventbus = EventBus()
+        service = ApprovalService(db=db, eventbus=eventbus)
+        await service.initialize()
+
+        req = await service.reopen(
+            id=id,
+            requester=requester,
+            body=body,
+            params=params,
+        )
+        await db.close()
+        return {
+            "id": req.id,
+            "type": req.type,
+            "status": req.status,
+            "title": req.title,
+        }
+
+    try:
+        result = asyncio.run(_reopen())
+        fmt.success(f"결재 재상신: {result['id']}", result)
+    except Exception as e:
+        fmt.error(str(e), code="APPROVAL_ERROR")
+        raise SystemExit(1) from e
+
+
 @approval.command("cancel")
 @click.argument("id")
 @click.option("--db-path", default="db/ante.db", help="DB 경로")

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -667,6 +667,7 @@ async def _init_notification(s: Services) -> None:
             bot_manager=s.bot_manager,
             treasury=s.treasury,
             system_state=s.system_state,
+            approval_service=s.approval_service,
         )
         s.telegram_receiver.start()
         logger.info("TelegramCommandReceiver 시작")

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -55,6 +55,7 @@ class Services:
     notification_service: Any = None
     telegram_receiver: Any = None
     web_task: asyncio.Task | None = None  # type: ignore[type-arg]
+    approval_expire_task: asyncio.Task | None = None  # type: ignore[type-arg]
     commission_rate: float = 0.00015
     sell_tax_rate: float = 0.0023
     _cleanup_tasks: list[str] = field(default_factory=list)
@@ -463,6 +464,30 @@ async def _init_feed(s: Services) -> None:
     await s.approval_service.initialize()
     logger.info("ApprovalService 초기화 완료")
 
+    # 결재 만료 스케줄러 등록
+    s.approval_expire_task = asyncio.create_task(
+        _approval_expire_loop(s.approval_service),
+        name="approval-expire",
+    )
+    logger.info("결재 만료 스케줄러 시작 (주기: 300초)")
+
+
+async def _approval_expire_loop(
+    approval_service: Any,
+    interval: float = 300.0,
+) -> None:
+    """만료 기한이 지난 결재 요청을 주기적으로 expired 처리."""
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            expired = await approval_service.expire_stale()
+            if expired:
+                logger.info("결재 만료 처리: %d건", expired)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("결재 만료 스케줄러 오류")
+
 
 async def _init_notification(s: Services) -> None:
     """NotificationService, TelegramCommandReceiver 초기화."""
@@ -587,6 +612,14 @@ async def _shutdown(s: Services) -> None:
     if s.telegram_receiver:
         await s.telegram_receiver.stop()
         logger.info("TelegramCommandReceiver 종료")
+
+    if s.approval_expire_task and not s.approval_expire_task.done():
+        s.approval_expire_task.cancel()
+        try:
+            await s.approval_expire_task
+        except asyncio.CancelledError:
+            pass
+        logger.info("결재 만료 스케줄러 종료")
 
     if s.web_task and not s.web_task.done():
         s.web_task.cancel()

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -416,6 +416,7 @@ async def _init_feed(s: Services) -> None:
     # ApprovalService
     from ante.approval import ApprovalService
     from ante.approval.auto_approve import AutoApproveConfig, AutoApproveEvaluator
+    from ante.approval.models import ValidationResult
 
     async def _exec_rule_change(params: dict) -> None:
         s.rule_engine.update_rules(params["bot_id"], params["rules"])
@@ -446,6 +447,139 @@ async def _init_feed(s: Services) -> None:
         "rule_change": _exec_rule_change,
     }
 
+    # 사전 검증 validator 정의
+    from ante.bot.config import BotStatus
+
+    def _validate_strategy_retire(params: dict) -> list[ValidationResult]:
+        """전략 폐기 사전 검증: 사용 중인 봇 존재 여부."""
+        strategy_id = params.get("strategy_id", "")
+        bots = [
+            b for b in s.bot_manager.list_bots() if b.get("strategy_id") == strategy_id
+        ]
+        if bots:
+            return [
+                ValidationResult(
+                    "fail",
+                    f"전략을 사용 중인 봇 {len(bots)}개 존재",
+                    "system:bot_manager",
+                )
+            ]
+        return [ValidationResult("pass", "", "system:bot_manager")]
+
+    def _validate_bot_create(params: dict) -> list[ValidationResult]:
+        """봇 생성 사전 검증: 전략 adopted 상태, 동일 봇 미존재."""
+        results: list[ValidationResult] = []
+        bot_id = params.get("bot_id", "")
+        if bot_id and s.bot_manager.get_bot(bot_id):
+            results.append(
+                ValidationResult(
+                    "fail",
+                    f"동일 ID의 봇이 이미 존재: {bot_id}",
+                    "system:bot_manager",
+                )
+            )
+        strategy_id = params.get("strategy_id", "")
+        if strategy_id:
+            # strategy_id로 리포트 확인은 비동기 — 동기 호출 불가이므로
+            # 이 검증은 executor 2단계 검증에 위임
+            pass
+        return results or [ValidationResult("pass", "", "system:bot_manager")]
+
+    def _validate_bot_delete(params: dict) -> list[ValidationResult]:
+        """봇 삭제 사전 검증: stopped 상태, 보유 포지션 없음."""
+        results: list[ValidationResult] = []
+        bot_id = params.get("bot_id", "")
+        bot = s.bot_manager.get_bot(bot_id)
+        if not bot:
+            return [
+                ValidationResult("fail", "봇이 존재하지 않음", "system:bot_manager")
+            ]
+        if bot.status != BotStatus.STOPPED:
+            results.append(
+                ValidationResult(
+                    "fail",
+                    f"봇이 {bot.status} 상태 (stopped 필요)",
+                    "system:bot_manager",
+                )
+            )
+        positions = s.position_history.get_positions_sync(bot_id)
+        if positions:
+            results.append(
+                ValidationResult(
+                    "fail",
+                    f"보유 포지션 {len(positions)}건 존재",
+                    "system:trade",
+                )
+            )
+        return results or [ValidationResult("pass", "", "system:bot_manager")]
+
+    def _validate_bot_change_strategy(params: dict) -> list[ValidationResult]:
+        """봇 전략 변경 사전 검증: stopped 상태 확인."""
+        bot_id = params.get("bot_id", "")
+        bot = s.bot_manager.get_bot(bot_id)
+        if not bot:
+            return [
+                ValidationResult("fail", "봇이 존재하지 않음", "system:bot_manager")
+            ]
+        if bot.status != BotStatus.STOPPED:
+            return [
+                ValidationResult(
+                    "fail",
+                    f"봇이 {bot.status} 상태 (stopped 필요)",
+                    "system:bot_manager",
+                )
+            ]
+        return [ValidationResult("pass", "", "system:bot_manager")]
+
+    def _validate_bot_assign_strategy(params: dict) -> list[ValidationResult]:
+        """봇 전략 배정 사전 검증: 전략 adopted 상태 확인."""
+        # 전략 상태 확인은 비동기 조회가 필요하므로 executor 2단계에 위임
+        return [ValidationResult("pass", "", "system:report_store")]
+
+    def _validate_bot_resume(params: dict) -> list[ValidationResult]:
+        """봇 재개 사전 검증: stopped/error 상태 확인."""
+        bot_id = params.get("bot_id", "")
+        bot = s.bot_manager.get_bot(bot_id)
+        if not bot:
+            return [
+                ValidationResult("fail", "봇이 존재하지 않음", "system:bot_manager")
+            ]
+        if bot.status not in (BotStatus.STOPPED, BotStatus.ERROR):
+            return [
+                ValidationResult(
+                    "fail",
+                    f"봇이 {bot.status} 상태 (stopped/error 필요)",
+                    "system:bot_manager",
+                )
+            ]
+        return [ValidationResult("pass", "", "system:bot_manager")]
+
+    def _validate_budget_change(params: dict) -> list[ValidationResult]:
+        """예산 변경 사전 검증: 미할당 잔액 충분 여부 (warn)."""
+        amount = float(params.get("amount", 0))
+        current = float(params.get("current", 0))
+        amount_diff = amount - current
+        if amount_diff > 0 and amount_diff > s.treasury.unallocated:
+            return [
+                ValidationResult(
+                    "warn",
+                    f"미할당 잔액({s.treasury.unallocated:,.0f}원) "
+                    f"< 증액분({amount_diff:,.0f}원)",
+                    "system:treasury",
+                )
+            ]
+        return [ValidationResult("pass", "", "system:treasury")]
+
+    approval_validators: dict = {
+        "strategy_retire": _validate_strategy_retire,
+        "bot_create": _validate_bot_create,
+        "bot_delete": _validate_bot_delete,
+        "bot_change_strategy": _validate_bot_change_strategy,
+        "bot_assign_strategy": _validate_bot_assign_strategy,
+        "bot_resume": _validate_bot_resume,
+        "budget_change": _validate_budget_change,
+    }
+
     # 전결 설정 로딩
     auto_approve_raw = s.config.get("approval.auto_approve", {})
     auto_approve_config = AutoApproveConfig.from_dict(
@@ -459,6 +593,7 @@ async def _init_feed(s: Services) -> None:
         db=s.db,
         eventbus=s.eventbus,
         executors=approval_executors,
+        validators=approval_validators,
         auto_approve_evaluator=auto_approve_evaluator,
     )
     await s.approval_service.initialize()

--- a/src/ante/notification/service.py
+++ b/src/ante/notification/service.py
@@ -120,6 +120,19 @@ class NotificationService:
             priority=0,
         )
 
+        from ante.eventbus.events import ApprovalCreatedEvent, ApprovalResolvedEvent
+
+        self._eventbus.subscribe(
+            ApprovalCreatedEvent,
+            self._on_approval_created,
+            priority=0,
+        )
+        self._eventbus.subscribe(
+            ApprovalResolvedEvent,
+            self._on_approval_resolved,
+            priority=0,
+        )
+
     def _make_dedup_key(self, level: NotificationLevel, message: str) -> str:
         """중복 방지 키 생성: level + message_hash."""
         import hashlib
@@ -462,6 +475,89 @@ class NotificationService:
             level,
             msg,
             event_type="CircuitBreakerEvent",
+        )
+
+    async def _on_approval_created(self, event: object) -> None:
+        """결재 요청 생성 알림 (인라인 버튼 포함)."""
+        from ante.eventbus.events import ApprovalCreatedEvent
+        from ante.notification.templates import APPROVAL_CREATED
+
+        if not isinstance(event, ApprovalCreatedEvent):
+            return
+
+        prefix = "[자동 승인] 📋 " if event.auto_approved else "📋 "
+        msg = APPROVAL_CREATED.format(
+            prefix=prefix,
+            approval_type=event.approval_type,
+            title=event.title,
+            requester=event.requester,
+            approval_id=event.approval_id,
+        )
+
+        # 자동 승인이 아닌 경우 인라인 버튼 포함 발송 시도
+        if not event.auto_approved:
+            from ante.notification.telegram import TelegramAdapter
+
+            if isinstance(self._adapter, TelegramAdapter):
+                buttons = [
+                    [
+                        {
+                            "text": "\u2705 승인",
+                            "callback_data": f"approve:{event.approval_id}",
+                        },
+                        {
+                            "text": "\u274c 거절",
+                            "callback_data": f"reject:{event.approval_id}",
+                        },
+                    ]
+                ]
+                success = False
+                error_message = ""
+                try:
+                    success = await self._adapter.send_with_buttons(
+                        NotificationLevel.INFO, msg, buttons
+                    )
+                except Exception as e:
+                    error_message = str(e)
+                    logger.warning("결재 알림 발송 실패: %s", e)
+
+                await self._record_history(
+                    level=NotificationLevel.INFO,
+                    title="결재 요청",
+                    message=msg,
+                    success=success,
+                    error_message=error_message,
+                    event_type="ApprovalCreatedEvent",
+                )
+                return
+
+        # 자동 승인 또는 TelegramAdapter가 아닌 경우 일반 발송
+        await self._send_and_record(
+            NotificationLevel.INFO,
+            msg,
+            title="결재 요청",
+            event_type="ApprovalCreatedEvent",
+        )
+
+    async def _on_approval_resolved(self, event: object) -> None:
+        """결재 처리 완료 알림."""
+        from ante.eventbus.events import ApprovalResolvedEvent
+        from ante.notification.templates import APPROVAL_RESOLVED
+
+        if not isinstance(event, ApprovalResolvedEvent):
+            return
+
+        msg = APPROVAL_RESOLVED.format(
+            approval_type=event.approval_type,
+            resolution=event.resolution,
+            resolved_by=event.resolved_by,
+            approval_id=event.approval_id,
+        )
+        await self._send_and_record(
+            NotificationLevel.INFO,
+            msg,
+            title="결재 처리 완료",
+            event_type="ApprovalResolvedEvent",
         )
 
     def _should_send(self, level: NotificationLevel) -> bool:

--- a/src/ante/notification/telegram.py
+++ b/src/ante/notification/telegram.py
@@ -46,7 +46,59 @@ class TelegramAdapter(NotificationAdapter):
         text = "\n".join(parts)
         return await self._send_message(text, parse_mode="Markdown")
 
-    async def _send_message(self, text: str, parse_mode: str = "") -> bool:
+    async def send_with_buttons(
+        self,
+        level: NotificationLevel,
+        message: str,
+        buttons: list[list[dict]],
+    ) -> bool:
+        """인라인 버튼이 포함된 알림 발송.
+
+        Args:
+            level: 알림 레벨.
+            message: 메시지 본문.
+            buttons: 인라인 키보드 버튼 행 목록.
+                [[{"text": "승인", "callback_data": "approve:id"}, ...], ...]
+        """
+        emoji = LEVEL_EMOJI.get(level, "\U0001f4cc")
+        text = f"{emoji} {message}"
+        reply_markup = {
+            "inline_keyboard": buttons,
+        }
+        return await self._send_message(
+            text, parse_mode="Markdown", reply_markup=reply_markup
+        )
+
+    async def answer_callback_query(
+        self,
+        callback_query_id: str,
+        text: str = "",
+    ) -> bool:
+        """answerCallbackQuery API 호출 (버튼 로딩 해제)."""
+        try:
+            import aiohttp
+        except ImportError:
+            return False
+
+        url = f"{self._api_base}/answerCallbackQuery"
+        payload: dict = {"callback_query_id": callback_query_id}
+        if text:
+            payload["text"] = text
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, json=payload) as resp:
+                    return resp.status == 200
+        except Exception as e:
+            logger.warning("answerCallbackQuery 오류: %s", e)
+            return False
+
+    async def _send_message(
+        self,
+        text: str,
+        parse_mode: str = "",
+        reply_markup: dict | None = None,
+    ) -> bool:
         """텔레그램 sendMessage API 호출."""
         try:
             import aiohttp
@@ -63,6 +115,8 @@ class TelegramAdapter(NotificationAdapter):
         }
         if parse_mode:
             payload["parse_mode"] = parse_mode
+        if reply_markup:
+            payload["reply_markup"] = reply_markup
 
         try:
             async with aiohttp.ClientSession() as session:

--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -9,6 +9,7 @@ from inspect import isawaitable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from ante.approval.service import ApprovalService
     from ante.bot.manager import BotManager
     from ante.config.system_state import SystemState
     from ante.notification.telegram import TelegramAdapter
@@ -33,6 +34,7 @@ class TelegramCommandReceiver:
         bot_manager: BotManager | None = None,
         treasury: Treasury | None = None,
         system_state: SystemState | None = None,
+        approval_service: ApprovalService | None = None,
     ) -> None:
         self._adapter = adapter
         self._allowed_user_ids = set(allowed_user_ids or [])
@@ -41,6 +43,7 @@ class TelegramCommandReceiver:
         self._bot_manager = bot_manager
         self._treasury = treasury
         self._system_state = system_state
+        self._approval_service = approval_service
 
         self._offset: int = 0
         self._task: asyncio.Task[None] | None = None
@@ -125,6 +128,11 @@ class TelegramCommandReceiver:
 
     async def _handle_update(self, update: dict[str, Any]) -> None:
         """개별 업데이트 처리."""
+        # callback_query (인라인 버튼) 처리
+        if "callback_query" in update:
+            await self._handle_callback_query(update["callback_query"])
+            return
+
         message = update.get("message")
         if not message:
             return
@@ -156,6 +164,58 @@ class TelegramCommandReceiver:
         if reply:
             await self._reply(chat_id, reply)
 
+    async def _handle_callback_query(self, callback_query: dict[str, Any]) -> None:
+        """인라인 버튼 콜백 처리 (결재 승인/거절)."""
+        callback_id = callback_query.get("id", "")
+        user = callback_query.get("from", {})
+        user_id = user.get("id", 0)
+        chat_id = callback_query.get("message", {}).get("chat", {}).get("id")
+        data = callback_query.get("data", "")
+
+        if not self._is_authorized(user_id):
+            logger.warning("미인가 콜백 시도: user_id=%d, data=%s", user_id, data)
+            await self._adapter.answer_callback_query(callback_id, "권한이 없습니다.")
+            return
+
+        if not self._approval_service:
+            await self._adapter.answer_callback_query(
+                callback_id, "ApprovalService가 연결되지 않았습니다."
+            )
+            return
+
+        # data 형식: "approve:{id}" 또는 "reject:{id}"
+        if ":" not in data:
+            await self._adapter.answer_callback_query(callback_id, "잘못된 요청입니다.")
+            return
+
+        action, approval_id = data.split(":", 1)
+
+        try:
+            if action == "approve":
+                await self._approval_service.approve(
+                    approval_id, resolved_by="telegram"
+                )
+                result_msg = f"결재 승인 완료: {approval_id}"
+            elif action == "reject":
+                await self._approval_service.reject(
+                    approval_id, resolved_by="telegram", reject_reason="사용자 거절"
+                )
+                result_msg = f"결재 거절 완료: {approval_id}"
+            else:
+                await self._adapter.answer_callback_query(
+                    callback_id, "알 수 없는 동작입니다."
+                )
+                return
+        except ValueError as e:
+            result_msg = f"처리 실패: {e}"
+        except Exception:
+            logger.exception("콜백 결재 처리 오류: %s", data)
+            result_msg = "처리 중 오류가 발생했습니다."
+
+        await self._adapter.answer_callback_query(callback_id, result_msg)
+        if chat_id:
+            await self._reply(chat_id, result_msg)
+
     def _is_authorized(self, user_id: int) -> bool:
         """화이트리스트 인증 확인."""
         return user_id in self._allowed_user_ids
@@ -185,6 +245,8 @@ class TelegramCommandReceiver:
             "bots": self._cmd_bots,
             "balance": self._cmd_balance,
             "activate": self._cmd_activate,
+            "approve": self._cmd_approve,
+            "reject": self._cmd_reject,
         }
 
         handler = handlers.get(command)
@@ -246,6 +308,8 @@ class TelegramCommandReceiver:
             "/halt [reason] — 전체 거래 중지 (확인 필요)\n"
             "/activate — 거래 재개\n"
             "/stop <bot_id> — 특정 봇 중지 (확인 필요)\n"
+            "/approve <id> — 결재 승인\n"
+            "/reject <id> [reason] — 결재 거절\n"
             "/help — 이 도움말"
         )
 
@@ -301,6 +365,43 @@ class TelegramCommandReceiver:
             f"할당: {allocated:,.0f}원 ({bot_count}개 봇)\n"
             f"미할당: {unallocated:,.0f}원"
         )
+
+    async def _cmd_approve(self, args: list[str]) -> str:
+        """결재 승인. /approve <id>"""
+        if not self._approval_service:
+            return "ApprovalService가 연결되지 않았습니다."
+        if not args:
+            return "결재 ID를 지정해 주세요. 예: /approve abc123"
+
+        approval_id = args[0]
+        try:
+            await self._approval_service.approve(approval_id, resolved_by="telegram")
+            return f"결재 승인 완료: {approval_id}"
+        except ValueError as e:
+            return f"승인 실패: {e}"
+        except Exception:
+            logger.exception("결재 승인 오류: %s", approval_id)
+            return "승인 처리 중 오류가 발생했습니다."
+
+    async def _cmd_reject(self, args: list[str]) -> str:
+        """결재 거절. /reject <id> [reason]"""
+        if not self._approval_service:
+            return "ApprovalService가 연결되지 않았습니다."
+        if not args:
+            return "결재 ID를 지정해 주세요. 예: /reject abc123 사유"
+
+        approval_id = args[0]
+        reason = " ".join(args[1:]) if len(args) > 1 else "사용자 거절"
+        try:
+            await self._approval_service.reject(
+                approval_id, resolved_by="telegram", reject_reason=reason
+            )
+            return f"결재 거절 완료: {approval_id} (사유: {reason})"
+        except ValueError as e:
+            return f"거절 실패: {e}"
+        except Exception:
+            logger.exception("결재 거절 오류: %s", approval_id)
+            return "거절 처리 중 오류가 발생했습니다."
 
     async def _cmd_halt(self, args: list[str]) -> str:
         """전체 거래 중지."""

--- a/src/ante/notification/templates.py
+++ b/src/ante/notification/templates.py
@@ -41,3 +41,21 @@ ORDER_FILLED = (
     "종목: *{display}*\n"
     "{side} {quantity}주 @ {price:,.0f}원"
 )
+
+# ── 결재 (Approval) ──────────────────────────
+
+APPROVAL_CREATED = (
+    "{prefix}*결재 요청*\n"
+    "유형: `{approval_type}`\n"
+    "제목: {title}\n"
+    "요청자: `{requester}`\n"
+    "ID: `{approval_id}`"
+)
+
+APPROVAL_RESOLVED = (
+    "📋 *결재 처리 완료*\n"
+    "유형: `{approval_type}`\n"
+    "결과: *{resolution}*\n"
+    "처리자: `{resolved_by}`\n"
+    "ID: `{approval_id}`"
+)

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -126,6 +126,9 @@ async def get_strategy(
     strategy_dict["status"] = (
         record.status.value if hasattr(record.status, "value") else str(record.status)
     )
+    # datetime → str 변환 (response_model 호환)
+    if hasattr(record.registered_at, "isoformat"):
+        strategy_dict["registered_at"] = record.registered_at.isoformat()
 
     bot_info = None
     if bot_manager is not None:

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -217,7 +217,14 @@ async def list_budgets(
     from dataclasses import asdict
 
     budgets = treasury.list_budgets()
-    return {"budgets": [asdict(b) for b in budgets]}
+    items = []
+    for b in budgets:
+        d = asdict(b)
+        # datetime → str 변환 (response_model 호환)
+        if hasattr(b.last_updated, "isoformat"):
+            d["last_updated"] = b.last_updated.isoformat()
+        items.append(d)
+    return {"budgets": items}
 
 
 @router.post(

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -850,3 +850,230 @@ class TestValidationModels:
         assert ApprovalType.BOT_CHANGE_STRATEGY == "bot_change_strategy"
         assert ApprovalType.BOT_RESUME == "bot_resume"
         assert ApprovalType.BOT_DELETE == "bot_delete"
+
+
+class TestExecutionFailed:
+    async def test_executor_failure_transitions_to_execution_failed(self, db, eventbus):
+        """executor 실패 시 execution_failed 상태로 전환."""
+
+        async def failing_executor(params: dict) -> None:
+            msg = "잔액 부족"
+            raise RuntimeError(msg)
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"budget_change": failing_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="실행 실패 테스트",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        result = await svc.approve(req.id)
+
+        assert result.status == "execution_failed"
+        assert any(h["action"] == "execution_failed" for h in result.history)
+        # 에러 메시지가 history에 기록
+        failed_entry = next(
+            h for h in result.history if h["action"] == "execution_failed"
+        )
+        assert "잔액 부족" in failed_entry["detail"]
+
+    async def test_execution_failed_persisted_in_db(self, db, eventbus):
+        """execution_failed 상태가 DB에 영속화."""
+
+        async def failing_executor(params: dict) -> None:
+            msg = "봇 미존재"
+            raise RuntimeError(msg)
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"bot_stop": failing_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="bot_stop",
+            requester="agent",
+            title="영속화 테스트",
+            params={"bot_id": "bot-1"},
+        )
+        await svc.approve(req.id)
+
+        fetched = await svc.get(req.id)
+        assert fetched is not None
+        assert fetched.status == "execution_failed"
+        assert any(h["action"] == "execution_failed" for h in fetched.history)
+
+    async def test_reapprove_after_execution_failed(self, db, eventbus):
+        """execution_failed 상태에서 재승인 → executor 재실행."""
+        call_count = 0
+
+        async def flaky_executor(params: dict) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                msg = "일시적 오류"
+                raise RuntimeError(msg)
+            # 두 번째 호출은 성공
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"budget_change": flaky_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="재승인 테스트",
+            params={"bot_id": "bot-1", "amount": 10000000},
+        )
+        failed = await svc.approve(req.id)
+        assert failed.status == "execution_failed"
+
+        # 재승인
+        success = await svc.approve(req.id)
+        assert success.status == "approved"
+        assert call_count == 2
+        assert any(h["action"] == "executed" for h in success.history)
+
+    async def test_reject_after_execution_failed(self, db, eventbus):
+        """execution_failed 상태에서 거절 가능."""
+
+        async def failing_executor(params: dict) -> None:
+            msg = "실패"
+            raise RuntimeError(msg)
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"budget_change": failing_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="거절 테스트",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        await svc.approve(req.id)
+        rejected = await svc.reject(req.id, reject_reason="원인 해소 불가")
+
+        assert rejected.status == "rejected"
+        assert rejected.reject_reason == "원인 해소 불가"
+
+    async def test_hold_after_execution_failed(self, db, eventbus):
+        """execution_failed 상태에서 보류 가능."""
+
+        async def failing_executor(params: dict) -> None:
+            msg = "실패"
+            raise RuntimeError(msg)
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"budget_change": failing_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="보류 테스트",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        await svc.approve(req.id)
+        held = await svc.hold(req.id)
+
+        assert held.status == "on_hold"
+
+    async def test_cancel_after_execution_failed(self, db, eventbus):
+        """execution_failed 상태에서 철회 가능."""
+
+        async def failing_executor(params: dict) -> None:
+            msg = "실패"
+            raise RuntimeError(msg)
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"budget_change": failing_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent:dev",
+            title="철회 테스트",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        await svc.approve(req.id)
+        cancelled = await svc.cancel(req.id, requester="agent:dev")
+
+        assert cancelled.status == "cancelled"
+
+    async def test_execution_failed_publishes_event(self, db, eventbus):
+        """executor 실패 시 ApprovalResolvedEvent에 execution_failed resolution."""
+        received = []
+
+        async def handler(event: object) -> None:
+            if isinstance(event, ApprovalResolvedEvent):
+                received.append(event)
+
+        eventbus.subscribe(ApprovalResolvedEvent, handler)
+
+        async def failing_executor(params: dict) -> None:
+            msg = "실패"
+            raise RuntimeError(msg)
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"budget_change": failing_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="이벤트 테스트",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        await svc.approve(req.id)
+
+        assert len(received) == 1
+        assert received[0].resolution == "execution_failed"
+
+    async def test_list_filter_execution_failed(self, db, eventbus):
+        """execution_failed 상태 필터 조회."""
+
+        async def failing_executor(params: dict) -> None:
+            msg = "실패"
+            raise RuntimeError(msg)
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            executors={"budget_change": failing_executor},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="필터 테스트",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        await svc.approve(req.id)
+
+        failed_list = await svc.list(status="execution_failed")
+        assert len(failed_list) == 1
+        assert failed_list[0].status == "execution_failed"

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -520,6 +520,109 @@ class TestExpire:
         count = await service.expire_stale()
         assert count == 0
 
+    async def test_expire_event_published(self, service, eventbus):
+        """만료 처리 시 건별 ApprovalResolvedEvent가 발행된다."""
+        past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        await service.create(
+            type="budget_change",
+            requester="agent",
+            title="만료 이벤트 테스트",
+            expires_at=past,
+        )
+
+        received: list[ApprovalResolvedEvent] = []
+
+        async def _handler(event: ApprovalResolvedEvent) -> None:
+            received.append(event)
+
+        eventbus.subscribe(ApprovalResolvedEvent, _handler)
+
+        count = await service.expire_stale()
+        assert count == 1
+        assert len(received) == 1
+        assert received[0].resolution == ApprovalStatus.EXPIRED
+        assert received[0].resolved_by == "system"
+
+
+# ── 만료 스케줄러 (US-8) ──────────────────────────────
+
+
+class TestExpireLoop:
+    @staticmethod
+    async def _expire_loop(approval_service, interval: float = 300.0):
+        """main._approval_expire_loop과 동일한 로직 (테스트용 복제)."""
+        import asyncio
+
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                expired = await approval_service.expire_stale()
+                if expired:
+                    pass  # 로깅 생략
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                pass  # 로깅 생략
+
+    async def test_expire_loop_calls_expire_stale(self):
+        """만료 스케줄러가 주기적으로 expire_stale()을 호출한다."""
+        import asyncio
+
+        call_count = 0
+
+        class FakeApprovalService:
+            async def expire_stale(self) -> int:
+                nonlocal call_count
+                call_count += 1
+                return call_count
+
+        fake_service = FakeApprovalService()
+        task = asyncio.create_task(
+            self._expire_loop(fake_service, interval=0.01),
+            name="test-expire-loop",
+        )
+
+        # 짧은 interval로 최소 2회 호출될 때까지 대기
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert call_count >= 2
+
+    async def test_expire_loop_survives_error(self):
+        """expire_stale()이 예외를 던져도 루프가 계속된다."""
+        import asyncio
+
+        call_count = 0
+
+        class FlakyApprovalService:
+            async def expire_stale(self) -> int:
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    msg = "일시적 DB 오류"
+                    raise RuntimeError(msg)
+                return 0
+
+        fake_service = FlakyApprovalService()
+        task = asyncio.create_task(
+            self._expire_loop(fake_service, interval=0.01),
+            name="test-expire-loop-error",
+        )
+
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        # 첫 번째에서 예외가 발생해도 두 번째 이후 호출이 이루어져야 한다
+        assert call_count >= 2
+
 
 # ── 이벤트 모델 (US-7) ──────────────────────────────
 

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -272,7 +272,9 @@ class TestResolve:
         )
         await service.approve(req.id)
 
-        with pytest.raises(ValueError, match="pending 상태에서만 승인 가능"):
+        with pytest.raises(
+            ValueError, match="pending/execution_failed 상태에서만 승인 가능"
+        ):
             await service.approve(req.id)
 
     async def test_reject(self, service):
@@ -293,7 +295,9 @@ class TestResolve:
         )
         await service.reject(req.id)
 
-        with pytest.raises(ValueError, match="pending 상태에서만 거절 가능"):
+        with pytest.raises(
+            ValueError, match="pending/execution_failed 상태에서만 거절 가능"
+        ):
             await service.reject(req.id)
 
     async def test_hold_and_resume(self, service):
@@ -317,7 +321,9 @@ class TestResolve:
         )
         await service.approve(req.id)
 
-        with pytest.raises(ValueError, match="pending 상태에서만 보류 가능"):
+        with pytest.raises(
+            ValueError, match="pending/execution_failed 상태에서만 보류 가능"
+        ):
             await service.hold(req.id)
 
     async def test_resume_non_hold_fails(self, service):
@@ -370,7 +376,9 @@ class TestCancel:
         )
         await service.approve(req.id)
 
-        with pytest.raises(ValueError, match="pending/on_hold 상태에서만 철회 가능"):
+        with pytest.raises(
+            ValueError, match="pending/on_hold/execution_failed 상태에서만 철회 가능"
+        ):
             await service.cancel(req.id, requester="agent:dev")
 
     async def test_cancel_publishes_event(self, service, eventbus):

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -6,7 +6,13 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from ante.approval.models import ApprovalRequest, ApprovalStatus, ApprovalType
+from ante.approval.models import (
+    ApprovalRequest,
+    ApprovalStatus,
+    ApprovalType,
+    ApprovalValidationError,
+    ValidationResult,
+)
 from ante.approval.service import ApprovalService
 from ante.core.database import Database
 from ante.eventbus.bus import EventBus
@@ -650,3 +656,197 @@ class TestEvents:
         )
         assert event.resolution == "approved"
         assert event.event_id is not None
+
+
+# ── 사전 검증 Validator (US-8) ────────────────────────
+
+
+class TestValidator:
+    """사전 검증(validator) 단위 테스트."""
+
+    async def test_fail_blocks_creation(self, db, eventbus):
+        """fail 등급 검증 결과 시 요청 생성이 차단된다."""
+
+        def fail_validator(params: dict) -> list[ValidationResult]:
+            return [ValidationResult("fail", "봇이 running 상태", "system:bot_manager")]
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            validators={"bot_delete": fail_validator},
+        )
+        await svc.initialize()
+
+        with pytest.raises(ApprovalValidationError, match="봇이 running 상태"):
+            await svc.create(
+                type="bot_delete",
+                requester="agent",
+                title="봇 삭제 요청",
+                params={"bot_id": "bot-1"},
+            )
+
+        # DB에 요청이 생성되지 않았는지 확인
+        all_requests = await svc.list()
+        assert len(all_requests) == 0
+
+    async def test_warn_attaches_review(self, db, eventbus):
+        """warn 등급 검증 결과 시 요청은 생성되고 reviews에 경고가 첨부된다."""
+
+        def warn_validator(params: dict) -> list[ValidationResult]:
+            return [
+                ValidationResult(
+                    "warn",
+                    "미할당 잔액 부족",
+                    "system:treasury",
+                )
+            ]
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            validators={"budget_change": warn_validator},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="예산 증액",
+            params={"bot_id": "bot-1", "amount": 50000000, "current": 10000000},
+        )
+
+        assert req.status == "pending"
+        assert len(req.reviews) == 1
+        assert req.reviews[0]["result"] == "warn"
+        assert req.reviews[0]["reviewer"] == "system:treasury"
+        assert "미할당 잔액 부족" in req.reviews[0]["detail"]
+
+    async def test_pass_creates_normally(self, db, eventbus):
+        """pass 등급 검증 결과 시 요청이 정상 생성된다."""
+
+        def pass_validator(params: dict) -> list[ValidationResult]:
+            return [ValidationResult("pass", "", "system:bot_manager")]
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            validators={"bot_delete": pass_validator},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="bot_delete",
+            requester="agent",
+            title="봇 삭제",
+            params={"bot_id": "bot-1"},
+        )
+
+        assert req.status == "pending"
+        assert len(req.reviews) == 0
+
+    async def test_no_validator_creates_normally(self, service):
+        """validator가 등록되지 않은 유형은 정상 생성된다."""
+        req = await service.create(
+            type="rule_change",
+            requester="agent",
+            title="규칙 변경",
+            params={"bot_id": "bot-1", "rules": {}},
+        )
+        assert req.status == "pending"
+
+    async def test_multiple_results_first_fail_blocks(self, db, eventbus):
+        """복수 검증 결과 중 첫 번째 fail이 생성을 차단한다."""
+
+        def multi_validator(params: dict) -> list[ValidationResult]:
+            return [
+                ValidationResult("fail", "봇이 running 상태", "system:bot_manager"),
+                ValidationResult("fail", "보유 포지션 존재", "system:trade"),
+            ]
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            validators={"bot_delete": multi_validator},
+        )
+        await svc.initialize()
+
+        with pytest.raises(ApprovalValidationError, match="봇이 running 상태"):
+            await svc.create(
+                type="bot_delete",
+                requester="agent",
+                title="봇 삭제",
+                params={"bot_id": "bot-1"},
+            )
+
+    async def test_warn_persisted_to_db(self, db, eventbus):
+        """warn reviews가 DB에 영속화된다."""
+
+        def warn_validator(params: dict) -> list[ValidationResult]:
+            return [ValidationResult("warn", "잔액 주의", "system:treasury")]
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            validators={"budget_change": warn_validator},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="예산 변경",
+            params={"bot_id": "bot-1", "amount": 20000000, "current": 10000000},
+        )
+
+        fetched = await svc.get(req.id)
+        assert fetched is not None
+        assert len(fetched.reviews) == 1
+        assert fetched.reviews[0]["result"] == "warn"
+
+    async def test_warn_with_reviewed_at(self, db, eventbus):
+        """warn review에 reviewed_at 시각이 포함된다."""
+
+        def warn_validator(params: dict) -> list[ValidationResult]:
+            return [ValidationResult("warn", "잔액 부족", "system:treasury")]
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            validators={"budget_change": warn_validator},
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="budget_change",
+            requester="agent",
+            title="예산 변경",
+            params={"bot_id": "bot-1", "amount": 20000000},
+        )
+
+        assert "reviewed_at" in req.reviews[0]
+        assert req.reviews[0]["reviewed_at"] != ""
+
+
+# ── 모델 추가분 (US-9) ──────────────────────────────
+
+
+class TestValidationModels:
+    def test_validation_result_frozen(self):
+        """ValidationResult는 불변이다."""
+        result = ValidationResult("fail", "테스트", "system:test")
+        with pytest.raises(AttributeError):
+            result.grade = "pass"  # type: ignore[misc]
+
+    def test_approval_validation_error(self):
+        """ApprovalValidationError에 detail 속성이 있다."""
+        error = ApprovalValidationError("검증 실패")
+        assert error.detail == "검증 실패"
+        assert str(error) == "검증 실패"
+
+    def test_approval_type_new_values(self):
+        """새로 추가된 ApprovalType 값."""
+        assert ApprovalType.STRATEGY_RETIRE == "strategy_retire"
+        assert ApprovalType.BOT_ASSIGN_STRATEGY == "bot_assign_strategy"
+        assert ApprovalType.BOT_CHANGE_STRATEGY == "bot_change_strategy"
+        assert ApprovalType.BOT_RESUME == "bot_resume"
+        assert ApprovalType.BOT_DELETE == "bot_delete"

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -1077,3 +1077,254 @@ class TestExecutionFailed:
         failed_list = await svc.list(status="execution_failed")
         assert len(failed_list) == 1
         assert failed_list[0].status == "execution_failed"
+
+
+# ── 재상신 Reopen (US-10) ────────────────────────────
+
+
+class TestReopen:
+    async def test_reopen_rejected_to_pending(self, service):
+        """거절된 요청을 재상신하면 pending 상태로 전환된다."""
+        req = await service.create(
+            type="budget_change",
+            requester="agent:dev",
+            title="재상신 테스트",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        await service.reject(req.id, reject_reason="금액 과다")
+
+        reopened = await service.reopen(
+            id=req.id,
+            requester="agent:dev",
+            params={"bot_id": "bot-1", "amount": 15000000},
+        )
+
+        assert reopened.status == "pending"
+        assert reopened.params == {"bot_id": "bot-1", "amount": 15000000}
+        assert reopened.reject_reason == ""
+        assert any(h["action"] == "reopened" for h in reopened.history)
+
+    async def test_reopen_updates_body(self, service):
+        """재상신 시 body를 갱신할 수 있다."""
+        req = await service.create(
+            type="budget_change",
+            requester="agent:dev",
+            title="body 갱신",
+            body="원본 사유",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        await service.reject(req.id)
+
+        reopened = await service.reopen(
+            id=req.id,
+            requester="agent:dev",
+            body="수정된 사유",
+        )
+
+        assert reopened.body == "수정된 사유"
+        # params는 기존 값 유지
+        assert reopened.params == {"bot_id": "bot-1", "amount": 25000000}
+
+    async def test_reopen_keeps_existing_when_none(self, service):
+        """body/params를 None으로 전달하면 기존 값이 유지된다."""
+        req = await service.create(
+            type="budget_change",
+            requester="agent:dev",
+            title="유지 테스트",
+            body="원본 본문",
+            params={"bot_id": "bot-1", "amount": 20000000},
+        )
+        await service.reject(req.id)
+
+        reopened = await service.reopen(id=req.id, requester="agent:dev")
+
+        assert reopened.body == "원본 본문"
+        assert reopened.params == {"bot_id": "bot-1", "amount": 20000000}
+
+    async def test_reopen_non_rejected_fails(self, service):
+        """rejected가 아닌 상태에서 reopen 시 에러."""
+        req = await service.create(
+            type="budget_change",
+            requester="agent:dev",
+            title="상태 에러",
+        )
+
+        with pytest.raises(ValueError, match="rejected 상태에서만 reopen 가능"):
+            await service.reopen(id=req.id, requester="agent:dev")
+
+    async def test_reopen_wrong_requester_fails(self, service):
+        """본인이 아닌 요청자가 reopen 시 에러."""
+        req = await service.create(
+            type="budget_change",
+            requester="agent:dev",
+            title="권한 에러",
+        )
+        await service.reject(req.id)
+
+        with pytest.raises(ValueError, match="본인 요청만 reopen 가능"):
+            await service.reopen(id=req.id, requester="agent:other")
+
+    async def test_reopen_nonexistent_fails(self, service):
+        """존재하지 않는 요청 reopen 시 에러."""
+        with pytest.raises(ValueError, match="결재 요청을 찾을 수 없음"):
+            await service.reopen(id="nonexistent", requester="agent:dev")
+
+    async def test_reopen_reruns_validator_fail(self, db, eventbus):
+        """reopen 시 validator가 재실행되고, fail이면 차단된다."""
+
+        def fail_validator(params: dict) -> list[ValidationResult]:
+            return [ValidationResult("fail", "잔액 부족", "system:treasury")]
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            validators={"budget_change": fail_validator},
+        )
+        await svc.initialize()
+
+        # validator 없이 생성 (직접 DB에 rejected 상태 만들기)
+        svc_no_validator = ApprovalService(db=db, eventbus=eventbus)
+        await svc_no_validator.initialize()
+        req = await svc_no_validator.create(
+            type="budget_change",
+            requester="agent:dev",
+            title="검증 실패 테스트",
+            params={"bot_id": "bot-1", "amount": 50000000},
+        )
+        await svc_no_validator.reject(req.id)
+
+        with pytest.raises(ApprovalValidationError, match="잔액 부족"):
+            await svc.reopen(
+                id=req.id,
+                requester="agent:dev",
+                params={"bot_id": "bot-1", "amount": 50000000},
+            )
+
+        # 상태가 여전히 rejected인지 확인
+        fetched = await svc.get(req.id)
+        assert fetched is not None
+        assert fetched.status == "rejected"
+
+    async def test_reopen_reruns_validator_warn(self, db, eventbus):
+        """reopen 시 validator warn이면 reviews에 첨부되고 pending 전환."""
+
+        def warn_validator(params: dict) -> list[ValidationResult]:
+            return [ValidationResult("warn", "잔액 주의", "system:treasury")]
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            validators={"budget_change": warn_validator},
+        )
+        await svc.initialize()
+
+        # validator 없이 생성
+        svc_no_validator = ApprovalService(db=db, eventbus=eventbus)
+        req = await svc_no_validator.create(
+            type="budget_change",
+            requester="agent:dev",
+            title="warn 테스트",
+            params={"bot_id": "bot-1", "amount": 30000000},
+        )
+        await svc_no_validator.reject(req.id)
+
+        reopened = await svc.reopen(
+            id=req.id,
+            requester="agent:dev",
+        )
+
+        assert reopened.status == "pending"
+        assert any(r["result"] == "warn" for r in reopened.reviews)
+
+    async def test_reopen_publishes_created_event(self, service, eventbus):
+        """reopen 시 ApprovalCreatedEvent가 재발행된다."""
+        received = []
+
+        async def handler(event: object) -> None:
+            if isinstance(event, ApprovalCreatedEvent):
+                received.append(event)
+
+        eventbus.subscribe(ApprovalCreatedEvent, handler)
+
+        req = await service.create(
+            type="budget_change",
+            requester="agent:dev",
+            title="이벤트 테스트",
+        )
+        created_event_count = len(received)
+
+        await service.reject(req.id)
+        await service.reopen(id=req.id, requester="agent:dev")
+
+        # 생성 시 1건 + reopen 시 1건
+        assert len(received) == created_event_count + 1
+        assert received[-1].approval_id == req.id
+
+    async def test_reopen_history_detail(self, service):
+        """reopen history에 수정 내용이 기록된다."""
+        req = await service.create(
+            type="budget_change",
+            requester="agent:dev",
+            title="이력 테스트",
+            body="원본",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        await service.reject(req.id)
+
+        reopened = await service.reopen(
+            id=req.id,
+            requester="agent:dev",
+            body="수정본",
+            params={"bot_id": "bot-1", "amount": 15000000},
+        )
+
+        reopened_entry = next(h for h in reopened.history if h["action"] == "reopened")
+        assert "body 수정" in reopened_entry["detail"]
+        assert "params 수정" in reopened_entry["detail"]
+
+    async def test_reopen_persisted_to_db(self, service):
+        """reopen 결과가 DB에 영속화된다."""
+        req = await service.create(
+            type="budget_change",
+            requester="agent:dev",
+            title="영속화 테스트",
+            body="원본",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        await service.reject(req.id)
+        await service.reopen(
+            id=req.id,
+            requester="agent:dev",
+            body="수정본",
+            params={"bot_id": "bot-1", "amount": 15000000},
+        )
+
+        fetched = await service.get(req.id)
+        assert fetched is not None
+        assert fetched.status == "pending"
+        assert fetched.body == "수정본"
+        assert fetched.params == {"bot_id": "bot-1", "amount": 15000000}
+        assert fetched.reject_reason == ""
+        assert fetched.resolved_at == ""
+        assert fetched.resolved_by == ""
+        assert any(h["action"] == "reopened" for h in fetched.history)
+
+    async def test_reopen_then_approve(self, service):
+        """reopen 후 승인까지의 전체 흐름."""
+        req = await service.create(
+            type="budget_change",
+            requester="agent:dev",
+            title="전체 흐름",
+            params={"bot_id": "bot-1", "amount": 25000000},
+        )
+        await service.reject(req.id, reject_reason="금액 과다")
+        await service.reopen(
+            id=req.id,
+            requester="agent:dev",
+            params={"bot_id": "bot-1", "amount": 15000000},
+        )
+        approved = await service.approve(req.id)
+
+        assert approved.status == "approved"
+        actions = [h["action"] for h in approved.history]
+        assert actions == ["created", "rejected", "reopened", "approved"]

--- a/tests/unit/test_auto_approve.py
+++ b/tests/unit/test_auto_approve.py
@@ -276,11 +276,12 @@ class TestServiceAutoApprove:
         assert req.status == ApprovalStatus.APPROVED
         assert req.resolved_by == "system:auto_approve"
         assert req.resolved_at != ""
-        # history: created + approved
-        assert len(req.history) == 2
+        # history: created + approved + executed
+        assert len(req.history) == 3
         assert req.history[0]["action"] == "created"
         assert req.history[1]["action"] == "approved"
         assert req.history[1]["actor"] == "system:auto_approve"
+        assert req.history[2]["action"] == "executed"
 
     async def test_auto_approve_executes_handler(self, service_with_auto_approve):
         """전결 시 executor가 실행된다."""
@@ -384,7 +385,7 @@ class TestServiceAutoApprove:
         assert fetched is not None
         assert fetched.status == "approved"
         assert fetched.resolved_by == "system:auto_approve"
-        assert len(fetched.history) == 2
+        assert len(fetched.history) == 3
 
     async def test_created_event_auto_approved_false_for_normal(
         self, service_without_auto_approve, eventbus

--- a/tests/unit/test_response_model_validation.py
+++ b/tests/unit/test_response_model_validation.py
@@ -171,7 +171,7 @@ class TestBotResponseModels:
         """GET /api/bots/{bot_id} — 기본."""
         data = {"bot": {"bot_id": "bot-1", "status": "running", "strategy_id": "s1"}}
         model = BotDetailResponse.model_validate(data)
-        assert model.bot["bot_id"] == "bot-1"
+        assert model.bot.bot_id == "bot-1"
 
     def test_bot_detail_response_with_extras(self):
         """GET /api/bots/{bot_id} — strategy, budget, positions 포함."""
@@ -203,7 +203,7 @@ class TestBotResponseModels:
             }
         }
         model = BotDetailResponse.model_validate(data)
-        assert model.bot["strategy"]["name"] == "TestStrategy"
+        assert model.bot.strategy["name"] == "TestStrategy"
 
 
 # ── 전략 라우트 응답 모델 ──────────────────────────
@@ -269,7 +269,7 @@ class TestStrategyResponseModels:
             "bot": None,
         }
         model = StrategyDetailResponse.model_validate(data)
-        assert model.strategy["strategy_id"] == "s1"
+        assert model.strategy.strategy_id == "s1"
         assert model.bot is None
 
     def test_strategy_detail_response_with_bot(self):
@@ -760,6 +760,8 @@ class TestApprovalResponseModels:
                     "id": "apr-001",
                     "type": "strategy_deploy",
                     "status": "pending",
+                    "requester": "agent-1",
+                    "title": "전략 배포 요청",
                     "reference_id": "rpt-001",
                 }
             ],
@@ -775,6 +777,8 @@ class TestApprovalResponseModels:
                 "id": "apr-001",
                 "type": "strategy_deploy",
                 "status": "pending",
+                "requester": "agent-1",
+                "title": "전략 배포 요청",
             },
             "report_detail": None,
         }
@@ -788,6 +792,8 @@ class TestApprovalResponseModels:
                 "id": "apr-001",
                 "type": "strategy_deploy",
                 "status": "pending",
+                "requester": "agent-1",
+                "title": "전략 배포 요청",
             },
             "report_detail": {
                 "report_id": "rpt-001",
@@ -804,10 +810,12 @@ class TestApprovalResponseModels:
                 "id": "apr-001",
                 "type": "strategy_deploy",
                 "status": "approved",
+                "requester": "agent-1",
+                "title": "전략 배포 요청",
             }
         }
         model = ApprovalUpdateResponse.model_validate(data)
-        assert model.approval["status"] == "approved"
+        assert model.approval.status == "approved"
 
 
 # ── 설정 라우트 응답 모델 ──────────────────────────
@@ -906,10 +914,11 @@ class TestMemberResponseModels:
                 "member_id": "admin",
                 "name": "관리자",
                 "type": "human",
+                "role": "owner",
             }
         }
         model = MemberDetailResponse.model_validate(data)
-        assert model.member["member_id"] == "admin"
+        assert model.member.member_id == "admin"
 
     def test_member_create_response(self):
         """POST /api/members."""
@@ -918,6 +927,7 @@ class TestMemberResponseModels:
                 "member_id": "agent-1",
                 "name": "분석 에이전트",
                 "type": "agent",
+                "role": "agent",
             },
             "token": "tok_abc123def456",
         }
@@ -927,7 +937,12 @@ class TestMemberResponseModels:
     def test_member_token_response(self):
         """POST /api/members/{member_id}/rotate-token."""
         data = {
-            "member": {"member_id": "agent-1", "name": "에이전트", "type": "agent"},
+            "member": {
+                "member_id": "agent-1",
+                "name": "에이전트",
+                "type": "agent",
+                "role": "agent",
+            },
             "token": "tok_new_token_789",
         }
         model = MemberTokenResponse.model_validate(data)
@@ -946,11 +961,12 @@ class TestMemberResponseModels:
                 "member_id": "agent-1",
                 "name": "에이전트",
                 "type": "agent",
+                "role": "agent",
                 "scopes": ["trade:read", "trade:write"],
             }
         }
         model = MemberScopesResponse.model_validate(data)
-        assert "scopes" in model.member
+        assert model.member.scopes == ["trade:read", "trade:write"]
 
 
 # ── 감사 로그 라우트 응답 모델 ──────────────────────────

--- a/tests/unit/test_telegram_approval.py
+++ b/tests/unit/test_telegram_approval.py
@@ -1,0 +1,462 @@
+"""텔레그램 결재 연동 테스트.
+
+TelegramAdapter.send_with_buttons(), TelegramCommandReceiver 콜백/명령어,
+NotificationService의 ApprovalEvent 구독을 검증한다.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ante.core.database import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import ApprovalCreatedEvent, ApprovalResolvedEvent
+from ante.notification.base import NotificationLevel
+from ante.notification.service import NOTIFICATION_HISTORY_SCHEMA, NotificationService
+from ante.notification.telegram import TelegramAdapter
+from ante.notification.telegram_receiver import TelegramCommandReceiver
+
+# ── Fixtures ──────────────────────────────────────
+
+
+@pytest.fixture
+def adapter():
+    """TelegramAdapter mock."""
+    mock = MagicMock(spec=TelegramAdapter)
+    mock._api_base = "https://api.telegram.org/botTEST"
+    mock._bot_token = "TEST"
+    mock._chat_id = "123"
+    mock.send = AsyncMock(return_value=True)
+    mock.send_rich = AsyncMock(return_value=True)
+    mock.send_with_buttons = AsyncMock(return_value=True)
+    mock.answer_callback_query = AsyncMock(return_value=True)
+    return mock
+
+
+@pytest.fixture
+def approval_service():
+    """ApprovalService mock."""
+    mock = MagicMock()
+    mock.approve = AsyncMock()
+    mock.reject = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def receiver(adapter, approval_service):
+    """approval_service가 주입된 TelegramCommandReceiver."""
+    return TelegramCommandReceiver(
+        adapter=adapter,
+        allowed_user_ids=[12345],
+        approval_service=approval_service,
+    )
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """테스트용 DB."""
+    _db = Database(str(tmp_path / "test.db"))
+    await _db.connect()
+    yield _db
+    await _db.close()
+
+
+# ── TelegramAdapter.send_with_buttons ─────────────
+
+
+class TestSendWithButtons:
+    """send_with_buttons() 단위 테스트."""
+
+    async def test_send_with_buttons_calls_api(self):
+        """send_with_buttons가 reply_markup과 함께 _send_message를 호출한다."""
+        adapter = TelegramAdapter(bot_token="TEST", chat_id="123")
+        adapter._send_message = AsyncMock(return_value=True)
+
+        buttons = [[{"text": "승인", "callback_data": "approve:abc"}]]
+        result = await adapter.send_with_buttons(
+            NotificationLevel.INFO, "테스트 메시지", buttons
+        )
+
+        assert result is True
+        adapter._send_message.assert_called_once()
+        call_kwargs = adapter._send_message.call_args
+        assert call_kwargs[1]["reply_markup"] == {"inline_keyboard": buttons}
+
+    async def test_send_with_buttons_includes_emoji(self):
+        """send_with_buttons가 레벨 이모지를 포함한다."""
+        adapter = TelegramAdapter(bot_token="TEST", chat_id="123")
+        adapter._send_message = AsyncMock(return_value=True)
+
+        await adapter.send_with_buttons(
+            NotificationLevel.INFO,
+            "테스트",
+            [[{"text": "OK", "callback_data": "ok"}]],
+        )
+
+        text_arg = adapter._send_message.call_args[0][0]
+        assert "\u2139\ufe0f" in text_arg  # INFO 이모지
+
+
+class TestAnswerCallbackQuery:
+    """answer_callback_query() 단위 테스트."""
+
+    async def test_answer_callback_query_success(self):
+        """answerCallbackQuery API 호출 성공."""
+        adapter = TelegramAdapter(bot_token="TEST", chat_id="123")
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await adapter.answer_callback_query("cb123", "완료")
+
+        assert result is True
+
+
+# ── Callback Query 처리 ──────────────────────────
+
+
+class TestCallbackQuery:
+    """인라인 버튼 콜백 처리 테스트."""
+
+    async def test_approve_callback(self, receiver, approval_service):
+        """approve 콜백이 ApprovalService.approve()를 호출한다."""
+        update = {
+            "callback_query": {
+                "id": "cb1",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "approve:abc123",
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
+
+        approval_service.approve.assert_called_once_with(
+            "abc123", resolved_by="telegram"
+        )
+
+    async def test_reject_callback(self, receiver, approval_service):
+        """reject 콜백이 ApprovalService.reject()를 호출한다."""
+        update = {
+            "callback_query": {
+                "id": "cb2",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "reject:abc123",
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
+
+        approval_service.reject.assert_called_once_with(
+            "abc123", resolved_by="telegram", reject_reason="사용자 거절"
+        )
+
+    async def test_callback_unauthorized(self, receiver, adapter):
+        """미인가 사용자의 콜백은 거부된다."""
+        update = {
+            "callback_query": {
+                "id": "cb3",
+                "from": {"id": 99999},
+                "message": {"chat": {"id": 100}},
+                "data": "approve:abc123",
+            }
+        }
+        await receiver._handle_update(update)
+        adapter.answer_callback_query.assert_called_once()
+        assert "권한" in adapter.answer_callback_query.call_args[0][1]
+
+    async def test_callback_invalid_data(self, receiver, adapter):
+        """잘못된 callback_data 형식 처리."""
+        update = {
+            "callback_query": {
+                "id": "cb4",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "invalid",
+            }
+        }
+        await receiver._handle_update(update)
+        adapter.answer_callback_query.assert_called_once()
+        assert "잘못된" in adapter.answer_callback_query.call_args[0][1]
+
+    async def test_callback_unknown_action(self, receiver, adapter):
+        """알 수 없는 action 처리."""
+        update = {
+            "callback_query": {
+                "id": "cb5",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "hold:abc123",
+            }
+        }
+        await receiver._handle_update(update)
+        adapter.answer_callback_query.assert_called()
+        assert "알 수 없는" in adapter.answer_callback_query.call_args[0][1]
+
+    async def test_callback_approve_error(self, receiver, approval_service, adapter):
+        """approve 실패 시 에러 메시지를 반환한다."""
+        approval_service.approve.side_effect = ValueError("pending 상태가 아님")
+        update = {
+            "callback_query": {
+                "id": "cb6",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "approve:abc123",
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
+        adapter.answer_callback_query.assert_called_once()
+        assert "실패" in adapter.answer_callback_query.call_args[0][1]
+
+    async def test_callback_no_approval_service(self, adapter):
+        """approval_service 없으면 안내 메시지."""
+        r = TelegramCommandReceiver(
+            adapter=adapter, allowed_user_ids=[12345], approval_service=None
+        )
+        update = {
+            "callback_query": {
+                "id": "cb7",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "approve:abc123",
+            }
+        }
+        await r._handle_update(update)
+        adapter.answer_callback_query.assert_called_once()
+        assert "ApprovalService" in adapter.answer_callback_query.call_args[0][1]
+
+    async def test_callback_sends_reply(self, receiver, adapter, approval_service):
+        """콜백 처리 후 결과 메시지를 chat에 발송한다."""
+        update = {
+            "callback_query": {
+                "id": "cb8",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "approve:abc123",
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
+        receiver._reply.assert_called_once()
+        assert "승인 완료" in receiver._reply.call_args[0][1]
+
+
+# ── /approve, /reject 명령어 ─────────────────────
+
+
+class TestApproveRejectCommands:
+    """텍스트 명령어 /approve, /reject 테스트."""
+
+    async def test_approve_command(self, receiver, approval_service):
+        """/approve <id> 명령이 ApprovalService.approve()를 호출한다."""
+        result = await receiver._cmd_approve(["abc123"])
+        assert "승인 완료" in result
+        approval_service.approve.assert_called_once_with(
+            "abc123", resolved_by="telegram"
+        )
+
+    async def test_approve_no_args(self, receiver):
+        """/approve 인자 없으면 안내 메시지."""
+        result = await receiver._cmd_approve([])
+        assert "ID를 지정" in result
+
+    async def test_approve_no_service(self, adapter):
+        """approval_service 없으면 안내 메시지."""
+        r = TelegramCommandReceiver(
+            adapter=adapter, allowed_user_ids=[12345], approval_service=None
+        )
+        result = await r._cmd_approve(["abc123"])
+        assert "연결되지 않았습니다" in result
+
+    async def test_approve_error(self, receiver, approval_service):
+        """approve 실패 시 에러 메시지."""
+        approval_service.approve.side_effect = ValueError("찾을 수 없음")
+        result = await receiver._cmd_approve(["abc123"])
+        assert "실패" in result
+
+    async def test_reject_command(self, receiver, approval_service):
+        """/reject <id> [reason] 명령이 reject를 호출한다."""
+        result = await receiver._cmd_reject(["abc123", "리스크", "과다"])
+        assert "거절 완료" in result
+        approval_service.reject.assert_called_once_with(
+            "abc123", resolved_by="telegram", reject_reason="리스크 과다"
+        )
+
+    async def test_reject_default_reason(self, receiver, approval_service):
+        """/reject <id> 사유 미지정 시 기본 사유."""
+        await receiver._cmd_reject(["abc123"])
+        approval_service.reject.assert_called_once_with(
+            "abc123", resolved_by="telegram", reject_reason="사용자 거절"
+        )
+
+    async def test_reject_no_args(self, receiver):
+        """/reject 인자 없으면 안내 메시지."""
+        result = await receiver._cmd_reject([])
+        assert "ID를 지정" in result
+
+    async def test_reject_no_service(self, adapter):
+        """approval_service 없으면 안내 메시지."""
+        r = TelegramCommandReceiver(
+            adapter=adapter, allowed_user_ids=[12345], approval_service=None
+        )
+        result = await r._cmd_reject(["abc123"])
+        assert "연결되지 않았습니다" in result
+
+    async def test_reject_error(self, receiver, approval_service):
+        """reject 실패 시 에러 메시지."""
+        approval_service.reject.side_effect = ValueError("이미 처리됨")
+        result = await receiver._cmd_reject(["abc123"])
+        assert "실패" in result
+
+    async def test_help_includes_approval_commands(self, receiver):
+        """/help에 /approve, /reject 명령이 포함된다."""
+        result = receiver._cmd_help([])
+        assert "/approve" in result
+        assert "/reject" in result
+
+    async def test_execute_approve(self, receiver, approval_service):
+        """_execute를 통해 /approve가 라우팅된다."""
+        result = await receiver._execute("approve", ["abc123"], 12345, 100)
+        assert "승인 완료" in result
+
+    async def test_execute_reject(self, receiver, approval_service):
+        """_execute를 통해 /reject가 라우팅된다."""
+        result = await receiver._execute("reject", ["abc123"], 12345, 100)
+        assert "거절 완료" in result
+
+
+# ── NotificationService 결재 이벤트 구독 ─────────
+
+
+class TestNotificationApprovalEvents:
+    """NotificationService의 ApprovalEvent 구독 테스트."""
+
+    async def test_approval_created_with_buttons(self, adapter, eventbus, db):
+        """ApprovalCreatedEvent가 인라인 버튼 메시지를 발송한다."""
+        await db.execute_script(NOTIFICATION_HISTORY_SCHEMA)
+
+        svc = NotificationService(
+            adapter=adapter,
+            eventbus=eventbus,
+            db=db,
+        )
+        await svc.initialize()
+        svc.subscribe()
+
+        event = ApprovalCreatedEvent(
+            approval_id="test-id",
+            approval_type="budget_change",
+            requester="agent",
+            title="예산 증액",
+            auto_approved=False,
+        )
+        await eventbus.publish(event)
+
+        # TelegramAdapter이므로 send_with_buttons 호출
+        adapter.send_with_buttons.assert_called_once()
+        call_args = adapter.send_with_buttons.call_args
+        assert call_args[0][0] == NotificationLevel.INFO
+        assert "결재 요청" in call_args[0][1]
+        assert "예산 증액" in call_args[0][1]
+        # 버튼 확인
+        buttons = call_args[0][2]
+        assert len(buttons) == 1
+        assert buttons[0][0]["callback_data"] == "approve:test-id"
+        assert buttons[0][1]["callback_data"] == "reject:test-id"
+
+    async def test_approval_created_auto_approved(self, adapter, eventbus, db):
+        """자동 승인 시 [자동 승인] 접두사가 포함된다."""
+        await db.execute_script(NOTIFICATION_HISTORY_SCHEMA)
+
+        svc = NotificationService(
+            adapter=adapter,
+            eventbus=eventbus,
+            db=db,
+        )
+        await svc.initialize()
+        svc.subscribe()
+
+        event = ApprovalCreatedEvent(
+            approval_id="test-auto",
+            approval_type="bot_stop",
+            requester="agent",
+            title="봇 중지",
+            auto_approved=True,
+        )
+        await eventbus.publish(event)
+
+        # 자동 승인이므로 send_with_buttons가 아닌 일반 send 호출
+        adapter.send_with_buttons.assert_not_called()
+        adapter.send.assert_called_once()
+        msg = adapter.send.call_args[0][1]
+        assert "[자동 승인]" in msg
+
+    async def test_approval_resolved_event(self, adapter, eventbus, db):
+        """ApprovalResolvedEvent가 결과 메시지를 발송한다."""
+        await db.execute_script(NOTIFICATION_HISTORY_SCHEMA)
+
+        svc = NotificationService(
+            adapter=adapter,
+            eventbus=eventbus,
+            db=db,
+        )
+        await svc.initialize()
+        svc.subscribe()
+
+        event = ApprovalResolvedEvent(
+            approval_id="test-id",
+            approval_type="budget_change",
+            resolution="approved",
+            resolved_by="telegram",
+        )
+        await eventbus.publish(event)
+
+        adapter.send.assert_called_once()
+        msg = adapter.send.call_args[0][1]
+        assert "처리 완료" in msg
+        assert "approved" in msg
+
+    async def test_approval_created_non_telegram_adapter(self, eventbus, db):
+        """TelegramAdapter가 아닌 경우 일반 send로 발송한다."""
+        await db.execute_script(NOTIFICATION_HISTORY_SCHEMA)
+
+        mock_adapter = MagicMock()
+        mock_adapter.send = AsyncMock(return_value=True)
+        mock_adapter.send_rich = AsyncMock(return_value=True)
+
+        svc = NotificationService(
+            adapter=mock_adapter,
+            eventbus=eventbus,
+            db=db,
+        )
+        await svc.initialize()
+        svc.subscribe()
+
+        event = ApprovalCreatedEvent(
+            approval_id="test-id",
+            approval_type="budget_change",
+            requester="agent",
+            title="예산 증액",
+            auto_approved=False,
+        )
+        await eventbus.publish(event)
+
+        # TelegramAdapter가 아니므로 일반 send 호출
+        mock_adapter.send.assert_called_once()


### PR DESCRIPTION
Refs #465

## 개요

결재 모듈의 미구현 기능을 완성하여 전체 생명주기(생성 → 검증 → 승인/거절 → 실행 → 만료/재상신)를 지원하고, Telegram 모바일 결재를 가능하게 한다.

## 하위 이슈 (5개, 모두 완료)

- #448 ✅ 결재 사전 검증(validator) — 유형별 validator 7건, fail/warn 분기
- #438 ✅ 결재 만료 스케줄러 — 5분 주기 expire_stale() 호출
- #439 ✅ 결재 실행 실패 상태(EXECUTION_FAILED) — executor 실패 시 상태 전환
- #449 ✅ 결재 재상신(reopen) — rejected → pending 전환, body/params 수정
- #441 ✅ Telegram 결재 연동 — 인라인 버튼 승인/거절, /approve /reject 명령어

## 테스트
- 1985 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)