### PR TITLE
feat: 감사 로그 기록 연동 — Web API + CLI

### DIFF
--- a/src/ante/cli/commands/approval.py
+++ b/src/ante/cli/commands/approval.py
@@ -11,6 +11,18 @@ from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
 
 
+async def _audit_log(db, **kwargs) -> None:  # noqa: ANN001
+    """감사 로그 기록 (실패해도 주 동작에 영향 없음)."""
+    try:
+        from ante.audit import AuditLogger
+
+        al = AuditLogger(db=db)
+        await al.initialize()
+        await al.log(**kwargs)
+    except Exception:
+        pass
+
+
 @click.group()
 def approval() -> None:
     """결재 관리."""
@@ -329,6 +341,14 @@ def cancel(ctx: click.Context, id: str, db_path: str) -> None:
         await service.initialize()
 
         req = await service.cancel(id=id, requester=requester)
+
+        await _audit_log(
+            db,
+            member_id=requester,
+            action="approval.cancel",
+            resource=f"approval:{id}",
+        )
+
         await db.close()
         return {"id": req.id, "status": req.status}
 
@@ -349,6 +369,7 @@ def cancel(ctx: click.Context, id: str, db_path: str) -> None:
 def approve(ctx: click.Context, id: str, db_path: str) -> None:
     """결재 승인."""
     fmt = get_formatter(ctx)
+    actor = get_member_id(ctx)
 
     async def _approve() -> dict:
         from ante.approval import ApprovalService
@@ -362,6 +383,14 @@ def approve(ctx: click.Context, id: str, db_path: str) -> None:
         await service.initialize()
 
         req = await service.approve(id=id)
+
+        await _audit_log(
+            db,
+            member_id=actor,
+            action="approval.approve",
+            resource=f"approval:{id}",
+        )
+
         await db.close()
         return {"id": req.id, "status": req.status, "type": req.type}
 
@@ -383,6 +412,7 @@ def approve(ctx: click.Context, id: str, db_path: str) -> None:
 def reject(ctx: click.Context, id: str, reason: str, db_path: str) -> None:
     """결재 거절."""
     fmt = get_formatter(ctx)
+    actor = get_member_id(ctx)
 
     async def _reject() -> dict:
         from ante.approval import ApprovalService
@@ -396,6 +426,15 @@ def reject(ctx: click.Context, id: str, reason: str, db_path: str) -> None:
         await service.initialize()
 
         req = await service.reject(id=id, reject_reason=reason)
+
+        await _audit_log(
+            db,
+            member_id=actor,
+            action="approval.reject",
+            resource=f"approval:{id}",
+            detail=reason,
+        )
+
         await db.close()
         return {"id": req.id, "status": req.status, "reject_reason": reason}
 

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -7,7 +7,7 @@ import asyncio
 import click
 
 from ante.cli.main import get_formatter
-from ante.cli.middleware import require_auth, require_scope
+from ante.cli.middleware import get_member_id, require_auth, require_scope
 
 
 @click.group()
@@ -30,6 +30,18 @@ async def _create_services():  # noqa: ANN202
     manager = BotManager(eventbus=eventbus, db=db)
     await manager.initialize()
     return db, eventbus, manager
+
+
+async def _audit_log(db, **kwargs) -> None:  # noqa: ANN001
+    """감사 로그 기록 (실패해도 주 동작에 영향 없음)."""
+    try:
+        from ante.audit import AuditLogger
+
+        al = AuditLogger(db=db)
+        await al.initialize()
+        await al.log(**kwargs)
+    except Exception:
+        pass
 
 
 @bot.command("list")
@@ -152,6 +164,7 @@ def bot_create(
 ) -> None:
     """봇 생성."""
     fmt = get_formatter(ctx)
+    actor = get_member_id(ctx)
 
     # 파라미터 파싱
     param_dict: dict = {}
@@ -185,6 +198,15 @@ def bot_create(
                    VALUES (?, ?, ?, ?, ?)""",
                 (bid, name, strategy, bot_type, json.dumps(config_dict)),
             )
+
+            await _audit_log(
+                db,
+                member_id=actor,
+                action="bot.create",
+                resource=f"bot:{bid}",
+                detail=f"strategy={strategy}",
+            )
+
             return config_dict
         finally:
             await db.close()
@@ -207,6 +229,7 @@ def bot_create(
 def bot_remove(ctx: click.Context, bot_id: str) -> None:
     """봇 삭제."""
     fmt = get_formatter(ctx)
+    actor = get_member_id(ctx)
 
     async def _run_remove() -> bool:
         db, _, _ = await _create_services()
@@ -222,6 +245,14 @@ def bot_remove(ctx: click.Context, bot_id: str) -> None:
                 " WHERE bot_id = ?",
                 (bot_id,),
             )
+
+            await _audit_log(
+                db,
+                member_id=actor,
+                action="bot.delete",
+                resource=f"bot:{bot_id}",
+            )
+
             return True
         finally:
             await db.close()

--- a/src/ante/cli/commands/system.py
+++ b/src/ante/cli/commands/system.py
@@ -29,6 +29,18 @@ async def _create_services():  # noqa: ANN202
     return db, eventbus
 
 
+async def _audit_log(db, **kwargs) -> None:  # noqa: ANN001
+    """감사 로그 기록 (실패해도 주 동작에 영향 없음)."""
+    try:
+        from ante.audit import AuditLogger
+
+        al = AuditLogger(db=db)
+        await al.initialize()
+        await al.log(**kwargs)
+    except Exception:
+        pass
+
+
 @system.command()
 @click.pass_context
 @require_auth
@@ -83,6 +95,15 @@ def halt(ctx: click.Context, reason: str) -> None:
             state = SystemState(db, eventbus)
             await state.initialize()
             await state.set_state(TradingState.HALTED, reason=reason, changed_by=actor)
+
+            await _audit_log(
+                db,
+                member_id=actor,
+                action="system.halt",
+                resource="system:kill_switch",
+                detail=reason,
+            )
+
             return {"trading_state": state.trading_state.value}
         finally:
             await db.close()
@@ -109,6 +130,15 @@ def activate(ctx: click.Context, reason: str) -> None:
             state = SystemState(db, eventbus)
             await state.initialize()
             await state.set_state(TradingState.ACTIVE, reason=reason, changed_by=actor)
+
+            await _audit_log(
+                db,
+                member_id=actor,
+                action="system.activate",
+                resource="system:kill_switch",
+                detail=reason,
+            )
+
             return {"trading_state": state.trading_state.value}
         finally:
             await db.close()

--- a/src/ante/web/app.py
+++ b/src/ante/web/app.py
@@ -48,6 +48,10 @@ def create_app(**services: Any) -> FastAPI:
         allow_headers=["*"],
     )
 
+    from ante.web.middleware.audit import AuditMiddleware
+
+    app.add_middleware(AuditMiddleware)
+
     for name, service in services.items():
         setattr(app.state, name, service)
 

--- a/src/ante/web/deps.py
+++ b/src/ante/web/deps.py
@@ -168,3 +168,8 @@ def get_config(request: Request) -> Any | None:
 def get_broker(request: Request) -> Any | None:
     """브로커 (선택적). 없으면 None."""
     return getattr(request.app.state, "broker", None)
+
+
+def get_audit_logger_optional(request: Request) -> Any | None:
+    """감사 로거 (선택적). 없으면 None."""
+    return getattr(request.app.state, "audit_logger", None)

--- a/src/ante/web/middleware/__init__.py
+++ b/src/ante/web/middleware/__init__.py
@@ -1,0 +1,5 @@
+"""Web API 미들웨어."""
+
+from ante.web.middleware.audit import AuditMiddleware
+
+__all__ = ["AuditMiddleware"]

--- a/src/ante/web/middleware/audit.py
+++ b/src/ante/web/middleware/audit.py
@@ -1,0 +1,53 @@
+"""감사 로그 미들웨어 — 상태 변경 API 자동 기록 (안전망)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+logger = logging.getLogger(__name__)
+
+# 자동 기록 대상 HTTP 메서드
+_MUTATING_METHODS = frozenset({"POST", "PUT", "DELETE", "PATCH"})
+
+
+class AuditMiddleware(BaseHTTPMiddleware):
+    """모든 상태 변경(POST/PUT/DELETE/PATCH) 성공 응답을 자동 기록한다.
+
+    핸들러의 명시적 audit 호출과 별도로 동작하며,
+    action 접두사 ``api:`` 로 구분된다.
+    """
+
+    async def dispatch(self, request: Request, call_next: Any) -> Response:
+        response = await call_next(request)
+
+        if request.method not in _MUTATING_METHODS:
+            return response
+
+        if not (200 <= response.status_code < 400):
+            return response
+
+        audit_logger = getattr(request.app.state, "audit_logger", None)
+        if audit_logger is None:
+            return response
+
+        member_id = getattr(request.state, "member_id", "anonymous")
+        ip = request.client.host if request.client else ""
+
+        try:
+            await audit_logger.log(
+                member_id=member_id,
+                action=f"api:{request.method.lower()}",
+                resource=request.url.path,
+                ip=ip,
+            )
+        except Exception:
+            logger.exception(
+                "AuditMiddleware 기록 실패: %s %s", request.method, request.url.path
+            )
+
+        return response

--- a/src/ante/web/routes/approvals.py
+++ b/src/ante/web/routes/approvals.py
@@ -6,10 +6,14 @@ import logging
 from dataclasses import asdict
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
-from ante.web.deps import get_approval_service, get_report_store_optional
+from ante.web.deps import (
+    get_approval_service,
+    get_audit_logger_optional,
+    get_report_store_optional,
+)
 from ante.web.schemas import (
     ApprovalDetailResponse,
     ApprovalListResponse,
@@ -94,7 +98,9 @@ async def get_approval(
 async def update_approval_status(
     approval_id: str,
     body: ApprovalStatusUpdate,
+    request: Request,
     approval_service: Annotated[Any, Depends(get_approval_service)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """결재 승인/거부 처리."""
     try:
@@ -113,5 +119,15 @@ async def update_approval_status(
             )
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
+
+    action = "approval.approve" if body.status == "approved" else "approval.reject"
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "user"),
+            action=action,
+            resource=f"approval:{approval_id}",
+            detail=body.memo,
+            ip=request.client.host if request.client else "",
+        )
 
     return {"approval": asdict(approval)}

--- a/src/ante/web/routes/auth.py
+++ b/src/ante/web/routes/auth.py
@@ -7,7 +7,11 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response
 
-from ante.web.deps import get_member_service, get_session_service
+from ante.web.deps import (
+    get_audit_logger_optional,
+    get_member_service,
+    get_session_service,
+)
 from ante.web.schemas import LoginRequest, LoginResponse, LogoutResponse, MeResponse
 
 logger = logging.getLogger(__name__)
@@ -32,6 +36,7 @@ async def login(
     response: Response,
     member_service: Annotated[Any, Depends(get_member_service)],
     session_service: Annotated[Any, Depends(get_session_service)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> LoginResponse:
     """패스워드 로그인 -> 세션 쿠키 발급."""
     try:
@@ -63,6 +68,14 @@ async def login(
         secure=request.url.scheme == "https",
     )
 
+    if audit_logger:
+        await audit_logger.log(
+            member_id=member.member_id,
+            action="auth.login",
+            resource=f"member:{member.member_id}",
+            ip=ip_address,
+        )
+
     return LoginResponse(
         member_id=member.member_id,
         name=member.name,
@@ -76,15 +89,30 @@ async def login(
     responses={503: {"description": "Session service not available"}},
 )
 async def logout(
+    request: Request,
     response: Response,
     session_service: Annotated[Any, Depends(get_session_service)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
     ante_session: str | None = Cookie(default=None),
 ) -> dict:
     """로그아웃 — 세션 삭제 + 쿠키 제거."""
+    member_id = "anonymous"
     if ante_session:
+        session = await session_service.validate(ante_session)
+        if session:
+            member_id = session.get("member_id", "anonymous")
         await session_service.delete(ante_session)
 
     response.delete_cookie(key=COOKIE_NAME)
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=member_id,
+            action="auth.logout",
+            resource=f"member:{member_id}",
+            ip=request.client.host if request.client else "",
+        )
+
     return {"ok": True}
 
 

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from ante.web.deps import (
+    get_audit_logger_optional,
     get_bot_manager,
     get_strategy_registry,
     get_strategy_registry_optional,
@@ -62,8 +63,10 @@ async def list_bots(
 )
 async def create_bot(
     body: BotCreateRequest,
+    request: Request,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     registry: Annotated[Any, Depends(get_strategy_registry)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """봇 생성."""
     from pathlib import Path
@@ -97,6 +100,15 @@ async def create_bot(
         )
     except BotError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "anonymous"),
+            action="bot.create",
+            resource=f"bot:{body.bot_id}",
+            detail=f"strategy={body.strategy_id}",
+            ip=request.client.host if request.client else "",
+        )
 
     return {"bot": bot.get_info()}
 
@@ -174,7 +186,9 @@ async def get_bot(
 )
 async def start_bot(
     bot_id: str,
+    request: Request,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """봇 시작."""
     from ante.bot.exceptions import BotError
@@ -187,6 +201,14 @@ async def start_bot(
         await bot_manager.start_bot(bot_id)
     except BotError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "anonymous"),
+            action="bot.start",
+            resource=f"bot:{bot_id}",
+            ip=request.client.host if request.client else "",
+        )
 
     return {"bot": bot.get_info()}
 
@@ -202,7 +224,9 @@ async def start_bot(
 )
 async def stop_bot(
     bot_id: str,
+    request: Request,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """봇 중지."""
     from ante.bot.exceptions import BotError
@@ -215,6 +239,14 @@ async def stop_bot(
         await bot_manager.stop_bot(bot_id)
     except BotError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "anonymous"),
+            action="bot.stop",
+            resource=f"bot:{bot_id}",
+            ip=request.client.host if request.client else "",
+        )
 
     return {"bot": bot.get_info()}
 
@@ -230,7 +262,9 @@ async def stop_bot(
 )
 async def delete_bot(
     bot_id: str,
+    request: Request,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> None:
     """봇 삭제."""
     from ante.bot.exceptions import BotError
@@ -243,3 +277,11 @@ async def delete_bot(
         await bot_manager.delete_bot(bot_id)
     except BotError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "anonymous"),
+            action="bot.delete",
+            resource=f"bot:{bot_id}",
+            ip=request.client.host if request.client else "",
+        )

--- a/src/ante/web/routes/config.py
+++ b/src/ante/web/routes/config.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from ante.web.deps import get_dynamic_config
+from ante.web.deps import get_audit_logger_optional, get_dynamic_config
 from ante.web.schemas import ConfigListResponse, ConfigUpdateResponse
 
 router = APIRouter()
@@ -44,7 +44,9 @@ async def list_configs(
 async def update_config(
     key: str,
     body: ConfigUpdateRequest,
+    request: Request,
     config_service: Annotated[Any, Depends(get_dynamic_config)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """동적 설정 값 변경."""
     if not await config_service.exists(key):
@@ -56,5 +58,14 @@ async def update_config(
     category = body.category or key.split(".")[0]
 
     await config_service.set(key, body.value, category=category, changed_by="dashboard")
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "dashboard"),
+            action="config.update",
+            resource=f"config:{key}",
+            detail=f"{old_value!r} -> {body.value!r}",
+            ip=request.client.host if request.client else "",
+        )
 
     return {"key": key, "old_value": old_value, "new_value": body.value}

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -6,9 +6,9 @@ import logging
 import shutil
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
-from ante.web.deps import get_data_store
+from ante.web.deps import get_audit_logger_optional, get_data_store
 from ante.web.schemas import (
     DataSchemaResponse,
     DatasetListResponse,
@@ -133,7 +133,9 @@ async def get_storage_summary(
 )
 async def delete_dataset(
     dataset_id: str,
+    request: Request,
     store: Annotated[Any | None, Depends(get_data_store)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
     data_type: str = Query("ohlcv", description="데이터 유형 (ohlcv, fundamental)"),
 ) -> None:
     """데이터셋 삭제.
@@ -161,6 +163,14 @@ async def delete_dataset(
     if not path.exists():
         raise HTTPException(status_code=404, detail="데이터셋을 찾을 수 없습니다")
     shutil.rmtree(path)
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "anonymous"),
+            action="data.delete_dataset",
+            resource=f"dataset:{dataset_id}",
+            ip=request.client.host if request.client else "",
+        )
 
 
 @router.get("/feed-status", response_model=FeedStatusResponse)

--- a/src/ante/web/routes/members.py
+++ b/src/ante/web/routes/members.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from dataclasses import asdict
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
-from ante.web.deps import get_member_service
+from ante.web.deps import get_audit_logger_optional, get_member_service
 from ante.web.schemas import (
     MemberCreateResponse,
     MemberDetailResponse,
@@ -77,7 +77,9 @@ async def list_members(
 )
 async def create_member(
     body: MemberCreateRequest,
+    request: Request,
     svc: Annotated[Any, Depends(get_member_service)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """멤버 등록. 토큰 1회 반환."""
     try:
@@ -94,6 +96,15 @@ async def create_member(
         raise HTTPException(status_code=400, detail=str(e)) from e
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "dashboard"),
+            action="member.create",
+            resource=f"member:{body.member_id}",
+            detail=f"type={body.member_type}, role={body.role}",
+            ip=request.client.host if request.client else "",
+        )
 
     return {"member": asdict(member), "token": token}
 
@@ -128,7 +139,9 @@ async def get_member(
 )
 async def suspend_member(
     member_id: str,
+    request: Request,
     svc: Annotated[Any, Depends(get_member_service)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """멤버 일시 정지."""
     try:
@@ -137,6 +150,15 @@ async def suspend_member(
         raise HTTPException(status_code=404, detail=str(e)) from e
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "dashboard"),
+            action="member.suspend",
+            resource=f"member:{member_id}",
+            ip=request.client.host if request.client else "",
+        )
+
     return {"member": asdict(member)}
 
 
@@ -151,7 +173,9 @@ async def suspend_member(
 )
 async def reactivate_member(
     member_id: str,
+    request: Request,
     svc: Annotated[Any, Depends(get_member_service)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """멤버 재활성화."""
     try:
@@ -160,6 +184,15 @@ async def reactivate_member(
         raise HTTPException(status_code=404, detail=str(e)) from e
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "dashboard"),
+            action="member.reactivate",
+            resource=f"member:{member_id}",
+            ip=request.client.host if request.client else "",
+        )
+
     return {"member": asdict(member)}
 
 
@@ -174,7 +207,9 @@ async def reactivate_member(
 )
 async def revoke_member(
     member_id: str,
+    request: Request,
     svc: Annotated[Any, Depends(get_member_service)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """멤버 영구 폐기."""
     try:
@@ -183,6 +218,15 @@ async def revoke_member(
         raise HTTPException(status_code=404, detail=str(e)) from e
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "dashboard"),
+            action="member.revoke",
+            resource=f"member:{member_id}",
+            ip=request.client.host if request.client else "",
+        )
+
     return {"member": asdict(member)}
 
 
@@ -197,7 +241,9 @@ async def revoke_member(
 )
 async def rotate_token(
     member_id: str,
+    request: Request,
     svc: Annotated[Any, Depends(get_member_service)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """토큰 재발급."""
     try:
@@ -206,6 +252,15 @@ async def rotate_token(
         raise HTTPException(status_code=404, detail=str(e)) from e
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "dashboard"),
+            action="member.rotate_token",
+            resource=f"member:{member_id}",
+            ip=request.client.host if request.client else "",
+        )
+
     return {"member": asdict(member), "token": token}
 
 
@@ -221,7 +276,9 @@ async def rotate_token(
 async def change_password(
     member_id: str,
     body: PasswordChangeRequest,
+    request: Request,
     svc: Annotated[Any, Depends(get_member_service)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """비밀번호 변경 (human 멤버 전용)."""
     try:
@@ -230,6 +287,15 @@ async def change_password(
         raise HTTPException(status_code=404, detail=str(e)) from e
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", member_id),
+            action="member.change_password",
+            resource=f"member:{member_id}",
+            ip=request.client.host if request.client else "",
+        )
+
     return {"ok": True}
 
 
@@ -245,7 +311,9 @@ async def change_password(
 async def update_scopes(
     member_id: str,
     body: ScopesUpdateRequest,
+    request: Request,
     svc: Annotated[Any, Depends(get_member_service)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """권한 범위 변경."""
     try:
@@ -254,4 +322,14 @@ async def update_scopes(
         raise HTTPException(status_code=404, detail=str(e)) from e
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "dashboard"),
+            action="member.update_scopes",
+            resource=f"member:{member_id}",
+            detail=f"scopes={body.scopes}",
+            ip=request.client.host if request.client else "",
+        )
+
     return {"member": asdict(member)}

--- a/src/ante/web/routes/reports.py
+++ b/src/ante/web/routes/reports.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 
-from ante.web.deps import get_report_store
+from ante.web.deps import get_audit_logger_optional, get_report_store
 from ante.web.schemas import (
     ReportDetailResponse,
     ReportListResponse,
@@ -34,10 +34,22 @@ async def get_report_schema() -> dict:
 )
 async def submit_report(
     body: dict,
+    request: Request,
     report_store: Annotated[Any, Depends(get_report_store)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """리포트 제출."""
     report = await report_store.submit(body)
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "anonymous"),
+            action="report.submit",
+            resource=f"report:{report.report_id}",
+            detail=f"strategy={report.strategy_name}",
+            ip=request.client.host if request.client else "",
+        )
+
     return {
         "report_id": report.report_id,
         "strategy": report.strategy_name,

--- a/src/ante/web/routes/system.py
+++ b/src/ante/web/routes/system.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from ante.web.deps import get_system_state, get_system_state_optional
+from ante.web.deps import (
+    get_audit_logger_optional,
+    get_system_state,
+    get_system_state_optional,
+)
 from ante.web.schemas import HealthResponse, KillSwitchResponse, StatusResponse
 
 router = APIRouter()
@@ -72,7 +76,9 @@ async def health_check() -> dict:
 )
 async def kill_switch(
     body: KillSwitchRequest,
+    request: Request,
     system_state: Annotated[Any, Depends(get_system_state)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """킬 스위치 제어 (halt/activate)."""
     from datetime import UTC, datetime
@@ -90,6 +96,17 @@ async def kill_switch(
         )
 
     await system_state.set_state(target, reason=body.reason, changed_by="dashboard")
+
+    action = "system.halt" if body.action == "halt" else "system.activate"
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "dashboard"),
+            action=action,
+            resource="system:kill_switch",
+            detail=body.reason,
+            ip=request.client.host if request.client else "",
+        )
+
     return {
         "status": system_state.trading_state.value,
         "changed_at": datetime.now(UTC).isoformat(),

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from ante.web.deps import get_broker, get_config, get_treasury
+from ante.web.deps import (
+    get_audit_logger_optional,
+    get_broker,
+    get_config,
+    get_treasury,
+)
 from ante.web.schemas import (
     BalanceSetResponse,
     BudgetListResponse,
@@ -142,7 +147,9 @@ async def list_transactions(
 async def allocate(
     bot_id: str,
     body: BudgetChangeRequest,
+    request: Request,
     treasury: Annotated[Any, Depends(get_treasury)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """봇에 예산 할당."""
     from ante.treasury.exceptions import BotNotStoppedError
@@ -159,6 +166,15 @@ async def allocate(
                 "예산 할당 실패: 미할당 자금 부족 또는 금액 오류"
                 f" (요청: {body.amount:,.0f}원)"
             ),
+        )
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "anonymous"),
+            action="treasury.allocate",
+            resource=f"bot:{bot_id}",
+            detail=f"amount={body.amount:,.0f}",
+            ip=request.client.host if request.client else "",
         )
 
     budget = treasury.get_budget(bot_id)
@@ -181,7 +197,9 @@ async def allocate(
 async def deallocate(
     bot_id: str,
     body: BudgetChangeRequest,
+    request: Request,
     treasury: Annotated[Any, Depends(get_treasury)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """봇 예산 회수."""
     from ante.treasury.exceptions import BotNotStoppedError
@@ -195,6 +213,15 @@ async def deallocate(
         raise HTTPException(
             status_code=400,
             detail=f"예산 회수 실패: 가용 예산 부족 (요청: {body.amount:,.0f}원)",
+        )
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "anonymous"),
+            action="treasury.deallocate",
+            resource=f"bot:{bot_id}",
+            detail=f"amount={body.amount:,.0f}",
+            ip=request.client.host if request.client else "",
         )
 
     budget = treasury.get_budget(bot_id)
@@ -234,12 +261,24 @@ async def list_budgets(
 )
 async def set_balance(
     body: BalanceSetRequest,
+    request: Request,
     treasury: Annotated[Any, Depends(get_treasury)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """계좌 총 잔고 수동 설정."""
     from datetime import UTC, datetime
 
     await treasury.set_account_balance(body.balance)
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "anonymous"),
+            action="treasury.set_balance",
+            resource="treasury",
+            detail=f"balance={body.balance:,.0f}",
+            ip=request.client.host if request.client else "",
+        )
+
     return {
         "total_balance": treasury.account_balance,
         "updated_at": datetime.now(UTC).isoformat(),

--- a/tests/unit/test_audit_integration.py
+++ b/tests/unit/test_audit_integration.py
@@ -1,0 +1,302 @@
+"""감사 로그 연동 테스트 — AuditMiddleware + 핸들러 명시적 호출."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402
+
+
+@pytest.fixture
+def audit_logger():
+    """Mock AuditLogger."""
+    mock = AsyncMock()
+    mock.log = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def app(audit_logger):
+    """audit_logger가 주입된 앱."""
+    return create_app(audit_logger=audit_logger)
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+# ── AuditMiddleware 테스트 ──────────────────────────
+
+
+class TestAuditMiddleware:
+    """미들웨어가 상태 변경 요청을 자동 기록한다."""
+
+    def test_post_success_logged(self, client, audit_logger):
+        """POST 성공 시 미들웨어가 api:post 액션으로 기록한다."""
+        # system/kill-switch는 system_state 없이 503 → 미들웨어 기록 안 됨
+        # health는 GET → 미들웨어 기록 안 됨
+        # 503은 성공이 아니므로 기록 안 됨
+        resp = client.get("/api/system/health")
+        assert resp.status_code == 200
+        # GET이므로 미들웨어 호출 없어야 함
+        middleware_calls = [
+            c
+            for c in audit_logger.log.call_args_list
+            if c.kwargs.get("action", "").startswith("api:")
+        ]
+        assert len(middleware_calls) == 0
+
+    def test_get_not_logged_by_middleware(self, client, audit_logger):
+        """GET 요청은 미들웨어가 기록하지 않는다."""
+        client.get("/api/system/status")
+        middleware_calls = [
+            c
+            for c in audit_logger.log.call_args_list
+            if c.kwargs.get("action", "").startswith("api:")
+        ]
+        assert len(middleware_calls) == 0
+
+    def test_failed_request_not_logged(self, client, audit_logger):
+        """실패(4xx/5xx) 응답은 미들웨어가 기록하지 않는다."""
+        # system_state가 없으므로 503 → 기록 안 됨
+        resp = client.post(
+            "/api/system/kill-switch",
+            json={"action": "halt"},
+        )
+        assert resp.status_code == 503
+        middleware_calls = [
+            c
+            for c in audit_logger.log.call_args_list
+            if c.kwargs.get("action", "").startswith("api:")
+        ]
+        assert len(middleware_calls) == 0
+
+
+# ── 핸들러 명시적 호출 테스트 ──────────────────────────
+
+
+class TestHandlerAuditLog:
+    """각 라우트 핸들러의 명시적 audit 호출을 검증한다."""
+
+    def test_login_audit(self, audit_logger):
+        """로그인 성공 시 auth.login 감사 로그가 기록된다."""
+        from types import SimpleNamespace
+
+        member_obj = SimpleNamespace(member_id="user-01", name="User 1", type="human")
+        member_mock = AsyncMock()
+        member_mock.authenticate_password = AsyncMock(return_value=member_obj)
+        member_mock.update_last_active = AsyncMock()
+
+        session_mock = AsyncMock()
+        session_mock.create = AsyncMock(return_value="sess-123")
+
+        app = create_app(
+            audit_logger=audit_logger,
+            member_service=member_mock,
+            session_service=session_mock,
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/api/auth/login",
+            json={"member_id": "user-01", "password": "pw123"},
+        )
+        assert resp.status_code == 200
+
+        # 핸들러 명시적 호출 확인
+        handler_calls = [
+            c
+            for c in audit_logger.log.call_args_list
+            if c.kwargs.get("action") == "auth.login"
+        ]
+        assert len(handler_calls) == 1
+        assert handler_calls[0].kwargs["member_id"] == "user-01"
+        assert handler_calls[0].kwargs["resource"] == "member:user-01"
+
+        # 미들웨어도 기록 (api:post)
+        mw_calls = [
+            c
+            for c in audit_logger.log.call_args_list
+            if c.kwargs.get("action") == "api:post"
+        ]
+        assert len(mw_calls) == 1
+
+    def test_logout_audit(self, audit_logger):
+        """로그아웃 시 auth.logout 감사 로그가 기록된다."""
+        session_mock = AsyncMock()
+        session_mock.validate = AsyncMock(
+            return_value={"member_id": "user-01", "created_at": "2026-01-01T00:00:00"}
+        )
+        session_mock.delete = AsyncMock()
+
+        app = create_app(
+            audit_logger=audit_logger,
+            session_service=session_mock,
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/api/auth/logout",
+            cookies={"ante_session": "sess-123"},
+        )
+        assert resp.status_code == 200
+
+        handler_calls = [
+            c
+            for c in audit_logger.log.call_args_list
+            if c.kwargs.get("action") == "auth.logout"
+        ]
+        assert len(handler_calls) == 1
+        assert handler_calls[0].kwargs["member_id"] == "user-01"
+
+    def test_kill_switch_halt_audit(self, audit_logger):
+        """킬 스위치 halt 시 system.halt 감사 로그가 기록된다."""
+        system_state_mock = AsyncMock()
+        system_state_mock.set_state = AsyncMock()
+        system_state_mock.trading_state = AsyncMock()
+        system_state_mock.trading_state.value = "halted"
+
+        app = create_app(
+            audit_logger=audit_logger,
+            system_state=system_state_mock,
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/api/system/kill-switch",
+            json={"action": "halt", "reason": "emergency"},
+        )
+        assert resp.status_code == 200
+
+        handler_calls = [
+            c
+            for c in audit_logger.log.call_args_list
+            if c.kwargs.get("action") == "system.halt"
+        ]
+        assert len(handler_calls) == 1
+        assert handler_calls[0].kwargs["resource"] == "system:kill_switch"
+        assert handler_calls[0].kwargs["detail"] == "emergency"
+
+    def test_kill_switch_activate_audit(self, audit_logger):
+        """킬 스위치 activate 시 system.activate 감사 로그가 기록된다."""
+        system_state_mock = AsyncMock()
+        system_state_mock.set_state = AsyncMock()
+        system_state_mock.trading_state = AsyncMock()
+        system_state_mock.trading_state.value = "active"
+
+        app = create_app(
+            audit_logger=audit_logger,
+            system_state=system_state_mock,
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/api/system/kill-switch",
+            json={"action": "activate", "reason": "recovered"},
+        )
+        assert resp.status_code == 200
+
+        handler_calls = [
+            c
+            for c in audit_logger.log.call_args_list
+            if c.kwargs.get("action") == "system.activate"
+        ]
+        assert len(handler_calls) == 1
+
+    def test_config_update_audit(self, audit_logger):
+        """설정 변경 시 config.update 감사 로그가 기록된다."""
+        config_mock = AsyncMock()
+        config_mock.exists = AsyncMock(return_value=True)
+        config_mock.get = AsyncMock(return_value=0.05)
+        config_mock.set = AsyncMock()
+
+        app = create_app(
+            audit_logger=audit_logger,
+            dynamic_config=config_mock,
+        )
+        client = TestClient(app)
+
+        resp = client.put(
+            "/api/config/risk.max_mdd",
+            json={"value": 0.10},
+        )
+        assert resp.status_code == 200
+
+        handler_calls = [
+            c
+            for c in audit_logger.log.call_args_list
+            if c.kwargs.get("action") == "config.update"
+        ]
+        assert len(handler_calls) == 1
+        assert handler_calls[0].kwargs["resource"] == "config:risk.max_mdd"
+
+    def test_treasury_set_balance_audit(self, audit_logger):
+        """잔고 설정 시 treasury.set_balance 감사 로그가 기록된다."""
+        treasury_mock = AsyncMock()
+        treasury_mock.set_account_balance = AsyncMock()
+        treasury_mock.account_balance = 10_000_000.0
+
+        app = create_app(
+            audit_logger=audit_logger,
+            treasury=treasury_mock,
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/api/treasury/balance",
+            json={"balance": 10_000_000},
+        )
+        assert resp.status_code == 200
+
+        handler_calls = [
+            c
+            for c in audit_logger.log.call_args_list
+            if c.kwargs.get("action") == "treasury.set_balance"
+        ]
+        assert len(handler_calls) == 1
+        assert handler_calls[0].kwargs["resource"] == "treasury"
+
+    def test_dual_recording(self, audit_logger):
+        """핸들러 + 미들웨어 이중 기록이 동작한다."""
+        config_mock = AsyncMock()
+        config_mock.exists = AsyncMock(return_value=True)
+        config_mock.get = AsyncMock(return_value="old")
+        config_mock.set = AsyncMock()
+
+        app = create_app(
+            audit_logger=audit_logger,
+            dynamic_config=config_mock,
+        )
+        client = TestClient(app)
+
+        resp = client.put(
+            "/api/config/test.key",
+            json={"value": "new"},
+        )
+        assert resp.status_code == 200
+
+        # 핸들러 기록
+        handler_calls = [
+            c
+            for c in audit_logger.log.call_args_list
+            if c.kwargs.get("action") == "config.update"
+        ]
+        assert len(handler_calls) == 1
+
+        # 미들웨어 기록
+        mw_calls = [
+            c
+            for c in audit_logger.log.call_args_list
+            if c.kwargs.get("action") == "api:put"
+        ]
+        assert len(mw_calls) == 1
+
+        # 총 2건 기록 (이중 구조)
+        assert audit_logger.log.call_count == 2

--- a/tests/unit/test_bot_create_params.py
+++ b/tests/unit/test_bot_create_params.py
@@ -102,8 +102,14 @@ class TestBotCreateWithParams:
             assert "생성 완료" in result.output
 
             # DB에 저장된 config_json에 params 포함 확인
-            call_args = mock_db.execute.call_args[0]
-            config_json = call_args[1][4]
+            # INSERT INTO bots 호출을 찾기 (audit 로그 호출과 구분)
+            bot_insert = [
+                c
+                for c in mock_db.execute.call_args_list
+                if "INSERT INTO bots" in str(c[0][0])
+            ]
+            assert len(bot_insert) == 1
+            config_json = bot_insert[0][0][1][4]
             config = json.loads(config_json)
             assert config["params"]["lookback"] == 20
             assert config["params"]["threshold"] == 0.5
@@ -122,8 +128,13 @@ class TestBotCreateWithParams:
             assert result.exit_code == 0
 
             # params 키가 없어야 함
-            call_args = mock_db.execute.call_args[0]
-            config_json = call_args[1][4]
+            bot_insert = [
+                c
+                for c in mock_db.execute.call_args_list
+                if "INSERT INTO bots" in str(c[0][0])
+            ]
+            assert len(bot_insert) == 1
+            config_json = bot_insert[0][0][1][4]
             config = json.loads(config_json)
             assert "params" not in config
 


### PR DESCRIPTION
## Summary

- AuditMiddleware(안전망) 구현: 모든 POST/PUT/DELETE/PATCH 성공 응답을 `api:{method}` 액션으로 자동 기록
- Web API 핸들러 20건에 명시적 audit 호출 추가 (auth, approval, bot, member, config, treasury, system, report, data)
- CLI 커맨드 7건에 감사 로그 기록 추가 (approval approve/reject/cancel, system halt/activate, bot create/remove)
- 미들웨어 + 핸들러 이중 기록 구조로 감사 로그 누락 방지

## Test plan

- [x] AuditMiddleware: GET 미기록, POST 성공 기록, 실패(4xx/5xx) 미기록 검증
- [x] 핸들러 명시적 호출: login, logout, kill-switch, config update, set balance 등 개별 검증
- [x] 이중 기록: 하나의 요청에 핸들러 + 미들웨어 2건 기록 확인
- [x] 기존 테스트 전체 통과 (1995 passed)

Refs #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)