### PR TITLE
feat(audit): 감사 로그 보존 기간 정책(retention) 구현

### DIFF
--- a/config/system.toml.example
+++ b/config/system.toml.example
@@ -2,7 +2,7 @@
 # 이 파일을 config/system.toml 로 복사하여 사용하세요.
 
 [system]
-log_level = "INFO"          # DEBUG, INFO, WARNING, ERROR
+log_level = "INFO"  # DEBUG, INFO, WARNING, ERROR
 timezone = "Asia/Seoul"
 
 [db]
@@ -12,7 +12,7 @@ path = "db/ante.db"
 path = "data/"
 
 [web]
-enabled = false             # 대시보드 활성화 시 true
+enabled = false  # 대시보드 활성화 시 true
 host = "0.0.0.0"
 port = 8000
 
@@ -20,30 +20,33 @@ port = 8000
 history_size = 1000
 
 [broker]
-type = "kis"                # "kis" | "test" | "mock"
+type = "kis"  # "kis" | "test" | "mock"
 # KIS: secrets.env 에서 앱키/시크릿/계좌번호 관리
 # Test: KIS 시크릿 없이 시뮬레이션 구동 (broker.test 섹션 참조)
 # Mock: E2E 테스트 자동화 전용
-is_paper = true             # true: 모의투자, false: 실전투자
-commission_rate = 0.00015   # 매매 수수료율
-sell_tax_rate = 0.0023      # 매도 세금율 (증권거래세+농특세)
+is_paper = true  # true: 모의투자, false: 실전투자
+commission_rate = 0.00015  # 매매 수수료율
+sell_tax_rate = 0.0023  # 매도 세금율 (증권거래세+농특세)
 
 # Test 브로커 전용 설정 (type = "test" 일 때만 사용)
 [broker.test]
-seed = 42                   # 재현 가능한 시뮬레이션 시드
-initial_cash = 100000000    # 초기 자금 (1억)
-tick_interval = 1.0         # 가격 변동 간격 (초)
+seed = 42  # 재현 가능한 시뮬레이션 시드
+initial_cash = 100000000  # 초기 자금 (1억)
+tick_interval = 1.0  # 가격 변동 간격 (초)
+
+[audit]
+retention_days = 90  # 감사 로그 보존 기간 (일). 0이면 무기한 보존
 
 [treasury]
-sync_interval_seconds = 300 # 잔고 동기화 주기 (초)
+sync_interval_seconds = 300  # 잔고 동기화 주기 (초)
 
 # 결재 전결 (자동 승인) 설정
 # ⚠️ 잘못된 설정은 의도하지 않은 거래·자금 변동으로 이어질 수 있으므로 신중하게 사용
 [approval.auto_approve]
-enabled = false                  # 전결 기능 전체 on/off (기본: false)
+enabled = false  # 전결 기능 전체 on/off (기본: false)
 
 # 유형별 전결 규칙 (enabled = true일 때만 적용)
 [approval.auto_approve.rules]
-bot_stop = true                  # 봇 중지는 항상 자동 승인
-bot_create_paper = true          # 모의투자 봇 생성은 자동 승인
-budget_change_max = 5000000      # 예산 변경 500만원 이하 자동 승인 (0이면 비활성)
+bot_stop = true  # 봇 중지는 항상 자동 승인
+bot_create_paper = true  # 모의투자 봇 생성은 자동 승인
+budget_change_max = 5000000  # 예산 변경 500만원 이하 자동 승인 (0이면 비활성)

--- a/src/ante/audit/logger.py
+++ b/src/ante/audit/logger.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from ante.core.database import Database
 
@@ -102,3 +102,35 @@ class AuditLogger:
         sql = f"SELECT COUNT(*) as cnt FROM audit_log {where}"
         row = await self._db.fetch_one(sql, tuple(params))
         return row["cnt"] if row else 0
+
+    async def cleanup(self, retention_days: int) -> int:
+        """보존 기간 초과 로그 삭제. 삭제 건수 반환.
+
+        Args:
+            retention_days: 보존 일수. 0이면 삭제하지 않음.
+
+        Returns:
+            삭제된 로그 건수.
+        """
+        if retention_days <= 0:
+            return 0
+
+        cutoff = (datetime.now(UTC) - timedelta(days=retention_days)).strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        )
+
+        # Database.execute()는 rowcount를 반환하지 않으므로 사전 카운트
+        row = await self._db.fetch_one(
+            "SELECT COUNT(*) as cnt FROM audit_log WHERE created_at < ?",
+            (cutoff,),
+        )
+        count = row["cnt"] if row else 0
+
+        if count > 0:
+            await self._db.execute(
+                "DELETE FROM audit_log WHERE created_at < ?",
+                (cutoff,),
+            )
+            logger.info("감사 로그 정리: %d건 삭제 (기준: %s)", count, cutoff)
+
+        return count

--- a/src/ante/config/defaults.py
+++ b/src/ante/config/defaults.py
@@ -25,6 +25,7 @@ DEFAULTS: dict[str, object] = {
     "broker.timeout.query": 5,
     "broker.timeout.auth": 10,
     "treasury.sync_interval_seconds": 300,
+    "audit.retention_days": 90,
     "telegram.command.polling_interval": 3.0,
     "telegram.command.confirm_timeout": 30.0,
 }

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -56,6 +56,7 @@ class Services:
     telegram_receiver: Any = None
     web_task: asyncio.Task | None = None  # type: ignore[type-arg]
     approval_expire_task: asyncio.Task | None = None  # type: ignore[type-arg]
+    audit_cleanup_task: asyncio.Task | None = None  # type: ignore[type-arg]
     commission_rate: float = 0.00015
     sell_tax_rate: float = 0.0023
     _cleanup_tasks: list[str] = field(default_factory=list)
@@ -117,6 +118,20 @@ async def _init_services(s: Services) -> None:
 
     s.audit_logger = AuditLogger(db=s.db)
     await s.audit_logger.initialize()
+
+    # 감사 로그 보존 기간 정리 태스크
+    retention_days = s.config.get("audit.retention_days", 90)
+    if retention_days > 0:
+        s.audit_cleanup_task = asyncio.create_task(
+            _audit_cleanup_loop(s.audit_logger, retention_days),
+            name="audit-cleanup",
+        )
+        logger.info(
+            "감사 로그 정리 스케줄러 시작 (보존: %d일, 주기: 24시간)", retention_days
+        )
+    else:
+        logger.info("감사 로그 자동 정리 비활성화 (retention_days=0)")
+
     logger.info("AuditLogger 초기화 완료")
 
     from ante.member import MemberService
@@ -607,6 +622,24 @@ async def _init_feed(s: Services) -> None:
     logger.info("결재 만료 스케줄러 시작 (주기: 300초)")
 
 
+async def _audit_cleanup_loop(
+    audit_logger: Any,
+    retention_days: int,
+    interval: float = 86400.0,
+) -> None:
+    """보존 기간 초과 감사 로그를 주기적으로 삭제."""
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            deleted = await audit_logger.cleanup(retention_days)
+            if deleted:
+                logger.info("감사 로그 정리 완료: %d건 삭제", deleted)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("감사 로그 정리 스케줄러 오류")
+
+
 async def _approval_expire_loop(
     approval_service: Any,
     interval: float = 300.0,
@@ -748,6 +781,14 @@ async def _shutdown(s: Services) -> None:
     if s.telegram_receiver:
         await s.telegram_receiver.stop()
         logger.info("TelegramCommandReceiver 종료")
+
+    if s.audit_cleanup_task and not s.audit_cleanup_task.done():
+        s.audit_cleanup_task.cancel()
+        try:
+            await s.audit_cleanup_task
+        except asyncio.CancelledError:
+            pass
+        logger.info("감사 로그 정리 스케줄러 종료")
 
     if s.approval_expire_task and not s.approval_expire_task.done():
         s.approval_expire_task.cancel()

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
 from ante.audit import AuditLogger
@@ -154,3 +156,102 @@ class TestAuditInit:
         await al.initialize()
         await al.log(member_id="test", action="test.action")
         assert await al.count() == 1
+
+
+# ── 보존 기간 정리 ────────────────────────────────
+
+
+class TestAuditCleanup:
+    """감사 로그 보존 기간(retention) 정리 테스트."""
+
+    async def test_cleanup_deletes_old_logs(
+        self, audit_logger: AuditLogger, db: Database
+    ) -> None:
+        """retention_days 이전 로그가 삭제된다."""
+        # 현재 로그 1건 기록
+        await audit_logger.log(member_id="user-01", action="auth.login")
+
+        # 100일 전 로그를 직접 INSERT
+        old_time = (datetime.now(UTC) - timedelta(days=100)).strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        )
+        await db.execute(
+            "INSERT INTO audit_log"
+            " (member_id, action, resource, detail, ip, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            ("user-01", "old.action", "", "", "", old_time),
+        )
+        assert await audit_logger.count() == 2
+
+        deleted = await audit_logger.cleanup(retention_days=90)
+        assert deleted == 1
+        assert await audit_logger.count() == 1
+
+        # 남은 건은 최근 로그
+        logs = await audit_logger.query()
+        assert logs[0]["action"] == "auth.login"
+
+    async def test_cleanup_keeps_recent_logs(
+        self, audit_logger: AuditLogger, db: Database
+    ) -> None:
+        """보존 기간 이내 로그는 삭제되지 않는다."""
+        # 30일 전 로그 (retention 90일 이내)
+        recent_time = (datetime.now(UTC) - timedelta(days=30)).strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        )
+        await db.execute(
+            "INSERT INTO audit_log"
+            " (member_id, action, resource, detail, ip, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            ("user-01", "recent.action", "", "", "", recent_time),
+        )
+        await audit_logger.log(member_id="user-01", action="auth.login")
+
+        deleted = await audit_logger.cleanup(retention_days=90)
+        assert deleted == 0
+        assert await audit_logger.count() == 2
+
+    async def test_cleanup_zero_retention_disabled(
+        self, audit_logger: AuditLogger, db: Database
+    ) -> None:
+        """retention_days=0이면 삭제하지 않는다."""
+        old_time = (datetime.now(UTC) - timedelta(days=1000)).strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        )
+        await db.execute(
+            "INSERT INTO audit_log"
+            " (member_id, action, resource, detail, ip, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            ("user-01", "ancient.action", "", "", "", old_time),
+        )
+        assert await audit_logger.count() == 1
+
+        deleted = await audit_logger.cleanup(retention_days=0)
+        assert deleted == 0
+        assert await audit_logger.count() == 1
+
+    async def test_cleanup_empty_table(self, audit_logger: AuditLogger) -> None:
+        """빈 테이블에서 cleanup 호출해도 안전."""
+        deleted = await audit_logger.cleanup(retention_days=90)
+        assert deleted == 0
+
+    async def test_cleanup_multiple_old_logs(
+        self, audit_logger: AuditLogger, db: Database
+    ) -> None:
+        """여러 건의 오래된 로그가 한 번에 삭제된다."""
+        old_time = (datetime.now(UTC) - timedelta(days=100)).strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        )
+        for i in range(5):
+            await db.execute(
+                "INSERT INTO audit_log"
+                " (member_id, action, resource, detail, ip, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                ("user-01", f"old.action.{i}", "", "", "", old_time),
+            )
+        await audit_logger.log(member_id="user-01", action="recent.action")
+        assert await audit_logger.count() == 6
+
+        deleted = await audit_logger.cleanup(retention_days=90)
+        assert deleted == 5
+        assert await audit_logger.count() == 1


### PR DESCRIPTION
## Summary
- `AuditLogger.cleanup(retention_days)` 메서드 추가: 보존 기간 초과 로그를 삭제하고 삭제 건수를 반환
- `retention_days = 0`이면 자동 삭제 비활성화 (무기한 보존)
- `main.py`에 24시간 주기 정리 태스크 등록 + graceful shutdown 처리
- `config/defaults.py`에 `audit.retention_days = 90` 기본값 추가
- `system.toml.example`에 `[audit]` 섹션 추가

## Changed Files
| 파일 | 변경 내용 |
|------|----------|
| `src/ante/audit/logger.py` | `cleanup()` 메서드 추가 |
| `src/ante/config/defaults.py` | `audit.retention_days` 기본값 추가 |
| `config/system.toml.example` | `[audit]` 섹션 추가 |
| `src/ante/main.py` | 주기적 정리 태스크 등록 + shutdown 처리 |
| `tests/unit/test_audit.py` | 5건 단위 테스트 추가 |

## Test plan
- [x] cleanup()이 retention_days 초과 로그를 삭제
- [x] 보존 기간 이내 로그는 삭제되지 않음
- [x] retention_days=0이면 삭제하지 않음
- [x] 빈 테이블에서도 안전
- [x] 여러 건의 오래된 로그 일괄 삭제
- [x] 전체 테스트 2000건 통과

Refs #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)