### PR TITLE
feat: KISStreamClient ↔ APIGateway 실시간 시세 연동

### DIFF
--- a/src/ante/gateway/__init__.py
+++ b/src/ante/gateway/__init__.py
@@ -6,6 +6,7 @@ from ante.gateway.gateway import APIGateway
 from ante.gateway.queue import APIRequest, RequestPriority, RequestQueue
 from ante.gateway.rate_limiter import RateLimitConfig, RateLimiter
 from ante.gateway.stop_order import StopOrderManager
+from ante.gateway.stream_integration import StreamIntegration
 
 __all__ = [
     "APIGateway",
@@ -17,4 +18,5 @@ __all__ = [
     "RequestPriority",
     "APIRequest",
     "StopOrderManager",
+    "StreamIntegration",
 ]

--- a/src/ante/gateway/stream_integration.py
+++ b/src/ante/gateway/stream_integration.py
@@ -1,0 +1,308 @@
+"""StreamIntegration — KISStreamClient와 APIGateway 실시간 시세 연동.
+
+KIS WebSocket 실시간 시세를 수신하여:
+- ResponseCache에 가격 적재
+- StopOrderManager에 가격 전달
+- 체결 통보 시 캐시 무효화 및 이벤트 발행
+- 활성 봇의 모니터링 종목 자동 구독/해제
+- 스트림 연결 해제 시 REST 폴링 폴백
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ante.bot.manager import BotManager
+    from ante.broker.kis_stream import KISStreamClient
+    from ante.eventbus.bus import EventBus
+    from ante.gateway.cache import ResponseCache
+    from ante.gateway.gateway import APIGateway
+    from ante.gateway.stop_order import StopOrderManager
+
+logger = logging.getLogger(__name__)
+
+# REST 폴링 폴백 주기 (초)
+DEFAULT_FALLBACK_POLL_INTERVAL = 5.0
+
+# 종목 구독 동기화 주기 (초)
+DEFAULT_SYNC_INTERVAL = 10.0
+
+
+class StreamIntegration:
+    """KISStreamClient ↔ APIGateway 실시간 시세 연동 관리자.
+
+    - 시세 콜백: cache.set + stop_order.on_price_update
+    - 체결 콜백: 캐시 무효화 + 이벤트 발행
+    - 활성 봇 종목 구독/해제 메커니즘
+    - 스트림 해제 시 REST 폴백
+    """
+
+    def __init__(
+        self,
+        stream_client: KISStreamClient,
+        cache: ResponseCache,
+        eventbus: EventBus,
+        stop_order_manager: StopOrderManager | None = None,
+        gateway: APIGateway | None = None,
+        bot_manager: BotManager | None = None,
+        fallback_poll_interval: float = DEFAULT_FALLBACK_POLL_INTERVAL,
+        sync_interval: float = DEFAULT_SYNC_INTERVAL,
+    ) -> None:
+        self._stream = stream_client
+        self._cache = cache
+        self._eventbus = eventbus
+        self._stop_order_manager = stop_order_manager
+        self._gateway = gateway
+        self._bot_manager = bot_manager
+        self._fallback_poll_interval = fallback_poll_interval
+        self._sync_interval = sync_interval
+
+        self._running = False
+        self._fallback_task: asyncio.Task[None] | None = None
+        self._sync_task: asyncio.Task[None] | None = None
+        self._fallback_active = False
+
+    @property
+    def is_stream_connected(self) -> bool:
+        """스트림 연결 상태."""
+        return self._stream.is_connected
+
+    @property
+    def is_fallback_active(self) -> bool:
+        """REST 폴링 폴백 활성 여부."""
+        return self._fallback_active
+
+    async def start(self) -> None:
+        """연동 시작: 콜백 등록 → 스트림 연결 → 구독 동기화 시작."""
+        if self._running:
+            return
+
+        self._running = True
+
+        # 콜백 등록
+        self._stream.on_price(self._on_price)
+        self._stream.on_execution(self._on_execution)
+
+        # 이벤트 구독 (연결/해제 감지)
+        from ante.eventbus.events import StreamConnectedEvent, StreamDisconnectedEvent
+
+        self._eventbus.subscribe(StreamConnectedEvent, self._on_stream_connected)
+        self._eventbus.subscribe(StreamDisconnectedEvent, self._on_stream_disconnected)
+
+        # 봇 시작/종료 이벤트 구독 (종목 구독 동기화용)
+        from ante.eventbus.events import BotStartedEvent, BotStoppedEvent
+
+        self._eventbus.subscribe(BotStartedEvent, self._on_bot_changed)
+        self._eventbus.subscribe(BotStoppedEvent, self._on_bot_changed)
+
+        # 스트림 연결
+        await self._stream.connect()
+        await self._stream.subscribe_execution()
+
+        # 종목 구독 동기화 태스크 시작
+        self._sync_task = asyncio.create_task(
+            self._subscription_sync_loop(),
+            name="stream-subscription-sync",
+        )
+
+        logger.info("StreamIntegration 시작")
+
+    async def stop(self) -> None:
+        """연동 중지: 폴백 중지 → 동기화 중지 → 스트림 해제."""
+        if not self._running:
+            return
+
+        self._running = False
+
+        # 폴백 태스크 정리
+        await self._stop_fallback()
+
+        # 동기화 태스크 정리
+        if self._sync_task and not self._sync_task.done():
+            self._sync_task.cancel()
+            try:
+                await self._sync_task
+            except asyncio.CancelledError:
+                pass
+            self._sync_task = None
+
+        # 스트림 해제
+        await self._stream.disconnect()
+
+        logger.info("StreamIntegration 중지")
+
+    # ── 시세 콜백 ──────────────────────────────────
+
+    async def _on_price(self, symbol: str, price: float) -> None:
+        """실시간 시세 수신 콜백.
+
+        KIS WebSocket ──시세수신──> 콜백
+            +-> ResponseCache.set("price:KRX:{symbol}", ...)
+            +-> StopOrderManager.on_price_update(symbol, price)
+        """
+        # 캐시 적재
+        cache_key = f"price:KRX:{symbol}"
+        self._cache.set(cache_key, price, ttl=5)
+
+        # StopOrderManager 시세 전달
+        if self._stop_order_manager:
+            try:
+                await self._stop_order_manager.on_price_update(symbol, price)
+            except Exception:
+                logger.exception("StopOrderManager 시세 전달 오류: %s", symbol)
+
+    # ── 체결 콜백 ──────────────────────────────────
+
+    async def _on_execution(self, execution: dict[str, Any]) -> None:
+        """실시간 체결 통보 콜백.
+
+        캐시 무효화 + OrderFilledEvent 발행.
+        """
+        symbol = execution.get("symbol", "")
+
+        # 캐시 무효화: balance, positions, 해당 종목 시세
+        self._cache.invalidate("balance")
+        self._cache.invalidate("positions")
+        if symbol:
+            self._cache.invalidate(f"price:KRX:{symbol}")
+
+        # 체결 이벤트 발행
+        from ante.eventbus.events import OrderFilledEvent
+
+        await self._eventbus.publish(
+            OrderFilledEvent(
+                order_id=execution.get("order_id", ""),
+                symbol=symbol,
+                side=execution.get("side", ""),
+                quantity=execution.get("quantity", 0.0),
+                price=execution.get("price", 0.0),
+                exchange="KRX",
+            )
+        )
+
+        logger.debug("체결 통보 처리: %s %s", symbol, execution.get("side", ""))
+
+    # ── 스트림 연결/해제 이벤트 ──────────────────────
+
+    async def _on_stream_connected(self, event: object) -> None:
+        """스트림 연결 성공 시 폴백 중지."""
+        await self._stop_fallback()
+        logger.info("스트림 연결됨 — REST 폴링 폴백 중지")
+
+    async def _on_stream_disconnected(self, event: object) -> None:
+        """스트림 연결 해제 시 REST 폴링 폴백 시작."""
+        if not self._running:
+            return
+        await self._start_fallback()
+        logger.warning("스트림 연결 해제 — REST 폴링 폴백 시작")
+
+    # ── REST 폴링 폴백 ──────────────────────────────
+
+    async def _start_fallback(self) -> None:
+        """REST 폴링 폴백 시작."""
+        if self._fallback_active:
+            return
+        if not self._gateway:
+            logger.warning("APIGateway 미설정 — REST 폴링 폴백 불가")
+            return
+
+        self._fallback_active = True
+        self._fallback_task = asyncio.create_task(
+            self._fallback_poll_loop(),
+            name="stream-fallback-poll",
+        )
+
+    async def _stop_fallback(self) -> None:
+        """REST 폴링 폴백 중지."""
+        self._fallback_active = False
+        if self._fallback_task and not self._fallback_task.done():
+            self._fallback_task.cancel()
+            try:
+                await self._fallback_task
+            except asyncio.CancelledError:
+                pass
+            self._fallback_task = None
+
+    async def _fallback_poll_loop(self) -> None:
+        """스트림 해제 시 REST API로 시세 폴링."""
+        while self._fallback_active and self._running:
+            try:
+                symbols = self._get_monitored_symbols()
+                for symbol in symbols:
+                    if not self._fallback_active or not self._running:
+                        return
+                    try:
+                        price = await self._gateway.get_current_price(symbol)
+                        cache_key = f"price:KRX:{symbol}"
+                        self._cache.set(cache_key, price, ttl=5)
+
+                        if self._stop_order_manager:
+                            await self._stop_order_manager.on_price_update(
+                                symbol, price
+                            )
+                    except Exception:
+                        logger.warning("REST 폴링 실패: %s", symbol, exc_info=True)
+
+                await asyncio.sleep(self._fallback_poll_interval)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("REST 폴링 폴백 루프 오류")
+                await asyncio.sleep(self._fallback_poll_interval)
+
+    # ── 종목 구독 동기화 ──────────────────────────────
+
+    async def _on_bot_changed(self, event: object) -> None:
+        """봇 시작/종료 시 종목 구독 즉시 동기화."""
+        await self._sync_subscriptions()
+
+    async def _subscription_sync_loop(self) -> None:
+        """주기적으로 활성 봇 종목과 스트림 구독 동기화."""
+        while self._running:
+            try:
+                await asyncio.sleep(self._sync_interval)
+                await self._sync_subscriptions()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("종목 구독 동기화 오류")
+
+    async def _sync_subscriptions(self) -> None:
+        """활성 봇 모니터링 종목을 스트림에 구독/해제."""
+        desired = self._get_monitored_symbols()
+        current = self._stream.subscribed_symbols
+
+        # 새로 구독해야 할 종목
+        to_subscribe = desired - current
+        # 해제해야 할 종목
+        to_unsubscribe = current - desired
+
+        for symbol in to_subscribe:
+            success = await self._stream.subscribe(symbol)
+            if success:
+                logger.debug("종목 구독 추가: %s", symbol)
+
+        for symbol in to_unsubscribe:
+            await self._stream.unsubscribe(symbol)
+            logger.debug("종목 구독 해제: %s", symbol)
+
+    def _get_monitored_symbols(self) -> set[str]:
+        """모니터링 대상 종목 수집 (활성 봇 + StopOrderManager)."""
+        symbols: set[str] = set()
+
+        # 활성 봇의 종목 (봇 info에서 추출 가능한 경우)
+        if self._bot_manager:
+            for bot_info in self._bot_manager.list_bots():
+                if bot_info.get("status") == "running":
+                    bot = self._bot_manager.get_bot(bot_info["bot_id"])
+                    if bot and hasattr(bot, "monitored_symbols"):
+                        symbols.update(bot.monitored_symbols)
+
+        # StopOrderManager의 모니터링 종목
+        if self._stop_order_manager:
+            symbols.update(self._stop_order_manager.monitored_symbols)
+
+        return symbols

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -46,6 +46,7 @@ class Services:
     strategy_snapshot: Any = None
     broker: Any = None
     api_gateway: Any = None
+    stream_integration: Any = None
     data_provider: Any = None
     parquet_store: Any = None
     data_collector: Any = None
@@ -253,8 +254,9 @@ async def _init_trading(s: Services) -> None:
 
 
 async def _init_broker(s: Services) -> None:
-    """Broker, APIGateway 연결 및 종목 마스터 동기화."""
+    """Broker, APIGateway, StreamIntegration 연결 및 종목 마스터 동기화."""
     from ante.gateway import APIGateway
+    from ante.gateway.stop_order import StopOrderManager
 
     broker_config = s.config.get("broker", {})
     broker_type = (
@@ -268,10 +270,22 @@ async def _init_broker(s: Services) -> None:
     else:
         await _connect_kis_broker(s, broker_config)
 
+    # StopOrderManager 초기화
+    stop_order_manager = StopOrderManager(eventbus=s.eventbus)
+    stop_order_manager.start()
+
     if s.broker:
-        s.api_gateway = APIGateway(broker=s.broker, eventbus=s.eventbus)
+        s.api_gateway = APIGateway(
+            broker=s.broker,
+            eventbus=s.eventbus,
+            stop_order_manager=stop_order_manager,
+        )
         s.api_gateway.start()
         logger.info("APIGateway 시작 완료")
+
+    # KIS 브로커일 때 StreamIntegration 초기화
+    if s.broker and broker_type == "kis":
+        await _init_stream_integration(s, broker_config, stop_order_manager)
 
     if s.broker:
         await _sync_instruments(s)
@@ -328,6 +342,48 @@ async def _connect_kis_broker(s: Services, broker_config: dict) -> None:
     except Exception:
         logger.warning("KISAdapter 연결 실패 — 브로커 없이 시작", exc_info=True)
         s.broker = None
+
+
+async def _init_stream_integration(
+    s: Services,
+    broker_config: dict,
+    stop_order_manager: Any,
+) -> None:
+    """KISStreamClient + StreamIntegration 초기화."""
+    from ante.broker.kis_stream import KISStreamClient
+    from ante.gateway.stream_integration import StreamIntegration
+
+    is_paper = broker_config.get("is_paper", True)
+    ws_url = (
+        "ws://ops.koreainvestment.com:21000"
+        if is_paper
+        else "ws://ops.koreainvestment.com:31000"
+    )
+
+    stream_client = KISStreamClient(
+        websocket_url=ws_url,
+        app_key=broker_config.get("app_key", ""),
+        app_secret=broker_config.get("app_secret", ""),
+        eventbus=s.eventbus,
+    )
+
+    s.stream_integration = StreamIntegration(
+        stream_client=stream_client,
+        cache=s.api_gateway._cache,
+        eventbus=s.eventbus,
+        stop_order_manager=stop_order_manager,
+        gateway=s.api_gateway,
+        bot_manager=s.bot_manager,
+    )
+
+    try:
+        await s.stream_integration.start()
+        logger.info("StreamIntegration 시작 완료 (paper=%s)", is_paper)
+    except Exception:
+        logger.warning(
+            "StreamIntegration 시작 실패 — REST 전용 모드로 운영", exc_info=True
+        )
+        s.stream_integration = None
 
 
 async def _sync_instruments(s: Services) -> None:
@@ -810,6 +866,10 @@ async def _shutdown(s: Services) -> None:
 
     await s.bot_manager.stop_all()
     logger.info("BotManager 종료 — 모든 봇 중지")
+
+    if s.stream_integration:
+        await s.stream_integration.stop()
+        logger.info("StreamIntegration 종료")
 
     if s.api_gateway:
         s.api_gateway.stop()

--- a/tests/unit/test_stream_integration.py
+++ b/tests/unit/test_stream_integration.py
@@ -1,0 +1,503 @@
+"""StreamIntegration 단위 테스트."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ante.eventbus.bus import EventBus
+from ante.eventbus.events import (
+    BotStartedEvent,
+    BotStoppedEvent,
+    OrderFilledEvent,
+    StreamConnectedEvent,
+    StreamDisconnectedEvent,
+)
+from ante.gateway.cache import ResponseCache
+from ante.gateway.stop_order import StopOrderManager
+from ante.gateway.stream_integration import StreamIntegration
+
+# ── Fixtures ──────────────────────────────────────
+
+
+class FakeStreamClient:
+    """테스트용 KISStreamClient 대체."""
+
+    def __init__(self) -> None:
+        self._connected = False
+        self._subscribed: set[str] = set()
+        self._price_callbacks: list = []
+        self._execution_callbacks: list = []
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    @property
+    def subscribed_symbols(self) -> set[str]:
+        return set(self._subscribed)
+
+    def on_price(self, callback: Any) -> None:
+        self._price_callbacks.append(callback)
+
+    def on_execution(self, callback: Any) -> None:
+        self._execution_callbacks.append(callback)
+
+    async def connect(self) -> None:
+        self._connected = True
+
+    async def disconnect(self) -> None:
+        self._connected = False
+        self._subscribed.clear()
+
+    async def subscribe(self, symbol: str) -> bool:
+        self._subscribed.add(symbol)
+        return True
+
+    async def unsubscribe(self, symbol: str) -> None:
+        self._subscribed.discard(symbol)
+
+    async def subscribe_execution(self) -> None:
+        pass
+
+    async def fire_price(self, symbol: str, price: float) -> None:
+        """테스트에서 시세 콜백 수동 호출."""
+        for cb in self._price_callbacks:
+            await cb(symbol, price)
+
+    async def fire_execution(self, execution: dict) -> None:
+        """테스트에서 체결 콜백 수동 호출."""
+        for cb in self._execution_callbacks:
+            await cb(execution)
+
+
+@pytest.fixture
+def eventbus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+def cache() -> ResponseCache:
+    return ResponseCache()
+
+
+@pytest.fixture
+def stop_order_manager(eventbus: EventBus) -> StopOrderManager:
+    mgr = StopOrderManager(eventbus=eventbus)
+    mgr.start()
+    return mgr
+
+
+@pytest.fixture
+def stream_client() -> FakeStreamClient:
+    return FakeStreamClient()
+
+
+@pytest.fixture
+def gateway_mock() -> MagicMock:
+    gw = MagicMock()
+    gw.get_current_price = AsyncMock(return_value=50000.0)
+    return gw
+
+
+@pytest.fixture
+def bot_manager_mock() -> MagicMock:
+    bm = MagicMock()
+    bm.list_bots.return_value = []
+    bm.get_bot.return_value = None
+    return bm
+
+
+@pytest.fixture
+def integration(
+    stream_client: FakeStreamClient,
+    cache: ResponseCache,
+    eventbus: EventBus,
+    stop_order_manager: StopOrderManager,
+    gateway_mock: MagicMock,
+    bot_manager_mock: MagicMock,
+) -> StreamIntegration:
+    return StreamIntegration(
+        stream_client=stream_client,
+        cache=cache,
+        eventbus=eventbus,
+        stop_order_manager=stop_order_manager,
+        gateway=gateway_mock,
+        bot_manager=bot_manager_mock,
+        fallback_poll_interval=0.1,
+        sync_interval=0.1,
+    )
+
+
+# ── 시세 콜백 테스트 ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_price_callback_updates_cache(
+    integration: StreamIntegration,
+    stream_client: FakeStreamClient,
+    cache: ResponseCache,
+) -> None:
+    """시세 수신 시 ResponseCache에 가격이 적재된다."""
+    await integration.start()
+    try:
+        await stream_client.fire_price("005930", 72000.0)
+
+        cached = cache.get("price:KRX:005930")
+        assert cached == 72000.0
+    finally:
+        await integration.stop()
+
+
+@pytest.mark.asyncio
+async def test_price_callback_calls_stop_order_manager(
+    integration: StreamIntegration,
+    stream_client: FakeStreamClient,
+    stop_order_manager: StopOrderManager,
+    eventbus: EventBus,
+) -> None:
+    """시세 수신 시 StopOrderManager.on_price_update가 호출된다."""
+    await integration.start()
+    try:
+        # 스탑 주문 등록
+        await stop_order_manager.register(
+            order_id="ord-1",
+            bot_id="bot-1",
+            strategy_id="stg-1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            order_type="stop",
+            stop_price=72000.0,
+        )
+
+        # 세션 시간을 항상 True로 패치 (테스트 시간에 무관하게 동작)
+        with patch.object(StopOrderManager, "_is_in_session", return_value=True):
+            # 시세 수신 — 트리거 조건 미충족
+            await stream_client.fire_price("005930", 71000.0)
+            assert len(stop_order_manager.active_orders) == 1
+
+            # 시세 수신 — 트리거 조건 충족
+            await stream_client.fire_price("005930", 72000.0)
+            assert len(stop_order_manager.active_orders) == 0
+    finally:
+        await integration.stop()
+
+
+# ── 체결 콜백 테스트 ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_execution_callback_invalidates_cache(
+    integration: StreamIntegration,
+    stream_client: FakeStreamClient,
+    cache: ResponseCache,
+) -> None:
+    """체결 통보 시 balance, positions, 해당 종목 시세 캐시가 무효화된다."""
+    await integration.start()
+    try:
+        # 캐시 사전 적재
+        cache.set("balance", {"total": 1000000}, ttl=30)
+        cache.set("positions", [{"symbol": "005930"}], ttl=30)
+        cache.set("price:KRX:005930", 70000.0, ttl=5)
+
+        execution = {
+            "symbol": "005930",
+            "order_id": "ord-1",
+            "side": "buy",
+            "quantity": 10.0,
+            "price": 70000.0,
+        }
+        await stream_client.fire_execution(execution)
+
+        assert cache.get("balance") is None
+        assert cache.get("positions") is None
+        assert cache.get("price:KRX:005930") is None
+    finally:
+        await integration.stop()
+
+
+@pytest.mark.asyncio
+async def test_execution_callback_publishes_event(
+    integration: StreamIntegration,
+    stream_client: FakeStreamClient,
+    eventbus: EventBus,
+) -> None:
+    """체결 통보 시 OrderFilledEvent가 발행된다."""
+    await integration.start()
+    try:
+        received: list[OrderFilledEvent] = []
+
+        async def handler(event: OrderFilledEvent) -> None:
+            received.append(event)
+
+        eventbus.subscribe(OrderFilledEvent, handler)
+
+        execution = {
+            "symbol": "005930",
+            "order_id": "ord-1",
+            "side": "buy",
+            "quantity": 10.0,
+            "price": 70000.0,
+        }
+        await stream_client.fire_execution(execution)
+
+        assert len(received) == 1
+        assert received[0].symbol == "005930"
+        assert received[0].price == 70000.0
+    finally:
+        await integration.stop()
+
+
+# ── 스트림 연결/해제 + 폴백 테스트 ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_fallback_starts_on_stream_disconnect(
+    integration: StreamIntegration,
+    eventbus: EventBus,
+) -> None:
+    """스트림 연결 해제 시 REST 폴링 폴백이 시작된다."""
+    await integration.start()
+    try:
+        assert not integration.is_fallback_active
+
+        await eventbus.publish(StreamDisconnectedEvent(broker="kis", reason="test"))
+        # 이벤트 처리 후 폴백 태스크 생성 대기
+        await asyncio.sleep(0.05)
+
+        assert integration.is_fallback_active
+    finally:
+        await integration.stop()
+
+
+@pytest.mark.asyncio
+async def test_fallback_stops_on_stream_reconnect(
+    integration: StreamIntegration,
+    eventbus: EventBus,
+) -> None:
+    """스트림 재연결 시 REST 폴링 폴백이 중지된다."""
+    await integration.start()
+    try:
+        # 먼저 폴백 시작
+        await eventbus.publish(StreamDisconnectedEvent(broker="kis", reason="test"))
+        await asyncio.sleep(0.05)
+        assert integration.is_fallback_active
+
+        # 재연결 시 폴백 중지
+        await eventbus.publish(StreamConnectedEvent(broker="kis", url="ws://test"))
+        await asyncio.sleep(0.05)
+
+        assert not integration.is_fallback_active
+    finally:
+        await integration.stop()
+
+
+@pytest.mark.asyncio
+async def test_fallback_polls_prices(
+    integration: StreamIntegration,
+    eventbus: EventBus,
+    gateway_mock: MagicMock,
+    cache: ResponseCache,
+    stop_order_manager: StopOrderManager,
+) -> None:
+    """REST 폴링 폴백 시 모니터링 종목의 시세를 REST로 조회한다."""
+    # 스탑 주문 등록 (모니터링 종목 생성)
+    await stop_order_manager.register(
+        order_id="ord-1",
+        bot_id="bot-1",
+        strategy_id="stg-1",
+        symbol="005930",
+        side="sell",
+        quantity=10.0,
+        order_type="stop",
+        stop_price=60000.0,
+    )
+
+    await integration.start()
+    try:
+        # 스트림 해제 → 폴백 시작
+        await eventbus.publish(StreamDisconnectedEvent(broker="kis", reason="test"))
+        await asyncio.sleep(0.3)
+
+        # REST API가 호출되었는지 확인
+        gateway_mock.get_current_price.assert_called()
+        call_args = [
+            call.args[0] for call in gateway_mock.get_current_price.call_args_list
+        ]
+        assert "005930" in call_args
+
+        # 캐시에 가격 적재 확인
+        cached = cache.get("price:KRX:005930")
+        assert cached == 50000.0
+    finally:
+        await integration.stop()
+
+
+# ── 종목 구독 동기화 테스트 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_subscription_sync_adds_stop_order_symbols(
+    integration: StreamIntegration,
+    stream_client: FakeStreamClient,
+    stop_order_manager: StopOrderManager,
+    eventbus: EventBus,
+) -> None:
+    """StopOrderManager 종목이 스트림에 구독된다."""
+    await stop_order_manager.register(
+        order_id="ord-1",
+        bot_id="bot-1",
+        strategy_id="stg-1",
+        symbol="035720",
+        side="buy",
+        quantity=5.0,
+        order_type="stop",
+        stop_price=100000.0,
+    )
+
+    await integration.start()
+    try:
+        # 동기화 주기 대기
+        await asyncio.sleep(0.2)
+
+        assert "035720" in stream_client.subscribed_symbols
+    finally:
+        await integration.stop()
+
+
+@pytest.mark.asyncio
+async def test_subscription_sync_on_bot_event(
+    integration: StreamIntegration,
+    stream_client: FakeStreamClient,
+    eventbus: EventBus,
+    bot_manager_mock: MagicMock,
+) -> None:
+    """봇 시작/종료 이벤트 시 종목 구독이 즉시 동기화된다."""
+    # 봇이 모니터링 종목을 가지도록 설정
+    mock_bot = MagicMock()
+    mock_bot.monitored_symbols = {"005930", "035720"}
+    bot_manager_mock.list_bots.return_value = [{"bot_id": "bot-1", "status": "running"}]
+    bot_manager_mock.get_bot.return_value = mock_bot
+
+    await integration.start()
+    try:
+        # 봇 시작 이벤트 발행
+        await eventbus.publish(BotStartedEvent(bot_id="bot-1"))
+        await asyncio.sleep(0.05)
+
+        assert "005930" in stream_client.subscribed_symbols
+        assert "035720" in stream_client.subscribed_symbols
+    finally:
+        await integration.stop()
+
+
+@pytest.mark.asyncio
+async def test_subscription_sync_removes_symbols(
+    integration: StreamIntegration,
+    stream_client: FakeStreamClient,
+    eventbus: EventBus,
+    bot_manager_mock: MagicMock,
+) -> None:
+    """봇 종료 후 해당 종목이 스트림에서 구독 해제된다."""
+    # 먼저 봇이 있는 상태
+    mock_bot = MagicMock()
+    mock_bot.monitored_symbols = {"005930"}
+    bot_manager_mock.list_bots.return_value = [{"bot_id": "bot-1", "status": "running"}]
+    bot_manager_mock.get_bot.return_value = mock_bot
+
+    await integration.start()
+    try:
+        await eventbus.publish(BotStartedEvent(bot_id="bot-1"))
+        await asyncio.sleep(0.05)
+        assert "005930" in stream_client.subscribed_symbols
+
+        # 봇이 없어진 상태로 변경
+        bot_manager_mock.list_bots.return_value = []
+        bot_manager_mock.get_bot.return_value = None
+
+        await eventbus.publish(BotStoppedEvent(bot_id="bot-1"))
+        await asyncio.sleep(0.05)
+
+        assert "005930" not in stream_client.subscribed_symbols
+    finally:
+        await integration.stop()
+
+
+# ── 시작/종료 라이프사이클 테스트 ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_connects_stream(
+    integration: StreamIntegration,
+    stream_client: FakeStreamClient,
+) -> None:
+    """start 시 스트림 클라이언트가 연결된다."""
+    assert not stream_client.is_connected
+
+    await integration.start()
+    try:
+        assert stream_client.is_connected
+    finally:
+        await integration.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_disconnects_stream(
+    integration: StreamIntegration,
+    stream_client: FakeStreamClient,
+) -> None:
+    """stop 시 스트림 클라이언트가 해제된다."""
+    await integration.start()
+    assert stream_client.is_connected
+
+    await integration.stop()
+    assert not stream_client.is_connected
+
+
+@pytest.mark.asyncio
+async def test_double_start_is_idempotent(
+    integration: StreamIntegration,
+    stream_client: FakeStreamClient,
+) -> None:
+    """중복 start 호출은 무해하다."""
+    await integration.start()
+    try:
+        await integration.start()  # 두 번째 호출 — 에러 없이 무시
+        assert stream_client.is_connected
+    finally:
+        await integration.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_without_start_is_safe(
+    integration: StreamIntegration,
+) -> None:
+    """start 없이 stop 호출은 안전하다."""
+    await integration.stop()  # 에러 없이 완료
+
+
+@pytest.mark.asyncio
+async def test_fallback_not_started_without_gateway(
+    stream_client: FakeStreamClient,
+    cache: ResponseCache,
+    eventbus: EventBus,
+) -> None:
+    """APIGateway 없이 생성된 경우 폴백이 시작되지 않는다."""
+    integration = StreamIntegration(
+        stream_client=stream_client,
+        cache=cache,
+        eventbus=eventbus,
+        gateway=None,
+    )
+    await integration.start()
+    try:
+        await eventbus.publish(StreamDisconnectedEvent(broker="kis", reason="test"))
+        await asyncio.sleep(0.05)
+
+        assert not integration.is_fallback_active
+    finally:
+        await integration.stop()


### PR DESCRIPTION
## Summary
- KIS WebSocket 실시간 시세를 ResponseCache 및 StopOrderManager와 연결하는 `StreamIntegration` 모듈 추가
- main.py에서 KIS 브로커 사용 시 StreamIntegration 라이프사이클(start/stop) 관리
- 스트림 연결 해제 시 REST 폴링 폴백으로 자동 전환

## Test plan
- [x] 시세 콜백 → ResponseCache 적재 확인
- [x] 시세 콜백 → StopOrderManager 트리거 확인
- [x] 체결 콜백 → 캐시 무효화 + 이벤트 발행 확인
- [x] 스트림 해제 → REST 폴링 폴백 시작/중지 확인
- [x] 봇 시작/종료 → 종목 구독 동기화 확인
- [x] 라이프사이클 (start/stop/idempotent) 확인
- [x] 전체 테스트 스위트 2022건 통과

Refs #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)