### PR TITLE
feat: LiveDataProvider.get_ohlcv() ParquetStore 연동 구현

### DIFF
--- a/src/ante/gateway/data_provider.py
+++ b/src/ante/gateway/data_provider.py
@@ -8,19 +8,28 @@ from typing import TYPE_CHECKING, Any
 from ante.strategy.base import DataProvider
 
 if TYPE_CHECKING:
+    from ante.data.store import ParquetStore
     from ante.gateway.gateway import APIGateway
 
 logger = logging.getLogger(__name__)
 
 
 class LiveDataProvider(DataProvider):
-    """라이브 모드 DataProvider. APIGateway 경유로 캐시 활용.
+    """라이브 모드 DataProvider. ParquetStore + APIGateway 조합.
+
+    과거 봉 데이터는 ParquetStore에서 읽고, 현재가는 APIGateway 캐시를 활용한다.
+    ParquetStore에 데이터가 없으면 APIGateway 경유로 폴백한다.
 
     Note: DataProvider 인터페이스 준수를 위해 async def를 유지한다.
     """
 
-    def __init__(self, gateway: APIGateway) -> None:
+    def __init__(
+        self,
+        gateway: APIGateway,
+        parquet_store: ParquetStore | None = None,
+    ) -> None:
         self._gateway = gateway
+        self._store = parquet_store
 
     async def get_ohlcv(
         self,
@@ -28,11 +37,30 @@ class LiveDataProvider(DataProvider):
         timeframe: str = "1d",
         limit: int = 100,
     ) -> list[dict[str, Any]]:
-        """OHLCV 데이터 조회 (APIGateway 경유).
+        """OHLCV 데이터 조회 (ParquetStore 우선, APIGateway 폴백).
 
-        APIGateway.get_ohlcv()를 통해 과거 봉 데이터를 가져온다.
-        BrokerAdapter에 get_ohlcv가 구현되어 있지 않으면 빈 리스트를 반환한다.
+        1. ParquetStore가 주입되어 있으면 과거 봉 데이터를 읽는다.
+        2. ParquetStore에 데이터가 없으면 APIGateway 경유로 폴백한다.
+        3. 둘 다 데이터가 없으면 빈 리스트를 반환한다.
         """
+        if self._store is not None:
+            try:
+                df = self._store.read(symbol, timeframe, limit=limit)
+                if not df.is_empty():
+                    return df.to_dicts()
+                logger.warning(
+                    "ParquetStore 데이터 없음 — APIGateway 폴백: %s %s",
+                    symbol,
+                    timeframe,
+                )
+            except Exception:
+                logger.warning(
+                    "ParquetStore 읽기 실패 — APIGateway 폴백: %s %s",
+                    symbol,
+                    timeframe,
+                    exc_info=True,
+                )
+
         return await self._gateway.get_ohlcv(symbol, timeframe=timeframe, limit=limit)
 
     async def get_current_price(self, symbol: str) -> float:

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -418,7 +418,10 @@ def _init_context_factory(s: Services) -> None:
     from ante.gateway.data_provider import LiveDataProvider
 
     if s.api_gateway:
-        s.data_provider = LiveDataProvider(gateway=s.api_gateway)
+        s.data_provider = LiveDataProvider(
+            gateway=s.api_gateway,
+            parquet_store=s.parquet_store,
+        )
         s.paper_executor._gateway = s.api_gateway
 
     live_trade_history = LiveTradeHistoryView(trade_recorder=s.trade_recorder)

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -422,8 +422,8 @@ class TestLiveDataProvider:
         assert price == 50000.0
         mock_gateway.get_current_price.assert_called_once_with("005930")
 
-    async def test_get_ohlcv_delegates_to_gateway(self):
-        """OHLCV 조회가 gateway.get_ohlcv()를 호출한다."""
+    async def test_get_ohlcv_delegates_to_gateway_without_store(self):
+        """ParquetStore 미주입 시 gateway.get_ohlcv()를 호출한다."""
         mock_gateway = AsyncMock()
         mock_gateway.get_ohlcv = AsyncMock(return_value=[{"close": 50000.0}])
         provider = LiveDataProvider(mock_gateway)
@@ -432,6 +432,61 @@ class TestLiveDataProvider:
         mock_gateway.get_ohlcv.assert_called_once_with(
             "005930", timeframe="1d", limit=100
         )
+
+    async def test_get_ohlcv_reads_from_parquet_store(self):
+        """ParquetStore에 데이터가 있으면 ParquetStore에서 읽는다."""
+        import polars as pl
+
+        mock_gateway = AsyncMock()
+        mock_store = MagicMock()
+        df = pl.DataFrame(
+            {
+                "timestamp": ["2026-01-01"],
+                "open": [49000.0],
+                "high": [51000.0],
+                "low": [48500.0],
+                "close": [50000.0],
+                "volume": [1000],
+            }
+        )
+        mock_store.read = MagicMock(return_value=df)
+
+        provider = LiveDataProvider(mock_gateway, parquet_store=mock_store)
+        result = await provider.get_ohlcv("005930", timeframe="1d", limit=50)
+
+        assert len(result) == 1
+        assert result[0]["close"] == 50000.0
+        mock_store.read.assert_called_once_with("005930", "1d", limit=50)
+        mock_gateway.get_ohlcv.assert_not_called()
+
+    async def test_get_ohlcv_fallback_to_gateway_when_store_empty(self):
+        """ParquetStore에 데이터가 없으면 APIGateway로 폴백한다."""
+        import polars as pl
+
+        mock_gateway = AsyncMock()
+        mock_gateway.get_ohlcv = AsyncMock(return_value=[{"close": 50000.0}])
+        mock_store = MagicMock()
+        mock_store.read = MagicMock(return_value=pl.DataFrame())
+
+        provider = LiveDataProvider(mock_gateway, parquet_store=mock_store)
+        result = await provider.get_ohlcv("005930")
+
+        assert result == [{"close": 50000.0}]
+        mock_store.read.assert_called_once()
+        mock_gateway.get_ohlcv.assert_called_once()
+
+    async def test_get_ohlcv_fallback_to_gateway_on_store_error(self):
+        """ParquetStore 읽기 실패 시 APIGateway로 폴백한다."""
+        mock_gateway = AsyncMock()
+        mock_gateway.get_ohlcv = AsyncMock(return_value=[{"close": 50000.0}])
+        mock_store = MagicMock()
+        mock_store.read = MagicMock(side_effect=Exception("parquet read error"))
+
+        provider = LiveDataProvider(mock_gateway, parquet_store=mock_store)
+        result = await provider.get_ohlcv("005930")
+
+        assert result == [{"close": 50000.0}]
+        mock_gateway.get_ohlcv.assert_called_once()
 
     async def test_get_indicator_returns_empty_when_no_ohlcv(self):
         """OHLCV 데이터 없을 때 빈 dict 반환."""


### PR DESCRIPTION
## Summary
- LiveDataProvider에 ParquetStore 주입 경로 추가 (선택적 파라미터)
- get_ohlcv()에서 ParquetStore 우선 조회, 데이터 없거나 읽기 실패 시 APIGateway 폴백
- main.py에서 LiveDataProvider 생성 시 parquet_store 전달

## Test plan
- [x] ParquetStore에 데이터 있을 때 ParquetStore에서 읽는지 확인
- [x] ParquetStore가 빈 DataFrame 반환 시 APIGateway로 폴백하는지 확인
- [x] ParquetStore 읽기 예외 시 APIGateway로 폴백하는지 확인
- [x] ParquetStore 미주입 시 기존 동작(APIGateway 직접 호출) 유지 확인
- [x] 전체 테스트 스위트 2025건 통과

Refs #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)