### PR TITLE
feat(broker): ReconcileScheduler — 주기적 자동 대사 스케줄러 구현

### DIFF
--- a/config/system.toml
+++ b/config/system.toml
@@ -27,3 +27,7 @@ sell_tax_rate = 0.0023      # 매도 세금율 (증권거래세+농특세)
 
 [treasury]
 sync_interval_seconds = 300 # 잔고 동기화 주기 (초)
+
+[reconcile]
+enabled = true              # 대사 스케줄러 활성화 여부
+interval_seconds = 1800     # 대사 반복 주기 (초, 기본 30분)

--- a/src/ante/broker/__init__.py
+++ b/src/ante/broker/__init__.py
@@ -15,6 +15,7 @@ from ante.broker.kis_stream import KISStreamClient
 from ante.broker.mock import MockBrokerAdapter
 from ante.broker.models import CommissionInfo
 from ante.broker.order_registry import OrderRegistry
+from ante.broker.scheduler import ReconcileScheduler
 from ante.broker.test import TestBrokerAdapter
 
 __all__ = [
@@ -27,6 +28,7 @@ __all__ = [
     "KISStreamClient",
     "MockBrokerAdapter",
     "OrderRegistry",
+    "ReconcileScheduler",
     "TestBrokerAdapter",
     "BrokerError",
     "AuthenticationError",

--- a/src/ante/broker/scheduler.py
+++ b/src/ante/broker/scheduler.py
@@ -1,0 +1,137 @@
+"""ReconcileScheduler — 주기적 자동 대사 스케줄러.
+
+설정된 간격(기본 30분)으로 모든 활성 봇의 포지션 대사를 수행한다.
+봇 시작 시 1회 대사도 지원한다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ante.bot.manager import BotManager
+    from ante.broker.base import BrokerAdapter
+    from ante.eventbus.bus import EventBus
+    from ante.trade.reconciler import PositionReconciler
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_INTERVAL_SECONDS = 1800  # 30분
+
+
+class ReconcileScheduler:
+    """주기적으로 모든 활성 봇의 포지션 대사를 수행한다.
+
+    Args:
+        reconciler: 포지션 대사 실행기.
+        broker: 브로커 어댑터 (실제 잔고 조회용).
+        bot_manager: 활성 봇 목록 조회용.
+        eventbus: 이벤트 발행용.
+        interval_seconds: 대사 반복 주기 (초). 기본 1800(30분).
+    """
+
+    def __init__(
+        self,
+        reconciler: PositionReconciler,
+        broker: BrokerAdapter,
+        bot_manager: BotManager,
+        eventbus: EventBus,
+        interval_seconds: float = DEFAULT_INTERVAL_SECONDS,
+    ) -> None:
+        self._reconciler = reconciler
+        self._broker = broker
+        self._bot_manager = bot_manager
+        self._eventbus = eventbus
+        self._interval = interval_seconds
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """대사 스케줄러를 시작한다. 시작 즉시 1회 대사를 수행한다."""
+        if self._task and not self._task.done():
+            logger.warning("ReconcileScheduler 이미 실행 중")
+            return
+
+        logger.info(
+            "ReconcileScheduler 시작 (주기: %d초)",
+            int(self._interval),
+        )
+        await self.run_once()
+        self._task = asyncio.create_task(
+            self._loop(),
+            name="reconcile-scheduler",
+        )
+
+    async def stop(self) -> None:
+        """스케줄러를 중지한다."""
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+            logger.info("ReconcileScheduler 종료")
+
+    async def run_once(self) -> list[dict[str, Any]]:
+        """1회 대사를 수행하고 보정 내역을 반환한다.
+
+        모든 활성(running) 봇에 대해 브로커 포지션을 조회하고,
+        PositionReconciler.reconcile()을 호출하여 불일치를 보정한다.
+
+        Returns:
+            각 봇별 보정 내역을 합산한 리스트.
+        """
+        from ante.bot.config import BotStatus
+
+        all_corrections: list[dict[str, Any]] = []
+
+        bots = self._bot_manager.list_bots()
+        active_bots = [b for b in bots if b.get("status") == BotStatus.RUNNING]
+
+        if not active_bots:
+            logger.debug("대사 대상 활성 봇 없음")
+            return all_corrections
+
+        try:
+            broker_positions = await self._broker.get_account_positions()
+        except Exception:
+            logger.exception("대사 중 브로커 포지션 조회 실패")
+            return all_corrections
+
+        for bot_info in active_bots:
+            bot_id = bot_info["bot_id"]
+            try:
+                corrections = await self._reconciler.reconcile(
+                    bot_id=bot_id,
+                    broker_positions=broker_positions,
+                )
+                all_corrections.extend(corrections)
+            except Exception:
+                logger.exception("대사 실패 [%s]", bot_id)
+
+        if all_corrections:
+            logger.info(
+                "주기 대사 완료: 활성 봇 %d개, 보정 %d건",
+                len(active_bots),
+                len(all_corrections),
+            )
+        else:
+            logger.debug(
+                "주기 대사 완료: 활성 봇 %d개, 불일치 없음",
+                len(active_bots),
+            )
+
+        return all_corrections
+
+    async def _loop(self) -> None:
+        """interval 간격으로 run_once()를 반복 호출한다."""
+        while True:
+            await asyncio.sleep(self._interval)
+            try:
+                await self.run_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("ReconcileScheduler 루프 오류")

--- a/src/ante/cli/commands/broker.py
+++ b/src/ante/cli/commands/broker.py
@@ -148,10 +148,13 @@ def positions(ctx: click.Context) -> None:
 
 
 @broker.command()
+@click.option(
+    "--fix", is_flag=True, default=False, help="불일치 발견 시 자동 보정 수행"
+)
 @click.pass_context
 @require_auth
 @require_scope("broker:read")
-def reconcile(ctx: click.Context) -> None:
+def reconcile(ctx: click.Context, fix: bool) -> None:
     """내부 데이터와 증권사 데이터 대사."""
     fmt = get_formatter(ctx)
 
@@ -160,6 +163,7 @@ def reconcile(ctx: click.Context) -> None:
         from ante.eventbus.bus import EventBus
         from ante.trade.performance import PerformanceTracker
         from ante.trade.position import PositionHistory
+        from ante.trade.reconciler import PositionReconciler
         from ante.trade.recorder import TradeRecorder
         from ante.trade.service import TradeService
 
@@ -168,10 +172,10 @@ def reconcile(ctx: click.Context) -> None:
         await db.connect()
         try:
             eventbus = EventBus()
-            recorder = TradeRecorder(db, eventbus)
-            await recorder.initialize()
-            position_history = PositionHistory(db, eventbus)
+            position_history = PositionHistory(db)
             await position_history.initialize()
+            recorder = TradeRecorder(db, position_history)
+            await recorder.initialize()
             performance = PerformanceTracker(db)
             await performance.initialize()
             trade_service = TradeService(recorder, position_history, performance)
@@ -199,10 +203,30 @@ def reconcile(ctx: click.Context) -> None:
                         }
                     )
 
+            corrections: list[dict] = []
+            if fix and discrepancies:
+                reconciler = PositionReconciler(
+                    trade_service=trade_service,
+                    eventbus=eventbus,
+                )
+                # 전체 봇 대사: 모든 봇 ID 수집
+                bot_ids = {p.bot_id for p in internal_positions if p.quantity > 0}
+                # 봇이 없어도 외부 매수가 있을 수 있으므로 기본 봇 사용
+                if not bot_ids:
+                    bot_ids = {"default"}
+                for bot_id in bot_ids:
+                    bot_corrections = await reconciler.reconcile(
+                        bot_id=bot_id,
+                        broker_positions=broker_positions,
+                    )
+                    corrections.extend(bot_corrections)
+
             return {
                 "total_symbols": len(all_symbols),
                 "discrepancies": discrepancies,
                 "match": len(discrepancies) == 0,
+                "fix_applied": fix and len(corrections) > 0,
+                "corrections": len(corrections),
             }
         finally:
             await adapter.disconnect()
@@ -225,3 +249,5 @@ def reconcile(ctx: click.Context) -> None:
                 result["discrepancies"],
                 ["symbol", "broker_qty", "internal_qty", "diff"],
             )
+        if result.get("fix_applied"):
+            click.echo(f"  자동 보정      : {result['corrections']}건 수행")

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -47,6 +47,7 @@ class Services:
     broker: Any = None
     api_gateway: Any = None
     stream_integration: Any = None
+    reconcile_scheduler: Any = None
     data_provider: Any = None
     parquet_store: Any = None
     data_collector: Any = None
@@ -289,6 +290,42 @@ async def _init_broker(s: Services) -> None:
 
     if s.broker:
         await _sync_instruments(s)
+
+    # ReconcileScheduler 초기화
+    if s.broker and s.trade_service:
+        await _init_reconcile_scheduler(s)
+
+
+async def _init_reconcile_scheduler(s: Services) -> None:
+    """ReconcileScheduler 생성 및 시작."""
+    from ante.broker.scheduler import ReconcileScheduler
+    from ante.trade.reconciler import PositionReconciler
+
+    reconcile_config = s.config.get("reconcile", {})
+    if not isinstance(reconcile_config, dict):
+        reconcile_config = {}
+
+    enabled = reconcile_config.get("enabled", True)
+    if not enabled:
+        logger.info("ReconcileScheduler 비활성화 (reconcile.enabled=false)")
+        return
+
+    interval = reconcile_config.get("interval_seconds", 1800)
+
+    reconciler = PositionReconciler(
+        trade_service=s.trade_service,
+        eventbus=s.eventbus,
+    )
+
+    s.reconcile_scheduler = ReconcileScheduler(
+        reconciler=reconciler,
+        broker=s.broker,
+        bot_manager=s.bot_manager,
+        eventbus=s.eventbus,
+        interval_seconds=interval,
+    )
+    await s.reconcile_scheduler.start()
+    logger.info("ReconcileScheduler 시작 완료 (주기: %d초)", interval)
 
 
 async def _connect_mock_broker(s: Services, broker_config: dict) -> None:
@@ -864,6 +901,10 @@ async def _shutdown(s: Services) -> None:
         except asyncio.CancelledError:
             pass
         logger.info("Web API 종료")
+
+    if s.reconcile_scheduler:
+        await s.reconcile_scheduler.stop()
+        logger.info("ReconcileScheduler 종료")
 
     await s.treasury.stop_sync()
 

--- a/tests/unit/test_reconcile_scheduler.py
+++ b/tests/unit/test_reconcile_scheduler.py
@@ -1,0 +1,211 @@
+"""ReconcileScheduler 단위 테스트."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.broker.scheduler import ReconcileScheduler
+
+# ── Fixtures ─────────────────────────────────────────
+
+
+@pytest.fixture
+def reconciler():
+    mock = AsyncMock()
+    mock.reconcile = AsyncMock(return_value=[])
+    return mock
+
+
+@pytest.fixture
+def broker():
+    mock = AsyncMock()
+    mock.get_account_positions = AsyncMock(
+        return_value=[
+            {"symbol": "005930", "quantity": 100, "avg_price": 50000},
+        ]
+    )
+    return mock
+
+
+@pytest.fixture
+def bot_manager():
+    mock = MagicMock()
+    mock.list_bots = MagicMock(
+        return_value=[
+            {"bot_id": "bot-1", "status": "running"},
+            {"bot_id": "bot-2", "status": "stopped"},
+        ]
+    )
+    return mock
+
+
+@pytest.fixture
+def eventbus():
+    from ante.eventbus.bus import EventBus
+
+    return EventBus()
+
+
+@pytest.fixture
+def scheduler(reconciler, broker, bot_manager, eventbus):
+    return ReconcileScheduler(
+        reconciler=reconciler,
+        broker=broker,
+        bot_manager=bot_manager,
+        eventbus=eventbus,
+        interval_seconds=0.1,  # 빠른 테스트용
+    )
+
+
+# ── run_once 테스트 ──────────────────────────────────
+
+
+class TestRunOnce:
+    async def test_reconciles_active_bots_only(self, scheduler, reconciler, broker):
+        """running 상태인 봇만 대사한다."""
+        await scheduler.run_once()
+
+        # bot-1만 running이므로 1회 호출
+        assert reconciler.reconcile.call_count == 1
+        call_args = reconciler.reconcile.call_args
+        assert call_args.kwargs["bot_id"] == "bot-1"
+
+    async def test_passes_broker_positions(self, scheduler, reconciler, broker):
+        """브로커 포지션을 reconciler에 전달한다."""
+        await scheduler.run_once()
+
+        call_args = reconciler.reconcile.call_args
+        assert call_args.kwargs["broker_positions"] == [
+            {"symbol": "005930", "quantity": 100, "avg_price": 50000},
+        ]
+
+    async def test_returns_all_corrections(self, scheduler, reconciler):
+        """보정 내역을 반환한다."""
+        reconciler.reconcile.return_value = [
+            {"symbol": "005930", "old_quantity": 50, "new_quantity": 100}
+        ]
+
+        result = await scheduler.run_once()
+
+        assert len(result) == 1
+        assert result[0]["symbol"] == "005930"
+
+    async def test_no_active_bots(self, scheduler, bot_manager, broker):
+        """활성 봇이 없으면 브로커 호출하지 않는다."""
+        bot_manager.list_bots.return_value = [
+            {"bot_id": "bot-1", "status": "stopped"},
+        ]
+
+        result = await scheduler.run_once()
+
+        assert result == []
+        broker.get_account_positions.assert_not_called()
+
+    async def test_broker_failure_returns_empty(self, scheduler, broker, reconciler):
+        """브로커 조회 실패 시 빈 리스트를 반환한다."""
+        broker.get_account_positions.side_effect = ConnectionError("연결 실패")
+
+        result = await scheduler.run_once()
+
+        assert result == []
+        reconciler.reconcile.assert_not_called()
+
+    async def test_single_bot_failure_continues(
+        self, scheduler, bot_manager, reconciler
+    ):
+        """한 봇의 대사 실패가 다른 봇에 영향주지 않는다."""
+        bot_manager.list_bots.return_value = [
+            {"bot_id": "bot-1", "status": "running"},
+            {"bot_id": "bot-2", "status": "running"},
+        ]
+        reconciler.reconcile.side_effect = [
+            Exception("bot-1 실패"),
+            [{"symbol": "005930", "corrected": True}],
+        ]
+
+        result = await scheduler.run_once()
+
+        assert len(result) == 1
+        assert reconciler.reconcile.call_count == 2
+
+
+# ── start/stop 테스트 ────────────────────────────────
+
+
+class TestStartStop:
+    async def test_start_runs_initial_reconcile(self, scheduler, reconciler):
+        """start() 시 즉시 1회 대사를 수행한다."""
+        await scheduler.start()
+        try:
+            assert reconciler.reconcile.call_count == 1
+        finally:
+            await scheduler.stop()
+
+    async def test_stop_cancels_task(self, scheduler):
+        """stop() 시 스케줄러 태스크가 취소된다."""
+        await scheduler.start()
+
+        assert scheduler._task is not None
+        assert not scheduler._task.done()
+
+        await scheduler.stop()
+
+        assert scheduler._task is None
+
+    async def test_periodic_loop(self, scheduler, reconciler):
+        """주기적으로 대사가 반복 실행된다."""
+        await scheduler.start()
+
+        # 짧은 대기로 주기 실행 확인 (interval=0.1s)
+        await asyncio.sleep(0.35)
+        await scheduler.stop()
+
+        # 시작 시 1회 + 루프 최소 2~3회
+        assert reconciler.reconcile.call_count >= 3
+
+    async def test_double_start_ignored(self, scheduler, reconciler):
+        """이미 실행 중인데 다시 start() 하면 무시된다."""
+        await scheduler.start()
+        initial_count = reconciler.reconcile.call_count
+
+        await scheduler.start()  # 두 번째 호출 — 무시돼야 함
+
+        # run_once()가 다시 호출되지 않아야 한다
+        assert reconciler.reconcile.call_count == initial_count
+        await scheduler.stop()
+
+    async def test_stop_without_start(self, scheduler):
+        """start() 없이 stop() 해도 오류 없음."""
+        await scheduler.stop()  # 예외 없이 완료
+
+
+# ── 설정 테스트 ──────────────────────────────────────
+
+
+class TestConfiguration:
+    def test_default_interval(self, reconciler, broker, bot_manager, eventbus):
+        """기본 간격은 1800초(30분)이다."""
+        from ante.broker.scheduler import DEFAULT_INTERVAL_SECONDS
+
+        sched = ReconcileScheduler(
+            reconciler=reconciler,
+            broker=broker,
+            bot_manager=bot_manager,
+            eventbus=eventbus,
+        )
+        assert sched._interval == DEFAULT_INTERVAL_SECONDS
+        assert DEFAULT_INTERVAL_SECONDS == 1800
+
+    def test_custom_interval(self, reconciler, broker, bot_manager, eventbus):
+        """interval_seconds로 주기를 변경할 수 있다."""
+        sched = ReconcileScheduler(
+            reconciler=reconciler,
+            broker=broker,
+            bot_manager=bot_manager,
+            eventbus=eventbus,
+            interval_seconds=600,
+        )
+        assert sched._interval == 600


### PR DESCRIPTION
## Summary
- `ReconcileScheduler` 클래스 신규 구현 (`src/ante/broker/scheduler.py`): 설정 간격(기본 30분)으로 활성 봇 포지션 대사 자동 수행
- `main.py` 연동: 봇 시작 시 1회 대사 + 주기적 루프, graceful shutdown 지원
- CLI `ante broker reconcile --fix` 자동 보정 플래그 추가
- `system.toml` `[reconcile]` 설정 섹션 추가 (enabled, interval_seconds)
- 단위 테스트 13건 (run_once, start/stop 생명주기, 에러 격리, 설정)

Refs #456

## Test plan
- [x] `pytest tests/unit/test_reconcile_scheduler.py` — 13건 전수 통과
- [x] `pytest tests/ --ignore=tests/e2e` — 전체 2038건 통과
- [x] `ruff check` + `ruff format` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)