### PR TITLE
feat: ante system start/stop — CLI 시스템 시작·종료 커맨드

### DIFF
--- a/src/ante/cli/commands/system.py
+++ b/src/ante/cli/commands/system.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import signal
+import subprocess
+import sys
 
 import click
 
@@ -39,6 +43,91 @@ async def _audit_log(db, **kwargs) -> None:  # noqa: ANN001
         await al.log(**kwargs)
     except Exception:
         pass
+
+
+def _is_process_alive(pid: int) -> bool:
+    """프로세스가 살아있는지 확인."""
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+@system.command()
+@click.option(
+    "--config-dir",
+    "config_dir",
+    type=click.Path(exists=False),
+    default=None,
+    help="설정 디렉토리 경로",
+)
+@click.pass_context
+@require_auth
+@require_scope("system:admin")
+def start(ctx: click.Context, config_dir: str | None) -> None:
+    """시스템 시작 (포어그라운드)."""
+    from ante.main import read_pid_file
+
+    fmt = get_formatter(ctx)
+
+    # 이미 실행 중인지 확인
+    existing_pid = read_pid_file()
+    if existing_pid is not None and _is_process_alive(existing_pid):
+        fmt.error(
+            f"시스템이 이미 실행 중입니다 (pid={existing_pid})", code="ALREADY_RUNNING"
+        )
+        raise SystemExit(1)
+
+    # python -m ante.main 실행
+    cmd = [sys.executable, "-m", "ante.main"]
+
+    env = os.environ.copy()
+    if config_dir:
+        env["ANTE_CONFIG_DIR"] = config_dir
+    # 루트 컨텍스트에서 --config-dir이 설정된 경우 전달
+    root_config_dir = ctx.obj.get("config_dir")
+    if root_config_dir and not config_dir:
+        env["ANTE_CONFIG_DIR"] = str(root_config_dir)
+
+    fmt.success("시스템 시작 중...")
+
+    try:
+        proc = subprocess.run(cmd, env=env)
+        raise SystemExit(proc.returncode)
+    except KeyboardInterrupt:
+        raise SystemExit(0)
+
+
+@system.command()
+@click.pass_context
+@require_auth
+@require_scope("system:admin")
+def stop(ctx: click.Context) -> None:
+    """시스템 정상 종료 (SIGTERM)."""
+    from ante.main import PID_FILE, read_pid_file
+
+    fmt = get_formatter(ctx)
+
+    pid = read_pid_file()
+    if pid is None:
+        fmt.error(
+            f"PID 파일이 없습니다 ({PID_FILE})",
+            code="PID_NOT_FOUND",
+        )
+        raise SystemExit(1)
+
+    if not _is_process_alive(pid):
+        # 프로세스가 없으면 stale PID 파일 정리
+        PID_FILE.unlink(missing_ok=True)
+        fmt.error(
+            f"프로세스가 존재하지 않습니다 (pid={pid}). PID 파일을 정리했습니다.",
+            code="PROCESS_NOT_FOUND",
+        )
+        raise SystemExit(1)
+
+    os.kill(pid, signal.SIGTERM)
+    fmt.success("종료 시그널 전송 완료", {"pid": pid})
 
 
 @system.command()

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -7,6 +7,7 @@ main()은 조율만 수행한다.
 
 import asyncio
 import logging
+import os
 import signal
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -17,6 +18,32 @@ from ante.core import Database
 from ante.eventbus import EventBus, EventHistoryStore
 
 logger = logging.getLogger(__name__)
+
+PID_FILE = Path("db/ante.pid")
+
+
+def _write_pid_file() -> None:
+    """PID 파일 기록."""
+    PID_FILE.parent.mkdir(parents=True, exist_ok=True)
+    PID_FILE.write_text(str(os.getpid()))
+    logger.info("PID 파일 기록: %s (pid=%d)", PID_FILE, os.getpid())
+
+
+def _remove_pid_file() -> None:
+    """PID 파일 삭제."""
+    try:
+        PID_FILE.unlink(missing_ok=True)
+        logger.info("PID 파일 삭제: %s", PID_FILE)
+    except OSError:
+        logger.warning("PID 파일 삭제 실패: %s", PID_FILE, exc_info=True)
+
+
+def read_pid_file() -> int | None:
+    """PID 파일에서 PID 읽기. 파일이 없거나 파싱 실패 시 None."""
+    try:
+        return int(PID_FILE.read_text().strip())
+    except (FileNotFoundError, ValueError):
+        return None
 
 
 @dataclass
@@ -941,14 +968,18 @@ async def main() -> None:
     종료 순서: 역순 (상위 소비자부터 정리)
     """
     s = Services()
+    _write_pid_file()
 
-    await _init_core(s)
-    await _init_services(s)
-    await _init_trading(s)
-    await _init_feed(s)
-    await _init_notification(s)
-    await _init_web(s)
-    await _run(s)
+    try:
+        await _init_core(s)
+        await _init_services(s)
+        await _init_trading(s)
+        await _init_feed(s)
+        await _init_notification(s)
+        await _init_web(s)
+        await _run(s)
+    finally:
+        _remove_pid_file()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cli_system.py
+++ b/tests/unit/test_cli_system.py
@@ -1,0 +1,246 @@
+"""CLI system start/stop 커맨드 단위 테스트."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+class TestSystemStart:
+    def test_start_already_running(self, runner):
+        """이미 실행 중인 프로세스가 있으면 에러."""
+        with (
+            patch("ante.main.read_pid_file", return_value=os.getpid()),
+            patch("ante.cli.commands.system._is_process_alive", return_value=True),
+        ):
+            result = runner.invoke(cli, ["system", "start"])
+            assert result.exit_code == 1
+            assert "이미 실행 중" in result.output
+
+    def test_start_already_running_json(self, runner):
+        """JSON 모드에서 이미 실행 중인 경우."""
+        with (
+            patch("ante.main.read_pid_file", return_value=12345),
+            patch("ante.cli.commands.system._is_process_alive", return_value=True),
+        ):
+            result = runner.invoke(cli, ["--format", "json", "system", "start"])
+            assert result.exit_code == 1
+            data = json.loads(result.output)
+            assert data["code"] == "ALREADY_RUNNING"
+
+    def test_start_stale_pid_proceeds(self, runner):
+        """PID 파일이 있지만 프로세스가 없으면 시작 진행."""
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+
+        with (
+            patch("ante.main.read_pid_file", return_value=99999),
+            patch("ante.cli.commands.system._is_process_alive", return_value=False),
+            patch(
+                "ante.cli.commands.system.subprocess.run", return_value=mock_proc
+            ) as mock_run,
+        ):
+            result = runner.invoke(cli, ["system", "start"])
+            assert result.exit_code == 0
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            assert cmd[-2:] == ["-m", "ante.main"]
+
+    def test_start_no_pid_file(self, runner):
+        """PID 파일이 없으면 정상 시작."""
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+
+        with (
+            patch("ante.main.read_pid_file", return_value=None),
+            patch(
+                "ante.cli.commands.system.subprocess.run", return_value=mock_proc
+            ) as mock_run,
+        ):
+            result = runner.invoke(cli, ["system", "start"])
+            assert result.exit_code == 0
+            mock_run.assert_called_once()
+
+    def test_start_config_dir_passed_via_env(self, runner):
+        """--config-dir 옵션이 환경변수로 전달."""
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+
+        with (
+            patch("ante.main.read_pid_file", return_value=None),
+            patch(
+                "ante.cli.commands.system.subprocess.run", return_value=mock_proc
+            ) as mock_run,
+        ):
+            result = runner.invoke(
+                cli, ["system", "start", "--config-dir", "/tmp/ante-config"]
+            )
+            assert result.exit_code == 0
+            env = mock_run.call_args[1]["env"]
+            assert env["ANTE_CONFIG_DIR"] == "/tmp/ante-config"
+
+    def test_start_nonzero_exit_code(self, runner):
+        """서브프로세스가 비정상 종료하면 해당 코드 전파."""
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+
+        with (
+            patch("ante.main.read_pid_file", return_value=None),
+            patch("ante.cli.commands.system.subprocess.run", return_value=mock_proc),
+        ):
+            result = runner.invoke(cli, ["system", "start"])
+            assert result.exit_code == 1
+
+
+class TestSystemStop:
+    def test_stop_no_pid_file(self, runner):
+        """PID 파일이 없으면 에러."""
+        with patch("ante.main.read_pid_file", return_value=None):
+            result = runner.invoke(cli, ["system", "stop"])
+            assert result.exit_code == 1
+            assert "PID 파일이 없습니다" in result.output
+
+    def test_stop_no_pid_file_json(self, runner):
+        """JSON 모드에서 PID 파일이 없는 경우."""
+        with patch("ante.main.read_pid_file", return_value=None):
+            result = runner.invoke(cli, ["--format", "json", "system", "stop"])
+            assert result.exit_code == 1
+            data = json.loads(result.output)
+            assert data["code"] == "PID_NOT_FOUND"
+
+    def test_stop_stale_pid(self, runner, tmp_path):
+        """프로세스가 없으면 stale PID 정리 후 에러."""
+        pid_file = tmp_path / "ante.pid"
+        pid_file.write_text("99999")
+
+        with (
+            patch("ante.main.read_pid_file", return_value=99999),
+            patch("ante.cli.commands.system._is_process_alive", return_value=False),
+            patch("ante.main.PID_FILE", pid_file),
+        ):
+            result = runner.invoke(cli, ["system", "stop"])
+            assert result.exit_code == 1
+            assert "프로세스가 존재하지 않습니다" in result.output
+            assert not pid_file.exists()
+
+    def test_stop_sends_sigterm(self, runner):
+        """정상 프로세스에 SIGTERM 전송."""
+        with (
+            patch("ante.main.read_pid_file", return_value=12345),
+            patch("ante.cli.commands.system._is_process_alive", return_value=True),
+            patch("ante.cli.commands.system.os.kill") as mock_kill,
+        ):
+            result = runner.invoke(cli, ["system", "stop"])
+            assert result.exit_code == 0
+            mock_kill.assert_called_once_with(12345, signal.SIGTERM)
+
+    def test_stop_sends_sigterm_json(self, runner):
+        """JSON 모드에서 정상 종료."""
+        with (
+            patch("ante.main.read_pid_file", return_value=12345),
+            patch("ante.cli.commands.system._is_process_alive", return_value=True),
+            patch("ante.cli.commands.system.os.kill"),
+        ):
+            result = runner.invoke(cli, ["--format", "json", "system", "stop"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["status"] == "ok"
+            assert data["pid"] == 12345
+
+
+class TestPidFileManagement:
+    def test_write_and_read_pid_file(self, tmp_path):
+        """PID 파일 기록 및 읽기."""
+        from ante.main import _write_pid_file, read_pid_file
+
+        pid_file = tmp_path / "ante.pid"
+        with patch("ante.main.PID_FILE", pid_file):
+            _write_pid_file()
+            result = read_pid_file()
+            assert result == os.getpid()
+
+    def test_read_pid_file_missing(self, tmp_path):
+        """PID 파일이 없으면 None."""
+        from ante.main import read_pid_file
+
+        with patch("ante.main.PID_FILE", tmp_path / "nonexistent.pid"):
+            assert read_pid_file() is None
+
+    def test_read_pid_file_invalid(self, tmp_path):
+        """PID 파일 내용이 숫자가 아니면 None."""
+        from ante.main import read_pid_file
+
+        pid_file = tmp_path / "ante.pid"
+        pid_file.write_text("not-a-number")
+        with patch("ante.main.PID_FILE", pid_file):
+            assert read_pid_file() is None
+
+    def test_remove_pid_file(self, tmp_path):
+        """PID 파일 삭제."""
+        from ante.main import _remove_pid_file
+
+        pid_file = tmp_path / "ante.pid"
+        pid_file.write_text("12345")
+        with patch("ante.main.PID_FILE", pid_file):
+            _remove_pid_file()
+            assert not pid_file.exists()
+
+    def test_remove_pid_file_missing(self, tmp_path):
+        """PID 파일이 없어도 에러 없이 진행."""
+        from ante.main import _remove_pid_file
+
+        pid_file = tmp_path / "nonexistent.pid"
+        with patch("ante.main.PID_FILE", pid_file):
+            _remove_pid_file()  # Should not raise
+
+
+class TestIsProcessAlive:
+    def test_current_process_is_alive(self):
+        """현재 프로세스는 살아있음."""
+        from ante.cli.commands.system import _is_process_alive
+
+        assert _is_process_alive(os.getpid()) is True
+
+    def test_nonexistent_process(self):
+        """존재하지 않는 PID는 False."""
+        from ante.cli.commands.system import _is_process_alive
+
+        # PID 99999999는 존재하지 않을 가능성이 높음
+        assert _is_process_alive(99999999) is False


### PR DESCRIPTION
## Summary
- `ante system start`: `python -m ante.main` 래핑 포어그라운드 실행, `--config-dir` 환경변수 연동
- `ante system stop`: PID 파일(`db/ante.pid`) 기반 SIGTERM 전송으로 graceful shutdown
- PID 파일 관리: `main.py` 시작 시 기록, 종료 시 삭제, stale PID 자동 정리

Refs #461

## Test plan
- [x] `ante system start` — 이미 실행 중인 프로세스 감지 (text/json)
- [x] `ante system start` — stale PID 파일 존재 시 정상 시작
- [x] `ante system start` — `--config-dir` 환경변수 전달
- [x] `ante system start` — 서브프로세스 exit code 전파
- [x] `ante system stop` — PID 파일 없을 때 에러 (text/json)
- [x] `ante system stop` — stale PID 정리
- [x] `ante system stop` — SIGTERM 전송 (text/json)
- [x] PID 파일 write/read/remove 단위 테스트
- [x] `_is_process_alive` 유틸 테스트
- [x] 전체 테스트 스위트 2056 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)