### PR TITLE
fix(main): NotificationService 초기화 코드 정리

### DIFF
--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -801,10 +801,7 @@ async def _init_notification(s: Services) -> None:
         adapter=adapter,
         eventbus=s.eventbus,
         min_level=NotificationLevel(min_level_str),
-        instrument_service=s.instrument_service,
-        db=s.db,
     )
-    await s.notification_service.initialize()
     s.notification_service.subscribe()
     logger.info("NotificationService 초기화 완료 (Telegram)")
 


### PR DESCRIPTION
## Summary
- `_init_notification()`에서 `NotificationService` 생성자 호출 시 불필요한 `instrument_service`, `db` 파라미터 제거
- `initialize()` 호출 삭제 (notification_history 테이블 불필요)

## Related
- Closes #488
- Epic: #489
- 선행: #484 (NotificationService 단순화)

## Test plan
- [x] ruff check 통과
- [x] pytest 통과 (기존 실패 1건은 base 브랜치에서도 동일하게 실패하는 pre-existing 이슈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)