### PR TITLE
feat(cli): ante strategy list/info/performance 커맨드 구현

### DIFF
--- a/src/ante/cli/commands/strategy.py
+++ b/src/ante/cli/commands/strategy.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+from dataclasses import asdict
 from pathlib import Path
 
 import click
@@ -13,6 +15,20 @@ from ante.cli.middleware import require_auth, require_scope
 @click.group()
 def strategy() -> None:
     """전략 관리."""
+
+
+def _run(coro):  # noqa: ANN001, ANN202
+    return asyncio.run(coro)
+
+
+async def _create_registry():  # noqa: ANN202
+    from ante.core.database import Database
+    from ante.strategy.registry import StrategyRegistry
+
+    db = Database("db/ante.db")
+    await db.connect()
+    registry = StrategyRegistry(db)
+    return registry, db
 
 
 @strategy.command()
@@ -48,10 +64,226 @@ def validate(ctx: click.Context, path: str) -> None:
 
 
 @strategy.command("list")
+@click.option(
+    "--status", default=None, help="상태 필터 (registered/active/inactive/archived)"
+)
 @click.pass_context
 @require_auth
 @require_scope("strategy:read")
-def strategy_list(ctx: click.Context) -> None:
+def strategy_list(ctx: click.Context, status: str | None) -> None:
     """등록된 전략 목록 조회."""
     fmt = get_formatter(ctx)
-    fmt.output({"message": "Strategy list requires a running system."})
+
+    async def _list() -> list[dict]:
+        from ante.strategy.registry import StrategyStatus
+
+        registry, db = await _create_registry()
+        try:
+            filter_status = StrategyStatus(status) if status else None
+            records = await registry.list_strategies(status=filter_status)
+            return [
+                {
+                    "strategy_id": r.strategy_id,
+                    "name": r.name,
+                    "version": r.version,
+                    "status": r.status.value,
+                    "description": r.description,
+                    "author": r.author,
+                    "registered_at": r.registered_at.isoformat(),
+                }
+                for r in records
+            ]
+        finally:
+            await db.close()
+
+    rows = _run(_list())
+
+    if not rows:
+        fmt.output({"message": "등록된 전략 없음", "strategies": []})
+        return
+
+    if fmt.is_json:
+        fmt.output({"strategies": rows})
+    else:
+        fmt.table(
+            rows,
+            ["strategy_id", "name", "version", "status", "author"],
+        )
+
+
+@strategy.command("info")
+@click.argument("name")
+@click.pass_context
+@require_auth
+@require_scope("strategy:read")
+def strategy_info(ctx: click.Context, name: str) -> None:
+    """전략 상세 정보 조회 (메타데이터 + 파라미터)."""
+    fmt = get_formatter(ctx)
+
+    async def _info() -> dict | None:
+        registry, db = await _create_registry()
+        try:
+            records = await registry.get_by_name(name)
+            if not records:
+                return None
+
+            # 최신 버전 사용
+            record = records[0]
+
+            result: dict = {
+                "strategy_id": record.strategy_id,
+                "name": record.name,
+                "version": record.version,
+                "status": record.status.value,
+                "description": record.description,
+                "author": record.author,
+                "filepath": record.filepath,
+                "registered_at": record.registered_at.isoformat(),
+                "validation_warnings": record.validation_warnings,
+            }
+
+            # 전략 파일에서 파라미터 정보 로드 시도
+            params = _load_strategy_params(record.filepath)
+            if params is not None:
+                result["params"] = params["params"]
+                result["param_schema"] = params["param_schema"]
+
+            # 동일 이름의 다른 버전 목록
+            if len(records) > 1:
+                result["other_versions"] = [
+                    {
+                        "version": r.version,
+                        "strategy_id": r.strategy_id,
+                        "status": r.status.value,
+                    }
+                    for r in records[1:]
+                ]
+
+            return result
+        finally:
+            await db.close()
+
+    result = _run(_info())
+
+    if result is None:
+        fmt.error(f"전략을 찾을 수 없습니다: {name}")
+        raise SystemExit(1)
+
+    if fmt.is_json:
+        fmt.output(result)
+    else:
+        click.echo(f"  {'이름':15s}: {result['name']}")
+        click.echo(f"  {'버전':15s}: {result['version']}")
+        click.echo(f"  {'상태':15s}: {result['status']}")
+        click.echo(f"  {'설명':15s}: {result['description']}")
+        click.echo(f"  {'작성자':15s}: {result['author']}")
+        click.echo(f"  {'파일 경로':15s}: {result['filepath']}")
+        click.echo(f"  {'등록일':15s}: {result['registered_at']}")
+        if result.get("validation_warnings"):
+            click.echo(f"  {'검증 경고':15s}:")
+            for w in result["validation_warnings"]:
+                click.echo(f"    - {w}")
+        if result.get("params"):
+            click.echo(f"  {'파라미터':15s}:")
+            schema = result.get("param_schema", {})
+            for key, value in result["params"].items():
+                desc = schema.get(key, "")
+                line = f"    {key} = {value}"
+                if desc:
+                    line += f"  ({desc})"
+                click.echo(line)
+        if result.get("other_versions"):
+            click.echo(f"  {'다른 버전':15s}:")
+            for v in result["other_versions"]:
+                click.echo(f"    - {v['strategy_id']} ({v['status']})")
+
+
+def _load_strategy_params(filepath: str) -> dict | None:
+    """전략 파일에서 파라미터 정보를 로드. 실패 시 None."""
+    try:
+        from ante.strategy.loader import StrategyLoader
+
+        path = Path(filepath)
+        if not path.exists():
+            return None
+        cls = StrategyLoader.load(path)
+        # 더미 컨텍스트로 인스턴스 생성하여 파라미터 조회
+        instance = cls(ctx=None)
+        return {
+            "params": instance.get_params(),
+            "param_schema": instance.get_param_schema(),
+        }
+    except Exception:
+        return None
+
+
+@strategy.command("performance")
+@click.argument("name")
+@click.pass_context
+@require_auth
+@require_scope("strategy:read")
+def strategy_performance(ctx: click.Context, name: str) -> None:
+    """전략 전체 성과 집계 (모든 봇 합산, Agent 피드백용)."""
+    fmt = get_formatter(ctx)
+
+    async def _perf() -> dict | None:
+        from ante.core.database import Database
+        from ante.strategy.registry import StrategyRegistry
+        from ante.trade.performance import PerformanceTracker
+
+        db = Database("db/ante.db")
+        await db.connect()
+        try:
+            registry = StrategyRegistry(db)
+            records = await registry.get_by_name(name)
+            if not records:
+                return None
+
+            tracker = PerformanceTracker(db)
+            # 최신 버전의 strategy_id 기준으로 성과 계산
+            record = records[0]
+            metrics = await tracker.calculate(strategy_id=record.name)
+
+            return {
+                "strategy_name": record.name,
+                "strategy_id": record.strategy_id,
+                "metrics": asdict(metrics),
+            }
+        finally:
+            await db.close()
+
+    result = _run(_perf())
+
+    if result is None:
+        fmt.error(f"전략을 찾을 수 없습니다: {name}")
+        raise SystemExit(1)
+
+    metrics = result["metrics"]
+
+    if fmt.is_json:
+        fmt.output(result)
+    else:
+        click.echo(f"전략 성과: {result['strategy_name']} ({result['strategy_id']})")
+        click.echo(f"  {'총 거래':15s}: {metrics['total_trades']}")
+        click.echo(f"  {'승률':15s}: {metrics['win_rate']:.1%}")
+        click.echo(f"  {'승리':15s}: {metrics['winning_trades']}")
+        click.echo(f"  {'패배':15s}: {metrics['losing_trades']}")
+        click.echo(f"  {'총 손익':15s}: {metrics['total_pnl']:,.0f}")
+        click.echo(f"  {'순 손익':15s}: {metrics['net_pnl']:,.0f}")
+        click.echo(f"  {'총 수수료':15s}: {metrics['total_commission']:,.0f}")
+        click.echo(f"  {'평균 수익':15s}: {metrics['avg_profit']:,.0f}")
+        click.echo(f"  {'평균 손실':15s}: {metrics['avg_loss']:,.0f}")
+        click.echo(f"  {'수익 팩터':15s}: {metrics['profit_factor']:.2f}")
+        click.echo(f"  {'MDD':15s}: {metrics['max_drawdown']:.1%}")
+        click.echo(f"  {'MDD 금액':15s}: {metrics['max_drawdown_amount']:,.0f}")
+        sharpe = metrics["sharpe_ratio"]
+        click.echo(
+            f"  {'샤프 비율':15s}: {sharpe:.2f}"
+            if sharpe is not None
+            else f"  {'샤프 비율':15s}: N/A (거래 30건 미만)"
+        )
+        click.echo(f"  {'활성 일수':15s}: {metrics['active_days']}")
+        if metrics.get("first_trade_at"):
+            click.echo(f"  {'첫 거래':15s}: {metrics['first_trade_at']}")
+        if metrics.get("last_trade_at"):
+            click.echo(f"  {'마지막 거래':15s}: {metrics['last_trade_at']}")

--- a/src/ante/strategy/registry.py
+++ b/src/ante/strategy/registry.py
@@ -150,6 +150,14 @@ class StrategyRegistry:
             (status.value, strategy_id),
         )
 
+    async def get_by_name(self, name: str) -> list[StrategyRecord]:
+        """이름으로 전략 레코드 조회 (동일 이름 여러 버전 가능)."""
+        rows = await self._db.fetch_all(
+            "SELECT * FROM strategies WHERE name = ? ORDER BY registered_at DESC",
+            (name,),
+        )
+        return [self._row_to_record(row) for row in rows]
+
     async def exists(self, strategy_id: str) -> bool:
         """전략 존재 여부 확인."""
         row = await self._db.fetch_one(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -225,8 +225,21 @@ class TestStrategyCommands:
         assert result.exit_code != 0
 
     def test_list(self, runner):
-        result = runner.invoke(cli, ["strategy", "list"])
-        assert result.exit_code == 0
+        from unittest.mock import AsyncMock, MagicMock
+
+        db = MagicMock()
+        db.connect = AsyncMock()
+        db.close = AsyncMock()
+        registry = MagicMock()
+        registry.list_strategies = AsyncMock(return_value=[])
+
+        with patch(
+            "ante.cli.commands.strategy._create_registry",
+            new_callable=AsyncMock,
+            return_value=(registry, db),
+        ):
+            result = runner.invoke(cli, ["strategy", "list"])
+            assert result.exit_code == 0
 
 
 # ── Data 커맨드 테스트 ──────────────────────────────

--- a/tests/unit/test_cli_auth.py
+++ b/tests/unit/test_cli_auth.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -106,16 +106,31 @@ def agent_no_scopes_runner():
     return r
 
 
+def _mock_strategy_registry():
+    """strategy list가 DB 접속 없이 동작하도록 mock."""
+    db = MagicMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    registry = MagicMock()
+    registry.list_strategies = AsyncMock(return_value=[])
+    return patch(
+        "ante.cli.commands.strategy._create_registry",
+        new_callable=AsyncMock,
+        return_value=(registry, db),
+    )
+
+
 class TestAuthRequired:
     """@require_auth 데코레이터 테스트."""
 
     def test_unauthenticated_command_fails(self, runner):
         """토큰 없이 인증 필수 커맨드 실행 시 실패."""
-        result = runner.invoke(cli, ["strategy", "list"])
-        assert result.exit_code != 0
-        assert "인증이 필요합니다" in result.output or "인증이 필요합니다" in (
-            result.output + (result.stderr_bytes or b"").decode()
-        )
+        with _mock_strategy_registry():
+            result = runner.invoke(cli, ["strategy", "list"])
+            assert result.exit_code != 0
+            assert "인증이 필요합니다" in result.output or "인증이 필요합니다" in (
+                result.output + (result.stderr_bytes or b"").decode()
+            )
 
     def test_authenticated_help_works(self, runner):
         """--help는 인증 없이도 동작."""
@@ -124,8 +139,9 @@ class TestAuthRequired:
 
     def test_authenticated_command_succeeds(self, auth_runner):
         """인증된 상태에서 커맨드 정상 실행."""
-        result = auth_runner.invoke(cli, ["strategy", "list"])
-        assert result.exit_code == 0
+        with _mock_strategy_registry():
+            result = auth_runner.invoke(cli, ["strategy", "list"])
+            assert result.exit_code == 0
 
 
 class TestRequireScope:
@@ -133,18 +149,21 @@ class TestRequireScope:
 
     def test_human_bypasses_scope_check(self, auth_runner):
         """Human(master) 멤버는 scope 검증 없이 통과."""
-        result = auth_runner.invoke(cli, ["strategy", "list"])
-        assert result.exit_code == 0
+        with _mock_strategy_registry():
+            result = auth_runner.invoke(cli, ["strategy", "list"])
+            assert result.exit_code == 0
 
     def test_agent_with_matching_scope_passes(self, agent_runner):
         """Agent가 필요 scope를 보유하면 통과."""
-        result = agent_runner.invoke(cli, ["strategy", "list"])
-        assert result.exit_code == 0
+        with _mock_strategy_registry():
+            result = agent_runner.invoke(cli, ["strategy", "list"])
+            assert result.exit_code == 0
 
     def test_agent_without_scope_fails(self, agent_no_scopes_runner):
         """Agent가 필요 scope가 없으면 실패."""
-        result = agent_no_scopes_runner.invoke(cli, ["strategy", "list"])
-        assert result.exit_code != 0
+        with _mock_strategy_registry():
+            result = agent_no_scopes_runner.invoke(cli, ["strategy", "list"])
+            assert result.exit_code != 0
 
 
 class TestAuthExemptCommands:

--- a/tests/unit/test_cli_strategy.py
+++ b/tests/unit/test_cli_strategy.py
@@ -1,0 +1,376 @@
+"""CLI strategy list/info/performance 커맨드 단위 테스트."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+from ante.strategy.registry import StrategyRecord, StrategyStatus
+from ante.trade.models import PerformanceMetrics
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+_NOW = datetime(2026, 3, 19, 12, 0, 0, tzinfo=UTC)
+
+_SAMPLE_RECORD = StrategyRecord(
+    strategy_id="momentum_v1.0",
+    name="momentum",
+    version="1.0",
+    filepath="/strategies/momentum.py",
+    status=StrategyStatus.ACTIVE,
+    registered_at=_NOW,
+    description="모멘텀 전략",
+    author="agent",
+    validation_warnings=[],
+)
+
+_SAMPLE_RECORD_V2 = StrategyRecord(
+    strategy_id="momentum_v2.0",
+    name="momentum",
+    version="2.0",
+    filepath="/strategies/momentum_v2.py",
+    status=StrategyStatus.REGISTERED,
+    registered_at=_NOW,
+    description="모멘텀 전략 v2",
+    author="agent",
+    validation_warnings=["warning1"],
+)
+
+_SAMPLE_METRICS = PerformanceMetrics(
+    total_trades=10,
+    winning_trades=7,
+    losing_trades=3,
+    win_rate=0.7,
+    total_pnl=500000.0,
+    total_commission=5000.0,
+    net_pnl=495000.0,
+    avg_profit=100000.0,
+    avg_loss=50000.0,
+    profit_factor=4.67,
+    max_drawdown=0.05,
+    max_drawdown_amount=25000.0,
+    sharpe_ratio=1.5,
+    first_trade_at=_NOW,
+    last_trade_at=_NOW,
+    active_days=5,
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _mock_db():
+    """Mock Database with connect/close."""
+    db = MagicMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    return db
+
+
+def _mock_registry(strategies=None):
+    """Mock StrategyRegistry."""
+    registry = MagicMock()
+    registry.list_strategies = AsyncMock(return_value=strategies or [])
+    registry.get_by_name = AsyncMock(return_value=strategies or [])
+    return registry
+
+
+class TestStrategyList:
+    def test_list_empty(self, runner):
+        """전략이 없으면 빈 목록 출력."""
+        db = _mock_db()
+        registry = _mock_registry([])
+
+        with (
+            patch(
+                "ante.cli.commands.strategy._create_registry",
+                new_callable=AsyncMock,
+                return_value=(registry, db),
+            ),
+        ):
+            result = runner.invoke(cli, ["strategy", "list"])
+            assert result.exit_code == 0
+            assert "등록된 전략 없음" in result.output
+
+    def test_list_empty_json(self, runner):
+        """JSON 모드 — 빈 목록."""
+        db = _mock_db()
+        registry = _mock_registry([])
+
+        with patch(
+            "ante.cli.commands.strategy._create_registry",
+            new_callable=AsyncMock,
+            return_value=(registry, db),
+        ):
+            result = runner.invoke(cli, ["--format", "json", "strategy", "list"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["strategies"] == []
+
+    def test_list_with_strategies(self, runner):
+        """전략이 있으면 테이블 출력."""
+        db = _mock_db()
+        registry = _mock_registry([_SAMPLE_RECORD])
+
+        with patch(
+            "ante.cli.commands.strategy._create_registry",
+            new_callable=AsyncMock,
+            return_value=(registry, db),
+        ):
+            result = runner.invoke(cli, ["strategy", "list"])
+            assert result.exit_code == 0
+            assert "momentum" in result.output
+
+    def test_list_json(self, runner):
+        """JSON 모드 — 전략 목록."""
+        db = _mock_db()
+        registry = _mock_registry([_SAMPLE_RECORD])
+
+        with patch(
+            "ante.cli.commands.strategy._create_registry",
+            new_callable=AsyncMock,
+            return_value=(registry, db),
+        ):
+            result = runner.invoke(cli, ["--format", "json", "strategy", "list"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert len(data["strategies"]) == 1
+            assert data["strategies"][0]["name"] == "momentum"
+            assert data["strategies"][0]["strategy_id"] == "momentum_v1.0"
+
+    def test_list_with_status_filter(self, runner):
+        """--status 필터 적용."""
+        db = _mock_db()
+        registry = _mock_registry([_SAMPLE_RECORD])
+
+        with patch(
+            "ante.cli.commands.strategy._create_registry",
+            new_callable=AsyncMock,
+            return_value=(registry, db),
+        ):
+            result = runner.invoke(cli, ["strategy", "list", "--status", "active"])
+            assert result.exit_code == 0
+            registry.list_strategies.assert_called_once_with(
+                status=StrategyStatus.ACTIVE,
+            )
+
+
+class TestStrategyInfo:
+    def test_info_not_found(self, runner):
+        """존재하지 않는 전략."""
+        db = _mock_db()
+        registry = _mock_registry([])
+
+        with patch(
+            "ante.cli.commands.strategy._create_registry",
+            new_callable=AsyncMock,
+            return_value=(registry, db),
+        ):
+            result = runner.invoke(cli, ["strategy", "info", "nonexistent"])
+            assert result.exit_code == 1
+
+    def test_info_not_found_json(self, runner):
+        """JSON 모드 — 존재하지 않는 전략."""
+        db = _mock_db()
+        registry = _mock_registry([])
+
+        with patch(
+            "ante.cli.commands.strategy._create_registry",
+            new_callable=AsyncMock,
+            return_value=(registry, db),
+        ):
+            result = runner.invoke(
+                cli, ["--format", "json", "strategy", "info", "nonexistent"]
+            )
+            assert result.exit_code == 1
+
+    def test_info_found(self, runner):
+        """전략 상세 정보 출력."""
+        db = _mock_db()
+        registry = _mock_registry([_SAMPLE_RECORD])
+
+        with (
+            patch(
+                "ante.cli.commands.strategy._create_registry",
+                new_callable=AsyncMock,
+                return_value=(registry, db),
+            ),
+            patch(
+                "ante.cli.commands.strategy._load_strategy_params",
+                return_value={
+                    "params": {"period": 20},
+                    "param_schema": {"period": "이동평균 기간"},
+                },
+            ),
+        ):
+            result = runner.invoke(cli, ["strategy", "info", "momentum"])
+            assert result.exit_code == 0
+            assert "momentum" in result.output
+            assert "1.0" in result.output
+
+    def test_info_json(self, runner):
+        """JSON 모드 — 전략 상세."""
+        db = _mock_db()
+        registry = _mock_registry([_SAMPLE_RECORD])
+
+        with (
+            patch(
+                "ante.cli.commands.strategy._create_registry",
+                new_callable=AsyncMock,
+                return_value=(registry, db),
+            ),
+            patch(
+                "ante.cli.commands.strategy._load_strategy_params",
+                return_value={
+                    "params": {"period": 20},
+                    "param_schema": {"period": "이동평균 기간"},
+                },
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["--format", "json", "strategy", "info", "momentum"]
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["name"] == "momentum"
+            assert data["params"] == {"period": 20}
+            assert data["param_schema"] == {"period": "이동평균 기간"}
+
+    def test_info_multiple_versions(self, runner):
+        """동일 이름의 여러 버전이 있을 때 최신 버전 + 다른 버전 목록."""
+        db = _mock_db()
+        registry = _mock_registry([_SAMPLE_RECORD_V2, _SAMPLE_RECORD])
+
+        with (
+            patch(
+                "ante.cli.commands.strategy._create_registry",
+                new_callable=AsyncMock,
+                return_value=(registry, db),
+            ),
+            patch(
+                "ante.cli.commands.strategy._load_strategy_params",
+                return_value=None,
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["--format", "json", "strategy", "info", "momentum"]
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["version"] == "2.0"
+            assert len(data["other_versions"]) == 1
+            assert data["other_versions"][0]["version"] == "1.0"
+
+    def test_info_params_load_failure(self, runner):
+        """전략 파일 로드 실패 시 params 필드 없음."""
+        db = _mock_db()
+        registry = _mock_registry([_SAMPLE_RECORD])
+
+        with (
+            patch(
+                "ante.cli.commands.strategy._create_registry",
+                new_callable=AsyncMock,
+                return_value=(registry, db),
+            ),
+            patch(
+                "ante.cli.commands.strategy._load_strategy_params",
+                return_value=None,
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["--format", "json", "strategy", "info", "momentum"]
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert "params" not in data
+
+
+class TestStrategyPerformance:
+    def test_perf_not_found(self, runner):
+        """존재하지 않는 전략."""
+        with (
+            patch("ante.cli.commands.strategy.asyncio.run") as mock_run,
+        ):
+            mock_run.return_value = None
+            result = runner.invoke(cli, ["strategy", "performance", "nonexistent"])
+            assert result.exit_code == 1
+
+    def test_perf_found(self, runner):
+        """전략 성과 출력 (text 모드)."""
+        expected = {
+            "strategy_name": "momentum",
+            "strategy_id": "momentum_v1.0",
+            "metrics": asdict(_SAMPLE_METRICS),
+        }
+
+        with patch("ante.cli.commands.strategy.asyncio.run", return_value=expected):
+            result = runner.invoke(cli, ["strategy", "performance", "momentum"])
+            assert result.exit_code == 0
+            assert "momentum" in result.output
+            assert "70.0%" in result.output
+
+    def test_perf_json(self, runner):
+        """JSON 모드 — 전략 성과."""
+        expected = {
+            "strategy_name": "momentum",
+            "strategy_id": "momentum_v1.0",
+            "metrics": asdict(_SAMPLE_METRICS),
+        }
+
+        with patch("ante.cli.commands.strategy.asyncio.run", return_value=expected):
+            result = runner.invoke(
+                cli, ["--format", "json", "strategy", "performance", "momentum"]
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["strategy_name"] == "momentum"
+            assert data["metrics"]["total_trades"] == 10
+            assert data["metrics"]["win_rate"] == 0.7
+
+    def test_perf_empty_metrics(self, runner):
+        """거래 없는 전략 성과."""
+        empty = PerformanceMetrics()
+        expected = {
+            "strategy_name": "momentum",
+            "strategy_id": "momentum_v1.0",
+            "metrics": asdict(empty),
+        }
+
+        with patch("ante.cli.commands.strategy.asyncio.run", return_value=expected):
+            result = runner.invoke(
+                cli, ["--format", "json", "strategy", "performance", "momentum"]
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["metrics"]["total_trades"] == 0


### PR DESCRIPTION
## Summary
- `ante strategy list` stub 해소 — StrategyRegistry에서 등록 전략 목록 조회/출력, `--status` 필터, `--format json` 지원
- `ante strategy info <name>` 신규 — 메타데이터 + 파라미터 상세, 동일 이름 다른 버전 목록, `--format json` 지원
- `ante strategy performance <name>` 신규 — 전략별 성과 집계 (PerformanceTracker 연동), `--format json` 지원
- `StrategyRegistry.get_by_name()` 메서드 추가
- 15개 단위 테스트 추가, 기존 테스트 호환성 수정

Refs #462

## Test plan
- [x] `ante strategy list` — 빈 목록, 전략 있는 목록, `--status` 필터, JSON 모드
- [x] `ante strategy info` — 존재/미존재, 파라미터 로드, 다중 버전, JSON 모드
- [x] `ante strategy performance` — 존재/미존재, 빈 메트릭, JSON 모드
- [x] 기존 테스트 (test_cli.py, test_cli_auth.py) 호환성 확인
- [x] 전체 테스트 스위트 통과 (2056 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)