### PR TITLE
fix(member): revoke 시 상태 검증 누락 수정

### DIFF
--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -507,6 +507,9 @@ class MemberService:
         """멤버 영구 폐기. 토큰 해시 삭제."""
         member = await self._get_or_raise(member_id)
         self._assert_not_master(member, "revoke")
+        self._assert_status(
+            member, (MemberStatus.ACTIVE, MemberStatus.SUSPENDED), "revoke"
+        )
 
         now = _now()
         await self._db.execute(
@@ -629,11 +632,15 @@ class MemberService:
             raise PermissionError(msg)
 
     @staticmethod
-    def _assert_status(member: Member, expected: str, action: str) -> None:
-        """특정 상태 검증."""
-        if member.status != expected:
+    def _assert_status(
+        member: Member, expected: str | tuple[str, ...], action: str
+    ) -> None:
+        """특정 상태 검증. 단일 또는 복수 상태를 허용한다."""
+        statuses = (expected,) if isinstance(expected, str) else expected
+        if member.status not in statuses:
+            allowed = ", ".join(statuses)
             msg = (
-                f"{action}은(는) {expected} 상태에서만 "
+                f"{action}은(는) {allowed} 상태에서만 "
                 f"가능합니다 (현재: {member.status})"
             )
             raise PermissionError(msg)

--- a/tests/unit/test_member.py
+++ b/tests/unit/test_member.py
@@ -264,6 +264,19 @@ class TestSuspendReactivateRevoke:
         assert m.status == MemberStatus.REVOKED
         assert m.token_hash == ""
 
+    async def test_revoke_suspended_member(self, service):
+        await service.register("agent-01", MemberType.AGENT)
+        await service.suspend("agent-01", suspended_by="owner")
+        m = await service.revoke("agent-01", revoked_by="owner")
+        assert m.status == MemberStatus.REVOKED
+        assert m.token_hash == ""
+
+    async def test_revoke_already_revoked_fails(self, service):
+        await service.register("agent-01", MemberType.AGENT)
+        await service.revoke("agent-01", revoked_by="owner")
+        with pytest.raises(PermissionError, match="active, suspended 상태에서만"):
+            await service.revoke("agent-01", revoked_by="owner")
+
     async def test_revoke_master_fails(self, service):
         await service.bootstrap_master("owner", "pass123")
         with pytest.raises(PermissionError, match="master는 revoke"):


### PR DESCRIPTION
## Summary
- `_assert_status()`를 복수 상태(tuple)도 허용하도록 확장
- `revoke()`에 `active`/`suspended` 상태 검증 추가 — 이미 `revoked`된 멤버의 재폐기를 `PermissionError`로 거부
- `suspended → revoke` 정상 동작 테스트 및 `revoked → revoke` 거부 테스트 추가

## Test plan
- [x] `test_revoke` — active → revoke 정상 동작 (기존)
- [x] `test_revoke_suspended_member` — suspended → revoke 정상 동작 (신규)
- [x] `test_revoke_already_revoked_fails` — revoked → revoke 거부 (신규)
- [x] 전체 테스트 스위트 2058 passed

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)