### PR TITLE
feat(cli): ante strategy submit 커맨드 구현

### DIFF
--- a/src/ante/cli/commands/strategy.py
+++ b/src/ante/cli/commands/strategy.py
@@ -63,6 +63,109 @@ def validate(ctx: click.Context, path: str) -> None:
             fmt.output(data)
 
 
+@strategy.command("submit")
+@click.argument("path", type=click.Path(exists=True))
+@click.pass_context
+@require_auth
+@require_scope("strategy:write")
+def submit(ctx: click.Context, path: str) -> None:
+    """전략 제출 (검증 -> 로드 테스트 -> Registry 등록)."""
+    from ante.strategy.exceptions import StrategyError, StrategyLoadError
+    from ante.strategy.loader import StrategyLoader
+    from ante.strategy.validator import StrategyValidator
+
+    fmt = get_formatter(ctx)
+    filepath = Path(path)
+
+    # 1. 정적 검증
+    validator = StrategyValidator()
+    validation = validator.validate(filepath)
+
+    if not validation.valid:
+        if fmt.is_json:
+            fmt.output(
+                {
+                    "submitted": False,
+                    "stage": "validate",
+                    "errors": validation.errors,
+                }
+            )
+        else:
+            fmt.error(f"Validation failed: {path}")
+            for err in validation.errors:
+                click.echo(f"  - {err}", err=True)
+        raise SystemExit(1)
+
+    if validation.warnings and not fmt.is_json:
+        for warn in validation.warnings:
+            click.echo(f"  [warn] {warn}", err=True)
+
+    # 2. 로드 테스트 — Strategy 클래스 import + meta 추출
+    try:
+        strategy_cls = StrategyLoader.load(filepath)
+    except StrategyLoadError as e:
+        if fmt.is_json:
+            fmt.output(
+                {
+                    "submitted": False,
+                    "stage": "load",
+                    "error": str(e),
+                }
+            )
+        else:
+            fmt.error(f"Load test failed: {e}")
+        raise SystemExit(1)
+
+    meta = strategy_cls.meta
+
+    # 3. Registry 등록
+    async def _register() -> dict:
+        registry, db = await _create_registry()
+        try:
+            await registry.initialize()
+            record = await registry.register(
+                filepath=filepath,
+                meta=meta,
+                warnings=validation.warnings,
+            )
+            return {
+                "submitted": True,
+                "strategy_id": record.strategy_id,
+                "name": record.name,
+                "version": record.version,
+                "description": record.description,
+                "author": record.author,
+                "filepath": str(record.filepath),
+                "registered_at": record.registered_at.isoformat(),
+                "validation_warnings": record.validation_warnings,
+            }
+        finally:
+            await db.close()
+
+    try:
+        result = _run(_register())
+    except StrategyError as e:
+        if fmt.is_json:
+            fmt.output(
+                {
+                    "submitted": False,
+                    "stage": "register",
+                    "error": str(e),
+                }
+            )
+        else:
+            fmt.error(str(e))
+        raise SystemExit(1)
+
+    if fmt.is_json:
+        fmt.output(result)
+    else:
+        fmt.success(
+            f"전략 등록 완료: {result['strategy_id']}",
+            result,
+        )
+
+
 @strategy.command("list")
 @click.option(
     "--status", default=None, help="상태 필터 (registered/active/inactive/archived)"

--- a/tests/unit/test_cli_strategy.py
+++ b/tests/unit/test_cli_strategy.py
@@ -1,4 +1,4 @@
-"""CLI strategy list/info/performance 커맨드 단위 테스트."""
+"""CLI strategy list/info/performance/submit 커맨드 단위 테스트."""
 
 from __future__ import annotations
 
@@ -374,3 +374,196 @@ class TestStrategyPerformance:
             assert result.exit_code == 0
             data = json.loads(result.output)
             assert data["metrics"]["total_trades"] == 0
+
+
+class TestStrategySubmit:
+    """ante strategy submit 커맨드 테스트."""
+
+    @pytest.fixture
+    def strategy_file(self, tmp_path):
+        """유효한 전략 파일 생성."""
+        import textwrap
+
+        code = textwrap.dedent("""\
+            from ante.strategy.base import Strategy, StrategyMeta, Signal
+
+            class MyStrategy(Strategy):
+                meta = StrategyMeta(
+                    name="test_strat",
+                    version="1.0.0",
+                    description="Test strategy",
+                    author="agent",
+                )
+
+                async def on_step(self, context):
+                    return []
+        """)
+        fp = tmp_path / "test_strat.py"
+        fp.write_text(code)
+        return str(fp)
+
+    @pytest.fixture
+    def invalid_strategy_file(self, tmp_path):
+        """검증 실패하는 전략 파일 (Strategy 클래스 없음)."""
+        fp = tmp_path / "bad_strat.py"
+        fp.write_text("x = 1\n")
+        return str(fp)
+
+    def test_submit_success(self, runner, strategy_file):
+        """검증 -> 로드 -> 등록 전체 성공 플로우."""
+
+        mock_record = StrategyRecord(
+            strategy_id="test_strat_v1.0.0",
+            name="test_strat",
+            version="1.0.0",
+            filepath=strategy_file,
+            status=StrategyStatus.REGISTERED,
+            registered_at=_NOW,
+            description="Test strategy",
+            author="agent",
+            validation_warnings=[],
+        )
+
+        db = _mock_db()
+        registry = MagicMock()
+        registry.initialize = AsyncMock()
+        registry.register = AsyncMock(return_value=mock_record)
+
+        with patch(
+            "ante.cli.commands.strategy._create_registry",
+            new_callable=AsyncMock,
+            return_value=(registry, db),
+        ):
+            result = runner.invoke(cli, ["strategy", "submit", strategy_file])
+            assert result.exit_code == 0
+            assert "test_strat_v1.0.0" in result.output
+
+    def test_submit_success_json(self, runner, strategy_file):
+        """JSON 모드 성공 출력."""
+        mock_record = StrategyRecord(
+            strategy_id="test_strat_v1.0.0",
+            name="test_strat",
+            version="1.0.0",
+            filepath=strategy_file,
+            status=StrategyStatus.REGISTERED,
+            registered_at=_NOW,
+            description="Test strategy",
+            author="agent",
+            validation_warnings=[],
+        )
+
+        db = _mock_db()
+        registry = MagicMock()
+        registry.initialize = AsyncMock()
+        registry.register = AsyncMock(return_value=mock_record)
+
+        with patch(
+            "ante.cli.commands.strategy._create_registry",
+            new_callable=AsyncMock,
+            return_value=(registry, db),
+        ):
+            result = runner.invoke(
+                cli, ["--format", "json", "strategy", "submit", strategy_file]
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["submitted"] is True
+            assert data["strategy_id"] == "test_strat_v1.0.0"
+            assert data["name"] == "test_strat"
+            assert data["version"] == "1.0.0"
+
+    def test_submit_validation_failure(self, runner, invalid_strategy_file):
+        """정적 검증 실패 시 exit 1."""
+        result = runner.invoke(cli, ["strategy", "submit", invalid_strategy_file])
+        assert result.exit_code == 1
+
+    def test_submit_validation_failure_json(self, runner, invalid_strategy_file):
+        """JSON 모드 — 검증 실패."""
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "strategy", "submit", invalid_strategy_file],
+        )
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["submitted"] is False
+        assert data["stage"] == "validate"
+        assert len(data["errors"]) > 0
+
+    def test_submit_load_failure(self, runner, tmp_path):
+        """로드 테스트 실패 (올바른 AST이지만 import 불가)."""
+        import textwrap
+
+        # 검증은 통과하지만 로드 시 실패하는 전략 파일
+        code = textwrap.dedent("""\
+            from ante.strategy.base import Strategy, StrategyMeta, Signal
+
+            class BrokenStrategy(Strategy):
+                meta = StrategyMeta(
+                    name="broken",
+                    version="1.0.0",
+                    description="Broken",
+                )
+
+                async def on_step(self, context):
+                    return []
+
+                def __init_subclass__(cls, **kwargs):
+                    raise RuntimeError("intentional break")
+        """)
+        fp = tmp_path / "broken.py"
+        fp.write_text(code)
+
+        # 검증은 통과하도록 mock, 로드만 실패
+        from ante.strategy.exceptions import StrategyLoadError
+
+        with patch(
+            "ante.strategy.loader.StrategyLoader.load",
+            side_effect=StrategyLoadError("Cannot load"),
+        ):
+            result = runner.invoke(cli, ["strategy", "submit", str(fp)])
+            assert result.exit_code == 1
+
+    def test_submit_duplicate(self, runner, strategy_file):
+        """중복 등록 시 에러."""
+        from ante.strategy.exceptions import StrategyError
+
+        db = _mock_db()
+        registry = MagicMock()
+        registry.initialize = AsyncMock()
+        registry.register = AsyncMock(
+            side_effect=StrategyError("Strategy already registered: test_strat_v1.0.0")
+        )
+
+        with patch(
+            "ante.cli.commands.strategy._create_registry",
+            new_callable=AsyncMock,
+            return_value=(registry, db),
+        ):
+            result = runner.invoke(cli, ["strategy", "submit", strategy_file])
+            assert result.exit_code == 1
+            assert "already registered" in result.output
+
+    def test_submit_duplicate_json(self, runner, strategy_file):
+        """JSON 모드 — 중복 등록 에러."""
+        from ante.strategy.exceptions import StrategyError
+
+        db = _mock_db()
+        registry = MagicMock()
+        registry.initialize = AsyncMock()
+        registry.register = AsyncMock(
+            side_effect=StrategyError("Strategy already registered: test_strat_v1.0.0")
+        )
+
+        with patch(
+            "ante.cli.commands.strategy._create_registry",
+            new_callable=AsyncMock,
+            return_value=(registry, db),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "strategy", "submit", strategy_file],
+            )
+            assert result.exit_code == 1
+            data = json.loads(result.output)
+            assert data["submitted"] is False
+            assert data["stage"] == "register"


### PR DESCRIPTION
## Summary
- `ante strategy submit <path>` 커맨드 구현: validate -> load -> register 3단계 파이프라인
- 각 단계 실패 시 명확한 에러 메시지 출력 및 exit 1
- `--format json` 지원 (등록 결과 또는 에러를 구조화된 JSON으로 출력)
- 중복 등록 방어 (동일 name+version 이미 존재 시 에러)
- 단위 테스트 7개 추가 (성공/검증실패/로드실패/중복 등 text+json 모드)

Closes #500

## Test plan
- [x] `ante strategy submit` 성공 플로우 (text/json)
- [x] 정적 검증 실패 시 에러 출력 (text/json)
- [x] 로드 테스트 실패 시 에러 출력
- [x] 중복 등록 시 에러 출력 (text/json)
- [x] 기존 테스트 전체 통과 (2077 passed)
- [x] ruff check/format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)