### PR TITLE
fix(test): CLI 서브커맨드 docstring 누락 방지 회귀 테스트 (#494)

### DIFF
--- a/tests/unit/test_generate_cli_reference.py
+++ b/tests/unit/test_generate_cli_reference.py
@@ -231,3 +231,21 @@ class TestGenerateCliReference:
 
         # bot create는 --name, --strategy 등 옵션이 많음
         assert "**Options:**" in content
+
+    def test_all_subcommands_have_description(self) -> None:
+        """모든 서브커맨드에 설명(docstring)이 존재한다.
+
+        요약 테이블의 설명 열이 비어 있으면 안 된다 (#494).
+        """
+        import re
+
+        buf = io.StringIO()
+        generate_cli_reference(buf)
+        content = buf.getvalue()
+
+        # 요약 테이블에서 명령어 행 추출
+        summary_rows = re.findall(r"\| `(ante [^`]+)` \| (.*?) \|", content)
+        assert len(summary_rows) > 0, "요약 테이블에서 명령어를 찾지 못함"
+
+        blank = [cmd for cmd, desc in summary_rows if not desc.strip()]
+        assert blank == [], f"설명이 비어 있는 명령어: {blank}"


### PR DESCRIPTION
## Summary
- 모든 CLI 서브커맨드(76개)에 docstring이 존재함을 확인
- `cli-reference.md` 재생성 시 설명 공백이 없음을 검증하는 회귀 테스트 추가 (`test_all_subcommands_have_description`)
- 향후 docstring 없이 CLI 커맨드가 추가되면 테스트가 즉시 실패하여 누락 방지

## Test plan
- [x] `pytest tests/unit/test_generate_cli_reference.py` — 20 passed
- [x] `pytest tests/ --ignore=tests/e2e` — 2071 passed
- [x] `ruff check` — passed
- [x] `scripts/generate_cli_reference.py --stdout` — 76 subcommands, 공백 설명 0건

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)