### PR TITLE
feat(backtest): 백테스트→리포트 DRAFT 자동 생성 플로우 (#493)

### DIFF
--- a/src/ante/backtest/__init__.py
+++ b/src/ante/backtest/__init__.py
@@ -9,6 +9,7 @@ from ante.backtest.exceptions import (
 from ante.backtest.executor import BacktestExecutor
 from ante.backtest.metrics import calculate_metrics
 from ante.backtest.result import BacktestResult, BacktestTrade
+from ante.backtest.run_store import BacktestRun, BacktestRunStore
 from ante.backtest.service import BacktestService
 
 __all__ = [
@@ -18,7 +19,9 @@ __all__ = [
     "BacktestError",
     "BacktestExecutor",
     "BacktestResult",
-    "calculate_metrics",
+    "BacktestRun",
+    "BacktestRunStore",
     "BacktestService",
     "BacktestTrade",
+    "calculate_metrics",
 ]

--- a/src/ante/backtest/run_store.py
+++ b/src/ante/backtest/run_store.py
@@ -1,0 +1,180 @@
+"""BacktestRunStore — 백테스트 실행 이력 저장·조회."""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+
+logger = logging.getLogger(__name__)
+
+BACKTEST_RUNS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS backtest_runs (
+    run_id           TEXT PRIMARY KEY,
+    strategy_name    TEXT NOT NULL,
+    strategy_version TEXT NOT NULL,
+    params_json      TEXT DEFAULT '{}',
+    total_return_pct REAL,
+    sharpe_ratio     REAL,
+    max_drawdown_pct REAL,
+    total_trades     INTEGER,
+    win_rate         REAL,
+    result_path      TEXT NOT NULL,
+    created_at       TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_backtest_runs_strategy
+    ON backtest_runs(strategy_name);
+"""
+
+
+@dataclass
+class BacktestRun:
+    """백테스트 실행 이력 레코드."""
+
+    run_id: str
+    strategy_name: str
+    strategy_version: str
+    params_json: str = "{}"
+    total_return_pct: float | None = None
+    sharpe_ratio: float | None = None
+    max_drawdown_pct: float | None = None
+    total_trades: int | None = None
+    win_rate: float | None = None
+    result_path: str = ""
+    created_at: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """딕셔너리 변환."""
+        return {
+            "run_id": self.run_id,
+            "strategy_name": self.strategy_name,
+            "strategy_version": self.strategy_version,
+            "params_json": self.params_json,
+            "total_return_pct": self.total_return_pct,
+            "sharpe_ratio": self.sharpe_ratio,
+            "max_drawdown_pct": self.max_drawdown_pct,
+            "total_trades": self.total_trades,
+            "win_rate": self.win_rate,
+            "result_path": self.result_path,
+            "created_at": self.created_at,
+        }
+
+
+class BacktestRunStore:
+    """백테스트 실행 이력 저장·조회."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    async def initialize(self) -> None:
+        """스키마 생성."""
+        await self._db.execute_script(BACKTEST_RUNS_SCHEMA)
+        logger.info("BacktestRunStore 초기화 완료")
+
+    async def save(
+        self,
+        *,
+        strategy_name: str,
+        strategy_version: str,
+        params: dict[str, Any] | None = None,
+        total_return_pct: float | None = None,
+        sharpe_ratio: float | None = None,
+        max_drawdown_pct: float | None = None,
+        total_trades: int | None = None,
+        win_rate: float | None = None,
+        result_path: str = "",
+    ) -> str:
+        """실행 이력 저장. run_id 반환."""
+        run_id = str(uuid.uuid4())
+        created_at = datetime.now(tz=UTC).isoformat()
+        params_json = json.dumps(params or {}, default=str)
+
+        await self._db.execute(
+            """INSERT INTO backtest_runs
+               (run_id, strategy_name, strategy_version, params_json,
+                total_return_pct, sharpe_ratio, max_drawdown_pct,
+                total_trades, win_rate, result_path, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                run_id,
+                strategy_name,
+                strategy_version,
+                params_json,
+                total_return_pct,
+                sharpe_ratio,
+                max_drawdown_pct,
+                total_trades,
+                win_rate,
+                result_path,
+                created_at,
+            ),
+        )
+        logger.info("백테스트 이력 저장: %s (%s)", run_id, strategy_name)
+        return run_id
+
+    async def get(self, run_id: str) -> BacktestRun | None:
+        """이력 조회."""
+        row = await self._db.fetch_one(
+            "SELECT * FROM backtest_runs WHERE run_id = ?",
+            (run_id,),
+        )
+        if not row:
+            return None
+        return self._row_to_run(row)
+
+    async def list_by_strategy(
+        self,
+        strategy_name: str,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[BacktestRun]:
+        """전략별 이력 조회 (최신순)."""
+        rows = await self._db.fetch_all(
+            """SELECT * FROM backtest_runs
+               WHERE strategy_name = ?
+               ORDER BY created_at DESC
+               LIMIT ? OFFSET ?""",
+            (strategy_name, limit, offset),
+        )
+        return [self._row_to_run(row) for row in rows]
+
+    @staticmethod
+    def _row_to_run(row: dict) -> BacktestRun:
+        """DB row → BacktestRun."""
+        return BacktestRun(
+            run_id=row["run_id"],
+            strategy_name=row["strategy_name"],
+            strategy_version=row["strategy_version"],
+            params_json=row.get("params_json", "{}"),
+            total_return_pct=(
+                float(row["total_return_pct"])
+                if row.get("total_return_pct") is not None
+                else None
+            ),
+            sharpe_ratio=(
+                float(row["sharpe_ratio"])
+                if row.get("sharpe_ratio") is not None
+                else None
+            ),
+            max_drawdown_pct=(
+                float(row["max_drawdown_pct"])
+                if row.get("max_drawdown_pct") is not None
+                else None
+            ),
+            total_trades=(
+                int(row["total_trades"])
+                if row.get("total_trades") is not None
+                else None
+            ),
+            win_rate=(
+                float(row["win_rate"]) if row.get("win_rate") is not None else None
+            ),
+            result_path=row.get("result_path", ""),
+            created_at=row.get("created_at", ""),
+        )

--- a/src/ante/backtest/service.py
+++ b/src/ante/backtest/service.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import logging
 import sys
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ante.backtest.data_provider import BacktestDataProvider
 from ante.backtest.exceptions import BacktestConfigError, BacktestError
@@ -14,6 +14,9 @@ from ante.backtest.executor import BacktestExecutor
 from ante.backtest.result import BacktestResult
 from ante.data.store import ParquetStore
 from ante.strategy.loader import StrategyLoader
+
+if TYPE_CHECKING:
+    from ante.eventbus.bus import EventBus
 
 logger = logging.getLogger(__name__)
 
@@ -24,8 +27,13 @@ class BacktestService:
     in-process 실행과 subprocess 격리 실행 두 모드를 지원한다.
     """
 
-    def __init__(self, data_path: str = "data/") -> None:
+    def __init__(
+        self,
+        data_path: str = "data/",
+        eventbus: EventBus | None = None,
+    ) -> None:
         self._data_path = data_path
+        self._eventbus = eventbus
         self._running: dict[str, asyncio.Task] = {}
 
     async def run(
@@ -60,7 +68,12 @@ class BacktestService:
             slippage_rate=config.get("slippage_rate", 0.001),
         )
 
-        return await executor.run(progress_callback=progress_callback)
+        result = await executor.run(progress_callback=progress_callback)
+
+        # BacktestCompleteEvent 발행
+        await self._publish_complete_event(result, config)
+
+        return result
 
     async def run_subprocess(self, config: dict[str, Any]) -> dict:
         """백테스트를 subprocess로 격리 실행 (D-004)."""
@@ -83,6 +96,27 @@ class BacktestService:
             raise BacktestError(msg)
 
         return json.loads(stdout.decode())
+
+    async def _publish_complete_event(
+        self,
+        result: BacktestResult,
+        config: dict[str, Any],
+    ) -> None:
+        """BacktestCompleteEvent 발행."""
+        if not self._eventbus:
+            return
+
+        from ante.eventbus.events import BacktestCompleteEvent
+
+        strategy_id = f"{result.strategy_name}_v{result.strategy_version}"
+        event = BacktestCompleteEvent(
+            backtest_id=strategy_id,
+            strategy_id=strategy_id,
+            status="completed",
+            result_path=config.get("result_path", ""),
+        )
+        await self._eventbus.publish(event)
+        logger.info("BacktestCompleteEvent 발행: %s", strategy_id)
 
     def _validate_config(self, config: dict[str, Any]) -> None:
         """설정 검증."""

--- a/src/ante/cli/commands/backtest.py
+++ b/src/ante/cli/commands/backtest.py
@@ -23,6 +23,7 @@ def backtest() -> None:
 @click.option("--balance", default=10_000_000, type=float, help="초기 자금")
 @click.option("--timeframe", default="1d", help="타임프레임")
 @click.option("--data-path", default="data/", help="데이터 디렉토리 경로")
+@click.option("--db-path", default="db/ante.db", help="DB 경로")
 @click.pass_context
 @require_auth
 @require_scope("backtest:run")
@@ -35,6 +36,7 @@ def run(
     balance: float,
     timeframe: str,
     data_path: str,
+    db_path: str,
 ) -> None:
     """백테스트 실행."""
     from ante.backtest.service import BacktestService
@@ -80,8 +82,13 @@ def run(
         result_dict = result.to_dict()
         metrics = result_dict.get("metrics", {})
 
+        # backtest_runs 이력 저장
+        run_id = asyncio.run(_save_backtest_run(db_path, result, config, metrics))
+        result_dict["run_id"] = run_id
+
         fmt.output(
             result_dict,
+            "Run ID: {run_id}\n"
             "Strategy: {strategy}\n"
             "Period: {period}\n"
             "Return: {total_return_pct}%\n"
@@ -93,6 +100,95 @@ def run(
             metric_rows = _format_metrics(metrics)
             fmt.table(metric_rows, ["지표", "값"])
 
+    except Exception as e:
+        fmt.error(str(e), code="BACKTEST_ERROR")
+        raise SystemExit(1) from e
+
+
+async def _save_backtest_run(
+    db_path: str,
+    result: object,
+    config: dict,
+    metrics: dict,
+) -> str:
+    """backtest_runs 테이블에 이력 저장."""
+    from ante.backtest.run_store import BacktestRunStore
+    from ante.core.database import Database
+
+    db = Database(db_path)
+    await db.connect()
+    try:
+        store = BacktestRunStore(db)
+        await store.initialize()
+        return await store.save(
+            strategy_name=result.strategy_name,
+            strategy_version=result.strategy_version,
+            params=config,
+            total_return_pct=round(result.total_return, 2),
+            sharpe_ratio=metrics.get("sharpe_ratio"),
+            max_drawdown_pct=metrics.get("max_drawdown"),
+            total_trades=len(result.trades),
+            win_rate=metrics.get("win_rate"),
+            result_path="",
+        )
+    finally:
+        await db.close()
+
+
+@backtest.command()
+@click.argument("strategy_name")
+@click.option("--limit", default=20, type=int, help="조회 건수")
+@click.option("--db-path", default="db/ante.db", help="DB 경로")
+@click.pass_context
+@require_auth
+@require_scope("backtest:run")
+def history(
+    ctx: click.Context,
+    strategy_name: str,
+    limit: int,
+    db_path: str,
+) -> None:
+    """전략별 백테스트 실행 이력 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _list() -> list[dict]:
+        from ante.backtest.run_store import BacktestRunStore
+        from ante.core.database import Database
+
+        db = Database(db_path)
+        await db.connect()
+        try:
+            store = BacktestRunStore(db)
+            await store.initialize()
+            runs = await store.list_by_strategy(strategy_name, limit=limit)
+            return [r.to_dict() for r in runs]
+        finally:
+            await db.close()
+
+    try:
+        rows = asyncio.run(_list())
+        if not rows:
+            fmt.output(
+                {"message": f"'{strategy_name}' 백테스트 이력이 없습니다.", "runs": []},
+                f"'{strategy_name}' 백테스트 이력이 없습니다.",
+            )
+            return
+
+        if fmt.is_json:
+            fmt.output({"strategy_name": strategy_name, "runs": rows})
+        else:
+            fmt.table(
+                rows,
+                [
+                    "run_id",
+                    "strategy_version",
+                    "total_return_pct",
+                    "sharpe_ratio",
+                    "total_trades",
+                    "win_rate",
+                    "created_at",
+                ],
+            )
     except Exception as e:
         fmt.error(str(e), code="BACKTEST_ERROR")
         raise SystemExit(1) from e

--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -32,10 +32,16 @@ def schema(ctx: click.Context) -> None:
 @report.command()
 @click.argument("json_path", type=click.Path(exists=True))
 @click.option("--db-path", default="db/ante.db", help="DB 경로")
+@click.option("--run", "run_id", default=None, help="참조할 백테스트 run_id")
 @click.pass_context
 @require_auth
 @require_scope("report:write")
-def submit(ctx: click.Context, json_path: str, db_path: str) -> None:
+def submit(
+    ctx: click.Context,
+    json_path: str,
+    db_path: str,
+    run_id: str | None,
+) -> None:
     """리포트 제출."""
     from ante.report import ReportStore
 
@@ -44,15 +50,66 @@ def submit(ctx: click.Context, json_path: str, db_path: str) -> None:
     with open(json_path) as f:
         report_data = json.load(f)
 
+    # --run 옵션으로 백테스트 run 참조 추가
+    if run_id:
+        report_data["backtest_run_id"] = run_id
+
     async def _submit() -> dict:
-        store = ReportStore(db_path=db_path)
-        await store.initialize()
-        report_obj = await store.submit(report_data)
-        return {
-            "report_id": report_obj.report_id,
-            "strategy": report_obj.strategy_name,
-            "status": report_obj.status.value,
-        }
+        from ante.core.database import Database
+
+        db = Database(db_path)
+        await db.connect()
+        try:
+            # run_id가 제공되면 backtest_runs에서 참조 검증
+            if run_id:
+                from ante.backtest.run_store import BacktestRunStore
+
+                run_store = BacktestRunStore(db)
+                await run_store.initialize()
+                bt_run = await run_store.get(run_id)
+                if not bt_run:
+                    msg = f"백테스트 run을 찾을 수 없습니다: {run_id}"
+                    raise ValueError(msg)
+
+            store = ReportStore(db)
+            await store.initialize()
+
+            # StrategyReport 생성
+            from datetime import UTC, datetime
+            from uuid import uuid4
+
+            from ante.report.models import ReportStatus, StrategyReport
+
+            report_obj = StrategyReport(
+                report_id=str(uuid4()),
+                strategy_name=report_data["strategy_name"],
+                strategy_version=report_data["strategy_version"],
+                strategy_path=report_data.get("strategy_path", ""),
+                status=ReportStatus.SUBMITTED,
+                submitted_at=datetime.now(tz=UTC),
+                submitted_by=report_data.get("submitted_by", "agent"),
+                backtest_period=report_data.get("backtest_period", ""),
+                total_return_pct=float(report_data.get("total_return_pct", 0)),
+                total_trades=int(report_data.get("total_trades", 0)),
+                sharpe_ratio=report_data.get("sharpe_ratio"),
+                max_drawdown_pct=report_data.get("max_drawdown_pct"),
+                win_rate=report_data.get("win_rate"),
+                summary=report_data.get("summary", ""),
+                rationale=report_data.get("rationale", ""),
+                risks=report_data.get("risks", ""),
+                recommendations=report_data.get("recommendations", ""),
+                detail_json=json.dumps(report_data.get("detail_json", {})),
+            )
+
+            report_id = await store.submit(report_obj)
+            return {
+                "report_id": report_id,
+                "strategy": report_obj.strategy_name,
+                "status": report_obj.status.value,
+                "backtest_run_id": run_id,
+            }
+        finally:
+            await db.close()
 
     try:
         result = asyncio.run(_submit())

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -546,11 +546,18 @@ async def _init_feed(s: Services) -> None:
         s.data_collector = DataCollector(store=s.parquet_store, eventbus=s.eventbus)
     logger.info("Data Pipeline 초기화 완료: %s", data_path)
 
-    # BacktestService
+    # BacktestService (EventBus 주입)
     from ante.backtest import BacktestService
 
-    s.backtest_service = BacktestService(data_path=data_path)
+    s.backtest_service = BacktestService(data_path=data_path, eventbus=s.eventbus)
     logger.info("BacktestService 초기화 완료")
+
+    # BacktestRunStore
+    from ante.backtest.run_store import BacktestRunStore
+
+    backtest_run_store = BacktestRunStore(db=s.db)
+    await backtest_run_store.initialize()
+    logger.info("BacktestRunStore 초기화 완료")
 
     # ReportStore
     from ante.report import ReportStore
@@ -558,6 +565,16 @@ async def _init_feed(s: Services) -> None:
     s.report_store = ReportStore(db=s.db)
     await s.report_store.initialize()
     logger.info("ReportStore 초기화 완료")
+
+    # ReportDraftGenerator — BacktestCompleteEvent 구독
+    from ante.report import ReportDraftGenerator
+
+    draft_generator = ReportDraftGenerator(
+        report_store=s.report_store,
+        eventbus=s.eventbus,
+    )
+    draft_generator.initialize()
+    logger.info("ReportDraftGenerator 초기화 완료")
 
     # ApprovalService
     from ante.approval import ApprovalService

--- a/src/ante/report/draft.py
+++ b/src/ante/report/draft.py
@@ -49,7 +49,7 @@ class ReportDraftGenerator:
                 return
 
             report = self.generate_draft(result_data, event.strategy_id)
-            await self._store.submit(report)
+            await self._store.upsert_draft(report)
 
             from ante.eventbus.events import NotificationEvent
 

--- a/src/ante/report/store.py
+++ b/src/ante/report/store.py
@@ -95,6 +95,59 @@ class ReportStore:
         )
         return report.report_id
 
+    async def upsert_draft(self, report: StrategyReport) -> str:
+        """DRAFT 리포트 upsert — 전략당 DRAFT 1건만 유지.
+
+        동일 strategy_name의 기존 DRAFT가 있으면 덮어쓰고,
+        없으면 새로 삽입한다.
+        """
+        existing = await self._db.fetch_one(
+            "SELECT report_id FROM reports WHERE strategy_name = ? AND status = ?",
+            (report.strategy_name, ReportStatus.DRAFT.value),
+        )
+
+        if existing:
+            # 기존 DRAFT 업데이트
+            old_id = existing["report_id"]
+            await self._db.execute(
+                """UPDATE reports
+                   SET strategy_version = ?, strategy_path = ?,
+                       submitted_at = ?, submitted_by = ?,
+                       backtest_period = ?, total_return_pct = ?,
+                       total_trades = ?, sharpe_ratio = ?,
+                       max_drawdown_pct = ?, win_rate = ?,
+                       summary = ?, rationale = ?, risks = ?,
+                       recommendations = ?, detail_json = ?
+                   WHERE report_id = ?""",
+                (
+                    report.strategy_version,
+                    report.strategy_path,
+                    report.submitted_at.isoformat(),
+                    report.submitted_by,
+                    report.backtest_period,
+                    report.total_return_pct,
+                    report.total_trades,
+                    report.sharpe_ratio,
+                    report.max_drawdown_pct,
+                    report.win_rate,
+                    report.summary,
+                    report.rationale,
+                    report.risks,
+                    report.recommendations,
+                    report.detail_json,
+                    old_id,
+                ),
+            )
+            logger.info(
+                "DRAFT 리포트 갱신: %s (%s)",
+                old_id,
+                report.strategy_name,
+            )
+            return old_id
+
+        # 신규 DRAFT 삽입
+        return await self.submit(report)
+
     async def get(self, report_id: str) -> StrategyReport | None:
         """리포트 조회."""
         row = await self._db.fetch_one(

--- a/tests/unit/test_backtest_complete_event.py
+++ b/tests/unit/test_backtest_complete_event.py
@@ -1,0 +1,90 @@
+"""BacktestCompleteEvent 발행 통합 테스트."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ante.backtest.service import BacktestService
+from ante.eventbus.events import BacktestCompleteEvent
+
+
+class TestBacktestCompleteEventPublish:
+    @pytest.mark.asyncio
+    async def test_run_publishes_complete_event(self):
+        """BacktestService.run() 완료 시 BacktestCompleteEvent 발행."""
+        mock_eventbus = MagicMock()
+        mock_eventbus.publish = AsyncMock()
+
+        service = BacktestService(data_path="data/", eventbus=mock_eventbus)
+
+        # BacktestResult mock
+        mock_result = MagicMock()
+        mock_result.strategy_name = "momentum"
+        mock_result.strategy_version = "1.0.0"
+
+        config = {
+            "strategy_path": "strategies/test.py",
+            "start_date": "2025-01-01",
+            "end_date": "2025-12-31",
+        }
+
+        with patch.object(service, "_validate_config"):
+            with patch(
+                "ante.backtest.service.StrategyLoader.load",
+                return_value=MagicMock,
+            ):
+                with patch(
+                    "ante.backtest.service.BacktestDataProvider",
+                    return_value=MagicMock(),
+                ):
+                    with patch(
+                        "ante.backtest.service.BacktestExecutor"
+                    ) as mock_executor_cls:
+                        mock_executor = MagicMock()
+                        mock_executor.run = AsyncMock(return_value=mock_result)
+                        mock_executor_cls.return_value = mock_executor
+
+                        await service.run(config)
+
+        mock_eventbus.publish.assert_called_once()
+        event = mock_eventbus.publish.call_args[0][0]
+        assert isinstance(event, BacktestCompleteEvent)
+        assert event.strategy_id == "momentum_v1.0.0"
+        assert event.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_run_without_eventbus(self):
+        """EventBus 미설정 시 이벤트 발행 건너뜀."""
+        service = BacktestService(data_path="data/", eventbus=None)
+
+        mock_result = MagicMock()
+        mock_result.strategy_name = "test"
+        mock_result.strategy_version = "1.0.0"
+
+        config = {
+            "strategy_path": "strategies/test.py",
+            "start_date": "2025-01-01",
+            "end_date": "2025-12-31",
+        }
+
+        with patch.object(service, "_validate_config"):
+            with patch(
+                "ante.backtest.service.StrategyLoader.load",
+                return_value=MagicMock,
+            ):
+                with patch(
+                    "ante.backtest.service.BacktestDataProvider",
+                    return_value=MagicMock(),
+                ):
+                    with patch(
+                        "ante.backtest.service.BacktestExecutor"
+                    ) as mock_executor_cls:
+                        mock_executor = MagicMock()
+                        mock_executor.run = AsyncMock(return_value=mock_result)
+                        mock_executor_cls.return_value = mock_executor
+
+                        result = await service.run(config)
+
+        assert result == mock_result  # 정상 반환

--- a/tests/unit/test_backtest_run_store.py
+++ b/tests/unit/test_backtest_run_store.py
@@ -1,0 +1,128 @@
+"""backtest_runs 저장/조회 단위 테스트."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ante.backtest.run_store import BacktestRunStore
+
+
+@pytest.fixture
+async def run_store(tmp_path):
+    """테스트용 BacktestRunStore."""
+    from ante.core.database import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    await db.connect()
+
+    store = BacktestRunStore(db)
+    await store.initialize()
+    yield store
+
+    await db.close()
+
+
+class TestBacktestRunStore:
+    @pytest.mark.asyncio
+    async def test_save_and_get(self, run_store):
+        run_id = await run_store.save(
+            strategy_name="momentum",
+            strategy_version="1.0.0",
+            params={"start_date": "2025-01-01", "end_date": "2025-12-31"},
+            total_return_pct=15.0,
+            sharpe_ratio=1.2,
+            max_drawdown_pct=-8.5,
+            total_trades=42,
+            win_rate=0.58,
+            result_path="/results/bt-1.json",
+        )
+
+        assert run_id  # UUID string
+
+        run = await run_store.get(run_id)
+        assert run is not None
+        assert run.strategy_name == "momentum"
+        assert run.strategy_version == "1.0.0"
+        assert run.total_return_pct == 15.0
+        assert run.sharpe_ratio == 1.2
+        assert run.max_drawdown_pct == -8.5
+        assert run.total_trades == 42
+        assert run.win_rate == 0.58
+        assert run.result_path == "/results/bt-1.json"
+
+        params = json.loads(run.params_json)
+        assert params["start_date"] == "2025-01-01"
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent(self, run_store):
+        result = await run_store.get("nonexistent-id")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_list_by_strategy(self, run_store):
+        for i in range(3):
+            await run_store.save(
+                strategy_name="momentum",
+                strategy_version="1.0.0",
+                total_return_pct=float(i * 5),
+                total_trades=i * 10,
+            )
+
+        await run_store.save(
+            strategy_name="other_strategy",
+            strategy_version="1.0.0",
+            total_return_pct=20.0,
+        )
+
+        runs = await run_store.list_by_strategy("momentum")
+        assert len(runs) == 3
+        assert all(r.strategy_name == "momentum" for r in runs)
+        # 최신순 정렬 확인
+        assert runs[0].total_return_pct == 10.0  # 마지막에 저장된 것
+
+    @pytest.mark.asyncio
+    async def test_list_by_strategy_with_limit(self, run_store):
+        for i in range(5):
+            await run_store.save(
+                strategy_name="test_stg",
+                strategy_version="1.0.0",
+                total_return_pct=float(i),
+            )
+
+        runs = await run_store.list_by_strategy("test_stg", limit=2)
+        assert len(runs) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_by_strategy_empty(self, run_store):
+        runs = await run_store.list_by_strategy("nonexistent")
+        assert runs == []
+
+    @pytest.mark.asyncio
+    async def test_save_minimal(self, run_store):
+        """필수 필드만으로 저장."""
+        run_id = await run_store.save(
+            strategy_name="minimal",
+            strategy_version="0.1.0",
+        )
+        run = await run_store.get(run_id)
+        assert run is not None
+        assert run.strategy_name == "minimal"
+        assert run.total_return_pct is None
+        assert run.sharpe_ratio is None
+        assert run.total_trades is None
+
+    @pytest.mark.asyncio
+    async def test_to_dict(self, run_store):
+        run_id = await run_store.save(
+            strategy_name="test",
+            strategy_version="1.0.0",
+            total_return_pct=10.0,
+        )
+        run = await run_store.get(run_id)
+        d = run.to_dict()
+        assert d["run_id"] == run_id
+        assert d["strategy_name"] == "test"
+        assert d["total_return_pct"] == 10.0

--- a/tests/unit/test_cli_backtest_report.py
+++ b/tests/unit/test_cli_backtest_report.py
@@ -1,0 +1,131 @@
+"""CLI backtest history / report submit --run 커맨드 테스트."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+class TestBacktestHistory:
+    def test_history_empty(self, runner):
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = []
+            result = runner.invoke(cli, ["backtest", "history", "test_stg"])
+            assert result.exit_code == 0
+            assert "이력이 없습니다" in result.output
+
+    def test_history_with_results(self, runner):
+        rows = [
+            {
+                "run_id": "run-1",
+                "strategy_name": "momentum",
+                "strategy_version": "1.0.0",
+                "params_json": "{}",
+                "total_return_pct": 15.0,
+                "sharpe_ratio": 1.2,
+                "max_drawdown_pct": -8.5,
+                "total_trades": 42,
+                "win_rate": 0.58,
+                "result_path": "",
+                "created_at": "2026-03-19T00:00:00",
+            },
+        ]
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = rows
+            result = runner.invoke(cli, ["backtest", "history", "momentum"])
+            assert result.exit_code == 0
+            assert "run-1" in result.output
+
+    def test_history_json_format(self, runner):
+        rows = [
+            {
+                "run_id": "run-1",
+                "strategy_name": "momentum",
+                "strategy_version": "1.0.0",
+                "params_json": "{}",
+                "total_return_pct": 15.0,
+                "sharpe_ratio": 1.2,
+                "max_drawdown_pct": -8.5,
+                "total_trades": 42,
+                "win_rate": 0.58,
+                "result_path": "",
+                "created_at": "2026-03-19T00:00:00",
+            },
+        ]
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = rows
+            result = runner.invoke(
+                cli, ["--format", "json", "backtest", "history", "momentum"]
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["strategy_name"] == "momentum"
+            assert len(data["runs"]) == 1
+
+
+class TestReportSubmitWithRun:
+    def test_submit_with_run_option(self, runner, tmp_path):
+        report_file = tmp_path / "report.json"
+        report_file.write_text(
+            json.dumps(
+                {
+                    "strategy_name": "momentum",
+                    "strategy_version": "1.0.0",
+                    "strategy_path": "strategies/momentum.py",
+                    "backtest_period": "2025-01 ~ 2025-12",
+                    "total_return_pct": 15.0,
+                    "total_trades": 42,
+                    "summary": "테스트 리포트",
+                    "rationale": "테스트",
+                }
+            )
+        )
+
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = {
+                "report_id": "rpt-123",
+                "strategy": "momentum",
+                "status": "submitted",
+                "backtest_run_id": "run-1",
+            }
+            result = runner.invoke(
+                cli,
+                ["report", "submit", str(report_file), "--run", "run-1"],
+            )
+            assert result.exit_code == 0
+            assert "rpt-123" in result.output

--- a/tests/unit/test_draft_upsert.py
+++ b/tests/unit/test_draft_upsert.py
@@ -1,0 +1,119 @@
+"""DRAFT upsert 단위 테스트."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from ante.report.models import ReportStatus, StrategyReport
+from ante.report.store import ReportStore
+
+
+@pytest.fixture
+async def report_store(tmp_path):
+    """테스트용 ReportStore."""
+    from ante.core.database import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    await db.connect()
+
+    store = ReportStore(db)
+    await store.initialize()
+    yield store
+
+    await db.close()
+
+
+def _make_draft(
+    strategy_name: str = "momentum",
+    total_return_pct: float = 10.0,
+    report_id: str = "rpt-1",
+) -> StrategyReport:
+    return StrategyReport(
+        report_id=report_id,
+        strategy_name=strategy_name,
+        strategy_version="1.0.0",
+        strategy_path="strategies/momentum.py",
+        status=ReportStatus.DRAFT,
+        submitted_at=datetime.now(tz=UTC),
+        submitted_by="system",
+        backtest_period="2025-01 ~ 2025-12",
+        total_return_pct=total_return_pct,
+        total_trades=42,
+        summary="초안",
+    )
+
+
+class TestDraftUpsert:
+    @pytest.mark.asyncio
+    async def test_upsert_creates_new_draft(self, report_store):
+        """기존 DRAFT가 없을 때 새로 생성."""
+        report = _make_draft()
+        result_id = await report_store.upsert_draft(report)
+
+        assert result_id == "rpt-1"
+        stored = await report_store.get("rpt-1")
+        assert stored is not None
+        assert stored.status == ReportStatus.DRAFT
+        assert stored.total_return_pct == 10.0
+
+    @pytest.mark.asyncio
+    async def test_upsert_overwrites_existing_draft(self, report_store):
+        """동일 전략의 기존 DRAFT를 덮어쓰기."""
+        report1 = _make_draft(total_return_pct=10.0, report_id="rpt-1")
+        await report_store.upsert_draft(report1)
+
+        report2 = _make_draft(total_return_pct=20.0, report_id="rpt-2")
+        result_id = await report_store.upsert_draft(report2)
+
+        # 기존 report_id 유지
+        assert result_id == "rpt-1"
+
+        # 내용이 업데이트됨
+        stored = await report_store.get("rpt-1")
+        assert stored is not None
+        assert stored.total_return_pct == 20.0
+
+        # 새 report_id는 저장되지 않음
+        not_found = await report_store.get("rpt-2")
+        assert not_found is None
+
+    @pytest.mark.asyncio
+    async def test_upsert_different_strategies(self, report_store):
+        """다른 전략의 DRAFT는 독립 유지."""
+        report_a = _make_draft(strategy_name="strategy_a", report_id="rpt-a")
+        report_b = _make_draft(strategy_name="strategy_b", report_id="rpt-b")
+
+        await report_store.upsert_draft(report_a)
+        await report_store.upsert_draft(report_b)
+
+        stored_a = await report_store.get("rpt-a")
+        stored_b = await report_store.get("rpt-b")
+        assert stored_a is not None
+        assert stored_b is not None
+        assert stored_a.strategy_name == "strategy_a"
+        assert stored_b.strategy_name == "strategy_b"
+
+    @pytest.mark.asyncio
+    async def test_submitted_does_not_block_new_draft(self, report_store):
+        """SUBMITTED 상태 리포트는 DRAFT 슬롯을 점유하지 않음."""
+        # DRAFT 생성 후 SUBMITTED로 전환
+        report1 = _make_draft(total_return_pct=10.0, report_id="rpt-1")
+        await report_store.upsert_draft(report1)
+        await report_store.update_status("rpt-1", ReportStatus.SUBMITTED)
+
+        # 새 DRAFT는 별도로 생성됨
+        report2 = _make_draft(total_return_pct=20.0, report_id="rpt-2")
+        result_id = await report_store.upsert_draft(report2)
+
+        assert result_id == "rpt-2"
+
+        # 둘 다 존재
+        stored1 = await report_store.get("rpt-1")
+        stored2 = await report_store.get("rpt-2")
+        assert stored1 is not None
+        assert stored1.status == ReportStatus.SUBMITTED
+        assert stored2 is not None
+        assert stored2.status == ReportStatus.DRAFT

--- a/tests/unit/test_report_draft.py
+++ b/tests/unit/test_report_draft.py
@@ -113,7 +113,7 @@ class TestOnBacktestComplete:
         result_file.write_text(json.dumps(_SAMPLE_RESULT))
 
         mock_store = AsyncMock()
-        mock_store.submit = AsyncMock(return_value="report-123")
+        mock_store.upsert_draft = AsyncMock(return_value="report-123")
         mock_eventbus = AsyncMock()
         mock_eventbus.subscribe = MagicMock()
         mock_eventbus.publish = AsyncMock()
@@ -129,8 +129,8 @@ class TestOnBacktestComplete:
 
         await generator._on_backtest_complete(event)
 
-        mock_store.submit.assert_called_once()
-        submitted_report = mock_store.submit.call_args[0][0]
+        mock_store.upsert_draft.assert_called_once()
+        submitted_report = mock_store.upsert_draft.call_args[0][0]
         assert submitted_report.status == ReportStatus.DRAFT
         assert submitted_report.total_return_pct == 15.0
 


### PR DESCRIPTION
## Summary
- `backtest_runs` 테이블 및 `BacktestRunStore` 구현으로 백테스트 실행 이력 관리
- `BacktestService`에 `EventBus` 의존성 주입 + `BacktestCompleteEvent` 발행
- `ReportStore.upsert_draft()` 구현으로 전략당 DRAFT 리포트 1건 유지 (upsert)
- `main.py` `_init_feed()`에서 `ReportDraftGenerator` 초기화 연결
- CLI 개선: `ante backtest run`에 `run_id` 출력, `ante backtest history` 신규, `ante report submit --run` 옵션

## 구현 체크리스트 (이슈 #493)
- [x] `backtest_runs` 테이블 스키마 + 저장 로직
- [x] `BacktestCompleteEvent` 발행 (EventBus 주입)
- [x] `ReportDraftGenerator` 초기화 연결 (`_init_feed`)
- [x] DRAFT 전략당 1건 유지 (upsert)
- [x] `ante backtest run` — `backtest_runs` 저장 + `run_id` 출력
- [x] `ante backtest history <strategy_name>` 신규
- [x] `ante report submit --run <run_id>` 옵션 추가
- [x] 테스트 17건 추가 (전체 2087건 통과)

## Test plan
- [x] `backtest_runs` 저장/조회 단위 테스트 (7건)
- [x] `BacktestCompleteEvent` 발행 통합 테스트 (2건)
- [x] DRAFT upsert 단위 테스트 (4건)
- [x] CLI 커맨드 테스트 (4건)
- [x] 기존 테스트 전체 통과 확인 (2087건)

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)