### PR TITLE
feat(trade): 장 마감 후 일일 성과 요약 알림 스케줄러 (#503)

### DIFF
--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -75,6 +75,7 @@ class Services:
     api_gateway: Any = None
     stream_integration: Any = None
     reconcile_scheduler: Any = None
+    daily_report_scheduler: Any = None
     data_provider: Any = None
     parquet_store: Any = None
     data_collector: Any = None
@@ -330,6 +331,10 @@ async def _init_broker(s: Services) -> None:
     if s.broker and s.trade_service:
         await _init_reconcile_scheduler(s)
 
+    # DailyReportScheduler 초기화
+    if s.performance_tracker and s.trade_recorder and s.position_history:
+        await _init_daily_report_scheduler(s)
+
 
 async def _init_reconcile_scheduler(s: Services) -> None:
     """ReconcileScheduler 생성 및 시작."""
@@ -361,6 +366,20 @@ async def _init_reconcile_scheduler(s: Services) -> None:
     )
     await s.reconcile_scheduler.start()
     logger.info("ReconcileScheduler 시작 완료 (주기: %d초)", interval)
+
+
+async def _init_daily_report_scheduler(s: Services) -> None:
+    """DailyReportScheduler 생성 및 시작."""
+    from ante.trade.daily_report import DailyReportScheduler
+
+    s.daily_report_scheduler = DailyReportScheduler(
+        performance_tracker=s.performance_tracker,
+        trade_recorder=s.trade_recorder,
+        position_history=s.position_history,
+        eventbus=s.eventbus,
+    )
+    await s.daily_report_scheduler.start()
+    logger.info("DailyReportScheduler 시작 완료")
 
 
 async def _connect_mock_broker(s: Services, broker_config: dict) -> None:
@@ -975,6 +994,10 @@ async def _shutdown(s: Services) -> None:
         except asyncio.CancelledError:
             pass
         logger.info("Web API 종료")
+
+    if s.daily_report_scheduler:
+        await s.daily_report_scheduler.stop()
+        logger.info("DailyReportScheduler 종료")
 
     if s.reconcile_scheduler:
         await s.reconcile_scheduler.stop()

--- a/src/ante/trade/__init__.py
+++ b/src/ante/trade/__init__.py
@@ -1,5 +1,6 @@
 """Trade 모듈 — 거래 기록, 포지션 추적, 성과 산출."""
 
+from ante.trade.daily_report import DailyReportScheduler
 from ante.trade.models import (
     DailySummary,
     MonthlySummary,
@@ -17,6 +18,7 @@ from ante.trade.recorder import TradeRecorder
 from ante.trade.service import TradeService
 
 __all__ = [
+    "DailyReportScheduler",
     "DailySummary",
     "MonthlySummary",
     "WeeklySummary",

--- a/src/ante/trade/daily_report.py
+++ b/src/ante/trade/daily_report.py
@@ -1,0 +1,164 @@
+"""DailyReportScheduler — 장 마감 후 일일 성과 요약 알림 발행.
+
+KRX 장 마감(15:30) 이후 지정 시각(기본 16:00)에 1회 실행하여,
+당일 거래 요약을 NotificationEvent로 발행한다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import date, datetime, time, timedelta, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ante.eventbus.bus import EventBus
+    from ante.trade.performance import PerformanceTracker
+    from ante.trade.position import PositionHistory
+    from ante.trade.recorder import TradeRecorder
+
+logger = logging.getLogger(__name__)
+
+KST = timezone(timedelta(hours=9))
+DEFAULT_REPORT_TIME = time(16, 0)  # 16:00 KST
+
+
+class DailyReportScheduler:
+    """장 마감 후 당일 거래 요약을 NotificationEvent로 발행한다.
+
+    ReconcileScheduler와 동일한 asyncio 루프 패턴을 사용한다.
+
+    Args:
+        performance_tracker: 일별 성과 집계 조회용.
+        trade_recorder: 당일 거래 건수(매수/매도) 조회용.
+        position_history: 보유 포지션 현황 조회용.
+        eventbus: NotificationEvent 발행용.
+        report_time: 리포트 발행 시각 (KST). 기본 16:00.
+    """
+
+    def __init__(
+        self,
+        performance_tracker: PerformanceTracker,
+        trade_recorder: TradeRecorder,
+        position_history: PositionHistory,
+        eventbus: EventBus,
+        report_time: time = DEFAULT_REPORT_TIME,
+    ) -> None:
+        self._performance = performance_tracker
+        self._recorder = trade_recorder
+        self._positions = position_history
+        self._eventbus = eventbus
+        self._report_time = report_time
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """스케줄러를 시작한다."""
+        if self._task and not self._task.done():
+            logger.warning("DailyReportScheduler 이미 실행 중")
+            return
+
+        logger.info(
+            "DailyReportScheduler 시작 (발행 시각: %s KST)",
+            self._report_time.strftime("%H:%M"),
+        )
+        self._task = asyncio.create_task(
+            self._loop(),
+            name="daily-report-scheduler",
+        )
+
+    async def stop(self) -> None:
+        """스케줄러를 중지한다."""
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+            logger.info("DailyReportScheduler 종료")
+
+    async def run_once(self, target_date: date | None = None) -> bool:
+        """수동 실행 (테스트/CLI용).
+
+        Args:
+            target_date: 대상 날짜. None이면 오늘(KST).
+
+        Returns:
+            True: 알림 발행됨, False: 당일 거래 0건으로 스킵.
+        """
+        today = target_date or datetime.now(KST).date()
+        today_str = today.isoformat()
+
+        # 1) 당일 체결 거래 조회 (매수/매도 건수)
+        from ante.trade.models import TradeStatus
+
+        trades = await self._recorder.get_trades(
+            status=TradeStatus.FILLED,
+            from_date=datetime.combine(today, time.min, tzinfo=KST),
+            to_date=datetime.combine(today, time.max, tzinfo=KST),
+            limit=10000,
+        )
+
+        if not trades:
+            logger.debug("일일 리포트 스킵 — 당일 거래 0건 (%s)", today_str)
+            return False
+
+        total_count = len(trades)
+        buy_count = sum(1 for t in trades if t.side == "buy")
+        sell_count = sum(1 for t in trades if t.side == "sell")
+
+        # 2) 일별 실현 손익 조회
+        summaries = await self._performance.get_daily_summary(
+            start_date=today_str,
+            end_date=today_str,
+        )
+        realized_pnl = summaries[0].realized_pnl if summaries else 0.0
+
+        # 3) 보유 포지션 현황
+        all_positions = await self._positions.get_all_positions()
+        position_count = len(all_positions)
+
+        # 4) NotificationEvent 발행
+        pnl_sign = "+" if realized_pnl >= 0 else ""
+        message = (
+            f"거래: {total_count}건 (매수 {buy_count} / 매도 {sell_count})\n"
+            f"실현 손익: {pnl_sign}{realized_pnl:,.0f}원\n"
+            f"보유 포지션: {position_count}종목"
+        )
+
+        from ante.eventbus.events import NotificationEvent
+
+        await self._eventbus.publish(
+            NotificationEvent(
+                level="info",
+                title=f"일일 성과 요약 ({today_str})",
+                message=message,
+                category="trade",
+            )
+        )
+
+        logger.info("일일 성과 요약 발행 완료 (%s): 거래 %d건", today_str, total_count)
+        return True
+
+    async def _loop(self) -> None:
+        """매일 report_time에 run_once()를 실행한다."""
+        while True:
+            now = datetime.now(KST)
+            target = datetime.combine(now.date(), self._report_time, tzinfo=KST)
+            if now >= target:
+                # 오늘 시각을 지났으면 내일로
+                target += timedelta(days=1)
+
+            delay = (target - now).total_seconds()
+            logger.debug(
+                "DailyReportScheduler 다음 실행까지 %.0f초 대기",
+                delay,
+            )
+            await asyncio.sleep(delay)
+
+            try:
+                await self.run_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("DailyReportScheduler 실행 오류")

--- a/tests/unit/test_daily_report.py
+++ b/tests/unit/test_daily_report.py
@@ -1,0 +1,264 @@
+"""DailyReportScheduler 단위 테스트."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from ante.eventbus.bus import EventBus
+from ante.eventbus.events import NotificationEvent
+from ante.trade.daily_report import DEFAULT_REPORT_TIME, DailyReportScheduler
+from ante.trade.models import DailySummary, PositionSnapshot, TradeRecord, TradeStatus
+
+KST = timezone(timedelta(hours=9))
+
+
+# ── Fixtures ─────────────────────────────────────────
+
+
+@pytest.fixture
+def performance_tracker():
+    mock = AsyncMock()
+    mock.get_daily_summary = AsyncMock(return_value=[])
+    return mock
+
+
+@pytest.fixture
+def trade_recorder():
+    mock = AsyncMock()
+    mock.get_trades = AsyncMock(return_value=[])
+    return mock
+
+
+@pytest.fixture
+def position_history():
+    mock = AsyncMock()
+    mock.get_all_positions = AsyncMock(return_value=[])
+    return mock
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+def scheduler(performance_tracker, trade_recorder, position_history, eventbus):
+    return DailyReportScheduler(
+        performance_tracker=performance_tracker,
+        trade_recorder=trade_recorder,
+        position_history=position_history,
+        eventbus=eventbus,
+    )
+
+
+def _make_trade(side: str = "buy") -> TradeRecord:
+    """테스트용 체결 거래 레코드 생성."""
+    return TradeRecord(
+        trade_id=uuid4(),
+        bot_id="bot-1",
+        strategy_id="strat-1",
+        symbol="005930",
+        side=side,
+        quantity=10.0,
+        price=50000.0,
+        status=TradeStatus.FILLED,
+        timestamp=datetime.now(KST),
+    )
+
+
+# ── run_once 테스트 ──────────────────────────────────
+
+
+class TestRunOnce:
+    async def test_skip_when_no_trades(self, scheduler, trade_recorder):
+        """당일 거래 0건이면 False를 반환하고 알림을 발행하지 않는다."""
+        trade_recorder.get_trades.return_value = []
+
+        result = await scheduler.run_once(target_date=date(2026, 3, 19))
+
+        assert result is False
+
+    async def test_publishes_notification_with_trades(
+        self,
+        scheduler,
+        trade_recorder,
+        performance_tracker,
+        position_history,
+        eventbus,
+    ):
+        """당일 거래가 있으면 NotificationEvent를 발행한다."""
+        # 거래 7건 매수, 5건 매도
+        buy_trades = [_make_trade("buy") for _ in range(7)]
+        sell_trades = [_make_trade("sell") for _ in range(5)]
+        trade_recorder.get_trades.return_value = buy_trades + sell_trades
+
+        performance_tracker.get_daily_summary.return_value = [
+            DailySummary(
+                date="2026-03-19",
+                realized_pnl=1250000.0,
+                trade_count=5,
+                win_rate=0.8,
+            )
+        ]
+
+        position_history.get_all_positions.return_value = [
+            PositionSnapshot(
+                bot_id="bot-1",
+                symbol=f"00593{i}",
+                quantity=100.0,
+                avg_entry_price=50000.0,
+            )
+            for i in range(4)
+        ]
+
+        received: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: received.append(e))
+
+        result = await scheduler.run_once(target_date=date(2026, 3, 19))
+
+        assert result is True
+        assert len(received) == 1
+
+        event = received[0]
+        assert event.level == "info"
+        assert "2026-03-19" in event.title
+        assert "12건" in event.message
+        assert "매수 7" in event.message
+        assert "매도 5" in event.message
+        assert "+1,250,000원" in event.message
+        assert "4종목" in event.message
+
+    async def test_negative_pnl_format(
+        self,
+        scheduler,
+        trade_recorder,
+        performance_tracker,
+        position_history,
+        eventbus,
+    ):
+        """음수 손익은 부호 없이 표시된다."""
+        trade_recorder.get_trades.return_value = [_make_trade("sell")]
+        performance_tracker.get_daily_summary.return_value = [
+            DailySummary(
+                date="2026-03-19",
+                realized_pnl=-500000.0,
+                trade_count=1,
+                win_rate=0.0,
+            )
+        ]
+        position_history.get_all_positions.return_value = []
+
+        received: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: received.append(e))
+
+        await scheduler.run_once(target_date=date(2026, 3, 19))
+
+        assert "-500,000원" in received[0].message
+
+    async def test_zero_pnl_when_no_daily_summary(
+        self,
+        scheduler,
+        trade_recorder,
+        performance_tracker,
+        position_history,
+        eventbus,
+    ):
+        """일별 요약이 없으면(매수만 있는 날) 실현 손익을 0으로 표시한다."""
+        trade_recorder.get_trades.return_value = [_make_trade("buy")]
+        performance_tracker.get_daily_summary.return_value = []
+        position_history.get_all_positions.return_value = []
+
+        received: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: received.append(e))
+
+        result = await scheduler.run_once(target_date=date(2026, 3, 19))
+
+        assert result is True
+        assert "+0원" in received[0].message
+
+    async def test_notification_category_is_trade(
+        self,
+        scheduler,
+        trade_recorder,
+        eventbus,
+    ):
+        """알림 카테고리가 trade이다."""
+        trade_recorder.get_trades.return_value = [_make_trade("buy")]
+
+        received: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: received.append(e))
+
+        await scheduler.run_once(target_date=date(2026, 3, 19))
+
+        assert received[0].category == "trade"
+
+
+# ── start/stop 테스트 ────────────────────────────────
+
+
+class TestStartStop:
+    async def test_start_creates_task(self, scheduler):
+        """start() 시 태스크가 생성된다."""
+        await scheduler.start()
+        try:
+            assert scheduler._task is not None
+            assert not scheduler._task.done()
+        finally:
+            await scheduler.stop()
+
+    async def test_stop_cancels_task(self, scheduler):
+        """stop() 시 태스크가 취소된다."""
+        await scheduler.start()
+        await scheduler.stop()
+
+        assert scheduler._task is None
+
+    async def test_double_start_ignored(self, scheduler):
+        """이미 실행 중인데 다시 start() 하면 무시된다."""
+        await scheduler.start()
+        first_task = scheduler._task
+
+        await scheduler.start()  # 두 번째 호출
+
+        assert scheduler._task is first_task
+        await scheduler.stop()
+
+    async def test_stop_without_start(self, scheduler):
+        """start() 없이 stop() 해도 오류 없음."""
+        await scheduler.stop()  # 예외 없이 완료
+
+
+# ── 설정 테스트 ──────────────────────────────────────
+
+
+class TestConfiguration:
+    def test_default_report_time(
+        self, performance_tracker, trade_recorder, position_history, eventbus
+    ):
+        """기본 발행 시각은 16:00이다."""
+        sched = DailyReportScheduler(
+            performance_tracker=performance_tracker,
+            trade_recorder=trade_recorder,
+            position_history=position_history,
+            eventbus=eventbus,
+        )
+        assert sched._report_time == DEFAULT_REPORT_TIME
+        assert DEFAULT_REPORT_TIME == time(16, 0)
+
+    def test_custom_report_time(
+        self, performance_tracker, trade_recorder, position_history, eventbus
+    ):
+        """report_time으로 발행 시각을 변경할 수 있다."""
+        custom_time = time(17, 30)
+        sched = DailyReportScheduler(
+            performance_tracker=performance_tracker,
+            trade_recorder=trade_recorder,
+            position_history=position_history,
+            eventbus=eventbus,
+            report_time=custom_time,
+        )
+        assert sched._report_time == custom_time


### PR DESCRIPTION
## Summary
- `DailyReportScheduler` 신규 구현: KRX 장 마감 후 16:00 KST에 당일 거래 요약을 `NotificationEvent`로 발행
- 당일 거래 0건 시 자동 스킵
- `main.py`에 초기화/종료 연결 완료
- 단위 테스트 11건 추가

## Test plan
- [x] 당일 거래 0건 시 스킵 검증
- [x] 거래 존재 시 NotificationEvent 발행 검증 (매수/매도 건수, 실현 손익, 보유 포지션)
- [x] 음수/영(0) 손익 포맷 검증
- [x] start/stop 생명주기 검증
- [x] 설정(report_time) 커스터마이즈 검증
- [x] 전체 테스트 스위트 2106건 통과

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)