### PR TITLE
feat(telegram): /balance 응답 상세 형식 확장

### DIFF
--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -356,15 +356,45 @@ class TelegramCommandReceiver:
 
         summary = self._treasury.get_summary()
         balance = summary.get("account_balance", 0)
+        purchasable = summary.get("purchasable_amount", 0)
+        ante_purchase = summary.get("ante_purchase_amount", 0)
+        ante_eval = summary.get("ante_eval_amount", 0)
+        ante_pl = summary.get("ante_profit_loss", 0)
         allocated = summary.get("total_allocated", 0)
         unallocated = summary.get("unallocated", 0)
         bot_count = summary.get("bot_count", 0)
 
-        return (
-            f"계좌 잔고: {balance:,.0f}원\n"
-            f"할당: {allocated:,.0f}원 ({bot_count}개 봇)\n"
-            f"미할당: {unallocated:,.0f}원"
-        )
+        # 손익 부호 및 이모지
+        if ante_pl > 0:
+            pl_sign = "+"
+            pl_emoji = "📈"
+        elif ante_pl < 0:
+            pl_sign = ""  # 음수는 자동으로 - 붙음
+            pl_emoji = "📉"
+        else:
+            pl_sign = ""
+            pl_emoji = "➖"
+
+        lines = [
+            "ℹ️ 자금 현황",
+            f"계좌 예수금: {balance:,.0f}원",
+            f"매수 가능: {purchasable:,.0f}원",
+        ]
+
+        # Ante 관리 종목 (매입금이 있을 때만 표시)
+        if ante_purchase > 0:
+            lines.append("")
+            lines.append(
+                f"{pl_emoji} Ante 관리 종목\n"
+                f"  매입: {ante_purchase:,.0f}원 → "
+                f"평가: {ante_eval:,.0f}원 ({pl_sign}{ante_pl:,.0f}원)"
+            )
+
+        lines.append("")
+        lines.append(f"봇 할당: {allocated:,.0f}원 ({bot_count}개)")
+        lines.append(f"미할당: {unallocated:,.0f}원")
+
+        return "\n".join(lines)
 
     async def _cmd_approve(self, args: list[str]) -> str:
         """결재 승인. /approve <id>"""

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -37,6 +37,10 @@ def treasury():
     mock = MagicMock()
     mock.get_summary.return_value = {
         "account_balance": 10_000_000,
+        "purchasable_amount": 7_000_000,
+        "ante_purchase_amount": 2_500_000,
+        "ante_eval_amount": 2_650_000,
+        "ante_profit_loss": 150_000,
         "total_allocated": 5_000_000,
         "unallocated": 5_000_000,
         "bot_count": 2,
@@ -157,9 +161,47 @@ class TestCommands:
 
     async def test_balance(self, receiver):
         result = receiver._cmd_balance([])
-        assert "계좌 잔고" in result
-        assert "10,000,000" in result
-        assert "할당" in result
+        assert "자금 현황" in result
+        assert "계좌 예수금: 10,000,000원" in result
+        assert "매수 가능: 7,000,000원" in result
+        assert "매입: 2,500,000원" in result
+        assert "평가: 2,650,000원" in result
+        assert "+150,000원" in result
+        assert "봇 할당: 5,000,000원 (2개)" in result
+        assert "미할당: 5,000,000원" in result
+
+    async def test_balance_no_positions(self, receiver, treasury):
+        """Ante 관리 종목이 없으면 해당 섹션 미표시."""
+        treasury.get_summary.return_value = {
+            "account_balance": 10_000_000,
+            "purchasable_amount": 10_000_000,
+            "ante_purchase_amount": 0,
+            "ante_eval_amount": 0,
+            "ante_profit_loss": 0,
+            "total_allocated": 0,
+            "unallocated": 10_000_000,
+            "bot_count": 0,
+        }
+        result = receiver._cmd_balance([])
+        assert "자금 현황" in result
+        assert "Ante 관리 종목" not in result
+        assert "봇 할당: 0원 (0개)" in result
+
+    async def test_balance_negative_pl(self, receiver, treasury):
+        """손실 시 음수 부호 및 📉 이모지."""
+        treasury.get_summary.return_value = {
+            "account_balance": 10_000_000,
+            "purchasable_amount": 7_000_000,
+            "ante_purchase_amount": 2_500_000,
+            "ante_eval_amount": 2_300_000,
+            "ante_profit_loss": -200_000,
+            "total_allocated": 5_000_000,
+            "unallocated": 5_000_000,
+            "bot_count": 2,
+        }
+        result = receiver._cmd_balance([])
+        assert "📉" in result
+        assert "-200,000원" in result
 
     async def test_balance_no_treasury(self, receiver):
         receiver._treasury = None


### PR DESCRIPTION
## Summary
- `/balance` 텔레그램 명령의 응답을 스펙(`docs/specs/treasury.md`) 상세 형식으로 확장
- Treasury.get_summary()의 `purchasable_amount`, `ante_purchase_amount`, `ante_eval_amount`, `ante_profit_loss` 필드를 활용
- Ante 관리 종목 미보유 시(매입금 0) 해당 섹션 자동 숨김, 손익 부호별 이모지 분기

## Test plan
- [x] 기존 balance 테스트 업데이트 (새 형식 검증)
- [x] 포지션 없는 경우 graceful 처리 테스트 추가
- [x] 손실(음수 PL) 시 이모지/부호 검증 테스트 추가
- [x] Treasury 미연결 시 에러 메시지 테스트 유지
- [x] 전체 테스트 2097건 통과

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)