### PR TITLE
refactor(main): _init_feed에서 approval 초기화를 _init_approval로 분리

### DIFF
--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -554,7 +554,7 @@ def _init_treasury_sync(s: Services) -> None:
 
 
 async def _init_feed(s: Services) -> None:
-    """Data Pipeline, BacktestService, ReportStore, ApprovalService 초기화."""
+    """Data Pipeline, BacktestService, ReportStore 초기화."""
     from ante.data import DataCollector, ParquetStore
 
     data_path = s.config.get("data.path", "data/")
@@ -595,7 +595,9 @@ async def _init_feed(s: Services) -> None:
     draft_generator.initialize()
     logger.info("ReportDraftGenerator 초기화 완료")
 
-    # ApprovalService
+
+async def _init_approval(s: Services) -> None:
+    """ApprovalService 초기화: Executor, Validator, 전결 설정, 만료 스케줄러."""
     from ante.approval import ApprovalService
     from ante.approval.auto_approve import AutoApproveConfig, AutoApproveEvaluator
     from ante.approval.models import ValidationResult
@@ -1031,9 +1033,10 @@ async def main() -> None:
     1. Core: Config, Database, EventBus, SystemState, DynamicConfig
     2. Services: AuditLogger, MemberService, InstrumentService
     3. Trading: Strategy, Rule, Treasury, Trade, Bot, Broker, Gateway
-    4. Feed: DataPipeline, Backtest, Report, Approval
-    5. Notification: Telegram
-    6. Web: FastAPI + uvicorn
+    4. Feed: DataPipeline, Backtest, Report
+    5. Approval: ApprovalService, Executor, Validator, 전결, 만료 스케줄러
+    6. Notification: Telegram
+    7. Web: FastAPI + uvicorn
 
     종료 순서: 역순 (상위 소비자부터 정리)
     """
@@ -1045,6 +1048,7 @@ async def main() -> None:
         await _init_services(s)
         await _init_trading(s)
         await _init_feed(s)
+        await _init_approval(s)
         await _init_notification(s)
         await _init_web(s)
         await _run(s)


### PR DESCRIPTION
## Summary
- `_init_feed()` (235줄)에서 ApprovalService 초기화 코드(184줄, 78%)를 별도 `_init_approval()` 함수로 추출
- `_init_feed()`는 43줄의 feed/backtest 전용 초기화 함수로 정리
- `main()` 호출 순서: `_init_trading` → `_init_feed` → `_init_approval` → `_init_notification` → `_init_web`

## Test plan
- [x] ruff lint 통과
- [x] 전체 테스트 2108개 통과 (`pytest tests/ --ignore=tests/e2e`)
- [x] `_init_feed()` 100줄 이하 (43줄)
- [x] approval 초기화가 별도 `_init_approval()` 함수로 분리됨

Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)