### PR TITLE
fix(logging): except-pass 7건에 logger.warning 추가

### DIFF
--- a/src/ante/broker/kis_stream.py
+++ b/src/ante/broker/kis_stream.py
@@ -391,8 +391,8 @@ class KISStreamClient:
         if self._ws:
             try:
                 await self._ws.close()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("WebSocket 종료 실패: %s", e)
             self._ws = None
 
     async def _publish_connected(self) -> None:

--- a/src/ante/cli/commands/approval.py
+++ b/src/ante/cli/commands/approval.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 
 import click
 
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
+
+logger = logging.getLogger(__name__)
 
 
 async def _audit_log(db, **kwargs) -> None:  # noqa: ANN001
@@ -19,8 +22,8 @@ async def _audit_log(db, **kwargs) -> None:  # noqa: ANN001
         al = AuditLogger(db=db)
         await al.initialize()
         await al.log(**kwargs)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("감사 로그 기록 실패: %s", e)
 
 
 @click.group()

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 import click
 
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
+
+logger = logging.getLogger(__name__)
 
 
 @click.group()
@@ -40,8 +43,8 @@ async def _audit_log(db, **kwargs) -> None:  # noqa: ANN001
         al = AuditLogger(db=db)
         await al.initialize()
         await al.log(**kwargs)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("감사 로그 기록 실패: %s", e)
 
 
 @bot.command("list")

--- a/src/ante/cli/commands/rule.py
+++ b/src/ante/cli/commands/rule.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 import click
 
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
+
+logger = logging.getLogger(__name__)
 
 
 @click.group()
@@ -98,8 +101,8 @@ def rule_list(ctx: click.Context, scope_filter: str | None) -> None:
         try:
             try:
                 _load_rules_from_config(engine)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("룰 설정 로드 실패: %s", e)
             rules = _collect_rules(engine)
             if scope_filter:
                 rules = [
@@ -141,8 +144,8 @@ def rule_info(ctx: click.Context, rule_id: str) -> None:
         try:
             try:
                 _load_rules_from_config(engine)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("룰 설정 로드 실패: %s", e)
             rules = _collect_rules(engine)
             return next((r for r in rules if r["rule_id"] == rule_id), None)
         finally:

--- a/src/ante/cli/commands/system.py
+++ b/src/ante/cli/commands/system.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import signal
 import subprocess
@@ -12,6 +13,8 @@ import click
 
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
+
+logger = logging.getLogger(__name__)
 
 
 @click.group()
@@ -41,8 +44,8 @@ async def _audit_log(db, **kwargs) -> None:  # noqa: ANN001
         al = AuditLogger(db=db)
         await al.initialize()
         await al.log(**kwargs)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("감사 로그 기록 실패: %s", e)
 
 
 def _is_process_alive(pid: int) -> bool:

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -22,6 +23,7 @@ from ante.web.schemas import (
 )
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 class BudgetChangeRequest(BaseModel):
@@ -68,8 +70,8 @@ async def get_summary(
                 summary["account_no"] = f"{account_no[:8]}-{account_no[8:]}"
             elif account_no:
                 summary["account_no"] = account_no
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("KIS 계좌번호 조회 실패: %s", e)
         broker_config = config.get("broker", {})
         if isinstance(broker_config, dict):
             summary["is_virtual"] = broker_config.get("is_paper", True)


### PR DESCRIPTION
## Summary
- 에러를 로깅 없이 삼키던 `except Exception: pass` 7건을 `except Exception as e: logger.warning(...)` 으로 교체
- 대상: `kis_stream.py`, `rule.py`(2건), `bot.py`, `approval.py`, `system.py`, `treasury.py`
- CLI 모듈 4개와 web/routes/treasury.py에 `logging` import 및 `logger` 선언 추가

## Test plan
- [x] ruff check 통과
- [x] pytest 2094건 통과 (기존 실패 2건·에러 7건은 본 변경과 무관)

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)