### PR TITLE
feat(config): SystemState.set_state() suppress_notification 옵션 추가

### DIFF
--- a/src/ante/config/system_state.py
+++ b/src/ante/config/system_state.py
@@ -76,9 +76,22 @@ class SystemState:
         return self._state
 
     async def set_state(
-        self, state: TradingState, reason: str = "", changed_by: str = ""
+        self,
+        state: TradingState,
+        reason: str = "",
+        changed_by: str = "",
+        *,
+        suppress_notification: bool = False,
     ) -> None:
-        """거래 상태 변경. 인메모리 즉시 반영 + DB 영속화 + 이벤트 발행."""
+        """거래 상태 변경. 인메모리 즉시 반영 + DB 영속화 + 이벤트 발행.
+
+        Args:
+            state: 변경할 거래 상태.
+            reason: 변경 사유.
+            changed_by: 변경 주체.
+            suppress_notification: True이면 NotificationEvent 발행을 생략한다.
+                TradingStateChangedEvent(도메인 이벤트)는 항상 발행된다.
+        """
         from ante.eventbus.events import TradingStateChangedEvent
 
         old_state = self._state
@@ -109,16 +122,17 @@ class SystemState:
             )
         )
 
-        from ante.eventbus.events import NotificationEvent
+        if not suppress_notification:
+            from ante.eventbus.events import NotificationEvent
 
-        await self._eventbus.publish(
-            NotificationEvent(
-                level="critical",
-                title="거래 상태 변경",
-                message=(f"{old_state.value} → *{state.value}*\n사유: {reason}"),
-                category="system",
+            await self._eventbus.publish(
+                NotificationEvent(
+                    level="critical",
+                    title="거래 상태 변경",
+                    message=(f"{old_state.value} → *{state.value}*\n사유: {reason}"),
+                    category="system",
+                )
             )
-        )
         logger.info(
             "거래 상태 변경: %s → %s (사유: %s, 변경자: %s)",
             old_state,

--- a/tests/unit/test_system_state.py
+++ b/tests/unit/test_system_state.py
@@ -97,6 +97,31 @@ async def test_state_history_recorded(state, db):
     assert rows[1]["new_state"] == "halted"
 
 
+async def test_suppress_notification_skips_notification_event(state, eventbus):
+    """suppress_notification=True이면 NotificationEvent를 발행하지 않는다."""
+    await state.set_state(
+        TradingState.HALTED, reason="silent", suppress_notification=True
+    )
+
+    # 도메인 이벤트(TradingStateChangedEvent)만 발행
+    assert len(eventbus.published) == 1
+    assert isinstance(eventbus.published[0], TradingStateChangedEvent)
+    assert eventbus.published[0].new_state == "halted"
+
+
+async def test_suppress_notification_false_publishes_both(state, eventbus):
+    """suppress_notification=False(기본값)이면 두 이벤트 모두 발행한다."""
+    from ante.eventbus.events import NotificationEvent
+
+    await state.set_state(
+        TradingState.REDUCING, reason="normal", suppress_notification=False
+    )
+
+    assert len(eventbus.published) == 2
+    assert isinstance(eventbus.published[0], TradingStateChangedEvent)
+    assert isinstance(eventbus.published[1], NotificationEvent)
+
+
 async def test_trading_state_enum_values():
     """TradingState enum 값 확인."""
     assert TradingState.ACTIVE == "active"


### PR DESCRIPTION
## Summary
- `SystemState.set_state()`에 `suppress_notification` keyword-only 인자 추가 (기본값 `False`)
- `suppress_notification=True`이면 `NotificationEvent` 발행을 생략하고, `TradingStateChangedEvent`(도메인 이벤트)는 항상 발행
- 텔레그램 명령 등 호출자가 자체 응답을 보내는 경우 중복 알림 방지 용도

## Test plan
- [x] `suppress_notification=True`일 때 `NotificationEvent` 미발행 확인
- [x] `suppress_notification=False`(기본값)일 때 기존 동작(두 이벤트 모두 발행) 유지 확인
- [x] 기존 테스트 9개 + 신규 2개 = 11개 전체 통과
- [x] 전체 테스트 스위트 2105개 통과
- [x] ruff check / ruff format 통과

Closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)