### PR TITLE
feat(bot): stop_bot() suppress_notification 파라미터 추가

### DIFF
--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -60,6 +60,7 @@ class BotManager:
         self._rule_engine = rule_engine
         self._strategy_rule_configs = strategy_rule_configs or {}
         self._bots: dict[str, Bot] = {}
+        self._suppress_notification_bot_ids: set[str] = set()
         self._restart_counts: dict[str, int] = {}
         self._restart_tasks: dict[str, asyncio.Task[None]] = {}
         self._restart_reset_tasks: dict[str, asyncio.Task[None]] = {}
@@ -290,9 +291,17 @@ class BotManager:
         self._load_strategy_rules(bot.config.strategy_id)
         await bot.start()
 
-    async def stop_bot(self, bot_id: str) -> None:
-        """봇 중지. 전략별 룰을 RuleEngine에서 제거."""
+    async def stop_bot(
+        self, bot_id: str, *, suppress_notification: bool = False
+    ) -> None:
+        """봇 중지. 전략별 룰을 RuleEngine에서 제거.
+
+        suppress_notification이 True이면 BotStoppedEvent에 의한
+        NotificationEvent 발행을 1회 억제한다.
+        """
         bot = self._get_bot(bot_id)
+        if suppress_notification:
+            self._suppress_notification_bot_ids.add(bot_id)
         await bot.stop()
         self._remove_strategy_rules(bot.config.strategy_id)
 
@@ -421,10 +430,13 @@ class BotManager:
         )
 
     async def _on_bot_stopped(self, event: object) -> None:
-        """봇 중지 알림 발행."""
+        """봇 중지 알림 발행. suppress 목록에 있으면 알림 생략."""
         from ante.eventbus.events import BotStoppedEvent, NotificationEvent
 
         if not isinstance(event, BotStoppedEvent):
+            return
+        if event.bot_id in self._suppress_notification_bot_ids:
+            self._suppress_notification_bot_ids.discard(event.bot_id)
             return
         await self._eventbus.publish(
             NotificationEvent(

--- a/tests/unit/test_bot_manager_methods.py
+++ b/tests/unit/test_bot_manager_methods.py
@@ -274,3 +274,75 @@ class TestResumeBot:
         """존재하지 않는 봇 재개 시 예외."""
         with pytest.raises(BotError, match="not found"):
             await manager.resume_bot("nonexistent")
+
+
+# ── stop_bot suppress_notification ──────────────
+
+
+class TestStopBotSuppressNotification:
+    async def test_suppress_false_publishes_notification(self, manager, eventbus, ctx):
+        """suppress_notification=False(기본값)이면 NotificationEvent가 발행된다."""
+        from ante.eventbus.events import NotificationEvent
+
+        notifications: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: notifications.append(e))
+
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+        await manager.stop_bot("bot1")
+
+        stop_notifs = [n for n in notifications if n.title == "봇 중지"]
+        assert len(stop_notifs) == 1
+
+    async def test_suppress_true_skips_notification(self, manager, eventbus, ctx):
+        """suppress_notification=True이면 NotificationEvent가 발행되지 않는다."""
+        from ante.eventbus.events import NotificationEvent
+
+        notifications: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: notifications.append(e))
+
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+        await manager.stop_bot("bot1", suppress_notification=True)
+
+        stop_notifs = [n for n in notifications if n.title == "봇 중지"]
+        assert len(stop_notifs) == 0
+
+    async def test_suppress_is_one_shot(self, manager, eventbus, ctx):
+        """suppress는 1회성이다. 두 번째 stop에서는 알림이 발행된다."""
+        from ante.eventbus.events import NotificationEvent
+
+        notifications: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: notifications.append(e))
+
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        # 1회차: suppress
+        await manager.start_bot("bot1")
+        await manager.stop_bot("bot1", suppress_notification=True)
+        stop_notifs_1 = [n for n in notifications if n.title == "봇 중지"]
+        assert len(stop_notifs_1) == 0
+
+        # 2회차: 기본값 (알림 발행)
+        await manager.start_bot("bot1")
+        await manager.stop_bot("bot1")
+        stop_notifs_2 = [n for n in notifications if n.title == "봇 중지"]
+        assert len(stop_notifs_2) == 1
+
+    async def test_suppress_preserves_bot_stopped_event(self, manager, eventbus, ctx):
+        """suppress_notification=True여도 BotStoppedEvent는 정상 발행된다."""
+        from ante.eventbus.events import BotStoppedEvent
+
+        stopped_events: list[BotStoppedEvent] = []
+        eventbus.subscribe(BotStoppedEvent, lambda e: stopped_events.append(e))
+
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+        await manager.stop_bot("bot1", suppress_notification=True)
+
+        assert len(stopped_events) == 1
+        assert stopped_events[0].bot_id == "bot1"


### PR DESCRIPTION
## Summary
- `BotManager.stop_bot(bot_id, *, suppress_notification=False)` 파라미터 추가
- `suppress_notification=True` 시 `_suppress_notification_bot_ids` set에 bot_id를 등록하고, `_on_bot_stopped()` 핸들러에서 해당 bot_id의 `NotificationEvent` 발행을 1회 억제
- `BotStoppedEvent`(도메인 이벤트)는 항상 정상 발행 유지

## Test plan
- [x] `suppress_notification=False`(기본값) — NotificationEvent 정상 발행 확인
- [x] `suppress_notification=True` — NotificationEvent 발행 억제 확인
- [x] 1회성 억제 — 두 번째 stop에서는 알림 정상 발행 확인
- [x] BotStoppedEvent는 suppress와 무관하게 항상 발행 확인
- [x] 전체 테스트 2107건 통과

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)