### PR TITLE
feat(approval): suppress_notification 파라미터 추가 (#516)

### DIFF
--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -138,6 +138,8 @@ class ApprovalService:
         self,
         id: str,
         resolved_by: str = "user",
+        *,
+        suppress_notification: bool = False,
     ) -> ApprovalRequest:
         """결재 승인 + 자동 실행."""
         request = await self.get(id)
@@ -178,7 +180,9 @@ class ApprovalService:
 
         logger.info("결재 승인: %s by %s", id, resolved_by)
 
-        await self._execute_approved(request, resolved_by)
+        await self._execute_approved(
+            request, resolved_by, suppress_notification=suppress_notification
+        )
 
         return request
 
@@ -187,6 +191,8 @@ class ApprovalService:
         id: str,
         resolved_by: str = "user",
         reject_reason: str = "",
+        *,
+        suppress_notification: bool = False,
     ) -> ApprovalRequest:
         """결재 거절."""
         request = await self.get(id)
@@ -244,9 +250,10 @@ class ApprovalService:
                 resolved_by=resolved_by,
             )
         )
-        await self._publish_resolved_notification(
-            id, request.type, ApprovalStatus.REJECTED, resolved_by
-        )
+        if not suppress_notification:
+            await self._publish_resolved_notification(
+                id, request.type, ApprovalStatus.REJECTED, resolved_by
+            )
 
         return request
 
@@ -704,7 +711,13 @@ class ApprovalService:
             )
         )
 
-    async def _execute_approved(self, request: ApprovalRequest, actor: str) -> None:
+    async def _execute_approved(
+        self,
+        request: ApprovalRequest,
+        actor: str,
+        *,
+        suppress_notification: bool = False,
+    ) -> None:
         """승인된 요청의 executor를 실행하고 결과를 반영한다.
 
         create()의 전결 실행과 approve()의 자동 실행에서 공유된다.
@@ -752,9 +765,10 @@ class ApprovalService:
                 resolved_by=actor,
             )
         )
-        await self._publish_resolved_notification(
-            request.id, request.type, request.status, actor
-        )
+        if not suppress_notification:
+            await self._publish_resolved_notification(
+                request.id, request.type, request.status, actor
+            )
 
     async def _publish_resolved_notification(
         self,

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -16,7 +16,10 @@ from ante.approval.models import (
 from ante.approval.service import ApprovalService
 from ante.core.database import Database
 from ante.eventbus.bus import EventBus
-from ante.eventbus.events import ApprovalCreatedEvent, ApprovalResolvedEvent
+from ante.eventbus.events import (
+    ApprovalCreatedEvent,
+    ApprovalResolvedEvent,
+)
 
 # ── Fixtures ─────────────────────────────────────────
 
@@ -1336,3 +1339,106 @@ class TestReopen:
         assert approved.status == "approved"
         actions = [h["action"] for h in approved.history]
         assert actions == ["created", "rejected", "reopened", "approved"]
+
+
+# ── suppress_notification (#516) ───────────────────
+
+
+class TestSuppressNotification:
+    """suppress_notification=True 시 NotificationEvent 미발행, 도메인 이벤트는 유지."""
+
+    async def test_approve_suppress_skips_notification(self, service, eventbus):
+        """approve(suppress_notification=True) 시 NotificationEvent 미발행."""
+        from ante.eventbus.events import NotificationEvent
+
+        notifications: list[NotificationEvent] = []
+        resolved: list[ApprovalResolvedEvent] = []
+
+        async def on_notification(event: NotificationEvent) -> None:
+            if event.category == "approval" and event.title == "결재 처리 완료":
+                notifications.append(event)
+
+        async def on_resolved(event: ApprovalResolvedEvent) -> None:
+            resolved.append(event)
+
+        eventbus.subscribe(NotificationEvent, on_notification)
+        eventbus.subscribe(ApprovalResolvedEvent, on_resolved)
+
+        req = await service.create(
+            type="budget_change", requester="agent", title="알림 억제 테스트"
+        )
+        await service.approve(req.id, suppress_notification=True)
+
+        # 도메인 이벤트는 발행됨
+        assert len(resolved) == 1
+        assert resolved[0].resolution == "approved"
+
+        # NotificationEvent는 미발행
+        assert len(notifications) == 0
+
+    async def test_approve_default_sends_notification(self, service, eventbus):
+        """approve() 기본 동작은 NotificationEvent 발행."""
+        from ante.eventbus.events import NotificationEvent
+
+        notifications: list[NotificationEvent] = []
+
+        async def on_notification(event: NotificationEvent) -> None:
+            if event.category == "approval" and event.title == "결재 처리 완료":
+                notifications.append(event)
+
+        eventbus.subscribe(NotificationEvent, on_notification)
+
+        req = await service.create(
+            type="budget_change", requester="agent", title="기본 동작 테스트"
+        )
+        await service.approve(req.id)
+
+        assert len(notifications) == 1
+
+    async def test_reject_suppress_skips_notification(self, service, eventbus):
+        """reject(suppress_notification=True) 시 NotificationEvent 미발행."""
+        from ante.eventbus.events import NotificationEvent
+
+        notifications: list[NotificationEvent] = []
+        resolved: list[ApprovalResolvedEvent] = []
+
+        async def on_notification(event: NotificationEvent) -> None:
+            if event.category == "approval" and event.title == "결재 처리 완료":
+                notifications.append(event)
+
+        async def on_resolved(event: ApprovalResolvedEvent) -> None:
+            resolved.append(event)
+
+        eventbus.subscribe(NotificationEvent, on_notification)
+        eventbus.subscribe(ApprovalResolvedEvent, on_resolved)
+
+        req = await service.create(
+            type="budget_change", requester="agent", title="거절 알림 억제"
+        )
+        await service.reject(req.id, suppress_notification=True)
+
+        # 도메인 이벤트는 발행됨
+        assert len(resolved) == 1
+        assert resolved[0].resolution == "rejected"
+
+        # NotificationEvent는 미발행
+        assert len(notifications) == 0
+
+    async def test_reject_default_sends_notification(self, service, eventbus):
+        """reject() 기본 동작은 NotificationEvent 발행."""
+        from ante.eventbus.events import NotificationEvent
+
+        notifications: list[NotificationEvent] = []
+
+        async def on_notification(event: NotificationEvent) -> None:
+            if event.category == "approval" and event.title == "결재 처리 완료":
+                notifications.append(event)
+
+        eventbus.subscribe(NotificationEvent, on_notification)
+
+        req = await service.create(
+            type="budget_change", requester="agent", title="거절 기본 동작"
+        )
+        await service.reject(req.id)
+
+        assert len(notifications) == 1


### PR DESCRIPTION
## Summary
- `approve()`, `reject()` 메서드에 `suppress_notification: bool = False` 키워드 인자 추가
- `suppress_notification=True` 시 `_publish_resolved_notification()` 호출 생략 (NotificationEvent 미발행)
- `ApprovalResolvedEvent` 도메인 이벤트는 항상 발행 (변경 없음)
- `_execute_approved()` 내부에도 동일 로직 전파

## Test plan
- [x] `test_approve_suppress_skips_notification` — 승인 시 알림 억제 확인
- [x] `test_approve_default_sends_notification` — 기본 동작(알림 발행) 회귀 확인
- [x] `test_reject_suppress_skips_notification` — 거절 시 알림 억제 확인
- [x] `test_reject_default_sends_notification` — 기본 동작(알림 발행) 회귀 확인
- [x] 전체 테스트 2107건 통과

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)