### PR TITLE
feat(telegram): /stop 응답 메시지 스펙 정합성 확보

### DIFF
--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -460,6 +460,8 @@ class TelegramCommandReceiver:
 
     async def _cmd_stop(self, args: list[str]) -> str:
         """특정 봇 중지."""
+        from ante.bot.config import BotStatus
+
         if not self._bot_manager:
             return "BotManager가 연결되지 않았습니다."
 
@@ -471,8 +473,35 @@ class TelegramCommandReceiver:
         if not bot:
             return f"봇을 찾을 수 없습니다: {bot_id}"
 
+        if bot.status != BotStatus.RUNNING:
+            return f"이미 중지된 봇입니다: {bot_id}"
+
+        # 중지 전 포지션·미체결 주문 조회
+        positions = bot._ctx.get_positions()
+        open_orders = bot._ctx.get_open_orders()
+
         await self._bot_manager.stop_bot(bot_id)
-        return f"봇 {bot_id}이 중지되었습니다."
+
+        bot_name = bot.config.name or bot_id
+        header = f"ℹ️ *봇 중지*\n\n봇: {bot_name} ({bot_id})\n상태: 실행 중 → 중지됨"
+
+        if not positions:
+            return f"{header}\n\n미체결 주문은 자동 취소되지 않습니다."
+
+        # 보유 종목 있음 — 메시지 B
+        symbols = sorted(positions.keys())
+        pending_amount = sum(order.get("amount", 0) for order in open_orders)
+
+        lines = [
+            header,
+            "",
+            f"⚠️ 보유 종목 {len(symbols)}개가 유지됩니다.",
+            "중지 후 포지션을 직접 관리해야 합니다.",
+            "",
+            f"보유: {', '.join(symbols)}",
+            f"체결대기: {pending_amount:,.0f}원",
+        ]
+        return "\n".join(lines)
 
     # ── 유틸 ────────────────────────────────────────
 

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -20,6 +20,24 @@ def adapter():
     return mock
 
 
+def _make_running_bot(
+    bot_id: str = "bot-1",
+    name: str = "테스트봇",
+    positions: dict | None = None,
+    open_orders: list | None = None,
+):
+    """RUNNING 상태의 Bot mock 생성 헬퍼."""
+    from ante.bot.config import BotStatus
+
+    bot = MagicMock()
+    bot.bot_id = bot_id
+    bot.status = BotStatus.RUNNING
+    bot.config.name = name
+    bot._ctx.get_positions.return_value = positions or {}
+    bot._ctx.get_open_orders.return_value = open_orders or []
+    return bot
+
+
 @pytest.fixture
 def bot_manager():
     mock = MagicMock()
@@ -27,7 +45,7 @@ def bot_manager():
         {"bot_id": "bot-1", "status": "running", "strategy_id": "s1"},
         {"bot_id": "bot-2", "status": "stopped", "strategy_id": "s2"},
     ]
-    mock.get_bot.return_value = MagicMock()
+    mock.get_bot.return_value = _make_running_bot()
     mock.stop_bot = AsyncMock()
     return mock
 
@@ -222,11 +240,47 @@ class TestCommands:
         result = await receiver._cmd_activate([])
         assert "연결되지 않았습니다" in result
 
-    async def test_stop_bot(self, receiver, bot_manager):
+    async def test_stop_bot_no_positions(self, receiver, bot_manager):
+        """보유 종목 없이 봇 중지 — 메시지 A."""
         result = await receiver._cmd_stop(["bot-1"])
-        assert "중지" in result
-        assert "bot-1" in result
+        assert "봇 중지" in result
+        assert "테스트봇 (bot-1)" in result
+        assert "실행 중 → 중지됨" in result
+        assert "미체결 주문은 자동 취소되지 않습니다" in result
         bot_manager.stop_bot.assert_called_once_with("bot-1")
+
+    async def test_stop_bot_with_positions(self, receiver, bot_manager):
+        """보유 종목 있으면 메시지 B — 종목명 및 체결대기 금액 표시."""
+        bot = _make_running_bot(
+            positions={
+                "005930": {
+                    "symbol": "005930",
+                    "quantity": 10,
+                    "avg_entry_price": 70000,
+                },
+                "035720": {"symbol": "035720", "quantity": 5, "avg_entry_price": 50000},
+            },
+            open_orders=[{"amount": 500_000}, {"amount": 300_000}],
+        )
+        bot_manager.get_bot.return_value = bot
+        result = await receiver._cmd_stop(["bot-1"])
+        assert "봇 중지" in result
+        assert "보유 종목 2개가 유지됩니다" in result
+        assert "포지션을 직접 관리" in result
+        assert "005930" in result
+        assert "035720" in result
+        assert "800,000원" in result
+
+    async def test_stop_bot_already_stopped(self, receiver, bot_manager):
+        """이미 중지된 봇은 안내 메시지 반환."""
+        from ante.bot.config import BotStatus
+
+        bot = MagicMock()
+        bot.status = BotStatus.STOPPED
+        bot_manager.get_bot.return_value = bot
+        result = await receiver._cmd_stop(["bot-1"])
+        assert "이미 중지된 봇입니다" in result
+        bot_manager.stop_bot.assert_not_called()
 
     async def test_stop_bot_no_args(self, receiver):
         result = await receiver._cmd_stop([])
@@ -241,6 +295,13 @@ class TestCommands:
         receiver._bot_manager = None
         result = await receiver._cmd_stop(["bot-1"])
         assert "연결되지 않았습니다" in result
+
+    async def test_stop_bot_name_fallback(self, receiver, bot_manager):
+        """봇 이름이 빈 문자열이면 bot_id로 대체."""
+        bot = _make_running_bot(name="")
+        bot_manager.get_bot.return_value = bot
+        result = await receiver._cmd_stop(["bot-1"])
+        assert "bot-1 (bot-1)" in result
 
 
 # ── US-4: 2단계 확인 ─────────────────────────────
@@ -275,7 +336,8 @@ class TestConfirmation:
         """confirm으로 stop이 실행된다."""
         await receiver._execute("stop", ["bot-1"], 12345, 100)
         result = await receiver._handle_confirm(12345)
-        assert "중지" in result
+        assert "봇 중지" in result
+        assert "실행 중 → 중지됨" in result
         bot_manager.stop_bot.assert_called_once_with("bot-1")
 
     async def test_confirm_no_pending(self, receiver):


### PR DESCRIPTION
## Summary
- `/stop` 명령 응답을 `docs/specs/bot.md` 스펙에 맞게 확장
- 이미 중지된 봇에 대한 분기(`이미 중지된 봇입니다`) 추가
- 포지션 유무에 따른 메시지 A(보유 없음)/B(보유 있음) 분기 구현
- 메시지에 봇 이름, 상태 전환(`실행 중 → 중지됨`), 보유 종목, 체결대기 금액 포함

## Test plan
- [x] 보유 종목 없이 봇 중지 시 메시지 A 반환 확인
- [x] 보유 종목 있을 때 메시지 B (종목 목록 + 체결대기 금액) 반환 확인
- [x] 이미 중지된 봇에 대한 안내 메시지 반환 확인
- [x] 봇 미존재, 인자 누락, BotManager 미연결 등 기존 분기 유지 확인
- [x] 봇 이름이 빈 문자열이면 bot_id로 대체되는지 확인
- [x] ruff 린트 통과
- [x] 전체 테스트 2106건 통과

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)