### PR TITLE
fix(telegram): /halt 응답 메시지 스펙 정합성 수정

### DIFF
--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -234,8 +234,13 @@ class TelegramCommandReceiver:
         if command == "confirm":
             return await self._handle_confirm(user_id)
 
-        # 위험 명령 → 확인 절차
+        # 위험 명령 → 확인 절차 (이미 해당 상태이면 즉시 반환)
         if command in _DANGEROUS_COMMANDS:
+            if command == "halt" and self._system_state:
+                from ante.config.system_state import TradingState
+
+                if self._system_state.trading_state == TradingState.HALTED:
+                    return "이미 거래가 중지된 상태입니다."
             return self._request_confirmation(command, args, user_id)
 
         # 즉시 실행 명령
@@ -440,11 +445,18 @@ class TelegramCommandReceiver:
 
         from ante.config.system_state import TradingState
 
+        if self._system_state.trading_state == TradingState.HALTED:
+            return "이미 거래가 중지된 상태입니다."
+
         reason = " ".join(args) if args else "텔레그램 명령"
         await self._system_state.set_state(
             TradingState.HALTED, reason=reason, changed_by="telegram"
         )
-        return f"전체 거래가 중지되었습니다. (사유: {reason})"
+        return (
+            "\U0001f6a8 전체 거래가 중지되었습니다.\n"
+            f"사유: {reason}\n"
+            "해제하려면 /activate 를 입력하세요."
+        )
 
     async def _cmd_activate(self, args: list[str]) -> str:
         """거래 재개."""

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -430,8 +430,31 @@ class TestIntegrationFlow:
         }
         await receiver._handle_update(confirm_update)
         assert receiver._reply.call_count == 2
-        assert "중지되었습니다" in receiver._reply.call_args[0][1]
+        reply_text = receiver._reply.call_args[0][1]
+        assert "중지되었습니다" in reply_text
+        assert "/activate" in reply_text
         system_state.set_state.assert_called_once()
+
+    async def test_halt_already_halted(self, receiver, system_state):
+        """이미 HALTED 상태이면 중복 메시지를 반환한다."""
+        from ante.config.system_state import TradingState
+
+        system_state.trading_state = TradingState.HALTED
+        receiver._reply = AsyncMock()
+
+        halt_update = {
+            "message": {
+                "text": "/halt",
+                "from": {"id": 12345},
+                "chat": {"id": 100},
+            }
+        }
+        await receiver._handle_update(halt_update)
+
+        # confirm 없이 즉시 응답
+        assert receiver._reply.call_count == 1
+        assert "이미 거래가 중지된 상태입니다" in receiver._reply.call_args[0][1]
+        system_state.set_state.assert_not_called()
 
     async def test_reply_with_no_chat_id(self, receiver):
         """chat_id가 없어도 에러 없이 처리."""


### PR DESCRIPTION
## Summary
- 이미 HALTED 상태에서 `/halt` 실행 시 확인 절차 없이 `이미 거래가 중지된 상태입니다.` 즉시 반환
- 성공 시 `docs/specs/core.md` 스펙에 맞는 응답 메시지 적용 (사유 + `/activate` 해제 안내)
- 확인 절차(`_request_confirmation`) 진입 전 상태 사전 검사로 불필요한 confirm 흐름 방지

Closes #540

## Test plan
- [x] 기존 43개 telegram_receiver 테스트 전체 통과
- [x] `test_halt_already_halted` — HALTED 상태에서 즉시 안내 메시지 반환 확인
- [x] `test_full_halt_confirm_flow` — 성공 시 `/activate` 해제 안내 포함 확인
- [x] 전체 테스트 스위트 2104개 통과
- [x] ruff check / ruff format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)