### PR TITLE
fix(telegram): /bots 응답 스펙 정합성 수정

### DIFF
--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -331,6 +331,15 @@ class TelegramCommandReceiver:
 
         return "\n".join(parts)
 
+    _STATUS_KO: dict[str, str] = {
+        "created": "생성됨",
+        "running": "실행 중",
+        "stopping": "중지 중",
+        "stopped": "중지됨",
+        "error": "에러",
+        "deleted": "삭제됨",
+    }
+
     def _cmd_bots(self, args: list[str]) -> str:
         """봇 목록."""
         if not self._bot_manager:
@@ -340,14 +349,17 @@ class TelegramCommandReceiver:
         if not bots:
             return "등록된 봇이 없습니다."
 
+        running = sum(1 for b in bots if b["status"] == "running")
+        total = len(bots)
+
         lines = []
         for b in bots:
-            status = b["status"]
+            status_ko = self._STATUS_KO.get(b["status"], b["status"])
             bot_id = b["bot_id"]
             strategy = b.get("strategy_id", "-")
-            lines.append(f"  {bot_id} [{status}] {strategy}")
+            lines.append(f"  {bot_id} [{status_ko}] {strategy}")
 
-        return "봇 목록:\n" + "\n".join(lines)
+        return f"\U0001f916 봇 목록 ({running}/{total} 실행 중)\n" + "\n".join(lines)
 
     def _cmd_balance(self, args: list[str]) -> str:
         """자금 현황."""

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -145,9 +145,11 @@ class TestCommands:
 
     async def test_bots(self, receiver):
         result = receiver._cmd_bots([])
-        assert "봇 목록" in result
+        assert "봇 목록 (1/2 실행 중)" in result
         assert "bot-1" in result
+        assert "[실행 중]" in result
         assert "bot-2" in result
+        assert "[중지됨]" in result
 
     async def test_bots_no_manager(self, receiver):
         receiver._bot_manager = None


### PR DESCRIPTION
## Summary
- `/bots` 텔레그램 응답 메시지를 `docs/specs/bot.md` 스펙에 맞게 수정
- 헤더: `봇 목록:` → `🤖 봇 목록 (N/M 실행 중)` 형식으로 실행 중 봇 수 표시
- 상태값 한글화: `running`→`실행 중`, `stopped`→`중지됨` 등 6개 상태 매핑

## Changes
- `src/ante/notification/telegram_receiver.py` — `_STATUS_KO` 클래스 변수 추가, `_cmd_bots()` 수정
- `tests/unit/test_telegram_receiver.py` — 헤더 포맷 및 한글 상태값 검증 추가

## Test plan
- [x] `test_bots` — 헤더 `(1/2 실행 중)` 포맷 및 `[실행 중]`, `[중지됨]` 한글 상태값 검증
- [x] 기존 42개 telegram_receiver 테스트 전체 통과
- [x] 전체 2103개 테스트 통과, ruff lint/format 통과

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)