### PR TITLE
feat(telegram): /activate 응답 메시지 스펙 적용

### DIFF
--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -453,10 +453,13 @@ class TelegramCommandReceiver:
 
         from ante.config.system_state import TradingState
 
+        if self._system_state.trading_state == TradingState.ACTIVE:
+            return "이미 거래가 활성 상태입니다."
+
         await self._system_state.set_state(
             TradingState.ACTIVE, reason="텔레그램 명령", changed_by="telegram"
         )
-        return "거래가 재개되었습니다."
+        return "✅ 거래가 재개되었습니다."
 
     async def _cmd_stop(self, args: list[str]) -> str:
         """특정 봇 중지."""

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -50,9 +50,10 @@ def treasury():
 
 @pytest.fixture
 def system_state():
+    from ante.config.system_state import TradingState
+
     mock = MagicMock()
-    mock.trading_state = MagicMock()
-    mock.trading_state.value = "active"
+    mock.trading_state = TradingState.HALTED
     mock.set_state = AsyncMock()
     return mock
 
@@ -129,7 +130,7 @@ class TestCommands:
     async def test_status(self, receiver):
         result = receiver._cmd_status([])
         assert "거래 상태" in result
-        assert "active" in result
+        assert "halted" in result
         assert "봇" in result
 
     async def test_status_no_manager(self, receiver):
@@ -214,8 +215,16 @@ class TestCommands:
 
     async def test_activate(self, receiver, system_state):
         result = await receiver._cmd_activate([])
-        assert "재개" in result
+        assert "거래가 재개되었습니다" in result
         system_state.set_state.assert_called_once()
+
+    async def test_activate_already_active(self, receiver, system_state):
+        from ante.config.system_state import TradingState
+
+        system_state.trading_state = TradingState.ACTIVE
+        result = await receiver._cmd_activate([])
+        assert "이미 거래가 활성 상태입니다" in result
+        system_state.set_state.assert_not_called()
 
     async def test_activate_no_state(self, receiver):
         receiver._system_state = None


### PR DESCRIPTION
## Summary
- `/activate` 명령 실행 시 이미 ACTIVE 상태이면 `이미 거래가 활성 상태입니다.` 반환
- HALTED → ACTIVE 전환 성공 시 `✅ 거래가 재개되었습니다.` 반환 (스펙 준수)
- 테스트 fixture를 `TradingState.HALTED`로 변경하고, 이미 활성 상태 테스트 케이스 추가

Closes #541

## Test plan
- [x] `test_activate` — HALTED → ACTIVE 전환 시 성공 메시지 확인
- [x] `test_activate_already_active` — 이미 ACTIVE일 때 중복 메시지 반환, `set_state` 미호출 확인
- [x] `test_activate_no_state` — SystemState 미연결 시 에러 메시지 확인
- [x] 전체 테스트 2104건 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)