### PR TITLE
feat(eventbus): SystemStartedEvent 도메인 이벤트 추가

### DIFF
--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -267,6 +267,13 @@ class TradingStateChangedEvent(Event):
 
 
 @dataclass(frozen=True)
+class SystemStartedEvent(Event):
+    """Main → EventBus: 시스템 초기화 완료."""
+
+    auto_started_bots: int = 0
+
+
+@dataclass(frozen=True)
 class SystemShutdownEvent(Event):
     """Main → EventBus: 시스템 종료 시작."""
 

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -936,7 +936,7 @@ async def _run(s: Services) -> None:
 
     logger.info("Ante 준비 완료 — 종료 시그널 대기 중")
 
-    from ante.eventbus.events import NotificationEvent
+    from ante.eventbus.events import NotificationEvent, SystemStartedEvent
 
     if s.eventbus:
         await s.eventbus.publish(
@@ -947,6 +947,7 @@ async def _run(s: Services) -> None:
                 category="system",
             )
         )
+        await s.eventbus.publish(SystemStartedEvent())
 
     await shutdown_event.wait()
 


### PR DESCRIPTION
## Summary
- `SystemStartedEvent(auto_started_bots: int = 0)` 이벤트 클래스를 `eventbus/events.py`에 추가
- `main.py`의 시스템 시작 시 `NotificationEvent` 발행 직후 `SystemStartedEvent` 발행
- 향후 `restore_bots()` 구현 시 `auto_started_bots` 필드에 실제 재개된 봇 수 반영 가능

Closes #539

## Test plan
- [x] ruff check 통과
- [x] pytest 2103 passed (tests/e2e 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)