### PR TITLE
feat(notification): quiet_hours 동적 설정 연동

### DIFF
--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -843,10 +843,25 @@ async def _init_notification(s: Services) -> None:
 
     adapter = TelegramAdapter(bot_token=telegram_token, chat_id=telegram_chat_id)
     min_level_str = s.config.get("notification.min_level", "info")
+
+    # quiet_hours 파싱
+    quiet_start = None
+    quiet_end = None
+    if s.dynamic_config:
+        from ante.notification.service import parse_quiet_hours
+
+        raw = await s.dynamic_config.get("notification.quiet_hours", default=None)
+        if raw:
+            parsed = parse_quiet_hours(str(raw))
+            if parsed:
+                quiet_start, quiet_end = parsed
+
     s.notification_service = NotificationService(
         adapter=adapter,
         eventbus=s.eventbus,
         min_level=NotificationLevel(min_level_str),
+        quiet_start=quiet_start,
+        quiet_end=quiet_end,
     )
     s.notification_service.subscribe()
     logger.info("NotificationService 초기화 완료 (Telegram)")

--- a/src/ante/notification/__init__.py
+++ b/src/ante/notification/__init__.py
@@ -1,7 +1,7 @@
 """Notification — 외부 알림 채널 관리."""
 
 from ante.notification.base import NotificationAdapter, NotificationLevel
-from ante.notification.service import NotificationService
+from ante.notification.service import NotificationService, parse_quiet_hours
 from ante.notification.telegram import TelegramAdapter
 from ante.notification.telegram_receiver import TelegramCommandReceiver
 
@@ -11,4 +11,5 @@ __all__ = [
     "NotificationService",
     "TelegramAdapter",
     "TelegramCommandReceiver",
+    "parse_quiet_hours",
 ]

--- a/src/ante/notification/service.py
+++ b/src/ante/notification/service.py
@@ -14,6 +14,21 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def parse_quiet_hours(value: str) -> tuple[time, time] | None:
+    """``"HH:MM-HH:MM"`` 형식 문자열을 ``(time, time)`` 으로 변환.
+
+    잘못된 형식이면 ``None`` 을 반환하고 경고 로그를 남긴다.
+    """
+    try:
+        start_str, end_str = value.split("-", 1)
+        sh, sm = start_str.strip().split(":")
+        eh, em = end_str.strip().split(":")
+        return time(int(sh), int(sm)), time(int(eh), int(em))
+    except Exception:
+        logger.warning("quiet_hours 파싱 실패 (무음 비활성 유지): %r", value)
+        return None
+
+
 _SUPPRESSED = object()  # 중복 억제 센티널
 
 
@@ -44,10 +59,41 @@ class NotificationService:
         self._dedup_cache: dict[str, tuple[float, int]] = {}
 
     def subscribe(self) -> None:
-        """이벤트 구독 등록 — NotificationEvent 단일 구독."""
-        from ante.eventbus.events import NotificationEvent
+        """이벤트 구독 등록 — NotificationEvent + ConfigChangedEvent."""
+        from ante.eventbus.events import ConfigChangedEvent, NotificationEvent
 
         self._eventbus.subscribe(NotificationEvent, self._on_notification, priority=0)
+        self._eventbus.subscribe(ConfigChangedEvent, self._on_config_changed)
+
+    async def _on_config_changed(self, event: object) -> None:
+        """``notification.quiet_hours`` 키 변경 시 무음 시간대를 갱신한다."""
+        from ante.eventbus.events import ConfigChangedEvent
+
+        if not isinstance(event, ConfigChangedEvent):
+            return
+        if event.key != "notification.quiet_hours":
+            return
+
+        import json
+
+        try:
+            raw = json.loads(event.new_value)
+        except (json.JSONDecodeError, TypeError):
+            raw = event.new_value
+
+        if not raw:
+            self._quiet_start = None
+            self._quiet_end = None
+            logger.info("무음 시간대 비활성화")
+            return
+
+        result = parse_quiet_hours(str(raw))
+        if result:
+            self._quiet_start, self._quiet_end = result
+            logger.info("무음 시간대 갱신: %s-%s", self._quiet_start, self._quiet_end)
+        else:
+            self._quiet_start = None
+            self._quiet_end = None
 
     def _make_dedup_key(self, level: NotificationLevel, message: str) -> str:
         """중복 방지 키 생성: level + message_hash."""

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -331,18 +331,148 @@ class TestNotificationService:
         )
         assert len(adapter.sent_rich) == 1
 
-    async def test_subscribe_only_notification_event(self, adapter, eventbus):
-        """subscribe()는 NotificationEvent만 구독한다."""
+    async def test_subscribe_registers_events(self, adapter, eventbus):
+        """subscribe()는 NotificationEvent + ConfigChangedEvent를 구독한다."""
+        from ante.eventbus.events import ConfigChangedEvent
+
         svc = NotificationService(adapter=adapter, eventbus=eventbus)
         svc.subscribe()
 
-        # NotificationEvent 핸들러만 등록되어 있어야 함
         handlers = eventbus._handlers
         assert NotificationEvent in handlers
-        assert len(handlers) == 1
+        assert ConfigChangedEvent in handlers
+        assert len(handlers) == 2
 
     async def test_no_instrument_service_dependency(self):
         """생성자에 instrument_service 파라미터가 없다."""
         sig = inspect.signature(NotificationService.__init__)
         param_names = list(sig.parameters.keys())
         assert "instrument_service" not in param_names
+
+
+# ── parse_quiet_hours ─────────────────────────────
+
+
+class TestParseQuietHours:
+    def test_valid_format(self):
+        """정상 형식 파싱."""
+        from ante.notification.service import parse_quiet_hours
+
+        result = parse_quiet_hours("23:00-07:00")
+        assert result == (time(23, 0), time(7, 0))
+
+    def test_with_spaces(self):
+        """공백 포함 형식 파싱."""
+        from ante.notification.service import parse_quiet_hours
+
+        result = parse_quiet_hours("23:00 - 07:00")
+        assert result == (time(23, 0), time(7, 0))
+
+    def test_invalid_format_returns_none(self):
+        """잘못된 형식은 None 반환."""
+        from ante.notification.service import parse_quiet_hours
+
+        assert parse_quiet_hours("invalid") is None
+        assert parse_quiet_hours("") is None
+        assert parse_quiet_hours("25:00-07:00") is None
+
+    def test_midnight_range(self):
+        """자정 포함 범위."""
+        from ante.notification.service import parse_quiet_hours
+
+        result = parse_quiet_hours("00:00-06:00")
+        assert result == (time(0, 0), time(6, 0))
+
+
+# ── ConfigChangedEvent → quiet_hours 갱신 ─────────
+
+
+class TestQuietHoursConfigChange:
+    @pytest.fixture
+    def adapter(self):
+        return MockAdapter()
+
+    @pytest.fixture
+    def eventbus(self):
+        return EventBus()
+
+    @pytest.fixture
+    def service(self, adapter, eventbus):
+        svc = NotificationService(adapter=adapter, eventbus=eventbus)
+        svc.subscribe()
+        return svc
+
+    async def test_config_change_updates_quiet_hours(self, service, eventbus):
+        """ConfigChangedEvent로 quiet_hours 갱신."""
+        from ante.eventbus.events import ConfigChangedEvent
+
+        await eventbus.publish(
+            ConfigChangedEvent(
+                category="notification",
+                key="notification.quiet_hours",
+                old_value="",
+                new_value='"23:00-07:00"',
+                changed_by="test",
+            )
+        )
+        assert service._quiet_start == time(23, 0)
+        assert service._quiet_end == time(7, 0)
+
+    async def test_config_change_clears_quiet_hours(self, service, eventbus):
+        """빈 값으로 quiet_hours 비활성화."""
+        from ante.eventbus.events import ConfigChangedEvent
+
+        # 먼저 설정
+        service._quiet_start = time(23, 0)
+        service._quiet_end = time(7, 0)
+
+        await eventbus.publish(
+            ConfigChangedEvent(
+                category="notification",
+                key="notification.quiet_hours",
+                old_value='"23:00-07:00"',
+                new_value='""',
+                changed_by="test",
+            )
+        )
+        assert service._quiet_start is None
+        assert service._quiet_end is None
+
+    async def test_config_change_ignores_other_keys(self, service, eventbus):
+        """다른 키 변경은 무시."""
+        from ante.eventbus.events import ConfigChangedEvent
+
+        service._quiet_start = time(23, 0)
+        service._quiet_end = time(7, 0)
+
+        await eventbus.publish(
+            ConfigChangedEvent(
+                category="system",
+                key="system.log_level",
+                old_value='"INFO"',
+                new_value='"DEBUG"',
+                changed_by="test",
+            )
+        )
+        # 변경 없음
+        assert service._quiet_start == time(23, 0)
+        assert service._quiet_end == time(7, 0)
+
+    async def test_config_change_invalid_format(self, service, eventbus):
+        """잘못된 형식이면 quiet_hours 비활성화."""
+        from ante.eventbus.events import ConfigChangedEvent
+
+        service._quiet_start = time(23, 0)
+        service._quiet_end = time(7, 0)
+
+        await eventbus.publish(
+            ConfigChangedEvent(
+                category="notification",
+                key="notification.quiet_hours",
+                old_value='"23:00-07:00"',
+                new_value='"invalid"',
+                changed_by="test",
+            )
+        )
+        assert service._quiet_start is None
+        assert service._quiet_end is None


### PR DESCRIPTION
## Summary
- `parse_quiet_hours()` 유틸 함수 추가: `"HH:MM-HH:MM"` → `(time, time)` 변환, 잘못된 형식은 경고 후 `None` 반환
- `_init_notification()`에서 `DynamicConfigService.get("notification.quiet_hours")`로 초기값을 읽어 `NotificationService` 생성자에 전달
- `NotificationService.subscribe()`에서 `ConfigChangedEvent` 구독 추가, `notification.quiet_hours` 키 변경 시 `quiet_start`/`quiet_end` 런타임 갱신

## Test plan
- [x] `parse_quiet_hours` 정상/공백/잘못된 형식/자정 범위 테스트 4건
- [x] `ConfigChangedEvent` → quiet_hours 갱신/비활성화/다른 키 무시/잘못된 형식 테스트 4건
- [x] 기존 `subscribe` 테스트를 `ConfigChangedEvent` 포함으로 갱신
- [x] 전체 테스트 스위트 2111건 통과

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)