### PR TITLE
feat(telegram): 명령 호출부에 suppress_notification=True 전달 (#519)

### DIFF
--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -192,22 +192,53 @@ class TelegramCommandReceiver:
 
         try:
             if action == "approve":
-                await self._approval_service.approve(
-                    approval_id, resolved_by="telegram"
+                request = await self._approval_service.approve(
+                    approval_id,
+                    resolved_by="telegram",
+                    suppress_notification=True,
                 )
-                result_msg = f"결재 승인 완료: {approval_id}"
+                if request.status == "execution_failed":
+                    detail = ""
+                    for entry in reversed(request.history):
+                        if entry.get("action") == "execution_failed":
+                            detail = entry.get("detail", "")
+                            break
+                    result_msg = (
+                        f"⚠️ 승인되었으나 실행 실패\n"
+                        f"제목: {request.title}\n"
+                        f"ID: {approval_id}\n"
+                        f"사유: {detail}"
+                    )
+                else:
+                    result_msg = (
+                        f"✅ 결재 승인 완료\n제목: {request.title}\nID: {approval_id}"
+                    )
             elif action == "reject":
-                await self._approval_service.reject(
-                    approval_id, resolved_by="telegram", reject_reason="사용자 거절"
+                request = await self._approval_service.reject(
+                    approval_id,
+                    resolved_by="telegram",
+                    reject_reason="사용자 거절",
+                    suppress_notification=True,
                 )
-                result_msg = f"결재 거절 완료: {approval_id}"
+                result_msg = (
+                    f"❌ 결재 거절 완료\n"
+                    f"제목: {request.title}\n"
+                    f"ID: {approval_id}\n"
+                    f"사유: 사용자 거절"
+                )
             else:
                 await self._adapter.answer_callback_query(
                     callback_id, "알 수 없는 동작입니다."
                 )
                 return
         except ValueError as e:
-            result_msg = f"처리 실패: {e}"
+            err = str(e)
+            if "찾을 수 없음" in err:
+                result_msg = f"❌ 결재를 찾을 수 없습니다\nID: {approval_id}"
+            elif "만료" in err:
+                result_msg = f"ℹ️ 만료된 결재입니다\nID: {approval_id}"
+            else:
+                result_msg = f"ℹ️ 이미 처리된 결재입니다 ({err})\nID: {approval_id}"
         except Exception:
             logger.exception("콜백 결재 처리 오류: %s", data)
             result_msg = "처리 중 오류가 발생했습니다."
@@ -405,10 +436,32 @@ class TelegramCommandReceiver:
 
         approval_id = args[0]
         try:
-            await self._approval_service.approve(approval_id, resolved_by="telegram")
-            return f"결재 승인 완료: {approval_id}"
+            request = await self._approval_service.approve(
+                approval_id,
+                resolved_by="telegram",
+                suppress_notification=True,
+            )
+            if request.status == "execution_failed":
+                # executor 실행 실패 — history 마지막 항목에서 사유 추출
+                detail = ""
+                for entry in reversed(request.history):
+                    if entry.get("action") == "execution_failed":
+                        detail = entry.get("detail", "")
+                        break
+                return (
+                    f"⚠️ 승인되었으나 실행 실패\n"
+                    f"제목: {request.title}\n"
+                    f"ID: {approval_id}\n"
+                    f"사유: {detail}"
+                )
+            return f"✅ 결재 승인 완료\n제목: {request.title}\nID: {approval_id}"
         except ValueError as e:
-            return f"승인 실패: {e}"
+            err = str(e)
+            if "찾을 수 없음" in err:
+                return f"❌ 결재를 찾을 수 없습니다\nID: {approval_id}"
+            if "만료" in err:
+                return f"ℹ️ 만료된 결재입니다\nID: {approval_id}"
+            return f"ℹ️ 이미 처리된 결재입니다 ({err})\nID: {approval_id}"
         except Exception:
             logger.exception("결재 승인 오류: %s", approval_id)
             return "승인 처리 중 오류가 발생했습니다."
@@ -423,12 +476,25 @@ class TelegramCommandReceiver:
         approval_id = args[0]
         reason = " ".join(args[1:]) if len(args) > 1 else "사용자 거절"
         try:
-            await self._approval_service.reject(
-                approval_id, resolved_by="telegram", reject_reason=reason
+            request = await self._approval_service.reject(
+                approval_id,
+                resolved_by="telegram",
+                reject_reason=reason,
+                suppress_notification=True,
             )
-            return f"결재 거절 완료: {approval_id} (사유: {reason})"
+            return (
+                f"❌ 결재 거절 완료\n"
+                f"제목: {request.title}\n"
+                f"ID: {approval_id}\n"
+                f"사유: {reason}"
+            )
         except ValueError as e:
-            return f"거절 실패: {e}"
+            err = str(e)
+            if "찾을 수 없음" in err:
+                return f"❌ 결재를 찾을 수 없습니다\nID: {approval_id}"
+            if "만료" in err:
+                return f"ℹ️ 만료된 결재입니다\nID: {approval_id}"
+            return f"ℹ️ 이미 처리된 결재입니다 ({err})\nID: {approval_id}"
         except Exception:
             logger.exception("결재 거절 오류: %s", approval_id)
             return "거절 처리 중 오류가 발생했습니다."
@@ -442,7 +508,10 @@ class TelegramCommandReceiver:
 
         reason = " ".join(args) if args else "텔레그램 명령"
         await self._system_state.set_state(
-            TradingState.HALTED, reason=reason, changed_by="telegram"
+            TradingState.HALTED,
+            reason=reason,
+            changed_by="telegram",
+            suppress_notification=True,
         )
         return f"전체 거래가 중지되었습니다. (사유: {reason})"
 
@@ -454,7 +523,10 @@ class TelegramCommandReceiver:
         from ante.config.system_state import TradingState
 
         await self._system_state.set_state(
-            TradingState.ACTIVE, reason="텔레그램 명령", changed_by="telegram"
+            TradingState.ACTIVE,
+            reason="텔레그램 명령",
+            changed_by="telegram",
+            suppress_notification=True,
         )
         return "거래가 재개되었습니다."
 
@@ -471,7 +543,7 @@ class TelegramCommandReceiver:
         if not bot:
             return f"봇을 찾을 수 없습니다: {bot_id}"
 
-        await self._bot_manager.stop_bot(bot_id)
+        await self._bot_manager.stop_bot(bot_id, suppress_notification=True)
         return f"봇 {bot_id}이 중지되었습니다."
 
     # ── 유틸 ────────────────────────────────────────

--- a/tests/unit/test_telegram_approval.py
+++ b/tests/unit/test_telegram_approval.py
@@ -17,6 +17,22 @@ from ante.notification.telegram_receiver import TelegramCommandReceiver
 # ── Fixtures ──────────────────────────────────────
 
 
+def _make_approval_request(
+    *,
+    approval_id: str = "abc123",
+    title: str = "테스트 결재",
+    status: str = "approved",
+    history: list | None = None,
+) -> MagicMock:
+    """ApprovalRequest mock 생성."""
+    req = MagicMock()
+    req.id = approval_id
+    req.title = title
+    req.status = status
+    req.history = history or []
+    return req
+
+
 @pytest.fixture
 def adapter():
     """TelegramAdapter mock."""
@@ -35,8 +51,8 @@ def adapter():
 def approval_service():
     """ApprovalService mock."""
     mock = MagicMock()
-    mock.approve = AsyncMock()
-    mock.reject = AsyncMock()
+    mock.approve = AsyncMock(return_value=_make_approval_request(status="approved"))
+    mock.reject = AsyncMock(return_value=_make_approval_request(status="rejected"))
     return mock
 
 
@@ -116,7 +132,7 @@ class TestCallbackQuery:
     """인라인 버튼 콜백 처리 테스트."""
 
     async def test_approve_callback(self, receiver, approval_service):
-        """approve 콜백이 ApprovalService.approve()를 호출한다."""
+        """approve 콜백이 suppress_notification=True로 호출한다."""
         update = {
             "callback_query": {
                 "id": "cb1",
@@ -129,11 +145,54 @@ class TestCallbackQuery:
         await receiver._handle_update(update)
 
         approval_service.approve.assert_called_once_with(
-            "abc123", resolved_by="telegram"
+            "abc123", resolved_by="telegram", suppress_notification=True
         )
 
+    async def test_approve_callback_response_format(self, receiver, approval_service):
+        """approve 콜백 성공 시 스펙 형식의 응답을 반환한다."""
+        approval_service.approve.return_value = _make_approval_request(
+            title="예산 증액", status="approved"
+        )
+        update = {
+            "callback_query": {
+                "id": "cb1",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "approve:abc123",
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
+
+        reply_text = receiver._reply.call_args[0][1]
+        assert "✅ 결재 승인 완료" in reply_text
+        assert "제목: 예산 증액" in reply_text
+        assert "ID: abc123" in reply_text
+
+    async def test_approve_callback_execution_failed(self, receiver, approval_service):
+        """approve 콜백 executor 실행 실패 시 경고 메시지."""
+        approval_service.approve.return_value = _make_approval_request(
+            title="봇 중지",
+            status="execution_failed",
+            history=[{"action": "execution_failed", "detail": "봇 미존재"}],
+        )
+        update = {
+            "callback_query": {
+                "id": "cb1",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "approve:abc123",
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
+
+        reply_text = receiver._reply.call_args[0][1]
+        assert "⚠️ 승인되었으나 실행 실패" in reply_text
+        assert "봇 미존재" in reply_text
+
     async def test_reject_callback(self, receiver, approval_service):
-        """reject 콜백이 ApprovalService.reject()를 호출한다."""
+        """reject 콜백이 suppress_notification=True로 호출한다."""
         update = {
             "callback_query": {
                 "id": "cb2",
@@ -146,8 +205,32 @@ class TestCallbackQuery:
         await receiver._handle_update(update)
 
         approval_service.reject.assert_called_once_with(
-            "abc123", resolved_by="telegram", reject_reason="사용자 거절"
+            "abc123",
+            resolved_by="telegram",
+            reject_reason="사용자 거절",
+            suppress_notification=True,
         )
+
+    async def test_reject_callback_response_format(self, receiver, approval_service):
+        """reject 콜백 성공 시 스펙 형식의 응답을 반환한다."""
+        approval_service.reject.return_value = _make_approval_request(
+            title="예산 증액", status="rejected"
+        )
+        update = {
+            "callback_query": {
+                "id": "cb2",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "reject:abc123",
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
+
+        reply_text = receiver._reply.call_args[0][1]
+        assert "❌ 결재 거절 완료" in reply_text
+        assert "제목: 예산 증액" in reply_text
+        assert "사유: 사용자 거절" in reply_text
 
     async def test_callback_unauthorized(self, receiver, adapter):
         """미인가 사용자의 콜백은 거부된다."""
@@ -192,8 +275,10 @@ class TestCallbackQuery:
         assert "알 수 없는" in adapter.answer_callback_query.call_args[0][1]
 
     async def test_callback_approve_error(self, receiver, approval_service, adapter):
-        """approve 실패 시 에러 메시지를 반환한다."""
-        approval_service.approve.side_effect = ValueError("pending 상태가 아님")
+        """approve ValueError 시 스펙 형식 에러 메시지를 반환한다."""
+        approval_service.approve.side_effect = ValueError(
+            "pending/execution_failed 상태에서만 승인 가능 (현재: approved)"
+        )
         update = {
             "callback_query": {
                 "id": "cb6",
@@ -204,8 +289,29 @@ class TestCallbackQuery:
         }
         receiver._reply = AsyncMock()
         await receiver._handle_update(update)
-        adapter.answer_callback_query.assert_called_once()
-        assert "실패" in adapter.answer_callback_query.call_args[0][1]
+        reply_text = receiver._reply.call_args[0][1]
+        assert "이미 처리된 결재입니다" in reply_text
+
+    async def test_callback_approve_not_found(
+        self, receiver, approval_service, adapter
+    ):
+        """approve 대상을 찾을 수 없을 때 스펙 형식 에러 메시지."""
+        approval_service.approve.side_effect = ValueError(
+            "결재 요청을 찾을 수 없음: abc123"
+        )
+        update = {
+            "callback_query": {
+                "id": "cb6",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "approve:abc123",
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
+        reply_text = receiver._reply.call_args[0][1]
+        assert "결재를 찾을 수 없습니다" in reply_text
+        assert "ID: abc123" in reply_text
 
     async def test_callback_no_approval_service(self, adapter):
         """approval_service 없으면 안내 메시지."""
@@ -247,12 +353,34 @@ class TestApproveRejectCommands:
     """텍스트 명령어 /approve, /reject 테스트."""
 
     async def test_approve_command(self, receiver, approval_service):
-        """/approve <id> 명령이 ApprovalService.approve()를 호출한다."""
+        """/approve <id> 명령이 suppress_notification=True로 호출한다."""
         result = await receiver._cmd_approve(["abc123"])
-        assert "승인 완료" in result
+        assert "✅ 결재 승인 완료" in result
         approval_service.approve.assert_called_once_with(
-            "abc123", resolved_by="telegram"
+            "abc123", resolved_by="telegram", suppress_notification=True
         )
+
+    async def test_approve_response_format(self, receiver, approval_service):
+        """/approve 성공 시 제목과 ID를 포함한 스펙 형식 응답."""
+        approval_service.approve.return_value = _make_approval_request(
+            title="봇 중지 요청", status="approved"
+        )
+        result = await receiver._cmd_approve(["abc123"])
+        assert "✅ 결재 승인 완료" in result
+        assert "제목: 봇 중지 요청" in result
+        assert "ID: abc123" in result
+
+    async def test_approve_execution_failed(self, receiver, approval_service):
+        """/approve executor 실행 실패 시 경고 형식 응답."""
+        approval_service.approve.return_value = _make_approval_request(
+            title="봇 중지 요청",
+            status="execution_failed",
+            history=[{"action": "execution_failed", "detail": "봇이 이미 중지됨"}],
+        )
+        result = await receiver._cmd_approve(["abc123"])
+        assert "⚠️ 승인되었으나 실행 실패" in result
+        assert "제목: 봇 중지 요청" in result
+        assert "사유: 봇이 이미 중지됨" in result
 
     async def test_approve_no_args(self, receiver):
         """/approve 인자 없으면 안내 메시지."""
@@ -267,25 +395,54 @@ class TestApproveRejectCommands:
         result = await r._cmd_approve(["abc123"])
         assert "연결되지 않았습니다" in result
 
-    async def test_approve_error(self, receiver, approval_service):
-        """approve 실패 시 에러 메시지."""
-        approval_service.approve.side_effect = ValueError("찾을 수 없음")
+    async def test_approve_not_found(self, receiver, approval_service):
+        """존재하지 않는 결재 ID에 대한 에러 메시지."""
+        approval_service.approve.side_effect = ValueError(
+            "결재 요청을 찾을 수 없음: abc123"
+        )
         result = await receiver._cmd_approve(["abc123"])
-        assert "실패" in result
+        assert "결재를 찾을 수 없습니다" in result
+        assert "ID: abc123" in result
+
+    async def test_approve_already_processed(self, receiver, approval_service):
+        """이미 처리된 결재에 대한 에러 메시지."""
+        approval_service.approve.side_effect = ValueError(
+            "pending/execution_failed 상태에서만 승인 가능 (현재: approved)"
+        )
+        result = await receiver._cmd_approve(["abc123"])
+        assert "이미 처리된 결재입니다" in result
+        assert "ID: abc123" in result
 
     async def test_reject_command(self, receiver, approval_service):
-        """/reject <id> [reason] 명령이 reject를 호출한다."""
+        """/reject <id> [reason] 명령이 suppress_notification=True로 호출한다."""
         result = await receiver._cmd_reject(["abc123", "리스크", "과다"])
-        assert "거절 완료" in result
+        assert "❌ 결재 거절 완료" in result
         approval_service.reject.assert_called_once_with(
-            "abc123", resolved_by="telegram", reject_reason="리스크 과다"
+            "abc123",
+            resolved_by="telegram",
+            reject_reason="리스크 과다",
+            suppress_notification=True,
         )
+
+    async def test_reject_response_format(self, receiver, approval_service):
+        """/reject 성공 시 스펙 형식 응답."""
+        approval_service.reject.return_value = _make_approval_request(
+            title="예산 변경", status="rejected"
+        )
+        result = await receiver._cmd_reject(["abc123", "리스크", "과다"])
+        assert "❌ 결재 거절 완료" in result
+        assert "제목: 예산 변경" in result
+        assert "ID: abc123" in result
+        assert "사유: 리스크 과다" in result
 
     async def test_reject_default_reason(self, receiver, approval_service):
         """/reject <id> 사유 미지정 시 기본 사유."""
         await receiver._cmd_reject(["abc123"])
         approval_service.reject.assert_called_once_with(
-            "abc123", resolved_by="telegram", reject_reason="사용자 거절"
+            "abc123",
+            resolved_by="telegram",
+            reject_reason="사용자 거절",
+            suppress_notification=True,
         )
 
     async def test_reject_no_args(self, receiver):
@@ -301,11 +458,21 @@ class TestApproveRejectCommands:
         result = await r._cmd_reject(["abc123"])
         assert "연결되지 않았습니다" in result
 
-    async def test_reject_error(self, receiver, approval_service):
-        """reject 실패 시 에러 메시지."""
-        approval_service.reject.side_effect = ValueError("이미 처리됨")
+    async def test_reject_not_found(self, receiver, approval_service):
+        """존재하지 않는 결재 ID에 대한 에러 메시지."""
+        approval_service.reject.side_effect = ValueError(
+            "결재 요청을 찾을 수 없음: abc123"
+        )
         result = await receiver._cmd_reject(["abc123"])
-        assert "실패" in result
+        assert "결재를 찾을 수 없습니다" in result
+
+    async def test_reject_already_processed(self, receiver, approval_service):
+        """이미 처리된 결재에 대한 에러 메시지."""
+        approval_service.reject.side_effect = ValueError(
+            "pending/execution_failed 상태에서만 거절 가능 (현재: rejected)"
+        )
+        result = await receiver._cmd_reject(["abc123"])
+        assert "이미 처리된 결재입니다" in result
 
     async def test_help_includes_approval_commands(self, receiver):
         """/help에 /approve, /reject 명령이 포함된다."""

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -216,6 +216,8 @@ class TestCommands:
         result = await receiver._cmd_activate([])
         assert "재개" in result
         system_state.set_state.assert_called_once()
+        call_kwargs = system_state.set_state.call_args
+        assert call_kwargs.kwargs.get("suppress_notification") is True
 
     async def test_activate_no_state(self, receiver):
         receiver._system_state = None
@@ -226,7 +228,9 @@ class TestCommands:
         result = await receiver._cmd_stop(["bot-1"])
         assert "중지" in result
         assert "bot-1" in result
-        bot_manager.stop_bot.assert_called_once_with("bot-1")
+        bot_manager.stop_bot.assert_called_once_with(
+            "bot-1", suppress_notification=True
+        )
 
     async def test_stop_bot_no_args(self, receiver):
         result = await receiver._cmd_stop([])
@@ -270,13 +274,17 @@ class TestConfirmation:
         result = await receiver._handle_confirm(12345)
         assert "중지되었습니다" in result
         system_state.set_state.assert_called_once()
+        call_kwargs = system_state.set_state.call_args
+        assert call_kwargs.kwargs.get("suppress_notification") is True
 
     async def test_confirm_executes_stop(self, receiver, bot_manager):
         """confirm으로 stop이 실행된다."""
         await receiver._execute("stop", ["bot-1"], 12345, 100)
         result = await receiver._handle_confirm(12345)
         assert "중지" in result
-        bot_manager.stop_bot.assert_called_once_with("bot-1")
+        bot_manager.stop_bot.assert_called_once_with(
+            "bot-1", suppress_notification=True
+        )
 
     async def test_confirm_no_pending(self, receiver):
         """대기 중인 명령이 없으면 안내 메시지."""
@@ -432,6 +440,8 @@ class TestIntegrationFlow:
         assert receiver._reply.call_count == 2
         assert "중지되었습니다" in receiver._reply.call_args[0][1]
         system_state.set_state.assert_called_once()
+        call_kwargs = system_state.set_state.call_args
+        assert call_kwargs.kwargs.get("suppress_notification") is True
 
     async def test_reply_with_no_chat_id(self, receiver):
         """chat_id가 없어도 에러 없이 처리."""


### PR DESCRIPTION
## Summary
- `TelegramCommandReceiver`의 모든 서비스 호출부(`_cmd_approve`, `_cmd_reject`, `_handle_callback_query`, `_cmd_halt`, `_cmd_activate`, `_cmd_stop`)에 `suppress_notification=True` 전달
- 결재 명령 응답 메시지를 스펙(`docs/specs/approval.md`) 정의 형식으로 보강 (성공/실행실패/이미처리/미존재/만료 분기)
- 콜백 쿼리(인라인 버튼)의 에러 핸들링도 동일 형식으로 통일

## Test plan
- [x] `_cmd_approve` / `_cmd_reject`에서 `suppress_notification=True` 전달 검증
- [x] `_handle_callback_query`에서 approve/reject 모두 `suppress_notification=True` 전달 검증
- [x] `_cmd_halt` / `_cmd_activate`에서 `set_state(suppress_notification=True)` 전달 검증
- [x] `_cmd_stop`에서 `stop_bot(suppress_notification=True)` 전달 검증
- [x] 승인 성공/실행실패/미존재/이미처리 응답 형식 검증
- [x] 거절 성공/미존재/이미처리 응답 형식 검증
- [x] 전체 테스트 2122건 통과

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)