### PR TITLE
epic/515: 텔레그램 명령 중복 알림 방지

### DIFF
--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -138,6 +138,8 @@ class ApprovalService:
         self,
         id: str,
         resolved_by: str = "user",
+        *,
+        suppress_notification: bool = False,
     ) -> ApprovalRequest:
         """결재 승인 + 자동 실행."""
         request = await self.get(id)
@@ -178,7 +180,9 @@ class ApprovalService:
 
         logger.info("결재 승인: %s by %s", id, resolved_by)
 
-        await self._execute_approved(request, resolved_by)
+        await self._execute_approved(
+            request, resolved_by, suppress_notification=suppress_notification
+        )
 
         return request
 
@@ -187,6 +191,8 @@ class ApprovalService:
         id: str,
         resolved_by: str = "user",
         reject_reason: str = "",
+        *,
+        suppress_notification: bool = False,
     ) -> ApprovalRequest:
         """결재 거절."""
         request = await self.get(id)
@@ -244,9 +250,10 @@ class ApprovalService:
                 resolved_by=resolved_by,
             )
         )
-        await self._publish_resolved_notification(
-            id, request.type, ApprovalStatus.REJECTED, resolved_by
-        )
+        if not suppress_notification:
+            await self._publish_resolved_notification(
+                id, request.type, ApprovalStatus.REJECTED, resolved_by
+            )
 
         return request
 
@@ -704,7 +711,13 @@ class ApprovalService:
             )
         )
 
-    async def _execute_approved(self, request: ApprovalRequest, actor: str) -> None:
+    async def _execute_approved(
+        self,
+        request: ApprovalRequest,
+        actor: str,
+        *,
+        suppress_notification: bool = False,
+    ) -> None:
         """승인된 요청의 executor를 실행하고 결과를 반영한다.
 
         create()의 전결 실행과 approve()의 자동 실행에서 공유된다.
@@ -752,9 +765,10 @@ class ApprovalService:
                 resolved_by=actor,
             )
         )
-        await self._publish_resolved_notification(
-            request.id, request.type, request.status, actor
-        )
+        if not suppress_notification:
+            await self._publish_resolved_notification(
+                request.id, request.type, request.status, actor
+            )
 
     async def _publish_resolved_notification(
         self,

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -60,6 +60,7 @@ class BotManager:
         self._rule_engine = rule_engine
         self._strategy_rule_configs = strategy_rule_configs or {}
         self._bots: dict[str, Bot] = {}
+        self._suppress_notification_bot_ids: set[str] = set()
         self._restart_counts: dict[str, int] = {}
         self._restart_tasks: dict[str, asyncio.Task[None]] = {}
         self._restart_reset_tasks: dict[str, asyncio.Task[None]] = {}
@@ -290,9 +291,17 @@ class BotManager:
         self._load_strategy_rules(bot.config.strategy_id)
         await bot.start()
 
-    async def stop_bot(self, bot_id: str) -> None:
-        """봇 중지. 전략별 룰을 RuleEngine에서 제거."""
+    async def stop_bot(
+        self, bot_id: str, *, suppress_notification: bool = False
+    ) -> None:
+        """봇 중지. 전략별 룰을 RuleEngine에서 제거.
+
+        suppress_notification이 True이면 BotStoppedEvent에 의한
+        NotificationEvent 발행을 1회 억제한다.
+        """
         bot = self._get_bot(bot_id)
+        if suppress_notification:
+            self._suppress_notification_bot_ids.add(bot_id)
         await bot.stop()
         self._remove_strategy_rules(bot.config.strategy_id)
 
@@ -421,10 +430,13 @@ class BotManager:
         )
 
     async def _on_bot_stopped(self, event: object) -> None:
-        """봇 중지 알림 발행."""
+        """봇 중지 알림 발행. suppress 목록에 있으면 알림 생략."""
         from ante.eventbus.events import BotStoppedEvent, NotificationEvent
 
         if not isinstance(event, BotStoppedEvent):
+            return
+        if event.bot_id in self._suppress_notification_bot_ids:
+            self._suppress_notification_bot_ids.discard(event.bot_id)
             return
         await self._eventbus.publish(
             NotificationEvent(

--- a/src/ante/config/system_state.py
+++ b/src/ante/config/system_state.py
@@ -76,9 +76,22 @@ class SystemState:
         return self._state
 
     async def set_state(
-        self, state: TradingState, reason: str = "", changed_by: str = ""
+        self,
+        state: TradingState,
+        reason: str = "",
+        changed_by: str = "",
+        *,
+        suppress_notification: bool = False,
     ) -> None:
-        """거래 상태 변경. 인메모리 즉시 반영 + DB 영속화 + 이벤트 발행."""
+        """거래 상태 변경. 인메모리 즉시 반영 + DB 영속화 + 이벤트 발행.
+
+        Args:
+            state: 변경할 거래 상태.
+            reason: 변경 사유.
+            changed_by: 변경 주체.
+            suppress_notification: True이면 NotificationEvent 발행을 생략한다.
+                TradingStateChangedEvent(도메인 이벤트)는 항상 발행된다.
+        """
         from ante.eventbus.events import TradingStateChangedEvent
 
         old_state = self._state
@@ -109,16 +122,17 @@ class SystemState:
             )
         )
 
-        from ante.eventbus.events import NotificationEvent
+        if not suppress_notification:
+            from ante.eventbus.events import NotificationEvent
 
-        await self._eventbus.publish(
-            NotificationEvent(
-                level="critical",
-                title="거래 상태 변경",
-                message=(f"{old_state.value} → *{state.value}*\n사유: {reason}"),
-                category="system",
+            await self._eventbus.publish(
+                NotificationEvent(
+                    level="critical",
+                    title="거래 상태 변경",
+                    message=(f"{old_state.value} → *{state.value}*\n사유: {reason}"),
+                    category="system",
+                )
             )
-        )
         logger.info(
             "거래 상태 변경: %s → %s (사유: %s, 변경자: %s)",
             old_state,

--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -192,22 +192,53 @@ class TelegramCommandReceiver:
 
         try:
             if action == "approve":
-                await self._approval_service.approve(
-                    approval_id, resolved_by="telegram"
+                request = await self._approval_service.approve(
+                    approval_id,
+                    resolved_by="telegram",
+                    suppress_notification=True,
                 )
-                result_msg = f"결재 승인 완료: {approval_id}"
+                if request.status == "execution_failed":
+                    detail = ""
+                    for entry in reversed(request.history):
+                        if entry.get("action") == "execution_failed":
+                            detail = entry.get("detail", "")
+                            break
+                    result_msg = (
+                        f"⚠️ 승인되었으나 실행 실패\n"
+                        f"제목: {request.title}\n"
+                        f"ID: {approval_id}\n"
+                        f"사유: {detail}"
+                    )
+                else:
+                    result_msg = (
+                        f"✅ 결재 승인 완료\n제목: {request.title}\nID: {approval_id}"
+                    )
             elif action == "reject":
-                await self._approval_service.reject(
-                    approval_id, resolved_by="telegram", reject_reason="사용자 거절"
+                request = await self._approval_service.reject(
+                    approval_id,
+                    resolved_by="telegram",
+                    reject_reason="사용자 거절",
+                    suppress_notification=True,
                 )
-                result_msg = f"결재 거절 완료: {approval_id}"
+                result_msg = (
+                    f"❌ 결재 거절 완료\n"
+                    f"제목: {request.title}\n"
+                    f"ID: {approval_id}\n"
+                    f"사유: 사용자 거절"
+                )
             else:
                 await self._adapter.answer_callback_query(
                     callback_id, "알 수 없는 동작입니다."
                 )
                 return
         except ValueError as e:
-            result_msg = f"처리 실패: {e}"
+            err = str(e)
+            if "찾을 수 없음" in err:
+                result_msg = f"❌ 결재를 찾을 수 없습니다\nID: {approval_id}"
+            elif "만료" in err:
+                result_msg = f"ℹ️ 만료된 결재입니다\nID: {approval_id}"
+            else:
+                result_msg = f"ℹ️ 이미 처리된 결재입니다 ({err})\nID: {approval_id}"
         except Exception:
             logger.exception("콜백 결재 처리 오류: %s", data)
             result_msg = "처리 중 오류가 발생했습니다."
@@ -405,10 +436,32 @@ class TelegramCommandReceiver:
 
         approval_id = args[0]
         try:
-            await self._approval_service.approve(approval_id, resolved_by="telegram")
-            return f"결재 승인 완료: {approval_id}"
+            request = await self._approval_service.approve(
+                approval_id,
+                resolved_by="telegram",
+                suppress_notification=True,
+            )
+            if request.status == "execution_failed":
+                # executor 실행 실패 — history 마지막 항목에서 사유 추출
+                detail = ""
+                for entry in reversed(request.history):
+                    if entry.get("action") == "execution_failed":
+                        detail = entry.get("detail", "")
+                        break
+                return (
+                    f"⚠️ 승인되었으나 실행 실패\n"
+                    f"제목: {request.title}\n"
+                    f"ID: {approval_id}\n"
+                    f"사유: {detail}"
+                )
+            return f"✅ 결재 승인 완료\n제목: {request.title}\nID: {approval_id}"
         except ValueError as e:
-            return f"승인 실패: {e}"
+            err = str(e)
+            if "찾을 수 없음" in err:
+                return f"❌ 결재를 찾을 수 없습니다\nID: {approval_id}"
+            if "만료" in err:
+                return f"ℹ️ 만료된 결재입니다\nID: {approval_id}"
+            return f"ℹ️ 이미 처리된 결재입니다 ({err})\nID: {approval_id}"
         except Exception:
             logger.exception("결재 승인 오류: %s", approval_id)
             return "승인 처리 중 오류가 발생했습니다."
@@ -423,12 +476,25 @@ class TelegramCommandReceiver:
         approval_id = args[0]
         reason = " ".join(args[1:]) if len(args) > 1 else "사용자 거절"
         try:
-            await self._approval_service.reject(
-                approval_id, resolved_by="telegram", reject_reason=reason
+            request = await self._approval_service.reject(
+                approval_id,
+                resolved_by="telegram",
+                reject_reason=reason,
+                suppress_notification=True,
             )
-            return f"결재 거절 완료: {approval_id} (사유: {reason})"
+            return (
+                f"❌ 결재 거절 완료\n"
+                f"제목: {request.title}\n"
+                f"ID: {approval_id}\n"
+                f"사유: {reason}"
+            )
         except ValueError as e:
-            return f"거절 실패: {e}"
+            err = str(e)
+            if "찾을 수 없음" in err:
+                return f"❌ 결재를 찾을 수 없습니다\nID: {approval_id}"
+            if "만료" in err:
+                return f"ℹ️ 만료된 결재입니다\nID: {approval_id}"
+            return f"ℹ️ 이미 처리된 결재입니다 ({err})\nID: {approval_id}"
         except Exception:
             logger.exception("결재 거절 오류: %s", approval_id)
             return "거절 처리 중 오류가 발생했습니다."
@@ -442,7 +508,10 @@ class TelegramCommandReceiver:
 
         reason = " ".join(args) if args else "텔레그램 명령"
         await self._system_state.set_state(
-            TradingState.HALTED, reason=reason, changed_by="telegram"
+            TradingState.HALTED,
+            reason=reason,
+            changed_by="telegram",
+            suppress_notification=True,
         )
         return f"전체 거래가 중지되었습니다. (사유: {reason})"
 
@@ -454,7 +523,10 @@ class TelegramCommandReceiver:
         from ante.config.system_state import TradingState
 
         await self._system_state.set_state(
-            TradingState.ACTIVE, reason="텔레그램 명령", changed_by="telegram"
+            TradingState.ACTIVE,
+            reason="텔레그램 명령",
+            changed_by="telegram",
+            suppress_notification=True,
         )
         return "거래가 재개되었습니다."
 
@@ -471,7 +543,7 @@ class TelegramCommandReceiver:
         if not bot:
             return f"봇을 찾을 수 없습니다: {bot_id}"
 
-        await self._bot_manager.stop_bot(bot_id)
+        await self._bot_manager.stop_bot(bot_id, suppress_notification=True)
         return f"봇 {bot_id}이 중지되었습니다."
 
     # ── 유틸 ────────────────────────────────────────

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -16,7 +16,10 @@ from ante.approval.models import (
 from ante.approval.service import ApprovalService
 from ante.core.database import Database
 from ante.eventbus.bus import EventBus
-from ante.eventbus.events import ApprovalCreatedEvent, ApprovalResolvedEvent
+from ante.eventbus.events import (
+    ApprovalCreatedEvent,
+    ApprovalResolvedEvent,
+)
 
 # ── Fixtures ─────────────────────────────────────────
 
@@ -1336,3 +1339,106 @@ class TestReopen:
         assert approved.status == "approved"
         actions = [h["action"] for h in approved.history]
         assert actions == ["created", "rejected", "reopened", "approved"]
+
+
+# ── suppress_notification (#516) ───────────────────
+
+
+class TestSuppressNotification:
+    """suppress_notification=True 시 NotificationEvent 미발행, 도메인 이벤트는 유지."""
+
+    async def test_approve_suppress_skips_notification(self, service, eventbus):
+        """approve(suppress_notification=True) 시 NotificationEvent 미발행."""
+        from ante.eventbus.events import NotificationEvent
+
+        notifications: list[NotificationEvent] = []
+        resolved: list[ApprovalResolvedEvent] = []
+
+        async def on_notification(event: NotificationEvent) -> None:
+            if event.category == "approval" and event.title == "결재 처리 완료":
+                notifications.append(event)
+
+        async def on_resolved(event: ApprovalResolvedEvent) -> None:
+            resolved.append(event)
+
+        eventbus.subscribe(NotificationEvent, on_notification)
+        eventbus.subscribe(ApprovalResolvedEvent, on_resolved)
+
+        req = await service.create(
+            type="budget_change", requester="agent", title="알림 억제 테스트"
+        )
+        await service.approve(req.id, suppress_notification=True)
+
+        # 도메인 이벤트는 발행됨
+        assert len(resolved) == 1
+        assert resolved[0].resolution == "approved"
+
+        # NotificationEvent는 미발행
+        assert len(notifications) == 0
+
+    async def test_approve_default_sends_notification(self, service, eventbus):
+        """approve() 기본 동작은 NotificationEvent 발행."""
+        from ante.eventbus.events import NotificationEvent
+
+        notifications: list[NotificationEvent] = []
+
+        async def on_notification(event: NotificationEvent) -> None:
+            if event.category == "approval" and event.title == "결재 처리 완료":
+                notifications.append(event)
+
+        eventbus.subscribe(NotificationEvent, on_notification)
+
+        req = await service.create(
+            type="budget_change", requester="agent", title="기본 동작 테스트"
+        )
+        await service.approve(req.id)
+
+        assert len(notifications) == 1
+
+    async def test_reject_suppress_skips_notification(self, service, eventbus):
+        """reject(suppress_notification=True) 시 NotificationEvent 미발행."""
+        from ante.eventbus.events import NotificationEvent
+
+        notifications: list[NotificationEvent] = []
+        resolved: list[ApprovalResolvedEvent] = []
+
+        async def on_notification(event: NotificationEvent) -> None:
+            if event.category == "approval" and event.title == "결재 처리 완료":
+                notifications.append(event)
+
+        async def on_resolved(event: ApprovalResolvedEvent) -> None:
+            resolved.append(event)
+
+        eventbus.subscribe(NotificationEvent, on_notification)
+        eventbus.subscribe(ApprovalResolvedEvent, on_resolved)
+
+        req = await service.create(
+            type="budget_change", requester="agent", title="거절 알림 억제"
+        )
+        await service.reject(req.id, suppress_notification=True)
+
+        # 도메인 이벤트는 발행됨
+        assert len(resolved) == 1
+        assert resolved[0].resolution == "rejected"
+
+        # NotificationEvent는 미발행
+        assert len(notifications) == 0
+
+    async def test_reject_default_sends_notification(self, service, eventbus):
+        """reject() 기본 동작은 NotificationEvent 발행."""
+        from ante.eventbus.events import NotificationEvent
+
+        notifications: list[NotificationEvent] = []
+
+        async def on_notification(event: NotificationEvent) -> None:
+            if event.category == "approval" and event.title == "결재 처리 완료":
+                notifications.append(event)
+
+        eventbus.subscribe(NotificationEvent, on_notification)
+
+        req = await service.create(
+            type="budget_change", requester="agent", title="거절 기본 동작"
+        )
+        await service.reject(req.id)
+
+        assert len(notifications) == 1

--- a/tests/unit/test_bot_manager_methods.py
+++ b/tests/unit/test_bot_manager_methods.py
@@ -274,3 +274,75 @@ class TestResumeBot:
         """존재하지 않는 봇 재개 시 예외."""
         with pytest.raises(BotError, match="not found"):
             await manager.resume_bot("nonexistent")
+
+
+# ── stop_bot suppress_notification ──────────────
+
+
+class TestStopBotSuppressNotification:
+    async def test_suppress_false_publishes_notification(self, manager, eventbus, ctx):
+        """suppress_notification=False(기본값)이면 NotificationEvent가 발행된다."""
+        from ante.eventbus.events import NotificationEvent
+
+        notifications: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: notifications.append(e))
+
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+        await manager.stop_bot("bot1")
+
+        stop_notifs = [n for n in notifications if n.title == "봇 중지"]
+        assert len(stop_notifs) == 1
+
+    async def test_suppress_true_skips_notification(self, manager, eventbus, ctx):
+        """suppress_notification=True이면 NotificationEvent가 발행되지 않는다."""
+        from ante.eventbus.events import NotificationEvent
+
+        notifications: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: notifications.append(e))
+
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+        await manager.stop_bot("bot1", suppress_notification=True)
+
+        stop_notifs = [n for n in notifications if n.title == "봇 중지"]
+        assert len(stop_notifs) == 0
+
+    async def test_suppress_is_one_shot(self, manager, eventbus, ctx):
+        """suppress는 1회성이다. 두 번째 stop에서는 알림이 발행된다."""
+        from ante.eventbus.events import NotificationEvent
+
+        notifications: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: notifications.append(e))
+
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        # 1회차: suppress
+        await manager.start_bot("bot1")
+        await manager.stop_bot("bot1", suppress_notification=True)
+        stop_notifs_1 = [n for n in notifications if n.title == "봇 중지"]
+        assert len(stop_notifs_1) == 0
+
+        # 2회차: 기본값 (알림 발행)
+        await manager.start_bot("bot1")
+        await manager.stop_bot("bot1")
+        stop_notifs_2 = [n for n in notifications if n.title == "봇 중지"]
+        assert len(stop_notifs_2) == 1
+
+    async def test_suppress_preserves_bot_stopped_event(self, manager, eventbus, ctx):
+        """suppress_notification=True여도 BotStoppedEvent는 정상 발행된다."""
+        from ante.eventbus.events import BotStoppedEvent
+
+        stopped_events: list[BotStoppedEvent] = []
+        eventbus.subscribe(BotStoppedEvent, lambda e: stopped_events.append(e))
+
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+        await manager.stop_bot("bot1", suppress_notification=True)
+
+        assert len(stopped_events) == 1
+        assert stopped_events[0].bot_id == "bot1"

--- a/tests/unit/test_system_state.py
+++ b/tests/unit/test_system_state.py
@@ -97,6 +97,31 @@ async def test_state_history_recorded(state, db):
     assert rows[1]["new_state"] == "halted"
 
 
+async def test_suppress_notification_skips_notification_event(state, eventbus):
+    """suppress_notification=True이면 NotificationEvent를 발행하지 않는다."""
+    await state.set_state(
+        TradingState.HALTED, reason="silent", suppress_notification=True
+    )
+
+    # 도메인 이벤트(TradingStateChangedEvent)만 발행
+    assert len(eventbus.published) == 1
+    assert isinstance(eventbus.published[0], TradingStateChangedEvent)
+    assert eventbus.published[0].new_state == "halted"
+
+
+async def test_suppress_notification_false_publishes_both(state, eventbus):
+    """suppress_notification=False(기본값)이면 두 이벤트 모두 발행한다."""
+    from ante.eventbus.events import NotificationEvent
+
+    await state.set_state(
+        TradingState.REDUCING, reason="normal", suppress_notification=False
+    )
+
+    assert len(eventbus.published) == 2
+    assert isinstance(eventbus.published[0], TradingStateChangedEvent)
+    assert isinstance(eventbus.published[1], NotificationEvent)
+
+
 async def test_trading_state_enum_values():
     """TradingState enum 값 확인."""
     assert TradingState.ACTIVE == "active"

--- a/tests/unit/test_telegram_approval.py
+++ b/tests/unit/test_telegram_approval.py
@@ -17,6 +17,22 @@ from ante.notification.telegram_receiver import TelegramCommandReceiver
 # ── Fixtures ──────────────────────────────────────
 
 
+def _make_approval_request(
+    *,
+    approval_id: str = "abc123",
+    title: str = "테스트 결재",
+    status: str = "approved",
+    history: list | None = None,
+) -> MagicMock:
+    """ApprovalRequest mock 생성."""
+    req = MagicMock()
+    req.id = approval_id
+    req.title = title
+    req.status = status
+    req.history = history or []
+    return req
+
+
 @pytest.fixture
 def adapter():
     """TelegramAdapter mock."""
@@ -35,8 +51,8 @@ def adapter():
 def approval_service():
     """ApprovalService mock."""
     mock = MagicMock()
-    mock.approve = AsyncMock()
-    mock.reject = AsyncMock()
+    mock.approve = AsyncMock(return_value=_make_approval_request(status="approved"))
+    mock.reject = AsyncMock(return_value=_make_approval_request(status="rejected"))
     return mock
 
 
@@ -116,7 +132,7 @@ class TestCallbackQuery:
     """인라인 버튼 콜백 처리 테스트."""
 
     async def test_approve_callback(self, receiver, approval_service):
-        """approve 콜백이 ApprovalService.approve()를 호출한다."""
+        """approve 콜백이 suppress_notification=True로 호출한다."""
         update = {
             "callback_query": {
                 "id": "cb1",
@@ -129,11 +145,54 @@ class TestCallbackQuery:
         await receiver._handle_update(update)
 
         approval_service.approve.assert_called_once_with(
-            "abc123", resolved_by="telegram"
+            "abc123", resolved_by="telegram", suppress_notification=True
         )
 
+    async def test_approve_callback_response_format(self, receiver, approval_service):
+        """approve 콜백 성공 시 스펙 형식의 응답을 반환한다."""
+        approval_service.approve.return_value = _make_approval_request(
+            title="예산 증액", status="approved"
+        )
+        update = {
+            "callback_query": {
+                "id": "cb1",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "approve:abc123",
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
+
+        reply_text = receiver._reply.call_args[0][1]
+        assert "✅ 결재 승인 완료" in reply_text
+        assert "제목: 예산 증액" in reply_text
+        assert "ID: abc123" in reply_text
+
+    async def test_approve_callback_execution_failed(self, receiver, approval_service):
+        """approve 콜백 executor 실행 실패 시 경고 메시지."""
+        approval_service.approve.return_value = _make_approval_request(
+            title="봇 중지",
+            status="execution_failed",
+            history=[{"action": "execution_failed", "detail": "봇 미존재"}],
+        )
+        update = {
+            "callback_query": {
+                "id": "cb1",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "approve:abc123",
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
+
+        reply_text = receiver._reply.call_args[0][1]
+        assert "⚠️ 승인되었으나 실행 실패" in reply_text
+        assert "봇 미존재" in reply_text
+
     async def test_reject_callback(self, receiver, approval_service):
-        """reject 콜백이 ApprovalService.reject()를 호출한다."""
+        """reject 콜백이 suppress_notification=True로 호출한다."""
         update = {
             "callback_query": {
                 "id": "cb2",
@@ -146,8 +205,32 @@ class TestCallbackQuery:
         await receiver._handle_update(update)
 
         approval_service.reject.assert_called_once_with(
-            "abc123", resolved_by="telegram", reject_reason="사용자 거절"
+            "abc123",
+            resolved_by="telegram",
+            reject_reason="사용자 거절",
+            suppress_notification=True,
         )
+
+    async def test_reject_callback_response_format(self, receiver, approval_service):
+        """reject 콜백 성공 시 스펙 형식의 응답을 반환한다."""
+        approval_service.reject.return_value = _make_approval_request(
+            title="예산 증액", status="rejected"
+        )
+        update = {
+            "callback_query": {
+                "id": "cb2",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "reject:abc123",
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
+
+        reply_text = receiver._reply.call_args[0][1]
+        assert "❌ 결재 거절 완료" in reply_text
+        assert "제목: 예산 증액" in reply_text
+        assert "사유: 사용자 거절" in reply_text
 
     async def test_callback_unauthorized(self, receiver, adapter):
         """미인가 사용자의 콜백은 거부된다."""
@@ -192,8 +275,10 @@ class TestCallbackQuery:
         assert "알 수 없는" in adapter.answer_callback_query.call_args[0][1]
 
     async def test_callback_approve_error(self, receiver, approval_service, adapter):
-        """approve 실패 시 에러 메시지를 반환한다."""
-        approval_service.approve.side_effect = ValueError("pending 상태가 아님")
+        """approve ValueError 시 스펙 형식 에러 메시지를 반환한다."""
+        approval_service.approve.side_effect = ValueError(
+            "pending/execution_failed 상태에서만 승인 가능 (현재: approved)"
+        )
         update = {
             "callback_query": {
                 "id": "cb6",
@@ -204,8 +289,29 @@ class TestCallbackQuery:
         }
         receiver._reply = AsyncMock()
         await receiver._handle_update(update)
-        adapter.answer_callback_query.assert_called_once()
-        assert "실패" in adapter.answer_callback_query.call_args[0][1]
+        reply_text = receiver._reply.call_args[0][1]
+        assert "이미 처리된 결재입니다" in reply_text
+
+    async def test_callback_approve_not_found(
+        self, receiver, approval_service, adapter
+    ):
+        """approve 대상을 찾을 수 없을 때 스펙 형식 에러 메시지."""
+        approval_service.approve.side_effect = ValueError(
+            "결재 요청을 찾을 수 없음: abc123"
+        )
+        update = {
+            "callback_query": {
+                "id": "cb6",
+                "from": {"id": 12345},
+                "message": {"chat": {"id": 100}},
+                "data": "approve:abc123",
+            }
+        }
+        receiver._reply = AsyncMock()
+        await receiver._handle_update(update)
+        reply_text = receiver._reply.call_args[0][1]
+        assert "결재를 찾을 수 없습니다" in reply_text
+        assert "ID: abc123" in reply_text
 
     async def test_callback_no_approval_service(self, adapter):
         """approval_service 없으면 안내 메시지."""
@@ -247,12 +353,34 @@ class TestApproveRejectCommands:
     """텍스트 명령어 /approve, /reject 테스트."""
 
     async def test_approve_command(self, receiver, approval_service):
-        """/approve <id> 명령이 ApprovalService.approve()를 호출한다."""
+        """/approve <id> 명령이 suppress_notification=True로 호출한다."""
         result = await receiver._cmd_approve(["abc123"])
-        assert "승인 완료" in result
+        assert "✅ 결재 승인 완료" in result
         approval_service.approve.assert_called_once_with(
-            "abc123", resolved_by="telegram"
+            "abc123", resolved_by="telegram", suppress_notification=True
         )
+
+    async def test_approve_response_format(self, receiver, approval_service):
+        """/approve 성공 시 제목과 ID를 포함한 스펙 형식 응답."""
+        approval_service.approve.return_value = _make_approval_request(
+            title="봇 중지 요청", status="approved"
+        )
+        result = await receiver._cmd_approve(["abc123"])
+        assert "✅ 결재 승인 완료" in result
+        assert "제목: 봇 중지 요청" in result
+        assert "ID: abc123" in result
+
+    async def test_approve_execution_failed(self, receiver, approval_service):
+        """/approve executor 실행 실패 시 경고 형식 응답."""
+        approval_service.approve.return_value = _make_approval_request(
+            title="봇 중지 요청",
+            status="execution_failed",
+            history=[{"action": "execution_failed", "detail": "봇이 이미 중지됨"}],
+        )
+        result = await receiver._cmd_approve(["abc123"])
+        assert "⚠️ 승인되었으나 실행 실패" in result
+        assert "제목: 봇 중지 요청" in result
+        assert "사유: 봇이 이미 중지됨" in result
 
     async def test_approve_no_args(self, receiver):
         """/approve 인자 없으면 안내 메시지."""
@@ -267,25 +395,54 @@ class TestApproveRejectCommands:
         result = await r._cmd_approve(["abc123"])
         assert "연결되지 않았습니다" in result
 
-    async def test_approve_error(self, receiver, approval_service):
-        """approve 실패 시 에러 메시지."""
-        approval_service.approve.side_effect = ValueError("찾을 수 없음")
+    async def test_approve_not_found(self, receiver, approval_service):
+        """존재하지 않는 결재 ID에 대한 에러 메시지."""
+        approval_service.approve.side_effect = ValueError(
+            "결재 요청을 찾을 수 없음: abc123"
+        )
         result = await receiver._cmd_approve(["abc123"])
-        assert "실패" in result
+        assert "결재를 찾을 수 없습니다" in result
+        assert "ID: abc123" in result
+
+    async def test_approve_already_processed(self, receiver, approval_service):
+        """이미 처리된 결재에 대한 에러 메시지."""
+        approval_service.approve.side_effect = ValueError(
+            "pending/execution_failed 상태에서만 승인 가능 (현재: approved)"
+        )
+        result = await receiver._cmd_approve(["abc123"])
+        assert "이미 처리된 결재입니다" in result
+        assert "ID: abc123" in result
 
     async def test_reject_command(self, receiver, approval_service):
-        """/reject <id> [reason] 명령이 reject를 호출한다."""
+        """/reject <id> [reason] 명령이 suppress_notification=True로 호출한다."""
         result = await receiver._cmd_reject(["abc123", "리스크", "과다"])
-        assert "거절 완료" in result
+        assert "❌ 결재 거절 완료" in result
         approval_service.reject.assert_called_once_with(
-            "abc123", resolved_by="telegram", reject_reason="리스크 과다"
+            "abc123",
+            resolved_by="telegram",
+            reject_reason="리스크 과다",
+            suppress_notification=True,
         )
+
+    async def test_reject_response_format(self, receiver, approval_service):
+        """/reject 성공 시 스펙 형식 응답."""
+        approval_service.reject.return_value = _make_approval_request(
+            title="예산 변경", status="rejected"
+        )
+        result = await receiver._cmd_reject(["abc123", "리스크", "과다"])
+        assert "❌ 결재 거절 완료" in result
+        assert "제목: 예산 변경" in result
+        assert "ID: abc123" in result
+        assert "사유: 리스크 과다" in result
 
     async def test_reject_default_reason(self, receiver, approval_service):
         """/reject <id> 사유 미지정 시 기본 사유."""
         await receiver._cmd_reject(["abc123"])
         approval_service.reject.assert_called_once_with(
-            "abc123", resolved_by="telegram", reject_reason="사용자 거절"
+            "abc123",
+            resolved_by="telegram",
+            reject_reason="사용자 거절",
+            suppress_notification=True,
         )
 
     async def test_reject_no_args(self, receiver):
@@ -301,11 +458,21 @@ class TestApproveRejectCommands:
         result = await r._cmd_reject(["abc123"])
         assert "연결되지 않았습니다" in result
 
-    async def test_reject_error(self, receiver, approval_service):
-        """reject 실패 시 에러 메시지."""
-        approval_service.reject.side_effect = ValueError("이미 처리됨")
+    async def test_reject_not_found(self, receiver, approval_service):
+        """존재하지 않는 결재 ID에 대한 에러 메시지."""
+        approval_service.reject.side_effect = ValueError(
+            "결재 요청을 찾을 수 없음: abc123"
+        )
         result = await receiver._cmd_reject(["abc123"])
-        assert "실패" in result
+        assert "결재를 찾을 수 없습니다" in result
+
+    async def test_reject_already_processed(self, receiver, approval_service):
+        """이미 처리된 결재에 대한 에러 메시지."""
+        approval_service.reject.side_effect = ValueError(
+            "pending/execution_failed 상태에서만 거절 가능 (현재: rejected)"
+        )
+        result = await receiver._cmd_reject(["abc123"])
+        assert "이미 처리된 결재입니다" in result
 
     async def test_help_includes_approval_commands(self, receiver):
         """/help에 /approve, /reject 명령이 포함된다."""

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -216,6 +216,8 @@ class TestCommands:
         result = await receiver._cmd_activate([])
         assert "재개" in result
         system_state.set_state.assert_called_once()
+        call_kwargs = system_state.set_state.call_args
+        assert call_kwargs.kwargs.get("suppress_notification") is True
 
     async def test_activate_no_state(self, receiver):
         receiver._system_state = None
@@ -226,7 +228,9 @@ class TestCommands:
         result = await receiver._cmd_stop(["bot-1"])
         assert "중지" in result
         assert "bot-1" in result
-        bot_manager.stop_bot.assert_called_once_with("bot-1")
+        bot_manager.stop_bot.assert_called_once_with(
+            "bot-1", suppress_notification=True
+        )
 
     async def test_stop_bot_no_args(self, receiver):
         result = await receiver._cmd_stop([])
@@ -270,13 +274,17 @@ class TestConfirmation:
         result = await receiver._handle_confirm(12345)
         assert "중지되었습니다" in result
         system_state.set_state.assert_called_once()
+        call_kwargs = system_state.set_state.call_args
+        assert call_kwargs.kwargs.get("suppress_notification") is True
 
     async def test_confirm_executes_stop(self, receiver, bot_manager):
         """confirm으로 stop이 실행된다."""
         await receiver._execute("stop", ["bot-1"], 12345, 100)
         result = await receiver._handle_confirm(12345)
         assert "중지" in result
-        bot_manager.stop_bot.assert_called_once_with("bot-1")
+        bot_manager.stop_bot.assert_called_once_with(
+            "bot-1", suppress_notification=True
+        )
 
     async def test_confirm_no_pending(self, receiver):
         """대기 중인 명령이 없으면 안내 메시지."""
@@ -432,6 +440,8 @@ class TestIntegrationFlow:
         assert receiver._reply.call_count == 2
         assert "중지되었습니다" in receiver._reply.call_args[0][1]
         system_state.set_state.assert_called_once()
+        call_kwargs = system_state.set_state.call_args
+        assert call_kwargs.kwargs.get("suppress_notification") is True
 
     async def test_reply_with_no_chat_id(self, receiver):
         """chat_id가 없어도 에러 없이 처리."""


### PR DESCRIPTION
Refs #515

## 개요
텔레그램 명령으로 처리된 작업에서 동일 알림이 2번 수신되는 문제 해결. suppress_notification 패턴 적용.

## 하위 이슈 (4개, 모두 완료)
- #516 ✅ ApprovalService suppress_notification
- #517 ✅ SystemState suppress_notification  
- #518 ✅ BotManager suppress_notification
- #519 ✅ TelegramCommandReceiver 호출부 수정 + 응답 보강

🤖 Generated with [Claude Code](https://claude.com/claude-code)