### PR TITLE
epic/531: 텔레그램 명령 응답 메시지 스펙 적용

### DIFF
--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -336,6 +336,15 @@ class TelegramCommandReceiver:
 
         return "\n".join(parts)
 
+    _STATUS_KO: dict[str, str] = {
+        "created": "생성됨",
+        "running": "실행 중",
+        "stopping": "중지 중",
+        "stopped": "중지됨",
+        "error": "에러",
+        "deleted": "삭제됨",
+    }
+
     def _cmd_bots(self, args: list[str]) -> str:
         """봇 목록."""
         if not self._bot_manager:
@@ -345,14 +354,17 @@ class TelegramCommandReceiver:
         if not bots:
             return "등록된 봇이 없습니다."
 
+        running = sum(1 for b in bots if b["status"] == "running")
+        total = len(bots)
+
         lines = []
         for b in bots:
-            status = b["status"]
+            status_ko = self._STATUS_KO.get(b["status"], b["status"])
             bot_id = b["bot_id"]
             strategy = b.get("strategy_id", "-")
-            lines.append(f"  {bot_id} [{status}] {strategy}")
+            lines.append(f"  {bot_id} [{status_ko}] {strategy}")
 
-        return "봇 목록:\n" + "\n".join(lines)
+        return f"\U0001f916 봇 목록 ({running}/{total} 실행 중)\n" + "\n".join(lines)
 
     def _cmd_balance(self, args: list[str]) -> str:
         """자금 현황."""

--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -477,10 +477,13 @@ class TelegramCommandReceiver:
 
         from ante.config.system_state import TradingState
 
+        if self._system_state.trading_state == TradingState.ACTIVE:
+            return "이미 거래가 활성 상태입니다."
+
         await self._system_state.set_state(
             TradingState.ACTIVE, reason="텔레그램 명령", changed_by="telegram"
         )
-        return "거래가 재개되었습니다."
+        return "✅ 거래가 재개되었습니다."
 
     async def _cmd_stop(self, args: list[str]) -> str:
         """특정 봇 중지."""

--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -460,6 +460,8 @@ class TelegramCommandReceiver:
 
     async def _cmd_stop(self, args: list[str]) -> str:
         """특정 봇 중지."""
+        from ante.bot.config import BotStatus
+
         if not self._bot_manager:
             return "BotManager가 연결되지 않았습니다."
 
@@ -471,8 +473,35 @@ class TelegramCommandReceiver:
         if not bot:
             return f"봇을 찾을 수 없습니다: {bot_id}"
 
+        if bot.status != BotStatus.RUNNING:
+            return f"이미 중지된 봇입니다: {bot_id}"
+
+        # 중지 전 포지션·미체결 주문 조회
+        positions = bot._ctx.get_positions()
+        open_orders = bot._ctx.get_open_orders()
+
         await self._bot_manager.stop_bot(bot_id)
-        return f"봇 {bot_id}이 중지되었습니다."
+
+        bot_name = bot.config.name or bot_id
+        header = f"ℹ️ *봇 중지*\n\n봇: {bot_name} ({bot_id})\n상태: 실행 중 → 중지됨"
+
+        if not positions:
+            return f"{header}\n\n미체결 주문은 자동 취소되지 않습니다."
+
+        # 보유 종목 있음 — 메시지 B
+        symbols = sorted(positions.keys())
+        pending_amount = sum(order.get("amount", 0) for order in open_orders)
+
+        lines = [
+            header,
+            "",
+            f"⚠️ 보유 종목 {len(symbols)}개가 유지됩니다.",
+            "중지 후 포지션을 직접 관리해야 합니다.",
+            "",
+            f"보유: {', '.join(symbols)}",
+            f"체결대기: {pending_amount:,.0f}원",
+        ]
+        return "\n".join(lines)
 
     # ── 유틸 ────────────────────────────────────────
 

--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -234,8 +234,13 @@ class TelegramCommandReceiver:
         if command == "confirm":
             return await self._handle_confirm(user_id)
 
-        # 위험 명령 → 확인 절차
+        # 위험 명령 → 확인 절차 (이미 해당 상태이면 즉시 반환)
         if command in _DANGEROUS_COMMANDS:
+            if command == "halt" and self._system_state:
+                from ante.config.system_state import TradingState
+
+                if self._system_state.trading_state == TradingState.HALTED:
+                    return "이미 거래가 중지된 상태입니다."
             return self._request_confirmation(command, args, user_id)
 
         # 즉시 실행 명령
@@ -440,11 +445,18 @@ class TelegramCommandReceiver:
 
         from ante.config.system_state import TradingState
 
+        if self._system_state.trading_state == TradingState.HALTED:
+            return "이미 거래가 중지된 상태입니다."
+
         reason = " ".join(args) if args else "텔레그램 명령"
         await self._system_state.set_state(
             TradingState.HALTED, reason=reason, changed_by="telegram"
         )
-        return f"전체 거래가 중지되었습니다. (사유: {reason})"
+        return (
+            "\U0001f6a8 전체 거래가 중지되었습니다.\n"
+            f"사유: {reason}\n"
+            "해제하려면 /activate 를 입력하세요."
+        )
 
     async def _cmd_activate(self, args: list[str]) -> str:
         """거래 재개."""

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -20,6 +20,24 @@ def adapter():
     return mock
 
 
+def _make_running_bot(
+    bot_id: str = "bot-1",
+    name: str = "테스트봇",
+    positions: dict | None = None,
+    open_orders: list | None = None,
+):
+    """RUNNING 상태의 Bot mock 생성 헬퍼."""
+    from ante.bot.config import BotStatus
+
+    bot = MagicMock()
+    bot.bot_id = bot_id
+    bot.status = BotStatus.RUNNING
+    bot.config.name = name
+    bot._ctx.get_positions.return_value = positions or {}
+    bot._ctx.get_open_orders.return_value = open_orders or []
+    return bot
+
+
 @pytest.fixture
 def bot_manager():
     mock = MagicMock()
@@ -27,7 +45,7 @@ def bot_manager():
         {"bot_id": "bot-1", "status": "running", "strategy_id": "s1"},
         {"bot_id": "bot-2", "status": "stopped", "strategy_id": "s2"},
     ]
-    mock.get_bot.return_value = MagicMock()
+    mock.get_bot.return_value = _make_running_bot()
     mock.stop_bot = AsyncMock()
     return mock
 
@@ -222,11 +240,47 @@ class TestCommands:
         result = await receiver._cmd_activate([])
         assert "연결되지 않았습니다" in result
 
-    async def test_stop_bot(self, receiver, bot_manager):
+    async def test_stop_bot_no_positions(self, receiver, bot_manager):
+        """보유 종목 없이 봇 중지 — 메시지 A."""
         result = await receiver._cmd_stop(["bot-1"])
-        assert "중지" in result
-        assert "bot-1" in result
+        assert "봇 중지" in result
+        assert "테스트봇 (bot-1)" in result
+        assert "실행 중 → 중지됨" in result
+        assert "미체결 주문은 자동 취소되지 않습니다" in result
         bot_manager.stop_bot.assert_called_once_with("bot-1")
+
+    async def test_stop_bot_with_positions(self, receiver, bot_manager):
+        """보유 종목 있으면 메시지 B — 종목명 및 체결대기 금액 표시."""
+        bot = _make_running_bot(
+            positions={
+                "005930": {
+                    "symbol": "005930",
+                    "quantity": 10,
+                    "avg_entry_price": 70000,
+                },
+                "035720": {"symbol": "035720", "quantity": 5, "avg_entry_price": 50000},
+            },
+            open_orders=[{"amount": 500_000}, {"amount": 300_000}],
+        )
+        bot_manager.get_bot.return_value = bot
+        result = await receiver._cmd_stop(["bot-1"])
+        assert "봇 중지" in result
+        assert "보유 종목 2개가 유지됩니다" in result
+        assert "포지션을 직접 관리" in result
+        assert "005930" in result
+        assert "035720" in result
+        assert "800,000원" in result
+
+    async def test_stop_bot_already_stopped(self, receiver, bot_manager):
+        """이미 중지된 봇은 안내 메시지 반환."""
+        from ante.bot.config import BotStatus
+
+        bot = MagicMock()
+        bot.status = BotStatus.STOPPED
+        bot_manager.get_bot.return_value = bot
+        result = await receiver._cmd_stop(["bot-1"])
+        assert "이미 중지된 봇입니다" in result
+        bot_manager.stop_bot.assert_not_called()
 
     async def test_stop_bot_no_args(self, receiver):
         result = await receiver._cmd_stop([])
@@ -241,6 +295,13 @@ class TestCommands:
         receiver._bot_manager = None
         result = await receiver._cmd_stop(["bot-1"])
         assert "연결되지 않았습니다" in result
+
+    async def test_stop_bot_name_fallback(self, receiver, bot_manager):
+        """봇 이름이 빈 문자열이면 bot_id로 대체."""
+        bot = _make_running_bot(name="")
+        bot_manager.get_bot.return_value = bot
+        result = await receiver._cmd_stop(["bot-1"])
+        assert "bot-1 (bot-1)" in result
 
 
 # ── US-4: 2단계 확인 ─────────────────────────────
@@ -275,7 +336,8 @@ class TestConfirmation:
         """confirm으로 stop이 실행된다."""
         await receiver._execute("stop", ["bot-1"], 12345, 100)
         result = await receiver._handle_confirm(12345)
-        assert "중지" in result
+        assert "봇 중지" in result
+        assert "실행 중 → 중지됨" in result
         bot_manager.stop_bot.assert_called_once_with("bot-1")
 
     async def test_confirm_no_pending(self, receiver):

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -163,9 +163,11 @@ class TestCommands:
 
     async def test_bots(self, receiver):
         result = receiver._cmd_bots([])
-        assert "봇 목록" in result
+        assert "봇 목록 (1/2 실행 중)" in result
         assert "bot-1" in result
+        assert "[실행 중]" in result
         assert "bot-2" in result
+        assert "[중지됨]" in result
 
     async def test_bots_no_manager(self, receiver):
         receiver._bot_manager = None

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -492,8 +492,31 @@ class TestIntegrationFlow:
         }
         await receiver._handle_update(confirm_update)
         assert receiver._reply.call_count == 2
-        assert "중지되었습니다" in receiver._reply.call_args[0][1]
+        reply_text = receiver._reply.call_args[0][1]
+        assert "중지되었습니다" in reply_text
+        assert "/activate" in reply_text
         system_state.set_state.assert_called_once()
+
+    async def test_halt_already_halted(self, receiver, system_state):
+        """이미 HALTED 상태이면 중복 메시지를 반환한다."""
+        from ante.config.system_state import TradingState
+
+        system_state.trading_state = TradingState.HALTED
+        receiver._reply = AsyncMock()
+
+        halt_update = {
+            "message": {
+                "text": "/halt",
+                "from": {"id": 12345},
+                "chat": {"id": 100},
+            }
+        }
+        await receiver._handle_update(halt_update)
+
+        # confirm 없이 즉시 응답
+        assert receiver._reply.call_count == 1
+        assert "이미 거래가 중지된 상태입니다" in receiver._reply.call_args[0][1]
+        system_state.set_state.assert_not_called()
 
     async def test_reply_with_no_chat_id(self, receiver):
         """chat_id가 없어도 에러 없이 처리."""

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -68,9 +68,10 @@ def treasury():
 
 @pytest.fixture
 def system_state():
+    from ante.config.system_state import TradingState
+
     mock = MagicMock()
-    mock.trading_state = MagicMock()
-    mock.trading_state.value = "active"
+    mock.trading_state = TradingState.HALTED
     mock.set_state = AsyncMock()
     return mock
 
@@ -147,7 +148,7 @@ class TestCommands:
     async def test_status(self, receiver):
         result = receiver._cmd_status([])
         assert "거래 상태" in result
-        assert "active" in result
+        assert "halted" in result
         assert "봇" in result
 
     async def test_status_no_manager(self, receiver):
@@ -234,8 +235,16 @@ class TestCommands:
 
     async def test_activate(self, receiver, system_state):
         result = await receiver._cmd_activate([])
-        assert "재개" in result
+        assert "거래가 재개되었습니다" in result
         system_state.set_state.assert_called_once()
+
+    async def test_activate_already_active(self, receiver, system_state):
+        from ante.config.system_state import TradingState
+
+        system_state.trading_state = TradingState.ACTIVE
+        result = await receiver._cmd_activate([])
+        assert "이미 거래가 활성 상태입니다" in result
+        system_state.set_state.assert_not_called()
 
     async def test_activate_no_state(self, receiver):
         receiver._system_state = None


### PR DESCRIPTION
Refs #531

## 개요
텔레그램 명령 응답 메시지를 스펙 문서에 정의된 형식으로 통일. 상태값 한글화, 결과 분기, 포지션 정보 표시.

## 하위 이슈 (4개, 모두 완료)
- #529 ✅ /bots 응답 메시지 스펙 적용 (헤더, 상태값 한글화)
- #530 ✅ /stop 응답 메시지 스펙 적용 (포지션 분기)
- #540 ✅ /halt 응답 메시지 스펙 적용 (이미 중지됨 분기)
- #541 ✅ /activate 응답 메시지 스펙 적용 (이미 활성 분기)

🤖 Generated with [Claude Code](https://claude.com/claude-code)