### PR TITLE
feat(trade): Trade 모델에 account_id 추가

### DIFF
--- a/src/ante/trade/models.py
+++ b/src/ante/trade/models.py
@@ -43,6 +43,8 @@ class TradeRecord:
     timestamp: datetime | None = None
     order_id: str | None = None
     exchange: str = "KRX"
+    account_id: str = "default"
+    currency: str = "KRW"
 
 
 @dataclass
@@ -56,6 +58,7 @@ class PositionSnapshot:
     realized_pnl: float = 0.0
     updated_at: str = ""
     exchange: str = "KRX"
+    account_id: str = "default"
 
 
 @dataclass(frozen=True)

--- a/src/ante/trade/performance.py
+++ b/src/ante/trade/performance.py
@@ -41,6 +41,7 @@ class PerformanceTracker:
 
     async def calculate(
         self,
+        account_id: str | None = None,
         bot_id: str | None = None,
         strategy_id: str | None = None,
         from_date: datetime | None = None,
@@ -48,9 +49,10 @@ class PerformanceTracker:
     ) -> PerformanceMetrics:
         """성과 지표 계산.
 
-        bot_id 또는 strategy_id 중 하나 이상 필수.
+        account_id, bot_id, strategy_id 중 하나 이상 필수.
         """
         trades = await self._get_filled_trades(
+            account_id=account_id,
             bot_id=bot_id,
             strategy_id=strategy_id,
             from_date=from_date,
@@ -309,6 +311,7 @@ class PerformanceTracker:
 
     async def _get_filled_trades(
         self,
+        account_id: str | None = None,
         bot_id: str | None = None,
         strategy_id: str | None = None,
         from_date: datetime | None = None,
@@ -318,6 +321,9 @@ class PerformanceTracker:
         conditions: list[str] = ["status = ?"]
         params: list[Any] = [TradeStatus.FILLED.value]
 
+        if account_id:
+            conditions.append("account_id = ?")
+            params.append(account_id)
         if bot_id:
             conditions.append("bot_id = ?")
             params.append(bot_id)
@@ -384,6 +390,8 @@ class PerformanceTracker:
             commission=float(row.get("commission", 0)),
             timestamp=datetime.fromisoformat(ts) if ts else None,
             order_id=row.get("order_id"),
+            account_id=row.get("account_id", "default"),
+            currency=row.get("currency", "KRW"),
         )
 
     @staticmethod

--- a/src/ante/trade/position.py
+++ b/src/ante/trade/position.py
@@ -53,6 +53,7 @@ class PositionHistory:
         """스키마 생성 + 마이그레이션 + 캐시 워밍."""
         await self._db.execute_script(POSITION_SCHEMA)
         await self._migrate_exchange_column()
+        await self._migrate_account_id_column()
         await self._warm_cache()
         logger.info("PositionHistory 초기화 완료")
 
@@ -82,6 +83,18 @@ class PositionHistory:
             except Exception:
                 pass  # 이미 존재
 
+    async def _migrate_account_id_column(self) -> None:
+        """account_id 컬럼 마이그레이션."""
+        columns = await self._db.fetch_all("PRAGMA table_info(positions)")
+        col_names = {row["name"] for row in columns}
+
+        if "account_id" not in col_names:
+            await self._db.execute(
+                "ALTER TABLE positions ADD COLUMN"
+                " account_id TEXT NOT NULL DEFAULT 'default'"
+            )
+            logger.info("positions 테이블에 account_id 컬럼 추가")
+
     async def on_trade(self, record: TradeRecord) -> None:
         """체결 기록을 반영하여 포지션 상태 갱신."""
         if record.status != TradeStatus.FILLED:
@@ -102,6 +115,7 @@ class PositionHistory:
                 record.symbol,
                 quantity=new_quantity,
                 avg_entry_price=new_avg,
+                account_id=record.account_id,
             )
 
             await self._save_history(
@@ -127,6 +141,7 @@ class PositionHistory:
                 if new_quantity > 0
                 else 0.0,
                 realized_pnl_delta=pnl,
+                account_id=record.account_id,
             )
 
             await self._save_history(
@@ -229,17 +244,19 @@ class PositionHistory:
         quantity: float,
         avg_entry_price: float,
         realized_pnl_delta: float = 0.0,
+        account_id: str = "default",
     ) -> None:
         """포지션 상태 갱신."""
         await self._db.execute(
             """INSERT INTO positions
                (bot_id, symbol, quantity, avg_entry_price,
-                realized_pnl, updated_at)
-               VALUES (?, ?, ?, ?, ?, datetime('now'))
+                realized_pnl, updated_at, account_id)
+               VALUES (?, ?, ?, ?, ?, datetime('now'), ?)
                ON CONFLICT(bot_id, symbol) DO UPDATE SET
                  quantity = ?,
                  avg_entry_price = ?,
                  realized_pnl = realized_pnl + ?,
+                 account_id = ?,
                  updated_at = datetime('now')""",
             (
                 bot_id,
@@ -247,14 +264,16 @@ class PositionHistory:
                 quantity,
                 avg_entry_price,
                 realized_pnl_delta,
+                account_id,
                 quantity,
                 avg_entry_price,
                 realized_pnl_delta,
+                account_id,
             ),
         )
         # 인메모리 캐시 갱신
         self._update_cache(
-            bot_id, symbol, quantity, avg_entry_price, realized_pnl_delta
+            bot_id, symbol, quantity, avg_entry_price, realized_pnl_delta, account_id
         )
 
     def _update_cache(
@@ -264,6 +283,7 @@ class PositionHistory:
         quantity: float,
         avg_entry_price: float,
         realized_pnl_delta: float = 0.0,
+        account_id: str = "default",
     ) -> None:
         """인메모리 포지션 캐시 갱신."""
         bot_cache = self._position_cache.setdefault(bot_id, {})
@@ -277,6 +297,7 @@ class PositionHistory:
                 quantity=quantity,
                 avg_entry_price=avg_entry_price,
                 realized_pnl=prev_pnl + realized_pnl_delta,
+                account_id=account_id,
             )
         else:
             bot_cache.pop(symbol, None)
@@ -310,4 +331,5 @@ class PositionHistory:
             avg_entry_price=float(row["avg_entry_price"]),
             realized_pnl=float(row.get("realized_pnl", 0)),
             updated_at=row.get("updated_at", ""),
+            account_id=row.get("account_id", "default"),
         )

--- a/src/ante/trade/recorder.py
+++ b/src/ante/trade/recorder.py
@@ -52,6 +52,7 @@ class TradeRecorder:
         """스키마 생성 + 마이그레이션."""
         await self._db.execute_script(TRADE_SCHEMA)
         await self._migrate_exchange_column()
+        await self._migrate_account_columns()
         logger.info("TradeRecorder 초기화 완료")
 
     async def _migrate_exchange_column(self) -> None:
@@ -63,6 +64,24 @@ class TradeRecorder:
             logger.info("trades 테이블에 exchange 컬럼 추가")
         except Exception:
             pass  # 이미 존재
+
+    async def _migrate_account_columns(self) -> None:
+        """account_id, currency 컬럼 마이그레이션."""
+        columns = await self._db.fetch_all("PRAGMA table_info(trades)")
+        col_names = {row["name"] for row in columns}
+
+        if "account_id" not in col_names:
+            await self._db.execute(
+                "ALTER TABLE trades ADD COLUMN"
+                " account_id TEXT NOT NULL DEFAULT 'default'"
+            )
+            logger.info("trades 테이블에 account_id 컬럼 추가")
+
+        if "currency" not in col_names:
+            await self._db.execute(
+                "ALTER TABLE trades ADD COLUMN currency TEXT NOT NULL DEFAULT 'KRW'"
+            )
+            logger.info("trades 테이블에 currency 컬럼 추가")
 
     def subscribe(self, eventbus: EventBus) -> None:
         """이벤트 구독 등록."""
@@ -213,8 +232,9 @@ class TradeRecorder:
         await self._db.execute(
             """INSERT OR IGNORE INTO trades
                (trade_id, bot_id, strategy_id, symbol, side, quantity, price,
-                status, order_type, reason, commission, timestamp, order_id)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                status, order_type, reason, commission, timestamp, order_id,
+                account_id, currency)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 str(record.trade_id),
                 record.bot_id,
@@ -229,6 +249,8 @@ class TradeRecorder:
                 record.commission,
                 record.timestamp.isoformat() if record.timestamp else None,
                 record.order_id,
+                record.account_id,
+                record.currency,
             ),
         )
 
@@ -262,6 +284,7 @@ class TradeRecorder:
 
     async def get_trades(
         self,
+        account_id: str | None = None,
         bot_id: str | None = None,
         strategy_id: str | None = None,
         symbol: str | None = None,
@@ -275,6 +298,9 @@ class TradeRecorder:
         conditions: list[str] = []
         params: list[Any] = []
 
+        if account_id:
+            conditions.append("account_id = ?")
+            params.append(account_id)
         if bot_id:
             conditions.append("bot_id = ?")
             params.append(bot_id)
@@ -324,4 +350,6 @@ class TradeRecorder:
             commission=float(row.get("commission", 0)),
             timestamp=datetime.fromisoformat(ts) if ts else None,
             order_id=row.get("order_id"),
+            account_id=row.get("account_id", "default"),
+            currency=row.get("currency", "KRW"),
         )

--- a/src/ante/trade/service.py
+++ b/src/ante/trade/service.py
@@ -39,6 +39,7 @@ class TradeService:
 
     async def get_trades(
         self,
+        account_id: str | None = None,
         bot_id: str | None = None,
         strategy_id: str | None = None,
         symbol: str | None = None,
@@ -50,6 +51,7 @@ class TradeService:
     ) -> list[TradeRecord]:
         """거래 기록 조회."""
         return await self._recorder.get_trades(
+            account_id=account_id,
             bot_id=bot_id,
             strategy_id=strategy_id,
             symbol=symbol,
@@ -92,6 +94,7 @@ class TradeService:
 
     async def get_performance(
         self,
+        account_id: str | None = None,
         bot_id: str | None = None,
         strategy_id: str | None = None,
         from_date: datetime | None = None,
@@ -99,6 +102,7 @@ class TradeService:
     ) -> PerformanceMetrics:
         """성과 지표 조회."""
         return await self._performance.calculate(
+            account_id=account_id,
             bot_id=bot_id,
             strategy_id=strategy_id,
             from_date=from_date,

--- a/tests/unit/test_trade.py
+++ b/tests/unit/test_trade.py
@@ -789,3 +789,185 @@ class TestModels:
         assert m.total_trades == 0
         assert m.sharpe_ratio is None
         assert m.first_trade_at is None
+
+
+# ── Account ID 관련 테스트 ──────────────────────────
+
+
+class TestAccountIdFields:
+    """#563: TradeRecord, PositionSnapshot에 account_id, currency 필드 추가."""
+
+    def test_trade_record_with_account(self):
+        """account_id, currency 필드 포함 TradeRecord 생성."""
+        record = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.FILLED,
+            account_id="my-account",
+            currency="USD",
+        )
+        assert record.account_id == "my-account"
+        assert record.currency == "USD"
+
+    def test_trade_record_default_values(self):
+        """기본값 'default', 'KRW' 확인."""
+        record = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.FILLED,
+        )
+        assert record.account_id == "default"
+        assert record.currency == "KRW"
+
+    def test_position_snapshot_with_account(self):
+        """account_id 필드 포함 PositionSnapshot 생성."""
+        snapshot = PositionSnapshot(
+            bot_id="bot1",
+            symbol="005930",
+            quantity=10,
+            avg_entry_price=50000,
+            account_id="my-account",
+        )
+        assert snapshot.account_id == "my-account"
+
+    def test_position_snapshot_default_account(self):
+        """PositionSnapshot 기본 account_id 확인."""
+        snapshot = PositionSnapshot(
+            bot_id="bot1",
+            symbol="005930",
+            quantity=10,
+            avg_entry_price=50000,
+        )
+        assert snapshot.account_id == "default"
+
+
+class TestAccountIdDbMigration:
+    """#563: DB 마이그레이션으로 account_id, currency 컬럼 추가."""
+
+    async def test_trades_migration_adds_columns(self, db, recorder):
+        """trades 테이블에 account_id, currency 컬럼 존재 확인."""
+        columns = await db.fetch_all("PRAGMA table_info(trades)")
+        col_names = {row["name"] for row in columns}
+        assert "account_id" in col_names
+        assert "currency" in col_names
+
+    async def test_positions_migration_adds_column(self, db, position_history):
+        """positions 테이블에 account_id 컬럼 존재 확인."""
+        columns = await db.fetch_all("PRAGMA table_info(positions)")
+        col_names = {row["name"] for row in columns}
+        assert "account_id" in col_names
+
+    async def test_trade_record_saved_with_account_id(self, recorder, db):
+        """account_id, currency가 DB에 저장되는지 확인."""
+        record = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.FILLED,
+            account_id="acct-kr",
+            currency="KRW",
+            timestamp=datetime.now(UTC),
+        )
+        await recorder.save(record)
+
+        rows = await db.fetch_all("SELECT * FROM trades")
+        assert len(rows) == 1
+        assert rows[0]["account_id"] == "acct-kr"
+        assert rows[0]["currency"] == "KRW"
+
+    async def test_trade_record_read_with_account_id(self, recorder):
+        """조회한 TradeRecord에 account_id, currency가 포함되는지 확인."""
+        record = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.FILLED,
+            account_id="acct-kr",
+            currency="USD",
+            timestamp=datetime.now(UTC),
+        )
+        await recorder.save(record)
+
+        trades = await recorder.get_trades(bot_id="bot1")
+        assert len(trades) == 1
+        assert trades[0].account_id == "acct-kr"
+        assert trades[0].currency == "USD"
+
+    async def test_get_trades_filter_by_account_id(self, recorder):
+        """account_id로 거래 필터링."""
+        for acct in ("acct-1", "acct-2"):
+            record = TradeRecord(
+                trade_id=uuid4(),
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10,
+                price=50000,
+                status=TradeStatus.FILLED,
+                account_id=acct,
+                timestamp=datetime.now(UTC),
+            )
+            await recorder.save(record)
+
+        trades = await recorder.get_trades(account_id="acct-1")
+        assert len(trades) == 1
+        assert trades[0].account_id == "acct-1"
+
+    async def test_position_saved_with_account_id(self, position_history):
+        """포지션 갱신 시 account_id가 DB에 저장되는지 확인."""
+        record = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.FILLED,
+            account_id="acct-kr",
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(record)
+
+        positions = await position_history.get_positions("bot1")
+        assert len(positions) == 1
+        assert positions[0].account_id == "acct-kr"
+
+    async def test_position_cache_has_account_id(self, position_history):
+        """인메모리 캐시에도 account_id가 반영되는지 확인."""
+        record = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.FILLED,
+            account_id="acct-us",
+            timestamp=datetime.now(UTC),
+        )
+        await position_history.on_trade(record)
+
+        cached = position_history.get_positions_sync("bot1")
+        assert len(cached) == 1
+        assert cached[0].account_id == "acct-us"


### PR DESCRIPTION
## Summary

- `TradeRecord`에 `account_id`(기본값 `"default"`)와 `currency`(기본값 `"KRW"`) 필드 추가
- `PositionSnapshot`에 `account_id`(기본값 `"default"`) 필드 추가
- DB 마이그레이션: `PRAGMA table_info()` 확인 후 `ALTER TABLE`로 컬럼 추가 (SQLite IF NOT EXISTS 미지원 대응)
- `get_trades`, `calculate` 등 조회 메서드에 `account_id` 필터 파라미터 추가
- 인메모리 포지션 캐시에 `account_id` 반영
- 신규 테스트 11건 추가 (모델 필드, DB 마이그레이션, 저장/조회/필터)

Refs #563

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `src/ante/trade/models.py` | TradeRecord에 account_id, currency 추가. PositionSnapshot에 account_id 추가 |
| `src/ante/trade/recorder.py` | DB 마이그레이션 + INSERT/SELECT에 신규 컬럼 반영 + account_id 필터 |
| `src/ante/trade/position.py` | DB 마이그레이션 + _update_position/캐시에 account_id 반영 |
| `src/ante/trade/service.py` | get_trades, get_performance에 account_id 파라미터 추가 |
| `src/ante/trade/performance.py` | calculate, _get_filled_trades에 account_id 파라미터 추가 |
| `tests/unit/test_trade.py` | 신규 테스트 11건 추가 |

## Test plan

- [x] 기존 테스트 37건 통과 (기본값으로 호환)
- [x] 신규 테스트 11건 통과
- [x] ruff check + format 통과