### PR TITLE
feat(account): Account 모델·서비스·DB 스키마 생성

### DIFF
--- a/src/ante/account/__init__.py
+++ b/src/ante/account/__init__.py
@@ -1,0 +1,26 @@
+"""Account — 계좌 관리 모듈."""
+
+from ante.account.errors import (
+    AccountAlreadyExistsError,
+    AccountDeletedException,
+    AccountError,
+    AccountNotFoundError,
+    InvalidBrokerTypeError,
+)
+from ante.account.models import Account, AccountStatus, BrokerPreset, TradingMode
+from ante.account.presets import BROKER_PRESETS
+from ante.account.service import AccountService
+
+__all__ = [
+    "Account",
+    "AccountAlreadyExistsError",
+    "AccountDeletedException",
+    "AccountError",
+    "AccountNotFoundError",
+    "AccountService",
+    "AccountStatus",
+    "BROKER_PRESETS",
+    "BrokerPreset",
+    "InvalidBrokerTypeError",
+    "TradingMode",
+]

--- a/src/ante/account/errors.py
+++ b/src/ante/account/errors.py
@@ -1,0 +1,35 @@
+"""Account 모듈 예외."""
+
+
+class AccountError(Exception):
+    """Account 기본 예외."""
+
+    pass
+
+
+class AccountNotFoundError(AccountError):
+    """계좌를 찾을 수 없음."""
+
+    pass
+
+
+class AccountAlreadyExistsError(AccountError):
+    """동일 account_id가 이미 존재."""
+
+    pass
+
+
+class InvalidBrokerTypeError(AccountError):
+    """등록되지 않은 broker_type."""
+
+    pass
+
+
+class AccountDeletedError(AccountError):
+    """DELETED 상태 계좌에 대한 수정/활성화 시도."""
+
+    pass
+
+
+# 하위 호환용 별칭
+AccountDeletedException = AccountDeletedError

--- a/src/ante/account/models.py
+++ b/src/ante/account/models.py
@@ -1,0 +1,75 @@
+"""Account 데이터 모델."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from enum import StrEnum
+
+
+class AccountStatus(StrEnum):
+    """계좌 상태."""
+
+    ACTIVE = "active"
+    SUSPENDED = "suspended"
+    DELETED = "deleted"
+
+
+class TradingMode(StrEnum):
+    """거래 모드."""
+
+    VIRTUAL = "virtual"
+    LIVE = "live"
+
+
+@dataclass
+class Account:
+    """계좌 엔티티.
+
+    거래소, 통화, 브로커, 수수료, 인증 정보를 하나로 묶는 최상위 엔티티.
+    """
+
+    # --- 식별 ---
+    account_id: str
+    name: str
+
+    # --- 시장 ---
+    exchange: str
+    currency: str
+    timezone: str = "Asia/Seoul"
+    trading_hours_start: str = "09:00"
+    trading_hours_end: str = "15:30"
+
+    # --- 거래 모드 ---
+    trading_mode: TradingMode = TradingMode.VIRTUAL
+
+    # --- 브로커 ---
+    broker_type: str = "test"
+    credentials: dict[str, str] = field(default_factory=dict)
+
+    # --- 비용 ---
+    buy_commission_rate: Decimal = Decimal("0")
+    sell_commission_rate: Decimal = Decimal("0")
+
+    # --- 상태 ---
+    status: AccountStatus = AccountStatus.ACTIVE
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class BrokerPreset:
+    """브로커별 기본값 프리셋.
+
+    계좌 생성 시 브로커 선택만으로 나머지 필드를 자동으로 채운다.
+    """
+
+    exchange: str
+    currency: str
+    timezone: str
+    trading_hours_start: str
+    trading_hours_end: str
+    buy_commission_rate: Decimal
+    sell_commission_rate: Decimal
+    default_account_id: str
+    default_name: str
+    required_credentials: list[str]

--- a/src/ante/account/presets.py
+++ b/src/ante/account/presets.py
@@ -1,0 +1,46 @@
+"""브로커 프리셋 정의."""
+
+from decimal import Decimal
+
+from ante.account.models import BrokerPreset
+
+BROKER_PRESETS: dict[str, BrokerPreset] = {
+    "test": BrokerPreset(
+        exchange="TEST",
+        currency="KRW",
+        timezone="Asia/Seoul",
+        trading_hours_start="00:00",
+        trading_hours_end="23:59",
+        buy_commission_rate=Decimal("0"),
+        sell_commission_rate=Decimal("0"),
+        default_account_id="test",
+        default_name="테스트",
+        required_credentials=[],
+    ),
+    "kis-domestic": BrokerPreset(
+        exchange="KRX",
+        currency="KRW",
+        timezone="Asia/Seoul",
+        trading_hours_start="09:00",
+        trading_hours_end="15:30",
+        buy_commission_rate=Decimal("0.00015"),
+        sell_commission_rate=Decimal("0.00195"),
+        default_account_id="domestic",
+        default_name="국내 주식",
+        required_credentials=["app_key", "app_secret", "account_no"],
+    ),
+    # kis-overseas 프리셋은 정의만 해둔다.
+    # KISOverseasAdapter 구현 및 BROKER_REGISTRY 등록은 1.1에서 지원.
+    "kis-overseas": BrokerPreset(
+        exchange="NYSE",
+        currency="USD",
+        timezone="America/New_York",
+        trading_hours_start="09:30",
+        trading_hours_end="16:00",
+        buy_commission_rate=Decimal("0.001"),
+        sell_commission_rate=Decimal("0.001"),
+        default_account_id="us-stock",
+        default_name="미국 주식",
+        required_credentials=["app_key", "app_secret", "account_no"],
+    ),
+}

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -1,0 +1,448 @@
+"""AccountService — 계좌 CRUD 및 상태 관리."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+from ante.account.errors import (
+    AccountAlreadyExistsError,
+    AccountDeletedException,
+    AccountNotFoundError,
+    InvalidBrokerTypeError,
+)
+from ante.account.models import Account, AccountStatus, TradingMode
+from ante.account.presets import BROKER_PRESETS
+
+if TYPE_CHECKING:
+    from ante.broker.base import BrokerAdapter
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+# 브로커 어댑터 레지스트리 — broker_type → 어댑터 클래스
+# kis-overseas는 1.1에서 등록 예정
+_BROKER_REGISTRY: dict[str, type[BrokerAdapter]] = {}
+
+_CREATE_TABLE_SQL = """\
+CREATE TABLE IF NOT EXISTS accounts (
+    account_id   TEXT PRIMARY KEY,
+    name         TEXT NOT NULL,
+    exchange     TEXT NOT NULL,
+    currency     TEXT NOT NULL,
+    timezone     TEXT NOT NULL DEFAULT 'Asia/Seoul',
+    trading_hours_start TEXT NOT NULL DEFAULT '09:00',
+    trading_hours_end   TEXT NOT NULL DEFAULT '15:30',
+    trading_mode TEXT NOT NULL DEFAULT 'virtual'
+        CHECK(trading_mode IN ('virtual', 'live')),
+    broker_type  TEXT NOT NULL,
+    credentials  TEXT NOT NULL DEFAULT '{}',
+    buy_commission_rate  REAL NOT NULL DEFAULT 0,
+    sell_commission_rate REAL NOT NULL DEFAULT 0,
+    status       TEXT NOT NULL DEFAULT 'active'
+        CHECK(status IN ('active', 'suspended', 'deleted')),
+    created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
+);
+"""
+
+
+def _register_brokers() -> None:
+    """브로커 어댑터를 lazy 등록한다.
+
+    순환 import 방지를 위해 최초 호출 시 import한다.
+    """
+    if _BROKER_REGISTRY:
+        return
+
+    from ante.broker.kis import KISAdapter
+    from ante.broker.test import TestBrokerAdapter
+
+    _BROKER_REGISTRY["test"] = TestBrokerAdapter
+    _BROKER_REGISTRY["kis-domestic"] = KISAdapter
+
+
+class AccountService:
+    """계좌 CRUD, 상태 관리, 브로커 인스턴스 생성."""
+
+    def __init__(self, db: Database, eventbus: EventBus) -> None:
+        self._db = db
+        self._eventbus = eventbus
+        self._accounts: dict[str, Account] = {}
+        self._brokers: dict[str, BrokerAdapter] = {}
+
+    # ── 초기화 ──────────────────────────────────────────
+
+    async def initialize(self) -> None:
+        """스키마 생성 + DB에서 계좌 목록 로드."""
+        await self._db.execute_script(_CREATE_TABLE_SQL)
+        rows = await self._db.fetch_all(
+            "SELECT * FROM accounts WHERE status != ?",
+            (AccountStatus.DELETED,),
+        )
+        for row in rows:
+            account = _row_to_account(row)
+            self._accounts[account.account_id] = account
+        logger.info("AccountService 초기화 완료: %d개 계좌 로드", len(self._accounts))
+
+    # ── CRUD ──────────────────────────────────────────
+
+    async def create(self, account: Account) -> Account:
+        """계좌 생성.
+
+        Args:
+            account: 생성할 계좌 정보.
+
+        Returns:
+            생성된 Account (created_at, updated_at 포함).
+
+        Raises:
+            AccountAlreadyExistsError: 동일 account_id가 이미 존재.
+            InvalidBrokerTypeError: broker_type이 프리셋에 정의되지 않음.
+        """
+        if account.account_id in self._accounts:
+            raise AccountAlreadyExistsError(
+                f"계좌 '{account.account_id}'가 이미 존재합니다."
+            )
+
+        # broker_type 유효성 검증 (프리셋에 정의된 것만 허용)
+        if account.broker_type not in BROKER_PRESETS:
+            raise InvalidBrokerTypeError(
+                f"유효하지 않은 broker_type: '{account.broker_type}'. "
+                f"가능한 값: {list(BROKER_PRESETS.keys())}"
+            )
+
+        now = datetime.now(UTC)
+        account.created_at = now
+        account.updated_at = now
+
+        await self._db.execute(
+            """INSERT INTO accounts
+               (account_id, name, exchange, currency, timezone,
+                trading_hours_start, trading_hours_end, trading_mode,
+                broker_type, credentials, buy_commission_rate, sell_commission_rate,
+                status, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                account.account_id,
+                account.name,
+                account.exchange,
+                account.currency,
+                account.timezone,
+                account.trading_hours_start,
+                account.trading_hours_end,
+                account.trading_mode.value,
+                account.broker_type,
+                json.dumps(account.credentials),
+                float(account.buy_commission_rate),
+                float(account.sell_commission_rate),
+                account.status.value,
+                now.isoformat(),
+                now.isoformat(),
+            ),
+        )
+
+        self._accounts[account.account_id] = account
+        logger.info(
+            "계좌 생성: %s (%s/%s)",
+            account.account_id,
+            account.exchange,
+            account.broker_type,
+        )
+        return account
+
+    async def get(self, account_id: str) -> Account:
+        """계좌 조회. DELETED 상태도 조회 가능.
+
+        Raises:
+            AccountNotFoundError: 계좌를 찾을 수 없음.
+        """
+        # 메모리 캐시에서 먼저 검색
+        if account_id in self._accounts:
+            return self._accounts[account_id]
+
+        # DELETED 계좌는 메모리에 없으므로 DB에서 검색
+        row = await self._db.fetch_one(
+            "SELECT * FROM accounts WHERE account_id = ?",
+            (account_id,),
+        )
+        if row is None:
+            raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
+        return _row_to_account(row)
+
+    async def list(self, status: AccountStatus | None = None) -> list[Account]:
+        """계좌 목록 조회. DELETED 제외가 기본."""
+        if status is not None:
+            if status == AccountStatus.DELETED:
+                # DELETED는 DB에서 직접 조회
+                rows = await self._db.fetch_all(
+                    "SELECT * FROM accounts WHERE status = ?",
+                    (AccountStatus.DELETED,),
+                )
+                return [_row_to_account(row) for row in rows]
+            return [a for a in self._accounts.values() if a.status == status]
+        # 기본: DELETED 제외 (메모리 캐시에는 DELETED가 없음)
+        return list(self._accounts.values())
+
+    async def update(self, account_id: str, **fields: Any) -> Account:
+        """계좌 부분 수정. updated_at 자동 갱신.
+
+        Raises:
+            AccountNotFoundError: 계좌를 찾을 수 없음.
+            AccountDeletedException: DELETED 계좌는 수정 불가.
+        """
+        account = await self.get(account_id)
+        if account.status == AccountStatus.DELETED:
+            raise AccountDeletedException(
+                f"삭제된 계좌 '{account_id}'는 수정할 수 없습니다."
+            )
+
+        updatable = {
+            "name",
+            "exchange",
+            "currency",
+            "timezone",
+            "trading_hours_start",
+            "trading_hours_end",
+            "trading_mode",
+            "broker_type",
+            "credentials",
+            "buy_commission_rate",
+            "sell_commission_rate",
+        }
+        for key, value in fields.items():
+            if key not in updatable:
+                continue
+            setattr(account, key, value)
+
+        now = datetime.now(UTC)
+        account.updated_at = now
+
+        await self._db.execute(
+            """UPDATE accounts SET
+               name=?, exchange=?, currency=?, timezone=?,
+               trading_hours_start=?, trading_hours_end=?, trading_mode=?,
+               broker_type=?, credentials=?,
+               buy_commission_rate=?, sell_commission_rate=?,
+               updated_at=?
+               WHERE account_id=?""",
+            (
+                account.name,
+                account.exchange,
+                account.currency,
+                account.timezone,
+                account.trading_hours_start,
+                account.trading_hours_end,
+                account.trading_mode.value,
+                account.broker_type,
+                json.dumps(account.credentials),
+                float(account.buy_commission_rate),
+                float(account.sell_commission_rate),
+                now.isoformat(),
+                account_id,
+            ),
+        )
+
+        self._accounts[account_id] = account
+        logger.info("계좌 수정: %s", account_id)
+        return account
+
+    # ── 상태 전이 ──────────────────────────────────────
+
+    async def suspend(self, account_id: str, reason: str, suspended_by: str) -> None:
+        """계좌 정지 (status -> SUSPENDED).
+
+        Raises:
+            AccountNotFoundError: 계좌를 찾을 수 없음.
+        """
+        account = await self.get(account_id)
+        account.status = AccountStatus.SUSPENDED
+        account.updated_at = datetime.now(UTC)
+
+        await self._db.execute(
+            "UPDATE accounts SET status=?, updated_at=? WHERE account_id=?",
+            (AccountStatus.SUSPENDED, account.updated_at.isoformat(), account_id),
+        )
+
+        logger.info(
+            "계좌 정지: %s (사유: %s, 요청자: %s)",
+            account_id,
+            reason,
+            suspended_by,
+        )
+
+    async def activate(self, account_id: str, activated_by: str) -> None:
+        """계좌 활성화 (status -> ACTIVE).
+
+        Raises:
+            AccountNotFoundError: 계좌를 찾을 수 없음.
+            AccountDeletedException: DELETED 계좌는 활성화 불가.
+        """
+        account = await self.get(account_id)
+        if account.status == AccountStatus.DELETED:
+            raise AccountDeletedException(
+                f"삭제된 계좌 '{account_id}'는 활성화할 수 없습니다."
+            )
+
+        account.status = AccountStatus.ACTIVE
+        account.updated_at = datetime.now(UTC)
+
+        await self._db.execute(
+            "UPDATE accounts SET status=?, updated_at=? WHERE account_id=?",
+            (AccountStatus.ACTIVE, account.updated_at.isoformat(), account_id),
+        )
+
+        logger.info("계좌 활성화: %s (요청자: %s)", account_id, activated_by)
+
+    async def delete(self, account_id: str, deleted_by: str) -> None:
+        """소프트 딜리트 (status -> DELETED).
+
+        Raises:
+            AccountNotFoundError: 계좌를 찾을 수 없음.
+        """
+        account = await self.get(account_id)
+        account.status = AccountStatus.DELETED
+        account.updated_at = datetime.now(UTC)
+
+        await self._db.execute(
+            "UPDATE accounts SET status=?, updated_at=? WHERE account_id=?",
+            (AccountStatus.DELETED, account.updated_at.isoformat(), account_id),
+        )
+
+        # 메모리 캐시에서 제거
+        self._accounts.pop(account_id, None)
+        # 브로커 캐시에서도 제거
+        self._brokers.pop(account_id, None)
+
+        logger.info("계좌 삭제: %s (요청자: %s)", account_id, deleted_by)
+
+    # ── 일괄 상태 전이 ──────────────────────────────────
+
+    async def suspend_all(self, reason: str, suspended_by: str) -> int:
+        """모든 ACTIVE 계좌를 SUSPENDED로 전환. DELETED 제외.
+
+        Returns:
+            전환된 계좌 수.
+        """
+        count = 0
+        for account_id in list(self._accounts.keys()):
+            account = self._accounts[account_id]
+            if account.status == AccountStatus.ACTIVE:
+                await self.suspend(account_id, reason, suspended_by)
+                count += 1
+        logger.info("전체 계좌 정지: %d개 (사유: %s)", count, reason)
+        return count
+
+    async def activate_all(self, activated_by: str) -> int:
+        """모든 SUSPENDED 계좌를 ACTIVE로 복구. DELETED 제외.
+
+        Returns:
+            전환된 계좌 수.
+        """
+        count = 0
+        for account_id in list(self._accounts.keys()):
+            account = self._accounts[account_id]
+            if account.status == AccountStatus.SUSPENDED:
+                await self.activate(account_id, activated_by)
+                count += 1
+        logger.info("전체 계좌 활성화: %d개", count)
+        return count
+
+    # ── 브로커 인스턴스 ──────────────────────────────────
+
+    async def get_broker(self, account_id: str) -> BrokerAdapter:
+        """계좌의 BrokerAdapter 인스턴스를 반환. lazy init + 캐싱.
+
+        Raises:
+            AccountNotFoundError: 계좌를 찾을 수 없음.
+            InvalidBrokerTypeError: broker_type이 BROKER_REGISTRY에 등록되지 않음.
+        """
+        if account_id in self._brokers:
+            return self._brokers[account_id]
+
+        _register_brokers()
+
+        account = await self.get(account_id)
+        broker_cls = _BROKER_REGISTRY.get(account.broker_type)
+        if broker_cls is None:
+            raise InvalidBrokerTypeError(
+                f"broker_type '{account.broker_type}'은 BROKER_REGISTRY에 "
+                f"등록되지 않았습니다. 등록된 타입: {list(_BROKER_REGISTRY.keys())}"
+            )
+
+        config: dict[str, Any] = {
+            "exchange": account.exchange,
+            "trading_mode": account.trading_mode.value,
+            "buy_commission_rate": float(account.buy_commission_rate),
+            "sell_commission_rate": float(account.sell_commission_rate),
+            **account.credentials,
+        }
+
+        broker = broker_cls(config)
+        self._brokers[account_id] = broker
+        logger.info(
+            "브로커 인스턴스 생성: %s (type=%s)",
+            account_id,
+            account.broker_type,
+        )
+        return broker
+
+    # ── 기본 테스트 계좌 ──────────────────────────────────
+
+    async def create_default_test_account(self) -> Account:
+        """테스트 계좌 자동 생성. 이미 존재하면 기존 계좌 반환."""
+        if "test" in self._accounts:
+            return self._accounts["test"]
+
+        preset = BROKER_PRESETS["test"]
+        account = Account(
+            account_id=preset.default_account_id,
+            name=preset.default_name,
+            exchange=preset.exchange,
+            currency=preset.currency,
+            timezone=preset.timezone,
+            trading_hours_start=preset.trading_hours_start,
+            trading_hours_end=preset.trading_hours_end,
+            trading_mode=TradingMode.VIRTUAL,
+            broker_type="test",
+            credentials={},
+            buy_commission_rate=preset.buy_commission_rate,
+            sell_commission_rate=preset.sell_commission_rate,
+        )
+        return await self.create(account)
+
+
+# ── 유틸리티 ──────────────────────────────────────────
+
+
+def _row_to_account(row: dict[str, Any]) -> Account:
+    """DB 행을 Account 객체로 변환."""
+    credentials = row.get("credentials", "{}")
+    if isinstance(credentials, str):
+        credentials = json.loads(credentials)
+
+    return Account(
+        account_id=row["account_id"],
+        name=row["name"],
+        exchange=row["exchange"],
+        currency=row["currency"],
+        timezone=row["timezone"],
+        trading_hours_start=row["trading_hours_start"],
+        trading_hours_end=row["trading_hours_end"],
+        trading_mode=TradingMode(row["trading_mode"]),
+        broker_type=row["broker_type"],
+        credentials=credentials,
+        buy_commission_rate=Decimal(str(row["buy_commission_rate"])),
+        sell_commission_rate=Decimal(str(row["sell_commission_rate"])),
+        status=AccountStatus(row["status"]),
+        created_at=datetime.fromisoformat(row["created_at"])
+        if row.get("created_at")
+        else None,
+        updated_at=datetime.fromisoformat(row["updated_at"])
+        if row.get("updated_at")
+        else None,
+    )

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -1,0 +1,366 @@
+"""Account 모듈 단위 테스트."""
+
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+
+from ante.account.errors import (
+    AccountAlreadyExistsError,
+    AccountDeletedException,
+    AccountNotFoundError,
+    InvalidBrokerTypeError,
+)
+from ante.account.models import Account, AccountStatus, TradingMode
+from ante.account.presets import BROKER_PRESETS
+from ante.account.service import AccountService
+from ante.core.database import Database
+from ante.eventbus.bus import EventBus
+
+
+@pytest_asyncio.fixture
+async def db(tmp_path):
+    """테스트용 인메모리 DB."""
+    db_path = str(tmp_path / "test_account.db")
+    database = Database(db_path)
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+def eventbus():
+    """테스트용 EventBus."""
+    return EventBus()
+
+
+@pytest_asyncio.fixture
+async def service(db, eventbus):
+    """초기화된 AccountService."""
+    svc = AccountService(db, eventbus)
+    await svc.initialize()
+    return svc
+
+
+def _make_account(
+    account_id: str = "test",
+    name: str = "테스트",
+    exchange: str = "TEST",
+    currency: str = "KRW",
+    broker_type: str = "test",
+    **kwargs,
+) -> Account:
+    """테스트용 Account 생성 헬퍼."""
+    return Account(
+        account_id=account_id,
+        name=name,
+        exchange=exchange,
+        currency=currency,
+        broker_type=broker_type,
+        **kwargs,
+    )
+
+
+# ── 생성 (create) ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_account(service):
+    """계좌 생성 후 조회 가능."""
+    account = _make_account()
+    result = await service.create(account)
+
+    assert result.account_id == "test"
+    assert result.name == "테스트"
+    assert result.exchange == "TEST"
+    assert result.currency == "KRW"
+    assert result.broker_type == "test"
+    assert result.status == AccountStatus.ACTIVE
+    assert result.created_at is not None
+    assert result.updated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_create_duplicate_raises(service):
+    """중복 account_id 생성 시 에러."""
+    await service.create(_make_account())
+
+    with pytest.raises(AccountAlreadyExistsError):
+        await service.create(_make_account())
+
+
+@pytest.mark.asyncio
+async def test_create_invalid_broker_type_raises(service):
+    """잘못된 broker_type 생성 시 에러."""
+    account = _make_account(broker_type="nonexistent-broker")
+
+    with pytest.raises(InvalidBrokerTypeError):
+        await service.create(account)
+
+
+# ── 조회 (get / list) ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_account(service):
+    """계좌 조회 성공."""
+    await service.create(_make_account())
+
+    result = await service.get("test")
+    assert result.account_id == "test"
+
+
+@pytest.mark.asyncio
+async def test_get_not_found_raises(service):
+    """존재하지 않는 계좌 조회 시 에러."""
+    with pytest.raises(AccountNotFoundError):
+        await service.get("nonexistent")
+
+
+@pytest.mark.asyncio
+async def test_list_accounts(service):
+    """계좌 목록 조회."""
+    await service.create(_make_account("acc1", broker_type="test"))
+    await service.create(_make_account("acc2", broker_type="test"))
+
+    accounts = await service.list()
+    assert len(accounts) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_by_status(service):
+    """상태별 계좌 목록 필터."""
+    await service.create(_make_account("acc1"))
+    await service.create(_make_account("acc2"))
+    await service.suspend("acc2", reason="테스트", suspended_by="system")
+
+    active = await service.list(status=AccountStatus.ACTIVE)
+    suspended = await service.list(status=AccountStatus.SUSPENDED)
+
+    assert len(active) == 1
+    assert len(suspended) == 1
+    assert active[0].account_id == "acc1"
+    assert suspended[0].account_id == "acc2"
+
+
+# ── 수정 (update) ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_account(service):
+    """계좌 부분 수정."""
+    await service.create(_make_account())
+
+    result = await service.update("test", name="수정된 이름")
+    assert result.name == "수정된 이름"
+
+    # DB에서 다시 로드해도 동일
+    fetched = await service.get("test")
+    assert fetched.name == "수정된 이름"
+
+
+@pytest.mark.asyncio
+async def test_update_deleted_raises(service):
+    """삭제된 계좌 수정 시 에러."""
+    await service.create(_make_account())
+    await service.delete("test", deleted_by="system")
+
+    with pytest.raises(AccountDeletedException):
+        await service.update("test", name="변경 시도")
+
+
+# ── 정지/활성화 (suspend / activate) ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_suspend_account(service):
+    """계좌 정지."""
+    await service.create(_make_account())
+    await service.suspend("test", reason="위험 감지", suspended_by="rule-engine")
+
+    account = await service.get("test")
+    assert account.status == AccountStatus.SUSPENDED
+
+
+@pytest.mark.asyncio
+async def test_activate_account(service):
+    """정지된 계좌 활성화."""
+    await service.create(_make_account())
+    await service.suspend("test", reason="테스트", suspended_by="system")
+    await service.activate("test", activated_by="admin")
+
+    account = await service.get("test")
+    assert account.status == AccountStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_activate_deleted_raises(service):
+    """삭제된 계좌 활성화 시 에러."""
+    await service.create(_make_account())
+    await service.delete("test", deleted_by="system")
+
+    with pytest.raises(AccountDeletedException):
+        await service.activate("test", activated_by="admin")
+
+
+# ── 삭제 (delete) ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_account(service):
+    """계좌 소프트 딜리트."""
+    await service.create(_make_account())
+    await service.delete("test", deleted_by="admin")
+
+    # 기본 목록에서는 안 보임
+    accounts = await service.list()
+    assert len(accounts) == 0
+
+    # DELETED 상태도 조회 가능
+    deleted = await service.get("test")
+    assert deleted.status == AccountStatus.DELETED
+
+
+# ── 일괄 정지/활성화 (suspend_all / activate_all) ──────
+
+
+@pytest.mark.asyncio
+async def test_suspend_all(service):
+    """모든 ACTIVE 계좌 정지. DELETED 제외."""
+    await service.create(_make_account("acc1"))
+    await service.create(_make_account("acc2"))
+    await service.create(_make_account("acc3"))
+    await service.delete("acc3", deleted_by="system")
+
+    count = await service.suspend_all(reason="시스템 긴급 정지", suspended_by="system")
+
+    assert count == 2  # acc3 (DELETED) 제외
+    accounts = await service.list(status=AccountStatus.ACTIVE)
+    assert len(accounts) == 0
+
+
+@pytest.mark.asyncio
+async def test_activate_all(service):
+    """모든 SUSPENDED 계좌 활성화. DELETED 제외."""
+    await service.create(_make_account("acc1"))
+    await service.create(_make_account("acc2"))
+    await service.suspend("acc1", reason="테스트", suspended_by="system")
+    await service.suspend("acc2", reason="테스트", suspended_by="system")
+
+    count = await service.activate_all(activated_by="admin")
+
+    assert count == 2
+    accounts = await service.list(status=AccountStatus.ACTIVE)
+    assert len(accounts) == 2
+
+
+# ── 브로커 인스턴스 (get_broker) ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_broker_test(service):
+    """test broker_type으로 TestBrokerAdapter 반환."""
+    await service.create(_make_account())
+
+    broker = await service.get_broker("test")
+    assert broker.broker_id == "test"
+
+
+@pytest.mark.asyncio
+async def test_get_broker_cached(service):
+    """두 번 호출 시 같은 인스턴스 반환 (캐싱)."""
+    await service.create(_make_account())
+
+    broker1 = await service.get_broker("test")
+    broker2 = await service.get_broker("test")
+    assert broker1 is broker2
+
+
+@pytest.mark.asyncio
+async def test_get_broker_kis_overseas_raises(service):
+    """kis-overseas broker_type으로 get_broker 호출 시 에러 (REGISTRY 미등록)."""
+    account = _make_account(
+        account_id="us-stock",
+        exchange="NYSE",
+        currency="USD",
+        broker_type="kis-overseas",
+        timezone="America/New_York",
+        trading_hours_start="09:30",
+        trading_hours_end="16:00",
+    )
+    await service.create(account)
+
+    with pytest.raises(InvalidBrokerTypeError):
+        await service.get_broker("us-stock")
+
+
+# ── 기본 테스트 계좌 ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_default_test_account(service):
+    """기본 테스트 계좌 자동 생성."""
+    account = await service.create_default_test_account()
+
+    assert account.account_id == "test"
+    assert account.exchange == "TEST"
+    assert account.trading_mode == TradingMode.VIRTUAL
+    assert account.broker_type == "test"
+
+
+@pytest.mark.asyncio
+async def test_create_default_test_account_idempotent(service):
+    """이미 존재하면 기존 계좌 반환 (멱등성)."""
+    first = await service.create_default_test_account()
+    second = await service.create_default_test_account()
+
+    assert first.account_id == second.account_id
+
+
+# ── DB 영속성 ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_db_persistence(db, eventbus):
+    """서비스 재시작 후에도 DB에서 계좌 복원."""
+    svc1 = AccountService(db, eventbus)
+    await svc1.initialize()
+    await svc1.create(_make_account())
+
+    # 새 서비스 인스턴스로 재초기화
+    svc2 = AccountService(db, eventbus)
+    await svc2.initialize()
+
+    accounts = await svc2.list()
+    assert len(accounts) == 1
+    assert accounts[0].account_id == "test"
+
+
+# ── 프리셋 ──────────────────────────────────────────
+
+
+def test_broker_presets_defined():
+    """test, kis-domestic, kis-overseas 프리셋이 정의되어 있음."""
+    assert "test" in BROKER_PRESETS
+    assert "kis-domestic" in BROKER_PRESETS
+    assert "kis-overseas" in BROKER_PRESETS
+
+
+def test_broker_preset_test_values():
+    """test 프리셋 기본값 확인."""
+    preset = BROKER_PRESETS["test"]
+    assert preset.exchange == "TEST"
+    assert preset.currency == "KRW"
+    assert preset.buy_commission_rate == Decimal("0")
+    assert preset.sell_commission_rate == Decimal("0")
+    assert preset.required_credentials == []
+
+
+def test_broker_preset_kis_domestic_values():
+    """kis-domestic 프리셋 기본값 확인."""
+    preset = BROKER_PRESETS["kis-domestic"]
+    assert preset.exchange == "KRX"
+    assert preset.currency == "KRW"
+    assert preset.buy_commission_rate == Decimal("0.00015")
+    assert preset.sell_commission_rate == Decimal("0.00195")
+    assert "app_key" in preset.required_credentials


### PR DESCRIPTION
## Summary

Refs #560

Account 모듈을 신규 생성하여 계좌 중심 아키텍처의 기반을 마련한다.

### 구현 내용

- **모델**: `AccountStatus`, `TradingMode` StrEnum + `Account` dataclass + `BrokerPreset` frozen dataclass
- **프리셋**: `BROKER_PRESETS` - test, kis-domestic, kis-overseas (정의만, REGISTRY 미등록)
- **서비스**: `AccountService` - CRUD, suspend/activate/delete, get_broker (lazy init + 캐싱), suspend_all/activate_all, create_default_test_account
- **에러**: `AccountNotFoundError`, `AccountAlreadyExistsError`, `InvalidBrokerTypeError`, `AccountDeletedError`
- **DB**: `accounts` 테이블 CREATE IF NOT EXISTS (SQLite)
- **테스트**: 24개 단위 테스트 (create/get/list/update/suspend/activate/delete/suspend_all/activate_all/get_broker/presets/persistence)

### 파일 변경

| 파일 | 설명 |
|------|------|
| `src/ante/account/__init__.py` | 패키지 초기화, public API re-export |
| `src/ante/account/models.py` | AccountStatus, TradingMode, Account, BrokerPreset |
| `src/ante/account/presets.py` | BROKER_PRESETS 딕셔너리 |
| `src/ante/account/service.py` | AccountService 클래스 + _BROKER_REGISTRY |
| `src/ante/account/errors.py` | 모듈 전용 예외 클래스 |
| `tests/unit/test_account.py` | 24개 단위 테스트 |

## Test plan

- [x] 24개 단위 테스트 통과
- [x] 기존 2157개 unit 테스트 통과 (기존 5개 telegram 실패는 무관)
- [x] ruff check / format 통과