### PR TITLE
refactor(broker): KISAdapter → KISBaseAdapter + KISDomesticAdapter 분리

### DIFF
--- a/src/ante/bot/providers/paper.py
+++ b/src/ante/bot/providers/paper.py
@@ -136,8 +136,8 @@ class PaperExecutor:
         self._eventbus = eventbus
         self._gateway = gateway
         self._commission_info = CommissionInfo(
-            commission_rate=commission_rate,
-            sell_tax_rate=sell_tax_rate,
+            buy_commission_rate=commission_rate,
+            sell_commission_rate=commission_rate + sell_tax_rate,
         )
         self._slippage_rate = slippage_rate
         self._portfolios: dict[str, PaperPortfolioView] = {}

--- a/src/ante/broker/__init__.py
+++ b/src/ante/broker/__init__.py
@@ -10,29 +10,39 @@ from ante.broker.exceptions import (
     OrderNotFoundError,
     RateLimitError,
 )
-from ante.broker.kis import KISAdapter
+from ante.broker.kis import KISAdapter, KISBaseAdapter, KISDomesticAdapter
 from ante.broker.kis_stream import KISStreamClient
 from ante.broker.mock import MockBrokerAdapter
 from ante.broker.models import CommissionInfo
 from ante.broker.order_registry import OrderRegistry
+from ante.broker.registry import (
+    BROKER_REGISTRY,
+    InvalidBrokerTypeError,
+    get_broker_class,
+)
 from ante.broker.scheduler import ReconcileScheduler
 from ante.broker.test import TestBrokerAdapter
 
 __all__ = [
+    "APIError",
+    "AuthenticationError",
+    "BROKER_REGISTRY",
     "BrokerAdapter",
+    "BrokerError",
     "CircuitBreaker",
     "CircuitOpenError",
     "CircuitState",
     "CommissionInfo",
+    "InvalidBrokerTypeError",
     "KISAdapter",
+    "KISBaseAdapter",
+    "KISDomesticAdapter",
     "KISStreamClient",
     "MockBrokerAdapter",
+    "OrderNotFoundError",
     "OrderRegistry",
+    "RateLimitError",
     "ReconcileScheduler",
     "TestBrokerAdapter",
-    "BrokerError",
-    "AuthenticationError",
-    "APIError",
-    "OrderNotFoundError",
-    "RateLimitError",
+    "get_broker_class",
 ]

--- a/src/ante/broker/base.py
+++ b/src/ante/broker/base.py
@@ -24,6 +24,7 @@ class BrokerAdapter(ABC):
         self.config = config
         self.is_connected: bool = False
         self.exchange: str = config.get("exchange", "KRX")
+        self.currency: str = config.get("currency", "KRW")
 
     @abstractmethod
     async def connect(self) -> None:

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -2,12 +2,18 @@
 
 KIS REST API를 통해 주문, 조회를 처리한다.
 실행 시 aiohttp 패키지가 필요하다.
+
+계층 구조:
+    BrokerAdapter (ABC)
+    └── KISBaseAdapter (ABC) — KIS 공통 레이어 (인증, HTTP, 에러 처리)
+        └── KISDomesticAdapter — 국내주식 전용
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+from abc import abstractmethod
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -154,27 +160,27 @@ class KISRetryHandler:
         await asyncio.sleep(wait)
 
 
-class KISAdapter(BrokerAdapter):
-    """한국투자증권 Open API 어댑터."""
+# ── KISBaseAdapter — KIS 공통 레이어 ─────────────────────
 
-    broker_id: str = "kis"
-    broker_name: str = "한국투자증권"
-    broker_short_name: str = "KIS"
+
+class KISBaseAdapter(BrokerAdapter):
+    """KIS Open API 공통 레이어 (인증, HTTP, 에러 처리, 재시도, 서킷브레이커).
+
+    국내/해외 공통 로직을 추상화하는 중간 계층.
+    시장별 서브클래스(KISDomesticAdapter, KISOverseasAdapter)가 이를 상속한다.
+    """
 
     def __init__(
         self,
         config: dict[str, Any],
         eventbus: EventBus | None = None,
     ) -> None:
-        config.setdefault("exchange", "KRX")
         super().__init__(config)
 
         self.app_key: str = config["app_key"]
         self.app_secret: str = config["app_secret"]
         self.account_no: str = config["account_no"]
         self.is_paper: bool = config.get("is_paper", False)
-        self._commission_rate: float = config.get("commission_rate", 0.00015)
-        self._sell_tax_rate: float = config.get("sell_tax_rate", 0.0023)
         self._eventbus = eventbus
 
         # API 엔드포인트
@@ -236,6 +242,8 @@ class KISAdapter(BrokerAdapter):
     def circuit_breaker(self) -> CircuitBreaker:
         """Circuit breaker 접근자."""
         return self._circuit_breaker
+
+    # ── 연결 ───────────────────────────────────────
 
     async def connect(self) -> None:
         """KIS API 연결 및 인증."""
@@ -428,6 +436,111 @@ class KISAdapter(BrokerAdapter):
                     url, headers=headers, json=json_data
                 ) as resp:
                     return await self._handle_response(resp)
+
+    # ── 서브클래스 확장 포인트 ──────────────────────
+
+    @abstractmethod
+    async def get_account_balance(self) -> dict[str, float]:
+        """계좌 잔고 조회."""
+        ...
+
+    @abstractmethod
+    async def get_positions(self) -> list[dict[str, Any]]:
+        """보유 포지션 조회."""
+        ...
+
+    @abstractmethod
+    async def get_current_price(self, symbol: str) -> float:
+        """현재가 조회."""
+        ...
+
+    @abstractmethod
+    async def place_order(
+        self,
+        symbol: str,
+        side: str,
+        quantity: float,
+        order_type: str = "market",
+        price: float | None = None,
+        stop_price: float | None = None,
+    ) -> str:
+        """주문 접수."""
+        ...
+
+    @abstractmethod
+    async def cancel_order(self, order_id: str) -> bool:
+        """주문 취소."""
+        ...
+
+    @abstractmethod
+    async def get_order_status(self, order_id: str) -> dict[str, Any]:
+        """주문 상태 조회."""
+        ...
+
+    @abstractmethod
+    async def get_pending_orders(self) -> list[dict[str, Any]]:
+        """미체결 주문 목록 조회."""
+        ...
+
+    @abstractmethod
+    async def get_account_positions(self) -> list[dict[str, Any]]:
+        """대사용 보유 잔고 조회."""
+        ...
+
+    @abstractmethod
+    async def get_order_history(
+        self,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """주문/체결 이력 조회."""
+        ...
+
+    @abstractmethod
+    async def get_instruments(self, exchange: str = "KRX") -> list[dict[str, Any]]:
+        """종목 마스터 데이터 조회."""
+        ...
+
+    @abstractmethod
+    def get_commission_info(self) -> CommissionInfo:
+        """수수료율 정보 반환."""
+        ...
+
+
+# ── KISDomesticAdapter — 국내주식 전용 ────────────────────
+
+
+class KISDomesticAdapter(KISBaseAdapter):
+    """한국투자증권 국내주식 전용 어댑터.
+
+    KISBaseAdapter를 상속하여 국내주식 API 경로, 주문 파라미터,
+    시세 조회, 수수료 등 국내 전용 로직을 구현한다.
+    """
+
+    broker_id: str = "kis-domestic"
+    broker_name: str = "한국투자증권 국내"
+    broker_short_name: str = "KIS"
+
+    def __init__(
+        self,
+        config: dict[str, Any],
+        eventbus: EventBus | None = None,
+    ) -> None:
+        config.setdefault("exchange", "KRX")
+        config.setdefault("currency", "KRW")
+        super().__init__(config, eventbus)
+
+        # 수수료율 (buy/sell 분리)
+        self._buy_commission_rate: float = config.get(
+            "buy_commission_rate",
+            config.get("commission_rate", 0.00015),
+        )
+        self._sell_commission_rate: float = config.get(
+            "sell_commission_rate",
+            # 하위호환: commission_rate + sell_tax_rate
+            config.get("commission_rate", 0.00015)
+            + config.get("sell_tax_rate", 0.0018),
+        )
 
     # ── 계좌 정보 조회 ─────────────────────────────
 
@@ -759,10 +872,10 @@ class KISAdapter(BrokerAdapter):
     # ── 수수료 ────────────────────────────────────────
 
     def get_commission_info(self) -> CommissionInfo:
-        """KIS 수수료율 정보 반환."""
+        """KIS 국내 수수료율 정보 반환."""
         return CommissionInfo(
-            commission_rate=self._commission_rate,
-            sell_tax_rate=self._sell_tax_rate,
+            buy_commission_rate=self._buy_commission_rate,
+            sell_commission_rate=self._sell_commission_rate,
         )
 
     # ── 대사용 조회 ────────────────────────────────
@@ -824,3 +937,8 @@ class KISAdapter(BrokerAdapter):
                 }
             )
         return history
+
+
+# ── 하위호환 별칭 ─────────────────────────────────────
+# 기존 코드에서 KISAdapter를 참조하는 곳이 있으므로 별칭을 유지한다.
+KISAdapter = KISDomesticAdapter

--- a/src/ante/broker/mock.py
+++ b/src/ante/broker/mock.py
@@ -93,8 +93,8 @@ class MockBrokerAdapter(BrokerAdapter):
         self._default_price: float = config.get("default_price", 50_000.0)
 
         self._commission = CommissionInfo(
-            commission_rate=config.get("commission_rate", 0.00015),
-            sell_tax_rate=config.get("sell_tax_rate", 0.0023),
+            buy_commission_rate=config.get("buy_commission_rate", 0.00015),
+            sell_commission_rate=config.get("sell_commission_rate", 0.00195),
         )
 
     # ── 연결 ──────────────────────────────────────────

--- a/src/ante/broker/models.py
+++ b/src/ante/broker/models.py
@@ -9,19 +9,23 @@ from dataclasses import dataclass
 class CommissionInfo:
     """증권사별 수수료율 정보.
 
-    commission_rate: 매매 수수료율 (예: 0.00015 = 0.015%)
-    sell_tax_rate: 매도 세금율 (증권거래세 + 농특세, 예: 0.0023 = 0.23%)
+    buy_commission_rate: 매수 수수료율 (예: 0.00015 = 0.015%)
+    sell_commission_rate: 매도 수수료율 (세금 포함, 예: 0.00195 = 0.195%)
+
+    변경 이유: 기존 commission_rate + sell_tax_rate 분리 방식은 국내주식 전용이었다.
+    해외주식은 매도 세금 구조가 다르므로, 매수/매도 총비용을 각각 단일 필드로
+    표현하여 시장에 무관하게 동일한 인터페이스를 제공한다.
     """
 
-    commission_rate: float = 0.00015
-    sell_tax_rate: float = 0.0023
+    buy_commission_rate: float = 0.00015
+    sell_commission_rate: float = 0.00195
 
     def calculate(self, side: str, filled_value: float) -> float:
         """체결 금액 기반 수수료 계산.
 
-        매수: filled_value × commission_rate
-        매도: filled_value × (commission_rate + sell_tax_rate)
+        매수: filled_value × buy_commission_rate
+        매도: filled_value × sell_commission_rate
         """
         if side == "sell":
-            return filled_value * (self.commission_rate + self.sell_tax_rate)
-        return filled_value * self.commission_rate
+            return filled_value * self.sell_commission_rate
+        return filled_value * self.buy_commission_rate

--- a/src/ante/broker/registry.py
+++ b/src/ante/broker/registry.py
@@ -1,0 +1,51 @@
+"""Broker Registry — broker_type 문자열을 어댑터 클래스로 매핑.
+
+AccountService.get_broker()에서 계좌의 broker_type으로
+어댑터를 인스턴스화할 때 사용한다.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ante.broker.base import BrokerAdapter
+
+
+class InvalidBrokerTypeError(Exception):
+    """미등록 broker_type 요청 시 발생."""
+
+    def __init__(self, broker_type: str) -> None:
+        self.broker_type = broker_type
+        registered = ", ".join(sorted(BROKER_REGISTRY.keys()))
+        super().__init__(
+            f"미등록 broker_type: '{broker_type}'. 등록된 타입: [{registered}]"
+        )
+
+
+def _build_registry() -> dict[str, type[BrokerAdapter]]:
+    """지연 import로 순환 의존을 방지하면서 레지스트리를 구축한다."""
+    from ante.broker.kis import KISDomesticAdapter
+    from ante.broker.test import TestBrokerAdapter
+
+    return {
+        "test": TestBrokerAdapter,
+        "kis-domestic": KISDomesticAdapter,
+        # "kis-overseas"는 1.1에서 등록. 현재 미등록.
+    }
+
+
+# 모듈 로드 시 레지스트리 초기화
+BROKER_REGISTRY: dict[str, type[BrokerAdapter]] = _build_registry()
+
+
+def get_broker_class(broker_type: str) -> type[BrokerAdapter]:
+    """broker_type에 해당하는 어댑터 클래스를 반환한다.
+
+    Raises:
+        InvalidBrokerTypeError: 미등록 broker_type
+    """
+    cls = BROKER_REGISTRY.get(broker_type)
+    if cls is None:
+        raise InvalidBrokerTypeError(broker_type)
+    return cls

--- a/src/ante/broker/test.py
+++ b/src/ante/broker/test.py
@@ -221,7 +221,8 @@ class TestBrokerAdapter(BrokerAdapter):
     broker_short_name: str = "TEST"
 
     def __init__(self, config: dict[str, Any]) -> None:
-        config.setdefault("exchange", "KRX")
+        config.setdefault("exchange", "TEST")
+        config.setdefault("currency", "KRW")
         super().__init__(config)
 
         self._seed: int = config.get("seed", 42)
@@ -237,10 +238,10 @@ class TestBrokerAdapter(BrokerAdapter):
         self._positions: dict[str, _TestPosition] = {}
         self._orders: dict[str, _TestOrder] = {}
 
-        # 수수료 (KIS 동일)
+        # 수수료 (buy/sell 분리)
         self._commission = CommissionInfo(
-            commission_rate=config.get("commission_rate", 0.00015),
-            sell_tax_rate=config.get("sell_tax_rate", 0.0023),
+            buy_commission_rate=config.get("buy_commission_rate", 0.0),
+            sell_commission_rate=config.get("sell_commission_rate", 0.0),
         )
 
     # ── 연결 ──────────────────────────────────────────────

--- a/tests/unit/test_broker_adapter_split.py
+++ b/tests/unit/test_broker_adapter_split.py
@@ -1,0 +1,357 @@
+"""Broker 어댑터 분리 테스트 (KISBase + KISDomestic + Registry).
+
+이슈 #561: KISAdapter → KISBaseAdapter + KISDomesticAdapter 분리,
+CommissionInfo buy/sell 분리, BROKER_REGISTRY 신규 생성.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ante.broker.base import BrokerAdapter
+from ante.broker.kis import KISAdapter, KISBaseAdapter, KISDomesticAdapter
+from ante.broker.mock import MockBrokerAdapter
+from ante.broker.models import CommissionInfo
+from ante.broker.registry import (
+    BROKER_REGISTRY,
+    InvalidBrokerTypeError,
+    get_broker_class,
+)
+from ante.broker.test import TestBrokerAdapter
+
+# ── CommissionInfo buy/sell 분리 ────────────────────────
+
+
+class TestCommissionInfoBuySell:
+    """CommissionInfo가 buy_commission_rate / sell_commission_rate로 분리되었다."""
+
+    def test_defaults(self):
+        """기본값: buy=0.015%, sell=0.195%."""
+        info = CommissionInfo()
+        assert info.buy_commission_rate == 0.00015
+        assert info.sell_commission_rate == 0.00195
+
+    def test_custom_rates(self):
+        """커스텀 수수료율."""
+        info = CommissionInfo(buy_commission_rate=0.001, sell_commission_rate=0.002)
+        assert info.buy_commission_rate == 0.001
+        assert info.sell_commission_rate == 0.002
+
+    def test_frozen(self):
+        """불변 객체."""
+        info = CommissionInfo()
+        with pytest.raises(AttributeError):
+            info.buy_commission_rate = 0.001  # type: ignore[misc]
+
+    def test_buy_calculation(self):
+        """매수 수수료: filled_value * buy_commission_rate."""
+        info = CommissionInfo(buy_commission_rate=0.00015, sell_commission_rate=0.00195)
+        commission = info.calculate("buy", 1_000_000.0)
+        assert commission == pytest.approx(150.0)
+
+    def test_sell_calculation(self):
+        """매도 수수료: filled_value * sell_commission_rate."""
+        info = CommissionInfo(buy_commission_rate=0.00015, sell_commission_rate=0.00195)
+        commission = info.calculate("sell", 1_000_000.0)
+        assert commission == pytest.approx(1_950.0)
+
+    def test_sell_higher_than_buy(self):
+        """기본 설정에서 매도 수수료가 매수보다 높다."""
+        info = CommissionInfo()
+        buy_fee = info.calculate("buy", 1_000_000.0)
+        sell_fee = info.calculate("sell", 1_000_000.0)
+        assert sell_fee > buy_fee
+
+    def test_zero_amount(self):
+        """0원 체결 → 수수료 0."""
+        info = CommissionInfo()
+        assert info.calculate("buy", 0.0) == 0.0
+        assert info.calculate("sell", 0.0) == 0.0
+
+    def test_equal_buy_sell_rates(self):
+        """해외주식처럼 buy/sell 동일 수수료."""
+        info = CommissionInfo(buy_commission_rate=0.001, sell_commission_rate=0.001)
+        buy_fee = info.calculate("buy", 1_000_000.0)
+        sell_fee = info.calculate("sell", 1_000_000.0)
+        assert buy_fee == pytest.approx(sell_fee)
+
+
+# ── BrokerAdapter ABC currency 속성 ──────────────────
+
+
+class TestBrokerAdapterCurrency:
+    """BrokerAdapter ABC에 currency 속성이 추가되었다."""
+
+    def test_default_currency(self):
+        """기본 currency는 KRW."""
+        adapter = MockBrokerAdapter({"exchange": "KRX"})
+        assert adapter.currency == "KRW"
+
+    def test_custom_currency(self):
+        """config에서 currency 지정."""
+        adapter = MockBrokerAdapter({"exchange": "NYSE", "currency": "USD"})
+        assert adapter.currency == "USD"
+
+
+# ── KISBaseAdapter + KISDomesticAdapter 계층 ─────────
+
+
+class TestKISAdapterHierarchy:
+    """KISBaseAdapter → KISDomesticAdapter 계층 구조."""
+
+    def test_kis_base_is_abstract(self):
+        """KISBaseAdapter는 직접 인스턴스화 불가 (ABC)."""
+        with pytest.raises(TypeError):
+            KISBaseAdapter(  # type: ignore[abstract]
+                {"app_key": "k", "app_secret": "s", "account_no": "1234567801"}
+            )
+
+    def test_kis_domestic_inherits_base(self):
+        """KISDomesticAdapter는 KISBaseAdapter를 상속한다."""
+        assert issubclass(KISDomesticAdapter, KISBaseAdapter)
+        assert issubclass(KISDomesticAdapter, BrokerAdapter)
+
+    def test_kis_adapter_alias(self):
+        """KISAdapter는 KISDomesticAdapter의 별칭이다."""
+        assert KISAdapter is KISDomesticAdapter
+
+
+class TestKISDomesticAdapterMeta:
+    """KISDomesticAdapter 메타정보."""
+
+    def test_broker_id(self):
+        assert KISDomesticAdapter.broker_id == "kis-domestic"
+
+    def test_broker_name(self):
+        assert KISDomesticAdapter.broker_name == "한국투자증권 국내"
+
+    def test_broker_short_name(self):
+        assert KISDomesticAdapter.broker_short_name == "KIS"
+
+
+KIS_CONFIG = {
+    "app_key": "test_key",
+    "app_secret": "test_secret",
+    "account_no": "1234567801",
+    "is_paper": True,
+}
+
+
+class TestKISDomesticAdapterInit:
+    """KISDomesticAdapter 초기화."""
+
+    def test_paper_mode(self):
+        """모의투자 모드."""
+        adapter = KISDomesticAdapter(KIS_CONFIG)
+        assert adapter.is_paper is True
+        assert "openapivts" in adapter.base_url
+        assert adapter._rate_limit_per_minute == 5
+        assert adapter.currency == "KRW"
+        assert adapter.exchange == "KRX"
+
+    def test_live_mode(self):
+        """실전투자 모드."""
+        config = {**KIS_CONFIG, "is_paper": False}
+        adapter = KISDomesticAdapter(config)
+        assert adapter.is_paper is False
+        assert "openapi.koreainvestment" in adapter.base_url
+        assert adapter._rate_limit_per_minute == 20
+
+    def test_commission_info_buy_sell(self):
+        """수수료율이 buy/sell로 분리된다."""
+        adapter = KISDomesticAdapter(KIS_CONFIG)
+        info = adapter.get_commission_info()
+        assert isinstance(info, CommissionInfo)
+        assert info.buy_commission_rate == 0.00015
+        # 기본: commission_rate(0.00015) + sell_tax_rate(0.0018)
+        assert info.sell_commission_rate == pytest.approx(0.00195)
+
+    def test_custom_buy_sell_commission(self):
+        """config에서 buy/sell 수수료율 직접 지정."""
+        config = {
+            **KIS_CONFIG,
+            "buy_commission_rate": 0.001,
+            "sell_commission_rate": 0.002,
+        }
+        adapter = KISDomesticAdapter(config)
+        info = adapter.get_commission_info()
+        assert info.buy_commission_rate == 0.001
+        assert info.sell_commission_rate == 0.002
+
+    def test_backward_compat_commission_rate(self):
+        """기존 commission_rate + sell_tax_rate 방식도 하위호환 지원."""
+        config = {
+            **KIS_CONFIG,
+            "commission_rate": 0.0001,
+            "sell_tax_rate": 0.002,
+        }
+        adapter = KISDomesticAdapter(config)
+        info = adapter.get_commission_info()
+        assert info.buy_commission_rate == 0.0001
+        assert info.sell_commission_rate == pytest.approx(0.0021)
+
+
+class TestKISDomesticAdapterMapping:
+    """KISDomesticAdapter 매핑 메서드."""
+
+    def test_map_order_type(self):
+        adapter = KISDomesticAdapter(KIS_CONFIG)
+        assert adapter._map_order_type("market") == "01"
+        assert adapter._map_order_type("limit") == "00"
+        assert adapter._map_order_type("unknown") == "01"
+
+    def test_map_order_status(self):
+        adapter = KISDomesticAdapter(KIS_CONFIG)
+        assert adapter._map_order_status("10") == "pending"
+        assert adapter._map_order_status("30") == "filled"
+        assert adapter._map_order_status("40") == "cancelled"
+        assert adapter._map_order_status("99") == "unknown"
+
+    def test_build_order_data_market(self):
+        adapter = KISDomesticAdapter(KIS_CONFIG)
+        data = adapter._build_order_data("005930", "buy", 10.0, "market", None)
+        assert data["PDNO"] == "005930"
+        assert data["ORD_DVSN"] == "01"
+        assert data["ORD_QTY"] == "10"
+        assert data["ORD_UNPR"] == "0"
+
+    def test_build_order_data_limit(self):
+        adapter = KISDomesticAdapter(KIS_CONFIG)
+        data = adapter._build_order_data("005930", "buy", 5.0, "limit", 70000.0)
+        assert data["ORD_DVSN"] == "00"
+        assert data["ORD_UNPR"] == "70000"
+
+    def test_balance_params(self):
+        adapter = KISDomesticAdapter(KIS_CONFIG)
+        params = adapter._balance_params()
+        assert params["CANO"] == "12345678"
+        assert params["ACNT_PRDT_CD"] == "01"
+
+
+class TestKISDomesticAdapterAPI:
+    """KISDomesticAdapter API 호출 테스트."""
+
+    @pytest.fixture
+    def adapter(self):
+        a = KISDomesticAdapter(KIS_CONFIG)
+        a.access_token = "test_token"
+        a.token_expires_at = datetime.now(UTC) + timedelta(hours=23)
+        a.is_connected = True
+        return a
+
+    def _mock_response(self, json_data: dict, status: int = 200) -> AsyncMock:
+        resp = AsyncMock()
+        resp.status = status
+        resp.json = AsyncMock(return_value=json_data)
+        resp.text = AsyncMock(return_value="error text")
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+        return resp
+
+    async def test_place_order_stop_raises(self, adapter):
+        """stop 주문 시 ValueError."""
+        with pytest.raises(ValueError, match="stop"):
+            await adapter.place_order("005930", "buy", 10, order_type="stop")
+
+
+# ── TestBrokerAdapter 정비 ────────────────────────────
+
+
+class TestTestBrokerAdapterUpdate:
+    """TestBrokerAdapter가 새 CommissionInfo를 사용한다."""
+
+    def test_default_exchange_test(self):
+        """기본 exchange는 TEST."""
+        adapter = TestBrokerAdapter({})
+        assert adapter.exchange == "TEST"
+
+    def test_default_currency_krw(self):
+        """기본 currency는 KRW."""
+        adapter = TestBrokerAdapter({})
+        assert adapter.currency == "KRW"
+
+    def test_zero_commission(self):
+        """test 브로커는 기본 수수료 0."""
+        adapter = TestBrokerAdapter({})
+        info = adapter.get_commission_info()
+        assert info.buy_commission_rate == 0.0
+        assert info.sell_commission_rate == 0.0
+
+    def test_custom_commission(self):
+        """config에서 수수료율 지정."""
+        adapter = TestBrokerAdapter(
+            {
+                "buy_commission_rate": 0.001,
+                "sell_commission_rate": 0.002,
+            }
+        )
+        info = adapter.get_commission_info()
+        assert info.buy_commission_rate == 0.001
+        assert info.sell_commission_rate == 0.002
+
+
+# ── MockBrokerAdapter 정비 ────────────────────────────
+
+
+class TestMockBrokerAdapterUpdate:
+    """MockBrokerAdapter가 새 CommissionInfo를 사용한다."""
+
+    def test_commission_buy_sell(self):
+        """MockBrokerAdapter 수수료율 확인."""
+        adapter = MockBrokerAdapter({"exchange": "KRX"})
+        info = adapter.get_commission_info()
+        assert info.buy_commission_rate == 0.00015
+        assert info.sell_commission_rate == 0.00195
+
+
+# ── BROKER_REGISTRY ──────────────────────────────────
+
+
+class TestBrokerRegistry:
+    """BROKER_REGISTRY에 test, kis-domestic만 등록되어 있다."""
+
+    def test_registry_contains_test(self):
+        """test 타입이 등록되어 있다."""
+        assert "test" in BROKER_REGISTRY
+        assert BROKER_REGISTRY["test"] is TestBrokerAdapter
+
+    def test_registry_contains_kis_domestic(self):
+        """kis-domestic 타입이 등록되어 있다."""
+        assert "kis-domestic" in BROKER_REGISTRY
+        assert BROKER_REGISTRY["kis-domestic"] is KISDomesticAdapter
+
+    def test_registry_not_contains_kis_overseas(self):
+        """kis-overseas는 1.1 범위이므로 미등록."""
+        assert "kis-overseas" not in BROKER_REGISTRY
+
+    def test_registry_size(self):
+        """현재 2개만 등록."""
+        assert len(BROKER_REGISTRY) == 2
+
+    def test_get_broker_class_test(self):
+        """get_broker_class로 test 어댑터 조회."""
+        cls = get_broker_class("test")
+        assert cls is TestBrokerAdapter
+
+    def test_get_broker_class_kis_domestic(self):
+        """get_broker_class로 kis-domestic 어댑터 조회."""
+        cls = get_broker_class("kis-domestic")
+        assert cls is KISDomesticAdapter
+
+    def test_get_broker_class_unknown_raises(self):
+        """미등록 타입 요청 시 InvalidBrokerTypeError."""
+        with pytest.raises(InvalidBrokerTypeError) as exc_info:
+            get_broker_class("unknown-broker")
+        assert "unknown-broker" in str(exc_info.value)
+        assert exc_info.value.broker_type == "unknown-broker"
+
+    def test_invalid_broker_type_error_message(self):
+        """에러 메시지에 등록된 타입 목록이 포함된다."""
+        with pytest.raises(InvalidBrokerTypeError) as exc_info:
+            get_broker_class("nonexistent")
+        msg = str(exc_info.value)
+        assert "kis-domestic" in msg
+        assert "test" in msg

--- a/tests/unit/test_broker_meta_api.py
+++ b/tests/unit/test_broker_meta_api.py
@@ -81,9 +81,9 @@ class TestBrokerAdapterMetaDefaults:
         assert adapter.broker_short_name == "MOCK"
 
     def test_kis_adapter_meta(self) -> None:
-        """KISAdapter 메타정보가 올바르다 (클래스 속성)."""
-        from ante.broker.kis import KISAdapter
+        """KISDomesticAdapter 메타정보가 올바르다 (클래스 속성)."""
+        from ante.broker.kis import KISDomesticAdapter
 
-        assert KISAdapter.broker_id == "kis"
-        assert KISAdapter.broker_name == "한국투자증권"
-        assert KISAdapter.broker_short_name == "KIS"
+        assert KISDomesticAdapter.broker_id == "kis-domestic"
+        assert KISDomesticAdapter.broker_name == "한국투자증권 국내"
+        assert KISDomesticAdapter.broker_short_name == "KIS"

--- a/tests/unit/test_broker_type_switch.py
+++ b/tests/unit/test_broker_type_switch.py
@@ -138,15 +138,15 @@ class TestTestBrokerConfigMerge:
         """broker 섹션의 수수료율이 TestBrokerAdapter에 전달된다."""
         broker_config = {
             "type": "test",
-            "commission_rate": 0.0002,
-            "sell_tax_rate": 0.003,
+            "buy_commission_rate": 0.0002,
+            "sell_commission_rate": 0.003,
             "test": {"seed": 42},
         }
         broker = await _create_broker_from_config(broker_config)
         assert isinstance(broker, TestBrokerAdapter)
         info = broker.get_commission_info()
-        assert info.commission_rate == 0.0002
-        assert info.sell_tax_rate == 0.003
+        assert info.buy_commission_rate == 0.0002
+        assert info.sell_commission_rate == 0.003
         await broker.disconnect()
 
     @pytest.mark.asyncio

--- a/tests/unit/test_commission.py
+++ b/tests/unit/test_commission.py
@@ -15,34 +15,34 @@ class TestCommissionInfo:
     def test_defaults(self):
         """기본 수수료율."""
         info = CommissionInfo()
-        assert info.commission_rate == 0.00015
-        assert info.sell_tax_rate == 0.0023
+        assert info.buy_commission_rate == 0.00015
+        assert info.sell_commission_rate == 0.00195
 
     def test_custom_rates(self):
         """커스텀 수수료율."""
-        info = CommissionInfo(commission_rate=0.0001, sell_tax_rate=0.0018)
-        assert info.commission_rate == 0.0001
-        assert info.sell_tax_rate == 0.0018
+        info = CommissionInfo(buy_commission_rate=0.0001, sell_commission_rate=0.002)
+        assert info.buy_commission_rate == 0.0001
+        assert info.sell_commission_rate == 0.002
 
     def test_frozen(self):
         """불변 객체."""
         info = CommissionInfo()
         with pytest.raises(AttributeError):
-            info.commission_rate = 0.001  # type: ignore[misc]
+            info.buy_commission_rate = 0.001  # type: ignore[misc]
 
 
 class TestCommissionCalculation:
     def test_buy_commission(self):
-        """매수 수수료: filled_value × commission_rate."""
-        info = CommissionInfo(commission_rate=0.00015, sell_tax_rate=0.0023)
+        """매수 수수료: filled_value × buy_commission_rate."""
+        info = CommissionInfo(buy_commission_rate=0.00015, sell_commission_rate=0.00245)
         commission = info.calculate("buy", 1_000_000.0)
         assert commission == pytest.approx(150.0)
 
-    def test_sell_commission_includes_tax(self):
-        """매도 수수료: filled_value × (commission_rate + sell_tax_rate)."""
-        info = CommissionInfo(commission_rate=0.00015, sell_tax_rate=0.0023)
+    def test_sell_commission(self):
+        """매도 수수료: filled_value × sell_commission_rate."""
+        info = CommissionInfo(buy_commission_rate=0.00015, sell_commission_rate=0.00245)
         commission = info.calculate("sell", 1_000_000.0)
-        expected = 1_000_000.0 * (0.00015 + 0.0023)
+        expected = 1_000_000.0 * 0.00245
         assert commission == pytest.approx(expected)
 
     def test_sell_commission_higher_than_buy(self):
@@ -58,41 +58,41 @@ class TestCommissionCalculation:
         assert info.calculate("buy", 0.0) == 0.0
         assert info.calculate("sell", 0.0) == 0.0
 
-    def test_kosdaq_tax_rate(self):
-        """코스닥 세율 적용 (0.0018)."""
-        info = CommissionInfo(commission_rate=0.00015, sell_tax_rate=0.0018)
+    def test_kosdaq_sell_rate(self):
+        """코스닥 매도 수수료율 적용."""
+        info = CommissionInfo(buy_commission_rate=0.00015, sell_commission_rate=0.00195)
         commission = info.calculate("sell", 1_000_000.0)
-        expected = 1_000_000.0 * (0.00015 + 0.0018)
+        expected = 1_000_000.0 * 0.00195
         assert commission == pytest.approx(expected)
 
 
-# ── US-1: KISAdapter.get_commission_info ──────────
+# ── US-1: KISDomesticAdapter.get_commission_info ──────────
 
 
 class TestKISCommissionInfo:
     def test_kis_default_commission(self):
-        """KISAdapter 기본 수수료율."""
-        from ante.broker.kis import KISAdapter
+        """KISDomesticAdapter 기본 수수료율."""
+        from ante.broker.kis import KISDomesticAdapter
 
-        adapter = KISAdapter.__new__(KISAdapter)
-        adapter._commission_rate = 0.00015
-        adapter._sell_tax_rate = 0.0023
+        adapter = KISDomesticAdapter.__new__(KISDomesticAdapter)
+        adapter._buy_commission_rate = 0.00015
+        adapter._sell_commission_rate = 0.00195
 
         info = adapter.get_commission_info()
-        assert info.commission_rate == 0.00015
-        assert info.sell_tax_rate == 0.0023
+        assert info.buy_commission_rate == 0.00015
+        assert info.sell_commission_rate == 0.00195
 
     def test_kis_custom_commission_from_config(self):
-        """KISAdapter config에서 수수료율 읽기."""
-        from ante.broker.kis import KISAdapter
+        """KISDomesticAdapter config에서 수수료율 읽기."""
+        from ante.broker.kis import KISDomesticAdapter
 
-        adapter = KISAdapter.__new__(KISAdapter)
-        adapter._commission_rate = 0.0001
-        adapter._sell_tax_rate = 0.0018
+        adapter = KISDomesticAdapter.__new__(KISDomesticAdapter)
+        adapter._buy_commission_rate = 0.0001
+        adapter._sell_commission_rate = 0.002
 
         info = adapter.get_commission_info()
-        assert info.commission_rate == 0.0001
-        assert info.sell_tax_rate == 0.0018
+        assert info.buy_commission_rate == 0.0001
+        assert info.sell_commission_rate == 0.002
 
 
 # ── US-2: PaperExecutor 매도 세금 반영 ────────────
@@ -100,7 +100,7 @@ class TestKISCommissionInfo:
 
 class TestPaperExecutorCommission:
     async def test_buy_commission(self):
-        """PaperExecutor 매수 수수료 = commission_rate만 적용."""
+        """PaperExecutor 매수 수수료 = buy_commission_rate만 적용."""
         from ante.bot.providers.paper import PaperExecutor, PaperPortfolioView
 
         eventbus = EventBus()

--- a/tests/unit/test_mock_broker.py
+++ b/tests/unit/test_mock_broker.py
@@ -278,8 +278,8 @@ async def test_get_instruments(broker: MockBrokerAdapter) -> None:
 async def test_get_commission_info(broker: MockBrokerAdapter) -> None:
     """수수료 정보를 반환한다."""
     info = broker.get_commission_info()
-    assert info.commission_rate == 0.00015
-    assert info.sell_tax_rate == 0.0023
+    assert info.buy_commission_rate == 0.00015
+    assert info.sell_commission_rate == 0.00195
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_test_broker.py
+++ b/tests/unit/test_test_broker.py
@@ -397,10 +397,10 @@ class TestCommission:
         assert isinstance(info, CommissionInfo)
 
     def test_default_rates(self, broker: TestBrokerAdapter) -> None:
-        """KIS 동일 수수료율이 설정된다."""
+        """테스트 브로커 기본 수수료율은 0 (무료)."""
         info = broker.get_commission_info()
-        assert info.commission_rate == 0.00015
-        assert info.sell_tax_rate == 0.0023
+        assert info.buy_commission_rate == 0.0
+        assert info.sell_commission_rate == 0.0
 
 
 # ── 시드 재현성 ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Refs #561

- **KISAdapter 분리**: 단일 `KISAdapter`를 `KISBaseAdapter`(공통 인증/HTTP/재시도/서킷브레이커) + `KISDomesticAdapter`(국내주식 전용)로 분리
- **CommissionInfo 개선**: `commission_rate` + `sell_tax_rate` → `buy_commission_rate` + `sell_commission_rate`로 통합하여 시장 무관 인터페이스 제공
- **BrokerAdapter ABC**: `currency` 속성 추가
- **BROKER_REGISTRY 신규**: `{"test": TestBrokerAdapter, "kis-domestic": KISDomesticAdapter}` 등록
- **TestBrokerAdapter 정비**: exchange 기본값 `TEST`, 수수료 기본값 `0`
- **하위호환**: `KISAdapter = KISDomesticAdapter` 별칭 유지, 기존 config 키 하위호환 지원

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `src/ante/broker/base.py` | `currency` 속성 추가 |
| `src/ante/broker/kis.py` | KISBaseAdapter + KISDomesticAdapter 분리, KISAdapter 별칭 |
| `src/ante/broker/models.py` | CommissionInfo buy/sell 분리 |
| `src/ante/broker/test.py` | exchange=TEST, 수수료 0 |
| `src/ante/broker/mock.py` | 새 CommissionInfo 필드 적용 |
| `src/ante/broker/registry.py` | **신규** BROKER_REGISTRY |
| `src/ante/broker/__init__.py` | 새 클래스 re-export |
| `src/ante/bot/providers/paper.py` | CommissionInfo 생성 하위호환 |
| `tests/unit/test_broker_adapter_split.py` | **신규** 분리 테스트 |
| `tests/unit/test_commission.py` | CommissionInfo 필드명 변경 반영 |
| `tests/unit/test_broker_meta_api.py` | KISDomesticAdapter 메타 반영 |
| `tests/unit/test_broker_type_switch.py` | 새 필드명 반영 |
| `tests/unit/test_mock_broker.py` | 새 필드명 반영 |
| `tests/unit/test_test_broker.py` | 새 필드명 반영 |

## Test plan

- [x] 신규 테스트 `test_broker_adapter_split.py` 통과 (40+ 케이스)
- [x] 기존 broker 테스트 모두 통과 (198 통과)
- [x] 전체 unit 테스트 통과 (2173 통과, 5 기존 실패는 telegram_receiver 관련으로 무관)
- [x] ruff check / ruff format 통과