### PR TITLE
feat(data): Parquet 경로에 exchange 차원 추가

### DIFF
--- a/src/ante/data/__init__.py
+++ b/src/ante/data/__init__.py
@@ -21,7 +21,7 @@ from ante.data.schemas import (
     TICK_SCHEMA,
     TIMEFRAMES,
 )
-from ante.data.store import ParquetStore
+from ante.data.store import ParquetStore, migrate_parquet_paths
 
 __all__ = [
     "BaseNormalizer",
@@ -41,5 +41,6 @@ __all__ = [
     "TIMEFRAMES",
     "YahooNormalizer",
     "get_normalizer",
+    "migrate_parquet_paths",
     "register_normalizer",
 ]

--- a/src/ante/data/collector.py
+++ b/src/ante/data/collector.py
@@ -30,6 +30,7 @@ class DataCollector:
         buffer_size: int = 100,
         flush_interval: float = 300.0,
         collect_interval: float = 60.0,
+        exchange: str = "KRX",
     ) -> None:
         self._store = store
         self._eventbus = eventbus
@@ -37,6 +38,7 @@ class DataCollector:
         self._buffer_size = buffer_size
         self._flush_interval = flush_interval
         self._collect_interval = collect_interval
+        self._exchange = exchange
         self._symbols: list[str] = []
         self._timeframes: list[str] = []
         self._collect_task: asyncio.Task | None = None
@@ -145,7 +147,7 @@ class DataCollector:
             return
         symbol, tf = key.split(":")
         try:
-            self._store.append(symbol, tf, rows)
+            self._store.append(symbol, tf, rows, exchange=self._exchange)
             logger.debug("Flushed %d rows for %s/%s", len(rows), symbol, tf)
         except Exception as e:
             logger.error("Failed to flush data for %s/%s: %s", symbol, tf, e)

--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import re
+import shutil
 from pathlib import Path
 
 import polars as pl
@@ -15,6 +17,87 @@ _TIME_COLUMN: dict[str, str] = {
     "fundamental": "date",
     "tick": "timestamp",
 }
+
+# 알려진 거래소 이름 — 마이그레이션 시 이미 exchange 디렉토리인지 판별용
+_KNOWN_EXCHANGES: frozenset[str] = frozenset({"KRX", "NYSE", "NASDAQ", "AMEX", "TEST"})
+
+# KRX 심볼 형식: 6자리 숫자
+_KRX_SYMBOL_PATTERN: re.Pattern[str] = re.compile(r"^\d{6}$")
+
+
+def _get_actual_dir_name(parent: Path, name: str) -> str | None:
+    """파일시스템 상의 실제 디렉토리 이름을 반환.
+
+    case-insensitive FS에서 krx/KRX 구분을 위해 사용한다.
+    """
+    if not parent.exists():
+        return None
+    for entry in parent.iterdir():
+        if entry.is_dir() and entry.name.lower() == name.lower():
+            return entry.name
+    return None
+
+
+def migrate_parquet_paths(data_path: Path) -> int:
+    """기존 exchange 없는 경로를 KRX/ 하위로 이동.
+
+    Args:
+        data_path: 데이터 저장소 루트 경로 (예: data/)
+
+    Returns:
+        이동된 디렉토리 수
+    """
+    moved = 0
+
+    # ohlcv 디렉토리 마이그레이션
+    ohlcv_path = data_path / "ohlcv"
+    if ohlcv_path.exists():
+        for timeframe_dir in ohlcv_path.iterdir():
+            if not timeframe_dir.is_dir():
+                continue
+            for symbol_dir in list(timeframe_dir.iterdir()):
+                if not symbol_dir.is_dir():
+                    continue
+                # 이미 exchange 디렉토리면 스킵
+                if symbol_dir.name in _KNOWN_EXCHANGES:
+                    continue
+                # KRX 심볼은 6자리 숫자 형식 검증
+                if not _KRX_SYMBOL_PATTERN.match(symbol_dir.name):
+                    logger.warning(
+                        "마이그레이션 스킵: %s — KRX 심볼 형식(6자리 숫자)이 아님",
+                        symbol_dir,
+                    )
+                    continue
+                target = timeframe_dir / "KRX" / symbol_dir.name
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(symbol_dir), str(target))
+                moved += 1
+                logger.info("마이그레이션: %s → %s", symbol_dir, target)
+
+    # fundamental/tick 디렉토리 마이그레이션 (krx → KRX)
+    for dtype in ("fundamental", "tick"):
+        dtype_path = data_path / dtype
+        if not dtype_path.exists():
+            continue
+        krx_lower = dtype_path / "krx"
+        if not krx_lower.exists():
+            continue
+        # case-insensitive FS에서는 krx == KRX이므로 실제 이름 확인
+        actual_name = _get_actual_dir_name(dtype_path, "krx")
+        if actual_name == "KRX":
+            # 이미 대문자 → 스킵
+            continue
+        # case-sensitive FS에서 krx → KRX 이동
+        target = dtype_path / "KRX"
+        if not target.exists():
+            shutil.move(str(krx_lower), str(target))
+            moved += 1
+            logger.info("마이그레이션: %s → %s", krx_lower, target)
+
+    if moved > 0:
+        logger.info("마이그레이션 완료: %d개 디렉토리 이동", moved)
+
+    return moved
 
 
 class ParquetStore:
@@ -31,22 +114,26 @@ class ParquetStore:
         return self._base
 
     def _resolve_path(
-        self, symbol: str, timeframe: str, data_type: str = "ohlcv"
+        self,
+        symbol: str,
+        timeframe: str,
+        data_type: str = "ohlcv",
+        exchange: str = "KRX",
     ) -> Path:
         """data_type에 따라 저장 경로를 결정.
 
-        - ohlcv: {base}/ohlcv/{timeframe}/{symbol}/
-        - fundamental: {base}/fundamental/krx/{symbol}/
-        - tick: {base}/tick/krx/{symbol}/
+        - ohlcv: {base}/ohlcv/{timeframe}/{exchange}/{symbol}/
+        - fundamental: {base}/fundamental/{exchange}/{symbol}/
+        - tick: {base}/tick/{exchange}/{symbol}/
         """
         if data_type == "ohlcv":
-            return self._base / "ohlcv" / timeframe / symbol
+            return self._base / "ohlcv" / timeframe / exchange / symbol
         elif data_type == "fundamental":
-            return self._base / "fundamental" / "krx" / symbol
+            return self._base / "fundamental" / exchange / symbol
         elif data_type == "tick":
-            return self._base / "tick" / "krx" / symbol
+            return self._base / "tick" / exchange / symbol
         else:
-            return self._base / data_type / timeframe / symbol
+            return self._base / data_type / timeframe / exchange / symbol
 
     def read(
         self,
@@ -56,6 +143,7 @@ class ParquetStore:
         end: str | None = None,
         limit: int | None = None,
         data_type: str = "ohlcv",
+        exchange: str = "KRX",
     ) -> pl.DataFrame:
         """Parquet에서 데이터 읽기.
 
@@ -66,8 +154,9 @@ class ParquetStore:
             end: 종료 시간 (ISO 형식, inclusive)
             limit: 최근 N건만 반환
             data_type: 데이터 타입 (ohlcv, fundamental, tick)
+            exchange: 거래소 코드 (KRX, NYSE, NASDAQ 등)
         """
-        path = self._resolve_path(symbol, timeframe, data_type)
+        path = self._resolve_path(symbol, timeframe, data_type, exchange)
         if not path.exists():
             return pl.DataFrame()
 
@@ -112,12 +201,13 @@ class ParquetStore:
         timeframe: str,
         data: pl.DataFrame,
         data_type: str = "ohlcv",
+        exchange: str = "KRX",
     ) -> None:
         """데이터를 Parquet에 기록. 월별 파티셔닝, 중복 제거(merge)."""
         if data.is_empty():
             return
 
-        path = self._resolve_path(symbol, timeframe, data_type)
+        path = self._resolve_path(symbol, timeframe, data_type, exchange)
         path.mkdir(parents=True, exist_ok=True)
 
         time_col = _TIME_COLUMN.get(data_type, "timestamp")
@@ -178,40 +268,52 @@ class ParquetStore:
         timeframe: str,
         rows: list[dict],
         data_type: str = "ohlcv",
+        exchange: str = "KRX",
     ) -> None:
         """버퍼 데이터를 기존 Parquet에 추가."""
         df = pl.DataFrame(rows)
-        self.write(symbol, timeframe, df, data_type=data_type)
+        self.write(symbol, timeframe, df, data_type=data_type, exchange=exchange)
 
     def list_symbols(
-        self, timeframe: str = "1d", data_type: str = "ohlcv"
+        self,
+        timeframe: str = "1d",
+        data_type: str = "ohlcv",
+        exchange: str = "KRX",
     ) -> list[str]:
         """보유 데이터의 종목 목록."""
         if data_type == "ohlcv":
-            path = self._base / "ohlcv" / timeframe
+            path = self._base / "ohlcv" / timeframe / exchange
         elif data_type in ("fundamental", "tick"):
-            path = self._base / data_type / "krx"
+            path = self._base / data_type / exchange
         else:
-            path = self._base / data_type / timeframe
+            path = self._base / data_type / timeframe / exchange
         if not path.exists():
             return []
         return sorted([d.name for d in path.iterdir() if d.is_dir()])
 
     def get_date_range(
-        self, symbol: str, timeframe: str, data_type: str = "ohlcv"
+        self,
+        symbol: str,
+        timeframe: str,
+        data_type: str = "ohlcv",
+        exchange: str = "KRX",
     ) -> tuple[str, str] | None:
         """종목의 데이터 기간 조회. (첫 파일 stem, 마지막 파일 stem) 반환."""
-        path = self._resolve_path(symbol, timeframe, data_type)
+        path = self._resolve_path(symbol, timeframe, data_type, exchange)
         files = sorted(path.glob("*.parquet")) if path.exists() else []
         if not files:
             return None
         return files[0].stem, files[-1].stem
 
     def get_row_count(
-        self, symbol: str, timeframe: str, data_type: str = "ohlcv"
+        self,
+        symbol: str,
+        timeframe: str,
+        data_type: str = "ohlcv",
+        exchange: str = "KRX",
     ) -> int:
         """종목의 총 행 수 조회. Parquet 메타데이터만 읽어 빠르게 반환."""
-        path = self._resolve_path(symbol, timeframe, data_type)
+        path = self._resolve_path(symbol, timeframe, data_type, exchange)
         if not path.exists():
             return 0
         files = sorted(path.glob("*.parquet"))
@@ -249,6 +351,7 @@ class ParquetStore:
         timeframe: str,
         fix: bool = False,
         data_type: str = "ohlcv",
+        exchange: str = "KRX",
     ) -> dict:
         """Parquet 파일 무결성 검증.
 
@@ -257,12 +360,13 @@ class ParquetStore:
             timeframe: 타임프레임
             fix: True이면 손상 파일을 .corrupted 확장자로 이동
             data_type: 데이터 타입 (ohlcv, fundamental, tick)
+            exchange: 거래소 코드 (KRX, NYSE, NASDAQ 등)
 
         Returns:
             {"symbol": str, "timeframe": str, "total": int,
              "valid": int, "corrupted": int, "corrupted_files": list[str]}
         """
-        path = self._resolve_path(symbol, timeframe, data_type)
+        path = self._resolve_path(symbol, timeframe, data_type, exchange)
         result: dict = {
             "symbol": symbol,
             "timeframe": timeframe,
@@ -294,10 +398,15 @@ class ParquetStore:
         return result
 
     def delete_file(
-        self, symbol: str, timeframe: str, month: str, data_type: str = "ohlcv"
+        self,
+        symbol: str,
+        timeframe: str,
+        month: str,
+        data_type: str = "ohlcv",
+        exchange: str = "KRX",
     ) -> bool:
         """특정 Parquet 파일 삭제. 성공 여부 반환."""
-        path = self._resolve_path(symbol, timeframe, data_type)
+        path = self._resolve_path(symbol, timeframe, data_type, exchange)
         filepath = path / f"{month}.parquet"
         if filepath.exists():
             filepath.unlink()

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -158,7 +158,7 @@ async def delete_dataset(
     if data_type == "fundamental":
         path = store._resolve_path(symbol, "", data_type="fundamental")
     else:
-        path = store.base_path / "ohlcv" / timeframe / symbol
+        path = store._resolve_path(symbol, timeframe, data_type="ohlcv")
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="데이터셋을 찾을 수 없습니다")

--- a/tests/fixtures/seed/generate_ohlcv.py
+++ b/tests/fixtures/seed/generate_ohlcv.py
@@ -60,7 +60,7 @@ def generate_sample_ohlcv(
 def write_sample_parquet(output_dir: Path, symbol: str = "005930") -> Path:
     """샘플 OHLCV Parquet 파일을 생성하고 경로를 반환한다."""
     df = generate_sample_ohlcv(symbol=symbol)
-    parquet_dir = output_dir / "ohlcv" / "1d" / symbol
+    parquet_dir = output_dir / "ohlcv" / "1d" / "KRX" / symbol
     parquet_dir.mkdir(parents=True, exist_ok=True)
     filepath = parquet_dir / "2026-03.parquet"
     df.write_parquet(filepath, compression="snappy")

--- a/tests/unit/feed/test_orchestrator.py
+++ b/tests/unit/feed/test_orchestrator.py
@@ -659,7 +659,7 @@ async def test_fundamental_written_to_store(
     await orchestrator.run_daily(tmp_data_path, basic_config)
 
     # fundamental 디렉토리 확인
-    fund_path = tmp_data_path / "fundamental" / "krx"
+    fund_path = tmp_data_path / "fundamental" / "KRX"
     if fund_path.exists():
         symbol_dirs = list(fund_path.iterdir())
         assert len(symbol_dirs) > 0

--- a/tests/unit/test_data_pipeline.py
+++ b/tests/unit/test_data_pipeline.py
@@ -146,7 +146,7 @@ class TestParquetStore:
         df = _make_ohlcv_df()
         store.write("005930", "1m", df)
 
-        parquet_path = data_dir / "ohlcv" / "1m" / "005930" / "2026-03.parquet"
+        parquet_path = data_dir / "ohlcv" / "1m" / "KRX" / "005930" / "2026-03.parquet"
         assert parquet_path.exists()
 
     async def test_write_merge_dedup(self, store):
@@ -266,8 +266,8 @@ class TestParquetStore:
         )
         store.write("005930", "1m", df)
 
-        march_file = data_dir / "ohlcv" / "1m" / "005930" / "2026-03.parquet"
-        april_file = data_dir / "ohlcv" / "1m" / "005930" / "2026-04.parquet"
+        march_file = data_dir / "ohlcv" / "1m" / "KRX" / "005930" / "2026-03.parquet"
+        april_file = data_dir / "ohlcv" / "1m" / "KRX" / "005930" / "2026-04.parquet"
         assert march_file.exists()
         assert april_file.exists()
 
@@ -290,7 +290,7 @@ class TestParquetStore:
         assert result["market_cap"][0] == 500000000000
 
     async def test_fundamental_path_structure(self, store, data_dir):
-        """fundamental은 {base}/fundamental/krx/{symbol}/ 경로."""
+        """fundamental은 {base}/fundamental/KRX/{symbol}/ 경로."""
         from datetime import date
 
         df = pl.DataFrame(
@@ -301,7 +301,7 @@ class TestParquetStore:
             }
         )
         store.write("005930", "", df, data_type="fundamental")
-        path = data_dir / "fundamental" / "krx" / "005930"
+        path = data_dir / "fundamental" / "KRX" / "005930"
         assert path.exists()
         assert list(path.glob("*.parquet"))
 
@@ -814,8 +814,8 @@ class TestRetentionPolicy:
         )
         store.write("005930", "", df, data_type="fundamental")
 
-        # fundamental/krx/005930/ 경로에 파일이 생성되었는지 확인
-        fundamental_path = data_dir / "fundamental" / "krx" / "005930"
+        # fundamental/KRX/005930/ 경로에 파일이 생성되었는지 확인
+        fundamental_path = data_dir / "fundamental" / "KRX" / "005930"
         assert fundamental_path.exists()
         assert len(list(fundamental_path.glob("*.parquet"))) == 2
 

--- a/tests/unit/test_parquet_exchange.py
+++ b/tests/unit/test_parquet_exchange.py
@@ -1,0 +1,303 @@
+"""Parquet 경로 exchange 차원 추가 테스트."""
+
+from __future__ import annotations
+
+from datetime import UTC
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from ante.data.store import ParquetStore, migrate_parquet_paths
+
+
+def _is_case_sensitive_fs() -> bool:
+    """현재 파일시스템이 대소문자를 구분하는지 검사."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        test_dir = Path(td) / "CaSe"
+        test_dir.mkdir()
+        return not (Path(td) / "case").exists()
+
+
+@pytest.fixture
+def tmp_store(tmp_path: Path) -> ParquetStore:
+    """임시 디렉토리 기반 ParquetStore."""
+    return ParquetStore(base_path=tmp_path)
+
+
+def _make_ohlcv_df(
+    symbol: str = "005930",
+    n: int = 3,
+    start: str = "2026-01-01T09:00:00",
+) -> pl.DataFrame:
+    """테스트용 OHLCV DataFrame 생성."""
+    from datetime import datetime, timedelta
+
+    base = datetime.fromisoformat(start).replace(tzinfo=UTC)
+    timestamps = [base + timedelta(days=i) for i in range(n)]
+    return pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": [symbol] * n,
+            "open": [50000.0 + i * 100 for i in range(n)],
+            "high": [51000.0 + i * 100 for i in range(n)],
+            "low": [49000.0 + i * 100 for i in range(n)],
+            "close": [50500.0 + i * 100 for i in range(n)],
+            "volume": [1000000 + i * 10000 for i in range(n)],
+            "amount": [50000000000 + i * 100000000 for i in range(n)],
+            "source": ["test"] * n,
+        }
+    )
+
+
+class TestResolvePathWithExchange:
+    """_resolve_path에 exchange 차원이 포함되는지 검증."""
+
+    def test_ohlcv_path_includes_exchange(self, tmp_store: ParquetStore) -> None:
+        """OHLCV 경로: {base}/ohlcv/{timeframe}/{exchange}/{symbol}/"""
+        path = tmp_store._resolve_path("005930", "1d", "ohlcv", "KRX")
+        assert path == tmp_store.base_path / "ohlcv" / "1d" / "KRX" / "005930"
+
+    def test_ohlcv_path_nyse(self, tmp_store: ParquetStore) -> None:
+        """NYSE 거래소 경로 생성."""
+        path = tmp_store._resolve_path("AAPL", "1d", "ohlcv", "NYSE")
+        assert path == tmp_store.base_path / "ohlcv" / "1d" / "NYSE" / "AAPL"
+
+    def test_fundamental_path_includes_exchange(self, tmp_store: ParquetStore) -> None:
+        """Fundamental 경로: {base}/fundamental/{exchange}/{symbol}/"""
+        path = tmp_store._resolve_path("005930", "", "fundamental", "KRX")
+        assert path == tmp_store.base_path / "fundamental" / "KRX" / "005930"
+
+    def test_tick_path_includes_exchange(self, tmp_store: ParquetStore) -> None:
+        """Tick 경로: {base}/tick/{exchange}/{symbol}/"""
+        path = tmp_store._resolve_path("005930", "", "tick", "KRX")
+        assert path == tmp_store.base_path / "tick" / "KRX" / "005930"
+
+    def test_default_exchange_is_krx(self, tmp_store: ParquetStore) -> None:
+        """exchange 기본값은 KRX."""
+        path = tmp_store._resolve_path("005930", "1d")
+        assert "KRX" in path.parts
+
+
+class TestReadWriteWithExchange:
+    """exchange 파라미터를 사용한 읽기/쓰기 검증."""
+
+    def test_write_creates_exchange_directory(
+        self, tmp_store: ParquetStore, tmp_path: Path
+    ) -> None:
+        """write 시 exchange 디렉토리가 생성된다."""
+        df = _make_ohlcv_df()
+        tmp_store.write("005930", "1d", df)
+        assert (tmp_path / "ohlcv" / "1d" / "KRX" / "005930").exists()
+
+    def test_write_and_read_with_exchange(self, tmp_store: ParquetStore) -> None:
+        """exchange 파라미터로 쓰고 읽기."""
+        df = _make_ohlcv_df()
+        tmp_store.write("005930", "1d", df, exchange="KRX")
+        result = tmp_store.read("005930", "1d", exchange="KRX")
+        assert len(result) == 3
+
+    def test_different_exchanges_are_isolated(self, tmp_store: ParquetStore) -> None:
+        """서로 다른 거래소의 데이터는 격리된다."""
+        df_krx = _make_ohlcv_df(symbol="005930")
+        df_nyse = _make_ohlcv_df(symbol="AAPL")
+        tmp_store.write("005930", "1d", df_krx, exchange="KRX")
+        tmp_store.write("AAPL", "1d", df_nyse, exchange="NYSE")
+
+        result_krx = tmp_store.read("005930", "1d", exchange="KRX")
+        result_nyse = tmp_store.read("AAPL", "1d", exchange="NYSE")
+        result_empty = tmp_store.read("005930", "1d", exchange="NYSE")
+
+        assert len(result_krx) == 3
+        assert len(result_nyse) == 3
+        assert result_empty.is_empty()
+
+    def test_list_symbols_with_exchange(self, tmp_store: ParquetStore) -> None:
+        """exchange별 종목 목록 조회."""
+        df1 = _make_ohlcv_df(symbol="005930")
+        df2 = _make_ohlcv_df(symbol="000660")
+        df3 = _make_ohlcv_df(symbol="AAPL")
+        tmp_store.write("005930", "1d", df1, exchange="KRX")
+        tmp_store.write("000660", "1d", df2, exchange="KRX")
+        tmp_store.write("AAPL", "1d", df3, exchange="NYSE")
+
+        krx_symbols = tmp_store.list_symbols("1d", exchange="KRX")
+        nyse_symbols = tmp_store.list_symbols("1d", exchange="NYSE")
+
+        assert krx_symbols == ["000660", "005930"]
+        assert nyse_symbols == ["AAPL"]
+
+    def test_append_with_exchange(self, tmp_store: ParquetStore) -> None:
+        """append도 exchange 경로를 사용한다."""
+        from datetime import datetime
+
+        rows = [
+            {
+                "timestamp": datetime(2026, 1, 1, 9, 0, tzinfo=UTC),
+                "symbol": "005930",
+                "open": 50000.0,
+                "high": 51000.0,
+                "low": 49000.0,
+                "close": 50500.0,
+                "volume": 1000000,
+                "amount": 50000000000,
+                "source": "test",
+            }
+        ]
+        tmp_store.append("005930", "1m", rows, exchange="KRX")
+        result = tmp_store.read("005930", "1m", exchange="KRX")
+        assert len(result) == 1
+
+    def test_get_date_range_with_exchange(self, tmp_store: ParquetStore) -> None:
+        """exchange별 데이터 기간 조회."""
+        df = _make_ohlcv_df()
+        tmp_store.write("005930", "1d", df, exchange="KRX")
+        result = tmp_store.get_date_range("005930", "1d", exchange="KRX")
+        assert result is not None
+        assert result[0] == "2026-01"
+
+    def test_get_row_count_with_exchange(self, tmp_store: ParquetStore) -> None:
+        """exchange별 행 수 조회."""
+        df = _make_ohlcv_df()
+        tmp_store.write("005930", "1d", df, exchange="KRX")
+        count = tmp_store.get_row_count("005930", "1d", exchange="KRX")
+        assert count == 3
+
+    def test_delete_file_with_exchange(self, tmp_store: ParquetStore) -> None:
+        """exchange 경로에서 파일 삭제."""
+        df = _make_ohlcv_df()
+        tmp_store.write("005930", "1d", df, exchange="KRX")
+        result = tmp_store.delete_file("005930", "1d", "2026-01", exchange="KRX")
+        assert result is True
+        remaining = tmp_store.read("005930", "1d", exchange="KRX")
+        assert remaining.is_empty()
+
+    def test_validate_with_exchange(self, tmp_store: ParquetStore) -> None:
+        """exchange 경로에서 검증."""
+        df = _make_ohlcv_df()
+        tmp_store.write("005930", "1d", df, exchange="KRX")
+        result = tmp_store.validate("005930", "1d", exchange="KRX")
+        assert result["total"] == 1
+        assert result["valid"] == 1
+
+
+class TestMigrateParquetPaths:
+    """기존 경로 → exchange 포함 경로 마이그레이션 검증."""
+
+    def test_migrate_ohlcv_to_krx(self, tmp_path: Path) -> None:
+        """기존 ohlcv/{tf}/{symbol}/ → ohlcv/{tf}/KRX/{symbol}/."""
+        old_path = tmp_path / "ohlcv" / "1d" / "005930"
+        old_path.mkdir(parents=True)
+        (old_path / "2026-01.parquet").write_bytes(b"dummy")
+
+        moved = migrate_parquet_paths(tmp_path)
+
+        assert moved == 1
+        assert not old_path.exists()
+        new_path = tmp_path / "ohlcv" / "1d" / "KRX" / "005930"
+        assert new_path.exists()
+        assert (new_path / "2026-01.parquet").exists()
+
+    def test_migrate_multiple_timeframes(self, tmp_path: Path) -> None:
+        """여러 타임프레임의 데이터를 모두 마이그레이션한다."""
+        for tf in ("1d", "1m", "5m"):
+            old_path = tmp_path / "ohlcv" / tf / "005930"
+            old_path.mkdir(parents=True)
+            (old_path / "2026-01.parquet").write_bytes(b"dummy")
+
+        moved = migrate_parquet_paths(tmp_path)
+
+        assert moved == 3
+        for tf in ("1d", "1m", "5m"):
+            new_path = tmp_path / "ohlcv" / tf / "KRX" / "005930"
+            assert new_path.exists()
+
+    def test_migrate_skips_existing_exchange_dir(self, tmp_path: Path) -> None:
+        """이미 exchange 디렉토리가 있으면 스킵."""
+        krx_path = tmp_path / "ohlcv" / "1d" / "KRX" / "005930"
+        krx_path.mkdir(parents=True)
+        (krx_path / "2026-01.parquet").write_bytes(b"dummy")
+
+        moved = migrate_parquet_paths(tmp_path)
+
+        assert moved == 0
+        assert krx_path.exists()
+
+    def test_migrate_skips_non_krx_symbol_format(self, tmp_path: Path) -> None:
+        """6자리 숫자가 아닌 심볼은 마이그레이션하지 않는다."""
+        old_path = tmp_path / "ohlcv" / "1d" / "AAPL"
+        old_path.mkdir(parents=True)
+        (old_path / "2026-01.parquet").write_bytes(b"dummy")
+
+        moved = migrate_parquet_paths(tmp_path)
+
+        # AAPL은 6자리 숫자가 아니므로 스킵
+        assert moved == 0
+        assert old_path.exists()
+
+    @pytest.mark.skipif(
+        not _is_case_sensitive_fs(),
+        reason="case-insensitive FS에서는 krx == KRX이므로 마이그레이션 불필요",
+    )
+    def test_migrate_fundamental_krx_lowercase(self, tmp_path: Path) -> None:
+        """fundamental/krx/ → fundamental/KRX/ 마이그레이션 (case-sensitive FS)."""
+        old_path = tmp_path / "fundamental" / "krx" / "005930"
+        old_path.mkdir(parents=True)
+        (old_path / "2026-01.parquet").write_bytes(b"dummy")
+
+        moved = migrate_parquet_paths(tmp_path)
+
+        assert moved == 1
+        new_path = tmp_path / "fundamental" / "KRX" / "005930"
+        assert new_path.exists()
+        assert (new_path / "2026-01.parquet").exists()
+
+    @pytest.mark.skipif(
+        not _is_case_sensitive_fs(),
+        reason="case-insensitive FS에서는 krx == KRX이므로 마이그레이션 불필요",
+    )
+    def test_migrate_tick_krx_lowercase(self, tmp_path: Path) -> None:
+        """tick/krx/ → tick/KRX/ 마이그레이션 (case-sensitive FS)."""
+        old_path = tmp_path / "tick" / "krx" / "005930"
+        old_path.mkdir(parents=True)
+        (old_path / "2026-03-12.parquet").write_bytes(b"dummy")
+
+        moved = migrate_parquet_paths(tmp_path)
+
+        assert moved == 1
+        new_path = tmp_path / "tick" / "KRX" / "005930"
+        assert new_path.exists()
+
+    def test_migrate_returns_zero_on_empty(self, tmp_path: Path) -> None:
+        """데이터 디렉토리가 비어있으면 0 반환."""
+        moved = migrate_parquet_paths(tmp_path)
+        assert moved == 0
+
+    def test_migrate_idempotent(self, tmp_path: Path) -> None:
+        """마이그레이션은 멱등이다. 두 번 실행해도 안전."""
+        old_path = tmp_path / "ohlcv" / "1d" / "005930"
+        old_path.mkdir(parents=True)
+        (old_path / "2026-01.parquet").write_bytes(b"dummy")
+
+        moved1 = migrate_parquet_paths(tmp_path)
+        moved2 = migrate_parquet_paths(tmp_path)
+
+        assert moved1 == 1
+        assert moved2 == 0
+
+    def test_migrate_preserves_data(self, tmp_path: Path) -> None:
+        """마이그레이션 후 데이터가 보존된다."""
+        # 기존 경로에 직접 데이터 생성 (마이그레이션 전)
+        old_path = tmp_path / "ohlcv" / "1d" / "005930"
+        old_path.mkdir(parents=True)
+        df = _make_ohlcv_df()
+        df.write_parquet(str(old_path / "2026-01.parquet"))
+
+        migrate_parquet_paths(tmp_path)
+
+        # 마이그레이션 후 새 경로로 읽기
+        store_after = ParquetStore(base_path=tmp_path)
+        result = store_after.read("005930", "1d", exchange="KRX")
+        assert len(result) == 3

--- a/tests/unit/test_parquet_validation.py
+++ b/tests/unit/test_parquet_validation.py
@@ -66,8 +66,12 @@ def _create_corrupted_parquet(path: Path) -> None:
 class TestParquetValidate:
     @pytest.mark.asyncio
     async def test_validate_all_valid(self, tmp_store, tmp_path):
-        _create_valid_parquet(tmp_path / "ohlcv" / "1d" / "005930" / "2026-01.parquet")
-        _create_valid_parquet(tmp_path / "ohlcv" / "1d" / "005930" / "2026-02.parquet")
+        _create_valid_parquet(
+            tmp_path / "ohlcv" / "1d" / "KRX" / "005930" / "2026-01.parquet"
+        )
+        _create_valid_parquet(
+            tmp_path / "ohlcv" / "1d" / "KRX" / "005930" / "2026-02.parquet"
+        )
 
         result = tmp_store.validate("005930", "1d")
 
@@ -78,9 +82,11 @@ class TestParquetValidate:
 
     @pytest.mark.asyncio
     async def test_validate_corrupted_file(self, tmp_store, tmp_path):
-        _create_valid_parquet(tmp_path / "ohlcv" / "1d" / "005930" / "2026-01.parquet")
+        _create_valid_parquet(
+            tmp_path / "ohlcv" / "1d" / "KRX" / "005930" / "2026-01.parquet"
+        )
         _create_corrupted_parquet(
-            tmp_path / "ohlcv" / "1d" / "005930" / "2026-02.parquet"
+            tmp_path / "ohlcv" / "1d" / "KRX" / "005930" / "2026-02.parquet"
         )
 
         result = tmp_store.validate("005930", "1d")
@@ -92,7 +98,9 @@ class TestParquetValidate:
 
     @pytest.mark.asyncio
     async def test_validate_fix_moves_corrupted(self, tmp_store, tmp_path):
-        corrupted_path = tmp_path / "ohlcv" / "1d" / "005930" / "2026-02.parquet"
+        corrupted_path = (
+            tmp_path / "ohlcv" / "1d" / "KRX" / "005930" / "2026-02.parquet"
+        )
         _create_corrupted_parquet(corrupted_path)
 
         result = tmp_store.validate("005930", "1d", fix=True)
@@ -111,7 +119,7 @@ class TestParquetValidate:
 
     @pytest.mark.asyncio
     async def test_validate_empty_directory(self, tmp_store, tmp_path):
-        (tmp_path / "ohlcv" / "1d" / "005930").mkdir(parents=True)
+        (tmp_path / "ohlcv" / "1d" / "KRX" / "005930").mkdir(parents=True)
 
         result = tmp_store.validate("005930", "1d")
 

--- a/tests/unit/test_seed_data.py
+++ b/tests/unit/test_seed_data.py
@@ -47,7 +47,7 @@ def test_write_sample_parquet(tmp_path: Path) -> None:
     filepath = write_sample_parquet(tmp_path)
     assert filepath.exists()
     assert filepath.suffix == ".parquet"
-    assert "ohlcv/1d/005930" in str(filepath)
+    assert "ohlcv/1d/KRX/005930" in str(filepath)
 
 
 # ── 시드 데이터 주입 테스트 ───────────────────────────


### PR DESCRIPTION
## Summary

- ParquetStore의 모든 경로에 `exchange` 계층 추가 (`ohlcv/{tf}/{exchange}/{symbol}/`)
- `migrate_parquet_paths()` 함수로 기존 데이터 자동 마이그레이션 (KRX 기본)
- DataCollector에 `exchange` 파라미터 전달 지원
- 웹 API 데이터셋 삭제 경로를 `_resolve_path` 사용으로 수정

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `src/ante/data/store.py` | `_resolve_path()`에 exchange 파라미터, `migrate_parquet_paths()` 함수 추가 |
| `src/ante/data/collector.py` | exchange 파라미터 지원 |
| `src/ante/data/__init__.py` | `migrate_parquet_paths` public API 노출 |
| `src/ante/web/routes/data.py` | 삭제 경로를 `_resolve_path` 사용으로 수정 |
| `tests/unit/test_parquet_exchange.py` | 신규 테스트 23건 (경로, 읽기/쓰기, 마이그레이션) |
| 기존 테스트 5개 파일 | 경로 패턴 업데이트 (`KRX/` 추가) |

## Test plan

- [x] 새 경로 형식 생성 테스트 (OHLCV, fundamental, tick)
- [x] exchange별 데이터 격리 테스트
- [x] 기존 경로 → KRX/ 마이그레이션 테스트
- [x] 마이그레이션 멱등성 테스트
- [x] 데이터 보존 검증 테스트
- [x] 기존 테스트 2161건 통과 (telegram 무관 5건 제외)

Refs #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)