### PR TITLE
feat(bot): Bot 모듈에 account_id 연동

### DIFF
--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -174,6 +174,13 @@ class AccountService:
             raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
         return _row_to_account(row)
 
+    def get_sync(self, account_id: str) -> Account | None:
+        """동기 캐시 조회. 인메모리에 있는 계좌만 반환, 없으면 None.
+
+        ContextFactory 등 동기 컨텍스트에서 사용한다.
+        """
+        return self._accounts.get(account_id)
+
     async def list(self, status: AccountStatus | None = None) -> list[Account]:
         """계좌 목록 조회. DELETED 제외가 기본."""
         if status is not None:

--- a/src/ante/bot/bot.py
+++ b/src/ante/bot/bot.py
@@ -31,9 +31,11 @@ class Bot:
         strategy_cls: type[Strategy],
         ctx: StrategyContext,
         eventbus: EventBus,
+        exchange: str = "",
     ) -> None:
         self.config = config
         self.bot_id = config.bot_id
+        self.exchange = exchange
         self._strategy_cls = strategy_cls
         self._ctx = ctx
         self._eventbus = eventbus
@@ -61,7 +63,9 @@ class Bot:
             name=f"bot_{self.bot_id}",
         )
 
-        await self._eventbus.publish(BotStartedEvent(bot_id=self.bot_id))
+        await self._eventbus.publish(
+            BotStartedEvent(bot_id=self.bot_id, account_id=self.config.account_id)
+        )
         logger.info("봇 시작: %s", self.bot_id)
 
     async def stop(self) -> None:
@@ -86,7 +90,9 @@ class Bot:
         self.status = BotStatus.STOPPED
         self.stopped_at = datetime.now(UTC)
 
-        await self._eventbus.publish(BotStoppedEvent(bot_id=self.bot_id))
+        await self._eventbus.publish(
+            BotStoppedEvent(bot_id=self.bot_id, account_id=self.config.account_id)
+        )
         logger.info("봇 중지: %s", self.bot_id)
 
     async def _run_loop(self) -> None:
@@ -141,6 +147,7 @@ class Bot:
                     await self._eventbus.publish(
                         BotErrorEvent(
                             bot_id=self.bot_id,
+                            account_id=self.config.account_id,
                             error_message=msg,
                         )
                     )
@@ -173,6 +180,7 @@ class Bot:
             await self._eventbus.publish(
                 BotErrorEvent(
                     bot_id=self.bot_id,
+                    account_id=self.config.account_id,
                     error_message=str(e),
                 )
             )
@@ -297,6 +305,7 @@ class Bot:
             await self._eventbus.publish(
                 OrderRequestEvent(
                     bot_id=self.bot_id,
+                    account_id=self.config.account_id,
                     strategy_id=self.config.strategy_id,
                     symbol=signal.symbol,
                     side=signal.side,
@@ -305,7 +314,7 @@ class Bot:
                     price=signal.price,
                     stop_price=signal.stop_price,
                     reason=signal.reason,
-                    exchange=self.config.exchange,
+                    exchange=self.exchange,
                 )
             )
 
@@ -318,6 +327,7 @@ class Bot:
                 await self._eventbus.publish(
                     OrderCancelEvent(
                         bot_id=self.bot_id,
+                        account_id=self.config.account_id,
                         order_id=action.order_id,
                         reason=action.reason,
                     )
@@ -326,6 +336,7 @@ class Bot:
                 await self._eventbus.publish(
                     OrderModifyEvent(
                         bot_id=self.bot_id,
+                        account_id=self.config.account_id,
                         order_id=action.order_id,
                         quantity=action.quantity or 0.0,
                         price=action.price,
@@ -339,7 +350,7 @@ class Bot:
             "bot_id": self.bot_id,
             "name": self.config.name,
             "status": self.status.value,
-            "bot_type": self.config.bot_type,
+            "account_id": self.config.account_id,
             "strategy_id": self.config.strategy_id,
             "interval_seconds": self.config.interval_seconds,
             "started_at": (self.started_at.isoformat() if self.started_at else None),

--- a/src/ante/bot/config.py
+++ b/src/ante/bot/config.py
@@ -29,10 +29,9 @@ class BotConfig:
     bot_id: str
     strategy_id: str
     name: str = ""
-    bot_type: str = "live"
+    account_id: str = "test"
     interval_seconds: int = 60
     paper_initial_balance: float = 10_000_000.0
-    exchange: str = "KRX"
     auto_restart: bool = True
     max_restart_attempts: int = 3
     restart_cooldown_seconds: int = 60

--- a/src/ante/bot/context_factory.py
+++ b/src/ante/bot/context_factory.py
@@ -1,15 +1,17 @@
-"""StrategyContextFactory — 봇 유형별 StrategyContext 자동 조립."""
+"""StrategyContextFactory — 계좌 거래모드별 StrategyContext 자동 조립."""
 
 from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING
 
+from ante.account.models import TradingMode
 from ante.bot.config import BotConfig
 from ante.bot.providers.paper import PaperExecutor, PaperOrderView, PaperPortfolioView
 from ante.strategy.context import StrategyContext
 
 if TYPE_CHECKING:
+    from ante.account.service import AccountService
     from ante.bot.providers.live import (
         LiveOrderView,
         LivePortfolioView,
@@ -21,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 class StrategyContextFactory:
-    """봇 유형(live/paper)에 따라 적절한 StrategyContext를 생성.
+    """Account.trading_mode에 따라 적절한 StrategyContext를 생성.
 
     main.py에서 생성되어 BotManager에 주입된다.
     """
@@ -29,22 +31,39 @@ class StrategyContextFactory:
     def __init__(
         self,
         data_provider: DataProvider,
+        account_service: AccountService | None = None,
         live_portfolio: LivePortfolioView | None = None,
         live_order_view: LiveOrderView | None = None,
         paper_executor: PaperExecutor | None = None,
         live_trade_history: LiveTradeHistoryView | None = None,
     ) -> None:
         self._data_provider = data_provider
+        self._account_service = account_service
         self._live_portfolio = live_portfolio
         self._live_order_view = live_order_view
         self._paper_executor = paper_executor
         self._live_trade_history = live_trade_history
 
     def create(self, config: BotConfig) -> StrategyContext:
-        """BotConfig 기반으로 적절한 StrategyContext 생성."""
-        if config.bot_type == "paper":
+        """BotConfig 기반으로 적절한 StrategyContext 생성.
+
+        AccountService가 주입된 경우 Account.trading_mode로 분기하고,
+        없으면 기본값(paper)으로 동작한다.
+        """
+        trading_mode = self._resolve_trading_mode(config)
+        if trading_mode == TradingMode.VIRTUAL:
             return self._create_paper_context(config)
         return self._create_live_context(config)
+
+    def _resolve_trading_mode(self, config: BotConfig) -> TradingMode:
+        """계좌의 trading_mode를 조회한다. AccountService 미설정 시 VIRTUAL."""
+        if self._account_service is None:
+            return TradingMode.VIRTUAL
+        account = self._account_service.get_sync(config.account_id)
+        if account is None:
+            logger.warning("계좌 '%s' 미발견 — VIRTUAL 모드로 대체", config.account_id)
+            return TradingMode.VIRTUAL
+        return account.trading_mode
 
     def _create_live_context(self, config: BotConfig) -> StrategyContext:
         """Live 봇용 StrategyContext 생성."""

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -29,13 +29,14 @@ CREATE TABLE IF NOT EXISTS bots (
     bot_id       TEXT PRIMARY KEY,
     name         TEXT NOT NULL DEFAULT '',
     strategy_id  TEXT NOT NULL,
-    bot_type     TEXT NOT NULL DEFAULT 'live',
+    account_id   TEXT NOT NULL DEFAULT 'test',
     config_json  TEXT NOT NULL,
     auto_start   BOOLEAN DEFAULT 0,
     status       TEXT DEFAULT 'created',
     created_at   TEXT DEFAULT (datetime('now')),
     updated_at   TEXT DEFAULT (datetime('now'))
 );
+CREATE INDEX IF NOT EXISTS idx_bots_account_id ON bots(account_id);
 """
 
 
@@ -66,14 +67,25 @@ class BotManager:
         self._restart_reset_tasks: dict[str, asyncio.Task[None]] = {}
 
     async def initialize(self) -> None:
-        """스키마 생성 + EventBus 구독 + 잔존 스냅샷 정리."""
+        """스키마 생성 + 마이그레이션 + EventBus 구독 + 잔존 스냅샷 정리."""
         await self._db.execute_script(BOT_SCHEMA)
+        await self._migrate_schema()
         self._subscribe_events()
         if self._snapshot:
             cleaned = self._snapshot.cleanup_all()
             if cleaned:
                 logger.info("잔존 전략 스냅샷 %d건 정리", cleaned)
         logger.info("BotManager 초기화 완료")
+
+    async def _migrate_schema(self) -> None:
+        """기존 bots 테이블에 account_id 컬럼이 없으면 추가한다."""
+        columns = await self._db.fetch_all("PRAGMA table_info(bots)")
+        col_names = {col["name"] for col in columns}
+        if "account_id" not in col_names:
+            await self._db.execute(
+                "ALTER TABLE bots ADD COLUMN account_id TEXT NOT NULL DEFAULT 'test'"
+            )
+            logger.info("bots 테이블에 account_id 컬럼 추가 (마이그레이션)")
 
     async def load_from_db(self) -> int:
         """DB에서 봇 설정을 읽어 메모리에 로드한다 (테스트용).
@@ -98,17 +110,22 @@ class BotManager:
         self._bots.clear()
 
         rows = await self._db.fetch_all(
-            "SELECT bot_id, name, strategy_id, bot_type, config_json, status"
+            "SELECT bot_id, name, strategy_id, account_id, config_json, status"
             " FROM bots WHERE status != 'deleted'"
         )
 
         for row in rows:
             config_data = json.loads(row["config_json"]) if row["config_json"] else {}
+            # 마이그레이션: 기존 config에 account_id가 없으면 기본값 사용
+            account_id = row.get("account_id") or config_data.get("account_id", "test")
+            # bot_type, exchange 키는 무시 (BotConfig에서 제거됨)
+            config_data.pop("bot_type", None)
+            config_data.pop("exchange", None)
             config = BotConfig(
                 bot_id=row["bot_id"],
                 strategy_id=row["strategy_id"],
                 name=row["name"] or config_data.get("name", row["bot_id"]),
-                bot_type=row["bot_type"] or "live",
+                account_id=account_id,
                 interval_seconds=config_data.get("interval_seconds", 60),
             )
             bot = Bot(
@@ -313,12 +330,8 @@ class BotManager:
 
         self._unregister_bot_events(bot)
 
-        # Paper 봇 PaperExecutor 등록 해제
-        if (
-            self._context_factory
-            and self._context_factory._paper_executor
-            and bot.config.bot_type == "paper"
-        ):
+        # PaperExecutor 등록 해제 (봇이 등록되어 있는 경우)
+        if self._context_factory and self._context_factory._paper_executor:
             self._context_factory._paper_executor.unregister_bot(bot_id)
 
         # 시그널 키 폐기
@@ -658,13 +671,13 @@ class BotManager:
             "bot_id": config.bot_id,
             "name": config.name,
             "strategy_id": config.strategy_id,
-            "bot_type": config.bot_type,
+            "account_id": config.account_id,
             "interval_seconds": config.interval_seconds,
             "paper_initial_balance": config.paper_initial_balance,
         }
         await self._db.execute(
             """INSERT INTO bots
-               (bot_id, name, strategy_id, bot_type, config_json)
+               (bot_id, name, strategy_id, account_id, config_json)
                VALUES (?, ?, ?, ?, ?)
                ON CONFLICT(bot_id) DO UPDATE SET
                  name = excluded.name,
@@ -674,7 +687,7 @@ class BotManager:
                 config.bot_id,
                 config.name,
                 config.strategy_id,
-                config.bot_type,
+                config.account_id,
                 json.dumps(config_dict),
             ),
         )

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -59,7 +59,7 @@ def bot_list(ctx: click.Context) -> None:
         db, _, _ = await _create_services()
         try:
             rows = await db.fetch_all(
-                "SELECT bot_id, name, strategy_id, bot_type, status, created_at"
+                "SELECT bot_id, name, strategy_id, account_id, status, created_at"
                 " FROM bots WHERE status != 'deleted'"
             )
             return [dict(r) for r in rows]
@@ -77,7 +77,7 @@ def bot_list(ctx: click.Context) -> None:
     else:
         fmt.table(
             result,
-            ["bot_id", "name", "strategy_id", "bot_type", "status", "created_at"],
+            ["bot_id", "name", "strategy_id", "account_id", "status", "created_at"],
         )
 
 
@@ -110,7 +110,7 @@ def bot_info(ctx: click.Context, bot_id: str) -> None:
         click.echo(f"  Bot ID    : {result['bot_id']}")
         click.echo(f"  이름      : {result['name']}")
         click.echo(f"  전략      : {result['strategy_id']}")
-        click.echo(f"  타입      : {result['bot_type']}")
+        click.echo(f"  계좌      : {result.get('account_id', 'test')}")
         click.echo(f"  상태      : {result['status']}")
         click.echo(f"  생성일    : {result['created_at']}")
 
@@ -134,11 +134,10 @@ def _parse_param(value: str) -> tuple[str, object]:
 @click.option("--name", required=True, help="봇 이름")
 @click.option("--strategy", required=True, help="전략 ID")
 @click.option(
-    "--type",
-    "bot_type",
-    type=click.Choice(["live", "paper"]),
-    default="live",
-    help="봇 타입",
+    "--account",
+    "account_id",
+    default="test",
+    help="계좌 ID",
 )
 @click.option(
     "--interval",
@@ -160,7 +159,7 @@ def bot_create(
     ctx: click.Context,
     name: str,
     strategy: str,
-    bot_type: str,
+    account_id: str,
     interval: int,
     bot_id: str,
     params: tuple[str, ...],
@@ -190,16 +189,16 @@ def bot_create(
                 "bot_id": bid,
                 "name": name,
                 "strategy_id": strategy,
-                "bot_type": bot_type,
+                "account_id": account_id,
                 "interval_seconds": interval,
             }
             if param_dict:
                 config_dict["params"] = param_dict
             await db.execute(
                 """INSERT INTO bots
-                   (bot_id, name, strategy_id, bot_type, config_json)
+                   (bot_id, name, strategy_id, account_id, config_json)
                    VALUES (?, ?, ?, ?, ?)""",
-                (bid, name, strategy, bot_type, json.dumps(config_dict)),
+                (bid, name, strategy, account_id, json.dumps(config_dict)),
             )
 
             await _audit_log(

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -28,7 +28,7 @@ class BotCreateRequest(BaseModel):
     bot_id: str
     strategy_id: str
     name: str = ""
-    bot_type: str = "live"
+    account_id: str = "test"
     interval_seconds: int = Field(default=60, ge=10, le=3600)
 
 
@@ -88,7 +88,7 @@ async def create_bot(
         bot_id=body.bot_id,
         strategy_id=body.strategy_id,
         name=body.name or body.bot_id,
-        bot_type=body.bot_type,
+        account_id=body.account_id,
         interval_seconds=body.interval_seconds,
     )
 

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -87,7 +87,7 @@ class BotInfo(BaseModel):
     bot_id: str
     name: str = ""
     status: str = ""
-    bot_type: str = ""
+    account_id: str = ""
     strategy_id: str = ""
     interval_seconds: int = 60
     started_at: str | None = None

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -145,7 +145,7 @@ class TestBotConfig:
         """BotConfig 기본값."""
         c = BotConfig(bot_id="b1", strategy_id="s1")
         assert c.name == ""
-        assert c.bot_type == "live"
+        assert c.account_id == "test"
         assert c.interval_seconds == 60
 
     def test_name_field(self):
@@ -698,3 +698,191 @@ class TestBotManager:
         row = await db.fetch_one("SELECT * FROM bots WHERE bot_id = 'bot1'")
         assert row is not None
         assert row["name"] == "모멘텀 봇"
+
+    async def test_bot_config_account_id(self, manager, eventbus, ctx, db):
+        """account_id 필드 존재 및 기본값."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        assert config.account_id == "test"
+
+        config2 = BotConfig(bot_id="bot2", strategy_id="s2", account_id="domestic")
+        assert config2.account_id == "domestic"
+
+    async def test_bot_config_no_bot_type(self):
+        """BotConfig에서 bot_type, exchange 필드가 제거되었음."""
+        config = BotConfig(bot_id="b1", strategy_id="s1")
+        assert not hasattr(config, "bot_type")
+        assert not hasattr(config, "exchange")
+
+    async def test_create_bot_with_account(self, manager, eventbus, ctx, db):
+        """BotManager.create_bot()에 account_id 전달 및 DB 저장."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="domestic")
+        bot = await manager.create_bot(config, SimpleStrategy, ctx)
+        assert bot.config.account_id == "domestic"
+
+        row = await db.fetch_one("SELECT * FROM bots WHERE bot_id = 'bot1'")
+        assert row is not None
+        assert row["account_id"] == "domestic"
+
+    async def test_order_request_has_account(self, eventbus, ctx):
+        """OrderRequestEvent에 account_id 포함."""
+        config = BotConfig(
+            bot_id="bot1",
+            strategy_id="buy_v1.0.0",
+            account_id="my-account",
+            interval_seconds=10,
+        )
+        received = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: received.append(e))
+
+        bot = Bot(
+            config=config,
+            strategy_cls=BuyStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+            exchange="KRX",
+        )
+        await bot.start()
+        await asyncio.sleep(0.05)
+        await bot.stop()
+
+        assert len(received) >= 1
+        assert received[0].account_id == "my-account"
+        assert received[0].exchange == "KRX"
+
+    async def test_load_bot_from_db_with_account(self, manager, eventbus, ctx, db):
+        """DB 복원 시 account_id 유지."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="domestic")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        # 새 매니저로 DB에서 로드
+        manager2 = BotManager(eventbus=eventbus, db=db)
+        await manager2.initialize()
+        count = await manager2.load_from_db()
+        assert count == 1
+
+        bot = manager2.get_bot("bot1")
+        assert bot is not None
+        assert bot.config.account_id == "domestic"
+
+    async def test_load_bot_migration_old_format(self, manager, eventbus, db):
+        """기존 bot_type/exchange 포함 config_json → account_id 마이그레이션."""
+        import json
+
+        # 기존 형식으로 직접 DB에 삽입
+        old_config = json.dumps(
+            {
+                "bot_id": "old-bot",
+                "strategy_id": "s1",
+                "bot_type": "paper",
+                "exchange": "KRX",
+                "interval_seconds": 60,
+            }
+        )
+        await db.execute(
+            """INSERT INTO bots
+               (bot_id, name, strategy_id, account_id, config_json, status)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("old-bot", "old", "s1", "test", old_config, "created"),
+        )
+
+        # 새 매니저로 로드 — bot_type/exchange 무시, account_id 사용
+        manager2 = BotManager(eventbus=eventbus, db=db)
+        await manager2.initialize()
+        count = await manager2.load_from_db()
+        assert count >= 1
+
+        bot = manager2.get_bot("old-bot")
+        assert bot is not None
+        assert bot.config.account_id == "test"
+        # bot_type, exchange는 BotConfig에 없으므로 속성 자체가 존재하지 않음
+        assert not hasattr(bot.config, "bot_type")
+        assert not hasattr(bot.config, "exchange")
+
+    async def test_bot_get_info_has_account(self, eventbus, ctx, simple_config):
+        """get_info()에 account_id 포함, bot_type 없음."""
+        bot = Bot(
+            config=simple_config,
+            strategy_cls=SimpleStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        info = bot.get_info()
+        assert "account_id" in info
+        assert info["account_id"] == "test"
+        assert "bot_type" not in info
+
+    async def test_bot_started_event_has_account_id(self, eventbus, ctx):
+        """봇 시작 시 BotStartedEvent에 account_id 포함."""
+        config = BotConfig(
+            bot_id="bot1",
+            strategy_id="s1",
+            account_id="my-account",
+            interval_seconds=999,
+        )
+        received = []
+        eventbus.subscribe(BotStartedEvent, lambda e: received.append(e))
+
+        bot = Bot(
+            config=config,
+            strategy_cls=SimpleStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        await bot.start()
+        assert len(received) == 1
+        assert received[0].account_id == "my-account"
+        await bot.stop()
+
+    async def test_bot_stopped_event_has_account_id(self, eventbus, ctx):
+        """봇 중지 시 BotStoppedEvent에 account_id 포함."""
+        config = BotConfig(
+            bot_id="bot1",
+            strategy_id="s1",
+            account_id="my-account",
+            interval_seconds=999,
+        )
+        received = []
+        eventbus.subscribe(BotStoppedEvent, lambda e: received.append(e))
+
+        bot = Bot(
+            config=config,
+            strategy_cls=SimpleStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        await bot.start()
+        await bot.stop()
+        assert len(received) == 1
+        assert received[0].account_id == "my-account"
+
+    async def test_cancel_event_has_account_id(self, eventbus, ctx):
+        """OrderCancelEvent에 account_id 포함."""
+
+        class CancelStrategy(Strategy):
+            meta = StrategyMeta(name="c", version="1.0.0", description="c")
+
+            async def on_step(self, context):
+                self.ctx.cancel_order("ord1", reason="test cancel")
+                return []
+
+        config = BotConfig(
+            bot_id="bot1",
+            strategy_id="c_v1.0.0",
+            account_id="acct-1",
+            interval_seconds=10,
+        )
+        received = []
+        eventbus.subscribe(OrderCancelEvent, lambda e: received.append(e))
+
+        bot = Bot(
+            config=config,
+            strategy_cls=CancelStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        await bot.start()
+        await asyncio.sleep(0.05)
+        await bot.stop()
+
+        assert len(received) >= 1
+        assert received[0].account_id == "acct-1"

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -30,7 +30,7 @@ class FakeBot:
             "bot_id": self.bot_id,
             "name": self.bot_id,
             "status": self._status,
-            "bot_type": "paper",
+            "account_id": "test",
             "strategy_id": self._strategy_id,
             "interval_seconds": 60,
             "started_at": None,

--- a/tests/unit/test_bot_guard.py
+++ b/tests/unit/test_bot_guard.py
@@ -54,7 +54,6 @@ def _make_bot(
     config = BotConfig(
         bot_id="bot-test",
         strategy_id="stg-test",
-        bot_type="paper",
         interval_seconds=interval,
         step_timeout_seconds=step_timeout,
         max_signals_per_step=max_signals,

--- a/tests/unit/test_bot_providers.py
+++ b/tests/unit/test_bot_providers.py
@@ -483,9 +483,9 @@ class TestStrategyContextFactory:
         config = BotConfig(
             bot_id="paper1",
             strategy_id="s1",
-            bot_type="paper",
             paper_initial_balance=5_000_000.0,
         )
+        # AccountService 미설정 → VIRTUAL 모드(paper) 기본 동작
         ctx = factory.create(config)
 
         assert isinstance(ctx, StrategyContext)
@@ -499,8 +499,20 @@ class TestStrategyContextFactory:
         assert balance["allocated"] == 5_000_000.0
 
     def test_create_live_context(self, eventbus):
-        """Live 봇 StrategyContext 생성."""
+        """Live 봇 StrategyContext 생성 (Account.trading_mode=LIVE)."""
+        from ante.account.models import Account, TradingMode
         from ante.bot.providers.live import LiveOrderView, LivePortfolioView
+
+        # AccountService mock: get_sync가 LIVE 모드 Account를 반환
+        class FakeAccountService:
+            def get_sync(self, account_id):
+                return Account(
+                    account_id=account_id,
+                    name="test",
+                    exchange="KRX",
+                    currency="KRW",
+                    trading_mode=TradingMode.LIVE,
+                )
 
         # 가짜 live providers
         class FakeLivePortfolio(LivePortfolioView):
@@ -522,11 +534,12 @@ class TestStrategyContextFactory:
 
         factory = StrategyContextFactory(
             data_provider=FakeDataProvider(),
+            account_service=FakeAccountService(),
             live_portfolio=FakeLivePortfolio(),
             live_order_view=FakeLiveOrders(),
         )
 
-        config = BotConfig(bot_id="live1", strategy_id="s1", bot_type="live")
+        config = BotConfig(bot_id="live1", strategy_id="s1", account_id="live-acct")
         ctx = factory.create(config)
 
         assert isinstance(ctx, StrategyContext)
@@ -534,8 +547,23 @@ class TestStrategyContextFactory:
 
     def test_live_without_providers_raises(self, eventbus):
         """Live providers 미설정 시 에러."""
-        factory = StrategyContextFactory(data_provider=FakeDataProvider())
-        config = BotConfig(bot_id="live1", strategy_id="s1", bot_type="live")
+        from ante.account.models import Account, TradingMode
+
+        class FakeAccountService:
+            def get_sync(self, account_id):
+                return Account(
+                    account_id=account_id,
+                    name="test",
+                    exchange="KRX",
+                    currency="KRW",
+                    trading_mode=TradingMode.LIVE,
+                )
+
+        factory = StrategyContextFactory(
+            data_provider=FakeDataProvider(),
+            account_service=FakeAccountService(),
+        )
+        config = BotConfig(bot_id="live1", strategy_id="s1", account_id="live-acct")
 
         with pytest.raises(ValueError, match="Provider"):
             factory.create(config)
@@ -574,7 +602,6 @@ class TestBotManagerWithFactory:
         config = BotConfig(
             bot_id="paper1",
             strategy_id="s1",
-            bot_type="paper",
             paper_initial_balance=5_000_000.0,
         )
         bot = await manager.create_bot(config, SimpleStrategy)
@@ -645,7 +672,7 @@ class TestBotManagerWithFactory:
         manager = BotManager(eventbus=eventbus, db=db, context_factory=factory)
         await manager.initialize()
 
-        config = BotConfig(bot_id="paper1", strategy_id="s1", bot_type="paper")
+        config = BotConfig(bot_id="paper1", strategy_id="s1")
         await manager.create_bot(config, SimpleStrategy)
         assert "paper1" in executor._portfolios
 

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -141,7 +141,7 @@ class TestBotCommands:
                         "bot_id": "bot-1",
                         "name": "테스트봇",
                         "strategy_id": "stg-1",
-                        "bot_type": "paper",
+                        "account_id": "test",
                         "status": "created",
                         "created_at": "2026-01-01",
                     }
@@ -175,7 +175,7 @@ class TestBotCommands:
                     "bot_id": "bot-1",
                     "name": "테스트봇",
                     "strategy_id": "stg-1",
-                    "bot_type": "live",
+                    "account_id": "test",
                     "status": "running",
                     "created_at": "2026-01-01",
                     "config_json": "{}",
@@ -206,8 +206,8 @@ class TestBotCommands:
                     "테스트봇",
                     "--strategy",
                     "stg-1",
-                    "--type",
-                    "paper",
+                    "--account",
+                    "test",
                 ],
             )
             assert result.exit_code == 0

--- a/tests/unit/test_external_signal_subscription.py
+++ b/tests/unit/test_external_signal_subscription.py
@@ -84,7 +84,6 @@ def _make_config(bot_id: str = "bot-001") -> BotConfig:
     return BotConfig(
         bot_id=bot_id,
         strategy_id="stg-001",
-        bot_type="paper",
         interval_seconds=60,
     )
 

--- a/tests/unit/test_external_signals.py
+++ b/tests/unit/test_external_signals.py
@@ -158,7 +158,7 @@ def _make_bot(strategy_cls: type[Strategy]) -> MagicMock:
     config = MagicMock()
     config.bot_id = "bot-001"
     config.strategy_id = "stg-001"
-    config.exchange = "KRX"
+    config.account_id = "test"
 
     ctx = MagicMock()
     ctx.get_positions.return_value = {}

--- a/tests/unit/test_instrument.py
+++ b/tests/unit/test_instrument.py
@@ -227,12 +227,12 @@ class TestExchangeDefaults:
         filled = OrderFilledEvent(symbol="005930")
         assert filled.exchange == "KRX"
 
-    def test_bot_config_default_exchange(self):
-        """BotConfig exchange 기본값 KRX."""
+    def test_bot_config_default_account_id(self):
+        """BotConfig account_id 기본값 test (exchange는 Account에서 관리)."""
         from ante.bot.config import BotConfig
 
         config = BotConfig(bot_id="bot-1", strategy_id="strat-1")
-        assert config.exchange == "KRX"
+        assert config.account_id == "test"
 
     def test_strategy_meta_default_exchange(self):
         """StrategyMeta exchange 기본값 KRX."""

--- a/tests/unit/test_kis_error_handling.py
+++ b/tests/unit/test_kis_error_handling.py
@@ -391,7 +391,6 @@ class TestBotCancelFailedHandling:
         config = BotConfig(
             bot_id="bot1",
             strategy_id="s1",
-            bot_type="paper",
         )
         bot = Bot(
             config=config,


### PR DESCRIPTION
## Summary

- `BotConfig`에서 `bot_type`·`exchange` 필드를 제거하고 `account_id` 필드를 추가
- `Bot`이 이벤트 발행 시 `account_id`를 포함하도록 변경 (OrderRequest, BotStarted, BotStopped, BotError, OrderCancel, OrderModify)
- `ContextFactory`가 `Account.trading_mode` 기반으로 Live/Paper 분기하도록 리팩토링
- `BotManager`의 DB 스키마에 `account_id` 컬럼 추가 및 기존 데이터 마이그레이션 지원
- `AccountService`에 동기 캐시 조회 `get_sync()` 메서드 추가
- Web API·CLI에서 `bot_type` → `account_id` 교체
- 기존 테스트 `bot_type` 참조 제거 + 신규 `account_id` 테스트 11건 추가

## Test plan

- [x] BotConfig에 account_id 필드 존재 및 기본값 "test" 검증
- [x] BotConfig에서 bot_type, exchange 필드 제거 확인
- [x] BotManager.create_bot()에 account_id 전달 및 DB 저장 검증
- [x] OrderRequestEvent에 account_id 포함 검증
- [x] DB 복원 시 account_id 유지 검증
- [x] 기존 bot_type/exchange 포함 config_json 마이그레이션 검증
- [x] get_info()에 account_id 포함, bot_type 없음 검증
- [x] BotStartedEvent, BotStoppedEvent에 account_id 포함 검증
- [x] OrderCancelEvent에 account_id 포함 검증
- [x] ContextFactory의 Account.trading_mode 분기 검증
- [x] 기존 테스트 189건 전체 통과

Refs #564