### PR TITLE
refactor(gateway): APIGateway 계좌 라우팅 전환 (#567)

### DIFF
--- a/src/ante/gateway/gateway.py
+++ b/src/ante/gateway/gateway.py
@@ -9,36 +9,64 @@ from ante.gateway.cache import ResponseCache
 from ante.gateway.rate_limiter import RateLimitConfig, RateLimiter
 
 if TYPE_CHECKING:
+    from ante.account.service import AccountService
     from ante.broker.base import BrokerAdapter
     from ante.eventbus.bus import EventBus
 
 logger = logging.getLogger(__name__)
 
 
+class _SingleBrokerAccountService:
+    """AccountService 미초기화 시 단일 브로커를 감싸는 폴백 래퍼.
+
+    모든 account_id에 대해 동일한 BrokerAdapter를 반환한다.
+    AccountService 통합 완료 후 제거 예정.
+    """
+
+    def __init__(self, broker: BrokerAdapter) -> None:
+        self._broker = broker
+
+    async def get_broker(self, account_id: str) -> BrokerAdapter:
+        """어떤 account_id든 동일 브로커 반환."""
+        return self._broker
+
+
 class APIGateway:
     """증권사 API 호출 중앙 관리.
 
-    - Rate limit 준수
-    - 응답 캐시 (시세, 잔고 등)
+    AccountService를 통해 계좌별 BrokerAdapter를 라우팅한다.
+    - 계좌별 독립 Rate limit 준수
+    - 계좌별 네임스페이스 캐시 (시세, 잔고 등)
     - EventBus 이벤트 기반 주문 처리
     - Stop order 라우팅 (StopOrderManager 연동)
     """
 
     def __init__(
         self,
-        broker: BrokerAdapter,
+        account_service: AccountService,
         eventbus: EventBus,
         rate_config: RateLimitConfig | None = None,
         stop_order_manager: Any | None = None,
     ) -> None:
-        self._broker = broker
+        self._account_service = account_service
         self._eventbus = eventbus
-        self._rate_limiter = RateLimiter(
-            rate_config or RateLimitConfig(max_requests=20, window_seconds=60)
+        self._default_rate_config = rate_config or RateLimitConfig(
+            max_requests=20, window_seconds=60
         )
+        self._rate_limiters: dict[str, RateLimiter] = {}
         self._cache = ResponseCache()
         self._running = False
         self._stop_order_manager = stop_order_manager
+
+    async def _get_broker(self, account_id: str) -> BrokerAdapter:
+        """AccountService에서 브로커 인스턴스를 획득한다."""
+        return await self._account_service.get_broker(account_id)
+
+    def _get_rate_limiter(self, account_id: str) -> RateLimiter:
+        """계좌별 독립 Rate Limiter를 반환한다."""
+        if account_id not in self._rate_limiters:
+            self._rate_limiters[account_id] = RateLimiter(self._default_rate_config)
+        return self._rate_limiters[account_id]
 
     def start(self) -> None:
         """이벤트 구독 시작."""
@@ -75,19 +103,22 @@ class APIGateway:
         timeframe: str = "1d",
         limit: int = 100,
         exchange: str = "KRX",
+        account_id: str = "",
     ) -> list[dict[str, Any]]:
         """과거 봉 데이터 조회 (캐시 우선).
 
+        OHLCV 캐시 키는 exchange 기반을 유지한다 (동일 거래소 데이터 공유).
         BrokerAdapter.get_ohlcv()가 미구현이면 빈 리스트를 반환한다.
-        추후 KIS 일봉 API 연동 시 BrokerAdapter에 구현체를 추가한다.
         """
         cache_key = f"ohlcv:{exchange}:{symbol}:{timeframe}:{limit}"
         cached = self._cache.get(cache_key)
         if cached is not None:
             return cached
 
-        await self._rate_limiter.acquire()
-        get_ohlcv = getattr(self._broker, "get_ohlcv", None)
+        rate_limiter = self._get_rate_limiter(account_id)
+        await rate_limiter.acquire()
+        broker = await self._get_broker(account_id)
+        get_ohlcv = getattr(broker, "get_ohlcv", None)
         if get_ohlcv is None:
             return []
         data: list[dict[str, Any]] = await get_ohlcv(
@@ -96,39 +127,47 @@ class APIGateway:
         self._cache.set(cache_key, data, ttl=60)
         return data
 
-    async def get_current_price(self, symbol: str, exchange: str = "KRX") -> float:
-        """현재가 조회 (캐시 우선)."""
-        cache_key = f"price:{exchange}:{symbol}"
+    async def get_current_price(
+        self, symbol: str, account_id: str = "", exchange: str = "KRX"
+    ) -> float:
+        """현재가 조회 (캐시 우선). account_id로 브로커 라우팅."""
+        cache_key = f"{account_id}:price:{symbol}"
         cached = self._cache.get(cache_key)
         if cached is not None:
             return cached
 
-        await self._rate_limiter.acquire()
-        price = await self._broker.get_current_price(symbol)
+        rate_limiter = self._get_rate_limiter(account_id)
+        await rate_limiter.acquire()
+        broker = await self._get_broker(account_id)
+        price = await broker.get_current_price(symbol)
         self._cache.set(cache_key, price, ttl=5)
         return price
 
-    async def get_positions(self) -> list[dict[str, Any]]:
-        """포지션 조회 (캐시 우선)."""
-        cache_key = "positions"
+    async def get_positions(self, account_id: str = "") -> list[dict[str, Any]]:
+        """포지션 조회 (캐시 우선). account_id로 브로커 라우팅."""
+        cache_key = f"{account_id}:positions"
         cached = self._cache.get(cache_key)
         if cached is not None:
             return cached
 
-        await self._rate_limiter.acquire()
-        positions = await self._broker.get_positions()
+        rate_limiter = self._get_rate_limiter(account_id)
+        await rate_limiter.acquire()
+        broker = await self._get_broker(account_id)
+        positions = await broker.get_positions()
         self._cache.set(cache_key, positions, ttl=30)
         return positions
 
-    async def get_account_balance(self) -> dict[str, float]:
-        """잔고 조회 (캐시 우선)."""
-        cache_key = "balance"
+    async def get_account_balance(self, account_id: str = "") -> dict[str, float]:
+        """잔고 조회 (캐시 우선). account_id로 브로커 라우팅."""
+        cache_key = f"{account_id}:balance"
         cached = self._cache.get(cache_key)
         if cached is not None:
             return cached
 
-        await self._rate_limiter.acquire()
-        balance = await self._broker.get_account_balance()
+        rate_limiter = self._get_rate_limiter(account_id)
+        await rate_limiter.acquire()
+        broker = await self._get_broker(account_id)
+        balance = await broker.get_account_balance()
         self._cache.set(cache_key, balance, ttl=30)
         return balance
 
@@ -140,10 +179,13 @@ class APIGateway:
         quantity: float,
         order_type: str = "market",
         price: float | None = None,
+        account_id: str = "",
     ) -> str:
-        """주문 제출. 캐시 없이 rate limit만 적용."""
-        await self._rate_limiter.acquire()
-        broker_order_id = await self._broker.place_order(
+        """주문 제출. 캐시 없이 rate limit만 적용. account_id로 브로커 라우팅."""
+        rate_limiter = self._get_rate_limiter(account_id)
+        await rate_limiter.acquire()
+        broker = await self._get_broker(account_id)
+        broker_order_id = await broker.place_order(
             symbol=symbol,
             side=side,
             quantity=quantity,
@@ -151,25 +193,29 @@ class APIGateway:
             price=price,
         )
         logger.info(
-            "주문 제출: %s %s %s %.0f주 → %s",
+            "주문 제출: %s %s %s %.0f주 → %s (account=%s)",
             bot_id,
             side,
             symbol,
             quantity,
             broker_order_id,
+            account_id,
         )
         return broker_order_id
 
-    async def cancel_order(self, order_id: str) -> bool:
-        """주문 취소."""
-        await self._rate_limiter.acquire()
-        return await self._broker.cancel_order(order_id)
+    async def cancel_order(self, order_id: str, account_id: str = "") -> bool:
+        """주문 취소. account_id로 브로커 라우팅."""
+        rate_limiter = self._get_rate_limiter(account_id)
+        await rate_limiter.acquire()
+        broker = await self._get_broker(account_id)
+        return await broker.cancel_order(order_id)
 
     # ── EventBus 핸들러 ──────────────────────────────
 
     async def _on_order_approved(self, event: object) -> None:
         """Treasury 자금 확보 완료 → 증권사에 주문 제출.
 
+        event.account_id로 올바른 BrokerAdapter를 라우팅한다.
         stop/stop_limit 주문은 StopOrderManager로 라우팅한다.
         """
         from ante.eventbus.events import (
@@ -201,6 +247,7 @@ class APIGateway:
                 logger.error("스탑 주문 등록 실패: %s — %s", event.order_id, e)
                 await self._eventbus.publish(
                     OrderFailedEvent(
+                        account_id=event.account_id,
                         order_id=event.order_id,
                         bot_id=event.bot_id,
                         strategy_id=event.strategy_id,
@@ -223,9 +270,11 @@ class APIGateway:
                 quantity=event.quantity,
                 order_type=event.order_type,
                 price=event.price,
+                account_id=event.account_id,
             )
             await self._eventbus.publish(
                 OrderSubmittedEvent(
+                    account_id=event.account_id,
                     order_id=event.order_id,
                     bot_id=event.bot_id,
                     strategy_id=event.strategy_id,
@@ -247,6 +296,7 @@ class APIGateway:
             logger.error("주문 제출 실패: %s — %s", event.order_id, e)
             await self._eventbus.publish(
                 OrderFailedEvent(
+                    account_id=event.account_id,
                     order_id=event.order_id,
                     bot_id=event.bot_id,
                     strategy_id=event.strategy_id,
@@ -262,7 +312,10 @@ class APIGateway:
             )
 
     async def _on_order_cancel(self, event: object) -> None:
-        """주문 취소 요청 → BrokerAdapter 전달 (룰 검증 생략)."""
+        """주문 취소 요청 → BrokerAdapter 전달 (룰 검증 생략).
+
+        event.account_id로 브로커를 선택한다.
+        """
         from ante.eventbus.events import (
             OrderCancelEvent,
             OrderCancelFailedEvent,
@@ -273,9 +326,10 @@ class APIGateway:
             return
 
         try:
-            await self.cancel_order(event.order_id)
+            await self.cancel_order(event.order_id, account_id=event.account_id)
             await self._eventbus.publish(
                 OrderCancelledEvent(
+                    account_id=event.account_id,
                     order_id=event.order_id,
                     bot_id=event.bot_id,
                     strategy_id=event.strategy_id,
@@ -309,7 +363,7 @@ class APIGateway:
         logger.warning("주문 정정은 추후 구현: %s", event.order_id)
 
     async def _on_order_filled(self, event: object) -> None:
-        """체결 시 관련 캐시 무효화.
+        """체결 시 해당 account_id 범위 내 캐시 무효화.
 
         Note: EventBus 핸들러 — isawaitable 패턴을 위해 async def 유지.
         """
@@ -317,6 +371,7 @@ class APIGateway:
 
         if not isinstance(event, OrderFilledEvent):
             return
-        self._cache.invalidate("balance")
-        self._cache.invalidate("positions")
-        self._cache.invalidate(f"price:{event.exchange}:{event.symbol}")
+        account_id = event.account_id
+        self._cache.invalidate(f"{account_id}:balance")
+        self._cache.invalidate(f"{account_id}:positions")
+        self._cache.invalidate(f"{account_id}:price:{event.symbol}")

--- a/src/ante/gateway/stream_integration.py
+++ b/src/ante/gateway/stream_integration.py
@@ -45,6 +45,7 @@ class StreamIntegration:
         stream_client: KISStreamClient,
         cache: ResponseCache,
         eventbus: EventBus,
+        account_id: str = "",
         stop_order_manager: StopOrderManager | None = None,
         gateway: APIGateway | None = None,
         bot_manager: BotManager | None = None,
@@ -54,6 +55,7 @@ class StreamIntegration:
         self._stream = stream_client
         self._cache = cache
         self._eventbus = eventbus
+        self._account_id = account_id
         self._stop_order_manager = stop_order_manager
         self._gateway = gateway
         self._bot_manager = bot_manager
@@ -140,11 +142,11 @@ class StreamIntegration:
         """실시간 시세 수신 콜백.
 
         KIS WebSocket ──시세수신──> 콜백
-            +-> ResponseCache.set("price:KRX:{symbol}", ...)
+            +-> ResponseCache.set("{account_id}:price:{symbol}", ...)
             +-> StopOrderManager.on_price_update(symbol, price)
         """
-        # 캐시 적재
-        cache_key = f"price:KRX:{symbol}"
+        # 캐시 적재 (account_id 기반 네임스페이스)
+        cache_key = f"{self._account_id}:price:{symbol}"
         self._cache.set(cache_key, price, ttl=5)
 
         # StopOrderManager 시세 전달
@@ -162,18 +164,20 @@ class StreamIntegration:
         캐시 무효화 + OrderFilledEvent 발행.
         """
         symbol = execution.get("symbol", "")
+        account_id = execution.get("account_id", self._account_id)
 
-        # 캐시 무효화: balance, positions, 해당 종목 시세
-        self._cache.invalidate("balance")
-        self._cache.invalidate("positions")
+        # 캐시 무효화: account_id 범위 내 balance, positions, 해당 종목 시세
+        self._cache.invalidate(f"{account_id}:balance")
+        self._cache.invalidate(f"{account_id}:positions")
         if symbol:
-            self._cache.invalidate(f"price:KRX:{symbol}")
+            self._cache.invalidate(f"{account_id}:price:{symbol}")
 
         # 체결 이벤트 발행
         from ante.eventbus.events import OrderFilledEvent
 
         await self._eventbus.publish(
             OrderFilledEvent(
+                account_id=account_id,
                 order_id=execution.get("order_id", ""),
                 symbol=symbol,
                 side=execution.get("side", ""),
@@ -235,8 +239,10 @@ class StreamIntegration:
                     if not self._fallback_active or not self._running:
                         return
                     try:
-                        price = await self._gateway.get_current_price(symbol)
-                        cache_key = f"price:KRX:{symbol}"
+                        price = await self._gateway.get_current_price(
+                            symbol, account_id=self._account_id
+                        )
+                        cache_key = f"{self._account_id}:price:{symbol}"
                         self._cache.set(cache_key, price, ttl=5)
 
                         if self._stop_order_manager:

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -312,8 +312,16 @@ async def _init_broker(s: Services) -> None:
     stop_order_manager.start()
 
     if s.broker:
+        # AccountService가 초기화된 경우 account_service 기반 라우팅 사용
+        if hasattr(s, "account_service") and s.account_service is not None:
+            account_svc = s.account_service
+        else:
+            # AccountService 미초기화 시 단일 브로커 래퍼로 폴백
+            from ante.gateway.gateway import _SingleBrokerAccountService
+
+            account_svc = _SingleBrokerAccountService(s.broker)
         s.api_gateway = APIGateway(
-            broker=s.broker,
+            account_service=account_svc,
             eventbus=s.eventbus,
             stop_order_manager=stop_order_manager,
         )

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -205,13 +205,19 @@ class TestAPIGateway:
         return b
 
     @pytest.fixture
+    def account_service(self, broker):
+        svc = AsyncMock()
+        svc.get_broker = AsyncMock(return_value=broker)
+        return svc
+
+    @pytest.fixture
     def eventbus(self):
         return EventBus()
 
     @pytest.fixture
-    async def gateway(self, broker, eventbus):
+    async def gateway(self, account_service, eventbus):
         gw = APIGateway(
-            broker=broker,
+            account_service=account_service,
             eventbus=eventbus,
             rate_config=RateLimitConfig(max_requests=100, window_seconds=60),
         )
@@ -219,44 +225,84 @@ class TestAPIGateway:
         return gw
 
     async def test_get_current_price(self, gateway, broker):
-        """현재가 조회."""
-        price = await gateway.get_current_price("005930")
+        """현재가 조회 — account_id 기반 브로커 라우팅."""
+        price = await gateway.get_current_price("005930", account_id="acc-001")
         assert price == 50000.0
         broker.get_current_price.assert_called_once_with("005930")
 
     async def test_get_current_price_cached(self, gateway, broker):
-        """현재가 캐시 적중."""
-        await gateway.get_current_price("005930")
-        await gateway.get_current_price("005930")
+        """현재가 캐시 적중 — 동일 account_id는 캐시 공유."""
+        await gateway.get_current_price("005930", account_id="acc-001")
+        await gateway.get_current_price("005930", account_id="acc-001")
         assert broker.get_current_price.call_count == 1
 
+    async def test_get_current_price_different_accounts(
+        self, gateway, broker, account_service
+    ):
+        """서로 다른 account_id는 캐시가 분리된다."""
+        await gateway.get_current_price("005930", account_id="acc-001")
+        await gateway.get_current_price("005930", account_id="acc-002")
+        assert broker.get_current_price.call_count == 2
+
     async def test_get_positions(self, gateway, broker):
-        """포지션 조회."""
-        positions = await gateway.get_positions()
+        """포지션 조회 — account_id로 라우팅."""
+        positions = await gateway.get_positions(account_id="acc-001")
         assert len(positions) == 1
         assert positions[0]["symbol"] == "005930"
 
+    async def test_get_positions_cached_per_account(self, gateway, broker):
+        """포지션 캐시가 account_id별로 분리된다."""
+        await gateway.get_positions(account_id="acc-001")
+        await gateway.get_positions(account_id="acc-001")
+        assert broker.get_positions.call_count == 1
+
+        await gateway.get_positions(account_id="acc-002")
+        assert broker.get_positions.call_count == 2
+
     async def test_get_account_balance(self, gateway, broker):
-        """잔고 조회."""
-        balance = await gateway.get_account_balance()
+        """잔고 조회 — account_id로 라우팅."""
+        balance = await gateway.get_account_balance(account_id="acc-001")
         assert balance["cash"] == 5000000.0
 
+    async def test_get_account_balance_cached_per_account(self, gateway, broker):
+        """잔고 캐시가 account_id별로 분리된다."""
+        await gateway.get_account_balance(account_id="acc-001")
+        await gateway.get_account_balance(account_id="acc-001")
+        assert broker.get_account_balance.call_count == 1
+
+        await gateway.get_account_balance(account_id="acc-002")
+        assert broker.get_account_balance.call_count == 2
+
     async def test_submit_order(self, gateway, broker):
-        """주문 제출."""
+        """주문 제출 — account_id로 라우팅."""
         order_id = await gateway.submit_order(
             bot_id="bot1",
             symbol="005930",
             side="buy",
             quantity=10,
+            account_id="acc-001",
         )
         assert order_id == "BROKER_ORD_001"
         broker.place_order.assert_called_once()
 
     async def test_cancel_order(self, gateway, broker):
-        """주문 취소."""
-        result = await gateway.cancel_order("ORD001")
+        """주문 취소 — account_id로 라우팅."""
+        result = await gateway.cancel_order("ORD001", account_id="acc-001")
         assert result is True
         broker.cancel_order.assert_called_once_with("ORD001")
+
+    async def test_rate_limiter_per_account(self, gateway):
+        """계좌별 독립 rate limiter 생성."""
+        rl1 = gateway._get_rate_limiter("acc-001")
+        rl2 = gateway._get_rate_limiter("acc-002")
+        rl1_again = gateway._get_rate_limiter("acc-001")
+        assert rl1 is not rl2
+        assert rl1 is rl1_again
+
+    async def test_account_service_get_broker_called(self, gateway, account_service):
+        """AccountService.get_broker()가 호출된다."""
+        await gateway.get_current_price("005930", account_id="acc-001")
+        account_service.get_broker.assert_called_with("acc-001")
 
 
 # ── APIGateway EventBus 통합 ──────────────────────
@@ -271,26 +317,35 @@ class TestAPIGatewayEvents:
         return b
 
     @pytest.fixture
+    def account_service(self, broker):
+        svc = AsyncMock()
+        svc.get_broker = AsyncMock(return_value=broker)
+        return svc
+
+    @pytest.fixture
     def eventbus(self):
         return EventBus()
 
     @pytest.fixture
-    async def gateway(self, broker, eventbus):
+    async def gateway(self, account_service, eventbus):
         gw = APIGateway(
-            broker=broker,
+            account_service=account_service,
             eventbus=eventbus,
             rate_config=RateLimitConfig(max_requests=100, window_seconds=60),
         )
         gw.start()
         return gw
 
-    async def test_order_approved_submits(self, gateway, eventbus, broker):
-        """OrderApprovedEvent → 주문 제출 → OrderSubmittedEvent."""
+    async def test_order_approved_submits_with_account_id(
+        self, gateway, eventbus, broker, account_service
+    ):
+        """OrderApprovedEvent → account_id로 브로커 라우팅 → OrderSubmittedEvent."""
         received = []
         eventbus.subscribe(OrderSubmittedEvent, lambda e: received.append(e))
 
         await eventbus.publish(
             OrderApprovedEvent(
+                account_id="acc-001",
                 order_id="ord1",
                 bot_id="bot1",
                 strategy_id="s1",
@@ -305,10 +360,13 @@ class TestAPIGatewayEvents:
         assert len(received) == 1
         assert received[0].broker_order_id == "BROKER_ORD_001"
         assert received[0].order_id == "ord1"
-        assert received[0].bot_id == "bot1"
+        assert received[0].account_id == "acc-001"
+        account_service.get_broker.assert_called_with("acc-001")
 
-    async def test_order_approved_failure(self, gateway, eventbus, broker):
-        """주문 제출 실패 → OrderFailedEvent."""
+    async def test_order_approved_failure(
+        self, gateway, eventbus, broker, account_service
+    ):
+        """주문 제출 실패 → OrderFailedEvent에 account_id 포함."""
         broker.place_order = AsyncMock(side_effect=RuntimeError("broker error"))
 
         received = []
@@ -316,6 +374,7 @@ class TestAPIGatewayEvents:
 
         await eventbus.publish(
             OrderApprovedEvent(
+                account_id="acc-001",
                 order_id="ord1",
                 bot_id="bot1",
                 strategy_id="s1",
@@ -329,9 +388,12 @@ class TestAPIGatewayEvents:
 
         assert len(received) == 1
         assert "broker error" in received[0].error_message
+        assert received[0].account_id == "acc-001"
         assert received[0].error_code == ""
 
-    async def test_order_failure_with_api_error_code(self, gateway, eventbus, broker):
+    async def test_order_failure_with_api_error_code(
+        self, gateway, eventbus, broker, account_service
+    ):
         """APIError 주문 실패 → error_code 전달."""
         from ante.broker.exceptions import APIError
 
@@ -349,6 +411,7 @@ class TestAPIGatewayEvents:
 
         await eventbus.publish(
             OrderApprovedEvent(
+                account_id="acc-001",
                 order_id="ord1",
                 bot_id="bot1",
                 strategy_id="s1",
@@ -364,13 +427,16 @@ class TestAPIGatewayEvents:
         assert received[0].error_code == "APBK0919"
         assert "잔고 부족" in received[0].error_message
 
-    async def test_order_cancel_event(self, gateway, eventbus, broker):
-        """OrderCancelEvent → 취소 → OrderCancelledEvent."""
+    async def test_order_cancel_event_with_account_id(
+        self, gateway, eventbus, broker, account_service
+    ):
+        """OrderCancelEvent → account_id로 브로커 선택 → OrderCancelledEvent."""
         received = []
         eventbus.subscribe(OrderCancelledEvent, lambda e: received.append(e))
 
         await eventbus.publish(
             OrderCancelEvent(
+                account_id="acc-001",
                 bot_id="bot1",
                 strategy_id="s1",
                 order_id="ord1",
@@ -381,16 +447,24 @@ class TestAPIGatewayEvents:
         assert len(received) == 1
         assert received[0].order_id == "ord1"
         assert received[0].reason == "test cancel"
+        assert received[0].account_id == "acc-001"
+        account_service.get_broker.assert_called_with("acc-001")
 
-    async def test_order_filled_invalidates_cache(self, gateway, eventbus, broker):
-        """체결 시 캐시 무효화."""
-        # 캐시에 데이터 넣기
-        gateway._cache.set("balance", {"cash": 5000000}, ttl=60)
-        gateway._cache.set("positions", [], ttl=60)
-        gateway._cache.set("price:KRX:005930", 50000, ttl=60)
+    async def test_order_filled_invalidates_account_cache(
+        self, gateway, eventbus, broker
+    ):
+        """체결 시 해당 account_id 범위 내 캐시만 무효화."""
+        # acc-001 캐시
+        gateway._cache.set("acc-001:balance", {"cash": 5000000}, ttl=60)
+        gateway._cache.set("acc-001:positions", [], ttl=60)
+        gateway._cache.set("acc-001:price:005930", 50000, ttl=60)
+        # acc-002 캐시 (영향 받지 않아야 함)
+        gateway._cache.set("acc-002:balance", {"cash": 3000000}, ttl=60)
+        gateway._cache.set("acc-002:positions", [{"symbol": "000660"}], ttl=60)
 
         await eventbus.publish(
             OrderFilledEvent(
+                account_id="acc-001",
                 order_id="ord1",
                 broker_order_id="bk1",
                 bot_id="bot1",
@@ -403,9 +477,13 @@ class TestAPIGatewayEvents:
             )
         )
 
-        assert gateway._cache.get("balance") is None
-        assert gateway._cache.get("positions") is None
-        assert gateway._cache.get("price:KRX:005930") is None
+        # acc-001 캐시 무효화 확인
+        assert gateway._cache.get("acc-001:balance") is None
+        assert gateway._cache.get("acc-001:positions") is None
+        assert gateway._cache.get("acc-001:price:005930") is None
+        # acc-002 캐시 유지 확인
+        assert gateway._cache.get("acc-002:balance") == {"cash": 3000000}
+        assert gateway._cache.get("acc-002:positions") == [{"symbol": "000660"}]
 
 
 # ── LiveDataProvider ───────────────────────────────

--- a/tests/unit/test_gateway_stop_routing.py
+++ b/tests/unit/test_gateway_stop_routing.py
@@ -23,6 +23,14 @@ def broker() -> MagicMock:
 
 
 @pytest.fixture
+def account_service(broker: MagicMock) -> MagicMock:
+    """AccountService mock."""
+    svc = MagicMock()
+    svc.get_broker = AsyncMock(return_value=broker)
+    return svc
+
+
+@pytest.fixture
 def eventbus() -> MagicMock:
     """EventBus mock."""
     bus = MagicMock()
@@ -41,20 +49,20 @@ def stop_manager(eventbus: MagicMock) -> MagicMock:
 
 @pytest.fixture
 def gateway(
-    broker: MagicMock, eventbus: MagicMock, stop_manager: MagicMock
+    account_service: MagicMock, eventbus: MagicMock, stop_manager: MagicMock
 ) -> APIGateway:
     """APIGateway with StopOrderManager."""
     return APIGateway(
-        broker=broker,
+        account_service=account_service,
         eventbus=eventbus,
         stop_order_manager=stop_manager,
     )
 
 
 @pytest.fixture
-def gateway_no_stop(broker: MagicMock, eventbus: MagicMock) -> APIGateway:
+def gateway_no_stop(account_service: MagicMock, eventbus: MagicMock) -> APIGateway:
     """APIGateway without StopOrderManager."""
-    return APIGateway(broker=broker, eventbus=eventbus)
+    return APIGateway(account_service=account_service, eventbus=eventbus)
 
 
 class TestStopOrderRouting:

--- a/tests/unit/test_kis_error_handling.py
+++ b/tests/unit/test_kis_error_handling.py
@@ -351,8 +351,10 @@ class TestGatewayCancelFailed:
         eventbus = EventBus()
         mock_broker = AsyncMock()
         mock_broker.cancel_order = AsyncMock(side_effect=Exception("network error"))
+        mock_account_service = AsyncMock()
+        mock_account_service.get_broker = AsyncMock(return_value=mock_broker)
 
-        gw = APIGateway(broker=mock_broker, eventbus=eventbus)
+        gw = APIGateway(account_service=mock_account_service, eventbus=eventbus)
         gw.start()
 
         received: list[OrderCancelFailedEvent] = []

--- a/tests/unit/test_stream_integration.py
+++ b/tests/unit/test_stream_integration.py
@@ -124,6 +124,7 @@ def integration(
         stream_client=stream_client,
         cache=cache,
         eventbus=eventbus,
+        account_id="acc-001",
         stop_order_manager=stop_order_manager,
         gateway=gateway_mock,
         bot_manager=bot_manager_mock,
@@ -146,7 +147,7 @@ async def test_price_callback_updates_cache(
     try:
         await stream_client.fire_price("005930", 72000.0)
 
-        cached = cache.get("price:KRX:005930")
+        cached = cache.get("acc-001:price:005930")
         assert cached == 72000.0
     finally:
         await integration.stop()
@@ -199,10 +200,10 @@ async def test_execution_callback_invalidates_cache(
     """체결 통보 시 balance, positions, 해당 종목 시세 캐시가 무효화된다."""
     await integration.start()
     try:
-        # 캐시 사전 적재
-        cache.set("balance", {"total": 1000000}, ttl=30)
-        cache.set("positions", [{"symbol": "005930"}], ttl=30)
-        cache.set("price:KRX:005930", 70000.0, ttl=5)
+        # 캐시 사전 적재 (account_id 기반 네임스페이스)
+        cache.set("acc-001:balance", {"total": 1000000}, ttl=30)
+        cache.set("acc-001:positions", [{"symbol": "005930"}], ttl=30)
+        cache.set("acc-001:price:005930", 70000.0, ttl=5)
 
         execution = {
             "symbol": "005930",
@@ -213,9 +214,9 @@ async def test_execution_callback_invalidates_cache(
         }
         await stream_client.fire_execution(execution)
 
-        assert cache.get("balance") is None
-        assert cache.get("positions") is None
-        assert cache.get("price:KRX:005930") is None
+        assert cache.get("acc-001:balance") is None
+        assert cache.get("acc-001:positions") is None
+        assert cache.get("acc-001:price:005930") is None
     finally:
         await integration.stop()
 
@@ -330,8 +331,8 @@ async def test_fallback_polls_prices(
         ]
         assert "005930" in call_args
 
-        # 캐시에 가격 적재 확인
-        cached = cache.get("price:KRX:005930")
+        # 캐시에 가격 적재 확인 (account_id 기반 네임스페이스)
+        cached = cache.get("acc-001:price:005930")
         assert cached == 50000.0
     finally:
         await integration.stop()


### PR DESCRIPTION
## Summary

- APIGateway가 단일 `_broker` 대신 `AccountService.get_broker(account_id)`로 계좌별 브로커를 라우팅
- 모든 공개 메서드에 `account_id` 파라미터 추가
- 캐시/레이트리미터를 계좌별로 분리
- StreamIntegration 캐시 키를 account_id 기반 네임스페이스로 변경
- 기존 테스트 전면 업데이트 및 신규 테스트 추가 (계좌별 캐시 분리, rate limiter 분리 등)

Refs #567

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `src/ante/gateway/gateway.py` | 생성자: broker → account_service. 메서드에 account_id 파라미터. 캐시/레이트리미터 account별 분리 |
| `src/ante/gateway/stream_integration.py` | 캐시 키에 account_id 기반으로 변경 |
| `src/ante/main.py` | APIGateway 생성 시 AccountService 사용 (미초기화 시 폴백 래퍼) |
| `tests/unit/test_gateway.py` | account_id 파라미터 테스트 전면 갱신 |
| `tests/unit/test_gateway_stop_routing.py` | account_service 기반으로 fixture 갱신 |
| `tests/unit/test_kis_error_handling.py` | APIGateway 시그니처 변경 반영 |
| `tests/unit/test_stream_integration.py` | account_id 기반 캐시 키 테스트 반영 |

## Test plan

- [x] `pytest tests/unit/test_gateway.py` — 37개 통과
- [x] `pytest tests/unit/test_gateway_stop_routing.py` — 5개 통과
- [x] `pytest tests/unit/test_stream_integration.py` — 15개 통과
- [x] `pytest tests/unit/test_kis_error_handling.py` — 모두 통과
- [x] `pytest tests/unit/test_main.py` — 모두 통과
- [x] `ruff check` + `ruff format` 통과

Generated with [Claude Code](https://claude.com/claude-code)