### PR TITLE
feat(strategy): exchange 호환성 검증 추가

### DIFF
--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -13,6 +13,7 @@ from ante.bot.config import BotConfig, BotStatus
 from ante.bot.exceptions import BotError
 
 if TYPE_CHECKING:
+    from ante.account.service import AccountService
     from ante.bot.context_factory import StrategyContextFactory
     from ante.bot.signal_key import SignalKeyManager  # noqa: F811
     from ante.core.database import Database
@@ -52,6 +53,7 @@ class BotManager:
         snapshot: StrategySnapshot | None = None,
         rule_engine: RuleEngine | None = None,
         strategy_rule_configs: dict[str, list[dict[str, Any]]] | None = None,
+        account_service: AccountService | None = None,
     ) -> None:
         self._eventbus = eventbus
         self._db = db
@@ -60,6 +62,7 @@ class BotManager:
         self._snapshot = snapshot
         self._rule_engine = rule_engine
         self._strategy_rule_configs = strategy_rule_configs or {}
+        self._account_service = account_service
         self._bots: dict[str, Bot] = {}
         self._suppress_notification_bot_ids: set[str] = set()
         self._restart_counts: dict[str, int] = {}
@@ -190,6 +193,20 @@ class BotManager:
                     f"'{existing_bot.bot_id}'에서 사용 중입니다. "
                     f"파라미터가 다른 전략은 별도 파일로 작성하세요."
                 )
+
+        # exchange 호환성 검증
+        if self._account_service and hasattr(strategy_cls, "meta"):
+            strategy_exchange = getattr(strategy_cls.meta, "exchange", "KRX")
+            strategy_name = getattr(strategy_cls.meta, "name", config.strategy_id)
+            account = await self._account_service.get(config.account_id)
+            from ante.strategy.validator import validate_exchange
+
+            validate_exchange(
+                strategy_exchange=strategy_exchange,
+                account_exchange=account.exchange,
+                strategy_name=strategy_name,
+                account_name=account.name,
+            )
 
         # 전략 파일 스냅샷 생성
         if self._snapshot and source_path:

--- a/src/ante/strategy/__init__.py
+++ b/src/ante/strategy/__init__.py
@@ -12,6 +12,7 @@ from ante.strategy.base import (
 )
 from ante.strategy.context import StrategyContext
 from ante.strategy.exceptions import (
+    IncompatibleExchangeError,
     StrategyError,
     StrategyFileAccessError,
     StrategyLoadError,
@@ -21,10 +22,16 @@ from ante.strategy.indicators import IndicatorCalculator
 from ante.strategy.loader import StrategyLoader
 from ante.strategy.registry import StrategyRecord, StrategyRegistry, StrategyStatus
 from ante.strategy.snapshot import StrategySnapshot
-from ante.strategy.validator import StrategyValidator, ValidationResult
+from ante.strategy.validator import (
+    VALID_EXCHANGES,
+    StrategyValidator,
+    ValidationResult,
+    validate_exchange,
+)
 
 __all__ = [
     "DataProvider",
+    "IncompatibleExchangeError",
     "IndicatorCalculator",
     "OrderAction",
     "OrderView",
@@ -44,5 +51,7 @@ __all__ = [
     "StrategyValidationError",
     "TradeHistoryView",
     "StrategyValidator",
+    "VALID_EXCHANGES",
     "ValidationResult",
+    "validate_exchange",
 ]

--- a/src/ante/strategy/exceptions.py
+++ b/src/ante/strategy/exceptions.py
@@ -23,3 +23,9 @@ class StrategyFileAccessError(StrategyError):
     """전략 파일 접근 오류."""
 
     pass
+
+
+class IncompatibleExchangeError(StrategyError):
+    """전략의 exchange와 계좌의 exchange가 호환되지 않음."""
+
+    pass

--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -6,6 +6,8 @@ import ast
 from dataclasses import dataclass, field
 from pathlib import Path
 
+VALID_EXCHANGES: set[str] = {"KRX", "NYSE", "NASDAQ", "AMEX", "TEST", "*"}
+
 
 @dataclass
 class ValidationResult:
@@ -97,7 +99,16 @@ class StrategyValidator:
                     "implement on_data() — external signals will use default handler"
                 )
 
-        # 4. 금지 모듈 import
+        # 4. exchange 유효성 검증
+        if len(strategy_classes) == 1:
+            exchange_value = self._extract_meta_exchange(strategy_classes[0])
+            if exchange_value is not None and exchange_value not in VALID_EXCHANGES:
+                errors.append(
+                    f"Invalid exchange value: '{exchange_value}'. "
+                    f"Valid values: {sorted(VALID_EXCHANGES)}"
+                )
+
+        # 5. 금지 모듈 import
         forbidden = self._find_forbidden_imports(tree)
         for module in forbidden:
             errors.append(f"Forbidden import: {module}")
@@ -148,6 +159,22 @@ class StrategyValidator:
                 if node.name == name:
                     return True
         return False
+
+    def _extract_meta_exchange(self, cls: ast.ClassDef) -> str | None:
+        """meta에서 exchange 값을 추출. 없으면 None 반환."""
+        for node in cls.body:
+            if isinstance(node, ast.Assign | ast.AnnAssign):
+                target = (
+                    node.targets[0] if isinstance(node, ast.Assign) else node.target
+                )
+                if not isinstance(target, ast.Name) or target.id != "meta":
+                    continue
+                value = node.value
+                if isinstance(value, ast.Call):
+                    for kw in value.keywords:
+                        if kw.arg == "exchange" and isinstance(kw.value, ast.Constant):
+                            return str(kw.value.value)
+        return None
 
     def _has_accepts_external_signals(self, cls: ast.ClassDef) -> bool:
         """meta에 accepts_external_signals=True 설정 여부 탐지."""
@@ -238,3 +265,46 @@ class StrategyValidator:
         warnings: list[str] = []
         # open()은 FORBIDDEN_BUILTINS로 승격되어 에러로 처리됨
         return warnings
+
+
+def validate_exchange(
+    strategy_exchange: str,
+    account_exchange: str,
+    *,
+    strategy_name: str = "",
+    account_name: str = "",
+) -> None:
+    """전략의 exchange와 계좌의 exchange 호환성을 런타임 검증.
+
+    전략 exchange가 "*"이면 모든 계좌와 호환된다.
+    그 외에는 전략 exchange와 계좌 exchange가 정확히 일치해야 한다.
+
+    Raises:
+        IncompatibleExchangeError: 호환되지 않는 경우.
+        ValueError: 유효하지 않은 exchange 값인 경우.
+    """
+    from ante.strategy.exceptions import IncompatibleExchangeError
+
+    if strategy_exchange not in VALID_EXCHANGES:
+        raise ValueError(
+            f"유효하지 않은 전략 exchange: '{strategy_exchange}'. "
+            f"허용 값: {sorted(VALID_EXCHANGES)}"
+        )
+
+    if account_exchange not in VALID_EXCHANGES or account_exchange == "*":
+        raise ValueError(
+            f"유효하지 않은 계좌 exchange: '{account_exchange}'. "
+            f"허용 값: {sorted(VALID_EXCHANGES - {'*'})}"
+        )
+
+    if strategy_exchange == "*":
+        return
+
+    if strategy_exchange != account_exchange:
+        strategy_desc = f"'{strategy_name}'" if strategy_name else "전략"
+        account_desc = f"'{account_name}'" if account_name else "계좌"
+        raise IncompatibleExchangeError(
+            f"{strategy_desc}의 exchange({strategy_exchange})와 "
+            f"{account_desc}의 exchange({account_exchange})가 "
+            f"호환되지 않습니다."
+        )

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -886,3 +886,117 @@ class TestBotManager:
 
         assert len(received) >= 1
         assert received[0].account_id == "acct-1"
+
+
+# ── Exchange 호환성 검증 (BotManager) ───────────────
+
+
+class TestBotManagerExchangeValidation:
+    """BotManager.create_bot() exchange 호환성 검증 테스트."""
+
+    @pytest.fixture
+    async def db(self, tmp_path):
+        database = Database(str(tmp_path / "test.db"))
+        await database.connect()
+        yield database
+        try:
+            await asyncio.wait_for(database.close(), timeout=5.0)
+        except TimeoutError:
+            pass
+
+    @pytest.fixture
+    async def account_service(self, db, eventbus):
+        from ante.account.service import AccountService
+
+        svc = AccountService(db=db, eventbus=eventbus)
+        await svc.initialize()
+        return svc
+
+    @pytest.fixture
+    async def manager_with_account(self, eventbus, db, account_service):
+        m = BotManager(eventbus=eventbus, db=db, account_service=account_service)
+        await m.initialize()
+        yield m
+        for bot in list(m._bots.values()):
+            if bot._task and not bot._task.done():
+                bot._task.cancel()
+        try:
+            await asyncio.wait_for(m.stop_all(), timeout=5.0)
+        except TimeoutError:
+            pass
+
+    async def test_compatible_exchange_allowed(
+        self, manager_with_account, account_service, ctx
+    ):
+        """동일 exchange 조합은 봇 생성 허용."""
+        from ante.account.models import Account
+
+        account = Account(
+            account_id="krx-acct",
+            name="국내계좌",
+            exchange="KRX",
+            currency="KRW",
+            broker_type="test",
+        )
+        await account_service.create(account)
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="krx-acct")
+        # SimpleStrategy.meta.exchange는 기본값 "KRX"
+        bot = await manager_with_account.create_bot(config, SimpleStrategy, ctx)
+        assert bot.status == BotStatus.CREATED
+
+    async def test_incompatible_exchange_rejected(
+        self, manager_with_account, account_service, ctx
+    ):
+        """KRX 전략 + NYSE 계좌 → IncompatibleExchangeError."""
+        from ante.account.models import Account
+        from ante.strategy.exceptions import IncompatibleExchangeError
+
+        account = Account(
+            account_id="nyse-acct",
+            name="미국계좌",
+            exchange="NYSE",
+            currency="USD",
+            broker_type="test",
+        )
+        await account_service.create(account)
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="nyse-acct")
+        with pytest.raises(IncompatibleExchangeError, match="simple"):
+            await manager_with_account.create_bot(config, SimpleStrategy, ctx)
+
+    async def test_wildcard_exchange_allowed(
+        self, manager_with_account, account_service, ctx
+    ):
+        """전략 exchange='*'이면 어떤 계좌든 허용."""
+        from ante.account.models import Account
+
+        class WildcardStrategy(Strategy):
+            meta = StrategyMeta(
+                name="wildcard",
+                version="1.0.0",
+                description="test",
+                exchange="*",
+            )
+
+            async def on_step(self, context):
+                return []
+
+        account = Account(
+            account_id="nyse-acct",
+            name="미국계좌",
+            exchange="NYSE",
+            currency="USD",
+            broker_type="test",
+        )
+        await account_service.create(account)
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="nyse-acct")
+        bot = await manager_with_account.create_bot(config, WildcardStrategy, ctx)
+        assert bot.status == BotStatus.CREATED
+
+    async def test_no_account_service_skips_validation(self, eventbus, db, ctx):
+        """AccountService 미주입 시 exchange 검증 스킵."""
+        manager = BotManager(eventbus=eventbus, db=db)
+        await manager.initialize()
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="any-acct")
+        # account_service가 없으므로 검증 스킵, 정상 생성
+        bot = await manager.create_bot(config, SimpleStrategy, ctx)
+        assert bot.status == BotStatus.CREATED

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -19,10 +19,12 @@ from ante.strategy import (
     StrategyValidator,
 )
 from ante.strategy.exceptions import (
+    IncompatibleExchangeError,
     StrategyError,
     StrategyFileAccessError,
     StrategyLoadError,
 )
+from ante.strategy.validator import validate_exchange
 
 # ── Test fixtures ─────────────────────────────────
 
@@ -704,3 +706,138 @@ class TestStrategyRegistry:
         await registry.register(filepath, meta)
 
         assert await registry.exists("momentum_v1.0.0")
+
+
+# ── Exchange 호환성 검증 테스트 ──────────────────────
+
+
+class TestValidateExchange:
+    """validate_exchange() 런타임 검증 테스트."""
+
+    def test_same_exchange_allowed(self):
+        """동일 exchange는 허용."""
+        validate_exchange("KRX", "KRX")  # should not raise
+
+    def test_wildcard_allows_any(self):
+        """전략 exchange='*'이면 모든 계좌 허용."""
+        validate_exchange("*", "KRX")
+        validate_exchange("*", "NYSE")
+        validate_exchange("*", "TEST")
+
+    def test_different_exchange_rejected(self):
+        """다른 exchange 조합은 거부."""
+        with pytest.raises(IncompatibleExchangeError):
+            validate_exchange("KRX", "NYSE")
+
+    def test_different_exchange_rejected_reverse(self):
+        """NYSE 전략 + KRX 계좌 거부."""
+        with pytest.raises(IncompatibleExchangeError):
+            validate_exchange("NYSE", "KRX")
+
+    def test_error_message_includes_names(self):
+        """에러 메시지에 전략명·계좌명 포함."""
+        with pytest.raises(IncompatibleExchangeError, match="momentum") as exc_info:
+            validate_exchange(
+                "KRX",
+                "NYSE",
+                strategy_name="momentum",
+                account_name="미국계좌",
+            )
+        assert "미국계좌" in str(exc_info.value)
+
+    def test_invalid_strategy_exchange(self):
+        """유효하지 않은 전략 exchange → ValueError."""
+        with pytest.raises(ValueError, match="유효하지 않은 전략"):
+            validate_exchange("INVALID", "KRX")
+
+    def test_invalid_account_exchange(self):
+        """유효하지 않은 계좌 exchange → ValueError."""
+        with pytest.raises(ValueError, match="유효하지 않은 계좌"):
+            validate_exchange("KRX", "INVALID")
+
+    def test_account_wildcard_rejected(self):
+        """계좌 exchange에 '*'는 허용하지 않음."""
+        with pytest.raises(ValueError, match="유효하지 않은 계좌"):
+            validate_exchange("KRX", "*")
+
+    def test_all_valid_exchanges(self):
+        """모든 유효한 exchange 조합 테스트."""
+        for exchange in ("KRX", "NYSE", "NASDAQ", "AMEX", "TEST"):
+            validate_exchange(exchange, exchange)  # same → OK
+            validate_exchange("*", exchange)  # wildcard → OK
+
+
+class TestValidatorExchangeCheck:
+    """StrategyValidator AST 기반 exchange 유효성 검증 테스트."""
+
+    @pytest.fixture
+    def validator(self):
+        return StrategyValidator()
+
+    def _write_strategy(self, tmp_path: Path, code: str) -> Path:
+        filepath = tmp_path / "test_strategy.py"
+        filepath.write_text(code)
+        return filepath
+
+    def test_valid_exchange(self, validator, tmp_path):
+        """유효한 exchange 값은 검증 통과."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0.0",
+        description="test", exchange="NYSE",
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+
+    def test_invalid_exchange(self, validator, tmp_path):
+        """유효하지 않은 exchange 값 → 에러."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(
+        name="test", version="1.0.0",
+        description="test", exchange="INVALID",
+    )
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert not result.valid
+        assert any("Invalid exchange" in e for e in result.errors)
+
+    def test_wildcard_exchange(self, validator, tmp_path):
+        """exchange='*' 범용 전략은 검증 통과."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="test", version="1.0.0", description="test", exchange="*")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid
+
+    def test_no_exchange_specified(self, validator, tmp_path):
+        """exchange 미지정 시 기본값(KRX) 사용 — 검증 통과."""
+        code = """
+from ante.strategy import Strategy, StrategyMeta
+
+class TestStrategy(Strategy):
+    meta = StrategyMeta(name="test", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+"""
+        result = validator.validate(self._write_strategy(tmp_path, code))
+        assert result.valid


### PR DESCRIPTION
## Summary

봇 생성 시 전략의 `exchange`와 계좌의 `exchange` 호환성을 검증합니다.

- `IncompatibleExchangeError` 예외 추가 (`strategy/exceptions.py`)
- `validate_exchange()` 런타임 검증 함수 추가 (`strategy/validator.py`)
- `VALID_EXCHANGES` 상수 정의: `{"KRX", "NYSE", "NASDAQ", "AMEX", "TEST", "*"}`
- `StrategyValidator`에 AST 기반 `meta.exchange` 유효성 검증 추가
- `BotManager.create_bot()`에 `AccountService` 연동 exchange 호환성 검증

### 검증 매트릭스

| 전략 exchange | 계좌 exchange | 결과 |
|--------------|--------------|------|
| KRX | KRX | 허용 |
| KRX | NYSE | 거부 (IncompatibleExchangeError) |
| * | 모든 계좌 | 허용 |

Refs #570

## Test plan

- [x] `validate_exchange()` 동일 exchange 허용
- [x] `validate_exchange()` wildcard(*) 모든 계좌 허용
- [x] `validate_exchange()` 다른 exchange 거부
- [x] 에러 메시지에 전략명·계좌명 포함
- [x] 유효하지 않은 exchange 값 → ValueError
- [x] AST 기반 유효/무효/wildcard exchange 검증
- [x] BotManager 호환 exchange 봇 생성 허용
- [x] BotManager 비호환 exchange 봇 생성 거부
- [x] BotManager wildcard 전략 모든 계좌 허용
- [x] AccountService 미주입 시 검증 스킵

🤖 Generated with [Claude Code](https://claude.com/claude-code)