### PR TITLE
refactor(rule): Rule Engine 계좌별 인스턴스 전환 (#566)

### DIFF
--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -185,7 +185,7 @@ async def _init_trading(s: Services) -> None:
     # RuleEngine
     from ante.rule import RuleEngine
 
-    s.rule_engine = RuleEngine(eventbus=s.eventbus, system_state=s.system_state)
+    s.rule_engine = RuleEngine(eventbus=s.eventbus)
     s.rule_engine.start()
 
     rule_configs = s.config.get("rules.global", [])

--- a/src/ante/rule/__init__.py
+++ b/src/ante/rule/__init__.py
@@ -15,6 +15,7 @@ from ante.rule.global_rules import (
     TotalExposureLimitRule,
     TradingHoursRule,
 )
+from ante.rule.manager import RuleEngineManager
 from ante.rule.strategy_rules import (
     PositionSizeRule,
     TradeFrequencyRule,
@@ -30,6 +31,7 @@ __all__ = [
     "RuleConfigError",
     "RuleContext",
     "RuleEngine",
+    "RuleEngineManager",
     "RuleError",
     "RuleEvaluation",
     "RuleResult",

--- a/src/ante/rule/base.py
+++ b/src/ante/rule/base.py
@@ -23,7 +23,7 @@ class RuleAction(StrEnum):
     LOG = "log"
     NOTIFY = "notify"
     STOP_BOT = "stop_bot"
-    HALT_SYSTEM = "halt_system"
+    HALT_ACCOUNT = "halt_account"
 
 
 @dataclass(frozen=True)
@@ -42,26 +42,28 @@ class RuleEvaluation:
 class RuleContext:
     """룰 평가 컨텍스트.
 
-    RuleEngine이 OrderRequestEvent와 시스템 상태를 조합하여 생성한다.
+    RuleEngine이 OrderRequestEvent와 계좌 상태를 조합하여 생성한다.
     """
 
     # 주문 정보
-    bot_id: str
-    strategy_id: str
-    symbol: str
-    side: str
-    quantity: float
-    order_type: str
+    bot_id: str = ""
+    account_id: str = ""
+    strategy_id: str = ""
+    symbol: str = ""
+    side: str = ""
+    quantity: float = 0.0
+    order_type: str = "market"
     price: float | None = None
     exchange: str = "KRX"
+    currency: str = "KRW"
 
     # 시장/포지션 정보
     current_price: float = 0.0
     current_position: float = 0.0
     available_balance: float = 0.0
 
-    # 시스템 상태
-    system_status: str = "active"
+    # 계좌 상태
+    account_status: str = "active"
     daily_pnl: float = 0.0
     total_pnl: float = 0.0
 

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -26,7 +26,7 @@ from ante.rule.strategy_rules import (
 )
 
 if TYPE_CHECKING:
-    from ante.config.system_state import SystemState
+    from ante.account.service import AccountService
     from ante.eventbus.bus import EventBus
 
 logger = logging.getLogger(__name__)
@@ -45,22 +45,31 @@ RULE_REGISTRY: dict[str, type[Rule]] = {
 class RuleEngine:
     """2계층 룰 평가 엔진.
 
-    전역 룰(모든 봇)과 전략별 룰을 순차 평가하여
+    계좌 룰(계좌 레벨)과 전략별 룰을 순차 평가하여
     OrderRequestEvent를 승인/거부한다.
+    각 RuleEngine은 특정 account_id에 바인딩되며,
+    해당 계좌의 이벤트만 처리한다.
     """
 
     def __init__(
         self,
         eventbus: EventBus,
-        system_state: SystemState,
+        account_id: str = "default",
+        account_service: AccountService | None = None,
         bot_strategy_resolver: Callable[[str], str | None] | None = None,
     ) -> None:
         self._eventbus = eventbus
-        self._system_state = system_state
+        self._account_id = account_id
+        self._account_service = account_service
         self._bot_strategy_resolver = bot_strategy_resolver
 
-        self._global_rules: list[Rule] = []
+        self._account_rules: list[Rule] = []
         self._strategy_rules: dict[str, list[Rule]] = {}
+
+    @property
+    def account_id(self) -> str:
+        """바인딩된 계좌 ID."""
+        return self._account_id
 
     def start(self) -> None:
         """EventBus 구독 등록."""
@@ -75,14 +84,18 @@ class RuleEngine:
         )
         self._eventbus.subscribe(OrderModifyEvent, self._on_order_modify, priority=100)
         self._eventbus.subscribe(ConfigChangedEvent, self._on_config_changed)
-        logger.info("RuleEngine 시작")
+        logger.info("RuleEngine 시작: account=%s", self._account_id)
 
     # ── 룰 관리 ─────────────────────────────────────
 
+    def add_account_rule(self, rule: Rule) -> None:
+        """계좌 룰 추가."""
+        self._account_rules.append(rule)
+        self._account_rules.sort(key=lambda r: r.priority)
+
     def add_global_rule(self, rule: Rule) -> None:
-        """전역 룰 추가."""
-        self._global_rules.append(rule)
-        self._global_rules.sort(key=lambda r: r.priority)
+        """전역 룰 추가. add_account_rule의 별칭 (하위 호환)."""
+        self.add_account_rule(rule)
 
     def add_strategy_rule(self, strategy_id: str, rule: Rule) -> None:
         """전략별 룰 추가."""
@@ -136,16 +149,16 @@ class RuleEngine:
 
     def clear_rules(self) -> None:
         """모든 룰 제거."""
-        self._global_rules.clear()
+        self._account_rules.clear()
         self._strategy_rules.clear()
 
     def load_rules_from_config(self, rule_configs: list[dict[str, Any]]) -> None:
-        """룰 설정 리스트에서 전역 룰 인스턴스 생성."""
+        """룰 설정 리스트에서 계좌 룰 인스턴스 생성."""
         for cfg in rule_configs:
             rule = self._create_rule(cfg)
             if rule is not None:
-                self._global_rules.append(rule)
-        self._global_rules.sort(key=lambda r: r.priority)
+                self._account_rules.append(rule)
+        self._account_rules.sort(key=lambda r: r.priority)
 
     def load_strategy_rules_from_config(
         self,
@@ -172,14 +185,21 @@ class RuleEngine:
         rule_id = config.get("id", rule_type)
         return rule_class(rule_id, config)
 
+    # ── 하위 호환 프로퍼티 ──────────────────────────────
+
+    @property
+    def _global_rules(self) -> list[Rule]:
+        """하위 호환: _global_rules → _account_rules."""
+        return self._account_rules
+
     # ── 룰 평가 ─────────────────────────────────────
 
     def evaluate(self, context: RuleContext) -> EvaluationResult:
-        """주문에 대한 룰 평가. 전역 → 전략별 순서로 평가."""
+        """주문에 대한 룰 평가. 계좌 룰 → 전략별 순서로 평가."""
         all_evaluations: list[RuleEvaluation] = []
 
-        # 전역 룰 평가
-        for rule in self._global_rules:
+        # 계좌 룰 평가
+        for rule in self._account_rules:
             if rule.is_applicable(context):
                 evaluation = rule.evaluate(context)
                 all_evaluations.append(evaluation)
@@ -187,7 +207,7 @@ class RuleEngine:
                 if evaluation.result in (RuleResult.BLOCK, RuleResult.REJECT):
                     break
 
-        # 전역 룰에서 차단되지 않았으면 전략별 룰 평가
+        # 계좌 룰에서 차단되지 않았으면 전략별 룰 평가
         if not any(
             e.result in (RuleResult.BLOCK, RuleResult.REJECT) for e in all_evaluations
         ):
@@ -256,8 +276,26 @@ class RuleEngine:
         if not isinstance(event, OrderRequestEvent):
             return
 
+        # account_id 필터링: 자기 계좌 이벤트만 처리
+        if event.account_id != self._account_id:
+            return
+
+        # 계좌 상태 조회
+        account_status = "active"
+        currency = "KRW"
+        if self._account_service is not None:
+            try:
+                account = await self._account_service.get(self._account_id)
+                account_status = account.status.value
+                currency = account.currency
+            except Exception:
+                logger.warning(
+                    "계좌 상태 조회 실패: %s — 기본값 사용", self._account_id
+                )
+
         context = RuleContext(
             bot_id=event.bot_id,
+            account_id=self._account_id,
             strategy_id=event.strategy_id,
             symbol=event.symbol,
             side=event.side,
@@ -265,7 +303,8 @@ class RuleEngine:
             order_type=event.order_type,
             price=event.price,
             current_price=event.price or 0.0,
-            system_status=self._system_state.trading_state.value,
+            account_status=account_status,
+            currency=currency,
         )
 
         try:
@@ -274,6 +313,7 @@ class RuleEngine:
             if result.overall_result in (RuleResult.PASS, RuleResult.WARN):
                 await self._eventbus.publish(
                     OrderValidatedEvent(
+                        account_id=self._account_id,
                         order_id=str(event.event_id),
                         bot_id=event.bot_id,
                         strategy_id=event.strategy_id,
@@ -299,6 +339,7 @@ class RuleEngine:
             else:
                 await self._eventbus.publish(
                     OrderRejectedEvent(
+                        account_id=self._account_id,
                         order_id=str(event.event_id),
                         bot_id=event.bot_id,
                         strategy_id=event.strategy_id,
@@ -316,6 +357,7 @@ class RuleEngine:
             logger.exception("룰 평가 실패: %s", event.event_id)
             await self._eventbus.publish(
                 OrderRejectedEvent(
+                    account_id=self._account_id,
                     order_id=str(event.event_id),
                     bot_id=event.bot_id,
                     strategy_id=event.strategy_id,
@@ -330,7 +372,6 @@ class RuleEngine:
 
     async def _execute_actions(self, actions: list[RuleAction], event: object) -> None:
         """룰 위반 조치 실행."""
-        from ante.config.system_state import TradingState
         from ante.eventbus.events import (
             BotStopEvent,
             NotificationEvent,
@@ -357,12 +398,18 @@ class RuleEngine:
                         reason="Rule violation",
                     )
                 )
-            elif action == RuleAction.HALT_SYSTEM:
-                await self._system_state.set_state(
-                    TradingState.HALTED,
-                    reason="Critical rule violation",
-                    changed_by="rule_engine",
-                )
+            elif action == RuleAction.HALT_ACCOUNT:
+                if self._account_service is not None:
+                    await self._account_service.suspend(
+                        self._account_id,
+                        reason="Critical rule violation",
+                        suspended_by="rule_engine",
+                    )
+                else:
+                    logger.warning(
+                        "HALT_ACCOUNT 액션이지만 AccountService가 없어 실행 불가: %s",
+                        self._account_id,
+                    )
 
     async def _on_order_modify(self, event: object) -> None:
         """OrderModifyEvent 수신 시 룰 평가. 위반 시 거부 이벤트 발행."""
@@ -374,8 +421,26 @@ class RuleEngine:
         if not isinstance(event, OrderModifyEvent):
             return
 
+        # account_id 필터링
+        if event.account_id != self._account_id:
+            return
+
+        # 계좌 상태 조회
+        account_status = "active"
+        currency = "KRW"
+        if self._account_service is not None:
+            try:
+                account = await self._account_service.get(self._account_id)
+                account_status = account.status.value
+                currency = account.currency
+            except Exception:
+                logger.warning(
+                    "계좌 상태 조회 실패: %s — 기본값 사용", self._account_id
+                )
+
         context = RuleContext(
             bot_id=event.bot_id,
+            account_id=self._account_id,
             strategy_id=event.strategy_id,
             symbol=event.symbol,
             side=event.side,
@@ -383,7 +448,8 @@ class RuleEngine:
             order_type="limit" if event.price else "market",
             price=event.price,
             current_price=event.price or 0.0,
-            system_status=self._system_state.trading_state.value,
+            account_status=account_status,
+            currency=currency,
         )
 
         try:
@@ -433,7 +499,7 @@ class RuleEngine:
     async def _on_config_changed(self, event: object) -> None:
         """설정 변경 시 룰 재로딩.
 
-        category가 ``"rule"`` 또는 ``"global_rule"``이면 전역 룰을 재로드하고,
+        category가 ``"rule"`` 또는 ``"global_rule"``이면 계좌 룰을 재로드하고,
         ``"strategy_rule"``이면 해당 전략 룰을 재로드한다.
 
         Note: EventBus 핸들러 — isawaitable 패턴을 위해 async def 유지.
@@ -460,9 +526,9 @@ class RuleEngine:
             return
 
         if event.category in ("rule", "global_rule"):
-            self._global_rules.clear()
+            self._account_rules.clear()
             self.load_rules_from_config(new_rules)
-            logger.info("전역 룰 재로드 완료: %d건", len(self._global_rules))
+            logger.info("계좌 룰 재로드 완료: %d건", len(self._account_rules))
         elif event.category == "strategy_rule":
             # key 형식: "rules.strategy.<strategy_id>" 또는 strategy_id 직접
             parts = event.key.rsplit(".", 1)

--- a/src/ante/rule/global_rules.py
+++ b/src/ante/rule/global_rules.py
@@ -1,4 +1,4 @@
-"""전역 룰 — 모든 봇에 적용되는 시스템 레벨 룰."""
+"""계좌 룰 — 계좌 레벨에서 모든 봇에 적용되는 룰."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from ante.rule.base import Rule, RuleAction, RuleContext, RuleEvaluation, RuleRe
 
 
 class DailyLossLimitRule(Rule):
-    """일일 손실 한도 초과 시 시스템 중지."""
+    """일일 손실 한도 초과 시 계좌 중지."""
 
     def evaluate(self, context: RuleContext) -> RuleEvaluation:
         max_daily_loss = self.config.get("max_daily_loss_percent", 0.05)
@@ -22,7 +22,7 @@ class DailyLossLimitRule(Rule):
                         rule_id=self.rule_id,
                         rule_name=self.name,
                         result=RuleResult.BLOCK,
-                        action=RuleAction.HALT_SYSTEM,
+                        action=RuleAction.HALT_ACCOUNT,
                         message=(
                             f"Daily loss limit exceeded: "
                             f"{daily_loss_percent:.2%} > {max_daily_loss:.2%}"

--- a/src/ante/rule/manager.py
+++ b/src/ante/rule/manager.py
@@ -1,0 +1,98 @@
+"""RuleEngineManager — 계좌별 RuleEngine 인스턴스 관리."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from ante.rule.engine import RuleEngine
+
+if TYPE_CHECKING:
+    from ante.account.models import Account
+    from ante.account.service import AccountService
+    from ante.eventbus.bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+
+class RuleEngineManager:
+    """계좌별 RuleEngine 인스턴스를 관리하는 상위 계층."""
+
+    def __init__(self, eventbus: EventBus, account_service: AccountService) -> None:
+        self._eventbus = eventbus
+        self._account_service = account_service
+        self._engines: dict[str, RuleEngine] = {}
+
+    def create_engine(
+        self,
+        account_id: str,
+        rule_configs: list[dict[str, Any]] | None = None,
+    ) -> RuleEngine:
+        """계좌별 RuleEngine 생성. EventBus에 자동 구독.
+
+        Args:
+            account_id: 계좌 ID.
+            rule_configs: 계좌 룰 설정 리스트. None이면 빈 룰.
+
+        Returns:
+            생성된 RuleEngine 인스턴스.
+        """
+        engine = RuleEngine(
+            eventbus=self._eventbus,
+            account_id=account_id,
+            account_service=self._account_service,
+        )
+
+        if rule_configs:
+            engine.load_rules_from_config(rule_configs)
+
+        engine.start()
+        self._engines[account_id] = engine
+
+        logger.info(
+            "RuleEngine 생성: account=%s, 룰 %d건",
+            account_id,
+            len(rule_configs) if rule_configs else 0,
+        )
+        return engine
+
+    def get(self, account_id: str) -> RuleEngine:
+        """계좌의 RuleEngine 인스턴스 반환.
+
+        Raises:
+            KeyError: 해당 계좌의 RuleEngine이 없음.
+        """
+        if account_id not in self._engines:
+            raise KeyError(f"account '{account_id}'의 RuleEngine이 존재하지 않습니다.")
+        return self._engines[account_id]
+
+    async def initialize_all(
+        self,
+        accounts: list[Account],
+        config: Any = None,
+    ) -> None:
+        """시스템 시작 시 모든 계좌의 RuleEngine 초기화.
+
+        각 계좌에 대해 RuleEngine을 생성하고, 계좌별 룰 설정을 로드한다.
+
+        Args:
+            accounts: 초기화할 계좌 목록.
+            config: 전체 설정 객체 (룰 설정 추출용). None이면 빈 룰.
+        """
+        for account in accounts:
+            rule_configs: list[dict[str, Any]] = []
+
+            # config에서 계좌별 룰 설정 추출
+            if config is not None and hasattr(config, "get"):
+                account_rules = config.get(f"accounts.{account.account_id}.rules", None)
+                if isinstance(account_rules, list):
+                    rule_configs = account_rules
+
+            self.create_engine(account.account_id, rule_configs)
+
+        logger.info("RuleEngineManager 초기화 완료: %d개 계좌", len(self._engines))
+
+    @property
+    def engines(self) -> dict[str, RuleEngine]:
+        """모든 RuleEngine 인스턴스 (읽기 전용 접근)."""
+        return dict(self._engines)

--- a/tests/unit/test_bot_rule_init.py
+++ b/tests/unit/test_bot_rule_init.py
@@ -4,11 +4,12 @@ Refs #498
 """
 
 import asyncio
+from unittest.mock import AsyncMock
 
 import pytest
 
+from ante.account.models import Account, AccountStatus
 from ante.bot import BotConfig, BotManager, BotStatus
-from ante.config.system_state import SystemState
 from ante.core import Database
 from ante.eventbus import EventBus
 from ante.rule.engine import RuleEngine
@@ -85,15 +86,29 @@ async def db(tmp_path):
 
 
 @pytest.fixture
-async def system_state(db, eventbus):
-    state = SystemState(db=db, eventbus=eventbus)
-    await state.initialize()
-    return state
+def mock_account_service():
+    """AccountService 목 객체."""
+    service = AsyncMock()
+    account = Account(
+        account_id="default",
+        name="테스트",
+        exchange="KRX",
+        currency="KRW",
+        broker_type="test",
+        status=AccountStatus.ACTIVE,
+    )
+    service.get = AsyncMock(return_value=account)
+    service.suspend = AsyncMock()
+    return service
 
 
 @pytest.fixture
-def rule_engine(eventbus, system_state):
-    engine = RuleEngine(eventbus=eventbus, system_state=system_state)
+def rule_engine(eventbus, mock_account_service):
+    engine = RuleEngine(
+        eventbus=eventbus,
+        account_id="default",
+        account_service=mock_account_service,
+    )
     return engine
 
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -130,7 +130,7 @@ async def test_composition_root_all_modules(tmp_path: Path) -> None:
     # 7. RuleEngine
     from ante.rule import RuleEngine
 
-    rule_engine = RuleEngine(eventbus=eventbus, system_state=system_state)
+    rule_engine = RuleEngine(eventbus=eventbus)
     rule_engine.start()
 
     # 8. Treasury

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -1,10 +1,11 @@
 """Rule Engine 모듈 단위 테스트."""
 
 from datetime import time
+from unittest.mock import AsyncMock
 
 import pytest
 
-from ante.core import Database
+from ante.account.models import Account, AccountStatus
 from ante.eventbus import EventBus
 from ante.eventbus.events import (
     OrderRejectedEvent,
@@ -17,6 +18,7 @@ from ante.rule import (
     RuleAction,
     RuleContext,
     RuleEngine,
+    RuleEngineManager,
     RuleEvaluation,
     RuleResult,
     TotalExposureLimitRule,
@@ -33,6 +35,7 @@ def base_context():
     """기본 RuleContext."""
     return RuleContext(
         bot_id="bot1",
+        account_id="domestic",
         strategy_id="momentum_v1",
         symbol="005930",
         side="buy",
@@ -41,10 +44,27 @@ def base_context():
         current_price=50000.0,
         current_position=0.0,
         available_balance=1000000.0,
-        system_status="active",
+        account_status="active",
         daily_pnl=0.0,
         total_pnl=100000.0,
     )
+
+
+@pytest.fixture
+def mock_account_service():
+    """AccountService 목 객체."""
+    service = AsyncMock()
+    account = Account(
+        account_id="domestic",
+        name="국내주식",
+        exchange="KRX",
+        currency="KRW",
+        broker_type="test",
+        status=AccountStatus.ACTIVE,
+    )
+    service.get = AsyncMock(return_value=account)
+    service.suspend = AsyncMock()
+    return service
 
 
 # ── RuleResult / RuleEvaluation ──────────────────
@@ -57,6 +77,12 @@ class TestRuleDataModels:
         assert RuleResult.WARN == "warn"
         assert RuleResult.BLOCK == "block"
         assert RuleResult.REJECT == "reject"
+
+    def test_rule_action_halt_account(self):
+        """RuleAction에 HALT_ACCOUNT이 존재한다."""
+        assert RuleAction.HALT_ACCOUNT == "halt_account"
+        # HALT_SYSTEM은 더 이상 존재하지 않아야 함
+        assert not hasattr(RuleAction, "HALT_SYSTEM")
 
     def test_rule_evaluation_frozen(self):
         """RuleEvaluation은 불변 객체."""
@@ -74,6 +100,7 @@ class TestRuleDataModels:
         """RuleContext는 가변 객체 (엔진이 필드를 채우므로)."""
         ctx = RuleContext(
             bot_id="b1",
+            account_id="domestic",
             strategy_id="s1",
             symbol="005930",
             side="buy",
@@ -82,6 +109,29 @@ class TestRuleDataModels:
         )
         ctx.current_price = 50000.0
         assert ctx.current_price == 50000.0
+
+    def test_rule_context_account_fields(self):
+        """RuleContext에 account_id, currency, account_status 필드가 있다."""
+        ctx = RuleContext(
+            bot_id="b1",
+            account_id="domestic",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            order_type="market",
+            currency="KRW",
+            account_status="active",
+        )
+        assert ctx.account_id == "domestic"
+        assert ctx.currency == "KRW"
+        assert ctx.account_status == "active"
+
+    def test_rule_context_no_system_status(self):
+        """RuleContext에 system_status 필드가 없다 (account_status로 대체)."""
+        ctx = RuleContext()
+        assert not hasattr(ctx, "system_status")
+        assert hasattr(ctx, "account_status")
 
 
 # ── DailyLossLimitRule ───────────────────────────
@@ -107,12 +157,12 @@ class TestDailyLossLimitRule:
         assert result.result == RuleResult.PASS
 
     def test_block_exceeds_limit(self, rule, base_context):
-        """손실이 한도 초과하면 BLOCK."""
+        """손실이 한도 초과하면 BLOCK + HALT_ACCOUNT."""
         base_context.daily_pnl = -10000.0
         base_context.total_pnl = 100000.0
         result = rule.evaluate(base_context)
         assert result.result == RuleResult.BLOCK
-        assert result.action == RuleAction.HALT_SYSTEM
+        assert result.action == RuleAction.HALT_ACCOUNT
 
     def test_pass_zero_total_pnl(self, rule, base_context):
         """총 수익이 0이면 통과 (0으로 나누기 방지)."""
@@ -307,27 +357,16 @@ class TestTradeFrequencyRule:
 
 class TestRuleEngine:
     @pytest.fixture
-    async def db(self, tmp_path):
-        database = Database(str(tmp_path / "test.db"))
-        await database.connect()
-        yield database
-        await database.close()
-
-    @pytest.fixture
     def eventbus(self):
         return EventBus()
 
     @pytest.fixture
-    async def system_state(self, db, eventbus):
-        from ante.config.system_state import SystemState
-
-        state = SystemState(db=db, eventbus=eventbus)
-        await state.initialize()
-        return state
-
-    @pytest.fixture
-    def engine(self, eventbus, system_state):
-        return RuleEngine(eventbus=eventbus, system_state=system_state)
+    def engine(self, eventbus, mock_account_service):
+        return RuleEngine(
+            eventbus=eventbus,
+            account_id="domestic",
+            account_service=mock_account_service,
+        )
 
     def test_evaluate_no_rules(self, engine, base_context):
         """룰이 없으면 PASS."""
@@ -335,17 +374,25 @@ class TestRuleEngine:
         assert result.overall_result == RuleResult.PASS
         assert len(result.evaluations) == 0
 
+    def test_evaluate_account_rule_pass(self, engine, base_context):
+        """계좌 룰 통과."""
+        engine.add_account_rule(
+            DailyLossLimitRule("dl", {"max_daily_loss_percent": 0.05})
+        )
+        result = engine.evaluate(base_context)
+        assert result.overall_result == RuleResult.PASS
+
     def test_evaluate_global_rule_pass(self, engine, base_context):
-        """전역 룰 통과."""
+        """add_global_rule 하위 호환 테스트."""
         engine.add_global_rule(
             DailyLossLimitRule("dl", {"max_daily_loss_percent": 0.05})
         )
         result = engine.evaluate(base_context)
         assert result.overall_result == RuleResult.PASS
 
-    def test_evaluate_global_rule_block(self, engine, base_context):
-        """전역 룰 차단 시 전략별 룰은 평가하지 않음."""
-        engine.add_global_rule(
+    def test_evaluate_account_rule_block(self, engine, base_context):
+        """계좌 룰 차단 시 전략별 룰은 평가하지 않음."""
+        engine.add_account_rule(
             DailyLossLimitRule("dl", {"max_daily_loss_percent": 0.05})
         )
         engine.add_strategy_rule(
@@ -358,7 +405,7 @@ class TestRuleEngine:
         result = engine.evaluate(base_context)
 
         assert result.overall_result == RuleResult.BLOCK
-        # 전역 룰만 평가됨
+        # 계좌 룰만 평가됨
         assert len(result.evaluations) == 1
         assert result.evaluations[0].rule_id == "dl"
 
@@ -386,8 +433,8 @@ class TestRuleEngine:
         rule_high = TradingHoursRule(
             "high", {"priority": 1, "allowed_hours": "09:00-15:30"}
         )
-        engine.add_global_rule(rule_low)
-        engine.add_global_rule(rule_high)
+        engine.add_account_rule(rule_low)
+        engine.add_account_rule(rule_high)
 
         base_context.metadata["current_time"] = time(10, 0)
         result = engine.evaluate(base_context)
@@ -423,7 +470,7 @@ class TestRuleEngine:
 
     def test_clear_rules(self, engine):
         """룰 초기화."""
-        engine.add_global_rule(
+        engine.add_account_rule(
             DailyLossLimitRule("dl", {"max_daily_loss_percent": 0.05})
         )
         engine.add_strategy_rule(
@@ -439,12 +486,36 @@ class TestRuleEngine:
             "dl",
             {"enabled": False, "max_daily_loss_percent": 0.001},
         )
-        engine.add_global_rule(rule)
+        engine.add_account_rule(rule)
         base_context.daily_pnl = -5000.0
         base_context.total_pnl = 100000.0
         result = engine.evaluate(base_context)
         assert result.overall_result == RuleResult.PASS
         assert len(result.evaluations) == 0
+
+    def test_engine_account_id(self, engine):
+        """RuleEngine에 account_id가 설정된다."""
+        assert engine.account_id == "domestic"
+
+    def test_engine_no_system_state(self, eventbus):
+        """SystemState 없이 AccountService만으로 동작."""
+        service = AsyncMock()
+        engine = RuleEngine(
+            eventbus=eventbus,
+            account_id="test",
+            account_service=service,
+        )
+        ctx = RuleContext(
+            bot_id="b1",
+            account_id="test",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=1.0,
+            order_type="market",
+        )
+        result = engine.evaluate(ctx)
+        assert result.overall_result == RuleResult.PASS
 
 
 # ── RuleEngine EventBus 통합 ─────────────────────
@@ -452,27 +523,16 @@ class TestRuleEngine:
 
 class TestRuleEngineEventBus:
     @pytest.fixture
-    async def db(self, tmp_path):
-        database = Database(str(tmp_path / "test.db"))
-        await database.connect()
-        yield database
-        await database.close()
-
-    @pytest.fixture
     def eventbus(self):
         return EventBus()
 
     @pytest.fixture
-    async def system_state(self, db, eventbus):
-        from ante.config.system_state import SystemState
-
-        state = SystemState(db=db, eventbus=eventbus)
-        await state.initialize()
-        return state
-
-    @pytest.fixture
-    async def engine(self, eventbus, system_state):
-        engine = RuleEngine(eventbus=eventbus, system_state=system_state)
+    async def engine(self, eventbus, mock_account_service):
+        engine = RuleEngine(
+            eventbus=eventbus,
+            account_id="domestic",
+            account_service=mock_account_service,
+        )
         engine.start()
         return engine
 
@@ -482,6 +542,7 @@ class TestRuleEngineEventBus:
         eventbus.subscribe(OrderValidatedEvent, lambda e: received.append(e))
 
         order = OrderRequestEvent(
+            account_id="domestic",
             bot_id="bot1",
             strategy_id="s1",
             symbol="005930",
@@ -494,30 +555,23 @@ class TestRuleEngineEventBus:
 
         assert len(received) == 1
         assert received[0].bot_id == "bot1"
+        assert received[0].account_id == "domestic"
 
     async def test_order_rejected_on_block(self, engine, eventbus):
         """룰 차단 시 OrderRejectedEvent 발행."""
-        engine.add_global_rule(
-            DailyLossLimitRule("dl", {"max_daily_loss_percent": 0.001})
-        )
-
-        received = []
-        eventbus.subscribe(OrderRejectedEvent, lambda e: received.append(e))
-
-        # 손실 상태를 context에 전달하기 위해 직접 evaluate 방식이 아닌,
-        # _on_order_request에서는 기본 context가 생성되므로
-        # 전역에서 항상 BLOCK하는 룰을 추가
-        # DailyLossLimitRule은 pnl이 0이면 pass하므로, 다른 방식 사용
-        # TradingHoursRule로 시간 외 거래 차단
         engine.clear_rules()
-        engine.add_global_rule(
+        engine.add_account_rule(
             TradingHoursRule(
                 "hours",
                 {"allowed_hours": "00:00-00:01"},  # 거의 항상 차단
             )
         )
 
+        received = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: received.append(e))
+
         order = OrderRequestEvent(
+            account_id="domestic",
             bot_id="bot1",
             strategy_id="s1",
             symbol="005930",
@@ -531,6 +585,59 @@ class TestRuleEngineEventBus:
         assert len(received) == 1
         assert "Trading not allowed" in received[0].reason
 
+    async def test_event_filtering_different_account(self, engine, eventbus):
+        """다른 account_id의 OrderRequestEvent는 무시한다."""
+        received_validated = []
+        received_rejected = []
+        eventbus.subscribe(OrderValidatedEvent, lambda e: received_validated.append(e))
+        eventbus.subscribe(OrderRejectedEvent, lambda e: received_rejected.append(e))
+
+        # 다른 계좌의 주문
+        order = OrderRequestEvent(
+            account_id="us-stock",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="AAPL",
+            side="buy",
+            quantity=10.0,
+            order_type="market",
+            price=150.0,
+        )
+        await eventbus.publish(order)
+
+        assert len(received_validated) == 0
+        assert len(received_rejected) == 0
+
+    async def test_halt_account_action(self, engine, eventbus, mock_account_service):
+        """HALT_ACCOUNT 발동 시 AccountService.suspend() 호출."""
+        engine.add_account_rule(
+            DailyLossLimitRule("dl", {"max_daily_loss_percent": 0.001})
+        )
+
+        # context에서 손실을 탐지하도록 metadata 설정
+        # DailyLossLimitRule은 context.daily_pnl과 total_pnl로 판단
+        # _on_order_request에서 기본 context는 pnl=0이므로,
+        # 직접 _execute_actions 테스트
+        from ante.eventbus.events import OrderRequestEvent
+
+        event = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            order_type="market",
+            price=50000.0,
+        )
+        await engine._execute_actions([RuleAction.HALT_ACCOUNT], event)
+
+        mock_account_service.suspend.assert_awaited_once_with(
+            "domestic",
+            reason="Critical rule violation",
+            suspended_by="rule_engine",
+        )
+
 
 # ── RuleEngine.update_rules ──────────────────────
 
@@ -539,23 +646,8 @@ class TestRuleEngineUpdateRules:
     """RuleEngine.update_rules() 단위 테스트."""
 
     @pytest.fixture
-    async def db(self, tmp_path):
-        database = Database(str(tmp_path / "test.db"))
-        await database.connect()
-        yield database
-        await database.close()
-
-    @pytest.fixture
     def eventbus(self):
         return EventBus()
-
-    @pytest.fixture
-    async def system_state(self, db, eventbus):
-        from ante.config.system_state import SystemState
-
-        state = SystemState(db=db, eventbus=eventbus)
-        await state.initialize()
-        return state
 
     @pytest.fixture
     def bot_strategies(self):
@@ -563,10 +655,11 @@ class TestRuleEngineUpdateRules:
         return {"bot1": "momentum_v1", "bot2": "mean_revert_v1"}
 
     @pytest.fixture
-    def engine(self, eventbus, system_state, bot_strategies):
+    def engine(self, eventbus, mock_account_service, bot_strategies):
         return RuleEngine(
             eventbus=eventbus,
-            system_state=system_state,
+            account_id="domestic",
+            account_service=mock_account_service,
             bot_strategy_resolver=lambda bid: bot_strategies.get(bid),
         )
 
@@ -601,11 +694,15 @@ class TestRuleEngineUpdateRules:
         assert "new_freq" in rule_ids
         assert "old_ps" not in rule_ids
 
-    def test_update_rules_no_resolver_raises(self, eventbus, system_state):
+    def test_update_rules_no_resolver_raises(self, eventbus, mock_account_service):
         """resolver 미설정 시 RuleError."""
         from ante.rule.exceptions import RuleError
 
-        engine = RuleEngine(eventbus=eventbus, system_state=system_state)
+        engine = RuleEngine(
+            eventbus=eventbus,
+            account_id="domestic",
+            account_service=mock_account_service,
+        )
         with pytest.raises(RuleError, match="bot_strategy_resolver"):
             engine.update_rules("bot1", [])
 
@@ -655,9 +752,13 @@ class TestRuleEngineUpdateRules:
         assert len(engine._strategy_rules["mean_revert_v1"]) == 1
         assert engine._strategy_rules["mean_revert_v1"][0].rule_id == "freq1"
 
-    def test_set_bot_strategy_resolver(self, eventbus, system_state):
+    def test_set_bot_strategy_resolver(self, eventbus, mock_account_service):
         """set_bot_strategy_resolver로 resolver를 나중에 설정할 수 있다."""
-        engine = RuleEngine(eventbus=eventbus, system_state=system_state)
+        engine = RuleEngine(
+            eventbus=eventbus,
+            account_id="domestic",
+            account_service=mock_account_service,
+        )
         engine.set_bot_strategy_resolver(lambda bid: "strat_a" if bid == "b1" else None)
 
         engine.update_rules(
@@ -686,6 +787,7 @@ class TestRuleEngineUpdateRules:
 
         context = RuleContext(
             bot_id="bot1",
+            account_id="domestic",
             strategy_id="momentum_v1",
             symbol="005930",
             side="buy",
@@ -693,7 +795,7 @@ class TestRuleEngineUpdateRules:
             order_type="market",
             current_price=50000.0,
             available_balance=1_000_000.0,
-            system_status="active",
+            account_status="active",
         )
         result = engine.evaluate(context)
         assert result.overall_result == RuleResult.PASS
@@ -715,47 +817,36 @@ class TestRuleEngineUpdateRules:
 
 
 class TestRuleEngineConfigReload:
-    """RuleEngine._on_config_changed() 전역/전략 룰 재로드 테스트."""
-
-    @pytest.fixture
-    async def db(self, tmp_path):
-        database = Database(str(tmp_path / "test.db"))
-        await database.connect()
-        yield database
-        await database.close()
+    """RuleEngine._on_config_changed() 계좌/전략 룰 재로드 테스트."""
 
     @pytest.fixture
     def eventbus(self):
         return EventBus()
 
     @pytest.fixture
-    async def system_state(self, db, eventbus):
-        from ante.config.system_state import SystemState
-
-        state = SystemState(db=db, eventbus=eventbus)
-        await state.initialize()
-        return state
-
-    @pytest.fixture
-    async def engine(self, eventbus, system_state):
-        engine = RuleEngine(eventbus=eventbus, system_state=system_state)
+    async def engine(self, eventbus, mock_account_service):
+        engine = RuleEngine(
+            eventbus=eventbus,
+            account_id="domestic",
+            account_service=mock_account_service,
+        )
         engine.start()
         return engine
 
     async def test_global_rule_reload_on_config_changed(self, engine, eventbus):
-        """category='global_rule' ConfigChangedEvent 발행 시 전역 룰이 재로드된다."""
+        """category='global_rule' ConfigChangedEvent 발행 시 계좌 룰이 재로드된다."""
         import json
 
         from ante.eventbus.events import ConfigChangedEvent
 
-        # 초기 전역 룰 설정
+        # 초기 계좌 룰 설정
         engine.load_rules_from_config(
             [{"type": "daily_loss_limit", "id": "dl", "max_daily_loss_percent": 0.05}]
         )
         assert len(engine._global_rules) == 1
         assert engine._global_rules[0].rule_id == "dl"
 
-        # ConfigChangedEvent로 전역 룰 교체
+        # ConfigChangedEvent로 계좌 룰 교체
         new_rules = [
             {"type": "total_exposure_limit", "id": "exp", "max_exposure_percent": 0.20},
             {
@@ -779,7 +870,7 @@ class TestRuleEngineConfigReload:
         assert "dl" not in rule_ids
 
     async def test_rule_category_reload(self, engine, eventbus):
-        """category='rule'도 전역 룰 재로드를 트리거한다."""
+        """category='rule'도 계좌 룰 재로드를 트리거한다."""
         import json
 
         from ante.eventbus.events import ConfigChangedEvent
@@ -902,3 +993,80 @@ class TestRuleEngineConfigReload:
         # 기존 룰 변경 없음
         assert len(engine._global_rules) == 1
         assert engine._global_rules[0].rule_id == "dl"
+
+
+# ── RuleEngineManager ────────────────────────────
+
+
+class TestRuleEngineManager:
+    """RuleEngineManager 단위 테스트."""
+
+    @pytest.fixture
+    def eventbus(self):
+        return EventBus()
+
+    @pytest.fixture
+    def manager(self, eventbus, mock_account_service):
+        return RuleEngineManager(
+            eventbus=eventbus, account_service=mock_account_service
+        )
+
+    def test_create_engine(self, manager):
+        """계좌별 RuleEngine을 생성할 수 있다."""
+        engine = manager.create_engine("domestic")
+        assert engine.account_id == "domestic"
+
+    def test_create_engine_with_rules(self, manager):
+        """룰 설정과 함께 RuleEngine을 생성할 수 있다."""
+        configs = [
+            {"type": "daily_loss_limit", "id": "dl", "max_daily_loss_percent": 0.05},
+        ]
+        engine = manager.create_engine("domestic", configs)
+        assert len(engine._global_rules) == 1
+
+    def test_get_engine(self, manager):
+        """생성된 RuleEngine을 account_id로 조회한다."""
+        manager.create_engine("domestic")
+        engine = manager.get("domestic")
+        assert engine.account_id == "domestic"
+
+    def test_get_engine_not_found(self, manager):
+        """존재하지 않는 account_id 조회 시 KeyError."""
+        with pytest.raises(KeyError, match="RuleEngine이 존재하지 않습니다"):
+            manager.get("nonexistent")
+
+    async def test_initialize_all(self, manager):
+        """모든 계좌의 RuleEngine을 초기화한다."""
+        accounts = [
+            Account(
+                account_id="domestic",
+                name="국내주식",
+                exchange="KRX",
+                currency="KRW",
+                broker_type="test",
+            ),
+            Account(
+                account_id="us-stock",
+                name="미국주식",
+                exchange="NYSE",
+                currency="USD",
+                broker_type="test",
+            ),
+        ]
+        await manager.initialize_all(accounts)
+
+        assert len(manager.engines) == 2
+        assert manager.get("domestic").account_id == "domestic"
+        assert manager.get("us-stock").account_id == "us-stock"
+
+    def test_multiple_engines_isolation(self, manager):
+        """2개 계좌의 RuleEngine이 서로 간섭하지 않는다."""
+        engine1 = manager.create_engine("domestic")
+        engine2 = manager.create_engine("us-stock")
+
+        engine1.add_account_rule(
+            DailyLossLimitRule("dl", {"max_daily_loss_percent": 0.05})
+        )
+
+        assert len(engine1._global_rules) == 1
+        assert len(engine2._global_rules) == 0

--- a/tests/unit/test_rule_modify.py
+++ b/tests/unit/test_rule_modify.py
@@ -1,9 +1,10 @@
 """OrderModifyEvent 룰 검증 테스트."""
 
+from unittest.mock import AsyncMock
+
 import pytest
 
-from ante.config.system_state import SystemState
-from ante.core import Database
+from ante.account.models import Account, AccountStatus
 from ante.eventbus import EventBus
 from ante.eventbus.events import OrderModifyEvent, OrderModifyRejectedEvent
 from ante.rule import RuleEngine
@@ -37,30 +38,37 @@ class AlwaysPassRule(Rule):
 
 
 @pytest.fixture
-async def db(tmp_path):
-    database = Database(str(tmp_path / "test.db"))
-    await database.connect()
-    yield database
-    await database.close()
+def mock_account_service():
+    """AccountService 목 객체."""
+    service = AsyncMock()
+    account = Account(
+        account_id="domestic",
+        name="국내주식",
+        exchange="KRX",
+        currency="KRW",
+        broker_type="test",
+        status=AccountStatus.ACTIVE,
+    )
+    service.get = AsyncMock(return_value=account)
+    service.suspend = AsyncMock()
+    return service
 
 
 @pytest.fixture
-async def system_state(db):
-    state = SystemState(db=db, eventbus=EventBus())
-    await state.initialize()
-    return state
-
-
-@pytest.fixture
-async def engine(system_state):
+async def engine(mock_account_service):
     eventbus = EventBus()
-    engine = RuleEngine(eventbus=eventbus, system_state=system_state)
+    engine = RuleEngine(
+        eventbus=eventbus,
+        account_id="domestic",
+        account_service=mock_account_service,
+    )
     engine.start()
     return engine
 
 
 def _make_modify_event(**kwargs):
     defaults = {
+        "account_id": "domestic",
         "bot_id": "bot1",
         "strategy_id": "s1",
         "order_id": "ord-1",
@@ -82,11 +90,11 @@ async def test_modify_passes_when_no_rules(engine):
 
 
 async def test_modify_rejected_by_global_rule(engine):
-    """전역 룰 위반 시 정정이 거부된다."""
+    """계좌 룰 위반 시 정정이 거부된다."""
     received = []
     engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
 
-    engine.add_global_rule(AlwaysRejectRule("reject", {"type": "test"}))
+    engine.add_account_rule(AlwaysRejectRule("reject", {"type": "test"}))
     await engine._on_order_modify(_make_modify_event())
 
     assert len(received) == 1
@@ -99,7 +107,7 @@ async def test_modify_passes_with_pass_rule(engine):
     received = []
     engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
 
-    engine.add_global_rule(AlwaysPassRule("pass", {"type": "test"}))
+    engine.add_account_rule(AlwaysPassRule("pass", {"type": "test"}))
     await engine._on_order_modify(_make_modify_event())
 
     assert len(received) == 0
@@ -110,7 +118,7 @@ async def test_modify_rejected_event_has_correct_fields(engine):
     received = []
     engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
 
-    engine.add_global_rule(AlwaysRejectRule("reject", {"type": "test"}))
+    engine.add_account_rule(AlwaysRejectRule("reject", {"type": "test"}))
 
     event = _make_modify_event(
         bot_id="bot1",
@@ -155,6 +163,19 @@ async def test_other_strategy_rule_not_applied(engine):
     engine.add_strategy_rule("strat2", AlwaysRejectRule("reject", {"type": "test"}))
 
     event = _make_modify_event(strategy_id="strat1")
+    await engine._on_order_modify(event)
+
+    assert len(received) == 0
+
+
+async def test_modify_event_filtered_by_account_id(engine):
+    """다른 account_id의 OrderModifyEvent는 무시한다."""
+    received = []
+    engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    engine.add_account_rule(AlwaysRejectRule("reject", {"type": "test"}))
+
+    event = _make_modify_event(account_id="us-stock")
     await engine._on_order_modify(event)
 
     assert len(received) == 0


### PR DESCRIPTION
## Summary

- `RuleAction.HALT_SYSTEM` → `HALT_ACCOUNT` 변경
- `RuleContext`에 `account_id`, `currency` 추가, `system_status` → `account_status` 변경
- `RuleEngine`에서 SystemState 의존성 제거, AccountService 사용으로 전환
- `RuleEngine`이 `account_id`로 이벤트 필터링 (자기 계좌 이벤트만 처리)
- `RuleEngineManager` 신규 구현 (계좌별 RuleEngine 생성·조회·일괄 초기화)
- `global_rules.py`의 `HALT_SYSTEM` → `HALT_ACCOUNT` 참조 변경
- 기존 테스트를 SystemState fixture → AccountService mock으로 전환
- 신규 테스트: 이벤트 필터링, HALT_ACCOUNT 액션, RuleEngineManager 테스트

## Changed files

| 파일 | 변경 내용 |
|------|----------|
| `src/ante/rule/base.py` | HALT_SYSTEM→HALT_ACCOUNT, RuleContext에 account_id·currency 추가, system_status→account_status |
| `src/ante/rule/engine.py` | RuleEngine에 account_id 추가, SystemState→AccountService, 이벤트 필터링 |
| `src/ante/rule/global_rules.py` | HALT_SYSTEM→HALT_ACCOUNT 참조 변경 |
| `src/ante/rule/manager.py` | **신규** RuleEngineManager |
| `src/ante/rule/__init__.py` | RuleEngineManager export 추가 |
| `src/ante/main.py` | RuleEngine 초기화에서 system_state 인자 제거 |
| `tests/unit/test_rule.py` | AccountService mock 전환 + 신규 테스트 |
| `tests/unit/test_rule_modify.py` | AccountService mock 전환 + account_id 필터링 테스트 |
| `tests/unit/test_bot_rule_init.py` | AccountService mock 전환 |
| `tests/unit/test_main.py` | RuleEngine 초기화 인자 수정 |

## Test plan

- [x] `HALT_SYSTEM` → `HALT_ACCOUNT` 변경 확인
- [x] `RuleContext`에서 `system_status` → `account_status` 변경 확인
- [x] RuleEngine이 SystemState 대신 AccountService 사용 확인
- [x] RuleEngine이 `account_id`로 이벤트 필터링 확인
- [x] RuleEngineManager 생성·조회·일괄 초기화 테스트
- [x] `global_rules.py` HALT_ACCOUNT 참조 확인
- [x] 기존 + 신규 테스트 74건 통과
- [x] ruff check + format 통과

Refs #566