### PR TITLE
feat(treasury): 계좌별 인스턴스 전환 및 TreasuryManager 도입

### DIFF
--- a/src/ante/bot/context_factory.py
+++ b/src/ante/bot/context_factory.py
@@ -1,4 +1,4 @@
-"""StrategyContextFactory — 계좌 거래모드별 StrategyContext 자동 조립."""
+"""StrategyContextFactory -- 계좌 거래모드별 StrategyContext 자동 조립."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from ante.account.models import TradingMode
 from ante.bot.config import BotConfig
+from ante.bot.providers.live import LivePortfolioView
 from ante.bot.providers.paper import PaperExecutor, PaperOrderView, PaperPortfolioView
 from ante.strategy.context import StrategyContext
 
@@ -14,10 +15,11 @@ if TYPE_CHECKING:
     from ante.account.service import AccountService
     from ante.bot.providers.live import (
         LiveOrderView,
-        LivePortfolioView,
         LiveTradeHistoryView,
     )
     from ante.strategy.base import DataProvider
+    from ante.trade.position import PositionHistory
+    from ante.treasury.manager import TreasuryManager
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +38,8 @@ class StrategyContextFactory:
         live_order_view: LiveOrderView | None = None,
         paper_executor: PaperExecutor | None = None,
         live_trade_history: LiveTradeHistoryView | None = None,
+        treasury_manager: TreasuryManager | None = None,
+        position_history: PositionHistory | None = None,
     ) -> None:
         self._data_provider = data_provider
         self._account_service = account_service
@@ -43,6 +47,8 @@ class StrategyContextFactory:
         self._live_order_view = live_order_view
         self._paper_executor = paper_executor
         self._live_trade_history = live_trade_history
+        self._treasury_manager = treasury_manager
+        self._position_history = position_history
 
     def create(self, config: BotConfig) -> StrategyContext:
         """BotConfig 기반으로 적절한 StrategyContext 생성.
@@ -61,20 +67,47 @@ class StrategyContextFactory:
             return TradingMode.VIRTUAL
         account = self._account_service.get_sync(config.account_id)
         if account is None:
-            logger.warning("계좌 '%s' 미발견 — VIRTUAL 모드로 대체", config.account_id)
+            logger.warning("계좌 '%s' 미발견 -- VIRTUAL 모드로 대체", config.account_id)
             return TradingMode.VIRTUAL
         return account.trading_mode
 
+    def _get_live_portfolio(self, config: BotConfig) -> LivePortfolioView:
+        """봇의 계좌에 맞는 LivePortfolioView를 반환.
+
+        TreasuryManager가 있으면 계좌별 Treasury로 새 LivePortfolioView를 생성하고,
+        없으면 기본 live_portfolio를 반환한다.
+        """
+        if self._treasury_manager and self._position_history:
+            try:
+                treasury = self._treasury_manager.get(config.account_id)
+                return LivePortfolioView(
+                    treasury=treasury,
+                    position_history=self._position_history,
+                )
+            except KeyError:
+                logger.warning(
+                    "계좌 '%s'의 Treasury 미발견 -- 기본 포트폴리오 사용",
+                    config.account_id,
+                )
+
+        if self._live_portfolio is not None:
+            return self._live_portfolio
+
+        msg = "Live 봇 생성에 필요한 Portfolio Provider가 설정되지 않았습니다"
+        raise ValueError(msg)
+
     def _create_live_context(self, config: BotConfig) -> StrategyContext:
         """Live 봇용 StrategyContext 생성."""
-        if self._live_portfolio is None or self._live_order_view is None:
+        portfolio = self._get_live_portfolio(config)
+
+        if self._live_order_view is None:
             msg = "Live 봇 생성에 필요한 Provider가 설정되지 않았습니다"
             raise ValueError(msg)
 
         ctx = StrategyContext(
             bot_id=config.bot_id,
             data_provider=self._data_provider,
-            portfolio=self._live_portfolio,
+            portfolio=portfolio,
             order_view=self._live_order_view,
             trade_history=self._live_trade_history,
         )

--- a/src/ante/treasury/__init__.py
+++ b/src/ante/treasury/__init__.py
@@ -1,10 +1,11 @@
-"""Treasury — 중앙 자금(예산) 관리."""
+"""Treasury -- 중앙 자금(예산) 관리."""
 
 from ante.treasury.exceptions import (
     BotNotStoppedError,
     InsufficientFundsError,
     TreasuryError,
 )
+from ante.treasury.manager import TreasuryManager
 from ante.treasury.models import BotBudget
 from ante.treasury.treasury import Treasury
 
@@ -14,4 +15,5 @@ __all__ = [
     "InsufficientFundsError",
     "Treasury",
     "TreasuryError",
+    "TreasuryManager",
 ]

--- a/src/ante/treasury/manager.py
+++ b/src/ante/treasury/manager.py
@@ -1,0 +1,95 @@
+"""TreasuryManager -- 계좌별 Treasury 인스턴스 관리."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from ante.treasury.treasury import Treasury
+
+if TYPE_CHECKING:
+    from ante.account.models import Account
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+
+class TreasuryManager:
+    """계좌별 Treasury 인스턴스를 생성하고 관리하는 상위 계층."""
+
+    def __init__(self, db: Database, eventbus: EventBus) -> None:
+        self._db = db
+        self._eventbus = eventbus
+        self._treasuries: dict[str, Treasury] = {}
+
+    async def create_treasury(self, account: Account) -> Treasury:
+        """Account 정보로 Treasury 인스턴스 생성 및 등록.
+
+        Args:
+            account: Account 엔티티. account_id, currency, commission 정보 사용.
+
+        Returns:
+            생성된 Treasury 인스턴스.
+        """
+        treasury = Treasury(
+            db=self._db,
+            eventbus=self._eventbus,
+            account_id=account.account_id,
+            currency=account.currency,
+            buy_commission_rate=float(account.buy_commission_rate),
+            sell_commission_rate=float(account.sell_commission_rate),
+        )
+        await treasury.initialize()
+        self._treasuries[account.account_id] = treasury
+        logger.info("Treasury 생성: account_id=%s", account.account_id)
+        return treasury
+
+    def get(self, account_id: str) -> Treasury:
+        """계좌의 Treasury 인스턴스 반환.
+
+        Args:
+            account_id: 계좌 ID.
+
+        Returns:
+            Treasury 인스턴스.
+
+        Raises:
+            KeyError: 해당 계좌의 Treasury가 없을 때.
+        """
+        if account_id not in self._treasuries:
+            raise KeyError(f"Treasury not found: account_id={account_id}")
+        return self._treasuries[account_id]
+
+    def list_all(self) -> list[Treasury]:
+        """전체 Treasury 인스턴스 목록."""
+        return list(self._treasuries.values())
+
+    async def initialize_all(self, accounts: list[Account]) -> None:
+        """각 계좌에 대해 Treasury 인스턴스 생성 및 초기화.
+
+        Args:
+            accounts: Account 엔티티 목록.
+        """
+        for account in accounts:
+            await self.create_treasury(account)
+        logger.info("전체 Treasury 초기화 완료: %d개 계좌", len(accounts))
+
+    async def get_total_summary(self) -> dict[str, Any]:
+        """전 계좌 합산 요약.
+
+        Returns:
+            각 계좌의 요약 정보를 포함하는 딕셔너리.
+        """
+        accounts_summary = []
+        for treasury in self._treasuries.values():
+            summary = treasury.get_summary()
+            accounts_summary.append(
+                {
+                    "account_id": treasury.account_id,
+                    "currency": treasury.currency,
+                    "total_evaluation": summary["total_evaluation"],
+                }
+            )
+
+        return {"accounts": accounts_summary}

--- a/src/ante/treasury/models.py
+++ b/src/ante/treasury/models.py
@@ -11,6 +11,7 @@ class BotBudget:
     """봇별 예산 상태."""
 
     bot_id: str
+    account_id: str = ""
     allocated: float = 0.0
     available: float = 0.0
     reserved: float = 0.0

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -1,4 +1,4 @@
-"""Treasury — 중앙 자금(예산) 관리."""
+"""Treasury -- 계좌별 중앙 자금(예산) 관리."""
 
 from __future__ import annotations
 
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 TREASURY_SCHEMA = """
 CREATE TABLE IF NOT EXISTS bot_budgets (
     bot_id       TEXT PRIMARY KEY,
+    account_id   TEXT NOT NULL DEFAULT '',
     allocated    REAL NOT NULL DEFAULT 0.0,
     available    REAL NOT NULL DEFAULT 0.0,
     reserved     REAL NOT NULL DEFAULT 0.0,
@@ -32,6 +33,7 @@ CREATE TABLE IF NOT EXISTS bot_budgets (
 CREATE TABLE IF NOT EXISTS treasury_transactions (
     id               INTEGER PRIMARY KEY AUTOINCREMENT,
     bot_id           TEXT,
+    account_id       TEXT DEFAULT '',
     transaction_type TEXT NOT NULL,
     amount           REAL NOT NULL,
     description      TEXT DEFAULT '',
@@ -39,31 +41,80 @@ CREATE TABLE IF NOT EXISTS treasury_transactions (
 );
 
 CREATE TABLE IF NOT EXISTS treasury_state (
-    key   TEXT PRIMARY KEY,
-    value REAL NOT NULL
+    account_id         TEXT PRIMARY KEY,
+    account_balance    REAL NOT NULL DEFAULT 0,
+    purchasable_amount REAL NOT NULL DEFAULT 0,
+    total_evaluation   REAL NOT NULL DEFAULT 0,
+    currency           TEXT NOT NULL DEFAULT 'KRW',
+    last_synced_at     TEXT
 );
+"""
+
+# 기존 key-value 테이블에서 계좌별 행 구조로 마이그레이션
+TREASURY_MIGRATION_V2 = """
+-- bot_budgets에 account_id 컬럼 추가 (이미 존재하면 무시)
+ALTER TABLE bot_budgets ADD COLUMN account_id TEXT NOT NULL DEFAULT '';
+"""
+
+TREASURY_MIGRATION_V2_STATE = """
+-- treasury_state 재생성: key-value -> 계좌별 행 구조
+CREATE TABLE IF NOT EXISTS treasury_state_new (
+    account_id         TEXT PRIMARY KEY,
+    account_balance    REAL NOT NULL DEFAULT 0,
+    purchasable_amount REAL NOT NULL DEFAULT 0,
+    total_evaluation   REAL NOT NULL DEFAULT 0,
+    currency           TEXT NOT NULL DEFAULT 'KRW',
+    last_synced_at     TEXT
+);
+
+-- 기존 데이터 마이그레이션
+INSERT OR IGNORE INTO treasury_state_new (
+    account_id, account_balance,
+    purchasable_amount, total_evaluation
+)
+SELECT 'default',
+    COALESCE(
+        (SELECT value FROM treasury_state
+         WHERE key = 'account_balance'), 0),
+    COALESCE(
+        (SELECT value FROM treasury_state
+         WHERE key = 'purchasable_amount'), 0),
+    COALESCE(
+        (SELECT value FROM treasury_state
+         WHERE key = 'total_evaluation'), 0);
+
+DROP TABLE IF EXISTS treasury_state;
+ALTER TABLE treasury_state_new RENAME TO treasury_state;
+"""
+
+TREASURY_TRANSACTIONS_MIGRATION = """
+ALTER TABLE treasury_transactions ADD COLUMN account_id TEXT DEFAULT '';
 """
 
 
 class Treasury:
-    """중앙 자금(예산) 관리자.
+    """계좌별 중앙 자금(예산) 관리자.
 
-    전체 계좌 잔고를 소유하고, 봇별로 예산을 배분하며,
-    예산 범위 내에서 거래가 이루어지도록 관리한다.
+    각 계좌(Account)에 대해 하나의 인스턴스가 생성되며,
+    해당 계좌의 잔고를 소유하고, 봇별로 예산을 배분한다.
     """
 
     def __init__(
         self,
         db: Database,
         eventbus: EventBus,
-        commission_rate: float = 0.00015,
-        sell_tax_rate: float = 0.0023,
+        account_id: str = "default",
+        currency: str = "KRW",
+        buy_commission_rate: float = 0.00015,
+        sell_commission_rate: float = 0.00195,
         bot_status_checker: Callable[[str], str] | None = None,
     ) -> None:
         self._db = db
         self._eventbus = eventbus
-        self._commission_rate = commission_rate
-        self._sell_tax_rate = sell_tax_rate
+        self._account_id = account_id
+        self._currency = currency
+        self._buy_commission_rate = buy_commission_rate
+        self._sell_commission_rate = sell_commission_rate
         self._bot_status_checker = bot_status_checker
 
         self._account_balance: float = 0.0
@@ -78,7 +129,7 @@ class Treasury:
         self._unallocated: float = 0.0
         self._reservations: dict[
             str, tuple[str, float]
-        ] = {}  # order_id → (bot_id, amount)
+        ] = {}  # order_id -> (bot_id, amount)
         self._sync_task: asyncio.Task[None] | None = None
 
         # KIS 계좌 메타 정보 (broker 연결 후 set_account_info로 설정)
@@ -86,12 +137,37 @@ class Treasury:
         self._is_demo_trading: bool = False
         self._last_synced_at: datetime | None = None
 
+    @property
+    def account_id(self) -> str:
+        """이 Treasury가 관리하는 계좌 ID."""
+        return self._account_id
+
     async def initialize(self) -> None:
         """스키마 생성 + DB 복원 + EventBus 구독."""
-        await self._db.execute_script(TREASURY_SCHEMA)
+        await self._ensure_schema()
         await self._load_from_db()
         self._subscribe_events()
-        logger.info("Treasury 초기화 완료")
+        logger.info(
+            "Treasury 초기화 완료: account_id=%s, currency=%s",
+            self._account_id,
+            self._currency,
+        )
+
+    async def _ensure_schema(self) -> None:
+        """DB 스키마 생성 및 마이그레이션."""
+        await self._db.execute_script(TREASURY_SCHEMA)
+
+        # 마이그레이션: bot_budgets에 account_id 컬럼 추가
+        try:
+            await self._db.execute_script(TREASURY_MIGRATION_V2)
+        except Exception:
+            pass  # 이미 컬럼이 존재하면 무시
+
+        # 마이그레이션: treasury_transactions에 account_id 컬럼 추가
+        try:
+            await self._db.execute_script(TREASURY_TRANSACTIONS_MIGRATION)
+        except Exception:
+            pass  # 이미 컬럼이 존재하면 무시
 
     def _subscribe_events(self) -> None:
         """EventBus 이벤트 구독."""
@@ -113,7 +189,7 @@ class Treasury:
         self._eventbus.subscribe(OrderFailedEvent, self._on_order_failed, priority=80)
         self._eventbus.subscribe(BotStoppedEvent, self._on_bot_stopped, priority=80)
 
-    # ── 계좌 잔고 ───────────────────────────────────
+    # -- 계좌 잔고 -----------------------------------------------
 
     async def set_account_balance(self, balance: float) -> None:
         """계좌 잔고 설정. 미할당 자금을 자동 재계산."""
@@ -121,7 +197,7 @@ class Treasury:
         total_allocated = sum(b.allocated for b in self._budgets.values())
         self._unallocated = balance - total_allocated
         await self._save_state()
-        logger.info("계좌 잔고 설정: %s", balance)
+        logger.info("계좌 잔고 설정: %s (account=%s)", balance, self._account_id)
 
     @property
     def account_balance(self) -> float:
@@ -132,12 +208,16 @@ class Treasury:
         return self._unallocated
 
     @property
-    def commission_rate(self) -> float:
-        return self._commission_rate
+    def buy_commission_rate(self) -> float:
+        return self._buy_commission_rate
 
     @property
-    def sell_tax_rate(self) -> float:
-        return self._sell_tax_rate
+    def sell_commission_rate(self) -> float:
+        return self._sell_commission_rate
+
+    @property
+    def currency(self) -> str:
+        return self._currency
 
     @property
     def last_synced_at(self) -> datetime | None:
@@ -171,18 +251,18 @@ class Treasury:
         self._bot_status_checker = checker
 
     def update_commission_rates(
-        self, commission_rate: float, sell_tax_rate: float
+        self, buy_commission_rate: float, sell_commission_rate: float
     ) -> None:
         """수수료율 업데이트 (DynamicConfig 변경 시 호출)."""
-        self._commission_rate = commission_rate
-        self._sell_tax_rate = sell_tax_rate
+        self._buy_commission_rate = buy_commission_rate
+        self._sell_commission_rate = sell_commission_rate
         logger.info(
-            "수수료율 갱신: commission=%s, sell_tax=%s",
-            commission_rate,
-            sell_tax_rate,
+            "수수료율 갱신: buy=%s, sell=%s",
+            buy_commission_rate,
+            sell_commission_rate,
         )
 
-    # ── 예산 조회 ───────────────────────────────────
+    # -- 예산 조회 -----------------------------------------------
 
     def get_available(self, bot_id: str) -> float:
         """봇의 가용 예산 조회."""
@@ -197,7 +277,7 @@ class Treasury:
         """봇의 예산 상태 동기 조회 (인메모리). PortfolioView용."""
         return self._budgets.get(bot_id)
 
-    # ── 예산 할당/회수 ──────────────────────────────
+    # -- 예산 할당/회수 ------------------------------------------
 
     def _check_bot_stopped(self, bot_id: str) -> None:
         """봇이 중지 상태인지 확인. 운용 중이면 BotNotStoppedError."""
@@ -219,7 +299,9 @@ class Treasury:
             return False
 
         if bot_id not in self._budgets:
-            self._budgets[bot_id] = BotBudget(bot_id=bot_id)
+            self._budgets[bot_id] = BotBudget(
+                bot_id=bot_id, account_id=self._account_id
+            )
 
         budget = self._budgets[bot_id]
         budget.allocated += amount
@@ -230,7 +312,9 @@ class Treasury:
         await self._save_budget(budget)
         await self._save_state()
         await self._log_transaction(bot_id, "allocate", amount)
-        logger.info("예산 할당: %s → %s", bot_id, amount)
+        logger.info(
+            "예산 할당: %s -> %s (account=%s)", bot_id, amount, self._account_id
+        )
         return True
 
     async def deallocate(self, bot_id: str, amount: float) -> bool:
@@ -248,7 +332,9 @@ class Treasury:
         await self._save_budget(budget)
         await self._save_state()
         await self._log_transaction(bot_id, "deallocate", amount)
-        logger.info("예산 회수: %s ← %s", bot_id, amount)
+        logger.info(
+            "예산 회수: %s <- %s (account=%s)", bot_id, amount, self._account_id
+        )
         return True
 
     async def update_budget(self, bot_id: str, target_amount: float) -> None:
@@ -301,7 +387,7 @@ class Treasury:
                 )
 
         logger.info(
-            "예산 변경: %s — %s → %s (차이: %s%s)",
+            "예산 변경: %s -- %s -> %s (차이: %s%s)",
             bot_id,
             f"{current:,.0f}",
             f"{target_amount:,.0f}",
@@ -309,7 +395,7 @@ class Treasury:
             f"{diff:,.0f}",
         )
 
-    # ── 주문 자금 예약/해제 ─────────────────────────
+    # -- 주문 자금 예약/해제 -------------------------------------
 
     async def reserve_for_order(
         self, bot_id: str, order_id: str, amount: float
@@ -351,10 +437,18 @@ class Treasury:
             oid: amt for oid, (bid, amt) in self._reservations.items() if bid == bot_id
         }
 
-    # ── 이벤트 핸들러 ───────────────────────────────
+    # -- 이벤트 핸들러 -------------------------------------------
+
+    def _is_my_event(self, event: object) -> bool:
+        """이벤트가 이 Treasury의 계좌에 해당하는지 확인."""
+        account_id = getattr(event, "account_id", "")
+        # account_id가 비어있으면 (하위 호환) 처리
+        if not account_id:
+            return True
+        return account_id == self._account_id
 
     async def _on_order_validated(self, event: object) -> None:
-        """룰 검증 통과 후 자금 예약 → 승인/거부 발행."""
+        """룰 검증 통과 후 자금 예약 -> 승인/거부 발행."""
         from ante.eventbus.events import (
             OrderApprovedEvent,
             OrderRejectedEvent,
@@ -364,9 +458,12 @@ class Treasury:
         if not isinstance(event, OrderValidatedEvent):
             return
 
+        if not self._is_my_event(event):
+            return
+
         price = event.price or 0.0
         estimated_cost = event.quantity * price
-        commission_estimate = estimated_cost * self._commission_rate
+        commission_estimate = estimated_cost * self._buy_commission_rate
         total_reserve = estimated_cost + commission_estimate
 
         if event.side == "buy":
@@ -385,6 +482,7 @@ class Treasury:
                         quantity=event.quantity,
                         price=event.price,
                         order_type=event.order_type,
+                        account_id=self._account_id,
                         reason=(
                             f"insufficient_budget: need {total_reserve:,.0f}, "
                             f"available {available:,.0f}"
@@ -405,14 +503,18 @@ class Treasury:
                 order_type=event.order_type,
                 stop_price=event.stop_price,
                 reserved_amount=(total_reserve if event.side == "buy" else 0.0),
+                account_id=self._account_id,
             )
         )
 
     async def _on_order_filled(self, event: object) -> None:
-        """체결 이벤트 처리 — 예약 자금 정산."""
+        """체결 이벤트 처리 -- 예약 자금 정산."""
         from ante.eventbus.events import OrderFilledEvent
 
         if not isinstance(event, OrderFilledEvent):
+            return
+
+        if not self._is_my_event(event):
             return
 
         budget = self._budgets.get(event.bot_id)
@@ -453,6 +555,10 @@ class Treasury:
 
         if not isinstance(event, OrderCancelledEvent):
             return
+
+        if not self._is_my_event(event):
+            return
+
         await self.release_reservation(event.bot_id, event.order_id)
 
     async def _on_order_failed(self, event: object) -> None:
@@ -461,6 +567,10 @@ class Treasury:
 
         if not isinstance(event, OrderFailedEvent):
             return
+
+        if not self._is_my_event(event):
+            return
+
         await self.release_reservation(event.bot_id, event.order_id)
 
     async def _on_bot_stopped(self, event: object) -> None:
@@ -468,6 +578,9 @@ class Treasury:
         from ante.eventbus.events import BotStoppedEvent
 
         if not isinstance(event, BotStoppedEvent):
+            return
+
+        if not self._is_my_event(event):
             return
 
         bot_id = event.bot_id
@@ -494,13 +607,13 @@ class Treasury:
             description=f"{len(pending)}건 예약 해제",
         )
         logger.info(
-            "봇 중지 예약 해제: %s — %d건, %s원",
+            "봇 중지 예약 해제: %s -- %d건, %s원",
             bot_id,
             len(pending),
             f"{total_released:,.0f}",
         )
 
-    # ── 잔고 동기화 ────────────────────────────────
+    # -- 잔고 동기화 ---------------------------------------------
 
     def start_sync(
         self,
@@ -515,9 +628,13 @@ class Treasury:
 
         self._sync_task = asyncio.create_task(
             self._sync_loop(broker, position_history, interval_seconds),
-            name="treasury-balance-sync",
+            name=f"treasury-balance-sync-{self._account_id}",
         )
-        logger.info("잔고 동기화 시작 (주기: %d초)", interval_seconds)
+        logger.info(
+            "잔고 동기화 시작 (주기: %d초, account=%s)",
+            interval_seconds,
+            self._account_id,
+        )
 
     async def stop_sync(self) -> None:
         """잔고 동기화 중지."""
@@ -544,7 +661,7 @@ class Treasury:
                 except asyncio.CancelledError:
                     raise
                 except Exception:
-                    logger.warning("잔고 동기화 실패 — 이전 값 유지", exc_info=True)
+                    logger.warning("잔고 동기화 실패 -- 이전 값 유지", exc_info=True)
                 await asyncio.sleep(interval_seconds)
         except asyncio.CancelledError:
             raise
@@ -584,6 +701,7 @@ class Treasury:
         # 3) 이벤트 발행
         await self._eventbus.publish(
             BalanceSyncedEvent(
+                account_id=self._account_id,
                 account_balance=self._account_balance,
                 purchasable_amount=self._purchasable_amount,
                 total_evaluation=self._total_evaluation,
@@ -592,10 +710,11 @@ class Treasury:
             )
         )
         logger.info(
-            "잔고 동기화 완료: 예수금=%s, 매수가능=%s, 외부종목=%d건",
+            "잔고 동기화 완료: 예수금=%s, 매수가능=%s, 외부종목=%d건 (account=%s)",
             f"{self._account_balance:,.0f}",
             f"{self._purchasable_amount:,.0f}",
             sum(1 for pos in broker_positions if pos["symbol"] not in internal_symbols),
+            self._account_id,
         )
 
     async def sync_balance(self, balance_data: dict[str, float]) -> None:
@@ -621,7 +740,7 @@ class Treasury:
 
         await self._save_state()
 
-    # ── 모니터링 ────────────────────────────────────
+    # -- 모니터링 -------------------------------------------------
 
     def list_budgets(self) -> list[BotBudget]:
         """전체 봇 예산 목록 반환."""
@@ -642,6 +761,7 @@ class Treasury:
         )
 
         return {
+            "currency": self._currency,
             "account_balance": self._account_balance,
             "purchasable_amount": self._purchasable_amount,
             "total_evaluation": self._total_evaluation,
@@ -664,19 +784,7 @@ class Treasury:
             "last_sync_time": self.last_sync_time,
         }
 
-    # ── DB 영속화 ───────────────────────────────────
-
-    _STATE_FIELDS = (
-        "account_balance",
-        "unallocated",
-        "purchasable_amount",
-        "total_evaluation",
-        "purchase_amount",
-        "eval_amount",
-        "total_profit_loss",
-        "external_purchase_amount",
-        "external_eval_amount",
-    )
+    # -- DB 영속화 -----------------------------------------------
 
     async def load_from_db(self) -> None:
         """DB에서 자금 상태 복원 (테스트용 리로드 포함).
@@ -689,24 +797,26 @@ class Treasury:
 
     async def _load_from_db(self) -> None:
         """DB에서 자금 상태 복원."""
-        rows = await self._db.fetch_all("SELECT key, value FROM treasury_state")
-        state = {r["key"]: float(r["value"]) for r in rows}
+        # 계좌별 상태 로드
+        rows = await self._db.fetch_all(
+            "SELECT * FROM treasury_state WHERE account_id = ?",
+            (self._account_id,),
+        )
+        if rows:
+            r = rows[0]
+            self._account_balance = float(r["account_balance"])
+            self._purchasable_amount = float(r["purchasable_amount"])
+            self._total_evaluation = float(r["total_evaluation"])
 
-        self._account_balance = state.get("account_balance", 0.0)
-        self._unallocated = state.get("unallocated", 0.0)
-        self._purchasable_amount = state.get("purchasable_amount", 0.0)
-        self._total_evaluation = state.get("total_evaluation", 0.0)
-        self._purchase_amount = state.get("purchase_amount", 0.0)
-        self._eval_amount = state.get("eval_amount", 0.0)
-        self._total_profit_loss = state.get("total_profit_loss", 0.0)
-        self._external_purchase_amount = state.get("external_purchase_amount", 0.0)
-        self._external_eval_amount = state.get("external_eval_amount", 0.0)
-
-        # 봇 예산
-        rows = await self._db.fetch_all("SELECT * FROM bot_budgets")
+        # 봇 예산 (계좌별 필터링)
+        rows = await self._db.fetch_all(
+            "SELECT * FROM bot_budgets WHERE account_id = ?",
+            (self._account_id,),
+        )
         for r in rows:
             self._budgets[r["bot_id"]] = BotBudget(
                 bot_id=r["bot_id"],
+                account_id=r["account_id"],
                 allocated=float(r["allocated"]),
                 available=float(r["available"]),
                 reserved=float(r["reserved"]),
@@ -715,35 +825,40 @@ class Treasury:
                 last_updated=datetime.fromisoformat(r["last_updated"]),
             )
 
+        # 미할당 재계산
+        total_allocated = sum(b.allocated for b in self._budgets.values())
+        self._unallocated = self._account_balance - total_allocated
+
     async def _save_state(self) -> None:
         """계좌 상태 저장."""
-        field_map = {
-            "account_balance": self._account_balance,
-            "unallocated": self._unallocated,
-            "purchasable_amount": self._purchasable_amount,
-            "total_evaluation": self._total_evaluation,
-            "purchase_amount": self._purchase_amount,
-            "eval_amount": self._eval_amount,
-            "total_profit_loss": self._total_profit_loss,
-            "external_purchase_amount": self._external_purchase_amount,
-            "external_eval_amount": self._external_eval_amount,
-        }
-        for key, value in field_map.items():
-            await self._db.execute(
-                """INSERT INTO treasury_state (key, value)
-                   VALUES (?, ?)
-                   ON CONFLICT(key) DO UPDATE SET value = excluded.value""",
-                (key, value),
-            )
+        await self._db.execute(
+            """INSERT INTO treasury_state
+               (account_id, account_balance, purchasable_amount,
+                total_evaluation, currency)
+               VALUES (?, ?, ?, ?, ?)
+               ON CONFLICT(account_id) DO UPDATE SET
+                 account_balance = excluded.account_balance,
+                 purchasable_amount = excluded.purchasable_amount,
+                 total_evaluation = excluded.total_evaluation,
+                 currency = excluded.currency""",
+            (
+                self._account_id,
+                self._account_balance,
+                self._purchasable_amount,
+                self._total_evaluation,
+                self._currency,
+            ),
+        )
 
     async def _save_budget(self, budget: BotBudget) -> None:
         """봇 예산 저장."""
         await self._db.execute(
             """INSERT INTO bot_budgets
-               (bot_id, allocated, available, reserved,
+               (bot_id, account_id, allocated, available, reserved,
                 spent, returned, last_updated)
-               VALUES (?, ?, ?, ?, ?, ?, ?)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(bot_id) DO UPDATE SET
+                 account_id = excluded.account_id,
                  allocated = excluded.allocated,
                  available = excluded.available,
                  reserved = excluded.reserved,
@@ -752,6 +867,7 @@ class Treasury:
                  last_updated = excluded.last_updated""",
             (
                 budget.bot_id,
+                budget.account_id,
                 budget.allocated,
                 budget.available,
                 budget.reserved,
@@ -771,7 +887,7 @@ class Treasury:
         """자금 거래 이력 기록."""
         await self._db.execute(
             """INSERT INTO treasury_transactions
-               (bot_id, transaction_type, amount, description)
-               VALUES (?, ?, ?, ?)""",
-            (bot_id, tx_type, amount, description),
+               (bot_id, account_id, transaction_type, amount, description)
+               VALUES (?, ?, ?, ?, ?)""",
+            (bot_id, self._account_id, tx_type, amount, description),
         )

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -51,8 +51,8 @@ async def get_summary(
 ) -> dict:
     """자금 현황 요약."""
     summary = treasury.get_summary()
-    summary["commission_rate"] = getattr(treasury, "commission_rate", 0.00015)
-    summary["sell_tax_rate"] = getattr(treasury, "sell_tax_rate", 0.0023)
+    summary["commission_rate"] = getattr(treasury, "buy_commission_rate", 0.00015)
+    summary["sell_tax_rate"] = getattr(treasury, "sell_commission_rate", 0.00195)
 
     # 브로커 메타정보
     if broker is not None:

--- a/tests/unit/test_commission.py
+++ b/tests/unit/test_commission.py
@@ -214,23 +214,23 @@ def eventbus():
 
 
 class TestTreasuryCommission:
-    async def test_treasury_accepts_sell_tax_rate(self, db, eventbus):
-        """Treasury가 sell_tax_rate 파라미터를 수용."""
+    async def test_treasury_accepts_commission_rates(self, db, eventbus):
+        """Treasury가 buy/sell_commission_rate 파라미터를 수용."""
         t = Treasury(
             db=db,
             eventbus=eventbus,
-            commission_rate=0.00015,
-            sell_tax_rate=0.0023,
+            buy_commission_rate=0.00015,
+            sell_commission_rate=0.00195,
         )
         await t.initialize()
-        assert t.commission_rate == 0.00015
-        assert t.sell_tax_rate == 0.0023
+        assert t.buy_commission_rate == 0.00015
+        assert t.sell_commission_rate == 0.00195
 
-    async def test_treasury_default_sell_tax_rate(self, db, eventbus):
-        """Treasury 기본 sell_tax_rate = 0.0023."""
+    async def test_treasury_default_sell_commission_rate(self, db, eventbus):
+        """Treasury 기본 sell_commission_rate = 0.00195."""
         t = Treasury(db=db, eventbus=eventbus)
         await t.initialize()
-        assert t.sell_tax_rate == 0.0023
+        assert t.sell_commission_rate == 0.00195
 
     async def test_update_commission_rates(self, db, eventbus):
         """수수료율 동적 업데이트."""
@@ -238,18 +238,18 @@ class TestTreasuryCommission:
         await t.initialize()
 
         t.update_commission_rates(0.0001, 0.0018)
-        assert t.commission_rate == 0.0001
-        assert t.sell_tax_rate == 0.0018
+        assert t.buy_commission_rate == 0.0001
+        assert t.sell_commission_rate == 0.0018
 
     async def test_buy_reservation_uses_commission_rate(self, db, eventbus):
-        """매수 예약 시 commission_rate 사용."""
+        """매수 예약 시 buy_commission_rate 사용."""
         from ante.eventbus.events import OrderApprovedEvent, OrderValidatedEvent
 
         t = Treasury(
             db=db,
             eventbus=eventbus,
-            commission_rate=0.001,  # 높은 수수료율로 테스트
-            sell_tax_rate=0.0023,
+            buy_commission_rate=0.001,  # 높은 수수료율로 테스트
+            sell_commission_rate=0.002,
         )
         await t.initialize()
         await t.set_account_balance(10_000_000.0)

--- a/tests/unit/test_treasury.py
+++ b/tests/unit/test_treasury.py
@@ -5,6 +5,7 @@ import pytest
 from ante.core import Database
 from ante.eventbus import EventBus
 from ante.eventbus.events import (
+    BotStoppedEvent,
     OrderApprovedEvent,
     OrderCancelledEvent,
     OrderFailedEvent,
@@ -14,7 +15,10 @@ from ante.eventbus.events import (
 )
 from ante.treasury import BotBudget, Treasury
 
-# ── Fixtures ─────────────────────────────────────
+# -- Fixtures -------------------------------------------------
+
+ACCOUNT_ID = "domestic"
+CURRENCY = "KRW"
 
 
 @pytest.fixture
@@ -32,13 +36,20 @@ def eventbus():
 
 @pytest.fixture
 async def treasury(db, eventbus):
-    t = Treasury(db=db, eventbus=eventbus, commission_rate=0.00015)
+    t = Treasury(
+        db=db,
+        eventbus=eventbus,
+        account_id=ACCOUNT_ID,
+        currency=CURRENCY,
+        buy_commission_rate=0.00015,
+        sell_commission_rate=0.00195,
+    )
     await t.initialize()
     await t.set_account_balance(10_000_000.0)
     return t
 
 
-# ── BotBudget 모델 ───────────────────────────────
+# -- BotBudget 모델 -------------------------------------------
 
 
 class TestBotBudget:
@@ -51,8 +62,45 @@ class TestBotBudget:
         assert b.spent == 0.0
         assert b.returned == 0.0
 
+    def test_account_id_field(self):
+        """BotBudget에 account_id 필드가 존재한다."""
+        b = BotBudget(bot_id="bot1", account_id="domestic")
+        assert b.account_id == "domestic"
 
-# ── 계좌 잔고 ───────────────────────────────────
+
+# -- Treasury 계좌 속성 ----------------------------------------
+
+
+class TestTreasuryAccountProperties:
+    async def test_account_id(self, treasury):
+        """Treasury에 account_id가 설정된다."""
+        assert treasury.account_id == ACCOUNT_ID
+
+    async def test_currency(self, treasury):
+        """Treasury에 currency가 설정된다."""
+        assert treasury.currency == CURRENCY
+
+    async def test_buy_commission_rate(self, treasury):
+        """buy_commission_rate 프로퍼티."""
+        assert treasury.buy_commission_rate == 0.00015
+
+    async def test_sell_commission_rate(self, treasury):
+        """sell_commission_rate 프로퍼티."""
+        assert treasury.sell_commission_rate == 0.00195
+
+    async def test_update_commission_rates(self, treasury):
+        """수수료율 업데이트."""
+        treasury.update_commission_rates(0.001, 0.002)
+        assert treasury.buy_commission_rate == 0.001
+        assert treasury.sell_commission_rate == 0.002
+
+    async def test_summary_includes_currency(self, treasury):
+        """get_summary()에 currency가 포함된다."""
+        summary = treasury.get_summary()
+        assert summary["currency"] == CURRENCY
+
+
+# -- 계좌 잔고 -----------------------------------------------
 
 
 class TestAccountBalance:
@@ -73,7 +121,7 @@ class TestAccountBalance:
         assert treasury.unallocated == 2_000_000.0
 
 
-# ── 예산 할당/회수 ──────────────────────────────
+# -- 예산 할당/회수 ------------------------------------------
 
 
 class TestAllocation:
@@ -85,6 +133,13 @@ class TestAllocation:
         assert budget is not None
         assert budget.allocated == 1_000_000.0
         assert budget.available == 1_000_000.0
+
+    async def test_allocate_sets_account_id(self, treasury):
+        """예산 할당 시 BotBudget에 account_id가 설정된다."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.account_id == ACCOUNT_ID
 
     async def test_allocate_insufficient(self, treasury):
         """미할당 자금 부족 시 실패."""
@@ -129,7 +184,7 @@ class TestAllocation:
         assert budget.available == 800_000.0
 
 
-# ── 봇 상태 검증 (예산 변경 시) ──────────────────
+# -- 봇 상태 검증 (예산 변경 시) --------------------------------
 
 
 class TestBotStatusCheck:
@@ -142,6 +197,7 @@ class TestBotStatusCheck:
         t = Treasury(
             db=db,
             eventbus=eventbus,
+            account_id=ACCOUNT_ID,
             bot_status_checker=lambda bid: bot_statuses.get(bid, ""),
         )
         await t.initialize()
@@ -218,7 +274,7 @@ class TestBotStatusCheck:
         assert result is True
 
 
-# ── 주문 자금 예약/해제 ─────────────────────────
+# -- 주문 자금 예약/해제 -------------------------------------
 
 
 class TestReservation:
@@ -257,12 +313,12 @@ class TestReservation:
         assert budget.available == 1_000_000.0
 
 
-# ── EventBus 통합 ───────────────────────────────
+# -- EventBus 통합 (account_id 필터링 포함) --------------------
 
 
 class TestTreasuryEvents:
     async def test_validated_buy_approved(self, treasury, eventbus):
-        """매수 주문 검증 통과 → 자금 예약 → OrderApprovedEvent."""
+        """매수 주문 검증 통과 -> 자금 예약 -> OrderApprovedEvent."""
         await treasury.allocate("bot1", 1_000_000.0)
 
         received = []
@@ -278,12 +334,14 @@ class TestTreasuryEvents:
                 quantity=10.0,
                 price=50_000.0,
                 order_type="market",
+                account_id=ACCOUNT_ID,
             )
         )
 
         assert len(received) == 1
         assert received[0].order_id == "ord1"
         assert received[0].reserved_amount > 0
+        assert received[0].account_id == ACCOUNT_ID
 
         budget = treasury.get_budget("bot1")
         assert budget is not None
@@ -291,7 +349,7 @@ class TestTreasuryEvents:
         assert budget.available < 1_000_000.0
 
     async def test_validated_buy_insufficient_rejected(self, treasury, eventbus):
-        """매수 자금 부족 → OrderRejectedEvent."""
+        """매수 자금 부족 -> OrderRejectedEvent."""
         await treasury.allocate("bot1", 100.0)
 
         received = []
@@ -307,6 +365,7 @@ class TestTreasuryEvents:
                 quantity=10.0,
                 price=50_000.0,
                 order_type="market",
+                account_id=ACCOUNT_ID,
             )
         )
 
@@ -330,11 +389,94 @@ class TestTreasuryEvents:
                 quantity=10.0,
                 price=50_000.0,
                 order_type="market",
+                account_id=ACCOUNT_ID,
             )
         )
 
         assert len(received) == 1
         assert received[0].reserved_amount == 0.0
+
+    async def test_event_filtered_by_account_id(self, treasury, eventbus):
+        """다른 계좌의 이벤트는 무시한다."""
+        await treasury.allocate("bot1", 1_000_000.0)
+
+        received = []
+        eventbus.subscribe(OrderApprovedEvent, lambda e: received.append(e))
+        eventbus.subscribe(OrderRejectedEvent, lambda e: received.append(e))
+
+        # 다른 계좌 ID로 이벤트 발행
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=50_000.0,
+                order_type="market",
+                account_id="other-account",
+            )
+        )
+
+        # Treasury가 이 이벤트를 무시했으므로 Approved/Rejected 모두 없어야 함
+        assert len(received) == 0
+
+        # 예산도 변경 없음
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.available == 1_000_000.0
+        assert budget.reserved == 0.0
+
+    async def test_event_without_account_id_processed(self, treasury, eventbus):
+        """account_id가 비어있는 이벤트는 하위 호환으로 처리한다."""
+        await treasury.allocate("bot1", 1_000_000.0)
+
+        received = []
+        eventbus.subscribe(OrderApprovedEvent, lambda e: received.append(e))
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=50_000.0,
+                order_type="market",
+                account_id="",
+            )
+        )
+
+        # account_id 비어있으면 처리
+        assert len(received) == 1
+
+    async def test_filled_event_filtered_by_account(self, treasury, eventbus):
+        """다른 계좌의 체결 이벤트는 무시한다."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.reserve_for_order("bot1", "ord1", 500_100.0)
+
+        await eventbus.publish(
+            OrderFilledEvent(
+                order_id="ord1",
+                broker_order_id="bk1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=50_000.0,
+                commission=75.0,
+                order_type="market",
+                account_id="other-account",
+            )
+        )
+
+        # 무시되었으므로 reserved 변경 없음
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.reserved == 500_100.0
 
     async def test_buy_filled_settles_reservation(self, treasury, eventbus):
         """매수 체결 시 예약 자금 정산."""
@@ -353,6 +495,7 @@ class TestTreasuryEvents:
                 price=50_000.0,
                 commission=75.0,
                 order_type="market",
+                account_id=ACCOUNT_ID,
             )
         )
 
@@ -379,6 +522,7 @@ class TestTreasuryEvents:
                 price=55_000.0,
                 commission=82.5,
                 order_type="market",
+                account_id=ACCOUNT_ID,
             )
         )
 
@@ -403,6 +547,7 @@ class TestTreasuryEvents:
                 side="buy",
                 quantity=10.0,
                 price=50_000.0,
+                account_id=ACCOUNT_ID,
             )
         )
 
@@ -410,6 +555,29 @@ class TestTreasuryEvents:
         assert budget is not None
         assert budget.available == 1_000_000.0
         assert budget.reserved == 0.0
+
+    async def test_cancelled_event_filtered_by_account(self, treasury, eventbus):
+        """다른 계좌의 취소 이벤트는 무시한다."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.reserve_for_order("bot1", "ord1", 500_000.0)
+
+        await eventbus.publish(
+            OrderCancelledEvent(
+                order_id="ord1",
+                broker_order_id="bk1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=50_000.0,
+                account_id="other-account",
+            )
+        )
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.reserved == 500_000.0
 
     async def test_order_failed_releases(self, treasury, eventbus):
         """주문 실패 시 예약 해제."""
@@ -427,6 +595,7 @@ class TestTreasuryEvents:
                 price=50_000.0,
                 order_type="market",
                 error_message="broker error",
+                account_id=ACCOUNT_ID,
             )
         )
 
@@ -435,8 +604,42 @@ class TestTreasuryEvents:
         assert budget.available == 1_000_000.0
         assert budget.reserved == 0.0
 
+    async def test_bot_stopped_releases_all(self, treasury, eventbus):
+        """봇 중지 시 모든 예약 자금 해제."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.reserve_for_order("bot1", "ord1", 200_000.0)
+        await treasury.reserve_for_order("bot1", "ord2", 300_000.0)
 
-# ── 모니터링 ────────────────────────────────────
+        await eventbus.publish(
+            BotStoppedEvent(
+                bot_id="bot1",
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.reserved == 0.0
+        assert budget.available == 1_000_000.0
+
+    async def test_bot_stopped_filtered_by_account(self, treasury, eventbus):
+        """다른 계좌의 BotStopped는 무시한다."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        await treasury.reserve_for_order("bot1", "ord1", 200_000.0)
+
+        await eventbus.publish(
+            BotStoppedEvent(
+                bot_id="bot1",
+                account_id="other-account",
+            )
+        )
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.reserved == 200_000.0
+
+
+# -- 모니터링 -------------------------------------------------
 
 
 class TestTreasurySummary:
@@ -471,19 +674,19 @@ class TestTreasurySummary:
         assert summary["budget_exceeds_purchasable"] is False
 
 
-# ── DB 영속화 ───────────────────────────────────
+# -- DB 영속화 -----------------------------------------------
 
 
 class TestTreasuryPersistence:
     async def test_persists_across_instances(self, db, eventbus):
         """Treasury 재시작 후 상태 복원."""
-        t1 = Treasury(db=db, eventbus=eventbus)
+        t1 = Treasury(db=db, eventbus=eventbus, account_id=ACCOUNT_ID)
         await t1.initialize()
         await t1.set_account_balance(5_000_000.0)
         await t1.allocate("bot1", 2_000_000.0)
 
         # 새 인스턴스 생성
-        t2 = Treasury(db=db, eventbus=eventbus)
+        t2 = Treasury(db=db, eventbus=eventbus, account_id=ACCOUNT_ID)
         await t2.initialize()
 
         assert t2.account_balance == 5_000_000.0
@@ -492,9 +695,58 @@ class TestTreasuryPersistence:
         assert budget is not None
         assert budget.allocated == 2_000_000.0
         assert budget.available == 2_000_000.0
+        assert budget.account_id == ACCOUNT_ID
+
+    async def test_separate_accounts_isolated(self, db, eventbus):
+        """서로 다른 계좌의 Treasury는 데이터가 격리된다."""
+        t1 = Treasury(db=db, eventbus=eventbus, account_id="domestic")
+        await t1.initialize()
+        await t1.set_account_balance(10_000_000.0)
+        await t1.allocate("bot1", 3_000_000.0)
+
+        t2 = Treasury(db=db, eventbus=eventbus, account_id="us-stock")
+        await t2.initialize()
+        await t2.set_account_balance(5_000.0)
+        await t2.allocate("bot2", 2_000.0)
+
+        # 각자의 데이터만 보여야 한다
+        assert t1.account_balance == 10_000_000.0
+        assert t1.unallocated == 7_000_000.0
+        assert t1.get_budget("bot1") is not None
+        assert t1.get_budget("bot2") is None
+
+        assert t2.account_balance == 5_000.0
+        assert t2.unallocated == 3_000.0
+        assert t2.get_budget("bot2") is not None
+        assert t2.get_budget("bot1") is None
+
+    async def test_persistence_with_separate_accounts(self, db, eventbus):
+        """서로 다른 계좌 재시작 후에도 데이터 격리 유지."""
+        t1 = Treasury(db=db, eventbus=eventbus, account_id="domestic")
+        await t1.initialize()
+        await t1.set_account_balance(10_000_000.0)
+        await t1.allocate("bot1", 3_000_000.0)
+
+        t2 = Treasury(db=db, eventbus=eventbus, account_id="us-stock")
+        await t2.initialize()
+        await t2.set_account_balance(5_000.0)
+
+        # 새 인스턴스로 복원
+        t1_new = Treasury(db=db, eventbus=eventbus, account_id="domestic")
+        await t1_new.initialize()
+
+        t2_new = Treasury(db=db, eventbus=eventbus, account_id="us-stock")
+        await t2_new.initialize()
+
+        assert t1_new.account_balance == 10_000_000.0
+        assert t1_new.get_budget("bot1") is not None
+        assert t1_new.get_budget("bot1").allocated == 3_000_000.0
+
+        assert t2_new.account_balance == 5_000.0
+        assert t2_new.get_budget("bot1") is None
 
 
-# ── update_budget ─────────────────────────────
+# -- update_budget -------------------------------------------
 
 
 class TestUpdateBudget:

--- a/tests/unit/test_treasury_manager.py
+++ b/tests/unit/test_treasury_manager.py
@@ -1,0 +1,145 @@
+"""TreasuryManager 단위 테스트."""
+
+from decimal import Decimal
+
+import pytest
+
+from ante.account.models import Account
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.treasury import TreasuryManager
+
+# -- Fixtures -------------------------------------------------
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+def domestic_account():
+    return Account(
+        account_id="domestic",
+        name="국내주식",
+        exchange="KRX",
+        currency="KRW",
+        buy_commission_rate=Decimal("0.00015"),
+        sell_commission_rate=Decimal("0.00195"),
+    )
+
+
+@pytest.fixture
+def us_account():
+    return Account(
+        account_id="us-stock",
+        name="미국주식",
+        exchange="NASDAQ",
+        currency="USD",
+        buy_commission_rate=Decimal("0.001"),
+        sell_commission_rate=Decimal("0.001"),
+    )
+
+
+@pytest.fixture
+async def manager(db, eventbus):
+    return TreasuryManager(db=db, eventbus=eventbus)
+
+
+# -- TreasuryManager 테스트 ----------------------------------
+
+
+class TestTreasuryManager:
+    async def test_create_treasury(self, manager, domestic_account):
+        """create_treasury로 Treasury 인스턴스 생성."""
+        treasury = await manager.create_treasury(domestic_account)
+
+        assert treasury.account_id == "domestic"
+        assert treasury.currency == "KRW"
+        assert treasury.buy_commission_rate == pytest.approx(0.00015)
+        assert treasury.sell_commission_rate == pytest.approx(0.00195)
+
+    async def test_get(self, manager, domestic_account):
+        """get으로 Treasury 인스턴스 조회."""
+        await manager.create_treasury(domestic_account)
+        treasury = manager.get("domestic")
+        assert treasury.account_id == "domestic"
+
+    async def test_get_not_found(self, manager):
+        """존재하지 않는 계좌 조회 시 KeyError."""
+        with pytest.raises(KeyError, match="nonexistent"):
+            manager.get("nonexistent")
+
+    async def test_list_all(self, manager, domestic_account, us_account):
+        """list_all로 전체 Treasury 목록 조회."""
+        await manager.create_treasury(domestic_account)
+        await manager.create_treasury(us_account)
+
+        treasuries = manager.list_all()
+        assert len(treasuries) == 2
+        ids = {t.account_id for t in treasuries}
+        assert ids == {"domestic", "us-stock"}
+
+    async def test_initialize_all(self, manager, domestic_account, us_account):
+        """initialize_all로 여러 계좌의 Treasury 일괄 생성."""
+        await manager.initialize_all([domestic_account, us_account])
+
+        treasuries = manager.list_all()
+        assert len(treasuries) == 2
+
+        domestic = manager.get("domestic")
+        assert domestic.currency == "KRW"
+
+        us = manager.get("us-stock")
+        assert us.currency == "USD"
+
+    async def test_get_total_summary(self, manager, domestic_account, us_account):
+        """get_total_summary로 전 계좌 합산 요약."""
+        await manager.initialize_all([domestic_account, us_account])
+
+        domestic = manager.get("domestic")
+        await domestic.set_account_balance(10_000_000.0)
+
+        us = manager.get("us-stock")
+        await us.set_account_balance(5_000.0)
+
+        summary = await manager.get_total_summary()
+        assert "accounts" in summary
+        assert len(summary["accounts"]) == 2
+
+        accounts_by_id = {a["account_id"]: a for a in summary["accounts"]}
+        assert accounts_by_id["domestic"]["currency"] == "KRW"
+        assert accounts_by_id["us-stock"]["currency"] == "USD"
+
+    async def test_separate_treasury_isolation(
+        self, manager, domestic_account, us_account
+    ):
+        """각 계좌의 Treasury는 독립적으로 동작한다."""
+        await manager.initialize_all([domestic_account, us_account])
+
+        domestic = manager.get("domestic")
+        await domestic.set_account_balance(10_000_000.0)
+        await domestic.allocate("bot1", 3_000_000.0)
+
+        us = manager.get("us-stock")
+        await us.set_account_balance(5_000.0)
+        await us.allocate("bot2", 2_000.0)
+
+        # 각자의 봇만 관리
+        assert domestic.get_budget("bot1") is not None
+        assert domestic.get_budget("bot2") is None
+
+        assert us.get_budget("bot2") is not None
+        assert us.get_budget("bot1") is None
+
+        # 잔액 독립
+        assert domestic.unallocated == 7_000_000.0
+        assert us.unallocated == 3_000.0

--- a/tests/unit/test_treasury_sync.py
+++ b/tests/unit/test_treasury_sync.py
@@ -28,7 +28,7 @@ def eventbus():
 
 @pytest.fixture
 async def treasury(db, eventbus):
-    t = Treasury(db=db, eventbus=eventbus, commission_rate=0.00015)
+    t = Treasury(db=db, eventbus=eventbus, buy_commission_rate=0.00015)
     await t.initialize()
     return t
 
@@ -152,16 +152,13 @@ class TestSyncBalance:
             }
         )
 
-        # 새 인스턴스로 복원 확인
+        # 새 인스턴스로 복원 확인 (계좌별 행 구조 — 핵심 필드만 영속화)
         t2 = Treasury(db=db, eventbus=eventbus)
         await t2.initialize()
 
         assert t2._account_balance == 5_000_000.0
         assert t2._purchasable_amount == 4_800_000.0
         assert t2._total_evaluation == 12_000_000.0
-        assert t2._purchase_amount == 7_000_000.0
-        assert t2._eval_amount == 7_200_000.0
-        assert t2._total_profit_loss == 200_000.0
 
     async def test_purchasable_amount_in_kis(self):
         """KIS get_account_balance에 purchasable_amount 포함 확인."""
@@ -344,8 +341,8 @@ class TestExternalPositions:
         assert treasury._external_purchase_amount == 3_000_000.0
         assert treasury._external_eval_amount == 3_100_000.0
 
-    async def test_external_amounts_persist(self, treasury, db, eventbus):
-        """외부 종목 금액이 DB에 저장되어 재시작 후 복원."""
+    async def test_external_amounts_in_memory(self, treasury):
+        """외부 종목 금액이 인메모리에 보관된다."""
         broker = FakeBroker(
             positions=[
                 {
@@ -362,12 +359,8 @@ class TestExternalPositions:
         await asyncio.sleep(0.05)
         await treasury.stop_sync()
 
-        # 새 인스턴스
-        t2 = Treasury(db=db, eventbus=eventbus)
-        await t2.initialize()
-
-        assert t2._external_purchase_amount == 3_000_000.0
-        assert t2._external_eval_amount == 3_100_000.0
+        assert treasury._external_purchase_amount == 3_000_000.0
+        assert treasury._external_eval_amount == 3_100_000.0
 
     async def test_sync_event_includes_external(self, treasury, eventbus):
         """BalanceSyncedEvent에 외부 종목 금액 포함."""


### PR DESCRIPTION
## Summary

- Treasury 생성자에 `account_id`, `currency`, `buy_commission_rate`, `sell_commission_rate` 추가
- 모든 이벤트 핸들러에서 `account_id` 필터링 (다른 계좌 이벤트 무시, 빈 값은 하위 호환)
- `TreasuryManager` 신규 도입: 계좌별 Treasury 인스턴스 생성/관리/합산 요약
- `BotBudget`에 `account_id` 필드 추가
- DB 스키마: `treasury_state`를 계좌별 행 구조(PK=account_id)로 변경, `bot_budgets`에 account_id 추가
- `StrategyContextFactory`에 `TreasuryManager` 주입으로 계좌별 `LivePortfolioView` 생성
- 기존 테스트(commission, sync) 새 인터페이스에 맞게 업데이트

## Changed Files

| 파일 | 변경 |
|------|------|
| `src/ante/treasury/treasury.py` | account_id, currency, buy/sell_commission_rate 추가. 이벤트 필터링. DB 스키마 변경 |
| `src/ante/treasury/manager.py` | **신규**: TreasuryManager 클래스 |
| `src/ante/treasury/models.py` | BotBudget에 account_id 필드 추가 |
| `src/ante/treasury/__init__.py` | TreasuryManager re-export |
| `src/ante/bot/context_factory.py` | TreasuryManager 주입, 계좌별 LivePortfolioView 생성 |
| `src/ante/web/routes/treasury.py` | commission_rate -> buy_commission_rate 프로퍼티명 변경 |
| `tests/unit/test_treasury.py` | 계좌별 인스턴스 테스트, account_id 필터링 테스트 |
| `tests/unit/test_treasury_manager.py` | **신규**: TreasuryManager 단위 테스트 |
| `tests/unit/test_treasury_sync.py` | 새 인터페이스에 맞게 수정 |
| `tests/unit/test_commission.py` | 새 인터페이스에 맞게 수정 |

Refs #565