### PR TITLE
feat(cli): ante account 명령어 그룹 (#571)

### DIFF
--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -1,0 +1,457 @@
+"""ante account -- 계좌 관리 커맨드."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+import click
+
+from ante.cli.main import get_formatter
+from ante.cli.middleware import get_member_id, require_auth, require_scope
+
+if TYPE_CHECKING:
+    from ante.account.models import Account
+    from ante.account.service import AccountService
+    from ante.core.database import Database
+
+logger = logging.getLogger(__name__)
+
+
+@click.group()
+def account() -> None:
+    """계좌 생성·조회·관리."""
+
+
+def _run(coro):  # noqa: ANN001, ANN202
+    return asyncio.run(coro)
+
+
+async def _create_account_service() -> tuple[AccountService, Database]:
+    """CLI에서 AccountService를 생성하는 헬퍼."""
+    from ante.account.service import AccountService
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+    db = Database("db/ante.db")
+    await db.connect()
+    eventbus = EventBus()
+    account_service = AccountService(db=db, eventbus=eventbus)
+    await account_service.initialize()
+    return account_service, db
+
+
+def mask_value(key: str, value: str) -> str:
+    """인증 정보 값을 마스킹한다.
+
+    6자 이하: '****'
+    초과: 앞 4자 + '****' + 뒤 2자
+    """
+    if len(value) <= 6:
+        return "****"
+    return value[:4] + "****" + value[-2:]
+
+
+def _get_selectable_broker_types() -> list[str]:
+    """BROKER_REGISTRY에 등록된 broker_type만 반환 (kis-overseas 제외)."""
+    from ante.broker.registry import BROKER_REGISTRY
+
+    return list(BROKER_REGISTRY.keys())
+
+
+# ── create ──────────────────────────────────────
+
+
+@account.command("create")
+@click.pass_context
+@require_auth
+@require_scope("account:write")
+def account_create(ctx: click.Context) -> None:
+    """대화형 계좌 생성."""
+    fmt = get_formatter(ctx)
+
+    from ante.account.models import Account, TradingMode
+    from ante.account.presets import BROKER_PRESETS
+
+    # 1) 브로커 선택 (BROKER_REGISTRY에 등록된 것만)
+    selectable = _get_selectable_broker_types()
+    click.echo("\n브로커를 선택하세요:")
+    for i, bt in enumerate(selectable, 1):
+        preset = BROKER_PRESETS[bt]
+        click.echo(f"  {i}) {bt} ({preset.default_name})")
+
+    choice = click.prompt("선택", type=click.IntRange(1, len(selectable)), default=1)
+    broker_type = selectable[choice - 1]
+    preset = BROKER_PRESETS[broker_type]
+
+    # 2) 계좌 ID, 이름
+    account_id = click.prompt("계좌 ID", default=preset.default_account_id)
+    name = click.prompt("이름", default=preset.default_name)
+
+    # 3) 거래 모드
+    click.echo("거래 모드를 선택하세요:")
+    click.echo("  1) virtual (가상거래)")
+    click.echo("  2) live (실제거래)")
+    mode_choice = click.prompt("선택", type=click.IntRange(1, 2), default=1)
+    trading_mode = TradingMode.VIRTUAL if mode_choice == 1 else TradingMode.LIVE
+
+    # 4) 인증 정보
+    credentials: dict[str, str] = {}
+    for cred_key in preset.required_credentials:
+        hide = cred_key.lower() in ("app_secret", "secret", "password")
+        value = click.prompt(cred_key.upper(), hide_input=hide)
+        credentials[cred_key] = value
+
+    # 5) Account 생성
+    new_account = Account(
+        account_id=account_id,
+        name=name,
+        exchange=preset.exchange,
+        currency=preset.currency,
+        timezone=preset.timezone,
+        trading_hours_start=preset.trading_hours_start,
+        trading_hours_end=preset.trading_hours_end,
+        trading_mode=trading_mode,
+        broker_type=broker_type,
+        credentials=credentials,
+        buy_commission_rate=preset.buy_commission_rate,
+        sell_commission_rate=preset.sell_commission_rate,
+    )
+
+    async def _do_create() -> Account:
+        svc, db = await _create_account_service()
+        try:
+            return await svc.create(new_account)
+        finally:
+            await db.close()
+
+    try:
+        created = _run(_do_create())
+    except Exception as e:
+        fmt.error(str(e))
+        raise SystemExit(1) from e
+
+    fmt.success(
+        f'계좌 "{created.account_id}" 생성 완료 '
+        f"({created.exchange} / {created.currency} / {created.broker_type})",
+        data={
+            "account_id": created.account_id,
+            "exchange": created.exchange,
+            "currency": created.currency,
+            "broker_type": created.broker_type,
+        },
+    )
+
+
+# ── list ──────────────────────────────────────
+
+
+@account.command("list")
+@click.option(
+    "--status",
+    "status_filter",
+    default=None,
+    help="상태 필터 (active/suspended/deleted)",
+)
+@click.pass_context
+@require_auth
+@require_scope("account:read")
+def account_list(ctx: click.Context, status_filter: str | None) -> None:
+    """계좌 목록 조회."""
+    fmt = get_formatter(ctx)
+
+    from ante.account.models import AccountStatus
+
+    async def _do_list() -> list[dict]:
+        svc, db = await _create_account_service()
+        try:
+            status = AccountStatus(status_filter) if status_filter else None
+            accounts = await svc.list(status=status)
+            return [_account_to_row(a) for a in accounts]
+        finally:
+            await db.close()
+
+    try:
+        rows = _run(_do_list())
+    except Exception as e:
+        fmt.error(str(e))
+        raise SystemExit(1) from e
+
+    if not rows:
+        fmt.output({"message": "등록된 계좌가 없습니다.", "accounts": []})
+        return
+
+    if fmt.is_json:
+        fmt.output({"accounts": rows})
+    else:
+        fmt.table(
+            rows,
+            ["account_id", "name", "exchange", "currency", "broker_type", "status"],
+        )
+
+
+# ── info ──────────────────────────────────────
+
+
+@account.command("info")
+@click.argument("account_id")
+@click.pass_context
+@require_auth
+@require_scope("account:read")
+def account_info(ctx: click.Context, account_id: str) -> None:
+    """계좌 상세 정보 조회."""
+    fmt = get_formatter(ctx)
+
+    async def _do_info() -> dict:
+        svc, db = await _create_account_service()
+        try:
+            acct = await svc.get(account_id)
+            return _account_to_detail(acct)
+        finally:
+            await db.close()
+
+    try:
+        detail = _run(_do_info())
+    except Exception as e:
+        fmt.error(str(e))
+        raise SystemExit(1) from e
+
+    if fmt.is_json:
+        fmt.output(detail)
+    else:
+        _print_account_detail(detail)
+
+
+# ── suspend ──────────────────────────────────────
+
+
+@account.command("suspend")
+@click.argument("account_id")
+@click.pass_context
+@require_auth
+@require_scope("account:write")
+def account_suspend(ctx: click.Context, account_id: str) -> None:
+    """계좌 거래 정지."""
+    fmt = get_formatter(ctx)
+    member_id = get_member_id(ctx)
+
+    async def _do_suspend() -> None:
+        svc, db = await _create_account_service()
+        try:
+            await svc.suspend(
+                account_id, reason="CLI 수동 정지", suspended_by=member_id
+            )
+        finally:
+            await db.close()
+
+    try:
+        _run(_do_suspend())
+    except Exception as e:
+        fmt.error(str(e))
+        raise SystemExit(1) from e
+
+    fmt.success(f'계좌 "{account_id}" 정지 완료')
+
+
+# ── activate ──────────────────────────────────────
+
+
+@account.command("activate")
+@click.argument("account_id")
+@click.pass_context
+@require_auth
+@require_scope("account:write")
+def account_activate(ctx: click.Context, account_id: str) -> None:
+    """계좌 활성화."""
+    fmt = get_formatter(ctx)
+    member_id = get_member_id(ctx)
+
+    async def _do_activate() -> None:
+        svc, db = await _create_account_service()
+        try:
+            await svc.activate(account_id, activated_by=member_id)
+        finally:
+            await db.close()
+
+    try:
+        _run(_do_activate())
+    except Exception as e:
+        fmt.error(str(e))
+        raise SystemExit(1) from e
+
+    fmt.success(f'계좌 "{account_id}" 활성화 완료')
+
+
+# ── delete ──────────────────────────────────────
+
+
+@account.command("delete")
+@click.argument("account_id")
+@click.pass_context
+@require_auth
+@require_scope("account:write")
+def account_delete(ctx: click.Context, account_id: str) -> None:
+    """계좌 삭제 (소프트 딜리트)."""
+    fmt = get_formatter(ctx)
+    member_id = get_member_id(ctx)
+
+    async def _do_delete() -> None:
+        svc, db = await _create_account_service()
+        try:
+            await svc.delete(account_id, deleted_by=member_id)
+        finally:
+            await db.close()
+
+    try:
+        _run(_do_delete())
+    except Exception as e:
+        fmt.error(str(e))
+        raise SystemExit(1) from e
+
+    fmt.success(f'계좌 "{account_id}" 삭제 완료')
+
+
+# ── credentials ──────────────────────────────────────
+
+
+@account.command("credentials")
+@click.argument("account_id")
+@click.pass_context
+@require_auth
+@require_scope("account:read")
+def account_credentials(ctx: click.Context, account_id: str) -> None:
+    """인증 정보 조회 (마스킹)."""
+    fmt = get_formatter(ctx)
+
+    async def _do_credentials() -> dict[str, str]:
+        svc, db = await _create_account_service()
+        try:
+            acct = await svc.get(account_id)
+            return {k: mask_value(k, v) for k, v in acct.credentials.items()}
+        finally:
+            await db.close()
+
+    try:
+        masked = _run(_do_credentials())
+    except Exception as e:
+        fmt.error(str(e))
+        raise SystemExit(1) from e
+
+    if not masked:
+        fmt.output({"message": "등록된 인증 정보가 없습니다.", "credentials": {}})
+        return
+
+    if fmt.is_json:
+        fmt.output({"account_id": account_id, "credentials": masked})
+    else:
+        click.echo(f"\n인증 정보 ({account_id})")
+        click.echo("-" * 35)
+        for key, value in masked.items():
+            click.echo(f"  {key.upper():14s}: {value}")
+
+
+# ── set-credentials ──────────────────────────────────────
+
+
+@account.command("set-credentials")
+@click.argument("account_id")
+@click.pass_context
+@require_auth
+@require_scope("account:write")
+def account_set_credentials(ctx: click.Context, account_id: str) -> None:
+    """인증 정보 재설정 (대화형)."""
+    fmt = get_formatter(ctx)
+
+    from ante.account.presets import BROKER_PRESETS
+
+    async def _do_set_credentials() -> None:
+        svc, db = await _create_account_service()
+        try:
+            acct = await svc.get(account_id)
+            preset = BROKER_PRESETS.get(acct.broker_type)
+            if not preset or not preset.required_credentials:
+                msg = f"브로커 '{acct.broker_type}'에는 인증 정보가 필요하지 않습니다."
+                fmt.output({"message": msg})
+                return
+
+            new_credentials: dict[str, str] = {}
+            click.echo(f"\n인증 정보 재설정 ({account_id})")
+            for cred_key in preset.required_credentials:
+                hide = cred_key.lower() in ("app_secret", "secret", "password")
+                value = click.prompt(cred_key.upper(), hide_input=hide)
+                new_credentials[cred_key] = value
+
+            await svc.update(account_id, credentials=new_credentials)
+            fmt.success(f'계좌 "{account_id}" 인증 정보 재설정 완료')
+        finally:
+            await db.close()
+
+    try:
+        _run(_do_set_credentials())
+    except Exception as e:
+        fmt.error(str(e))
+        raise SystemExit(1) from e
+
+
+# ── 유틸리티 ──────────────────────────────────────
+
+
+def _account_to_row(acct: Account) -> dict:
+    """Account를 테이블 행 dict로 변환."""
+    return {
+        "account_id": acct.account_id,
+        "name": acct.name,
+        "exchange": acct.exchange,
+        "currency": acct.currency,
+        "broker_type": acct.broker_type,
+        "status": acct.status.value,
+    }
+
+
+def _account_to_detail(acct: Account) -> dict:
+    """Account를 상세 dict로 변환."""
+    return {
+        "account_id": acct.account_id,
+        "name": acct.name,
+        "exchange": acct.exchange,
+        "currency": acct.currency,
+        "broker_type": acct.broker_type,
+        "trading_mode": acct.trading_mode.value,
+        "buy_commission_rate": str(acct.buy_commission_rate),
+        "sell_commission_rate": str(acct.sell_commission_rate),
+        "status": acct.status.value,
+        "timezone": acct.timezone,
+        "trading_hours": f"{acct.trading_hours_start}-{acct.trading_hours_end}",
+        "created_at": str(acct.created_at) if acct.created_at else "",
+    }
+
+
+def _print_account_detail(detail: dict) -> None:
+    """텍스트 모드로 계좌 상세 출력."""
+    click.echo("\n계좌 정보")
+    click.echo("-" * 35)
+    labels = {
+        "account_id": "ID",
+        "name": "이름",
+        "exchange": "거래소",
+        "currency": "통화",
+        "broker_type": "브로커",
+        "trading_mode": "거래 모드",
+        "buy_commission_rate": "매수 수수료",
+        "sell_commission_rate": "매도 수수료",
+        "status": "상태",
+        "timezone": "시간대",
+        "trading_hours": "거래 시간",
+        "created_at": "생성일",
+    }
+    for key, label in labels.items():
+        value = detail.get(key, "")
+        if key in ("buy_commission_rate", "sell_commission_rate") and value:
+            # 퍼센트로 표시
+            try:
+                pct = float(value) * 100
+                value = f"{pct:.3f}%"
+            except ValueError:
+                pass
+        click.echo(f"  {label:14s}: {value}")

--- a/src/ante/cli/main.py
+++ b/src/ante/cli/main.py
@@ -44,6 +44,7 @@ def get_formatter(ctx: click.Context) -> OutputFormatter:
 
 
 # 서브커맨드 등록
+from ante.cli.commands.account import account  # noqa: E402
 from ante.cli.commands.approval import approval  # noqa: E402
 from ante.cli.commands.audit import audit  # noqa: E402
 from ante.cli.commands.backtest import backtest  # noqa: E402
@@ -64,6 +65,7 @@ from ante.cli.commands.trade import trade  # noqa: E402
 from ante.cli.commands.treasury import treasury  # noqa: E402
 from ante.feed.cli import feed  # noqa: E402
 
+cli.add_command(account)
 cli.add_command(audit)
 cli.add_command(approval)
 cli.add_command(init)

--- a/tests/unit/test_account_cli.py
+++ b/tests/unit/test_account_cli.py
@@ -1,0 +1,299 @@
+"""ante account CLI 명령어 테스트."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.commands.account import mask_value
+
+# ── mask_value 단위 테스트 ──────────────────────────────
+
+
+class TestMaskValue:
+    """mask_value 함수 테스트."""
+
+    def test_short_value_masked_fully(self) -> None:
+        """6자 이하는 '****'로 마스킹."""
+        assert mask_value("key", "abc") == "****"
+        assert mask_value("key", "123456") == "****"
+
+    def test_long_value_partial_mask(self) -> None:
+        """6자 초과는 앞 4자 + '****' + 뒤 2자."""
+        assert mask_value("key", "PSxxxxxxxx") == "PSxx****xx"
+        assert mask_value("key", "1234567") == "1234****67"
+
+    def test_exactly_seven_chars(self) -> None:
+        """7자(경계값) 테스트."""
+        assert mask_value("key", "abcdefg") == "abcd****fg"
+
+    def test_empty_value(self) -> None:
+        """빈 문자열은 6자 이하이므로 '****'."""
+        assert mask_value("key", "") == "****"
+
+
+# ── CLI 통합 테스트 헬퍼 ──────────────────────────────
+
+
+def _make_cli():
+    """테스트용 CLI 인스턴스를 생성한다 (인증 우회)."""
+    from ante.cli.main import cli
+
+    return cli
+
+
+def _invoke(args: list[str], input_text: str | None = None):
+    """CLI를 실행하고 결과를 반환한다."""
+    runner = CliRunner()
+    cli = _make_cli()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    result = runner.invoke(cli, args, env=env, input=input_text, catch_exceptions=False)
+    return result
+
+
+# ── Account 모듈 Mock ──────────────────────────────
+
+
+def _mock_account(
+    account_id: str = "test",
+    name: str = "테스트",
+    exchange: str = "TEST",
+    currency: str = "KRW",
+    broker_type: str = "test",
+    status: str = "active",
+    trading_mode: str = "virtual",
+    credentials: dict | None = None,
+):
+    """테스트용 Account mock 객체."""
+    from decimal import Decimal
+
+    from ante.account.models import Account, AccountStatus, TradingMode
+
+    return Account(
+        account_id=account_id,
+        name=name,
+        exchange=exchange,
+        currency=currency,
+        broker_type=broker_type,
+        status=AccountStatus(status),
+        trading_mode=TradingMode(trading_mode),
+        credentials=credentials or {},
+        buy_commission_rate=Decimal("0.00015"),
+        sell_commission_rate=Decimal("0.00195"),
+    )
+
+
+@pytest.fixture
+def mock_account_service():
+    """AccountService mock을 patch하는 fixture."""
+    svc = AsyncMock()
+    db = AsyncMock()
+
+    async def _create_service():
+        return svc, db
+
+    with patch(
+        "ante.cli.commands.account._create_account_service", new=_create_service
+    ):
+        yield svc
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    """인증을 우회한다."""
+    from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+    mock_member = Member(
+        member_id="tester",
+        name="테스터",
+        type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+        status=MemberStatus.ACTIVE,
+        scopes=[],
+    )
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": mock_member}),
+    ):
+        yield
+
+
+# ── account list 테스트 ──────────────────────────────
+
+
+class TestAccountList:
+    """ante account list 테스트."""
+
+    def test_list_empty(self, mock_account_service: AsyncMock) -> None:
+        """계좌가 없으면 빈 목록 메시지."""
+        mock_account_service.list.return_value = []
+        result = _invoke(["account", "list"])
+        assert result.exit_code == 0
+        assert "등록된 계좌가 없습니다" in result.output
+
+    def test_list_text_format(self, mock_account_service: AsyncMock) -> None:
+        """텍스트 모드로 계좌 목록 출력."""
+        mock_account_service.list.return_value = [
+            _mock_account("test", "테스트", "TEST", "KRW", "test"),
+            _mock_account("domestic", "국내 주식", "KRX", "KRW", "kis-domestic"),
+        ]
+        result = _invoke(["account", "list"])
+        assert result.exit_code == 0
+        assert "test" in result.output
+        assert "domestic" in result.output
+
+    def test_list_json_format(self, mock_account_service: AsyncMock) -> None:
+        """JSON 모드로 계좌 목록 출력."""
+        mock_account_service.list.return_value = [
+            _mock_account("test", "테스트", "TEST", "KRW", "test"),
+        ]
+        result = _invoke(["--format", "json", "account", "list"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "accounts" in data
+        assert len(data["accounts"]) == 1
+        assert data["accounts"][0]["account_id"] == "test"
+
+    def test_list_with_status_filter(self, mock_account_service: AsyncMock) -> None:
+        """--status 필터로 목록 조회."""
+        mock_account_service.list.return_value = [
+            _mock_account("test", "테스트", status="suspended"),
+        ]
+        result = _invoke(["account", "list", "--status", "suspended"])
+        assert result.exit_code == 0
+
+
+# ── account info 테스트 ──────────────────────────────
+
+
+class TestAccountInfo:
+    """ante account info 테스트."""
+
+    def test_info_text_format(self, mock_account_service: AsyncMock) -> None:
+        """텍스트 모드로 계좌 상세 출력."""
+        mock_account_service.get.return_value = _mock_account(
+            "domestic", "국내 주식", "KRX", "KRW", "kis-domestic"
+        )
+        result = _invoke(["account", "info", "domestic"])
+        assert result.exit_code == 0
+        assert "국내 주식" in result.output
+        assert "KRX" in result.output
+
+    def test_info_json_format(self, mock_account_service: AsyncMock) -> None:
+        """JSON 모드로 계좌 상세 출력."""
+        mock_account_service.get.return_value = _mock_account(
+            "domestic", "국내 주식", "KRX", "KRW", "kis-domestic"
+        )
+        result = _invoke(["--format", "json", "account", "info", "domestic"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["account_id"] == "domestic"
+        assert data["exchange"] == "KRX"
+
+    def test_info_not_found(self, mock_account_service: AsyncMock) -> None:
+        """존재하지 않는 계좌 조회."""
+        from ante.account.errors import AccountNotFoundError
+
+        mock_account_service.get.side_effect = AccountNotFoundError("not found")
+        result = _invoke(["account", "info", "nope"])
+        assert result.exit_code == 1
+
+
+# ── account credentials 마스킹 테스트 ──────────────────
+
+
+class TestAccountCredentials:
+    """ante account credentials 테스트."""
+
+    def test_credentials_masking(self, mock_account_service: AsyncMock) -> None:
+        """인증 정보가 마스킹되어 출력된다."""
+        mock_account_service.get.return_value = _mock_account(
+            "domestic",
+            credentials={
+                "app_key": "PSxxxxxxxx",
+                "app_secret": "abcdefghij1234567890abcdefghij12",
+                "account_no": "50123456-01",
+            },
+        )
+        result = _invoke(["account", "credentials", "domestic"])
+        assert result.exit_code == 0
+        assert "PSxx****xx" in result.output
+        assert "abcd****12" in result.output
+        assert "5012****01" in result.output
+
+    def test_credentials_json_format(self, mock_account_service: AsyncMock) -> None:
+        """JSON 모드로 마스킹된 인증 정보 출력."""
+        mock_account_service.get.return_value = _mock_account(
+            "domestic",
+            credentials={"app_key": "PSxxxxxxxx"},
+        )
+        result = _invoke(["--format", "json", "account", "credentials", "domestic"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["credentials"]["app_key"] == "PSxx****xx"
+
+    def test_credentials_empty(self, mock_account_service: AsyncMock) -> None:
+        """인증 정보가 없는 계좌."""
+        mock_account_service.get.return_value = _mock_account("test", credentials={})
+        result = _invoke(["account", "credentials", "test"])
+        assert result.exit_code == 0
+        assert "등록된 인증 정보가 없습니다" in result.output
+
+
+# ── account create 대화형 테스트 ──────────────────
+
+
+class TestAccountCreate:
+    """ante account create 테스트."""
+
+    def test_create_excludes_overseas(self) -> None:
+        """_get_selectable_broker_types가 kis-overseas를 제외한다."""
+        from ante.cli.commands.account import _get_selectable_broker_types
+
+        selectable = _get_selectable_broker_types()
+        assert "kis-overseas" not in selectable
+        assert "test" in selectable
+        assert "kis-domestic" in selectable
+
+    def test_create_interactive(self, mock_account_service: AsyncMock) -> None:
+        """대화형 생성 흐름이 정상 동작한다."""
+        created = _mock_account("test", "테스트", "TEST", "KRW", "test")
+        mock_account_service.create.return_value = created
+
+        # 입력: 브로커 1(test), 계좌ID(기본), 이름(기본), 거래모드 1(virtual)
+        input_text = "1\n\n\n1\n"
+        result = _invoke(["account", "create"], input_text=input_text)
+        assert result.exit_code == 0
+        assert "생성 완료" in result.output
+        mock_account_service.create.assert_called_once()
+
+
+# ── account suspend/activate/delete 테스트 ──────────
+
+
+class TestAccountStateTransitions:
+    """계좌 상태 전이 커맨드 테스트."""
+
+    def test_suspend(self, mock_account_service: AsyncMock) -> None:
+        """계좌 정지."""
+        result = _invoke(["account", "suspend", "domestic"])
+        assert result.exit_code == 0
+        assert "정지 완료" in result.output
+        mock_account_service.suspend.assert_called_once()
+
+    def test_activate(self, mock_account_service: AsyncMock) -> None:
+        """계좌 활성화."""
+        result = _invoke(["account", "activate", "domestic"])
+        assert result.exit_code == 0
+        assert "활성화 완료" in result.output
+        mock_account_service.activate.assert_called_once()
+
+    def test_delete(self, mock_account_service: AsyncMock) -> None:
+        """계좌 삭제."""
+        result = _invoke(["account", "delete", "domestic"])
+        assert result.exit_code == 0
+        assert "삭제 완료" in result.output
+        mock_account_service.delete.assert_called_once()


### PR DESCRIPTION
## Summary

- `ante account` CLI 명령어 그룹 8종 구현 (create, list, info, suspend, activate, delete, credentials, set-credentials)
- `src/ante/cli/main.py`에 account 그룹 등록
- 대화형 create에서 `BROKER_REGISTRY` 미등록 브로커(kis-overseas) 자동 제외
- 인증 정보 마스킹 규칙 구현 (6자 이하: `****`, 초과: 앞4+`****`+뒤2)

## Test plan

- [x] mask_value 단위 테스트 (짧은/긴/경계값/빈 문자열)
- [x] account list (빈 목록, text/json 포맷, status 필터)
- [x] account info (text/json 포맷, 미존재 계좌 에러)
- [x] account credentials (마스킹 검증, json 포맷, 빈 인증정보)
- [x] account create (overseas 제외 검증, 대화형 흐름)
- [x] account suspend/activate/delete 상태 전이
- [x] 전체 기존 테스트 통과 확인

Refs #571

Generated with [Claude Code](https://claude.com/claude-code)