### PR TITLE
feat(web): Account CRUD REST API 엔드포인트

### DIFF
--- a/src/ante/web/app.py
+++ b/src/ante/web/app.py
@@ -55,6 +55,7 @@ def create_app(**services: Any) -> FastAPI:
     for name, service in services.items():
         setattr(app.state, name, service)
 
+    from ante.web.routes.accounts import router as accounts_router
     from ante.web.routes.approvals import router as approvals_router
     from ante.web.routes.audit import router as audit_router
     from ante.web.routes.auth import router as auth_router
@@ -70,6 +71,7 @@ def create_app(**services: Any) -> FastAPI:
     from ante.web.routes.trades import router as trades_router
     from ante.web.routes.treasury import router as treasury_router
 
+    app.include_router(accounts_router, prefix="/api/accounts", tags=["accounts"])
     app.include_router(auth_router, prefix="/api/auth", tags=["auth"])
     app.include_router(approvals_router, prefix="/api/approvals", tags=["approvals"])
     app.include_router(audit_router, prefix="/api/audit", tags=["audit"])

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -1,0 +1,335 @@
+"""Account REST API — 계좌 CRUD + 정지/활성화."""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from ante.web.deps import get_account_service, get_audit_logger_optional
+from ante.web.schemas import (
+    AccountActionResponse,
+    AccountCreateRequest,
+    AccountDetailResponse,
+    AccountListResponse,
+    AccountSuspendRequest,
+    AccountUpdateRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _account_to_response(account: Any) -> dict[str, Any]:
+    """Account 객체를 AccountResponse 호환 dict로 변환.
+
+    credentials는 보안상 응답에 포함하지 않는다.
+    """
+    return {
+        "account_id": account.account_id,
+        "name": account.name,
+        "exchange": account.exchange,
+        "currency": account.currency,
+        "timezone": account.timezone,
+        "trading_hours_start": account.trading_hours_start,
+        "trading_hours_end": account.trading_hours_end,
+        "trading_mode": (
+            account.trading_mode.value
+            if hasattr(account.trading_mode, "value")
+            else str(account.trading_mode)
+        ),
+        "broker_type": account.broker_type,
+        "buy_commission_rate": float(account.buy_commission_rate),
+        "sell_commission_rate": float(account.sell_commission_rate),
+        "status": (
+            account.status.value
+            if hasattr(account.status, "value")
+            else str(account.status)
+        ),
+        "created_at": (account.created_at.isoformat() if account.created_at else ""),
+        "updated_at": (account.updated_at.isoformat() if account.updated_at else ""),
+    }
+
+
+@router.get("", response_model=AccountListResponse)
+async def list_accounts(
+    account_service: Annotated[Any, Depends(get_account_service)],
+    status: str | None = None,
+) -> dict[str, Any]:
+    """계좌 목록 조회."""
+    from ante.account.models import AccountStatus
+
+    filter_status: AccountStatus | None = None
+    if status is not None:
+        try:
+            filter_status = AccountStatus(status)
+        except ValueError:
+            raise HTTPException(
+                status_code=400,
+                detail=f"유효하지 않은 status 값: '{status}'. "
+                f"가능한 값: {[s.value for s in AccountStatus]}",
+            )
+
+    accounts = await account_service.list(status=filter_status)
+    return {"accounts": [_account_to_response(a) for a in accounts]}
+
+
+@router.post("", response_model=AccountDetailResponse, status_code=201)
+async def create_account(
+    body: AccountCreateRequest,
+    request: Request,
+    account_service: Annotated[Any, Depends(get_account_service)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
+) -> dict[str, Any]:
+    """계좌 생성."""
+    from ante.account.errors import (
+        AccountAlreadyExistsError,
+        InvalidBrokerTypeError,
+    )
+    from ante.account.models import Account, TradingMode
+    from ante.account.presets import BROKER_PRESETS
+
+    # broker_type에서 프리셋 기본값 적용
+    preset = BROKER_PRESETS.get(body.broker_type)
+
+    try:
+        trading_mode = TradingMode(body.trading_mode)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=f"유효하지 않은 trading_mode: '{body.trading_mode}'",
+        )
+
+    from decimal import Decimal
+
+    account = Account(
+        account_id=body.account_id,
+        name=body.name,
+        exchange=body.exchange or (preset.exchange if preset else ""),
+        currency=body.currency or (preset.currency if preset else ""),
+        timezone=body.timezone or (preset.timezone if preset else "Asia/Seoul"),
+        trading_hours_start=body.trading_hours_start
+        or (preset.trading_hours_start if preset else "09:00"),
+        trading_hours_end=body.trading_hours_end
+        or (preset.trading_hours_end if preset else "15:30"),
+        trading_mode=trading_mode,
+        broker_type=body.broker_type,
+        credentials=body.credentials,
+        buy_commission_rate=Decimal(str(body.buy_commission_rate))
+        if body.buy_commission_rate
+        else (preset.buy_commission_rate if preset else Decimal("0")),
+        sell_commission_rate=Decimal(str(body.sell_commission_rate))
+        if body.sell_commission_rate
+        else (preset.sell_commission_rate if preset else Decimal("0")),
+    )
+
+    try:
+        created = await account_service.create(account)
+    except InvalidBrokerTypeError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except AccountAlreadyExistsError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+
+    # 브로커 어댑터 인스턴스 생성 가능 여부 검증
+    # kis-overseas 등 BROKER_REGISTRY에 미등록된 타입은 생성 직후 롤백
+    try:
+        await account_service.get_broker(created.account_id)
+    except InvalidBrokerTypeError as e:
+        await account_service.delete(created.account_id, deleted_by="system")
+        raise HTTPException(status_code=400, detail=str(e))
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "dashboard"),
+            action="account.create",
+            resource=f"account:{created.account_id}",
+            detail=f"계좌 생성: {created.account_id} ({created.broker_type})",
+            ip=request.client.host if request.client else "",
+        )
+
+    return {"account": _account_to_response(created)}
+
+
+@router.get("/{account_id}", response_model=AccountDetailResponse)
+async def get_account(
+    account_id: str,
+    account_service: Annotated[Any, Depends(get_account_service)],
+) -> dict[str, Any]:
+    """계좌 상세 조회."""
+    from ante.account.errors import AccountNotFoundError
+
+    try:
+        account = await account_service.get(account_id)
+    except AccountNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    return {"account": _account_to_response(account)}
+
+
+@router.put("/{account_id}", response_model=AccountDetailResponse)
+async def update_account(
+    account_id: str,
+    body: AccountUpdateRequest,
+    request: Request,
+    account_service: Annotated[Any, Depends(get_account_service)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
+) -> dict[str, Any]:
+    """계좌 수정."""
+    from ante.account.errors import AccountDeletedError, AccountNotFoundError
+
+    # None이 아닌 필드만 업데이트 대상
+    fields: dict[str, Any] = {}
+    for field_name in (
+        "name",
+        "exchange",
+        "currency",
+        "timezone",
+        "trading_hours_start",
+        "trading_hours_end",
+        "trading_mode",
+        "broker_type",
+        "credentials",
+        "buy_commission_rate",
+        "sell_commission_rate",
+    ):
+        value = getattr(body, field_name, None)
+        if value is not None:
+            if field_name in ("buy_commission_rate", "sell_commission_rate"):
+                from decimal import Decimal
+
+                value = Decimal(str(value))
+            elif field_name == "trading_mode":
+                from ante.account.models import TradingMode
+
+                try:
+                    value = TradingMode(value)
+                except ValueError:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"유효하지 않은 trading_mode: '{value}'",
+                    )
+            fields[field_name] = value
+
+    if not fields:
+        raise HTTPException(status_code=400, detail="수정할 필드가 없습니다.")
+
+    try:
+        updated = await account_service.update(account_id, **fields)
+    except AccountNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except AccountDeletedError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "dashboard"),
+            action="account.update",
+            resource=f"account:{account_id}",
+            detail=f"계좌 수정: {list(fields.keys())}",
+            ip=request.client.host if request.client else "",
+        )
+
+    return {"account": _account_to_response(updated)}
+
+
+@router.post("/{account_id}/suspend", response_model=AccountActionResponse)
+async def suspend_account(
+    account_id: str,
+    body: AccountSuspendRequest,
+    request: Request,
+    account_service: Annotated[Any, Depends(get_account_service)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
+) -> dict[str, Any]:
+    """계좌 정지."""
+    from ante.account.errors import AccountNotFoundError
+
+    reason = body.reason or "dashboard"
+    suspended_by = getattr(request.state, "member_id", "dashboard")
+
+    try:
+        await account_service.suspend(
+            account_id, reason=reason, suspended_by=suspended_by
+        )
+    except AccountNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    account = await account_service.get(account_id)
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=suspended_by,
+            action="account.suspend",
+            resource=f"account:{account_id}",
+            detail=f"계좌 정지: {reason}",
+            ip=request.client.host if request.client else "",
+        )
+
+    return {
+        "account": _account_to_response(account),
+        "message": f"계좌 '{account_id}'가 정지되었습니다.",
+    }
+
+
+@router.post("/{account_id}/activate", response_model=AccountActionResponse)
+async def activate_account(
+    account_id: str,
+    request: Request,
+    account_service: Annotated[Any, Depends(get_account_service)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
+) -> dict[str, Any]:
+    """계좌 재활성화."""
+    from ante.account.errors import AccountDeletedError, AccountNotFoundError
+
+    activated_by = getattr(request.state, "member_id", "dashboard")
+
+    try:
+        await account_service.activate(account_id, activated_by=activated_by)
+    except AccountNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except AccountDeletedError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    account = await account_service.get(account_id)
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=activated_by,
+            action="account.activate",
+            resource=f"account:{account_id}",
+            detail="계좌 활성화",
+            ip=request.client.host if request.client else "",
+        )
+
+    return {
+        "account": _account_to_response(account),
+        "message": f"계좌 '{account_id}'가 활성화되었습니다.",
+    }
+
+
+@router.delete("/{account_id}", status_code=204)
+async def delete_account(
+    account_id: str,
+    request: Request,
+    account_service: Annotated[Any, Depends(get_account_service)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
+) -> None:
+    """계좌 소프트 딜리트."""
+    from ante.account.errors import AccountNotFoundError
+
+    deleted_by = getattr(request.state, "member_id", "dashboard")
+
+    try:
+        await account_service.delete(account_id, deleted_by=deleted_by)
+    except AccountNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=deleted_by,
+            action="account.delete",
+            resource=f"account:{account_id}",
+            detail="계좌 삭제",
+            ip=request.client.host if request.client else "",
+        )

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -17,6 +17,86 @@ class ErrorResponse(BaseModel):
     instance: str = ""
 
 
+# ── 계좌 ──────────────────────────────────────────────
+
+
+class AccountResponse(BaseModel):
+    """계좌 응답. credentials는 보안상 포함하지 않는다."""
+
+    account_id: str
+    name: str
+    exchange: str
+    currency: str
+    timezone: str
+    trading_hours_start: str
+    trading_hours_end: str
+    trading_mode: str
+    broker_type: str
+    buy_commission_rate: float
+    sell_commission_rate: float
+    status: str
+    created_at: str
+    updated_at: str
+
+
+class AccountListResponse(BaseModel):
+    """계좌 목록 응답."""
+
+    accounts: list[AccountResponse]
+
+
+class AccountDetailResponse(BaseModel):
+    """계좌 상세 응답."""
+
+    account: AccountResponse
+
+
+class AccountCreateRequest(BaseModel):
+    """계좌 생성 요청."""
+
+    account_id: str
+    name: str
+    exchange: str = ""
+    currency: str = ""
+    timezone: str = ""
+    trading_hours_start: str = ""
+    trading_hours_end: str = ""
+    trading_mode: str = "virtual"
+    broker_type: str = "test"
+    credentials: dict[str, str] = {}
+    buy_commission_rate: float = 0.0
+    sell_commission_rate: float = 0.0
+
+
+class AccountUpdateRequest(BaseModel):
+    """계좌 수정 요청."""
+
+    name: str | None = None
+    exchange: str | None = None
+    currency: str | None = None
+    timezone: str | None = None
+    trading_hours_start: str | None = None
+    trading_hours_end: str | None = None
+    trading_mode: str | None = None
+    broker_type: str | None = None
+    credentials: dict[str, str] | None = None
+    buy_commission_rate: float | None = None
+    sell_commission_rate: float | None = None
+
+
+class AccountSuspendRequest(BaseModel):
+    """계좌 정지 요청."""
+
+    reason: str = ""
+
+
+class AccountActionResponse(BaseModel):
+    """계좌 상태 변경 응답."""
+
+    account: AccountResponse
+    message: str
+
+
 # ── 시스템 ──────────────────────────────────────────────
 
 

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -1,0 +1,430 @@
+"""Account REST API 단위 테스트."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.account.errors import (  # noqa: E402
+    AccountDeletedError,
+    AccountNotFoundError,
+    InvalidBrokerTypeError,
+)
+from ante.account.models import Account, AccountStatus, TradingMode  # noqa: E402
+from ante.web.app import create_app  # noqa: E402
+
+
+class FakeAccountService:
+    """테스트용 AccountService 모의 객체."""
+
+    def __init__(self) -> None:
+        self._accounts: dict[str, Account] = {}
+        self._audit_logs: list[dict[str, Any]] = []
+        self._deleted: set[str] = set()
+
+    async def create(self, account: Account) -> Account:
+        if account.account_id in self._accounts:
+            from ante.account.errors import AccountAlreadyExistsError
+
+            raise AccountAlreadyExistsError(
+                f"계좌 '{account.account_id}'가 이미 존재합니다."
+            )
+        from ante.account.presets import BROKER_PRESETS
+
+        if account.broker_type not in BROKER_PRESETS:
+            raise InvalidBrokerTypeError(
+                f"유효하지 않은 broker_type: '{account.broker_type}'"
+            )
+        now = datetime.now(UTC)
+        account.created_at = now
+        account.updated_at = now
+        self._accounts[account.account_id] = account
+        return account
+
+    async def get(self, account_id: str) -> Account:
+        if account_id not in self._accounts:
+            raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
+        return self._accounts[account_id]
+
+    async def list(self, status: AccountStatus | None = None) -> list[Account]:
+        accounts = list(self._accounts.values())
+        if status is not None:
+            accounts = [a for a in accounts if a.status == status]
+        return accounts
+
+    async def update(self, account_id: str, **fields: Any) -> Account:
+        if account_id not in self._accounts:
+            raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
+        account = self._accounts[account_id]
+        if account.status == AccountStatus.DELETED:
+            raise AccountDeletedError(
+                f"삭제된 계좌 '{account_id}'는 수정할 수 없습니다."
+            )
+        for key, value in fields.items():
+            setattr(account, key, value)
+        account.updated_at = datetime.now(UTC)
+        return account
+
+    async def suspend(self, account_id: str, reason: str, suspended_by: str) -> None:
+        if account_id not in self._accounts:
+            raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
+        self._accounts[account_id].status = AccountStatus.SUSPENDED
+
+    async def activate(self, account_id: str, activated_by: str) -> None:
+        if account_id not in self._accounts:
+            raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
+        account = self._accounts[account_id]
+        if account.status == AccountStatus.DELETED:
+            raise AccountDeletedError(
+                f"삭제된 계좌 '{account_id}'는 활성화할 수 없습니다."
+            )
+        account.status = AccountStatus.ACTIVE
+
+    async def delete(self, account_id: str, deleted_by: str) -> None:
+        if account_id not in self._accounts:
+            raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
+        self._accounts[account_id].status = AccountStatus.DELETED
+        self._deleted.add(account_id)
+        del self._accounts[account_id]
+
+    async def get_broker(self, account_id: str) -> Any:
+        """브로커 인스턴스 반환 모의. kis-overseas는 미등록."""
+        account = await self.get(account_id)
+        # test, kis-domestic만 등록됨
+        if account.broker_type not in ("test", "kis-domestic"):
+            raise InvalidBrokerTypeError(
+                f"broker_type '{account.broker_type}'은 BROKER_REGISTRY에 "
+                f"등록되지 않았습니다."
+            )
+        return object()  # 더미 브로커
+
+
+class FakeAuditLogger:
+    """테스트용 감사 로거."""
+
+    def __init__(self) -> None:
+        self.logs: list[dict[str, Any]] = []
+
+    async def log(self, **kwargs: Any) -> None:
+        self.logs.append(kwargs)
+
+
+@pytest.fixture
+def account_service() -> FakeAccountService:
+    return FakeAccountService()
+
+
+@pytest.fixture
+def audit_logger() -> FakeAuditLogger:
+    return FakeAuditLogger()
+
+
+@pytest.fixture
+def app(account_service: FakeAccountService, audit_logger: FakeAuditLogger):
+    return create_app(
+        account_service=account_service,
+        audit_logger=audit_logger,
+    )
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app)
+
+
+def _make_account(
+    account_id: str = "test-account",
+    broker_type: str = "test",
+) -> Account:
+    """테스트용 Account 생성 헬퍼."""
+    return Account(
+        account_id=account_id,
+        name="테스트 계좌",
+        exchange="TEST",
+        currency="KRW",
+        timezone="Asia/Seoul",
+        trading_hours_start="00:00",
+        trading_hours_end="23:59",
+        trading_mode=TradingMode.VIRTUAL,
+        broker_type=broker_type,
+        credentials={"secret_key": "hidden"},
+        buy_commission_rate=Decimal("0"),
+        sell_commission_rate=Decimal("0"),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+class TestListAccounts:
+    """GET /api/accounts."""
+
+    def test_empty_list(self, client: TestClient) -> None:
+        resp = client.get("/api/accounts")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["accounts"] == []
+
+    def test_list_with_accounts(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.get("/api/accounts")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["accounts"]) == 1
+        assert data["accounts"][0]["account_id"] == "test-account"
+
+    def test_list_filter_by_status(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        a1 = _make_account("a1")
+        a2 = _make_account("a2")
+        a2.status = AccountStatus.SUSPENDED
+        account_service._accounts["a1"] = a1
+        account_service._accounts["a2"] = a2
+
+        resp = client.get("/api/accounts?status=active")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["accounts"]) == 1
+        assert data["accounts"][0]["account_id"] == "a1"
+
+    def test_list_invalid_status(self, client: TestClient) -> None:
+        resp = client.get("/api/accounts?status=invalid")
+        assert resp.status_code == 400
+
+
+class TestCreateAccount:
+    """POST /api/accounts."""
+
+    def test_create_success(
+        self,
+        client: TestClient,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        resp = client.post(
+            "/api/accounts",
+            json={
+                "account_id": "new-test",
+                "name": "새 테스트 계좌",
+                "broker_type": "test",
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["account"]["account_id"] == "new-test"
+        assert data["account"]["broker_type"] == "test"
+        # 감사 로그 확인
+        route_logs = [
+            log for log in audit_logger.logs if log["action"] == "account.create"
+        ]
+        assert len(route_logs) == 1
+
+    def test_create_duplicate(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        account = _make_account("existing")
+        account_service._accounts["existing"] = account
+
+        resp = client.post(
+            "/api/accounts",
+            json={
+                "account_id": "existing",
+                "name": "중복 계좌",
+                "broker_type": "test",
+            },
+        )
+        assert resp.status_code == 409
+
+    def test_create_overseas_account_rejected(self, client: TestClient) -> None:
+        """kis-overseas broker_type은 BROKER_REGISTRY에 미등록이므로 거부."""
+        resp = client.post(
+            "/api/accounts",
+            json={
+                "account_id": "us-stock",
+                "name": "미국 주식",
+                "broker_type": "kis-overseas",
+            },
+        )
+        assert resp.status_code == 400
+        data = resp.json()
+        assert "BROKER_REGISTRY" in data["detail"]
+
+
+class TestGetAccount:
+    """GET /api/accounts/:id."""
+
+    def test_get_success(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.get("/api/accounts/test-account")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["account"]["account_id"] == "test-account"
+
+    def test_get_not_found(self, client: TestClient) -> None:
+        resp = client.get("/api/accounts/nonexistent")
+        assert resp.status_code == 404
+
+    def test_account_no_credentials_in_response(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """응답에 credentials가 포함되지 않아야 한다."""
+        account = _make_account()
+        account.credentials = {"app_key": "secret123", "app_secret": "secret456"}
+        account_service._accounts[account.account_id] = account
+
+        resp = client.get("/api/accounts/test-account")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "credentials" not in data["account"]
+
+
+class TestUpdateAccount:
+    """PUT /api/accounts/:id."""
+
+    def test_update_success(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"name": "변경된 이름"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["account"]["name"] == "변경된 이름"
+        route_logs = [
+            log for log in audit_logger.logs if log["action"] == "account.update"
+        ]
+        assert len(route_logs) == 1
+
+    def test_update_not_found(self, client: TestClient) -> None:
+        resp = client.put(
+            "/api/accounts/nonexistent",
+            json={"name": "변경"},
+        )
+        assert resp.status_code == 404
+
+    def test_update_no_fields(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put("/api/accounts/test-account", json={})
+        assert resp.status_code == 400
+
+
+class TestSuspendAccount:
+    """POST /api/accounts/:id/suspend."""
+
+    def test_suspend_success(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.post(
+            "/api/accounts/test-account/suspend",
+            json={"reason": "테스트 정지"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["account"]["status"] == "suspended"
+        assert "정지" in data["message"]
+        route_logs = [
+            log for log in audit_logger.logs if log["action"] == "account.suspend"
+        ]
+        assert len(route_logs) == 1
+
+    def test_suspend_not_found(self, client: TestClient) -> None:
+        resp = client.post(
+            "/api/accounts/nonexistent/suspend",
+            json={"reason": "없는 계좌"},
+        )
+        assert resp.status_code == 404
+
+
+class TestActivateAccount:
+    """POST /api/accounts/:id/activate."""
+
+    def test_activate_success(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        account = _make_account()
+        account.status = AccountStatus.SUSPENDED
+        account_service._accounts[account.account_id] = account
+
+        resp = client.post("/api/accounts/test-account/activate")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["account"]["status"] == "active"
+        route_logs = [
+            log for log in audit_logger.logs if log["action"] == "account.activate"
+        ]
+        assert len(route_logs) == 1
+
+    def test_activate_not_found(self, client: TestClient) -> None:
+        resp = client.post("/api/accounts/nonexistent/activate")
+        assert resp.status_code == 404
+
+
+class TestDeleteAccount:
+    """DELETE /api/accounts/:id."""
+
+    def test_delete_success(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.delete("/api/accounts/test-account")
+        assert resp.status_code == 204
+        assert "test-account" not in account_service._accounts
+        route_logs = [
+            log for log in audit_logger.logs if log["action"] == "account.delete"
+        ]
+        assert len(route_logs) == 1
+
+    def test_delete_not_found(self, client: TestClient) -> None:
+        resp = client.delete("/api/accounts/nonexistent")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Refs #574

Account CRUD REST API 엔드포인트를 추가합니다.

### 변경 사항

- **`src/ante/web/routes/accounts.py`** (신규): Account REST API 라우터
  - `GET /api/accounts` — 계좌 목록 (status 필터)
  - `POST /api/accounts` — 계좌 생성 (프리셋 기본값 적용, kis-overseas 거부)
  - `GET /api/accounts/:id` — 계좌 상세
  - `PUT /api/accounts/:id` — 계좌 부분 수정
  - `POST /api/accounts/:id/suspend` — 계좌 정지
  - `POST /api/accounts/:id/activate` — 계좌 재활성화
  - `DELETE /api/accounts/:id` — 소프트 딜리트 (204)
- **`src/ante/web/schemas.py`**: Account 관련 Pydantic 스키마 추가 (AccountResponse, AccountListResponse, AccountCreateRequest 등)
- **`src/ante/web/app.py`**: accounts 라우터 등록
- **`tests/unit/test_account_api.py`** (신규): 19개 테스트

### 완료 기준 충족

- [x] Account CRUD 엔드포인트 동작
- [x] credentials가 API 응답에 노출되지 않음
- [x] kis-overseas 계좌 생성 시도 → 에러 (BROKER_REGISTRY 미등록)
- [x] 감사 로그 기록
- [x] 테스트 통과 (19/19)