### PR TITLE
feat(cli): 기존 CLI 명령어 account_id 연동 (#573)

### DIFF
--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -23,6 +23,7 @@ def _run(coro):  # noqa: ANN001, ANN202
 
 
 async def _create_services():  # noqa: ANN202
+    from ante.account.service import AccountService
     from ante.bot.manager import BotManager
     from ante.core.database import Database
     from ante.eventbus.bus import EventBus
@@ -30,9 +31,11 @@ async def _create_services():  # noqa: ANN202
     db = Database("db/ante.db")
     await db.connect()
     eventbus = EventBus()
+    account_service = AccountService(db=db, eventbus=eventbus)
+    await account_service.initialize()
     manager = BotManager(eventbus=eventbus, db=db)
     await manager.initialize()
-    return db, eventbus, manager
+    return db, eventbus, manager, account_service
 
 
 async def _audit_log(db, **kwargs) -> None:  # noqa: ANN001
@@ -48,20 +51,28 @@ async def _audit_log(db, **kwargs) -> None:  # noqa: ANN001
 
 
 @bot.command("list")
+@click.option("--account", "account_id", default=None, help="계좌 ID로 필터링")
 @click.pass_context
 @require_auth
 @require_scope("bot:read")
-def bot_list(ctx: click.Context) -> None:
+def bot_list(ctx: click.Context, account_id: str | None) -> None:
     """봇 목록 조회."""
     fmt = get_formatter(ctx)
 
     async def _run_list() -> list[dict]:
-        db, _, _ = await _create_services()
+        db, _, _, _ = await _create_services()
         try:
-            rows = await db.fetch_all(
-                "SELECT bot_id, name, strategy_id, account_id, status, created_at"
-                " FROM bots WHERE status != 'deleted'"
-            )
+            if account_id:
+                rows = await db.fetch_all(
+                    "SELECT bot_id, name, strategy_id, account_id, status, created_at"
+                    " FROM bots WHERE status != 'deleted' AND account_id = ?",
+                    (account_id,),
+                )
+            else:
+                rows = await db.fetch_all(
+                    "SELECT bot_id, name, strategy_id, account_id, status, created_at"
+                    " FROM bots WHERE status != 'deleted'"
+                )
             return [dict(r) for r in rows]
         finally:
             await db.close()
@@ -91,7 +102,7 @@ def bot_info(ctx: click.Context, bot_id: str) -> None:
     fmt = get_formatter(ctx)
 
     async def _run_info() -> dict | None:
-        db, _, _ = await _create_services()
+        db, _, _, _ = await _create_services()
         try:
             row = await db.fetch_one("SELECT * FROM bots WHERE bot_id = ?", (bot_id,))
             return dict(row) if row else None
@@ -130,14 +141,34 @@ def _parse_param(value: str) -> tuple[str, object]:
     return key.strip(), parsed
 
 
+def _select_account_interactive(accounts: list) -> str:
+    """활성 계좌 목록에서 대화형으로 계좌를 선택한다."""
+    if not accounts:
+        click.echo("활성 계좌가 없습니다. 먼저 계좌를 등록하세요.")
+        raise SystemExit(1)
+
+    if len(accounts) == 1:
+        selected = accounts[0]
+        msg = f"계좌 자동 선택: {selected.account_id}"
+        msg += f" ({selected.exchange} / {selected.currency})"
+        click.echo(msg)
+        return selected.account_id
+
+    click.echo("계좌를 선택하세요:")
+    for i, acc in enumerate(accounts, 1):
+        click.echo(f"  {i}) {acc.account_id} ({acc.exchange} / {acc.currency})")
+    choice = click.prompt("", type=click.IntRange(1, len(accounts)))
+    return accounts[choice - 1].account_id
+
+
 @bot.command("create")
 @click.option("--name", required=True, help="봇 이름")
 @click.option("--strategy", required=True, help="전략 ID")
 @click.option(
     "--account",
     "account_id",
-    default="test",
-    help="계좌 ID",
+    default=None,
+    help="계좌 ID (미지정 시 대화형 선택)",
 )
 @click.option(
     "--interval",
@@ -159,7 +190,7 @@ def bot_create(
     ctx: click.Context,
     name: str,
     strategy: str,
-    account_id: str,
+    account_id: str | None,
     interval: int,
     bot_id: str,
     params: tuple[str, ...],
@@ -178,18 +209,31 @@ def bot_create(
             fmt.error(str(e))
             return
 
+    # 계좌 미지정 시 대화형 선택
+    if account_id is None:
+        from ante.account.models import AccountStatus
+
+        async def _list_accounts() -> list:
+            _, _, _, account_service = await _create_services()
+            return await account_service.list(status=AccountStatus.ACTIVE)
+
+        accounts = _run(_list_accounts())
+        account_id = _select_account_interactive(accounts)
+
+    resolved_account_id = account_id
+
     async def _run_create() -> dict:
         import json
         from uuid import uuid4
 
-        db, _, _ = await _create_services()
+        db, _, _, _ = await _create_services()
         try:
             bid = bot_id or f"bot-{uuid4().hex[:8]}"
             config_dict: dict = {
                 "bot_id": bid,
                 "name": name,
                 "strategy_id": strategy,
-                "account_id": account_id,
+                "account_id": resolved_account_id,
                 "interval_seconds": interval,
             }
             if param_dict:
@@ -198,7 +242,7 @@ def bot_create(
                 """INSERT INTO bots
                    (bot_id, name, strategy_id, account_id, config_json)
                    VALUES (?, ?, ?, ?, ?)""",
-                (bid, name, strategy, account_id, json.dumps(config_dict)),
+                (bid, name, strategy, resolved_account_id, json.dumps(config_dict)),
             )
 
             await _audit_log(
@@ -206,7 +250,7 @@ def bot_create(
                 member_id=actor,
                 action="bot.create",
                 resource=f"bot:{bid}",
-                detail=f"strategy={strategy}",
+                detail=f"strategy={strategy}, account={resolved_account_id}",
             )
 
             return config_dict
@@ -234,7 +278,7 @@ def bot_remove(ctx: click.Context, bot_id: str) -> None:
     actor = get_member_id(ctx)
 
     async def _run_remove() -> bool:
-        db, _, _ = await _create_services()
+        db, _, _, _ = await _create_services()
         try:
             row = await db.fetch_one(
                 "SELECT bot_id FROM bots WHERE bot_id = ? AND status != 'deleted'",
@@ -279,7 +323,7 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
     async def _run_signal_key() -> dict:
         from ante.bot.signal_key import SignalKeyManager
 
-        db, _, _ = await _create_services()
+        db, _, _, _ = await _create_services()
         try:
             skm = SignalKeyManager(db)
             await skm.initialize()

--- a/src/ante/cli/commands/broker.py
+++ b/src/ante/cli/commands/broker.py
@@ -19,7 +19,31 @@ def _run(coro):  # noqa: ANN001, ANN202
     return asyncio.run(coro)
 
 
-async def _create_broker():  # noqa: ANN202
+async def _create_account_service():  # noqa: ANN202
+    from ante.account.service import AccountService
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+    db = Database("db/ante.db")
+    await db.connect()
+    eventbus = EventBus()
+    account_service = AccountService(db=db, eventbus=eventbus)
+    await account_service.initialize()
+    return account_service, db
+
+
+async def _get_broker(account_id: str | None = None):  # noqa: ANN202
+    """AccountService를 통해 브로커 어댑터를 획득한다.
+
+    account_id가 None이면 기존 Config 기반 폴백을 사용한다.
+    """
+    if account_id:
+        account_service, db = await _create_account_service()
+        adapter = await account_service.get_broker(account_id)
+        await adapter.connect()
+        return adapter, db
+
+    # 폴백: 기존 Config 기반 브로커 생성
     from ante.config.config import Config
 
     config = Config.load()
@@ -33,35 +57,40 @@ async def _create_broker():  # noqa: ANN202
 
         adapter = KISAdapter(broker_config)
         await adapter.connect()
-        return adapter
+        return adapter, None
     elif broker_type == "mock":
         from ante.broker.mock import MockBrokerAdapter
 
         adapter = MockBrokerAdapter(broker_config)
         await adapter.connect()
-        return adapter
+        return adapter, None
     else:
         msg = f"지원하지 않는 브로커: {broker_type}"
         raise ValueError(msg)
 
 
 @broker.command()
+@click.option("--account", "account_id", default=None, help="계좌 ID")
 @click.pass_context
 @require_auth
 @require_scope("broker:read")
-def status(ctx: click.Context) -> None:
+def status(ctx: click.Context, account_id: str | None) -> None:
     """증권사 연결 상태 조회."""
     fmt = get_formatter(ctx)
 
     async def _run_status() -> dict:
         try:
-            adapter = await _create_broker()
-            healthy = await adapter.health_check()
-            return {
-                "connected": adapter.is_connected,
-                "healthy": healthy,
-                "exchange": adapter.exchange,
-            }
+            adapter, db = await _get_broker(account_id)
+            try:
+                healthy = await adapter.health_check()
+                return {
+                    "connected": adapter.is_connected,
+                    "healthy": healthy,
+                    "exchange": adapter.exchange,
+                }
+            finally:
+                if db:
+                    await db.close()
         except Exception as e:
             return {
                 "connected": False,
@@ -85,19 +114,22 @@ def status(ctx: click.Context) -> None:
 
 
 @broker.command()
+@click.option("--account", "account_id", default=None, help="계좌 ID")
 @click.pass_context
 @require_auth
 @require_scope("broker:read")
-def balance(ctx: click.Context) -> None:
+def balance(ctx: click.Context, account_id: str | None) -> None:
     """증권사 계좌 잔고 조회."""
     fmt = get_formatter(ctx)
 
     async def _run_balance() -> dict:
-        adapter = await _create_broker()
+        adapter, db = await _get_broker(account_id)
         try:
             return await adapter.get_account_balance()
         finally:
             await adapter.disconnect()
+            if db:
+                await db.close()
 
     try:
         result = _run(_run_balance())
@@ -116,19 +148,22 @@ def balance(ctx: click.Context) -> None:
 
 
 @broker.command()
+@click.option("--account", "account_id", default=None, help="계좌 ID")
 @click.pass_context
 @require_auth
 @require_scope("broker:read")
-def positions(ctx: click.Context) -> None:
+def positions(ctx: click.Context, account_id: str | None) -> None:
     """증권사 보유 종목 조회."""
     fmt = get_formatter(ctx)
 
     async def _run_positions() -> list[dict]:
-        adapter = await _create_broker()
+        adapter, db = await _get_broker(account_id)
         try:
             return await adapter.get_positions()
         finally:
             await adapter.disconnect()
+            if db:
+                await db.close()
 
     try:
         result = _run(_run_positions())
@@ -148,13 +183,14 @@ def positions(ctx: click.Context) -> None:
 
 
 @broker.command()
+@click.option("--account", "account_id", default=None, help="계좌 ID")
 @click.option(
     "--fix", is_flag=True, default=False, help="불일치 발견 시 자동 보정 수행"
 )
 @click.pass_context
 @require_auth
 @require_scope("broker:read")
-def reconcile(ctx: click.Context, fix: bool) -> None:
+def reconcile(ctx: click.Context, account_id: str | None, fix: bool) -> None:
     """내부 데이터와 증권사 데이터 대사."""
     fmt = get_formatter(ctx)
 
@@ -167,9 +203,10 @@ def reconcile(ctx: click.Context, fix: bool) -> None:
         from ante.trade.recorder import TradeRecorder
         from ante.trade.service import TradeService
 
-        adapter = await _create_broker()
-        db = Database("db/ante.db")
-        await db.connect()
+        adapter, adapter_db = await _get_broker(account_id)
+        db = adapter_db or Database("db/ante.db")
+        if not adapter_db:
+            await db.connect()
         try:
             eventbus = EventBus()
             position_history = PositionHistory(db)

--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -19,7 +19,8 @@ def _run(coro):  # noqa: ANN001, ANN202
     return asyncio.run(coro)
 
 
-async def _create_treasury():  # noqa: ANN202
+async def _create_treasury(account_id: str | None = None):  # noqa: ANN202
+    from ante.account.service import AccountService
     from ante.core.database import Database
     from ante.eventbus.bus import EventBus
     from ante.treasury.treasury import Treasury
@@ -27,21 +28,37 @@ async def _create_treasury():  # noqa: ANN202
     db = Database("db/ante.db")
     await db.connect()
     eventbus = EventBus()
-    t = Treasury(db, eventbus)
+    account_service = AccountService(db=db, eventbus=eventbus)
+    await account_service.initialize()
+
+    if account_id:
+        account = await account_service.get(account_id)
+        t = Treasury(
+            db,
+            eventbus,
+            account_id=account.account_id,
+            currency=account.currency,
+            buy_commission_rate=float(account.buy_commission_rate),
+            sell_commission_rate=float(account.sell_commission_rate),
+        )
+    else:
+        t = Treasury(db, eventbus)
+
     await t.initialize()
     return t, db
 
 
 @treasury.command()
+@click.option("--account", "account_id", default=None, help="계좌 ID로 필터링")
 @click.pass_context
 @require_auth
 @require_scope("treasury:read")
-def status(ctx: click.Context) -> None:
+def status(ctx: click.Context, account_id: str | None) -> None:
     """자금 현황 요약."""
     fmt = get_formatter(ctx)
 
     async def _run_status() -> dict:
-        t, db = await _create_treasury()
+        t, db = await _create_treasury(account_id)
         try:
             return t.get_summary()
         finally:

--- a/tests/unit/test_bot_create_params.py
+++ b/tests/unit/test_bot_create_params.py
@@ -81,7 +81,7 @@ class TestBotCreateWithParams:
             mock_db = AsyncMock()
             mock_db.execute = AsyncMock()
             mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock(), MagicMock())
+            mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
 
             result = runner.invoke(
                 cli,
@@ -92,6 +92,8 @@ class TestBotCreateWithParams:
                     "테스트봇",
                     "--strategy",
                     "stg-1",
+                    "--account",
+                    "test",
                     "--param",
                     "lookback=20",
                     "--param",
@@ -119,11 +121,20 @@ class TestBotCreateWithParams:
             mock_db = AsyncMock()
             mock_db.execute = AsyncMock()
             mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock(), MagicMock())
+            mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
 
             result = runner.invoke(
                 cli,
-                ["bot", "create", "--name", "테스트봇", "--strategy", "stg-1"],
+                [
+                    "bot",
+                    "create",
+                    "--name",
+                    "테스트봇",
+                    "--strategy",
+                    "stg-1",
+                    "--account",
+                    "test",
+                ],
             )
             assert result.exit_code == 0
 
@@ -159,7 +170,7 @@ class TestBotCreateWithParams:
             mock_db = AsyncMock()
             mock_db.execute = AsyncMock()
             mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock(), MagicMock())
+            mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
 
             result = runner.invoke(
                 cli,
@@ -172,6 +183,8 @@ class TestBotCreateWithParams:
                     "테스트봇",
                     "--strategy",
                     "stg-1",
+                    "--account",
+                    "test",
                     "--param",
                     "window=30",
                 ],

--- a/tests/unit/test_cli_account_integration.py
+++ b/tests/unit/test_cli_account_integration.py
@@ -1,0 +1,500 @@
+"""CLI 명령어 account_id 연동 테스트 (#573)."""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.account.models import Account, AccountStatus, TradingMode
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+_MOCK_ACCOUNT_1 = Account(
+    account_id="domestic",
+    name="국내 주식",
+    exchange="KRX",
+    currency="KRW",
+    timezone="Asia/Seoul",
+    trading_mode=TradingMode.VIRTUAL,
+    broker_type="test",
+    buy_commission_rate=Decimal("0.00015"),
+    sell_commission_rate=Decimal("0.00195"),
+    status=AccountStatus.ACTIVE,
+)
+
+_MOCK_ACCOUNT_2 = Account(
+    account_id="overseas",
+    name="해외 주식",
+    exchange="NYSE",
+    currency="USD",
+    timezone="America/New_York",
+    trading_mode=TradingMode.VIRTUAL,
+    broker_type="test",
+    buy_commission_rate=Decimal("0"),
+    sell_commission_rate=Decimal("0"),
+    status=AccountStatus.ACTIVE,
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _make_mock_db(rows=None):
+    """모의 Database 객체 생성."""
+    db = AsyncMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    db.execute = AsyncMock()
+    db.execute_script = AsyncMock()
+    if rows is not None:
+        db.fetch_all = AsyncMock(return_value=rows)
+        db.fetch_one = AsyncMock(return_value=rows[0] if rows else None)
+    else:
+        db.fetch_all = AsyncMock(return_value=[])
+        db.fetch_one = AsyncMock(return_value=None)
+    return db
+
+
+def _make_mock_account_service(accounts=None):
+    """모의 AccountService 객체 생성."""
+    svc = AsyncMock()
+    svc.initialize = AsyncMock()
+    svc.list = AsyncMock(return_value=accounts or [])
+    svc.get = AsyncMock()
+    svc.suspend_all = AsyncMock(return_value=2)
+    svc.activate_all = AsyncMock(return_value=2)
+    return svc
+
+
+# ── bot list --account ──────────────────────────────────
+
+
+class TestBotListAccountFilter:
+    def test_bot_list_with_account_filter(self, runner):
+        """--account 옵션으로 특정 계좌의 봇만 필터링."""
+        bot_rows = [
+            {
+                "bot_id": "bot-1",
+                "name": "테스트봇",
+                "strategy_id": "s1",
+                "account_id": "domestic",
+                "status": "idle",
+                "created_at": "2026-01-01",
+            },
+        ]
+        mock_db = _make_mock_db(bot_rows)
+        mock_account_svc = _make_mock_account_service()
+
+        with patch("ante.cli.commands.bot._create_services") as mock_cs:
+            mock_cs.return_value = (
+                mock_db,
+                MagicMock(),
+                MagicMock(),
+                mock_account_svc,
+            )
+            result = runner.invoke(cli, ["bot", "list", "--account", "domestic"])
+
+        assert result.exit_code == 0
+        # fetch_all 호출 시 account_id 파라미터가 전달됨
+        call_args = mock_db.fetch_all.call_args
+        assert "domestic" in call_args[0][1]
+
+    def test_bot_list_without_account_filter(self, runner):
+        """--account 미지정 시 전체 봇 목록."""
+        mock_db = _make_mock_db([])
+        mock_account_svc = _make_mock_account_service()
+
+        with patch("ante.cli.commands.bot._create_services") as mock_cs:
+            mock_cs.return_value = (
+                mock_db,
+                MagicMock(),
+                MagicMock(),
+                mock_account_svc,
+            )
+            result = runner.invoke(cli, ["bot", "list"])
+
+        assert result.exit_code == 0
+        call_args = mock_db.fetch_all.call_args
+        # 파라미터 없이 호출
+        assert len(call_args[0]) == 1  # SQL만 전달
+
+    def test_bot_list_with_account_json(self, runner):
+        """JSON 모드에서 --account 필터."""
+        bot_rows = [
+            {
+                "bot_id": "bot-1",
+                "name": "테스트봇",
+                "strategy_id": "s1",
+                "account_id": "domestic",
+                "status": "idle",
+                "created_at": "2026-01-01",
+            },
+        ]
+        mock_db = _make_mock_db(bot_rows)
+        mock_account_svc = _make_mock_account_service()
+
+        with patch("ante.cli.commands.bot._create_services") as mock_cs:
+            mock_cs.return_value = (
+                mock_db,
+                MagicMock(),
+                MagicMock(),
+                mock_account_svc,
+            )
+            result = runner.invoke(
+                cli, ["--format", "json", "bot", "list", "--account", "domestic"]
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "bots" in data
+        assert data["bots"][0]["account_id"] == "domestic"
+
+
+# ── bot create --account (대화형 선택) ──────────────────
+
+
+class TestBotCreateAccountOption:
+    def test_bot_create_with_account_option(self, runner):
+        """--account 옵션으로 계좌 지정."""
+        mock_db = _make_mock_db()
+        mock_account_svc = _make_mock_account_service()
+
+        with patch("ante.cli.commands.bot._create_services") as mock_cs:
+            mock_cs.return_value = (
+                mock_db,
+                MagicMock(),
+                MagicMock(),
+                mock_account_svc,
+            )
+            result = runner.invoke(
+                cli,
+                [
+                    "bot",
+                    "create",
+                    "--name",
+                    "테스트봇",
+                    "--strategy",
+                    "s1",
+                    "--account",
+                    "domestic",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "봇 생성 완료" in result.output
+        # 첫 번째 execute 호출이 INSERT (audit_log 이전)
+        insert_call = mock_db.execute.call_args_list[0]
+        insert_args = insert_call[0][1]
+        assert insert_args[3] == "domestic"
+
+    def test_bot_create_interactive_single_account(self, runner):
+        """계좌 미지정 + 활성 계좌 1개 → 자동 선택."""
+        mock_db = _make_mock_db()
+        mock_account_svc = _make_mock_account_service([_MOCK_ACCOUNT_1])
+
+        with patch("ante.cli.commands.bot._create_services") as mock_cs:
+            mock_cs.return_value = (
+                mock_db,
+                MagicMock(),
+                MagicMock(),
+                mock_account_svc,
+            )
+            result = runner.invoke(
+                cli,
+                ["bot", "create", "--name", "테스트봇", "--strategy", "s1"],
+            )
+
+        assert result.exit_code == 0
+        assert "계좌 자동 선택" in result.output
+        assert "domestic" in result.output
+
+    def test_bot_create_interactive_multiple_accounts(self, runner):
+        """계좌 미지정 + 활성 계좌 여러 개 → 대화형 선택."""
+        mock_db = _make_mock_db()
+        mock_account_svc = _make_mock_account_service(
+            [_MOCK_ACCOUNT_1, _MOCK_ACCOUNT_2]
+        )
+
+        with patch("ante.cli.commands.bot._create_services") as mock_cs:
+            mock_cs.return_value = (
+                mock_db,
+                MagicMock(),
+                MagicMock(),
+                mock_account_svc,
+            )
+            result = runner.invoke(
+                cli,
+                ["bot", "create", "--name", "테스트봇", "--strategy", "s1"],
+                input="1\n",
+            )
+
+        assert result.exit_code == 0
+        assert "계좌를 선택하세요" in result.output
+        assert "domestic" in result.output
+        assert "overseas" in result.output
+
+    def test_bot_create_interactive_no_accounts(self, runner):
+        """계좌 미지정 + 활성 계좌 0개 → 에러."""
+        mock_account_svc = _make_mock_account_service([])
+
+        with patch("ante.cli.commands.bot._create_services") as mock_cs:
+            mock_cs.return_value = (
+                _make_mock_db(),
+                MagicMock(),
+                MagicMock(),
+                mock_account_svc,
+            )
+            result = runner.invoke(
+                cli,
+                ["bot", "create", "--name", "테스트봇", "--strategy", "s1"],
+            )
+
+        assert result.exit_code == 1
+        assert "활성 계좌가 없습니다" in result.output
+
+
+# ── system halt/activate ────────────────────────────────
+
+
+class TestSystemHaltActivate:
+    def test_system_halt_uses_account_service(self, runner):
+        """system halt가 AccountService.suspend_all() 호출."""
+        mock_account_svc = _make_mock_account_service()
+        mock_db = _make_mock_db()
+
+        with (
+            patch("ante.cli.commands.system._create_services") as mock_cs,
+            patch(
+                "ante.account.service.AccountService",
+                return_value=mock_account_svc,
+            ),
+        ):
+            mock_cs.return_value = (mock_db, MagicMock())
+            result = runner.invoke(cli, ["system", "halt"])
+
+        assert result.exit_code == 0
+        assert "HALTED" in result.output
+        mock_account_svc.suspend_all.assert_called_once()
+
+    def test_system_activate_uses_account_service(self, runner):
+        """system activate가 AccountService.activate_all() 호출."""
+        mock_account_svc = _make_mock_account_service()
+        mock_db = _make_mock_db()
+
+        with (
+            patch("ante.cli.commands.system._create_services") as mock_cs,
+            patch(
+                "ante.account.service.AccountService",
+                return_value=mock_account_svc,
+            ),
+        ):
+            mock_cs.return_value = (mock_db, MagicMock())
+            result = runner.invoke(cli, ["system", "activate"])
+
+        assert result.exit_code == 0
+        assert "ACTIVE" in result.output
+        mock_account_svc.activate_all.assert_called_once()
+
+
+# ── treasury status --account ───────────────────────────
+
+
+class TestTreasuryStatusAccount:
+    def test_treasury_status_with_account(self, runner):
+        """--account 옵션으로 계좌별 자금 현황 조회."""
+        mock_treasury = MagicMock()
+        mock_treasury.get_summary.return_value = {
+            "account_balance": 10000000,
+            "purchasable_amount": 8000000,
+            "total_evaluation": 12000000,
+            "total_profit_loss": 200000,
+            "total_allocated": 5000000,
+            "total_reserved": 1000000,
+            "unallocated": 3000000,
+            "bot_count": 2,
+        }
+        mock_treasury.initialize = AsyncMock()
+        mock_db = _make_mock_db()
+
+        with patch("ante.cli.commands.treasury._create_treasury") as mock_ct:
+            mock_ct.return_value = (mock_treasury, mock_db)
+            result = runner.invoke(cli, ["treasury", "status", "--account", "domestic"])
+
+        assert result.exit_code == 0
+        assert "10,000,000" in result.output
+        # _create_treasury가 account_id와 함께 호출됨
+        mock_ct.assert_called_once_with("domestic")
+
+    def test_treasury_status_without_account(self, runner):
+        """--account 미지정 시 기본 자금 현황."""
+        mock_treasury = MagicMock()
+        mock_treasury.get_summary.return_value = {
+            "account_balance": 10000000,
+            "purchasable_amount": 8000000,
+            "total_evaluation": 12000000,
+            "total_profit_loss": 200000,
+            "total_allocated": 5000000,
+            "total_reserved": 1000000,
+            "unallocated": 3000000,
+            "bot_count": 2,
+        }
+        mock_treasury.initialize = AsyncMock()
+        mock_db = _make_mock_db()
+
+        with patch("ante.cli.commands.treasury._create_treasury") as mock_ct:
+            mock_ct.return_value = (mock_treasury, mock_db)
+            result = runner.invoke(cli, ["treasury", "status"])
+
+        assert result.exit_code == 0
+        mock_ct.assert_called_once_with(None)
+
+    def test_treasury_status_with_account_json(self, runner):
+        """JSON 모드에서 --account 필터."""
+        mock_treasury = MagicMock()
+        mock_treasury.get_summary.return_value = {
+            "account_balance": 10000000,
+            "purchasable_amount": 8000000,
+            "total_evaluation": 12000000,
+            "total_profit_loss": 200000,
+            "total_allocated": 5000000,
+            "total_reserved": 1000000,
+            "unallocated": 3000000,
+            "bot_count": 2,
+        }
+        mock_treasury.initialize = AsyncMock()
+        mock_db = _make_mock_db()
+
+        with patch("ante.cli.commands.treasury._create_treasury") as mock_ct:
+            mock_ct.return_value = (mock_treasury, mock_db)
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "treasury", "status", "--account", "domestic"],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["account_balance"] == 10000000
+
+
+# ── broker balance/positions --account ──────────────────
+
+
+class TestBrokerAccountOption:
+    def test_broker_balance_with_account(self, runner):
+        """--account 옵션으로 계좌별 잔고 조회."""
+        mock_adapter = AsyncMock()
+        mock_adapter.get_account_balance = AsyncMock(
+            return_value={"cash": 5000000.0, "total": 8000000.0}
+        )
+        mock_adapter.disconnect = AsyncMock()
+        mock_db = _make_mock_db()
+
+        with patch("ante.cli.commands.broker._get_broker") as mock_gb:
+            mock_gb.return_value = (mock_adapter, mock_db)
+            result = runner.invoke(cli, ["broker", "balance", "--account", "domestic"])
+
+        assert result.exit_code == 0
+        mock_gb.assert_called_once_with("domestic")
+
+    def test_broker_balance_without_account(self, runner):
+        """--account 미지정 시 기존 Config 기반 폴백."""
+        mock_adapter = AsyncMock()
+        mock_adapter.get_account_balance = AsyncMock(return_value={"cash": 5000000.0})
+        mock_adapter.disconnect = AsyncMock()
+
+        with patch("ante.cli.commands.broker._get_broker") as mock_gb:
+            mock_gb.return_value = (mock_adapter, None)
+            result = runner.invoke(cli, ["broker", "balance"])
+
+        assert result.exit_code == 0
+        mock_gb.assert_called_once_with(None)
+
+    def test_broker_positions_with_account(self, runner):
+        """--account 옵션으로 계좌별 포지션 조회."""
+        mock_adapter = AsyncMock()
+        mock_adapter.get_positions = AsyncMock(
+            return_value=[
+                {
+                    "symbol": "005930",
+                    "quantity": 10,
+                    "avg_price": 70000.0,
+                    "eval_amount": 700000.0,
+                },
+            ]
+        )
+        mock_adapter.disconnect = AsyncMock()
+        mock_db = _make_mock_db()
+
+        with patch("ante.cli.commands.broker._get_broker") as mock_gb:
+            mock_gb.return_value = (mock_adapter, mock_db)
+            result = runner.invoke(
+                cli, ["broker", "positions", "--account", "domestic"]
+            )
+
+        assert result.exit_code == 0
+        mock_gb.assert_called_once_with("domestic")
+
+    def test_broker_positions_with_account_json(self, runner):
+        """JSON 모드에서 --account로 포지션 조회."""
+        mock_adapter = AsyncMock()
+        mock_adapter.get_positions = AsyncMock(
+            return_value=[
+                {
+                    "symbol": "005930",
+                    "quantity": 10,
+                    "avg_price": 70000.0,
+                    "eval_amount": 700000.0,
+                },
+            ]
+        )
+        mock_adapter.disconnect = AsyncMock()
+        mock_db = _make_mock_db()
+
+        with patch("ante.cli.commands.broker._get_broker") as mock_gb:
+            mock_gb.return_value = (mock_adapter, mock_db)
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "broker",
+                    "positions",
+                    "--account",
+                    "domestic",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data["positions"]) == 1
+        assert data["positions"][0]["symbol"] == "005930"

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -135,7 +135,7 @@ class TestBotCommands:
             mock_db = AsyncMock()
             mock_db.fetch_all = AsyncMock(return_value=[])
             mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock(), MagicMock())
+            mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
 
             result = runner.invoke(cli, ["bot", "list"])
             assert result.exit_code == 0
@@ -156,7 +156,7 @@ class TestBotCommands:
                 ]
             )
             mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock(), MagicMock())
+            mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
 
             result = runner.invoke(cli, ["--format", "json", "bot", "list"])
             assert result.exit_code == 0
@@ -169,7 +169,7 @@ class TestBotCommands:
             mock_db = AsyncMock()
             mock_db.fetch_one = AsyncMock(return_value=None)
             mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock(), MagicMock())
+            mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
 
             result = runner.invoke(cli, ["bot", "info", "nonexistent"])
             assert result.exit_code == 0
@@ -192,7 +192,7 @@ class TestBotCommands:
                 }
             )
             mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock(), MagicMock())
+            mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
 
             result = runner.invoke(cli, ["bot", "info", "bot-1"])
             assert result.exit_code == 0
@@ -203,7 +203,7 @@ class TestBotCommands:
             mock_db = AsyncMock()
             mock_db.execute = AsyncMock()
             mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock(), MagicMock())
+            mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
 
             result = runner.invoke(
                 cli,
@@ -394,19 +394,19 @@ class TestRuleCommands:
 
 class TestBrokerCommands:
     def test_broker_status_connected(self, runner):
-        with patch("ante.cli.commands.broker._create_broker") as mock_create:
+        with patch("ante.cli.commands.broker._get_broker") as mock_create:
             mock_adapter = AsyncMock()
             mock_adapter.is_connected = True
             mock_adapter.health_check = AsyncMock(return_value=True)
             mock_adapter.exchange = "KRX"
-            mock_create.return_value = mock_adapter
+            mock_create.return_value = (mock_adapter, None)
 
             result = runner.invoke(cli, ["broker", "status"])
             assert result.exit_code == 0
             assert "연결됨" in result.output
 
     def test_broker_status_error(self, runner):
-        with patch("ante.cli.commands.broker._create_broker") as mock_create:
+        with patch("ante.cli.commands.broker._get_broker") as mock_create:
             mock_create.side_effect = Exception("connection failed")
 
             result = runner.invoke(cli, ["broker", "status"])
@@ -414,13 +414,13 @@ class TestBrokerCommands:
             assert "미연결" in result.output
 
     def test_broker_balance(self, runner):
-        with patch("ante.cli.commands.broker._create_broker") as mock_create:
+        with patch("ante.cli.commands.broker._get_broker") as mock_create:
             mock_adapter = AsyncMock()
             mock_adapter.get_account_balance = AsyncMock(
                 return_value={"cash": 10000000.0, "total_assets": 15000000.0}
             )
             mock_adapter.disconnect = AsyncMock()
-            mock_create.return_value = mock_adapter
+            mock_create.return_value = (mock_adapter, None)
 
             result = runner.invoke(cli, ["--format", "json", "broker", "balance"])
             assert result.exit_code == 0
@@ -428,11 +428,11 @@ class TestBrokerCommands:
             assert data["cash"] == 10000000.0
 
     def test_broker_positions_empty(self, runner):
-        with patch("ante.cli.commands.broker._create_broker") as mock_create:
+        with patch("ante.cli.commands.broker._get_broker") as mock_create:
             mock_adapter = AsyncMock()
             mock_adapter.get_positions = AsyncMock(return_value=[])
             mock_adapter.disconnect = AsyncMock()
-            mock_create.return_value = mock_adapter
+            mock_create.return_value = (mock_adapter, None)
 
             result = runner.invoke(cli, ["broker", "positions"])
             assert result.exit_code == 0


### PR DESCRIPTION
## Summary

기존 CLI 명령어에 `--account` 옵션을 추가하여 Account 모델과 연동합니다.

Refs #573

## 변경 사항

### bot.py
- `bot list --account <id>`: 계좌별 봇 필터링
- `bot create --account <id>`: 미지정 시 대화형 계좌 선택 UI (활성 계좌 1개면 자동 선택)
- `_create_services()` 헬퍼에 AccountService 생성 추가

### treasury.py
- `treasury status --account <id>`: 계좌별 자금 현황 조회
- `_create_treasury()` 헬퍼가 account_id로 AccountService 연동

### broker.py
- `broker balance/positions/status/reconcile --account <id>`: AccountService로 브로커 획득
- `_get_broker()` 헬퍼 신규: account_id 지정 시 AccountService, 미지정 시 Config 폴백

### system.py
- 이미 #568에서 AccountService 기반으로 변경 완료 (추가 변경 없음)

### 테스트
- `test_cli_account_integration.py`: 16개 신규 테스트
- `test_cli_live.py`, `test_bot_create_params.py`: 4-tuple 반환값 호환성 수정

## Test plan
- [x] `bot list --account` 필터링 동작
- [x] `bot create` 대화형 계좌 선택 (단일/복수/미등록)
- [x] `treasury status --account` 필터링
- [x] `broker balance/positions --account` AccountService 연동
- [x] `system halt/activate` AccountService 사용 확인
- [x] 기존 테스트 2279개 전체 통과