### PR TITLE
refactor(cli): ante init 흐름에서 KIS 연동을 Account 등록으로 교체

### DIFF
--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -32,11 +32,6 @@ SECRETS_ENV_TEMPLATE = """\
 # Ante 비밀값 설정
 # 환경변수가 이 파일보다 우선합니다.
 
-# KIS 증권 API
-# KIS_APP_KEY=
-# KIS_APP_SECRET=
-# KIS_ACCOUNT_NO=
-
 # 텔레그램 알림 (선택)
 # TELEGRAM_BOT_TOKEN=
 # TELEGRAM_CHAT_ID=
@@ -79,47 +74,91 @@ def _write_secrets_env(config_path: Path, entries: dict[str, str]) -> None:
         secrets_env.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
 
 
-def _set_broker_test(config_path: Path) -> None:
-    """system.toml에 broker.type = 'test'를 추가한다."""
-    system_toml = config_path / _SYSTEM_TOML_FILENAME
-    content = system_toml.read_text()
-    if "[broker]" not in content:
-        content += '\n[broker]\ntype = "test"\n'
-        system_toml.write_text(content)
-
-
 def _prompt_master_account() -> tuple[str, str, str]:
     """Master 계정 정보를 대화형으로 입력받는다."""
-    click.echo("\n── 1. Master 계정 ──────────────────────────────")
+    click.echo("\n── [1/4] Master 계정 ───────────────────────────")
     member_id = click.prompt("Member ID")
     name = click.prompt("이름")
     password = click.prompt("패스워드", hide_input=True, confirmation_prompt=True)
     return member_id, name, password
 
 
-def _prompt_kis() -> dict[str, str] | None:
-    """KIS 연동 정보를 입력받는다. 스킵 시 None 반환."""
-    click.echo("\n── 2. 증권사 연동 (KIS) ────────────────────────")
-    click.echo("  건너뛰면 Test 증권사로 설정됩니다.")
-    click.echo("  나중에 secrets.env에서 변경할 수 있습니다.")
-    if not click.confirm("KIS 연동 정보를 입력하시겠습니까?", default=False):
-        return None
+def _get_available_brokers() -> list[tuple[str, str]]:
+    """등록 가능한 브로커 목록을 반환한다. kis-overseas 제외.
 
-    app_key = click.prompt("APP KEY")
-    app_secret = click.prompt("APP SECRET")
-    account_no = click.prompt("계좌번호 (예: 50123456-01)")
-    is_virtual = click.confirm("모의투자 여부", default=False)
-    return {
-        "KIS_APP_KEY": app_key,
-        "KIS_APP_SECRET": app_secret,
-        "KIS_ACCOUNT_NO": account_no,
-        "KIS_VIRTUAL": "1" if is_virtual else "0",
-    }
+    Returns:
+        (broker_type, display_label) 튜플 리스트.
+    """
+    from ante.account.presets import BROKER_PRESETS
+
+    excluded = {"test", "kis-overseas"}
+    result = []
+    for broker_type, preset in BROKER_PRESETS.items():
+        if broker_type in excluded:
+            continue
+        label = f"{broker_type} ({preset.exchange} / {preset.currency})"
+        result.append((broker_type, label))
+    return result
+
+
+def _prompt_account() -> list[dict[str, str]]:
+    """계좌 등록 정보를 대화형으로 입력받는다.
+
+    Returns:
+        등록할 계좌 정보 딕셔너리 리스트. 빈 리스트면 테스트 계좌만 생성.
+    """
+    from ante.account.presets import BROKER_PRESETS
+
+    click.echo("\n── [2/4] 계좌 설정 ─────────────────────────────")
+    click.echo("  등록하지 않으면 테스트 계좌가 자동으로 생성됩니다.")
+    click.echo("  나중에 `ante account create` 명령어로도 추가할 수 있습니다.")
+
+    accounts: list[dict[str, str]] = []
+    brokers = _get_available_brokers()
+
+    while True:
+        if not click.confirm("실제 거래 계좌를 등록하시겠습니까?", default=False):
+            break
+
+        # 브로커 선택
+        click.echo("\n  브로커를 선택하세요:")
+        for i, (_, label) in enumerate(brokers, 1):
+            click.echo(f"    {i}) {label}")
+
+        choice = click.prompt("  선택", type=click.IntRange(1, len(brokers)), default=1)
+        broker_type = brokers[choice - 1][0]
+        preset = BROKER_PRESETS[broker_type]
+
+        # 계좌 ID, 이름
+        account_id = click.prompt("  계좌 ID", default=preset.default_account_id)
+        account_name = click.prompt("  이름", default=preset.default_name)
+
+        # 인증 정보 입력
+        credentials: dict[str, str] = {}
+        for cred_key in preset.required_credentials:
+            value = click.prompt(f"  {cred_key}")
+            credentials[cred_key] = value
+
+        accounts.append(
+            {
+                "account_id": account_id,
+                "name": account_name,
+                "broker_type": broker_type,
+                "credentials": credentials,
+            }
+        )
+
+        click.echo(
+            f'  -> 계좌 "{account_id}" 등록 예정 '
+            f"({preset.exchange} / {preset.currency} / {broker_type})"
+        )
+
+    return accounts
 
 
 def _prompt_telegram() -> dict[str, str] | None:
     """Telegram 연동 정보를 입력받는다. 스킵 시 None 반환."""
-    click.echo("\n── 3. 텔레그램 알림 (선택) ─────────────────────")
+    click.echo("\n── [3/4] 텔레그램 알림 (선택) ──────────────────")
     click.echo("  나중에 secrets.env에서 설정할 수 있습니다.")
     if not click.confirm("텔레그램 알림을 설정하시겠습니까?", default=False):
         return None
@@ -134,7 +173,7 @@ def _prompt_telegram() -> dict[str, str] | None:
 
 def _prompt_datafeed(config_path: Path) -> None:
     """DataFeed API 키를 입력받아 .feed/.env에 저장한다."""
-    click.echo("\n── 4. 데이터 수집 API (선택) ───────────────────")
+    click.echo("\n── [4/4] 데이터 수집 API (선택) ────────────────")
     click.echo("  설정하면 백테스팅용 KRX 시세·재무 데이터를 자동 수집할 수 있습니다.")
     click.echo("  data.go.kr과 DART의 Open API Key가 필요합니다.")
     click.echo("  나중에 `ante feed config set` 명령어로도 설정할 수 있습니다.")
@@ -180,6 +219,74 @@ async def _bootstrap_master(
             token,
             recovery_key,
         )
+    finally:
+        await db.close()
+
+
+async def _create_accounts(
+    db_path: str,
+    account_inputs: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    """AccountService를 통해 계좌를 생성한다.
+
+    테스트 계좌는 항상 생성되고, account_inputs가 있으면 실제 계좌도 생성한다.
+
+    Returns:
+        생성된 계좌 정보 딕셔너리 리스트 (account_id, broker_type 포함).
+    """
+    from ante.account.models import Account, TradingMode
+    from ante.account.presets import BROKER_PRESETS
+    from ante.account.service import AccountService
+    from ante.core.database import Database
+    from ante.eventbus.bus import EventBus
+
+    db = Database(db_path)
+    await db.connect()
+    try:
+        eventbus = EventBus()
+        service = AccountService(db, eventbus)
+        await service.initialize()
+
+        created: list[dict[str, str]] = []
+
+        # 테스트 계좌 자동 생성
+        test_account = await service.create_default_test_account()
+        created.append(
+            {
+                "account_id": test_account.account_id,
+                "broker_type": test_account.broker_type,
+                "exchange": test_account.exchange,
+            }
+        )
+
+        # 실제 계좌 생성
+        for info in account_inputs:
+            broker_type = info["broker_type"]
+            preset = BROKER_PRESETS[broker_type]
+            account = Account(
+                account_id=info["account_id"],
+                name=info["name"],
+                exchange=preset.exchange,
+                currency=preset.currency,
+                timezone=preset.timezone,
+                trading_hours_start=preset.trading_hours_start,
+                trading_hours_end=preset.trading_hours_end,
+                trading_mode=TradingMode.LIVE,
+                broker_type=broker_type,
+                credentials=info["credentials"],
+                buy_commission_rate=preset.buy_commission_rate,
+                sell_commission_rate=preset.sell_commission_rate,
+            )
+            await service.create(account)
+            created.append(
+                {
+                    "account_id": account.account_id,
+                    "broker_type": broker_type,
+                    "exchange": preset.exchange,
+                }
+            )
+
+        return created
     finally:
         await db.close()
 
@@ -231,16 +338,8 @@ def init(ctx: click.Context, target_dir: str | None, seed: bool) -> None:
     # 2. Master 계정 입력
     member_id, name, password = _prompt_master_account()
 
-    # 3. KIS 연동
-    kis_info = _prompt_kis()
-    if kis_info:
-        _write_secrets_env(config_path, kis_info)
-        broker_label = (
-            "KIS (모의투자)" if kis_info.get("KIS_VIRTUAL") == "1" else "KIS (실투자)"
-        )
-    else:
-        _set_broker_test(config_path)
-        broker_label = "Test"
+    # 3. 계좌 설정
+    account_inputs = _prompt_account()
 
     # 4. Telegram 연동
     telegram_info = _prompt_telegram()
@@ -262,7 +361,21 @@ def init(ctx: click.Context, target_dir: str | None, seed: bool) -> None:
         fmt.error(str(e))
         return
 
-    # 7. 결과 출력
+    # 7. 계좌 생성 (테스트 계좌 자동 + 실제 계좌)
+    try:
+        created_accounts = _run(_create_accounts(db_path, account_inputs))
+    except Exception as e:
+        fmt.error(f"계좌 생성 실패: {e}")
+        return
+
+    # 계좌 라벨 생성
+    if account_inputs:
+        labels = [f"{a['account_id']} ({a['broker_type']})" for a in created_accounts]
+        account_label = ", ".join(labels)
+    else:
+        account_label = "test (테스트 계좌만)"
+
+    # 8. 결과 출력
     click.echo("\n── 완료 ────────────────────────────────────────")
 
     if fmt.is_json:
@@ -270,26 +383,26 @@ def init(ctx: click.Context, target_dir: str | None, seed: bool) -> None:
             {
                 **result,
                 "config_dir": str(config_path),
-                "broker": broker_label,
+                "accounts": created_accounts,
                 "token": token,
                 "recovery_key": recovery_key,
             }
         )
         return
 
-    click.echo("\n✅ 초기 설정 완료")
+    click.echo("\n초기 설정 완료")
     click.echo(f"  설정 디렉토리: {config_path}")
     click.echo(f"  Member ID   : {result['member_id']}")
     click.echo(f"  이모지      : {result['emoji']}")
-    click.echo(f"  브로커      : {broker_label}")
-    click.echo(f"\n🔑 토큰: {token}")
+    click.echo(f"  계좌        : {account_label}")
+    click.echo(f"\n  토큰: {token}")
     click.echo("\n   셸 프로필에 추가하면 매번 입력하지 않아도 됩니다:")
     click.echo(f"   echo 'export ANTE_MEMBER_TOKEN={token}' >> ~/.zshrc")
     click.echo("\n   또는 현재 세션에서만 사용:")
     click.echo(f"   export ANTE_MEMBER_TOKEN={token}")
     click.echo("\n   이제 시스템을 시작할 수 있습니다:")
     click.echo("   ante system start")
-    click.echo(f"\n⚠️  Recovery Key: {recovery_key}")
+    click.echo(f"\n   Recovery Key: {recovery_key}")
     click.echo("   이 키는 다시 표시되지 않습니다. 안전한 곳에 보관하세요.")
 
 

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -45,17 +45,62 @@ _MOCK_RESULT = {
 }
 
 
+_MOCK_TEST_ACCOUNT = [
+    {
+        "account_id": "test",
+        "broker_type": "test",
+        "exchange": "TEST",
+    }
+]
+
+
 def _mock_bootstrap(*args, **kwargs):
     """bootstrap_master mock — 3-tuple (dict, token, recovery_key) 반환."""
     return _MOCK_RESULT, _MOCK_TOKEN, _MOCK_RECOVERY_KEY
 
 
+def _mock_create_accounts_test_only(*args, **kwargs):
+    """_create_accounts mock — 테스트 계좌만 생성."""
+    return _MOCK_TEST_ACCOUNT
+
+
+def _mock_create_accounts_with_real(*args, **kwargs):
+    """_create_accounts mock — 테스트 + 실제 계좌."""
+    return [
+        *_MOCK_TEST_ACCOUNT,
+        {
+            "account_id": "domestic",
+            "broker_type": "kis-domestic",
+            "exchange": "KRX",
+        },
+    ]
+
+
 def _patch_bootstrap_and_auth():
-    """bootstrap_master + authenticate_member + DB를 모두 mock."""
+    """bootstrap_master + _create_accounts + authenticate_member mock."""
     return [
         patch(
             "ante.cli.commands.init._bootstrap_master",
             new=AsyncMock(side_effect=_mock_bootstrap),
+        ),
+        patch(
+            "ante.cli.commands.init._create_accounts",
+            new=AsyncMock(side_effect=_mock_create_accounts_test_only),
+        ),
+        patch("ante.cli.main.authenticate_member"),
+    ]
+
+
+def _patch_with_real_account():
+    """실제 계좌 등록 포함 mock."""
+    return [
+        patch(
+            "ante.cli.commands.init._bootstrap_master",
+            new=AsyncMock(side_effect=_mock_bootstrap),
+        ),
+        patch(
+            "ante.cli.commands.init._create_accounts",
+            new=AsyncMock(side_effect=_mock_create_accounts_with_real),
         ),
         patch("ante.cli.main.authenticate_member"),
     ]
@@ -64,8 +109,8 @@ def _patch_bootstrap_and_auth():
 class TestInitInteractive:
     """ante init 대화형 통합 흐름 테스트."""
 
-    def test_init_full_with_kis(self, runner, tmp_path):
-        """KIS 연동 입력 시 secrets.env에 키가 기록된다."""
+    def test_init_skip_account_creates_test(self, runner, tmp_path):
+        """계좌 등록 스킵 시 테스트 계좌만 생성된다."""
         target = tmp_path / "config"
         input_lines = "\n".join(
             [
@@ -73,11 +118,7 @@ class TestInitInteractive:
                 "홈트레이더",  # 이름
                 "pass1234",  # 패스워드
                 "pass1234",  # 패스워드 확인
-                "y",  # KIS 연동? y
-                "PSxxxxxxx",  # APP KEY
-                "secretkey123",  # APP SECRET
-                "50123456-01",  # 계좌번호
-                "n",  # 모의투자? n
+                "n",  # 실제 계좌 등록? n
                 "n",  # 텔레그램? n
                 "n",  # data.go.kr? n
                 "n",  # DART? n
@@ -97,19 +138,50 @@ class TestInitInteractive:
 
         assert result.exit_code == 0, result.output
         assert "초기 설정 완료" in result.output
+        assert "test (테스트 계좌만)" in result.output
         assert _MOCK_TOKEN in result.output
         assert _MOCK_RECOVERY_KEY in result.output
 
-        # secrets.env에 KIS 키가 기록됨
-        secrets_env = target / "secrets.env"
-        assert secrets_env.exists()
-        content = secrets_env.read_text()
-        assert "KIS_APP_KEY=PSxxxxxxx" in content
-        assert "KIS_APP_SECRET=secretkey123" in content
-        assert "KIS_ACCOUNT_NO=50123456-01" in content
+    def test_init_with_real_account(self, runner, tmp_path):
+        """실제 계좌 등록 시 계좌 정보가 표시된다."""
+        target = tmp_path / "config"
+        input_lines = "\n".join(
+            [
+                "owner",  # Member ID
+                "홈트레이더",  # 이름
+                "pass1234",  # 패스워드
+                "pass1234",  # 패스워드 확인
+                "y",  # 실제 계좌 등록? y
+                "1",  # 브로커 선택 (kis-domestic)
+                "domestic",  # 계좌 ID
+                "국내 주식",  # 이름
+                "PSxxxxxxxx",  # app_key
+                "secretkey123",  # app_secret
+                "50123456-01",  # account_no
+                "n",  # 추가 계좌? n
+                "n",  # 텔레그램? n
+                "n",  # data.go.kr? n
+                "n",  # DART? n
+            ]
+        )
 
-    def test_init_skip_kis_sets_test_broker(self, runner, tmp_path):
-        """KIS 스킵 시 system.toml에 broker.type = 'test' 설정."""
+        patches = _patch_with_real_account()
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(
+                cli, ["init", "--dir", str(target)], input=input_lines
+            )
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert result.exit_code == 0, result.output
+        assert "초기 설정 완료" in result.output
+        assert _MOCK_TOKEN in result.output
+
+    def test_init_no_kis_keys_in_secrets_env(self, runner, tmp_path):
+        """계좌 스킵 시 secrets.env에 KIS 키가 없다 (Account.credentials로 이동)."""
         target = tmp_path / "config"
         input_lines = "\n".join(
             [
@@ -117,7 +189,7 @@ class TestInitInteractive:
                 "홈트레이더",
                 "pass1234",
                 "pass1234",
-                "n",  # KIS 스킵
+                "n",  # 계좌 스킵
                 "n",  # 텔레그램 스킵
                 "n",  # data.go.kr 스킵
                 "n",  # DART 스킵
@@ -136,12 +208,46 @@ class TestInitInteractive:
                 p.stop()
 
         assert result.exit_code == 0, result.output
-        assert "Test" in result.output
+        secrets_env = target / "secrets.env"
+        content = secrets_env.read_text()
+        # KIS 관련 키가 secrets.env에 없어야 함
+        assert "KIS_APP_KEY" not in content
+        assert "KIS_APP_SECRET" not in content
+        assert "KIS_ACCOUNT_NO" not in content
 
+    def test_init_no_broker_in_system_toml(self, runner, tmp_path):
+        """계좌 스킵 시 system.toml에 [broker] 섹션이 추가되지 않는다."""
+        target = tmp_path / "config"
+        input_lines = "\n".join(
+            [
+                "owner",
+                "홈트레이더",
+                "pass1234",
+                "pass1234",
+                "n",  # 계좌 스킵
+                "n",  # 텔레그램 스킵
+                "n",  # data.go.kr 스킵
+                "n",  # DART 스킵
+            ]
+        )
+
+        patches = _patch_bootstrap_and_auth()
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(
+                cli, ["init", "--dir", str(target)], input=input_lines
+            )
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert result.exit_code == 0, result.output
         system_toml = target / "system.toml"
         content = system_toml.read_text()
-        assert "[broker]" in content
-        assert 'type = "test"' in content
+        # 이전에는 KIS 스킵 시 [broker] type = "test" 추가했으나,
+        # 이제는 Account 모델로 관리하므로 system.toml에 [broker] 없어야 함
+        assert "[broker]" not in content
 
     def test_init_skip_telegram(self, runner, tmp_path):
         """텔레그램 스킵 시 secrets.env에 텔레그램 키가 없다."""
@@ -152,7 +258,7 @@ class TestInitInteractive:
                 "홈트레이더",
                 "pass1234",
                 "pass1234",
-                "n",  # KIS 스킵
+                "n",  # 계좌 스킵
                 "n",  # 텔레그램 스킵
                 "n",  # data.go.kr 스킵
                 "n",  # DART 스킵
@@ -184,7 +290,7 @@ class TestInitInteractive:
                 "홈트레이더",
                 "pass1234",
                 "pass1234",
-                "n",  # KIS 스킵
+                "n",  # 계좌 스킵
                 "y",  # 텔레그램? y
                 "bot123token",  # 봇 토큰
                 "12345678",  # 채팅 ID
@@ -219,7 +325,7 @@ class TestInitInteractive:
                 "홈트레이더",
                 "pass1234",
                 "pass1234",
-                "n",  # KIS 스킵
+                "n",  # 계좌 스킵
                 "n",  # 텔레그램 스킵
                 "y",  # data.go.kr? y
                 "datagokr_key",  # data.go.kr API 키
@@ -257,7 +363,7 @@ class TestInitInteractive:
                 "홈트레이더",
                 "pass1234",
                 "pass1234",
-                "n",  # KIS 스킵
+                "n",  # 계좌 스킵
                 "n",  # 텔레그램 스킵
                 "n",  # data.go.kr 스킵
                 "n",  # DART 스킵
@@ -280,7 +386,7 @@ class TestInitInteractive:
         assert not feed_env.exists()
 
     def test_init_json_output(self, runner, tmp_path):
-        """--format json 시 JSON 출력."""
+        """--format json 시 JSON 출력에 accounts 포함."""
         target = tmp_path / "config"
         input_lines = "\n".join(
             [
@@ -311,7 +417,6 @@ class TestInitInteractive:
         assert result.exit_code == 0, result.output
         # JSON 출력은 대화형 프롬프트 텍스트 뒤에 위치
         lines = result.output.strip().splitlines()
-        # 마지막 }를 포함하는 JSON 블록 추출
         json_start = None
         for i, line in enumerate(lines):
             if line.strip().startswith("{"):
@@ -323,6 +428,8 @@ class TestInitInteractive:
         assert data["member_id"] == "owner"
         assert data["token"] == _MOCK_TOKEN
         assert data["recovery_key"] == _MOCK_RECOVERY_KEY
+        assert "accounts" in data
+        assert data["accounts"][0]["account_id"] == "test"
 
 
 class TestInitIdempotent:
@@ -338,6 +445,20 @@ class TestInitIdempotent:
 
         assert result.exit_code == 0
         assert "이미 존재합니다" in result.output
+
+
+class TestPromptAccount:
+    """_prompt_account / _get_available_brokers 단위 테스트."""
+
+    def test_kis_overseas_excluded(self):
+        """kis-overseas가 브로커 선택지에서 제외된다."""
+        from ante.cli.commands.init import _get_available_brokers
+
+        brokers = _get_available_brokers()
+        broker_types = [bt for bt, _ in brokers]
+        assert "kis-overseas" not in broker_types
+        assert "test" not in broker_types
+        assert "kis-domestic" in broker_types
 
 
 class TestBootstrapTokenReturn:


### PR DESCRIPTION
## Summary

- `_prompt_kis()` 제거 → `_prompt_account()` 추가 (BROKER_PRESETS 기반 대화형 계좌 등록)
- kis-overseas를 브로커 선택지에서 제외 (1.1 지원 예정)
- 계좌 미등록 시 테스트 계좌 자동 생성 (`AccountService.create_default_test_account`)
- `secrets.env`에서 KIS 관련 키 제거 (Account.credentials로 대체)
- `_set_broker_test()` 제거 (system.toml의 `[broker]` 섹션 불필요 — Account 모델로 관리)
- `_create_accounts()` 함수 추가: AccountService를 통한 DB 기반 계좌 생성
- 테스트를 새 흐름에 맞게 전면 수정 (13개 테스트 통과)

Refs #572

## Test plan

- [x] 계좌 스킵 시 테스트 계좌만 생성 확인
- [x] 실제 계좌 등록 흐름 동작 확인
- [x] secrets.env에 KIS 키 미포함 확인
- [x] system.toml에 [broker] 섹션 미추가 확인
- [x] kis-overseas 브로커 선택지 제외 확인
- [x] 텔레그램/DataFeed 기존 흐름 호환
- [x] JSON 출력 시 accounts 필드 포함 확인
- [x] 멱등성 (기존 설정 존재 시 거부)
- [x] 기존 테스트 suite 무영향

🤖 Generated with [Claude Code](https://claude.com/claude-code)