### PR TITLE
feat(web): 기존 API 엔드포인트 account_id 연동 (#575)

### DIFF
--- a/src/ante/web/deps.py
+++ b/src/ante/web/deps.py
@@ -88,6 +88,14 @@ def get_account_service(request: Request) -> Any:
     return svc
 
 
+def get_treasury_manager(request: Request) -> Any:
+    """Treasury 매니저 (필수)."""
+    svc = getattr(request.app.state, "treasury_manager", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Treasury manager not available")
+    return svc
+
+
 def get_notification_service(request: Request) -> Any:
     """알림 서비스 (필수)."""
     svc = getattr(request.app.state, "notification_service", None)
@@ -158,6 +166,11 @@ def get_report_store_optional(request: Request) -> Any | None:
 def get_account_service_optional(request: Request) -> Any | None:
     """계좌 서비스 (선택적). 없으면 None."""
     return getattr(request.app.state, "account_service", None)
+
+
+def get_treasury_manager_optional(request: Request) -> Any | None:
+    """Treasury 매니저 (선택적). 없으면 None."""
+    return getattr(request.app.state, "treasury_manager", None)
 
 
 def get_config(request: Request) -> Any | None:

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -39,6 +39,7 @@ class BotCreateRequest(BaseModel):
 )
 async def list_bots(
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
+    account_id: str | None = None,
     limit: int = 20,
     cursor: str | None = None,
 ) -> dict:
@@ -46,6 +47,17 @@ async def list_bots(
     from ante.web.pagination import paginate
 
     bots = bot_manager.list_bots()
+    if account_id:
+        bots = [
+            b
+            for b in bots
+            if (
+                b.get("account_id")
+                if isinstance(b, dict)
+                else getattr(b, "account_id", None)
+            )
+            == account_id
+        ]
     result = paginate(bots, cursor_field="bot_id", limit=limit, cursor=cursor)
     return {"bots": result["items"], "next_cursor": result["next_cursor"]}
 

--- a/src/ante/web/routes/portfolio.py
+++ b/src/ante/web/routes/portfolio.py
@@ -8,7 +8,12 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query
 
-from ante.web.deps import get_bot_manager, get_trade_service, get_treasury
+from ante.web.deps import (
+    get_bot_manager,
+    get_trade_service,
+    get_treasury,
+    get_treasury_manager_optional,
+)
 from ante.web.schemas import PortfolioHistoryResponse, PortfolioValueResponse
 
 logger = logging.getLogger(__name__)
@@ -23,9 +28,23 @@ router = APIRouter()
 )
 async def portfolio_value(
     treasury: Annotated[Any, Depends(get_treasury)],
+    treasury_manager: Annotated[Any | None, Depends(get_treasury_manager_optional)],
+    account_id: str | None = None,
 ) -> dict:
     """총 자산 가치 + 오늘 손익."""
-    summary = treasury.get_summary()
+    from fastapi import HTTPException
+
+    target_treasury = treasury
+    if account_id and treasury_manager is not None:
+        try:
+            target_treasury = treasury_manager.get(account_id)
+        except KeyError:
+            raise HTTPException(
+                status_code=404,
+                detail=f"계좌를 찾을 수 없습니다: {account_id}",
+            )
+
+    summary = target_treasury.get_summary()
     total_value = summary["total_evaluation"]
     daily_pnl = summary["total_profit_loss"]
     daily_pnl_pct = (daily_pnl / total_value * 100) if total_value else 0.0
@@ -58,6 +77,7 @@ _PERIOD_DAYS = {
 async def portfolio_history(
     trade_service: Annotated[Any, Depends(get_trade_service)],
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
+    account_id: str | None = None,
     period: str = Query(default="1m", pattern="^(1d|1w|1m|3m|all)$"),
 ) -> dict:
     """기간별 자산 추이."""
@@ -67,6 +87,17 @@ async def portfolio_history(
     feedback = PerformanceFeedback(trade_service, bot_manager)
 
     bots = bot_manager.list_bots() if hasattr(bot_manager, "list_bots") else []
+    if account_id:
+        bots = [
+            b
+            for b in bots
+            if (
+                b.get("account_id")
+                if isinstance(b, dict)
+                else getattr(b, "account_id", None)
+            )
+            == account_id
+        ]
     bot_ids = [b["bot_id"] if isinstance(b, dict) else b.bot_id for b in bots]
 
     # 봇이 없으면 빈 데이터

--- a/src/ante/web/routes/trades.py
+++ b/src/ante/web/routes/trades.py
@@ -19,6 +19,7 @@ router = APIRouter()
 )
 async def list_trades(
     trade_service: Annotated[Any, Depends(get_trade_service)],
+    account_id: str | None = None,
     bot_id: str | None = None,
     symbol: str | None = None,
     limit: int = 20,
@@ -28,6 +29,7 @@ async def list_trades(
     from ante.web.pagination import paginate
 
     trades = await trade_service.get_trades(
+        account_id=account_id,
         bot_id=bot_id,
         symbol=symbol,
         limit=limit + 1,
@@ -36,6 +38,9 @@ async def list_trades(
         {
             "trade_id": t.trade_id,
             "bot_id": t.bot_id,
+            "account_id": str(a)
+            if isinstance(a := getattr(t, "account_id", ""), str)
+            else "",
             "symbol": t.symbol,
             "side": t.side,
             "quantity": t.quantity,

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -10,9 +10,8 @@ from pydantic import BaseModel
 
 from ante.web.deps import (
     get_audit_logger_optional,
-    get_broker,
-    get_config,
     get_treasury,
+    get_treasury_manager_optional,
 )
 from ante.web.schemas import (
     BalanceSetResponse,
@@ -42,30 +41,53 @@ class BalanceSetRequest(BaseModel):
     "",
     response_model=TreasurySummaryResponse,
     response_model_exclude_none=True,
-    responses={503: {"description": "Treasury not available"}},
+    responses={
+        404: {"description": "Account not found"},
+        503: {"description": "Treasury not available"},
+    },
 )
 async def get_summary(
+    request: Request,
     treasury: Annotated[Any, Depends(get_treasury)],
-    broker: Annotated[Any | None, Depends(get_broker)],
-    config: Annotated[Any | None, Depends(get_config)],
+    treasury_manager: Annotated[Any | None, Depends(get_treasury_manager_optional)],
+    account_id: str | None = None,
 ) -> dict:
-    """자금 현황 요약."""
-    summary = treasury.get_summary()
-    summary["commission_rate"] = getattr(treasury, "buy_commission_rate", 0.00015)
-    summary["sell_tax_rate"] = getattr(treasury, "sell_commission_rate", 0.00195)
+    """자금 현황 요약.
 
-    # 브로커 메타정보
+    account_id 지정 시 해당 계좌의 Treasury 요약을 반환한다.
+    미지정 시 기본 Treasury 요약을 반환한다 (하위 호환).
+    """
+    target_treasury = treasury
+    if account_id and treasury_manager is not None:
+        try:
+            target_treasury = treasury_manager.get(account_id)
+        except KeyError:
+            raise HTTPException(
+                status_code=404,
+                detail=f"계좌를 찾을 수 없습니다: {account_id}",
+            )
+
+    summary = target_treasury.get_summary()
+    summary["account_id"] = getattr(target_treasury, "account_id", None)
+    summary["currency"] = getattr(target_treasury, "currency", "KRW")
+    summary["commission_rate"] = getattr(
+        target_treasury, "buy_commission_rate", 0.00015
+    )
+    summary["sell_tax_rate"] = getattr(target_treasury, "sell_commission_rate", 0.00195)
+
+    # 브로커 메타정보 (하위 호환)
+    broker = getattr(request.app.state, "broker", None)
     if broker is not None:
         summary["broker_id"] = broker.broker_id
         summary["broker_name"] = broker.broker_name
         summary["broker_short_name"] = broker.broker_short_name
         summary["exchange"] = broker.exchange
 
-    # KIS 계좌 헤더 정보
+    # KIS 계좌 헤더 정보 (하위 호환)
+    config = getattr(request.app.state, "config", None)
     if config is not None:
         try:
             account_no = config.secret("KIS_ACCOUNT_NO")
-            # "1234567801" -> "12345678-01" 포맷 변환
             if account_no and len(account_no) == 10:
                 summary["account_no"] = f"{account_no[:8]}-{account_no[8:]}"
             elif account_no:
@@ -76,7 +98,7 @@ async def get_summary(
         if isinstance(broker_config, dict):
             summary["is_virtual"] = broker_config.get("is_paper", True)
 
-    last_synced = getattr(treasury, "last_synced_at", None)
+    last_synced = getattr(target_treasury, "last_synced_at", None)
     if last_synced is not None:
         summary["synced_at"] = last_synced.isoformat()
 
@@ -90,6 +112,7 @@ async def get_summary(
 )
 async def list_transactions(
     treasury: Annotated[Any, Depends(get_treasury)],
+    account_id: str | None = None,
     type: str | None = None,
     bot_id: str | None = None,
     limit: int = 20,
@@ -103,6 +126,9 @@ async def list_transactions(
     where_clauses: list[str] = []
     params: list[str | int] = []
 
+    if account_id:
+        where_clauses.append("account_id = ?")
+        params.append(account_id)
     if type:
         where_clauses.append("transaction_type = ?")
         params.append(type)

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -618,6 +618,7 @@ class TradeItem(BaseModel):
 
     trade_id: str
     bot_id: str
+    account_id: str = ""
     symbol: str
     side: str
     quantity: float

--- a/tests/unit/test_web_account_filter.py
+++ b/tests/unit/test_web_account_filter.py
@@ -1,0 +1,321 @@
+"""기존 API 엔드포인트의 account_id 필터 테스트.
+
+이슈 #575: Web API — 기존 엔드포인트 account_id 연동.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402
+
+# ── Stubs ───────────────────────────────────────────
+
+
+class FakeBot:
+    """테스트용 Bot stub."""
+
+    def __init__(
+        self,
+        bot_id: str,
+        account_id: str = "test",
+        status: str = "created",
+        strategy_id: str = "s1",
+    ) -> None:
+        self.bot_id = bot_id
+        self._status = status
+        self._strategy_id = strategy_id
+        self._account_id = account_id
+
+    def get_info(self) -> dict:
+        return {
+            "bot_id": self.bot_id,
+            "name": self.bot_id,
+            "status": self._status,
+            "account_id": self._account_id,
+            "strategy_id": self._strategy_id,
+            "interval_seconds": 60,
+            "started_at": None,
+            "stopped_at": None,
+            "error_message": None,
+        }
+
+
+class FakeBotManager:
+    """테스트용 BotManager stub."""
+
+    def __init__(self) -> None:
+        self._bots: dict[str, FakeBot] = {}
+
+    def list_bots(self) -> list[dict]:
+        return [b.get_info() for b in self._bots.values()]
+
+    def get_bot(self, bot_id: str) -> FakeBot | None:
+        return self._bots.get(bot_id)
+
+
+class FakeTreasury:
+    """테스트용 Treasury stub."""
+
+    def __init__(
+        self,
+        account_id: str = "default",
+        currency: str = "KRW",
+    ) -> None:
+        self.account_id = account_id
+        self.currency = currency
+        self.buy_commission_rate = 0.00015
+        self.sell_commission_rate = 0.00195
+        self._db = None
+
+    def get_summary(self) -> dict:
+        return {
+            "total_balance": 10_000_000.0,
+            "unallocated": 5_000_000.0,
+            "total_allocated": 5_000_000.0,
+            "total_evaluation": 10_500_000.0,
+            "total_profit_loss": 500_000.0,
+        }
+
+    def list_budgets(self) -> list:
+        return []
+
+    def get_budget(self, bot_id: str) -> None:
+        return None
+
+
+class FakeTreasuryManager:
+    """테스트용 TreasuryManager stub."""
+
+    def __init__(self) -> None:
+        self._treasuries: dict[str, FakeTreasury] = {}
+
+    def get(self, account_id: str) -> FakeTreasury:
+        if account_id not in self._treasuries:
+            raise KeyError(f"Treasury not found: account_id={account_id}")
+        return self._treasuries[account_id]
+
+    def list_all(self) -> list[FakeTreasury]:
+        return list(self._treasuries.values())
+
+
+class FakeTradeRecord:
+    """테스트용 TradeRecord stub."""
+
+    def __init__(
+        self,
+        trade_id: str,
+        bot_id: str,
+        account_id: str = "test",
+        symbol: str = "005930",
+        side: str = "buy",
+        quantity: float = 10.0,
+        price: float = 70000.0,
+        status: str = "filled",
+        created_at: str = "2025-01-01T00:00:00",
+    ) -> None:
+        self.trade_id = trade_id
+        self.bot_id = bot_id
+        self.account_id = account_id
+        self.symbol = symbol
+        self.side = side
+        self.quantity = quantity
+        self.price = price
+        self.status = status
+        self.created_at = created_at
+
+
+class FakeTradeService:
+    """테스트용 TradeService stub."""
+
+    def __init__(self) -> None:
+        self._trades: list[FakeTradeRecord] = []
+
+    async def get_trades(
+        self,
+        account_id: str | None = None,
+        bot_id: str | None = None,
+        symbol: str | None = None,
+        limit: int = 100,
+        **kwargs: object,
+    ) -> list[FakeTradeRecord]:
+        result = self._trades
+        if account_id:
+            result = [t for t in result if t.account_id == account_id]
+        if bot_id:
+            result = [t for t in result if t.bot_id == bot_id]
+        if symbol:
+            result = [t for t in result if t.symbol == symbol]
+        return result[:limit]
+
+
+# ── Fixtures ───────────────────────────────────────
+
+
+@pytest.fixture
+def bot_manager():
+    mgr = FakeBotManager()
+    mgr._bots["bot-a"] = FakeBot("bot-a", account_id="acct-1")
+    mgr._bots["bot-b"] = FakeBot("bot-b", account_id="acct-2")
+    mgr._bots["bot-c"] = FakeBot("bot-c", account_id="acct-1")
+    return mgr
+
+
+@pytest.fixture
+def treasury():
+    return FakeTreasury(account_id="default", currency="KRW")
+
+
+@pytest.fixture
+def treasury_manager():
+    mgr = FakeTreasuryManager()
+    mgr._treasuries["acct-1"] = FakeTreasury(account_id="acct-1", currency="KRW")
+    mgr._treasuries["acct-2"] = FakeTreasury(account_id="acct-2", currency="USD")
+    return mgr
+
+
+@pytest.fixture
+def trade_service():
+    svc = FakeTradeService()
+    svc._trades = [
+        FakeTradeRecord("t1", "bot-a", account_id="acct-1", symbol="005930"),
+        FakeTradeRecord("t2", "bot-b", account_id="acct-2", symbol="AAPL"),
+        FakeTradeRecord("t3", "bot-c", account_id="acct-1", symbol="035720"),
+    ]
+    return svc
+
+
+@pytest.fixture
+def client(bot_manager, treasury, treasury_manager, trade_service):
+    app = create_app(
+        bot_manager=bot_manager,
+        treasury=treasury,
+        treasury_manager=treasury_manager,
+        trade_service=trade_service,
+    )
+    return TestClient(app)
+
+
+# ── Tests: Bots ────────────────────────────────────
+
+
+class TestBotsAccountFilter:
+    def test_filter_by_account_id(self, client):
+        """account_id로 봇 필터링."""
+        resp = client.get("/api/bots?account_id=acct-1")
+        assert resp.status_code == 200
+        bots = resp.json()["bots"]
+        assert len(bots) == 2
+        assert all(b["account_id"] == "acct-1" for b in bots)
+
+    def test_filter_by_account_id_no_match(self, client):
+        """일치하는 account_id 없으면 빈 목록."""
+        resp = client.get("/api/bots?account_id=nonexistent")
+        assert resp.status_code == 200
+        assert resp.json()["bots"] == []
+
+    def test_no_filter_returns_all(self, client):
+        """account_id 미지정 시 전체 반환 (하위 호환)."""
+        resp = client.get("/api/bots")
+        assert resp.status_code == 200
+        assert len(resp.json()["bots"]) == 3
+
+    def test_bot_response_has_account_id(self, client):
+        """봇 응답에 account_id 필드 포함."""
+        resp = client.get("/api/bots")
+        assert resp.status_code == 200
+        for bot in resp.json()["bots"]:
+            assert "account_id" in bot
+
+
+# ── Tests: Treasury ────────────────────────────────
+
+
+class TestTreasuryAccountFilter:
+    def test_filter_by_account_id(self, client):
+        """account_id로 특정 계좌 Treasury 조회."""
+        resp = client.get("/api/treasury?account_id=acct-1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["account_id"] == "acct-1"
+        assert data["currency"] == "KRW"
+
+    def test_filter_by_account_id_usd(self, client):
+        """USD 계좌 Treasury 조회."""
+        resp = client.get("/api/treasury?account_id=acct-2")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["account_id"] == "acct-2"
+        assert data["currency"] == "USD"
+
+    def test_no_filter_returns_default(self, client):
+        """account_id 미지정 시 기본 Treasury 반환 (하위 호환)."""
+        resp = client.get("/api/treasury")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_balance"] == 10_000_000.0
+
+    def test_nonexistent_account(self, client):
+        """존재하지 않는 account_id → 404."""
+        resp = client.get("/api/treasury?account_id=nonexistent")
+        assert resp.status_code == 404
+
+
+# ── Tests: Trades ──────────────────────────────────
+
+
+class TestTradesAccountFilter:
+    def test_filter_by_account_id(self, client):
+        """account_id로 거래 필터링."""
+        resp = client.get("/api/trades?account_id=acct-1")
+        assert resp.status_code == 200
+        trades = resp.json()["trades"]
+        assert len(trades) == 2
+        assert all(t["account_id"] == "acct-1" for t in trades)
+
+    def test_no_filter_returns_all(self, client):
+        """account_id 미지정 시 전체 반환 (하위 호환)."""
+        resp = client.get("/api/trades")
+        assert resp.status_code == 200
+        assert len(resp.json()["trades"]) == 3
+
+    def test_trade_response_has_account_id(self, client):
+        """거래 응답에 account_id 필드 포함."""
+        resp = client.get("/api/trades")
+        assert resp.status_code == 200
+        for trade in resp.json()["trades"]:
+            assert "account_id" in trade
+
+
+# ── Tests: Portfolio ──────────────────────────────
+
+
+class TestPortfolioAccountFilter:
+    def test_value_no_filter(self, client):
+        """account_id 미지정 시 기본 Treasury 사용 (하위 호환)."""
+        resp = client.get("/api/portfolio/value")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_value"] == 10_500_000.0
+
+    def test_value_with_account_id(self, client):
+        """account_id 지정 시 해당 계좌 Treasury 사용."""
+        resp = client.get("/api/portfolio/value?account_id=acct-1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_value"] == 10_500_000.0
+
+    def test_value_nonexistent_account(self, client):
+        """존재하지 않는 account_id → 404."""
+        resp = client.get("/api/portfolio/value?account_id=nonexistent")
+        assert resp.status_code == 404
+
+    def test_history_with_nonexistent_account(self, client):
+        """존재하지 않는 account_id로 필터하면 빈 데이터 (봇 없음)."""
+        resp = client.get("/api/portfolio/history?account_id=nonexistent")
+        assert resp.status_code == 200
+        assert resp.json()["data"] == []


### PR DESCRIPTION
## Summary

기존 Web API 엔드포인트에 `account_id` 쿼리 파라미터와 응답 필드를 추가하여, 계좌별 데이터 조회를 지원한다.

- **bots**: `GET /api/bots?account_id=...`로 계좌별 봇 필터링
- **treasury**: `GET /api/treasury?account_id=...`로 TreasuryManager를 통한 계좌별 잔고 조회, 응답에 `account_id`/`currency` 포함
- **trades**: `GET /api/trades?account_id=...`로 계좌별 거래 내역 필터링, 응답에 `account_id` 포함
- **portfolio**: `GET /api/portfolio/value?account_id=...`, `GET /api/portfolio/history?account_id=...`로 계좌별 자산 현황 조회
- **deps**: `get_treasury_manager`, `get_treasury_manager_optional` 의존성 함수 추가
- 모든 엔드포인트에서 `account_id` 미지정 시 전체 조회 (하위 호환 유지)

Refs #575

## Test plan

- [x] bots — account_id 필터링, 미지정 시 전체 반환, 응답에 account_id 포함
- [x] treasury — 계좌별 조회, 존재하지 않는 계좌 404, 기본 조회 하위 호환
- [x] trades — account_id 필터링, 미지정 시 전체 반환, 응답에 account_id 포함
- [x] portfolio — 계좌별 자산 가치, 존재하지 않는 계좌 404, 하위 호환
- [x] 기존 테스트 (test_bot_api, test_api_pagination, test_broker_meta_api 등) 무영향