### PR TITLE
fix(config): 웹 대시보드 기본 포트를 3982로 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,6 @@ COPY tests/fixtures/seed/scenarios/ tests/fixtures/seed/scenarios/
 COPY config/system.toml.example config/system.toml
 RUN sed -i 's/^enabled = false/enabled = true/' config/system.toml
 
-EXPOSE 8000
+EXPOSE 3982
 
 ENTRYPOINT ["python", "-m", "ante.main"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -44,6 +44,6 @@ COPY config/system.test.toml config/system.toml
 COPY scripts/e2e-entrypoint.sh /app/e2e-entrypoint.sh
 RUN chmod +x /app/e2e-entrypoint.sh
 
-EXPOSE 8000
+EXPOSE 3982
 
 ENTRYPOINT ["/app/e2e-entrypoint.sh"]

--- a/config/system.test.toml
+++ b/config/system.test.toml
@@ -14,7 +14,7 @@ path = "data/"
 [web]
 enabled = true
 host = "0.0.0.0"
-port = 8000
+port = 3982
 
 [eventbus]
 history_size = 1000

--- a/config/system.toml
+++ b/config/system.toml
@@ -14,7 +14,7 @@ path = "data/"
 [web]
 enabled = false             # 대시보드 활성화 시 true
 host = "0.0.0.0"
-port = 8000
+port = 3982
 
 [eventbus]
 history_size = 1000

--- a/config/system.toml.example
+++ b/config/system.toml.example
@@ -14,7 +14,7 @@ path = "data/"
 [web]
 enabled = false  # 대시보드 활성화 시 true
 host = "0.0.0.0"
-port = 8000
+port = 3982
 
 [eventbus]
 history_size = 1000

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -15,14 +15,14 @@ services:
       context: .
       dockerfile: Dockerfile.test
     ports:
-      - "8000:8000"
+      - "3982:3982"
     environment:
       - ANTE_CONFIG_DIR=/app/config
       - ANTE_TEST_MODE=1
       - TELEGRAM_BOT_TOKEN=dummy-token-for-test
       - TELEGRAM_CHAT_ID=dummy-chat-id-for-test
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/system/health')"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:3982/api/system/health')"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -41,7 +41,7 @@ services:
       ante-test:
         condition: service_healthy
     environment:
-      - E2E_BASE_URL=http://ante-test:8000
+      - E2E_BASE_URL=http://ante-test:3982
       - E2E_TEST_PASSWORD=test1234
     volumes:
       - ./test-results:/app/test-results
@@ -49,7 +49,7 @@ services:
       - e2e-net
     command: >
       tests/e2e/ -m e2e
-      --base-url http://ante-test:8000
+      --base-url http://ante-test:3982
       -v --tb=short
       --output=test-results
       --junit-xml=test-results/e2e-results.xml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   ante:
     build: .
     ports:
-      - "8000:8000"
+      - "3982:3982"
     volumes:
       - ./config:/app/config
       - ante-data:/app/data

--- a/frontend/scripts/generate-types.sh
+++ b/frontend/scripts/generate-types.sh
@@ -10,8 +10,8 @@
 #   2. 이 스크립트 실행
 #
 # 서버 기반:
-#   1. 백엔드 서버 실행 (기본: http://localhost:8000)
-#   2. npm run generate-types -- --url http://localhost:8000/openapi.json
+#   1. 백엔드 서버 실행 (기본: http://localhost:3982)
+#   2. npm run generate-types -- --url http://localhost:3982/openapi.json
 
 set -euo pipefail
 
@@ -53,9 +53,9 @@ else
   echo ""
   echo "다음 중 하나를 수행하세요:"
   echo "  1. frontend/openapi.json 파일 배치 후 재실행"
-  echo "     curl http://localhost:8000/openapi.json -o frontend/openapi.json"
+  echo "     curl http://localhost:3982/openapi.json -o frontend/openapi.json"
   echo "  2. 서버 URL 직접 지정"
-  echo "     npm run generate-types -- --url http://localhost:8000/openapi.json"
+  echo "     npm run generate-types -- --url http://localhost:3982/openapi.json"
   exit 1
 fi
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: 'http://localhost:3982',
         changeOrigin: true,
       },
     },

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -16,7 +16,7 @@ if [ -n "$FLOW" ]; then
     docker compose -f "$COMPOSE_FILE" up --build -d ante-test
     docker compose -f "$COMPOSE_FILE" run --rm e2e-runner \
         pytest "tests/e2e/${FLOW}.py" -m e2e -v --tb=short \
-        --base-url http://ante-test:8000 \
+        --base-url http://ante-test:3982 \
         --output=test-results \
         --junit-xml=test-results/e2e-results.xml
 else

--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -25,7 +25,7 @@ path = "db/ante.db"
 
 [web]
 host = "0.0.0.0"
-port = 8000
+port = 3982
 """
 
 SECRETS_ENV_TEMPLATE = """\

--- a/src/ante/config/defaults.py
+++ b/src/ante/config/defaults.py
@@ -8,7 +8,7 @@ DEFAULTS: dict[str, object] = {
     "parquet.base_path": "data/",
     "parquet.compression": "snappy",
     "web.host": "0.0.0.0",
-    "web.port": 8000,
+    "web.port": 3982,
     "eventbus.history_size": 1000,
     "member.token_ttl_days": 90,
     "instrument.cache_ttl_seconds": 3600,

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -951,7 +951,7 @@ async def _init_web(s: Services) -> None:
     uv_config = uvicorn.Config(
         app,
         host=s.config.get("web.host", "0.0.0.0"),
-        port=s.config.get("web.port", 8000),
+        port=s.config.get("web.port", 3982),
         log_level="info",
     )
     server = uvicorn.Server(uv_config)

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -43,7 +43,7 @@ playwright install chromium
 docker compose -f docker-compose.test.yml up --build -d ante-test
 
 # 호스트에서 테스트 실행
-pytest tests/e2e/ -m e2e --base-url http://localhost:8000 -v
+pytest tests/e2e/ -m e2e --base-url http://localhost:3982 -v
 
 # 정리
 docker compose -f docker-compose.test.yml down -v

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -2,10 +2,10 @@
 
 사용법:
     # Docker 내부 (e2e-runner 컨테이너)
-    pytest tests/e2e/ -m e2e --base-url http://ante-test:8000
+    pytest tests/e2e/ -m e2e --base-url http://ante-test:3982
 
     # 로컬 개발 (ante-test 컨테이너 실행 중)
-    pytest tests/e2e/ -m e2e --base-url http://localhost:8000
+    pytest tests/e2e/ -m e2e --base-url http://localhost:3982
 """
 
 from __future__ import annotations
@@ -43,12 +43,12 @@ def base_url(request: pytest.FixtureRequest) -> str:
         return cli_url
     if env_url:
         return env_url
-    return "http://localhost:8000"
+    return "http://localhost:3982"
 
 
 @pytest.fixture(scope="session")
 def api_url(base_url: str) -> str:
-    """API base URL (예: http://ante-test:8000/api)."""
+    """API base URL (예: http://ante-test:3982/api)."""
     return f"{base_url}/api"
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -28,7 +28,7 @@ class TestConfigLoad:
         config = Config.load(config_dir=tmp_path)
 
         assert config.get("db.path") == "db/ante.db"
-        assert config.get("web.port") == 8000
+        assert config.get("web.port") == 3982
 
     def test_load_with_dotenv(self, tmp_path: Path) -> None:
         """.env 파일에서 비밀값을 로드한다."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -13,7 +13,7 @@ async def test_full_initialization(tmp_path: Path) -> None:
     # 1. Config
     toml = tmp_path / "system.toml"
     toml.write_text(
-        '[db]\npath = "{}"\n\n[web]\nport = 8000\n'.format(str(tmp_path / "test.db"))
+        '[db]\npath = "{}"\n\n[web]\nport = 3982\n'.format(str(tmp_path / "test.db"))
     )
     config = Config.load(config_dir=tmp_path)
     config.validate()
@@ -105,7 +105,7 @@ async def test_composition_root_account_based(tmp_path: Path) -> None:
     toml = tmp_path / "system.toml"
     toml.write_text(
         '[db]\npath = "{db}"\n\n'
-        "[web]\nenabled = false\nport = 8000\n\n"
+        "[web]\nenabled = false\nport = 3982\n\n"
         '[data]\npath = "{data}"\n'.format(
             db=str(tmp_path / "test.db"),
             data=str(tmp_path / "data"),


### PR DESCRIPTION
## Summary

웹 대시보드 및 API 서버의 기본 포트를 `8000`에서 `3982`로 변경합니다.

Refs #558

## 변경 내용

- `src/ante/config/defaults.py` — `web.port` 기본값 3982
- `src/ante/main.py` — uvicorn fallback 값 3982
- `src/ante/cli/commands/init.py` — init 시 생성하는 config 템플릿 포트 3982
- `config/system.toml`, `config/system.test.toml`, `config/system.toml.example` — 설정 파일 포트 3982
- `Dockerfile`, `Dockerfile.test` — EXPOSE 포트 3982
- `docker-compose.yml`, `docker-compose.test.yml` — 포트 매핑 3982:3982
- `frontend/vite.config.ts` — 프록시 대상 포트 3982
- `frontend/scripts/generate-types.sh`, `scripts/run-e2e.sh` — 스크립트 내 포트 참조 3982
- `tests/unit/test_config.py`, `tests/unit/test_main.py` — 테스트 기대값 3982
- `tests/e2e/conftest.py`, `tests/e2e/README.md` — E2E 테스트 기본 URL 포트 3982

## Test plan

- [x] `ruff check` 통과
- [x] `ruff format` 통과
- [x] `pytest tests/unit/` 전체 통과 (2382 passed)
- [x] 포트 8000 참조 잔존 여부 전체 검색 확인 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)