### PR TITLE
feat(web): Agent 토큰 인증 시 last_active_at 갱신 (5분 스로틀링)

### DIFF
--- a/src/ante/web/app.py
+++ b/src/ante/web/app.py
@@ -49,8 +49,10 @@ def create_app(**services: Any) -> FastAPI:
     )
 
     from ante.web.middleware.audit import AuditMiddleware
+    from ante.web.middleware.token_auth import TokenAuthMiddleware
 
     app.add_middleware(AuditMiddleware)
+    app.add_middleware(TokenAuthMiddleware)
 
     for name, service in services.items():
         setattr(app.state, name, service)

--- a/src/ante/web/middleware/__init__.py
+++ b/src/ante/web/middleware/__init__.py
@@ -1,5 +1,6 @@
 """Web API 미들웨어."""
 
 from ante.web.middleware.audit import AuditMiddleware
+from ante.web.middleware.token_auth import TokenAuthMiddleware
 
-__all__ = ["AuditMiddleware"]
+__all__ = ["AuditMiddleware", "TokenAuthMiddleware"]

--- a/src/ante/web/middleware/token_auth.py
+++ b/src/ante/web/middleware/token_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -14,6 +15,15 @@ logger = logging.getLogger(__name__)
 # Authorization 헤더 접두어
 _BEARER_PREFIX = "Bearer "
 
+# last_active_at 갱신 최소 간격 (5분)
+_UPDATE_INTERVAL = timedelta(minutes=5)
+
+# 인메모리 캐시: member_id → 마지막 갱신 시각
+_last_updated: dict[str, datetime] = {}
+
+# epoch 기준값 (캐시 미스 시 사용)
+_EPOCH = datetime(2000, 1, 1, tzinfo=UTC)
+
 
 class TokenAuthMiddleware(BaseHTTPMiddleware):
     """API 토큰 인증 미들웨어.
@@ -22,7 +32,7 @@ class TokenAuthMiddleware(BaseHTTPMiddleware):
     인증 성공 시:
     - request.state.member_id 설정 (AuditMiddleware에서 사용)
     - request.state.member 설정 (라우트 핸들러에서 사용 가능)
-    - MemberService.update_last_active() 호출
+    - last_active_at 갱신 (5분 간격 스로틀링)
 
     헤더가 없으면 인증을 시도하지 않고 다음 미들웨어로 넘긴다.
     """
@@ -46,8 +56,18 @@ class TokenAuthMiddleware(BaseHTTPMiddleware):
             member = await member_service.authenticate(token)
             request.state.member_id = member.member_id
             request.state.member = member
-            await member_service.update_last_active(member.member_id)
+            await self._throttled_update(member_service, member.member_id)
             logger.debug("토큰 인증 성공: %s", member.member_id)
         except PermissionError:
             # 인증 실패는 라우트 핸들러에서 처리
             logger.debug("토큰 인증 실패: 유효하지 않은 토큰")
+
+    @staticmethod
+    async def _throttled_update(member_service: Any, member_id: str) -> None:
+        """5분 간격으로 last_active_at을 갱신한다."""
+        now = datetime.now(UTC)
+        last = _last_updated.get(member_id, _EPOCH)
+        if now - last < _UPDATE_INTERVAL:
+            return
+        await member_service.update_last_active(member_id)
+        _last_updated[member_id] = now

--- a/src/ante/web/middleware/token_auth.py
+++ b/src/ante/web/middleware/token_auth.py
@@ -1,0 +1,53 @@
+"""토큰 인증 미들웨어 — API 토큰 인증 + last_active_at 갱신."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+logger = logging.getLogger(__name__)
+
+# Authorization 헤더 접두어
+_BEARER_PREFIX = "Bearer "
+
+
+class TokenAuthMiddleware(BaseHTTPMiddleware):
+    """API 토큰 인증 미들웨어.
+
+    Authorization: Bearer <token> 헤더가 있으면 토큰 인증을 수행한다.
+    인증 성공 시:
+    - request.state.member_id 설정 (AuditMiddleware에서 사용)
+    - request.state.member 설정 (라우트 핸들러에서 사용 가능)
+    - MemberService.update_last_active() 호출
+
+    헤더가 없으면 인증을 시도하지 않고 다음 미들웨어로 넘긴다.
+    """
+
+    async def dispatch(self, request: Request, call_next: Any) -> Response:
+        auth_header = request.headers.get("authorization", "")
+
+        if auth_header.startswith(_BEARER_PREFIX):
+            token = auth_header[len(_BEARER_PREFIX) :]
+            await self._authenticate_token(request, token)
+
+        return await call_next(request)
+
+    async def _authenticate_token(self, request: Request, token: str) -> None:
+        """토큰 인증 수행. 실패 시 무시 (라우트에서 별도 처리)."""
+        member_service = getattr(request.app.state, "member_service", None)
+        if member_service is None:
+            return
+
+        try:
+            member = await member_service.authenticate(token)
+            request.state.member_id = member.member_id
+            request.state.member = member
+            await member_service.update_last_active(member.member_id)
+            logger.debug("토큰 인증 성공: %s", member.member_id)
+        except PermissionError:
+            # 인증 실패는 라우트 핸들러에서 처리
+            logger.debug("토큰 인증 실패: 유효하지 않은 토큰")

--- a/tests/unit/test_token_auth_middleware.py
+++ b/tests/unit/test_token_auth_middleware.py
@@ -1,0 +1,151 @@
+"""토큰 인증 미들웨어 테스트 — Agent 토큰 인증 시 last_active_at 갱신 검증."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402
+
+
+@dataclass
+class FakeMember:
+    member_id: str
+    type: str = "agent"
+    role: str = "default"
+    org: str = "default"
+    name: str = ""
+    emoji: str = ""
+    status: str = "active"
+    scopes: list[str] = field(default_factory=list)
+    token_hash: str = ""
+    password_hash: str = ""
+    recovery_key_hash: str = ""
+    created_at: str = ""
+    created_by: str = ""
+    last_active_at: str = ""
+    suspended_at: str = ""
+    revoked_at: str = ""
+    token_expires_at: str = ""
+
+
+class TestTokenAuthMiddleware:
+    """TokenAuthMiddleware가 토큰 인증 성공 시 last_active_at을 갱신한다."""
+
+    @pytest.fixture
+    def agent_member(self) -> FakeMember:
+        return FakeMember(
+            member_id="test-agent-01",
+            type="agent",
+            name="테스트 에이전트",
+        )
+
+    @pytest.fixture
+    def member_service(self, agent_member: FakeMember) -> AsyncMock:
+        svc = AsyncMock()
+        svc.authenticate = AsyncMock(return_value=agent_member)
+        svc.update_last_active = AsyncMock()
+        return svc
+
+    @pytest.fixture
+    def app(self, member_service: AsyncMock) -> object:
+        return create_app(member_service=member_service)
+
+    @pytest.fixture
+    def client(self, app: object) -> TestClient:
+        return TestClient(app)
+
+    def test_agent_token_auth_updates_last_active(
+        self,
+        client: TestClient,
+        member_service: AsyncMock,
+        agent_member: FakeMember,
+    ) -> None:
+        """Agent 토큰 인증 성공 시 update_last_active가 호출된다."""
+        resp = client.get(
+            "/api/system/health",
+            headers={"Authorization": "Bearer ante_ak_test_token_123"},
+        )
+        assert resp.status_code == 200
+
+        member_service.authenticate.assert_called_once_with("ante_ak_test_token_123")
+        member_service.update_last_active.assert_called_once_with("test-agent-01")
+
+    def test_no_auth_header_skips_authentication(
+        self,
+        client: TestClient,
+        member_service: AsyncMock,
+    ) -> None:
+        """Authorization 헤더 없으면 인증을 시도하지 않는다."""
+        resp = client.get("/api/system/health")
+        assert resp.status_code == 200
+
+        member_service.authenticate.assert_not_called()
+        member_service.update_last_active.assert_not_called()
+
+    def test_invalid_token_does_not_update_last_active(
+        self,
+        client: TestClient,
+        member_service: AsyncMock,
+    ) -> None:
+        """토큰 인증 실패 시 update_last_active를 호출하지 않는다."""
+        member_service.authenticate = AsyncMock(
+            side_effect=PermissionError("인증 실패")
+        )
+
+        resp = client.get(
+            "/api/system/health",
+            headers={"Authorization": "Bearer invalid_token"},
+        )
+        # 미들웨어는 인증 실패를 무시하고 요청을 통과시킨다
+        assert resp.status_code == 200
+
+        member_service.authenticate.assert_called_once()
+        member_service.update_last_active.assert_not_called()
+
+    def test_non_bearer_auth_header_skips_authentication(
+        self,
+        client: TestClient,
+        member_service: AsyncMock,
+    ) -> None:
+        """Bearer 접두어가 없는 Authorization 헤더는 무시한다."""
+        resp = client.get(
+            "/api/system/health",
+            headers={"Authorization": "Basic dXNlcjpwYXNz"},
+        )
+        assert resp.status_code == 200
+
+        member_service.authenticate.assert_not_called()
+        member_service.update_last_active.assert_not_called()
+
+    def test_member_id_set_on_request_state(
+        self,
+        client: TestClient,
+        member_service: AsyncMock,
+        agent_member: FakeMember,
+    ) -> None:
+        """인증 성공 시 request.state.member_id가 설정된다 (AuditMiddleware 연동)."""
+        # AuditMiddleware가 member_id를 참조하므로, POST 요청으로 확인
+        audit_logger = AsyncMock()
+        audit_logger.log = AsyncMock()
+
+        app = create_app(
+            member_service=member_service,
+            audit_logger=audit_logger,
+        )
+        test_client = TestClient(app)
+
+        # POST 요청으로 AuditMiddleware가 member_id를 사용하는지 확인
+        test_client.post(
+            "/api/system/halt",
+            headers={"Authorization": "Bearer ante_ak_test_token_123"},
+        )
+        # halt는 account_service 없어서 503이지만 미들웨어는 동작함
+        member_service.authenticate.assert_called_once_with("ante_ak_test_token_123")
+        member_service.update_last_active.assert_called_once_with("test-agent-01")

--- a/tests/unit/test_token_auth_middleware.py
+++ b/tests/unit/test_token_auth_middleware.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 
 import pytest
@@ -12,6 +13,7 @@ httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.web.app import create_app  # noqa: E402
+from ante.web.middleware import token_auth as _ta_mod  # noqa: E402
 
 
 @dataclass
@@ -37,6 +39,11 @@ class FakeMember:
 
 class TestTokenAuthMiddleware:
     """TokenAuthMiddleware가 토큰 인증 성공 시 last_active_at을 갱신한다."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_throttle_cache(self) -> None:
+        """각 테스트 전에 스로틀링 캐시를 초기화한다."""
+        _ta_mod._last_updated.clear()
 
     @pytest.fixture
     def agent_member(self) -> FakeMember:
@@ -149,3 +156,40 @@ class TestTokenAuthMiddleware:
         # halt는 account_service 없어서 503이지만 미들웨어는 동작함
         member_service.authenticate.assert_called_once_with("ante_ak_test_token_123")
         member_service.update_last_active.assert_called_once_with("test-agent-01")
+
+    def test_throttle_skips_update_within_interval(
+        self,
+        client: TestClient,
+        member_service: AsyncMock,
+    ) -> None:
+        """5분 이내 재요청 시 update_last_active를 호출하지 않는다."""
+        headers = {"Authorization": "Bearer ante_ak_test_token_123"}
+
+        # 첫 번째 요청: 갱신 발생
+        client.get("/api/system/health", headers=headers)
+        assert member_service.update_last_active.call_count == 1
+
+        # 두 번째 요청: 5분 이내이므로 스킵
+        client.get("/api/system/health", headers=headers)
+        assert member_service.update_last_active.call_count == 1
+
+    def test_throttle_updates_after_interval(
+        self,
+        client: TestClient,
+        member_service: AsyncMock,
+    ) -> None:
+        """5분 경과 후 재요청 시 update_last_active를 다시 호출한다."""
+        headers = {"Authorization": "Bearer ante_ak_test_token_123"}
+
+        # 첫 번째 요청
+        client.get("/api/system/health", headers=headers)
+        assert member_service.update_last_active.call_count == 1
+
+        # 캐시를 6분 전으로 조작
+        _ta_mod._last_updated["test-agent-01"] = datetime.now(UTC) - timedelta(
+            minutes=6
+        )
+
+        # 두 번째 요청: 간격 초과이므로 갱신 발생
+        client.get("/api/system/health", headers=headers)
+        assert member_service.update_last_active.call_count == 2


### PR DESCRIPTION
Refs #599

## Summary

- Agent가 API 토큰(`Authorization: Bearer`)으로 인증할 때 `last_active_at`을 갱신하는 `TokenAuthMiddleware` 추가
- 인메모리 캐시 기반 5분 스로틀링으로 불필요한 DB 쓰기 방지
- 서버 재시작 시 캐시 초기화 → 첫 요청에서만 DB UPDATE 발생 (이후 5분 간격)

## 변경 파일

- `src/ante/web/middleware/token_auth.py` (신규) — 미들웨어 + 스로틀링 로직
- `src/ante/web/middleware/__init__.py` — re-export
- `src/ante/web/app.py` — 미들웨어 등록
- `tests/unit/test_token_auth_middleware.py` (신규) — 7개 테스트

## Test plan

- [x] 토큰 인증 성공 시 `update_last_active` 호출
- [x] 5분 이내 재요청 시 스킵
- [x] 5분 경과 후 재요청 시 재갱신
- [x] 인증 실패/헤더 없음/non-Bearer 시 미호출
- [x] request.state.member_id 설정 (AuditMiddleware 연동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)