### PR TITLE
feat(qa): QA 서버 설정 및 엔트리포인트 작성

### DIFF
--- a/config/system.qa.toml
+++ b/config/system.qa.toml
@@ -1,0 +1,35 @@
+# Ante QA 테스트 전용 설정
+# docker-compose.qa.yml에서 사용한다.
+# Mock 브로커로 실제 거래소 연결 없이 전체 기능을 검증한다.
+
+[system]
+log_level = "DEBUG"
+timezone = "Asia/Seoul"
+
+[db]
+path = "/app/db/ante.db"
+
+[data]
+path = "/app/data/"
+
+[web]
+enabled = true
+host = "0.0.0.0"
+port = 8000
+
+[eventbus]
+history_size = 1000
+
+[broker]
+type = "mock"
+fill_mode = "immediate"
+initial_cash = 100000000.0
+default_price = 50000.0
+commission_rate = 0.00015
+sell_tax_rate = 0.0023
+
+[treasury]
+sync_interval_seconds = 60
+
+[reconcile]
+enabled = false

--- a/scripts/qa-entrypoint.sh
+++ b/scripts/qa-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# QA 테스트 환경 엔트리포인트
+# 1. Ante 서버 백그라운드 기동
+# 2. 헬스체크 대기 (최대 30초)
+# 3. QA Admin 멤버 부트스트랩
+# 4. 서버 포그라운드 전환
+set -e
+
+echo "[qa] Ante 서버 시작 (백그라운드)..."
+python -m ante.main &
+SERVER_PID=$!
+
+echo "[qa] 헬스체크 대기 (최대 30초)..."
+for i in $(seq 1 30); do
+    if python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/system/health')" 2>/dev/null; then
+        echo "[qa] 서버 준비 완료 (${i}초)"
+        break
+    fi
+    if [ "$i" -eq 30 ]; then
+        echo "[qa] 서버 헬스체크 타임아웃 (30초)" >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+echo "[qa] QA Admin 멤버 부트스트랩..."
+# bootstrap은 대화형 패스워드 프롬프트를 사용하므로
+# confirmation_prompt=True → 패스워드를 2번 입력해야 한다
+QA_PASSWORD="${QA_ADMIN_PASSWORD:-qaadmin123!}"
+printf '%s\n%s\n' "$QA_PASSWORD" "$QA_PASSWORD" | \
+    ante member bootstrap --id qa-admin --name "QA Admin" 2>/dev/null || true
+
+echo "[qa] 엔트리포인트 초기화 완료"
+
+# 서버 포그라운드 전환
+wait $SERVER_PID

--- a/tests/unit/test_qa_config.py
+++ b/tests/unit/test_qa_config.py
@@ -1,0 +1,111 @@
+"""QA 서버 설정 및 엔트리포인트 파일 유효성 검증."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tomllib
+from pathlib import Path
+
+# 프로젝트 루트 기준 경로
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+
+
+class TestSystemQaToml:
+    """config/system.qa.toml 유효성 검증."""
+
+    def setup_method(self) -> None:
+        self.path = PROJECT_ROOT / "config" / "system.qa.toml"
+
+    def test_file_exists(self) -> None:
+        assert self.path.exists(), f"{self.path} 파일이 존재하지 않습니다"
+
+    def test_valid_toml(self) -> None:
+        with open(self.path, "rb") as f:
+            config = tomllib.load(f)
+        assert isinstance(config, dict)
+
+    def test_required_sections(self) -> None:
+        with open(self.path, "rb") as f:
+            config = tomllib.load(f)
+        required = ["system", "db", "web", "broker", "treasury"]
+        for section in required:
+            assert section in config, f"[{section}] 섹션이 누락되었습니다"
+
+    def test_debug_log_level(self) -> None:
+        with open(self.path, "rb") as f:
+            config = tomllib.load(f)
+        assert config["system"]["log_level"] == "DEBUG"
+
+    def test_web_enabled_on_port_8000(self) -> None:
+        with open(self.path, "rb") as f:
+            config = tomllib.load(f)
+        assert config["web"]["enabled"] is True
+        assert config["web"]["port"] == 8000
+
+    def test_mock_broker_immediate_fill(self) -> None:
+        with open(self.path, "rb") as f:
+            config = tomllib.load(f)
+        assert config["broker"]["type"] == "mock"
+        assert config["broker"]["fill_mode"] == "immediate"
+
+    def test_db_path_absolute(self) -> None:
+        with open(self.path, "rb") as f:
+            config = tomllib.load(f)
+        db_path = config["db"]["path"]
+        assert db_path == "/app/db/ante.db", (
+            f"Docker 환경에서의 DB 경로가 절대경로여야 합니다: {db_path}"
+        )
+
+
+class TestQaEntrypoint:
+    """scripts/qa-entrypoint.sh 유효성 검증."""
+
+    def setup_method(self) -> None:
+        self.path = PROJECT_ROOT / "scripts" / "qa-entrypoint.sh"
+
+    def test_file_exists(self) -> None:
+        assert self.path.exists(), f"{self.path} 파일이 존재하지 않습니다"
+
+    def test_executable_permission(self) -> None:
+        mode = os.stat(self.path).st_mode
+        assert mode & stat.S_IXUSR, "실행 권한(u+x)이 없습니다"
+
+    def test_valid_bash_syntax(self) -> None:
+        result = subprocess.run(
+            ["bash", "-n", str(self.path)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"bash 구문 오류: {result.stderr}"
+
+    def test_shebang_line(self) -> None:
+        with open(self.path) as f:
+            first_line = f.readline().strip()
+        assert first_line == "#!/bin/bash", f"shebang이 올바르지 않습니다: {first_line}"
+
+    def test_contains_healthcheck_loop(self) -> None:
+        content = self.path.read_text()
+        assert "health" in content, "헬스체크 로직이 포함되어야 합니다"
+        assert "seq 1 30" in content, "30초 헬스체크 대기 루프가 포함되어야 합니다"
+
+    def test_contains_member_bootstrap(self) -> None:
+        content = self.path.read_text()
+        assert "member bootstrap" in content, "멤버 부트스트랩 명령이 포함되어야 합니다"
+
+    def test_contains_server_background_start(self) -> None:
+        content = self.path.read_text()
+        assert "python -m ante.main &" in content, (
+            "서버 백그라운드 기동 명령이 포함되어야 합니다"
+        )
+
+    def test_contains_wait_for_foreground(self) -> None:
+        content = self.path.read_text()
+        assert "wait $SERVER_PID" in content, (
+            "서버 포그라운드 전환(wait)이 포함되어야 합니다"
+        )
+
+    def test_set_e_for_error_handling(self) -> None:
+        content = self.path.read_text()
+        assert "set -e" in content, "set -e로 에러 시 즉시 종료해야 합니다"


### PR DESCRIPTION
## Summary

Refs #607

- `config/system.qa.toml`: QA Docker 컨테이너용 시스템 설정 (Mock 브로커, immediate fill, DEBUG 로그, 절대경로 DB)
- `scripts/qa-entrypoint.sh`: 서버 백그라운드 기동 → 30초 헬스체크 → QA Admin 멤버 부트스트랩 → 포그라운드 전환
- `tests/unit/test_qa_config.py`: TOML 구조/값 유효성 16개 테스트

## Test plan

- [x] TOML 파일 유효성 검증 (필수 섹션, mock 브로커, 포트 8000, DEBUG 로그)
- [x] 엔트리포인트 스크립트 bash 구문 검증
- [x] 헬스체크 루프, 멤버 부트스트랩, 서버 기동/전환 로직 포함 확인
- [x] 기존 단위 테스트 2399건 통과 확인