### PR TITLE
feat(skill): QA 테스트 에이전트 스킬 작성 (#610)

### DIFF
--- a/.claude/skills/qa-tester/SKILL.md
+++ b/.claude/skills/qa-tester/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: qa-tester
+description: Docker 서버에서 Gherkin TC를 실행하고 결과를 리포트하는 QA 테스트 에이전트. 버그 발견 시 GitHub Issue 자동 등록.
+argument-hint: [카테고리|all] [--fix]
+user-invocable: true
+allowed-tools: Bash, Read, Write, Grep, Glob, Agent, WebFetch
+---
+
+# QA 테스트 에이전트
+
+$ARGUMENTS로 테스트 범위를 지정한다.
+
+- `/qa-test account` — account 카테고리 TC만 실행
+- `/qa-test all` — 전체 TC 실행
+- `/qa-test scenario/full-pipeline` — 특정 Feature 실행
+- `/qa-test account --fix` — 실패 시 자동 수정 시도
+
+## 사전 조건
+
+### 1. Docker 컨테이너 확인
+
+```bash
+docker ps --filter name=ante-qa --format '{{.Status}}'
+```
+
+컨테이너가 없거나 실행 중이 아니면 자동으로 기동한다:
+
+```bash
+docker compose -f docker-compose.qa.yml up -d --wait
+```
+
+### 2. 인증 토큰 확보
+
+```bash
+# 멤버 ID 확인
+docker exec ante-qa ante member list --format json
+
+# 토큰 획득
+curl -s -X POST http://localhost:8000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"member_id": "<멤버ID>", "password": "<패스워드>"}'
+```
+
+응답에서 `access_token`을 추출하여 이후 API 호출에 `Authorization: Bearer $TOKEN` 헤더로 사용한다.
+
+## 실행 흐름
+
+### 1단계: .feature 파일 로드
+
+$ARGUMENTS를 파싱하여 대상 TC 파일을 결정한다.
+
+| 인자 | 대상 |
+|------|------|
+| `account` | `tests/tc/account/*.feature` |
+| `all` | `tests/tc/**/*.feature` (전체 재귀 순회) |
+| `scenario/full-pipeline` | `tests/tc/scenario/full-pipeline.feature` |
+
+Glob 도구로 파일 목록을 수집하고, 각 `.feature` 파일을 Read 도구로 읽는다.
+
+### 2단계: Scenario 순차 실행
+
+Feature 파일 내 Scenario를 위에서 아래 순서로 실행한다.
+각 Step을 자연어로 해석하여 실제 명령으로 변환한다.
+
+Step 해석 규칙의 상세는 [gherkin-guide.md](gherkin-guide.md)를 참조한다.
+
+**주요 Step 패턴:**
+
+| Step 패턴 | 실행 방식 |
+|-----------|----------|
+| `When POST/GET/PUT/DELETE /api/...` | curl로 HTTP 요청 |
+| `When 컨테이너에서 실행: ...` | `docker exec ante-qa {명령}` |
+| `Then 응답 상태는 {코드}` | HTTP 상태 코드 검증 |
+| `And 응답 body.{path} 는 ...` | JSON 응답 값 검증 |
+| `And ...를 {변수}로 저장한다` | 응답값을 변수에 저장 |
+| `And N초 대기` | `sleep N` |
+
+### 3단계: 결과 기록
+
+각 Scenario 실행 후 즉시 결과를 판정한다:
+
+| 결과 | 조건 |
+|------|------|
+| **PASS** | 모든 Then/And 검증 통과 |
+| **FAIL** | 검증 불일치 (실제값 vs 기대값 기록) |
+| **ERROR** | 실행 자체 실패 (타임아웃, 연결 오류 등) |
+| **SKIP** | 선행 Scenario 실패로 필요한 변수 미확보 |
+
+### 4단계: 리포트 출력
+
+모든 Scenario 실행 완료 후 [report-format.md](report-format.md)에 정의된 형식으로 리포트를 출력한다.
+
+### 5단계: 버그 처리
+
+FAIL인 Scenario에 대해 GitHub Issue를 자동 등록한다:
+
+```bash
+gh issue create \
+  --title "QA: {Feature명} -- {Scenario명} 실패" \
+  --label bug \
+  --body "## TC 정보
+- Feature: {파일 경로}
+- Scenario: {이름}
+
+## 실패 Step
+{step 원문}
+
+## 기대
+{Then 문}
+
+## 실제
+{응답 상세}"
+```
+
+`--fix` 플래그가 있으면:
+1. 등록된 이슈 번호로 `/implement-issue #{이슈번호}` 호출하여 즉시 수정 시도
+2. 수정 후 해당 Scenario만 재실행하여 검증
+
+## 주의사항
+
+- Feature 내 Scenario는 위에서 아래 순서로 실행되며, 변수를 공유한다.
+- Feature 간 변수는 공유하지 않는다. 새 Feature 파일 진입 시 변수를 초기화한다.
+- 컨테이너 재시작이 필요하면 `docker compose -f docker-compose.qa.yml restart`를 사용한다.
+- Background 블록의 Step은 매 Scenario 실행 전에 검증/실행한다.

--- a/.claude/skills/qa-tester/gherkin-guide.md
+++ b/.claude/skills/qa-tester/gherkin-guide.md
@@ -1,0 +1,247 @@
+# Gherkin Step 해석 가이드
+
+QA 테스트 에이전트가 `.feature` 파일의 Step을 실제 명령으로 변환하는 규칙을 정의한다.
+
+TC 작성 컨벤션은 [tests/tc/README.md](../../../tests/tc/README.md)를 참조한다.
+
+---
+
+## 1. API Step 변환 규칙
+
+### HTTP 요청 실행
+
+`When {METHOD} /api/{path}` 패턴의 Step은 curl 명령으로 변환한다.
+
+```gherkin
+When POST /api/accounts 요청:
+  | field    | value          |
+  | name     | QA 테스트 계좌 |
+  | exchange | KRX            |
+```
+
+변환 결과:
+
+```bash
+curl -s -w '\n%{http_code}' -X POST http://localhost:8000/api/accounts \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "QA 테스트 계좌", "exchange": "KRX"}'
+```
+
+### curl 옵션 규칙
+
+| 옵션 | 용도 |
+|------|------|
+| `-s` | 진행률 출력 억제 |
+| `-w '\n%{http_code}'` | 응답 본문 뒤에 HTTP 상태 코드 출력 |
+| `-X {METHOD}` | HTTP 메서드 지정 |
+| `-H "Authorization: Bearer $TOKEN"` | 인증 헤더 (Background에서 확보한 토큰) |
+| `-H "Content-Type: application/json"` | JSON 요청 본문이 있는 경우 |
+| `-d '{...}'` | JSON 요청 본문 |
+
+### Data Table에서 JSON 변환
+
+Data Table의 `field | value` 행을 JSON 객체로 변환한다.
+
+**타입 추론 규칙:**
+
+| value 형태 | JSON 타입 | 예시 |
+|-----------|-----------|------|
+| 정수 패턴 (`^\d+$`) | number | `10000000` -> `10000000` |
+| 소수점 패턴 (`^\d+\.\d+$`) | number | `0.05` -> `0.05` |
+| `true` / `false` | boolean | `true` -> `true` |
+| `null` | null | `null` -> `null` |
+| `{변수명}` | 변수 치환 후 원래 타입 유지 | `{account_id}` -> 저장된 값 |
+| 그 외 | string | `"QA 테스트 계좌"` |
+
+### 요청 본문 없는 요청
+
+Step이 콜론(`:`)으로 끝나지 않으면 요청 본문이 없는 요청이다.
+
+```gherkin
+When GET /api/accounts/{account_id}
+When DELETE /api/accounts/{account_id}
+```
+
+변환 결과:
+
+```bash
+curl -s -w '\n%{http_code}' -X GET http://localhost:8000/api/accounts/abc-123 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+---
+
+## 2. CLI Step 변환 규칙
+
+`When 컨테이너에서 실행: {명령}` 패턴의 Step은 docker exec로 변환한다.
+
+```gherkin
+When 컨테이너에서 실행: ante account list --format json
+```
+
+변환 결과:
+
+```bash
+docker exec ante-qa ante account list --format json
+```
+
+### 실행 결과 캡처
+
+CLI 실행 결과에서 다음을 캡처한다:
+
+| 항목 | 용도 |
+|------|------|
+| stdout | 표준 출력 (JSON 파싱 또는 텍스트 검색 대상) |
+| stderr | 에러 메시지 (ERROR 판정 시 참조) |
+| exit code | `Then 종료 코드는 {N}` 검증 대상 |
+
+---
+
+## 3. 변수 치환 규칙
+
+### 변수 저장
+
+`{변수명}으로 저장한다` 패턴의 Step에서 응답값을 변수에 저장한다.
+
+```gherkin
+And 응답 body.account_id 를 {account_id}로 저장한다
+```
+
+실행 로직:
+1. 직전 API 응답 JSON에서 `account_id` 필드 값을 추출한다.
+2. 변수 저장소에 `account_id = "추출된 값"` 형태로 저장한다.
+
+```gherkin
+And 첫 번째 항목의 strategy_id 를 {strategy_id}로 저장한다
+```
+
+실행 로직:
+1. 직전 API 응답이 배열이면 첫 번째 요소(`[0]`)에서 `strategy_id`를 추출한다.
+
+### 변수 참조
+
+`{변수명}` 패턴이 Step 텍스트나 Data Table value에 나타나면 저장된 값으로 치환한다.
+
+```gherkin
+When GET /api/accounts/{account_id}
+```
+
+`{account_id}`가 `"abc-123"`으로 저장되어 있으면:
+
+```
+When GET /api/accounts/abc-123
+```
+
+### 미확보 변수 처리
+
+변수가 저장되어 있지 않은 경우 해당 Scenario를 SKIP 처리한다.
+SKIP 사유를 리포트에 명시한다: `SKIP: 변수 {변수명} 미확보 (선행 Scenario 실패)`
+
+---
+
+## 4. 검증 Step 변환 규칙
+
+### HTTP 상태 코드 검증
+
+```gherkin
+Then 응답 상태는 201
+```
+
+curl 출력의 마지막 줄(http_code)을 파싱하여 기대값과 비교한다.
+
+### 복합 조건 (OR)
+
+```gherkin
+Then 응답 상태는 404 또는 응답 body.status 는 "deleted"
+```
+
+`또는`으로 분리된 두 조건 중 하나라도 참이면 PASS.
+
+### JSON body 값 검증
+
+```gherkin
+And 응답 body.name 은 "QA 테스트 계좌"
+And 응답 body.status 는 "active"
+```
+
+JSON 응답에서 dot-path로 값을 추출하여 기대값과 비교한다.
+
+### null 검증
+
+```gherkin
+And 응답 body.account_id 는 null이 아니다
+```
+
+해당 필드가 존재하고 null이 아닌지 검증한다.
+
+### 숫자 비교
+
+```gherkin
+And 응답 body.count 는 0보다 크다
+```
+
+숫자 값을 추출하여 비교 연산을 수행한다.
+
+### 배열 길이 검증
+
+```gherkin
+And 응답 body 배열 길이는 1 이상이다
+```
+
+응답이 배열일 때 길이를 검증한다.
+
+### 포함 여부
+
+```gherkin
+And 응답 body.detail 에 "exchange" 가 포함되어 있다
+And stdout에 {account_id} 가 포함되어 있다
+```
+
+문자열 포함 여부를 검증한다.
+
+### CLI 종료 코드
+
+```gherkin
+Then 종료 코드는 0
+```
+
+docker exec의 종료 코드를 검증한다.
+
+### CLI stdout JSON 검증
+
+```gherkin
+And stdout JSON의 .status 는 "active"
+And stdout JSON 배열 길이는 1 이상이다
+```
+
+stdout을 JSON으로 파싱한 후 값을 검증한다.
+
+---
+
+## 5. Background 처리
+
+Background 블록의 Step은 각 Scenario 실행 전에 실행/검증한다.
+
+```gherkin
+Background:
+  Given ante-qa 컨테이너가 실행 중이다
+  And QA Admin 인증 토큰이 확보되어 있다
+```
+
+| Step | 실행 로직 |
+|------|----------|
+| `Given ante-qa 컨테이너가 실행 중이다` | `docker ps --filter name=ante-qa` 확인. 없으면 `docker compose -f docker-compose.qa.yml up -d --wait` |
+| `And QA Admin 인증 토큰이 확보되어 있다` | 토큰이 없으면 로그인 API 호출하여 확보 |
+
+Background 검증 실패 시 해당 Feature 전체를 ERROR 처리한다.
+
+---
+
+## 6. 대기 Step
+
+```gherkin
+And 3초 대기
+```
+
+`sleep 3`을 실행한다. 봇 실행 사이클 대기 등 비동기 작업에 사용한다.

--- a/.claude/skills/qa-tester/report-format.md
+++ b/.claude/skills/qa-tester/report-format.md
@@ -1,0 +1,190 @@
+# QA 테스트 리포트 출력 포맷
+
+QA 테스트 에이전트가 TC 실행 완료 후 출력하는 리포트의 포맷을 정의한다.
+
+---
+
+## 1. 리포트 구조
+
+리포트는 다음 순서로 구성한다:
+
+1. 요약 헤더
+2. FAIL 상세 (있는 경우)
+3. ERROR 상세 (있는 경우)
+4. SKIP 상세 (있는 경우)
+5. PASS 목록
+
+---
+
+## 2. 요약 헤더
+
+```
+## QA 테스트 리포트
+
+- 실행 시각: 2026-03-20 14:30
+- 대상: account (3 feature files)
+- 결과: 18/22 PASS, 2 FAIL, 1 ERROR, 1 SKIP
+```
+
+| 필드 | 설명 |
+|------|------|
+| 실행 시각 | 테스트 시작 시각 (YYYY-MM-DD HH:MM) |
+| 대상 | 실행한 카테고리 또는 Feature 파일명 |
+| 결과 | 전체 Scenario 수 대비 각 상태 건수 |
+
+---
+
+## 3. FAIL 상세
+
+FAIL은 검증 불일치가 발생한 경우다. 디버깅에 필요한 정보를 모두 포함한다.
+
+```
+### FAIL (2)
+
+**[FAIL] account/crud.feature -- 존재하지 않는 계좌 조회**
+- Step: `When GET /api/accounts/nonexistent-id-12345`
+- 검증: `Then 응답 상태는 404`
+- 기대: 404
+- 실제: 500 -- {"detail": "Internal server error"}
+
+**[FAIL] account/crud.feature -- 필수 필드 누락 계좌 생성**
+- Step: `When POST /api/accounts 요청`
+- 검증: `Then 응답 상태는 422`
+- 기대: 422
+- 실제: 500 -- {"detail": "Internal server error"}
+```
+
+### FAIL 항목 필수 필드
+
+| 필드 | 설명 |
+|------|------|
+| Feature/Scenario | 파일 경로와 Scenario 제목 |
+| Step | 실패가 발생한 When Step 원문 |
+| 검증 | 실패한 Then/And Step 원문 |
+| 기대 | 기대한 값 |
+| 실제 | 실제로 받은 값 (응답 상태 코드 + 본문 요약) |
+
+---
+
+## 4. ERROR 상세
+
+ERROR는 실행 자체가 실패한 경우다 (타임아웃, 연결 오류 등).
+
+```
+### ERROR (1)
+
+**[ERROR] bot/lifecycle.feature -- 봇 시작 및 거래 확인**
+- Step: `When POST /api/bots/{bot_id}/start`
+- 오류: Connection refused -- http://localhost:8000 연결 불가
+```
+
+---
+
+## 5. SKIP 상세
+
+SKIP은 선행 Scenario 실패로 필요한 변수가 확보되지 않은 경우다.
+
+```
+### SKIP (1)
+
+**[SKIP] account/crud.feature -- 생성된 계좌 조회 (API)**
+- 사유: 변수 {account_id} 미확보 (선행 Scenario "계좌 생성 (API)" 실패)
+```
+
+---
+
+## 6. PASS 목록
+
+PASS는 간결하게 목록으로 출력한다.
+
+```
+### PASS (18)
+
+- [PASS] account/crud.feature -- 계좌 생성 (API)
+- [PASS] account/crud.feature -- 계좌 목록 조회 (CLI)
+- [PASS] account/crud.feature -- 계좌 정보 조회 (CLI)
+- [PASS] account/crud.feature -- 계좌 이름 수정 (API)
+- [PASS] account/crud.feature -- 계좌 삭제 (CLI)
+- [PASS] account/lifecycle.feature -- 계좌 정지 (API)
+...
+```
+
+---
+
+## 7. GitHub Issue 본문 템플릿
+
+FAIL 항목에 대해 자동 생성하는 GitHub Issue의 본문 형식:
+
+```markdown
+## TC 정보
+- Feature: tests/tc/account/crud.feature
+- Scenario: 존재하지 않는 계좌 조회
+
+## 실패 Step
+When GET /api/accounts/nonexistent-id-12345
+
+## 기대
+응답 상태는 404
+
+## 실제
+응답 상태 500 -- {"detail": "Internal server error"}
+
+## 재현 명령
+curl -s -X GET http://localhost:8000/api/accounts/nonexistent-id-12345 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Issue 제목 형식
+
+```
+QA: {Feature명} -- {Scenario명} 실패
+```
+
+예시: `QA: 계좌 CRUD -- 존재하지 않는 계좌 조회 실패`
+
+### Issue 라벨
+
+자동 생성 Issue에는 `bug` 라벨을 부여한다.
+
+---
+
+## 8. 복수 Feature 실행 시 리포트
+
+`/qa-test all`처럼 여러 Feature를 실행하는 경우, Feature별로 섹션을 나누어 출력한다.
+
+```
+## QA 테스트 리포트
+
+- 실행 시각: 2026-03-20 14:30
+- 대상: all (8 feature files)
+- 결과: 95/102 PASS, 5 FAIL, 1 ERROR, 1 SKIP
+
+---
+
+### account/ (3 files, 22 scenarios)
+- 결과: 20/22 PASS, 2 FAIL
+
+### bot/ (3 files, 20 scenarios)
+- 결과: 18/20 PASS, 1 FAIL, 1 ERROR
+
+### treasury/ (2 files, 10 scenarios)
+- 결과: 10/10 PASS
+
+...
+
+---
+
+### FAIL (5)
+(FAIL 상세 항목들)
+
+### ERROR (1)
+(ERROR 상세 항목들)
+
+### SKIP (1)
+(SKIP 상세 항목들)
+
+### PASS (95)
+(PASS 목록)
+```
+
+Feature 별 요약을 먼저 보여준 뒤, 전체 FAIL/ERROR/SKIP/PASS 상세를 아래에 출력한다.

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # Agent 참고 자료 (설계 문서, 스펙, 런북 — 로컬 관리)
 CLAUDE.md
 AGENT.md
-.claude/
+.claude/*
+!.claude/skills/
 docs/
 
 # Runtime data (루트 디렉토리만 — src/ante/data/ 는 소스코드)


### PR DESCRIPTION
## Summary

- `.claude/skills/qa-tester/` 디렉토리 신규 생성
- **SKILL.md**: `/qa-test` 스킬 메타데이터 및 실행 흐름 정의 (컨테이너 확인, 인증 토큰 확보, TC 로드, Scenario 순차 실행, 결과 기록, 리포트 출력, 버그 자동 등록)
- **gherkin-guide.md**: Step 패턴별 실행 방법 레퍼런스 (API→curl 변환, CLI→docker exec 변환, 변수 치환, 검증 규칙)
- **report-format.md**: PASS/FAIL/ERROR/SKIP 리포트 출력 포맷 및 GitHub Issue 본문 템플릿
- `.gitignore` 수정: `.claude/skills/` 디렉토리를 Git 추적 대상으로 허용

Closes #610

## Test plan

- [ ] `/qa-test account` 호출 시 SKILL.md가 스킬로 인식되는지 확인
- [ ] gherkin-guide.md의 변환 규칙이 tests/tc/README.md 컨벤션과 일치하는지 확인
- [ ] report-format.md의 포맷이 qa-agent-testing-plan.md 설계와 일치하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)