### PR TITLE
test(tc): Bot 모듈 TC 작성 — crud + lifecycle + budget (#614)

### DIFF
--- a/tests/tc/bot/budget.feature
+++ b/tests/tc/bot/budget.feature
@@ -1,0 +1,92 @@
+Feature: 봇 자금 관리
+  봇에 대한 자금 할당(allocate) 및 회수(deallocate)를 검증한다.
+
+  Background:
+    Given ante-qa 컨테이너가 실행 중이다
+    And QA Admin 인증 토큰이 확보되어 있다
+
+  # ── 사전 준비: 계좌 + 잔고 + 봇 ──
+
+  Scenario: 자금 테스트용 계좌 생성 (API)
+    When POST /api/accounts 요청:
+      | field               | value                |
+      | account_id          | qa-bot-budget-acct   |
+      | name                | 봇 자금 테스트 계좌  |
+      | exchange            | KRX                  |
+      | currency            | KRW                  |
+      | timezone            | Asia/Seoul           |
+      | trading_hours_start | 09:00                |
+      | trading_hours_end   | 15:30                |
+      | trading_mode        | virtual              |
+      | broker_type         | mock                 |
+    Then 응답 상태는 201
+    And 응답 body.account.account_id 를 {account_id}로 저장한다
+
+  Scenario: 자금 테스트용 잔고 설정 (API)
+    When POST /api/treasury/balance 요청:
+      | field   | value    |
+      | balance | 10000000 |
+    Then 응답 상태는 200
+    And 응답 body.total_balance 는 0보다 크다
+
+  Scenario: 자금 테스트용 전략 확인 (API)
+    When GET /api/strategies
+    Then 응답 상태는 200
+    And 첫 번째 항목의 strategy_id 를 {strategy_id}로 저장한다
+
+  Scenario: 자금 테스트용 봇 생성 (API)
+    When POST /api/bots 요청:
+      | field            | value              |
+      | bot_id           | qa-bot-budget-01   |
+      | strategy_id      | {strategy_id}      |
+      | name             | 자금 테스트 봇     |
+      | account_id       | {account_id}       |
+      | interval_seconds | 60                 |
+    Then 응답 상태는 201
+    And 응답 body.bot.bot_id 를 {bot_id}로 저장한다
+
+  # ── 정상 흐름: 할당 → 회수 ──
+
+  Scenario: 봇에 자금 할당 (API)
+    When POST /api/treasury/bots/{bot_id}/allocate 요청:
+      | field  | value   |
+      | amount | 1000000 |
+    Then 응답 상태는 200
+    And 응답 body.bot_id 는 "{bot_id}"
+    And 응답 body.allocated 는 0보다 크다
+
+  Scenario: 자금 회수 (API)
+    When POST /api/treasury/bots/{bot_id}/deallocate 요청:
+      | field  | value  |
+      | amount | 500000 |
+    Then 응답 상태는 200
+    And 응답 body.bot_id 는 "{bot_id}"
+    And 응답 body.allocated 는 0보다 크다
+
+  # ── 에러 케이스 ──
+
+  Scenario: 할당 초과 시 에러 (API)
+    When POST /api/treasury/bots/{bot_id}/allocate 요청:
+      | field  | value         |
+      | amount | 999999999999  |
+    Then 응답 상태는 400
+
+  Scenario: 실행 중 봇 자금 회수 거부 (API)
+    # 봇 시작
+    When POST /api/bots/{bot_id}/start
+    Then 응답 상태는 200
+    And 3초 대기
+    # 실행 중 자금 회수 시도 → 거부
+    When POST /api/treasury/bots/{bot_id}/deallocate 요청:
+      | field  | value  |
+      | amount | 100000 |
+    Then 응답 상태는 409
+    # 정리: 봇 정지
+    When POST /api/bots/{bot_id}/stop
+    Then 응답 상태는 200
+
+  Scenario: 가용 예산 초과 회수 시 에러 (API)
+    When POST /api/treasury/bots/{bot_id}/deallocate 요청:
+      | field  | value         |
+      | amount | 999999999999  |
+    Then 응답 상태는 400

--- a/tests/tc/bot/crud.feature
+++ b/tests/tc/bot/crud.feature
@@ -1,0 +1,97 @@
+Feature: 봇 CRUD
+  Ante 시스템의 봇 생성, 조회, 목록, 삭제를 검증한다.
+
+  Background:
+    Given ante-qa 컨테이너가 실행 중이다
+    And QA Admin 인증 토큰이 확보되어 있다
+
+  # ── 사전 준비: 테스트용 계좌 + 전략 ──
+
+  Scenario: CRUD 테스트용 계좌 생성 (API)
+    When POST /api/accounts 요청:
+      | field               | value              |
+      | account_id          | qa-bot-crud-acct   |
+      | name                | 봇 CRUD 테스트 계좌 |
+      | exchange            | KRX                |
+      | currency            | KRW                |
+      | timezone            | Asia/Seoul         |
+      | trading_hours_start | 09:00              |
+      | trading_hours_end   | 15:30              |
+      | trading_mode        | virtual            |
+      | broker_type         | mock               |
+    Then 응답 상태는 201
+    And 응답 body.account.account_id 를 {account_id}로 저장한다
+
+  Scenario: CRUD 테스트용 전략 등록 확인 (API)
+    When GET /api/strategies
+    Then 응답 상태는 200
+    And 응답 body 배열 길이는 1 이상이다
+    And 첫 번째 항목의 strategy_id 를 {strategy_id}로 저장한다
+
+  # ── 정상 흐름: 봇 CRUD ──
+
+  Scenario: 봇 생성 (API)
+    When POST /api/bots 요청:
+      | field            | value            |
+      | bot_id           | qa-bot-crud-01   |
+      | strategy_id      | {strategy_id}    |
+      | name             | QA 테스트 봇     |
+      | account_id       | {account_id}     |
+      | interval_seconds | 60               |
+    Then 응답 상태는 201
+    And 응답 body.bot.bot_id 는 null이 아니다
+    And 응답 body.bot.name 은 "QA 테스트 봇"
+    And 응답 body.bot.bot_id 를 {bot_id}로 저장한다
+
+  Scenario: 봇 생성 (CLI)
+    When 컨테이너에서 실행: ante bot create --name "CLI 테스트 봇" --strategy {strategy_id} --account {account_id} --id qa-bot-crud-02 --format json
+    Then 종료 코드는 0
+    And stdout에 "qa-bot-crud-02" 가 포함되어 있다
+
+  Scenario: 봇 목록 조회 (API)
+    When GET /api/bots
+    Then 응답 상태는 200
+    And 응답 body.bots 배열 길이는 2 이상이다
+
+  Scenario: 봇 목록 조회 (CLI)
+    When 컨테이너에서 실행: ante bot list --format json
+    Then 종료 코드는 0
+    And stdout JSON 배열 길이는 1 이상이다
+
+  Scenario: 봇 상세 조회 (API)
+    When GET /api/bots/{bot_id}
+    Then 응답 상태는 200
+    And 응답 body.bot.bot_id 는 "{bot_id}"
+    And 응답 body.bot.name 은 "QA 테스트 봇"
+
+  Scenario: 봇 상세 조회 (CLI)
+    When 컨테이너에서 실행: ante bot info {bot_id} --format json
+    Then 종료 코드는 0
+    And stdout에 {bot_id} 가 포함되어 있다
+    And stdout JSON의 .name 은 "QA 테스트 봇"
+
+  # ── 삭제 ──
+
+  Scenario: 봇 삭제 (API)
+    When DELETE /api/bots/qa-bot-crud-02
+    Then 응답 상태는 204
+
+  Scenario: 봇 삭제 (CLI)
+    When 컨테이너에서 실행: ante bot remove {bot_id} --yes
+    Then 종료 코드는 0
+
+  # ── 에러 케이스 ──
+
+  Scenario: 존재하지 않는 봇 조회 (API)
+    When GET /api/bots/nonexistent-bot-12345
+    Then 응답 상태는 404
+
+  Scenario: 잘못된 strategy_id로 봇 생성 (API)
+    When POST /api/bots 요청:
+      | field            | value                     |
+      | bot_id           | qa-bot-crud-bad           |
+      | strategy_id      | nonexistent-strategy-9999 |
+      | name             | 잘못된 전략 봇            |
+      | account_id       | {account_id}              |
+      | interval_seconds | 60                        |
+    Then 응답 상태는 404

--- a/tests/tc/bot/lifecycle.feature
+++ b/tests/tc/bot/lifecycle.feature
@@ -1,0 +1,103 @@
+Feature: 봇 생명주기
+  봇의 상태 전이(생성 → 시작 → 정지 → 재시작 → 삭제)를 검증한다.
+
+  Background:
+    Given ante-qa 컨테이너가 실행 중이다
+    And QA Admin 인증 토큰이 확보되어 있다
+
+  # ── 사전 준비: 테스트용 계좌 + 전략 + 봇 ──
+
+  Scenario: 생명주기 테스트용 계좌 생성 (API)
+    When POST /api/accounts 요청:
+      | field               | value                |
+      | account_id          | qa-bot-life-acct     |
+      | name                | 봇 생명주기 테스트 계좌 |
+      | exchange            | KRX                  |
+      | currency            | KRW                  |
+      | timezone            | Asia/Seoul           |
+      | trading_hours_start | 09:00                |
+      | trading_hours_end   | 15:30                |
+      | trading_mode        | virtual              |
+      | broker_type         | mock                 |
+    Then 응답 상태는 201
+    And 응답 body.account.account_id 를 {account_id}로 저장한다
+
+  Scenario: 생명주기 테스트용 인증정보 설정 (CLI)
+    When 컨테이너에서 실행: ante account set-credentials {account_id} --app-key test-key --app-secret test-secret --format json
+    Then 종료 코드는 0
+
+  Scenario: 생명주기 테스트용 전략 확인 (API)
+    When GET /api/strategies
+    Then 응답 상태는 200
+    And 첫 번째 항목의 strategy_id 를 {strategy_id}로 저장한다
+
+  Scenario: 생명주기 테스트용 봇 생성 (API)
+    When POST /api/bots 요청:
+      | field            | value            |
+      | bot_id           | qa-bot-life-01   |
+      | strategy_id      | {strategy_id}    |
+      | name             | 생명주기 테스트 봇 |
+      | account_id       | {account_id}     |
+      | interval_seconds | 60               |
+    Then 응답 상태는 201
+    And 응답 body.bot.bot_id 를 {bot_id}로 저장한다
+
+  # ── 정상 흐름: 시작 → 정지 → 재시작 ──
+
+  Scenario: 봇 시작 (API)
+    When POST /api/bots/{bot_id}/start
+    Then 응답 상태는 200
+    And 응답 body.bot.bot_id 는 "{bot_id}"
+
+  Scenario: 봇 시작 후 상태 확인 (API)
+    And 3초 대기
+    When GET /api/bots/{bot_id}
+    Then 응답 상태는 200
+    And 응답 body.bot.status 는 "running"
+
+  Scenario: 봇 정지 (API)
+    When POST /api/bots/{bot_id}/stop
+    Then 응답 상태는 200
+    And 응답 body.bot.bot_id 는 "{bot_id}"
+
+  Scenario: 봇 정지 후 상태 확인 (API)
+    When GET /api/bots/{bot_id}
+    Then 응답 상태는 200
+    And 응답 body.bot.status 는 "stopped"
+
+  Scenario: 정지된 봇 재시작 (API)
+    When POST /api/bots/{bot_id}/start
+    Then 응답 상태는 200
+    And 응답 body.bot.bot_id 는 "{bot_id}"
+
+  Scenario: 재시작 후 정지 (API)
+    And 3초 대기
+    When POST /api/bots/{bot_id}/stop
+    Then 응답 상태는 200
+
+  # ── CLI: Signal Key / 포지션 ──
+
+  Scenario: Signal Key 조회 (CLI)
+    When 컨테이너에서 실행: ante bot signal-key {bot_id} --format json
+    Then 종료 코드는 0
+    And stdout에 {bot_id} 가 포함되어 있다
+
+  Scenario: 봇 포지션 조회 (CLI)
+    When 컨테이너에서 실행: ante bot positions {bot_id} --format json
+    Then 종료 코드는 0
+
+  # ── 에러 케이스 ──
+
+  Scenario: 이미 실행 중인 봇 재시작 시도 (API)
+    When POST /api/bots/{bot_id}/start
+    Then 응답 상태는 200
+    And 3초 대기
+    When POST /api/bots/{bot_id}/start
+    Then 응답 상태는 409
+
+  Scenario: 이미 정지된 봇 재정지 시도 (API)
+    When POST /api/bots/{bot_id}/stop
+    Then 응답 상태는 200
+    And 3초 대기
+    When POST /api/bots/{bot_id}/stop
+    Then 응답 상태는 409


### PR DESCRIPTION
## Summary
- Bot CRUD TC 작성 (12 Scenario): 생성/조회/목록/삭제 API+CLI, 에러 케이스 포함
- Bot 생명주기 TC 작성 (14 Scenario): 시작/정지/재시작, Signal Key/포지션 CLI, 상태 충돌 에러
- Bot 자금 관리 TC 작성 (9 Scenario): 할당/회수, 초과 할당/실행 중 회수 거부 에러

## Test plan
- [ ] `/qa-test bot` 전체 PASS
- [ ] crud.feature ~12 Scenario
- [ ] lifecycle.feature ~14 Scenario
- [ ] budget.feature ~9 Scenario

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)