### PR TITLE
fix(qa): QA 환경에 qa_sample.py 전략 파일 추가

### DIFF
--- a/Dockerfile.qa
+++ b/Dockerfile.qa
@@ -17,6 +17,9 @@ RUN pip install --no-cache-dir .
 # 런타임 디렉토리
 RUN mkdir -p config data db strategies
 
+# QA용 샘플 전략 파일
+COPY strategies/qa_sample.py strategies/
+
 # QA용 설정
 COPY config/system.qa.toml config/system.toml
 

--- a/strategies/qa_sample.py
+++ b/strategies/qa_sample.py
@@ -1,0 +1,31 @@
+"""QA 테스트용 최소 샘플 전략.
+
+전략 검증 API(/api/strategies/validate)의 정상 동작을 확인하기 위한
+최소 구현체다. 실제 매매 로직은 포함하지 않는다.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+STRATEGY_VERSION = "0.1.0"
+
+
+class QaSampleStrategy(Strategy):
+    """QA 검증용 샘플 전략."""
+
+    meta = StrategyMeta(
+        name="qa_sample",
+        version=STRATEGY_VERSION,
+        description="QA 테스트 전용 샘플 전략",
+        author="qa",
+        symbols=["005930"],
+        timeframe="1d",
+        exchange="KRX",
+    )
+
+    async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+        """시그널 없이 빈 리스트를 반환한다."""
+        return []


### PR DESCRIPTION
## Summary
- QA TC에서 `/api/strategies/validate` 호출 시 `/app/strategies/qa_sample.py`가 컨테이너에 없어 404 발생하던 문제 수정
- `strategies/qa_sample.py`: `StrategyValidator`를 통과하는 최소 샘플 전략 파일 생성
- `Dockerfile.qa`: 해당 파일을 컨테이너에 COPY하는 명령 추가

## Test plan
- [x] `ruff check` / `ruff format` 통과
- [x] `pytest tests/ -v` 전체 통과 (2397 passed)
- [ ] QA 컨테이너 빌드 후 `POST /api/strategies/validate {"path": "/app/strategies/qa_sample.py"}` → 200 확인

Refs #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)