### PR TITLE
fix(qa): QA 엔트리포인트에 동적 설정 시드 등록

### DIFF
--- a/scripts/qa-entrypoint.sh
+++ b/scripts/qa-entrypoint.sh
@@ -30,6 +30,9 @@ QA_PASSWORD="${QA_ADMIN_PASSWORD:-qaadmin123!}"
 printf '%s\n%s\n' "$QA_PASSWORD" "$QA_PASSWORD" | \
     ante member bootstrap --id qa-admin --name "QA Admin" 2>/dev/null || true
 
+echo "[qa] QA 테스트용 동적 설정 시드 등록..."
+sqlite3 db/ante.db "INSERT OR IGNORE INTO dynamic_config (key, value, category, updated_at) VALUES ('risk.test_qa_key', '0', 'risk', datetime('now'));"
+
 echo "[qa] 엔트리포인트 초기화 완료"
 
 # 서버 포그라운드 전환


### PR DESCRIPTION
## Summary
- QA TC에서 `PUT /api/config/risk.test_qa_key` 호출 시 해당 키가 미등록이라 404가 반환되는 문제 수정
- `scripts/qa-entrypoint.sh`에서 서버 기동 후 `sqlite3`로 `risk.test_qa_key` 설정을 사전 등록
- API 로직(미등록 키 → 404)은 유지하여 TC 에러 케이스(`nonexistent.key.12345` → 404)도 정상 동작

## 방안 선택 근거
3가지 방안 중 **방안 1(QA 시드)** 선택:
- 시스템 코드 변경 없음 (QA 엔트리포인트 쉘 스크립트만 수정)
- PUT API의 미등록 키 404 동작 유지 → TC 에러 케이스도 통과
- `DynamicConfigService.set()`이 이미 upsert를 지원하지만, API 레이어의 exists 체크를 제거하면 에러 케이스 TC가 실패

## Test plan
- [x] `pytest tests/ -v` 전체 통과 (2397 passed)
- [ ] QA 컨테이너 환경에서 TC `동적 설정 변경 (API)` 시나리오 통과 확인

Refs #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)