### PR TITLE
feat(cli): CLI 전 커맨드에 --format json 옵션 추가

### DIFF
--- a/src/ante/cli/__init__.py
+++ b/src/ante/cli/__init__.py
@@ -1,6 +1,6 @@
 """CLI — ante 커맨드 인터페이스."""
 
-from ante.cli.formatter import OutputFormatter
+from ante.cli.formatter import OutputFormatter, format_option
 from ante.cli.main import cli
 
-__all__ = ["OutputFormatter", "cli"]
+__all__ = ["OutputFormatter", "cli", "format_option"]

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import click
 
+from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
 
@@ -154,6 +155,7 @@ def account_create(ctx: click.Context) -> None:
     default=None,
     help="상태 필터 (active/suspended/deleted)",
 )
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("account:read")
@@ -196,6 +198,7 @@ def account_list(ctx: click.Context, status_filter: str | None) -> None:
 
 @account.command("info")
 @click.argument("account_id")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("account:read")
@@ -288,13 +291,20 @@ def account_activate(ctx: click.Context, account_id: str) -> None:
 
 @account.command("delete")
 @click.argument("account_id")
+@click.option(
+    "--yes", "skip_confirm", is_flag=True, default=False, help="확인 없이 삭제"
+)
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("account:write")
-def account_delete(ctx: click.Context, account_id: str) -> None:
+def account_delete(ctx: click.Context, account_id: str, skip_confirm: bool) -> None:
     """계좌 삭제 (소프트 딜리트)."""
     fmt = get_formatter(ctx)
     member_id = get_member_id(ctx)
+
+    if not skip_confirm:
+        click.confirm(f'계좌 "{account_id}"를 삭제하시겠습니까?', abort=True)
 
     async def _do_delete() -> None:
         svc, db = await _create_account_service()
@@ -317,6 +327,7 @@ def account_delete(ctx: click.Context, account_id: str) -> None:
 
 @account.command("credentials")
 @click.argument("account_id")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("account:read")
@@ -356,11 +367,19 @@ def account_credentials(ctx: click.Context, account_id: str) -> None:
 
 @account.command("set-credentials")
 @click.argument("account_id")
+@click.option("--app-key", default=None, help="APP_KEY (비대화형)")
+@click.option("--app-secret", default=None, help="APP_SECRET (비대화형)")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("account:write")
-def account_set_credentials(ctx: click.Context, account_id: str) -> None:
-    """인증 정보 재설정 (대화형)."""
+def account_set_credentials(
+    ctx: click.Context,
+    account_id: str,
+    app_key: str | None,
+    app_secret: str | None,
+) -> None:
+    """인증 정보 재설정 (대화형 또는 --app-key/--app-secret 옵션)."""
     fmt = get_formatter(ctx)
 
     from ante.account.presets import BROKER_PRESETS
@@ -375,12 +394,24 @@ def account_set_credentials(ctx: click.Context, account_id: str) -> None:
                 fmt.output({"message": msg})
                 return
 
-            new_credentials: dict[str, str] = {}
-            click.echo(f"\n인증 정보 재설정 ({account_id})")
-            for cred_key in preset.required_credentials:
-                hide = cred_key.lower() in ("app_secret", "secret", "password")
-                value = click.prompt(cred_key.upper(), hide_input=hide)
-                new_credentials[cred_key] = value
+            # CLI 옵션으로 전달된 인증 정보가 있으면 비대화형 처리
+            cli_creds: dict[str, str] = {}
+            if app_key is not None:
+                cli_creds["app_key"] = app_key
+            if app_secret is not None:
+                cli_creds["app_secret"] = app_secret
+
+            if cli_creds:
+                # CLI 옵션으로 전달된 값 사용
+                new_credentials = cli_creds
+            else:
+                # 대화형 입력
+                new_credentials = {}
+                click.echo(f"\n인증 정보 재설정 ({account_id})")
+                for cred_key in preset.required_credentials:
+                    hide = cred_key.lower() in ("app_secret", "secret", "password")
+                    value = click.prompt(cred_key.upper(), hide_input=hide)
+                    new_credentials[cred_key] = value
 
             await svc.update(account_id, credentials=new_credentials)
             fmt.success(f'계좌 "{account_id}" 인증 정보 재설정 완료')

--- a/src/ante/cli/commands/config.py
+++ b/src/ante/cli/commands/config.py
@@ -7,6 +7,7 @@ import json
 
 import click
 
+from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
 
@@ -96,6 +97,7 @@ def _render_list(result: list[dict], fmt) -> None:  # noqa: ANN001
 
 @config.command("get")
 @click.argument("key", required=False, default=None)
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("config:read")
@@ -123,6 +125,7 @@ def config_get(ctx: click.Context, key: str | None) -> None:
 @config.command("set")
 @click.argument("key")
 @click.argument("value")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("config:write")
@@ -185,6 +188,7 @@ def config_set(ctx: click.Context, key: str, value: str) -> None:
 @config.command("history")
 @click.argument("key")
 @click.option("--limit", "-n", default=20, help="조회 건수 (기본 20)")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("config:read")

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -6,6 +6,7 @@ import asyncio
 
 import click
 
+from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
 
@@ -90,6 +91,7 @@ def bootstrap(ctx: click.Context, member_id: str, name: str) -> None:
 @click.option(
     "--status", type=click.Choice(["active", "suspended", "revoked"]), help="상태 필터"
 )
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("member:read")
@@ -202,6 +204,7 @@ def member_info(ctx: click.Context, member_id: str) -> None:
 @click.option("--org", default="default", help="소속 조직")
 @click.option("--name", default="", help="표시 이름")
 @click.option("--scopes", default="", help="권한 범위 (쉼표 구분)")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("member:admin")

--- a/src/ante/cli/commands/strategy.py
+++ b/src/ante/cli/commands/strategy.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import click
 
+from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
 
@@ -170,6 +171,7 @@ def submit(ctx: click.Context, path: str) -> None:
 @click.option(
     "--status", default=None, help="상태 필터 (registered/active/inactive/archived)"
 )
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("strategy:read")
@@ -216,6 +218,7 @@ def strategy_list(ctx: click.Context, status: str | None) -> None:
 
 @strategy.command("info")
 @click.argument("name")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("strategy:read")

--- a/src/ante/cli/commands/trade.py
+++ b/src/ante/cli/commands/trade.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 import click
 
+from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
 
@@ -46,6 +47,7 @@ async def _create_trade_service():  # noqa: ANN202
 @click.option("--from", "from_date", default=None, help="시작일 (YYYY-MM-DD)")
 @click.option("--to", "to_date", default=None, help="종료일 (YYYY-MM-DD)")
 @click.option("--limit", default=50, help="최대 조회 수")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("trade:read")
@@ -100,6 +102,7 @@ def trade_list(
 
 @trade.command("info")
 @click.argument("trade_id")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("trade:read")

--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -6,6 +6,7 @@ import asyncio
 
 import click
 
+from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
 
@@ -50,6 +51,7 @@ async def _create_treasury(account_id: str | None = None):  # noqa: ANN202
 
 @treasury.command()
 @click.option("--account", "account_id", default=None, help="계좌 ID로 필터링")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("treasury:read")

--- a/src/ante/cli/formatter.py
+++ b/src/ante/cli/formatter.py
@@ -2,9 +2,41 @@
 
 from __future__ import annotations
 
+import functools
 import json
+from typing import TYPE_CHECKING
 
 import click
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def format_option(fn: Callable) -> Callable:
+    """서브커맨드용 --format 옵션 데코레이터.
+
+    루트 그룹의 --format 보다 서브커맨드의 --format이 우선한다.
+    ``ante account list --format json`` 형태 호출을 지원한다.
+    """
+
+    @click.option(
+        "--format",
+        "output_format",
+        type=click.Choice(["text", "json"]),
+        default=None,
+        help="출력 형식 (text 또는 json)",
+    )
+    @functools.wraps(fn)
+    def wrapper(
+        *args: object, output_format: str | None = None, **kwargs: object
+    ) -> object:
+        if output_format is not None:
+            ctx = click.get_current_context()
+            ctx.obj["format"] = output_format
+            ctx.obj["formatter"] = OutputFormatter(output_format)
+        return fn(*args, **kwargs)
+
+    return wrapper
 
 
 class OutputFormatter:

--- a/tests/unit/test_account_cli.py
+++ b/tests/unit/test_account_cli.py
@@ -291,9 +291,22 @@ class TestAccountStateTransitions:
         assert "활성화 완료" in result.output
         mock_account_service.activate.assert_called_once()
 
-    def test_delete(self, mock_account_service: AsyncMock) -> None:
-        """계좌 삭제."""
-        result = _invoke(["account", "delete", "domestic"])
+    def test_delete_with_yes(self, mock_account_service: AsyncMock) -> None:
+        """계좌 삭제 (--yes 옵션)."""
+        result = _invoke(["account", "delete", "domestic", "--yes"])
         assert result.exit_code == 0
         assert "삭제 완료" in result.output
         mock_account_service.delete.assert_called_once()
+
+    def test_delete_with_confirm(self, mock_account_service: AsyncMock) -> None:
+        """계좌 삭제 (확인 프롬프트 y 입력)."""
+        result = _invoke(["account", "delete", "domestic"], input_text="y\n")
+        assert result.exit_code == 0
+        assert "삭제 완료" in result.output
+        mock_account_service.delete.assert_called_once()
+
+    def test_delete_abort(self, mock_account_service: AsyncMock) -> None:
+        """계좌 삭제 취소 (확인 프롬프트 n 입력)."""
+        result = _invoke(["account", "delete", "domestic"], input_text="n\n")
+        assert result.exit_code == 1
+        mock_account_service.delete.assert_not_called()

--- a/tests/unit/test_cli_format_option.py
+++ b/tests/unit/test_cli_format_option.py
@@ -1,0 +1,514 @@
+"""CLI --format json 서브커맨드 뒤 배치 테스트.
+
+이슈 #632: QA TC에서 `ante account list --format json` 형태로 호출할 때
+서브커맨드 뒤의 --format 옵션이 올바르게 동작하는지 검증한다.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    """인증된 상태의 CliRunner."""
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _mock_db() -> MagicMock:
+    db = MagicMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    return db
+
+
+# ── member list --format json ────────────────────────────
+
+
+class TestMemberListFormatOption:
+    """ante member list --format json (서브커맨드 뒤 배치)."""
+
+    def test_format_after_subcommand(self, runner: CliRunner) -> None:
+        """member list --format json 이 올바르게 JSON 출력."""
+        svc = MagicMock()
+        db = _mock_db()
+        svc.list = AsyncMock(return_value=[])
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new_callable=AsyncMock,
+            return_value=(svc, db),
+        ):
+            result = runner.invoke(cli, ["member", "list", "--format", "json"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert "members" in data or "message" in data
+
+    def test_format_before_subcommand_still_works(self, runner: CliRunner) -> None:
+        """--format json member list (루트 옵션) 도 여전히 동작."""
+        svc = MagicMock()
+        db = _mock_db()
+        svc.list = AsyncMock(return_value=[])
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new_callable=AsyncMock,
+            return_value=(svc, db),
+        ):
+            result = runner.invoke(cli, ["--format", "json", "member", "list"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert "members" in data or "message" in data
+
+
+# ── member register --format json ────────────────────────
+
+
+class TestMemberRegisterFormatOption:
+    """ante member register ... --format json."""
+
+    def test_register_format_after(self, runner: CliRunner) -> None:
+        """register --format json 이 JSON 출력."""
+        svc = MagicMock()
+        db = _mock_db()
+        mock_member = MagicMock()
+        mock_member.member_id = "new-agent"
+        mock_member.type = "agent"
+        mock_member.role = "member"
+        mock_member.org = "default"
+        mock_member.name = "Agent"
+        svc.register = AsyncMock(return_value=(mock_member, "token-123"))
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new_callable=AsyncMock,
+            return_value=(svc, db),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "member",
+                    "register",
+                    "--id",
+                    "new-agent",
+                    "--type",
+                    "agent",
+                    "--format",
+                    "json",
+                ],
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["member_id"] == "new-agent"
+            assert data["token"] == "token-123"
+
+
+# ── account list --format json ────────────────────────────
+
+
+class TestAccountListFormatOption:
+    """ante account list --format json."""
+
+    def test_format_after_subcommand(self, runner: CliRunner) -> None:
+        svc = AsyncMock()
+        db = _mock_db()
+        svc.list.return_value = []
+
+        with patch(
+            "ante.cli.commands.account._create_account_service",
+            new_callable=AsyncMock,
+            return_value=(svc, db),
+        ):
+            result = runner.invoke(cli, ["account", "list", "--format", "json"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert "accounts" in data or "message" in data
+
+
+# ── account info --format json ────────────────────────────
+
+
+class TestAccountInfoFormatOption:
+    """ante account info {id} --format json."""
+
+    def test_format_after_subcommand(self, runner: CliRunner) -> None:
+        from decimal import Decimal
+
+        from ante.account.models import Account, AccountStatus, TradingMode
+
+        svc = AsyncMock()
+        db = _mock_db()
+        svc.get.return_value = Account(
+            account_id="test-acct",
+            name="테스트",
+            exchange="KRX",
+            currency="KRW",
+            broker_type="mock",
+            status=AccountStatus.ACTIVE,
+            trading_mode=TradingMode.VIRTUAL,
+            credentials={},
+            buy_commission_rate=Decimal("0.00015"),
+            sell_commission_rate=Decimal("0.00195"),
+        )
+
+        with patch(
+            "ante.cli.commands.account._create_account_service",
+            new_callable=AsyncMock,
+            return_value=(svc, db),
+        ):
+            result = runner.invoke(
+                cli, ["account", "info", "test-acct", "--format", "json"]
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["account_id"] == "test-acct"
+
+
+# ── account delete --yes ──────────────────────────────
+
+
+class TestAccountDeleteYes:
+    """ante account delete {id} --yes."""
+
+    def test_delete_with_yes_skips_confirm(self, runner: CliRunner) -> None:
+        svc = AsyncMock()
+        db = _mock_db()
+
+        with patch(
+            "ante.cli.commands.account._create_account_service",
+            new_callable=AsyncMock,
+            return_value=(svc, db),
+        ):
+            result = runner.invoke(cli, ["account", "delete", "test-acct", "--yes"])
+            assert result.exit_code == 0
+            assert "삭제 완료" in result.output
+            svc.delete.assert_called_once()
+
+    def test_delete_without_yes_prompts(self, runner: CliRunner) -> None:
+        """--yes 없이 호출하면 확인 프롬프트가 나타남."""
+        svc = AsyncMock()
+        db = _mock_db()
+
+        with patch(
+            "ante.cli.commands.account._create_account_service",
+            new_callable=AsyncMock,
+            return_value=(svc, db),
+        ):
+            result = runner.invoke(cli, ["account", "delete", "test-acct"], input="y\n")
+            assert result.exit_code == 0
+            assert "삭제 완료" in result.output
+
+
+# ── treasury status --format json ─────────────────────────
+
+
+class TestTreasuryStatusFormatOption:
+    """ante treasury status --format json."""
+
+    def test_format_after_subcommand(self, runner: CliRunner) -> None:
+        mock_treasury = MagicMock()
+        db = _mock_db()
+        mock_treasury.get_summary.return_value = {
+            "account_balance": 1000000,
+            "purchasable_amount": 800000,
+            "total_evaluation": 1200000,
+            "total_profit_loss": 200000,
+            "total_allocated": 500000,
+            "total_reserved": 100000,
+            "unallocated": 300000,
+            "bot_count": 2,
+        }
+
+        with patch(
+            "ante.cli.commands.treasury._create_treasury",
+            new_callable=AsyncMock,
+            return_value=(mock_treasury, db),
+        ):
+            result = runner.invoke(cli, ["treasury", "status", "--format", "json"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["account_balance"] == 1000000
+            assert data["bot_count"] == 2
+
+
+# ── strategy list --format json ───────────────────────────
+
+
+class TestStrategyListFormatOption:
+    """ante strategy list --format json."""
+
+    def test_format_after_subcommand(self, runner: CliRunner) -> None:
+        db = _mock_db()
+        registry = MagicMock()
+        registry.list_strategies = AsyncMock(return_value=[])
+
+        with patch(
+            "ante.cli.commands.strategy._create_registry",
+            new_callable=AsyncMock,
+            return_value=(registry, db),
+        ):
+            result = runner.invoke(cli, ["strategy", "list", "--format", "json"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert "strategies" in data or "message" in data
+
+
+# ── strategy info --format json ───────────────────────────
+
+
+class TestStrategyInfoFormatOption:
+    """ante strategy info {name} --format json."""
+
+    def test_format_after_subcommand(self, runner: CliRunner) -> None:
+        from datetime import UTC, datetime
+
+        from ante.strategy.registry import StrategyRecord, StrategyStatus
+
+        db = _mock_db()
+        record = StrategyRecord(
+            strategy_id="test_v1.0",
+            name="test",
+            version="1.0",
+            filepath="/strats/test.py",
+            status=StrategyStatus.ACTIVE,
+            registered_at=datetime(2026, 1, 1, tzinfo=UTC),
+            description="테스트 전략",
+            author="agent",
+            validation_warnings=[],
+        )
+        registry = MagicMock()
+        registry.get_by_name = AsyncMock(return_value=[record])
+
+        with (
+            patch(
+                "ante.cli.commands.strategy._create_registry",
+                new_callable=AsyncMock,
+                return_value=(registry, db),
+            ),
+            patch(
+                "ante.cli.commands.strategy._load_strategy_params",
+                return_value=None,
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["strategy", "info", "test", "--format", "json"]
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["name"] == "test"
+
+
+# ── config get --format json ──────────────────────────────
+
+
+class TestConfigGetFormatOption:
+    """ante config get --format json."""
+
+    def test_format_after_subcommand(self, runner: CliRunner) -> None:
+        mock_config = MagicMock()
+        mock_config.get.side_effect = lambda k, d=None: d
+        mock_dynamic = AsyncMock()
+        mock_db = AsyncMock()
+        mock_db.fetch_all = AsyncMock(return_value=[])
+        mock_db.close = AsyncMock()
+
+        with patch(
+            "ante.cli.commands.config._create_services",
+            new_callable=AsyncMock,
+            return_value=(mock_config, mock_dynamic, mock_db),
+        ):
+            result = runner.invoke(cli, ["config", "get", "--format", "json"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert "configs" in data
+
+
+# ── config set --format json ──────────────────────────────
+
+
+class TestConfigSetFormatOption:
+    """ante config set KEY VALUE --format json."""
+
+    def test_format_after_subcommand(self, runner: CliRunner) -> None:
+        mock_config = MagicMock()
+        mock_config.get.return_value = None
+        mock_dynamic = AsyncMock()
+        mock_dynamic.exists = AsyncMock(return_value=False)
+        mock_dynamic.set = AsyncMock()
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+
+        with patch(
+            "ante.cli.commands.config._create_services",
+            new_callable=AsyncMock,
+            return_value=(mock_config, mock_dynamic, mock_db),
+        ):
+            result = runner.invoke(
+                cli, ["config", "set", "custom.key", "hello", "--format", "json"]
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["success"] is True
+
+
+# ── config history --format json ──────────────────────────
+
+
+class TestConfigHistoryFormatOption:
+    """ante config history KEY --format json."""
+
+    def test_format_after_subcommand(self, runner: CliRunner) -> None:
+        mock_config = MagicMock()
+        mock_dynamic = AsyncMock()
+        mock_dynamic.get_history = AsyncMock(return_value=[])
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+
+        with patch(
+            "ante.cli.commands.config._create_services",
+            new_callable=AsyncMock,
+            return_value=(mock_config, mock_dynamic, mock_db),
+        ):
+            result = runner.invoke(
+                cli,
+                ["config", "history", "risk.test_qa_key", "--format", "json"],
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["key"] == "risk.test_qa_key"
+            assert data["history"] == []
+
+
+# ── trade list --format json ──────────────────────────────
+
+
+class TestTradeListFormatOption:
+    """ante trade list --format json."""
+
+    def test_format_after_subcommand(self, runner: CliRunner) -> None:
+        svc = MagicMock()
+        db = _mock_db()
+        svc.get_trades = AsyncMock(return_value=[])
+
+        with patch(
+            "ante.cli.commands.trade._create_trade_service",
+            new_callable=AsyncMock,
+            return_value=(svc, db),
+        ):
+            result = runner.invoke(cli, ["trade", "list", "--format", "json"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert "trades" in data or "message" in data
+
+
+# ── trade info --format json ──────────────────────────────
+
+
+class TestTradeInfoFormatOption:
+    """ante trade info {id} --format json."""
+
+    def test_format_after_subcommand(self, runner: CliRunner) -> None:
+        mock_db = AsyncMock()
+        mock_db.connect = AsyncMock()
+        mock_db.close = AsyncMock()
+        mock_db.fetch_one = AsyncMock(return_value=None)
+
+        with patch(
+            "ante.cli.commands.trade.asyncio.run",
+            return_value=None,
+        ):
+            result = runner.invoke(
+                cli, ["trade", "info", "trade-123", "--format", "json"]
+            )
+            assert result.exit_code == 0
+            # Not found case produces JSON error
+            data = json.loads(result.output)
+            assert "error" in data
+
+
+# ── account set-credentials 비대화형 테스트 ────────────────
+
+
+class TestAccountSetCredentialsNonInteractive:
+    """ante account set-credentials {id} --app-key KEY --app-secret SECRET."""
+
+    def test_set_credentials_non_interactive(self, runner: CliRunner) -> None:
+        from decimal import Decimal
+
+        from ante.account.models import Account, AccountStatus, TradingMode
+
+        svc = AsyncMock()
+        db = _mock_db()
+        svc.get.return_value = Account(
+            account_id="test-acct",
+            name="테스트",
+            exchange="KRX",
+            currency="KRW",
+            broker_type="kis-domestic",
+            status=AccountStatus.ACTIVE,
+            trading_mode=TradingMode.VIRTUAL,
+            credentials={},
+            buy_commission_rate=Decimal("0.00015"),
+            sell_commission_rate=Decimal("0.00195"),
+        )
+
+        with patch(
+            "ante.cli.commands.account._create_account_service",
+            new_callable=AsyncMock,
+            return_value=(svc, db),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "account",
+                    "set-credentials",
+                    "test-acct",
+                    "--app-key",
+                    "my-key",
+                    "--app-secret",
+                    "my-secret",
+                    "--format",
+                    "json",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "재설정 완료" in result.output
+            svc.update.assert_called_once()
+            # 전달된 credentials 확인
+            call_kwargs = svc.update.call_args
+            creds = call_kwargs.kwargs.get("credentials") or call_kwargs[1].get(
+                "credentials"
+            )
+            assert creds["app_key"] == "my-key"
+            assert creds["app_secret"] == "my-secret"


### PR DESCRIPTION
## Summary
- CLI 전 커맨드에서 `ante account list --format json` 형태로 서브커맨드 뒤에 `--format` 옵션 배치 지원
- `ante account delete`에 `--yes` 옵션 추가 (확인 없이 삭제)
- `ante account set-credentials`에 `--app-key`/`--app-secret` 비대화형 옵션 추가

## 변경 내용
- `format_option` 데코레이터를 `formatter.py`에 신규 추가하여 각 서브커맨드에서 `--format` 옵션을 독립적으로 처리
- 영향 커맨드: member register/list, account list/info/delete/credentials/set-credentials, treasury status, strategy list/info, config get/set/history, trade list/info
- 루트 `--format` 옵션도 기존처럼 동작 (하위 호환성 유지)

## Test plan
- [x] 16개 신규 테스트 추가 (`test_cli_format_option.py`) — 모든 서브커맨드 뒤 `--format json` 검증
- [x] 기존 CLI 테스트 97개 전부 통과 (하위 호환성 검증)
- [x] 전체 테스트 스위트 2415개 passed
- [x] `ruff check` + `ruff format` 통과

Refs #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)