### PR TITLE
fix(api): body 없는 POST /accounts/{id}/suspend 422 해결

### DIFF
--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -237,15 +237,15 @@ async def update_account(
 @router.post("/{account_id}/suspend", response_model=AccountActionResponse)
 async def suspend_account(
     account_id: str,
-    body: AccountSuspendRequest,
     request: Request,
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
+    body: AccountSuspendRequest | None = None,
 ) -> dict[str, Any]:
     """계좌 정지."""
     from ante.account.errors import AccountNotFoundError
 
-    reason = body.reason or "dashboard"
+    reason = (body.reason if body else None) or "dashboard"
     suspended_by = getattr(request.state, "member_id", "dashboard")
 
     try:

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -370,6 +370,20 @@ class TestSuspendAccount:
         ]
         assert len(route_logs) == 1
 
+    def test_suspend_without_body(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """body 없이 POST 호출 시에도 200을 반환해야 한다 (GH-640)."""
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.post("/api/accounts/test-account/suspend")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["account"]["status"] == "suspended"
+
     def test_suspend_not_found(self, client: TestClient) -> None:
         resp = client.post(
             "/api/accounts/nonexistent/suspend",


### PR DESCRIPTION
## Summary
- `POST /api/accounts/{id}/suspend` 엔드포인트의 `AccountSuspendRequest` body 파라미터를 Optional로 변경
- body 없이(Content-Type 헤더 없이) 호출 시 422 대신 정상 200 반환
- `members/suspend`, `members/reactivate`, `members/revoke`, `auth/logout`은 이미 body 파라미터가 없어 수정 불필요

## Changes
- `src/ante/web/routes/accounts.py`: `body: AccountSuspendRequest` → `body: AccountSuspendRequest | None = None`
- `tests/unit/test_account_api.py`: body 없이 suspend 호출하는 테스트 추가

## Test plan
- [x] `ruff check` + `ruff format` 통과
- [x] `test_account_api.py` 20개 테스트 전체 통과 (신규 1개 포함)
- [x] `test_member_api.py`, `test_session_auth.py` 관련 테스트 통과 (총 51개)

Refs #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)