### PR TITLE
fix(tc): TC 데이터 보완 — DELETE 204, 봇 필수필드, 비밀번호 불일치

### DIFF
--- a/tests/tc/account/credentials.feature
+++ b/tests/tc/account/credentials.feature
@@ -34,10 +34,15 @@ Feature: 계좌 인증정보 관리
     And stdout JSON의 .app_key 는 null이 아니다
 
   Scenario: 인증정보 설정 후 봇 생성 및 시작 가능
+    When GET /api/strategies
+    Then 응답 상태는 200
+    And 첫 번째 항목의 id 를 {strategy_id}로 저장한다
     When POST /api/bots 요청:
-      | field      | value              |
-      | account_id | {account_id}       |
-      | name       | 인증정보 있는 봇   |
+      | field       | value              |
+      | bot_id      | qa-cred-bot-01     |
+      | account_id  | {account_id}       |
+      | name        | 인증정보 있는 봇   |
+      | strategy_id | {strategy_id}      |
     Then 응답 상태는 201
     And 응답 body.bot.bot_id 를 {bot_id}로 저장한다
 
@@ -60,9 +65,11 @@ Feature: 계좌 인증정보 관리
     And 응답 body.account.account_id 를 {no_cred_account_id}로 저장한다
     # 봇 생성
     When POST /api/bots 요청:
-      | field      | value                 |
-      | account_id | {no_cred_account_id}  |
-      | name       | 인증정보 없는 봇      |
+      | field       | value                 |
+      | bot_id      | qa-no-cred-bot-01     |
+      | account_id  | {no_cred_account_id}  |
+      | name        | 인증정보 없는 봇      |
+      | strategy_id | {strategy_id}         |
     Then 응답 상태는 201
     And 응답 body.bot.bot_id 를 {no_cred_bot_id}로 저장한다
     # 봇 시작 시도 → 인증정보 미설정 에러

--- a/tests/tc/account/lifecycle.feature
+++ b/tests/tc/account/lifecycle.feature
@@ -47,7 +47,7 @@ Feature: 계좌 생명주기
 
   Scenario: 계좌 삭제 (API)
     When DELETE /api/accounts/{account_id}
-    Then 응답 상태는 200
+    Then 응답 상태는 204
 
   Scenario: 삭제된 계좌 조회 시 상태 확인
     When GET /api/accounts/{account_id}
@@ -72,10 +72,15 @@ Feature: 계좌 생명주기
     And 응답 body.account.account_id 를 {suspended_account_id}로 저장한다
     When POST /api/accounts/{suspended_account_id}/suspend
     Then 응답 상태는 200
+    When GET /api/strategies
+    Then 응답 상태는 200
+    And 첫 번째 항목의 id 를 {strategy_id}로 저장한다
     When POST /api/bots 요청:
       | field      | value                  |
+      | bot_id     | qa-lifecycle-bot-01    |
       | account_id | {suspended_account_id} |
       | name       | 거부될 봇              |
+      | strategy_id| {strategy_id}          |
     Then 응답 상태는 409
 
   Scenario: 삭제된 계좌 재활성화 불가
@@ -94,7 +99,7 @@ Feature: 계좌 생명주기
     Then 응답 상태는 201
     And 응답 body.account.account_id 를 {deleted_account_id}로 저장한다
     When DELETE /api/accounts/{deleted_account_id}
-    Then 응답 상태는 200
+    Then 응답 상태는 204
     When POST /api/accounts/{deleted_account_id}/activate
     Then 응답 상태는 404 또는 응답 상태는 409
 

--- a/tests/tc/member/management.feature
+++ b/tests/tc/member/management.feature
@@ -67,12 +67,21 @@ Feature: 멤버 관리
     And 응답 body.member.status 는 "revoked"
 
   # ── 비밀번호 변경 ──
+  # qa-admin은 bootstrap으로 생성되어 비밀번호(qa-password)가 설정된 멤버
 
   Scenario: 비밀번호 변경 (API)
-    When PATCH /api/members/qa-test-human-01/password 요청:
+    When PATCH /api/members/qa-admin/password 요청:
       | field        | value        |
       | old_password | qa-password  |
       | new_password | new-password |
+    Then 응답 상태는 200
+    And 응답 body.ok 는 true
+
+  Scenario: 변경된 비밀번호 복구 (API)
+    When PATCH /api/members/qa-admin/password 요청:
+      | field        | value        |
+      | old_password | new-password |
+      | new_password | qa-password  |
     Then 응답 상태는 200
     And 응답 body.ok 는 true
 


### PR DESCRIPTION
## Summary
- **#643**: `account/lifecycle.feature`의 DELETE 응답 기대값을 200 → 204로 수정 (REST 표준 관례)
- **#644**: `account/credentials.feature`, `account/lifecycle.feature`의 봇 생성 Data Table에 `bot_id`, `strategy_id` 필수 필드 추가 (전략 목록 조회로 동적 확보)
- **#645**: `member/management.feature`의 비밀번호 변경 대상을 `qa-test-human-01`(비밀번호 미설정) → `qa-admin`(bootstrap으로 비밀번호 설정됨)으로 변경, 비밀번호 복구 시나리오 추가

Refs #643, Refs #644, Refs #645

## Test plan
- [x] 기존 단위 테스트 통과 확인 (2415 passed, 2 skipped)
- [ ] QA 컨테이너에서 수정된 TC 시나리오 실행 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)