### PR TITLE
fix(qa): Treasury 503 fallback 및 QA 시드 계좌 추가

### DIFF
--- a/scripts/qa-entrypoint.sh
+++ b/scripts/qa-entrypoint.sh
@@ -30,6 +30,39 @@ QA_PASSWORD="${QA_ADMIN_PASSWORD:-qaadmin123!}"
 printf '%s\n%s\n' "$QA_PASSWORD" "$QA_PASSWORD" | \
     ante member bootstrap --id qa-admin --name "QA Admin" 2>/dev/null || true
 
+echo "[qa] QA 시드 계좌 확인 (Treasury 초기화 보장)..."
+# 계좌가 없으면 API로 테스트 계좌 생성 → 서버 재기동하여 Treasury 초기화
+ACCOUNT_COUNT=$(curl -sf http://localhost:8000/api/accounts | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('accounts',[])))" 2>/dev/null || echo "0")
+if [ "$ACCOUNT_COUNT" = "0" ]; then
+    echo "[qa] 계좌 없음 — 시드 계좌 생성 중..."
+    curl -sf -X POST http://localhost:8000/api/accounts \
+        -H "Content-Type: application/json" \
+        -d '{"account_id":"test","name":"QA Test","broker_type":"test","trading_mode":"virtual"}' \
+        > /dev/null 2>&1 || true
+
+    # 계좌 생성 후 서버 재기동하여 Treasury 초기화
+    echo "[qa] 서버 재기동 (Treasury 초기화)..."
+    kill $SERVER_PID 2>/dev/null || true
+    wait $SERVER_PID 2>/dev/null || true
+
+    python -m ante.main &
+    SERVER_PID=$!
+
+    for i in $(seq 1 30); do
+        if python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/system/health')" 2>/dev/null; then
+            echo "[qa] 서버 재기동 완료 (${i}초)"
+            break
+        fi
+        if [ "$i" -eq 30 ]; then
+            echo "[qa] 서버 재기동 헬스체크 타임아웃" >&2
+            exit 1
+        fi
+        sleep 1
+    done
+else
+    echo "[qa] 계좌 ${ACCOUNT_COUNT}개 확인됨 — 시드 생략"
+fi
+
 echo "[qa] QA 테스트용 동적 설정 시드 등록..."
 sqlite3 db/ante.db "INSERT OR IGNORE INTO dynamic_config (key, value, category, updated_at) VALUES ('risk.test_qa_key', '0', 'risk', datetime('now'));"
 

--- a/src/ante/web/deps.py
+++ b/src/ante/web/deps.py
@@ -49,11 +49,23 @@ def get_strategy_registry(request: Request) -> Any:
 
 
 def get_treasury(request: Request) -> Any:
-    """자금 관리 (필수)."""
+    """자금 관리 (필수).
+
+    app.state.treasury가 없으면 treasury_manager에서
+    첫 번째 Treasury 인스턴스를 fallback으로 반환한다.
+    """
     svc = getattr(request.app.state, "treasury", None)
-    if svc is None:
-        raise HTTPException(status_code=503, detail="Treasury not available")
-    return svc
+    if svc is not None:
+        return svc
+
+    # fallback: treasury_manager에서 첫 번째 Treasury 반환
+    manager = getattr(request.app.state, "treasury_manager", None)
+    if manager is not None:
+        treasuries = manager.list_all()
+        if treasuries:
+            return treasuries[0]
+
+    raise HTTPException(status_code=503, detail="Treasury not available")
 
 
 def get_trade_service(request: Request) -> Any:

--- a/tests/unit/test_treasury_api.py
+++ b/tests/unit/test_treasury_api.py
@@ -123,3 +123,50 @@ class TestSetBalance:
         )
         assert resp.status_code == 200
         assert resp.json()["total_balance"] == 0
+
+
+class FakeTreasuryManager:
+    """테스트용 TreasuryManager stub."""
+
+    def __init__(self, treasuries: list[FakeTreasury] | None = None) -> None:
+        self._treasuries: list[FakeTreasury] = treasuries or []
+
+    def list_all(self) -> list[FakeTreasury]:
+        return list(self._treasuries)
+
+    def get(self, account_id: str) -> FakeTreasury:
+        for t in self._treasuries:
+            if getattr(t, "account_id", None) == account_id:
+                return t
+        raise KeyError(f"Treasury not found: {account_id}")
+
+
+class TestTreasuryFallback:
+    """treasury_manager fallback 테스트 (이슈 #641)."""
+
+    def test_treasury_manager_fallback(self):
+        """treasury 미설정 시 treasury_manager에서 첫 번째 인스턴스 반환."""
+        fake_treasury = FakeTreasury()
+        manager = FakeTreasuryManager(treasuries=[fake_treasury])
+        app = create_app(treasury_manager=manager)
+        client = TestClient(app)
+
+        resp = client.get("/api/treasury/budgets")
+        assert resp.status_code == 200
+
+    def test_no_treasury_no_manager_returns_503(self):
+        """treasury도 treasury_manager도 없으면 503."""
+        app = create_app()
+        client = TestClient(app)
+
+        resp = client.get("/api/treasury/budgets")
+        assert resp.status_code == 503
+
+    def test_empty_manager_returns_503(self):
+        """treasury_manager에 Treasury가 없으면 503."""
+        manager = FakeTreasuryManager(treasuries=[])
+        app = create_app(treasury_manager=manager)
+        client = TestClient(app)
+
+        resp = client.get("/api/treasury/budgets")
+        assert resp.status_code == 503


### PR DESCRIPTION
## Summary
- `get_treasury` 의존성에 `treasury_manager` fallback 추가: `app.state.treasury`가 없을 때 `treasury_manager.list_all()[0]`을 반환
- QA 엔트리포인트에 시드 계좌 생성 로직 추가: 계좌 없으면 API로 test 계좌 생성 후 서버 재기동
- fallback 로직 테스트 3건 추가 (정상/503 경우)

## Root Cause
`_init_web()`에서 `create_app()`에 `treasury_manager`만 전달하고 개별 `treasury` 인스턴스를 전달하지 않음. `get_treasury` 의존성은 `app.state.treasury`만 찾았기 때문에 항상 503 반환.

## Test plan
- [x] `test_treasury_manager_fallback`: treasury 미설정 시 manager에서 첫 번째 인스턴스 반환 → 200
- [x] `test_no_treasury_no_manager_returns_503`: 둘 다 없으면 503
- [x] `test_empty_manager_returns_503`: manager에 Treasury 없으면 503
- [x] 기존 테스트 전체 통과 (2418 passed)

Refs #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)