### PR TITLE
fix(cli): trade CLI hang 해결

### DIFF
--- a/src/ante/cli/commands/trade.py
+++ b/src/ante/cli/commands/trade.py
@@ -23,7 +23,6 @@ def _run(coro):  # noqa: ANN001, ANN202
 
 async def _create_trade_service():  # noqa: ANN202
     from ante.core.database import Database
-    from ante.eventbus.bus import EventBus
     from ante.trade.performance import PerformanceTracker
     from ante.trade.position import PositionHistory
     from ante.trade.recorder import TradeRecorder
@@ -31,13 +30,11 @@ async def _create_trade_service():  # noqa: ANN202
 
     db = Database("db/ante.db")
     await db.connect()
-    eventbus = EventBus()
-    recorder = TradeRecorder(db, eventbus)
-    await recorder.initialize()
-    position_history = PositionHistory(db, eventbus)
+    position_history = PositionHistory(db=db)
     await position_history.initialize()
-    performance = PerformanceTracker(db)
-    await performance.initialize()
+    recorder = TradeRecorder(db=db, position_history=position_history)
+    await recorder.initialize()
+    performance = PerformanceTracker(db=db)
     service = TradeService(recorder, position_history, performance)
     return service, db
 

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -237,6 +237,50 @@ class TestTradeCommands:
             result = runner.invoke(cli, ["trade", "list"])
             assert result.exit_code == 0
 
+    def test_create_trade_service_constructor_args(self):
+        """_create_trade_service가 올바른 생성자 시그니처로 호출되는지 검증.
+
+        이전 버전에서는 EventBus를 잘못된 인자로 전달하여 hang이 발생했다.
+        Refs #642.
+        """
+        import asyncio
+
+        with (
+            patch("ante.core.database.Database") as mock_db_cls,
+            patch("ante.trade.position.PositionHistory") as mock_ph_cls,
+            patch("ante.trade.recorder.TradeRecorder") as mock_rec_cls,
+            patch("ante.trade.performance.PerformanceTracker") as mock_perf_cls,
+            patch("ante.trade.service.TradeService") as mock_svc_cls,
+        ):
+            mock_db = AsyncMock()
+            mock_db.connect = AsyncMock()
+            mock_db_cls.return_value = mock_db
+
+            mock_ph = AsyncMock()
+            mock_ph.initialize = AsyncMock()
+            mock_ph_cls.return_value = mock_ph
+
+            mock_rec = AsyncMock()
+            mock_rec.initialize = AsyncMock()
+            mock_rec_cls.return_value = mock_rec
+
+            mock_perf = MagicMock()
+            mock_perf_cls.return_value = mock_perf
+
+            mock_service = MagicMock()
+            mock_svc_cls.return_value = mock_service
+
+            from ante.cli.commands.trade import _create_trade_service
+
+            service, db = asyncio.run(_create_trade_service())
+
+            # PositionHistory는 db만 받아야 한다
+            mock_ph_cls.assert_called_once_with(db=mock_db)
+            # TradeRecorder는 db + position_history를 받아야 한다
+            mock_rec_cls.assert_called_once_with(db=mock_db, position_history=mock_ph)
+            # PerformanceTracker는 db만 받아야 한다
+            mock_perf_cls.assert_called_once_with(db=mock_db)
+
     def test_trade_info_not_found(self, runner):
         with patch("ante.core.database.Database") as mock_db_cls:
             mock_db = AsyncMock()


### PR DESCRIPTION
## Summary
- `ante trade list` CLI 커맨드가 무한 대기(hang) 후 SIGKILL(exit code 137)로 종료되던 버그 수정
- `_create_trade_service()`에서 `TradeRecorder`, `PositionHistory` 생성자 인자가 `main.py`의 올바른 패턴과 불일치하여 발생
- 생성자 시그니처 검증 테스트 추가

## Root Cause
`_create_trade_service()`가 다음과 같은 잘못된 호출을 하고 있었다:
1. `TradeRecorder(db, eventbus)` — `position_history` 자리에 `EventBus` 전달
2. `PositionHistory(db, eventbus)` — `db`만 받는 생성자에 추가 인자 전달
3. `await performance.initialize()` — 존재하지 않는 메서드 호출

## Changes
- `PositionHistory(db=db)` — db만 전달하도록 수정
- `TradeRecorder(db=db, position_history=position_history)` — 올바른 인자 전달
- `PerformanceTracker.initialize()` 호출 제거
- 불필요한 `EventBus` import 제거
- 생성자 시그니처 검증 단위 테스트 추가

## Test plan
- [x] `test_create_trade_service_constructor_args` — 생성자 인자 검증
- [x] 기존 `test_trade_list_empty`, `test_trade_info_not_found` 통과
- [x] 전체 unit test 2416 passed

Refs #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)