### PR TITLE
fix(bot): 정지된 계좌에서 봇 생성 시 409 반환

### DIFF
--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from ante.web.deps import (
+    get_account_service,
     get_audit_logger_optional,
     get_bot_manager,
     get_strategy_registry,
@@ -78,14 +79,24 @@ async def create_bot(
     request: Request,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     registry: Annotated[Any, Depends(get_strategy_registry)],
+    account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """봇 생성."""
     from pathlib import Path
 
+    from ante.account.models import AccountStatus
     from ante.bot.config import BotConfig
     from ante.bot.exceptions import BotError
     from ante.strategy.loader import StrategyLoader
+
+    # 계좌 상태 검증: active가 아니면 봇 생성 거부
+    account = await account_service.get(body.account_id)
+    if account.status != AccountStatus.ACTIVE:
+        raise HTTPException(
+            status_code=409,
+            detail=f"계좌가 '{account.status}' 상태이므로 봇을 생성할 수 없습니다",
+        )
 
     record = await registry.get(body.strategy_id)
     if not record:

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -300,6 +300,126 @@ class TestGetBotWithPositions:
         assert "positions" not in resp.json()["bot"]
 
 
+class FakeAccount:
+    """테스트용 Account stub."""
+
+    def __init__(
+        self, account_id: str = "test", status: str = "active", exchange: str = "KRX"
+    ) -> None:
+        self.account_id = account_id
+        self.name = account_id
+        self.status = status
+        self.exchange = exchange
+
+
+class FakeAccountService:
+    """테스트용 AccountService stub."""
+
+    def __init__(self) -> None:
+        self._accounts: dict[str, FakeAccount] = {}
+
+    async def get(self, account_id: str) -> FakeAccount:
+        from ante.account.errors import AccountNotFoundError
+
+        account = self._accounts.get(account_id)
+        if account is None:
+            raise AccountNotFoundError(f"Account not found: {account_id}")
+        return account
+
+
+class FakeStrategyRecord:
+    """테스트용 StrategyRecord stub."""
+
+    def __init__(self, strategy_id: str = "s1", filepath: str = "/tmp/s1.py") -> None:
+        self.strategy_id = strategy_id
+        self.filepath = filepath
+        self.name = strategy_id
+        self.version = "0.1.0"
+        self.author = "test"
+        self.description = "test strategy"
+
+
+class FakeStrategyRegistry:
+    """테스트용 StrategyRegistry stub."""
+
+    def __init__(self) -> None:
+        self._strategies: dict[str, FakeStrategyRecord] = {}
+
+    async def get(self, strategy_id: str) -> FakeStrategyRecord | None:
+        return self._strategies.get(strategy_id)
+
+
+class TestCreateBotAccountStatus:
+    """봇 생성 시 계좌 상태 검증 테스트."""
+
+    @pytest.fixture
+    def account_service(self):
+        svc = FakeAccountService()
+        svc._accounts["test"] = FakeAccount("test", status="active")
+        return svc
+
+    @pytest.fixture
+    def suspended_account_service(self):
+        svc = FakeAccountService()
+        svc._accounts["test"] = FakeAccount("test", status="suspended")
+        return svc
+
+    @pytest.fixture
+    def strategy_registry(self):
+        reg = FakeStrategyRegistry()
+        reg._strategies["s1"] = FakeStrategyRecord("s1")
+        return reg
+
+    @pytest.fixture
+    def client_suspended(
+        self, bot_manager, suspended_account_service, strategy_registry
+    ):
+        app = create_app(
+            bot_manager=bot_manager,
+            account_service=suspended_account_service,
+            strategy_registry=strategy_registry,
+        )
+        return TestClient(app)
+
+    def test_create_bot_suspended_account_returns_409(self, client_suspended):
+        """정지된 계좌에서 봇 생성 → 409 Conflict."""
+        resp = client_suspended.post(
+            "/api/bots",
+            json={
+                "bot_id": "bot-1",
+                "strategy_id": "s1",
+                "account_id": "test",
+            },
+        )
+        assert resp.status_code == 409
+        assert "suspended" in resp.json()["detail"]
+
+    def test_create_bot_deleted_account_returns_409(
+        self, bot_manager, strategy_registry
+    ):
+        """삭제된 계좌에서 봇 생성 → 409 Conflict."""
+        account_svc = FakeAccountService()
+        account_svc._accounts["deleted-acc"] = FakeAccount(
+            "deleted-acc", status="deleted"
+        )
+        app = create_app(
+            bot_manager=bot_manager,
+            account_service=account_svc,
+            strategy_registry=strategy_registry,
+        )
+        client = TestClient(app)
+        resp = client.post(
+            "/api/bots",
+            json={
+                "bot_id": "bot-1",
+                "strategy_id": "s1",
+                "account_id": "deleted-acc",
+            },
+        )
+        assert resp.status_code == 409
+        assert "deleted" in resp.json()["detail"]
+
+
 class TestBotLifecycle:
     def test_start_stop_lifecycle(self, client, bot_manager):
         """봇 시작 → 중지 lifecycle."""


### PR DESCRIPTION
## Summary
- 봇 생성 API(`POST /api/bots`)에서 계좌 상태 검증 추가
- `account.status != "active"`이면 409 Conflict 반환 (suspended, deleted 모두 거부)
- 계좌 상태별 봇 생성 거부 테스트 2건 추가

## Changes
- `src/ante/web/routes/bots.py`: `create_bot()` 핸들러에 `account_service` 의존성 주입, 계좌 상태 검증 로직 추가
- `tests/unit/test_bot_api.py`: `TestCreateBotAccountStatus` 클래스 추가 (suspended/deleted 계좌 테스트)

## Test plan
- [x] 정지된(suspended) 계좌에서 봇 생성 시 409 반환 확인
- [x] 삭제된(deleted) 계좌에서 봇 생성 시 409 반환 확인
- [x] 기존 봇 API 테스트 전체 통과 (18건)
- [x] 전체 테스트 스위트 통과 (2422건)

Refs #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)