### PR TITLE
fix(account): 이미 정지된 계좌 재정지 시 409 반환

### DIFF
--- a/src/ante/account/errors.py
+++ b/src/ante/account/errors.py
@@ -25,6 +25,12 @@ class InvalidBrokerTypeError(AccountError):
     pass
 
 
+class AccountAlreadySuspendedError(AccountError):
+    """이미 정지 상태인 계좌에 대한 재정지 시도."""
+
+    pass
+
+
 class AccountDeletedError(AccountError):
     """DELETED 상태 계좌에 대한 수정/활성화 시도."""
 

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -268,7 +268,11 @@ class AccountService:
         """
         account = await self.get(account_id)
         if account.status == AccountStatus.SUSPENDED:
-            return
+            from ante.account.errors import AccountAlreadySuspendedError
+
+            raise AccountAlreadySuspendedError(
+                f"이미 정지된 계좌입니다: '{account_id}'"
+            )
         account.status = AccountStatus.SUSPENDED
         account.updated_at = datetime.now(UTC)
 

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -243,7 +243,7 @@ async def suspend_account(
     body: AccountSuspendRequest | None = None,
 ) -> dict[str, Any]:
     """계좌 정지."""
-    from ante.account.errors import AccountNotFoundError
+    from ante.account.errors import AccountAlreadySuspendedError, AccountNotFoundError
 
     reason = (body.reason if body else None) or "dashboard"
     suspended_by = getattr(request.state, "member_id", "dashboard")
@@ -254,6 +254,8 @@ async def suspend_account(
         )
     except AccountNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except AccountAlreadySuspendedError as e:
+        raise HTTPException(status_code=409, detail=str(e))
 
     account = await account_service.get(account_id)
 

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -75,6 +75,12 @@ class FakeAccountService:
     async def suspend(self, account_id: str, reason: str, suspended_by: str) -> None:
         if account_id not in self._accounts:
             raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
+        from ante.account.errors import AccountAlreadySuspendedError
+
+        if self._accounts[account_id].status == AccountStatus.SUSPENDED:
+            raise AccountAlreadySuspendedError(
+                f"이미 정지된 계좌입니다: '{account_id}'"
+            )
         self._accounts[account_id].status = AccountStatus.SUSPENDED
 
     async def activate(self, account_id: str, activated_by: str) -> None:
@@ -390,6 +396,24 @@ class TestSuspendAccount:
             json={"reason": "없는 계좌"},
         )
         assert resp.status_code == 404
+
+    def test_suspend_already_suspended_returns_409(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """이미 정지된 계좌를 재정지하면 409 Conflict를 반환해야 한다 (GH-651)."""
+        account = _make_account()
+        account.status = AccountStatus.SUSPENDED
+        account_service._accounts[account.account_id] = account
+
+        resp = client.post(
+            "/api/accounts/test-account/suspend",
+            json={"reason": "재정지 시도"},
+        )
+        assert resp.status_code == 409
+        data = resp.json()
+        assert "이미 정지된 계좌" in data["detail"]
 
 
 class TestActivateAccount:


### PR DESCRIPTION
## Summary
- 이미 SUSPENDED 상태인 계좌에 `POST /api/accounts/{id}/suspend` 재호출 시 200 대신 409 Conflict 반환
- `AccountAlreadySuspendedError` 예외 클래스 추가 및 서비스/라우트 레이어에서 처리
- 재정지 시 409 반환 검증 테스트 추가

## Test plan
- [x] 이미 정지된 계좌 재정지 → 409 반환 확인
- [x] 정상 정지 (ACTIVE → SUSPENDED) → 200 반환 확인
- [x] 존재하지 않는 계좌 정지 → 404 반환 확인
- [x] body 없이 정지 호출 → 200 반환 확인
- [x] 전체 테스트 스위트 통과 (기존 실패 2건은 무관)

Refs #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)