### PR TITLE
fix(account): test 브로커 required_credentials 추가

### DIFF
--- a/src/ante/account/presets.py
+++ b/src/ante/account/presets.py
@@ -15,7 +15,7 @@ BROKER_PRESETS: dict[str, BrokerPreset] = {
         sell_commission_rate=Decimal("0"),
         default_account_id="test",
         default_name="테스트",
-        required_credentials=[],
+        required_credentials=["app_key", "app_secret"],
     ),
     "kis-domestic": BrokerPreset(
         exchange="KRX",

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -353,7 +353,7 @@ def test_broker_preset_test_values():
     assert preset.currency == "KRW"
     assert preset.buy_commission_rate == Decimal("0")
     assert preset.sell_commission_rate == Decimal("0")
-    assert preset.required_credentials == []
+    assert preset.required_credentials == ["app_key", "app_secret"]
 
 
 def test_broker_preset_kis_domestic_values():


### PR DESCRIPTION
## Summary
- test 브로커 프리셋의 `required_credentials`가 빈 배열(`[]`)이어서 크레덴셜 저장 로직이 건너뛰어지는 버그 수정
- `["app_key", "app_secret"]`을 추가하여 크레덴셜 설정/조회가 정상 동작하도록 함
- 기존 테스트(`test_broker_preset_test_values`)의 기대값도 함께 업데이트

Refs #652

## Test plan
- [x] `ruff check` + `ruff format` 통과
- [x] `pytest tests/unit/test_account.py` 24개 전체 통과
- [ ] `ante account set-credentials test --app-key xxx --app-secret yyy` 후 조회 시 정상 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)