### PR TITLE
fix(qa): QA 전략 레지스트리 시딩 구현

### DIFF
--- a/Dockerfile.qa
+++ b/Dockerfile.qa
@@ -17,8 +17,11 @@ RUN pip install --no-cache-dir .
 # 런타임 디렉토리
 RUN mkdir -p config data db strategies
 
-# QA용 샘플 전략 파일
-COPY strategies/qa_sample.py strategies/
+# QA용 전략 파일 (qa_*.py)
+COPY strategies/qa_*.py strategies/
+
+# QA 전략 시딩 스크립트
+COPY scripts/qa_seed_strategies.py scripts/
 
 # QA용 설정
 COPY config/system.qa.toml config/system.toml

--- a/scripts/qa-entrypoint.sh
+++ b/scripts/qa-entrypoint.sh
@@ -63,6 +63,9 @@ else
     echo "[qa] 계좌 ${ACCOUNT_COUNT}개 확인됨 — 시드 생략"
 fi
 
+echo "[qa] QA 전략 레지스트리 시딩..."
+python scripts/qa_seed_strategies.py --strategies-dir strategies --db-path db/ante.db
+
 echo "[qa] QA 테스트용 동적 설정 시드 등록..."
 sqlite3 db/ante.db "INSERT OR IGNORE INTO dynamic_config (key, value, category, updated_at) VALUES ('risk.test_qa_key', '0', 'risk', datetime('now'));"
 

--- a/scripts/qa_seed_strategies.py
+++ b/scripts/qa_seed_strategies.py
@@ -1,0 +1,160 @@
+"""QA 전략 레지스트리 시딩 스크립트.
+
+strategies/ 디렉토리의 qa_*.py 전략 파일을 스캔하여
+DB 레지스트리에 자동 등록한다. 이미 등록된 전략은 건너뛴다.
+
+Usage::
+
+    python scripts/qa_seed_strategies.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
+
+from ante.core.database import Database
+from ante.strategy.base import StrategyMeta
+from ante.strategy.registry import StrategyRegistry
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_meta_from_file(filepath: Path) -> StrategyMeta | None:
+    """AST를 파싱하여 전략 파일에서 StrategyMeta를 추출한다.
+
+    런타임 import 없이 정적으로 메타데이터를 읽는다.
+    """
+    try:
+        source = filepath.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(filepath))
+    except SyntaxError:
+        logger.warning("구문 오류 — 건너뜀: %s", filepath)
+        return None
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        is_strategy = any(
+            (isinstance(base, ast.Name) and base.id == "Strategy")
+            or (isinstance(base, ast.Attribute) and base.attr == "Strategy")
+            for base in node.bases
+        )
+        if not is_strategy:
+            continue
+
+        for item in node.body:
+            if isinstance(item, ast.Assign):
+                targets = item.targets
+                value = item.value
+            elif isinstance(item, ast.AnnAssign):
+                targets = [item.target]
+                value = item.value
+            else:
+                continue
+
+            for target in targets:
+                if not isinstance(target, ast.Name) or target.id != "meta":
+                    continue
+                if not isinstance(value, ast.Call):
+                    continue
+                return _parse_strategy_meta_call(value)
+
+    logger.warning("StrategyMeta를 찾을 수 없음 — 건너뜀: %s", filepath)
+    return None
+
+
+def _parse_strategy_meta_call(call: ast.Call) -> StrategyMeta:
+    """ast.Call 노드에서 StrategyMeta 키워드 인자를 파싱."""
+    kwargs: dict[str, Any] = {}
+    for kw in call.keywords:
+        if kw.arg is None:
+            continue
+        value = _eval_constant(kw.value)
+        if value is not None:
+            kwargs[kw.arg] = value
+    return StrategyMeta(**kwargs)
+
+
+def _eval_constant(node: ast.expr) -> Any:
+    """AST 상수 노드를 Python 값으로 변환한다."""
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.List):
+        return [_eval_constant(elt) for elt in node.elts]
+    return None
+
+
+async def seed_strategies(strategies_dir: Path, db_path: str) -> int:
+    """strategies_dir의 qa_*.py 파일을 DB에 등록한다.
+
+    Returns:
+        등록된 전략 수.
+    """
+    db = Database(db_path)
+    await db.connect()
+
+    try:
+        registry = StrategyRegistry(db)
+        await registry.initialize()
+
+        strategy_files = sorted(strategies_dir.glob("qa_*.py"))
+        if not strategy_files:
+            logger.warning("시딩 대상 전략 파일 없음: %s", strategies_dir)
+            return 0
+
+        registered_count = 0
+        for filepath in strategy_files:
+            meta = _extract_meta_from_file(filepath)
+            if meta is None:
+                continue
+
+            strategy_id = f"{meta.name}_v{meta.version}"
+            if await registry.exists(strategy_id):
+                logger.info("이미 등록됨 — 건너뜀: %s", strategy_id)
+                continue
+
+            try:
+                await registry.register(filepath=filepath, meta=meta)
+                registered_count += 1
+                logger.info("전략 등록 완료: %s", strategy_id)
+            except Exception:
+                logger.exception("전략 등록 실패: %s", filepath.name)
+
+        return registered_count
+    finally:
+        await db.close()
+
+
+def main() -> None:
+    """CLI 진입점."""
+    parser = argparse.ArgumentParser(description="QA 전략 레지스트리 시딩")
+    parser.add_argument(
+        "--strategies-dir",
+        type=Path,
+        default=Path("strategies"),
+        help="전략 파일 디렉토리 (기본: strategies/)",
+    )
+    parser.add_argument(
+        "--db-path",
+        type=str,
+        default="db/ante.db",
+        help="SQLite DB 경로 (기본: db/ante.db)",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[qa-seed] %(message)s",
+    )
+
+    count = asyncio.run(seed_strategies(args.strategies_dir, args.db_path))
+    logger.info("시딩 완료: %d개 전략 등록", count)
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/qa_buy_signal.py
+++ b/strategies/qa_buy_signal.py
@@ -1,0 +1,38 @@
+"""QA 테스트용 매수 시그널 전략.
+
+항상 BUY 시그널을 반환하여 매수 시그널 처리 파이프라인을 검증한다.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+STRATEGY_VERSION = "0.1.0"
+
+
+class QaBuySignalStrategy(Strategy):
+    """항상 매수 시그널을 반환하는 QA 전략."""
+
+    meta = StrategyMeta(
+        name="qa_buy_signal",
+        version=STRATEGY_VERSION,
+        description="QA 테스트 전용 — 항상 BUY 시그널 반환",
+        author="qa",
+        symbols=["005930"],
+        timeframe="1d",
+        exchange="KRX",
+    )
+
+    async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+        """항상 매수 시그널 1건을 반환한다."""
+        return [
+            Signal(
+                symbol="005930",
+                side="buy",
+                quantity=1.0,
+                order_type="market",
+                reason="QA 테스트 — 항상 매수",
+            )
+        ]

--- a/strategies/qa_external_signal.py
+++ b/strategies/qa_external_signal.py
@@ -1,0 +1,36 @@
+"""QA 테스트용 외부 시그널 수신 전략.
+
+accepts_external_signals=True 설정으로 외부 시그널 수신 전략의
+등록 및 검증을 테스트한다.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+STRATEGY_VERSION = "0.1.0"
+
+
+class QaExternalSignalStrategy(Strategy):
+    """외부 시그널을 수신하는 QA 전략."""
+
+    meta = StrategyMeta(
+        name="qa_external_signal",
+        version=STRATEGY_VERSION,
+        description="QA 테스트 전용 — 외부 시그널 수신 전략",
+        author="qa",
+        symbols=["005930"],
+        timeframe="1d",
+        exchange="KRX",
+        accepts_external_signals=True,
+    )
+
+    async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+        """시그널 없이 빈 리스트를 반환한다."""
+        return []
+
+    async def on_data(self, data: dict[str, Any]) -> list[Signal]:
+        """외부 데이터 수신 시 처리한다."""
+        return []

--- a/strategies/qa_invalid_meta.py
+++ b/strategies/qa_invalid_meta.py
@@ -1,0 +1,31 @@
+"""QA 테스트용 메타 검증 실패 전략.
+
+exchange 필드에 유효하지 않은 값을 설정하여
+전략 검증기의 오류 감지를 테스트한다.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+STRATEGY_VERSION = "0.1.0"
+
+
+class QaInvalidMetaStrategy(Strategy):
+    """메타데이터 검증 실패를 유발하는 QA 전략."""
+
+    meta = StrategyMeta(
+        name="qa_invalid_meta",
+        version=STRATEGY_VERSION,
+        description="QA 테스트 전용 — 유효하지 않은 exchange",
+        author="qa",
+        symbols=["005930"],
+        timeframe="1d",
+        exchange="INVALID_EXCHANGE",
+    )
+
+    async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+        """시그널 없이 빈 리스트를 반환한다."""
+        return []

--- a/strategies/qa_multi_symbol.py
+++ b/strategies/qa_multi_symbol.py
@@ -1,0 +1,30 @@
+"""QA 테스트용 다중 종목 전략.
+
+여러 심볼을 대상으로 하는 전략의 등록 및 조회를 검증한다.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+STRATEGY_VERSION = "0.1.0"
+
+
+class QaMultiSymbolStrategy(Strategy):
+    """다중 종목을 대상으로 하는 QA 전략."""
+
+    meta = StrategyMeta(
+        name="qa_multi_symbol",
+        version=STRATEGY_VERSION,
+        description="QA 테스트 전용 — 다중 종목 전략",
+        author="qa",
+        symbols=["005930", "000660", "035420"],
+        timeframe="1d",
+        exchange="KRX",
+    )
+
+    async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+        """시그널 없이 빈 리스트를 반환한다."""
+        return []

--- a/strategies/qa_nyse.py
+++ b/strategies/qa_nyse.py
@@ -1,0 +1,30 @@
+"""QA 테스트용 해외(NYSE) 시장 전략.
+
+exchange="NYSE" 설정으로 해외 시장 전략의 등록 및 조회를 검증한다.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+STRATEGY_VERSION = "0.1.0"
+
+
+class QaNyseStrategy(Strategy):
+    """NYSE 시장을 대상으로 하는 QA 전략."""
+
+    meta = StrategyMeta(
+        name="qa_nyse",
+        version=STRATEGY_VERSION,
+        description="QA 테스트 전용 — NYSE 시장 전략",
+        author="qa",
+        symbols=["AAPL"],
+        timeframe="1d",
+        exchange="NYSE",
+    )
+
+    async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+        """시그널 없이 빈 리스트를 반환한다."""
+        return []


### PR DESCRIPTION
## Summary
- QA 테스트용 더미 전략 파일 5개 추가 (`qa_buy_signal`, `qa_multi_symbol`, `qa_invalid_meta`, `qa_nyse`, `qa_external_signal`)
- AST 기반 전략 메타 추출 시딩 스크립트 추가 (`scripts/qa_seed_strategies.py`) — 런타임 import 없이 정적 파싱으로 StrategyMeta 추출 후 DB 등록
- `qa-entrypoint.sh`에서 서버 기동 후 시딩 스크립트를 호출하여 `GET /api/strategies`가 전략 목록을 반환하도록 수정
- `Dockerfile.qa`에서 모든 `qa_*.py` 전략 파일 및 시딩 스크립트를 COPY

Refs #650

## Test plan
- [ ] `ruff check` / `ruff format` 통과 확인
- [ ] `pytest tests/ -v` 전체 통과 확인 (2423 passed)
- [ ] QA 컨테이너 빌드 후 `GET /api/strategies` 응답에 6개 전략 반환 확인
- [ ] `qa_invalid_meta` 전략이 등록되지만 validate 시 exchange 오류 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)