### PR TITLE
fix(strategy): 전략 성과 조회 500 에러 수정

### DIFF
--- a/src/ante/trade/performance.py
+++ b/src/ante/trade/performance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sqlite3
 import statistics
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -141,7 +142,10 @@ class PerformanceTracker:
             ORDER BY trade_date ASC
         """
 
-        rows = await self._db.fetch_all(query, tuple(params))
+        try:
+            rows = await self._db.fetch_all(query, tuple(params))
+        except sqlite3.OperationalError:
+            return []
         return [
             DailySummary(
                 date=row["trade_date"],
@@ -192,7 +196,10 @@ class PerformanceTracker:
             ORDER BY week_start ASC
         """
 
-        rows = await self._db.fetch_all(query, tuple(params))
+        try:
+            rows = await self._db.fetch_all(query, tuple(params))
+        except sqlite3.OperationalError:
+            return []
         return [
             WeeklySummary(
                 week_start=row["week_start"],
@@ -247,7 +254,10 @@ class PerformanceTracker:
             ORDER BY yr ASC, mo ASC
         """
 
-        rows = await self._db.fetch_all(query, tuple(params))
+        try:
+            rows = await self._db.fetch_all(query, tuple(params))
+        except sqlite3.OperationalError:
+            return []
         return [
             MonthlySummary(
                 year=int(row["yr"]),
@@ -340,7 +350,11 @@ class PerformanceTracker:
         where = " AND ".join(conditions)
         query = f"SELECT * FROM trades WHERE {where} ORDER BY timestamp ASC"
 
-        rows = await self._db.fetch_all(query, tuple(params))
+        try:
+            rows = await self._db.fetch_all(query, tuple(params))
+        except sqlite3.OperationalError:
+            logger.debug("trades 테이블 없음 — 빈 목록 반환")
+            return []
         return [self._row_to_record(row) for row in rows]
 
     async def _calculate_pnl_per_trade(
@@ -356,13 +370,16 @@ class PerformanceTracker:
         pnl_list: list[float] = []
         for trade in sell_trades:
             # position_history에서 해당 거래의 pnl 조회
-            row = await self._db.fetch_one(
-                """SELECT pnl FROM position_history
-                   WHERE bot_id = ? AND symbol = ? AND action = 'sell'
-                     AND price = ? AND quantity = ?
-                   ORDER BY created_at DESC LIMIT 1""",
-                (trade.bot_id, trade.symbol, trade.price, trade.quantity),
-            )
+            try:
+                row = await self._db.fetch_one(
+                    """SELECT pnl FROM position_history
+                       WHERE bot_id = ? AND symbol = ? AND action = 'sell'
+                         AND price = ? AND quantity = ?
+                       ORDER BY created_at DESC LIMIT 1""",
+                    (trade.bot_id, trade.symbol, trade.price, trade.quantity),
+                )
+            except sqlite3.OperationalError:
+                row = None
             if row:
                 pnl_list.append(float(row["pnl"]))
             else:

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -166,6 +166,9 @@ async def get_strategy_performance(
     metrics = await tracker.calculate(strategy_id=strategy_id)
 
     result = asdict(metrics)
+    # sharpe_ratio가 None이면 응답 모델(float)과 호환되도록 0.0으로 변환
+    if result.get("sharpe_ratio") is None:
+        result["sharpe_ratio"] = 0.0
 
     # equity curve: bot_id가 있으면 추가
     equity_curve: list[dict] = []

--- a/tests/unit/test_strategy_api.py
+++ b/tests/unit/test_strategy_api.py
@@ -236,3 +236,72 @@ class TestStrategyTrades:
         data = resp.json()
         assert len(data["trades"]) == 2
         assert data["next_cursor"] is not None
+
+
+class TestStrategyPerformance:
+    """전략 성과 조회 API 테스트."""
+
+    def test_performance_no_trades_table(self, registry):
+        """trades 테이블이 없을 때 500이 아닌 200 반환 (#659)."""
+        import sqlite3
+        from unittest.mock import AsyncMock
+
+        fake_db = AsyncMock()
+        fake_db.fetch_all = AsyncMock(
+            side_effect=sqlite3.OperationalError("no such table: trades")
+        )
+
+        registry._strategies = [
+            FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
+        ]
+
+        app = create_app(
+            strategy_registry=registry,
+            db=fake_db,
+        )
+        client = TestClient(app)
+
+        resp = client.get("/api/strategies/s1/performance")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_trades"] == 0
+        assert data["win_rate"] == 0.0
+        assert data["total_pnl"] == 0.0
+        assert data["equity_curve"] == []
+
+    def test_performance_empty_trades(self, registry):
+        """trades 테이블은 있지만 거래가 없을 때 200 반환."""
+        from unittest.mock import AsyncMock
+
+        fake_db = AsyncMock()
+        fake_db.fetch_all = AsyncMock(return_value=[])
+
+        registry._strategies = [
+            FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
+        ]
+
+        app = create_app(
+            strategy_registry=registry,
+            db=fake_db,
+        )
+        client = TestClient(app)
+
+        resp = client.get("/api/strategies/s1/performance")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_trades"] == 0
+        assert data["equity_curve"] == []
+
+    def test_performance_nonexistent_strategy(self, registry):
+        """존재하지 않는 전략 성과 → 404."""
+        from unittest.mock import AsyncMock
+
+        fake_db = AsyncMock()
+        app = create_app(
+            strategy_registry=registry,
+            db=fake_db,
+        )
+        client = TestClient(app)
+
+        resp = client.get("/api/strategies/nonexistent/performance")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- 거래 기록이 없는 전략 성과 조회 시 500 대신 빈 성과(0값) 반환
- `trades`/`position_history` 테이블 미존재 시 `OperationalError` 처리 추가
- `sharpe_ratio: None` → `0.0` 변환으로 응답 모델 검증 오류 수정

## Test plan
- [x] 거래 테이블 미존재 시 200 + 빈 성과 반환 확인
- [x] 거래 0건 시 200 + 빈 성과 반환 확인
- [x] 존재하지 않는 전략 조회 시 404 확인
- [x] 기존 테스트 전체 통과 확인

Refs #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)