### PR TITLE
fix(account): 삭제된 계좌 활성화 시 409 반환

### DIFF
--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -220,7 +220,7 @@ async def update_account(
     except AccountNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except AccountDeletedError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=409, detail=str(e))
 
     if audit_logger:
         await audit_logger.log(
@@ -291,7 +291,7 @@ async def activate_account(
     except AccountNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except AccountDeletedError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=409, detail=str(e))
 
     account = await account_service.get(account_id)
 

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -442,6 +442,18 @@ class TestActivateAccount:
         resp = client.post("/api/accounts/nonexistent/activate")
         assert resp.status_code == 404
 
+    def test_activate_deleted_returns_409(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        account = _make_account()
+        account.status = AccountStatus.DELETED
+        account_service._accounts[account.account_id] = account
+
+        resp = client.post("/api/accounts/test-account/activate")
+        assert resp.status_code == 409
+
 
 class TestDeleteAccount:
     """DELETE /api/accounts/:id."""


### PR DESCRIPTION
## Summary
- 삭제된 계좌 활성화/수정 시 HTTP 400 → 409 (Conflict) 변경
- 기존 `AccountAlreadySuspendedError` → 409 패턴과 일관성 유지
- activate, update 핸들러 모두 동일하게 수정

## Test plan
- [x] 삭제된 계좌 활성화 시 409 반환 확인
- [x] 기존 테스트 전체 통과 확인

Refs #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)