### PR TITLE
fix(tc): credentials.feature broker_type 재설계

### DIFF
--- a/tests/tc/account/credentials.feature
+++ b/tests/tc/account/credentials.feature
@@ -31,7 +31,7 @@ Feature: 계좌 인증정보 관리
   Scenario: 인증정보 조회 (CLI)
     When 컨테이너에서 실행: ante account credentials {account_id} --format json
     Then 종료 코드는 0
-    And stdout JSON의 .app_key 는 null이 아니다
+    And stdout JSON의 .credentials.app_key 는 null이 아니다
 
   Scenario: 인증정보 설정 후 봇 생성 및 시작 가능
     When GET /api/strategies
@@ -49,7 +49,7 @@ Feature: 계좌 인증정보 관리
   # ── 에러 케이스 ──
 
   Scenario: 인증정보 없는 계좌로 봇 시작 시 에러
-    # 인증정보 없는 새 계좌 생성
+    # 인증정보 없는 새 계좌 생성 (test 브로커, virtual 모드)
     When POST /api/accounts 요청:
       | field               | value                |
       | account_id          | qa-cred-acct-02      |
@@ -59,8 +59,8 @@ Feature: 계좌 인증정보 관리
       | timezone            | Asia/Seoul           |
       | trading_hours_start | 09:00                |
       | trading_hours_end   | 15:30                |
-      | trading_mode        | live                 |
-      | broker_type         | kis                  |
+      | trading_mode        | virtual              |
+      | broker_type         | test                 |
     Then 응답 상태는 201
     And 응답 body.account.account_id 를 {no_cred_account_id}로 저장한다
     # 봇 생성


### PR DESCRIPTION
## Summary
- 인증정보 조회 시나리오의 JSON 경로를 `.app_key` → `.credentials.app_key`로 수정하여 실제 CLI 출력 구조와 일치시킴
- 인증정보 없는 봇 시작 에러 시나리오에서 존재하지 않는 `broker_type: kis`를 유효한 `broker_type: test`로 변경, `trading_mode`를 `virtual`로 수정

## Test plan
- [ ] QA 환경에서 `credentials.feature` 전체 시나리오 실행
- [ ] 인증정보 조회 시나리오에서 `.credentials.app_key`가 null이 아닌지 확인
- [ ] 인증정보 없는 계좌로 봇 시작 시 422 응답 확인

Refs #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)