### PR TITLE
fix(api): 전략 상세 응답에 root-level status 필드 추가

### DIFF
--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -137,7 +137,11 @@ async def get_strategy(
                 bot_info = b
                 break
 
-    return {"strategy": strategy_dict, "bot": bot_info}
+    return {
+        "strategy": strategy_dict,
+        "bot": bot_info,
+        "status": strategy_dict["status"],
+    }
 
 
 @router.get(

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -242,6 +242,7 @@ class StrategyDetailResponse(BaseModel):
 
     strategy: StrategyInfo
     bot: BotInfo | None = None
+    status: str | None = None
 
 
 class EquityCurvePoint(BaseModel):

--- a/tests/unit/test_strategy_api.py
+++ b/tests/unit/test_strategy_api.py
@@ -179,6 +179,23 @@ class TestGetStrategy:
         assert data["strategy"]["strategy_id"] == "ma_cross_v1"
         assert data["strategy"]["description"] == "이동평균 크로스"
 
+    def test_root_level_status(self, client, registry):
+        """응답 root level에 status 필드 포함 (#672)."""
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                status=StrategyStatus.REGISTERED,
+            ),
+        ]
+        resp = client.get("/api/strategies/s1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] is not None
+        assert data["status"] == "registered"
+        assert data["status"] == data["strategy"]["status"]
+
     def test_get_nonexistent(self, client):
         """존재하지 않는 전략 → 404."""
         resp = client.get("/api/strategies/nonexistent")


### PR DESCRIPTION
## Summary
- GET `/api/strategies/{strategy_id}` 응답에 root-level `status` 필드 추가 (`strategy.status` 미러링)
- `StrategyDetailResponse` 스키마에 `status: str | None` 필드 추가
- 해당 동작 검증 단위 테스트 추가

Closes #672

## Test plan
- [x] `test_root_level_status`: 응답 root level에 status가 존재하고 strategy.status와 동일한 값인지 검증
- [x] 기존 13개 테스트 모두 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)