### PR TITLE
fix(cli): DART API 키 프롬프트 EOF Abort 수정 (#673)

### DIFF
--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -186,7 +186,11 @@ def _prompt_datafeed(config_path: Path) -> None:
         key = click.prompt("data.go.kr API 키")
         feed_cfg.set_api_key("ANTE_DATAGOKR_API_KEY", key)
 
-    if click.confirm("DART API 키를 입력하시겠습니까?", default=False):
+    try:
+        want_dart = click.confirm("DART API 키를 입력하시겠습니까?", default=False)
+    except (click.Abort, EOFError):
+        want_dart = False
+    if want_dart:
         key = click.prompt("DART API 키")
         feed_cfg.set_api_key("ANTE_DART_API_KEY", key)
 

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -385,6 +385,40 @@ class TestInitInteractive:
         feed_env = target / "data" / ".feed" / ".env"
         assert not feed_env.exists()
 
+    def test_init_dart_prompt_eof_defaults_no(self, runner, tmp_path):
+        """DART 프롬프트에서 EOF 수신 시 Abort 없이 기본값 'N'으로 처리된다 (#673)."""
+        target = tmp_path / "config"
+        # 7개 입력만 제공 — DART 프롬프트에서 EOF 발생
+        input_lines = "\n".join(
+            [
+                "owner",  # Member ID
+                "홈트레이더",  # 이름
+                "pass1234",  # 패스워드
+                "pass1234",  # 패스워드 확인
+                "n",  # 계좌 등록? n
+                "n",  # 텔레그램? n
+                "n",  # data.go.kr? n
+                # DART 입력 없음 → EOF
+            ]
+        )
+
+        patches = _patch_bootstrap_and_auth()
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(
+                cli, ["init", "--dir", str(target)], input=input_lines
+            )
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert result.exit_code == 0, result.output
+        assert "초기 설정 완료" in result.output
+        # DART 키가 저장되지 않아야 함
+        feed_env = target / "data" / ".feed" / ".env"
+        assert not feed_env.exists()
+
     def test_init_json_output(self, runner, tmp_path):
         """--format json 시 JSON 출력에 accounts 포함."""
         target = tmp_path / "config"


### PR DESCRIPTION
## Summary
- `ante init` 대화형 설치에서 DART API 키 프롬프트가 EOF를 수신하면 `click.Abort` 예외로 설치가 중단되는 버그 수정
- `click.Abort`/`EOFError`를 catch하여 기본값 'N'(스킵)으로 처리
- EOF 발생 시나리오 검증 단위 테스트 추가

## Changes
- `src/ante/cli/commands/init.py`: `_prompt_datafeed()`의 DART confirm을 try/except로 감싸 EOF 처리
- `tests/unit/test_cli_init.py`: 7개 입력만 제공하여 DART 프롬프트 EOF 시 정상 완료되는 테스트 추가

## Test plan
- [x] 기존 14개 단위 테스트 전체 통과
- [x] 새 테스트 `test_init_dart_prompt_eof_defaults_no` 통과 (7개 입력으로 EOF 시나리오 검증)

Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)