### PR TITLE
fix(treasury): 봇 삭제 시 Treasury budget 환수 및 정리

### DIFF
--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from ante.strategy.base import Strategy
     from ante.strategy.context import StrategyContext
     from ante.strategy.snapshot import StrategySnapshot
+    from ante.treasury.manager import TreasuryManager  # noqa: F811
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,7 @@ class BotManager:
         rule_engine: RuleEngine | None = None,
         strategy_rule_configs: dict[str, list[dict[str, Any]]] | None = None,
         account_service: AccountService | None = None,
+        treasury_manager: TreasuryManager | None = None,
     ) -> None:
         self._eventbus = eventbus
         self._db = db
@@ -63,6 +65,7 @@ class BotManager:
         self._rule_engine = rule_engine
         self._strategy_rule_configs = strategy_rule_configs or {}
         self._account_service = account_service
+        self._treasury_manager = treasury_manager
         self._bots: dict[str, Bot] = {}
         self._suppress_notification_bot_ids: set[str] = set()
         self._restart_counts: dict[str, int] = {}
@@ -358,6 +361,23 @@ class BotManager:
         # 전략 스냅샷 정리
         if self._snapshot:
             self._snapshot.cleanup(bot_id)
+
+        # Treasury budget 환수
+        if self._treasury_manager:
+            try:
+                treasury = self._treasury_manager.get(bot.config.account_id)
+                released = await treasury.release_budget(bot_id)
+                if released > 0:
+                    logger.info(
+                        "봇 삭제 시 예산 환수: %s -- %s",
+                        bot_id,
+                        f"{released:,.0f}",
+                    )
+            except KeyError:
+                logger.debug(
+                    "봇 삭제 시 Treasury 미존재: account_id=%s",
+                    bot.config.account_id,
+                )
 
         bot.status = BotStatus.DELETED
         del self._bots[bot_id]

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -275,6 +275,7 @@ async def _init_trading(s: Services) -> None:
         context_factory=None,  # APIGateway 연결 후 갱신
         snapshot=s.strategy_snapshot,
         account_service=s.account_service,
+        treasury_manager=s.treasury_manager,
     )
     await s.bot_manager.initialize()
 

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -337,6 +337,50 @@ class Treasury:
         )
         return True
 
+    async def release_budget(self, bot_id: str) -> float:
+        """봇의 할당액 전액을 미할당으로 환수하고 budget 레코드를 삭제한다.
+
+        봇 삭제 시 호출된다. bot_status_checker를 우회하여 어떤 상태에서든
+        환수가 가능하다 (delete_bot에서 이미 봇을 중지한 뒤 호출하므로).
+
+        Args:
+            bot_id: 대상 봇 ID.
+
+        Returns:
+            환수된 금액. budget이 없으면 0.0.
+        """
+        budget = self._budgets.pop(bot_id, None)
+        if not budget:
+            return 0.0
+
+        released = budget.allocated
+        self._unallocated += released
+
+        # DB에서 budget 레코드 삭제
+        await self._db.execute(
+            "DELETE FROM bot_budgets WHERE bot_id = ?",
+            (bot_id,),
+        )
+        await self._save_state()
+        await self._log_transaction(
+            bot_id, "release", released, "봇 삭제에 의한 예산 전액 환수"
+        )
+
+        # 해당 봇의 미체결 예약도 정리
+        pending_orders = [
+            oid for oid, (bid, _) in self._reservations.items() if bid == bot_id
+        ]
+        for oid in pending_orders:
+            self._reservations.pop(oid, None)
+
+        logger.info(
+            "예산 전액 환수: %s -- %s (account=%s)",
+            bot_id,
+            f"{released:,.0f}",
+            self._account_id,
+        )
+        return released
+
     async def update_budget(self, bot_id: str, target_amount: float) -> None:
         """봇의 예산을 목표 금액으로 변경.
 

--- a/tests/unit/test_bot_delete_budget.py
+++ b/tests/unit/test_bot_delete_budget.py
@@ -1,0 +1,244 @@
+"""봇 삭제 시 Treasury budget 환수 테스트.
+
+Refs #677
+"""
+
+import asyncio
+
+import pytest
+
+from ante.bot import BotConfig, BotManager
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.strategy import (
+    DataProvider,
+    OrderView,
+    PortfolioView,
+    Strategy,
+    StrategyContext,
+    StrategyMeta,
+)
+from ante.treasury.treasury import Treasury
+
+# -- Fake 구현체 --
+
+
+class FakeDataProvider(DataProvider):
+    async def get_ohlcv(self, symbol, timeframe="1d", limit=100):
+        return [{"close": 100.0}]
+
+    async def get_current_price(self, symbol):
+        return 100.0
+
+    async def get_indicator(self, symbol, indicator, params=None):
+        return {}
+
+
+class FakePortfolioView(PortfolioView):
+    def get_positions(self, bot_id):
+        return {}
+
+    def get_balance(self, bot_id):
+        return {"total": 1000000.0, "available": 500000.0}
+
+
+class FakeOrderView(OrderView):
+    def get_open_orders(self, bot_id):
+        return []
+
+
+class SimpleStrategy(Strategy):
+    meta = StrategyMeta(name="simple", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+
+
+class FakeTreasuryManager:
+    """TreasuryManager의 경량 대체."""
+
+    def __init__(self) -> None:
+        self._treasuries: dict[str, Treasury] = {}
+
+    def register(self, account_id: str, treasury: Treasury) -> None:
+        self._treasuries[account_id] = treasury
+
+    def get(self, account_id: str) -> Treasury:
+        if account_id not in self._treasuries:
+            raise KeyError(f"Treasury not found: account_id={account_id}")
+        return self._treasuries[account_id]
+
+
+# -- Fixtures --
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+def ctx():
+    return StrategyContext(
+        bot_id="bot1",
+        data_provider=FakeDataProvider(),
+        portfolio=FakePortfolioView(),
+        order_view=FakeOrderView(),
+    )
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    try:
+        await asyncio.wait_for(database.close(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+@pytest.fixture
+async def treasury(db, eventbus):
+    t = Treasury(db=db, eventbus=eventbus, account_id="test")
+    await t.initialize()
+    await t.set_account_balance(1_000_000)
+    return t
+
+
+@pytest.fixture
+async def treasury_manager(treasury):
+    mgr = FakeTreasuryManager()
+    mgr.register("test", treasury)
+    return mgr
+
+
+@pytest.fixture
+async def manager(eventbus, db, treasury_manager):
+    m = BotManager(eventbus=eventbus, db=db, treasury_manager=treasury_manager)
+    await m.initialize()
+    yield m
+    for bot in list(m._bots.values()):
+        if bot._task and not bot._task.done():
+            bot._task.cancel()
+    try:
+        await asyncio.wait_for(m.stop_all(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+# -- Tests --
+
+
+class TestDeleteBotBudgetRelease:
+    """봇 삭제 시 Treasury budget 환수 검증."""
+
+    async def test_delete_releases_budget(self, manager, ctx, treasury):
+        """봇 삭제 시 할당액이 전액 환수되고 budget이 제거된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        # 예산 할당
+        result = await treasury.allocate("bot1", 200_000)
+        assert result is True
+        assert treasury.get_budget("bot1") is not None
+        assert treasury.get_budget("bot1").allocated == 200_000
+        assert treasury.unallocated == 800_000
+
+        # 봇 삭제
+        await manager.delete_bot("bot1")
+
+        # 검증: budget이 제거되고 미할당으로 환수
+        assert treasury.get_budget("bot1") is None
+        assert treasury.unallocated == 1_000_000
+
+    async def test_delete_without_budget(self, manager, ctx, treasury):
+        """예산 할당 없는 봇 삭제 시에도 정상 동작한다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        # 예산 할당 없이 삭제
+        await manager.delete_bot("bot1")
+
+        assert treasury.get_budget("bot1") is None
+        assert treasury.unallocated == 1_000_000
+
+    async def test_delete_releases_full_amount_after_partial_spend(
+        self, manager, ctx, treasury
+    ):
+        """일부 사용 후 삭제 시 남은 할당액이 환수된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        await treasury.allocate("bot1", 300_000)
+        # 내부 spent 시뮬레이션 (available 감소)
+        budget = treasury.get_budget("bot1")
+        budget.available -= 50_000
+        budget.spent += 50_000
+
+        await manager.delete_bot("bot1")
+
+        # allocated 전체(300_000)가 unallocated로 환수
+        assert treasury.get_budget("bot1") is None
+        assert treasury.unallocated == 1_000_000
+
+    async def test_delete_without_treasury_manager(self, eventbus, db, ctx):
+        """treasury_manager 없이 생성된 BotManager에서도 삭제가 정상 동작한다."""
+        m = BotManager(eventbus=eventbus, db=db)
+        await m.initialize()
+
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await m.create_bot(config, SimpleStrategy, ctx)
+        await m.delete_bot("bot1")
+
+        assert m.get_bot("bot1") is None
+
+    async def test_budget_db_record_deleted(self, manager, ctx, treasury, db):
+        """삭제 후 DB에서도 budget 레코드가 제거된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await treasury.allocate("bot1", 100_000)
+
+        await manager.delete_bot("bot1")
+
+        row = await db.fetch_one("SELECT * FROM bot_budgets WHERE bot_id = 'bot1'")
+        assert row is None
+
+    async def test_transaction_log_recorded(self, manager, ctx, treasury, db):
+        """삭제 시 release 트랜잭션 로그가 기록된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await treasury.allocate("bot1", 150_000)
+
+        await manager.delete_bot("bot1")
+
+        rows = await db.fetch_all(
+            "SELECT * FROM treasury_transactions"
+            " WHERE bot_id = 'bot1' AND transaction_type = 'release'"
+        )
+        assert len(rows) == 1
+        assert rows[0]["amount"] == 150_000
+
+    async def test_recreate_after_delete_no_accumulation(
+        self, manager, ctx, treasury, eventbus, db
+    ):
+        """삭제 후 동일 bot_id로 재생성 시 이전 할당이 누적되지 않는다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await treasury.allocate("bot1", 200_000)
+
+        await manager.delete_bot("bot1")
+
+        # 동일 bot_id로 재생성
+        ctx2 = StrategyContext(
+            bot_id="bot1",
+            data_provider=FakeDataProvider(),
+            portfolio=FakePortfolioView(),
+            order_view=FakeOrderView(),
+        )
+        await manager.create_bot(config, SimpleStrategy, ctx2)
+        await treasury.allocate("bot1", 100_000)
+
+        budget = treasury.get_budget("bot1")
+        assert budget.allocated == 100_000  # 이전 200_000이 누적되지 않음
+        assert treasury.unallocated == 900_000


### PR DESCRIPTION
## Summary
- 봇 삭제(`delete_bot`) 시 Treasury의 budget 레코드가 정리되지 않아 삭제된 봇의 할당액이 잔존하는 버그를 수정
- `Treasury.release_budget(bot_id)` 메서드를 추가하여 전액 환수 + DB 레코드 삭제 + 트랜잭션 로그 기록을 수행
- `BotManager`에 `treasury_manager` 의존성을 주입하고, `delete_bot()`에서 soft delete 전 budget 환수를 호출

## Changes
- `src/ante/treasury/treasury.py`: `release_budget()` 메서드 추가
- `src/ante/bot/manager.py`: `treasury_manager` 파라미터 추가 + `delete_bot()`에서 환수 호출
- `src/ante/main.py`: BotManager 생성 시 `treasury_manager` 전달
- `tests/unit/test_bot_delete_budget.py`: 단위 테스트 7건 추가

## Test plan
- [x] 봇 삭제 후 budget이 전액 환수되고 레코드가 제거되는지 확인
- [x] 예산 할당 없는 봇 삭제 시 정상 동작 확인
- [x] treasury_manager 미주입 시에도 삭제 정상 동작 확인
- [x] 삭제 후 동일 bot_id 재생성 시 이전 할당 누적 방지 확인
- [x] DB 레코드 삭제 및 트랜잭션 로그 기록 확인
- [x] 기존 전체 단위 테스트 2446건 PASS 확인

Refs #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)