### PR TITLE
fix(account): soft-delete된 계좌 ID 충돌 시 409 반환

### DIFF
--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -109,6 +109,16 @@ class AccountService:
                 f"계좌 '{account.account_id}'가 이미 존재합니다."
             )
 
+        # DB에서 soft-delete된 동일 ID 존재 여부 확인
+        deleted = await self._db.fetch_one(
+            "SELECT account_id FROM accounts WHERE account_id = ? AND status = ?",
+            (account.account_id, AccountStatus.DELETED),
+        )
+        if deleted:
+            raise AccountAlreadyExistsError(
+                f"계좌 '{account.account_id}'가 이미 존재합니다 (삭제 상태)."
+            )
+
         # broker_type 유효성 검증 (프리셋에 정의된 것만 허용)
         if account.broker_type not in BROKER_PRESETS:
             raise InvalidBrokerTypeError(

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -90,6 +90,17 @@ async def test_create_duplicate_raises(service):
 
 
 @pytest.mark.asyncio
+async def test_create_soft_deleted_duplicate_raises(service):
+    """soft-delete된 계좌와 동일 ID로 생성 시 AccountAlreadyExistsError."""
+    await service.create(_make_account())
+    await service.delete("test", deleted_by="system")
+
+    # 메모리에서는 제거되었지만 DB에 deleted 상태로 남아 있음
+    with pytest.raises(AccountAlreadyExistsError, match="삭제 상태"):
+        await service.create(_make_account())
+
+
+@pytest.mark.asyncio
 async def test_create_invalid_broker_type_raises(service):
     """잘못된 broker_type 생성 시 에러."""
     account = _make_account(broker_type="nonexistent-broker")


### PR DESCRIPTION
## Summary
- `AccountService.create()`에서 메모리 캐시 중복 체크 후 DB에서 soft-delete된 동일 `account_id` 존재 여부를 추가 확인
- UNIQUE constraint 위반(500 Internal Server Error) 대신 `AccountAlreadyExistsError`(409 Conflict)를 반환하도록 수정
- 웹 라우터는 이미 `AccountAlreadyExistsError` -> 409 매핑이 되어 있어 추가 변경 불필요

## Test plan
- [x] `test_create_soft_deleted_duplicate_raises` 테스트 추가 및 통과 확인
- [x] 기존 25개 테스트 전체 통과 확인
- [x] ruff check / ruff format 통과

Refs #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)