### PR TITLE
feat(trade): DailyReportScheduler Account 기반 실행 시각 + DailyReportEvent 신설

### DIFF
--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -427,6 +427,23 @@ class MemberAuthFailedEvent(Event):
     reason: str = ""
 
 
+# ── 일일 리포트 (DailyReport) ──────────────────────
+
+
+@dataclass(frozen=True)
+class DailyReportEvent(Event):
+    """DailyReportScheduler → EventBus: 일일 성과 리포트 발행."""
+
+    account_id: str = ""
+    report_date: str = ""  # YYYY-MM-DD
+    trade_count: int = 0
+    has_trades: bool = False
+    daily_pnl: float = 0.0
+    daily_return: float = 0.0
+    net_trade_amount: float = 0.0
+    unrealized_pnl: float = 0.0
+
+
 # ── 잔고 동기화 (Treasury) ──────────────────────
 
 

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -411,17 +411,47 @@ async def _init_reconcile_scheduler(s: Services) -> None:
 
 
 async def _init_daily_report_scheduler(s: Services) -> None:
-    """DailyReportScheduler 생성 및 시작."""
-    from ante.trade.daily_report import DailyReportScheduler
-
-    s.daily_report_scheduler = DailyReportScheduler(
-        performance_tracker=s.performance_tracker,
-        trade_recorder=s.trade_recorder,
-        position_history=s.position_history,
-        eventbus=s.eventbus,
+    """DailyReportScheduler 생성 및 시작 (Account 기반 실행 시각)."""
+    from ante.trade.daily_report import (
+        DailyReportScheduler,
+        compute_report_time,
     )
+
+    # 첫 번째 활성 계좌 기반으로 report_time, account_id, currency 결정
+    accounts = await s.account_service.list() if s.account_service else []
+    account = accounts[0] if accounts else None
+
+    report_time = compute_report_time(account.trading_hours_end) if account else None
+    account_id = account.account_id if account else ""
+    currency = account.currency if account else "KRW"
+
+    # Treasury 인스턴스 조회
+    treasury = None
+    if s.treasury_manager and account_id:
+        try:
+            treasury = s.treasury_manager.get(account_id)
+        except KeyError:
+            logger.warning("Treasury not found for account_id=%s", account_id)
+
+    kwargs: dict = {
+        "performance_tracker": s.performance_tracker,
+        "trade_recorder": s.trade_recorder,
+        "position_history": s.position_history,
+        "eventbus": s.eventbus,
+        "account_id": account_id,
+        "currency": currency,
+        "treasury": treasury,
+    }
+    if report_time is not None:
+        kwargs["report_time"] = report_time
+
+    s.daily_report_scheduler = DailyReportScheduler(**kwargs)
     await s.daily_report_scheduler.start()
-    logger.info("DailyReportScheduler 시작 완료")
+    logger.info(
+        "DailyReportScheduler 시작 완료 (account=%s, currency=%s)",
+        account_id,
+        currency,
+    )
 
 
 async def _init_stream_integration(

--- a/src/ante/trade/daily_report.py
+++ b/src/ante/trade/daily_report.py
@@ -1,7 +1,8 @@
-"""DailyReportScheduler — 장 마감 후 일일 성과 요약 알림 발행.
+"""DailyReportScheduler -- Account 기반 일일 성과 리포트 발행.
 
-KRX 장 마감(15:30) 이후 지정 시각(기본 16:00)에 1회 실행하여,
-당일 거래 요약을 NotificationEvent로 발행한다.
+Account의 trading_hours_end + 30분 시각에 매일 실행하여,
+DailyReportEvent를 무조건 발행하고 (거래 0건이어도),
+거래 1건 이상일 때만 NotificationEvent를 추가 발행한다.
 """
 
 from __future__ import annotations
@@ -16,24 +17,71 @@ if TYPE_CHECKING:
     from ante.trade.performance import PerformanceTracker
     from ante.trade.position import PositionHistory
     from ante.trade.recorder import TradeRecorder
+    from ante.treasury.treasury import Treasury
 
 logger = logging.getLogger(__name__)
 
 KST = timezone(timedelta(hours=9))
 DEFAULT_REPORT_TIME = time(16, 0)  # 16:00 KST
 
+# 통화 기호 매핑
+_CURRENCY_SYMBOLS: dict[str, str] = {
+    "KRW": "원",
+    "USD": "$",
+}
+
+
+def compute_report_time(trading_hours_end: str) -> time:
+    """trading_hours_end(HH:MM) + 30분을 report_time으로 변환.
+
+    Args:
+        trading_hours_end: "HH:MM" 형식 문자열.
+
+    Returns:
+        report_time (time).
+    """
+    h, m = trading_hours_end.split(":")
+    dt = datetime(2000, 1, 1, int(h), int(m)) + timedelta(minutes=30)
+    return dt.time()
+
+
+def format_currency(value: float, currency: str) -> str:
+    """통화 단위를 적용하여 금액 포맷팅.
+
+    Args:
+        value: 금액.
+        currency: 통화 코드 (KRW, USD 등).
+
+    Returns:
+        포맷된 문자열.
+    """
+    symbol = _CURRENCY_SYMBOLS.get(currency, currency)
+    if value >= 0:
+        sign = "+"
+    else:
+        sign = "-"
+        value = abs(value)
+    if currency == "USD":
+        return f"{sign}{symbol}{value:,.2f}"
+    return f"{sign}{value:,.0f}{symbol}"
+
 
 class DailyReportScheduler:
-    """장 마감 후 당일 거래 요약을 NotificationEvent로 발행한다.
+    """Account 기반 일일 성과 리포트 스케줄러.
 
-    ReconcileScheduler와 동일한 asyncio 루프 패턴을 사용한다.
+    매일 report_time에 실행하여:
+    1. DailyReportEvent를 무조건 발행 (성과 데이터 포함)
+    2. NotificationEvent는 거래 1건 이상일 때만 발행
 
     Args:
         performance_tracker: 일별 성과 집계 조회용.
         trade_recorder: 당일 거래 건수(매수/매도) 조회용.
         position_history: 보유 포지션 현황 조회용.
-        eventbus: NotificationEvent 발행용.
+        eventbus: 이벤트 발행용.
         report_time: 리포트 발행 시각 (KST). 기본 16:00.
+        account_id: 계좌 ID.
+        currency: 통화 코드 (KRW, USD 등).
+        treasury: Treasury 인스턴스 (성과 산출용). Optional.
     """
 
     def __init__(
@@ -43,22 +91,28 @@ class DailyReportScheduler:
         position_history: PositionHistory,
         eventbus: EventBus,
         report_time: time = DEFAULT_REPORT_TIME,
+        account_id: str = "",
+        currency: str = "KRW",
+        treasury: Treasury | None = None,
     ) -> None:
         self._performance = performance_tracker
         self._recorder = trade_recorder
         self._positions = position_history
         self._eventbus = eventbus
         self._report_time = report_time
+        self._account_id = account_id
+        self._currency = currency
+        self._treasury = treasury
         self._task: asyncio.Task[None] | None = None
 
     async def start(self) -> None:
-        """스케줄러를 시작한다."""
+        """Start the scheduler."""
         if self._task and not self._task.done():
-            logger.warning("DailyReportScheduler 이미 실행 중")
+            logger.warning("DailyReportScheduler already running")
             return
 
         logger.info(
-            "DailyReportScheduler 시작 (발행 시각: %s KST)",
+            "DailyReportScheduler start (report_time: %s KST)",
             self._report_time.strftime("%H:%M"),
         )
         self._task = asyncio.create_task(
@@ -67,7 +121,7 @@ class DailyReportScheduler:
         )
 
     async def stop(self) -> None:
-        """스케줄러를 중지한다."""
+        """Stop the scheduler."""
         if self._task and not self._task.done():
             self._task.cancel()
             try:
@@ -75,21 +129,27 @@ class DailyReportScheduler:
             except asyncio.CancelledError:
                 pass
             self._task = None
-            logger.info("DailyReportScheduler 종료")
+            logger.info("DailyReportScheduler stopped")
 
     async def run_once(self, target_date: date | None = None) -> bool:
-        """수동 실행 (테스트/CLI용).
+        """Execute daily report for the given date.
+
+        Always publishes DailyReportEvent.
+        Publishes NotificationEvent only when there are trades.
 
         Args:
-            target_date: 대상 날짜. None이면 오늘(KST).
+            target_date: Target date. Defaults to today (KST).
 
         Returns:
-            True: 알림 발행됨, False: 당일 거래 0건으로 스킵.
+            True if there were trades (NotificationEvent published),
+            False if no trades (only DailyReportEvent published).
         """
         today = target_date or datetime.now(KST).date()
         today_str = today.isoformat()
+        yesterday = today - timedelta(days=1)
+        yesterday_str = yesterday.isoformat()
 
-        # 1) 당일 체결 거래 조회 (매수/매도 건수)
+        # 1) Query today's filled trades
         from ante.trade.models import TradeStatus
 
         trades = await self._recorder.get_trades(
@@ -99,30 +159,86 @@ class DailyReportScheduler:
             limit=10000,
         )
 
-        if not trades:
-            logger.debug("일일 리포트 스킵 — 당일 거래 0건 (%s)", today_str)
-            return False
-
         total_count = len(trades)
+        has_trades = total_count > 0
         buy_count = sum(1 for t in trades if t.side == "buy")
         sell_count = sum(1 for t in trades if t.side == "sell")
 
-        # 2) 일별 실현 손익 조회
+        # 2) Compute performance metrics
+        net_trade_amount = 0.0
+        for t in trades:
+            if t.side == "buy":
+                net_trade_amount += t.price * t.quantity
+            else:
+                net_trade_amount -= t.price * t.quantity
+
+        # Get today's ante_eval_amount from Treasury
+        today_ante_eval = 0.0
+        ante_purchase_amount = 0.0
+        yesterday_ante_eval = 0.0
+
+        if self._treasury:
+            summary = self._treasury.get_summary()
+            today_ante_eval = summary.get("ante_eval_amount", 0.0)
+            ante_purchase_amount = summary.get("ante_purchase_amount", 0.0)
+
+            # Get yesterday's snapshot
+            prev_snapshot = await self._treasury.get_daily_snapshot(yesterday_str)
+            if prev_snapshot:
+                yesterday_ante_eval = prev_snapshot["ante_eval_amount"]
+
+        # daily_pnl = today_eval - net_trade_amount - yesterday_eval
+        daily_pnl = today_ante_eval - net_trade_amount - yesterday_ante_eval
+        # daily_return = daily_pnl / yesterday_eval (0 if no prev)
+        daily_return = (
+            daily_pnl / yesterday_ante_eval if yesterday_ante_eval != 0 else 0.0
+        )
+        # unrealized_pnl = ante_eval_amount - ante_purchase_amount
+        unrealized_pnl = today_ante_eval - ante_purchase_amount
+
+        # 3) Save today's snapshot for tomorrow's reference
+        if self._treasury:
+            await self._treasury.save_daily_snapshot(today_str)
+
+        # 4) Always publish DailyReportEvent
+        from ante.eventbus.events import DailyReportEvent
+
+        await self._eventbus.publish(
+            DailyReportEvent(
+                account_id=self._account_id,
+                report_date=today_str,
+                trade_count=total_count,
+                has_trades=has_trades,
+                daily_pnl=daily_pnl,
+                daily_return=daily_return,
+                net_trade_amount=net_trade_amount,
+                unrealized_pnl=unrealized_pnl,
+            )
+        )
+
+        # 5) Publish NotificationEvent only when trades exist
+        if not has_trades:
+            logger.debug(
+                "DailyReport: no trades on %s — DailyReportEvent only",
+                today_str,
+            )
+            return False
+
+        # Realized PnL from performance tracker (existing logic)
         summaries = await self._performance.get_daily_summary(
             start_date=today_str,
             end_date=today_str,
         )
         realized_pnl = summaries[0].realized_pnl if summaries else 0.0
 
-        # 3) 보유 포지션 현황
+        # Position count
         all_positions = await self._positions.get_all_positions()
         position_count = len(all_positions)
 
-        # 4) NotificationEvent 발행
-        pnl_sign = "+" if realized_pnl >= 0 else ""
+        pnl_formatted = format_currency(realized_pnl, self._currency)
         message = (
             f"거래: {total_count}건 (매수 {buy_count} / 매도 {sell_count})\n"
-            f"실현 손익: {pnl_sign}{realized_pnl:,.0f}원\n"
+            f"실현 손익: {pnl_formatted}\n"
             f"보유 포지션: {position_count}종목"
         )
 
@@ -137,21 +253,20 @@ class DailyReportScheduler:
             )
         )
 
-        logger.info("일일 성과 요약 발행 완료 (%s): 거래 %d건", today_str, total_count)
+        logger.info("DailyReport published (%s): %d trades", today_str, total_count)
         return True
 
     async def _loop(self) -> None:
-        """매일 report_time에 run_once()를 실행한다."""
+        """Execute run_once() daily at report_time."""
         while True:
             now = datetime.now(KST)
             target = datetime.combine(now.date(), self._report_time, tzinfo=KST)
             if now >= target:
-                # 오늘 시각을 지났으면 내일로
                 target += timedelta(days=1)
 
             delay = (target - now).total_seconds()
             logger.debug(
-                "DailyReportScheduler 다음 실행까지 %.0f초 대기",
+                "DailyReportScheduler next run in %.0f seconds",
                 delay,
             )
             await asyncio.sleep(delay)
@@ -161,4 +276,4 @@ class DailyReportScheduler:
             except asyncio.CancelledError:
                 raise
             except Exception:
-                logger.exception("DailyReportScheduler 실행 오류")
+                logger.exception("DailyReportScheduler execution error")

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -48,6 +48,15 @@ CREATE TABLE IF NOT EXISTS treasury_state (
     currency           TEXT NOT NULL DEFAULT 'KRW',
     last_synced_at     TEXT
 );
+
+CREATE TABLE IF NOT EXISTS treasury_daily_snapshots (
+    account_id         TEXT NOT NULL,
+    snapshot_date      TEXT NOT NULL,
+    ante_eval_amount   REAL NOT NULL DEFAULT 0,
+    ante_purchase_amount REAL NOT NULL DEFAULT 0,
+    created_at         TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (account_id, snapshot_date)
+);
 """
 
 # 기존 key-value 테이블에서 계좌별 행 구조로 마이그레이션
@@ -920,6 +929,50 @@ class Treasury:
                 budget.last_updated.isoformat(),
             ),
         )
+
+    async def save_daily_snapshot(self, snapshot_date: str) -> None:
+        """당일 ante_eval_amount, ante_purchase_amount 스냅샷 저장.
+
+        Args:
+            snapshot_date: YYYY-MM-DD 형식의 날짜 문자열.
+        """
+        summary = self.get_summary()
+        await self._db.execute(
+            """INSERT INTO treasury_daily_snapshots
+               (account_id, snapshot_date, ante_eval_amount, ante_purchase_amount)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(account_id, snapshot_date) DO UPDATE SET
+                 ante_eval_amount = excluded.ante_eval_amount,
+                 ante_purchase_amount = excluded.ante_purchase_amount""",
+            (
+                self._account_id,
+                snapshot_date,
+                summary.get("ante_eval_amount", 0.0),
+                summary.get("ante_purchase_amount", 0.0),
+            ),
+        )
+
+    async def get_daily_snapshot(self, snapshot_date: str) -> dict[str, float] | None:
+        """특정 날짜의 스냅샷 조회.
+
+        Args:
+            snapshot_date: YYYY-MM-DD 형식의 날짜 문자열.
+
+        Returns:
+            {"ante_eval_amount": ..., "ante_purchase_amount": ...} 또는 None.
+        """
+        rows = await self._db.fetch_all(
+            """SELECT ante_eval_amount, ante_purchase_amount
+               FROM treasury_daily_snapshots
+               WHERE account_id = ? AND snapshot_date = ?""",
+            (self._account_id, snapshot_date),
+        )
+        if not rows:
+            return None
+        return {
+            "ante_eval_amount": float(rows[0]["ante_eval_amount"]),
+            "ante_purchase_amount": float(rows[0]["ante_purchase_amount"]),
+        }
 
     async def _log_transaction(
         self,

--- a/tests/unit/test_daily_report.py
+++ b/tests/unit/test_daily_report.py
@@ -9,8 +9,13 @@ from uuid import uuid4
 import pytest
 
 from ante.eventbus.bus import EventBus
-from ante.eventbus.events import NotificationEvent
-from ante.trade.daily_report import DEFAULT_REPORT_TIME, DailyReportScheduler
+from ante.eventbus.events import DailyReportEvent, NotificationEvent
+from ante.trade.daily_report import (
+    DEFAULT_REPORT_TIME,
+    DailyReportScheduler,
+    compute_report_time,
+    format_currency,
+)
 from ante.trade.models import DailySummary, PositionSnapshot, TradeRecord, TradeStatus
 
 KST = timezone(timedelta(hours=9))
@@ -46,42 +51,269 @@ def eventbus():
 
 
 @pytest.fixture
-def scheduler(performance_tracker, trade_recorder, position_history, eventbus):
+def treasury():
+    mock = AsyncMock()
+    mock.get_summary = lambda: {
+        "ante_eval_amount": 10_000_000.0,
+        "ante_purchase_amount": 9_500_000.0,
+    }
+    mock.get_daily_snapshot = AsyncMock(return_value=None)
+    mock.save_daily_snapshot = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def scheduler(
+    performance_tracker, trade_recorder, position_history, eventbus, treasury
+):
     return DailyReportScheduler(
         performance_tracker=performance_tracker,
         trade_recorder=trade_recorder,
         position_history=position_history,
         eventbus=eventbus,
+        account_id="acc-1",
+        currency="KRW",
+        treasury=treasury,
     )
 
 
-def _make_trade(side: str = "buy") -> TradeRecord:
-    """테스트용 체결 거래 레코드 생성."""
+def _make_trade(
+    side: str = "buy", price: float = 50000.0, quantity: float = 10.0
+) -> TradeRecord:
+    """Build a test trade record."""
     return TradeRecord(
         trade_id=uuid4(),
         bot_id="bot-1",
         strategy_id="strat-1",
         symbol="005930",
         side=side,
-        quantity=10.0,
-        price=50000.0,
+        quantity=quantity,
+        price=price,
         status=TradeStatus.FILLED,
         timestamp=datetime.now(KST),
     )
 
 
-# ── run_once 테스트 ──────────────────────────────────
+# ── compute_report_time ─────────────────────────────
 
 
-class TestRunOnce:
-    async def test_skip_when_no_trades(self, scheduler, trade_recorder):
-        """당일 거래 0건이면 False를 반환하고 알림을 발행하지 않는다."""
+class TestComputeReportTime:
+    def test_standard_krx(self):
+        """KRX 15:30 + 30min = 16:00."""
+        assert compute_report_time("15:30") == time(16, 0)
+
+    def test_us_market(self):
+        """US 16:00 + 30min = 16:30."""
+        assert compute_report_time("16:00") == time(16, 30)
+
+    def test_late_night(self):
+        """23:59 + 30min wraps to 00:29."""
+        assert compute_report_time("23:59") == time(0, 29)
+
+
+# ── format_currency ──────────────────────────────────
+
+
+class TestFormatCurrency:
+    def test_krw_positive(self):
+        assert format_currency(1250000.0, "KRW") == "+1,250,000원"
+
+    def test_krw_negative(self):
+        assert format_currency(-500000.0, "KRW") == "-500,000원"
+
+    def test_krw_zero(self):
+        assert format_currency(0.0, "KRW") == "+0원"
+
+    def test_usd_positive(self):
+        assert format_currency(1234.56, "USD") == "+$1,234.56"
+
+    def test_usd_negative(self):
+        assert format_currency(-99.99, "USD") == "-$99.99"
+
+    def test_unknown_currency(self):
+        """Unknown currency code is used as-is."""
+        result = format_currency(100.0, "EUR")
+        assert "EUR" in result
+
+
+# ── run_once: DailyReportEvent always published ──────
+
+
+class TestDailyReportEventAlwaysPublished:
+    async def test_no_trades_still_publishes_daily_report(
+        self, scheduler, trade_recorder, eventbus
+    ):
+        """Even with 0 trades, DailyReportEvent is published."""
         trade_recorder.get_trades.return_value = []
+
+        report_events: list[DailyReportEvent] = []
+        eventbus.subscribe(DailyReportEvent, lambda e: report_events.append(e))
+
+        notif_events: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: notif_events.append(e))
 
         result = await scheduler.run_once(target_date=date(2026, 3, 19))
 
         assert result is False
+        assert len(report_events) == 1
+        assert report_events[0].account_id == "acc-1"
+        assert report_events[0].report_date == "2026-03-19"
+        assert report_events[0].trade_count == 0
+        assert report_events[0].has_trades is False
+        # No NotificationEvent
+        assert len(notif_events) == 0
 
+    async def test_with_trades_publishes_both_events(
+        self,
+        scheduler,
+        trade_recorder,
+        performance_tracker,
+        position_history,
+        eventbus,
+        treasury,
+    ):
+        """With trades, both DailyReportEvent and NotificationEvent are published."""
+        buy_trades = [_make_trade("buy") for _ in range(3)]
+        sell_trades = [_make_trade("sell") for _ in range(2)]
+        trade_recorder.get_trades.return_value = buy_trades + sell_trades
+
+        performance_tracker.get_daily_summary.return_value = [
+            DailySummary(
+                date="2026-03-19",
+                realized_pnl=500000.0,
+                trade_count=5,
+                win_rate=0.6,
+            )
+        ]
+        position_history.get_all_positions.return_value = [
+            PositionSnapshot(
+                bot_id="bot-1",
+                symbol="005930",
+                quantity=100.0,
+                avg_entry_price=50000.0,
+            )
+        ]
+
+        report_events: list[DailyReportEvent] = []
+        eventbus.subscribe(DailyReportEvent, lambda e: report_events.append(e))
+
+        notif_events: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: notif_events.append(e))
+
+        result = await scheduler.run_once(target_date=date(2026, 3, 19))
+
+        assert result is True
+        assert len(report_events) == 1
+        assert report_events[0].trade_count == 5
+        assert report_events[0].has_trades is True
+        assert len(notif_events) == 1
+
+
+# ── run_once: performance metrics ────────────────────
+
+
+class TestPerformanceMetrics:
+    async def test_net_trade_amount_calculation(
+        self, scheduler, trade_recorder, eventbus, treasury
+    ):
+        """net_trade_amount = sum(buy price*qty) - sum(sell price*qty)."""
+        trades = [
+            _make_trade("buy", price=50000.0, quantity=10.0),  # +500,000
+            _make_trade("sell", price=55000.0, quantity=5.0),  # -275,000
+        ]
+        trade_recorder.get_trades.return_value = trades
+
+        report_events: list[DailyReportEvent] = []
+        eventbus.subscribe(DailyReportEvent, lambda e: report_events.append(e))
+
+        await scheduler.run_once(target_date=date(2026, 3, 19))
+
+        # net = 500000 - 275000 = 225000
+        assert report_events[0].net_trade_amount == pytest.approx(225000.0)
+
+    async def test_daily_pnl_with_yesterday_snapshot(
+        self, scheduler, trade_recorder, eventbus, treasury
+    ):
+        """daily_pnl = today_eval - net_trade - yesterday_eval."""
+        trade_recorder.get_trades.return_value = [
+            _make_trade("buy", price=50000.0, quantity=10.0),
+        ]
+
+        # today eval = 10,000,000 (from treasury mock)
+        # yesterday eval = 9,000,000
+        treasury.get_daily_snapshot.return_value = {
+            "ante_eval_amount": 9_000_000.0,
+            "ante_purchase_amount": 8_500_000.0,
+        }
+
+        report_events: list[DailyReportEvent] = []
+        eventbus.subscribe(DailyReportEvent, lambda e: report_events.append(e))
+
+        await scheduler.run_once(target_date=date(2026, 3, 19))
+
+        net_trade = 50000.0 * 10.0  # 500,000
+        expected_pnl = 10_000_000 - net_trade - 9_000_000  # 500,000
+        assert report_events[0].daily_pnl == pytest.approx(expected_pnl)
+
+    async def test_daily_return_calculation(
+        self, scheduler, trade_recorder, eventbus, treasury
+    ):
+        """daily_return = daily_pnl / yesterday_eval."""
+        trade_recorder.get_trades.return_value = []
+
+        treasury.get_daily_snapshot.return_value = {
+            "ante_eval_amount": 10_000_000.0,
+            "ante_purchase_amount": 9_500_000.0,
+        }
+
+        report_events: list[DailyReportEvent] = []
+        eventbus.subscribe(DailyReportEvent, lambda e: report_events.append(e))
+
+        await scheduler.run_once(target_date=date(2026, 3, 19))
+
+        # daily_pnl = 10M - 0 - 10M = 0
+        # daily_return = 0 / 10M = 0
+        assert report_events[0].daily_return == pytest.approx(0.0)
+
+    async def test_daily_return_zero_when_no_prev_snapshot(
+        self, scheduler, trade_recorder, eventbus, treasury
+    ):
+        """daily_return = 0 when no yesterday snapshot."""
+        trade_recorder.get_trades.return_value = []
+        treasury.get_daily_snapshot.return_value = None
+
+        report_events: list[DailyReportEvent] = []
+        eventbus.subscribe(DailyReportEvent, lambda e: report_events.append(e))
+
+        await scheduler.run_once(target_date=date(2026, 3, 19))
+
+        assert report_events[0].daily_return == 0.0
+
+    async def test_unrealized_pnl(self, scheduler, trade_recorder, eventbus, treasury):
+        """unrealized_pnl = ante_eval - ante_purchase."""
+        trade_recorder.get_trades.return_value = []
+
+        report_events: list[DailyReportEvent] = []
+        eventbus.subscribe(DailyReportEvent, lambda e: report_events.append(e))
+
+        await scheduler.run_once(target_date=date(2026, 3, 19))
+
+        # 10M - 9.5M = 500,000
+        assert report_events[0].unrealized_pnl == pytest.approx(500_000.0)
+
+    async def test_saves_daily_snapshot(self, scheduler, trade_recorder, treasury):
+        """run_once saves today's snapshot for next day's reference."""
+        trade_recorder.get_trades.return_value = []
+
+        await scheduler.run_once(target_date=date(2026, 3, 19))
+
+        treasury.save_daily_snapshot.assert_called_once_with("2026-03-19")
+
+
+# ── run_once: NotificationEvent ──────────────────────
+
+
+class TestNotificationEvent:
     async def test_publishes_notification_with_trades(
         self,
         scheduler,
@@ -90,8 +322,7 @@ class TestRunOnce:
         position_history,
         eventbus,
     ):
-        """당일 거래가 있으면 NotificationEvent를 발행한다."""
-        # 거래 7건 매수, 5건 매도
+        """Trades present -> NotificationEvent published with correct data."""
         buy_trades = [_make_trade("buy") for _ in range(7)]
         sell_trades = [_make_trade("sell") for _ in range(5)]
         trade_recorder.get_trades.return_value = buy_trades + sell_trades
@@ -140,7 +371,7 @@ class TestRunOnce:
         position_history,
         eventbus,
     ):
-        """음수 손익은 부호 없이 표시된다."""
+        """Negative PnL is displayed without explicit sign."""
         trade_recorder.get_trades.return_value = [_make_trade("sell")]
         performance_tracker.get_daily_summary.return_value = [
             DailySummary(
@@ -167,7 +398,7 @@ class TestRunOnce:
         position_history,
         eventbus,
     ):
-        """일별 요약이 없으면(매수만 있는 날) 실현 손익을 0으로 표시한다."""
+        """No daily summary -> realized PnL shown as 0."""
         trade_recorder.get_trades.return_value = [_make_trade("buy")]
         performance_tracker.get_daily_summary.return_value = []
         position_history.get_all_positions.return_value = []
@@ -186,7 +417,7 @@ class TestRunOnce:
         trade_recorder,
         eventbus,
     ):
-        """알림 카테고리가 trade이다."""
+        """Notification category is 'trade'."""
         trade_recorder.get_trades.return_value = [_make_trade("buy")]
 
         received: list[NotificationEvent] = []
@@ -197,12 +428,54 @@ class TestRunOnce:
         assert received[0].category == "trade"
 
 
-# ── start/stop 테스트 ────────────────────────────────
+# ── Currency-aware notification ──────────────────────
+
+
+class TestCurrencyAwareNotification:
+    async def test_usd_currency_in_notification(
+        self,
+        performance_tracker,
+        trade_recorder,
+        position_history,
+        eventbus,
+        treasury,
+    ):
+        """USD account shows $ symbol in notification message."""
+        sched = DailyReportScheduler(
+            performance_tracker=performance_tracker,
+            trade_recorder=trade_recorder,
+            position_history=position_history,
+            eventbus=eventbus,
+            account_id="acc-us",
+            currency="USD",
+            treasury=treasury,
+        )
+
+        trade_recorder.get_trades.return_value = [_make_trade("buy")]
+        performance_tracker.get_daily_summary.return_value = [
+            DailySummary(
+                date="2026-03-19",
+                realized_pnl=1234.56,
+                trade_count=1,
+                win_rate=1.0,
+            )
+        ]
+        position_history.get_all_positions.return_value = []
+
+        received: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: received.append(e))
+
+        await sched.run_once(target_date=date(2026, 3, 19))
+
+        assert "+$1,234.56" in received[0].message
+
+
+# ── start/stop ───────────────────────────────────────
 
 
 class TestStartStop:
     async def test_start_creates_task(self, scheduler):
-        """start() 시 태스크가 생성된다."""
+        """start() creates background task."""
         await scheduler.start()
         try:
             assert scheduler._task is not None
@@ -211,35 +484,35 @@ class TestStartStop:
             await scheduler.stop()
 
     async def test_stop_cancels_task(self, scheduler):
-        """stop() 시 태스크가 취소된다."""
+        """stop() cancels background task."""
         await scheduler.start()
         await scheduler.stop()
 
         assert scheduler._task is None
 
     async def test_double_start_ignored(self, scheduler):
-        """이미 실행 중인데 다시 start() 하면 무시된다."""
+        """Second start() is ignored when already running."""
         await scheduler.start()
         first_task = scheduler._task
 
-        await scheduler.start()  # 두 번째 호출
+        await scheduler.start()
 
         assert scheduler._task is first_task
         await scheduler.stop()
 
     async def test_stop_without_start(self, scheduler):
-        """start() 없이 stop() 해도 오류 없음."""
-        await scheduler.stop()  # 예외 없이 완료
+        """stop() without start() does not raise."""
+        await scheduler.stop()
 
 
-# ── 설정 테스트 ──────────────────────────────────────
+# ── Configuration ────────────────────────────────────
 
 
 class TestConfiguration:
     def test_default_report_time(
         self, performance_tracker, trade_recorder, position_history, eventbus
     ):
-        """기본 발행 시각은 16:00이다."""
+        """Default report time is 16:00."""
         sched = DailyReportScheduler(
             performance_tracker=performance_tracker,
             trade_recorder=trade_recorder,
@@ -252,7 +525,7 @@ class TestConfiguration:
     def test_custom_report_time(
         self, performance_tracker, trade_recorder, position_history, eventbus
     ):
-        """report_time으로 발행 시각을 변경할 수 있다."""
+        """report_time parameter overrides default."""
         custom_time = time(17, 30)
         sched = DailyReportScheduler(
             performance_tracker=performance_tracker,
@@ -262,3 +535,50 @@ class TestConfiguration:
             report_time=custom_time,
         )
         assert sched._report_time == custom_time
+
+    def test_account_id_and_currency(
+        self, performance_tracker, trade_recorder, position_history, eventbus
+    ):
+        """account_id and currency are stored."""
+        sched = DailyReportScheduler(
+            performance_tracker=performance_tracker,
+            trade_recorder=trade_recorder,
+            position_history=position_history,
+            eventbus=eventbus,
+            account_id="acc-1",
+            currency="USD",
+        )
+        assert sched._account_id == "acc-1"
+        assert sched._currency == "USD"
+
+
+# ── No treasury fallback ────────────────────────────
+
+
+class TestNoTreasuryFallback:
+    async def test_works_without_treasury(
+        self,
+        performance_tracker,
+        trade_recorder,
+        position_history,
+        eventbus,
+    ):
+        """Scheduler works with treasury=None (all metrics are 0)."""
+        sched = DailyReportScheduler(
+            performance_tracker=performance_tracker,
+            trade_recorder=trade_recorder,
+            position_history=position_history,
+            eventbus=eventbus,
+        )
+
+        trade_recorder.get_trades.return_value = []
+
+        report_events: list[DailyReportEvent] = []
+        eventbus.subscribe(DailyReportEvent, lambda e: report_events.append(e))
+
+        result = await sched.run_once(target_date=date(2026, 3, 19))
+
+        assert result is False
+        assert len(report_events) == 1
+        assert report_events[0].daily_pnl == 0.0
+        assert report_events[0].unrealized_pnl == 0.0


### PR DESCRIPTION
## Summary
- `DailyReportEvent` 이벤트 클래스 신설 (account_id, report_date, daily_pnl, daily_return, net_trade_amount, unrealized_pnl 등 성과 필드 포함)
- `DailyReportScheduler`가 Account의 `trading_hours_end + 30min`에서 실행 시각을 계산하도록 개선
- 매 실행 시 `DailyReportEvent`를 무조건 발행 (거래 0건이어도), `NotificationEvent`는 거래 1건 이상일 때만 발행
- 알림 메시지 통화 단위를 Account `currency` 기반으로 동적 표시 (KRW -> "원", USD -> "$")
- Treasury에 `treasury_daily_snapshots` 테이블 및 `save_daily_snapshot()` / `get_daily_snapshot()` 메서드 추가
- `main.py`에서 첫 번째 활성 계좌의 Account 정보를 DailyReportScheduler에 주입

## Test plan
- [x] 단위 테스트 30건 통과 (`tests/unit/test_daily_report.py`)
- [x] `ruff check` 통과
- [x] `ruff format --check` 통과
- [ ] 통합 환경에서 거래 0건/다건 시나리오 확인
- [ ] USD 계좌에서 통화 기호 표시 확인

Refs #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)