### PR TITLE
feat(treasury): 일별 자산 스냅샷 확장 — 성과 필드, 범위 조회, 자동 삭제

### DIFF
--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from ante.treasury.models import BotBudget
@@ -50,11 +50,20 @@ CREATE TABLE IF NOT EXISTS treasury_state (
 );
 
 CREATE TABLE IF NOT EXISTS treasury_daily_snapshots (
-    account_id         TEXT NOT NULL,
-    snapshot_date      TEXT NOT NULL,
-    ante_eval_amount   REAL NOT NULL DEFAULT 0,
-    ante_purchase_amount REAL NOT NULL DEFAULT 0,
-    created_at         TEXT DEFAULT (datetime('now')),
+    account_id           TEXT    NOT NULL,
+    snapshot_date        TEXT    NOT NULL,
+    total_asset          REAL    NOT NULL DEFAULT 0,
+    ante_eval_amount     REAL    NOT NULL DEFAULT 0,
+    ante_purchase_amount REAL    NOT NULL DEFAULT 0,
+    unallocated          REAL    NOT NULL DEFAULT 0,
+    account_balance      REAL    NOT NULL DEFAULT 0,
+    total_allocated      REAL    NOT NULL DEFAULT 0,
+    bot_count            INTEGER NOT NULL DEFAULT 0,
+    daily_pnl            REAL    DEFAULT 0.0,
+    daily_return         REAL    DEFAULT 0.0,
+    net_trade_amount     REAL    DEFAULT 0.0,
+    unrealized_pnl       REAL    DEFAULT 0.0,
+    created_at           TEXT    DEFAULT (datetime('now')),
     PRIMARY KEY (account_id, snapshot_date)
 );
 """
@@ -99,6 +108,22 @@ ALTER TABLE treasury_state_new RENAME TO treasury_state;
 TREASURY_TRANSACTIONS_MIGRATION = """
 ALTER TABLE treasury_transactions ADD COLUMN account_id TEXT DEFAULT '';
 """
+
+# daily_snapshots 성과 필드 추가 마이그레이션
+_SNAPSHOT_MIGRATION_COLUMNS = [
+    ("total_asset", "REAL NOT NULL DEFAULT 0"),
+    ("unallocated", "REAL NOT NULL DEFAULT 0"),
+    ("account_balance", "REAL NOT NULL DEFAULT 0"),
+    ("total_allocated", "REAL NOT NULL DEFAULT 0"),
+    ("bot_count", "INTEGER NOT NULL DEFAULT 0"),
+    ("daily_pnl", "REAL DEFAULT 0.0"),
+    ("daily_return", "REAL DEFAULT 0.0"),
+    ("net_trade_amount", "REAL DEFAULT 0.0"),
+    ("unrealized_pnl", "REAL DEFAULT 0.0"),
+]
+
+# 5년 초과 스냅샷 자동 삭제 기준
+_SNAPSHOT_RETENTION_DAYS = 365 * 5
 
 
 class Treasury:
@@ -178,10 +203,21 @@ class Treasury:
         except Exception:
             pass  # 이미 컬럼이 존재하면 무시
 
+        # 마이그레이션: daily_snapshots 성과 필드 추가
+        for col_name, col_def in _SNAPSHOT_MIGRATION_COLUMNS:
+            try:
+                await self._db.execute_script(
+                    f"ALTER TABLE treasury_daily_snapshots "
+                    f"ADD COLUMN {col_name} {col_def};"
+                )
+            except Exception:
+                pass  # 이미 컬럼이 존재하면 무시
+
     def _subscribe_events(self) -> None:
         """EventBus 이벤트 구독."""
         from ante.eventbus.events import (
             BotStoppedEvent,
+            DailyReportEvent,
             OrderCancelledEvent,
             OrderFailedEvent,
             OrderFilledEvent,
@@ -197,6 +233,7 @@ class Treasury:
         )
         self._eventbus.subscribe(OrderFailedEvent, self._on_order_failed, priority=80)
         self._eventbus.subscribe(BotStoppedEvent, self._on_bot_stopped, priority=80)
+        self._eventbus.subscribe(DailyReportEvent, self._on_daily_report, priority=70)
 
     # -- 계좌 잔고 -----------------------------------------------
 
@@ -931,7 +968,10 @@ class Treasury:
         )
 
     async def save_daily_snapshot(self, snapshot_date: str) -> None:
-        """당일 ante_eval_amount, ante_purchase_amount 스냅샷 저장.
+        """당일 자산 현황만 스냅샷에 저장 (하위 호환).
+
+        DailyReportEvent 기반의 take_snapshot()이 주 진입점이며,
+        이 메서드는 이벤트 발행 전 자산 현황만 먼저 기록할 때 사용한다.
 
         Args:
             snapshot_date: YYYY-MM-DD 형식의 날짜 문자열.
@@ -939,40 +979,171 @@ class Treasury:
         summary = self.get_summary()
         await self._db.execute(
             """INSERT INTO treasury_daily_snapshots
-               (account_id, snapshot_date, ante_eval_amount, ante_purchase_amount)
-               VALUES (?, ?, ?, ?)
+               (account_id, snapshot_date, total_asset,
+                ante_eval_amount, ante_purchase_amount,
+                unallocated, account_balance, total_allocated, bot_count)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(account_id, snapshot_date) DO UPDATE SET
+                 total_asset = excluded.total_asset,
                  ante_eval_amount = excluded.ante_eval_amount,
-                 ante_purchase_amount = excluded.ante_purchase_amount""",
+                 ante_purchase_amount = excluded.ante_purchase_amount,
+                 unallocated = excluded.unallocated,
+                 account_balance = excluded.account_balance,
+                 total_allocated = excluded.total_allocated,
+                 bot_count = excluded.bot_count""",
             (
                 self._account_id,
                 snapshot_date,
+                summary.get("total_evaluation", 0.0),
                 summary.get("ante_eval_amount", 0.0),
                 summary.get("ante_purchase_amount", 0.0),
+                summary.get("unallocated", 0.0),
+                summary.get("account_balance", 0.0),
+                summary.get("total_allocated", 0.0),
+                summary.get("bot_count", 0),
             ),
         )
 
-    async def get_daily_snapshot(self, snapshot_date: str) -> dict[str, float] | None:
+    async def take_snapshot(self, event: object) -> None:
+        """DailyReportEvent 수신 시 자산 현황 + 성과 필드를 합쳐 스냅샷 저장.
+
+        Args:
+            event: DailyReportEvent 인스턴스.
+        """
+        from ante.eventbus.events import DailyReportEvent
+
+        if not isinstance(event, DailyReportEvent):
+            return
+
+        snapshot_date = event.report_date
+        summary = self.get_summary()
+
+        await self._db.execute(
+            """INSERT INTO treasury_daily_snapshots
+               (account_id, snapshot_date, total_asset,
+                ante_eval_amount, ante_purchase_amount,
+                unallocated, account_balance, total_allocated, bot_count,
+                daily_pnl, daily_return, net_trade_amount, unrealized_pnl)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(account_id, snapshot_date) DO UPDATE SET
+                 total_asset = excluded.total_asset,
+                 ante_eval_amount = excluded.ante_eval_amount,
+                 ante_purchase_amount = excluded.ante_purchase_amount,
+                 unallocated = excluded.unallocated,
+                 account_balance = excluded.account_balance,
+                 total_allocated = excluded.total_allocated,
+                 bot_count = excluded.bot_count,
+                 daily_pnl = excluded.daily_pnl,
+                 daily_return = excluded.daily_return,
+                 net_trade_amount = excluded.net_trade_amount,
+                 unrealized_pnl = excluded.unrealized_pnl""",
+            (
+                self._account_id,
+                snapshot_date,
+                summary.get("total_evaluation", 0.0),
+                summary.get("ante_eval_amount", 0.0),
+                summary.get("ante_purchase_amount", 0.0),
+                summary.get("unallocated", 0.0),
+                summary.get("account_balance", 0.0),
+                summary.get("total_allocated", 0.0),
+                summary.get("bot_count", 0),
+                event.daily_pnl,
+                event.daily_return,
+                event.net_trade_amount,
+                event.unrealized_pnl,
+            ),
+        )
+
+        # 오래된 스냅샷 자동 삭제
+        await self._cleanup_old_snapshots()
+
+        logger.info(
+            "일별 스냅샷 저장: account=%s, date=%s, pnl=%.0f",
+            self._account_id,
+            snapshot_date,
+            event.daily_pnl,
+        )
+
+    async def get_daily_snapshot(self, snapshot_date: str) -> dict[str, Any] | None:
         """특정 날짜의 스냅샷 조회.
 
         Args:
             snapshot_date: YYYY-MM-DD 형식의 날짜 문자열.
 
         Returns:
-            {"ante_eval_amount": ..., "ante_purchase_amount": ...} 또는 None.
+            스냅샷 딕셔너리 또는 None.
         """
         rows = await self._db.fetch_all(
-            """SELECT ante_eval_amount, ante_purchase_amount
-               FROM treasury_daily_snapshots
+            """SELECT * FROM treasury_daily_snapshots
                WHERE account_id = ? AND snapshot_date = ?""",
             (self._account_id, snapshot_date),
         )
         if not rows:
             return None
+        return self._row_to_snapshot(rows[0])
+
+    async def get_snapshots(
+        self, start_date: str, end_date: str
+    ) -> list[dict[str, Any]]:
+        """날짜 범위의 스냅샷 조회.
+
+        Args:
+            start_date: 시작 날짜 (YYYY-MM-DD, 포함).
+            end_date: 종료 날짜 (YYYY-MM-DD, 포함).
+
+        Returns:
+            스냅샷 딕셔너리 리스트 (날짜순 정렬).
+        """
+        rows = await self._db.fetch_all(
+            """SELECT * FROM treasury_daily_snapshots
+               WHERE account_id = ? AND snapshot_date >= ? AND snapshot_date <= ?
+               ORDER BY snapshot_date ASC""",
+            (self._account_id, start_date, end_date),
+        )
+        return [self._row_to_snapshot(r) for r in rows]
+
+    async def _cleanup_old_snapshots(self) -> None:
+        """5년 초과 스냅샷 자동 삭제."""
+        cutoff = (
+            datetime.now(UTC) - timedelta(days=_SNAPSHOT_RETENTION_DAYS)
+        ).strftime("%Y-%m-%d")
+        await self._db.execute(
+            """DELETE FROM treasury_daily_snapshots
+               WHERE account_id = ? AND snapshot_date < ?""",
+            (self._account_id, cutoff),
+        )
+
+    @staticmethod
+    def _row_to_snapshot(row: Any) -> dict[str, Any]:
+        """DB 행을 스냅샷 딕셔너리로 변환."""
         return {
-            "ante_eval_amount": float(rows[0]["ante_eval_amount"]),
-            "ante_purchase_amount": float(rows[0]["ante_purchase_amount"]),
+            "account_id": row["account_id"],
+            "snapshot_date": row["snapshot_date"],
+            "total_asset": float(row["total_asset"]),
+            "ante_eval_amount": float(row["ante_eval_amount"]),
+            "ante_purchase_amount": float(row["ante_purchase_amount"]),
+            "unallocated": float(row["unallocated"]),
+            "account_balance": float(row["account_balance"]),
+            "total_allocated": float(row["total_allocated"]),
+            "bot_count": int(row["bot_count"]),
+            "daily_pnl": float(row["daily_pnl"]),
+            "daily_return": float(row["daily_return"]),
+            "net_trade_amount": float(row["net_trade_amount"]),
+            "unrealized_pnl": float(row["unrealized_pnl"]),
+            "created_at": row["created_at"],
         }
+
+    async def _on_daily_report(self, event: object) -> None:
+        """DailyReportEvent 핸들러 -- 일별 스냅샷 저장."""
+        from ante.eventbus.events import DailyReportEvent
+
+        if not isinstance(event, DailyReportEvent):
+            return
+
+        if not self._is_my_event(event):
+            return
+
+        await self.take_snapshot(event)
 
     async def _log_transaction(
         self,

--- a/tests/unit/test_daily_snapshot.py
+++ b/tests/unit/test_daily_snapshot.py
@@ -1,0 +1,278 @@
+"""Daily Asset Snapshot 단위 테스트 (#682).
+
+take_snapshot, get_snapshots, _cleanup_old_snapshots,
+DailyReportEvent 구독을 검증한다.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import DailyReportEvent
+from ante.treasury import Treasury
+
+ACCOUNT_ID = "domestic"
+CURRENCY = "KRW"
+
+
+# -- Fixtures -------------------------------------------------
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+async def treasury(db, eventbus):
+    t = Treasury(
+        db=db,
+        eventbus=eventbus,
+        account_id=ACCOUNT_ID,
+        currency=CURRENCY,
+    )
+    await t.initialize()
+    await t.set_account_balance(10_000_000.0)
+    return t
+
+
+def _make_event(
+    report_date: str = "2026-03-21",
+    daily_pnl: float = 50_000.0,
+    daily_return: float = 0.005,
+    net_trade_amount: float = 1_000_000.0,
+    unrealized_pnl: float = 150_000.0,
+    account_id: str = ACCOUNT_ID,
+) -> DailyReportEvent:
+    return DailyReportEvent(
+        account_id=account_id,
+        report_date=report_date,
+        trade_count=3,
+        has_trades=True,
+        daily_pnl=daily_pnl,
+        daily_return=daily_return,
+        net_trade_amount=net_trade_amount,
+        unrealized_pnl=unrealized_pnl,
+    )
+
+
+# -- DDL: 확장 컬럼 존재 확인 ------------------------------------
+
+
+class TestSnapshotSchema:
+    async def test_schema_has_performance_columns(self, db, treasury):
+        """DDL에 성과 필드 컬럼이 존재한다."""
+        rows = await db.fetch_all("PRAGMA table_info(treasury_daily_snapshots)")
+        col_names = {r["name"] for r in rows}
+        expected = {
+            "account_id",
+            "snapshot_date",
+            "total_asset",
+            "ante_eval_amount",
+            "ante_purchase_amount",
+            "unallocated",
+            "account_balance",
+            "total_allocated",
+            "bot_count",
+            "daily_pnl",
+            "daily_return",
+            "net_trade_amount",
+            "unrealized_pnl",
+            "created_at",
+        }
+        assert expected.issubset(col_names)
+
+
+# -- take_snapshot -----------------------------------------------
+
+
+class TestTakeSnapshot:
+    async def test_take_snapshot_saves_all_fields(self, treasury):
+        """take_snapshot은 자산 현황 + 성과 필드를 모두 저장한다."""
+        event = _make_event()
+        await treasury.take_snapshot(event)
+
+        snap = await treasury.get_daily_snapshot("2026-03-21")
+        assert snap is not None
+        assert snap["account_id"] == ACCOUNT_ID
+        assert snap["snapshot_date"] == "2026-03-21"
+        assert snap["daily_pnl"] == 50_000.0
+        assert snap["daily_return"] == 0.005
+        assert snap["net_trade_amount"] == 1_000_000.0
+        assert snap["unrealized_pnl"] == 150_000.0
+        # 자산 현황 필드도 존재
+        assert snap["account_balance"] == 10_000_000.0
+        assert snap["bot_count"] == 0
+
+    async def test_take_snapshot_upsert(self, treasury):
+        """동일 계좌+날짜에 대해 INSERT OR REPLACE 동작."""
+        event1 = _make_event(daily_pnl=100.0)
+        event2 = _make_event(daily_pnl=200.0)
+
+        await treasury.take_snapshot(event1)
+        await treasury.take_snapshot(event2)
+
+        snap = await treasury.get_daily_snapshot("2026-03-21")
+        assert snap is not None
+        assert snap["daily_pnl"] == 200.0
+
+    async def test_take_snapshot_includes_summary_fields(self, treasury):
+        """take_snapshot은 get_summary() 값을 자산 필드에 반영한다."""
+        # 봇 예산 할당하여 summary 값 변경
+        await treasury.allocate("bot1", 3_000_000.0)
+
+        event = _make_event()
+        await treasury.take_snapshot(event)
+
+        snap = await treasury.get_daily_snapshot("2026-03-21")
+        assert snap is not None
+        assert snap["total_allocated"] == 3_000_000.0
+        assert snap["unallocated"] == 7_000_000.0
+        assert snap["bot_count"] == 1
+
+    async def test_take_snapshot_ignores_non_daily_report_event(self, treasury):
+        """DailyReportEvent가 아닌 이벤트는 무시한다."""
+        await treasury.take_snapshot("not an event")
+        snap = await treasury.get_daily_snapshot("2026-03-21")
+        assert snap is None
+
+
+# -- get_snapshots (범위 조회) -----------------------------------
+
+
+class TestGetSnapshots:
+    async def test_get_snapshots_range(self, treasury):
+        """날짜 범위로 스냅샷을 조회한다."""
+        for day in range(18, 22):
+            event = _make_event(
+                report_date=f"2026-03-{day:02d}",
+                daily_pnl=float(day * 100),
+            )
+            await treasury.take_snapshot(event)
+
+        result = await treasury.get_snapshots("2026-03-19", "2026-03-21")
+        assert len(result) == 3
+        assert result[0]["snapshot_date"] == "2026-03-19"
+        assert result[-1]["snapshot_date"] == "2026-03-21"
+
+    async def test_get_snapshots_empty(self, treasury):
+        """범위에 해당하는 스냅샷이 없으면 빈 리스트."""
+        result = await treasury.get_snapshots("2025-01-01", "2025-01-31")
+        assert result == []
+
+    async def test_get_snapshots_ordered_by_date(self, treasury):
+        """결과는 날짜 오름차순 정렬."""
+        # 역순으로 삽입
+        for day in [21, 19, 20]:
+            event = _make_event(report_date=f"2026-03-{day:02d}")
+            await treasury.take_snapshot(event)
+
+        result = await treasury.get_snapshots("2026-03-19", "2026-03-21")
+        dates = [s["snapshot_date"] for s in result]
+        assert dates == ["2026-03-19", "2026-03-20", "2026-03-21"]
+
+
+# -- _cleanup_old_snapshots ------------------------------------
+
+
+class TestCleanupOldSnapshots:
+    async def test_cleanup_deletes_old_snapshots(self, treasury):
+        """5년 초과 스냅샷이 삭제된다."""
+        old_date = (datetime.now(UTC) - timedelta(days=365 * 5 + 1)).strftime(
+            "%Y-%m-%d"
+        )
+        recent_date = "2026-03-21"
+
+        # 오래된 스냅샷 직접 삽입
+        await treasury.save_daily_snapshot(old_date)
+        # 최근 스냅샷은 take_snapshot으로 (cleanup 트리거)
+        event = _make_event(report_date=recent_date)
+        await treasury.take_snapshot(event)
+
+        old_snap = await treasury.get_daily_snapshot(old_date)
+        recent_snap = await treasury.get_daily_snapshot(recent_date)
+
+        assert old_snap is None
+        assert recent_snap is not None
+
+    async def test_cleanup_keeps_recent_snapshots(self, treasury):
+        """5년 이내 스냅샷은 유지된다."""
+        dates = ["2022-01-01", "2023-06-15", "2026-03-21"]
+        for d in dates:
+            event = _make_event(report_date=d)
+            await treasury.take_snapshot(event)
+
+        # 2022-01-01은 약 4년 전이므로 유지
+        for d in dates:
+            snap = await treasury.get_daily_snapshot(d)
+            assert snap is not None, f"{d} should be retained"
+
+
+# -- DailyReportEvent 구독 (EventBus) ---------------------------
+
+
+class TestDailyReportSubscription:
+    async def test_eventbus_triggers_snapshot(self, treasury, eventbus):
+        """DailyReportEvent 발행 시 자동으로 스냅샷이 저장된다."""
+        event = _make_event()
+        await eventbus.publish(event)
+
+        snap = await treasury.get_daily_snapshot("2026-03-21")
+        assert snap is not None
+        assert snap["daily_pnl"] == 50_000.0
+
+    async def test_eventbus_ignores_other_account(self, db, eventbus):
+        """다른 계좌의 이벤트는 무시한다."""
+        t = Treasury(
+            db=db,
+            eventbus=eventbus,
+            account_id="overseas",
+            currency="USD",
+        )
+        await t.initialize()
+
+        # domestic 계좌 이벤트 발행
+        event = _make_event(account_id=ACCOUNT_ID)
+        await eventbus.publish(event)
+
+        # overseas treasury에는 저장되지 않음
+        snap = await t.get_daily_snapshot("2026-03-21")
+        assert snap is None
+
+
+# -- save_daily_snapshot (하위 호환) ----------------------------
+
+
+class TestSaveDailySnapshotCompat:
+    async def test_save_daily_snapshot_still_works(self, treasury):
+        """기존 save_daily_snapshot도 확장된 스키마에서 동작한다."""
+        await treasury.save_daily_snapshot("2026-03-21")
+
+        snap = await treasury.get_daily_snapshot("2026-03-21")
+        assert snap is not None
+        assert snap["account_balance"] == 10_000_000.0
+        # 성과 필드는 기본값
+        assert snap["daily_pnl"] == 0.0
+        assert snap["daily_return"] == 0.0
+
+    async def test_take_snapshot_overwrites_save_daily(self, treasury):
+        """save_daily_snapshot 후 take_snapshot이 성과 필드를 덮어쓴다."""
+        await treasury.save_daily_snapshot("2026-03-21")
+        event = _make_event(daily_pnl=99_999.0)
+        await treasury.take_snapshot(event)
+
+        snap = await treasury.get_daily_snapshot("2026-03-21")
+        assert snap is not None
+        assert snap["daily_pnl"] == 99_999.0


### PR DESCRIPTION
## Summary
- DDL 확장: `treasury_daily_snapshots`에 `total_asset`, `unallocated`, `account_balance`, `total_allocated`, `bot_count`, `daily_pnl`, `daily_return`, `net_trade_amount`, `unrealized_pnl` 필드 추가
- `take_snapshot(event)`: DailyReportEvent 수신 시 `get_summary()` + 성과 필드를 합쳐 저장
- `get_snapshots(start_date, end_date)`: 날짜 범위 조회 메서드 추가
- `_cleanup_old_snapshots()`: 5년 초과 데이터 자동 삭제
- DailyReportEvent 구독 설정 (`_subscribe_events`에서 priority=70으로 등록)
- 기존 `save_daily_snapshot()` 하위 호환 유지

Refs #682

## Test plan
- [x] DDL에 14개 컬럼 모두 존재하는지 확인
- [x] `take_snapshot`이 자산 현황 + 성과 필드 모두 저장하는지 확인
- [x] 동일 계좌/날짜 UPSERT 동작 확인
- [x] `get_snapshots` 범위 조회 및 날짜순 정렬 확인
- [x] 5년 초과 스냅샷 자동 삭제 확인
- [x] EventBus를 통한 DailyReportEvent 구독 동작 확인
- [x] 다른 계좌 이벤트 무시 확인
- [x] 기존 `save_daily_snapshot` 하위 호환 확인
- [x] 기존 treasury, daily_report 테스트 89건 모두 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)