### PR TITLE
feat(web): 일별 자산 스냅샷 Web API 엔드포인트 (#684)

### DIFF
--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -1082,6 +1082,22 @@ class Treasury:
             return None
         return self._row_to_snapshot(rows[0])
 
+    async def get_latest_snapshot(self) -> dict[str, Any] | None:
+        """가장 최근 일별 스냅샷 조회.
+
+        Returns:
+            최신 스냅샷 딕셔너리 또는 None.
+        """
+        rows = await self._db.fetch_all(
+            """SELECT * FROM treasury_daily_snapshots
+               WHERE account_id = ?
+               ORDER BY snapshot_date DESC LIMIT 1""",
+            (self._account_id,),
+        )
+        if not rows:
+            return None
+        return self._row_to_snapshot(rows[0])
+
     async def get_snapshots(
         self, start_date: str, end_date: str
     ) -> list[dict[str, Any]]:

--- a/src/ante/web/routes/portfolio.py
+++ b/src/ante/web/routes/portfolio.py
@@ -12,6 +12,10 @@ from ante.web.deps import (
     get_treasury,
     get_treasury_manager_optional,
 )
+from ante.web.schemas import (
+    PortfolioHistoryResponse,
+    PortfolioValueResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +41,9 @@ def _resolve_treasury(
 
 @router.get(
     "/value",
+    response_model=PortfolioValueResponse,
+    response_model_exclude_none=True,
     responses={
-        404: {"description": "No snapshot found"},
         503: {"description": "Treasury not available"},
     },
 )
@@ -50,21 +55,34 @@ async def portfolio_value(
     """총 자산 가치 + 당일 손익 + 수익률 + 미실현 손익 (최신 스냅샷 기반)."""
     target = _resolve_treasury(treasury, treasury_manager, account_id)
     snapshot = await target.get_latest_snapshot()
-    if snapshot is None:
-        raise HTTPException(status_code=404, detail="스냅샷이 없습니다")
+    if snapshot is not None:
+        daily_return = snapshot["daily_return"]
+        return {
+            "total_value": snapshot["total_asset"],
+            "daily_pnl": snapshot["daily_pnl"],
+            "daily_pnl_pct": daily_return,
+            "daily_return": daily_return,
+            "unrealized_pnl": snapshot["unrealized_pnl"],
+            "snapshot_date": snapshot["snapshot_date"],
+            "updated_at": snapshot["created_at"],
+        }
 
+    # 스냅샷 미존재 시 get_summary() fallback (시스템 초기 구동)
+    summary = target.get_summary()
+    now = datetime.now(UTC).isoformat()
     return {
-        "total_value": snapshot["total_asset"],
-        "daily_pnl": snapshot["daily_pnl"],
-        "daily_return": snapshot["daily_return"],
-        "unrealized_pnl": snapshot["unrealized_pnl"],
-        "snapshot_date": snapshot["snapshot_date"],
-        "updated_at": snapshot["created_at"],
+        "total_value": summary.get("total_evaluation", 0.0),
+        "daily_pnl": 0.0,
+        "daily_pnl_pct": 0.0,
+        "daily_return": 0.0,
+        "unrealized_pnl": 0.0,
+        "updated_at": now,
     }
 
 
 @router.get(
     "/history",
+    response_model=PortfolioHistoryResponse,
     responses={
         503: {"description": "Treasury not available"},
     },

--- a/src/ante/web/routes/portfolio.py
+++ b/src/ante/web/routes/portfolio.py
@@ -1,4 +1,4 @@
-"""포트폴리오 API — 자산 가치 + 추이."""
+"""포트폴리오 API — 자산 가치 + 추이 (스냅샷 기반)."""
 
 from __future__ import annotations
 
@@ -6,118 +6,98 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException
 
 from ante.web.deps import (
-    get_bot_manager,
-    get_trade_service,
     get_treasury,
     get_treasury_manager_optional,
 )
-from ante.web.schemas import PortfolioHistoryResponse, PortfolioValueResponse
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 
+def _resolve_treasury(
+    treasury: Any,
+    treasury_manager: Any | None,
+    account_id: str | None,
+) -> Any:
+    """account_id가 주어지면 해당 계좌의 Treasury를 반환한다."""
+    if account_id and treasury_manager is not None:
+        try:
+            return treasury_manager.get(account_id)
+        except KeyError:
+            raise HTTPException(
+                status_code=404,
+                detail=f"계좌를 찾을 수 없습니다: {account_id}",
+            )
+    return treasury
+
+
 @router.get(
     "/value",
-    response_model=PortfolioValueResponse,
-    responses={503: {"description": "Treasury not available"}},
+    responses={
+        404: {"description": "No snapshot found"},
+        503: {"description": "Treasury not available"},
+    },
 )
 async def portfolio_value(
     treasury: Annotated[Any, Depends(get_treasury)],
     treasury_manager: Annotated[Any | None, Depends(get_treasury_manager_optional)],
     account_id: str | None = None,
 ) -> dict:
-    """총 자산 가치 + 오늘 손익."""
-    from fastapi import HTTPException
-
-    target_treasury = treasury
-    if account_id and treasury_manager is not None:
-        try:
-            target_treasury = treasury_manager.get(account_id)
-        except KeyError:
-            raise HTTPException(
-                status_code=404,
-                detail=f"계좌를 찾을 수 없습니다: {account_id}",
-            )
-
-    summary = target_treasury.get_summary()
-    total_value = summary["total_evaluation"]
-    daily_pnl = summary["total_profit_loss"]
-    daily_pnl_pct = (daily_pnl / total_value * 100) if total_value else 0.0
+    """총 자산 가치 + 당일 손익 + 수익률 + 미실현 손익 (최신 스냅샷 기반)."""
+    target = _resolve_treasury(treasury, treasury_manager, account_id)
+    snapshot = await target.get_latest_snapshot()
+    if snapshot is None:
+        raise HTTPException(status_code=404, detail="스냅샷이 없습니다")
 
     return {
-        "total_value": total_value,
-        "daily_pnl": daily_pnl,
-        "daily_pnl_pct": round(daily_pnl_pct, 4),
-        "updated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "total_value": snapshot["total_asset"],
+        "daily_pnl": snapshot["daily_pnl"],
+        "daily_return": snapshot["daily_return"],
+        "unrealized_pnl": snapshot["unrealized_pnl"],
+        "snapshot_date": snapshot["snapshot_date"],
+        "updated_at": snapshot["created_at"],
     }
-
-
-# 기간 -> 일수 매핑
-_PERIOD_DAYS = {
-    "1d": 1,
-    "1w": 7,
-    "1m": 30,
-    "3m": 90,
-    "all": 0,
-}
 
 
 @router.get(
     "/history",
-    response_model=PortfolioHistoryResponse,
     responses={
-        503: {"description": "Trade service or bot manager not available"},
+        503: {"description": "Treasury not available"},
     },
 )
 async def portfolio_history(
-    trade_service: Annotated[Any, Depends(get_trade_service)],
-    bot_manager: Annotated[Any, Depends(get_bot_manager)],
+    treasury: Annotated[Any, Depends(get_treasury)],
+    treasury_manager: Annotated[Any | None, Depends(get_treasury_manager_optional)],
     account_id: str | None = None,
-    period: str = Query(default="1m", pattern="^(1d|1w|1m|3m|all)$"),
+    start_date: str | None = None,
+    end_date: str | None = None,
 ) -> dict:
-    """기간별 자산 추이."""
-    # 모든 봇의 equity curve를 합산
-    from ante.report.feedback import PerformanceFeedback
+    """기간별 자산 추이 (daily_snapshots 시계열 반환)."""
+    target = _resolve_treasury(treasury, treasury_manager, account_id)
 
-    feedback = PerformanceFeedback(trade_service, bot_manager)
+    if end_date is None:
+        end_date = datetime.now(UTC).strftime("%Y-%m-%d")
+    if start_date is None:
+        start_date = (datetime.now(UTC) - timedelta(days=30)).strftime("%Y-%m-%d")
 
-    bots = bot_manager.list_bots() if hasattr(bot_manager, "list_bots") else []
-    if account_id:
-        bots = [
-            b
-            for b in bots
-            if (
-                b.get("account_id")
-                if isinstance(b, dict)
-                else getattr(b, "account_id", None)
-            )
-            == account_id
-        ]
-    bot_ids = [b["bot_id"] if isinstance(b, dict) else b.bot_id for b in bots]
+    snapshots = await target.get_snapshots(start_date, end_date)
+    data = [
+        {
+            "date": s["snapshot_date"],
+            "total_asset": s["total_asset"],
+            "daily_pnl": s["daily_pnl"],
+            "daily_return": s["daily_return"],
+            "unrealized_pnl": s["unrealized_pnl"],
+        }
+        for s in snapshots
+    ]
 
-    # 봇이 없으면 빈 데이터
-    if not bot_ids:
-        return {"data": [], "period": period}
-
-    # 전체 봇의 equity curve 합산
-    merged: dict[str, float] = {}
-    for bot_id in bot_ids:
-        curve = await feedback.get_equity_curve(bot_id=bot_id)
-        for point in curve:
-            date = point["date"]
-            merged[date] = merged.get(date, 0.0) + point["value"]
-
-    # 기간 필터
-    days = _PERIOD_DAYS.get(period, 30)
-    if days > 0 and merged:
-        cutoff = (datetime.now(UTC) - timedelta(days=days)).strftime("%Y-%m-%d")
-        merged = {d: v for d, v in merged.items() if d >= cutoff}
-
-    data = [{"date": d, "value": round(v, 2)} for d, v in sorted(merged.items())]
-
-    return {"data": data, "period": period}
+    return {
+        "data": data,
+        "start_date": start_date,
+        "end_date": end_date,
+    }

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -328,3 +329,90 @@ async def set_balance(
         "total_balance": treasury.account_balance,
         "updated_at": datetime.now(UTC).isoformat(),
     }
+
+
+# ── 일별 자산 스냅샷 ──────────────────────────────────────
+
+
+def _resolve_treasury(
+    treasury: Any,
+    treasury_manager: Any | None,
+    account_id: str | None,
+) -> Any:
+    """account_id가 주어지면 해당 계좌의 Treasury를 반환한다."""
+    if account_id and treasury_manager is not None:
+        try:
+            return treasury_manager.get(account_id)
+        except KeyError:
+            raise HTTPException(
+                status_code=404,
+                detail=f"계좌를 찾을 수 없습니다: {account_id}",
+            )
+    return treasury
+
+
+@router.get(
+    "/snapshots/latest",
+    responses={
+        404: {"description": "No snapshot found"},
+        503: {"description": "Treasury not available"},
+    },
+)
+async def get_latest_snapshot(
+    treasury: Annotated[Any, Depends(get_treasury)],
+    treasury_manager: Annotated[Any | None, Depends(get_treasury_manager_optional)],
+    account_id: str | None = None,
+) -> dict:
+    """가장 최근 일별 스냅샷 조회."""
+    target = _resolve_treasury(treasury, treasury_manager, account_id)
+    snapshot = await target.get_latest_snapshot()
+    if snapshot is None:
+        raise HTTPException(status_code=404, detail="스냅샷이 없습니다")
+    return {"snapshot": snapshot}
+
+
+@router.get(
+    "/snapshots",
+    responses={503: {"description": "Treasury not available"}},
+)
+async def list_snapshots(
+    treasury: Annotated[Any, Depends(get_treasury)],
+    treasury_manager: Annotated[Any | None, Depends(get_treasury_manager_optional)],
+    account_id: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> dict:
+    """기간별 일별 스냅샷 목록."""
+    target = _resolve_treasury(treasury, treasury_manager, account_id)
+
+    if start_date is None:
+        start_date = "2000-01-01"
+    if end_date is None:
+        end_date = datetime.now(UTC).strftime("%Y-%m-%d")
+
+    snapshots = await target.get_snapshots(start_date, end_date)
+    return {"snapshots": snapshots}
+
+
+@router.get(
+    "/snapshots/{date}",
+    responses={
+        404: {"description": "Snapshot not found"},
+        503: {"description": "Treasury not available"},
+    },
+)
+async def get_snapshot_by_date(
+    date: str,
+    treasury: Annotated[Any, Depends(get_treasury)],
+    treasury_manager: Annotated[Any | None, Depends(get_treasury_manager_optional)],
+    account_id: str | None = None,
+) -> dict:
+    """특정일 스냅샷 조회."""
+    target = _resolve_treasury(treasury, treasury_manager, account_id)
+    snapshot = await target.get_daily_snapshot(date)
+    if snapshot is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"스냅샷을 찾을 수 없습니다: {date}",
+        )
+    return {"snapshot": snapshot}

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -19,6 +19,8 @@ from ante.web.schemas import (
     BalanceSetResponse,
     BudgetListResponse,
     BudgetOperationResponse,
+    SnapshotListResponse,
+    SnapshotResponse,
     TransactionListResponse,
     TreasurySummaryResponse,
 )
@@ -353,8 +355,8 @@ def _resolve_treasury(
 
 @router.get(
     "/snapshots/latest",
+    response_model=SnapshotResponse,
     responses={
-        404: {"description": "No snapshot found"},
         503: {"description": "Treasury not available"},
     },
 )
@@ -366,13 +368,36 @@ async def get_latest_snapshot(
     """가장 최근 일별 스냅샷 조회."""
     target = _resolve_treasury(treasury, treasury_manager, account_id)
     snapshot = await target.get_latest_snapshot()
-    if snapshot is None:
-        raise HTTPException(status_code=404, detail="스냅샷이 없습니다")
-    return {"snapshot": snapshot}
+    if snapshot is not None:
+        return {"snapshot": snapshot}
+
+    # 스냅샷 미존재 시 get_summary() fallback (시스템 초기 구동)
+    summary = target.get_summary()
+    now = datetime.now(UTC)
+    today = now.strftime("%Y-%m-%d")
+    return {
+        "snapshot": {
+            "account_id": getattr(target, "account_id", ""),
+            "snapshot_date": today,
+            "total_asset": summary.get("total_evaluation", 0.0),
+            "ante_eval_amount": summary.get("ante_eval_amount", 0.0),
+            "ante_purchase_amount": summary.get("ante_purchase_amount", 0.0),
+            "unallocated": summary.get("unallocated", 0.0),
+            "account_balance": summary.get("account_balance", 0.0),
+            "total_allocated": summary.get("total_allocated", 0.0),
+            "bot_count": summary.get("bot_count", 0),
+            "daily_pnl": 0.0,
+            "daily_return": 0.0,
+            "net_trade_amount": 0.0,
+            "unrealized_pnl": 0.0,
+            "created_at": now.isoformat(),
+        }
+    }
 
 
 @router.get(
     "/snapshots",
+    response_model=SnapshotListResponse,
     responses={503: {"description": "Treasury not available"}},
 )
 async def list_snapshots(
@@ -396,6 +421,7 @@ async def list_snapshots(
 
 @router.get(
     "/snapshots/{date}",
+    response_model=SnapshotResponse,
     responses={
         404: {"description": "Snapshot not found"},
         503: {"description": "Treasury not available"},

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -747,26 +747,33 @@ class ConfigUpdateResponse(BaseModel):
 
 
 class PortfolioValueResponse(BaseModel):
-    """총 자산 가치 응답."""
+    """총 자산 가치 응답 (스냅샷 기반)."""
 
     total_value: float
     daily_pnl: float
     daily_pnl_pct: float
+    daily_return: float
+    unrealized_pnl: float = 0.0
+    snapshot_date: str | None = None
     updated_at: str
 
 
 class PortfolioHistoryPoint(BaseModel):
-    """자산 추이 데이터 포인트."""
+    """자산 추이 데이터 포인트 (스냅샷 기반)."""
 
     date: str
-    value: float
+    total_asset: float
+    daily_pnl: float
+    daily_return: float
+    unrealized_pnl: float
 
 
 class PortfolioHistoryResponse(BaseModel):
     """기간별 자산 추이 응답."""
 
     data: list[PortfolioHistoryPoint]
-    period: str
+    start_date: str
+    end_date: str
 
 
 # ── 감사 로그 ──────────────────────────────────────────────

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -417,6 +417,39 @@ class BalanceSetResponse(BaseModel):
     updated_at: str
 
 
+class SnapshotItem(BaseModel):
+    """일별 자산 스냅샷 아이템."""
+
+    account_id: str
+    snapshot_date: str
+    total_asset: float
+    ante_eval_amount: float
+    ante_purchase_amount: float
+    unallocated: float
+    account_balance: float
+    total_allocated: float
+    bot_count: int
+    daily_pnl: float
+    daily_return: float
+    net_trade_amount: float
+    unrealized_pnl: float
+    created_at: str
+
+    model_config = ConfigDict(extra="allow")
+
+
+class SnapshotResponse(BaseModel):
+    """단일 스냅샷 응답."""
+
+    snapshot: SnapshotItem
+
+
+class SnapshotListResponse(BaseModel):
+    """스냅샷 목록 응답."""
+
+    snapshots: list[SnapshotItem]
+
+
 # ── 리포트 ──────────────────────────────────────────────
 
 

--- a/tests/unit/test_portfolio_api.py
+++ b/tests/unit/test_portfolio_api.py
@@ -72,11 +72,26 @@ class TestPortfolioValue:
         assert data["unrealized_pnl"] == 2_000_000.0
         assert data["snapshot_date"] == "2026-03-20"
 
-    def test_no_snapshot_returns_404(self, client, treasury):
-        """스냅샷이 없으면 404."""
+    def test_daily_pnl_pct_backward_compat(self, client):
+        """daily_pnl_pct 하위 호환 필드가 daily_return과 동일 값으로 포함된다."""
+        resp = client.get("/api/portfolio/value")
+        data = resp.json()
+        assert data["daily_pnl_pct"] == data["daily_return"]
+        assert data["daily_pnl_pct"] == 1.01
+
+    def test_no_snapshot_fallback_to_summary(self, client, treasury):
+        """스냅샷이 없으면 get_summary() fallback으로 기본 응답을 반환한다."""
         treasury.get_latest_snapshot = AsyncMock(return_value=None)
         resp = client.get("/api/portfolio/value")
-        assert resp.status_code == 404
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_value"] == 50_000_000.0
+        assert data["daily_pnl"] == 0.0
+        assert data["daily_pnl_pct"] == 0.0
+        assert data["daily_return"] == 0.0
+        assert data["unrealized_pnl"] == 0.0
+        assert "updated_at" in data
+        treasury.get_summary.assert_called_once()
 
 
 class TestPortfolioHistory:

--- a/tests/unit/test_portfolio_api.py
+++ b/tests/unit/test_portfolio_api.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -11,6 +11,23 @@ httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.web.app import create_app  # noqa: E402
+
+_SNAPSHOT = {
+    "account_id": "acc-001",
+    "snapshot_date": "2026-03-20",
+    "total_asset": 50_000_000.0,
+    "ante_eval_amount": 40_000_000.0,
+    "ante_purchase_amount": 38_000_000.0,
+    "unallocated": 10_000_000.0,
+    "account_balance": 10_000_000.0,
+    "total_allocated": 40_000_000.0,
+    "bot_count": 3,
+    "daily_pnl": 500_000.0,
+    "daily_return": 1.01,
+    "net_trade_amount": 200_000.0,
+    "unrealized_pnl": 2_000_000.0,
+    "created_at": "2026-03-20T18:00:00+09:00",
+}
 
 
 @pytest.fixture
@@ -21,36 +38,14 @@ def treasury():
         "total_profit_loss": 500_000.0,
         "account_balance": 10_000_000.0,
     }
+    mock.get_latest_snapshot = AsyncMock(return_value=_SNAPSHOT)
+    mock.get_snapshots = AsyncMock(return_value=[_SNAPSHOT])
     return mock
 
 
 @pytest.fixture
-def trade_service():
-    return MagicMock()
-
-
-@pytest.fixture
-def bot_manager():
-    mock = MagicMock()
-    mock.list_bots.return_value = [
-        {"bot_id": "bot-001"},
-    ]
-    return mock
-
-
-@pytest.fixture
-def report_store():
-    return MagicMock()
-
-
-@pytest.fixture
-def app(treasury, trade_service, bot_manager, report_store):
-    return create_app(
-        treasury=treasury,
-        trade_service=trade_service,
-        bot_manager=bot_manager,
-        report_store=report_store,
-    )
+def app(treasury):
+    return create_app(treasury=treasury)
 
 
 @pytest.fixture
@@ -66,74 +61,42 @@ class TestPortfolioValue:
         data = resp.json()
         assert data["total_value"] == 50_000_000.0
         assert data["daily_pnl"] == 500_000.0
-        assert "daily_pnl_pct" in data
+        assert "daily_return" in data
         assert "updated_at" in data
 
-    def test_pnl_percentage(self, client):
-        """손익 비율 계산."""
+    def test_snapshot_fields(self, client):
+        """스냅샷 기반 필드 반환."""
         resp = client.get("/api/portfolio/value")
         data = resp.json()
-        expected_pct = round(500_000.0 / 50_000_000.0 * 100, 4)
-        assert data["daily_pnl_pct"] == expected_pct
+        assert data["daily_return"] == 1.01
+        assert data["unrealized_pnl"] == 2_000_000.0
+        assert data["snapshot_date"] == "2026-03-20"
 
-    def test_zero_total_value(self, client, treasury):
-        """총 자산이 0일 때 pnl_pct는 0."""
-        treasury.get_summary.return_value = {
-            "total_evaluation": 0.0,
-            "total_profit_loss": 0.0,
-        }
+    def test_no_snapshot_returns_404(self, client, treasury):
+        """스냅샷이 없으면 404."""
+        treasury.get_latest_snapshot = AsyncMock(return_value=None)
         resp = client.get("/api/portfolio/value")
-        data = resp.json()
-        assert data["daily_pnl_pct"] == 0.0
+        assert resp.status_code == 404
 
 
 class TestPortfolioHistory:
-    def test_empty_bots(self, client, bot_manager):
-        """봇이 없을 때 빈 데이터."""
-        bot_manager.list_bots.return_value = []
-        resp = client.get("/api/portfolio/history?period=1m")
+    def test_returns_time_series(self, client):
+        """시계열 데이터 반환."""
+        resp = client.get(
+            "/api/portfolio/history",
+            params={"start_date": "2026-03-01", "end_date": "2026-03-20"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["data"]) == 1
+        assert data["data"][0]["date"] == "2026-03-20"
+        assert data["start_date"] == "2026-03-01"
+        assert data["end_date"] == "2026-03-20"
+
+    def test_empty_snapshots(self, client, treasury):
+        """스냅샷이 없으면 빈 데이터."""
+        treasury.get_snapshots = AsyncMock(return_value=[])
+        resp = client.get("/api/portfolio/history")
         assert resp.status_code == 200
         data = resp.json()
         assert data["data"] == []
-        assert data["period"] == "1m"
-
-    def test_with_equity_data(self, client):
-        """equity curve 데이터가 있는 경우."""
-        mock_curve = [
-            {"date": "2026-03-01", "value": 10_000_000.0},
-            {"date": "2026-03-10", "value": 10_500_000.0},
-            {"date": "2026-03-14", "value": 10_200_000.0},
-        ]
-        with patch(
-            "ante.report.feedback.PerformanceFeedback", autospec=True
-        ) as mock_feedback_cls:
-            instance = mock_feedback_cls.return_value
-            instance.get_equity_curve = AsyncMock(return_value=mock_curve)
-
-            resp = client.get("/api/portfolio/history?period=1m")
-            assert resp.status_code == 200
-            data = resp.json()
-            assert len(data["data"]) == 3
-            assert data["data"][0]["date"] == "2026-03-01"
-
-    def test_invalid_period(self, client):
-        """잘못된 기간 값은 422."""
-        resp = client.get("/api/portfolio/history?period=2y")
-        assert resp.status_code == 422
-
-    def test_all_period(self, client):
-        """period=all은 필터 없이 전체 반환."""
-        mock_curve = [
-            {"date": "2025-01-01", "value": 5_000_000.0},
-            {"date": "2026-03-14", "value": 10_000_000.0},
-        ]
-        with patch(
-            "ante.report.feedback.PerformanceFeedback", autospec=True
-        ) as mock_feedback_cls:
-            instance = mock_feedback_cls.return_value
-            instance.get_equity_curve = AsyncMock(return_value=mock_curve)
-
-            resp = client.get("/api/portfolio/history?period=all")
-            assert resp.status_code == 200
-            data = resp.json()
-            assert len(data["data"]) == 2

--- a/tests/unit/test_snapshot_api.py
+++ b/tests/unit/test_snapshot_api.py
@@ -53,6 +53,7 @@ _SNAPSHOT_20260319 = {
 @pytest.fixture
 def treasury():
     mock = MagicMock()
+    mock.account_id = "acc-001"
     mock.get_summary.return_value = {
         "total_evaluation": 50_000_000.0,
         "total_profit_loss": 500_000.0,
@@ -90,11 +91,17 @@ class TestTreasurySnapshotLatest:
         assert data["snapshot"]["daily_pnl"] == 500_000.0
         treasury.get_latest_snapshot.assert_awaited_once()
 
-    def test_returns_404_when_no_snapshot(self, client, treasury):
-        """스냅샷이 없으면 404."""
+    def test_fallback_to_summary_when_no_snapshot(self, client, treasury):
+        """스냅샷이 없으면 get_summary() fallback으로 기본 응답을 반환한다."""
         treasury.get_latest_snapshot = AsyncMock(return_value=None)
         resp = client.get("/api/treasury/snapshots/latest")
-        assert resp.status_code == 404
+        assert resp.status_code == 200
+        data = resp.json()
+        snapshot = data["snapshot"]
+        assert snapshot["total_asset"] == 50_000_000.0
+        assert snapshot["daily_pnl"] == 0.0
+        assert snapshot["daily_return"] == 0.0
+        treasury.get_summary.assert_called_once()
 
 
 class TestTreasurySnapshotList:
@@ -153,16 +160,23 @@ class TestPortfolioValue:
         assert data["total_value"] == 50_000_000.0
         assert data["daily_pnl"] == 500_000.0
         assert data["daily_return"] == 1.01
+        assert data["daily_pnl_pct"] == 1.01
         assert data["unrealized_pnl"] == 2_000_000.0
         assert data["snapshot_date"] == "2026-03-20"
         assert "updated_at" in data
         treasury.get_latest_snapshot.assert_awaited_once()
 
-    def test_returns_404_when_no_snapshot(self, client, treasury):
-        """스냅샷이 없으면 404."""
+    def test_fallback_to_summary_when_no_snapshot(self, client, treasury):
+        """스냅샷이 없으면 get_summary() fallback으로 기본 응답을 반환한다."""
         treasury.get_latest_snapshot = AsyncMock(return_value=None)
         resp = client.get("/api/portfolio/value")
-        assert resp.status_code == 404
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_value"] == 50_000_000.0
+        assert data["daily_pnl"] == 0.0
+        assert data["daily_pnl_pct"] == 0.0
+        assert data["daily_return"] == 0.0
+        treasury.get_summary.assert_called()
 
 
 class TestPortfolioHistory:

--- a/tests/unit/test_snapshot_api.py
+++ b/tests/unit/test_snapshot_api.py
@@ -1,0 +1,197 @@
+"""일별 자산 스냅샷 및 포트폴리오 API 테스트."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402
+
+# ── 공통 픽스처 ─────────────────────────────────────────
+
+
+_SNAPSHOT_20260320 = {
+    "account_id": "acc-001",
+    "snapshot_date": "2026-03-20",
+    "total_asset": 50_000_000.0,
+    "ante_eval_amount": 40_000_000.0,
+    "ante_purchase_amount": 38_000_000.0,
+    "unallocated": 10_000_000.0,
+    "account_balance": 10_000_000.0,
+    "total_allocated": 40_000_000.0,
+    "bot_count": 3,
+    "daily_pnl": 500_000.0,
+    "daily_return": 1.01,
+    "net_trade_amount": 200_000.0,
+    "unrealized_pnl": 2_000_000.0,
+    "created_at": "2026-03-20T18:00:00+09:00",
+}
+
+_SNAPSHOT_20260319 = {
+    "account_id": "acc-001",
+    "snapshot_date": "2026-03-19",
+    "total_asset": 49_500_000.0,
+    "ante_eval_amount": 39_500_000.0,
+    "ante_purchase_amount": 37_500_000.0,
+    "unallocated": 10_000_000.0,
+    "account_balance": 10_000_000.0,
+    "total_allocated": 39_500_000.0,
+    "bot_count": 3,
+    "daily_pnl": 300_000.0,
+    "daily_return": 0.61,
+    "net_trade_amount": 100_000.0,
+    "unrealized_pnl": 1_500_000.0,
+    "created_at": "2026-03-19T18:00:00+09:00",
+}
+
+
+@pytest.fixture
+def treasury():
+    mock = MagicMock()
+    mock.get_summary.return_value = {
+        "total_evaluation": 50_000_000.0,
+        "total_profit_loss": 500_000.0,
+        "account_balance": 10_000_000.0,
+    }
+    mock.get_latest_snapshot = AsyncMock(return_value=_SNAPSHOT_20260320)
+    mock.get_daily_snapshot = AsyncMock(return_value=_SNAPSHOT_20260320)
+    mock.get_snapshots = AsyncMock(
+        return_value=[_SNAPSHOT_20260319, _SNAPSHOT_20260320]
+    )
+    return mock
+
+
+@pytest.fixture
+def app(treasury):
+    return create_app(treasury=treasury)
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+# ── Treasury 스냅샷 API 테스트 ──────────────────────────
+
+
+class TestTreasurySnapshotLatest:
+    def test_returns_latest_snapshot(self, client, treasury):
+        """최신 스냅샷 반환."""
+        resp = client.get("/api/treasury/snapshots/latest")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["snapshot"]["snapshot_date"] == "2026-03-20"
+        assert data["snapshot"]["total_asset"] == 50_000_000.0
+        assert data["snapshot"]["daily_pnl"] == 500_000.0
+        treasury.get_latest_snapshot.assert_awaited_once()
+
+    def test_returns_404_when_no_snapshot(self, client, treasury):
+        """스냅샷이 없으면 404."""
+        treasury.get_latest_snapshot = AsyncMock(return_value=None)
+        resp = client.get("/api/treasury/snapshots/latest")
+        assert resp.status_code == 404
+
+
+class TestTreasurySnapshotList:
+    def test_returns_snapshots_with_date_range(self, client, treasury):
+        """날짜 범위로 스냅샷 목록 조회."""
+        resp = client.get(
+            "/api/treasury/snapshots",
+            params={"start_date": "2026-03-19", "end_date": "2026-03-20"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["snapshots"]) == 2
+        assert data["snapshots"][0]["snapshot_date"] == "2026-03-19"
+        assert data["snapshots"][1]["snapshot_date"] == "2026-03-20"
+        treasury.get_snapshots.assert_awaited_once_with("2026-03-19", "2026-03-20")
+
+    def test_defaults_when_no_dates(self, client, treasury):
+        """날짜 미지정 시 기본값으로 조회."""
+        resp = client.get("/api/treasury/snapshots")
+        assert resp.status_code == 200
+        treasury.get_snapshots.assert_awaited_once()
+
+    def test_returns_empty_list(self, client, treasury):
+        """결과가 없으면 빈 목록."""
+        treasury.get_snapshots = AsyncMock(return_value=[])
+        resp = client.get("/api/treasury/snapshots")
+        assert resp.status_code == 200
+        assert resp.json()["snapshots"] == []
+
+
+class TestTreasurySnapshotByDate:
+    def test_returns_snapshot_for_date(self, client, treasury):
+        """특정일 스냅샷 조회."""
+        resp = client.get("/api/treasury/snapshots/2026-03-20")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["snapshot"]["snapshot_date"] == "2026-03-20"
+        treasury.get_daily_snapshot.assert_awaited_once_with("2026-03-20")
+
+    def test_returns_404_when_not_found(self, client, treasury):
+        """해당 날짜 스냅샷이 없으면 404."""
+        treasury.get_daily_snapshot = AsyncMock(return_value=None)
+        resp = client.get("/api/treasury/snapshots/2026-01-01")
+        assert resp.status_code == 404
+
+
+# ── Portfolio API 테스트 (스냅샷 기반) ────────────────────
+
+
+class TestPortfolioValue:
+    def test_returns_snapshot_based_value(self, client, treasury):
+        """스냅샷 기반 총 자산 가치 반환."""
+        resp = client.get("/api/portfolio/value")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_value"] == 50_000_000.0
+        assert data["daily_pnl"] == 500_000.0
+        assert data["daily_return"] == 1.01
+        assert data["unrealized_pnl"] == 2_000_000.0
+        assert data["snapshot_date"] == "2026-03-20"
+        assert "updated_at" in data
+        treasury.get_latest_snapshot.assert_awaited_once()
+
+    def test_returns_404_when_no_snapshot(self, client, treasury):
+        """스냅샷이 없으면 404."""
+        treasury.get_latest_snapshot = AsyncMock(return_value=None)
+        resp = client.get("/api/portfolio/value")
+        assert resp.status_code == 404
+
+
+class TestPortfolioHistory:
+    def test_returns_snapshot_time_series(self, client, treasury):
+        """스냅샷 기반 시계열 반환."""
+        resp = client.get(
+            "/api/portfolio/history",
+            params={"start_date": "2026-03-19", "end_date": "2026-03-20"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["data"]) == 2
+        assert data["data"][0]["date"] == "2026-03-19"
+        assert data["data"][0]["total_asset"] == 49_500_000.0
+        assert data["data"][0]["daily_pnl"] == 300_000.0
+        assert data["start_date"] == "2026-03-19"
+        assert data["end_date"] == "2026-03-20"
+
+    def test_defaults_when_no_dates(self, client, treasury):
+        """날짜 미지정 시 기본 30일 범위로 조회."""
+        resp = client.get("/api/portfolio/history")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "start_date" in data
+        assert "end_date" in data
+
+    def test_returns_empty_when_no_snapshots(self, client, treasury):
+        """스냅샷이 없으면 빈 데이터."""
+        treasury.get_snapshots = AsyncMock(return_value=[])
+        resp = client.get("/api/portfolio/history")
+        assert resp.status_code == 200
+        assert resp.json()["data"] == []


### PR DESCRIPTION
## Summary
- Treasury 스냅샷 API 3개 엔드포인트 추가: `GET /api/treasury/snapshots/latest`, `GET /api/treasury/snapshots`, `GET /api/treasury/snapshots/{date}`
- Portfolio API 2개 엔드포인트를 스냅샷 기반으로 전환: `GET /api/portfolio/value` (최신 스냅샷 기반 총자산/손익/수익률/미실현손익), `GET /api/portfolio/history` (start_date/end_date 파라미터로 시계열 반환)
- Treasury 클래스에 `get_latest_snapshot()` 메서드 추가
- Pydantic 스키마 `SnapshotItem`, `SnapshotResponse`, `SnapshotListResponse` 추가
- 단위 테스트 17건 (12건 신규 + 5건 기존 갱신)

## Test plan
- [x] `pytest tests/unit/test_snapshot_api.py` — 12건 통과
- [x] `pytest tests/unit/test_portfolio_api.py` — 5건 통과
- [x] `pytest tests/unit/test_response_model_validation.py` — 70건 통과 (기존 회귀 없음)
- [x] `ruff check` + `ruff format --check` 통과

Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)