### PR TITLE
refactor(web): portfolio API에서 daily_pnl_pct 하위호환 필드 제거

### DIFF
--- a/src/ante/web/routes/portfolio.py
+++ b/src/ante/web/routes/portfolio.py
@@ -60,7 +60,6 @@ async def portfolio_value(
         return {
             "total_value": snapshot["total_asset"],
             "daily_pnl": snapshot["daily_pnl"],
-            "daily_pnl_pct": daily_return,
             "daily_return": daily_return,
             "unrealized_pnl": snapshot["unrealized_pnl"],
             "snapshot_date": snapshot["snapshot_date"],
@@ -73,7 +72,6 @@ async def portfolio_value(
     return {
         "total_value": summary.get("total_evaluation", 0.0),
         "daily_pnl": 0.0,
-        "daily_pnl_pct": 0.0,
         "daily_return": 0.0,
         "unrealized_pnl": 0.0,
         "updated_at": now,

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -751,7 +751,6 @@ class PortfolioValueResponse(BaseModel):
 
     total_value: float
     daily_pnl: float
-    daily_pnl_pct: float
     daily_return: float
     unrealized_pnl: float = 0.0
     snapshot_date: str | None = None

--- a/tests/unit/test_portfolio_api.py
+++ b/tests/unit/test_portfolio_api.py
@@ -72,13 +72,6 @@ class TestPortfolioValue:
         assert data["unrealized_pnl"] == 2_000_000.0
         assert data["snapshot_date"] == "2026-03-20"
 
-    def test_daily_pnl_pct_backward_compat(self, client):
-        """daily_pnl_pct 하위 호환 필드가 daily_return과 동일 값으로 포함된다."""
-        resp = client.get("/api/portfolio/value")
-        data = resp.json()
-        assert data["daily_pnl_pct"] == data["daily_return"]
-        assert data["daily_pnl_pct"] == 1.01
-
     def test_no_snapshot_fallback_to_summary(self, client, treasury):
         """스냅샷이 없으면 get_summary() fallback으로 기본 응답을 반환한다."""
         treasury.get_latest_snapshot = AsyncMock(return_value=None)
@@ -87,7 +80,6 @@ class TestPortfolioValue:
         data = resp.json()
         assert data["total_value"] == 50_000_000.0
         assert data["daily_pnl"] == 0.0
-        assert data["daily_pnl_pct"] == 0.0
         assert data["daily_return"] == 0.0
         assert data["unrealized_pnl"] == 0.0
         assert "updated_at" in data

--- a/tests/unit/test_response_model_validation.py
+++ b/tests/unit/test_response_model_validation.py
@@ -858,7 +858,7 @@ class TestPortfolioResponseModels:
         data = {
             "total_value": 10500000.0,
             "daily_pnl": 50000.0,
-            "daily_pnl_pct": 0.4784,
+            "daily_return": 0.4784,
             "updated_at": "2026-03-19T10:00:00Z",
         }
         model = PortfolioValueResponse.model_validate(data)

--- a/tests/unit/test_snapshot_api.py
+++ b/tests/unit/test_snapshot_api.py
@@ -160,7 +160,6 @@ class TestPortfolioValue:
         assert data["total_value"] == 50_000_000.0
         assert data["daily_pnl"] == 500_000.0
         assert data["daily_return"] == 1.01
-        assert data["daily_pnl_pct"] == 1.01
         assert data["unrealized_pnl"] == 2_000_000.0
         assert data["snapshot_date"] == "2026-03-20"
         assert "updated_at" in data
@@ -174,7 +173,6 @@ class TestPortfolioValue:
         data = resp.json()
         assert data["total_value"] == 50_000_000.0
         assert data["daily_pnl"] == 0.0
-        assert data["daily_pnl_pct"] == 0.0
         assert data["daily_return"] == 0.0
         treasury.get_summary.assert_called()
 


### PR DESCRIPTION
## Summary
- `PortfolioValueResponse` 스키마에서 `daily_pnl_pct` 필드 제거 (`daily_return`으로 일원화)
- `portfolio_value` 라우터의 스냅샷/fallback 응답에서 `daily_pnl_pct` 키 제거
- 관련 테스트 3개 파일에서 `daily_pnl_pct` assertion 정리

## Test plan
- [x] `tests/unit/test_portfolio_api.py` 전체 통과 확인
- [x] `tests/unit/test_snapshot_api.py` 전체 통과 확인
- [x] `tests/unit/test_response_model_validation.py::TestPortfolioResponseModels::test_portfolio_value_response` 통과 확인
- [x] ruff check / ruff format 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)