### PR TITLE
fix(account): 불변 필드 수정 차단 (#690)

### DIFF
--- a/src/ante/account/__init__.py
+++ b/src/ante/account/__init__.py
@@ -4,6 +4,7 @@ from ante.account.errors import (
     AccountAlreadyExistsError,
     AccountDeletedException,
     AccountError,
+    AccountImmutableFieldError,
     AccountNotFoundError,
     InvalidBrokerTypeError,
 )
@@ -16,6 +17,7 @@ __all__ = [
     "AccountAlreadyExistsError",
     "AccountDeletedException",
     "AccountError",
+    "AccountImmutableFieldError",
     "AccountNotFoundError",
     "AccountService",
     "AccountStatus",

--- a/src/ante/account/errors.py
+++ b/src/ante/account/errors.py
@@ -37,5 +37,11 @@ class AccountDeletedError(AccountError):
     pass
 
 
+class AccountImmutableFieldError(AccountError):
+    """불변 필드 수정 시도."""
+
+    pass
+
+
 # 하위 호환용 별칭
 AccountDeletedException = AccountDeletedError

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 from ante.account.errors import (
     AccountAlreadyExistsError,
     AccountDeletedException,
+    AccountImmutableFieldError,
     AccountNotFoundError,
     InvalidBrokerTypeError,
 )
@@ -205,12 +206,18 @@ class AccountService:
         # 기본: DELETED 제외 (메모리 캐시에는 DELETED가 없음)
         return list(self._accounts.values())
 
+    # 생성 후 변경 불가능한 필드
+    IMMUTABLE_FIELDS: frozenset[str] = frozenset(
+        {"exchange", "currency", "trading_mode", "broker_type"}
+    )
+
     async def update(self, account_id: str, **fields: Any) -> Account:
         """계좌 부분 수정. updated_at 자동 갱신.
 
         Raises:
             AccountNotFoundError: 계좌를 찾을 수 없음.
             AccountDeletedException: DELETED 계좌는 수정 불가.
+            AccountImmutableFieldError: 불변 필드 수정 시도.
         """
         account = await self.get(account_id)
         if account.status == AccountStatus.DELETED:
@@ -218,15 +225,18 @@ class AccountService:
                 f"삭제된 계좌 '{account_id}'는 수정할 수 없습니다."
             )
 
+        # 불변 필드 수정 시도 차단
+        attempted_immutable = set(fields.keys()) & self.IMMUTABLE_FIELDS
+        if attempted_immutable:
+            raise AccountImmutableFieldError(
+                f"다음 필드는 수정할 수 없습니다: {sorted(attempted_immutable)}"
+            )
+
         updatable = {
             "name",
-            "exchange",
-            "currency",
             "timezone",
             "trading_hours_start",
             "trading_hours_end",
-            "trading_mode",
-            "broker_type",
             "credentials",
             "buy_commission_rate",
             "sell_commission_rate",

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -177,19 +177,19 @@ async def update_account(
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict[str, Any]:
     """계좌 수정."""
-    from ante.account.errors import AccountDeletedError, AccountNotFoundError
+    from ante.account.errors import (
+        AccountDeletedError,
+        AccountImmutableFieldError,
+        AccountNotFoundError,
+    )
 
     # None이 아닌 필드만 업데이트 대상
     fields: dict[str, Any] = {}
     for field_name in (
         "name",
-        "exchange",
-        "currency",
         "timezone",
         "trading_hours_start",
         "trading_hours_end",
-        "trading_mode",
-        "broker_type",
         "credentials",
         "buy_commission_rate",
         "sell_commission_rate",
@@ -200,16 +200,12 @@ async def update_account(
                 from decimal import Decimal
 
                 value = Decimal(str(value))
-            elif field_name == "trading_mode":
-                from ante.account.models import TradingMode
+            fields[field_name] = value
 
-                try:
-                    value = TradingMode(value)
-                except ValueError:
-                    raise HTTPException(
-                        status_code=400,
-                        detail=f"유효하지 않은 trading_mode: '{value}'",
-                    )
+    # 불변 필드가 요청에 포함된 경우 서비스 레이어에서 차단하도록 전달
+    for field_name in ("exchange", "currency", "trading_mode", "broker_type"):
+        value = getattr(body, field_name, None)
+        if value is not None:
             fields[field_name] = value
 
     if not fields:
@@ -221,6 +217,8 @@ async def update_account(
         raise HTTPException(status_code=404, detail=str(e))
     except AccountDeletedError as e:
         raise HTTPException(status_code=409, detail=str(e))
+    except AccountImmutableFieldError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
     if audit_logger:
         await audit_logger.log(

--- a/tests/unit/test_account_immutable_fields.py
+++ b/tests/unit/test_account_immutable_fields.py
@@ -1,0 +1,114 @@
+"""Account 불변 필드 수정 차단 테스트."""
+
+import pytest
+import pytest_asyncio
+
+from ante.account.errors import AccountImmutableFieldError
+from ante.account.models import Account, TradingMode
+from ante.account.service import AccountService
+from ante.core.database import Database
+from ante.eventbus.bus import EventBus
+
+
+@pytest_asyncio.fixture
+async def db(tmp_path):
+    """테스트용 인메모리 DB."""
+    db_path = str(tmp_path / "test_immutable.db")
+    database = Database(db_path)
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+def eventbus():
+    """테스트용 EventBus."""
+    return EventBus()
+
+
+@pytest_asyncio.fixture
+async def service(db, eventbus):
+    """초기화된 AccountService."""
+    svc = AccountService(db, eventbus)
+    await svc.initialize()
+    return svc
+
+
+def _make_account(account_id: str = "test") -> Account:
+    return Account(
+        account_id=account_id,
+        name="테스트",
+        exchange="TEST",
+        currency="KRW",
+        broker_type="test",
+    )
+
+
+# ── 불변 필드 수정 차단 ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_immutable_exchange_raises(service):
+    """exchange 수정 시도 시 AccountImmutableFieldError 발생."""
+    await service.create(_make_account())
+    with pytest.raises(AccountImmutableFieldError, match="exchange"):
+        await service.update("test", exchange="NYSE")
+
+
+@pytest.mark.asyncio
+async def test_update_immutable_currency_raises(service):
+    """currency 수정 시도 시 AccountImmutableFieldError 발생."""
+    await service.create(_make_account())
+    with pytest.raises(AccountImmutableFieldError, match="currency"):
+        await service.update("test", currency="USD")
+
+
+@pytest.mark.asyncio
+async def test_update_immutable_trading_mode_raises(service):
+    """trading_mode 수정 시도 시 AccountImmutableFieldError 발생."""
+    await service.create(_make_account())
+    with pytest.raises(AccountImmutableFieldError, match="trading_mode"):
+        await service.update("test", trading_mode=TradingMode.LIVE)
+
+
+@pytest.mark.asyncio
+async def test_update_immutable_broker_type_raises(service):
+    """broker_type 수정 시도 시 AccountImmutableFieldError 발생."""
+    await service.create(_make_account())
+    with pytest.raises(AccountImmutableFieldError, match="broker_type"):
+        await service.update("test", broker_type="kis-domestic")
+
+
+@pytest.mark.asyncio
+async def test_update_multiple_immutable_fields_raises(service):
+    """여러 불변 필드 동시 수정 시도 시 AccountImmutableFieldError 발생."""
+    await service.create(_make_account())
+    with pytest.raises(AccountImmutableFieldError):
+        await service.update("test", exchange="NYSE", currency="USD")
+
+
+# ── 허용 필드 수정은 정상 동작 ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_mutable_name_succeeds(service):
+    """name 수정은 정상 동작."""
+    await service.create(_make_account())
+    updated = await service.update("test", name="새이름")
+    assert updated.name == "새이름"
+
+
+@pytest.mark.asyncio
+async def test_update_mutable_timezone_succeeds(service):
+    """timezone 수정은 정상 동작."""
+    await service.create(_make_account())
+    updated = await service.update("test", timezone="US/Eastern")
+    assert updated.timezone == "US/Eastern"
+
+
+@pytest.mark.asyncio
+async def test_update_mutable_with_immutable_raises(service):
+    """허용 필드와 불변 필드를 함께 보내면 불변 필드 에러가 발생."""
+    await service.create(_make_account())
+    with pytest.raises(AccountImmutableFieldError, match="exchange"):
+        await service.update("test", name="새이름", exchange="NYSE")


### PR DESCRIPTION
## Summary
- Account의 `exchange`, `currency`, `trading_mode`, `broker_type` 4개 필드를 생성 후 수정 불가(immutable)로 지정
- `AccountService.update()`에서 불변 필드 수정 시도 시 `AccountImmutableFieldError` 발생
- 웹 라우터에서 해당 에러를 400 응답으로 매핑

## Test plan
- [x] 불변 필드 개별 수정 시도 시 `AccountImmutableFieldError` 발생 확인 (4건)
- [x] 복수 불변 필드 동시 수정 시도 시 에러 확인
- [x] 허용 필드(name, timezone) 수정 정상 동작 확인
- [x] 허용 + 불변 필드 혼합 시 에러 확인
- [x] 기존 account 테스트 47건 전체 통과

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)