### PR TITLE
feat(treasury): Virtual 모드 자산 평가 동기화 (#692)

### DIFF
--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -562,35 +562,66 @@ def _init_context_factory(s: Services) -> None:
 
 async def _init_treasury_sync(s: Services, accounts: list) -> None:
     """각 계좌의 Treasury 잔고 동기화 시작 (Broker 연결 이후)."""
+    from ante.account.models import TradingMode
+
     sync_interval = s.config.get("treasury.sync_interval_seconds", 300)
 
     for account in accounts:
         try:
-            broker = await s.account_service.get_broker(account.account_id)
             treasury = s.treasury_manager.get(account.account_id)
+            trading_mode = getattr(account, "trading_mode", TradingMode.VIRTUAL)
+            is_virtual = trading_mode == TradingMode.VIRTUAL
 
-            account_no = getattr(broker, "account_no", "")
-            is_paper = getattr(broker, "is_paper", False)
-            formatted_account = (
-                f"{account_no[:8]}-{account_no[8:]}"
-                if len(account_no) >= 10
-                else account_no
-            )
-            treasury.set_account_info(
-                account_number=formatted_account,
-                is_demo_trading=is_paper,
-            )
+            if is_virtual:
+                # Virtual 모드: 브로커 없이 Trade DB 기반 동기화
+                price_resolver = None
+                if s.api_gateway:
+                    gateway = s.api_gateway
 
-            treasury.start_sync(
-                broker=broker,
-                position_history=s.position_history,
-                interval_seconds=sync_interval,
-            )
-            logger.info(
-                "Treasury 잔고 동기화 시작: account=%s (주기: %d초)",
-                account.account_id,
-                sync_interval,
-            )
+                    async def _resolve_price(symbol: str) -> float:
+                        return await gateway.get_current_price(symbol)
+
+                    price_resolver = _resolve_price
+
+                treasury.start_sync(
+                    broker=None,
+                    position_history=s.position_history,
+                    interval_seconds=sync_interval,
+                    trading_mode="virtual",
+                    price_resolver=price_resolver,
+                )
+                logger.info(
+                    "Treasury Virtual 동기화 시작: account=%s (주기: %d초)",
+                    account.account_id,
+                    sync_interval,
+                )
+            else:
+                # Live 모드: 브로커 기반 동기화
+                broker = await s.account_service.get_broker(account.account_id)
+
+                account_no = getattr(broker, "account_no", "")
+                is_paper = getattr(broker, "is_paper", False)
+                formatted_account = (
+                    f"{account_no[:8]}-{account_no[8:]}"
+                    if len(account_no) >= 10
+                    else account_no
+                )
+                treasury.set_account_info(
+                    account_number=formatted_account,
+                    is_demo_trading=is_paper,
+                )
+
+                treasury.start_sync(
+                    broker=broker,
+                    position_history=s.position_history,
+                    interval_seconds=sync_interval,
+                    trading_mode="live",
+                )
+                logger.info(
+                    "Treasury Live 동기화 시작: account=%s (주기: %d초)",
+                    account.account_id,
+                    sync_interval,
+                )
         except Exception:
             logger.warning(
                 "Treasury 동기화 시작 실패: account=%s — 건너뜀",

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -707,23 +707,41 @@ class Treasury:
 
     def start_sync(
         self,
-        broker: BrokerAdapter,
+        broker: BrokerAdapter | None,
         position_history: PositionHistory,
         interval_seconds: int = 300,
+        trading_mode: str = "live",
+        price_resolver: Callable[[str], Awaitable[float]] | None = None,
     ) -> None:
-        """KIS 계좌 잔고 주기적 동기화 시작."""
+        """계좌 잔고 주기적 동기화 시작.
+
+        Args:
+            broker: 브로커 어댑터. Virtual 모드에서는 None 허용.
+            position_history: 포지션 이력 관리자.
+            interval_seconds: 동기화 주기 (초).
+            trading_mode: "live" 또는 "virtual".
+            price_resolver: Virtual 모드에서 종목 현재가를 조회하는 콜백.
+                None이면 avg_entry_price를 fallback으로 사용.
+        """
         if self._sync_task and not self._sync_task.done():
             logger.warning("이미 동기화 루프가 실행 중입니다")
             return
 
         self._sync_task = asyncio.create_task(
-            self._sync_loop(broker, position_history, interval_seconds),
+            self._sync_loop(
+                broker,
+                position_history,
+                interval_seconds,
+                trading_mode=trading_mode,
+                price_resolver=price_resolver,
+            ),
             name=f"treasury-balance-sync-{self._account_id}",
         )
         logger.info(
-            "잔고 동기화 시작 (주기: %d초, account=%s)",
+            "잔고 동기화 시작 (주기: %d초, account=%s, mode=%s)",
             interval_seconds,
             self._account_id,
+            trading_mode,
         )
 
     async def stop_sync(self) -> None:
@@ -739,15 +757,21 @@ class Treasury:
 
     async def _sync_loop(
         self,
-        broker: BrokerAdapter,
+        broker: BrokerAdapter | None,
         position_history: PositionHistory,
         interval_seconds: int,
+        trading_mode: str = "live",
+        price_resolver: Callable[[str], Awaitable[float]] | None = None,
     ) -> None:
         """주기적 잔고 동기화 루프."""
         try:
             while True:
                 try:
-                    await self._do_sync(broker, position_history)
+                    if trading_mode == "virtual":
+                        await self._do_sync_virtual(position_history, price_resolver)
+                    else:
+                        assert broker is not None, "Live 모드에서는 broker가 필수입니다"
+                        await self._do_sync(broker, position_history)
                 except asyncio.CancelledError:
                     raise
                 except Exception:
@@ -761,7 +785,7 @@ class Treasury:
         broker: BrokerAdapter,
         position_history: PositionHistory,
     ) -> None:
-        """한 번의 잔고 동기화 수행."""
+        """한 번의 잔고 동기화 수행 (Live 모드)."""
         from ante.eventbus.events import BalanceSyncedEvent
 
         # 1) KIS 계좌 잔고 (output2)
@@ -804,6 +828,64 @@ class Treasury:
             f"{self._account_balance:,.0f}",
             f"{self._purchasable_amount:,.0f}",
             sum(1 for pos in broker_positions if pos["symbol"] not in internal_symbols),
+            self._account_id,
+        )
+
+    async def _do_sync_virtual(
+        self,
+        position_history: PositionHistory,
+        price_resolver: Callable[[str], Awaitable[float]] | None = None,
+    ) -> None:
+        """한 번의 잔고 동기화 수행 (Virtual 모드).
+
+        Trade DB의 포지션 데이터로 purchase/eval 금액을 직접 계산한다.
+        브로커 연결 없이 동작하므로 외부 종목은 항상 0이다.
+        """
+        from ante.eventbus.events import BalanceSyncedEvent
+
+        positions = await position_history.get_all_positions()
+
+        purchase_amount = 0.0
+        eval_amount = 0.0
+        for pos in positions:
+            purchase_amount += pos.avg_entry_price * pos.quantity
+            if price_resolver:
+                try:
+                    current_price = await price_resolver(pos.symbol)
+                except Exception:
+                    logger.debug(
+                        "Virtual 시세 조회 실패: %s — avg_entry_price 사용",
+                        pos.symbol,
+                    )
+                    current_price = pos.avg_entry_price
+            else:
+                current_price = pos.avg_entry_price
+            eval_amount += current_price * pos.quantity
+
+        self._purchase_amount = purchase_amount
+        self._eval_amount = eval_amount
+        self._external_purchase_amount = 0.0
+        self._external_eval_amount = 0.0
+        await self._save_state()
+
+        self._last_synced_at = datetime.now(UTC)
+
+        # 이벤트 발행
+        await self._eventbus.publish(
+            BalanceSyncedEvent(
+                account_id=self._account_id,
+                account_balance=self._account_balance,
+                purchasable_amount=self._purchasable_amount,
+                total_evaluation=self._total_evaluation,
+                external_purchase_amount=0.0,
+                external_eval_amount=0.0,
+            )
+        )
+        logger.info(
+            "Virtual 잔고 동기화 완료: 매수금=%s, 평가금=%s, 포지션=%d건 (account=%s)",
+            f"{purchase_amount:,.0f}",
+            f"{eval_amount:,.0f}",
+            len(positions),
             self._account_id,
         )
 

--- a/tests/unit/test_treasury_sync.py
+++ b/tests/unit/test_treasury_sync.py
@@ -341,6 +341,29 @@ class TestExternalPositions:
         assert treasury._external_purchase_amount == 3_000_000.0
         assert treasury._external_eval_amount == 3_100_000.0
 
+    async def test_live_mode_explicit(self, treasury):
+        """trading_mode='live' 명시해도 기존 동작과 동일."""
+        broker = FakeBroker(
+            positions=[
+                {
+                    "symbol": "035720",
+                    "quantity": 50.0,
+                    "avg_price": 60000.0,
+                    "eval_amount": 3_100_000.0,
+                },
+            ]
+        )
+        pos_history = FakePositionHistory(positions=[])
+
+        treasury.start_sync(
+            broker, pos_history, interval_seconds=100, trading_mode="live"
+        )
+        await asyncio.sleep(0.05)
+        await treasury.stop_sync()
+
+        assert treasury._external_purchase_amount == 3_000_000.0
+        assert treasury._external_eval_amount == 3_100_000.0
+
     async def test_external_amounts_in_memory(self, treasury):
         """외부 종목 금액이 인메모리에 보관된다."""
         broker = FakeBroker(
@@ -452,3 +475,207 @@ class TestAntePurePerformance:
         assert summary["total_profit_loss"] == 200_000.0
         assert summary["external_purchase_amount"] == 0.0
         assert summary["external_eval_amount"] == 0.0
+
+
+# ── US-5: Virtual 모드 동기화 ──────────────────────
+
+
+class TestVirtualSync:
+    async def test_virtual_sync_calculates_from_positions(self, treasury):
+        """Virtual 모드에서 Trade DB 포지션 기반으로 purchase/eval 계산."""
+        pos_history = FakePositionHistory(
+            positions=[
+                PositionSnapshot(
+                    bot_id="bot1",
+                    symbol="005930",
+                    quantity=100.0,
+                    avg_entry_price=70000.0,
+                ),
+                PositionSnapshot(
+                    bot_id="bot1",
+                    symbol="035720",
+                    quantity=50.0,
+                    avg_entry_price=60000.0,
+                ),
+            ]
+        )
+
+        treasury.start_sync(
+            broker=None,
+            position_history=pos_history,
+            interval_seconds=100,
+            trading_mode="virtual",
+        )
+        await asyncio.sleep(0.05)
+        await treasury.stop_sync()
+
+        # price_resolver 없으면 avg_entry_price 사용 -> eval == purchase
+        assert treasury._purchase_amount == 10_000_000.0  # 100*70000 + 50*60000
+        assert treasury._eval_amount == 10_000_000.0
+        assert treasury._external_purchase_amount == 0.0
+        assert treasury._external_eval_amount == 0.0
+
+    async def test_virtual_sync_with_price_resolver(self, treasury):
+        """Virtual 모드에서 price_resolver 사용 시 eval 금액이 시세 반영."""
+        prices = {"005930": 75000.0, "035720": 62000.0}
+
+        async def mock_price_resolver(symbol: str) -> float:
+            return prices[symbol]
+
+        pos_history = FakePositionHistory(
+            positions=[
+                PositionSnapshot(
+                    bot_id="bot1",
+                    symbol="005930",
+                    quantity=100.0,
+                    avg_entry_price=70000.0,
+                ),
+                PositionSnapshot(
+                    bot_id="bot1",
+                    symbol="035720",
+                    quantity=50.0,
+                    avg_entry_price=60000.0,
+                ),
+            ]
+        )
+
+        treasury.start_sync(
+            broker=None,
+            position_history=pos_history,
+            interval_seconds=100,
+            trading_mode="virtual",
+            price_resolver=mock_price_resolver,
+        )
+        await asyncio.sleep(0.05)
+        await treasury.stop_sync()
+
+        assert treasury._purchase_amount == 10_000_000.0  # 100*70000 + 50*60000
+        assert treasury._eval_amount == 10_600_000.0  # 100*75000 + 50*62000
+
+    async def test_virtual_sync_price_resolver_fallback(self, treasury):
+        """price_resolver 실패 시 avg_entry_price로 fallback."""
+
+        async def failing_resolver(symbol: str) -> float:
+            raise ConnectionError("시세 조회 실패")
+
+        pos_history = FakePositionHistory(
+            positions=[
+                PositionSnapshot(
+                    bot_id="bot1",
+                    symbol="005930",
+                    quantity=100.0,
+                    avg_entry_price=70000.0,
+                ),
+            ]
+        )
+
+        treasury.start_sync(
+            broker=None,
+            position_history=pos_history,
+            interval_seconds=100,
+            trading_mode="virtual",
+            price_resolver=failing_resolver,
+        )
+        await asyncio.sleep(0.05)
+        await treasury.stop_sync()
+
+        # fallback: avg_entry_price 사용
+        assert treasury._purchase_amount == 7_000_000.0
+        assert treasury._eval_amount == 7_000_000.0
+
+    async def test_virtual_sync_empty_positions(self, treasury):
+        """Virtual 모드에서 포지션이 없으면 0."""
+        pos_history = FakePositionHistory(positions=[])
+
+        treasury.start_sync(
+            broker=None,
+            position_history=pos_history,
+            interval_seconds=100,
+            trading_mode="virtual",
+        )
+        await asyncio.sleep(0.05)
+        await treasury.stop_sync()
+
+        assert treasury._purchase_amount == 0.0
+        assert treasury._eval_amount == 0.0
+
+    async def test_virtual_sync_get_summary_reflects_values(self, treasury):
+        """Virtual 동기화 후 get_summary()에 ante 필드가 정상 반영."""
+        prices = {"005930": 75000.0}
+
+        async def mock_resolver(symbol: str) -> float:
+            return prices[symbol]
+
+        pos_history = FakePositionHistory(
+            positions=[
+                PositionSnapshot(
+                    bot_id="bot1",
+                    symbol="005930",
+                    quantity=100.0,
+                    avg_entry_price=70000.0,
+                ),
+            ]
+        )
+
+        treasury.start_sync(
+            broker=None,
+            position_history=pos_history,
+            interval_seconds=100,
+            trading_mode="virtual",
+            price_resolver=mock_resolver,
+        )
+        await asyncio.sleep(0.05)
+        await treasury.stop_sync()
+
+        summary = treasury.get_summary()
+
+        # Virtual 모드: external = 0 이므로 ante = total
+        assert summary["ante_purchase_amount"] == 7_000_000.0  # 100 * 70000
+        assert summary["ante_eval_amount"] == 7_500_000.0  # 100 * 75000
+        assert summary["ante_profit_loss"] == 500_000.0  # 7.5M - 7M
+
+    async def test_virtual_sync_publishes_event(self, treasury, eventbus):
+        """Virtual 동기화 성공 시 BalanceSyncedEvent 발행."""
+        received = []
+        eventbus.subscribe(BalanceSyncedEvent, lambda e: received.append(e))
+
+        pos_history = FakePositionHistory(
+            positions=[
+                PositionSnapshot(
+                    bot_id="bot1",
+                    symbol="005930",
+                    quantity=100.0,
+                    avg_entry_price=70000.0,
+                ),
+            ]
+        )
+
+        treasury.start_sync(
+            broker=None,
+            position_history=pos_history,
+            interval_seconds=100,
+            trading_mode="virtual",
+        )
+        await asyncio.sleep(0.05)
+        await treasury.stop_sync()
+
+        assert len(received) == 1
+        assert received[0].external_purchase_amount == 0.0
+        assert received[0].external_eval_amount == 0.0
+
+    async def test_virtual_sync_updates_last_synced(self, treasury):
+        """Virtual 동기화 후 last_synced_at 갱신."""
+        pos_history = FakePositionHistory(positions=[])
+
+        assert treasury.last_synced_at is None
+
+        treasury.start_sync(
+            broker=None,
+            position_history=pos_history,
+            interval_seconds=100,
+            trading_mode="virtual",
+        )
+        await asyncio.sleep(0.05)
+        await treasury.stop_sync()
+
+        assert treasury.last_synced_at is not None


### PR DESCRIPTION
## Summary
- Virtual 모드에서 broker 없이 Trade DB(PositionHistory)의 포지션 데이터로 `ante_eval_amount`, `ante_purchase_amount`, `ante_profit_loss`를 직접 계산
- `start_sync()`에 `trading_mode`와 `price_resolver` 파라미터 추가, Virtual/Live 분기 처리
- `_do_sync_virtual()` 메서드 추가: 포지션 기반 purchase/eval 계산, price_resolver 실패 시 avg_entry_price fallback
- `main.py`의 `_init_treasury_sync()`에서 Account.trading_mode에 따라 자동 분기
- Live 모드 기존 동작 변경 없음 (하위 호환)

## Test plan
- [x] Virtual 모드 포지션 기반 purchase/eval 계산 테스트
- [x] price_resolver 사용 시 시세 반영 테스트
- [x] price_resolver 실패 시 avg_entry_price fallback 테스트
- [x] 빈 포지션 시 0 반환 테스트
- [x] get_summary() ante 필드 정상 반영 테스트
- [x] BalanceSyncedEvent 발행 테스트
- [x] last_synced_at 갱신 테스트
- [x] Live 모드 명시적 지정 시 기존 동작 유지 테스트
- [x] 기존 29개 테스트 전체 통과 (총 29 -> 37개)
- [x] ruff check / ruff format 통과

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)