### PR TITLE
feat(ipc): IPC 인프라 구축 — ServiceRegistry, 프로토콜, IPCServer/Client

### DIFF
--- a/src/ante/core/registry.py
+++ b/src/ante/core/registry.py
@@ -1,0 +1,32 @@
+"""ServiceRegistry — 런타임 서비스 인스턴스를 보관하는 데이터 컨테이너.
+
+IPC 핸들러가 필요한 서비스에 접근할 때 사용한다.
+순환 임포트를 방지하기 위해 타입 힌트는 TYPE_CHECKING 블록에서만 임포트한다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ante.account.service import AccountService
+    from ante.approval.service import ApprovalService
+    from ante.bot.manager import BotManager
+    from ante.config.dynamic import DynamicConfigService
+    from ante.eventbus import EventBus
+    from ante.trade.reconciler import PositionReconciler
+    from ante.treasury.manager import TreasuryManager
+
+
+@dataclass
+class ServiceRegistry:
+    """IPC 핸들러가 참조하는 서비스 레지스트리."""
+
+    account: AccountService | Any
+    bot_manager: BotManager | Any
+    treasury_manager: TreasuryManager | Any
+    dynamic_config: DynamicConfigService | Any
+    approval: ApprovalService | Any
+    reconciler: PositionReconciler | Any
+    eventbus: EventBus | Any

--- a/src/ante/ipc/__init__.py
+++ b/src/ante/ipc/__init__.py
@@ -1,0 +1,16 @@
+"""IPC (Inter-Process Communication) 인프라.
+
+Unix 도메인 소켓 기반의 프로세스 간 통신을 제공한다.
+CLI, MCP 등 외부 프로세스가 실행 중인 Ante 서버에 명령을 보낼 때 사용한다.
+"""
+
+from ante.ipc.client import IPCClient
+from ante.ipc.exceptions import IPCTimeoutError, ServerNotRunningError
+from ante.ipc.server import IPCServer
+
+__all__ = [
+    "IPCClient",
+    "IPCServer",
+    "IPCTimeoutError",
+    "ServerNotRunningError",
+]

--- a/src/ante/ipc/client.py
+++ b/src/ante/ipc/client.py
@@ -1,0 +1,93 @@
+"""IPCClient — Unix 도메인 소켓 IPC 클라이언트.
+
+실행 중인 Ante 서버에 명령을 전송하고 응답을 받는다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from pathlib import Path
+
+from ante.ipc import protocol
+from ante.ipc.exceptions import IPCTimeoutError, ServerNotRunningError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 30.0  # seconds
+
+
+class IPCClient:
+    """Unix 도메인 소켓 IPC 클라이언트."""
+
+    def __init__(
+        self,
+        socket_path: str,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        self._socket_path = socket_path
+        self._timeout = timeout
+
+    async def send(
+        self,
+        command: str,
+        args: dict | None = None,
+        actor: str = "cli",
+    ) -> dict:
+        """커맨드를 서버에 전송하고 응답을 반환.
+
+        Args:
+            command: 실행할 커맨드 이름 (예: "system.halt")
+            args: 커맨드 인자
+            actor: 요청자 식별자
+
+        Returns:
+            서버 응답 dict
+
+        Raises:
+            ServerNotRunningError: 소켓 파일이 없거나 연결 거부
+            IPCTimeoutError: 타임아웃 초과
+        """
+        path = Path(self._socket_path)
+        if not path.exists():
+            raise ServerNotRunningError(
+                f"Ante 서버가 실행 중이지 않습니다 (소켓 없음: {self._socket_path})"
+            )
+
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_unix_connection(self._socket_path),
+                timeout=self._timeout,
+            )
+        except (ConnectionRefusedError, OSError) as e:
+            raise ServerNotRunningError(f"Ante 서버에 연결할 수 없습니다: {e}") from e
+        except TimeoutError as e:
+            raise IPCTimeoutError(f"서버 연결 타임아웃 ({self._timeout}초)") from e
+
+        try:
+            request = {
+                "id": str(uuid.uuid4()),
+                "command": command,
+                "args": args or {},
+                "actor": actor,
+            }
+
+            data = await protocol.encode(request)
+            writer.write(data)
+            await writer.drain()
+
+            response = await asyncio.wait_for(
+                protocol.decode(reader),
+                timeout=self._timeout,
+            )
+
+            return response
+        except TimeoutError as e:
+            raise IPCTimeoutError(f"서버 응답 타임아웃 ({self._timeout}초)") from e
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass

--- a/src/ante/ipc/exceptions.py
+++ b/src/ante/ipc/exceptions.py
@@ -1,0 +1,17 @@
+"""IPC 모듈 예외 클래스."""
+
+
+class IPCError(Exception):
+    """IPC 기본 예외."""
+
+
+class ServerNotRunningError(IPCError):
+    """서버가 실행 중이지 않을 때 (소켓 파일 없음 또는 연결 거부)."""
+
+
+class IPCTimeoutError(IPCError):
+    """요청 타임아웃 초과."""
+
+
+class MessageTooLargeError(IPCError):
+    """메시지 크기가 최대 제한(1MB)을 초과."""

--- a/src/ante/ipc/protocol.py
+++ b/src/ante/ipc/protocol.py
@@ -1,0 +1,39 @@
+"""길이 접두사 프레이밍 프로토콜.
+
+메시지 형식: [4바이트 빅엔디안 길이][JSON 페이로드]
+최대 메시지 크기: 1MB (1_048_576 바이트)
+"""
+
+import asyncio
+import json
+import struct
+
+from ante.ipc.exceptions import MessageTooLargeError
+
+MAX_MESSAGE_SIZE = 1_048_576  # 1MB
+
+
+async def encode(data: dict) -> bytes:
+    """dict를 길이 접두사 + JSON 바이트로 직렬화."""
+    payload = json.dumps(data, ensure_ascii=False).encode("utf-8")
+    if len(payload) > MAX_MESSAGE_SIZE:
+        raise MessageTooLargeError(
+            f"메시지 크기({len(payload)} bytes)가 "
+            f"최대 제한({MAX_MESSAGE_SIZE} bytes)을 초과"
+        )
+    length_prefix = struct.pack("!I", len(payload))
+    return length_prefix + payload
+
+
+async def decode(reader: asyncio.StreamReader) -> dict:
+    """StreamReader에서 길이 접두사 프레이밍 메시지를 읽어 dict로 역직렬화."""
+    raw_length = await reader.readexactly(4)
+    (length,) = struct.unpack("!I", raw_length)
+
+    if length > MAX_MESSAGE_SIZE:
+        raise MessageTooLargeError(
+            f"메시지 크기({length} bytes)가 최대 제한({MAX_MESSAGE_SIZE} bytes)을 초과"
+        )
+
+    payload = await reader.readexactly(length)
+    return json.loads(payload.decode("utf-8"))

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -1,0 +1,199 @@
+"""CommandRegistry — IPC 커맨드 핸들러 등록 및 조회.
+
+각 커맨드 핸들러는 (ServiceRegistry, args: dict, actor: str) -> dict 시그니처를 따른다.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ante.core.registry import ServiceRegistry
+
+CommandHandler = Callable[["ServiceRegistry", dict, str], Awaitable[dict]]
+
+logger = logging.getLogger(__name__)
+
+
+class CommandRegistry:
+    """커맨드 이름 -> 핸들러 매핑."""
+
+    def __init__(self) -> None:
+        self._handlers: dict[str, CommandHandler] = {}
+
+    def register(self, command: str, handler: CommandHandler) -> None:
+        """핸들러 등록."""
+        self._handlers[command] = handler
+
+    def get(self, command: str) -> CommandHandler | None:
+        """핸들러 조회. 미등록이면 None."""
+        return self._handlers.get(command)
+
+    @property
+    def commands(self) -> list[str]:
+        """등록된 커맨드 목록."""
+        return list(self._handlers.keys())
+
+
+# ── 핸들러 구현 ──────────────────────────────────────
+
+
+async def _handle_system_halt(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    reason = args.get("reason", "IPC halt")
+    count = await svc.account.suspend_all(reason=reason, suspended_by=actor)
+    return {"suspended_count": count}
+
+
+async def _handle_system_activate(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    count = await svc.account.activate_all(activated_by=actor)
+    return {"activated_count": count}
+
+
+async def _handle_account_suspend(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    account_id = args["account_id"]
+    reason = args.get("reason", "IPC suspend")
+    await svc.account.suspend(account_id, reason=reason, suspended_by=actor)
+    return {"account_id": account_id, "status": "suspended"}
+
+
+async def _handle_account_activate(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    account_id = args["account_id"]
+    await svc.account.activate(account_id, activated_by=actor)
+    return {"account_id": account_id, "status": "active"}
+
+
+async def _handle_bot_create(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    bot = await svc.bot_manager.create_bot(**args)
+    return {"bot_id": bot.bot_id}
+
+
+async def _handle_bot_remove(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    bot_id = args["bot_id"]
+    await svc.bot_manager.remove_bot(bot_id)
+    return {"bot_id": bot_id, "removed": True}
+
+
+async def _handle_treasury_allocate(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    account_id = args["account_id"]
+    bot_id = args["bot_id"]
+    amount = args["amount"]
+    treasury = svc.treasury_manager.get(account_id)
+    result = await treasury.allocate(bot_id, amount)
+    return {"account_id": account_id, "bot_id": bot_id, "success": result}
+
+
+async def _handle_treasury_deallocate(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    account_id = args["account_id"]
+    bot_id = args["bot_id"]
+    amount = args["amount"]
+    treasury = svc.treasury_manager.get(account_id)
+    result = await treasury.deallocate(bot_id, amount)
+    return {"account_id": account_id, "bot_id": bot_id, "success": result}
+
+
+async def _handle_config_set(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    key = args["key"]
+    value = args["value"]
+    category = args.get("category", "user")
+    await svc.dynamic_config.set(key, value, category=category, changed_by=actor)
+    return {"key": key, "value": value}
+
+
+async def _handle_approval_request(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    request = await svc.approval.create(
+        type=args["type"],
+        requester=actor,
+        title=args["title"],
+        body=args.get("body", ""),
+        params=args.get("params"),
+        reference_id=args.get("reference_id", ""),
+        expires_at=args.get("expires_at", ""),
+    )
+    return {"id": request.id, "status": str(request.status)}
+
+
+async def _handle_approval_approve(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    request = await svc.approval.approve(args["id"], resolved_by=actor)
+    return {"id": request.id, "status": str(request.status)}
+
+
+async def _handle_approval_reject(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    request = await svc.approval.reject(
+        args["id"],
+        resolved_by=actor,
+        reject_reason=args.get("reason", ""),
+    )
+    return {"id": request.id, "status": str(request.status)}
+
+
+async def _handle_approval_cancel(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    request = await svc.approval.cancel(args["id"], requester=actor)
+    return {"id": request.id, "status": str(request.status)}
+
+
+async def _handle_approval_reopen(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    request = await svc.approval.reopen(
+        args["id"],
+        requester=actor,
+        body=args.get("body"),
+        params=args.get("params"),
+    )
+    return {"id": request.id, "status": str(request.status)}
+
+
+async def _handle_broker_reconcile(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    bot_id = args["bot_id"]
+    broker_positions = args.get("broker_positions", [])
+    adjustments = await svc.reconciler.reconcile(bot_id, broker_positions)
+    return {"bot_id": bot_id, "adjustments": adjustments}
+
+
+def register_all_handlers(registry: CommandRegistry) -> None:
+    """15개 런타임 커맨드 핸들러를 일괄 등록."""
+    registry.register("system.halt", _handle_system_halt)
+    registry.register("system.activate", _handle_system_activate)
+    registry.register("account.suspend", _handle_account_suspend)
+    registry.register("account.activate", _handle_account_activate)
+    registry.register("bot.create", _handle_bot_create)
+    registry.register("bot.remove", _handle_bot_remove)
+    registry.register("treasury.allocate", _handle_treasury_allocate)
+    registry.register("treasury.deallocate", _handle_treasury_deallocate)
+    registry.register("config.set", _handle_config_set)
+    registry.register("approval.request", _handle_approval_request)
+    registry.register("approval.approve", _handle_approval_approve)
+    registry.register("approval.reject", _handle_approval_reject)
+    registry.register("approval.cancel", _handle_approval_cancel)
+    registry.register("approval.reopen", _handle_approval_reopen)
+    registry.register("broker.reconcile", _handle_broker_reconcile)

--- a/src/ante/ipc/server.py
+++ b/src/ante/ipc/server.py
@@ -1,0 +1,150 @@
+"""IPCServer — Unix 도메인 소켓 기반 IPC 서버.
+
+asyncio.start_unix_server를 사용하여 외부 프로세스(CLI, MCP)의
+명령을 수신하고 처리한다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ante.ipc import protocol
+from ante.ipc.exceptions import MessageTooLargeError
+
+if TYPE_CHECKING:
+    from ante.core.registry import ServiceRegistry
+    from ante.ipc.registry import CommandRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class IPCServer:
+    """Unix 도메인 소켓 IPC 서버."""
+
+    def __init__(
+        self,
+        socket_path: str,
+        service_registry: ServiceRegistry,
+        command_registry: CommandRegistry,
+    ) -> None:
+        self._socket_path = socket_path
+        self._service_registry = service_registry
+        self._command_registry = command_registry
+        self._server: asyncio.AbstractServer | None = None
+
+    @property
+    def socket_path(self) -> str:
+        return self._socket_path
+
+    async def start(self) -> None:
+        """서버 시작. 기존 소켓 파일이 있으면 삭제 후 재생성."""
+        path = Path(self._socket_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        # 잔존 소켓 파일 정리
+        if path.exists():
+            path.unlink()
+
+        self._server = await asyncio.start_unix_server(
+            self._handle_connection,
+            path=self._socket_path,
+        )
+
+        # 소켓 파일 권한 설정 (소유자만 접근)
+        os.chmod(self._socket_path, 0o600)
+
+        logger.info("IPCServer 시작: %s", self._socket_path)
+
+    async def stop(self) -> None:
+        """서버 종료 및 소켓 파일 삭제."""
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+        path = Path(self._socket_path)
+        if path.exists():
+            path.unlink()
+
+        logger.info("IPCServer 종료: %s", self._socket_path)
+
+    async def _handle_connection(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """클라이언트 연결 처리. 요청을 읽고 응답을 보낸다."""
+        try:
+            while True:
+                try:
+                    request = await protocol.decode(reader)
+                except asyncio.IncompleteReadError:
+                    # 클라이언트 연결 종료
+                    break
+                except MessageTooLargeError as e:
+                    response = {
+                        "id": None,
+                        "status": "error",
+                        "error": {
+                            "code": "MESSAGE_TOO_LARGE",
+                            "message": str(e),
+                        },
+                    }
+                    data = await protocol.encode(response)
+                    writer.write(data)
+                    await writer.drain()
+                    break
+
+                response = await self._dispatch(request)
+                data = await protocol.encode(response)
+                writer.write(data)
+                await writer.drain()
+        except Exception:
+            logger.exception("IPC 연결 처리 중 오류")
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    async def _dispatch(self, request: dict) -> dict:
+        """요청을 적절한 핸들러로 라우팅."""
+        request_id = request.get("id", str(uuid.uuid4()))
+        command = request.get("command", "")
+        args = request.get("args", {})
+        actor = request.get("actor", "ipc")
+
+        handler = self._command_registry.get(command)
+        if handler is None:
+            return {
+                "id": request_id,
+                "status": "error",
+                "error": {
+                    "code": "UNKNOWN_COMMAND",
+                    "message": f"미등록 커맨드: {command}",
+                },
+            }
+
+        try:
+            result = await handler(self._service_registry, args, actor)
+            return {
+                "id": request_id,
+                "status": "ok",
+                "result": result,
+            }
+        except Exception as e:
+            logger.exception("IPC 커맨드 실행 오류: %s", command)
+            return {
+                "id": request_id,
+                "status": "error",
+                "error": {
+                    "code": "EXECUTION_ERROR",
+                    "message": str(e),
+                },
+            }

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -100,6 +100,7 @@ class Services:
     approval_service: Any = None
     notification_service: Any = None
     telegram_receiver: Any = None
+    ipc_server: Any = None
     web_task: asyncio.Task | None = None  # type: ignore[type-arg]
     approval_expire_task: asyncio.Task | None = None  # type: ignore[type-arg]
     audit_cleanup_task: asyncio.Task | None = None  # type: ignore[type-arg]
@@ -978,6 +979,39 @@ async def _init_notification(s: Services) -> None:
         logger.info("TelegramCommandReceiver 건너뜀 — allowed_user_ids 비어있음")
 
 
+async def _init_ipc(s: Services) -> None:
+    """IPC 서버 초기화 — Unix 도메인 소켓 기반 프로세스 간 통신."""
+    from ante.core.registry import ServiceRegistry
+    from ante.ipc.registry import CommandRegistry, register_all_handlers
+    from ante.ipc.server import IPCServer
+    from ante.trade.reconciler import PositionReconciler
+
+    # PositionReconciler 인스턴스 생성
+    reconciler = PositionReconciler(
+        trade_service=s.trade_service,
+        eventbus=s.eventbus,
+    )
+
+    service_registry = ServiceRegistry(
+        account=s.account_service,
+        bot_manager=s.bot_manager,
+        treasury_manager=s.treasury_manager,
+        dynamic_config=s.dynamic_config,
+        approval=s.approval_service,
+        reconciler=reconciler,
+        eventbus=s.eventbus,
+    )
+
+    command_registry = CommandRegistry()
+    register_all_handlers(command_registry)
+
+    db_path = s.config.get("db.path", "db/ante.db")
+    socket_path = str(Path(db_path).parent / "ante.sock")
+    s.ipc_server = IPCServer(socket_path, service_registry, command_registry)
+    await s.ipc_server.start()
+    logger.info("IPC 서버 초기화 완료: %s", socket_path)
+
+
 async def _init_web(s: Services) -> None:
     """FastAPI 앱 생성 및 uvicorn 서버 시작."""
     web_enabled = s.config.get("web.enabled", False)
@@ -1113,6 +1147,10 @@ async def _shutdown(s: Services) -> None:
             pass
         logger.info("Web API 종료")
 
+    if s.ipc_server:
+        await s.ipc_server.stop()
+        logger.info("IPCServer 종료")
+
     if s.daily_report_scheduler:
         await s.daily_report_scheduler.stop()
         logger.info("DailyReportScheduler 종료")
@@ -1178,7 +1216,8 @@ async def main() -> None:
     6. Feed: DataPipeline, Backtest, Report
     7. Approval: ApprovalService
     8. Notification: Telegram(account_service 주입)
-    9. Web: FastAPI(account_service 주입)
+    9. IPC: Unix 도메인 소켓 서버
+    10. Web: FastAPI(account_service 주입)
 
     종료 순서: 역순 (상위 소비자부터 정리)
     """
@@ -1194,6 +1233,7 @@ async def main() -> None:
         await _init_feed(s)
         await _init_approval(s)
         await _init_notification(s)
+        await _init_ipc(s)
         await _init_web(s)
         await _run(s)
     finally:

--- a/tests/unit/ipc/test_protocol.py
+++ b/tests/unit/ipc/test_protocol.py
@@ -1,0 +1,78 @@
+"""프레이밍 프로토콜 테스트."""
+
+import asyncio
+import struct
+
+import pytest
+
+from ante.ipc.exceptions import MessageTooLargeError
+from ante.ipc.protocol import MAX_MESSAGE_SIZE, decode, encode
+
+
+@pytest.mark.asyncio
+async def test_encode_decode_roundtrip() -> None:
+    """encode → decode 라운드트립 검증."""
+    original = {"command": "system.halt", "args": {"reason": "test"}, "id": "abc-123"}
+    encoded = await encode(original)
+
+    # 길이 접두사 확인
+    (length,) = struct.unpack("!I", encoded[:4])
+    assert length == len(encoded) - 4
+
+    # decode
+    reader = asyncio.StreamReader()
+    reader.feed_data(encoded)
+    decoded = await decode(reader)
+    assert decoded == original
+
+
+@pytest.mark.asyncio
+async def test_encode_decode_unicode() -> None:
+    """한글 등 유니코드 메시지 라운드트립."""
+    original = {"message": "한글 테스트 메시지", "value": 42}
+    encoded = await encode(original)
+
+    reader = asyncio.StreamReader()
+    reader.feed_data(encoded)
+    decoded = await decode(reader)
+    assert decoded == original
+
+
+@pytest.mark.asyncio
+async def test_encode_too_large() -> None:
+    """최대 크기 초과 시 MessageTooLargeError."""
+    large_data = {"data": "x" * (MAX_MESSAGE_SIZE + 1)}
+    with pytest.raises(MessageTooLargeError):
+        await encode(large_data)
+
+
+@pytest.mark.asyncio
+async def test_decode_too_large_length_prefix() -> None:
+    """길이 접두사가 최대 크기를 초과하면 MessageTooLargeError."""
+    fake_length = struct.pack("!I", MAX_MESSAGE_SIZE + 1)
+    reader = asyncio.StreamReader()
+    reader.feed_data(fake_length + b"\x00" * 100)
+    with pytest.raises(MessageTooLargeError):
+        await decode(reader)
+
+
+@pytest.mark.asyncio
+async def test_decode_incomplete_read() -> None:
+    """불완전한 데이터 시 IncompleteReadError."""
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"\x00\x00")  # 4바이트 미만
+    reader.feed_eof()
+    with pytest.raises(asyncio.IncompleteReadError):
+        await decode(reader)
+
+
+@pytest.mark.asyncio
+async def test_encode_empty_dict() -> None:
+    """빈 dict 인코딩/디코딩."""
+    original: dict = {}
+    encoded = await encode(original)
+
+    reader = asyncio.StreamReader()
+    reader.feed_data(encoded)
+    decoded = await decode(reader)
+    assert decoded == original

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -1,0 +1,62 @@
+"""CommandRegistry 테스트."""
+
+import pytest
+
+from ante.ipc.registry import CommandRegistry, register_all_handlers
+
+
+@pytest.fixture
+def registry() -> CommandRegistry:
+    return CommandRegistry()
+
+
+def test_register_and_get(registry: CommandRegistry) -> None:
+    """핸들러 등록 후 조회."""
+
+    async def dummy_handler(svc, args, actor):  # type: ignore[no-untyped-def]
+        return {"ok": True}
+
+    registry.register("test.command", dummy_handler)
+    assert registry.get("test.command") is dummy_handler
+
+
+def test_get_unregistered_returns_none(registry: CommandRegistry) -> None:
+    """미등록 커맨드 조회 시 None 반환."""
+    assert registry.get("nonexistent.command") is None
+
+
+def test_commands_property(registry: CommandRegistry) -> None:
+    """commands 프로퍼티가 등록된 커맨드 목록을 반환."""
+
+    async def handler(svc, args, actor):  # type: ignore[no-untyped-def]
+        return {}
+
+    registry.register("a.command", handler)
+    registry.register("b.command", handler)
+    assert set(registry.commands) == {"a.command", "b.command"}
+
+
+def test_register_all_handlers() -> None:
+    """register_all_handlers가 15개 핸들러를 등록."""
+    registry = CommandRegistry()
+    register_all_handlers(registry)
+    assert len(registry.commands) == 15
+
+    expected = {
+        "system.halt",
+        "system.activate",
+        "account.suspend",
+        "account.activate",
+        "bot.create",
+        "bot.remove",
+        "treasury.allocate",
+        "treasury.deallocate",
+        "config.set",
+        "approval.request",
+        "approval.approve",
+        "approval.reject",
+        "approval.cancel",
+        "approval.reopen",
+        "broker.reconcile",
+    }
+    assert set(registry.commands) == expected

--- a/tests/unit/ipc/test_server_client.py
+++ b/tests/unit/ipc/test_server_client.py
@@ -1,0 +1,177 @@
+"""IPCServer + IPCClient 통합 테스트."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from ante.core.registry import ServiceRegistry
+from ante.ipc.client import IPCClient
+from ante.ipc.exceptions import ServerNotRunningError
+from ante.ipc.registry import CommandRegistry
+from ante.ipc.server import IPCServer
+
+
+def _make_service_registry() -> ServiceRegistry:
+    return ServiceRegistry(
+        account=MagicMock(),
+        bot_manager=MagicMock(),
+        treasury_manager=MagicMock(),
+        dynamic_config=MagicMock(),
+        approval=MagicMock(),
+        reconciler=MagicMock(),
+        eventbus=MagicMock(),
+    )
+
+
+@pytest.fixture
+def socket_path() -> str:
+    """Unix 소켓 경로 길이 제한(104바이트)을 위해 /tmp 직접 사용."""
+    td = tempfile.mkdtemp(prefix="ipc", dir="/tmp")
+    return str(Path(td) / "t.sock")
+
+
+@pytest.fixture
+def service_registry() -> ServiceRegistry:
+    return _make_service_registry()
+
+
+@pytest.mark.asyncio
+async def test_roundtrip(socket_path: str, service_registry: ServiceRegistry) -> None:
+    """요청 -> 응답 라운드트립."""
+    cmd_registry = CommandRegistry()
+
+    async def echo_handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {"echo": args, "actor": actor}
+
+    cmd_registry.register("test.echo", echo_handler)
+
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+
+    try:
+        client = IPCClient(socket_path, timeout=5.0)
+        response = await client.send("test.echo", {"msg": "hello"}, actor="tester")
+        assert response["status"] == "ok"
+        assert response["result"]["echo"] == {"msg": "hello"}
+        assert response["result"]["actor"] == "tester"
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_unknown_command(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """미등록 커맨드 에러 응답."""
+    cmd_registry = CommandRegistry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+
+    try:
+        client = IPCClient(socket_path, timeout=5.0)
+        response = await client.send("nonexistent.command")
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "UNKNOWN_COMMAND"
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_handler_exception(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """핸들러 예외 발생 시 에러 응답."""
+    cmd_registry = CommandRegistry()
+
+    async def failing_handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        raise ValueError("의도적 예외")
+
+    cmd_registry.register("test.fail", failing_handler)
+
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+
+    try:
+        client = IPCClient(socket_path, timeout=5.0)
+        response = await client.send("test.fail")
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "EXECUTION_ERROR"
+        assert "의도적 예외" in response["error"]["message"]
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_server_not_running() -> None:
+    """서버 미기동 시 ServerNotRunningError."""
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = str(Path(tmp) / "nonexistent.sock")
+        client = IPCClient(sock, timeout=2.0)
+        with pytest.raises(ServerNotRunningError):
+            await client.send("test.command")
+
+
+@pytest.mark.asyncio
+async def test_socket_permissions(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """소켓 파일 권한이 0o600으로 설정되는지 확인."""
+    cmd_registry = CommandRegistry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+
+    try:
+        import os
+        import stat
+
+        mode = os.stat(socket_path).st_mode
+        file_perm = stat.S_IMODE(mode)
+        assert file_perm == 0o600
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_socket_cleanup_on_stop(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """서버 종료 시 소켓 파일 삭제."""
+    cmd_registry = CommandRegistry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+    assert Path(socket_path).exists()
+
+    await server.stop()
+    assert not Path(socket_path).exists()
+
+
+@pytest.mark.asyncio
+async def test_multiple_requests(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """여러 요청을 순차적으로 처리."""
+    cmd_registry = CommandRegistry()
+    call_count = 0
+
+    async def counter_handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        nonlocal call_count
+        call_count += 1
+        return {"count": call_count}
+
+    cmd_registry.register("test.count", counter_handler)
+
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+
+    try:
+        for i in range(3):
+            client = IPCClient(socket_path, timeout=5.0)
+            response = await client.send("test.count")
+            assert response["status"] == "ok"
+            assert response["result"]["count"] == i + 1
+    finally:
+        await server.stop()

--- a/tests/unit/ipc/test_service_registry.py
+++ b/tests/unit/ipc/test_service_registry.py
@@ -1,0 +1,34 @@
+"""ServiceRegistry 테스트."""
+
+from unittest.mock import MagicMock
+
+from ante.core.registry import ServiceRegistry
+
+
+def test_service_registry_creation() -> None:
+    """ServiceRegistry 데이터클래스 생성 확인."""
+    account = MagicMock()
+    bot_manager = MagicMock()
+    treasury_manager = MagicMock()
+    dynamic_config = MagicMock()
+    approval = MagicMock()
+    reconciler = MagicMock()
+    eventbus = MagicMock()
+
+    reg = ServiceRegistry(
+        account=account,
+        bot_manager=bot_manager,
+        treasury_manager=treasury_manager,
+        dynamic_config=dynamic_config,
+        approval=approval,
+        reconciler=reconciler,
+        eventbus=eventbus,
+    )
+
+    assert reg.account is account
+    assert reg.bot_manager is bot_manager
+    assert reg.treasury_manager is treasury_manager
+    assert reg.dynamic_config is dynamic_config
+    assert reg.approval is approval
+    assert reg.reconciler is reconciler
+    assert reg.eventbus is eventbus


### PR DESCRIPTION
## Summary

- Unix 도메인 소켓 기반 IPC 인프라 구축: CLI/MCP 등 외부 프로세스가 실행 중인 Ante 서버에 명령 전송 가능
- `ServiceRegistry` (서비스 컨테이너), 길이 접두사 프레이밍 프로토콜, `CommandRegistry` (15개 런타임 커맨드), `IPCServer`/`IPCClient` 구현
- `main.py`에 `_init_ipc()` 통합: 서버 기동 시 자동 시작, shutdown 시 정리

## Test plan

- [x] 프레이밍 프로토콜 encode/decode 라운드트립 (유니코드, 빈 메시지, 최대 크기 초과)
- [x] CommandRegistry 등록/조회, 15개 핸들러 일괄 등록 확인
- [x] IPCServer + IPCClient 통합: 라운드트립, 미등록 커맨드 에러, 핸들러 예외 처리
- [x] 소켓 파일 권한(0o600), 종료 시 소켓 파일 삭제
- [x] 서버 미기동 시 `ServerNotRunningError`
- [x] 18개 테스트 전체 통과, ruff format/check 통과

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)