### PR TITLE
refactor(cli): Bot/Treasury 커맨드 IPC 전환 #697

### DIFF
--- a/src/ante/cli/commands/_ipc.py
+++ b/src/ante/cli/commands/_ipc.py
@@ -1,0 +1,54 @@
+"""CLI -> IPC 공통 헬퍼.
+
+서버가 실행 중인 상태에서 CLI 커맨드를 IPC로 전달하기 위한
+유틸리티 함수를 제공한다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from ante.ipc.client import IPCClient
+from ante.ipc.exceptions import IPCTimeoutError, ServerNotRunningError
+
+
+def _get_socket_path() -> str:
+    """Config에서 DB 경로를 읽어 소켓 파일 경로를 반환."""
+    from ante.config import Config
+
+    config = Config.load()
+    db_path = config.get("db.path", "db/ante.db")
+    return str(Path(db_path).parent / "ante.sock")
+
+
+async def ipc_send(command: str, args: dict, actor: str = "cli") -> dict:
+    """IPC 커맨드를 서버에 전송하고 결과를 반환.
+
+    성공 시 result dict를 반환하고,
+    서버 미실행/타임아웃/실행 오류 시 click.ClickException을 발생시킨다.
+
+    Returns:
+        서버 응답의 "result" 필드 (status == "ok"인 경우).
+
+    Raises:
+        click.ClickException: 서버 미실행, 타임아웃, 서버 측 실행 오류 시.
+    """
+    try:
+        client = IPCClient(socket_path=_get_socket_path())
+        response = await client.send(command, args, actor)
+    except ServerNotRunningError:
+        raise click.ClickException(
+            "서버가 실행 중이 아닙니다. 'ante system start'로 시작하세요."
+        )
+    except IPCTimeoutError:
+        raise click.ClickException("서버 응답 시간 초과")
+
+    if response.get("status") == "error":
+        error = response.get("error", {})
+        code = error.get("code", "UNKNOWN")
+        message = error.get("message", "알 수 없는 오류")
+        raise click.ClickException(f"{code}: {message}")
+
+    return response.get("result", {})

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -223,47 +223,29 @@ def bot_create(
     resolved_account_id = account_id
 
     async def _run_create() -> dict:
-        import json
-        from uuid import uuid4
+        from ante.cli.commands._ipc import ipc_send
 
-        db, _, _, _ = await _create_services()
-        try:
-            bid = bot_id or f"bot-{uuid4().hex[:8]}"
-            config_dict: dict = {
-                "bot_id": bid,
-                "name": name,
-                "strategy_id": strategy,
-                "account_id": resolved_account_id,
-                "interval_seconds": interval,
-            }
-            if param_dict:
-                config_dict["params"] = param_dict
-            await db.execute(
-                """INSERT INTO bots
-                   (bot_id, name, strategy_id, account_id, config_json)
-                   VALUES (?, ?, ?, ?, ?)""",
-                (bid, name, strategy, resolved_account_id, json.dumps(config_dict)),
-            )
-
-            await _audit_log(
-                db,
-                member_id=actor,
-                action="bot.create",
-                resource=f"bot:{bid}",
-                detail=f"strategy={strategy}, account={resolved_account_id}",
-            )
-
-            return config_dict
-        finally:
-            await db.close()
+        args: dict = {
+            "name": name,
+            "strategy_id": strategy,
+            "account_id": resolved_account_id,
+            "interval_seconds": interval,
+        }
+        if bot_id:
+            args["bot_id"] = bot_id
+        if param_dict:
+            args["params"] = param_dict
+        return await ipc_send("bot.create", args, actor=actor)
 
     try:
         result = _run(_run_create())
+    except click.ClickException:
+        raise
     except Exception as e:
         fmt.error(str(e))
         return
 
-    fmt.success(f"봇 생성 완료: {result['bot_id']}", result)
+    fmt.success(f"봇 생성 완료: {result.get('bot_id', '')}", result)
 
 
 @bot.command("remove")
@@ -277,37 +259,23 @@ def bot_remove(ctx: click.Context, bot_id: str) -> None:
     fmt = get_formatter(ctx)
     actor = get_member_id(ctx)
 
-    async def _run_remove() -> bool:
-        db, _, _, _ = await _create_services()
-        try:
-            row = await db.fetch_one(
-                "SELECT bot_id FROM bots WHERE bot_id = ? AND status != 'deleted'",
-                (bot_id,),
-            )
-            if not row:
-                return False
-            await db.execute(
-                "UPDATE bots SET status = 'deleted', updated_at = datetime('now')"
-                " WHERE bot_id = ?",
-                (bot_id,),
-            )
+    async def _run_remove() -> dict:
+        from ante.cli.commands._ipc import ipc_send
 
-            await _audit_log(
-                db,
-                member_id=actor,
-                action="bot.delete",
-                resource=f"bot:{bot_id}",
-            )
+        return await ipc_send("bot.remove", {"bot_id": bot_id}, actor=actor)
 
-            return True
-        finally:
-            await db.close()
-
-    if not _run(_run_remove()):
-        fmt.error(f"봇을 찾을 수 없습니다: {bot_id}")
+    try:
+        result = _run(_run_remove())
+    except click.ClickException:
+        raise
+    except Exception as e:
+        fmt.error(str(e))
         return
 
-    fmt.success(f"봇 삭제 완료: {bot_id}")
+    if result.get("removed"):
+        fmt.success(f"봇 삭제 완료: {bot_id}")
+    else:
+        fmt.error(f"봇을 찾을 수 없습니다: {bot_id}")
 
 
 @bot.command("signal-key")

--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -8,6 +8,7 @@ import click
 
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
+from ante.cli.middleware import get_member_id as _get_member_id
 from ante.cli.middleware import require_auth, require_scope
 
 
@@ -84,32 +85,36 @@ def status(ctx: click.Context, account_id: str | None) -> None:
 @treasury.command()
 @click.argument("bot_id")
 @click.argument("amount", type=float)
+@click.option("--account", "account_id", required=True, help="계좌 ID")
 @click.pass_context
 @require_auth
 @require_scope("treasury:admin")
-def allocate(ctx: click.Context, bot_id: str, amount: float) -> None:
+def allocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) -> None:
     """봇에 예산 할당."""
     fmt = get_formatter(ctx)
+    actor = _get_member_id(ctx)
 
-    from ante.treasury.exceptions import BotNotStoppedError
+    async def _run_allocate() -> dict:
+        from ante.cli.commands._ipc import ipc_send
 
-    async def _run_allocate() -> bool:
-        t, db = await _create_treasury()
-        try:
-            return await t.allocate(bot_id, amount)
-        finally:
-            await db.close()
+        return await ipc_send(
+            "treasury.allocate",
+            {"account_id": account_id, "bot_id": bot_id, "amount": amount},
+            actor=actor,
+        )
 
     try:
-        success = _run(_run_allocate())
-    except BotNotStoppedError as e:
+        result = _run(_run_allocate())
+    except click.ClickException:
+        raise
+    except Exception as e:
         fmt.error(str(e))
         return
 
-    if success:
+    if result.get("success"):
         fmt.success(
-            f"예산 할당 완료: {bot_id} ← {amount:,.0f}원",
-            {"bot_id": bot_id, "amount": amount},
+            f"예산 할당 완료: {bot_id} <- {amount:,.0f}원",
+            {"bot_id": bot_id, "amount": amount, "account_id": account_id},
         )
     else:
         fmt.error(
@@ -120,32 +125,36 @@ def allocate(ctx: click.Context, bot_id: str, amount: float) -> None:
 @treasury.command()
 @click.argument("bot_id")
 @click.argument("amount", type=float)
+@click.option("--account", "account_id", required=True, help="계좌 ID")
 @click.pass_context
 @require_auth
 @require_scope("treasury:admin")
-def deallocate(ctx: click.Context, bot_id: str, amount: float) -> None:
+def deallocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) -> None:
     """봇 예산 회수."""
     fmt = get_formatter(ctx)
+    actor = _get_member_id(ctx)
 
-    from ante.treasury.exceptions import BotNotStoppedError
+    async def _run_deallocate() -> dict:
+        from ante.cli.commands._ipc import ipc_send
 
-    async def _run_deallocate() -> bool:
-        t, db = await _create_treasury()
-        try:
-            return await t.deallocate(bot_id, amount)
-        finally:
-            await db.close()
+        return await ipc_send(
+            "treasury.deallocate",
+            {"account_id": account_id, "bot_id": bot_id, "amount": amount},
+            actor=actor,
+        )
 
     try:
-        success = _run(_run_deallocate())
-    except BotNotStoppedError as e:
+        result = _run(_run_deallocate())
+    except click.ClickException:
+        raise
+    except Exception as e:
         fmt.error(str(e))
         return
 
-    if success:
+    if result.get("success"):
         fmt.success(
-            f"예산 회수 완료: {bot_id} → {amount:,.0f}원",
-            {"bot_id": bot_id, "amount": amount},
+            f"예산 회수 완료: {bot_id} -> {amount:,.0f}원",
+            {"bot_id": bot_id, "amount": amount, "account_id": account_id},
         )
     else:
         fmt.error(f"예산 회수 실패: 가용 예산 부족 (요청: {amount:,.0f}원)")

--- a/tests/unit/test_bot_create_params.py
+++ b/tests/unit/test_bot_create_params.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -77,12 +77,20 @@ class TestParseParam:
 
 class TestBotCreateWithParams:
     def test_create_with_params(self, runner):
-        with patch("ante.cli.commands.bot._create_services") as mock_svc:
-            mock_db = AsyncMock()
-            mock_db.execute = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot_id": "bot-abc123"},
+        }
 
+        with (
+            patch(
+                "ante.cli.commands._ipc._get_socket_path",
+                return_value="/tmp/test.sock",
+            ),
+            patch("ante.cli.commands._ipc.IPCClient", return_value=mock_client),
+        ):
             result = runner.invoke(
                 cli,
                 [
@@ -103,26 +111,26 @@ class TestBotCreateWithParams:
             assert result.exit_code == 0
             assert "생성 완료" in result.output
 
-            # DB에 저장된 config_json에 params 포함 확인
-            # INSERT INTO bots 호출을 찾기 (audit 로그 호출과 구분)
-            bot_insert = [
-                c
-                for c in mock_db.execute.call_args_list
-                if "INSERT INTO bots" in str(c[0][0])
-            ]
-            assert len(bot_insert) == 1
-            config_json = bot_insert[0][0][1][4]
-            config = json.loads(config_json)
-            assert config["params"]["lookback"] == 20
-            assert config["params"]["threshold"] == 0.5
+            # IPC로 전달된 args에 params 포함 확인
+            sent_args = mock_client.send.call_args[0][1]
+            assert sent_args["params"]["lookback"] == 20
+            assert sent_args["params"]["threshold"] == 0.5
 
     def test_create_without_params(self, runner):
-        with patch("ante.cli.commands.bot._create_services") as mock_svc:
-            mock_db = AsyncMock()
-            mock_db.execute = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot_id": "bot-abc123"},
+        }
 
+        with (
+            patch(
+                "ante.cli.commands._ipc._get_socket_path",
+                return_value="/tmp/test.sock",
+            ),
+            patch("ante.cli.commands._ipc.IPCClient", return_value=mock_client),
+        ):
             result = runner.invoke(
                 cli,
                 [
@@ -139,15 +147,8 @@ class TestBotCreateWithParams:
             assert result.exit_code == 0
 
             # params 키가 없어야 함
-            bot_insert = [
-                c
-                for c in mock_db.execute.call_args_list
-                if "INSERT INTO bots" in str(c[0][0])
-            ]
-            assert len(bot_insert) == 1
-            config_json = bot_insert[0][0][1][4]
-            config = json.loads(config_json)
-            assert "params" not in config
+            sent_args = mock_client.send.call_args[0][1]
+            assert "params" not in sent_args
 
     def test_create_invalid_param_format(self, runner):
         result = runner.invoke(
@@ -166,12 +167,20 @@ class TestBotCreateWithParams:
         assert "잘못된 파라미터 형식" in result.output
 
     def test_create_with_json_output(self, runner):
-        with patch("ante.cli.commands.bot._create_services") as mock_svc:
-            mock_db = AsyncMock()
-            mock_db.execute = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot_id": "bot-abc123", "params": {"window": 30}},
+        }
 
+        with (
+            patch(
+                "ante.cli.commands._ipc._get_socket_path",
+                return_value="/tmp/test.sock",
+            ),
+            patch("ante.cli.commands._ipc.IPCClient", return_value=mock_client),
+        ):
             result = runner.invoke(
                 cli,
                 [

--- a/tests/unit/test_cli_account_integration.py
+++ b/tests/unit/test_cli_account_integration.py
@@ -186,16 +186,20 @@ class TestBotListAccountFilter:
 class TestBotCreateAccountOption:
     def test_bot_create_with_account_option(self, runner):
         """--account 옵션으로 계좌 지정."""
-        mock_db = _make_mock_db()
-        mock_account_svc = _make_mock_account_service()
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot_id": "bot-abc123"},
+        }
 
-        with patch("ante.cli.commands.bot._create_services") as mock_cs:
-            mock_cs.return_value = (
-                mock_db,
-                MagicMock(),
-                MagicMock(),
-                mock_account_svc,
-            )
+        with (
+            patch(
+                "ante.cli.commands._ipc._get_socket_path",
+                return_value="/tmp/test.sock",
+            ),
+            patch("ante.cli.commands._ipc.IPCClient", return_value=mock_client),
+        ):
             result = runner.invoke(
                 cli,
                 [
@@ -212,19 +216,30 @@ class TestBotCreateAccountOption:
 
         assert result.exit_code == 0
         assert "봇 생성 완료" in result.output
-        # 첫 번째 execute 호출이 INSERT (audit_log 이전)
-        insert_call = mock_db.execute.call_args_list[0]
-        insert_args = insert_call[0][1]
-        assert insert_args[3] == "domestic"
+        # IPC로 전달된 account_id 확인
+        sent_args = mock_client.send.call_args[0][1]
+        assert sent_args["account_id"] == "domestic"
 
     def test_bot_create_interactive_single_account(self, runner):
         """계좌 미지정 + 활성 계좌 1개 → 자동 선택."""
-        mock_db = _make_mock_db()
         mock_account_svc = _make_mock_account_service([_MOCK_ACCOUNT_1])
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot_id": "bot-abc123"},
+        }
 
-        with patch("ante.cli.commands.bot._create_services") as mock_cs:
+        with (
+            patch("ante.cli.commands.bot._create_services") as mock_cs,
+            patch(
+                "ante.cli.commands._ipc._get_socket_path",
+                return_value="/tmp/test.sock",
+            ),
+            patch("ante.cli.commands._ipc.IPCClient", return_value=mock_client),
+        ):
             mock_cs.return_value = (
-                mock_db,
+                _make_mock_db(),
                 MagicMock(),
                 MagicMock(),
                 mock_account_svc,
@@ -240,14 +255,26 @@ class TestBotCreateAccountOption:
 
     def test_bot_create_interactive_multiple_accounts(self, runner):
         """계좌 미지정 + 활성 계좌 여러 개 → 대화형 선택."""
-        mock_db = _make_mock_db()
         mock_account_svc = _make_mock_account_service(
             [_MOCK_ACCOUNT_1, _MOCK_ACCOUNT_2]
         )
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot_id": "bot-abc123"},
+        }
 
-        with patch("ante.cli.commands.bot._create_services") as mock_cs:
+        with (
+            patch("ante.cli.commands.bot._create_services") as mock_cs,
+            patch(
+                "ante.cli.commands._ipc._get_socket_path",
+                return_value="/tmp/test.sock",
+            ),
+            patch("ante.cli.commands._ipc.IPCClient", return_value=mock_client),
+        ):
             mock_cs.return_value = (
-                mock_db,
+                _make_mock_db(),
                 MagicMock(),
                 MagicMock(),
                 mock_account_svc,

--- a/tests/unit/test_cli_bot_treasury_ipc.py
+++ b/tests/unit/test_cli_bot_treasury_ipc.py
@@ -1,0 +1,456 @@
+"""Bot/Treasury CLI 커맨드 IPC 전환 테스트.
+
+bot create, bot remove, treasury allocate, treasury deallocate 커맨드가
+IPCClient를 통해 서버에 전달되는지 검증한다.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import click
+import pytest
+
+from ante.cli.commands._ipc import ipc_send
+from ante.ipc.exceptions import IPCTimeoutError, ServerNotRunningError
+
+# ── ipc_send 헬퍼 테스트 ──────────────────────────────
+
+
+class TestIpcSend:
+    """ipc_send 공통 헬퍼 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_success(self) -> None:
+        """정상 응답 시 result를 반환한다."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "abc",
+            "status": "ok",
+            "result": {"bot_id": "bot-1"},
+        }
+
+        with (
+            patch(
+                "ante.cli.commands._ipc._get_socket_path", return_value="/tmp/test.sock"
+            ),
+            patch("ante.cli.commands._ipc.IPCClient", return_value=mock_client),
+        ):
+            result = await ipc_send("bot.create", {"name": "test"}, actor="user1")
+
+        assert result == {"bot_id": "bot-1"}
+        mock_client.send.assert_awaited_once_with(
+            "bot.create", {"name": "test"}, "user1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_server_not_running(self) -> None:
+        """ServerNotRunningError -> ClickException."""
+        mock_client = AsyncMock()
+        mock_client.send.side_effect = ServerNotRunningError("no server")
+
+        with (
+            patch(
+                "ante.cli.commands._ipc._get_socket_path", return_value="/tmp/test.sock"
+            ),
+            patch("ante.cli.commands._ipc.IPCClient", return_value=mock_client),
+        ):
+            with pytest.raises(click.ClickException, match="서버가 실행 중이 아닙니다"):
+                await ipc_send("bot.create", {})
+
+    @pytest.mark.asyncio
+    async def test_timeout(self) -> None:
+        """IPCTimeoutError -> ClickException."""
+        mock_client = AsyncMock()
+        mock_client.send.side_effect = IPCTimeoutError("timeout")
+
+        with (
+            patch(
+                "ante.cli.commands._ipc._get_socket_path", return_value="/tmp/test.sock"
+            ),
+            patch("ante.cli.commands._ipc.IPCClient", return_value=mock_client),
+        ):
+            with pytest.raises(click.ClickException, match="서버 응답 시간 초과"):
+                await ipc_send("bot.create", {})
+
+    @pytest.mark.asyncio
+    async def test_server_error_response(self) -> None:
+        """서버가 error 응답을 보내면 ClickException."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "abc",
+            "status": "error",
+            "error": {"code": "EXECUTION_ERROR", "message": "봇을 찾을 수 없습니다"},
+        }
+
+        with (
+            patch(
+                "ante.cli.commands._ipc._get_socket_path", return_value="/tmp/test.sock"
+            ),
+            patch("ante.cli.commands._ipc.IPCClient", return_value=mock_client),
+        ):
+            with pytest.raises(click.ClickException, match="EXECUTION_ERROR"):
+                await ipc_send("bot.remove", {"bot_id": "x"})
+
+
+# ── Bot CLI IPC 테스트 ──────────────────────────────
+
+
+def _make_member():
+    """테스트용 Member mock 객체."""
+    member = MagicMock()
+    member.member_id = "test-user"
+    member.type = MagicMock()
+    member.type.value = "human"
+    # MemberType.HUMAN 비교를 위해
+    from ante.member.models import MemberType
+
+    member.type = MemberType.HUMAN
+    return member
+
+
+def _mock_authenticate(ctx):
+    """테스트용 인증 우회 — Member를 ctx.obj에 직접 주입."""
+    ctx.obj["member"] = _make_member()
+
+
+def _invoke_cli(args: list[str], input_text: str | None = None):
+    """CLI를 실행하고 결과를 반환한다 (인증 우회)."""
+    from click.testing import CliRunner
+
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    with patch("ante.cli.main.authenticate_member", side_effect=_mock_authenticate):
+        result = runner.invoke(
+            cli,
+            args,
+            obj={"member": _make_member()},
+            env={"ANTE_MEMBER_TOKEN": ""},
+            input=input_text,
+            catch_exceptions=False,
+        )
+    return result
+
+
+class TestBotCreateIpc:
+    """bot create 커맨드가 IPC를 통해 서버에 전달되는지 검증."""
+
+    @patch("ante.cli.commands.bot._create_services")
+    @patch("ante.cli.commands._ipc._get_socket_path", return_value="/tmp/test.sock")
+    @patch("ante.cli.commands._ipc.IPCClient")
+    def test_bot_create_ipc(self, mock_ipc_cls, mock_socket, mock_services) -> None:
+        """bot create가 bot.create IPC 커맨드를 전송한다."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot_id": "bot-abc123"},
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        # _create_services는 계좌 대화형 선택 시에만 호출됨
+        # --account 지정 시 호출되지 않음
+
+        result = _invoke_cli(
+            [
+                "bot",
+                "create",
+                "--name",
+                "테스트봇",
+                "--strategy",
+                "strat-1",
+                "--account",
+                "acc-1",
+                "--interval",
+                "120",
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert "봇 생성 완료" in result.output
+
+        # IPC send 호출 확인
+        mock_client.send.assert_awaited_once()
+        call_args = mock_client.send.call_args
+        assert call_args[0][0] == "bot.create"
+        sent_args = call_args[0][1]
+        assert sent_args["name"] == "테스트봇"
+        assert sent_args["strategy_id"] == "strat-1"
+        assert sent_args["account_id"] == "acc-1"
+        assert sent_args["interval_seconds"] == 120
+
+    @patch("ante.cli.commands._ipc._get_socket_path", return_value="/tmp/test.sock")
+    @patch("ante.cli.commands._ipc.IPCClient")
+    def test_bot_create_with_params(self, mock_ipc_cls, mock_socket) -> None:
+        """--param 옵션이 IPC args에 포함된다."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot_id": "bot-abc123"},
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(
+            [
+                "bot",
+                "create",
+                "--name",
+                "테스트봇",
+                "--strategy",
+                "strat-1",
+                "--account",
+                "acc-1",
+                "--param",
+                "threshold=0.5",
+                "--param",
+                "window=20",
+            ]
+        )
+
+        assert result.exit_code == 0
+        sent_args = mock_client.send.call_args[0][1]
+        assert sent_args["params"] == {"threshold": 0.5, "window": 20}
+
+
+class TestBotRemoveIpc:
+    """bot remove 커맨드가 IPC를 통해 서버에 전달되는지 검증."""
+
+    @patch("ante.cli.commands._ipc._get_socket_path", return_value="/tmp/test.sock")
+    @patch("ante.cli.commands._ipc.IPCClient")
+    def test_bot_remove_ipc(self, mock_ipc_cls, mock_socket) -> None:
+        """bot remove가 bot.remove IPC 커맨드를 전송한다."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot_id": "bot-abc", "removed": True},
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(["bot", "remove", "bot-abc", "--yes"])
+
+        assert result.exit_code == 0
+        assert "봇 삭제 완료" in result.output
+
+        mock_client.send.assert_awaited_once()
+        call_args = mock_client.send.call_args
+        assert call_args[0][0] == "bot.remove"
+        assert call_args[0][1] == {"bot_id": "bot-abc"}
+
+    @patch("ante.cli.commands._ipc._get_socket_path", return_value="/tmp/test.sock")
+    @patch("ante.cli.commands._ipc.IPCClient")
+    def test_bot_remove_server_error(self, mock_ipc_cls, mock_socket) -> None:
+        """서버 에러 시 사용자에게 에러 메시지를 출력한다."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "error",
+            "error": {"code": "EXECUTION_ERROR", "message": "Bot not found"},
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(["bot", "remove", "bot-xxx", "--yes"])
+        assert result.exit_code != 0
+        assert "EXECUTION_ERROR" in result.output
+
+
+# ── Treasury CLI IPC 테스트 ──────────────────────────────
+
+
+class TestTreasuryAllocateIpc:
+    """treasury allocate 커맨드가 IPC를 통해 서버에 전달되는지 검증."""
+
+    @patch("ante.cli.commands._ipc._get_socket_path", return_value="/tmp/test.sock")
+    @patch("ante.cli.commands._ipc.IPCClient")
+    def test_treasury_allocate_ipc(self, mock_ipc_cls, mock_socket) -> None:
+        """treasury allocate가 treasury.allocate IPC 커맨드를 전송한다."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {
+                "account_id": "acc-1",
+                "bot_id": "bot-1",
+                "success": True,
+            },
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(
+            [
+                "treasury",
+                "allocate",
+                "bot-1",
+                "100000",
+                "--account",
+                "acc-1",
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert "예산 할당 완료" in result.output
+
+        mock_client.send.assert_awaited_once()
+        call_args = mock_client.send.call_args
+        assert call_args[0][0] == "treasury.allocate"
+        sent_args = call_args[0][1]
+        assert sent_args["account_id"] == "acc-1"
+        assert sent_args["bot_id"] == "bot-1"
+        assert sent_args["amount"] == 100000.0
+
+    @patch("ante.cli.commands._ipc._get_socket_path", return_value="/tmp/test.sock")
+    @patch("ante.cli.commands._ipc.IPCClient")
+    def test_treasury_allocate_failure(self, mock_ipc_cls, mock_socket) -> None:
+        """할당 실패 시(success=False) 에러 메시지를 출력한다."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {
+                "account_id": "acc-1",
+                "bot_id": "bot-1",
+                "success": False,
+            },
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(
+            [
+                "treasury",
+                "allocate",
+                "bot-1",
+                "999999999",
+                "--account",
+                "acc-1",
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert "예산 할당 실패" in result.output
+
+
+class TestTreasuryDeallocateIpc:
+    """treasury deallocate 커맨드가 IPC를 통해 서버에 전달되는지 검증."""
+
+    @patch("ante.cli.commands._ipc._get_socket_path", return_value="/tmp/test.sock")
+    @patch("ante.cli.commands._ipc.IPCClient")
+    def test_treasury_deallocate_ipc(self, mock_ipc_cls, mock_socket) -> None:
+        """treasury deallocate가 treasury.deallocate IPC 커맨드를 전송한다."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {
+                "account_id": "acc-1",
+                "bot_id": "bot-1",
+                "success": True,
+            },
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(
+            [
+                "treasury",
+                "deallocate",
+                "bot-1",
+                "50000",
+                "--account",
+                "acc-1",
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert "예산 회수 완료" in result.output
+
+        mock_client.send.assert_awaited_once()
+        call_args = mock_client.send.call_args
+        assert call_args[0][0] == "treasury.deallocate"
+        sent_args = call_args[0][1]
+        assert sent_args["account_id"] == "acc-1"
+        assert sent_args["bot_id"] == "bot-1"
+        assert sent_args["amount"] == 50000.0
+
+    @patch("ante.cli.commands._ipc._get_socket_path", return_value="/tmp/test.sock")
+    @patch("ante.cli.commands._ipc.IPCClient")
+    def test_treasury_deallocate_failure(self, mock_ipc_cls, mock_socket) -> None:
+        """회수 실패 시(success=False) 에러 메시지를 출력한다."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {
+                "account_id": "acc-1",
+                "bot_id": "bot-1",
+                "success": False,
+            },
+        }
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(
+            [
+                "treasury",
+                "deallocate",
+                "bot-1",
+                "999999999",
+                "--account",
+                "acc-1",
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert "예산 회수 실패" in result.output
+
+
+# ── 서버 미실행 테스트 ──────────────────────────────
+
+
+class TestServerNotRunning:
+    """서버 미실행 시 사용자 친화적 메시지 테스트."""
+
+    @patch("ante.cli.commands._ipc._get_socket_path", return_value="/tmp/test.sock")
+    @patch("ante.cli.commands._ipc.IPCClient")
+    def test_bot_create_server_not_running(self, mock_ipc_cls, mock_socket) -> None:
+        """서버 미실행 시 사용자 친화적 에러 메시지를 출력한다."""
+        mock_client = AsyncMock()
+        mock_client.send.side_effect = ServerNotRunningError("no server")
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(
+            [
+                "bot",
+                "create",
+                "--name",
+                "test",
+                "--strategy",
+                "s1",
+                "--account",
+                "acc-1",
+            ]
+        )
+        assert result.exit_code != 0
+        assert "서버가 실행 중이 아닙니다" in result.output
+
+    @patch("ante.cli.commands._ipc._get_socket_path", return_value="/tmp/test.sock")
+    @patch("ante.cli.commands._ipc.IPCClient")
+    def test_treasury_allocate_server_not_running(
+        self, mock_ipc_cls, mock_socket
+    ) -> None:
+        """서버 미실행 시 사용자 친화적 에러 메시지를 출력한다."""
+        mock_client = AsyncMock()
+        mock_client.send.side_effect = ServerNotRunningError("no server")
+        mock_ipc_cls.return_value = mock_client
+
+        result = _invoke_cli(
+            [
+                "treasury",
+                "allocate",
+                "bot-1",
+                "100000",
+                "--account",
+                "acc-1",
+            ]
+        )
+        assert result.exit_code != 0
+        assert "서버가 실행 중이 아닙니다" in result.output

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -199,12 +199,20 @@ class TestBotCommands:
             assert "bot-1" in result.output
 
     def test_bot_create(self, runner):
-        with patch("ante.cli.commands.bot._create_services") as mock_svc:
-            mock_db = AsyncMock()
-            mock_db.execute = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"bot_id": "bot-abc123"},
+        }
 
+        with (
+            patch(
+                "ante.cli.commands._ipc._get_socket_path",
+                return_value="/tmp/test.sock",
+            ),
+            patch("ante.cli.commands._ipc.IPCClient", return_value=mock_client),
+        ):
             result = runner.invoke(
                 cli,
                 [
@@ -342,38 +350,67 @@ class TestTreasuryCommands:
             assert data["account_balance"] == 10000000.0
 
     def test_treasury_allocate_success(self, runner):
-        with patch("ante.cli.commands.treasury._create_treasury") as mock_svc:
-            mock_treasury = AsyncMock()
-            mock_treasury.allocate = AsyncMock(return_value=True)
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_treasury, mock_db)
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"account_id": "acc-1", "bot_id": "bot-1", "success": True},
+        }
 
-            result = runner.invoke(cli, ["treasury", "allocate", "bot-1", "1000000"])
+        with (
+            patch(
+                "ante.cli.commands._ipc._get_socket_path",
+                return_value="/tmp/test.sock",
+            ),
+            patch("ante.cli.commands._ipc.IPCClient", return_value=mock_client),
+        ):
+            result = runner.invoke(
+                cli, ["treasury", "allocate", "bot-1", "1000000", "--account", "acc-1"]
+            )
             assert result.exit_code == 0
             assert "할당 완료" in result.output
 
     def test_treasury_allocate_fail(self, runner):
-        with patch("ante.cli.commands.treasury._create_treasury") as mock_svc:
-            mock_treasury = AsyncMock()
-            mock_treasury.allocate = AsyncMock(return_value=False)
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_treasury, mock_db)
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"account_id": "acc-1", "bot_id": "bot-1", "success": False},
+        }
 
-            result = runner.invoke(cli, ["treasury", "allocate", "bot-1", "999999999"])
+        with (
+            patch(
+                "ante.cli.commands._ipc._get_socket_path",
+                return_value="/tmp/test.sock",
+            ),
+            patch("ante.cli.commands._ipc.IPCClient", return_value=mock_client),
+        ):
+            result = runner.invoke(
+                cli,
+                ["treasury", "allocate", "bot-1", "999999999", "--account", "acc-1"],
+            )
             assert result.exit_code == 0
             assert "실패" in result.output
 
     def test_treasury_deallocate_success(self, runner):
-        with patch("ante.cli.commands.treasury._create_treasury") as mock_svc:
-            mock_treasury = AsyncMock()
-            mock_treasury.deallocate = AsyncMock(return_value=True)
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
-            mock_svc.return_value = (mock_treasury, mock_db)
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "req-1",
+            "status": "ok",
+            "result": {"account_id": "acc-1", "bot_id": "bot-1", "success": True},
+        }
 
-            result = runner.invoke(cli, ["treasury", "deallocate", "bot-1", "500000"])
+        with (
+            patch(
+                "ante.cli.commands._ipc._get_socket_path",
+                return_value="/tmp/test.sock",
+            ),
+            patch("ante.cli.commands._ipc.IPCClient", return_value=mock_client),
+        ):
+            result = runner.invoke(
+                cli,
+                ["treasury", "deallocate", "bot-1", "500000", "--account", "acc-1"],
+            )
             assert result.exit_code == 0
             assert "회수 완료" in result.output
 


### PR DESCRIPTION
## Summary
- `bot create`, `bot remove`, `treasury allocate`, `treasury deallocate` CLI 커맨드를 직접 DB/서비스 생성 방식에서 IPCClient 기반 서버 전달 방식으로 전환
- 공통 IPC 헬퍼 모듈(`_ipc.py`)을 추가하여 소켓 경로 해석, 에러 핸들링을 일원화
- `treasury allocate/deallocate`에 `--account` 필수 옵션 추가 (IPC 핸들러가 account_id를 요구)
- 서버 미실행, 타임아웃, 실행 오류 시 사용자 친화적 에러 메시지 출력

## Test plan
- [x] `test_bot_create_ipc` — IPCClient.send mock으로 "bot.create" 호출 확인
- [x] `test_bot_remove_ipc` — IPCClient.send mock으로 "bot.remove" 호출 확인
- [x] `test_treasury_allocate_ipc` — IPCClient.send mock으로 "treasury.allocate" 호출 확인
- [x] `test_treasury_deallocate_ipc` — IPCClient.send mock으로 "treasury.deallocate" 호출 확인
- [x] `test_server_not_running` — ServerNotRunningError 시 사용자 친화적 메시지
- [x] 기존 bot/treasury CLI 테스트 443개 통과
- [x] 전체 단위 테스트 2464개 통과 (pre-existing failures 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)