### PR TITLE
fix(cli): config set JSON 출력에 status 필드 복원

### DIFF
--- a/src/ante/cli/commands/config.py
+++ b/src/ante/cli/commands/config.py
@@ -148,7 +148,8 @@ def config_set(ctx: click.Context, key: str, value: str) -> None:
         return
 
     if fmt.is_json:
-        fmt.output(result)
+        output = {"status": "success", **result}
+        fmt.output(output)
     else:
         fmt.success(
             f"설정 변경 완료: {result.get('key', key)} = {result.get('value', value)}",

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -178,7 +178,7 @@ class TestConfigSet:
             {
                 "id": "r1",
                 "status": "ok",
-                "result": {"success": True, "key": "custom.flag", "value": True},
+                "result": {"key": "custom.flag", "value": True},
             }
         )
         with ipc_cls, socket:
@@ -188,6 +188,7 @@ class TestConfigSet:
             )
             assert result.exit_code == 0
             data = json.loads(result.output)
-            assert data["success"] is True
+            assert data["status"] == "success"
+            assert "success" in result.output
             assert data["key"] == "custom.flag"
             assert data["value"] is True


### PR DESCRIPTION
## Summary
- `config set --format json` 출력에 `"status": "success"` 필드가 누락된 버그 수정
- #698 IPC 전환 시 CLI 출력 형식이 변경되어 TC와 불일치한 문제 복원
- 테스트를 실제 IPC 응답 구조에 맞게 업데이트

Closes #705

## Test plan
- [x] `tests/unit/test_cli_config.py` 9개 테스트 전체 통과 확인
- [x] `test_set_json_format`: JSON 출력에 `"status": "success"` 포함 검증
- [x] `ruff format` / `ruff check` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)