### PR TITLE
fix(rule): DailyLossLimitRule 손실률 분모를 전일 총 자산으로 수정 #708

### DIFF
--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -248,6 +248,7 @@ async def _init_trading(s: Services) -> None:
     s.rule_engine_manager = RuleEngineManager(
         eventbus=s.eventbus,
         account_service=s.account_service,
+        treasury_manager=s.treasury_manager,
     )
     await s.rule_engine_manager.initialize_all(accounts, config=s.config)
     logger.info("RuleEngineManager 초기화 완료: %d개 계좌", len(accounts))

--- a/src/ante/rule/base.py
+++ b/src/ante/rule/base.py
@@ -66,6 +66,7 @@ class RuleContext:
     account_status: str = "active"
     daily_pnl: float = 0.0
     total_pnl: float = 0.0
+    prev_day_total_asset: float = 0.0
 
     # 추가 메타데이터
     metadata: dict[str, Any] = field(default_factory=dict)

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -28,6 +28,7 @@ from ante.rule.strategy_rules import (
 if TYPE_CHECKING:
     from ante.account.service import AccountService
     from ante.eventbus.bus import EventBus
+    from ante.treasury.treasury import Treasury
 
 logger = logging.getLogger(__name__)
 
@@ -57,11 +58,13 @@ class RuleEngine:
         account_id: str = "default",
         account_service: AccountService | None = None,
         bot_strategy_resolver: Callable[[str], str | None] | None = None,
+        treasury: Treasury | None = None,
     ) -> None:
         self._eventbus = eventbus
         self._account_id = account_id
         self._account_service = account_service
         self._bot_strategy_resolver = bot_strategy_resolver
+        self._treasury = treasury
 
         self._account_rules: list[Rule] = []
         self._strategy_rules: dict[str, list[Rule]] = {}
@@ -293,6 +296,25 @@ class RuleEngine:
                     "계좌 상태 조회 실패: %s — 기본값 사용", self._account_id
                 )
 
+        # Treasury 데이터 조회
+        total_pnl = 0.0
+        prev_day_total_asset = 0.0
+        if self._treasury is not None:
+            try:
+                summary = self._treasury.get_summary()
+                total_pnl = summary.get("total_profit_loss", 0.0)
+            except Exception:
+                logger.warning("Treasury summary 조회 실패: %s", self._account_id)
+            try:
+                from datetime import date, timedelta
+
+                yesterday = (date.today() - timedelta(days=1)).isoformat()
+                snapshot = await self._treasury.get_daily_snapshot(yesterday)
+                if snapshot is not None:
+                    prev_day_total_asset = snapshot.get("total_asset", 0.0)
+            except Exception:
+                logger.warning("Treasury 전일 스냅샷 조회 실패: %s", self._account_id)
+
         context = RuleContext(
             bot_id=event.bot_id,
             account_id=self._account_id,
@@ -305,6 +327,8 @@ class RuleEngine:
             current_price=event.price or 0.0,
             account_status=account_status,
             currency=currency,
+            total_pnl=total_pnl,
+            prev_day_total_asset=prev_day_total_asset,
         )
 
         try:
@@ -438,6 +462,25 @@ class RuleEngine:
                     "계좌 상태 조회 실패: %s — 기본값 사용", self._account_id
                 )
 
+        # Treasury 데이터 조회
+        total_pnl = 0.0
+        prev_day_total_asset = 0.0
+        if self._treasury is not None:
+            try:
+                summary = self._treasury.get_summary()
+                total_pnl = summary.get("total_profit_loss", 0.0)
+            except Exception:
+                logger.warning("Treasury summary 조회 실패: %s", self._account_id)
+            try:
+                from datetime import date, timedelta
+
+                yesterday = (date.today() - timedelta(days=1)).isoformat()
+                snapshot = await self._treasury.get_daily_snapshot(yesterday)
+                if snapshot is not None:
+                    prev_day_total_asset = snapshot.get("total_asset", 0.0)
+            except Exception:
+                logger.warning("Treasury 전일 스냅샷 조회 실패: %s", self._account_id)
+
         context = RuleContext(
             bot_id=event.bot_id,
             account_id=self._account_id,
@@ -450,6 +493,8 @@ class RuleEngine:
             current_price=event.price or 0.0,
             account_status=account_status,
             currency=currency,
+            total_pnl=total_pnl,
+            prev_day_total_asset=prev_day_total_asset,
         )
 
         try:

--- a/src/ante/rule/global_rules.py
+++ b/src/ante/rule/global_rules.py
@@ -11,28 +11,26 @@ class DailyLossLimitRule(Rule):
     def evaluate(self, context: RuleContext) -> RuleEvaluation:
         max_daily_loss = self.config.get("max_daily_loss_percent", 0.05)
 
-        if context.daily_pnl < 0 and context.total_pnl != 0:
-            daily_loss_amount = abs(context.daily_pnl)
-            base = context.total_pnl + daily_loss_amount
-            if base > 0:
-                daily_loss_percent = daily_loss_amount / base
+        if context.daily_pnl < 0 and context.prev_day_total_asset > 0:
+            daily_loss_percent = abs(context.daily_pnl) / context.prev_day_total_asset
 
-                if daily_loss_percent > max_daily_loss:
-                    return RuleEvaluation(
-                        rule_id=self.rule_id,
-                        rule_name=self.name,
-                        result=RuleResult.BLOCK,
-                        action=RuleAction.HALT_ACCOUNT,
-                        message=(
-                            f"Daily loss limit exceeded: "
-                            f"{daily_loss_percent:.2%} > {max_daily_loss:.2%}"
-                        ),
-                        metadata={
-                            "daily_loss_percent": daily_loss_percent,
-                            "max_daily_loss_percent": max_daily_loss,
-                            "daily_pnl": context.daily_pnl,
-                        },
-                    )
+            if daily_loss_percent > max_daily_loss:
+                return RuleEvaluation(
+                    rule_id=self.rule_id,
+                    rule_name=self.name,
+                    result=RuleResult.BLOCK,
+                    action=RuleAction.HALT_ACCOUNT,
+                    message=(
+                        f"Daily loss limit exceeded: "
+                        f"{daily_loss_percent:.2%} > {max_daily_loss:.2%}"
+                    ),
+                    metadata={
+                        "daily_loss_percent": daily_loss_percent,
+                        "max_daily_loss_percent": max_daily_loss,
+                        "daily_pnl": context.daily_pnl,
+                        "prev_day_total_asset": context.prev_day_total_asset,
+                    },
+                )
 
         return RuleEvaluation(
             rule_id=self.rule_id,

--- a/src/ante/rule/manager.py
+++ b/src/ante/rule/manager.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from ante.account.models import Account
     from ante.account.service import AccountService
     from ante.eventbus.bus import EventBus
+    from ante.treasury import TreasuryManager as TreasuryManagerType
 
 logger = logging.getLogger(__name__)
 
@@ -18,9 +19,15 @@ logger = logging.getLogger(__name__)
 class RuleEngineManager:
     """계좌별 RuleEngine 인스턴스를 관리하는 상위 계층."""
 
-    def __init__(self, eventbus: EventBus, account_service: AccountService) -> None:
+    def __init__(
+        self,
+        eventbus: EventBus,
+        account_service: AccountService,
+        treasury_manager: TreasuryManagerType | None = None,
+    ) -> None:
         self._eventbus = eventbus
         self._account_service = account_service
+        self._treasury_manager = treasury_manager
         self._engines: dict[str, RuleEngine] = {}
 
     def create_engine(
@@ -37,10 +44,18 @@ class RuleEngineManager:
         Returns:
             생성된 RuleEngine 인스턴스.
         """
+        treasury = None
+        if self._treasury_manager is not None:
+            try:
+                treasury = self._treasury_manager.get(account_id)
+            except KeyError:
+                logger.warning("Treasury 없음: account=%s", account_id)
+
         engine = RuleEngine(
             eventbus=self._eventbus,
             account_id=account_id,
             account_service=self._account_service,
+            treasury=treasury,
         )
 
         if rule_configs:

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -47,6 +47,7 @@ def base_context():
         account_status="active",
         daily_pnl=0.0,
         total_pnl=100000.0,
+        prev_day_total_asset=100000.0,
     )
 
 
@@ -152,24 +153,39 @@ class TestDailyLossLimitRule:
     def test_pass_within_limit(self, rule, base_context):
         """손실이 한도 내면 통과."""
         base_context.daily_pnl = -3000.0
-        base_context.total_pnl = 100000.0
+        base_context.prev_day_total_asset = 100000.0
         result = rule.evaluate(base_context)
         assert result.result == RuleResult.PASS
 
     def test_block_exceeds_limit(self, rule, base_context):
         """손실이 한도 초과하면 BLOCK + HALT_ACCOUNT."""
         base_context.daily_pnl = -10000.0
-        base_context.total_pnl = 100000.0
+        base_context.prev_day_total_asset = 100000.0
         result = rule.evaluate(base_context)
         assert result.result == RuleResult.BLOCK
         assert result.action == RuleAction.HALT_ACCOUNT
+        assert result.metadata["prev_day_total_asset"] == 100000.0
 
-    def test_pass_zero_total_pnl(self, rule, base_context):
-        """총 수익이 0이면 통과 (0으로 나누기 방지)."""
+    def test_pass_zero_prev_day_total_asset(self, rule, base_context):
+        """전일 총 자산이 0이면 통과 (0으로 나누기 방지)."""
         base_context.daily_pnl = -1000.0
-        base_context.total_pnl = 0.0
+        base_context.prev_day_total_asset = 0.0
         result = rule.evaluate(base_context)
         assert result.result == RuleResult.PASS
+
+    def test_pass_large_asset_small_loss(self, rule, base_context):
+        """자산 1억, 손실 50만 -> 0.5% < 5% -> PASS."""
+        base_context.daily_pnl = -500000.0
+        base_context.prev_day_total_asset = 100000000.0
+        result = rule.evaluate(base_context)
+        assert result.result == RuleResult.PASS
+
+    def test_block_small_asset_large_loss(self, rule, base_context):
+        """자산 100만, 손실 10만 -> 10% > 5% -> BLOCK."""
+        base_context.daily_pnl = -100000.0
+        base_context.prev_day_total_asset = 1000000.0
+        result = rule.evaluate(base_context)
+        assert result.result == RuleResult.BLOCK
 
 
 # ── TotalExposureLimitRule ───────────────────────
@@ -401,7 +417,7 @@ class TestRuleEngine:
         )
 
         base_context.daily_pnl = -10000.0
-        base_context.total_pnl = 100000.0
+        base_context.prev_day_total_asset = 100000.0
         result = engine.evaluate(base_context)
 
         assert result.overall_result == RuleResult.BLOCK
@@ -488,7 +504,7 @@ class TestRuleEngine:
         )
         engine.add_account_rule(rule)
         base_context.daily_pnl = -5000.0
-        base_context.total_pnl = 100000.0
+        base_context.prev_day_total_asset = 100000.0
         result = engine.evaluate(base_context)
         assert result.overall_result == RuleResult.PASS
         assert len(result.evaluations) == 0


### PR DESCRIPTION
## Summary
- DailyLossLimitRule의 일일 손실률 산식을 스펙에 맞게 수정: `abs(daily_pnl) / prev_day_total_asset`
- RuleContext에 `prev_day_total_asset` 필드 추가, RuleEngine이 Treasury 전일 스냅샷에서 조회하여 주입
- RuleEngineManager -> RuleEngine -> Treasury 의존성 경로를 main.py에서 완성

## Changes (6 files)
- `src/ante/rule/base.py` — RuleContext에 `prev_day_total_asset: float = 0.0` 추가
- `src/ante/rule/global_rules.py` — DailyLossLimitRule 산식을 `prev_day_total_asset` 기반으로 수정
- `src/ante/rule/engine.py` — Treasury 의존성 추가, `_on_order_request`/`_on_order_modify`에서 Treasury 데이터 주입
- `src/ante/rule/manager.py` — TreasuryManager 의존성 추가, `create_engine`에서 Treasury 인스턴스 전달
- `src/ante/main.py` — RuleEngineManager에 `treasury_manager` 주입
- `tests/unit/test_rule.py` — 기존 테스트를 `prev_day_total_asset` 기반으로 갱신 + 추가 케이스 2건

## Test plan
- [x] `ruff check` 통과
- [x] `ruff format --check` 통과
- [x] `pytest tests/unit/test_rule.py` 63건 전체 통과
- [ ] Treasury가 없는 환경에서 하위 호환 확인 (prev_day_total_asset=0.0 → PASS)
- [ ] Treasury 전일 스냅샷이 없는 경우 graceful fallback 확인

Refs #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)