### PR TITLE
feat(rule): RuleContext 자산/노출 필드 추가 및 Treasury 조회 헬퍼 추출 #711

### DIFF
--- a/src/ante/rule/base.py
+++ b/src/ante/rule/base.py
@@ -67,6 +67,8 @@ class RuleContext:
     daily_pnl: float = 0.0
     total_pnl: float = 0.0
     prev_day_total_asset: float = 0.0
+    total_asset: float = 0.0
+    total_exposure: float = 0.0
 
     # 추가 메타데이터
     metadata: dict[str, Any] = field(default_factory=dict)

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -265,6 +265,56 @@ class RuleEngine:
 
         return overall, reason, actions
 
+    # ── Treasury 조회 ──────────────────────────────
+
+    async def _query_treasury_data(self) -> dict[str, float]:
+        """Treasury에서 자산/손익 데이터를 조회한다.
+
+        Returns:
+            daily_pnl, total_pnl, prev_day_total_asset,
+            total_asset, total_exposure 딕셔너리.
+            조회 실패 시 각 값은 0.0.
+        """
+        result = {
+            "daily_pnl": 0.0,
+            "total_pnl": 0.0,
+            "prev_day_total_asset": 0.0,
+            "total_asset": 0.0,
+            "total_exposure": 0.0,
+        }
+        if self._treasury is None:
+            return result
+
+        # get_summary()는 동기 메서드
+        try:
+            summary = self._treasury.get_summary()
+            result["total_pnl"] = summary.get("total_profit_loss", 0.0)
+            result["total_asset"] = summary.get("total_evaluation", 0.0)
+            result["total_exposure"] = summary.get("ante_eval_amount", 0.0)
+        except Exception:
+            logger.warning("Treasury summary 조회 실패: %s", self._account_id)
+
+        # get_daily_snapshot()은 비동기 메서드
+        try:
+            from datetime import date, timedelta
+
+            yesterday = (date.today() - timedelta(days=1)).isoformat()
+            snapshot = await self._treasury.get_daily_snapshot(yesterday)
+            if snapshot is not None:
+                result["prev_day_total_asset"] = snapshot.get("total_asset", 0.0)
+        except Exception:
+            logger.warning("Treasury 전일 스냅샷 조회 실패: %s", self._account_id)
+
+        # daily_pnl: 최신 스냅샷에서 조회
+        try:
+            latest = await self._treasury.get_latest_snapshot()
+            if latest is not None:
+                result["daily_pnl"] = latest.get("daily_pnl", 0.0)
+        except Exception:
+            logger.warning("Treasury 최신 스냅샷 조회 실패: %s", self._account_id)
+
+        return result
+
     # ── EventBus 핸들러 ──────────────────────────────
 
     async def _on_order_request(self, event: object) -> None:
@@ -297,23 +347,7 @@ class RuleEngine:
                 )
 
         # Treasury 데이터 조회
-        total_pnl = 0.0
-        prev_day_total_asset = 0.0
-        if self._treasury is not None:
-            try:
-                summary = self._treasury.get_summary()
-                total_pnl = summary.get("total_profit_loss", 0.0)
-            except Exception:
-                logger.warning("Treasury summary 조회 실패: %s", self._account_id)
-            try:
-                from datetime import date, timedelta
-
-                yesterday = (date.today() - timedelta(days=1)).isoformat()
-                snapshot = await self._treasury.get_daily_snapshot(yesterday)
-                if snapshot is not None:
-                    prev_day_total_asset = snapshot.get("total_asset", 0.0)
-            except Exception:
-                logger.warning("Treasury 전일 스냅샷 조회 실패: %s", self._account_id)
+        treasury_data = await self._query_treasury_data()
 
         context = RuleContext(
             bot_id=event.bot_id,
@@ -327,8 +361,11 @@ class RuleEngine:
             current_price=event.price or 0.0,
             account_status=account_status,
             currency=currency,
-            total_pnl=total_pnl,
-            prev_day_total_asset=prev_day_total_asset,
+            daily_pnl=treasury_data["daily_pnl"],
+            total_pnl=treasury_data["total_pnl"],
+            prev_day_total_asset=treasury_data["prev_day_total_asset"],
+            total_asset=treasury_data["total_asset"],
+            total_exposure=treasury_data["total_exposure"],
         )
 
         try:
@@ -463,23 +500,7 @@ class RuleEngine:
                 )
 
         # Treasury 데이터 조회
-        total_pnl = 0.0
-        prev_day_total_asset = 0.0
-        if self._treasury is not None:
-            try:
-                summary = self._treasury.get_summary()
-                total_pnl = summary.get("total_profit_loss", 0.0)
-            except Exception:
-                logger.warning("Treasury summary 조회 실패: %s", self._account_id)
-            try:
-                from datetime import date, timedelta
-
-                yesterday = (date.today() - timedelta(days=1)).isoformat()
-                snapshot = await self._treasury.get_daily_snapshot(yesterday)
-                if snapshot is not None:
-                    prev_day_total_asset = snapshot.get("total_asset", 0.0)
-            except Exception:
-                logger.warning("Treasury 전일 스냅샷 조회 실패: %s", self._account_id)
+        treasury_data = await self._query_treasury_data()
 
         context = RuleContext(
             bot_id=event.bot_id,
@@ -493,8 +514,11 @@ class RuleEngine:
             current_price=event.price or 0.0,
             account_status=account_status,
             currency=currency,
-            total_pnl=total_pnl,
-            prev_day_total_asset=prev_day_total_asset,
+            daily_pnl=treasury_data["daily_pnl"],
+            total_pnl=treasury_data["total_pnl"],
+            prev_day_total_asset=treasury_data["prev_day_total_asset"],
+            total_asset=treasury_data["total_asset"],
+            total_exposure=treasury_data["total_exposure"],
         )
 
         try:

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -1086,3 +1086,58 @@ class TestRuleEngineManager:
 
         assert len(engine1._global_rules) == 1
         assert len(engine2._global_rules) == 0
+
+
+# ── RuleEngine Treasury 연동 ────────────────────
+
+
+class TestRuleEngineTreasuryIntegration:
+    """RuleEngine ↔ Treasury 연동 테스트."""
+
+    @pytest.fixture
+    def mock_treasury(self):
+        """Treasury mock."""
+        from unittest.mock import MagicMock
+
+        treasury = MagicMock()
+        treasury.get_summary.return_value = {
+            "total_profit_loss": 500000.0,
+            "total_evaluation": 100000000.0,
+            "ante_eval_amount": 20000000.0,
+        }
+        treasury.get_daily_snapshot = AsyncMock(
+            return_value={
+                "total_asset": 99000000.0,
+            }
+        )
+        treasury.get_latest_snapshot = AsyncMock(
+            return_value={
+                "daily_pnl": -300000.0,
+            }
+        )
+        return treasury
+
+    async def test_query_treasury_data(self, mock_treasury):
+        """Treasury에서 자산/손익 데이터를 정상 조회."""
+        engine = RuleEngine(eventbus=EventBus(), treasury=mock_treasury)
+        data = await engine._query_treasury_data()
+        assert data["total_pnl"] == 500000.0
+        assert data["total_asset"] == 100000000.0
+        assert data["total_exposure"] == 20000000.0
+        assert data["prev_day_total_asset"] == 99000000.0
+        assert data["daily_pnl"] == -300000.0
+
+    async def test_query_treasury_data_none(self):
+        """Treasury가 None이면 기본값 반환."""
+        engine = RuleEngine(eventbus=EventBus(), treasury=None)
+        data = await engine._query_treasury_data()
+        assert all(v == 0.0 for v in data.values())
+
+    async def test_query_treasury_data_exception(self, mock_treasury):
+        """Treasury 조회 실패 시 기본값 fallback."""
+        mock_treasury.get_summary.side_effect = Exception("DB error")
+        mock_treasury.get_daily_snapshot = AsyncMock(side_effect=Exception("DB error"))
+        mock_treasury.get_latest_snapshot = AsyncMock(side_effect=Exception("DB error"))
+        engine = RuleEngine(eventbus=EventBus(), treasury=mock_treasury)
+        data = await engine._query_treasury_data()
+        assert all(v == 0.0 for v in data.values())


### PR DESCRIPTION
## Summary
- `RuleContext`에 `total_asset`(현재 총 자산), `total_exposure`(전 봇 포지션 평가액 합계) 필드 추가
- `_query_treasury_data()` 헬퍼 메서드를 추출하여 `_on_order_request()`와 `_on_order_modify()`의 중복 Treasury 조회 코드 통합
- `daily_pnl`을 Treasury 최신 스냅샷(`get_latest_snapshot()`)에서 조회하도록 확장
- `TestRuleEngineTreasuryIntegration` 테스트 클래스 추가 (정상 조회, None fallback, 예외 fallback)

## Test plan
- [x] `pytest tests/unit/test_rule.py` 66개 테스트 전체 통과
- [x] `ruff check` + `ruff format --check` 통과
- [ ] CI 통과 확인

Refs #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)