### PR TITLE
fix(rule): DailyLossLimitRule/TotalExposureLimitRule 매도(손절) 허용 및 알림 전환 #715

### DIFF
--- a/src/ante/rule/global_rules.py
+++ b/src/ante/rule/global_rules.py
@@ -15,14 +15,35 @@ class DailyLossLimitRule(Rule):
             daily_loss_percent = abs(context.daily_pnl) / context.prev_day_total_asset
 
             if daily_loss_percent > max_daily_loss:
+                # 매도(손절)는 항상 허용 — 포지션 정리를 차단하면 안 됨
+                if context.side == "sell":
+                    return RuleEvaluation(
+                        rule_id=self.rule_id,
+                        rule_name=self.name,
+                        result=RuleResult.PASS,
+                        action=RuleAction.LOG,
+                        message=(
+                            f"Daily loss limit exceeded "
+                            f"({daily_loss_percent:.2%} > {max_daily_loss:.2%}) "
+                            f"but sell order is allowed for position liquidation"
+                        ),
+                        metadata={
+                            "daily_loss_percent": daily_loss_percent,
+                            "max_daily_loss_percent": max_daily_loss,
+                            "daily_pnl": context.daily_pnl,
+                            "prev_day_total_asset": context.prev_day_total_asset,
+                        },
+                    )
+
                 return RuleEvaluation(
                     rule_id=self.rule_id,
                     rule_name=self.name,
-                    result=RuleResult.BLOCK,
-                    action=RuleAction.HALT_ACCOUNT,
+                    result=RuleResult.REJECT,
+                    action=RuleAction.NOTIFY,
                     message=(
                         f"Daily loss limit exceeded: "
-                        f"{daily_loss_percent:.2%} > {max_daily_loss:.2%}"
+                        f"{daily_loss_percent:.2%} > {max_daily_loss:.2%}. "
+                        f"Buy orders blocked. Sell orders are still allowed."
                     ),
                     metadata={
                         "daily_loss_percent": daily_loss_percent,
@@ -45,6 +66,16 @@ class TotalExposureLimitRule(Rule):
     """총 포지션 노출 한도 초과 시 거래 제한."""
 
     def evaluate(self, context: RuleContext) -> RuleEvaluation:
+        # 매도(손절)는 항상 허용 — 포지션 정리를 차단하면 안 됨
+        if context.side == "sell":
+            return RuleEvaluation(
+                rule_id=self.rule_id,
+                rule_name=self.name,
+                result=RuleResult.PASS,
+                action=RuleAction.LOG,
+                message="Sell order is always allowed for position liquidation",
+            )
+
         max_exposure_percent = self.config.get("max_exposure_percent", 0.20)
         max_exposure_amount = self.config.get("max_exposure_amount", float("inf"))
 
@@ -65,7 +96,8 @@ class TotalExposureLimitRule(Rule):
                     action=RuleAction.NOTIFY,
                     message=(
                         f"Total exposure would exceed limit: "
-                        f"{expected_exposure:.2f} > {exposure_limit:.2f}"
+                        f"{expected_exposure:.2f} > {exposure_limit:.2f}. "
+                        f"Buy orders blocked. Sell orders are still allowed."
                     ),
                     metadata={
                         "total_exposure": context.total_exposure,

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -157,14 +157,26 @@ class TestDailyLossLimitRule:
         result = rule.evaluate(base_context)
         assert result.result == RuleResult.PASS
 
-    def test_block_exceeds_limit(self, rule, base_context):
-        """손실이 한도 초과하면 BLOCK + HALT_ACCOUNT."""
+    def test_reject_buy_exceeds_limit(self, rule, base_context):
+        """손실이 한도 초과하면 매수는 REJECT + NOTIFY (매도는 허용)."""
         base_context.daily_pnl = -10000.0
         base_context.prev_day_total_asset = 100000.0
+        base_context.side = "buy"
         result = rule.evaluate(base_context)
-        assert result.result == RuleResult.BLOCK
-        assert result.action == RuleAction.HALT_ACCOUNT
+        assert result.result == RuleResult.REJECT
+        assert result.action == RuleAction.NOTIFY
         assert result.metadata["prev_day_total_asset"] == 100000.0
+        assert "Buy orders blocked" in result.message
+        assert "Sell orders are still allowed" in result.message
+
+    def test_pass_sell_during_loss_limit(self, rule, base_context):
+        """손실 한도 초과 상태에서도 매도(손절)는 PASS."""
+        base_context.daily_pnl = -10000.0
+        base_context.prev_day_total_asset = 100000.0
+        base_context.side = "sell"
+        result = rule.evaluate(base_context)
+        assert result.result == RuleResult.PASS
+        assert "sell order is allowed" in result.message
 
     def test_pass_zero_prev_day_total_asset(self, rule, base_context):
         """전일 총 자산이 0이면 통과 (0으로 나누기 방지)."""
@@ -180,12 +192,14 @@ class TestDailyLossLimitRule:
         result = rule.evaluate(base_context)
         assert result.result == RuleResult.PASS
 
-    def test_block_small_asset_large_loss(self, rule, base_context):
-        """자산 100만, 손실 10만 -> 10% > 5% -> BLOCK."""
+    def test_reject_small_asset_large_loss(self, rule, base_context):
+        """자산 100만, 손실 10만 -> 10% > 5% -> REJECT + NOTIFY."""
         base_context.daily_pnl = -100000.0
         base_context.prev_day_total_asset = 1000000.0
+        base_context.side = "buy"
         result = rule.evaluate(base_context)
-        assert result.result == RuleResult.BLOCK
+        assert result.result == RuleResult.REJECT
+        assert result.action == RuleAction.NOTIFY
 
 
 # ── TotalExposureLimitRule ───────────────────────
@@ -243,6 +257,16 @@ class TestTotalExposureLimitRule:
         base_context.quantity = 1.0  # 주문 5만 -> 합산 23만 > 20만
         result = rule.evaluate(base_context)
         assert result.result == RuleResult.REJECT
+
+    def test_pass_sell_during_exposure_limit(self, rule, base_context):
+        """노출 한도 초과 상태에서도 매도(손절)는 PASS."""
+        base_context.total_asset = 1000000.0
+        base_context.total_exposure = 180000.0
+        base_context.quantity = 1.0
+        base_context.side = "sell"
+        result = rule.evaluate(base_context)
+        assert result.result == RuleResult.PASS
+        assert "Sell order is always allowed" in result.message
 
 
 # ── TradingHoursRule ─────────────────────────────
@@ -441,7 +465,7 @@ class TestRuleEngine:
         base_context.prev_day_total_asset = 100000.0
         result = engine.evaluate(base_context)
 
-        assert result.overall_result == RuleResult.BLOCK
+        assert result.overall_result == RuleResult.REJECT
         # 계좌 룰만 평가됨
         assert len(result.evaluations) == 1
         assert result.evaluations[0].rule_id == "dl"


### PR DESCRIPTION
## Summary
- DailyLossLimitRule: 손실 한도 초과 시 매도(손절) 주문은 PASS로 허용, 매수만 REJECT+NOTIFY로 차단 (기존 BLOCK+HALT_ACCOUNT에서 완화)
- TotalExposureLimitRule: 노출 한도 초과 시 매도 주문은 즉시 PASS로 허용
- 양쪽 룰 모두 차단 메시지에 "Sell orders are still allowed" 안내 추가

## Test plan
- [x] `test_reject_buy_exceeds_limit`: 손실 한도 초과 + buy → REJECT + NOTIFY 확인
- [x] `test_pass_sell_during_loss_limit`: 손실 한도 초과 + sell → PASS 확인
- [x] `test_reject_small_asset_large_loss`: REJECT + NOTIFY로 변경 확인
- [x] `test_pass_sell_during_exposure_limit`: 노출 한도 초과 + sell → PASS 확인
- [x] `test_evaluate_account_rule_block`: overall_result REJECT로 변경 확인
- [x] 전체 70개 테스트 통과

Refs #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)