### PR TITLE
fix(account): delete()에서 이벤트 발행 및 CLI IPC 전환 #717

### DIFF
--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -359,12 +359,32 @@ class AccountService:
             AccountNotFoundError: 계좌를 찾을 수 없음.
         """
         account = await self.get(account_id)
+
+        # 소속 봇 중지 트리거 (이미 SUSPENDED/DELETED면 스킵)
+        if account.status not in (AccountStatus.SUSPENDED, AccountStatus.DELETED):
+            from ante.eventbus.events import AccountSuspendedEvent
+
+            await self._eventbus.publish(
+                AccountSuspendedEvent(
+                    account_id=account_id,
+                    reason="Account deletion",
+                    suspended_by=deleted_by,
+                )
+            )
+
         account.status = AccountStatus.DELETED
         account.updated_at = datetime.now(UTC)
 
         await self._db.execute(
             "UPDATE accounts SET status=?, updated_at=? WHERE account_id=?",
             (AccountStatus.DELETED, account.updated_at.isoformat(), account_id),
+        )
+
+        # 삭제 완료 이벤트
+        from ante.eventbus.events import AccountDeletedEvent
+
+        await self._eventbus.publish(
+            AccountDeletedEvent(account_id=account_id, deleted_by=deleted_by)
         )
 
         # 메모리 캐시에서 제거

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -305,21 +305,24 @@ def account_activate(ctx: click.Context, account_id: str) -> None:
 @require_scope("account:write")
 def account_delete(ctx: click.Context, account_id: str, skip_confirm: bool) -> None:
     """계좌 삭제 (소프트 딜리트)."""
+    from ante.cli.commands.ipc_helpers import ipc_send
+
     fmt = get_formatter(ctx)
     member_id = get_member_id(ctx)
 
     if not skip_confirm:
         click.confirm(f'계좌 "{account_id}"를 삭제하시겠습니까?', abort=True)
 
-    async def _do_delete() -> None:
-        svc, db = await _create_account_service()
-        try:
-            await svc.delete(account_id, deleted_by=member_id)
-        finally:
-            await db.close()
-
     try:
-        _run(_do_delete())
+        _run(
+            ipc_send(
+                "account.delete",
+                {"account_id": account_id},
+                actor=member_id,
+            )
+        )
+    except click.ClickException:
+        raise
     except Exception as e:
         fmt.error(str(e))
         raise SystemExit(1) from e

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -72,6 +72,14 @@ async def _handle_account_activate(
     return {"account_id": account_id, "status": "active"}
 
 
+async def _handle_account_delete(
+    svc: ServiceRegistry, args: dict[str, Any], actor: str
+) -> dict:
+    account_id = args["account_id"]
+    await svc.account.delete(account_id, deleted_by=actor)
+    return {"account_id": account_id, "status": "deleted"}
+
+
 async def _handle_bot_create(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
@@ -186,6 +194,7 @@ def register_all_handlers(registry: CommandRegistry) -> None:
     registry.register("system.activate", _handle_system_activate)
     registry.register("account.suspend", _handle_account_suspend)
     registry.register("account.activate", _handle_account_activate)
+    registry.register("account.delete", _handle_account_delete)
     registry.register("bot.create", _handle_bot_create)
     registry.register("bot.remove", _handle_bot_remove)
     registry.register("treasury.allocate", _handle_treasury_allocate)

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -37,14 +37,15 @@ def test_commands_property(registry: CommandRegistry) -> None:
 
 
 def test_register_all_handlers() -> None:
-    """register_all_handlers가 15개 핸들러를 등록."""
+    """register_all_handlers가 16개 핸들러를 등록."""
     registry = CommandRegistry()
     register_all_handlers(registry)
-    assert len(registry.commands) == 15
+    assert len(registry.commands) == 16
 
     expected = {
         "system.halt",
         "system.activate",
+        "account.delete",
         "account.suspend",
         "account.activate",
         "bot.create",

--- a/tests/unit/test_account_cli.py
+++ b/tests/unit/test_account_cli.py
@@ -320,22 +320,49 @@ class TestAccountStateTransitions:
         assert "활성화 완료" in result.output
         mock_client.send.assert_called_once()
 
-    def test_delete_with_yes(self, mock_account_service: AsyncMock) -> None:
-        """계좌 삭제 (--yes 옵션)."""
-        result = _invoke(["account", "delete", "domestic", "--yes"])
+    def test_delete_with_yes(self) -> None:
+        """계좌 삭제 (--yes 옵션, IPC 전환)."""
+        mock_response = {"status": "ok", "data": {}}
+
+        with patch(
+            "ante.cli.commands.ipc_helpers.IPCClient", autospec=True
+        ) as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.send.return_value = mock_response
+            mock_cls.return_value = mock_client
+
+            with patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/test.sock",
+            ):
+                result = _invoke(["account", "delete", "domestic", "--yes"])
+
         assert result.exit_code == 0
         assert "삭제 완료" in result.output
-        mock_account_service.delete.assert_called_once()
+        mock_client.send.assert_called_once()
 
-    def test_delete_with_confirm(self, mock_account_service: AsyncMock) -> None:
-        """계좌 삭제 (확인 프롬프트 y 입력)."""
-        result = _invoke(["account", "delete", "domestic"], input_text="y\n")
+    def test_delete_with_confirm(self) -> None:
+        """계좌 삭제 (확인 프롬프트 y 입력, IPC 전환)."""
+        mock_response = {"status": "ok", "data": {}}
+
+        with patch(
+            "ante.cli.commands.ipc_helpers.IPCClient", autospec=True
+        ) as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.send.return_value = mock_response
+            mock_cls.return_value = mock_client
+
+            with patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/test.sock",
+            ):
+                result = _invoke(["account", "delete", "domestic"], input_text="y\n")
+
         assert result.exit_code == 0
         assert "삭제 완료" in result.output
-        mock_account_service.delete.assert_called_once()
+        mock_client.send.assert_called_once()
 
-    def test_delete_abort(self, mock_account_service: AsyncMock) -> None:
+    def test_delete_abort(self) -> None:
         """계좌 삭제 취소 (확인 프롬프트 n 입력)."""
         result = _invoke(["account", "delete", "domestic"], input_text="n\n")
         assert result.exit_code == 1
-        mock_account_service.delete.assert_not_called()

--- a/tests/unit/test_account_delete_events.py
+++ b/tests/unit/test_account_delete_events.py
@@ -1,0 +1,130 @@
+"""AccountService.delete() 이벤트 발행 테스트 (#717)."""
+
+import pytest
+import pytest_asyncio
+
+from ante.account.models import Account, AccountStatus
+from ante.account.service import AccountService
+from ante.core.database import Database
+from ante.eventbus.bus import EventBus
+from ante.eventbus.events import (
+    AccountDeletedEvent,
+    AccountSuspendedEvent,
+)
+
+
+@pytest_asyncio.fixture
+async def db(tmp_path):
+    """테스트용 인메모리 DB."""
+    db_path = str(tmp_path / "test_account_delete.db")
+    database = Database(db_path)
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+def eventbus():
+    """테스트용 EventBus."""
+    return EventBus()
+
+
+@pytest_asyncio.fixture
+async def service(db, eventbus):
+    """초기화된 AccountService."""
+    svc = AccountService(db, eventbus)
+    await svc.initialize()
+    return svc
+
+
+def _make_account(
+    account_id: str = "test",
+    name: str = "테스트",
+    exchange: str = "TEST",
+    currency: str = "KRW",
+    broker_type: str = "test",
+    **kwargs,
+) -> Account:
+    """테스트용 Account 생성 헬퍼."""
+    return Account(
+        account_id=account_id,
+        name=name,
+        exchange=exchange,
+        currency=currency,
+        broker_type=broker_type,
+        **kwargs,
+    )
+
+
+class TestAccountDeleteEvents:
+    """AccountService.delete() 이벤트 발행 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_delete_publishes_events(self, service, eventbus):
+        """delete()가 AccountSuspendedEvent -> AccountDeletedEvent 순서로 발행."""
+        await service.create(_make_account())
+
+        published: list = []
+
+        async def on_suspended(event: AccountSuspendedEvent) -> None:
+            published.append(("suspended", event))
+
+        async def on_deleted(event: AccountDeletedEvent) -> None:
+            published.append(("deleted", event))
+
+        eventbus.subscribe(AccountSuspendedEvent, on_suspended)
+        eventbus.subscribe(AccountDeletedEvent, on_deleted)
+
+        await service.delete("test", deleted_by="admin")
+
+        assert len(published) == 2
+
+        # 순서 검증: suspended -> deleted
+        assert published[0][0] == "suspended"
+        assert published[0][1].account_id == "test"
+        assert published[0][1].reason == "Account deletion"
+        assert published[0][1].suspended_by == "admin"
+
+        assert published[1][0] == "deleted"
+        assert published[1][1].account_id == "test"
+        assert published[1][1].deleted_by == "admin"
+
+    @pytest.mark.asyncio
+    async def test_delete_already_suspended_skips_suspend_event(
+        self, service, eventbus
+    ):
+        """이미 SUSPENDED인 계좌 삭제 시 SuspendedEvent 미발행."""
+        await service.create(_make_account())
+        await service.suspend("test", reason="test reason", suspended_by="system")
+
+        published: list = []
+
+        async def on_suspended(event: AccountSuspendedEvent) -> None:
+            published.append(("suspended", event))
+
+        async def on_deleted(event: AccountDeletedEvent) -> None:
+            published.append(("deleted", event))
+
+        eventbus.subscribe(AccountSuspendedEvent, on_suspended)
+        eventbus.subscribe(AccountDeletedEvent, on_deleted)
+
+        await service.delete("test", deleted_by="admin")
+
+        # AccountSuspendedEvent는 발행되지 않아야 함
+        assert len(published) == 1
+        assert published[0][0] == "deleted"
+        assert published[0][1].account_id == "test"
+        assert published[0][1].deleted_by == "admin"
+
+    @pytest.mark.asyncio
+    async def test_delete_sets_status_and_clears_cache(self, service):
+        """delete() 후 상태가 DELETED로 변경되고 메모리 캐시에서 제거."""
+        await service.create(_make_account())
+        await service.delete("test", deleted_by="admin")
+
+        # 메모리 캐시에서 제거됨
+        assert "test" not in service._accounts
+
+        # DB에서 DELETED 상태로 조회 가능
+        account = await service.get("test")
+        assert account.status == AccountStatus.DELETED

--- a/tests/unit/test_cli_format_option.py
+++ b/tests/unit/test_cli_format_option.py
@@ -202,32 +202,46 @@ class TestAccountDeleteYes:
     """ante account delete {id} --yes."""
 
     def test_delete_with_yes_skips_confirm(self, runner: CliRunner) -> None:
-        svc = AsyncMock()
-        db = _mock_db()
+        mock_response = {"status": "ok", "data": {}}
 
         with patch(
-            "ante.cli.commands.account._create_account_service",
-            new_callable=AsyncMock,
-            return_value=(svc, db),
-        ):
-            result = runner.invoke(cli, ["account", "delete", "test-acct", "--yes"])
-            assert result.exit_code == 0
-            assert "삭제 완료" in result.output
-            svc.delete.assert_called_once()
+            "ante.cli.commands.ipc_helpers.IPCClient", autospec=True
+        ) as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.send.return_value = mock_response
+            mock_cls.return_value = mock_client
+
+            with patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/test.sock",
+            ):
+                result = runner.invoke(cli, ["account", "delete", "test-acct", "--yes"])
+
+        assert result.exit_code == 0
+        assert "삭제 완료" in result.output
+        mock_client.send.assert_called_once()
 
     def test_delete_without_yes_prompts(self, runner: CliRunner) -> None:
         """--yes 없이 호출하면 확인 프롬프트가 나타남."""
-        svc = AsyncMock()
-        db = _mock_db()
+        mock_response = {"status": "ok", "data": {}}
 
         with patch(
-            "ante.cli.commands.account._create_account_service",
-            new_callable=AsyncMock,
-            return_value=(svc, db),
-        ):
-            result = runner.invoke(cli, ["account", "delete", "test-acct"], input="y\n")
-            assert result.exit_code == 0
-            assert "삭제 완료" in result.output
+            "ante.cli.commands.ipc_helpers.IPCClient", autospec=True
+        ) as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.send.return_value = mock_response
+            mock_cls.return_value = mock_client
+
+            with patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/test.sock",
+            ):
+                result = runner.invoke(
+                    cli, ["account", "delete", "test-acct"], input="y\n"
+                )
+
+        assert result.exit_code == 0
+        assert "삭제 완료" in result.output
 
 
 # ── treasury status --format json ─────────────────────────


### PR DESCRIPTION
## Summary
- `AccountService.delete()`에서 `AccountSuspendedEvent`(봇 중지 트리거)와 `AccountDeletedEvent`(삭제 완료) 이벤트를 발행하도록 수정
- 이미 SUSPENDED/DELETED 상태인 계좌는 `AccountSuspendedEvent` 중복 발행 방지
- CLI `account delete` 커맨드를 직접 서비스 호출에서 IPC(`ipc_send`) 경유로 전환하여 서버 EventBus를 통한 이벤트 전파 보장
- IPC registry에 `account.delete` 핸들러 등록

## Test plan
- [x] `test_delete_publishes_events`: ACTIVE 계좌 삭제 시 AccountSuspendedEvent -> AccountDeletedEvent 순서 발행 검증
- [x] `test_delete_already_suspended_skips_suspend_event`: SUSPENDED 계좌 삭제 시 AccountSuspendedEvent 미발행 검증
- [x] `test_delete_sets_status_and_clears_cache`: 삭제 후 상태 변경 및 캐시 정리 검증
- [x] 기존 CLI 테스트(`test_account_cli.py`) IPC 패턴으로 업데이트 및 통과
- [x] ruff check / ruff format 통과

Refs #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)