### PR TITLE
fix(account): DELETED 계좌 suspend/delete 상태 전이 가드 추가 #718

### DIFF
--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -287,6 +287,10 @@ class AccountService:
             AccountNotFoundError: 계좌를 찾을 수 없음.
         """
         account = await self.get(account_id)
+        if account.status == AccountStatus.DELETED:
+            raise AccountDeletedException(
+                f"삭제된 계좌 '{account_id}'는 정지할 수 없습니다."
+            )
         if account.status == AccountStatus.SUSPENDED:
             from ante.account.errors import AccountAlreadySuspendedError
 
@@ -359,6 +363,8 @@ class AccountService:
             AccountNotFoundError: 계좌를 찾을 수 없음.
         """
         account = await self.get(account_id)
+        if account.status == AccountStatus.DELETED:
+            raise AccountDeletedException(f"이미 삭제된 계좌입니다: '{account_id}'")
 
         # 소속 봇 중지 트리거 (이미 SUSPENDED/DELETED면 스킵)
         if account.status not in (AccountStatus.SUSPENDED, AccountStatus.DELETED):

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -285,6 +285,7 @@ class AccountService:
 
         Raises:
             AccountNotFoundError: 계좌를 찾을 수 없음.
+            AccountDeletedException: 삭제된 계좌.
         """
         account = await self.get(account_id)
         if account.status == AccountStatus.DELETED:
@@ -361,6 +362,7 @@ class AccountService:
 
         Raises:
             AccountNotFoundError: 계좌를 찾을 수 없음.
+            AccountDeletedException: 삭제된 계좌.
         """
         account = await self.get(account_id)
         if account.status == AccountStatus.DELETED:

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -214,6 +214,26 @@ async def test_activate_deleted_raises(service):
         await service.activate("test", activated_by="admin")
 
 
+@pytest.mark.asyncio
+async def test_suspend_deleted_account_raises(service):
+    """DELETED 계좌에 suspend 시도 시 AccountDeletedException."""
+    await service.create(_make_account())
+    await service.delete("test", deleted_by="system")
+
+    with pytest.raises(AccountDeletedException):
+        await service.suspend("test", reason="테스트", suspended_by="system")
+
+
+@pytest.mark.asyncio
+async def test_delete_already_deleted_account_raises(service):
+    """이미 DELETED 계좌에 delete 시도 시 AccountDeletedException."""
+    await service.create(_make_account())
+    await service.delete("test", deleted_by="system")
+
+    with pytest.raises(AccountDeletedException):
+        await service.delete("test", deleted_by="system")
+
+
 # ── 삭제 (delete) ──────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- DELETED 상태 계좌에 `suspend()` 호출 시 `AccountDeletedException` 발생하도록 가드 추가
- DELETED 상태 계좌에 `delete()` 호출 시 `AccountDeletedException` 발생하도록 가드 추가
- 두 케이스에 대한 단위 테스트 추가 (총 27개 테스트 통과)

## Test plan
- [x] `test_suspend_deleted_account_raises` — DELETED 계좌 suspend 시 예외 확인
- [x] `test_delete_already_deleted_account_raises` — DELETED 계좌 재삭제 시 예외 확인
- [x] 기존 25개 테스트 회귀 없음 확인
- [x] ruff check / ruff format 통과

Refs #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)