### PR TITLE
feat(backtest): BacktestDataProvider에 loaded_datasets 이력 기록 Refs #726

### DIFF
--- a/src/ante/backtest/data_provider.py
+++ b/src/ante/backtest/data_provider.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import polars as pl
 
+from ante.backtest.config import DatasetInfo
 from ante.backtest.exceptions import BacktestDataError
 from ante.strategy.base import DataProvider
 
@@ -36,6 +37,7 @@ class BacktestDataProvider(DataProvider):
         self._end = end_date
         self._cache: dict[str, pl.DataFrame] = {}
         self._current_idx: int = 0
+        self._loaded_datasets: list[DatasetInfo] = []
 
     @property
     def current_idx(self) -> int:
@@ -49,11 +51,30 @@ class BacktestDataProvider(DataProvider):
     def end(self) -> str:
         return self._end
 
+    @property
+    def loaded_datasets(self) -> list[DatasetInfo]:
+        """로드된 데이터셋 메타정보 목록."""
+        return list(self._loaded_datasets)
+
     def load(self, symbol: str, timeframe: str) -> int:
         """데이터를 캐시에 로드. 로드된 행 수 반환."""
         key = f"{symbol}:{timeframe}"
         df = self._store.read(symbol, timeframe, start=self._start, end=self._end)
         self._cache[key] = df
+
+        data_dir = self._store.resolve_path(symbol, timeframe)
+        file_count = len(list(data_dir.glob("*.parquet"))) if data_dir.exists() else 0
+        info = DatasetInfo(
+            symbol=symbol,
+            timeframe=timeframe,
+            row_count=len(df),
+            start_date=str(df["timestamp"][0]) if len(df) > 0 else "",
+            end_date=str(df["timestamp"][-1]) if len(df) > 0 else "",
+            data_dir=str(data_dir),
+            file_count=file_count,
+        )
+        self._loaded_datasets.append(info)
+
         return len(df)
 
     async def get_ohlcv(
@@ -117,3 +138,4 @@ class BacktestDataProvider(DataProvider):
     def reset(self) -> None:
         """인덱스 초기화."""
         self._current_idx = 0
+        self._loaded_datasets.clear()

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -255,6 +255,65 @@ class TestBacktestDataProvider:
         df = await data_provider.get_indicator("005930", "sma", {"period": 5})
         assert len(df) > 0
 
+    async def test_loaded_datasets_empty_on_init(self, loaded_store):
+        """초기 상태에서 loaded_datasets는 빈 리스트."""
+        provider = BacktestDataProvider(
+            store=loaded_store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        assert provider.loaded_datasets == []
+
+    async def test_loaded_datasets_after_single_load(self, loaded_store):
+        """load() 1회 호출 후 DatasetInfo 1건 기록."""
+        from ante.backtest.config import DatasetInfo
+
+        provider = BacktestDataProvider(
+            store=loaded_store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+
+        datasets = provider.loaded_datasets
+        assert len(datasets) == 1
+        info = datasets[0]
+        assert isinstance(info, DatasetInfo)
+        assert info.symbol == "005930"
+        assert info.timeframe == "1d"
+        assert info.row_count == 10
+        assert info.start_date != ""
+        assert info.end_date != ""
+        assert info.file_count >= 1
+
+    async def test_loaded_datasets_after_multiple_loads(self, loaded_store):
+        """load() 여러 번 호출 시 DatasetInfo가 누적된다."""
+        # 두 번째 심볼 데이터도 적재
+        df = _make_ohlcv_df(symbol="000660", n=5, base_price=100000.0)
+        loaded_store.write("000660", "1d", df)
+
+        provider = BacktestDataProvider(
+            store=loaded_store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+        provider.load("000660", "1d")
+
+        datasets = provider.loaded_datasets
+        assert len(datasets) == 2
+        assert datasets[0].symbol == "005930"
+        assert datasets[0].row_count == 10
+        assert datasets[1].symbol == "000660"
+        assert datasets[1].row_count == 5
+
+    async def test_loaded_datasets_after_reset(self, data_provider):
+        """reset() 호출 시 loaded_datasets가 초기화된다."""
+        assert len(data_provider.loaded_datasets) >= 1
+        data_provider.reset()
+        assert data_provider.loaded_datasets == []
+
+    async def test_loaded_datasets_returns_copy(self, data_provider):
+        """loaded_datasets는 내부 리스트의 복사본을 반환한다."""
+        datasets1 = data_provider.loaded_datasets
+        datasets2 = data_provider.loaded_datasets
+        assert datasets1 == datasets2
+        assert datasets1 is not datasets2
+
 
 # ── BacktestStrategyContext 테스트 ─────────────────
 


### PR DESCRIPTION
## Summary
- `BacktestDataProvider.load()` 호출 시 `DatasetInfo`를 생성하여 `_loaded_datasets`에 누적 기록
- `loaded_datasets` property로 기록된 데이터셋 메타정보 조회 (복사본 반환)
- `reset()` 호출 시 `_loaded_datasets` 초기화

## Test plan
- [x] `test_loaded_datasets_empty_on_init` — 초기 상태 빈 리스트 확인
- [x] `test_loaded_datasets_after_single_load` — 단일 load 후 DatasetInfo 필드 검증
- [x] `test_loaded_datasets_after_multiple_loads` — 다중 load 시 누적 확인
- [x] `test_loaded_datasets_after_reset` — reset 후 초기화 확인
- [x] `test_loaded_datasets_returns_copy` — 반환값이 내부 리스트 복사본인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)