### PR TITLE
feat(backtest): _validate_config() -> BacktestConfig 통합 + 수수료 분리 #727

### DIFF
--- a/src/ante/backtest/config.py
+++ b/src/ante/backtest/config.py
@@ -15,7 +15,8 @@ class BacktestConfig:
     start_date: str = ""
     end_date: str = ""
     initial_balance: float = 10_000_000.0
-    commission_rate: float = 0.00015
+    buy_commission_rate: float = 0.00015
+    sell_commission_rate: float = 0.00195
     slippage_rate: float = 0.001
     data_paths: list[str] = field(default_factory=lambda: ["data/"])
 

--- a/src/ante/backtest/executor.py
+++ b/src/ante/backtest/executor.py
@@ -27,13 +27,15 @@ class BacktestExecutor:
         strategy_cls: type[Strategy],
         data_provider: BacktestDataProvider,
         initial_balance: float = 10_000_000,
-        commission_rate: float = 0.00015,
+        buy_commission_rate: float = 0.00015,
+        sell_commission_rate: float = 0.00195,
         slippage_rate: float = 0.001,
     ) -> None:
         self._strategy_cls = strategy_cls
         self._data = data_provider
         self._initial_balance = initial_balance
-        self._commission_rate = commission_rate
+        self._buy_commission_rate = buy_commission_rate
+        self._sell_commission_rate = sell_commission_rate
         self._slippage_rate = slippage_rate
 
         self._balance = initial_balance
@@ -120,7 +122,12 @@ class BacktestExecutor:
         else:
             exec_price = price * (1 - self._slippage_rate)
 
-        commission = exec_price * signal.quantity * self._commission_rate
+        rate = (
+            self._buy_commission_rate
+            if signal.side == "buy"
+            else self._sell_commission_rate
+        )
+        commission = exec_price * signal.quantity * rate
 
         if signal.side == "buy":
             cost = exec_price * signal.quantity + commission

--- a/src/ante/backtest/service.py
+++ b/src/ante/backtest/service.py
@@ -8,6 +8,7 @@ import logging
 import sys
 from typing import TYPE_CHECKING, Any
 
+from ante.backtest.config import BacktestConfig
 from ante.backtest.data_provider import BacktestDataProvider
 from ante.backtest.exceptions import BacktestConfigError, BacktestError
 from ante.backtest.executor import BacktestExecutor
@@ -42,33 +43,36 @@ class BacktestService:
         progress_callback: Any | None = None,
     ) -> BacktestResult:
         """백테스트를 in-process로 실행."""
-        self._validate_config(config)
-
         from pathlib import Path
 
-        strategy_cls = StrategyLoader.load(Path(config["strategy_path"]))
+        validated = self._validate_config(config)
 
-        store = ParquetStore(base_path=config.get("data_path", self._data_path))
+        strategy_cls = StrategyLoader.load(Path(validated.strategy_path))
+
+        store = ParquetStore(
+            base_path=config.get("data_path", self._data_path),
+        )
         data_provider = BacktestDataProvider(
             store=store,
-            start_date=config["start_date"],
-            end_date=config["end_date"],
+            start_date=validated.start_date,
+            end_date=validated.end_date,
         )
 
-        symbols = config.get("symbols", [])
-        timeframe = config.get("timeframe", "1d")
-        for symbol in symbols:
-            data_provider.load(symbol, timeframe)
+        for symbol in validated.symbols:
+            data_provider.load(symbol, validated.timeframe)
 
         executor = BacktestExecutor(
             strategy_cls=strategy_cls,
             data_provider=data_provider,
-            initial_balance=config.get("initial_balance", 10_000_000),
-            commission_rate=config.get("commission_rate", 0.00015),
-            slippage_rate=config.get("slippage_rate", 0.001),
+            initial_balance=validated.initial_balance,
+            buy_commission_rate=validated.buy_commission_rate,
+            sell_commission_rate=validated.sell_commission_rate,
+            slippage_rate=validated.slippage_rate,
         )
 
         result = await executor.run(progress_callback=progress_callback)
+        result.config = validated
+        result.datasets = data_provider.loaded_datasets
 
         # BacktestCompleteEvent 발행
         await self._publish_complete_event(result, config)
@@ -118,10 +122,31 @@ class BacktestService:
         await self._eventbus.publish(event)
         logger.info("BacktestCompleteEvent 발행: %s", strategy_id)
 
-    def _validate_config(self, config: dict[str, Any]) -> None:
-        """설정 검증."""
+    def _validate_config(self, config: dict[str, Any]) -> BacktestConfig:
+        """설정 검증 후 BacktestConfig를 반환."""
         required = ["strategy_path", "start_date", "end_date"]
         missing = [k for k in required if k not in config]
         if missing:
             msg = f"Missing required config keys: {missing}"
             raise BacktestConfigError(msg)
+
+        data_paths = config.get(
+            "data_paths",
+            [config.get("data_path", self._data_path)],
+        )
+
+        return BacktestConfig(
+            strategy_path=config["strategy_path"],
+            symbols=config.get("symbols", []),
+            timeframe=config.get("timeframe", "1d"),
+            start_date=config.get("start_date", ""),
+            end_date=config.get("end_date", ""),
+            initial_balance=config.get("initial_balance", 10_000_000.0),
+            buy_commission_rate=config.get(
+                "buy_commission_rate",
+                config.get("commission_rate", 0.00015),
+            ),
+            sell_commission_rate=config.get("sell_commission_rate", 0.00195),
+            slippage_rate=config.get("slippage_rate", 0.001),
+            data_paths=data_paths,
+        )

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from typing import Any
+from unittest.mock import patch
 
 import polars as pl
 import pytest
 
+from ante.backtest.config import BacktestConfig, DatasetInfo
 from ante.backtest.context import BacktestStrategyContext
 from ante.backtest.data_provider import BacktestDataProvider
 from ante.backtest.exceptions import (
@@ -266,7 +268,6 @@ class TestBacktestDataProvider:
 
     async def test_loaded_datasets_after_single_load(self, loaded_store):
         """load() 1회 호출 후 DatasetInfo 1건 기록."""
-        from ante.backtest.config import DatasetInfo
 
         provider = BacktestDataProvider(
             store=loaded_store, start_date="2026-01-01", end_date="2026-12-31"
@@ -586,7 +587,6 @@ class TestBacktestService:
             service._validate_config({"start_date": "2026-01-01"})
 
     def test_validate_config_returns_backtest_config(self):
-        from ante.backtest.config import BacktestConfig
 
         service = BacktestService()
         result = service._validate_config(
@@ -660,6 +660,40 @@ class TestBacktestService:
         )
         assert result.data_paths == ["a/", "b/"]
 
+    async def test_run_injects_config_and_datasets(self, loaded_store, data_dir):
+        """run() 후 result.config=BacktestConfig, datasets=list[DatasetInfo]."""
+        service = BacktestService(data_path=str(data_dir))
+
+        config = {
+            "strategy_path": "dummy.py",
+            "start_date": "2026-01-01",
+            "end_date": "2026-12-31",
+            "symbols": ["005930"],
+            "timeframe": "1d",
+            "data_path": str(data_dir),
+        }
+
+        with patch(
+            "ante.backtest.service.StrategyLoader.load",
+            return_value=EmptyStrategy,
+        ):
+            result = await service.run(config)
+
+        # config는 BacktestConfig 인스턴스
+        assert isinstance(result.config, BacktestConfig)
+        assert result.config.strategy_path == "dummy.py"
+        assert result.config.symbols == ["005930"]
+        assert result.config.start_date == "2026-01-01"
+        assert result.config.end_date == "2026-12-31"
+
+        # datasets는 list이고 DatasetInfo 원소를 포함
+        assert isinstance(result.datasets, list)
+        assert len(result.datasets) == 1
+        assert isinstance(result.datasets[0], DatasetInfo)
+        assert result.datasets[0].symbol == "005930"
+        assert result.datasets[0].timeframe == "1d"
+        assert result.datasets[0].row_count > 0
+
 
 # ── Exceptions 테스트 ──────────────────────────────
 
@@ -696,7 +730,6 @@ class TestBacktestResultConfigFields:
 
     def test_result_to_dict_with_config(self):
         """config 설정된 결과의 to_dict() 검증."""
-        from ante.backtest.config import BacktestConfig
 
         cfg = BacktestConfig(
             strategy_path="strategies/ma_cross.py",
@@ -727,7 +760,6 @@ class TestBacktestResultConfigFields:
 
     def test_result_to_dict_with_datasets(self):
         """datasets 포함된 결과의 to_dict() 검증."""
-        from ante.backtest.config import DatasetInfo
 
         ds = DatasetInfo(
             symbol="005930",

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -404,7 +404,8 @@ class TestBacktestExecutor:
             strategy_cls=BuyAndHoldStrategy,
             data_provider=data_provider,
             initial_balance=10_000_000,
-            commission_rate=0.0,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
             slippage_rate=0.0,
         )
         result = await executor.run()
@@ -420,7 +421,8 @@ class TestBacktestExecutor:
             strategy_cls=BuySellStrategy,
             data_provider=data_provider,
             initial_balance=10_000_000,
-            commission_rate=0.0,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
             slippage_rate=0.0,
         )
         result = await executor.run()
@@ -433,7 +435,8 @@ class TestBacktestExecutor:
         executor = BacktestExecutor(
             strategy_cls=BuyAndHoldStrategy,
             data_provider=data_provider,
-            commission_rate=0.01,
+            buy_commission_rate=0.01,
+            sell_commission_rate=0.01,
             slippage_rate=0.0,
         )
         result = await executor.run()
@@ -444,7 +447,8 @@ class TestBacktestExecutor:
         executor = BacktestExecutor(
             strategy_cls=BuyAndHoldStrategy,
             data_provider=data_provider,
-            commission_rate=0.0,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
             slippage_rate=0.01,
         )
         result = await executor.run()
@@ -464,7 +468,8 @@ class TestBacktestExecutor:
         executor = BacktestExecutor(
             strategy_cls=BuySellStrategy,
             data_provider=data_provider,
-            commission_rate=0.0,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
             slippage_rate=0.0,
         )
         result = await executor.run()
@@ -530,12 +535,45 @@ class TestBacktestExecutor:
         executor = BacktestExecutor(
             strategy_cls=SellTooMuch,
             data_provider=data_provider,
-            commission_rate=0.0,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
             slippage_rate=0.0,
         )
         result = await executor.run()
         assert len(result.trades) == 2
         # 매도 거래는 실제로 실행됨 (보유량 5주만 매도)
+
+    async def test_executor_split_commission(self, data_provider):
+        """매수/매도 수수료율이 각각 독립 적용되는지 검증."""
+        data_provider.reset()
+        buy_rate = 0.001
+        sell_rate = 0.005
+        executor = BacktestExecutor(
+            strategy_cls=BuySellStrategy,
+            data_provider=data_provider,
+            initial_balance=10_000_000,
+            buy_commission_rate=buy_rate,
+            sell_commission_rate=sell_rate,
+            slippage_rate=0.0,
+        )
+        result = await executor.run()
+        assert len(result.trades) == 2
+
+        buy_trade = result.trades[0]
+        sell_trade = result.trades[1]
+        assert buy_trade.side == "buy"
+        assert sell_trade.side == "sell"
+
+        # 매수 수수료 = price * qty * buy_rate
+        expected_buy_comm = buy_trade.price * buy_trade.quantity * buy_rate
+        assert abs(buy_trade.commission - expected_buy_comm) < 0.01
+
+        # 매도 수수료 = price * qty * sell_rate
+        expected_sell_comm = sell_trade.price * sell_trade.quantity * sell_rate
+        assert abs(sell_trade.commission - expected_sell_comm) < 0.01
+
+        # 매수/매도 수수료율이 다르므로 수수료 비율도 다름
+        assert buy_trade.commission != sell_trade.commission
 
 
 # ── BacktestService 테스트 ─────────────────────────
@@ -547,15 +585,80 @@ class TestBacktestService:
         with pytest.raises(BacktestConfigError, match="strategy_path"):
             service._validate_config({"start_date": "2026-01-01"})
 
-    def test_validate_config_valid(self):
+    def test_validate_config_returns_backtest_config(self):
+        from ante.backtest.config import BacktestConfig
+
         service = BacktestService()
-        service._validate_config(
+        result = service._validate_config(
+            {
+                "strategy_path": "test.py",
+                "start_date": "2026-01-01",
+                "end_date": "2026-06-30",
+                "symbols": ["005930"],
+            }
+        )
+        assert isinstance(result, BacktestConfig)
+        assert result.strategy_path == "test.py"
+        assert result.start_date == "2026-01-01"
+        assert result.end_date == "2026-06-30"
+        assert result.symbols == ["005930"]
+
+    def test_validate_config_default_values(self):
+        """buy/sell commission 기본값 검증."""
+        service = BacktestService()
+        result = service._validate_config(
             {
                 "strategy_path": "test.py",
                 "start_date": "2026-01-01",
                 "end_date": "2026-06-30",
             }
         )
+        assert result.buy_commission_rate == 0.00015
+        assert result.sell_commission_rate == 0.00195
+        assert result.slippage_rate == 0.001
+        assert result.initial_balance == 10_000_000.0
+        assert result.timeframe == "1d"
+
+    def test_validate_config_commission_rate_backward_compat(self):
+        """기존 commission_rate 키가 buy_commission_rate로 매핑."""
+        service = BacktestService()
+        result = service._validate_config(
+            {
+                "strategy_path": "test.py",
+                "start_date": "2026-01-01",
+                "end_date": "2026-06-30",
+                "commission_rate": 0.005,
+            }
+        )
+        assert result.buy_commission_rate == 0.005
+        assert result.sell_commission_rate == 0.00195
+
+    def test_validate_config_data_path_backward_compat(self):
+        """data_path -> data_paths 하위호환."""
+        service = BacktestService(data_path="default/")
+        result = service._validate_config(
+            {
+                "strategy_path": "test.py",
+                "start_date": "2026-01-01",
+                "end_date": "2026-06-30",
+                "data_path": "custom/data/",
+            }
+        )
+        assert result.data_paths == ["custom/data/"]
+
+    def test_validate_config_data_paths_preferred(self):
+        """data_paths가 있으면 data_path보다 우선."""
+        service = BacktestService()
+        result = service._validate_config(
+            {
+                "strategy_path": "test.py",
+                "start_date": "2026-01-01",
+                "end_date": "2026-06-30",
+                "data_path": "ignored/",
+                "data_paths": ["a/", "b/"],
+            }
+        )
+        assert result.data_paths == ["a/", "b/"]
 
 
 # ── Exceptions 테스트 ──────────────────────────────
@@ -602,7 +705,8 @@ class TestBacktestResultConfigFields:
             start_date="2026-01-01",
             end_date="2026-06-30",
             initial_balance=10_000_000.0,
-            commission_rate=0.00015,
+            buy_commission_rate=0.00015,
+            sell_commission_rate=0.00195,
             slippage_rate=0.001,
         )
         result = BacktestResult(


### PR DESCRIPTION
## Summary
- `BacktestConfig.commission_rate`를 `buy_commission_rate`/`sell_commission_rate`로 분리 (KRX 기본값: 매수 0.015%, 매도 0.195%)
- `BacktestExecutor._execute_signal()`에서 매수/매도별 독립 수수료율 적용
- `BacktestService._validate_config()` 반환타입을 `None` -> `BacktestConfig`로 변경하고, `run()`에서 `result.config`과 `result.datasets`를 주입
- 기존 `commission_rate` 키 하위호환 유지 (buy_commission_rate로 매핑), `data_path` -> `data_paths` 하위호환 지원

## Test plan
- [x] 기존 48개 테스트 전부 통과 확인
- [x] `test_validate_config_returns_backtest_config` — 반환 타입 검증
- [x] `test_validate_config_default_values` — buy/sell commission 기본값
- [x] `test_validate_config_commission_rate_backward_compat` — 기존 commission_rate 키 호환
- [x] `test_validate_config_data_path_backward_compat` — data_path 하위호환
- [x] `test_validate_config_data_paths_preferred` — data_paths 우선
- [x] `test_executor_split_commission` — 매수/매도 수수료율 독립 적용 검증
- [x] ruff check + ruff format 통과

Refs #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)