### PR TITLE
epic/#728: BacktestResult 실행 설정(config/datasets) 포함

### DIFF
--- a/src/ante/backtest/__init__.py
+++ b/src/ante/backtest/__init__.py
@@ -1,5 +1,6 @@
 """Backtest Engine — 전략 검증 시뮬레이션."""
 
+from ante.backtest.config import BacktestConfig, DatasetInfo
 from ante.backtest.data_provider import BacktestDataProvider
 from ante.backtest.exceptions import (
     BacktestConfigError,
@@ -13,6 +14,7 @@ from ante.backtest.run_store import BacktestRun, BacktestRunStore
 from ante.backtest.service import BacktestService
 
 __all__ = [
+    "BacktestConfig",
     "BacktestConfigError",
     "BacktestDataError",
     "BacktestDataProvider",
@@ -23,5 +25,6 @@ __all__ = [
     "BacktestRunStore",
     "BacktestService",
     "BacktestTrade",
+    "DatasetInfo",
     "calculate_metrics",
 ]

--- a/src/ante/backtest/config.py
+++ b/src/ante/backtest/config.py
@@ -15,7 +15,8 @@ class BacktestConfig:
     start_date: str = ""
     end_date: str = ""
     initial_balance: float = 10_000_000.0
-    commission_rate: float = 0.00015
+    buy_commission_rate: float = 0.00015
+    sell_commission_rate: float = 0.00195
     slippage_rate: float = 0.001
     data_paths: list[str] = field(default_factory=lambda: ["data/"])
 

--- a/src/ante/backtest/config.py
+++ b/src/ante/backtest/config.py
@@ -1,0 +1,33 @@
+"""백테스트 실행 설정 및 데이터셋 메타정보."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class BacktestConfig:
+    """백테스트 실행 설정."""
+
+    strategy_path: str = ""
+    symbols: list[str] = field(default_factory=list)
+    timeframe: str = "1d"
+    start_date: str = ""
+    end_date: str = ""
+    initial_balance: float = 10_000_000.0
+    commission_rate: float = 0.00015
+    slippage_rate: float = 0.001
+    data_paths: list[str] = field(default_factory=lambda: ["data/"])
+
+
+@dataclass(frozen=True)
+class DatasetInfo:
+    """로드된 데이터셋 메타정보 (불변)."""
+
+    symbol: str = ""
+    timeframe: str = ""
+    row_count: int = 0
+    start_date: str = ""
+    end_date: str = ""
+    data_dir: str = ""
+    file_count: int = 0

--- a/src/ante/backtest/data_provider.py
+++ b/src/ante/backtest/data_provider.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import polars as pl
 
+from ante.backtest.config import DatasetInfo
 from ante.backtest.exceptions import BacktestDataError
 from ante.strategy.base import DataProvider
 
@@ -36,6 +37,7 @@ class BacktestDataProvider(DataProvider):
         self._end = end_date
         self._cache: dict[str, pl.DataFrame] = {}
         self._current_idx: int = 0
+        self._loaded_datasets: list[DatasetInfo] = []
 
     @property
     def current_idx(self) -> int:
@@ -49,11 +51,30 @@ class BacktestDataProvider(DataProvider):
     def end(self) -> str:
         return self._end
 
+    @property
+    def loaded_datasets(self) -> list[DatasetInfo]:
+        """로드된 데이터셋 메타정보 목록."""
+        return list(self._loaded_datasets)
+
     def load(self, symbol: str, timeframe: str) -> int:
         """데이터를 캐시에 로드. 로드된 행 수 반환."""
         key = f"{symbol}:{timeframe}"
         df = self._store.read(symbol, timeframe, start=self._start, end=self._end)
         self._cache[key] = df
+
+        data_dir = self._store.resolve_path(symbol, timeframe)
+        file_count = len(list(data_dir.glob("*.parquet"))) if data_dir.exists() else 0
+        info = DatasetInfo(
+            symbol=symbol,
+            timeframe=timeframe,
+            row_count=len(df),
+            start_date=str(df["timestamp"][0]) if len(df) > 0 else "",
+            end_date=str(df["timestamp"][-1]) if len(df) > 0 else "",
+            data_dir=str(data_dir),
+            file_count=file_count,
+        )
+        self._loaded_datasets.append(info)
+
         return len(df)
 
     async def get_ohlcv(
@@ -117,3 +138,4 @@ class BacktestDataProvider(DataProvider):
     def reset(self) -> None:
         """인덱스 초기화."""
         self._current_idx = 0
+        self._loaded_datasets.clear()

--- a/src/ante/backtest/executor.py
+++ b/src/ante/backtest/executor.py
@@ -27,13 +27,15 @@ class BacktestExecutor:
         strategy_cls: type[Strategy],
         data_provider: BacktestDataProvider,
         initial_balance: float = 10_000_000,
-        commission_rate: float = 0.00015,
+        buy_commission_rate: float = 0.00015,
+        sell_commission_rate: float = 0.00195,
         slippage_rate: float = 0.001,
     ) -> None:
         self._strategy_cls = strategy_cls
         self._data = data_provider
         self._initial_balance = initial_balance
-        self._commission_rate = commission_rate
+        self._buy_commission_rate = buy_commission_rate
+        self._sell_commission_rate = sell_commission_rate
         self._slippage_rate = slippage_rate
 
         self._balance = initial_balance
@@ -120,7 +122,12 @@ class BacktestExecutor:
         else:
             exec_price = price * (1 - self._slippage_rate)
 
-        commission = exec_price * signal.quantity * self._commission_rate
+        rate = (
+            self._buy_commission_rate
+            if signal.side == "buy"
+            else self._sell_commission_rate
+        )
+        commission = exec_price * signal.quantity * rate
 
         if signal.side == "buy":
             cost = exec_price * signal.quantity + commission

--- a/src/ante/backtest/result.py
+++ b/src/ante/backtest/result.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
+
+from ante.backtest.config import BacktestConfig, DatasetInfo
 
 
 @dataclass(frozen=True)
@@ -35,6 +37,8 @@ class BacktestResult:
     trades: list[BacktestTrade] = field(default_factory=list)
     equity_curve: list[dict] = field(default_factory=list)
     metrics: dict = field(default_factory=dict)
+    config: BacktestConfig = field(default_factory=BacktestConfig)
+    datasets: list[DatasetInfo] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         """결과를 딕셔너리로 변환."""
@@ -60,4 +64,6 @@ class BacktestResult:
                 }
                 for t in self.trades
             ],
+            "config": asdict(self.config),
+            "datasets": [asdict(d) for d in self.datasets],
         }

--- a/src/ante/backtest/service.py
+++ b/src/ante/backtest/service.py
@@ -8,6 +8,7 @@ import logging
 import sys
 from typing import TYPE_CHECKING, Any
 
+from ante.backtest.config import BacktestConfig
 from ante.backtest.data_provider import BacktestDataProvider
 from ante.backtest.exceptions import BacktestConfigError, BacktestError
 from ante.backtest.executor import BacktestExecutor
@@ -42,33 +43,36 @@ class BacktestService:
         progress_callback: Any | None = None,
     ) -> BacktestResult:
         """백테스트를 in-process로 실행."""
-        self._validate_config(config)
-
         from pathlib import Path
 
-        strategy_cls = StrategyLoader.load(Path(config["strategy_path"]))
+        validated = self._validate_config(config)
 
-        store = ParquetStore(base_path=config.get("data_path", self._data_path))
+        strategy_cls = StrategyLoader.load(Path(validated.strategy_path))
+
+        store = ParquetStore(
+            base_path=config.get("data_path", self._data_path),
+        )
         data_provider = BacktestDataProvider(
             store=store,
-            start_date=config["start_date"],
-            end_date=config["end_date"],
+            start_date=validated.start_date,
+            end_date=validated.end_date,
         )
 
-        symbols = config.get("symbols", [])
-        timeframe = config.get("timeframe", "1d")
-        for symbol in symbols:
-            data_provider.load(symbol, timeframe)
+        for symbol in validated.symbols:
+            data_provider.load(symbol, validated.timeframe)
 
         executor = BacktestExecutor(
             strategy_cls=strategy_cls,
             data_provider=data_provider,
-            initial_balance=config.get("initial_balance", 10_000_000),
-            commission_rate=config.get("commission_rate", 0.00015),
-            slippage_rate=config.get("slippage_rate", 0.001),
+            initial_balance=validated.initial_balance,
+            buy_commission_rate=validated.buy_commission_rate,
+            sell_commission_rate=validated.sell_commission_rate,
+            slippage_rate=validated.slippage_rate,
         )
 
         result = await executor.run(progress_callback=progress_callback)
+        result.config = validated
+        result.datasets = data_provider.loaded_datasets
 
         # BacktestCompleteEvent 발행
         await self._publish_complete_event(result, config)
@@ -118,10 +122,31 @@ class BacktestService:
         await self._eventbus.publish(event)
         logger.info("BacktestCompleteEvent 발행: %s", strategy_id)
 
-    def _validate_config(self, config: dict[str, Any]) -> None:
-        """설정 검증."""
+    def _validate_config(self, config: dict[str, Any]) -> BacktestConfig:
+        """설정 검증 후 BacktestConfig를 반환."""
         required = ["strategy_path", "start_date", "end_date"]
         missing = [k for k in required if k not in config]
         if missing:
             msg = f"Missing required config keys: {missing}"
             raise BacktestConfigError(msg)
+
+        data_paths = config.get(
+            "data_paths",
+            [config.get("data_path", self._data_path)],
+        )
+
+        return BacktestConfig(
+            strategy_path=config["strategy_path"],
+            symbols=config.get("symbols", []),
+            timeframe=config.get("timeframe", "1d"),
+            start_date=config.get("start_date", ""),
+            end_date=config.get("end_date", ""),
+            initial_balance=config.get("initial_balance", 10_000_000.0),
+            buy_commission_rate=config.get(
+                "buy_commission_rate",
+                config.get("commission_rate", 0.00015),
+            ),
+            sell_commission_rate=config.get("sell_commission_rate", 0.00195),
+            slippage_rate=config.get("slippage_rate", 0.001),
+            data_paths=data_paths,
+        )

--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -135,6 +135,16 @@ class ParquetStore:
         else:
             return self._base / data_type / timeframe / exchange / symbol
 
+    def resolve_path(
+        self,
+        symbol: str,
+        timeframe: str,
+        data_type: str = "ohlcv",
+        exchange: str = "KRX",
+    ) -> Path:
+        """데이터 경로를 해석한다. _resolve_path()의 public 인터페이스."""
+        return self._resolve_path(symbol, timeframe, data_type, exchange)
+
     def read(
         self,
         symbol: str,

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -169,6 +169,8 @@ class TestBacktestResult:
         assert d["strategy"] == "test_v1.0"
         assert d["total_return_pct"] == 5.0
         assert d["total_trades"] == 0
+        assert "config" in d
+        assert "datasets" in d
 
     def test_result_to_dict_with_trades(self):
         trade = BacktestTrade(
@@ -493,6 +495,8 @@ class TestBacktestExecutor:
         assert "strategy" in d
         assert "total_return_pct" in d
         assert "trades" in d
+        assert "config" in d
+        assert "datasets" in d
 
     async def test_insufficient_balance_skips_buy(self, data_provider):
         data_provider.reset()
@@ -565,3 +569,110 @@ class TestExceptions:
     def test_backtest_error_message(self):
         err = BacktestError("test error")
         assert str(err) == "test error"
+
+
+# ── BacktestResult config/datasets 필드 테스트 ────
+
+
+class TestBacktestResultConfigFields:
+    def test_result_default_config(self):
+        """기본 생성 시 config == BacktestConfig(), datasets == []."""
+        from ante.backtest.config import BacktestConfig  # noqa: F811
+
+        result = BacktestResult(
+            strategy_name="test",
+            strategy_version="1.0",
+            start_date="2026-01-01",
+            end_date="2026-06-30",
+            initial_balance=10_000_000,
+            final_balance=10_000_000,
+            total_return=0.0,
+        )
+        assert result.config == BacktestConfig()
+        assert result.datasets == []
+
+    def test_result_to_dict_with_config(self):
+        """config 설정된 결과의 to_dict() 검증."""
+        from ante.backtest.config import BacktestConfig
+
+        cfg = BacktestConfig(
+            strategy_path="strategies/ma_cross.py",
+            symbols=["005930"],
+            timeframe="1d",
+            start_date="2026-01-01",
+            end_date="2026-06-30",
+            initial_balance=10_000_000.0,
+            commission_rate=0.00015,
+            slippage_rate=0.001,
+        )
+        result = BacktestResult(
+            strategy_name="test",
+            strategy_version="1.0",
+            start_date="2026-01-01",
+            end_date="2026-06-30",
+            initial_balance=10_000_000,
+            final_balance=10_500_000,
+            total_return=5.0,
+            config=cfg,
+        )
+        d = result.to_dict()
+        assert d["config"]["strategy_path"] == "strategies/ma_cross.py"
+        assert d["config"]["symbols"] == ["005930"]
+        assert d["config"]["timeframe"] == "1d"
+        assert d["config"]["initial_balance"] == 10_000_000.0
+
+    def test_result_to_dict_with_datasets(self):
+        """datasets 포함된 결과의 to_dict() 검증."""
+        from ante.backtest.config import DatasetInfo
+
+        ds = DatasetInfo(
+            symbol="005930",
+            timeframe="1d",
+            row_count=1200,
+            start_date="2020-01-02",
+            end_date="2024-12-30",
+            data_dir="data/ohlcv/1d/KRX/005930",
+            file_count=60,
+        )
+        result = BacktestResult(
+            strategy_name="test",
+            strategy_version="1.0",
+            start_date="2026-01-01",
+            end_date="2026-06-30",
+            initial_balance=10_000_000,
+            final_balance=10_500_000,
+            total_return=5.0,
+            datasets=[ds],
+        )
+        d = result.to_dict()
+        assert len(d["datasets"]) == 1
+        assert d["datasets"][0]["symbol"] == "005930"
+        assert d["datasets"][0]["row_count"] == 1200
+        assert d["datasets"][0]["file_count"] == 60
+
+    def test_result_backward_compatible(self):
+        """기존 키들이 여전히 존재하는지 확인."""
+        result = BacktestResult(
+            strategy_name="test",
+            strategy_version="1.0",
+            start_date="2026-01-01",
+            end_date="2026-06-30",
+            initial_balance=10_000_000,
+            final_balance=10_500_000,
+            total_return=5.0,
+        )
+        d = result.to_dict()
+        expected_keys = {
+            "strategy",
+            "period",
+            "initial_balance",
+            "final_balance",
+            "total_return_pct",
+            "total_trades",
+            "metrics",
+            "equity_curve",
+            "trades",
+            "config",
+            "datasets",
+        }
+        assert set(d.keys()) == expected_keys

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from typing import Any
+from unittest.mock import patch
 
 import polars as pl
 import pytest
 
+from ante.backtest.config import BacktestConfig, DatasetInfo
 from ante.backtest.context import BacktestStrategyContext
 from ante.backtest.data_provider import BacktestDataProvider
 from ante.backtest.exceptions import (
@@ -266,7 +268,6 @@ class TestBacktestDataProvider:
 
     async def test_loaded_datasets_after_single_load(self, loaded_store):
         """load() 1회 호출 후 DatasetInfo 1건 기록."""
-        from ante.backtest.config import DatasetInfo
 
         provider = BacktestDataProvider(
             store=loaded_store, start_date="2026-01-01", end_date="2026-12-31"
@@ -404,7 +405,8 @@ class TestBacktestExecutor:
             strategy_cls=BuyAndHoldStrategy,
             data_provider=data_provider,
             initial_balance=10_000_000,
-            commission_rate=0.0,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
             slippage_rate=0.0,
         )
         result = await executor.run()
@@ -420,7 +422,8 @@ class TestBacktestExecutor:
             strategy_cls=BuySellStrategy,
             data_provider=data_provider,
             initial_balance=10_000_000,
-            commission_rate=0.0,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
             slippage_rate=0.0,
         )
         result = await executor.run()
@@ -433,7 +436,8 @@ class TestBacktestExecutor:
         executor = BacktestExecutor(
             strategy_cls=BuyAndHoldStrategy,
             data_provider=data_provider,
-            commission_rate=0.01,
+            buy_commission_rate=0.01,
+            sell_commission_rate=0.01,
             slippage_rate=0.0,
         )
         result = await executor.run()
@@ -444,7 +448,8 @@ class TestBacktestExecutor:
         executor = BacktestExecutor(
             strategy_cls=BuyAndHoldStrategy,
             data_provider=data_provider,
-            commission_rate=0.0,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
             slippage_rate=0.01,
         )
         result = await executor.run()
@@ -464,7 +469,8 @@ class TestBacktestExecutor:
         executor = BacktestExecutor(
             strategy_cls=BuySellStrategy,
             data_provider=data_provider,
-            commission_rate=0.0,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
             slippage_rate=0.0,
         )
         result = await executor.run()
@@ -530,12 +536,45 @@ class TestBacktestExecutor:
         executor = BacktestExecutor(
             strategy_cls=SellTooMuch,
             data_provider=data_provider,
-            commission_rate=0.0,
+            buy_commission_rate=0.0,
+            sell_commission_rate=0.0,
             slippage_rate=0.0,
         )
         result = await executor.run()
         assert len(result.trades) == 2
         # 매도 거래는 실제로 실행됨 (보유량 5주만 매도)
+
+    async def test_executor_split_commission(self, data_provider):
+        """매수/매도 수수료율이 각각 독립 적용되는지 검증."""
+        data_provider.reset()
+        buy_rate = 0.001
+        sell_rate = 0.005
+        executor = BacktestExecutor(
+            strategy_cls=BuySellStrategy,
+            data_provider=data_provider,
+            initial_balance=10_000_000,
+            buy_commission_rate=buy_rate,
+            sell_commission_rate=sell_rate,
+            slippage_rate=0.0,
+        )
+        result = await executor.run()
+        assert len(result.trades) == 2
+
+        buy_trade = result.trades[0]
+        sell_trade = result.trades[1]
+        assert buy_trade.side == "buy"
+        assert sell_trade.side == "sell"
+
+        # 매수 수수료 = price * qty * buy_rate
+        expected_buy_comm = buy_trade.price * buy_trade.quantity * buy_rate
+        assert abs(buy_trade.commission - expected_buy_comm) < 0.01
+
+        # 매도 수수료 = price * qty * sell_rate
+        expected_sell_comm = sell_trade.price * sell_trade.quantity * sell_rate
+        assert abs(sell_trade.commission - expected_sell_comm) < 0.01
+
+        # 매수/매도 수수료율이 다르므로 수수료 비율도 다름
+        assert buy_trade.commission != sell_trade.commission
 
 
 # ── BacktestService 테스트 ─────────────────────────
@@ -547,15 +586,113 @@ class TestBacktestService:
         with pytest.raises(BacktestConfigError, match="strategy_path"):
             service._validate_config({"start_date": "2026-01-01"})
 
-    def test_validate_config_valid(self):
+    def test_validate_config_returns_backtest_config(self):
+
         service = BacktestService()
-        service._validate_config(
+        result = service._validate_config(
+            {
+                "strategy_path": "test.py",
+                "start_date": "2026-01-01",
+                "end_date": "2026-06-30",
+                "symbols": ["005930"],
+            }
+        )
+        assert isinstance(result, BacktestConfig)
+        assert result.strategy_path == "test.py"
+        assert result.start_date == "2026-01-01"
+        assert result.end_date == "2026-06-30"
+        assert result.symbols == ["005930"]
+
+    def test_validate_config_default_values(self):
+        """buy/sell commission 기본값 검증."""
+        service = BacktestService()
+        result = service._validate_config(
             {
                 "strategy_path": "test.py",
                 "start_date": "2026-01-01",
                 "end_date": "2026-06-30",
             }
         )
+        assert result.buy_commission_rate == 0.00015
+        assert result.sell_commission_rate == 0.00195
+        assert result.slippage_rate == 0.001
+        assert result.initial_balance == 10_000_000.0
+        assert result.timeframe == "1d"
+
+    def test_validate_config_commission_rate_backward_compat(self):
+        """기존 commission_rate 키가 buy_commission_rate로 매핑."""
+        service = BacktestService()
+        result = service._validate_config(
+            {
+                "strategy_path": "test.py",
+                "start_date": "2026-01-01",
+                "end_date": "2026-06-30",
+                "commission_rate": 0.005,
+            }
+        )
+        assert result.buy_commission_rate == 0.005
+        assert result.sell_commission_rate == 0.00195
+
+    def test_validate_config_data_path_backward_compat(self):
+        """data_path -> data_paths 하위호환."""
+        service = BacktestService(data_path="default/")
+        result = service._validate_config(
+            {
+                "strategy_path": "test.py",
+                "start_date": "2026-01-01",
+                "end_date": "2026-06-30",
+                "data_path": "custom/data/",
+            }
+        )
+        assert result.data_paths == ["custom/data/"]
+
+    def test_validate_config_data_paths_preferred(self):
+        """data_paths가 있으면 data_path보다 우선."""
+        service = BacktestService()
+        result = service._validate_config(
+            {
+                "strategy_path": "test.py",
+                "start_date": "2026-01-01",
+                "end_date": "2026-06-30",
+                "data_path": "ignored/",
+                "data_paths": ["a/", "b/"],
+            }
+        )
+        assert result.data_paths == ["a/", "b/"]
+
+    async def test_run_injects_config_and_datasets(self, loaded_store, data_dir):
+        """run() 후 result.config=BacktestConfig, datasets=list[DatasetInfo]."""
+        service = BacktestService(data_path=str(data_dir))
+
+        config = {
+            "strategy_path": "dummy.py",
+            "start_date": "2026-01-01",
+            "end_date": "2026-12-31",
+            "symbols": ["005930"],
+            "timeframe": "1d",
+            "data_path": str(data_dir),
+        }
+
+        with patch(
+            "ante.backtest.service.StrategyLoader.load",
+            return_value=EmptyStrategy,
+        ):
+            result = await service.run(config)
+
+        # config는 BacktestConfig 인스턴스
+        assert isinstance(result.config, BacktestConfig)
+        assert result.config.strategy_path == "dummy.py"
+        assert result.config.symbols == ["005930"]
+        assert result.config.start_date == "2026-01-01"
+        assert result.config.end_date == "2026-12-31"
+
+        # datasets는 list이고 DatasetInfo 원소를 포함
+        assert isinstance(result.datasets, list)
+        assert len(result.datasets) == 1
+        assert isinstance(result.datasets[0], DatasetInfo)
+        assert result.datasets[0].symbol == "005930"
+        assert result.datasets[0].timeframe == "1d"
+        assert result.datasets[0].row_count > 0
 
 
 # ── Exceptions 테스트 ──────────────────────────────
@@ -593,7 +730,6 @@ class TestBacktestResultConfigFields:
 
     def test_result_to_dict_with_config(self):
         """config 설정된 결과의 to_dict() 검증."""
-        from ante.backtest.config import BacktestConfig
 
         cfg = BacktestConfig(
             strategy_path="strategies/ma_cross.py",
@@ -602,7 +738,8 @@ class TestBacktestResultConfigFields:
             start_date="2026-01-01",
             end_date="2026-06-30",
             initial_balance=10_000_000.0,
-            commission_rate=0.00015,
+            buy_commission_rate=0.00015,
+            sell_commission_rate=0.00195,
             slippage_rate=0.001,
         )
         result = BacktestResult(
@@ -623,7 +760,6 @@ class TestBacktestResultConfigFields:
 
     def test_result_to_dict_with_datasets(self):
         """datasets 포함된 결과의 to_dict() 검증."""
-        from ante.backtest.config import DatasetInfo
 
         ds = DatasetInfo(
             symbol="005930",

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -255,6 +255,65 @@ class TestBacktestDataProvider:
         df = await data_provider.get_indicator("005930", "sma", {"period": 5})
         assert len(df) > 0
 
+    async def test_loaded_datasets_empty_on_init(self, loaded_store):
+        """초기 상태에서 loaded_datasets는 빈 리스트."""
+        provider = BacktestDataProvider(
+            store=loaded_store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        assert provider.loaded_datasets == []
+
+    async def test_loaded_datasets_after_single_load(self, loaded_store):
+        """load() 1회 호출 후 DatasetInfo 1건 기록."""
+        from ante.backtest.config import DatasetInfo
+
+        provider = BacktestDataProvider(
+            store=loaded_store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+
+        datasets = provider.loaded_datasets
+        assert len(datasets) == 1
+        info = datasets[0]
+        assert isinstance(info, DatasetInfo)
+        assert info.symbol == "005930"
+        assert info.timeframe == "1d"
+        assert info.row_count == 10
+        assert info.start_date != ""
+        assert info.end_date != ""
+        assert info.file_count >= 1
+
+    async def test_loaded_datasets_after_multiple_loads(self, loaded_store):
+        """load() 여러 번 호출 시 DatasetInfo가 누적된다."""
+        # 두 번째 심볼 데이터도 적재
+        df = _make_ohlcv_df(symbol="000660", n=5, base_price=100000.0)
+        loaded_store.write("000660", "1d", df)
+
+        provider = BacktestDataProvider(
+            store=loaded_store, start_date="2026-01-01", end_date="2026-12-31"
+        )
+        provider.load("005930", "1d")
+        provider.load("000660", "1d")
+
+        datasets = provider.loaded_datasets
+        assert len(datasets) == 2
+        assert datasets[0].symbol == "005930"
+        assert datasets[0].row_count == 10
+        assert datasets[1].symbol == "000660"
+        assert datasets[1].row_count == 5
+
+    async def test_loaded_datasets_after_reset(self, data_provider):
+        """reset() 호출 시 loaded_datasets가 초기화된다."""
+        assert len(data_provider.loaded_datasets) >= 1
+        data_provider.reset()
+        assert data_provider.loaded_datasets == []
+
+    async def test_loaded_datasets_returns_copy(self, data_provider):
+        """loaded_datasets는 내부 리스트의 복사본을 반환한다."""
+        datasets1 = data_provider.loaded_datasets
+        datasets2 = data_provider.loaded_datasets
+        assert datasets1 == datasets2
+        assert datasets1 is not datasets2
+
 
 # ── BacktestStrategyContext 테스트 ─────────────────
 

--- a/tests/unit/test_backtest_config.py
+++ b/tests/unit/test_backtest_config.py
@@ -1,0 +1,114 @@
+"""BacktestConfig / DatasetInfo 단위 테스트."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from ante.backtest.config import BacktestConfig, DatasetInfo
+
+
+class TestBacktestConfig:
+    """BacktestConfig 데이터클래스 테스트."""
+
+    def test_default_values(self) -> None:
+        cfg = BacktestConfig()
+        assert cfg.strategy_path == ""
+        assert cfg.symbols == []
+        assert cfg.timeframe == "1d"
+        assert cfg.start_date == ""
+        assert cfg.end_date == ""
+        assert cfg.initial_balance == 10_000_000.0
+        assert cfg.commission_rate == 0.00015
+        assert cfg.slippage_rate == 0.001
+        assert cfg.data_paths == ["data/"]
+
+    def test_explicit_values(self) -> None:
+        cfg = BacktestConfig(
+            strategy_path="strategies/ma_cross.py",
+            symbols=["005930", "000660"],
+            timeframe="1h",
+            start_date="2025-01-01",
+            end_date="2025-12-31",
+            initial_balance=50_000_000.0,
+            commission_rate=0.0003,
+            slippage_rate=0.002,
+            data_paths=["data/kr/", "data/us/"],
+        )
+        assert cfg.strategy_path == "strategies/ma_cross.py"
+        assert cfg.symbols == ["005930", "000660"]
+        assert cfg.timeframe == "1h"
+        assert cfg.start_date == "2025-01-01"
+        assert cfg.end_date == "2025-12-31"
+        assert cfg.initial_balance == 50_000_000.0
+        assert cfg.commission_rate == 0.0003
+        assert cfg.slippage_rate == 0.002
+        assert cfg.data_paths == ["data/kr/", "data/us/"]
+
+    def test_data_paths_default_is_independent(self) -> None:
+        """각 인스턴스의 data_paths가 독립적인 리스트인지 확인."""
+        cfg1 = BacktestConfig()
+        cfg2 = BacktestConfig()
+        cfg1.data_paths.append("extra/")
+        assert cfg2.data_paths == ["data/"]
+
+    def test_symbols_default_is_independent(self) -> None:
+        """각 인스턴스의 symbols가 독립적인 리스트인지 확인."""
+        cfg1 = BacktestConfig()
+        cfg2 = BacktestConfig()
+        cfg1.symbols.append("005930")
+        assert cfg2.symbols == []
+
+
+class TestDatasetInfo:
+    """DatasetInfo 데이터클래스 테스트."""
+
+    def test_default_values(self) -> None:
+        info = DatasetInfo()
+        assert info.symbol == ""
+        assert info.timeframe == ""
+        assert info.row_count == 0
+        assert info.start_date == ""
+        assert info.end_date == ""
+        assert info.data_dir == ""
+        assert info.file_count == 0
+
+    def test_all_fields(self) -> None:
+        info = DatasetInfo(
+            symbol="005930",
+            timeframe="1d",
+            row_count=1200,
+            start_date="2020-01-02",
+            end_date="2024-12-30",
+            data_dir="data/ohlcv/1d/KRX/005930",
+            file_count=60,
+        )
+        assert info.symbol == "005930"
+        assert info.timeframe == "1d"
+        assert info.row_count == 1200
+        assert info.start_date == "2020-01-02"
+        assert info.end_date == "2024-12-30"
+        assert info.data_dir == "data/ohlcv/1d/KRX/005930"
+        assert info.file_count == 60
+
+    def test_frozen_immutability(self) -> None:
+        """frozen=True로 인해 필드 변경 시 FrozenInstanceError 발생."""
+        info = DatasetInfo(symbol="005930")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            info.symbol = "000660"  # type: ignore[misc]
+
+    def test_frozen_immutability_all_fields(self) -> None:
+        """모든 필드에 대해 일반 대입이 FrozenInstanceError를 발생시키는지 확인."""
+        info = DatasetInfo(
+            symbol="005930",
+            timeframe="1d",
+            row_count=100,
+            start_date="2025-01-01",
+            end_date="2025-12-31",
+            data_dir="data/",
+            file_count=5,
+        )
+        for f in dataclasses.fields(info):
+            with pytest.raises(dataclasses.FrozenInstanceError):
+                setattr(info, f.name, "changed")

--- a/tests/unit/test_backtest_config.py
+++ b/tests/unit/test_backtest_config.py
@@ -20,7 +20,8 @@ class TestBacktestConfig:
         assert cfg.start_date == ""
         assert cfg.end_date == ""
         assert cfg.initial_balance == 10_000_000.0
-        assert cfg.commission_rate == 0.00015
+        assert cfg.buy_commission_rate == 0.00015
+        assert cfg.sell_commission_rate == 0.00195
         assert cfg.slippage_rate == 0.001
         assert cfg.data_paths == ["data/"]
 
@@ -32,7 +33,8 @@ class TestBacktestConfig:
             start_date="2025-01-01",
             end_date="2025-12-31",
             initial_balance=50_000_000.0,
-            commission_rate=0.0003,
+            buy_commission_rate=0.0003,
+            sell_commission_rate=0.002,
             slippage_rate=0.002,
             data_paths=["data/kr/", "data/us/"],
         )
@@ -42,7 +44,8 @@ class TestBacktestConfig:
         assert cfg.start_date == "2025-01-01"
         assert cfg.end_date == "2025-12-31"
         assert cfg.initial_balance == 50_000_000.0
-        assert cfg.commission_rate == 0.0003
+        assert cfg.buy_commission_rate == 0.0003
+        assert cfg.sell_commission_rate == 0.002
         assert cfg.slippage_rate == 0.002
         assert cfg.data_paths == ["data/kr/", "data/us/"]
 

--- a/tests/unit/test_backtest_metrics.py
+++ b/tests/unit/test_backtest_metrics.py
@@ -364,3 +364,5 @@ class TestBacktestResultToDict:
         assert "equity_curve" in d
         assert len(d["equity_curve"]) == 1
         assert "metrics" in d
+        assert "config" in d
+        assert "datasets" in d

--- a/tests/unit/test_parquet_exchange.py
+++ b/tests/unit/test_parquet_exchange.py
@@ -81,6 +81,40 @@ class TestResolvePathWithExchange:
         assert "KRX" in path.parts
 
 
+class TestResolvePath:
+    """resolve_path() public 메서드 검증."""
+
+    def test_resolve_path_ohlcv(self, tmp_store: ParquetStore) -> None:
+        """OHLCV 경로: {base}/ohlcv/{timeframe}/{exchange}/{symbol}/"""
+        path = tmp_store.resolve_path("005930", "1d", "ohlcv", "KRX")
+        assert path == tmp_store.base_path / "ohlcv" / "1d" / "KRX" / "005930"
+
+    def test_resolve_path_fundamental(self, tmp_store: ParquetStore) -> None:
+        """Fundamental 경로: {base}/fundamental/{exchange}/{symbol}/"""
+        path = tmp_store.resolve_path("005930", "", "fundamental", "KRX")
+        assert path == tmp_store.base_path / "fundamental" / "KRX" / "005930"
+
+    def test_resolve_path_tick(self, tmp_store: ParquetStore) -> None:
+        """Tick 경로: {base}/tick/{exchange}/{symbol}/"""
+        path = tmp_store.resolve_path("005930", "", "tick", "KRX")
+        assert path == tmp_store.base_path / "tick" / "KRX" / "005930"
+
+    def test_resolve_path_different_exchange(self, tmp_store: ParquetStore) -> None:
+        """다른 거래소 경로 생성."""
+        path = tmp_store.resolve_path("AAPL", "1d", "ohlcv", "NYSE")
+        assert path == tmp_store.base_path / "ohlcv" / "1d" / "NYSE" / "AAPL"
+
+    def test_resolve_path_matches_private(self, tmp_store: ParquetStore) -> None:
+        """resolve_path()는 _resolve_path()와 동일한 결과를 반환한다."""
+        for args in [
+            ("005930", "1d", "ohlcv", "KRX"),
+            ("AAPL", "5m", "ohlcv", "NYSE"),
+            ("005930", "", "fundamental", "KRX"),
+            ("005930", "", "tick", "KRX"),
+        ]:
+            assert tmp_store.resolve_path(*args) == tmp_store._resolve_path(*args)
+
+
 class TestReadWriteWithExchange:
     """exchange 파라미터를 사용한 읽기/쓰기 검증."""
 


### PR DESCRIPTION
Refs #728

## 하위 이슈
- #722 BacktestConfig/DatasetInfo 데이터 클래스 생성
- #723 BacktestResult에 config/datasets 필드 추가
- #724 ParquetStore.resolve_path() public 노출
- #726 BacktestDataProvider에 loaded_datasets 이력 기록
- #727 BacktestService._validate_config() → BacktestConfig 통합 + 수수료 분리

## 변경 요약
- BacktestConfig/DatasetInfo 데이터 클래스 신규 생성
- BacktestResult에 config/datasets 필드 추가 + to_dict() 직렬화
- ParquetStore.resolve_path() public 노출
- BacktestDataProvider load() 시 DatasetInfo 자동 기록
- BacktestService._validate_config() → BacktestConfig 반환
- BacktestExecutor 매수/매도 수수료 분리 (buy_commission_rate/sell_commission_rate)
- 테스트 30건+ 추가/수정