### PR TITLE
chore(deps): add cryptography package for Fernet encryption #719

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "fastapi>=0.115",
     "uvicorn>=0.34",
     "websockets>=13.0",
+    "cryptography>=44.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- credentials 암호화(Fernet) 구현을 위해 `cryptography>=44.0` 패키지를 pyproject.toml dependencies에 추가

Refs #719

## Test plan
- [ ] `pip install -e .` 로 cryptography 패키지가 정상 설치되는지 확인
- [ ] Docker 이미지 빌드 시 cryptography가 포함되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)