### PR TITLE
fix(account): credentials Fernet 암호화 적용 #721

### DIFF
--- a/config/secrets.env.example
+++ b/config/secrets.env.example
@@ -2,6 +2,9 @@
 # 이 파일을 config/secrets.env 로 복사하여 실제 값을 입력하세요.
 # 절대 git에 커밋하지 마세요. (.gitignore에 등록됨)
 
+# DB 암호화 키 (Fernet, python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())" 로 생성)
+ANTE_DB_ENCRYPTION_KEY=
+
 # KIS Open API
 KIS_APP_KEY=your_app_key_here
 KIS_APP_SECRET=your_app_secret_here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "fastapi>=0.115",
     "uvicorn>=0.34",
     "websockets>=13.0",
+    "cryptography>=42.0",
 ]
 
 [project.scripts]

--- a/src/ante/account/crypto.py
+++ b/src/ante/account/crypto.py
@@ -1,0 +1,30 @@
+"""credentials Fernet 암호화."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from cryptography.fernet import Fernet
+
+
+def _get_fernet() -> Fernet:
+    """환경변수에서 Fernet 키를 읽어 인스턴스를 반환한다.
+
+    Raises:
+        RuntimeError: ANTE_DB_ENCRYPTION_KEY 환경변수가 설정되지 않은 경우.
+    """
+    key = os.environ.get("ANTE_DB_ENCRYPTION_KEY")
+    if not key:
+        raise RuntimeError("ANTE_DB_ENCRYPTION_KEY 환경변수가 설정되지 않았습니다.")
+    return Fernet(key.encode())
+
+
+def encrypt_credentials(credentials: dict) -> str:
+    """credentials dict를 Fernet 암호화된 문자열로 변환한다."""
+    return _get_fernet().encrypt(json.dumps(credentials).encode()).decode()
+
+
+def decrypt_credentials(encrypted: str) -> dict:
+    """Fernet 암호화된 문자열을 credentials dict로 복호화한다."""
+    return json.loads(_get_fernet().decrypt(encrypted.encode()).decode())

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
+from ante.account.crypto import decrypt_credentials, encrypt_credentials
 from ante.account.errors import (
     AccountAlreadyExistsError,
     AccountDeletedException,
@@ -148,7 +148,7 @@ class AccountService:
                 account.trading_hours_end,
                 account.trading_mode.value,
                 account.broker_type,
-                json.dumps(account.credentials),
+                encrypt_credentials(account.credentials),
                 float(account.buy_commission_rate),
                 float(account.sell_commission_rate),
                 account.status.value,
@@ -266,7 +266,7 @@ class AccountService:
                 account.trading_hours_end,
                 account.trading_mode.value,
                 account.broker_type,
-                json.dumps(account.credentials),
+                encrypt_credentials(account.credentials),
                 float(account.buy_commission_rate),
                 float(account.sell_commission_rate),
                 now.isoformat(),
@@ -503,9 +503,11 @@ class AccountService:
 
 def _row_to_account(row: dict[str, Any]) -> Account:
     """DB 행을 Account 객체로 변환."""
-    credentials = row.get("credentials", "{}")
-    if isinstance(credentials, str):
-        credentials = json.loads(credentials)
+    credentials_raw = row.get("credentials", "{}")
+    if isinstance(credentials_raw, str):
+        credentials = decrypt_credentials(credentials_raw)
+    else:
+        credentials = credentials_raw
 
     return Account(
         account_id=row["account_id"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,14 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
+def _set_encryption_key(monkeypatch):
+    """테스트용 Fernet 키 자동 설정."""
+    from cryptography.fernet import Fernet
+
+    monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+
+@pytest.fixture(autouse=True)
 async def _cleanup_tasks():
     """각 async 테스트 후 잔여 asyncio 태스크를 강제 정리.
 

--- a/tests/unit/test_account_crypto.py
+++ b/tests/unit/test_account_crypto.py
@@ -1,0 +1,100 @@
+"""credentials Fernet 암호화 단위 테스트."""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet, InvalidToken
+
+from ante.account.crypto import decrypt_credentials, encrypt_credentials
+
+
+class TestEncryptDecryptRoundtrip:
+    """암호화/복호화 라운드트립 테스트."""
+
+    def test_roundtrip_simple(self):
+        """간단한 credentials dict가 암호화 후 복호화하면 원본과 동일하다."""
+        original = {"app_key": "my-key", "app_secret": "my-secret"}
+        encrypted = encrypt_credentials(original)
+        decrypted = decrypt_credentials(encrypted)
+        assert decrypted == original
+
+    def test_roundtrip_empty(self):
+        """빈 dict도 암호화/복호화가 정상 동작한다."""
+        original: dict = {}
+        encrypted = encrypt_credentials(original)
+        decrypted = decrypt_credentials(encrypted)
+        assert decrypted == original
+
+    def test_roundtrip_nested(self):
+        """중첩 dict도 암호화/복호화가 정상 동작한다."""
+        original = {
+            "app_key": "key123",
+            "app_secret": "secret456",
+            "extra": {"nested": True, "count": 42},
+        }
+        encrypted = encrypt_credentials(original)
+        decrypted = decrypt_credentials(encrypted)
+        assert decrypted == original
+
+
+class TestEncryptOutput:
+    """암호화 출력 검증."""
+
+    def test_encrypt_returns_different_from_plaintext(self):
+        """암호화 결과가 평문 JSON과 다르다."""
+        original = {"app_key": "my-key", "app_secret": "my-secret"}
+        encrypted = encrypt_credentials(original)
+        assert encrypted != '{"app_key": "my-key", "app_secret": "my-secret"}'
+
+    def test_encrypt_returns_string(self):
+        """암호화 결과가 문자열이다."""
+        encrypted = encrypt_credentials({"key": "value"})
+        assert isinstance(encrypted, str)
+
+    def test_decrypt_returns_dict(self):
+        """복호화 결과가 dict이다."""
+        encrypted = encrypt_credentials({"key": "value"})
+        decrypted = decrypt_credentials(encrypted)
+        assert isinstance(decrypted, dict)
+
+
+class TestMissingKey:
+    """환경변수 미설정 시 에러 검증."""
+
+    def test_encrypt_missing_key_raises(self, monkeypatch):
+        """ANTE_DB_ENCRYPTION_KEY 미설정 시 RuntimeError."""
+        monkeypatch.delenv("ANTE_DB_ENCRYPTION_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="ANTE_DB_ENCRYPTION_KEY"):
+            encrypt_credentials({"key": "value"})
+
+    def test_decrypt_missing_key_raises(self, monkeypatch):
+        """ANTE_DB_ENCRYPTION_KEY 미설정 시 RuntimeError."""
+        monkeypatch.delenv("ANTE_DB_ENCRYPTION_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="ANTE_DB_ENCRYPTION_KEY"):
+            decrypt_credentials("some-encrypted-string")
+
+
+class TestWrongKey:
+    """다른 키로 복호화 시 에러 검증."""
+
+    def test_wrong_key_raises(self, monkeypatch):
+        """암호화 시 사용한 키와 다른 키로 복호화하면 InvalidToken."""
+        original = {"app_key": "my-key"}
+        encrypted = encrypt_credentials(original)
+
+        # 다른 키로 변경
+        new_key = Fernet.generate_key().decode()
+        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", new_key)
+
+        with pytest.raises(InvalidToken):
+            decrypt_credentials(encrypted)
+
+
+class TestEmptyKey:
+    """빈 키 처리."""
+
+    def test_empty_key_raises(self, monkeypatch):
+        """빈 문자열 키는 RuntimeError."""
+        monkeypatch.setenv("ANTE_DB_ENCRYPTION_KEY", "")
+        with pytest.raises(RuntimeError, match="ANTE_DB_ENCRYPTION_KEY"):
+            encrypt_credentials({"key": "value"})


### PR DESCRIPTION
## Summary
- `src/ante/account/crypto.py` 신규 모듈: `encrypt_credentials` / `decrypt_credentials` (Fernet 대칭 암호화)
- `service.py`의 `create()`, `update()` 시 `json.dumps` -> `encrypt_credentials`, `_row_to_account()` 시 `json.loads` -> `decrypt_credentials`로 교체
- `tests/conftest.py`에 autouse fixture로 테스트용 Fernet 키 자동 설정 (모든 테스트에 적용)
- `tests/unit/test_account_crypto.py` 신규: roundtrip, 출력 검증, 키 누락/불일치 에러 등 10개 테스트
- `pyproject.toml`에 `cryptography>=42.0` 의존성 추가
- `config/secrets.env.example`에 `ANTE_DB_ENCRYPTION_KEY` 항목 추가

## Design decisions
- 하위 호환 없음: 기존 평문 데이터 마이그레이션 미포함 (이슈에서 명시적 결정)
- fallback 없음: `ANTE_DB_ENCRYPTION_KEY` 미설정 시 RuntimeError

## Test plan
- [x] `test_account_crypto.py` 10개 테스트 통과
- [x] 기존 `test_account.py` 27개 테스트 통과 (회귀 없음)
- [x] ruff check / ruff format 통과

Refs #721