### PR TITLE
chore(ci): CI/QA에 ANTE_DB_ENCRYPTION_KEY 환경변수 추가 #721

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,6 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Run unit tests
+        env:
+          ANTE_DB_ENCRYPTION_KEY: "sm4fkbGXHVNKjw2OvQIrQX5g9qdRGqNKST8pFixdNPk="
         run: pytest tests/unit/ -v -x

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -11,6 +11,7 @@ services:
       - TELEGRAM_BOT_TOKEN=dummy
       - TELEGRAM_CHAT_ID=dummy
       - QA_ADMIN_PASSWORD=qa-password
+      - ANTE_DB_ENCRYPTION_KEY=sm4fkbGXHVNKjw2OvQIrQX5g9qdRGqNKST8pFixdNPk=
     volumes:
       - qa-db:/app/db
       - qa-data:/app/data


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml` test job에 `ANTE_DB_ENCRYPTION_KEY` 환경변수 추가 (테스트용 Fernet 키)
- `docker-compose.qa.yml`에 `ANTE_DB_ENCRYPTION_KEY` 환경변수 추가
- #721 완료 조건 중 PR #740에서 누락된 CI/QA 인프라 설정 보완

## Test plan

- [ ] CI 파이프라인에서 `ANTE_DB_ENCRYPTION_KEY` 환경변수가 정상 로드되는지 확인
- [ ] `tests/unit/test_account_crypto.py` 전체 통과 확인
- [ ] QA docker-compose 환경에서 계좌 CRUD 동작 확인

Refs #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)