### PR TITLE
fix(trade): force_update() 후 인메모리 캐시 갱신 누락 수정

### DIFF
--- a/src/ante/trade/position.py
+++ b/src/ante/trade/position.py
@@ -220,6 +220,8 @@ class PositionHistory:
                  updated_at = excluded.updated_at""",
             (bot_id, symbol, quantity, avg_entry_price),
         )
+        # 인메모리 캐시 갱신
+        self._update_cache(bot_id, symbol, quantity, avg_entry_price)
 
     async def _get_current(self, bot_id: str, symbol: str) -> dict:
         """현재 포지션 조회. 없으면 빈 포지션 반환."""

--- a/tests/unit/test_trade.py
+++ b/tests/unit/test_trade.py
@@ -500,6 +500,29 @@ class TestPositionHistory:
         assert pos["quantity"] == 100
         assert pos["avg_entry_price"] == 45000
 
+    async def test_force_update_syncs_cache(self, position_history):
+        """force_update() 후 get_positions_sync()가 갱신된 값을 반환."""
+        await position_history.force_update(
+            bot_id="bot1",
+            symbol="005930",
+            quantity=50,
+            avg_entry_price=60000,
+        )
+
+        cached = position_history.get_positions_sync("bot1")
+        assert len(cached) == 1
+        assert cached[0].quantity == 50
+        assert cached[0].avg_entry_price == 60000
+
+        # 수량 0으로 갱신하면 캐시에서 제거
+        await position_history.force_update(
+            bot_id="bot1",
+            symbol="005930",
+            quantity=0,
+            avg_entry_price=0,
+        )
+        assert position_history.get_positions_sync("bot1") == []
+
     async def test_get_history(self, position_history):
         """포지션 변동 이력 조회."""
         buy = TradeRecord(


### PR DESCRIPTION
## Summary
- `PositionHistory.force_update()`가 DB만 갱신하고 `_update_cache()`를 호출하지 않아, Reconciler 보정 후 `get_positions_sync()`가 이전 캐시 값을 반환하던 버그 수정
- `force_update()` 마지막에 `_update_cache(bot_id, symbol, quantity, avg_entry_price)` 호출 추가
- 단위 테스트: `force_update()` 후 캐시 동기화 및 수량 0 시 캐시 제거 검증

## Test plan
- [x] `test_force_update` 기존 테스트 통과
- [x] `test_force_update_syncs_cache` 신규 테스트 통과 — force_update 후 get_positions_sync 반환값 검증
- [x] ruff check / ruff format 통과

Refs #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)