### PR TITLE
fix(treasury): total_asset 산식을 스펙대로 수정 #743

### DIFF
--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -1076,7 +1076,7 @@ class Treasury:
             (
                 self._account_id,
                 snapshot_date,
-                summary.get("total_evaluation", 0.0),
+                summary.get("ante_eval_amount", 0.0) + summary.get("unallocated", 0.0),
                 summary.get("ante_eval_amount", 0.0),
                 summary.get("ante_purchase_amount", 0.0),
                 summary.get("unallocated", 0.0),
@@ -1122,7 +1122,7 @@ class Treasury:
             (
                 self._account_id,
                 snapshot_date,
-                summary.get("total_evaluation", 0.0),
+                summary.get("ante_eval_amount", 0.0) + summary.get("unallocated", 0.0),
                 summary.get("ante_eval_amount", 0.0),
                 summary.get("ante_purchase_amount", 0.0),
                 summary.get("unallocated", 0.0),

--- a/tests/unit/test_daily_snapshot.py
+++ b/tests/unit/test_daily_snapshot.py
@@ -142,6 +142,28 @@ class TestTakeSnapshot:
         assert snap["unallocated"] == 7_000_000.0
         assert snap["bot_count"] == 1
 
+    async def test_total_asset_equals_ante_eval_plus_unallocated(self, treasury):
+        """total_asset은 ante_eval_amount + unallocated 이어야 한다 (#743)."""
+        await treasury.allocate("bot1", 3_000_000.0)
+
+        event = _make_event()
+        await treasury.take_snapshot(event)
+
+        snap = await treasury.get_daily_snapshot("2026-03-21")
+        assert snap is not None
+        expected = snap["ante_eval_amount"] + snap["unallocated"]
+        assert snap["total_asset"] == expected
+
+    async def test_save_daily_snapshot_total_asset_formula(self, treasury):
+        """save_daily_snapshot도 total_asset = ante_eval_amount + unallocated (#743)."""
+        await treasury.allocate("bot1", 2_000_000.0)
+        await treasury.save_daily_snapshot("2026-03-21")
+
+        snap = await treasury.get_daily_snapshot("2026-03-21")
+        assert snap is not None
+        expected = snap["ante_eval_amount"] + snap["unallocated"]
+        assert snap["total_asset"] == expected
+
     async def test_take_snapshot_ignores_non_daily_report_event(self, treasury):
         """DailyReportEvent가 아닌 이벤트는 무시한다."""
         await treasury.take_snapshot("not an event")


### PR DESCRIPTION
## Summary
- `save_daily_snapshot`과 `take_snapshot`에서 `total_asset` 값을 `summary["total_evaluation"]`(외부 종목 포함) 대신 `summary["ante_eval_amount"] + summary["unallocated"]`로 변경
- 두 새 테스트 추가: `total_asset == ante_eval_amount + unallocated` 산식 검증 (take_snapshot, save_daily_snapshot 각각)

## Test plan
- [x] 기존 16개 스냅샷 테스트 전체 통과
- [x] ruff check / ruff format 통과

Refs #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)