### PR TITLE
fix(account): update()에서 미인식 필드 전달 시 ValueError 발생 #748

### DIFF
--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -241,6 +241,9 @@ class AccountService:
             "buy_commission_rate",
             "sell_commission_rate",
         }
+        unrecognized = set(fields.keys()) - updatable - self.IMMUTABLE_FIELDS
+        if unrecognized:
+            raise ValueError(f"인식할 수 없는 필드입니다: {sorted(unrecognized)}")
         for key, value in fields.items():
             if key not in updatable:
                 continue

--- a/tests/unit/test_account_immutable_fields.py
+++ b/tests/unit/test_account_immutable_fields.py
@@ -112,3 +112,30 @@ async def test_update_mutable_with_immutable_raises(service):
     await service.create(_make_account())
     with pytest.raises(AccountImmutableFieldError, match="exchange"):
         await service.update("test", name="새이름", exchange="NYSE")
+
+
+# ── 미인식 필드 거부 ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_unrecognized_field_raises(service):
+    """updatable에도 IMMUTABLE_FIELDS에도 없는 필드는 ValueError 발생."""
+    await service.create(_make_account())
+    with pytest.raises(ValueError, match="foo"):
+        await service.update("test", foo="bar")
+
+
+@pytest.mark.asyncio
+async def test_update_multiple_unrecognized_fields_raises(service):
+    """여러 미인식 필드 전달 시 모든 필드명이 에러 메시지에 포함."""
+    await service.create(_make_account())
+    with pytest.raises(ValueError, match="abc.*xyz|xyz.*abc"):
+        await service.update("test", abc="1", xyz="2")
+
+
+@pytest.mark.asyncio
+async def test_update_unrecognized_with_valid_raises(service):
+    """유효한 필드와 미인식 필드를 함께 보내면 ValueError 발생."""
+    await service.create(_make_account())
+    with pytest.raises(ValueError, match="unknown"):
+        await service.update("test", name="새이름", unknown="value")


### PR DESCRIPTION
## Summary
- `AccountService.update()`에서 `updatable`에도 `IMMUTABLE_FIELDS`에도 속하지 않는 필드를 전달하면 `ValueError`를 발생시키도록 수정
- 미인식 필드 거부 테스트 3건 추가 (단일/복수/유효+미인식 혼합)

## Test plan
- [x] `test_update_unrecognized_field_raises` — 단일 미인식 필드 시 ValueError
- [x] `test_update_multiple_unrecognized_fields_raises` — 복수 미인식 필드 시 ValueError
- [x] `test_update_unrecognized_with_valid_raises` — 유효 필드와 미인식 필드 혼합 시 ValueError
- [x] 기존 account 테스트 78건 전체 통과

Refs #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)