### PR TITLE
fix(event): BotRestartExhaustedEvent에 account_id 필드 추가

### DIFF
--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -559,7 +559,9 @@ class BotManager:
         count = self._restart_counts.get(event.bot_id, 0)
 
         if count >= config.max_restart_attempts:
-            await self._on_restart_exhausted(event.bot_id, count, event.error_message)
+            await self._on_restart_exhausted(
+                event.bot_id, config.account_id, count, event.error_message
+            )
             return
 
         self._restart_counts[event.bot_id] = count + 1
@@ -639,7 +641,7 @@ class BotManager:
         self._restart_reset_tasks.pop(bot_id, None)
 
     async def _on_restart_exhausted(
-        self, bot_id: str, attempts: int, last_error: str
+        self, bot_id: str, account_id: str, attempts: int, last_error: str
     ) -> None:
         """재시작 한도 소진 시 이벤트 + 알림 발행."""
         from ante.eventbus.events import BotRestartExhaustedEvent, NotificationEvent
@@ -652,6 +654,7 @@ class BotManager:
         await self._eventbus.publish(
             BotRestartExhaustedEvent(
                 bot_id=bot_id,
+                account_id=account_id,
                 restart_attempts=attempts,
                 last_error=last_error,
             )

--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -266,6 +266,7 @@ class BotRestartExhaustedEvent(Event):
     """BotManager → EventBus: 봇 재시작 한도 소진."""
 
     bot_id: str = ""
+    account_id: str = ""
     restart_attempts: int = 0
     last_error: str = ""
 

--- a/tests/unit/test_bot_restart.py
+++ b/tests/unit/test_bot_restart.py
@@ -135,6 +135,7 @@ class TestBotAutoRestart:
 
         assert len(exhausted) == 1
         assert exhausted[0].bot_id == "b1"
+        assert exhausted[0].account_id == "test"
         assert exhausted[0].restart_attempts == 2
 
     async def test_restart_count_increments(self, manager, eventbus):
@@ -254,9 +255,16 @@ class TestBotRestartExhaustedEvent:
         """이벤트 필드 확인."""
         event = BotRestartExhaustedEvent(
             bot_id="b1",
+            account_id="acc-1",
             restart_attempts=3,
             last_error="connection lost",
         )
         assert event.bot_id == "b1"
+        assert event.account_id == "acc-1"
         assert event.restart_attempts == 3
         assert event.last_error == "connection lost"
+
+    def test_account_id_default_empty(self):
+        """account_id 기본값은 빈 문자열."""
+        event = BotRestartExhaustedEvent(bot_id="b1")
+        assert event.account_id == ""

--- a/tests/unit/test_module_notification_events.py
+++ b/tests/unit/test_module_notification_events.py
@@ -93,7 +93,7 @@ class TestBotManagerNotifications:
         self, manager, eventbus, notifications
     ):
         """재시작 한도 소진 시 NotificationEvent 발행."""
-        await manager._on_restart_exhausted("bot-1", 3, "Crash")
+        await manager._on_restart_exhausted("bot-1", "account-1", 3, "Crash")
         assert len(notifications) == 1
         assert notifications[0].level == "error"
         assert notifications[0].category == "bot"


### PR DESCRIPTION
## Summary
- `BotRestartExhaustedEvent`에 스펙에 정의된 `account_id: str = ""` 필드 추가
- `BotManager._on_restart_exhausted` 발행처에서 `BotConfig.account_id`를 전달하도록 수정
- 기존 테스트에 `account_id` 검증 추가 및 기본값 테스트 케이스 신규 작성

Refs #749

## Test plan
- [x] `TestBotRestartExhaustedEvent::test_event_fields` - account_id 포함 필드 검증
- [x] `TestBotRestartExhaustedEvent::test_account_id_default_empty` - 기본값 빈 문자열
- [x] `TestBotAutoRestart::test_restart_exhausted` - 통합: 이벤트 발행 시 account_id 전달 확인
- [x] 전체 12개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)