### PR TITLE
fix(treasury): DailyReportEvent 구독 priority 70→80 통일 #751

### DIFF
--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -233,7 +233,7 @@ class Treasury:
         )
         self._eventbus.subscribe(OrderFailedEvent, self._on_order_failed, priority=80)
         self._eventbus.subscribe(BotStoppedEvent, self._on_bot_stopped, priority=80)
-        self._eventbus.subscribe(DailyReportEvent, self._on_daily_report, priority=70)
+        self._eventbus.subscribe(DailyReportEvent, self._on_daily_report, priority=80)
 
     # -- 계좌 잔고 -----------------------------------------------
 

--- a/tests/unit/test_daily_snapshot.py
+++ b/tests/unit/test_daily_snapshot.py
@@ -258,7 +258,7 @@ class TestDailyReportSubscription:
 class TestDailyReportSubscriptionPriority:
     async def test_daily_report_priority_is_80(self, treasury, eventbus):
         """Treasury의 DailyReportEvent 구독 priority는 80이어야 한다 (스펙 일치)."""
-        handlers = eventbus._handlers.get(DailyReportEvent, [])
+        handlers = eventbus.get_handlers(DailyReportEvent)
         assert len(handlers) >= 1
         for priority, _handler in handlers:
             assert priority == 80, (

--- a/tests/unit/test_daily_snapshot.py
+++ b/tests/unit/test_daily_snapshot.py
@@ -252,6 +252,20 @@ class TestDailyReportSubscription:
         assert snap is None
 
 
+# -- DailyReportEvent 구독 priority 검증 (#751) ----------------
+
+
+class TestDailyReportSubscriptionPriority:
+    async def test_daily_report_priority_is_80(self, treasury, eventbus):
+        """Treasury의 DailyReportEvent 구독 priority는 80이어야 한다 (스펙 일치)."""
+        handlers = eventbus._handlers.get(DailyReportEvent, [])
+        assert len(handlers) >= 1
+        for priority, _handler in handlers:
+            assert priority == 80, (
+                f"DailyReportEvent handler priority should be 80, got {priority}"
+            )
+
+
 # -- save_daily_snapshot (하위 호환) ----------------------------
 
 


### PR DESCRIPTION
## Summary
- Treasury의 DailyReportEvent 구독 priority를 70에서 80으로 수정하여 스펙과 일치시킴
- priority 80 검증 단위 테스트 추가

## Test plan
- [x] `test_daily_report_priority_is_80` — DailyReportEvent 구독 priority가 80인지 검증
- [x] 기존 15개 테스트 전체 통과
- [x] ruff check / ruff format 통과

Refs #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)