### PR TITLE
fix(member): register/update_scopes master 권한 검증 추가

### DIFF
--- a/src/ante/member/__init__.py
+++ b/src/ante/member/__init__.py
@@ -1,6 +1,7 @@
 """Member — 멤버 등록·인증·관리."""
 
 from ante.member.auth_service import AuthService
+from ante.member.errors import MemberError, PermissionDeniedError
 from ante.member.models import Member, MemberRole, MemberStatus, MemberType
 from ante.member.recovery_key_manager import RecoveryKeyManager
 from ante.member.service import MemberService
@@ -9,10 +10,12 @@ from ante.member.token_manager import TokenManager
 __all__ = [
     "AuthService",
     "Member",
+    "MemberError",
     "MemberRole",
     "MemberService",
     "MemberStatus",
     "MemberType",
+    "PermissionDeniedError",
     "RecoveryKeyManager",
     "TokenManager",
 ]

--- a/src/ante/member/errors.py
+++ b/src/ante/member/errors.py
@@ -1,0 +1,9 @@
+"""Member 모듈 예외."""
+
+
+class MemberError(Exception):
+    """Member 기본 예외."""
+
+
+class PermissionDeniedError(MemberError):
+    """권한 부족 — master만 수행 가능한 작업을 비-master가 시도."""

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -343,6 +343,8 @@ class MemberService:
         registered_by: str = "",
     ) -> tuple[Member, str]:
         """멤버 등록 + 토큰 반환."""
+        if registered_by:
+            await self._assert_master(registered_by, "register")
         self._assert_type_role(member_type, role)
 
         existing = await self.get(member_id)
@@ -579,6 +581,8 @@ class MemberService:
         self, member_id: str, scopes: list[str], updated_by: str = ""
     ) -> Member:
         """권한 범위 변경."""
+        if updated_by:
+            await self._assert_master(updated_by, "update_scopes")
         member = await self._get_or_raise(member_id)
         self._assert_active(member, "update_scopes")
 
@@ -601,6 +605,16 @@ class MemberService:
         )
 
     # ── 내부 헬퍼 ──────────────────────────────────────
+
+    async def _assert_master(self, caller_id: str, action: str) -> None:
+        """호출자가 master인지 검증."""
+        from ante.member.errors import PermissionDeniedError
+
+        caller = await self.get(caller_id)
+        if not caller or caller.role != MemberRole.MASTER:
+            raise PermissionDeniedError(
+                f"'{action}'은(는) master만 수행할 수 있습니다."
+            )
 
     async def _get_or_raise(self, member_id: str) -> Member:
         """멤버 조회. 없으면 ValueError."""

--- a/tests/unit/test_member.py
+++ b/tests/unit/test_member.py
@@ -158,6 +158,7 @@ class TestBootstrapMaster:
 
 class TestRegister:
     async def test_register_agent(self, service):
+        await service.bootstrap_master("owner", "pass123")
         member, token = await service.register(
             member_id="agent-01",
             member_type=MemberType.AGENT,
@@ -212,6 +213,7 @@ class TestAuthenticate:
 
     async def test_authenticate_type_mismatch(self, service, db):
         """agent 토큰으로 human 멤버를 인증할 수 없다."""
+        await service.bootstrap_master("owner", "pass123")
         _, token = await service.register(
             "human-01", MemberType.HUMAN, registered_by="owner"
         )
@@ -356,6 +358,7 @@ class TestPasswordManagement:
 
 class TestScopes:
     async def test_update_scopes(self, service):
+        await service.bootstrap_master("owner", "pass123")
         await service.register("agent-01", MemberType.AGENT)
         m = await service.update_scopes(
             "agent-01", ["strategy:write", "data:read"], updated_by="owner"
@@ -364,6 +367,82 @@ class TestScopes:
         # DB에 반영 확인
         fetched = await service.get("agent-01")
         assert fetched.scopes == ["strategy:write", "data:read"]
+
+
+class TestMasterPermissionCheck:
+    """register/update_scopes에서 master 권한 검증 테스트."""
+
+    async def test_register_by_agent_fails(self, service):
+        """agent 역할의 멤버가 register 호출 시 PermissionDeniedError."""
+        from ante.member.errors import PermissionDeniedError
+
+        await service.register("agent-caller", MemberType.AGENT)
+        with pytest.raises(PermissionDeniedError, match="master만"):
+            await service.register(
+                "new-agent", MemberType.AGENT, registered_by="agent-caller"
+            )
+
+    async def test_register_by_default_human_fails(self, service):
+        """default 역할의 human이 register 호출 시 PermissionDeniedError."""
+        from ante.member.errors import PermissionDeniedError
+
+        await service.bootstrap_master("owner", "pass123")
+        await service.register(
+            "human-default",
+            MemberType.HUMAN,
+            role=MemberRole.DEFAULT,
+            registered_by="owner",
+        )
+        with pytest.raises(PermissionDeniedError, match="master만"):
+            await service.register(
+                "new-agent", MemberType.AGENT, registered_by="human-default"
+            )
+
+    async def test_register_by_master_succeeds(self, service):
+        """master 역할이면 register 정상 수행."""
+        await service.bootstrap_master("owner", "pass123")
+        member, token = await service.register(
+            "agent-01", MemberType.AGENT, registered_by="owner"
+        )
+        assert member.member_id == "agent-01"
+
+    async def test_register_by_nonexistent_caller_fails(self, service):
+        """존재하지 않는 호출자로 register 호출 시 PermissionDeniedError."""
+        from ante.member.errors import PermissionDeniedError
+
+        with pytest.raises(PermissionDeniedError, match="master만"):
+            await service.register("new-agent", MemberType.AGENT, registered_by="ghost")
+
+    async def test_register_without_caller_succeeds(self, service):
+        """registered_by가 빈 문자열(내부 호출)이면 검증 스킵."""
+        member, token = await service.register("agent-01", MemberType.AGENT)
+        assert member.member_id == "agent-01"
+
+    async def test_update_scopes_by_agent_fails(self, service):
+        """agent 역할의 멤버가 update_scopes 호출 시 PermissionDeniedError."""
+        from ante.member.errors import PermissionDeniedError
+
+        await service.register("agent-01", MemberType.AGENT)
+        await service.register("agent-caller", MemberType.AGENT)
+        with pytest.raises(PermissionDeniedError, match="master만"):
+            await service.update_scopes(
+                "agent-01", ["strategy:write"], updated_by="agent-caller"
+            )
+
+    async def test_update_scopes_by_master_succeeds(self, service):
+        """master 역할이면 update_scopes 정상 수행."""
+        await service.bootstrap_master("owner", "pass123")
+        await service.register("agent-01", MemberType.AGENT)
+        m = await service.update_scopes(
+            "agent-01", ["strategy:write"], updated_by="owner"
+        )
+        assert m.scopes == ["strategy:write"]
+
+    async def test_update_scopes_without_caller_succeeds(self, service):
+        """updated_by가 빈 문자열(내부 호출)이면 검증 스킵."""
+        await service.register("agent-01", MemberType.AGENT)
+        m = await service.update_scopes("agent-01", ["data:read"])
+        assert m.scopes == ["data:read"]
 
 
 class TestList:

--- a/tests/unit/test_token_expiry.py
+++ b/tests/unit/test_token_expiry.py
@@ -157,8 +157,15 @@ class TestTokenExpiryOnRegister:
     @pytest.mark.asyncio
     async def test_register_sets_expiry(self):
         """멤버 등록 시 토큰 만료 시각 설정."""
+        master_row = _make_member_row(
+            member_id="admin",
+            member_type=MemberType.HUMAN,
+        )
+        master_row["role"] = "master"
+
         db = AsyncMock()
-        db.fetch_one = AsyncMock(return_value=None)
+        db.fetch_one = AsyncMock(side_effect=[master_row, None])
+        db.fetch_all = AsyncMock(return_value=[])
         db.execute = AsyncMock()
         eventbus = MagicMock()
         eventbus.publish = AsyncMock()


### PR DESCRIPTION
## Summary
- `register()`와 `update_scopes()`에서 `registered_by`/`updated_by`가 master인지 검증하는 가드를 추가하여 비-master 멤버의 무단 등록 및 권한 변경을 차단
- `PermissionDeniedError` 에러 클래스를 `member/errors.py`에 신설
- 내부 호출(빈 문자열)은 기존 동작을 유지하여 bootstrap 등 시스템 호출에 영향 없음

## Test plan
- [x] agent role로 register 호출 시 PermissionDeniedError 발생 확인
- [x] default human role로 register 호출 시 PermissionDeniedError 발생 확인
- [x] master role로 register 정상 수행 확인
- [x] 존재하지 않는 caller로 register 호출 시 PermissionDeniedError 확인
- [x] registered_by 빈 문자열(내부 호출)로 register 정상 수행 확인
- [x] agent role로 update_scopes 호출 시 PermissionDeniedError 발생 확인
- [x] master role로 update_scopes 정상 수행 확인
- [x] updated_by 빈 문자열(내부 호출)로 update_scopes 정상 수행 확인
- [x] 기존 테스트 75건 + API 테스트 17건 전부 통과

Refs #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)