### PR TITLE
fix(trade): INSERT문에 exchange 컬럼 누락 수정

### DIFF
--- a/src/ante/trade/position.py
+++ b/src/ante/trade/position.py
@@ -126,6 +126,7 @@ class PositionHistory:
                 price=record.price,
                 pnl=0.0,
                 timestamp=record.timestamp,
+                exchange=record.exchange,
             )
 
         elif record.side == "sell":
@@ -152,6 +153,7 @@ class PositionHistory:
                 price=record.price,
                 pnl=pnl,
                 timestamp=record.timestamp,
+                exchange=record.exchange,
             )
 
     async def get_positions(
@@ -311,14 +313,15 @@ class PositionHistory:
         price: float,
         pnl: float,
         timestamp: object | None,
+        exchange: str = "KRX",
     ) -> None:
         """포지션 변동 이력 저장."""
         ts = timestamp.isoformat() if hasattr(timestamp, "isoformat") else None
         await self._db.execute(
             """INSERT INTO position_history
-               (bot_id, symbol, action, quantity, price, pnl, timestamp)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
-            (bot_id, symbol, action, quantity, price, pnl, ts),
+               (bot_id, symbol, action, quantity, price, pnl, timestamp, exchange)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (bot_id, symbol, action, quantity, price, pnl, ts, exchange),
         )
 
     @staticmethod

--- a/src/ante/trade/recorder.py
+++ b/src/ante/trade/recorder.py
@@ -121,6 +121,7 @@ class TradeRecorder:
             commission=event.commission,
             timestamp=event.timestamp,
             order_id=event.order_id,
+            exchange=event.exchange,
         )
         await self._save(record)
         await self._position_history.on_trade(record)
@@ -233,8 +234,8 @@ class TradeRecorder:
             """INSERT OR IGNORE INTO trades
                (trade_id, bot_id, strategy_id, symbol, side, quantity, price,
                 status, order_type, reason, commission, timestamp, order_id,
-                account_id, currency)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                account_id, currency, exchange)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 str(record.trade_id),
                 record.bot_id,
@@ -251,6 +252,7 @@ class TradeRecorder:
                 record.order_id,
                 record.account_id,
                 record.currency,
+                record.exchange,
             ),
         )
 

--- a/tests/unit/test_trade_exchange_column.py
+++ b/tests/unit/test_trade_exchange_column.py
@@ -1,0 +1,112 @@
+"""Trade/PositionHistory INSERT exchange 컬럼 저장 테스트. Refs #737."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from ante.core.database import Database
+from ante.trade.models import TradeRecord, TradeStatus
+from ante.trade.position import PositionHistory
+from ante.trade.recorder import TradeRecorder
+
+
+@pytest.fixture
+async def db(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    return db
+
+
+@pytest.fixture
+async def position_history(db):
+    ph = PositionHistory(db)
+    await ph.initialize()
+    return ph
+
+
+@pytest.fixture
+async def recorder(db, position_history):
+    rec = TradeRecorder(db, position_history)
+    await rec.initialize()
+    return rec
+
+
+def _make_record(*, exchange: str = "KRX", side: str = "buy", **kwargs) -> TradeRecord:
+    defaults = dict(
+        trade_id=uuid4(),
+        bot_id="bot1",
+        strategy_id="s1",
+        symbol="005930",
+        side=side,
+        quantity=10,
+        price=50000,
+        status=TradeStatus.FILLED,
+        timestamp=datetime.now(UTC),
+        exchange=exchange,
+    )
+    defaults.update(kwargs)
+    return TradeRecord(**defaults)
+
+
+class TestRecorderExchangeColumn:
+    """recorder._save()가 exchange 값을 DB에 기록하는지 확인."""
+
+    async def test_default_exchange_saved(self, recorder, db):
+        """exchange 기본값(KRX)이 저장된다."""
+        record = _make_record()
+        await recorder._save(record)
+
+        rows = await db.fetch_all("SELECT exchange FROM trades")
+        assert len(rows) == 1
+        assert rows[0]["exchange"] == "KRX"
+
+    async def test_custom_exchange_saved(self, recorder, db):
+        """KRX가 아닌 exchange 값이 정상 저장된다."""
+        record = _make_record(exchange="NASDAQ")
+        await recorder._save(record)
+
+        rows = await db.fetch_all("SELECT exchange FROM trades")
+        assert len(rows) == 1
+        assert rows[0]["exchange"] == "NASDAQ"
+
+
+class TestPositionHistoryExchangeColumn:
+    """position_history._save_history()가 exchange 값을 DB에 기록하는지 확인."""
+
+    async def test_buy_exchange_saved(self, position_history, db):
+        """매수 시 position_history에 exchange가 저장된다."""
+        record = _make_record(exchange="NYSE", side="buy")
+        await position_history.on_trade(record)
+
+        rows = await db.fetch_all("SELECT exchange FROM position_history")
+        assert len(rows) == 1
+        assert rows[0]["exchange"] == "NYSE"
+
+    async def test_sell_exchange_saved(self, position_history, db):
+        """매도 시 position_history에 exchange가 저장된다."""
+        buy = _make_record(exchange="NASDAQ", side="buy")
+        await position_history.on_trade(buy)
+
+        sell = _make_record(
+            exchange="NASDAQ",
+            side="sell",
+            quantity=5,
+            price=55000,
+        )
+        await position_history.on_trade(sell)
+
+        rows = await db.fetch_all("SELECT exchange FROM position_history")
+        assert len(rows) == 2
+        assert all(r["exchange"] == "NASDAQ" for r in rows)
+
+    async def test_default_exchange_fallback(self, position_history, db):
+        """exchange 미지정 시 기본값 KRX로 저장된다."""
+        record = _make_record(side="buy")  # exchange 기본값 = "KRX"
+        await position_history.on_trade(record)
+
+        rows = await db.fetch_all("SELECT exchange FROM position_history")
+        assert len(rows) == 1
+        assert rows[0]["exchange"] == "KRX"


### PR DESCRIPTION
## Summary
- `recorder.py` `_save()` INSERT문에 `exchange` 컬럼 및 `record.exchange` 값 추가
- `position.py` `_save_history()`에 `exchange` 파라미터 추가 및 INSERT문 반영
- `_on_filled()`에서 `event.exchange`를 `TradeRecord`에 전달하도록 수정
- 단위 테스트 5건 추가 (default/custom exchange 저장, buy/sell history, fallback)

Refs #737

## Test plan
- [x] `test_default_exchange_saved` -- 기본값 KRX 저장 확인
- [x] `test_custom_exchange_saved` -- NASDAQ 등 비기본값 저장 확인
- [x] `test_buy_exchange_saved` -- position_history 매수 시 exchange 저장
- [x] `test_sell_exchange_saved` -- position_history 매도 시 exchange 저장
- [x] `test_default_exchange_fallback` -- exchange 미지정 시 KRX fallback
- [x] 기존 test_trade.py 48건 전체 통과 (회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)