### PR TITLE
fix(treasury): 재시작 시 평가액 데이터 유실 수정

### DIFF
--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -109,6 +109,15 @@ TREASURY_TRANSACTIONS_MIGRATION = """
 ALTER TABLE treasury_transactions ADD COLUMN account_id TEXT DEFAULT '';
 """
 
+# treasury_state에 평가액/매입액 필드 추가 마이그레이션
+_STATE_MIGRATION_COLUMNS = [
+    ("purchase_amount", "REAL NOT NULL DEFAULT 0"),
+    ("eval_amount", "REAL NOT NULL DEFAULT 0"),
+    ("total_profit_loss", "REAL NOT NULL DEFAULT 0"),
+    ("external_purchase_amount", "REAL NOT NULL DEFAULT 0"),
+    ("external_eval_amount", "REAL NOT NULL DEFAULT 0"),
+]
+
 # daily_snapshots 성과 필드 추가 마이그레이션
 _SNAPSHOT_MIGRATION_COLUMNS = [
     ("total_asset", "REAL NOT NULL DEFAULT 0"),
@@ -202,6 +211,15 @@ class Treasury:
             await self._db.execute_script(TREASURY_TRANSACTIONS_MIGRATION)
         except Exception:
             pass  # 이미 컬럼이 존재하면 무시
+
+        # 마이그레이션: treasury_state 평가액/매입액 필드 추가
+        for col_name, col_def in _STATE_MIGRATION_COLUMNS:
+            try:
+                await self._db.execute_script(
+                    f"ALTER TABLE treasury_state ADD COLUMN {col_name} {col_def};"
+                )
+            except Exception:
+                pass  # 이미 컬럼이 존재하면 무시
 
         # 마이그레이션: daily_snapshots 성과 필드 추가
         for col_name, col_def in _SNAPSHOT_MIGRATION_COLUMNS:
@@ -979,6 +997,15 @@ class Treasury:
             self._account_balance = float(r["account_balance"])
             self._purchasable_amount = float(r["purchasable_amount"])
             self._total_evaluation = float(r["total_evaluation"])
+            self._purchase_amount = float(r["purchase_amount"])
+            self._eval_amount = float(r["eval_amount"])
+            self._total_profit_loss = float(r["total_profit_loss"])
+            self._external_purchase_amount = float(r["external_purchase_amount"])
+            self._external_eval_amount = float(r["external_eval_amount"])
+            last_synced = r["last_synced_at"]
+            self._last_synced_at = (
+                datetime.fromisoformat(last_synced) if last_synced else None
+            )
 
         # 봇 예산 (계좌별 필터링)
         rows = await self._db.fetch_all(
@@ -1006,19 +1033,34 @@ class Treasury:
         await self._db.execute(
             """INSERT INTO treasury_state
                (account_id, account_balance, purchasable_amount,
-                total_evaluation, currency)
-               VALUES (?, ?, ?, ?, ?)
+                total_evaluation, currency,
+                purchase_amount, eval_amount, total_profit_loss,
+                external_purchase_amount, external_eval_amount,
+                last_synced_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(account_id) DO UPDATE SET
                  account_balance = excluded.account_balance,
                  purchasable_amount = excluded.purchasable_amount,
                  total_evaluation = excluded.total_evaluation,
-                 currency = excluded.currency""",
+                 currency = excluded.currency,
+                 purchase_amount = excluded.purchase_amount,
+                 eval_amount = excluded.eval_amount,
+                 total_profit_loss = excluded.total_profit_loss,
+                 external_purchase_amount = excluded.external_purchase_amount,
+                 external_eval_amount = excluded.external_eval_amount,
+                 last_synced_at = excluded.last_synced_at""",
             (
                 self._account_id,
                 self._account_balance,
                 self._purchasable_amount,
                 self._total_evaluation,
                 self._currency,
+                self._purchase_amount,
+                self._eval_amount,
+                self._total_profit_loss,
+                self._external_purchase_amount,
+                self._external_eval_amount,
+                self._last_synced_at.isoformat() if self._last_synced_at else None,
             ),
         )
 

--- a/tests/unit/test_treasury.py
+++ b/tests/unit/test_treasury.py
@@ -745,6 +745,74 @@ class TestTreasuryPersistence:
         assert t2_new.account_balance == 5_000.0
         assert t2_new.get_budget("bot1") is None
 
+    async def test_persists_evaluation_fields(self, db, eventbus):
+        """재시작 후 평가액/매입액/손익/외부 필드가 복원된다."""
+        t1 = Treasury(db=db, eventbus=eventbus, account_id=ACCOUNT_ID)
+        await t1.initialize()
+        await t1.set_account_balance(10_000_000.0)
+
+        # sync_balance로 평가액 필드 설정
+        await t1.sync_balance(
+            {
+                "cash": 10_000_000.0,
+                "purchasable_amount": 8_000_000.0,
+                "total_assets": 12_000_000.0,
+                "purchase_amount": 7_000_000.0,
+                "eval_amount": 7_200_000.0,
+                "total_profit_loss": 200_000.0,
+            }
+        )
+
+        # 외부 종목 금액 설정을 위해 내부 속성 직접 설정 후 저장
+        t1._external_purchase_amount = 1_000_000.0
+        t1._external_eval_amount = 1_100_000.0
+        await t1._save_state()
+
+        # 새 인스턴스로 복원
+        t2 = Treasury(db=db, eventbus=eventbus, account_id=ACCOUNT_ID)
+        await t2.initialize()
+
+        summary = t2.get_summary()
+        assert summary["account_balance"] == 10_000_000.0
+        assert summary["purchasable_amount"] == 8_000_000.0
+        assert summary["total_evaluation"] == 12_000_000.0
+        assert summary["purchase_amount"] == 7_000_000.0
+        assert summary["eval_amount"] == 7_200_000.0
+        assert summary["total_profit_loss"] == 200_000.0
+        assert summary["external_purchase_amount"] == 1_000_000.0
+        assert summary["external_eval_amount"] == 1_100_000.0
+
+    async def test_persists_last_synced_at(self, db, eventbus):
+        """재시작 후 last_synced_at이 복원된다."""
+        from datetime import UTC, datetime
+
+        t1 = Treasury(db=db, eventbus=eventbus, account_id=ACCOUNT_ID)
+        await t1.initialize()
+
+        # last_synced_at 설정 후 저장
+        now = datetime.now(UTC)
+        t1._last_synced_at = now
+        await t1._save_state()
+
+        # 새 인스턴스로 복원
+        t2 = Treasury(db=db, eventbus=eventbus, account_id=ACCOUNT_ID)
+        await t2.initialize()
+
+        assert t2.last_synced_at is not None
+        assert t2.last_synced_at.isoformat() == now.isoformat()
+
+    async def test_persists_last_synced_at_none(self, db, eventbus):
+        """last_synced_at이 None이면 복원 후에도 None이다."""
+        t1 = Treasury(db=db, eventbus=eventbus, account_id=ACCOUNT_ID)
+        await t1.initialize()
+        await t1.set_account_balance(1_000_000.0)
+
+        # 새 인스턴스로 복원
+        t2 = Treasury(db=db, eventbus=eventbus, account_id=ACCOUNT_ID)
+        await t2.initialize()
+
+        assert t2.last_synced_at is None
+
 
 # -- update_budget -------------------------------------------
 


### PR DESCRIPTION
## Summary
- `treasury_state` 테이블에 `purchase_amount`, `eval_amount`, `total_profit_loss`, `external_purchase_amount`, `external_eval_amount` 5개 컬럼 마이그레이션 추가
- `_save_state()`에서 위 5개 필드 + `last_synced_at` 저장
- `_load_from_db()`에서 위 6개 필드 복원
- 재시작 후 `get_summary()` 값이 정상 반환됨

Refs #745

## Test plan
- [x] 기존 62개 테스트 통과
- [x] 관련 테스트 48개 통과 (sync, api, bot_check, manager)
- [x] `test_persists_evaluation_fields`: sync_balance 후 새 인스턴스에서 평가액 필드 복원 확인
- [x] `test_persists_last_synced_at`: last_synced_at ISO 문자열 복원 확인
- [x] `test_persists_last_synced_at_none`: None 값 유지 확인
- [x] ruff check / ruff format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)