### PR TITLE
fix(bot): BotConfig.paper_initial_balance 필드 제거 #747

### DIFF
--- a/src/ante/bot/config.py
+++ b/src/ante/bot/config.py
@@ -31,7 +31,6 @@ class BotConfig:
     name: str = ""
     account_id: str = "test"
     interval_seconds: int = 60
-    paper_initial_balance: float = 10_000_000.0
     auto_restart: bool = True
     max_restart_attempts: int = 3
     restart_cooldown_seconds: int = 60

--- a/src/ante/bot/context_factory.py
+++ b/src/ante/bot/context_factory.py
@@ -116,9 +116,10 @@ class StrategyContextFactory:
 
     def _create_paper_context(self, config: BotConfig) -> StrategyContext:
         """Paper 봇용 StrategyContext 생성."""
+        initial_balance = self._resolve_paper_balance(config)
         paper_portfolio = PaperPortfolioView(
             bot_id=config.bot_id,
-            initial_balance=config.paper_initial_balance,
+            initial_balance=initial_balance,
         )
         paper_order_view = PaperOrderView(portfolio=paper_portfolio)
 
@@ -135,6 +136,26 @@ class StrategyContextFactory:
         logger.info(
             "Paper StrategyContext 생성: %s (잔고: %s)",
             config.bot_id,
-            config.paper_initial_balance,
+            initial_balance,
         )
         return ctx
+
+    def _resolve_paper_balance(self, config: BotConfig) -> float:
+        """Paper 봇의 초기 잔고를 Account 레벨(Treasury)에서 조회.
+
+        Treasury에 해당 봇의 예산이 배정되어 있으면 allocated 값을 사용하고,
+        Treasury가 없으면 0.0을 반환한다.
+        """
+        if self._treasury_manager is not None:
+            try:
+                treasury = self._treasury_manager.get(config.account_id)
+                budget = treasury.get_budget(config.bot_id)
+                if budget is not None:
+                    return budget.allocated
+            except KeyError:
+                logger.warning(
+                    "Paper 봇 '%s': 계좌 '%s'의 Treasury 미발견 -- 잔고 0",
+                    config.bot_id,
+                    config.account_id,
+                )
+        return 0.0

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -748,7 +748,6 @@ class BotManager:
             "strategy_id": config.strategy_id,
             "account_id": config.account_id,
             "interval_seconds": config.interval_seconds,
-            "paper_initial_balance": config.paper_initial_balance,
         }
         await self._db.execute(
             """INSERT INTO bots

--- a/tests/unit/test_bot_providers.py
+++ b/tests/unit/test_bot_providers.py
@@ -483,7 +483,6 @@ class TestStrategyContextFactory:
         config = BotConfig(
             bot_id="paper1",
             strategy_id="s1",
-            paper_initial_balance=5_000_000.0,
         )
         # AccountService 미설정 → VIRTUAL 모드(paper) 기본 동작
         ctx = factory.create(config)
@@ -494,9 +493,9 @@ class TestStrategyContextFactory:
         # Paper 봇이 PaperExecutor에 등록되었는지 확인
         assert "paper1" in executor._portfolios
 
-        # 초기 잔고 확인
+        # Treasury 미설정 시 초기 잔고 0
         balance = ctx.get_balance()
-        assert balance["allocated"] == 5_000_000.0
+        assert balance["allocated"] == 0.0
 
     def test_create_live_context(self, eventbus):
         """Live 봇 StrategyContext 생성 (Account.trading_mode=LIVE)."""
@@ -602,7 +601,6 @@ class TestBotManagerWithFactory:
         config = BotConfig(
             bot_id="paper1",
             strategy_id="s1",
-            paper_initial_balance=5_000_000.0,
         )
         bot = await manager.create_bot(config, SimpleStrategy)
 

--- a/tests/unit/test_bot_providers.py
+++ b/tests/unit/test_bot_providers.py
@@ -544,6 +544,53 @@ class TestStrategyContextFactory:
         assert isinstance(ctx, StrategyContext)
         assert ctx.bot_id == "live1"
 
+    def test_resolve_paper_balance_with_budget(self, eventbus):
+        """TreasuryManager 존재 + BotBudget 배정 시 allocated 값 반환."""
+        from ante.treasury.models import BotBudget
+
+        class FakeTreasury:
+            def get_budget(self, bot_id):
+                if bot_id == "paper1":
+                    return BotBudget(bot_id="paper1", allocated=2_000_000.0)
+                return None
+
+        class FakeTreasuryManager:
+            def get(self, account_id):
+                return FakeTreasury()
+
+        executor = PaperExecutor(eventbus=eventbus)
+        factory = StrategyContextFactory(
+            data_provider=FakeDataProvider(),
+            paper_executor=executor,
+            treasury_manager=FakeTreasuryManager(),
+        )
+
+        config = BotConfig(bot_id="paper1", strategy_id="s1", account_id="acct1")
+        ctx = factory.create(config)
+
+        balance = ctx.get_balance()
+        assert balance["allocated"] == 2_000_000.0
+
+    def test_resolve_paper_balance_key_error(self, eventbus):
+        """TreasuryManager 존재하나 bot_id 미배정 시 0.0 반환."""
+
+        class FakeTreasuryManager:
+            def get(self, account_id):
+                raise KeyError(account_id)
+
+        executor = PaperExecutor(eventbus=eventbus)
+        factory = StrategyContextFactory(
+            data_provider=FakeDataProvider(),
+            paper_executor=executor,
+            treasury_manager=FakeTreasuryManager(),
+        )
+
+        config = BotConfig(bot_id="paper1", strategy_id="s1", account_id="no-acct")
+        ctx = factory.create(config)
+
+        balance = ctx.get_balance()
+        assert balance["allocated"] == 0.0
+
     def test_live_without_providers_raises(self, eventbus):
         """Live providers 미설정 시 에러."""
         from ante.account.models import Account, TradingMode


### PR DESCRIPTION
## Summary
- `BotConfig.paper_initial_balance` 필드 제거 (스펙 GAP-020)
- `context_factory._create_paper_context`에서 Treasury의 봇 예산(BotBudget.allocated)으로 초기 잔고 조회하도록 전환
- `manager._save_bot_config`에서 해당 필드 참조 제거

## Test plan
- [x] `tests/unit/test_bot_providers.py` 전체 통과 (34 passed)
- [x] `tests/unit/` 전체 통과 (2633 passed, 2 skipped)
- [x] ruff check / ruff format 통과

Refs #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)