### PR TITLE
fix(web): 멤버 API 라우트 caller_id 하드코딩 제거 #767

### DIFF
--- a/src/ante/web/routes/members.py
+++ b/src/ante/web/routes/members.py
@@ -8,6 +8,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
+from ante.member.errors import PermissionDeniedError
 from ante.web.deps import get_audit_logger_optional, get_member_service
 from ante.web.schemas import (
     MemberCreateResponse,
@@ -19,6 +20,11 @@ from ante.web.schemas import (
 )
 
 router = APIRouter()
+
+
+def _caller_id(request: Request) -> str:
+    """인증 미들웨어가 설정한 member_id를 반환. 미설정 시 빈 문자열."""
+    return getattr(request.state, "member_id", "")
 
 
 class MemberCreateRequest(BaseModel):
@@ -82,6 +88,7 @@ async def create_member(
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """멤버 등록. 토큰 1회 반환."""
+    caller = _caller_id(request)
     try:
         member, token = await svc.register(
             member_id=body.member_id,
@@ -90,16 +97,16 @@ async def create_member(
             org=body.org,
             name=body.name,
             scopes=body.scopes,
-            registered_by="dashboard",
+            registered_by=caller,
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    except PermissionError as e:
+    except (PermissionError, PermissionDeniedError) as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
 
     if audit_logger:
         await audit_logger.log(
-            member_id=getattr(request.state, "member_id", "dashboard"),
+            member_id=caller or "anonymous",
             action="member.create",
             resource=f"member:{body.member_id}",
             detail=f"type={body.member_type}, role={body.role}",
@@ -144,16 +151,17 @@ async def suspend_member(
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """멤버 일시 정지."""
+    caller = _caller_id(request)
     try:
-        member = await svc.suspend(member_id, suspended_by="dashboard")
+        member = await svc.suspend(member_id, suspended_by=caller)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
-    except PermissionError as e:
+    except (PermissionError, PermissionDeniedError) as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
 
     if audit_logger:
         await audit_logger.log(
-            member_id=getattr(request.state, "member_id", "dashboard"),
+            member_id=caller or "anonymous",
             action="member.suspend",
             resource=f"member:{member_id}",
             ip=request.client.host if request.client else "",
@@ -178,16 +186,17 @@ async def reactivate_member(
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """멤버 재활성화."""
+    caller = _caller_id(request)
     try:
-        member = await svc.reactivate(member_id, reactivated_by="dashboard")
+        member = await svc.reactivate(member_id, reactivated_by=caller)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
-    except PermissionError as e:
+    except (PermissionError, PermissionDeniedError) as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
 
     if audit_logger:
         await audit_logger.log(
-            member_id=getattr(request.state, "member_id", "dashboard"),
+            member_id=caller or "anonymous",
             action="member.reactivate",
             resource=f"member:{member_id}",
             ip=request.client.host if request.client else "",
@@ -212,16 +221,17 @@ async def revoke_member(
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """멤버 영구 폐기."""
+    caller = _caller_id(request)
     try:
-        member = await svc.revoke(member_id, revoked_by="dashboard")
+        member = await svc.revoke(member_id, revoked_by=caller)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
-    except PermissionError as e:
+    except (PermissionError, PermissionDeniedError) as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
 
     if audit_logger:
         await audit_logger.log(
-            member_id=getattr(request.state, "member_id", "dashboard"),
+            member_id=caller or "anonymous",
             action="member.revoke",
             resource=f"member:{member_id}",
             ip=request.client.host if request.client else "",
@@ -246,16 +256,17 @@ async def rotate_token(
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """토큰 재발급."""
+    caller = _caller_id(request)
     try:
-        member, token = await svc.rotate_token(member_id, rotated_by="dashboard")
+        member, token = await svc.rotate_token(member_id, rotated_by=caller)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
-    except PermissionError as e:
+    except (PermissionError, PermissionDeniedError) as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
 
     if audit_logger:
         await audit_logger.log(
-            member_id=getattr(request.state, "member_id", "dashboard"),
+            member_id=caller or "anonymous",
             action="member.rotate_token",
             resource=f"member:{member_id}",
             ip=request.client.host if request.client else "",
@@ -281,16 +292,17 @@ async def change_password(
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """비밀번호 변경 (human 멤버 전용)."""
+    caller = _caller_id(request)
     try:
         await svc.change_password(member_id, body.old_password, body.new_password)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
-    except PermissionError as e:
+    except (PermissionError, PermissionDeniedError) as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
 
     if audit_logger:
         await audit_logger.log(
-            member_id=getattr(request.state, "member_id", member_id),
+            member_id=caller or member_id,
             action="member.change_password",
             resource=f"member:{member_id}",
             ip=request.client.host if request.client else "",
@@ -316,16 +328,17 @@ async def update_scopes(
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """권한 범위 변경."""
+    caller = _caller_id(request)
     try:
-        member = await svc.update_scopes(member_id, body.scopes, updated_by="dashboard")
+        member = await svc.update_scopes(member_id, body.scopes, updated_by=caller)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
-    except PermissionError as e:
+    except (PermissionError, PermissionDeniedError) as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
 
     if audit_logger:
         await audit_logger.log(
-            member_id=getattr(request.state, "member_id", "dashboard"),
+            member_id=caller or "anonymous",
             action="member.update_scopes",
             resource=f"member:{member_id}",
             detail=f"scopes={body.scopes}",

--- a/tests/unit/test_member_api.py
+++ b/tests/unit/test_member_api.py
@@ -328,3 +328,113 @@ class TestScopesUpdate:
         )
         assert resp.status_code == 200
         assert resp.json()["member"]["scopes"] == ["trade:read", "trade:write"]
+
+
+class TestCallerIdPropagation:
+    """request.state.member_id가 서비스 호출로 전달되는지 검증."""
+
+    def test_register_passes_caller_id(self, member_service):
+        """인증된 사용자의 member_id가 registered_by로 전달."""
+        captured: dict[str, str] = {}
+        original_register = member_service.register
+
+        async def spy_register(**kwargs):
+            captured["registered_by"] = kwargs.get("registered_by", "")
+            return await original_register(**kwargs)
+
+        member_service.register = spy_register
+
+        app = create_app(member_service=member_service)
+
+        @app.middleware("http")
+        async def inject_member_id(request, call_next):
+            request.state.member_id = "master-user"
+            return await call_next(request)
+
+        client = TestClient(app)
+        resp = client.post(
+            "/api/members",
+            json={"member_id": "new-agent", "member_type": "agent"},
+        )
+        assert resp.status_code == 201
+        assert captured["registered_by"] == "master-user"
+
+    def test_update_scopes_passes_caller_id(self, member_service):
+        """인증된 사용자의 member_id가 updated_by로 전달."""
+        captured: dict[str, str] = {}
+        original_update = member_service.update_scopes
+
+        async def spy_update(member_id, scopes, updated_by=""):
+            captured["updated_by"] = updated_by
+            return await original_update(member_id, scopes, updated_by=updated_by)
+
+        member_service.update_scopes = spy_update
+        member_service._members["agent-01"] = FakeMember(member_id="agent-01")
+
+        app = create_app(member_service=member_service)
+
+        @app.middleware("http")
+        async def inject_member_id(request, call_next):
+            request.state.member_id = "master-user"
+            return await call_next(request)
+
+        client = TestClient(app)
+        resp = client.put(
+            "/api/members/agent-01/scopes",
+            json={"scopes": ["trade:read"]},
+        )
+        assert resp.status_code == 200
+        assert captured["updated_by"] == "master-user"
+
+    def test_no_auth_passes_empty_string(self, client, member_service):
+        """인증 컨텍스트 없을 때 빈 문자열 전달 (내부 호출)."""
+        captured: dict[str, str] = {}
+        original_register = member_service.register
+
+        async def spy_register(**kwargs):
+            captured["registered_by"] = kwargs.get("registered_by", "")
+            return await original_register(**kwargs)
+
+        member_service.register = spy_register
+        resp = client.post(
+            "/api/members",
+            json={"member_id": "new-agent", "member_type": "agent"},
+        )
+        assert resp.status_code == 201
+        assert captured["registered_by"] == ""
+
+
+class TestPermissionDeniedErrorHandling:
+    """PermissionDeniedError가 403으로 처리되는지 검증."""
+
+    def test_register_permission_denied(self, client, member_service):
+        """PermissionDeniedError → 403."""
+        from ante.member.errors import PermissionDeniedError
+
+        async def raise_pde(**kwargs):
+            raise PermissionDeniedError("'register'은(는) master만 수행할 수 있습니다.")
+
+        member_service.register = raise_pde
+        resp = client.post(
+            "/api/members",
+            json={"member_id": "new-agent", "member_type": "agent"},
+        )
+        assert resp.status_code == 403
+
+    def test_update_scopes_permission_denied(self, client, member_service):
+        """update_scopes PermissionDeniedError → 403."""
+        from ante.member.errors import PermissionDeniedError
+
+        member_service._members["agent-01"] = FakeMember(member_id="agent-01")
+
+        async def raise_pde(member_id, scopes, updated_by=""):
+            raise PermissionDeniedError(
+                "'update_scopes'은(는) master만 수행할 수 있습니다."
+            )
+
+        member_service.update_scopes = raise_pde
+        resp = client.put(
+            "/api/members/agent-01/scopes",
+            json={"scopes": ["trade:read"]},
+        )
+        assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- 멤버 API 라우트의 `registered_by`/`updated_by`/`suspended_by`/`reactivated_by`/`revoked_by`/`rotated_by`에 하드코딩된 `"dashboard"`를 `request.state.member_id`(인증 미들웨어 설정값)로 교체
- 인증 컨텍스트가 없는 경우 빈 문자열 `""`을 전달하여 `_assert_master()` 검증을 스킵 (내부 호출로 간주)
- `PermissionDeniedError`를 `except` 블록에 추가하여 403 응답으로 처리 (기존에는 `PermissionError`만 잡아 500으로 떨어짐)

## Test plan
- [x] 기존 22개 멤버 API 테스트 전체 통과 확인
- [x] caller_id 전파 테스트 3개 추가 (인증 있음/없음, register/update_scopes)
- [x] PermissionDeniedError → 403 처리 테스트 2개 추가
- [x] ruff check / ruff format --check 통과

Refs #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)