### PR TITLE
fix(account): kis-overseas 프리셋 제거 #770

### DIFF
--- a/src/ante/account/presets.py
+++ b/src/ante/account/presets.py
@@ -29,18 +29,4 @@ BROKER_PRESETS: dict[str, BrokerPreset] = {
         default_name="국내 주식",
         required_credentials=["app_key", "app_secret", "account_no"],
     ),
-    # kis-overseas 프리셋은 정의만 해둔다.
-    # KISOverseasAdapter 구현 및 BROKER_REGISTRY 등록은 1.1에서 지원.
-    "kis-overseas": BrokerPreset(
-        exchange="NYSE",
-        currency="USD",
-        timezone="America/New_York",
-        trading_hours_start="09:30",
-        trading_hours_end="16:00",
-        buy_commission_rate=Decimal("0.001"),
-        sell_commission_rate=Decimal("0.001"),
-        default_account_id="us-stock",
-        default_name="미국 주식",
-        required_credentials=["app_key", "app_secret", "account_no"],
-    ),
 }

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # 브로커 어댑터 레지스트리 — broker_type → 어댑터 클래스
-# kis-overseas는 1.1에서 등록 예정
 _BROKER_REGISTRY: dict[str, type[BrokerAdapter]] = {}
 
 _CREATE_TABLE_SQL = """\

--- a/src/ante/broker/registry.py
+++ b/src/ante/broker/registry.py
@@ -31,7 +31,6 @@ def _build_registry() -> dict[str, type[BrokerAdapter]]:
     return {
         "test": TestBrokerAdapter,
         "kis-domestic": KISDomesticAdapter,
-        # "kis-overseas"는 1.1에서 등록. 현재 미등록.
     }
 
 

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -55,7 +55,7 @@ def mask_value(key: str, value: str) -> str:
 
 
 def _get_selectable_broker_types() -> list[str]:
-    """BROKER_REGISTRY에 등록된 broker_type만 반환 (kis-overseas 제외)."""
+    """BROKER_REGISTRY에 등록된 broker_type만 반환."""
     from ante.broker.registry import BROKER_REGISTRY
 
     return list(BROKER_REGISTRY.keys())

--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -84,14 +84,14 @@ def _prompt_master_account() -> tuple[str, str, str]:
 
 
 def _get_available_brokers() -> list[tuple[str, str]]:
-    """등록 가능한 브로커 목록을 반환한다. kis-overseas 제외.
+    """등록 가능한 브로커 목록을 반환한다.
 
     Returns:
         (broker_type, display_label) 튜플 리스트.
     """
     from ante.account.presets import BROKER_PRESETS
 
-    excluded = {"test", "kis-overseas"}
+    excluded = {"test"}
     result = []
     for broker_type, preset in BROKER_PRESETS.items():
         if broker_type in excluded:

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -133,7 +133,7 @@ async def create_account(
         raise HTTPException(status_code=409, detail=str(e))
 
     # 브로커 어댑터 인스턴스 생성 가능 여부 검증
-    # kis-overseas 등 BROKER_REGISTRY에 미등록된 타입은 생성 직후 롤백
+    # BROKER_REGISTRY에 미등록된 타입은 생성 직후 롤백
     try:
         await account_service.get_broker(created.account_id)
     except InvalidBrokerTypeError as e:

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -307,24 +307,6 @@ async def test_get_broker_cached(service):
     assert broker1 is broker2
 
 
-@pytest.mark.asyncio
-async def test_get_broker_kis_overseas_raises(service):
-    """kis-overseas broker_type으로 get_broker 호출 시 에러 (REGISTRY 미등록)."""
-    account = _make_account(
-        account_id="us-stock",
-        exchange="NYSE",
-        currency="USD",
-        broker_type="kis-overseas",
-        timezone="America/New_York",
-        trading_hours_start="09:30",
-        trading_hours_end="16:00",
-    )
-    await service.create(account)
-
-    with pytest.raises(InvalidBrokerTypeError):
-        await service.get_broker("us-stock")
-
-
 # ── 기본 테스트 계좌 ──────────────────────────────────
 
 
@@ -371,10 +353,9 @@ async def test_db_persistence(db, eventbus):
 
 
 def test_broker_presets_defined():
-    """test, kis-domestic, kis-overseas 프리셋이 정의되어 있음."""
+    """test, kis-domestic 프리셋이 정의되어 있음."""
     assert "test" in BROKER_PRESETS
     assert "kis-domestic" in BROKER_PRESETS
-    assert "kis-overseas" in BROKER_PRESETS
 
 
 def test_broker_preset_test_values():

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -101,7 +101,7 @@ class FakeAccountService:
         del self._accounts[account_id]
 
     async def get_broker(self, account_id: str) -> Any:
-        """브로커 인스턴스 반환 모의. kis-overseas는 미등록."""
+        """브로커 인스턴스 반환 모의."""
         account = await self.get(account_id)
         # test, kis-domestic만 등록됨
         if account.broker_type not in ("test", "kis-domestic"):
@@ -256,20 +256,6 @@ class TestCreateAccount:
             },
         )
         assert resp.status_code == 409
-
-    def test_create_overseas_account_rejected(self, client: TestClient) -> None:
-        """kis-overseas broker_type은 BROKER_REGISTRY에 미등록이므로 거부."""
-        resp = client.post(
-            "/api/accounts",
-            json={
-                "account_id": "us-stock",
-                "name": "미국 주식",
-                "broker_type": "kis-overseas",
-            },
-        )
-        assert resp.status_code == 400
-        data = resp.json()
-        assert "BROKER_REGISTRY" in data["detail"]
 
 
 class TestGetAccount:

--- a/tests/unit/test_account_cli.py
+++ b/tests/unit/test_account_cli.py
@@ -249,15 +249,6 @@ class TestAccountCredentials:
 class TestAccountCreate:
     """ante account create 테스트."""
 
-    def test_create_excludes_overseas(self) -> None:
-        """_get_selectable_broker_types가 kis-overseas를 제외한다."""
-        from ante.cli.commands.account import _get_selectable_broker_types
-
-        selectable = _get_selectable_broker_types()
-        assert "kis-overseas" not in selectable
-        assert "test" in selectable
-        assert "kis-domestic" in selectable
-
     def test_create_interactive(self, mock_account_service: AsyncMock) -> None:
         """대화형 생성 흐름이 정상 동작한다."""
         created = _mock_account("test", "테스트", "TEST", "KRW", "test")

--- a/tests/unit/test_broker_adapter_split.py
+++ b/tests/unit/test_broker_adapter_split.py
@@ -323,10 +323,6 @@ class TestBrokerRegistry:
         assert "kis-domestic" in BROKER_REGISTRY
         assert BROKER_REGISTRY["kis-domestic"] is KISDomesticAdapter
 
-    def test_registry_not_contains_kis_overseas(self):
-        """kis-overseas는 1.1 범위이므로 미등록."""
-        assert "kis-overseas" not in BROKER_REGISTRY
-
     def test_registry_size(self):
         """현재 2개만 등록."""
         assert len(BROKER_REGISTRY) == 2

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -484,13 +484,12 @@ class TestInitIdempotent:
 class TestPromptAccount:
     """_prompt_account / _get_available_brokers 단위 테스트."""
 
-    def test_kis_overseas_excluded(self):
-        """kis-overseas가 브로커 선택지에서 제외된다."""
+    def test_test_excluded(self):
+        """test 프리셋이 브로커 선택지에서 제외된다."""
         from ante.cli.commands.init import _get_available_brokers
 
         brokers = _get_available_brokers()
         broker_types = [bt for bt, _ in brokers]
-        assert "kis-overseas" not in broker_types
         assert "test" not in broker_types
         assert "kis-domestic" in broker_types
 


### PR DESCRIPTION
## Summary
- `BROKER_PRESETS`에서 `kis-overseas` 프리셋 항목 및 관련 주석 2줄 제거
- `service.py`, `registry.py`, CLI 커맨드, 웹 라우트의 `kis-overseas` 관련 주석 정리
- 제거된 프리셋을 참조하던 테스트 케이스 정리 (6개 테스트 파일)

## Test plan
- [x] `ruff check` / `ruff format --check` 통과
- [x] 관련 단위 테스트 120개 전체 통과
- [x] 코드베이스에 `kis-overseas` 참조 잔존 없음 확인

Refs #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)