### PR TITLE
fix(rule): PositionSizeRule 분모를 봇 할당 예산으로 수정

### DIFF
--- a/src/ante/rule/base.py
+++ b/src/ante/rule/base.py
@@ -61,6 +61,7 @@ class RuleContext:
     current_price: float = 0.0
     current_position: float = 0.0
     available_balance: float = 0.0
+    bot_allocated_budget: float = 0.0
 
     # 계좌 상태
     account_status: str = "active"

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -267,12 +267,15 @@ class RuleEngine:
 
     # ── Treasury 조회 ──────────────────────────────
 
-    async def _query_treasury_data(self) -> dict[str, float]:
+    async def _query_treasury_data(self, bot_id: str = "") -> dict[str, float]:
         """Treasury에서 자산/손익 데이터를 조회한다.
+
+        Args:
+            bot_id: 봇 할당 예산 조회를 위한 봇 ID.
 
         Returns:
             daily_pnl, total_pnl, prev_day_total_asset,
-            total_asset, total_exposure 딕셔너리.
+            total_asset, total_exposure, bot_allocated_budget 딕셔너리.
             조회 실패 시 각 값은 0.0.
         """
         result = {
@@ -281,6 +284,7 @@ class RuleEngine:
             "prev_day_total_asset": 0.0,
             "total_asset": 0.0,
             "total_exposure": 0.0,
+            "bot_allocated_budget": 0.0,
         }
         if self._treasury is None:
             return result
@@ -293,6 +297,15 @@ class RuleEngine:
             result["total_exposure"] = summary.get("ante_eval_amount", 0.0)
         except Exception:
             logger.warning("Treasury summary 조회 실패: %s", self._account_id)
+
+        # 봇 할당 예산 조회
+        if bot_id:
+            try:
+                budget = self._treasury.get_budget(bot_id)
+                if budget is not None:
+                    result["bot_allocated_budget"] = budget.allocated
+            except Exception:
+                logger.warning("Treasury 봇 예산 조회 실패: bot=%s", bot_id)
 
         # get_daily_snapshot()은 비동기 메서드
         try:
@@ -347,7 +360,7 @@ class RuleEngine:
                 )
 
         # Treasury 데이터 조회
-        treasury_data = await self._query_treasury_data()
+        treasury_data = await self._query_treasury_data(bot_id=event.bot_id)
 
         context = RuleContext(
             bot_id=event.bot_id,
@@ -366,6 +379,7 @@ class RuleEngine:
             prev_day_total_asset=treasury_data["prev_day_total_asset"],
             total_asset=treasury_data["total_asset"],
             total_exposure=treasury_data["total_exposure"],
+            bot_allocated_budget=treasury_data["bot_allocated_budget"],
         )
 
         try:
@@ -500,7 +514,7 @@ class RuleEngine:
                 )
 
         # Treasury 데이터 조회
-        treasury_data = await self._query_treasury_data()
+        treasury_data = await self._query_treasury_data(bot_id=event.bot_id)
 
         context = RuleContext(
             bot_id=event.bot_id,
@@ -519,6 +533,7 @@ class RuleEngine:
             prev_day_total_asset=treasury_data["prev_day_total_asset"],
             total_asset=treasury_data["total_asset"],
             total_exposure=treasury_data["total_exposure"],
+            bot_allocated_budget=treasury_data["bot_allocated_budget"],
         )
 
         try:

--- a/src/ante/rule/strategy_rules.py
+++ b/src/ante/rule/strategy_rules.py
@@ -16,7 +16,7 @@ class PositionSizeRule(Rule):
         order_value = context.quantity * context.current_price
         total_position_value = current_position_value + order_value
 
-        balance_limit = context.available_balance * max_position_percent
+        balance_limit = context.bot_allocated_budget * max_position_percent
         position_limit = min(max_position_amount, balance_limit)
 
         if total_position_value > position_limit > 0:

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -44,6 +44,7 @@ def base_context():
         current_price=50000.0,
         current_position=0.0,
         available_balance=1000000.0,
+        bot_allocated_budget=1000000.0,
         account_status="active",
         daily_pnl=0.0,
         total_pnl=100000.0,
@@ -344,6 +345,40 @@ class TestPositionSizeRule:
         # 총 150,000 > 100,000
         result = rule.evaluate(base_context)
         assert result.result == RuleResult.REJECT
+
+    def test_uses_bot_allocated_budget_not_available_balance(self, rule, base_context):
+        """분모가 bot_allocated_budget이며 available_balance가 아님을 검증."""
+        # available_balance가 크더라도 bot_allocated_budget이 작으면 REJECT
+        base_context.available_balance = 10_000_000.0  # 1천만 (큰 값)
+        base_context.bot_allocated_budget = 500_000.0  # 50만
+        base_context.quantity = 2.0  # 주문가치 100,000
+        base_context.current_position = 0.0
+        # balance_limit = 500,000 * 0.10 = 50,000
+        # position_limit = min(200,000, 50,000) = 50,000
+        # total_position_value = 100,000 > 50,000 → REJECT
+        result = rule.evaluate(base_context)
+        assert result.result == RuleResult.REJECT
+
+    def test_stable_denominator_across_purchases(self, rule, base_context):
+        """매수로 가용잔고가 줄어도 bot_allocated_budget은 변하지 않아 비율이 안정적."""
+        base_context.bot_allocated_budget = 1_000_000.0
+        base_context.available_balance = 200_000.0  # 이미 많이 매수함
+        base_context.quantity = 1.0  # 50,000
+        base_context.current_position = 0.0
+        # balance_limit = 1,000,000 * 0.10 = 100,000
+        # position_limit = min(200,000, 100,000) = 100,000
+        # total_position_value = 50,000 < 100,000 → PASS
+        result = rule.evaluate(base_context)
+        assert result.result == RuleResult.PASS
+
+    def test_zero_budget_skips_percent_check(self, rule, base_context):
+        """budget 0이면 limit>0 불충족으로 PASS."""
+        base_context.bot_allocated_budget = 0.0
+        base_context.quantity = 100.0  # 큰 주문
+        result = rule.evaluate(base_context)
+        # position_limit = min(200000, 0) = 0
+        # total > 0 > 0 → False (0 is not > 0) → PASS
+        assert result.result == RuleResult.PASS
 
 
 # ── UnrealizedLossLimitRule ──────────────────────
@@ -856,6 +891,7 @@ class TestRuleEngineUpdateRules:
             order_type="market",
             current_price=50000.0,
             available_balance=1_000_000.0,
+            bot_allocated_budget=1_000_000.0,
             account_status="active",
         )
         result = engine.evaluate(context)


### PR DESCRIPTION
## Summary
- `PositionSizeRule`의 포지션 비율 분모를 `available_balance`(가용 잔고)에서 `bot_allocated_budget`(봇 할당 예산)으로 변경하여 매수 진행 시 가용 잔고 감소로 인한 비율 과대 계산 왜곡 해소
- `RuleContext`에 `bot_allocated_budget: float = 0.0` 필드 추가
- `RuleEngine._query_treasury_data()`에서 `Treasury.get_budget(bot_id)`를 통해 봇 할당 예산을 조회하고, `on_order_request`/`on_order_modify` 양쪽 RuleContext 생성 시 주입

## Test plan
- [x] 기존 PositionSizeRule 테스트 통과 확인
- [x] `test_uses_bot_allocated_budget_not_available_balance`: available_balance가 크더라도 bot_allocated_budget이 작으면 REJECT
- [x] `test_stable_denominator_across_purchases`: 가용잔고가 줄어도 할당 예산 기준으로 안정적 비율 계산
- [x] `test_zero_budget_skips_percent_check`: budget 0일 때 percent 체크 스킵
- [x] ruff check / ruff format 통과

Refs #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)