### PR TITLE
fix(member): 패스워드 변경/리셋 시 기존 토큰 무효화 #772

### DIFF
--- a/src/ante/member/recovery_key_manager.py
+++ b/src/ante/member/recovery_key_manager.py
@@ -49,6 +49,7 @@ class RecoveryKeyManager:
             "UPDATE members SET password_hash = ? WHERE member_id = ?",
             (hash_password(new_password), member.member_id),
         )
+        await self._invalidate_token(member.member_id)
         logger.info("패스워드 변경 완료: %s", member.member_id)
 
     async def reset_password(
@@ -68,6 +69,7 @@ class RecoveryKeyManager:
             "UPDATE members SET password_hash = ? WHERE member_id = ?",
             (hash_password(new_password), member.member_id),
         )
+        await self._invalidate_token(member.member_id)
         logger.info("패스워드 리셋 완료 (recovery key): %s", member.member_id)
 
     async def regenerate_recovery_key(self, member: Member, password: str) -> str:
@@ -88,6 +90,15 @@ class RecoveryKeyManager:
         )
         logger.info("Recovery key 재발급 완료: %s", member.member_id)
         return recovery_key
+
+    async def _invalidate_token(self, member_id: str) -> None:
+        """기존 토큰 무효화 (token_hash, token_expires_at 삭제)."""
+        await self._db.execute(
+            "UPDATE members SET token_hash = NULL, "
+            "token_expires_at = NULL WHERE member_id = ?",
+            (member_id,),
+        )
+        logger.info("기존 토큰 무효화 완료: %s", member_id)
 
     async def _publish_auth_failed(self, member_id: str, reason: str) -> None:
         """인증 실패 이벤트 발행."""

--- a/tests/unit/test_password_token_invalidation.py
+++ b/tests/unit/test_password_token_invalidation.py
@@ -1,0 +1,110 @@
+"""패스워드 변경/리셋 시 토큰 무효화 테스트 (GAP-034, #772)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.core.database import Database
+from ante.eventbus import EventBus
+from ante.member.service import MemberService
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """테스트용 SQLite DB."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+async def service(db, eventbus):
+    svc = MemberService(db, eventbus)
+    await svc.initialize()
+    return svc
+
+
+class TestChangePasswordTokenInvalidation:
+    """change_password 후 토큰 무효화 검증."""
+
+    async def test_token_invalidated_after_change_password(self, service, db):
+        """패스워드 변경 후 token_hash, token_expires_at이 NULL이어야 한다."""
+        member, token, _ = await service.bootstrap_master("owner", "pass123")
+
+        # 변경 전: token_hash 존재
+        row = await db.fetch_one(
+            "SELECT token_hash, token_expires_at FROM members WHERE member_id = ?",
+            ("owner",),
+        )
+        assert row["token_hash"] is not None
+        assert row["token_hash"] != ""
+
+        await service.change_password("owner", "pass123", "newpass")
+
+        # 변경 후: token_hash가 NULL
+        row = await db.fetch_one(
+            "SELECT token_hash, token_expires_at FROM members WHERE member_id = ?",
+            ("owner",),
+        )
+        assert row["token_hash"] is None
+        assert row["token_expires_at"] is None
+
+    async def test_old_token_fails_after_change_password(self, service):
+        """패스워드 변경 후 기존 토큰으로 인증 실패."""
+        _, token, _ = await service.bootstrap_master("owner", "pass123")
+
+        # 변경 전: 토큰 인증 성공
+        m = await service.authenticate(token)
+        assert m.member_id == "owner"
+
+        await service.change_password("owner", "pass123", "newpass")
+
+        # 변경 후: 기존 토큰 인증 실패
+        with pytest.raises(PermissionError):
+            await service.authenticate(token)
+
+
+class TestResetPasswordTokenInvalidation:
+    """reset_password 후 토큰 무효화 검증."""
+
+    async def test_token_invalidated_after_reset_password(self, service, db):
+        """패스워드 리셋 후 token_hash, token_expires_at이 NULL이어야 한다."""
+        _, token, recovery_key = await service.bootstrap_master("owner", "pass123")
+
+        # 리셋 전: token_hash 존재
+        row = await db.fetch_one(
+            "SELECT token_hash, token_expires_at FROM members WHERE member_id = ?",
+            ("owner",),
+        )
+        assert row["token_hash"] is not None
+        assert row["token_hash"] != ""
+
+        await service.reset_password("owner", recovery_key, "resetpass")
+
+        # 리셋 후: token_hash가 NULL
+        row = await db.fetch_one(
+            "SELECT token_hash, token_expires_at FROM members WHERE member_id = ?",
+            ("owner",),
+        )
+        assert row["token_hash"] is None
+        assert row["token_expires_at"] is None
+
+    async def test_old_token_fails_after_reset_password(self, service):
+        """패스워드 리셋 후 기존 토큰으로 인증 실패."""
+        _, token, recovery_key = await service.bootstrap_master("owner", "pass123")
+
+        # 리셋 전: 토큰 인증 성공
+        m = await service.authenticate(token)
+        assert m.member_id == "owner"
+
+        await service.reset_password("owner", recovery_key, "resetpass")
+
+        # 리셋 후: 기존 토큰 인증 실패
+        with pytest.raises(PermissionError):
+            await service.authenticate(token)


### PR DESCRIPTION
## Summary
- `change_password()` 성공 후 `token_hash`, `token_expires_at`을 NULL로 설정하여 기존 토큰 즉시 무효화
- `reset_password()` 성공 후 동일하게 기존 토큰 즉시 무효화
- `RecoveryKeyManager._invalidate_token()` 내부 헬퍼 메서드 추가 (DB 직접 접근, TokenManager 의존 없음)

## Test plan
- [x] `change_password()` 후 DB에서 `token_hash`/`token_expires_at`이 NULL인지 검증
- [x] `change_password()` 후 기존 토큰으로 `authenticate()` 호출 시 `PermissionError` 발생 검증
- [x] `reset_password()` 후 DB에서 `token_hash`/`token_expires_at`이 NULL인지 검증
- [x] `reset_password()` 후 기존 토큰으로 `authenticate()` 호출 시 `PermissionError` 발생 검증
- [x] 기존 member 테스트 75개 전부 통과 확인

Refs #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)