### PR TITLE
fix(member): 패스워드 변경/리셋 시 NotificationEvent 발행 추가 #773

### DIFF
--- a/src/ante/member/recovery_key_manager.py
+++ b/src/ante/member/recovery_key_manager.py
@@ -50,6 +50,7 @@ class RecoveryKeyManager:
             (hash_password(new_password), member.member_id),
         )
         await self._invalidate_token(member.member_id)
+        await self._publish_password_changed(member.member_id)
         logger.info("패스워드 변경 완료: %s", member.member_id)
 
     async def reset_password(
@@ -70,6 +71,7 @@ class RecoveryKeyManager:
             (hash_password(new_password), member.member_id),
         )
         await self._invalidate_token(member.member_id)
+        await self._publish_password_reset(member.member_id)
         logger.info("패스워드 리셋 완료 (recovery key): %s", member.member_id)
 
     async def regenerate_recovery_key(self, member: Member, password: str) -> str:
@@ -99,6 +101,40 @@ class RecoveryKeyManager:
             (member_id,),
         )
         logger.info("기존 토큰 무효화 완료: %s", member_id)
+
+    async def _publish_password_changed(self, member_id: str) -> None:
+        """패스워드 변경 알림 발행."""
+        from ante.eventbus.events import NotificationEvent
+
+        await self._eventbus.publish(
+            NotificationEvent(
+                level="warning",
+                title="패스워드 변경",
+                message=(
+                    f"멤버 `{member_id}`의 패스워드가 변경되었습니다.\n"
+                    "기존 세션이 무효화되었습니다.\n"
+                    "본인이 아닌 경우 즉시 토큰을 재발급하세요."
+                ),
+                category="security",
+            )
+        )
+
+    async def _publish_password_reset(self, member_id: str) -> None:
+        """패스워드 리셋 알림 발행."""
+        from ante.eventbus.events import NotificationEvent
+
+        await self._eventbus.publish(
+            NotificationEvent(
+                level="warning",
+                title="패스워드 리셋",
+                message=(
+                    f"멤버 `{member_id}`의 패스워드가 recovery key로 리셋되었습니다.\n"
+                    "기존 세션이 무효화되었습니다.\n"
+                    "본인이 아닌 경우 즉시 recovery key를 재발급하세요."
+                ),
+                category="security",
+            )
+        )
 
     async def _publish_auth_failed(self, member_id: str, reason: str) -> None:
         """인증 실패 이벤트 발행."""

--- a/tests/unit/test_password_change_notification.py
+++ b/tests/unit/test_password_change_notification.py
@@ -1,0 +1,108 @@
+"""패스워드 변경/리셋 시 텔레그램 알림 발행 테스트 (GAP-035, #773)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.core.database import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import NotificationEvent
+from ante.member.service import MemberService
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """테스트용 SQLite DB."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+async def service(db, eventbus):
+    svc = MemberService(db, eventbus)
+    await svc.initialize()
+    return svc
+
+
+class TestChangePasswordNotification:
+    """change_password 성공 시 NotificationEvent 발행 검증."""
+
+    async def test_notification_published_on_change_password(self, service, eventbus):
+        """패스워드 변경 성공 시 warning 레벨 NotificationEvent가 발행되어야 한다."""
+        captured: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: captured.append(e))
+
+        _, _token, _ = await service.bootstrap_master("owner", "pass123")
+        await service.change_password("owner", "pass123", "newpass")
+
+        security_events = [
+            e for e in captured if e.category == "security" and "변경" in e.title
+        ]
+        assert len(security_events) == 1
+        evt = security_events[0]
+        assert evt.level == "warning"
+        assert evt.title == "패스워드 변경"
+        assert "`owner`" in evt.message
+        assert "세션이 무효화" in evt.message
+        assert "토큰을 재발급" in evt.message
+
+    async def test_no_notification_on_wrong_password(self, service, eventbus):
+        """잘못된 패스워드로 변경 시도 시 변경 알림이 발행되지 않아야 한다."""
+        captured: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: captured.append(e))
+
+        _, _token, _ = await service.bootstrap_master("owner", "pass123")
+
+        with pytest.raises(PermissionError):
+            await service.change_password("owner", "wrong", "newpass")
+
+        change_events = [
+            e for e in captured if e.category == "security" and "변경" in e.title
+        ]
+        assert len(change_events) == 0
+
+
+class TestResetPasswordNotification:
+    """reset_password 성공 시 NotificationEvent 발행 검증."""
+
+    async def test_notification_published_on_reset_password(self, service, eventbus):
+        """패스워드 리셋 성공 시 warning 레벨 NotificationEvent가 발행되어야 한다."""
+        captured: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: captured.append(e))
+
+        _, _token, recovery_key = await service.bootstrap_master("owner", "pass123")
+        await service.reset_password("owner", recovery_key, "resetpass")
+
+        security_events = [
+            e for e in captured if e.category == "security" and "리셋" in e.title
+        ]
+        assert len(security_events) == 1
+        evt = security_events[0]
+        assert evt.level == "warning"
+        assert evt.title == "패스워드 리셋"
+        assert "`owner`" in evt.message
+        assert "recovery key로 리셋" in evt.message
+        assert "세션이 무효화" in evt.message
+        assert "recovery key를 재발급" in evt.message
+
+    async def test_no_notification_on_wrong_recovery_key(self, service, eventbus):
+        """잘못된 recovery key로 리셋 시도 시 리셋 알림이 발행되지 않아야 한다."""
+        captured: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: captured.append(e))
+
+        _, _token, _ = await service.bootstrap_master("owner", "pass123")
+
+        with pytest.raises(PermissionError):
+            await service.reset_password("owner", "wrong-key", "resetpass")
+
+        reset_events = [
+            e for e in captured if e.category == "security" and "리셋" in e.title
+        ]
+        assert len(reset_events) == 0


### PR DESCRIPTION
## Summary
- `change_password()` 성공 후 security 카테고리 warning 레벨 NotificationEvent 발행 추가
- `reset_password()` 성공 후 security 카테고리 warning 레벨 NotificationEvent 발행 추가
- 4개 단위 테스트 추가 (성공 시 알림 발행 검증, 실패 시 미발행 검증)

## Test plan
- [x] `change_password` 성공 시 NotificationEvent 발행 확인
- [x] `change_password` 실패 시 NotificationEvent 미발행 확인
- [x] `reset_password` 성공 시 NotificationEvent 발행 확인
- [x] `reset_password` 실패 시 NotificationEvent 미발행 확인
- [x] 기존 테스트 79건 통과 확인 (test_password_token_invalidation + test_member)
- [x] ruff check / ruff format 통과

Refs #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)