### PR TITLE
fix(account): create()에서 account_id 형식 검증 추가 #774

### DIFF
--- a/src/ante/account/__init__.py
+++ b/src/ante/account/__init__.py
@@ -7,6 +7,7 @@ from ante.account.errors import (
     AccountImmutableFieldError,
     AccountNotFoundError,
     AccountSuspendedError,
+    InvalidAccountIdError,
     InvalidBrokerTypeError,
 )
 from ante.account.models import Account, AccountStatus, BrokerPreset, TradingMode
@@ -21,6 +22,7 @@ __all__ = [
     "AccountImmutableFieldError",
     "AccountNotFoundError",
     "AccountSuspendedError",
+    "InvalidAccountIdError",
     "AccountService",
     "AccountStatus",
     "BROKER_PRESETS",

--- a/src/ante/account/errors.py
+++ b/src/ante/account/errors.py
@@ -43,6 +43,12 @@ class AccountSuspendedError(AccountError):
     pass
 
 
+class InvalidAccountIdError(AccountError):
+    """account_id 형식이 올바르지 않음."""
+
+    pass
+
+
 class AccountImmutableFieldError(AccountError):
     """불변 필드 수정 시도."""
 

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
@@ -13,6 +14,7 @@ from ante.account.errors import (
     AccountDeletedException,
     AccountImmutableFieldError,
     AccountNotFoundError,
+    InvalidAccountIdError,
     InvalidBrokerTypeError,
 )
 from ante.account.models import Account, AccountStatus, TradingMode
@@ -102,8 +104,16 @@ class AccountService:
 
         Raises:
             AccountAlreadyExistsError: 동일 account_id가 이미 존재.
+            InvalidAccountIdError: account_id 형식이 올바르지 않음.
             InvalidBrokerTypeError: broker_type이 프리셋에 정의되지 않음.
         """
+        # account_id 형식 검증
+        if not re.fullmatch(r"[a-zA-Z0-9\-]{3,30}", account.account_id):
+            raise InvalidAccountIdError(
+                f"account_id 형식이 올바르지 않습니다: '{account.account_id}'. "
+                "영문, 숫자, 하이픈만 허용하며 3~30자여야 합니다."
+            )
+
         if account.account_id in self._accounts:
             raise AccountAlreadyExistsError(
                 f"계좌 '{account.account_id}'가 이미 존재합니다."

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -9,6 +9,7 @@ from ante.account.errors import (
     AccountAlreadyExistsError,
     AccountDeletedException,
     AccountNotFoundError,
+    InvalidAccountIdError,
     InvalidBrokerTypeError,
 )
 from ante.account.models import Account, AccountStatus, TradingMode
@@ -107,6 +108,49 @@ async def test_create_invalid_broker_type_raises(service):
 
     with pytest.raises(InvalidBrokerTypeError):
         await service.create(account)
+
+
+# ── account_id 형식 검증 ──────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "",
+        "ab",
+        "a" * 31,
+        "has space",
+        "has_under",
+        "id@#$",
+    ],
+)
+async def test_create_invalid_account_id_raises(service, bad_id):
+    """형식 미준수 account_id로 생성 시 InvalidAccountIdError."""
+    account = _make_account(account_id=bad_id)
+
+    with pytest.raises(InvalidAccountIdError):
+        await service.create(account)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "good_id",
+    [
+        "abc",
+        "a" * 30,
+        "test",
+        "my-account-01",
+        "ABC",
+        "Test-123",
+    ],
+)
+async def test_create_valid_account_id_passes(service, good_id):
+    """형식 준수 account_id로 생성 시 정상 통과."""
+    account = _make_account(account_id=good_id)
+    result = await service.create(account)
+
+    assert result.account_id == good_id
 
 
 # ── 조회 (get / list) ──────────────────────────────


### PR DESCRIPTION
## Summary
- `AccountService.create()`에 `account_id` 정규식 검증 추가: `[a-zA-Z0-9\-]{3,30}`
- 형식 미준수 시 `InvalidAccountIdError` 발생 (기존 `AccountError` 상속 패턴)
- 빈 문자열, 2자 미만, 31자 초과, 공백/언더스코어/특수문자 등 잘못된 ID 차단

## Test plan
- [x] 잘못된 account_id 6가지 케이스에서 `InvalidAccountIdError` 발생 확인
- [x] 유효한 account_id 6가지 케이스에서 정상 생성 확인
- [x] 기존 테스트 38개 전체 통과 (기본 "test" ID 포함)
- [x] Account API 테스트 21개 전체 통과
- [x] ruff check / ruff format 통과

Refs #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)