### PR TITLE
fix(account): create()에서 required_credentials 검증 추가 #775

### DIFF
--- a/src/ante/account/__init__.py
+++ b/src/ante/account/__init__.py
@@ -9,6 +9,7 @@ from ante.account.errors import (
     AccountSuspendedError,
     InvalidAccountIdError,
     InvalidBrokerTypeError,
+    MissingCredentialsError,
 )
 from ante.account.models import Account, AccountStatus, BrokerPreset, TradingMode
 from ante.account.presets import BROKER_PRESETS
@@ -28,5 +29,6 @@ __all__ = [
     "BROKER_PRESETS",
     "BrokerPreset",
     "InvalidBrokerTypeError",
+    "MissingCredentialsError",
     "TradingMode",
 ]

--- a/src/ante/account/errors.py
+++ b/src/ante/account/errors.py
@@ -25,6 +25,12 @@ class InvalidBrokerTypeError(AccountError):
     pass
 
 
+class MissingCredentialsError(AccountError):
+    """필수 credentials 키 누락."""
+
+    pass
+
+
 class AccountAlreadySuspendedError(AccountError):
     """이미 정지 상태인 계좌에 대한 재정지 시도."""
 

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -16,6 +16,7 @@ from ante.account.errors import (
     AccountNotFoundError,
     InvalidAccountIdError,
     InvalidBrokerTypeError,
+    MissingCredentialsError,
 )
 from ante.account.models import Account, AccountStatus, TradingMode
 from ante.account.presets import BROKER_PRESETS
@@ -106,6 +107,7 @@ class AccountService:
             AccountAlreadyExistsError: 동일 account_id가 이미 존재.
             InvalidAccountIdError: account_id 형식이 올바르지 않음.
             InvalidBrokerTypeError: broker_type이 프리셋에 정의되지 않음.
+            MissingCredentialsError: 필수 credentials 키 누락.
         """
         # account_id 형식 검증
         if not re.fullmatch(r"[a-zA-Z0-9\-]{3,30}", account.account_id):
@@ -134,6 +136,18 @@ class AccountService:
             raise InvalidBrokerTypeError(
                 f"유효하지 않은 broker_type: '{account.broker_type}'. "
                 f"가능한 값: {list(BROKER_PRESETS.keys())}"
+            )
+
+        # credentials 필수 키 검증
+        preset = BROKER_PRESETS[account.broker_type]
+        missing = [
+            k for k in preset.required_credentials if k not in account.credentials
+        ]
+        if missing:
+            raise MissingCredentialsError(
+                f"필수 credentials 누락: {missing}. "
+                f"broker_type '{account.broker_type}'에 필요: "
+                f"{preset.required_credentials}"
             )
 
         now = datetime.now(UTC)
@@ -503,7 +517,7 @@ class AccountService:
             trading_hours_end=preset.trading_hours_end,
             trading_mode=TradingMode.VIRTUAL,
             broker_type="test",
-            credentials={},
+            credentials={k: "test" for k in preset.required_credentials},
             buy_commission_rate=preset.buy_commission_rate,
             sell_commission_rate=preset.sell_commission_rate,
         )

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -11,6 +11,7 @@ from ante.account.errors import (
     AccountNotFoundError,
     InvalidAccountIdError,
     InvalidBrokerTypeError,
+    MissingCredentialsError,
 )
 from ante.account.models import Account, AccountStatus, TradingMode
 from ante.account.presets import BROKER_PRESETS
@@ -52,6 +53,8 @@ def _make_account(
     **kwargs,
 ) -> Account:
     """테스트용 Account 생성 헬퍼."""
+    if "credentials" not in kwargs:
+        kwargs["credentials"] = {"app_key": "test", "app_secret": "test"}
     return Account(
         account_id=account_id,
         name=name,
@@ -108,6 +111,39 @@ async def test_create_invalid_broker_type_raises(service):
 
     with pytest.raises(InvalidBrokerTypeError):
         await service.create(account)
+
+
+# ── credentials 필수 키 검증 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_missing_credentials_raises(service):
+    """필수 credentials 키 누락 시 MissingCredentialsError."""
+    account = _make_account(credentials={})
+
+    with pytest.raises(MissingCredentialsError, match="app_key"):
+        await service.create(account)
+
+
+@pytest.mark.asyncio
+async def test_create_partial_credentials_raises(service):
+    """일부 credentials 키만 제공 시 누락 키를 메시지에 포함."""
+    account = _make_account(credentials={"app_key": "key1"})
+
+    with pytest.raises(MissingCredentialsError, match="app_secret"):
+        await service.create(account)
+
+
+@pytest.mark.asyncio
+async def test_create_full_credentials_passes(service):
+    """모든 필수 credentials 제공 시 정상 생성."""
+    account = _make_account(
+        credentials={"app_key": "key1", "app_secret": "secret1"},
+    )
+    result = await service.create(account)
+
+    assert result.account_id == "test"
+    assert result.credentials["app_key"] == "key1"
 
 
 # ── account_id 형식 검증 ──────────────────────────────

--- a/tests/unit/test_account_delete_events.py
+++ b/tests/unit/test_account_delete_events.py
@@ -46,6 +46,8 @@ def _make_account(
     **kwargs,
 ) -> Account:
     """테스트용 Account 생성 헬퍼."""
+    if "credentials" not in kwargs:
+        kwargs["credentials"] = {"app_key": "test", "app_secret": "test"}
     return Account(
         account_id=account_id,
         name=name,

--- a/tests/unit/test_account_immutable_fields.py
+++ b/tests/unit/test_account_immutable_fields.py
@@ -41,6 +41,7 @@ def _make_account(account_id: str = "test") -> Account:
         exchange="TEST",
         currency="KRW",
         broker_type="test",
+        credentials={"app_key": "test", "app_secret": "test"},
     )
 
 

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -962,6 +962,7 @@ class TestBotManagerExchangeValidation:
             exchange="KRX",
             currency="KRW",
             broker_type="test",
+            credentials={"app_key": "test", "app_secret": "test"},
         )
         await account_service.create(account)
         config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="krx-acct")
@@ -982,6 +983,7 @@ class TestBotManagerExchangeValidation:
             exchange="NYSE",
             currency="USD",
             broker_type="test",
+            credentials={"app_key": "test", "app_secret": "test"},
         )
         await account_service.create(account)
         config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="nyse-acct")
@@ -1011,6 +1013,7 @@ class TestBotManagerExchangeValidation:
             exchange="NYSE",
             currency="USD",
             broker_type="test",
+            credentials={"app_key": "test", "app_secret": "test"},
         )
         await account_service.create(account)
         config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="nyse-acct")

--- a/tests/unit/test_bot_account_status.py
+++ b/tests/unit/test_bot_account_status.py
@@ -131,6 +131,7 @@ class TestBotAccountStatusValidation:
             currency="KRW",
             broker_type="test",
             status=AccountStatus.ACTIVE,
+            credentials={"app_key": "test", "app_secret": "test"},
         )
         await account_service.create(account)
         config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="active-acct")
@@ -146,6 +147,7 @@ class TestBotAccountStatusValidation:
             currency="KRW",
             broker_type="test",
             status=AccountStatus.ACTIVE,
+            credentials={"app_key": "test", "app_secret": "test"},
         )
         await account_service.create(account)
         await account_service.suspend(
@@ -165,6 +167,7 @@ class TestBotAccountStatusValidation:
             currency="KRW",
             broker_type="test",
             status=AccountStatus.ACTIVE,
+            credentials={"app_key": "test", "app_secret": "test"},
         )
         await account_service.create(account)
         await account_service.suspend(
@@ -187,6 +190,7 @@ class TestBotAccountStatusValidation:
             currency="KRW",
             broker_type="test",
             status=AccountStatus.ACTIVE,
+            credentials={"app_key": "test", "app_secret": "test"},
         )
         await account_service.create(account)
         await account_service.suspend(

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -300,6 +300,7 @@ async def test_init_account_skips_when_accounts_exist(tmp_path: Path) -> None:
         exchange="KRX",
         trading_mode=TradingMode.LIVE,
         currency="KRW",
+        credentials={"app_key": "test", "app_secret": "test", "account_no": "test"},
     )
     await account_service.create(existing)
 
@@ -492,6 +493,7 @@ async def test_treasury_manager_multi_account(tmp_path: Path) -> None:
             exchange="TEST",
             trading_mode=TradingMode.VIRTUAL,
             currency="KRW",
+            credentials={"app_key": "test", "app_secret": "test"},
         )
         await account_service.create(account)
 
@@ -531,6 +533,7 @@ async def test_rule_engine_manager_multi_account(tmp_path: Path) -> None:
             exchange="TEST",
             trading_mode=TradingMode.VIRTUAL,
             currency="KRW",
+            credentials={"app_key": "test", "app_secret": "test"},
         )
         await account_service.create(account)
 


### PR DESCRIPTION
## Summary
- `AccountService.create()`에서 broker_type 프리셋의 `required_credentials` 키 존재 여부를 검증하고, 누락 시 `MissingCredentialsError` 발생
- 에러 메시지에 누락 키 목록과 해당 broker_type에 필요한 전체 키 목록 포함
- `create_default_test_account()`가 프리셋의 required_credentials를 자동으로 채우도록 수정
- 기존 테스트의 `_make_account` 헬퍼에 기본 credentials 추가하여 전체 테스트 통과

## Test plan
- [x] 빈 credentials로 생성 시 `MissingCredentialsError` 발생 확인
- [x] 일부 키만 제공 시 누락 키가 에러 메시지에 포함되는지 확인
- [x] 모든 필수 키 제공 시 정상 생성 확인
- [x] 기존 96개 테스트 전체 통과 확인
- [x] ruff check / ruff format 통과

Refs #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)