### PR TITLE
fix(trade): PerformanceTracker.calculate() account_id 필수화 #776

### DIFF
--- a/src/ante/cli/commands/strategy.py
+++ b/src/ante/cli/commands/strategy.py
@@ -347,10 +347,11 @@ def _load_strategy_params(filepath: str) -> dict | None:
 
 @strategy.command("performance")
 @click.argument("name")
+@click.option("--account-id", default=None, help="계좌 ID (미지정 시 'default')")
 @click.pass_context
 @require_auth
 @require_scope("strategy:read")
-def strategy_performance(ctx: click.Context, name: str) -> None:
+def strategy_performance(ctx: click.Context, name: str, account_id: str | None) -> None:
     """전략 전체 성과 집계 (모든 봇 합산, Agent 피드백용)."""
     fmt = get_formatter(ctx)
 
@@ -370,7 +371,10 @@ def strategy_performance(ctx: click.Context, name: str) -> None:
             tracker = PerformanceTracker(db)
             # 최신 버전의 strategy_id 기준으로 성과 계산
             record = records[0]
-            metrics = await tracker.calculate(strategy_id=record.name)
+            resolved = account_id or "default"
+            metrics = await tracker.calculate(
+                account_id=resolved, strategy_id=record.name
+            )
 
             return {
                 "strategy_name": record.name,

--- a/src/ante/report/feedback.py
+++ b/src/ante/report/feedback.py
@@ -22,7 +22,11 @@ class PerformanceFeedback:
 
     async def get_bot_performance(self, bot_id: str) -> dict:
         """봇의 실전 성과 조회."""
-        metrics = await self._trade.get_performance(bot_id=bot_id)
+        bot = self._bots.get_bot(bot_id)
+        account_id = bot.config.account_id if bot else "default"
+        metrics = await self._trade.get_performance(
+            account_id=account_id, bot_id=bot_id
+        )
         positions = await self._trade.get_positions(bot_id)
         return {
             "bot_id": bot_id,

--- a/src/ante/trade/performance.py
+++ b/src/ante/trade/performance.py
@@ -42,7 +42,7 @@ class PerformanceTracker:
 
     async def calculate(
         self,
-        account_id: str | None = None,
+        account_id: str,
         bot_id: str | None = None,
         strategy_id: str | None = None,
         from_date: datetime | None = None,
@@ -50,7 +50,7 @@ class PerformanceTracker:
     ) -> PerformanceMetrics:
         """성과 지표 계산.
 
-        account_id, bot_id, strategy_id 중 하나 이상 필수.
+        account_id는 필수. 계좌를 섞어 계산한 성과 지표는 의미가 없다.
         """
         trades = await self._get_filled_trades(
             account_id=account_id,
@@ -321,19 +321,16 @@ class PerformanceTracker:
 
     async def _get_filled_trades(
         self,
-        account_id: str | None = None,
+        account_id: str,
         bot_id: str | None = None,
         strategy_id: str | None = None,
         from_date: datetime | None = None,
         to_date: datetime | None = None,
     ) -> list[TradeRecord]:
         """체결 완료 거래 조회."""
-        conditions: list[str] = ["status = ?"]
-        params: list[Any] = [TradeStatus.FILLED.value]
+        conditions: list[str] = ["status = ?", "account_id = ?"]
+        params: list[Any] = [TradeStatus.FILLED.value, account_id]
 
-        if account_id:
-            conditions.append("account_id = ?")
-            params.append(account_id)
         if bot_id:
             conditions.append("bot_id = ?")
             params.append(bot_id)

--- a/src/ante/trade/service.py
+++ b/src/ante/trade/service.py
@@ -94,7 +94,7 @@ class TradeService:
 
     async def get_performance(
         self,
-        account_id: str | None = None,
+        account_id: str,
         bot_id: str | None = None,
         strategy_id: str | None = None,
         from_date: datetime | None = None,
@@ -111,10 +111,10 @@ class TradeService:
 
     # ── 요약 ──────────────────────────────────────
 
-    async def get_summary(self, bot_id: str) -> dict:
+    async def get_summary(self, bot_id: str, account_id: str) -> dict:
         """봇 요약 정보 (대시보드용)."""
         positions = await self.get_positions(bot_id)
-        performance = await self.get_performance(bot_id=bot_id)
+        performance = await self.get_performance(account_id=account_id, bot_id=bot_id)
         recent_trades = await self.get_trades(bot_id=bot_id, limit=10)
 
         return {

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -158,16 +158,29 @@ async def get_strategy_performance(
     db: Annotated[Any, Depends(get_db)],
     bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
     trade_service: Annotated[Any | None, Depends(get_trade_service_optional)],
+    account_id: str | None = None,
 ) -> dict:
     """전략 성과 지표 조회."""
     record = await registry.get(strategy_id)
     if not record:
         raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
 
+    # account_id 결정: 쿼리 파라미터 우선, 없으면 봇에서 추출
+    resolved_account_id = account_id
+    if not resolved_account_id and bot_manager is not None:
+        for b in bot_manager.list_bots():
+            if b.get("strategy_id") == strategy_id:
+                resolved_account_id = b.get("account_id")
+                break
+    if not resolved_account_id:
+        resolved_account_id = "default"
+
     from ante.trade.performance import PerformanceTracker
 
     tracker = PerformanceTracker(db)
-    metrics = await tracker.calculate(strategy_id=strategy_id)
+    metrics = await tracker.calculate(
+        account_id=resolved_account_id, strategy_id=strategy_id
+    )
 
     result = asdict(metrics)
     # sharpe_ratio가 None이면 응답 모델(float)과 호환되도록 0.0으로 변환

--- a/tests/unit/test_trade.py
+++ b/tests/unit/test_trade.py
@@ -699,7 +699,7 @@ class TestPositionHistory:
 class TestPerformanceTracker:
     async def test_empty_trades_returns_empty_metrics(self, performance):
         """거래 없으면 빈 지표."""
-        metrics = await performance.calculate(bot_id="nonexistent")
+        metrics = await performance.calculate(account_id="acc1", bot_id="nonexistent")
         assert metrics.total_trades == 0
         assert metrics.win_rate == 0.0
         assert metrics.net_pnl == 0.0
@@ -768,7 +768,7 @@ class TestPerformanceTracker:
         )
         await recorder._on_filled(sell2)
 
-        metrics = await performance.calculate(bot_id="bot1")
+        metrics = await performance.calculate(account_id="default", bot_id="bot1")
         assert metrics.total_trades == 2  # 매도 2건
         assert metrics.winning_trades == 1
         assert metrics.losing_trades == 1
@@ -833,7 +833,7 @@ class TestPerformanceTracker:
         )
         await recorder._on_filled(sell)
 
-        metrics = await performance.calculate(bot_id="bot1")
+        metrics = await performance.calculate(account_id="default", bot_id="bot1")
         assert metrics.profit_factor == float("inf")
 
 
@@ -847,7 +847,7 @@ class TestTradeService:
             _make_filled_event(side="buy", quantity=10, price=50000)
         )
 
-        summary = await service.get_summary("bot1")
+        summary = await service.get_summary("bot1", account_id="default")
         assert "positions" in summary
         assert "performance" in summary
         assert "recent_trades" in summary
@@ -924,7 +924,7 @@ class TestTradeService:
 
     async def test_get_performance_delegates(self, service):
         """성과 조회 위임."""
-        metrics = await service.get_performance(bot_id="bot1")
+        metrics = await service.get_performance(account_id="default", bot_id="bot1")
         assert isinstance(metrics, PerformanceMetrics)
 
 


### PR DESCRIPTION
## Summary
- `PerformanceTracker.calculate()`와 `TradeService.get_performance()`의 `account_id` 파라미터를 `str | None = None`에서 `str`(필수)로 변경
- `TradeService.get_summary()`에 `account_id` 파라미터 추가
- 모든 호출처(웹 API 라우트, CLI 커맨드, PerformanceFeedback)에서 `account_id`를 전달하도록 수정
- `_get_filled_trades()` 내부에서 `account_id` 필터를 항상 적용하도록 변경

## Test plan
- [x] `tests/unit/test_trade.py` 전체 53건 통과
- [x] 전체 유닛 테스트 2703건 통과 (2 skipped)
- [x] ruff check / ruff format 통과

Refs #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)