### PR TITLE
fix(treasury): reserve_for_order() amount <= 0 입력 검증 추가 #801

### DIFF
--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -509,6 +509,9 @@ class Treasury:
         self, bot_id: str, order_id: str, amount: float
     ) -> bool:
         """주문 제출 시 자금 예약."""
+        if amount <= 0:
+            raise ValueError("amount must be positive")
+
         budget = self._budgets.get(bot_id)
         if not budget or budget.available < amount:
             return False

--- a/tests/unit/test_treasury.py
+++ b/tests/unit/test_treasury.py
@@ -288,6 +288,18 @@ class TestReservation:
         assert budget.available == 500_000.0
         assert budget.reserved == 500_000.0
 
+    async def test_reserve_zero_amount_raises(self, treasury):
+        """amount가 0이면 ValueError 발생."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        with pytest.raises(ValueError, match="amount must be positive"):
+            await treasury.reserve_for_order("bot1", "ord1", 0)
+
+    async def test_reserve_negative_amount_raises(self, treasury):
+        """음수 amount이면 ValueError 발생."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        with pytest.raises(ValueError, match="amount must be positive"):
+            await treasury.reserve_for_order("bot1", "ord1", -100_000.0)
+
     async def test_reserve_insufficient(self, treasury):
         """가용 예산 부족 시 예약 실패."""
         await treasury.allocate("bot1", 100_000.0)


### PR DESCRIPTION
## Summary
- `Treasury.reserve_for_order()`에 `amount <= 0` 가드 추가하여 음수/0 입력 시 `ValueError("amount must be positive")` 발생
- 음수 및 0 amount에 대한 단위 테스트 2건 추가

## Test plan
- [x] `test_reserve_zero_amount_raises`: amount=0일 때 ValueError 발생 확인
- [x] `test_reserve_negative_amount_raises`: 음수 amount일 때 ValueError 발생 확인
- [x] 기존 예약 관련 테스트 전체 통과 확인 (6/6 passed)

Refs #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)