### PR TITLE
fix(bot): 연속 타임아웃 초과 시 ERROR 상태 전이 및 BotErrorEvent 발행 #793

### DIFF
--- a/src/ante/bot/bot.py
+++ b/src/ante/bot/bot.py
@@ -126,11 +126,23 @@ class Bot:
                         self._max_consecutive_failures,
                     )
                     if self._consecutive_failures >= self._max_consecutive_failures:
+                        msg = (
+                            f"연속 타임아웃 한도 초과 "
+                            f"({self._consecutive_failures}/{self._max_consecutive_failures})"
+                        )
                         logger.error(
-                            "연속 타임아웃 한도 초과 — 봇 중지: %s",
+                            "연속 타임아웃 한도 초과 — 봇 ERROR 전이: %s",
                             self.bot_id,
                         )
-                        await self.stop()
+                        self.status = BotStatus.ERROR
+                        self.error_message = msg
+                        await self._eventbus.publish(
+                            BotErrorEvent(
+                                bot_id=self.bot_id,
+                                account_id=self.config.account_id,
+                                error_message=msg,
+                            )
+                        )
                         return
                     await asyncio.sleep(self.config.interval_seconds)
                     continue

--- a/tests/unit/test_bot_guard.py
+++ b/tests/unit/test_bot_guard.py
@@ -107,18 +107,23 @@ class TestStepTimeout:
         ]
         assert len(order_calls) == 0
 
-    async def test_consecutive_timeout_stops_bot(self) -> None:
-        """연속 3회 타임아웃 시 봇 중지."""
+    async def test_consecutive_timeout_transitions_to_error(self) -> None:
+        """연속 3회 타임아웃 시 ERROR 상태 전이 + BotErrorEvent 발행."""
         bot = _make_bot(_SlowStrategy, step_timeout=1, interval=10)
         bot.strategy = _SlowStrategy(ctx=MagicMock())
         bot.status = BotStatus.RUNNING
 
-        # stop()이 호출되는지 확인
-        with patch.object(bot, "stop", new_callable=AsyncMock) as mock_stop:
-            await bot._run_loop()
-            mock_stop.assert_called_once()
+        await bot._run_loop()
 
+        assert bot.status == BotStatus.ERROR
         assert bot._consecutive_failures >= 3
+        # BotErrorEvent 발행 검증
+        error_calls = [
+            c
+            for c in bot._eventbus.publish.call_args_list
+            if "BotErrorEvent" in str(type(c[0][0]))
+        ]
+        assert len(error_calls) >= 1
 
     async def test_normal_execution_resets_counter(self) -> None:
         """정상 실행 시 카운터 리셋."""

--- a/tests/unit/test_bot_timeout_error.py
+++ b/tests/unit/test_bot_timeout_error.py
@@ -1,0 +1,167 @@
+"""연속 타임아웃 시 ERROR 상태 전이 및 BotErrorEvent 발행 테스트 (#793)."""
+
+import asyncio
+
+import pytest
+
+from ante.bot import Bot, BotConfig, BotStatus
+from ante.eventbus import EventBus
+from ante.eventbus.events import BotErrorEvent
+from ante.strategy import (
+    DataProvider,
+    OrderView,
+    PortfolioView,
+    Signal,
+    Strategy,
+    StrategyContext,
+    StrategyMeta,
+)
+
+# ── Fake 구현체 ──────────────────────────────────
+
+
+class FakeDataProvider(DataProvider):
+    async def get_ohlcv(self, symbol, timeframe="1d", limit=100):
+        return [{"close": 100.0}]
+
+    async def get_current_price(self, symbol):
+        return 100.0
+
+    async def get_indicator(self, symbol, indicator, params=None):
+        return {}
+
+
+class FakePortfolioView(PortfolioView):
+    def get_positions(self, bot_id):
+        return {}
+
+    def get_balance(self, bot_id):
+        return {"total": 1000000.0, "available": 500000.0}
+
+
+class FakeOrderView(OrderView):
+    def get_open_orders(self, bot_id):
+        return []
+
+
+class TimeoutStrategy(Strategy):
+    """on_step에서 항상 타임아웃을 유발하는 전략."""
+
+    meta = StrategyMeta(name="timeout", version="0.1.0", description="test")
+
+    async def on_step(self, context) -> list[Signal]:
+        await asyncio.sleep(9999)
+        return []
+
+
+# ── Fixtures ──────────────────────────────────
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+def ctx():
+    return StrategyContext(
+        bot_id="bot1",
+        data_provider=FakeDataProvider(),
+        portfolio=FakePortfolioView(),
+        order_view=FakeOrderView(),
+    )
+
+
+def _make_bot(strategy_cls, eventbus, ctx, *, step_timeout=0.01):
+    """테스트용 Bot 생성. interval 검증 통과 후 짧은 값으로 교체한다."""
+    config = BotConfig(
+        bot_id="bot1",
+        strategy_id="test_stg",
+        account_id="test",
+        interval_seconds=60,
+        step_timeout_seconds=step_timeout,
+    )
+    # 검증 통과 후 interval을 짧게 교체하여 테스트 속도 확보
+    config.interval_seconds = 0.01
+    bot = Bot(
+        config=config,
+        strategy_cls=strategy_cls,
+        ctx=ctx,
+        eventbus=eventbus,
+    )
+    bot._max_consecutive_failures = 3
+    return bot
+
+
+# ── Tests ─────────────────────────────────────
+
+
+class TestConsecutiveTimeoutError:
+    """연속 타임아웃 초과 시 ERROR 전이 테스트."""
+
+    async def test_consecutive_timeout_transitions_to_error(self, eventbus, ctx):
+        """연속 타임아웃이 한도를 초과하면 BotStatus.ERROR로 전이해야 한다."""
+        bot = _make_bot(TimeoutStrategy, eventbus, ctx)
+
+        bot.strategy = TimeoutStrategy(ctx=ctx)
+        bot.status = BotStatus.RUNNING
+
+        await bot._run_loop()
+
+        assert bot.status == BotStatus.ERROR
+        assert bot.error_message is not None
+        assert "타임아웃" in bot.error_message
+
+    async def test_consecutive_timeout_publishes_bot_error_event(self, eventbus, ctx):
+        """연속 타임아웃 초과 시 BotErrorEvent가 발행되어야 한다."""
+        bot = _make_bot(TimeoutStrategy, eventbus, ctx)
+        bot.strategy = TimeoutStrategy(ctx=ctx)
+        bot.status = BotStatus.RUNNING
+
+        captured_events: list[BotErrorEvent] = []
+
+        async def on_error(event: BotErrorEvent) -> None:
+            captured_events.append(event)
+
+        eventbus.subscribe(BotErrorEvent, on_error)
+
+        await bot._run_loop()
+
+        assert len(captured_events) == 1
+        evt = captured_events[0]
+        assert evt.bot_id == "bot1"
+        assert evt.account_id == "test"
+        assert "타임아웃" in evt.error_message
+
+    async def test_timeout_below_limit_keeps_running(self, eventbus, ctx):
+        """타임아웃 횟수가 한도 미만이면 RUNNING 상태를 유지하고 카운터가 리셋된다."""
+        call_count = 0
+        stop_after = 4  # 4번째 호출 후 루프 탈출
+
+        class PartialTimeoutStrategy(Strategy):
+            """처음 2회는 타임아웃, 이후 정상 반환 후 루프 탈출."""
+
+            meta = StrategyMeta(
+                name="partial_timeout", version="0.1.0", description="test"
+            )
+
+            async def on_step(self, context) -> list[Signal]:
+                nonlocal call_count
+                call_count += 1
+                if call_count <= 2:
+                    await asyncio.sleep(9999)
+                if call_count >= stop_after:
+                    bot.status = BotStatus.STOPPED
+                return []
+
+        bot = _make_bot(PartialTimeoutStrategy, eventbus, ctx)
+        bot.strategy = PartialTimeoutStrategy(ctx=ctx)
+        bot.status = BotStatus.RUNNING
+
+        await bot._run_loop()
+
+        # STOPPED로 정상 탈출 (ERROR가 아님)
+        assert bot.status == BotStatus.STOPPED
+        # 정상 실행 후 연속 실패 카운터가 리셋
+        assert bot._consecutive_failures == 0
+        assert call_count >= 3


### PR DESCRIPTION
## Summary
- 연속 타임아웃이 한도(`_max_consecutive_failures`)를 초과할 때 `self.stop()`으로 STOPPED 전이하던 것을 `BotStatus.ERROR`로 전이하고 `BotErrorEvent`를 발행하도록 수정
- 예외 발생 시의 에러 처리 경로(`except Exception`)와 동일한 패턴으로 일관성 확보

## Changes
- `src/ante/bot/bot.py`: 타임아웃 한도 초과 시 `self.stop()` 대신 `self.status = BotStatus.ERROR` + `BotErrorEvent` 발행
- `tests/unit/test_bot_timeout_error.py`: 신규 테스트 3건
  - ERROR 상태 전이 검증
  - BotErrorEvent 발행 검증
  - 한도 미만 타임아웃 시 RUNNING 유지 및 카운터 리셋 검증

## Test plan
- [x] `test_consecutive_timeout_transitions_to_error` — 3회 연속 타임아웃 후 ERROR 전이
- [x] `test_consecutive_timeout_publishes_bot_error_event` — BotErrorEvent 발행 및 필드 검증
- [x] `test_timeout_below_limit_keeps_running` — 2회 타임아웃 후 정상 복귀 시 RUNNING 유지
- [x] 기존 `test_bot.py` 52건 전체 통과 (회귀 없음)

Refs #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)