### PR TITLE
fix(treasury): treasury_transactions account_id DEFAULT 제거, NOT NULL 강제 #804

### DIFF
--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS bot_budgets (
 CREATE TABLE IF NOT EXISTS treasury_transactions (
     id               INTEGER PRIMARY KEY AUTOINCREMENT,
     bot_id           TEXT,
-    account_id       TEXT DEFAULT '',
+    account_id       TEXT NOT NULL,
     transaction_type TEXT NOT NULL,
     amount           REAL NOT NULL,
     description      TEXT DEFAULT '',


### PR DESCRIPTION
## Summary
- `treasury_transactions` DDL에서 `account_id` 컬럼의 `DEFAULT ''`를 제거하고 `NOT NULL`만 유지
- 기존 INSERT 코드(`_record_transaction`)는 이미 `self._account_id`를 명시적으로 전달하므로 영향 없음
- 전체 treasury 관련 테스트 180건 통과 확인

## Test plan
- [x] 기존 테스트 통과 (`test_bot_delete_budget.py`, `test_bot_stop_release.py` 포함 180건)
- [x] DDL에서 DEFAULT 제거, NOT NULL 유지 확인
- [x] ruff check / ruff format 통과

Refs #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)