### PR TITLE
fix(member): reactivate()에 MemberReactivatedEvent 발행 추가 #797

### DIFF
--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -413,6 +413,14 @@ class MemberSuspendedEvent(Event):
 
 
 @dataclass(frozen=True)
+class MemberReactivatedEvent(Event):
+    """MemberService → EventBus: 멤버 재활성화."""
+
+    member_id: str = ""
+    reactivated_by: str = ""
+
+
+@dataclass(frozen=True)
 class MemberRevokedEvent(Event):
     """MemberService → EventBus: 멤버 폐기."""
 

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -504,6 +504,15 @@ class MemberService:
             (MemberStatus.ACTIVE, member_id),
         )
 
+        from ante.eventbus.events import MemberReactivatedEvent
+
+        await self._eventbus.publish(
+            MemberReactivatedEvent(
+                member_id=member_id,
+                reactivated_by=reactivated_by,
+            )
+        )
+
         logger.info("멤버 재활성화: %s (by %s)", member_id, reactivated_by)
         member.status = MemberStatus.ACTIVE
         return member

--- a/tests/unit/test_member.py
+++ b/tests/unit/test_member.py
@@ -298,6 +298,18 @@ class TestSuspendReactivateRevoke:
         assert len(events) == 1
         assert events[0].member_id == "agent-01"
 
+    async def test_reactivate_publishes_event(self, service, eventbus):
+        from ante.eventbus.events import MemberReactivatedEvent
+
+        events: list = []
+        eventbus.subscribe(MemberReactivatedEvent, events.append)
+        await service.register("agent-01", MemberType.AGENT)
+        await service.suspend("agent-01", suspended_by="owner")
+        await service.reactivate("agent-01", reactivated_by="owner")
+        assert len(events) == 1
+        assert events[0].member_id == "agent-01"
+        assert events[0].reactivated_by == "owner"
+
     async def test_revoke_publishes_event(self, service, eventbus):
         events = []
         eventbus.subscribe(MemberRevokedEvent, events.append)


### PR DESCRIPTION
## Summary
- `MemberReactivatedEvent` frozen dataclass 정의 (member_id, reactivated_by 필드, MemberSuspendedEvent 패턴 동일)
- `MemberService.reactivate()` 끝에 이벤트 발행 추가
- 이벤트 발행 및 필드 값 검증 단위 테스트 추가

Refs #797

## Test plan
- [x] `test_reactivate_publishes_event`: suspend → reactivate 후 MemberReactivatedEvent 발행 확인, member_id/reactivated_by 필드 검증
- [x] 기존 76개 테스트 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)