### PR TITLE
fix(member): RecoveryKeyManager 인증 실패 시 NotificationEvent 발행 추가

### DIFF
--- a/src/ante/member/recovery_key_manager.py
+++ b/src/ante/member/recovery_key_manager.py
@@ -137,11 +137,20 @@ class RecoveryKeyManager:
         )
 
     async def _publish_auth_failed(self, member_id: str, reason: str) -> None:
-        """인증 실패 이벤트 발행."""
-        from ante.eventbus.events import MemberAuthFailedEvent
+        """인증 실패 이벤트 + 알림 발행."""
+        from ante.eventbus.events import MemberAuthFailedEvent, NotificationEvent
 
         await self._eventbus.publish(
             MemberAuthFailedEvent(member_id=member_id, reason=reason)
+        )
+        target = f"멤버 `{member_id}`" if member_id else "알 수 없는 멤버"
+        await self._eventbus.publish(
+            NotificationEvent(
+                level="warning",
+                title="인증 실패",
+                message=f"{target}\n사유: {reason}",
+                category="member",
+            )
         )
 
     @staticmethod

--- a/tests/unit/test_recovery_auth_notification.py
+++ b/tests/unit/test_recovery_auth_notification.py
@@ -1,0 +1,78 @@
+"""RecoveryKeyManager 인증 실패 시 NotificationEvent 발행 테스트 (#807)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.core.database import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import MemberAuthFailedEvent, NotificationEvent
+from ante.member.service import MemberService
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """테스트용 SQLite DB."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+async def service(db, eventbus):
+    svc = MemberService(db, eventbus)
+    await svc.initialize()
+    return svc
+
+
+class TestRecoveryAuthFailedNotification:
+    """RecoveryKeyManager._publish_auth_failed 시 NotificationEvent 발행 검증."""
+
+    async def test_notification_on_invalid_recovery_key(self, service, eventbus):
+        """잘못된 recovery key로 리셋 시도 시 NotificationEvent 발행."""
+        notifications: list[NotificationEvent] = []
+        auth_failed: list[MemberAuthFailedEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: notifications.append(e))
+        eventbus.subscribe(MemberAuthFailedEvent, lambda e: auth_failed.append(e))
+
+        _, _token, _ = await service.bootstrap_master("owner", "pass123")
+
+        with pytest.raises(PermissionError):
+            await service.reset_password("owner", "wrong-key", "newpass")
+
+        # MemberAuthFailedEvent 발행 확인
+        assert len(auth_failed) == 1
+        assert auth_failed[0].member_id == "owner"
+        assert "recovery key" in auth_failed[0].reason
+
+        # NotificationEvent 발행 확인
+        member_notifications = [e for e in notifications if e.category == "member"]
+        assert len(member_notifications) == 1
+        evt = member_notifications[0]
+        assert evt.level == "warning"
+        assert evt.title == "인증 실패"
+        assert "`owner`" in evt.message
+        assert "recovery key" in evt.message
+
+    async def test_no_auth_failed_notification_on_valid_recovery_key(
+        self, service, eventbus
+    ):
+        """올바른 recovery key로 리셋 시 인증 실패 알림이 발행되지 않아야 한다."""
+        notifications: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: notifications.append(e))
+
+        _, _token, recovery_key = await service.bootstrap_master("owner", "pass123")
+        await service.reset_password("owner", recovery_key, "newpass")
+
+        auth_fail_notifications = [
+            e
+            for e in notifications
+            if e.category == "member" and "인증 실패" in e.title
+        ]
+        assert len(auth_fail_notifications) == 0


### PR DESCRIPTION
## Summary
- `RecoveryKeyManager._publish_auth_failed()`에서 `MemberAuthFailedEvent`만 발행하던 것을 `AuthService`와 동일하게 `NotificationEvent(level=warning, category=member)`도 함께 발행하도록 수정
- 단위 테스트 2건 추가: 잘못된 recovery key 시 알림 발행 확인, 올바른 recovery key 시 인증 실패 알림 미발행 확인

## Test plan
- [x] `test_notification_on_invalid_recovery_key` — 잘못된 recovery key 입력 시 NotificationEvent 발행 검증
- [x] `test_no_auth_failed_notification_on_valid_recovery_key` — 정상 recovery key 사용 시 인증 실패 알림 미발행 검증
- [x] 기존 `test_password_change_notification.py` 4건 통과 확인
- [x] ruff check / ruff format 통과

Refs #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)