### PR TITLE
fix(trade): MDD 비율 계산을 equity curve 기반으로 전환 #788

### DIFF
--- a/src/ante/trade/performance.py
+++ b/src/ante/trade/performance.py
@@ -47,6 +47,7 @@ class PerformanceTracker:
         strategy_id: str | None = None,
         from_date: datetime | None = None,
         to_date: datetime | None = None,
+        bot_allocated_budget: float = 0.0,
     ) -> PerformanceMetrics:
         """성과 지표 계산.
 
@@ -78,7 +79,9 @@ class PerformanceTracker:
         total_loss = abs(sum(losing)) if losing else 0.0
         total_commission = sum(t.commission for t in trades)
 
-        max_drawdown, max_drawdown_amount = self._calculate_mdd(pnl_list)
+        max_drawdown, max_drawdown_amount = self._calculate_mdd(
+            pnl_list, bot_allocated_budget
+        )
 
         return PerformanceMetrics(
             total_trades=total_trades,
@@ -274,31 +277,40 @@ class PerformanceTracker:
         ]
 
     @staticmethod
-    def _calculate_mdd(pnl_list: list[float]) -> tuple[float, float]:
-        """MDD 계산. 누적 손익의 고점 대비 최대 하락.
+    def _calculate_mdd(
+        pnl_list: list[float],
+        bot_allocated_budget: float = 0.0,
+    ) -> tuple[float, float]:
+        """MDD 계산. equity curve (할당 예산 + 누적 PnL) 기반 고점 대비 최대 하락.
+
+        Args:
+            pnl_list: 거래별 실현 손익 리스트
+            bot_allocated_budget: 봇에 할당된 예산 (equity curve 기준점)
 
         Returns:
-            (비율, 금액) 튜플
+            (비율, 금액) 튜플. 비율 = (Peak - Trough) / Peak
         """
         if not pnl_list:
             return 0.0, 0.0
 
-        cumulative: list[float] = []
+        # equity curve 구축: 할당 예산 + 누적 PnL
+        equity: list[float] = []
         running = 0.0
         for pnl in pnl_list:
             running += pnl
-            cumulative.append(running)
+            equity.append(bot_allocated_budget + running)
 
-        peak = cumulative[0]
+        peak = equity[0]
         max_dd_amount = 0.0
 
-        for value in cumulative:
+        for value in equity:
             if value > peak:
                 peak = value
             drawdown = peak - value
             if drawdown > max_dd_amount:
                 max_dd_amount = drawdown
 
+        # MDD% = (Peak - Trough) / Peak; peak <= 0이면 비율 산출 불가
         max_dd_rate = max_dd_amount / peak if peak > 0 else 0.0
         return max_dd_rate, max_dd_amount
 

--- a/tests/unit/test_trade.py
+++ b/tests/unit/test_trade.py
@@ -775,14 +775,14 @@ class TestPerformanceTracker:
         assert metrics.win_rate == pytest.approx(0.5)
 
     async def test_mdd_calculation(self, performance):
-        """MDD 계산 정확성."""
-        # 고점 후 하락 → 회복 → 재하락
+        """MDD 계산 정확성 — equity curve 기반."""
+        budget = 1000.0
         pnl_list = [100, 50, -200, 150, -300]
-        rate, amount = performance._calculate_mdd(pnl_list)
-        # cumulative: [100, 150, -50, 100, -200]
-        # peak: 150, max drawdown: 150 - (-200) = 350
+        rate, amount = performance._calculate_mdd(pnl_list, budget)
+        # equity: [1100, 1150, 950, 1100, 800]
+        # peak: 1150, trough: 800, drawdown: 350
         assert amount == pytest.approx(350.0)
-        assert rate == pytest.approx(350.0 / 150.0)
+        assert rate == pytest.approx(350.0 / 1150.0)
 
     async def test_mdd_empty(self, performance):
         """빈 리스트 MDD = 0."""
@@ -792,8 +792,28 @@ class TestPerformanceTracker:
 
     async def test_mdd_only_profits(self, performance):
         """수익만 있으면 MDD = 0."""
-        rate, amount = performance._calculate_mdd([100, 200, 300])
+        rate, amount = performance._calculate_mdd([100, 200, 300], 1000.0)
         assert amount == 0.0
+
+    async def test_mdd_all_loss(self, performance):
+        """전 구간 손실 케이스 — equity curve 기반 MDD."""
+        budget = 1000.0
+        pnl_list = [-100, -200, -150]
+        rate, amount = performance._calculate_mdd(pnl_list, budget)
+        # equity: [900, 700, 550]
+        # peak: 900 (첫 값), trough: 550, drawdown: 350
+        assert amount == pytest.approx(350.0)
+        assert rate == pytest.approx(350.0 / 900.0)
+
+    async def test_mdd_no_budget_backward_compat(self, performance):
+        """bot_allocated_budget=0 (기본값) 시 기존 누적PnL 기반 동작."""
+        pnl_list = [100, 50, -200, 150, -300]
+        rate, amount = performance._calculate_mdd(pnl_list)
+        # equity (budget=0): [100, 150, -50, 100, -200]
+        # peak: 150, trough: -200, drawdown amount: 350
+        assert amount == pytest.approx(350.0)
+        # peak > 0이므로 비율 산출 가능
+        assert rate == pytest.approx(350.0 / 150.0)
 
     async def test_sharpe_under_30_returns_none(self, performance):
         """30건 미만이면 None."""


### PR DESCRIPTION
## Summary
- `_calculate_mdd()`에 `bot_allocated_budget` 파라미터 추가, equity curve (할당 예산 + 누적 PnL) 기반 MDD 계산으로 전환
- MDD% = (Peak - Trough) / Peak 공식 적용
- `calculate()` 메서드에도 `bot_allocated_budget` 파라미터 전달 경로 추가 (기본값 0.0으로 하위 호환 유지)

## Test plan
- [x] equity curve 기반 MDD 계산 정확성 테스트
- [x] 전 구간 손실 케이스 테스트 (`test_mdd_all_loss`)
- [x] budget=0 하위 호환 테스트 (`test_mdd_no_budget_backward_compat`)
- [x] 기존 55개 테스트 전체 통과 확인
- [x] ruff check / ruff format 통과

Closes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)