### PR TITLE
fix(bot): SignalChannel에 OrderCancelFailedEvent 구독 추가 #779

### DIFF
--- a/src/ante/bot/signal_channel.py
+++ b/src/ante/bot/signal_channel.py
@@ -154,6 +154,7 @@ class SignalChannel:
     def _subscribe_events(self) -> None:
         """체결/주문 상태 이벤트 구독."""
         from ante.eventbus.events import (
+            OrderCancelFailedEvent,
             OrderCancelledEvent,
             OrderFailedEvent,
             OrderFilledEvent,
@@ -167,12 +168,14 @@ class SignalChannel:
             OrderRejectedEvent,
             OrderCancelledEvent,
             OrderFailedEvent,
+            OrderCancelFailedEvent,
         ):
             self._eventbus.subscribe(evt, self._on_order_update)
 
     def _unsubscribe_events(self) -> None:
         """이벤트 구독 해제."""
         from ante.eventbus.events import (
+            OrderCancelFailedEvent,
             OrderCancelledEvent,
             OrderFailedEvent,
             OrderFilledEvent,
@@ -186,6 +189,7 @@ class SignalChannel:
             OrderRejectedEvent,
             OrderCancelledEvent,
             OrderFailedEvent,
+            OrderCancelFailedEvent,
         ):
             self._eventbus.unsubscribe(evt, self._on_order_update)
 
@@ -224,6 +228,7 @@ class SignalChannel:
             return
 
         from ante.eventbus.events import (
+            OrderCancelFailedEvent,
             OrderCancelledEvent,
             OrderFailedEvent,
             OrderRejectedEvent,
@@ -242,6 +247,9 @@ class SignalChannel:
             reason = event.reason
         elif isinstance(event, OrderFailedEvent):
             status = "failed"
+            reason = event.error_message
+        elif isinstance(event, OrderCancelFailedEvent):
+            status = "cancel_failed"
             reason = event.error_message
 
         if status:

--- a/tests/unit/test_signal_channel.py
+++ b/tests/unit/test_signal_channel.py
@@ -281,3 +281,22 @@ class TestEventForwarding:
 
         resp = json.loads(output.getvalue().strip())
         assert resp["status"] == "cancelled"
+
+    async def test_order_cancel_failed_forwarded(
+        self, channel: SignalChannel, output: io.StringIO
+    ) -> None:
+        """주문 취소 실패 → 외부 전달."""
+        from ante.eventbus.events import OrderCancelFailedEvent
+
+        event = OrderCancelFailedEvent(
+            order_id="ORD-005",
+            bot_id="bot-001",
+            error_message="cancel_rejected",
+        )
+
+        await channel._on_order_update(event)
+
+        resp = json.loads(output.getvalue().strip())
+        assert resp["type"] == "order_update"
+        assert resp["status"] == "cancel_failed"
+        assert resp["reason"] == "cancel_rejected"


### PR DESCRIPTION
## Summary
- `SignalChannel._subscribe_events()`와 `_unsubscribe_events()`에 `OrderCancelFailedEvent` 구독/해제 추가
- `_on_order_update()`에서 `OrderCancelFailedEvent`를 `cancel_failed` 상태로 외부 전달
- 새 이벤트 전달에 대한 단위 테스트 추가

Refs #779

## Test plan
- [x] 기존 15개 테스트 통과
- [x] 신규 `test_order_cancel_failed_forwarded` 테스트 통과
- [x] ruff check / ruff format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)