### PR TITLE
fix(trade): PerformanceTracker JOIN 조건을 trade_id FK 기반으로 변경 #785

### DIFF
--- a/src/ante/trade/performance.py
+++ b/src/ante/trade/performance.py
@@ -27,11 +27,8 @@ _COND_STATUS_FILLED = "t.status = ?"
 _COND_SIDE_SELL = "t.side = 'sell'"
 _COND_BOT_ID = "t.bot_id = ?"
 _JOIN_POSITION_HISTORY = """LEFT JOIN position_history ph
-                ON ph.bot_id = t.bot_id
-                AND ph.symbol = t.symbol
-                AND ph.action = 'sell'
-                AND ph.price = t.price
-                AND ph.quantity = t.quantity"""
+                ON ph.trade_id = CAST(t.trade_id AS TEXT)
+                AND ph.action = 'sell'"""
 
 
 class PerformanceTracker:
@@ -378,14 +375,13 @@ class PerformanceTracker:
         """
         pnl_list: list[float] = []
         for trade in sell_trades:
-            # position_history에서 해당 거래의 pnl 조회
+            # position_history에서 trade_id 기반으로 pnl 조회
             try:
                 row = await self._db.fetch_one(
                     """SELECT pnl FROM position_history
-                       WHERE bot_id = ? AND symbol = ? AND action = 'sell'
-                         AND price = ? AND quantity = ?
-                       ORDER BY created_at DESC LIMIT 1""",
-                    (trade.bot_id, trade.symbol, trade.price, trade.quantity),
+                       WHERE trade_id = ? AND action = 'sell'
+                       LIMIT 1""",
+                    (str(trade.trade_id),),
                 )
             except sqlite3.OperationalError:
                 row = None

--- a/src/ante/trade/position.py
+++ b/src/ante/trade/position.py
@@ -54,6 +54,7 @@ class PositionHistory:
         await self._db.execute_script(POSITION_SCHEMA)
         await self._migrate_exchange_column()
         await self._migrate_account_id_column()
+        await self._migrate_trade_id_column()
         await self._warm_cache()
         logger.info("PositionHistory 초기화 완료")
 
@@ -82,6 +83,16 @@ class PositionHistory:
                 logger.info("%s 테이블에 exchange 컬럼 추가", table)
             except Exception:
                 pass  # 이미 존재
+
+    async def _migrate_trade_id_column(self) -> None:
+        """position_history에 trade_id 컬럼 마이그레이션."""
+        try:
+            await self._db.execute(
+                "ALTER TABLE position_history ADD COLUMN trade_id TEXT"
+            )
+            logger.info("position_history 테이블에 trade_id 컬럼 추가")
+        except Exception:
+            pass  # 이미 존재
 
     async def _migrate_account_id_column(self) -> None:
         """account_id 컬럼 마이그레이션."""
@@ -127,6 +138,7 @@ class PositionHistory:
                 pnl=0.0,
                 timestamp=record.timestamp,
                 exchange=record.exchange,
+                trade_id=str(record.trade_id),
             )
 
         elif record.side == "sell":
@@ -168,6 +180,7 @@ class PositionHistory:
                 pnl=pnl,
                 timestamp=record.timestamp,
                 exchange=record.exchange,
+                trade_id=str(record.trade_id),
             )
 
     async def get_positions(
@@ -330,14 +343,16 @@ class PositionHistory:
         pnl: float,
         timestamp: object | None,
         exchange: str = "KRX",
+        trade_id: str | None = None,
     ) -> None:
         """포지션 변동 이력 저장."""
         ts = timestamp.isoformat() if hasattr(timestamp, "isoformat") else None
         await self._db.execute(
             """INSERT INTO position_history
-               (bot_id, symbol, action, quantity, price, pnl, timestamp, exchange)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-            (bot_id, symbol, action, quantity, price, pnl, ts, exchange),
+               (bot_id, symbol, action, quantity, price, pnl, timestamp,
+                exchange, trade_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (bot_id, symbol, action, quantity, price, pnl, ts, exchange, trade_id),
         )
 
     @staticmethod

--- a/tests/unit/test_trade_id_fk.py
+++ b/tests/unit/test_trade_id_fk.py
@@ -1,0 +1,237 @@
+"""trade_id FK 기반 JOIN 단위 테스트 (#785)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from ante.trade.models import TradeRecord, TradeStatus
+from ante.trade.performance import PerformanceTracker
+from ante.trade.position import PositionHistory
+
+
+class TestPositionHistoryTradeId:
+    """PositionHistory._save_history 가 trade_id를 저장하는지 검증."""
+
+    @pytest.mark.asyncio
+    async def test_save_history_includes_trade_id(self):
+        """_save_history 호출 시 trade_id가 INSERT 파라미터에 포함된다."""
+        db = AsyncMock()
+        db.execute = AsyncMock()
+        db.execute_script = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+        db.fetch_one = AsyncMock(return_value=None)
+
+        ph = PositionHistory(db)
+
+        trade_id = uuid4()
+        record = TradeRecord(
+            trade_id=trade_id,
+            bot_id="bot-1",
+            strategy_id="strat-1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            price=70000.0,
+            status=TradeStatus.FILLED,
+            timestamp=datetime(2026, 3, 23, 10, 0, 0),
+        )
+
+        await ph.on_trade(record)
+
+        # _save_history 에서 INSERT 실행됨
+        insert_calls = [
+            c for c in db.execute.call_args_list if "position_history" in str(c)
+        ]
+        assert len(insert_calls) >= 1
+        # 마지막 파라미터가 trade_id 문자열
+        params = insert_calls[0][0][1]
+        assert str(trade_id) in params
+
+    @pytest.mark.asyncio
+    async def test_on_trade_sell_passes_trade_id(self):
+        """매도 on_trade 시 trade_id가 position_history에 저장된다."""
+        db = AsyncMock()
+        db.execute = AsyncMock()
+        db.execute_script = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+        # 매도 시 기존 포지션이 있어야 함
+        db.fetch_one = AsyncMock(
+            return_value={
+                "bot_id": "bot-1",
+                "symbol": "005930",
+                "quantity": 10.0,
+                "avg_entry_price": 65000.0,
+                "realized_pnl": 0.0,
+            }
+        )
+
+        ph = PositionHistory(db)
+
+        trade_id = uuid4()
+        record = TradeRecord(
+            trade_id=trade_id,
+            bot_id="bot-1",
+            strategy_id="strat-1",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            price=70000.0,
+            status=TradeStatus.FILLED,
+            timestamp=datetime(2026, 3, 23, 11, 0, 0),
+        )
+
+        await ph.on_trade(record)
+
+        insert_calls = [
+            c for c in db.execute.call_args_list if "position_history" in str(c)
+        ]
+        assert len(insert_calls) >= 1
+        params = insert_calls[0][0][1]
+        assert str(trade_id) in params
+
+
+class TestPerformanceTrackerTradeIdJoin:
+    """PerformanceTracker가 trade_id 기반 JOIN을 사용하는지 검증."""
+
+    @pytest.mark.asyncio
+    async def test_calculate_pnl_uses_trade_id(self):
+        """_calculate_pnl_per_trade가 trade_id로 조회한다."""
+        db = AsyncMock()
+        trade_id = uuid4()
+        db.fetch_one = AsyncMock(return_value={"pnl": 50000.0})
+
+        tracker = PerformanceTracker(db)
+        sell_trade = TradeRecord(
+            trade_id=trade_id,
+            bot_id="bot-1",
+            strategy_id="strat-1",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            price=70000.0,
+            status=TradeStatus.FILLED,
+            timestamp=datetime(2026, 3, 23, 11, 0, 0),
+        )
+
+        pnl_list = await tracker._calculate_pnl_per_trade([sell_trade], "bot-1")
+
+        assert pnl_list == [50000.0]
+        # trade_id 파라미터로 조회했는지 확인
+        call_args = db.fetch_one.call_args
+        query = call_args[0][0]
+        params = call_args[0][1]
+        assert "trade_id = ?" in query
+        assert str(trade_id) in params
+
+    @pytest.mark.asyncio
+    async def test_daily_summary_join_uses_trade_id(self):
+        """일별 집계 SQL이 trade_id 기반 JOIN을 사용한다."""
+        db = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+
+        tracker = PerformanceTracker(db)
+        await tracker.get_daily_summary()
+
+        call_args = db.fetch_all.call_args
+        query = call_args[0][0]
+        assert "ph.trade_id" in query
+        # 기존 price/quantity JOIN 조건이 없어야 함
+        assert "ph.price = t.price" not in query
+        assert "ph.quantity = t.quantity" not in query
+
+    @pytest.mark.asyncio
+    async def test_duplicate_price_sell_resolved_by_trade_id(self):
+        """동일 가격 반복 매도 시 trade_id로 정확히 구분된다."""
+        db = AsyncMock()
+        trade_id_1 = uuid4()
+        trade_id_2 = uuid4()
+
+        # 두 번 호출되면 각기 다른 pnl 반환
+        db.fetch_one = AsyncMock(
+            side_effect=[
+                {"pnl": 10000.0},
+                {"pnl": -5000.0},
+            ]
+        )
+
+        tracker = PerformanceTracker(db)
+
+        # 동일 종목, 동일 가격, 동일 수량이지만 trade_id가 다른 두 매도
+        sell_1 = TradeRecord(
+            trade_id=trade_id_1,
+            bot_id="bot-1",
+            strategy_id="strat-1",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            price=70000.0,
+            status=TradeStatus.FILLED,
+            timestamp=datetime(2026, 3, 23, 11, 0, 0),
+        )
+        sell_2 = TradeRecord(
+            trade_id=trade_id_2,
+            bot_id="bot-1",
+            strategy_id="strat-1",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            price=70000.0,
+            status=TradeStatus.FILLED,
+            timestamp=datetime(2026, 3, 23, 12, 0, 0),
+        )
+
+        pnl_list = await tracker._calculate_pnl_per_trade([sell_1, sell_2], "bot-1")
+
+        assert pnl_list == [10000.0, -5000.0]
+        # 각각 다른 trade_id로 조회했는지 확인
+        calls = db.fetch_one.call_args_list
+        assert len(calls) == 2
+        assert str(trade_id_1) in calls[0][0][1]
+        assert str(trade_id_2) in calls[1][0][1]
+
+
+class TestMigrateTradeIdColumn:
+    """trade_id 컬럼 마이그레이션 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_migrate_adds_trade_id_column(self):
+        """초기화 시 ALTER TABLE로 trade_id 컬럼을 추가한다."""
+        db = AsyncMock()
+        db.execute = AsyncMock()
+        db.execute_script = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+        db.fetch_one = AsyncMock(return_value=None)
+
+        ph = PositionHistory(db)
+        await ph.initialize()
+
+        alter_calls = [
+            c
+            for c in db.execute.call_args_list
+            if "trade_id" in str(c) and "ALTER" in str(c)
+        ]
+        assert len(alter_calls) == 1
+        assert "position_history" in str(alter_calls[0])
+
+    @pytest.mark.asyncio
+    async def test_migrate_idempotent(self):
+        """이미 trade_id 컬럼이 있으면 예외 없이 넘어간다."""
+        db = AsyncMock()
+        db.execute_script = AsyncMock()
+        db.fetch_all = AsyncMock(return_value=[])
+        db.fetch_one = AsyncMock(return_value=None)
+
+        # ALTER TABLE이 예외를 발생시키는 상황 (이미 컬럼 존재)
+        async def _execute_side_effect(sql, *args, **kwargs):
+            if "ALTER TABLE position_history" in sql and "trade_id" in sql:
+                raise Exception("duplicate column name: trade_id")
+
+        db.execute = AsyncMock(side_effect=_execute_side_effect)
+
+        ph = PositionHistory(db)
+        # 예외 없이 정상 완료되어야 함
+        await ph.initialize()


### PR DESCRIPTION
## Summary
- `position_history` 테이블에 `trade_id TEXT` 컬럼 추가 (ALTER TABLE 마이그레이션)
- `_save_history()`에 `trade_id` 파라미터 추가, `on_trade()` 호출 시 `TradeRecord.trade_id` 전달
- `PerformanceTracker`의 `_JOIN_POSITION_HISTORY` 및 `_calculate_pnl_per_trade`를 `price/quantity` 매칭 대신 `trade_id` 기반으로 변경
- 동일 가격 반복 매도 시 부정확한 PnL 집계가 발생하던 GAP-050 문제 해결

## Test plan
- [x] trade_id 컬럼 마이그레이션 테스트 (추가/멱등성)
- [x] 매수/매도 on_trade 시 trade_id가 position_history에 저장되는지 검증
- [x] _calculate_pnl_per_trade가 trade_id 기반으로 조회하는지 검증
- [x] 일별 집계 SQL이 trade_id JOIN을 사용하는지 검증
- [x] 동일 가격 반복 매도 시 trade_id로 정확히 구분되는지 검증
- [x] 기존 테스트 111건 전체 통과

Refs #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)