### PR TITLE
fix(rule): TradingHoursRule Account 자동 주입 — RuleContext 경유 #781

### DIFF
--- a/src/ante/rule/base.py
+++ b/src/ante/rule/base.py
@@ -74,6 +74,11 @@ class RuleContext:
     total_asset: float = 0.0
     total_exposure: float = 0.0
 
+    # 거래 시간 (Account에서 주입)
+    trading_hours_start: str = "09:00"
+    trading_hours_end: str = "15:30"
+    timezone: str = "Asia/Seoul"
+
     # 추가 메타데이터
     metadata: dict[str, Any] = field(default_factory=dict)
 

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -386,11 +386,17 @@ class RuleEngine:
         # 계좌 상태 조회
         account_status = "active"
         currency = "KRW"
+        trading_hours_start = "09:00"
+        trading_hours_end = "15:30"
+        timezone = "Asia/Seoul"
         if self._account_service is not None:
             try:
                 account = await self._account_service.get(self._account_id)
                 account_status = account.status.value
                 currency = account.currency
+                trading_hours_start = account.trading_hours_start
+                trading_hours_end = account.trading_hours_end
+                timezone = account.timezone
             except Exception:
                 logger.warning(
                     "계좌 상태 조회 실패: %s — 기본값 사용", self._account_id
@@ -426,6 +432,9 @@ class RuleEngine:
             total_asset=treasury_data["total_asset"],
             total_exposure=treasury_data["total_exposure"],
             bot_allocated_budget=treasury_data["bot_allocated_budget"],
+            trading_hours_start=trading_hours_start,
+            trading_hours_end=trading_hours_end,
+            timezone=timezone,
         )
 
         try:
@@ -549,11 +558,17 @@ class RuleEngine:
         # 계좌 상태 조회
         account_status = "active"
         currency = "KRW"
+        trading_hours_start = "09:00"
+        trading_hours_end = "15:30"
+        timezone = "Asia/Seoul"
         if self._account_service is not None:
             try:
                 account = await self._account_service.get(self._account_id)
                 account_status = account.status.value
                 currency = account.currency
+                trading_hours_start = account.trading_hours_start
+                trading_hours_end = account.trading_hours_end
+                timezone = account.timezone
             except Exception:
                 logger.warning(
                     "계좌 상태 조회 실패: %s — 기본값 사용", self._account_id
@@ -589,6 +604,9 @@ class RuleEngine:
             total_asset=treasury_data["total_asset"],
             total_exposure=treasury_data["total_exposure"],
             bot_allocated_budget=treasury_data["bot_allocated_budget"],
+            trading_hours_start=trading_hours_start,
+            trading_hours_end=trading_hours_end,
+            timezone=timezone,
         )
 
         try:

--- a/src/ante/rule/global_rules.py
+++ b/src/ante/rule/global_rules.py
@@ -127,8 +127,28 @@ class TradingHoursRule(Rule):
         from datetime import datetime, time
         from zoneinfo import ZoneInfo
 
-        allowed_hours: str = self.config.get("allowed_hours", "09:00-15:30")
-        timezone_str: str = self.config.get("timezone", "Asia/Seoul")
+        # context 필드가 기본값이 아니면 context 우선, 그렇지 않으면 config fallback
+        _default_start, _default_end = "09:00", "15:30"
+        context_overridden = (
+            context.trading_hours_start != _default_start
+            or context.trading_hours_end != _default_end
+        )
+
+        if context_overridden:
+            start_str = context.trading_hours_start
+            end_str = context.trading_hours_end
+        else:
+            # 하위 호환: config의 allowed_hours 파싱
+            allowed_hours_cfg = self.config.get("allowed_hours", "")
+            if allowed_hours_cfg:
+                parts = allowed_hours_cfg.split("-")
+                start_str = parts[0].strip() if len(parts) == 2 else _default_start
+                end_str = parts[1].strip() if len(parts) == 2 else _default_end
+            else:
+                start_str = _default_start
+                end_str = _default_end
+
+        timezone_str = context.timezone or self.config.get("timezone", "Asia/Seoul")
 
         # 테스트 주입 또는 실제 시각
         now = context.metadata.get("current_time")
@@ -138,9 +158,9 @@ class TradingHoursRule(Rule):
 
         current_time = now.time() if isinstance(now, datetime) else now
 
-        start_str, end_str = allowed_hours.split("-")
-        start_time = time.fromisoformat(start_str.strip())
-        end_time = time.fromisoformat(end_str.strip())
+        start_time = time.fromisoformat(start_str)
+        end_time = time.fromisoformat(end_str)
+        allowed_hours = f"{start_str}-{end_str}"
 
         if not (start_time <= current_time <= end_time):
             return RuleEvaluation(

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -1446,3 +1446,94 @@ class TestRuleEngineStartSync:
         assert len(handlers) >= 1, (
             "start() 후 OrderRequestEvent 핸들러가 등록되어야 합니다"
         )
+
+
+# ── TradingHoursRule: 계좌별 거래시간 컨텍스트 주입 (#781) ────
+
+
+class TestTradingHoursRuleContextFields:
+    """TradingHoursRule이 RuleContext의 trading_hours 필드를 사용하는지 검증."""
+
+    def test_context_fields_override_config(self, base_context):
+        """context 필드가 config의 allowed_hours보다 우선한다."""
+        rule = TradingHoursRule(
+            "hours",
+            {"name": "Trading Hours", "allowed_hours": "09:00-15:30"},
+        )
+        # 계좌가 08:00~16:00 거래 시간 설정
+        base_context.trading_hours_start = "08:00"
+        base_context.trading_hours_end = "16:00"
+        base_context.metadata["current_time"] = time(8, 30)
+
+        result = rule.evaluate(base_context)
+        # config는 09:00-15:30이지만 context가 08:00-16:00이므로 통과
+        assert result.result == RuleResult.PASS
+
+    def test_context_fields_reject_outside(self, base_context):
+        """context 필드의 거래시간 밖이면 차단."""
+        rule = TradingHoursRule(
+            "hours",
+            {"name": "Trading Hours", "allowed_hours": "09:00-15:30"},
+        )
+        # 계좌가 10:00~14:00 으로 좁은 거래 시간 설정
+        base_context.trading_hours_start = "10:00"
+        base_context.trading_hours_end = "14:00"
+        base_context.metadata["current_time"] = time(9, 30)
+
+        result = rule.evaluate(base_context)
+        assert result.result == RuleResult.REJECT
+
+    def test_default_context_fields_with_config_allowed_hours(self, base_context):
+        """context가 기본값이면 config의 allowed_hours가 사용된다."""
+        rule = TradingHoursRule(
+            "hours",
+            {"name": "Trading Hours", "allowed_hours": "10:00-14:00"},
+        )
+        # context 필드는 기본값 (09:00, 15:30)
+        base_context.metadata["current_time"] = time(9, 30)
+
+        result = rule.evaluate(base_context)
+        # config의 10:00-14:00이 적용되어 09:30은 차단
+        assert result.result == RuleResult.REJECT
+
+    def test_different_accounts_different_hours(self, base_context):
+        """서로 다른 계좌의 거래시간이 독립적으로 적용된다."""
+        rule = TradingHoursRule("hours", {"name": "Trading Hours"})
+
+        # 국내 계좌: 09:00-15:30
+        base_context.trading_hours_start = "09:00"
+        base_context.trading_hours_end = "15:30"
+        base_context.metadata["current_time"] = time(10, 0)
+        result_kr = rule.evaluate(base_context)
+        assert result_kr.result == RuleResult.PASS
+
+        # 미국 계좌: 22:30-05:00 (단순화하여 22:30-23:59 테스트)
+        base_context.trading_hours_start = "22:30"
+        base_context.trading_hours_end = "23:59"
+        base_context.metadata["current_time"] = time(10, 0)
+        result_us = rule.evaluate(base_context)
+        assert result_us.result == RuleResult.REJECT
+
+        base_context.metadata["current_time"] = time(23, 0)
+        result_us2 = rule.evaluate(base_context)
+        assert result_us2.result == RuleResult.PASS
+
+    def test_rule_context_has_trading_hours_fields(self):
+        """RuleContext에 trading_hours 필드가 존재하고 기본값이 올바르다."""
+        ctx = RuleContext()
+        assert ctx.trading_hours_start == "09:00"
+        assert ctx.trading_hours_end == "15:30"
+        assert ctx.timezone == "Asia/Seoul"
+
+    def test_context_timezone_field(self, base_context):
+        """context의 timezone 필드가 TradingHoursRule에 전달된다."""
+        rule = TradingHoursRule("hours", {"name": "Trading Hours"})
+        base_context.trading_hours_start = "09:00"
+        base_context.trading_hours_end = "15:30"
+        base_context.timezone = "US/Eastern"
+        base_context.metadata["current_time"] = time(10, 0)
+
+        result = rule.evaluate(base_context)
+        # current_time이 직접 주입되어 timezone은 실제 시각 조회에만 영향
+        # 09:00-15:30 범위 내이므로 통과
+        assert result.result == RuleResult.PASS


### PR DESCRIPTION
## Summary
- `RuleContext`에 `trading_hours_start`, `trading_hours_end`, `timezone` 필드 추가 (기본값: 09:00, 15:30, Asia/Seoul)
- `RuleEngine._on_order_request()`와 `_on_order_modify()`에서 AccountService 조회 시 거래시간 필드를 RuleContext에 주입
- `TradingHoursRule`이 context 필드 우선 사용, context가 기본값이면 config의 `allowed_hours` fallback (하위 호환)

## Test plan
- [x] context 필드가 config의 allowed_hours보다 우선하는지 검증
- [x] context 필드의 거래시간 밖이면 차단되는지 검증
- [x] context가 기본값이면 config의 allowed_hours가 적용되는지 검증 (하위 호환)
- [x] 서로 다른 계좌의 거래시간이 독립적으로 적용되는지 검증
- [x] RuleContext 기본값 검증
- [x] timezone 필드 전달 검증
- [x] 기존 84개 테스트 전체 통과 확인

Refs #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)