### PR TITLE
fix(trade): 체결 알림에 누적 수량/평단가/손익 추가 #777

### DIFF
--- a/src/ante/trade/recorder.py
+++ b/src/ante/trade/recorder.py
@@ -128,15 +128,32 @@ class TradeRecorder:
 
         side_label = "매수" if event.side == "buy" else "매도"
         if self._eventbus:
+            position = await self._position_history.get_current(
+                event.bot_id, event.symbol
+            )
+            base_msg = (
+                f"봇 `{event.bot_id}`\n"
+                f"종목: `{event.symbol}`\n"
+                f"{side_label} {event.quantity}주 @ {event.price:,.0f}원"
+            )
+            if event.side == "buy":
+                base_msg += (
+                    f"\n누적 {position['quantity']:.0f}주"
+                    f" · 평단가 {position['avg_entry_price']:,.0f}원"
+                )
+            else:
+                pnl = position["realized_pnl"]
+                pnl_sign = "+" if pnl >= 0 else ""
+                base_msg += (
+                    f"\n잔여 {position['quantity']:.0f}주"
+                    f" · 평단가 {position['avg_entry_price']:,.0f}원"
+                    f"\n실현 손익 {pnl_sign}{pnl:,.0f}원"
+                )
             await self._eventbus.publish(
                 NotificationEvent(
                     level="info",
                     title=f"체결 완료 ({side_label})",
-                    message=(
-                        f"봇 `{event.bot_id}`\n"
-                        f"종목: `{event.symbol}`\n"
-                        f"{side_label} {event.quantity}주 @ {event.price:,.0f}원"
-                    ),
+                    message=base_msg,
                     category="trade",
                 )
             )

--- a/tests/unit/test_trade.py
+++ b/tests/unit/test_trade.py
@@ -249,6 +249,45 @@ class TestTradeRecorder:
         trades = await recorder.get_trades()
         assert len(trades) == 1
 
+    async def test_on_filled_buy_notification_includes_cumulative(
+        self, recorder, eventbus
+    ):
+        """매수 알림에 누적 수량, 평단가 포함."""
+        from ante.eventbus.events import NotificationEvent
+
+        captured: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: captured.append(e))
+        recorder.subscribe(eventbus)
+
+        await eventbus.publish(_make_filled_event(side="buy", quantity=10, price=50000))
+        await eventbus.publish(_make_filled_event(side="buy", quantity=20, price=60000))
+
+        assert len(captured) == 2
+        # 2차 매수 알림: 누적 30주, 평단가 = (10*50000+20*60000)/30 ≈ 56667
+        msg = captured[1].message
+        assert "누적 30주" in msg
+        assert "평단가" in msg
+
+    async def test_on_filled_sell_notification_includes_pnl(self, recorder, eventbus):
+        """매도 알림에 잔여 수량, 평단가, 실현 손익 포함."""
+        from ante.eventbus.events import NotificationEvent
+
+        captured: list[NotificationEvent] = []
+        eventbus.subscribe(NotificationEvent, lambda e: captured.append(e))
+        recorder.subscribe(eventbus)
+
+        # 매수 10주 @ 50,000
+        await eventbus.publish(_make_filled_event(side="buy", quantity=10, price=50000))
+        # 매도 5주 @ 60,000 → 실현 손익 = (60000 - 50000) * 5 = 50,000
+        await eventbus.publish(_make_filled_event(side="sell", quantity=5, price=60000))
+
+        assert len(captured) == 2
+        sell_msg = captured[1].message
+        assert "잔여 5주" in sell_msg
+        assert "평단가" in sell_msg
+        assert "실현 손익" in sell_msg
+        assert "+50,000원" in sell_msg
+
 
 # ── PositionHistory ──────────────────────────────────
 


### PR DESCRIPTION
## Summary
- 매수 체결 알림에 누적 수량, 평단가 정보 추가
- 매도 체결 알림에 잔여 수량, 평단가, 실현 손익 정보 추가
- 포지션 갱신 후 PositionHistory에서 최신 포지션을 조회하여 메시지에 반영

Closes #777

## Test plan
- [x] 매수 알림에 누적 수량/평단가 포함 검증 (`test_on_filled_buy_notification_includes_cumulative`)
- [x] 매도 알림에 잔여 수량/평단가/실현 손익 포함 검증 (`test_on_filled_sell_notification_includes_pnl`)
- [x] 기존 57개 테스트 전체 통과
- [x] ruff check / ruff format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)