### PR TITLE
feat(bot): GET /api/bots 응답에 strategy_name 추가 #792

### DIFF
--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -42,6 +42,7 @@ class BotCreateRequest(BaseModel):
 )
 async def list_bots(
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
+    registry: Annotated[Any | None, Depends(get_strategy_registry_optional)],
     account_id: str | None = None,
     limit: int = 20,
     cursor: str | None = None,
@@ -61,6 +62,25 @@ async def list_bots(
             )
             == account_id
         ]
+
+    # 전략 이름/작성자 조인
+    if registry is not None:
+        for bot_info in bots:
+            sid = (
+                bot_info.get("strategy_id", "")
+                if isinstance(bot_info, dict)
+                else getattr(bot_info, "strategy_id", "")
+            )
+            if sid:
+                record = await registry.get(sid)
+                if record:
+                    if isinstance(bot_info, dict):
+                        bot_info["strategy_name"] = record.name
+                        bot_info["strategy_author_name"] = record.author
+                    else:
+                        bot_info.strategy_name = record.name
+                        bot_info.strategy_author_name = record.author
+
     result = paginate(bots, cursor_field="bot_id", limit=limit, cursor=cursor)
     return {"bots": result["items"], "next_cursor": result["next_cursor"]}
 
@@ -164,6 +184,8 @@ async def get_bot(
     if registry is not None:
         record = await registry.get(info.get("strategy_id", ""))
         if record:
+            info["strategy_name"] = record.name
+            info["strategy_author_name"] = record.author
             info["strategy"] = {
                 "name": record.name,
                 "version": record.version,

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -169,6 +169,8 @@ class BotInfo(BaseModel):
     status: str = ""
     account_id: str = ""
     strategy_id: str = ""
+    strategy_name: str | None = None
+    strategy_author_name: str | None = None
     interval_seconds: int = 60
     started_at: str | None = None
     stopped_at: str | None = None

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -422,12 +422,18 @@ class FakeAccountService:
 class FakeStrategyRecord:
     """테스트용 StrategyRecord stub."""
 
-    def __init__(self, strategy_id: str = "s1", filepath: str = "/tmp/s1.py") -> None:
+    def __init__(
+        self,
+        strategy_id: str = "s1",
+        filepath: str = "/tmp/s1.py",
+        name: str = "",
+        author: str = "test",
+    ) -> None:
         self.strategy_id = strategy_id
         self.filepath = filepath
-        self.name = strategy_id
+        self.name = name or strategy_id
         self.version = "0.1.0"
-        self.author = "test"
+        self.author = author
         self.description = "test strategy"
 
 
@@ -530,3 +536,105 @@ class TestBotLifecycle:
         # delete
         resp = client.delete("/api/bots/bot-1")
         assert resp.status_code == 204
+
+
+class TestListBotsStrategyName:
+    """list_bots 응답에 strategy_name, strategy_author_name 포함 테스트."""
+
+    @pytest.fixture
+    def strategy_registry(self):
+        reg = FakeStrategyRegistry()
+        reg._strategies["s1"] = FakeStrategyRecord(
+            "s1", name="MyStrategy", author="alice"
+        )
+        return reg
+
+    @pytest.fixture
+    def client_with_registry(
+        self, bot_manager, default_account_service, strategy_registry
+    ):
+        app = create_app(
+            bot_manager=bot_manager,
+            account_service=default_account_service,
+            strategy_registry=strategy_registry,
+        )
+        return TestClient(app)
+
+    def test_strategy_name_included(self, client_with_registry, bot_manager):
+        """봇 목록에 strategy_name, strategy_author_name 포함."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", strategy_id="s1")
+        resp = client_with_registry.get("/api/bots")
+        assert resp.status_code == 200
+        bot = resp.json()["bots"][0]
+        assert bot["strategy_name"] == "MyStrategy"
+        assert bot["strategy_author_name"] == "alice"
+
+    def test_strategy_not_found_returns_null(self, client_with_registry, bot_manager):
+        """레지스트리에 없는 전략이면 strategy_name은 null."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", strategy_id="unknown")
+        resp = client_with_registry.get("/api/bots")
+        assert resp.status_code == 200
+        bot = resp.json()["bots"][0]
+        assert bot["strategy_name"] is None
+        assert bot["strategy_author_name"] is None
+
+    def test_no_registry_returns_null(self, client, bot_manager):
+        """레지스트리 없으면 strategy_name은 null."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", strategy_id="s1")
+        resp = client.get("/api/bots")
+        assert resp.status_code == 200
+        bot = resp.json()["bots"][0]
+        assert bot["strategy_name"] is None
+        assert bot["strategy_author_name"] is None
+
+
+class TestGetBotStrategyName:
+    """get_bot 응답에 strategy_name, strategy_author_name 포함 테스트."""
+
+    @pytest.fixture
+    def strategy_registry(self):
+        reg = FakeStrategyRegistry()
+        reg._strategies["s1"] = FakeStrategyRecord(
+            "s1", name="MyStrategy", author="alice"
+        )
+        return reg
+
+    @pytest.fixture
+    def client_with_registry(
+        self, bot_manager, default_account_service, strategy_registry
+    ):
+        app = create_app(
+            bot_manager=bot_manager,
+            account_service=default_account_service,
+            strategy_registry=strategy_registry,
+        )
+        return TestClient(app)
+
+    def test_strategy_name_included(self, client_with_registry, bot_manager):
+        """봇 상세 조회에 strategy_name, strategy_author_name 포함."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", strategy_id="s1")
+        resp = client_with_registry.get("/api/bots/bot-1")
+        assert resp.status_code == 200
+        bot = resp.json()["bot"]
+        assert bot["strategy_name"] == "MyStrategy"
+        assert bot["strategy_author_name"] == "alice"
+        # strategy 상세 객체도 여전히 포함
+        assert bot["strategy"]["name"] == "MyStrategy"
+
+    def test_strategy_not_found_returns_null(self, client_with_registry, bot_manager):
+        """레지스트리에 없는 전략이면 strategy_name은 null."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", strategy_id="unknown")
+        resp = client_with_registry.get("/api/bots/bot-1")
+        assert resp.status_code == 200
+        bot = resp.json()["bot"]
+        assert bot["strategy_name"] is None
+        assert bot["strategy_author_name"] is None
+
+    def test_no_registry_returns_null(self, client, bot_manager):
+        """레지스트리 없으면 strategy_name은 null."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", strategy_id="s1")
+        resp = client.get("/api/bots/bot-1")
+        assert resp.status_code == 200
+        bot = resp.json()["bot"]
+        assert bot["strategy_name"] is None
+        assert bot["strategy_author_name"] is None


### PR DESCRIPTION
## Summary
- `list_bots`, `get_bot` 응답에 `strategy_name`, `strategy_author_name` 필드 추가
- StrategyRegistry 조인으로 전략명/작성자명을 조회하며, 미등록 시 `null` 반환
- `BotInfo` 스키마에 optional 필드 2개 추가

## Test plan
- [x] list_bots: 레지스트리 있을 때 strategy_name/strategy_author_name 포함 확인
- [x] list_bots: 레지스트리에 없는 전략 → null 반환 확인
- [x] list_bots: 레지스트리 미연동 → null 반환 확인
- [x] get_bot: 레지스트리 있을 때 strategy_name/strategy_author_name + strategy 상세 객체 포함 확인
- [x] get_bot: 레지스트리에 없는 전략 → null 반환 확인
- [x] get_bot: 레지스트리 미연동 → null 반환 확인
- [x] 기존 테스트 27개 전체 통과

Refs #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)