### PR TITLE
feat(bot): PUT /api/bots/{bot_id} 봇 설정 수정 API #795

### DIFF
--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -279,6 +279,74 @@ class BotManager:
         logger.info("봇 생성: %s (전략: %s)", config.bot_id, config.strategy_id)
         return bot
 
+    async def update_bot(self, bot_id: str, **kwargs: Any) -> Bot:
+        """봇 설정 수정. 중지 상태에서만 허용.
+
+        BotConfig를 재생성하고 DB를 갱신한다.
+        budget이 변경되면 TreasuryManager를 통해 예산을 조정한다.
+
+        Args:
+            bot_id: 대상 봇 ID.
+            **kwargs: 변경할 설정 필드 (None 값은 무시).
+
+        Returns:
+            수정된 Bot 인스턴스.
+
+        Raises:
+            BotError: 봇이 중지 상태가 아닌 경우.
+        """
+        bot = self._get_bot(bot_id)
+        allowed_statuses = {BotStatus.CREATED, BotStatus.STOPPED, BotStatus.ERROR}
+        if bot.status not in allowed_statuses:
+            raise BotError(
+                f"봇 설정은 중지 상태에서만 수정할 수 있습니다: {bot_id} "
+                f"(현재: {bot.status})"
+            )
+
+        # budget은 BotConfig 필드가 아니므로 별도 처리
+        new_budget = kwargs.pop("budget", None)
+
+        # None이 아닌 값만 필터
+        updates = {k: v for k, v in kwargs.items() if v is not None}
+
+        if not updates and new_budget is None:
+            return bot
+
+        # BotConfig 재생성
+        old_config = bot.config
+        config_fields = {
+            "bot_id": old_config.bot_id,
+            "strategy_id": old_config.strategy_id,
+            "name": old_config.name,
+            "account_id": old_config.account_id,
+            "interval_seconds": old_config.interval_seconds,
+            "auto_restart": old_config.auto_restart,
+            "max_restart_attempts": old_config.max_restart_attempts,
+            "restart_cooldown_seconds": old_config.restart_cooldown_seconds,
+            "step_timeout_seconds": old_config.step_timeout_seconds,
+            "max_signals_per_step": old_config.max_signals_per_step,
+        }
+        config_fields.update(updates)
+        new_config = BotConfig(**config_fields)
+        bot.config = new_config
+
+        # DB 갱신
+        await self._save_bot_config(new_config)
+
+        # budget 변경 시 Treasury 연동
+        if new_budget is not None and self._treasury_manager:
+            try:
+                treasury = self._treasury_manager.get(new_config.account_id)
+                await treasury.update_budget(bot_id, new_budget)
+            except KeyError:
+                logger.debug(
+                    "봇 수정 시 Treasury 미존재: account_id=%s",
+                    new_config.account_id,
+                )
+
+        logger.info("봇 설정 수정: %s (변경: %s)", bot_id, list(updates.keys()))
+        return bot
+
     async def assign_strategy(self, bot_id: str, strategy_id: str) -> None:
         """봇에 전략 배정.
 

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -18,7 +18,7 @@ from ante.web.deps import (
     get_trade_service_optional,
     get_treasury_optional,
 )
-from ante.web.schemas import BotDetailResponse, BotListResponse
+from ante.web.schemas import BotDetailResponse, BotListResponse, BotUpdateRequest
 
 router = APIRouter()
 
@@ -342,6 +342,50 @@ async def delete_bot(
             resource=f"bot:{bot_id}",
             ip=request.client.host if request.client else "",
         )
+
+
+@router.put(
+    "/{bot_id}",
+    response_model=BotDetailResponse,
+    responses={
+        404: {"description": "Bot not found"},
+        409: {"description": "Bot state conflict (not stopped)"},
+        503: {"description": "Bot manager not available"},
+    },
+)
+async def update_bot(
+    bot_id: str,
+    body: BotUpdateRequest,
+    request: Request,
+    bot_manager: Annotated[Any, Depends(get_bot_manager)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
+) -> dict:
+    """봇 설정 수정. 중지 상태에서만 허용."""
+    from ante.bot.exceptions import BotError
+
+    bot = bot_manager.get_bot(bot_id)
+    if bot is None:
+        raise HTTPException(status_code=404, detail=_BOT_NOT_FOUND)
+
+    updates = body.model_dump(exclude_none=True)
+    if not updates:
+        return {"bot": bot.get_info()}
+
+    try:
+        bot = await bot_manager.update_bot(bot_id, **updates)
+    except BotError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "anonymous"),
+            action="bot.update",
+            resource=f"bot:{bot_id}",
+            detail=f"fields={list(updates.keys())}",
+            ip=request.client.host if request.client else "",
+        )
+
+    return {"bot": bot.get_info()}
 
 
 @router.get(

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ErrorResponse(BaseModel):
@@ -178,6 +178,19 @@ class BotInfo(BaseModel):
 
     # 봇 상세 조회 시 추가되는 동적 필드 (strategy, budget, positions 등)
     model_config = ConfigDict(extra="allow")
+
+
+class BotUpdateRequest(BaseModel):
+    """봇 설정 수정 요청. None인 필드는 변경하지 않는다."""
+
+    name: str | None = None
+    interval_seconds: int | None = Field(default=None, ge=10, le=3600)
+    budget: float | None = Field(default=None, gt=0)
+    auto_restart: bool | None = None
+    max_restart_attempts: int | None = None
+    restart_cooldown_seconds: int | None = None
+    step_timeout_seconds: int | None = None
+    max_signals_per_step: int | None = None
 
 
 class BotListResponse(BaseModel):

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -35,6 +35,8 @@ class FakeBot:
         self.bot_id = bot_id
         self._status = status
         self._strategy_id = strategy_id
+        self._name = bot_id
+        self._interval_seconds = 60
         self.config = FakeBotConfig(
             bot_id, account_id=account_id, strategy_id=strategy_id
         )
@@ -46,11 +48,11 @@ class FakeBot:
     def get_info(self) -> dict:
         return {
             "bot_id": self.bot_id,
-            "name": self.bot_id,
+            "name": self._name,
             "status": self._status,
             "account_id": self.config.account_id,
             "strategy_id": self._strategy_id,
-            "interval_seconds": 60,
+            "interval_seconds": self._interval_seconds,
             "trading_mode": "",
             "exchange": "",
             "currency": "",
@@ -98,6 +100,26 @@ class FakeBotManager:
     async def delete_bot(self, bot_id: str) -> None:
         if bot_id in self._bots:
             del self._bots[bot_id]
+
+    async def update_bot(self, bot_id: str, **kwargs: object) -> FakeBot:
+        from ante.bot.exceptions import BotError
+
+        bot = self._bots.get(bot_id)
+        if bot is None:
+            raise BotError(f"Bot not found: {bot_id}")
+        if bot._status not in ("created", "stopped", "error"):
+            raise BotError(
+                f"봇 설정은 중지 상태에서만 수정할 수 있습니다: {bot_id} "
+                f"(현재: {bot._status})"
+            )
+        updates = {k: v for k, v in kwargs.items() if v is not None}
+        if "name" in updates:
+            bot.config.bot_id = bot.config.bot_id  # keep bot_id
+            # Update the name returned by get_info
+            bot._name = updates["name"]
+        if "interval_seconds" in updates:
+            bot._interval_seconds = updates["interval_seconds"]
+        return bot
 
 
 class FakeBotBudget:
@@ -638,3 +660,72 @@ class TestGetBotStrategyName:
         bot = resp.json()["bot"]
         assert bot["strategy_name"] is None
         assert bot["strategy_author_name"] is None
+
+
+class TestUpdateBot:
+    """PUT /api/bots/{bot_id} 봇 설정 수정 테스트."""
+
+    def test_update_name(self, client, bot_manager):
+        """이름 변경."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.put("/api/bots/bot-1", json={"name": "새 이름"})
+        assert resp.status_code == 200
+        assert resp.json()["bot"]["name"] == "새 이름"
+
+    def test_update_interval_seconds(self, client, bot_manager):
+        """실행 간격 변경."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.put("/api/bots/bot-1", json={"interval_seconds": 120})
+        assert resp.status_code == 200
+        assert resp.json()["bot"]["interval_seconds"] == 120
+
+    def test_update_nonexistent_bot_returns_404(self, client):
+        """존재하지 않는 봇 수정 -> 404."""
+        resp = client.put("/api/bots/nonexistent", json={"name": "x"})
+        assert resp.status_code == 404
+
+    def test_update_running_bot_returns_409(self, client, bot_manager):
+        """실행 중인 봇 수정 -> 409."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="running")
+        resp = client.put("/api/bots/bot-1", json={"name": "x"})
+        assert resp.status_code == 409
+        assert "중지 상태" in resp.json()["detail"]
+
+    def test_update_created_bot_allowed(self, client, bot_manager):
+        """created 상태 봇 수정 허용."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="created")
+        resp = client.put("/api/bots/bot-1", json={"name": "updated"})
+        assert resp.status_code == 200
+
+    def test_update_error_bot_allowed(self, client, bot_manager):
+        """error 상태 봇 수정 허용."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="error")
+        resp = client.put("/api/bots/bot-1", json={"name": "fixed"})
+        assert resp.status_code == 200
+
+    def test_empty_body_returns_current(self, client, bot_manager):
+        """빈 body면 현재 상태 반환."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.put("/api/bots/bot-1", json={})
+        assert resp.status_code == 200
+        assert resp.json()["bot"]["bot_id"] == "bot-1"
+
+    def test_interval_below_min_returns_422(self, client, bot_manager):
+        """interval_seconds < 10 -> 422 (validation error)."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.put("/api/bots/bot-1", json={"interval_seconds": 5})
+        assert resp.status_code == 422
+
+    def test_interval_above_max_returns_422(self, client, bot_manager):
+        """interval_seconds > 3600 -> 422 (validation error)."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.put("/api/bots/bot-1", json={"interval_seconds": 7200})
+        assert resp.status_code == 422
+
+    def test_budget_zero_or_negative_returns_422(self, client, bot_manager):
+        """budget <= 0 -> 422 (validation error)."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.put("/api/bots/bot-1", json={"budget": 0})
+        assert resp.status_code == 422
+        resp = client.put("/api/bots/bot-1", json={"budget": -100})
+        assert resp.status_code == 422

--- a/tests/unit/test_bot_manager_methods.py
+++ b/tests/unit/test_bot_manager_methods.py
@@ -346,3 +346,116 @@ class TestStopBotSuppressNotification:
 
         assert len(stopped_events) == 1
         assert stopped_events[0].bot_id == "bot1"
+
+
+# ── update_bot ──────────────────────────────────
+
+
+class TestUpdateBot:
+    async def test_update_name(self, manager, ctx):
+        """중지 상태 봇의 이름 변경."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager.update_bot("bot1", name="new-name")
+
+        assert bot.config.name == "new-name"
+
+    async def test_update_interval(self, manager, ctx):
+        """실행 간격 변경."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=60)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager.update_bot("bot1", interval_seconds=120)
+
+        assert bot.config.interval_seconds == 120
+
+    async def test_update_multiple_fields(self, manager, ctx):
+        """여러 필드 동시 변경."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager.update_bot(
+            "bot1",
+            name="updated",
+            interval_seconds=300,
+            auto_restart=False,
+            max_restart_attempts=5,
+        )
+
+        assert bot.config.name == "updated"
+        assert bot.config.interval_seconds == 300
+        assert bot.config.auto_restart is False
+        assert bot.config.max_restart_attempts == 5
+
+    async def test_update_preserves_unchanged_fields(self, manager, ctx):
+        """변경하지 않은 필드는 기존 값 유지."""
+        config = BotConfig(
+            bot_id="bot1",
+            strategy_id="s1",
+            name="original",
+            interval_seconds=60,
+            auto_restart=True,
+        )
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        await manager.update_bot("bot1", name="updated")
+
+        bot = manager.get_bot("bot1")
+        assert bot.config.name == "updated"
+        assert bot.config.interval_seconds == 60
+        assert bot.config.auto_restart is True
+        assert bot.config.strategy_id == "s1"
+
+    async def test_update_running_raises(self, manager, ctx):
+        """running 상태에서 수정 시 예외."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+
+        with pytest.raises(BotError, match="중지 상태"):
+            await manager.update_bot("bot1", name="x")
+
+    async def test_update_created_allowed(self, manager, ctx):
+        """created 상태에서 수정 허용."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        assert manager.get_bot("bot1").status == BotStatus.CREATED
+
+        bot = await manager.update_bot("bot1", name="updated")
+        assert bot.config.name == "updated"
+
+    async def test_update_error_allowed(self, manager, ctx):
+        """error 상태에서 수정 허용."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        manager.get_bot("bot1").status = BotStatus.ERROR
+
+        bot = await manager.update_bot("bot1", name="fixed")
+        assert bot.config.name == "fixed"
+
+    async def test_update_saves_to_db(self, manager, ctx, db):
+        """수정 결과가 DB에 반영된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", name="old")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        await manager.update_bot("bot1", name="new")
+
+        row = await db.fetch_one("SELECT config_json FROM bots WHERE bot_id = 'bot1'")
+        import json
+
+        saved = json.loads(row["config_json"])
+        assert saved["name"] == "new"
+
+    async def test_update_not_found_raises(self, manager):
+        """존재하지 않는 봇 수정 시 예외."""
+        with pytest.raises(BotError, match="not found"):
+            await manager.update_bot("nonexistent", name="x")
+
+    async def test_update_no_changes_returns_bot(self, manager, ctx):
+        """변경 사항 없으면 그대로 반환."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager.update_bot("bot1")
+        assert bot.config.bot_id == "bot1"


### PR DESCRIPTION
## Summary
- `BotManager.update_bot()` 메서드 추가: 중지 상태(created/stopped/error) 가드, BotConfig 재생성 패턴, DB 갱신, budget 변경 시 Treasury 연동
- `PUT /api/bots/{bot_id}` 핸들러 추가: BotUpdateRequest 스키마 기반 부분 수정 지원
- `BotUpdateRequest` Pydantic 스키마: name, interval_seconds(10~3600), budget(>0), auto_restart, max_restart_attempts, restart_cooldown_seconds, step_timeout_seconds, max_signals_per_step

## Test plan
- [x] API 테스트 10건 (test_bot_api.py): PUT 정상/404/409/422 검증
- [x] BotManager 단위 테스트 10건 (test_bot_manager_methods.py): 필드 변경, DB 반영, 상태 가드 검증
- [x] ruff check + ruff format 통과

Refs #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)