### PR TITLE
feat(bot): DELETE /api/bots/{id}에 handle_positions 옵션 추가 #796

### DIFF
--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from ante.strategy.base import Strategy
     from ante.strategy.context import StrategyContext
     from ante.strategy.snapshot import StrategySnapshot
+    from ante.trade.service import TradeService
     from ante.treasury.manager import TreasuryManager  # noqa: F811
 
 logger = logging.getLogger(__name__)
@@ -56,6 +57,7 @@ class BotManager:
         strategy_rule_configs: dict[str, list[dict[str, Any]]] | None = None,
         account_service: AccountService | None = None,
         treasury_manager: TreasuryManager | None = None,
+        trade_service: TradeService | None = None,
     ) -> None:
         self._eventbus = eventbus
         self._db = db
@@ -66,6 +68,7 @@ class BotManager:
         self._strategy_rule_configs = strategy_rule_configs or {}
         self._account_service = account_service
         self._treasury_manager = treasury_manager
+        self._trade_service = trade_service
         self._bots: dict[str, Bot] = {}
         self._suppress_notification_bot_ids: set[str] = set()
         self._restart_counts: dict[str, int] = {}
@@ -365,11 +368,28 @@ class BotManager:
         await bot.stop()
         self._remove_strategy_rules(bot.config.strategy_id)
 
-    async def delete_bot(self, bot_id: str) -> None:
-        """봇 소프트 딜리트. 실행 중이면 먼저 중지."""
+    async def delete_bot(self, bot_id: str, handle_positions: str = "keep") -> None:
+        """봇 소프트 딜리트. 실행 중이면 먼저 중지.
+
+        Args:
+            bot_id: 삭제할 봇 ID.
+            handle_positions: 포지션 처리 방식.
+                - ``keep`` (기본): 포지션을 유지한 채 봇만 삭제.
+                - ``liquidate``: 보유 종목 시장가 매도 주문 발행 후 삭제.
+        """
+        if handle_positions not in ("keep", "liquidate"):
+            raise BotError(
+                f"잘못된 handle_positions 값: {handle_positions!r} "
+                f"(허용: keep, liquidate)"
+            )
+
         bot = self._get_bot(bot_id)
         if bot.status == BotStatus.RUNNING:
             await bot.stop()
+
+        # liquidate: 보유 포지션 시장가 매도 주문 발행
+        if handle_positions == "liquidate":
+            await self._liquidate_positions(bot)
 
         self._unregister_bot_events(bot)
 
@@ -411,9 +431,57 @@ class BotManager:
         )
         logger.info("봇 삭제 (soft delete): %s", bot_id)
 
-    async def remove_bot(self, bot_id: str) -> None:
+    async def remove_bot(self, bot_id: str, handle_positions: str = "keep") -> None:
         """봇 삭제. delete_bot()의 별칭 (하위 호환)."""
-        await self.delete_bot(bot_id)
+        await self.delete_bot(bot_id, handle_positions=handle_positions)
+
+    async def _liquidate_positions(self, bot: Bot) -> None:
+        """봇의 보유 포지션에 대해 시장가 매도 주문을 발행한다.
+
+        체결 완료를 기다리지 않고 주문 발행 시점에서 반환한다.
+        TradeService가 없으면 경고 로그만 남기고 건너뛴다.
+        """
+        if not self._trade_service:
+            logger.warning(
+                "TradeService 미설정 — 포지션 청산 건너뜀: bot=%s",
+                bot.bot_id,
+            )
+            return
+
+        from ante.eventbus.events import OrderRequestEvent
+
+        positions = await self._trade_service.get_positions(bot_id=bot.bot_id)
+        open_positions = [p for p in positions if p.quantity > 0]
+
+        if not open_positions:
+            logger.info("청산 대상 포지션 없음: bot=%s", bot.bot_id)
+            return
+
+        for pos in open_positions:
+            event = OrderRequestEvent(
+                account_id=bot.config.account_id,
+                bot_id=bot.bot_id,
+                strategy_id=bot.config.strategy_id,
+                symbol=pos.symbol,
+                side="sell",
+                quantity=pos.quantity,
+                order_type="market",
+                reason=f"봇 삭제 청산 (bot={bot.bot_id})",
+                exchange=getattr(pos, "exchange", "KRX"),
+            )
+            await self._eventbus.publish(event)
+            logger.info(
+                "청산 주문 발행: bot=%s symbol=%s qty=%.4f",
+                bot.bot_id,
+                pos.symbol,
+                pos.quantity,
+            )
+
+        logger.info(
+            "봇 삭제 청산 주문 %d건 발행 완료: bot=%s",
+            len(open_positions),
+            bot.bot_id,
+        )
 
     async def stop_all(self) -> None:
         """모든 봇 중지."""

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -279,6 +279,7 @@ async def _init_trading(s: Services) -> None:
         snapshot=s.strategy_snapshot,
         account_service=s.account_service,
         treasury_manager=s.treasury_manager,
+        trade_service=s.trade_service,
     )
     await s.bot_manager.initialize()
 

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -314,6 +314,7 @@ async def stop_bot(
     responses={
         404: {"description": "Bot not found"},
         409: {"description": "Bot state conflict"},
+        422: {"description": "Invalid handle_positions value"},
         503: {"description": "Bot manager not available"},
     },
 )
@@ -322,16 +323,29 @@ async def delete_bot(
     request: Request,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
+    handle_positions: str = "keep",
 ) -> None:
-    """봇 삭제."""
+    """봇 삭제.
+
+    handle_positions:
+        - keep (기본): 포지션을 유지한 채 봇만 삭제.
+        - liquidate: 보유 종목 시장가 매도 주문 발행 후 삭제.
+    """
     from ante.bot.exceptions import BotError
+
+    if handle_positions not in ("keep", "liquidate"):
+        raise HTTPException(
+            status_code=422,
+            detail=f"잘못된 handle_positions 값: {handle_positions!r} "
+            f"(허용: keep, liquidate)",
+        )
 
     bot = bot_manager.get_bot(bot_id)
     if bot is None:
         raise HTTPException(status_code=404, detail=_BOT_NOT_FOUND)
 
     try:
-        await bot_manager.delete_bot(bot_id)
+        await bot_manager.delete_bot(bot_id, handle_positions=handle_positions)
     except BotError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
 
@@ -340,6 +354,7 @@ async def delete_bot(
             member_id=getattr(request.state, "member_id", "anonymous"),
             action="bot.delete",
             resource=f"bot:{bot_id}",
+            detail=f"handle_positions={handle_positions}",
             ip=request.client.host if request.client else "",
         )
 

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -95,7 +95,8 @@ class FakeBotManager:
         if bot:
             bot._status = "stopped"
 
-    async def delete_bot(self, bot_id: str) -> None:
+    async def delete_bot(self, bot_id: str, handle_positions: str = "keep") -> None:
+        self.last_delete_handle_positions = handle_positions
         if bot_id in self._bots:
             del self._bots[bot_id]
 
@@ -638,3 +639,91 @@ class TestGetBotStrategyName:
         bot = resp.json()["bot"]
         assert bot["strategy_name"] is None
         assert bot["strategy_author_name"] is None
+
+
+class TestDeleteBotHandlePositions:
+    """DELETE /api/bots/{id}?handle_positions 테스트."""
+
+    def test_delete_keep_default(self, client, bot_manager):
+        """기본값(keep)으로 봇 삭제."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.delete("/api/bots/bot-1")
+        assert resp.status_code == 204
+        assert bot_manager.last_delete_handle_positions == "keep"
+
+    def test_delete_keep_explicit(self, client, bot_manager):
+        """handle_positions=keep 명시적 전달."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.delete("/api/bots/bot-1?handle_positions=keep")
+        assert resp.status_code == 204
+        assert bot_manager.last_delete_handle_positions == "keep"
+
+    def test_delete_liquidate(self, client, bot_manager):
+        """handle_positions=liquidate로 봇 삭제."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.delete("/api/bots/bot-1?handle_positions=liquidate")
+        assert resp.status_code == 204
+        assert bot_manager.last_delete_handle_positions == "liquidate"
+
+    def test_delete_invalid_handle_positions(self, client, bot_manager):
+        """잘못된 handle_positions 값 -> 422."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.delete("/api/bots/bot-1?handle_positions=invalid")
+        assert resp.status_code == 422
+        assert "handle_positions" in resp.json()["detail"]
+
+    def test_delete_nonexistent_with_liquidate(self, client):
+        """존재하지 않는 봇에 liquidate -> 404."""
+        resp = client.delete("/api/bots/nonexistent?handle_positions=liquidate")
+        assert resp.status_code == 404
+
+
+class TestDeleteBotAuditLog:
+    """봇 삭제 감사 로그에 handle_positions 기록 테스트."""
+
+    @pytest.fixture
+    def audit_logs(self):
+        return []
+
+    @pytest.fixture
+    def fake_audit_logger(self, audit_logs):
+        class _FakeAuditLogger:
+            async def log(self, **kwargs):
+                audit_logs.append(kwargs)
+
+        return _FakeAuditLogger()
+
+    @pytest.fixture
+    def client_with_audit(
+        self, bot_manager, default_account_service, fake_audit_logger
+    ):
+        app = create_app(
+            bot_manager=bot_manager,
+            account_service=default_account_service,
+            audit_logger=fake_audit_logger,
+        )
+        return TestClient(app)
+
+    def test_audit_log_records_keep(self, client_with_audit, bot_manager, audit_logs):
+        """감사 로그에 handle_positions=keep 기록."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client_with_audit.delete("/api/bots/bot-1")
+        assert resp.status_code == 204
+        delete_logs = [
+            entry for entry in audit_logs if entry.get("action") == "bot.delete"
+        ]
+        assert len(delete_logs) == 1
+        assert delete_logs[0]["detail"] == "handle_positions=keep"
+
+    def test_audit_log_records_liquidate(
+        self, client_with_audit, bot_manager, audit_logs
+    ):
+        """감사 로그에 handle_positions=liquidate 기록."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client_with_audit.delete("/api/bots/bot-1?handle_positions=liquidate")
+        assert resp.status_code == 204
+        delete_logs = [
+            entry for entry in audit_logs if entry.get("action") == "bot.delete"
+        ]
+        assert len(delete_logs) == 1
+        assert delete_logs[0]["detail"] == "handle_positions=liquidate"

--- a/tests/unit/test_bot_delete_positions.py
+++ b/tests/unit/test_bot_delete_positions.py
@@ -1,0 +1,304 @@
+"""봇 삭제 시 handle_positions 옵션 테스트.
+
+Refs #796
+"""
+
+import asyncio
+
+import pytest
+
+from ante.bot import BotConfig, BotManager
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import OrderRequestEvent
+from ante.strategy import (
+    DataProvider,
+    OrderView,
+    PortfolioView,
+    Strategy,
+    StrategyContext,
+    StrategyMeta,
+)
+
+# -- Fake 구현체 --
+
+
+class FakeDataProvider(DataProvider):
+    async def get_ohlcv(self, symbol, timeframe="1d", limit=100):
+        return [{"close": 100.0}]
+
+    async def get_current_price(self, symbol):
+        return 100.0
+
+    async def get_indicator(self, symbol, indicator, params=None):
+        return {}
+
+
+class FakePortfolioView(PortfolioView):
+    def get_positions(self, bot_id):
+        return {}
+
+    def get_balance(self, bot_id):
+        return {"total": 1000000.0, "available": 500000.0}
+
+
+class FakeOrderView(OrderView):
+    def get_open_orders(self, bot_id):
+        return []
+
+
+class SimpleStrategy(Strategy):
+    meta = StrategyMeta(name="simple", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+
+
+class FakePositionSnapshot:
+    """테스트용 PositionSnapshot stub."""
+
+    def __init__(
+        self,
+        bot_id: str,
+        symbol: str,
+        quantity: float,
+        avg_entry_price: float = 0.0,
+        exchange: str = "KRX",
+    ) -> None:
+        self.bot_id = bot_id
+        self.symbol = symbol
+        self.quantity = quantity
+        self.avg_entry_price = avg_entry_price
+        self.exchange = exchange
+
+
+class FakeTradeService:
+    """테스트용 TradeService stub."""
+
+    def __init__(self) -> None:
+        self._positions: dict[str, list[FakePositionSnapshot]] = {}
+
+    async def get_positions(
+        self, bot_id: str, include_closed: bool = False
+    ) -> list[FakePositionSnapshot]:
+        return self._positions.get(bot_id, [])
+
+
+# -- Fixtures --
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+def ctx():
+    return StrategyContext(
+        bot_id="bot1",
+        data_provider=FakeDataProvider(),
+        portfolio=FakePortfolioView(),
+        order_view=FakeOrderView(),
+    )
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    try:
+        await asyncio.wait_for(database.close(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+@pytest.fixture
+def trade_service():
+    return FakeTradeService()
+
+
+@pytest.fixture
+async def manager(eventbus, db, trade_service):
+    m = BotManager(eventbus=eventbus, db=db, trade_service=trade_service)
+    await m.initialize()
+    yield m
+    for bot in list(m._bots.values()):
+        if bot._task and not bot._task.done():
+            bot._task.cancel()
+    try:
+        await asyncio.wait_for(m.stop_all(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+@pytest.fixture
+async def manager_no_trade(eventbus, db):
+    """TradeService 없는 BotManager."""
+    m = BotManager(eventbus=eventbus, db=db)
+    await m.initialize()
+    yield m
+    for bot in list(m._bots.values()):
+        if bot._task and not bot._task.done():
+            bot._task.cancel()
+    try:
+        await asyncio.wait_for(m.stop_all(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+# -- Tests --
+
+
+class TestDeleteBotHandlePositions:
+    """delete_bot handle_positions 파라미터 검증."""
+
+    async def test_keep_default_no_orders(self, manager, ctx, eventbus, trade_service):
+        """기본값(keep) 시 청산 주문이 발행되지 않는다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        trade_service._positions["bot1"] = [
+            FakePositionSnapshot("bot1", "005930", 50),
+        ]
+
+        published: list[OrderRequestEvent] = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: published.append(e))
+
+        await manager.delete_bot("bot1")
+
+        assert manager.get_bot("bot1") is None
+        assert len(published) == 0
+
+    async def test_liquidate_publishes_sell_orders(
+        self, manager, ctx, eventbus, trade_service
+    ):
+        """liquidate 시 보유 포지션에 대해 시장가 매도 주문을 발행한다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        trade_service._positions["bot1"] = [
+            FakePositionSnapshot("bot1", "005930", 50),
+            FakePositionSnapshot("bot1", "035420", 15),
+        ]
+
+        published: list[OrderRequestEvent] = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: published.append(e))
+
+        await manager.delete_bot("bot1", handle_positions="liquidate")
+
+        assert manager.get_bot("bot1") is None
+        assert len(published) == 2
+
+        # 주문 내용 검증
+        symbols = {e.symbol for e in published}
+        assert symbols == {"005930", "035420"}
+        for event in published:
+            assert event.side == "sell"
+            assert event.order_type == "market"
+            assert event.bot_id == "bot1"
+            assert event.account_id == "test"
+            assert event.strategy_id == "s1"
+
+        # 수량 검증
+        qty_map = {e.symbol: e.quantity for e in published}
+        assert qty_map["005930"] == 50
+        assert qty_map["035420"] == 15
+
+    async def test_liquidate_skips_zero_quantity(
+        self, manager, ctx, eventbus, trade_service
+    ):
+        """quantity=0 포지션은 청산 주문 대상에서 제외한다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        trade_service._positions["bot1"] = [
+            FakePositionSnapshot("bot1", "005930", 50),
+            FakePositionSnapshot("bot1", "035720", 0),  # 이미 청산됨
+        ]
+
+        published: list[OrderRequestEvent] = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: published.append(e))
+
+        await manager.delete_bot("bot1", handle_positions="liquidate")
+
+        assert len(published) == 1
+        assert published[0].symbol == "005930"
+
+    async def test_liquidate_no_positions(self, manager, ctx, eventbus, trade_service):
+        """보유 포지션 없으면 주문 없이 삭제된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        published: list[OrderRequestEvent] = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: published.append(e))
+
+        await manager.delete_bot("bot1", handle_positions="liquidate")
+
+        assert manager.get_bot("bot1") is None
+        assert len(published) == 0
+
+    async def test_liquidate_without_trade_service(
+        self, manager_no_trade, ctx, eventbus
+    ):
+        """TradeService 미설정 시에도 삭제는 정상 진행된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager_no_trade.create_bot(config, SimpleStrategy, ctx)
+
+        published: list[OrderRequestEvent] = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: published.append(e))
+
+        await manager_no_trade.delete_bot("bot1", handle_positions="liquidate")
+
+        assert manager_no_trade.get_bot("bot1") is None
+        assert len(published) == 0
+
+    async def test_invalid_handle_positions_raises(self, manager, ctx):
+        """잘못된 handle_positions 값은 BotError를 발생시킨다."""
+        from ante.bot.exceptions import BotError
+
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        with pytest.raises(BotError, match="handle_positions"):
+            await manager.delete_bot("bot1", handle_positions="invalid")
+
+        # 봇이 삭제되지 않았는지 확인
+        assert manager.get_bot("bot1") is not None
+
+    async def test_liquidate_order_includes_exchange(
+        self, manager, ctx, eventbus, trade_service
+    ):
+        """청산 주문에 포지션의 exchange가 포함된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        trade_service._positions["bot1"] = [
+            FakePositionSnapshot("bot1", "AAPL", 10, exchange="NASDAQ"),
+        ]
+
+        published: list[OrderRequestEvent] = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: published.append(e))
+
+        await manager.delete_bot("bot1", handle_positions="liquidate")
+
+        assert len(published) == 1
+        assert published[0].exchange == "NASDAQ"
+
+    async def test_liquidate_reason_includes_bot_id(
+        self, manager, ctx, eventbus, trade_service
+    ):
+        """청산 주문의 reason에 bot_id가 포함된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        trade_service._positions["bot1"] = [
+            FakePositionSnapshot("bot1", "005930", 50),
+        ]
+
+        published: list[OrderRequestEvent] = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: published.append(e))
+
+        await manager.delete_bot("bot1", handle_positions="liquidate")
+
+        assert "bot1" in published[0].reason


### PR DESCRIPTION
## Summary
- `DELETE /api/bots/{bot_id}?handle_positions=keep|liquidate` query param 추가
- `liquidate` 선택 시 보유 포지션에 대해 시장가 매도 `OrderRequestEvent` 발행 후 봇 삭제 진행
- `keep` (기본값)은 기존 동작 유지 (포지션 유지한 채 봇만 삭제)
- 감사 로그에 `handle_positions` 값 기록

## Changes
- `src/ante/bot/manager.py` -- `delete_bot()`에 `handle_positions` 파라미터 추가, `_liquidate_positions()` 메서드 구현, 생성자에 `trade_service` 의존성 추가
- `src/ante/web/routes/bots.py` -- DELETE 핸들러에 query param 추가, 유효성 검증(422), 감사 로그 detail 기록
- `src/ante/main.py` -- BotManager 생성 시 `trade_service` 전달
- `tests/unit/test_bot_api.py` -- API 레벨 테스트 7건 (keep/liquidate/invalid/audit)
- `tests/unit/test_bot_delete_positions.py` -- 매니저 레벨 테스트 8건 (청산 주문 발행, zero qty 스킵, TradeService 미설정 등)

## Test plan
- [x] `handle_positions=keep` (기본) 시 기존 동작 유지 확인
- [x] `handle_positions=liquidate` 시 시장가 매도 OrderRequestEvent 발행 확인
- [x] quantity=0 포지션은 청산 대상에서 제외 확인
- [x] TradeService 미설정 시에도 삭제 정상 진행 확인
- [x] 잘못된 handle_positions 값 시 422 응답 확인
- [x] 감사 로그에 handle_positions 값 기록 확인
- [x] 기존 봇 삭제/예산 환수 테스트 통과 확인

Refs #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)