### PR TITLE
feat(web): GET /api/strategies 응답에 cumulative_return 추가 #800

### DIFF
--- a/src/ante/web/deps.py
+++ b/src/ante/web/deps.py
@@ -145,6 +145,11 @@ def get_db(request: Request) -> Any:
 # ── 선택적 의존성 ───────────────────────────────────────
 
 
+def get_db_optional(request: Request) -> Any | None:
+    """데이터베이스 (선택적). 없으면 None."""
+    return getattr(request.app.state, "db", None)
+
+
 def get_data_store(request: Request) -> Any | None:
     """데이터 저장소 (선택적). 없으면 None."""
     return getattr(request.app.state, "data_store", None)

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import asdict
 from pathlib import Path
 from typing import Annotated, Any
@@ -11,6 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from ante.web.deps import (
     get_bot_manager_optional,
     get_db,
+    get_db_optional,
     get_strategy_registry,
     get_trade_service,
     get_trade_service_optional,
@@ -29,6 +31,7 @@ from ante.web.schemas import (
 router = APIRouter()
 
 _STRATEGY_NOT_FOUND = "전략을 찾을 수 없습니다"
+_logger = logging.getLogger(__name__)
 
 
 @router.post(
@@ -72,6 +75,7 @@ async def validate_strategy(body: dict) -> dict:
 async def list_strategies(
     registry: Annotated[Any, Depends(get_strategy_registry)],
     bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
+    db: Annotated[Any | None, Depends(get_db_optional)],
     status: str | None = Query(default=None),
 ) -> dict:
     """전략 목록 조회."""
@@ -83,6 +87,33 @@ async def list_strategies(
             sid = bot_info.get("strategy_id", "")
             if sid:
                 bots_by_strategy[sid] = bot_info
+
+    # 전략별 cumulative_return 일괄 조회
+    cumulative_returns: dict[str, float | None] = {}
+    if db is not None:
+        from ante.trade.performance import PerformanceTracker
+
+        tracker = PerformanceTracker(db)
+        for r in records:
+            bot_info_for_perf = bots_by_strategy.get(r.strategy_id)
+            account_id = (
+                bot_info_for_perf.get("account_id", "default")
+                if bot_info_for_perf
+                else "default"
+            )
+            try:
+                metrics = await tracker.calculate(
+                    account_id=account_id, strategy_id=r.strategy_id
+                )
+                if metrics.total_trades > 0:
+                    cumulative_returns[r.strategy_id] = metrics.net_pnl
+                else:
+                    cumulative_returns[r.strategy_id] = None
+            except Exception:
+                _logger.debug(
+                    "전략 %s cumulative_return 계산 실패", r.strategy_id, exc_info=True
+                )
+                cumulative_returns[r.strategy_id] = None
 
     strategies = []
     for r in records:
@@ -98,6 +129,7 @@ async def list_strategies(
                 "author": r.author,
                 "bot_id": bot_info["bot_id"] if bot_info else None,
                 "bot_status": bot_info["status"] if bot_info else None,
+                "cumulative_return": cumulative_returns.get(r.strategy_id),
             }
         )
 
@@ -126,7 +158,7 @@ async def get_strategy(
     strategy_dict["status"] = (
         record.status.value if hasattr(record.status, "value") else str(record.status)
     )
-    # datetime → str 변환 (response_model 호환)
+    # datetime -> str 변환 (response_model 호환)
     if hasattr(record.registered_at, "isoformat"):
         strategy_dict["registered_at"] = record.registered_at.isoformat()
 

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -227,6 +227,7 @@ class StrategyListItem(BaseModel):
     author: str
     bot_id: str | None = None
     bot_status: str | None = None
+    cumulative_return: float | None = None
 
 
 class StrategyListResponse(BaseModel):

--- a/tests/unit/test_strategy_api.py
+++ b/tests/unit/test_strategy_api.py
@@ -161,6 +161,99 @@ class TestListStrategies:
         assert data["bot_id"] == "bot-1"
         assert data["bot_status"] == "running"
 
+    def test_cumulative_return_null_without_db(self, client, registry):
+        """DB 없으면 cumulative_return은 null."""
+        registry._strategies = [
+            FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
+        ]
+        resp = client.get("/api/strategies")
+        assert resp.status_code == 200
+        data = resp.json()["strategies"][0]
+        assert data["cumulative_return"] is None
+
+    def test_cumulative_return_null_no_trades(self, registry):
+        """거래 없으면 cumulative_return은 null."""
+        from unittest.mock import AsyncMock
+
+        fake_db = AsyncMock()
+        fake_db.fetch_all = AsyncMock(return_value=[])
+
+        registry._strategies = [
+            FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
+        ]
+
+        app = create_app(strategy_registry=registry, db=fake_db)
+        c = TestClient(app)
+
+        resp = c.get("/api/strategies")
+        assert resp.status_code == 200
+        data = resp.json()["strategies"][0]
+        assert data["cumulative_return"] is None
+
+    def test_cumulative_return_with_trades(self, registry, bot_manager):
+        """거래가 있으면 cumulative_return에 net_pnl 값 반환."""
+        from unittest.mock import AsyncMock, patch
+
+        from ante.trade.models import PerformanceMetrics
+
+        fake_db = AsyncMock()
+        fake_metrics = PerformanceMetrics(
+            total_trades=5,
+            net_pnl=12345.0,
+        )
+
+        registry._strategies = [
+            FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
+        ]
+        bot_manager._bots = [
+            {
+                "bot_id": "bot-1",
+                "strategy_id": "s1",
+                "status": "running",
+                "account_id": "acc-1",
+            },
+        ]
+
+        app = create_app(
+            strategy_registry=registry,
+            bot_manager=bot_manager,
+            db=fake_db,
+        )
+        c = TestClient(app)
+
+        with patch(
+            "ante.trade.performance.PerformanceTracker.calculate",
+            new_callable=AsyncMock,
+            return_value=fake_metrics,
+        ):
+            resp = c.get("/api/strategies")
+        assert resp.status_code == 200
+        data = resp.json()["strategies"][0]
+        assert data["cumulative_return"] == 12345.0
+
+    def test_cumulative_return_db_error_graceful(self, registry):
+        """DB 에러 시 cumulative_return은 null (500 아님)."""
+        from unittest.mock import AsyncMock, patch
+
+        fake_db = AsyncMock()
+
+        registry._strategies = [
+            FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
+        ]
+
+        app = create_app(strategy_registry=registry, db=fake_db)
+        c = TestClient(app)
+
+        with patch(
+            "ante.trade.performance.PerformanceTracker.calculate",
+            new_callable=AsyncMock,
+            side_effect=Exception("DB error"),
+        ):
+            resp = c.get("/api/strategies")
+        assert resp.status_code == 200
+        data = resp.json()["strategies"][0]
+        assert data["cumulative_return"] is None
+
 
 class TestGetStrategy:
     def test_get_existing(self, client, registry):


### PR DESCRIPTION
## Summary
- `GET /api/strategies` 응답의 각 전략 항목에 `cumulative_return` 필드 추가
- `PerformanceTracker.calculate()`를 호출하여 전략별 `net_pnl` 값을 반환
- DB 미연결, 거래 데이터 없음, DB 에러 시 `null` 반환 (graceful degradation)

## Changes
- `StrategyListItem` 스키마에 `cumulative_return: float | None` 필드 추가
- `get_db_optional` 의존성 함수 추가 (`deps.py`)
- `list_strategies` 핸들러에서 전략별 성과 지표 조회 로직 추가
- 4개 테스트 케이스 추가 (DB 없음, 거래 없음, 거래 있음, DB 에러)

## Test plan
- [x] DB 없을 때 cumulative_return이 null인지 확인
- [x] 거래 데이터 없을 때 cumulative_return이 null인지 확인
- [x] 거래 데이터 있을 때 net_pnl 값이 반환되는지 확인
- [x] DB 에러 시 500이 아닌 200 + null 반환 확인
- [x] 기존 테스트 전체 통과 확인

Refs #800

🤖 Generated with [Claude Code](https://claude.com/claude-code)