### PR TITLE
feat(web): GET/PUT /api/accounts/{id}/rules 리스크 룰 API #798

### DIFF
--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -7,7 +7,12 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from ante.web.deps import get_account_service, get_audit_logger_optional
+from ante.web.deps import (
+    get_account_service,
+    get_audit_logger_optional,
+    get_config,
+    get_dynamic_config,
+)
 from ante.web.schemas import (
     AccountActionResponse,
     AccountCreateRequest,
@@ -15,6 +20,9 @@ from ante.web.schemas import (
     AccountListResponse,
     AccountSuspendRequest,
     AccountUpdateRequest,
+    RuleListResponse,
+    RuleUpdateRequest,
+    RuleUpdateResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -333,3 +341,167 @@ async def delete_account(
             detail="계좌 삭제",
             ip=request.client.host if request.client else "",
         )
+
+
+# ── 리스크 룰 ─────────────────────────────────────────
+
+
+def _config_key(account_id: str) -> str:
+    """계좌별 룰 설정 Config 키."""
+    return f"accounts.{account_id}.rules"
+
+
+def _rule_config_to_item(cfg: dict[str, Any]) -> dict[str, Any]:
+    """룰 설정 dict를 RuleItem 호환 dict로 변환.
+
+    config dict에서 type, enabled를 분리하고 나머지를 params로 묶는다.
+    """
+    params = {k: v for k, v in cfg.items() if k not in ("type", "id", "enabled")}
+    return {
+        "type": cfg.get("type", ""),
+        "enabled": cfg.get("enabled", True),
+        "params": params,
+    }
+
+
+def _item_to_rule_config(
+    rule_type: str, enabled: bool, params: dict[str, Any]
+) -> dict[str, Any]:
+    """RuleItem 데이터를 룰 설정 dict로 변환."""
+    cfg: dict[str, Any] = {"type": rule_type, "enabled": enabled}
+    cfg.update(params)
+    return cfg
+
+
+@router.get("/{account_id}/rules", response_model=RuleListResponse)
+async def get_account_rules(
+    account_id: str,
+    account_service: Annotated[Any, Depends(get_account_service)],
+    config: Annotated[Any | None, Depends(get_config)],
+    dynamic_config: Annotated[Any | None, Depends(get_dynamic_config)],
+) -> dict[str, Any]:
+    """계좌 리스크 룰 목록 조회.
+
+    DynamicConfig를 우선 조회하고, 없으면 정적 Config에서 읽는다.
+    RULE_REGISTRY에 등록된 룰 타입만 구조화하여 반환한다.
+    """
+    from ante.account.errors import AccountNotFoundError
+    from ante.rule.engine import RULE_REGISTRY
+
+    # 계좌 존재 확인
+    try:
+        await account_service.get(account_id)
+    except AccountNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    key = _config_key(account_id)
+    raw_rules: list[dict[str, Any]] = []
+
+    # 1) DynamicConfig에서 조회
+    if dynamic_config is not None:
+        try:
+            value = await dynamic_config.get(key)
+            if isinstance(value, list):
+                raw_rules = value
+        except Exception:
+            pass
+
+    # 2) 정적 Config fallback
+    if not raw_rules and config is not None and hasattr(config, "get"):
+        value = config.get(key)
+        if isinstance(value, list):
+            raw_rules = value
+
+    # RULE_REGISTRY에 등록된 타입만 필터링
+    rules = []
+    for cfg in raw_rules:
+        rule_type = cfg.get("type", "")
+        if rule_type in RULE_REGISTRY:
+            rules.append(_rule_config_to_item(cfg))
+
+    return {"account_id": account_id, "rules": rules}
+
+
+@router.put("/{account_id}/rules/{rule_type}", response_model=RuleUpdateResponse)
+async def update_account_rule(
+    account_id: str,
+    rule_type: str,
+    body: RuleUpdateRequest,
+    request: Request,
+    account_service: Annotated[Any, Depends(get_account_service)],
+    config: Annotated[Any | None, Depends(get_config)],
+    dynamic_config: Annotated[Any, Depends(get_dynamic_config)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
+) -> dict[str, Any]:
+    """계좌 리스크 룰 개별 수정.
+
+    RULE_REGISTRY에 등록된 타입만 허용하며,
+    DynamicConfigService에 위임하여 ConfigChangedEvent를 발행한다.
+    """
+    from ante.account.errors import AccountNotFoundError
+    from ante.rule.engine import RULE_REGISTRY
+
+    # 계좌 존재 확인
+    try:
+        await account_service.get(account_id)
+    except AccountNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    # 룰 타입 유효성 검증
+    if rule_type not in RULE_REGISTRY:
+        raise HTTPException(
+            status_code=400,
+            detail=f"알 수 없는 룰 타입: '{rule_type}'. "
+            f"가능한 값: {list(RULE_REGISTRY.keys())}",
+        )
+
+    key = _config_key(account_id)
+
+    # 기존 룰 설정 조회
+    raw_rules: list[dict[str, Any]] = []
+
+    # DynamicConfig에서 조회
+    try:
+        value = await dynamic_config.get(key)
+        if isinstance(value, list):
+            raw_rules = value
+    except Exception:
+        pass
+
+    # 정적 Config fallback
+    if not raw_rules and config is not None and hasattr(config, "get"):
+        value = config.get(key)
+        if isinstance(value, list):
+            raw_rules = list(value)  # 복사
+
+    # 해당 rule_type 찾아서 업데이트 또는 새로 추가
+    new_config = _item_to_rule_config(rule_type, body.enabled, body.params)
+    updated = False
+    for i, cfg in enumerate(raw_rules):
+        if cfg.get("type") == rule_type:
+            raw_rules[i] = new_config
+            updated = True
+            break
+
+    if not updated:
+        raw_rules.append(new_config)
+
+    # DynamicConfig에 저장 (ConfigChangedEvent 발행됨)
+    changed_by = getattr(request.state, "member_id", "dashboard")
+    await dynamic_config.set(key, raw_rules, category="rule", changed_by=changed_by)
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=changed_by,
+            action="account.rule.update",
+            resource=f"account:{account_id}:rule:{rule_type}",
+            detail=f"룰 수정: {rule_type} enabled={body.enabled}",
+            ip=request.client.host if request.client else "",
+        )
+
+    rule_item = _rule_config_to_item(new_config)
+    return {
+        "account_id": account_id,
+        "rule_type": rule_type,
+        "rule": rule_item,
+    }

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -823,3 +823,36 @@ class SeedResetResponse(BaseModel):
 
     ok: bool
     scenario: str
+
+
+# ── 리스크 룰 ──────────────────────────────────────────────
+
+
+class RuleItem(BaseModel):
+    """룰 설정 아이템."""
+
+    type: str
+    enabled: bool = True
+    params: dict[str, Any] = {}
+
+
+class RuleListResponse(BaseModel):
+    """계좌 룰 목록 응답."""
+
+    account_id: str
+    rules: list[RuleItem]
+
+
+class RuleUpdateRequest(BaseModel):
+    """룰 설정 변경 요청."""
+
+    enabled: bool = True
+    params: dict[str, Any] = {}
+
+
+class RuleUpdateResponse(BaseModel):
+    """룰 설정 변경 응답."""
+
+    account_id: str
+    rule_type: str
+    rule: RuleItem

--- a/tests/unit/test_account_rules_api.py
+++ b/tests/unit/test_account_rules_api.py
@@ -1,0 +1,421 @@
+"""Account Rules REST API 단위 테스트.
+
+GET /api/accounts/{account_id}/rules
+PUT /api/accounts/{account_id}/rules/{rule_type}
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.account.errors import AccountNotFoundError  # noqa: E402
+from ante.account.models import Account, AccountStatus, TradingMode  # noqa: E402
+from ante.web.app import create_app  # noqa: E402
+
+
+class FakeAccountService:
+    """테스트용 AccountService 모의 객체."""
+
+    def __init__(self) -> None:
+        self._accounts: dict[str, Account] = {}
+
+    async def get(self, account_id: str) -> Account:
+        if account_id not in self._accounts:
+            raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
+        return self._accounts[account_id]
+
+    async def list(self, status: AccountStatus | None = None) -> list[Account]:
+        return list(self._accounts.values())
+
+
+class FakeAuditLogger:
+    """테스트용 감사 로거."""
+
+    def __init__(self) -> None:
+        self.logs: list[dict[str, Any]] = []
+
+    async def log(self, **kwargs: Any) -> None:
+        self.logs.append(kwargs)
+
+
+class FakeDynamicConfig:
+    """테스트용 DynamicConfigService 모의 객체."""
+
+    _MISSING = object()
+
+    def __init__(self) -> None:
+        self._store: dict[str, Any] = {}
+
+    async def get(self, key: str, default: Any = _MISSING) -> Any:
+        if key not in self._store:
+            if default is not self._MISSING:
+                return default
+            from ante.config.exceptions import ConfigError
+
+            raise ConfigError(f"Dynamic config not found: {key}")
+        return self._store[key]
+
+    async def set(
+        self, key: str, value: Any, category: str, changed_by: str = "system"
+    ) -> None:
+        self._store[key] = value
+
+    async def exists(self, key: str) -> bool:
+        return key in self._store
+
+    async def get_all(self) -> list[dict[str, Any]]:
+        return [{"key": k, "value": v} for k, v in self._store.items()]
+
+
+class FakeConfig:
+    """테스트용 정적 Config 모의 객체."""
+
+    def __init__(self, data: dict[str, Any] | None = None) -> None:
+        self._data = data or {}
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._data.get(key, default)
+
+
+def _make_account(account_id: str = "test-account") -> Account:
+    return Account(
+        account_id=account_id,
+        name="테스트 계좌",
+        exchange="TEST",
+        currency="KRW",
+        timezone="Asia/Seoul",
+        trading_hours_start="00:00",
+        trading_hours_end="23:59",
+        trading_mode=TradingMode.VIRTUAL,
+        broker_type="test",
+        credentials={},
+        buy_commission_rate=Decimal("0"),
+        sell_commission_rate=Decimal("0"),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+def _add_account(service: FakeAccountService, account_id: str = "acct-1") -> Account:
+    """테스트용 계좌를 직접 삽입하는 헬퍼."""
+    account = _make_account(account_id)
+    service._accounts[account_id] = account
+    return account
+
+
+@pytest.fixture
+def account_service() -> FakeAccountService:
+    return FakeAccountService()
+
+
+@pytest.fixture
+def audit_logger() -> FakeAuditLogger:
+    return FakeAuditLogger()
+
+
+@pytest.fixture
+def dynamic_config() -> FakeDynamicConfig:
+    return FakeDynamicConfig()
+
+
+@pytest.fixture
+def static_config() -> FakeConfig:
+    return FakeConfig()
+
+
+@pytest.fixture
+def app(
+    account_service: FakeAccountService,
+    audit_logger: FakeAuditLogger,
+    dynamic_config: FakeDynamicConfig,
+    static_config: FakeConfig,
+):
+    return create_app(
+        account_service=account_service,
+        audit_logger=audit_logger,
+        dynamic_config=dynamic_config,
+        config=static_config,
+    )
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app)
+
+
+class TestGetAccountRules:
+    """GET /api/accounts/{account_id}/rules."""
+
+    def test_account_not_found(self, client: TestClient) -> None:
+        resp = client.get("/api/accounts/nonexistent/rules")
+        assert resp.status_code == 404
+
+    def test_empty_rules(
+        self, client: TestClient, account_service: FakeAccountService
+    ) -> None:
+        _add_account(account_service, "acct-1")
+
+        resp = client.get("/api/accounts/acct-1/rules")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["account_id"] == "acct-1"
+        assert data["rules"] == []
+
+    def test_rules_from_dynamic_config(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        dynamic_config: FakeDynamicConfig,
+    ) -> None:
+        _add_account(account_service, "acct-1")
+        dynamic_config._store["accounts.acct-1.rules"] = [
+            {
+                "type": "daily_loss_limit",
+                "enabled": True,
+                "max_daily_loss_percent": 0.05,
+            },
+            {
+                "type": "trading_hours",
+                "enabled": False,
+                "allowed_hours": "09:00-15:30",
+            },
+        ]
+
+        resp = client.get("/api/accounts/acct-1/rules")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["rules"]) == 2
+        assert data["rules"][0]["type"] == "daily_loss_limit"
+        assert data["rules"][0]["enabled"] is True
+        assert data["rules"][0]["params"]["max_daily_loss_percent"] == 0.05
+        assert data["rules"][1]["type"] == "trading_hours"
+        assert data["rules"][1]["enabled"] is False
+
+    def test_rules_from_static_config_fallback(
+        self,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """DynamicConfig에 없으면 정적 Config에서 읽는다."""
+        _add_account(account_service, "acct-1")
+
+        static_config = FakeConfig(
+            {
+                "accounts.acct-1.rules": [
+                    {
+                        "type": "total_exposure_limit",
+                        "enabled": True,
+                        "max_exposure_percent": 0.20,
+                    },
+                ]
+            }
+        )
+        app = create_app(
+            account_service=account_service,
+            audit_logger=audit_logger,
+            dynamic_config=FakeDynamicConfig(),
+            config=static_config,
+        )
+        client = TestClient(app)
+
+        resp = client.get("/api/accounts/acct-1/rules")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["rules"]) == 1
+        assert data["rules"][0]["type"] == "total_exposure_limit"
+        assert data["rules"][0]["params"]["max_exposure_percent"] == 0.20
+
+    def test_unknown_rule_types_filtered(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        dynamic_config: FakeDynamicConfig,
+    ) -> None:
+        """RULE_REGISTRY에 없는 룰 타입은 필터링된다."""
+        _add_account(account_service, "acct-1")
+        dynamic_config._store["accounts.acct-1.rules"] = [
+            {"type": "daily_loss_limit", "enabled": True},
+            {"type": "unknown_rule_xyz", "enabled": True},
+        ]
+
+        resp = client.get("/api/accounts/acct-1/rules")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["rules"]) == 1
+        assert data["rules"][0]["type"] == "daily_loss_limit"
+
+
+class TestUpdateAccountRule:
+    """PUT /api/accounts/{account_id}/rules/{rule_type}."""
+
+    def test_account_not_found(self, client: TestClient) -> None:
+        resp = client.put(
+            "/api/accounts/nonexistent/rules/daily_loss_limit",
+            json={"enabled": True, "params": {}},
+        )
+        assert resp.status_code == 404
+
+    def test_unknown_rule_type(
+        self, client: TestClient, account_service: FakeAccountService
+    ) -> None:
+        _add_account(account_service, "acct-1")
+
+        resp = client.put(
+            "/api/accounts/acct-1/rules/nonexistent_rule",
+            json={"enabled": True, "params": {}},
+        )
+        assert resp.status_code == 400
+        assert "nonexistent_rule" in resp.json()["detail"]
+
+    def test_add_new_rule(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        dynamic_config: FakeDynamicConfig,
+    ) -> None:
+        _add_account(account_service, "acct-1")
+
+        resp = client.put(
+            "/api/accounts/acct-1/rules/daily_loss_limit",
+            json={"enabled": True, "params": {"max_daily_loss_percent": 0.03}},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["account_id"] == "acct-1"
+        assert data["rule_type"] == "daily_loss_limit"
+        assert data["rule"]["type"] == "daily_loss_limit"
+        assert data["rule"]["enabled"] is True
+        assert data["rule"]["params"]["max_daily_loss_percent"] == 0.03
+
+        # DynamicConfig에 저장되었는지 확인
+        stored = dynamic_config._store["accounts.acct-1.rules"]
+        assert len(stored) == 1
+        assert stored[0]["type"] == "daily_loss_limit"
+
+    def test_update_existing_rule(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        dynamic_config: FakeDynamicConfig,
+    ) -> None:
+        _add_account(account_service, "acct-1")
+
+        # 기존 룰 설정
+        dynamic_config._store["accounts.acct-1.rules"] = [
+            {
+                "type": "daily_loss_limit",
+                "enabled": True,
+                "max_daily_loss_percent": 0.05,
+            },
+            {
+                "type": "trading_hours",
+                "enabled": True,
+            },
+        ]
+
+        # daily_loss_limit 업데이트
+        resp = client.put(
+            "/api/accounts/acct-1/rules/daily_loss_limit",
+            json={"enabled": False, "params": {"max_daily_loss_percent": 0.10}},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["rule"]["enabled"] is False
+        assert data["rule"]["params"]["max_daily_loss_percent"] == 0.10
+
+        # trading_hours는 그대로, daily_loss_limit만 변경되었는지 확인
+        stored = dynamic_config._store["accounts.acct-1.rules"]
+        assert len(stored) == 2
+        daily_loss = next(r for r in stored if r["type"] == "daily_loss_limit")
+        assert daily_loss["enabled"] is False
+        assert daily_loss["max_daily_loss_percent"] == 0.10
+        trading_hours = next(r for r in stored if r["type"] == "trading_hours")
+        assert trading_hours["enabled"] is True
+
+    def test_audit_log_created(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        _add_account(account_service, "acct-1")
+
+        resp = client.put(
+            "/api/accounts/acct-1/rules/position_size",
+            json={"enabled": True, "params": {"max_position_percent": 0.15}},
+        )
+        assert resp.status_code == 200
+
+        # AuditMiddleware도 로그를 남기므로 action으로 필터링
+        rule_logs = [
+            lg for lg in audit_logger.logs if lg.get("action") == "account.rule.update"
+        ]
+        assert len(rule_logs) == 1
+        log = rule_logs[0]
+        assert "position_size" in log["resource"]
+
+    def test_all_rule_types_accepted(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """RULE_REGISTRY에 등록된 모든 룰 타입이 PUT으로 수정 가능하다."""
+        from ante.rule.engine import RULE_REGISTRY
+
+        _add_account(account_service, "acct-1")
+
+        for rule_type in RULE_REGISTRY:
+            resp = client.put(
+                f"/api/accounts/acct-1/rules/{rule_type}",
+                json={"enabled": True, "params": {}},
+            )
+            assert resp.status_code == 200, f"Failed for rule_type={rule_type}"
+            assert resp.json()["rule_type"] == rule_type
+
+    def test_static_config_fallback_on_update(
+        self,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """정적 Config에 있는 룰이 업데이트되면 DynamicConfig에 저장된다."""
+        _add_account(account_service, "acct-1")
+
+        static_config = FakeConfig(
+            {
+                "accounts.acct-1.rules": [
+                    {
+                        "type": "total_exposure_limit",
+                        "enabled": True,
+                        "max_exposure_percent": 0.20,
+                    },
+                ]
+            }
+        )
+        dynamic_config = FakeDynamicConfig()
+        app = create_app(
+            account_service=account_service,
+            audit_logger=audit_logger,
+            dynamic_config=dynamic_config,
+            config=static_config,
+        )
+        client = TestClient(app)
+
+        resp = client.put(
+            "/api/accounts/acct-1/rules/total_exposure_limit",
+            json={"enabled": False, "params": {"max_exposure_percent": 0.30}},
+        )
+        assert resp.status_code == 200
+
+        # DynamicConfig에 저장되었는지 확인
+        stored = dynamic_config._store["accounts.acct-1.rules"]
+        assert len(stored) == 1
+        assert stored[0]["max_exposure_percent"] == 0.30
+        assert stored[0]["enabled"] is False


### PR DESCRIPTION
## Summary
- GET /api/accounts/{account_id}/rules: RULE_REGISTRY 기반 계좌별 리스크 룰 조회 (DynamicConfig 우선, 정적 Config fallback)
- PUT /api/accounts/{account_id}/rules/{rule_type}: 룰 타입 검증 후 DynamicConfigService에 위임하여 ConfigChangedEvent 발행
- RuleListResponse, RuleUpdateRequest, RuleUpdateResponse Pydantic 스키마 추가
- 12건 단위 테스트 커버리지

## Test plan
- [x] GET 계좌 미존재 시 404
- [x] GET 빈 룰 목록 정상 반환
- [x] GET DynamicConfig에서 룰 조회
- [x] GET 정적 Config fallback
- [x] GET RULE_REGISTRY 미등록 룰 타입 필터링
- [x] PUT 계좌 미존재 시 404
- [x] PUT 미등록 룰 타입 400
- [x] PUT 신규 룰 추가
- [x] PUT 기존 룰 수정 (다른 룰 유지)
- [x] PUT 감사 로그 생성
- [x] PUT 모든 RULE_REGISTRY 타입 수정 가능
- [x] PUT 정적 Config fallback → DynamicConfig 저장

Refs #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)