### PR TITLE
feat(web): GET /api/data/datasets/{dataset_id} 데이터셋 상세 API #799

### DIFF
--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from ante.web.deps import get_audit_logger_optional, get_data_store
 from ante.web.schemas import (
     DataSchemaResponse,
+    DatasetDetailResponse,
     DatasetListResponse,
     FeedStatusResponse,
     StorageSummaryResponse,
@@ -87,6 +88,73 @@ async def list_datasets(
     total = len(all_datasets)
     items = all_datasets[offset : offset + limit]
     return {"items": items, "total": total}
+
+
+@router.get("/datasets/{dataset_id}", response_model=DatasetDetailResponse)
+async def get_dataset_detail(
+    dataset_id: str,
+    store: Annotated[Any | None, Depends(get_data_store)],
+) -> dict:
+    """데이터셋 상세 조회 (메타데이터 + 최근 5행 미리보기).
+
+    dataset_id 형식: "{symbol}__{timeframe}" (예: "005930__1d")
+    """
+    if store is None:
+        raise HTTPException(status_code=503, detail="Data store not available")
+
+    parts = dataset_id.split("__", 1)
+    if len(parts) != 2:
+        raise HTTPException(
+            status_code=400,
+            detail="dataset_id는 '{symbol}__{timeframe}' 형식이어야 합니다",
+        )
+
+    symbol, timeframe = parts
+
+    # fundamental 타입 판별
+    is_fundamental = timeframe == "fundamental"
+    data_type = "fundamental" if is_fundamental else "ohlcv"
+    tf_for_store = "" if is_fundamental else timeframe
+
+    # 존재 여부 확인
+    path = store._resolve_path(symbol, tf_for_store, data_type=data_type)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="데이터셋을 찾을 수 없습니다")
+
+    # 메타데이터
+    date_range = store.get_date_range(symbol, tf_for_store, data_type=data_type)
+    row_count = 0 if is_fundamental else store.get_row_count(symbol, tf_for_store)
+
+    dataset_meta = {
+        "id": dataset_id,
+        "symbol": symbol,
+        "timeframe": timeframe if not is_fundamental else "",
+        "data_type": data_type,
+        "start_date": date_range[0] if date_range else None,
+        "end_date": date_range[1] if date_range else None,
+        "row_count": row_count,
+    }
+
+    # 최근 5행 미리보기
+    preview: list[dict[str, Any]] = []
+    try:
+        df = store.read(symbol, tf_for_store, limit=5, data_type=data_type)
+        if not df.is_empty():
+            # DataFrame → list[dict] 변환 (날짜/시간 → ISO 문자열)
+            for row in df.iter_rows(named=True):
+                record: dict[str, Any] = {}
+                for k, v in row.items():
+                    if hasattr(v, "isoformat"):
+                        record[k] = v.isoformat()
+                    elif isinstance(v, float) and (v != v):  # NaN check
+                        record[k] = None
+                    else:
+                        record[k] = v
+                preview.append(record)
+    except Exception:
+        logger.warning("데이터셋 미리보기 로드 실패: %s", dataset_id)
+
+    return {"dataset": dataset_meta, "preview": preview}
 
 
 @router.get("/schema", response_model=DataSchemaResponse)

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -569,6 +569,13 @@ class DatasetListResponse(BaseModel):
     total: int
 
 
+class DatasetDetailResponse(BaseModel):
+    """데이터셋 상세 응답 (메타데이터 + 미리보기)."""
+
+    dataset: DatasetItem
+    preview: list[dict[str, Any]] = []
+
+
 class DataSchemaResponse(BaseModel):
     """데이터 스키마 응답 (동적 키-값)."""
 

--- a/tests/unit/test_dataset_detail_api.py
+++ b/tests/unit/test_dataset_detail_api.py
@@ -1,0 +1,147 @@
+"""GET /api/data/datasets/{dataset_id} 데이터셋 상세 API 테스트."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import polars as pl
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.data.store import ParquetStore  # noqa: E402
+from ante.web.app import create_app  # noqa: E402
+
+
+def _make_ohlcv_df(n: int = 10) -> pl.DataFrame:
+    timestamps = pl.datetime_range(
+        datetime(2026, 3, 1, 9, 0),
+        datetime(2026, 3, 1, 9, n - 1),
+        interval="1m",
+        eager=True,
+        time_zone="UTC",
+    )
+    count = len(timestamps)
+    return pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": ["005930"] * count,
+            "open": [50000.0 + i for i in range(count)],
+            "high": [50100.0] * count,
+            "low": [49900.0] * count,
+            "close": [50050.0] * count,
+            "volume": [1000] * count,
+            "source": ["test"] * count,
+        }
+    )
+
+
+def _make_fundamental_df() -> pl.DataFrame:
+    from datetime import date
+
+    return pl.DataFrame(
+        {
+            "date": [date(2026, 3, 1), date(2026, 3, 2)],
+            "symbol": ["005930", "005930"],
+            "market_cap": [400_000_000_000, 401_000_000_000],
+            "per": [12.5, 12.6],
+            "pbr": [1.2, 1.3],
+            "source": ["test", "test"],
+        }
+    )
+
+
+@pytest.fixture
+def store(tmp_path):
+    return ParquetStore(base_path=tmp_path / "data")
+
+
+@pytest.fixture
+def client(store):
+    app = create_app(data_store=store)
+    return TestClient(app)
+
+
+class TestDatasetDetail:
+    """GET /api/data/datasets/{dataset_id} 상세 조회 테스트."""
+
+    async def test_basic_response_structure(self, client, store):
+        """응답이 dataset + preview 구조를 갖는다."""
+        store.write("005930", "1d", _make_ohlcv_df())
+        resp = client.get("/api/data/datasets/005930__1d")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "dataset" in body
+        assert "preview" in body
+
+    async def test_metadata_fields(self, client, store):
+        """메타데이터에 필수 필드가 모두 포함된다."""
+        store.write("005930", "1d", _make_ohlcv_df())
+        resp = client.get("/api/data/datasets/005930__1d")
+        ds = resp.json()["dataset"]
+        assert ds["id"] == "005930__1d"
+        assert ds["symbol"] == "005930"
+        assert ds["timeframe"] == "1d"
+        assert ds["data_type"] == "ohlcv"
+        assert ds["start_date"] is not None
+        assert ds["end_date"] is not None
+        assert isinstance(ds["row_count"], int)
+        assert ds["row_count"] > 0
+
+    async def test_preview_limit_5(self, client, store):
+        """미리보기는 최대 5행을 반환한다."""
+        store.write("005930", "1d", _make_ohlcv_df(n=10))
+        resp = client.get("/api/data/datasets/005930__1d")
+        preview = resp.json()["preview"]
+        assert len(preview) == 5
+
+    async def test_preview_less_than_5(self, client, store):
+        """데이터가 5행 미만이면 전체를 반환한다."""
+        store.write("005930", "1d", _make_ohlcv_df(n=3))
+        resp = client.get("/api/data/datasets/005930__1d")
+        preview = resp.json()["preview"]
+        assert len(preview) == 3
+
+    async def test_preview_contains_ohlcv_fields(self, client, store):
+        """미리보기 행에 OHLCV 필드가 포함된다."""
+        store.write("005930", "1d", _make_ohlcv_df())
+        resp = client.get("/api/data/datasets/005930__1d")
+        row = resp.json()["preview"][0]
+        for field in ("timestamp", "open", "high", "low", "close", "volume"):
+            assert field in row, f"missing field: {field}"
+
+    async def test_preview_serializes_datetime(self, client, store):
+        """datetime이 ISO 문자열로 직렬화된다."""
+        store.write("005930", "1d", _make_ohlcv_df())
+        resp = client.get("/api/data/datasets/005930__1d")
+        row = resp.json()["preview"][0]
+        assert isinstance(row["timestamp"], str)
+
+    def test_not_found(self, client):
+        """존재하지 않는 dataset_id는 404를 반환한다."""
+        resp = client.get("/api/data/datasets/999999__1d")
+        assert resp.status_code == 404
+
+    def test_invalid_id_format(self, client):
+        """잘못된 dataset_id 형식은 400을 반환한다."""
+        resp = client.get("/api/data/datasets/invalid_format")
+        assert resp.status_code == 400
+
+    def test_store_unavailable(self):
+        """store가 None이면 503을 반환한다."""
+        app = create_app(data_store=None)
+        c = TestClient(app)
+        resp = c.get("/api/data/datasets/005930__1d")
+        assert resp.status_code == 503
+
+    async def test_fundamental_dataset_detail(self, client, store):
+        """fundamental 데이터셋 상세 조회."""
+        store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        resp = client.get("/api/data/datasets/005930__fundamental")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["dataset"]["data_type"] == "fundamental"
+        assert body["dataset"]["symbol"] == "005930"
+        assert len(body["preview"]) > 0


### PR DESCRIPTION
## Summary
- `GET /api/data/datasets/{dataset_id}` 엔드포인트 추가 (dataset_id = `{symbol}__{timeframe}`)
- 메타데이터(symbol, timeframe, data_type, start_date, end_date, row_count) + 최근 5행 미리보기 반환
- 404(미존재), 400(잘못된 형식), 503(store 미사용) 에러 처리, fundamental 데이터셋도 지원

## Test plan
- [x] 응답 구조(dataset + preview) 검증
- [x] 메타데이터 필수 필드 검증
- [x] 미리보기 5행 제한 및 5행 미만 처리
- [x] OHLCV 필드 포함 및 datetime ISO 직렬화
- [x] 404/400/503 에러 케이스
- [x] fundamental 데이터셋 상세 조회
- [x] 기존 dataset 목록/삭제 테스트 회귀 없음

Refs #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)