### PR TITLE
feat(web): GET /api/strategies/{id} 응답에 params, rationale, risks 추가 #802

### DIFF
--- a/src/ante/strategy/registry.py
+++ b/src/ante/strategy/registry.py
@@ -28,7 +28,9 @@ CREATE TABLE IF NOT EXISTS strategies (
     registered_at        TEXT NOT NULL,
     description          TEXT DEFAULT '',
     author               TEXT DEFAULT 'agent',
-    validation_warnings  TEXT DEFAULT '[]'
+    validation_warnings  TEXT DEFAULT '[]',
+    rationale            TEXT DEFAULT '',
+    risks                TEXT DEFAULT '[]'
 );
 """
 
@@ -55,6 +57,8 @@ class StrategyRecord:
     description: str = ""
     author: str = "agent"
     validation_warnings: list[str] = field(default_factory=list)
+    rationale: str = ""
+    risks: list[str] = field(default_factory=list)
 
 
 class StrategyRegistry:
@@ -66,12 +70,31 @@ class StrategyRegistry:
     async def initialize(self) -> None:
         """스키마 생성."""
         await self._db.execute_script(STRATEGY_REGISTRY_SCHEMA)
+        await self._migrate_rationale_risks()
+
+    async def _migrate_rationale_risks(self) -> None:
+        """기존 strategies 테이블에 rationale, risks 컬럼이 없으면 추가한다."""
+        columns = await self._db.fetch_all("PRAGMA table_info(strategies)")
+        col_names = {col["name"] for col in columns}
+        if "rationale" not in col_names:
+            await self._db.execute(
+                "ALTER TABLE strategies ADD COLUMN rationale TEXT DEFAULT ''"
+            )
+            logger.info("strategies 테이블에 rationale 컬럼 추가 (마이그레이션)")
+        if "risks" not in col_names:
+            await self._db.execute(
+                "ALTER TABLE strategies ADD COLUMN risks TEXT DEFAULT '[]'"
+            )
+            logger.info("strategies 테이블에 risks 컬럼 추가 (마이그레이션)")
 
     async def register(
         self,
         filepath: Path,
         meta: StrategyMeta,
         warnings: list[str] | None = None,
+        *,
+        rationale: str = "",
+        risks: list[str] | None = None,
     ) -> StrategyRecord:
         """전략 등록."""
         strategy_id = f"{meta.name}_v{meta.version}"
@@ -90,14 +113,16 @@ class StrategyRegistry:
             description=meta.description,
             author=meta.author,
             validation_warnings=warnings or [],
+            rationale=rationale,
+            risks=risks or [],
         )
 
         await self._db.execute(
             """INSERT INTO strategies
                (strategy_id, name, version, filepath, status,
                 registered_at, description, author,
-                validation_warnings)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                validation_warnings, rationale, risks)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 record.strategy_id,
                 record.name,
@@ -108,6 +133,8 @@ class StrategyRegistry:
                 record.description,
                 record.author,
                 json.dumps(record.validation_warnings),
+                record.rationale,
+                json.dumps(record.risks),
             ),
         )
         logger.info("전략 등록: %s", strategy_id)
@@ -178,4 +205,6 @@ class StrategyRegistry:
             description=row["description"],
             author=row["author"],
             validation_warnings=json.loads(row["validation_warnings"]),
+            rationale=row.get("rationale", ""),
+            risks=json.loads(row["risks"]) if row.get("risks") else [],
         )

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -169,10 +169,38 @@ async def get_strategy(
                 bot_info = b
                 break
 
+    # 전략 클래스에서 params/param_schema 런타임 추출
+    params: dict[str, Any] = {}
+    param_schema: dict[str, str] = {}
+    filepath = record.filepath
+    if filepath:
+        try:
+            from ante.strategy.loader import StrategyLoader
+
+            strategy_cls = StrategyLoader.load(Path(filepath))
+            instance = strategy_cls(ctx=None)
+            params = instance.get_params()
+            param_schema = instance.get_param_schema()
+        except Exception:
+            _logger.debug(
+                "전략 %s params 추출 실패 (filepath=%s)",
+                strategy_id,
+                filepath,
+                exc_info=True,
+            )
+
+    # rationale, risks: StrategyRecord에서 추출
+    rationale = getattr(record, "rationale", "") or ""
+    risks = getattr(record, "risks", []) or []
+
     return {
         "strategy": strategy_dict,
         "bot": bot_info,
         "status": strategy_dict["status"],
+        "params": params,
+        "param_schema": param_schema,
+        "rationale": rationale,
+        "risks": risks,
     }
 
 

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -248,6 +248,8 @@ class StrategyInfo(BaseModel):
     description: str = ""
     author: str = "agent"
     validation_warnings: list[str] = []
+    rationale: str = ""
+    risks: list[str] = []
 
     # asdict(StrategyRecord) 변환 시 추가 필드 허용
     model_config = ConfigDict(extra="allow")
@@ -259,6 +261,10 @@ class StrategyDetailResponse(BaseModel):
     strategy: StrategyInfo
     bot: BotInfo | None = None
     status: str | None = None
+    params: dict[str, Any] = {}
+    param_schema: dict[str, str] = {}
+    rationale: str = ""
+    risks: list[str] = []
 
 
 class EquityCurvePoint(BaseModel):

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -707,6 +707,65 @@ class TestStrategyRegistry:
 
         assert await registry.exists("momentum_v1.0.0")
 
+    async def test_register_with_rationale_risks(self, registry, meta, tmp_path):
+        """rationale, risks를 포함하여 등록한다 (#802)."""
+        filepath = tmp_path / "test.py"
+        filepath.write_text("")
+
+        record = await registry.register(
+            filepath,
+            meta,
+            rationale="모멘텀 팩터 기반 전략",
+            risks=["급락장 리스크", "유동성 리스크"],
+        )
+        assert record.rationale == "모멘텀 팩터 기반 전략"
+        assert record.risks == ["급락장 리스크", "유동성 리스크"]
+
+        # DB에서 다시 읽어도 동일
+        loaded = await registry.get("momentum_v1.0.0")
+        assert loaded is not None
+        assert loaded.rationale == "모멘텀 팩터 기반 전략"
+        assert loaded.risks == ["급락장 리스크", "유동성 리스크"]
+
+    async def test_register_without_rationale_risks(self, registry, meta, tmp_path):
+        """rationale, risks 미지정 시 기본값 (#802)."""
+        filepath = tmp_path / "test.py"
+        filepath.write_text("")
+
+        record = await registry.register(filepath, meta)
+        assert record.rationale == ""
+        assert record.risks == []
+
+    async def test_migrate_rationale_risks_columns(self, db, tmp_path):
+        """기존 테이블에 rationale, risks 컬럼이 없어도 마이그레이션으로 추가 (#802)."""
+        # rationale, risks 없는 구식 스키마 생성
+        await db.execute_script("""
+            CREATE TABLE IF NOT EXISTS strategies (
+                strategy_id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                version TEXT NOT NULL,
+                filepath TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'registered',
+                registered_at TEXT NOT NULL,
+                description TEXT DEFAULT '',
+                author TEXT DEFAULT 'agent',
+                validation_warnings TEXT DEFAULT '[]'
+            );
+        """)
+
+        registry = StrategyRegistry(db=db)
+        await registry.initialize()
+
+        # 마이그레이션 후 등록이 정상 동작
+        meta = StrategyMeta(name="test", version="1.0.0", description="test")
+        filepath = tmp_path / "test.py"
+        filepath.write_text("")
+        record = await registry.register(
+            filepath, meta, rationale="test rationale", risks=["risk1"]
+        )
+        assert record.rationale == "test rationale"
+        assert record.risks == ["risk1"]
+
 
 # ── Exchange 호환성 검증 테스트 ──────────────────────
 

--- a/tests/unit/test_strategy_api.py
+++ b/tests/unit/test_strategy_api.py
@@ -26,6 +26,8 @@ class FakeStrategyRecord:
     description: str = ""
     author: str = "agent"
     validation_warnings: list[str] = field(default_factory=list)
+    rationale: str = ""
+    risks: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -293,6 +295,93 @@ class TestGetStrategy:
         """존재하지 않는 전략 → 404."""
         resp = client.get("/api/strategies/nonexistent")
         assert resp.status_code == 404
+
+    def test_detail_includes_rationale_risks(self, client, registry):
+        """응답에 rationale, risks 포함 (#802)."""
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                rationale="모멘텀 기반 매매 전략",
+                risks=["급락장에서 큰 손실 가능", "거래량 부족 종목 슬리피지"],
+            ),
+        ]
+        resp = client.get("/api/strategies/s1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["rationale"] == "모멘텀 기반 매매 전략"
+        assert data["risks"] == ["급락장에서 큰 손실 가능", "거래량 부족 종목 슬리피지"]
+        # strategy 객체에도 포함
+        assert data["strategy"]["rationale"] == "모멘텀 기반 매매 전략"
+        assert data["strategy"]["risks"] == [
+            "급락장에서 큰 손실 가능",
+            "거래량 부족 종목 슬리피지",
+        ]
+
+    def test_detail_includes_params_defaults(self, client, registry):
+        """params, param_schema는 전략 로드 실패 시 빈 dict (#802)."""
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                filepath="/nonexistent/path.py",
+            ),
+        ]
+        resp = client.get("/api/strategies/s1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["params"] == {}
+        assert data["param_schema"] == {}
+
+    def test_detail_params_from_strategy_file(self, client, registry, tmp_path):
+        """전략 파일이 존재하면 params/param_schema를 런타임 추출 (#802)."""
+        code = """
+from ante.strategy.base import Strategy, StrategyMeta, Signal
+
+class TestStrat(Strategy):
+    meta = StrategyMeta(name="test", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+
+    def get_params(self):
+        return {"lookback": 20, "threshold": 0.05}
+
+    def get_param_schema(self):
+        return {"lookback": "되돌아볼 기간", "threshold": "매매 임계값"}
+"""
+        filepath = tmp_path / "test_strat.py"
+        filepath.write_text(code)
+
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                filepath=str(filepath),
+            ),
+        ]
+        resp = client.get("/api/strategies/s1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["params"] == {"lookback": 20, "threshold": 0.05}
+        assert data["param_schema"] == {
+            "lookback": "되돌아볼 기간",
+            "threshold": "매매 임계값",
+        }
+
+    def test_detail_rationale_risks_defaults(self, client, registry):
+        """rationale, risks 미설정 시 기본값 (#802)."""
+        registry._strategies = [
+            FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
+        ]
+        resp = client.get("/api/strategies/s1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["rationale"] == ""
+        assert data["risks"] == []
 
 
 class TestStrategyTrades:


### PR DESCRIPTION
## Summary
- StrategyRecord에 `rationale`, `risks` 필드를 추가하고 SQLite 마이그레이션으로 기존 DB 호환성 확보
- `GET /api/strategies/{id}` 응답에 `params`, `param_schema`, `rationale`, `risks` 필드 포함
- 전략 파일이 존재하면 `StrategyLoader`로 클래스를 로드하여 `get_params()`, `get_param_schema()`를 런타임 추출 (실패 시 빈 dict)

## Test plan
- [x] rationale, risks가 응답에 포함되는지 확인 (test_detail_includes_rationale_risks)
- [x] params/param_schema가 전략 파일에서 런타임 추출되는지 확인 (test_detail_params_from_strategy_file)
- [x] 전략 파일 로드 실패 시 params/param_schema가 빈 dict인지 확인 (test_detail_includes_params_defaults)
- [x] rationale, risks 미설정 시 기본값 확인 (test_detail_rationale_risks_defaults)
- [x] StrategyRegistry에 rationale, risks 포함 등록/조회 테스트
- [x] 기존 테이블 마이그레이션 테스트 (test_migrate_rationale_risks_columns)

Refs #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)