### PR TITLE
epic/#790: 대시보드 API 보강 — 누락 API 4건 + 응답 확장 5건

### DIFF
--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -592,6 +592,7 @@ class ApprovalService:
         self,
         status: str | None = None,
         type: str | None = None,
+        search: str | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> list[ApprovalRequest]:
@@ -605,6 +606,10 @@ class ApprovalService:
         if type:
             conditions.append("type = ?")
             params.append(type)
+        if search:
+            conditions.append("(title LIKE ? OR requester LIKE ?)")
+            like_pattern = f"%{search}%"
+            params.extend([like_pattern, like_pattern])
 
         where = " AND ".join(conditions) if conditions else "1=1"
         query = (

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from ante.strategy.base import Strategy
     from ante.strategy.context import StrategyContext
     from ante.strategy.snapshot import StrategySnapshot
+    from ante.trade.service import TradeService
     from ante.treasury.manager import TreasuryManager  # noqa: F811
 
 logger = logging.getLogger(__name__)
@@ -56,6 +57,7 @@ class BotManager:
         strategy_rule_configs: dict[str, list[dict[str, Any]]] | None = None,
         account_service: AccountService | None = None,
         treasury_manager: TreasuryManager | None = None,
+        trade_service: TradeService | None = None,
     ) -> None:
         self._eventbus = eventbus
         self._db = db
@@ -66,6 +68,7 @@ class BotManager:
         self._strategy_rule_configs = strategy_rule_configs or {}
         self._account_service = account_service
         self._treasury_manager = treasury_manager
+        self._trade_service = trade_service
         self._bots: dict[str, Bot] = {}
         self._suppress_notification_bot_ids: set[str] = set()
         self._restart_counts: dict[str, int] = {}
@@ -433,11 +436,28 @@ class BotManager:
         await bot.stop()
         self._remove_strategy_rules(bot.config.strategy_id)
 
-    async def delete_bot(self, bot_id: str) -> None:
-        """봇 소프트 딜리트. 실행 중이면 먼저 중지."""
+    async def delete_bot(self, bot_id: str, handle_positions: str = "keep") -> None:
+        """봇 소프트 딜리트. 실행 중이면 먼저 중지.
+
+        Args:
+            bot_id: 삭제할 봇 ID.
+            handle_positions: 포지션 처리 방식.
+                - ``keep`` (기본): 포지션을 유지한 채 봇만 삭제.
+                - ``liquidate``: 보유 종목 시장가 매도 주문 발행 후 삭제.
+        """
+        if handle_positions not in ("keep", "liquidate"):
+            raise BotError(
+                f"잘못된 handle_positions 값: {handle_positions!r} "
+                f"(허용: keep, liquidate)"
+            )
+
         bot = self._get_bot(bot_id)
         if bot.status == BotStatus.RUNNING:
             await bot.stop()
+
+        # liquidate: 보유 포지션 시장가 매도 주문 발행
+        if handle_positions == "liquidate":
+            await self._liquidate_positions(bot)
 
         self._unregister_bot_events(bot)
 
@@ -479,9 +499,57 @@ class BotManager:
         )
         logger.info("봇 삭제 (soft delete): %s", bot_id)
 
-    async def remove_bot(self, bot_id: str) -> None:
+    async def remove_bot(self, bot_id: str, handle_positions: str = "keep") -> None:
         """봇 삭제. delete_bot()의 별칭 (하위 호환)."""
-        await self.delete_bot(bot_id)
+        await self.delete_bot(bot_id, handle_positions=handle_positions)
+
+    async def _liquidate_positions(self, bot: Bot) -> None:
+        """봇의 보유 포지션에 대해 시장가 매도 주문을 발행한다.
+
+        체결 완료를 기다리지 않고 주문 발행 시점에서 반환한다.
+        TradeService가 없으면 경고 로그만 남기고 건너뛴다.
+        """
+        if not self._trade_service:
+            logger.warning(
+                "TradeService 미설정 — 포지션 청산 건너뜀: bot=%s",
+                bot.bot_id,
+            )
+            return
+
+        from ante.eventbus.events import OrderRequestEvent
+
+        positions = await self._trade_service.get_positions(bot_id=bot.bot_id)
+        open_positions = [p for p in positions if p.quantity > 0]
+
+        if not open_positions:
+            logger.info("청산 대상 포지션 없음: bot=%s", bot.bot_id)
+            return
+
+        for pos in open_positions:
+            event = OrderRequestEvent(
+                account_id=bot.config.account_id,
+                bot_id=bot.bot_id,
+                strategy_id=bot.config.strategy_id,
+                symbol=pos.symbol,
+                side="sell",
+                quantity=pos.quantity,
+                order_type="market",
+                reason=f"봇 삭제 청산 (bot={bot.bot_id})",
+                exchange=getattr(pos, "exchange", "KRX"),
+            )
+            await self._eventbus.publish(event)
+            logger.info(
+                "청산 주문 발행: bot=%s symbol=%s qty=%.4f",
+                bot.bot_id,
+                pos.symbol,
+                pos.quantity,
+            )
+
+        logger.info(
+            "봇 삭제 청산 주문 %d건 발행 완료: bot=%s",
+            len(open_positions),
+            bot.bot_id,
+        )
 
     async def stop_all(self) -> None:
         """모든 봇 중지."""

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -279,6 +279,74 @@ class BotManager:
         logger.info("봇 생성: %s (전략: %s)", config.bot_id, config.strategy_id)
         return bot
 
+    async def update_bot(self, bot_id: str, **kwargs: Any) -> Bot:
+        """봇 설정 수정. 중지 상태에서만 허용.
+
+        BotConfig를 재생성하고 DB를 갱신한다.
+        budget이 변경되면 TreasuryManager를 통해 예산을 조정한다.
+
+        Args:
+            bot_id: 대상 봇 ID.
+            **kwargs: 변경할 설정 필드 (None 값은 무시).
+
+        Returns:
+            수정된 Bot 인스턴스.
+
+        Raises:
+            BotError: 봇이 중지 상태가 아닌 경우.
+        """
+        bot = self._get_bot(bot_id)
+        allowed_statuses = {BotStatus.CREATED, BotStatus.STOPPED, BotStatus.ERROR}
+        if bot.status not in allowed_statuses:
+            raise BotError(
+                f"봇 설정은 중지 상태에서만 수정할 수 있습니다: {bot_id} "
+                f"(현재: {bot.status})"
+            )
+
+        # budget은 BotConfig 필드가 아니므로 별도 처리
+        new_budget = kwargs.pop("budget", None)
+
+        # None이 아닌 값만 필터
+        updates = {k: v for k, v in kwargs.items() if v is not None}
+
+        if not updates and new_budget is None:
+            return bot
+
+        # BotConfig 재생성
+        old_config = bot.config
+        config_fields = {
+            "bot_id": old_config.bot_id,
+            "strategy_id": old_config.strategy_id,
+            "name": old_config.name,
+            "account_id": old_config.account_id,
+            "interval_seconds": old_config.interval_seconds,
+            "auto_restart": old_config.auto_restart,
+            "max_restart_attempts": old_config.max_restart_attempts,
+            "restart_cooldown_seconds": old_config.restart_cooldown_seconds,
+            "step_timeout_seconds": old_config.step_timeout_seconds,
+            "max_signals_per_step": old_config.max_signals_per_step,
+        }
+        config_fields.update(updates)
+        new_config = BotConfig(**config_fields)
+        bot.config = new_config
+
+        # DB 갱신
+        await self._save_bot_config(new_config)
+
+        # budget 변경 시 Treasury 연동
+        if new_budget is not None and self._treasury_manager:
+            try:
+                treasury = self._treasury_manager.get(new_config.account_id)
+                await treasury.update_budget(bot_id, new_budget)
+            except KeyError:
+                logger.debug(
+                    "봇 수정 시 Treasury 미존재: account_id=%s",
+                    new_config.account_id,
+                )
+
+        logger.info("봇 설정 수정: %s (변경: %s)", bot_id, list(updates.keys()))
+        return bot
+
     async def assign_strategy(self, bot_id: str, strategy_id: str) -> None:
         """봇에 전략 배정.
 

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -279,6 +279,7 @@ async def _init_trading(s: Services) -> None:
         snapshot=s.strategy_snapshot,
         account_service=s.account_service,
         treasury_manager=s.treasury_manager,
+        trade_service=s.trade_service,
     )
     await s.bot_manager.initialize()
 

--- a/src/ante/strategy/registry.py
+++ b/src/ante/strategy/registry.py
@@ -28,7 +28,9 @@ CREATE TABLE IF NOT EXISTS strategies (
     registered_at        TEXT NOT NULL,
     description          TEXT DEFAULT '',
     author               TEXT DEFAULT 'agent',
-    validation_warnings  TEXT DEFAULT '[]'
+    validation_warnings  TEXT DEFAULT '[]',
+    rationale            TEXT DEFAULT '',
+    risks                TEXT DEFAULT '[]'
 );
 """
 
@@ -55,6 +57,8 @@ class StrategyRecord:
     description: str = ""
     author: str = "agent"
     validation_warnings: list[str] = field(default_factory=list)
+    rationale: str = ""
+    risks: list[str] = field(default_factory=list)
 
 
 class StrategyRegistry:
@@ -66,12 +70,31 @@ class StrategyRegistry:
     async def initialize(self) -> None:
         """스키마 생성."""
         await self._db.execute_script(STRATEGY_REGISTRY_SCHEMA)
+        await self._migrate_rationale_risks()
+
+    async def _migrate_rationale_risks(self) -> None:
+        """기존 strategies 테이블에 rationale, risks 컬럼이 없으면 추가한다."""
+        columns = await self._db.fetch_all("PRAGMA table_info(strategies)")
+        col_names = {col["name"] for col in columns}
+        if "rationale" not in col_names:
+            await self._db.execute(
+                "ALTER TABLE strategies ADD COLUMN rationale TEXT DEFAULT ''"
+            )
+            logger.info("strategies 테이블에 rationale 컬럼 추가 (마이그레이션)")
+        if "risks" not in col_names:
+            await self._db.execute(
+                "ALTER TABLE strategies ADD COLUMN risks TEXT DEFAULT '[]'"
+            )
+            logger.info("strategies 테이블에 risks 컬럼 추가 (마이그레이션)")
 
     async def register(
         self,
         filepath: Path,
         meta: StrategyMeta,
         warnings: list[str] | None = None,
+        *,
+        rationale: str = "",
+        risks: list[str] | None = None,
     ) -> StrategyRecord:
         """전략 등록."""
         strategy_id = f"{meta.name}_v{meta.version}"
@@ -90,14 +113,16 @@ class StrategyRegistry:
             description=meta.description,
             author=meta.author,
             validation_warnings=warnings or [],
+            rationale=rationale,
+            risks=risks or [],
         )
 
         await self._db.execute(
             """INSERT INTO strategies
                (strategy_id, name, version, filepath, status,
                 registered_at, description, author,
-                validation_warnings)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                validation_warnings, rationale, risks)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 record.strategy_id,
                 record.name,
@@ -108,6 +133,8 @@ class StrategyRegistry:
                 record.description,
                 record.author,
                 json.dumps(record.validation_warnings),
+                record.rationale,
+                json.dumps(record.risks),
             ),
         )
         logger.info("전략 등록: %s", strategy_id)
@@ -178,4 +205,6 @@ class StrategyRegistry:
             description=row["description"],
             author=row["author"],
             validation_warnings=json.loads(row["validation_warnings"]),
+            rationale=row.get("rationale", ""),
+            risks=json.loads(row["risks"]) if row.get("risks") else [],
         )

--- a/src/ante/web/deps.py
+++ b/src/ante/web/deps.py
@@ -145,6 +145,11 @@ def get_db(request: Request) -> Any:
 # ── 선택적 의존성 ───────────────────────────────────────
 
 
+def get_db_optional(request: Request) -> Any | None:
+    """데이터베이스 (선택적). 없으면 None."""
+    return getattr(request.app.state, "db", None)
+
+
 def get_data_store(request: Request) -> Any | None:
     """데이터 저장소 (선택적). 없으면 None."""
     return getattr(request.app.state, "data_store", None)

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -7,7 +7,12 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from ante.web.deps import get_account_service, get_audit_logger_optional
+from ante.web.deps import (
+    get_account_service,
+    get_audit_logger_optional,
+    get_config,
+    get_dynamic_config,
+)
 from ante.web.schemas import (
     AccountActionResponse,
     AccountCreateRequest,
@@ -15,6 +20,9 @@ from ante.web.schemas import (
     AccountListResponse,
     AccountSuspendRequest,
     AccountUpdateRequest,
+    RuleListResponse,
+    RuleUpdateRequest,
+    RuleUpdateResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -333,3 +341,167 @@ async def delete_account(
             detail="계좌 삭제",
             ip=request.client.host if request.client else "",
         )
+
+
+# ── 리스크 룰 ─────────────────────────────────────────
+
+
+def _config_key(account_id: str) -> str:
+    """계좌별 룰 설정 Config 키."""
+    return f"accounts.{account_id}.rules"
+
+
+def _rule_config_to_item(cfg: dict[str, Any]) -> dict[str, Any]:
+    """룰 설정 dict를 RuleItem 호환 dict로 변환.
+
+    config dict에서 type, enabled를 분리하고 나머지를 params로 묶는다.
+    """
+    params = {k: v for k, v in cfg.items() if k not in ("type", "id", "enabled")}
+    return {
+        "type": cfg.get("type", ""),
+        "enabled": cfg.get("enabled", True),
+        "params": params,
+    }
+
+
+def _item_to_rule_config(
+    rule_type: str, enabled: bool, params: dict[str, Any]
+) -> dict[str, Any]:
+    """RuleItem 데이터를 룰 설정 dict로 변환."""
+    cfg: dict[str, Any] = {"type": rule_type, "enabled": enabled}
+    cfg.update(params)
+    return cfg
+
+
+@router.get("/{account_id}/rules", response_model=RuleListResponse)
+async def get_account_rules(
+    account_id: str,
+    account_service: Annotated[Any, Depends(get_account_service)],
+    config: Annotated[Any | None, Depends(get_config)],
+    dynamic_config: Annotated[Any | None, Depends(get_dynamic_config)],
+) -> dict[str, Any]:
+    """계좌 리스크 룰 목록 조회.
+
+    DynamicConfig를 우선 조회하고, 없으면 정적 Config에서 읽는다.
+    RULE_REGISTRY에 등록된 룰 타입만 구조화하여 반환한다.
+    """
+    from ante.account.errors import AccountNotFoundError
+    from ante.rule.engine import RULE_REGISTRY
+
+    # 계좌 존재 확인
+    try:
+        await account_service.get(account_id)
+    except AccountNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    key = _config_key(account_id)
+    raw_rules: list[dict[str, Any]] = []
+
+    # 1) DynamicConfig에서 조회
+    if dynamic_config is not None:
+        try:
+            value = await dynamic_config.get(key)
+            if isinstance(value, list):
+                raw_rules = value
+        except Exception:
+            pass
+
+    # 2) 정적 Config fallback
+    if not raw_rules and config is not None and hasattr(config, "get"):
+        value = config.get(key)
+        if isinstance(value, list):
+            raw_rules = value
+
+    # RULE_REGISTRY에 등록된 타입만 필터링
+    rules = []
+    for cfg in raw_rules:
+        rule_type = cfg.get("type", "")
+        if rule_type in RULE_REGISTRY:
+            rules.append(_rule_config_to_item(cfg))
+
+    return {"account_id": account_id, "rules": rules}
+
+
+@router.put("/{account_id}/rules/{rule_type}", response_model=RuleUpdateResponse)
+async def update_account_rule(
+    account_id: str,
+    rule_type: str,
+    body: RuleUpdateRequest,
+    request: Request,
+    account_service: Annotated[Any, Depends(get_account_service)],
+    config: Annotated[Any | None, Depends(get_config)],
+    dynamic_config: Annotated[Any, Depends(get_dynamic_config)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
+) -> dict[str, Any]:
+    """계좌 리스크 룰 개별 수정.
+
+    RULE_REGISTRY에 등록된 타입만 허용하며,
+    DynamicConfigService에 위임하여 ConfigChangedEvent를 발행한다.
+    """
+    from ante.account.errors import AccountNotFoundError
+    from ante.rule.engine import RULE_REGISTRY
+
+    # 계좌 존재 확인
+    try:
+        await account_service.get(account_id)
+    except AccountNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    # 룰 타입 유효성 검증
+    if rule_type not in RULE_REGISTRY:
+        raise HTTPException(
+            status_code=400,
+            detail=f"알 수 없는 룰 타입: '{rule_type}'. "
+            f"가능한 값: {list(RULE_REGISTRY.keys())}",
+        )
+
+    key = _config_key(account_id)
+
+    # 기존 룰 설정 조회
+    raw_rules: list[dict[str, Any]] = []
+
+    # DynamicConfig에서 조회
+    try:
+        value = await dynamic_config.get(key)
+        if isinstance(value, list):
+            raw_rules = value
+    except Exception:
+        pass
+
+    # 정적 Config fallback
+    if not raw_rules and config is not None and hasattr(config, "get"):
+        value = config.get(key)
+        if isinstance(value, list):
+            raw_rules = list(value)  # 복사
+
+    # 해당 rule_type 찾아서 업데이트 또는 새로 추가
+    new_config = _item_to_rule_config(rule_type, body.enabled, body.params)
+    updated = False
+    for i, cfg in enumerate(raw_rules):
+        if cfg.get("type") == rule_type:
+            raw_rules[i] = new_config
+            updated = True
+            break
+
+    if not updated:
+        raw_rules.append(new_config)
+
+    # DynamicConfig에 저장 (ConfigChangedEvent 발행됨)
+    changed_by = getattr(request.state, "member_id", "dashboard")
+    await dynamic_config.set(key, raw_rules, category="rule", changed_by=changed_by)
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=changed_by,
+            action="account.rule.update",
+            resource=f"account:{account_id}:rule:{rule_type}",
+            detail=f"룰 수정: {rule_type} enabled={body.enabled}",
+            ip=request.client.host if request.client else "",
+        )
+
+    rule_item = _rule_config_to_item(new_config)
+    return {
+        "account_id": account_id,
+        "rule_type": rule_type,
+        "rule": rule_item,
+    }

--- a/src/ante/web/routes/approvals.py
+++ b/src/ante/web/routes/approvals.py
@@ -41,12 +41,13 @@ async def list_approvals(
     approval_service: Annotated[Any, Depends(get_approval_service)],
     status: str | None = Query(default=None),
     type: str | None = Query(default=None),
+    search: str | None = Query(default=None),
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=20, ge=1, le=100),
 ) -> dict:
     """결재 목록 조회."""
     approvals = await approval_service.list(
-        status=status, type=type, limit=limit, offset=offset
+        status=status, type=type, search=search, limit=limit, offset=offset
     )
 
     return {

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -314,6 +314,7 @@ async def stop_bot(
     responses={
         404: {"description": "Bot not found"},
         409: {"description": "Bot state conflict"},
+        422: {"description": "Invalid handle_positions value"},
         503: {"description": "Bot manager not available"},
     },
 )
@@ -322,16 +323,29 @@ async def delete_bot(
     request: Request,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
+    handle_positions: str = "keep",
 ) -> None:
-    """봇 삭제."""
+    """봇 삭제.
+
+    handle_positions:
+        - keep (기본): 포지션을 유지한 채 봇만 삭제.
+        - liquidate: 보유 종목 시장가 매도 주문 발행 후 삭제.
+    """
     from ante.bot.exceptions import BotError
+
+    if handle_positions not in ("keep", "liquidate"):
+        raise HTTPException(
+            status_code=422,
+            detail=f"잘못된 handle_positions 값: {handle_positions!r} "
+            f"(허용: keep, liquidate)",
+        )
 
     bot = bot_manager.get_bot(bot_id)
     if bot is None:
         raise HTTPException(status_code=404, detail=_BOT_NOT_FOUND)
 
     try:
-        await bot_manager.delete_bot(bot_id)
+        await bot_manager.delete_bot(bot_id, handle_positions=handle_positions)
     except BotError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
 
@@ -340,6 +354,7 @@ async def delete_bot(
             member_id=getattr(request.state, "member_id", "anonymous"),
             action="bot.delete",
             resource=f"bot:{bot_id}",
+            detail=f"handle_positions={handle_positions}",
             ip=request.client.host if request.client else "",
         )
 

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -18,7 +18,7 @@ from ante.web.deps import (
     get_trade_service_optional,
     get_treasury_optional,
 )
-from ante.web.schemas import BotDetailResponse, BotListResponse
+from ante.web.schemas import BotDetailResponse, BotListResponse, BotUpdateRequest
 
 router = APIRouter()
 
@@ -342,6 +342,50 @@ async def delete_bot(
             resource=f"bot:{bot_id}",
             ip=request.client.host if request.client else "",
         )
+
+
+@router.put(
+    "/{bot_id}",
+    response_model=BotDetailResponse,
+    responses={
+        404: {"description": "Bot not found"},
+        409: {"description": "Bot state conflict (not stopped)"},
+        503: {"description": "Bot manager not available"},
+    },
+)
+async def update_bot(
+    bot_id: str,
+    body: BotUpdateRequest,
+    request: Request,
+    bot_manager: Annotated[Any, Depends(get_bot_manager)],
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
+) -> dict:
+    """봇 설정 수정. 중지 상태에서만 허용."""
+    from ante.bot.exceptions import BotError
+
+    bot = bot_manager.get_bot(bot_id)
+    if bot is None:
+        raise HTTPException(status_code=404, detail=_BOT_NOT_FOUND)
+
+    updates = body.model_dump(exclude_none=True)
+    if not updates:
+        return {"bot": bot.get_info()}
+
+    try:
+        bot = await bot_manager.update_bot(bot_id, **updates)
+    except BotError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+
+    if audit_logger:
+        await audit_logger.log(
+            member_id=getattr(request.state, "member_id", "anonymous"),
+            action="bot.update",
+            resource=f"bot:{bot_id}",
+            detail=f"fields={list(updates.keys())}",
+            ip=request.client.host if request.client else "",
+        )
+
+    return {"bot": bot.get_info()}
 
 
 @router.get(

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -42,6 +42,7 @@ class BotCreateRequest(BaseModel):
 )
 async def list_bots(
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
+    registry: Annotated[Any | None, Depends(get_strategy_registry_optional)],
     account_id: str | None = None,
     limit: int = 20,
     cursor: str | None = None,
@@ -61,6 +62,25 @@ async def list_bots(
             )
             == account_id
         ]
+
+    # 전략 이름/작성자 조인
+    if registry is not None:
+        for bot_info in bots:
+            sid = (
+                bot_info.get("strategy_id", "")
+                if isinstance(bot_info, dict)
+                else getattr(bot_info, "strategy_id", "")
+            )
+            if sid:
+                record = await registry.get(sid)
+                if record:
+                    if isinstance(bot_info, dict):
+                        bot_info["strategy_name"] = record.name
+                        bot_info["strategy_author_name"] = record.author
+                    else:
+                        bot_info.strategy_name = record.name
+                        bot_info.strategy_author_name = record.author
+
     result = paginate(bots, cursor_field="bot_id", limit=limit, cursor=cursor)
     return {"bots": result["items"], "next_cursor": result["next_cursor"]}
 
@@ -164,6 +184,8 @@ async def get_bot(
     if registry is not None:
         record = await registry.get(info.get("strategy_id", ""))
         if record:
+            info["strategy_name"] = record.name
+            info["strategy_author_name"] = record.author
             info["strategy"] = {
                 "name": record.name,
                 "version": record.version,

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from ante.web.deps import get_audit_logger_optional, get_data_store
 from ante.web.schemas import (
     DataSchemaResponse,
+    DatasetDetailResponse,
     DatasetListResponse,
     FeedStatusResponse,
     StorageSummaryResponse,
@@ -87,6 +88,73 @@ async def list_datasets(
     total = len(all_datasets)
     items = all_datasets[offset : offset + limit]
     return {"items": items, "total": total}
+
+
+@router.get("/datasets/{dataset_id}", response_model=DatasetDetailResponse)
+async def get_dataset_detail(
+    dataset_id: str,
+    store: Annotated[Any | None, Depends(get_data_store)],
+) -> dict:
+    """데이터셋 상세 조회 (메타데이터 + 최근 5행 미리보기).
+
+    dataset_id 형식: "{symbol}__{timeframe}" (예: "005930__1d")
+    """
+    if store is None:
+        raise HTTPException(status_code=503, detail="Data store not available")
+
+    parts = dataset_id.split("__", 1)
+    if len(parts) != 2:
+        raise HTTPException(
+            status_code=400,
+            detail="dataset_id는 '{symbol}__{timeframe}' 형식이어야 합니다",
+        )
+
+    symbol, timeframe = parts
+
+    # fundamental 타입 판별
+    is_fundamental = timeframe == "fundamental"
+    data_type = "fundamental" if is_fundamental else "ohlcv"
+    tf_for_store = "" if is_fundamental else timeframe
+
+    # 존재 여부 확인
+    path = store._resolve_path(symbol, tf_for_store, data_type=data_type)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="데이터셋을 찾을 수 없습니다")
+
+    # 메타데이터
+    date_range = store.get_date_range(symbol, tf_for_store, data_type=data_type)
+    row_count = 0 if is_fundamental else store.get_row_count(symbol, tf_for_store)
+
+    dataset_meta = {
+        "id": dataset_id,
+        "symbol": symbol,
+        "timeframe": timeframe if not is_fundamental else "",
+        "data_type": data_type,
+        "start_date": date_range[0] if date_range else None,
+        "end_date": date_range[1] if date_range else None,
+        "row_count": row_count,
+    }
+
+    # 최근 5행 미리보기
+    preview: list[dict[str, Any]] = []
+    try:
+        df = store.read(symbol, tf_for_store, limit=5, data_type=data_type)
+        if not df.is_empty():
+            # DataFrame → list[dict] 변환 (날짜/시간 → ISO 문자열)
+            for row in df.iter_rows(named=True):
+                record: dict[str, Any] = {}
+                for k, v in row.items():
+                    if hasattr(v, "isoformat"):
+                        record[k] = v.isoformat()
+                    elif isinstance(v, float) and (v != v):  # NaN check
+                        record[k] = None
+                    else:
+                        record[k] = v
+                preview.append(record)
+    except Exception:
+        logger.warning("데이터셋 미리보기 로드 실패: %s", dataset_id)
+
+    return {"dataset": dataset_meta, "preview": preview}
 
 
 @router.get("/schema", response_model=DataSchemaResponse)

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -169,10 +169,38 @@ async def get_strategy(
                 bot_info = b
                 break
 
+    # 전략 클래스에서 params/param_schema 런타임 추출
+    params: dict[str, Any] = {}
+    param_schema: dict[str, str] = {}
+    filepath = record.filepath
+    if filepath:
+        try:
+            from ante.strategy.loader import StrategyLoader
+
+            strategy_cls = StrategyLoader.load(Path(filepath))
+            instance = strategy_cls(ctx=None)
+            params = instance.get_params()
+            param_schema = instance.get_param_schema()
+        except Exception:
+            _logger.debug(
+                "전략 %s params 추출 실패 (filepath=%s)",
+                strategy_id,
+                filepath,
+                exc_info=True,
+            )
+
+    # rationale, risks: StrategyRecord에서 추출
+    rationale = getattr(record, "rationale", "") or ""
+    risks = getattr(record, "risks", []) or []
+
     return {
         "strategy": strategy_dict,
         "bot": bot_info,
         "status": strategy_dict["status"],
+        "params": params,
+        "param_schema": param_schema,
+        "rationale": rationale,
+        "risks": risks,
     }
 
 

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import asdict
 from pathlib import Path
 from typing import Annotated, Any
@@ -11,6 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from ante.web.deps import (
     get_bot_manager_optional,
     get_db,
+    get_db_optional,
     get_strategy_registry,
     get_trade_service,
     get_trade_service_optional,
@@ -29,6 +31,7 @@ from ante.web.schemas import (
 router = APIRouter()
 
 _STRATEGY_NOT_FOUND = "전략을 찾을 수 없습니다"
+_logger = logging.getLogger(__name__)
 
 
 @router.post(
@@ -72,6 +75,7 @@ async def validate_strategy(body: dict) -> dict:
 async def list_strategies(
     registry: Annotated[Any, Depends(get_strategy_registry)],
     bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
+    db: Annotated[Any | None, Depends(get_db_optional)],
     status: str | None = Query(default=None),
 ) -> dict:
     """전략 목록 조회."""
@@ -83,6 +87,33 @@ async def list_strategies(
             sid = bot_info.get("strategy_id", "")
             if sid:
                 bots_by_strategy[sid] = bot_info
+
+    # 전략별 cumulative_return 일괄 조회
+    cumulative_returns: dict[str, float | None] = {}
+    if db is not None:
+        from ante.trade.performance import PerformanceTracker
+
+        tracker = PerformanceTracker(db)
+        for r in records:
+            bot_info_for_perf = bots_by_strategy.get(r.strategy_id)
+            account_id = (
+                bot_info_for_perf.get("account_id", "default")
+                if bot_info_for_perf
+                else "default"
+            )
+            try:
+                metrics = await tracker.calculate(
+                    account_id=account_id, strategy_id=r.strategy_id
+                )
+                if metrics.total_trades > 0:
+                    cumulative_returns[r.strategy_id] = metrics.net_pnl
+                else:
+                    cumulative_returns[r.strategy_id] = None
+            except Exception:
+                _logger.debug(
+                    "전략 %s cumulative_return 계산 실패", r.strategy_id, exc_info=True
+                )
+                cumulative_returns[r.strategy_id] = None
 
     strategies = []
     for r in records:
@@ -98,6 +129,7 @@ async def list_strategies(
                 "author": r.author,
                 "bot_id": bot_info["bot_id"] if bot_info else None,
                 "bot_status": bot_info["status"] if bot_info else None,
+                "cumulative_return": cumulative_returns.get(r.strategy_id),
             }
         )
 
@@ -126,7 +158,7 @@ async def get_strategy(
     strategy_dict["status"] = (
         record.status.value if hasattr(record.status, "value") else str(record.status)
     )
-    # datetime → str 변환 (response_model 호환)
+    # datetime -> str 변환 (response_model 호환)
     if hasattr(record.registered_at, "isoformat"):
         strategy_dict["registered_at"] = record.registered_at.isoformat()
 

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -227,6 +227,7 @@ class StrategyListItem(BaseModel):
     author: str
     bot_id: str | None = None
     bot_status: str | None = None
+    cumulative_return: float | None = None
 
 
 class StrategyListResponse(BaseModel):

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -248,6 +248,8 @@ class StrategyInfo(BaseModel):
     description: str = ""
     author: str = "agent"
     validation_warnings: list[str] = []
+    rationale: str = ""
+    risks: list[str] = []
 
     # asdict(StrategyRecord) 변환 시 추가 필드 허용
     model_config = ConfigDict(extra="allow")
@@ -259,6 +261,10 @@ class StrategyDetailResponse(BaseModel):
     strategy: StrategyInfo
     bot: BotInfo | None = None
     status: str | None = None
+    params: dict[str, Any] = {}
+    param_schema: dict[str, str] = {}
+    rationale: str = ""
+    risks: list[str] = []
 
 
 class EquityCurvePoint(BaseModel):

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -169,6 +169,8 @@ class BotInfo(BaseModel):
     status: str = ""
     account_id: str = ""
     strategy_id: str = ""
+    strategy_name: str | None = None
+    strategy_author_name: str | None = None
     interval_seconds: int = 60
     started_at: str | None = None
     stopped_at: str | None = None

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ErrorResponse(BaseModel):
@@ -178,6 +178,19 @@ class BotInfo(BaseModel):
 
     # 봇 상세 조회 시 추가되는 동적 필드 (strategy, budget, positions 등)
     model_config = ConfigDict(extra="allow")
+
+
+class BotUpdateRequest(BaseModel):
+    """봇 설정 수정 요청. None인 필드는 변경하지 않는다."""
+
+    name: str | None = None
+    interval_seconds: int | None = Field(default=None, ge=10, le=3600)
+    budget: float | None = Field(default=None, gt=0)
+    auto_restart: bool | None = None
+    max_restart_attempts: int | None = None
+    restart_cooldown_seconds: int | None = None
+    step_timeout_seconds: int | None = None
+    max_signals_per_step: int | None = None
 
 
 class BotListResponse(BaseModel):

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -569,6 +569,13 @@ class DatasetListResponse(BaseModel):
     total: int
 
 
+class DatasetDetailResponse(BaseModel):
+    """데이터셋 상세 응답 (메타데이터 + 미리보기)."""
+
+    dataset: DatasetItem
+    preview: list[dict[str, Any]] = []
+
+
 class DataSchemaResponse(BaseModel):
     """데이터 스키마 응답 (동적 키-값)."""
 

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -824,3 +824,36 @@ class SeedResetResponse(BaseModel):
 
     ok: bool
     scenario: str
+
+
+# ── 리스크 룰 ──────────────────────────────────────────────
+
+
+class RuleItem(BaseModel):
+    """룰 설정 아이템."""
+
+    type: str
+    enabled: bool = True
+    params: dict[str, Any] = {}
+
+
+class RuleListResponse(BaseModel):
+    """계좌 룰 목록 응답."""
+
+    account_id: str
+    rules: list[RuleItem]
+
+
+class RuleUpdateRequest(BaseModel):
+    """룰 설정 변경 요청."""
+
+    enabled: bool = True
+    params: dict[str, Any] = {}
+
+
+class RuleUpdateResponse(BaseModel):
+    """룰 설정 변경 응답."""
+
+    account_id: str
+    rule_type: str
+    rule: RuleItem

--- a/tests/unit/test_account_rules_api.py
+++ b/tests/unit/test_account_rules_api.py
@@ -1,0 +1,421 @@
+"""Account Rules REST API 단위 테스트.
+
+GET /api/accounts/{account_id}/rules
+PUT /api/accounts/{account_id}/rules/{rule_type}
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.account.errors import AccountNotFoundError  # noqa: E402
+from ante.account.models import Account, AccountStatus, TradingMode  # noqa: E402
+from ante.web.app import create_app  # noqa: E402
+
+
+class FakeAccountService:
+    """테스트용 AccountService 모의 객체."""
+
+    def __init__(self) -> None:
+        self._accounts: dict[str, Account] = {}
+
+    async def get(self, account_id: str) -> Account:
+        if account_id not in self._accounts:
+            raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
+        return self._accounts[account_id]
+
+    async def list(self, status: AccountStatus | None = None) -> list[Account]:
+        return list(self._accounts.values())
+
+
+class FakeAuditLogger:
+    """테스트용 감사 로거."""
+
+    def __init__(self) -> None:
+        self.logs: list[dict[str, Any]] = []
+
+    async def log(self, **kwargs: Any) -> None:
+        self.logs.append(kwargs)
+
+
+class FakeDynamicConfig:
+    """테스트용 DynamicConfigService 모의 객체."""
+
+    _MISSING = object()
+
+    def __init__(self) -> None:
+        self._store: dict[str, Any] = {}
+
+    async def get(self, key: str, default: Any = _MISSING) -> Any:
+        if key not in self._store:
+            if default is not self._MISSING:
+                return default
+            from ante.config.exceptions import ConfigError
+
+            raise ConfigError(f"Dynamic config not found: {key}")
+        return self._store[key]
+
+    async def set(
+        self, key: str, value: Any, category: str, changed_by: str = "system"
+    ) -> None:
+        self._store[key] = value
+
+    async def exists(self, key: str) -> bool:
+        return key in self._store
+
+    async def get_all(self) -> list[dict[str, Any]]:
+        return [{"key": k, "value": v} for k, v in self._store.items()]
+
+
+class FakeConfig:
+    """테스트용 정적 Config 모의 객체."""
+
+    def __init__(self, data: dict[str, Any] | None = None) -> None:
+        self._data = data or {}
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._data.get(key, default)
+
+
+def _make_account(account_id: str = "test-account") -> Account:
+    return Account(
+        account_id=account_id,
+        name="테스트 계좌",
+        exchange="TEST",
+        currency="KRW",
+        timezone="Asia/Seoul",
+        trading_hours_start="00:00",
+        trading_hours_end="23:59",
+        trading_mode=TradingMode.VIRTUAL,
+        broker_type="test",
+        credentials={},
+        buy_commission_rate=Decimal("0"),
+        sell_commission_rate=Decimal("0"),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+def _add_account(service: FakeAccountService, account_id: str = "acct-1") -> Account:
+    """테스트용 계좌를 직접 삽입하는 헬퍼."""
+    account = _make_account(account_id)
+    service._accounts[account_id] = account
+    return account
+
+
+@pytest.fixture
+def account_service() -> FakeAccountService:
+    return FakeAccountService()
+
+
+@pytest.fixture
+def audit_logger() -> FakeAuditLogger:
+    return FakeAuditLogger()
+
+
+@pytest.fixture
+def dynamic_config() -> FakeDynamicConfig:
+    return FakeDynamicConfig()
+
+
+@pytest.fixture
+def static_config() -> FakeConfig:
+    return FakeConfig()
+
+
+@pytest.fixture
+def app(
+    account_service: FakeAccountService,
+    audit_logger: FakeAuditLogger,
+    dynamic_config: FakeDynamicConfig,
+    static_config: FakeConfig,
+):
+    return create_app(
+        account_service=account_service,
+        audit_logger=audit_logger,
+        dynamic_config=dynamic_config,
+        config=static_config,
+    )
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app)
+
+
+class TestGetAccountRules:
+    """GET /api/accounts/{account_id}/rules."""
+
+    def test_account_not_found(self, client: TestClient) -> None:
+        resp = client.get("/api/accounts/nonexistent/rules")
+        assert resp.status_code == 404
+
+    def test_empty_rules(
+        self, client: TestClient, account_service: FakeAccountService
+    ) -> None:
+        _add_account(account_service, "acct-1")
+
+        resp = client.get("/api/accounts/acct-1/rules")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["account_id"] == "acct-1"
+        assert data["rules"] == []
+
+    def test_rules_from_dynamic_config(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        dynamic_config: FakeDynamicConfig,
+    ) -> None:
+        _add_account(account_service, "acct-1")
+        dynamic_config._store["accounts.acct-1.rules"] = [
+            {
+                "type": "daily_loss_limit",
+                "enabled": True,
+                "max_daily_loss_percent": 0.05,
+            },
+            {
+                "type": "trading_hours",
+                "enabled": False,
+                "allowed_hours": "09:00-15:30",
+            },
+        ]
+
+        resp = client.get("/api/accounts/acct-1/rules")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["rules"]) == 2
+        assert data["rules"][0]["type"] == "daily_loss_limit"
+        assert data["rules"][0]["enabled"] is True
+        assert data["rules"][0]["params"]["max_daily_loss_percent"] == 0.05
+        assert data["rules"][1]["type"] == "trading_hours"
+        assert data["rules"][1]["enabled"] is False
+
+    def test_rules_from_static_config_fallback(
+        self,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """DynamicConfig에 없으면 정적 Config에서 읽는다."""
+        _add_account(account_service, "acct-1")
+
+        static_config = FakeConfig(
+            {
+                "accounts.acct-1.rules": [
+                    {
+                        "type": "total_exposure_limit",
+                        "enabled": True,
+                        "max_exposure_percent": 0.20,
+                    },
+                ]
+            }
+        )
+        app = create_app(
+            account_service=account_service,
+            audit_logger=audit_logger,
+            dynamic_config=FakeDynamicConfig(),
+            config=static_config,
+        )
+        client = TestClient(app)
+
+        resp = client.get("/api/accounts/acct-1/rules")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["rules"]) == 1
+        assert data["rules"][0]["type"] == "total_exposure_limit"
+        assert data["rules"][0]["params"]["max_exposure_percent"] == 0.20
+
+    def test_unknown_rule_types_filtered(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        dynamic_config: FakeDynamicConfig,
+    ) -> None:
+        """RULE_REGISTRY에 없는 룰 타입은 필터링된다."""
+        _add_account(account_service, "acct-1")
+        dynamic_config._store["accounts.acct-1.rules"] = [
+            {"type": "daily_loss_limit", "enabled": True},
+            {"type": "unknown_rule_xyz", "enabled": True},
+        ]
+
+        resp = client.get("/api/accounts/acct-1/rules")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["rules"]) == 1
+        assert data["rules"][0]["type"] == "daily_loss_limit"
+
+
+class TestUpdateAccountRule:
+    """PUT /api/accounts/{account_id}/rules/{rule_type}."""
+
+    def test_account_not_found(self, client: TestClient) -> None:
+        resp = client.put(
+            "/api/accounts/nonexistent/rules/daily_loss_limit",
+            json={"enabled": True, "params": {}},
+        )
+        assert resp.status_code == 404
+
+    def test_unknown_rule_type(
+        self, client: TestClient, account_service: FakeAccountService
+    ) -> None:
+        _add_account(account_service, "acct-1")
+
+        resp = client.put(
+            "/api/accounts/acct-1/rules/nonexistent_rule",
+            json={"enabled": True, "params": {}},
+        )
+        assert resp.status_code == 400
+        assert "nonexistent_rule" in resp.json()["detail"]
+
+    def test_add_new_rule(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        dynamic_config: FakeDynamicConfig,
+    ) -> None:
+        _add_account(account_service, "acct-1")
+
+        resp = client.put(
+            "/api/accounts/acct-1/rules/daily_loss_limit",
+            json={"enabled": True, "params": {"max_daily_loss_percent": 0.03}},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["account_id"] == "acct-1"
+        assert data["rule_type"] == "daily_loss_limit"
+        assert data["rule"]["type"] == "daily_loss_limit"
+        assert data["rule"]["enabled"] is True
+        assert data["rule"]["params"]["max_daily_loss_percent"] == 0.03
+
+        # DynamicConfig에 저장되었는지 확인
+        stored = dynamic_config._store["accounts.acct-1.rules"]
+        assert len(stored) == 1
+        assert stored[0]["type"] == "daily_loss_limit"
+
+    def test_update_existing_rule(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        dynamic_config: FakeDynamicConfig,
+    ) -> None:
+        _add_account(account_service, "acct-1")
+
+        # 기존 룰 설정
+        dynamic_config._store["accounts.acct-1.rules"] = [
+            {
+                "type": "daily_loss_limit",
+                "enabled": True,
+                "max_daily_loss_percent": 0.05,
+            },
+            {
+                "type": "trading_hours",
+                "enabled": True,
+            },
+        ]
+
+        # daily_loss_limit 업데이트
+        resp = client.put(
+            "/api/accounts/acct-1/rules/daily_loss_limit",
+            json={"enabled": False, "params": {"max_daily_loss_percent": 0.10}},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["rule"]["enabled"] is False
+        assert data["rule"]["params"]["max_daily_loss_percent"] == 0.10
+
+        # trading_hours는 그대로, daily_loss_limit만 변경되었는지 확인
+        stored = dynamic_config._store["accounts.acct-1.rules"]
+        assert len(stored) == 2
+        daily_loss = next(r for r in stored if r["type"] == "daily_loss_limit")
+        assert daily_loss["enabled"] is False
+        assert daily_loss["max_daily_loss_percent"] == 0.10
+        trading_hours = next(r for r in stored if r["type"] == "trading_hours")
+        assert trading_hours["enabled"] is True
+
+    def test_audit_log_created(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        _add_account(account_service, "acct-1")
+
+        resp = client.put(
+            "/api/accounts/acct-1/rules/position_size",
+            json={"enabled": True, "params": {"max_position_percent": 0.15}},
+        )
+        assert resp.status_code == 200
+
+        # AuditMiddleware도 로그를 남기므로 action으로 필터링
+        rule_logs = [
+            lg for lg in audit_logger.logs if lg.get("action") == "account.rule.update"
+        ]
+        assert len(rule_logs) == 1
+        log = rule_logs[0]
+        assert "position_size" in log["resource"]
+
+    def test_all_rule_types_accepted(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """RULE_REGISTRY에 등록된 모든 룰 타입이 PUT으로 수정 가능하다."""
+        from ante.rule.engine import RULE_REGISTRY
+
+        _add_account(account_service, "acct-1")
+
+        for rule_type in RULE_REGISTRY:
+            resp = client.put(
+                f"/api/accounts/acct-1/rules/{rule_type}",
+                json={"enabled": True, "params": {}},
+            )
+            assert resp.status_code == 200, f"Failed for rule_type={rule_type}"
+            assert resp.json()["rule_type"] == rule_type
+
+    def test_static_config_fallback_on_update(
+        self,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """정적 Config에 있는 룰이 업데이트되면 DynamicConfig에 저장된다."""
+        _add_account(account_service, "acct-1")
+
+        static_config = FakeConfig(
+            {
+                "accounts.acct-1.rules": [
+                    {
+                        "type": "total_exposure_limit",
+                        "enabled": True,
+                        "max_exposure_percent": 0.20,
+                    },
+                ]
+            }
+        )
+        dynamic_config = FakeDynamicConfig()
+        app = create_app(
+            account_service=account_service,
+            audit_logger=audit_logger,
+            dynamic_config=dynamic_config,
+            config=static_config,
+        )
+        client = TestClient(app)
+
+        resp = client.put(
+            "/api/accounts/acct-1/rules/total_exposure_limit",
+            json={"enabled": False, "params": {"max_exposure_percent": 0.30}},
+        )
+        assert resp.status_code == 200
+
+        # DynamicConfig에 저장되었는지 확인
+        stored = dynamic_config._store["accounts.acct-1.rules"]
+        assert len(stored) == 1
+        assert stored[0]["max_exposure_percent"] == 0.30
+        assert stored[0]["enabled"] is False

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -1442,3 +1442,86 @@ class TestSuppressNotification:
         await service.reject(req.id)
 
         assert len(notifications) == 1
+
+
+class TestListSearch:
+    """list() search 파라미터 테스트."""
+
+    async def test_search_by_title(self, service):
+        """title LIKE 검색."""
+        await service.create(
+            type="budget_change", requester="agent-01", title="예산 증액 요청"
+        )
+        await service.create(
+            type="strategy_adopt", requester="agent-02", title="전략 채택 요청"
+        )
+
+        results = await service.list(search="예산")
+        assert len(results) == 1
+        assert results[0].title == "예산 증액 요청"
+
+    async def test_search_by_requester(self, service):
+        """requester LIKE 검색."""
+        await service.create(
+            type="budget_change", requester="agent-alpha", title="요청 A"
+        )
+        await service.create(
+            type="budget_change", requester="agent-beta", title="요청 B"
+        )
+
+        results = await service.list(search="alpha")
+        assert len(results) == 1
+        assert results[0].requester == "agent-alpha"
+
+    async def test_search_matches_title_or_requester(self, service):
+        """title 또는 requester 중 하나라도 매치되면 반환."""
+        await service.create(
+            type="budget_change", requester="agent-01", title="검색어포함"
+        )
+        await service.create(
+            type="budget_change", requester="검색어포함", title="일반 제목"
+        )
+        await service.create(
+            type="budget_change", requester="agent-02", title="관련 없는 제목"
+        )
+
+        results = await service.list(search="검색어포함")
+        assert len(results) == 2
+
+    async def test_search_no_match(self, service):
+        """매치 없으면 빈 목록."""
+        await service.create(
+            type="budget_change", requester="agent-01", title="예산 요청"
+        )
+
+        results = await service.list(search="존재하지않는키워드")
+        assert len(results) == 0
+
+    async def test_search_empty_string(self, service):
+        """빈 문자열이면 전체 반환 (search 미지정과 동일)."""
+        await service.create(type="budget_change", requester="agent-01", title="요청 1")
+        await service.create(type="budget_change", requester="agent-02", title="요청 2")
+
+        results = await service.list(search="")
+        assert len(results) == 2
+
+    async def test_search_combined_with_status_filter(self, service):
+        """search와 status 필터 조합."""
+        req = await service.create(
+            type="budget_change", requester="agent-01", title="승인될 요청"
+        )
+        await service.create(
+            type="budget_change", requester="agent-01", title="대기 중 요청"
+        )
+        await service.approve(req.id)
+
+        results = await service.list(search="요청", status="pending")
+        assert len(results) == 1
+        assert results[0].title == "대기 중 요청"
+
+    async def test_search_none_returns_all(self, service):
+        """search=None이면 기존 동작 (전체 반환)."""
+        await service.create(type="budget_change", requester="agent-01", title="요청 1")
+
+        results = await service.list(search=None)
+        assert len(results) == 1

--- a/tests/unit/test_approval_api.py
+++ b/tests/unit/test_approval_api.py
@@ -92,6 +92,40 @@ class TestListApprovals:
         assert resp.status_code == 200
         assert resp.json()["total"] == 0
 
+    async def test_search_by_title(self, client, sample_approval):
+        """search 파라미터로 title 검색."""
+        resp = client.get("/api/approvals?search=전략 채택")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+
+    async def test_search_by_requester(self, client, sample_approval):
+        """search 파라미터로 requester 검색."""
+        resp = client.get("/api/approvals?search=agent-01")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+
+    async def test_search_no_match(self, client, sample_approval):
+        """search 매치 없으면 빈 목록."""
+        resp = client.get("/api/approvals?search=존재하지않는키워드")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    def test_search_without_data(self, client):
+        """데이터 없을 때 search 파라미터."""
+        resp = client.get("/api/approvals?search=anything")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    async def test_search_combined_with_status(self, client, sample_approval):
+        """search와 status 필터 조합."""
+        resp = client.get("/api/approvals?search=전략&status=pending")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+
+        resp = client.get("/api/approvals?search=전략&status=approved")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
 
 class TestGetApproval:
     async def test_get_existing(self, client, sample_approval):

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -422,12 +422,18 @@ class FakeAccountService:
 class FakeStrategyRecord:
     """테스트용 StrategyRecord stub."""
 
-    def __init__(self, strategy_id: str = "s1", filepath: str = "/tmp/s1.py") -> None:
+    def __init__(
+        self,
+        strategy_id: str = "s1",
+        filepath: str = "/tmp/s1.py",
+        name: str = "",
+        author: str = "test",
+    ) -> None:
         self.strategy_id = strategy_id
         self.filepath = filepath
-        self.name = strategy_id
+        self.name = name or strategy_id
         self.version = "0.1.0"
-        self.author = "test"
+        self.author = author
         self.description = "test strategy"
 
 
@@ -530,3 +536,105 @@ class TestBotLifecycle:
         # delete
         resp = client.delete("/api/bots/bot-1")
         assert resp.status_code == 204
+
+
+class TestListBotsStrategyName:
+    """list_bots 응답에 strategy_name, strategy_author_name 포함 테스트."""
+
+    @pytest.fixture
+    def strategy_registry(self):
+        reg = FakeStrategyRegistry()
+        reg._strategies["s1"] = FakeStrategyRecord(
+            "s1", name="MyStrategy", author="alice"
+        )
+        return reg
+
+    @pytest.fixture
+    def client_with_registry(
+        self, bot_manager, default_account_service, strategy_registry
+    ):
+        app = create_app(
+            bot_manager=bot_manager,
+            account_service=default_account_service,
+            strategy_registry=strategy_registry,
+        )
+        return TestClient(app)
+
+    def test_strategy_name_included(self, client_with_registry, bot_manager):
+        """봇 목록에 strategy_name, strategy_author_name 포함."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", strategy_id="s1")
+        resp = client_with_registry.get("/api/bots")
+        assert resp.status_code == 200
+        bot = resp.json()["bots"][0]
+        assert bot["strategy_name"] == "MyStrategy"
+        assert bot["strategy_author_name"] == "alice"
+
+    def test_strategy_not_found_returns_null(self, client_with_registry, bot_manager):
+        """레지스트리에 없는 전략이면 strategy_name은 null."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", strategy_id="unknown")
+        resp = client_with_registry.get("/api/bots")
+        assert resp.status_code == 200
+        bot = resp.json()["bots"][0]
+        assert bot["strategy_name"] is None
+        assert bot["strategy_author_name"] is None
+
+    def test_no_registry_returns_null(self, client, bot_manager):
+        """레지스트리 없으면 strategy_name은 null."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", strategy_id="s1")
+        resp = client.get("/api/bots")
+        assert resp.status_code == 200
+        bot = resp.json()["bots"][0]
+        assert bot["strategy_name"] is None
+        assert bot["strategy_author_name"] is None
+
+
+class TestGetBotStrategyName:
+    """get_bot 응답에 strategy_name, strategy_author_name 포함 테스트."""
+
+    @pytest.fixture
+    def strategy_registry(self):
+        reg = FakeStrategyRegistry()
+        reg._strategies["s1"] = FakeStrategyRecord(
+            "s1", name="MyStrategy", author="alice"
+        )
+        return reg
+
+    @pytest.fixture
+    def client_with_registry(
+        self, bot_manager, default_account_service, strategy_registry
+    ):
+        app = create_app(
+            bot_manager=bot_manager,
+            account_service=default_account_service,
+            strategy_registry=strategy_registry,
+        )
+        return TestClient(app)
+
+    def test_strategy_name_included(self, client_with_registry, bot_manager):
+        """봇 상세 조회에 strategy_name, strategy_author_name 포함."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", strategy_id="s1")
+        resp = client_with_registry.get("/api/bots/bot-1")
+        assert resp.status_code == 200
+        bot = resp.json()["bot"]
+        assert bot["strategy_name"] == "MyStrategy"
+        assert bot["strategy_author_name"] == "alice"
+        # strategy 상세 객체도 여전히 포함
+        assert bot["strategy"]["name"] == "MyStrategy"
+
+    def test_strategy_not_found_returns_null(self, client_with_registry, bot_manager):
+        """레지스트리에 없는 전략이면 strategy_name은 null."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", strategy_id="unknown")
+        resp = client_with_registry.get("/api/bots/bot-1")
+        assert resp.status_code == 200
+        bot = resp.json()["bot"]
+        assert bot["strategy_name"] is None
+        assert bot["strategy_author_name"] is None
+
+    def test_no_registry_returns_null(self, client, bot_manager):
+        """레지스트리 없으면 strategy_name은 null."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", strategy_id="s1")
+        resp = client.get("/api/bots/bot-1")
+        assert resp.status_code == 200
+        bot = resp.json()["bot"]
+        assert bot["strategy_name"] is None
+        assert bot["strategy_author_name"] is None

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -35,6 +35,8 @@ class FakeBot:
         self.bot_id = bot_id
         self._status = status
         self._strategy_id = strategy_id
+        self._name = bot_id
+        self._interval_seconds = 60
         self.config = FakeBotConfig(
             bot_id, account_id=account_id, strategy_id=strategy_id
         )
@@ -46,11 +48,11 @@ class FakeBot:
     def get_info(self) -> dict:
         return {
             "bot_id": self.bot_id,
-            "name": self.bot_id,
+            "name": self._name,
             "status": self._status,
             "account_id": self.config.account_id,
             "strategy_id": self._strategy_id,
-            "interval_seconds": 60,
+            "interval_seconds": self._interval_seconds,
             "trading_mode": "",
             "exchange": "",
             "currency": "",
@@ -98,6 +100,26 @@ class FakeBotManager:
     async def delete_bot(self, bot_id: str) -> None:
         if bot_id in self._bots:
             del self._bots[bot_id]
+
+    async def update_bot(self, bot_id: str, **kwargs: object) -> FakeBot:
+        from ante.bot.exceptions import BotError
+
+        bot = self._bots.get(bot_id)
+        if bot is None:
+            raise BotError(f"Bot not found: {bot_id}")
+        if bot._status not in ("created", "stopped", "error"):
+            raise BotError(
+                f"봇 설정은 중지 상태에서만 수정할 수 있습니다: {bot_id} "
+                f"(현재: {bot._status})"
+            )
+        updates = {k: v for k, v in kwargs.items() if v is not None}
+        if "name" in updates:
+            bot.config.bot_id = bot.config.bot_id  # keep bot_id
+            # Update the name returned by get_info
+            bot._name = updates["name"]
+        if "interval_seconds" in updates:
+            bot._interval_seconds = updates["interval_seconds"]
+        return bot
 
 
 class FakeBotBudget:
@@ -638,3 +660,72 @@ class TestGetBotStrategyName:
         bot = resp.json()["bot"]
         assert bot["strategy_name"] is None
         assert bot["strategy_author_name"] is None
+
+
+class TestUpdateBot:
+    """PUT /api/bots/{bot_id} 봇 설정 수정 테스트."""
+
+    def test_update_name(self, client, bot_manager):
+        """이름 변경."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.put("/api/bots/bot-1", json={"name": "새 이름"})
+        assert resp.status_code == 200
+        assert resp.json()["bot"]["name"] == "새 이름"
+
+    def test_update_interval_seconds(self, client, bot_manager):
+        """실행 간격 변경."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.put("/api/bots/bot-1", json={"interval_seconds": 120})
+        assert resp.status_code == 200
+        assert resp.json()["bot"]["interval_seconds"] == 120
+
+    def test_update_nonexistent_bot_returns_404(self, client):
+        """존재하지 않는 봇 수정 -> 404."""
+        resp = client.put("/api/bots/nonexistent", json={"name": "x"})
+        assert resp.status_code == 404
+
+    def test_update_running_bot_returns_409(self, client, bot_manager):
+        """실행 중인 봇 수정 -> 409."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="running")
+        resp = client.put("/api/bots/bot-1", json={"name": "x"})
+        assert resp.status_code == 409
+        assert "중지 상태" in resp.json()["detail"]
+
+    def test_update_created_bot_allowed(self, client, bot_manager):
+        """created 상태 봇 수정 허용."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="created")
+        resp = client.put("/api/bots/bot-1", json={"name": "updated"})
+        assert resp.status_code == 200
+
+    def test_update_error_bot_allowed(self, client, bot_manager):
+        """error 상태 봇 수정 허용."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="error")
+        resp = client.put("/api/bots/bot-1", json={"name": "fixed"})
+        assert resp.status_code == 200
+
+    def test_empty_body_returns_current(self, client, bot_manager):
+        """빈 body면 현재 상태 반환."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.put("/api/bots/bot-1", json={})
+        assert resp.status_code == 200
+        assert resp.json()["bot"]["bot_id"] == "bot-1"
+
+    def test_interval_below_min_returns_422(self, client, bot_manager):
+        """interval_seconds < 10 -> 422 (validation error)."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.put("/api/bots/bot-1", json={"interval_seconds": 5})
+        assert resp.status_code == 422
+
+    def test_interval_above_max_returns_422(self, client, bot_manager):
+        """interval_seconds > 3600 -> 422 (validation error)."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.put("/api/bots/bot-1", json={"interval_seconds": 7200})
+        assert resp.status_code == 422
+
+    def test_budget_zero_or_negative_returns_422(self, client, bot_manager):
+        """budget <= 0 -> 422 (validation error)."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.put("/api/bots/bot-1", json={"budget": 0})
+        assert resp.status_code == 422
+        resp = client.put("/api/bots/bot-1", json={"budget": -100})
+        assert resp.status_code == 422

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -97,7 +97,8 @@ class FakeBotManager:
         if bot:
             bot._status = "stopped"
 
-    async def delete_bot(self, bot_id: str) -> None:
+    async def delete_bot(self, bot_id: str, handle_positions: str = "keep") -> None:
+        self.last_delete_handle_positions = handle_positions
         if bot_id in self._bots:
             del self._bots[bot_id]
 
@@ -660,6 +661,94 @@ class TestGetBotStrategyName:
         bot = resp.json()["bot"]
         assert bot["strategy_name"] is None
         assert bot["strategy_author_name"] is None
+
+
+class TestDeleteBotHandlePositions:
+    """DELETE /api/bots/{id}?handle_positions 테스트."""
+
+    def test_delete_keep_default(self, client, bot_manager):
+        """기본값(keep)으로 봇 삭제."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.delete("/api/bots/bot-1")
+        assert resp.status_code == 204
+        assert bot_manager.last_delete_handle_positions == "keep"
+
+    def test_delete_keep_explicit(self, client, bot_manager):
+        """handle_positions=keep 명시적 전달."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.delete("/api/bots/bot-1?handle_positions=keep")
+        assert resp.status_code == 204
+        assert bot_manager.last_delete_handle_positions == "keep"
+
+    def test_delete_liquidate(self, client, bot_manager):
+        """handle_positions=liquidate로 봇 삭제."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.delete("/api/bots/bot-1?handle_positions=liquidate")
+        assert resp.status_code == 204
+        assert bot_manager.last_delete_handle_positions == "liquidate"
+
+    def test_delete_invalid_handle_positions(self, client, bot_manager):
+        """잘못된 handle_positions 값 -> 422."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.delete("/api/bots/bot-1?handle_positions=invalid")
+        assert resp.status_code == 422
+        assert "handle_positions" in resp.json()["detail"]
+
+    def test_delete_nonexistent_with_liquidate(self, client):
+        """존재하지 않는 봇에 liquidate -> 404."""
+        resp = client.delete("/api/bots/nonexistent?handle_positions=liquidate")
+        assert resp.status_code == 404
+
+
+class TestDeleteBotAuditLog:
+    """봇 삭제 감사 로그에 handle_positions 기록 테스트."""
+
+    @pytest.fixture
+    def audit_logs(self):
+        return []
+
+    @pytest.fixture
+    def fake_audit_logger(self, audit_logs):
+        class _FakeAuditLogger:
+            async def log(self, **kwargs):
+                audit_logs.append(kwargs)
+
+        return _FakeAuditLogger()
+
+    @pytest.fixture
+    def client_with_audit(
+        self, bot_manager, default_account_service, fake_audit_logger
+    ):
+        app = create_app(
+            bot_manager=bot_manager,
+            account_service=default_account_service,
+            audit_logger=fake_audit_logger,
+        )
+        return TestClient(app)
+
+    def test_audit_log_records_keep(self, client_with_audit, bot_manager, audit_logs):
+        """감사 로그에 handle_positions=keep 기록."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client_with_audit.delete("/api/bots/bot-1")
+        assert resp.status_code == 204
+        delete_logs = [
+            entry for entry in audit_logs if entry.get("action") == "bot.delete"
+        ]
+        assert len(delete_logs) == 1
+        assert delete_logs[0]["detail"] == "handle_positions=keep"
+
+    def test_audit_log_records_liquidate(
+        self, client_with_audit, bot_manager, audit_logs
+    ):
+        """감사 로그에 handle_positions=liquidate 기록."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client_with_audit.delete("/api/bots/bot-1?handle_positions=liquidate")
+        assert resp.status_code == 204
+        delete_logs = [
+            entry for entry in audit_logs if entry.get("action") == "bot.delete"
+        ]
+        assert len(delete_logs) == 1
+        assert delete_logs[0]["detail"] == "handle_positions=liquidate"
 
 
 class TestUpdateBot:

--- a/tests/unit/test_bot_delete_positions.py
+++ b/tests/unit/test_bot_delete_positions.py
@@ -1,0 +1,304 @@
+"""봇 삭제 시 handle_positions 옵션 테스트.
+
+Refs #796
+"""
+
+import asyncio
+
+import pytest
+
+from ante.bot import BotConfig, BotManager
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import OrderRequestEvent
+from ante.strategy import (
+    DataProvider,
+    OrderView,
+    PortfolioView,
+    Strategy,
+    StrategyContext,
+    StrategyMeta,
+)
+
+# -- Fake 구현체 --
+
+
+class FakeDataProvider(DataProvider):
+    async def get_ohlcv(self, symbol, timeframe="1d", limit=100):
+        return [{"close": 100.0}]
+
+    async def get_current_price(self, symbol):
+        return 100.0
+
+    async def get_indicator(self, symbol, indicator, params=None):
+        return {}
+
+
+class FakePortfolioView(PortfolioView):
+    def get_positions(self, bot_id):
+        return {}
+
+    def get_balance(self, bot_id):
+        return {"total": 1000000.0, "available": 500000.0}
+
+
+class FakeOrderView(OrderView):
+    def get_open_orders(self, bot_id):
+        return []
+
+
+class SimpleStrategy(Strategy):
+    meta = StrategyMeta(name="simple", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+
+
+class FakePositionSnapshot:
+    """테스트용 PositionSnapshot stub."""
+
+    def __init__(
+        self,
+        bot_id: str,
+        symbol: str,
+        quantity: float,
+        avg_entry_price: float = 0.0,
+        exchange: str = "KRX",
+    ) -> None:
+        self.bot_id = bot_id
+        self.symbol = symbol
+        self.quantity = quantity
+        self.avg_entry_price = avg_entry_price
+        self.exchange = exchange
+
+
+class FakeTradeService:
+    """테스트용 TradeService stub."""
+
+    def __init__(self) -> None:
+        self._positions: dict[str, list[FakePositionSnapshot]] = {}
+
+    async def get_positions(
+        self, bot_id: str, include_closed: bool = False
+    ) -> list[FakePositionSnapshot]:
+        return self._positions.get(bot_id, [])
+
+
+# -- Fixtures --
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+def ctx():
+    return StrategyContext(
+        bot_id="bot1",
+        data_provider=FakeDataProvider(),
+        portfolio=FakePortfolioView(),
+        order_view=FakeOrderView(),
+    )
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    try:
+        await asyncio.wait_for(database.close(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+@pytest.fixture
+def trade_service():
+    return FakeTradeService()
+
+
+@pytest.fixture
+async def manager(eventbus, db, trade_service):
+    m = BotManager(eventbus=eventbus, db=db, trade_service=trade_service)
+    await m.initialize()
+    yield m
+    for bot in list(m._bots.values()):
+        if bot._task and not bot._task.done():
+            bot._task.cancel()
+    try:
+        await asyncio.wait_for(m.stop_all(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+@pytest.fixture
+async def manager_no_trade(eventbus, db):
+    """TradeService 없는 BotManager."""
+    m = BotManager(eventbus=eventbus, db=db)
+    await m.initialize()
+    yield m
+    for bot in list(m._bots.values()):
+        if bot._task and not bot._task.done():
+            bot._task.cancel()
+    try:
+        await asyncio.wait_for(m.stop_all(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+# -- Tests --
+
+
+class TestDeleteBotHandlePositions:
+    """delete_bot handle_positions 파라미터 검증."""
+
+    async def test_keep_default_no_orders(self, manager, ctx, eventbus, trade_service):
+        """기본값(keep) 시 청산 주문이 발행되지 않는다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        trade_service._positions["bot1"] = [
+            FakePositionSnapshot("bot1", "005930", 50),
+        ]
+
+        published: list[OrderRequestEvent] = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: published.append(e))
+
+        await manager.delete_bot("bot1")
+
+        assert manager.get_bot("bot1") is None
+        assert len(published) == 0
+
+    async def test_liquidate_publishes_sell_orders(
+        self, manager, ctx, eventbus, trade_service
+    ):
+        """liquidate 시 보유 포지션에 대해 시장가 매도 주문을 발행한다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        trade_service._positions["bot1"] = [
+            FakePositionSnapshot("bot1", "005930", 50),
+            FakePositionSnapshot("bot1", "035420", 15),
+        ]
+
+        published: list[OrderRequestEvent] = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: published.append(e))
+
+        await manager.delete_bot("bot1", handle_positions="liquidate")
+
+        assert manager.get_bot("bot1") is None
+        assert len(published) == 2
+
+        # 주문 내용 검증
+        symbols = {e.symbol for e in published}
+        assert symbols == {"005930", "035420"}
+        for event in published:
+            assert event.side == "sell"
+            assert event.order_type == "market"
+            assert event.bot_id == "bot1"
+            assert event.account_id == "test"
+            assert event.strategy_id == "s1"
+
+        # 수량 검증
+        qty_map = {e.symbol: e.quantity for e in published}
+        assert qty_map["005930"] == 50
+        assert qty_map["035420"] == 15
+
+    async def test_liquidate_skips_zero_quantity(
+        self, manager, ctx, eventbus, trade_service
+    ):
+        """quantity=0 포지션은 청산 주문 대상에서 제외한다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        trade_service._positions["bot1"] = [
+            FakePositionSnapshot("bot1", "005930", 50),
+            FakePositionSnapshot("bot1", "035720", 0),  # 이미 청산됨
+        ]
+
+        published: list[OrderRequestEvent] = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: published.append(e))
+
+        await manager.delete_bot("bot1", handle_positions="liquidate")
+
+        assert len(published) == 1
+        assert published[0].symbol == "005930"
+
+    async def test_liquidate_no_positions(self, manager, ctx, eventbus, trade_service):
+        """보유 포지션 없으면 주문 없이 삭제된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        published: list[OrderRequestEvent] = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: published.append(e))
+
+        await manager.delete_bot("bot1", handle_positions="liquidate")
+
+        assert manager.get_bot("bot1") is None
+        assert len(published) == 0
+
+    async def test_liquidate_without_trade_service(
+        self, manager_no_trade, ctx, eventbus
+    ):
+        """TradeService 미설정 시에도 삭제는 정상 진행된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager_no_trade.create_bot(config, SimpleStrategy, ctx)
+
+        published: list[OrderRequestEvent] = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: published.append(e))
+
+        await manager_no_trade.delete_bot("bot1", handle_positions="liquidate")
+
+        assert manager_no_trade.get_bot("bot1") is None
+        assert len(published) == 0
+
+    async def test_invalid_handle_positions_raises(self, manager, ctx):
+        """잘못된 handle_positions 값은 BotError를 발생시킨다."""
+        from ante.bot.exceptions import BotError
+
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        with pytest.raises(BotError, match="handle_positions"):
+            await manager.delete_bot("bot1", handle_positions="invalid")
+
+        # 봇이 삭제되지 않았는지 확인
+        assert manager.get_bot("bot1") is not None
+
+    async def test_liquidate_order_includes_exchange(
+        self, manager, ctx, eventbus, trade_service
+    ):
+        """청산 주문에 포지션의 exchange가 포함된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        trade_service._positions["bot1"] = [
+            FakePositionSnapshot("bot1", "AAPL", 10, exchange="NASDAQ"),
+        ]
+
+        published: list[OrderRequestEvent] = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: published.append(e))
+
+        await manager.delete_bot("bot1", handle_positions="liquidate")
+
+        assert len(published) == 1
+        assert published[0].exchange == "NASDAQ"
+
+    async def test_liquidate_reason_includes_bot_id(
+        self, manager, ctx, eventbus, trade_service
+    ):
+        """청산 주문의 reason에 bot_id가 포함된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="test")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        trade_service._positions["bot1"] = [
+            FakePositionSnapshot("bot1", "005930", 50),
+        ]
+
+        published: list[OrderRequestEvent] = []
+        eventbus.subscribe(OrderRequestEvent, lambda e: published.append(e))
+
+        await manager.delete_bot("bot1", handle_positions="liquidate")
+
+        assert "bot1" in published[0].reason

--- a/tests/unit/test_bot_manager_methods.py
+++ b/tests/unit/test_bot_manager_methods.py
@@ -346,3 +346,116 @@ class TestStopBotSuppressNotification:
 
         assert len(stopped_events) == 1
         assert stopped_events[0].bot_id == "bot1"
+
+
+# ── update_bot ──────────────────────────────────
+
+
+class TestUpdateBot:
+    async def test_update_name(self, manager, ctx):
+        """중지 상태 봇의 이름 변경."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager.update_bot("bot1", name="new-name")
+
+        assert bot.config.name == "new-name"
+
+    async def test_update_interval(self, manager, ctx):
+        """실행 간격 변경."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=60)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager.update_bot("bot1", interval_seconds=120)
+
+        assert bot.config.interval_seconds == 120
+
+    async def test_update_multiple_fields(self, manager, ctx):
+        """여러 필드 동시 변경."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager.update_bot(
+            "bot1",
+            name="updated",
+            interval_seconds=300,
+            auto_restart=False,
+            max_restart_attempts=5,
+        )
+
+        assert bot.config.name == "updated"
+        assert bot.config.interval_seconds == 300
+        assert bot.config.auto_restart is False
+        assert bot.config.max_restart_attempts == 5
+
+    async def test_update_preserves_unchanged_fields(self, manager, ctx):
+        """변경하지 않은 필드는 기존 값 유지."""
+        config = BotConfig(
+            bot_id="bot1",
+            strategy_id="s1",
+            name="original",
+            interval_seconds=60,
+            auto_restart=True,
+        )
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        await manager.update_bot("bot1", name="updated")
+
+        bot = manager.get_bot("bot1")
+        assert bot.config.name == "updated"
+        assert bot.config.interval_seconds == 60
+        assert bot.config.auto_restart is True
+        assert bot.config.strategy_id == "s1"
+
+    async def test_update_running_raises(self, manager, ctx):
+        """running 상태에서 수정 시 예외."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        await manager.start_bot("bot1")
+
+        with pytest.raises(BotError, match="중지 상태"):
+            await manager.update_bot("bot1", name="x")
+
+    async def test_update_created_allowed(self, manager, ctx):
+        """created 상태에서 수정 허용."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        assert manager.get_bot("bot1").status == BotStatus.CREATED
+
+        bot = await manager.update_bot("bot1", name="updated")
+        assert bot.config.name == "updated"
+
+    async def test_update_error_allowed(self, manager, ctx):
+        """error 상태에서 수정 허용."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+        manager.get_bot("bot1").status = BotStatus.ERROR
+
+        bot = await manager.update_bot("bot1", name="fixed")
+        assert bot.config.name == "fixed"
+
+    async def test_update_saves_to_db(self, manager, ctx, db):
+        """수정 결과가 DB에 반영된다."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1", name="old")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        await manager.update_bot("bot1", name="new")
+
+        row = await db.fetch_one("SELECT config_json FROM bots WHERE bot_id = 'bot1'")
+        import json
+
+        saved = json.loads(row["config_json"])
+        assert saved["name"] == "new"
+
+    async def test_update_not_found_raises(self, manager):
+        """존재하지 않는 봇 수정 시 예외."""
+        with pytest.raises(BotError, match="not found"):
+            await manager.update_bot("nonexistent", name="x")
+
+    async def test_update_no_changes_returns_bot(self, manager, ctx):
+        """변경 사항 없으면 그대로 반환."""
+        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        bot = await manager.update_bot("bot1")
+        assert bot.config.bot_id == "bot1"

--- a/tests/unit/test_dataset_detail_api.py
+++ b/tests/unit/test_dataset_detail_api.py
@@ -1,0 +1,147 @@
+"""GET /api/data/datasets/{dataset_id} 데이터셋 상세 API 테스트."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import polars as pl
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.data.store import ParquetStore  # noqa: E402
+from ante.web.app import create_app  # noqa: E402
+
+
+def _make_ohlcv_df(n: int = 10) -> pl.DataFrame:
+    timestamps = pl.datetime_range(
+        datetime(2026, 3, 1, 9, 0),
+        datetime(2026, 3, 1, 9, n - 1),
+        interval="1m",
+        eager=True,
+        time_zone="UTC",
+    )
+    count = len(timestamps)
+    return pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "symbol": ["005930"] * count,
+            "open": [50000.0 + i for i in range(count)],
+            "high": [50100.0] * count,
+            "low": [49900.0] * count,
+            "close": [50050.0] * count,
+            "volume": [1000] * count,
+            "source": ["test"] * count,
+        }
+    )
+
+
+def _make_fundamental_df() -> pl.DataFrame:
+    from datetime import date
+
+    return pl.DataFrame(
+        {
+            "date": [date(2026, 3, 1), date(2026, 3, 2)],
+            "symbol": ["005930", "005930"],
+            "market_cap": [400_000_000_000, 401_000_000_000],
+            "per": [12.5, 12.6],
+            "pbr": [1.2, 1.3],
+            "source": ["test", "test"],
+        }
+    )
+
+
+@pytest.fixture
+def store(tmp_path):
+    return ParquetStore(base_path=tmp_path / "data")
+
+
+@pytest.fixture
+def client(store):
+    app = create_app(data_store=store)
+    return TestClient(app)
+
+
+class TestDatasetDetail:
+    """GET /api/data/datasets/{dataset_id} 상세 조회 테스트."""
+
+    async def test_basic_response_structure(self, client, store):
+        """응답이 dataset + preview 구조를 갖는다."""
+        store.write("005930", "1d", _make_ohlcv_df())
+        resp = client.get("/api/data/datasets/005930__1d")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "dataset" in body
+        assert "preview" in body
+
+    async def test_metadata_fields(self, client, store):
+        """메타데이터에 필수 필드가 모두 포함된다."""
+        store.write("005930", "1d", _make_ohlcv_df())
+        resp = client.get("/api/data/datasets/005930__1d")
+        ds = resp.json()["dataset"]
+        assert ds["id"] == "005930__1d"
+        assert ds["symbol"] == "005930"
+        assert ds["timeframe"] == "1d"
+        assert ds["data_type"] == "ohlcv"
+        assert ds["start_date"] is not None
+        assert ds["end_date"] is not None
+        assert isinstance(ds["row_count"], int)
+        assert ds["row_count"] > 0
+
+    async def test_preview_limit_5(self, client, store):
+        """미리보기는 최대 5행을 반환한다."""
+        store.write("005930", "1d", _make_ohlcv_df(n=10))
+        resp = client.get("/api/data/datasets/005930__1d")
+        preview = resp.json()["preview"]
+        assert len(preview) == 5
+
+    async def test_preview_less_than_5(self, client, store):
+        """데이터가 5행 미만이면 전체를 반환한다."""
+        store.write("005930", "1d", _make_ohlcv_df(n=3))
+        resp = client.get("/api/data/datasets/005930__1d")
+        preview = resp.json()["preview"]
+        assert len(preview) == 3
+
+    async def test_preview_contains_ohlcv_fields(self, client, store):
+        """미리보기 행에 OHLCV 필드가 포함된다."""
+        store.write("005930", "1d", _make_ohlcv_df())
+        resp = client.get("/api/data/datasets/005930__1d")
+        row = resp.json()["preview"][0]
+        for field in ("timestamp", "open", "high", "low", "close", "volume"):
+            assert field in row, f"missing field: {field}"
+
+    async def test_preview_serializes_datetime(self, client, store):
+        """datetime이 ISO 문자열로 직렬화된다."""
+        store.write("005930", "1d", _make_ohlcv_df())
+        resp = client.get("/api/data/datasets/005930__1d")
+        row = resp.json()["preview"][0]
+        assert isinstance(row["timestamp"], str)
+
+    def test_not_found(self, client):
+        """존재하지 않는 dataset_id는 404를 반환한다."""
+        resp = client.get("/api/data/datasets/999999__1d")
+        assert resp.status_code == 404
+
+    def test_invalid_id_format(self, client):
+        """잘못된 dataset_id 형식은 400을 반환한다."""
+        resp = client.get("/api/data/datasets/invalid_format")
+        assert resp.status_code == 400
+
+    def test_store_unavailable(self):
+        """store가 None이면 503을 반환한다."""
+        app = create_app(data_store=None)
+        c = TestClient(app)
+        resp = c.get("/api/data/datasets/005930__1d")
+        assert resp.status_code == 503
+
+    async def test_fundamental_dataset_detail(self, client, store):
+        """fundamental 데이터셋 상세 조회."""
+        store.write("005930", "", _make_fundamental_df(), data_type="fundamental")
+        resp = client.get("/api/data/datasets/005930__fundamental")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["dataset"]["data_type"] == "fundamental"
+        assert body["dataset"]["symbol"] == "005930"
+        assert len(body["preview"]) > 0

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -707,6 +707,65 @@ class TestStrategyRegistry:
 
         assert await registry.exists("momentum_v1.0.0")
 
+    async def test_register_with_rationale_risks(self, registry, meta, tmp_path):
+        """rationale, risks를 포함하여 등록한다 (#802)."""
+        filepath = tmp_path / "test.py"
+        filepath.write_text("")
+
+        record = await registry.register(
+            filepath,
+            meta,
+            rationale="모멘텀 팩터 기반 전략",
+            risks=["급락장 리스크", "유동성 리스크"],
+        )
+        assert record.rationale == "모멘텀 팩터 기반 전략"
+        assert record.risks == ["급락장 리스크", "유동성 리스크"]
+
+        # DB에서 다시 읽어도 동일
+        loaded = await registry.get("momentum_v1.0.0")
+        assert loaded is not None
+        assert loaded.rationale == "모멘텀 팩터 기반 전략"
+        assert loaded.risks == ["급락장 리스크", "유동성 리스크"]
+
+    async def test_register_without_rationale_risks(self, registry, meta, tmp_path):
+        """rationale, risks 미지정 시 기본값 (#802)."""
+        filepath = tmp_path / "test.py"
+        filepath.write_text("")
+
+        record = await registry.register(filepath, meta)
+        assert record.rationale == ""
+        assert record.risks == []
+
+    async def test_migrate_rationale_risks_columns(self, db, tmp_path):
+        """기존 테이블에 rationale, risks 컬럼이 없어도 마이그레이션으로 추가 (#802)."""
+        # rationale, risks 없는 구식 스키마 생성
+        await db.execute_script("""
+            CREATE TABLE IF NOT EXISTS strategies (
+                strategy_id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                version TEXT NOT NULL,
+                filepath TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'registered',
+                registered_at TEXT NOT NULL,
+                description TEXT DEFAULT '',
+                author TEXT DEFAULT 'agent',
+                validation_warnings TEXT DEFAULT '[]'
+            );
+        """)
+
+        registry = StrategyRegistry(db=db)
+        await registry.initialize()
+
+        # 마이그레이션 후 등록이 정상 동작
+        meta = StrategyMeta(name="test", version="1.0.0", description="test")
+        filepath = tmp_path / "test.py"
+        filepath.write_text("")
+        record = await registry.register(
+            filepath, meta, rationale="test rationale", risks=["risk1"]
+        )
+        assert record.rationale == "test rationale"
+        assert record.risks == ["risk1"]
+
 
 # ── Exchange 호환성 검증 테스트 ──────────────────────
 

--- a/tests/unit/test_strategy_api.py
+++ b/tests/unit/test_strategy_api.py
@@ -26,6 +26,8 @@ class FakeStrategyRecord:
     description: str = ""
     author: str = "agent"
     validation_warnings: list[str] = field(default_factory=list)
+    rationale: str = ""
+    risks: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -293,6 +295,93 @@ class TestGetStrategy:
         """존재하지 않는 전략 → 404."""
         resp = client.get("/api/strategies/nonexistent")
         assert resp.status_code == 404
+
+    def test_detail_includes_rationale_risks(self, client, registry):
+        """응답에 rationale, risks 포함 (#802)."""
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                rationale="모멘텀 기반 매매 전략",
+                risks=["급락장에서 큰 손실 가능", "거래량 부족 종목 슬리피지"],
+            ),
+        ]
+        resp = client.get("/api/strategies/s1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["rationale"] == "모멘텀 기반 매매 전략"
+        assert data["risks"] == ["급락장에서 큰 손실 가능", "거래량 부족 종목 슬리피지"]
+        # strategy 객체에도 포함
+        assert data["strategy"]["rationale"] == "모멘텀 기반 매매 전략"
+        assert data["strategy"]["risks"] == [
+            "급락장에서 큰 손실 가능",
+            "거래량 부족 종목 슬리피지",
+        ]
+
+    def test_detail_includes_params_defaults(self, client, registry):
+        """params, param_schema는 전략 로드 실패 시 빈 dict (#802)."""
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                filepath="/nonexistent/path.py",
+            ),
+        ]
+        resp = client.get("/api/strategies/s1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["params"] == {}
+        assert data["param_schema"] == {}
+
+    def test_detail_params_from_strategy_file(self, client, registry, tmp_path):
+        """전략 파일이 존재하면 params/param_schema를 런타임 추출 (#802)."""
+        code = """
+from ante.strategy.base import Strategy, StrategyMeta, Signal
+
+class TestStrat(Strategy):
+    meta = StrategyMeta(name="test", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+
+    def get_params(self):
+        return {"lookback": 20, "threshold": 0.05}
+
+    def get_param_schema(self):
+        return {"lookback": "되돌아볼 기간", "threshold": "매매 임계값"}
+"""
+        filepath = tmp_path / "test_strat.py"
+        filepath.write_text(code)
+
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                filepath=str(filepath),
+            ),
+        ]
+        resp = client.get("/api/strategies/s1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["params"] == {"lookback": 20, "threshold": 0.05}
+        assert data["param_schema"] == {
+            "lookback": "되돌아볼 기간",
+            "threshold": "매매 임계값",
+        }
+
+    def test_detail_rationale_risks_defaults(self, client, registry):
+        """rationale, risks 미설정 시 기본값 (#802)."""
+        registry._strategies = [
+            FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
+        ]
+        resp = client.get("/api/strategies/s1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["rationale"] == ""
+        assert data["risks"] == []
 
 
 class TestStrategyTrades:

--- a/tests/unit/test_strategy_api.py
+++ b/tests/unit/test_strategy_api.py
@@ -161,6 +161,99 @@ class TestListStrategies:
         assert data["bot_id"] == "bot-1"
         assert data["bot_status"] == "running"
 
+    def test_cumulative_return_null_without_db(self, client, registry):
+        """DB 없으면 cumulative_return은 null."""
+        registry._strategies = [
+            FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
+        ]
+        resp = client.get("/api/strategies")
+        assert resp.status_code == 200
+        data = resp.json()["strategies"][0]
+        assert data["cumulative_return"] is None
+
+    def test_cumulative_return_null_no_trades(self, registry):
+        """거래 없으면 cumulative_return은 null."""
+        from unittest.mock import AsyncMock
+
+        fake_db = AsyncMock()
+        fake_db.fetch_all = AsyncMock(return_value=[])
+
+        registry._strategies = [
+            FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
+        ]
+
+        app = create_app(strategy_registry=registry, db=fake_db)
+        c = TestClient(app)
+
+        resp = c.get("/api/strategies")
+        assert resp.status_code == 200
+        data = resp.json()["strategies"][0]
+        assert data["cumulative_return"] is None
+
+    def test_cumulative_return_with_trades(self, registry, bot_manager):
+        """거래가 있으면 cumulative_return에 net_pnl 값 반환."""
+        from unittest.mock import AsyncMock, patch
+
+        from ante.trade.models import PerformanceMetrics
+
+        fake_db = AsyncMock()
+        fake_metrics = PerformanceMetrics(
+            total_trades=5,
+            net_pnl=12345.0,
+        )
+
+        registry._strategies = [
+            FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
+        ]
+        bot_manager._bots = [
+            {
+                "bot_id": "bot-1",
+                "strategy_id": "s1",
+                "status": "running",
+                "account_id": "acc-1",
+            },
+        ]
+
+        app = create_app(
+            strategy_registry=registry,
+            bot_manager=bot_manager,
+            db=fake_db,
+        )
+        c = TestClient(app)
+
+        with patch(
+            "ante.trade.performance.PerformanceTracker.calculate",
+            new_callable=AsyncMock,
+            return_value=fake_metrics,
+        ):
+            resp = c.get("/api/strategies")
+        assert resp.status_code == 200
+        data = resp.json()["strategies"][0]
+        assert data["cumulative_return"] == 12345.0
+
+    def test_cumulative_return_db_error_graceful(self, registry):
+        """DB 에러 시 cumulative_return은 null (500 아님)."""
+        from unittest.mock import AsyncMock, patch
+
+        fake_db = AsyncMock()
+
+        registry._strategies = [
+            FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
+        ]
+
+        app = create_app(strategy_registry=registry, db=fake_db)
+        c = TestClient(app)
+
+        with patch(
+            "ante.trade.performance.PerformanceTracker.calculate",
+            new_callable=AsyncMock,
+            side_effect=Exception("DB error"),
+        ):
+            resp = c.get("/api/strategies")
+        assert resp.status_code == 200
+        data = resp.json()["strategies"][0]
+        assert data["cumulative_return"] is None
+
 
 class TestGetStrategy:
     def test_get_existing(self, client, registry):


### PR DESCRIPTION
Refs #790

하위 이슈: #792, #794, #795, #796, #798, #799, #800, #802

## Summary
- GET /api/bots에 strategy_name 추가
- GET /api/approvals에 search 파라미터 추가
- PUT /api/bots/{bot_id} 봇 설정 수정 API
- DELETE /api/bots/{id}에 handle_positions 옵션
- GET/PUT /api/accounts/{id}/rules 리스크 룰 API
- GET /api/data/datasets/{id} 데이터셋 상세
- GET /api/strategies에 cumulative_return 추가
- GET /api/strategies/{id}에 params, rationale, risks 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)