### PR TITLE
feat(frontend): 로그인 스펙 정합성 보완 (Phase 1) Refs #832

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -14,7 +14,8 @@ client.interceptors.response.use(
   (error) => {
     if (error.response?.status === 401) {
       if (window.location.pathname !== '/login') {
-        window.location.href = '/login'
+        const currentPath = window.location.pathname + window.location.search
+        window.location.href = `/login?redirect=${encodeURIComponent(currentPath)}`
       }
       return Promise.reject(error)
     }

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { login, logout, getMe } from '../api/auth'
 import type { LoginRequest } from '../types/auth'
 
@@ -15,12 +15,14 @@ export function useUser() {
 export function useLogin() {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
 
   return useMutation({
     mutationFn: (data: LoginRequest) => login(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['auth', 'me'] })
-      navigate('/', { replace: true })
+      const redirect = searchParams.get('redirect') || '/treasury'
+      navigate(redirect, { replace: true })
     },
   })
 }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -6,7 +6,7 @@ export default function Login() {
   const { data: user, isLoading } = useUser()
 
   if (!isLoading && user) {
-    return <Navigate to="/" replace />
+    return <Navigate to="/treasury" replace />
   }
 
   return (
@@ -18,7 +18,7 @@ export default function Login() {
           <img src="/logo-t.svg" alt="T" className="w-14 h-14" />
           <img src="/logo-e.svg" alt="E" className="w-14 h-14" />
         </div>
-        <div className="text-[13px] text-text-muted mb-8">AI-Native Trading Engine</div>
+        <div className="text-[13px] text-text-muted mb-8">Ante Up. Agents Do the Rest.</div>
         <LoginForm />
       </div>
     </div>


### PR DESCRIPTION
## Summary

- 로그인 유저스토리(L-1, L-3) 대비 미구현/불일치 5건 보완
- 로그인 성공 시 `redirect` 쿼리파라미터 지원 (`/treasury` 기본)
- 부제 텍스트를 스펙 일치로 변경 ("Ante Up. Agents Do the Rest.")
- Enter 키 폼 제출은 기존 `<form onSubmit>` + `<button type="submit">` 구조로 이미 구현되어 있음을 확인
- 401 인터셉터에서 현재 경로를 `/login?redirect=` 쿼리파라미터로 보존
- 이미 로그인 상태 시 `/treasury`로 리다이렉트 (기존 `/` → `/treasury`)

## Test plan

- [ ] 로그인 성공 시 `/treasury`로 정상 리다이렉트 확인
- [ ] `/login?redirect=/strategies` 접근 후 로그인 시 `/strategies`로 이동 확인
- [ ] 세션 만료(401) 시 현재 URL이 redirect 파라미터로 보존되는지 확인
- [ ] 재로그인 후 원래 페이지로 복귀 확인
- [ ] 이미 로그인 상태에서 `/login` 접근 시 `/treasury`로 리다이렉트 확인
- [ ] Enter 키로 폼 제출 동작 확인
- [ ] 부제 텍스트 "Ante Up. Agents Do the Rest." 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)