### PR TITLE
feat(frontend): 자금관리 Phase 2 — 가상 거래 배너 + 자산 추이 차트 + 예산 가드

### DIFF
--- a/frontend/src/api/treasury.ts
+++ b/frontend/src/api/treasury.ts
@@ -1,9 +1,18 @@
 import client from './client'
-import type { TreasurySummary, BotBudget, TreasuryTransaction } from '../types/treasury'
+import type { TreasurySummary, BotBudget, TreasuryTransaction, TreasurySnapshot } from '../types/treasury'
 
 export async function getTreasurySummary(): Promise<TreasurySummary> {
   const res = await client.get('/api/treasury')
   return res.data
+}
+
+export async function getTreasurySnapshots(params: {
+  account_id?: string
+  start_date?: string
+  end_date?: string
+}): Promise<TreasurySnapshot[]> {
+  const res = await client.get('/api/treasury/snapshots', { params })
+  return res.data.snapshots ?? []
 }
 
 export async function getBotBudgets(): Promise<BotBudget[]> {

--- a/frontend/src/components/charts/AssetTrendChart.tsx
+++ b/frontend/src/components/charts/AssetTrendChart.tsx
@@ -1,0 +1,86 @@
+import { useCallback } from 'react'
+import { AreaSeries, HistogramSeries, type IChartApi } from 'lightweight-charts'
+import LightweightChart from './LightweightChart'
+
+export interface SnapshotDataPoint {
+  snapshot_date: string
+  total_asset: number
+  daily_return: number
+}
+
+interface AssetTrendChartProps {
+  data: SnapshotDataPoint[]
+}
+
+export default function AssetTrendChart({ data }: AssetTrendChartProps) {
+  const handleChartReady = useCallback(
+    (chart: IChartApi) => {
+      // Area series (left axis) - total asset
+      const areaSeries = chart.addSeries(AreaSeries, {
+        lineColor: '#1E8EFF',
+        topColor: 'rgba(30, 142, 255, 0.28)',
+        bottomColor: 'rgba(30, 142, 255, 0.02)',
+        lineWidth: 2,
+        priceScaleId: 'left',
+        priceFormat: {
+          type: 'custom',
+          formatter: (price: number) => {
+            if (price >= 100_000_000) return `${(price / 100_000_000).toFixed(1)}억`
+            if (price >= 10_000) return `${(price / 10_000).toFixed(0)}만`
+            return price.toLocaleString()
+          },
+        },
+      })
+
+      // Histogram series (right axis) - daily return %
+      const histogramSeries = chart.addSeries(HistogramSeries, {
+        priceScaleId: 'right',
+        priceFormat: {
+          type: 'custom',
+          formatter: (price: number) => `${price.toFixed(2)}%`,
+        },
+      })
+
+      // Configure scales
+      chart.priceScale('left').applyOptions({
+        borderColor: '#2a2a35',
+        scaleMargins: { top: 0.1, bottom: 0.25 },
+      })
+      chart.priceScale('right').applyOptions({
+        borderColor: '#2a2a35',
+        scaleMargins: { top: 0.7, bottom: 0.05 },
+      })
+
+      // Set data
+      const areaData = data.map((d) => ({
+        time: d.snapshot_date,
+        value: d.total_asset,
+      }))
+
+      const histogramData = data.map((d) => {
+        const pct = d.daily_return * 100
+        return {
+          time: d.snapshot_date,
+          value: pct,
+          color: pct >= 0 ? 'rgba(30, 142, 255, 0.6)' : 'rgba(232, 88, 48, 0.6)',
+        }
+      })
+
+      areaSeries.setData(areaData as Parameters<typeof areaSeries.setData>[0])
+      histogramSeries.setData(histogramData as Parameters<typeof histogramSeries.setData>[0])
+
+      chart.timeScale().fitContent()
+    },
+    [data],
+  )
+
+  if (data.length === 0) {
+    return (
+      <div className="h-[240px] flex items-center justify-center text-[13px] text-text-muted">
+        스냅샷 데이터가 없습니다.
+      </div>
+    )
+  }
+
+  return <LightweightChart key={data.length} onChartReady={handleChartReady} className="h-[240px]" />
+}

--- a/frontend/src/components/charts/LightweightChart.tsx
+++ b/frontend/src/components/charts/LightweightChart.tsx
@@ -1,0 +1,61 @@
+import { useRef, useEffect } from 'react'
+import { createChart, type IChartApi, type DeepPartial, type ChartOptions } from 'lightweight-charts'
+
+interface LightweightChartProps {
+  options?: DeepPartial<ChartOptions>
+  onChartReady: (chart: IChartApi) => void
+  className?: string
+}
+
+export default function LightweightChart({ options, onChartReady, className }: LightweightChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const chartRef = useRef<IChartApi | null>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const chart = createChart(container, {
+      width: container.clientWidth,
+      height: container.clientHeight || 240,
+      layout: {
+        background: { color: 'transparent' },
+        textColor: '#8b8fa3',
+        fontSize: 11,
+      },
+      grid: {
+        vertLines: { color: 'rgba(42, 42, 53, 0.5)' },
+        horzLines: { color: 'rgba(42, 42, 53, 0.5)' },
+      },
+      crosshair: {
+        vertLine: { color: 'rgba(139, 143, 163, 0.3)' },
+        horzLine: { color: 'rgba(139, 143, 163, 0.3)' },
+      },
+      timeScale: {
+        borderColor: '#2a2a35',
+        timeVisible: false,
+      },
+      ...options,
+    })
+
+    chartRef.current = chart
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect
+        chart.applyOptions({ width, height })
+      }
+    })
+    resizeObserver.observe(container)
+
+    onChartReady(chart)
+
+    return () => {
+      resizeObserver.disconnect()
+      chart.remove()
+      chartRef.current = null
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return <div ref={containerRef} className={className} />
+}

--- a/frontend/src/components/common/VirtualModeBanner.tsx
+++ b/frontend/src/components/common/VirtualModeBanner.tsx
@@ -1,0 +1,14 @@
+interface VirtualModeBannerProps {
+  isVirtual: boolean
+}
+
+export default function VirtualModeBanner({ isVirtual }: VirtualModeBannerProps) {
+  if (!isVirtual) return null
+
+  return (
+    <div className="flex items-center gap-2 px-3.5 py-2.5 rounded-lg bg-info-bg border border-info/25 text-info text-[13px] mb-4">
+      <span className="text-[15px]">&#9432;</span>
+      <span>가상 거래 계좌입니다. 표시된 손익은 시뮬레이션 결과입니다.</span>
+    </div>
+  )
+}

--- a/frontend/src/components/treasury/AllocationForm.tsx
+++ b/frontend/src/components/treasury/AllocationForm.tsx
@@ -1,11 +1,18 @@
 import { useState } from 'react'
 import { useAllocateBudget, useDeallocateBudget } from '../../hooks/useTreasury'
+import { useBots } from '../../hooks/useBots'
+import { showToast } from '../common/Toast'
 import { formatKRW } from '../../utils/formatters'
+import { BOT_STATUS_LABELS } from '../../utils/constants'
 import type { BotBudget } from '../../types/treasury'
+import type { AxiosError } from 'axios'
 
 interface AllocationFormProps {
   budgets: BotBudget[]
 }
+
+/** Bot statuses that are considered "running" and block budget changes. */
+const RUNNING_STATUSES = new Set(['running', 'stopping'])
 
 export default function AllocationForm({ budgets }: AllocationFormProps) {
   const [botId, setBotId] = useState(budgets[0]?.bot_id ?? '')
@@ -13,17 +20,34 @@ export default function AllocationForm({ budgets }: AllocationFormProps) {
   const [showConfirm, setShowConfirm] = useState(false)
   const allocate = useAllocateBudget()
   const deallocate = useDeallocateBudget()
+  const { data: botsData } = useBots()
+
+  const bots = botsData?.items ?? []
+  const selectedBot = bots.find((b) => b.bot_id === botId)
+  const isBotRunning = selectedBot ? RUNNING_STATUSES.has(selectedBot.status) : false
 
   const selectedBudget = budgets.find((b) => b.bot_id === botId)
   const numAmount = Number(amount.replace(/,/g, ''))
 
+  const handleError = (error: unknown) => {
+    const axiosErr = error as AxiosError<{ detail?: string }>
+    if (axiosErr.response?.status === 409) {
+      showToast(axiosErr.response.data?.detail ?? '봇이 실행 중이므로 예산을 변경할 수 없습니다.', 'error')
+    }
+    setShowConfirm(false)
+  }
+
   const handleSubmit = () => {
     if (!selectedBudget || !numAmount) return
     const diff = numAmount - selectedBudget.allocated
+    const callbacks = {
+      onSuccess: () => { setAmount(''); setShowConfirm(false) },
+      onError: handleError,
+    }
     if (diff > 0) {
-      allocate.mutate({ botId, amount: diff }, { onSuccess: () => { setAmount(''); setShowConfirm(false) } })
+      allocate.mutate({ botId, amount: diff }, callbacks)
     } else if (diff < 0) {
-      deallocate.mutate({ botId, amount: Math.abs(diff) }, { onSuccess: () => { setAmount(''); setShowConfirm(false) } })
+      deallocate.mutate({ botId, amount: Math.abs(diff) }, callbacks)
     } else {
       setShowConfirm(false)
     }
@@ -45,9 +69,15 @@ export default function AllocationForm({ budgets }: AllocationFormProps) {
               onChange={(e) => setBotId(e.target.value)}
               className="w-full bg-bg border border-border rounded-lg px-3 py-2 text-text text-[14px] h-[38px]"
             >
-              {budgets.map((b) => (
-                <option key={b.bot_id} value={b.bot_id}>{b.bot_id}</option>
-              ))}
+              {budgets.map((b) => {
+                const bot = bots.find((bt) => bt.bot_id === b.bot_id)
+                const statusLabel = bot ? BOT_STATUS_LABELS[bot.status] ?? bot.status : ''
+                return (
+                  <option key={b.bot_id} value={b.bot_id}>
+                    {b.bot_id}{statusLabel ? ` (${statusLabel})` : ''}
+                  </option>
+                )
+              })}
             </select>
           </div>
 
@@ -69,9 +99,15 @@ export default function AllocationForm({ budgets }: AllocationFormProps) {
             />
           </div>
 
+          {isBotRunning && (
+            <div className="text-[12px] text-warning">
+              봇이 중지된 상태에서만 예산을 변경할 수 있습니다.
+            </div>
+          )}
+
           <button
             onClick={() => numAmount > 0 && botId && setShowConfirm(true)}
-            disabled={!botId || !numAmount}
+            disabled={!botId || !numAmount || isBotRunning}
             className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50"
           >
             예산 변경

--- a/frontend/src/components/treasury/AnteSummary.tsx
+++ b/frontend/src/components/treasury/AnteSummary.tsx
@@ -1,7 +1,8 @@
+import type { ReactNode } from 'react'
 import { formatKRW, formatPercent } from '../../utils/formatters'
 import type { TreasurySummary } from '../../types/treasury'
 
-export default function AnteSummary({ summary }: { summary: TreasurySummary }) {
+export default function AnteSummary({ summary, children }: { summary: TreasurySummary; children?: ReactNode }) {
   const anteProfitLoss = summary.ante_profit_loss ?? 0
   const antePurchaseAmount = summary.ante_purchase_amount ?? 0
   const anteEvalAmount = summary.ante_eval_amount ?? 0
@@ -76,6 +77,8 @@ export default function AnteSummary({ summary }: { summary: TreasurySummary }) {
           <div className="text-[22px] font-bold text-text-muted">{formatKRW(totalReserved)}</div>
         </div>
       </div>
+
+      {children}
     </div>
   )
 }

--- a/frontend/src/hooks/useTreasury.ts
+++ b/frontend/src/hooks/useTreasury.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getTreasurySummary, getBotBudgets, allocateBudget, deallocateBudget, getTreasuryTransactions } from '../api/treasury'
+import { getTreasurySummary, getBotBudgets, allocateBudget, deallocateBudget, getTreasuryTransactions, getTreasurySnapshots } from '../api/treasury'
 
 export function useTreasurySummary() {
   return useQuery({
@@ -32,6 +32,17 @@ export function useDeallocateBudget() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['treasury'] })
     },
+  })
+}
+
+export function useTreasurySnapshots(params: {
+  account_id?: string
+  start_date?: string
+  end_date?: string
+}) {
+  return useQuery({
+    queryKey: ['treasury', 'snapshots', params],
+    queryFn: () => getTreasurySnapshots(params),
   })
 }
 

--- a/frontend/src/pages/Treasury.tsx
+++ b/frontend/src/pages/Treasury.tsx
@@ -1,22 +1,101 @@
-import { useTreasurySummary, useBotBudgets } from '../hooks/useTreasury'
+import { useState, useMemo } from 'react'
+import { useTreasurySummary, useBotBudgets, useTreasurySnapshots } from '../hooks/useTreasury'
+import VirtualModeBanner from '../components/common/VirtualModeBanner'
 import AccountSummary from '../components/treasury/AccountSummary'
 import AnteSummary from '../components/treasury/AnteSummary'
 import BudgetPieChart from '../components/treasury/BudgetPieChart'
 import BudgetTable from '../components/treasury/BudgetTable'
 import AllocationForm from '../components/treasury/AllocationForm'
 import RecentTransactions from '../components/treasury/RecentTransactions'
+import AssetTrendChart from '../components/charts/AssetTrendChart'
+import { formatKRW, formatPercent } from '../utils/formatters'
 import { PageSkeleton } from '../components/common/Skeleton'
 
+type PeriodKey = '1w' | '1m' | '3m' | '1y' | 'all'
+
+const PERIODS: { key: PeriodKey; label: string; days: number | null }[] = [
+  { key: '1w', label: '1주', days: 7 },
+  { key: '1m', label: '1개월', days: 30 },
+  { key: '3m', label: '3개월', days: 90 },
+  { key: '1y', label: '1년', days: 365 },
+  { key: 'all', label: '전체', days: null },
+]
+
+function getDateRange(period: PeriodKey): { start_date?: string; end_date: string } {
+  const today = new Date()
+  const end_date = today.toISOString().slice(0, 10)
+  const selected = PERIODS.find((p) => p.key === period)
+  if (!selected || selected.days === null) {
+    return { end_date }
+  }
+  const start = new Date(today)
+  start.setDate(start.getDate() - selected.days)
+  return { start_date: start.toISOString().slice(0, 10), end_date }
+}
+
 export default function Treasury() {
+  const [period, setPeriod] = useState<PeriodKey>('1w')
   const { data: summary, isLoading: summaryLoading } = useTreasurySummary()
   const { data: budgets, isLoading: budgetsLoading } = useBotBudgets()
 
+  const dateRange = useMemo(() => getDateRange(period), [period])
+  const { data: snapshots } = useTreasurySnapshots(dateRange)
+
   if (summaryLoading || budgetsLoading) return <PageSkeleton />
+
+  const isVirtual = summary?.is_virtual === true
+
+  // Period summary calculations
+  const periodPnl = (snapshots ?? []).reduce((sum, s) => sum + s.daily_pnl, 0)
+  const periodReturn = (snapshots ?? []).reduce((acc, s) => acc * (1 + s.daily_return), 1) - 1
+  const periodPnlColor = periodPnl >= 0 ? 'text-positive' : 'text-negative'
+  const lastSnapshot = (snapshots ?? []).length > 0 ? (snapshots ?? [])[(snapshots ?? []).length - 1] : null
 
   return (
     <>
-      {summary && <AccountSummary summary={summary} />}
-      {summary && <AnteSummary summary={summary} />}
+      <VirtualModeBanner isVirtual={isVirtual} />
+
+      {!isVirtual && summary && <AccountSummary summary={summary} />}
+      {summary && (
+        <AnteSummary summary={summary}>
+          {/* T-2: Asset Trend Chart inside Ante card */}
+          <div className="border-t border-border px-5 pt-4">
+            <div className="flex items-center justify-between mb-3">
+              <div>
+                <div className="font-semibold mb-1">자산 추이</div>
+                <div className="text-[13px] text-text-muted">
+                  기간 손익 <span className={`font-semibold ${periodPnlColor}`}>{formatKRW(periodPnl)}</span>
+                  {' '}&middot;{' '}
+                  기간 수익률 <span className={`font-semibold ${periodPnlColor}`}>{formatPercent(periodReturn)}</span>
+                </div>
+              </div>
+              <div className="flex gap-1">
+                {PERIODS.map((p) => (
+                  <button
+                    key={p.key}
+                    onClick={() => setPeriod(p.key)}
+                    className={`px-3 py-1 rounded text-[12px] font-medium cursor-pointer border-none ${
+                      period === p.key
+                        ? 'bg-primary text-white'
+                        : 'bg-transparent text-text-muted hover:text-text'
+                    }`}
+                  >
+                    {p.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+          <div className="mx-5 mb-2">
+            <AssetTrendChart data={snapshots ?? []} />
+          </div>
+          {lastSnapshot && (
+            <div className="text-right text-[11px] text-text-muted px-5 pb-4">
+              산정 기준일 {lastSnapshot.snapshot_date}
+            </div>
+          )}
+        </AnteSummary>
+      )}
 
       <div className="grid grid-cols-[1fr_1fr] gap-6 mb-6">
         {/* 파이 차트 */}

--- a/frontend/src/types/treasury.ts
+++ b/frontend/src/types/treasury.ts
@@ -54,3 +54,21 @@ export interface BotBudget {
 }
 
 export type TransactionType = 'allocate' | 'deallocate' | 'fill' | 'bot_stopped_release'
+
+/** 일별 자산 스냅샷 -- 백엔드 SnapshotItem 대응 */
+export interface TreasurySnapshot {
+  account_id: string
+  snapshot_date: string
+  total_asset: number
+  ante_eval_amount: number
+  ante_purchase_amount: number
+  unallocated: number
+  account_balance: number
+  total_allocated: number
+  bot_count: number
+  daily_pnl: number
+  daily_return: number
+  net_trade_amount: number
+  unrealized_pnl: number
+  created_at: string
+}


### PR DESCRIPTION
## Summary

- **2-1 VirtualModeBanner**: `is_virtual === true`일 때 info 배너 표시 + AccountSummary 카드 숨김
- **2-2 AssetTrendChart**: Lightweight Charts v5 듀얼 축 차트 (좌축: total_asset Area, 우축: daily_return% Histogram) + 기간 선택(1주/1개월/3개월/1년/전체) + 기간 손익/수익률 계산 + 산정 기준일
- **2-3 예산 가드**: AllocationForm에서 useBots() 훅으로 봇 상태 조회, 실행 중 봇 선택 시 버튼 비활성화 + 안내 텍스트 + 409 응답 시 toast 에러 처리

### 신규 파일 (3건)
- `components/common/VirtualModeBanner.tsx`
- `components/charts/LightweightChart.tsx` (createChart + ResizeObserver + cleanup 래퍼)
- `components/charts/AssetTrendChart.tsx`

### 수정 파일 (6건)
- `api/treasury.ts` — `getTreasurySnapshots` 추가
- `hooks/useTreasury.ts` — `useTreasurySnapshots` 훅 추가
- `types/treasury.ts` — `TreasurySnapshot` 인터페이스 추가
- `pages/Treasury.tsx` — 배너/차트/기간 선택 통합
- `components/treasury/AnteSummary.tsx` — children prop 추가 (차트 삽입용)
- `components/treasury/AllocationForm.tsx` — 봇 상태 가드 + 409 에러 처리

Refs #833

## Test plan

- [ ] 가상 거래 모드에서 배너 표시 + AccountSummary 숨김 확인
- [ ] 실전 투자 모드에서 배너 미표시 + AccountSummary 표시 확인
- [ ] 차트 기간 버튼(1주/1개월/3개월/1년/전체) 클릭 시 API 호출 + 차트 갱신 확인
- [ ] 기간 손익/수익률이 선택 기간에 맞게 재계산되는지 확인
- [ ] 스냅샷 데이터 없을 때 빈 상태 메시지 표시 확인
- [ ] 실행 중 봇 선택 시 "예산 변경" 버튼 비활성화 + 안내 텍스트 확인
- [ ] 중지된 봇 선택 시 정상 예산 변경 가능 확인
- [ ] 409 응답 시 toast 에러 메시지 표시 확인
- [ ] `npm run build` 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)