### PR TITLE
feat(dashboard): 전략 목록 UI 보강 (Phase 4a) #836

### DIFF
--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -1,8 +1,8 @@
 import client from './client'
 import type { Strategy, StrategyDetail, StrategyPerformance, Trade, DailySummary, WeeklySummary, MonthlySummary } from '../types/strategy'
 
-export async function getStrategies(): Promise<Strategy[]> {
-  const res = await client.get('/api/strategies')
+export async function getStrategies(params?: { search?: string }): Promise<Strategy[]> {
+  const res = await client.get('/api/strategies', { params })
   return res.data.strategies ?? res.data
 }
 

--- a/frontend/src/components/strategies/PeriodPerformance.tsx
+++ b/frontend/src/components/strategies/PeriodPerformance.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { formatKRW, formatPercent } from '../../utils/formatters'
 import type { DailySummary, WeeklySummary, MonthlySummary } from '../../types/strategy'
 
@@ -28,7 +29,7 @@ export default function PeriodPerformance({ daily, weekly, monthly, strategyId }
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-[15px] font-semibold">기간별 성과</h3>
         {strategyId && (
-          <span className="text-[13px] text-primary cursor-pointer hover:underline">더 보기 &rarr;</span>
+          <Link to={`/strategies/${strategyId}/performance`} className="text-[13px] text-primary no-underline hover:underline">더 보기 &rarr;</Link>
         )}
       </div>
       <div className="flex gap-1 bg-bg rounded-lg p-0.5 w-fit mb-4">

--- a/frontend/src/hooks/useStrategies.ts
+++ b/frontend/src/hooks/useStrategies.ts
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
 import { getStrategies, getStrategyDetail, getStrategyPerformance, getStrategyTrades, getStrategyDailySummary, getStrategyWeeklySummary, getStrategyMonthlySummary, getStrategyTradesPaginated } from '../api/strategies'
 
-export function useStrategies() {
+export function useStrategies(params?: { search?: string }) {
   return useQuery({
-    queryKey: ['strategies'],
-    queryFn: getStrategies,
+    queryKey: ['strategies', params],
+    queryFn: () => getStrategies(params),
   })
 }
 

--- a/frontend/src/pages/Strategies.tsx
+++ b/frontend/src/pages/Strategies.tsx
@@ -10,14 +10,16 @@ const STATUS_FILTERS: { key: StrategyStatus | 'all'; label: string }[] = [
   { key: 'active', label: '운용중' },
   { key: 'registered', label: '대기' },
   { key: 'inactive', label: '중지' },
+  { key: 'archived', label: '보관' },
 ]
 
-const PAGE_SIZE = 5
+const PAGE_SIZE = 15
 
 export default function Strategies() {
   const [statusFilter, setStatusFilter] = useState<StrategyStatus | 'all'>('all')
+  const [search, setSearch] = useState('')
   const [offset, setOffset] = useState(0)
-  const { data: strategies, isLoading } = useStrategies()
+  const { data: strategies, isLoading } = useStrategies({ search })
 
   const filtered = (strategies ?? []).filter(
     (s) => statusFilter === 'all' || s.status === statusFilter,
@@ -30,24 +32,38 @@ export default function Strategies() {
     setOffset(0)
   }
 
+  const handleSearchChange = (value: string) => {
+    setSearch(value)
+    setOffset(0)
+  }
+
   return (
     <>
-      <div className="flex gap-1 bg-bg rounded-lg p-0.5 mb-4 w-fit">
-        {STATUS_FILTERS.map((f) => (
-          <button
-            key={f.key}
-            onClick={() => handleFilterChange(f.key)}
-            className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
-              statusFilter === f.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
-            }`}
-          >
-            {f.label}
-          </button>
-        ))}
+      <div className="flex items-center gap-3 mb-4">
+        <div className="flex gap-1 bg-bg rounded-lg p-0.5 w-fit">
+          {STATUS_FILTERS.map((f) => (
+            <button
+              key={f.key}
+              onClick={() => handleFilterChange(f.key)}
+              className={`px-3.5 py-1.5 rounded text-[12px] font-medium border-none cursor-pointer ${
+                statusFilter === f.key ? 'bg-surface text-text' : 'bg-transparent text-text-muted hover:text-text'
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => handleSearchChange(e.target.value)}
+          placeholder="전략명 검색"
+          className="px-3 py-1.5 rounded-lg border border-border bg-surface text-text text-[13px] outline-none placeholder:text-text-muted w-48 focus:border-primary"
+        />
       </div>
       <div className="bg-surface border border-border rounded-lg p-5">
         {isLoading ? (
-          <TableSkeleton rows={5} cols={6} />
+          <TableSkeleton rows={15} cols={6} />
         ) : (
           <>
             <StrategyTable items={paged} />


### PR DESCRIPTION
## Summary
- **4-2**: `PAGE_SIZE` 5 → 15로 교정 (S-1 동작 규칙 반영)
- **4-3**: 전략명 검색 input 추가, `useStrategies` 훅과 `getStrategies` API에 `search` 파라미터 전달
- **4-4**: STATUS_FILTERS에 `archived`(보관) 탭 추가
- **4-8**: PeriodPerformance의 "더 보기" `<span>`을 `<Link to={.../performance}>` 로 교체

## Test plan
- [ ] 전략 목록 페이지에서 15건까지 표시되는지 확인
- [ ] 검색 input에 키워드 입력 시 전략 목록이 필터링되는지 확인
- [ ] "보관" 탭 클릭 시 archived 상태 전략만 표시되는지 확인
- [ ] 전략 상세 > 기간별 성과 "더 보기" 클릭 시 성과 페이지로 이동하는지 확인
- [ ] `npm run build` 정상 통과 확인

Refs #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)