### PR TITLE
feat(frontend): 봇 관리 카드·UI 정리 (Phase 3a) Refs #834

### DIFF
--- a/frontend/src/components/bots/BotCard.tsx
+++ b/frontend/src/components/bots/BotCard.tsx
@@ -9,9 +9,6 @@ const STATUS_VARIANT: Record<BotStatus, string> = {
 
 interface BotCardProps {
   bot: Bot
-  onStart: (id: string) => void
-  onStop: (id: string) => void
-  onDelete: (id: string) => void
 }
 
 function BotIcon({ status }: { status: BotStatus }) {
@@ -54,7 +51,7 @@ function BotIcon({ status }: { status: BotStatus }) {
   )
 }
 
-export default function BotCard({ bot, onStart, onStop, onDelete }: BotCardProps) {
+export default function BotCard({ bot }: BotCardProps) {
   const navigate = useNavigate()
 
   return (
@@ -68,31 +65,16 @@ export default function BotCard({ bot, onStart, onStop, onDelete }: BotCardProps
         <div className="text-[13px] text-text-muted mb-3">
           <a onClick={() => navigate(`/bots/${bot.bot_id}`)} className="hover:text-primary cursor-pointer">{bot.bot_id}</a>
         </div>
-        <div className="flex flex-col gap-1.5 text-[13px] text-text-muted mb-4">
+        <div className="flex flex-col gap-1.5 text-[13px] text-text-muted">
           <div className="flex justify-between">
             <span>전략</span>
             <span>{bot.strategy_name ? <a onClick={() => navigate(`/strategies/${bot.strategy_name}`)} className="text-primary hover:underline cursor-pointer">{bot.strategy_name}</a> : '-'}</span>
-          </div>
-          <div className="flex justify-between">
-            <span>모드</span>
-            <StatusBadge variant={bot.mode === 'live' ? 'primary' : 'warning'}>{bot.mode === 'live' ? '실전' : '모의'}</StatusBadge>
           </div>
           {bot.interval_seconds != null && (
             <div className="flex justify-between">
               <span>실행 간격</span>
               <span>{bot.interval_seconds}초</span>
             </div>
-          )}
-        </div>
-        <div className="flex gap-2 justify-end">
-          {(bot.status === 'stopped' || bot.status === 'created' || bot.status === 'error') && (
-            <>
-              <button onClick={() => onStart(bot.bot_id)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">시작</button>
-              <button onClick={() => onDelete(bot.bot_id)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-negative border-none cursor-pointer hover:underline">삭제</button>
-            </>
-          )}
-          {bot.status === 'running' && (
-            <button onClick={() => onStop(bot.bot_id)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-negative border border-negative cursor-pointer hover:bg-negative-bg">중지</button>
           )}
         </div>
       </div>

--- a/frontend/src/components/bots/BotCreateForm.tsx
+++ b/frontend/src/components/bots/BotCreateForm.tsx
@@ -3,7 +3,6 @@ import { useCreateBot } from '../../hooks/useBots'
 import { useStrategies } from '../../hooks/useStrategies'
 import { useTreasurySummary } from '../../hooks/useTreasury'
 import { formatNumber } from '../../utils/formatters'
-import type { BotMode } from '../../types/bot'
 
 interface BotCreateFormProps {
   onClose: () => void
@@ -15,7 +14,6 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
   const [botId, setBotId] = useState('')
   const [name, setName] = useState('')
   const [strategyName, setStrategyName] = useState('')
-  const [mode, setMode] = useState<BotMode>('paper')
   const [interval, setInterval] = useState('60')
   const [budget, setBudget] = useState('')
   const [botIdError, setBotIdError] = useState('')
@@ -47,7 +45,6 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
         bot_id: botId,
         name,
         strategy_name: strategyName,
-        mode,
         interval_seconds: Number(interval),
         budget: Number(budget.replace(/,/g, '')),
         symbols: [],
@@ -83,13 +80,6 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
                 <option key={s.id} value={s.name}>{s.name} {s.version}</option>
               ))}
             </select>
-          </div>
-          <div className="mb-4">
-            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">봇 유형</label>
-            <div className="inline-flex rounded-lg border border-border overflow-hidden">
-              <button type="button" onClick={() => setMode('paper')} className={`px-4 py-2 text-[13px] font-medium border-none cursor-pointer ${mode === 'paper' ? 'bg-primary text-white' : 'bg-transparent text-text-muted hover:bg-surface-hover'}`}>모의투자</button>
-              <button type="button" onClick={() => setMode('live')} className={`px-4 py-2 text-[13px] font-medium border-none cursor-pointer ${mode === 'live' ? 'bg-primary text-white' : 'bg-transparent text-text-muted hover:bg-surface-hover'}`}>실전투자</button>
-            </div>
           </div>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">실행 간격 (초)</label>

--- a/frontend/src/components/bots/BotDeleteModal.tsx
+++ b/frontend/src/components/bots/BotDeleteModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import type { Bot } from '../../types/bot'
 
-export type DeleteOption = 'force_liquidate' | 'manual_liquidate'
+export type DeleteOption = 'force_liquidate' | 'keep'
 
 interface BotDeleteModalProps {
   bot: Bot & {
@@ -15,7 +15,7 @@ interface BotDeleteModalProps {
 export default function BotDeleteModal({ bot, onConfirm, onClose, isPending }: BotDeleteModalProps) {
   const positions = bot.positions?.filter((p) => p.quantity > 0) ?? []
   const hasPositions = positions.length > 0
-  const [deleteOption, setDeleteOption] = useState<DeleteOption>('manual_liquidate')
+  const [deleteOption, setDeleteOption] = useState<DeleteOption>('keep')
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]" onClick={onClose}>
@@ -25,8 +25,14 @@ export default function BotDeleteModal({ bot, onConfirm, onClose, isPending }: B
         <div className="text-[13px] text-text-muted mb-4">
           {hasPositions
             ? '보유 종목이 있습니다. 삭제 전 포지션 처리 방법을 선택해주세요.'
-            : <>Bot을 삭제하면 더 이상 실행할 수 없습니다.<br />거래 이력과 성과 기록은 보존됩니다.</>
+            : 'Bot을 삭제하면 더 이상 실행할 수 없습니다.'
           }
+        </div>
+
+        {/* 거래 이력 보존 안내 */}
+        <div className="flex items-center gap-2 px-3.5 py-2.5 rounded-lg bg-info-bg border border-info/25 text-info text-[13px] mb-4">
+          <span className="text-[15px]">&#9432;</span>
+          <span>거래 이력과 성과 기록은 보존됩니다.</span>
         </div>
 
         {/* Bot 정보 */}
@@ -64,13 +70,13 @@ export default function BotDeleteModal({ bot, onConfirm, onClose, isPending }: B
               <input
                 type="radio"
                 name="deleteOption"
-                checked={deleteOption === 'manual_liquidate'}
-                onChange={() => setDeleteOption('manual_liquidate')}
+                checked={deleteOption === 'keep'}
+                onChange={() => setDeleteOption('keep')}
                 className="mt-0.5"
               />
               <div>
-                <div className="text-[13px] font-medium">직접 청산</div>
-                <div className="text-[12px] text-text-muted">보유 종목을 먼저 청산한 후 삭제할 수 있습니다</div>
+                <div className="text-[13px] font-medium">포지션 유지 후 삭제</div>
+                <div className="text-[12px] text-text-muted">보유 종목을 유지한 채 Bot만 삭제합니다. 포지션은 운영자가 직접 관리해야 합니다.</div>
               </div>
             </label>
           </div>

--- a/frontend/src/pages/BotDetail.tsx
+++ b/frontend/src/pages/BotDetail.tsx
@@ -8,7 +8,7 @@ import { PageSkeleton } from '../components/common/Skeleton'
 import BotStopModal from '../components/bots/BotStopModal'
 import { formatKRW, formatDateTime, formatPercent } from '../utils/formatters'
 import { BOT_STATUS_LABELS } from '../utils/constants'
-import type { BotStatus, BotMode, BotDetail as BotDetailType } from '../types/bot'
+import type { BotStatus, BotDetail as BotDetailType, BotLogResult } from '../types/bot'
 
 const STATUS_VARIANT: Record<BotStatus, string> = {
   created: 'muted', running: 'positive', stopping: 'warning', stopped: 'warning', error: 'negative', deleted: 'muted',
@@ -86,12 +86,6 @@ export default function BotDetail() {
         <div className="bg-surface border border-border rounded-lg p-5">
           <h3 className="text-[15px] font-semibold mb-3">실행 설정</h3>
           <div className="space-y-2">
-            <div className="flex justify-between py-1.5 text-[13px]">
-              <span className="text-text-muted">모드</span>
-              <StatusBadge variant={bot.mode === 'live' ? 'primary' : 'warning'}>
-                {bot.mode === 'live' ? '실전' : '모의'}
-              </StatusBadge>
-            </div>
             <div className="flex justify-between py-1.5 text-[13px]">
               <span className="text-text-muted">상태</span>
               <StatusBadge variant={STATUS_VARIANT[bot.status] as 'positive'}>
@@ -197,15 +191,18 @@ export default function BotDetail() {
           <div className="py-4 text-text-muted text-[13px] text-center">로그가 없습니다</div>
         ) : (
           <div className="space-y-0">
-            {bot.logs.slice(0, 10).map((log, i) => (
-              <div key={i} className="flex gap-3 py-2 border-b border-border text-[13px]">
-                <span className="text-text-muted font-mono text-[12px] whitespace-nowrap">{formatDateTime(log.timestamp)}</span>
-                <StatusBadge variant={log.success ? 'positive' : 'negative'}>
-                  {log.success ? '성공' : '실패'}
-                </StatusBadge>
-                {log.message && <span className={log.success ? '' : 'text-negative'}>{log.message}</span>}
-              </div>
-            ))}
+            {bot.logs.slice(0, 10).map((log, i) => {
+              const result: BotLogResult = log.result ?? (log.success ? 'success' : 'failure')
+              const variant = result === 'success' ? 'positive' : result === 'stopped' ? 'warning' : 'negative'
+              const label = result === 'success' ? '성공' : result === 'stopped' ? '중지' : '실패'
+              return (
+                <div key={i} className="flex gap-3 py-2 border-b border-border text-[13px]">
+                  <span className="text-text-muted font-mono text-[12px] whitespace-nowrap">{formatDateTime(log.timestamp)}</span>
+                  <StatusBadge variant={variant}>{label}</StatusBadge>
+                  {log.message && <span className={result === 'failure' ? 'text-negative' : ''}>{log.message}</span>}
+                </div>
+              )
+            })}
           </div>
         )}
       </div>
@@ -233,7 +230,6 @@ function BotEditModal({ bot, onClose }: { bot: BotDetailType; onClose: () => voi
   const { data: treasury } = useTreasurySummary()
   const [name, setName] = useState(bot.name || '')
   const [strategyName, setStrategyName] = useState(bot.strategy_name || '')
-  const [mode, setMode] = useState<BotMode>(bot.mode)
   const [intervalSeconds, setIntervalSeconds] = useState(bot.interval_seconds)
   const [budget, setBudget] = useState(bot.allocated_budget)
 
@@ -280,35 +276,6 @@ function BotEditModal({ bot, onClose }: { bot: BotDetailType; onClose: () => voi
                 <option key={s.id} value={s.name}>{s.name}</option>
               ))}
             </select>
-          </div>
-
-          {/* Bot 유형 */}
-          <div>
-            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">Bot 유형</label>
-            <div className="inline-flex rounded-lg border border-border overflow-hidden">
-              <button
-                type="button"
-                onClick={() => setMode('paper')}
-                className={`px-4 py-2 text-[13px] font-medium border-none cursor-pointer ${
-                  mode === 'paper'
-                    ? 'bg-primary text-white'
-                    : 'bg-transparent text-text-muted hover:bg-surface-hover'
-                }`}
-              >
-                모의투자
-              </button>
-              <button
-                type="button"
-                onClick={() => setMode('live')}
-                className={`px-4 py-2 text-[13px] font-medium border-none cursor-pointer ${
-                  mode === 'live'
-                    ? 'bg-primary text-white'
-                    : 'bg-transparent text-text-muted hover:bg-surface-hover'
-                }`}
-              >
-                실전투자
-              </button>
-            </div>
           </div>
 
           {/* 실행 간격 */}

--- a/frontend/src/pages/Bots.tsx
+++ b/frontend/src/pages/Bots.tsx
@@ -1,44 +1,29 @@
 import { useState } from 'react'
-import { useBots, useBotControl } from '../hooks/useBots'
+import { useBots } from '../hooks/useBots'
 import BotCard from '../components/bots/BotCard'
 import BotCreateForm from '../components/bots/BotCreateForm'
-import BotStopModal from '../components/bots/BotStopModal'
-import BotDeleteModal from '../components/bots/BotDeleteModal'
+import VirtualModeBanner from '../components/common/VirtualModeBanner'
 import { TableSkeleton } from '../components/common/Skeleton'
-import type { Bot } from '../types/bot'
+import type { BotStatus } from '../types/bot'
+
+const STATUS_ORDER: Record<BotStatus, number> = {
+  running: 0,
+  stopped: 1,
+  error: 2,
+  created: 3,
+  stopping: 4,
+  deleted: 5,
+}
 
 export default function Bots() {
   const [showCreate, setShowCreate] = useState(false)
-  const [stopTarget, setStopTarget] = useState<Bot | null>(null)
-  const [deleteTarget, setDeleteTarget] = useState<Bot | null>(null)
   const { data, isLoading } = useBots()
-  const { start, stop, remove } = useBotControl()
 
-  const allBots = data?.items ?? []
-  const runningBots = allBots.filter((b) => b.status === 'running')
-  const inactiveBots = allBots.filter((b) => b.status !== 'running' && b.status !== 'deleted')
+  const allBots = [...(data?.items ?? [])]
+    .filter((b) => b.status !== 'deleted')
+    .sort((a, b) => (STATUS_ORDER[a.status] ?? 99) - (STATUS_ORDER[b.status] ?? 99))
 
-  const handleStopClick = (id: string) => {
-    const bot = allBots.find((b) => b.bot_id === id)
-    if (bot) setStopTarget(bot)
-  }
-
-  const handleDeleteClick = (id: string) => {
-    const bot = allBots.find((b) => b.bot_id === id)
-    if (bot) setDeleteTarget(bot)
-  }
-
-  const handleStopConfirm = () => {
-    if (stopTarget) {
-      stop.mutate(stopTarget.bot_id, { onSuccess: () => setStopTarget(null) })
-    }
-  }
-
-  const handleDeleteConfirm = () => {
-    if (deleteTarget) {
-      remove.mutate(deleteTarget.bot_id, { onSuccess: () => setDeleteTarget(null) })
-    }
-  }
+  const isVirtual = allBots.length > 0 && allBots.every((b) => b.mode === 'paper')
 
   return (
     <>
@@ -46,11 +31,12 @@ export default function Bots() {
         <TableSkeleton rows={3} cols={3} />
       ) : (
         <>
-          {/* 실행 중 섹션 */}
+          <VirtualModeBanner isVirtual={isVirtual} />
+
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-2 text-[15px] font-semibold text-text-muted">
-              실행 중
-              <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded-full">{runningBots.length}</span>
+              봇 관리
+              <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded-full">{allBots.length}</span>
             </div>
             <button
               onClick={() => setShowCreate(true)}
@@ -61,32 +47,12 @@ export default function Bots() {
           </div>
 
           <div className="mb-8">
-            {runningBots.length === 0 ? (
-              <div className="text-[13px] text-text-muted py-8 text-center">실행 중인 봇이 없습니다</div>
+            {allBots.length === 0 ? (
+              <div className="text-[13px] text-text-muted py-8 text-center">등록된 봇이 없습니다</div>
             ) : (
               <div className="grid grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4">
-                {runningBots.map((bot) => (
-                  <BotCard key={bot.bot_id} bot={bot} onStart={(id) => start.mutate(id)} onStop={handleStopClick} onDelete={handleDeleteClick} />
-                ))}
-              </div>
-            )}
-          </div>
-
-          {/* 비활성 섹션 */}
-          <div className="mb-4">
-            <div className="flex items-center gap-2 text-[15px] font-semibold text-text-muted">
-              비활성
-              <span className="bg-border text-text text-[12px] font-medium px-2 py-0.5 rounded-full">{inactiveBots.length}</span>
-            </div>
-          </div>
-
-          <div className="mb-8">
-            {inactiveBots.length === 0 ? (
-              <div className="text-[13px] text-text-muted py-8 text-center">비활성 봇이 없습니다</div>
-            ) : (
-              <div className="grid grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4">
-                {inactiveBots.map((bot) => (
-                  <BotCard key={bot.bot_id} bot={bot} onStart={(id) => start.mutate(id)} onStop={handleStopClick} onDelete={handleDeleteClick} />
+                {allBots.map((bot) => (
+                  <BotCard key={bot.bot_id} bot={bot} />
                 ))}
               </div>
             )}
@@ -95,24 +61,6 @@ export default function Bots() {
       )}
 
       {showCreate && <BotCreateForm onClose={() => setShowCreate(false)} />}
-
-      {stopTarget && (
-        <BotStopModal
-          bot={stopTarget}
-          onConfirm={handleStopConfirm}
-          onClose={() => setStopTarget(null)}
-          isPending={stop.isPending}
-        />
-      )}
-
-      {deleteTarget && (
-        <BotDeleteModal
-          bot={deleteTarget}
-          onConfirm={handleDeleteConfirm}
-          onClose={() => setDeleteTarget(null)}
-          isPending={remove.isPending}
-        />
-      )}
     </>
   )
 }

--- a/frontend/src/types/bot.ts
+++ b/frontend/src/types/bot.ts
@@ -51,9 +51,12 @@ export interface BotDetail extends Bot {
   positions?: BotPosition[]
 }
 
+export type BotLogResult = 'success' | 'failure' | 'stopped'
+
 export interface BotLog {
   timestamp: string
   success: boolean
+  result?: BotLogResult
   message?: string
 }
 
@@ -61,7 +64,6 @@ export interface BotCreateRequest {
   bot_id: string
   name: string
   strategy_name: string
-  mode: BotMode
   interval_seconds: number
   budget: number
   symbols: string[]


### PR DESCRIPTION
## Summary

- BotCard에서 액션 버튼(시작/중지/삭제) JSX 제거 -- 상세 페이지에서만 수행
- BotCard에서 mode 뱃지(실전/모의) JSX 제거
- 봇 목록 정렬을 단일 배열 + `statusOrder` 맵 기반으로 변경 (running=0 > stopped=1 > error=2)
- 가상 거래 배너 `VirtualModeBanner` 재사용
- 실행 로그에 `result === 'stopped'` 시 StatusBadge `variant="warning"` 뱃지 추가
- 봇 생성/수정 폼에서 mode 관련 JSX, state, request 필드 삭제
- BotDeleteModal 삭제 옵션 레이블 교정: `'keep'` -> "포지션 유지 후 삭제" + 설명 텍스트
- BotDeleteModal에 info 배너 "거래 이력과 성과 기록은 보존됩니다" 추가

## Test plan

- [ ] 봇 목록 페이지에서 카드에 액션 버튼, mode 뱃지가 없는 것 확인
- [ ] 봇 목록이 running > stopped > error 순으로 정렬되는 것 확인
- [ ] 가상 거래 모드에서 배너가 표시되는 것 확인
- [ ] 봇 상세 > 실행 로그에서 stopped 결과가 warning 뱃지로 표시되는 것 확인
- [ ] 봇 생성 폼에서 mode 선택 UI가 없는 것 확인
- [ ] 봇 삭제 모달에서 "포지션 유지 후 삭제" 레이블과 info 배너 확인
- [ ] `npm run build` 정상 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)