### PR TITLE
feat(dashboard): 결재함·에이전트·백테스트·리포트 보완 (Phase 5) Refs #838

### DIFF
--- a/frontend/src/api/members.ts
+++ b/frontend/src/api/members.ts
@@ -44,3 +44,7 @@ export async function changePassword(id: string, oldPassword: string, newPasswor
 export async function updateScopes(id: string, scopes: string[]): Promise<void> {
   await client.put(`/api/members/${id}/scopes`, { scopes })
 }
+
+export async function updateMemberInfo(id: string, data: { name: string; org: string }): Promise<void> {
+  await client.patch(`/api/members/${id}`, data)
+}

--- a/frontend/src/components/agents/AgentEditModal.tsx
+++ b/frontend/src/components/agents/AgentEditModal.tsx
@@ -1,0 +1,101 @@
+import { useState, useEffect } from 'react'
+import Modal from '../common/Modal'
+import { ALL_SCOPES, type MemberDetail } from '../../types/member'
+
+interface AgentEditModalProps {
+  open: boolean
+  member: MemberDetail
+  onClose: () => void
+  onSave: (data: { name: string; org: string; scopes: string[] }) => void
+  isPending?: boolean
+}
+
+export default function AgentEditModal({ open, member, onClose, onSave, isPending }: AgentEditModalProps) {
+  const [name, setName] = useState(member.name)
+  const [org, setOrg] = useState(member.org)
+  const [scopes, setScopes] = useState<string[]>([...member.scopes])
+
+  useEffect(() => {
+    if (open) {
+      setName(member.name)
+      setOrg(member.org)
+      setScopes([...member.scopes])
+    }
+  }, [open, member])
+
+  const toggleScope = (scope: string) => {
+    setScopes((prev) =>
+      prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope],
+    )
+  }
+
+  const handleSave = () => {
+    onSave({ name: name.trim(), org: org.trim(), scopes })
+  }
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <div className="text-[16px] font-semibold mb-5">정보 수정</div>
+
+      <div className="mb-4">
+        <label className="block text-[12px] font-semibold text-text-muted mb-1.5">Agent ID</label>
+        <div className="w-full bg-bg border border-border rounded-lg px-3 py-2 text-text text-[13px] font-mono opacity-60">
+          {member.member_id}
+        </div>
+      </div>
+
+      <div className="mb-4">
+        <label className="block text-[12px] font-semibold text-text-muted mb-1.5">이름</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full bg-bg border border-border rounded-lg px-3 py-2 text-text text-[13px] focus:outline-none focus:border-primary"
+        />
+      </div>
+
+      <div className="mb-4">
+        <label className="block text-[12px] font-semibold text-text-muted mb-1.5">소속 (org)</label>
+        <input
+          type="text"
+          value={org}
+          onChange={(e) => setOrg(e.target.value)}
+          className="w-full bg-bg border border-border rounded-lg px-3 py-2 text-text text-[13px] focus:outline-none focus:border-primary"
+        />
+      </div>
+
+      <div className="mb-5">
+        <label className="block text-[12px] font-semibold text-text-muted mb-2">권한 범위 (Scopes)</label>
+        <div className="grid grid-cols-2 gap-2">
+          {ALL_SCOPES.map((scope) => (
+            <label key={scope} className="flex items-center gap-2 text-[13px] cursor-pointer">
+              <input
+                type="checkbox"
+                checked={scopes.includes(scope)}
+                onChange={() => toggleScope(scope)}
+                className="accent-primary"
+              />
+              <span className="font-mono text-[12px]">{scope}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 pt-4 border-t border-border">
+        <button
+          onClick={onClose}
+          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover"
+        >
+          취소
+        </button>
+        <button
+          onClick={handleSave}
+          disabled={isPending || !name.trim()}
+          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50"
+        >
+          저장
+        </button>
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/src/components/approvals/ApprovalFilters.tsx
+++ b/frontend/src/components/approvals/ApprovalFilters.tsx
@@ -10,9 +10,13 @@ const STATUS_OPTIONS: { key: ApprovalStatus | 'all'; label: string }[] = [
 const TYPE_OPTIONS: { key: ApprovalType | 'all'; label: string }[] = [
   { key: 'all', label: '전체 유형' },
   { key: 'strategy_adopt', label: '전략 채택' },
+  { key: 'strategy_report', label: '전략 리포트' },
   { key: 'budget_change', label: '예산 변경' },
+  { key: 'budget_allocate', label: '예산 할당' },
   { key: 'bot_create', label: '봇 생성' },
   { key: 'bot_stop', label: '봇 중지' },
+  { key: 'live_switch', label: '실전 전환' },
+  { key: 'risk_alert', label: '위험 알림' },
   { key: 'rule_change', label: '규칙 변경' },
 ]
 

--- a/frontend/src/components/approvals/ReviewControls.tsx
+++ b/frontend/src/components/approvals/ReviewControls.tsx
@@ -65,6 +65,7 @@ function ApproveModalSummary({ type, params }: { type?: ApprovalType; params?: R
 export default function ReviewControls({ approvalId, isPending, title, reviews, type, params }: ReviewControlsProps) {
   const [showApprove, setShowApprove] = useState(false)
   const [showReject, setShowReject] = useState(false)
+  const [approveMemo, setApproveMemo] = useState('')
   const [rejectReason, setRejectReason] = useState('')
   const updateStatus = useUpdateApprovalStatus()
 
@@ -73,8 +74,8 @@ export default function ReviewControls({ approvalId, isPending, title, reviews, 
   const hasWarnings = reviews?.some((r) => r.result === 'warn' || r.result === 'fail') ?? false
 
   const handleApprove = () => {
-    updateStatus.mutate({ id: approvalId, status: 'approved' }, {
-      onSuccess: () => setShowApprove(false),
+    updateStatus.mutate({ id: approvalId, status: 'approved', memo: approveMemo.trim() || undefined }, {
+      onSuccess: () => { setShowApprove(false); setApproveMemo('') },
     })
   }
 
@@ -119,6 +120,17 @@ export default function ReviewControls({ approvalId, isPending, title, reviews, 
             {'\u26A0'} 검토 의견에 <strong>warn</strong> 또는 <strong>fail</strong> 결과가 포함되어 있습니다. 검증 내용을 확인하세요.
           </div>
         )}
+        <div className="mb-4">
+          <label className="block text-[12px] font-semibold text-text-muted mb-1.5">메모 (선택)</label>
+          <textarea
+            value={approveMemo}
+            onChange={(e) => setApproveMemo(e.target.value)}
+            placeholder="승인 사유 또는 코멘트를 남겨주세요"
+            aria-label="승인 메모"
+            rows={3}
+            className="w-full bg-bg border border-border rounded-lg px-3 py-2 text-text text-[13px] focus:outline-none focus:border-primary resize-none"
+          />
+        </div>
         <div className="flex justify-end gap-2 mt-4">
           <button
             onClick={() => setShowApprove(false)}

--- a/frontend/src/hooks/useMembers.ts
+++ b/frontend/src/hooks/useMembers.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getMembers, getMemberDetail, createMember, suspendMember, reactivateMember, revokeMember, rotateToken, changePassword, updateScopes } from '../api/members'
+import { getMembers, getMemberDetail, createMember, suspendMember, reactivateMember, revokeMember, rotateToken, changePassword, updateScopes, updateMemberInfo } from '../api/members'
 import type { MemberCreateRequest } from '../types/member'
 
 export function useMembers(params?: { type?: string; org?: string; status?: string }) {
@@ -49,6 +49,10 @@ export function useMemberControl() {
     }),
     updateScopes: useMutation({
       mutationFn: ({ id, scopes }: { id: string; scopes: string[] }) => updateScopes(id, scopes),
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ['members'] }),
+    }),
+    updateInfo: useMutation({
+      mutationFn: ({ id, name, org }: { id: string; name: string; org: string }) => updateMemberInfo(id, { name, org }),
       onSuccess: () => queryClient.invalidateQueries({ queryKey: ['members'] }),
     }),
   }

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -2,10 +2,11 @@ import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { useMemberDetail, useMemberControl } from '../hooks/useMembers'
 import StatusBadge from '../components/common/StatusBadge'
+import AgentEditModal from '../components/agents/AgentEditModal'
 import { PageSkeleton } from '../components/common/Skeleton'
 import { formatDateTime } from '../utils/formatters'
 import { MEMBER_STATUS_LABELS } from '../utils/constants'
-import { ALL_SCOPES, type MemberStatus } from '../types/member'
+import type { MemberStatus } from '../types/member'
 
 const STATUS_VARIANT: Record<MemberStatus, string> = {
   active: 'positive', suspended: 'warning', revoked: 'negative',
@@ -14,17 +15,24 @@ const STATUS_VARIANT: Record<MemberStatus, string> = {
 export default function AgentDetail() {
   const { id } = useParams<{ id: string }>()
   const { data: member, isLoading } = useMemberDetail(id!)
-  const { suspend, reactivate, revoke, rotateToken, updateScopes } = useMemberControl()
+  const { suspend, reactivate, revoke, rotateToken, updateScopes, updateInfo } = useMemberControl()
   const [newToken, setNewToken] = useState<string | null>(null)
-  const [editingScopes, setEditingScopes] = useState(false)
-  const [scopesDraft, setScopesDraft] = useState<string[]>([])
+  const [showEditModal, setShowEditModal] = useState(false)
 
   if (isLoading) return <PageSkeleton />
   if (!member) return <div className="text-text-muted text-center py-12">에이전트를 찾을 수 없습니다</div>
 
-  const startEditScopes = () => {
-    setScopesDraft([...member.scopes])
-    setEditingScopes(true)
+  const handleEditSave = async (data: { name: string; org: string; scopes: string[] }) => {
+    const scopesChanged = JSON.stringify([...data.scopes].sort()) !== JSON.stringify([...member.scopes].sort())
+    const infoChanged = data.name !== member.name || data.org !== member.org
+
+    if (infoChanged) {
+      await updateInfo.mutateAsync({ id: member.member_id, name: data.name, org: data.org })
+    }
+    if (scopesChanged) {
+      await updateScopes.mutateAsync({ id: member.member_id, scopes: data.scopes })
+    }
+    setShowEditModal(false)
   }
 
   const handleRotateToken = () => {
@@ -47,14 +55,17 @@ export default function AgentDetail() {
           </div>
         </div>
         <div className="flex gap-2">
+          {member.status !== 'revoked' && (
+            <button onClick={() => setShowEditModal(true)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">정보 수정</button>
+          )}
           {member.status === 'active' && (
-            <button onClick={() => suspend.mutate(member.member_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">정지</button>
+            <button onClick={() => suspend.mutate(member.member_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">일시 정지</button>
           )}
           {member.status === 'suspended' && (
             <button onClick={() => reactivate.mutate(member.member_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">재활성화</button>
           )}
           {member.status !== 'revoked' && (
-            <button onClick={() => { if (confirm('영구 폐기하시겠습니까?')) revoke.mutate(member.member_id) }} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative-hover">폐기</button>
+            <button onClick={() => { if (confirm('이 작업은 되돌릴 수 없습니다. 정말 삭제하시겠습니까?')) revoke.mutate(member.member_id) }} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-negative border border-border cursor-pointer hover:bg-surface-hover">삭제</button>
           )}
         </div>
       </div>
@@ -139,41 +150,24 @@ export default function AgentDetail() {
       <div className="bg-surface border border-border rounded-lg p-5">
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-[15px] font-semibold">권한 범위 (Scopes)</h3>
-          {!editingScopes ? (
-            <button onClick={startEditScopes} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">편집</button>
-          ) : null}
         </div>
 
         {/* 현재 scope 표시 */}
-        <div className="flex flex-wrap gap-1 mb-4">
+        <div className="flex flex-wrap gap-1">
           {member.scopes.map((s) => (
             <span key={s} className="text-[11px] px-1.5 py-[1px] rounded-sm bg-bg border border-border text-text-muted font-mono">{s}</span>
           ))}
         </div>
-
-        {/* scope 편집 (토글) */}
-        {editingScopes && (
-          <div className="border-t border-border pt-4">
-            <div className="grid grid-cols-2 gap-2 mb-4">
-              {ALL_SCOPES.map((scope) => (
-                <label key={scope} className="flex items-center gap-2 text-[13px] cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={scopesDraft.includes(scope)}
-                    onChange={() => setScopesDraft((prev) => prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope])}
-                    className="accent-primary"
-                  />
-                  <span className="font-mono text-[12px]">{scope}</span>
-                </label>
-              ))}
-            </div>
-            <div className="flex gap-2">
-              <button onClick={() => { updateScopes.mutate({ id: member.member_id, scopes: scopesDraft }); setEditingScopes(false) }} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">저장</button>
-              <button onClick={() => setEditingScopes(false)} className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
-            </div>
-          </div>
-        )}
       </div>
+
+      {/* 정보 수정 모달 */}
+      <AgentEditModal
+        open={showEditModal}
+        member={member}
+        onClose={() => setShowEditModal(false)}
+        onSave={handleEditSave}
+        isPending={updateInfo.isPending || updateScopes.isPending}
+      />
 
       {/* 토큰 표시 모달 */}
       {newToken && (

--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -1,49 +1,49 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getDatasets, getStorageInfo, deleteDataset } from '../api/data'
-import type { DataType } from '../api/data'
+import type { Dataset } from '../api/data'
 import { formatNumber, formatDate } from '../utils/formatters'
-import { TableSkeleton } from '../components/common/Skeleton'
+import { Skeleton } from '../components/common/Skeleton'
 import FeedStatusPanel from '../components/data/FeedStatusPanel'
 
-const LIMIT = 15
-const TF_OPTIONS = ['all', '1d', '1h', '1m'] as const
-const TF_LABELS: Record<string, string> = { '1d': '1일', '1h': '1시간', '1m': '1분' }
+const TF_LABELS: Record<string, string> = { '1d': '1일', '1h': '1시간', '1m': '1분', quarterly: '분기', annual: '연간' }
 
-const DATA_TYPE_OPTIONS: { value: DataType; label: string }[] = [
-  { value: 'ohlcv', label: 'OHLCV (시세)' },
-  { value: 'fundamental', label: 'Fundamental (재무)' },
-]
+type DirPath = string[]
+
+interface FileEntry {
+  name: string
+  isDir: boolean
+  meta?: string
+  dataset?: Dataset
+}
+
+function formatSize(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`
+  if (bytes >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(0)} MB`
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(0)} KB`
+  return `${bytes} B`
+}
+
+function pathToString(path: DirPath): string {
+  if (path.length === 0) return '~/data'
+  return `~/data/${path.join('/')}`
+}
 
 export default function BacktestData() {
+  const [currentPath, setCurrentPath] = useState<DirPath>([])
+  const [focusIndex, setFocusIndex] = useState(0)
+  const [selectedDataset, setSelectedDataset] = useState<Dataset | null>(null)
   const [search, setSearch] = useState('')
-  const [dataType, setDataType] = useState<DataType>('ohlcv')
-  const [timeframe, setTimeframe] = useState<string>('all')
-  const [offset, setOffset] = useState(0)
-  const [deleteTarget, setDeleteTarget] = useState<{ id: string; symbol: string; timeframe: string; data_type: DataType; start_date: string; end_date: string; row_count: number } | null>(null)
+  const [isSearching, setIsSearching] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<Dataset | null>(null)
+  const searchRef = useRef<HTMLInputElement>(null)
+  const fileListRef = useRef<HTMLDivElement>(null)
   const queryClient = useQueryClient()
 
-  /* 자동완성용: 전체 데이터셋에서 고유 종목 목록 추출 */
-  const { data: allDatasets } = useQuery({
-    queryKey: ['datasets-all-symbols', dataType],
-    queryFn: () => getDatasets({ data_type: dataType, limit: 1000 }),
-  })
-
-  const symbolOptions = useMemo(() => {
-    if (!allDatasets?.items) return []
-    return [...new Set(allDatasets.items.map((ds) => ds.symbol))]
-  }, [allDatasets])
-
-  const { data, isLoading } = useQuery({
-    queryKey: ['datasets', search, dataType, timeframe, offset],
-    queryFn: () =>
-      getDatasets({
-        symbol: search || undefined,
-        data_type: dataType,
-        timeframe: dataType === 'ohlcv' && timeframe !== 'all' ? timeframe : undefined,
-        offset,
-        limit: LIMIT,
-      }),
+  // Fetch all datasets for building the directory tree
+  const { data: allData, isLoading } = useQuery({
+    queryKey: ['datasets-all'],
+    queryFn: () => getDatasets({ limit: 10000 }),
   })
 
   const { data: storage } = useQuery({
@@ -52,149 +52,272 @@ export default function BacktestData() {
   })
 
   const deleteMutation = useMutation({
-    mutationFn: (target: { id: string; data_type: DataType }) => deleteDataset(target.id, target.data_type),
+    mutationFn: (target: Dataset) => deleteDataset(target.id, target.data_type),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['datasets'] })
-      queryClient.invalidateQueries({ queryKey: ['datasets-all-symbols'] })
+      queryClient.invalidateQueries({ queryKey: ['datasets-all'] })
       queryClient.invalidateQueries({ queryKey: ['storage'] })
       setDeleteTarget(null)
+      setSelectedDataset(null)
     },
   })
 
-  const isFundamental = dataType === 'fundamental'
+  const allDatasets = allData?.items ?? []
+
+  // Build directory tree from datasets
+  const entries = useMemo((): FileEntry[] => {
+    // If searching, return flat list of matching files
+    if (isSearching && search.trim()) {
+      const q = search.trim().toLowerCase()
+      const matched = allDatasets.filter((ds) =>
+        ds.symbol.toLowerCase().includes(q),
+      )
+      return matched.map((ds) => ({
+        name: `${ds.data_type}/${ds.symbol}/${ds.timeframe}.parquet`,
+        isDir: false,
+        meta: `${formatNumber(ds.row_count)}`,
+        dataset: ds,
+      }))
+    }
+
+    const depth = currentPath.length
+
+    if (depth === 0) {
+      // Root: show ohlcv/ and fundamental/ dirs
+      const types = new Set(allDatasets.map((ds) => ds.data_type))
+      return Array.from(types).sort().map((t) => ({
+        name: `${t}/`,
+        isDir: true,
+      }))
+    }
+
+    if (depth === 1) {
+      // Type level: show symbol dirs
+      const dataType = currentPath[0]
+      const symbols = new Set(
+        allDatasets.filter((ds) => ds.data_type === dataType).map((ds) => ds.symbol),
+      )
+      return Array.from(symbols).sort().map((sym) => ({
+        name: `${sym}/`,
+        isDir: true,
+      }))
+    }
+
+    if (depth === 2) {
+      // Symbol level: show timeframe files
+      const [dataType, symbol] = currentPath
+      const files = allDatasets.filter(
+        (ds) => ds.data_type === dataType && ds.symbol === symbol,
+      )
+      return files
+        .sort((a, b) => a.timeframe.localeCompare(b.timeframe))
+        .map((ds) => ({
+          name: `${ds.timeframe}.parquet`,
+          isDir: false,
+          meta: `${formatNumber(ds.row_count)}`,
+          dataset: ds,
+        }))
+    }
+
+    return []
+  }, [allDatasets, currentPath, isSearching, search])
+
+  // Full list including parent entry
+  const fullList = useMemo(() => {
+    if (isSearching && search.trim()) return entries
+    const showParent = currentPath.length > 0
+    return showParent ? [{ name: '../', isDir: true } as FileEntry, ...entries] : entries
+  }, [entries, currentPath, isSearching, search])
+
+  // Reset focus on path/search change
+  useEffect(() => {
+    setFocusIndex(0)
+  }, [currentPath, isSearching, search])
+
+  const navigateUp = useCallback(() => {
+    if (currentPath.length > 0) {
+      setCurrentPath((prev) => prev.slice(0, -1))
+      setSelectedDataset(null)
+    }
+  }, [currentPath])
+
+  const handleEntryClick = useCallback((entry: FileEntry, index: number) => {
+    setFocusIndex(index)
+    if (entry.name === '../') {
+      navigateUp()
+    } else if (entry.isDir) {
+      const dirName = entry.name.replace(/\/$/, '')
+      setCurrentPath((prev) => [...prev, dirName])
+      setSelectedDataset(null)
+    } else if (entry.dataset) {
+      // If from search results, navigate to the file's directory
+      if (isSearching && search.trim()) {
+        const ds = entry.dataset
+        setCurrentPath([ds.data_type, ds.symbol])
+        setIsSearching(false)
+        setSearch('')
+      }
+      setSelectedDataset(entry.dataset)
+    }
+  }, [navigateUp, isSearching, search])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === '/') {
+      e.preventDefault()
+      searchRef.current?.focus()
+      setIsSearching(true)
+      return
+    }
+
+    if (e.key === 'Escape' && isSearching) {
+      setIsSearching(false)
+      setSearch('')
+      fileListRef.current?.focus()
+      return
+    }
+
+    if (e.key === 'Backspace' && !isSearching) {
+      e.preventDefault()
+      navigateUp()
+      return
+    }
+
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setFocusIndex((prev) => Math.max(0, prev - 1))
+      return
+    }
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setFocusIndex((prev) => Math.min(fullList.length - 1, prev + 1))
+      return
+    }
+
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      const entry = fullList[focusIndex]
+      if (entry) handleEntryClick(entry, focusIndex)
+      return
+    }
+  }, [fullList, focusIndex, handleEntryClick, navigateUp, isSearching])
+
+  const handleSearchKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      setIsSearching(false)
+      setSearch('')
+      fileListRef.current?.focus()
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      fileListRef.current?.focus()
+    }
+  }
+
+  // Storage info string
+  const storageStr = storage
+    ? `전체 ${formatSize(storage.total_bytes ?? storage.total_mb * 1024 * 1024)}`
+      + (storage.by_timeframe && Object.keys(storage.by_timeframe).length > 0
+        ? ` — ${Object.entries(storage.by_timeframe).map(([tf, bytes]) => `${TF_LABELS[tf] ?? tf} ${formatSize(bytes)}`).join(' · ')}`
+        : '')
+    : ''
 
   return (
     <>
-      {/* 안내 배너 */}
-      <div className="bg-info-bg rounded px-3.5 py-2.5 mb-4 text-[12px] text-info">
-        {'\u{1f4a1}'} 데이터 수집은 Agent에게 요청하거나 CLI(<code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante feed</code>)를 사용하세요.
-      </div>
-
-      {/* Feed 파이프라인 상태 (BD-6) */}
+      {/* Feed 파이프라인 상태 */}
       <FeedStatusPanel />
 
-      {/* 데이터셋 카드 */}
-      <div className="bg-surface border border-border rounded-lg p-5">
-        {/* 카드 헤더: 타이틀 + 필터를 한 줄 배치 */}
-        <div className="flex items-center justify-between mb-4">
-          <span className="text-[15px] font-semibold text-text">데이터셋</span>
-          <div className="flex items-center gap-2">
-            <input
-              type="text"
-              value={search}
-              onChange={(e) => { setSearch(e.target.value); setOffset(0) }}
-              list="symbol-list"
-              placeholder="종목 검색"
-              className="bg-bg border border-border rounded px-2 py-1 text-text text-[13px] w-40 placeholder:text-text-muted focus:outline-none focus:border-primary"
-            />
-            <datalist id="symbol-list">
-              {symbolOptions.map((sym) => (
-                <option key={sym} value={sym} />
-              ))}
-            </datalist>
-            <select
-              value={dataType}
-              onChange={(e) => { setDataType(e.target.value as DataType); setTimeframe('all'); setOffset(0) }}
-              className="bg-bg border border-border rounded px-2 py-1 text-text text-[13px] cursor-pointer focus:outline-none focus:border-primary"
+      {/* 터미널 파일 탐색기 */}
+      <div
+        className="flex flex-col border border-border rounded-lg overflow-hidden font-mono"
+        onKeyDown={handleKeyDown}
+      >
+        {/* 상단: 검색 바 + 용량 */}
+        <div className="flex items-center gap-3 px-3.5 py-2.5 border-b border-border bg-surface">
+          <input
+            ref={searchRef}
+            type="text"
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value)
+              if (e.target.value.trim()) setIsSearching(true)
+              else setIsSearching(false)
+            }}
+            onFocus={() => { if (search.trim()) setIsSearching(true) }}
+            onKeyDown={handleSearchKeyDown}
+            placeholder="검색 (종목명 또는 코드)"
+            className="w-[260px] px-2.5 py-1.5 text-[13px] bg-transparent border border-border rounded text-text font-mono placeholder:text-text-muted focus:outline-none focus:border-primary"
+          />
+          <span className="text-[11px] text-text-muted ml-auto whitespace-nowrap">
+            {storageStr}
+          </span>
+        </div>
+
+        {/* 하단: 2열 (파일 브라우저 + 상세 패널) */}
+        <div className="flex min-h-[480px]">
+          {/* 왼쪽: 파일 브라우저 */}
+          <div className="w-[320px] min-w-[320px] border-r border-border flex flex-col bg-bg">
+            {/* 경로 */}
+            <div className="px-3.5 py-2 border-b border-border text-[12px] text-text-muted">
+              <span className="text-primary">{pathToString(currentPath)}</span>
+            </div>
+
+            {/* 파일 리스트 */}
+            <div
+              ref={fileListRef}
+              className="flex-1 overflow-y-auto py-1 focus:outline-none"
+              tabIndex={0}
             >
-              {DATA_TYPE_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>{opt.label}</option>
-              ))}
-            </select>
-            {!isFundamental && (
-              <select
-                value={timeframe}
-                onChange={(e) => { setTimeframe(e.target.value); setOffset(0) }}
-                className="bg-bg border border-border rounded px-2 py-1 text-text text-[13px] cursor-pointer focus:outline-none focus:border-primary"
-              >
-                <option value="all">전체 타임프레임</option>
-                {TF_OPTIONS.filter((tf) => tf !== 'all').map((tf) => (
-                  <option key={tf} value={tf}>{TF_LABELS[tf] ?? tf}</option>
-                ))}
-              </select>
+              {isLoading ? (
+                <div className="p-4 space-y-2">
+                  <Skeleton className="h-5 w-full" />
+                  <Skeleton className="h-5 w-3/4" />
+                  <Skeleton className="h-5 w-5/6" />
+                </div>
+              ) : fullList.length === 0 ? (
+                <div className="px-3.5 py-4 text-[13px] text-text-muted text-center">
+                  {isSearching ? '검색 결과 없음' : '항목 없음'}
+                </div>
+              ) : (
+                fullList.map((entry, idx) => {
+                  const isFocused = idx === focusIndex
+                  const isActive = !entry.isDir && entry.dataset?.id === selectedDataset?.id
+                  const isParent = entry.name === '../'
+                  return (
+                    <div
+                      key={`${entry.name}-${idx}`}
+                      onClick={() => handleEntryClick(entry, idx)}
+                      className={`flex items-center gap-2 px-3.5 py-1.5 text-[13px] cursor-pointer border-l-2 ${
+                        isActive
+                          ? 'text-positive border-l-positive'
+                          : isFocused
+                            ? 'bg-surface-hover border-l-primary'
+                            : 'border-l-transparent'
+                      } ${isParent ? 'text-text-muted' : entry.isDir ? 'text-primary' : 'text-text-muted'} hover:bg-surface-hover`}
+                    >
+                      <span className="flex-1 truncate">{entry.name}</span>
+                      {entry.meta && (
+                        <span className="text-[11px] text-text-muted shrink-0">{entry.meta}</span>
+                      )}
+                    </div>
+                  )
+                })
+              )}
+            </div>
+          </div>
+
+          {/* 오른쪽: 터미널 스타일 상세 패널 */}
+          <div className="flex-1 overflow-y-auto p-4 bg-bg text-[12px] leading-relaxed text-text-muted font-mono">
+            {selectedDataset ? (
+              <DatasetDetailPanel dataset={selectedDataset} onDelete={setDeleteTarget} />
+            ) : (
+              <pre>
+                <span className="text-positive">$</span>{' '}
+                <span className="text-text opacity-40">_</span>
+              </pre>
             )}
           </div>
         </div>
-        {isLoading ? (
-          <TableSkeleton rows={5} cols={isFundamental ? 5 : 6} />
-        ) : (
-          <>
-            <div className="overflow-x-auto">
-              <table className="w-full border-collapse">
-                <thead>
-                  <tr>
-                    <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">종목</th>
-                    {!isFundamental && (
-                      <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">타임프레임</th>
-                    )}
-                    <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">시작일</th>
-                    <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">종료일</th>
-                    <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border">행 수</th>
-                    <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted uppercase tracking-wider border-b border-border"></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {(data?.items ?? []).length === 0 ? (
-                    <tr><td colSpan={isFundamental ? 5 : 6} className="px-3 py-8 text-center text-text-muted text-[13px]">데이터셋이 없습니다</td></tr>
-                  ) : (
-                    (data?.items ?? []).map((ds, idx, arr) => {
-                      const isLast = idx === arr.length - 1
-                      const borderCls = isLast ? '' : 'border-b border-border'
-                      return (
-                      <tr key={ds.id} className="hover:bg-surface-hover">
-                        <td className={`px-3 py-3 ${borderCls} text-[13px] font-mono font-medium`}>{ds.symbol}</td>
-                        {!isFundamental && (
-                          <td className={`px-3 py-3 ${borderCls} text-[13px]`}>{TF_LABELS[ds.timeframe] ?? ds.timeframe}</td>
-                        )}
-                        <td className={`px-3 py-3 ${borderCls} text-[13px] text-text-muted`}>{formatDate(ds.start_date)}</td>
-                        <td className={`px-3 py-3 ${borderCls} text-[13px] text-text-muted`}>{formatDate(ds.end_date)}</td>
-                        <td className={`px-3 py-3 ${borderCls} text-[13px] text-right`}>{formatNumber(ds.row_count)}</td>
-                        <td className={`px-3 py-3 ${borderCls} text-[13px] text-right`}>
-                          <button
-                            onClick={() => setDeleteTarget({ id: ds.id, symbol: ds.symbol, timeframe: ds.timeframe, data_type: ds.data_type, start_date: ds.start_date, end_date: ds.end_date, row_count: ds.row_count })}
-                            className="px-2.5 py-1 rounded text-[12px] bg-transparent text-negative border border-border cursor-pointer hover:bg-surface-hover hover:text-text"
-                          >
-                            삭제
-                          </button>
-                        </td>
-                      </tr>
-                      )
-                    })
-                  )}
-                </tbody>
-              </table>
-            </div>
-
-            <div className="flex items-center justify-between pt-3 text-[13px] text-text-muted">
-              <span>
-                총 {formatNumber(data?.total ?? 0)}건
-                {(data?.total ?? 0) > 0 && ` 중 ${offset + 1}-${Math.min(offset + LIMIT, data?.total ?? 0)}`}
-                {storage && ` · 전체 ${storage.total_mb >= 1024 ? `${(storage.total_mb / 1024).toFixed(1)} GB` : `${storage.total_mb.toFixed(1)} MB`}`}
-                {storage?.by_timeframe && Object.keys(storage.by_timeframe).length > 0 && (
-                  <> ({Object.entries(storage.by_timeframe).map(([tf, bytes], i) => (
-                    <span key={tf}>{i > 0 && ' · '}{TF_LABELS[tf] ?? tf} {(bytes / 1024 / 1024).toFixed(0)} MB</span>
-                  ))})</>
-                )}
-              </span>
-              <div className="flex items-center gap-1">
-                <button
-                  onClick={() => setOffset(Math.max(0, offset - LIMIT))}
-                  disabled={offset <= 0}
-                  className="px-2.5 py-1 rounded text-[12px] font-medium border border-border bg-transparent text-text-muted hover:bg-surface-hover hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
-                >
-                  &larr; 이전
-                </button>
-                <button
-                  onClick={() => setOffset(offset + LIMIT)}
-                  disabled={offset + LIMIT >= (data?.total ?? 0)}
-                  className="px-2.5 py-1 rounded text-[12px] font-medium border border-border bg-transparent text-text-muted hover:bg-surface-hover hover:text-text disabled:opacity-40 disabled:cursor-not-allowed"
-                >
-                  다음 &rarr;
-                </button>
-              </div>
-            </div>
-          </>
-        )}
       </div>
 
       {/* 삭제 확인 모달 */}
@@ -216,7 +339,7 @@ export default function BacktestData() {
             <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
               <button onClick={() => setDeleteTarget(null)} className="px-4 py-2 rounded text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover hover:text-text">취소</button>
               <button
-                onClick={() => deleteMutation.mutate({ id: deleteTarget.id, data_type: deleteTarget.data_type })}
+                onClick={() => deleteMutation.mutate(deleteTarget)}
                 disabled={deleteMutation.isPending}
                 className="px-4 py-2 rounded text-[13px] font-medium bg-negative text-white border border-negative cursor-pointer hover:bg-negative-hover disabled:opacity-50"
               >
@@ -227,5 +350,52 @@ export default function BacktestData() {
         </div>
       )}
     </>
+  )
+}
+
+/* ── 상세 패널 ── */
+function DatasetDetailPanel({ dataset, onDelete }: { dataset: Dataset; onDelete: (ds: Dataset) => void }) {
+  const ds = dataset
+  const filePath = `${ds.data_type}/${ds.symbol}/${ds.timeframe}.parquet`
+  const typeLabel = ds.data_type === 'ohlcv' ? 'OHLCV' : 'Fundamental'
+  const isOhlcv = ds.data_type === 'ohlcv'
+
+  const separator = '\u2500'.repeat(65)
+  const headerCols = isOhlcv
+    ? 'date         open     high     low      close    volume'
+    : 'quarter      revenue       op_profit     net_profit    eps      roe'
+
+  return (
+    <div className="space-y-4">
+      <pre className="m-0 whitespace-pre overflow-x-auto">
+        <span className="text-positive">$</span>{' '}
+        <span className="text-text">ante data show {filePath}</span>
+      </pre>
+      <pre className="m-0 whitespace-pre overflow-x-auto">
+        <span className="text-text font-semibold">{'File'}</span>{'       '}{filePath}{'\n'}
+        <span className="text-text font-semibold">{'Symbol'}</span>{'     '}{ds.symbol}{'\n'}
+        <span className="text-text font-semibold">{'Type'}</span>{'       '}{typeLabel}{'\n'}
+        <span className="text-text font-semibold">{'Timeframe'}</span>{'  '}{ds.timeframe}{'\n'}
+        <span className="text-text font-semibold">{'Period'}</span>{'     '}{ds.start_date} ~ {ds.end_date}{'\n'}
+        <span className="text-text font-semibold">{'Rows'}</span>{'       '}<span className="text-text">{formatNumber(ds.row_count)}</span>{'\n'}
+        <span className="text-text font-semibold">{'Size'}</span>{'       '}<span className="text-text">-</span>
+      </pre>
+      <pre className="m-0 whitespace-pre overflow-x-auto text-text-muted">
+        <span className="text-border">{separator}</span>{'\n'}
+        <span className="text-text font-semibold">{headerCols}</span>{'\n'}
+        <span className="text-border">{separator}</span>{'\n'}
+        <span className="text-text-muted opacity-50">  데이터 미리보기는 API 확장 후 제공됩니다</span>{'\n'}
+        <span className="text-border">{separator}</span>
+      </pre>
+      <pre className="m-0 whitespace-pre overflow-x-auto">
+        <span className="text-positive">$</span>{' '}
+        <button
+          onClick={() => onDelete(ds)}
+          className="text-negative bg-transparent border-none cursor-pointer font-mono text-[12px] underline p-0"
+        >
+          삭제
+        </button>
+      </pre>
+    </div>
   )
 }

--- a/frontend/src/pages/ReportDetail.tsx
+++ b/frontend/src/pages/ReportDetail.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { useReportDetail } from '../hooks/useReports'
 import StatusBadge from '../components/common/StatusBadge'
 import { PageSkeleton } from '../components/common/Skeleton'
@@ -46,7 +46,61 @@ function ReportInfoCard({ report }: { report: ReportDetailType }) {
       <InfoRow label="상태" value={<StatusBadge variant={status.variant as 'info'}>{status.label}</StatusBadge>} />
       <InfoRow label="수행자" value={report.submitted_by} />
       <InfoRow label="수행일" value={formatDateTime(report.submitted_at)} />
+    </div>
+  )
+}
+
+/* ── 백테스트 설정 카드 (R-2) ── */
+function BacktestSettingsCard({ report }: { report: ReportDetailType }) {
+  const config = report.config
+  const datasets = report.datasets ?? []
+  const symbols = datasets.map((d) => d.symbol)
+
+  if (!config && datasets.length === 0) {
+    return (
+      <div className="bg-surface border border-border rounded-lg p-5">
+        <h3 className="text-[15px] font-semibold mb-3">백테스트 설정</h3>
+        <div className="text-[13px] text-text-muted py-4 text-center">설정 정보 없음</div>
+      </div>
+    )
+  }
+
+  const formatRate = (value: number | undefined): string => {
+    if (value == null) return '-'
+    return `${(value * 100).toFixed(3)}%`
+  }
+
+  const renderSymbols = () => {
+    if (symbols.length === 0) return '-'
+    if (symbols.length <= 3) {
+      return symbols.map((s, i) => (
+        <span key={s}>
+          {i > 0 && ', '}
+          <span className="font-mono">{s}</span>
+        </span>
+      ))
+    }
+    return (
+      <>
+        <span className="font-mono">{symbols[0]}</span>
+        {', '}
+        <span className="font-mono">{symbols[1]}</span>
+        {' '}
+        <span className="text-text-muted">외 {symbols.length - 2}</span>
+      </>
+    )
+  }
+
+  return (
+    <div className="bg-surface border border-border rounded-lg p-5">
+      <h3 className="text-[15px] font-semibold mb-3">백테스트 설정</h3>
       <InfoRow label="백테스트 기간" value={report.backtest_period || '-'} />
+      <InfoRow label="초기 자금" value={config?.initial_balance != null ? `${config.initial_balance.toLocaleString()}원` : formatCurrency(report.initial_balance)} />
+      <InfoRow label="타임프레임" value={config?.timeframe ?? '-'} />
+      <InfoRow label="매수 수수료율" value={formatRate(config?.buy_commission_rate)} />
+      <InfoRow label="매도 수수료율" value={formatRate(config?.sell_commission_rate)} />
+      <InfoRow label="슬리피지율" value={formatRate(config?.slippage_rate)} />
+      <InfoRow label="대상 종목" value={<span>{renderSymbols()}</span>} />
     </div>
   )
 }
@@ -88,51 +142,6 @@ function PerformanceCard({ report }: { report: ReportDetailType }) {
   )
 }
 
-/* ── 백테스트 데이터 카드 ── */
-function BacktestDataCard({ report }: { report: ReportDetailType }) {
-  const symbols = report.symbols ?? []
-  const visible = symbols.slice(0, 3)
-  const remaining = symbols.length - 3
-
-  return (
-    <div className="bg-surface border border-border rounded-lg p-5">
-      <h3 className="text-[15px] font-semibold mb-3">백테스트 데이터</h3>
-      <InfoRow label="초기 자금" value={formatCurrency(report.initial_balance)} />
-      {symbols.length > 0 && (
-        <div className="mt-3 overflow-x-auto">
-          <table className="w-full border-collapse">
-            <thead>
-              <tr>
-                <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">종목</th>
-                <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">타임프레임</th>
-                <th className="text-left px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">기간</th>
-                <th className="text-right px-3 py-2 text-[12px] font-semibold text-text-muted border-b border-border">행 수</th>
-              </tr>
-            </thead>
-            <tbody>
-              {visible.map((s) => (
-                <tr key={s.symbol}>
-                  <td className="px-3 py-2 border-b border-border text-[13px]">{s.name} ({s.symbol})</td>
-                  <td className="px-3 py-2 border-b border-border text-[13px]">{s.timeframe}</td>
-                  <td className="px-3 py-2 border-b border-border text-[13px]">{s.period}</td>
-                  <td className="px-3 py-2 border-b border-border text-[13px] text-right">{s.rows.toLocaleString()}</td>
-                </tr>
-              ))}
-              {remaining > 0 && (
-                <tr>
-                  <td colSpan={4} className="px-3 py-2 text-center text-[12px] text-text-muted">
-                    외 {remaining}종목 · <Link to="/backtest-data" className="text-primary no-underline hover:underline">백테스트 데이터 관리</Link>
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </div>
-  )
-}
-
 /* ── 메인 페이지 ── */
 export default function ReportDetail() {
   const { id } = useParams<{ id: string }>()
@@ -148,15 +157,11 @@ export default function ReportDetail() {
         <h2 className="text-[20px] font-bold">{report.strategy_name} {report.strategy_version} 검증 리포트</h2>
       </div>
 
-      {/* 1행: 리포트 정보 | 백테스트 성과 */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+      {/* 1행: 리포트 정보 | 백테스트 설정 | 백테스트 성과 (3열) */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
         <ReportInfoCard report={report} />
+        <BacktestSettingsCard report={report} />
         <PerformanceCard report={report} />
-      </div>
-
-      {/* 2행: 백테스트 데이터 */}
-      <div className="mb-6">
-        <BacktestDataCard report={report} />
       </div>
 
       {/* 3행: 자산 곡선 차트 (플레이스홀더) */}

--- a/frontend/src/types/report.ts
+++ b/frontend/src/types/report.ts
@@ -16,6 +16,22 @@ export interface ReportSymbol {
   rows: number
 }
 
+export interface BacktestConfig {
+  initial_balance?: number
+  timeframe?: string
+  buy_commission_rate?: number
+  sell_commission_rate?: number
+  slippage_rate?: number
+}
+
+export interface DatasetInfo {
+  symbol: string
+  symbol_name?: string
+  timeframe?: string
+  start_date?: string
+  end_date?: string
+}
+
 export interface ReportDetail {
   report_id: string
   strategy_name: string
@@ -41,4 +57,6 @@ export interface ReportDetail {
   symbols: ReportSymbol[]
   user_notes: string
   reviewed_at: string | null
+  config?: BacktestConfig
+  datasets?: DatasetInfo[]
 }


### PR DESCRIPTION
## Summary
- **5-1** 결재함 유형 필터 확장: TYPE_OPTIONS에 strategy_report, budget_allocate, live_switch, risk_alert 추가
- **5-2** 결재 승인 모달에 optional 메모 textarea 추가 (A-8 완료 조건 충족)
- **5-3** 에이전트 상세 AgentEditModal: 이름, 소속, 권한 범위를 한 모달에서 수정 (M-6 완료). 기존 인라인 scope 편집 제거, 상세 헤더에 "정보 수정" 버튼 배치
- **5-4** 백테스트 데이터 2분할 파일 브라우저: 좌측 디렉토리 네비게이션(~/data > ohlcv/fundamental > 종목 > 파일) + 우측 터미널 스타일 상세 패널. 키보드 내비게이션(화살표/Enter/Backspace) + 글로벌 검색(/ 키, Escape 해제)
- **5-5** 리포트 상세 3열 레이아웃: 리포트 정보 | 백테스트 설정(기간, 초기자금, 타임프레임, 매수/매도 수수료율, 슬리피지율, 대상종목) | 백테스트 성과
- **5-6 스킵**: Phase 4b (#837, blocked)의 EquityCurveChart에 의존

## Test plan
- [ ] 결재함 유형 필터 드롭다운에 9개 유형 모두 표시 확인
- [ ] 결재 승인 모달에서 메모 입력 후 승인 시 memo 파라미터 전달 확인
- [ ] 에이전트 상세에서 "정보 수정" 클릭 → 모달에 현재 값 pre-fill → 저장 동작 확인
- [ ] 백테스트 데이터 페이지: ~/data 루트에서 ohlcv/, fundamental/ 디렉토리 표시 → 클릭으로 진입 → 파일 선택 시 우측 상세 패널 갱신 확인
- [ ] 키보드 내비게이션: 화살표(↑/↓), Enter(진입/선택), Backspace(상위), /(검색) 동작 확인
- [ ] 리포트 상세 3열 레이아웃 + 백테스트 설정 카드 7개 필드 표시 확인
- [ ] `npm run build` 정상 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)