### PR TITLE
fix(account): credentials 누락 시 500 대신 422 반환 Refs #848

### DIFF
--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -95,6 +95,7 @@ async def create_account(
     from ante.account.errors import (
         AccountAlreadyExistsError,
         InvalidBrokerTypeError,
+        MissingCredentialsError,
     )
     from ante.account.models import Account, TradingMode
     from ante.account.presets import BROKER_PRESETS
@@ -139,6 +140,8 @@ async def create_account(
         raise HTTPException(status_code=400, detail=str(e))
     except AccountAlreadyExistsError as e:
         raise HTTPException(status_code=409, detail=str(e))
+    except MissingCredentialsError as e:
+        raise HTTPException(status_code=422, detail=str(e))
 
     # 브로커 어댑터 인스턴스 생성 가능 여부 검증
     # BROKER_REGISTRY에 미등록된 타입은 생성 직후 롤백

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -42,6 +42,19 @@ class FakeAccountService:
             raise InvalidBrokerTypeError(
                 f"유효하지 않은 broker_type: '{account.broker_type}'"
             )
+        # credentials 필수 키 검증
+        preset = BROKER_PRESETS[account.broker_type]
+        missing = [
+            k for k in preset.required_credentials if k not in account.credentials
+        ]
+        if missing:
+            from ante.account.errors import MissingCredentialsError
+
+            raise MissingCredentialsError(
+                f"필수 credentials 누락: {missing}. "
+                f"broker_type '{account.broker_type}'에 필요: "
+                f"{preset.required_credentials}"
+            )
         now = datetime.now(UTC)
         account.created_at = now
         account.updated_at = now
@@ -227,6 +240,7 @@ class TestCreateAccount:
                 "account_id": "new-test",
                 "name": "새 테스트 계좌",
                 "broker_type": "test",
+                "credentials": {"app_key": "key", "app_secret": "secret"},
             },
         )
         assert resp.status_code == 201
@@ -256,6 +270,24 @@ class TestCreateAccount:
             },
         )
         assert resp.status_code == 409
+
+    def test_create_missing_credentials_returns_422(
+        self,
+        client: TestClient,
+    ) -> None:
+        """credentials 누락 시 422 Validation Error를 반환해야 한다 (GH-848)."""
+        resp = client.post(
+            "/api/accounts",
+            json={
+                "account_id": "no-creds",
+                "name": "크레덴셜 누락 계좌",
+                "broker_type": "test",
+                "credentials": {},
+            },
+        )
+        assert resp.status_code == 422
+        data = resp.json()
+        assert "credentials" in data["detail"].lower() or "누락" in data["detail"]
 
 
 class TestGetAccount:


### PR DESCRIPTION
## Summary
- 계좌 생성(`POST /api/accounts`) 시 credentials를 누락하면 `MissingCredentialsError`가 catch되지 않아 500으로 노출되던 문제 수정
- 라우트 핸들러에서 `MissingCredentialsError`를 422 Validation Error로 매핑
- FakeAccountService에 credentials 검증 로직 추가 및 단위 테스트 작성

## Test plan
- [x] `test_create_missing_credentials_returns_422`: 빈 credentials로 계좌 생성 시 422 반환 확인
- [x] 기존 `test_create_success`에 credentials 포함하여 정상 동작 유지 확인
- [x] 전체 22개 account API 테스트 통과 확인

Refs #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)