### PR TITLE
fix(bot): PUT /api/bots/{id} budget 수정 시 500 → 422 반환

### DIFF
--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -365,6 +365,7 @@ async def delete_bot(
     responses={
         404: {"description": "Bot not found"},
         409: {"description": "Bot state conflict (not stopped)"},
+        422: {"description": "Budget update failed (e.g. insufficient funds)"},
         503: {"description": "Bot manager not available"},
     },
 )
@@ -377,6 +378,7 @@ async def update_bot(
 ) -> dict:
     """봇 설정 수정. 중지 상태에서만 허용."""
     from ante.bot.exceptions import BotError
+    from ante.treasury.exceptions import TreasuryError
 
     bot = bot_manager.get_bot(bot_id)
     if bot is None:
@@ -390,6 +392,8 @@ async def update_bot(
         bot = await bot_manager.update_bot(bot_id, **updates)
     except BotError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
+    except TreasuryError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
 
     if audit_logger:
         await audit_logger.log(

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -818,3 +818,38 @@ class TestUpdateBot:
         assert resp.status_code == 422
         resp = client.put("/api/bots/bot-1", json={"budget": -100})
         assert resp.status_code == 422
+
+    def test_budget_treasury_error_returns_422(
+        self, bot_manager, default_account_service
+    ):
+        """budget 변경 시 TreasuryError 발생하면 500이 아닌 422 반환."""
+        from ante.treasury.exceptions import InsufficientFundsError
+
+        async def update_bot_with_treasury_error(bot_id, **kwargs):
+            bot = bot_manager._bots.get(bot_id)
+            if bot is None:
+                from ante.bot.exceptions import BotError
+
+                raise BotError(f"Bot not found: {bot_id}")
+            if "budget" in kwargs:
+                raise InsufficientFundsError(
+                    "미할당 잔액 부족: 필요 2,000,000, 가용 500,000"
+                )
+            return bot
+
+        bot_manager.update_bot = update_bot_with_treasury_error
+        app = create_app(
+            bot_manager=bot_manager,
+            account_service=default_account_service,
+        )
+        client = TestClient(app)
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.put("/api/bots/bot-1", json={"budget": 2000000})
+        assert resp.status_code == 422
+        assert "잔액 부족" in resp.json()["detail"]
+
+    def test_budget_update_success(self, client, bot_manager):
+        """budget 변경 성공 시 200 반환."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.put("/api/bots/bot-1", json={"budget": 2000000})
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- `PUT /api/bots/{bot_id}`에서 budget 변경 시 `TreasuryError`(잔액 부족 등)가 포착되지 않아 500 Internal Server Error가 반환되던 문제 수정
- 라우트 핸들러에 `TreasuryError` 예외 처리 추가하여 422 Unprocessable Entity로 반환
- OpenAPI 응답 명세에 422 케이스 추가

## Changes
- `src/ante/web/routes/bots.py`: `TreasuryError` catch 및 422 응답 반환
- `tests/unit/test_bot_api.py`: treasury error → 422, budget 정상 변경 → 200 테스트 추가

## Test plan
- [x] `TestUpdateBot::test_budget_treasury_error_returns_422` -- InsufficientFundsError 발생 시 422 반환 확인
- [x] `TestUpdateBot::test_budget_update_success` -- budget 정상 변경 시 200 반환 확인
- [x] 기존 46건 테스트 전체 통과 확인

Refs #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)