### PR TITLE
fix(qa): docker exec 시 CLI 토큰 파일 폴백으로 인증 실패 해결 Refs #854

### DIFF
--- a/scripts/qa-entrypoint.sh
+++ b/scripts/qa-entrypoint.sh
@@ -49,7 +49,11 @@ fi
 if [ -n "$QA_TOKEN" ]; then
     export ANTE_MEMBER_TOKEN="$QA_TOKEN"
     echo "export ANTE_MEMBER_TOKEN=\"$QA_TOKEN\"" >> /root/.bashrc
-    echo "[qa] ANTE_MEMBER_TOKEN 설정 완료"
+    # docker exec는 컨테이너의 환경변수를 상속하지 않으므로
+    # 토큰을 파일로도 저장하여 CLI가 자동으로 읽을 수 있게 한다
+    echo -n "$QA_TOKEN" > /run/ante-token
+    chmod 600 /run/ante-token
+    echo "[qa] ANTE_MEMBER_TOKEN 설정 완료 (환경변수 + /run/ante-token)"
 else
     echo "[qa] WARNING: ANTE_MEMBER_TOKEN 설정 실패" >&2
 fi

--- a/src/ante/cli/middleware.py
+++ b/src/ante/cli/middleware.py
@@ -25,8 +25,30 @@ _AUTH_EXEMPT_COMMANDS: set[str] = {
 }
 
 
+def _resolve_token() -> str:
+    """ANTE_MEMBER_TOKEN을 환경변수 또는 토큰 파일에서 확보한다.
+
+    우선순위:
+    1. ANTE_MEMBER_TOKEN 환경변수
+    2. ANTE_TOKEN_FILE 환경변수가 가리키는 파일
+    3. /run/ante-token 파일 (QA 컨테이너 기본 경로)
+    """
+    token = os.environ.get("ANTE_MEMBER_TOKEN", "")
+    if token:
+        return token
+
+    token_file = os.environ.get("ANTE_TOKEN_FILE", "/run/ante-token")
+    try:
+        with open(token_file) as f:
+            token = f.read().strip()
+    except (FileNotFoundError, PermissionError):
+        pass
+
+    return token
+
+
 def authenticate_member(ctx: click.Context) -> None:
-    """ANTE_MEMBER_TOKEN 환경변수로 멤버 인증.
+    """ANTE_MEMBER_TOKEN 환경변수 또는 토큰 파일로 멤버 인증.
 
     인증된 Member를 ctx.obj["member"]에 저장한다.
     면제 커맨드이거나 --help 플래그가 있으면 건너뛴다.
@@ -40,7 +62,7 @@ def authenticate_member(ctx: click.Context) -> None:
         ctx.obj["member"] = None
         return
 
-    token = os.environ.get("ANTE_MEMBER_TOKEN", "")
+    token = _resolve_token()
     if not token:
         ctx.obj["member"] = None
         return

--- a/tests/unit/test_cli_resolve_token.py
+++ b/tests/unit/test_cli_resolve_token.py
@@ -1,0 +1,59 @@
+"""_resolve_token 함수 단위 테스트 — 환경변수 및 토큰 파일 우선순위."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from ante.cli.middleware import _resolve_token
+
+
+class TestResolveToken:
+    """토큰 해석 우선순위 테스트."""
+
+    def test_env_var_takes_precedence(self, tmp_path):
+        """ANTE_MEMBER_TOKEN 환경변수가 있으면 파일을 읽지 않는다."""
+        token_file = tmp_path / "token"
+        token_file.write_text("file_token")
+        with patch.dict(
+            os.environ,
+            {"ANTE_MEMBER_TOKEN": "env_token", "ANTE_TOKEN_FILE": str(token_file)},
+        ):
+            assert _resolve_token() == "env_token"
+
+    def test_token_file_via_env(self, tmp_path):
+        """ANTE_TOKEN_FILE이 가리키는 파일에서 토큰을 읽는다."""
+        token_file = tmp_path / "token"
+        token_file.write_text("file_token_custom")
+        with patch.dict(
+            os.environ,
+            {"ANTE_MEMBER_TOKEN": "", "ANTE_TOKEN_FILE": str(token_file)},
+            clear=False,
+        ):
+            # 환경변수 제거
+            env = os.environ.copy()
+            env.pop("ANTE_MEMBER_TOKEN", None)
+            with patch.dict(os.environ, env, clear=True):
+                os.environ["ANTE_TOKEN_FILE"] = str(token_file)
+                assert _resolve_token() == "file_token_custom"
+
+    def test_default_token_file(self, tmp_path, monkeypatch):
+        """ANTE_TOKEN_FILE도 없으면 /run/ante-token을 시도한다."""
+        monkeypatch.delenv("ANTE_MEMBER_TOKEN", raising=False)
+        monkeypatch.delenv("ANTE_TOKEN_FILE", raising=False)
+        # /run/ante-token은 테스트 환경에서 없으므로 빈 문자열 반환
+        assert _resolve_token() == ""
+
+    def test_token_file_strips_whitespace(self, tmp_path, monkeypatch):
+        """토큰 파일의 앞뒤 공백/개행을 제거한다."""
+        token_file = tmp_path / "token"
+        token_file.write_text("  ante_token_abc123  \n")
+        monkeypatch.delenv("ANTE_MEMBER_TOKEN", raising=False)
+        monkeypatch.setenv("ANTE_TOKEN_FILE", str(token_file))
+        assert _resolve_token() == "ante_token_abc123"
+
+    def test_missing_token_file_returns_empty(self, tmp_path, monkeypatch):
+        """토큰 파일이 없으면 빈 문자열을 반환한다."""
+        monkeypatch.delenv("ANTE_MEMBER_TOKEN", raising=False)
+        monkeypatch.setenv("ANTE_TOKEN_FILE", str(tmp_path / "nonexistent"))
+        assert _resolve_token() == ""


### PR DESCRIPTION
## Summary
- `qa-entrypoint.sh`에서 부트스트랩한 토큰을 `/run/ante-token` 파일로도 저장하여 `docker exec` 환경에서 CLI가 토큰을 읽을 수 있도록 함
- CLI 미들웨어에 `_resolve_token()` 함수를 추가하여 환경변수 -> 토큰 파일 순서로 폴백
- `ANTE_TOKEN_FILE` 환경변수로 토큰 파일 경로 커스텀 가능 (기본: `/run/ante-token`)

## Test plan
- [x] `_resolve_token` 단위 테스트 5건 통과 (환경변수 우선, 파일 폴백, 공백 제거, 파일 미존재)
- [x] 기존 CLI 인증 테스트 9건 회귀 없음
- [ ] QA 환경에서 `docker exec ante-qa ante bot list` 인증 오류 없이 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)