### PR TITLE
fix(tc): treasury TC credentials 404 수정 및 allocation 정리 Refs #855

### DIFF
--- a/tests/tc/treasury/allocation.feature
+++ b/tests/tc/treasury/allocation.feature
@@ -5,6 +5,14 @@ Feature: Treasury 예산 할당·회수
     Given ante-qa 컨테이너가 실행 중이다
     And QA Admin 인증 토큰이 확보되어 있다
 
+  # ── 환경 정리: 이전 실행 잔여 할당 회수 ──
+
+  Scenario: 기존 할당 정리
+    When POST /api/treasury/bots/qa-alloc-bot-01/deallocate 요청:
+      | field  | value     |
+      | amount | 999999999 |
+    Then 응답 상태는 200 또는 응답 상태는 404
+
   # ── 사전 준비: 계좌 + 잔고 + 전략 확보 + 봇 생성 ──
 
   Scenario: 할당 테스트용 계좌 생성 (API)
@@ -19,6 +27,7 @@ Feature: Treasury 예산 할당·회수
       | trading_hours_end   | 15:30                  |
       | trading_mode        | virtual                |
       | broker_type         | test                   |
+      | credentials         | {"app_key": "test", "app_secret": "test"} |
     Then 응답 상태는 201 또는 응답 상태는 409
     And 응답 body.account.account_id 를 {account_id}로 저장한다
 

--- a/tests/tc/treasury/balance.feature
+++ b/tests/tc/treasury/balance.feature
@@ -19,7 +19,8 @@ Feature: Treasury 잔고 관리
       | trading_hours_end   | 15:30                |
       | trading_mode        | virtual              |
       | broker_type         | test                 |
-    Then 응답 상태는 201
+      | credentials         | {"app_key": "test", "app_secret": "test"} |
+    Then 응답 상태는 201 또는 응답 상태는 409
     And 응답 body.account.account_id 를 {account_id}로 저장한다
 
   # ── 정상 흐름: 잔고 조회 및 설정 ──


### PR DESCRIPTION
## Summary
- **balance.feature**: 계좌 생성 시 `credentials` 필드를 포함하여 별도 credentials API 호출 불필요. 응답 검증을 `201 또는 409`로 변경하여 재실행 시에도 정상 동작.
- **allocation.feature**: 동일하게 `credentials` 필드 추가. 시작 부분에 "기존 할당 정리" Scenario를 추가하여 이전 실행의 잔여 할당을 회수, 연속 실행 시 누적 문제 해결.

## Test plan
- [ ] balance.feature 연속 2회 실행 시 credentials 관련 404 없이 PASS
- [ ] allocation.feature 연속 2회 실행 시 할당 누적 없이 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)