### PR TITLE
feat(dashboard): 봇 관리 실행 설정·수정·삭제 API 연동 (Phase 3b)

### DIFF
--- a/frontend/src/api/bots.ts
+++ b/frontend/src/api/bots.ts
@@ -1,12 +1,26 @@
 import client from './client'
-import type { Bot, BotDetail, BotCreateRequest } from '../types/bot'
+import type { Bot, BotDetail, BotCreateRequest, BotUpdateRequest, HandlePositions } from '../types/bot'
 
 function mapBot(raw: Record<string, unknown>): Bot {
-  return {
+  const mapped: Record<string, unknown> = {
     ...raw,
     strategy_name: raw.strategy_name ?? raw.strategy_id,
     mode: raw.mode ?? raw.bot_type,
-  } as Bot
+  }
+
+  // config 블록이 없으면 flat 필드에서 조립
+  if (!mapped.config && raw.auto_restart !== undefined) {
+    mapped.config = {
+      interval_seconds: raw.interval_seconds as number,
+      auto_restart: raw.auto_restart as boolean,
+      max_restart_attempts: raw.max_restart_attempts as number,
+      restart_cooldown_seconds: raw.restart_cooldown_seconds as number,
+      step_timeout_seconds: raw.step_timeout_seconds as number,
+      max_signals_per_step: raw.max_signals_per_step as number,
+    }
+  }
+
+  return mapped as unknown as Bot
 }
 
 export async function getBots(): Promise<{ items: Bot[] }> {
@@ -34,6 +48,14 @@ export async function stopBot(botId: string): Promise<void> {
   await client.post(`/api/bots/${botId}/stop`)
 }
 
-export async function deleteBot(botId: string): Promise<void> {
-  await client.delete(`/api/bots/${botId}`)
+export async function updateBot(botId: string, data: BotUpdateRequest): Promise<BotDetail> {
+  const res = await client.put(`/api/bots/${botId}`, data)
+  const raw = res.data.bot ?? res.data
+  return mapBot(raw) as BotDetail
+}
+
+export async function deleteBot(botId: string, handlePositions?: HandlePositions): Promise<void> {
+  await client.delete(`/api/bots/${botId}`, {
+    params: handlePositions ? { handle_positions: handlePositions } : undefined,
+  })
 }

--- a/frontend/src/hooks/useBots.ts
+++ b/frontend/src/hooks/useBots.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getBots, getBotDetail, createBot, startBot, stopBot, deleteBot } from '../api/bots'
-import type { BotCreateRequest } from '../types/bot'
+import { getBots, getBotDetail, createBot, updateBot, startBot, stopBot, deleteBot } from '../api/bots'
+import type { BotCreateRequest, BotUpdateRequest, HandlePositions } from '../types/bot'
 
 export function useBots() {
   return useQuery({
@@ -25,6 +25,17 @@ export function useCreateBot() {
   })
 }
 
+export function useBotUpdate() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ botId, data }: { botId: string; data: BotUpdateRequest }) => updateBot(botId, data),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['bots', variables.botId] })
+      queryClient.invalidateQueries({ queryKey: ['bots'] })
+    },
+  })
+}
+
 export function useBotControl() {
   const queryClient = useQueryClient()
   return {
@@ -37,7 +48,8 @@ export function useBotControl() {
       onSuccess: () => queryClient.invalidateQueries({ queryKey: ['bots'] }),
     }),
     remove: useMutation({
-      mutationFn: deleteBot,
+      mutationFn: ({ botId, handlePositions }: { botId: string; handlePositions?: HandlePositions }) =>
+        deleteBot(botId, handlePositions),
       onSuccess: () => queryClient.invalidateQueries({ queryKey: ['bots'] }),
     }),
   }

--- a/frontend/src/pages/BotDetail.tsx
+++ b/frontend/src/pages/BotDetail.tsx
@@ -1,14 +1,16 @@
 import { useState } from 'react'
-import { useParams, Link } from 'react-router-dom'
-import { useBotDetail, useBotControl } from '../hooks/useBots'
+import { useParams, Link, useNavigate } from 'react-router-dom'
+import { useBotDetail, useBotControl, useBotUpdate } from '../hooks/useBots'
 import { useStrategies } from '../hooks/useStrategies'
 import { useTreasurySummary } from '../hooks/useTreasury'
 import StatusBadge from '../components/common/StatusBadge'
+import HintTooltip from '../components/common/HintTooltip'
 import { PageSkeleton } from '../components/common/Skeleton'
 import BotStopModal from '../components/bots/BotStopModal'
+import BotDeleteModal from '../components/bots/BotDeleteModal'
 import { formatKRW, formatDateTime, formatPercent } from '../utils/formatters'
 import { BOT_STATUS_LABELS } from '../utils/constants'
-import type { BotStatus, BotDetail as BotDetailType, BotLogResult } from '../types/bot'
+import type { BotStatus, BotDetail as BotDetailType, BotLogResult, HandlePositions } from '../types/bot'
 
 const STATUS_VARIANT: Record<BotStatus, string> = {
   created: 'muted', running: 'positive', stopping: 'warning', stopped: 'warning', error: 'negative', deleted: 'muted',
@@ -16,10 +18,12 @@ const STATUS_VARIANT: Record<BotStatus, string> = {
 
 export default function BotDetail() {
   const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
   const { data: bot, isLoading } = useBotDetail(id!)
-  const { start, stop } = useBotControl()
+  const { start, stop, remove } = useBotControl()
   const [showEditModal, setShowEditModal] = useState(false)
   const [showStopModal, setShowStopModal] = useState(false)
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
 
   if (isLoading) return <PageSkeleton />
   if (!bot) return <div className="text-text-muted text-center py-12">봇을 찾을 수 없습니다</div>
@@ -45,6 +49,9 @@ export default function BotDetail() {
           </h2>
         </div>
         <div className="flex gap-2">
+          {canEdit && (
+            <button onClick={() => setShowDeleteModal(true)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-negative border border-negative cursor-pointer hover:bg-negative-bg">삭제</button>
+          )}
           {canEdit && (
             <button onClick={() => setShowEditModal(true)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">설정 수정</button>
           )}
@@ -73,7 +80,12 @@ export default function BotDetail() {
             </div>
             <div className="flex justify-between py-1.5 text-[13px]">
               <span className="text-text-muted">작성자</span>
-              <span>{bot.strategy?.author || '-'}</span>
+              <span>
+                {bot.strategy_author_name || bot.strategy?.author || '-'}
+                {bot.strategy_author_id && (
+                  <span className="text-text-muted text-[12px] ml-1">({bot.strategy_author_id})</span>
+                )}
+              </span>
             </div>
             <div className="flex justify-between py-1.5 text-[13px]">
               <span className="text-text-muted">설명</span>
@@ -94,7 +106,31 @@ export default function BotDetail() {
             </div>
             <div className="flex justify-between py-1.5 text-[13px]">
               <span className="text-text-muted">실행 간격</span>
-              <span>{bot.interval_seconds}초</span>
+              <span>{bot.config?.interval_seconds ?? bot.interval_seconds}초</span>
+            </div>
+            <div className="flex justify-between py-1.5 text-[13px]">
+              <span className="text-text-muted">자동 재시작</span>
+              {bot.config ? (
+                <StatusBadge variant={bot.config.auto_restart ? 'positive' : 'muted'}>
+                  {bot.config.auto_restart ? 'ON' : 'OFF'}
+                </StatusBadge>
+              ) : <span>-</span>}
+            </div>
+            <div className="flex justify-between py-1.5 text-[13px]">
+              <span className="text-text-muted">최대 재시작</span>
+              <span>{bot.config ? `${bot.config.max_restart_attempts}회` : '-'}</span>
+            </div>
+            <div className="flex justify-between py-1.5 text-[13px]">
+              <span className="text-text-muted flex items-center">재시작 쿨다운<HintTooltip text="재시작 시도 사이의 대기 시간" /></span>
+              <span>{bot.config ? `${bot.config.restart_cooldown_seconds}초` : '-'}</span>
+            </div>
+            <div className="flex justify-between py-1.5 text-[13px]">
+              <span className="text-text-muted flex items-center">스텝 타임아웃<HintTooltip text="전략의 1회 실행(on_step)이 이 시간을 초과하면 경고" /></span>
+              <span>{bot.config ? `${bot.config.step_timeout_seconds}초` : '-'}</span>
+            </div>
+            <div className="flex justify-between py-1.5 text-[13px]">
+              <span className="text-text-muted flex items-center">스텝당 최대 시그널<HintTooltip text="전략의 1회 실행에서 발생할 수 있는 매매 신호 수 상한" /></span>
+              <span>{bot.config?.max_signals_per_step ?? '-'}</span>
             </div>
           </div>
         </div>
@@ -219,6 +255,22 @@ export default function BotDetail() {
         />
       )}
 
+      {/* 삭제 확인 모달 */}
+      {showDeleteModal && (
+        <BotDeleteModal
+          bot={bot}
+          onConfirm={(option) => {
+            const handlePositions: HandlePositions | undefined = option === 'force_liquidate' ? 'liquidate' : option === 'keep' ? 'keep' : undefined
+            remove.mutate(
+              { botId: bot.bot_id, handlePositions },
+              { onSuccess: () => navigate('/bots') },
+            )
+          }}
+          onClose={() => setShowDeleteModal(false)}
+          isPending={remove.isPending}
+        />
+      )}
+
       {/* 설정 수정 모달 */}
       {showEditModal && <BotEditModal bot={bot} onClose={() => setShowEditModal(false)} />}
     </>
@@ -228,17 +280,44 @@ export default function BotDetail() {
 function BotEditModal({ bot, onClose }: { bot: BotDetailType; onClose: () => void }) {
   const { data: strategies } = useStrategies()
   const { data: treasury } = useTreasurySummary()
+  const updateMutation = useBotUpdate()
   const [name, setName] = useState(bot.name || '')
   const [strategyName, setStrategyName] = useState(bot.strategy_name || '')
-  const [intervalSeconds, setIntervalSeconds] = useState(bot.interval_seconds)
+  const [intervalSeconds, setIntervalSeconds] = useState(bot.config?.interval_seconds ?? bot.interval_seconds)
   const [budget, setBudget] = useState(bot.allocated_budget)
+  const [autoRestart, setAutoRestart] = useState(bot.config?.auto_restart ?? true)
+  const [maxRestartAttempts, setMaxRestartAttempts] = useState(bot.config?.max_restart_attempts ?? 3)
+  const [restartCooldownSeconds, setRestartCooldownSeconds] = useState(bot.config?.restart_cooldown_seconds ?? 60)
+  const [stepTimeoutSeconds, setStepTimeoutSeconds] = useState(bot.config?.step_timeout_seconds ?? 30)
+  const [maxSignalsPerStep, setMaxSignalsPerStep] = useState(bot.config?.max_signals_per_step ?? 50)
 
   const currentBudget = bot.allocated_budget
   const maxPossible = treasury ? currentBudget + treasury.unallocated : currentBudget
 
+  const handleSave = () => {
+    updateMutation.mutate(
+      {
+        botId: bot.bot_id,
+        data: {
+          name,
+          interval_seconds: intervalSeconds,
+          budget,
+          auto_restart: autoRestart,
+          max_restart_attempts: maxRestartAttempts,
+          restart_cooldown_seconds: restartCooldownSeconds,
+          step_timeout_seconds: stepTimeoutSeconds,
+          max_signals_per_step: maxSignalsPerStep,
+        },
+      },
+      { onSuccess: () => onClose() },
+    )
+  }
+
+  const inputClass = 'w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary'
+
   return (
-    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
-      <div className="bg-surface border border-border rounded-lg p-6 w-[480px] max-h-[90vh] overflow-y-auto">
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]" onClick={onClose}>
+      <div className="bg-surface border border-border rounded-lg p-6 w-[480px] max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
         <h2 className="text-[18px] font-bold mb-5">Bot 설정 수정</h2>
         <div className="space-y-4">
           {/* Bot ID (읽기 전용) */}
@@ -259,7 +338,7 @@ function BotEditModal({ bot, onClose }: { bot: BotDetailType; onClose: () => voi
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary"
+              className={inputClass}
             />
           </div>
 
@@ -269,7 +348,7 @@ function BotEditModal({ bot, onClose }: { bot: BotDetailType; onClose: () => voi
             <select
               value={strategyName}
               onChange={(e) => setStrategyName(e.target.value)}
-              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary"
+              className={inputClass}
             >
               <option value="">전략을 선택하세요</option>
               {(strategies ?? []).map((s) => (
@@ -287,7 +366,7 @@ function BotEditModal({ bot, onClose }: { bot: BotDetailType; onClose: () => voi
               onChange={(e) => setIntervalSeconds(Number(e.target.value))}
               min={10}
               max={3600}
-              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary"
+              className={inputClass}
             />
             <div className="text-[11px] text-text-muted mt-1">최소 10초 ~ 최대 3,600초 (1시간)</div>
           </div>
@@ -299,16 +378,101 @@ function BotEditModal({ bot, onClose }: { bot: BotDetailType; onClose: () => voi
               type="number"
               value={budget}
               onChange={(e) => setBudget(Number(e.target.value))}
-              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary"
+              className={inputClass}
             />
             <div className="text-[11px] text-text-muted mt-1">
               현재 배정예산: {formatKRW(currentBudget)} · 최대 가능: {formatKRW(maxPossible)}
             </div>
           </div>
+
+          {/* 자동 재시작 */}
+          <div>
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">자동 재시작</label>
+            <button
+              type="button"
+              onClick={() => setAutoRestart(!autoRestart)}
+              className={`px-4 py-2.5 rounded-lg text-[14px] font-medium border cursor-pointer w-full text-left ${
+                autoRestart
+                  ? 'bg-positive-bg text-positive border-positive/25'
+                  : 'bg-bg text-text-muted border-border'
+              }`}
+            >
+              {autoRestart ? 'ON' : 'OFF'}
+            </button>
+          </div>
+
+          {/* 최대 재시작 횟수 */}
+          <div>
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">최대 재시작 횟수</label>
+            <input
+              type="number"
+              value={maxRestartAttempts}
+              onChange={(e) => setMaxRestartAttempts(Number(e.target.value))}
+              min={1}
+              max={10}
+              className={inputClass}
+            />
+            <div className="text-[11px] text-text-muted mt-1">1~10회</div>
+          </div>
+
+          {/* 재시작 쿨다운 */}
+          <div>
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5 flex items-center">
+              재시작 쿨다운 (초)<HintTooltip text="재시작 시도 사이의 대기 시간" />
+            </label>
+            <input
+              type="number"
+              value={restartCooldownSeconds}
+              onChange={(e) => setRestartCooldownSeconds(Number(e.target.value))}
+              min={10}
+              max={600}
+              className={inputClass}
+            />
+            <div className="text-[11px] text-text-muted mt-1">10~600초</div>
+          </div>
+
+          {/* 스텝 타임아웃 */}
+          <div>
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5 flex items-center">
+              스텝 타임아웃 (초)<HintTooltip text="전략의 1회 실행(on_step)이 이 시간을 초과하면 경고" />
+            </label>
+            <input
+              type="number"
+              value={stepTimeoutSeconds}
+              onChange={(e) => setStepTimeoutSeconds(Number(e.target.value))}
+              min={5}
+              max={120}
+              className={inputClass}
+            />
+            <div className="text-[11px] text-text-muted mt-1">5~120초</div>
+          </div>
+
+          {/* 스텝당 최대 시그널 */}
+          <div>
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5 flex items-center">
+              스텝당 최대 시그널<HintTooltip text="전략의 1회 실행에서 발생할 수 있는 매매 신호 수 상한" />
+            </label>
+            <input
+              type="number"
+              value={maxSignalsPerStep}
+              onChange={(e) => setMaxSignalsPerStep(Number(e.target.value))}
+              min={1}
+              max={200}
+              className={inputClass}
+            />
+            <div className="text-[11px] text-text-muted mt-1">1~200</div>
+          </div>
         </div>
         <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
           <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
-          <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">저장</button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={updateMutation.isPending}
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50"
+          >
+            {updateMutation.isPending ? '저장 중...' : '저장'}
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/types/bot.ts
+++ b/frontend/src/types/bot.ts
@@ -19,6 +19,15 @@ export interface Bot {
   created_at: string
 }
 
+export interface BotConfig {
+  interval_seconds: number
+  auto_restart: boolean
+  max_restart_attempts: number
+  restart_cooldown_seconds: number
+  step_timeout_seconds: number
+  max_signals_per_step: number
+}
+
 export interface BotStrategy {
   name: string
   version: string
@@ -47,6 +56,9 @@ export interface BotDetail extends Bot {
   allocated_budget: number
   logs: BotLog[]
   strategy?: BotStrategy
+  strategy_author_name?: string
+  strategy_author_id?: string
+  config?: BotConfig
   budget?: BotBudgetDetail
   positions?: BotPosition[]
 }
@@ -68,3 +80,16 @@ export interface BotCreateRequest {
   budget: number
   symbols: string[]
 }
+
+export interface BotUpdateRequest {
+  name?: string
+  interval_seconds?: number
+  budget?: number
+  auto_restart?: boolean
+  max_restart_attempts?: number
+  restart_cooldown_seconds?: number
+  step_timeout_seconds?: number
+  max_signals_per_step?: number
+}
+
+export type HandlePositions = 'keep' | 'liquidate'


### PR DESCRIPTION
## Summary
- **3-13**: `BotConfig` 인터페이스 + `strategy_author_name`, `strategy_author_id` 필드를 `BotDetail` 타입에 추가
- **3-5**: 실행 설정 카드에 7개 필드(상태, 실행 간격, 자동 재시작, 최대 재시작, 재시작 쿨다운, 스텝 타임아웃, 스텝당 최대 시그널) 표시 + HintTooltip 적용
- **3-6**: 운용 전략 카드 작성자 영역에 `strategy_author_name` + `strategy_author_id` 표시
- **3-9**: 봇 설정 수정 폼에 config 5개 필드(자동 재시작, 최대 재시작 횟수, 재시작 쿨다운, 스텝 타임아웃, 스텝당 최대 시그널) 추가 + `useBotUpdate` 뮤테이션 연동 (PUT /api/bots/:id)
- **3-11**: `deleteBot` API에 `handle_positions` 쿼리파라미터 전달 + 삭제 후 봇 목록으로 이동

## Test plan
- [ ] 봇 상세 페이지에서 실행 설정 카드 7개 필드가 표시되는지 확인
- [ ] HintTooltip이 재시작 쿨다운, 스텝 타임아웃, 스텝당 최대 시그널 필드에 표시되는지 확인
- [ ] 작성자 영역에 이름 + ID가 표시되는지 확인
- [ ] 봇 설정 수정 폼에서 config 필드 변경 후 저장 시 API 호출 확인
- [ ] 봇 삭제 시 handle_positions 옵션이 API 쿼리파라미터로 전달되는지 확인
- [ ] `npm run build` 통과 확인

Refs #835

🤖 Generated with [Claude Code](https://claude.com/claude-code)