### PR TITLE
feat(dashboard): 전략과 성과 Phase 4b — 차트·성과·필터·상태 전환

### DIFF
--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -39,6 +39,13 @@ export async function getStrategyMonthlySummary(id: string): Promise<MonthlySumm
   return res.data.items
 }
 
+export async function updateStrategyStatus(
+  id: string,
+  status: string,
+): Promise<void> {
+  await client.patch(`/api/strategies/${id}/status`, { status })
+}
+
 export async function getStrategyTradesPaginated(
   id: string,
   params?: { offset?: number; limit?: number; side?: string; start_date?: string; end_date?: string },

--- a/frontend/src/components/charts/EquityCurveChart.tsx
+++ b/frontend/src/components/charts/EquityCurveChart.tsx
@@ -1,0 +1,53 @@
+import { useCallback } from 'react'
+import { AreaSeries, type IChartApi } from 'lightweight-charts'
+import LightweightChart from './LightweightChart'
+
+export interface EquityDataPoint {
+  date: string
+  value: number
+}
+
+interface EquityCurveChartProps {
+  data: EquityDataPoint[]
+  className?: string
+}
+
+export default function EquityCurveChart({ data, className }: EquityCurveChartProps) {
+  const handleChartReady = useCallback(
+    (chart: IChartApi) => {
+      const areaSeries = chart.addSeries(AreaSeries, {
+        lineColor: '#1E8EFF',
+        topColor: 'rgba(30, 142, 255, 0.28)',
+        bottomColor: 'rgba(30, 142, 255, 0.02)',
+        lineWidth: 2,
+        priceFormat: {
+          type: 'custom',
+          formatter: (price: number) => {
+            if (price >= 100_000_000) return `${(price / 100_000_000).toFixed(1)}억`
+            if (price >= 10_000) return `${(price / 10_000).toFixed(0)}만`
+            return price.toLocaleString()
+          },
+        },
+      })
+
+      const seriesData = data.map((d) => ({
+        time: d.date,
+        value: d.value,
+      }))
+
+      areaSeries.setData(seriesData as Parameters<typeof areaSeries.setData>[0])
+      chart.timeScale().fitContent()
+    },
+    [data],
+  )
+
+  if (data.length === 0) {
+    return (
+      <div className={`flex items-center justify-center text-[13px] text-text-muted ${className ?? 'h-[240px]'}`}>
+        아직 자산 추이 데이터가 없습니다
+      </div>
+    )
+  }
+
+  return <LightweightChart key={data.length} onChartReady={handleChartReady} className={className ?? 'h-[240px]'} />
+}

--- a/frontend/src/components/strategies/PerformancePanel.tsx
+++ b/frontend/src/components/strategies/PerformancePanel.tsx
@@ -11,7 +11,13 @@ interface StatItem {
   subColor?: string
 }
 
-export default function PerformancePanel({ perf }: { perf: StrategyPerformance | null | undefined }) {
+interface PerformancePanelProps {
+  perf: StrategyPerformance | null | undefined
+  budgetAllocated?: number
+  unrealizedPnl?: number
+}
+
+export default function PerformancePanel({ perf, budgetAllocated, unrealizedPnl }: PerformancePanelProps) {
   const isEmpty = !perf || perf.total_trades === 0
 
   if (isEmpty) {
@@ -26,12 +32,18 @@ export default function PerformancePanel({ perf }: { perf: StrategyPerformance |
     )
   }
 
-  const netPnl = perf.net_pnl ?? perf.total_pnl ?? 0
+  const totalPnl = perf.total_pnl ?? 0
+  const resolvedUnrealizedPnl = unrealizedPnl ?? perf.unrealized_pnl ?? 0
+  const netPnl = totalPnl + resolvedUnrealizedPnl
   const totalCommission = perf.total_commission ?? 0
   const avgProfit = perf.avg_profit ?? perf.avg_pnl ?? 0
   const avgLoss = perf.avg_loss ?? 0
-  const realizedPnl = perf.realized_pnl ?? 0
+  const realizedPnl = perf.realized_pnl ?? totalPnl
   const activeDays = perf.active_days ?? 0
+  const resolvedBudget = budgetAllocated ?? perf.budget_allocated ?? 0
+
+  // 순손익 수익률: (total_pnl + unrealized_pnl) / budget.allocated * 100
+  const netReturnPct = resolvedBudget > 0 ? (netPnl / resolvedBudget) : null
 
   const row1: StatItem[] = [
     {
@@ -39,7 +51,7 @@ export default function PerformancePanel({ perf }: { perf: StrategyPerformance |
       value: formatKRW(netPnl),
       hint: '실현 손익 + 미실현 손익의 합계',
       color: netPnl >= 0 ? 'text-positive' : 'text-negative',
-      sub: netPnl !== 0 ? `(${netPnl >= 0 ? '+' : ''}${formatPercent(perf.win_rate).replace(/^[+-]/, netPnl >= 0 ? '+' : '-')})` : undefined,
+      sub: netReturnPct != null ? `(${netReturnPct >= 0 ? '+' : ''}${(netReturnPct * 100).toFixed(2)}%)` : undefined,
       subColor: netPnl >= 0 ? 'text-positive' : 'text-negative',
     },
     { label: '총 거래 수', value: formatNumber(perf.total_trades), hint: '전체 거래 횟수' },
@@ -65,7 +77,12 @@ export default function PerformancePanel({ perf }: { perf: StrategyPerformance |
     { label: '평균 수익', value: formatKRW(avgProfit), hint: '수익 거래의 평균 이익 금액', color: 'text-positive' },
     { label: '평균 손실', value: formatKRW(avgLoss), hint: '손실 거래의 평균 손실 금액', color: 'text-negative' },
     { label: '실현 손익', value: formatKRW(realizedPnl), hint: '매도 완료된 거래의 확정 손익', color: realizedPnl >= 0 ? 'text-positive' : 'text-negative' },
-    { label: '미실현 손익', value: '-', hint: '보유 중인 종목의 평가 손익 (미확정)' },
+    {
+      label: '미실현 손익',
+      value: resolvedUnrealizedPnl !== 0 ? formatKRW(resolvedUnrealizedPnl) : '-',
+      hint: '보유 중인 종목의 평가 손익 (미확정)',
+      color: resolvedUnrealizedPnl > 0 ? 'text-positive' : resolvedUnrealizedPnl < 0 ? 'text-negative' : undefined,
+    },
   ]
 
   return (

--- a/frontend/src/components/strategies/StrategyTable.tsx
+++ b/frontend/src/components/strategies/StrategyTable.tsx
@@ -23,11 +23,12 @@ export default function StrategyTable({ items }: { items: Strategy[] }) {
             <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">상태</th>
             <th className="text-left px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">실행 봇</th>
             <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">누적 수익률</th>
+            <th className="text-right px-3 py-2.5 text-[12px] font-semibold text-text-muted border-b border-border">백테스트 수익률</th>
           </tr>
         </thead>
         <tbody>
           {items.length === 0 ? (
-            <tr><td colSpan={6} className="px-3 py-8 text-center text-text-muted text-[13px]">등록된 전략이 없습니다</td></tr>
+            <tr><td colSpan={7} className="px-3 py-8 text-center text-text-muted text-[13px]">등록된 전략이 없습니다</td></tr>
           ) : (
             items.map((s) => (
               <tr key={s.id} className="hover:bg-surface-hover">
@@ -56,6 +57,15 @@ export default function StrategyTable({ items }: { items: Strategy[] }) {
                   {s.cumulative_return != null ? (
                     <span className={`font-bold ${s.cumulative_return >= 0 ? 'text-positive' : 'text-negative'}`}>
                       {formatPercent(s.cumulative_return / 100)}
+                    </span>
+                  ) : (
+                    <span className="text-text-muted">-</span>
+                  )}
+                </td>
+                <td className="px-3 py-3 border-b border-border text-[13px] text-right">
+                  {s.backtest_return != null ? (
+                    <span className={s.backtest_return >= 0 ? 'text-positive' : 'text-negative'}>
+                      {formatPercent(s.backtest_return / 100)}
                     </span>
                   ) : (
                     <span className="text-text-muted">-</span>

--- a/frontend/src/hooks/useStrategies.ts
+++ b/frontend/src/hooks/useStrategies.ts
@@ -1,5 +1,6 @@
-import { useQuery } from '@tanstack/react-query'
-import { getStrategies, getStrategyDetail, getStrategyPerformance, getStrategyTrades, getStrategyDailySummary, getStrategyWeeklySummary, getStrategyMonthlySummary, getStrategyTradesPaginated } from '../api/strategies'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getStrategies, getStrategyDetail, getStrategyPerformance, getStrategyTrades, getStrategyDailySummary, getStrategyWeeklySummary, getStrategyMonthlySummary, getStrategyTradesPaginated, updateStrategyStatus } from '../api/strategies'
+import { showToast } from '../components/common/Toast'
 
 export function useStrategies(params?: { search?: string }) {
   return useQuery({
@@ -64,5 +65,22 @@ export function useStrategyTradesPaginated(
     queryKey: ['strategies', id, 'trades-paginated', params],
     queryFn: () => getStrategyTradesPaginated(id, params),
     enabled: !!id,
+  })
+}
+
+export function useStrategyStatusTransition() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, status }: { id: string; status: string }) =>
+      updateStrategyStatus(id, status),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['strategies'] })
+      queryClient.invalidateQueries({ queryKey: ['strategies', variables.id] })
+      showToast('전략 상태가 변경되었습니다.', 'success')
+    },
+    onError: () => {
+      showToast('전략 상태 변경에 실패했습니다.', 'error')
+    },
   })
 }

--- a/frontend/src/pages/Performance.tsx
+++ b/frontend/src/pages/Performance.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
-import { useStrategyPerformance, useStrategyDailySummary, useStrategyWeeklySummary, useStrategyMonthlySummary } from '../hooks/useStrategies'
+import { useStrategies, useStrategyPerformance, useStrategyDailySummary, useStrategyWeeklySummary, useStrategyMonthlySummary } from '../hooks/useStrategies'
 import { PageSkeleton } from '../components/common/Skeleton'
 import Pagination from '../components/common/Pagination'
 import { formatKRW, formatPercent } from '../utils/formatters'
@@ -21,8 +21,11 @@ function StatCard({ label, value, colorClass }: { label: string; value: string; 
   )
 }
 
-function DailyTable({ items, offset }: { items: DailySummary[]; offset: number }) {
-  const page = items.slice(offset, offset + DAILY_PAGE_SIZE)
+function DailyTable({ items, offset, startDate, endDate }: { items: DailySummary[]; offset: number; startDate: string; endDate: string }) {
+  let filtered = items
+  if (startDate) filtered = filtered.filter((d) => d.date >= startDate)
+  if (endDate) filtered = filtered.filter((d) => d.date <= endDate)
+  const page = filtered.slice(offset, offset + DAILY_PAGE_SIZE)
 
   if (page.length === 0) {
     return <div className="py-8 text-center text-text-muted text-[13px]">데이터가 없습니다</div>
@@ -56,8 +59,11 @@ function DailyTable({ items, offset }: { items: DailySummary[]; offset: number }
   )
 }
 
-function WeeklyTable({ items, offset }: { items: WeeklySummary[]; offset: number }) {
-  const page = items.slice(offset, offset + WEEKLY_PAGE_SIZE)
+function WeeklyTable({ items, offset, startDate, endDate }: { items: WeeklySummary[]; offset: number; startDate: string; endDate: string }) {
+  let filtered = items
+  if (startDate) filtered = filtered.filter((w) => w.week_end >= startDate)
+  if (endDate) filtered = filtered.filter((w) => w.week_start <= endDate)
+  const page = filtered.slice(offset, offset + WEEKLY_PAGE_SIZE)
 
   if (page.length === 0) {
     return <div className="py-8 text-center text-text-muted text-[13px]">데이터가 없습니다</div>
@@ -91,8 +97,17 @@ function WeeklyTable({ items, offset }: { items: WeeklySummary[]; offset: number
   )
 }
 
-function MonthlyTable({ items, offset }: { items: MonthlySummary[]; offset: number }) {
-  const page = items.slice(offset, offset + MONTHLY_PAGE_SIZE)
+function MonthlyTable({ items, offset, startDate, endDate }: { items: MonthlySummary[]; offset: number; startDate: string; endDate: string }) {
+  let filtered = items
+  if (startDate) {
+    const [sy, sm] = startDate.split('-').map(Number)
+    filtered = filtered.filter((m) => m.year > sy || (m.year === sy && m.month >= sm))
+  }
+  if (endDate) {
+    const [ey, em] = endDate.split('-').map(Number)
+    filtered = filtered.filter((m) => m.year < ey || (m.year === ey && m.month <= em))
+  }
+  const page = filtered.slice(offset, offset + MONTHLY_PAGE_SIZE)
 
   if (page.length === 0) {
     return <div className="py-8 text-center text-text-muted text-[13px]">데이터가 없습니다</div>
@@ -127,18 +142,27 @@ function MonthlyTable({ items, offset }: { items: MonthlySummary[]; offset: numb
 }
 
 export default function Performance() {
-  const { id = '' } = useParams<{ id: string }>()
+  const { id: routeId = '' } = useParams<{ id: string }>()
+  const [selectedStrategyId, setSelectedStrategyId] = useState(routeId)
+  const [strategySearch, setStrategySearch] = useState('')
   const [tab, setTab] = useState<PeriodTab>('monthly')
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [appliedStartDate, setAppliedStartDate] = useState('')
+  const [appliedEndDate, setAppliedEndDate] = useState('')
   const [dailyOffset, setDailyOffset] = useState(0)
   const [weeklyOffset, setWeeklyOffset] = useState(0)
   const [monthlyOffset, setMonthlyOffset] = useState(0)
 
-  const { data: performance, isLoading } = useStrategyPerformance(id)
-  const { data: dailyData } = useStrategyDailySummary(id)
-  const { data: weeklyData } = useStrategyWeeklySummary(id)
-  const { data: monthlyData } = useStrategyMonthlySummary(id)
+  const strategyId = selectedStrategyId || routeId
 
-  if (isLoading) return <PageSkeleton />
+  const { data: strategies } = useStrategies()
+  const { data: performance, isLoading } = useStrategyPerformance(strategyId)
+  const { data: dailyData } = useStrategyDailySummary(strategyId)
+  const { data: weeklyData } = useStrategyWeeklySummary(strategyId)
+  const { data: monthlyData } = useStrategyMonthlySummary(strategyId)
+
+  if (isLoading && !performance) return <PageSkeleton />
 
   const daily = (dailyData ?? []).slice().reverse()
   const weekly = (weeklyData ?? []).slice().reverse()
@@ -155,12 +179,29 @@ export default function Performance() {
   const winRate = performance?.win_rate ?? 0
   const profitFactor = performance?.profit_factor
 
+  const handleQuery = () => {
+    setAppliedStartDate(startDate)
+    setAppliedEndDate(endDate)
+    setDailyOffset(0)
+    setWeeklyOffset(0)
+    setMonthlyOffset(0)
+  }
+
+  const handleStrategySelect = (value: string) => {
+    setStrategySearch(value)
+    // find matching strategy by name
+    const match = (strategies ?? []).find((s) => s.name === value)
+    if (match) {
+      setSelectedStrategyId(String(match.id))
+    }
+  }
+
   return (
     <>
       {/* 헤더 */}
       <div className="flex items-center gap-3 mb-6">
         <Link
-          to={`/strategies/${id}`}
+          to={`/strategies/${strategyId}`}
           className="text-[13px] text-text-muted no-underline hover:text-text"
         >
           &larr; 전략 상세
@@ -171,6 +212,22 @@ export default function Performance() {
       {/* 필터 바 */}
       <div className="bg-surface border border-border rounded-lg p-5 mb-6">
         <div className="flex items-center gap-4 flex-wrap">
+          <div>
+            <label className="text-[12px] text-text-muted block mb-1">전략</label>
+            <input
+              type="text"
+              list="strategy-list"
+              value={strategySearch}
+              onChange={(e) => handleStrategySelect(e.target.value)}
+              placeholder="전략명 검색"
+              className="h-8 px-3 rounded-lg border border-border bg-bg text-[13px] text-text w-48 outline-none placeholder:text-text-muted focus:border-primary"
+            />
+            <datalist id="strategy-list">
+              {(strategies ?? []).map((s) => (
+                <option key={s.id} value={s.name} />
+              ))}
+            </datalist>
+          </div>
           <div>
             <label className="text-[12px] text-text-muted block mb-1">기간</label>
             <div className="flex gap-1 bg-bg rounded-lg p-0.5">
@@ -188,6 +245,32 @@ export default function Performance() {
                 </button>
               ))}
             </div>
+          </div>
+          <div>
+            <label className="text-[12px] text-text-muted block mb-1">시작일</label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="h-8 px-3 rounded-lg border border-border bg-bg text-[13px] text-text outline-none focus:border-primary"
+            />
+          </div>
+          <div>
+            <label className="text-[12px] text-text-muted block mb-1">종료일</label>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="h-8 px-3 rounded-lg border border-border bg-bg text-[13px] text-text outline-none focus:border-primary"
+            />
+          </div>
+          <div className="flex items-end">
+            <button
+              onClick={handleQuery}
+              className="h-8 px-4 rounded-lg bg-primary text-text text-[13px] font-medium border-none cursor-pointer hover:opacity-90 mt-4"
+            >
+              조회
+            </button>
           </div>
         </div>
       </div>
@@ -217,7 +300,7 @@ export default function Performance() {
 
         {tab === 'daily' && (
           <>
-            <DailyTable items={daily} offset={dailyOffset} />
+            <DailyTable items={daily} offset={dailyOffset} startDate={appliedStartDate} endDate={appliedEndDate} />
             {daily.length > DAILY_PAGE_SIZE && (
               <Pagination
                 total={daily.length}
@@ -231,7 +314,7 @@ export default function Performance() {
 
         {tab === 'weekly' && (
           <>
-            <WeeklyTable items={weekly} offset={weeklyOffset} />
+            <WeeklyTable items={weekly} offset={weeklyOffset} startDate={appliedStartDate} endDate={appliedEndDate} />
             {weekly.length > WEEKLY_PAGE_SIZE && (
               <Pagination
                 total={weekly.length}
@@ -245,7 +328,7 @@ export default function Performance() {
 
         {tab === 'monthly' && (
           <>
-            <MonthlyTable items={monthly} offset={monthlyOffset} />
+            <MonthlyTable items={monthly} offset={monthlyOffset} startDate={appliedStartDate} endDate={appliedEndDate} />
             {monthly.length > MONTHLY_PAGE_SIZE && (
               <Pagination
                 total={monthly.length}

--- a/frontend/src/pages/Strategies.tsx
+++ b/frontend/src/pages/Strategies.tsx
@@ -63,7 +63,7 @@ export default function Strategies() {
       </div>
       <div className="bg-surface border border-border rounded-lg p-5">
         {isLoading ? (
-          <TableSkeleton rows={15} cols={6} />
+          <TableSkeleton rows={15} cols={7} />
         ) : (
           <>
             <StrategyTable items={paged} />

--- a/frontend/src/pages/StrategyDetail.tsx
+++ b/frontend/src/pages/StrategyDetail.tsx
@@ -1,9 +1,11 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { useParams, Link } from 'react-router-dom'
-import { useStrategyDetail, useStrategyPerformance, useStrategyTrades, useStrategyDailySummary, useStrategyWeeklySummary, useStrategyMonthlySummary } from '../hooks/useStrategies'
+import { useStrategyDetail, useStrategyPerformance, useStrategyTrades, useStrategyDailySummary, useStrategyWeeklySummary, useStrategyMonthlySummary, useStrategyStatusTransition } from '../hooks/useStrategies'
 import PerformancePanel from '../components/strategies/PerformancePanel'
 import PeriodPerformance from '../components/strategies/PeriodPerformance'
+import EquityCurveChart from '../components/charts/EquityCurveChart'
 import StatusBadge from '../components/common/StatusBadge'
+import HintTooltip from '../components/common/HintTooltip'
 import { PageSkeleton } from '../components/common/Skeleton'
 import { formatNumber } from '../utils/formatters'
 import { STRATEGY_STATUS_LABELS } from '../utils/constants'
@@ -19,6 +21,16 @@ function isStrategyParam(v: unknown): v is StrategyParam {
   return typeof v === 'object' && v !== null && 'value' in v
 }
 
+function getPeriodDates(period: EquityCurvePeriod): { start?: Date } {
+  if (period === 'all') return {}
+  const now = new Date()
+  const start = new Date(now)
+  if (period === '1w') start.setDate(start.getDate() - 7)
+  else if (period === '1m') start.setMonth(start.getMonth() - 1)
+  else if (period === '3m') start.setMonth(start.getMonth() - 3)
+  return { start }
+}
+
 export default function StrategyDetail() {
   const { id = '' } = useParams<{ id: string }>()
   const [equityPeriod, setEquityPeriod] = useState<EquityCurvePeriod>('1m')
@@ -29,17 +41,44 @@ export default function StrategyDetail() {
   const { data: dailySummary } = useStrategyDailySummary(id)
   const { data: weeklySummary } = useStrategyWeeklySummary(id)
   const { data: monthlySummary } = useStrategyMonthlySummary(id)
+  const statusTransition = useStrategyStatusTransition()
+
+  const equityCurveData = useMemo(() => {
+    const raw = performance?.equity_curve ?? []
+    if (raw.length === 0) return []
+    const { start } = getPeriodDates(equityPeriod)
+    if (!start) return raw
+    const startStr = start.toISOString().slice(0, 10)
+    return raw.filter((p) => p.date >= startStr)
+  }, [performance?.equity_curve, equityPeriod])
 
   if (isLoading) return <PageSkeleton />
   if (!strategy) return <div className="text-text-muted text-center py-12">전략을 찾을 수 없습니다</div>
+
+  const status = strategy.status as StrategyStatus
+  const hasRunningBot = !!strategy.bot_id && strategy.bot_status === 'running'
+  const budgetAllocated = strategy.budget_allocated
+  const unrealizedPnl = strategy.unrealized_pnl
+
+  const handleStatusTransition = (newStatus: string) => {
+    statusTransition.mutate({ id, status: newStatus })
+  }
 
   return (
     <>
       {/* 전략 정보 헤더 */}
       <div className="mb-6">
-        <h2 className="text-[20px] font-bold">{strategy.name}</h2>
+        <div className="flex items-center justify-between">
+          <h2 className="text-[20px] font-bold">{strategy.name}</h2>
+          <StatusActionButtons
+            status={status}
+            hasRunningBot={hasRunningBot}
+            isPending={statusTransition.isPending}
+            onTransition={handleStatusTransition}
+          />
+        </div>
         <div className="flex gap-3 items-center mt-1">
-          <StatusBadge variant={(STATUS_VARIANT[strategy.status as StrategyStatus] ?? 'muted') as 'positive'}>
+          <StatusBadge variant={(STATUS_VARIANT[status] ?? 'muted') as 'positive'}>
             {STRATEGY_STATUS_LABELS[strategy.status]}
           </StatusBadge>
           <span className="text-text-muted text-[13px]">v{strategy.version}</span>
@@ -137,19 +176,15 @@ export default function StrategyDetail() {
             ))}
           </div>
         </div>
-        {!performance || performance.total_trades === 0 ? (
-          <div className="py-8 text-center text-text-muted text-[13px]">
-            아직 자산 추이 데이터가 없습니다
-          </div>
-        ) : (
-          <div className="h-[240px] bg-bg border border-dashed border-border rounded-lg flex items-center justify-center text-text-muted text-[13px]">
-            Equity Curve — 전략 자산 가치 변화
-          </div>
-        )}
+        <EquityCurveChart data={equityCurveData} className="h-[240px]" />
       </div>
 
       {/* 성과 지표 */}
-      <PerformancePanel perf={performance} />
+      <PerformancePanel
+        perf={performance}
+        budgetAllocated={budgetAllocated}
+        unrealizedPnl={unrealizedPnl}
+      />
 
       {/* 2열 그리드: 기간별 성과 + 최근 거래 */}
       <div className="grid grid-cols-2 gap-4">
@@ -229,4 +264,52 @@ function formatShortDateTime(dateStr: string | undefined | null): string {
   const hh = String(d.getHours()).padStart(2, '0')
   const min = String(d.getMinutes()).padStart(2, '0')
   return `${mm}-${dd} ${hh}:${min}`
+}
+
+/** 전략 상태별 액션 버튼 */
+function StatusActionButtons({
+  status,
+  hasRunningBot,
+  isPending,
+  onTransition,
+}: {
+  status: StrategyStatus
+  hasRunningBot: boolean
+  isPending: boolean
+  onTransition: (newStatus: string) => void
+}) {
+  if (status === 'archived') return null
+
+  if (status === 'active') {
+    const disabled = hasRunningBot || isPending
+    return (
+      <div className="relative">
+        <button
+          disabled={disabled}
+          onClick={() => onTransition('inactive')}
+          className={`px-3 py-1.5 rounded-lg border text-[12px] font-medium ${
+            disabled
+              ? 'border-border text-text-muted cursor-not-allowed opacity-50'
+              : 'border-warning text-warning cursor-pointer hover:bg-warning-bg'
+          }`}
+        >
+          비활성화
+        </button>
+        {hasRunningBot && (
+          <HintTooltip text="실행 중인 봇을 먼저 중지하세요" />
+        )}
+      </div>
+    )
+  }
+
+  // registered or inactive -> archive
+  return (
+    <button
+      disabled={isPending}
+      onClick={() => onTransition('archived')}
+      className="px-3 py-1.5 rounded-lg border border-border text-text-muted text-[12px] font-medium cursor-pointer hover:bg-surface-hover disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      보관
+    </button>
+  )
 }

--- a/frontend/src/pages/Trades.tsx
+++ b/frontend/src/pages/Trades.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
-import { useStrategyTradesPaginated } from '../hooks/useStrategies'
+import { useStrategies, useStrategyTradesPaginated } from '../hooks/useStrategies'
 import { PageSkeleton } from '../components/common/Skeleton'
 import StatusBadge from '../components/common/StatusBadge'
 import Pagination from '../components/common/Pagination'
@@ -9,14 +9,25 @@ import { formatKRW, formatDateTime } from '../utils/formatters'
 const PAGE_SIZE = 15
 
 export default function Trades() {
-  const { id = '' } = useParams<{ id: string }>()
+  const { id: routeId = '' } = useParams<{ id: string }>()
+  const [selectedStrategyId, setSelectedStrategyId] = useState(routeId)
+  const [strategySearch, setStrategySearch] = useState('')
   const [offset, setOffset] = useState(0)
   const [sideFilter, setSideFilter] = useState<string>('')
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [appliedStartDate, setAppliedStartDate] = useState('')
+  const [appliedEndDate, setAppliedEndDate] = useState('')
 
-  const { data, isLoading } = useStrategyTradesPaginated(id, {
+  const strategyId = selectedStrategyId || routeId
+
+  const { data: strategies } = useStrategies()
+  const { data, isLoading } = useStrategyTradesPaginated(strategyId, {
     offset,
     limit: PAGE_SIZE,
     side: sideFilter || undefined,
+    start_date: appliedStartDate || undefined,
+    end_date: appliedEndDate || undefined,
   })
 
   if (isLoading && !data) return <PageSkeleton />
@@ -24,12 +35,27 @@ export default function Trades() {
   const trades = data?.items ?? []
   const total = data?.total ?? 0
 
+  const handleQuery = () => {
+    setAppliedStartDate(startDate)
+    setAppliedEndDate(endDate)
+    setOffset(0)
+  }
+
+  const handleStrategySelect = (value: string) => {
+    setStrategySearch(value)
+    const match = (strategies ?? []).find((s) => s.name === value)
+    if (match) {
+      setSelectedStrategyId(String(match.id))
+      setOffset(0)
+    }
+  }
+
   return (
     <>
       {/* 헤더 */}
       <div className="flex items-center gap-3 mb-6">
         <Link
-          to={`/strategies/${id}`}
+          to={`/strategies/${strategyId}`}
           className="text-[13px] text-text-muted no-underline hover:text-text"
         >
           &larr; 전략 상세
@@ -40,6 +66,22 @@ export default function Trades() {
       {/* 필터 바 */}
       <div className="bg-surface border border-border rounded-lg p-5 mb-6">
         <div className="flex items-center gap-4 flex-wrap">
+          <div>
+            <label className="text-[12px] text-text-muted block mb-1">전략</label>
+            <input
+              type="text"
+              list="strategy-list-trades"
+              value={strategySearch}
+              onChange={(e) => handleStrategySelect(e.target.value)}
+              placeholder="전략명 검색"
+              className="h-8 px-3 rounded-lg border border-border bg-bg text-[13px] text-text w-48 outline-none placeholder:text-text-muted focus:border-primary"
+            />
+            <datalist id="strategy-list-trades">
+              {(strategies ?? []).map((s) => (
+                <option key={s.id} value={s.name} />
+              ))}
+            </datalist>
+          </div>
           <div>
             <label className="text-[12px] text-text-muted block mb-1">매매</label>
             <select
@@ -54,6 +96,32 @@ export default function Trades() {
               <option value="buy">매수</option>
               <option value="sell">매도</option>
             </select>
+          </div>
+          <div>
+            <label className="text-[12px] text-text-muted block mb-1">시작일</label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="h-8 px-3 rounded-lg border border-border bg-bg text-[13px] text-text outline-none focus:border-primary"
+            />
+          </div>
+          <div>
+            <label className="text-[12px] text-text-muted block mb-1">종료일</label>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="h-8 px-3 rounded-lg border border-border bg-bg text-[13px] text-text outline-none focus:border-primary"
+            />
+          </div>
+          <div className="flex items-end">
+            <button
+              onClick={handleQuery}
+              className="h-8 px-4 rounded-lg bg-primary text-text text-[13px] font-medium border-none cursor-pointer hover:opacity-90 mt-4"
+            >
+              조회
+            </button>
           </div>
         </div>
       </div>

--- a/frontend/src/types/strategy.ts
+++ b/frontend/src/types/strategy.ts
@@ -34,6 +34,8 @@ export interface Strategy {
   bot_id?: string | null
   bot_status?: string | null
   cumulative_return?: number
+  backtest_return?: number | null
+  budget_allocated?: number
   created_at?: string
 }
 
@@ -43,6 +45,8 @@ export interface StrategyDetail extends Strategy {
   rationale?: string
   risks?: string
   params?: Record<string, StrategyParam | unknown>
+  budget_allocated?: number
+  unrealized_pnl?: number
 }
 
 export interface StrategyParam {
@@ -72,6 +76,8 @@ export interface StrategyPerformance {
   sharpe_ratio: number | null
   active_days?: number
   realized_pnl?: number
+  unrealized_pnl?: number
+  budget_allocated?: number
   equity_curve: { date: string; value: number }[]
 }
 


### PR DESCRIPTION
## Summary
- 전략 목록에 백테스트 수익률 컬럼 추가 (4-1)
- EquityCurveChart 공용 컴포넌트 신설 — Lightweight Charts Area Series 기반 에쿼티 커브 차트 (4-5)
- PerformancePanel에서 unrealized_pnl 연동 및 순손익 수익률 계산 (4-6, 4-7)
- Performance.tsx, Trades.tsx에 전략 선택(datalist), 시작일/종료일, 조회 버튼 필터 보강 (4-9, 4-10)
- StrategyDetail 헤더에 상태별 액션 버튼(비활성화/보관) + 실행 중 봇 disabled 가드 + useStrategyStatusTransition 뮤테이션 훅 (4-11)

Refs #837

## Test plan
- [ ] 전략 목록에서 백테스트 수익률 컬럼이 표시되는지 확인 (미실행 시 `-`)
- [ ] 전략 상세에서 에쿼티 커브 차트가 기간별로 렌더링되는지 확인
- [ ] 성과 지표에 미실현 손익이 표시되고 순손익 수익률이 계산되는지 확인
- [ ] 기간별 성과 페이지에서 전략 선택, 날짜 필터, 조회 버튼이 동작하는지 확인
- [ ] 거래 내역 페이지에서 전략 선택, 날짜 필터, 조회 버튼이 동작하는지 확인
- [ ] ACTIVE 상태 전략에서 실행 중 봇 있으면 비활성화 버튼이 disabled되는지 확인
- [ ] REGISTERED/INACTIVE 상태에서 보관 버튼 클릭 시 상태 전환 API 호출되는지 확인
- [ ] `npm run build` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)