### PR TITLE
feat(dashboard): 리포트 상세 자산 커브 차트 연동

### DIFF
--- a/frontend/src/pages/ReportDetail.tsx
+++ b/frontend/src/pages/ReportDetail.tsx
@@ -2,6 +2,7 @@ import { useParams } from 'react-router-dom'
 import { useReportDetail } from '../hooks/useReports'
 import StatusBadge from '../components/common/StatusBadge'
 import { PageSkeleton } from '../components/common/Skeleton'
+import EquityCurveChart from '../components/charts/EquityCurveChart'
 import { formatDateTime } from '../utils/formatters'
 import type { ReportDetail as ReportDetailType, ReportStatus } from '../types/report'
 
@@ -164,12 +165,16 @@ export default function ReportDetail() {
         <PerformanceCard report={report} />
       </div>
 
-      {/* 3행: 자산 곡선 차트 (플레이스홀더) */}
+      {/* 3행: 자산 곡선 차트 */}
       <div className="bg-surface border border-border rounded-lg p-5 mb-6">
         <h3 className="text-[15px] font-semibold mb-3">자산 곡선</h3>
-        <div className="h-[240px] bg-bg-elevated rounded flex items-center justify-center text-text-muted text-[13px]">
-          equity_curve 차트 영역 (detail_json.equity_curve 데이터 기반)
-        </div>
+        {report.equity_curve && report.equity_curve.length > 0 ? (
+          <EquityCurveChart data={report.equity_curve} className="h-[240px]" />
+        ) : (
+          <div className="h-[240px] bg-bg-elevated rounded flex items-center justify-center text-text-muted text-[13px]">
+            자산 곡선 데이터가 없습니다
+          </div>
+        )}
       </div>
 
       {/* 4행: 전략 요약 | 리스크 분석 */}


### PR DESCRIPTION
## Summary
- 리포트 상세 페이지의 자산 곡선 플레이스홀더를 `EquityCurveChart` 컴포넌트로 교체
- `report.equity_curve` 데이터가 없으면 "자산 곡선 데이터가 없습니다" 안내 표시
- `npm run build` 통과 확인

Refs #838

## Test plan
- [ ] 리포트 상세 페이지에서 equity_curve 데이터가 있는 리포트의 자산 곡선 차트가 렌더링되는지 확인
- [ ] equity_curve가 빈 배열이거나 없는 리포트에서 "데이터 없음" 플레이스홀더가 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)