### PR TITLE
fix(trade): QA 시드 데이터 trade_id UUID 파싱 실패 수정 #865

### DIFF
--- a/scripts/qa_seed_datasets.py
+++ b/scripts/qa_seed_datasets.py
@@ -22,8 +22,18 @@ import argparse
 import logging
 import sqlite3
 from datetime import datetime, timedelta
+from uuid import UUID, uuid5
 
 logger = logging.getLogger(__name__)
+
+# QA 시드 데이터 전용 UUID 네임스페이스 (결정적 생성으로 멱등성 보장)
+_QA_NS = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+
+
+def _qa_trade_id(name: str) -> str:
+    """결정적 UUID5를 문자열로 반환한다."""
+    return str(uuid5(_QA_NS, name))
+
 
 # ---------------------------------------------------------------------------
 # 상수
@@ -64,7 +74,7 @@ def _trade_timestamp(day_offset: int, hour: int = 10, minute: int = 0) -> str:
 TRADES = [
     # bot-01: 삼성전자 매수 5건, 매도 2건
     (
-        "qa-trade-001",
+        _qa_trade_id("qa-trade-001"),
         "qa-test-bot-01",
         STRATEGY_IDS[0],
         "005930",
@@ -78,7 +88,7 @@ TRADES = [
         _trade_timestamp(0, 9, 30),
     ),
     (
-        "qa-trade-002",
+        _qa_trade_id("qa-trade-002"),
         "qa-test-bot-01",
         STRATEGY_IDS[0],
         "005930",
@@ -92,7 +102,7 @@ TRADES = [
         _trade_timestamp(1, 10, 0),
     ),
     (
-        "qa-trade-003",
+        _qa_trade_id("qa-trade-003"),
         "qa-test-bot-01",
         STRATEGY_IDS[0],
         "005930",
@@ -106,7 +116,7 @@ TRADES = [
         _trade_timestamp(3, 14, 0),
     ),
     (
-        "qa-trade-004",
+        _qa_trade_id("qa-trade-004"),
         "qa-test-bot-01",
         STRATEGY_IDS[0],
         "005930",
@@ -120,7 +130,7 @@ TRADES = [
         _trade_timestamp(5, 11, 30),
     ),
     (
-        "qa-trade-005",
+        _qa_trade_id("qa-trade-005"),
         "qa-test-bot-01",
         STRATEGY_IDS[0],
         "005930",
@@ -134,7 +144,7 @@ TRADES = [
         _trade_timestamp(7, 13, 0),
     ),
     (
-        "qa-trade-006",
+        _qa_trade_id("qa-trade-006"),
         "qa-test-bot-01",
         STRATEGY_IDS[0],
         "005930",
@@ -148,7 +158,7 @@ TRADES = [
         _trade_timestamp(9, 10, 30),
     ),
     (
-        "qa-trade-007",
+        _qa_trade_id("qa-trade-007"),
         "qa-test-bot-01",
         STRATEGY_IDS[0],
         "005930",
@@ -163,7 +173,7 @@ TRADES = [
     ),
     # bot-02: SK하이닉스 매수 3건, 매도 2건
     (
-        "qa-trade-008",
+        _qa_trade_id("qa-trade-008"),
         "qa-test-bot-02",
         STRATEGY_IDS[1],
         "000660",
@@ -177,7 +187,7 @@ TRADES = [
         _trade_timestamp(0, 10, 0),
     ),
     (
-        "qa-trade-009",
+        _qa_trade_id("qa-trade-009"),
         "qa-test-bot-02",
         STRATEGY_IDS[1],
         "000660",
@@ -191,7 +201,7 @@ TRADES = [
         _trade_timestamp(2, 14, 30),
     ),
     (
-        "qa-trade-010",
+        _qa_trade_id("qa-trade-010"),
         "qa-test-bot-02",
         STRATEGY_IDS[1],
         "000660",
@@ -205,7 +215,7 @@ TRADES = [
         _trade_timestamp(4, 11, 0),
     ),
     (
-        "qa-trade-011",
+        _qa_trade_id("qa-trade-011"),
         "qa-test-bot-02",
         STRATEGY_IDS[1],
         "000660",
@@ -219,7 +229,7 @@ TRADES = [
         _trade_timestamp(8, 13, 30),
     ),
     (
-        "qa-trade-012",
+        _qa_trade_id("qa-trade-012"),
         "qa-test-bot-02",
         STRATEGY_IDS[1],
         "000660",

--- a/src/ante/trade/performance.py
+++ b/src/ante/trade/performance.py
@@ -397,9 +397,16 @@ class PerformanceTracker:
         """DB row → TradeRecord."""
         from uuid import UUID
 
+        raw_id = row["trade_id"]
+        try:
+            trade_id = UUID(raw_id)
+        except (ValueError, AttributeError):
+            logger.warning("trade_id UUID 파싱 실패, 문자열 그대로 사용: %s", raw_id)
+            trade_id = raw_id  # type: ignore[assignment]
+
         ts = row.get("timestamp")
         return TradeRecord(
-            trade_id=UUID(row["trade_id"]),
+            trade_id=trade_id,
             bot_id=row["bot_id"],
             strategy_id=row["strategy_id"],
             symbol=row["symbol"],

--- a/src/ante/trade/recorder.py
+++ b/src/ante/trade/recorder.py
@@ -354,9 +354,16 @@ class TradeRecorder:
         """DB row → TradeRecord 변환."""
         from uuid import UUID as _UUID
 
+        raw_id = row["trade_id"]
+        try:
+            trade_id = _UUID(raw_id)
+        except (ValueError, AttributeError):
+            logger.warning("trade_id UUID 파싱 실패, 문자열 그대로 사용: %s", raw_id)
+            trade_id = raw_id  # type: ignore[assignment]
+
         ts = row.get("timestamp")
         return TradeRecord(
-            trade_id=_UUID(row["trade_id"]),
+            trade_id=trade_id,
             bot_id=row["bot_id"],
             strategy_id=row["strategy_id"],
             symbol=row["symbol"],

--- a/tests/unit/test_trade_id_uuid_parsing.py
+++ b/tests/unit/test_trade_id_uuid_parsing.py
@@ -1,0 +1,83 @@
+"""trade_id UUID 파싱 방어 코드 단위 테스트.
+
+_row_to_record()가 유효한 UUID뿐 아니라 비-UUID 문자열도
+에러 없이 처리하는지 검증한다. (Refs #865)
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from ante.trade.models import TradeStatus
+from ante.trade.recorder import TradeRecorder
+
+
+class TestRowToRecordUUIDParsing:
+    """TradeRecorder._row_to_record의 trade_id 파싱 테스트."""
+
+    @staticmethod
+    def _make_row(trade_id: str = "", **overrides: object) -> dict:
+        base = {
+            "trade_id": trade_id or str(uuid4()),
+            "bot_id": "test-bot",
+            "strategy_id": "test-strategy",
+            "symbol": "005930",
+            "side": "buy",
+            "quantity": 10,
+            "price": 70000,
+            "status": "filled",
+            "order_type": "market",
+            "reason": "",
+            "commission": 0.0,
+            "timestamp": "2026-03-20 10:00:00",
+            "order_id": None,
+            "account_id": "default",
+            "currency": "KRW",
+        }
+        base.update(overrides)
+        return base
+
+    def test_valid_uuid_parsed(self) -> None:
+        """유효한 UUID4 문자열은 UUID 객체로 변환된다."""
+        uid = uuid4()
+        row = self._make_row(trade_id=str(uid))
+        record = TradeRecorder._row_to_record(row)
+        assert isinstance(record.trade_id, UUID)
+        assert record.trade_id == uid
+
+    def test_invalid_uuid_falls_back_to_string(self) -> None:
+        """비-UUID 문자열은 에러 없이 문자열 그대로 반환된다."""
+        row = self._make_row(trade_id="qa-trade-001")
+        record = TradeRecorder._row_to_record(row)
+        assert record.trade_id == "qa-trade-001"
+
+    def test_uuid5_string_parsed(self) -> None:
+        """UUID5 형식 문자열도 정상 파싱된다."""
+        from uuid import UUID as _UUID
+        from uuid import uuid5
+
+        ns = _UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        uid = uuid5(ns, "qa-trade-001")
+        row = self._make_row(trade_id=str(uid))
+        record = TradeRecorder._row_to_record(row)
+        assert isinstance(record.trade_id, UUID)
+        assert record.trade_id == uid
+
+    def test_record_fields_correct(self) -> None:
+        """trade_id 외 다른 필드도 정상 매핑된다."""
+        row = self._make_row(
+            trade_id=str(uuid4()),
+            bot_id="my-bot",
+            symbol="000660",
+            side="sell",
+            quantity=5,
+            price=190000,
+            status="filled",
+        )
+        record = TradeRecorder._row_to_record(row)
+        assert record.bot_id == "my-bot"
+        assert record.symbol == "000660"
+        assert record.side == "sell"
+        assert record.quantity == 5.0
+        assert record.price == 190000.0
+        assert record.status == TradeStatus.FILLED


### PR DESCRIPTION
## Summary
- `scripts/qa_seed_datasets.py`의 trade_id를 비-UUID 문자열(`qa-trade-001`)에서 결정적 UUID5로 변경하여 멱등성 보장
- `src/ante/trade/recorder.py`, `src/ante/trade/performance.py`의 `_row_to_record()`에 UUID 파싱 실패 시 문자열 폴백 방어 코드 추가
- `_row_to_record()` UUID 파싱 방어 코드 단위 테스트 4건 추가

## Test plan
- [x] `tests/unit/test_trade_id_uuid_parsing.py` 4건 PASSED
- [ ] `tests/tc/trade/query.feature` QA 환경에서 재검증
- [ ] `tests/tc/strategy/registry.feature` 전략별 거래 내역 조회 재검증

Refs #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)