### PR TITLE
fix(qa): QA TC 환경 결함 5건 수정 Refs #866

### DIFF
--- a/config/secrets.env.example
+++ b/config/secrets.env.example
@@ -2,14 +2,21 @@
 # 이 파일을 config/secrets.env 로 복사하여 실제 값을 입력하세요.
 # 절대 git에 커밋하지 마세요. (.gitignore에 등록됨)
 
-# DB 암호화 키 (Fernet, python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())" 로 생성)
+# ─── 필수 ───────────────────────────────────────────────
+# DB 암호화 키 (Fernet)
+# 생성: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 ANTE_DB_ENCRYPTION_KEY=
 
-# KIS Open API
-KIS_APP_KEY=your_app_key_here
-KIS_APP_SECRET=your_app_secret_here
-KIS_ACCOUNT_NO=your_account_no_here  # 계좌번호 (8자리-2자리, 예: 12345678-90)
+# ─── KIS Open API (한국투자증권) ────────────────────────
+KIS_APP_KEY=
+KIS_APP_SECRET=
+KIS_ACCOUNT_NO=              # 계좌번호 (8자리-2자리, 예: 50172878-01)
 
-# Telegram 알림 (선택)
-# TELEGRAM_BOT_TOKEN=your_bot_token
-# TELEGRAM_CHAT_ID=your_chat_id
+# ─── Telegram 알림 ──────────────────────────────────────
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+
+# ─── DataFeed ───────────────────────────────────────────
+# 컨테이너 내에서 ante feed config set 으로 등록할 때 참조
+ANTE_DART_API_KEY=           # 금융감독원 DART OpenAPI 인증키
+ANTE_DATAGOKR_API_KEY=       # data.go.kr 공공데이터포털 서비스키

--- a/scripts/qa-entrypoint.sh
+++ b/scripts/qa-entrypoint.sh
@@ -52,7 +52,9 @@ if [ -n "$QA_TOKEN" ]; then
     # docker exec는 컨테이너의 환경변수를 상속하지 않으므로
     # 토큰을 파일로도 저장하여 CLI가 자동으로 읽을 수 있게 한다
     echo -n "$QA_TOKEN" > /run/ante-token
-    chmod 600 /run/ante-token
+    chmod 644 /run/ante-token
+    # docker exec에서 CLI가 토큰 파일을 찾을 수 있도록 환경변수 파일에도 기록
+    echo "ANTE_TOKEN_FILE=/run/ante-token" >> /etc/environment
     echo "[qa] ANTE_MEMBER_TOKEN 설정 완료 (환경변수 + /run/ante-token)"
 else
     echo "[qa] WARNING: ANTE_MEMBER_TOKEN 설정 실패" >&2
@@ -65,7 +67,7 @@ if [ "$ACCOUNT_COUNT" = "0" ]; then
     echo "[qa] 계좌 없음 — 시드 계좌 생성 중..."
     curl -sf -X POST http://localhost:8000/api/accounts \
         -H "Content-Type: application/json" \
-        -d '{"account_id":"test","name":"QA Test","broker_type":"test","trading_mode":"virtual"}' \
+        -d '{"account_id":"test","name":"QA Test","broker_type":"test","trading_mode":"virtual","credentials":{"app_key":"test","app_secret":"test"}}' \
         > /dev/null 2>&1 || true
 
     # 계좌 생성 후 서버 재기동하여 Treasury 초기화
@@ -94,8 +96,8 @@ fi
 echo "[qa] QA 전략 레지스트리 시딩..."
 python scripts/qa_seed_strategies.py --strategies-dir strategies --db-path db/ante.db
 
-echo "[qa] QA 데이터셋 시딩 (봇, 거래, 성과)..."
-python scripts/qa_seed_datasets.py --db-path db/ante.db
+echo "[qa] QA 데이터셋 시딩 (봇, 거래, 성과, Parquet)..."
+python scripts/qa_seed_datasets.py --db-path db/ante.db --data-path data/
 
 echo "[qa] QA 테스트용 동적 설정 시드 등록..."
 sqlite3 db/ante.db "INSERT OR IGNORE INTO dynamic_config (key, value, category, updated_at) VALUES ('risk.test_qa_key', '0', 'risk', datetime('now'));"

--- a/scripts/qa_seed_datasets.py
+++ b/scripts/qa_seed_datasets.py
@@ -423,6 +423,84 @@ def seed(db_path: str) -> None:
         conn.close()
 
 
+def seed_parquet(data_path: str = "data/") -> None:
+    """ParquetStore에 최소 OHLCV 데이터셋을 시딩한다.
+
+    dataset.feature TC에서 데이터셋 목록/상세 조회를 검증하려면
+    실제 Parquet 파일이 필요하다.
+    심볼 000001 (test 브로커 가상 종목), 타임프레임 1d, 30일분.
+    """
+    try:
+        import polars as pl
+    except ImportError:
+        logger.warning("polars 미설치 — Parquet 시딩 건너뜀")
+        return
+
+    from pathlib import Path
+
+    base = Path(data_path)
+    symbol = "000001"
+    timeframe = "1d"
+    exchange = "KRX"
+
+    # ohlcv/{timeframe}/{exchange}/{symbol}/ 구조
+    target_dir = base / "ohlcv" / timeframe / exchange / symbol
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    # 이미 파일이 있으면 건너뛴다
+    existing = list(target_dir.glob("*.parquet"))
+    if existing:
+        logger.info("Parquet 데이터셋 이미 존재 (%d개 파일) — 건너뜀", len(existing))
+        return
+
+    # 30일분 가상 OHLCV 생성
+    base_date = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    rows = []
+    base_price = 50000.0
+    for i in range(30):
+        dt = base_date - timedelta(days=29 - i)
+        # 약간의 변동 시뮬레이션
+        o = base_price + (i % 7 - 3) * 100
+        h = o + 500
+        low = o - 300
+        c = o + (i % 5 - 2) * 150
+        vol = 100000 + i * 5000
+        rows.append(
+            {
+                "timestamp": dt,
+                "open": o,
+                "high": h,
+                "low": low,
+                "close": c,
+                "volume": vol,
+            }
+        )
+
+    df = pl.DataFrame(rows)
+    # timestamp를 Datetime으로 변환
+    df = df.with_columns(pl.col("timestamp").cast(pl.Datetime("us")))
+
+    # 월별 파티셔닝 (단순히 파일 하나로 기록)
+    month_groups: dict[str, list[int]] = {}
+    for idx, row in enumerate(rows):
+        month_key = row["timestamp"].strftime("%Y-%m")
+        month_groups.setdefault(month_key, []).append(idx)
+
+    for month_key, indices in month_groups.items():
+        partition = df[indices]
+        filepath = target_dir / f"{month_key}.parquet"
+        partition.write_parquet(str(filepath))
+
+    logger.info(
+        "Parquet 데이터셋 시딩 완료: %s/%s/%s (%d행, %d파일)",
+        exchange,
+        symbol,
+        timeframe,
+        len(rows),
+        len(month_groups),
+    )
+
+
 def main() -> None:
     """CLI 진입점."""
     parser = argparse.ArgumentParser(description="QA 데이터셋 시딩")
@@ -432,6 +510,12 @@ def main() -> None:
         default="db/ante.db",
         help="SQLite DB 경로 (기본: db/ante.db)",
     )
+    parser.add_argument(
+        "--data-path",
+        type=str,
+        default="data/",
+        help="Parquet 데이터 저장소 경로 (기본: data/)",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -440,6 +524,7 @@ def main() -> None:
     )
 
     seed(args.db_path)
+    seed_parquet(args.data_path)
 
 
 if __name__ == "__main__":

--- a/tests/tc/account/credentials.feature
+++ b/tests/tc/account/credentials.feature
@@ -1,5 +1,5 @@
 Feature: 계좌 인증정보 관리
-  계좌의 인증정보(credentials) 설정, 조회, 미설정 시 봇 시작 에러를 검증한다.
+  계좌의 인증정보(credentials) 설정, 조회, 필수 누락 에러를 검증한다.
 
   Background:
     Given ante-qa 컨테이너가 실행 중이다
@@ -38,6 +38,7 @@ Feature: 계좌 인증정보 관리
       | trading_hours_end   | 15:30               |
       | trading_mode        | virtual             |
       | broker_type         | test                |
+      | credentials         | {"app_key": "test", "app_secret": "test"} |
     Then 응답 상태는 201
     And 응답 body.account.account_id 를 {account_id}로 저장한다
 
@@ -67,8 +68,8 @@ Feature: 계좌 인증정보 관리
 
   # ── 에러 케이스 ──
 
-  Scenario: 인증정보 없는 계좌로 봇 시작 시 에러
-    # 인증정보 없는 새 계좌 생성 (test 브로커, virtual 모드)
+  Scenario: 인증정보 누락 계좌 생성 시 422 에러
+    # PR #850 이후 credentials 필수 — 누락 시 422 반환
     When POST /api/accounts 요청:
       | field               | value                |
       | account_id          | qa-cred-acct-02      |
@@ -80,17 +81,4 @@ Feature: 계좌 인증정보 관리
       | trading_hours_end   | 15:30                |
       | trading_mode        | virtual              |
       | broker_type         | test                 |
-    Then 응답 상태는 201
-    And 응답 body.account.account_id 를 {no_cred_account_id}로 저장한다
-    # 봇 생성
-    When POST /api/bots 요청:
-      | field       | value                 |
-      | bot_id      | qa-no-cred-bot-01     |
-      | account_id  | {no_cred_account_id}  |
-      | name        | 인증정보 없는 봇      |
-      | strategy_id | {strategy_id}         |
-    Then 응답 상태는 201
-    And 응답 body.bot.bot_id 를 {no_cred_bot_id}로 저장한다
-    # 봇 시작 시도 → 인증정보 미설정 에러
-    When POST /api/bots/{no_cred_bot_id}/start
     Then 응답 상태는 422

--- a/tests/tc/account/crud.feature
+++ b/tests/tc/account/crud.feature
@@ -17,6 +17,7 @@ Feature: 계좌 CRUD
       | trading_hours_end   | 15:30              |
       | trading_mode        | virtual            |
       | broker_type         | test               |
+      | credentials         | {"app_key": "test", "app_secret": "test"} |
     Then 응답 상태는 201
     And 응답 body.account.account_id 는 null이 아니다
     And 응답 body.account.name 은 "QA 테스트 계좌"

--- a/tests/tc/account/lifecycle.feature
+++ b/tests/tc/account/lifecycle.feature
@@ -19,6 +19,7 @@ Feature: 계좌 생명주기
       | trading_hours_end   | 15:30                |
       | trading_mode        | virtual              |
       | broker_type         | test                 |
+      | credentials         | {"app_key": "test", "app_secret": "test"} |
     Then 응답 상태는 201
     And 응답 body.account.status 는 "active"
     And 응답 body.account.account_id 를 {account_id}로 저장한다
@@ -68,6 +69,7 @@ Feature: 계좌 생명주기
       | trading_hours_end   | 15:30                |
       | trading_mode        | virtual              |
       | broker_type         | test                 |
+      | credentials         | {"app_key": "test", "app_secret": "test"} |
     Then 응답 상태는 201
     And 응답 body.account.account_id 를 {suspended_account_id}로 저장한다
     When POST /api/accounts/{suspended_account_id}/suspend
@@ -96,6 +98,7 @@ Feature: 계좌 생명주기
       | trading_hours_end   | 15:30                |
       | trading_mode        | virtual              |
       | broker_type         | test                 |
+      | credentials         | {"app_key": "test", "app_secret": "test"} |
     Then 응답 상태는 201
     And 응답 body.account.account_id 를 {deleted_account_id}로 저장한다
     When DELETE /api/accounts/{deleted_account_id}
@@ -115,6 +118,7 @@ Feature: 계좌 생명주기
       | trading_hours_end   | 15:30                |
       | trading_mode        | virtual              |
       | broker_type         | test                 |
+      | credentials         | {"app_key": "test", "app_secret": "test"} |
     Then 응답 상태는 201
     And 응답 body.account.account_id 를 {dup_suspend_id}로 저장한다
     When POST /api/accounts/{dup_suspend_id}/suspend

--- a/tests/tc/account/rules.feature
+++ b/tests/tc/account/rules.feature
@@ -20,6 +20,7 @@ Feature: 계좌 리스크 룰 관리
       | trading_hours_end   | 15:30              |
       | trading_mode        | virtual            |
       | broker_type         | test               |
+      | credentials         | {"app_key": "test", "app_secret": "test"} |
     Then 응답 상태는 201 또는 응답 상태는 409
     # 409 시 body.account 가 없으므로 리터럴 account_id를 직접 사용한다
 
@@ -29,7 +30,7 @@ Feature: 계좌 리스크 룰 관리
     When PUT /api/accounts/qa-rules-acct-01/rules/daily_loss_limit 요청:
       | field   | value |
       | enabled | true  |
-      | config  | {"max_loss_pct": 5.0} |
+      | params  | {"max_loss_pct": 5.0} |
     Then 응답 상태는 200
     And 응답 body.rule.type 은 "daily_loss_limit"
     And 응답 body.rule.enabled 는 true
@@ -61,12 +62,12 @@ Feature: 계좌 리스크 룰 관리
     When PUT /api/accounts/qa-rules-acct-01/rules/nonexistent_rule 요청:
       | field   | value |
       | enabled | true  |
-      | config  | {}    |
+      | params  | {}    |
     Then 응답 상태는 400
 
-  Scenario: 유효하지 않은 룰 config (API)
+  Scenario: 유효하지 않은 룰 params (API)
     When PUT /api/accounts/qa-rules-acct-01/rules/daily_loss_limit 요청:
       | field   | value |
       | enabled | true  |
-      | config  | {"max_loss_pct": -1} |
+      | params  | {"max_loss_pct": -1} |
     Then 응답 상태는 422

--- a/tests/tc/treasury/allocation.feature
+++ b/tests/tc/treasury/allocation.feature
@@ -69,6 +69,13 @@ Feature: Treasury 예산 할당·회수
     Then 응답 상태는 201
     And 응답 body.bot.bot_id 를 {bot_id}로 저장한다
 
+  Scenario: 잔고 재설정 (할당 초기화 보장)
+    When POST /api/treasury/balance 요청:
+      | field   | value    |
+      | balance | 10000000 |
+    Then 응답 상태는 200
+    And 응답 body.total_balance 는 10000000
+
   # ── 정상 흐름: 예산 할당 ──
 
   Scenario: 봇 예산 할당 (API)


### PR DESCRIPTION
## Summary
- **CLI 토큰**: 토큰 파일 권한 `600`→`644`, `/etc/environment`에 경로 기록으로 `docker exec` 호환성 확보
- **credentials 누락**: account TC 6곳 + `qa-entrypoint.sh` 시드 계좌에 credentials 필드 추가 (PR #850 필수화 대응)
- **allocation 누적**: 봇 재생성 후 잔고 재설정 시나리오 추가로 재실행 멱등성 확보
- **데이터셋 부재**: `qa_seed_datasets.py`에 `seed_parquet()` 추가 — 30일분 OHLCV Parquet 시딩
- **룰 params**: rules TC의 필드명 `config`→`params` 수정 (API `RuleUpdateRequest` 스키마 일치)
- **secrets.env.example**: Telegram·DART·data.go.kr 키 항목 추가

## Test plan
- [ ] QA Docker 리빌드 후 전수 검사 실행
- [ ] 기존 FAIL 13건 (4+2+2+4+1) 해소 확인
- [ ] 기존 PASS TC 회귀 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)