### PR TITLE
fix(ui): 타이포그래피 위반 22건 + 인라인 스타일 1건 수정

### DIFF
--- a/frontend/src/components/agents/AgentEditModal.tsx
+++ b/frontend/src/components/agents/AgentEditModal.tsx
@@ -35,7 +35,7 @@ export default function AgentEditModal({ open, member, onClose, onSave, isPendin
 
   return (
     <Modal open={open} onClose={onClose}>
-      <div className="text-[16px] font-semibold mb-5">정보 수정</div>
+      <div className="text-[15px] font-semibold mb-5">정보 수정</div>
 
       <div className="mb-4">
         <label className="block text-[12px] font-semibold text-text-muted mb-1.5">Agent ID</label>

--- a/frontend/src/components/agents/MemberCard.tsx
+++ b/frontend/src/components/agents/MemberCard.tsx
@@ -48,7 +48,7 @@ export default function MemberCard({ member, onSuspend, onReactivate, onRevoke, 
       {/* 프로필 아바타 */}
       <div className="relative shrink-0 flex items-start justify-center">
         {isOwner && (
-          <div className="absolute -top-[13px] left-1/2 -translate-x-1/2 text-[16px] leading-none">
+          <div className="absolute -top-[13px] left-1/2 -translate-x-1/2 text-[15px] leading-none">
             {'👑'}
           </div>
         )}

--- a/frontend/src/components/approvals/ReviewControls.tsx
+++ b/frontend/src/components/approvals/ReviewControls.tsx
@@ -105,7 +105,7 @@ export default function ReviewControls({ approvalId, isPending, title, reviews, 
 
       {/* 승인 확인 모달 */}
       <Modal open={showApprove} onClose={() => setShowApprove(false)}>
-        <div className="text-[16px] font-semibold text-positive mb-4">결재 승인</div>
+        <div className="text-[15px] font-semibold text-positive mb-4">결재 승인</div>
         <div className="text-[13px] text-text-muted mb-4">
           <strong className="text-text">{title}</strong>을 승인하시겠습니까?
         </div>
@@ -150,7 +150,7 @@ export default function ReviewControls({ approvalId, isPending, title, reviews, 
 
       {/* 거부 확인 모달 */}
       <Modal open={showReject} onClose={() => setShowReject(false)}>
-        <div className="text-[16px] font-semibold text-negative mb-4">결재 거부</div>
+        <div className="text-[15px] font-semibold text-negative mb-4">결재 거부</div>
         <div className="text-[13px] text-text-muted mb-4">
           <strong className="text-text">{title}</strong>을 거부하시겠습니까?
         </div>

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -29,7 +29,7 @@ export default class ErrorBoundary extends Component<Props, State> {
         <div className="flex items-center justify-center min-h-screen bg-bg">
           <div className="text-center max-w-md px-6">
             <div className="text-[48px] mb-4">💥</div>
-            <h1 className="text-[20px] font-semibold mb-2">예기치 않은 오류가 발생했습니다</h1>
+            <h1 className="text-[18px] font-semibold mb-2">예기치 않은 오류가 발생했습니다</h1>
             <p className="text-text-muted text-[14px] mb-6">
               {this.state.error?.message || '알 수 없는 오류'}
             </p>

--- a/frontend/src/components/common/HintTooltip.tsx
+++ b/frontend/src/components/common/HintTooltip.tsx
@@ -9,7 +9,7 @@ export default function HintTooltip({ text }: { text: string }) {
       onMouseEnter={() => setShow(true)}
       onMouseLeave={() => setShow(false)}
     >
-      <span className="w-4 h-4 rounded-full bg-[rgba(139,143,163,0.15)] text-text-muted text-[10px] font-bold flex items-center justify-center">
+      <span className="w-4 h-4 rounded-full bg-[rgba(139,143,163,0.15)] text-text-muted text-[11px] font-bold flex items-center justify-center">
         ?
       </span>
       {show && (

--- a/frontend/src/components/common/Toast.tsx
+++ b/frontend/src/components/common/Toast.tsx
@@ -74,7 +74,7 @@ function ToastMessage({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id: 
       <span className="flex-1 break-words">{toast.message}</span>
       <button
         onClick={() => onDismiss(toast.id)}
-        className="bg-transparent border-none text-text-muted cursor-pointer text-[16px] p-0 leading-none hover:text-text"
+        className="bg-transparent border-none text-text-muted cursor-pointer text-[15px] p-0 leading-none hover:text-text"
       >
         x
       </button>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -60,7 +60,7 @@ export default function Header() {
             ←
           </button>
         )}
-        <h1 className="text-[16px] font-semibold">{title}</h1>
+        <h1 className="text-[15px] font-semibold">{title}</h1>
       </div>
 
       <div className="flex items-center gap-2 md:gap-4">

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -65,7 +65,7 @@ export default function Sidebar() {
                 }`
               }
             >
-              <span className="text-[16px] w-5 text-center">{item.icon}</span>
+              <span className="text-[15px] w-5 text-center">{item.icon}</span>
               <span className="leading-none">{item.label}</span>
               {item.showBadge && pendingCount > 0 && (
                 <span className="ml-auto bg-negative text-white text-[11px] px-1.5 py-px rounded-[10px] font-semibold">

--- a/frontend/src/components/strategies/PerformancePanel.tsx
+++ b/frontend/src/components/strategies/PerformancePanel.tsx
@@ -103,7 +103,7 @@ function StatsRow({ items, last }: { items: StatItem[]; last?: boolean }) {
             {m.label}
             <HintTooltip text={m.hint} />
           </div>
-          <div className={`text-[20px] font-bold ${m.color ?? ''}`}>{m.value}</div>
+          <div className={`text-[18px] font-bold ${m.color ?? ''}`}>{m.value}</div>
           {m.sub && (
             <div className={`text-[13px] mt-[-4px] ${m.subColor ?? 'text-text-muted'}`}>{m.sub}</div>
           )}

--- a/frontend/src/components/treasury/BudgetPieChart.tsx
+++ b/frontend/src/components/treasury/BudgetPieChart.tsx
@@ -50,7 +50,7 @@ export default function BudgetPieChart({ budgets }: Props) {
     <div className="flex items-center gap-6 h-[240px]">
       {/* SVG Pie Chart */}
       <div className="flex-shrink-0">
-        <svg width="180" height="180" viewBox="-1 -1 2 2" style={{ transform: 'rotate(-90deg)' }}>
+        <svg width="180" height="180" viewBox="-1 -1 2 2" className="-rotate-90">
           {slices.map((slice) => {
             if (slice.percentage >= 99.99) {
               // Full circle

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -45,7 +45,7 @@ export default function AgentDetail() {
       {/* 에이전트 정보 헤더 — 목업 detail-header 기준 */}
       <div className="flex items-center justify-between mb-6 pb-4 border-b border-border">
         <div>
-          <h2 className="text-[20px] font-bold font-mono mb-1">{member.member_id}</h2>
+          <h2 className="text-[18px] font-bold font-mono mb-1">{member.member_id}</h2>
           <div className="flex gap-2 items-center">
             <StatusBadge variant={STATUS_VARIANT[member.status] as 'positive'}>
               {MEMBER_STATUS_LABELS[member.status]}

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -156,7 +156,7 @@ export default function Agents() {
 
             <div className="mb-2">
               <div className="text-[12px] font-semibold text-text-muted">Agent ID</div>
-              <div className="text-[16px] font-semibold">{createdToken.agentId}</div>
+              <div className="text-[15px] font-semibold">{createdToken.agentId}</div>
             </div>
 
             <div className="my-5">

--- a/frontend/src/pages/ApprovalDetail.tsx
+++ b/frontend/src/pages/ApprovalDetail.tsx
@@ -166,14 +166,14 @@ export default function ApprovalDetail() {
     <>
       {/* 상세 헤더 */}
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-[20px] font-bold">{approval.title}</h2>
+        <h2 className="text-[18px] font-bold">{approval.title}</h2>
         {isPending && <ReviewControls approvalId={approval.id} isPending={isPending} title={approval.title} reviews={approval.reviews} type={approval.type} params={approval.params} />}
       </div>
 
       {/* 거부 사유 배너 */}
       {approval.status === 'rejected' && approval.reject_reason && (
         <div className="bg-negative/10 text-negative rounded-lg px-[18px] py-[14px] mb-6 flex items-start gap-2.5 text-[13px]">
-          <span className="text-[16px] leading-none mt-0.5">{'\u2715'}</span>
+          <span className="text-[15px] leading-none mt-0.5">{'\u2715'}</span>
           <div>
             <div className="font-semibold mb-1">거부 사유</div>
             <div className="text-[12px]">{approval.reject_reason}</div>

--- a/frontend/src/pages/BotDetail.tsx
+++ b/frontend/src/pages/BotDetail.tsx
@@ -43,9 +43,9 @@ export default function BotDetail() {
       {/* 헤더 */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h2 className="text-[20px] font-bold flex items-center gap-2">
+          <h2 className="text-[18px] font-bold flex items-center gap-2">
             {bot.name || bot.bot_id}
-            {bot.name && <span className="text-[16px] font-normal text-text-muted">{bot.bot_id}</span>}
+            {bot.name && <span className="text-[15px] font-normal text-text-muted">{bot.bot_id}</span>}
           </h2>
         </div>
         <div className="flex gap-2">

--- a/frontend/src/pages/Performance.tsx
+++ b/frontend/src/pages/Performance.tsx
@@ -16,7 +16,7 @@ function StatCard({ label, value, colorClass }: { label: string; value: string; 
   return (
     <div className="bg-surface border border-border rounded-lg p-5">
       <div className="text-[12px] text-text-muted mb-1">{label}</div>
-      <div className={`text-[20px] font-bold ${colorClass ?? ''}`}>{value}</div>
+      <div className={`text-[18px] font-bold ${colorClass ?? ''}`}>{value}</div>
     </div>
   )
 }
@@ -206,7 +206,7 @@ export default function Performance() {
         >
           &larr; 전략 상세
         </Link>
-        <h2 className="text-[20px] font-bold">기간별 성과</h2>
+        <h2 className="text-[18px] font-bold">기간별 성과</h2>
       </div>
 
       {/* 필터 바 */}

--- a/frontend/src/pages/ReportDetail.tsx
+++ b/frontend/src/pages/ReportDetail.tsx
@@ -155,7 +155,7 @@ export default function ReportDetail() {
     <>
       {/* 헤더 */}
       <div className="mb-6">
-        <h2 className="text-[20px] font-bold">{report.strategy_name} {report.strategy_version} 검증 리포트</h2>
+        <h2 className="text-[18px] font-bold">{report.strategy_name} {report.strategy_version} 검증 리포트</h2>
       </div>
 
       {/* 1행: 리포트 정보 | 백테스트 설정 | 백테스트 성과 (3열) */}

--- a/frontend/src/pages/StrategyDetail.tsx
+++ b/frontend/src/pages/StrategyDetail.tsx
@@ -69,7 +69,7 @@ export default function StrategyDetail() {
       {/* 전략 정보 헤더 */}
       <div className="mb-6">
         <div className="flex items-center justify-between">
-          <h2 className="text-[20px] font-bold">{strategy.name}</h2>
+          <h2 className="text-[18px] font-bold">{strategy.name}</h2>
           <StatusActionButtons
             status={status}
             hasRunningBot={hasRunningBot}
@@ -158,7 +158,7 @@ export default function StrategyDetail() {
       </div>
 
       {/* 전략 성과 섹션 제목 */}
-      <h3 className="text-[16px] font-semibold mb-4">전략 성과</h3>
+      <h3 className="text-[15px] font-semibold mb-4">전략 성과</h3>
 
       {/* 자산 추이 (Equity Curve) */}
       <div className="bg-surface border border-border rounded-lg p-5 mb-6">

--- a/frontend/src/pages/Trades.tsx
+++ b/frontend/src/pages/Trades.tsx
@@ -60,7 +60,7 @@ export default function Trades() {
         >
           &larr; 전략 상세
         </Link>
-        <h2 className="text-[20px] font-bold">거래 내역</h2>
+        <h2 className="text-[18px] font-bold">거래 내역</h2>
       </div>
 
       {/* 필터 바 */}


### PR DESCRIPTION
## Summary
- `text-[16px]` -> `text-[15px]` 11건, `text-[20px]` -> `text-[18px]` 10건, `text-[10px]` -> `text-[11px]` 1건 수정
- `BudgetPieChart`의 인라인 `style={{ transform: 'rotate(-90deg)' }}`를 Tailwind `-rotate-90` 클래스로 대체
- 18개 파일, 23건 변경

Refs #870

## Test plan
- [x] `npm run build` 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)