### PR TITLE
fix(frontend): 디자인 토큰 위반 일괄 수정 #869

### DIFF
--- a/frontend/src/components/agents/AgentEditModal.tsx
+++ b/frontend/src/components/agents/AgentEditModal.tsx
@@ -91,7 +91,7 @@ export default function AgentEditModal({ open, member, onClose, onSave, isPendin
         <button
           onClick={handleSave}
           disabled={isPending || !name.trim()}
-          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50"
+          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-on-primary border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50"
         >
           저장
         </button>

--- a/frontend/src/components/agents/AgentRegisterForm.tsx
+++ b/frontend/src/components/agents/AgentRegisterForm.tsx
@@ -34,7 +34,7 @@ export default function AgentRegisterForm({ onClose, onTokenCreated }: AgentRegi
   }
 
   return (
-    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+    <div className="fixed inset-0 bg-overlay flex items-center justify-center z-[200]">
       <div className="bg-surface border border-border rounded-lg p-6 w-[480px] max-h-[90vh] overflow-y-auto">
         <h2 className="text-[18px] font-bold mb-5">에이전트 등록</h2>
         <form onSubmit={handleSubmit}>
@@ -77,7 +77,7 @@ export default function AgentRegisterForm({ onClose, onTokenCreated }: AgentRegi
           </div>
           <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
             <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
-            <button type="submit" disabled={createMember.isPending} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50">등록</button>
+            <button type="submit" disabled={createMember.isPending} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-on-primary border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50">등록</button>
           </div>
         </form>
       </div>

--- a/frontend/src/components/agents/AgentTable.tsx
+++ b/frontend/src/components/agents/AgentTable.tsx
@@ -52,7 +52,7 @@ export default function AgentTable({ items, onSuspend, onReactivate, onRevoke }:
                       <button onClick={() => onSuspend(m.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-warning border border-border cursor-pointer hover:bg-warning-bg">정지</button>
                     )}
                     {m.status === 'suspended' && (
-                      <button onClick={() => onReactivate(m.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">재활성화</button>
+                      <button onClick={() => onReactivate(m.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-positive text-on-primary border-none cursor-pointer hover:bg-positive-hover">재활성화</button>
                     )}
                     {m.status !== 'revoked' && (
                       <button onClick={() => onRevoke(m.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-negative border border-border cursor-pointer hover:bg-negative-bg">폐기</button>

--- a/frontend/src/components/agents/ChangePasswordModal.tsx
+++ b/frontend/src/components/agents/ChangePasswordModal.tsx
@@ -44,7 +44,7 @@ export default function ChangePasswordModal({ memberId, onClose }: ChangePasswor
 
   if (success) {
     return (
-      <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+      <div className="fixed inset-0 bg-overlay flex items-center justify-center z-[200]">
         <div className="bg-surface border border-border rounded-lg p-6 w-[400px] text-center">
           <h3 className="text-[18px] font-bold mb-4 text-positive">비밀번호 변경 완료</h3>
           <p className="text-[13px] text-text-muted mb-5">
@@ -52,7 +52,7 @@ export default function ChangePasswordModal({ memberId, onClose }: ChangePasswor
           </p>
           <button
             onClick={onClose}
-            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-on-primary border-none cursor-pointer hover:bg-primary-hover"
           >
             닫기
           </button>
@@ -62,7 +62,7 @@ export default function ChangePasswordModal({ memberId, onClose }: ChangePasswor
   }
 
   return (
-    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+    <div className="fixed inset-0 bg-overlay flex items-center justify-center z-[200]">
       <div className="bg-surface border border-border rounded-lg p-6 w-[400px]">
         <h2 className="text-[18px] font-bold mb-5">비밀번호 변경</h2>
         <p className="text-[13px] text-text-muted mb-4">
@@ -114,7 +114,7 @@ export default function ChangePasswordModal({ memberId, onClose }: ChangePasswor
             <button
               type="submit"
               disabled={changePassword.isPending}
-              className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50"
+              className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-on-primary border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50"
             >
               {changePassword.isPending ? '변경 중...' : '변경'}
             </button>

--- a/frontend/src/components/agents/MemberCard.tsx
+++ b/frontend/src/components/agents/MemberCard.tsx
@@ -9,7 +9,7 @@ const STATUS_VARIANT: Record<MemberStatus, string> = {
 
 const ROLE_BADGE_STYLE: Record<HumanRole, string> = {
   owner: 'bg-primary/15 text-primary',
-  master: 'bg-purple-500/15 text-purple-400',
+  master: 'bg-info-bg text-info',
   admin: 'bg-border text-text-muted',
 }
 
@@ -137,7 +137,7 @@ export default function MemberCard({ member, onSuspend, onReactivate, onRevoke, 
               <button onClick={() => onSuspend(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">정지</button>
             )}
             {member.status === 'suspended' && onReactivate && (
-              <button onClick={() => onReactivate(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">재활성화</button>
+              <button onClick={() => onReactivate(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-positive text-on-primary border-none cursor-pointer hover:bg-positive-hover">재활성화</button>
             )}
             {onRevoke && (
               <button onClick={() => onRevoke(member.member_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-negative border-none cursor-pointer hover:bg-negative-bg">폐기</button>

--- a/frontend/src/components/approvals/ReviewControls.tsx
+++ b/frontend/src/components/approvals/ReviewControls.tsx
@@ -97,7 +97,7 @@ export default function ReviewControls({ approvalId, isPending, title, reviews, 
         </button>
         <button
           onClick={() => setShowApprove(true)}
-          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover"
+          className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-on-primary border-none cursor-pointer hover:bg-positive-hover"
         >
           승인
         </button>
@@ -141,7 +141,7 @@ export default function ReviewControls({ approvalId, isPending, title, reviews, 
           <button
             onClick={handleApprove}
             disabled={updateStatus.isPending}
-            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover disabled:opacity-50"
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-on-primary border-none cursor-pointer hover:bg-positive-hover disabled:opacity-50"
           >
             승인
           </button>
@@ -175,7 +175,7 @@ export default function ReviewControls({ approvalId, isPending, title, reviews, 
           <button
             onClick={handleReject}
             disabled={updateStatus.isPending || !rejectReason.trim()}
-            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative-hover disabled:opacity-50"
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-on-primary border-none cursor-pointer hover:bg-negative-hover disabled:opacity-50"
           >
             거부
           </button>

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -60,7 +60,7 @@ export default function LoginForm() {
       <button
         type="submit"
         disabled={loginMutation.isPending || !memberId || !password}
-        className="w-full inline-flex items-center justify-center py-3 bg-primary text-white rounded-lg text-[14px] font-semibold mt-2 hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer border-none transition-colors duration-150"
+        className="w-full inline-flex items-center justify-center py-3 bg-primary text-on-primary rounded-lg text-[14px] font-semibold mt-2 hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer border-none transition-colors duration-150"
       >
         {loginMutation.isPending ? '로그인 중...' : '로그인'}
       </button>

--- a/frontend/src/components/bots/BotCreateForm.tsx
+++ b/frontend/src/components/bots/BotCreateForm.tsx
@@ -54,7 +54,7 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
   }
 
   return (
-    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+    <div className="fixed inset-0 bg-overlay flex items-center justify-center z-[200]">
       <div className="bg-surface border border-border rounded-lg p-6 w-[480px] max-h-[90vh] overflow-y-auto">
         <h2 className="text-[18px] font-bold mb-5">봇 생성</h2>
         <form onSubmit={handleSubmit}>
@@ -93,7 +93,7 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
           </div>
           <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
             <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
-            <button type="submit" disabled={createBot.isPending || !!botIdError} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50">생성</button>
+            <button type="submit" disabled={createBot.isPending || !!botIdError} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-on-primary border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50">생성</button>
           </div>
         </form>
       </div>

--- a/frontend/src/components/bots/BotDeleteModal.tsx
+++ b/frontend/src/components/bots/BotDeleteModal.tsx
@@ -18,7 +18,7 @@ export default function BotDeleteModal({ bot, onConfirm, onClose, isPending }: B
   const [deleteOption, setDeleteOption] = useState<DeleteOption>('keep')
 
   return (
-    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]" onClick={onClose}>
+    <div className="fixed inset-0 bg-overlay flex items-center justify-center z-[200]" onClick={onClose}>
       <div className="bg-surface border border-border rounded-lg p-6 w-[480px] max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
         <h2 className="text-[18px] font-bold mb-4 text-negative">Bot 삭제</h2>
 
@@ -91,7 +91,7 @@ export default function BotDeleteModal({ bot, onConfirm, onClose, isPending }: B
             type="button"
             onClick={() => onConfirm(hasPositions ? deleteOption : undefined)}
             disabled={isPending}
-            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative/80 disabled:opacity-50"
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-on-primary border-none cursor-pointer hover:bg-negative/80 disabled:opacity-50"
           >
             {isPending ? '삭제 중...' : '삭제'}
           </button>

--- a/frontend/src/components/bots/BotStopModal.tsx
+++ b/frontend/src/components/bots/BotStopModal.tsx
@@ -18,7 +18,7 @@ export default function BotStopModal({ bot, onConfirm, onClose, isPending }: Bot
   const reserved = bot.budget?.reserved ?? 0
 
   return (
-    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]" onClick={onClose}>
+    <div className="fixed inset-0 bg-overlay flex items-center justify-center z-[200]" onClick={onClose}>
       <div className="bg-surface border border-border rounded-lg p-6 w-[480px] max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
         <h2 className="text-[18px] font-bold mb-4 text-negative">Bot 중지</h2>
 
@@ -64,7 +64,7 @@ export default function BotStopModal({ bot, onConfirm, onClose, isPending }: Bot
             type="button"
             onClick={onConfirm}
             disabled={isPending}
-            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative/80 disabled:opacity-50"
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-on-primary border-none cursor-pointer hover:bg-negative/80 disabled:opacity-50"
           >
             {isPending ? '중지 중...' : '중지 확인'}
           </button>

--- a/frontend/src/components/bots/BotTable.tsx
+++ b/frontend/src/components/bots/BotTable.tsx
@@ -51,7 +51,7 @@ export default function BotTable({ items, onStart, onStop, onDelete }: BotTableP
                 <td className="px-3 py-3 border-b border-border text-[13px] text-right">
                   <div className="flex gap-2 justify-end" onClick={(e) => e.stopPropagation()}>
                     {bot.status === 'stopped' || bot.status === 'created' ? (
-                      <button onClick={() => onStart(bot.bot_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">시작</button>
+                      <button onClick={() => onStart(bot.bot_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-positive text-on-primary border-none cursor-pointer hover:bg-positive-hover">시작</button>
                     ) : bot.status === 'running' ? (
                       <button onClick={() => onStop(bot.bot_id)} className="px-2.5 py-1 rounded-lg text-[12px] bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">중지</button>
                     ) : null}

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -38,7 +38,7 @@ export default class ErrorBoundary extends Component<Props, State> {
                 this.setState({ hasError: false, error: null })
                 window.location.href = '/'
               }}
-              className="px-4 py-2 bg-primary text-white rounded-lg border-none cursor-pointer text-[14px] hover:bg-primary-hover"
+              className="px-4 py-2 bg-primary text-on-primary rounded-lg border-none cursor-pointer text-[14px] hover:bg-primary-hover"
             >
               대시보드로 돌아가기
             </button>

--- a/frontend/src/components/common/HintTooltip.tsx
+++ b/frontend/src/components/common/HintTooltip.tsx
@@ -9,7 +9,7 @@ export default function HintTooltip({ text }: { text: string }) {
       onMouseEnter={() => setShow(true)}
       onMouseLeave={() => setShow(false)}
     >
-      <span className="w-4 h-4 rounded-full bg-[rgba(139,143,163,0.15)] text-text-muted text-[11px] font-bold flex items-center justify-center">
+      <span className="w-4 h-4 rounded-full bg-muted-bg text-text-muted text-[11px] font-bold flex items-center justify-center">
         ?
       </span>
       {show && (

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -24,7 +24,7 @@ export default function Modal({ open, onClose, children }: ModalProps) {
     <div
       ref={overlayRef}
       onClick={(e) => { if (e.target === overlayRef.current) onClose() }}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-overlay"
     >
       <div className="bg-surface border border-border rounded-lg p-6 w-full max-w-[440px] shadow-lg">
         {children}

--- a/frontend/src/components/common/Pagination.tsx
+++ b/frontend/src/components/common/Pagination.tsx
@@ -14,7 +14,7 @@ export default function Pagination({ total, offset, limit, onPageChange }: Pagin
   const btnBase =
     'w-8 h-8 flex items-center justify-center rounded-lg text-[13px] font-medium border cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed'
   const btnOutline = `${btnBase} border-border bg-transparent text-text-muted hover:bg-surface-hover hover:text-text`
-  const btnActive = `${btnBase} border-primary bg-primary text-white`
+  const btnActive = `${btnBase} border-primary bg-primary text-on-primary`
 
   // Build visible page numbers: show up to 5 pages centered around current
   const getPageNumbers = (): number[] => {

--- a/frontend/src/components/common/ServiceUnavailable.tsx
+++ b/frontend/src/components/common/ServiceUnavailable.tsx
@@ -9,7 +9,7 @@ export default function ServiceUnavailable() {
         </p>
         <button
           onClick={() => window.location.reload()}
-          className="px-4 py-2 bg-primary text-white rounded-lg border-none cursor-pointer text-[14px] hover:bg-primary-hover"
+          className="px-4 py-2 bg-primary text-on-primary rounded-lg border-none cursor-pointer text-[14px] hover:bg-primary-hover"
         >
           새로고침
         </button>

--- a/frontend/src/components/common/StatusBadge.tsx
+++ b/frontend/src/components/common/StatusBadge.tsx
@@ -3,7 +3,7 @@ const VARIANT_CLASSES: Record<string, string> = {
   negative: 'bg-negative-bg text-negative',
   warning: 'bg-warning-bg text-warning',
   info: 'bg-info-bg text-info',
-  muted: 'bg-[rgba(139,143,163,0.15)] text-text-muted',
+  muted: 'bg-muted-bg text-text-muted',
   primary: 'bg-positive-bg text-primary',
 }
 

--- a/frontend/src/components/data/ApiKeyStatusPanel.tsx
+++ b/frontend/src/components/data/ApiKeyStatusPanel.tsx
@@ -67,7 +67,7 @@ export default function ApiKeyStatusPanel() {
       </div>
       {api_keys.some((k) => !k.set) && (
         <div className="bg-info-bg rounded px-3.5 py-2.5 mt-3 text-[12px] text-info">
-          API 키 설정: <code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante feed config set {'<KEY>'} {'<VALUE>'}</code>
+          API 키 설정: <code className="bg-code-bg px-1.5 py-0.5 rounded-sm text-[12px]">ante feed config set {'<KEY>'} {'<VALUE>'}</code>
         </div>
       )}
     </div>

--- a/frontend/src/components/data/FeedStatusPanel.tsx
+++ b/frontend/src/components/data/FeedStatusPanel.tsx
@@ -52,7 +52,7 @@ export default function FeedStatusPanel() {
 
       {!initialized ? (
         <div className="text-[13px] text-text-muted">
-          Feed가 초기화되지 않았습니다. <code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante feed init</code> 명령으로 초기화하세요.
+          Feed가 초기화되지 않았습니다. <code className="bg-code-bg px-1.5 py-0.5 rounded-sm text-[12px]">ante feed init</code> 명령으로 초기화하세요.
         </div>
       ) : (
         <div className="space-y-4">
@@ -73,7 +73,7 @@ export default function FeedStatusPanel() {
 
           {checkpoints.length === 0 && !latestReport && (
             <div className="text-[13px] text-text-muted">
-              아직 수집이 실행되지 않았습니다. <code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante feed run daily</code> 또는 <code className="bg-[rgba(255,255,255,0.08)] px-1.5 py-0.5 rounded-sm text-[12px]">ante feed run backfill</code> 명령으로 수집을 시작하세요.
+              아직 수집이 실행되지 않았습니다. <code className="bg-code-bg px-1.5 py-0.5 rounded-sm text-[12px]">ante feed run daily</code> 또는 <code className="bg-code-bg px-1.5 py-0.5 rounded-sm text-[12px]">ante feed run backfill</code> 명령으로 수집을 시작하세요.
             </div>
           )}
         </div>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -32,7 +32,7 @@ export default function Sidebar() {
       {/* 모바일 오버레이 */}
       {mobileOpen && (
         <div
-          className="fixed inset-0 bg-black/50 z-[100] md:hidden"
+          className="fixed inset-0 bg-overlay z-[100] md:hidden"
           onClick={() => setMobileOpen(false)}
         />
       )}
@@ -60,7 +60,7 @@ export default function Sidebar() {
               className={({ isActive }) =>
                 `flex items-center gap-[10px] px-3 py-[10px] rounded-lg text-[15px] font-medium no-underline transition-colors ${
                   isActive
-                    ? 'bg-primary !text-white'
+                    ? 'bg-primary !text-on-primary'
                     : 'text-text-muted hover:bg-surface-hover hover:text-text'
                 }`
               }
@@ -68,7 +68,7 @@ export default function Sidebar() {
               <span className="text-[15px] w-5 text-center">{item.icon}</span>
               <span className="leading-none">{item.label}</span>
               {item.showBadge && pendingCount > 0 && (
-                <span className="ml-auto bg-negative text-white text-[11px] px-1.5 py-px rounded-[10px] font-semibold">
+                <span className="ml-auto bg-negative text-on-primary text-[11px] px-1.5 py-px rounded-[10px] font-semibold">
                   {pendingCount}
                 </span>
               )}

--- a/frontend/src/components/treasury/AccountSummary.tsx
+++ b/frontend/src/components/treasury/AccountSummary.tsx
@@ -17,7 +17,7 @@ export default function AccountSummary({ summary }: { summary: TreasurySummary }
       {/* 브로커 헤더 */}
       <div className="flex items-center gap-4 px-5 py-3 border-b border-border">
         <div className="flex items-center gap-2">
-          <span className="bg-primary text-white text-[11px] font-bold px-2 py-0.5 rounded">{summary.broker_short_name || 'KIS'}</span>
+          <span className="bg-primary text-on-primary text-[11px] font-bold px-2 py-0.5 rounded">{summary.broker_short_name || 'KIS'}</span>
           <span className="text-[14px] font-semibold">{summary.broker_name || '한국투자증권'}</span>
           {summary.exchange && (
             <span className="text-[11px] text-text-muted border border-border px-1.5 py-0.5 rounded">{summary.exchange}</span>

--- a/frontend/src/components/treasury/AllocationForm.tsx
+++ b/frontend/src/components/treasury/AllocationForm.tsx
@@ -108,7 +108,7 @@ export default function AllocationForm({ budgets }: AllocationFormProps) {
           <button
             onClick={() => numAmount > 0 && botId && setShowConfirm(true)}
             disabled={!botId || !numAmount || isBotRunning}
-            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50"
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-on-primary border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50"
           >
             예산 변경
           </button>
@@ -117,7 +117,7 @@ export default function AllocationForm({ budgets }: AllocationFormProps) {
 
       {/* 예산 변경 확인 모달 */}
       {showConfirm && selectedBudget && (
-        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+        <div className="fixed inset-0 bg-overlay flex items-center justify-center z-[200]">
           <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
             <h3 className="text-[18px] font-bold mb-5">예산 변경 확인</h3>
             <div className="text-[13px] text-text-muted mb-4">아래 내용으로 예산을 변경합니다.</div>
@@ -143,7 +143,7 @@ export default function AllocationForm({ budgets }: AllocationFormProps) {
             </div>
             <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
               <button onClick={() => setShowConfirm(false)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
-              <button onClick={handleSubmit} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">변경 확인</button>
+              <button onClick={handleSubmit} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-on-primary border-none cursor-pointer hover:bg-primary-hover">변경 확인</button>
             </div>
           </div>
         </div>

--- a/frontend/src/components/treasury/AnteSummary.tsx
+++ b/frontend/src/components/treasury/AnteSummary.tsx
@@ -25,7 +25,7 @@ export default function AnteSummary({ summary, children }: { summary: TreasurySu
       {/* Ante 헤더 */}
       <div className="flex items-center gap-4 px-5 py-3 border-b border-border">
         <div className="flex items-center gap-2">
-          <span className="bg-positive text-white text-[11px] font-bold px-2 py-0.5 rounded">Ante</span>
+          <span className="bg-positive text-on-primary text-[11px] font-bold px-2 py-0.5 rounded">Ante</span>
           <span className="text-[14px] font-semibold">관리 자금</span>
         </div>
         <span className="text-[13px] text-text-muted">Bot {summary.bot_count ?? 0}개 운용 중</span>

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -62,7 +62,7 @@ export default function AgentDetail() {
             <button onClick={() => suspend.mutate(member.member_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">일시 정지</button>
           )}
           {member.status === 'suspended' && (
-            <button onClick={() => reactivate.mutate(member.member_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover">재활성화</button>
+            <button onClick={() => reactivate.mutate(member.member_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-on-primary border-none cursor-pointer hover:bg-positive-hover">재활성화</button>
           )}
           {member.status !== 'revoked' && (
             <button onClick={() => { if (confirm('이 작업은 되돌릴 수 없습니다. 정말 삭제하시겠습니까?')) revoke.mutate(member.member_id) }} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-negative border border-border cursor-pointer hover:bg-surface-hover">삭제</button>
@@ -171,7 +171,7 @@ export default function AgentDetail() {
 
       {/* 토큰 표시 모달 */}
       {newToken && (
-        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+        <div className="fixed inset-0 bg-overlay flex items-center justify-center z-[200]">
           <div className="bg-surface border border-border rounded-lg p-6 w-[480px] text-center">
             <h3 className="text-[18px] font-bold mb-4 text-positive">{'✓'} 새 토큰 발급 완료</h3>
 
@@ -185,7 +185,7 @@ export default function AgentDetail() {
             </div>
 
             <div className="flex justify-center gap-2">
-              <button onClick={() => navigator.clipboard.writeText(newToken)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">토큰 복사</button>
+              <button onClick={() => navigator.clipboard.writeText(newToken)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-on-primary border-none cursor-pointer hover:bg-primary-hover">토큰 복사</button>
               <button onClick={() => setNewToken(null)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">닫기</button>
             </div>
           </div>

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -79,7 +79,7 @@ export default function Agents() {
               <div className="ml-auto">
                 <button
                   onClick={() => setShowRegister(true)}
-                  className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
+                  className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-on-primary border-none cursor-pointer hover:bg-primary-hover"
                 >
                   + 에이전트 등록
                 </button>
@@ -95,7 +95,7 @@ export default function Agents() {
                     onClick={() => setStatusFilter(tab.value)}
                     className={`px-3 py-1.5 rounded-lg text-[13px] font-medium border cursor-pointer transition-colors ${
                       statusFilter === tab.value
-                        ? 'bg-primary text-white border-primary'
+                        ? 'bg-primary text-on-primary border-primary'
                         : 'bg-transparent text-text-muted border-border hover:bg-surface-hover'
                     }`}
                   >
@@ -150,7 +150,7 @@ export default function Agents() {
 
       {/* 토큰 표시 모달 — 목업 tokenModal 기준 */}
       {createdToken && (
-        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+        <div className="fixed inset-0 bg-overlay flex items-center justify-center z-[200]">
           <div className="bg-surface border border-border rounded-lg p-6 w-[480px] text-center">
             <h3 className="text-[18px] font-bold mb-4 text-positive">{'✓'} 에이전트 등록 완료</h3>
 
@@ -173,7 +173,7 @@ export default function Agents() {
             <div className="flex justify-center gap-2">
               <button
                 onClick={() => navigator.clipboard.writeText(createdToken.token)}
-                className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
+                className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-on-primary border-none cursor-pointer hover:bg-primary-hover"
               >
                 토큰 복사
               </button>

--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -322,7 +322,7 @@ export default function BacktestData() {
 
       {/* 삭제 확인 모달 */}
       {deleteTarget && (
-        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+        <div className="fixed inset-0 bg-overlay flex items-center justify-center z-[200]">
           <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
             <h3 className="text-[18px] font-bold mb-5 text-negative">데이터셋 삭제</h3>
             <div className="mb-4 text-[13px] text-text-muted">
@@ -341,7 +341,7 @@ export default function BacktestData() {
               <button
                 onClick={() => deleteMutation.mutate(deleteTarget)}
                 disabled={deleteMutation.isPending}
-                className="px-4 py-2 rounded text-[13px] font-medium bg-negative text-white border border-negative cursor-pointer hover:bg-negative-hover disabled:opacity-50"
+                className="px-4 py-2 rounded text-[13px] font-medium bg-negative text-on-primary border border-negative cursor-pointer hover:bg-negative-hover disabled:opacity-50"
               >
                 삭제
               </button>

--- a/frontend/src/pages/BotDetail.tsx
+++ b/frontend/src/pages/BotDetail.tsx
@@ -56,7 +56,7 @@ export default function BotDetail() {
             <button onClick={() => setShowEditModal(true)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">설정 수정</button>
           )}
           {canStart && (
-            <button onClick={() => start.mutate(bot.bot_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover">시작</button>
+            <button onClick={() => start.mutate(bot.bot_id)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-on-primary border-none cursor-pointer hover:bg-primary-hover">시작</button>
           )}
           {canStop && (
             <button onClick={() => setShowStopModal(true)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-negative border border-negative cursor-pointer hover:bg-negative-bg">중지</button>
@@ -316,7 +316,7 @@ function BotEditModal({ bot, onClose }: { bot: BotDetailType; onClose: () => voi
   const inputClass = 'w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary'
 
   return (
-    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]" onClick={onClose}>
+    <div className="fixed inset-0 bg-overlay flex items-center justify-center z-[200]" onClick={onClose}>
       <div className="bg-surface border border-border rounded-lg p-6 w-[480px] max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
         <h2 className="text-[18px] font-bold mb-5">Bot 설정 수정</h2>
         <div className="space-y-4">
@@ -469,7 +469,7 @@ function BotEditModal({ bot, onClose }: { bot: BotDetailType; onClose: () => voi
             type="button"
             onClick={handleSave}
             disabled={updateMutation.isPending}
-            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50"
+            className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-on-primary border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50"
           >
             {updateMutation.isPending ? '저장 중...' : '저장'}
           </button>

--- a/frontend/src/pages/Bots.tsx
+++ b/frontend/src/pages/Bots.tsx
@@ -40,7 +40,7 @@ export default function Bots() {
             </div>
             <button
               onClick={() => setShowCreate(true)}
-              className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-white border-none cursor-pointer hover:bg-primary-hover"
+              className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-on-primary border-none cursor-pointer hover:bg-primary-hover"
             >
               + 봇 생성
             </button>

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -11,7 +11,7 @@ export default function NotFound() {
         </p>
         <Link
           to="/"
-          className="inline-block px-4 py-2 bg-primary text-white rounded-lg no-underline text-[14px] hover:bg-primary-hover"
+          className="inline-block px-4 py-2 bg-primary text-on-primary rounded-lg no-underline text-[14px] hover:bg-primary-hover"
         >
           대시보드로 돌아가기
         </Link>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -72,7 +72,7 @@ export default function Settings() {
               <div className="text-[13px] text-text-muted">현재 모든 봇의 거래가 정상 운용 중입니다.</div>
               <button
                 onClick={() => setShowHaltModal(true)}
-                className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative-hover whitespace-nowrap"
+                className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-on-primary border-none cursor-pointer hover:bg-negative-hover whitespace-nowrap"
               >
                 비상 거래 정지
               </button>
@@ -91,7 +91,7 @@ export default function Settings() {
               </div>
               <button
                 onClick={handleActivate}
-                className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-white border-none cursor-pointer hover:bg-positive-hover whitespace-nowrap"
+                className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-on-primary border-none cursor-pointer hover:bg-positive-hover whitespace-nowrap"
               >
                 거래 재개
               </button>
@@ -223,7 +223,7 @@ export default function Settings() {
                     getConfigValue(cfg.key) === 'true' ? 'bg-positive' : 'bg-border'
                   }`}
                 >
-                  <span className={`absolute top-[2px] w-[18px] h-[18px] bg-white rounded-full transition-transform ${
+                  <span className={`absolute top-[2px] w-[18px] h-[18px] bg-on-primary rounded-full transition-transform ${
                     getConfigValue(cfg.key) === 'true' ? 'left-[20px]' : 'left-[2px]'
                   }`} />
                 </button>
@@ -235,7 +235,7 @@ export default function Settings() {
 
       {/* 비상 거래 정지 모달 */}
       {showHaltModal && (
-        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]">
+        <div className="fixed inset-0 bg-overlay flex items-center justify-center z-[200]">
           <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
             <h3 className="text-[18px] font-bold text-negative mb-5">비상 거래 정지</h3>
             <p className="text-[13px] text-text-muted mb-4">
@@ -257,7 +257,7 @@ export default function Settings() {
             </div>
             <div className="flex justify-end gap-2 pt-4 border-t border-border mt-6">
               <button onClick={() => { setShowHaltModal(false); setHaltReason('') }} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
-              <button onClick={handleHalt} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-white border-none cursor-pointer hover:bg-negative-hover">거래 정지 확인</button>
+              <button onClick={handleHalt} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-on-primary border-none cursor-pointer hover:bg-negative-hover">거래 정지 확인</button>
             </div>
           </div>
         </div>
@@ -272,7 +272,7 @@ function CurrencyFormatButton({ label, active, onClick }: { label: string; activ
       onClick={onClick}
       className={`px-2.5 py-1 rounded-lg text-[12px] font-medium border cursor-pointer transition-colors ${
         active
-          ? 'bg-primary text-white border-primary'
+          ? 'bg-primary text-on-primary border-primary'
           : 'bg-transparent text-text-muted border-border hover:bg-surface-hover'
       }`}
     >

--- a/frontend/src/pages/Treasury.tsx
+++ b/frontend/src/pages/Treasury.tsx
@@ -76,7 +76,7 @@ export default function Treasury() {
                     onClick={() => setPeriod(p.key)}
                     className={`px-3 py-1 rounded text-[12px] font-medium cursor-pointer border-none ${
                       period === p.key
-                        ? 'bg-primary text-white'
+                        ? 'bg-primary text-on-primary'
                         : 'bg-transparent text-text-muted hover:text-text'
                     }`}
                   >


### PR DESCRIPTION
## Summary

- `index.css` `@theme`에 정의된 시맨틱 토큰 대신 Tailwind 기본 색상/임의 값을 사용한 60건을 일괄 치환
- `text-white` → `text-on-primary` (38건), `bg-black/50|60` → `bg-overlay` (14건), rgba 임의값 → `bg-muted-bg`/`bg-code-bg` (5건), `bg-purple-500/15`/`text-purple-400` → `bg-info-bg`/`text-info` (2건), `bg-white` → `bg-on-primary` (1건)
- 31개 파일 수정, `npm run build` 성공 확인

Refs #869

## Test plan

- [ ] `frontend/src/` 내 `text-white`, `bg-white`, `bg-black/5`, `bg-black/6`, `bg-purple`, `text-purple`, 임의 rgba 검색 시 0건 확인
- [ ] `npm run build` 성공
- [ ] 대시보드 주요 화면(로그인, 봇 목록, 에이전트, 설정, 모달) 시각적 이상 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)