### PR TITLE
refactor: BacktestData 페이지 데이터 흐름 컨벤션 준수

### DIFF
--- a/frontend/src/api/data.ts
+++ b/frontend/src/api/data.ts
@@ -1,23 +1,8 @@
 import client from './client'
 import type { FeedStatus } from '../types/feed'
+import type { DataType, Dataset, StorageInfo } from '../types/data'
 
-export type DataType = 'ohlcv' | 'fundamental'
-
-export interface Dataset {
-  id: string
-  symbol: string
-  timeframe: string
-  data_type: DataType
-  start_date: string
-  end_date: string
-  row_count: number
-}
-
-export interface StorageInfo {
-  total_bytes: number
-  total_mb: number
-  by_timeframe: Record<string, number>
-}
+export type { DataType, Dataset, StorageInfo }
 
 export async function getDatasets(params?: {
   symbol?: string

--- a/frontend/src/hooks/useBacktestData.ts
+++ b/frontend/src/hooks/useBacktestData.ts
@@ -1,0 +1,35 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getDatasets, getStorageInfo, deleteDataset } from '../api/data'
+import type { Dataset } from '../types/data'
+
+export function useDatasets(params?: {
+  symbol?: string
+  timeframe?: string
+  data_type?: 'ohlcv' | 'fundamental'
+  offset?: number
+  limit?: number
+}) {
+  return useQuery({
+    queryKey: ['datasets-all', params],
+    queryFn: () => getDatasets(params),
+  })
+}
+
+export function useStorageInfo() {
+  return useQuery({
+    queryKey: ['storage'],
+    queryFn: getStorageInfo,
+  })
+}
+
+export function useDeleteDataset() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (target: Dataset) => deleteDataset(target.id, target.data_type),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['datasets'] })
+      queryClient.invalidateQueries({ queryKey: ['datasets-all'] })
+      queryClient.invalidateQueries({ queryKey: ['storage'] })
+    },
+  })
+}

--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getDatasets, getStorageInfo, deleteDataset } from '../api/data'
-import type { Dataset } from '../api/data'
+import type { Dataset } from '../types/data'
+import { useDatasets, useStorageInfo, useDeleteDataset } from '../hooks/useBacktestData'
 import { formatNumber, formatDate } from '../utils/formatters'
 import { Skeleton } from '../components/common/Skeleton'
 import FeedStatusPanel from '../components/data/FeedStatusPanel'
@@ -38,29 +37,11 @@ export default function BacktestData() {
   const [deleteTarget, setDeleteTarget] = useState<Dataset | null>(null)
   const searchRef = useRef<HTMLInputElement>(null)
   const fileListRef = useRef<HTMLDivElement>(null)
-  const queryClient = useQueryClient()
 
   // Fetch all datasets for building the directory tree
-  const { data: allData, isLoading } = useQuery({
-    queryKey: ['datasets-all'],
-    queryFn: () => getDatasets({ limit: 10000 }),
-  })
-
-  const { data: storage } = useQuery({
-    queryKey: ['storage'],
-    queryFn: getStorageInfo,
-  })
-
-  const deleteMutation = useMutation({
-    mutationFn: (target: Dataset) => deleteDataset(target.id, target.data_type),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['datasets'] })
-      queryClient.invalidateQueries({ queryKey: ['datasets-all'] })
-      queryClient.invalidateQueries({ queryKey: ['storage'] })
-      setDeleteTarget(null)
-      setSelectedDataset(null)
-    },
-  })
+  const { data: allData, isLoading } = useDatasets({ limit: 10000 })
+  const { data: storage } = useStorageInfo()
+  const deleteMutation = useDeleteDataset()
 
   const allDatasets = allData?.items ?? []
 
@@ -339,7 +320,9 @@ export default function BacktestData() {
             <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
               <button onClick={() => setDeleteTarget(null)} className="px-4 py-2 rounded text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover hover:text-text">취소</button>
               <button
-                onClick={() => deleteMutation.mutate(deleteTarget)}
+                onClick={() => deleteMutation.mutate(deleteTarget, {
+                  onSuccess: () => { setDeleteTarget(null); setSelectedDataset(null) },
+                })}
                 disabled={deleteMutation.isPending}
                 className="px-4 py-2 rounded text-[13px] font-medium bg-negative text-on-primary border border-negative cursor-pointer hover:bg-negative-hover disabled:opacity-50"
               >

--- a/frontend/src/types/data.ts
+++ b/frontend/src/types/data.ts
@@ -1,0 +1,17 @@
+export type DataType = 'ohlcv' | 'fundamental'
+
+export interface Dataset {
+  id: string
+  symbol: string
+  timeframe: string
+  data_type: DataType
+  start_date: string
+  end_date: string
+  row_count: number
+}
+
+export interface StorageInfo {
+  total_bytes: number
+  total_mb: number
+  by_timeframe: Record<string, number>
+}


### PR DESCRIPTION
## Summary
- `types/data.ts` 신설 — `Dataset`, `DataType`, `StorageInfo` 타입을 `api/data.ts`에서 분리
- `hooks/useBacktestData.ts` 신설 — `useDatasets`, `useStorageInfo`, `useDeleteDataset` React Query 훅
- `pages/BacktestData.tsx`에서 `api/` 직접 import 제거, `hooks/` 경유로 전환
- 기존 기능 동일 동작, `npm run build` 성공 확인

## Test plan
- [ ] 백테스트 데이터 페이지 진입 시 데이터셋 목록 정상 로드
- [ ] 디렉토리 탐색(ohlcv/fundamental -> 종목 -> 타임프레임) 정상 동작
- [ ] 검색 기능 정상 동작
- [ ] 데이터셋 삭제 후 목록 자동 갱신
- [ ] 스토리지 용량 표시 정상

Refs #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)