### PR TITLE
fix(broker): AccountService.get_broker()에 is_paper 미주입 수정

### DIFF
--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -485,6 +485,7 @@ class AccountService:
         config: dict[str, Any] = {
             "exchange": account.exchange,
             "trading_mode": account.trading_mode.value,
+            "is_paper": account.trading_mode == TradingMode.VIRTUAL,
             "buy_commission_rate": float(account.buy_commission_rate),
             "sell_commission_rate": float(account.sell_commission_rate),
             **account.credentials,

--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -180,7 +180,7 @@ class KISBaseAdapter(BrokerAdapter):
         self.app_key: str = config["app_key"]
         self.app_secret: str = config["app_secret"]
         self.account_no: str = config["account_no"]
-        self.is_paper: bool = config.get("is_paper", False)
+        self.is_paper: bool = config.get("is_paper", True)
         self._eventbus = eventbus
 
         # API 엔드포인트

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -387,6 +387,36 @@ async def test_get_broker_cached(service):
     assert broker1 is broker2
 
 
+@pytest.mark.asyncio
+async def test_get_broker_injects_is_paper_virtual(service):
+    """VIRTUAL 계좌 → config에 is_paper=True 주입."""
+    await service.create(_make_account(trading_mode=TradingMode.VIRTUAL))
+    broker = await service.get_broker("test")
+    assert broker.config.get("is_paper") is True
+
+
+@pytest.mark.asyncio
+async def test_get_broker_injects_is_paper_live(service):
+    """LIVE 계좌 → config에 is_paper=False 주입."""
+    await service.create(_make_account(trading_mode=TradingMode.LIVE))
+    broker = await service.get_broker("test")
+    assert broker.config.get("is_paper") is False
+
+
+@pytest.mark.asyncio
+async def test_get_broker_credentials_override_is_paper(service):
+    """credentials에 is_paper 명시 시 우선 적용."""
+    await service.create(
+        _make_account(
+            trading_mode=TradingMode.VIRTUAL,
+            credentials={"app_key": "k", "app_secret": "s", "is_paper": False},
+        )
+    )
+    broker = await service.get_broker("test")
+    # credentials spread가 뒤에 위치하므로 is_paper=False로 덮어씀
+    assert broker.config.get("is_paper") is False
+
+
 # ── 기본 테스트 계좌 ──────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- `AccountService.get_broker()`에서 `trading_mode == VIRTUAL`일 때 `is_paper=True`를 config에 주입하여 KIS 어댑터가 모의투자 URL/tr_id를 사용하도록 수정
- `KISBaseAdapter`의 `is_paper` 기본값을 `False`→`True`로 변경 (안전한 방향)
- credentials에 `is_paper`를 명시한 경우 기존처럼 spread로 덮어쓰기 가능

## Test plan
- [x] `test_get_broker_injects_is_paper_virtual` — VIRTUAL 계좌 → is_paper=True 검증
- [x] `test_get_broker_injects_is_paper_live` — LIVE 계좌 → is_paper=False 검증
- [x] `test_get_broker_credentials_override_is_paper` — credentials 수동 오버라이드 검증
- [ ] KIS 모의투자 Docker 환경에서 `모의투자: True` 로그 확인

Closes #895

🤖 Generated with [Claude Code](https://claude.com/claude-code)