### PR TITLE
fix(frontend): BotEditModal 전략 변경이 서버에 전송되지 않음

### DIFF
--- a/frontend/src/pages/BotDetail.tsx
+++ b/frontend/src/pages/BotDetail.tsx
@@ -300,6 +300,7 @@ function BotEditModal({ bot, onClose }: { bot: BotDetailType; onClose: () => voi
         botId: bot.bot_id,
         data: {
           name,
+          strategy_name: strategyName,
           interval_seconds: intervalSeconds,
           budget,
           auto_restart: autoRestart,

--- a/frontend/src/types/bot.ts
+++ b/frontend/src/types/bot.ts
@@ -83,6 +83,7 @@ export interface BotCreateRequest {
 
 export interface BotUpdateRequest {
   name?: string
+  strategy_name?: string
   interval_seconds?: number
   budget?: number
   auto_restart?: boolean

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -374,6 +374,7 @@ async def update_bot(
     body: BotUpdateRequest,
     request: Request,
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
+    registry: Annotated[Any | None, Depends(get_strategy_registry_optional)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """봇 설정 수정. 중지 상태에서만 허용."""
@@ -387,6 +388,20 @@ async def update_bot(
     updates = body.model_dump(exclude_none=True)
     if not updates:
         return {"bot": bot.get_info()}
+
+    # strategy_name → strategy_id 변환
+    strategy_name = updates.pop("strategy_name", None)
+    if strategy_name is not None:
+        if registry is None:
+            raise HTTPException(
+                status_code=503, detail="전략 레지스트리를 사용할 수 없습니다"
+            )
+        records = await registry.get_by_name(strategy_name)
+        if not records:
+            raise HTTPException(
+                status_code=404, detail=f"전략을 찾을 수 없습니다: {strategy_name}"
+            )
+        updates["strategy_id"] = records[0].strategy_id
 
     try:
         bot = await bot_manager.update_bot(bot_id, **updates)

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -184,6 +184,7 @@ class BotUpdateRequest(BaseModel):
     """봇 설정 수정 요청. None인 필드는 변경하지 않는다."""
 
     name: str | None = None
+    strategy_name: str | None = None
     interval_seconds: int | None = Field(default=None, ge=10, le=3600)
     budget: float | None = Field(default=None, gt=0)
     auto_restart: bool | None = None

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -120,6 +120,9 @@ class FakeBotManager:
             bot._name = updates["name"]
         if "interval_seconds" in updates:
             bot._interval_seconds = updates["interval_seconds"]
+        if "strategy_id" in updates:
+            bot._strategy_id = updates["strategy_id"]
+            bot.config.strategy_id = updates["strategy_id"]
         return bot
 
 
@@ -468,6 +471,9 @@ class FakeStrategyRegistry:
 
     async def get(self, strategy_id: str) -> FakeStrategyRecord | None:
         return self._strategies.get(strategy_id)
+
+    async def get_by_name(self, name: str) -> list[FakeStrategyRecord]:
+        return [r for r in self._strategies.values() if r.name == name]
 
 
 class TestCreateBotAccountStatus:
@@ -853,3 +859,53 @@ class TestUpdateBot:
         bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
         resp = client.put("/api/bots/bot-1", json={"budget": 2000000})
         assert resp.status_code == 200
+
+
+class TestUpdateBotStrategy:
+    """PUT /api/bots/{bot_id} 전략 변경 테스트."""
+
+    @pytest.fixture
+    def strategy_registry(self):
+        reg = FakeStrategyRegistry()
+        reg._strategies["s1"] = FakeStrategyRecord("s1", name="OldStrategy")
+        reg._strategies["s2"] = FakeStrategyRecord("s2", name="NewStrategy")
+        return reg
+
+    @pytest.fixture
+    def client_with_registry(
+        self, bot_manager, strategy_registry, default_account_service
+    ):
+        app = create_app(
+            bot_manager=bot_manager,
+            strategy_registry=strategy_registry,
+            account_service=default_account_service,
+        )
+        return TestClient(app)
+
+    def test_update_strategy_name(
+        self, client_with_registry, bot_manager, strategy_registry
+    ):
+        """strategy_name으로 전략 변경 성공."""
+        bot_manager._bots["bot-1"] = FakeBot(
+            "bot-1", status="stopped", strategy_id="s1"
+        )
+        resp = client_with_registry.put(
+            "/api/bots/bot-1", json={"strategy_name": "NewStrategy"}
+        )
+        assert resp.status_code == 200
+        assert bot_manager._bots["bot-1"]._strategy_id == "s2"
+
+    def test_update_strategy_name_not_found(self, client_with_registry, bot_manager):
+        """존재하지 않는 전략 이름 -> 404."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client_with_registry.put(
+            "/api/bots/bot-1", json={"strategy_name": "NonExistent"}
+        )
+        assert resp.status_code == 404
+        assert "전략을 찾을 수 없습니다" in resp.json()["detail"]
+
+    def test_update_strategy_without_registry(self, client, bot_manager):
+        """strategy_registry가 없을 때 strategy_name 전달 -> 503."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        resp = client.put("/api/bots/bot-1", json={"strategy_name": "SomeStrategy"})
+        assert resp.status_code == 503


### PR DESCRIPTION
## Summary
- BotEditModal의 `handleSave`에서 `strategy_name`이 mutation payload에 누락되어 전략 변경이 서버에 전송되지 않던 버그 수정
- 백엔드 `BotUpdateRequest` 스키마에 `strategy_name` 필드 추가, 라우트에서 `strategy_name` → `strategy_id` 변환 로직 추가
- 프론트엔드 `BotUpdateRequest` 타입에 `strategy_name` 필드 추가

## Test plan
- [x] 기존 봇 API 테스트 46건 통과 확인
- [x] 전략 변경 성공 테스트 추가 (`test_update_strategy_name`)
- [x] 존재하지 않는 전략 이름 → 404 테스트 추가 (`test_update_strategy_name_not_found`)
- [x] 레지스트리 미사용 시 → 503 테스트 추가 (`test_update_strategy_without_registry`)
- [x] 프론트엔드 TypeScript 타입 체크 통과

Refs #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)