### PR TITLE
epic/875: 유저스토리 라벨·문구 스펙 불일치 수정

### DIFF
--- a/frontend/src/components/agents/MemberCard.tsx
+++ b/frontend/src/components/agents/MemberCard.tsx
@@ -43,7 +43,7 @@ export default function MemberCard({ member, onSuspend, onReactivate, onRevoke, 
   return (
     <div
       onClick={() => isAgent ? navigate(`/agents/${member.member_id}`) : undefined}
-      className={`bg-surface border border-border rounded-lg p-5 flex gap-5 transition-colors${isRevoked ? ' opacity-50' : ''}${isAgent ? ' cursor-pointer hover:border-primary/50' : ''}`}
+      className={`bg-surface border border-border rounded-lg p-5 flex gap-5 transition-colors${isAgent ? ' cursor-pointer hover:border-primary/50' : ''}`}
     >
       {/* 프로필 아바타 */}
       <div className="relative shrink-0 flex items-start justify-center">
@@ -52,7 +52,7 @@ export default function MemberCard({ member, onSuspend, onReactivate, onRevoke, 
             {'👑'}
           </div>
         )}
-        <div className={`w-[72px] h-[72px] rounded-full flex items-center justify-center text-[45px] shrink-0 transition-transform hover:scale-[1.15] hover:-rotate-[8deg] cursor-default ${avatarColorClass}${isRevoked ? ' opacity-50' : ''}`}>
+        <div className={`w-[72px] h-[72px] rounded-full flex items-center justify-center text-[45px] shrink-0 transition-transform hover:scale-[1.15] hover:-rotate-[8deg] cursor-default ${avatarColorClass}${member.status === 'suspended' ? ' opacity-50' : ''}`}>
           {member.emoji || (isHuman ? '👤' : '🤖')}
         </div>
       </div>

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -10,7 +10,6 @@ const STATUS_TABS: { label: string; value: MemberStatus | 'all' }[] = [
   { label: '전체', value: 'all' },
   { label: 'active', value: 'active' },
   { label: 'suspended', value: 'suspended' },
-  { label: 'revoked', value: 'revoked' },
 ]
 
 export default function Agents() {
@@ -36,7 +35,7 @@ export default function Agents() {
     orgFilter === 'all' ? items : items.filter((m) => m.org === orgFilter)
 
   const filterAgents = (items: typeof allItems) => {
-    let filtered = filterByOrg(items)
+    let filtered = filterByOrg(items).filter(m => m.status !== 'revoked')
     if (statusFilter !== 'all') {
       filtered = filtered.filter((m) => m.status === statusFilter)
     }

--- a/frontend/src/pages/ApprovalDetail.tsx
+++ b/frontend/src/pages/ApprovalDetail.tsx
@@ -170,6 +170,17 @@ export default function ApprovalDetail() {
         {isPending && <ReviewControls approvalId={approval.id} isPending={isPending} title={approval.title} reviews={approval.reviews} type={approval.type} params={approval.params} />}
       </div>
 
+      {/* 승인 완료 배너 */}
+      {approval.status === 'approved' && (
+        <div className="bg-positive/10 text-positive rounded-lg px-[18px] py-[14px] mb-6 flex items-start gap-2.5 text-[13px]">
+          <span className="text-[15px] leading-none mt-0.5">{'\u2713'}</span>
+          <div>
+            <div className="font-semibold mb-1">승인 완료</div>
+            {approval.memo && <div className="text-[12px]">{approval.memo}</div>}
+          </div>
+        </div>
+      )}
+
       {/* 거부 사유 배너 */}
       {approval.status === 'rejected' && approval.reject_reason && (
         <div className="bg-negative/10 text-negative rounded-lg px-[18px] py-[14px] mb-6 flex items-start gap-2.5 text-[13px]">

--- a/frontend/src/pages/ReportDetail.tsx
+++ b/frontend/src/pages/ReportDetail.tsx
@@ -11,7 +11,7 @@ const STATUS_BADGE: Record<ReportStatus, { label: string; variant: string }> = {
   submitted: { label: '제출됨', variant: 'warning' },
   reviewed: { label: '검토됨', variant: 'info' },
   adopted: { label: '채택됨', variant: 'positive' },
-  rejected: { label: '거부됨', variant: 'negative' },
+  rejected: { label: '미채택', variant: 'negative' },
   archived: { label: '보관됨', variant: 'muted' },
 }
 
@@ -45,7 +45,7 @@ function ReportInfoCard({ report }: { report: ReportDetailType }) {
       <InfoRow label="전략명" value={<span className="font-mono text-[12px]">{report.strategy_name}</span>} />
       <InfoRow label="버전" value={report.strategy_version} />
       <InfoRow label="상태" value={<StatusBadge variant={status.variant as 'info'}>{status.label}</StatusBadge>} />
-      <InfoRow label="수행자" value={report.submitted_by} />
+      <InfoRow label="수행자" value={report.submitted_by_id ? `${report.submitted_by} (${report.submitted_by_id})` : report.submitted_by} />
       <InfoRow label="수행일" value={formatDateTime(report.submitted_at)} />
     </div>
   )

--- a/frontend/src/types/report.ts
+++ b/frontend/src/types/report.ts
@@ -40,6 +40,7 @@ export interface ReportDetail {
   status: ReportStatus
   submitted_at: string
   submitted_by: string
+  submitted_by_id?: string
   backtest_period: string
   total_return_pct: number
   total_trades: number

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -16,7 +16,7 @@ export const STRATEGY_STATUS_LABELS: Record<string, string> = {
   registered: '대기',
   active: '운용중',
   inactive: '중지',
-  archived: '보관됨',
+  archived: '보관',
 }
 
 /** 결재 상태 라벨 */


### PR DESCRIPTION
Refs #875

## 하위 이슈
- #879 S-1: 전략 상태 뱃지 라벨 불일치 → ✅
- #880 S-2: 전략 필터 탭 라벨 불일치 → ✅ (이미 적용)
- #881 R-1: 리포트 rejected 라벨 불일치 및 수행자 병기 → ✅
- #883 A-11: 결재 승인 완료 시 positive 배너 → ✅
- #884 M-1: revoked 에이전트 숨김 + suspended dimmed → ✅