### PR TITLE
fix(frontend): 에이전트 등록 폼 개선 및 상태 버튼 상세 전용 전환

### DIFF
--- a/frontend/src/components/agents/AgentRegisterForm.tsx
+++ b/frontend/src/components/agents/AgentRegisterForm.tsx
@@ -9,12 +9,19 @@ interface AgentRegisterFormProps {
   onTokenCreated: (agentId: string, token: string) => void
 }
 
+const AGENT_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/
+
 export default function AgentRegisterForm({ onClose, onTokenCreated }: AgentRegisterFormProps) {
   const [memberId, setMemberId] = useState('')
   const [name, setName] = useState('')
   const [org, setOrg] = useState('default')
   const [scopes, setScopes] = useState<string[]>([])
   const createMember = useCreateMember()
+
+  const memberIdError = memberId.length > 0 && !AGENT_ID_PATTERN.test(memberId)
+    ? '영문 소문자, 숫자, 하이픈만 사용 가능하며 첫 글자는 영문 소문자 또는 숫자여야 합니다'
+    : ''
+  const isFormValid = memberId.length > 0 && !memberIdError
 
   // 기존 소속 목록에서 동적으로 추출, 기본값과 병합
   const { data: allMembers } = useMembers({})
@@ -40,8 +47,12 @@ export default function AgentRegisterForm({ onClose, onTokenCreated }: AgentRegi
         <form onSubmit={handleSubmit}>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">Agent ID</label>
-            <input value={memberId} onChange={(e) => setMemberId(e.target.value)} placeholder="strategy-dev-03" className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary" required />
-            <div className="text-[12px] text-text-muted mt-1">영문, 숫자, 하이픈만 사용 가능</div>
+            <input value={memberId} onChange={(e) => setMemberId(e.target.value)} placeholder="strategy-dev-03" className={`w-full bg-bg border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none ${memberIdError ? 'border-negative focus:border-negative' : 'border-border focus:border-primary'}`} required />
+            {memberIdError ? (
+              <div className="text-[12px] text-negative mt-1">{memberIdError}</div>
+            ) : (
+              <div className="text-[12px] text-text-muted mt-1">영문 소문자, 숫자, 하이픈만 사용 가능</div>
+            )}
           </div>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">이름</label>
@@ -49,15 +60,18 @@ export default function AgentRegisterForm({ onClose, onTokenCreated }: AgentRegi
           </div>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">소속 (org)</label>
-            <select
+            <input
               value={org}
               onChange={(e) => setOrg(e.target.value)}
-              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary cursor-pointer"
-            >
+              list="org-options"
+              placeholder="소속을 입력하거나 선택하세요"
+              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary"
+            />
+            <datalist id="org-options">
               {orgOptions.map((o) => (
-                <option key={o} value={o}>{o}</option>
+                <option key={o} value={o} />
               ))}
-            </select>
+            </datalist>
           </div>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-2">권한 범위 (Scopes)</label>
@@ -77,7 +91,7 @@ export default function AgentRegisterForm({ onClose, onTokenCreated }: AgentRegi
           </div>
           <div className="flex justify-end gap-2 mt-6 pt-4 border-t border-border">
             <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
-            <button type="submit" disabled={createMember.isPending} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-on-primary border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50">등록</button>
+            <button type="submit" disabled={createMember.isPending || !isFormValid} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-primary text-on-primary border-none cursor-pointer hover:bg-primary-hover disabled:opacity-50">등록</button>
           </div>
         </form>
       </div>

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -22,7 +22,7 @@ export default function Agents() {
   const { data: allMembers, isLoading } = useMembers({})
   const { data: humanMembers } = useMembers({ type: 'human' })
   const { data: agentMembers } = useMembers({ type: 'agent' })
-  const { suspend, reactivate, revoke } = useMemberControl()
+  const { suspend } = useMemberControl()
 
   const humans = humanMembers ?? []
   const agents = agentMembers ?? []
@@ -122,9 +122,6 @@ export default function Agents() {
                   <MemberCard
                     key={m.member_id}
                     member={m}
-                    onSuspend={(id) => suspend.mutate(id)}
-                    onReactivate={(id) => reactivate.mutate(id)}
-                    onRevoke={(id) => { if (confirm('이 에이전트를 영구 폐기하시겠습니까?')) revoke.mutate(id) }}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Summary
- **#888**: 에이전트 등록 폼의 소속(org) 필드를 `<select>`에서 `<input>` + `<datalist>`로 변경하여 자유입력과 기존 목록 제안을 동시 지원. Agent ID에 `/^[a-z0-9][a-z0-9-]*$/` 정규식 검증 추가, 실패 시 에러 메시지 표시 및 제출 버튼 비활성화
- **#889**: Agent 카드(MemberCard)에서 상태 전환 버튼(정지/재활성화/폐기) props 제거. 상세 페이지(AgentDetail)에서만 노출되도록 변경. Human 멤버 액션은 기존 유지

## Test plan
- [ ] 에이전트 등록 폼에서 소속 필드에 자유 텍스트 입력 가능 확인
- [ ] 소속 필드 datalist에 기존 소속 목록이 제안되는지 확인
- [ ] Agent ID에 대문자, 특수문자, 하이픈으로 시작하는 값 입력 시 에러 메시지 표시 확인
- [ ] Agent ID 검증 실패 시 등록 버튼 비활성화 확인
- [ ] Agent 카드에서 정지/재활성화/폐기 버튼이 노출되지 않는지 확인
- [ ] Agent 상세 페이지에서는 상태 전환 버튼이 정상 노출되는지 확인
- [ ] Human 멤버 카드의 정지/비밀번호 변경 버튼은 기존과 동일하게 동작하는지 확인

Refs #888, #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)