### PR TITLE
feat: 자금 거래내역 날짜 필터, 데이터셋 파일크기/미리보기, 검색 debounce

### DIFF
--- a/frontend/src/api/data.ts
+++ b/frontend/src/api/data.ts
@@ -15,6 +15,11 @@ export async function getDatasets(params?: {
   return res.data
 }
 
+export async function getDatasetDetail(id: string): Promise<{ dataset: Dataset; preview: Record<string, unknown>[] }> {
+  const res = await client.get(`/api/data/datasets/${id}`)
+  return res.data
+}
+
 export async function getStorageInfo(): Promise<StorageInfo> {
   const res = await client.get('/api/data/storage')
   return res.data

--- a/frontend/src/api/treasury.ts
+++ b/frontend/src/api/treasury.ts
@@ -33,6 +33,8 @@ export async function getTreasuryTransactions(params: {
   limit?: number
   type?: string
   bot_id?: string
+  start_date?: string
+  end_date?: string
 }): Promise<{ items: TreasuryTransaction[]; total: number }> {
   const res = await client.get('/api/treasury/transactions', { params })
   return res.data

--- a/frontend/src/hooks/useBacktestData.ts
+++ b/frontend/src/hooks/useBacktestData.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getDatasets, getStorageInfo, deleteDataset } from '../api/data'
+import { getDatasets, getDatasetDetail, getStorageInfo, deleteDataset } from '../api/data'
 import type { Dataset } from '../types/data'
 
 export function useDatasets(params?: {
@@ -12,6 +12,14 @@ export function useDatasets(params?: {
   return useQuery({
     queryKey: ['datasets-all', params],
     queryFn: () => getDatasets(params),
+  })
+}
+
+export function useDatasetDetail(datasetId: string | null) {
+  return useQuery({
+    queryKey: ['dataset-detail', datasetId],
+    queryFn: () => getDatasetDetail(datasetId!),
+    enabled: !!datasetId,
   })
 }
 

--- a/frontend/src/hooks/useTreasury.ts
+++ b/frontend/src/hooks/useTreasury.ts
@@ -51,6 +51,8 @@ export function useTreasuryTransactions(params: {
   limit?: number
   type?: string
   bot_id?: string
+  start_date?: string
+  end_date?: string
 }) {
   return useQuery({
     queryKey: ['treasury', 'transactions', params],

--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
 import type { Dataset } from '../types/data'
-import { useDatasets, useStorageInfo, useDeleteDataset } from '../hooks/useBacktestData'
+import { useDatasets, useDatasetDetail, useStorageInfo, useDeleteDataset } from '../hooks/useBacktestData'
 import { formatNumber, formatDate } from '../utils/formatters'
 import { Skeleton } from '../components/common/Skeleton'
 import FeedStatusPanel from '../components/data/FeedStatusPanel'
@@ -32,6 +32,7 @@ export default function BacktestData() {
   const [currentPath, setCurrentPath] = useState<DirPath>([])
   const [focusIndex, setFocusIndex] = useState(0)
   const [selectedDataset, setSelectedDataset] = useState<Dataset | null>(null)
+  const [inputValue, setInputValue] = useState('')
   const [search, setSearch] = useState('')
   const [isSearching, setIsSearching] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<Dataset | null>(null)
@@ -56,7 +57,7 @@ export default function BacktestData() {
       return matched.map((ds) => ({
         name: `${ds.data_type}/${ds.symbol}/${ds.timeframe}.parquet`,
         isDir: false,
-        meta: `${formatNumber(ds.row_count)}`,
+        meta: `${formatNumber(ds.row_count)}${ds.file_size ? ' · ' + formatSize(ds.file_size) : ''}`,
         dataset: ds,
       }))
     }
@@ -95,7 +96,7 @@ export default function BacktestData() {
         .map((ds) => ({
           name: `${ds.timeframe}.parquet`,
           isDir: false,
-          meta: `${formatNumber(ds.row_count)}`,
+          meta: `${formatNumber(ds.row_count)}${ds.file_size ? ' · ' + formatSize(ds.file_size) : ''}`,
           dataset: ds,
         }))
     }
@@ -109,6 +110,14 @@ export default function BacktestData() {
     const showParent = currentPath.length > 0
     return showParent ? [{ name: '../', isDir: true } as FileEntry, ...entries] : entries
   }, [entries, currentPath, isSearching, search])
+
+  // Debounce search input (300ms)
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearch(inputValue)
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [inputValue])
 
   // Reset focus on path/search change
   useEffect(() => {
@@ -136,6 +145,7 @@ export default function BacktestData() {
         const ds = entry.dataset
         setCurrentPath([ds.data_type, ds.symbol])
         setIsSearching(false)
+        setInputValue('')
         setSearch('')
       }
       setSelectedDataset(entry.dataset)
@@ -152,6 +162,7 @@ export default function BacktestData() {
 
     if (e.key === 'Escape' && isSearching) {
       setIsSearching(false)
+      setInputValue('')
       setSearch('')
       fileListRef.current?.focus()
       return
@@ -186,6 +197,7 @@ export default function BacktestData() {
   const handleSearchKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
       setIsSearching(false)
+      setInputValue('')
       setSearch('')
       fileListRef.current?.focus()
     }
@@ -218,15 +230,15 @@ export default function BacktestData() {
           <input
             ref={searchRef}
             type="text"
-            value={search}
+            value={inputValue}
             onChange={(e) => {
-              setSearch(e.target.value)
+              setInputValue(e.target.value)
               if (e.target.value.trim()) setIsSearching(true)
               else setIsSearching(false)
             }}
-            onFocus={() => { if (search.trim()) setIsSearching(true) }}
+            onFocus={() => { if (inputValue.trim()) setIsSearching(true) }}
             onKeyDown={handleSearchKeyDown}
-            placeholder="검색 (종목명 또는 코드)"
+            placeholder="종목 코드 검색"
             className="w-[260px] px-2.5 py-1.5 text-[13px] bg-transparent border border-border rounded text-text font-mono placeholder:text-text-muted focus:outline-none focus:border-primary"
           />
           <span className="text-[11px] text-text-muted ml-auto whitespace-nowrap">
@@ -341,12 +353,15 @@ function DatasetDetailPanel({ dataset, onDelete }: { dataset: Dataset; onDelete:
   const ds = dataset
   const filePath = `${ds.data_type}/${ds.symbol}/${ds.timeframe}.parquet`
   const typeLabel = ds.data_type === 'ohlcv' ? 'OHLCV' : 'Fundamental'
-  const isOhlcv = ds.data_type === 'ohlcv'
+
+  const { data: detail } = useDatasetDetail(ds.id)
+  const preview = detail?.preview ?? []
+  const fileSize = detail?.dataset?.file_size ?? ds.file_size
 
   const separator = '\u2500'.repeat(65)
-  const headerCols = isOhlcv
-    ? 'date         open     high     low      close    volume'
-    : 'quarter      revenue       op_profit     net_profit    eps      roe'
+
+  // Build preview table from actual data
+  const previewColumns = preview.length > 0 ? Object.keys(preview[0]) : []
 
   return (
     <div className="space-y-4">
@@ -361,13 +376,25 @@ function DatasetDetailPanel({ dataset, onDelete }: { dataset: Dataset; onDelete:
         <span className="text-text font-semibold">{'Timeframe'}</span>{'  '}{ds.timeframe}{'\n'}
         <span className="text-text font-semibold">{'Period'}</span>{'     '}{ds.start_date} ~ {ds.end_date}{'\n'}
         <span className="text-text font-semibold">{'Rows'}</span>{'       '}<span className="text-text">{formatNumber(ds.row_count)}</span>{'\n'}
-        <span className="text-text font-semibold">{'Size'}</span>{'       '}<span className="text-text">-</span>
+        <span className="text-text font-semibold">{'Size'}</span>{'       '}<span className="text-text">{fileSize ? formatSize(fileSize) : '-'}</span>
       </pre>
       <pre className="m-0 whitespace-pre overflow-x-auto text-text-muted">
         <span className="text-border">{separator}</span>{'\n'}
-        <span className="text-text font-semibold">{headerCols}</span>{'\n'}
-        <span className="text-border">{separator}</span>{'\n'}
-        <span className="text-text-muted opacity-50">  데이터 미리보기는 API 확장 후 제공됩니다</span>{'\n'}
+        {preview.length > 0 ? (
+          <>
+            <span className="text-text font-semibold">{previewColumns.map((c) => c.padEnd(14)).join('')}</span>{'\n'}
+            <span className="text-border">{separator}</span>{'\n'}
+            {preview.map((row, i) => (
+              <span key={i}>
+                {previewColumns.map((c) => String(row[c] ?? '').padEnd(14)).join('')}{'\n'}
+              </span>
+            ))}
+          </>
+        ) : (
+          <>
+            <span className="text-text-muted opacity-50">  미리보기 데이터가 없습니다</span>{'\n'}
+          </>
+        )}
         <span className="text-border">{separator}</span>
       </pre>
       <pre className="m-0 whitespace-pre overflow-x-auto">

--- a/frontend/src/pages/TreasuryHistory.tsx
+++ b/frontend/src/pages/TreasuryHistory.tsx
@@ -17,6 +17,8 @@ const TYPE_TABS = [
 export default function TreasuryHistory() {
   const [typeFilter, setTypeFilter] = useState('')
   const [botFilter, setBotFilter] = useState('')
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
   const [offset, setOffset] = useState(0)
 
   const { data: budgets } = useBotBudgets()
@@ -27,6 +29,8 @@ export default function TreasuryHistory() {
     limit: LIMIT,
     type: typeFilter || undefined,
     bot_id: botFilter || undefined,
+    start_date: startDate || undefined,
+    end_date: endDate || undefined,
   })
 
   const handleTypeChange = (t: string) => { setTypeFilter(t); setOffset(0) }
@@ -61,6 +65,21 @@ export default function TreasuryHistory() {
             <option key={id} value={id}>{id}</option>
           ))}
         </select>
+        <div className="flex items-center gap-1.5 ml-auto">
+          <input
+            type="date"
+            value={startDate}
+            onChange={(e) => { setStartDate(e.target.value); setOffset(0) }}
+            className="bg-bg border border-border rounded-lg px-2.5 py-1.5 text-text text-[13px]"
+          />
+          <span className="text-text-muted text-[13px]">~</span>
+          <input
+            type="date"
+            value={endDate}
+            onChange={(e) => { setEndDate(e.target.value); setOffset(0) }}
+            className="bg-bg border border-border rounded-lg px-2.5 py-1.5 text-text text-[13px]"
+          />
+        </div>
       </div>
 
       {/* 이력 테이블 */}

--- a/frontend/src/types/data.ts
+++ b/frontend/src/types/data.ts
@@ -8,6 +8,7 @@ export interface Dataset {
   start_date: string
   end_date: string
   row_count: number
+  file_size?: number
 }
 
 export interface StorageInfo {

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -51,6 +51,15 @@ async def list_datasets(
             if symbol and sym != symbol:
                 continue
             date_range = store.get_date_range(sym, "", data_type="fundamental")
+            file_size = 0
+            try:
+                p = store._resolve_path(sym, "", data_type="fundamental")
+                if p.exists():
+                    file_size = sum(
+                        f.stat().st_size for f in p.rglob("*") if f.is_file()
+                    )
+            except Exception:
+                pass
             all_datasets.append(
                 {
                     "id": f"{sym}__fundamental",
@@ -60,6 +69,7 @@ async def list_datasets(
                     "start_date": date_range[0] if date_range else None,
                     "end_date": date_range[1] if date_range else None,
                     "row_count": 0,
+                    "file_size": file_size,
                 }
             )
     else:
@@ -73,6 +83,15 @@ async def list_datasets(
                     continue
                 date_range = store.get_date_range(sym, tf)
                 row_count = store.get_row_count(sym, tf)
+                file_size = 0
+                try:
+                    p = store._resolve_path(sym, tf, data_type="ohlcv")
+                    if p.exists():
+                        file_size = sum(
+                            f.stat().st_size for f in p.rglob("*") if f.is_file()
+                        )
+                except Exception:
+                    pass
                 all_datasets.append(
                     {
                         "id": f"{sym}__{tf}",
@@ -82,6 +101,7 @@ async def list_datasets(
                         "start_date": date_range[0] if date_range else None,
                         "end_date": date_range[1] if date_range else None,
                         "row_count": row_count,
+                        "file_size": file_size,
                     }
                 )
 
@@ -124,6 +144,12 @@ async def get_dataset_detail(
     # 메타데이터
     date_range = store.get_date_range(symbol, tf_for_store, data_type=data_type)
     row_count = 0 if is_fundamental else store.get_row_count(symbol, tf_for_store)
+    file_size = 0
+    try:
+        if path.exists():
+            file_size = sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
+    except Exception:
+        pass
 
     dataset_meta = {
         "id": dataset_id,
@@ -133,6 +159,7 @@ async def get_dataset_detail(
         "start_date": date_range[0] if date_range else None,
         "end_date": date_range[1] if date_range else None,
         "row_count": row_count,
+        "file_size": file_size,
     }
 
     # 최근 5행 미리보기

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -119,6 +119,8 @@ async def list_transactions(
     account_id: str | None = None,
     type: str | None = None,
     bot_id: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
     limit: int = 20,
     offset: int = 0,
 ) -> dict:
@@ -139,6 +141,12 @@ async def list_transactions(
     if bot_id:
         where_clauses.append("bot_id = ?")
         params.append(bot_id)
+    if start_date:
+        where_clauses.append("created_at >= ?")
+        params.append(start_date)
+    if end_date:
+        where_clauses.append("created_at <= ?")
+        params.append(end_date + " 23:59:59")
 
     where_sql = (" WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
 

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -567,6 +567,7 @@ class DatasetItem(BaseModel):
     start_date: str | None = None
     end_date: str | None = None
     row_count: int = 0
+    file_size: int = 0
 
 
 class DatasetListResponse(BaseModel):


### PR DESCRIPTION
## Summary
- **#885**: 자금 거래내역에 기간(날짜) 필터 추가 — 백엔드 `start_date`/`end_date` 파라미터, 프론트엔드 날짜 입력 UI
- **#886**: 데이터셋 파일 크기(`file_size`) 목록/상세 응답 연동, 상세 API 미리보기 데이터 테이블 렌더링
- **#887**: 종목 검색 입력에 300ms debounce 적용, placeholder를 "종목 코드 검색"으로 변경 (종목명 검색은 백엔드 선행 작업 필요 — 이슈에 코멘트 완료)

## Test plan
- [ ] Treasury History 페이지에서 시작일/종료일 선택 후 거래내역이 필터링되는지 확인
- [ ] BacktestData 페이지에서 데이터셋 선택 시 파일 크기와 미리보기 테이블이 표시되는지 확인
- [ ] BacktestData 검색창에 빠르게 타이핑 시 debounce가 적용되어 검색이 지연되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)