### PR TITLE
feat: 결재함 서버사이드 검색 + 스토리지 유형별 용량 표시

### DIFF
--- a/frontend/src/api/approvals.ts
+++ b/frontend/src/api/approvals.ts
@@ -4,6 +4,7 @@ import type { Approval, ApprovalDetail, ApprovalStatus, ApprovalType } from '../
 interface ApprovalsParams {
   status?: ApprovalStatus | 'all'
   type?: ApprovalType | 'all'
+  search?: string
   offset?: number
   limit?: number
 }
@@ -26,6 +27,7 @@ export async function getApprovals(params: ApprovalsParams): Promise<ApprovalsRe
   const query: Record<string, string | number> = {}
   if (params.status && params.status !== 'all') query.status = params.status
   if (params.type && params.type !== 'all') query.type = params.type
+  if (params.search) query.search = params.search
   if (params.offset) query.offset = params.offset
   if (params.limit) query.limit = params.limit
   const res = await client.get('/api/approvals', { params: query })

--- a/frontend/src/hooks/useApprovals.ts
+++ b/frontend/src/hooks/useApprovals.ts
@@ -5,6 +5,7 @@ import type { ApprovalStatus, ApprovalType } from '../types/approval'
 export function useApprovals(params: {
   status?: ApprovalStatus | 'all'
   type?: ApprovalType | 'all'
+  search?: string
   offset?: number
   limit?: number
 }) {

--- a/frontend/src/pages/Approvals.tsx
+++ b/frontend/src/pages/Approvals.tsx
@@ -14,13 +14,10 @@ export default function Approvals() {
   const [search, setSearch] = useState('')
   const [offset, setOffset] = useState(0)
 
-  const { data, isLoading } = useApprovals({ status, type, offset, limit: LIMIT })
+  const { data, isLoading } = useApprovals({ status, type, search: search || undefined, offset, limit: LIMIT })
   const pendingQuery = useApprovals({ status: 'pending', limit: 0 })
 
   const allItems = data?.items ?? []
-  const filtered = search
-    ? allItems.filter((item) => item.title.toLowerCase().includes(search.toLowerCase()))
-    : allItems
 
   return (
     <>
@@ -38,7 +35,7 @@ export default function Approvals() {
           <TableSkeleton rows={5} cols={6} />
         ) : (
           <>
-            <ApprovalTable items={filtered} />
+            <ApprovalTable items={allItems} />
             {(data?.total ?? 0) > LIMIT && (
               <Pagination
                 total={data?.total ?? 0}

--- a/frontend/src/pages/BacktestData.tsx
+++ b/frontend/src/pages/BacktestData.tsx
@@ -208,11 +208,14 @@ export default function BacktestData() {
   }
 
   // Storage info string
+  const DATA_TYPE_LABELS: Record<string, string> = { ohlcv: 'OHLCV', fundamental: 'Fundamental' }
   const storageStr = storage
     ? `전체 ${formatSize(storage.total_bytes ?? storage.total_mb * 1024 * 1024)}`
-      + (storage.by_timeframe && Object.keys(storage.by_timeframe).length > 0
-        ? ` — ${Object.entries(storage.by_timeframe).map(([tf, bytes]) => `${TF_LABELS[tf] ?? tf} ${formatSize(bytes)}`).join(' · ')}`
-        : '')
+      + (storage.by_data_type && Object.keys(storage.by_data_type).length > 0
+        ? ` — ${Object.entries(storage.by_data_type).map(([dt, mb]) => `${DATA_TYPE_LABELS[dt] ?? dt} ${mb.toFixed(1)} MB`).join(' · ')}`
+        : storage.by_timeframe && Object.keys(storage.by_timeframe).length > 0
+          ? ` — ${Object.entries(storage.by_timeframe).map(([tf, mb]) => `${TF_LABELS[tf] ?? tf} ${mb.toFixed(1)} MB`).join(' · ')}`
+          : '')
     : ''
 
   return (

--- a/frontend/src/types/data.ts
+++ b/frontend/src/types/data.ts
@@ -15,4 +15,5 @@ export interface StorageInfo {
   total_bytes: number
   total_mb: number
   by_timeframe: Record<string, number>
+  by_data_type?: Record<string, number>
 }

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -205,15 +205,31 @@ async def get_storage_summary(
 ) -> dict:
     """저장 용량 현황."""
     if store is None:
-        return {"total_bytes": 0, "total_mb": 0.0, "by_timeframe": {}}
+        return {
+            "total_bytes": 0,
+            "total_mb": 0.0,
+            "by_timeframe": {},
+            "by_data_type": {},
+        }
     usage = store.get_storage_usage()
     total = sum(usage.values())
+
+    # 유형별 용량 집계: ohlcv = timeframe 키들의 합, 나머지는 그대로
+    ohlcv_keys = {"fundamental", "tick"}
+    ohlcv_total = sum(v for k, v in usage.items() if k not in ohlcv_keys)
+    by_data_type: dict[str, float] = {}
+    if ohlcv_total > 0:
+        by_data_type["ohlcv"] = round(ohlcv_total / 1024 / 1024, 1)
+    if usage.get("fundamental", 0) > 0:
+        by_data_type["fundamental"] = round(usage["fundamental"] / 1024 / 1024, 1)
+
     return {
         "total_bytes": total,
         "total_mb": round(total / 1024 / 1024, 1),
         "by_timeframe": {
             tf: round(size / 1024 / 1024, 1) for tf, size in usage.items()
         },
+        "by_data_type": by_data_type,
     }
 
 

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -597,6 +597,7 @@ class StorageSummaryResponse(BaseModel):
     total_bytes: int
     total_mb: float
     by_timeframe: dict[str, float]
+    by_data_type: dict[str, float] | None = None
 
 
 class FeedStatusResponse(BaseModel):


### PR DESCRIPTION
## Summary
- **#890 결재함 서버사이드 제목 검색**: 프론트엔드 API/hook/페이지에서 `search` 파라미터를 서버로 전달하고, 클라이언트 필터링을 제거하여 서버사이드 검색으로 전환
- **#891 스토리지 유형별 용량 표시**: 백엔드 `StorageSummaryResponse`에 `by_data_type` 필드를 추가하여 OHLCV/Fundamental별 용량을 집계하고, 프론트엔드에서 우선 표시 (폴백: 기존 `by_timeframe`)

## Test plan
- [ ] 결재함에서 제목 검색 시 서버 API에 `search` 쿼리 파라미터가 전달되는지 확인
- [ ] 검색 결과가 서버에서 필터링되어 반환되는지 확인
- [ ] 스토리지 현황에 "OHLCV X.X MB · Fundamental X.X MB" 형식으로 표시되는지 확인
- [ ] `by_data_type`이 없는 이전 API 응답에서 `by_timeframe` 폴백이 동작하는지 확인

Refs #890, #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)