### PR TITLE
feat(frontend): 리포트 상세 듀얼 차트·마크다운·수익률% 병기

### DIFF
--- a/frontend/src/components/charts/DailyReturnChart.tsx
+++ b/frontend/src/components/charts/DailyReturnChart.tsx
@@ -1,0 +1,64 @@
+import { useCallback } from 'react'
+import { HistogramSeries, type IChartApi } from 'lightweight-charts'
+import LightweightChart from './LightweightChart'
+import type { EquityDataPoint } from './EquityCurveChart'
+
+interface DailyReturnChartProps {
+  data: EquityDataPoint[]
+  className?: string
+}
+
+interface DailyReturnPoint {
+  time: string
+  value: number
+  color: string
+}
+
+const POSITIVE_COLOR = 'rgba(30, 142, 255, 0.85)' // --color-positive
+const NEGATIVE_COLOR = 'rgba(232, 88, 48, 0.85)' // --color-negative
+
+function computeDailyReturns(data: EquityDataPoint[]): DailyReturnPoint[] {
+  if (data.length < 2) return []
+
+  const returns: DailyReturnPoint[] = []
+  for (let i = 1; i < data.length; i++) {
+    const prev = data[i - 1].value
+    if (prev === 0) continue
+    const pct = ((data[i].value - prev) / prev) * 100
+    returns.push({
+      time: data[i].date,
+      value: pct,
+      color: pct >= 0 ? POSITIVE_COLOR : NEGATIVE_COLOR,
+    })
+  }
+  return returns
+}
+
+export default function DailyReturnChart({ data, className }: DailyReturnChartProps) {
+  const handleChartReady = useCallback(
+    (chart: IChartApi) => {
+      const histogramSeries = chart.addSeries(HistogramSeries, {
+        priceFormat: {
+          type: 'custom',
+          formatter: (price: number) => `${price.toFixed(2)}%`,
+        },
+      })
+
+      const returns = computeDailyReturns(data)
+      histogramSeries.setData(returns as Parameters<typeof histogramSeries.setData>[0])
+      chart.timeScale().fitContent()
+    },
+    [data],
+  )
+
+  const returns = computeDailyReturns(data)
+  if (returns.length === 0) {
+    return (
+      <div className={`flex items-center justify-center text-[13px] text-text-muted ${className ?? 'h-[180px]'}`}>
+        일별 수익률 데이터가 부족합니다
+      </div>
+    )
+  }
+
+  return <LightweightChart key={data.length} onChartReady={handleChartReady} className={className ?? 'h-[180px]'} />
+}

--- a/frontend/src/pages/ReportDetail.tsx
+++ b/frontend/src/pages/ReportDetail.tsx
@@ -1,8 +1,10 @@
 import { useParams } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
 import { useReportDetail } from '../hooks/useReports'
 import StatusBadge from '../components/common/StatusBadge'
 import { PageSkeleton } from '../components/common/Skeleton'
 import EquityCurveChart from '../components/charts/EquityCurveChart'
+import DailyReturnChart from '../components/charts/DailyReturnChart'
 import { formatDateTime } from '../utils/formatters'
 import type { ReportDetail as ReportDetailType, ReportStatus } from '../types/report'
 
@@ -135,8 +137,26 @@ function PerformanceCard({ report }: { report: ReportDetailType }) {
           </span>
         }
       />
-      <InfoRow label="평균 수익" value={<span className="text-positive">{formatCurrency(report.metrics?.avg_profit ? Math.round(report.metrics.avg_profit) : null)}</span>} />
-      <InfoRow label="평균 손실" value={<span className="text-negative">{formatCurrency(report.metrics?.avg_loss ? Math.round(report.metrics.avg_loss) : null)}</span>} />
+      <InfoRow
+        label="평균 수익"
+        value={
+          <span className="text-positive">
+            {report.metrics?.avg_profit != null && initialBalance
+              ? `${formatCurrency(Math.round(report.metrics.avg_profit))} (${((report.metrics.avg_profit / initialBalance) * 100).toFixed(2)}%)`
+              : formatCurrency(report.metrics?.avg_profit ? Math.round(report.metrics.avg_profit) : null)}
+          </span>
+        }
+      />
+      <InfoRow
+        label="평균 손실"
+        value={
+          <span className="text-negative">
+            {report.metrics?.avg_loss != null && initialBalance
+              ? `${formatCurrency(Math.round(report.metrics.avg_loss))} (${((report.metrics.avg_loss / initialBalance) * 100).toFixed(2)}%)`
+              : formatCurrency(report.metrics?.avg_loss ? Math.round(report.metrics.avg_loss) : null)}
+          </span>
+        }
+      />
       <InfoRow label="수수료 합계" value={<span className="text-text-muted">{formatCurrency(report.metrics?.total_commission ? Math.round(report.metrics.total_commission) : null)}</span>} />
       <InfoRow label="활성 거래일" value={report.metrics?.active_days ? `${report.metrics.active_days}일` : '-'} />
     </div>
@@ -177,6 +197,18 @@ export default function ReportDetail() {
         )}
       </div>
 
+      {/* 일별 수익률 차트 */}
+      <div className="bg-surface border border-border rounded-lg p-5 mb-6">
+        <h3 className="text-[15px] font-semibold mb-3">일별 수익률</h3>
+        {report.equity_curve && report.equity_curve.length > 1 ? (
+          <DailyReturnChart data={report.equity_curve} className="h-[180px]" />
+        ) : (
+          <div className="h-[180px] bg-bg-elevated rounded flex items-center justify-center text-text-muted text-[13px]">
+            일별 수익률 데이터가 없습니다
+          </div>
+        )}
+      </div>
+
       {/* 4행: 전략 요약 | 리스크 분석 */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div className="bg-surface border border-border rounded-lg p-5">
@@ -185,13 +217,17 @@ export default function ReportDetail() {
             {report.summary && (
               <div>
                 <div className="text-text font-semibold mb-1">요약</div>
-                <p>{report.summary}</p>
+                <div className="prose prose-sm prose-invert max-w-none text-[13px] text-text-muted">
+                  <ReactMarkdown>{report.summary}</ReactMarkdown>
+                </div>
               </div>
             )}
             {report.rationale && (
               <div>
                 <div className="text-text font-semibold mb-1">근거</div>
-                <p>{report.rationale}</p>
+                <div className="prose prose-sm prose-invert max-w-none text-[13px] text-text-muted">
+                  <ReactMarkdown>{report.rationale}</ReactMarkdown>
+                </div>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- **R-3**: `DailyReturnChart` 컴포넌트 신규 추가 — equity_curve에서 일별 수익률을 계산하여 Histogram series로 렌더링 (positive/negative 색상 구분)
- **R-4**: 전략 요약(summary)과 근거(rationale) 텍스트에 `ReactMarkdown` 적용, prose 스타일 유지
- **R-5**: PerformanceCard 평균 수익/손실 행에 초기자금 대비 수익률(%) 병기 — `"1,234원 (0.12%)"` 형식

Refs #892

## Test plan
- [ ] 리포트 상세 페이지에서 자산 곡선 차트 아래에 일별 수익률 바 차트가 표시되는지 확인
- [ ] 양수 수익률은 positive(파란) 색상, 음수는 negative(빨간) 색상인지 확인
- [ ] equity_curve 데이터가 1개 이하일 때 빈 상태 메시지 표시 확인
- [ ] summary/rationale에 마크다운 문법(굵게, 목록 등)이 올바르게 렌더링되는지 확인
- [ ] 평균 수익/손실 행에 금액과 퍼센트가 함께 표시되는지 확인
- [ ] initial_balance가 null일 때 퍼센트 없이 금액만 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)