### PR TITLE
feat(cli): 서버 실행 중 확인 유틸 함수 추가

### DIFF
--- a/src/ante/cli/commands/update.py
+++ b/src/ante/cli/commands/update.py
@@ -1,0 +1,19 @@
+"""업데이트 관련 유틸리티."""
+
+from __future__ import annotations
+
+import os
+
+
+def check_server_running() -> bool:
+    """서버가 실행 중인지 PID 파일로 확인. stale PID는 무시."""
+    from ante.main import read_pid_file
+
+    pid = read_pid_file()
+    if pid is None:
+        return False
+    try:
+        os.kill(pid, 0)  # 프로세스 존재 확인
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False

--- a/tests/unit/test_cli_update.py
+++ b/tests/unit/test_cli_update.py
@@ -1,0 +1,35 @@
+"""check_server_running 유틸 함수 테스트."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from ante.cli.commands.update import check_server_running
+
+
+class TestCheckServerRunning:
+    """check_server_running 테스트."""
+
+    @patch("ante.cli.commands.update.os.kill")
+    @patch("ante.main.read_pid_file", return_value=12345)
+    def test_pid_exists_and_process_running(
+        self, mock_read_pid: object, mock_kill: object
+    ) -> None:
+        """PID 파일 존재 + 프로세스 실행 중 -> True."""
+        assert check_server_running() is True
+
+    @patch(
+        "ante.cli.commands.update.os.kill",
+        side_effect=ProcessLookupError,
+    )
+    @patch("ante.main.read_pid_file", return_value=12345)
+    def test_pid_exists_but_stale(
+        self, mock_read_pid: object, mock_kill: object
+    ) -> None:
+        """PID 파일 존재 + 프로세스 미존재 (stale) -> False."""
+        assert check_server_running() is False
+
+    @patch("ante.main.read_pid_file", return_value=None)
+    def test_no_pid_file(self, mock_read_pid: object) -> None:
+        """PID 파일 미존재 -> False."""
+        assert check_server_running() is False


### PR DESCRIPTION
## Summary
- `check_server_running()` 유틸 함수 추가 (`src/ante/cli/commands/update.py`)
- PID 파일을 읽어 서버 프로세스 실행 여부를 확인하며, stale PID는 무시
- 3개 단위 테스트 추가 (`tests/unit/test_cli_update.py`)

Closes #915

## Test plan
- [x] PID 파일 존재 + 프로세스 실행 중 -> True
- [x] PID 파일 존재 + 프로세스 미존재 (stale) -> False
- [x] PID 파일 미존재 -> False
- [x] ruff check / ruff format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)