### PR TITLE
feat(db): Database 트랜잭션 컨텍스트 매니저 추가

### DIFF
--- a/src/ante/core/database.py
+++ b/src/ante/core/database.py
@@ -1,5 +1,8 @@
 """SQLite WAL 모드 비동기 래퍼."""
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
 import aiosqlite
 
 
@@ -10,6 +13,7 @@ class Database:
         self._db_path = db_path
         self._writer: aiosqlite.Connection | None = None
         self._reader: aiosqlite.Connection | None = None
+        self._in_transaction: bool = False
 
     async def _init_conn(self) -> aiosqlite.Connection:
         """공통 PRAGMA 설정으로 연결 초기화."""
@@ -48,7 +52,8 @@ class Database:
         """INSERT/UPDATE/DELETE 실행."""
         conn = self._get_writer()
         await conn.execute(sql, params)
-        await conn.commit()
+        if not self._in_transaction:
+            await conn.commit()
 
     async def fetch_one(self, sql: str, params: tuple = ()) -> dict | None:
         """단일 행 조회. dict(컬럼명 → 값) 반환."""
@@ -68,3 +73,20 @@ class Database:
         """DDL 스크립트 실행 (테이블 생성 등)."""
         conn = self._get_writer()
         await conn.executescript(sql)
+
+    @asynccontextmanager
+    async def transaction(self) -> AsyncIterator["Database"]:
+        """트랜잭션 컨텍스트 매니저. 실패 시 자동 ROLLBACK."""
+        if self._in_transaction:
+            raise RuntimeError("중첩 트랜잭션은 지원하지 않습니다")
+        conn = self._get_writer()
+        self._in_transaction = True
+        try:
+            await conn.execute("BEGIN")
+            yield self
+            await conn.execute("COMMIT")
+        except Exception:
+            await conn.execute("ROLLBACK")
+            raise
+        finally:
+            self._in_transaction = False

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -56,3 +56,60 @@ async def test_not_connected_raises():
     db = Database(":memory:")
     with pytest.raises(RuntimeError, match="DB 연결되지 않음"):
         await db.execute("SELECT 1")
+
+
+# --- 트랜잭션 컨텍스트 매니저 테스트 ---
+
+
+async def test_transaction_commit(db):
+    """트랜잭션 내 INSERT 2건이 context 탈출 후 정상 커밋된다."""
+    await db.execute_script("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);")
+
+    async with db.transaction():
+        await db.execute("INSERT INTO t (val) VALUES (?)", ("a",))
+        await db.execute("INSERT INTO t (val) VALUES (?)", ("b",))
+
+    rows = await db.fetch_all("SELECT * FROM t ORDER BY val")
+    assert len(rows) == 2
+    assert rows[0]["val"] == "a"
+    assert rows[1]["val"] == "b"
+
+
+async def test_transaction_rollback_on_exception(db):
+    """트랜잭션 내 예외 발생 시 INSERT가 롤백된다."""
+    await db.execute_script("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);")
+
+    with pytest.raises(ValueError, match="의도적 예외"):
+        async with db.transaction():
+            await db.execute("INSERT INTO t (val) VALUES (?)", ("a",))
+            raise ValueError("의도적 예외")
+
+    rows = await db.fetch_all("SELECT * FROM t")
+    assert len(rows) == 0
+
+
+async def test_transaction_nested_raises(db):
+    """이미 트랜잭션 중 재진입 시 RuntimeError가 발생한다."""
+    async with db.transaction():
+        with pytest.raises(RuntimeError, match="중첩 트랜잭션은 지원하지 않습니다"):
+            async with db.transaction():
+                pass  # pragma: no cover
+
+
+async def test_transaction_ddl(db):
+    """ALTER TABLE 2건을 하나의 트랜잭션으로 묶어 실행한다."""
+    await db.execute_script("CREATE TABLE t (id INTEGER PRIMARY KEY, col_a TEXT);")
+
+    async with db.transaction():
+        await db.execute("ALTER TABLE t ADD COLUMN col_b TEXT")
+        await db.execute("ALTER TABLE t ADD COLUMN col_c TEXT")
+
+    # 추가된 컬럼에 값을 삽입하여 DDL이 정상 적용되었는지 검증
+    await db.execute(
+        "INSERT INTO t (col_a, col_b, col_c) VALUES (?, ?, ?)",
+        ("a", "b", "c"),
+    )
+    row = await db.fetch_one("SELECT * FROM t WHERE col_a = ?", ("a",))
+    assert row is not None
+    assert row["col_b"] == "b"
+    assert row["col_c"] == "c"


### PR DESCRIPTION
## Summary
- `Database` 클래스에 `transaction()` async context manager 추가 (BEGIN/COMMIT/ROLLBACK 자동 관리)
- `execute()` 내부에서 `_in_transaction` 플래그를 확인하여 트랜잭션 중 auto-commit 비활성화
- 중첩 트랜잭션 시도 시 `RuntimeError` 발생

## Test plan
- [x] 정상 커밋: 트랜잭션 내 INSERT 2건 → context 탈출 후 SELECT 2건 확인
- [x] 예외 시 롤백: INSERT 후 예외 raise → SELECT 0건 확인
- [x] 중첩 트랜잭션 방지: 이미 트랜잭션 중 재진입 시 RuntimeError
- [x] DDL 트랜잭션: ALTER TABLE 2건 묶어 실행 후 컬럼 존재 확인

Refs #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)