### PR TITLE
ci: PyPI 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (빌드만, 업로드 안함)"
+        type: boolean
+        default: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+          rm -rf ../src/ante/web/static/assets
+          cp -r dist/* ../src/ante/web/static/
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build package
+        run: |
+          pip install build
+          python -m build
+
+      - name: Verify wheel contents
+        run: |
+          pip install dist/*.whl
+          python -c "from ante.web import app; print('OK')"
+
+      - name: Publish to PyPI
+        if: github.event_name == 'release' || inputs.dry_run != true
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Summary
- `release` 이벤트(published) 또는 `workflow_dispatch`로 트리거되는 PyPI 배포 워크플로우 추가
- 프론트엔드 빌드 -> Python 패키지 빌드 -> wheel 검증 -> PyPI 퍼블리시 파이프라인 구성
- `workflow_dispatch`에서 dry_run 옵션으로 빌드만 실행 가능

## Test plan
- [ ] `workflow_dispatch`로 dry_run=true 실행하여 빌드 성공 확인
- [ ] dry_run=false 실행하여 PyPI 업로드 동작 확인
- [ ] GitHub Release 생성 시 자동 트리거 확인

Closes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)