### PR TITLE
feat(update): DB 안전 백업 함수 구현

### DIFF
--- a/src/ante/db/backup.py
+++ b/src/ante/db/backup.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+MAX_BACKUPS = 3
+
+
+def backup_db(src_path: Path, version: str) -> Path:
+    """sqlite3.backup()으로 안전한 DB 백업. 최근 MAX_BACKUPS개만 유지."""
+    if not src_path.exists():
+        raise FileNotFoundError(f"원본 DB 파일이 존재하지 않습니다: {src_path}")
+
+    dst_path = src_path.parent / f"{src_path.name}.bak.v{version}"
+
+    src_conn = sqlite3.connect(str(src_path))
+    dst_conn = sqlite3.connect(str(dst_path))
+    try:
+        src_conn.backup(dst_conn)
+    finally:
+        dst_conn.close()
+        src_conn.close()
+
+    logger.info("DB 백업 완료: %s", dst_path)
+    _cleanup_old_backups(src_path, keep=MAX_BACKUPS)
+    return dst_path
+
+
+def _cleanup_old_backups(src_path: Path, keep: int = MAX_BACKUPS) -> None:
+    """오래된 백업 파일 삭제. 최신 keep개만 유지."""
+    pattern = f"{src_path.name}.bak.v*"
+    backups = sorted(src_path.parent.glob(pattern), key=lambda p: p.stat().st_mtime)
+    for old in backups[:-keep]:
+        old.unlink()
+        logger.info("오래된 백업 삭제: %s", old)

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from ante.db.backup import backup_db
+
+
+@pytest.fixture()
+def wal_db(tmp_path: Path) -> Path:
+    """WAL 모드가 활성화된 테스트 DB를 생성한다."""
+    db_path = tmp_path / "ante.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)")
+    conn.execute("INSERT INTO items (name) VALUES ('alpha')")
+    conn.execute("INSERT INTO items (name) VALUES ('beta')")
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+class TestBackupIntegrity:
+    """TC-1: WAL 모드 DB 백업 정합성."""
+
+    def test_wal_backup_data_matches(self, wal_db: Path) -> None:
+        bak_path = backup_db(wal_db, "001")
+
+        conn = sqlite3.connect(str(bak_path))
+        rows = conn.execute("SELECT name FROM items ORDER BY id").fetchall()
+        conn.close()
+
+        assert rows == [("alpha",), ("beta",)]
+
+
+class TestNoWalShm:
+    """TC-2: 백업 경로에 -wal, -shm 파일이 없어야 한다."""
+
+    def test_no_wal_shm_files(self, wal_db: Path) -> None:
+        bak_path = backup_db(wal_db, "001")
+
+        assert not Path(f"{bak_path}-wal").exists()
+        assert not Path(f"{bak_path}-shm").exists()
+
+
+class TestBackupFileName:
+    """TC-3: 백업 파일명 형식 검증."""
+
+    def test_filename_pattern(self, wal_db: Path) -> None:
+        bak_path = backup_db(wal_db, "002")
+
+        assert bak_path.name == "ante.db.bak.v002"
+
+
+class TestOldBackupCleanup:
+    """TC-4: 오래된 백업 자동 삭제 — 4개 백업 후 최근 3개만 유지."""
+
+    def test_keeps_only_max_backups(self, wal_db: Path) -> None:
+        for i in range(4):
+            backup_db(wal_db, f"00{i + 1}")
+            time.sleep(0.05)  # mtime 차이 보장
+
+        pattern = f"{wal_db.name}.bak.v*"
+        remaining = sorted(wal_db.parent.glob(pattern))
+
+        assert len(remaining) == 3
+        assert not (wal_db.parent / "ante.db.bak.v001").exists()
+
+
+class TestMissingSourceDb:
+    """TC-5: 원본 DB 미존재 시 오류."""
+
+    def test_raises_on_missing_db(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nonexistent.db"
+
+        with pytest.raises(Exception):
+            backup_db(missing, "001")


### PR DESCRIPTION
## Summary
- `sqlite3.backup()` API를 사용한 안전한 DB 백업 함수 (`src/ante/db/backup.py`) 추가
- WAL 모드 DB 정합성 백업, 최근 3개 백업만 유지하여 디스크 공간 관리
- 원본 DB 미존재 시 `FileNotFoundError` 발생

## Test plan
- [x] WAL 모드 DB 백업 정합성 (INSERT -> 백업 -> SELECT 일치)
- [x] 백업 경로에 `-wal`, `-shm` 파일 없음
- [x] 백업 파일명 형식 `ante.db.bak.v{version}` 패턴 검증
- [x] 오래된 백업 자동 삭제 (4개 -> 최근 3개만 유지)
- [x] 원본 DB 미존재 시 오류

Closes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)