### PR TITLE
feat(update): 업데이트 전 의존성 스냅샷 저장

### DIFF
--- a/src/ante/cli/commands/update.py
+++ b/src/ante/cli/commands/update.py
@@ -86,12 +86,21 @@ def update(check: bool, target_version: str | None, yes: bool, force: bool) -> N
         pip_upgrade,
         rollback_update,
         run_post_update_migrations,
+        snapshot_dependencies,
     )
 
     db_path = Path("db/ante.db")
     if db_path.exists():
         click.echo("DB 백업 중...")
         backup_db(db_path, current)
+
+    # 의존성 스냅샷 저장
+    click.echo("의존성 스냅샷 저장 중...")
+    snapshot_path = snapshot_dependencies(current)
+    if snapshot_path:
+        click.echo(f"스냅샷 저장 완료: {snapshot_path}")
+    else:
+        click.echo("의존성 스냅샷 저장 실패 (계속 진행)", err=True)
 
     click.echo(f"업데이트 중: {current} → {latest}...")
     if not pip_upgrade(target_version):
@@ -105,10 +114,15 @@ def update(check: bool, target_version: str | None, yes: bool, force: bool) -> N
         backup_path = db_path.parent / f"{db_path.name}.bak.v{current}"
         if rollback_update(current, backup_path):
             click.echo(f"롤백 완료: {current}으로 복원됨")
+            if snapshot_path:
+                click.echo(f"의존성 복원: pip install -r {snapshot_path}")
         else:
+            restore_hint = f"  pip install ante=={current}"
+            if snapshot_path:
+                restore_hint += f"\n  pip install -r {snapshot_path}"
             click.echo(
                 f"자동 롤백 실패. 수동 복구 필요:\n"
-                f"  pip install ante=={current}\n"
+                f"{restore_hint}\n"
                 f"  cp {backup_path} db/ante.db",
                 err=True,
             )

--- a/src/ante/update/executor.py
+++ b/src/ante/update/executor.py
@@ -11,6 +11,33 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
+def snapshot_dependencies(version: str, db_dir: Path | None = None) -> Path | None:
+    """현재 pip freeze 결과를 파일로 저장한다.
+
+    저장 경로: ``{db_dir}/pip_freeze_v{version}.txt``
+
+    Returns:
+        저장된 파일의 Path. 실패 시 None.
+    """
+    if db_dir is None:
+        db_dir = Path("db")
+    db_dir.mkdir(parents=True, exist_ok=True)
+
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-m", "pip", "freeze"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        logger.error("pip freeze 실패: %s", result.stderr)
+        return None
+
+    snapshot_path = db_dir / f"pip_freeze_v{version}.txt"
+    snapshot_path.write_text(result.stdout, encoding="utf-8")
+    logger.info("의존성 스냅샷 저장: %s", snapshot_path)
+    return snapshot_path
+
+
 def pip_upgrade(version: str | None = None) -> bool:
     """pip으로 ante 패키지를 업그레이드한다. 성공 시 True."""
     cmd = [sys.executable, "-m", "pip", "install", "--upgrade"]

--- a/tests/unit/test_update_snapshot.py
+++ b/tests/unit/test_update_snapshot.py
@@ -1,0 +1,159 @@
+"""의존성 스냅샷(pip freeze) 단위 테스트."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.commands.update import update
+from ante.update.executor import snapshot_dependencies
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# snapshot_dependencies 함수 직접 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotDependencies:
+    """snapshot_dependencies 함수 단위 테스트."""
+
+    def test_creates_snapshot_file(self, tmp_path: Path) -> None:
+        """업데이트 실행 후 pip_freeze_v{version}.txt 파일이 생성된다."""
+        freeze_output = "requests==2.31.0\nclick==8.1.7\n"
+
+        with patch("ante.update.executor.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=freeze_output)
+            result = snapshot_dependencies("1.0.0", db_dir=tmp_path)
+
+        assert result is not None
+        expected = tmp_path / "pip_freeze_v1.0.0.txt"
+        assert expected.exists()
+        assert result == expected
+
+    def test_snapshot_content_valid(self, tmp_path: Path) -> None:
+        """스냅샷 파일에 package==version 형식 라인이 포함된다."""
+        freeze_output = "requests==2.31.0\nclick==8.1.7\nante==1.0.0\n"
+
+        with patch("ante.update.executor.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=freeze_output)
+            result = snapshot_dependencies("1.0.0", db_dir=tmp_path)
+
+        assert result is not None
+        content = result.read_text(encoding="utf-8")
+        lines = [line for line in content.strip().split("\n") if line]
+        for line in lines:
+            assert "==" in line, f"package==version 형식이 아님: {line}"
+
+    def test_pip_freeze_failure_returns_none(self, tmp_path: Path) -> None:
+        """pip freeze가 실패하면 None을 반환한다."""
+        with patch("ante.update.executor.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stderr="error")
+            result = snapshot_dependencies("1.0.0", db_dir=tmp_path)
+
+        assert result is None
+
+    def test_creates_db_dir_if_missing(self, tmp_path: Path) -> None:
+        """db 디렉터리가 없으면 자동으로 생성한다."""
+        db_dir = tmp_path / "subdir" / "db"
+        assert not db_dir.exists()
+
+        with patch("ante.update.executor.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="pkg==1.0\n")
+            result = snapshot_dependencies("0.5.0", db_dir=db_dir)
+
+        assert result is not None
+        assert db_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# CLI 통합: 롤백 안내에 스냅샷 경로 포함
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotInRollbackMessage:
+    """롤백 시 안내 메시지에 스냅샷 파일 경로가 포함되는지 테스트."""
+
+    def _make_patches(
+        self,
+        *,
+        migration_ok: bool = False,
+        rollback_ok: bool = True,
+        snapshot_path: Path | None = Path("db/pip_freeze_v1.0.0.txt"),
+    ) -> list:
+        return [
+            patch(
+                "ante.cli.commands.update.check_server_running",
+                return_value=False,
+            ),
+            patch(
+                "ante.update.checker.get_current_version",
+                return_value="1.0.0",
+            ),
+            patch(
+                "ante.update.checker.get_latest_version",
+                return_value="2.0.0",
+            ),
+            patch("ante.update.executor.pip_upgrade", return_value=True),
+            patch(
+                "ante.update.executor.run_post_update_migrations",
+                return_value=migration_ok,
+            ),
+            patch(
+                "ante.update.executor.rollback_update",
+                return_value=rollback_ok,
+            ),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("ante.db.backup.backup_db"),
+            patch(
+                "ante.update.executor.snapshot_dependencies",
+                return_value=snapshot_path,
+            ),
+        ]
+
+    def test_rollback_message_includes_snapshot_path(self, runner: CliRunner) -> None:
+        """롤백 성공 시 의존성 복원 안내에 스냅샷 경로가 포함된다."""
+        patches = self._make_patches(migration_ok=False, rollback_ok=True)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+        ):
+            result = runner.invoke(update, ["-y"])
+
+        assert result.exit_code == 1
+        assert "pip install -r" in result.output
+        assert "pip_freeze_v1.0.0.txt" in result.output
+
+    def test_manual_recovery_includes_snapshot_path(self, runner: CliRunner) -> None:
+        """수동 복구 안내에도 스냅샷 경로가 포함된다."""
+        patches = self._make_patches(migration_ok=False, rollback_ok=False)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+        ):
+            result = runner.invoke(update, ["-y"])
+
+        assert result.exit_code == 1
+        assert "pip install -r" in result.output
+        assert "pip_freeze_v1.0.0.txt" in result.output


### PR DESCRIPTION
## Summary
- 업데이트 전 `pip freeze` 결과를 `db/pip_freeze_v{version}.txt`에 저장하는 `snapshot_dependencies()` 함수 추가
- CLI `ante update` 명령에서 pip upgrade 직전에 스냅샷을 자동 저장
- 롤백 성공/실패 시 안내 메시지에 `pip install -r` 복원 명령 포함

## Test plan
- [x] 스냅샷 파일 생성 확인 (`test_creates_snapshot_file`)
- [x] 스냅샷 내용 유효성 검증 (`test_snapshot_content_valid`)
- [x] pip freeze 실패 시 None 반환 (`test_pip_freeze_failure_returns_none`)
- [x] db 디렉터리 자동 생성 (`test_creates_db_dir_if_missing`)
- [x] 롤백 메시지에 스냅샷 경로 포함 (`test_rollback_message_includes_snapshot_path`)
- [x] 수동 복구 안내에 스냅샷 경로 포함 (`test_manual_recovery_includes_snapshot_path`)
- [x] 기존 26개 테스트 전체 통과 확인

Closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)