### PR TITLE
feat(update): 디스크 공간 사전 검사

### DIFF
--- a/src/ante/cli/commands/update.py
+++ b/src/ante/cli/commands/update.py
@@ -3,8 +3,44 @@
 from __future__ import annotations
 
 import os
+import shutil
+from pathlib import Path
 
 import click
+
+# pip 다운로드 등 임시 파일을 위한 최소 여유 공간
+_MIN_FREE_MB = 100
+
+
+def check_disk_space(db_path: Path) -> tuple[bool, str]:
+    """디스크 여유 공간이 업데이트에 충분한지 확인한다.
+
+    필요 공간 = DB 크기 × 2 (백업 + 임시) + 100 MB (pip 다운로드).
+    DB 파일이 없으면 100 MB만 확인한다.
+
+    Returns:
+        (통과 여부, 안내 메시지) 튜플.
+    """
+    if db_path.exists():
+        db_size = db_path.stat().st_size
+        required = db_size * 2 + _MIN_FREE_MB * 1024 * 1024
+    else:
+        db_size = 0
+        required = _MIN_FREE_MB * 1024 * 1024
+
+    free = shutil.disk_usage(
+        db_path.parent if db_path.parent.exists() else Path(".")
+    ).free
+
+    if free >= required:
+        return True, ""
+
+    required_mb = required / (1024 * 1024)
+    free_mb = free / (1024 * 1024)
+    return False, (
+        f"디스크 공간 부족: 필요 {required_mb:.0f}MB, 여유 {free_mb:.0f}MB. "
+        "불필요한 파일을 정리한 후 다시 시도하세요."
+    )
 
 
 def check_server_running() -> bool:
@@ -73,13 +109,19 @@ def update(check: bool, target_version: str | None, yes: bool, force: bool) -> N
         click.echo("이미 최신 버전입니다")
         return
 
+    # 디스크 공간 사전 검사
+    db_path = Path("db/ante.db")
+    ok, msg = check_disk_space(db_path)
+    if not ok:
+        click.echo(msg, err=True)
+        raise SystemExit(1)
+
     if not yes:
         if not click.confirm(f"{current} → {latest}로 업데이트하시겠습니까?"):
             click.echo("업데이트를 취소했습니다")
             return
 
     # Phase A: 백업 + pip upgrade
-    from pathlib import Path
 
     from ante.db.backup import backup_db
     from ante.update.executor import (
@@ -88,7 +130,6 @@ def update(check: bool, target_version: str | None, yes: bool, force: bool) -> N
         run_post_update_migrations,
     )
 
-    db_path = Path("db/ante.db")
     if db_path.exists():
         click.echo("DB 백업 중...")
         backup_db(db_path, current)

--- a/tests/unit/test_disk_space_check.py
+++ b/tests/unit/test_disk_space_check.py
@@ -1,0 +1,151 @@
+"""check_disk_space 함수 단위 테스트. Refs #922."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.commands.update import _MIN_FREE_MB, check_disk_space
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestCheckDiskSpace:
+    """check_disk_space 유틸 함수 테스트."""
+
+    def test_sufficient_space_with_db(self, tmp_path: Path) -> None:
+        """DB 존재 + 충분한 공간 -> 통과."""
+        db_file = tmp_path / "ante.db"
+        db_file.write_bytes(b"\x00" * 1024 * 1024)  # 1 MB
+
+        required = 1024 * 1024 * 2 + _MIN_FREE_MB * 1024 * 1024
+        fake_free = required + 1024  # 여유 있음
+
+        with patch(
+            "ante.cli.commands.update.shutil.disk_usage",
+            return_value=type("Usage", (), {"free": fake_free})(),
+        ):
+            ok, msg = check_disk_space(db_file)
+
+        assert ok is True
+        assert msg == ""
+
+    def test_insufficient_space_with_db(self, tmp_path: Path) -> None:
+        """DB 존재 + 공간 부족 -> 실패 + 안내 메시지."""
+        db_file = tmp_path / "ante.db"
+        db_file.write_bytes(b"\x00" * 1024 * 1024)  # 1 MB
+
+        fake_free = 1024  # 거의 없음
+
+        with patch(
+            "ante.cli.commands.update.shutil.disk_usage",
+            return_value=type("Usage", (), {"free": fake_free})(),
+        ):
+            ok, msg = check_disk_space(db_file)
+
+        assert ok is False
+        assert "디스크 공간 부족" in msg
+
+    def test_no_db_file_sufficient_space(self, tmp_path: Path) -> None:
+        """DB 미존재 -> 100MB만 확인, 충분하면 통과."""
+        db_file = tmp_path / "ante.db"  # 생성 안 함
+
+        fake_free = _MIN_FREE_MB * 1024 * 1024 + 1024
+
+        with patch(
+            "ante.cli.commands.update.shutil.disk_usage",
+            return_value=type("Usage", (), {"free": fake_free})(),
+        ):
+            ok, msg = check_disk_space(db_file)
+
+        assert ok is True
+        assert msg == ""
+
+    def test_no_db_file_insufficient_space(self, tmp_path: Path) -> None:
+        """DB 미존재 + 100MB 미만 -> 실패."""
+        db_file = tmp_path / "ante.db"
+
+        fake_free = 1024  # 거의 없음
+
+        with patch(
+            "ante.cli.commands.update.shutil.disk_usage",
+            return_value=type("Usage", (), {"free": fake_free})(),
+        ):
+            ok, msg = check_disk_space(db_file)
+
+        assert ok is False
+        assert "디스크 공간 부족" in msg
+
+
+class TestUpdateDiskSpaceIntegration:
+    """update CLI 명령에서 디스크 공간 검사 통합 테스트."""
+
+    def test_disk_space_insufficient_blocks_update(self, runner: CliRunner) -> None:
+        """디스크 공간 부족 시 exit code 1로 종료한다."""
+        from ante.cli.commands.update import update
+
+        with (
+            patch(
+                "ante.cli.commands.update.check_server_running",
+                return_value=False,
+            ),
+            patch(
+                "ante.update.checker.get_current_version",
+                return_value="1.0.0",
+            ),
+            patch(
+                "ante.update.checker.get_latest_version",
+                return_value="2.0.0",
+            ),
+            patch(
+                "ante.cli.commands.update.check_disk_space",
+                return_value=(
+                    False,
+                    "디스크 공간 부족",
+                ),
+            ),
+        ):
+            result = runner.invoke(update, ["-y"])
+
+        assert result.exit_code == 1
+        assert "디스크 공간 부족" in result.output
+
+    def test_disk_space_sufficient_proceeds(self, runner: CliRunner) -> None:
+        """디스크 공간 충분 시 업데이트를 계속 진행한다."""
+        from ante.cli.commands.update import update
+
+        with (
+            patch(
+                "ante.cli.commands.update.check_server_running",
+                return_value=False,
+            ),
+            patch(
+                "ante.update.checker.get_current_version",
+                return_value="1.0.0",
+            ),
+            patch(
+                "ante.update.checker.get_latest_version",
+                return_value="2.0.0",
+            ),
+            patch(
+                "ante.cli.commands.update.check_disk_space",
+                return_value=(True, ""),
+            ),
+            patch("ante.db.backup.backup_db"),
+            patch("ante.update.executor.pip_upgrade", return_value=True),
+            patch(
+                "ante.update.executor.run_post_update_migrations",
+                return_value=True,
+            ),
+            patch("pathlib.Path.exists", return_value=False),
+        ):
+            result = runner.invoke(update, ["-y"])
+
+        assert result.exit_code == 0
+        assert "업데이트 완료" in result.output


### PR DESCRIPTION
## Summary
- 업데이트 실행 전 디스크 여유 공간을 확인하는 `check_disk_space()` 함수 추가
- DB 파일 존재 시 DB 크기 x 2 + 100MB, 미존재 시 100MB를 기준으로 판단
- 부족하면 안내 메시지 출력 후 exit code 1로 종료

## Test plan
- [x] 충분한 공간 시 검사 통과 확인
- [x] 부족한 공간 시 "디스크 공간 부족" 메시지 + exit code 1 확인
- [x] DB 파일 미존재 시 100MB만 확인
- [x] CLI 통합: 공간 부족 시 업데이트 차단, 충분 시 진행
- [x] 기존 테스트(test_update.py, test_cli_update.py) 전체 통과

Closes #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)