### PR TITLE
feat(cli): ante update --format json 지원

### DIFF
--- a/src/ante/cli/commands/update.py
+++ b/src/ante/cli/commands/update.py
@@ -6,6 +6,9 @@ import os
 
 import click
 
+from ante.cli.formatter import format_option
+from ante.cli.main import get_formatter
+
 
 def check_server_running() -> bool:
     """서버가 실행 중인지 PID 파일로 확인. stale PID는 무시."""
@@ -28,7 +31,15 @@ def check_server_running() -> bool:
 )
 @click.option("--yes", "-y", is_flag=True, help="확인 프롬프트 건너뛰기")
 @click.option("--force", is_flag=True, help="서버 실행 중이면 자동 중지")
-def update(check: bool, target_version: str | None, yes: bool, force: bool) -> None:
+@format_option
+@click.pass_context
+def update(
+    ctx: click.Context,
+    check: bool,
+    target_version: str | None,
+    yes: bool,
+    force: bool,
+) -> None:
     """ante를 최신 버전으로 업데이트합니다."""
     from ante.update.checker import (
         get_current_version,
@@ -36,28 +47,42 @@ def update(check: bool, target_version: str | None, yes: bool, force: bool) -> N
         is_update_available,
     )
 
+    fmt = get_formatter(ctx)
+
     # 서버 실행 중 확인
     if check_server_running():
         if force:
-            click.echo("서버를 중지합니다...")
+            if fmt.is_json:
+                pass  # JSON 모드에서는 중간 메시지 생략
+            else:
+                click.echo("서버를 중지합니다...")
             # TODO: graceful shutdown
         else:
-            click.echo(
+            fmt.error(
                 "서버가 실행 중입니다. "
-                "먼저 서버를 중지하거나 --force 옵션을 사용하세요.",
-                err=True,
+                "먼저 서버를 중지하거나 --force 옵션을 사용하세요."
             )
             raise SystemExit(1)
 
     current = get_current_version()
-    click.echo(f"현재 버전: {current}")
+    if not fmt.is_json:
+        click.echo(f"현재 버전: {current}")
 
     if check:
         latest = get_latest_version()
         if latest is None:
-            click.echo("PyPI 버전 확인 실패", err=True)
+            fmt.error("PyPI 버전 확인 실패")
             raise SystemExit(1)
-        if is_update_available(current, latest):
+        available = is_update_available(current, latest)
+        if fmt.is_json:
+            fmt.output(
+                {
+                    "current_version": current,
+                    "latest_version": latest,
+                    "update_available": available,
+                }
+            )
+        elif available:
             click.echo(f"업데이트 가능: {current} → {latest}")
         else:
             click.echo("이미 최신 버전입니다")
@@ -66,11 +91,20 @@ def update(check: bool, target_version: str | None, yes: bool, force: bool) -> N
     # 업데이트 실행
     latest = target_version or get_latest_version()
     if latest is None:
-        click.echo("PyPI 버전 확인 실패", err=True)
+        fmt.error("PyPI 버전 확인 실패")
         raise SystemExit(1)
 
     if not target_version and not is_update_available(current, latest):
-        click.echo("이미 최신 버전입니다")
+        if fmt.is_json:
+            fmt.output(
+                {
+                    "current_version": current,
+                    "latest_version": latest,
+                    "update_available": False,
+                }
+            )
+        else:
+            click.echo("이미 최신 버전입니다")
         return
 
     if not yes:
@@ -90,28 +124,47 @@ def update(check: bool, target_version: str | None, yes: bool, force: bool) -> N
 
     db_path = Path("db/ante.db")
     if db_path.exists():
-        click.echo("DB 백업 중...")
+        if not fmt.is_json:
+            click.echo("DB 백업 중...")
         backup_db(db_path, current)
 
-    click.echo(f"업데이트 중: {current} → {latest}...")
+    if not fmt.is_json:
+        click.echo(f"업데이트 중: {current} → {latest}...")
     if not pip_upgrade(target_version):
-        click.echo("업데이트 실패", err=True)
+        fmt.error("업데이트 실패")
         raise SystemExit(1)
 
     # Phase B: 마이그레이션
-    click.echo("DB 마이그레이션 실행 중...")
+    if not fmt.is_json:
+        click.echo("DB 마이그레이션 실행 중...")
     if not run_post_update_migrations():
-        click.echo("마이그레이션 실패. 자동 롤백 시도 중...", err=True)
+        if not fmt.is_json:
+            click.echo("마이그레이션 실패. 자동 롤백 시도 중...", err=True)
         backup_path = db_path.parent / f"{db_path.name}.bak.v{current}"
         if rollback_update(current, backup_path):
-            click.echo(f"롤백 완료: {current}으로 복원됨")
+            if fmt.is_json:
+                fmt.error("마이그레이션 실패. 롤백 완료.", code="migration_failed")
+            else:
+                click.echo(f"롤백 완료: {current}으로 복원됨")
         else:
-            click.echo(
-                f"자동 롤백 실패. 수동 복구 필요:\n"
-                f"  pip install ante=={current}\n"
-                f"  cp {backup_path} db/ante.db",
-                err=True,
-            )
+            if fmt.is_json:
+                fmt.error("마이그레이션 실패. 자동 롤백 실패.", code="rollback_failed")
+            else:
+                click.echo(
+                    f"자동 롤백 실패. 수동 복구 필요:\n"
+                    f"  pip install ante=={current}\n"
+                    f"  cp {backup_path} db/ante.db",
+                    err=True,
+                )
         raise SystemExit(1)
 
-    click.echo(f"업데이트 완료: {latest}")
+    if fmt.is_json:
+        fmt.success(
+            "업데이트 완료",
+            {
+                "previous_version": current,
+                "current_version": latest,
+            },
+        )
+    else:
+        click.echo(f"업데이트 완료: {latest}")

--- a/tests/unit/test_cli_update.py
+++ b/tests/unit/test_cli_update.py
@@ -1,10 +1,18 @@
-"""check_server_running 유틸 함수 테스트."""
+"""check_server_running 유틸 함수 및 --format json 테스트.
+
+이슈 #920: --format json 옵션 지원 검증.
+"""
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
+import pytest
+from click.testing import CliRunner
+
 from ante.cli.commands.update import check_server_running
+from ante.cli.main import cli
 
 
 class TestCheckServerRunning:
@@ -33,3 +41,160 @@ class TestCheckServerRunning:
     def test_no_pid_file(self, mock_read_pid: object) -> None:
         """PID 파일 미존재 -> False."""
         assert check_server_running() is False
+
+
+# ── --format json 테스트 ──────────────────────────────────────
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    """인증 우회 CliRunner."""
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+class TestUpdateFormatJson:
+    """--format json 출력 테스트."""
+
+    def test_check_format_json_valid(self, runner: CliRunner) -> None:
+        """--format json 출력이 유효한 JSON이다 (TC#1)."""
+        with (
+            patch(
+                "ante.cli.commands.update.check_server_running",
+                return_value=False,
+            ),
+            patch("ante.update.checker.get_current_version", return_value="0.6.1"),
+            patch("ante.update.checker.get_latest_version", return_value="0.7.0"),
+        ):
+            result = runner.invoke(cli, ["update", "--check", "--format", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, dict)
+
+    def test_check_format_json_fields(self, runner: CliRunner) -> None:
+        """JSON 출력에 필수 필드 존재 (TC#2)."""
+        with (
+            patch(
+                "ante.cli.commands.update.check_server_running",
+                return_value=False,
+            ),
+            patch("ante.update.checker.get_current_version", return_value="0.6.1"),
+            patch("ante.update.checker.get_latest_version", return_value="0.7.0"),
+        ):
+            result = runner.invoke(cli, ["update", "--check", "--format", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "current_version" in data
+        assert "latest_version" in data
+        assert "update_available" in data
+
+    def test_check_format_json_update_available_true(self, runner: CliRunner) -> None:
+        """업데이트 가능 시 update_available=true."""
+        with (
+            patch(
+                "ante.cli.commands.update.check_server_running",
+                return_value=False,
+            ),
+            patch("ante.update.checker.get_current_version", return_value="0.6.1"),
+            patch("ante.update.checker.get_latest_version", return_value="0.7.0"),
+        ):
+            result = runner.invoke(cli, ["update", "--check", "--format", "json"])
+
+        data = json.loads(result.output)
+        assert data["current_version"] == "0.6.1"
+        assert data["latest_version"] == "0.7.0"
+        assert data["update_available"] is True
+
+    def test_check_format_json_no_update(self, runner: CliRunner) -> None:
+        """이미 최신 버전이면 update_available=false."""
+        with (
+            patch(
+                "ante.cli.commands.update.check_server_running",
+                return_value=False,
+            ),
+            patch("ante.update.checker.get_current_version", return_value="0.7.0"),
+            patch("ante.update.checker.get_latest_version", return_value="0.7.0"),
+        ):
+            result = runner.invoke(cli, ["update", "--check", "--format", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["update_available"] is False
+
+
+class TestUpdateFormatText:
+    """--format text (기본) 출력 테스트 (TC#3)."""
+
+    def test_check_default_text(self, runner: CliRunner) -> None:
+        """기본 출력은 사람이 읽을 수 있는 텍스트 형식이다."""
+        with (
+            patch(
+                "ante.cli.commands.update.check_server_running",
+                return_value=False,
+            ),
+            patch("ante.update.checker.get_current_version", return_value="0.6.1"),
+            patch("ante.update.checker.get_latest_version", return_value="0.7.0"),
+        ):
+            result = runner.invoke(cli, ["update", "--check"])
+
+        assert result.exit_code == 0
+        assert "현재 버전: 0.6.1" in result.output
+        assert "업데이트 가능" in result.output
+
+    def test_check_explicit_text(self, runner: CliRunner) -> None:
+        """--format text 명시 시에도 텍스트 출력."""
+        with (
+            patch(
+                "ante.cli.commands.update.check_server_running",
+                return_value=False,
+            ),
+            patch("ante.update.checker.get_current_version", return_value="0.6.1"),
+            patch("ante.update.checker.get_latest_version", return_value="0.7.0"),
+        ):
+            result = runner.invoke(cli, ["update", "--check", "--format", "text"])
+
+        assert result.exit_code == 0
+        assert "현재 버전: 0.6.1" in result.output
+
+
+class TestUpdateFormatJsonError:
+    """JSON 모드 에러 출력 테스트."""
+
+    def test_server_running_json_error(self, runner: CliRunner) -> None:
+        """서버 실행 중 에러도 JSON으로 출력된다."""
+        with patch("ante.cli.commands.update.check_server_running", return_value=True):
+            result = runner.invoke(cli, ["update", "--check", "--format", "json"])
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert "error" in data
+
+    def test_pypi_failure_json_error(self, runner: CliRunner) -> None:
+        """PyPI 조회 실패 시 JSON 에러 출력."""
+        with (
+            patch(
+                "ante.cli.commands.update.check_server_running",
+                return_value=False,
+            ),
+            patch("ante.update.checker.get_current_version", return_value="1.0.0"),
+            patch("ante.update.checker.get_latest_version", return_value=None),
+        ):
+            result = runner.invoke(cli, ["update", "--check", "--format", "json"])
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert "error" in data

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -7,12 +7,26 @@ from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 
-from ante.cli.commands.update import update
+from ante.cli.main import cli
 
 
-@pytest.fixture
+@pytest.fixture()
 def runner() -> CliRunner:
-    return CliRunner()
+    """인증 우회 CliRunner."""
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
 
 
 class TestUpdateCheckFlag:
@@ -25,7 +39,7 @@ class TestUpdateCheckFlag:
             patch("ante.update.checker.get_current_version", return_value="1.0.0"),
             patch("ante.update.checker.get_latest_version", return_value="2.0.0"),
         ):
-            result = runner.invoke(update, ["--check"])
+            result = runner.invoke(cli, ["update", "--check"])
 
         assert result.exit_code == 0
         assert "현재 버전: 1.0.0" in result.output
@@ -39,7 +53,7 @@ class TestUpdateCheckFlag:
             patch("ante.update.checker.get_current_version", return_value="2.0.0"),
             patch("ante.update.checker.get_latest_version", return_value="2.0.0"),
         ):
-            result = runner.invoke(update, ["--check"])
+            result = runner.invoke(cli, ["update", "--check"])
 
         assert result.exit_code == 0
         assert "이미 최신 버전입니다" in result.output
@@ -51,7 +65,7 @@ class TestServerRunningBlock:
     def test_server_running_blocks_update(self, runner: CliRunner) -> None:
         """서버가 실행 중이면 exit code 1로 종료한다."""
         with patch("ante.cli.commands.update.check_server_running", return_value=True):
-            result = runner.invoke(update, ["--check"])
+            result = runner.invoke(cli, ["update", "--check"])
 
         assert result.exit_code == 1
         assert "서버가 실행 중입니다" in result.output

--- a/tests/unit/test_update_rollback.py
+++ b/tests/unit/test_update_rollback.py
@@ -8,13 +8,27 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from ante.cli.commands.update import update
+from ante.cli.main import cli
 from ante.update.executor import rollback_update
 
 
-@pytest.fixture
+@pytest.fixture()
 def runner() -> CliRunner:
-    return CliRunner()
+    """인증 우회 CliRunner."""
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
 
 
 # ---------------------------------------------------------------------------
@@ -135,7 +149,7 @@ class TestUpdateMigrationFailureRollback:
             patches[6],
             patches[7],
         ):
-            result = runner.invoke(update, ["-y"])
+            result = runner.invoke(cli, ["update", "-y"])
 
         assert result.exit_code == 1
         mock_rollback.assert_called_once()
@@ -156,7 +170,7 @@ class TestUpdateMigrationFailureRollback:
             patches[6],
             patches[7],
         ):
-            result = runner.invoke(update, ["-y"])
+            result = runner.invoke(cli, ["update", "-y"])
 
         assert result.exit_code == 1
         assert "자동 롤백 실패" in result.output
@@ -175,7 +189,7 @@ class TestUpdateMigrationFailureRollback:
             patches[6],
             patches[7],
         ):
-            result = runner.invoke(update, ["-y"])
+            result = runner.invoke(cli, ["update", "-y"])
 
         assert result.exit_code == 0
         mock_rollback.assert_not_called()


### PR DESCRIPTION
## Summary
- `ante update --check --format json` 지원 추가: `current_version`, `latest_version`, `update_available` 필드를 포함한 JSON 출력
- 에러 상황(서버 실행 중, PyPI 조회 실패)에서도 JSON 형식 에러 출력
- 기존 `test_update.py`, `test_update_rollback.py` 테스트를 `@click.pass_context` 변경에 맞게 업데이트

Closes #920

## Test plan
- [x] `--format json` 출력이 `json.loads`로 파싱 가능한 유효한 JSON
- [x] JSON 필드 존재 검증: `current_version`, `latest_version`, `update_available`
- [x] `--format text` 기본 출력이 사람이 읽을 수 있는 텍스트 형식
- [x] 에러 상황에서도 JSON 형식 출력 (`server_running`, `pypi_failure`)
- [x] 기존 28개 테스트 모두 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)