### PR TITLE
feat(db): Parquet 마이그레이션을 중앙 러너에 통합

### DIFF
--- a/src/ante/db/migrations.py
+++ b/src/ante/db/migrations.py
@@ -1,21 +1,34 @@
 """중앙 마이그레이션 러너.
 
 schema_version 테이블을 관리하며, 등록된 마이그레이션을 순차 실행한다.
+DB 마이그레이션과 Parquet 데이터 마이그레이션을 모두 지원한다.
 """
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable, Coroutine
+from pathlib import Path
 from typing import Any
 
 from ante.core.database import Database
-from ante.db.versions import v001_baseline
+from ante.db.versions import v001_baseline, v002_parquet_migration
 
-MigrateFn = Callable[[Database], Coroutine[Any, Any, None]]
+# 마이그레이션 함수 시그니처:
+#   async def migrate(db: Database) -> None                          (DB 전용)
+#   async def migrate(db: Database, *, data_path: Path | None) -> None  (DB + 데이터)
+MigrateFn = Callable[..., Coroutine[Any, Any, None]]
 
 MIGRATIONS: list[tuple[int, str, MigrateFn]] = [
     (1, "0.7.0", v001_baseline.migrate),
+    (2, "0.7.0", v002_parquet_migration.migrate),
 ]
+
+
+def _accepts_data_path(fn: MigrateFn) -> bool:
+    """마이그레이션 함수가 data_path 키워드 인자를 받는지 검사한다."""
+    sig = inspect.signature(fn)
+    return "data_path" in sig.parameters
 
 
 async def ensure_schema_version_table(db: Database) -> None:
@@ -35,15 +48,27 @@ async def get_applied_seqs(db: Database) -> set[int]:
     return {r["seq"] for r in rows}
 
 
-async def run_migrations(db: Database) -> list[str]:
-    """미적용 마이그레이션을 순차 실행하고, 적용된 항목 라벨을 반환한다."""
+async def run_migrations(
+    db: Database,
+    *,
+    data_path: Path | None = None,
+) -> list[str]:
+    """미적용 마이그레이션을 순차 실행하고, 적용된 항목 라벨을 반환한다.
+
+    Args:
+        db: Database 인스턴스.
+        data_path: 데이터 저장소 루트 경로. Parquet 마이그레이션에 전달된다.
+    """
     await ensure_schema_version_table(db)
     applied = await get_applied_seqs(db)
     newly_applied: list[str] = []
     for seq, version, migrate_fn in sorted(MIGRATIONS, key=lambda x: x[0]):
         if seq not in applied:
+            kwargs: dict[str, Any] = {}
+            if _accepts_data_path(migrate_fn):
+                kwargs["data_path"] = data_path
             async with db.transaction():
-                await migrate_fn(db)
+                await migrate_fn(db, **kwargs)
                 await db.execute(
                     "INSERT INTO schema_version (seq, version) VALUES (?, ?)",
                     (seq, version),
@@ -58,7 +83,7 @@ if __name__ == "__main__":
     async def main() -> None:
         db = Database("db/ante.db")
         await db.initialize()
-        applied = await run_migrations(db)
+        applied = await run_migrations(db, data_path=Path("data/"))
         if applied:
             print(f"마이그레이션 적용: {', '.join(applied)}")
         else:

--- a/src/ante/db/versions/v002_parquet_migration.py
+++ b/src/ante/db/versions/v002_parquet_migration.py
@@ -1,0 +1,36 @@
+"""Parquet 데이터 파일 경로 마이그레이션.
+
+기존 exchange 없는 Parquet 경로를 KRX/ 하위로 이동한다.
+DB 마이그레이션은 no-op이며, data_path가 전달되면 Parquet 경로 마이그레이션을 수행한다.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+
+logger = logging.getLogger(__name__)
+
+
+async def migrate(db: Database, *, data_path: Path | None = None) -> None:
+    """Parquet 경로 마이그레이션.
+
+    Args:
+        db: Database 인스턴스 (schema_version 기록용).
+        data_path: 데이터 저장소 루트 경로. None이면 Parquet 마이그레이션을 건너뛴다.
+    """
+    if data_path is None:
+        logger.info("data_path 미지정 — Parquet 마이그레이션 건너뜀")
+        return
+
+    from ante.data.store import migrate_parquet_paths
+
+    moved = migrate_parquet_paths(data_path)
+    if moved:
+        logger.info("Parquet 경로 마이그레이션 완료: %d개 이동", moved)
+    else:
+        logger.debug("Parquet 경로 마이그레이션: 변경 없음")

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1232,7 +1232,8 @@ async def main() -> None:
 
         from ante.db.migrations import run_migrations
 
-        applied = await run_migrations(s.db)
+        data_path = Path(s.config.get("data.path", "data/"))
+        applied = await run_migrations(s.db, data_path=data_path)
         if applied:
             logger.info("DB 마이그레이션 적용: %s", ", ".join(applied))
 

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -1,13 +1,18 @@
 """schema_version 테이블 + 중앙 마이그레이션 러너 테스트."""
 
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
 from ante.core.database import Database
 from ante.db.migrations import (
+    _accepts_data_path,
     ensure_schema_version_table,
     get_applied_seqs,
     run_migrations,
 )
+from ante.db.versions import v001_baseline, v002_parquet_migration
 
 
 @pytest.fixture
@@ -96,3 +101,91 @@ class TestRunMigrations:
             "WHERE type='table' AND name='schema_version'"
         )
         assert row is not None
+
+
+class TestParquetMigrationIntegration:
+    """Parquet 마이그레이션의 중앙 러너 통합 테스트."""
+
+    async def test_data_path_passed_to_parquet_migration(
+        self, db: Database, tmp_path: Path
+    ):
+        """마이그레이션 러너에서 data_path 인자가 Parquet 마이그레이션에 전달된다."""
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+
+        with patch(
+            "ante.data.store.migrate_parquet_paths",
+            return_value=0,
+        ) as mock_migrate:
+            await run_migrations(db, data_path=data_path)
+
+        mock_migrate.assert_called_once_with(data_path)
+
+    async def test_parquet_migration_moves_paths(self, db: Database, tmp_path: Path):
+        """Parquet 경로 변경이 실제로 적용된다 (구 경로 -> 신 경로)."""
+        data_path = tmp_path / "data"
+        old_path = data_path / "ohlcv" / "1d" / "005930"
+        old_path.mkdir(parents=True)
+        (old_path / "2026-01.parquet").write_bytes(b"dummy-parquet-data")
+
+        await run_migrations(db, data_path=data_path)
+
+        # 구 경로 사라짐
+        assert not old_path.exists()
+        # 신 경로 생성됨
+        new_path = data_path / "ohlcv" / "1d" / "KRX" / "005930"
+        assert new_path.exists()
+        assert (new_path / "2026-01.parquet").read_bytes() == b"dummy-parquet-data"
+
+    async def test_parquet_data_preserved_after_migration(
+        self, db: Database, tmp_path: Path
+    ):
+        """마이그레이션 전후 Parquet 내용이 일치한다."""
+        data_path = tmp_path / "data"
+        old_path = data_path / "ohlcv" / "1d" / "005930"
+        old_path.mkdir(parents=True)
+        original_content = b"parquet-binary-content-12345"
+        (old_path / "2026-01.parquet").write_bytes(original_content)
+
+        await run_migrations(db, data_path=data_path)
+
+        new_file = data_path / "ohlcv" / "1d" / "KRX" / "005930" / "2026-01.parquet"
+        assert new_file.read_bytes() == original_content
+
+    async def test_v002_registered_in_migrations(self):
+        """v002_parquet_migration이 MIGRATIONS 리스트에 등록되어 있다."""
+        from ante.db.migrations import MIGRATIONS
+
+        seqs = [seq for seq, _, _ in MIGRATIONS]
+        fns = [fn for _, _, fn in MIGRATIONS]
+        assert 2 in seqs
+        assert v002_parquet_migration.migrate in fns
+
+    async def test_run_migrations_without_data_path(self, db: Database):
+        """data_path 없이 호출해도 정상 동작한다 (하위 호환)."""
+        result = await run_migrations(db)
+        assert "002_0.7.0" in result
+
+        applied = await get_applied_seqs(db)
+        assert 2 in applied
+
+    async def test_no_data_path_skips_parquet_move(self, db: Database):
+        """data_path=None이면 Parquet 마이그레이션이 파일 이동 없이 완료된다."""
+        with patch(
+            "ante.data.store.migrate_parquet_paths",
+        ) as mock_migrate:
+            await run_migrations(db)
+
+        mock_migrate.assert_not_called()
+
+
+class TestAcceptsDataPath:
+    """_accepts_data_path 유틸리티 테스트."""
+
+    def test_v001_does_not_accept_data_path(self):
+        """v001_baseline은 data_path 파라미터가 없다."""
+        assert not _accepts_data_path(v001_baseline.migrate)
+
+    def test_v002_accepts_data_path(self):
+        """v002_parquet_migration은 data_path 파라미터를 받는다."""
+        assert _accepts_data_path(v002_parquet_migration.migrate)


### PR DESCRIPTION
## Summary
- Parquet 데이터 파일의 경로 마이그레이션을 중앙 마이그레이션 러너(`run_migrations`)에 통합
- `v002_parquet_migration.py` 생성: `data_path` 인자가 전달되면 `migrate_parquet_paths()`를 호출하여 기존 경로를 exchange 차원 포함 경로로 이동
- `run_migrations()`에 `data_path` 키워드 인자 추가 (기존 호출 하위 호환 유지)
- `_accepts_data_path()` 헬퍼로 마이그레이션 함수 시그니처를 자동 감지하여, DB 전용 마이그레이션과 데이터 마이그레이션을 구분

Closes #924

## Test plan
- [x] data_path 인자가 Parquet 마이그레이션 함수에 정상 전달되는지 확인
- [x] 구 경로 -> 신 경로 이동 검증 (ohlcv/{tf}/{symbol} -> ohlcv/{tf}/KRX/{symbol})
- [x] 마이그레이션 전후 Parquet 데이터 무손실 확인
- [x] data_path 없이 호출 시 하위 호환 동작 확인
- [x] v001(DB 전용)은 data_path를 받지 않고, v002는 받는 시그니처 감지 확인
- [x] ruff check / ruff format 통과
- [x] pytest 14건 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)