### PR TITLE
refactor(account): Account 모델에 broker_config 필드 추가

### DIFF
--- a/src/ante/account/models.py
+++ b/src/ante/account/models.py
@@ -1,9 +1,12 @@
 """Account 데이터 모델."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from datetime import datetime
 from decimal import Decimal
 from enum import StrEnum
+from typing import Any
 
 
 class AccountStatus(StrEnum):
@@ -45,6 +48,7 @@ class Account:
     # --- 브로커 ---
     broker_type: str = "test"
     credentials: dict[str, str] = field(default_factory=dict)
+    broker_config: dict[str, Any] = field(default_factory=dict)
 
     # --- 비용 ---
     buy_commission_rate: Decimal = Decimal("0")

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from datetime import UTC, datetime
@@ -44,6 +45,7 @@ CREATE TABLE IF NOT EXISTS accounts (
         CHECK(trading_mode IN ('virtual', 'live')),
     broker_type  TEXT NOT NULL,
     credentials  TEXT NOT NULL DEFAULT '{}',
+    broker_config TEXT NOT NULL DEFAULT '{}',
     buy_commission_rate  REAL NOT NULL DEFAULT 0,
     sell_commission_rate REAL NOT NULL DEFAULT 0,
     status       TEXT NOT NULL DEFAULT 'active'
@@ -158,9 +160,10 @@ class AccountService:
             """INSERT INTO accounts
                (account_id, name, exchange, currency, timezone,
                 trading_hours_start, trading_hours_end, trading_mode,
-                broker_type, credentials, buy_commission_rate, sell_commission_rate,
+                broker_type, credentials, broker_config,
+                buy_commission_rate, sell_commission_rate,
                 status, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 account.account_id,
                 account.name,
@@ -172,6 +175,7 @@ class AccountService:
                 account.trading_mode.value,
                 account.broker_type,
                 encrypt_credentials(account.credentials),
+                json.dumps(account.broker_config),
                 float(account.buy_commission_rate),
                 float(account.sell_commission_rate),
                 account.status.value,
@@ -261,6 +265,7 @@ class AccountService:
             "trading_hours_start",
             "trading_hours_end",
             "credentials",
+            "broker_config",
             "buy_commission_rate",
             "sell_commission_rate",
         }
@@ -279,7 +284,7 @@ class AccountService:
             """UPDATE accounts SET
                name=?, exchange=?, currency=?, timezone=?,
                trading_hours_start=?, trading_hours_end=?, trading_mode=?,
-               broker_type=?, credentials=?,
+               broker_type=?, credentials=?, broker_config=?,
                buy_commission_rate=?, sell_commission_rate=?,
                updated_at=?
                WHERE account_id=?""",
@@ -293,6 +298,7 @@ class AccountService:
                 account.trading_mode.value,
                 account.broker_type,
                 encrypt_credentials(account.credentials),
+                json.dumps(account.broker_config),
                 float(account.buy_commission_rate),
                 float(account.sell_commission_rate),
                 now.isoformat(),
@@ -485,10 +491,10 @@ class AccountService:
         config: dict[str, Any] = {
             "exchange": account.exchange,
             "trading_mode": account.trading_mode.value,
-            "is_paper": account.trading_mode == TradingMode.VIRTUAL,
             "buy_commission_rate": float(account.buy_commission_rate),
             "sell_commission_rate": float(account.sell_commission_rate),
             **account.credentials,
+            **account.broker_config,
         }
 
         broker = broker_cls(config)
@@ -536,6 +542,13 @@ def _row_to_account(row: dict[str, Any]) -> Account:
     else:
         credentials = credentials_raw
 
+    broker_config_raw = row.get("broker_config", "{}")
+    broker_config: dict[str, Any] = (
+        json.loads(broker_config_raw)
+        if isinstance(broker_config_raw, str)
+        else (broker_config_raw or {})
+    )
+
     return Account(
         account_id=row["account_id"],
         name=row["name"],
@@ -547,6 +560,7 @@ def _row_to_account(row: dict[str, Any]) -> Account:
         trading_mode=TradingMode(row["trading_mode"]),
         broker_type=row["broker_type"],
         credentials=credentials,
+        broker_config=broker_config,
         buy_commission_rate=Decimal(str(row["buy_commission_rate"])),
         sell_commission_rate=Decimal(str(row["sell_commission_rate"])),
         status=AccountStatus(row["status"]),

--- a/src/ante/db/migrations.py
+++ b/src/ante/db/migrations.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from ante.core.database import Database
-from ante.db.versions import v001_baseline, v002_parquet_migration
+from ante.db.versions import v001_baseline, v002_parquet_migration, v003_broker_config
 
 # 마이그레이션 함수 시그니처:
 #   async def migrate(db: Database) -> None                          (DB 전용)
@@ -22,6 +22,7 @@ MigrateFn = Callable[..., Coroutine[Any, Any, None]]
 MIGRATIONS: list[tuple[int, str, MigrateFn]] = [
     (1, "0.7.0", v001_baseline.migrate),
     (2, "0.7.0", v002_parquet_migration.migrate),
+    (3, "0.8.0", v003_broker_config.migrate),
 ]
 
 

--- a/src/ante/db/versions/v003_broker_config.py
+++ b/src/ante/db/versions/v003_broker_config.py
@@ -1,0 +1,15 @@
+"""v003: Account 테이블에 broker_config 컬럼 추가."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+
+
+async def migrate(db: Database) -> None:
+    """Account 테이블에 broker_config 컬럼 추가."""
+    await db.execute(
+        "ALTER TABLE accounts ADD COLUMN broker_config TEXT NOT NULL DEFAULT '{}'"
+    )

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -49,6 +49,7 @@ def _account_to_response(account: Any) -> dict[str, Any]:
             else str(account.trading_mode)
         ),
         "broker_type": account.broker_type,
+        "broker_config": account.broker_config,
         "buy_commission_rate": float(account.buy_commission_rate),
         "sell_commission_rate": float(account.sell_commission_rate),
         "status": (
@@ -126,6 +127,7 @@ async def create_account(
         trading_mode=trading_mode,
         broker_type=body.broker_type,
         credentials=body.credentials,
+        broker_config=body.broker_config,
         buy_commission_rate=Decimal(str(body.buy_commission_rate))
         if body.buy_commission_rate
         else (preset.buy_commission_rate if preset else Decimal("0")),
@@ -202,6 +204,7 @@ async def update_account(
         "trading_hours_start",
         "trading_hours_end",
         "credentials",
+        "broker_config",
         "buy_commission_rate",
         "sell_commission_rate",
     ):

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -32,6 +32,7 @@ class AccountResponse(BaseModel):
     trading_hours_end: str
     trading_mode: str
     broker_type: str
+    broker_config: dict[str, Any] = {}
     buy_commission_rate: float
     sell_commission_rate: float
     status: str
@@ -64,6 +65,7 @@ class AccountCreateRequest(BaseModel):
     trading_mode: str = "virtual"
     broker_type: str = "test"
     credentials: dict[str, str] = {}
+    broker_config: dict[str, Any] = {}
     buy_commission_rate: float = 0.0
     sell_commission_rate: float = 0.0
 
@@ -80,6 +82,7 @@ class AccountUpdateRequest(BaseModel):
     trading_mode: str | None = None
     broker_type: str | None = None
     credentials: dict[str, str] | None = None
+    broker_config: dict[str, Any] | None = None
     buy_commission_rate: float | None = None
     sell_commission_rate: float | None = None
 

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -388,33 +388,34 @@ async def test_get_broker_cached(service):
 
 
 @pytest.mark.asyncio
-async def test_get_broker_injects_is_paper_virtual(service):
-    """VIRTUAL 계좌 → config에 is_paper=True 주입."""
-    await service.create(_make_account(trading_mode=TradingMode.VIRTUAL))
+async def test_get_broker_uses_broker_config(service):
+    """broker_config={"is_paper": True} -> config에 전달."""
+    await service.create(
+        _make_account(broker_config={"is_paper": True}),
+    )
     broker = await service.get_broker("test")
     assert broker.config.get("is_paper") is True
 
 
 @pytest.mark.asyncio
-async def test_get_broker_injects_is_paper_live(service):
-    """LIVE 계좌 → config에 is_paper=False 주입."""
-    await service.create(_make_account(trading_mode=TradingMode.LIVE))
+async def test_get_broker_broker_config_default(service):
+    """broker_config={} -> is_paper 키 없음 (KIS 기본값 사용)."""
+    await service.create(_make_account())
     broker = await service.get_broker("test")
-    assert broker.config.get("is_paper") is False
+    assert "is_paper" not in broker.config
 
 
 @pytest.mark.asyncio
-async def test_get_broker_credentials_override_is_paper(service):
-    """credentials에 is_paper 명시 시 우선 적용."""
-    await service.create(
-        _make_account(
-            trading_mode=TradingMode.VIRTUAL,
-            credentials={"app_key": "k", "app_secret": "s", "is_paper": False},
-        )
-    )
-    broker = await service.get_broker("test")
-    # credentials spread가 뒤에 위치하므로 is_paper=False로 덮어씀
-    assert broker.config.get("is_paper") is False
+async def test_create_account_with_broker_config(service):
+    """생성 시 broker_config가 DB에 저장/로드."""
+    account = _make_account(broker_config={"is_paper": True, "hts_id": "myid"})
+    created = await service.create(account)
+
+    assert created.broker_config == {"is_paper": True, "hts_id": "myid"}
+
+    # DB에서 다시 로드
+    fetched = await service.get("test")
+    assert fetched.broker_config == {"is_paper": True, "hts_id": "myid"}
 
 
 # ── 기본 테스트 계좌 ──────────────────────────────────


### PR DESCRIPTION
## Summary
- Account 모델에 `broker_config: dict[str, Any]` 필드 추가하여 브로커별 설정(is_paper 등)을 명시적으로 관리
- `get_broker()`에서 하드코딩된 `is_paper` 주입 제거, `broker_config` spread로 대체
- DB 마이그레이션 v003 추가 (ALTER TABLE accounts ADD COLUMN broker_config)
- API 스키마/라우트에 broker_config 필드 반영

## Test plan
- [x] `test_get_broker_uses_broker_config`: broker_config에 is_paper 전달 확인
- [x] `test_get_broker_broker_config_default`: 빈 broker_config 시 is_paper 키 없음 확인
- [x] `test_create_account_with_broker_config`: 생성/로드 시 broker_config 영속성 확인
- [x] 기존 41개 테스트 회귀 없음 (총 44 passed)

Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)