### PR TITLE
fix(broker): KIS WebSocket 모의/실전 포트 번호 반전 수정

### DIFF
--- a/src/ante/broker/kis.py
+++ b/src/ante/broker/kis.py
@@ -186,10 +186,10 @@ class KISBaseAdapter(BrokerAdapter):
         # API 엔드포인트
         if self.is_paper:
             self.base_url = "https://openapivts.koreainvestment.com:29443"
-            self.websocket_url = "ws://ops.koreainvestment.com:21000"
+            self.websocket_url = "ws://ops.koreainvestment.com:31000"
         else:
             self.base_url = "https://openapi.koreainvestment.com:9443"
-            self.websocket_url = "ws://ops.koreainvestment.com:31000"
+            self.websocket_url = "ws://ops.koreainvestment.com:21000"
 
         # 인증
         self.access_token: str | None = None

--- a/tests/unit/test_kis_stream.py
+++ b/tests/unit/test_kis_stream.py
@@ -26,7 +26,7 @@ def eventbus() -> MagicMock:
 def stream_client(eventbus: MagicMock) -> KISStreamClient:
     """KISStreamClient 인스턴스."""
     return KISStreamClient(
-        websocket_url="ws://ops.koreainvestment.com:21000",
+        websocket_url="ws://ops.koreainvestment.com:31000",
         app_key="test_key",
         app_secret="test_secret",
         approval_key="test_approval",
@@ -38,19 +38,19 @@ class TestKISStreamClientInit:
     """초기화 테스트."""
 
     def test_init_paper(self, stream_client: KISStreamClient) -> None:
-        assert stream_client._url == "ws://ops.koreainvestment.com:21000"
+        assert stream_client._url == "ws://ops.koreainvestment.com:31000"
         assert not stream_client.is_connected
         assert len(stream_client.subscribed_symbols) == 0
 
     def test_init_real(self, eventbus: MagicMock) -> None:
         client = KISStreamClient(
-            websocket_url="ws://ops.koreainvestment.com:31000",
+            websocket_url="ws://ops.koreainvestment.com:21000",
             app_key="key",
             app_secret="secret",
             approval_key="approval",
             eventbus=eventbus,
         )
-        assert client._url == "ws://ops.koreainvestment.com:31000"
+        assert client._url == "ws://ops.koreainvestment.com:21000"
 
 
 class TestSubscription:

--- a/tests/unit/test_kis_websocket_url.py
+++ b/tests/unit/test_kis_websocket_url.py
@@ -1,0 +1,34 @@
+"""KIS WebSocket URL 포트 번호 검증 테스트.
+
+모의투자는 31000, 실전투자는 21000 포트를 사용해야 한다.
+Refs #942
+"""
+
+from __future__ import annotations
+
+from ante.broker.kis import KISDomesticAdapter
+
+_BASE_CONFIG = {
+    "app_key": "test_key",
+    "app_secret": "test_secret",
+    "account_no": "12345678-01",
+}
+
+
+class TestKISWebSocketURL:
+    """KISBaseAdapter WebSocket URL 포트 매핑 테스트."""
+
+    def test_paper_websocket_url_uses_port_31000(self) -> None:
+        """모의투자 WebSocket URL은 31000 포트를 사용한다."""
+        adapter = KISDomesticAdapter({**_BASE_CONFIG, "is_paper": True})
+        assert adapter.websocket_url == "ws://ops.koreainvestment.com:31000"
+
+    def test_live_websocket_url_uses_port_21000(self) -> None:
+        """실전투자 WebSocket URL은 21000 포트를 사용한다."""
+        adapter = KISDomesticAdapter({**_BASE_CONFIG, "is_paper": False})
+        assert adapter.websocket_url == "ws://ops.koreainvestment.com:21000"
+
+    def test_default_is_paper_uses_port_31000(self) -> None:
+        """is_paper 미지정 시 기본값(True)이므로 31000 포트를 사용한다."""
+        adapter = KISDomesticAdapter({**_BASE_CONFIG})
+        assert adapter.websocket_url == "ws://ops.koreainvestment.com:31000"


### PR DESCRIPTION
## Summary
- KIS WebSocket URL의 모의투자/실전투자 포트 번호가 반전되어 있던 버그를 수정
  - 모의투자: 21000(잘못됨) -> 31000(올바름)
  - 실전투자: 31000(잘못됨) -> 21000(올바름)
- 기존 `test_kis_stream.py`의 포트 매핑도 일괄 수정
- `test_kis_websocket_url.py` 추가: KISBaseAdapter 레벨에서 포트 매핑 검증

## Test plan
- [x] `test_kis_websocket_url.py` 3개 케이스 통과 (paper/live/default)
- [x] `test_kis_stream.py` 기존 14개 케이스 통과
- [x] ruff check + ruff format 통과

Closes #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)