### PR TITLE
fix(data): DART 체크포인트 키 형식 수정 및 순서 비교 오류 해결

### DIFF
--- a/src/ante/feed/pipeline/dart_collector.py
+++ b/src/ante/feed/pipeline/dart_collector.py
@@ -20,8 +20,16 @@ from ante.feed.sources.dart import (
 
 logger = logging.getLogger(__name__)
 
-# DART 보고서 코드 (분기별)
+# DART 보고서 코드 (시간순: 1Q → 반기 → 3Q → 연간)
 REPRT_CODES = ["11013", "11012", "11014", "11011"]
+
+# REPRT_CODE → 분기 매핑
+REPRT_TO_QUARTER: dict[str, str] = {
+    "11013": "Q1",  # 1분기
+    "11012": "Q2",  # 반기
+    "11014": "Q3",  # 3분기
+    "11011": "Q4",  # 사업보고서(연간)
+}
 
 # 기본 설정 상수
 DEFAULT_BACKFILL_SINCE = "2015-01-01"
@@ -61,6 +69,7 @@ class DARTCollector:
 
         start_year, end_year = self._resolve_year_range(config)
         last_checkpoint = checkpoint.get_last_date()
+        last_checkpoint = self._migrate_checkpoint_key(last_checkpoint)
 
         return await self._collect_quarters(
             corp_code_map,
@@ -92,6 +101,15 @@ class DARTCollector:
         end_year = date.today().year
         return start_year, end_year
 
+    @staticmethod
+    def _migrate_checkpoint_key(last: str | None) -> str | None:
+        """기존 'YYYY-REPRT_CODE' -> 'YYYY-QN' 형식 변환."""
+        if last and "-" in last:
+            parts = last.split("-", 1)
+            if len(parts) == 2 and parts[1] in REPRT_TO_QUARTER:
+                return f"{parts[0]}-{REPRT_TO_QUARTER[parts[1]]}"
+        return last
+
     async def _collect_quarters(
         self,
         corp_code_map: dict[str, str],
@@ -109,7 +127,7 @@ class DARTCollector:
 
         for year in range(start_year, end_year + 1):
             for reprt_code in REPRT_CODES:
-                quarter_key = f"{year}-{reprt_code}"
+                quarter_key = f"{year}-{REPRT_TO_QUARTER[reprt_code]}"
                 if last_checkpoint and quarter_key <= last_checkpoint:
                     continue
 

--- a/tests/unit/feed/test_dart_collector.py
+++ b/tests/unit/feed/test_dart_collector.py
@@ -1,0 +1,80 @@
+"""DARTCollector 체크포인트 키 형식 테스트."""
+
+from __future__ import annotations
+
+from ante.feed.pipeline.dart_collector import REPRT_TO_QUARTER, DARTCollector
+
+
+class TestCheckpointKeyFormat:
+    """체크포인트 키가 YYYY-QN 형식인지 확인한다."""
+
+    def test_checkpoint_key_format(self) -> None:
+        """REPRT_TO_QUARTER 매핑으로 생성된 키가 YYYY-QN 형식이다."""
+        for reprt_code, quarter in REPRT_TO_QUARTER.items():
+            key = f"2026-{quarter}"
+            assert key.startswith("2026-Q")
+            assert key in {"2026-Q1", "2026-Q2", "2026-Q3", "2026-Q4"}
+
+    def test_all_reprt_codes_mapped(self) -> None:
+        """모든 REPRT_CODE가 매핑에 존재한다."""
+        from ante.feed.pipeline.dart_collector import REPRT_CODES
+
+        for code in REPRT_CODES:
+            assert code in REPRT_TO_QUARTER
+
+
+class TestCheckpointOrdering:
+    """Q1 < Q2 < Q3 < Q4 문자열 비교 정합성 확인."""
+
+    def test_quarter_ordering_same_year(self) -> None:
+        """같은 연도 내에서 Q1 < Q2 < Q3 < Q4 순서가 보장된다."""
+        keys = [f"2026-{q}" for q in ["Q1", "Q2", "Q3", "Q4"]]
+        assert keys == sorted(keys)
+
+    def test_quarter_ordering_across_years(self) -> None:
+        """연도가 다르면 연도 기준으로 정렬된다."""
+        keys = ["2025-Q4", "2026-Q1"]
+        assert keys == sorted(keys)
+
+    def test_old_format_ordering_broken(self) -> None:
+        """기존 REPRT_CODE 형식은 시간순과 문자열 순서가 불일치한다.
+
+        11011(Q4)이 11012(Q2)보다 작아서 문자열 비교 시 순서가 뒤바뀐다.
+        """
+        old_keys_time_order = ["2026-11013", "2026-11012", "2026-11014", "2026-11011"]
+        assert sorted(old_keys_time_order) != old_keys_time_order
+
+
+class TestCheckpointMigration:
+    """기존 YYYY-REPRT_CODE -> YYYY-QN 변환 테스트."""
+
+    def test_migrate_q1(self) -> None:
+        result = DARTCollector._migrate_checkpoint_key("2026-11013")
+        assert result == "2026-Q1"
+
+    def test_migrate_q2(self) -> None:
+        result = DARTCollector._migrate_checkpoint_key("2026-11012")
+        assert result == "2026-Q2"
+
+    def test_migrate_q3(self) -> None:
+        result = DARTCollector._migrate_checkpoint_key("2026-11014")
+        assert result == "2026-Q3"
+
+    def test_migrate_q4(self) -> None:
+        result = DARTCollector._migrate_checkpoint_key("2026-11011")
+        assert result == "2026-Q4"
+
+    def test_already_migrated_passthrough(self) -> None:
+        """이미 QN 형식이면 그대로 반환한다."""
+        result = DARTCollector._migrate_checkpoint_key("2026-Q3")
+        assert result == "2026-Q3"
+
+    def test_none_passthrough(self) -> None:
+        """None은 그대로 반환한다."""
+        result = DARTCollector._migrate_checkpoint_key(None)
+        assert result is None
+
+    def test_empty_string_passthrough(self) -> None:
+        """빈 문자열은 그대로 반환한다."""
+        result = DARTCollector._migrate_checkpoint_key("")
+        assert result == ""


### PR DESCRIPTION
## Summary
- DART 체크포인트 키를 `YYYY-REPRT_CODE`(예: `2026-11014`) 에서 `YYYY-QN`(예: `2026-Q3`) 형식으로 변경하여 문자열 비교 시 시간순 정합성 보장
- `REPRT_TO_QUARTER` 매핑 딕셔너리 추가 및 기존 체크포인트 자동 마이그레이션(`_migrate_checkpoint_key`) 구현
- 12개 단위 테스트 추가 (키 형식, 순서 비교, 마이그레이션)

Closes #944

## Test plan
- [x] `test_checkpoint_key_format`: 체크포인트 키가 `YYYY-QN` 형식인지 확인
- [x] `test_checkpoint_ordering`: Q1 < Q2 < Q3 < Q4 문자열 비교 정합성
- [x] `test_checkpoint_migration`: 기존 `"2026-11014"` -> `"2026-Q3"` 변환
- [x] ruff check + ruff format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)