### PR TITLE
perf(api): datasets 목록 API 이벤트 루프 블로킹 해소

### DIFF
--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import shutil
+from concurrent.futures import ThreadPoolExecutor
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -24,6 +26,8 @@ router = APIRouter()
 # 지원하는 데이터 유형
 DATA_TYPES = ["ohlcv", "fundamental"]
 
+_executor = ThreadPoolExecutor(max_workers=2)
+
 
 @router.get("/datasets", response_model=DatasetListResponse)
 async def list_datasets(
@@ -37,77 +41,82 @@ async def list_datasets(
     """보유 데이터셋 목록 (페이지네이션 지원).
 
     data_type에 따라 해당 유형의 데이터셋만 반환한다.
+
+    종목 목록만 먼저 수집하여 페이지네이션을 적용한 뒤,
+    해당 페이지의 종목에 대해서만 date_range를 계산한다.
+    row_count와 file_size는 상세 조회 전용이므로 기본값(0)을 반환한다.
+
     Returns:
         {items: [...], total: int}
     """
     if store is None:
         return {"items": [], "total": 0}
 
-    all_datasets = []
+    loop = asyncio.get_event_loop()
 
-    if data_type == "fundamental":
-        symbols = store.list_symbols(data_type="fundamental")
-        for sym in symbols:
-            if symbol and sym != symbol:
-                continue
-            date_range = store.get_date_range(sym, "", data_type="fundamental")
-            file_size = 0
-            try:
-                p = store._resolve_path(sym, "", data_type="fundamental")
-                if p.exists():
-                    file_size = sum(
-                        f.stat().st_size for f in p.rglob("*") if f.is_file()
-                    )
-            except Exception:
-                pass
-            all_datasets.append(
-                {
-                    "id": f"{sym}__fundamental",
-                    "symbol": sym,
-                    "timeframe": "",
-                    "data_type": "fundamental",
-                    "start_date": date_range[0] if date_range else None,
-                    "end_date": date_range[1] if date_range else None,
-                    "row_count": 0,
-                    "file_size": file_size,
-                }
-            )
-    else:
-        from ante.data.schemas import TIMEFRAMES
-
-        tf_list = [timeframe] if timeframe else TIMEFRAMES
-        for tf in tf_list:
-            symbols = store.list_symbols(tf)
+    def _collect_datasets() -> list[dict[str, Any]]:
+        """종목 목록만 수집 (동기 I/O를 스레드에서 수행)."""
+        datasets: list[dict[str, Any]] = []
+        if data_type == "fundamental":
+            symbols = store.list_symbols(data_type="fundamental")
             for sym in symbols:
                 if symbol and sym != symbol:
                     continue
-                date_range = store.get_date_range(sym, tf)
-                row_count = store.get_row_count(sym, tf)
-                file_size = 0
-                try:
-                    p = store._resolve_path(sym, tf, data_type="ohlcv")
-                    if p.exists():
-                        file_size = sum(
-                            f.stat().st_size for f in p.rglob("*") if f.is_file()
-                        )
-                except Exception:
-                    pass
-                all_datasets.append(
+                datasets.append(
                     {
-                        "id": f"{sym}__{tf}",
+                        "id": f"{sym}__fundamental",
                         "symbol": sym,
-                        "timeframe": tf,
-                        "data_type": "ohlcv",
-                        "start_date": date_range[0] if date_range else None,
-                        "end_date": date_range[1] if date_range else None,
-                        "row_count": row_count,
-                        "file_size": file_size,
+                        "timeframe": "",
+                        "data_type": "fundamental",
                     }
                 )
+        else:
+            from ante.data.schemas import TIMEFRAMES
 
+            tf_list = [timeframe] if timeframe else TIMEFRAMES
+            for tf in tf_list:
+                syms = store.list_symbols(tf)
+                for sym in syms:
+                    if symbol and sym != symbol:
+                        continue
+                    datasets.append(
+                        {
+                            "id": f"{sym}__{tf}",
+                            "symbol": sym,
+                            "timeframe": tf,
+                            "data_type": "ohlcv",
+                        }
+                    )
+        return datasets
+
+    all_datasets = await loop.run_in_executor(_executor, _collect_datasets)
     total = len(all_datasets)
-    items = all_datasets[offset : offset + limit]
-    return {"items": items, "total": total}
+
+    # 페이지네이션 적용 후 해당 페이지만 date_range 계산
+    paged = all_datasets[offset : offset + limit]
+
+    def _enrich(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """페이지 내 항목에 date_range만 보강 (동기 I/O)."""
+        for item in items:
+            dt = item["data_type"]
+            tf = item["timeframe"]
+            sym = item["symbol"]
+            try:
+                dr = store.get_date_range(
+                    sym, tf if dt == "ohlcv" else "", data_type=dt
+                )
+                item["start_date"] = dr[0] if dr else None
+                item["end_date"] = dr[1] if dr else None
+            except Exception:
+                item["start_date"] = None
+                item["end_date"] = None
+            # row_count, file_size는 상세 조회 전용 — 목록에서는 기본값 반환
+            item["row_count"] = 0
+            item["file_size"] = 0
+        return items
+
+    enriched = await loop.run_in_executor(_executor, _enrich, paged)
+    return {"items": enriched, "total": total}
 
 
 @router.get("/datasets/{dataset_id}", response_model=DatasetDetailResponse)

--- a/tests/unit/test_datasets_list_api.py
+++ b/tests/unit/test_datasets_list_api.py
@@ -1,0 +1,205 @@
+"""list_datasets 핸들러 단위 테스트.
+
+이벤트 루프 블로킹 해소 (#949) 관련 변경사항을 검증한다:
+- 종목 목록 수집 후 페이지네이션 -> 해당 페이지만 date_range 계산
+- row_count, file_size는 목록 응답에서 항상 0
+- 동기 I/O가 run_in_executor로 래핑되어 이벤트 루프를 블로킹하지 않음
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ante.web.routes.data import list_datasets
+
+# --- 헬퍼 ---
+
+
+def _make_store(symbols_by_tf: dict[str, list[str]] | None = None) -> MagicMock:
+    """테스트용 mock DataStore를 생성한다."""
+    store = MagicMock()
+
+    if symbols_by_tf is None:
+        symbols_by_tf = {}
+
+    def _list_symbols(tf=None, data_type=None):
+        if data_type == "fundamental":
+            return symbols_by_tf.get("fundamental", [])
+        return symbols_by_tf.get(tf, [])
+
+    store.list_symbols.side_effect = _list_symbols
+    store.get_date_range.return_value = ("2024-01-01", "2024-12-31")
+    store.get_row_count.return_value = 100
+    return store
+
+
+# --- 테스트 ---
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_returns_empty_when_no_store():
+    """store가 None이면 빈 응답을 반환한다."""
+    result = await list_datasets(
+        store=None, symbol=None, timeframe=None, data_type="ohlcv", offset=0, limit=50
+    )
+    assert result == {"items": [], "total": 0}
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_pagination_limits_enrichment():
+    """페이지네이션이 적용되어 해당 페이지 종목만 enrich한다."""
+    syms = [f"00{i:04d}" for i in range(5)]
+    store = _make_store({"1d": syms})
+
+    result = await list_datasets(
+        store=store,
+        symbol=None,
+        timeframe="1d",
+        data_type="ohlcv",
+        offset=0,
+        limit=2,
+    )
+
+    assert result["total"] == 5
+    assert len(result["items"]) == 2
+    # get_date_range는 페이지 내 2건에 대해서만 호출
+    assert store.get_date_range.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_row_count_and_file_size_are_zero():
+    """목록 응답의 row_count, file_size는 항상 0이다."""
+    store = _make_store({"1d": ["005930"]})
+
+    result = await list_datasets(
+        store=store,
+        symbol=None,
+        timeframe="1d",
+        data_type="ohlcv",
+        offset=0,
+        limit=50,
+    )
+
+    item = result["items"][0]
+    assert item["row_count"] == 0
+    assert item["file_size"] == 0
+    # get_row_count는 호출되지 않아야 한다
+    store.get_row_count.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_date_range_included():
+    """목록 응답에 start_date, end_date가 포함된다."""
+    store = _make_store({"1d": ["005930"]})
+
+    result = await list_datasets(
+        store=store,
+        symbol=None,
+        timeframe="1d",
+        data_type="ohlcv",
+        offset=0,
+        limit=50,
+    )
+
+    item = result["items"][0]
+    assert item["start_date"] == "2024-01-01"
+    assert item["end_date"] == "2024-12-31"
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_fundamental_type():
+    """fundamental 데이터 타입 조회가 동작한다."""
+    store = _make_store({"fundamental": ["005930"]})
+
+    result = await list_datasets(
+        store=store,
+        symbol=None,
+        timeframe=None,
+        data_type="fundamental",
+        offset=0,
+        limit=50,
+    )
+
+    assert result["total"] == 1
+    item = result["items"][0]
+    assert item["data_type"] == "fundamental"
+    assert item["id"] == "005930__fundamental"
+    assert item["row_count"] == 0
+    assert item["file_size"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_symbol_filter():
+    """symbol 필터가 적용된다."""
+    store = _make_store({"1d": ["005930", "000660", "035720"]})
+
+    result = await list_datasets(
+        store=store,
+        symbol="005930",
+        timeframe="1d",
+        data_type="ohlcv",
+        offset=0,
+        limit=50,
+    )
+
+    assert result["total"] == 1
+    assert result["items"][0]["symbol"] == "005930"
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_offset_pagination():
+    """offset 페이지네이션이 올바르게 동작한다."""
+    syms = [f"SYM{i}" for i in range(10)]
+    store = _make_store({"1d": syms})
+
+    result = await list_datasets(
+        store=store,
+        symbol=None,
+        timeframe="1d",
+        data_type="ohlcv",
+        offset=8,
+        limit=5,
+    )
+
+    assert result["total"] == 10
+    # offset=8, limit=5 -> 8,9 인덱스만 반환
+    assert len(result["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_date_range_exception_handled():
+    """get_date_range에서 예외가 발생해도 None으로 처리된다."""
+    store = _make_store({"1d": ["005930"]})
+    store.get_date_range.side_effect = Exception("disk error")
+
+    result = await list_datasets(
+        store=store,
+        symbol=None,
+        timeframe="1d",
+        data_type="ohlcv",
+        offset=0,
+        limit=50,
+    )
+
+    item = result["items"][0]
+    assert item["start_date"] is None
+    assert item["end_date"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_no_resolve_path_called():
+    """목록 API에서는 _resolve_path (file_size 계산)를 호출하지 않는다."""
+    store = _make_store({"1d": ["005930"]})
+
+    await list_datasets(
+        store=store,
+        symbol=None,
+        timeframe="1d",
+        data_type="ohlcv",
+        offset=0,
+        limit=50,
+    )
+
+    store._resolve_path.assert_not_called()


### PR DESCRIPTION
## Summary
- 2,879종목 전체에 대해 row_count/file_size를 동기로 계산하던 `list_datasets` 핸들러를 최적화
- 종목 목록만 먼저 수집하여 페이지네이션 적용 후, 해당 페이지 종목에 대해서만 `date_range` 계산
- `row_count`, `file_size`는 목록 응답에서 기본값(0)으로 반환 (상세 조회 전용)
- 동기 I/O를 `run_in_executor`로 래핑하여 이벤트 루프 블로킹 방지

## Test plan
- [x] `test_list_datasets_returns_empty_when_no_store` — store가 None일 때 빈 응답
- [x] `test_list_datasets_pagination_limits_enrichment` — 페이지 내 항목만 date_range 계산
- [x] `test_list_datasets_row_count_and_file_size_are_zero` — row_count/file_size가 항상 0
- [x] `test_list_datasets_date_range_included` — date_range 정상 포함
- [x] `test_list_datasets_fundamental_type` — fundamental 타입 동작
- [x] `test_list_datasets_symbol_filter` — symbol 필터 동작
- [x] `test_list_datasets_offset_pagination` — offset 페이지네이션 동작
- [x] `test_list_datasets_date_range_exception_handled` — date_range 예외 시 None 처리
- [x] `test_list_datasets_no_resolve_path_called` — 목록에서 _resolve_path 미호출

Closes #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)