### PR TITLE
fix(api): approvals/members 목록 total을 전체 건수로 수정

### DIFF
--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -622,6 +622,33 @@ class ApprovalService:
         rows = await self._db.fetch_all(query, tuple(params))
         return [self._row_to_request(row) for row in rows]
 
+    async def count(
+        self,
+        status: str | None = None,
+        type: str | None = None,
+        search: str | None = None,
+    ) -> int:
+        """필터 조건에 맞는 전체 건수를 반환한다."""
+        conditions: list[str] = []
+        params: list[object] = []
+
+        if status:
+            conditions.append("status = ?")
+            params.append(status)
+        if type:
+            conditions.append("type = ?")
+            params.append(type)
+        if search:
+            conditions.append("(title LIKE ? OR requester LIKE ?)")
+            like_pattern = f"%{search}%"
+            params.extend([like_pattern, like_pattern])
+
+        where = " AND ".join(conditions) if conditions else "1=1"
+        query = f"SELECT COUNT(*) AS cnt FROM approvals WHERE {where}"  # noqa: S608
+
+        row = await self._db.fetch_one(query, tuple(params))
+        return row["cnt"] if row else 0
+
     def _validate_params(
         self,
         type: str,

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -466,6 +466,33 @@ class MemberService:
         )
         return [_row_to_member(row) for row in rows]
 
+    async def count(
+        self,
+        member_type: str | None = None,
+        org: str | None = None,
+        status: str | None = None,
+    ) -> int:
+        """필터 조건에 맞는 전체 건수를 반환한다."""
+        conditions: list[str] = []
+        params: list[str] = []
+
+        if member_type:
+            conditions.append("type = ?")
+            params.append(member_type)
+        if org:
+            conditions.append("org = ?")
+            params.append(org)
+        if status:
+            conditions.append("status = ?")
+            params.append(status)
+
+        where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+        row = await self._db.fetch_one(
+            f"SELECT COUNT(*) AS cnt FROM members{where}",  # noqa: S608
+            tuple(params),
+        )
+        return row["cnt"] if row else 0
+
     # ── 상태 변경 ──────────────────────────────────────
 
     async def suspend(self, member_id: str, suspended_by: str = "") -> Member:

--- a/src/ante/web/routes/approvals.py
+++ b/src/ante/web/routes/approvals.py
@@ -49,10 +49,11 @@ async def list_approvals(
     approvals = await approval_service.list(
         status=status, type=type, search=search, limit=limit, offset=offset
     )
+    total = await approval_service.count(status=status, type=type, search=search)
 
     return {
         "approvals": [asdict(a) for a in approvals],
-        "total": len(approvals),
+        "total": total,
     }
 
 

--- a/src/ante/web/routes/members.py
+++ b/src/ante/web/routes/members.py
@@ -68,7 +68,8 @@ async def list_members(
     members = await svc.list(
         member_type=type, org=org, status=status, limit=limit, offset=offset
     )
-    return {"members": [asdict(m) for m in members], "total": len(members)}
+    total = await svc.count(member_type=type, org=org, status=status)
+    return {"members": [asdict(m) for m in members], "total": total}
 
 
 @router.post(

--- a/tests/unit/test_approval_api.py
+++ b/tests/unit/test_approval_api.py
@@ -72,6 +72,22 @@ class TestListApprovals:
         assert data["approvals"][0]["id"] == sample_approval.id
         assert data["approvals"][0]["type"] == "strategy_adopt"
 
+    async def test_total_is_full_count_not_page_size(self, client, approval_service):
+        """total은 페이지 크기가 아닌 전체 건수를 반환해야 한다."""
+        for i in range(5):
+            await approval_service.create(
+                type="strategy_adopt",
+                requester="agent-01",
+                title=f"전략 채택 요청 {i}",
+                body="테스트",
+                reference_id=f"report-{i:03d}",
+            )
+        resp = client.get("/api/approvals?limit=2&offset=0")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["approvals"]) == 2
+        assert data["total"] == 5
+
     async def test_filter_by_status(self, client, sample_approval):
         """상태 필터."""
         resp = client.get("/api/approvals?status=pending")

--- a/tests/unit/test_member_api.py
+++ b/tests/unit/test_member_api.py
@@ -49,6 +49,23 @@ class FakeMemberService:
         limit: int = 100,
         offset: int = 0,
     ) -> list[FakeMember]:
+        result = self._filtered(member_type=member_type, org=org, status=status)
+        return result[offset : offset + limit]
+
+    async def count(
+        self,
+        member_type: str | None = None,
+        org: str | None = None,
+        status: str | None = None,
+    ) -> int:
+        return len(self._filtered(member_type=member_type, org=org, status=status))
+
+    def _filtered(
+        self,
+        member_type: str | None = None,
+        org: str | None = None,
+        status: str | None = None,
+    ) -> list[FakeMember]:
         result = list(self._members.values())
         if member_type:
             result = [m for m in result if m.type == member_type]
@@ -56,7 +73,7 @@ class FakeMemberService:
             result = [m for m in result if m.org == org]
         if status:
             result = [m for m in result if m.status == status]
-        return result[offset : offset + limit]
+        return result
 
     async def register(
         self,
@@ -169,6 +186,18 @@ class TestListMembers:
         resp = client.get("/api/members")
         assert resp.status_code == 200
         assert len(resp.json()["members"]) == 1
+
+    def test_total_is_full_count_not_page_size(self, client, member_service):
+        """total은 페이지 크기가 아닌 전체 건수를 반환해야 한다."""
+        for i in range(5):
+            member_service._members[f"agent-{i:02d}"] = FakeMember(
+                member_id=f"agent-{i:02d}", type="agent"
+            )
+        resp = client.get("/api/members?limit=2&offset=0")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["members"]) == 2
+        assert data["total"] == 5
 
     def test_filter_by_type(self, client, member_service):
         """타입 필터."""


### PR DESCRIPTION
## Summary
- approvals/members 목록 API의 `total` 필드가 페이지 크기(`len(items)`)를 반환하던 버그 수정
- `ApprovalService.count()`와 `MemberService.count()` 메서드를 추가하여 `SELECT COUNT(*)`로 전체 건수 산출
- 라우트 핸들러에서 `count()` 호출 결과를 `total`로 반환

## Test plan
- [x] `test_total_is_full_count_not_page_size` 테스트 추가 (approval, member 각 1건)
- [x] 기존 테스트 39건 전체 통과 확인
- [x] ruff check + ruff format 통과

Closes #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)