### PR TITLE
fix(api): datasets 목록 data_type 미지정 시 전체 타입 반환

### DIFF
--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -34,13 +34,15 @@ async def list_datasets(
     store: Annotated[Any | None, Depends(get_data_store)],
     symbol: str | None = None,
     timeframe: str | None = None,
-    data_type: str = Query("ohlcv", description="데이터 유형 (ohlcv, fundamental)"),
+    data_type: str | None = Query(
+        None, description="데이터 유형 (ohlcv, fundamental, 미지정 시 전체)"
+    ),
     offset: int = 0,
     limit: int = 50,
 ) -> dict:
     """보유 데이터셋 목록 (페이지네이션 지원).
 
-    data_type에 따라 해당 유형의 데이터셋만 반환한다.
+    data_type 미지정 시 모든 유형을 반환하고, 지정 시 해당 유형만 반환한다.
 
     종목 목록만 먼저 수집하여 페이지네이션을 적용한 뒤,
     해당 페이지의 종목에 대해서만 date_range를 계산한다.
@@ -57,7 +59,9 @@ async def list_datasets(
     def _collect_datasets() -> list[dict[str, Any]]:
         """종목 목록만 수집 (동기 I/O를 스레드에서 수행)."""
         datasets: list[dict[str, Any]] = []
-        if data_type == "fundamental":
+
+        # fundamental 수집 (data_type이 None 또는 "fundamental"일 때)
+        if data_type is None or data_type == "fundamental":
             symbols = store.list_symbols(data_type="fundamental")
             for sym in symbols:
                 if symbol and sym != symbol:
@@ -70,7 +74,9 @@ async def list_datasets(
                         "data_type": "fundamental",
                     }
                 )
-        else:
+
+        # ohlcv 수집 (data_type이 None 또는 "ohlcv"일 때)
+        if data_type is None or data_type == "ohlcv":
             from ante.data.schemas import TIMEFRAMES
 
             tf_list = [timeframe] if timeframe else TIMEFRAMES

--- a/tests/unit/test_datasets_list_api.py
+++ b/tests/unit/test_datasets_list_api.py
@@ -203,3 +203,61 @@ async def test_list_datasets_no_resolve_path_called():
     )
 
     store._resolve_path.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_no_data_type_returns_all():
+    """data_type 미지정 시 ohlcv + fundamental 모두 반환한다."""
+    store = _make_store({"1d": ["005930"], "fundamental": ["005930", "000660"]})
+
+    result = await list_datasets(
+        store=store,
+        symbol=None,
+        timeframe="1d",
+        data_type=None,
+        offset=0,
+        limit=50,
+    )
+
+    types = {item["data_type"] for item in result["items"]}
+    assert types == {"ohlcv", "fundamental"}
+    # fundamental 2건 + ohlcv 1건
+    assert result["total"] == 3
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_data_type_ohlcv():
+    """data_type=ohlcv 지정 시 ohlcv만 반환한다."""
+    store = _make_store({"1d": ["005930"], "fundamental": ["005930"]})
+
+    result = await list_datasets(
+        store=store,
+        symbol=None,
+        timeframe="1d",
+        data_type="ohlcv",
+        offset=0,
+        limit=50,
+    )
+
+    types = {item["data_type"] for item in result["items"]}
+    assert types == {"ohlcv"}
+    assert result["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_data_type_fundamental():
+    """data_type=fundamental 지정 시 fundamental만 반환한다."""
+    store = _make_store({"1d": ["005930"], "fundamental": ["005930"]})
+
+    result = await list_datasets(
+        store=store,
+        symbol=None,
+        timeframe=None,
+        data_type="fundamental",
+        offset=0,
+        limit=50,
+    )
+
+    types = {item["data_type"] for item in result["items"]}
+    assert types == {"fundamental"}
+    assert result["total"] == 1


### PR DESCRIPTION
## Summary
- `list_datasets` 핸들러의 `data_type` 파라미터 기본값을 `"ohlcv"`에서 `None`으로 변경
- `data_type` 미지정 시 ohlcv + fundamental 모든 데이터셋을 반환하도록 `_collect_datasets()` 분기 로직 수정
- 신규 테스트 3건 추가 (전체/ohlcv만/fundamental만 반환 검증)

Closes #948

## Test plan
- [x] `test_list_datasets_no_data_type_returns_all`: data_type 미지정 → ohlcv + fundamental 모두 반환
- [x] `test_list_datasets_data_type_ohlcv`: data_type=ohlcv → ohlcv만 반환
- [x] `test_list_datasets_data_type_fundamental`: data_type=fundamental → fundamental만 반환
- [x] 기존 테스트 9건 모두 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)