### PR TITLE
fix(web): 사이드바 UI 버그 3건 수정

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -43,7 +43,7 @@ export default function Sidebar() {
           mobileOpen ? 'translate-x-0' : '-translate-x-full'
         } md:translate-x-0`}
       >
-        <div className="h-header flex items-center justify-center gap-0 px-5 border-b border-border">
+        <div className="h-header flex items-center gap-0 px-5 border-b border-border">
           <img src="/logo-a.svg" alt="A" className="w-8 h-8" />
           <img src="/logo-n.svg" alt="N" className="w-8 h-8" />
           <img src="/logo-t.svg" alt="T" className="w-8 h-8" />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -22,6 +22,7 @@
   --color-info-bg: rgba(167, 139, 250, 0.10);
   --color-primary: #1E8EFF;
   --color-primary-hover: #0A7AEE;
+  --color-on-primary: #ffffff;
 
   --spacing-sidebar: 220px;
   --spacing-header: 56px;
@@ -49,6 +50,10 @@ a {
 
 a:hover {
   text-decoration: underline;
+}
+
+a.no-underline:hover {
+  text-decoration: none;
 }
 
 /* Bot icon running animations */


### PR DESCRIPTION
## Summary
- `@theme`에 `--color-on-primary: #ffffff` 토큰 추가하여 활성 메뉴 글자색 흰색 적용
- `a.no-underline:hover` CSS 규칙 추가하여 사이드바 메뉴 hover 시 언더스코어 노출 방지
- 로고 컨테이너에서 `justify-center` 제거하여 좌측 정렬로 변경

Closes #957

## Test plan
- [ ] 사이드바에서 현재 활성 메뉴의 글자색이 흰색(#ffffff)인지 확인
- [ ] 사이드바 메뉴 항목에 마우스 hover 시 밑줄이 나타나지 않는지 확인
- [ ] 사이드바 상단 로고가 좌측 정렬되어 있는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)