### PR TITLE
fix(web): 브라우저 탭 타이틀·파비콘 변경

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/logo-a.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>Ante - Ante Up. Agents Do the Rest.</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- 브라우저 탭 타이틀을 `frontend` → `Ante - Ante Up. Agents Do the Rest.`로 변경
- 파비콘을 기본 `favicon.svg` → `logo-a.svg`로 변경

Closes #963

## Test plan
- [ ] 브라우저 탭에 변경된 타이틀이 표시되는지 확인
- [ ] 파비콘이 logo-a.svg로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)