### PR TITLE
feat(config): 트레이딩/리스크/알림 기본값을 Config 서비스에 시드 등록

### DIFF
--- a/src/ante/config/defaults.py
+++ b/src/ante/config/defaults.py
@@ -16,4 +16,21 @@ DEFAULTS: dict[str, object] = {
     "audit.retention_days": 90,
     "telegram.command.polling_interval": 3.0,
     "telegram.command.confirm_timeout": 30.0,
+    # ── 리스크 관리 ──
+    "rule.daily_loss_limit": 0.05,
+    "rule.max_exposure_percent": 0.20,
+    "rule.max_unrealized_loss": 0.10,
+    "rule.max_trades_per_hour": 10,
+    "rule.allowed_hours": "09:00-15:30",
+    "risk.max_mdd_pct": 0.10,
+    "risk.max_position_pct": 0.10,
+    # ── 봇 기본 ──
+    "bot.default_interval_sec": 60,
+    # ── 거래 비용 ──
+    "broker.commission_rate": 0.00015,
+    "broker.sell_tax_rate": 0.0018,
+    # ── 알림 ──
+    "notification.telegram_level": "important",
+    "notification.fill_alert": "true",
+    "notification.daily_report": "true",
 }

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -139,15 +139,33 @@ async def _init_core(s: Services) -> None:
     s.dynamic_config = DynamicConfigService(db=s.db, eventbus=s.eventbus)
     await s.dynamic_config.initialize()
 
+    from ante.config.defaults import DEFAULTS
     from ante.config.dynamic import _on_log_level_changed
     from ante.eventbus.events import ConfigChangedEvent
 
+    category_map = {
+        "rule": "trading",
+        "risk": "trading",
+        "bot": "trading",
+        "broker": "trading",
+        "notification": "notification",
+        "display": "display",
+        "system": "system",
+    }
+
+    # system.log_level은 CLI 인자 우선이므로 DEFAULTS보다 먼저 등록
     await s.dynamic_config.register_default(
         "system.log_level", log_level, category="system"
     )
     await s.dynamic_config.register_default(
         "display.currency_position", "suffix", category="display"
     )
+
+    for key, value in DEFAULTS.items():
+        prefix = key.split(".")[0]
+        category = category_map.get(prefix, "system")
+        await s.dynamic_config.register_default(key, str(value), category=category)
+
     s.eventbus.subscribe(ConfigChangedEvent, _on_log_level_changed)
     logger.info("DynamicConfigService 초기화 완료")
 

--- a/tests/unit/test_config_defaults_seed.py
+++ b/tests/unit/test_config_defaults_seed.py
@@ -1,0 +1,109 @@
+"""Config 기본값 시드 등록 테스트."""
+
+import pytest
+
+from ante.config import DynamicConfigService
+from ante.config.defaults import DEFAULTS
+from ante.core import Database
+
+
+class FakeEventBus:
+    """테스트용 EventBus 대역."""
+
+    def __init__(self):
+        self.published: list = []
+
+    async def publish(self, event):
+        self.published.append(event)
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+def eventbus():
+    return FakeEventBus()
+
+
+@pytest.fixture
+async def service(db, eventbus):
+    svc = DynamicConfigService(db=db, eventbus=eventbus)
+    await svc.initialize()
+    return svc
+
+
+CATEGORY_MAP = {
+    "rule": "trading",
+    "risk": "trading",
+    "bot": "trading",
+    "broker": "trading",
+    "notification": "notification",
+    "display": "display",
+    "system": "system",
+}
+
+
+async def _seed_defaults(service: DynamicConfigService) -> None:
+    """DEFAULTS를 register_default로 시드하는 헬퍼."""
+    for key, value in DEFAULTS.items():
+        prefix = key.split(".")[0]
+        category = CATEGORY_MAP.get(prefix, "system")
+        await service.register_default(key, str(value), category=category)
+
+
+async def test_defaults_seeded(service):
+    """초기화 후 DEFAULTS의 모든 키가 등록되어 있는지 확인한다."""
+    await _seed_defaults(service)
+
+    all_configs = await service.get_all()
+    registered_keys = {row["key"] for row in all_configs}
+
+    for key in DEFAULTS:
+        assert key in registered_keys, f"기본값 키 '{key}'가 등록되지 않았다"
+
+
+async def test_existing_value_not_overwritten(service):
+    """이미 수정된 값이 register_default로 덮어써지지 않는다."""
+    # 사용자가 먼저 값을 설정
+    await service.set("rule.daily_loss_limit", 0.03, category="trading")
+
+    # 기본값 시드 실행
+    await _seed_defaults(service)
+
+    # 사용자가 설정한 값이 보존되어야 함
+    value = await service.get("rule.daily_loss_limit")
+    assert value == 0.03, f"사용자 설정값 0.03이 기본값으로 덮어써졌다: {value}"
+
+
+async def test_new_defaults_contain_risk_keys(service):
+    """리스크 관리 관련 기본값 키가 DEFAULTS에 포함되어 있다."""
+    expected_risk_keys = [
+        "rule.daily_loss_limit",
+        "rule.max_exposure_percent",
+        "rule.max_unrealized_loss",
+        "rule.max_trades_per_hour",
+        "rule.allowed_hours",
+        "risk.max_mdd_pct",
+        "risk.max_position_pct",
+    ]
+    for key in expected_risk_keys:
+        assert key in DEFAULTS, f"리스크 키 '{key}'가 DEFAULTS에 없다"
+
+
+async def test_new_defaults_contain_trading_keys(service):
+    """봇, 거래비용, 알림 관련 기본값 키가 DEFAULTS에 포함되어 있다."""
+    expected_keys = [
+        "bot.default_interval_sec",
+        "broker.commission_rate",
+        "broker.sell_tax_rate",
+        "notification.telegram_level",
+        "notification.fill_alert",
+        "notification.daily_report",
+    ]
+    for key in expected_keys:
+        assert key in DEFAULTS, f"키 '{key}'가 DEFAULTS에 없다"


### PR DESCRIPTION
## Summary
- `DEFAULTS` 딕셔너리에 리스크 관리(rule/risk), 봇(bot), 거래 비용(broker), 알림(notification) 기본값 14개 항목 추가
- `main.py` 초기화 루틴에서 `DEFAULTS` 전체를 순회하며 `register_default()`로 시드 등록 (카테고리 자동 매핑)
- 기존 사용자 수정값이 `register_default`에 의해 덮어써지지 않음을 테스트로 검증

## Test plan
- [x] `test_defaults_seeded`: 시드 후 DEFAULTS의 모든 키가 등록되는지 확인
- [x] `test_existing_value_not_overwritten`: 사용자 설정값이 시드로 덮어써지지 않는지 확인
- [x] `test_new_defaults_contain_risk_keys`: 리스크 관련 키가 DEFAULTS에 포함되는지 확인
- [x] `test_new_defaults_contain_trading_keys`: 봇/거래비용/알림 키가 DEFAULTS에 포함되는지 확인
- [x] 기존 `test_dynamic_config.py`, `test_main.py` 전체 통과 확인

Refs #965

🤖 Generated with [Claude Code](https://claude.com/claude-code)