### PR TITLE
fix(web): 전략 상세 페이지 파라미터 미표시 및 빈 값 렌더링 수정 Refs #972

### DIFF
--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -8,7 +8,17 @@ export async function getStrategies(params?: { search?: string }): Promise<Strat
 
 export async function getStrategyDetail(id: string): Promise<StrategyDetail> {
   const res = await client.get(`/api/strategies/${id}`)
-  return res.data.strategy ?? res.data
+  const { strategy, params, param_schema, rationale, risks, ...rest } = res.data
+  if (strategy) {
+    return {
+      ...strategy,
+      params: params ?? strategy.params,
+      param_schema: param_schema ?? strategy.param_schema,
+      rationale: rationale ?? strategy.rationale,
+      risks: risks ?? strategy.risks,
+    }
+  }
+  return rest
 }
 
 export async function getStrategyPerformance(id: string): Promise<StrategyPerformance> {

--- a/frontend/src/pages/StrategyDetail.tsx
+++ b/frontend/src/pages/StrategyDetail.tsx
@@ -117,13 +117,13 @@ export default function StrategyDetail() {
             <span className="text-text-muted">설명</span>
             <span className="text-[12px] text-text-muted">{strategy.description || '-'}</span>
           </div>
-          {strategy.rationale && (
+          {strategy.rationale && strategy.rationale.length > 0 && (
             <div className="mt-3">
               <div className="text-[12px] text-text-muted font-semibold mb-1">투자 근거</div>
               <div className="text-[12px] text-text-muted leading-relaxed whitespace-pre-line">{strategy.rationale}</div>
             </div>
           )}
-          {strategy.risks && (
+          {strategy.risks && strategy.risks.length > 0 && (
             <div className="mt-3 pt-3 border-t border-border">
               <div className="text-[12px] text-text-muted font-semibold mb-1">리스크</div>
               <div className="text-[12px] text-text-muted leading-relaxed whitespace-pre-line">{strategy.risks}</div>

--- a/frontend/src/types/strategy.ts
+++ b/frontend/src/types/strategy.ts
@@ -43,8 +43,9 @@ export interface Strategy {
 export interface StrategyDetail extends Strategy {
   description?: string
   rationale?: string
-  risks?: string
+  risks?: string | string[]
   params?: Record<string, StrategyParam | unknown>
+  param_schema?: Record<string, string>
   budget_allocated?: number
   unrealized_pnl?: number
 }


### PR DESCRIPTION
## Summary
- `getStrategyDetail()`에서 API 응답의 `params`, `param_schema`, `rationale`, `risks`를 `strategy` 객체에 머지하여 전략 파라미터가 정상 표시되도록 수정
- `rationale`/`risks` 빈 값 판정을 `.length > 0`으로 통일하여 빈 문자열(`""`)과 빈 배열(`[]`) 모두 일관되게 섹션을 숨기도록 수정
- `StrategyDetail` 타입에 `param_schema` 필드 및 `risks` 배열 타입 추가

## 변경 파일
- `frontend/src/api/strategies.ts` — API 응답에서 params/param_schema/rationale/risks를 strategy에 머지
- `frontend/src/pages/StrategyDetail.tsx` — 빈 값 판정 통일 (`.length > 0`)
- `frontend/src/types/strategy.ts` — `param_schema`, `risks` 타입 확장

## Test plan
- [ ] 전략 상세 페이지에서 파라미터가 있는 전략의 "전략 파라미터" 카드에 값이 표시되는지 확인
- [ ] 파라미터가 없는 전략에서 "파라미터가 없습니다" 메시지가 표시되는지 확인
- [ ] `rationale`이 빈 문자열일 때 "투자 근거" 섹션이 숨겨지는지 확인
- [ ] `risks`가 빈 배열일 때 "리스크" 섹션이 숨겨지는지 확인
- [ ] `rationale`/`risks`에 값이 있을 때 정상 렌더링되는지 확인

Refs #972

🤖 Generated with [Claude Code](https://claude.com/claude-code)