### PR TITLE
fix(account): is_paper를 Account.broker_config으로 이관 Refs #989

### DIFF
--- a/config/system.toml
+++ b/config/system.toml
@@ -19,11 +19,6 @@ port = 3982
 [eventbus]
 history_size = 1000
 
-[broker]
-# KIS 모의투자 설정 — secrets.env 에서 앱키/시크릿/계좌번호 관리
-# commission_rate, sell_tax_rate → Account 모델로 이관됨
-is_paper = true             # true: 모의투자, false: 실전투자
-
 [treasury]
 sync_interval_seconds = 300 # 잔고 동기화 주기 (초)
 

--- a/config/system.toml.example
+++ b/config/system.toml.example
@@ -19,20 +19,8 @@ port = 3982
 [eventbus]
 history_size = 1000
 
-[broker]
-type = "kis"  # "kis" | "test" | "mock"
-# KIS: secrets.env 에서 앱키/시크릿/계좌번호 관리
-# Test: KIS 시크릿 없이 시뮬레이션 구동 (broker.test 섹션 참조)
-# Mock: E2E 테스트 자동화 전용
-is_paper = true  # true: 모의투자, false: 실전투자
-commission_rate = 0.00015  # 매매 수수료율
-sell_tax_rate = 0.0023  # 매도 세금율 (증권거래세+농특세)
-
-# Test 브로커 전용 설정 (type = "test" 일 때만 사용)
-[broker.test]
-seed = 42  # 재현 가능한 시뮬레이션 시드
-initial_cash = 100000000  # 초기 자금 (1억)
-tick_interval = 1.0  # 가격 변동 간격 (초)
+# [broker] 섹션은 Account.broker_config으로 이관됨
+# is_paper, commission_rate 등은 `ante account create` 시 계좌별로 설정
 
 [audit]
 retention_days = 90  # 감사 로그 보존 기간 (일). 0이면 무기한 보존

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -104,7 +104,13 @@ def account_create(ctx: click.Context) -> None:
         value = click.prompt(cred_key.upper(), hide_input=hide)
         credentials[cred_key] = value
 
-    # 5) Account 생성
+    # 5) 브로커 설정 (broker_config)
+    broker_config: dict[str, Any] = {}
+    if broker_type == "kis-domestic":
+        is_paper = click.confirm("모의투자 모드로 사용하시겠습니까?", default=True)
+        broker_config["is_paper"] = is_paper
+
+    # 6) Account 생성
     new_account = Account(
         account_id=account_id,
         name=name,
@@ -116,6 +122,7 @@ def account_create(ctx: click.Context) -> None:
         trading_mode=trading_mode,
         broker_type=broker_type,
         credentials=credentials,
+        broker_config=broker_config,
         buy_commission_rate=preset.buy_commission_rate,
         sell_commission_rate=preset.sell_commission_rate,
     )

--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -139,12 +139,21 @@ def _prompt_account() -> list[dict[str, str]]:
             value = click.prompt(f"  {cred_key}")
             credentials[cred_key] = value
 
+        # 브로커 설정 (broker_config)
+        broker_config: dict[str, object] = {}
+        if broker_type == "kis-domestic":
+            is_paper = click.confirm(
+                "  모의투자 모드로 사용하시겠습니까?", default=True
+            )
+            broker_config["is_paper"] = is_paper
+
         accounts.append(
             {
                 "account_id": account_id,
                 "name": account_name,
                 "broker_type": broker_type,
                 "credentials": credentials,
+                "broker_config": broker_config,
             }
         )
 
@@ -278,6 +287,7 @@ async def _create_accounts(
                 trading_mode=TradingMode.LIVE,
                 broker_type=broker_type,
                 credentials=info["credentials"],
+                broker_config=info.get("broker_config", {}),
                 buy_commission_rate=preset.buy_commission_rate,
                 sell_commission_rate=preset.sell_commission_rate,
             )

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -219,6 +219,43 @@ async def _init_account(s: Services) -> None:
 
     logger.info("AccountService 초기화 완료")
 
+    # 레거시 system.toml [broker].is_paper → Account.broker_config 마이그레이션
+    await _migrate_is_paper_to_broker_config(s)
+
+
+async def _migrate_is_paper_to_broker_config(s: Services) -> None:
+    """system.toml [broker].is_paper를 Account.broker_config으로 1회성 이관한다.
+
+    조건: system.toml에 broker.is_paper가 존재하고,
+    KIS 계좌의 broker_config에 is_paper가 아직 없는 경우에만 이관한다.
+    """
+    legacy_is_paper = s.config.get("broker.is_paper")
+    if legacy_is_paper is None:
+        return
+
+    accounts = await s.account_service.list()
+    migrated: list[str] = []
+    for account in accounts:
+        if account.broker_type not in ("kis", "kis-domestic"):
+            continue
+        if "is_paper" in account.broker_config:
+            continue
+        new_broker_config = {**account.broker_config, "is_paper": legacy_is_paper}
+        await s.account_service.update(
+            account.account_id, broker_config=new_broker_config
+        )
+        migrated.append(account.account_id)
+
+    if migrated:
+        logger.info(
+            "[마이그레이션] system.toml [broker].is_paper=%s → "
+            "Account.broker_config으로 이관 완료: %s\n"
+            "  system.toml의 [broker].is_paper 설정은 더 이상 사용되지 않습니다. "
+            "제거해도 안전합니다.",
+            legacy_is_paper,
+            ", ".join(migrated),
+        )
+
 
 async def _init_trading(s: Services) -> None:
     """Strategy, Trade, TreasuryManager, RuleEngineManager, BotManager."""
@@ -358,7 +395,7 @@ async def _init_gateway(s: Services) -> None:
         if account.broker_type == "kis":
             try:
                 broker = await s.account_service.get_broker(account.account_id)
-                broker_config = account.credentials
+                broker_config = {**account.credentials, **account.broker_config}
                 await _init_stream_integration(s, broker_config, stop_order_manager)
             except Exception:
                 logger.warning(

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -158,6 +158,7 @@ class TestInitInteractive:
                 "PSxxxxxxxx",  # app_key
                 "secretkey123",  # app_secret
                 "50123456-01",  # account_no
+                "y",  # 모의투자 모드? y
                 "n",  # 추가 계좌? n
                 "n",  # 텔레그램? n
                 "n",  # data.go.kr? n

--- a/tests/unit/test_is_paper_migration.py
+++ b/tests/unit/test_is_paper_migration.py
@@ -1,0 +1,331 @@
+"""is_paper를 Account.broker_config으로 이관하는 로직 테스트 (Refs #989)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.account.models import Account
+
+# ── 마이그레이션 로직 단위 테스트 ──────────────────
+
+
+def _make_account(
+    account_id: str = "domestic",
+    broker_type: str = "kis-domestic",
+    broker_config: dict | None = None,
+    credentials: dict | None = None,
+) -> Account:
+    return Account(
+        account_id=account_id,
+        name="테스트",
+        exchange="KRX",
+        currency="KRW",
+        broker_type=broker_type,
+        broker_config=broker_config or {},
+        credentials=credentials or {"app_key": "k", "app_secret": "s"},
+        buy_commission_rate=Decimal("0.00015"),
+        sell_commission_rate=Decimal("0.00195"),
+    )
+
+
+class TestMigrateIsPaperToBrokerConfig:
+    """_migrate_is_paper_to_broker_config 단위 테스트."""
+
+    @pytest.fixture
+    def services(self):
+        """mock Services 객체."""
+        s = MagicMock()
+        s.config = MagicMock()
+        s.account_service = AsyncMock()
+        return s
+
+    async def test_no_legacy_setting_skips(self, services):
+        """system.toml에 broker.is_paper가 없으면 아무것도 하지 않는다."""
+        from ante.main import _migrate_is_paper_to_broker_config
+
+        services.config.get.return_value = None
+
+        await _migrate_is_paper_to_broker_config(services)
+
+        services.account_service.list.assert_not_called()
+
+    async def test_migrates_kis_accounts(self, services):
+        """KIS 계좌에 is_paper를 이관한다."""
+        from ante.main import _migrate_is_paper_to_broker_config
+
+        services.config.get.return_value = True
+        services.account_service.list.return_value = [
+            _make_account("domestic", "kis-domestic"),
+        ]
+
+        await _migrate_is_paper_to_broker_config(services)
+
+        services.account_service.update.assert_called_once_with(
+            "domestic", broker_config={"is_paper": True}
+        )
+
+    async def test_skips_non_kis_accounts(self, services):
+        """KIS가 아닌 계좌는 건너뛴다."""
+        from ante.main import _migrate_is_paper_to_broker_config
+
+        services.config.get.return_value = True
+        services.account_service.list.return_value = [
+            _make_account("test", "test"),
+        ]
+
+        await _migrate_is_paper_to_broker_config(services)
+
+        services.account_service.update.assert_not_called()
+
+    async def test_skips_already_migrated(self, services):
+        """이미 broker_config에 is_paper가 있으면 건너뛴다."""
+        from ante.main import _migrate_is_paper_to_broker_config
+
+        services.config.get.return_value = True
+        services.account_service.list.return_value = [
+            _make_account(
+                "domestic", "kis-domestic", broker_config={"is_paper": False}
+            ),
+        ]
+
+        await _migrate_is_paper_to_broker_config(services)
+
+        services.account_service.update.assert_not_called()
+
+    async def test_migrates_false_value(self, services):
+        """is_paper=false도 정상 이관된다."""
+        from ante.main import _migrate_is_paper_to_broker_config
+
+        services.config.get.return_value = False
+        services.account_service.list.return_value = [
+            _make_account("domestic", "kis-domestic"),
+        ]
+
+        await _migrate_is_paper_to_broker_config(services)
+
+        services.account_service.update.assert_called_once_with(
+            "domestic", broker_config={"is_paper": False}
+        )
+
+    async def test_migrates_kis_broker_type(self, services):
+        """broker_type='kis'인 계좌도 이관 대상이다."""
+        from ante.main import _migrate_is_paper_to_broker_config
+
+        services.config.get.return_value = True
+        services.account_service.list.return_value = [
+            _make_account("old-kis", "kis"),
+        ]
+
+        await _migrate_is_paper_to_broker_config(services)
+
+        services.account_service.update.assert_called_once_with(
+            "old-kis", broker_config={"is_paper": True}
+        )
+
+
+# ── main.py broker_config 병합 테스트 ──────────────────
+
+
+class TestBrokerConfigMerge:
+    """main.py에서 stream 초기화 시 broker_config이 credentials에 병합되는지 확인."""
+
+    def test_broker_config_overrides_credentials(self):
+        """broker_config의 is_paper가 credentials의 is_paper보다 우선한다."""
+        account = _make_account(
+            credentials={"app_key": "k", "app_secret": "s", "is_paper": "true"},
+            broker_config={"is_paper": False},
+        )
+        merged = {**account.credentials, **account.broker_config}
+        assert merged["is_paper"] is False
+
+    def test_broker_config_adds_is_paper(self):
+        """credentials에 is_paper가 없어도 broker_config에서 추가된다."""
+        account = _make_account(
+            credentials={"app_key": "k", "app_secret": "s"},
+            broker_config={"is_paper": True},
+        )
+        merged = {**account.credentials, **account.broker_config}
+        assert merged["is_paper"] is True
+
+
+# ── CLI account create is_paper 프롬프트 테스트 ──────────
+
+
+class TestAccountCreateIsPaper:
+    """ante account create에서 kis-domestic 선택 시 is_paper 입력 확인."""
+
+    @pytest.fixture(autouse=True)
+    def bypass_auth(self):
+        from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+        mock_member = Member(
+            member_id="tester",
+            name="테스터",
+            type=MemberType.HUMAN,
+            role=MemberRole.MASTER,
+            status=MemberStatus.ACTIVE,
+            scopes=[],
+        )
+        with patch(
+            "ante.cli.main.authenticate_member",
+            side_effect=lambda ctx: ctx.obj.update({"member": mock_member}),
+        ):
+            yield
+
+    @pytest.fixture
+    def mock_account_service(self):
+        svc = AsyncMock()
+        db = AsyncMock()
+
+        async def _create_service():
+            return svc, db
+
+        with patch(
+            "ante.cli.commands.account._create_account_service", new=_create_service
+        ):
+            yield svc
+
+    def test_kis_domestic_asks_is_paper(self, mock_account_service):
+        """kis-domestic 선택 시 모의투자 모드 질문이 표시된다."""
+        from ante.cli.main import cli
+
+        created = _make_account("domestic", "kis-domestic")
+        mock_account_service.create.return_value = created
+
+        runner = CliRunner()
+        # 브로커 2(kis-domestic), 계좌ID(기본), 이름(기본), 거래모드 1(virtual),
+        # app_key, app_secret, account_no, is_paper=y
+        input_text = "2\n\n\n1\ntest_key\ntest_secret\n50123456-01\ny\n"
+        result = runner.invoke(cli, ["account", "create"], input=input_text)
+
+        assert result.exit_code == 0, result.output
+        assert "모의투자 모드" in result.output
+        # create에 전달된 Account의 broker_config 확인
+        call_args = mock_account_service.create.call_args
+        account_arg = call_args[0][0]
+        assert account_arg.broker_config == {"is_paper": True}
+
+    def test_kis_domestic_is_paper_false(self, mock_account_service):
+        """모의투자 N 선택 시 is_paper=False로 저장된다."""
+        from ante.cli.main import cli
+
+        created = _make_account("domestic", "kis-domestic")
+        mock_account_service.create.return_value = created
+
+        runner = CliRunner()
+        input_text = "2\n\n\n1\ntest_key\ntest_secret\n50123456-01\nn\n"
+        result = runner.invoke(cli, ["account", "create"], input=input_text)
+
+        assert result.exit_code == 0, result.output
+        call_args = mock_account_service.create.call_args
+        account_arg = call_args[0][0]
+        assert account_arg.broker_config == {"is_paper": False}
+
+    def test_test_broker_no_is_paper(self, mock_account_service):
+        """test 브로커 선택 시 is_paper 질문이 없다."""
+        from ante.cli.main import cli
+
+        created = _make_account("test", "test", broker_config={})
+        mock_account_service.create.return_value = created
+
+        runner = CliRunner()
+        # 브로커 1(test), 계좌ID(기본), 이름(기본), 거래모드 1(virtual),
+        # app_key, app_secret
+        input_text = "1\n\n\n1\ntest_key\ntest_secret\n"
+        result = runner.invoke(cli, ["account", "create"], input=input_text)
+
+        assert result.exit_code == 0, result.output
+        assert "모의투자 모드" not in result.output
+        call_args = mock_account_service.create.call_args
+        account_arg = call_args[0][0]
+        assert account_arg.broker_config == {}
+
+
+# ── CLI init is_paper 프롬프트 테스트 ──────────
+
+
+class TestInitIsPaper:
+    """ante init에서 kis-domestic 선택 시 is_paper 입력 확인."""
+
+    def test_init_with_kis_asks_is_paper(self, runner, tmp_path):
+        """kis-domestic 등록 시 모의투자 모드 질문이 표시된다."""
+        from ante.cli.main import cli
+
+        target = tmp_path / "config"
+        input_lines = "\n".join(
+            [
+                "owner",  # Member ID
+                "홈트레이더",  # 이름
+                "pass1234",  # 패스워드
+                "pass1234",  # 패스워드 확인
+                "y",  # 실제 계좌 등록? y
+                "1",  # 브로커 선택 (kis-domestic)
+                "domestic",  # 계좌 ID
+                "국내 주식",  # 이름
+                "PSxxxxxxxx",  # app_key
+                "secretkey123",  # app_secret
+                "50123456-01",  # account_no
+                "y",  # 모의투자 모드? y
+                "n",  # 추가 계좌? n
+                "n",  # 텔레그램? n
+                "n",  # data.go.kr? n
+                "n",  # DART? n
+            ]
+        )
+
+        mock_result = {"member_id": "owner", "role": "master", "emoji": "f"}
+        mock_token = "ante_hk_test_token_123"
+        mock_recovery_key = "ANTE-RK-XXXX"
+
+        def _mock_bootstrap(*a, **kw):
+            return mock_result, mock_token, mock_recovery_key
+
+        mock_test_account = [
+            {"account_id": "test", "broker_type": "test", "exchange": "TEST"},
+            {
+                "account_id": "domestic",
+                "broker_type": "kis-domestic",
+                "exchange": "KRX",
+            },
+        ]
+
+        create_accounts_mock = AsyncMock(side_effect=lambda *a, **kw: mock_test_account)
+
+        patches = [
+            patch(
+                "ante.cli.commands.init._bootstrap_master",
+                new=AsyncMock(side_effect=_mock_bootstrap),
+            ),
+            patch(
+                "ante.cli.commands.init._create_accounts",
+                new=create_accounts_mock,
+            ),
+            patch("ante.cli.main.authenticate_member"),
+        ]
+
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(
+                cli, ["init", "--dir", str(target)], input=input_lines
+            )
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert result.exit_code == 0, result.output
+        assert "모의투자 모드" in result.output
+
+        # _create_accounts에 전달된 account_inputs에 broker_config 포함 확인
+        call_args = create_accounts_mock.call_args
+        account_inputs = call_args[0][1]
+        assert len(account_inputs) == 1
+        assert account_inputs[0]["broker_config"] == {"is_paper": True}
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()


### PR DESCRIPTION
## Summary
- `ante account create` / `ante init`에서 kis-domestic 선택 시 모의투자 모드(is_paper) 입력 단계를 추가하여 `Account.broker_config`에 저장
- `main.py` 스트림 초기화 시 `account.credentials`만 사용하던 것을 `{**credentials, **broker_config}`으로 병합하여 `is_paper`가 올바르게 전달되도록 수정
- `system.toml` / `system.toml.example`에서 레거시 `[broker].is_paper` 설정 제거
- 시스템 시작 시 기존 `[broker].is_paper` 값을 KIS 계좌의 `broker_config`으로 자동 이관하는 마이그레이션 로직 추가

## Test plan
- [x] `TestMigrateIsPaperToBrokerConfig` 6건: 마이그레이션 로직 (skip/migrate/이미 이관된 경우 등)
- [x] `TestBrokerConfigMerge` 2건: credentials + broker_config 병합 우선순위 확인
- [x] `TestAccountCreateIsPaper` 3건: CLI account create에서 is_paper 프롬프트 동작
- [x] `TestInitIsPaper` 1건: CLI init에서 is_paper 프롬프트 동작
- [x] 기존 `test_cli_init.py` 14건, `test_account_cli.py` 20건 모두 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)