### PR TITLE
fix(strategy): 전략 상세 페이지 rationale·risks·params 미노출 수정

### DIFF
--- a/src/ante/cli/commands/strategy.py
+++ b/src/ante/cli/commands/strategy.py
@@ -119,7 +119,17 @@ def submit(ctx: click.Context, path: str) -> None:
 
     meta = strategy_cls.meta
 
-    # 3. Registry 등록
+    # 3. 전략 인스턴스에서 rationale/risks 추출
+    rationale = ""
+    risks: list[str] = []
+    try:
+        instance = strategy_cls(ctx=None)
+        rationale = instance.get_rationale()
+        risks = instance.get_risks()
+    except Exception:
+        pass  # 인스턴스 생성 실패 시 빈 값 사용
+
+    # 4. Registry 등록
     async def _register() -> dict:
         registry, db = await _create_registry()
         try:
@@ -128,6 +138,8 @@ def submit(ctx: click.Context, path: str) -> None:
                 filepath=filepath,
                 meta=meta,
                 warnings=validation.warnings,
+                rationale=rationale,
+                risks=risks,
             )
             return {
                 "submitted": True,
@@ -256,6 +268,8 @@ def strategy_info(ctx: click.Context, name: str) -> None:
             if params is not None:
                 result["params"] = params["params"]
                 result["param_schema"] = params["param_schema"]
+                result["rationale"] = params["rationale"]
+                result["risks"] = params["risks"]
 
             # 동일 이름의 다른 버전 목록
             if len(records) > 1:
@@ -295,6 +309,8 @@ def _print_info_text(result: dict) -> None:
     click.echo(f"  {'파일 경로':15s}: {result['filepath']}")
     click.echo(f"  {'등록일':15s}: {result['registered_at']}")
     _print_info_warnings(result.get("validation_warnings"))
+    _print_info_rationale(result.get("rationale"))
+    _print_info_risks(result.get("risks"))
     _print_info_params(result.get("params"), result.get("param_schema", {}))
     _print_info_versions(result.get("other_versions"))
 
@@ -306,6 +322,22 @@ def _print_info_warnings(warnings: list[str] | None) -> None:
     click.echo(f"  {'검증 경고':15s}:")
     for w in warnings:
         click.echo(f"    - {w}")
+
+
+def _print_info_rationale(rationale: str | None) -> None:
+    """투자 근거 섹션 출력."""
+    if not rationale:
+        return
+    click.echo(f"  {'투자 근거':15s}: {rationale}")
+
+
+def _print_info_risks(risks: list[str] | None) -> None:
+    """리스크 섹션 출력."""
+    if not risks:
+        return
+    click.echo(f"  {'리스크':15s}:")
+    for r in risks:
+        click.echo(f"    - {r}")
 
 
 def _print_info_params(params: dict | None, schema: dict) -> None:
@@ -344,6 +376,8 @@ def _load_strategy_params(filepath: str) -> dict | None:
         return {
             "params": instance.get_params(),
             "param_schema": instance.get_param_schema(),
+            "rationale": instance.get_rationale(),
+            "risks": instance.get_risks(),
         }
     except Exception:
         return None

--- a/src/ante/strategy/base.py
+++ b/src/ante/strategy/base.py
@@ -240,3 +240,11 @@ class Strategy(ABC):
     def get_param_schema(self) -> dict[str, str]:
         """파라미터 설명 반환. {파라미터명: 설명} 형식."""
         return {}
+
+    def get_rationale(self) -> str:
+        """투자 근거 반환."""
+        return ""
+
+    def get_risks(self) -> list[str]:
+        """리스크 항목 반환."""
+        return []

--- a/strategies/ma_crossover.py
+++ b/strategies/ma_crossover.py
@@ -1,0 +1,109 @@
+"""이동평균 크로스오버 전략.
+
+단기(5일) 이동평균이 장기(20일) 이동평균을 상향 돌파하면 매수,
+하향 돌파하면 매도 시그널을 발생시킨다.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+STRATEGY_VERSION = "0.2.0"
+
+
+class MaCrossoverStrategy(Strategy):
+    """이동평균 골든/데드 크로스 전략."""
+
+    meta = StrategyMeta(
+        name="ma_crossover",
+        version=STRATEGY_VERSION,
+        description="MA(5/20) 골든크로스 매수 / 데드크로스 매도",
+        author_name="test-agent-001",
+        author_id="test-agent-001",
+        symbols=["005930"],
+        timeframe="1d",
+        exchange="KRX",
+    )
+
+    SHORT_PERIOD = 5
+    LONG_PERIOD = 20
+
+    def get_params(self) -> dict[str, Any]:
+        """백테스트 최적화 파라미터 반환."""
+        return {
+            "short_period": self.SHORT_PERIOD,
+            "long_period": self.LONG_PERIOD,
+        }
+
+    def get_param_schema(self) -> dict[str, str]:
+        """파라미터 설명 반환."""
+        return {
+            "short_period": "단기 이동평균 기간",
+            "long_period": "장기 이동평균 기간",
+        }
+
+    def get_rationale(self) -> str:
+        """투자 근거 반환."""
+        return (
+            "단기 이동평균이 장기 이동평균을 상향 돌파(골든크로스)하면 "
+            "상승 추세 전환으로 판단하여 매수하고, "
+            "하향 돌파(데드크로스)하면 하락 추세 전환으로 "
+            "판단하여 매도하는 추세추종 전략."
+        )
+
+    def get_risks(self) -> list[str]:
+        """리스크 항목 반환."""
+        return [
+            "횡보장에서 잦은 크로스로 거짓 신호 다발 가능",
+            "이동평균 후행 특성으로 진입/청산 타이밍 지연",
+            "급등/급락 시 신호 발생이 늦어 수익 기회 일부 상실",
+        ]
+
+    async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+        """이동평균 크로스오버 시그널 생성."""
+        signals: list[Signal] = []
+
+        for symbol in self.meta.symbols:
+            ohlcv = await self.ctx.get_ohlcv(symbol, "1d", limit=self.LONG_PERIOD + 2)
+            if ohlcv.is_empty() or len(ohlcv) < self.LONG_PERIOD + 1:
+                continue
+
+            prices = ohlcv["close"].to_list()
+
+            short_now = sum(prices[-self.SHORT_PERIOD :]) / self.SHORT_PERIOD
+            short_prev = sum(prices[-self.SHORT_PERIOD - 1 : -1]) / self.SHORT_PERIOD
+            long_now = sum(prices[-self.LONG_PERIOD :]) / self.LONG_PERIOD
+            long_prev = sum(prices[-self.LONG_PERIOD - 1 : -1]) / self.LONG_PERIOD
+
+            # 골든크로스: 단기가 장기를 상향 돌파
+            if short_prev <= long_prev and short_now > long_now:
+                signals.append(
+                    Signal(
+                        symbol=symbol,
+                        side="buy",
+                        quantity=1.0,
+                        order_type="market",
+                        reason=(
+                            f"골든크로스 MA{self.SHORT_PERIOD}={short_now:.0f}"
+                            f" > MA{self.LONG_PERIOD}={long_now:.0f}"
+                        ),
+                    )
+                )
+            # 데드크로스: 단기가 장기를 하향 돌파
+            elif short_prev >= long_prev and short_now < long_now:
+                signals.append(
+                    Signal(
+                        symbol=symbol,
+                        side="sell",
+                        quantity=1.0,
+                        order_type="market",
+                        reason=(
+                            f"데드크로스 MA{self.SHORT_PERIOD}={short_now:.0f}"
+                            f" < MA{self.LONG_PERIOD}={long_now:.0f}"
+                        ),
+                    )
+                )
+
+        return signals

--- a/strategies/rsi_mean_reversion.py
+++ b/strategies/rsi_mean_reversion.py
@@ -1,0 +1,121 @@
+"""RSI 평균회귀 전략.
+
+RSI(14)가 과매도(30 이하) 구간에서 매수,
+과매수(70 이상) 구간에서 매도 시그널을 발생시킨다.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+STRATEGY_VERSION = "0.2.0"
+
+
+class RsiMeanReversionStrategy(Strategy):
+    """RSI 기반 평균회귀 전략."""
+
+    meta = StrategyMeta(
+        name="rsi_mean_reversion",
+        version=STRATEGY_VERSION,
+        description="RSI(14) 과매도 매수 / 과매수 매도 평균회귀",
+        author_name="test-agent-001",
+        author_id="test-agent-001",
+        symbols=["005930", "000660"],
+        timeframe="1d",
+        exchange="KRX",
+    )
+
+    RSI_PERIOD = 14
+    OVERSOLD = 30.0
+    OVERBOUGHT = 70.0
+
+    def get_params(self) -> dict[str, Any]:
+        """백테스트 최적화 파라미터 반환."""
+        return {
+            "rsi_period": self.RSI_PERIOD,
+            "oversold": self.OVERSOLD,
+            "overbought": self.OVERBOUGHT,
+        }
+
+    def get_param_schema(self) -> dict[str, str]:
+        """파라미터 설명 반환."""
+        return {
+            "rsi_period": "RSI 계산 기간",
+            "oversold": "과매도 판단 RSI 임계값",
+            "overbought": "과매수 판단 RSI 임계값",
+        }
+
+    def get_rationale(self) -> str:
+        """투자 근거 반환."""
+        return (
+            "RSI가 극단적 과매도/과매수 영역에 도달하면 "
+            "평균으로 회귀하는 경향을 이용한 역추세 전략. "
+            "단기 과매도 반등과 과매수 조정을 포착한다."
+        )
+
+    def get_risks(self) -> list[str]:
+        """리스크 항목 반환."""
+        return [
+            "강한 추세장에서 역추세 진입으로 손실 확대 가능",
+            "RSI 단일 지표 의존으로 거짓 신호 발생 가능",
+            "급락장에서 과매도 매수 후 추가 하락 위험",
+        ]
+
+    async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+        """RSI 기반 시그널 생성."""
+        signals: list[Signal] = []
+
+        for symbol in self.meta.symbols:
+            ohlcv = await self.ctx.get_ohlcv(symbol, "1d", limit=self.RSI_PERIOD + 5)
+            if ohlcv.is_empty() or len(ohlcv) < self.RSI_PERIOD + 1:
+                continue
+
+            closes = ohlcv["close"].to_list()
+            rsi = self._calc_rsi(closes, self.RSI_PERIOD)
+            if rsi is None:
+                continue
+
+            if rsi <= self.OVERSOLD:
+                signals.append(
+                    Signal(
+                        symbol=symbol,
+                        side="buy",
+                        quantity=1.0,
+                        order_type="market",
+                        reason=f"RSI {rsi:.1f} <= {self.OVERSOLD} 과매도 매수",
+                    )
+                )
+            elif rsi >= self.OVERBOUGHT:
+                signals.append(
+                    Signal(
+                        symbol=symbol,
+                        side="sell",
+                        quantity=1.0,
+                        order_type="market",
+                        reason=f"RSI {rsi:.1f} >= {self.OVERBOUGHT} 과매수 매도",
+                    )
+                )
+
+        return signals
+
+    @staticmethod
+    def _calc_rsi(prices: list[float], period: int) -> float | None:
+        """단순 RSI 계산."""
+        if len(prices) < period + 1:
+            return None
+
+        changes = [prices[i] - prices[i - 1] for i in range(1, len(prices))]
+        recent = changes[-period:]
+
+        gains = [c for c in recent if c > 0]
+        losses = [-c for c in recent if c < 0]
+
+        avg_gain = sum(gains) / period if gains else 0.0
+        avg_loss = sum(losses) / period if losses else 0.0
+
+        if avg_loss == 0:
+            return 100.0
+        rs = avg_gain / avg_loss
+        return 100.0 - (100.0 / (1.0 + rs))

--- a/strategies/volume_breakout.py
+++ b/strategies/volume_breakout.py
@@ -1,0 +1,99 @@
+"""거래량 돌파 전략.
+
+당일 거래량이 20일 평균 거래량의 2배를 초과하고
+종가가 전일 대비 상승하면 매수 시그널을 발생시킨다.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+STRATEGY_VERSION = "0.2.0"
+
+
+class VolumeBreakoutStrategy(Strategy):
+    """거래량 급증 돌파 전략."""
+
+    meta = StrategyMeta(
+        name="volume_breakout",
+        version=STRATEGY_VERSION,
+        description="거래량 2배 돌파 + 가격 상승 시 매수",
+        author_name="test-agent-001",
+        author_id="test-agent-001",
+        symbols=["005930", "000660", "035420"],
+        timeframe="1d",
+        exchange="KRX",
+    )
+
+    LOOKBACK = 20
+    VOLUME_MULTIPLIER = 2.0
+
+    def get_params(self) -> dict[str, Any]:
+        """백테스트 최적화 파라미터 반환."""
+        return {
+            "lookback": self.LOOKBACK,
+            "volume_multiplier": self.VOLUME_MULTIPLIER,
+        }
+
+    def get_param_schema(self) -> dict[str, str]:
+        """파라미터 설명 반환."""
+        return {
+            "lookback": "평균 거래량 계산 기간 (일)",
+            "volume_multiplier": "거래량 돌파 배수 기준",
+        }
+
+    def get_rationale(self) -> str:
+        """투자 근거 반환."""
+        return (
+            "거래량이 평균 대비 급증하면서 가격이 상승하는 종목은 "
+            "기관/외국인 등 큰 손의 매집 신호일 가능성이 높다. "
+            "거래량 돌파와 가격 상승이 동시에 발생하는 시점을 포착하여 매수한다."
+        )
+
+    def get_risks(self) -> list[str]:
+        """리스크 항목 반환."""
+        return [
+            "거래량 급증이 단발성 이벤트(뉴스 등)일 경우 후속 상승 부재",
+            "매수 전용 전략으로 하락장 대응 수단 부재",
+            "대량 매도에 의한 거래량 급증을 매수 신호로 오인할 가능성",
+        ]
+
+    async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+        """거래량 돌파 시그널 생성."""
+        signals: list[Signal] = []
+
+        for symbol in self.meta.symbols:
+            ohlcv = await self.ctx.get_ohlcv(symbol, "1d", limit=self.LOOKBACK + 2)
+            if ohlcv.is_empty() or len(ohlcv) < self.LOOKBACK + 1:
+                continue
+
+            volumes = ohlcv["volume"].to_list()
+            closes = ohlcv["close"].to_list()
+
+            avg_volume = sum(volumes[-self.LOOKBACK - 1 : -1]) / self.LOOKBACK
+            current_volume = volumes[-1]
+            price_change = closes[-1] - closes[-2]
+
+            if avg_volume == 0:
+                continue
+
+            volume_ratio = current_volume / avg_volume
+
+            if volume_ratio >= self.VOLUME_MULTIPLIER and price_change > 0:
+                signals.append(
+                    Signal(
+                        symbol=symbol,
+                        side="buy",
+                        quantity=1.0,
+                        order_type="market",
+                        reason=(
+                            f"거래량 돌파 {volume_ratio:.1f}x"
+                            f" (>{self.VOLUME_MULTIPLIER}x)"
+                            " + 가격 상승"
+                        ),
+                    )
+                )
+
+        return signals

--- a/tests/unit/test_strategy_submit.py
+++ b/tests/unit/test_strategy_submit.py
@@ -1,0 +1,227 @@
+"""전략 submit 시 rationale/risks 전달 검증 테스트."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+from ante.strategy.base import Signal, Strategy, StrategyMeta
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+# ── 테스트용 전략 클래스 ─────────────────────────────
+
+
+class MinimalStrategy(Strategy):
+    """get_rationale/get_risks 오버라이드 없는 최소 전략."""
+
+    meta = StrategyMeta(
+        name="minimal",
+        version="0.1.0",
+        description="test",
+    )
+
+    async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+        return []
+
+
+class RichStrategy(Strategy):
+    """rationale/risks를 오버라이드한 전략."""
+
+    meta = StrategyMeta(
+        name="rich",
+        version="0.1.0",
+        description="test with rationale",
+    )
+
+    async def on_step(self, context: dict[str, Any]) -> list[Signal]:
+        return []
+
+    def get_rationale(self) -> str:
+        return "test rationale"
+
+    def get_risks(self) -> list[str]:
+        return ["risk A", "risk B"]
+
+    def get_params(self) -> dict[str, Any]:
+        return {"period": 14}
+
+    def get_param_schema(self) -> dict[str, str]:
+        return {"period": "lookback period"}
+
+
+# ── Fixtures ─────────────────────────────────────────
+
+
+@pytest.fixture()
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _mock_registry() -> MagicMock:
+    registry = MagicMock()
+    registry.initialize = AsyncMock()
+    record = MagicMock()
+    record.strategy_id = "rich_v0.1.0"
+    record.name = "rich"
+    record.version = "0.1.0"
+    record.description = "test with rationale"
+    record.author_name = "agent"
+    record.author_id = "agent"
+    record.filepath = "/tmp/rich.py"
+    record.registered_at = MagicMock()
+    record.registered_at.isoformat.return_value = "2026-01-01T00:00:00"
+    record.validation_warnings = []
+    registry.register = AsyncMock(return_value=record)
+    return registry
+
+
+def _mock_db() -> MagicMock:
+    db = MagicMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    return db
+
+
+# ── Strategy ABC 기본 메서드 테스트 ──────────────────
+
+
+class TestStrategyABCDefaults:
+    """Strategy ABC의 기본 get_rationale/get_risks 반환값 검증."""
+
+    def test_default_get_rationale(self) -> None:
+        instance = MinimalStrategy(ctx=None)
+        assert instance.get_rationale() == ""
+
+    def test_default_get_risks(self) -> None:
+        instance = MinimalStrategy(ctx=None)
+        assert instance.get_risks() == []
+
+    def test_default_get_params(self) -> None:
+        instance = MinimalStrategy(ctx=None)
+        assert instance.get_params() == {}
+
+    def test_default_get_param_schema(self) -> None:
+        instance = MinimalStrategy(ctx=None)
+        assert instance.get_param_schema() == {}
+
+
+class TestStrategyOverrides:
+    """오버라이드된 get_rationale/get_risks 반환값 검증."""
+
+    def test_overridden_get_rationale(self) -> None:
+        instance = RichStrategy(ctx=None)
+        assert instance.get_rationale() == "test rationale"
+
+    def test_overridden_get_risks(self) -> None:
+        instance = RichStrategy(ctx=None)
+        assert instance.get_risks() == ["risk A", "risk B"]
+
+    def test_overridden_get_params(self) -> None:
+        instance = RichStrategy(ctx=None)
+        assert instance.get_params() == {"period": 14}
+
+    def test_overridden_get_param_schema(self) -> None:
+        instance = RichStrategy(ctx=None)
+        assert instance.get_param_schema() == {"period": "lookback period"}
+
+
+# ── Submit CLI: rationale/risks 추출 → register 전달 검증 ──
+
+
+class TestSubmitRationaleRisks:
+    """submit 커맨드에서 rationale/risks가 register에 전달되는지 검증."""
+
+    def test_submit_extracts_rationale_risks(self, runner) -> None:
+        """submit 시 전략 인스턴스에서 rationale/risks를 추출."""
+        db = _mock_db()
+        registry = _mock_registry()
+
+        validation_result = MagicMock()
+        validation_result.valid = True
+        validation_result.errors = []
+        validation_result.warnings = []
+
+        with (
+            patch("ante.strategy.validator.StrategyValidator") as mock_validator_cls,
+            patch("ante.strategy.loader.StrategyLoader") as mock_loader,
+            patch(
+                "ante.cli.commands.strategy._create_registry",
+                new_callable=AsyncMock,
+                return_value=(registry, db),
+            ),
+        ):
+            mock_validator_cls.return_value.validate.return_value = validation_result
+            mock_loader.load.return_value = RichStrategy
+
+            result = runner.invoke(
+                cli,
+                ["strategy", "submit", __file__],
+            )
+
+            assert result.exit_code == 0
+            registry.register.assert_called_once()
+            call_kwargs = registry.register.call_args
+            assert call_kwargs.kwargs.get("rationale") == "test rationale"
+            assert call_kwargs.kwargs.get("risks") == ["risk A", "risk B"]
+
+    def test_submit_with_no_rationale_risks(self, runner) -> None:
+        """rationale/risks가 없는 전략은 빈 값으로 전달."""
+        db = _mock_db()
+        registry = _mock_registry()
+
+        validation_result = MagicMock()
+        validation_result.valid = True
+        validation_result.errors = []
+        validation_result.warnings = []
+
+        with (
+            patch("ante.strategy.validator.StrategyValidator") as mock_validator_cls,
+            patch("ante.strategy.loader.StrategyLoader") as mock_loader,
+            patch(
+                "ante.cli.commands.strategy._create_registry",
+                new_callable=AsyncMock,
+                return_value=(registry, db),
+            ),
+        ):
+            mock_validator_cls.return_value.validate.return_value = validation_result
+            mock_loader.load.return_value = MinimalStrategy
+
+            result = runner.invoke(
+                cli,
+                ["strategy", "submit", __file__],
+            )
+
+            assert result.exit_code == 0
+            registry.register.assert_called_once()
+            call_kwargs = registry.register.call_args
+            assert call_kwargs.kwargs.get("rationale") == ""
+            assert call_kwargs.kwargs.get("risks") == []


### PR DESCRIPTION
## Summary
- Strategy ABC에 `get_rationale()`, `get_risks()` 기본 메서드 추가
- Submit CLI에서 전략 인스턴스의 rationale/risks를 추출하여 `registry.register()`에 전달
- 3개 전략 파일(`rsi_mean_reversion`, `ma_crossover`, `volume_breakout`)에 `get_params`/`get_param_schema`/`get_rationale`/`get_risks` 오버라이드 구현
- `strategy info` 커맨드에서 투자 근거/리스크 섹션 텍스트 및 JSON 출력 지원
- 단위 테스트 10건 추가 (ABC 기본값 검증 + submit 시 rationale/risks 전달 검증)

Refs #994

## Test plan
- [x] `ruff check` 및 `ruff format --check` 통과
- [x] `pytest tests/unit/test_strategy_submit.py` 10건 전체 통과
- [ ] 전략 상세 페이지에서 투자 근거/리스크/파라미터 섹션 정상 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)