### PR TITLE
fix(typing): mypy ignore 목록 중간 난이도 오류 27건 해소

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,14 +64,8 @@ ignore_missing_imports = true
 module = [
     "ante.cli.*",
     "ante.main",
-    "ante.feed.transform.validate",
-    "ante.notification.service",
-    "ante.member.*",
-    "ante.approval.service",
-    "ante.bot.*",
     "ante.report.store",
     "ante.strategy.registry",
-    "ante.web.routes.strategies",
 ]
 ignore_errors = true
 

--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -588,7 +588,7 @@ class ApprovalService:
             return None
         return self._row_to_request(row)
 
-    async def list(
+    async def list_approvals(
         self,
         status: str | None = None,
         type: str | None = None,

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -319,7 +319,7 @@ class BotManager:
             "max_signals_per_step": old_config.max_signals_per_step,
         }
         config_fields.update(updates)
-        new_config = BotConfig(**config_fields)
+        new_config = BotConfig(**config_fields)  # type: ignore[arg-type]
         bot.config = new_config
 
         # DB 갱신

--- a/src/ante/bot/signal_channel.py
+++ b/src/ante/bot/signal_channel.py
@@ -126,6 +126,7 @@ class SignalChannel:
         params = msg.get("params", {})
 
         try:
+            data: Any = None
             if method == "positions":
                 data = self._ctx.get_positions()
             elif method == "balance":

--- a/src/ante/cli/commands/approval.py
+++ b/src/ante/cli/commands/approval.py
@@ -101,7 +101,7 @@ def approval_list(
         service = ApprovalService(db=db, eventbus=eventbus)
         await service.initialize()
 
-        requests = await service.list(status=status, type=approval_type)
+        requests = await service.list_approvals(status=status, type=approval_type)
         await db.close()
         return [
             {
@@ -367,7 +367,7 @@ async def _find_request(service, id: str):  # type: ignore[no-untyped-def]
         return req
 
     # prefix 검색
-    all_requests = await service.list(limit=100)
+    all_requests = await service.list_approvals(limit=100)
     matches = [r for r in all_requests if r.id.startswith(id)]
     if len(matches) == 1:
         return matches[0]

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -104,7 +104,7 @@ def member_list(
     async def _run_list() -> list[dict]:
         service, db = await _create_service()
         try:
-            members = await service.list(
+            members = await service.list_members(
                 member_type=member_type, org=org, status=status
             )
             return [
@@ -411,7 +411,7 @@ def member_reset_password(ctx: click.Context, recovery_key: str) -> None:
     async def _run_reset() -> None:
         service, db = await _create_service()
         try:
-            members = await service.list(member_type="human")
+            members = await service.list_members(member_type="human")
             master = next((m for m in members if m.role == "master"), None)
             if not master:
                 msg = "master 멤버가 존재하지 않습니다"
@@ -439,7 +439,7 @@ def member_regenerate_recovery_key(ctx: click.Context) -> None:
     async def _run_regen() -> str:
         service, db = await _create_service()
         try:
-            members = await service.list(member_type="human")
+            members = await service.list_members(member_type="human")
             master = next((m for m in members if m.role == "master"), None)
             if not master:
                 msg = "master 멤버가 존재하지 않습니다"

--- a/src/ante/feed/transform/validate.py
+++ b/src/ante/feed/transform/validate.py
@@ -257,7 +257,7 @@ def _check_ohlc_relationship(
     except (ValueError, TypeError):
         return  # 숫자 변환 실패는 스키마 계층에서 처리
 
-    if not all(v is not None for v in (o, h, low_val, c)):
+    if o is None or h is None or low_val is None or c is None:
         return
 
     if low_val > c:

--- a/src/ante/member/auth_service.py
+++ b/src/ante/member/auth_service.py
@@ -10,6 +10,8 @@ from ante.member.models import Member, MemberStatus, MemberType
 from ante.member.token_manager import TokenManager
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from ante.core.database import Database
     from ante.eventbus.bus import EventBus
 
@@ -24,7 +26,7 @@ class AuthService:
         db: Database,
         eventbus: EventBus,
         token_manager: TokenManager,
-        get_member: object,
+        get_member: Callable[[str], Awaitable[Member | None]],
     ) -> None:
         self._db = db
         self._eventbus = eventbus

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -435,7 +435,7 @@ class MemberService:
         )
         return _row_to_member(row) if row else None
 
-    async def list(
+    async def list_members(
         self,
         member_type: str | None = None,
         org: str | None = None,

--- a/src/ante/notification/service.py
+++ b/src/ante/notification/service.py
@@ -155,7 +155,7 @@ class NotificationService:
             return False
 
         if dedup_result:
-            message = message + dedup_result
+            message = message + str(dedup_result)
 
         try:
             return await self._adapter.send(level, message)
@@ -178,7 +178,7 @@ class NotificationService:
             return False
 
         if dedup_result:
-            body = (body or "") + dedup_result
+            body = (body or "") + str(dedup_result)
 
         try:
             return await self._adapter.send_rich(
@@ -202,7 +202,7 @@ class NotificationService:
             return False
 
         if dedup_result:
-            body = (body or "") + dedup_result
+            body = (body or "") + str(dedup_result)
 
         # 어댑터가 send_with_buttons를 지원하는 경우 사용, 아니면 send_rich fallback
         try:

--- a/src/ante/web/routes/approvals.py
+++ b/src/ante/web/routes/approvals.py
@@ -46,7 +46,7 @@ async def list_approvals(
     limit: int = Query(default=20, ge=1, le=100),
 ) -> dict:
     """결재 목록 조회."""
-    approvals = await approval_service.list(
+    approvals = await approval_service.list_approvals(
         status=status, type=type, search=search, limit=limit, offset=offset
     )
     total = await approval_service.count(status=status, type=type, search=search)

--- a/src/ante/web/routes/members.py
+++ b/src/ante/web/routes/members.py
@@ -65,7 +65,7 @@ async def list_members(
     offset: int = Query(default=0, ge=0),
 ) -> dict:
     """멤버 목록 조회."""
-    members = await svc.list(
+    members = await svc.list_members(
         member_type=type, org=org, status=status, limit=limit, offset=offset
     )
     total = await svc.count(member_type=type, org=org, status=status)

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -117,7 +117,7 @@ async def list_strategies(
         ]
         results = await asyncio.gather(*tasks, return_exceptions=True)
         for r, result in zip(records, results):
-            if isinstance(result, Exception):
+            if isinstance(result, BaseException):
                 _logger.debug(
                     "전략 %s cumulative_return 계산 실패",
                     r.strategy_id,
@@ -263,6 +263,7 @@ async def get_strategy_performance(
         if bot_info:
             from ante.report.feedback import PerformanceFeedback
 
+            assert bot_manager is not None  # guarded by bot_info check
             feedback = PerformanceFeedback(
                 trade_service=trade_service,
                 bot_manager=bot_manager,

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -170,7 +170,7 @@ class TestCreate:
         await service.create(type="bot_create", requester="agent", title="요청 2")
         await service.create(type="bot_stop", requester="agent", title="요청 3")
 
-        all_requests = await service.list()
+        all_requests = await service.list_approvals()
         assert len(all_requests) == 3
 
     async def test_list_filter_status(self, service):
@@ -181,10 +181,10 @@ class TestCreate:
         await service.create(type="bot_create", requester="agent", title="요청 2")
         await service.approve(req.id)
 
-        pending = await service.list(status="pending")
+        pending = await service.list_approvals(status="pending")
         assert len(pending) == 1
 
-        approved = await service.list(status="approved")
+        approved = await service.list_approvals(status="approved")
         assert len(approved) == 1
 
     async def test_list_filter_type(self, service):
@@ -192,7 +192,7 @@ class TestCreate:
         await service.create(type="budget_change", requester="agent", title="요청 1")
         await service.create(type="bot_create", requester="agent", title="요청 2")
 
-        budget = await service.list(type="budget_change")
+        budget = await service.list_approvals(type="budget_change")
         assert len(budget) == 1
         assert budget[0].type == "budget_change"
 
@@ -203,8 +203,8 @@ class TestCreate:
                 type="budget_change", requester="agent", title=f"요청 {i}"
             )
 
-        page1 = await service.list(limit=2, offset=0)
-        page2 = await service.list(limit=2, offset=2)
+        page1 = await service.list_approvals(limit=2, offset=0)
+        page2 = await service.list_approvals(limit=2, offset=2)
         assert len(page1) == 2
         assert len(page2) == 2
 
@@ -499,7 +499,7 @@ class TestExpire:
         count = await service.expire_stale()
         assert count == 1
 
-        requests = await service.list(status="expired")
+        requests = await service.list_approvals(status="expired")
         assert len(requests) == 1
         assert any(h["action"] == "expired" for h in requests[0].history)
 
@@ -697,7 +697,7 @@ class TestValidator:
             )
 
         # DB에 요청이 생성되지 않았는지 확인
-        all_requests = await svc.list()
+        all_requests = await svc.list_approvals()
         assert len(all_requests) == 0
 
     async def test_warn_attaches_review(self, db, eventbus):
@@ -1085,7 +1085,7 @@ class TestExecutionFailed:
         )
         await svc.approve(req.id)
 
-        failed_list = await svc.list(status="execution_failed")
+        failed_list = await svc.list_approvals(status="execution_failed")
         assert len(failed_list) == 1
         assert failed_list[0].status == "execution_failed"
 
@@ -1456,7 +1456,7 @@ class TestListSearch:
             type="strategy_adopt", requester="agent-02", title="전략 채택 요청"
         )
 
-        results = await service.list(search="예산")
+        results = await service.list_approvals(search="예산")
         assert len(results) == 1
         assert results[0].title == "예산 증액 요청"
 
@@ -1469,7 +1469,7 @@ class TestListSearch:
             type="budget_change", requester="agent-beta", title="요청 B"
         )
 
-        results = await service.list(search="alpha")
+        results = await service.list_approvals(search="alpha")
         assert len(results) == 1
         assert results[0].requester == "agent-alpha"
 
@@ -1485,7 +1485,7 @@ class TestListSearch:
             type="budget_change", requester="agent-02", title="관련 없는 제목"
         )
 
-        results = await service.list(search="검색어포함")
+        results = await service.list_approvals(search="검색어포함")
         assert len(results) == 2
 
     async def test_search_no_match(self, service):
@@ -1494,7 +1494,7 @@ class TestListSearch:
             type="budget_change", requester="agent-01", title="예산 요청"
         )
 
-        results = await service.list(search="존재하지않는키워드")
+        results = await service.list_approvals(search="존재하지않는키워드")
         assert len(results) == 0
 
     async def test_search_empty_string(self, service):
@@ -1502,7 +1502,7 @@ class TestListSearch:
         await service.create(type="budget_change", requester="agent-01", title="요청 1")
         await service.create(type="budget_change", requester="agent-02", title="요청 2")
 
-        results = await service.list(search="")
+        results = await service.list_approvals(search="")
         assert len(results) == 2
 
     async def test_search_combined_with_status_filter(self, service):
@@ -1515,7 +1515,7 @@ class TestListSearch:
         )
         await service.approve(req.id)
 
-        results = await service.list(search="요청", status="pending")
+        results = await service.list_approvals(search="요청", status="pending")
         assert len(results) == 1
         assert results[0].title == "대기 중 요청"
 
@@ -1523,5 +1523,5 @@ class TestListSearch:
         """search=None이면 기존 동작 (전체 반환)."""
         await service.create(type="budget_change", requester="agent-01", title="요청 1")
 
-        results = await service.list(search=None)
+        results = await service.list_approvals(search=None)
         assert len(results) == 1

--- a/tests/unit/test_cli_format_option.py
+++ b/tests/unit/test_cli_format_option.py
@@ -63,7 +63,7 @@ class TestMemberListFormatOption:
         """member list --format json 이 올바르게 JSON 출력."""
         svc = MagicMock()
         db = _mock_db()
-        svc.list = AsyncMock(return_value=[])
+        svc.list_members = AsyncMock(return_value=[])
 
         with patch(
             "ante.cli.commands.member._create_service",
@@ -79,7 +79,7 @@ class TestMemberListFormatOption:
         """--format json member list (루트 옵션) 도 여전히 동작."""
         svc = MagicMock()
         db = _mock_db()
-        svc.list = AsyncMock(return_value=[])
+        svc.list_members = AsyncMock(return_value=[])
 
         with patch(
             "ante.cli.commands.member._create_service",

--- a/tests/unit/test_member.py
+++ b/tests/unit/test_member.py
@@ -461,20 +461,20 @@ class TestList:
     async def test_list_all(self, service):
         await service.register("agent-01", MemberType.AGENT)
         await service.register("agent-02", MemberType.AGENT, org="risk")
-        members = await service.list()
+        members = await service.list_members()
         assert len(members) == 2
 
     async def test_list_by_type(self, service):
         await service.bootstrap_master("owner", "pass123")
         await service.register("agent-01", MemberType.AGENT)
-        humans = await service.list(member_type=MemberType.HUMAN)
+        humans = await service.list_members(member_type=MemberType.HUMAN)
         assert len(humans) == 1
         assert humans[0].type == MemberType.HUMAN
 
     async def test_list_by_org(self, service):
         await service.register("a1", MemberType.AGENT, org="strategy-lab")
         await service.register("a2", MemberType.AGENT, org="risk")
-        result = await service.list(org="risk")
+        result = await service.list_members(org="risk")
         assert len(result) == 1
         assert result[0].member_id == "a2"
 

--- a/tests/unit/test_member_api.py
+++ b/tests/unit/test_member_api.py
@@ -41,7 +41,7 @@ class FakeMemberService:
         self._members: dict[str, FakeMember] = {}
         self._token_counter = 0
 
-    async def list(
+    async def list_members(
         self,
         member_type: str | None = None,
         org: str | None = None,


### PR DESCRIPTION
## Summary
- mypy ignore 목록 중 구조 이해가 필요한 27건의 타입 오류를 해소
- 6개 모듈(`feed.transform.validate`, `notification.service`, `bot.*`, `web.routes.strategies`, `approval.service`, `member.*`)을 ignore 목록에서 제거
- `ApprovalService.list` -> `list_approvals`, `MemberService.list` -> `list_members` 리네임 및 전체 호출부 동기 수정

## Changes
| 파일 | 수정 내용 |
|------|----------|
| `feed/transform/validate.py` | `all(v is not None ...)` -> 개별 `is None` 체크로 mypy narrowing 지원 |
| `notification/service.py` | `str + object` -> `str + str(dedup_result)` 캐스팅 |
| `bot/signal_channel.py` | `data` 변수 `Any` 타입 명시 선언 |
| `bot/manager.py` | `BotConfig(**dict)` 호출에 `type: ignore[arg-type]` |
| `web/routes/strategies.py` | `isinstance(BaseException)` 분기 + `assert bot_manager is not None` |
| `approval/service.py` | `list` -> `list_approvals` 리네임 |
| `member/service.py` | `list` -> `list_members` 리네임 |
| `member/auth_service.py` | `get_member: object` -> `Callable[[str], Awaitable[Member | None]]` |
| `pyproject.toml` | 해소된 6개 모듈 ignore 목록에서 제거 |

## Test plan
- [x] `mypy src/` 통과 (0 errors)
- [x] `ruff check src/` 통과
- [x] `ruff format --check src/` 통과
- [x] 리네임 영향받는 테스트 전체 통과 (test_approval, test_member, test_member_api, test_cli_format_option)
- [x] 전체 테스트 스위트 통과 (기존 실패 2건은 본 PR과 무관한 test_main.py 이슈)

Refs #1013

🤖 Generated with [Claude Code](https://claude.com/claude-code)