### PR TITLE
fix(typing): cli/main.py mypy has-type 오류 18건 inline ignore 처리

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = [
-    "ante.cli.*",
+    "ante.cli.commands.backtest",
+    "ante.cli.commands.bot",
+    "ante.cli.commands.init",
+    "ante.cli.commands.report",
     "ante.main",
     "ante.report.store",
     "ante.strategy.registry",

--- a/src/ante/cli/main.py
+++ b/src/ante/cli/main.py
@@ -73,24 +73,24 @@ from ante.cli.commands.treasury import treasury  # noqa: E402
 from ante.cli.commands.update import update  # noqa: E402
 from ante.feed.cli import feed  # noqa: E402
 
-cli.add_command(account)
-cli.add_command(audit)
-cli.add_command(approval)
-cli.add_command(init)
-cli.add_command(bot)
-cli.add_command(broker)
-cli.add_command(config)
-cli.add_command(strategy)
-cli.add_command(data)
-cli.add_command(backtest)
-cli.add_command(report)
-cli.add_command(instrument)
-cli.add_command(member)
+cli.add_command(account)  # type: ignore[has-type]
+cli.add_command(audit)  # type: ignore[has-type]
+cli.add_command(approval)  # type: ignore[has-type]
+cli.add_command(init)  # type: ignore[has-type]
+cli.add_command(bot)  # type: ignore[has-type]
+cli.add_command(broker)  # type: ignore[has-type]
+cli.add_command(config)  # type: ignore[has-type]
+cli.add_command(strategy)  # type: ignore[has-type]
+cli.add_command(data)  # type: ignore[has-type]
+cli.add_command(backtest)  # type: ignore[has-type]
+cli.add_command(report)  # type: ignore[has-type]
+cli.add_command(instrument)  # type: ignore[has-type]
+cli.add_command(member)  # type: ignore[has-type]
 cli.add_command(notification)
-cli.add_command(rule)
+cli.add_command(rule)  # type: ignore[has-type]
 cli.add_command(signal)
-cli.add_command(system)
-cli.add_command(trade)
-cli.add_command(treasury)
-cli.add_command(update)
+cli.add_command(system)  # type: ignore[has-type]
+cli.add_command(trade)  # type: ignore[has-type]
+cli.add_command(treasury)  # type: ignore[has-type]
+cli.add_command(update)  # type: ignore[has-type]
 cli.add_command(feed)


### PR DESCRIPTION
## Summary
- `cli/main.py`의 Click `lazy_subcommand` 패턴으로 인한 mypy `[has-type]` 오류 18건에 `# type: ignore[has-type]` 인라인 주석 추가
- `pyproject.toml` mypy override에서 `ante.cli.*` 와일드카드를 제거하고, 아직 오류가 남은 4개 서브모듈(`backtest`, `bot`, `init`, `report`)만 개별 등록
- `mypy src/` 전체 통과 확인 (220 source files)

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `src/ante/cli/main.py` | 18개 `add_command()` 라인에 `# type: ignore[has-type]` 추가 |
| `pyproject.toml` | `ante.cli.*` -> 4개 개별 모듈로 세분화 |

## Test plan
- [x] `mypy src/` 통과 (220 files, 0 errors)
- [x] `ruff check` 통과
- [x] `ruff format --check` 통과
- [x] 기존 테스트 전체 통과 (기존 실패 1건 `test_approval.py::TestCreate::test_list_all`은 base 브랜치에서도 동일하게 실패하는 기존 이슈)

Refs #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)