### PR TITLE
fix(test): test_init_account에 Config 주입 누락 수정

### DIFF
--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -266,7 +266,8 @@ async def test_init_account_creates_test_account(tmp_path: Path) -> None:
     await db.connect()
 
     eventbus = EventBus(history_size=100)
-    s = Services(db=db, eventbus=eventbus)
+    config = Config(static={}, secrets={})
+    s = Services(db=db, eventbus=eventbus, config=config)
 
     await _init_account(s)
 
@@ -305,7 +306,8 @@ async def test_init_account_skips_when_accounts_exist(tmp_path: Path) -> None:
     await account_service.create(existing)
 
     # _init_account 재실행
-    s = Services(db=db, eventbus=eventbus)
+    config = Config(static={}, secrets={})
+    s = Services(db=db, eventbus=eventbus, config=config)
     await _init_account(s)
 
     accounts = await s.account_service.list()


### PR DESCRIPTION
## Summary
- `test_init_account_creates_test_account`, `test_init_account_skips_when_accounts_exist` 테스트에서 `Services` 생성 시 `config` 미설정으로 CI 실패
- `_init_account()` → `_migrate_is_paper_to_broker_config()` → `s.config.get()` 호출 시 `NoneType.get` AttributeError 발생
- 빈 `Config(static={}, secrets={})` 주입하여 해결

## Test plan
- [x] 두 테스트 로컬 통과 확인
- [ ] CI 전체 테스트 통과

Refs #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)