### PR TITLE
epic/#1030: mypy ignore_errors 전체 해소 — 타입 안전성 확보

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,18 +60,6 @@ ignore_missing_imports = true
 # disallow_untyped_defs = true
 # warn_return_any = true
 
-[[tool.mypy.overrides]]
-module = [
-    "ante.cli.commands.backtest",
-    "ante.cli.commands.bot",
-    "ante.cli.commands.init",
-    "ante.cli.commands.report",
-
-    "ante.report.store",
-    "ante.strategy.registry",
-]
-ignore_errors = true
-
 [tool.coverage.run]
 source = ["src/ante"]
 omit = ["src/ante/web/static/*"]

--- a/src/ante/cli/commands/backtest.py
+++ b/src/ante/cli/commands/backtest.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+from typing import TYPE_CHECKING, Any
 
 import click
 
 from ante.cli.main import get_formatter
+
+if TYPE_CHECKING:
+    from ante.backtest.result import BacktestResult
 from ante.cli.middleware import require_auth, require_scope
 
 
@@ -56,7 +60,7 @@ def run(
         service = BacktestService(data_path=data_path)
         show_progress = not fmt.is_json
 
-        progress_bar = None
+        progress_bar: Any = None
 
         def _progress_callback(current: int, total: int) -> None:
             nonlocal progress_bar
@@ -107,7 +111,7 @@ def run(
 
 async def _save_backtest_run(
     db_path: str,
-    result: object,
+    result: BacktestResult,
     config: dict,
     metrics: dict,
 ) -> str:

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -338,7 +338,6 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
 
     async def _run_positions() -> list[dict]:
         from ante.core.database import Database
-        from ante.eventbus.bus import EventBus
         from ante.trade.performance import PerformanceTracker
         from ante.trade.position import PositionHistory
         from ante.trade.recorder import TradeRecorder
@@ -347,13 +346,12 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
         db = Database("db/ante.db")
         await db.connect()
         try:
-            eventbus = EventBus()
-            recorder = TradeRecorder(db, eventbus)
-            await recorder.initialize()
-            position_history = PositionHistory(db, eventbus)
+            position_history = PositionHistory(db)
             await position_history.initialize()
+            recorder = TradeRecorder(db, position_history)
+            await recorder.initialize()
             performance = PerformanceTracker(db)
-            await performance.initialize()
+
             service = TradeService(recorder, position_history, performance)
             positions = await service.get_positions(bot_id)
             return [

--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import stat
 from pathlib import Path
+from typing import Any, cast
 
 import click
 
@@ -101,7 +102,7 @@ def _get_available_brokers() -> list[tuple[str, str]]:
     return result
 
 
-def _prompt_account() -> list[dict[str, str]]:
+def _prompt_account() -> list[dict[str, Any]]:
     """계좌 등록 정보를 대화형으로 입력받는다.
 
     Returns:
@@ -113,7 +114,7 @@ def _prompt_account() -> list[dict[str, str]]:
     click.echo("  등록하지 않으면 테스트 계좌가 자동으로 생성됩니다.")
     click.echo("  나중에 `ante account create` 명령어로도 추가할 수 있습니다.")
 
-    accounts: list[dict[str, str]] = []
+    accounts: list[dict[str, Any]] = []
     brokers = _get_available_brokers()
 
     while True:
@@ -238,7 +239,7 @@ async def _bootstrap_master(
 
 async def _create_accounts(
     db_path: str,
-    account_inputs: list[dict[str, str]],
+    account_inputs: list[dict[str, Any]],
 ) -> list[dict[str, str]]:
     """AccountService를 통해 계좌를 생성한다.
 
@@ -274,11 +275,13 @@ async def _create_accounts(
 
         # 실제 계좌 생성
         for info in account_inputs:
-            broker_type = info["broker_type"]
+            broker_type = str(info["broker_type"])
             preset = BROKER_PRESETS[broker_type]
+            credentials = cast(dict[str, str], info["credentials"])
+            broker_config = cast(dict[str, Any], info.get("broker_config", {}))
             account = Account(
-                account_id=info["account_id"],
-                name=info["name"],
+                account_id=str(info["account_id"]),
+                name=str(info["name"]),
                 exchange=preset.exchange,
                 currency=preset.currency,
                 timezone=preset.timezone,
@@ -286,8 +289,8 @@ async def _create_accounts(
                 trading_hours_end=preset.trading_hours_end,
                 trading_mode=TradingMode.LIVE,
                 broker_type=broker_type,
-                credentials=info["credentials"],
-                broker_config=info.get("broker_config", {}),
+                credentials=credentials,
+                broker_config=broker_config,
                 buy_commission_rate=preset.buy_commission_rate,
                 sell_commission_rate=preset.sell_commission_rate,
             )

--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -132,9 +132,15 @@ def report_list(ctx: click.Context, status: str | None, db_path: str) -> None:
     fmt = get_formatter(ctx)
 
     async def _list() -> list[dict]:
-        store = ReportStore(db_path=db_path)
+        from ante.core.database import Database
+        from ante.report.models import ReportStatus
+
+        db = Database(db_path)
+        await db.connect()
+        store = ReportStore(db=db)
         await store.initialize()
-        reports = await store.list_reports(status=status)
+        report_status = ReportStatus(status) if status else None
+        reports = await store.list_reports(status=report_status)
         return [
             {
                 "report_id": r.report_id,
@@ -189,17 +195,18 @@ def report_performance(
         try:
             tracker = PerformanceTracker(db)
             if period == "daily":
-                summaries = await tracker.get_daily_summary(
+                daily_summaries = await tracker.get_daily_summary(
                     bot_id=bot_id,
                     start_date=start,
                     end_date=end,
                 )
+                return [asdict(s) for s in daily_summaries]
             else:
-                summaries = await tracker.get_monthly_summary(
+                monthly_summaries = await tracker.get_monthly_summary(
                     bot_id=bot_id,
                     year=year,
                 )
-            return [asdict(s) for s in summaries]
+                return [asdict(s) for s in monthly_summaries]
         finally:
             await db.close()
 


### PR DESCRIPTION
## Summary
- 잔여 6개 모듈의 mypy `ignore_errors` override를 해소하여 `[[tool.mypy.overrides]]` 섹션 완전 삭제
- CLI commands 4개 파일(report, init, bot, backtest)의 mypy 오류 15건 수정
- 그 중 3건은 **기존 런타임 버그** (잘못된 생성자 호출)를 함께 수정

## 하위 이슈
- #1028 CLI commands 타입 오류 해소 15건 (PR #1031) ✅
- #1022~#1027, #1029 — #1011 에픽에서 이미 완료 ✅

## Test plan
- [ ] `mypy src/` 가 override 없이 통과
- [ ] 전체 pytest 통과
- [ ] ruff check/format 통과

Refs #1030

🤖 Generated with [Claude Code](https://claude.com/claude-code)