### PR TITLE
refactor(strategy): StrategyStatus 3단계 간소화 Refs #1000

### DIFF
--- a/src/ante/cli/commands/strategy.py
+++ b/src/ante/cli/commands/strategy.py
@@ -181,9 +181,7 @@ def submit(ctx: click.Context, path: str) -> None:
 
 
 @strategy.command("list")
-@click.option(
-    "--status", default=None, help="상태 필터 (registered/active/inactive/archived)"
-)
+@click.option("--status", default=None, help="상태 필터 (registered/adopted/archived)")
 @format_option
 @click.pass_context
 @require_auth

--- a/src/ante/db/migrations.py
+++ b/src/ante/db/migrations.py
@@ -12,7 +12,12 @@ from pathlib import Path
 from typing import Any
 
 from ante.core.database import Database
-from ante.db.versions import v001_baseline, v002_parquet_migration, v003_broker_config
+from ante.db.versions import (
+    v001_baseline,
+    v002_parquet_migration,
+    v003_broker_config,
+    v004_strategy_status_simplify,
+)
 
 # 마이그레이션 함수 시그니처:
 #   async def migrate(db: Database) -> None                          (DB 전용)
@@ -23,6 +28,7 @@ MIGRATIONS: list[tuple[int, str, MigrateFn]] = [
     (1, "0.7.0", v001_baseline.migrate),
     (2, "0.7.0", v002_parquet_migration.migrate),
     (3, "0.8.0", v003_broker_config.migrate),
+    (4, "0.8.0", v004_strategy_status_simplify.migrate),
 ]
 
 

--- a/src/ante/db/versions/v004_strategy_status_simplify.py
+++ b/src/ante/db/versions/v004_strategy_status_simplify.py
@@ -1,0 +1,16 @@
+"""v004: StrategyStatus 간소화 (active→adopted, inactive→archived)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+
+
+async def migrate(db: Database) -> None:
+    """기존 active/inactive 상태를 adopted/archived로 변환한다."""
+    await db.execute("UPDATE strategies SET status = 'adopted' WHERE status = 'active'")
+    await db.execute(
+        "UPDATE strategies SET status = 'archived' WHERE status = 'inactive'"
+    )

--- a/src/ante/strategy/registry.py
+++ b/src/ante/strategy/registry.py
@@ -67,9 +67,15 @@ class StrategyStatus(StrEnum):
     """전략 상태."""
 
     REGISTERED = "registered"
-    ACTIVE = "active"
-    INACTIVE = "inactive"
+    ADOPTED = "adopted"
     ARCHIVED = "archived"
+
+
+_ALLOWED_TRANSITIONS: dict[StrategyStatus, set[StrategyStatus]] = {
+    StrategyStatus.REGISTERED: {StrategyStatus.ADOPTED, StrategyStatus.ARCHIVED},
+    StrategyStatus.ADOPTED: {StrategyStatus.ARCHIVED},
+    StrategyStatus.ARCHIVED: set(),
+}
 
 
 @dataclass
@@ -207,7 +213,18 @@ class StrategyRegistry:
         strategy_id: str,
         status: StrategyStatus,
     ) -> None:
-        """전략 상태 변경."""
+        """전략 상태 변경. 허용된 전환만 수행한다."""
+        record = await self.get(strategy_id)
+        if record is None:
+            raise StrategyError(f"Strategy not found: {strategy_id}")
+
+        allowed = _ALLOWED_TRANSITIONS.get(record.status, set())
+        if status not in allowed:
+            raise ValueError(
+                f"전환 불가: {record.status.value} → {status.value} "
+                f"(허용: {', '.join(s.value for s in sorted(allowed))})"
+            )
+
         await self._db.execute(
             "UPDATE strategies SET status = ? WHERE strategy_id = ?",
             (status.value, strategy_id),

--- a/tests/unit/test_cli_format_option.py
+++ b/tests/unit/test_cli_format_option.py
@@ -315,7 +315,7 @@ class TestStrategyInfoFormatOption:
             name="test",
             version="1.0",
             filepath="/strats/test.py",
-            status=StrategyStatus.ACTIVE,
+            status=StrategyStatus.ADOPTED,
             registered_at=datetime(2026, 1, 1, tzinfo=UTC),
             description="테스트 전략",
             author_name="agent",

--- a/tests/unit/test_cli_strategy.py
+++ b/tests/unit/test_cli_strategy.py
@@ -32,7 +32,7 @@ _SAMPLE_RECORD = StrategyRecord(
     name="momentum",
     version="1.0",
     filepath="/strategies/momentum.py",
-    status=StrategyStatus.ACTIVE,
+    status=StrategyStatus.ADOPTED,
     registered_at=_NOW,
     description="모멘텀 전략",
     author_name="agent",
@@ -181,10 +181,10 @@ class TestStrategyList:
             new_callable=AsyncMock,
             return_value=(registry, db),
         ):
-            result = runner.invoke(cli, ["strategy", "list", "--status", "active"])
+            result = runner.invoke(cli, ["strategy", "list", "--status", "adopted"])
             assert result.exit_code == 0
             registry.list_strategies.assert_called_once_with(
-                status=StrategyStatus.ACTIVE,
+                status=StrategyStatus.ADOPTED,
             )
 
 

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -711,10 +711,10 @@ class TestStrategyRegistry:
         filepath.write_text("")
 
         await registry.register(filepath, meta)
-        await registry.update_status("momentum_v1.0.0", StrategyStatus.ACTIVE)
+        await registry.update_status("momentum_v1.0.0", StrategyStatus.ADOPTED)
 
-        active = await registry.list_strategies(status=StrategyStatus.ACTIVE)
-        assert len(active) == 1
+        adopted = await registry.list_strategies(status=StrategyStatus.ADOPTED)
+        assert len(adopted) == 1
 
         registered = await registry.list_strategies(status=StrategyStatus.REGISTERED)
         assert len(registered) == 0
@@ -725,11 +725,29 @@ class TestStrategyRegistry:
         filepath.write_text("")
 
         await registry.register(filepath, meta)
-        await registry.update_status("momentum_v1.0.0", StrategyStatus.ACTIVE)
+        await registry.update_status("momentum_v1.0.0", StrategyStatus.ADOPTED)
 
         record = await registry.get("momentum_v1.0.0")
         assert record is not None
-        assert record.status == StrategyStatus.ACTIVE
+        assert record.status == StrategyStatus.ADOPTED
+
+    async def test_update_status_invalid_transition(self, registry, meta, tmp_path):
+        """허용되지 않은 상태 전환 시 ValueError."""
+        filepath = tmp_path / "test.py"
+        filepath.write_text("")
+
+        await registry.register(filepath, meta)
+        await registry.update_status("momentum_v1.0.0", StrategyStatus.ARCHIVED)
+
+        with pytest.raises(ValueError, match="전환 불가"):
+            await registry.update_status("momentum_v1.0.0", StrategyStatus.ADOPTED)
+
+    async def test_update_status_not_found(self, registry):
+        """존재하지 않는 전략 상태 변경 시 StrategyError."""
+        from ante.strategy.exceptions import StrategyError
+
+        with pytest.raises(StrategyError, match="not found"):
+            await registry.update_status("nonexistent_v1.0.0", StrategyStatus.ADOPTED)
 
     async def test_exists(self, registry, meta, tmp_path):
         """존재 여부 확인."""

--- a/tests/unit/test_strategy_api.py
+++ b/tests/unit/test_strategy_api.py
@@ -21,7 +21,7 @@ class FakeStrategyRecord:
     name: str
     version: str
     filepath: str = ""
-    status: StrategyStatus = StrategyStatus.ACTIVE
+    status: StrategyStatus = StrategyStatus.ADOPTED
     registered_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     description: str = ""
     author_name: str = "agent"
@@ -125,7 +125,7 @@ class TestListStrategies:
                 strategy_id="ma_cross_v1",
                 name="ma_cross",
                 version="1",
-                status=StrategyStatus.ACTIVE,
+                status=StrategyStatus.ADOPTED,
             ),
         ]
         resp = client.get("/api/strategies")
@@ -134,19 +134,19 @@ class TestListStrategies:
         assert len(data["strategies"]) == 1
         assert data["strategies"][0]["id"] == "ma_cross_v1"
         assert data["strategies"][0]["name"] == "ma_cross"
-        assert data["strategies"][0]["status"] == "active"
+        assert data["strategies"][0]["status"] == "adopted"
 
     def test_filter_by_status(self, client, registry):
         """상태 필터."""
         registry._strategies = [
             FakeStrategyRecord(
-                strategy_id="s1", name="s1", version="1", status=StrategyStatus.ACTIVE
+                strategy_id="s1", name="s1", version="1", status=StrategyStatus.ADOPTED
             ),
             FakeStrategyRecord(
-                strategy_id="s2", name="s2", version="1", status=StrategyStatus.INACTIVE
+                strategy_id="s2", name="s2", version="1", status=StrategyStatus.ARCHIVED
             ),
         ]
-        resp = client.get("/api/strategies?status=active")
+        resp = client.get("/api/strategies?status=adopted")
         assert resp.status_code == 200
         assert len(resp.json()["strategies"]) == 1
         assert resp.json()["strategies"][0]["id"] == "s1"


### PR DESCRIPTION
## Summary
- `StrategyStatus` StrEnum에서 `ACTIVE`/`INACTIVE`를 제거하고 `ADOPTED`를 추가하여 REGISTERED/ADOPTED/ARCHIVED 3단계로 간소화
- `update_status()`에 상태 전환 검증 로직 추가 (허용되지 않은 전환 시 `ValueError`)
- DB 마이그레이션 v004 추가 (active->adopted, inactive->archived)
- CLI help 텍스트 및 테스트 전체 업데이트

## Test plan
- [x] `ruff check` / `ruff format --check` 통과
- [x] 관련 테스트 141건 전체 통과 (test_strategy, test_strategy_api, test_cli_strategy, test_cli_format_option)
- [x] 허용되지 않은 상태 전환 시 ValueError 발생 테스트 추가
- [x] 존재하지 않는 전략 상태 변경 시 StrategyError 발생 테스트 추가

Refs #1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)