### PR TITLE
fix(bot): 봇 생성 모달 전략 셀렉트 ADOPTED 필터링

### DIFF
--- a/frontend/src/components/bots/BotCreateForm.tsx
+++ b/frontend/src/components/bots/BotCreateForm.tsx
@@ -13,7 +13,7 @@ const BOT_ID_PATTERN = /^[a-zA-Z0-9-]+$/
 export default function BotCreateForm({ onClose }: BotCreateFormProps) {
   const [botId, setBotId] = useState('')
   const [name, setName] = useState('')
-  const [strategyName, setStrategyName] = useState('')
+  const [strategyId, setStrategyId] = useState('')
   const [interval, setInterval] = useState('60')
   const [budget, setBudget] = useState('')
   const [botIdError, setBotIdError] = useState('')
@@ -21,7 +21,7 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
   const { data: strategies } = useStrategies()
   const { data: treasury } = useTreasurySummary()
 
-  const activeStrategies = strategies?.filter((s) => s.status === 'active' || s.status === 'registered') ?? []
+  const adoptedStrategies = strategies?.filter((s) => s.status === 'adopted') ?? []
   const remainingBudget = treasury?.unallocated ?? 0
 
   const validateBotId = (value: string) => {
@@ -44,7 +44,7 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
       {
         bot_id: botId,
         name,
-        strategy_name: strategyName,
+        strategy_id: strategyId,
         interval_seconds: Number(interval),
         budget: Number(budget.replace(/,/g, '')),
       },
@@ -73,12 +73,15 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
           </div>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">전략 선택</label>
-            <select value={strategyName} onChange={(e) => setStrategyName(e.target.value)} className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary appearance-none cursor-pointer" required>
-              <option value="">전략을 선택하세요</option>
-              {activeStrategies.map((s) => (
-                <option key={s.id} value={s.name}>{s.name} {s.version}</option>
+            <select value={strategyId} onChange={(e) => setStrategyId(e.target.value)} className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary appearance-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed" required disabled={adoptedStrategies.length === 0}>
+              <option value="">{adoptedStrategies.length === 0 ? '채택된 전략이 없습니다' : '전략을 선택하세요'}</option>
+              {adoptedStrategies.map((s) => (
+                <option key={s.id} value={String(s.id)}>{s.name} {s.version} ({s.id})</option>
               ))}
             </select>
+            {adoptedStrategies.length === 0 && (
+              <div className="text-[11px] text-warning mt-1">봇을 생성하려면 먼저 전략을 채택해 주세요</div>
+            )}
           </div>
           <div className="mb-4">
             <label className="block text-[12px] font-semibold text-text-muted mb-1.5">실행 간격 (초)</label>

--- a/frontend/src/components/strategies/StrategyTable.tsx
+++ b/frontend/src/components/strategies/StrategyTable.tsx
@@ -7,6 +7,7 @@ import type { Strategy, StrategyStatus } from '../../types/strategy'
 const STATUS_VARIANT: Record<StrategyStatus, string> = {
   active: 'positive',
   registered: 'warning',
+  adopted: 'primary',
   inactive: 'muted',
   archived: 'muted',
 }

--- a/frontend/src/pages/Strategies.tsx
+++ b/frontend/src/pages/Strategies.tsx
@@ -8,6 +8,7 @@ import type { StrategyStatus } from '../types/strategy'
 const STATUS_FILTERS: { key: StrategyStatus | 'all'; label: string }[] = [
   { key: 'all', label: '전체' },
   { key: 'active', label: '운용중' },
+  { key: 'adopted', label: '채택' },
   { key: 'registered', label: '대기' },
   { key: 'inactive', label: '중지' },
   { key: 'archived', label: '보관' },

--- a/frontend/src/pages/StrategyDetail.tsx
+++ b/frontend/src/pages/StrategyDetail.tsx
@@ -12,7 +12,7 @@ import { STRATEGY_STATUS_LABELS } from '../utils/constants'
 import type { StrategyStatus, StrategyParam } from '../types/strategy'
 
 const STATUS_VARIANT: Record<StrategyStatus, string> = {
-  active: 'positive', registered: 'warning', inactive: 'muted', archived: 'muted',
+  active: 'positive', registered: 'warning', adopted: 'primary', inactive: 'muted', archived: 'muted',
 }
 
 type EquityCurvePeriod = '1w' | '1m' | '3m' | 'all'

--- a/frontend/src/types/strategy.ts
+++ b/frontend/src/types/strategy.ts
@@ -18,7 +18,7 @@ export type MonthlySummary = MonthlySummaryItem
 export type { EquityCurvePoint }
 
 // ── 프론트엔드 전용 타입 ──────────────────────────────────
-export type StrategyStatus = 'registered' | 'active' | 'inactive' | 'archived'
+export type StrategyStatus = 'registered' | 'adopted' | 'active' | 'inactive' | 'archived'
 
 /**
  * 전략 목록 아이템.

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -14,6 +14,7 @@ export const BOT_STATUS_LABELS: Record<string, string> = {
 /** 전략 상태 라벨 */
 export const STRATEGY_STATUS_LABELS: Record<string, string> = {
   registered: '대기',
+  adopted: '채택',
   active: '운용중',
   inactive: '중지',
   archived: '보관',


### PR DESCRIPTION
## Summary
- 봇 생성 모달의 전략 셀렉트에서 `adopted` 상태 전략만 표시하도록 변경
- 셀렉트 옵션에 `name version (strategy_id)` 형식으로 표시 (예: `모멘텀 돌파 전략 v2.0 (momentum_breakout_v2.0)`)
- ADOPTED 전략이 0건일 때 셀렉트 비활성화 + "채택된 전략이 없습니다" 안내 문구 표시
- `StrategyStatus` 타입 및 관련 상수/UI에 `adopted` 상태 추가

Closes #1006

## Test plan
- [ ] 봇 생성 모달에서 ADOPTED 전략만 표시되는지 확인
- [ ] REGISTERED, ARCHIVED 전략이 목록에 나타나지 않는지 확인
- [ ] 셀렉트 옵션에 name+version(id) 형식으로 표시되는지 확인
- [ ] ADOPTED 전략이 0건일 때 셀렉트가 비활성화되고 안내 문구가 나오는지 확인
- [ ] npm run build 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)