### PR TITLE
fix(approval): 결재 승인 시 StrategyRegistry 상태 동기화 Refs #1001

### DIFF
--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -83,7 +83,7 @@ class ApprovalService:
         now = datetime.now(UTC).isoformat()
         params = params or {}
 
-        reviews = self._validate_params(type, params, now)
+        reviews = await self._validate_params(type, params, now)
 
         request = ApprovalRequest(
             id=str(uuid4()),
@@ -292,7 +292,7 @@ class ApprovalService:
 
         # 사전 검증(validator) 재실행
         now = datetime.now(UTC).isoformat()
-        warn_reviews = self._validate_params(request.type, request.params, now)
+        warn_reviews = await self._validate_params(request.type, request.params, now)
         request.reviews.extend(warn_reviews)
 
         # 상태 전환 + 이력 기록
@@ -649,19 +649,29 @@ class ApprovalService:
         row = await self._db.fetch_one(query, tuple(params))
         return row["cnt"] if row else 0
 
-    def _validate_params(
+    async def _validate_params(
         self,
         type: str,
         params: dict,
         now: str,
     ) -> list[dict]:
-        """사전 검증(validator)을 실행하고 warn reviews를 반환한다."""
+        """사전 검증(validator)을 실행하고 warn reviews를 반환한다.
+
+        validator가 async이면 await, 동기이면 그대로 호출한다.
+        """
+        import inspect
+
         reviews: list[dict] = []
         validator = self._validators.get(type)
         if not validator:
             return reviews
 
-        results = validator(params)
+        result_or_coro = validator(params)
+        if inspect.isawaitable(result_or_coro):
+            results = await result_or_coro
+        else:
+            results = result_or_coro
+
         for r in results:
             if r.grade == "fail":
                 logger.info("사전 검증 실패 (%s): %s — %s", type, r.reviewer, r.detail)

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -765,14 +765,24 @@ async def _init_approval(s: Services) -> None:
         engine = s.rule_engine_manager.get(account_id)
         engine.update_rules(params["bot_id"], params["rules"])
 
+    from ante.strategy.registry import StrategyStatus
+
+    async def _exec_strategy_adopt(params: dict) -> None:
+        await s.report_store.update_status(params["report_id"], ReportStatus.ADOPTED)
+        await s.strategy_registry.update_status(
+            params["strategy_id"], StrategyStatus.ADOPTED
+        )
+
+    async def _exec_strategy_retire(params: dict) -> None:
+        await s.report_store.update_status(params["report_id"], ReportStatus.ARCHIVED)
+        await s.strategy_registry.update_status(
+            params["strategy_id"], StrategyStatus.ARCHIVED
+        )
+
     approval_executors: dict = {
         # 전략 관련
-        "strategy_adopt": lambda params: s.report_store.update_status(
-            params["report_id"], ReportStatus.ADOPTED
-        ),
-        "strategy_retire": lambda params: s.report_store.update_status(
-            params["report_id"], ReportStatus.ARCHIVED
-        ),
+        "strategy_adopt": _exec_strategy_adopt,
+        "strategy_retire": _exec_strategy_retire,
         # 봇 생명주기
         "bot_create": lambda params: s.bot_manager.create_bot(**params),
         "bot_assign_strategy": lambda params: s.bot_manager.assign_strategy(
@@ -794,21 +804,17 @@ async def _init_approval(s: Services) -> None:
     # 사전 검증 validator 정의
     from ante.bot.config import BotStatus
 
-    def _validate_strategy_retire(params: dict) -> list[ValidationResult]:
-        """전략 폐기 사전 검증: 사용 중인 봇 존재 여부."""
+    async def _validate_strategy_retire(params: dict) -> list[ValidationResult]:
+        """전략 폐기 사전 검증: 전략 상태 확인."""
         strategy_id = params.get("strategy_id", "")
-        bots = [
-            b for b in s.bot_manager.list_bots() if b.get("strategy_id") == strategy_id
-        ]
-        if bots:
-            return [
-                ValidationResult(
-                    "fail",
-                    f"전략을 사용 중인 봇 {len(bots)}개 존재",
-                    "system:bot_manager",
-                )
-            ]
-        return [ValidationResult("pass", "", "system:bot_manager")]
+        if not strategy_id:
+            return [ValidationResult("fail", "strategy_id가 누락되었습니다", "system")]
+        record = await s.strategy_registry.get(strategy_id)
+        if record is None:
+            return [ValidationResult("fail", "전략을 찾을 수 없습니다", "system")]
+        if record.status == StrategyStatus.ARCHIVED:
+            return [ValidationResult("fail", "이미 보관된 전략입니다", "system")]
+        return [ValidationResult("pass", "", "system")]
 
     def _validate_bot_create(params: dict) -> list[ValidationResult]:
         """봇 생성 사전 검증: 전략 adopted 상태, 동일 봇 미존재."""

--- a/tests/unit/test_approval_executors.py
+++ b/tests/unit/test_approval_executors.py
@@ -34,8 +34,13 @@ def _build_executors() -> tuple[dict, dict]:
     Returns:
         (executors dict, mocks dict) — mocks에서 호출 검증 가능.
     """
+    from ante.strategy.registry import StrategyStatus
+
     report_store = MagicMock()
     report_store.update_status = AsyncMock()
+
+    strategy_registry = MagicMock()
+    strategy_registry.update_status = AsyncMock()
 
     bot_manager = MagicMock()
     bot_manager.create_bot = AsyncMock()
@@ -51,16 +56,24 @@ def _build_executors() -> tuple[dict, dict]:
     rule_engine = MagicMock()
     rule_engine.update_rules = MagicMock()  # sync
 
+    async def _exec_strategy_adopt(params: dict) -> None:
+        await report_store.update_status(params["report_id"], ReportStatus.ADOPTED)
+        await strategy_registry.update_status(
+            params["strategy_id"], StrategyStatus.ADOPTED
+        )
+
+    async def _exec_strategy_retire(params: dict) -> None:
+        await report_store.update_status(params["report_id"], ReportStatus.ARCHIVED)
+        await strategy_registry.update_status(
+            params["strategy_id"], StrategyStatus.ARCHIVED
+        )
+
     async def _exec_rule_change(params: dict) -> None:
         rule_engine.update_rules(params["bot_id"], params["rules"])
 
     executors = {
-        "strategy_adopt": lambda params: report_store.update_status(
-            params["report_id"], ReportStatus.ADOPTED
-        ),
-        "strategy_retire": lambda params: report_store.update_status(
-            params["report_id"], ReportStatus.ARCHIVED
-        ),
+        "strategy_adopt": _exec_strategy_adopt,
+        "strategy_retire": _exec_strategy_retire,
         "bot_create": lambda params: bot_manager.create_bot(**params),
         "bot_assign_strategy": lambda params: bot_manager.assign_strategy(
             params["bot_id"], params["strategy_id"]
@@ -79,6 +92,7 @@ def _build_executors() -> tuple[dict, dict]:
 
     mocks = {
         "report_store": report_store,
+        "strategy_registry": strategy_registry,
         "bot_manager": bot_manager,
         "treasury": treasury,
         "rule_engine": rule_engine,
@@ -99,16 +113,25 @@ class TestStrategyAdoptExecutor:
     """strategy_adopt executor 테스트."""
 
     async def test_approve_calls_update_status_adopted(self, service_with_executors):
+        from ante.strategy.registry import StrategyStatus
+
         svc, mocks = service_with_executors
         req = await svc.create(
             type="strategy_adopt",
             requester="agent",
             title="전략 채택",
-            params={"report_id": "rpt-001", "strategy_name": "momentum"},
+            params={
+                "report_id": "rpt-001",
+                "strategy_id": "strat-001",
+                "strategy_name": "momentum",
+            },
         )
         await svc.approve(req.id)
         mocks["report_store"].update_status.assert_awaited_once_with(
             "rpt-001", ReportStatus.ADOPTED
+        )
+        mocks["strategy_registry"].update_status.assert_awaited_once_with(
+            "strat-001", StrategyStatus.ADOPTED
         )
 
 
@@ -116,16 +139,25 @@ class TestStrategyRetireExecutor:
     """strategy_retire executor 테스트."""
 
     async def test_approve_calls_update_status_retired(self, service_with_executors):
+        from ante.strategy.registry import StrategyStatus
+
         svc, mocks = service_with_executors
         req = await svc.create(
             type="strategy_retire",
             requester="agent",
             title="전략 폐기",
-            params={"report_id": "rpt-002", "strategy_name": "mean_revert"},
+            params={
+                "report_id": "rpt-002",
+                "strategy_id": "strat-002",
+                "strategy_name": "mean_revert",
+            },
         )
         await svc.approve(req.id)
         mocks["report_store"].update_status.assert_awaited_once_with(
             "rpt-002", ReportStatus.ARCHIVED
+        )
+        mocks["strategy_registry"].update_status.assert_awaited_once_with(
+            "strat-002", StrategyStatus.ARCHIVED
         )
 
 

--- a/tests/unit/test_approval_strategy_lifecycle.py
+++ b/tests/unit/test_approval_strategy_lifecycle.py
@@ -1,0 +1,231 @@
+"""결재 승인 시 전략 상태 전환 통합 테스트.
+
+Refs #1001: strategy_adopt/retire executor가 ReportStore + StrategyRegistry
+모두 업데이트하는지, validator가 전략 상태를 올바르게 검증하는지 확인.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.approval.models import ApprovalValidationError, ValidationResult
+from ante.approval.service import ApprovalService
+from ante.core.database import Database
+from ante.eventbus.bus import EventBus
+from ante.report.models import ReportStatus
+from ante.strategy.registry import StrategyStatus
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """테스트용 SQLite DB."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    return db
+
+
+@pytest.fixture
+async def eventbus():
+    return EventBus()
+
+
+def _make_strategy_record(strategy_id: str, status: StrategyStatus):
+    """간이 StrategyRecord stub."""
+
+    @dataclass
+    class _Record:
+        strategy_id: str
+        status: StrategyStatus
+
+    return _Record(strategy_id=strategy_id, status=status)
+
+
+def _build_service_with_validators(db, eventbus, registry_records: dict | None = None):
+    """executor + async validator가 포함된 ApprovalService를 생성한다."""
+    report_store = MagicMock()
+    report_store.update_status = AsyncMock()
+
+    strategy_registry = MagicMock()
+    strategy_registry.update_status = AsyncMock()
+
+    # get()은 async — strategy_id로 record 반환
+    records = registry_records or {}
+
+    async def _get(sid: str):
+        return records.get(sid)
+
+    strategy_registry.get = AsyncMock(side_effect=_get)
+
+    async def _exec_strategy_adopt(params: dict) -> None:
+        await report_store.update_status(params["report_id"], ReportStatus.ADOPTED)
+        await strategy_registry.update_status(
+            params["strategy_id"], StrategyStatus.ADOPTED
+        )
+
+    async def _exec_strategy_retire(params: dict) -> None:
+        await report_store.update_status(params["report_id"], ReportStatus.ARCHIVED)
+        await strategy_registry.update_status(
+            params["strategy_id"], StrategyStatus.ARCHIVED
+        )
+
+    executors = {
+        "strategy_adopt": _exec_strategy_adopt,
+        "strategy_retire": _exec_strategy_retire,
+    }
+
+    async def _validate_strategy_retire(params: dict) -> list[ValidationResult]:
+        strategy_id = params.get("strategy_id", "")
+        if not strategy_id:
+            return [ValidationResult("fail", "strategy_id가 누락되었습니다", "system")]
+        record = await strategy_registry.get(strategy_id)
+        if record is None:
+            return [ValidationResult("fail", "전략을 찾을 수 없습니다", "system")]
+        if record.status == StrategyStatus.ARCHIVED:
+            return [ValidationResult("fail", "이미 보관된 전략입니다", "system")]
+        return [ValidationResult("pass", "", "system")]
+
+    validators = {
+        "strategy_retire": _validate_strategy_retire,
+    }
+
+    svc = ApprovalService(
+        db=db,
+        eventbus=eventbus,
+        executors=executors,
+        validators=validators,
+    )
+
+    mocks = {
+        "report_store": report_store,
+        "strategy_registry": strategy_registry,
+    }
+    return svc, mocks
+
+
+class TestStrategyAdoptLifecycle:
+    """strategy_adopt 승인 시 ReportStore + StrategyRegistry 모두 업데이트."""
+
+    async def test_adopt_updates_both_stores(self, db, eventbus):
+        svc, mocks = _build_service_with_validators(db, eventbus)
+        await svc.initialize()
+
+        req = await svc.create(
+            type="strategy_adopt",
+            requester="agent",
+            title="전략 채택",
+            params={
+                "report_id": "rpt-001",
+                "strategy_id": "strat-001",
+            },
+        )
+        await svc.approve(req.id)
+
+        mocks["report_store"].update_status.assert_awaited_once_with(
+            "rpt-001", ReportStatus.ADOPTED
+        )
+        mocks["strategy_registry"].update_status.assert_awaited_once_with(
+            "strat-001", StrategyStatus.ADOPTED
+        )
+
+
+class TestStrategyRetireLifecycle:
+    """strategy_retire 승인 시 ReportStore + StrategyRegistry 모두 업데이트."""
+
+    async def test_retire_updates_both_stores(self, db, eventbus):
+        records = {
+            "strat-002": _make_strategy_record("strat-002", StrategyStatus.ADOPTED),
+        }
+        svc, mocks = _build_service_with_validators(db, eventbus, records)
+        await svc.initialize()
+
+        req = await svc.create(
+            type="strategy_retire",
+            requester="agent",
+            title="전략 폐기",
+            params={
+                "report_id": "rpt-002",
+                "strategy_id": "strat-002",
+            },
+        )
+        await svc.approve(req.id)
+
+        mocks["report_store"].update_status.assert_awaited_once_with(
+            "rpt-002", ReportStatus.ARCHIVED
+        )
+        mocks["strategy_registry"].update_status.assert_awaited_once_with(
+            "strat-002", StrategyStatus.ARCHIVED
+        )
+
+
+class TestStrategyRetireValidator:
+    """strategy_retire validator가 전략 상태를 올바르게 검증한다."""
+
+    async def test_missing_strategy_id_fails(self, db, eventbus):
+        svc, _ = _build_service_with_validators(db, eventbus)
+        await svc.initialize()
+
+        with pytest.raises(ApprovalValidationError, match="strategy_id가 누락"):
+            await svc.create(
+                type="strategy_retire",
+                requester="agent",
+                title="전략 폐기",
+                params={"report_id": "rpt-003"},
+            )
+
+    async def test_unknown_strategy_fails(self, db, eventbus):
+        svc, _ = _build_service_with_validators(db, eventbus, registry_records={})
+        await svc.initialize()
+
+        with pytest.raises(ApprovalValidationError, match="전략을 찾을 수 없습니다"):
+            await svc.create(
+                type="strategy_retire",
+                requester="agent",
+                title="전략 폐기",
+                params={
+                    "report_id": "rpt-003",
+                    "strategy_id": "strat-nonexist",
+                },
+            )
+
+    async def test_already_archived_fails(self, db, eventbus):
+        records = {
+            "strat-archived": _make_strategy_record(
+                "strat-archived", StrategyStatus.ARCHIVED
+            ),
+        }
+        svc, _ = _build_service_with_validators(db, eventbus, records)
+        await svc.initialize()
+
+        with pytest.raises(ApprovalValidationError, match="이미 보관된 전략"):
+            await svc.create(
+                type="strategy_retire",
+                requester="agent",
+                title="전략 폐기",
+                params={
+                    "report_id": "rpt-004",
+                    "strategy_id": "strat-archived",
+                },
+            )
+
+    async def test_adopted_strategy_passes_validation(self, db, eventbus):
+        records = {
+            "strat-adopted": _make_strategy_record(
+                "strat-adopted", StrategyStatus.ADOPTED
+            ),
+        }
+        svc, _ = _build_service_with_validators(db, eventbus, records)
+        await svc.initialize()
+
+        req = await svc.create(
+            type="strategy_retire",
+            requester="agent",
+            title="전략 폐기",
+            params={
+                "report_id": "rpt-005",
+                "strategy_id": "strat-adopted",
+            },
+        )
+        assert req.status.value == "pending"


### PR DESCRIPTION
## Summary
- strategy_adopt/retire executor를 async 함수로 전환하여 ReportStore와 StrategyRegistry 상태를 모두 업데이트
- strategy_retire validator를 봇 사용 여부 확인에서 전략 상태 확인 방식으로 변경
- ApprovalService._validate_params를 async로 전환하여 async validator 지원
- strategy_id 누락/미존재/이미 보관 상태에 대한 validator 검증 추가

## Test plan
- [x] strategy_adopt 승인 시 ReportStore + StrategyRegistry 모두 ADOPTED로 전환됨
- [x] strategy_retire 승인 시 ReportStore + StrategyRegistry 모두 ARCHIVED로 전환됨
- [x] strategy_retire validator: strategy_id 누락 시 fail
- [x] strategy_retire validator: 전략 미존재 시 fail
- [x] strategy_retire validator: 이미 ARCHIVED 상태 시 fail
- [x] strategy_retire validator: ADOPTED 상태 전략은 통과
- [x] 기존 approval 테스트 160건 통과
- [x] ruff check + format 통과

Closes #1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)