### PR TITLE
feat(strategy): 전략 상태 변경 API 및 목록 필터 검증 Refs #1003

### DIFF
--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -21,6 +21,7 @@ from ante.web.deps import (
 from ante.web.schemas import (
     DailySummaryResponse,
     MonthlySummaryResponse,
+    StatusUpdateRequest,
     StrategyDetailResponse,
     StrategyListResponse,
     StrategyPerformanceResponse,
@@ -32,6 +33,7 @@ from ante.web.schemas import (
 router = APIRouter()
 
 _STRATEGY_NOT_FOUND = "전략을 찾을 수 없습니다"
+_VALID_STATUS_FILTERS = {"registered", "adopted", "archived"}
 _logger = logging.getLogger(__name__)
 
 
@@ -90,6 +92,12 @@ async def list_strategies(
     status: str | None = Query(default=None),
 ) -> dict:
     """전략 목록 조회."""
+    if status is not None and status not in _VALID_STATUS_FILTERS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"허용되지 않은 status 값: {status} "
+            f"(허용: {', '.join(sorted(_VALID_STATUS_FILTERS))})",
+        )
     records = await registry.list_strategies(status=status)
 
     bots_by_strategy: dict[str, dict] = {}
@@ -149,6 +157,40 @@ async def list_strategies(
         )
 
     return {"strategies": strategies}
+
+
+@router.patch(
+    "/{strategy_id}/status",
+    status_code=204,
+    responses={
+        400: {"description": "허용되지 않은 상태 전환"},
+        404: {"description": "Strategy not found"},
+    },
+)
+async def update_strategy_status(
+    strategy_id: str,
+    body: StatusUpdateRequest,
+    registry: Annotated[Any, Depends(get_strategy_registry)],
+) -> None:
+    """전략 상태 변경. 보관 전환용."""
+    from ante.strategy.exceptions import StrategyError
+    from ante.strategy.registry import StrategyStatus
+
+    try:
+        new_status = StrategyStatus(body.status)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=f"유효하지 않은 status 값: {body.status} "
+            f"(허용: {', '.join(s.value for s in StrategyStatus)})",
+        )
+
+    try:
+        await registry.update_status(strategy_id, new_status)
+    except StrategyError:
+        raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 @router.get(

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -214,6 +214,12 @@ class BotDetailResponse(BaseModel):
 # ── 전략 ──────────────────────────────────────────────
 
 
+class StatusUpdateRequest(BaseModel):
+    """전략 상태 변경 요청."""
+
+    status: str  # "adopted" | "archived"
+
+
 class StrategyValidateResponse(BaseModel):
     """전략 검증 응답."""
 

--- a/tests/unit/test_strategy_api.py
+++ b/tests/unit/test_strategy_api.py
@@ -61,6 +61,30 @@ class FakeRegistry:
                 return s
         return None
 
+    async def update_status(self, strategy_id: str, status: StrategyStatus) -> None:
+        from ante.strategy.exceptions import StrategyError
+
+        record = await self.get(strategy_id)
+        if record is None:
+            raise StrategyError(f"Strategy not found: {strategy_id}")
+
+        # 허용된 전환만 수행 (실제 registry와 동일한 로직)
+        _allowed: dict[StrategyStatus, set[StrategyStatus]] = {
+            StrategyStatus.REGISTERED: {
+                StrategyStatus.ADOPTED,
+                StrategyStatus.ARCHIVED,
+            },
+            StrategyStatus.ADOPTED: {StrategyStatus.ARCHIVED},
+            StrategyStatus.ARCHIVED: set(),
+        }
+        allowed = _allowed.get(record.status, set())
+        if status not in allowed:
+            raise ValueError(
+                f"전환 불가: {record.status.value} → {status.value} "
+                f"(허용: {', '.join(s.value for s in sorted(allowed))})"
+            )
+        record.status = status
+
 
 class FakeBotManager:
     def __init__(self) -> None:
@@ -505,3 +529,127 @@ class TestStrategyPerformance:
 
         resp = client.get("/api/strategies/nonexistent/performance")
         assert resp.status_code == 404
+
+
+class TestUpdateStrategyStatus:
+    """PATCH /api/strategies/{id}/status 테스트."""
+
+    def test_update_status_adopted(self, client, registry):
+        """registered -> adopted 전환 성공 시 204."""
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                status=StrategyStatus.REGISTERED,
+            ),
+        ]
+        resp = client.patch("/api/strategies/s1/status", json={"status": "adopted"})
+        assert resp.status_code == 204
+        assert registry._strategies[0].status == StrategyStatus.ADOPTED
+
+    def test_update_status_archived(self, client, registry):
+        """adopted -> archived 전환 성공 시 204."""
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                status=StrategyStatus.ADOPTED,
+            ),
+        ]
+        resp = client.patch("/api/strategies/s1/status", json={"status": "archived"})
+        assert resp.status_code == 204
+        assert registry._strategies[0].status == StrategyStatus.ARCHIVED
+
+    def test_update_status_not_found(self, client):
+        """존재하지 않는 전략 -> 404."""
+        resp = client.patch(
+            "/api/strategies/nonexistent/status", json={"status": "adopted"}
+        )
+        assert resp.status_code == 404
+
+    def test_update_status_invalid_transition(self, client, registry):
+        """archived -> adopted 전환 불가 -> 400."""
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                status=StrategyStatus.ARCHIVED,
+            ),
+        ]
+        resp = client.patch("/api/strategies/s1/status", json={"status": "adopted"})
+        assert resp.status_code == 400
+        assert "전환 불가" in resp.json()["detail"]
+
+    def test_update_status_invalid_value(self, client, registry):
+        """유효하지 않은 status 값 -> 400."""
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                status=StrategyStatus.REGISTERED,
+            ),
+        ]
+        resp = client.patch(
+            "/api/strategies/s1/status", json={"status": "invalid_status"}
+        )
+        assert resp.status_code == 400
+        assert "유효하지 않은 status" in resp.json()["detail"]
+
+
+class TestListStrategiesStatusFilter:
+    """GET /api/strategies?status= 필터 검증 테스트."""
+
+    def test_filter_active_rejected(self, client):
+        """deprecated status=active 전달 시 400."""
+        resp = client.get("/api/strategies?status=active")
+        assert resp.status_code == 400
+        assert "허용되지 않은 status" in resp.json()["detail"]
+
+    def test_filter_inactive_rejected(self, client):
+        """deprecated status=inactive 전달 시 400."""
+        resp = client.get("/api/strategies?status=inactive")
+        assert resp.status_code == 400
+
+    def test_filter_registered_accepted(self, client, registry):
+        """status=registered 허용."""
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                status=StrategyStatus.REGISTERED,
+            ),
+        ]
+        resp = client.get("/api/strategies?status=registered")
+        assert resp.status_code == 200
+        assert len(resp.json()["strategies"]) == 1
+
+    def test_filter_adopted_accepted(self, client, registry):
+        """status=adopted 허용."""
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                status=StrategyStatus.ADOPTED,
+            ),
+        ]
+        resp = client.get("/api/strategies?status=adopted")
+        assert resp.status_code == 200
+
+    def test_filter_archived_accepted(self, client, registry):
+        """status=archived 허용."""
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                status=StrategyStatus.ARCHIVED,
+            ),
+        ]
+        resp = client.get("/api/strategies?status=archived")
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- PATCH `/api/strategies/{id}/status` 엔드포인트 구현 (204 No Content / 400 / 404)
- GET `/api/strategies` status 쿼리 필터에서 `registered`, `adopted`, `archived`만 허용, `active`/`inactive` 전달 시 400
- `StatusUpdateRequest` Pydantic 스키마 추가
- 테스트 10건 추가 (상태 전환 성공/실패 5건 + 필터 검증 5건, 기존 21건 모두 통과)

## Test plan
- [x] PATCH /api/strategies/{id}/status 에서 registered->adopted 전환 시 204
- [x] PATCH /api/strategies/{id}/status 에서 adopted->archived 전환 시 204
- [x] 존재하지 않는 strategy_id 시 404
- [x] 허용되지 않은 전환(archived->adopted) 시 400 + 사유
- [x] 유효하지 않은 status 값 시 400
- [x] ?status=active 전달 시 400
- [x] ?status=inactive 전달 시 400
- [x] ?status=registered/adopted/archived 정상 동작
- [x] 기존 전략 API 테스트 21건 모두 통과

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)