### PR TITLE
fix(tc): TC 스펙/구현체 불일치 4건 수정 + 개선 2건

### DIFF
--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -72,6 +72,9 @@ async def get_summary(
             )
 
     summary = target_treasury.get_summary()
+    # account_balance → total_balance 매핑 (TreasurySummaryResponse 스키마 정합)
+    if "account_balance" in summary and "total_balance" not in summary:
+        summary["total_balance"] = summary["account_balance"]
     summary["account_id"] = getattr(target_treasury, "account_id", None)
     summary["currency"] = getattr(target_treasury, "currency", "KRW")
     summary["commission_rate"] = getattr(

--- a/tests/tc/account/crud.feature
+++ b/tests/tc/account/crud.feature
@@ -35,7 +35,7 @@ Feature: 계좌 CRUD
   Scenario: 계좌 목록 조회 (CLI)
     When 컨테이너에서 실행: ante account list --format json
     Then 종료 코드는 0
-    And stdout JSON 배열 길이는 1 이상이다
+    And stdout JSON의 .accounts 배열 길이는 1 이상이다
 
   Scenario: 계좌 정보 조회 (CLI)
     When 컨테이너에서 실행: ante account info {account_id} --format json

--- a/tests/tc/bot/crud.feature
+++ b/tests/tc/bot/crud.feature
@@ -90,12 +90,16 @@ Feature: 봇 CRUD
     Then 응답 상태는 200
     And 응답 body.bot.interval_seconds 는 120
 
-  # TODO: API 응답에 budget 필드 미포함 — 봇 응답 DTO 확인 필요
   Scenario: 봇 예산 수정 (API)
     When PUT /api/bots/{bot_id} 요청:
       | field  | value   |
       | budget | 2000000 |
     Then 응답 상태는 200
+
+  Scenario: 봇 예산 수정 반영 확인 (API)
+    When GET /api/bots/{bot_id}
+    Then 응답 상태는 200
+    And 응답 body.bot.budget.allocated 는 2000000
 
   # ── 봇 수정 에러 케이스 (#795) ──
 

--- a/tests/tc/scenario/init.feature
+++ b/tests/tc/scenario/init.feature
@@ -83,4 +83,4 @@ Feature: 최초 설치 및 초기화
   Scenario: 12. CLI 계좌 목록 확인
     When 컨테이너에서 실행: ante account list --format json
     Then 종료 코드는 0
-    And stdout JSON 배열 길이는 1 이상이다
+    And stdout JSON의 .accounts 배열 길이는 1 이상이다

--- a/tests/tc/treasury/allocation.feature
+++ b/tests/tc/treasury/allocation.feature
@@ -11,7 +11,7 @@ Feature: Treasury 예산 할당·회수
     When POST /api/treasury/bots/qa-alloc-bot-01/deallocate 요청:
       | field  | value     |
       | amount | 999999999 |
-    Then 응답 상태는 200 또는 응답 상태는 404
+    Then 응답 상태는 200 또는 응답 상태는 404 또는 응답 상태는 400
 
   # ── 사전 준비: 계좌 + 잔고 + 전략 확보 + 봇 생성 ──
 

--- a/tests/tc/treasury/balance.feature
+++ b/tests/tc/treasury/balance.feature
@@ -28,7 +28,7 @@ Feature: Treasury 잔고 관리
   Scenario: Treasury 현황 조회 (API)
     When GET /api/treasury
     Then 응답 상태는 200
-    And 응답 body.account_balance 는 null이 아니다
+    And 응답 body.total_balance 는 null이 아니다
     And 응답 body.unallocated 는 null이 아니다
     And 응답 body.total_allocated 는 null이 아니다
 
@@ -48,4 +48,4 @@ Feature: Treasury 잔고 관리
   Scenario: 설정 후 잔고 반영 확인 (API)
     When GET /api/treasury
     Then 응답 상태는 200
-    And 응답 body.account_balance 는 10000000
+    And 응답 body.total_balance 는 10000000


### PR DESCRIPTION
## Summary

- **불일치 수정 4건**: CLI JSON 배열 구조(account/crud, scenario/init), Treasury 응답 필드명(treasury/balance 2건) 정합
- **라우터 버그 수정**: `GET /api/treasury`에서 `account_balance` → `total_balance` 매핑 누락 수정
- **개선 2건**: 봇 예산 수정 반영 확인 시나리오 추가(bot/crud), 할당 정리 OR 조건 보완(treasury/allocation)

## Changes

| # | 파일 | 변경 |
|---|------|------|
| 1 | `tests/tc/account/crud.feature:38` | `stdout JSON 배열 길이` → `stdout JSON의 .accounts 배열 길이` |
| 2 | `tests/tc/scenario/init.feature:86` | 동일 수정 |
| 3 | `tests/tc/treasury/balance.feature:31` | `body.account_balance` → `body.total_balance` |
| 4 | `tests/tc/treasury/balance.feature:51` | `body.account_balance` → `body.total_balance` |
| 5 | `tests/tc/bot/crud.feature:93-98` | TODO 제거 + GET 반영 확인 시나리오 추가 |
| 6 | `tests/tc/treasury/allocation.feature:14` | OR 조건에 `응답 상태는 400` 추가 |
| Bug | `src/ante/web/routes/treasury.py:74-76` | `account_balance` → `total_balance` 매핑 추가 |

## Test plan

- [x] `ruff check` / `ruff format` 통과
- [x] `tests/unit/test_response_model_validation.py` 70건 통과
- [x] `tests/unit/test_treasury.py` 64건 통과
- [ ] CI 통과

Refs #1052

🤖 Generated with [Claude Code](https://claude.com/claude-code)