### PR TITLE
test: 리스크 룰 조회 TC 추가 (#1043)

### DIFF
--- a/config/system.qa.toml
+++ b/config/system.qa.toml
@@ -45,3 +45,41 @@ enabled = true
 bot_stop = true
 bot_create_paper = true
 budget_change_max = 10000000
+
+# ── 리스크 룰 ──
+
+[[rules.global]]
+type = "daily_loss_limit"
+enabled = true
+priority = 10
+params = { max_loss_pct = 5.0 }
+
+[[rules.global]]
+type = "total_exposure_limit"
+enabled = true
+priority = 20
+params = { max_exposure_percent = 0.8 }
+
+[[rules.global]]
+type = "trading_hours"
+enabled = true
+priority = 30
+params = { allowed_hours = "09:00-15:30" }
+
+[[rules.strategy.qa_default]]
+type = "position_size"
+enabled = true
+priority = 10
+params = { max_position_percent = 0.1 }
+
+[[rules.strategy.qa_default]]
+type = "unrealized_loss_limit"
+enabled = true
+priority = 20
+params = { max_unrealized_loss_percent = 0.1 }
+
+[[rules.strategy.qa_default]]
+type = "trade_frequency"
+enabled = true
+priority = 30
+params = { max_trades_per_hour = 10 }

--- a/src/ante/cli/commands/rule.py
+++ b/src/ante/cli/commands/rule.py
@@ -152,7 +152,7 @@ def rule_info(ctx: click.Context, rule_id: str) -> None:
 
     if not result:
         fmt.error(f"룰을 찾을 수 없습니다: {rule_id}")
-        return
+        raise SystemExit(1)
 
     if fmt.is_json:
         fmt.output(result)

--- a/tests/tc/rule/query.feature
+++ b/tests/tc/rule/query.feature
@@ -1,0 +1,45 @@
+Feature: 리스크 룰 조회
+  리스크 룰 목록 조회, 범위 필터링, 상세 조회를 검증한다.
+  관련 이슈: #1043 (Rule Engine TC 보강)
+
+  Background:
+    Given ante-qa 컨테이너가 실행 중이다
+    And QA Admin 인증 토큰이 확보되어 있다
+
+  # ── 전체 룰 목록 조회 ──
+
+  Scenario: 전체 룰 목록 조회 (CLI)
+    When 컨테이너에서 실행: ante rule list --format json
+    Then 종료 코드는 0
+    And stdout에 "rules" 가 포함되어 있다
+    And stdout에 "daily_loss_limit" 가 포함되어 있다
+
+  # ── 글로벌 룰 필터링 ──
+
+  Scenario: 글로벌 룰 필터링 (CLI)
+    When 컨테이너에서 실행: ante rule list --scope global --format json
+    Then 종료 코드는 0
+    And stdout에 "rules" 가 포함되어 있다
+    And stdout에 "global" 가 포함되어 있다
+
+  # ── 전략별 룰 필터링 ──
+
+  Scenario: 전략별 룰 필터링 (CLI)
+    When 컨테이너에서 실행: ante rule list --scope strategy --format json
+    Then 종료 코드는 0
+    And stdout에 "rules" 가 포함되어 있다
+
+  # ── 룰 상세 조회 ──
+
+  Scenario: 룰 상세 조회 (CLI)
+    When 컨테이너에서 실행: ante rule info daily_loss_limit --format json
+    Then 종료 코드는 0
+    And stdout에 "daily_loss_limit" 가 포함되어 있다
+    And stdout에 "rule_id" 가 포함되어 있다
+
+  # ── 에러 케이스 ──
+
+  Scenario: 존재하지 않는 룰 조회 (CLI)
+    When 컨테이너에서 실행: ante rule info nonexistent_rule_99999 --format json
+    Then 종료 코드는 1
+    And stdout에 "찾을 수 없습니다" 가 포함되어 있다

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -474,7 +474,7 @@ class TestRuleCommands:
 
             with patch("ante.cli.commands.rule._load_rules_from_config"):
                 result = runner.invoke(cli, ["rule", "info", "nonexistent"])
-                assert result.exit_code == 0
+                assert result.exit_code == 1
                 assert "찾을 수 없습니다" in result.output
 
 


### PR DESCRIPTION
## Summary
- `tests/tc/rule/query.feature` 신규 생성: 리스크 룰 CLI 조회 5개 시나리오
  - 전체 룰 목록 조회 (`ante rule list --format json`)
  - 글로벌 룰 필터링 (`--scope global`)
  - 전략별 룰 필터링 (`--scope strategy`)
  - 룰 상세 조회 (`ante rule info daily_loss_limit`)
  - 존재하지 않는 룰 조회 시 종료 코드 1
- `rule info` 미존재 룰 조회 시 `SystemExit(1)` 반환하도록 CLI 수정
- QA 설정(`config/system.qa.toml`)에 리스크 룰 6종 추가 (글로벌 3 + 전략 3)

Closes #1043

## Test plan
- [ ] QA 컨테이너에서 `ante rule list --format json` 실행 시 6개 룰 출력 확인
- [ ] `--scope global` 필터 시 글로벌 룰 3건만 출력
- [ ] `--scope strategy` 필터 시 전략 룰 3건만 출력
- [ ] `ante rule info daily_loss_limit` 상세 조회 정상 동작
- [ ] `ante rule info nonexistent_rule_99999` 시 종료 코드 1 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)