### PR TITLE
test(backtest): 백테스트 실행 및 성과 검증 TC 추가 (#1044)

### DIFF
--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -15,6 +15,7 @@ services:
     volumes:
       - qa-db:/app/db
       - qa-data:/app/data
+      - ante_ante-data:/app/data-prod:ro
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/system/health')"]
       interval: 3s
@@ -24,3 +25,5 @@ services:
 volumes:
   qa-db:
   qa-data:
+  ante_ante-data:
+    external: true

--- a/tests/tc/backtest/execution.feature
+++ b/tests/tc/backtest/execution.feature
@@ -1,0 +1,54 @@
+Feature: 백테스트 실행
+  전략의 과거 데이터 기반 시뮬레이션 실행과 결과 검증.
+  관련 이슈: #1044
+
+  Background:
+    Given ante-qa 컨테이너가 실행 중이다
+    And QA Admin 인증 토큰이 확보되어 있다
+
+  # --- 데이터 확보 확인 ---
+
+  Scenario: 백테스트용 데이터셋 존재 확인
+    When GET /api/data/datasets
+    Then 응답 상태는 200
+    And 응답 body.items 배열 길이는 1 이상이다
+
+  # --- 백테스트 실행 ---
+
+  Scenario: 백테스트 실행 (기본 옵션)
+    When 컨테이너에서 실행: ante backtest run strategies/qa_buy_signal.py --start 2025-04-01 --end 2025-12-31 --format json
+    Then 종료 코드는 0
+    And stdout에 "run_id" 가 포함되어 있다
+    And stdout JSON의 .run_id 를 {run_id}로 저장한다
+
+  Scenario: 백테스트 실행 (초기 잔고 지정)
+    When 컨테이너에서 실행: ante backtest run strategies/qa_buy_signal.py --start 2025-04-01 --end 2025-09-30 --balance 50000000 --format json
+    Then 종료 코드는 0
+
+  Scenario: 백테스트 실행 (심볼 지정)
+    When 컨테이너에서 실행: ante backtest run strategies/qa_buy_signal.py --start 2025-04-01 --end 2025-09-30 --symbols 005930 --format json
+    Then 종료 코드는 0
+
+  # --- 이력 조회 ---
+
+  Scenario: 백테스트 이력 조회
+    When 컨테이너에서 실행: ante backtest history qa_buy_signal --format json
+    Then 종료 코드는 0
+
+  # --- 성과 지표 검증 ---
+
+  Scenario: 성과 지표 필드 존재 확인
+    When 컨테이너에서 실행: ante backtest run strategies/qa_buy_signal.py --start 2025-04-01 --end 2025-12-31 --format json
+    Then 종료 코드는 0
+    And stdout에 "sharpe_ratio" 가 포함되어 있다
+    And stdout에 "max_drawdown" 가 포함되어 있다
+
+  # --- 에러 케이스 ---
+
+  Scenario: 존재하지 않는 전략으로 백테스트
+    When 컨테이너에서 실행: ante backtest run strategies/nonexistent_strategy.py --start 2025-04-01 --end 2025-12-31
+    Then 종료 코드는 2
+
+  Scenario: 시작일이 종료일 이후
+    When 컨테이너에서 실행: ante backtest run strategies/qa_buy_signal.py --start 2026-01-01 --end 2025-01-01
+    Then 종료 코드는 1


### PR DESCRIPTION
## Summary
- `tests/tc/backtest/execution.feature` 신규 생성 (8 시나리오): 데이터셋 확인, 백테스트 기본/잔고/심볼 실행, 이력 조회, 성과 지표 필드 검증, 에러 케이스 2건
- `docker-compose.qa.yml`: 운영 데이터 볼륨(`ante_ante-data`)을 `/app/data-prod`에 읽기 전용 마운트 추가

## Test plan
- [ ] QA 컨테이너 빌드 후 `ante backtest run` CLI 동작 확인
- [ ] 운영 데이터 볼륨 마운트 상태에서 Parquet 데이터 읽기 검증
- [ ] 에러 케이스 (존재하지 않는 전략, 시작일>종료일) 종료 코드 확인

Closes #1044

🤖 Generated with [Claude Code](https://claude.com/claude-code)