### PR TITLE
test(report): 성과 집계 조회 TC 추가 (#1048)

### DIFF
--- a/tests/tc/report/performance.feature
+++ b/tests/tc/report/performance.feature
@@ -1,0 +1,33 @@
+Feature: 성과 집계 조회
+  거래 성과를 일별/월별로 집계 조회한다. (CLI 전용)
+  관련 이슈: #1048
+
+  Background:
+    Given ante-qa 컨테이너가 실행 중이다
+    And QA Admin 인증 토큰이 확보되어 있다
+
+  # ── 일별 성과 ──
+
+  Scenario: 일별 성과 조회
+    When 컨테이너에서 실행: ante report performance --period daily --start 2025-01-01 --end 2025-12-31 --format json
+    Then 종료 코드는 0
+
+  # ── 월별 성과 ──
+
+  Scenario: 월별 성과 조회
+    When 컨테이너에서 실행: ante report performance --period monthly --year 2025 --format json
+    Then 종료 코드는 0
+
+  # ── 에러 케이스 ──
+
+  Scenario: daily인데 start/end 누락 → 종료 코드 1
+    When 컨테이너에서 실행: ante report performance --period daily --format json
+    Then 종료 코드는 1
+
+  Scenario: monthly인데 year 누락 → 종료 코드 1
+    When 컨테이너에서 실행: ante report performance --period monthly --format json
+    Then 종료 코드는 1
+
+  Scenario: 잘못된 period 값 → 종료 코드 2
+    When 컨테이너에서 실행: ante report performance --period invalid --format json
+    Then 종료 코드는 2


### PR DESCRIPTION
## Summary
- `tests/tc/report/performance.feature` 신규 추가 (5개 시나리오)
- 일별/월별 성과 집계 CLI 전용 TC (에픽 #1051 Phase 3-2)
- 정상 케이스 2건: daily(start/end), monthly(year)
- 에러 케이스 3건: 필수 인자 누락(종료 코드 1), 잘못된 period 값(종료 코드 2)

## Test plan
- [ ] QA 환경에서 `ante report performance` CLI 명령어 동작 검증
- [ ] 종료 코드 1/2 구분 확인

Closes #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)