### PR TITLE
test(trade,config): trade/query, config/dynamic TC 시나리오 확장 (#1049)

### DIFF
--- a/tests/tc/config/dynamic.feature
+++ b/tests/tc/config/dynamic.feature
@@ -39,6 +39,12 @@ Feature: 동적 설정 관리
     Then 종료 코드는 0
     And stdout에 "history" 가 포함되어 있다
 
+  # --- 개별 설정 조회 (CLI) ---
+
+  Scenario: 개별 설정 키 조회 (CLI)
+    When 컨테이너에서 실행: ante config get approval.auto_approve.enabled --format json
+    Then 종료 코드는 0
+
   # --- 에러 케이스 ---
 
   Scenario: 존재하지 않는 설정 키 변경 (API)
@@ -46,3 +52,8 @@ Feature: 동적 설정 관리
       | field | value |
       | value | 1     |
     Then 응답 상태는 404
+
+  Scenario: 존재하지 않는 키 조회 (CLI)
+    When 컨테이너에서 실행: ante config get nonexistent_key_99999 --format json
+    Then 종료 코드는 0
+    And stdout에 "not_found" 가 포함되어 있다

--- a/tests/tc/trade/query.feature
+++ b/tests/tc/trade/query.feature
@@ -29,6 +29,27 @@ Feature: 거래 내역 조회
     Then 종료 코드는 0
     And stdout에 "trades" 가 포함되어 있다
 
+  # --- 종목별 거래 필터링 ---
+
+  Scenario: 종목별 거래 필터링 (API)
+    When GET /api/trades?symbol=000001
+    Then 응답 상태는 200
+    And 응답 body.trades 는 null이 아니다
+
+  # --- 계좌별 거래 필터링 ---
+
+  Scenario: 계좌별 거래 필터링 (API)
+    When GET /api/trades?account_id=qa-trade-exec-01
+    Then 응답 상태는 200
+    And 응답 body.trades 는 null이 아니다
+
+  # --- 거래 목록 limit 제한 ---
+
+  Scenario: 거래 목록 limit 제한 (API)
+    When GET /api/trades?limit=1
+    Then 응답 상태는 200
+    And 응답 body.trades 배열 길이는 1 이하이다
+
   # --- 거래 상세 조회 (CLI) ---
 
   Scenario: 존재하지 않는 거래 조회 (CLI)


### PR DESCRIPTION
## Summary
- `trade/query.feature`: 5 → 8 시나리오 확장 (종목별 거래 필터링, 계좌별 거래 필터링, limit 제한)
- `config/dynamic.feature`: 6 → 8 시나리오 확장 (개별 설정 키 조회 CLI, 존재하지 않는 키 조회 CLI)
- TC 확장 계획 Phase 4 완료

## Notes
- Trade API의 cursor 기반 페이지네이션에 맞춰 `account_id`, `symbol`, `limit` 파라미터만 사용
- Config API에 GET 단일 키 엔드포인트가 없으므로, 개별 키 조회와 존재하지 않는 키 조회는 CLI(`ante config get`)로 검증
- TC 계획의 `ante config list`는 실제 CLI에 없는 명령이므로 기존 `ante config get` (인자 없음)으로 대체 (이미 기존 TC에 포함)

## Test plan
- [ ] QA Docker 환경에서 trade/query.feature 8 시나리오 PASS 확인
- [ ] QA Docker 환경에서 config/dynamic.feature 8 시나리오 PASS 확인

Closes #1049

🤖 Generated with [Claude Code](https://claude.com/claude-code)