### PR TITLE
fix(cli): backtest 시작일 > 종료일 입력 검증 추가

### DIFF
--- a/src/ante/cli/commands/backtest.py
+++ b/src/ante/cli/commands/backtest.py
@@ -43,9 +43,27 @@ def run(
     db_path: str,
 ) -> None:
     """백테스트 실행."""
+    import datetime
+
     from ante.backtest.service import BacktestService
 
     fmt = get_formatter(ctx)
+
+    # 시작일/종료일 검증
+    try:
+        start_date = datetime.date.fromisoformat(start)
+        end_date = datetime.date.fromisoformat(end)
+    except ValueError as e:
+        fmt.error(f"날짜 형식이 올바르지 않습니다: {e}", code="INVALID_DATE")
+        raise SystemExit(1) from e
+
+    if start_date > end_date:
+        fmt.error(
+            f"시작일({start})이 종료일({end}) 이후입니다.",
+            code="INVALID_DATE_RANGE",
+        )
+        raise SystemExit(1)
+
     config = {
         "strategy_path": strategy_path,
         "start_date": start,

--- a/tests/unit/test_cli_backtest_date_validation.py
+++ b/tests/unit/test_cli_backtest_date_validation.py
@@ -1,0 +1,127 @@
+"""CLI backtest run 날짜 검증 테스트."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+def _make_runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+class TestBacktestDateValidation:
+    """backtest run 시작일/종료일 검증."""
+
+    def test_start_after_end_returns_exit_code_1(self, tmp_path):
+        """시작일이 종료일 이후이면 exit code 1."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "backtest",
+                "run",
+                str(strategy),
+                "--start",
+                "2026-01-01",
+                "--end",
+                "2025-01-01",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "시작일" in result.output
+
+    def test_start_after_end_error_message(self, tmp_path):
+        """에러 메시지에 날짜 정보가 포함된다."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "backtest",
+                "run",
+                str(strategy),
+                "--start",
+                "2026-06-01",
+                "--end",
+                "2025-06-01",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "2026-06-01" in result.output
+        assert "2025-06-01" in result.output
+
+    def test_same_date_is_allowed(self, tmp_path):
+        """시작일 == 종료일은 허용 (날짜 검증 통과, INVALID_DATE_RANGE 에러 없음)."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "backtest",
+                "run",
+                str(strategy),
+                "--start",
+                "2025-06-01",
+                "--end",
+                "2025-06-01",
+            ],
+        )
+        # 날짜 검증 에러가 아닌 것만 확인 (이후 단계에서 다른 에러 발생 가능)
+        assert "시작일" not in result.output
+
+    def test_invalid_date_format(self, tmp_path):
+        """잘못된 날짜 형식이면 exit code 1."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "backtest",
+                "run",
+                str(strategy),
+                "--start",
+                "not-a-date",
+                "--end",
+                "2025-01-01",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "날짜 형식" in result.output


### PR DESCRIPTION
## Summary
- `ante backtest run` 명령에서 시작일이 종료일보다 이후인 경우 에러 메시지와 함께 exit code 1로 종료하도록 검증 추가
- 잘못된 날짜 형식(YYYY-MM-DD 외)에 대한 검증도 함께 추가
- 4개의 단위 테스트 추가 (시작일>종료일, 에러 메시지 확인, 동일 날짜 허용, 잘못된 형식)

Closes #1066

## Test plan
- [x] `test_start_after_end_returns_exit_code_1` — 시작일 > 종료일 시 exit code 1
- [x] `test_start_after_end_error_message` — 에러 메시지에 날짜 정보 포함
- [x] `test_same_date_is_allowed` — 시작일 == 종료일은 허용
- [x] `test_invalid_date_format` — 잘못된 날짜 형식 시 exit code 1
- [x] 기존 단위 테스트 3087건 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)