### PR TITLE
fix: POST /api/reports 500 에러 수정

### DIFF
--- a/src/ante/web/routes/reports.py
+++ b/src/ante/web/routes/reports.py
@@ -11,6 +11,7 @@ from ante.web.schemas import (
     ReportDetailResponse,
     ReportListResponse,
     ReportSchemaResponse,
+    ReportSubmitRequest,
     ReportSubmitResponse,
 )
 
@@ -33,13 +34,38 @@ async def get_report_schema() -> dict:
     responses={503: {"description": "Report store not available"}},
 )
 async def submit_report(
-    body: dict,
+    body: ReportSubmitRequest,
     request: Request,
     report_store: Annotated[Any, Depends(get_report_store)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
     """리포트 제출."""
-    report = await report_store.submit(body)
+    import uuid
+    from datetime import UTC, datetime
+
+    from ante.report.models import ReportStatus, StrategyReport
+
+    report = StrategyReport(
+        report_id=f"rpt-{uuid.uuid4().hex[:12]}",
+        strategy_name=body.strategy_name,
+        strategy_version=body.strategy_version,
+        strategy_path=body.strategy_path,
+        status=ReportStatus.SUBMITTED,
+        submitted_at=datetime.now(UTC),
+        submitted_by=getattr(request.state, "member_id", "agent"),
+        backtest_period=body.backtest_period,
+        total_return_pct=body.total_return_pct,
+        total_trades=body.total_trades,
+        sharpe_ratio=body.sharpe_ratio,
+        max_drawdown_pct=body.max_drawdown_pct,
+        win_rate=body.win_rate,
+        summary=body.summary,
+        rationale=body.rationale,
+        risks=body.risks,
+        recommendations=body.recommendations,
+        detail_json=body.detail_json,
+    )
+    await report_store.submit(report)
 
     if audit_logger:
         await audit_logger.log(

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -493,9 +493,19 @@ class ReportSubmitRequest(BaseModel):
 
     strategy_name: str
     strategy_version: str
-    backtest_result: dict
+    strategy_path: str
+    backtest_period: str = ""
+    total_return_pct: float = 0.0
+    total_trades: int = 0
+    sharpe_ratio: float | None = None
+    max_drawdown_pct: float | None = None
+    win_rate: float | None = None
     summary: str = ""
-    recommendation: str = ""
+    rationale: str = ""
+    risks: str = ""
+    recommendations: str = ""
+    detail_json: str = "{}"
+    sections: dict[str, Any] | None = None
 
 
 class ReportSubmitResponse(BaseModel):

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -291,10 +291,26 @@ class TestReportRoutes:
         assert data["status"] == 503
 
     def test_submit_no_store(self, client):
-        resp = client.post("/api/reports", json={"test": True})
+        resp = client.post(
+            "/api/reports",
+            json={
+                "strategy_name": "test",
+                "strategy_version": "1.0.0",
+                "strategy_path": "strategies/test.py",
+            },
+        )
         assert resp.status_code == 503
         data = resp.json()
         assert data["type"] == "/errors/internal"
+
+    def test_submit_missing_fields(self):
+        from unittest.mock import AsyncMock
+
+        store = AsyncMock()
+        app = create_app(report_store=store)
+        c = TestClient(app)
+        resp = c.post("/api/reports", json={"strategy_name": "incomplete"})
+        assert resp.status_code == 422
 
 
 # ── RFC 7807 에러 응답 테스트 ────────────────────────


### PR DESCRIPTION
## Summary
- `POST /api/reports` 핸들러가 raw dict를 `ReportStore.submit()`에 직접 전달하여 `StrategyReport` 객체 기대 시 `AttributeError`로 500 발생
- `ReportSubmitRequest` Pydantic 모델로 요청 바디 검증 추가하여 필수 필드 누락 시 422 반환
- 검증 통과 시 `StrategyReport` 객체를 생성하여 `submit()` 호출, 201 반환

## Test plan
- [x] 기존 단위 테스트 전체 통과 (3084 passed)
- [x] `test_submit_no_store`: report_store 없이 유효한 요청 → 503
- [x] `test_submit_missing_fields`: 필수 필드 누락 → 422

Closes #1065

🤖 Generated with [Claude Code](https://claude.com/claude-code)