### PR TITLE
fix(tc): Background에 잔존 데이터 정리 Step 추가 (#1072)

### DIFF
--- a/tests/tc/account/rules.feature
+++ b/tests/tc/account/rules.feature
@@ -5,6 +5,8 @@ Feature: 계좌 리스크 룰 관리
   Background:
     Given ante-qa 컨테이너가 실행 중이다
     And QA Admin 인증 토큰이 확보되어 있다
+    # setup — 이전 실행 잔존 데이터 정리 (실패 무시)
+    And DELETE /api/accounts/qa-rules-acct-01 요청 (실패 무시)
 
   # ── 사전 준비: 테스트용 계좌 생성 ──
 

--- a/tests/tc/bot/crud.feature
+++ b/tests/tc/bot/crud.feature
@@ -5,6 +5,9 @@ Feature: 봇 CRUD
   Background:
     Given ante-qa 컨테이너가 실행 중이다
     And QA Admin 인증 토큰이 확보되어 있다
+    # setup — 이전 실행 잔존 데이터 정리 (실패 무시)
+    And DELETE /api/bots/qa-bot-crud-bot-01 요청 (실패 무시)
+    And DELETE /api/accounts/qa-bot-crud-01 요청 (실패 무시)
 
   # ── 사전 준비: 계좌 + 전략 + 잔고 확보 ──
 

--- a/tests/tc/bot/lifecycle.feature
+++ b/tests/tc/bot/lifecycle.feature
@@ -5,6 +5,11 @@ Feature: 봇 생명주기
   Background:
     Given ante-qa 컨테이너가 실행 중이다
     And QA Admin 인증 토큰이 확보되어 있다
+    # setup — 이전 실행 잔존 데이터 정리 (실패 무시)
+    And DELETE /api/bots/qa-bot-life-bot-01 요청 (실패 무시)
+    And DELETE /api/bots/qa-bot-life-bot-02 요청 (실패 무시)
+    And DELETE /api/bots/qa-bot-life-bot-03 요청 (실패 무시)
+    And DELETE /api/accounts/qa-bot-life-01 요청 (실패 무시)
 
   # ── 사전 준비: 계좌 + 잔고 + 전략 + 크레덴셜 + 봇 생성 ──
 

--- a/tests/tc/member/management.feature
+++ b/tests/tc/member/management.feature
@@ -4,6 +4,9 @@ Feature: 멤버 관리
   Background:
     Given ante-qa 컨테이너가 실행 중이다
     And QA Admin 인증 토큰이 확보되어 있다
+    # setup — 이전 실행 잔존 데이터 정리 (실패 무시)
+    And DELETE /api/members/qa-test-agent-01 요청 (실패 무시)
+    And DELETE /api/members/qa-test-human-01 요청 (실패 무시)
 
   # ── 멤버 등록 ──
 

--- a/tests/tc/scenario/full-cycle.feature
+++ b/tests/tc/scenario/full-cycle.feature
@@ -4,6 +4,9 @@ Feature: 전략 라이프사이클 전체 흐름 (E2E)
   Background:
     Given ante-qa 컨테이너가 실행 중이다
     And QA Admin 인증 토큰이 확보되어 있다
+    # setup — 이전 실행 잔존 데이터 정리 (실패 무시)
+    And DELETE /api/bots/qa-e2e-bot 요청 (실패 무시)
+    And DELETE /api/accounts/qa-e2e-cycle 요청 (실패 무시)
 
   # 1. 계좌 생성
   Scenario: E2E 테스트 계좌 생성

--- a/tests/tc/trade/execution.feature
+++ b/tests/tc/trade/execution.feature
@@ -4,6 +4,9 @@ Feature: 거래 실행 및 포지션 반영
   Background:
     Given ante-qa 컨테이너가 실행 중이다
     And QA Admin 인증 토큰이 확보되어 있다
+    # setup — 이전 실행 잔존 데이터 정리 (실패 무시)
+    And DELETE /api/bots/qa-trade-bot-01 요청 (실패 무시)
+    And DELETE /api/accounts/qa-trade-exec-01 요청 (실패 무시)
 
   # --- 사전 준비 ---
 

--- a/tests/tc/treasury/allocation.feature
+++ b/tests/tc/treasury/allocation.feature
@@ -4,6 +4,9 @@ Feature: Treasury 예산 할당·회수
   Background:
     Given ante-qa 컨테이너가 실행 중이다
     And QA Admin 인증 토큰이 확보되어 있다
+    # setup — 이전 실행 잔존 데이터 정리 (실패 무시)
+    And DELETE /api/bots/qa-alloc-bot-01 요청 (실패 무시)
+    And DELETE /api/accounts/qa-treasury-alloc-01 요청 (실패 무시)
 
   # ── 환경 정리: 이전 실행 잔여 할당 회수 ──
 

--- a/tests/tc/treasury/balance.feature
+++ b/tests/tc/treasury/balance.feature
@@ -4,6 +4,8 @@ Feature: Treasury 잔고 관리
   Background:
     Given ante-qa 컨테이너가 실행 중이다
     And QA Admin 인증 토큰이 확보되어 있다
+    # setup — 이전 실행 잔존 데이터 정리 (실패 무시)
+    And DELETE /api/accounts/qa-treasury-bal-01 요청 (실패 무시)
 
   # ── 사전 준비: 테스트용 계좌 생성 ──
 


### PR DESCRIPTION
## Summary
- 8개 Feature 파일의 Background에 이전 실행 잔존 데이터를 정리하는 `(실패 무시)` DELETE Step 추가
- 삭제 순서는 의존성 역순(봇 -> 계좌 -> 멤버)을 준수
- QA Step 해석기(gherkin-guide.md)에 `(실패 무시)` 접미사 해석 규칙 추가 (gitignore 대상, 로컬 반영)

### 변경 파일
| Feature | 정리 대상 리소스 |
|---------|-----------------|
| member/management | `qa-test-agent-01`, `qa-test-human-01` (멤버) |
| account/rules | `qa-rules-acct-01` (계좌) |
| bot/crud | `qa-bot-crud-bot-01` (봇), `qa-bot-crud-01` (계좌) |
| bot/lifecycle | `qa-bot-life-bot-01/02/03` (봇), `qa-bot-life-01` (계좌) |
| trade/execution | `qa-trade-bot-01` (봇), `qa-trade-exec-01` (계좌) |
| treasury/allocation | `qa-alloc-bot-01` (봇), `qa-treasury-alloc-01` (계좌) |
| treasury/balance | `qa-treasury-bal-01` (계좌) |
| scenario/full-cycle | `qa-e2e-bot` (봇), `qa-e2e-cycle` (계좌) |

Refs #1072

## Test plan
- [ ] 각 Feature를 2회 연속 실행하여 두 번째 실행에서도 PASS 확인
- [ ] `(실패 무시)` Step이 404 응답에서도 PASS 처리되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)