### PR TITLE
fix(tc): 전략 조회 TC에 전략 이름을 명시적으로 지정 (#1073)

### DIFF
--- a/tests/tc/account/credentials.feature
+++ b/tests/tc/account/credentials.feature
@@ -54,7 +54,7 @@ Feature: 계좌 인증정보 관리
     And stdout JSON의 .credentials.app_key 는 null이 아니다
 
   Scenario: 인증정보 설정 후 봇 생성 및 시작 가능
-    When GET /api/strategies
+    When GET /api/strategies?name=qa_sample
     Then 응답 상태는 200
     And 첫 번째 항목의 id 를 {strategy_id}로 저장한다
     When POST /api/bots 요청:

--- a/tests/tc/account/lifecycle.feature
+++ b/tests/tc/account/lifecycle.feature
@@ -74,7 +74,7 @@ Feature: 계좌 생명주기
     And 응답 body.account.account_id 를 {suspended_account_id}로 저장한다
     When POST /api/accounts/{suspended_account_id}/suspend
     Then 응답 상태는 200
-    When GET /api/strategies
+    When GET /api/strategies?name=qa_sample
     Then 응답 상태는 200
     And 첫 번째 항목의 id 를 {strategy_id}로 저장한다
     When POST /api/bots 요청:

--- a/tests/tc/bot/crud.feature
+++ b/tests/tc/bot/crud.feature
@@ -33,8 +33,8 @@ Feature: 봇 CRUD
       | balance | 10000000 |
     Then 응답 상태는 200
 
-  Scenario: QA 전략 확보
-    When GET /api/strategies
+  Scenario: QA 샘플 전략 확보
+    When GET /api/strategies?name=qa_sample
     Then 응답 상태는 200
     And 첫 번째 항목의 id 를 {strategy_id}로 저장한다
     And 첫 번째 항목의 name 을 {strategy_name}으로 저장한다

--- a/tests/tc/bot/lifecycle.feature
+++ b/tests/tc/bot/lifecycle.feature
@@ -35,8 +35,8 @@ Feature: 봇 생명주기
       | balance | 10000000 |
     Then 응답 상태는 200
 
-  Scenario: QA 전략 확보
-    When GET /api/strategies
+  Scenario: QA 샘플 전략 확보
+    When GET /api/strategies?name=qa_sample
     Then 응답 상태는 200
     And 첫 번째 항목의 id 를 {strategy_id}로 저장한다
 

--- a/tests/tc/scenario/full-cycle.feature
+++ b/tests/tc/scenario/full-cycle.feature
@@ -32,8 +32,8 @@ Feature: 전략 라이프사이클 전체 흐름 (E2E)
     Then 응답 상태는 200
 
   # 3. 전략 확보
-  Scenario: 전략 ID 확보
-    When GET /api/strategies
+  Scenario: QA 매수 전략 확보
+    When GET /api/strategies?name=qa_buy_signal
     Then 응답 상태는 200
     And 첫 번째 항목의 id 를 {strategy_id}로 저장한다
 

--- a/tests/tc/trade/execution.feature
+++ b/tests/tc/trade/execution.feature
@@ -31,8 +31,8 @@ Feature: 거래 실행 및 포지션 반영
       | balance | 10000000 |
     Then 응답 상태는 200
 
-  Scenario: QA 전략 확보
-    When GET /api/strategies
+  Scenario: QA 매수 전략 확보
+    When GET /api/strategies?name=qa_buy_signal
     Then 응답 상태는 200
     And 첫 번째 항목의 id 를 {strategy_id}로 저장한다
 

--- a/tests/tc/treasury/allocation.feature
+++ b/tests/tc/treasury/allocation.feature
@@ -41,8 +41,8 @@ Feature: Treasury 예산 할당·회수
     Then 응답 상태는 200
     And 응답 body.total_balance 는 10000000
 
-  Scenario: QA 전략 확보
-    When GET /api/strategies
+  Scenario: QA 샘플 전략 확보
+    When GET /api/strategies?name=qa_sample
     Then 응답 상태는 200
     And 첫 번째 항목의 id 를 {strategy_id}로 저장한다
 


### PR DESCRIPTION
## Summary
- 거래 실행이 필요한 TC(`trade/execution.feature`, `scenario/full-cycle.feature`)는 `?name=qa_buy_signal`로 전략을 명시 지정
- 봇 CRUD/생명주기/자금할당/계좌 TC는 `?name=qa_sample`로 명시 지정
- Scenario 이름도 용도에 맞게 "QA 매수 전략 확보" / "QA 샘플 전략 확보"로 변경

## Test plan
- [ ] `trade/execution.feature` TC 실행 시 qa_buy_signal 전략이 선택되어 거래가 발생하는지 확인
- [ ] `bot/crud.feature` 등 비거래 TC에서 qa_sample 전략으로 정상 동작 확인
- [ ] QA 전체 TC suite 통과 확인

Refs #1073

🤖 Generated with [Claude Code](https://claude.com/claude-code)