### PR TITLE
fix(cli): approval 서브커맨드에 @format_option 데코레이터 추가

### DIFF
--- a/src/ante/cli/commands/approval.py
+++ b/src/ante/cli/commands/approval.py
@@ -7,6 +7,7 @@ import json
 
 import click
 
+from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
 
@@ -23,6 +24,7 @@ def approval() -> None:
 @click.option("--params", "params_json", default="{}", help="실행 파라미터 (JSON)")
 @click.option("--reference-id", default="", help="참조 ID (report_id 등)")
 @click.option("--expires-in", default="", help="만료 기한 (예: 72h, 7d)")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("approval:write")
@@ -78,6 +80,7 @@ def request(
 @click.option("--status", default=None, help="상태 필터")
 @click.option("--type", "approval_type", default=None, help="유형 필터")
 @click.option("--db-path", default="db/ante.db", help="DB 경로")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("approval:read")
@@ -126,6 +129,7 @@ def approval_list(
 @approval.command()
 @click.argument("id")
 @click.option("--db-path", default="db/ante.db", help="DB 경로")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("approval:read")
@@ -183,6 +187,7 @@ def info(ctx: click.Context, id: str, db_path: str) -> None:
 )
 @click.option("--detail", default="", help="검토 상세")
 @click.option("--db-path", default="db/ante.db", help="DB 경로")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("approval:read")
@@ -239,6 +244,7 @@ def review(
     default=None,
     help="수정할 파라미터 (JSON, 미지정 시 기존 값 유지)",
 )
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("approval:write")
@@ -282,6 +288,7 @@ def reopen(
 
 @approval.command("cancel")
 @click.argument("id")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("approval:write")
@@ -307,6 +314,7 @@ def cancel(ctx: click.Context, id: str) -> None:
 
 @approval.command("approve")
 @click.argument("id")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("approval:admin")
@@ -333,6 +341,7 @@ def approve(ctx: click.Context, id: str) -> None:
 @approval.command("reject")
 @click.argument("id")
 @click.option("--reason", default="", help="거절 사유")
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("approval:admin")

--- a/tests/unit/test_cli_approval_format_option.py
+++ b/tests/unit/test_cli_approval_format_option.py
@@ -1,0 +1,60 @@
+"""CLI approval 서브커맨드 --format 옵션 등록 테스트.
+
+이슈 #1078: approval 서브커맨드에 @format_option 누락으로
+`--format json` 사용 시 'No such option: --format' 발생하던 문제 검증.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from ante.cli.commands.approval import (
+    approval_list,
+    approve,
+    cancel,
+    info,
+    reject,
+    reopen,
+    request,
+    review,
+)
+
+_SUBCOMMANDS = [
+    ("request", request),
+    ("list", approval_list),
+    ("info", info),
+    ("review", review),
+    ("reopen", reopen),
+    ("cancel", cancel),
+    ("approve", approve),
+    ("reject", reject),
+]
+
+
+class TestApprovalFormatOptionRegistered:
+    """모든 approval 서브커맨드에 --format 옵션이 등록되어 있는지 검증."""
+
+    @pytest.mark.parametrize(
+        "name,cmd",
+        _SUBCOMMANDS,
+        ids=[s[0] for s in _SUBCOMMANDS],
+    )
+    def test_format_option_exists(self, name: str, cmd: click.Command) -> None:
+        """approval {name} 커맨드에 --format 옵션이 존재해야 한다."""
+        param_names = [p.name for p in cmd.params]
+        assert "output_format" in param_names, (
+            f"approval {name} 커맨드에 --format 옵션이 없습니다"
+        )
+
+    @pytest.mark.parametrize(
+        "name,cmd",
+        _SUBCOMMANDS,
+        ids=[s[0] for s in _SUBCOMMANDS],
+    )
+    def test_format_option_choices(self, name: str, cmd: click.Command) -> None:
+        """--format 옵션은 text/json 중 선택 가능해야 한다."""
+        fmt_param = next(p for p in cmd.params if p.name == "output_format")
+        assert isinstance(fmt_param.type, click.Choice)
+        assert "json" in fmt_param.type.choices
+        assert "text" in fmt_param.type.choices


### PR DESCRIPTION
## Summary
- `approval` 모듈의 8개 서브커맨드(request, list, info, review, reopen, cancel, approve, reject)에 `@format_option` 데코레이터 추가
- `--format json` 옵션 사용 시 `No such option: --format` 에러가 발생하던 문제 수정
- 모든 서브커맨드에 `--format` 옵션 등록 여부를 검증하는 단위 테스트 16건 추가

## Test plan
- [x] `ruff check` 통과
- [x] `ruff format --check` 통과
- [x] `pytest tests/unit/test_cli_approval_format_option.py` 16건 전체 통과

Refs #1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)