### PR TITLE
fix(tc): Background 계좌 DELETE 제거 및 전략 필터 Step 변경 (#1079)

### DIFF
--- a/tests/tc/account/credentials.feature
+++ b/tests/tc/account/credentials.feature
@@ -54,9 +54,9 @@ Feature: 계좌 인증정보 관리
     And stdout JSON의 .credentials.app_key 는 null이 아니다
 
   Scenario: 인증정보 설정 후 봇 생성 및 시작 가능
-    When GET /api/strategies?name=qa_sample
+    When GET /api/strategies
     Then 응답 상태는 200
-    And 첫 번째 항목의 id 를 {strategy_id}로 저장한다
+    And name이 "qa_sample"인 항목의 id 를 {strategy_id}로 저장한다
     When POST /api/bots 요청:
       | field       | value              |
       | bot_id      | qa-cred-bot-01     |

--- a/tests/tc/account/lifecycle.feature
+++ b/tests/tc/account/lifecycle.feature
@@ -74,9 +74,9 @@ Feature: 계좌 생명주기
     And 응답 body.account.account_id 를 {suspended_account_id}로 저장한다
     When POST /api/accounts/{suspended_account_id}/suspend
     Then 응답 상태는 200
-    When GET /api/strategies?name=qa_sample
+    When GET /api/strategies
     Then 응답 상태는 200
-    And 첫 번째 항목의 id 를 {strategy_id}로 저장한다
+    And name이 "qa_sample"인 항목의 id 를 {strategy_id}로 저장한다
     When POST /api/bots 요청:
       | field      | value                  |
       | bot_id     | qa-lifecycle-bot-01    |

--- a/tests/tc/account/rules.feature
+++ b/tests/tc/account/rules.feature
@@ -5,8 +5,6 @@ Feature: 계좌 리스크 룰 관리
   Background:
     Given ante-qa 컨테이너가 실행 중이다
     And QA Admin 인증 토큰이 확보되어 있다
-    # setup — 이전 실행 잔존 데이터 정리 (실패 무시)
-    And DELETE /api/accounts/qa-rules-acct-01 요청 (실패 무시)
 
   # ── 사전 준비: 테스트용 계좌 생성 ──
 

--- a/tests/tc/bot/crud.feature
+++ b/tests/tc/bot/crud.feature
@@ -7,7 +7,6 @@ Feature: 봇 CRUD
     And QA Admin 인증 토큰이 확보되어 있다
     # setup — 이전 실행 잔존 데이터 정리 (실패 무시)
     And DELETE /api/bots/qa-bot-crud-bot-01 요청 (실패 무시)
-    And DELETE /api/accounts/qa-bot-crud-01 요청 (실패 무시)
 
   # ── 사전 준비: 계좌 + 전략 + 잔고 확보 ──
 
@@ -34,10 +33,10 @@ Feature: 봇 CRUD
     Then 응답 상태는 200
 
   Scenario: QA 샘플 전략 확보
-    When GET /api/strategies?name=qa_sample
+    When GET /api/strategies
     Then 응답 상태는 200
-    And 첫 번째 항목의 id 를 {strategy_id}로 저장한다
-    And 첫 번째 항목의 name 을 {strategy_name}으로 저장한다
+    And name이 "qa_sample"인 항목의 id 를 {strategy_id}로 저장한다
+    And name이 "qa_sample"인 항목의 name 을 {strategy_name}으로 저장한다
 
   # ── 봇 생성 ──
 

--- a/tests/tc/bot/lifecycle.feature
+++ b/tests/tc/bot/lifecycle.feature
@@ -9,7 +9,6 @@ Feature: 봇 생명주기
     And DELETE /api/bots/qa-bot-life-bot-01 요청 (실패 무시)
     And DELETE /api/bots/qa-bot-life-bot-02 요청 (실패 무시)
     And DELETE /api/bots/qa-bot-life-bot-03 요청 (실패 무시)
-    And DELETE /api/accounts/qa-bot-life-01 요청 (실패 무시)
 
   # ── 사전 준비: 계좌 + 잔고 + 전략 + 크레덴셜 + 봇 생성 ──
 
@@ -36,9 +35,9 @@ Feature: 봇 생명주기
     Then 응답 상태는 200
 
   Scenario: QA 샘플 전략 확보
-    When GET /api/strategies?name=qa_sample
+    When GET /api/strategies
     Then 응답 상태는 200
-    And 첫 번째 항목의 id 를 {strategy_id}로 저장한다
+    And name이 "qa_sample"인 항목의 id 를 {strategy_id}로 저장한다
 
   Scenario: 생명주기 테스트 봇 생성 (API)
     When POST /api/bots 요청:

--- a/tests/tc/scenario/full-cycle.feature
+++ b/tests/tc/scenario/full-cycle.feature
@@ -6,7 +6,6 @@ Feature: 전략 라이프사이클 전체 흐름 (E2E)
     And QA Admin 인증 토큰이 확보되어 있다
     # setup — 이전 실행 잔존 데이터 정리 (실패 무시)
     And DELETE /api/bots/qa-e2e-bot 요청 (실패 무시)
-    And DELETE /api/accounts/qa-e2e-cycle 요청 (실패 무시)
 
   # 1. 계좌 생성
   Scenario: E2E 테스트 계좌 생성
@@ -33,9 +32,9 @@ Feature: 전략 라이프사이클 전체 흐름 (E2E)
 
   # 3. 전략 확보
   Scenario: QA 매수 전략 확보
-    When GET /api/strategies?name=qa_buy_signal
+    When GET /api/strategies
     Then 응답 상태는 200
-    And 첫 번째 항목의 id 를 {strategy_id}로 저장한다
+    And name이 "qa_buy_signal"인 항목의 id 를 {strategy_id}로 저장한다
 
   # 4. 봇 생성 및 실행
   Scenario: 봇 생성

--- a/tests/tc/trade/execution.feature
+++ b/tests/tc/trade/execution.feature
@@ -6,7 +6,6 @@ Feature: 거래 실행 및 포지션 반영
     And QA Admin 인증 토큰이 확보되어 있다
     # setup — 이전 실행 잔존 데이터 정리 (실패 무시)
     And DELETE /api/bots/qa-trade-bot-01 요청 (실패 무시)
-    And DELETE /api/accounts/qa-trade-exec-01 요청 (실패 무시)
 
   # --- 사전 준비 ---
 
@@ -32,9 +31,9 @@ Feature: 거래 실행 및 포지션 반영
     Then 응답 상태는 200
 
   Scenario: QA 매수 전략 확보
-    When GET /api/strategies?name=qa_buy_signal
+    When GET /api/strategies
     Then 응답 상태는 200
-    And 첫 번째 항목의 id 를 {strategy_id}로 저장한다
+    And name이 "qa_buy_signal"인 항목의 id 를 {strategy_id}로 저장한다
 
   Scenario: 매수 시그널 봇 생성
     When POST /api/bots 요청:

--- a/tests/tc/treasury/allocation.feature
+++ b/tests/tc/treasury/allocation.feature
@@ -6,7 +6,6 @@ Feature: Treasury 예산 할당·회수
     And QA Admin 인증 토큰이 확보되어 있다
     # setup — 이전 실행 잔존 데이터 정리 (실패 무시)
     And DELETE /api/bots/qa-alloc-bot-01 요청 (실패 무시)
-    And DELETE /api/accounts/qa-treasury-alloc-01 요청 (실패 무시)
 
   # ── 환경 정리: 이전 실행 잔여 할당 회수 ──
 
@@ -42,9 +41,9 @@ Feature: Treasury 예산 할당·회수
     And 응답 body.total_balance 는 10000000
 
   Scenario: QA 샘플 전략 확보
-    When GET /api/strategies?name=qa_sample
+    When GET /api/strategies
     Then 응답 상태는 200
-    And 첫 번째 항목의 id 를 {strategy_id}로 저장한다
+    And name이 "qa_sample"인 항목의 id 를 {strategy_id}로 저장한다
 
   Scenario: 할당 테스트용 봇 생성 (API)
     When POST /api/bots 요청:

--- a/tests/tc/treasury/balance.feature
+++ b/tests/tc/treasury/balance.feature
@@ -4,8 +4,6 @@ Feature: Treasury 잔고 관리
   Background:
     Given ante-qa 컨테이너가 실행 중이다
     And QA Admin 인증 토큰이 확보되어 있다
-    # setup — 이전 실행 잔존 데이터 정리 (실패 무시)
-    And DELETE /api/accounts/qa-treasury-bal-01 요청 (실패 무시)
 
   # ── 사전 준비: 테스트용 계좌 생성 ──
 


### PR DESCRIPTION
## Summary
- Background에서 계좌 `DELETE` Step을 제거하여 soft-delete 후 재생성 시 409 충돌로 인한 반복 실행 실패 해소
- `?name=` 쿼리 파라미터(미동작) 대신 `name이 "xxx"인 항목의 id 를 {변수}로 저장한다` 조건부 변수 저장 패턴으로 전략 선택 방식 변경
- `.claude/skills/qa-tester/gherkin-guide.md` 3절에 조건부 변수 저장 규칙 추가 (gitignore 대상, 커밋 제외)

## Test plan
- [ ] `tests/tc/trade/execution.feature` 반복 실행 시 201/409 정상 처리 확인
- [ ] `tests/tc/scenario/full-cycle.feature` 반복 실행 안정성 확인
- [ ] 전략 조회 시 name 필터가 올바르게 동작하는지 확인

Refs #1079

🤖 Generated with [Claude Code](https://claude.com/claude-code)