### PR TITLE
fix(api): GET /api/members 에러 핸들링 및 로깅 추가

### DIFF
--- a/src/ante/web/routes/members.py
+++ b/src/ante/web/routes/members.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import asdict
 from typing import Annotated, Any
 
@@ -18,6 +19,8 @@ from ante.web.schemas import (
     MemberTokenResponse,
     OkResponse,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -65,10 +68,23 @@ async def list_members(
     offset: int = Query(default=0, ge=0),
 ) -> dict:
     """멤버 목록 조회."""
-    members = await svc.list_members(
-        member_type=type, org=org, status=status, limit=limit, offset=offset
-    )
-    total = await svc.count(member_type=type, org=org, status=status)
+    try:
+        members = await svc.list_members(
+            member_type=type, org=org, status=status, limit=limit, offset=offset
+        )
+        total = await svc.count(member_type=type, org=org, status=status)
+    except Exception:
+        logger.exception(
+            "멤버 목록 조회 실패 (type=%s, org=%s, status=%s, limit=%d, offset=%d)",
+            type,
+            org,
+            status,
+            limit,
+            offset,
+        )
+        raise HTTPException(
+            status_code=503, detail="멤버 목록을 조회할 수 없습니다"
+        ) from None
     return {"members": [asdict(m) for m in members], "total": total}
 
 
@@ -130,7 +146,13 @@ async def get_member(
     svc: Annotated[Any, Depends(get_member_service)],
 ) -> dict:
     """멤버 상세 조회."""
-    member = await svc.get(member_id)
+    try:
+        member = await svc.get(member_id)
+    except Exception:
+        logger.exception("멤버 상세 조회 실패 (member_id=%s)", member_id)
+        raise HTTPException(
+            status_code=503, detail="멤버 정보를 조회할 수 없습니다"
+        ) from None
     if member is None:
         raise HTTPException(status_code=404, detail="멤버를 찾을 수 없습니다")
     return {"member": asdict(member)}

--- a/tests/unit/test_member_api.py
+++ b/tests/unit/test_member_api.py
@@ -467,3 +467,81 @@ class TestPermissionDeniedErrorHandling:
             json={"scopes": ["trade:read"]},
         )
         assert resp.status_code == 403
+
+
+class TestErrorHandlingLogging:
+    """서비스 예외 발생 시 503 응답과 로깅을 검증."""
+
+    def test_list_members_service_error_returns_503(self, client, member_service):
+        """list_members에서 예외 발생 시 503 반환."""
+
+        async def raise_error(**kwargs):
+            raise RuntimeError("DB connection lost")
+
+        member_service.list_members = raise_error
+        resp = client.get("/api/members")
+        assert resp.status_code == 503
+        assert "조회할 수 없습니다" in resp.json()["detail"]
+
+    def test_list_members_count_error_returns_503(self, client, member_service):
+        """count에서 예외 발생 시 503 반환."""
+
+        async def raise_error(**kwargs):
+            raise RuntimeError("DB connection lost")
+
+        member_service.count = raise_error
+        resp = client.get("/api/members")
+        assert resp.status_code == 503
+
+    def test_list_members_service_error_logs_params(
+        self, client, member_service, caplog
+    ):
+        """예외 발생 시 쿼리 파라미터가 로그에 포함."""
+        import logging
+
+        async def raise_error(**kwargs):
+            raise RuntimeError("DB connection lost")
+
+        member_service.list_members = raise_error
+        with caplog.at_level(logging.ERROR, logger="ante.web.routes.members"):
+            client.get("/api/members?type=agent&org=default&status=active")
+        assert "type=agent" in caplog.text
+        assert "org=default" in caplog.text
+        assert "status=active" in caplog.text
+
+    def test_get_member_service_error_returns_503(self, client, member_service):
+        """get_member에서 예외 발생 시 503 반환."""
+
+        async def raise_error(member_id):
+            raise RuntimeError("DB connection lost")
+
+        member_service.get = raise_error
+        resp = client.get("/api/members/agent-01")
+        assert resp.status_code == 503
+        assert "조회할 수 없습니다" in resp.json()["detail"]
+
+    def test_get_member_service_error_logs_member_id(
+        self, client, member_service, caplog
+    ):
+        """get_member 예외 시 member_id가 로그에 포함."""
+        import logging
+
+        async def raise_error(member_id):
+            raise RuntimeError("DB connection lost")
+
+        member_service.get = raise_error
+        with caplog.at_level(logging.ERROR, logger="ante.web.routes.members"):
+            client.get("/api/members/agent-01")
+        assert "agent-01" in caplog.text
+
+    def test_list_members_normal_response_unchanged(self, client, member_service):
+        """정상 케이스의 응답은 기존과 동일."""
+        member_service._members["agent-01"] = FakeMember(
+            member_id="agent-01", type="agent", name="테스트"
+        )
+        resp = client.get("/api/members")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["members"]) == 1
+        assert data["total"] == 1
+        assert data["members"][0]["member_id"] == "agent-01"


### PR DESCRIPTION
## Summary
- `list_members`, `get_member` 핸들러에 try-except 추가: 서비스 예외 발생 시 500 대신 503 응답 반환
- `logger.exception()`으로 쿼리 파라미터 포함 traceback 기록하여 간헐적 장애 원인 추적 가능하도록 개선
- 6건의 단위 테스트 추가 (503 응답, 로그 파라미터 포함, 정상 응답 불변 검증)

## Test plan
- [x] `pytest tests/unit/test_member_api.py` — 29건 전체 통과
- [x] `ruff check` / `ruff format --check` 통과

Refs #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)