### PR TITLE
fix(tc): bot/crud.feature 미구현 엔드포인트 참조 수정 (#1085)

### DIFF
--- a/tests/tc/bot/crud.feature
+++ b/tests/tc/bot/crud.feature
@@ -93,7 +93,7 @@ Feature: 봇 CRUD
     And 응답 body.bot.interval_seconds 는 120
 
   Scenario: 봇 예산 수정 전 잔고 확보 (API)
-    When PUT /api/treasury/{account_id}/balance 요청:
+    When POST /api/treasury/balance 요청:
       | field   | value    |
       | balance | 10000000 |
     Then 응답 상태는 200


### PR DESCRIPTION
## Summary
- `bot/crud.feature`의 "봇 예산 수정 전 잔고 확보" Scenario에서 미구현 엔드포인트 `PUT /api/treasury/{account_id}/balance` 대신 기존 전역 잔고 설정 API `POST /api/treasury/balance`를 사용하도록 수정

## Test plan
- [ ] `tests/tc/bot/crud.feature` TC 실행 시 404 에러 없이 정상 통과 확인

Refs #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>