### PR TITLE
fix(paper): PaperExecutor가 OrderApprovedEvent를 구독하도록 변경

### DIFF
--- a/src/ante/bot/providers/paper.py
+++ b/src/ante/bot/providers/paper.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import logging
-import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -121,8 +120,8 @@ class PaperOrderView(OrderView):
 class PaperExecutor:
     """Paper 봇의 주문을 가상 체결하는 실행기.
 
-    EventBus에서 OrderRequestEvent를 구독하여 paper 봇의 주문만 처리한다.
-    즉시 가상 체결 후 OrderFilledEvent를 발행한다.
+    EventBus에서 OrderApprovedEvent를 구독하여 paper 봇의 주문만 처리한다.
+    RuleEngine → Treasury 파이프라인을 거친 승인된 주문만 체결한다.
     """
 
     def __init__(
@@ -154,28 +153,30 @@ class PaperExecutor:
         logger.info("PaperExecutor: 봇 해제 %s", bot_id)
 
     def subscribe(self) -> None:
-        """EventBus에 OrderRequestEvent 구독."""
-        from ante.eventbus.events import OrderRequestEvent
+        """EventBus에 OrderApprovedEvent 구독."""
+        from ante.eventbus.events import OrderApprovedEvent
 
-        self._eventbus.subscribe(OrderRequestEvent, self._on_order_request, priority=50)
+        self._eventbus.subscribe(
+            OrderApprovedEvent, self._on_order_approved, priority=50
+        )
         logger.info("PaperExecutor 구독 완료")
 
-    async def _on_order_request(self, event: object) -> None:
-        """OrderRequestEvent 처리. paper 봇의 주문만 처리."""
+    async def _on_order_approved(self, event: object) -> None:
+        """OrderApprovedEvent 처리. paper 봇의 주문만 처리."""
         from ante.eventbus.events import (
+            OrderApprovedEvent,
             OrderFilledEvent,
-            OrderRejectedEvent,
-            OrderRequestEvent,
         )
 
-        if not isinstance(event, OrderRequestEvent):
+        if not isinstance(event, OrderApprovedEvent):
             return
 
         portfolio = self._portfolios.get(event.bot_id)
         if portfolio is None:
             return  # live 봇의 주문 → 무시 (APIGateway가 처리)
 
-        order_id = str(uuid.uuid4())
+        order_id = event.order_id
+        account_id = event.account_id
         symbol = event.symbol
         side = event.side
         quantity = event.quantity
@@ -207,31 +208,6 @@ class PaperExecutor:
         trade_amount = fill_price * quantity
         commission = self._commission_info.calculate(side, trade_amount)
 
-        # 잔고 확인 (매수 시)
-        if side == "buy":
-            total_cost = trade_amount + commission
-            if not portfolio.check_balance(total_cost):
-                await self._eventbus.publish(
-                    OrderRejectedEvent(
-                        order_id=order_id,
-                        bot_id=event.bot_id,
-                        strategy_id=event.strategy_id,
-                        symbol=symbol,
-                        side=side,
-                        quantity=quantity,
-                        order_type=order_type,
-                        reason="잔고 부족 (paper)",
-                    )
-                )
-                logger.info(
-                    "Paper 주문 거부 (잔고 부족): %s %s %s qty=%s",
-                    event.bot_id,
-                    side,
-                    symbol,
-                    quantity,
-                )
-                return
-
         # 가상 체결: 포지션/잔고 업데이트
         portfolio.apply_fill(symbol, side, quantity, fill_price, commission)
 
@@ -242,6 +218,7 @@ class PaperExecutor:
                 broker_order_id=f"paper-{order_id[:8]}",
                 bot_id=event.bot_id,
                 strategy_id=event.strategy_id,
+                account_id=account_id,
                 symbol=symbol,
                 side=side,
                 quantity=quantity,

--- a/tests/unit/test_bot_providers.py
+++ b/tests/unit/test_bot_providers.py
@@ -11,9 +11,8 @@ from ante.bot.providers.paper import PaperExecutor, PaperOrderView, PaperPortfol
 from ante.core import Database
 from ante.eventbus import EventBus
 from ante.eventbus.events import (
+    OrderApprovedEvent,
     OrderFilledEvent,
-    OrderRejectedEvent,
-    OrderRequestEvent,
 )
 from ante.strategy.base import DataProvider
 from ante.strategy.context import StrategyContext
@@ -227,7 +226,9 @@ class TestPaperExecutor:
         eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
 
         await eventbus.publish(
-            OrderRequestEvent(
+            OrderApprovedEvent(
+                order_id="ord-001",
+                account_id="acct1",
                 bot_id="paper1",
                 strategy_id="s1",
                 symbol="005930",
@@ -244,6 +245,8 @@ class TestPaperExecutor:
         assert filled[0].quantity == 10.0
         assert filled[0].price == 50000.0
         assert filled[0].commission == 50000.0 * 10.0 * 0.00015
+        assert filled[0].order_id == "ord-001"
+        assert filled[0].account_id == "acct1"
 
         # 포지션 반영 확인
         positions = portfolio.get_positions("paper1")
@@ -258,7 +261,9 @@ class TestPaperExecutor:
 
         # 먼저 매수
         await eventbus.publish(
-            OrderRequestEvent(
+            OrderApprovedEvent(
+                order_id="ord-001",
+                account_id="acct1",
                 bot_id="paper1",
                 strategy_id="s1",
                 symbol="005930",
@@ -274,7 +279,9 @@ class TestPaperExecutor:
 
         # 매도
         await eventbus.publish(
-            OrderRequestEvent(
+            OrderApprovedEvent(
+                order_id="ord-002",
+                account_id="acct1",
                 bot_id="paper1",
                 strategy_id="s1",
                 symbol="005930",
@@ -290,31 +297,6 @@ class TestPaperExecutor:
         assert sell_fill.side == "sell"
         assert sell_fill.price == 55000.0
 
-    async def test_paper_buy_insufficient_balance(self, eventbus):
-        """잔고 부족 시 OrderRejectedEvent 발행."""
-        executor = PaperExecutor(eventbus=eventbus)
-        portfolio = PaperPortfolioView(bot_id="paper1", initial_balance=100.0)
-        executor.register_bot("paper1", portfolio)
-        executor.subscribe()
-
-        rejected = []
-        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
-
-        await eventbus.publish(
-            OrderRequestEvent(
-                bot_id="paper1",
-                strategy_id="s1",
-                symbol="005930",
-                side="buy",
-                quantity=10.0,
-                order_type="limit",
-                price=50000.0,
-            )
-        )
-
-        assert len(rejected) == 1
-        assert "잔고 부족" in rejected[0].reason
-
     async def test_ignores_live_bot(self, eventbus):
         """live 봇의 주문은 무시."""
         executor = PaperExecutor(eventbus=eventbus)
@@ -324,7 +306,9 @@ class TestPaperExecutor:
         eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
 
         await eventbus.publish(
-            OrderRequestEvent(
+            OrderApprovedEvent(
+                order_id="ord-001",
+                account_id="acct1",
                 bot_id="live_bot",
                 strategy_id="s1",
                 symbol="005930",
@@ -351,7 +335,9 @@ class TestPaperExecutor:
         eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
 
         await eventbus.publish(
-            OrderRequestEvent(
+            OrderApprovedEvent(
+                order_id="ord-001",
+                account_id="acct1",
                 bot_id="paper1",
                 strategy_id="s1",
                 symbol="005930",
@@ -375,7 +361,9 @@ class TestPaperExecutor:
         eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
 
         await eventbus.publish(
-            OrderRequestEvent(
+            OrderApprovedEvent(
+                order_id="ord-001",
+                account_id="acct1",
                 bot_id="paper1",
                 strategy_id="s1",
                 symbol="005930",
@@ -402,7 +390,9 @@ class TestPaperExecutor:
         eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
 
         await eventbus.publish(
-            OrderRequestEvent(
+            OrderApprovedEvent(
+                order_id="ord-001",
+                account_id="acct1",
                 bot_id="paper1",
                 strategy_id="s1",
                 symbol="005930",
@@ -430,7 +420,9 @@ class TestPaperExecutor:
         eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
 
         await eventbus.publish(
-            OrderRequestEvent(
+            OrderApprovedEvent(
+                order_id="ord-001",
+                account_id="acct1",
                 bot_id="paper1",
                 strategy_id="s1",
                 symbol="005930",
@@ -456,7 +448,9 @@ class TestPaperExecutor:
         eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
 
         await eventbus.publish(
-            OrderRequestEvent(
+            OrderApprovedEvent(
+                order_id="ord-001",
+                account_id="acct1",
                 bot_id="paper1",
                 strategy_id="s1",
                 symbol="005930",


### PR DESCRIPTION
## Summary
- PaperExecutor가 `OrderRequestEvent`를 직접 구독하여 RuleEngine → Treasury 파이프라인을 우회하던 버그 수정
- `OrderApprovedEvent` 구독으로 변경하여 예산 검증(Treasury)을 거친 주문만 체결
- PaperExecutor 자체 잔고 검증 로직 제거 (Treasury가 담당)

## Test plan
- [x] `tests/unit/test_bot_providers.py` 35건 전체 PASS
- [ ] QA sweep에서 관련 TC 검증

Closes #1092

🤖 Generated with [Claude Code](https://claude.com/claude-code)