### PR TITLE
fix(ipc): bot.create 핸들러 시그니처 불일치 수정

### DIFF
--- a/src/ante/core/registry.py
+++ b/src/ante/core/registry.py
@@ -6,7 +6,7 @@ IPC 핸들러가 필요한 서비스에 접근할 때 사용한다.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from ante.bot.manager import BotManager
     from ante.config.dynamic import DynamicConfigService
     from ante.eventbus import EventBus
+    from ante.strategy.registry import StrategyRegistry
     from ante.trade.reconciler import PositionReconciler
     from ante.treasury.manager import TreasuryManager
 
@@ -30,3 +31,4 @@ class ServiceRegistry:
     approval: ApprovalService | Any
     reconciler: PositionReconciler | Any
     eventbus: EventBus | Any
+    strategy_registry: StrategyRegistry | Any = field(default=None)

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -83,7 +83,32 @@ async def _handle_account_delete(
 async def _handle_bot_create(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
-    bot = await svc.bot_manager.create_bot(**args)
+    from pathlib import Path
+
+    from ante.bot.config import BotConfig
+    from ante.strategy.loader import StrategyLoader
+
+    strategy_id = args["strategy_id"]
+    record = await svc.strategy_registry.get(strategy_id)
+    if record is None:
+        msg = f"전략을 찾을 수 없습니다: {strategy_id}"
+        raise ValueError(msg)
+
+    strategy_cls = StrategyLoader.load(Path(record.filepath))
+
+    config = BotConfig(
+        bot_id=args.get("bot_id", ""),
+        strategy_id=strategy_id,
+        name=args.get("name", ""),
+        account_id=args.get("account_id", ""),
+        interval_seconds=args.get("interval_seconds", 60),
+    )
+
+    bot = await svc.bot_manager.create_bot(
+        config=config,
+        strategy_cls=strategy_cls,
+        source_path=Path(record.filepath),
+    )
     return {"bot_id": bot.bot_id}
 
 

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1151,6 +1151,7 @@ async def _init_ipc(s: Services) -> None:
         approval=s.approval_service,
         reconciler=reconciler,
         eventbus=s.eventbus,
+        strategy_registry=s.strategy_registry,
     )
 
     command_registry = CommandRegistry()

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -64,3 +64,81 @@ def test_register_all_handlers() -> None:
         "broker.reconcile",
     }
     assert set(registry.commands) == expected
+
+
+# ── _handle_bot_create 변환 로직 테스트 ──────────────
+
+
+class TestHandleBotCreate:
+    async def test_creates_bot_with_config_and_strategy(self):
+        """strategy_id → StrategyLoader → BotConfig → create_bot 변환."""
+        from dataclasses import dataclass
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ante.ipc.registry import _handle_bot_create
+
+        @dataclass
+        class FakeRecord:
+            filepath: str = "/tmp/strategy.py"
+
+        fake_registry = AsyncMock()
+        fake_registry.get.return_value = FakeRecord()
+
+        fake_bot = MagicMock()
+        fake_bot.bot_id = "new-bot"
+
+        fake_bot_manager = AsyncMock()
+        fake_bot_manager.create_bot.return_value = fake_bot
+
+        svc = MagicMock()
+        svc.strategy_registry = fake_registry
+        svc.bot_manager = fake_bot_manager
+
+        # StrategyLoader.load를 모킹
+        import ante.strategy.loader
+
+        original_load = ante.strategy.loader.StrategyLoader.load
+        ante.strategy.loader.StrategyLoader.load = MagicMock(
+            return_value=type("FakeStrategy", (), {})
+        )
+        try:
+            result = await _handle_bot_create(
+                svc,
+                {
+                    "strategy_id": "strat-1",
+                    "name": "테스트봇",
+                    "account_id": "acct-1",
+                    "interval_seconds": 30,
+                },
+                "cli-user",
+            )
+        finally:
+            ante.strategy.loader.StrategyLoader.load = original_load
+
+        assert result == {"bot_id": "new-bot"}
+        fake_registry.get.assert_awaited_once_with("strat-1")
+        fake_bot_manager.create_bot.assert_awaited_once()
+        call_kwargs = fake_bot_manager.create_bot.call_args.kwargs
+        assert call_kwargs["config"].strategy_id == "strat-1"
+        assert call_kwargs["config"].name == "테스트봇"
+        assert call_kwargs["config"].account_id == "acct-1"
+        assert call_kwargs["config"].interval_seconds == 30
+
+    async def test_raises_when_strategy_not_found(self):
+        """미등록 strategy_id → ValueError."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ante.ipc.registry import _handle_bot_create
+
+        fake_registry = AsyncMock()
+        fake_registry.get.return_value = None
+
+        svc = MagicMock()
+        svc.strategy_registry = fake_registry
+
+        with pytest.raises(ValueError, match="전략을 찾을 수 없습니다"):
+            await _handle_bot_create(
+                svc,
+                {"strategy_id": "nonexistent"},
+                "cli-user",
+            )


### PR DESCRIPTION
## Summary
- `_handle_bot_create`가 CLI args를 `BotManager.create_bot(**args)`에 그대로 전달하던 시그니처 불일치 수정
- Web API와 동일한 변환 로직 적용: strategy_id → StrategyRegistry → StrategyLoader → BotConfig → create_bot
- `ServiceRegistry`에 `strategy_registry` 필드 추가

## Test plan
- [x] `tests/unit/ipc/test_registry.py` 6건 전체 PASS
- [ ] QA sweep에서 관련 TC 검증

Closes #1090

🤖 Generated with [Claude Code](https://claude.com/claude-code)