### PR TITLE
feat(dashboard): 봇 생성 모달에 계좌 선택 드롭다운 추가

### DIFF
--- a/frontend/src/api/accounts.ts
+++ b/frontend/src/api/accounts.ts
@@ -1,0 +1,7 @@
+import client from './client'
+import type { Account } from '../types/account'
+
+export async function getAccounts(params?: { status?: string }): Promise<Account[]> {
+  const res = await client.get('/api/accounts', { params })
+  return res.data.accounts ?? []
+}

--- a/frontend/src/components/bots/BotCreateForm.tsx
+++ b/frontend/src/components/bots/BotCreateForm.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useCreateBot } from '../../hooks/useBots'
 import { useStrategies } from '../../hooks/useStrategies'
+import { useActiveAccounts } from '../../hooks/useAccounts'
 import { useTreasurySummary } from '../../hooks/useTreasury'
 import { formatNumber } from '../../utils/formatters'
 
@@ -14,15 +15,26 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
   const [botId, setBotId] = useState('')
   const [name, setName] = useState('')
   const [strategyId, setStrategyId] = useState('')
+  const [accountId, setAccountId] = useState('')
   const [interval, setInterval] = useState('60')
   const [budget, setBudget] = useState('')
   const [botIdError, setBotIdError] = useState('')
   const createBot = useCreateBot()
   const { data: strategies } = useStrategies()
+  const { data: accounts, isLoading: accountsLoading } = useActiveAccounts()
   const { data: treasury } = useTreasurySummary()
 
   const adoptedStrategies = strategies?.filter((s) => s.status === 'adopted') ?? []
   const remainingBudget = treasury?.unallocated ?? 0
+
+  const activeAccounts = accounts ?? []
+
+  // 활성 계좌가 1개면 자동 선택
+  useEffect(() => {
+    if (activeAccounts.length === 1 && !accountId) {
+      setAccountId(activeAccounts[0].account_id)
+    }
+  }, [activeAccounts, accountId])
 
   const validateBotId = (value: string) => {
     if (value && !BOT_ID_PATTERN.test(value)) {
@@ -45,6 +57,7 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
         bot_id: botId,
         name,
         strategy_id: strategyId,
+        account_id: accountId || undefined,
         interval_seconds: Number(interval),
         budget: Number(budget.replace(/,/g, '')),
       },
@@ -81,6 +94,41 @@ export default function BotCreateForm({ onClose }: BotCreateFormProps) {
             </select>
             {adoptedStrategies.length === 0 && (
               <div className="text-[11px] text-warning mt-1">봇을 생성하려면 먼저 전략을 채택해 주세요</div>
+            )}
+          </div>
+          <div className="mb-4">
+            <label className="block text-[12px] font-semibold text-text-muted mb-1.5">계좌 선택</label>
+            <select
+              value={accountId}
+              onChange={(e) => setAccountId(e.target.value)}
+              className="w-full bg-bg border border-border rounded-lg px-3 py-2.5 text-text text-[14px] focus:outline-none focus:border-primary appearance-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              required
+              disabled={accountsLoading || activeAccounts.length === 0}
+            >
+              {accountsLoading ? (
+                <option value="">계좌 목록 로딩 중...</option>
+              ) : activeAccounts.length === 0 ? (
+                <option value="">활성 계좌가 없습니다</option>
+              ) : activeAccounts.length === 1 ? (
+                <option value={activeAccounts[0].account_id}>
+                  {activeAccounts[0].name} ({activeAccounts[0].exchange} / {activeAccounts[0].trading_mode})
+                </option>
+              ) : (
+                <>
+                  <option value="">계좌를 선택하세요</option>
+                  {activeAccounts.map((acc) => (
+                    <option key={acc.account_id} value={acc.account_id}>
+                      {acc.name} ({acc.exchange} / {acc.trading_mode})
+                    </option>
+                  ))}
+                </>
+              )}
+            </select>
+            {!accountsLoading && activeAccounts.length === 0 && (
+              <div className="text-[11px] text-warning mt-1">봇을 생성하려면 먼저 계좌를 등록해 주세요</div>
+            )}
+            {!accountsLoading && activeAccounts.length === 1 && (
+              <div className="text-[11px] text-text-muted mt-1">활성 계좌가 1개뿐이므로 자동 선택되었습니다</div>
             )}
           </div>
           <div className="mb-4">

--- a/frontend/src/hooks/useAccounts.ts
+++ b/frontend/src/hooks/useAccounts.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query'
+import { getAccounts } from '../api/accounts'
+
+export function useAccounts(params?: { status?: string }) {
+  return useQuery({
+    queryKey: ['accounts', params],
+    queryFn: () => getAccounts(params),
+  })
+}
+
+/** 활성 계좌만 조회하는 편의 훅. */
+export function useActiveAccounts() {
+  return useAccounts({ status: 'active' })
+}

--- a/frontend/src/types/account.ts
+++ b/frontend/src/types/account.ts
@@ -1,0 +1,26 @@
+/**
+ * Account 도메인 타입.
+ *
+ * 백엔드 AccountResponse 스키마 기반.
+ * api.generated.ts에 Account 타입이 아직 없으므로 프론트엔드에서 명시 정의한다.
+ */
+
+export type AccountStatus = 'active' | 'suspended' | 'deleted'
+
+export interface Account {
+  account_id: string
+  name: string
+  exchange: string
+  currency: string
+  timezone: string
+  trading_hours_start: string
+  trading_hours_end: string
+  trading_mode: string
+  broker_type: string
+  broker_config: Record<string, unknown>
+  buy_commission_rate: number
+  sell_commission_rate: number
+  status: AccountStatus
+  created_at: string
+  updated_at: string
+}


### PR DESCRIPTION
## Summary
- 봇 생성 모달에 **계좌 선택 드롭다운**을 추가하여 다중 계좌 환경에서 의도한 계좌로 봇을 생성할 수 있도록 함
- Account 타입(`types/account.ts`), API 함수(`api/accounts.ts`), React Query 훅(`hooks/useAccounts.ts`) 신규 생성
- `GET /api/accounts?status=active`로 활성 계좌만 조회하여 드롭다운에 표시
- 활성 계좌가 1개면 자동 선택, 복수면 사용자가 직접 선택
- `POST /api/bots` 요청 시 `account_id` 파라미터를 함께 전달

Closes #1091

## Test plan
- [ ] 활성 계좌가 0개일 때 "활성 계좌가 없습니다" 메시지와 경고 표시 확인
- [ ] 활성 계좌가 1개일 때 자동 선택 및 안내 메시지 확인
- [ ] 활성 계좌가 2개 이상일 때 드롭다운에서 선택 가능 확인
- [ ] 봇 생성 시 선택한 account_id가 API 요청에 포함되는지 확인
- [ ] 빌드 성공 확인 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)