### PR TITLE
fix(main): Gateway/Stream/Treasury 초기화 실패 시 알림 발행

### DIFF
--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -398,6 +398,20 @@ async def _init_gateway(s: Services) -> None:
                 account.account_id,
                 exc_info=True,
             )
+            from ante.eventbus.events import NotificationEvent
+
+            if s.eventbus is not None:
+                await s.eventbus.publish(
+                    NotificationEvent(
+                        level="error",
+                        title="Broker 연결 실패",
+                        message=(
+                            f"계좌 {account.account_id} 브로커 연결에 실패했습니다."
+                            " 주문 실행이 불가능할 수 있습니다."
+                        ),
+                        category="system",
+                    )
+                )
     if connected_count:
         logger.info("Broker 연결 완료: %d/%d개 계좌", connected_count, len(accounts))
 
@@ -414,6 +428,20 @@ async def _init_gateway(s: Services) -> None:
                     account.account_id,
                     exc_info=True,
                 )
+                from ante.eventbus.events import NotificationEvent
+
+                if s.eventbus is not None:
+                    await s.eventbus.publish(
+                        NotificationEvent(
+                            level="error",
+                            title="실시간 시세 연결 실패",
+                            message=(
+                                f"계좌 {account.account_id} StreamIntegration 초기화에"
+                                " 실패했습니다. 실시간 시세가 수신되지 않습니다."
+                            ),
+                            category="system",
+                        )
+                    )
 
     # 종목 마스터 동기화 (연결된 첫 번째 Broker 사용)
     if connected_count:
@@ -702,6 +730,21 @@ async def _init_treasury_sync(s: Services, accounts: list) -> None:
                 account.account_id,
                 exc_info=True,
             )
+            from ante.eventbus.events import NotificationEvent
+
+            if s.eventbus is not None:
+                await s.eventbus.publish(
+                    NotificationEvent(
+                        level="error",
+                        title="Treasury 잔고 동기화 실패",
+                        message=(
+                            f"계좌 {account.account_id} Treasury 잔고 동기화에"
+                            " 실패했습니다. 봇 운영 시 잔고 불일치가"
+                            " 발생할 수 있습니다."
+                        ),
+                        category="system",
+                    )
+                )
 
 
 async def _init_feed(s: Services) -> None:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -557,3 +557,54 @@ async def test_rule_engine_manager_multi_account(tmp_path: Path) -> None:
     assert len(rule_engine_manager.engines) == 2
 
     await db.close()
+
+
+async def test_init_treasury_sync_publishes_notification_on_failure(
+    tmp_path: Path,
+) -> None:
+    """Treasury 동기화 실패 시 NotificationEvent(level=error)를 발행한다."""
+    from ante.eventbus.events import NotificationEvent
+    from ante.main import Services, _init_treasury_sync
+
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    eventbus = EventBus(history_size=100)
+
+    from ante.account import AccountService
+
+    account_service = AccountService(db=db, eventbus=eventbus)
+    await account_service.initialize()
+    await account_service.create_default_test_account()
+    accounts = await account_service.list()
+
+    # treasury_manager.get()가 실패하도록 빈 manager 준비
+    class _FailingTreasuryManager:
+        def get(self, account_id: str):
+            raise RuntimeError("treasury not initialized")
+
+    config = Config(static={}, secrets={})
+    s = Services(
+        db=db,
+        eventbus=eventbus,
+        config=config,
+        account_service=account_service,
+        treasury_manager=_FailingTreasuryManager(),
+    )
+
+    # 알림 수집
+    captured: list[NotificationEvent] = []
+
+    async def _collect(event: NotificationEvent) -> None:
+        captured.append(event)
+
+    eventbus.subscribe(NotificationEvent, _collect)
+
+    await _init_treasury_sync(s, accounts)
+
+    assert len(captured) == 1
+    assert captured[0].level == "error"
+    assert captured[0].category == "system"
+    assert "Treasury" in captured[0].title
+    assert accounts[0].account_id in captured[0].message
+
+    await db.close()


### PR DESCRIPTION
## Summary
- Broker 연결 실패 / StreamIntegration 초기화 실패 / Treasury 잔고 동기화 실패 시 기존 warning 로그에 더해 `NotificationEvent(level=\"error\", category=\"system\")`를 EventBus로 발행하여 대시보드/텔레그램에서 사용자가 즉시 인지할 수 있도록 한다.
- 세 실패 지점 모두 기존 동작(건너뛰고 계속 진행)은 유지. 알림만 추가.
- `_init_treasury_sync` 실패 경로에서 NotificationEvent가 발행되는지 검증하는 단위 테스트 추가.

Refs #1098

## Test plan
- [x] `ruff check src/ante/main.py tests/unit/test_main.py`
- [x] `ruff format --check`
- [x] `pytest tests/unit/test_main.py` (11 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)