### PR TITLE
fix(web): /health가 DB/Broker 실제 상태를 반영하도록 수정

### DIFF
--- a/src/ante/web/routes/system.py
+++ b/src/ante/web/routes/system.py
@@ -53,9 +53,39 @@ async def get_system_status(
 
 
 @router.get("/health", response_model=HealthResponse)
-async def health_check() -> dict:
-    """헬스체크."""
-    return {"ok": True}
+async def health_check(
+    request: Request,
+    account_service: Annotated[Any | None, Depends(get_account_service_optional)],
+) -> dict:
+    """헬스체크 — 핵심 의존성(DB, Broker)의 실제 상태를 반영한다."""
+    checks: dict[str, bool] = {"db": False, "broker": False}
+
+    # DB 접근 확인
+    db = getattr(request.app.state, "db", None)
+    if db is not None:
+        try:
+            await db.fetch_one("SELECT 1")
+            checks["db"] = True
+        except Exception:
+            pass
+
+    # Broker 연결 확인: 연결된 Broker 1개라도 있으면 True
+    if account_service is not None:
+        try:
+            accounts = await account_service.list()
+            for a in accounts:
+                try:
+                    broker = await account_service.get_broker(a.account_id)
+                    if getattr(broker, "connected", False):
+                        checks["broker"] = True
+                        break
+                except Exception:
+                    continue
+        except Exception:
+            pass
+
+    ok = all(checks.values())
+    return {"ok": ok, "checks": checks}
 
 
 @router.post(

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -117,6 +117,7 @@ class HealthResponse(BaseModel):
     """헬스체크 응답."""
 
     ok: bool
+    checks: dict[str, bool] = {}
 
 
 class KillSwitchResponse(BaseModel):

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -35,7 +35,11 @@ class TestSystemRoutes:
     def test_health(self, client):
         resp = client.get("/api/system/health")
         assert resp.status_code == 200
-        assert resp.json()["ok"] is True
+        data = resp.json()
+        # 기본 앱(DB/broker 미주입)에서는 ok=False + checks 내 의존성 상태 False
+        assert "ok" in data
+        assert data["checks"] == {"db": False, "broker": False}
+        assert data["ok"] is False
 
 
 # ── Strategy 라우트 테스트 ────────────────────────
@@ -512,7 +516,9 @@ class TestResponseModelCoverage:
         assert resp.status_code == 200
         data = resp.json()
         model = HealthResponse(**data)
-        assert model.ok is True
+        # 기본 앱에서는 DB/broker 미주입 → ok=False
+        assert model.ok is False
+        assert model.checks == {"db": False, "broker": False}
 
     def test_response_model_validates_strategy_validate(self, client, tmp_path):
         """StrategyValidateResponse 모델이 실제 응답과 일치하는지 검증."""

--- a/tests/unit/web/test_system_health.py
+++ b/tests/unit/web/test_system_health.py
@@ -1,0 +1,161 @@
+"""/api/system/health — DB/Broker 실제 상태 반영 검증 (#1100)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402
+
+
+@dataclass
+class FakeAccount:
+    account_id: str
+
+
+class _FakeDBOk:
+    """정상 동작하는 fake DB (fetch_one 성공)."""
+
+    async def fetch_one(self, _query: str) -> dict:
+        return {"1": 1}
+
+
+class _FakeDBFail:
+    """fetch_one이 예외를 던지는 fake DB."""
+
+    async def fetch_one(self, _query: str) -> dict:
+        raise RuntimeError("db unavailable")
+
+
+def _make_account_service(
+    accounts: list[FakeAccount],
+    brokers: dict[str, object],
+) -> AsyncMock:
+    """list()와 get_broker()를 제공하는 fake account_service 생성."""
+    svc = AsyncMock()
+    svc.list = AsyncMock(return_value=accounts)
+
+    async def _get_broker(account_id: str) -> object:
+        return brokers[account_id]
+
+    svc.get_broker = AsyncMock(side_effect=_get_broker)
+    return svc
+
+
+class _ConnectedBroker:
+    connected = True
+
+
+class _DisconnectedBroker:
+    connected = False
+
+
+class TestSystemHealth:
+    def test_db_ok_and_broker_connected_returns_ok_true(self) -> None:
+        """DB 정상 + broker 중 1개 이상 연결 → ok=True."""
+        account_service = _make_account_service(
+            accounts=[FakeAccount(account_id="a1"), FakeAccount(account_id="a2")],
+            brokers={"a1": _DisconnectedBroker(), "a2": _ConnectedBroker()},
+        )
+        app = create_app(db=_FakeDBOk(), account_service=account_service)
+        client = TestClient(app)
+
+        resp = client.get("/api/system/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == {"ok": True, "checks": {"db": True, "broker": True}}
+
+    def test_db_failure_returns_ok_false(self) -> None:
+        """DB fetch 실패 → checks.db=False, ok=False."""
+        account_service = _make_account_service(
+            accounts=[FakeAccount(account_id="a1")],
+            brokers={"a1": _ConnectedBroker()},
+        )
+        app = create_app(db=_FakeDBFail(), account_service=account_service)
+        client = TestClient(app)
+
+        resp = client.get("/api/system/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is False
+        assert data["checks"]["db"] is False
+        assert data["checks"]["broker"] is True
+
+    def test_all_brokers_disconnected_returns_ok_false(self) -> None:
+        """모든 broker 연결이 끊김 → checks.broker=False, ok=False."""
+        account_service = _make_account_service(
+            accounts=[FakeAccount(account_id="a1"), FakeAccount(account_id="a2")],
+            brokers={"a1": _DisconnectedBroker(), "a2": _DisconnectedBroker()},
+        )
+        app = create_app(db=_FakeDBOk(), account_service=account_service)
+        client = TestClient(app)
+
+        resp = client.get("/api/system/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is False
+        assert data["checks"]["db"] is True
+        assert data["checks"]["broker"] is False
+
+    def test_account_service_none_returns_broker_false(self) -> None:
+        """account_service가 주입되지 않음 → broker=False, ok=False."""
+        app = create_app(db=_FakeDBOk())
+        client = TestClient(app)
+
+        resp = client.get("/api/system/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["checks"]["broker"] is False
+        assert data["ok"] is False
+
+    def test_account_service_list_raises_returns_broker_false(self) -> None:
+        """account_service.list() 예외 → 500 아닌 checks.broker=False."""
+        svc = AsyncMock()
+        svc.list = AsyncMock(side_effect=RuntimeError("account list failed"))
+        app = create_app(db=_FakeDBOk(), account_service=svc)
+        client = TestClient(app)
+
+        resp = client.get("/api/system/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["checks"]["broker"] is False
+        assert data["ok"] is False
+
+    def test_get_broker_raises_skips_account(self) -> None:
+        """특정 계좌의 get_broker가 실패해도 다음 계좌로 폴백하여 검사한다."""
+        accounts = [FakeAccount(account_id="a1"), FakeAccount(account_id="a2")]
+        svc = AsyncMock()
+        svc.list = AsyncMock(return_value=accounts)
+
+        async def _get_broker(account_id: str) -> object:
+            if account_id == "a1":
+                raise RuntimeError("broker unavailable")
+            return _ConnectedBroker()
+
+        svc.get_broker = AsyncMock(side_effect=_get_broker)
+
+        app = create_app(db=_FakeDBOk(), account_service=svc)
+        client = TestClient(app)
+
+        resp = client.get("/api/system/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["checks"]["broker"] is True
+
+    def test_no_db_state_returns_db_false(self) -> None:
+        """app.state.db가 없음 → checks.db=False."""
+        app = create_app()  # db 미주입
+        client = TestClient(app)
+
+        resp = client.get("/api/system/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["checks"] == {"db": False, "broker": False}
+        assert data["ok"] is False


### PR DESCRIPTION
## Summary
- `GET /api/system/health`가 항상 `{"ok": true}`를 반환하던 문제(#1100)를 수정.
- DB(`app.state.db.fetch_one("SELECT 1")`)와 Broker(`account_service.get_broker().connected`)의 실제 상태를 검사하여 `checks: {db, broker}`와 `ok = all(checks)`를 응답한다.
- `HealthResponse` 스키마에 `checks: dict[str, bool] = {}` 필드를 추가 (기본값으로 하위 호환 유지).

## Changes
- `src/ante/web/schemas.py`: `HealthResponse.checks` 필드 추가
- `src/ante/web/routes/system.py`: `health_check` 로직 교체 (`Request`, `get_account_service_optional` 주입)
- `tests/unit/web/test_system_health.py`: 신규 — DB OK/실패, broker connected/disconnected, account_service None, list 예외, get_broker 예외, state.db 미주입 등 7 케이스
- `tests/unit/test_web_api.py`: 기존 `test_health` 및 response model 검증을 새 스키마에 맞게 업데이트

## Test plan
- [x] `pytest tests/unit/web/test_system_health.py` — 7 케이스 통과
- [x] `pytest tests/unit/test_web_api.py tests/unit/test_response_model_validation.py tests/unit/test_audit_integration.py tests/unit/test_token_auth_middleware.py` — 127 전부 통과
- [x] `ruff check` / `ruff format --check` 통과

Refs #1100