### PR TITLE
feat(log): compute_fingerprint() — 예외 dedup fingerprint 유틸리티 (#1107)

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -35,9 +35,8 @@ src/ante/
 │
 ├── core/
 │   ├── database.py              # Database — SQLite WAL 연결 관리
-│   └── log/                     # 시스템 로그 인프라 (JSONL 포맷, fingerprint)
+│   └── log/                     # 시스템 로그 인프라
 │       ├── __init__.py
-│       ├── formatter.py         # JsonFormatter — JSONL 직렬화
 │       └── fingerprint.py       # compute_fingerprint() — 예외 dedup 키
 │
 ├── config/

--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -34,7 +34,11 @@ src/ante/
 ├── main.py                      # asyncio 엔트리포인트 (Composition Root)
 │
 ├── core/
-│   └── database.py              # Database — SQLite WAL 연결 관리
+│   ├── database.py              # Database — SQLite WAL 연결 관리
+│   └── log/                     # 시스템 로그 인프라 (JSONL 포맷, fingerprint)
+│       ├── __init__.py
+│       ├── formatter.py         # JsonFormatter — JSONL 직렬화
+│       └── fingerprint.py       # compute_fingerprint() — 예외 dedup 키
 │
 ├── config/
 │   ├── config.py                # ConfigService — 설정 로딩 (system.toml + secrets.env)

--- a/src/ante/core/log/__init__.py
+++ b/src/ante/core/log/__init__.py
@@ -1,0 +1,1 @@
+"""Ante core logging 서브패키지."""

--- a/src/ante/core/log/fingerprint.py
+++ b/src/ante/core/log/fingerprint.py
@@ -9,11 +9,7 @@
 
 from __future__ import annotations
 
-import re
-import traceback
 from types import TracebackType
-
-_ANTE_MODULE_RE = re.compile(r"(ante/[^.]+)\.py$")
 
 
 def compute_fingerprint(
@@ -24,9 +20,12 @@ def compute_fingerprint(
     """Exception fingerprint 문자열을 생성한다.
 
     형식은 ``{exception class}@{최근 ante.* 프레임 module:function}``이다.
-    스택을 최근 호출 → 먼 호출 순으로 순회하면서 모듈 경로가 ``ante/`` 접두어
-    아래에 있는 첫 프레임을 선택한다. 해당 프레임이 없으면
-    ``{exception class}@{logger_name}`` 으로 폴백한다.
+    traceback 체인을 오래된 호출 → 최근 호출 순으로 순회하면서 ``f_globals['__name__']``
+    이 ``ante.`` 으로 시작하는 프레임을 수집한다. 가장 최근(= 가장 깊은) 프레임을
+    선택한다. 해당 프레임이 없으면 ``{exception class}@{logger_name}`` 으로 폴백한다.
+
+    파일 경로 대신 Python이 설정한 ``__name__`` 을 사용하므로 설치 경로나
+    체크아웃 경로에 독립적이다.
 
     Args:
         exc_type: 발생한 예외의 클래스.
@@ -38,21 +37,20 @@ def compute_fingerprint(
     """
     if exc_tb is None:
         return f"{exc_type.__name__}@{logger_name}"
-    frames = traceback.extract_tb(exc_tb)
-    for frame in reversed(frames):
-        module = _module_path(frame.filename)
-        if module:
-            return f"{exc_type.__name__}@{module}:{frame.name}"
+
+    # 오래된 → 최근 순 순회, ante.* 프레임 수집
+    ante_frames: list[tuple[str, str]] = []
+    tb = exc_tb
+    while tb is not None:
+        frame = tb.tb_frame
+        module = frame.f_globals.get("__name__", "")
+        if module == "ante" or module.startswith("ante."):
+            ante_frames.append((module, frame.f_code.co_name))
+        tb = tb.tb_next
+
+    if ante_frames:
+        # 가장 최근 = 리스트의 마지막 원소
+        module, func = ante_frames[-1]
+        return f"{exc_type.__name__}@{module}:{func}"
+
     return f"{exc_type.__name__}@{logger_name}"
-
-
-def _module_path(filename: str) -> str | None:
-    """파일 경로에서 ante 패키지 상대 경로를 추출하여 module 표기로 변환한다.
-
-    예: ``/app/src/ante/broker/kis_stream.py`` → ``ante.broker.kis_stream``.
-    ante 패키지 경로가 아니면 ``None``을 반환한다.
-    """
-    m = _ANTE_MODULE_RE.search(filename)
-    if not m:
-        return None
-    return m.group(1).replace("/", ".")

--- a/src/ante/core/log/fingerprint.py
+++ b/src/ante/core/log/fingerprint.py
@@ -1,0 +1,58 @@
+"""Exception fingerprint 생성 유틸리티.
+
+감시 에이전트가 "같은 근본 원인의 반복 발생"을 묶기 위해 사용하는 안정
+식별자다. 라인번호에 의존하지 않고 리팩터링에 저항적인 ``module:function``
+단위 해상도를 사용한다.
+
+자세한 규칙은 ``docs/specs/logging/04-fingerprint.md`` 참조.
+"""
+
+from __future__ import annotations
+
+import re
+import traceback
+from types import TracebackType
+
+_ANTE_MODULE_RE = re.compile(r"(ante/[^.]+)\.py$")
+
+
+def compute_fingerprint(
+    exc_type: type,
+    exc_tb: TracebackType | None,
+    logger_name: str,
+) -> str:
+    """Exception fingerprint 문자열을 생성한다.
+
+    형식은 ``{exception class}@{최근 ante.* 프레임 module:function}``이다.
+    스택을 최근 호출 → 먼 호출 순으로 순회하면서 모듈 경로가 ``ante/`` 접두어
+    아래에 있는 첫 프레임을 선택한다. 해당 프레임이 없으면
+    ``{exception class}@{logger_name}`` 으로 폴백한다.
+
+    Args:
+        exc_type: 발생한 예외의 클래스.
+        exc_tb: 예외의 traceback. ``None``이면 logger 이름으로 폴백한다.
+        logger_name: 폴백에 사용할 logger 이름.
+
+    Returns:
+        Fingerprint 문자열.
+    """
+    if exc_tb is None:
+        return f"{exc_type.__name__}@{logger_name}"
+    frames = traceback.extract_tb(exc_tb)
+    for frame in reversed(frames):
+        module = _module_path(frame.filename)
+        if module:
+            return f"{exc_type.__name__}@{module}:{frame.name}"
+    return f"{exc_type.__name__}@{logger_name}"
+
+
+def _module_path(filename: str) -> str | None:
+    """파일 경로에서 ante 패키지 상대 경로를 추출하여 module 표기로 변환한다.
+
+    예: ``/app/src/ante/broker/kis_stream.py`` → ``ante.broker.kis_stream``.
+    ante 패키지 경로가 아니면 ``None``을 반환한다.
+    """
+    m = _ANTE_MODULE_RE.search(filename)
+    if not m:
+        return None
+    return m.group(1).replace("/", ".")

--- a/src/ante/core/log/fingerprint.py
+++ b/src/ante/core/log/fingerprint.py
@@ -44,7 +44,7 @@ def compute_fingerprint(
     while tb is not None:
         frame = tb.tb_frame
         module = frame.f_globals.get("__name__", "")
-        if module == "ante" or module.startswith("ante."):
+        if module.startswith("ante."):
             ante_frames.append((module, frame.f_code.co_name))
         tb = tb.tb_next
 

--- a/tests/unit/test_log_fingerprint.py
+++ b/tests/unit/test_log_fingerprint.py
@@ -3,110 +3,65 @@
 from __future__ import annotations
 
 import sys
-import traceback
 import types
-from pathlib import Path
-from unittest.mock import patch
 
-from ante.core.log.fingerprint import _module_path, compute_fingerprint
+from ante.core.log.fingerprint import compute_fingerprint
 
 # ---------------------------------------------------------------------------
-# _module_path 단위 테스트
+# 테스트 헬퍼
 # ---------------------------------------------------------------------------
 
 
-class TestModulePath:
-    """경로 → ante 모듈 표기 변환 규칙 검증."""
+def _make_tb_with_modules(
+    frames: list[tuple[str, str]],
+) -> types.TracebackType:
+    """지정한 (module_name, func_name) 목록으로 traceback을 생성한다.
 
-    def test_ante_bot_manager_path(self) -> None:
-        """/app/src/ante/bot/manager.py -> ante.bot.manager."""
-        assert _module_path("/app/src/ante/bot/manager.py") == "ante.bot.manager"
-
-    def test_ante_broker_kis_stream_path(self) -> None:
-        """중첩된 서브모듈 경로도 올바르게 변환된다."""
-        assert (
-            _module_path("/app/src/ante/broker/kis_stream.py")
-            == "ante.broker.kis_stream"
-        )
-
-    def test_external_stdlib_path_returns_none(self) -> None:
-        """표준 라이브러리 경로는 None."""
-        assert _module_path("/usr/lib/python3.12/asyncio/tasks.py") is None
-
-    def test_external_third_party_path_returns_none(self) -> None:
-        """외부 라이브러리 경로는 None."""
-        assert (
-            _module_path("/usr/lib/python3.12/site-packages/httpx/_client.py") is None
-        )
-
-    def test_non_python_file_returns_none(self) -> None:
-        """확장자가 .py가 아니면 None."""
-        assert _module_path("/app/src/ante/broker/kis_stream.txt") is None
-
-    def test_path_without_ante_returns_none(self) -> None:
-        """ante 세그먼트가 없으면 None."""
-        assert _module_path("/app/src/other/module.py") is None
-
-
-# ---------------------------------------------------------------------------
-# compute_fingerprint 테스트 헬퍼
-# ---------------------------------------------------------------------------
-
-
-def _make_tb_from_frames(frames: list[tuple[str, int, str]]) -> types.TracebackType:
-    """지정한 (filename, lineno, funcname) 목록으로 실제 ``TracebackType``을 생성한다.
-
-    각 프레임을 ``exec`` 로 실제 실행하여 중첩된 호출 스택을 만들고,
-    가장 안쪽에서 예외를 발생시켜 traceback 체인을 얻는다.
+    각 프레임을 ``exec`` 로 실행하되, 전달하는 namespace에 ``__name__``을
+    원하는 모듈명으로 설정한다. 이렇게 하면 ``frame.f_globals['__name__']``이
+    지정한 값을 반환하므로, 파일 경로와 무관하게 모듈 식별을 테스트할 수 있다.
 
     Args:
-        frames: ``(filename, lineno, funcname)`` 튜플 리스트.
-            첫 원소가 바깥쪽(오래된) 프레임, 마지막 원소가 가장 안쪽(최근) 프레임이다.
+        frames: ``(module_name, func_name)`` 튜플 리스트.
+            첫 원소가 바깥쪽(오래된) 프레임, 마지막이 가장 안쪽(최근) 프레임이다.
 
     Returns:
         생성된 예외의 ``__traceback__``.
     """
-    # 각 프레임을 함수로 정의하고 연쇄 호출한 뒤, 가장 안쪽에서 raise 한다.
-    # exec에 전용 code object를 전달해 각 프레임의 filename을 원하는 값으로 지정한다.
-    func_names = [fn for (_, _, fn) in frames]
+    func_names = [fn for (_, fn) in frames]
 
-    # 안쪽부터 바깥쪽 순으로 함수 정의를 쌓는다 (호출은 바깥 → 안쪽).
-    def make_code(
-        filename: str,
-        lineno: int,
-        funcname: str,
-        body: str,
-    ) -> types.CodeType:
-        # body 앞에 빈 줄을 넣어 lineno 위치에 실제 코드가 오도록 보정한다.
-        padding = "\n" * max(lineno - 1, 0)
-        source = f"{padding}def {funcname}():\n    {body}\n"
-        return compile(source, filename, "exec")
-
-    # 안쪽 함수부터 역순으로 생성하면서 outer가 inner를 호출하도록 구성한다.
-    # 가장 안쪽 프레임은 raise 만 수행.
-    namespaces: list[dict] = []
-
-    # innermost
-    inner_file, inner_line, inner_name = frames[-1]
-    inner_ns: dict = {}
+    # 가장 안쪽 프레임: raise 만 수행
+    inner_module, inner_name = frames[-1]
+    inner_ns: dict = {"__name__": inner_module}
     exec(
-        make_code(inner_file, inner_line, inner_name, "raise ValueError('boom')"),
+        compile(
+            f"def {inner_name}():\n    raise ValueError('boom')",
+            f"<{inner_module}>",
+            "exec",
+        ),
         inner_ns,
     )
-    namespaces.append(inner_ns)
 
-    # 바깥 프레임들을 역순(안쪽 직전 → 가장 바깥)으로 쌓는다.
+    # 바깥 프레임들을 안쪽 → 바깥 순서로 쌓는다
+    chain_ns = [inner_ns]
     for i in range(len(frames) - 2, -1, -1):
-        outer_file, outer_line, outer_name = frames[i]
+        outer_module, outer_name = frames[i]
         inner_callable_name = func_names[i + 1]
-        ns: dict = {inner_callable_name: namespaces[-1][inner_callable_name]}
+        ns: dict = {
+            "__name__": outer_module,
+            inner_callable_name: chain_ns[-1][inner_callable_name],
+        }
         exec(
-            make_code(outer_file, outer_line, outer_name, f"{inner_callable_name}()"),
+            compile(
+                f"def {outer_name}():\n    {inner_callable_name}()",
+                f"<{outer_module}>",
+                "exec",
+            ),
             ns,
         )
-        namespaces.append(ns)
+        chain_ns.append(ns)
 
-    outermost_ns = namespaces[-1]
+    outermost_ns = chain_ns[-1]
     outermost_name = func_names[0]
     try:
         outermost_ns[outermost_name]()
@@ -128,32 +83,28 @@ class TestComputeFingerprint:
 
     def test_single_ante_frame(self) -> None:
         """단일 ante 모듈 프레임 → 정상 fingerprint."""
-        tb = _make_tb_from_frames(
-            [
-                ("/app/src/ante/broker/kis_stream.py", 10, "handle_reconnect"),
-            ]
-        )
+        tb = _make_tb_with_modules([("ante.broker.kis_stream", "handle_reconnect")])
         result = compute_fingerprint(ConnectionError, tb, "ante.broker.kis_stream")
         assert result == "ConnectionError@ante.broker.kis_stream:handle_reconnect"
 
     def test_multiple_ante_frames_picks_most_recent(self) -> None:
-        """여러 ante 프레임이 있으면 reversed 첫 번째(가장 안쪽) 선택."""
-        tb = _make_tb_from_frames(
+        """여러 ante 프레임이 있으면 가장 최근(깊은) 프레임 선택."""
+        tb = _make_tb_with_modules(
             [
-                ("/app/src/ante/bot/manager.py", 5, "start"),
-                ("/app/src/ante/broker/kis_stream.py", 12, "handle_reconnect"),
+                ("ante.bot.manager", "start"),
+                ("ante.broker.kis_stream", "handle_reconnect"),
             ]
         )
         result = compute_fingerprint(ConnectionError, tb, "ante.broker.kis_stream")
         assert result == "ConnectionError@ante.broker.kis_stream:handle_reconnect"
 
     def test_external_frame_between_ante_frames(self) -> None:
-        """외부 라이브러리 프레임이 가장 안쪽이면 건너뛰고 최근 ante 프레임 선택."""
-        tb = _make_tb_from_frames(
+        """외부 프레임이 가장 안쪽이면 건너뛰고 최근 ante 프레임 선택."""
+        tb = _make_tb_with_modules(
             [
-                ("/app/src/ante/bot/manager.py", 3, "start"),
-                ("/app/src/ante/broker/kis_stream.py", 8, "handle_reconnect"),
-                ("/usr/lib/python3.12/asyncio/tasks.py", 20, "run"),
+                ("ante.bot.manager", "start"),
+                ("ante.broker.kis_stream", "handle_reconnect"),
+                ("asyncio.tasks", "run"),
             ]
         )
         result = compute_fingerprint(ConnectionError, tb, "ante.broker.kis_stream")
@@ -161,10 +112,10 @@ class TestComputeFingerprint:
 
     def test_no_ante_frame_falls_back_to_logger_name(self) -> None:
         """ante 프레임이 전혀 없으면 logger_name으로 폴백한다."""
-        tb = _make_tb_from_frames(
+        tb = _make_tb_with_modules(
             [
-                ("/usr/lib/python3.12/asyncio/tasks.py", 15, "run"),
-                ("/usr/lib/python3.12/site-packages/httpx/_client.py", 42, "send"),
+                ("asyncio.tasks", "run"),
+                ("httpx._client", "send"),
             ]
         )
         result = compute_fingerprint(ValueError, tb, "ante.broker.kis")
@@ -181,13 +132,23 @@ class TestComputeFingerprint:
         class CustomError(Exception):
             pass
 
-        tb = _make_tb_from_frames(
-            [
-                ("/app/src/ante/bot/manager.py", 7, "start"),
-            ]
-        )
+        tb = _make_tb_with_modules([("ante.bot.manager", "start")])
         result = compute_fingerprint(CustomError, tb, "ante.bot.manager")
         assert result == "CustomError@ante.bot.manager:start"
+
+    def test_fingerprint_ignores_line_numbers(self) -> None:
+        """같은 함수에서 라인이 달라도 동일한 fingerprint가 생성된다."""
+        tb1 = _make_tb_with_modules([("ante.bot.manager", "start")])
+        tb2 = _make_tb_with_modules([("ante.bot.manager", "start")])
+        fp1 = compute_fingerprint(ValueError, tb1, "ante.bot.manager")
+        fp2 = compute_fingerprint(ValueError, tb2, "ante.bot.manager")
+        assert fp1 == fp2 == "ValueError@ante.bot.manager:start"
+
+    def test_ante_root_module_is_matched(self) -> None:
+        """모듈명이 'ante' 그 자체여도 매칭된다."""
+        tb = _make_tb_with_modules([("ante", "some_func")])
+        result = compute_fingerprint(ValueError, tb, "ante")
+        assert result == "ValueError@ante:some_func"
 
 
 # ---------------------------------------------------------------------------
@@ -201,8 +162,8 @@ class TestComputeFingerprintEndToEnd:
     def test_real_exception_without_ante_frame_uses_fallback(self) -> None:
         """테스트 코드에서 직접 raise하면 ante 프레임이 없어 폴백한다.
 
-        테스트 파일 경로는 ``tests/unit/test_log_fingerprint.py`` 이므로
-        ``ante/`` 접두어 매칭에 걸리지 않는다.
+        이 테스트 파일의 ``f_globals['__name__']``은 ``tests.unit.test_log_fingerprint``
+        이므로 ``ante.`` 조건에 걸리지 않는다.
         """
         try:
             raise ConnectionError("simulated connection failure")
@@ -213,109 +174,18 @@ class TestComputeFingerprintEndToEnd:
 
         assert result == "ConnectionError@ante.broker.kis"
 
-    def test_fingerprint_ignores_line_numbers(self) -> None:
-        """같은 함수에서 라인 번호가 달라도 동일한 fingerprint를 생성한다."""
-        tb1 = _make_tb_from_frames(
-            [("/app/src/ante/bot/manager.py", 5, "start")],
-        )
-        tb2 = _make_tb_from_frames(
-            [("/app/src/ante/bot/manager.py", 42, "start")],
-        )
-        fp1 = compute_fingerprint(ValueError, tb1, "ante.bot.manager")
-        fp2 = compute_fingerprint(ValueError, tb2, "ante.bot.manager")
-        assert fp1 == fp2 == "ValueError@ante.bot.manager:start"
+    def test_checkout_path_does_not_confuse_module_detection(self) -> None:
+        """프로젝트 체크아웃 경로에 'ante'가 포함되어도 모듈 탐지가 혼동되지 않는다.
 
-
-# ---------------------------------------------------------------------------
-# mock 기반 unit test (traceback.extract_tb를 직접 대체)
-# ---------------------------------------------------------------------------
-
-
-class TestComputeFingerprintWithMockedExtract:
-    """traceback.extract_tb를 모킹하여 스택 구성을 직접 제어한다.
-
-    실제 TracebackType 생성 경로와 별개로, extract_tb 결과에 따른
-    reversed 순회 로직을 독립적으로 검증한다.
-    """
-
-    def _make_frame_summary(self, filename: str, name: str) -> traceback.FrameSummary:
-        return traceback.FrameSummary(filename, 1, name)
-
-    def test_reversed_iteration_selects_innermost_ante_frame(self) -> None:
-        """reversed 순회 시 마지막(=가장 안쪽) ante 프레임이 선택된다."""
-        frames = [
-            self._make_frame_summary("/app/src/ante/bot/manager.py", "start"),
-            self._make_frame_summary(
-                "/app/src/ante/broker/kis_stream.py", "handle_reconnect"
-            ),
-        ]
-
-        # compute_fingerprint 내부의 exc_tb is None 체크를 우회하기 위해
-        # 임의의 traceback 객체 + extract_tb patch 조합을 사용한다.
+        파일 경로 대신 ``f_globals['__name__']``을 사용하므로,
+        '/Users/.../ante/src/ante/...' 같은 경로의 경우에도 테스트 모듈은
+        ante.* 모듈로 오판되지 않는다.
+        """
         try:
-            raise RuntimeError("sentinel")
-        except RuntimeError:
-            _, _, fake_tb = sys.exc_info()
+            raise ValueError("path confusion test")
+        except ValueError:
+            exc_type, _, exc_tb = sys.exc_info()
+            result = compute_fingerprint(exc_type, exc_tb, "ante.test.logger")
 
-        with patch(
-            "ante.core.log.fingerprint.traceback.extract_tb",
-            return_value=frames,
-        ):
-            result = compute_fingerprint(ConnectionError, fake_tb, "logger")
-
-        assert result == "ConnectionError@ante.broker.kis_stream:handle_reconnect"
-
-    def test_skips_external_innermost_frame(self) -> None:
-        """가장 안쪽이 외부 프레임이면 건너뛰고 이전 ante 프레임을 선택한다."""
-        frames = [
-            self._make_frame_summary("/app/src/ante/bot/manager.py", "start"),
-            self._make_frame_summary(
-                "/usr/lib/python3.12/site-packages/httpx/_client.py", "send"
-            ),
-        ]
-
-        try:
-            raise RuntimeError("sentinel")
-        except RuntimeError:
-            _, _, fake_tb = sys.exc_info()
-
-        with patch(
-            "ante.core.log.fingerprint.traceback.extract_tb",
-            return_value=frames,
-        ):
-            result = compute_fingerprint(ValueError, fake_tb, "logger")
-
-        assert result == "ValueError@ante.bot.manager:start"
-
-    def test_all_external_frames_falls_back(self) -> None:
-        """모든 프레임이 외부면 logger_name 폴백."""
-        frames = [
-            self._make_frame_summary("/usr/lib/python3.12/asyncio/tasks.py", "run"),
-            self._make_frame_summary(
-                "/usr/lib/python3.12/site-packages/httpx/_client.py", "send"
-            ),
-        ]
-
-        try:
-            raise RuntimeError("sentinel")
-        except RuntimeError:
-            _, _, fake_tb = sys.exc_info()
-
-        with patch(
-            "ante.core.log.fingerprint.traceback.extract_tb",
-            return_value=frames,
-        ):
-            result = compute_fingerprint(ValueError, fake_tb, "ante.broker.kis")
-
-        assert result == "ValueError@ante.broker.kis"
-
-
-# ---------------------------------------------------------------------------
-# Regex 규칙 정상성 - test file 자체 경로로 negative sanity
-# ---------------------------------------------------------------------------
-
-
-def test_tests_unit_path_is_not_matched_as_ante_module() -> None:
-    """tests/unit/ 경로는 ante.* 매칭에 걸리지 않아야 한다."""
-    here = str(Path(__file__).resolve())
-    assert _module_path(here) is None
+        # 이 테스트 프레임은 ante.* 모듈이 아니므로 폴백
+        assert result == "ValueError@ante.test.logger"

--- a/tests/unit/test_log_fingerprint.py
+++ b/tests/unit/test_log_fingerprint.py
@@ -1,0 +1,321 @@
+"""`ante.core.log.fingerprint` 단위 테스트."""
+
+from __future__ import annotations
+
+import sys
+import traceback
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+from ante.core.log.fingerprint import _module_path, compute_fingerprint
+
+# ---------------------------------------------------------------------------
+# _module_path 단위 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestModulePath:
+    """경로 → ante 모듈 표기 변환 규칙 검증."""
+
+    def test_ante_bot_manager_path(self) -> None:
+        """/app/src/ante/bot/manager.py -> ante.bot.manager."""
+        assert _module_path("/app/src/ante/bot/manager.py") == "ante.bot.manager"
+
+    def test_ante_broker_kis_stream_path(self) -> None:
+        """중첩된 서브모듈 경로도 올바르게 변환된다."""
+        assert (
+            _module_path("/app/src/ante/broker/kis_stream.py")
+            == "ante.broker.kis_stream"
+        )
+
+    def test_external_stdlib_path_returns_none(self) -> None:
+        """표준 라이브러리 경로는 None."""
+        assert _module_path("/usr/lib/python3.12/asyncio/tasks.py") is None
+
+    def test_external_third_party_path_returns_none(self) -> None:
+        """외부 라이브러리 경로는 None."""
+        assert (
+            _module_path("/usr/lib/python3.12/site-packages/httpx/_client.py") is None
+        )
+
+    def test_non_python_file_returns_none(self) -> None:
+        """확장자가 .py가 아니면 None."""
+        assert _module_path("/app/src/ante/broker/kis_stream.txt") is None
+
+    def test_path_without_ante_returns_none(self) -> None:
+        """ante 세그먼트가 없으면 None."""
+        assert _module_path("/app/src/other/module.py") is None
+
+
+# ---------------------------------------------------------------------------
+# compute_fingerprint 테스트 헬퍼
+# ---------------------------------------------------------------------------
+
+
+def _make_tb_from_frames(frames: list[tuple[str, int, str]]) -> types.TracebackType:
+    """지정한 (filename, lineno, funcname) 목록으로 실제 ``TracebackType``을 생성한다.
+
+    각 프레임을 ``exec`` 로 실제 실행하여 중첩된 호출 스택을 만들고,
+    가장 안쪽에서 예외를 발생시켜 traceback 체인을 얻는다.
+
+    Args:
+        frames: ``(filename, lineno, funcname)`` 튜플 리스트.
+            첫 원소가 바깥쪽(오래된) 프레임, 마지막 원소가 가장 안쪽(최근) 프레임이다.
+
+    Returns:
+        생성된 예외의 ``__traceback__``.
+    """
+    # 각 프레임을 함수로 정의하고 연쇄 호출한 뒤, 가장 안쪽에서 raise 한다.
+    # exec에 전용 code object를 전달해 각 프레임의 filename을 원하는 값으로 지정한다.
+    func_names = [fn for (_, _, fn) in frames]
+
+    # 안쪽부터 바깥쪽 순으로 함수 정의를 쌓는다 (호출은 바깥 → 안쪽).
+    def make_code(
+        filename: str,
+        lineno: int,
+        funcname: str,
+        body: str,
+    ) -> types.CodeType:
+        # body 앞에 빈 줄을 넣어 lineno 위치에 실제 코드가 오도록 보정한다.
+        padding = "\n" * max(lineno - 1, 0)
+        source = f"{padding}def {funcname}():\n    {body}\n"
+        return compile(source, filename, "exec")
+
+    # 안쪽 함수부터 역순으로 생성하면서 outer가 inner를 호출하도록 구성한다.
+    # 가장 안쪽 프레임은 raise 만 수행.
+    namespaces: list[dict] = []
+
+    # innermost
+    inner_file, inner_line, inner_name = frames[-1]
+    inner_ns: dict = {}
+    exec(
+        make_code(inner_file, inner_line, inner_name, "raise ValueError('boom')"),
+        inner_ns,
+    )
+    namespaces.append(inner_ns)
+
+    # 바깥 프레임들을 역순(안쪽 직전 → 가장 바깥)으로 쌓는다.
+    for i in range(len(frames) - 2, -1, -1):
+        outer_file, outer_line, outer_name = frames[i]
+        inner_callable_name = func_names[i + 1]
+        ns: dict = {inner_callable_name: namespaces[-1][inner_callable_name]}
+        exec(
+            make_code(outer_file, outer_line, outer_name, f"{inner_callable_name}()"),
+            ns,
+        )
+        namespaces.append(ns)
+
+    outermost_ns = namespaces[-1]
+    outermost_name = func_names[0]
+    try:
+        outermost_ns[outermost_name]()
+    except ValueError:
+        _, _, tb = sys.exc_info()
+        assert tb is not None
+        return tb
+
+    raise RuntimeError("expected exception was not raised")  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# compute_fingerprint 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFingerprint:
+    """fingerprint 생성 규칙 검증."""
+
+    def test_single_ante_frame(self) -> None:
+        """단일 ante 모듈 프레임 → 정상 fingerprint."""
+        tb = _make_tb_from_frames(
+            [
+                ("/app/src/ante/broker/kis_stream.py", 10, "handle_reconnect"),
+            ]
+        )
+        result = compute_fingerprint(ConnectionError, tb, "ante.broker.kis_stream")
+        assert result == "ConnectionError@ante.broker.kis_stream:handle_reconnect"
+
+    def test_multiple_ante_frames_picks_most_recent(self) -> None:
+        """여러 ante 프레임이 있으면 reversed 첫 번째(가장 안쪽) 선택."""
+        tb = _make_tb_from_frames(
+            [
+                ("/app/src/ante/bot/manager.py", 5, "start"),
+                ("/app/src/ante/broker/kis_stream.py", 12, "handle_reconnect"),
+            ]
+        )
+        result = compute_fingerprint(ConnectionError, tb, "ante.broker.kis_stream")
+        assert result == "ConnectionError@ante.broker.kis_stream:handle_reconnect"
+
+    def test_external_frame_between_ante_frames(self) -> None:
+        """외부 라이브러리 프레임이 가장 안쪽이면 건너뛰고 최근 ante 프레임 선택."""
+        tb = _make_tb_from_frames(
+            [
+                ("/app/src/ante/bot/manager.py", 3, "start"),
+                ("/app/src/ante/broker/kis_stream.py", 8, "handle_reconnect"),
+                ("/usr/lib/python3.12/asyncio/tasks.py", 20, "run"),
+            ]
+        )
+        result = compute_fingerprint(ConnectionError, tb, "ante.broker.kis_stream")
+        assert result == "ConnectionError@ante.broker.kis_stream:handle_reconnect"
+
+    def test_no_ante_frame_falls_back_to_logger_name(self) -> None:
+        """ante 프레임이 전혀 없으면 logger_name으로 폴백한다."""
+        tb = _make_tb_from_frames(
+            [
+                ("/usr/lib/python3.12/asyncio/tasks.py", 15, "run"),
+                ("/usr/lib/python3.12/site-packages/httpx/_client.py", 42, "send"),
+            ]
+        )
+        result = compute_fingerprint(ValueError, tb, "ante.broker.kis")
+        assert result == "ValueError@ante.broker.kis"
+
+    def test_none_traceback_falls_back_to_logger_name(self) -> None:
+        """exc_tb가 None이면 logger_name으로 폴백한다."""
+        result = compute_fingerprint(RuntimeError, None, "ante.core.log")
+        assert result == "RuntimeError@ante.core.log"
+
+    def test_uses_exception_class_name(self) -> None:
+        """exception class 이름이 fingerprint 앞에 들어간다 (네임스페이스 제외)."""
+
+        class CustomError(Exception):
+            pass
+
+        tb = _make_tb_from_frames(
+            [
+                ("/app/src/ante/bot/manager.py", 7, "start"),
+            ]
+        )
+        result = compute_fingerprint(CustomError, tb, "ante.bot.manager")
+        assert result == "CustomError@ante.bot.manager:start"
+
+
+# ---------------------------------------------------------------------------
+# 실제 예외를 통한 end-to-end 검증
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFingerprintEndToEnd:
+    """실제 예외 발생 케이스 검증."""
+
+    def test_real_exception_without_ante_frame_uses_fallback(self) -> None:
+        """테스트 코드에서 직접 raise하면 ante 프레임이 없어 폴백한다.
+
+        테스트 파일 경로는 ``tests/unit/test_log_fingerprint.py`` 이므로
+        ``ante/`` 접두어 매칭에 걸리지 않는다.
+        """
+        try:
+            raise ConnectionError("simulated connection failure")
+        except ConnectionError:
+            exc_type, _, exc_tb = sys.exc_info()
+            assert exc_type is ConnectionError
+            result = compute_fingerprint(exc_type, exc_tb, "ante.broker.kis")
+
+        assert result == "ConnectionError@ante.broker.kis"
+
+    def test_fingerprint_ignores_line_numbers(self) -> None:
+        """같은 함수에서 라인 번호가 달라도 동일한 fingerprint를 생성한다."""
+        tb1 = _make_tb_from_frames(
+            [("/app/src/ante/bot/manager.py", 5, "start")],
+        )
+        tb2 = _make_tb_from_frames(
+            [("/app/src/ante/bot/manager.py", 42, "start")],
+        )
+        fp1 = compute_fingerprint(ValueError, tb1, "ante.bot.manager")
+        fp2 = compute_fingerprint(ValueError, tb2, "ante.bot.manager")
+        assert fp1 == fp2 == "ValueError@ante.bot.manager:start"
+
+
+# ---------------------------------------------------------------------------
+# mock 기반 unit test (traceback.extract_tb를 직접 대체)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFingerprintWithMockedExtract:
+    """traceback.extract_tb를 모킹하여 스택 구성을 직접 제어한다.
+
+    실제 TracebackType 생성 경로와 별개로, extract_tb 결과에 따른
+    reversed 순회 로직을 독립적으로 검증한다.
+    """
+
+    def _make_frame_summary(self, filename: str, name: str) -> traceback.FrameSummary:
+        return traceback.FrameSummary(filename, 1, name)
+
+    def test_reversed_iteration_selects_innermost_ante_frame(self) -> None:
+        """reversed 순회 시 마지막(=가장 안쪽) ante 프레임이 선택된다."""
+        frames = [
+            self._make_frame_summary("/app/src/ante/bot/manager.py", "start"),
+            self._make_frame_summary(
+                "/app/src/ante/broker/kis_stream.py", "handle_reconnect"
+            ),
+        ]
+
+        # compute_fingerprint 내부의 exc_tb is None 체크를 우회하기 위해
+        # 임의의 traceback 객체 + extract_tb patch 조합을 사용한다.
+        try:
+            raise RuntimeError("sentinel")
+        except RuntimeError:
+            _, _, fake_tb = sys.exc_info()
+
+        with patch(
+            "ante.core.log.fingerprint.traceback.extract_tb",
+            return_value=frames,
+        ):
+            result = compute_fingerprint(ConnectionError, fake_tb, "logger")
+
+        assert result == "ConnectionError@ante.broker.kis_stream:handle_reconnect"
+
+    def test_skips_external_innermost_frame(self) -> None:
+        """가장 안쪽이 외부 프레임이면 건너뛰고 이전 ante 프레임을 선택한다."""
+        frames = [
+            self._make_frame_summary("/app/src/ante/bot/manager.py", "start"),
+            self._make_frame_summary(
+                "/usr/lib/python3.12/site-packages/httpx/_client.py", "send"
+            ),
+        ]
+
+        try:
+            raise RuntimeError("sentinel")
+        except RuntimeError:
+            _, _, fake_tb = sys.exc_info()
+
+        with patch(
+            "ante.core.log.fingerprint.traceback.extract_tb",
+            return_value=frames,
+        ):
+            result = compute_fingerprint(ValueError, fake_tb, "logger")
+
+        assert result == "ValueError@ante.bot.manager:start"
+
+    def test_all_external_frames_falls_back(self) -> None:
+        """모든 프레임이 외부면 logger_name 폴백."""
+        frames = [
+            self._make_frame_summary("/usr/lib/python3.12/asyncio/tasks.py", "run"),
+            self._make_frame_summary(
+                "/usr/lib/python3.12/site-packages/httpx/_client.py", "send"
+            ),
+        ]
+
+        try:
+            raise RuntimeError("sentinel")
+        except RuntimeError:
+            _, _, fake_tb = sys.exc_info()
+
+        with patch(
+            "ante.core.log.fingerprint.traceback.extract_tb",
+            return_value=frames,
+        ):
+            result = compute_fingerprint(ValueError, fake_tb, "ante.broker.kis")
+
+        assert result == "ValueError@ante.broker.kis"
+
+
+# ---------------------------------------------------------------------------
+# Regex 규칙 정상성 - test file 자체 경로로 negative sanity
+# ---------------------------------------------------------------------------
+
+
+def test_tests_unit_path_is_not_matched_as_ante_module() -> None:
+    """tests/unit/ 경로는 ante.* 매칭에 걸리지 않아야 한다."""
+    here = str(Path(__file__).resolve())
+    assert _module_path(here) is None

--- a/tests/unit/test_log_fingerprint.py
+++ b/tests/unit/test_log_fingerprint.py
@@ -144,11 +144,11 @@ class TestComputeFingerprint:
         fp2 = compute_fingerprint(ValueError, tb2, "ante.bot.manager")
         assert fp1 == fp2 == "ValueError@ante.bot.manager:start"
 
-    def test_ante_root_module_is_matched(self) -> None:
-        """모듈명이 'ante' 그 자체여도 매칭된다."""
+    def test_bare_ante_module_falls_back(self) -> None:
+        """모듈명이 'ante' 그 자체이면 ante.* 조건에 해당하지 않아 폴백한다."""
         tb = _make_tb_with_modules([("ante", "some_func")])
-        result = compute_fingerprint(ValueError, tb, "ante")
-        assert result == "ValueError@ante:some_func"
+        result = compute_fingerprint(ValueError, tb, "ante.core")
+        assert result == "ValueError@ante.core"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1107

## Summary
- `src/ante/core/log/fingerprint.py`: `compute_fingerprint()` 구현
  - traceback의 `f_globals['__name__']`로 `ante.*` 프레임 탐지 (경로 독립적)
  - 가장 최근(깊은) `ante.*` 프레임 선택, 없으면 `logger_name` 폴백
  - 형식: `{ExcClass}@{module}:{func}` 또는 `{ExcClass}@{logger_name}`
- `tests/unit/test_log_fingerprint.py`: 8개 단위 + 2개 e2e 테스트

## Test Plan
- `pytest tests/unit/test_log_fingerprint.py` — 10/10 통과
- `ruff check`, `ruff format` — 클린
- Codex 브랜치 리뷰: PASS (HEAD `b19ed98`)