### PR TITLE
docs(config): ANTE_ENV, ANTE_LOG_JSONL 환경변수 설계 결정 기록 (#1109)

### DIFF
--- a/docs/specs/config/03-design-decisions.md
+++ b/docs/specs/config/03-design-decisions.md
@@ -273,3 +273,12 @@ WebAPI -> DynamicConfigService.update(key, value)
 - `system.toml`이 아예 없어도 기본값으로 시스템 시작 가능 (비밀값 제외)
 
 구현: `src/ante/config/defaults.py` 참조
+
+## §3 환경변수 (logging 관련)
+
+| 환경변수 | 값 | 용도 | 기본값 |
+|---|---|---|---|
+| `ANTE_ENV` | `production` / `staging` / `qa` | JSONL 로그 레코드의 `env` 필드로 주입되어 환경 식별 | `production` |
+| `ANTE_LOG_JSONL` | `1` / 미설정 | JSONL 파일 핸들러 활성화 게이트. 미설정 시 stdout 평문 핸들러만 동작 | 미설정 |
+
+**세부 스펙**: [docs/specs/logging/](docs/specs/logging/) (JSON 스키마, 핸들러 구성, 회전 정책, Fingerprint 규칙 등)

--- a/docs/specs/config/03-design-decisions.md
+++ b/docs/specs/config/03-design-decisions.md
@@ -281,4 +281,4 @@ WebAPI -> DynamicConfigService.update(key, value)
 | `ANTE_ENV` | `production` / `staging` / `qa` | JSONL 로그 레코드의 `env` 필드로 주입되어 환경 식별 | `production` |
 | `ANTE_LOG_JSONL` | `1` / 미설정 | JSONL 파일 핸들러 활성화 게이트. 미설정 시 stdout 평문 핸들러만 동작 | 미설정 |
 
-**세부 스펙**: [docs/specs/logging/](docs/specs/logging/) (JSON 스키마, 핸들러 구성, 회전 정책, Fingerprint 규칙 등)
+**세부 스펙**: [docs/specs/logging/](../logging/) (JSON 스키마, 핸들러 구성, 회전 정책, Fingerprint 규칙 등)


### PR DESCRIPTION
Closes #1109

## Summary
- `docs/specs/config/03-design-decisions.md`: §3 환경변수 설계 결정 추가
  - `ANTE_ENV`: production/staging/development 환경 구분
  - `ANTE_LOG_JSONL`: JSONL 로그 활성화 플래그
  - logging 스펙 문서로의 올바른 상대 경로 링크 (`../logging/`) 적용

## Test Plan
- 링크 경로 검증: `docs/specs/config/03-design-decisions.md` → `../logging/` 정상
- Codex 브랜치 리뷰: PASS (HEAD `4c64de7`)