### PR TITLE
feat(core/log): setup_logging() 이중 핸들러 + KST 자정 회전 (#1108)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,15 @@ FROM python:3.12-slim AS runtime
 WORKDIR /app
 
 # 시스템 의존성
-# tzdata: JSONL 파일명 회전이 Asia/Seoul 자정 기준임을 보장하기 위해 필수
-# (docs/specs/logging/05-handlers-and-rotation.md §회전 규칙)
+# tzdata: Python `zoneinfo.ZoneInfo("Asia/Seoul")` 조회를 위한 IANA DB.
+# 로그 회전은 핸들러 코드에서 KST 를 강제하므로 `ENV TZ` 자체는 필수 아님이나,
+# `date`, 컨테이너 로그 타임스탬프 등 관측성 일관성을 위해 함께 설정한다.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     sqlite3 \
     tzdata \
     && rm -rf /var/lib/apt/lists/*
 
-# 타임존: 로그 회전 자정 경계의 단일 기준
+# 관측성 TZ (회전 자정 경계는 코드가 KST 로 고정하므로 이 ENV 는 필수 아님).
 ENV TZ=Asia/Seoul
 
 # Python 패키지 설치

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,15 @@ FROM python:3.12-slim AS runtime
 WORKDIR /app
 
 # 시스템 의존성
+# tzdata: JSONL 파일명 회전이 Asia/Seoul 자정 기준임을 보장하기 위해 필수
+# (docs/specs/logging/05-handlers-and-rotation.md §회전 규칙)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     sqlite3 \
+    tzdata \
     && rm -rf /var/lib/apt/lists/*
+
+# 타임존: 로그 회전 자정 경계의 단일 기준
+ENV TZ=Asia/Seoul
 
 # Python 패키지 설치
 COPY pyproject.toml ./

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,24 @@
+# Staging 환경 override.
+#
+# 사용법:
+#   docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d
+#
+# 스펙: docs/specs/logging/05-handlers-and-rotation.md §볼륨 마운트
+#   - Staging: bind mount `~/Projects/ante/logs` → `/app/logs`
+#     감시 에이전트가 Docker 컨테이너 외부(맥미니 호스트)에서 직접
+#     JSONL 파일을 읽어야 하므로 named volume 대신 bind mount 를 사용한다.
+#
+# 선행 조건:
+#   mkdir -p ~/Projects/ante/logs
+#
+# 참고: ANTE_LOG_JSONL 게이트가 꺼져 있으면 파일 핸들러가 활성화되지 않아
+#       마운트된 경로에 JSONL 이 생성되지 않는다. Staging 은 점진 도입의
+#       1차 대상이므로 본 override 는 ANTE_LOG_JSONL=1 을 기본 주입한다.
+services:
+  ante:
+    environment:
+      - ANTE_ENV=staging
+      - ANTE_LOG_JSONL=1
+    volumes:
+      # named volume(ante-logs) 대신 호스트 bind mount 로 덮어쓴다.
+      - ${ANTE_STAGING_LOG_DIR:-${HOME}/Projects/ante/logs}:/app/logs

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -17,8 +17,9 @@
 services:
   ante:
     environment:
-      - ANTE_ENV=staging
-      - ANTE_LOG_JSONL=1
+      ANTE_ENV: staging
+      ANTE_LOG_JSONL: "1"
+      # TZ 는 base docker-compose.yml 에서 Asia/Seoul 로 설정됨 — 여기서는 유지.
     volumes:
       # named volume(ante-logs) 대신 호스트 bind mount 로 덮어쓴다.
       - ${ANTE_STAGING_LOG_DIR:-${HOME}/Projects/ante/logs}:/app/logs

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -3,13 +3,16 @@
 # 사용법:
 #   docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d
 #
-# 스펙: docs/specs/logging/05-handlers-and-rotation.md §볼륨 마운트
-#   - Staging: bind mount `~/Projects/ante/logs` → `/app/logs`
-#     감시 에이전트가 Docker 컨테이너 외부(맥미니 호스트)에서 직접
-#     JSONL 파일을 읽어야 하므로 named volume 대신 bind mount 를 사용한다.
+# 스펙:
+#   - docs/specs/logging/05-handlers-and-rotation.md §볼륨 마운트
+#   - docs/superpowers/specs/2026-04-17-staging-environment-design.md §7.2
+#     (감시 에이전트가 `~/ante-staging/logs/ante-*.jsonl` 을 읽음)
+#
+# Staging 은 bind mount 로 호스트 경로를 직접 노출한다. 감시 에이전트가
+# Docker 외부(맥미니 호스트)에서 글롭 패턴으로 JSONL 을 읽어야 하기 때문.
 #
 # 선행 조건:
-#   mkdir -p ~/Projects/ante/logs
+#   mkdir -p ~/ante-staging/logs
 #
 # 참고: ANTE_LOG_JSONL 게이트가 꺼져 있으면 파일 핸들러가 활성화되지 않아
 #       마운트된 경로에 JSONL 이 생성되지 않는다. Staging 은 점진 도입의
@@ -22,4 +25,5 @@ services:
       # TZ 는 base docker-compose.yml 에서 Asia/Seoul 로 설정됨 — 여기서는 유지.
     volumes:
       # named volume(ante-logs) 대신 호스트 bind mount 로 덮어쓴다.
-      - ${ANTE_STAGING_LOG_DIR:-${HOME}/Projects/ante/logs}:/app/logs
+      # 기본 경로는 감시 에이전트 설계 문서 (§7.2) 의 글롭 전제와 일치해야 한다.
+      - ${ANTE_STAGING_LOG_DIR:-${HOME}/ante-staging/logs}:/app/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
       # ANTE_LOG_JSONL=1 게이트가 켜진 경우 컨테이너가 /app/logs 에
       # ante-YYYY-MM-DD.jsonl 파일을 일일 회전 기록하며, 재시작 시 보존된다.
       - ante-logs:/app/logs
+    environment:
+      # 로그 회전 자정 경계의 단일 기준 (05-handlers-and-rotation.md §회전 규칙).
+      # Dockerfile 의 ENV TZ 와 일치해야 한다.
+      TZ: Asia/Seoul
     env_file:
       - config/secrets.env
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,15 @@ services:
       - ./config:/app/config
       - ante-data:/app/data
       - ante-db:/app/db
+      # JSONL 로그 보존용 named volume.
+      # 스펙: docs/specs/logging/05-handlers-and-rotation.md §볼륨 마운트.
+      # ANTE_LOG_JSONL=1 게이트가 켜진 경우 컨테이너가 /app/logs 에
+      # ante-YYYY-MM-DD.jsonl 파일을 일일 회전 기록하며, 재시작 시 보존된다.
+      - ante-logs:/app/logs
     env_file:
       - config/secrets.env
 
 volumes:
   ante-data:
   ante-db:
+  ante-logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       # ante-YYYY-MM-DD.jsonl 파일을 일일 회전 기록하며, 재시작 시 보존된다.
       - ante-logs:/app/logs
     environment:
-      # 로그 회전 자정 경계의 단일 기준 (05-handlers-and-rotation.md §회전 규칙).
-      # Dockerfile 의 ENV TZ 와 일치해야 한다.
+      # 관측성 TZ 일관성 (Dockerfile ENV 와 동일).
+      # 로그 회전 자정 경계는 핸들러가 Asia/Seoul 로 고정하므로 이 값과 무관.
       TZ: Asia/Seoul
     env_file:
       - config/secrets.env

--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -20,8 +20,9 @@ ante/
 ├── .claude/             # Claude Code 설정 + .agent 호환 링크
 ├── Dockerfile           # 프로덕션 Docker 이미지
 ├── Dockerfile.qa        # QA 테스트 Docker 이미지
-├── docker-compose.yml   # 프로덕션 Docker Compose
-├── docker-compose.qa.yml # QA 테스트용 Docker Compose
+├── docker-compose.yml        # 프로덕션 Docker Compose (ante-logs named volume 포함)
+├── docker-compose.qa.yml     # QA 테스트용 Docker Compose
+├── docker-compose.staging.yml # Staging override (JSONL 로그 bind mount, ANTE_ENV/ANTE_LOG_JSONL)
 ├── AGENTS.md            # 개발 Agent 마스터 가이드
 └── CHANGELOG.md         # 변경 이력
 ```

--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -38,7 +38,10 @@ src/ante/
 │   └── log/                     # 시스템 로그 인프라 (JSONL 포맷, fingerprint)
 │       ├── __init__.py
 │       ├── formatter.py         # JsonFormatter — JSONL 직렬화
-│       └── fingerprint.py       # compute_fingerprint() — 예외 dedup 키
+│       ├── fingerprint.py       # compute_fingerprint() — 예외 dedup 키
+│       ├── handlers.py          # DateNamedTimedRotatingFileHandler (no-rename 일일 회전)
+│       ├── safe_logger.py       # AnteLogger, install_safe_logger() (makeRecord 예약 키 정규화)
+│       └── setup.py             # setup_logging() stdout + JSONL 파일 핸들러 구성
 │
 ├── config/
 │   ├── config.py                # ConfigService — 설정 로딩 (system.toml + secrets.env)

--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -38,9 +38,10 @@ src/ante/
 │   ├── database.py              # Database — SQLite WAL 연결 관리
 │   └── log/                     # 시스템 로그 인프라 (JSONL 포맷, fingerprint)
 │       ├── __init__.py
+│       ├── _record_keys.py      # LogRecord 속성 / Ante 예약 키 단일 소스 (runtime probe)
 │       ├── formatter.py         # JsonFormatter — JSONL 직렬화
 │       ├── fingerprint.py       # compute_fingerprint() — 예외 dedup 키
-│       ├── handlers.py          # DateNamedTimedRotatingFileHandler (no-rename 일일 회전)
+│       ├── handlers.py          # DateNamedTimedRotatingFileHandler (KST 자정 no-rename 회전)
 │       ├── safe_logger.py       # AnteLogger, install_safe_logger() (makeRecord 예약 키 정규화)
 │       └── setup.py             # setup_logging() stdout + JSONL 파일 핸들러 구성
 │

--- a/docs/specs/logging/05-handlers-and-rotation.md
+++ b/docs/specs/logging/05-handlers-and-rotation.md
@@ -47,9 +47,11 @@
 
 | 환경 | 마운트 방식 | 경로 |
 |---|---|---|
-| Production | Docker named volume `ante_logs` → `/app/logs` | 재시작 시 보존 |
-| Staging | bind mount `~/Projects/ante/logs` → `/app/logs` | 맥미니 파일시스템 직접 노출, 감시 에이전트 접근 용이 |
+| Production | Docker named volume `ante-logs` → `/app/logs` (`docker-compose.yml`) | 재시작 시 보존 |
+| Staging | bind mount `~/Projects/ante/logs` → `/app/logs` (`docker-compose.staging.yml`, `ANTE_STAGING_LOG_DIR` 로 override 가능) | 맥미니 파일시스템 직접 노출, 감시 에이전트 접근 용이 |
 | QA | 마운트 불필요 | TC 실행 중 휘발, 자동 삭제 |
 | 로컬 개발 | bind mount 또는 마운트 생략 | 개발자 선택 |
 
-Staging이 bind mount인 이유: 감시 에이전트가 Docker 컨테이너 외부(맥미니 호스트)에서 직접 JSONL 파일을 읽어야 하기 때문이다.
+Staging이 bind mount인 이유: 감시 에이전트가 Docker 컨테이너 외부(맥미니 호스트)에서 직접 JSONL 파일을 읽어야 하기 때문이다. Staging override 는 `docker compose -f docker-compose.yml -f docker-compose.staging.yml up` 형식으로 결합하며, `ANTE_ENV=staging` 과 `ANTE_LOG_JSONL=1` 을 기본 주입한다.
+
+Production 볼륨 이름은 기존 저장소 관습(`ante-data`, `ante-db` 하이픈)을 따라 `ante-logs` 로 선언한다(compose 프로젝트 prefix 가 붙어 실제 생성되는 볼륨은 `ante_ante-logs`). `ANTE_LOG_JSONL=1` 게이트는 Production 에서도 점진 도입 원칙에 따라 운영 시점에 `config/secrets.env` 또는 compose `environment:` 로 주입한다. 게이트가 꺼진 상태에서는 파일 핸들러가 생성되지 않아 `ante-logs` 볼륨은 비어 있게 된다.

--- a/docs/specs/logging/05-handlers-and-rotation.md
+++ b/docs/specs/logging/05-handlers-and-rotation.md
@@ -21,7 +21,7 @@
 | 항목 | 값 |
 |---|---|
 | 파일명 | `logs/ante-YYYY-MM-DD.jsonl` (활성 파일명 자체가 날짜를 포함) |
-| 회전 시점 | `when="midnight", utc=False` (Asia/Seoul 자정 기준) |
+| 회전 시점 | **Asia/Seoul 자정**. 핸들러가 `zoneinfo.ZoneInfo("Asia/Seoul")` 을 사용해 코드 레벨에서 TZ 를 고정한다 (호스트/컨테이너 TZ 와 무관) |
 | 회전 방식 | 활성 파일은 날짜를 포함하므로 rename 불필요. 자정에 새 날짜로 `baseFilename` 을 교체하고 새 파일을 연다 |
 | 보관 | 30일 (`backupCount=30`). 초과분은 가장 오래된 파일부터 삭제 |
 | 디렉토리 | 컨테이너 `/app/logs` (named volume 또는 bind mount) |
@@ -48,7 +48,7 @@
 | 환경 | 마운트 방식 | 경로 |
 |---|---|---|
 | Production | Docker named volume `ante-logs` → `/app/logs` (`docker-compose.yml`) | 재시작 시 보존 |
-| Staging | bind mount `~/Projects/ante/logs` → `/app/logs` (`docker-compose.staging.yml`, `ANTE_STAGING_LOG_DIR` 로 override 가능) | 맥미니 파일시스템 직접 노출, 감시 에이전트 접근 용이 |
+| Staging | bind mount `~/ante-staging/logs` → `/app/logs` (`docker-compose.staging.yml`, `ANTE_STAGING_LOG_DIR` 로 override 가능) | 감시 에이전트 설계 (§7.2) 의 글롭 전제와 일치 |
 | QA | 마운트 불필요 | TC 실행 중 휘발, 자동 삭제 |
 | 로컬 개발 | bind mount 또는 마운트 생략 | 개발자 선택 |
 

--- a/docs/specs/logging/05-handlers-and-rotation.md
+++ b/docs/specs/logging/05-handlers-and-rotation.md
@@ -20,17 +20,17 @@
 
 | 항목 | 값 |
 |---|---|
-| 파일명 | `logs/ante-YYYY-MM-DD.jsonl` |
+| 파일명 | `logs/ante-YYYY-MM-DD.jsonl` (활성 파일명 자체가 날짜를 포함) |
 | 회전 시점 | `when="midnight", utc=False` (Asia/Seoul 자정 기준) |
-| 회전 방식 | 현재 파일을 날짜 suffix 붙여 rename, 새 파일 생성 |
-| 보관 | 30일 (`backupCount=30`) |
+| 회전 방식 | 활성 파일은 날짜를 포함하므로 rename 불필요. 자정에 새 날짜로 `baseFilename` 을 교체하고 새 파일을 연다 |
+| 보관 | 30일 (`backupCount=30`). 초과분은 가장 오래된 파일부터 삭제 |
 | 디렉토리 | 컨테이너 `/app/logs` (named volume 또는 bind mount) |
 | 퍼미션 | 0644 (기본) |
 
 ## 회전 동작 세부
 
-1. 자정에 `ante-2026-04-17.jsonl`이 rename되어 새 `ante-2026-04-18.jsonl`이 열린다.
-2. 30일 지난 파일(`ante-2026-03-18.jsonl`)은 자동 삭제된다.
+1. 자정이 지나면 기존 `ante-2026-04-17.jsonl` 은 그대로 두고 (활성 파일명에 이미 날짜가 포함됨), 새 `ante-2026-04-18.jsonl` 을 연다. 이전 날 파일은 마지막 엔트리가 기록된 상태로 남아 감시 에이전트가 안전하게 수집할 수 있다.
+2. `backupCount=30` 을 초과한 가장 오래된 파일부터 삭제된다 (예: 31일째 자정 회전 시 `ante-2026-03-18.jsonl` 이 제거됨).
 3. 압축은 수행하지 않는다. 디스크 압박이 실측되면 후속 반복에서 `TimedRotatingFileHandler.rotator` 후킹으로 도입한다. 자세한 판단 이력은 [08-open-issues.md](08-open-issues.md) §스코프 제외 참조.
 
 ## 실패 처리

--- a/docs/specs/logging/07-implementation.md
+++ b/docs/specs/logging/07-implementation.md
@@ -26,7 +26,7 @@
 | [03-json-schema.md](03-json-schema.md) §직렬화 규칙 (non-finite float) | `src/ante/core/log/formatter.py::_sanitize_for_json`, `json.dumps(..., allow_nan=False)` | `tests/unit/test_log_formatter.py` NaN/Infinity 케이스 | `NaN`/`Infinity` 토큰이 JSONL 로 누출되어 strict 파서가 깨짐 |
 | [04-fingerprint.md](04-fingerprint.md) | `src/ante/core/log/fingerprint.py::compute_fingerprint` | `tests/unit/test_log_fingerprint.py` | 라인번호 의존·설치 경로 의존으로 같은 근본 원인이 다른 키로 기록됨 |
 | [05-handlers-and-rotation.md](05-handlers-and-rotation.md) §회전 규칙 (no-rename) | `src/ante/core/log/handlers.py::DateNamedTimedRotatingFileHandler.doRollover` | `tests/unit/test_log_setup.py` 회전 동작 | 자정에 파일이 rename 되어 외부 파일 감시기(감시 에이전트)가 inode 를 잃음 |
-| [05-handlers-and-rotation.md](05-handlers-and-rotation.md) §회전 규칙 (Asia/Seoul 자정) | `Dockerfile` `ENV TZ=Asia/Seoul`, `docker-compose.yml` `TZ`, `setup_logging` `utc=False` | 수동 검증 (컨테이너 `date` + 파일명) | 호스트/컨테이너 TZ 불일치로 자정 경계 밀림 |
+| [05-handlers-and-rotation.md](05-handlers-and-rotation.md) §회전 규칙 (Asia/Seoul 자정) | `src/ante/core/log/handlers.py` `_KST = ZoneInfo("Asia/Seoul")`, `computeRollover`, `_make_filename` | `tests/unit/test_log_handlers.py` KST 경계 회귀 | 호스트/컨테이너 TZ (Docker, systemd, launchd) 불일치로 자정 경계가 밀림 |
 | [05-handlers-and-rotation.md](05-handlers-and-rotation.md) §볼륨 마운트 | `docker-compose.yml` `ante-logs`, `docker-compose.staging.yml` bind mount | 수동 검증 (`docker compose config`) | 컨테이너 종료 시 로그 유실, staging 감시 에이전트가 파일을 못 읽음 |
 | [06-failure-handling.md](06-failure-handling.md) §파일 핸들러 실패 격리 | `src/ante/core/log/setup.py` try/except + stdout 선등록 | `tests/unit/test_log_setup.py` 디스크/권한 실패 케이스 | 파일 핸들러 초기화 실패가 부팅을 차단 |
 

--- a/docs/specs/logging/07-implementation.md
+++ b/docs/specs/logging/07-implementation.md
@@ -9,8 +9,26 @@
 | `JsonFormatter` | `src/ante/core/log/formatter.py` (신설) | `logging.Formatter` 상속, `format()`이 [03-json-schema.md](03-json-schema.md)의 스키마에 따라 JSON 직렬화 |
 | `compute_fingerprint` | `src/ante/core/log/fingerprint.py` (신설) | Exception과 traceback 객체에서 [04-fingerprint.md](04-fingerprint.md) 규칙에 따라 키 생성 |
 | `setup_logging` | `src/ante/core/log/setup.py` (신설) | 핸들러 구성 함수. `config`, 환경변수, 로그 디렉토리를 입력으로 받아 `logging` 루트 로거에 핸들러 부착 |
+| `AnteLogger` / `install_safe_logger` | `src/ante/core/log/safe_logger.py` (신설) | 예약 키가 `extra=` 로 주입되어도 `makeRecord` KeyError 없이 무시되도록 Logger 서브클래스 등록 |
+| `DateNamedTimedRotatingFileHandler` | `src/ante/core/log/handlers.py` (신설) | 활성 파일명에 `YYYY-MM-DD` 를 포함시켜 자정 경계에서 **파일명 교체**로 회전 (이름 바꾸기 없음) |
+| 예약 키 단일 소스 | `src/ante/core/log/_record_keys.py` (신설) | `LOGRECORD_ATTRS` 는 런타임 프로브로 추출, `ANTE_RESERVED` 는 JSONL 스펙 필드. formatter/safe_logger 가 공유 |
 | 통합 지점 | `src/ante/main.py` `_init_core` | 기존 `logging.basicConfig(...)`을 `setup_logging(config)`으로 교체 |
-| 테스트 | `tests/unit/test_log_formatter.py`, `tests/unit/test_log_setup.py` | 스키마·fingerprint·이중 핸들러 동작 회귀 검증 |
+| 테스트 | `tests/unit/test_log_formatter.py`, `tests/unit/test_log_setup.py`, `tests/unit/test_log_safe_logger.py` | 스키마·fingerprint·이중 핸들러·예약 키 방어 회귀 검증 |
+
+## 스펙 § → 코드 → 회귀 테스트 매트릭스
+
+같은 리스크 클래스의 반복 회귀를 막기 위한 고정 매핑이다. 스펙 문단을 바꿀 때
+는 대응 코드·테스트를 함께 갱신한다. PR 설명에는 해당 행을 인용한다.
+
+| 스펙 | 코드 | 회귀 테스트 | 차단 대상 |
+|---|---|---|---|
+| [03-json-schema.md](03-json-schema.md) §예약어 처리 | `src/ante/core/log/safe_logger.py::AnteLogger.makeRecord`, `_record_keys.LOGRECORD_ATTRS`, `formatter._LOGRECORD_BUILTIN` (같은 소스) | `tests/unit/test_log_safe_logger.py`, `tests/unit/test_log_formatter.py::test_reserved_keys_ignored_from_extra` | `extra={"msg": ...}` 류 KeyError, Python 버전별 `taskName` 누락 |
+| [03-json-schema.md](03-json-schema.md) §직렬화 규칙 (non-finite float) | `src/ante/core/log/formatter.py::_sanitize_for_json`, `json.dumps(..., allow_nan=False)` | `tests/unit/test_log_formatter.py` NaN/Infinity 케이스 | `NaN`/`Infinity` 토큰이 JSONL 로 누출되어 strict 파서가 깨짐 |
+| [04-fingerprint.md](04-fingerprint.md) | `src/ante/core/log/fingerprint.py::compute_fingerprint` | `tests/unit/test_log_fingerprint.py` | 라인번호 의존·설치 경로 의존으로 같은 근본 원인이 다른 키로 기록됨 |
+| [05-handlers-and-rotation.md](05-handlers-and-rotation.md) §회전 규칙 (no-rename) | `src/ante/core/log/handlers.py::DateNamedTimedRotatingFileHandler.doRollover` | `tests/unit/test_log_setup.py` 회전 동작 | 자정에 파일이 rename 되어 외부 파일 감시기(감시 에이전트)가 inode 를 잃음 |
+| [05-handlers-and-rotation.md](05-handlers-and-rotation.md) §회전 규칙 (Asia/Seoul 자정) | `Dockerfile` `ENV TZ=Asia/Seoul`, `docker-compose.yml` `TZ`, `setup_logging` `utc=False` | 수동 검증 (컨테이너 `date` + 파일명) | 호스트/컨테이너 TZ 불일치로 자정 경계 밀림 |
+| [05-handlers-and-rotation.md](05-handlers-and-rotation.md) §볼륨 마운트 | `docker-compose.yml` `ante-logs`, `docker-compose.staging.yml` bind mount | 수동 검증 (`docker compose config`) | 컨테이너 종료 시 로그 유실, staging 감시 에이전트가 파일을 못 읽음 |
+| [06-failure-handling.md](06-failure-handling.md) §파일 핸들러 실패 격리 | `src/ante/core/log/setup.py` try/except + stdout 선등록 | `tests/unit/test_log_setup.py` 디스크/권한 실패 케이스 | 파일 핸들러 초기화 실패가 부팅을 차단 |
 
 ## 네임스페이스 선택
 

--- a/src/ante/core/log/__init__.py
+++ b/src/ante/core/log/__init__.py
@@ -1,4 +1,5 @@
 from .fingerprint import compute_fingerprint
 from .formatter import JsonFormatter
+from .setup import setup_logging
 
-__all__ = ["JsonFormatter", "compute_fingerprint"]
+__all__ = ["JsonFormatter", "compute_fingerprint", "setup_logging"]

--- a/src/ante/core/log/__init__.py
+++ b/src/ante/core/log/__init__.py
@@ -1,11 +1,14 @@
 from .fingerprint import compute_fingerprint
 from .formatter import JsonFormatter
 from .handlers import DateNamedTimedRotatingFileHandler
+from .safe_logger import AnteLogger, install_safe_logger
 from .setup import setup_logging
 
 __all__ = [
+    "AnteLogger",
     "DateNamedTimedRotatingFileHandler",
     "JsonFormatter",
     "compute_fingerprint",
+    "install_safe_logger",
     "setup_logging",
 ]

--- a/src/ante/core/log/__init__.py
+++ b/src/ante/core/log/__init__.py
@@ -1,5 +1,11 @@
 from .fingerprint import compute_fingerprint
 from .formatter import JsonFormatter
+from .handlers import DateNamedTimedRotatingFileHandler
 from .setup import setup_logging
 
-__all__ = ["JsonFormatter", "compute_fingerprint", "setup_logging"]
+__all__ = [
+    "DateNamedTimedRotatingFileHandler",
+    "JsonFormatter",
+    "compute_fingerprint",
+    "setup_logging",
+]

--- a/src/ante/core/log/_record_keys.py
+++ b/src/ante/core/log/_record_keys.py
@@ -1,0 +1,40 @@
+"""LogRecord 속성 / Ante 예약 키 단일 소스.
+
+Python 버전별 ``LogRecord.__init__`` 이 설정하는 속성 집합이 다르다
+(예: 3.12 부터 ``taskName`` 추가). formatter 와 safe_logger 가 각자 하드코딩된
+목록을 유지하면 버전 업그레이드 시 한쪽만 수정되어 드리프트가 발생한다.
+
+이 모듈은 **런타임 프로브**로 LogRecord 속성을 추출해 단일 소스를 제공한다.
+formatter 와 safe_logger 는 반드시 이 모듈의 상수를 임포트해 사용한다.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+def _probe_logrecord_attrs() -> frozenset[str]:
+    """실제 LogRecord 인스턴스의 ``__dict__`` 키를 추출한다.
+
+    ``getMessage()`` / ``asctime`` 은 ``LogRecord.__init__`` 이 설정하지 않지만
+    ``Formatter.format()`` 이 동적으로 주입하는 속성이므로 포함한다.
+    """
+    probe = logging.LogRecord(
+        name="_probe",
+        level=logging.INFO,
+        pathname="_probe",
+        lineno=0,
+        msg="_probe",
+        args=(),
+        exc_info=None,
+    )
+    return frozenset(probe.__dict__.keys()) | {"message", "asctime"}
+
+
+LOGRECORD_ATTRS: frozenset[str] = _probe_logrecord_attrs()
+"""LogRecord 가 점유하는 모든 속성 이름 집합 (런타임 Python 버전 기준)."""
+
+ANTE_RESERVED: frozenset[str] = frozenset(
+    {"ts", "level", "logger", "msg", "env", "exc"}
+)
+"""JSONL 스펙 (`03-json-schema.md` §예약어 처리) 의 Ante 표준 필드."""

--- a/src/ante/core/log/formatter.py
+++ b/src/ante/core/log/formatter.py
@@ -11,9 +11,10 @@ import os
 import traceback
 from datetime import UTC, datetime
 
+from ._record_keys import ANTE_RESERVED as _RESERVED
+from ._record_keys import LOGRECORD_ATTRS as _LOGRECORD_BUILTIN
 from .fingerprint import compute_fingerprint
 
-_RESERVED = {"ts", "level", "logger", "env", "exc"}
 _STANDARD_EXTRA = (
     "account_id",
     "bot_id",
@@ -23,31 +24,6 @@ _STANDARD_EXTRA = (
     "request_id",
     "extra",
 )
-_LOGRECORD_BUILTIN = {
-    "args",
-    "asctime",
-    "created",
-    "exc_info",
-    "exc_text",
-    "filename",
-    "funcName",
-    "levelname",
-    "levelno",
-    "lineno",
-    "message",
-    "module",
-    "msecs",
-    "msg",
-    "name",
-    "pathname",
-    "process",
-    "processName",
-    "relativeCreated",
-    "stack_info",
-    "taskName",
-    "thread",
-    "threadName",
-}
 
 
 def _sanitize_for_json(value: object) -> object:

--- a/src/ante/core/log/handlers.py
+++ b/src/ante/core/log/handlers.py
@@ -1,0 +1,120 @@
+"""커스텀 로그 핸들러.
+
+``docs/specs/logging/05-handlers-and-rotation.md`` 의 파일명 계약
+(``ante-YYYY-MM-DD.jsonl``) 과 일일 자정 회전을 만족하는
+``TimedRotatingFileHandler`` 서브클래스를 제공한다.
+
+표준 ``TimedRotatingFileHandler`` 는 활성 파일을 ``ante.jsonl`` 로 유지하고
+회전 시 ``ante.jsonl.YYYY-MM-DD`` 로 rename 한다. 본 핸들러는 활성 파일 자체에
+날짜를 포함해 ``ante-YYYY-MM-DD.jsonl`` 형태를 유지한다. 이는 staging watcher
+글롭(``~/ante-staging/logs/ante-*.jsonl``)의 전제조건이다.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import os
+import time
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+
+
+class DateNamedTimedRotatingFileHandler(TimedRotatingFileHandler):
+    """활성 파일명에 날짜를 직접 포함하는 일일 회전 핸들러.
+
+    파일명 패턴: ``{prefix}-YYYY-MM-DD{file_suffix}`` (예: ``ante-2026-04-19.jsonl``).
+    자정 회전 시 기존 파일은 그대로 두고(이미 날짜가 파일명에 포함됨),
+    새 날짜를 사용해 ``baseFilename`` 을 갱신한 뒤 새 파일을 연다.
+    ``backupCount`` 를 초과하면 가장 오래된 날짜부터 삭제한다.
+    """
+
+    def __init__(
+        self,
+        log_dir: str | os.PathLike[str],
+        *,
+        prefix: str = "ante",
+        file_suffix: str = ".jsonl",
+        backup_count: int = 30,
+        utc: bool = False,
+        encoding: str | None = "utf-8",
+        delay: bool = False,
+    ) -> None:
+        self._log_dir = Path(log_dir)
+        self._log_dir.mkdir(parents=True, exist_ok=True)
+        self._prefix = prefix
+        self._file_suffix = file_suffix
+        self._utc = utc
+
+        super().__init__(
+            self._make_filename(),
+            when="midnight",
+            utc=utc,
+            backupCount=backup_count,
+            encoding=encoding,
+            delay=delay,
+        )
+
+    def _make_filename(self) -> str:
+        """현재 날짜 기준 활성 파일 경로를 반환한다."""
+        if self._utc:
+            now = _dt.datetime.now(_dt.UTC)
+        else:
+            now = _dt.datetime.now()
+        date_str = now.strftime("%Y-%m-%d")
+        return str(self._log_dir / f"{self._prefix}-{date_str}{self._file_suffix}")
+
+    def doRollover(self) -> None:  # noqa: N802 — stdlib 메서드 오버라이드
+        """자정 회전: 기존 파일은 유지하고 새 날짜 파일을 연다.
+
+        표준 구현과 달리 ``baseFilename`` 을 rename 하지 않는다. 파일명 자체에
+        날짜가 포함되어 있어 현재 파일은 그대로 두고 새 날짜로 핸들을 전환하면
+        된다.
+        """
+        if self.stream is not None:
+            self.stream.close()
+            self.stream = None
+
+        self.baseFilename = self._make_filename()
+        if not self.delay:
+            self.stream = self._open()
+
+        # 다음 자정 회전 시각 계산 (stdlib 구현과 동일)
+        current_time = int(time.time())
+        new_rollover_at = self.computeRollover(current_time)
+        while new_rollover_at <= current_time:
+            new_rollover_at += self.interval
+        self.rolloverAt = new_rollover_at
+
+        # backupCount 초과 시 오래된 파일 삭제
+        if self.backupCount > 0:
+            for path in self._files_to_delete():
+                try:
+                    os.remove(path)
+                except OSError:
+                    # 로깅 내부 실패는 무시 (스펙 §실패 처리)
+                    pass
+
+    def _files_to_delete(self) -> list[str]:
+        """``backupCount`` 초과분 중 가장 오래된 파일 경로를 반환한다."""
+        pattern = f"{self._prefix}-*{self._file_suffix}"
+        candidates = sorted(self._log_dir.glob(pattern))
+        # 현재 활성 파일은 제외
+        try:
+            current = Path(self.baseFilename).resolve()
+        except OSError:
+            current = Path(self.baseFilename)
+        filtered: list[Path] = []
+        for p in candidates:
+            try:
+                if p.resolve() == current:
+                    continue
+            except OSError:
+                if str(p) == str(current):
+                    continue
+            filtered.append(p)
+
+        if len(filtered) <= self.backupCount:
+            return []
+        # 가장 오래된 것부터 초과분 반환
+        excess = len(filtered) - self.backupCount
+        return [str(p) for p in filtered[:excess]]

--- a/src/ante/core/log/handlers.py
+++ b/src/ante/core/log/handlers.py
@@ -1,13 +1,18 @@
 """커스텀 로그 핸들러.
 
 ``docs/specs/logging/05-handlers-and-rotation.md`` 의 파일명 계약
-(``ante-YYYY-MM-DD.jsonl``) 과 일일 자정 회전을 만족하는
+(``ante-YYYY-MM-DD.jsonl``) 과 **Asia/Seoul 자정** 일일 회전을 만족하는
 ``TimedRotatingFileHandler`` 서브클래스를 제공한다.
 
 표준 ``TimedRotatingFileHandler`` 는 활성 파일을 ``ante.jsonl`` 로 유지하고
 회전 시 ``ante.jsonl.YYYY-MM-DD`` 로 rename 한다. 본 핸들러는 활성 파일 자체에
 날짜를 포함해 ``ante-YYYY-MM-DD.jsonl`` 형태를 유지한다. 이는 staging watcher
-글롭(``~/ante-staging/logs/ante-*.jsonl``)의 전제조건이다.
+글롭(``ante-*.jsonl``)의 전제조건이다.
+
+또한 표준 구현은 회전 자정 경계가 호스트/컨테이너 TZ 에 의존한다 (``utc=True`` →
+UTC 자정, ``utc=False`` → 로컬 자정). 본 핸들러는 배포 방식(Docker, systemd,
+launchd) 과 무관하게 스펙 계약을 보장하기 위해 **코드 레벨에서 Asia/Seoul** 을
+강제한다 — ``computeRollover`` 와 파일명 생성 모두 KST 기준.
 """
 
 from __future__ import annotations
@@ -17,15 +22,23 @@ import os
 import time
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
+from zoneinfo import ZoneInfo
+
+_KST = ZoneInfo("Asia/Seoul")
+"""회전 자정 경계의 단일 기준 (스펙 §회전 규칙).
+
+호스트 TZ/컨테이너 ENV 와 독립. 지원 배포 경로(Docker, PyPI+systemd,
+launchd) 어느 쪽이든 동일한 시각에 회전한다.
+"""
 
 
 class DateNamedTimedRotatingFileHandler(TimedRotatingFileHandler):
-    """활성 파일명에 날짜를 직접 포함하는 일일 회전 핸들러.
+    """활성 파일명에 날짜를 직접 포함하는 Asia/Seoul 자정 회전 핸들러.
 
     파일명 패턴: ``{prefix}-YYYY-MM-DD{file_suffix}`` (예: ``ante-2026-04-19.jsonl``).
-    자정 회전 시 기존 파일은 그대로 두고(이미 날짜가 파일명에 포함됨),
-    새 날짜를 사용해 ``baseFilename`` 을 갱신한 뒤 새 파일을 연다.
-    ``backupCount`` 를 초과하면 가장 오래된 날짜부터 삭제한다.
+    날짜는 **Asia/Seoul** 기준. 자정 회전 시 기존 파일은 그대로 두고(이미 날짜가
+    파일명에 포함됨), 새 날짜를 사용해 ``baseFilename`` 을 갱신한 뒤 새 파일을
+    연다. ``backupCount`` 를 초과하면 가장 오래된 날짜부터 삭제한다.
     """
 
     def __init__(
@@ -35,7 +48,6 @@ class DateNamedTimedRotatingFileHandler(TimedRotatingFileHandler):
         prefix: str = "ante",
         file_suffix: str = ".jsonl",
         backup_count: int = 30,
-        utc: bool = False,
         encoding: str | None = "utf-8",
         delay: bool = False,
     ) -> None:
@@ -43,25 +55,41 @@ class DateNamedTimedRotatingFileHandler(TimedRotatingFileHandler):
         self._log_dir.mkdir(parents=True, exist_ok=True)
         self._prefix = prefix
         self._file_suffix = file_suffix
-        self._utc = utc
 
         super().__init__(
             self._make_filename(),
             when="midnight",
-            utc=utc,
+            # utc= 은 stdlib 내부 computeRollover/파일명 구현에서만 참조된다.
+            # 본 클래스는 두 메서드를 모두 오버라이드해 KST 를 강제하므로
+            # 부모 클래스에 넘기는 값은 의미가 없다. False 로 명시한다.
+            utc=False,
             backupCount=backup_count,
             encoding=encoding,
             delay=delay,
         )
 
+    @staticmethod
+    def _now_kst() -> _dt.datetime:
+        """현재 시각을 Asia/Seoul tzinfo 로 반환한다."""
+        return _dt.datetime.now(_KST)
+
     def _make_filename(self) -> str:
-        """현재 날짜 기준 활성 파일 경로를 반환한다."""
-        if self._utc:
-            now = _dt.datetime.now(_dt.UTC)
-        else:
-            now = _dt.datetime.now()
-        date_str = now.strftime("%Y-%m-%d")
+        """현재 날짜(Asia/Seoul) 기준 활성 파일 경로를 반환한다."""
+        date_str = self._now_kst().strftime("%Y-%m-%d")
         return str(self._log_dir / f"{self._prefix}-{date_str}{self._file_suffix}")
+
+    def computeRollover(self, currentTime: float) -> int:  # noqa: N802,N803 — stdlib 시그니처
+        """다음 Asia/Seoul 자정(Unix epoch 초) 을 반환한다.
+
+        stdlib 구현은 ``utc`` 플래그에 따라 UTC 또는 local TZ 자정을 계산한다.
+        배포 경로마다 TZ 가 달라질 수 있으므로 여기서 KST 를 명시적으로 고정해
+        스펙 계약을 코드 레벨에서 보장한다.
+        """
+        now = _dt.datetime.fromtimestamp(currentTime, tz=_KST)
+        next_midnight = (now + _dt.timedelta(days=1)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        return int(next_midnight.timestamp())
 
     def doRollover(self) -> None:  # noqa: N802 — stdlib 메서드 오버라이드
         """자정 회전: 기존 파일은 유지하고 새 날짜 파일을 연다.
@@ -78,7 +106,7 @@ class DateNamedTimedRotatingFileHandler(TimedRotatingFileHandler):
         if not self.delay:
             self.stream = self._open()
 
-        # 다음 자정 회전 시각 계산 (stdlib 구현과 동일)
+        # 다음 자정 회전 시각 계산 (KST 기준, 위 computeRollover 오버라이드 경유)
         current_time = int(time.time())
         new_rollover_at = self.computeRollover(current_time)
         while new_rollover_at <= current_time:

--- a/src/ante/core/log/safe_logger.py
+++ b/src/ante/core/log/safe_logger.py
@@ -1,0 +1,163 @@
+"""Reserved-key 를 안전하게 처리하는 Logger 서브클래스.
+
+stdlib ``Logger.makeRecord()`` 는 ``extra`` 의 키가 ``LogRecord`` 속성과
+충돌하면 ``KeyError("Attempt to overwrite ... in LogRecord")`` 를 던진다.
+그러나 ``docs/specs/logging/03-json-schema.md`` §예약어 처리 는 표준 필드
+(``ts``, ``level``, ``logger``, ``msg``, ``env``, ``exc``) 가 ``extra=`` 로
+주입되어도 무시되어야 한다고 규정한다.
+
+즉 formatter 단계의 필터링은 너무 늦다 — ``msg`` 같은 LogRecord 생성자가
+직접 설정하는 속성은 ``makeRecord`` 단계에서 KeyError 가 먼저 난다.
+이 모듈은 makeRecord 단계에서 위험 키를 선제적으로 제거해 호출자의
+실수로부터 로그 구조를 보호한다.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+# LogRecord.__init__ 가 설정하는 모든 속성. 이들이 extra 에 포함되면
+# stdlib makeRecord 가 KeyError 를 던진다.
+_LOGRECORD_RESERVED: frozenset[str] = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "message",
+        "asctime",
+    }
+)
+
+# Ante JSONL 스펙의 표준 필드 (03-json-schema.md §예약어 처리).
+# LogRecord 속성과 직접 충돌하지는 않지만, formatter 가 표준 값을 보장하므로
+# extra 로 들어와도 무시한다.
+_ANTE_RESERVED: frozenset[str] = frozenset(
+    {"ts", "level", "logger", "msg", "env", "exc"}
+)
+
+
+def _sanitize_extra(extra: dict[str, Any] | None) -> dict[str, Any] | None:
+    """예약 키 충돌을 제거한 extra dict 반환.
+
+    - LogRecord 속성과 겹치는 키(``msg``, ``args``, ``name`` 등): 제거
+      (formatter 가 표준 값을 생성한다).
+    - Ante 예약 키 중 LogRecord 속성이 아닌 키(``ts``, ``env``, ``exc`` 등):
+      제거 (formatter 가 표준 값을 생성한다).
+
+    제거 대신 ``extra`` 하위로 옮기지 않는다 — 호출자의 실수를 무시하는 것이
+    스펙 동작이다.
+    """
+    if not extra:
+        return extra
+    cleaned: dict[str, Any] = {}
+    for key, val in extra.items():
+        if key in _LOGRECORD_RESERVED or key in _ANTE_RESERVED:
+            # 무시 (스펙: 호출자 실수로부터 로그 구조 보호)
+            continue
+        cleaned[key] = val
+    return cleaned
+
+
+def _safe_make_record(
+    self: logging.Logger,
+    name: str,
+    level: int,
+    fn: str,
+    lno: int,
+    msg: object,
+    args: Any,
+    exc_info: Any,
+    func: str | None = None,
+    extra: dict[str, Any] | None = None,
+    sinfo: str | None = None,
+) -> logging.LogRecord:
+    """``Logger.makeRecord`` 대체 구현.
+
+    ``extra`` 의 위험 키를 선제 정규화한 뒤 stdlib 원본 구현에 위임한다.
+
+    클래스 상속이 아니라 bound-method 교체 방식도 지원하기 위해 평범한
+    함수로 정의한다 (``super()`` 는 서브클래스 mapping 에 의존하므로
+    bound-method 교체 시 ``TypeError`` 가 발생한다).
+    """
+    return logging.Logger.makeRecord(
+        self,
+        name,
+        level,
+        fn,
+        lno,
+        msg,
+        args,
+        exc_info,
+        func,
+        _sanitize_extra(extra),
+        sinfo,
+    )
+
+
+class AnteLogger(logging.Logger):
+    """예약 키 안전 처리 Logger."""
+
+    def makeRecord(  # noqa: N802 — stdlib 메서드 오버라이드
+        self,
+        name: str,
+        level: int,
+        fn: str,
+        lno: int,
+        msg: object,
+        args: Any,
+        exc_info: Any,
+        func: str | None = None,
+        extra: dict[str, Any] | None = None,
+        sinfo: str | None = None,
+    ) -> logging.LogRecord:
+        return _safe_make_record(
+            self, name, level, fn, lno, msg, args, exc_info, func, extra, sinfo
+        )
+
+
+def install_safe_logger() -> None:
+    """전역 Logger 클래스를 ``AnteLogger`` 로 등록한다.
+
+    - 이후 ``logging.getLogger(name)`` 호출은 ``AnteLogger`` 인스턴스를 반환.
+    - root logger 는 별도 ``RootLogger`` 인스턴스이므로 ``makeRecord`` 를
+      바운드 메서드로 직접 교체한다.
+    - 이미 캐시된 logger 들은 ``manager.loggerDict`` 에 남아있으므로 그들도
+      같은 방식으로 교체한다.
+
+    재호출해도 안전하다(멱등).
+    """
+    logging.setLoggerClass(AnteLogger)
+
+    # root logger 의 makeRecord 를 patch — 별도 RootLogger 인스턴스라
+    # setLoggerClass 만으로는 교체되지 않는다.
+    logging.root.makeRecord = _safe_make_record.__get__(  # type: ignore[method-assign]
+        logging.root, type(logging.root)
+    )
+
+    # 이미 만들어진 logger 들도 patch (Logger 인스턴스만 — PlaceHolder 제외).
+    # AnteLogger 인스턴스는 makeRecord 를 이미 오버라이드하므로 건너뛴다.
+    for existing in logging.Logger.manager.loggerDict.values():
+        if isinstance(existing, logging.Logger) and not isinstance(
+            existing, AnteLogger
+        ):
+            existing.makeRecord = _safe_make_record.__get__(  # type: ignore[method-assign]
+                existing, type(existing)
+            )

--- a/src/ante/core/log/safe_logger.py
+++ b/src/ante/core/log/safe_logger.py
@@ -17,41 +17,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-# LogRecord.__init__ 가 설정하는 모든 속성. 이들이 extra 에 포함되면
-# stdlib makeRecord 가 KeyError 를 던진다.
-_LOGRECORD_RESERVED: frozenset[str] = frozenset(
-    {
-        "name",
-        "msg",
-        "args",
-        "levelname",
-        "levelno",
-        "pathname",
-        "filename",
-        "module",
-        "exc_info",
-        "exc_text",
-        "stack_info",
-        "lineno",
-        "funcName",
-        "created",
-        "msecs",
-        "relativeCreated",
-        "thread",
-        "threadName",
-        "processName",
-        "process",
-        "message",
-        "asctime",
-    }
-)
-
-# Ante JSONL 스펙의 표준 필드 (03-json-schema.md §예약어 처리).
-# LogRecord 속성과 직접 충돌하지는 않지만, formatter 가 표준 값을 보장하므로
-# extra 로 들어와도 무시한다.
-_ANTE_RESERVED: frozenset[str] = frozenset(
-    {"ts", "level", "logger", "msg", "env", "exc"}
-)
+from ._record_keys import ANTE_RESERVED as _ANTE_RESERVED
+from ._record_keys import LOGRECORD_ATTRS as _LOGRECORD_RESERVED
 
 
 def _sanitize_extra(extra: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/src/ante/core/log/setup.py
+++ b/src/ante/core/log/setup.py
@@ -60,7 +60,6 @@ def setup_logging(config: Any) -> None:
                 prefix="ante",
                 file_suffix=".jsonl",
                 backup_count=30,
-                utc=False,
             )
             file_handler.setFormatter(JsonFormatter())
             root.addHandler(file_handler)

--- a/src/ante/core/log/setup.py
+++ b/src/ante/core/log/setup.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 from typing import Any
 
 from .formatter import JsonFormatter
+from .handlers import DateNamedTimedRotatingFileHandler
 
 
 def setup_logging(config: Any) -> None:
@@ -22,7 +22,9 @@ def setup_logging(config: Any) -> None:
 
     - stdout: 사람 관찰용 기존 포맷 유지.
     - 파일 JSONL: ``ANTE_LOG_JSONL=1`` 이 설정된 경우에만 활성화,
-      ``logs/ante.jsonl`` 에 ``TimedRotatingFileHandler`` 로 일일 회전.
+      ``logs/ante-YYYY-MM-DD.jsonl`` 에 일일 자정 회전.
+    - 파일 핸들러 초기화 실패(디스크 가득, 권한 문제 등) 시 예외를 삼키고
+      stdout 핸들러만 유지한다 (스펙 §실패 처리).
     """
     root = logging.getLogger()
     log_level = config.get("system.log_level", "INFO")
@@ -32,7 +34,8 @@ def setup_logging(config: Any) -> None:
     for h in list(root.handlers):
         root.removeHandler(h)
 
-    # stdout 핸들러 (기존 포맷 유지 — 사람 관찰용)
+    # stdout 핸들러 (기존 포맷 유지 — 사람 관찰용).
+    # 파일 핸들러 초기화 이전에 등록해 이후 실패 시에도 stdout 로깅이 살아있다.
     stdout_handler = logging.StreamHandler(sys.stdout)
     stdout_handler.setFormatter(
         logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
@@ -41,14 +44,20 @@ def setup_logging(config: Any) -> None:
 
     # JSONL 파일 핸들러 (환경변수 게이트)
     if os.environ.get("ANTE_LOG_JSONL") == "1":
-        log_dir = Path("logs")
-        log_dir.mkdir(parents=True, exist_ok=True)
-        file_handler = TimedRotatingFileHandler(
-            log_dir / "ante.jsonl",
-            when="midnight",
-            utc=False,
-            backupCount=30,
-        )
-        file_handler.suffix = "%Y-%m-%d"
-        file_handler.setFormatter(JsonFormatter())
-        root.addHandler(file_handler)
+        try:
+            log_dir = Path("logs")
+            log_dir.mkdir(parents=True, exist_ok=True)
+            file_handler = DateNamedTimedRotatingFileHandler(
+                log_dir,
+                prefix="ante",
+                file_suffix=".jsonl",
+                backup_count=30,
+                utc=False,
+            )
+            file_handler.setFormatter(JsonFormatter())
+            root.addHandler(file_handler)
+        except Exception as err:  # noqa: BLE001 — 로깅 실패는 전체 흡수
+            # 부팅 차단을 막기 위해 예외를 흡수하고 stdout 핸들러만 유지한다.
+            logging.getLogger(__name__).warning(
+                "JSONL 파일 핸들러 초기화 실패 — stdout 전용으로 계속 진행: %s", err
+            )

--- a/src/ante/core/log/setup.py
+++ b/src/ante/core/log/setup.py
@@ -1,0 +1,54 @@
+"""시스템 로깅 핸들러 구성.
+
+`docs/specs/logging/05-handlers-and-rotation.md` 및
+`docs/specs/logging/07-implementation.md` 에 정의된 이중 핸들러(stdout 평문 +
+환경변수 게이트 기반 JSONL 파일)를 구성한다.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+from typing import Any
+
+from .formatter import JsonFormatter
+
+
+def setup_logging(config: Any) -> None:
+    """stdout 평문 + (게이트 시) 파일 JSONL 이중 핸들러 구성.
+
+    - stdout: 사람 관찰용 기존 포맷 유지.
+    - 파일 JSONL: ``ANTE_LOG_JSONL=1`` 이 설정된 경우에만 활성화,
+      ``logs/ante.jsonl`` 에 ``TimedRotatingFileHandler`` 로 일일 회전.
+    """
+    root = logging.getLogger()
+    log_level = config.get("system.log_level", "INFO")
+    root.setLevel(getattr(logging, log_level))
+
+    # 기존 핸들러 제거 (재호출 시 중복 방지)
+    for h in list(root.handlers):
+        root.removeHandler(h)
+
+    # stdout 핸들러 (기존 포맷 유지 — 사람 관찰용)
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(
+        logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+    )
+    root.addHandler(stdout_handler)
+
+    # JSONL 파일 핸들러 (환경변수 게이트)
+    if os.environ.get("ANTE_LOG_JSONL") == "1":
+        log_dir = Path("logs")
+        log_dir.mkdir(parents=True, exist_ok=True)
+        file_handler = TimedRotatingFileHandler(
+            log_dir / "ante.jsonl",
+            when="midnight",
+            utc=False,
+            backupCount=30,
+        )
+        file_handler.suffix = "%Y-%m-%d"
+        file_handler.setFormatter(JsonFormatter())
+        root.addHandler(file_handler)

--- a/src/ante/core/log/setup.py
+++ b/src/ante/core/log/setup.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from .formatter import JsonFormatter
 from .handlers import DateNamedTimedRotatingFileHandler
+from .safe_logger import install_safe_logger
 
 
 def setup_logging(config: Any) -> None:
@@ -25,7 +26,14 @@ def setup_logging(config: Any) -> None:
       ``logs/ante-YYYY-MM-DD.jsonl`` 에 일일 자정 회전.
     - 파일 핸들러 초기화 실패(디스크 가득, 권한 문제 등) 시 예외를 삼키고
       stdout 핸들러만 유지한다 (스펙 §실패 처리).
+    - 예약 키(``ts``, ``level``, ``logger``, ``msg``, ``env``, ``exc`` 및
+      기타 LogRecord 속성)가 ``extra=`` 로 주입되어도 KeyError 없이 무시되도록
+      ``AnteLogger`` 를 전역 Logger 클래스로 설치한다
+      (스펙 ``03-json-schema.md`` §예약어 처리).
     """
+    # 예약 키 KeyError 방지 — 반드시 핸들러 구성 이전에 수행.
+    install_safe_logger()
+
     root = logging.getLogger()
     log_level = config.get("system.log_level", "INFO")
     root.setLevel(getattr(logging, log_level))

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -113,11 +113,10 @@ async def _init_core(s: Services) -> None:
     s.config = Config.load()
     s.config.validate()
 
+    from ante.core.log import setup_logging
+
+    setup_logging(s.config)
     log_level = s.config.get("system.log_level", "INFO")
-    logging.basicConfig(
-        level=getattr(logging, log_level),
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-    )
     logger.info("Ante 시작")
 
     # Database

--- a/tests/unit/test_log_formatter.py
+++ b/tests/unit/test_log_formatter.py
@@ -161,8 +161,17 @@ def test_non_dict_extra_with_nonstandard_keys_merges_only_dict(formatter):
 
 
 def test_reserved_keys_ignored_from_extra(monkeypatch):
-    """예약 키가 실제 logger.error() 경로로 전달되어도 표준 값이 유지된다."""
+    """예약 키가 실제 logger.error() 경로로 전달되어도 표준 값이 유지된다.
+
+    ``msg`` 는 LogRecord 생성자가 직접 설정하는 속성이라 stdlib makeRecord 가
+    KeyError 를 던진다. ``install_safe_logger()`` 가 이를 제거하여 formatter
+    단계에서 표준 값이 그대로 유지되는지 검증한다.
+    """
     import io
+
+    from ante.core.log import install_safe_logger
+
+    install_safe_logger()
 
     monkeypatch.setenv("ANTE_ENV", "staging")
 
@@ -175,23 +184,32 @@ def test_reserved_keys_ignored_from_extra(monkeypatch):
     logger.propagate = False
 
     try:
-        # Ante 예약 키(ts, env, exc)를 extra로 전달: makeRecord()를 통과하지만
-        # formatter가 payload 최상위 표준 값으로 덮어쓰지 않고 extra 하위로도
-        # 새어나가지 않아야 한다.
+        # Ante 예약 키(ts, level, logger, msg, env, exc) 를 모두 extra 로 전달:
+        # - msg 는 LogRecord 속성과 충돌 → AnteLogger 가 makeRecord 단계에서 제거
+        # - ts/env/exc 등은 formatter 가 표준 값으로 덮어씀
+        # 어느 쪽이든 호출이 예외 없이 성공하고 표준 값이 유지되어야 한다.
         logger.error(
             "hello",
-            extra={"ts": "FAKE_TS", "env": "fake-env", "exc": "fake-exc"},
+            extra={
+                "ts": "FAKE_TS",
+                "level": "FAKE_LEVEL",
+                "logger": "fake.logger",
+                "msg": "FAKE_MSG",
+                "env": "fake-env",
+                "exc": "fake-exc",
+            },
         )
     finally:
         logger.removeHandler(handler)
 
     payload = json.loads(stream.getvalue().strip())
 
-    assert payload["level"] == "ERROR"
-    assert payload["logger"] == "ante.test.reserved"
-    assert payload["msg"] == "hello"
+    assert payload["level"] == "ERROR"  # extra["level"] 이 아님
+    assert payload["logger"] == "ante.test.reserved"  # extra["logger"] 이 아님
+    assert payload["msg"] == "hello"  # extra["msg"] 가 아님
     assert payload["env"] == "staging"  # ANTE_ENV 환경변수 값, extra["env"] 아님
     assert payload["ts"].endswith("Z")  # 실제 타임스탬프, "FAKE_TS" 아님
+    assert "exc" not in payload  # extra["exc"] 가 새어나오지 않음
     assert "extra" not in payload
 
 

--- a/tests/unit/test_log_handlers.py
+++ b/tests/unit/test_log_handlers.py
@@ -1,0 +1,90 @@
+"""DateNamedTimedRotatingFileHandler 회귀 테스트.
+
+주된 계약 (`docs/specs/logging/05-handlers-and-rotation.md` §회전 규칙):
+- 파일명은 Asia/Seoul 날짜 기준 `ante-YYYY-MM-DD.jsonl`.
+- `computeRollover` 는 호스트/컨테이너 TZ 와 무관하게 다음 KST 자정을
+  Unix epoch 초로 돌려준다.
+- 자정 회전 시 기존 파일은 rename 되지 않고 새 날짜로 핸들을 전환한다.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from ante.core.log.handlers import DateNamedTimedRotatingFileHandler
+
+
+def test_filename_uses_kst_date_regardless_of_host_tz(tmp_path: Path) -> None:
+    """호스트 TZ 가 UTC 등 다른 값이어도 파일명은 KST 날짜를 따른다."""
+    handler = DateNamedTimedRotatingFileHandler(
+        tmp_path, prefix="ante", file_suffix=".jsonl", backup_count=30
+    )
+    try:
+        expected_date = _dt.datetime.now(ZoneInfo("Asia/Seoul")).strftime("%Y-%m-%d")
+        assert handler.baseFilename.endswith(f"ante-{expected_date}.jsonl")
+    finally:
+        handler.close()
+
+
+def test_compute_rollover_returns_next_kst_midnight(tmp_path: Path) -> None:
+    """임의의 현재 시각에 대해 다음 Asia/Seoul 자정을 Unix epoch 으로 반환한다.
+
+    케이스: KST 기준 정오(12:00). 다음 자정까지 12 시간 남음.
+    """
+    handler = DateNamedTimedRotatingFileHandler(tmp_path)
+    try:
+        kst = ZoneInfo("Asia/Seoul")
+        noon_kst = _dt.datetime(2026, 4, 17, 12, 0, 0, tzinfo=kst)
+        next_midnight_kst = _dt.datetime(2026, 4, 18, 0, 0, 0, tzinfo=kst)
+
+        actual = handler.computeRollover(noon_kst.timestamp())
+        assert actual == int(next_midnight_kst.timestamp())
+    finally:
+        handler.close()
+
+
+def test_compute_rollover_crosses_utc_day_boundary(tmp_path: Path) -> None:
+    """UTC 자정과 KST 자정이 불일치하는 경계에서 올바르게 KST 기준으로 회전한다.
+
+    UTC 23:00 (= KST 08:00) 에서 호출하면 다음 KST 자정(16 시간 후) 을 반환한다.
+    """
+    handler = DateNamedTimedRotatingFileHandler(tmp_path)
+    try:
+        utc = ZoneInfo("UTC")
+        kst = ZoneInfo("Asia/Seoul")
+        # 2026-04-17 23:00 UTC == 2026-04-18 08:00 KST
+        probe_utc = _dt.datetime(2026, 4, 17, 23, 0, 0, tzinfo=utc)
+        # 다음 KST 자정은 2026-04-19 00:00 KST == 2026-04-18 15:00 UTC
+        next_midnight_kst = _dt.datetime(2026, 4, 19, 0, 0, 0, tzinfo=kst)
+
+        actual = handler.computeRollover(probe_utc.timestamp())
+        assert actual == int(next_midnight_kst.timestamp())
+    finally:
+        handler.close()
+
+
+def test_rollover_does_not_rename_existing_file(tmp_path: Path) -> None:
+    """자정 회전 시 기존 파일은 rename 되지 않고 새 날짜 파일이 생성된다."""
+    handler = DateNamedTimedRotatingFileHandler(tmp_path, backup_count=30)
+    try:
+        original_path = Path(handler.baseFilename)
+        # 핸들러가 파일에 한 줄 쓰도록 직접 스트림에 기록
+        handler.stream.write('{"msg":"original"}\n')
+        handler.stream.flush()
+        assert original_path.exists()
+
+        # 다음 날로 전환하도록 파일명 헬퍼를 가로챈다
+        fake_next = tmp_path / "ante-9999-12-31.jsonl"
+        handler._make_filename = lambda: str(fake_next)  # type: ignore[method-assign]
+
+        handler.doRollover()
+
+        # 기존 파일은 rename 되지 않고 그대로 남아 있어야 한다
+        assert original_path.exists()
+        assert original_path.read_text().strip() == '{"msg":"original"}'
+        # 새 파일명이 활성 baseFilename 이 된다
+        assert handler.baseFilename == str(fake_next)
+    finally:
+        handler.close()

--- a/tests/unit/test_log_safe_logger.py
+++ b/tests/unit/test_log_safe_logger.py
@@ -1,0 +1,259 @@
+"""AnteLogger / install_safe_logger() 단위 테스트.
+
+stdlib ``Logger.makeRecord()`` 는 ``extra`` 의 키가 ``LogRecord`` 속성과
+충돌하면 ``KeyError`` 를 던진다. ``docs/specs/logging/03-json-schema.md``
+§예약어 처리 는 표준 필드가 ``extra=`` 로 주입되어도 무시되어야 한다고
+규정하므로, 이를 makeRecord 단계에서 선제 정규화하는 동작을 검증한다.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+
+import pytest
+
+from ante.core.log import (
+    AnteLogger,
+    JsonFormatter,
+    install_safe_logger,
+    setup_logging,
+)
+
+
+class _StubConfig:
+    def __init__(self, values: dict | None = None) -> None:
+        self._values = values or {}
+
+    def get(self, key: str, default=None):
+        return self._values.get(key, default)
+
+
+@pytest.fixture(autouse=True)
+def _restore_logging_state():
+    """테스트 간 logging 전역 상태 격리.
+
+    ``install_safe_logger()`` 는 기존 Logger 인스턴스의 ``makeRecord`` 를
+    bound-method 로 직접 교체한다. 테스트 격리를 위해 각 테스트 종료 시:
+    1. 테스트가 만든 개별 Logger 인스턴스들의 ``makeRecord`` 오버라이드 제거
+    2. ``loggerDict`` 를 이전 스냅샷으로 복원
+    3. root logger 의 ``makeRecord`` 를 stdlib 구현으로 복원
+    4. Logger 클래스를 stdlib ``logging.Logger`` 로 복원
+    """
+    saved_logger_class = logging.getLoggerClass()
+    saved_root_dict = logging.root.__dict__.copy()
+    saved_root_level = logging.root.level
+    saved_root_handlers = list(logging.root.handlers)
+    saved_logger_dict = dict(logging.Logger.manager.loggerDict)
+
+    # 시작 시 순수 stdlib 상태를 보장 — 다른 테스트 스위트가 남긴 오염을 제거
+    logging.setLoggerClass(logging.Logger)
+    if "makeRecord" in logging.root.__dict__:
+        del logging.root.__dict__["makeRecord"]
+    for existing in list(logging.Logger.manager.loggerDict.values()):
+        if isinstance(existing, logging.Logger) and "makeRecord" in existing.__dict__:
+            del existing.__dict__["makeRecord"]
+
+    for h in list(logging.root.handlers):
+        logging.root.removeHandler(h)
+
+    try:
+        yield
+    finally:
+        # 개별 Logger 인스턴스의 makeRecord 오버라이드 제거
+        for existing in list(logging.Logger.manager.loggerDict.values()):
+            if (
+                isinstance(existing, logging.Logger)
+                and "makeRecord" in existing.__dict__
+            ):
+                del existing.__dict__["makeRecord"]
+        # root logger 복원
+        for h in list(logging.root.handlers):
+            logging.root.removeHandler(h)
+            try:
+                h.close()
+            except Exception:
+                pass
+        if "makeRecord" in logging.root.__dict__:
+            del logging.root.__dict__["makeRecord"]
+        logging.root.__dict__.update(saved_root_dict)
+        for h in saved_root_handlers:
+            logging.root.addHandler(h)
+        logging.root.setLevel(saved_root_level)
+        # Logger 클래스 복원
+        logging.setLoggerClass(saved_logger_class)
+        # loggerDict 복원
+        logging.Logger.manager.loggerDict = saved_logger_dict  # type: ignore[assignment]
+
+
+def _attach_stream(logger: logging.Logger, formatter=None) -> io.StringIO:
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(formatter or logging.Formatter("%(message)s"))
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    return stream
+
+
+# ── 0. 사전 조건: stdlib 은 extra={"msg": ...} 에서 KeyError 를 낸다 ──
+
+
+def test_stdlib_raises_keyerror_on_extra_msg_without_install():
+    """설치 전에는 stdlib 이 실제로 KeyError 를 던진다는 베이스라인 확인."""
+    logger = logging.getLogger("ante.test.stdlib_baseline")
+    _attach_stream(logger)
+
+    with pytest.raises(KeyError, match="msg"):
+        logger.info("hi", extra={"msg": "fake"})
+
+
+# ── 1. install_safe_logger 후 msg 키가 KeyError 없이 처리됨 ─────
+
+
+def test_install_prevents_keyerror_on_reserved_msg():
+    install_safe_logger()
+    logger = logging.getLogger("ante.test.install_msg")
+    stream = _attach_stream(logger)
+
+    # stdlib 이라면 여기서 KeyError — 설치 후에는 무시되고 정상 로깅
+    logger.info("hi", extra={"msg": "fake"})
+
+    assert stream.getvalue().strip() == "hi"
+
+
+def test_install_prevents_keyerror_on_multiple_logrecord_attrs():
+    """msg, args, name, levelname, exc_info, pathname 모두 안전."""
+    install_safe_logger()
+    logger = logging.getLogger("ante.test.install_many")
+    stream = _attach_stream(logger)
+
+    logger.info(
+        "hi",
+        extra={
+            "msg": "fake",
+            "args": (1, 2),
+            "name": "fake_name",
+            "levelname": "FAKE",
+            "exc_info": None,
+            "pathname": "/fake/path",
+            "created": 0,
+            "filename": "x",
+            "lineno": 99,
+        },
+    )
+
+    assert stream.getvalue().strip() == "hi"
+
+
+def test_install_prevents_keyerror_on_ante_reserved_keys():
+    """Ante JSONL 예약 키 (ts, level, logger, env, exc) 도 무시된다."""
+    install_safe_logger()
+    logger = logging.getLogger("ante.test.install_ante_reserved")
+    stream = _attach_stream(logger)
+
+    logger.info(
+        "hi",
+        extra={
+            "ts": "fake",
+            "level": "FAKE",
+            "logger": "fake",
+            "env": "fake-env",
+            "exc": "fake-exc",
+        },
+    )
+
+    assert stream.getvalue().strip() == "hi"
+
+
+# ── 2. 루트 로거도 안전 ────────────────────────────────────────
+
+
+def test_root_logger_safe_after_install():
+    install_safe_logger()
+    root = logging.getLogger()
+    stream = _attach_stream(root)
+
+    root.info("root-hi", extra={"msg": "fake", "ts": "fake"})
+
+    assert stream.getvalue().strip() == "root-hi"
+
+
+# ── 3. 이미 캐시된 logger 도 install 후 patch 된다 ─────────────
+
+
+def test_preexisting_cached_logger_is_patched():
+    """install 이전에 만들어진 logger 도 안전해야 한다."""
+    logger = logging.getLogger("ante.preexisting.child")
+    _attach_stream(logger)
+
+    # 설치 전에는 KeyError
+    with pytest.raises(KeyError):
+        logger.info("hi", extra={"msg": "fake"})
+
+    install_safe_logger()
+
+    # 설치 후 같은 logger 인스턴스가 안전해야 한다
+    logger.info("hi", extra={"msg": "fake", "ts": "fake"})
+
+
+# ── 4. 정상 extra 필드는 보존된다 ──────────────────────────────
+
+
+def test_custom_extra_preserved():
+    install_safe_logger()
+    logger = logging.getLogger("ante.test.custom_extra")
+    stream = _attach_stream(logger, formatter=JsonFormatter())
+
+    logger.info(
+        "hello",
+        extra={
+            "account_id": "abc",
+            "custom_field": 123,
+            "msg": "should_be_ignored",
+        },
+    )
+
+    payload = json.loads(stream.getvalue().strip())
+    assert payload["msg"] == "hello"  # 표준 msg 유지
+    assert payload["account_id"] == "abc"  # 표준 컨텍스트 필드 승격
+    assert payload.get("extra") == {"custom_field": 123}  # 비표준 키는 extra 하위
+
+
+# ── 5. setup_logging() 이 install 을 수행 ──────────────────────
+
+
+def test_setup_logging_installs_safe_logger(monkeypatch, tmp_path):
+    monkeypatch.delenv("ANTE_LOG_JSONL", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    # 사전 상태: 순수 Logger 클래스
+    logging.setLoggerClass(logging.Logger)
+
+    setup_logging(_StubConfig())
+
+    # setup_logging 후 새 logger 는 AnteLogger
+    new_logger = logging.getLogger("ante.test.setup_makes_ante")
+    assert isinstance(new_logger, AnteLogger)
+
+    # 실제 호출도 안전
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    new_logger.addHandler(handler)
+    new_logger.setLevel(logging.DEBUG)
+    new_logger.propagate = False
+    new_logger.info("ok", extra={"msg": "fake"})
+
+
+# ── 6. 재호출 멱등성 ───────────────────────────────────────────
+
+
+def test_install_is_idempotent():
+    install_safe_logger()
+    install_safe_logger()
+    install_safe_logger()
+
+    logger = logging.getLogger("ante.test.idempotent")
+    _attach_stream(logger)
+    logger.info("hi", extra={"msg": "fake"})  # 여전히 안전

--- a/tests/unit/test_log_setup.py
+++ b/tests/unit/test_log_setup.py
@@ -264,7 +264,6 @@ def test_rollover_preserves_previous_file_and_opens_new_date(
         prefix="ante",
         file_suffix=".jsonl",
         backup_count=30,
-        utc=False,
     )
     try:
         handler.setFormatter(logging.Formatter("%(message)s"))
@@ -377,7 +376,6 @@ def test_rollover_deletes_oldest_files_beyond_backup_count(
         prefix="ante",
         file_suffix=".jsonl",
         backup_count=2,
-        utc=False,
     )
     try:
         # 회전 후 새 파일명

--- a/tests/unit/test_log_setup.py
+++ b/tests/unit/test_log_setup.py
@@ -7,13 +7,18 @@
 from __future__ import annotations
 
 import logging
+import re
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from ante.core.log import JsonFormatter, setup_logging
+from ante.core.log import (
+    DateNamedTimedRotatingFileHandler,
+    JsonFormatter,
+    setup_logging,
+)
 
 
 class _StubConfig:
@@ -97,11 +102,18 @@ def test_dual_handlers_when_jsonl_gate_enabled(
     assert len(stream_handlers) == 1
 
     file_handler = file_handlers[0]
+    assert isinstance(file_handler, DateNamedTimedRotatingFileHandler)
     assert isinstance(file_handler.formatter, JsonFormatter)
     assert file_handler.when == "MIDNIGHT"
     assert file_handler.backupCount == 30
-    assert file_handler.suffix == "%Y-%m-%d"
-    assert Path(file_handler.baseFilename).name == "ante.jsonl"
+
+    # 활성 파일명 계약: ante-YYYY-MM-DD.jsonl
+    name = Path(file_handler.baseFilename).name
+    assert re.match(r"^ante-\d{4}-\d{2}-\d{2}\.jsonl$", name), (
+        f"활성 파일명이 스펙과 불일치: {name!r}"
+    )
+    # logs/ 디렉토리 아래에 위치
+    assert Path(file_handler.baseFilename).parent.name == "logs"
 
 
 # ── 3. system.log_level 이 루트 로거 레벨에 반영 ──────────────
@@ -175,3 +187,149 @@ def test_idempotent_on_repeated_calls_with_jsonl(
     setup_logging(_StubConfig())
 
     assert len(logging.getLogger().handlers) == 2
+
+
+# ── 6. 파일 핸들러 초기화 실패 격리 ────────────────────────────
+
+
+def test_file_handler_failure_does_not_break_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+    _cwd_tmp: Path,
+):
+    """디스크 가득/권한 등 파일 핸들러 초기화 실패 시 stdout만 유지하고 진행."""
+    monkeypatch.setenv("ANTE_LOG_JSONL", "1")
+
+    def _raise(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise OSError("disk full (simulated)")
+
+    # DateNamedTimedRotatingFileHandler 생성자에서 OSError 발생시키기
+    import ante.core.log.setup as setup_mod
+
+    monkeypatch.setattr(setup_mod, "DateNamedTimedRotatingFileHandler", _raise)
+
+    # 예외가 전파되지 않아야 한다
+    setup_logging(_StubConfig())
+
+    root = logging.getLogger()
+    # stdout 핸들러 1개만 살아있다
+    assert len(root.handlers) == 1
+    assert isinstance(root.handlers[0], logging.StreamHandler)
+    assert not isinstance(root.handlers[0], TimedRotatingFileHandler)
+
+
+def test_file_handler_mkdir_failure_does_not_break_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+    _cwd_tmp: Path,
+):
+    """``logs/`` 디렉토리 생성 실패도 stdout 전용으로 흡수된다."""
+    monkeypatch.setenv("ANTE_LOG_JSONL", "1")
+
+    original_mkdir = Path.mkdir
+
+    def _raise_for_logs(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        if self.name == "logs":
+            raise PermissionError("permission denied (simulated)")
+        return original_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", _raise_for_logs)
+
+    # 예외가 전파되지 않아야 한다
+    setup_logging(_StubConfig())
+
+    root = logging.getLogger()
+    assert len(root.handlers) == 1
+    assert isinstance(root.handlers[0], logging.StreamHandler)
+    assert not isinstance(root.handlers[0], TimedRotatingFileHandler)
+
+
+# ── 7. 회전 시 새 baseFilename 이 새 날짜로 갱신됨 ────────────
+
+
+def test_rollover_updates_base_filename_to_next_date(
+    monkeypatch: pytest.MonkeyPatch,
+    _cwd_tmp: Path,
+):
+    """``doRollover()`` 호출 후 baseFilename 이 새 날짜 파일을 가리킨다."""
+    log_dir = _cwd_tmp / "logs"
+    log_dir.mkdir()
+
+    # 초기 생성 시점의 파일명은 "오늘"
+    handler = DateNamedTimedRotatingFileHandler(
+        log_dir,
+        prefix="ante",
+        file_suffix=".jsonl",
+        backup_count=30,
+        utc=False,
+    )
+    try:
+        initial_name = Path(handler.baseFilename).name
+        assert re.match(r"^ante-\d{4}-\d{2}-\d{2}\.jsonl$", initial_name)
+
+        # _make_filename() 을 "다음 날" 로 고정
+        next_day = "ante-2099-01-01.jsonl"
+        monkeypatch.setattr(
+            handler,
+            "_make_filename",
+            lambda: str(log_dir / next_day),
+        )
+
+        handler.doRollover()
+
+        # 새 baseFilename 이 새 날짜를 가리킨다
+        assert Path(handler.baseFilename).name == next_day
+        # 기존 파일은 rename 되지 않고 그대로 존재
+        assert (log_dir / initial_name).exists() or not Path(
+            log_dir / initial_name
+        ).exists()
+        # 새 파일은 생성되어 있어야 한다
+        assert (log_dir / next_day).exists()
+    finally:
+        handler.close()
+
+
+# ── 8. backup_count 초과 시 가장 오래된 파일 삭제 ─────────────
+
+
+def test_rollover_deletes_oldest_files_beyond_backup_count(
+    monkeypatch: pytest.MonkeyPatch,
+    _cwd_tmp: Path,
+):
+    """``backup_count=2`` 에서 이미 3개 파일이 있다면 회전 후 가장 오래된 1개 삭제."""
+    log_dir = _cwd_tmp / "logs"
+    log_dir.mkdir()
+
+    # 더미 옛날 파일들 (오름차순 정렬 시 가장 오래된 것이 맨 앞)
+    old1 = log_dir / "ante-2024-01-01.jsonl"
+    old2 = log_dir / "ante-2024-06-01.jsonl"
+    old3 = log_dir / "ante-2025-01-01.jsonl"
+    for p in (old1, old2, old3):
+        p.write_text("dummy\n", encoding="utf-8")
+
+    handler = DateNamedTimedRotatingFileHandler(
+        log_dir,
+        prefix="ante",
+        file_suffix=".jsonl",
+        backup_count=2,
+        utc=False,
+    )
+    try:
+        # 회전 후 새 파일명
+        next_day = "ante-2099-01-01.jsonl"
+        monkeypatch.setattr(
+            handler,
+            "_make_filename",
+            lambda: str(log_dir / next_day),
+        )
+
+        handler.doRollover()
+
+        # backup_count=2 이므로 활성 파일 제외 최대 2개만 남아야 한다
+        remaining = sorted(p.name for p in log_dir.glob("ante-*.jsonl"))
+        # 활성 파일 + 최신 2개 backup 유지; 가장 오래된 old1 은 삭제
+        assert old1.name not in remaining, (
+            f"가장 오래된 파일이 삭제되지 않음: {remaining}"
+        )
+        # 활성 파일은 보존
+        assert next_day in remaining
+    finally:
+        handler.close()

--- a/tests/unit/test_log_setup.py
+++ b/tests/unit/test_log_setup.py
@@ -1,0 +1,177 @@
+"""setup_logging() 단위 테스트.
+
+`docs/specs/logging/05-handlers-and-rotation.md` 의 이중 핸들러 구성과
+환경변수 게이트(``ANTE_LOG_JSONL``) 동작을 검증한다.
+"""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ante.core.log import JsonFormatter, setup_logging
+
+
+class _StubConfig:
+    """``Config.get(key, default)`` 계약만 만족하는 최소 더블."""
+
+    def __init__(self, values: dict[str, Any] | None = None) -> None:
+        self._values = values or {}
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._values.get(key, default)
+
+
+@pytest.fixture(autouse=True)
+def _restore_root_logger():
+    """테스트 간 루트 로거 상태를 격리한다."""
+    root = logging.getLogger()
+    saved_level = root.level
+    saved_handlers = list(root.handlers)
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    try:
+        yield
+    finally:
+        for h in list(root.handlers):
+            root.removeHandler(h)
+            try:
+                h.close()
+            except Exception:
+                pass
+        for h in saved_handlers:
+            root.addHandler(h)
+        root.setLevel(saved_level)
+
+
+@pytest.fixture(autouse=True)
+def _cwd_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """``logs/`` 디렉토리 생성이 현재 작업 디렉토리 기준이므로 격리."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+# ── 1. ANTE_LOG_JSONL 미설정 시 stdout 핸들러 1개만 추가 ───────
+
+
+def test_stdout_only_when_jsonl_gate_unset(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("ANTE_LOG_JSONL", raising=False)
+
+    setup_logging(_StubConfig())
+
+    root = logging.getLogger()
+    assert len(root.handlers) == 1
+    assert isinstance(root.handlers[0], logging.StreamHandler)
+    assert not isinstance(root.handlers[0], TimedRotatingFileHandler)
+
+
+# ── 2. ANTE_LOG_JSONL=1 시 stdout + 파일 핸들러 2개 ────────────
+
+
+def test_dual_handlers_when_jsonl_gate_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    _cwd_tmp: Path,
+):
+    monkeypatch.setenv("ANTE_LOG_JSONL", "1")
+
+    setup_logging(_StubConfig())
+
+    root = logging.getLogger()
+    assert len(root.handlers) == 2
+
+    file_handlers = [
+        h for h in root.handlers if isinstance(h, TimedRotatingFileHandler)
+    ]
+    stream_handlers = [
+        h
+        for h in root.handlers
+        if isinstance(h, logging.StreamHandler)
+        and not isinstance(h, TimedRotatingFileHandler)
+    ]
+
+    assert len(file_handlers) == 1
+    assert len(stream_handlers) == 1
+
+    file_handler = file_handlers[0]
+    assert isinstance(file_handler.formatter, JsonFormatter)
+    assert file_handler.when == "MIDNIGHT"
+    assert file_handler.backupCount == 30
+    assert file_handler.suffix == "%Y-%m-%d"
+    assert Path(file_handler.baseFilename).name == "ante.jsonl"
+
+
+# ── 3. system.log_level 이 루트 로거 레벨에 반영 ──────────────
+
+
+@pytest.mark.parametrize(
+    "level_name,level_value",
+    [
+        ("DEBUG", logging.DEBUG),
+        ("INFO", logging.INFO),
+        ("WARNING", logging.WARNING),
+        ("ERROR", logging.ERROR),
+    ],
+)
+def test_log_level_reflected_in_root_logger(
+    monkeypatch: pytest.MonkeyPatch,
+    level_name: str,
+    level_value: int,
+):
+    monkeypatch.delenv("ANTE_LOG_JSONL", raising=False)
+
+    setup_logging(_StubConfig({"system.log_level": level_name}))
+
+    assert logging.getLogger().level == level_value
+
+
+def test_log_level_defaults_to_info(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("ANTE_LOG_JSONL", raising=False)
+
+    setup_logging(_StubConfig())
+
+    assert logging.getLogger().level == logging.INFO
+
+
+# ── 4. 로그 디렉토리 자동 생성 ─────────────────────────────────
+
+
+def test_logs_directory_auto_created(monkeypatch: pytest.MonkeyPatch, _cwd_tmp: Path):
+    monkeypatch.setenv("ANTE_LOG_JSONL", "1")
+    log_dir = _cwd_tmp / "logs"
+    assert not log_dir.exists()
+
+    setup_logging(_StubConfig())
+
+    assert log_dir.exists()
+    assert log_dir.is_dir()
+
+
+# ── 5. 재호출 시 핸들러 중복 없음 ──────────────────────────────
+
+
+def test_idempotent_on_repeated_calls(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("ANTE_LOG_JSONL", raising=False)
+
+    setup_logging(_StubConfig())
+    first_count = len(logging.getLogger().handlers)
+
+    setup_logging(_StubConfig())
+    setup_logging(_StubConfig())
+
+    assert len(logging.getLogger().handlers) == first_count == 1
+
+
+def test_idempotent_on_repeated_calls_with_jsonl(
+    monkeypatch: pytest.MonkeyPatch, _cwd_tmp: Path
+):
+    monkeypatch.setenv("ANTE_LOG_JSONL", "1")
+
+    setup_logging(_StubConfig())
+    setup_logging(_StubConfig())
+    setup_logging(_StubConfig())
+
+    assert len(logging.getLogger().handlers) == 2

--- a/tests/unit/test_log_setup.py
+++ b/tests/unit/test_log_setup.py
@@ -242,18 +242,23 @@ def test_file_handler_mkdir_failure_does_not_break_stdout(
     assert not isinstance(root.handlers[0], TimedRotatingFileHandler)
 
 
-# ── 7. 회전 시 새 baseFilename 이 새 날짜로 갱신됨 ────────────
+# ── 7. no-rename 회전 계약 검증 ─────────────────────────────
+
+# 회전 계약 (`docs/specs/logging/05-handlers-and-rotation.md`):
+#   1) 활성 파일명에 날짜가 포함되므로 기존 파일은 rename 되지 않는다
+#   2) 자정에 baseFilename 이 새 날짜 파일로 교체되고 새 파일이 열린다
+#   3) 회전 전에 기록된 엔트리는 이전 날 파일에 그대로 남아 있다
+#   4) 회전 후 emit() 호출은 새 파일에 기록된다
 
 
-def test_rollover_updates_base_filename_to_next_date(
+def test_rollover_preserves_previous_file_and_opens_new_date(
     monkeypatch: pytest.MonkeyPatch,
     _cwd_tmp: Path,
 ):
-    """``doRollover()`` 호출 후 baseFilename 이 새 날짜 파일을 가리킨다."""
+    """no-rename 회전 계약: 기존 파일은 내용 보존 + 새 날짜 파일이 열린다."""
     log_dir = _cwd_tmp / "logs"
     log_dir.mkdir()
 
-    # 초기 생성 시점의 파일명은 "오늘"
     handler = DateNamedTimedRotatingFileHandler(
         log_dir,
         prefix="ante",
@@ -262,27 +267,89 @@ def test_rollover_updates_base_filename_to_next_date(
         utc=False,
     )
     try:
-        initial_name = Path(handler.baseFilename).name
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        # 1) 오늘 파일에 엔트리 기록
+        initial_path = Path(handler.baseFilename)
+        initial_name = initial_path.name
         assert re.match(r"^ante-\d{4}-\d{2}-\d{2}\.jsonl$", initial_name)
 
-        # _make_filename() 을 "다음 날" 로 고정
+        pre_rollover_record = logging.LogRecord(
+            name="ante.test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=0,
+            msg="PRE_ROLLOVER_ENTRY",
+            args=None,
+            exc_info=None,
+        )
+        handler.emit(pre_rollover_record)
+        handler.flush()
+
+        # 기록이 실제로 디스크에 반영됐는지 확인
+        pre_content = initial_path.read_text(encoding="utf-8")
+        assert "PRE_ROLLOVER_ENTRY" in pre_content
+
+        # 2) _make_filename() 을 "다음 날" 로 monkeypatch
         next_day = "ante-2099-01-01.jsonl"
+        next_path = log_dir / next_day
         monkeypatch.setattr(
             handler,
             "_make_filename",
-            lambda: str(log_dir / next_day),
+            lambda: str(next_path),
         )
 
+        # 3) 회전 실행
         handler.doRollover()
 
-        # 새 baseFilename 이 새 날짜를 가리킨다
+        # 4) 어서션: no-rename 계약
+        #    (a) baseFilename 이 새 날짜 파일로 교체됨
         assert Path(handler.baseFilename).name == next_day
-        # 기존 파일은 rename 되지 않고 그대로 존재
-        assert (log_dir / initial_name).exists() or not Path(
-            log_dir / initial_name
-        ).exists()
-        # 새 파일은 생성되어 있어야 한다
-        assert (log_dir / next_day).exists()
+
+        #    (b) 기존 파일이 여전히 존재하고 기록된 엔트리를 보존
+        assert initial_path.exists(), (
+            f"기존 파일이 사라졌다 (rename 의심): {initial_name}"
+        )
+        assert "PRE_ROLLOVER_ENTRY" in initial_path.read_text(encoding="utf-8"), (
+            "기존 파일 내용이 손실됨 — no-rename 계약 위반"
+        )
+
+        #    (c) 새 날짜 파일이 생성됨
+        assert next_path.exists(), "새 baseFilename 파일이 열리지 않음"
+
+        #    (d) 기존 파일이 ".bak" / 무날짜 ante.jsonl 등으로 rename 되지 않음
+        suspicious = [
+            p.name for p in log_dir.iterdir() if p.name not in {initial_name, next_day}
+        ]
+        assert suspicious == [], (
+            f"회전 과정에서 예상 외 파일이 생성됨 (rename 의심): {suspicious}"
+        )
+        assert not (log_dir / "ante.jsonl").exists(), (
+            "무날짜 활성 파일이 생성됨 — 표준 TimedRotatingFileHandler 로 회귀"
+        )
+        for bak_pattern in (".bak", ".1", ".old"):
+            assert not (log_dir / f"{initial_name}{bak_pattern}").exists(), (
+                f"기존 파일이 {bak_pattern} suffix 로 rename 됨"
+            )
+
+        # 5) 회전 후 emit() 이 새 파일에 기록되는지 검증
+        post_rollover_record = logging.LogRecord(
+            name="ante.test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=0,
+            msg="POST_ROLLOVER_ENTRY",
+            args=None,
+            exc_info=None,
+        )
+        handler.emit(post_rollover_record)
+        handler.flush()
+
+        # 새 파일에만 POST 엔트리가 있어야 한다
+        assert next_path.stat().st_size > 0
+        assert "POST_ROLLOVER_ENTRY" in next_path.read_text(encoding="utf-8")
+        # 기존 파일에는 POST 엔트리가 없어야 한다 (스트림이 전환됐음을 확인)
+        assert "POST_ROLLOVER_ENTRY" not in initial_path.read_text(encoding="utf-8")
     finally:
         handler.close()
 


### PR DESCRIPTION
Closes #1108

## Summary
- `setup_logging()` 신설: stdout 평문 + (`ANTE_LOG_JSONL=1` 게이트 시) 파일 JSONL 이중 핸들러 구성. `main.py` `_init_core` 에서 기존 `logging.basicConfig()` 를 교체.
- `DateNamedTimedRotatingFileHandler` 신설: 활성 파일명에 날짜를 직접 포함하는 no-rename 회전 (`ante-YYYY-MM-DD.jsonl`). `ZoneInfo("Asia/Seoul")` 을 코드 레벨에서 고정해 배포 경로(Docker / systemd / launchd) 와 무관하게 스펙 계약을 보장.
- `AnteLogger` / `install_safe_logger()`: 예약 키(`msg`, `args` 등 LogRecord 속성 + JSONL 스펙 필드)가 `extra=` 로 주입되어도 `makeRecord` KeyError 없이 무시되도록 서브클래스 등록.
- `_record_keys.py` 단일 소스: `LogRecord.__dict__` 런타임 프로브로 속성 집합 추출. formatter·safe_logger 가 공유해 Python 버전 드리프트(예: 3.12 `taskName`) 방지.
- Deploy 계약: `docker-compose.yml` 에 `ante-logs` named volume + `TZ`, `docker-compose.staging.yml` 에 `~/ante-staging/logs` bind mount(감시 에이전트 §7.2 글롭 전제), Dockerfile `tzdata` + `ENV TZ`.
- 스펙 반영: `05-handlers-and-rotation.md` §회전 규칙·볼륨 마운트, `07-implementation.md` 스펙↔코드↔회귀 테스트 매트릭스.

## Test Plan
- `ruff check src/ tests/` ✅
- `ruff format --check src/ tests/` ✅
- `pytest tests/unit/test_log_*.py` — 54 passed
  - `test_log_handlers.py` (신설): KST 파일명, `computeRollover` KST 경계, UTC 경계 테스트, no-rename 회전
  - `test_log_safe_logger.py`: 예약 키 `extra=` 주입 방어
  - `test_log_setup.py`: 이중 핸들러 구성, 파일 핸들러 실패 격리, 회전 동작
  - `test_log_formatter.py`, `test_log_fingerprint.py`: 기존 회귀

## Review History
- 7차 Codex 브랜치 리뷰 SUCCESS (HEAD `e140943`, run 24623899145)
- 6차 blocking: KST 보장이 Docker 경로에만 묶여있다는 지적 → 핸들러에서 `ZoneInfo` 명시 사용으로 근본 해결
- 1~5차: 파일명 패턴, 예약 키 makeRecord KeyError, no-rename 회전 스펙 정합, 볼륨 마운트, TZ 단일 소스