### PR TITLE
fix(log): align logger typing with mypy after #1115

### DIFF
--- a/src/ante/core/log/handlers.py
+++ b/src/ante/core/log/handlers.py
@@ -22,6 +22,7 @@ import os
 import time
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
+from typing import Any, cast
 from zoneinfo import ZoneInfo
 
 _KST = ZoneInfo("Asia/Seoul")
@@ -100,7 +101,7 @@ class DateNamedTimedRotatingFileHandler(TimedRotatingFileHandler):
         """
         if self.stream is not None:
             self.stream.close()
-            self.stream = None
+            self.stream = cast(Any, None)
 
         self.baseFilename = self._make_filename()
         if not self.delay:

--- a/src/ante/core/log/safe_logger.py
+++ b/src/ante/core/log/safe_logger.py
@@ -15,13 +15,16 @@ stdlib ``Logger.makeRecord()`` 는 ``extra`` 의 키가 ``LogRecord`` 속성과
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
 from ._record_keys import ANTE_RESERVED as _ANTE_RESERVED
 from ._record_keys import LOGRECORD_ATTRS as _LOGRECORD_RESERVED
 
 
-def _sanitize_extra(extra: dict[str, Any] | None) -> dict[str, Any] | None:
+def _sanitize_extra(
+    extra: Mapping[str, object] | None,
+) -> dict[str, object] | None:
     """예약 키 충돌을 제거한 extra dict 반환.
 
     - LogRecord 속성과 겹치는 키(``msg``, ``args``, ``name`` 등): 제거
@@ -32,9 +35,9 @@ def _sanitize_extra(extra: dict[str, Any] | None) -> dict[str, Any] | None:
     제거 대신 ``extra`` 하위로 옮기지 않는다 — 호출자의 실수를 무시하는 것이
     스펙 동작이다.
     """
-    if not extra:
-        return extra
-    cleaned: dict[str, Any] = {}
+    if extra is None:
+        return None
+    cleaned: dict[str, object] = {}
     for key, val in extra.items():
         if key in _LOGRECORD_RESERVED or key in _ANTE_RESERVED:
             # 무시 (스펙: 호출자 실수로부터 로그 구조 보호)
@@ -53,7 +56,7 @@ def _safe_make_record(
     args: Any,
     exc_info: Any,
     func: str | None = None,
-    extra: dict[str, Any] | None = None,
+    extra: Mapping[str, object] | None = None,
     sinfo: str | None = None,
 ) -> logging.LogRecord:
     """``Logger.makeRecord`` 대체 구현.
@@ -92,7 +95,7 @@ class AnteLogger(logging.Logger):
         args: Any,
         exc_info: Any,
         func: str | None = None,
-        extra: dict[str, Any] | None = None,
+        extra: Mapping[str, object] | None = None,
         sinfo: str | None = None,
     ) -> logging.LogRecord:
         return _safe_make_record(


### PR DESCRIPTION
## Summary
- `safe_logger.py`의 `Logger.makeRecord()` override 시그니처를 stdlib 타입 정의(`Mapping[str, object] | None`)에 맞췄습니다.
- `_sanitize_extra()`의 `None` 처리와 `handlers.py`의 `stream` reset 타입을 정리해 `mypy src/`가 통과되도록 보정했습니다.
- `#1115`가 머지된 뒤 확인된 lint follow-up만 담았고, 기능 동작 변경은 없습니다.

## Verification
- `/Users/jingulee/Projects/ante/.venv/bin/python -m mypy src/`
- `/Users/jingulee/Projects/ante/.venv/bin/python -m ruff check src/ tests/`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/test_log_handlers.py tests/unit/test_log_safe_logger.py -q`

## Context
- `#1115`가 먼저 머지되어 lint 수정 커밋(`e2289da`)은 `main`에 포함되지 않았습니다.
- 이 PR은 그 후속 보정입니다.
