### PR TITLE
fix(main): telegram_enabled=false 시 Telegram 시크릿 없이도 부팅 (#1118)

### DIFF
--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1091,21 +1091,37 @@ async def _approval_expire_loop(
 
 
 async def _init_notification(s: Services) -> None:
-    """NotificationService, TelegramCommandReceiver 초기화."""
+    """NotificationService, TelegramCommandReceiver 초기화.
+
+    ``notification.telegram_enabled=false`` 로 Telegram 을 비활성화한 경우에는
+    ``TELEGRAM_BOT_TOKEN`` / ``TELEGRAM_CHAT_ID`` 시크릿이 없어도 부팅이 막히지
+    않아야 한다. ``Config.secret()`` 이 누락 시 ``ConfigError`` 를 raise 하므로
+    반드시 dynamic config 플래그를 먼저 확인한 뒤 시크릿을 조회한다 (#1118).
+    """
     assert s.eventbus is not None
     assert s.dynamic_config is not None
 
+    from ante.config import ConfigError
     from ante.notification import (
         NotificationLevel,
         NotificationService,
         TelegramAdapter,
     )
 
-    telegram_token = s.config.secret("TELEGRAM_BOT_TOKEN")
-    telegram_chat_id = s.config.secret("TELEGRAM_CHAT_ID")
+    telegram_enabled = await s.dynamic_config.get(
+        "notification.telegram_enabled", default="true"
+    )
+    telegram_enabled_bool = str(telegram_enabled) == "true"
 
-    if not (telegram_token and telegram_chat_id):
-        logger.info("NotificationService 건너뜀 — Telegram 설정 없음")
+    if not telegram_enabled_bool:
+        logger.info("NotificationService 건너뜀 — telegram_enabled=false")
+        return
+
+    try:
+        telegram_token = s.config.secret("TELEGRAM_BOT_TOKEN")
+        telegram_chat_id = s.config.secret("TELEGRAM_CHAT_ID")
+    except ConfigError as err:
+        logger.info("NotificationService 건너뜀 — Telegram 시크릿 없음: %s", err)
         return
 
     adapter = TelegramAdapter(bot_token=telegram_token, chat_id=telegram_chat_id)
@@ -1122,11 +1138,6 @@ async def _init_notification(s: Services) -> None:
             parsed = parse_quiet_hours(str(raw))
             if parsed:
                 quiet_start, quiet_end = parsed
-
-    telegram_enabled = await s.dynamic_config.get(
-        "notification.telegram_enabled", default="true"
-    )
-    telegram_enabled_bool = str(telegram_enabled) == "true"
 
     s.notification_service = NotificationService(
         adapter=adapter,
@@ -1152,7 +1163,7 @@ async def _init_notification(s: Services) -> None:
                 "TELEGRAM_CHAT_ID 값이 올바른 정수가 아닙니다: %r — 무시합니다",
                 chat_id_str,
             )
-    if telegram_enabled_bool and chat_id is not None:
+    if chat_id is not None:
         s.telegram_receiver = TelegramCommandReceiver(
             adapter=adapter,
             allowed_user_ids=[chat_id],
@@ -1164,8 +1175,6 @@ async def _init_notification(s: Services) -> None:
         )
         s.telegram_receiver.start()
         logger.info("TelegramCommandReceiver 시작 (chat_id=%s)", chat_id)
-    elif not telegram_enabled_bool:
-        logger.info("TelegramCommandReceiver 건너뜀 — telegram_enabled=false")
     else:
         logger.info("TelegramCommandReceiver 건너뜀 — TELEGRAM_CHAT_ID 미설정")
 

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1093,10 +1093,23 @@ async def _approval_expire_loop(
 async def _init_notification(s: Services) -> None:
     """NotificationService, TelegramCommandReceiver 초기화.
 
-    ``notification.telegram_enabled=false`` 로 Telegram 을 비활성화한 경우에는
-    ``TELEGRAM_BOT_TOKEN`` / ``TELEGRAM_CHAT_ID`` 시크릿이 없어도 부팅이 막히지
-    않아야 한다. ``Config.secret()`` 이 누락 시 ``ConfigError`` 를 raise 하므로
-    반드시 dynamic config 플래그를 먼저 확인한 뒤 시크릿을 조회한다 (#1118).
+    부팅 계약 (#1118):
+
+    - ``TELEGRAM_BOT_TOKEN`` / ``TELEGRAM_CHAT_ID`` 시크릿이 누락(``ConfigError``)
+      되거나 공란이면 NotificationService 를 생성하지 않고 부팅을 계속한다.
+      과거에는 시크릿이 아예 없을 때 ``Config.secret()`` 이 raise 하여 부팅이
+      막혔다 — ``notification.telegram_enabled=false`` 로 Telegram 을 끈 stage
+      환경에서도 우회가 필요했던 원인이다.
+    - 시크릿이 존재하면 ``notification.telegram_enabled`` 플래그와 무관하게
+      ``NotificationService`` 를 항상 생성한다. 플래그는 서비스 내부의 필터링
+      (CRITICAL 이외 차단) 과 ``ConfigChangedEvent`` 기반 런타임 재활성화
+      계약에만 사용된다 — `docs/specs/notification/notification.md` §_should_send
+      참조. 서비스 자체를 지워 버리면 disabled 상태에서도 보장되어야 할
+      CRITICAL 알림 경로와 동적 토글이 함께 무력화된다.
+    - 공란 시크릿(``TELEGRAM_BOT_TOKEN=`` 등) 역시 비활성화 신호로 취급한다
+      (`docs/superpowers/specs/2026-04-17-staging-environment-design.md` 참고).
+      ``Config.secret()`` 은 이 경우 raise 하지 않고 빈 문자열을 반환하므로
+      별도 가드가 필요하다.
     """
     assert s.eventbus is not None
     assert s.dynamic_config is not None
@@ -1108,20 +1121,15 @@ async def _init_notification(s: Services) -> None:
         TelegramAdapter,
     )
 
-    telegram_enabled = await s.dynamic_config.get(
-        "notification.telegram_enabled", default="true"
-    )
-    telegram_enabled_bool = str(telegram_enabled) == "true"
-
-    if not telegram_enabled_bool:
-        logger.info("NotificationService 건너뜀 — telegram_enabled=false")
-        return
-
     try:
         telegram_token = s.config.secret("TELEGRAM_BOT_TOKEN")
         telegram_chat_id = s.config.secret("TELEGRAM_CHAT_ID")
     except ConfigError as err:
         logger.info("NotificationService 건너뜀 — Telegram 시크릿 없음: %s", err)
+        return
+
+    if not (telegram_token and telegram_chat_id):
+        logger.info("NotificationService 건너뜀 — Telegram 시크릿이 공란")
         return
 
     adapter = TelegramAdapter(bot_token=telegram_token, chat_id=telegram_chat_id)
@@ -1139,6 +1147,11 @@ async def _init_notification(s: Services) -> None:
             if parsed:
                 quiet_start, quiet_end = parsed
 
+    telegram_enabled = await s.dynamic_config.get(
+        "notification.telegram_enabled", default="true"
+    )
+    telegram_enabled_bool = str(telegram_enabled) == "true"
+
     s.notification_service = NotificationService(
         adapter=adapter,
         eventbus=s.eventbus,
@@ -1148,7 +1161,9 @@ async def _init_notification(s: Services) -> None:
         telegram_enabled=telegram_enabled_bool,
     )
     s.notification_service.subscribe()
-    logger.info("NotificationService 초기화 완료 (Telegram)")
+    logger.info(
+        "NotificationService 초기화 완료 (Telegram, enabled=%s)", telegram_enabled_bool
+    )
 
     # TelegramCommandReceiver
     from ante.notification import TelegramCommandReceiver
@@ -1163,7 +1178,7 @@ async def _init_notification(s: Services) -> None:
                 "TELEGRAM_CHAT_ID 값이 올바른 정수가 아닙니다: %r — 무시합니다",
                 chat_id_str,
             )
-    if chat_id is not None:
+    if telegram_enabled_bool and chat_id is not None:
         s.telegram_receiver = TelegramCommandReceiver(
             adapter=adapter,
             allowed_user_ids=[chat_id],
@@ -1175,6 +1190,8 @@ async def _init_notification(s: Services) -> None:
         )
         s.telegram_receiver.start()
         logger.info("TelegramCommandReceiver 시작 (chat_id=%s)", chat_id)
+    elif not telegram_enabled_bool:
+        logger.info("TelegramCommandReceiver 건너뜀 — telegram_enabled=false")
     else:
         logger.info("TelegramCommandReceiver 건너뜀 — TELEGRAM_CHAT_ID 미설정")
 

--- a/tests/unit/test_main_init_notification.py
+++ b/tests/unit/test_main_init_notification.py
@@ -1,0 +1,186 @@
+"""``_init_notification`` 단위 테스트 (#1118).
+
+``notification.telegram_enabled=false`` 일 때 Telegram 시크릿 조회 없이
+즉시 반환되는지, 활성화 상태에서 시크릿이 없으면 ``ConfigError`` 를
+흡수하고 건너뛰는지 검증한다.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from ante.config import ConfigError
+from ante.main import Services, _init_notification
+
+
+class _StubConfig:
+    """``Config.secret/get`` 계약만 만족하는 최소 더블."""
+
+    def __init__(
+        self,
+        *,
+        secrets: dict[str, str] | None = None,
+        values: dict[str, Any] | None = None,
+    ) -> None:
+        self._secrets = secrets or {}
+        self._values = values or {}
+
+    def secret(self, key: str) -> str:
+        if key not in self._secrets:
+            raise ConfigError(f"Secret not found: {key}")
+        return self._secrets[key]
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._values.get(key, default)
+
+
+class _StubDynamicConfig:
+    """``DynamicConfigService.get`` 계약만 만족하는 최소 더블."""
+
+    def __init__(self, values: dict[str, Any] | None = None) -> None:
+        self._values = values or {}
+
+    async def get(self, key: str, default: Any = None) -> Any:
+        return self._values.get(key, default)
+
+
+class _StubEventBus:
+    pass
+
+
+def _make_services(
+    *,
+    telegram_enabled: str | None = "true",
+    secrets: dict[str, str] | None = None,
+) -> Services:
+    values: dict[str, Any] = {}
+    if telegram_enabled is not None:
+        # 정적 config 는 사용되지 않지만 secret/get 계약 일관성을 위해 둔다.
+        values["notification.min_level"] = "info"
+    s = Services()
+    s.config = _StubConfig(secrets=secrets, values=values)  # type: ignore[assignment]
+    s.eventbus = _StubEventBus()  # type: ignore[assignment]
+    dynamic_values: dict[str, Any] = {}
+    if telegram_enabled is not None:
+        dynamic_values["notification.telegram_enabled"] = telegram_enabled
+    s.dynamic_config = _StubDynamicConfig(dynamic_values)  # type: ignore[assignment]
+    return s
+
+
+@pytest.mark.asyncio
+async def test_disabled_skips_without_secrets() -> None:
+    """telegram_enabled=false + 시크릿 없음 → ConfigError 없이 정상 return."""
+    s = _make_services(telegram_enabled="false", secrets=None)
+
+    await _init_notification(s)
+
+    assert s.notification_service is None
+    assert s.telegram_receiver is None
+
+
+@pytest.mark.asyncio
+async def test_disabled_skips_even_with_secrets() -> None:
+    """telegram_enabled=false 면 시크릿이 있어도 NotificationService 미생성."""
+    s = _make_services(
+        telegram_enabled="false",
+        secrets={"TELEGRAM_BOT_TOKEN": "t", "TELEGRAM_CHAT_ID": "42"},
+    )
+
+    await _init_notification(s)
+
+    assert s.notification_service is None
+    assert s.telegram_receiver is None
+
+
+@pytest.mark.asyncio
+async def test_enabled_without_secrets_skips_gracefully() -> None:
+    """telegram_enabled=true 이지만 시크릿 누락 → ConfigError 흡수 후 skip."""
+    s = _make_services(telegram_enabled="true", secrets=None)
+
+    await _init_notification(s)
+
+    assert s.notification_service is None
+    assert s.telegram_receiver is None
+
+
+@pytest.mark.asyncio
+async def test_enabled_with_only_token_skips_gracefully() -> None:
+    """두 시크릿 중 하나라도 빠지면 부팅을 막지 않고 skip."""
+    s = _make_services(
+        telegram_enabled="true",
+        secrets={"TELEGRAM_BOT_TOKEN": "t"},  # CHAT_ID 누락
+    )
+
+    await _init_notification(s)
+
+    assert s.notification_service is None
+    assert s.telegram_receiver is None
+
+
+@pytest.mark.asyncio
+async def test_default_enabled_when_dynamic_config_empty() -> None:
+    """dynamic_config 에 값이 없으면 기본값 "true" 로 해석되어 시크릿을 조회한다.
+
+    시크릿 없음 → ConfigError 흡수 경로로 skip 되어야 한다 (부팅 안 막힘).
+    """
+    s = _make_services(telegram_enabled=None, secrets=None)
+
+    await _init_notification(s)
+
+    assert s.notification_service is None
+    assert s.telegram_receiver is None
+
+
+@pytest.mark.asyncio
+async def test_enabled_with_secrets_initializes_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """telegram_enabled=true + 시크릿 모두 존재 → NotificationService 생성."""
+    s = _make_services(
+        telegram_enabled="true",
+        secrets={"TELEGRAM_BOT_TOKEN": "t", "TELEGRAM_CHAT_ID": "42"},
+    )
+
+    # TELEGRAM_CHAT_ID 환경변수가 parse 될 수 있도록 설정 (receiver 활성화 경로).
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "42")
+
+    # NotificationService.subscribe 가 실제 EventBus 계약을 요구하므로,
+    # 서비스 생성 후 subscribe 단계에서 실패해도 본 테스트의 목적(= 시크릿
+    # 조회 순서 + 초기화 진입)에는 영향 없다. 생성 단계까지만 검증한다.
+    created: list[Any] = []
+
+    import ante.notification as notification_mod
+
+    original_cls = notification_mod.NotificationService
+
+    class _StubNotificationService:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            created.append(SimpleNamespace(args=args, kwargs=kwargs))
+
+        def subscribe(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        notification_mod, "NotificationService", _StubNotificationService
+    )
+
+    class _StubReceiver:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.started = False
+
+        def start(self) -> None:
+            self.started = True
+
+    monkeypatch.setattr(notification_mod, "TelegramCommandReceiver", _StubReceiver)
+
+    try:
+        await _init_notification(s)
+    finally:
+        monkeypatch.setattr(notification_mod, "NotificationService", original_cls)
+
+    assert len(created) == 1, "NotificationService 생성자 호출 누락"
+    assert s.notification_service is not None
+    assert s.telegram_receiver is not None

--- a/tests/unit/test_main_init_notification.py
+++ b/tests/unit/test_main_init_notification.py
@@ -82,11 +82,72 @@ async def test_disabled_skips_without_secrets() -> None:
 
 
 @pytest.mark.asyncio
-async def test_disabled_skips_even_with_secrets() -> None:
-    """telegram_enabled=false 면 시크릿이 있어도 NotificationService 미생성."""
+async def test_disabled_with_secrets_still_creates_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """telegram_enabled=false + 시크릿 존재 → 서비스는 생성한다.
+
+    CRITICAL 알림 예외 경로와 ``ConfigChangedEvent`` 기반 동적 재활성화
+    (notification 스펙 §_should_send) 를 보존하려면, disabled 상태에서도
+    NotificationService 자체는 살아 있어야 한다. ``telegram_enabled=False``
+    플래그만 필터로 전달한다. Receiver 는 토글 OFF 상태이므로 시작하지 않는다.
+    """
     s = _make_services(
         telegram_enabled="false",
         secrets={"TELEGRAM_BOT_TOKEN": "t", "TELEGRAM_CHAT_ID": "42"},
+    )
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "42")
+
+    created_kwargs: list[dict[str, Any]] = []
+
+    import ante.notification as notification_mod
+
+    class _StubNotificationService:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            created_kwargs.append(kwargs)
+
+        def subscribe(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        notification_mod, "NotificationService", _StubNotificationService
+    )
+
+    await _init_notification(s)
+
+    assert len(created_kwargs) == 1, "disabled 상태에서도 서비스는 생성되어야 한다"
+    assert created_kwargs[0]["telegram_enabled"] is False
+    assert s.notification_service is not None
+    assert s.telegram_receiver is None, (
+        "Receiver 는 telegram_enabled=false 일 때 시작되면 안 된다"
+    )
+
+
+@pytest.mark.asyncio
+async def test_disabled_with_empty_secrets_skips() -> None:
+    """telegram_enabled=false + 공란 시크릿 → skip (adapter 생성 불가)."""
+    s = _make_services(
+        telegram_enabled="false",
+        secrets={"TELEGRAM_BOT_TOKEN": "", "TELEGRAM_CHAT_ID": ""},
+    )
+
+    await _init_notification(s)
+
+    assert s.notification_service is None
+    assert s.telegram_receiver is None
+
+
+@pytest.mark.asyncio
+async def test_enabled_with_empty_secrets_skips() -> None:
+    """telegram_enabled=true + 공란 시크릿 → broken adapter 방지 skip.
+
+    ``Config.secret()`` 은 env 가 ``""`` 로 설정된 경우 빈 문자열을 반환하므로
+    (raise 가 아님), 명시적 공란 가드가 필요하다. 스테이징 환경에서 시크릿을
+    의도적으로 비워 두는 방식을 안전하게 지원한다.
+    """
+    s = _make_services(
+        telegram_enabled="true",
+        secrets={"TELEGRAM_BOT_TOKEN": "", "TELEGRAM_CHAT_ID": ""},
     )
 
     await _init_notification(s)


### PR DESCRIPTION
Closes #1118

## Summary
- `_init_notification()` 이 `Config.secret()` 의 `ConfigError` 를 먼저 흡수하도록 순서를 재배치 — Telegram 자격증명이 없는 stage 환경에서도 부팅이 막히지 않는다.
- 공란 시크릿 가드 복원 — `Config.secret()` 이 env `""` 값을 그대로 반환하므로 `if not (token and chat_id): return` 가드가 반드시 필요하다.
- 시크릿이 존재하면 `notification.telegram_enabled` 플래그와 무관하게 `NotificationService` 를 항상 생성 — CRITICAL 알림 예외 경로와 `ConfigChangedEvent` 기반 런타임 재활성화 계약을 보존한다 (`docs/specs/notification/notification.md` §_should_send).
- Receiver 는 기존대로 `telegram_enabled=true` 이고 `TELEGRAM_CHAT_ID` 파싱 가능한 경우에만 시작.

## Context
브랜치 리뷰(5d079f8) 에서 초기 구현이 두 계약을 깼다는 지적을 받고 수정한 2번째 커밋(0409ca7) 이 재검토 PASS.

**Initial FAIL → Resolved**
1. 초기 구현은 `telegram_enabled=false` 시 NotificationService 자체를 지워 CRITICAL 알림/토글 계약이 깨졌음 → 시크릿 존재 시 서비스는 항상 생성하도록 수정.
2. 공란 시크릿 가드가 제거되어 broken adapter 가 초기화될 위험 → 가드 복원.

## Test Plan
- `pytest tests/unit/test_main_init_notification.py tests/unit/test_notification.py tests/unit/test_main.py` — 49 passed
- `ruff check`, `ruff format --check`, `mypy src/ante/main.py` — 전부 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)