### PR TITLE
chore(repo): 로컬 에이전트 아티팩트 ignore 및 github-auth 스킬 추가

### DIFF
--- a/.agent/skills/github-auth.md
+++ b/.agent/skills/github-auth.md
@@ -1,0 +1,56 @@
+# GitHub 인증 스킬
+
+> 이 저장소에서 GitHub CLI 쓰기 작업을 하기 전에 로컬 PAT를 로드하고 상태를 점검한다.
+
+## 목적
+
+- `gh pr create`
+- `gh issue comment`
+- `gh run rerun`
+- `gh workflow run`
+
+같은 GitHub CLI 작업 전에 인증 상태를 일관되게 맞춘다.
+
+## 로컬 파일 위치
+
+- 실제 토큰 파일: `.github/local/github.env`
+- 예시 파일: `.github/local/github.env.example`
+
+실제 토큰 파일은 `.gitignore`로 제외한다.
+
+## 사전 조건
+
+- 토큰은 fine-grained PAT 권장
+- 권한 권장치:
+  - `Contents`: `Read and write`
+  - `Pull requests`: `Read and write`
+  - `Issues`: `Read and write`
+  - `Actions`: `Read` 또는 `Write`
+
+## 초기 설정
+
+```bash
+cp .github/local/github.env.example .github/local/github.env
+```
+
+`GH_TOKEN` 값을 실제 PAT로 바꾼다.
+
+## 사용 절차
+
+```bash
+source .github/local/github.env
+gh auth status
+```
+
+## 점검 규칙
+
+1. `gh auth status`가 성공하면 그대로 진행한다.
+2. 실패하면 `.github/local/github.env`가 존재하는지 확인한다.
+3. 파일이 있으면 다시 `source .github/local/github.env` 후 `gh auth status`를 재실행한다.
+4. 계속 실패하면 PAT 만료 또는 권한 부족으로 보고 토큰을 재발급한다.
+
+## 보안 원칙
+
+- 토큰 문자열을 문서, 커밋, 이슈, PR 코멘트에 직접 남기지 않는다.
+- `config/secrets.env`와 혼용하지 않는다.
+- 쓰기 권한이 필요한 저장소만 대상으로 최소 권한으로 발급한다.

--- a/.agent/skills/github-auth.md
+++ b/.agent/skills/github-auth.md
@@ -25,7 +25,7 @@
   - `Contents`: `Read and write`
   - `Pull requests`: `Read and write`
   - `Issues`: `Read and write`
-  - `Actions`: `Read` 또는 `Write`
+  - `Actions`: `Read and write` (수동 복구에 `gh run rerun` / `gh workflow run` 필요)
 
 ## 초기 설정
 

--- a/.github/local/github.env.example
+++ b/.github/local/github.env.example
@@ -1,0 +1,11 @@
+# Repo-local GitHub CLI authentication
+#
+# Usage:
+#   cp .github/local/github.env.example .github/local/github.env
+#   edit .github/local/github.env
+#   source .github/local/github.env
+#   gh auth status
+#
+# Do not commit .github/local/github.env.
+
+export GH_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 
 # Local agent overrides
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/worktrees/
+
+# Repo-local GitHub CLI auth (tokens)
+.github/local/*
+!.github/local/*.example
 
 # Agent 참고 자료 (임시 작업 디렉토리만 제외)
 docs/temp/

--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -3,7 +3,7 @@
 > 이 문서는 실제 소스 트리에서 생성된 문서입니다.
 > 새 모듈/파일 추가 시 이 문서도 함께 최신화해 주세요.
 >
-> 마지막 갱신: 2026-03-25
+> 마지막 갱신: 2026-04-21
 
 ## 최상위 구조
 
@@ -18,6 +18,7 @@ ante/
 ├── scripts/             # 설치·운영·문서 생성 스크립트
 ├── .agent/              # 에이전트 정의/명령/스킬
 ├── .claude/             # Claude Code 설정 + .agent 호환 링크
+├── .github/             # GitHub 워크플로/이슈 템플릿/로컬 인증 파일
 ├── Dockerfile           # 프로덕션 Docker 이미지
 ├── Dockerfile.qa        # QA 테스트 Docker 이미지
 ├── docker-compose.yml        # 프로덕션 Docker Compose (ante-logs named volume 포함)
@@ -674,11 +675,23 @@ frontend/src/
 └── skills/                      # 프로젝트 스킬 (컨벤션·패턴 참조)
     ├── asyncio-patterns.md
     ├── frontend-conventions.md
+    ├── github-auth.md           # GitHub CLI 로컬 PAT 인증 절차
     ├── module-conventions.md
     ├── qa-tester/               # QA 테스터 스킬 (Gherkin 해석)
     ├── release.md               # /release 릴리스 절차
     ├── review-pr.md
     └── sqlite-patterns.md
+```
+
+## .github/ — GitHub 워크플로/이슈 템플릿/로컬 인증
+
+```
+.github/
+├── ISSUE_TEMPLATE/              # 이슈 템플릿
+├── workflows/                   # GitHub Actions 워크플로
+├── local/                       # 저장소-로컬 개발용 파일 (.gitignore 제외 대상)
+│   └── github.env.example       # gh CLI 인증 환경변수 예시 (실제 github.env는 커밋 금지)
+└── review-output.schema.json    # 리뷰 게이트 출력 스키마
 ```
 
 ## .claude/ — Claude Code 설정 및 호환 레이어


### PR DESCRIPTION
## Summary
- `.gitignore`에 로컬 에이전트 런타임 아티팩트 3종 추가: `.claude/scheduled_tasks.lock`, `.claude/worktrees/`, `.github/local/*` (단 `*.example` 은 허용)
- `.agent/skills/github-auth.md`: GitHub CLI 인증 스킬 문서 추가 (동일 디렉토리 타 스킬과 일관성 맞춤)
- `.github/local/github.env.example`: 스킬 문서가 참조하는 PAT 설정 예시 파일 신규 작성

## Why
- 로컬 PAT 시크릿(`.github/local/github.env`)이 `.gitignore` 규칙 누락으로 untracked 노출되던 문제 해결
- `schedule`/`loop` 스킬 런타임 락·worktree 디렉토리가 작업 트리에 계속 나타나는 노이즈 제거
- github-auth 스킬 문서가 저장소에 없어 에이전트가 참조할 수 없던 상태 보완

## 안전성 감사 (PAT 유출 여부)
- `git log --all --full-history`에서 `.github/local/github.env` 경로 이력 **0건**
- PAT 접두어 패턴(`ghp_`, `github_pat_`, `gho_`, `ghu_`, `ghs_`, `ghr_`) 전체 히스토리 검색 결과 **매치 없음**
- 원격 브랜치에는 `github.env.example`(빈 `export GH_TOKEN=`)만 존재

## Test plan
- [x] `git check-ignore -v` 로 세 규칙 모두 적용 확인
- [x] `git ls-tree -r origin/<branch>` 로 원격에 시크릿 파일 부재 확인
- [ ] 머지 후 main 브랜치에서 `git status`가 언커밋 untracked 0건인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)