### PR TITLE
fix(ci): auto-merge 이후 post-merge 후처리 복구

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -48,6 +48,16 @@ jobs:
               return [...(text || "").matchAll(closingPattern)].map((match) => Number(match[1]));
             }
 
+            async function fetchPullRequest(pullNumber) {
+              return (
+                await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: pullNumber,
+                })
+              ).data;
+            }
+
             async function dispatchPostMergeHandoff(pullNumber, nextDepth) {
               if (!workflowRef) {
                 core.setFailed("Missing workflow ref for post-merge handoff dispatch.");
@@ -75,18 +85,11 @@ jobs:
             async function waitForMergedPullRequest(pullNumber, handoffDepth) {
               const delayMs = 30_000;
               const maxAttempts = 660;
-              const maxHandoffDepth = 6;
               let attempt = 0;
 
               while (attempt < maxAttempts) {
                 attempt += 1;
-                const current = (
-                  await github.rest.pulls.get({
-                    owner,
-                    repo,
-                    pull_number: pullNumber,
-                  })
-                ).data;
+                const current = await fetchPullRequest(pullNumber);
 
                 if (current.merged_at) {
                   core.info(`PR #${pullNumber} merged at ${current.merged_at}.`);
@@ -108,16 +111,39 @@ jobs:
                 await new Promise((resolve) => setTimeout(resolve, delayMs));
               }
 
-              if (handoffDepth < maxHandoffDepth) {
-                const dispatched = await dispatchPostMergeHandoff(pullNumber, handoffDepth + 1);
-                return dispatched ? { type: "handoff" } : { type: "dispatch_failed" };
+              const latest = await fetchPullRequest(pullNumber);
+
+              if (latest.merged_at) {
+                core.info(`PR #${pullNumber} merged at ${latest.merged_at} during handoff boundary.`);
+                return { type: "merged", pr: latest };
               }
 
-              core.setFailed(
-                `PR #${pullNumber} did not merge after ${maxAttempts} attempts ` +
-                `and reached the maximum handoff depth (${maxHandoffDepth}).`,
-              );
-              return { type: "timeout" };
+              if (latest.state === "closed") {
+                core.setFailed(`PR #${pullNumber} was closed without merge.`);
+                return { type: "closed" };
+              }
+
+              try {
+                const dispatched = await dispatchPostMergeHandoff(pullNumber, handoffDepth + 1);
+                return dispatched ? { type: "handoff" } : { type: "dispatch_failed" };
+              } catch (error) {
+                const afterDispatchFailure = await fetchPullRequest(pullNumber);
+
+                if (afterDispatchFailure.merged_at) {
+                  core.info(
+                    `PR #${pullNumber} merged at ${afterDispatchFailure.merged_at} ` +
+                    `while dispatching handoff; continuing in the current run.`,
+                  );
+                  return { type: "merged", pr: afterDispatchFailure };
+                }
+
+                if (afterDispatchFailure.state === "closed") {
+                  core.setFailed(`PR #${pullNumber} was closed without merge.`);
+                  return { type: "closed" };
+                }
+
+                throw error;
+              }
             }
 
             let pr = null;
@@ -132,13 +158,7 @@ jobs:
                 Number.isInteger(handoffDepth) && handoffDepth >= 0 ? handoffDepth : 0;
 
               if (prNumberInput) {
-                pr = (
-                  await github.rest.pulls.get({
-                    owner,
-                    repo,
-                    pull_number: Number(prNumberInput),
-                  })
-                ).data;
+                pr = await fetchPullRequest(Number(prNumberInput));
 
                 if (!pr.merged_at) {
                   const waitResult = await waitForMergedPullRequest(pr.number, normalizedHandoffDepth);

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -20,6 +20,7 @@ jobs:
     name: post-merge
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
+    timeout-minutes: 360
     permissions:
       contents: read
       issues: write
@@ -40,10 +41,11 @@ jobs:
             }
 
             async function waitForMergedPullRequest(pullNumber) {
-              const maxAttempts = 80;
-              const delayMs = 15_000;
+              const delayMs = 30_000;
+              let attempt = 0;
 
-              for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+              while (true) {
+                attempt += 1;
                 const current = (
                   await github.rest.pulls.get({
                     owner,
@@ -65,15 +67,12 @@ jobs:
                 if (attempt === 1 || attempt % 5 === 0) {
                   core.info(
                     `PR #${pullNumber} is not merged yet ` +
-                    `(attempt ${attempt}/${maxAttempts}, state=${current.state}). Waiting ${delayMs / 1000}s...`,
+                    `(attempt ${attempt}, state=${current.state}). Waiting ${delayMs / 1000}s...`,
                   );
                 }
 
                 await new Promise((resolve) => setTimeout(resolve, delayMs));
               }
-
-              core.setFailed(`PR #${pullNumber} did not reach merged state within 20 minutes.`);
-              return null;
             }
 
             let pr = null;

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -79,8 +79,9 @@ jobs:
             let issueNumbers = [];
 
             if (eventName === "workflow_dispatch") {
-              const prNumberInput = core.getInput("pr_number");
-              const issueNumbersInput = core.getInput("issue_numbers");
+              const workflowInputs = context.payload.inputs || {};
+              const prNumberInput = String(workflowInputs.pr_number || "").trim();
+              const issueNumbersInput = String(workflowInputs.issue_numbers || "").trim();
 
               if (prNumberInput) {
                 pr = (

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -14,6 +14,10 @@ on:
         description: Comma-separated issue numbers to reconcile directly
         required: false
         type: string
+      handoff_depth:
+        description: Internal retry depth for long-running merge waits
+        required: false
+        type: string
 
 jobs:
   post-merge:
@@ -22,17 +26,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     permissions:
+      actions: write
       contents: read
       issues: write
       pull-requests: read
     steps:
       - name: Update linked issues
         uses: actions/github-script@v7
+        env:
+          WORKFLOW_REF: ${{ github.ref_name }}
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const eventName = context.eventName;
+            const workflowRef = process.env.WORKFLOW_REF || "";
             const closingPattern =
               /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
 
@@ -40,11 +48,37 @@ jobs:
               return [...(text || "").matchAll(closingPattern)].map((match) => Number(match[1]));
             }
 
-            async function waitForMergedPullRequest(pullNumber) {
+            async function dispatchPostMergeHandoff(pullNumber, nextDepth) {
+              if (!workflowRef) {
+                core.setFailed("Missing workflow ref for post-merge handoff dispatch.");
+                return false;
+              }
+
+              await github.rest.actions.createWorkflowDispatch({
+                owner,
+                repo,
+                workflow_id: "post-merge.yml",
+                ref: workflowRef,
+                inputs: {
+                  pr_number: String(pullNumber),
+                  handoff_depth: String(nextDepth),
+                },
+              });
+
+              core.warning(
+                `PR #${pullNumber} is still waiting to merge. ` +
+                `Dispatched a follow-up post-merge run on ref ${workflowRef} (handoff depth ${nextDepth}).`,
+              );
+              return true;
+            }
+
+            async function waitForMergedPullRequest(pullNumber, handoffDepth) {
               const delayMs = 30_000;
+              const maxAttempts = 660;
+              const maxHandoffDepth = 6;
               let attempt = 0;
 
-              while (true) {
+              while (attempt < maxAttempts) {
                 attempt += 1;
                 const current = (
                   await github.rest.pulls.get({
@@ -56,12 +90,12 @@ jobs:
 
                 if (current.merged_at) {
                   core.info(`PR #${pullNumber} merged at ${current.merged_at}.`);
-                  return current;
+                  return { type: "merged", pr: current };
                 }
 
                 if (current.state === "closed") {
                   core.setFailed(`PR #${pullNumber} was closed without merge.`);
-                  return null;
+                  return { type: "closed" };
                 }
 
                 if (attempt === 1 || attempt % 5 === 0) {
@@ -73,6 +107,17 @@ jobs:
 
                 await new Promise((resolve) => setTimeout(resolve, delayMs));
               }
+
+              if (handoffDepth < maxHandoffDepth) {
+                const dispatched = await dispatchPostMergeHandoff(pullNumber, handoffDepth + 1);
+                return dispatched ? { type: "handoff" } : { type: "dispatch_failed" };
+              }
+
+              core.setFailed(
+                `PR #${pullNumber} did not merge after ${maxAttempts} attempts ` +
+                `and reached the maximum handoff depth (${maxHandoffDepth}).`,
+              );
+              return { type: "timeout" };
             }
 
             let pr = null;
@@ -82,6 +127,9 @@ jobs:
               const workflowInputs = context.payload.inputs || {};
               const prNumberInput = String(workflowInputs.pr_number || "").trim();
               const issueNumbersInput = String(workflowInputs.issue_numbers || "").trim();
+              const handoffDepth = Number.parseInt(String(workflowInputs.handoff_depth || "0"), 10);
+              const normalizedHandoffDepth =
+                Number.isInteger(handoffDepth) && handoffDepth >= 0 ? handoffDepth : 0;
 
               if (prNumberInput) {
                 pr = (
@@ -93,10 +141,11 @@ jobs:
                 ).data;
 
                 if (!pr.merged_at) {
-                  pr = await waitForMergedPullRequest(pr.number);
-                  if (!pr) {
+                  const waitResult = await waitForMergedPullRequest(pr.number, normalizedHandoffDepth);
+                  if (waitResult.type !== "merged") {
                     return;
                   }
+                  pr = waitResult.pr;
                 }
 
                 issueNumbers.push(...parseIssueNumbers(pr.body || ""));

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -33,10 +33,47 @@ jobs:
             const repo = context.repo.repo;
             const eventName = context.eventName;
             const closingPattern =
-              /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?)\s+#(\d+)/gi;
+              /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
 
             function parseIssueNumbers(text) {
               return [...(text || "").matchAll(closingPattern)].map((match) => Number(match[1]));
+            }
+
+            async function waitForMergedPullRequest(pullNumber) {
+              const maxAttempts = 80;
+              const delayMs = 15_000;
+
+              for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+                const current = (
+                  await github.rest.pulls.get({
+                    owner,
+                    repo,
+                    pull_number: pullNumber,
+                  })
+                ).data;
+
+                if (current.merged_at) {
+                  core.info(`PR #${pullNumber} merged at ${current.merged_at}.`);
+                  return current;
+                }
+
+                if (current.state === "closed") {
+                  core.setFailed(`PR #${pullNumber} was closed without merge.`);
+                  return null;
+                }
+
+                if (attempt === 1 || attempt % 5 === 0) {
+                  core.info(
+                    `PR #${pullNumber} is not merged yet ` +
+                    `(attempt ${attempt}/${maxAttempts}, state=${current.state}). Waiting ${delayMs / 1000}s...`,
+                  );
+                }
+
+                await new Promise((resolve) => setTimeout(resolve, delayMs));
+              }
+
+              core.setFailed(`PR #${pullNumber} did not reach merged state within 20 minutes.`);
+              return null;
             }
 
             let pr = null;
@@ -55,11 +92,14 @@ jobs:
                   })
                 ).data;
 
-                issueNumbers.push(...parseIssueNumbers(pr.body || ""));
-
                 if (!pr.merged_at) {
-                  core.warning(`PR #${pr.number} is not merged. Proceeding with manual reconciliation.`);
+                  pr = await waitForMergedPullRequest(pr.number);
+                  if (!pr) {
+                    return;
+                  }
                 }
+
+                issueNumbers.push(...parseIssueNumbers(pr.body || ""));
               }
 
               if (issueNumbersInput) {

--- a/.github/workflows/pr-approvals.yml
+++ b/.github/workflows/pr-approvals.yml
@@ -555,26 +555,6 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash
 
-      - name: Wait for merged pull request
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          for attempt in {1..20}; do
-            MERGED_AT="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json mergedAt --jq '.mergedAt // ""')"
-            if [[ -n "$MERGED_AT" ]]; then
-              echo "PR #$PR_NUMBER merged at $MERGED_AT"
-              exit 0
-            fi
-
-            STATE="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq '.state')"
-            echo "Waiting for PR #$PR_NUMBER to merge (attempt $attempt/20, state=$STATE)..."
-            sleep 3
-          done
-
-          echo "Timed out waiting for PR #$PR_NUMBER to merge after enabling auto-merge." >&2
-          exit 1
-
       - name: Dispatch post-merge reconciliation
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-approvals.yml
+++ b/.github/workflows/pr-approvals.yml
@@ -558,5 +558,6 @@ jobs:
       - name: Dispatch post-merge reconciliation
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh workflow run post-merge.yml --repo "$GITHUB_REPOSITORY" -f pr_number="$PR_NUMBER"
+        run: gh workflow run post-merge.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD_REF" -f pr_number="$PR_NUMBER"

--- a/.github/workflows/pr-approvals.yml
+++ b/.github/workflows/pr-approvals.yml
@@ -545,6 +545,7 @@ jobs:
       - codex-pr-approve
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       pull-requests: write
     steps:
@@ -553,3 +554,29 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash
+
+      - name: Wait for merged pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          for attempt in {1..20}; do
+            MERGED_AT="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json mergedAt --jq '.mergedAt // ""')"
+            if [[ -n "$MERGED_AT" ]]; then
+              echo "PR #$PR_NUMBER merged at $MERGED_AT"
+              exit 0
+            fi
+
+            STATE="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq '.state')"
+            echo "Waiting for PR #$PR_NUMBER to merge (attempt $attempt/20, state=$STATE)..."
+            sleep 3
+          done
+
+          echo "Timed out waiting for PR #$PR_NUMBER to merge after enabling auto-merge." >&2
+          exit 1
+
+      - name: Dispatch post-merge reconciliation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh workflow run post-merge.yml --repo "$GITHUB_REPOSITORY" -f pr_number="$PR_NUMBER"

--- a/.github/workflows/pr-approvals.yml
+++ b/.github/workflows/pr-approvals.yml
@@ -549,15 +549,15 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Enable auto-merge
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash
-
       - name: Dispatch post-merge reconciliation
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: gh workflow run post-merge.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD_REF" -f pr_number="$PR_NUMBER"
+
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash

--- a/docs/runbooks/03-git-workflow.md
+++ b/docs/runbooks/03-git-workflow.md
@@ -139,6 +139,8 @@ PR을 열기 전, 최신 브랜치 HEAD는 반드시 Codex 사전 리뷰를 통�
 - 기본 머지 방식은 **squash merge**
 - merge 실행 주체는 GitHub auto-merge
 - head branch 삭제는 GitHub의 **Automatically delete head branches** 설정 사용
+- head branch 자동 삭제가 필요하면 repository ruleset / branch protection이 모든 브랜치 삭제를 막지 않도록 확인한다
+- `main` 보호는 `main` branch protection의 `allow_deletions=false`를 기준으로 두고, 전 브랜치 공통 ruleset에 `deletion`을 넣지 않는다
 
 ### 4.5 PR 크기 가이드
 

--- a/docs/runbooks/04-ci-cd.md
+++ b/docs/runbooks/04-ci-cd.md
@@ -135,7 +135,7 @@ post-merge automation
 
 출력:
 - auto-merge 활성화 또는 유지
-- auto-merge 활성화 직후 PR head ref 기준 `workflow_dispatch`로 `post-merge.yml` 호출
+- auto-merge 활성화 전에 PR head ref 기준 `workflow_dispatch`로 `post-merge.yml` 호출
 - `post-merge.yml`은 별도 workflow run 안에서 PR의 실제 merged 상태를 기다린 뒤 후처리를 수행
 - 머지 불가 시 대기
 
@@ -224,8 +224,9 @@ pytest tests/unit/ -v
 - 알려진 실패 모드:
   - GitHub Actions의 `GITHUB_TOKEN`으로 수행한 auto-merge는 후속 workflow run을 자동으로 만들지 않아 `pull_request.closed` 후처리가 누락될 수 있음
   - `workflow_dispatch`를 default branch 기준으로 실행하면, 머지 전에는 최신 PR 브랜치의 `post-merge.yml` 변경이 반영되지 않음
+  - `workflow_dispatch`를 auto-merge 뒤에 호출하면, head branch 자동 삭제와 경쟁해 PR head ref를 찾지 못할 수 있음
   - merge actor나 이벤트 경로 차이로 `pull_request.closed` 후처리가 기대대로 실행되지 않음
-  - auto-merge 직후 별도 `post-merge` run이 시작되어도, 실제 merged 상태가 늦게 반영될 수 있어 workflow 내부 대기가 필요함
+  - auto-merge 전에 별도 `post-merge` run을 시작해도, 실제 merged 상태가 늦게 반영될 수 있어 workflow 내부 대기가 필요함
   - `workflow_dispatch` 입력 파싱 실패
   - GitHub 기본 auto-close는 되었지만 체크박스/에픽 동기화가 누락됨
 - 복구 순서:

--- a/docs/runbooks/04-ci-cd.md
+++ b/docs/runbooks/04-ci-cd.md
@@ -135,7 +135,8 @@ post-merge automation
 
 출력:
 - auto-merge 활성화 또는 유지
-- auto-merge 직후 PR이 실제로 merged 상태가 되면 `workflow_dispatch`로 `post-merge.yml` 호출
+- auto-merge 활성화 직후 `workflow_dispatch`로 `post-merge.yml` 호출
+- `post-merge.yml`은 별도 workflow run 안에서 PR의 실제 merged 상태를 기다린 뒤 후처리를 수행
 - 머지 불가 시 대기
 
 **원칙**: merge gate는 세 번째 코드 리뷰어가 아니라 **정책 집행자**다.
@@ -223,6 +224,7 @@ pytest tests/unit/ -v
 - 알려진 실패 모드:
   - GitHub Actions의 `GITHUB_TOKEN`으로 수행한 auto-merge는 후속 workflow run을 자동으로 만들지 않아 `pull_request.closed` 후처리가 누락될 수 있음
   - merge actor나 이벤트 경로 차이로 `pull_request.closed` 후처리가 기대대로 실행되지 않음
+  - auto-merge 직후 별도 `post-merge` run이 시작되어도, 실제 merged 상태가 늦게 반영되면 workflow 내부 대기나 timeout이 필요함
   - `workflow_dispatch` 입력 파싱 실패
   - GitHub 기본 auto-close는 되었지만 체크박스/에픽 동기화가 누락됨
 - 복구 순서:

--- a/docs/runbooks/04-ci-cd.md
+++ b/docs/runbooks/04-ci-cd.md
@@ -135,7 +135,7 @@ post-merge automation
 
 출력:
 - auto-merge 활성화 또는 유지
-- auto-merge 활성화 직후 `workflow_dispatch`로 `post-merge.yml` 호출
+- auto-merge 활성화 직후 PR head ref 기준 `workflow_dispatch`로 `post-merge.yml` 호출
 - `post-merge.yml`은 별도 workflow run 안에서 PR의 실제 merged 상태를 기다린 뒤 후처리를 수행
 - 머지 불가 시 대기
 
@@ -223,8 +223,9 @@ pytest tests/unit/ -v
 
 - 알려진 실패 모드:
   - GitHub Actions의 `GITHUB_TOKEN`으로 수행한 auto-merge는 후속 workflow run을 자동으로 만들지 않아 `pull_request.closed` 후처리가 누락될 수 있음
+  - `workflow_dispatch`를 default branch 기준으로 실행하면, 머지 전에는 최신 PR 브랜치의 `post-merge.yml` 변경이 반영되지 않음
   - merge actor나 이벤트 경로 차이로 `pull_request.closed` 후처리가 기대대로 실행되지 않음
-  - auto-merge 직후 별도 `post-merge` run이 시작되어도, 실제 merged 상태가 늦게 반영되면 workflow 내부 대기나 timeout이 필요함
+  - auto-merge 직후 별도 `post-merge` run이 시작되어도, 실제 merged 상태가 늦게 반영될 수 있어 workflow 내부 대기가 필요함
   - `workflow_dispatch` 입력 파싱 실패
   - GitHub 기본 auto-close는 되었지만 체크박스/에픽 동기화가 누락됨
 - 복구 순서:

--- a/docs/runbooks/04-ci-cd.md
+++ b/docs/runbooks/04-ci-cd.md
@@ -136,7 +136,7 @@ post-merge automation
 출력:
 - auto-merge 활성화 또는 유지
 - auto-merge 활성화 전에 PR head ref 기준 `workflow_dispatch`로 `post-merge.yml` 호출
-- `post-merge.yml`은 별도 workflow run 안에서 PR의 실제 merged 상태를 기다린 뒤 후처리를 수행
+- `post-merge.yml`은 별도 workflow run 안에서 PR의 실제 merged 상태를 기다린 뒤 후처리를 수행하고, 장기 대기 시 timeout 전에 자기 자신을 다시 dispatch해 대기를 넘겨받는다
 - 머지 불가 시 대기
 
 **원칙**: merge gate는 세 번째 코드 리뷰어가 아니라 **정책 집행자**다.
@@ -226,7 +226,7 @@ pytest tests/unit/ -v
   - `workflow_dispatch`를 default branch 기준으로 실행하면, 머지 전에는 최신 PR 브랜치의 `post-merge.yml` 변경이 반영되지 않음
   - `workflow_dispatch`를 auto-merge 뒤에 호출하면, head branch 자동 삭제와 경쟁해 PR head ref를 찾지 못할 수 있음
   - merge actor나 이벤트 경로 차이로 `pull_request.closed` 후처리가 기대대로 실행되지 않음
-  - auto-merge 전에 별도 `post-merge` run을 시작해도, 실제 merged 상태가 늦게 반영될 수 있어 workflow 내부 대기가 필요함
+  - auto-merge 전에 별도 `post-merge` run을 시작해도, 실제 merged 상태가 늦게 반영될 수 있어 workflow 내부 대기와 handoff 재-dispatch가 필요함
   - `workflow_dispatch` 입력 파싱 실패
   - GitHub 기본 auto-close는 되었지만 체크박스/에픽 동기화가 누락됨
 - 복구 순서:

--- a/docs/runbooks/04-ci-cd.md
+++ b/docs/runbooks/04-ci-cd.md
@@ -136,7 +136,8 @@ post-merge automation
 출력:
 - auto-merge 활성화 또는 유지
 - auto-merge 활성화 전에 PR head ref 기준 `workflow_dispatch`로 `post-merge.yml` 호출
-- `post-merge.yml`은 별도 workflow run 안에서 PR의 실제 merged 상태를 기다린 뒤 후처리를 수행하고, 장기 대기 시 timeout 전에 자기 자신을 다시 dispatch해 대기를 넘겨받는다
+- `post-merge.yml`은 별도 workflow run 안에서 PR의 실제 merged 상태를 기다린 뒤 후처리를 수행하고, 장기 대기 시 handoff 직전에 PR 상태를 다시 확인한 뒤 자기 자신을 다시 dispatch해 대기를 넘겨받는다
+- 장기 대기 handoff에는 고정 횟수 제한을 두지 않고 merged 상태까지 자동 경로를 유지한다
 - 머지 불가 시 대기
 
 **원칙**: merge gate는 세 번째 코드 리뷰어가 아니라 **정책 집행자**다.

--- a/docs/runbooks/04-ci-cd.md
+++ b/docs/runbooks/04-ci-cd.md
@@ -135,6 +135,7 @@ post-merge automation
 
 출력:
 - auto-merge 활성화 또는 유지
+- auto-merge 직후 PR이 실제로 merged 상태가 되면 `workflow_dispatch`로 `post-merge.yml` 호출
 - 머지 불가 시 대기
 
 **원칙**: merge gate는 세 번째 코드 리뷰어가 아니라 **정책 집행자**다.
@@ -149,7 +150,7 @@ post-merge automation
     ├── ci.yml                    # Gate B: lint + test
     ├── codex-branch-review.yml   # Gate A: PR 전 Codex 브랜치 리뷰
     ├── pr-approvals.yml          # Gate C/D: Claude + Codex PR 승인
-    ├── post-merge.yml            # 머지 후 이슈 정리, 후처리
+    ├── post-merge.yml            # 머지 후 이슈 정리, 후처리 (closed event + workflow_dispatch)
     ├── semantic-release.yml      # 수동 릴리스
     └── publish.yml               # Release 기반 배포
 ```
@@ -220,6 +221,7 @@ pytest tests/unit/ -v
 ### 5.2 Post-merge 실패 모드와 복구
 
 - 알려진 실패 모드:
+  - GitHub Actions의 `GITHUB_TOKEN`으로 수행한 auto-merge는 후속 workflow run을 자동으로 만들지 않아 `pull_request.closed` 후처리가 누락될 수 있음
   - merge actor나 이벤트 경로 차이로 `pull_request.closed` 후처리가 기대대로 실행되지 않음
   - `workflow_dispatch` 입력 파싱 실패
   - GitHub 기본 auto-close는 되었지만 체크박스/에픽 동기화가 누락됨

--- a/docs/runbooks/07-review-gate.md
+++ b/docs/runbooks/07-review-gate.md
@@ -191,7 +191,8 @@ PR 승인 워커 실패는 아래처럼 분리해서 처리한다.
 ### 6.1 Post-merge 수동 복구
 
 - auto-merged PR은 `merge-gate`가 auto-merge 활성화 전에 PR head ref 기준 `workflow_dispatch`로 `post-merge`를 호출한다.
-- `post-merge`는 별도 workflow run 안에서 PR의 실제 merged 상태를 기다린 뒤 이슈 reconciliation을 수행하고, 장기 대기 시 timeout 전에 자기 자신을 다시 dispatch해 대기를 넘겨받는다.
+- `post-merge`는 별도 workflow run 안에서 PR의 실제 merged 상태를 기다린 뒤 이슈 reconciliation을 수행하고, 장기 대기 시 handoff 직전에 PR 상태를 다시 확인한 뒤 자기 자신을 다시 dispatch해 대기를 넘겨받는다.
+- 장기 대기 handoff에는 고정 횟수 제한을 두지 않고 merged 상태까지 자동 경로를 유지한다.
 - `post-merge`가 자동으로 실행되지 않거나, 실행되었어도 체크박스/에픽 동기화가 누락될 수 있다.
 - 복구 순서:
   1. PR 번호 기준 `workflow_dispatch`

--- a/docs/runbooks/07-review-gate.md
+++ b/docs/runbooks/07-review-gate.md
@@ -190,7 +190,8 @@ PR 승인 워커 실패는 아래처럼 분리해서 처리한다.
 
 ### 6.1 Post-merge 수동 복구
 
-- auto-merged PR은 `merge-gate`가 merged 상태를 확인한 뒤 `workflow_dispatch`로 `post-merge`를 다시 호출한다.
+- auto-merged PR은 `merge-gate`가 auto-merge 활성화 직후 `workflow_dispatch`로 `post-merge`를 호출한다.
+- `post-merge`는 별도 workflow run 안에서 PR의 실제 merged 상태를 기다린 뒤 이슈 reconciliation을 수행한다.
 - `post-merge`가 자동으로 실행되지 않거나, 실행되었어도 체크박스/에픽 동기화가 누락될 수 있다.
 - 복구 순서:
   1. PR 번호 기준 `workflow_dispatch`

--- a/docs/runbooks/07-review-gate.md
+++ b/docs/runbooks/07-review-gate.md
@@ -191,7 +191,7 @@ PR 승인 워커 실패는 아래처럼 분리해서 처리한다.
 ### 6.1 Post-merge 수동 복구
 
 - auto-merged PR은 `merge-gate`가 auto-merge 활성화 전에 PR head ref 기준 `workflow_dispatch`로 `post-merge`를 호출한다.
-- `post-merge`는 별도 workflow run 안에서 PR의 실제 merged 상태를 기다린 뒤 이슈 reconciliation을 수행한다.
+- `post-merge`는 별도 workflow run 안에서 PR의 실제 merged 상태를 기다린 뒤 이슈 reconciliation을 수행하고, 장기 대기 시 timeout 전에 자기 자신을 다시 dispatch해 대기를 넘겨받는다.
 - `post-merge`가 자동으로 실행되지 않거나, 실행되었어도 체크박스/에픽 동기화가 누락될 수 있다.
 - 복구 순서:
   1. PR 번호 기준 `workflow_dispatch`

--- a/docs/runbooks/07-review-gate.md
+++ b/docs/runbooks/07-review-gate.md
@@ -190,7 +190,7 @@ PR 승인 워커 실패는 아래처럼 분리해서 처리한다.
 
 ### 6.1 Post-merge 수동 복구
 
-- auto-merged PR은 `merge-gate`가 auto-merge 활성화 직후 PR head ref 기준 `workflow_dispatch`로 `post-merge`를 호출한다.
+- auto-merged PR은 `merge-gate`가 auto-merge 활성화 전에 PR head ref 기준 `workflow_dispatch`로 `post-merge`를 호출한다.
 - `post-merge`는 별도 workflow run 안에서 PR의 실제 merged 상태를 기다린 뒤 이슈 reconciliation을 수행한다.
 - `post-merge`가 자동으로 실행되지 않거나, 실행되었어도 체크박스/에픽 동기화가 누락될 수 있다.
 - 복구 순서:

--- a/docs/runbooks/07-review-gate.md
+++ b/docs/runbooks/07-review-gate.md
@@ -190,7 +190,7 @@ PR 승인 워커 실패는 아래처럼 분리해서 처리한다.
 
 ### 6.1 Post-merge 수동 복구
 
-- auto-merged PR은 `merge-gate`가 auto-merge 활성화 직후 `workflow_dispatch`로 `post-merge`를 호출한다.
+- auto-merged PR은 `merge-gate`가 auto-merge 활성화 직후 PR head ref 기준 `workflow_dispatch`로 `post-merge`를 호출한다.
 - `post-merge`는 별도 workflow run 안에서 PR의 실제 merged 상태를 기다린 뒤 이슈 reconciliation을 수행한다.
 - `post-merge`가 자동으로 실행되지 않거나, 실행되었어도 체크박스/에픽 동기화가 누락될 수 있다.
 - 복구 순서:

--- a/docs/runbooks/07-review-gate.md
+++ b/docs/runbooks/07-review-gate.md
@@ -182,7 +182,7 @@ PR 승인 워커 실패는 아래처럼 분리해서 처리한다.
 | 작업 | 담당 |
 |------|------|
 | PR 머지 | GitHub auto-merge |
-| head branch 삭제 | GitHub repository setting |
+| head branch 삭제 | GitHub repository setting + head branch 삭제를 막지 않는 ruleset |
 | 이슈 체크박스 갱신 + close | `post-merge.yml` |
 | 로컬 worktree 정리 | Claude 구현 머신 |
 
@@ -190,6 +190,7 @@ PR 승인 워커 실패는 아래처럼 분리해서 처리한다.
 
 ### 6.1 Post-merge 수동 복구
 
+- auto-merged PR은 `merge-gate`가 merged 상태를 확인한 뒤 `workflow_dispatch`로 `post-merge`를 다시 호출한다.
 - `post-merge`가 자동으로 실행되지 않거나, 실행되었어도 체크박스/에픽 동기화가 누락될 수 있다.
 - 복구 순서:
   1. PR 번호 기준 `workflow_dispatch`
@@ -215,7 +216,8 @@ PR 승인 워커 실패는 아래처럼 분리해서 처리한다.
 ## 8. 이슈와의 연결
 
 - PR 본문은 기본적으로 `Closes #이슈번호`를 사용한다
-- 이슈 close는 GitHub 기본 auto-close를 우선 사용하고, `post-merge`는 체크박스 / 에픽 상태 동기화와 수동 복구 경로를 담당한다
+- `Refs #이슈번호`는 GitHub 기본 auto-close를 만들지 않으므로, 이슈를 닫을 변경은 `Closes #이슈번호`를 사용한다
+- 이슈 close는 GitHub 기본 auto-close를 우선 사용하고, `post-merge`는 체크박스 / 에픽 상태 동기화와 auto-merge 후속 복구를 담당한다
 - PR 승인 실패로 다시 수정이 발생해도 같은 이슈/같은 PR을 계속 사용한다
 - PR 승인 실패가 `content`인 경우에만 Claude 자동 재수정이 같은 PR 브랜치에서 최대 3회 동작한다
 - 승인 워커는 verdict만 남기지 않고 아래 정보를 함께 남긴다.


### PR DESCRIPTION
## Summary
- `merge-gate`가 auto-merge를 활성화한 뒤 PR이 실제로 `merged` 상태가 될 때까지 기다리고, 이후 `workflow_dispatch`로 `post-merge.yml`을 다시 호출하도록 보강했습니다.
- runbook에 `GITHUB_TOKEN` 기반 auto-merge가 후속 workflow run을 자동으로 만들지 않는 제약과, post-merge 복구 경로를 명시했습니다.
- 브랜치 삭제 정책 문서를 정리해 `main` 보호는 branch protection에 두고, 작업 브랜치 자동 삭제를 막는 전역 `deletion` ruleset을 두지 않도록 명확히 했습니다.
- PR 본문의 `Refs #N`은 auto-close를 만들지 않고 `Closes #N`만 이슈 종료를 유발한다는 점을 runbook에 반영했습니다.

## Root Cause
- `merge-gate`가 `GITHUB_TOKEN`으로 auto-merge를 걸면, 그 결과 발생하는 `pull_request.closed` 이벤트만 믿고는 `post-merge.yml`이 항상 실행되지 않았습니다.
- 저장소 운영 가이드에는 `Automatically delete head branches` 전제가 있었지만, 실제 GitHub 설정은 전역 branch ruleset의 `deletion` 규칙 때문에 머지된 head branch 삭제를 막을 수 있는 상태였습니다.

## Impact
- 앞으로 auto-merged PR도 post-merge 후처리 경로를 안정적으로 타서 체크박스 동기화와 이슈 reconciliation 누락 가능성이 줄어듭니다.
- `main`만 보호하고 나머지 head branch는 머지 후 자동 삭제되도록 운영 기준을 문서와 workflow 수준에서 맞췄습니다.

## Validation
- `git diff --check --cached`
- workflow / runbook diff 정적 검토
- `actionlint`는 로컬에 없어 실행하지 못했습니다.
