### PR TITLE
chore(agent): align autopilot queue and GitHub ops

### DIFF
--- a/.agent/commands/arch-review.md
+++ b/.agent/commands/arch-review.md
@@ -1,5 +1,7 @@
 오픈 이슈를 아키텍트 관점에서 순회하며, 구현 시 주의사항과 보완 의견을 GitHub 코멘트로 남긴다.
 
+GitHub 조회/코멘트 절차는 `.agent/skills/github-ops.md`를 따르고, 쓰기 작업 전 인증은 `.agent/skills/github-auth.md`를 먼저 따른다.
+
 ## 인자
 
 $ARGUMENTS — 옵션 (생략 가능)
@@ -104,6 +106,10 @@ gh issue comment #{이슈번호} --body "{코멘트}"
 ```markdown
 🏗️ **아키텍트 리뷰**
 
+### 판정
+- verdict: `ready | caution | blocked`
+- next-step: `implement-issue | narrow-scope | split-issue | invoke-human`
+
 ### 관련 스펙
 - `docs/specs/{모듈}/{모듈}.md` — {관련 섹션 요약}
 
@@ -131,6 +137,7 @@ gh issue comment #{이슈번호} --body "{코멘트}"
 2. **간결함 우선**: 이슈당 코멘트는 주의사항 5개 이내로 압축한다. 모든 체크리스트 항목을 나열하지 않고, 실제 발견된 사항만 기술한다.
 3. **판단 보류**: 스펙 불일치를 발견해도 스펙을 수정하지 않는다. 불일치 사실만 기록하고 사용자 판단을 요청한다.
 4. **기존 코드 참조**: "이렇게 구현하라"보다 "기존 {모듈}의 {패턴}을 참고하라"로 안내한다.
+5. **판정 명시**: 구현을 바로 시작해도 되는지(`ready`), 주의사항이 많은지(`caution`), 사람 판단/선행 작업이 먼저인지(`blocked`)를 한 줄로 명확히 남긴다.
 
 ### 4단계: 결과 요약
 

--- a/.agent/commands/arch-review.md
+++ b/.agent/commands/arch-review.md
@@ -26,11 +26,17 @@ gh issue list --state open --label "feature,bug,refactor,epic" --limit 50 --json
 gh issue view #{번호} --json number,title,labels,body
 ```
 
-이미 아키텍트 리뷰가 달린 이슈는 건너뛴다:
+기존 아키텍트 리뷰는 먼저 확인하되, 아래 경우에는 **refresh 리뷰**를 새 코멘트로 다시 남긴다:
 ```bash
-# 코멘트에 "🏗️ **아키텍트 리뷰**" 가 있으면 스킵
-gh issue view #{번호} --json comments --jq '.comments[].body' | rg -q "🏗️ \\*\\*아키텍트 리뷰\\*\\*"
+# 기존 리뷰 확인
+gh issue view #{번호} --json comments --jq '.comments[].body' | rg "🏗️ \\*\\*아키텍트 리뷰\\*\\*"
 ```
+
+- 최신 리뷰에 `verdict:` 필드가 없다
+- 최신 verdict가 `blocked` 또는 `caution`인데, 이슈 본문/스펙/선행 조건이 이후 정리되었다
+- 사용자가 `/arch-review`를 다시 호출해 최신 판단을 요청했다
+
+즉, 같은 헤더가 있다는 이유만으로 무조건 스킵하지 않는다. verdict를 구현 게이트로 재사용하는 이상, 최신 상태로 갱신할 경로가 있어야 한다.
 
 ### 2단계: 이슈별 분석
 
@@ -109,6 +115,7 @@ gh issue comment #{이슈번호} --body "{코멘트}"
 ### 판정
 - verdict: `ready | caution | blocked`
 - next-step: `implement-issue | narrow-scope | split-issue | invoke-human`
+- review-mode: `fresh | refresh`
 
 ### 관련 스펙
 - `docs/specs/{모듈}/{모듈}.md` — {관련 섹션 요약}
@@ -138,6 +145,7 @@ gh issue comment #{이슈번호} --body "{코멘트}"
 3. **판단 보류**: 스펙 불일치를 발견해도 스펙을 수정하지 않는다. 불일치 사실만 기록하고 사용자 판단을 요청한다.
 4. **기존 코드 참조**: "이렇게 구현하라"보다 "기존 {모듈}의 {패턴}을 참고하라"로 안내한다.
 5. **판정 명시**: 구현을 바로 시작해도 되는지(`ready`), 주의사항이 많은지(`caution`), 사람 판단/선행 작업이 먼저인지(`blocked`)를 한 줄로 명확히 남긴다.
+6. **refresh 허용**: 이전 리뷰가 있어도 verdict가 오래되었거나 조건이 바뀌면 같은 헤더로 새 코멘트를 남겨 최신 verdict를 갱신한다.
 
 ### 4단계: 결과 요약
 
@@ -153,5 +161,6 @@ gh issue comment #{이슈번호} --body "{코멘트}"
 | #103 | 리스크 엔진 | 🚫 스펙 미정의 — 구현 보류 권고 |
 
 리뷰가 달린 이슈: {N}건
-스킵 (이미 리뷰 완료): {M}건
+기존 리뷰 재사용: {M}건
+refresh 리뷰: {K}건
 ```

--- a/.agent/commands/autopilot.md
+++ b/.agent/commands/autopilot.md
@@ -73,6 +73,7 @@ GitHub 조회/코멘트/PR 관련 절차는 `.agent/skills/github-ops.md`를 따
 - 이슈에 최신 `🏗️ **아키텍트 리뷰**` 코멘트가 있으면 그대로 재사용한다.
 - 이슈에 최신 `🧪 **QA 리뷰**` 코멘트가 있으면 그대로 재사용한다.
 - 이미 남아 있는 사전 리뷰 증적을 덮어쓰지 않는다. 새 정보가 없으면 중복 리뷰를 남기지 않는다.
+- 다만 최신 리뷰에 `verdict:`가 없거나, 최신 verdict가 `blocked`/`caution`인데 이슈 본문·스펙·선행 조건이 이후 바뀌었다면 `/arch-review` 또는 `/qa-review`를 다시 호출해 refresh verdict를 남긴다.
 
 ### 판정 해석
 
@@ -109,6 +110,8 @@ gh issue list --state open --limit 100 --json number,title,labels,body,createdAt
 4. `arch-review` 필요 여부 판단
 5. `qa-review` 필요 여부 판단
 6. 기존 리뷰 증적 재사용 또는 신규 리뷰 실행
+
+최신 사전 리뷰에 `verdict:`가 없거나, 오래된 `blocked` verdict가 최신 이슈 상태를 반영하지 못하면 refresh 리뷰를 먼저 남긴 뒤 그 결과를 사용한다.
 
 사전 리뷰 결과가 `blocked`면 이슈 코멘트에 다음을 남기고 스킵한다.
 

--- a/.agent/commands/autopilot.md
+++ b/.agent/commands/autopilot.md
@@ -1,0 +1,183 @@
+오픈 이슈 큐를 야간 배치로 순차 처리하며, 필요 시 사전 리뷰 증적을 남긴 뒤 `/implement-issue`에 위임한다.
+
+## 인자
+
+$ARGUMENTS — 옵션 (생략 가능)
+- 없음: 기본 autopilot 큐 전체
+- `--limit {N}`: 이번 배치에서 처리할 최대 이슈 수
+- `--time-budget {예: 4h, 90m}`: 시간 예산이 소진되면 다음 이슈로 넘어가지 않고 종료
+- `--label {라벨}`: 특정 라벨만 대상으로 제한
+- `--strict-merge`: PR 생성 인계가 아니라 실제 merge/post-merge까지 확인
+- `--dry-run`: 큐 선별과 선행 리뷰 필요 여부만 계산하고 실제 구현은 시작하지 않음
+
+## 목적
+
+`/autopilot`은 직접 코드를 구현하는 명령이 아니다. 이 커맨드는 오픈 이슈 큐를 정리하고, 지금 자동으로 처리해도 되는 이슈만 골라 **한 번에 하나씩** `/implement-issue`에 넘기는 야간 배치 오케스트레이터다.
+
+GitHub 조회/코멘트/PR 관련 절차는 `.agent/skills/github-ops.md`를 따르고, 쓰기 작업 전 인증은 `.agent/skills/github-auth.md`를 먼저 따른다.
+
+기본 성공 기준:
+
+- 이슈가 `/implement-issue`를 통해 PR 생성까지 진행되고
+- 이후 CI + 승인 + auto-merge 파이프라인으로 인계되었음
+
+`--strict-merge`가 있을 때만 실제 merge/post-merge까지 기다린다.
+
+## 큐 선별 규칙
+
+### 포함 대상
+
+- 상태가 `open`
+- 라벨이 `feature`, `bug`, `refactor`, `docs`, `test`, `chore` 중 하나
+- 필요 시 `--label`로 좁힌 결과
+
+### 기본 제외 대상
+
+- `needs-triage`
+- `question`
+- `blocked`
+- `blocked:review-loop`
+- `blocked:pr-review-loop`
+- `epic`
+- 이미 open PR이 연결된 이슈
+- 선행 의존 이슈가 아직 close되지 않은 이슈
+
+새 이슈는 배치 시작 시점에 snapshot으로 고정한다. 배치 도중 새로 등록된 이슈나 follow-up 이슈는 다음 실행으로 넘긴다.
+
+## 정렬 규칙
+
+1. 우선순위 `P0 → P1 → P2 → P3`
+2. 같은 우선순위 안에서는 선행 의존성이 없는 이슈 우선
+3. 같은 조건이면 오래 열린 이슈 우선
+
+여러 이슈를 동시에 구현하지 않는다. 현재 활성 이슈가 PR 생성 또는 명시적 보류 상태로 정리된 뒤에만 다음 이슈로 이동한다.
+
+## 사전 리뷰 규칙
+
+### `arch-review`를 먼저 거는 경우
+
+- API / CLI / schema / field rename 가능성
+- cache / invalidate / reconnect / mutable config / health-path 신호
+- 둘 이상의 모듈과 소비자 경로가 함께 흔들릴 가능성
+- 에픽 하위 이슈의 선행/후속 관계가 불명확
+
+### `qa-review`를 먼저 거는 경우
+
+- 수용 조건이 2개 이상인데 기존 TC 매핑이 불명확
+- happy path 외 에러/경계값 검증이 핵심
+- frontend / API 변경으로 수용 조건과 TC 동기화가 중요
+- 에픽 하위 이슈 또는 통합 시나리오가 필요한 경우
+
+### 재사용 규칙
+
+- 이슈에 최신 `🏗️ **아키텍트 리뷰**` 코멘트가 있으면 그대로 재사용한다.
+- 이슈에 최신 `🧪 **QA 리뷰**` 코멘트가 있으면 그대로 재사용한다.
+- 이미 남아 있는 사전 리뷰 증적을 덮어쓰지 않는다. 새 정보가 없으면 중복 리뷰를 남기지 않는다.
+
+### 판정 해석
+
+- `ready`: 구현 진행 가능
+- `caution`: 구현 진행 가능하나 주의사항 또는 TC follow-up을 반드시 반영
+- `blocked`: autopilot이 구현을 시작하지 않고 다음 이슈로 이동
+
+`blocked`가 나오면 같은 배치에서 억지로 `/implement-issue`를 호출하지 않는다. 보류 사유를 이슈 코멘트로 남기고 사람 판단이나 후속 이슈를 기다린다.
+
+## 실행 절차
+
+### 1단계: 단일 실행 보장
+
+- 같은 시간대에 다른 autopilot 배치가 이미 진행 중이면 새 배치를 시작하지 않는다.
+- 중복 실행이 감지되면 이번 배치는 종료하고 사용자에게 보고한다.
+
+### 2단계: 큐 snapshot 수집
+
+```bash
+gh issue list --state open --limit 100 --json number,title,labels,body,createdAt
+```
+
+- 위 결과에서 포함/제외 규칙을 적용해 이번 배치 큐를 고정한다.
+- 이번 배치 큐가 1건 이상이면 실행 모드와 관계없이 `docs/temp/autopilot-report-<YYYYMMDD-HHMM>.md` 리포트를 반드시 생성한다.
+- `--dry-run`이면 이 단계 결과를 리포트에 남기고 종료한다.
+
+### 3단계: 이슈별 사전 점검
+
+각 이슈마다 다음을 순서대로 수행한다.
+
+1. `needs-triage` 여부 재확인
+2. 선행 의존 이슈 close 여부 확인
+3. open PR 존재 여부 확인
+4. `arch-review` 필요 여부 판단
+5. `qa-review` 필요 여부 판단
+6. 기존 리뷰 증적 재사용 또는 신규 리뷰 실행
+
+사전 리뷰 결과가 `blocked`면 이슈 코멘트에 다음을 남기고 스킵한다.
+
+```markdown
+🤖 **Autopilot 보류**
+- 이슈: #{번호}
+- 사유: {needs-triage | 선행 이슈 미완료 | arch-review blocked | qa-review blocked}
+- 다음 단계: {triage 제거 | 선행 이슈 완료 대기 | 스펙 정리 | TC 설계 보강}
+```
+
+### 4단계: `/implement-issue`로 위임
+
+사전 리뷰를 통과한 이슈만 `/implement-issue #{번호}`로 넘긴다.
+
+- `arch-review` / `qa-review` 증적은 이슈 코멘트에 남아 있어야 한다.
+- `/implement-issue`는 그 증적을 읽고 구현 착수 코멘트와 개발 에이전트 프롬프트에 요약을 포함한다.
+
+### 5단계: 결과 분류
+
+각 이슈는 아래 중 하나로 정리한다.
+
+- `handed-off`: PR 생성 후 기존 게이트에 인계
+- `deferred-triage`: `needs-triage`가 남아 있어 보류
+- `deferred-dependency`: 선행 이슈 미완
+- `deferred-review`: `arch-review` 또는 `qa-review`가 `blocked`
+- `retry-later-infra`: 인증/러너/네트워크 등 공통 인프라 문제
+- `skipped-in-progress`: 이미 open PR 또는 사람이 작업 중
+
+### 6단계: 배치 종료
+
+종료 시에는 사용자에게 다음을 요약한다.
+
+- 실행 시각과 소요 시간
+- 큐 snapshot 크기
+- PR 인계 건수
+- 보류 건수와 사유 분포
+- 인프라 오류 여부
+
+이번 배치 큐 snapshot이 1건 이상이었다면 `docs/temp/autopilot-report-<YYYYMMDD-HHMM>.md`를 반드시 남긴다.
+
+리포트 최소 포함 항목:
+
+- 실행 시각 / 종료 시각 / 소요 시간
+- 실행 모드 (`default | strict-merge | dry-run`)
+- 큐 snapshot 크기
+- 이슈별 결과 표 (`handed-off | deferred-* | retry-later-infra | skipped-in-progress`)
+- 스킵/보류 상세
+- 남은 작업 또는 후속 조치
+
+리포트 말미에는 **프로세스 회고**를 반드시 포함한다.
+
+- `### 있었던 사건`
+  - 예: 특정 runner 대기 지연, PR 승인 워커 충돌, stale base, merge conflict, review-loop 반복, 인증 실패, 수동 재실행 필요
+- `### 개선 포인트`
+  - 예: 라벨 규칙 보강, 선행 리뷰 강제, runner capacity 조정, 코멘트 템플릿 정리, 큐 정렬 규칙 수정
+
+공식 증적은 GitHub 이슈/PR 코멘트와 status check이고, `docs/temp/autopilot-report-*.md`는 배치 전체를 한 번에 회고하는 운영 리포트다.
+
+## 중단 규칙
+
+- 공통 인프라 오류가 3회 연속 나오면 이번 배치를 중단한다.
+- 시간 예산이 소진되면 현재 이슈 정리 후 종료한다.
+- 같은 이슈를 같은 배치에서 반복 재집지 않는다.
+- `blocked:review-loop` 또는 `blocked:pr-review-loop`가 붙은 이슈는 배치가 억지로 밀어붙이지 않는다.
+
+## 원칙
+
+1. autopilot은 큐 관리자이지 새 구현 파이프라인이 아니다
+2. 공식 구현 절차는 `/implement-issue`가 계속 SSOT다
+3. 사전 리뷰 증적은 이슈 코멘트에 남기고 재사용한다
+4. `needs-triage`가 붙은 이슈는 사람이 분류하기 전까지 건드리지 않는다
+5. 기본 모드는 throughput 우선, `--strict-merge`는 안정성 확인이 더 중요한 경우에만 사용한다

--- a/.agent/commands/autopilot.md
+++ b/.agent/commands/autopilot.md
@@ -93,10 +93,28 @@ GitHub 조회/코멘트/PR 관련 절차는 `.agent/skills/github-ops.md`를 따
 ### 2단계: 큐 snapshot 수집
 
 ```bash
-gh issue list --state open --limit 100 --json number,title,labels,body,createdAt
+REPO="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+QUERY="repo:${REPO} is:issue is:open sort:created-asc \
+  -label:needs-triage \
+  -label:question \
+  -label:blocked \
+  -label:blocked:review-loop \
+  -label:blocked:pr-review-loop \
+  -label:epic"
+
+page=1
+while :; do
+  batch="$(gh api search/issues -f q="$QUERY" -f per_page=100 -f page="$page" --jq '.items')"
+  [[ "$batch" == "[]" ]] && break
+  printf '%s\n' "$batch"
+  page=$((page + 1))
+done
 ```
 
-- 위 결과에서 포함/제외 규칙을 적용해 이번 배치 큐를 고정한다.
+- 큐 snapshot은 "앞 100건만 가져온 뒤 로컬에서 후행 필터링"하지 않는다.
+- `needs-triage`와 기본 제외 라벨은 **수집 단계에서 server-side search filter로 먼저 제외**한다.
+- snapshot은 100건 단일 조회가 아니라 **pagination으로 끝까지 수집한 전체 open issue 후보 집합**으로 고정한다.
+- 위 전체 snapshot에 대해서만 open PR 존재, 선행 의존 이슈 close 여부, `--label` 좁히기처럼 server-side로 표현하기 어려운 후행 검사를 적용한다.
 - 이번 배치 큐가 1건 이상이면 실행 모드와 관계없이 `docs/temp/autopilot-report-<YYYYMMDD-HHMM>.md` 리포트를 반드시 생성한다.
 - `--dry-run`이면 이 단계 결과를 리포트에 남기고 종료한다.
 
@@ -112,6 +130,8 @@ gh issue list --state open --limit 100 --json number,title,labels,body,createdAt
 6. 기존 리뷰 증적 재사용 또는 신규 리뷰 실행
 
 최신 사전 리뷰에 `verdict:`가 없거나, 오래된 `blocked` verdict가 최신 이슈 상태를 반영하지 못하면 refresh 리뷰를 먼저 남긴 뒤 그 결과를 사용한다.
+
+`needs-triage`는 이미 2단계 server-side snapshot에서 제외되어 있어야 하며, 여기서는 stale snapshot이나 수동 개입 여부를 다시 확인하는 안전 검사를 수행한다.
 
 사전 리뷰 결과가 `blocked`면 이슈 코멘트에 다음을 남기고 스킵한다.
 

--- a/.agent/commands/implement-issue.md
+++ b/.agent/commands/implement-issue.md
@@ -85,8 +85,9 @@ mkdir -p "$WORKTREE_ROOT"
 - latest verdict (`ready | caution | blocked`)
 - 구현 전에 반드시 반영할 주의사항
 - TC 추가/보완이 필요한 항목
+- 최신 리뷰에 `verdict:`가 없거나, 리뷰 이후 이슈 본문/스펙/선행 조건이 바뀌었는지 여부
 
-가장 최신 사전 리뷰 verdict가 `blocked`면 구현을 시작하지 않고 이슈에 보류 사유를 남긴다.
+최신 사전 리뷰에 `verdict:`가 없거나 stale하다고 판단되면 `/arch-review` 또는 `/qa-review` refresh를 먼저 요청한다. 가장 최신 사전 리뷰 verdict가 여전히 `blocked`일 때만 구현을 시작하지 않고 이슈에 보류 사유를 남긴다.
 
 ### 구현 시작 기록 (오케스트레이터)
 

--- a/.agent/commands/implement-issue.md
+++ b/.agent/commands/implement-issue.md
@@ -1,5 +1,7 @@
 GitHub 이슈의 유저스토리를 기반으로 구현하고, Codex 브랜치 리뷰를 통과한 뒤 PR을 생성한다.
 
+GitHub 조회/코멘트/PR 관련 절차는 `.agent/skills/github-ops.md`를 따르고, 쓰기 작업 전 인증은 `.agent/skills/github-auth.md`를 먼저 따른다.
+
 ## 인자
 
 $ARGUMENTS — GitHub 이슈 번호 (예: 43, 39 등)
@@ -28,6 +30,7 @@ mkdir -p "$WORKTREE_ROOT"
 | 1~4 (분석) | 오케스트레이터 | Claude 메인 세션 | 스킵 시 이슈 코멘트 |
 | 4a (경량 계획) | 오케스트레이터 | Claude 메인 세션 | 필요 시 이슈 코멘트 |
 | 4b (조건부 계획 리뷰) | Claude | `@code-reviewer` | 필요 시 이슈 코멘트 |
+| 4c (사전 리뷰 증적 수집) | 오케스트레이터 | Claude 메인 세션 | 기존 이슈 코멘트 재사용 |
 | 5 (착수 기록) | 오케스트레이터 | Claude 메인 세션 | 이슈 코멘트 |
 | 6~9 (구현 + push) | 개발 에이전트 | `@backend-dev` / `@frontend-dev` / `@devops` / `@strategy-dev` | 브랜치 push |
 | 10~11 (사전 리뷰 루프) | Codex + Claude | GitHub workflow + Claude 개발 에이전트 | `codex-branch-review` + 이슈 코멘트 |
@@ -42,6 +45,7 @@ mkdir -p "$WORKTREE_ROOT"
 1. **이슈 읽기**: `gh issue view #{번호}`로 이슈 본문을 읽고 유저스토리와 수용 조건을 파악한다.
    - **에픽 이슈인 경우**: 아래 "에픽 이슈 처리 절차"를 따른다.
    - **하위 이슈인 경우**: 선행 이슈가 모두 close 상태인지 확인한다. 미완성이면 이 이슈를 스킵하고 사용자에게 보고한다.
+   - **`needs-triage` 라벨이 붙어 있으면**: 구현을 시작하지 않고 이슈에 보류 사유를 남긴다.
 2. **설계 문서 확인**: 관련 설계 문서(`docs/specs/{모듈}/{모듈}.md`)를 읽고 인터페이스와 요구사항을 파악한다.
    - 스펙에 정의되지 않은 인터페이스·동작을 요구하면 구현하지 않고 이슈에 스킵 사유를 남긴다.
 3. **대상 에이전트 결정**:
@@ -71,6 +75,19 @@ mkdir -p "$WORKTREE_ROOT"
 
 `@code-reviewer` verdict가 `approve-implement` 또는 `narrow-scope`가 아니면 6단계 구현으로 넘어가지 않는다.
 
+4c. **사전 리뷰 증적 수집**: 최신 이슈 코멘트에서 아래 증적을 읽고 구현 프롬프트에 반영한다.
+
+- `🏗️ **아키텍트 리뷰**` (`/arch-review`)
+- `🧪 **QA 리뷰**` (`/qa-review`)
+
+정리할 내용:
+
+- latest verdict (`ready | caution | blocked`)
+- 구현 전에 반드시 반영할 주의사항
+- TC 추가/보완이 필요한 항목
+
+가장 최신 사전 리뷰 verdict가 `blocked`면 구현을 시작하지 않고 이슈에 보류 사유를 남긴다.
+
 ### 구현 시작 기록 (오케스트레이터)
 
 5. **이슈에 착수 코멘트**:
@@ -81,7 +98,9 @@ gh issue comment #{이슈번호} --body "🤖 **구현 착수**
 - 변경 대상: {src/ante/xxx, frontend/ 등}
 - base 브랜치: {main 또는 epic/#{에픽번호}-{설명}}
 - 계획 리뷰: {not-required | approve-implement | narrow-scope}
-- risk flags: {없음 또는 쉼표 구분 목록}"
+- risk flags: {없음 또는 쉼표 구분 목록}
+- 사전 리뷰: {arch=ready/caution/n-a, qa=ready/caution/n-a}
+- 사전 리뷰 요약: {핵심 주의사항 1~2줄 또는 없음}"
 ```
 
 ### 구현 단계 (개발 에이전트)
@@ -111,6 +130,9 @@ Agent(
 
 ## 계획 리뷰 verdict
 {not-required | approve-implement | narrow-scope}
+
+## 사전 리뷰 증적
+{arch-review / qa-review의 최신 verdict와 핵심 주의사항, TC follow-up}
 
 브랜치명과 push한 HEAD SHA를 반환하라.
 """,

--- a/.agent/commands/implement-issue.md
+++ b/.agent/commands/implement-issue.md
@@ -82,12 +82,13 @@ mkdir -p "$WORKTREE_ROOT"
 
 정리할 내용:
 
-- latest verdict (`ready | caution | blocked`)
+- latest `arch-review` verdict (`ready | caution | blocked | n-a`)
+- latest `qa-review` verdict (`ready | caution | blocked | n-a`)
 - 구현 전에 반드시 반영할 주의사항
 - TC 추가/보완이 필요한 항목
 - 최신 리뷰에 `verdict:`가 없거나, 리뷰 이후 이슈 본문/스펙/선행 조건이 바뀌었는지 여부
 
-최신 사전 리뷰에 `verdict:`가 없거나 stale하다고 판단되면 `/arch-review` 또는 `/qa-review` refresh를 먼저 요청한다. 가장 최신 사전 리뷰 verdict가 여전히 `blocked`일 때만 구현을 시작하지 않고 이슈에 보류 사유를 남긴다.
+최신 `arch-review` 또는 `qa-review`에 `verdict:`가 없거나 stale하다고 판단되면 해당 리뷰 타입의 refresh를 먼저 요청한다. 두 리뷰 타입의 최신 verdict를 각각 평가하고, 둘 중 하나라도 `blocked`이면 구현을 시작하지 않고 이슈에 보류 사유를 남긴다.
 
 ### 구현 시작 기록 (오케스트레이터)
 

--- a/.agent/commands/qa-review.md
+++ b/.agent/commands/qa-review.md
@@ -1,5 +1,7 @@
 오픈 이슈를 QA 엔지니어 관점에서 순회하며, TC 추가 작성 및 보완 필요 여부를 파악하고 GitHub 코멘트로 남긴다.
 
+GitHub 조회/코멘트 절차는 `.agent/skills/github-ops.md`를 따르고, 쓰기 작업 전 인증은 `.agent/skills/github-auth.md`를 먼저 따른다.
+
 ## 인자
 
 $ARGUMENTS — 옵션 (생략 가능)
@@ -113,6 +115,10 @@ gh issue comment #{이슈번호} --body "{코멘트}"
 ```markdown
 🧪 **QA 리뷰**
 
+### 판정
+- verdict: `ready | caution | blocked`
+- next-step: `implement-issue | add-tc-followup | invoke-human`
+
 ### TC 커버리지 현황
 
 | 수용 조건 | 기존 TC | 상태 |
@@ -150,6 +156,7 @@ gh issue comment #{이슈번호} --body "{코멘트}"
 2. **기존 TC 참조**: 새 시나리오 작성 시, 같은 카테고리의 기존 `.feature` 파일 스타일(Background, 변수명, 스텝 패턴)을 따르도록 안내한다.
 3. **과도한 TC 방지**: 수용 조건에 직접 대응하는 TC만 제안한다. 이슈 범위를 넘는 "있으면 좋을" TC는 제안하지 않는다.
 4. **QA 환경 고려**: TC 초안은 Docker QA 환경(`ante-qa` 컨테이너)에서 실행 가능한 형태로 작성한다. `gherkin-guide.md`의 스텝 패턴을 준수한다.
+5. **판정 명시**: 구현을 바로 시작할 수 있는지(`ready`), 구현은 가능하지만 TC follow-up이 필요한지(`caution`), 수용 조건/검증 경로가 불명확해 사람 판단이 먼저인지(`blocked`)를 명확히 남긴다.
 
 ### 4단계: 결과 요약
 

--- a/.agent/commands/qa-review.md
+++ b/.agent/commands/qa-review.md
@@ -30,10 +30,16 @@ gh issue list --state open --label "feature,bug,epic" --limit 50 --json number,t
 gh issue view #{번호} --json number,title,labels,body
 ```
 
-이미 QA 리뷰가 달린 이슈는 건너뛴다:
+기존 QA 리뷰는 먼저 확인하되, 아래 경우에는 **refresh 리뷰**를 새 코멘트로 다시 남긴다:
 ```bash
-gh issue view #{번호} --json comments --jq '.comments[].body' | rg -q "🧪 \\*\\*QA 리뷰\\*\\*"
+gh issue view #{번호} --json comments --jq '.comments[].body' | rg "🧪 \\*\\*QA 리뷰\\*\\*"
 ```
+
+- 최신 리뷰에 `verdict:` 필드가 없다
+- 최신 verdict가 `blocked` 또는 `caution`인데, 수용 조건/TC 경로/선행 이슈가 이후 정리되었다
+- 사용자가 `/qa-review`를 다시 호출해 최신 판단을 요청했다
+
+같은 헤더가 있다는 이유만으로 무조건 스킵하지 않는다. verdict를 구현 게이트로 사용하는 이상, 최신 TC 판단으로 갱신할 수 있어야 한다.
 
 ### 2단계: 이슈별 분석
 
@@ -118,6 +124,7 @@ gh issue comment #{이슈번호} --body "{코멘트}"
 ### 판정
 - verdict: `ready | caution | blocked`
 - next-step: `implement-issue | add-tc-followup | invoke-human`
+- review-mode: `fresh | refresh`
 
 ### TC 커버리지 현황
 
@@ -157,6 +164,7 @@ gh issue comment #{이슈번호} --body "{코멘트}"
 3. **과도한 TC 방지**: 수용 조건에 직접 대응하는 TC만 제안한다. 이슈 범위를 넘는 "있으면 좋을" TC는 제안하지 않는다.
 4. **QA 환경 고려**: TC 초안은 Docker QA 환경(`ante-qa` 컨테이너)에서 실행 가능한 형태로 작성한다. `gherkin-guide.md`의 스텝 패턴을 준수한다.
 5. **판정 명시**: 구현을 바로 시작할 수 있는지(`ready`), 구현은 가능하지만 TC follow-up이 필요한지(`caution`), 수용 조건/검증 경로가 불명확해 사람 판단이 먼저인지(`blocked`)를 명확히 남긴다.
+6. **refresh 허용**: 이전 QA 리뷰가 있어도 verdict가 오래되었거나 수용 조건/TC 정보가 바뀌면 같은 헤더로 새 코멘트를 남겨 최신 verdict를 갱신한다.
 
 ### 4단계: 결과 요약
 
@@ -170,7 +178,8 @@ gh issue comment #{이슈번호} --body "{코멘트}"
 | #103 | 리스크 엔진 | ❌ TC 없음 — 신규 3건 제안 |
 
 리뷰 완료: {N}건
-스킵 (이미 리뷰 완료): {M}건
+기존 리뷰 재사용: {M}건
+refresh 리뷰: {K}건
 TC 추가 제안: {총 건수}건
 TC 보완 제안: {총 건수}건
 ```

--- a/.agent/commands/qa-test.md
+++ b/.agent/commands/qa-test.md
@@ -1,5 +1,7 @@
 지정된 Gherkin TC(.feature)를 Docker 서버에서 실행하고 결과를 리포트한다.
 
+버그 이슈 생성 같은 GitHub 쓰기 작업은 `.agent/skills/github-ops.md`를 따르고, 인증은 `.agent/skills/github-auth.md`를 먼저 따른다.
+
 ## 인자
 
 $ARGUMENTS — 테스트 대상 (예: account, bot/lifecycle, scenario/full-pipeline)

--- a/.agent/skills/github-ops.md
+++ b/.agent/skills/github-ops.md
@@ -1,0 +1,136 @@
+# GitHub 운용 스킬
+
+> 이 저장소에서 에이전트가 GitHub CLI(`gh`)를 사용할 때, 인증·조회·코멘트·PR·워크플로우 재실행 절차를 일관되게 맞추기 위한 공통 스킬이다.
+
+## 목적
+
+- 여러 커맨드가 GitHub를 제각각 다루지 않도록 공통 규칙을 제공한다.
+- 공식 기록 위치를 이슈/PR 코멘트와 status check로 통일한다.
+- `gh` 쓰기 작업 전에 인증 확인 절차를 강제한다.
+
+## 함께 쓰는 스킬
+
+- 쓰기 작업 전에는 항상 `.agent/skills/github-auth.md`를 먼저 따른다.
+- 이 스킬은 인증 이후의 GitHub 운용 규칙을 정의한다.
+
+## 기본 원칙
+
+1. **공식 기록은 GitHub에 남긴다**
+   - 이슈 분석, 사전 리뷰, 구현 착수, PR 생성, 보류 사유, 수동 복구 근거는 GitHub 이슈/PR 코멘트에 남긴다.
+   - `docs/temp/` 리포트는 요약본일 뿐 공식 증적 저장소가 아니다.
+
+2. **같은 의미의 코멘트를 중복으로 남기지 않는다**
+   - 새 코멘트를 남기기 전에 기존 코멘트 헤더를 먼저 확인한다.
+   - 예:
+     - `🏗️ **아키텍트 리뷰**`
+     - `🧪 **QA 리뷰**`
+     - `🤖 **구현 착수**`
+     - `🤖 **PR 생성 완료**`
+     - `🤖 **Autopilot 보류**`
+
+3. **조회와 쓰기의 목적을 분리한다**
+   - 조회: `gh issue list/view`, `gh pr list/view/diff`, `gh run list/view`
+   - 쓰기: `gh issue comment/create`, `gh pr create/edit`, `gh run rerun`, `gh workflow run`
+
+4. **사람 판단이 필요한 경우는 코멘트로 이유를 남기고 멈춘다**
+   - `needs-triage`
+   - 스펙 불일치
+   - 선행 의존 미완료
+   - 반복 review loop
+
+## 표준 절차
+
+### 1. 인증 확인
+
+쓰기 작업 전:
+
+```bash
+source .github/local/github.env
+gh auth status
+```
+
+상세 절차는 `.agent/skills/github-auth.md`를 따른다.
+
+### 2. 이슈 조회
+
+기본 조회:
+
+```bash
+gh issue view #{번호} --json number,title,body,labels,comments
+```
+
+큐 조회:
+
+```bash
+gh issue list --state open --limit 100 --json number,title,labels,body,createdAt
+```
+
+### 3. 기존 증적 확인
+
+리뷰나 보류 코멘트를 쓰기 전에는 같은 헤더가 이미 있는지 먼저 확인한다.
+
+예:
+
+```bash
+gh issue view #{번호} --json comments --jq '.comments[].body'
+```
+
+### 4. 이슈 코멘트 작성
+
+코멘트는 아래 원칙을 따른다.
+
+- 첫 줄에 의미가 분명한 헤더를 둔다.
+- 다음 단계 또는 보류 사유를 함께 적는다.
+- 자동화가 읽을 수 있도록 상태 단어를 고정한다.
+
+예:
+
+```markdown
+🤖 **Autopilot 보류**
+- 사유: needs-triage
+- 다음 단계: triage 후 라벨 제거
+```
+
+### 5. PR 생성/조회
+
+PR 생성 전 확인:
+
+- 최신 branch review 성공 여부
+- open PR 중복 여부
+- base 브랜치 적합성
+
+기본 조회:
+
+```bash
+gh pr view #{번호} --json title,body,baseRefName,headRefName,labels,files
+```
+
+기본 생성:
+
+```bash
+gh pr create --base {base} --title "{title}" --body "{body}"
+```
+
+### 6. 워크플로우 재실행/수동 실행
+
+- 같은 head SHA에서 러너/일시적 환경 문제면 `gh run rerun` 우선
+- `pull_request` 이벤트가 꼭 필요할 때만 다른 수단 사용
+- 수동 재실행 후에는 PR 또는 이슈 코멘트에 이유와 새 run 근거를 남긴다
+
+## 커맨드별 기대 동작
+
+- `/autopilot`
+  - 큐 snapshot, open PR 여부 확인, 보류 코멘트, 사전 리뷰 증적 재사용
+- `/implement-issue`
+  - 이슈 조회, 구현 착수 코멘트, 리뷰 요청 코멘트, PR 생성, PR 생성 완료 코멘트
+- `/arch-review`, `/qa-review`
+  - 기존 코멘트 중복 확인 후 증적 게시
+- `/qa-test`
+  - FAIL 발견 시 버그 이슈 생성
+
+## 금지 사항
+
+- 인증 상태를 확인하지 않은 채 `gh` 쓰기 작업을 시작하지 않는다.
+- 같은 상황에 대해 헤더만 다른 중복 코멘트를 여러 개 남기지 않는다.
+- 로컬 메모만 남기고 GitHub에 근거를 생략하지 않는다.
+- `config/secrets.env`와 GitHub 토큰 관리 절차를 혼용하지 않는다.

--- a/.agent/skills/github-ops.md
+++ b/.agent/skills/github-ops.md
@@ -21,6 +21,7 @@
 
 2. **같은 의미의 코멘트를 중복으로 남기지 않는다**
    - 새 코멘트를 남기기 전에 기존 코멘트 헤더를 먼저 확인한다.
+   - 단, `arch-review` / `qa-review`처럼 verdict를 갱신해야 하는 리뷰는 예외다. 최신 verdict가 없거나 stale하면 같은 헤더로 refresh 코멘트를 새로 남긴다.
    - 예:
      - `🏗️ **아키텍트 리뷰**`
      - `🧪 **QA 리뷰**`
@@ -124,7 +125,7 @@ gh pr create --base {base} --title "{title}" --body "{body}"
 - `/implement-issue`
   - 이슈 조회, 구현 착수 코멘트, 리뷰 요청 코멘트, PR 생성, PR 생성 완료 코멘트
 - `/arch-review`, `/qa-review`
-  - 기존 코멘트 중복 확인 후 증적 게시
+  - 기존 코멘트를 확인하되, stale verdict 또는 verdict 누락 시 refresh 코멘트로 증적 갱신
 - `/qa-test`
   - FAIL 발견 시 버그 이슈 생성
 

--- a/.github/workflows/codex-branch-review.yml
+++ b/.github/workflows/codex-branch-review.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'feat/**'
       - 'fix/**'
+      - 'perf/**'
       - 'refactor/**'
       - 'docs/**'
       - 'test/**'

--- a/.github/workflows/codex-branch-review.yml
+++ b/.github/workflows/codex-branch-review.yml
@@ -7,6 +7,8 @@ on:
       - 'fix/**'
       - 'refactor/**'
       - 'docs/**'
+      - 'test/**'
+      - 'chore/**'
       - 'epic/**'
 
 concurrency:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,13 +41,11 @@ Ante는 **개인의 홈서버 위에 존재하는 작은 투자 회사**다.
 > CI/CD: [docs/runbooks/04-ci-cd.md](docs/runbooks/04-ci-cd.md)
 > 테스트 전략: [docs/runbooks/05-testing.md](docs/runbooks/05-testing.md)
 
+
 ## 프로젝트 디렉토리 구조
 
 > 파일 단위 상세 구조: [docs/architecture/generated/project-structure.md](docs/architecture/generated/project-structure.md)
 
-
-## 향후 계획
-- 개인 운용으로 충분히 검증 후 오픈소스 공개 고려
 
 ## 규칙
 - 모든 대화는 **한국어**로 진행한다.
@@ -56,3 +54,4 @@ Ante는 **개인의 홈서버 위에 존재하는 작은 투자 회사**다.
 - 사용자의 질문에 임의로 대답하지 않는다. 항상 스펙 문서를 확인 후 답변한다.
 - 사용자에 스펙을 제안할 때는 YAGNI가 아닌지 확인한다. 
 - .gitignore 에 등록된 파일은 커밋 여부를 묻지 않는다.
+- 설계·계획 단계 에이전트(Claude 오케스트레이터, `superpowers:writing-plans` 등)는 **GitHub 이슈 등록까지만** 수행한다. 실제 구현·PR 생성·리뷰 대응은 `/implement-issue` 에이전트에 위임한다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,4 +54,4 @@ Ante는 **개인의 홈서버 위에 존재하는 작은 투자 회사**다.
 - 사용자의 질문에 임의로 대답하지 않는다. 항상 스펙 문서를 확인 후 답변한다.
 - 사용자에 스펙을 제안할 때는 YAGNI가 아닌지 확인한다. 
 - .gitignore 에 등록된 파일은 커밋 여부를 묻지 않는다.
-- 설계·계획 단계 에이전트(Claude 오케스트레이터, `superpowers:writing-plans` 등)는 **GitHub 이슈 등록까지만** 수행한다. 실제 구현·PR 생성·리뷰 대응은 `/implement-issue` 에이전트에 위임한다.
+- 설계·계획 단계 에이전트(`superpowers:writing-plans` 등 스펙/플래닝 스킬)는 **GitHub 이슈 등록까지만** 수행한다. 직접 코드 구현은 `/implement-issue` 흐름 안에서만 개발 서브에이전트(`@backend-dev`, `@frontend-dev`, `@devops`, `@strategy-dev`)에게 위임한다. Claude 오케스트레이터는 `/implement-issue`·`/autopilot` 커맨드 계약에 따라 사전 리뷰 조율, 이슈/브랜치/PR 코멘트, PR 생성까지 수행할 수 있다. 자세한 분담은 [docs/runbooks/02-agent-structure.md](docs/runbooks/02-agent-structure.md)를 따른다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,12 +34,16 @@ Ante는 **개인의 홈서버 위에 존재하는 작은 투자 회사**다.
 > 설계 결정 이력: [docs/decisions/README.md](docs/decisions/README.md)
 
 ## 개발 프로세스
+> 런북 인덱스: [docs/runbooks/README.md](docs/runbooks/README.md)
 > 이슈 관리: [docs/runbooks/00-issue-management.md](docs/runbooks/00-issue-management.md)
 > 개발 프로세스: [docs/runbooks/01-development-process.md](docs/runbooks/01-development-process.md)
 > 에이전트 구조: [docs/runbooks/02-agent-structure.md](docs/runbooks/02-agent-structure.md)
 > Git 워크플로우: [docs/runbooks/03-git-workflow.md](docs/runbooks/03-git-workflow.md)
 > CI/CD: [docs/runbooks/04-ci-cd.md](docs/runbooks/04-ci-cd.md)
 > 테스트 전략: [docs/runbooks/05-testing.md](docs/runbooks/05-testing.md)
+> 릴리스 운영: [docs/runbooks/06-release.md](docs/runbooks/06-release.md)
+> 리뷰 게이트: [docs/runbooks/07-review-gate.md](docs/runbooks/07-review-gate.md)
+> Autopilot 운영: [docs/runbooks/08-autopilot-operations.md](docs/runbooks/08-autopilot-operations.md)
 
 
 ## 프로젝트 디렉토리 구조
@@ -54,4 +58,6 @@ Ante는 **개인의 홈서버 위에 존재하는 작은 투자 회사**다.
 - 사용자의 질문에 임의로 대답하지 않는다. 항상 스펙 문서를 확인 후 답변한다.
 - 사용자에 스펙을 제안할 때는 YAGNI가 아닌지 확인한다. 
 - .gitignore 에 등록된 파일은 커밋 여부를 묻지 않는다.
-- 설계·계획 단계 에이전트(`superpowers:writing-plans` 등 스펙/플래닝 스킬)는 **GitHub 이슈 등록까지만** 수행한다. 직접 코드 구현은 `/implement-issue` 흐름 안에서만 개발 서브에이전트(`@backend-dev`, `@frontend-dev`, `@devops`, `@strategy-dev`)에게 위임한다. Claude 오케스트레이터는 `/implement-issue`·`/autopilot` 커맨드 계약에 따라 사전 리뷰 조율, 이슈/브랜치/PR 코멘트, PR 생성까지 수행할 수 있다. 자세한 분담은 [docs/runbooks/02-agent-structure.md](docs/runbooks/02-agent-structure.md)를 따른다.
+- 설계·계획 단계 에이전트(`superpowers:writing-plans` 등 스펙/플래닝 스킬)는 **GitHub 이슈 등록까지만** 수행한다.
+- Claude 오케스트레이터와 `/autopilot`은 `/implement-issue`·`/autopilot` 커맨드 계약에 따라 사전 리뷰 조율, 이슈/브랜치/PR 코멘트, PR 생성, 상태 보고 같은 오케스트레이션을 수행할 수 있다. 자세한 분담은 [docs/runbooks/02-agent-structure.md](docs/runbooks/02-agent-structure.md)를 따른다.
+- 직접 코드 구현과 작업 브랜치 수정은 `/implement-issue` 흐름 안에서만 개발 서브에이전트(`@backend-dev`, `@frontend-dev`, `@devops`, `@strategy-dev`)에게 위임한다.

--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -451,6 +451,8 @@ docs/
 │   ├── 04-ci-cd.md
 │   ├── 05-testing.md
 │   ├── 06-release.md           # 릴리스 절차
+│   ├── 07-review-gate.md       # 리뷰 게이트와 merge gate
+│   ├── 08-autopilot-operations.md # 야간 autopilot 큐 운영
 │   └── README.md
 ├── specs/                      # 모듈별 세부 설계
 │   ├── README.md
@@ -671,11 +673,14 @@ frontend/src/
 │   ├── autopilot.md             # /autopilot
 │   ├── qa-test.md               # /qa-test
 │   ├── qa-sweep.md              # /qa-sweep
-│   └── api-docs.md              # /api-docs
+│   ├── api-docs.md              # /api-docs
+│   ├── arch-review.md           # /arch-review
+│   └── qa-review.md             # /qa-review
 └── skills/                      # 프로젝트 스킬 (컨벤션·패턴 참조)
     ├── asyncio-patterns.md
     ├── frontend-conventions.md
     ├── github-auth.md           # GitHub CLI 로컬 PAT 인증 절차
+    ├── github-ops.md            # GitHub 조회/코멘트/PR/재실행 공통 절차
     ├── module-conventions.md
     ├── qa-tester/               # QA 테스터 스킬 (Gherkin 해석)
     ├── release.md               # /release 릴리스 절차

--- a/docs/runbooks/00-issue-management.md
+++ b/docs/runbooks/00-issue-management.md
@@ -43,11 +43,13 @@
 |-----------|------|---------------|
 | `feat` | `feature` | `feat/` |
 | `fix` | `bug` | `fix/` |
+| `perf` | `feature` | `perf/` |
 | `refactor` | `refactor` | `refactor/` |
 | `docs` | `docs` | `docs/` |
 | `test` | `test` | `test/` |
 | `chore` | `chore` | `chore/` |
 
+`feature` 라벨은 이슈 타입에 따라 `feat/` 또는 `perf/` 브랜치로 연결될 수 있다.
 `/implement-issue`, `/autopilot`, `codex-branch-review`는 이 매핑을 공통 기준으로 사용한다.
 
 ### 예시
@@ -235,6 +237,7 @@ GitHub 기본 라벨 또는 프로젝트 보드로 관리:
   - 선행 의존 이슈가 아직 close되지 않은 이슈
 - 브랜치 prefix 매핑:
   - `feature -> feat/*`
+  - `feature(perf) -> perf/*`
   - `bug -> fix/*`
   - `refactor -> refactor/*`
   - `docs -> docs/*`

--- a/docs/runbooks/00-issue-management.md
+++ b/docs/runbooks/00-issue-management.md
@@ -185,7 +185,18 @@ A → D     (A 완료 후 B, D 병렬 가능)
 | `question` | 논의/질문 | 주황색 |
 | `epic` | 에픽 (하위 이슈 묶음) | 검정색 |
 | `blocked` | 다른 작업에 의존하여 대기 | 빨간색 |
+| `needs-triage` | 자동 처리 전 사람 분류 필요 | 회색 |
+| `blocked:review-loop` | 브랜치 리뷰 반복 실패로 자동 진행 중단 | 진한 빨간색 |
+| `blocked:pr-review-loop` | PR 승인 반복 실패로 자동 진행 중단 | 진한 빨간색 |
 | `good first issue` | 에이전트가 자율 처리 가능 | 연두색 |
+
+### 4.1 `needs-triage` 라벨
+
+- `needs-triage`는 "이 이슈를 autopilot이나 `/implement-issue`가 바로 집으면 안 된다"는 뜻이다.
+- watcher, QA, 리뷰 후속 자동화처럼 에이전트가 새 이슈를 만들었지만 중복/우선순위/스펙 준비 상태를 아직 사람이 확인하지 않았을 때 사용한다.
+- 이 라벨이 붙은 이슈는 autopilot 큐에서 제외한다.
+- 수동 `/implement-issue`도 `needs-triage`가 남아 있으면 구현을 시작하지 않는다.
+- 사용자 또는 오케스트레이터가 이슈를 확인한 뒤, 실제로 처리할 가치와 범위가 맞는다고 판단하면 라벨을 제거한다.
 
 ## 5. 우선순위
 
@@ -198,10 +209,28 @@ GitHub 기본 라벨 또는 프로젝트 보드로 관리:
 | `P2 - Medium` | 일반 기능/개선 — 스프린트 내 처리 |
 | `P3 - Low` | 편의 기능, 기술 부채 — 여유 시 처리 |
 
+### 5.1 Autopilot 큐 선별
+
+야간/정기 배치의 `/autopilot`은 아래 규칙으로 대상을 고른다.
+
+- 포함: `feature`, `bug`, `refactor`, `docs`, `test`, `chore`
+- 제외: `needs-triage`, `question`, `blocked`, `blocked:review-loop`, `blocked:pr-review-loop`, `epic`
+- 추가 제외:
+  - 이미 open PR이 연결된 이슈
+  - 선행 의존 이슈가 아직 close되지 않은 이슈
+- 정렬:
+  - `P0 → P1 → P2 → P3`
+  - 같은 우선순위에서는 오래 열린 이슈 우선
+- 실행 방식:
+  - 배치 시작 시점의 snapshot 기준으로 한 번에 하나의 이슈만 활성 처리
+
 ## 6. 이슈 생명주기
 
 ```
 등록 (Open)
+  │
+  ├── `needs-triage`가 붙은 경우
+  │     → 사람/오케스트레이터가 분류 후 라벨 제거 전까지 autopilot 제외
   │
   ├── 에이전트 또는 사용자가 작업 시작
   │     → 브랜치 생성: {type}/#{번호}-{짧은설명}
@@ -243,6 +272,8 @@ BotManager가 중복 주문을 발행하면 Treasury 잔고가 음수가 되는 
 - [ ] 동시 주문 시나리오 테스트 추가" \
   --label "bug"
 ```
+
+watcher나 QA 자동화가 만든 새 이슈가 아직 분류 전이면 `needs-triage`를 함께 붙여 autopilot 대상에서 잠시 제외한다.
 
 ## 8. 이슈와 버전 관리의 연결
 

--- a/docs/runbooks/00-issue-management.md
+++ b/docs/runbooks/00-issue-management.md
@@ -35,6 +35,21 @@
 | `test` | 테스트 추가/수정 | `test` |
 | `chore` | 빌드, CI, 인프라 등 | `chore` |
 
+### 2.1 이슈 타입과 브랜치 prefix 매핑
+
+이슈 제목/라벨과 실제 작업 브랜치 prefix는 아래를 기준으로 맞춘다.
+
+| 이슈 타입 | 라벨 | 브랜치 prefix |
+|-----------|------|---------------|
+| `feat` | `feature` | `feat/` |
+| `fix` | `bug` | `fix/` |
+| `refactor` | `refactor` | `refactor/` |
+| `docs` | `docs` | `docs/` |
+| `test` | `test` | `test/` |
+| `chore` | `chore` | `chore/` |
+
+`/implement-issue`, `/autopilot`, `codex-branch-review`는 이 매핑을 공통 기준으로 사용한다.
+
 ### 예시
 
 ```
@@ -218,6 +233,13 @@ GitHub 기본 라벨 또는 프로젝트 보드로 관리:
 - 추가 제외:
   - 이미 open PR이 연결된 이슈
   - 선행 의존 이슈가 아직 close되지 않은 이슈
+- 브랜치 prefix 매핑:
+  - `feature -> feat/*`
+  - `bug -> fix/*`
+  - `refactor -> refactor/*`
+  - `docs -> docs/*`
+  - `test -> test/*`
+  - `chore -> chore/*`
 - 정렬:
   - `P0 → P1 → P2 → P3`
   - 같은 우선순위에서는 오래 열린 이슈 우선
@@ -233,7 +255,8 @@ GitHub 기본 라벨 또는 프로젝트 보드로 관리:
   │     → 사람/오케스트레이터가 분류 후 라벨 제거 전까지 autopilot 제외
   │
   ├── 에이전트 또는 사용자가 작업 시작
-  │     → 브랜치 생성: {type}/#{번호}-{짧은설명}
+  │     → 브랜치 생성: {branch-prefix}/#{번호}-{짧은설명}
+  │       예: `feat/#42-symbol-validation`, `fix/#57-treasury-rounding`, `chore/#88-runner-cleanup`
   │
   ├── 브랜치 push → codex-branch-review 통과
   │

--- a/docs/runbooks/01-development-process.md
+++ b/docs/runbooks/01-development-process.md
@@ -86,11 +86,14 @@ Claude 오케스트레이터
 | 커맨드 | 역할 | 파일 |
 |--------|------|------|
 | `/implement-issue` | 이슈 구현 전체 흐름 (분석 → 경량 계획 → 조건부 계획 리뷰(필요 시) → 구현 → Codex 브랜치 리뷰 → PR 생성) | `.agent/commands/implement-issue.md` |
+| `/autopilot` | 오픈 이슈 큐 순차 처리 (선별 → 필요 시 `arch-review`/`qa-review` → `/implement-issue` 인계) | `.agent/commands/autopilot.md` |
 | `/qa-test` | 지정 TC 실행 (`@qa-engineer` 위임) | `.agent/commands/qa-test.md` |
 | `/qa-sweep` | 전체 TC 순차 실행 (전수 검사) | `.agent/commands/qa-sweep.md` |
 | `/api-docs` | OpenAPI 스키마 조회 | `.agent/commands/api-docs.md` |
 | `/arch-review` | 이슈 사전 아키텍처 검토 | `.agent/commands/arch-review.md` |
 | `/qa-review` | 이슈 사전 QA 커버리지 검토 | `.agent/commands/qa-review.md` |
+
+야간 배치나 backlog 정리에서는 `/autopilot`이 오픈 이슈 큐 snapshot을 잡고, 필요 시 `/arch-review`와 `/qa-review` 증적을 이슈 코멘트로 남긴 뒤 `/implement-issue`에 개별 구현을 위임한다. `/autopilot`의 기본 성공 기준은 merge 자체가 아니라 **PR 생성 후 기존 리뷰 게이트에 인계**하는 것이다.
 
 ### 4.1 조건부 계획 리뷰
 

--- a/docs/runbooks/01-development-process.md
+++ b/docs/runbooks/01-development-process.md
@@ -127,11 +127,13 @@ Claude 오케스트레이터
 
 ```
 main
-  └─ {type}/#{issue번호}-{짧은설명}
+  └─ {branch-prefix}/#{issue번호}-{짧은설명}
        ├─ 구현 + push
        ├─ codex-branch-review PASS
        └─ PR → main → auto-merge
 ```
+
+`branch-prefix`는 [00-issue-management.md 섹션 2.1](00-issue-management.md#21-이슈-타입과-브랜치-prefix-매핑)의 canonical 매핑을 따른다.
 
 **에픽 이슈**:
 

--- a/docs/runbooks/02-agent-structure.md
+++ b/docs/runbooks/02-agent-structure.md
@@ -84,7 +84,7 @@ Codex는 `.agent/` 내부 에이전트가 아니라 GitHub 이벤트에 반응�
 
 | 역할 | 트리거 | 책임 |
 |------|--------|------|
-| **Codex 브랜치 리뷰어** | `feat/*`, `fix/*`, `refactor/*`, `docs/*`, `test/*`, `chore/*`, `epic/*` 브랜치 push | PR 전 blocking issue 식별, `codex-branch-review` 상태 기록 |
+| **Codex 브랜치 리뷰어** | `feat/*`, `fix/*`, `perf/*`, `refactor/*`, `docs/*`, `test/*`, `chore/*`, `epic/*` 브랜치 push | PR 전 blocking issue 식별, `codex-branch-review` 상태 기록 |
 | **Codex PR 승인 워커** | `pull_request` opened/synchronize/ready_for_review | 최종 승인 체크, `codex-pr-approve` 상태 기록 |
 
 ### 1.9 Claude PR 승인 워커

--- a/docs/runbooks/02-agent-structure.md
+++ b/docs/runbooks/02-agent-structure.md
@@ -84,7 +84,7 @@ Codex는 `.agent/` 내부 에이전트가 아니라 GitHub 이벤트에 반응�
 
 | 역할 | 트리거 | 책임 |
 |------|--------|------|
-| **Codex 브랜치 리뷰어** | feature/fix/refactor 브랜치 push | PR 전 blocking issue 식별, `codex-branch-review` 상태 기록 |
+| **Codex 브랜치 리뷰어** | `feat/*`, `fix/*`, `refactor/*`, `docs/*`, `test/*`, `chore/*`, `epic/*` 브랜치 push | PR 전 blocking issue 식별, `codex-branch-review` 상태 기록 |
 | **Codex PR 승인 워커** | `pull_request` opened/synchronize/ready_for_review | 최종 승인 체크, `codex-pr-approve` 상태 기록 |
 
 ### 1.9 Claude PR 승인 워커

--- a/docs/runbooks/02-agent-structure.md
+++ b/docs/runbooks/02-agent-structure.md
@@ -19,6 +19,7 @@
 **역할**:
 - 작업 분석과 분해
 - 경량 계획 체크리스트 작성과 조건부 계획 리뷰 여부 판단
+- 야간 `/autopilot` 배치에서 이슈 큐 snapshot, 선행 리뷰 증적, handoff 조율
 - 적절한 Claude 서브에이전트 위임
 - 이슈/브랜치/PR GitHub 기록 관리
 - Codex 브랜치 리뷰 결과를 받아 수정 루프 조율
@@ -109,6 +110,7 @@ Claude도 PR 단계에서는 독립 승인 워커로 동작한다.
 │   └── code-reviewer.md       # @code-reviewer — 조건부 계획 리뷰 / 구조 리스크 메타 리뷰
 ├── commands/              # 커스텀 슬래시 명령어 (작업 절차 SSOT)
 │   ├── implement-issue.md     # /implement-issue
+│   ├── autopilot.md           # /autopilot
 │   ├── qa-test.md             # /qa-test
 │   ├── qa-sweep.md            # /qa-sweep
 │   ├── api-docs.md            # /api-docs
@@ -166,6 +168,7 @@ Claude도 PR 단계에서는 독립 승인 워커로 동작한다.
 반복적인 개발 작업을 슬래시 명령으로 정의한다:
 
 - `/implement-issue #{번호}` — 분석 → 경량 계획 → 조건부 계획 리뷰(필요 시) → 구현 → Codex 브랜치 리뷰 → PR 생성
+- `/autopilot` — 오픈 이슈 큐 snapshot → 필요 시 `arch-review` / `qa-review` → `/implement-issue` 순차 위임
 - `/qa-test {카테고리}` — 지정 TC 실행
 - `/qa-sweep` — 전체 TC 전수 검사
 - `/api-docs` — OpenAPI 스키마 조회
@@ -176,6 +179,9 @@ Claude도 PR 단계에서는 독립 승인 워커로 동작한다.
 - **백엔드**: `module-conventions`, `asyncio-patterns`, `sqlite-patterns`
 - **프론트엔드**: `frontend-conventions`
 - **리뷰 공통 규약**: `review-pr`
+- **GitHub 운용 공통 스킬**:
+  - `github-auth`
+  - `github-ops`
 - **구현 품질 보조 스킬**:
   - `lightweight-planning`
   - `receive-review`

--- a/docs/runbooks/03-git-workflow.md
+++ b/docs/runbooks/03-git-workflow.md
@@ -9,6 +9,7 @@
 ```
 feat/#42-symbol-validation
 fix/#57-treasury-rounding
+perf/#61-column-pruning
 refactor/#63-broker-interface
 docs/#70-api-reference
 test/#81-regression-coverage
@@ -22,17 +23,18 @@ epic/#300-datafeed
 - 에픽은 통합용 `epic/*` 브랜치를 별도로 두고, 하위 이슈는 각자 작업 브랜치를 사용한다.
 - 에픽과 하위 이슈를 하나의 공용 작업 브랜치에 순차 누적하지 않는다.
 
-### 1.2 이슈 라벨과 브랜치 prefix 매핑
+### 1.2 이슈 타입과 브랜치 prefix 매핑
 
-| 이슈 라벨 | 브랜치 prefix |
-|-----------|---------------|
-| `feature` | `feat/` |
-| `bug` | `fix/` |
-| `refactor` | `refactor/` |
-| `docs` | `docs/` |
-| `test` | `test/` |
-| `chore` | `chore/` |
-| `epic` | `epic/` |
+| 이슈 타입 | 대응 라벨 | 브랜치 prefix |
+|-----------|-----------|---------------|
+| `feat` | `feature` | `feat/` |
+| `fix` | `bug` | `fix/` |
+| `perf` | `feature` | `perf/` |
+| `refactor` | `refactor` | `refactor/` |
+| `docs` | `docs` | `docs/` |
+| `test` | `test` | `test/` |
+| `chore` | `chore` | `chore/` |
+| `epic` | `epic` | `epic/` |
 
 `/implement-issue`, `/autopilot`, `codex-branch-review`는 이 매핑을 기준으로 정렬한다.
 
@@ -90,7 +92,7 @@ PR을 열기 전, 최신 브랜치 HEAD는 반드시 Codex 사전 리뷰를 통�
 
 ### 3.1 브랜치 리뷰 트리거
 
-- 대상 브랜치: `feat/*`, `fix/*`, `refactor/*`, `docs/*`, `test/*`, `chore/*`, `epic/*`
+- 대상 브랜치: `feat/*`, `fix/*`, `perf/*`, `refactor/*`, `docs/*`, `test/*`, `chore/*`, `epic/*`
 - 트리거: 원격 브랜치 push
 - 상태 체크: `codex-branch-review`
 

--- a/docs/runbooks/03-git-workflow.md
+++ b/docs/runbooks/03-git-workflow.md
@@ -11,6 +11,8 @@ feat/#42-symbol-validation
 fix/#57-treasury-rounding
 refactor/#63-broker-interface
 docs/#70-api-reference
+test/#81-regression-coverage
+chore/#88-runner-cleanup
 epic/#300-datafeed
 ```
 
@@ -20,7 +22,21 @@ epic/#300-datafeed
 - 에픽은 통합용 `epic/*` 브랜치를 별도로 두고, 하위 이슈는 각자 작업 브랜치를 사용한다.
 - 에픽과 하위 이슈를 하나의 공용 작업 브랜치에 순차 누적하지 않는다.
 
-### 1.2 에픽 하위 브랜치 최신화
+### 1.2 이슈 라벨과 브랜치 prefix 매핑
+
+| 이슈 라벨 | 브랜치 prefix |
+|-----------|---------------|
+| `feature` | `feat/` |
+| `bug` | `fix/` |
+| `refactor` | `refactor/` |
+| `docs` | `docs/` |
+| `test` | `test/` |
+| `chore` | `chore/` |
+| `epic` | `epic/` |
+
+`/implement-issue`, `/autopilot`, `codex-branch-review`는 이 매핑을 기준으로 정렬한다.
+
+### 1.3 에픽 하위 브랜치 최신화
 
 - 에픽 하위 이슈 브랜치는 PR 생성 전 최신 `origin/epic/*`를 기준으로 해야 한다.
 - sibling PR이 `epic/*`에 머지되면 다음 확인을 수행한다.
@@ -74,7 +90,7 @@ PR을 열기 전, 최신 브랜치 HEAD는 반드시 Codex 사전 리뷰를 통�
 
 ### 3.1 브랜치 리뷰 트리거
 
-- 대상 브랜치: `feat/*`, `fix/*`, `refactor/*`, `docs/*`, `epic/*`
+- 대상 브랜치: `feat/*`, `fix/*`, `refactor/*`, `docs/*`, `test/*`, `chore/*`, `epic/*`
 - 트리거: 원격 브랜치 push
 - 상태 체크: `codex-branch-review`
 

--- a/docs/runbooks/04-ci-cd.md
+++ b/docs/runbooks/04-ci-cd.md
@@ -43,7 +43,7 @@ post-merge automation
 
 **목적**: PR 전 브랜치 품질 게이트
 
-- **트리거**: `feat/*`, `fix/*`, `refactor/*`, `docs/*`, `test/*`, `chore/*`, `epic/*` 브랜치 push
+- **트리거**: `feat/*`, `fix/*`, `perf/*`, `refactor/*`, `docs/*`, `test/*`, `chore/*`, `epic/*` 브랜치 push
 - **결과**: `codex-branch-review`
 - **실패 시**: Claude가 같은 브랜치에서 수정 후 재push
 - **해석 주의**: 리뷰 단계가 finding을 생성했고 마지막 `Enforce review verdict`만 실패한 경우, 이는 워크플로우 장애가 아니라 **의도된 content fail**이다.

--- a/docs/runbooks/04-ci-cd.md
+++ b/docs/runbooks/04-ci-cd.md
@@ -43,7 +43,7 @@ post-merge automation
 
 **목적**: PR 전 브랜치 품질 게이트
 
-- **트리거**: feature/fix/refactor/docs/epic 브랜치 push
+- **트리거**: `feat/*`, `fix/*`, `refactor/*`, `docs/*`, `test/*`, `chore/*`, `epic/*` 브랜치 push
 - **결과**: `codex-branch-review`
 - **실패 시**: Claude가 같은 브랜치에서 수정 후 재push
 - **해석 주의**: 리뷰 단계가 finding을 생성했고 마지막 `Enforce review verdict`만 실패한 경우, 이는 워크플로우 장애가 아니라 **의도된 content fail**이다.

--- a/docs/runbooks/07-review-gate.md
+++ b/docs/runbooks/07-review-gate.md
@@ -53,7 +53,7 @@
 ### 3.1 트리거
 
 - 브랜치 push
-- 대상: `feat/*`, `fix/*`, `refactor/*`, `docs/*`, `epic/*`
+- 대상: `feat/*`, `fix/*`, `refactor/*`, `docs/*`, `test/*`, `chore/*`, `epic/*`
 
 ### 3.2 결과
 

--- a/docs/runbooks/07-review-gate.md
+++ b/docs/runbooks/07-review-gate.md
@@ -53,7 +53,7 @@
 ### 3.1 트리거
 
 - 브랜치 push
-- 대상: `feat/*`, `fix/*`, `refactor/*`, `docs/*`, `test/*`, `chore/*`, `epic/*`
+- 대상: `feat/*`, `fix/*`, `perf/*`, `refactor/*`, `docs/*`, `test/*`, `chore/*`, `epic/*`
 
 ### 3.2 결과
 

--- a/docs/runbooks/08-autopilot-operations.md
+++ b/docs/runbooks/08-autopilot-operations.md
@@ -96,7 +96,7 @@ autopilot은 필요 시 구현 전에 두 종류의 리뷰 증적을 남긴다.
 - `🏗️ **아키텍트 리뷰**`
 - `🧪 **QA 리뷰**`
 
-최신 리뷰 verdict는 `ready | caution | blocked` 중 하나로 남긴다.
+각 리뷰 타입의 최신 verdict는 `ready | caution | blocked` 중 하나로 남긴다.
 
 최신 리뷰에 verdict가 없거나, `blocked`/`caution` verdict 이후 이슈 본문·스펙·선행 조건이 바뀌었다면 `/arch-review` 또는 `/qa-review`를 다시 실행해 refresh verdict를 남길 수 있어야 한다.
 
@@ -113,7 +113,8 @@ autopilot은 필요 시 구현 전에 두 종류의 리뷰 증적을 남긴다.
 - `/implement-issue`는 이슈 코멘트에 남아 있는 `arch-review` / `qa-review` 증적을 읽고:
   - 구현 착수 코멘트에 요약을 남기고
   - 개발 에이전트 프롬프트에도 같은 요약을 포함한다
-- verdict가 없거나 stale한 리뷰는 구현 게이트로 쓰지 않고, refresh 리뷰를 먼저 남긴 뒤 최신 verdict를 사용한다.
+- verdict가 없거나 stale한 리뷰는 구현 게이트로 쓰지 않고, 해당 리뷰 타입의 refresh 리뷰를 먼저 남긴 뒤 최신 verdict를 사용한다.
+- 구현 게이트는 단일 최신 사전 리뷰가 아니라, `arch-review`와 `qa-review`의 최신 verdict를 각각 평가한다. 둘 중 하나라도 `blocked`면 구현을 시작하지 않는다.
 
 이렇게 해야 사전 리뷰 증적과 실제 구현이 끊기지 않는다.
 

--- a/docs/runbooks/08-autopilot-operations.md
+++ b/docs/runbooks/08-autopilot-operations.md
@@ -24,6 +24,8 @@
 ### 2.1 Snapshot 원칙
 
 - 배치 시작 시점의 open issue 목록을 snapshot으로 고정한다.
+- snapshot 수집은 `needs-triage`와 기본 제외 라벨을 **server-side filter로 먼저 제외한 뒤**, pagination으로 전체 후보 집합을 끝까지 모으는 방식이어야 한다.
+- "앞 100건만 가져온 뒤 로컬에서 제외 라벨을 거르는 방식"은 backlog가 커질 때 실제 처리 가능 이슈를 누락시킬 수 있으므로 사용하지 않는다.
 - 배치 도중 새로 생긴 이슈나 follow-up 이슈는 다음 실행으로 넘긴다.
 - 같은 배치에서 같은 이슈를 두 번 재선택하지 않는다.
 
@@ -49,6 +51,8 @@
 - 이미 open PR이 연결된 이슈
 - 선행 의존 이슈가 close되지 않은 이슈
 
+라벨 기반 제외는 snapshot 수집 시점에 server-side로 먼저 적용하고, open PR 존재 여부나 선행 의존성처럼 추가 조회가 필요한 조건만 후행 검사로 남긴다.
+
 ### 2.3 정렬 규칙
 
 1. `P0 - Critical`
@@ -63,6 +67,7 @@
 - `needs-triage`는 "이 이슈를 autopilot이 바로 집으면 안 된다"는 의미다.
 - watcher나 QA 자동화가 만든 이슈, 중복/오탐 가능성이 있는 이슈, 스펙 준비 여부를 사람이 먼저 판단해야 하는 이슈에 붙인다.
 - autopilot은 `needs-triage`가 남아 있는 이슈를 건너뛴다.
+- 이 건너뛰기는 후보를 다 가져온 뒤 후행 필터링하는 방식이 아니라, queue snapshot 수집 단계에서 `-label:needs-triage`를 먼저 적용해 보장한다.
 - 수동 `/implement-issue`도 `needs-triage`가 붙어 있으면 구현을 시작하지 않는다.
 - 사람이 이슈를 검토한 뒤 실제 처리 가치와 범위를 확인하면 라벨을 제거한다.
 

--- a/docs/runbooks/08-autopilot-operations.md
+++ b/docs/runbooks/08-autopilot-operations.md
@@ -98,6 +98,8 @@ autopilot은 필요 시 구현 전에 두 종류의 리뷰 증적을 남긴다.
 
 최신 리뷰 verdict는 `ready | caution | blocked` 중 하나로 남긴다.
 
+최신 리뷰에 verdict가 없거나, `blocked`/`caution` verdict 이후 이슈 본문·스펙·선행 조건이 바뀌었다면 `/arch-review` 또는 `/qa-review`를 다시 실행해 refresh verdict를 남길 수 있어야 한다.
+
 ### 4.4 verdict 해석
 
 - `ready`: 구현 진행 가능
@@ -111,6 +113,7 @@ autopilot은 필요 시 구현 전에 두 종류의 리뷰 증적을 남긴다.
 - `/implement-issue`는 이슈 코멘트에 남아 있는 `arch-review` / `qa-review` 증적을 읽고:
   - 구현 착수 코멘트에 요약을 남기고
   - 개발 에이전트 프롬프트에도 같은 요약을 포함한다
+- verdict가 없거나 stale한 리뷰는 구현 게이트로 쓰지 않고, refresh 리뷰를 먼저 남긴 뒤 최신 verdict를 사용한다.
 
 이렇게 해야 사전 리뷰 증적과 실제 구현이 끊기지 않는다.
 

--- a/docs/runbooks/08-autopilot-operations.md
+++ b/docs/runbooks/08-autopilot-operations.md
@@ -1,0 +1,206 @@
+# 08. Autopilot 운영
+
+> 야간/정기 배치에서 오픈 이슈를 순차 처리할 때의 큐 선별, `needs-triage`, 사전 리뷰 증적, `/implement-issue` 인계 규칙을 정의한다.
+
+---
+
+## 1. 목적
+
+`/autopilot`의 목적은 GitHub에 쌓인 오픈 이슈를 밤 시간대에 **한 번에 하나씩 최대한 많이 전진시키는 것**이다.
+
+- autopilot은 새 구현 파이프라인을 만들지 않는다.
+- 실제 구현 절차 SSOT는 계속 `/implement-issue`다.
+- autopilot은 이슈 선별, 보류 판단, 사전 리뷰 증적, 인계 순서를 책임진다.
+
+기본 성공 기준:
+
+- 이슈가 PR 생성까지 진행되었고
+- 이후 CI + 승인 + auto-merge 파이프라인으로 인계되었음
+
+실제 merge/post-merge까지 기다리는 동작은 예외 모드(`--strict-merge`)로만 사용한다.
+
+## 2. 큐 모델
+
+### 2.1 Snapshot 원칙
+
+- 배치 시작 시점의 open issue 목록을 snapshot으로 고정한다.
+- 배치 도중 새로 생긴 이슈나 follow-up 이슈는 다음 실행으로 넘긴다.
+- 같은 배치에서 같은 이슈를 두 번 재선택하지 않는다.
+
+### 2.2 포함/제외 규칙
+
+포함:
+
+- `feature`
+- `bug`
+- `refactor`
+- `docs`
+- `test`
+- `chore`
+
+제외:
+
+- `needs-triage`
+- `question`
+- `blocked`
+- `blocked:review-loop`
+- `blocked:pr-review-loop`
+- `epic`
+- 이미 open PR이 연결된 이슈
+- 선행 의존 이슈가 close되지 않은 이슈
+
+### 2.3 정렬 규칙
+
+1. `P0 - Critical`
+2. `P1 - High`
+3. `P2 - Medium`
+4. `P3 - Low`
+
+같은 우선순위 안에서는 오래 열린 이슈를 먼저 처리한다.
+
+## 3. `needs-triage`
+
+- `needs-triage`는 "이 이슈를 autopilot이 바로 집으면 안 된다"는 의미다.
+- watcher나 QA 자동화가 만든 이슈, 중복/오탐 가능성이 있는 이슈, 스펙 준비 여부를 사람이 먼저 판단해야 하는 이슈에 붙인다.
+- autopilot은 `needs-triage`가 남아 있는 이슈를 건너뛴다.
+- 수동 `/implement-issue`도 `needs-triage`가 붙어 있으면 구현을 시작하지 않는다.
+- 사람이 이슈를 검토한 뒤 실제 처리 가치와 범위를 확인하면 라벨을 제거한다.
+
+## 4. 사전 리뷰 증적
+
+autopilot은 필요 시 구현 전에 두 종류의 리뷰 증적을 남긴다.
+
+### 4.1 `arch-review`
+
+아래 신호가 있으면 먼저 검토한다.
+
+- API / CLI / schema / field rename
+- cache / invalidate / reconnect / mutable config
+- 둘 이상의 모듈과 소비자 경로 동시 영향
+- health / readiness / background task 변경
+- 선행/후속 이슈 구조가 애매한 경우
+
+### 4.2 `qa-review`
+
+아래 신호가 있으면 먼저 검토한다.
+
+- 수용 조건이 여러 개인데 기존 TC 매핑이 불명확
+- 에러/경계값 검증이 핵심
+- frontend/API 변경으로 contract와 TC 동기화가 중요
+- 에픽 하위 이슈나 통합 시나리오가 필요한 경우
+
+### 4.3 증적 위치
+
+공식 증적은 GitHub 이슈 코멘트다.
+
+- `🏗️ **아키텍트 리뷰**`
+- `🧪 **QA 리뷰**`
+
+최신 리뷰 verdict는 `ready | caution | blocked` 중 하나로 남긴다.
+
+### 4.4 verdict 해석
+
+- `ready`: 구현 진행 가능
+- `caution`: 구현 진행 가능하지만 주의사항과 TC follow-up을 반드시 반영
+- `blocked`: autopilot이 구현을 시작하지 않고 사람 판단이나 선행 작업을 기다림
+
+## 5. `/implement-issue` 인계
+
+- autopilot은 직접 코드를 구현하지 않는다.
+- 사전 리뷰를 통과한 이슈만 `/implement-issue #{번호}`로 넘긴다.
+- `/implement-issue`는 이슈 코멘트에 남아 있는 `arch-review` / `qa-review` 증적을 읽고:
+  - 구현 착수 코멘트에 요약을 남기고
+  - 개발 에이전트 프롬프트에도 같은 요약을 포함한다
+
+이렇게 해야 사전 리뷰 증적과 실제 구현이 끊기지 않는다.
+
+## 6. 결과 상태
+
+각 이슈는 배치 안에서 아래 상태 중 하나로 정리한다.
+
+- `handed-off`: PR 생성 후 기존 리뷰 게이트에 인계
+- `deferred-triage`: `needs-triage`
+- `deferred-dependency`: 선행 이슈 미완료
+- `deferred-review`: `arch-review` 또는 `qa-review`가 `blocked`
+- `retry-later-infra`: 인증/러너/네트워크/공통 환경 문제
+- `skipped-in-progress`: 이미 open PR이 있거나 사람이 작업 중
+
+## 7. 중단 규칙
+
+- 공통 인프라 오류가 3회 연속 발생하면 현재 배치를 중단한다.
+- 시간 예산이 소진되면 현재 이슈 정리 후 종료한다.
+- `blocked:review-loop`, `blocked:pr-review-loop` 이슈는 강제로 다시 밀어붙이지 않는다.
+- 같은 배치에서 같은 이슈를 반복 재집지 않는다.
+
+## 8. 보고와 기록
+
+공식 기록:
+
+- 이슈 코멘트 (`arch-review`, `qa-review`, 구현 착수, PR 생성, 보류 사유)
+- PR 코멘트와 status check (`codex-branch-review`, `ci`, `claude-pr-approve`, `codex-pr-approve`)
+
+필수 요약 기록:
+
+- 배치 큐 snapshot이 1건 이상이면 `docs/temp/autopilot-report-*.md`
+
+`docs/temp` 리포트는 이슈/PR 단위의 공식 증적을 대체하지는 않지만, 배치 전체 흐름과 회고를 남기는 **필수 운영 요약본**이다.
+
+### 8.1 Autopilot 리포트 의무화
+
+- 이번 배치의 autopilot 큐 snapshot이 1건 이상이면 실행 모드와 관계없이 리포트를 반드시 남긴다.
+- `--dry-run`도 예외가 아니다. 실제 구현을 시작하지 않았더라도 큐 판단과 보류 사유를 남긴다.
+- 큐 snapshot이 0건인 경우에만 리포트를 생략할 수 있다.
+
+### 8.2 리포트 최소 구조
+
+```markdown
+## Autopilot 결과 보고
+
+- 실행 시각:
+- 종료 시각:
+- 소요 시간:
+- 실행 모드:
+- 큐 snapshot 크기:
+
+### 이슈별 결과
+| 이슈 | 제목 | 결과 | PR/비고 |
+|------|------|------|---------|
+
+### 보류/스킵 상세
+- ...
+
+### 후속 조치
+- ...
+
+### 프로세스 회고
+
+#### 있었던 사건
+- ...
+
+#### 개선 포인트
+- ...
+```
+
+### 8.3 회고에 남겨야 할 사건 예시
+
+- 특정 runner가 비정상적으로 오래 대기하거나 실패를 반복함
+- Claude/Codex 또는 다른 에이전트 판단이 충돌해 review loop가 길어짐
+- merge conflict, stale base, duplicate commit 때문에 히스토리 정리가 필요했음
+- 인증 실패, `gh` 권한 부족, workflow 수동 재실행 등 운영 마찰이 있었음
+- `needs-triage`가 늦게 정리되어 배치 throughput이 떨어졌음
+- 선행 이슈나 TC 부재 때문에 구현보다 보류 판단이 많았음
+
+### 8.4 회고의 목적
+
+- 단순 사건 나열이 아니라, 다음 배치에서 덜 흔들리기 위한 개선 포인트를 남긴다.
+- 이슈 단위의 정답/오답보다, autopilot 큐 운영과 에이전트 협업 마찰을 줄이는 데 초점을 둔다.
+
+GitHub 조회/코멘트/PR/재실행 절차는 `.agent/skills/github-ops.md`를 공통으로 따른다.
+
+## 9. 운영 원칙
+
+1. autopilot은 큐 관리자다
+2. 구현 절차는 `/implement-issue`가 SSOT다
+3. `needs-triage`는 autopilot 안전핀이다
+4. 사전 리뷰 증적은 GitHub 이슈 코멘트에 남기고 재사용한다
+5. 기본 모드는 throughput 우선, merge 대기 모드는 예외적으로만 사용한다

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -16,12 +16,14 @@
 | [04-ci-cd.md](04-ci-cd.md) | CI/CD 파이프라인 (Codex 브랜치 리뷰, 이중 승인, auto-merge) |
 | [05-testing.md](05-testing.md) | 테스트 전략 (단위/통합/QA TC 테스트, 커버리지) |
 | [07-review-gate.md](07-review-gate.md) | 조건부 계획 리뷰, 리뷰 단계와 merge gate의 책임 분리, 확장 리뷰 규칙, status check 기준 |
+| [08-autopilot-operations.md](08-autopilot-operations.md) | 야간 autopilot 배치 운영 규칙 (`needs-triage`, 큐 선별, 사전 리뷰 증적, `/implement-issue` 인계) |
 
 ## 에이전트 커맨드 (작업 절차 SSOT)
 
 | 커맨드 | 설명 |
 |--------|------|
 | `/implement-issue` | 이슈 구현 전체 흐름 (분석 → 경량 계획 → 조건부 계획 리뷰(필요 시) → 구현 → Codex 브랜치 리뷰 → PR 생성) |
+| `/autopilot` | 오픈 이슈 큐 순차 처리 (필요 시 `arch-review` / `qa-review` 후 `/implement-issue`에 인계) |
 | `/qa-test` | 지정 TC 실행 (`@qa-engineer` 위임) |
 | `/qa-sweep` | 전체 TC 순차 실행 (전수 검사) |
 | `/api-docs` | OpenAPI 스키마 조회 |

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -15,6 +15,7 @@
 | [03-git-workflow.md](03-git-workflow.md) | 커밋 컨벤션 (+ 버전 범프), `Closes #N` 기반 PR 규칙 |
 | [04-ci-cd.md](04-ci-cd.md) | CI/CD 파이프라인 (Codex 브랜치 리뷰, 이중 승인, auto-merge) |
 | [05-testing.md](05-testing.md) | 테스트 전략 (단위/통합/QA TC 테스트, 커버리지) |
+| [06-release.md](06-release.md) | 릴리스 운영 (버전 관리, 태그, 배포 체크리스트) |
 | [07-review-gate.md](07-review-gate.md) | 조건부 계획 리뷰, 리뷰 단계와 merge gate의 책임 분리, 확장 리뷰 규칙, status check 기준 |
 | [08-autopilot-operations.md](08-autopilot-operations.md) | 야간 autopilot 배치 운영 규칙 (`needs-triage`, 큐 선별, 사전 리뷰 증적, `/implement-issue` 인계) |
 

--- a/docs/superpowers/specs/2026-04-17-staging-environment-design.md
+++ b/docs/superpowers/specs/2026-04-17-staging-environment-design.md
@@ -224,7 +224,7 @@ QA 컴포즈의 `ante_ante-data:ro` 같은 프로덕션 볼륨 참조 마운트�
 ### 7.4 자동 처리 게이트
 
 - 감시 에이전트는 **`needs-triage` 라벨을 반드시 붙인다**.
-- [.agent/commands/autopilot.md](../../.agent/commands/autopilot.md) 및 `implement-issue`는 이슈 선별 시 `-label:needs-triage` 필터를 적용한다 (관련 커맨드 보강 필요 — §11 참조).
+- [.agent/commands/autopilot.md](../../.agent/commands/autopilot.md)는 이슈 큐 선별 시 `-label:needs-triage`를 적용하고, [.agent/commands/implement-issue.md](../../.agent/commands/implement-issue.md)는 `needs-triage`가 붙은 단건 이슈를 거부한다.
 - 사용자/오케스트레이터가 판단 후 `needs-triage`를 제거하면 autopilot이 처리한다.
 
 ### 7.5 스케줄
@@ -277,7 +277,6 @@ macOS `launchd` plist를 `deploy/staging/com.ante.staging-watcher.plist`로 제�
 
 ## 11. 오픈 이슈 (1차 구현 시 확인)
 
-- [ ] autopilot/implement-issue가 `-label:needs-triage` 필터를 지원하는지 확인. 미지원 시 커맨드 md 보강.
 - [ ] Notification 모듈이 `TELEGRAM_BOT_TOKEN` 공란 시 silent 동작을 실제로 지원하는지 확인. 미지원 시 가드 추가.
 - [ ] macOS `launchd`에서 `claude` CLI 호출 시 PATH/인증 전달 방식 검증 (기존 shell 세션 환경과 차이 확인 필요).
 - [ ] GitHub 이슈 검색 API의 타이틀 내 fingerprint 매칭 정확도 확인. 불충분 시 이슈 body HTML 코멘트 마커(`<!-- fingerprint: ... -->`) 스캔으로 폴백.

--- a/docs/superpowers/specs/2026-04-17-staging-environment-design.md
+++ b/docs/superpowers/specs/2026-04-17-staging-environment-design.md
@@ -224,7 +224,7 @@ QA 컴포즈의 `ante_ante-data:ro` 같은 프로덕션 볼륨 참조 마운트�
 ### 7.4 자동 처리 게이트
 
 - 감시 에이전트는 **`needs-triage` 라벨을 반드시 붙인다**.
-- [.agent/commands/autopilot.md](../../.agent/commands/autopilot.md)는 이슈 큐 선별 시 `-label:needs-triage`를 적용하고, [.agent/commands/implement-issue.md](../../.agent/commands/implement-issue.md)는 `needs-triage`가 붙은 단건 이슈를 거부한다.
+- [.agent/commands/autopilot.md](../../.agent/commands/autopilot.md)는 이슈 큐 선별 시 `-label:needs-triage`를 포함한 server-side exclusion filter를 먼저 적용하고, pagination 기반 전체 snapshot을 만든다. [.agent/commands/implement-issue.md](../../.agent/commands/implement-issue.md)는 `needs-triage`가 붙은 단건 이슈를 거부한다.
 - 사용자/오케스트레이터가 판단 후 `needs-triage`를 제거하면 autopilot이 처리한다.
 
 ### 7.5 스케줄

--- a/docs/superpowers/specs/2026-04-17-staging-environment-design.md
+++ b/docs/superpowers/specs/2026-04-17-staging-environment-design.md
@@ -224,7 +224,7 @@ QA 컴포즈의 `ante_ante-data:ro` 같은 프로덕션 볼륨 참조 마운트�
 ### 7.4 자동 처리 게이트
 
 - 감시 에이전트는 **`needs-triage` 라벨을 반드시 붙인다**.
-- [.agent/commands/autopilot.md](../../.agent/commands/autopilot.md)는 이슈 큐 선별 시 `-label:needs-triage`를 적용하고, [.agent/commands/implement-issue.md](../../.agent/commands/implement-issue.md)는 `needs-triage`가 붙은 단건 이슈를 거부한다.
+- [.agent/commands/autopilot.md](../../../.agent/commands/autopilot.md)는 이슈 큐 선별 시 `-label:needs-triage`를 적용하고, [.agent/commands/implement-issue.md](../../../.agent/commands/implement-issue.md)는 `needs-triage`가 붙은 단건 이슈를 거부한다.
 - 사용자/오케스트레이터가 판단 후 `needs-triage`를 제거하면 autopilot이 처리한다.
 
 ### 7.5 스케줄


### PR DESCRIPTION
## Summary
- add `/autopilot` as the nightly backlog queue orchestrator and define its runbook, queue selection, `needs-triage`, and reporting rules
- wire `arch-review` / `qa-review` evidence into `/implement-issue`, and standardize review verdicts as `ready | caution | blocked`
- add a shared `github-ops` skill so autopilot, implementation, review, and QA commands use GitHub consistently
- include the current `AGENTS.md` rule update so planning/orchestration stops at issue registration and implementation/PR work stays delegated to `/implement-issue`

## Why
The repo had review and merge rules, but autopilot itself was not a real SSOT command yet. GitHub usage was also spread across commands without one shared operating rule, which made agent behavior inconsistent. This change makes nightly issue handling explicit, keeps evidence in GitHub, and adds required batch reporting plus process retrospectives when work actually ran.

## Impact
- autopilot can now select issues predictably, skip `needs-triage`, require pre-reviews when needed, and always leave a temp report when the queue was non-empty
- implementation handoff now reuses existing architecture/QA review evidence instead of losing that context at `/implement-issue`
- GitHub auth/issue/PR/workflow usage should be more consistent across agent commands

## Root Cause
- `/autopilot` existed in design discussions and generated docs, but not as a current command SSOT
- `arch-review` / `qa-review` evidence was not connected into `/implement-issue`
- GitHub CLI behavior was described in pieces instead of one shared operating skill

## Validation
- `git diff --check`
- `git diff --cached --check`
- no automated tests were run; this PR changes command/runbook/spec documents only
