### PR TITLE
fix(config): treat empty env var as explicit empty secret (#1119)

### DIFF
--- a/src/ante/config/config.py
+++ b/src/ante/config/config.py
@@ -120,10 +120,15 @@ class Config:
     def secret(self, key: str) -> str:
         """비밀값 조회. 환경변수 우선, 없으면 .env에서.
 
+        환경변수가 존재하면(빈 문자열 포함) 그대로 반환하며, 빈 값 허용
+        여부는 호출자가 판단한다.
+
         예: config.secret("KIS_APP_KEY")
         Raises: ConfigError if not found
         """
-        value = os.environ.get(key) or self._secrets.get(key)
+        if key in os.environ:
+            return os.environ[key]
+        value = self._secrets.get(key)
         if value is None:
             raise ConfigError(f"Secret not found: {key}")
         return value

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -118,6 +118,23 @@ class TestConfigSecret:
         with pytest.raises(ConfigError, match="Secret not found"):
             config.secret("NONEXISTENT")
 
+    def test_empty_env_returns_empty_string(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """환경변수가 빈 문자열이면 그대로 빈 문자열을 반환한다."""
+        monkeypatch.setenv("API_KEY", "")
+        config = Config(static={}, secrets={"API_KEY": "from_file"})
+        # 환경변수가 명시적으로 빈 문자열이면 dotenv로 fallback하지 않는다.
+        assert config.secret("API_KEY") == ""
+
+    def test_empty_env_does_not_fallback_to_dotenv(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """명시적 빈 환경변수는 .env fallback을 발생시키지 않는다."""
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "")
+        config = Config(static={}, secrets={"TELEGRAM_BOT_TOKEN": "file_value"})
+        assert config.secret("TELEGRAM_BOT_TOKEN") == ""
+
 
 # ── 유효성 검증 ──────────────────────────────────
 


### PR DESCRIPTION
Closes #1119

## Summary
- `Config.secret()`가 환경변수 존재 여부를 `key in os.environ`로 판정하여, 빈 문자열 환경변수를 "누락"으로 오인하지 않고 그대로 반환.
- 이슈 본문 방침대로 "빈 값 허용 여부는 호출자가 판단"하도록 책임 경계를 맞춤.
- `TestConfigSecret`에 빈 환경변수 회귀 테스트 2건 추가.

## Test Plan
- [x] `pytest tests/unit/test_config.py -v` (19 passed)
- [x] 영향 호출부(`src/ante/main.py:1125`, `src/ante/web/routes/treasury.py:97`)는 이미 빈 문자열 가드를 보유해 회귀 없음 확인
- [x] `ruff check`, `ruff format --check`, `mypy src/ante/config/config.py`