### PR TITLE
chore: tighten autopilot cycle monitoring

### DIFF
--- a/.agent/commands/autopilot.md
+++ b/.agent/commands/autopilot.md
@@ -3,25 +3,91 @@
 ## 인자
 
 $ARGUMENTS — 옵션 (생략 가능)
-- 없음: 기본 autopilot 큐 전체
-- `--limit {N}`: 이번 배치에서 처리할 최대 이슈 수
+- 없음: 기본 autopilot 큐 (`--limit 10`)
+- `--limit {N}`: 이번 배치에서 처리할 최대 이슈 수 (기본 10, 최대 10)
 - `--time-budget {예: 4h, 90m}`: 시간 예산이 소진되면 다음 이슈로 넘어가지 않고 종료
 - `--label {라벨}`: 특정 라벨만 대상으로 제한
-- `--strict-merge`: PR 생성 인계가 아니라 실제 merge/post-merge까지 확인
+- `--handoff-only`: 예외적으로 PR 생성 후 기존 게이트 인계까지만 처리하고 merge/post-merge 확인은 생략
+- `--strict-merge`: deprecated alias. 현재는 기본 동작과 동일하게 merge/post-merge까지 확인
 - `--dry-run`: 큐 선별과 선행 리뷰 필요 여부만 계산하고 실제 구현은 시작하지 않음
 
 ## 목적
 
-`/autopilot`은 직접 코드를 구현하는 명령이 아니다. 이 커맨드는 오픈 이슈 큐를 정리하고, 지금 자동으로 처리해도 되는 이슈만 골라 **한 번에 하나씩** `/implement-issue`에 넘기는 야간 배치 오케스트레이터다.
+`/autopilot`은 직접 코드를 구현하는 명령이 아니다. 이 커맨드는 오픈 이슈 큐를 정리하고, 지금 자동으로 처리해도 되는 이슈만 골라 **한 번에 하나씩** `/implement-issue`에 넘기고, 각 이슈의 merge/post-merge까지 순차 모니터링하는 야간 배치 오케스트레이터다.
 
 GitHub 조회/코멘트/PR 관련 절차는 `.agent/skills/github-ops.md`를 따르고, 쓰기 작업 전 인증은 `.agent/skills/github-auth.md`를 먼저 따른다.
 
 기본 성공 기준:
 
-- 이슈가 `/implement-issue`를 통해 PR 생성까지 진행되고
-- 이후 CI + 승인 + auto-merge 파이프라인으로 인계되었음
+- 사전 리뷰 결과가 구현 체크리스트로 정리되었고
+- 이슈가 `/implement-issue`를 통해 실제 수정과 PR 생성까지 진행되었고
+- 같은 이슈의 CI + 승인 + auto-merge + post-merge가 확인되었음
 
-`--strict-merge`가 있을 때만 실제 merge/post-merge까지 기다린다.
+`--handoff-only`일 때만 PR 생성 후 기존 리뷰 게이트 인계에서 종료한다.
+
+## 운영 사이클
+
+`/autopilot`은 아래 3개 사이클을 **같은 이슈에 대해 순차적으로** 끝낸 뒤에만 다음 이슈로 이동한다.
+
+1. **의견 검토 사이클**
+   - `arch-review` / `qa-review`를 재사용 또는 refresh한다.
+   - `ready` / `caution` verdict에서 나온 주의사항, TC follow-up, 범위 경계는 구현 체크리스트로 승격한다.
+2. **개별 이슈 실행 사이클**
+   - `/implement-issue #{번호}`를 호출해 실제 수정, 검증, PR 생성까지 진행한다.
+   - 사전 리뷰의 `caution`은 종료 사유가 아니라, 구현 프롬프트에 강제 반영할 항목이다.
+3. **머지 모니터링 사이클**
+   - CI, `claude-pr-approve`, `codex-pr-approve`, auto-merge, `post-merge`까지 같은 이슈를 계속 추적한다.
+   - 승인 워커의 `content` FAIL은 현재 이슈의 수정 루프 일부로 간주하며, 다음 이슈로 넘어가지 않는다.
+
+## 상태 코멘트 계약
+
+`/autopilot`은 활성 이슈마다 최신 `🤖 **Autopilot 사이클 상태**` 코멘트를 유지해 3개 사이클의 현재 상태를 한눈에 보이게 한다.
+
+- 가능하면 같은 코멘트를 갱신한다.
+- 코멘트 수정이 어렵다면 같은 헤더의 새 코멘트를 남기되, **가장 최신 코멘트**를 공식 상태로 본다.
+- 이 코멘트는 이슈 단위의 운영 상태판이며, PR status check를 대체하지 않는다.
+
+필수 필드:
+
+- `batch`: `YYYYMMDD-HHMM`
+- `issue`: `#번호`
+- `current-cycle`: `review | implement | merge-monitor | completed`
+- `review-state`: `pending | running | blocked | done`
+- `implement-state`: `pending | running | blocked | done`
+- `merge-monitor-state`: `pending | running | blocked | done`
+- `review-verdicts`: `arch=ready/caution/blocked/n-a, qa=ready/caution/blocked/n-a`
+- `pr`: `#번호 | n-a`
+- `head`: `{SHA7} | n-a`
+- `result`: `in-progress | merged | handed-off | deferred-* | retry-later-infra | skipped-in-progress`
+- `next`: 다음 자동 동작 또는 대기 사유
+- `updated_at`: UTC timestamp
+
+권장 템플릿:
+
+```markdown
+🤖 **Autopilot 사이클 상태**
+- batch: 20260423-0130
+- issue: #1234
+- current-cycle: implement
+- review-state: done
+- implement-state: running
+- merge-monitor-state: pending
+- review-verdicts: arch=caution, qa=ready
+- pr: n-a
+- head: a1b2c3d
+- result: in-progress
+- next: `/implement-issue #1234` 완료 후 PR 생성 대기
+- updated_at: 2026-04-23T01:42:00Z
+```
+
+상태 전이 원칙:
+
+- 의견 검토 시작: `review-state=running`, 나머지는 `pending`
+- 사전 리뷰 통과 후 구현 위임: `review-state=done`, `implement-state=running`
+- PR 생성 완료: `implement-state=done`, `merge-monitor-state=running`, `pr`/`head` 채움
+- 리뷰/의존성/triage로 보류: 해당 사이클을 `blocked`로 두고 `result`를 `deferred-*`로 기록
+- 머지 및 post-merge 확인 완료: `merge-monitor-state=done`, `current-cycle=completed`, `result=merged`
+- `--handoff-only`: `merge-monitor-state=done`, `result=handed-off`
 
 ## 큐 선별 규칙
 
@@ -50,7 +116,14 @@ GitHub 조회/코멘트/PR 관련 절차는 `.agent/skills/github-ops.md`를 따
 2. 같은 우선순위 안에서는 선행 의존성이 없는 이슈 우선
 3. 같은 조건이면 오래 열린 이슈 우선
 
-여러 이슈를 동시에 구현하지 않는다. 현재 활성 이슈가 PR 생성 또는 명시적 보류 상태로 정리된 뒤에만 다음 이슈로 이동한다.
+여러 이슈를 동시에 구현하지 않는다. 현재 활성 이슈가 merge/post-merge 완료 또는 명시적 보류 상태로 정리된 뒤에만 다음 이슈로 이동한다.
+
+## 배치 한도
+
+- 기본 처리 한도는 `10`개다.
+- `--limit`이 생략되면 `10`으로 간주한다.
+- `--limit`에 `10`보다 큰 값이 들어오면 `10`으로 고정하고, 그 사실을 리포트에 기록한다.
+- 현재 활성 이슈가 merge/post-merge까지 정리되지 않으면, 남은 한도와 무관하게 다음 이슈로 넘어가지 않는다.
 
 ## 사전 리뷰 규칙
 
@@ -80,6 +153,8 @@ GitHub 조회/코멘트/PR 관련 절차는 `.agent/skills/github-ops.md`를 따
 - `ready`: 구현 진행 가능
 - `caution`: 구현 진행 가능하나 주의사항 또는 TC follow-up을 반드시 반영
 - `blocked`: autopilot이 구현을 시작하지 않고 다음 이슈로 이동
+
+`ready` / `caution`은 모두 다음 사이클(`/implement-issue`)로 이어져야 한다. `caution` 항목은 착수 코멘트와 구현 프롬프트의 **필수 반영 체크리스트**로 넘기고, `blocked`만 보류 사유가 된다.
 
 `blocked`가 나오면 같은 배치에서 억지로 `/implement-issue`를 호출하지 않는다. 보류 사유를 이슈 코멘트로 남기고 사람 판단이나 후속 이슈를 기다린다.
 
@@ -115,10 +190,11 @@ done
 - `needs-triage`와 기본 제외 라벨은 **수집 단계에서 server-side search filter로 먼저 제외**한다.
 - snapshot은 100건 단일 조회가 아니라 **pagination으로 끝까지 수집한 전체 open issue 후보 집합**으로 고정한다.
 - 위 전체 snapshot에 대해서만 open PR 존재, 선행 의존 이슈 close 여부, `--label` 좁히기처럼 server-side로 표현하기 어려운 후행 검사를 적용한다.
+- snapshot 후 실제 처리 대상은 정렬 결과 상위 `min(limit, 10)`건으로 자른다.
 - 이번 배치 큐가 1건 이상이면 실행 모드와 관계없이 `docs/temp/autopilot-report-<YYYYMMDD-HHMM>.md` 리포트를 반드시 생성한다.
 - `--dry-run`이면 이 단계 결과를 리포트에 남기고 종료한다.
 
-### 3단계: 이슈별 사전 점검
+### 3단계: 의견 검토 사이클
 
 각 이슈마다 다음을 순서대로 수행한다.
 
@@ -131,6 +207,17 @@ done
 
 최신 사전 리뷰에 `verdict:`가 없거나, 오래된 `blocked` verdict가 최신 이슈 상태를 반영하지 못하면 refresh 리뷰를 먼저 남긴 뒤 그 결과를 사용한다.
 
+이 단계에 진입하면 이슈의 최신 `🤖 **Autopilot 사이클 상태**` 코멘트를 `current-cycle=review`, `review-state=running`으로 맞춘다.
+
+`ready` 또는 `caution` verdict가 나오면, autopilot은 다음 정보를 **구현 필수 체크리스트**로 묶어 다음 단계에 넘긴다.
+
+- 아키텍처 주의사항
+- QA TC follow-up
+- 범위에 포함해야 할 스펙/문서/생성 산출물 동기화
+- 이번 PR에서 하지 말아야 할 확장
+
+사전 리뷰가 `caution`이라는 이유만으로 같은 배치에서 종료하지 않는다. 구현 착수 여부를 결정하는 기준은 `blocked` 여부와 남은 시간 예산이다.
+
 `needs-triage`는 이미 2단계 server-side snapshot에서 제외되어 있어야 하며, 여기서는 stale snapshot이나 수동 개입 여부를 다시 확인하는 안전 검사를 수행한다.
 
 사전 리뷰 결과가 `blocked`면 이슈 코멘트에 다음을 남기고 스킵한다.
@@ -142,31 +229,59 @@ done
 - 다음 단계: {triage 제거 | 선행 이슈 완료 대기 | 스펙 정리 | TC 설계 보강}
 ```
 
-### 4단계: `/implement-issue`로 위임
+### 4단계: 개별 이슈 실행 사이클
 
 사전 리뷰를 통과한 이슈만 `/implement-issue #{번호}`로 넘긴다.
 
 - `arch-review` / `qa-review` 증적은 이슈 코멘트에 남아 있어야 한다.
 - `/implement-issue`는 그 증적을 읽고 구현 착수 코멘트와 개발 에이전트 프롬프트에 요약을 포함한다.
+- `caution` verdict의 주의사항과 TC follow-up은 **선택 메모가 아니라 Done criteria**다.
+- 리뷰 의견을 반영한 실제 수정, 테스트, PR 생성이 확인될 때까지 같은 이슈를 유지한다.
+- 이 단계에 진입하면 상태 코멘트를 `review-state=done`, `implement-state=running`, `current-cycle=implement`로 갱신한다.
 
-### 5단계: 결과 분류
+사전 리뷰는 의견만 남기고 종료하는 단계가 아니다. autopilot은 리뷰 증적을 구현 단계로 연결하지 못한 이슈를 성공으로 취급하지 않는다.
+
+### 5단계: 머지 모니터링 사이클
+
+PR이 생성되면 autopilot은 같은 이슈에 머물며 아래를 순서대로 모니터링한다.
+
+1. `ci`
+2. `claude-pr-approve`
+3. `codex-pr-approve`
+4. `merge-gate`
+5. auto-merge
+6. `post-merge` 후처리
+
+모니터링 규칙:
+
+- `content` FAIL이 나오면 Claude 자동 재수정 루프가 새 커밋을 push할 때까지 기다리고, 새 head SHA 기준으로 같은 모니터링을 반복한다.
+- 같은 head SHA에서 `quota`, `script_error`, `auth_error`, `infra_error`로 멈추면 `gh run rerun`을 우선하고, 복구되지 않으면 `retry-later-infra`로 종료한다.
+- 상태 변화 없이 장시간 대기하거나 `--time-budget`이 소진되면 현재 이슈를 `deferred-merge-monitoring`으로 기록하고 배치를 종료한다.
+- `--handoff-only`일 때만 PR 생성 직후 모니터링을 생략하고 `handed-off`로 기록한다.
+- PR이 생성되는 즉시 상태 코멘트를 `implement-state=done`, `merge-monitor-state=running`, `current-cycle=merge-monitor`로 갱신하고 `pr`/`head`를 채운다.
+
+### 6단계: 결과 분류
 
 각 이슈는 아래 중 하나로 정리한다.
 
-- `handed-off`: PR 생성 후 기존 게이트에 인계
+- `merged`: PR merged + post-merge 확인 완료
+- `handed-off`: `--handoff-only`에서만 사용
 - `deferred-triage`: `needs-triage`가 남아 있어 보류
 - `deferred-dependency`: 선행 이슈 미완
 - `deferred-review`: `arch-review` 또는 `qa-review`가 `blocked`
+- `deferred-scope`: 리뷰 결과를 구현으로 이어가려면 남은 배치 예산을 초과
+- `deferred-merge-monitoring`: PR은 생성됐지만 merge/post-merge 확인 전 시간 예산 또는 대기 임계값 소진
 - `retry-later-infra`: 인증/러너/네트워크 등 공통 인프라 문제
 - `skipped-in-progress`: 이미 open PR 또는 사람이 작업 중
 
-### 6단계: 배치 종료
+### 7단계: 배치 종료
 
 종료 시에는 사용자에게 다음을 요약한다.
 
 - 실행 시각과 소요 시간
 - 큐 snapshot 크기
-- PR 인계 건수
+- 실제 처리 한도 (`limit`, clamp 여부)
+- merge 완료 건수
 - 보류 건수와 사유 분포
 - 인프라 오류 여부
 
@@ -175,9 +290,11 @@ done
 리포트 최소 포함 항목:
 
 - 실행 시각 / 종료 시각 / 소요 시간
-- 실행 모드 (`default | strict-merge | dry-run`)
+- 실행 모드 (`default | handoff-only | dry-run`)
 - 큐 snapshot 크기
-- 이슈별 결과 표 (`handed-off | deferred-* | retry-later-infra | skipped-in-progress`)
+- 실제 처리 한도 (`limit`, clamp 여부)
+- 이슈별 사이클 상태 표 (`review-state | implement-state | merge-monitor-state`)
+- 이슈별 결과 표 (`merged | handed-off | deferred-* | retry-later-infra | skipped-in-progress`)
 - 스킵/보류 상세
 - 남은 작업 또는 후속 조치
 
@@ -196,11 +313,13 @@ done
 - 시간 예산이 소진되면 현재 이슈 정리 후 종료한다.
 - 같은 이슈를 같은 배치에서 반복 재집지 않는다.
 - `blocked:review-loop` 또는 `blocked:pr-review-loop`가 붙은 이슈는 배치가 억지로 밀어붙이지 않는다.
+- 위 라벨은 각각 브랜치 리뷰 10회 소진, PR 승인 재수정 10회 소진의 안전장치로 해석하며, autopilot은 해당 이슈를 보류하고 다음 이슈로 넘어간다.
+- 현재 이슈가 merge/post-merge 확인 전 상태라면, 다음 이슈를 시작하지 않고 해당 이슈 상태를 먼저 확정한다.
 
 ## 원칙
 
-1. autopilot은 큐 관리자이지 새 구현 파이프라인이 아니다
+1. autopilot은 큐 관리자이지만, review → implement → merge-monitor의 3사이클을 끝까지 잇는 오케스트레이터다
 2. 공식 구현 절차는 `/implement-issue`가 계속 SSOT다
-3. 사전 리뷰 증적은 이슈 코멘트에 남기고 재사용한다
+3. 사전 리뷰 증적은 이슈 코멘트에 남기고 재사용하되, `ready`/`caution`은 구현 체크리스트로 반드시 소비한다
 4. `needs-triage`가 붙은 이슈는 사람이 분류하기 전까지 건드리지 않는다
-5. 기본 모드는 throughput 우선, `--strict-merge`는 안정성 확인이 더 중요한 경우에만 사용한다
+5. 기본 모드는 merge-confirmation 우선이며, `--handoff-only`는 예외적인 throughput 모드다

--- a/.agent/commands/implement-issue.md
+++ b/.agent/commands/implement-issue.md
@@ -86,9 +86,12 @@ mkdir -p "$WORKTREE_ROOT"
 - latest `qa-review` verdict (`ready | caution | blocked | n-a`)
 - 구현 전에 반드시 반영할 주의사항
 - TC 추가/보완이 필요한 항목
+- 구현 완료 전 반드시 체크해야 할 리뷰 체크리스트
 - 최신 리뷰에 `verdict:`가 없거나, 리뷰 이후 이슈 본문/스펙/선행 조건이 바뀌었는지 여부
 
 최신 `arch-review` 또는 `qa-review`에 `verdict:`가 없거나 stale하다고 판단되면 해당 리뷰 타입의 refresh를 먼저 요청한다. 두 리뷰 타입의 최신 verdict를 각각 평가하고, 둘 중 하나라도 `blocked`이면 구현을 시작하지 않고 이슈에 보류 사유를 남긴다.
+
+`ready` / `caution` verdict에서 나온 주의사항은 구현 프롬프트의 **필수 반영 항목**이다. 특히 `caution`은 "좋으면 반영" 메모가 아니라, 코드/테스트/문서 Done criteria로 승격한다.
 
 ### 구현 시작 기록 (오케스트레이터)
 
@@ -136,6 +139,9 @@ Agent(
 ## 사전 리뷰 증적
 {arch-review / qa-review의 최신 verdict와 핵심 주의사항, TC follow-up}
 
+## 구현 필수 체크리스트
+{사전 리뷰에서 승격된 must-fix / must-test / must-sync 항목}
+
 브랜치명과 push한 HEAD SHA를 반환하라.
 """,
   isolation="worktree"
@@ -172,7 +178,7 @@ while codex-branch-review != success:
 - 같은 blocking finding 제목이 2회 이상 연속 반복되면 escalation 신호로 보고 원인 파악을 우선한다.
 - 자동 수정 전에 finding을 곧바로 patch로 번역하지 말고 `.agent/skills/receive-review.md` 규칙으로 사실/추론/영향 범위를 먼저 다시 정리한다.
 - 같은 `risk class`가 2회 반복되면 `@code-reviewer`를 호출해 구조 리스크와 계획 편차를 먼저 정리한다.
-- 반복 실패가 5회 이상이면 `blocked:review-loop` 라벨이 붙고 Codex 브랜치 리뷰를 더 이상 자동 실행하지 않는다.
+- 반복 실패가 10회 이상이면 `blocked:review-loop` 라벨이 붙고 Codex 브랜치 리뷰를 더 이상 자동 실행하지 않는다.
 - 이 상태에서는 사용자가 개입해 원인을 정리하거나 라벨을 해제하기 전까지 같은 이슈를 계속 밀어붙이지 않는다.
 
 11a. **메타 리뷰 호출 조건**: 아래에 해당하면 PR을 만들기 전에 Claude `@code-reviewer`를 다시 호출한다.
@@ -216,7 +222,7 @@ gh issue comment #{이슈번호} --body "🤖 **PR 생성 완료**
 - `ci`
 - `claude-pr-approve`
 - `codex-pr-approve`
-- PR 승인 `content` FAIL 시 Claude는 `.agent/skills/receive-review.md` 규칙으로 finding을 정리한 뒤 자동 재수정을 최대 3회 수행
+- PR 승인 `content` FAIL 시 Claude는 `.agent/skills/receive-review.md` 규칙으로 finding을 정리한 뒤 자동 재수정을 최대 10회 수행
 - 구조 리스크가 반복되면 `@code-reviewer` 메타 리뷰 우선
 - `quota`, `script_error`, `auth_error`, `infra_error`는 자동 재수정 없이 중단 사유만 남김
 - 모든 체크가 green이면 auto-merge

--- a/.github/workflows/codex-branch-review.yml
+++ b/.github/workflows/codex-branch-review.yml
@@ -16,6 +16,9 @@ concurrency:
   group: codex-branch-review-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  REVIEW_LOOP_THRESHOLD: "10"
+
 jobs:
   codex-branch-review:
     name: codex-branch-review
@@ -112,7 +115,7 @@ jobs:
             --input "$RESULT_PATH" \
             --engine codex \
             --phase branch \
-            --threshold 5 > "$ANALYSIS_PATH"
+            --threshold "$REVIEW_LOOP_THRESHOLD" > "$ANALYSIS_PATH"
 
           echo "blocked=$(python3 scripts/ai_review.py analysis-field --input "$ANALYSIS_PATH" --field blocked)" >> "$GITHUB_OUTPUT"
           echo "failure_count=$(python3 scripts/ai_review.py analysis-field --input "$ANALYSIS_PATH" --field failure_count)" >> "$GITHUB_OUTPUT"
@@ -128,7 +131,7 @@ jobs:
           gh api -X POST "repos/$GITHUB_REPOSITORY/labels" \
             -f name='blocked:review-loop' \
             -f color='B60205' \
-            -f description='Codex branch review failed 5 times or more' >/dev/null 2>&1 || true
+            -f description="Codex branch review failed ${REVIEW_LOOP_THRESHOLD} times or more" >/dev/null 2>&1 || true
 
           gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/labels" \
             -f labels[]='blocked:review-loop' >/dev/null

--- a/.github/workflows/pr-approvals.yml
+++ b/.github/workflows/pr-approvals.yml
@@ -15,6 +15,9 @@ concurrency:
   group: pr-approvals-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+env:
+  PR_FIX_THRESHOLD: "10"
+
 jobs:
   claude-pr-approve:
     name: claude-pr-approve
@@ -371,21 +374,21 @@ jobs:
           gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" > "$COMMENTS_PATH"
           python3 scripts/ai_review.py analyze-fix-loop \
             --comments "$COMMENTS_PATH" \
-            --threshold 3 > "$ANALYSIS_PATH"
+            --threshold "$PR_FIX_THRESHOLD" > "$ANALYSIS_PATH"
 
           ATTEMPT_COUNT="$(python3 scripts/ai_review.py analysis-field --input "$ANALYSIS_PATH" --field attempt_count)"
           BLOCKED="$(python3 scripts/ai_review.py analysis-field --input "$ANALYSIS_PATH" --field blocked)"
           NEXT_ATTEMPT="$((ATTEMPT_COUNT + 1))"
           ENGINE_LIST="$(printf '%s\n' "${SOURCE_ENGINES[@]}" | paste -sd, -)"
 
-          if [[ "$BLOCKED" == "true" || "$NEXT_ATTEMPT" -gt 3 ]]; then
+          if [[ "$BLOCKED" == "true" || "$NEXT_ATTEMPT" -gt "$PR_FIX_THRESHOLD" ]]; then
             {
               echo "should_fix=false"
               echo "reason=attempt_limit"
               echo "attempt=$ATTEMPT_COUNT"
               echo "source_engines=$ENGINE_LIST"
               echo "message<<EOF"
-              echo "PR 승인 실패에 대한 Claude 재수정 시도가 3회를 모두 사용해 자동 재수정을 중단합니다."
+              echo "PR 승인 실패에 대한 Claude 재수정 시도가 ${PR_FIX_THRESHOLD}회를 모두 사용해 자동 재수정을 중단합니다."
               echo "EOF"
             } >> "$GITHUB_OUTPUT"
             exit 0
@@ -407,7 +410,7 @@ jobs:
           gh api -X POST "repos/$GITHUB_REPOSITORY/labels" \
             -f name='blocked:pr-review-loop' \
             -f color='B60205' \
-            -f description='Claude PR auto-fix exhausted 3 attempts' >/dev/null 2>&1 || true
+            -f description="Claude PR auto-fix exhausted ${PR_FIX_THRESHOLD} attempts" >/dev/null 2>&1 || true
 
           gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
             -f labels[]='blocked:pr-review-loop' >/dev/null
@@ -434,7 +437,7 @@ jobs:
             --reason "$REASON" \
             --message "$MESSAGE" \
             --attempt "${ATTEMPT:-0}" \
-            --threshold 3 > "$RUNNER_TEMP/claude-pr-fix-skipped.md"
+            --threshold "$PR_FIX_THRESHOLD" > "$RUNNER_TEMP/claude-pr-fix-skipped.md"
 
           gh pr comment "$PR_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \
@@ -459,7 +462,7 @@ jobs:
             --head-sha "$HEAD_SHA" \
             --run-url "$RUN_URL" \
             --attempt "$ATTEMPT" \
-            --threshold 3 \
+            --threshold "$PR_FIX_THRESHOLD" \
             --source-engines "$SOURCE_ENGINES" > "$RUNNER_TEMP/claude-pr-fix-started.md"
 
           gh pr comment "$PR_NUMBER" \
@@ -476,7 +479,7 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
           ATTEMPT: ${{ steps.policy.outputs.attempt }}
-          FIX_THRESHOLD: 3
+          FIX_THRESHOLD: ${{ env.PR_FIX_THRESHOLD }}
           CLAUDE_REVIEW_DIR: ${{ runner.temp }}/approvals/claude
           CODEX_REVIEW_DIR: ${{ runner.temp }}/approvals/codex
           FIX_STATUS_PATH: ${{ runner.temp }}/claude-pr-fix/status.json
@@ -518,7 +521,7 @@ jobs:
               --run-url "$RUN_URL" \
               --status "$STATUS_PATH" \
               --attempt "$ATTEMPT" \
-              --threshold 3 > "$RUNNER_TEMP/claude-pr-fix-result.md"
+              --threshold "$PR_FIX_THRESHOLD" > "$RUNNER_TEMP/claude-pr-fix-result.md"
           else
             python3 scripts/ai_review.py render-issue-comment \
               --stage fix-skipped \
@@ -530,7 +533,7 @@ jobs:
               --reason "$FAILURE_KIND" \
               --message "$(python3 scripts/ai_review.py analysis-field --input "$STATUS_PATH" --field message)" \
               --attempt "$ATTEMPT" \
-              --threshold 3 > "$RUNNER_TEMP/claude-pr-fix-result.md"
+              --threshold "$PR_FIX_THRESHOLD" > "$RUNNER_TEMP/claude-pr-fix-result.md"
           fi
 
           gh pr comment "$PR_NUMBER" \

--- a/docs/runbooks/00-issue-management.md
+++ b/docs/runbooks/00-issue-management.md
@@ -269,7 +269,7 @@ GitHub 기본 라벨 또는 프로젝트 보드로 관리:
   │
   ├── post-merge automation → 체크박스 갱신 + issue close
   │
-  └── 5회 실패 시 → `blocked:review-loop` 라벨 + 에스컬레이션
+  └── 10회 실패 시 → `blocked:review-loop` 라벨 + 에스컬레이션
 ```
 
 ### 이슈 close 규칙

--- a/docs/runbooks/01-development-process.md
+++ b/docs/runbooks/01-development-process.md
@@ -64,7 +64,7 @@ Claude 오케스트레이터
   │    ├── Claude PR 승인 (`claude-pr-approve`)
   │    └── Codex PR 승인 (`codex-pr-approve`)
   │
-  ├── PR 승인 content FAIL → Claude 자동 재수정 (최대 3회)
+  ├── PR 승인 content FAIL → Claude 자동 재수정 (최대 10회)
   │
   ├── 모든 게이트 green → GitHub auto-merge
   │
@@ -86,14 +86,16 @@ Claude 오케스트레이터
 | 커맨드 | 역할 | 파일 |
 |--------|------|------|
 | `/implement-issue` | 이슈 구현 전체 흐름 (분석 → 경량 계획 → 조건부 계획 리뷰(필요 시) → 구현 → Codex 브랜치 리뷰 → PR 생성) | `.agent/commands/implement-issue.md` |
-| `/autopilot` | 오픈 이슈 큐 순차 처리 (선별 → 필요 시 `arch-review`/`qa-review` → `/implement-issue` 인계) | `.agent/commands/autopilot.md` |
+| `/autopilot` | 오픈 이슈 큐 순차 처리 (선별 → 의견 검토 → `/implement-issue` → merge/post-merge 모니터링, 기본 `limit=10`) | `.agent/commands/autopilot.md` |
 | `/qa-test` | 지정 TC 실행 (`@qa-engineer` 위임) | `.agent/commands/qa-test.md` |
 | `/qa-sweep` | 전체 TC 순차 실행 (전수 검사) | `.agent/commands/qa-sweep.md` |
 | `/api-docs` | OpenAPI 스키마 조회 | `.agent/commands/api-docs.md` |
 | `/arch-review` | 이슈 사전 아키텍처 검토 | `.agent/commands/arch-review.md` |
 | `/qa-review` | 이슈 사전 QA 커버리지 검토 | `.agent/commands/qa-review.md` |
 
-야간 배치나 backlog 정리에서는 `/autopilot`이 오픈 이슈 큐 snapshot을 잡고, 필요 시 `/arch-review`와 `/qa-review` 증적을 이슈 코멘트로 남긴 뒤 `/implement-issue`에 개별 구현을 위임한다. `/autopilot`의 기본 성공 기준은 merge 자체가 아니라 **PR 생성 후 기존 리뷰 게이트에 인계**하는 것이다.
+야간 배치나 backlog 정리에서는 `/autopilot`이 오픈 이슈 큐 snapshot을 잡고, 필요 시 `/arch-review`와 `/qa-review` 증적을 이슈 코멘트로 남긴 뒤 `/implement-issue`에 개별 구현을 위임한다. 사전 리뷰의 `ready`/`caution`은 구현 체크리스트로 승격되며, `/autopilot`은 기본적으로 **한 번에 최대 10개 이슈를 review → implement → merge/post-merge까지 순차 모니터링**한다.
+
+운영 중인 이슈의 현재 단계는 최신 `🤖 **Autopilot 사이클 상태**` 코멘트로 노출하며, 여기서 `review-state`, `implement-state`, `merge-monitor-state`를 각각 `pending | running | blocked | done`으로 추적한다.
 
 ### 4.1 조건부 계획 리뷰
 
@@ -197,13 +199,13 @@ main
 - 같은 blocking finding 제목이 2회 이상 연속 반복되면 escalation 신호로 본다.
 - 같은 `risk class` failure가 2회 반복되면 `@code-reviewer` 메타 리뷰를 호출하고, 그 전까지는 얕은 auto-fix만 반복하지 않는다.
 - 반복되는 구조 리스크가 현재 계획 자체의 문제로 보이면, 다시 구현을 밀기보다 조건부 계획 리뷰 단계로 되돌린다.
-- 동일 유형의 blocking failure가 5회 누적되면 `blocked:review-loop` 라벨을 붙이고 자동 브랜치 리뷰를 중단한다.
+- 동일 유형의 blocking failure가 10회 누적되면 `blocked:review-loop` 라벨을 붙이고 자동 브랜치 리뷰를 중단한다.
 - `blocked:review-loop`가 최초 부착되거나, PR 자동 재수정 결과가 `NO_CHANGES`로 끝나면 얕은 자동 수정 루프를 중단하고 `@code-reviewer` 메타 리뷰 또는 사람 확인을 우선한다.
 - Codex 브랜치 리뷰에서 잡힌 이슈는 PR 생성 전에 해소해야 한다.
-- PR 승인 단계에서는 `content` 실패에 한해 Claude 자동 재수정을 최대 3회 시도한다.
+- PR 승인 단계에서는 `content` 실패에 한해 Claude 자동 재수정을 최대 10회 시도한다.
 - 자동 재수정 전에는 `.agent/skills/receive-review.md` 규칙으로 finding을 재서술하고 영향 범위를 다시 그린다.
 - `quota`, `script_error`, `auth_error`, `infra_error`는 자동 재수정 예산에 포함하지 않는다.
-- PR 승인 content 실패가 3회 재수정 후에도 해소되지 않으면 `blocked:pr-review-loop` 라벨을 붙이고 자동 재수정을 중단한다.
+- PR 승인 content 실패가 10회 재수정 후에도 해소되지 않으면 `blocked:pr-review-loop` 라벨을 붙이고 자동 재수정을 중단한다.
 - PR 승인에서 `lifecycle`, `contract-drift`, `generated-artifact-sync` 같은 구조 리스크가 2회 반복되면 자동 재수정보다 `@code-reviewer` 또는 사람 개입을 우선한다.
 
 ### 5.2 승인 루프 수동 복구

--- a/docs/runbooks/02-agent-structure.md
+++ b/docs/runbooks/02-agent-structure.md
@@ -19,7 +19,7 @@
 **역할**:
 - 작업 분석과 분해
 - 경량 계획 체크리스트 작성과 조건부 계획 리뷰 여부 판단
-- 야간 `/autopilot` 배치에서 이슈 큐 snapshot, 선행 리뷰 증적, handoff 조율
+- 야간 `/autopilot` 배치에서 이슈 큐 snapshot, 선행 리뷰 증적, 구현 위임, merge 모니터링 조율
 - 적절한 Claude 서브에이전트 위임
 - 이슈/브랜치/PR GitHub 기록 관리
 - Codex 브랜치 리뷰 결과를 받아 수정 루프 조율
@@ -168,7 +168,7 @@ Claude도 PR 단계에서는 독립 승인 워커로 동작한다.
 반복적인 개발 작업을 슬래시 명령으로 정의한다:
 
 - `/implement-issue #{번호}` — 분석 → 경량 계획 → 조건부 계획 리뷰(필요 시) → 구현 → Codex 브랜치 리뷰 → PR 생성
-- `/autopilot` — 오픈 이슈 큐 snapshot → 필요 시 `arch-review` / `qa-review` → `/implement-issue` 순차 위임
+- `/autopilot` — 오픈 이슈 큐 snapshot → 필요 시 `arch-review` / `qa-review` → `/implement-issue` → merge/post-merge 순차 모니터링
 - `/qa-test {카테고리}` — 지정 TC 실행
 - `/qa-sweep` — 전체 TC 전수 검사
 - `/api-docs` — OpenAPI 스키마 조회

--- a/docs/runbooks/03-git-workflow.md
+++ b/docs/runbooks/03-git-workflow.md
@@ -105,7 +105,7 @@ PR을 열기 전, 최신 브랜치 HEAD는 반드시 Codex 사전 리뷰를 통�
 - 동일 SHA에 실패한 상태에서 PR을 먼저 열지 않는다
 - 실패 횟수는 이슈 코멘트로 누적 관리한다.
 - 같은 blocking finding 제목이 2회 이상 연속 반복되면 escalation 대상으로 본다.
-- 실패가 5회 누적되면 이슈에 `blocked:review-loop` 라벨을 붙이고 자동 브랜치 리뷰를 중단한다.
+- 실패가 10회 누적되면 이슈에 `blocked:review-loop` 라벨을 붙이고 자동 브랜치 리뷰를 중단한다.
 
 ### 3.3 Stale Base / Duplicate Commit / Merge Conflict 대응
 
@@ -145,12 +145,12 @@ PR을 열기 전, 최신 브랜치 HEAD는 반드시 Codex 사전 리뷰를 통�
 ### 4.3 PR 승인 실패 처리
 
 - `claude-pr-approve` 또는 `codex-pr-approve`가 `content` FAIL이면 Claude가 같은 PR 브랜치에서 자동 재수정을 시도한다.
-- 자동 재수정은 최대 3회까지 허용한다.
+- 자동 재수정은 최대 10회까지 허용한다.
 - `quota`, `script_error`, `auth_error`, `infra_error`는 코드 내용 실패로 보지 않으며, 자동 재수정 횟수에 포함하지 않는다.
 - 자동 재수정 결과가 `NO_CHANGES`이면, 이를 성공으로 취급하지 않고 메타 리뷰 또는 수동 수정 단계로 승격한다.
 - 같은 head SHA에서 재실행만 필요할 때는 `gh run rerun`을 우선한다.
 - `pull_request` 이벤트 자체를 다시 발생시켜야 할 때만 PR `close → reopen`을 예외적으로 허용하고, 재트리거 이유를 PR 코멘트에 남긴다.
-- 3회 소진 시 `blocked:pr-review-loop` 라벨을 붙이고 PR을 사람 확인 대상으로 넘긴다.
+- 10회 소진 시 `blocked:pr-review-loop` 라벨을 붙이고 PR을 사람 확인 대상으로 넘긴다.
 
 ### 4.4 머지 방식
 

--- a/docs/runbooks/04-ci-cd.md
+++ b/docs/runbooks/04-ci-cd.md
@@ -27,7 +27,7 @@ Claude 구현 (worktree 격리)
   │
   ├──▶ [Meta] code-reviewer ───────────── 고위험 변경 / 반복 risk class 시 원인 분석
   │
-  ├──▶ [Loop] Claude PR repair ────────── 최대 3회, quota/script/auth/infra는 제외
+  ├──▶ [Loop] Claude PR repair ────────── 최대 10회, quota/script/auth/infra는 제외
   │
   ├──▶ [Gate E] merge-gate ────────────── 모든 게이트 성공 시 auto-merge
   │
@@ -115,11 +115,11 @@ post-merge automation
 
 - **트리거**: `claude-pr-approve` 또는 `codex-pr-approve`의 `content` FAIL
 - **실행 주체**: Claude self-hosted runner
-- **예산**: 최대 3회
+- **예산**: 최대 10회
 - **비포함 실패**: `quota`, `script_error`, `auth_error`, `infra_error`
 - **결과**:
   - 새 커밋 push → `pull_request synchronize`로 Gate B/C/D 재실행
-  - 3회 초과 → `blocked:pr-review-loop`
+  - 10회 초과 → `blocked:pr-review-loop`
   - `NO_CHANGES` → 자동 루프 중단 후 메타 리뷰 또는 수동 수정으로 승격
 
 ### Gate E — Merge Gate
@@ -209,8 +209,8 @@ pytest tests/unit/ -v
 | `claude-pr-approve` | 스펙/계약/테스트 누락 | Claude 자동 재수정 워커 또는 `@devops` |
 | `codex-pr-approve` | 버그/회귀/설계 위반 | Claude 자동 재수정 워커 또는 `@devops` |
 
-`codex-branch-review`는 실패 이력을 이슈 코멘트에 누적하고, 같은 blocking finding 제목이 반복되면 escalation 신호를 남긴다. 실패가 5회 누적되면 `blocked:review-loop` 라벨을 붙이고 더 이상의 자동 브랜치 리뷰를 중단한다.
-`claude-pr-approve` / `codex-pr-approve`는 `content` FAIL일 때만 Claude 자동 재수정을 최대 3회 시도한다. `quota`, `script_error`, `auth_error`, `infra_error`는 자동 재수정을 건너뛰고 PR 코멘트에 원인을 남긴다.
+`codex-branch-review`는 실패 이력을 이슈 코멘트에 누적하고, 같은 blocking finding 제목이 반복되면 escalation 신호를 남긴다. 실패가 10회 누적되면 `blocked:review-loop` 라벨을 붙이고 더 이상의 자동 브랜치 리뷰를 중단한다.
+`claude-pr-approve` / `codex-pr-approve`는 `content` FAIL일 때만 Claude 자동 재수정을 최대 10회 시도한다. `quota`, `script_error`, `auth_error`, `infra_error`는 자동 재수정을 건너뛰고 PR 코멘트에 원인을 남긴다.
 `lifecycle`, `contract-drift`, `generated-artifact-sync` 같은 구조 리스크가 2회 반복되면 Meta Review를 먼저 수행한다.
 
 ### 5.1 승인 루프 수동 복구 순서

--- a/docs/runbooks/07-review-gate.md
+++ b/docs/runbooks/07-review-gate.md
@@ -74,7 +74,7 @@
 - 실패 횟수는 이슈 코멘트 기준으로 누적한다.
 - 같은 blocking finding 제목이 2회 이상 연속 반복되면 escalation 신호를 이슈 코멘트에 남긴다.
 - 같은 `risk class`가 2회 반복되면 Claude 오케스트레이터가 `@code-reviewer` 메타 리뷰를 호출한다.
-- 실패가 5회 누적되면 `blocked:review-loop` 라벨을 붙이고 추가 Codex 브랜치 리뷰를 중단한다.
+- 실패가 10회 누적되면 `blocked:review-loop` 라벨을 붙이고 추가 Codex 브랜치 리뷰를 중단한다.
 - sibling PR 머지 후 stale base나 duplicate commit이 의심되면, 브랜치 리뷰 재시도 전에 최신 base로 rebase하고 히스토리를 정리한다.
 
 ### 3.4 역할
@@ -132,11 +132,11 @@
 
 - `claude-pr-approve` 또는 `codex-pr-approve`가 **content FAIL**을 반환하면, GitHub automation이 같은 PR 브랜치에서 Claude 재수정을 시도한다.
 - 자동 재수정 전 Claude는 `.agent/skills/receive-review.md` 규칙으로 finding을 사실/추론/영향 범위로 다시 정리한다.
-- 자동 재수정은 최대 **3회**까지 시도한다.
+- 자동 재수정은 최대 **10회**까지 시도한다.
 - 각 시도는 **새 커밋을 push한 경우에만** 다음 승인 사이클로 이어진다.
 - 재수정 결과는 PR 코멘트에 남기고, 새 커밋이 push되면 `pull_request synchronize`로 승인 워크플로우를 다시 시작한다.
 - 자동 재수정 결과가 `NO_CHANGES`면, 승인 루프를 성공으로 보지 않고 메타 리뷰 또는 수동 수정 단계로 승격한다.
-- 3회 소진 후에도 승인 실패가 반복되면 `blocked:pr-review-loop` 라벨을 붙이고 자동 재수정을 중단한다.
+- 10회 소진 후에도 승인 실패가 반복되면 `blocked:pr-review-loop` 라벨을 붙이고 자동 재수정을 중단한다.
 - 같은 head SHA에서 재실행만 필요할 때는 `gh run rerun`을 우선하고, `pull_request` 이벤트가 필요할 때만 PR `close → reopen`을 예외적으로 사용한다.
 
 ### 4.7 실패 분류
@@ -151,7 +151,7 @@ PR 승인 워커 실패는 아래처럼 분리해서 처리한다.
 | `auth_error` | AI CLI 인증 만료/누락 | 실행 안 함 |
 | `infra_error` | 기타 runner/환경 실패 | 실행 안 함 |
 
-- `quota`, `script_error`, `auth_error`, `infra_error`는 **재수정 예산 3회에 포함하지 않는다**.
+- `quota`, `script_error`, `auth_error`, `infra_error`는 **재수정 예산 10회에 포함하지 않는다**.
 - 이 경우 PR 코멘트에 중단 사유를 남기고, 워커 복구 또는 수동 재실행을 기다린다.
 - `content` FAIL이라도 같은 `risk class`가 2회 반복되면, 다음 자동 재수정 전에 `@code-reviewer` 메타 리뷰를 우선한다.
 - review 결과가 생성되었고 마지막 verdict step만 실패했다면, 이를 워커 장애보다 **실제 content finding**으로 우선 해석한다.
@@ -221,7 +221,7 @@ PR 승인 워커 실패는 아래처럼 분리해서 처리한다.
 - `Refs #이슈번호`는 GitHub 기본 auto-close를 만들지 않으므로, 이슈를 닫을 변경은 `Closes #이슈번호`를 사용한다
 - 이슈 close는 GitHub 기본 auto-close를 우선 사용하고, `post-merge`는 체크박스 / 에픽 상태 동기화와 auto-merge 후속 복구를 담당한다
 - PR 승인 실패로 다시 수정이 발생해도 같은 이슈/같은 PR을 계속 사용한다
-- PR 승인 실패가 `content`인 경우에만 Claude 자동 재수정이 같은 PR 브랜치에서 최대 3회 동작한다
+- PR 승인 실패가 `content`인 경우에만 Claude 자동 재수정이 같은 PR 브랜치에서 최대 10회 동작한다
 - 승인 워커는 verdict만 남기지 않고 아래 정보를 함께 남긴다.
   - `blocking findings`
   - `follow-ups`

--- a/docs/runbooks/08-autopilot-operations.md
+++ b/docs/runbooks/08-autopilot-operations.md
@@ -6,18 +6,19 @@
 
 ## 1. 목적
 
-`/autopilot`의 목적은 GitHub에 쌓인 오픈 이슈를 밤 시간대에 **한 번에 하나씩 최대한 많이 전진시키는 것**이다.
+`/autopilot`의 목적은 GitHub에 쌓인 오픈 이슈를 밤 시간대에 **한 번에 하나씩 review → implement → merge-monitor 사이클까지 끝내는 것**이다.
 
 - autopilot은 새 구현 파이프라인을 만들지 않는다.
 - 실제 구현 절차 SSOT는 계속 `/implement-issue`다.
-- autopilot은 이슈 선별, 보류 판단, 사전 리뷰 증적, 인계 순서를 책임진다.
+- autopilot은 이슈 선별, 보류 판단, 사전 리뷰 증적, 구현 위임, merge/post-merge 모니터링 순서를 책임진다.
 
 기본 성공 기준:
 
-- 이슈가 PR 생성까지 진행되었고
-- 이후 CI + 승인 + auto-merge 파이프라인으로 인계되었음
+- 사전 리뷰 결과가 구현 체크리스트로 정리되었고
+- 이슈가 실제 수정/PR 생성까지 진행되었고
+- 같은 이슈의 CI + 승인 + auto-merge + post-merge가 확인되었음
 
-실제 merge/post-merge까지 기다리는 동작은 예외 모드(`--strict-merge`)로만 사용한다.
+예외 모드(`--handoff-only`)일 때만 PR 생성 후 기존 게이트 인계에서 종료한다.
 
 ## 2. 큐 모델
 
@@ -61,6 +62,13 @@
 4. `P3 - Low`
 
 같은 우선순위 안에서는 오래 열린 이슈를 먼저 처리한다.
+
+### 2.4 배치 한도
+
+- 기본 처리 한도는 `10`개다.
+- `--limit`이 생략되면 `10`으로 간주한다.
+- `--limit`에 `10`보다 큰 값이 들어오면 `10`으로 고정하고, 리포트에 clamp 사실을 남긴다.
+- 현재 활성 이슈가 merge/post-merge까지 정리되지 않으면 남은 한도와 무관하게 다음 이슈로 넘어가지 않는다.
 
 ## 3. `needs-triage`
 
@@ -111,26 +119,102 @@ autopilot은 필요 시 구현 전에 두 종류의 리뷰 증적을 남긴다.
 - `caution`: 구현 진행 가능하지만 주의사항과 TC follow-up을 반드시 반영
 - `blocked`: autopilot이 구현을 시작하지 않고 사람 판단이나 선행 작업을 기다림
 
-## 5. `/implement-issue` 인계
+`ready` / `caution`은 모두 구현 사이클로 이어져야 한다. `caution`은 종료 상태가 아니라, 착수 코멘트와 개발 프롬프트의 **필수 반영 체크리스트**로 승격한다.
+
+## 5. 운영 사이클
+
+### 5.1 의견 검토 사이클
+
+- `arch-review` / `qa-review` 최신 verdict를 재사용하거나 refresh한다.
+- `ready` / `caution` verdict에서 나온 주의사항, TC follow-up, 금지할 확장을 구현 체크리스트로 정리한다.
+- `blocked`만 같은 배치의 보류 사유가 된다.
+
+### 5.2 개별 이슈 실행 사이클
 
 - autopilot은 직접 코드를 구현하지 않는다.
 - 사전 리뷰를 통과한 이슈만 `/implement-issue #{번호}`로 넘긴다.
 - `/implement-issue`는 이슈 코멘트에 남아 있는 `arch-review` / `qa-review` 증적을 읽고:
   - 구현 착수 코멘트에 요약을 남기고
   - 개발 에이전트 프롬프트에도 같은 요약을 포함한다
+  - `caution` 항목을 Done criteria로 승격한다
 - verdict가 없거나 stale한 리뷰는 구현 게이트로 쓰지 않고, 해당 리뷰 타입의 refresh 리뷰를 먼저 남긴 뒤 최신 verdict를 사용한다.
 - 구현 게이트는 단일 최신 사전 리뷰가 아니라, `arch-review`와 `qa-review`의 최신 verdict를 각각 평가한다. 둘 중 하나라도 `blocked`면 구현을 시작하지 않는다.
 
 이렇게 해야 사전 리뷰 증적과 실제 구현이 끊기지 않는다.
 
+### 5.3 머지 모니터링 사이클
+
+- PR이 생성되면 autopilot은 같은 이슈에 머물며 `ci`, `claude-pr-approve`, `codex-pr-approve`, `merge-gate`, auto-merge, `post-merge`를 순서대로 추적한다.
+- 승인 워커의 `content` FAIL은 다음 이슈로 넘길 이유가 아니라, 현재 이슈의 수정 루프로 본다.
+- 같은 head SHA에서 `quota`, `script_error`, `auth_error`, `infra_error`로 멈추면 `gh run rerun`을 우선하고, 복구되지 않으면 `retry-later-infra`로 종료한다.
+- `--handoff-only`가 아니면 merge/post-merge 확인 전에는 다음 이슈를 시작하지 않는다.
+
+### 5.4 사이클 상태판
+
+autopilot은 활성 이슈마다 최신 `🤖 **Autopilot 사이클 상태**` 코멘트를 유지해 3개 사이클의 상태를 분리해서 노출한다.
+
+- 코멘트 수정이 가능하면 같은 코멘트를 갱신한다.
+- 수정이 어렵다면 같은 헤더의 새 코멘트를 남기고, **가장 최신 코멘트**를 공식 상태로 본다.
+- 이 코멘트는 이슈 단위 운영 상태판이며, PR check run과 역할이 다르다.
+
+필수 필드:
+
+- `batch`
+- `issue`
+- `current-cycle`
+- `review-state`
+- `implement-state`
+- `merge-monitor-state`
+- `review-verdicts`
+- `pr`
+- `head`
+- `result`
+- `next`
+- `updated_at`
+
+권장 값 집합:
+
+- `current-cycle`: `review | implement | merge-monitor | completed`
+- 각 `*-state`: `pending | running | blocked | done`
+- `result`: `in-progress | merged | handed-off | deferred-* | retry-later-infra | skipped-in-progress`
+
+권장 예시:
+
+```markdown
+🤖 **Autopilot 사이클 상태**
+- batch: 20260423-0130
+- issue: #1234
+- current-cycle: merge-monitor
+- review-state: done
+- implement-state: done
+- merge-monitor-state: running
+- review-verdicts: arch=caution, qa=ready
+- pr: #1250
+- head: a1b2c3d
+- result: in-progress
+- next: `codex-pr-approve` 완료 대기
+- updated_at: 2026-04-23T02:10:00Z
+```
+
+전이 규칙:
+
+- 의견 검토 시작 시 `review-state=running`
+- 구현 위임 시 `review-state=done`, `implement-state=running`
+- PR 생성 시 `implement-state=done`, `merge-monitor-state=running`
+- 보류 시 해당 사이클을 `blocked`로 두고 `result`를 `deferred-*`로 기록
+- merge/post-merge 확인 완료 시 `merge-monitor-state=done`, `current-cycle=completed`, `result=merged`
+
 ## 6. 결과 상태
 
 각 이슈는 배치 안에서 아래 상태 중 하나로 정리한다.
 
-- `handed-off`: PR 생성 후 기존 리뷰 게이트에 인계
+- `merged`: PR merged + post-merge 확인 완료
+- `handed-off`: `--handoff-only`에서만 사용
 - `deferred-triage`: `needs-triage`
 - `deferred-dependency`: 선행 이슈 미완료
 - `deferred-review`: `arch-review` 또는 `qa-review`가 `blocked`
+- `deferred-scope`: 리뷰 결과를 구현으로 이어가려면 남은 배치 예산을 초과
+- `deferred-merge-monitoring`: PR은 생성됐지만 merge/post-merge 확인 전 시간 예산 또는 대기 임계값 소진
 - `retry-later-infra`: 인증/러너/네트워크/공통 환경 문제
 - `skipped-in-progress`: 이미 open PR이 있거나 사람이 작업 중
 
@@ -139,13 +223,14 @@ autopilot은 필요 시 구현 전에 두 종류의 리뷰 증적을 남긴다.
 - 공통 인프라 오류가 3회 연속 발생하면 현재 배치를 중단한다.
 - 시간 예산이 소진되면 현재 이슈 정리 후 종료한다.
 - `blocked:review-loop`, `blocked:pr-review-loop` 이슈는 강제로 다시 밀어붙이지 않는다.
+- 위 라벨은 각각 브랜치 리뷰 10회 소진, PR 승인 재수정 10회 소진의 안전장치로 해석하고 다음 이슈로 이동한다.
 - 같은 배치에서 같은 이슈를 반복 재집지 않는다.
 
 ## 8. 보고와 기록
 
 공식 기록:
 
-- 이슈 코멘트 (`arch-review`, `qa-review`, 구현 착수, PR 생성, 보류 사유)
+- 이슈 코멘트 (`arch-review`, `qa-review`, 구현 착수, PR 생성, 보류 사유, `🤖 **Autopilot 사이클 상태**`)
 - PR 코멘트와 status check (`codex-branch-review`, `ci`, `claude-pr-approve`, `codex-pr-approve`)
 
 필수 요약 기록:
@@ -170,10 +255,11 @@ autopilot은 필요 시 구현 전에 두 종류의 리뷰 증적을 남긴다.
 - 소요 시간:
 - 실행 모드:
 - 큐 snapshot 크기:
+- 실제 처리 한도:
 
 ### 이슈별 결과
-| 이슈 | 제목 | 결과 | PR/비고 |
-|------|------|------|---------|
+| 이슈 | 제목 | review | implement | merge-monitor | 결과 | PR/비고 |
+|------|------|--------|-----------|---------------|------|---------|
 
 ### 보류/스킵 상세
 - ...
@@ -208,8 +294,8 @@ GitHub 조회/코멘트/PR/재실행 절차는 `.agent/skills/github-ops.md`를 
 
 ## 9. 운영 원칙
 
-1. autopilot은 큐 관리자다
+1. autopilot은 review → implement → merge-monitor 3사이클을 잇는 큐 관리자다
 2. 구현 절차는 `/implement-issue`가 SSOT다
 3. `needs-triage`는 autopilot 안전핀이다
-4. 사전 리뷰 증적은 GitHub 이슈 코멘트에 남기고 재사용한다
-5. 기본 모드는 throughput 우선, merge 대기 모드는 예외적으로만 사용한다
+4. 사전 리뷰 증적은 GitHub 이슈 코멘트에 남기고 재사용하되, `ready`/`caution`은 구현 체크리스트로 반드시 소비한다
+5. 기본 모드는 merge-confirmation 우선, `--handoff-only`는 예외적인 throughput 모드다

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -17,14 +17,14 @@
 | [05-testing.md](05-testing.md) | 테스트 전략 (단위/통합/QA TC 테스트, 커버리지) |
 | [06-release.md](06-release.md) | 릴리스 운영 (버전 관리, 태그, 배포 체크리스트) |
 | [07-review-gate.md](07-review-gate.md) | 조건부 계획 리뷰, 리뷰 단계와 merge gate의 책임 분리, 확장 리뷰 규칙, status check 기준 |
-| [08-autopilot-operations.md](08-autopilot-operations.md) | 야간 autopilot 배치 운영 규칙 (`needs-triage`, 큐 선별, 사전 리뷰 증적, `/implement-issue` 인계) |
+| [08-autopilot-operations.md](08-autopilot-operations.md) | 야간 autopilot 배치 운영 규칙 (`needs-triage`, 큐 선별, 사전 리뷰 증적, `/implement-issue`, merge/post-merge 모니터링) |
 
 ## 에이전트 커맨드 (작업 절차 SSOT)
 
 | 커맨드 | 설명 |
 |--------|------|
 | `/implement-issue` | 이슈 구현 전체 흐름 (분석 → 경량 계획 → 조건부 계획 리뷰(필요 시) → 구현 → Codex 브랜치 리뷰 → PR 생성) |
-| `/autopilot` | 오픈 이슈 큐 순차 처리 (필요 시 `arch-review` / `qa-review` 후 `/implement-issue`에 인계) |
+| `/autopilot` | 오픈 이슈 큐 순차 처리 (필요 시 `arch-review` / `qa-review` 후 `/implement-issue`와 merge/post-merge까지 순차 모니터링, 기본 `limit=10`) |
 | `/qa-test` | 지정 TC 실행 (`@qa-engineer` 위임) |
 | `/qa-sweep` | 전체 TC 순차 실행 (전수 검사) |
 | `/api-docs` | OpenAPI 스키마 조회 |


### PR DESCRIPTION
## Summary
- autopilot 기본 운영을 `의견 검토 → 개별 이슈 실행 → 머지 모니터링` 3사이클로 명시하고, 각 사이클을 추적하는 `🤖 **Autopilot 사이클 상태**` 코멘트 계약을 추가합니다.
- autopilot 기본 배치 한도를 최대 10건으로 고정하고, handoff-only 예외 모드와 merge/post-merge 확인 기준을 런북과 명령 계약에 맞춰 정리합니다.
- 브랜치 리뷰와 PR 승인 자동 재수정의 실패 예산을 각각 10회로 상향하고, `blocked:review-loop` / `blocked:pr-review-loop` 안전장치를 문서와 워크플로에 반영합니다.

## Why
최근 autopilot 실행에서 사전 리뷰, 구현, 머지 모니터링이 하나의 흐름으로 보이지 않아 잔여 PR과 보류 이슈를 한눈에 추적하기 어려웠습니다. 또한 리뷰/승인 루프의 재시도 한도가 운영 기대치보다 낮아 자동 복구 여지가 부족했습니다.

## Impact
- autopilot 운영자는 각 이슈의 현재 사이클과 다음 대기 상태를 이슈 코멘트 하나로 확인할 수 있습니다.
- 런북과 명령 계약이 동일한 용어와 상태 전이를 사용하게 됩니다.
- GitHub Actions의 브랜치 리뷰/PR 승인 재시도 정책이 문서와 일치하게 됩니다.

## Validation
- `git diff --stat main...HEAD`
- `rg -n "Autopilot 사이클 상태|review-state|implement-state|merge-monitor-state" .agent/commands/autopilot.md docs/runbooks/08-autopilot-operations.md docs/runbooks/01-development-process.md`
- 문서/워크플로 diff 수동 검토
