### PR TITLE
chore: align PR fix threshold fallback

### DIFF
--- a/scripts/run_pr_fix.sh
+++ b/scripts/run_pr_fix.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 PR_NUMBER="${PR_NUMBER:?PR_NUMBER is required}"
 HEAD_REF="${HEAD_REF:?HEAD_REF is required}"
 ATTEMPT="${ATTEMPT:?ATTEMPT is required}"
-FIX_THRESHOLD="${FIX_THRESHOLD:-3}"
+FIX_THRESHOLD="${FIX_THRESHOLD:-10}"
 
 WORKSPACE="${GITHUB_WORKSPACE:-$(pwd)}"
 TMP_DIR="$(mktemp -d)"


### PR DESCRIPTION
## Summary
- `scripts/run_pr_fix.sh`의 fallback `FIX_THRESHOLD` 기본값을 `3`에서 `10`으로 올려 workflow 주입값과 맞춥니다.

## Why
- `pr-approvals.yml`은 이미 `PR_FIX_THRESHOLD=10`을 사용하지만, 스크립트 단독 실행이나 fallback 경로에서는 기본값이 여전히 `3`이라 운영 드리프트가 남아 있었습니다.

## Validation
- `bash -n scripts/run_pr_fix.sh`
- `git diff -- scripts/run_pr_fix.sh`
