### PR TITLE
fix(account,web): block runtime structural mutations with cold-path 409

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -176,6 +176,9 @@
           },
           "422": {
             "description": "비구조(mutable) 필드 schema 검증 실패. structural 필드 키는 422가 아닌 409로 차단된다."
+          },
+          "503": {
+            "description": "Account service not available"
           }
         }
       },

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -123,7 +123,7 @@
           "accounts"
         ],
         "summary": "Update Account",
-        "description": "계좌 수정.\n\n런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도\n포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path\n응답과 ``AccountDeletedError`` 경로의 409를 구분한다.\n\nbody는 자유 ``dict[str, Any] | None``로 받는다. FastAPI 선행 Pydantic\n검증이 켜지면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가\nstructural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.\n핸들러 본문에서는 raw payload key 검사로 cold-path 가드를 먼저 수행한 뒤,\n비구조 필드를 그대로 ``account_service.update``에 forward한다.\nservice-layer가 알 수 없는/불변 필드는 자체 검증으로 거부한다\n(`AccountImmutableFieldError → 400`, `ValueError(unknown field)` 등).\nPUT requestBody의 OpenAPI schema accuracy 회복(mutable 모델 노출)은 후속\n이슈 #1143에서 다룬다.",
+        "description": "계좌 수정.\n\n런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도\n포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path\n응답과 ``AccountDeletedError`` 경로의 409를 구분한다.\n\nbody는 자유 ``dict[str, Any] | None``로 받는다. FastAPI 선행 Pydantic\n검증이 켜지면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가\nstructural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.\n핸들러 본문에서는 raw payload key 검사로 cold-path 가드를 먼저 수행한 뒤,\nstructural을 제외한 비구조 페이로드만 ``AccountUpdateRequest``로\n``model_validate``하여 mutable 필드의 type 검증을 수행한다(``{\"name\":\nnull}`` / ``{\"timezone\": {}}`` 같은 잘못된 값이 service/DB까지 흘러가\n상태를 오염시키는 것을 차단한다 — P1 회귀 보호). 검증 실패는 명시적으로\n422로 변환한다.\n\nPUT requestBody의 OpenAPI schema accuracy 회복(mutable 모델 노출)은 후속\n이슈 #1143에서 다룬다.",
         "operationId": "update_account_api_accounts__account_id__put",
         "parameters": [
           {
@@ -195,8 +195,8 @@
               }
             }
           },
-          "503": {
-            "description": "Account service not available 또는 broker 재연결 실패",
+          "422": {
+            "description": "비구조(mutable) 필드 type 검증 실패. structural 필드 키는 422가 아닌 409로 차단된다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -205,12 +205,12 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
+          "503": {
+            "description": "Account service not available 또는 broker 재연결 실패",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -60,23 +60,18 @@
           "accounts"
         ],
         "summary": "Create Account",
-        "description": "계좌 생성.\n\n런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.\n실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로\n수행한다.\n\nbody 파라미터를 받지 않는 이유: cold-path 차단은 입력 valid 여부와\n무관하게 항상 409여야 하므로, FastAPI가 핸들러 진입 전에 body\nvalidation을 수행하지 않도록 시그니처에서 의도적으로 제외한다.\n또한 OpenAPI에서도 requestBody가 노출되지 않아 클라이언트에\n\"런타임 POST는 어떤 body도 받지 않는다\"는 계약이 정확히 전달된다.",
+        "description": "계좌 생성.\n\n런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.\n실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로\n수행한다.\n\n의존성/Pydantic body schema/audit logger를 모두 시그니처에서 제외해\n핸들러 진입 즉시 409가 반환되도록 한다(invariant I1). 또한 OpenAPI에는\nsuccess contract(200/201/204)가 노출되지 않으며, 응답 모델은\n``ErrorResponse``로 고정된다(invariant I2/I3).\n\n이 경로의 service-layer 회귀 보호는 ``tests/unit/test_account.py``가\n담당한다.",
         "operationId": "create_account_api_accounts_post",
         "responses": {
-          "200": {
-            "description": "Successful Response",
+          "409": {
+            "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 생성 차단",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Create Account Api Accounts Post"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
-          },
-          "409": {
-            "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 생성 차단"
           }
         }
       }
@@ -128,7 +123,7 @@
           "accounts"
         ],
         "summary": "Update Account",
-        "description": "계좌 수정.\n\n런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도\n포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path\n응답과 ``AccountDeletedError`` 경로의 409를 구분한다.",
+        "description": "계좌 수정.\n\n런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도\n포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path\n응답과 ``AccountDeletedError`` 경로의 409를 구분한다.\n\nbody는 검증되지 않은 raw ``dict``로 받는다(invariant I4). 가드 판정은\nPydantic이 변환한 값(``is not None``)이 아니라 **요청 body의 키 존재\n여부**로 수행하므로, ``{\"credentials\": null}``처럼 명시적으로 null을\n보낸 경우와 ``{\"buy_commission_rate\": \"bad\"}``처럼 structural 필드가 타입\n오류인 경우 모두 cold-path 가드보다 먼저 422가 발생하지 않는다. 비구조\n필드만 추출한 dict로 ``AccountUpdateRequest.model_validate(...)``를 호출해\n기존 200/404/400/409(deleted) 분기를 보존한다.",
         "operationId": "update_account_api_accounts__account_id__put",
         "parameters": [
           {
@@ -142,11 +137,19 @@
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AccountUpdateRequest"
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Body"
               }
             }
           }
@@ -188,7 +191,7 @@
           "accounts"
         ],
         "summary": "Delete Account",
-        "description": "계좌 소프트 딜리트.\n\n런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.\n실제 계좌 삭제는 서버 정지 상태에서 ``ante account delete`` CLI로\n수행한다. service-layer 회귀 보호는 ``tests/unit/test_account.py``의\n``test_delete_account``, ``test_delete_already_deleted_account_raises``가\n담당한다.",
+        "description": "계좌 소프트 딜리트.\n\n런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.\n실제 계좌 삭제는 서버 정지 상태에서 ``ante account delete`` CLI로\n수행한다.\n\n의존성/audit logger를 시그니처에서 제외해 핸들러 진입 즉시 409가\n반환되도록 한다(invariant I1). OpenAPI에는 success contract(200/201/\n204)가 노출되지 않으며, 응답 모델은 ``ErrorResponse``로 고정된다\n(invariant I2/I3). service-layer 회귀 보호는\n``tests/unit/test_account.py``의 ``test_delete_account``,\n``test_delete_already_deleted_account_raises``가 담당한다.",
         "operationId": "delete_account_api_accounts__account_id__delete",
         "parameters": [
           {
@@ -202,16 +205,15 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Successful Response",
+          "409": {
+            "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 삭제 차단",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
-          },
-          "409": {
-            "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 삭제 차단"
           },
           "422": {
             "description": "Validation Error",
@@ -4088,149 +4090,6 @@
         "title": "AccountSuspendRequest",
         "description": "계좌 정지 요청."
       },
-      "AccountUpdateRequest": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "exchange": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Exchange"
-          },
-          "currency": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Currency"
-          },
-          "timezone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Timezone"
-          },
-          "trading_hours_start": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Trading Hours Start"
-          },
-          "trading_hours_end": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Trading Hours End"
-          },
-          "trading_mode": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Trading Mode"
-          },
-          "broker_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Broker Type"
-          },
-          "credentials": {
-            "anyOf": [
-              {
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Credentials"
-          },
-          "broker_config": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Broker Config"
-          },
-          "buy_commission_rate": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buy Commission Rate"
-          },
-          "sell_commission_rate": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sell Commission Rate"
-          }
-        },
-        "type": "object",
-        "title": "AccountUpdateRequest",
-        "description": "계좌 수정 요청."
-      },
       "ActivateRequest": {
         "properties": {
           "reason": {
@@ -5183,6 +5042,38 @@
         ],
         "title": "DatasetListResponse",
         "description": "데이터셋 목록 응답."
+      },
+      "ErrorResponse": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "default": "/errors/internal"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title",
+            "default": "Internal Server Error"
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail",
+            "default": ""
+          },
+          "status": {
+            "type": "integer",
+            "title": "Status",
+            "default": 500
+          },
+          "instance": {
+            "type": "string",
+            "title": "Instance",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "ErrorResponse",
+        "description": "RFC 7807 Problem Details 에러 응답."
       },
       "FeedStatusResponse": {
         "properties": {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -123,7 +123,7 @@
           "accounts"
         ],
         "summary": "Update Account",
-        "description": "계좌 수정.\n\n런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도\n포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path\n응답과 ``AccountDeletedError`` 경로의 409를 구분한다.\n\nbody는 검증되지 않은 raw ``dict``로 받는다(invariant I4). 가드 판정은\nPydantic이 변환한 값(``is not None``)이 아니라 **요청 body의 키 존재\n여부**로 수행하므로, ``{\"credentials\": null}``처럼 명시적으로 null을\n보낸 경우와 ``{\"buy_commission_rate\": \"bad\"}``처럼 structural 필드가 타입\n오류인 경우 모두 cold-path 가드보다 먼저 422가 발생하지 않는다. 비구조\n필드만 추출한 dict로 ``AccountUpdateRequest.model_validate(...)``를 호출해\n기존 200/404/400/409(deleted) 분기를 보존한다.",
+        "description": "계좌 수정.\n\n런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도\n포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path\n응답과 ``AccountDeletedError`` 경로의 409를 구분한다.\n\nOpenAPI 노출용 body schema는 ``AccountMutableUpdateRequest``를 사용해\nmutable 4 필드만 클라이언트에게 노출한다(P3 schema accuracy). 단, raw\npayload key 가드(I4)를 보존하기 위해 라우트 본문에서는 ``body`` 인자를\n사용하지 않고 ``await request.json()``으로 raw dict를 직접 읽는다 —\nPydantic이 정의 외 키(예: ``credentials``)를 모델 인스턴스에서 제거해도\nstructural 키 존재 여부 판정이 우회되지 않아야 하기 때문이다.\n\n비구조 필드는 raw payload에서 cold-path 가드를 통과한 뒤\n``AccountMutableUpdateRequest.model_validate(...)``로 재검증하며, 이\n단계에서 발생하는 ``ValidationError``는 422 ``HTTPException``으로 명시\n변환된다(P2 — 회귀 보호). 이전 attempt에서는 이 경로가 FastAPI의\n자동 ``RequestValidationError`` 422를 잃어 422 contract가 회귀했다.",
         "operationId": "update_account_api_accounts__account_id__put",
         "parameters": [
           {
@@ -142,8 +142,7 @@
               "schema": {
                 "anyOf": [
                   {
-                    "type": "object",
-                    "additionalProperties": true
+                    "$ref": "#/components/schemas/AccountMutableUpdateRequest"
                   },
                   {
                     "type": "null"
@@ -175,14 +174,7 @@
             "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER (런타임 구조 변경 차단) 또는 삭제된 계좌 수정 시도"
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "description": "비구조(mutable) 필드 schema 검증 실패. structural 필드 키는 422가 아닌 409로 차단된다."
           }
         }
       },
@@ -3992,6 +3984,57 @@
         ],
         "title": "AccountListResponse",
         "description": "계좌 목록 응답."
+      },
+      "AccountMutableUpdateRequest": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "timezone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timezone"
+          },
+          "trading_hours_start": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trading Hours Start"
+          },
+          "trading_hours_end": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trading Hours End"
+          }
+        },
+        "type": "object",
+        "title": "AccountMutableUpdateRequest",
+        "description": "런타임에 PUT /api/accounts/{id}로 수정 가능한 비구조 필드만 노출.\n\n구조(structural) 필드(``credentials``, ``broker_config``,\n``buy_commission_rate``, ``sell_commission_rate``, ``broker_type``,\n``exchange``, ``currency``, ``trading_mode``)는 cold-path 전용이므로 이\n모델에 포함하지 않는다. OpenAPI/타입 생성 소비자에게는 mutable 4 필드만\n노출되어 schema accuracy가 회복된다.\n\n라우트는 raw payload(`request.json()`)에서 structural 키 가드를 먼저\n수행한 뒤(invariant I4) 비구조 필드만 이 모델로 검증한다. 이 단계의\n``ValidationError``는 422로 명시 변환된다."
       },
       "AccountResponse": {
         "properties": {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -166,19 +166,54 @@
             }
           },
           "400": {
-            "description": "수정할 필드가 없음"
+            "description": "수정할 필드가 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "404": {
-            "description": "계좌를 찾을 수 없음"
+            "description": "계좌를 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "409": {
-            "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER (런타임 구조 변경 차단) 또는 삭제된 계좌 수정 시도"
+            "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER (런타임 구조 변경 차단) 또는 삭제된 계좌 수정 시도",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "422": {
-            "description": "비구조(mutable) 필드 schema 검증 실패. structural 필드 키는 422가 아닌 409로 차단된다."
+            "description": "비구조(mutable) 필드 schema 검증 실패. structural 필드 키는 422가 아닌 409로 차단된다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "503": {
-            "description": "Account service not available"
+            "description": "Account service not available",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -60,41 +60,23 @@
           "accounts"
         ],
         "summary": "Create Account",
-        "description": "계좌 생성.\n\n런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.\n실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로\n수행한다.",
+        "description": "계좌 생성.\n\n런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.\n실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로\n수행한다.\n\nbody 파라미터를 받지 않는 이유: cold-path 차단은 입력 valid 여부와\n무관하게 항상 409여야 하므로, FastAPI가 핸들러 진입 전에 body\nvalidation을 수행하지 않도록 시그니처에서 의도적으로 제외한다.\n또한 OpenAPI에서도 requestBody가 노출되지 않아 클라이언트에\n\"런타임 POST는 어떤 body도 받지 않는다\"는 계약이 정확히 전달된다.",
         "operationId": "create_account_api_accounts_post",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AccountCreateRequest"
-              }
-            }
-          }
-        },
         "responses": {
-          "201": {
+          "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AccountDetailResponse"
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Create Account Api Accounts Post"
                 }
               }
             }
           },
           "409": {
             "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 생성 차단"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
           }
         }
       }
@@ -220,8 +202,13 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "Successful Response"
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "409": {
             "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 삭제 차단"
@@ -3973,84 +3960,6 @@
         ],
         "title": "AccountActionResponse",
         "description": "계좌 상태 변경 응답."
-      },
-      "AccountCreateRequest": {
-        "properties": {
-          "account_id": {
-            "type": "string",
-            "title": "Account Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "exchange": {
-            "type": "string",
-            "title": "Exchange",
-            "default": ""
-          },
-          "currency": {
-            "type": "string",
-            "title": "Currency",
-            "default": ""
-          },
-          "timezone": {
-            "type": "string",
-            "title": "Timezone",
-            "default": ""
-          },
-          "trading_hours_start": {
-            "type": "string",
-            "title": "Trading Hours Start",
-            "default": ""
-          },
-          "trading_hours_end": {
-            "type": "string",
-            "title": "Trading Hours End",
-            "default": ""
-          },
-          "trading_mode": {
-            "type": "string",
-            "title": "Trading Mode",
-            "default": "virtual"
-          },
-          "broker_type": {
-            "type": "string",
-            "title": "Broker Type",
-            "default": "test"
-          },
-          "credentials": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "type": "object",
-            "title": "Credentials",
-            "default": {}
-          },
-          "broker_config": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Broker Config",
-            "default": {}
-          },
-          "buy_commission_rate": {
-            "type": "number",
-            "title": "Buy Commission Rate",
-            "default": 0.0
-          },
-          "sell_commission_rate": {
-            "type": "number",
-            "title": "Sell Commission Rate",
-            "default": 0.0
-          }
-        },
-        "type": "object",
-        "required": [
-          "account_id",
-          "name"
-        ],
-        "title": "AccountCreateRequest",
-        "description": "계좌 생성 요청."
       },
       "AccountDetailResponse": {
         "properties": {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -123,7 +123,7 @@
           "accounts"
         ],
         "summary": "Update Account",
-        "description": "계좌 수정.\n\n런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도\n포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path\n응답과 ``AccountDeletedError`` 경로의 409를 구분한다.\n\nOpenAPI 노출용 body schema는 ``AccountMutableUpdateRequest``를 사용해\nmutable 4 필드만 클라이언트에게 노출한다(P3 schema accuracy). 단, raw\npayload key 가드(I4)를 보존하기 위해 라우트 본문에서는 ``body`` 인자를\n사용하지 않고 ``await request.json()``으로 raw dict를 직접 읽는다 —\nPydantic이 정의 외 키(예: ``credentials``)를 모델 인스턴스에서 제거해도\nstructural 키 존재 여부 판정이 우회되지 않아야 하기 때문이다.\n\n비구조 필드는 raw payload에서 cold-path 가드를 통과한 뒤\n``AccountMutableUpdateRequest.model_validate(...)``로 재검증하며, 이\n단계에서 발생하는 ``ValidationError``는 422 ``HTTPException``으로 명시\n변환된다(P2 — 회귀 보호). 이전 attempt에서는 이 경로가 FastAPI의\n자동 ``RequestValidationError`` 422를 잃어 422 contract가 회귀했다.",
+        "description": "계좌 수정.\n\n런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도\n포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path\n응답과 ``AccountDeletedError`` 경로의 409를 구분한다.\n\nbody는 자유 ``dict[str, Any] | None``로 받는다. FastAPI 선행 Pydantic\n검증이 켜지면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가\nstructural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.\n핸들러 본문에서는 raw payload key 검사로 cold-path 가드를 먼저 수행한 뒤,\n비구조 필드만 ``AccountMutableUpdateRequest.model_validate(...)``로\n재검증한다. 이 단계의 ``ValidationError``는 422 ``HTTPException``으로\n명시 변환된다(P2 — 회귀 보호). PUT requestBody의 OpenAPI schema accuracy\n회복(mutable 모델 노출)은 후속 이슈 #1143에서 다룬다.",
         "operationId": "update_account_api_accounts__account_id__put",
         "parameters": [
           {
@@ -142,7 +142,8 @@
               "schema": {
                 "anyOf": [
                   {
-                    "$ref": "#/components/schemas/AccountMutableUpdateRequest"
+                    "type": "object",
+                    "additionalProperties": true
                   },
                   {
                     "type": "null"
@@ -3984,57 +3985,6 @@
         ],
         "title": "AccountListResponse",
         "description": "계좌 목록 응답."
-      },
-      "AccountMutableUpdateRequest": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "timezone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Timezone"
-          },
-          "trading_hours_start": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Trading Hours Start"
-          },
-          "trading_hours_end": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Trading Hours End"
-          }
-        },
-        "type": "object",
-        "title": "AccountMutableUpdateRequest",
-        "description": "런타임에 PUT /api/accounts/{id}로 수정 가능한 비구조 필드만 노출.\n\n구조(structural) 필드(``credentials``, ``broker_config``,\n``buy_commission_rate``, ``sell_commission_rate``, ``broker_type``,\n``exchange``, ``currency``, ``trading_mode``)는 cold-path 전용이므로 이\n모델에 포함하지 않는다. OpenAPI/타입 생성 소비자에게는 mutable 4 필드만\n노출되어 schema accuracy가 회복된다.\n\n라우트는 raw payload(`request.json()`)에서 structural 키 가드를 먼저\n수행한 뒤(invariant I4) 비구조 필드만 이 모델로 검증한다. 이 단계의\n``ValidationError``는 422로 명시 변환된다."
       },
       "AccountResponse": {
         "properties": {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -123,7 +123,7 @@
           "accounts"
         ],
         "summary": "Update Account",
-        "description": "계좌 수정.\n\n런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도\n포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path\n응답과 ``AccountDeletedError`` 경로의 409를 구분한다.\n\nbody는 자유 ``dict[str, Any] | None``로 받는다. FastAPI 선행 Pydantic\n검증이 켜지면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가\nstructural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.\n핸들러 본문에서는 raw payload key 검사로 cold-path 가드를 먼저 수행한 뒤,\n비구조 필드만 ``AccountMutableUpdateRequest.model_validate(...)``로\n재검증한다. 이 단계의 ``ValidationError``는 422 ``HTTPException``으로\n명시 변환된다(P2 — 회귀 보호). PUT requestBody의 OpenAPI schema accuracy\n회복(mutable 모델 노출)은 후속 이슈 #1143에서 다룬다.",
+        "description": "계좌 수정.\n\n런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도\n포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path\n응답과 ``AccountDeletedError`` 경로의 409를 구분한다.\n\nbody는 자유 ``dict[str, Any] | None``로 받는다. FastAPI 선행 Pydantic\n검증이 켜지면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가\nstructural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.\n핸들러 본문에서는 raw payload key 검사로 cold-path 가드를 먼저 수행한 뒤,\n비구조 필드를 그대로 ``account_service.update``에 forward한다.\nservice-layer가 알 수 없는/불변 필드는 자체 검증으로 거부한다\n(`AccountImmutableFieldError → 400`, `ValueError(unknown field)` 등).\nPUT requestBody의 OpenAPI schema accuracy 회복(mutable 모델 노출)은 후속\n이슈 #1143에서 다룬다.",
         "operationId": "update_account_api_accounts__account_id__put",
         "parameters": [
           {
@@ -166,7 +166,7 @@
             }
           },
           "400": {
-            "description": "수정할 필드가 없음",
+            "description": "수정할 필드가 없거나 service-layer가 거부한 비구조 필드",
             "content": {
               "application/json": {
                 "schema": {
@@ -195,8 +195,8 @@
               }
             }
           },
-          "422": {
-            "description": "비구조(mutable) 필드 schema 검증 실패. structural 필드 키는 422가 아닌 409로 차단된다.",
+          "503": {
+            "description": "Account service not available 또는 broker 재연결 실패",
             "content": {
               "application/json": {
                 "schema": {
@@ -205,12 +205,12 @@
               }
             }
           },
-          "503": {
-            "description": "Account service not available",
+          "422": {
+            "description": "Validation Error",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -60,7 +60,7 @@
           "accounts"
         ],
         "summary": "Create Account",
-        "description": "계좌 생성.",
+        "description": "계좌 생성.\n\n런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.\n실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로\n수행한다.",
         "operationId": "create_account_api_accounts_post",
         "requestBody": {
           "required": true,
@@ -82,6 +82,9 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 생성 차단"
           },
           "422": {
             "description": "Validation Error",
@@ -143,7 +146,7 @@
           "accounts"
         ],
         "summary": "Update Account",
-        "description": "계좌 수정.",
+        "description": "계좌 수정.\n\n런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도\n포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path\n응답과 ``AccountDeletedError`` 경로의 409를 구분한다.",
         "operationId": "update_account_api_accounts__account_id__put",
         "parameters": [
           {
@@ -178,16 +181,13 @@
             }
           },
           "400": {
-            "description": "수정할 필드가 없거나 불변 필드 수정 시도"
+            "description": "수정할 필드가 없음"
           },
           "404": {
             "description": "계좌를 찾을 수 없음"
           },
           "409": {
-            "description": "삭제된 계좌 수정 시도"
-          },
-          "503": {
-            "description": "DB에는 계좌 정보가 저장되었으나 새 설정으로 브로커 재연결에 실패한 부분 성공 상태. 자격증명/브로커 설정을 확인한 뒤 재시도."
+            "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER (런타임 구조 변경 차단) 또는 삭제된 계좌 수정 시도"
           },
           "422": {
             "description": "Validation Error",
@@ -206,7 +206,7 @@
           "accounts"
         ],
         "summary": "Delete Account",
-        "description": "계좌 소프트 딜리트.",
+        "description": "계좌 소프트 딜리트.\n\n런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.\n실제 계좌 삭제는 서버 정지 상태에서 ``ante account delete`` CLI로\n수행한다. service-layer 회귀 보호는 ``tests/unit/test_account.py``의\n``test_delete_account``, ``test_delete_already_deleted_account_raises``가\n담당한다.",
         "operationId": "delete_account_api_accounts__account_id__delete",
         "parameters": [
           {
@@ -222,6 +222,9 @@
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "409": {
+            "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 삭제 차단"
           },
           "422": {
             "description": "Validation Error",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -66,9 +66,12 @@ export type paths = {
          *     검증이 켜지면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가
          *     structural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.
          *     핸들러 본문에서는 raw payload key 검사로 cold-path 가드를 먼저 수행한 뒤,
-         *     비구조 필드를 그대로 ``account_service.update``에 forward한다.
-         *     service-layer가 알 수 없는/불변 필드는 자체 검증으로 거부한다
-         *     (`AccountImmutableFieldError → 400`, `ValueError(unknown field)` 등).
+         *     structural을 제외한 비구조 페이로드만 ``AccountUpdateRequest``로
+         *     ``model_validate``하여 mutable 필드의 type 검증을 수행한다(``{"name":
+         *     null}`` / ``{"timezone": {}}`` 같은 잘못된 값이 service/DB까지 흘러가
+         *     상태를 오염시키는 것을 차단한다 — P1 회귀 보호). 검증 실패는 명시적으로
+         *     422로 변환한다.
+         *
          *     PUT requestBody의 OpenAPI schema accuracy 회복(mutable 모델 노출)은 후속
          *     이슈 #1143에서 다룬다.
          */
@@ -3360,13 +3363,13 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Validation Error */
+            /** @description 비구조(mutable) 필드 type 검증 실패. structural 필드 키는 422가 아닌 409로 차단된다. */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Account service not available 또는 broker 재연결 실패 */

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -66,10 +66,11 @@ export type paths = {
          *     검증이 켜지면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가
          *     structural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.
          *     핸들러 본문에서는 raw payload key 검사로 cold-path 가드를 먼저 수행한 뒤,
-         *     비구조 필드만 ``AccountMutableUpdateRequest.model_validate(...)``로
-         *     재검증한다. 이 단계의 ``ValidationError``는 422 ``HTTPException``으로
-         *     명시 변환된다(P2 — 회귀 보호). PUT requestBody의 OpenAPI schema accuracy
-         *     회복(mutable 모델 노출)은 후속 이슈 #1143에서 다룬다.
+         *     비구조 필드를 그대로 ``account_service.update``에 forward한다.
+         *     service-layer가 알 수 없는/불변 필드는 자체 검증으로 거부한다
+         *     (`AccountImmutableFieldError → 400`, `ValueError(unknown field)` 등).
+         *     PUT requestBody의 OpenAPI schema accuracy 회복(mutable 모델 노출)은 후속
+         *     이슈 #1143에서 다룬다.
          */
         put: operations["update_account_api_accounts__account_id__put"];
         post?: never;
@@ -3332,7 +3333,7 @@ export interface operations {
                     "application/json": components["schemas"]["AccountDetailResponse"];
                 };
             };
-            /** @description 수정할 필드가 없음 */
+            /** @description 수정할 필드가 없거나 service-layer가 거부한 비구조 필드 */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -3359,16 +3360,16 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description 비구조(mutable) 필드 schema 검증 실패. structural 필드 키는 422가 아닌 409로 차단된다. */
+            /** @description Validation Error */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
-            /** @description Account service not available */
+            /** @description Account service not available 또는 broker 재연결 실패 */
             503: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -25,11 +25,13 @@ export type paths = {
          *     실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로
          *     수행한다.
          *
-         *     body 파라미터를 받지 않는 이유: cold-path 차단은 입력 valid 여부와
-         *     무관하게 항상 409여야 하므로, FastAPI가 핸들러 진입 전에 body
-         *     validation을 수행하지 않도록 시그니처에서 의도적으로 제외한다.
-         *     또한 OpenAPI에서도 requestBody가 노출되지 않아 클라이언트에
-         *     "런타임 POST는 어떤 body도 받지 않는다"는 계약이 정확히 전달된다.
+         *     의존성/Pydantic body schema/audit logger를 모두 시그니처에서 제외해
+         *     핸들러 진입 즉시 409가 반환되도록 한다(invariant I1). 또한 OpenAPI에는
+         *     success contract(200/201/204)가 노출되지 않으며, 응답 모델은
+         *     ``ErrorResponse``로 고정된다(invariant I2/I3).
+         *
+         *     이 경로의 service-layer 회귀 보호는 ``tests/unit/test_account.py``가
+         *     담당한다.
          */
         post: operations["create_account_api_accounts_post"];
         delete?: never;
@@ -59,6 +61,14 @@ export type paths = {
          *     포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는
          *     ``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path
          *     응답과 ``AccountDeletedError`` 경로의 409를 구분한다.
+         *
+         *     body는 검증되지 않은 raw ``dict``로 받는다(invariant I4). 가드 판정은
+         *     Pydantic이 변환한 값(``is not None``)이 아니라 **요청 body의 키 존재
+         *     여부**로 수행하므로, ``{"credentials": null}``처럼 명시적으로 null을
+         *     보낸 경우와 ``{"buy_commission_rate": "bad"}``처럼 structural 필드가 타입
+         *     오류인 경우 모두 cold-path 가드보다 먼저 422가 발생하지 않는다. 비구조
+         *     필드만 추출한 dict로 ``AccountUpdateRequest.model_validate(...)``를 호출해
+         *     기존 200/404/400/409(deleted) 분기를 보존한다.
          */
         put: operations["update_account_api_accounts__account_id__put"];
         post?: never;
@@ -68,9 +78,14 @@ export type paths = {
          *
          *     런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.
          *     실제 계좌 삭제는 서버 정지 상태에서 ``ante account delete`` CLI로
-         *     수행한다. service-layer 회귀 보호는 ``tests/unit/test_account.py``의
-         *     ``test_delete_account``, ``test_delete_already_deleted_account_raises``가
-         *     담당한다.
+         *     수행한다.
+         *
+         *     의존성/audit logger를 시그니처에서 제외해 핸들러 진입 즉시 409가
+         *     반환되도록 한다(invariant I1). OpenAPI에는 success contract(200/201/
+         *     204)가 노출되지 않으며, 응답 모델은 ``ErrorResponse``로 고정된다
+         *     (invariant I2/I3). service-layer 회귀 보호는
+         *     ``tests/unit/test_account.py``의 ``test_delete_account``,
+         *     ``test_delete_already_deleted_account_raises``가 담당한다.
          */
         delete: operations["delete_account_api_accounts__account_id__delete"];
         options?: never;
@@ -1409,40 +1424,6 @@ export type components = {
             reason: string;
         };
         /**
-         * AccountUpdateRequest
-         * @description 계좌 수정 요청.
-         */
-        AccountUpdateRequest: {
-            /** Broker Config */
-            broker_config?: {
-                [key: string]: unknown;
-            } | null;
-            /** Broker Type */
-            broker_type?: string | null;
-            /** Buy Commission Rate */
-            buy_commission_rate?: number | null;
-            /** Credentials */
-            credentials?: {
-                [key: string]: string;
-            } | null;
-            /** Currency */
-            currency?: string | null;
-            /** Exchange */
-            exchange?: string | null;
-            /** Name */
-            name?: string | null;
-            /** Sell Commission Rate */
-            sell_commission_rate?: number | null;
-            /** Timezone */
-            timezone?: string | null;
-            /** Trading Hours End */
-            trading_hours_end?: string | null;
-            /** Trading Hours Start */
-            trading_hours_start?: string | null;
-            /** Trading Mode */
-            trading_mode?: string | null;
-        };
-        /**
          * ActivateRequest
          * @description 거래 재개 요청.
          */
@@ -1956,6 +1937,37 @@ export type components = {
             items: components["schemas"]["DatasetItem"][];
             /** Total */
             total: number;
+        };
+        /**
+         * ErrorResponse
+         * @description RFC 7807 Problem Details 에러 응답.
+         */
+        ErrorResponse: {
+            /**
+             * Detail
+             * @default
+             */
+            detail: string;
+            /**
+             * Instance
+             * @default
+             */
+            instance: string;
+            /**
+             * Status
+             * @default 500
+             */
+            status: number;
+            /**
+             * Title
+             * @default Internal Server Error
+             */
+            title: string;
+            /**
+             * Type
+             * @default /errors/internal
+             */
+            type: string;
         };
         /**
          * FeedStatusResponse
@@ -3123,7 +3135,6 @@ export type AccountDetailResponse = components['schemas']['AccountDetailResponse
 export type AccountListResponse = components['schemas']['AccountListResponse'];
 export type AccountResponse = components['schemas']['AccountResponse'];
 export type AccountSuspendRequest = components['schemas']['AccountSuspendRequest'];
-export type AccountUpdateRequest = components['schemas']['AccountUpdateRequest'];
 export type ActivateRequest = components['schemas']['ActivateRequest'];
 export type ApprovalDetailResponse = components['schemas']['ApprovalDetailResponse'];
 export type ApprovalItem = components['schemas']['ApprovalItem'];
@@ -3153,6 +3164,7 @@ export type DataSchemaResponse = components['schemas']['DataSchemaResponse'];
 export type DatasetDetailResponse = components['schemas']['DatasetDetailResponse'];
 export type DatasetItem = components['schemas']['DatasetItem'];
 export type DatasetListResponse = components['schemas']['DatasetListResponse'];
+export type ErrorResponse = components['schemas']['ErrorResponse'];
 export type FeedStatusResponse = components['schemas']['FeedStatusResponse'];
 export type HaltRequest = components['schemas']['HaltRequest'];
 export type HealthResponse = components['schemas']['HealthResponse'];
@@ -3251,23 +3263,14 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
             /** @description ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 생성 차단 */
             409: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
             };
         };
     };
@@ -3311,9 +3314,11 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody: {
+        requestBody?: {
             content: {
-                "application/json": components["schemas"]["AccountUpdateRequest"];
+                "application/json": {
+                    [key: string]: unknown;
+                } | null;
             };
         };
         responses: {
@@ -3369,21 +3374,14 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
             /** @description ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 삭제 차단 */
             409: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
             };
             /** @description Validation Error */
             422: {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -20,6 +20,10 @@ export type paths = {
         /**
          * Create Account
          * @description 계좌 생성.
+         *
+         *     런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.
+         *     실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로
+         *     수행한다.
          */
         post: operations["create_account_api_accounts_post"];
         delete?: never;
@@ -43,12 +47,24 @@ export type paths = {
         /**
          * Update Account
          * @description 계좌 수정.
+         *
+         *     런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,
+         *     ``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도
+         *     포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는
+         *     ``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path
+         *     응답과 ``AccountDeletedError`` 경로의 409를 구분한다.
          */
         put: operations["update_account_api_accounts__account_id__put"];
         post?: never;
         /**
          * Delete Account
          * @description 계좌 소프트 딜리트.
+         *
+         *     런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.
+         *     실제 계좌 삭제는 서버 정지 상태에서 ``ante account delete`` CLI로
+         *     수행한다. service-layer 회귀 보호는 ``tests/unit/test_account.py``의
+         *     ``test_delete_account``, ``test_delete_already_deleted_account_raises``가
+         *     담당한다.
          */
         delete: operations["delete_account_api_accounts__account_id__delete"];
         options?: never;
@@ -3312,6 +3328,13 @@ export interface operations {
                     "application/json": components["schemas"]["AccountDetailResponse"];
                 };
             };
+            /** @description ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 생성 차단 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -3378,7 +3401,7 @@ export interface operations {
                     "application/json": components["schemas"]["AccountDetailResponse"];
                 };
             };
-            /** @description 수정할 필드가 없거나 불변 필드 수정 시도 */
+            /** @description 수정할 필드가 없음 */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -3392,7 +3415,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description 삭제된 계좌 수정 시도 */
+            /** @description ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER (런타임 구조 변경 차단) 또는 삭제된 계좌 수정 시도 */
             409: {
                 headers: {
                     [name: string]: unknown;
@@ -3407,13 +3430,6 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
-            };
-            /** @description DB에는 계좌 정보가 저장되었으나 새 설정으로 브로커 재연결에 실패한 부분 성공 상태. 자격증명/브로커 설정을 확인한 뒤 재시도. */
-            503: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
             };
         };
     };
@@ -3430,6 +3446,13 @@ export interface operations {
         responses: {
             /** @description Successful Response */
             204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 삭제 차단 */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -3360,6 +3360,13 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Account service not available */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     delete_account_api_accounts__account_id__delete: {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -24,6 +24,12 @@ export type paths = {
          *     런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.
          *     실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로
          *     수행한다.
+         *
+         *     body 파라미터를 받지 않는 이유: cold-path 차단은 입력 valid 여부와
+         *     무관하게 항상 409여야 하므로, FastAPI가 핸들러 진입 전에 body
+         *     validation을 수행하지 않도록 시그니처에서 의도적으로 제외한다.
+         *     또한 OpenAPI에서도 requestBody가 노출되지 않아 클라이언트에
+         *     "런타임 POST는 어떤 body도 받지 않는다"는 계약이 정확히 전달된다.
          */
         post: operations["create_account_api_accounts_post"];
         delete?: never;
@@ -1334,75 +1340,6 @@ export type components = {
             account: components["schemas"]["AccountResponse"];
             /** Message */
             message: string;
-        };
-        /**
-         * AccountCreateRequest
-         * @description 계좌 생성 요청.
-         */
-        AccountCreateRequest: {
-            /** Account Id */
-            account_id: string;
-            /**
-             * Broker Config
-             * @default {}
-             */
-            broker_config: {
-                [key: string]: unknown;
-            };
-            /**
-             * Broker Type
-             * @default test
-             */
-            broker_type: string;
-            /**
-             * Buy Commission Rate
-             * @default 0
-             */
-            buy_commission_rate: number;
-            /**
-             * Credentials
-             * @default {}
-             */
-            credentials: {
-                [key: string]: string;
-            };
-            /**
-             * Currency
-             * @default
-             */
-            currency: string;
-            /**
-             * Exchange
-             * @default
-             */
-            exchange: string;
-            /** Name */
-            name: string;
-            /**
-             * Sell Commission Rate
-             * @default 0
-             */
-            sell_commission_rate: number;
-            /**
-             * Timezone
-             * @default
-             */
-            timezone: string;
-            /**
-             * Trading Hours End
-             * @default
-             */
-            trading_hours_end: string;
-            /**
-             * Trading Hours Start
-             * @default
-             */
-            trading_hours_start: string;
-            /**
-             * Trading Mode
-             * @default virtual
-             */
-            trading_mode: string;
         };
         /**
          * AccountDetailResponse
@@ -3182,7 +3119,6 @@ export type components = {
     pathItems: never;
 };
 export type AccountActionResponse = components['schemas']['AccountActionResponse'];
-export type AccountCreateRequest = components['schemas']['AccountCreateRequest'];
 export type AccountDetailResponse = components['schemas']['AccountDetailResponse'];
 export type AccountListResponse = components['schemas']['AccountListResponse'];
 export type AccountResponse = components['schemas']['AccountResponse'];
@@ -3313,19 +3249,17 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AccountCreateRequest"];
-            };
-        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
-            201: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AccountDetailResponse"];
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 생성 차단 */
@@ -3334,15 +3268,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
             };
         };
     };
@@ -3445,11 +3370,13 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description Successful Response */
-            204: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": unknown;
+                };
             };
             /** @description ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 삭제 차단 */
             409: {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -62,18 +62,14 @@ export type paths = {
          *     ``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path
          *     응답과 ``AccountDeletedError`` 경로의 409를 구분한다.
          *
-         *     OpenAPI 노출용 body schema는 ``AccountMutableUpdateRequest``를 사용해
-         *     mutable 4 필드만 클라이언트에게 노출한다(P3 schema accuracy). 단, raw
-         *     payload key 가드(I4)를 보존하기 위해 라우트 본문에서는 ``body`` 인자를
-         *     사용하지 않고 ``await request.json()``으로 raw dict를 직접 읽는다 —
-         *     Pydantic이 정의 외 키(예: ``credentials``)를 모델 인스턴스에서 제거해도
-         *     structural 키 존재 여부 판정이 우회되지 않아야 하기 때문이다.
-         *
-         *     비구조 필드는 raw payload에서 cold-path 가드를 통과한 뒤
-         *     ``AccountMutableUpdateRequest.model_validate(...)``로 재검증하며, 이
-         *     단계에서 발생하는 ``ValidationError``는 422 ``HTTPException``으로 명시
-         *     변환된다(P2 — 회귀 보호). 이전 attempt에서는 이 경로가 FastAPI의
-         *     자동 ``RequestValidationError`` 422를 잃어 422 contract가 회귀했다.
+         *     body는 자유 ``dict[str, Any] | None``로 받는다. FastAPI 선행 Pydantic
+         *     검증이 켜지면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가
+         *     structural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.
+         *     핸들러 본문에서는 raw payload key 검사로 cold-path 가드를 먼저 수행한 뒤,
+         *     비구조 필드만 ``AccountMutableUpdateRequest.model_validate(...)``로
+         *     재검증한다. 이 단계의 ``ValidationError``는 422 ``HTTPException``으로
+         *     명시 변환된다(P2 — 회귀 보호). PUT requestBody의 OpenAPI schema accuracy
+         *     회복(mutable 모델 노출)은 후속 이슈 #1143에서 다룬다.
          */
         put: operations["update_account_api_accounts__account_id__put"];
         post?: never;
@@ -1375,30 +1371,6 @@ export type components = {
         AccountListResponse: {
             /** Accounts */
             accounts: components["schemas"]["AccountResponse"][];
-        };
-        /**
-         * AccountMutableUpdateRequest
-         * @description 런타임에 PUT /api/accounts/{id}로 수정 가능한 비구조 필드만 노출.
-         *
-         *     구조(structural) 필드(``credentials``, ``broker_config``,
-         *     ``buy_commission_rate``, ``sell_commission_rate``, ``broker_type``,
-         *     ``exchange``, ``currency``, ``trading_mode``)는 cold-path 전용이므로 이
-         *     모델에 포함하지 않는다. OpenAPI/타입 생성 소비자에게는 mutable 4 필드만
-         *     노출되어 schema accuracy가 회복된다.
-         *
-         *     라우트는 raw payload(`request.json()`)에서 structural 키 가드를 먼저
-         *     수행한 뒤(invariant I4) 비구조 필드만 이 모델로 검증한다. 이 단계의
-         *     ``ValidationError``는 422로 명시 변환된다.
-         */
-        AccountMutableUpdateRequest: {
-            /** Name */
-            name?: string | null;
-            /** Timezone */
-            timezone?: string | null;
-            /** Trading Hours End */
-            trading_hours_end?: string | null;
-            /** Trading Hours Start */
-            trading_hours_start?: string | null;
         };
         /**
          * AccountResponse
@@ -3162,7 +3134,6 @@ export type components = {
 export type AccountActionResponse = components['schemas']['AccountActionResponse'];
 export type AccountDetailResponse = components['schemas']['AccountDetailResponse'];
 export type AccountListResponse = components['schemas']['AccountListResponse'];
-export type AccountMutableUpdateRequest = components['schemas']['AccountMutableUpdateRequest'];
 export type AccountResponse = components['schemas']['AccountResponse'];
 export type AccountSuspendRequest = components['schemas']['AccountSuspendRequest'];
 export type ActivateRequest = components['schemas']['ActivateRequest'];
@@ -3346,7 +3317,9 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                "application/json": components["schemas"]["AccountMutableUpdateRequest"] | null;
+                "application/json": {
+                    [key: string]: unknown;
+                } | null;
             };
         };
         responses: {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -3337,35 +3337,45 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
             };
             /** @description 계좌를 찾을 수 없음 */
             404: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
             };
             /** @description ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER (런타임 구조 변경 차단) 또는 삭제된 계좌 수정 시도 */
             409: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
             };
             /** @description 비구조(mutable) 필드 schema 검증 실패. structural 필드 키는 422가 아닌 409로 차단된다. */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
             };
             /** @description Account service not available */
             503: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
             };
         };
     };

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -62,13 +62,18 @@ export type paths = {
          *     ``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path
          *     응답과 ``AccountDeletedError`` 경로의 409를 구분한다.
          *
-         *     body는 검증되지 않은 raw ``dict``로 받는다(invariant I4). 가드 판정은
-         *     Pydantic이 변환한 값(``is not None``)이 아니라 **요청 body의 키 존재
-         *     여부**로 수행하므로, ``{"credentials": null}``처럼 명시적으로 null을
-         *     보낸 경우와 ``{"buy_commission_rate": "bad"}``처럼 structural 필드가 타입
-         *     오류인 경우 모두 cold-path 가드보다 먼저 422가 발생하지 않는다. 비구조
-         *     필드만 추출한 dict로 ``AccountUpdateRequest.model_validate(...)``를 호출해
-         *     기존 200/404/400/409(deleted) 분기를 보존한다.
+         *     OpenAPI 노출용 body schema는 ``AccountMutableUpdateRequest``를 사용해
+         *     mutable 4 필드만 클라이언트에게 노출한다(P3 schema accuracy). 단, raw
+         *     payload key 가드(I4)를 보존하기 위해 라우트 본문에서는 ``body`` 인자를
+         *     사용하지 않고 ``await request.json()``으로 raw dict를 직접 읽는다 —
+         *     Pydantic이 정의 외 키(예: ``credentials``)를 모델 인스턴스에서 제거해도
+         *     structural 키 존재 여부 판정이 우회되지 않아야 하기 때문이다.
+         *
+         *     비구조 필드는 raw payload에서 cold-path 가드를 통과한 뒤
+         *     ``AccountMutableUpdateRequest.model_validate(...)``로 재검증하며, 이
+         *     단계에서 발생하는 ``ValidationError``는 422 ``HTTPException``으로 명시
+         *     변환된다(P2 — 회귀 보호). 이전 attempt에서는 이 경로가 FastAPI의
+         *     자동 ``RequestValidationError`` 422를 잃어 422 contract가 회귀했다.
          */
         put: operations["update_account_api_accounts__account_id__put"];
         post?: never;
@@ -1370,6 +1375,30 @@ export type components = {
         AccountListResponse: {
             /** Accounts */
             accounts: components["schemas"]["AccountResponse"][];
+        };
+        /**
+         * AccountMutableUpdateRequest
+         * @description 런타임에 PUT /api/accounts/{id}로 수정 가능한 비구조 필드만 노출.
+         *
+         *     구조(structural) 필드(``credentials``, ``broker_config``,
+         *     ``buy_commission_rate``, ``sell_commission_rate``, ``broker_type``,
+         *     ``exchange``, ``currency``, ``trading_mode``)는 cold-path 전용이므로 이
+         *     모델에 포함하지 않는다. OpenAPI/타입 생성 소비자에게는 mutable 4 필드만
+         *     노출되어 schema accuracy가 회복된다.
+         *
+         *     라우트는 raw payload(`request.json()`)에서 structural 키 가드를 먼저
+         *     수행한 뒤(invariant I4) 비구조 필드만 이 모델로 검증한다. 이 단계의
+         *     ``ValidationError``는 422로 명시 변환된다.
+         */
+        AccountMutableUpdateRequest: {
+            /** Name */
+            name?: string | null;
+            /** Timezone */
+            timezone?: string | null;
+            /** Trading Hours End */
+            trading_hours_end?: string | null;
+            /** Trading Hours Start */
+            trading_hours_start?: string | null;
         };
         /**
          * AccountResponse
@@ -3133,6 +3162,7 @@ export type components = {
 export type AccountActionResponse = components['schemas']['AccountActionResponse'];
 export type AccountDetailResponse = components['schemas']['AccountDetailResponse'];
 export type AccountListResponse = components['schemas']['AccountListResponse'];
+export type AccountMutableUpdateRequest = components['schemas']['AccountMutableUpdateRequest'];
 export type AccountResponse = components['schemas']['AccountResponse'];
 export type AccountSuspendRequest = components['schemas']['AccountSuspendRequest'];
 export type ActivateRequest = components['schemas']['ActivateRequest'];
@@ -3316,9 +3346,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                "application/json": {
-                    [key: string]: unknown;
-                } | null;
+                "application/json": components["schemas"]["AccountMutableUpdateRequest"] | null;
             };
         };
         responses: {
@@ -3352,14 +3380,12 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Validation Error */
+            /** @description 비구조(mutable) 필드 schema 검증 실패. structural 필드 키는 422가 아닌 409로 차단된다. */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
+                content?: never;
             };
         };
     };

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -186,14 +186,14 @@ async def get_account(
                 "structural 필드 키는 422가 아닌 409로 차단된다."
             )
         },
+        503: {"description": "Account service not available"},
     },
 )
 async def update_account(
     account_id: str,
     request: Request,
-    account_service: Annotated[Any, Depends(get_account_service)],
-    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
     body: dict[str, Any] | None = Body(default=None),
+    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)] = None,
 ) -> dict[str, Any]:
     """계좌 수정.
 
@@ -256,6 +256,16 @@ async def update_account(
 
     if not fields:
         raise HTTPException(status_code=400, detail="수정할 필드가 없습니다.")
+
+    # service는 비구조 분기에 도달한 뒤에만 lazy 해소한다. structural body가
+    # 들어온 경로에서는 위 가드에서 이미 409가 raise되었기 때문에 service
+    # 미주입 환경에서도 503이 선행되지 않는다(invariant I1/I4 보호 — P3 회귀).
+    account_service = getattr(request.app.state, "account_service", None)
+    if account_service is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Account service not available",
+        )
 
     try:
         updated = await account_service.update(account_id, **fields)

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -6,6 +6,7 @@ import logging
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
+from pydantic import ValidationError
 
 from ante.web.deps import (
     get_account_service,
@@ -18,6 +19,7 @@ from ante.web.schemas import (
     AccountDetailResponse,
     AccountListResponse,
     AccountSuspendRequest,
+    AccountUpdateRequest,
     ErrorResponse,
     RuleListResponse,
     RuleUpdateRequest,
@@ -182,6 +184,13 @@ async def get_account(
                 "(런타임 구조 변경 차단) 또는 삭제된 계좌 수정 시도"
             ),
         },
+        422: {
+            "model": ErrorResponse,
+            "description": (
+                "비구조(mutable) 필드 type 검증 실패. "
+                "structural 필드 키는 422가 아닌 409로 차단된다."
+            ),
+        },
         503: {
             "model": ErrorResponse,
             "description": "Account service not available 또는 broker 재연결 실패",
@@ -206,9 +215,12 @@ async def update_account(
     검증이 켜지면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가
     structural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.
     핸들러 본문에서는 raw payload key 검사로 cold-path 가드를 먼저 수행한 뒤,
-    비구조 필드를 그대로 ``account_service.update``에 forward한다.
-    service-layer가 알 수 없는/불변 필드는 자체 검증으로 거부한다
-    (`AccountImmutableFieldError → 400`, `ValueError(unknown field)` 등).
+    structural을 제외한 비구조 페이로드만 ``AccountUpdateRequest``로
+    ``model_validate``하여 mutable 필드의 type 검증을 수행한다(``{"name":
+    null}`` / ``{"timezone": {}}`` 같은 잘못된 값이 service/DB까지 흘러가
+    상태를 오염시키는 것을 차단한다 — P1 회귀 보호). 검증 실패는 명시적으로
+    422로 변환한다.
+
     PUT requestBody의 OpenAPI schema accuracy 회복(mutable 모델 노출)은 후속
     이슈 #1143에서 다룬다.
     """
@@ -226,7 +238,8 @@ async def update_account(
     # cold-path 가드: structural 필드 키가 payload에 하나라도 등장하면
     # DB/서비스 호출 전 409로 즉시 차단한다(invariant I1/I4). 값이 null이거나
     # 타입이 잘못돼도 동일하게 차단된다 — Pydantic 검증을 통과한 값이 아니라
-    # 키 존재 여부만 본다.
+    # 키 존재 여부만 본다. 따라서 structural mutable 검증보다 *먼저* 수행해야
+    # mutable 422가 cold-path 409를 가리지 않는다.
     structural_hits = sorted(set(payload) & set(STRUCTURAL_FIELDS))
     if structural_hits:
         raise HTTPException(
@@ -236,9 +249,25 @@ async def update_account(
             ),
         )
 
-    # structural 가드를 통과한 키만 service.update에 forward한다. service가
-    # unknown/invalid 필드를 거부하므로 라우트는 추가 schema 검증을 하지 않는다.
-    fields = {k: v for k, v in payload.items() if k not in STRUCTURAL_FIELDS}
+    # 비구조 필드만 모은다. structural 키는 위 가드에서 이미 차단되었으므로
+    # 여기에는 들어오지 않는다. mutable 필드만 들어온 raw dict를 기존
+    # ``AccountUpdateRequest``로 model_validate하여 type 검증한다(새 모델
+    # 추가 없음 — 메타 리뷰 #2 결정 보존). structural 필드는 input에 없으므로
+    # None default로 통과되고, mutable 필드의 잘못된 값(예: null, dict 등)은
+    # ValidationError로 거부된다.
+    mutable_payload_in = {
+        k: v for k, v in payload.items() if k not in STRUCTURAL_FIELDS
+    }
+
+    try:
+        validated = AccountUpdateRequest.model_validate(mutable_payload_in)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.errors())
+
+    # ``exclude_none=True``로 set된 mutable 필드만 추출한다. ``{"name": null}``
+    # 같이 명시적으로 null이 들어온 경우 model_dump에서 빠지므로 service까지
+    # null이 흘러가지 않는다(P1: DB 오염 차단).
+    fields = validated.model_dump(exclude_none=True)
     if not fields:
         raise HTTPException(status_code=400, detail="수정할 필드가 없습니다.")
 

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -15,7 +15,6 @@ from ante.web.deps import (
 )
 from ante.web.schemas import (
     AccountActionResponse,
-    AccountCreateRequest,
     AccountDetailResponse,
     AccountListResponse,
     AccountSuspendRequest,
@@ -115,8 +114,6 @@ async def list_accounts(
 
 @router.post(
     "",
-    response_model=AccountDetailResponse,
-    status_code=201,
     responses={
         409: {
             "description": (
@@ -127,7 +124,6 @@ async def list_accounts(
     },
 )
 async def create_account(
-    body: AccountCreateRequest,
     request: Request,
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
@@ -137,6 +133,12 @@ async def create_account(
     런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.
     실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로
     수행한다.
+
+    body 파라미터를 받지 않는 이유: cold-path 차단은 입력 valid 여부와
+    무관하게 항상 409여야 하므로, FastAPI가 핸들러 진입 전에 body
+    validation을 수행하지 않도록 시그니처에서 의도적으로 제외한다.
+    또한 OpenAPI에서도 requestBody가 노출되지 않아 클라이언트에
+    "런타임 POST는 어떤 body도 받지 않는다"는 계약이 정확히 전달된다.
     """
     # 다른 검증/서비스 호출 전, 진입 즉시 cold-path 409 응답.
     # AccountService 생성 호출, broker connect, 감사 로그 모두 발생하지 않는다.
@@ -330,7 +332,6 @@ async def activate_account(
 
 @router.delete(
     "/{account_id}",
-    status_code=204,
     responses={
         409: {
             "description": (

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -6,7 +6,6 @@ import logging
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
-from pydantic import ValidationError
 
 from ante.web.deps import (
     get_account_service,
@@ -18,7 +17,6 @@ from ante.web.schemas import (
     AccountActionResponse,
     AccountDetailResponse,
     AccountListResponse,
-    AccountMutableUpdateRequest,
     AccountSuspendRequest,
     ErrorResponse,
     RuleListResponse,
@@ -172,7 +170,10 @@ async def get_account(
     "/{account_id}",
     response_model=AccountDetailResponse,
     responses={
-        400: {"model": ErrorResponse, "description": "수정할 필드가 없음"},
+        400: {
+            "model": ErrorResponse,
+            "description": ("수정할 필드가 없거나 service-layer가 거부한 비구조 필드"),
+        },
         404: {"model": ErrorResponse, "description": "계좌를 찾을 수 없음"},
         409: {
             "model": ErrorResponse,
@@ -181,14 +182,10 @@ async def get_account(
                 "(런타임 구조 변경 차단) 또는 삭제된 계좌 수정 시도"
             ),
         },
-        422: {
+        503: {
             "model": ErrorResponse,
-            "description": (
-                "비구조(mutable) 필드 schema 검증 실패. "
-                "structural 필드 키는 422가 아닌 409로 차단된다."
-            ),
+            "description": "Account service not available 또는 broker 재연결 실패",
         },
-        503: {"model": ErrorResponse, "description": "Account service not available"},
     },
 )
 async def update_account(
@@ -209,14 +206,17 @@ async def update_account(
     검증이 켜지면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가
     structural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.
     핸들러 본문에서는 raw payload key 검사로 cold-path 가드를 먼저 수행한 뒤,
-    비구조 필드만 ``AccountMutableUpdateRequest.model_validate(...)``로
-    재검증한다. 이 단계의 ``ValidationError``는 422 ``HTTPException``으로
-    명시 변환된다(P2 — 회귀 보호). PUT requestBody의 OpenAPI schema accuracy
-    회복(mutable 모델 노출)은 후속 이슈 #1143에서 다룬다.
+    비구조 필드를 그대로 ``account_service.update``에 forward한다.
+    service-layer가 알 수 없는/불변 필드는 자체 검증으로 거부한다
+    (`AccountImmutableFieldError → 400`, `ValueError(unknown field)` 등).
+    PUT requestBody의 OpenAPI schema accuracy 회복(mutable 모델 노출)은 후속
+    이슈 #1143에서 다룬다.
     """
     from ante.account.errors import (
         AccountDeletedError,
+        AccountImmutableFieldError,
         AccountNotFoundError,
+        BrokerReconnectFailedError,
     )
 
     # body는 dict로 직접 받으므로 별도 raw bytes 파싱이 필요 없다.
@@ -226,10 +226,7 @@ async def update_account(
     # cold-path 가드: structural 필드 키가 payload에 하나라도 등장하면
     # DB/서비스 호출 전 409로 즉시 차단한다(invariant I1/I4). 값이 null이거나
     # 타입이 잘못돼도 동일하게 차단된다 — Pydantic 검증을 통과한 값이 아니라
-    # 키 존재 여부만 본다. 가드 이후의 service.update는 비구조 필드만 받으므로
-    # AccountImmutableFieldError/BrokerReconnectFailedError 경로에 도달하지
-    # 않는다. service-layer 동작 회귀는 `tests/unit/test_account.py`,
-    # `tests/unit/test_account_immutable_fields.py`가 보호한다.
+    # 키 존재 여부만 본다.
     structural_hits = sorted(set(payload) & set(STRUCTURAL_FIELDS))
     if structural_hits:
         raise HTTPException(
@@ -239,23 +236,9 @@ async def update_account(
             ),
         )
 
-    # 비구조 필드만 모아 mutable schema로 재검증. structural 키는 위 가드에서
-    # 이미 걸렀고, mutable 모델에는 정의되어 있지 않다. 알 수 없는 추가 키는
-    # Pydantic 기본(extra='ignore')으로 무시된다.
-    mutable_payload = {k: v for k, v in payload.items() if k not in STRUCTURAL_FIELDS}
-    if not mutable_payload:
-        raise HTTPException(status_code=400, detail="수정할 필드가 없습니다.")
-
-    try:
-        parsed = AccountMutableUpdateRequest.model_validate(mutable_payload)
-    except ValidationError as e:
-        # FastAPI 자동 422와 동일한 구조화 에러를 반환해 클라이언트가 422를
-        # 잃지 않도록 한다(P2 회귀 보호).
-        raise HTTPException(status_code=422, detail=e.errors())
-
-    # None이 아닌 비구조 필드만 업데이트 대상.
-    fields = parsed.model_dump(exclude_none=True)
-
+    # structural 가드를 통과한 키만 service.update에 forward한다. service가
+    # unknown/invalid 필드를 거부하므로 라우트는 추가 schema 검증을 하지 않는다.
+    fields = {k: v for k, v in payload.items() if k not in STRUCTURAL_FIELDS}
     if not fields:
         raise HTTPException(status_code=400, detail="수정할 필드가 없습니다.")
 
@@ -275,6 +258,13 @@ async def update_account(
         raise HTTPException(status_code=404, detail=str(e))
     except AccountDeletedError as e:
         raise HTTPException(status_code=409, detail=str(e))
+    except AccountImmutableFieldError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except BrokerReconnectFailedError as e:
+        raise HTTPException(
+            status_code=503,
+            detail=str(e),
+        )
 
     if audit_logger:
         await audit_logger.log(

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Body, Depends, HTTPException, Request
 
 from ante.web.deps import (
     get_account_service,
@@ -19,6 +19,7 @@ from ante.web.schemas import (
     AccountListResponse,
     AccountSuspendRequest,
     AccountUpdateRequest,
+    ErrorResponse,
     RuleListResponse,
     RuleUpdateRequest,
     RuleUpdateResponse,
@@ -114,36 +115,33 @@ async def list_accounts(
 
 @router.post(
     "",
+    status_code=409,
+    response_model=ErrorResponse,
     responses={
         409: {
+            "model": ErrorResponse,
             "description": (
                 "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER "
                 "— 런타임 계좌 생성 차단"
-            )
+            ),
         },
     },
 )
-async def create_account(
-    request: Request,
-    account_service: Annotated[Any, Depends(get_account_service)],
-    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
-) -> dict[str, Any]:
+async def create_account(request: Request) -> ErrorResponse:
     """계좌 생성.
 
     런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.
     실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로
     수행한다.
 
-    body 파라미터를 받지 않는 이유: cold-path 차단은 입력 valid 여부와
-    무관하게 항상 409여야 하므로, FastAPI가 핸들러 진입 전에 body
-    validation을 수행하지 않도록 시그니처에서 의도적으로 제외한다.
-    또한 OpenAPI에서도 requestBody가 노출되지 않아 클라이언트에
-    "런타임 POST는 어떤 body도 받지 않는다"는 계약이 정확히 전달된다.
+    의존성/Pydantic body schema/audit logger를 모두 시그니처에서 제외해
+    핸들러 진입 즉시 409가 반환되도록 한다(invariant I1). 또한 OpenAPI에는
+    success contract(200/201/204)가 노출되지 않으며, 응답 모델은
+    ``ErrorResponse``로 고정된다(invariant I2/I3).
+
+    이 경로의 service-layer 회귀 보호는 ``tests/unit/test_account.py``가
+    담당한다.
     """
-    # 다른 검증/서비스 호출 전, 진입 즉시 cold-path 409 응답.
-    # AccountService 생성 호출, broker connect, 감사 로그 모두 발생하지 않는다.
-    # 이 경로의 회귀 보호는 service-layer 테스트(`tests/unit/test_account.py`)가
-    # 담당한다.
     raise HTTPException(
         status_code=409,
         detail=_cold_path_detail(
@@ -185,10 +183,10 @@ async def get_account(
 )
 async def update_account(
     account_id: str,
-    body: AccountUpdateRequest,
     request: Request,
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
+    body: dict[str, Any] | None = Body(default=None),
 ) -> dict[str, Any]:
     """계좌 수정.
 
@@ -197,28 +195,43 @@ async def update_account(
     포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는
     ``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path
     응답과 ``AccountDeletedError`` 경로의 409를 구분한다.
+
+    body는 검증되지 않은 raw ``dict``로 받는다(invariant I4). 가드 판정은
+    Pydantic이 변환한 값(``is not None``)이 아니라 **요청 body의 키 존재
+    여부**로 수행하므로, ``{"credentials": null}``처럼 명시적으로 null을
+    보낸 경우와 ``{"buy_commission_rate": "bad"}``처럼 structural 필드가 타입
+    오류인 경우 모두 cold-path 가드보다 먼저 422가 발생하지 않는다. 비구조
+    필드만 추출한 dict로 ``AccountUpdateRequest.model_validate(...)``를 호출해
+    기존 200/404/400/409(deleted) 분기를 보존한다.
     """
     from ante.account.errors import (
         AccountDeletedError,
         AccountNotFoundError,
     )
 
-    # cold-path 가드: structural 필드가 하나라도 명시(`is not None`)되면
-    # DB/서비스 호출 전 409로 즉시 차단한다.
-    # 가드 이후의 service.update는 비구조 필드만 받으므로
+    # cold-path 가드: structural 필드 키가 raw payload에 하나라도 등장하면
+    # DB/서비스 호출 전 409로 즉시 차단한다(invariant I1/I4). 값이 null이거나
+    # 타입이 잘못돼도 동일하게 차단된다 — Pydantic 검증을 통과한 값이 아니라
+    # 키 존재 여부만 본다. 가드 이후의 service.update는 비구조 필드만 받으므로
     # AccountImmutableFieldError/BrokerReconnectFailedError 경로에 도달하지
-    # 않는다. 해당 service-layer 동작 회귀는 `tests/unit/test_account.py`,
+    # 않는다. service-layer 동작 회귀는 `tests/unit/test_account.py`,
     # `tests/unit/test_account_immutable_fields.py`가 보호한다.
-    triggered_structural = [
-        name for name in STRUCTURAL_FIELDS if getattr(body, name, None) is not None
-    ]
-    if triggered_structural:
+    payload = body or {}
+    structural_hits = sorted(set(payload) & set(STRUCTURAL_FIELDS))
+    if structural_hits:
         raise HTTPException(
             status_code=409,
             detail=_cold_path_detail(
-                f"다음 필드는 cold-path 전용입니다: {', '.join(triggered_structural)}"
+                f"다음 필드는 cold-path 전용입니다: {', '.join(structural_hits)}"
             ),
         )
+
+    # 비구조 필드만 모아 Pydantic으로 재검증. 알 수 없는 키는 Pydantic이
+    # 무시(extra='ignore' 기본)하므로 cold-path 가드 통과 후에도 안전하다.
+    non_structural_payload = {
+        k: v for k, v in payload.items() if k not in STRUCTURAL_FIELDS
+    }
+    parsed = AccountUpdateRequest.model_validate(non_structural_payload)
 
     # None이 아닌 비구조 필드만 업데이트 대상
     fields: dict[str, Any] = {}
@@ -228,7 +241,7 @@ async def update_account(
         "trading_hours_start",
         "trading_hours_end",
     ):
-        value = getattr(body, field_name, None)
+        value = getattr(parsed, field_name, None)
         if value is not None:
             fields[field_name] = value
 
@@ -332,28 +345,31 @@ async def activate_account(
 
 @router.delete(
     "/{account_id}",
+    status_code=409,
+    response_model=ErrorResponse,
     responses={
         409: {
+            "model": ErrorResponse,
             "description": (
                 "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER "
                 "— 런타임 계좌 삭제 차단"
-            )
+            ),
         },
     },
 )
-async def delete_account(
-    account_id: str,
-    request: Request,
-    account_service: Annotated[Any, Depends(get_account_service)],
-    audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
-) -> None:
+async def delete_account(account_id: str, request: Request) -> ErrorResponse:
     """계좌 소프트 딜리트.
 
     런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.
     실제 계좌 삭제는 서버 정지 상태에서 ``ante account delete`` CLI로
-    수행한다. service-layer 회귀 보호는 ``tests/unit/test_account.py``의
-    ``test_delete_account``, ``test_delete_already_deleted_account_raises``가
-    담당한다.
+    수행한다.
+
+    의존성/audit logger를 시그니처에서 제외해 핸들러 진입 즉시 409가
+    반환되도록 한다(invariant I1). OpenAPI에는 success contract(200/201/
+    204)가 노출되지 않으며, 응답 모델은 ``ErrorResponse``로 고정된다
+    (invariant I2/I3). service-layer 회귀 보호는
+    ``tests/unit/test_account.py``의 ``test_delete_account``,
+    ``test_delete_already_deleted_account_raises``가 담당한다.
     """
     raise HTTPException(
         status_code=409,

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -172,21 +172,23 @@ async def get_account(
     "/{account_id}",
     response_model=AccountDetailResponse,
     responses={
-        400: {"description": "수정할 필드가 없음"},
-        404: {"description": "계좌를 찾을 수 없음"},
+        400: {"model": ErrorResponse, "description": "수정할 필드가 없음"},
+        404: {"model": ErrorResponse, "description": "계좌를 찾을 수 없음"},
         409: {
+            "model": ErrorResponse,
             "description": (
                 "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER "
                 "(런타임 구조 변경 차단) 또는 삭제된 계좌 수정 시도"
-            )
+            ),
         },
         422: {
+            "model": ErrorResponse,
             "description": (
                 "비구조(mutable) 필드 schema 검증 실패. "
                 "structural 필드 키는 422가 아닌 409로 차단된다."
-            )
+            ),
         },
-        503: {"description": "Account service not available"},
+        503: {"model": ErrorResponse, "description": "Account service not available"},
     },
 )
 async def update_account(

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -30,6 +30,34 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+# Cold-path 전용 필드: 서버 실행 중에는 변경할 수 없다.
+# 출처: docs/specs/account/04-account-service.md 51-58줄.
+# - credentials, broker_config, buy_commission_rate, sell_commission_rate:
+#   broker adapter 재초기화가 필요한 필드
+# - exchange, currency, trading_mode, broker_type:
+#   계좌 생성 후 불변 필드 (구조 변경 시 모든 소비자 재구성 필요)
+STRUCTURAL_FIELDS: tuple[str, ...] = (
+    "credentials",
+    "broker_config",
+    "buy_commission_rate",
+    "sell_commission_rate",
+    "broker_type",
+    "exchange",
+    "currency",
+    "trading_mode",
+)
+
+# 응답 detail prefix로 노출되는 cold-path 식별자.
+# 클라이언트는 이 prefix로 cold-path 응답과 다른 409 경로(예: 삭제된 계좌
+# 수정 시도)를 구분한다.
+STRUCTURAL_CHANGE_ERROR_CODE = "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER"
+
+
+def _cold_path_detail(message: str) -> str:
+    """Cold-path 차단 응답의 표준 detail 문자열을 만든다."""
+    return f"{STRUCTURAL_CHANGE_ERROR_CODE}: {message}"
+
+
 def _account_to_response(account: Any) -> dict[str, Any]:
     """Account 객체를 AccountResponse 호환 dict로 변환.
 
@@ -85,101 +113,42 @@ async def list_accounts(
     return {"accounts": [_account_to_response(a) for a in accounts]}
 
 
-@router.post("", response_model=AccountDetailResponse, status_code=201)
+@router.post(
+    "",
+    response_model=AccountDetailResponse,
+    status_code=201,
+    responses={
+        409: {
+            "description": (
+                "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER "
+                "— 런타임 계좌 생성 차단"
+            )
+        },
+    },
+)
 async def create_account(
     body: AccountCreateRequest,
     request: Request,
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict[str, Any]:
-    """계좌 생성."""
-    from ante.account.errors import (
-        AccountAlreadyExistsError,
-        InvalidBrokerTypeError,
-        MissingCredentialsError,
+    """계좌 생성.
+
+    런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.
+    실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로
+    수행한다.
+    """
+    # 다른 검증/서비스 호출 전, 진입 즉시 cold-path 409 응답.
+    # AccountService 생성 호출, broker connect, 감사 로그 모두 발생하지 않는다.
+    # 이 경로의 회귀 보호는 service-layer 테스트(`tests/unit/test_account.py`)가
+    # 담당한다.
+    raise HTTPException(
+        status_code=409,
+        detail=_cold_path_detail(
+            "계좌 생성은 cold-path 전용입니다. "
+            "서버를 정지한 뒤 ante account create로 수행하세요."
+        ),
     )
-    from ante.account.models import Account, TradingMode
-    from ante.account.presets import BROKER_PRESETS
-
-    # broker_type에서 프리셋 기본값 적용
-    preset = BROKER_PRESETS.get(body.broker_type)
-
-    try:
-        trading_mode = TradingMode(body.trading_mode)
-    except ValueError:
-        raise HTTPException(
-            status_code=400,
-            detail=f"유효하지 않은 trading_mode: '{body.trading_mode}'",
-        )
-
-    from decimal import Decimal
-
-    account = Account(
-        account_id=body.account_id,
-        name=body.name,
-        exchange=body.exchange or (preset.exchange if preset else ""),
-        currency=body.currency or (preset.currency if preset else ""),
-        timezone=body.timezone or (preset.timezone if preset else "Asia/Seoul"),
-        trading_hours_start=body.trading_hours_start
-        or (preset.trading_hours_start if preset else "09:00"),
-        trading_hours_end=body.trading_hours_end
-        or (preset.trading_hours_end if preset else "15:30"),
-        trading_mode=trading_mode,
-        broker_type=body.broker_type,
-        credentials=body.credentials,
-        broker_config=body.broker_config,
-        buy_commission_rate=Decimal(str(body.buy_commission_rate))
-        if body.buy_commission_rate
-        else (preset.buy_commission_rate if preset else Decimal("0")),
-        sell_commission_rate=Decimal(str(body.sell_commission_rate))
-        if body.sell_commission_rate
-        else (preset.sell_commission_rate if preset else Decimal("0")),
-    )
-
-    try:
-        created = await account_service.create(account)
-    except InvalidBrokerTypeError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except AccountAlreadyExistsError as e:
-        raise HTTPException(status_code=409, detail=str(e))
-    except MissingCredentialsError as e:
-        raise HTTPException(status_code=422, detail=str(e))
-
-    # 브로커 어댑터 인스턴스 생성 가능 여부 검증
-    # BROKER_REGISTRY에 미등록된 타입은 생성 직후 롤백
-    try:
-        broker = await account_service.get_broker(created.account_id)
-    except InvalidBrokerTypeError as e:
-        await account_service.delete(created.account_id, deleted_by="system")
-        raise HTTPException(status_code=400, detail=str(e))
-
-    # 런타임 계좌 추가 직후 /api/system/health와 APIGateway 호출이 즉시
-    # 동작하도록 새 브로커를 connect한다. 부팅 시 _init_gateway와 동일한
-    # best-effort 정책 — connect 실패는 계좌 자체를 롤백하지 않고 경고만
-    # 로그에 남긴다. 실패 시 /health가 broker=false로 떨어져 운영자가
-    # 자격증명/설정을 교정한 뒤 재시도할 수 있게 한다. 이 connect 호출이
-    # 없으면 신규 계좌가 추가된 인스턴스의 /health가 재시작 전까지 영구적
-    # 으로 unhealthy가 되는 회귀가 발생한다.
-    try:
-        await broker.connect()
-    except Exception:
-        logger.warning(
-            "신규 계좌 브로커 connect 실패: account=%s — /health가 "
-            "broker=false를 보고할 수 있습니다.",
-            created.account_id,
-            exc_info=True,
-        )
-
-    if audit_logger:
-        await audit_logger.log(
-            member_id=getattr(request.state, "member_id", "dashboard"),
-            action="account.create",
-            resource=f"account:{created.account_id}",
-            detail=f"계좌 생성: {created.account_id} ({created.broker_type})",
-            ip=request.client.host if request.client else "",
-        )
-
-    return {"account": _account_to_response(created)}
 
 
 @router.get("/{account_id}", response_model=AccountDetailResponse)
@@ -202,13 +171,12 @@ async def get_account(
     "/{account_id}",
     response_model=AccountDetailResponse,
     responses={
-        400: {"description": "수정할 필드가 없거나 불변 필드 수정 시도"},
+        400: {"description": "수정할 필드가 없음"},
         404: {"description": "계좌를 찾을 수 없음"},
-        409: {"description": "삭제된 계좌 수정 시도"},
-        503: {
+        409: {
             "description": (
-                "DB에는 계좌 정보가 저장되었으나 새 설정으로 브로커 재연결에 "
-                "실패한 부분 성공 상태. 자격증명/브로커 설정을 확인한 뒤 재시도."
+                "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER "
+                "(런타임 구조 변경 차단) 또는 삭제된 계좌 수정 시도"
             )
         },
     },
@@ -220,36 +188,44 @@ async def update_account(
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict[str, Any]:
-    """계좌 수정."""
+    """계좌 수정.
+
+    런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,
+    ``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도
+    포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는
+    ``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path
+    응답과 ``AccountDeletedError`` 경로의 409를 구분한다.
+    """
     from ante.account.errors import (
         AccountDeletedError,
-        AccountImmutableFieldError,
         AccountNotFoundError,
-        BrokerReconnectFailedError,
     )
 
-    # None이 아닌 필드만 업데이트 대상
+    # cold-path 가드: structural 필드가 하나라도 명시(`is not None`)되면
+    # DB/서비스 호출 전 409로 즉시 차단한다.
+    # 가드 이후의 service.update는 비구조 필드만 받으므로
+    # AccountImmutableFieldError/BrokerReconnectFailedError 경로에 도달하지
+    # 않는다. 해당 service-layer 동작 회귀는 `tests/unit/test_account.py`,
+    # `tests/unit/test_account_immutable_fields.py`가 보호한다.
+    triggered_structural = [
+        name for name in STRUCTURAL_FIELDS if getattr(body, name, None) is not None
+    ]
+    if triggered_structural:
+        raise HTTPException(
+            status_code=409,
+            detail=_cold_path_detail(
+                f"다음 필드는 cold-path 전용입니다: {', '.join(triggered_structural)}"
+            ),
+        )
+
+    # None이 아닌 비구조 필드만 업데이트 대상
     fields: dict[str, Any] = {}
     for field_name in (
         "name",
         "timezone",
         "trading_hours_start",
         "trading_hours_end",
-        "credentials",
-        "broker_config",
-        "buy_commission_rate",
-        "sell_commission_rate",
     ):
-        value = getattr(body, field_name, None)
-        if value is not None:
-            if field_name in ("buy_commission_rate", "sell_commission_rate"):
-                from decimal import Decimal
-
-                value = Decimal(str(value))
-            fields[field_name] = value
-
-    # 불변 필드가 요청에 포함된 경우 서비스 레이어에서 차단하도록 전달
-    for field_name in ("exchange", "currency", "trading_mode", "broker_type"):
         value = getattr(body, field_name, None)
         if value is not None:
             fields[field_name] = value
@@ -263,20 +239,6 @@ async def update_account(
         raise HTTPException(status_code=404, detail=str(e))
     except AccountDeletedError as e:
         raise HTTPException(status_code=409, detail=str(e))
-    except AccountImmutableFieldError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except BrokerReconnectFailedError as e:
-        # 계좌 정보는 DB에 반영됐지만 새 설정으로 브로커를 재연결하지
-        # 못한 부분 실패 상태. 503으로 명시해 운영자가 자격증명/설정을
-        # 교정 후 재시도하도록 유도한다. 캐시에는 기존 브로커가 그대로
-        # 남아 있어 기존 연결 기반 호출은 계속 동작한다.
-        raise HTTPException(
-            status_code=503,
-            detail=(
-                f"{e} 계좌 정보는 저장되었으나 브로커 재연결에 실패했습니다. "
-                "자격증명/브로커 설정을 확인한 뒤 다시 시도하세요."
-            ),
-        )
 
     if audit_logger:
         await audit_logger.log(
@@ -366,31 +328,39 @@ async def activate_account(
     }
 
 
-@router.delete("/{account_id}", status_code=204)
+@router.delete(
+    "/{account_id}",
+    status_code=204,
+    responses={
+        409: {
+            "description": (
+                "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER "
+                "— 런타임 계좌 삭제 차단"
+            )
+        },
+    },
+)
 async def delete_account(
     account_id: str,
     request: Request,
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> None:
-    """계좌 소프트 딜리트."""
-    from ante.account.errors import AccountNotFoundError
+    """계좌 소프트 딜리트.
 
-    deleted_by = getattr(request.state, "member_id", "dashboard")
-
-    try:
-        await account_service.delete(account_id, deleted_by=deleted_by)
-    except AccountNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-
-    if audit_logger:
-        await audit_logger.log(
-            member_id=deleted_by,
-            action="account.delete",
-            resource=f"account:{account_id}",
-            detail="계좌 삭제",
-            ip=request.client.host if request.client else "",
-        )
+    런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.
+    실제 계좌 삭제는 서버 정지 상태에서 ``ante account delete`` CLI로
+    수행한다. service-layer 회귀 보호는 ``tests/unit/test_account.py``의
+    ``test_delete_account``, ``test_delete_already_deleted_account_raises``가
+    담당한다.
+    """
+    raise HTTPException(
+        status_code=409,
+        detail=_cold_path_detail(
+            "계좌 삭제는 cold-path 전용입니다. "
+            "서버를 정지한 뒤 ante account delete로 수행하세요."
+        ),
+    )
 
 
 # ── 리스크 룰 ─────────────────────────────────────────

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
+from pydantic import ValidationError
 
 from ante.web.deps import (
     get_account_service,
@@ -17,8 +19,8 @@ from ante.web.schemas import (
     AccountActionResponse,
     AccountDetailResponse,
     AccountListResponse,
+    AccountMutableUpdateRequest,
     AccountSuspendRequest,
-    AccountUpdateRequest,
     ErrorResponse,
     RuleListResponse,
     RuleUpdateRequest,
@@ -179,6 +181,12 @@ async def get_account(
                 "(런타임 구조 변경 차단) 또는 삭제된 계좌 수정 시도"
             )
         },
+        422: {
+            "description": (
+                "비구조(mutable) 필드 schema 검증 실패. "
+                "structural 필드 키는 422가 아닌 409로 차단된다."
+            )
+        },
     },
 )
 async def update_account(
@@ -186,7 +194,7 @@ async def update_account(
     request: Request,
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
-    body: dict[str, Any] | None = Body(default=None),
+    body: AccountMutableUpdateRequest | None = Body(default=None),
 ) -> dict[str, Any]:
     """계좌 수정.
 
@@ -196,18 +204,46 @@ async def update_account(
     ``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path
     응답과 ``AccountDeletedError`` 경로의 409를 구분한다.
 
-    body는 검증되지 않은 raw ``dict``로 받는다(invariant I4). 가드 판정은
-    Pydantic이 변환한 값(``is not None``)이 아니라 **요청 body의 키 존재
-    여부**로 수행하므로, ``{"credentials": null}``처럼 명시적으로 null을
-    보낸 경우와 ``{"buy_commission_rate": "bad"}``처럼 structural 필드가 타입
-    오류인 경우 모두 cold-path 가드보다 먼저 422가 발생하지 않는다. 비구조
-    필드만 추출한 dict로 ``AccountUpdateRequest.model_validate(...)``를 호출해
-    기존 200/404/400/409(deleted) 분기를 보존한다.
+    OpenAPI 노출용 body schema는 ``AccountMutableUpdateRequest``를 사용해
+    mutable 4 필드만 클라이언트에게 노출한다(P3 schema accuracy). 단, raw
+    payload key 가드(I4)를 보존하기 위해 라우트 본문에서는 ``body`` 인자를
+    사용하지 않고 ``await request.json()``으로 raw dict를 직접 읽는다 —
+    Pydantic이 정의 외 키(예: ``credentials``)를 모델 인스턴스에서 제거해도
+    structural 키 존재 여부 판정이 우회되지 않아야 하기 때문이다.
+
+    비구조 필드는 raw payload에서 cold-path 가드를 통과한 뒤
+    ``AccountMutableUpdateRequest.model_validate(...)``로 재검증하며, 이
+    단계에서 발생하는 ``ValidationError``는 422 ``HTTPException``으로 명시
+    변환된다(P2 — 회귀 보호). 이전 attempt에서는 이 경로가 FastAPI의
+    자동 ``RequestValidationError`` 422를 잃어 422 contract가 회귀했다.
     """
     from ante.account.errors import (
         AccountDeletedError,
         AccountNotFoundError,
     )
+
+    # body 인자는 OpenAPI requestBody schema 노출용으로만 선언되며,
+    # 실제 cold-path 가드는 raw payload key 검사로 수행한다(invariant I4).
+    # FastAPI가 이미 body를 한 번 소비했더라도 Starlette가 raw bytes를
+    # 캐싱하므로 `request.body()`는 같은 payload를 다시 돌려준다.
+    _ = body  # OpenAPI schema 전용 — 라우트 본문에서는 raw payload만 사용한다.
+
+    raw_bytes = await request.body()
+    if raw_bytes:
+        try:
+            raw_payload = json.loads(raw_bytes)
+        except json.JSONDecodeError as e:
+            raise HTTPException(
+                status_code=422,
+                detail=f"요청 본문이 유효한 JSON이 아닙니다: {e.msg}",
+            )
+        if not isinstance(raw_payload, dict):
+            raise HTTPException(
+                status_code=422,
+                detail="요청 본문은 JSON object 여야 합니다.",
+            )
+    else:
+        raw_payload = {}
 
     # cold-path 가드: structural 필드 키가 raw payload에 하나라도 등장하면
     # DB/서비스 호출 전 409로 즉시 차단한다(invariant I1/I4). 값이 null이거나
@@ -216,8 +252,7 @@ async def update_account(
     # AccountImmutableFieldError/BrokerReconnectFailedError 경로에 도달하지
     # 않는다. service-layer 동작 회귀는 `tests/unit/test_account.py`,
     # `tests/unit/test_account_immutable_fields.py`가 보호한다.
-    payload = body or {}
-    structural_hits = sorted(set(payload) & set(STRUCTURAL_FIELDS))
+    structural_hits = sorted(set(raw_payload) & set(STRUCTURAL_FIELDS))
     if structural_hits:
         raise HTTPException(
             status_code=409,
@@ -226,24 +261,21 @@ async def update_account(
             ),
         )
 
-    # 비구조 필드만 모아 Pydantic으로 재검증. 알 수 없는 키는 Pydantic이
-    # 무시(extra='ignore' 기본)하므로 cold-path 가드 통과 후에도 안전하다.
-    non_structural_payload = {
-        k: v for k, v in payload.items() if k not in STRUCTURAL_FIELDS
+    # 비구조 필드만 모아 mutable schema로 재검증. structural 키는 위 가드에서
+    # 이미 걸렀고, mutable 모델에는 정의되어 있지 않다. 알 수 없는 추가 키는
+    # Pydantic 기본(extra='ignore')으로 무시된다.
+    mutable_payload = {
+        k: v for k, v in raw_payload.items() if k not in STRUCTURAL_FIELDS
     }
-    parsed = AccountUpdateRequest.model_validate(non_structural_payload)
+    try:
+        parsed = AccountMutableUpdateRequest.model_validate(mutable_payload)
+    except ValidationError as e:
+        # FastAPI 자동 422와 동일한 구조화 에러를 반환해 클라이언트가 422를
+        # 잃지 않도록 한다(P2 회귀 보호).
+        raise HTTPException(status_code=422, detail=e.errors())
 
-    # None이 아닌 비구조 필드만 업데이트 대상
-    fields: dict[str, Any] = {}
-    for field_name in (
-        "name",
-        "timezone",
-        "trading_hours_start",
-        "trading_hours_end",
-    ):
-        value = getattr(parsed, field_name, None)
-        if value is not None:
-            fields[field_name] = value
+    # None이 아닌 비구조 필드만 업데이트 대상.
+    fields = parsed.model_dump(exclude_none=True)
 
     if not fields:
         raise HTTPException(status_code=400, detail="수정할 필드가 없습니다.")

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Annotated, Any
 
@@ -194,7 +193,7 @@ async def update_account(
     request: Request,
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
-    body: AccountMutableUpdateRequest | None = Body(default=None),
+    body: dict[str, Any] | None = Body(default=None),
 ) -> dict[str, Any]:
     """계좌 수정.
 
@@ -204,55 +203,32 @@ async def update_account(
     ``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path
     응답과 ``AccountDeletedError`` 경로의 409를 구분한다.
 
-    OpenAPI 노출용 body schema는 ``AccountMutableUpdateRequest``를 사용해
-    mutable 4 필드만 클라이언트에게 노출한다(P3 schema accuracy). 단, raw
-    payload key 가드(I4)를 보존하기 위해 라우트 본문에서는 ``body`` 인자를
-    사용하지 않고 ``await request.json()``으로 raw dict를 직접 읽는다 —
-    Pydantic이 정의 외 키(예: ``credentials``)를 모델 인스턴스에서 제거해도
-    structural 키 존재 여부 판정이 우회되지 않아야 하기 때문이다.
-
-    비구조 필드는 raw payload에서 cold-path 가드를 통과한 뒤
-    ``AccountMutableUpdateRequest.model_validate(...)``로 재검증하며, 이
-    단계에서 발생하는 ``ValidationError``는 422 ``HTTPException``으로 명시
-    변환된다(P2 — 회귀 보호). 이전 attempt에서는 이 경로가 FastAPI의
-    자동 ``RequestValidationError`` 422를 잃어 422 contract가 회귀했다.
+    body는 자유 ``dict[str, Any] | None``로 받는다. FastAPI 선행 Pydantic
+    검증이 켜지면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가
+    structural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.
+    핸들러 본문에서는 raw payload key 검사로 cold-path 가드를 먼저 수행한 뒤,
+    비구조 필드만 ``AccountMutableUpdateRequest.model_validate(...)``로
+    재검증한다. 이 단계의 ``ValidationError``는 422 ``HTTPException``으로
+    명시 변환된다(P2 — 회귀 보호). PUT requestBody의 OpenAPI schema accuracy
+    회복(mutable 모델 노출)은 후속 이슈 #1143에서 다룬다.
     """
     from ante.account.errors import (
         AccountDeletedError,
         AccountNotFoundError,
     )
 
-    # body 인자는 OpenAPI requestBody schema 노출용으로만 선언되며,
-    # 실제 cold-path 가드는 raw payload key 검사로 수행한다(invariant I4).
-    # FastAPI가 이미 body를 한 번 소비했더라도 Starlette가 raw bytes를
-    # 캐싱하므로 `request.body()`는 같은 payload를 다시 돌려준다.
-    _ = body  # OpenAPI schema 전용 — 라우트 본문에서는 raw payload만 사용한다.
+    # body는 dict로 직접 받으므로 별도 raw bytes 파싱이 필요 없다.
+    # FastAPI는 JSON 파싱 실패 / non-dict body를 자동 422로 처리한다.
+    payload = body or {}
 
-    raw_bytes = await request.body()
-    if raw_bytes:
-        try:
-            raw_payload = json.loads(raw_bytes)
-        except json.JSONDecodeError as e:
-            raise HTTPException(
-                status_code=422,
-                detail=f"요청 본문이 유효한 JSON이 아닙니다: {e.msg}",
-            )
-        if not isinstance(raw_payload, dict):
-            raise HTTPException(
-                status_code=422,
-                detail="요청 본문은 JSON object 여야 합니다.",
-            )
-    else:
-        raw_payload = {}
-
-    # cold-path 가드: structural 필드 키가 raw payload에 하나라도 등장하면
+    # cold-path 가드: structural 필드 키가 payload에 하나라도 등장하면
     # DB/서비스 호출 전 409로 즉시 차단한다(invariant I1/I4). 값이 null이거나
     # 타입이 잘못돼도 동일하게 차단된다 — Pydantic 검증을 통과한 값이 아니라
     # 키 존재 여부만 본다. 가드 이후의 service.update는 비구조 필드만 받으므로
     # AccountImmutableFieldError/BrokerReconnectFailedError 경로에 도달하지
     # 않는다. service-layer 동작 회귀는 `tests/unit/test_account.py`,
     # `tests/unit/test_account_immutable_fields.py`가 보호한다.
-    structural_hits = sorted(set(raw_payload) & set(STRUCTURAL_FIELDS))
+    structural_hits = sorted(set(payload) & set(STRUCTURAL_FIELDS))
     if structural_hits:
         raise HTTPException(
             status_code=409,
@@ -264,9 +240,10 @@ async def update_account(
     # 비구조 필드만 모아 mutable schema로 재검증. structural 키는 위 가드에서
     # 이미 걸렀고, mutable 모델에는 정의되어 있지 않다. 알 수 없는 추가 키는
     # Pydantic 기본(extra='ignore')으로 무시된다.
-    mutable_payload = {
-        k: v for k, v in raw_payload.items() if k not in STRUCTURAL_FIELDS
-    }
+    mutable_payload = {k: v for k, v in payload.items() if k not in STRUCTURAL_FIELDS}
+    if not mutable_payload:
+        raise HTTPException(status_code=400, detail="수정할 필드가 없습니다.")
+
     try:
         parsed = AccountMutableUpdateRequest.model_validate(mutable_payload)
     except ValidationError as e:

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -73,7 +73,13 @@ class AccountCreateRequest(BaseModel):
 
 
 class AccountUpdateRequest(BaseModel):
-    """계좌 수정 요청."""
+    """계좌 수정 요청.
+
+    하위 호환을 위해 모든 필드를 옵션으로 노출하지만, 런타임 PUT 라우트는
+    structural 필드를 cold-path로 차단한다. 런타임 mutable 4 필드만 노출하는
+    schema는 ``AccountMutableUpdateRequest``를 참고한다. 이 모델은 다른
+    소비자(테스트, CLI 등)와의 하위 호환을 위해 유지한다.
+    """
 
     name: str | None = None
     exchange: str | None = None
@@ -87,6 +93,26 @@ class AccountUpdateRequest(BaseModel):
     broker_config: dict[str, Any] | None = None
     buy_commission_rate: float | None = None
     sell_commission_rate: float | None = None
+
+
+class AccountMutableUpdateRequest(BaseModel):
+    """런타임에 PUT /api/accounts/{id}로 수정 가능한 비구조 필드만 노출.
+
+    구조(structural) 필드(``credentials``, ``broker_config``,
+    ``buy_commission_rate``, ``sell_commission_rate``, ``broker_type``,
+    ``exchange``, ``currency``, ``trading_mode``)는 cold-path 전용이므로 이
+    모델에 포함하지 않는다. OpenAPI/타입 생성 소비자에게는 mutable 4 필드만
+    노출되어 schema accuracy가 회복된다.
+
+    라우트는 raw payload(`request.json()`)에서 structural 키 가드를 먼저
+    수행한 뒤(invariant I4) 비구조 필드만 이 모델로 검증한다. 이 단계의
+    ``ValidationError``는 422로 명시 변환된다.
+    """
+
+    name: str | None = None
+    timezone: str | None = None
+    trading_hours_start: str | None = None
+    trading_hours_end: str | None = None
 
 
 class AccountSuspendRequest(BaseModel):

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -76,9 +76,9 @@ class AccountUpdateRequest(BaseModel):
     """계좌 수정 요청.
 
     하위 호환을 위해 모든 필드를 옵션으로 노출하지만, 런타임 PUT 라우트는
-    structural 필드를 cold-path로 차단한다. 런타임 mutable 4 필드만 노출하는
-    schema는 ``AccountMutableUpdateRequest``를 참고한다. 이 모델은 다른
-    소비자(테스트, CLI 등)와의 하위 호환을 위해 유지한다.
+    structural 필드를 cold-path로 차단한다. 이 모델은 다른 소비자(테스트,
+    CLI 등)와의 하위 호환을 위해 유지한다. PUT requestBody의 schema accuracy
+    회복(mutable 모델 노출)은 후속 이슈 #1143에서 다룬다.
     """
 
     name: str | None = None
@@ -93,26 +93,6 @@ class AccountUpdateRequest(BaseModel):
     broker_config: dict[str, Any] | None = None
     buy_commission_rate: float | None = None
     sell_commission_rate: float | None = None
-
-
-class AccountMutableUpdateRequest(BaseModel):
-    """런타임에 PUT /api/accounts/{id}로 수정 가능한 비구조 필드만 노출.
-
-    구조(structural) 필드(``credentials``, ``broker_config``,
-    ``buy_commission_rate``, ``sell_commission_rate``, ``broker_type``,
-    ``exchange``, ``currency``, ``trading_mode``)는 cold-path 전용이므로 이
-    모델에 포함하지 않는다. OpenAPI/타입 생성 소비자에게는 mutable 4 필드만
-    노출되어 schema accuracy가 회복된다.
-
-    라우트는 raw payload(`request.json()`)에서 structural 키 가드를 먼저
-    수행한 뒤(invariant I4) 비구조 필드만 이 모델로 검증한다. 이 단계의
-    ``ValidationError``는 422로 명시 변환된다.
-    """
-
-    name: str | None = None
-    timezone: str | None = None
-    trading_hours_start: str | None = None
-    trading_hours_end: str | None = None
 
 
 class AccountSuspendRequest(BaseModel):

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -301,6 +301,50 @@ class TestCreateAccount:
         ]
         assert create_logs == []
 
+    def test_create_blocked_with_empty_body_409(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """빈 body여도 422가 아니라 409로 차단된다.
+
+        라우트는 body schema를 받지 않으므로 FastAPI의 body validation
+        단계가 사라져 입력 valid 여부와 무관하게 cold-path 409가 일관되게
+        반환된다.
+        """
+        resp = client.post("/api/accounts", json={})
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert account_service._accounts == {}
+        assert account_service._brokers == {}
+        create_logs = [
+            log for log in audit_logger.logs if log["action"] == "account.create"
+        ]
+        assert create_logs == []
+
+    def test_create_blocked_with_invalid_body_409(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """알 수 없는 키만 들어간 body여도 422가 아니라 409로 차단된다.
+
+        cold-path 가드는 모든 입력 형태에 대해 같은 409 응답을 보장한다.
+        """
+        resp = client.post("/api/accounts", json={"unknown": "x"})
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert account_service._accounts == {}
+        assert account_service._brokers == {}
+        create_logs = [
+            log for log in audit_logger.logs if log["action"] == "account.create"
+        ]
+        assert create_logs == []
+
 
 class TestGetAccount:
     """GET /api/accounts/:id."""

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -772,8 +772,8 @@ class TestUpdateAccount:
     ) -> None:
         """JSON 파싱 자체가 실패하면 422.
 
-        FastAPI는 보통 자동 처리하지만, 이 라우트는 raw body를 직접 읽으므로
-        파싱 실패 경로가 라우트 본문에서 422로 변환되는지 보장한다.
+        body가 ``dict[str, Any] | None``이므로 FastAPI의 자동
+        ``RequestValidationError`` 처리가 422를 보장한다.
         """
         account = _make_account()
         account_service._accounts[account.account_id] = account
@@ -792,8 +792,9 @@ class TestUpdateAccount:
     ) -> None:
         """JSON object가 아닌 body(예: 배열, 문자열)는 422.
 
-        라우트는 dict 형태의 raw payload만 허용한다 — structural 키 가드와
-        mutable schema 검증 모두 dict 가정에 의존한다.
+        body가 ``dict[str, Any] | None``으로 선언되어 있으므로 FastAPI가
+        non-dict JSON을 자동 422로 처리한다 — structural 키 가드와 mutable
+        schema 검증 모두 dict 가정에 의존하기 때문이다.
         """
         account = _make_account()
         account_service._accounts[account.account_id] = account
@@ -804,50 +805,40 @@ class TestUpdateAccount:
         )
         assert resp.status_code == 422
 
-
-class TestUpdateAccountOpenAPISchema:
-    """PUT /api/accounts/:id의 OpenAPI requestBody schema 노출 보호 (P3).
-
-    런타임 mutable 4 필드만 노출하는 ``AccountMutableUpdateRequest``가
-    requestBody schema로 노출되어야 한다. 이전 attempt에서는 body가
-    ``dict[str, Any] | None``이라 schema accuracy를 잃었다.
-    """
-
-    def test_openapi_put_uses_mutable_update_request(
+    def test_update_blocks_when_structural_with_invalid_mutable_returns_409(
         self,
         client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
     ) -> None:
-        """OpenAPI document의 PUT requestBody가 mutable 모델을 참조한다."""
-        resp = client.get("/openapi.json")
-        assert resp.status_code == 200
-        spec = resp.json()
+        """structural 키 + 잘못된 mutable 타입이 같이 와도 cold-path 409 우선.
 
-        path = spec["paths"]["/api/accounts/{account_id}"]["put"]
-        request_body_schema = path["requestBody"]["content"]["application/json"][
-            "schema"
-        ]
-        # anyOf wrapper로 nullable 표현될 수 있다.
-        if "anyOf" in request_body_schema:
-            refs = [
-                item.get("$ref", "")
-                for item in request_body_schema["anyOf"]
-                if "$ref" in item
-            ]
-        else:
-            refs = [request_body_schema.get("$ref", "")]
-        assert any("AccountMutableUpdateRequest" in ref for ref in refs), (
-            f"expected AccountMutableUpdateRequest reference, got {refs}"
+        attempt 4의 P2 finding 회귀 보호. 구조 필드 가드는 mutable schema
+        검증보다 먼저 실행되어야 한다 — ``credentials`` 키가 등장한 시점에
+        cold-path 위반이 확정되며, 같은 페이로드에 schema 검증 실패 트리거가
+        있어도 응답은 422가 아닌 409여야 한다.
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"credentials": {"app_key": "x"}, "timezone": {}},
         )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "credentials" in detail
+        # service.update 미호출 — 계좌 timezone 보존
+        assert account_service._accounts["test-account"].timezone == "Asia/Seoul"
+        # audit 미발행
+        assert [
+            log for log in audit_logger.logs if log["action"] == "account.update"
+        ] == []
 
-        # mutable 모델 정의 확인 — mutable 4 필드만 노출되어야 한다.
-        mutable_schema = spec["components"]["schemas"]["AccountMutableUpdateRequest"]
-        properties = set(mutable_schema.get("properties", {}).keys())
-        assert properties == {
-            "name",
-            "timezone",
-            "trading_hours_start",
-            "trading_hours_end",
-        }
+
+# PUT requestBody schema accuracy(mutable 모델 노출)는 issue #1143에서 처리.
+# 본 이슈는 cold-path invariant(I1~I4)와 P2(ValidationError 422)에 한정한다.
 
 
 class TestSuspendAccount:

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -345,6 +345,30 @@ class TestCreateAccount:
         ]
         assert create_logs == []
 
+    def test_create_account_returns_409_without_account_service(self) -> None:
+        """AccountService가 미주입된 환경에서도 503이 아니라 409여야 한다.
+
+        invariant I1: 핸들러는 어떤 의존성보다 먼저 cold-path 409를 raise해야
+        하므로, ``app.state.account_service``가 None이어도 503으로 새지 않는다.
+        ``get_account_service`` 의존성을 시그니처에서 제거한 게 회귀 차단의
+        본질이며, 이 테스트가 그 invariant를 직접 단언한다.
+        """
+        app = create_app()  # account_service 미주입
+        # account_service 미주입 확인
+        assert getattr(app.state, "account_service", None) is None
+        with TestClient(app) as bare_client:
+            resp = bare_client.post(
+                "/api/accounts",
+                json={
+                    "account_id": "x",
+                    "name": "x",
+                    "broker_type": "test",
+                },
+            )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+
 
 class TestGetAccount:
     """GET /api/accounts/:id."""
@@ -612,6 +636,87 @@ class TestUpdateAccount:
         assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
         assert "trading_mode" in detail
 
+    def test_update_blocks_when_structural_field_is_null_explicitly(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """structural 필드가 명시적으로 null이어도 cold-path 409로 차단된다.
+
+        invariant I4: 가드는 검증된 Pydantic 값(``is not None``)이 아니라 raw
+        body의 키 존재 여부로 판정한다. ``credentials: null``이라도 키가 등장
+        했다는 사실이 cold-path 위반이며, Pydantic이 None으로 정규화한다고
+        해서 우회되어선 안 된다.
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+        original_name = account.name
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"name": "변경 시도", "credentials": None},
+        )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "credentials" in detail
+        # 비구조 필드(name)도 함께 차단되었는지 확인 — service.update 미호출.
+        assert account_service._accounts["test-account"].name == original_name
+        assert [
+            log for log in audit_logger.logs if log["action"] == "account.update"
+        ] == []
+
+    def test_update_blocks_when_structural_field_has_type_error(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """structural 필드 타입이 잘못돼도 422가 아니라 409로 차단된다.
+
+        invariant I4: 가드는 Pydantic 검증보다 먼저 raw 키만 확인하므로,
+        ``buy_commission_rate: "bad"``처럼 타입이 어긋나도 cold-path 409가
+        나와야 한다. 만약 422가 먼저 나온다면 cold-path 가드가 schema
+        validation에 의해 우회되는 상황이다.
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"buy_commission_rate": "bad"},
+        )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "buy_commission_rate" in detail
+        assert [
+            log for log in audit_logger.logs if log["action"] == "account.update"
+        ] == []
+
+    def test_update_blocks_when_payload_has_unknown_structural_extras(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """structural 키와 unknown 키가 섞여도 cold-path 409가 우선한다.
+
+        Pydantic이 무시할 미지의 필드와 structural 키가 같이 와도,
+        키 존재 여부 가드가 먼저 동작해 409를 보장한다.
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"unknown_field": "x", "exchange": "KRX"},
+        )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "exchange" in detail
+
 
 class TestSuspendAccount:
     """POST /api/accounts/:id/suspend."""
@@ -751,3 +856,18 @@ class TestDeleteAccount:
         assert [
             log for log in audit_logger.logs if log["action"] == "account.delete"
         ] == []
+
+    def test_delete_account_returns_409_without_account_service(self) -> None:
+        """AccountService가 미주입된 환경에서도 503이 아니라 409여야 한다.
+
+        invariant I1: DELETE 핸들러도 ``get_account_service`` 의존성을 거치지
+        않아야 하며, account_service가 None일 때도 cold-path 409가 일관되게
+        반환되어야 한다.
+        """
+        app = create_app()  # account_service 미주입
+        assert getattr(app.state, "account_service", None) is None
+        with TestClient(app) as bare_client:
+            resp = bare_client.delete("/api/accounts/some-id")
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -717,6 +717,138 @@ class TestUpdateAccount:
         assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
         assert "exchange" in detail
 
+    def test_update_invalid_mutable_field_type_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """비구조(mutable) 필드 타입이 잘못되면 422를 반환한다 (P2 회귀 보호).
+
+        ``timezone``은 ``str | None``인데 dict가 들어오면
+        ``AccountMutableUpdateRequest.model_validate``가 ``ValidationError``를
+        던지고, 라우트는 이를 422 ``HTTPException``으로 명시 변환한다.
+        이전 attempt에서는 ``ValidationError``가 그대로 전파되어 클라이언트가
+        FastAPI 자동 422 contract를 잃는 회귀가 있었다.
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"timezone": {}},
+        )
+        assert resp.status_code == 422
+        # service.update 미호출 — 계좌 timezone 보존
+        assert account_service._accounts["test-account"].timezone == "Asia/Seoul"
+        # audit 미발행
+        assert [
+            log for log in audit_logger.logs if log["action"] == "account.update"
+        ] == []
+
+    def test_update_invalid_name_type_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """``name`` 타입 오류도 422 (P2 회귀 보호).
+
+        Pydantic은 dict → str 강제 변환을 허용하지 않으므로 422가 발생해야
+        한다. 422가 아닌 다른 status는 schema validation 회귀 신호다.
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"name": {"nested": "object"}},
+        )
+        assert resp.status_code == 422
+
+    def test_update_invalid_json_body_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """JSON 파싱 자체가 실패하면 422.
+
+        FastAPI는 보통 자동 처리하지만, 이 라우트는 raw body를 직접 읽으므로
+        파싱 실패 경로가 라우트 본문에서 422로 변환되는지 보장한다.
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            content=b"not-valid-json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 422
+
+    def test_update_non_dict_json_body_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """JSON object가 아닌 body(예: 배열, 문자열)는 422.
+
+        라우트는 dict 형태의 raw payload만 허용한다 — structural 키 가드와
+        mutable schema 검증 모두 dict 가정에 의존한다.
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json=["array", "not", "object"],
+        )
+        assert resp.status_code == 422
+
+
+class TestUpdateAccountOpenAPISchema:
+    """PUT /api/accounts/:id의 OpenAPI requestBody schema 노출 보호 (P3).
+
+    런타임 mutable 4 필드만 노출하는 ``AccountMutableUpdateRequest``가
+    requestBody schema로 노출되어야 한다. 이전 attempt에서는 body가
+    ``dict[str, Any] | None``이라 schema accuracy를 잃었다.
+    """
+
+    def test_openapi_put_uses_mutable_update_request(
+        self,
+        client: TestClient,
+    ) -> None:
+        """OpenAPI document의 PUT requestBody가 mutable 모델을 참조한다."""
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        spec = resp.json()
+
+        path = spec["paths"]["/api/accounts/{account_id}"]["put"]
+        request_body_schema = path["requestBody"]["content"]["application/json"][
+            "schema"
+        ]
+        # anyOf wrapper로 nullable 표현될 수 있다.
+        if "anyOf" in request_body_schema:
+            refs = [
+                item.get("$ref", "")
+                for item in request_body_schema["anyOf"]
+                if "$ref" in item
+            ]
+        else:
+            refs = [request_body_schema.get("$ref", "")]
+        assert any("AccountMutableUpdateRequest" in ref for ref in refs), (
+            f"expected AccountMutableUpdateRequest reference, got {refs}"
+        )
+
+        # mutable 모델 정의 확인 — mutable 4 필드만 노출되어야 한다.
+        mutable_schema = spec["components"]["schemas"]["AccountMutableUpdateRequest"]
+        properties = set(mutable_schema.get("properties", {}).keys())
+        assert properties == {
+            "name",
+            "timezone",
+            "trading_hours_start",
+            "trading_hours_end",
+        }
+
 
 class TestSuspendAccount:
     """POST /api/accounts/:id/suspend."""

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -98,7 +98,28 @@ class FakeAccountService:
             accounts = [a for a in accounts if a.status == status]
         return accounts
 
+    # 실제 AccountService.update와 동일한 분류로 비구조 필드를 다룬다.
+    # 라우트는 STRUCTURAL_FIELDS를 cold-path 409로 사전 차단하므로, fake는
+    # service.update가 비구조 분기에 forward 받을 수 있는 키 집합만 다룬다.
+    UPDATABLE_FIELDS = frozenset(
+        {
+            "name",
+            "timezone",
+            "trading_hours_start",
+            "trading_hours_end",
+            "credentials",
+            "broker_config",
+            "buy_commission_rate",
+            "sell_commission_rate",
+        }
+    )
+    IMMUTABLE_FIELDS = frozenset(
+        {"exchange", "currency", "trading_mode", "broker_type"}
+    )
+
     async def update(self, account_id: str, **fields: Any) -> Account:
+        from ante.account.errors import AccountImmutableFieldError
+
         if account_id not in self._accounts:
             raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
         account = self._accounts[account_id]
@@ -106,6 +127,19 @@ class FakeAccountService:
             raise AccountDeletedError(
                 f"삭제된 계좌 '{account_id}'는 수정할 수 없습니다."
             )
+
+        # 실제 service와 동일하게 IMMUTABLE/unknown 필드를 거부한다.
+        attempted_immutable = set(fields.keys()) & self.IMMUTABLE_FIELDS
+        if attempted_immutable:
+            raise AccountImmutableFieldError(
+                f"다음 필드는 수정할 수 없습니다: {sorted(attempted_immutable)}"
+            )
+        unrecognized = (
+            set(fields.keys()) - self.UPDATABLE_FIELDS - self.IMMUTABLE_FIELDS
+        )
+        if unrecognized:
+            raise ValueError(f"인식할 수 없는 필드입니다: {sorted(unrecognized)}")
+
         for key, value in fields.items():
             setattr(account, key, value)
         account.updated_at = datetime.now(UTC)
@@ -717,53 +751,44 @@ class TestUpdateAccount:
         assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
         assert "exchange" in detail
 
-    def test_update_invalid_mutable_field_type_returns_422(
+    def test_update_unknown_mutable_field_forwarded_to_service(
         self,
         client: TestClient,
         account_service: FakeAccountService,
         audit_logger: FakeAuditLogger,
     ) -> None:
-        """비구조(mutable) 필드 타입이 잘못되면 422를 반환한다 (P2 회귀 보호).
+        """알 수 없는 비구조 필드는 service-layer가 거부한다 (글로벌 400 매핑).
 
-        ``timezone``은 ``str | None``인데 dict가 들어오면
-        ``AccountMutableUpdateRequest.model_validate``가 ``ValidationError``를
-        던지고, 라우트는 이를 422 ``HTTPException``으로 명시 변환한다.
-        이전 attempt에서는 ``ValidationError``가 그대로 전파되어 클라이언트가
-        FastAPI 자동 422 contract를 잃는 회귀가 있었다.
+        attempt 8에서 라우트 단 ``AccountMutableUpdateRequest`` 검증이 제거
+        되면서 비구조 필드 schema 검증은 service-layer로 위임된다. structural
+        가드를 통과한 unknown 키는 ``account_service.update``로 그대로 forward
+        되며, 실제 ``AccountService.update``는 unknown field에 ``ValueError``를
+        던진다. 글로벌 예외 핸들러(``app.py``의 ValueError handler)가 이를
+        RFC 7807 400 ``ErrorResponse``로 매핑한다.
+
+        본 테스트는 service-위임 동작과 글로벌 400 매핑을 함께 확인한다.
+        라우트가 unknown field를 PUT 422로 명시 매핑하는 schema accuracy 회복은
+        #1143에서 다룬다. service-layer 회귀 보호처:
+        ``tests/unit/test_account_immutable_fields.py``의
+        ``test_update_unknown_field_raises_value_error``.
         """
         account = _make_account()
         account_service._accounts[account.account_id] = account
 
         resp = client.put(
             "/api/accounts/test-account",
-            json={"timezone": {}},
+            json={"some_unknown_field": "x"},
         )
-        assert resp.status_code == 422
-        # service.update 미호출 — 계좌 timezone 보존
-        assert account_service._accounts["test-account"].timezone == "Asia/Seoul"
-        # audit 미발행
+        # 글로벌 ValueError 핸들러가 400으로 매핑.
+        assert resp.status_code == 400
+        body = resp.json()
+        # ErrorResponse 형태로 매핑됨.
+        assert body.get("status") == 400
+        assert "some_unknown_field" in body.get("detail", "")
+        # audit 미발행 (service.update가 raise하면 logger 호출 전에 끊긴다)
         assert [
             log for log in audit_logger.logs if log["action"] == "account.update"
         ] == []
-
-    def test_update_invalid_name_type_returns_422(
-        self,
-        client: TestClient,
-        account_service: FakeAccountService,
-    ) -> None:
-        """``name`` 타입 오류도 422 (P2 회귀 보호).
-
-        Pydantic은 dict → str 강제 변환을 허용하지 않으므로 422가 발생해야
-        한다. 422가 아닌 다른 status는 schema validation 회귀 신호다.
-        """
-        account = _make_account()
-        account_service._accounts[account.account_id] = account
-
-        resp = client.put(
-            "/api/accounts/test-account",
-            json={"name": {"nested": "object"}},
-        )
-        assert resp.status_code == 422
 
     def test_update_invalid_json_body_returns_422(
         self,
@@ -813,10 +838,10 @@ class TestUpdateAccount:
     ) -> None:
         """structural 키 + 잘못된 mutable 타입이 같이 와도 cold-path 409 우선.
 
-        attempt 4의 P2 finding 회귀 보호. 구조 필드 가드는 mutable schema
-        검증보다 먼저 실행되어야 한다 — ``credentials`` 키가 등장한 시점에
-        cold-path 위반이 확정되며, 같은 페이로드에 schema 검증 실패 트리거가
-        있어도 응답은 422가 아닌 409여야 한다.
+        구조 필드 가드는 service.update 호출보다 먼저 실행되어야 한다 —
+        ``credentials`` 키가 등장한 시점에 cold-path 위반이 확정되며, 같은
+        페이로드에 비구조 필드가 있어도 응답은 409여야 한다. service.update는
+        호출되지 않으므로 비구조 필드도 변경되지 않는다.
         """
         account = _make_account()
         account_service._accounts[account.account_id] = account

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -836,6 +836,49 @@ class TestUpdateAccount:
             log for log in audit_logger.logs if log["action"] == "account.update"
         ] == []
 
+    def test_update_blocks_when_structural_without_account_service(self) -> None:
+        """AccountService 미주입 환경에서도 structural body는 503이 아니라 409.
+
+        attempt 5의 P3 회귀 보호: PUT 핸들러 시그니처가
+        ``Depends(get_account_service)``를 들고 있으면 FastAPI가 핸들러 진입
+        *전* 의존성을 평가해 service 미주입 시 503을 선행한다. 그 결과
+        structural body가 들어와도 cold-path 가드(invariant I1/I4)에 도달하지
+        못해 503이 응답된다.
+
+        attempt 6은 PUT의 ``account_service``를
+        ``request.app.state.account_service``로 lazy 해소해 structural 분기에서
+        service에 의존하지 않도록 한다. 이 테스트가 그 invariant를 직접
+        단언한다 — service 미주입 + ``credentials`` body → 409.
+        """
+        app = create_app()  # account_service 미주입
+        assert getattr(app.state, "account_service", None) is None
+        with TestClient(app) as bare_client:
+            resp = bare_client.put(
+                "/api/accounts/some-id",
+                json={"credentials": {"app_key": "x"}},
+            )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "credentials" in detail
+
+    def test_update_returns_503_for_mutable_when_service_missing(self) -> None:
+        """service 미주입 + 비구조 body → 503 (attempt 6의 명시적 트레이드오프).
+
+        cold-path 가드를 통과한 분기는 ``app.state.account_service``를
+        lazy하게 가져온다. 미주입이면 503으로 응답한다 — 이 동작은 attempt 6의
+        invariant I1 회복(structural body → 409)과 짝을 이룬다.
+        """
+        app = create_app()  # account_service 미주입
+        assert getattr(app.state, "account_service", None) is None
+        with TestClient(app) as bare_client:
+            resp = bare_client.put(
+                "/api/accounts/some-id",
+                json={"name": "변경"},
+            )
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "Account service not available"
+
 
 # PUT requestBody schema accuracy(mutable 모델 노출)는 issue #1143에서 처리.
 # 본 이슈는 cold-path invariant(I1~I4)와 P2(ValidationError 422)에 한정한다.

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -257,121 +257,49 @@ class TestListAccounts:
 
 
 class TestCreateAccount:
-    """POST /api/accounts."""
+    """POST /api/accounts.
 
-    def test_create_success(
+    런타임 Web API에서 계좌 생성은 cold-path 전용이므로 항상 409로 차단된다.
+    서비스 단의 회귀 보호(중복/missing credentials/broker connect 등)는
+    `tests/unit/test_account.py`의 `test_create_account`,
+    `test_create_duplicate_raises`, `test_create_invalid_broker_type_raises`,
+    `test_create_missing_credentials_raises`,
+    `test_create_partial_credentials_raises` 등이 담당한다.
+    """
+
+    def test_create_blocked_runtime_409(
         self,
         client: TestClient,
+        account_service: FakeAccountService,
         audit_logger: FakeAuditLogger,
     ) -> None:
+        """런타임 POST /api/accounts는 cold-path 409로 즉시 차단된다.
+
+        - 응답 status 409
+        - detail에 `ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER` 포함
+        - AccountService는 호출되지 않아 계좌가 만들어지지 않음
+        - audit 로그도 남기지 않음
+        """
         resp = client.post(
             "/api/accounts",
             json={
                 "account_id": "new-test",
-                "name": "새 테스트 계좌",
+                "name": "런타임 생성 시도",
                 "broker_type": "test",
-                "credentials": {"app_key": "key", "app_secret": "secret"},
-            },
-        )
-        assert resp.status_code == 201
-        data = resp.json()
-        assert data["account"]["account_id"] == "new-test"
-        assert data["account"]["broker_type"] == "test"
-        # 감사 로그 확인
-        route_logs = [
-            log for log in audit_logger.logs if log["action"] == "account.create"
-        ]
-        assert len(route_logs) == 1
-
-    def test_create_duplicate(
-        self,
-        client: TestClient,
-        account_service: FakeAccountService,
-    ) -> None:
-        account = _make_account("existing")
-        account_service._accounts["existing"] = account
-
-        resp = client.post(
-            "/api/accounts",
-            json={
-                "account_id": "existing",
-                "name": "중복 계좌",
-                "broker_type": "test",
+                "credentials": {"app_key": "k", "app_secret": "s"},
             },
         )
         assert resp.status_code == 409
-
-    def test_create_connects_broker_so_health_stays_up(
-        self,
-        client: TestClient,
-        account_service: FakeAccountService,
-    ) -> None:
-        """신규 계좌 생성 시 브로커 connect()가 호출되어 /health가 계속 healthy.
-
-        회귀 방지: 부팅 시 _init_gateway의 connect 루프를 타지 않은 런타임
-        신규 계좌는 connect가 별도로 호출되지 않으면 /health가 broker=false
-        로 고정된다. 본 테스트는 POST /api/accounts 이후 반환된 어댑터의
-        is_connected가 True임을 검증한다.
-        """
-        resp = client.post(
-            "/api/accounts",
-            json={
-                "account_id": "new-live",
-                "name": "런타임 추가 계좌",
-                "broker_type": "test",
-                "credentials": {"app_key": "k", "app_secret": "s"},
-            },
-        )
-        assert resp.status_code == 201
-        broker = account_service._brokers["new-live"]
-        assert broker.connect_calls == 1
-        assert broker.is_connected is True
-
-    def test_create_survives_broker_connect_failure(
-        self,
-        client: TestClient,
-        account_service: FakeAccountService,
-    ) -> None:
-        """브로커 connect 실패해도 계좌 생성 자체는 성공(201)한다.
-
-        운영자는 이후 /health에서 broker=false를 확인하고 설정을 교정 후
-        재시도한다. main._init_gateway의 best-effort 패턴과 동일.
-        """
-        account_service._fail_connect_for.add("flaky")
-
-        resp = client.post(
-            "/api/accounts",
-            json={
-                "account_id": "flaky",
-                "name": "플레이키 계좌",
-                "broker_type": "test",
-                "credentials": {"app_key": "k", "app_secret": "s"},
-            },
-        )
-        assert resp.status_code == 201
-        broker = account_service._brokers["flaky"]
-        assert broker.connect_calls == 1
-        assert broker.is_connected is False
-        # 계좌 레코드는 유지된다 (롤백되지 않음)
-        assert "flaky" in account_service._accounts
-
-    def test_create_missing_credentials_returns_422(
-        self,
-        client: TestClient,
-    ) -> None:
-        """credentials 누락 시 422 Validation Error를 반환해야 한다 (GH-848)."""
-        resp = client.post(
-            "/api/accounts",
-            json={
-                "account_id": "no-creds",
-                "name": "크레덴셜 누락 계좌",
-                "broker_type": "test",
-                "credentials": {},
-            },
-        )
-        assert resp.status_code == 422
-        data = resp.json()
-        assert "credentials" in data["detail"].lower() or "누락" in data["detail"]
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        # 서비스 미호출 — 계좌가 생성되지 않았다.
+        assert account_service._accounts == {}
+        assert account_service._brokers == {}
+        # audit 로그도 남기지 않는다.
+        create_logs = [
+            log for log in audit_logger.logs if log["action"] == "account.create"
+        ]
+        assert create_logs == []
 
 
 class TestGetAccount:
@@ -411,7 +339,27 @@ class TestGetAccount:
 
 
 class TestUpdateAccount:
-    """PUT /api/accounts/:id."""
+    """PUT /api/accounts/:id.
+
+    비구조 필드(`name`, `timezone`, `trading_hours_start`, `trading_hours_end`)는
+    런타임 PUT 200 경로를 유지한다. structural 필드(`credentials`,
+    `broker_config`, `buy_commission_rate`, `sell_commission_rate`,
+    `broker_type`, `exchange`, `currency`, `trading_mode`)가 포함되면
+    cold-path 409로 즉시 차단된다.
+
+    Service-layer 회귀 보호처:
+    - `tests/unit/test_account_immutable_fields.py`의
+      `test_update_immutable_*`, `test_update_mutable_*`
+    - `tests/unit/test_account.py`의
+      `test_update_credentials_invalidates_broker_cache`,
+      `test_update_broker_config_invalidates_broker_cache`,
+      `test_update_commission_rate_invalidates_broker_cache`,
+      `test_update_preserves_cache_when_new_broker_connect_fails`
+    503 매핑(`BrokerReconnectFailedError`) 회귀는 라우트 가드가 credentials를
+    409로 차단해 도달할 수 없으므로 라우트 레벨 테스트는 제거. 매핑 자체는
+    코드 inspection(`update_account`의 `except BrokerReconnectFailedError`)으로
+    확인한다.
+    """
 
     def test_update_success(
         self,
@@ -434,6 +382,29 @@ class TestUpdateAccount:
         ]
         assert len(route_logs) == 1
 
+    def test_update_non_structural_fields_succeed(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """`timezone`, `trading_hours_start`, `trading_hours_end` 동시 변경 200."""
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={
+                "timezone": "America/New_York",
+                "trading_hours_start": "09:30",
+                "trading_hours_end": "16:00",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["account"]["timezone"] == "America/New_York"
+        assert data["account"]["trading_hours_start"] == "09:30"
+        assert data["account"]["trading_hours_end"] == "16:00"
+
     def test_update_not_found(self, client: TestClient) -> None:
         resp = client.put(
             "/api/accounts/nonexistent",
@@ -452,38 +423,150 @@ class TestUpdateAccount:
         resp = client.put("/api/accounts/test-account", json={})
         assert resp.status_code == 400
 
-    def test_update_broker_reconnect_failed_returns_503(
+    def test_update_credentials_blocked_409(
         self,
         client: TestClient,
         account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
     ) -> None:
-        """브로커 재연결 실패는 503과 부분 성공 메시지로 노출된다.
-
-        회귀 방지: service.update가 BrokerReconnectFailedError를 올리면
-        (DB는 반영됐지만 새 설정으로 connect 실패한 부분 성공 상태)
-        전역 500이 아닌 503으로 매핑되어, 응답 본문이 '계좌 정보는
-        저장되었으나 브로커 재연결에 실패했습니다'를 포함해야 한다.
-        """
-        from ante.account.errors import BrokerReconnectFailedError
-
+        """`credentials` 변경 요청은 cold-path 409로 즉시 차단된다."""
         account = _make_account()
         account_service._accounts[account.account_id] = account
-
-        async def raise_reconnect_failed(account_id: str, **fields: Any) -> Account:
-            raise BrokerReconnectFailedError(
-                f"계좌 '{account_id}' 브로커 connect() 실패"
-            )
-
-        account_service.update = raise_reconnect_failed  # type: ignore[method-assign]
 
         resp = client.put(
             "/api/accounts/test-account",
             json={"credentials": {"app_key": "new", "app_secret": "new"}},
         )
-        assert resp.status_code == 503
+        assert resp.status_code == 409
         detail = resp.json()["detail"]
-        assert "브로커 재연결에 실패" in detail
-        assert "저장" in detail
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "credentials" in detail
+        # service 미호출 — 계좌 필드가 변경되지 않음
+        assert account_service._accounts["test-account"].credentials == {
+            "secret_key": "hidden"
+        }
+        assert [
+            log for log in audit_logger.logs if log["action"] == "account.update"
+        ] == []
+
+    def test_update_broker_config_blocked_409(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"broker_config": {"is_paper": True}},
+        )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "broker_config" in detail
+
+    def test_update_buy_commission_blocked_409(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"buy_commission_rate": 0.001},
+        )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "buy_commission_rate" in detail
+
+    def test_update_sell_commission_blocked_409(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"sell_commission_rate": 0.002},
+        )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "sell_commission_rate" in detail
+
+    def test_update_broker_type_blocked_409(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"broker_type": "kis-domestic"},
+        )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "broker_type" in detail
+
+    def test_update_exchange_blocked_409(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"exchange": "KRX"},
+        )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "exchange" in detail
+
+    def test_update_currency_blocked_409(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"currency": "USD"},
+        )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "currency" in detail
+
+    def test_update_trading_mode_blocked_409(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"trading_mode": "live"},
+        )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "trading_mode" in detail
 
 
 class TestSuspendAccount:
@@ -591,25 +674,36 @@ class TestActivateAccount:
 
 
 class TestDeleteAccount:
-    """DELETE /api/accounts/:id."""
+    """DELETE /api/accounts/:id.
 
-    def test_delete_success(
+    런타임 Web API에서 계좌 삭제는 cold-path 전용이므로 항상 409로 차단된다.
+    Service-layer 회귀 보호처: `tests/unit/test_account.py::test_delete_account`,
+    `tests/unit/test_account.py::test_delete_already_deleted_account_raises`.
+    """
+
+    def test_delete_blocked_runtime_409(
         self,
         client: TestClient,
         account_service: FakeAccountService,
         audit_logger: FakeAuditLogger,
     ) -> None:
+        """런타임 DELETE /api/accounts/:id는 cold-path 409로 즉시 차단된다.
+
+        - 응답 status 409
+        - detail에 `ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER` 포함
+        - AccountService는 호출되지 않음 (`_accounts`/`_deleted` 변경 없음)
+        - audit 로그 미발행
+        """
         account = _make_account()
         account_service._accounts[account.account_id] = account
 
         resp = client.delete("/api/accounts/test-account")
-        assert resp.status_code == 204
-        assert "test-account" not in account_service._accounts
-        route_logs = [
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        # 서비스 미호출 — 계좌 그대로 유지, soft-delete 트래킹도 변경 없음
+        assert "test-account" in account_service._accounts
+        assert account_service._deleted == set()
+        assert [
             log for log in audit_logger.logs if log["action"] == "account.delete"
-        ]
-        assert len(route_logs) == 1
-
-    def test_delete_not_found(self, client: TestClient) -> None:
-        resp = client.delete("/api/accounts/nonexistent")
-        assert resp.status_code == 404
+        ] == []

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -751,24 +751,26 @@ class TestUpdateAccount:
         assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
         assert "exchange" in detail
 
-    def test_update_unknown_mutable_field_forwarded_to_service(
+    def test_update_unknown_mutable_field_rejected_at_route(
         self,
         client: TestClient,
         account_service: FakeAccountService,
         audit_logger: FakeAuditLogger,
     ) -> None:
-        """알 수 없는 비구조 필드는 service-layer가 거부한다 (글로벌 400 매핑).
+        """알 수 없는 비구조 필드는 라우트의 mutable 검증 단계에서 무시된다.
 
-        attempt 8에서 라우트 단 ``AccountMutableUpdateRequest`` 검증이 제거
-        되면서 비구조 필드 schema 검증은 service-layer로 위임된다. structural
-        가드를 통과한 unknown 키는 ``account_service.update``로 그대로 forward
-        되며, 실제 ``AccountService.update``는 unknown field에 ``ValueError``를
-        던진다. 글로벌 예외 핸들러(``app.py``의 ValueError handler)가 이를
-        RFC 7807 400 ``ErrorResponse``로 매핑한다.
+        attempt 9는 P1 회귀 보호로 비구조 페이로드를
+        ``AccountUpdateRequest.model_validate``에 통과시킨다. Pydantic의
+        기본 동작은 unknown field를 ignore하므로, ``some_unknown_field``는
+        ``model_dump(exclude_none=True)`` 결과에서 사라진다 → 라우트는
+        ``fields``가 비었다고 판단해 400 "수정할 필드가 없습니다."로 응답한다.
 
-        본 테스트는 service-위임 동작과 글로벌 400 매핑을 함께 확인한다.
-        라우트가 unknown field를 PUT 422로 명시 매핑하는 schema accuracy 회복은
-        #1143에서 다룬다. service-layer 회귀 보호처:
+        결과적으로 service.update는 호출되지 않으며, unknown field가 DB에
+        도달할 가능성이 차단된다. unknown field에 대한 schema-accurate 422
+        매핑(라우트가 명시적으로 reject)은 #1143에서 mutable 모델을 직접
+        노출할 때 함께 정리한다.
+
+        service-layer 회귀 보호처(별도 invariant):
         ``tests/unit/test_account_immutable_fields.py``의
         ``test_update_unknown_field_raises_value_error``.
         """
@@ -779,13 +781,90 @@ class TestUpdateAccount:
             "/api/accounts/test-account",
             json={"some_unknown_field": "x"},
         )
-        # 글로벌 ValueError 핸들러가 400으로 매핑.
+        # 라우트 단 400 — unknown field가 Pydantic에서 무시되어 fields가 비었다.
         assert resp.status_code == 400
         body = resp.json()
-        # ErrorResponse 형태로 매핑됨.
         assert body.get("status") == 400
-        assert "some_unknown_field" in body.get("detail", "")
-        # audit 미발행 (service.update가 raise하면 logger 호출 전에 끊긴다)
+        assert body.get("detail") == "수정할 필드가 없습니다."
+        # service.update 미호출 — DB 오염 차단.
+        assert account_service._accounts["test-account"].name == "테스트 계좌"
+        # audit 미발행
+        assert [
+            log for log in audit_logger.logs if log["action"] == "account.update"
+        ] == []
+
+    def test_update_invalid_mutable_field_type_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """비구조 필드의 type이 잘못되면 422 (P1 회귀 보호).
+
+        ``timezone``은 문자열이어야 한다. dict가 들어오면 라우트의
+        ``AccountUpdateRequest.model_validate``가 ``ValidationError``를
+        발생시키고, 라우트는 이를 명시적으로 422로 매핑한다. 잘못된 값이
+        service/DB까지 도달해 상태를 오염시키는 것을 차단한다.
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"timezone": {}},
+        )
+        assert resp.status_code == 422
+        # service.update 미호출 — timezone 보존
+        assert account_service._accounts["test-account"].timezone == "Asia/Seoul"
+        # audit 미발행
+        assert [
+            log for log in audit_logger.logs if log["action"] == "account.update"
+        ] == []
+
+    def test_update_invalid_name_type_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """``name``에 dict가 들어오면 422 (P1 회귀 보호)."""
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"name": {"nested": "x"}},
+        )
+        assert resp.status_code == 422
+        # service.update 미호출 — name 보존
+        assert account_service._accounts["test-account"].name == "테스트 계좌"
+
+    def test_update_null_mutable_field_treated_as_no_op(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """``{"name": null}``은 fields가 비어 400으로 차단된다 (P1 회귀 보호).
+
+        ``AccountUpdateRequest`` 모든 필드는 ``str | None = None``이라 null도
+        Pydantic 검증을 통과한다. 그러나 ``model_dump(exclude_none=True)``로
+        None 필드를 제외하면 fields가 비고, 라우트는 400 "수정할 필드가
+        없습니다."로 응답한다 — null이 service까지 forward되어 DB의 name을
+        지우거나 NOT NULL 제약 위반을 일으킬 가능성을 차단한다.
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+        original_name = account_service._accounts[account.account_id].name
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"name": None},
+        )
+        assert resp.status_code == 400
+        assert resp.json().get("detail") == "수정할 필드가 없습니다."
+        # service.update 미호출 — name 보존 (DB 오염 차단)
+        assert account_service._accounts["test-account"].name == original_name
+        # audit 미발행
         assert [
             log for log in audit_logger.logs if log["action"] == "account.update"
         ] == []

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -743,7 +743,6 @@ class TestResponseModelCoverage:
     def test_openapi_account_routes_have_error_response_models(self, client):
         """cold-path 라우트의 명시 4xx/5xx 응답이 ErrorResponse를 노출.
 
-        Codex review (이슈 #1140 attempt 6) finding P2 회귀 보호:
         PUT/DELETE/POST 라우트가 ``responses=`` 데코레이터에 명시 등록한
         4xx/5xx 응답은 ``model: ErrorResponse``를 일관 등록해야 OpenAPI/
         codegen에서 bodyless 4xx/5xx로 표현되지 않는다. ``application/json``
@@ -751,8 +750,9 @@ class TestResponseModelCoverage:
 
         FastAPI가 자동 생성하는 path/dependency 검증용 422 응답은
         ``HTTPValidationError`` 표준 schema를 사용하므로 본 테스트의
-        검증 대상에서 제외한다 (PUT 422는 핸들러 본문이 명시 raise한
-        ``HTTPException(422)``이므로 ErrorResponse를 가져야 한다).
+        검증 대상에서 제외한다. attempt 8에서 PUT 422 명시 등록은 제거되어
+        (mutable schema 검증을 service-layer로 위임) ``responses=``의 422
+        강제 단언도 제외했다 — schema accuracy 회복은 #1143에서 다룬다.
         """
         resp = client.get("/openapi.json")
         assert resp.status_code == 200
@@ -766,7 +766,7 @@ class TestResponseModelCoverage:
         # 에러 status code 집합 — FastAPI 자동 422는 제외한다.
         target_routes: list[tuple[str, str, set[str]]] = [
             ("/api/accounts", "post", {"409"}),
-            ("/api/accounts/{account_id}", "put", {"400", "404", "409", "422", "503"}),
+            ("/api/accounts/{account_id}", "put", {"400", "404", "409", "503"}),
             ("/api/accounts/{account_id}", "delete", {"409"}),
         ]
 
@@ -804,28 +804,8 @@ class TestResponseModelCoverage:
             + "\n".join(f"  - {m}" for m in missing)
         )
 
-    def test_openapi_put_account_422_references_error_response(self, client):
-        """PUT /api/accounts/{account_id} 422 응답이 ErrorResponse 참조를 가진다.
-
-        attempt 6에서 Codex review가 잡은 정확한 finding 회귀 보호:
-        PUT 라우트의 422 응답에 ``model: ErrorResponse``가 빠져 있어
-        OpenAPI/codegen이 bodyless 422로 표현하던 문제가 다시 발생하지 않도록
-        고정한다.
-        """
-        resp = client.get("/openapi.json")
-        assert resp.status_code == 200
-        openapi = resp.json()
-
-        spec = openapi["paths"]["/api/accounts/{account_id}"]["put"]
-        responses = spec["responses"]
-        assert "422" in responses, "PUT 422 응답이 OpenAPI에 없음"
-
-        content = responses["422"].get("content", {})
-        json_content = content.get("application/json")
-        assert json_content is not None, "PUT 422 응답에 application/json content 없음"
-
-        schema = json_content.get("schema", {})
-        ref = schema.get("$ref", "")
-        assert "ErrorResponse" in ref, (
-            f"PUT 422 응답 schema가 ErrorResponse를 참조하지 않음: {schema!r}"
-        )
+    # PUT /api/accounts/{account_id} 422 schema accuracy(mutable 모델 노출 +
+    # 422에 ErrorResponse 참조)는 attempt 8에서 service-layer 위임 전략으로
+    # 전환하면서 라우트 ``responses=``에서 제거되었다. 후속 작업은 #1143에서
+    # 다룬다 — body schema(mutable 모델)와 422 응답 모델을 함께 노출하는
+    # 패턴 자체가 schema accuracy 카테고리의 분리된 결정이다.

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -749,10 +749,11 @@ class TestResponseModelCoverage:
         content가 있고 schema가 ``ErrorResponse``를 가리키는지 확인한다.
 
         FastAPI가 자동 생성하는 path/dependency 검증용 422 응답은
-        ``HTTPValidationError`` 표준 schema를 사용하므로 본 테스트의
-        검증 대상에서 제외한다. attempt 8에서 PUT 422 명시 등록은 제거되어
-        (mutable schema 검증을 service-layer로 위임) ``responses=``의 422
-        강제 단언도 제외했다 — schema accuracy 회복은 #1143에서 다룬다.
+        ``HTTPValidationError`` 표준 schema를 사용하지만, 본 PUT 라우트는
+        attempt 9에서 mutable 필드 type 검증 실패에 대한 422 응답을 명시
+        등록(``model: ErrorResponse``)했으므로 본 테스트의 검증 대상에 포함
+        한다. body requestBody의 schema accuracy(mutable 모델 직접 노출)는
+        후속 이슈 #1143에서 다룬다.
         """
         resp = client.get("/openapi.json")
         assert resp.status_code == 200
@@ -763,10 +764,16 @@ class TestResponseModelCoverage:
         # 다른 account 라우트(suspend/activate/rules)의 4xx 커버리지 확장은
         # 후속 이슈(#1143 schema accuracy)에서 다룬다.
         # 각 튜플의 세 번째 요소는 ``responses=`` 데코레이터에 명시 등록된
-        # 에러 status code 집합 — FastAPI 자동 422는 제외한다.
+        # 에러 status code 집합 — FastAPI 자동 422는 제외하지만, attempt 9
+        # 에서 PUT은 mutable type 검증용 422를 명시 등록했으므로 PUT 422도
+        # 강제 단언 대상에 포함한다.
         target_routes: list[tuple[str, str, set[str]]] = [
             ("/api/accounts", "post", {"409"}),
-            ("/api/accounts/{account_id}", "put", {"400", "404", "409", "503"}),
+            (
+                "/api/accounts/{account_id}",
+                "put",
+                {"400", "404", "409", "422", "503"},
+            ),
             ("/api/accounts/{account_id}", "delete", {"409"}),
         ]
 
@@ -804,8 +811,32 @@ class TestResponseModelCoverage:
             + "\n".join(f"  - {m}" for m in missing)
         )
 
-    # PUT /api/accounts/{account_id} 422 schema accuracy(mutable 모델 노출 +
-    # 422에 ErrorResponse 참조)는 attempt 8에서 service-layer 위임 전략으로
-    # 전환하면서 라우트 ``responses=``에서 제거되었다. 후속 작업은 #1143에서
-    # 다룬다 — body schema(mutable 모델)와 422 응답 모델을 함께 노출하는
-    # 패턴 자체가 schema accuracy 카테고리의 분리된 결정이다.
+    def test_openapi_put_account_422_references_error_response(self, client):
+        """PUT /api/accounts/{account_id}의 422 응답이 ErrorResponse를 가리킨다.
+
+        attempt 9 P1 회귀 보호: 라우트는 비구조 필드 type 검증 실패를
+        ``HTTPException(status_code=422)``로 명시 변환한다. ``responses[422]``
+        에 ``model: ErrorResponse``가 등록되어 OpenAPI/codegen에서 422가
+        bodyless가 아닌 ``ErrorResponse`` 본문을 갖도록 한다 — 클라이언트는
+        type-safe하게 422 응답을 다룰 수 있다.
+
+        body requestBody schema accuracy(mutable 모델 직접 노출)는
+        후속 이슈 #1143에서 다룬다.
+        """
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        openapi = resp.json()
+        spec = (
+            openapi.get("paths", {})
+            .get("/api/accounts/{account_id}", {})
+            .get("put", {})
+        )
+        responses = spec.get("responses", {})
+        response_422 = responses.get("422")
+        assert response_422 is not None, "PUT 422 응답이 명시 등록되지 않음"
+        json_content = response_422.get("content", {}).get("application/json")
+        assert json_content is not None, "PUT 422에 application/json content 없음"
+        ref = json_content.get("schema", {}).get("$ref", "")
+        assert "ErrorResponse" in ref, (
+            f"PUT 422가 ErrorResponse를 가리키지 않음 (schema ref={ref!r})"
+        )

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -739,3 +739,93 @@ class TestResponseModelCoverage:
         data = resp.json()
         model = FeedStatusResponse(**data)
         assert model.initialized is False
+
+    def test_openapi_account_routes_have_error_response_models(self, client):
+        """cold-path 라우트의 명시 4xx/5xx 응답이 ErrorResponse를 노출.
+
+        Codex review (이슈 #1140 attempt 6) finding P2 회귀 보호:
+        PUT/DELETE/POST 라우트가 ``responses=`` 데코레이터에 명시 등록한
+        4xx/5xx 응답은 ``model: ErrorResponse``를 일관 등록해야 OpenAPI/
+        codegen에서 bodyless 4xx/5xx로 표현되지 않는다. ``application/json``
+        content가 있고 schema가 ``ErrorResponse``를 가리키는지 확인한다.
+
+        FastAPI가 자동 생성하는 path/dependency 검증용 422 응답은
+        ``HTTPValidationError`` 표준 schema를 사용하므로 본 테스트의
+        검증 대상에서 제외한다 (PUT 422는 핸들러 본문이 명시 raise한
+        ``HTTPException(422)``이므로 ErrorResponse를 가져야 한다).
+        """
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        openapi = resp.json()
+        paths = openapi.get("paths", {})
+
+        # cold-path PUT/POST/DELETE 라우트만 본 attempt에서 강제한다.
+        # 다른 account 라우트(suspend/activate/rules)의 4xx 커버리지 확장은
+        # 후속 이슈(#1143 schema accuracy)에서 다룬다.
+        # 각 튜플의 세 번째 요소는 ``responses=`` 데코레이터에 명시 등록된
+        # 에러 status code 집합 — FastAPI 자동 422는 제외한다.
+        target_routes: list[tuple[str, str, set[str]]] = [
+            ("/api/accounts", "post", {"409"}),
+            ("/api/accounts/{account_id}", "put", {"400", "404", "409", "422", "503"}),
+            ("/api/accounts/{account_id}", "delete", {"409"}),
+        ]
+
+        missing: list[str] = []
+        for path, method, explicit_codes in target_routes:
+            spec = paths.get(path, {}).get(method)
+            assert spec is not None, f"라우트 정의 누락: {method.upper()} {path}"
+
+            responses = spec.get("responses", {})
+            for code in explicit_codes:
+                response_spec = responses.get(code)
+                if response_spec is None:
+                    missing.append(f"{method.upper()} {path} ({code}): 응답 정의 누락")
+                    continue
+                content = response_spec.get("content", {})
+                json_content = content.get("application/json")
+                if json_content is None:
+                    missing.append(
+                        f"{method.upper()} {path} ({code}): "
+                        "application/json content 없음"
+                    )
+                    continue
+                schema = json_content.get("schema", {})
+                ref = schema.get("$ref", "")
+                # FastAPI는 model: ErrorResponse를 받으면
+                # `#/components/schemas/ErrorResponse`로 참조한다.
+                if "ErrorResponse" not in ref:
+                    missing.append(
+                        f"{method.upper()} {path} ({code}): "
+                        f"ErrorResponse 참조 없음 (schema={schema!r})"
+                    )
+
+        assert missing == [], (
+            "cold-path account 라우트 에러 응답에 ErrorResponse 모델 누락:\n"
+            + "\n".join(f"  - {m}" for m in missing)
+        )
+
+    def test_openapi_put_account_422_references_error_response(self, client):
+        """PUT /api/accounts/{account_id} 422 응답이 ErrorResponse 참조를 가진다.
+
+        attempt 6에서 Codex review가 잡은 정확한 finding 회귀 보호:
+        PUT 라우트의 422 응답에 ``model: ErrorResponse``가 빠져 있어
+        OpenAPI/codegen이 bodyless 422로 표현하던 문제가 다시 발생하지 않도록
+        고정한다.
+        """
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        openapi = resp.json()
+
+        spec = openapi["paths"]["/api/accounts/{account_id}"]["put"]
+        responses = spec["responses"]
+        assert "422" in responses, "PUT 422 응답이 OpenAPI에 없음"
+
+        content = responses["422"].get("content", {})
+        json_content = content.get("application/json")
+        assert json_content is not None, "PUT 422 응답에 application/json content 없음"
+
+        schema = json_content.get("schema", {})
+        ref = schema.get("$ref", "")
+        assert "ErrorResponse" in ref, (
+            f"PUT 422 응답 schema가 ErrorResponse를 참조하지 않음: {schema!r}"
+        )


### PR DESCRIPTION
Closes #1140

## Summary

Web API의 계좌 구조 변경 경로(POST/DELETE/PUT `/api/accounts`)를 런타임에서 cold-path 전용으로 차단한다. 모든 런타임 입력은 즉시 `409 ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER`로 거부되며, PUT의 비구조 필드 타입 검증은 라우트에서 수행해 잘못된 mutable payload가 service/DB에 도달하는 것을 막는다.

## Cold-Path Invariants (모두 만족)

- **I1 — 즉시 409**: POST/DELETE/PUT 모두 service 미주입 환경에서도 cold-path 가드가 먼저 도달
- **I2 — `response_model` 명시**: cold-path 라우트의 모든 4xx/5xx 응답에 `model: ErrorResponse` 일관 등록
- **I3 — 도달 불가 success 미노출**: POST/DELETE 데코레이터에서 success status_code/200/201/204 모두 제거
- **I4 — raw payload key 가드**: PUT body가 dict로 받아 raw key 교집합으로 structural 차단 (검증된 Pydantic 값 기반 가드 사용 안 함)

추가로 PUT의 mutable 필드는 기존 `AccountUpdateRequest`를 재사용해 `model_validate` → `ValidationError` → `422 HTTPException` 변환으로 type 검증 (새 모델 추가 없음).

## Out of Scope (의도적 분리)

`@code-reviewer` 메타 리뷰 #2 판정에 따라 다음은 본 PR 범위 밖으로 분리된다 — invariant I1(핸들러 시그니처에 Pydantic body 파라미터가 없어야 service 미주입 환경에서도 즉시 409)과 단일 라우트에서 기술적으로 양립 불가:

- **POST `/api/accounts` requestBody schema** (`AccountCreateRequest`가 OpenAPI에서 `never`로 표현) → #1143
- **PUT `/api/accounts/{id}` mutable body schema accuracy** (`object | null`로 표현, mutable 4필드 제약 미노출) → #1143
- **AccountService raise 계약 정렬** (서비스 자체에서 `AccountStructuralChangeRequiresStoppedServerError` raise) → #1144
- **cold-path 외 라우트의 ErrorResponse 일관 적용** (suspend/activate/rules 등) → #1145

런타임은 cold-path 409로 항상 차단되므로 schema accuracy 분리는 동작 회귀가 아니라 OpenAPI/codegen에서의 표현 정확도 한계다.

## Codex 브랜치 리뷰 메모

attempts 1~9 동안 같은 `contract-drift` risk class가 반복됐다. attempt 9 시점에 invariant + mutable P1 검증은 모두 PASS이고, 남은 P2 finding 2건은 모두 위 Out of Scope에 해당하는 schema accuracy다. 메타 리뷰 #2(2026-04-26)가 이를 root cause = review context drift로 판정하고 PR description으로 명시 정당화 + 후속 이슈 분리를 권고했다. 본 PR은 그 결정을 따른다.

## Test Plan

- [x] `pytest tests/unit/test_account_api.py tests/unit/test_account.py tests/unit/test_account_immutable_fields.py tests/unit/test_account_delete_events.py tests/unit/test_web_api.py` → 157 passed
- [x] `ruff check src/ante/web/routes/accounts.py tests/unit/test_account_api.py tests/unit/test_web_api.py` → All checks passed
- [x] `ruff format --check ...` → already formatted
- [x] `npm --prefix frontend run generate-types` → 동기화 완료
- [x] cold-path 회귀 보호:
  - service 미주입 환경 POST/DELETE/PUT structural 입력 → 409 (503 아님)
  - `{"name":"x","credentials":null}` → 409 (cold-path 가드 우선, raw key 검사)
  - `{"buy_commission_rate":"bad"}` → 409 (mutable validate 도달 전 차단)
  - `{"timezone":{}}` → 422 (mutable type 검증 P1)
  - `{"name":null}` → 400 (model_dump exclude_none 후 빈 fields)
- [x] OpenAPI 동기화: PUT 422 응답이 `application/json` + `ErrorResponse $ref`로 노출되는지 단언

🤖 Generated with [Claude Code](https://claude.com/claude-code)