### PR TITLE
fix(ci): restore ruff lint pass

### DIFF
--- a/src/ante/__init__.py
+++ b/src/ante/__init__.py
@@ -7,7 +7,8 @@ Web API/OpenAPI/CLI 등 공개 버전 표면은 모두 이 값을 참조한다.
 from __future__ import annotations
 
 import tomllib
-from importlib.metadata import PackageNotFoundError, version as _pkg_version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
 _FALLBACK_VERSION = "0.0.0"

--- a/src/ante/cli/main.py
+++ b/src/ante/cli/main.py
@@ -61,7 +61,7 @@ class LeafAwareGroup(click.Group):
         cmd: click.Command = self
         path: list[str] = []
         i = 0
-        while i < len(args) and isinstance(cmd, click.MultiCommand):
+        while i < len(args) and isinstance(cmd, click.Group):
             token = args[i]
             if token.startswith("-"):
                 i += 1

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1144,7 +1144,10 @@ async def _init_notification(s: Services) -> None:
     try:
         min_level = NotificationLevel(min_level_str)
     except ValueError:
-        logger.warning("notification.min_level 무시: 유효하지 않은 값 %r", min_level_raw)
+        logger.warning(
+            "notification.min_level 무시: 유효하지 않은 값 %r",
+            min_level_raw,
+        )
         min_level = NotificationLevel.INFO
 
     # quiet_hours 파싱

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import sqlite3
 import stat
@@ -41,6 +42,13 @@ def _mock_bootstrap(*args, **kwargs):
 def _mock_create_test_account(*args, **kwargs):
     """_create_test_account mock — test account dict 반환."""
     return _MOCK_TEST_ACCOUNT
+
+
+def _split_stderr_runner() -> CliRunner:
+    """Click 8.1/8.3 양쪽에서 stderr 분리 캡처를 요청한다."""
+    if "mix_stderr" in inspect.signature(CliRunner).parameters:
+        return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 def _patch_init(*, master_exists: bool = False, test_account_exists: bool = False):
@@ -411,8 +419,8 @@ class TestInitFiveStateGuard:
         bootstrap_mock = AsyncMock(side_effect=_mock_bootstrap)
         create_acc_mock = AsyncMock(side_effect=RuntimeError("DB lock"))
 
-        # mix_stderr=False로 stdout/stderr 분리
-        runner_split = CliRunner(mix_stderr=False)
+        # Click 버전별 stderr 캡처 API 차이를 흡수한다.
+        runner_split = _split_stderr_runner()
 
         with (
             patch("ante.cli.commands.init._bootstrap_master", new=bootstrap_mock),
@@ -888,7 +896,7 @@ class TestInitCredentialsSingleEmission:
     ):
         """JSON 성공 경로 — stderr에 master_bootstrap_complete 이벤트 없음."""
         target = tmp_path / "config"
-        runner_split = CliRunner(mix_stderr=False)
+        runner_split = _split_stderr_runner()
 
         bootstrap_mock = AsyncMock(side_effect=_mock_bootstrap)
         create_acc_mock = AsyncMock(side_effect=_mock_create_test_account)
@@ -932,7 +940,7 @@ class TestInitCredentialsSingleEmission:
     def test_json_failure_preserves_credentials_in_stderr(self, runner, tmp_path):
         """JSON 실패 경로 — stderr에 master_bootstrap_complete 이벤트(비밀값 포함)."""
         target = tmp_path / "config"
-        runner_split = CliRunner(mix_stderr=False)
+        runner_split = _split_stderr_runner()
 
         bootstrap_mock = AsyncMock(side_effect=_mock_bootstrap)
         create_acc_mock = AsyncMock(side_effect=RuntimeError("DB lock"))

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -966,10 +966,11 @@ class TestInitCredentialsSingleEmission:
         # stderr에 master_bootstrap_complete 이벤트 (복구 수단)
         assert "master_bootstrap_complete" in result.stderr
         # stdout에는 에러 payload, 비밀값 미포함
-        assert _MOCK_TOKEN not in result.output, (
-            f"JSON 실패 payload(stdout)에 토큰 포함: {result.output!r}"
+        stdout = result.stdout
+        assert _MOCK_TOKEN not in stdout, (
+            f"JSON 실패 payload(stdout)에 토큰 포함: {stdout!r}"
         )
-        assert _MOCK_RECOVERY_KEY not in result.output
+        assert _MOCK_RECOVERY_KEY not in stdout
         # stderr에는 비밀값 정확히 1회
         assert result.stderr.count(_MOCK_TOKEN) == 1
         assert result.stderr.count(_MOCK_RECOVERY_KEY) == 1

--- a/tests/unit/test_cli_main_db_path.py
+++ b/tests/unit/test_cli_main_db_path.py
@@ -190,8 +190,7 @@ def test_get_data_path_reads_system_toml(
     custom_dir.mkdir()
     custom_data = tmp_path / "shared" / "ante-data"
     (custom_dir / "system.toml").write_text(
-        "[db]\npath = \"/tmp/ante.db\"\n\n"
-        f'[data]\npath = "{custom_data}"\n'
+        f'[db]\npath = "/tmp/ante.db"\n\n[data]\npath = "{custom_data}"\n'
     )
 
     ctx = click.Context(cli, obj={"config_dir": custom_dir})
@@ -204,8 +203,7 @@ def test_get_data_path_env_var(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
     env_dir.mkdir()
     custom_data = tmp_path / "env-data"
     (env_dir / "system.toml").write_text(
-        "[db]\npath = \"/tmp/ante.db\"\n\n"
-        f'[data]\npath = "{custom_data}"\n'
+        f'[db]\npath = "/tmp/ante.db"\n\n[data]\npath = "{custom_data}"\n'
     )
     monkeypatch.setenv("ANTE_CONFIG_DIR", str(env_dir))
 
@@ -220,8 +218,7 @@ def test_get_data_path_override_beats_env(
     env_dir = tmp_path / "env-cfg"
     env_dir.mkdir()
     (env_dir / "system.toml").write_text(
-        "[db]\npath = \"/tmp/env-ante.db\"\n\n"
-        '[data]\npath = "/should-not-be-used"\n'
+        '[db]\npath = "/tmp/env-ante.db"\n\n[data]\npath = "/should-not-be-used"\n'
     )
     monkeypatch.setenv("ANTE_CONFIG_DIR", str(env_dir))
 
@@ -229,8 +226,7 @@ def test_get_data_path_override_beats_env(
     override_dir.mkdir()
     custom_data = tmp_path / "override-data"
     (override_dir / "system.toml").write_text(
-        "[db]\npath = \"/tmp/override-ante.db\"\n\n"
-        f'[data]\npath = "{custom_data}"\n'
+        f'[db]\npath = "/tmp/override-ante.db"\n\n[data]\npath = "{custom_data}"\n'
     )
 
     ctx = click.Context(cli, obj={"config_dir": override_dir})


### PR DESCRIPTION
## 요약

- ruff I001 실패를 내던 `src/ante/__init__.py` import block을 정렬했습니다.
- ruff E501 실패를 내던 `src/ante/main.py` notification warning 로그를 줄바꿈했습니다.
- CI의 `ruff format --check`가 잡은 `tests/unit/test_cli_main_db_path.py` 포맷 드리프트를 정리했습니다.
- 같은 `lint` job의 MyPy 단계가 최신 Click 타입에서 실패하지 않도록 `LeafAwareGroup` 타입 좁히기를 `click.Group` 기준으로 조정했습니다.
- 최신 Click에서 `CliRunner(mix_stderr=False)`가 제거되고 `result.output`이 stderr를 포함하는 환경도 통과하도록 stderr 분리 테스트 헬퍼와 stdout 기준 검증을 추가했습니다.

## 검증

- `python3 -m ruff check src/ tests/`
- `python3 -m ruff format --check src/ tests/`
- `python3 -m mypy src/`

Fixes #1147