### PR TITLE
chore(ci): mark AI review as advisory check

### DIFF
--- a/.agent/commands/autopilot.md
+++ b/.agent/commands/autopilot.md
@@ -23,7 +23,7 @@ GitHub 조회/코멘트/PR 관련 절차는 `.agent/skills/github-ops.md`를 따
 
 - Plan Preflight 결과가 이슈 본문 구현계획으로 확정되었고
 - 이슈가 `/implement-issue`를 통해 실제 수정과 PR 생성까지 진행되었고
-- 같은 이슈의 CI + 승인 + auto-merge + post-merge가 확인되었음
+- 같은 이슈의 `ci` 통과 + auto-merge + post-merge가 확인되었음 (AI 승인은 advisory monitoring)
 
 `--handoff-only`일 때만 PR 생성 후 기존 리뷰 게이트 인계에서 종료한다.
 

--- a/.agent/commands/autopilot.md
+++ b/.agent/commands/autopilot.md
@@ -38,8 +38,8 @@ GitHub 조회/코멘트/PR 관련 절차는 `.agent/skills/github-ops.md`를 따
    - `/implement-issue #{번호}`를 호출해 실제 수정, 검증, PR 생성까지 진행한다.
    - Plan Preflight의 tasks, verification, risk flags, stop conditions는 구현 프롬프트에 강제 반영할 항목이다.
 3. **머지 모니터링 사이클**
-   - CI, `claude-pr-approve`, `codex-pr-approve`, auto-merge, `post-merge`까지 같은 이슈를 계속 추적한다.
-   - 승인 워커의 `content` FAIL은 현재 이슈의 수정 루프 일부로 간주하며, 다음 이슈로 넘어가지 않는다.
+   - 머지 조건은 `ci` + `merge-gate` + auto-merge + `post-merge`다. `claude-pr-approve` / `codex-pr-approve`는 advisory monitoring으로 함께 보지만 머지 차단 게이트가 아니다.
+   - 승인 워커의 `content` FAIL은 advisory 신호이므로 머지를 막지 않지만, autopilot은 현재 이슈의 advisory 자동 재수정 루프가 정리될 때까지 다음 이슈로 넘어가지 않는다.
 
 별도 선행 작업:
 
@@ -247,12 +247,16 @@ Plan Preflight는 의견만 남기고 종료하는 단계가 아니다. autopilo
 
 PR이 생성되면 autopilot은 같은 이슈에 머물며 아래를 순서대로 모니터링한다.
 
-1. `ci`
-2. `claude-pr-approve`
-3. `codex-pr-approve`
-4. `merge-gate`
-5. auto-merge
-6. `post-merge` 후처리
+1. `ci` (required, 머지 차단 게이트)
+2. `merge-gate`
+3. auto-merge
+4. `post-merge` 후처리
+
+advisory monitoring으로 함께 살피지만 머지 차단 게이트가 아닌 신호:
+
+- `claude-pr-approve` (advisory)
+- `codex-pr-approve` (advisory)
+- `claude-pr-fix` 자동 재수정 루프 (advisory)
 
 모니터링 규칙:
 

--- a/.agent/commands/implement-issue.md
+++ b/.agent/commands/implement-issue.md
@@ -243,20 +243,19 @@ PR 생성 후 이슈에 코멘트를 남긴다:
 gh issue comment #{이슈번호} --body "🤖 **PR 생성 완료**
 - PR: #{PR번호}
 - branch-review: `/codex:review --base {base}` PASS
-- 이후 단계: CI + claude-pr-approve + codex-pr-approve + auto-merge"
+- 이후 단계: ci required + AI 승인 advisory + auto-merge"
 ```
 
 ### PR 이후 단계
 
 13. **최종 승인과 머지**: PR 생성 이후에는 GitHub automation이 다음을 수행한다.
 
-- `ci`
-- `claude-pr-approve`
-- `codex-pr-approve`
-- PR 승인 `content` FAIL 시 Claude는 `.agent/skills/receive-review.md` 규칙으로 finding을 정리한 뒤 자동 재수정을 최대 10회 수행
+- `ci` 통과는 머지 차단 게이트다. (required status check)
+- `claude-pr-approve`, `codex-pr-approve`는 advisory check이며 머지 가능 여부를 결정하지 않는다.
+- AI 승인 워커가 `content` FAIL을 남기면 Claude는 `.agent/skills/receive-review.md` 규칙으로 finding을 정리한 뒤 자동 재수정을 최대 10회 수행한다. (advisory 신호)
 - 구조 리스크가 반복되면 `@code-reviewer` 메타 리뷰 우선
-- `quota`, `script_error`, `auth_error`, `infra_error`는 자동 재수정 없이 중단 사유만 남김
-- 모든 체크가 green이면 auto-merge
+- AI 워커의 `quota`, `script_error`, `auth_error`, `infra_error`는 자동 재수정 없이 중단 사유만 남긴다. 머지를 막지는 않는다.
+- `ci` 통과 + 충돌 없음 + 대화 해결 완료 + auto-merge 활성화 가능 상태이면 GitHub auto-merge가 squash merge를 수행한다.
 - 머지 후 post-merge automation이 이슈 체크박스를 갱신하고 close
 - `/autopilot` 실행 중이면 최신 `🤖 **Autopilot 사이클 상태**` 이슈 코멘트를 `current-cycle=merge-monitor`에서 `completed`까지 갱신한다.
 - `post-merge.yml`은 연결 이슈에 `🤖 **Post-merge 정리 완료**` 코멘트를 남긴다.
@@ -296,7 +295,7 @@ git push -u origin epic/#{에픽번호}-{짧은설명}
 1. 에픽 브랜치 최신화 및 로컬 검증
 2. `/codex:review --base main` 통과
 3. `epic/* -> main` PR 생성
-4. `ci + claude-pr-approve + codex-pr-approve` 통과 후 auto-merge
+4. `ci` 통과 후 auto-merge (`claude-pr-approve`/`codex-pr-approve`는 advisory)
 
 ### E5. 정리
 

--- a/.agent/commands/release.md
+++ b/.agent/commands/release.md
@@ -137,7 +137,7 @@ PR 본문에는 다음을 포함한다.
 - Docker build 검증 결과
 - publish는 merge 후 `/release publish`에서만 수행한다는 문구
 
-release PR도 일반 PR과 동일하게 CI, Claude PR 승인, Codex PR 승인을 통과해야 한다.
+release PR도 일반 PR과 동일하게 `ci`를 통과해야 한다. Claude PR 승인, Codex PR 승인은 advisory check이며 머지 차단 게이트가 아니다.
 
 ## `/release publish`
 

--- a/.github/workflows/pr-approvals.yml
+++ b/.github/workflows/pr-approvals.yml
@@ -549,31 +549,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Wait for ci workflow success
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          deadline=$(( $(date +%s) + 5400 ))  # 90분 한도 (ci.yml test 잡 timeout 45분 + 큐/다른 step 여유)
-          while [ "$(date +%s)" -lt "$deadline" ]; do
-            run_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$HEAD_SHA&event=pull_request" --jq '[.workflow_runs[] | select(.path == ".github/workflows/ci.yml")] | .[0] // {}')
-            status=$(echo "$run_json" | jq -r '.status // "missing"')
-            conclusion=$(echo "$run_json" | jq -r '.conclusion // ""')
-            if [ "$status" = "completed" ]; then
-              if [ "$conclusion" = "success" ]; then
-                echo "ci workflow succeeded for $HEAD_SHA"
-                exit 0
-              fi
-              echo "ci workflow concluded with: $conclusion"
-              exit 1
-            fi
-            echo "ci workflow status=$status conclusion=$conclusion (waiting 30s)"
-            sleep 30
-          done
-          echo "Timed out waiting for ci workflow on $HEAD_SHA"
-          exit 1
-
       - name: Dispatch post-merge reconciliation
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-approvals.yml
+++ b/.github/workflows/pr-approvals.yml
@@ -549,6 +549,31 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Wait for ci workflow success
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          deadline=$(( $(date +%s) + 1800 ))  # 30분 한도
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            run_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$HEAD_SHA&event=pull_request" --jq '[.workflow_runs[] | select(.path == ".github/workflows/ci.yml")] | .[0] // {}')
+            status=$(echo "$run_json" | jq -r '.status // "missing"')
+            conclusion=$(echo "$run_json" | jq -r '.conclusion // ""')
+            if [ "$status" = "completed" ]; then
+              if [ "$conclusion" = "success" ]; then
+                echo "ci workflow succeeded for $HEAD_SHA"
+                exit 0
+              fi
+              echo "ci workflow concluded with: $conclusion"
+              exit 1
+            fi
+            echo "ci workflow status=$status conclusion=$conclusion (waiting 30s)"
+            sleep 30
+          done
+          echo "Timed out waiting for ci workflow on $HEAD_SHA"
+          exit 1
+
       - name: Dispatch post-merge reconciliation
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-approvals.yml
+++ b/.github/workflows/pr-approvals.yml
@@ -542,10 +542,7 @@ jobs:
 
   merge-gate:
     name: merge-gate
-    if: ${{ vars.AI_REVIEW_ENABLED == 'true' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false }}
-    needs:
-      - claude-pr-approve
-      - codex-pr-approve
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/pr-approvals.yml
+++ b/.github/workflows/pr-approvals.yml
@@ -555,7 +555,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          deadline=$(( $(date +%s) + 1800 ))  # 30분 한도
+          deadline=$(( $(date +%s) + 5400 ))  # 90분 한도 (ci.yml test 잡 timeout 45분 + 큐/다른 step 여유)
           while [ "$(date +%s)" -lt "$deadline" ]; do
             run_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$HEAD_SHA&event=pull_request" --jq '[.workflow_runs[] | select(.path == ".github/workflows/ci.yml")] | .[0] // {}')
             status=$(echo "$run_json" | jq -r '.status // "missing"')

--- a/docs/runbooks/01-development-process.md
+++ b/docs/runbooks/01-development-process.md
@@ -80,11 +80,11 @@ Claude 오케스트레이터
   │     └── PR 생성 (`Closes #이슈`) + PR 생성 완료: 이슈 코멘트
   │
   ├──▶ PR 게이트 (GitHub Actions)
-  │     ├── CI (`ci`)
-  │     ├── Claude PR 승인 (`claude-pr-approve`)
-  │     ├── Codex PR 승인 (`codex-pr-approve`)
-  │     ├── content FAIL → Claude PR repair 후 같은 PR에서 재검증
-  │     └── 모든 게이트 green → GitHub auto-merge
+  │     ├── CI (`ci`) — required, 머지 차단 게이트
+  │     ├── Claude PR 승인 (`claude-pr-approve`) — advisory
+  │     ├── Codex PR 승인 (`codex-pr-approve`) — advisory
+  │     ├── content FAIL → Claude PR repair 후 같은 PR에서 재검증 (advisory 신호)
+  │     └── `ci` green + 충돌 없음 + 대화 해결 → GitHub auto-merge
   │        └── `/autopilot` 실행 중이면 사이클 상태: 이슈 코멘트
   │
   ├──▶ post-merge automation
@@ -225,9 +225,9 @@ release PR은 릴리스 메타데이터와 Docker build 검증만 포함하며, 
 > 상세 규칙: [04-ci-cd.md](04-ci-cd.md)
 
 - **브랜치 리뷰 단계**: Codex만 수행한다. GitHub Actions가 아니라 `/codex:review --base <ref>` 내부 루프로 도는 PR 전 품질 게이트다.
-- **PR 승인 단계**: Claude와 Codex가 각각 독립적으로 수행한다.
+- **PR 승인 단계**: Claude와 Codex가 각각 독립적으로 수행한다. 두 승인은 advisory check이며 머지 게이트 입력이 아니다.
 - **메타 리뷰 단계**: `@code-reviewer`는 상시 게이트가 아니라, 고위험 변경과 반복 failure에서만 호출한다.
-- **소스 오브 트루스**: 브랜치 리뷰는 이슈 코멘트의 최신 `/codex:review` PASS 기록을 PR 생성 조건으로 삼고, PR 승인과 CI는 **status check 결과**를 merge gate의 기준으로 삼는다.
+- **소스 오브 트루스**: 브랜치 리뷰는 이슈 코멘트의 최신 `/codex:review` PASS 기록을 PR 생성 조건으로 삼고, merge gate는 **`ci` status check + 충돌 없음 + 대화 해결**을 기준으로 삼는다. AI 승인 status check는 advisory 신호이며 머지 가능 여부 판정에 들어가지 않는다.
 - **머지 담당**: GitHub auto-merge
 - **이슈 close**: PR 본문의 `Closes #N`으로 GitHub 기본 auto-close를 우선 사용하고, `post-merge`가 체크박스/에픽 동기화와 수동 복구를 맡는다.
 - **원격 브랜치 삭제**: GitHub의 "Automatically delete head branches" 기능 사용

--- a/docs/runbooks/02-agent-structure.md
+++ b/docs/runbooks/02-agent-structure.md
@@ -76,7 +76,7 @@ Codex는 `.agent/` 내부 에이전트가 아니라 GitHub 이벤트에 반응�
 |------|--------|------|
 | **Codex Plan Review 워커** | `plan-preflight:started` 라벨 또는 구현 전 계획 검증 필요 | `/codex:adversarial-review`로 구현계획의 가정, 위험, 대안을 검토하고 이슈 코멘트에 verdict 기록 |
 | **Codex 브랜치 리뷰어** | `/implement-issue`의 PR 생성 전 내부 `/codex:review --base <ref>` 실행 | PR 전 blocking issue 식별, 이슈 코멘트에 PASS/FAIL 기록 |
-| **Codex PR 승인 워커** | `pull_request` opened/synchronize/ready_for_review | 최종 승인 체크, `codex-pr-approve` 상태 기록 |
+| **Codex PR 승인 워커** | `pull_request` opened/synchronize/ready_for_review | advisory check, branch protection required 아님. `codex-pr-approve` 상태 기록 |
 
 ### 1.8 Claude PR 승인 워커
 
@@ -84,7 +84,7 @@ Claude도 PR 단계에서는 독립 승인 워커로 동작한다.
 
 | 역할 | 트리거 | 책임 |
 |------|--------|------|
-| **Claude PR 승인 워커** | `pull_request` opened/synchronize/ready_for_review | 최종 승인 체크, `claude-pr-approve` 상태 기록 |
+| **Claude PR 승인 워커** | `pull_request` opened/synchronize/ready_for_review | advisory check, branch protection required 아님. `claude-pr-approve` 상태 기록 |
 
 ## 2. `.agent/` 및 `.claude/` 디렉토리 구조
 

--- a/docs/runbooks/03-git-workflow.md
+++ b/docs/runbooks/03-git-workflow.md
@@ -151,21 +151,21 @@ PR을 열기 전, 최신 로컬 브랜치 HEAD는 반드시 Codex 사전 리뷰�
 ### 4.2 PR 머지 조건
 
 1. `ci` 성공
-2. `claude-pr-approve` 성공
-3. `codex-pr-approve` 성공
-4. 충돌 없음
-5. 미해결 대화 없음
-6. auto-merge 활성화 가능 상태
+2. 충돌 없음
+3. 미해결 대화 없음
+4. auto-merge 활성화 가능 상태
+
+`claude-pr-approve`와 `codex-pr-approve`는 advisory check이며 머지 조건이 아니다. PR 본문/코멘트에서는 advisory 보조 신호로 참고하지만, 실패해도 머지 게이트를 막지 않는다.
 
 ### 4.3 PR 승인 실패 처리
 
-- `claude-pr-approve` 또는 `codex-pr-approve`가 `content` FAIL이면 Claude가 같은 PR 브랜치에서 자동 재수정을 시도한다.
+- `claude-pr-approve` 또는 `codex-pr-approve`가 `content` FAIL이면 Claude가 같은 PR 브랜치에서 자동 재수정을 시도한다. 두 승인은 advisory check이므로 자동 재수정 루프 자체는 머지를 막는 게이트가 아니라 권고 신호다.
 - 자동 재수정은 최대 10회까지 허용한다.
 - `quota`, `script_error`, `auth_error`, `infra_error`는 코드 내용 실패로 보지 않으며, 자동 재수정 횟수에 포함하지 않는다.
 - 자동 재수정 결과가 `NO_CHANGES`이면, 이를 성공으로 취급하지 않고 메타 리뷰 또는 수동 수정 단계로 승격한다.
 - 같은 head SHA에서 재실행만 필요할 때는 `gh run rerun`을 우선한다.
 - `pull_request` 이벤트 자체를 다시 발생시켜야 할 때만 PR `close → reopen`을 예외적으로 허용하고, 재트리거 이유를 PR 코멘트에 남긴다.
-- 10회 소진 시 `blocked:pr-review-loop` 라벨을 붙이고 PR을 사람 확인 대상으로 넘긴다.
+- 10회 소진 시 `blocked:pr-review-loop` 라벨을 붙이고 PR을 사람 확인 대상으로 넘긴다. advisory 환경에서도 `blocked:pr-review-loop`는 자동 재수정 루프 종료 신호로 유지하며, 사람이 advisory finding을 검토한 뒤 머지 여부를 판단한다.
 
 ### 4.4 머지 방식
 
@@ -186,8 +186,7 @@ PR을 열기 전, 최신 로컬 브랜치 HEAD는 반드시 Codex 사전 리뷰�
 
 - required status checks:
   - `ci`
-  - `claude-pr-approve`
-  - `codex-pr-approve`
+- AI 승인(`claude-pr-approve`, `codex-pr-approve`)은 advisory check이므로 required status checks에 포함하지 않는다.
 - require conversation resolution
 - allow auto-merge
 - automatically delete head branches

--- a/docs/runbooks/04-ci-cd.md
+++ b/docs/runbooks/04-ci-cd.md
@@ -29,15 +29,15 @@ Claude 구현 (worktree 격리)
   │
   ├──▶ [Gate B] ci ─────────────────────── 실패 → Claude 또는 DevOps가 수정
   │
-  ├──▶ [Gate C] claude-pr-approve ─────── content 실패 → Claude 자동 재수정
+  ├──▶ [Gate C] claude-pr-approve (advisory) ─ content 실패 → Claude 자동 재수정 (권고 신호)
   │
-  ├──▶ [Gate D] codex-pr-approve ──────── content 실패 → Claude 자동 재수정
+  ├──▶ [Gate D] codex-pr-approve (advisory) ── content 실패 → Claude 자동 재수정 (권고 신호)
   │
   ├──▶ [Meta] code-reviewer ───────────── 고위험 변경 / 반복 risk class 시 원인 분석
   │
   ├──▶ [Loop] Claude PR repair ────────── 최대 10회, quota/script/auth/infra는 제외
   │
-  ├──▶ [Gate E] merge-gate ────────────── 모든 게이트 성공 시 auto-merge
+  ├──▶ [Gate E] merge-gate ────────────── ci 통과 + 충돌 없음 + 대화 해결 시 auto-merge
   │
   ▼
 post-merge automation
@@ -95,27 +95,29 @@ post-merge automation
 
 ### Gate C — Claude PR 승인
 
-**목적**: PR head SHA 기준 계약/스펙/테스트 최종 확인
+**목적**: PR head SHA 기준 계약/스펙/테스트 최종 확인 (advisory)
 
 - **트리거**: `pull_request` opened / synchronize / ready_for_review
 - **결과**: `claude-pr-approve`
+- **성격**: **advisory check이며 branch protection의 required status check가 아니다.** 머지 게이트(Gate E)는 이 결과를 입력으로 삼지 않는다.
 - **기준**: `.agent/skills/review-pr.md`
 - **후속 처리**:
-  - `content` FAIL → Claude 자동 재수정 루프
+  - `content` FAIL → Claude 자동 재수정 루프 (advisory 환경에서도 동작하나 PR 머지를 차단하는 게이트가 아니라 권고 신호)
   - `quota/script_error/auth_error/infra_error` → 재수정 없이 PR 코멘트로 중단 사유 기록
-- **해석 주의**: review 결과 파일이 있고 마지막 verdict step만 실패하면, 빨간 체크는 실제 finding을 의미한다.
+- **해석 주의**: review 결과 파일이 있고 마지막 verdict step만 실패하면, 빨간 체크는 실제 finding을 의미한다. 머지를 차단하지는 않지만 사람/오케스트레이터가 검토해야 할 신호다.
 
 ### Gate D — Codex PR 승인
 
-**목적**: PR head SHA 기준 독립 교차검증
+**목적**: PR head SHA 기준 독립 교차검증 (advisory)
 
 - **트리거**: `pull_request` opened / synchronize / ready_for_review
 - **결과**: `codex-pr-approve`
+- **성격**: **advisory check이며 branch protection의 required status check가 아니다.** 머지 게이트(Gate E)는 이 결과를 입력으로 삼지 않는다.
 - **기준**: `.agent/skills/review-pr.md`
 - **후속 처리**:
-  - `content` FAIL → Claude 자동 재수정 루프
+  - `content` FAIL → Claude 자동 재수정 루프 (advisory 환경에서도 동작하나 PR 머지를 차단하는 게이트가 아니라 권고 신호)
   - `quota/script_error/auth_error/infra_error` → 재수정 없이 PR 코멘트로 중단 사유 기록
-- **해석 주의**: review 결과 생성 후 verdict gate만 실패한 경우, CI 인프라 문제보다 코드/계약 finding을 먼저 본다.
+- **해석 주의**: review 결과 생성 후 verdict gate만 실패한 경우, CI 인프라 문제보다 코드/계약 finding을 먼저 본다. 머지를 차단하지는 않지만 사람/오케스트레이터가 검토해야 할 신호다.
 
 ### PR 승인 공통 원칙
 
@@ -162,11 +164,12 @@ post-merge automation
 **목적**: 머지 가능성만 판단하는 정책 게이트
 
 입력:
-- `ci`
-- `claude-pr-approve`
-- `codex-pr-approve`
-- 충돌 여부
-- 대화 해결 여부
+- `ci` (required)
+- 충돌 없음
+- 대화 해결 완료
+- auto-merge 활성화 가능 상태
+
+AI 승인(`claude-pr-approve`, `codex-pr-approve`)은 advisory check이므로 merge gate의 입력이 아니다. AI 승인 실패는 머지 게이트를 막지 않는다.
 
 출력:
 - auto-merge 활성화 또는 유지
@@ -176,7 +179,7 @@ post-merge automation
 - 머지 불가 시 대기
 
 **원칙**: merge gate는 세 번째 코드 리뷰어가 아니라 **정책 집행자**다.
-코드 품질을 새로 판단하지 않고, CI와 승인 상태만 집행한다.
+코드 품질을 새로 판단하지 않고, CI와 머지 가능성만 집행한다.
 
 ### Post-merge 책임 분리
 
@@ -218,8 +221,8 @@ GitHub branch protection에서 required status checks를 사용할 경우, 각 j
 - `codex-pr-approve`는 self-hosted runner label `codex-review`를 전제로 한다.
 - PR 전 Codex 브랜치 리뷰는 runner workflow가 아니라 Claude 세션의 `/codex:review --base <ref>` 내부 루프로 수행한다.
 - `claude-pr-approve`는 self-hosted runner label `claude-review`를 전제로 한다.
-- 저장소 변수 `AI_REVIEW_ENABLED=true`일 때만 PR 단계 AI 리뷰 workflow를 활성화한다.
-- runner가 준비되기 전에는 `AI_REVIEW_ENABLED`를 비워 두거나 `false`로 유지한다.
+- self-hosted runner가 준비되지 않은 상태는 정상 운영 상태다. AI 리뷰는 advisory이므로 runner가 없어도 PR 머지가 차단되지 않는다.
+- 저장소 변수 `AI_REVIEW_ENABLED`는 **선택 리뷰 workflow 활성화 플래그**다. `true`일 때만 advisory 리뷰 잡을 실행하며, 비어 있거나 `false`이면 advisory 리뷰만 생략된다. merge gate는 이 플래그와 무관하게 동작한다.
 
 ### 3.3 저장소 설정 권장값
 
@@ -227,8 +230,7 @@ GitHub branch protection에서 required status checks를 사용할 경우, 각 j
 - `Automatically delete head branches`: 활성화
 - branch protection required status checks:
   - `ci`
-  - `claude-pr-approve`
-  - `codex-pr-approve`
+- AI 승인(`claude-pr-approve`, `codex-pr-approve`)은 advisory check이므로 required status checks에 포함하지 않는다.
 - `Require conversation resolution before merging`: 활성화 권장
 
 ### 3.4 AI 리뷰 러너 / 검증 환경 체크리스트
@@ -261,15 +263,15 @@ pytest tests/unit/ -v
 실제 명령 실행과 GitHub 코멘트 절차는 `.agent/skills/github-ops.md`를 따르고,
 구현 전 브랜치 리뷰 실행 루프는 `.agent/commands/implement-issue.md`와 [03-git-workflow.md](03-git-workflow.md)를 따른다.
 
-| 실패 게이트 | 주 원인 | 복구 담당 |
-|------------|--------|----------|
-| `/codex:review` | 설계/코드 품질 문제 | Claude 개발 에이전트 |
-| `ci` | lint/test/type/CI 설정 | Claude 개발 에이전트 또는 `@devops` |
-| `claude-pr-approve` | 스펙/계약/테스트 누락 | Claude 자동 재수정 워커 또는 `@devops` |
-| `codex-pr-approve` | 버그/회귀/설계 위반 | Claude 자동 재수정 워커 또는 `@devops` |
+| 실패 게이트 | 성격 | 머지 차단 여부 | 주 원인 | 복구 담당 |
+|------------|-----|---------------|--------|----------|
+| `/codex:review` | PR 전 advisory | PR 생성 차단 (이슈 증적) | 설계/코드 품질 문제 | Claude 개발 에이전트 |
+| `ci` | required | 차단 | lint/test/type/CI 설정 | Claude 개발 에이전트 또는 `@devops` |
+| `claude-pr-approve` | advisory | 차단하지 않음 | 스펙/계약/테스트 누락 | Claude 자동 재수정 워커 또는 `@devops` |
+| `codex-pr-approve` | advisory | 차단하지 않음 | 버그/회귀/설계 위반 | Claude 자동 재수정 워커 또는 `@devops` |
 
 내부 `/codex:review` 브랜치 리뷰는 실패 이력을 이슈 코멘트에 누적하고, 같은 blocking finding 제목이 반복되면 escalation 신호를 남긴다. 실패가 10회 누적되면 `blocked:review-loop` 라벨을 붙이고 더 이상의 자동 브랜치 리뷰를 중단한다.
-`claude-pr-approve` / `codex-pr-approve`는 `content` FAIL일 때만 Claude 자동 재수정을 최대 10회 시도한다. `quota`, `script_error`, `auth_error`, `infra_error`는 자동 재수정을 건너뛰고 PR 코멘트에 원인을 남긴다.
+`claude-pr-approve` / `codex-pr-approve`는 advisory check이므로 실패해도 merge gate를 막지 않는다. 다만 `content` FAIL일 때 Claude 자동 재수정 루프는 advisory 신호로 계속 동작하며 최대 10회까지 시도한다. `quota`, `script_error`, `auth_error`, `infra_error`는 자동 재수정을 건너뛰고 PR 코멘트에 원인을 남긴다. 자동 재수정 루프 자체는 PR 차단 게이트가 아니라 권고 신호다.
 `lifecycle`, `contract-drift`, `generated-artifact-sync` 같은 구조 리스크가 2회 반복되면 Meta Review를 먼저 수행한다.
 
 ### 5.1 승인 루프 수동 복구 순서

--- a/docs/runbooks/04-ci-cd.md
+++ b/docs/runbooks/04-ci-cd.md
@@ -231,6 +231,7 @@ GitHub branch protection에서 required status checks를 사용할 경우, 각 j
 - branch protection required status checks:
   - `ci`
 - AI 승인(`claude-pr-approve`, `codex-pr-approve`)은 advisory check이므로 required status checks에 포함하지 않는다.
+- `main` 외에 `epic/**` 통합 브랜치도 같은 required status checks(`ci`)를 적용해 base가 epic이어도 ci 통과 없이는 머지되지 않도록 한다.
 - `Require conversation resolution before merging`: 활성화 권장
 
 ### 3.4 AI 리뷰 러너 / 검증 환경 체크리스트

--- a/docs/runbooks/06-release.md
+++ b/docs/runbooks/06-release.md
@@ -67,7 +67,7 @@
 | 커밋 | `chore(release): vX.Y.Z` |
 | 허용 변경 | `pyproject.toml`, `CHANGELOG.md`, 릴리스 노트 등 릴리스 메타데이터 |
 | 금지 변경 | 기능 수정, 버그 수정, 스펙 변경, unrelated workflow 변경 |
-| PR 게이트 | 일반 PR과 동일하게 CI, Claude PR 승인, Codex PR 승인 |
+| PR 게이트 | 일반 PR과 동일: `ci` required + Claude/Codex PR 승인 advisory |
 | Docker | PR에서는 build 검증만 수행하고 push 금지 |
 
 release PR이 열려 있는 동안 main에 새 커밋이 들어오면 release PR은 stale로 본다.


### PR DESCRIPTION
Closes #1151

## Summary

- AI 리뷰(`claude-pr-approve`, `codex-pr-approve`)를 GitHub branch protection의 required status check에서 advisory check로 전환한다.
- `merge-gate` 잡에서 `vars.AI_REVIEW_ENABLED == 'true'` 게이트와 `needs: [claude-pr-approve, codex-pr-approve]` 의존을 제거해 AI 리뷰 비활성/실패 상태에서도 PR 이벤트 시 즉시 auto-merge 활성화 + post-merge.yml dispatch가 진행된다. 머지 차단은 GitHub auto-merge가 branch protection의 required check를 기다리는 로직에 위임한다.
- 다섯 런북(`04-ci-cd.md`, `01-development-process.md`, `03-git-workflow.md`, `02-agent-structure.md`, `06-release.md`)과 두 커맨드(`autopilot.md`, `implement-issue.md`, `release.md`)에서 AI 승인을 advisory check로 정리했다. required는 `ci`만 남았다.
- `04-ci-cd.md` §3.3에 `epic/**` 통합 브랜치도 동일한 required status check(`ci`)를 적용해야 한다는 권장 라인을 추가했다.
- AI 리뷰 워커 본체(`claude-pr-approve`, `codex-pr-approve`, `claude-pr-fix`)와 `Enforce approval verdict` step, `/codex:review --base <ref>` 사전 브랜치 리뷰, `ci.yml`, `post-merge.yml`, `scripts/run_ai_review.sh`/`scripts/run_pr_fix.sh`/`scripts/ai_review.py`는 변경하지 않았다.

## Test Plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-approvals.yml'))"` PASS
- [x] `ruff check src/ tests/` PASS (코드 변경 없음)
- [x] `ruff format --check src/ tests/` PASS (코드 변경 없음)
- [x] 잔존 `claude-pr-approve`/`codex-pr-approve`/`AI_REVIEW_ENABLED` grep 결과 모두 advisory 맥락 표기 또는 식별자 인용임을 확인
- [x] Codex Plan Review: approve-implement (focus: assumptions, scope fit, missing consumers, generated artifacts, rollback/test gaps)
- [x] Codex 브랜치 리뷰 (`/codex:review --base main`) PASS — "diff 내에서 별도의 명확한 회귀나 차단 버그를 발견하지 못했습니다."

## 후속(수동) 작업 — 저장소 owner

이 PR이 머지되면 GitHub repo Settings → Branches → Branch protection rules에서 다음을 적용한다:

- `main` branch protection의 required status checks를 `ci`만 남기고 `claude-pr-approve`, `codex-pr-approve`를 제거한다.
- `epic/**` 통합 브랜치에도 같은 required status checks(`ci`)를 적용한다.

위 설정 적용 전에는 advisory 정책과 branch protection이 어긋나 PR 머지가 막힐 수 있다.