### PR TITLE
fix(account,web): expose POST /api/accounts request body OpenAPI schema (#1143)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -60,7 +60,7 @@
           "accounts"
         ],
         "summary": "Create Account",
-        "description": "계좌 생성.\n\n런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.\n실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로\n수행한다.\n\n의존성/Pydantic body schema/audit logger를 모두 시그니처에서 제외해\n핸들러 진입 즉시 409가 반환되도록 한다(invariant I1). 또한 OpenAPI에는\nsuccess contract(200/201/204)가 노출되지 않으며, 응답 모델은\n``ErrorResponse``로 고정된다(invariant I2/I3).\n\n이 경로의 service-layer 회귀 보호는 ``tests/unit/test_account.py``가\n담당한다.",
+        "description": "계좌 생성.\n\n런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.\n실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로\n수행한다.\n\n의존성/Pydantic body schema/audit logger를 모두 시그니처에서 제외해\n핸들러 진입 즉시 409가 반환되도록 한다(invariant I1). 또한 OpenAPI에는\nsuccess contract(200/201/204)가 노출되지 않으며, 응답 모델은\n``ErrorResponse``로 고정된다(invariant I2/I3).\n\n이 경로의 service-layer 회귀 보호는 ``tests/unit/test_account.py``가\n담당한다.\n\n본 PR(#1143)에서 OpenAPI requestBody schema가 spec-aligned\n``ACCOUNT_CREATE_REQUEST_SCHEMA``로 노출되어 codegen 클라이언트가\ncold-path payload 필드를 발견할 수 있게 됐다. 런타임은 어떤 body든\n무시하고 409를 반환한다.",
         "operationId": "create_account_api_accounts_post",
         "responses": {
           "409": {
@@ -69,6 +69,102 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "title": "AccountCreateRequest",
+                "description": "POST /api/accounts cold-path 입력 contract. 런타임에서는 cold-path 가드가 어떤 입력이든 즉시 409로 차단한다 (ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER). 실제 계좌 생성은 서버 정지 상태에서 ante account create CLI로 수행한다. 스키마 SSOT: docs/specs/account/03-data-model.md 60-87줄.",
+                "additionalProperties": false,
+                "required": [
+                  "account_id",
+                  "name",
+                  "exchange",
+                  "currency",
+                  "broker_type"
+                ],
+                "properties": {
+                  "account_id": {
+                    "type": "string",
+                    "description": "고유 식별자 (영문+숫자+하이픈, 3–30자)."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "사용자에게 표시되는 이름."
+                  },
+                  "exchange": {
+                    "type": "string",
+                    "enum": [
+                      "KRX",
+                      "NYSE",
+                      "NASDAQ",
+                      "TEST"
+                    ],
+                    "description": "대상 거래소 코드."
+                  },
+                  "currency": {
+                    "type": "string",
+                    "description": "거래 통화 (ISO 4217)."
+                  },
+                  "timezone": {
+                    "type": "string",
+                    "default": "Asia/Seoul",
+                    "description": "거래소 현지 시간대 (IANA)."
+                  },
+                  "trading_hours_start": {
+                    "type": "string",
+                    "default": "09:00",
+                    "description": "거래 시작 시각 (현지 시간, HH:MM)."
+                  },
+                  "trading_hours_end": {
+                    "type": "string",
+                    "default": "15:30",
+                    "description": "거래 종료 시각 (현지 시간, HH:MM)."
+                  },
+                  "trading_mode": {
+                    "type": "string",
+                    "enum": [
+                      "VIRTUAL",
+                      "LIVE"
+                    ],
+                    "default": "VIRTUAL",
+                    "description": "거래 모드 (VIRTUAL / LIVE)."
+                  },
+                  "broker_type": {
+                    "type": "string",
+                    "description": "브로커 어댑터 유형."
+                  },
+                  "credentials": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "default": {},
+                    "description": "브로커 인증 정보 (dict[str, str], 암호화 저장). cold-path 전용."
+                  },
+                  "broker_config": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "default": {},
+                    "description": "브로커 동작 설정 (예: KIS is_paper). 임의 키-값 dict. cold-path 전용."
+                  },
+                  "buy_commission_rate": {
+                    "type": "number",
+                    "default": 0,
+                    "description": "매수 수수료율 (cold-path 전용)."
+                  },
+                  "sell_commission_rate": {
+                    "type": "number",
+                    "default": 0,
+                    "description": "매도 수수료율, 세금 포함 (cold-path 전용)."
+                  }
                 }
               }
             }

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -32,6 +32,11 @@ export type paths = {
          *
          *     이 경로의 service-layer 회귀 보호는 ``tests/unit/test_account.py``가
          *     담당한다.
+         *
+         *     본 PR(#1143)에서 OpenAPI requestBody schema가 spec-aligned
+         *     ``ACCOUNT_CREATE_REQUEST_SCHEMA``로 노출되어 codegen 클라이언트가
+         *     cold-path payload 필드를 발견할 수 있게 됐다. 런타임은 어떤 body든
+         *     무시하고 409를 반환한다.
          */
         post: operations["create_account_api_accounts_post"];
         delete?: never;
@@ -3266,7 +3271,70 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description 고유 식별자 (영문+숫자+하이픈, 3–30자). */
+                    account_id: string;
+                    /**
+                     * @description 브로커 동작 설정 (예: KIS is_paper). 임의 키-값 dict. cold-path 전용.
+                     * @default {}
+                     */
+                    broker_config?: {
+                        [key: string]: unknown;
+                    };
+                    /** @description 브로커 어댑터 유형. */
+                    broker_type: string;
+                    /**
+                     * @description 매수 수수료율 (cold-path 전용).
+                     * @default 0
+                     */
+                    buy_commission_rate?: number;
+                    /**
+                     * @description 브로커 인증 정보 (dict[str, str], 암호화 저장). cold-path 전용.
+                     * @default {}
+                     */
+                    credentials?: {
+                        [key: string]: string;
+                    };
+                    /** @description 거래 통화 (ISO 4217). */
+                    currency: string;
+                    /**
+                     * @description 대상 거래소 코드.
+                     * @enum {string}
+                     */
+                    exchange: "KRX" | "NYSE" | "NASDAQ" | "TEST";
+                    /** @description 사용자에게 표시되는 이름. */
+                    name: string;
+                    /**
+                     * @description 매도 수수료율, 세금 포함 (cold-path 전용).
+                     * @default 0
+                     */
+                    sell_commission_rate?: number;
+                    /**
+                     * @description 거래소 현지 시간대 (IANA).
+                     * @default Asia/Seoul
+                     */
+                    timezone?: string;
+                    /**
+                     * @description 거래 종료 시각 (현지 시간, HH:MM).
+                     * @default 15:30
+                     */
+                    trading_hours_end?: string;
+                    /**
+                     * @description 거래 시작 시각 (현지 시간, HH:MM).
+                     * @default 09:00
+                     */
+                    trading_hours_start?: string;
+                    /**
+                     * @description 거래 모드 (VIRTUAL / LIVE).
+                     * @default VIRTUAL
+                     * @enum {string}
+                     */
+                    trading_mode?: "VIRTUAL" | "LIVE";
+                };
+            };
+        };
         responses: {
             /** @description ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 생성 차단 */
             409: {

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -54,6 +54,111 @@ STRUCTURAL_FIELDS: tuple[str, ...] = (
 STRUCTURAL_CHANGE_ERROR_CODE = "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER"
 
 
+# POST /api/accounts cold-path 전용 OpenAPI request body 문서.
+# 출처: docs/specs/account/03-data-model.md 60-87줄 필드 표(SSOT) +
+# docs/specs/account/04-account-service.md 51-58줄 cold-path 전용 필드.
+#
+# 런타임 라우트는 cold-path 가드로 어떤 입력이든 즉시 409로 차단되지만
+# (invariant I1), Swagger UI / agent client / SDK는 cold-path 계좌 생성
+# payload 필드를 정확히 발견할 수 있어야 한다(이슈 #1143).
+#
+# ``AccountCreateRequest.model_json_schema()`` 직접 노출 금지: BrokerPreset
+# 자동 채움 때문에 Pydantic 모델은 모든 필드가 default를 갖고 있어 spec 표
+# (``exchange``/``currency``/``broker_type`` required)와 어긋난다(#1143
+# attempt 6 finding). 본 dict 상수는 spec과 1:1 정합한 cold-path 문서 전용
+# schema이며, ``AccountCreateRequest`` Pydantic 모델은 다른 소비자(테스트,
+# CLI 등) 호환을 위해 변경하지 않는다.
+ACCOUNT_CREATE_REQUEST_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "title": "AccountCreateRequest",
+    "description": (
+        "POST /api/accounts cold-path 입력 contract. "
+        "런타임에서는 cold-path 가드가 어떤 입력이든 즉시 409로 차단한다 "
+        "(ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER). "
+        "실제 계좌 생성은 서버 정지 상태에서 ante account create CLI로 수행한다. "
+        "스키마 SSOT: docs/specs/account/03-data-model.md 60-87줄."
+    ),
+    "additionalProperties": False,
+    "required": [
+        "account_id",
+        "name",
+        "exchange",
+        "currency",
+        "broker_type",
+    ],
+    "properties": {
+        "account_id": {
+            "type": "string",
+            "description": "고유 식별자 (영문+숫자+하이픈, 3–30자).",
+        },
+        "name": {
+            "type": "string",
+            "description": "사용자에게 표시되는 이름.",
+        },
+        "exchange": {
+            "type": "string",
+            "enum": ["KRX", "NYSE", "NASDAQ", "TEST"],
+            "description": "대상 거래소 코드.",
+        },
+        "currency": {
+            "type": "string",
+            "description": "거래 통화 (ISO 4217).",
+        },
+        "timezone": {
+            "type": "string",
+            "default": "Asia/Seoul",
+            "description": "거래소 현지 시간대 (IANA).",
+        },
+        "trading_hours_start": {
+            "type": "string",
+            "default": "09:00",
+            "description": "거래 시작 시각 (현지 시간, HH:MM).",
+        },
+        "trading_hours_end": {
+            "type": "string",
+            "default": "15:30",
+            "description": "거래 종료 시각 (현지 시간, HH:MM).",
+        },
+        "trading_mode": {
+            "type": "string",
+            "enum": ["VIRTUAL", "LIVE"],
+            "default": "VIRTUAL",
+            "description": "거래 모드 (VIRTUAL / LIVE).",
+        },
+        "broker_type": {
+            "type": "string",
+            "description": "브로커 어댑터 유형.",
+        },
+        "credentials": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+            "default": {},
+            "description": (
+                "브로커 인증 정보 (dict[str, str], 암호화 저장). cold-path 전용."
+            ),
+        },
+        "broker_config": {
+            "type": "object",
+            "additionalProperties": True,
+            "default": {},
+            "description": (
+                "브로커 동작 설정 (예: KIS is_paper). 임의 키-값 dict. cold-path 전용."
+            ),
+        },
+        "buy_commission_rate": {
+            "type": "number",
+            "default": 0,
+            "description": "매수 수수료율 (cold-path 전용).",
+        },
+        "sell_commission_rate": {
+            "type": "number",
+            "default": 0,
+            "description": "매도 수수료율, 세금 포함 (cold-path 전용).",
+        },
+    },
+}
+
+
 def _cold_path_detail(message: str) -> str:
     """Cold-path 차단 응답의 표준 detail 문자열을 만든다."""
     return f"{STRUCTURAL_CHANGE_ERROR_CODE}: {message}"
@@ -127,6 +232,16 @@ async def list_accounts(
             ),
         },
     },
+    openapi_extra={
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/json": {
+                    "schema": ACCOUNT_CREATE_REQUEST_SCHEMA,
+                },
+            },
+        },
+    },
 )
 async def create_account(request: Request) -> ErrorResponse:
     """계좌 생성.
@@ -142,6 +257,11 @@ async def create_account(request: Request) -> ErrorResponse:
 
     이 경로의 service-layer 회귀 보호는 ``tests/unit/test_account.py``가
     담당한다.
+
+    본 PR(#1143)에서 OpenAPI requestBody schema가 spec-aligned
+    ``ACCOUNT_CREATE_REQUEST_SCHEMA``로 노출되어 codegen 클라이언트가
+    cold-path payload 필드를 발견할 수 있게 됐다. 런타임은 어떤 body든
+    무시하고 409를 반환한다.
     """
     raise HTTPException(
         status_code=409,

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -840,3 +840,256 @@ class TestResponseModelCoverage:
         assert "ErrorResponse" in ref, (
             f"PUT 422가 ErrorResponse를 가리키지 않음 (schema ref={ref!r})"
         )
+
+
+# ── #1143 POST /api/accounts request body schema 노출 ──────────────
+
+
+class TestPostAccountRequestBodySchema:
+    """POST /api/accounts requestBody OpenAPI schema 노출 (이슈 #1143).
+
+    cold-path 가드는 어떤 입력이든 즉시 409로 차단하지만(invariant I1),
+    OpenAPI/codegen 클라이언트는 정확한 입력 contract를 발견할 수 있어야
+    한다. 본 테스트군은 ``openapi_extra``로 노출한 spec-aligned schema가
+    docs/specs/account/03-data-model.md 60-87줄 필드 표와 1:1 정합한지
+    단언한다.
+
+    Pydantic ``AccountCreateRequest.model_json_schema()`` 직접 노출은 금지다
+    (BrokerPreset 자동 채움 때문에 모든 필드가 default를 갖고 있어
+    ``exchange``/``currency``/``broker_type`` required와 어긋남 — attempt 6
+    finding). spec-aligned dict 상수 ``ACCOUNT_CREATE_REQUEST_SCHEMA``로
+    별도 정의해 노출한다.
+    """
+
+    @staticmethod
+    def _post_request_body(client: TestClient) -> dict:
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        openapi = resp.json()
+        spec = openapi.get("paths", {}).get("/api/accounts", {}).get("post", {})
+        request_body = spec.get("requestBody")
+        assert request_body is not None, (
+            "POST /api/accounts requestBody가 OpenAPI에 노출되지 않음"
+        )
+        return request_body
+
+    @staticmethod
+    def _post_request_schema(client: TestClient) -> dict:
+        request_body = TestPostAccountRequestBodySchema._post_request_body(client)
+        json_content = request_body.get("content", {}).get("application/json")
+        assert json_content is not None, (
+            "POST /api/accounts requestBody에 application/json content 없음"
+        )
+        schema = json_content.get("schema")
+        assert isinstance(schema, dict), (
+            "POST /api/accounts requestBody schema가 dict가 아님"
+        )
+        return schema
+
+    def test_openapi_post_account_request_body_is_spec_aligned(self, client):
+        """spec 표(docs/specs/account/03-data-model.md 60-87줄)와 정합."""
+        schema = self._post_request_schema(client)
+
+        # additionalProperties: False — 알 수 없는 키 차단을 contract에 표현
+        ap = schema.get("additionalProperties")
+        assert ap is False, f"additionalProperties가 False가 아님: {ap!r}"
+
+        # required 표현
+        required = schema.get("required", [])
+        for field in ("account_id", "name", "exchange", "currency", "broker_type"):
+            assert field in required, (
+                f"required에 필수 필드 '{field}' 누락: {required!r}"
+            )
+
+        properties = schema.get("properties", {})
+        assert isinstance(properties, dict), f"properties가 dict가 아님: {properties!r}"
+
+        # default 표현
+        assert properties.get("timezone", {}).get("default") == "Asia/Seoul"
+        assert properties.get("trading_hours_start", {}).get("default") == "09:00", (
+            properties.get("trading_hours_start")
+        )
+        assert properties.get("trading_hours_end", {}).get("default") == "15:30", (
+            properties.get("trading_hours_end")
+        )
+        assert properties.get("trading_mode", {}).get("default") == "VIRTUAL", (
+            properties.get("trading_mode")
+        )
+
+        # exchange enum
+        assert properties.get("exchange", {}).get("enum") == [
+            "KRX",
+            "NYSE",
+            "NASDAQ",
+            "TEST",
+        ], properties.get("exchange")
+
+        # trading_mode enum (보조)
+        assert properties.get("trading_mode", {}).get("enum") == [
+            "VIRTUAL",
+            "LIVE",
+        ], properties.get("trading_mode")
+
+        # 어떤 properties도 nullable이 아님 — anyOf/oneOf에 null type 없음,
+        # nullable: True 없음. 각 property는 단일 type을 가져야 한다.
+        for name, prop in properties.items():
+            assert isinstance(prop, dict), f"properties.{name}가 dict가 아님: {prop!r}"
+            assert "nullable" not in prop or prop.get("nullable") is not True, (
+                f"properties.{name}에 nullable: True가 노출됨"
+            )
+            for combinator in ("anyOf", "oneOf"):
+                variants = prop.get(combinator)
+                if variants:
+                    for variant in variants:
+                        assert variant.get("type") != "null", (
+                            f"properties.{name}.{combinator}에 null type 포함"
+                        )
+
+    def test_openapi_post_account_request_body_required_true(self, client):
+        """codegen이 body를 optional로 만들지 않도록 required: True."""
+        request_body = self._post_request_body(client)
+        assert request_body.get("required") is True, (
+            f"requestBody.required가 True가 아님: {request_body.get('required')!r}"
+        )
+
+    def test_openapi_post_account_credentials_is_string_map(self, client):
+        """credentials는 dict[str, str] — codegen Record<string, never> 회피."""
+        schema = self._post_request_schema(client)
+        credentials = schema.get("properties", {}).get("credentials", {})
+        assert credentials.get("type") == "object", credentials
+        assert credentials.get("additionalProperties") == {"type": "string"}, (
+            f"credentials.additionalProperties가 string map이 아님: {credentials!r}"
+        )
+        assert credentials.get("default") == {}, credentials
+
+    def test_openapi_post_account_broker_config_is_open_map(self, client):
+        """broker_config는 임의 dict — additionalProperties: True."""
+        schema = self._post_request_schema(client)
+        broker_config = schema.get("properties", {}).get("broker_config", {})
+        assert broker_config.get("type") == "object", broker_config
+        assert broker_config.get("additionalProperties") is True, (
+            f"broker_config.additionalProperties가 True가 아님: {broker_config!r}"
+        )
+        assert broker_config.get("default") == {}, broker_config
+
+
+class TestGeneratedTsPostAccountRequestBody:
+    """generated TS api.generated.ts에서 POST /api/accounts request body가
+    spec-aligned 형태로 노출되는지 보조 단언한다(이슈 #1143).
+
+    같은 PR에 ``frontend/src/types/api.generated.ts``가 함께 갱신되어야
+    하므로 generated artifact drift를 차단한다.
+    """
+
+    @staticmethod
+    def _generated_ts_text() -> str:
+        path = (
+            Path(__file__).resolve().parents[2]
+            / "frontend"
+            / "src"
+            / "types"
+            / "api.generated.ts"
+        )
+        assert path.exists(), f"generated TS 파일이 존재하지 않음: {path}"
+        return path.read_text(encoding="utf-8")
+
+    @staticmethod
+    def _post_account_operation_block(text: str) -> str:
+        """create_account_api_accounts_post operation 블록을 잘라낸다."""
+        marker = "create_account_api_accounts_post:"
+        idx = text.find(marker)
+        assert idx != -1, "generated TS에 create_account operation이 없음"
+        # 다음 operation 시작 전까지 잘라낸다(들여쓰기 4 + 식별자).
+        rest = text[idx:]
+        # 다음 operation 식별자를 정규식 없이 단순 키워드로 찾는다.
+        next_markers = [
+            "get_account_api_accounts__account_id__get:",
+            "update_account_api_accounts__account_id__put:",
+            "delete_account_api_accounts__account_id__delete:",
+        ]
+        end_offsets = [rest.find(m, 1) for m in next_markers]
+        end_offsets = [o for o in end_offsets if o != -1]
+        end = min(end_offsets) if end_offsets else len(rest)
+        return rest[:end]
+
+    def test_generated_ts_post_account_request_body_not_never(self):
+        """POST /api/accounts에 requestBody?: never가 없어야 한다."""
+        block = self._post_account_operation_block(self._generated_ts_text())
+        assert "requestBody?: never" not in block, (
+            "POST /api/accounts에 requestBody?: never 회귀:\n" + block
+        )
+
+    def test_generated_ts_post_account_request_body_required_not_optional(self):
+        """POST /api/accounts requestBody가 optional 표시(?:)가 아닌 required."""
+        block = self._post_account_operation_block(self._generated_ts_text())
+        # requestBody?: 가 등장하면 codegen이 body를 optional로 만든 것이다.
+        assert "requestBody?:" not in block, (
+            "POST /api/accounts requestBody가 optional로 노출됨:\n" + block
+        )
+        # 명시 requestBody: 정의가 있어야 한다.
+        assert "requestBody:" in block, (
+            "POST /api/accounts에 requestBody: 정의가 없음:\n" + block
+        )
+
+    @staticmethod
+    def _field_type_block(operation_block: str, field_name: str) -> str:
+        """operation 블록에서 ``field_name`` 정의 라인부터 닫는 ``};``까지를 잘라낸다.
+
+        openapi-typescript 멀티라인 출력(예: credentials의 본문은 다음 라인의
+        ``[key: string]: string;``)에서 type 본문을 한 덩어리로 보기 위해 사용한다.
+        """
+        lines = operation_block.splitlines()
+        start_idx: int | None = None
+        for idx, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped.startswith(f"{field_name}:") or stripped.startswith(
+                f"{field_name}?:"
+            ):
+                start_idx = idx
+                break
+        assert start_idx is not None, (
+            f"field '{field_name}'가 operation block에 없음:\n{operation_block}"
+        )
+        # 시작 라인이 inline type(같은 줄에 ;로 끝남)이면 그 줄만 반환.
+        first_line = lines[start_idx].rstrip()
+        if first_line.endswith(";") and "{" not in first_line:
+            return first_line
+        # 멀티라인 type — base 들여쓰기 추적해서 매칭되는 ``};``를 찾는다.
+        base_indent = len(first_line) - len(first_line.lstrip())
+        collected = [first_line]
+        for line in lines[start_idx + 1 :]:
+            collected.append(line)
+            stripped = line.lstrip()
+            indent = len(line) - len(stripped)
+            if indent <= base_indent and stripped.startswith("};"):
+                break
+        return "\n".join(collected)
+
+    def test_generated_ts_post_account_credentials_not_record_never(self):
+        """credentials 타입이 Record<string, never> / {}가 아니어야 한다.
+
+        spec dict[str, str] → openapi-typescript는 보통
+        ``Record<string, string>`` 또는 ``{[key: string]: string}``로 생성한다.
+        """
+        operation_block = self._post_account_operation_block(self._generated_ts_text())
+        field_block = self._field_type_block(operation_block, "credentials")
+        assert "Record<string, never>" not in field_block, (
+            "credentials가 Record<string, never>로 좁혀짐:\n" + field_block
+        )
+        # 빈 객체 타입({})만 단독으로 사용되면 안 된다.
+        assert (
+            "Record<string, string>" in field_block
+            or "[key: string]: string" in field_block
+        ), f"credentials가 string-map 형태로 노출되지 않음:\n{field_block}"
+
+    def test_generated_ts_post_account_broker_config_not_record_never(self):
+        """broker_config 타입이 Record<string, never> / {}가 아니어야 한다."""
+        operation_block = self._post_account_operation_block(self._generated_ts_text())
+        field_block = self._field_type_block(operation_block, "broker_config")
+        assert "Record<string, never>" not in field_block, (
+            "broker_config가 Record<string, never>로 좁혀짐:\n" + field_block
+        )
+        assert (
+            "Record<string, unknown>" in field_block
+            or "[key: string]: unknown" in field_block
+        ), f"broker_config가 open-map 형태로 노출되지 않음:\n{field_block}"


### PR DESCRIPTION
Closes #1143

## Summary
- POST `/api/accounts`의 OpenAPI `requestBody` schema 노출 회복(narrow-scope, plan-preflight attempts 1~8 합의 v8).
- `src/ante/web/routes/accounts.py` 모듈 상단에 spec-aligned `ACCOUNT_CREATE_REQUEST_SCHEMA` dict 상수를 추가하고, POST 데코레이터에 `openapi_extra={"requestBody": {"required": True, "content": {"application/json": {"schema": ACCOUNT_CREATE_REQUEST_SCHEMA}}}}` 주입.
- `AccountCreateRequest` Pydantic 모델은 변경 없음(다른 소비자 호환). 핸들러 시그니처/본문 변경 없음 → cold-path invariant I1(즉시 409) 보존.
- generated artifact(`frontend/openapi.json`, `frontend/src/types/api.generated.ts`) 같은 PR에 동기화.
- 회귀 보호: OpenAPI JSON 단언 4건 + generated TS 단언 4건 신규(`tests/unit/test_web_api.py`).

## Scope decision
- **narrow-scope**: POST request body schema 노출만. PUT 일체 변경 없음(#1153로 분리).
- 베이스라인: main HEAD `57780c2` (PR #1146 cold-path 머지 commit).

## Codex 브랜치 리뷰 attempt 1 finding 처리
- attempt 1에서 [P2] "POST schema가 BROKER_PRESETS 자동 채움과 모순" finding 1건.
- @code-reviewer 메타 리뷰 결과: **B (split-issue)**. 본 finding은 spec `docs/specs/account/03-data-model.md` 60-87줄 표 ↔ 119-147줄 BROKER_PRESETS 표 사이의 *spec 본문 자체 모순*을 가리키며, 본 PR은 60-87줄을 1:1 미러한 narrow-scope 합의를 충실히 따랐을 뿐 — 본 PR이 위험을 새로 만든 것이 아님.
- 위험창 평가: 런타임 라우트는 invariant I1(#1140)으로 모든 입력을 즉시 409 차단 + cold-path는 CLI 1차 채널 → SDK 잘못된 payload가 service로 흘러갈 회귀 경로가 닫혀 있음. P2 non-blocker.
- SSOT 정책 결정과 plan-preflight 가드 보강은 별도 후속 이슈로 분리 예정(사용자 결정).

## Test Plan
- `pytest tests/unit/test_account_api.py tests/unit/test_account.py tests/unit/test_account_immutable_fields.py tests/unit/test_account_delete_events.py tests/unit/test_web_api.py` → **165 passed** (cold-path 회귀 9건 + #1143 신규 8건 모두 PASS)
- `ruff check src/ante/web/routes/accounts.py tests/` → All checks passed
- `ruff format --check src/ante/web/routes/accounts.py tests/` → already formatted
- `npm --prefix frontend run generate-types` → 성공
- TDD RED 게이트 사전 확인: 구현 전 신규 8개 테스트 실패 확인.