### PR TITLE
fix(account,cli,ipc): align account cold-path with 1.0 single-active-runtime policy (#1139)

### DIFF
--- a/docs/specs/account/04-account-service.md
+++ b/docs/specs/account/04-account-service.md
@@ -22,7 +22,7 @@ AccountService(db: Database, eventbus: EventBus)
 | `update` | `account_id: str, **fields` | `Account` | 부분 수정. 런타임에는 비구조 필드만 허용. structural field 포함 시 `AccountStructuralChangeRequiresStoppedServerError`. DELETED 계좌는 수정 불가 (`AccountDeletedException`). 불변 필드(`exchange`, `currency`, `trading_mode`, `broker_type`) 포함 시 `AccountImmutableFieldError` |
 | `suspend` | `account_id: str, reason: str, suspended_by: str` | `None` | status → SUSPENDED. 이미 SUSPENDED이면 `AccountAlreadySuspendedError` (409). `AccountSuspendedEvent` 발행 + 소속 봇 중지 트리거 |
 | `activate` | `account_id: str, activated_by: str` | `None` | status → ACTIVE. DELETED 계좌는 활성화 불가. `AccountActivatedEvent` 발행 |
-| `delete` | `account_id: str, deleted_by: str` | `None` | 소프트 딜리트 (status=DELETED). **cold-path 전용**. 서버 실행 중에는 거부 |
+| `delete` | `account_id: str, deleted_by: str` | `None` | 소프트 딜리트 (status=DELETED). **cold-path 전용**. active Ante runtime이 살아 있으면 거부. 진입 직후 `bots` 테이블을 검사해 동일 `account_id`의 활성(non-deleted) 봇이 남아 있으면 `AccountHasActiveBotsError`로 차단(orphan bot 무결성). 1.0 정책상 `AccountDeletedEvent`는 발행하지 않는다 |
 | `get_broker` | `account_id: str` | `BrokerAdapter` | 계좌의 BrokerAdapter 인스턴스 반환. lazy init + 캐싱 |
 | `create_default_test_account` | — | `Account` | 테스트 계좌 자동 생성 (`ante init` 시 호출). 이미 존재하면 스킵 |
 | `suspend_all` | `reason: str, suspended_by: str` | `int` | 모든 ACTIVE 계좌를 SUSPENDED로 전환. 전환된 수 반환 (시스템 전체 Kill Switch) |
@@ -59,8 +59,9 @@ AccountService(db: Database, eventbus: EventBus)
 
 서버 실행 중 structural field 변경 요청이 들어오면 DB를 수정하지 않고
 `AccountStructuralChangeRequiresStoppedServerError`를 발생시킨다. CLI cold-path 명령은
-같은 `config_dir`의 PID/socket guard로 서버 실행 여부를 먼저 확인하고, 서버가 실행 중이면
-서비스 메서드를 호출하지 않는다.
+active Ante runtime guard로 서버 실행 여부를 먼저 확인하고, runtime이 살아 있으면
+서비스 메서드를 호출하지 않는다. 1.0 정책상 동일 OS user/home server 기준으로 active
+runtime은 항상 단일이며, `config_dir`은 데이터/설정 프로필 경계지 동시 namespace가 아니다.
 
 ### 에러 클래스
 
@@ -73,6 +74,7 @@ class AccountDeletedException(AccountError): ...  # DELETED 계좌 수정/활성
 class AccountImmutableFieldError(AccountError): ...  # 불변 필드 수정 시도 시 (exchange, currency, trading_mode, broker_type)
 class AccountAlreadySuspendedError(AccountError): ...  # 이미 정지된 계좌 재정지 시도 시 (409)
 class AccountStructuralChangeRequiresStoppedServerError(AccountError): ...  # 런타임 구조 변경 차단
+class AccountHasActiveBotsError(AccountError): ...  # delete() 시 활성(non-deleted) 봇 잔존 시 (orphan bot 무결성)
 ```
 
 소스: `src/ante/account/errors.py`

--- a/docs/specs/account/05-eventbus-integration.md
+++ b/docs/specs/account/05-eventbus-integration.md
@@ -11,10 +11,12 @@
 | `AccountSuspendedEvent` | `suspend()` 호출 시 | BotManager (소속 봇 전체 중지), RuleEngine, Notification |
 | `AccountActivatedEvent` | `activate()` 호출 시 | BotManager (해당 계좌 봇 재개), RuleEngine, Notification |
 
-`AccountCreatedEvent`와 `AccountDeletedEvent`는 1.0 런타임 wiring 이벤트가 아니다. 계좌 생성/삭제는
-cold-path 전용이므로 서버 실행 중 EventBus 구독자에게 새 topology를 전파하지 않는다.
-구조 변경 이력은 필요 시 감사 로그나 cold-path maintenance 결과로 남기며, 라이브 서비스의
-consumer 생성/제거를 트리거하지 않는다.
+`AccountCreatedEvent`와 `AccountDeletedEvent`는 1.0 런타임 EventBus 계약에 포함하지 않는다.
+계좌 생성/삭제는 cold-path 전용이며 active Ante runtime이 없는 상태에서만 수행되므로,
+EventBus 구독자에게 새 topology를 전파할 대상이 없다. cold-path delete는 consumer
+wiring을 트리거하지 않으며, 따라서 `AccountDeletedEvent`는 `ante.eventbus.events`에
+정의되지 않고 `AccountService.delete()`도 publish하지 않는다. 구조 변경 이력은 필요 시
+감사 로그나 cold-path maintenance 결과로 남긴다.
 
 ### 구독 이벤트
 

--- a/docs/specs/account/09-cli.md
+++ b/docs/specs/account/09-cli.md
@@ -50,8 +50,12 @@ ante system activate                # 전체 거래 재개
 | `ante account delete <account_id>` | cold-path 전용 | 서버 실행 중이면 DB 수정 전 거부 |
 | `ante account set-credentials <account_id>` | cold-path 전용 | 서버 실행 중이면 DB 수정 전 거부 |
 
-cold-path 전용 명령은 같은 `config_dir`의 PID/socket guard로 서버 실행 여부를 먼저 확인한다.
-서버가 실행 중이면 `ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER` 에러로 종료한다.
+cold-path 전용 명령은 active Ante runtime guard로 서버 실행 여부를 먼저 확인한다.
+1.0 정책상 동일 OS user/home server 기준으로 active runtime은 항상 단일이며,
+runtime이 살아 있으면 `ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER` 에러로 종료한다.
+`ante account delete`는 IPC 런타임 커맨드가 아니다. cold-path CLI에서 직접
+`AccountService.delete()`를 호출하며, 해당 계좌에 활성(non-deleted) 봇이 남아 있으면
+삭제는 `AccountHasActiveBotsError`로 차단된다(orphan bot 무결성).
 
 ### CLI 출력 예시
 

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -21,7 +21,7 @@
 | `offline` | 서버 프로세스와 무관하게 CLI가 직접 서비스/저장소를 생성해 실행한다. 서버 실행 중에도 live 상태를 바꾸지 않는다. |
 | `runtime IPC` | 서버 프로세스의 서비스 인스턴스, EventBus, 인메모리 상태, 외부 연결, 세션 상태가 필요하므로 IPC로 위임한다. |
 | `runtime IPC + snapshot fallback` | 서버 실행 중에는 IPC로 live 상태를 조회하고, 서버 정지 중에는 DB에 저장된 persisted snapshot만 조회한다. |
-| `cold-path` | 서버 topology 또는 broker 초기화 입력을 바꾸므로 같은 `config_dir`의 서버가 정지된 상태에서만 직접 DB를 수정한다. |
+| `cold-path` | 서버 topology 또는 broker 초기화 입력을 바꾸므로 active Ante runtime이 없는 상태에서만 직접 DB를 수정한다. |
 | `external process` | 별도 프로세스 실행, OS signal, 장기 실행 파이프/스케줄러처럼 CLI 프로세스 경계를 넘는 작업이다. |
 | `bootstrap/maintenance` | 초기화·복구 목적의 인증 면제 또는 서버 정지 fallback 경로다. |
 
@@ -114,8 +114,11 @@ ante account delete <account_id>              # 계좌 삭제 (cold-path 전용,
 ```
 
 `account create/delete/set-credentials`는 계좌 topology 또는 브로커 초기화 입력을 바꾸므로
-서버 실행 중에는 차단된다. 실행 전 같은 `config_dir`의 PID/socket guard를 확인하고,
-서버가 실행 중이면 `ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER`로 종료한다.
+서버 실행 중에는 차단된다. 실행 전 active Ante runtime guard를 확인하고,
+runtime이 살아 있으면 `ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER`로 종료한다.
+1.0 정책상 동일 OS user/home server 기준으로 active runtime은 항상 단일이며,
+`account.delete`는 IPC 런타임 커맨드가 아니므로 cold-path CLI에서 직접
+`AccountService.delete()`를 호출한다.
 
 ### `ante bot` — 봇 관리
 
@@ -300,6 +303,8 @@ ante init [--member-id owner] [--name Owner] [--dir <경로>]
 `system.toml`은 `db.path = "db/ante.db"`, `data.path = "data"`,
 `runtime.socket_path = "run/ante.sock"`, `runtime.pid_path = "run/ante.pid"`,
 `logging.directory = "logs"`처럼 `config_dir` 기준 상대 경로를 기록한다.
+1.0 정책상 `config_dir`은 데이터/설정 프로필 경계이며, 단일 active runtime
+정책 하에서 동시 namespace로 사용하지 않는다.
 
 **내부 실행 순서**: 1. 디렉토리 생성 → 2. master bootstrap → 3. test account 생성
 

--- a/docs/specs/config/03-design-decisions.md
+++ b/docs/specs/config/03-design-decisions.md
@@ -176,6 +176,19 @@ WebAPI -> DynamicConfigService.update(key, value)
 - SQLite에 저장하므로 재시작 후에도 유지
 - EventBus 알림으로 모듈이 능동적으로 반영 (폴링 불필요)
 
+### 1.0 단일 active runtime 정책
+
+Ante 1.0은 동일 OS user/home server 기준으로 **단일 active runtime server만**
+공식 지원한다. `config_dir`은 데이터/설정 프로필 경계이지 동시 namespace가 아니다.
+즉, 서로 다른 `config_dir`을 사용해도 같은 호스트에서 두 개의 Ante runtime을
+동시에 실행하는 구성은 1.0의 보증 범위 밖이다.
+
+이 정책은 cold-path CLI 명령(`ante account create/delete/set-credentials`)의
+차단 기준에 직접 영향을 준다. CLI는 "active Ante runtime guard"로 서버 실행
+여부를 판정하며, runtime이 살아 있으면 `ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER`로
+종료한다. 같은 OS user에서 다중 runtime이 필요하다면 별도 인스턴스 분리/스케줄링은
+1.x 후속 결정 사항으로 분리한다.
+
 ### Ante instance/path contract
 
 Ante 인스턴스의 루트는 `config_dir`이다. `system.toml`이 있는 디렉토리와

--- a/docs/specs/ipc/ipc.md
+++ b/docs/specs/ipc/ipc.md
@@ -78,7 +78,10 @@ CLI 명령 시그니처와 전체 실행 분류의 SSOT는
 | `ante account activate` | `account.activate` | `AccountService.activate()` | `AccountActivatedEvent` → BotManager 봇 재시작 |
 
 `ante account create`, `ante account delete`, `ante account set-credentials`는 IPC 대상이 아니다.
-이 명령들은 cold-path structural 커맨드이며, 서버 실행 중이면 CLI guard에서 차단된다.
+이 명령들은 cold-path structural 커맨드이며, active Ante runtime이 살아 있으면 CLI guard에서 차단된다.
+특히 `account.delete`는 1.0 IPC 계약(`CommandRegistry`)에 등록되지 않으며, cold-path CLI에서
+직접 `AccountService.delete()`를 호출한다. 활성 봇이 남아 있는 계좌는 service preflight
+(`AccountHasActiveBotsError`)에서 차단된다.
 
 #### Bot
 
@@ -157,14 +160,19 @@ maintenance/test 스펙 없이는 제공하지 않는다.
 
 ### Cold-path structural 커맨드
 
-서버 topology를 바꾸는 명령은 IPC로 서버에 위임하지 않는다. 같은 `config_dir`의 서버가
-실행 중이면 실패하고, 서버 정지 상태에서만 직접 DB를 수정한다.
+서버 topology를 바꾸는 명령은 IPC로 서버에 위임하지 않는다. active Ante runtime이
+살아 있으면 실패하고, 서버 정지 상태에서만 직접 DB를 수정한다. 1.0 정책상 동일 OS
+user/home server 기준으로 active runtime은 항상 단일이며, `config_dir`은 데이터/설정
+프로필 경계지 동시 namespace가 아니다.
 
-| CLI 커맨드 | 서버 실행 중 동작 | 이유 |
+| CLI 커맨드 | active runtime 시 동작 | 이유 |
 |-----------|------------------|------|
 | `ante account create` | 차단 | Treasury/RuleEngine/Gateway/Bot hot wiring 비지원 |
-| `ante account delete` | 차단 | 실행 중 consumer 제거와 partial failure 보상 비지원 |
+| `ante account delete` | 차단 | 실행 중 consumer 제거와 partial failure 보상 비지원. 활성 봇이 남아 있으면 service preflight(`AccountHasActiveBotsError`)에서도 차단 |
 | `ante account set-credentials` | 차단 | BrokerAdapter 재초기화와 장기 실행 consumer 전파 비지원 |
+
+`account.delete`는 1.0 IPC 계약에서 제외된다. cold-path CLI는 `AccountService.delete()`를
+직접 호출하며, IPC 라우팅 테이블(`CommandRegistry`)에 등록하지 않는다.
 
 ### 서버 정지 maintenance fallback
 

--- a/src/ante/account/errors.py
+++ b/src/ante/account/errors.py
@@ -77,15 +77,24 @@ class AccountHasActiveBotsError(AccountError):
     cold-path AccountService.delete()는 status mutation 전에 ``bots`` 테이블을
     조회하여 동일 ``account_id``의 활성 봇이 있으면 삭제를 거부한다. 이는
     봇이 가리키는 계좌가 사라져 orphan bot이 되는 무결성 위반을 막는다.
-    운영자는 봇을 먼저 제거(`ante bot remove ...`)한 뒤 계좌를 삭제해야 한다.
+
+    1.0 운영 절차(R-A mitigation): ``ante account delete``는 cold-path 전용,
+    ``ante bot remove``는 IPC runtime command이기 때문에 봇이 남은 계좌를
+    삭제하려면 다음 4단계를 순서대로 실행해야 한다. 메시지에 이 절차가 그대로
+    포함되어 사용자/Agent가 별도 문서를 참조하지 않고도 복구할 수 있다.
+    근본 해소(bot remove cold-path 지원)는 #1161에서 다룬다.
     """
 
     def __init__(self, account_id: str, bot_count: int) -> None:
         self.account_id = account_id
         self.bot_count = bot_count
         super().__init__(
-            f"계좌 '{account_id}'에 활성 봇이 {bot_count}개 남아 있어 "
-            f"삭제할 수 없습니다."
+            f"계좌 '{account_id}'에 연결된 활성 봇이 {bot_count}개 있어 "
+            f"삭제할 수 없습니다. 다음 순서로 진행하세요:\n"
+            f"  1) ante system start\n"
+            f"  2) ante bot remove <bot_id>  (각 봇에 대해 반복)\n"
+            f"  3) ante system stop\n"
+            f"  4) ante account delete {account_id}"
         )
 
 

--- a/src/ante/account/errors.py
+++ b/src/ante/account/errors.py
@@ -71,5 +71,23 @@ class BrokerReconnectFailedError(AccountError):
     pass
 
 
+class AccountHasActiveBotsError(AccountError):
+    """delete() 시 해당 계좌에 활성(non-deleted) 봇이 남아 있음 (#1139).
+
+    cold-path AccountService.delete()는 status mutation 전에 ``bots`` 테이블을
+    조회하여 동일 ``account_id``의 활성 봇이 있으면 삭제를 거부한다. 이는
+    봇이 가리키는 계좌가 사라져 orphan bot이 되는 무결성 위반을 막는다.
+    운영자는 봇을 먼저 제거(`ante bot remove ...`)한 뒤 계좌를 삭제해야 한다.
+    """
+
+    def __init__(self, account_id: str, bot_count: int) -> None:
+        self.account_id = account_id
+        self.bot_count = bot_count
+        super().__init__(
+            f"계좌 '{account_id}'에 활성 봇이 {bot_count}개 남아 있어 "
+            f"삭제할 수 없습니다."
+        )
+
+
 # 하위 호환용 별칭
 AccountDeletedException = AccountDeletedError

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -13,6 +13,7 @@ from ante.account.crypto import decrypt_credentials, encrypt_credentials
 from ante.account.errors import (
     AccountAlreadyExistsError,
     AccountDeletedException,
+    AccountHasActiveBotsError,
     AccountImmutableFieldError,
     AccountNotFoundError,
     BrokerReconnectFailedError,
@@ -462,17 +463,38 @@ class AccountService:
         logger.info("계좌 활성화: %s (요청자: %s)", account_id, activated_by)
 
     async def delete(self, account_id: str, deleted_by: str) -> None:
-        """소프트 딜리트 (status -> DELETED).
+        """소프트 딜리트 (status -> DELETED). cold-path 전용.
+
+        진입 직후 ``bots`` 테이블을 검사하여 active(non-deleted) 봇이 남아 있으면
+        ``AccountHasActiveBotsError``를 raise한다 (#1139, orphan bot 무결성).
+        ``bots`` 테이블 자체가 없으면(BotManager 미초기화 환경) active 봇이
+        없는 것으로 간주한다.
+
+        1.0 EventBus 계약: ``AccountDeletedEvent``는 발행하지 않는다. cold-path
+        delete는 consumer wiring을 트리거하지 않는다. ``AccountSuspendedEvent``
+        (reason="Account deletion")는 BotManager가 소속 봇을 중지시키도록 유지한다.
 
         Raises:
             AccountNotFoundError: 계좌를 찾을 수 없음.
-            AccountDeletedException: 삭제된 계좌.
+            AccountDeletedException: 이미 삭제된 계좌.
+            AccountHasActiveBotsError: 활성(non-deleted) 봇이 남아 있음.
         """
         account = await self.get(account_id)
         if account.status == AccountStatus.DELETED:
             raise AccountDeletedException(f"이미 삭제된 계좌입니다: '{account_id}'")
 
-        # 소속 봇 중지 트리거 (이미 SUSPENDED/DELETED면 스킵)
+        # cold-path preflight: orphan bot 무결성 검사.
+        # bots 테이블이 없으면 active 봇이 없는 것으로 간주.
+        active_bot_count = await self._count_active_bots(account_id)
+        if active_bot_count > 0:
+            raise AccountHasActiveBotsError(
+                account_id=account_id, bot_count=active_bot_count
+            )
+
+        # 소속 봇 중지 트리거 (이미 SUSPENDED/DELETED면 스킵).
+        # 봇이 없는 정상 흐름에서는 사실상 no-op이지만, 봇 중지 시점과 cold-path
+        # delete 사이의 race로 잔존 ACTIVE 상태 consumer가 있을 가능성에 대비해
+        # 유지한다.
         if account.status not in (AccountStatus.SUSPENDED, AccountStatus.DELETED):
             from ante.eventbus.events import AccountSuspendedEvent
 
@@ -492,19 +514,34 @@ class AccountService:
             (AccountStatus.DELETED, account.updated_at.isoformat(), account_id),
         )
 
-        # 삭제 완료 이벤트
-        from ante.eventbus.events import AccountDeletedEvent
-
-        await self._eventbus.publish(
-            AccountDeletedEvent(account_id=account_id, deleted_by=deleted_by)
-        )
-
         # 메모리 캐시에서 제거
         self._accounts.pop(account_id, None)
         # 브로커 캐시에서도 제거
         self._brokers.pop(account_id, None)
 
         logger.info("계좌 삭제: %s (요청자: %s)", account_id, deleted_by)
+
+    async def _count_active_bots(self, account_id: str) -> int:
+        """``bots`` 테이블에서 동일 account_id의 non-deleted 봇 수를 센다.
+
+        ``bots`` 테이블이 존재하지 않는 환경(BotManager 미초기화 단위 테스트
+        등)은 0을 반환한다. 운영 서버는 항상 BotManager 초기화 시점에
+        스키마를 적용하므로 이 fallback은 cold-path CLI 실행 환경 차이만
+        흡수한다.
+        """
+        try:
+            row = await self._db.fetch_one(
+                "SELECT COUNT(*) AS cnt FROM bots WHERE account_id = ? AND status != ?",
+                (account_id, "deleted"),
+            )
+        except Exception:
+            # bots 테이블 부재 등 → active 봇 없음으로 간주
+            return 0
+
+        if row is None:
+            return 0
+        cnt = row.get("cnt", 0) if isinstance(row, dict) else row[0]
+        return int(cnt or 0)
 
     # ── 일괄 상태 전이 ──────────────────────────────────
 

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import click
@@ -15,6 +17,7 @@ from ante.cli.middleware import get_member_id, require_auth, require_scope
 if TYPE_CHECKING:
     from ante.account.models import Account
     from ante.account.service import AccountService
+    from ante.cli.formatter import OutputFormatter
     from ante.core.database import Database
 
 logger = logging.getLogger(__name__)
@@ -27,6 +30,60 @@ def account() -> None:
 
 def _run(coro):  # noqa: ANN001, ANN202
     return asyncio.run(coro)
+
+
+# ── cold-path active runtime guard ──────────────────────────────
+
+
+# Cold-path 차단 응답 코드. SSOT는 docs/specs/cli/03-commands.md 117-118줄,
+# docs/specs/account/09-cli.md 49-54줄.
+_COLD_PATH_BLOCKED_CODE = "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER"
+
+
+def _assert_no_active_runtime(fmt: OutputFormatter) -> None:
+    """active Ante runtime이 있으면 cold-path 명령을 차단한다.
+
+    1.0 정책(단일 active runtime)에 따라 PID 파일이 가리키는 프로세스가
+    살아 있고 IPC socket이 존재하면 active runtime이 있는 것으로 본다.
+    PID는 alive지만 socket이 부재하면 stale PID로 보고 cold-path 진행을
+    허용한다(다른 프로세스가 해당 PID를 차지한 상태일 수 있다).
+
+    monkeypatch 호환을 위해 ``ante.main.read_pid_file``과
+    ``ante.cli.commands.ipc_helpers.get_socket_path``는 함수 내부에서
+    local import한다.
+    """
+    from ante.main import read_pid_file
+
+    pid = read_pid_file()
+    if pid is None:
+        return  # PID 파일 부재 → active runtime 없음
+
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return  # stale PID → active runtime 없음
+
+    from ante.cli.commands.ipc_helpers import get_socket_path
+
+    try:
+        socket_path = get_socket_path()
+    except Exception:
+        # socket 경로 해석 실패 시는 차단 측으로 판정하지 않는다
+        # (config 부재 등). 그러나 PID alive 단독으로는 단정할 수 없으므로
+        # offline으로 간주한다.
+        return
+
+    if not Path(socket_path).exists():
+        return  # PID alive but socket absent → stale PID/타 프로세스 → 통과
+
+    # PID alive AND socket exists → active runtime 있음 → 차단.
+    # text 출력 경로도 차단 코드를 식별할 수 있도록 메시지에 prefix를 포함한다.
+    fmt.error(
+        f"{_COLD_PATH_BLOCKED_CODE}: 서버가 실행 중입니다. "
+        "cold-path 명령은 서버 정지 상태에서만 실행할 수 있습니다.",
+        code=_COLD_PATH_BLOCKED_CODE,
+    )
+    raise SystemExit(1)
 
 
 async def _create_account_service() -> tuple[AccountService, Database]:
@@ -72,6 +129,9 @@ def _get_selectable_broker_types() -> list[str]:
 def account_create(ctx: click.Context) -> None:
     """대화형 계좌 생성."""
     fmt = get_formatter(ctx)
+
+    # cold-path: active runtime이 있으면 진입 직후 차단
+    _assert_no_active_runtime(fmt)
 
     from ante.account.models import Account, TradingMode
     from ante.account.presets import BROKER_PRESETS
@@ -312,23 +372,50 @@ def account_activate(ctx: click.Context, account_id: str) -> None:
 @require_auth
 @require_scope("account:write")
 def account_delete(ctx: click.Context, account_id: str, skip_confirm: bool) -> None:
-    """계좌 삭제 (소프트 딜리트)."""
-    from ante.cli.commands.ipc_helpers import ipc_send
+    """계좌 삭제 (소프트 딜리트, cold-path 전용).
 
+    1.0 정책: account.delete는 IPC runtime command가 아니다. active Ante
+    runtime이 있으면 차단되며, 서버 정지 상태에서만 AccountService.delete를
+    직접 호출한다. 소속 봇이 살아 있는 계좌는 AccountHasActiveBotsError로
+    차단된다(orphan bot 무결성).
+    """
     fmt = get_formatter(ctx)
     member_id = get_member_id(ctx)
 
     if not skip_confirm:
         click.confirm(f'계좌 "{account_id}"를 삭제하시겠습니까?', abort=True)
 
+    # cold-path: confirm 통과 직후 active runtime 차단
+    _assert_no_active_runtime(fmt)
+
+    from ante.account.errors import (
+        AccountDeletedError,
+        AccountHasActiveBotsError,
+        AccountNotFoundError,
+    )
+
+    async def _do_delete() -> None:
+        svc, db = await _create_account_service()
+        try:
+            await svc.delete(account_id, deleted_by=member_id)
+        finally:
+            await db.close()
+
     try:
-        _run(
-            ipc_send(
-                "account.delete",
-                {"account_id": account_id},
-                actor=member_id,
-            )
+        _run(_do_delete())
+    except AccountHasActiveBotsError as e:
+        fmt.error(
+            f"계좌 '{e.account_id}'에 활성 봇이 {e.bot_count}개 남아 있어 "
+            f"삭제할 수 없습니다. 봇을 먼저 제거한 뒤 다시 시도하세요.",
+            code="ACCOUNT_HAS_ACTIVE_BOTS",
         )
+        raise SystemExit(1) from e
+    except AccountNotFoundError as e:
+        fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
+        raise SystemExit(1) from e
+    except AccountDeletedError as e:
+        fmt.error(str(e), code="ACCOUNT_ALREADY_DELETED")
+        raise SystemExit(1) from e
     except click.ClickException:
         raise
     except Exception as e:
@@ -395,8 +482,11 @@ def account_set_credentials(
     app_key: str | None,
     app_secret: str | None,
 ) -> None:
-    """인증 정보 재설정 (대화형 또는 --app-key/--app-secret 옵션)."""
+    """인증 정보 재설정 (대화형 또는 --app-key/--app-secret 옵션, cold-path 전용)."""
     fmt = get_formatter(ctx)
+
+    # cold-path: active runtime이 있으면 진입 직후 차단
+    _assert_no_active_runtime(fmt)
 
     from ante.account.presets import BROKER_PRESETS
 

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -404,11 +404,9 @@ def account_delete(ctx: click.Context, account_id: str, skip_confirm: bool) -> N
     try:
         _run(_do_delete())
     except AccountHasActiveBotsError as e:
-        fmt.error(
-            f"계좌 '{e.account_id}'에 활성 봇이 {e.bot_count}개 남아 있어 "
-            f"삭제할 수 없습니다. 봇을 먼저 제거한 뒤 다시 시도하세요.",
-            code="ACCOUNT_HAS_ACTIVE_BOTS",
-        )
+        # 메시지 본문은 errors.py에서 multi-step 복구 절차까지 포함해 빌드한다.
+        # (#1139 R-A) 별도 wording을 만들지 말고 그대로 출력한다.
+        fmt.error(str(e), code="ACCOUNT_HAS_ACTIVE_BOTS")
         raise SystemExit(1) from e
     except AccountNotFoundError as e:
         fmt.error(str(e), code="ACCOUNT_NOT_FOUND")

--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -591,9 +591,8 @@ class AccountActivatedEvent(Event):
     activated_by: str = ""
 
 
-@dataclass(frozen=True)
-class AccountDeletedEvent(Event):
-    """AccountService → EventBus: 계좌 삭제."""
-
-    account_id: str = ""
-    deleted_by: str = ""
+# AccountDeletedEvent는 1.0 EventBus 계약에서 제거되었다 (#1139).
+# 계좌 삭제는 cold-path structural operation이며, 서버 실행 중 consumer
+# topology를 hot wiring하지 않는다. 정합 SSOT는
+# docs/specs/eventbus/eventbus.md 119-127줄과
+# docs/specs/account/05-eventbus-integration.md 8-17줄.

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -72,14 +72,6 @@ async def _handle_account_activate(
     return {"account_id": account_id, "status": "active"}
 
 
-async def _handle_account_delete(
-    svc: ServiceRegistry, args: dict[str, Any], actor: str
-) -> dict:
-    account_id = args["account_id"]
-    await svc.account.delete(account_id, deleted_by=actor)
-    return {"account_id": account_id, "status": "deleted"}
-
-
 async def _handle_bot_create(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
@@ -243,12 +235,15 @@ async def _handle_broker_reconcile(
 
 
 def register_all_handlers(registry: CommandRegistry) -> None:
-    """18개 런타임 커맨드 핸들러를 일괄 등록."""
+    """18개 런타임 커맨드 핸들러를 일괄 등록.
+
+    `account.delete`는 1.0 IPC 계약에서 제외되었다 (#1139). cold-path CLI에서
+    AccountService.delete()를 직접 호출하므로 IPC 라우팅 대상이 아니다.
+    """
     registry.register("system.halt", _handle_system_halt)
     registry.register("system.activate", _handle_system_activate)
     registry.register("account.suspend", _handle_account_suspend)
     registry.register("account.activate", _handle_account_activate)
-    registry.register("account.delete", _handle_account_delete)
     registry.register("bot.create", _handle_bot_create)
     registry.register("bot.remove", _handle_bot_remove)
     registry.register("treasury.allocate", _handle_treasury_allocate)

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -37,15 +37,18 @@ def test_commands_property(registry: CommandRegistry) -> None:
 
 
 def test_register_all_handlers() -> None:
-    """register_all_handlers가 19개 핸들러를 등록."""
+    """register_all_handlers가 18개 핸들러를 등록 (account.delete 제외).
+
+    `account.delete`는 1.0 IPC 계약에서 제거되어 cold-path CLI에서 직접
+    AccountService를 호출한다.
+    """
     registry = CommandRegistry()
     register_all_handlers(registry)
-    assert len(registry.commands) == 19
+    assert len(registry.commands) == 18
 
     expected = {
         "system.halt",
         "system.activate",
-        "account.delete",
         "account.suspend",
         "account.activate",
         "bot.create",
@@ -64,6 +67,8 @@ def test_register_all_handlers() -> None:
         "broker.reconcile",
     }
     assert set(registry.commands) == expected
+    # account.delete는 cold-path 전용이므로 IPC 등록 대상이 아니다.
+    assert "account.delete" not in registry.commands
 
 
 # ── _handle_bot_create 변환 로직 테스트 ──────────────

--- a/tests/unit/specs/test_cold_path_terminology.py
+++ b/tests/unit/specs/test_cold_path_terminology.py
@@ -1,0 +1,48 @@
+"""Cold-path 용어 정합 회귀 가드 (#1139).
+
+1.0 단일 active runtime 정책 하에서 cold-path 차단 기준은
+"같은 ``config_dir``의 PID/socket guard"가 아니라 "active Ante runtime guard"다.
+
+이 테스트는 cold-path 명령(`account create/delete/set-credentials`)을 다루는
+SSOT 스펙에서 1.0 차단 기준 맥락에 옛 표현이 잔존하지 않는지 grep 단언한다.
+
+대상 스펙:
+- docs/specs/cli/03-commands.md
+- docs/specs/account/09-cli.md
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+SPEC_FILES = [
+    REPO_ROOT / "docs" / "specs" / "cli" / "03-commands.md",
+    REPO_ROOT / "docs" / "specs" / "account" / "09-cli.md",
+]
+
+# 1.0 차단 기준 맥락에서 등장해서는 안 되는 옛 표현 패턴.
+# "같은" + (임의 텍스트) + "config_dir" + (임의 텍스트) + ("PID" 또는 "socket")
+# 형태의 가드 설명을 잡는다.
+LEGACY_GUARD_PATTERN = re.compile(
+    r"같은[^\n]*config_dir[^\n]*(PID|socket)",
+    re.IGNORECASE,
+)
+
+
+@pytest.mark.parametrize("spec_path", SPEC_FILES, ids=lambda p: p.name)
+def test_cold_path_guard_terminology_uses_active_runtime(spec_path: Path) -> None:
+    """cold-path 차단 기준은 active Ante runtime guard로 표현되어야 한다."""
+    assert spec_path.exists(), f"spec 파일이 존재해야 함: {spec_path}"
+    text = spec_path.read_text(encoding="utf-8")
+
+    matches = LEGACY_GUARD_PATTERN.findall(text)
+    assert not matches, (
+        f"{spec_path} 에서 1.0 차단 기준 맥락의 옛 PID/socket guard 표현이 "
+        f"잔존한다: {matches}. "
+        f"#1139 정책: 'active Ante runtime guard'로 표현해야 한다."
+    )

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -333,6 +333,75 @@ async def test_delete_account(service):
     assert deleted.status == AccountStatus.DELETED
 
 
+# ── delete preflight: active bot 차단 ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_raises_when_active_bots_present(service, db):
+    """non-deleted 봇이 있으면 delete가 AccountHasActiveBotsError로 차단된다.
+
+    bots 테이블에 status != 'deleted' 행이 있으면 status mutation 전에
+    AccountHasActiveBotsError가 raise되어야 하며, 계좌 status는 ACTIVE 그대로
+    유지되어야 한다.
+    """
+    from ante.account.errors import AccountHasActiveBotsError
+    from ante.bot.manager import BOT_SCHEMA
+
+    await service.create(_make_account())
+    await db.execute_script(BOT_SCHEMA)
+    await db.execute(
+        """INSERT INTO bots
+           (bot_id, name, strategy_id, account_id, config_json, status)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        ("bot-1", "테스트봇", "strat", "test", "{}", "running"),
+    )
+
+    with pytest.raises(AccountHasActiveBotsError) as excinfo:
+        await service.delete("test", deleted_by="admin")
+
+    assert excinfo.value.account_id == "test"
+    assert excinfo.value.bot_count == 1
+
+    # 계좌 status는 ACTIVE 그대로 유지되어야 함
+    account = await service.get("test")
+    assert account.status == AccountStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_delete_succeeds_when_no_active_bots(service, db):
+    """bots 테이블이 비어 있으면 delete는 정상 진행된다."""
+    from ante.bot.manager import BOT_SCHEMA
+
+    await service.create(_make_account())
+    # 빈 bots 테이블
+    await db.execute_script(BOT_SCHEMA)
+
+    await service.delete("test", deleted_by="admin")
+
+    deleted = await service.get("test")
+    assert deleted.status == AccountStatus.DELETED
+
+
+@pytest.mark.asyncio
+async def test_delete_succeeds_when_only_deleted_bots(service, db):
+    """같은 account_id에 status='deleted' 봇만 있으면 delete 정상 진행."""
+    from ante.bot.manager import BOT_SCHEMA
+
+    await service.create(_make_account())
+    await db.execute_script(BOT_SCHEMA)
+    await db.execute(
+        """INSERT INTO bots
+           (bot_id, name, strategy_id, account_id, config_json, status)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        ("bot-old", "삭제봇", "strat", "test", "{}", "deleted"),
+    )
+
+    await service.delete("test", deleted_by="admin")
+
+    deleted = await service.get("test")
+    assert deleted.status == AccountStatus.DELETED
+
+
 # ── 일괄 정지/활성화 (suspend_all / activate_all) ──────
 
 

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -402,6 +402,54 @@ async def test_delete_succeeds_when_only_deleted_bots(service, db):
     assert deleted.status == AccountStatus.DELETED
 
 
+@pytest.mark.asyncio
+async def test_delete_error_message_includes_multistep_procedure(service, db):
+    """AccountHasActiveBotsError 메시지는 multi-step 복구 절차를 안내한다 (#1139 R-A).
+
+    1.0에서 cold-path delete는 active 봇이 있으면 차단되지만, ``ante bot remove``
+    는 IPC 전용이므로 운영자는 (start → bot remove → stop → account delete) 4단계
+    절차를 따라야 한다. 에러 메시지에 이 절차가 정확한 순서로 포함되어야 하며,
+    ``account_id``와 ``bot_count``도 함께 노출되어야 한다 (#1161까지의 mitigation).
+    """
+    import re
+
+    from ante.account.errors import AccountHasActiveBotsError
+    from ante.bot.manager import BOT_SCHEMA
+
+    await service.create(_make_account())
+    await db.execute_script(BOT_SCHEMA)
+    await db.execute(
+        """INSERT INTO bots
+           (bot_id, name, strategy_id, account_id, config_json, status)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        ("bot-1", "테스트봇", "strat", "test", "{}", "running"),
+    )
+
+    with pytest.raises(AccountHasActiveBotsError) as excinfo:
+        await service.delete("test", deleted_by="admin")
+
+    message = str(excinfo.value)
+
+    # account_id / bot_count 포함
+    assert "test" in message
+    assert "1" in message
+
+    # 4개 절차 토큰이 모두 포함되어야 한다
+    assert "ante system start" in message
+    assert "ante bot remove" in message
+    assert "ante system stop" in message
+    assert "ante account delete" in message
+
+    # 정확한 순서로 등장해야 한다 (multi-step 절차의 핵심)
+    order_pattern = re.compile(
+        r"ante system start.*?ante bot remove.*?ante system stop.*?ante account delete",
+        re.DOTALL,
+    )
+    assert order_pattern.search(message) is not None, (
+        f"multi-step 절차가 정확한 순서로 메시지에 포함되어야 한다: {message!r}"
+    )
+
+
 # ── 일괄 정지/활성화 (suspend_all / activate_all) ──────
 
 

--- a/tests/unit/test_account_cli.py
+++ b/tests/unit/test_account_cli.py
@@ -243,13 +243,62 @@ class TestAccountCredentials:
         assert "등록된 인증 정보가 없습니다" in result.output
 
 
+# ── active runtime guard 헬퍼 ──────────────────────────────
+
+
+@pytest.fixture
+def offline_runtime():
+    """active runtime이 없는 상태(PID 파일 부재)를 모사한다.
+
+    cold-path 명령이 active runtime guard를 통과하도록 read_pid_file이
+    None을 반환하게 하고, 보강 socket guard가 호출되어도 안전하도록
+    get_socket_path가 존재하지 않는 임시 경로를 반환하게 한다.
+    """
+    with (
+        patch("ante.main.read_pid_file", return_value=None),
+        patch(
+            "ante.cli.commands.ipc_helpers.get_socket_path",
+            return_value="/tmp/__ante_offline_runtime_test__.sock",
+        ),
+    ):
+        yield
+
+
+@pytest.fixture
+def active_runtime():
+    """active runtime(PID alive + socket present)을 모사한다."""
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.NamedTemporaryFile(
+        prefix="ante_active_runtime_", suffix=".sock"
+    ) as f:
+        socket_path = f.name
+        # 파일이 존재하는 상태로 patches 적용
+        with (
+            patch("ante.main.read_pid_file", return_value=12345),
+            patch(
+                "ante.cli.commands.account.os.kill",
+                return_value=None,
+            ),
+            patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value=socket_path,
+            ),
+        ):
+            assert Path(socket_path).exists()
+            yield
+
+
 # ── account create 대화형 테스트 ──────────────────
 
 
 class TestAccountCreate:
     """ante account create 테스트."""
 
-    def test_create_interactive(self, mock_account_service: AsyncMock) -> None:
+    def test_create_interactive(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
         """대화형 생성 흐름이 정상 동작한다."""
         created = _mock_account("test", "테스트", "TEST", "KRW", "test")
         mock_account_service.create.return_value = created
@@ -260,6 +309,56 @@ class TestAccountCreate:
         result = _invoke(["account", "create"], input_text=input_text)
         assert result.exit_code == 0
         assert "생성 완료" in result.output
+        mock_account_service.create.assert_called_once()
+
+    def test_create_blocked_when_active_runtime(
+        self, mock_account_service: AsyncMock, active_runtime
+    ) -> None:
+        """active runtime이 있으면 cold-path가 차단된다."""
+        input_text = "1\n\n\n1\ntest\ntest\n"
+        result = _invoke(["account", "create"], input_text=input_text)
+        assert result.exit_code == 1
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in result.output
+        mock_account_service.create.assert_not_called()
+
+    def test_create_offline_succeeds(self, mock_account_service: AsyncMock) -> None:
+        """PID 파일 부재(offline) 시 guard 통과."""
+        created = _mock_account("test", "테스트", "TEST", "KRW", "test")
+        mock_account_service.create.return_value = created
+
+        with (
+            patch("ante.main.read_pid_file", return_value=None),
+            patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/__ante_does_not_exist__.sock",
+            ),
+        ):
+            input_text = "1\n\n\n1\ntest\ntest\n"
+            result = _invoke(["account", "create"], input_text=input_text)
+        assert result.exit_code == 0
+        mock_account_service.create.assert_called_once()
+
+    def test_create_offline_when_pid_alive_but_socket_absent(
+        self, mock_account_service: AsyncMock
+    ) -> None:
+        """PID는 alive지만 socket이 부재하면 stale PID로 보고 guard 통과."""
+        created = _mock_account("test", "테스트", "TEST", "KRW", "test")
+        mock_account_service.create.return_value = created
+
+        with (
+            patch("ante.main.read_pid_file", return_value=12345),
+            patch(
+                "ante.cli.commands.account.os.kill",
+                return_value=None,
+            ),
+            patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/__ante_no_such_socket_xxx__.sock",
+            ),
+        ):
+            input_text = "1\n\n\n1\ntest\ntest\n"
+            result = _invoke(["account", "create"], input_text=input_text)
+        assert result.exit_code == 0
         mock_account_service.create.assert_called_once()
 
 
@@ -311,49 +410,203 @@ class TestAccountStateTransitions:
         assert "활성화 완료" in result.output
         mock_client.send.assert_called_once()
 
-    def test_delete_with_yes(self) -> None:
-        """계좌 삭제 (--yes 옵션, IPC 전환)."""
-        mock_response = {"status": "ok", "data": {}}
+    def test_delete_with_yes(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """계좌 삭제 (--yes 옵션, cold-path direct service 호출)."""
+        mock_account_service.delete.return_value = None
 
-        with patch(
-            "ante.cli.commands.ipc_helpers.IPCClient", autospec=True
-        ) as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.send.return_value = mock_response
-            mock_cls.return_value = mock_client
-
-            with patch(
-                "ante.cli.commands.ipc_helpers.get_socket_path",
-                return_value="/tmp/test.sock",
-            ):
-                result = _invoke(["account", "delete", "domestic", "--yes"])
+        result = _invoke(["account", "delete", "domestic", "--yes"])
 
         assert result.exit_code == 0
         assert "삭제 완료" in result.output
-        mock_client.send.assert_called_once()
+        mock_account_service.delete.assert_called_once()
 
-    def test_delete_with_confirm(self) -> None:
-        """계좌 삭제 (확인 프롬프트 y 입력, IPC 전환)."""
-        mock_response = {"status": "ok", "data": {}}
+    def test_delete_with_confirm(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """계좌 삭제 (확인 프롬프트 y 입력, cold-path direct service 호출)."""
+        mock_account_service.delete.return_value = None
 
-        with patch(
-            "ante.cli.commands.ipc_helpers.IPCClient", autospec=True
-        ) as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.send.return_value = mock_response
-            mock_cls.return_value = mock_client
-
-            with patch(
-                "ante.cli.commands.ipc_helpers.get_socket_path",
-                return_value="/tmp/test.sock",
-            ):
-                result = _invoke(["account", "delete", "domestic"], input_text="y\n")
+        result = _invoke(["account", "delete", "domestic"], input_text="y\n")
 
         assert result.exit_code == 0
         assert "삭제 완료" in result.output
-        mock_client.send.assert_called_once()
+        mock_account_service.delete.assert_called_once()
 
     def test_delete_abort(self) -> None:
         """계좌 삭제 취소 (확인 프롬프트 n 입력)."""
         result = _invoke(["account", "delete", "domestic"], input_text="n\n")
         assert result.exit_code == 1
+
+    def test_delete_blocked_when_active_runtime(
+        self, mock_account_service: AsyncMock, active_runtime
+    ) -> None:
+        """active runtime이 있으면 cold-path delete가 차단된다."""
+        result = _invoke(["account", "delete", "domestic", "--yes"])
+        assert result.exit_code == 1
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in result.output
+        mock_account_service.delete.assert_not_called()
+
+    def test_delete_offline_succeeds(self, mock_account_service: AsyncMock) -> None:
+        """PID 파일 부재(offline) 시 guard 통과 후 delete 호출."""
+        mock_account_service.delete.return_value = None
+        with (
+            patch("ante.main.read_pid_file", return_value=None),
+            patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/__ante_does_not_exist_del__.sock",
+            ),
+        ):
+            result = _invoke(["account", "delete", "domestic", "--yes"])
+        assert result.exit_code == 0
+        mock_account_service.delete.assert_called_once()
+
+    def test_delete_offline_when_pid_alive_but_socket_absent(
+        self, mock_account_service: AsyncMock
+    ) -> None:
+        """PID alive지만 socket 부재면 stale PID로 보고 guard 통과."""
+        mock_account_service.delete.return_value = None
+        with (
+            patch("ante.main.read_pid_file", return_value=12345),
+            patch("ante.cli.commands.account.os.kill", return_value=None),
+            patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/__ante_no_socket_del_xxx__.sock",
+            ),
+        ):
+            result = _invoke(["account", "delete", "domestic", "--yes"])
+        assert result.exit_code == 0
+        mock_account_service.delete.assert_called_once()
+
+    def test_delete_blocks_when_active_bots_present(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """non-deleted 봇이 있는 계좌의 delete는 명확한 메시지로 차단된다."""
+        from ante.account.errors import AccountHasActiveBotsError
+
+        mock_account_service.delete.side_effect = AccountHasActiveBotsError(
+            account_id="domestic",
+            bot_count=2,
+        )
+
+        result = _invoke(["account", "delete", "domestic", "--yes"])
+
+        assert result.exit_code == 1
+        assert "domestic" in result.output
+        # bot_count 또는 명확한 메시지가 사용자에게 노출되어야 한다
+        assert "봇" in result.output or "bot" in result.output.lower()
+        mock_account_service.delete.assert_called_once()
+
+
+# ── account set-credentials cold-path guard 테스트 ──────
+
+
+class TestAccountSetCredentialsRuntimeGuard:
+    """ante account set-credentials cold-path active runtime guard."""
+
+    def test_set_credentials_blocked_when_active_runtime(
+        self, mock_account_service: AsyncMock, active_runtime
+    ) -> None:
+        """active runtime이 있으면 cold-path set-credentials가 차단된다."""
+        result = _invoke(
+            [
+                "account",
+                "set-credentials",
+                "domestic",
+                "--app-key",
+                "k",
+                "--app-secret",
+                "s",
+            ]
+        )
+        assert result.exit_code == 1
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in result.output
+        mock_account_service.update.assert_not_called()
+
+    def test_set_credentials_offline_succeeds(
+        self, mock_account_service: AsyncMock
+    ) -> None:
+        """PID 파일 부재(offline) 시 guard 통과 후 update 호출."""
+        from decimal import Decimal
+
+        from ante.account.models import Account, AccountStatus, TradingMode
+
+        mock_account_service.get.return_value = Account(
+            account_id="domestic",
+            name="국내",
+            exchange="KRX",
+            currency="KRW",
+            broker_type="kis-domestic",
+            status=AccountStatus.ACTIVE,
+            trading_mode=TradingMode.VIRTUAL,
+            credentials={},
+            buy_commission_rate=Decimal("0.00015"),
+            sell_commission_rate=Decimal("0.00195"),
+        )
+        mock_account_service.update.return_value = None
+
+        with (
+            patch("ante.main.read_pid_file", return_value=None),
+            patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/__ante_offline_setc__.sock",
+            ),
+        ):
+            result = _invoke(
+                [
+                    "account",
+                    "set-credentials",
+                    "domestic",
+                    "--app-key",
+                    "k",
+                    "--app-secret",
+                    "s",
+                ]
+            )
+        assert result.exit_code == 0
+        mock_account_service.update.assert_called_once()
+
+    def test_set_credentials_offline_when_pid_alive_but_socket_absent(
+        self, mock_account_service: AsyncMock
+    ) -> None:
+        """PID alive지만 socket 부재면 stale PID로 보고 guard 통과."""
+        from decimal import Decimal
+
+        from ante.account.models import Account, AccountStatus, TradingMode
+
+        mock_account_service.get.return_value = Account(
+            account_id="domestic",
+            name="국내",
+            exchange="KRX",
+            currency="KRW",
+            broker_type="kis-domestic",
+            status=AccountStatus.ACTIVE,
+            trading_mode=TradingMode.VIRTUAL,
+            credentials={},
+            buy_commission_rate=Decimal("0.00015"),
+            sell_commission_rate=Decimal("0.00195"),
+        )
+        mock_account_service.update.return_value = None
+
+        with (
+            patch("ante.main.read_pid_file", return_value=12345),
+            patch("ante.cli.commands.account.os.kill", return_value=None),
+            patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/__ante_no_socket_setc_xxx__.sock",
+            ),
+        ):
+            result = _invoke(
+                [
+                    "account",
+                    "set-credentials",
+                    "domestic",
+                    "--app-key",
+                    "k",
+                    "--app-secret",
+                    "s",
+                ]
+            )
+        assert result.exit_code == 0
+        mock_account_service.update.assert_called_once()

--- a/tests/unit/test_account_delete_events.py
+++ b/tests/unit/test_account_delete_events.py
@@ -1,4 +1,9 @@
-"""AccountService.delete() 이벤트 발행 테스트 (#717)."""
+"""AccountService.delete() 이벤트 발행 테스트 (#717, #1139).
+
+#1139로 `AccountDeletedEvent`는 1.0 EventBus 계약에서 제거되었다.
+cold-path delete는 consumer wiring을 트리거하지 않으며, 같은 모듈에서
+발행되던 `AccountSuspendedEvent`(소속 봇 중지 트리거) 동작만 회귀 검증한다.
+"""
 
 import pytest
 import pytest_asyncio
@@ -7,10 +12,7 @@ from ante.account.models import Account, AccountStatus
 from ante.account.service import AccountService
 from ante.core.database import Database
 from ante.eventbus.bus import EventBus
-from ante.eventbus.events import (
-    AccountDeletedEvent,
-    AccountSuspendedEvent,
-)
+from ante.eventbus.events import AccountSuspendedEvent
 
 
 @pytest_asyncio.fixture
@@ -58,12 +60,32 @@ def _make_account(
     )
 
 
+def test_account_deleted_event_is_not_part_of_runtime_contract():
+    """AccountDeletedEvent는 1.0 EventBus 계약에서 제거되었다.
+
+    회귀 가드: 향후 누군가 다시 정의하더라도 이 직접 단언이 fail하여
+    cold-path consumer wiring 트리거 변경이 곧바로 노출된다.
+    """
+    import ante.eventbus.events as events_module
+
+    assert not hasattr(events_module, "AccountDeletedEvent"), (
+        "AccountDeletedEvent는 #1139에서 1.0 비계약으로 분류되었다. "
+        "cold-path delete는 consumer wiring을 트리거하지 않으므로 "
+        "이 이벤트를 다시 도입하지 말 것."
+    )
+
+
 class TestAccountDeleteEvents:
     """AccountService.delete() 이벤트 발행 테스트."""
 
     @pytest.mark.asyncio
-    async def test_delete_publishes_events(self, service, eventbus):
-        """delete()가 AccountSuspendedEvent -> AccountDeletedEvent 순서로 발행."""
+    async def test_delete_publishes_suspend_only(self, service, eventbus):
+        """delete()는 AccountSuspendedEvent만 발행한다.
+
+        AccountDeletedEvent는 1.0 비계약이므로 발행되지 않는다.
+        AccountSuspendedEvent(reason="Account deletion")는 BotManager가 소속
+        봇을 중지시키도록 유지된다.
+        """
         await service.create(_make_account())
 
         published: list = []
@@ -71,25 +93,15 @@ class TestAccountDeleteEvents:
         async def on_suspended(event: AccountSuspendedEvent) -> None:
             published.append(("suspended", event))
 
-        async def on_deleted(event: AccountDeletedEvent) -> None:
-            published.append(("deleted", event))
-
         eventbus.subscribe(AccountSuspendedEvent, on_suspended)
-        eventbus.subscribe(AccountDeletedEvent, on_deleted)
 
         await service.delete("test", deleted_by="admin")
 
-        assert len(published) == 2
-
-        # 순서 검증: suspended -> deleted
+        assert len(published) == 1
         assert published[0][0] == "suspended"
         assert published[0][1].account_id == "test"
         assert published[0][1].reason == "Account deletion"
         assert published[0][1].suspended_by == "admin"
-
-        assert published[1][0] == "deleted"
-        assert published[1][1].account_id == "test"
-        assert published[1][1].deleted_by == "admin"
 
     @pytest.mark.asyncio
     async def test_delete_already_suspended_skips_suspend_event(
@@ -104,19 +116,13 @@ class TestAccountDeleteEvents:
         async def on_suspended(event: AccountSuspendedEvent) -> None:
             published.append(("suspended", event))
 
-        async def on_deleted(event: AccountDeletedEvent) -> None:
-            published.append(("deleted", event))
-
         eventbus.subscribe(AccountSuspendedEvent, on_suspended)
-        eventbus.subscribe(AccountDeletedEvent, on_deleted)
 
         await service.delete("test", deleted_by="admin")
 
-        # AccountSuspendedEvent는 발행되지 않아야 함
-        assert len(published) == 1
-        assert published[0][0] == "deleted"
-        assert published[0][1].account_id == "test"
-        assert published[0][1].deleted_by == "admin"
+        # AccountSuspendedEvent는 새로 발행되지 않아야 함
+        # (이미 suspend 시 1회 발행되었지만 delete()에서는 추가 발행 없음)
+        assert len(published) == 0
 
     @pytest.mark.asyncio
     async def test_delete_sets_status_and_clears_cache(self, service):

--- a/tests/unit/test_cli_format_option.py
+++ b/tests/unit/test_cli_format_option.py
@@ -199,49 +199,54 @@ class TestAccountInfoFormatOption:
 
 
 class TestAccountDeleteYes:
-    """ante account delete {id} --yes."""
+    """ante account delete {id} --yes (#1139: IPC → cold-path direct service)."""
 
     def test_delete_with_yes_skips_confirm(self, runner: CliRunner) -> None:
-        mock_response = {"status": "ok", "data": {}}
+        svc = AsyncMock()
+        db = _mock_db()
+        svc.delete.return_value = None
 
-        with patch(
-            "ante.cli.commands.ipc_helpers.IPCClient", autospec=True
-        ) as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.send.return_value = mock_response
-            mock_cls.return_value = mock_client
-
-            with patch(
+        with (
+            patch(
+                "ante.cli.commands.account._create_account_service",
+                new_callable=AsyncMock,
+                return_value=(svc, db),
+            ),
+            patch("ante.main.read_pid_file", return_value=None),
+            patch(
                 "ante.cli.commands.ipc_helpers.get_socket_path",
-                return_value="/tmp/test.sock",
-            ):
-                result = runner.invoke(cli, ["account", "delete", "test-acct", "--yes"])
+                return_value="/tmp/__ante_offline_fmt_del__.sock",
+            ),
+        ):
+            result = runner.invoke(cli, ["account", "delete", "test-acct", "--yes"])
 
         assert result.exit_code == 0
         assert "삭제 완료" in result.output
-        mock_client.send.assert_called_once()
+        svc.delete.assert_called_once()
 
     def test_delete_without_yes_prompts(self, runner: CliRunner) -> None:
-        """--yes 없이 호출하면 확인 프롬프트가 나타남."""
-        mock_response = {"status": "ok", "data": {}}
+        """--yes 없이 호출하면 확인 프롬프트가 나타남 (cold-path direct service)."""
+        svc = AsyncMock()
+        db = _mock_db()
+        svc.delete.return_value = None
 
-        with patch(
-            "ante.cli.commands.ipc_helpers.IPCClient", autospec=True
-        ) as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.send.return_value = mock_response
-            mock_cls.return_value = mock_client
-
-            with patch(
+        with (
+            patch(
+                "ante.cli.commands.account._create_account_service",
+                new_callable=AsyncMock,
+                return_value=(svc, db),
+            ),
+            patch("ante.main.read_pid_file", return_value=None),
+            patch(
                 "ante.cli.commands.ipc_helpers.get_socket_path",
-                return_value="/tmp/test.sock",
-            ):
-                result = runner.invoke(
-                    cli, ["account", "delete", "test-acct"], input="y\n"
-                )
+                return_value="/tmp/__ante_offline_fmt_del2__.sock",
+            ),
+        ):
+            result = runner.invoke(cli, ["account", "delete", "test-acct"], input="y\n")
 
         assert result.exit_code == 0
         assert "삭제 완료" in result.output
+        svc.delete.assert_called_once()
 
 
 # ── treasury status --format json ─────────────────────────

--- a/tests/unit/test_eventbus_account_events.py
+++ b/tests/unit/test_eventbus_account_events.py
@@ -1,6 +1,8 @@
-"""EventBus Account 이벤트 확장 테스트 (#562).
+"""EventBus Account 이벤트 확장 테스트 (#562, #1139).
 
-Account 이벤트 3종 추가 및 기존 이벤트 account_id 필드 하위 호환 검증.
+#1139에서 AccountDeletedEvent는 1.0 EventBus 계약에서 제거되었다.
+잔존 Account 이벤트 2종(Suspended/Activated)과 기존 이벤트 account_id 필드
+하위 호환을 검증한다.
 """
 
 import pytest
@@ -8,7 +10,6 @@ import pytest
 from ante.eventbus import EventBus
 from ante.eventbus.events import (
     AccountActivatedEvent,
-    AccountDeletedEvent,
     AccountSuspendedEvent,
     BalanceSyncedEvent,
     BotErrorEvent,
@@ -77,24 +78,6 @@ class TestAccountEvents:
         assert received[0].account_id == "acc-001"
         assert received[0].activated_by == "admin"
 
-    async def test_account_deleted_event(self, bus: EventBus):
-        """AccountDeletedEvent 생성 및 발행."""
-        received: list[AccountDeletedEvent] = []
-
-        async def handler(event: AccountDeletedEvent) -> None:
-            received.append(event)
-
-        bus.subscribe(AccountDeletedEvent, handler)
-        event = AccountDeletedEvent(
-            account_id="acc-001",
-            deleted_by="admin",
-        )
-        await bus.publish(event)
-
-        assert len(received) == 1
-        assert received[0].account_id == "acc-001"
-        assert received[0].deleted_by == "admin"
-
     async def test_account_events_are_frozen(self):
         """Account 이벤트는 불변이다."""
         event = AccountSuspendedEvent(account_id="acc-001")
@@ -111,10 +94,6 @@ class TestAccountEvents:
         activated = AccountActivatedEvent()
         assert activated.account_id == ""
         assert activated.activated_by == ""
-
-        deleted = AccountDeletedEvent()
-        assert deleted.account_id == ""
-        assert deleted.deleted_by == ""
 
 
 # ── 기존 이벤트 account_id 하위 호환 ─────────────────


### PR DESCRIPTION
Closes #1139

## Summary
- Ante 1.0 단일 active runtime 정책에 맞춰 Account cold-path 경계 재정렬.
- `_assert_no_active_runtime(fmt)` cold-path guard 신설 (`PID alive + socket exists` 패턴, baseline `read_pid_file()`/`get_socket_path()` 미러).
- `account create/delete/set-credentials` 모두 진입 직후 guard 호출 → active runtime 중 DB/service 호출 전 차단.
- `account delete`를 IPC → direct service 호출로 교체 (cold-path 일관).
- `account.delete` IPC handler/registry 제거.
- `AccountDeletedEvent` 클래스/publish 제거 (1.0 EventBus 비계약).
- `AccountService.delete()`에 active bot preflight 검사 추가 (orphan bot 무결성). 활성 봇이 있으면 신규 `AccountHasActiveBotsError` raise + multi-step 절차 안내 메시지.
- 스펙 6개 갱신 (`config/03-design-decisions.md`, `cli/03-commands.md`, `account/09-cli.md`, `account/04-account-service.md`, `account/05-eventbus-integration.md`, `ipc/ipc.md`).

## Scope decision (narrow-scope)
이 PR은 **baseline parity 유지**로 의도적 제한된 narrow-scope다. 다음 영역은 명시적 후속 이슈로 분리됐다:
- **#1157** — runtime path canonical resolver (`runtime.pid_path`/`socket_path` + system.py/IPC 통합). 본 PR `_assert_no_active_runtime`이 baseline `read_pid_file()`(cwd-relative `db/ante.pid`)/`get_socket_path()`(`<config_dir>/db/ante.sock`)을 미러링한 결과 좌표계 비대칭이 그대로 남는다 — Ante 1.0 단일 active runtime 정책 하에서는 의미적 충분.
- **#1158** — DB path resolver 정합 (`get_db_path()` ↔ `Config.get('db.path')` split-brain).
- **#1159** — ante shutdown ordering (IPC socket unlink가 BotManager/DB close 이전이라 race window).
- **#1160** — ante startup ordering (`_write_pid_file()`이 IPC 시작보다 먼저 호출되어 PID-only 창).
- **#1161** — `ante bot remove` cold-path 지원 (현재 IPC 전용이라 `account delete`와 multi-step 절차 필요).

## Plan/Review history
- Plan Preflight v1~v4: `same config_dir` PID/socket → 1.0 단일 active runtime 정책으로 정합 (R4 + A 채택, 사용자 승인 2026-04-29). plan v4가 canonical plan.
- Codex Plan Review v3 (1 critical + 2 high) → #1157/#1158 분리 + orphan bot plan v4 흡수.
- Codex Plan Review v4 → narrow-scope verdict (R4 결정 + 1.0 정책 하 baseline 미러 의미적 충분).
- Codex 브랜치 리뷰 attempt 1: 3 findings → 메타 리뷰 R-A.
  - bot deletion deadlock → 메시지 강화 (multi-step 절차 안내)
  - runtime PID + race window → #1157/#1159/#1160 분리.
- Codex 브랜치 리뷰 attempt 2: 같은 분리 영역(#1157/#1159/#1160)을 다시 P1 격상 지적. **R4 narrow-scope 결정과 메타 리뷰 권고에 따라 분리 유지**. PR description에 분리 의도 박아 후속 리뷰가 컨텍스트를 인지하도록 한다.

## Risk Flags (이슈 본문 명시)
- `lifecycle`, `contract-drift`, `multi-consumer`, `spec-rewrite`, `data-integrity`

## Test Plan
- `PYTHONPATH=$(pwd)/src .venv/bin/python -m pytest tests/unit -x --ignore=tests/unit/web` → **3314 passed**
- 좁은 회귀: `tests/unit/test_account_cli.py tests/unit/test_account.py tests/unit/test_account_immutable_fields.py tests/unit/test_account_delete_events.py tests/unit/test_eventbus_account_events.py tests/unit/ipc/test_registry.py tests/unit/test_cli_ipc_commands.py tests/unit/test_cli_format_option.py tests/unit/specs/test_cold_path_terminology.py` → **148+ passed** (메시지 강화 회귀 1건 포함)
- TDD 회귀 가드 검증: `_assert_no_active_runtime` socket 보강 임시 제거 → 3개 RED → 원복 후 PASS. `delete()` preflight 임시 제거 → service-level RED → 원복 후 PASS. `AccountHasActiveBotsError` 메시지 강화 전 → multi-step 토큰 단언 RED → 강화 후 PASS.
- `ruff check src/ante tests/` → All checks passed
- `ruff format --check src/ante tests/` → 420 files already formatted
- `grep -rn "AccountDeletedEvent" src tests` → 코멘트 외 0건
- `grep -n "account.delete" src/ante/ipc/registry.py src/ante/cli/commands/account.py` → IPC 등록 0건
- `grep -nE "같은[^\\n]*config_dir[^\\n]*(PID|socket)" docs/specs/cli/03-commands.md docs/specs/account/09-cli.md` → 0건

## Acceptance (이슈 본문 완료 조건)
- [x] 1.0 단일 active runtime 정책이 스펙 문서에 명시됨
- [x] Account cold-path 스펙의 차단 기준이 active Ante runtime 기준으로 갱신됨
- [x] `ante account create/delete/set-credentials` 모두 active runtime 중 DB/service 호출 전 차단
- [x] active runtime이 없을 때 cold-path direct mutation 허용
- [x] CLI `account delete`가 IPC 대신 direct service 경로 사용
- [x] `account.delete` IPC handler/registry 제거
- [x] `AccountDeletedEvent` runtime 계약 잔여 제거
- [x] `AccountService.delete()`가 active bot 참조를 차단 (orphan bot 무결성)
- [x] 관련 CLI/IPC/EventBus/Service/spec 테스트 갱신