### PR TITLE
fix(account,web): align PUT /api/accounts request body schema and add Content-Type 415 gate (#1153)

### DIFF
--- a/docs/specs/account/10-web-api.md
+++ b/docs/specs/account/10-web-api.md
@@ -50,6 +50,10 @@ Web API는 서버 프로세스 내부에서 실행되므로 계좌 구조 변경
 브로커 재초기화성 변경은 서버를 정지한 뒤 cold-path CLI로 수행하고, 서버 재시작 시 새
 계좌 topology가 반영된다.
 
+`PUT /api/accounts/:id` 본문은 `Content-Type: application/json` (charset suffix 허용)
+만 허용하며, 다른 media type은 415 Unsupported Media Type을 반환한다. structural 필드
+키 검사(409)는 Content-Type 검사(415)보다 우선한다(invariant I4 — raw key 가드).
+
 ### 기존 엔드포인트 계좌 필터
 
 멀티 계좌 환경에서 모든 거래·잔고·봇 관련 API 응답에 계좌 컨텍스트를 포함한다.

--- a/docs/specs/web-api/05-resource-endpoints.md
+++ b/docs/specs/web-api/05-resource-endpoints.md
@@ -13,7 +13,7 @@
 | GET | `/api/accounts` | 계좌 목록 |
 | POST | `/api/accounts` | 계좌 등록. cold-path 전용이므로 런타임 서버에서는 409 `ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER` 반환. Body: account_id, exchange, currency, broker_type, trading_mode, credentials, broker_config, buy_commission_rate, sell_commission_rate |
 | GET | `/api/accounts/{account_id}` | 계좌 상세 조회 |
-| PUT | `/api/accounts/{account_id}` | 계좌 수정. 런타임에는 `name`, `timezone`, `trading_hours_start`, `trading_hours_end` 같은 비구조 필드만 허용. `credentials`, `broker_config`, `buy_commission_rate`, `sell_commission_rate`, `broker_type`, `exchange`, `currency`, `trading_mode` 포함 시 409 |
+| PUT | `/api/accounts/{account_id}` | 계좌 수정. 런타임에는 `name`, `timezone`, `trading_hours_start`, `trading_hours_end` 같은 비구조 필드만 허용. `credentials`, `broker_config`, `buy_commission_rate`, `sell_commission_rate`, `broker_type`, `exchange`, `currency`, `trading_mode` 포함 시 409. 본문은 `Content-Type: application/json`(charset suffix 허용)만 허용하며, 그 외 media type은 415 반환. 다른 mutate 라우트의 415 게이트 도입은 본 변경 범위 밖. |
 | GET | `/api/accounts/{account_id}/credentials` | 인증 정보 마스킹 조회 |
 | POST | `/api/accounts/{account_id}/suspend` | 계좌 거래 정지. Body: reason. 이미 정지 상태이면 409 Conflict |
 | POST | `/api/accounts/{account_id}/activate` | 계좌 거래 재개. 이미 활성 상태이면 409 Conflict |

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -219,7 +219,7 @@
           "accounts"
         ],
         "summary": "Update Account",
-        "description": "계좌 수정.\n\n런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도\n포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path\n응답과 ``AccountDeletedError`` 경로의 409를 구분한다.\n\nbody는 자유 ``dict[str, Any] | None``로 받는다. FastAPI 선행 Pydantic\n검증이 켜지면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가\nstructural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.\n핸들러 본문에서는 raw payload key 검사로 cold-path 가드를 먼저 수행한 뒤,\nstructural을 제외한 비구조 페이로드만 ``AccountUpdateRequest``로\n``model_validate``하여 mutable 필드의 type 검증을 수행한다(``{\"name\":\nnull}`` / ``{\"timezone\": {}}`` 같은 잘못된 값이 service/DB까지 흘러가\n상태를 오염시키는 것을 차단한다 — P1 회귀 보호). 검증 실패는 명시적으로\n422로 변환한다.\n\nPUT requestBody의 OpenAPI schema accuracy 회복(mutable 모델 노출)은 후속\n이슈 #1143에서 다룬다.",
+        "description": "계좌 수정.\n\n런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도\n포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path\n응답과 ``AccountDeletedError`` 경로의 409를 구분한다.\n\nbody는 raw bytes로 받는다(``request.body()``). FastAPI 선행 Pydantic\n검증을 거치면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가\nstructural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.\n\n핸들러 단계 순서(이슈 #1153 Implementation Plan):\n\n1. raw bytes 읽기.\n2. **빈 body**(``b\"\"``) → ``payload = {}``로 두고 Content-Type 검사·JSON\n   파싱 모두 건너뛰고 mutable 단계까지 흘려보낸다(현재 400 no-op 의미 보존).\n3. **JSON 파싱 실패**: Content-Type ≠ application/json → 415,\n   Content-Type 정상 → 422.\n4. **non-dict JSON**: Content-Type ≠ application/json → 415,\n   Content-Type 정상 → 422.\n5. **structural 가드(I4 우선)**: dict payload에 structural 키 존재 → 409\n   (Content-Type 무관, structural+text/plain도 409).\n6. ``len(payload) == 0`` (``{}`` 명시 송신) → 400 no-op (Content-Type\n   검사 건너뜀; #1152 후속에서 422로 정렬).\n7. **Content-Type 415 게이트**: ``application/json``(charset suffix 허용)\n   이외 → 415.\n8. **unknown 키 / mutable type**: structural 제외한 raw dict의 unknown\n   키 → 422. ``AccountUpdateRequest.model_validate`` ValidationError → 422.\n9. ``model_dump(exclude_none=True)`` 결과 비면 400 (예: ``{\"name\": null}``\n   단독 — 기존 의미 유지).\n10. service 호출.",
         "operationId": "update_account_api_accounts__account_id__put",
         "parameters": [
           {
@@ -232,24 +232,6 @@
             }
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "additionalProperties": true
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "Body"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -291,8 +273,18 @@
               }
             }
           },
+          "415": {
+            "description": "Content-Type이 application/json이 아님",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "422": {
-            "description": "비구조(mutable) 필드 type 검증 실패. structural 필드 키는 422가 아닌 409로 차단된다.",
+            "description": "비구조(mutable) 필드 type 검증 실패 또는 unknown 키. structural 필드 키는 422가 아닌 409로 차단된다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -307,6 +299,37 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "title": "AccountMutableUpdateRequest",
+                "description": "PUT /api/accounts/{account_id} 런타임 mutable 입력 contract. 런타임에는 비구조 필드만 변경할 수 있다. structural 필드(credentials, broker_config, buy_commission_rate, sell_commission_rate, broker_type, exchange, currency, trading_mode)는 cold-path 409로 차단된다. 스키마 SSOT: docs/specs/account/10-web-api.md 16-22줄.",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "사용자에게 표시되는 이름."
+                  },
+                  "timezone": {
+                    "type": "string",
+                    "description": "거래소 현지 시간대 (IANA)."
+                  },
+                  "trading_hours_start": {
+                    "type": "string",
+                    "description": "거래 시작 시각 (현지 시간, HH:MM)."
+                  },
+                  "trading_hours_end": {
+                    "type": "string",
+                    "description": "거래 종료 시각 (현지 시간, HH:MM)."
+                  }
                 }
               }
             }

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -67,18 +67,30 @@ export type paths = {
          *     ``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path
          *     응답과 ``AccountDeletedError`` 경로의 409를 구분한다.
          *
-         *     body는 자유 ``dict[str, Any] | None``로 받는다. FastAPI 선행 Pydantic
-         *     검증이 켜지면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가
+         *     body는 raw bytes로 받는다(``request.body()``). FastAPI 선행 Pydantic
+         *     검증을 거치면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가
          *     structural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.
-         *     핸들러 본문에서는 raw payload key 검사로 cold-path 가드를 먼저 수행한 뒤,
-         *     structural을 제외한 비구조 페이로드만 ``AccountUpdateRequest``로
-         *     ``model_validate``하여 mutable 필드의 type 검증을 수행한다(``{"name":
-         *     null}`` / ``{"timezone": {}}`` 같은 잘못된 값이 service/DB까지 흘러가
-         *     상태를 오염시키는 것을 차단한다 — P1 회귀 보호). 검증 실패는 명시적으로
-         *     422로 변환한다.
          *
-         *     PUT requestBody의 OpenAPI schema accuracy 회복(mutable 모델 노출)은 후속
-         *     이슈 #1143에서 다룬다.
+         *     핸들러 단계 순서(이슈 #1153 Implementation Plan):
+         *
+         *     1. raw bytes 읽기.
+         *     2. **빈 body**(``b""``) → ``payload = {}``로 두고 Content-Type 검사·JSON
+         *        파싱 모두 건너뛰고 mutable 단계까지 흘려보낸다(현재 400 no-op 의미 보존).
+         *     3. **JSON 파싱 실패**: Content-Type ≠ application/json → 415,
+         *        Content-Type 정상 → 422.
+         *     4. **non-dict JSON**: Content-Type ≠ application/json → 415,
+         *        Content-Type 정상 → 422.
+         *     5. **structural 가드(I4 우선)**: dict payload에 structural 키 존재 → 409
+         *        (Content-Type 무관, structural+text/plain도 409).
+         *     6. ``len(payload) == 0`` (``{}`` 명시 송신) → 400 no-op (Content-Type
+         *        검사 건너뜀; #1152 후속에서 422로 정렬).
+         *     7. **Content-Type 415 게이트**: ``application/json``(charset suffix 허용)
+         *        이외 → 415.
+         *     8. **unknown 키 / mutable type**: structural 제외한 raw dict의 unknown
+         *        키 → 422. ``AccountUpdateRequest.model_validate`` ValidationError → 422.
+         *     9. ``model_dump(exclude_none=True)`` 결과 비면 400 (예: ``{"name": null}``
+         *        단독 — 기존 의미 유지).
+         *     10. service 호출.
          */
         put: operations["update_account_api_accounts__account_id__put"];
         post?: never;
@@ -3387,11 +3399,18 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: {
+        requestBody: {
             content: {
                 "application/json": {
-                    [key: string]: unknown;
-                } | null;
+                    /** @description 사용자에게 표시되는 이름. */
+                    name?: string;
+                    /** @description 거래소 현지 시간대 (IANA). */
+                    timezone?: string;
+                    /** @description 거래 종료 시각 (현지 시간, HH:MM). */
+                    trading_hours_end?: string;
+                    /** @description 거래 시작 시각 (현지 시간, HH:MM). */
+                    trading_hours_start?: string;
+                };
             };
         };
         responses: {
@@ -3431,7 +3450,16 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description 비구조(mutable) 필드 type 검증 실패. structural 필드 키는 422가 아닌 409로 차단된다. */
+            /** @description Content-Type이 application/json이 아님 */
+            415: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description 비구조(mutable) 필드 type 검증 실패 또는 unknown 키. structural 필드 키는 422가 아닌 409로 차단된다. */
             422: {
                 headers: {
                     [name: string]: unknown;

--- a/src/ante/web/errors.py
+++ b/src/ante/web/errors.py
@@ -20,6 +20,7 @@ ERROR_CATALOG: dict[int, tuple[str, str]] = {
     403: ("/errors/forbidden", "Forbidden"),
     404: ("/errors/not-found", "Not Found"),
     409: ("/errors/conflict", "Conflict"),
+    415: ("/errors/unsupported-media-type", "Unsupported Media Type"),
     422: ("/errors/validation", "Validation Error"),
     500: ("/errors/internal", "Internal Server Error"),
     503: ("/errors/internal", "Service Unavailable"),

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import ValidationError
 
 from ante.web.deps import (
@@ -48,10 +49,68 @@ STRUCTURAL_FIELDS: tuple[str, ...] = (
     "trading_mode",
 )
 
+# PUT /api/accounts/{account_id} 비구조(런타임 mutable) 필드 화이트리스트.
+# 출처: docs/specs/account/10-web-api.md 16-22줄,
+#       docs/specs/account/04-account-service.md.
+# 런타임 PUT은 이 4개 필드만 변경할 수 있으며, 나머지는 STRUCTURAL_FIELDS로 분류되어
+# cold-path 409로 차단된다.
+MUTABLE_FIELDS: tuple[str, ...] = (
+    "name",
+    "timezone",
+    "trading_hours_start",
+    "trading_hours_end",
+)
+
 # 응답 detail prefix로 노출되는 cold-path 식별자.
 # 클라이언트는 이 prefix로 cold-path 응답과 다른 409 경로(예: 삭제된 계좌
 # 수정 시도)를 구분한다.
 STRUCTURAL_CHANGE_ERROR_CODE = "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER"
+
+
+# PUT /api/accounts/{account_id} 런타임 mutable 입력 contract.
+# 출처: docs/specs/account/10-web-api.md 16-22줄(런타임 차단 규칙 + mutable 필드).
+#
+# 런타임 PUT 핸들러는 raw body 파싱 → structural 가드(I1/I4) → Content-Type 415
+# 게이트 → mutable 검증 순서로 처리하지만(이슈 #1153), Swagger UI / agent client /
+# SDK는 정확한 mutable 입력 contract를 발견할 수 있어야 한다.
+#
+# ``AccountUpdateRequest.model_json_schema()`` 직접 노출 금지: 다른 소비자(테스트,
+# CLI) 호환을 위해 모든 필드가 ``str | None = None`` 옵션이고 structural 키도
+# 포함되어 있다. 본 dict 상수는 mutable 4 필드만 노출하며, ``required``는 schema
+# 안에 두지 않는다(빈 dict + ``{"name": null}`` 의 기존 400 no-op 의미를
+# 보존하기 위해; #1152 후속에서 422로 정렬). ``required: True``는
+# ``requestBody`` level에 둔다.
+ACCOUNT_MUTABLE_UPDATE_REQUEST_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "title": "AccountMutableUpdateRequest",
+    "description": (
+        "PUT /api/accounts/{account_id} 런타임 mutable 입력 contract. "
+        "런타임에는 비구조 필드만 변경할 수 있다. "
+        "structural 필드(credentials, broker_config, "
+        "buy_commission_rate, sell_commission_rate, broker_type, exchange, "
+        "currency, trading_mode)는 cold-path 409로 차단된다. "
+        "스키마 SSOT: docs/specs/account/10-web-api.md 16-22줄."
+    ),
+    "additionalProperties": False,
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "사용자에게 표시되는 이름.",
+        },
+        "timezone": {
+            "type": "string",
+            "description": "거래소 현지 시간대 (IANA).",
+        },
+        "trading_hours_start": {
+            "type": "string",
+            "description": "거래 시작 시각 (현지 시간, HH:MM).",
+        },
+        "trading_hours_end": {
+            "type": "string",
+            "description": "거래 종료 시각 (현지 시간, HH:MM).",
+        },
+    },
+}
 
 
 # POST /api/accounts cold-path 전용 OpenAPI request body 문서.
@@ -304,10 +363,14 @@ async def get_account(
                 "(런타임 구조 변경 차단) 또는 삭제된 계좌 수정 시도"
             ),
         },
+        415: {
+            "model": ErrorResponse,
+            "description": "Content-Type이 application/json이 아님",
+        },
         422: {
             "model": ErrorResponse,
             "description": (
-                "비구조(mutable) 필드 type 검증 실패. "
+                "비구조(mutable) 필드 type 검증 실패 또는 unknown 키. "
                 "structural 필드 키는 422가 아닌 409로 차단된다."
             ),
         },
@@ -316,11 +379,23 @@ async def get_account(
             "description": "Account service not available 또는 broker 재연결 실패",
         },
     },
+    openapi_extra={
+        "requestBody": {
+            # 빈 body 400 no-op 호환을 위해 schema-level required 강제 X.
+            # 단, requestBody-level은 True로 두어 codegen이 body를 optional로
+            # 만들지 않도록 한다(#1153 패턴 SSOT — POST 패턴 일치).
+            "required": True,
+            "content": {
+                "application/json": {
+                    "schema": ACCOUNT_MUTABLE_UPDATE_REQUEST_SCHEMA,
+                },
+            },
+        },
+    },
 )
 async def update_account(
     account_id: str,
     request: Request,
-    body: dict[str, Any] | None = Body(default=None),
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)] = None,
 ) -> dict[str, Any]:
     """계좌 수정.
@@ -331,18 +406,30 @@ async def update_account(
     ``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path
     응답과 ``AccountDeletedError`` 경로의 409를 구분한다.
 
-    body는 자유 ``dict[str, Any] | None``로 받는다. FastAPI 선행 Pydantic
-    검증이 켜지면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가
+    body는 raw bytes로 받는다(``request.body()``). FastAPI 선행 Pydantic
+    검증을 거치면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가
     structural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.
-    핸들러 본문에서는 raw payload key 검사로 cold-path 가드를 먼저 수행한 뒤,
-    structural을 제외한 비구조 페이로드만 ``AccountUpdateRequest``로
-    ``model_validate``하여 mutable 필드의 type 검증을 수행한다(``{"name":
-    null}`` / ``{"timezone": {}}`` 같은 잘못된 값이 service/DB까지 흘러가
-    상태를 오염시키는 것을 차단한다 — P1 회귀 보호). 검증 실패는 명시적으로
-    422로 변환한다.
 
-    PUT requestBody의 OpenAPI schema accuracy 회복(mutable 모델 노출)은 후속
-    이슈 #1143에서 다룬다.
+    핸들러 단계 순서(이슈 #1153 Implementation Plan):
+
+    1. raw bytes 읽기.
+    2. **빈 body**(``b""``) → ``payload = {}``로 두고 Content-Type 검사·JSON
+       파싱 모두 건너뛰고 mutable 단계까지 흘려보낸다(현재 400 no-op 의미 보존).
+    3. **JSON 파싱 실패**: Content-Type ≠ application/json → 415,
+       Content-Type 정상 → 422.
+    4. **non-dict JSON**: Content-Type ≠ application/json → 415,
+       Content-Type 정상 → 422.
+    5. **structural 가드(I4 우선)**: dict payload에 structural 키 존재 → 409
+       (Content-Type 무관, structural+text/plain도 409).
+    6. ``len(payload) == 0`` (``{}`` 명시 송신) → 400 no-op (Content-Type
+       검사 건너뜀; #1152 후속에서 422로 정렬).
+    7. **Content-Type 415 게이트**: ``application/json``(charset suffix 허용)
+       이외 → 415.
+    8. **unknown 키 / mutable type**: structural 제외한 raw dict의 unknown
+       키 → 422. ``AccountUpdateRequest.model_validate`` ValidationError → 422.
+    9. ``model_dump(exclude_none=True)`` 결과 비면 400 (예: ``{"name": null}``
+       단독 — 기존 의미 유지).
+    10. service 호출.
     """
     from ante.account.errors import (
         AccountDeletedError,
@@ -351,15 +438,55 @@ async def update_account(
         BrokerReconnectFailedError,
     )
 
-    # body는 dict로 직접 받으므로 별도 raw bytes 파싱이 필요 없다.
-    # FastAPI는 JSON 파싱 실패 / non-dict body를 자동 422로 처리한다.
-    payload = body or {}
+    # 1. raw body 읽기.
+    raw = await request.body()
 
-    # cold-path 가드: structural 필드 키가 payload에 하나라도 등장하면
-    # DB/서비스 호출 전 409로 즉시 차단한다(invariant I1/I4). 값이 null이거나
-    # 타입이 잘못돼도 동일하게 차단된다 — Pydantic 검증을 통과한 값이 아니라
-    # 키 존재 여부만 본다. 따라서 structural mutable 검증보다 *먼저* 수행해야
-    # mutable 422가 cold-path 409를 가리지 않는다.
+    # Content-Type media type 추출(charset suffix 허용 — `;` 앞부분 lowercase
+    # 매칭으로 `application/json; charset=utf-8` 같은 정상 변형을 통과시킨다).
+    content_type_header = request.headers.get("content-type", "") or ""
+    media_type = content_type_header.split(";", 1)[0].strip().lower()
+    is_json_media = media_type == "application/json"
+
+    # 2. 빈 body — Content-Type 검사·JSON 파싱 건너뛰고 payload = {} 로 두어
+    # 단계 6의 400 no-op 분기로 떨어지게 한다(기존 의미 보존).
+    if raw == b"":
+        payload: Any = {}
+    else:
+        # 3. JSON 파싱.
+        try:
+            payload = json.loads(raw)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            # Content-Type 자체가 잘못된 경우 415가 더 정보량이 크므로 우선.
+            if not is_json_media:
+                raise HTTPException(
+                    status_code=415,
+                    detail=(
+                        "Content-Type은 application/json이어야 합니다. "
+                        f"받은 값: {content_type_header!r}"
+                    ),
+                ) from None
+            raise HTTPException(
+                status_code=422,
+                detail="요청 body의 JSON 파싱에 실패했습니다.",
+            ) from None
+
+        # 4. non-dict JSON(예: [], "x", 123): Content-Type 분기.
+        if not isinstance(payload, dict):
+            if not is_json_media:
+                raise HTTPException(
+                    status_code=415,
+                    detail=(
+                        "Content-Type은 application/json이어야 합니다. "
+                        f"받은 값: {content_type_header!r}"
+                    ),
+                )
+            raise HTTPException(
+                status_code=422,
+                detail="요청 body는 JSON object여야 합니다.",
+            )
+
+    # 5. structural 가드(I4 우선): structural 키가 등장하면 Content-Type과
+    # 무관하게 409로 차단(structural+text/plain도 409).
     structural_hits = sorted(set(payload) & set(STRUCTURAL_FIELDS))
     if structural_hits:
         raise HTTPException(
@@ -369,22 +496,39 @@ async def update_account(
             ),
         )
 
-    # 비구조 필드만 모은다. structural 키는 위 가드에서 이미 차단되었으므로
-    # 여기에는 들어오지 않는다. mutable 필드만 들어온 raw dict를 기존
-    # ``AccountUpdateRequest``로 model_validate하여 type 검증한다(새 모델
-    # 추가 없음 — 메타 리뷰 #2 결정 보존). structural 필드는 input에 없으므로
-    # None default로 통과되고, mutable 필드의 잘못된 값(예: null, dict 등)은
-    # ValidationError로 거부된다.
+    # 6. ``len(payload) == 0`` (``{}`` 명시 송신 또는 빈 body): Content-Type
+    # 검사 건너뛰고 400 no-op로 즉시 떨어뜨려 기존 의미 보존(#1152 후속에서
+    # 422로 정렬).
+    if len(payload) == 0:
+        raise HTTPException(status_code=400, detail="수정할 필드가 없습니다.")
+
+    # 7. Content-Type 415 게이트: 비-application/json은 415.
+    if not is_json_media:
+        raise HTTPException(
+            status_code=415,
+            detail=(
+                "Content-Type은 application/json이어야 합니다. "
+                f"받은 값: {content_type_header!r}"
+            ),
+        )
+
+    # 8. unknown 키 / mutable type 검증.
     mutable_payload_in = {
         k: v for k, v in payload.items() if k not in STRUCTURAL_FIELDS
     }
+    unknown_keys = sorted(set(mutable_payload_in) - set(MUTABLE_FIELDS))
+    if unknown_keys:
+        raise HTTPException(
+            status_code=422,
+            detail=(f"알 수 없는 필드가 포함되었습니다: {', '.join(unknown_keys)}"),
+        )
 
     try:
         validated = AccountUpdateRequest.model_validate(mutable_payload_in)
     except ValidationError as e:
-        raise HTTPException(status_code=422, detail=e.errors())
+        raise HTTPException(status_code=422, detail=e.errors()) from None
 
-    # ``exclude_none=True``로 set된 mutable 필드만 추출한다. ``{"name": null}``
+    # 9. ``exclude_none=True``로 set된 mutable 필드만 추출. ``{"name": null}``
     # 같이 명시적으로 null이 들어온 경우 model_dump에서 빠지므로 service까지
     # null이 흘러가지 않는다(P1: DB 오염 차단).
     fields = validated.model_dump(exclude_none=True)

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -757,18 +757,17 @@ class TestUpdateAccount:
         account_service: FakeAccountService,
         audit_logger: FakeAuditLogger,
     ) -> None:
-        """알 수 없는 비구조 필드는 라우트의 mutable 검증 단계에서 무시된다.
+        """알 수 없는 비구조 필드는 라우트가 명시적으로 422로 reject한다(이슈 #1153).
 
-        attempt 9는 P1 회귀 보호로 비구조 페이로드를
-        ``AccountUpdateRequest.model_validate``에 통과시킨다. Pydantic의
-        기본 동작은 unknown field를 ignore하므로, ``some_unknown_field``는
-        ``model_dump(exclude_none=True)`` 결과에서 사라진다 → 라우트는
-        ``fields``가 비었다고 판단해 400 "수정할 필드가 없습니다."로 응답한다.
+        이슈 #1153은 PUT 핸들러를 raw body 파싱 + structural 가드(I1/I4) +
+        Content-Type 415 게이트 + mutable 검증 순서로 재구성하면서, unknown
+        키에 대해 ``mutable_payload_in`` 단계에서 ``MUTABLE_FIELDS`` 화이트
+        리스트와 비교하여 422 "알 수 없는 필드가 포함되었습니다"로 명시적
+        reject한다. 그 결과 codegen이 ``additionalProperties: False``로 표현
+        한 contract와 런타임 응답이 1:1 정합한다.
 
-        결과적으로 service.update는 호출되지 않으며, unknown field가 DB에
-        도달할 가능성이 차단된다. unknown field에 대한 schema-accurate 422
-        매핑(라우트가 명시적으로 reject)은 #1143에서 mutable 모델을 직접
-        노출할 때 함께 정리한다.
+        service.update는 호출되지 않으며, unknown field가 DB에 도달할 가능성
+        도 차단된다.
 
         service-layer 회귀 보호처(별도 invariant):
         ``tests/unit/test_account_immutable_fields.py``의
@@ -781,11 +780,10 @@ class TestUpdateAccount:
             "/api/accounts/test-account",
             json={"some_unknown_field": "x"},
         )
-        # 라우트 단 400 — unknown field가 Pydantic에서 무시되어 fields가 비었다.
-        assert resp.status_code == 400
+        # 라우트 단 422 — unknown field가 명시적으로 reject된다.
+        assert resp.status_code == 422
         body = resp.json()
-        assert body.get("status") == 400
-        assert body.get("detail") == "수정할 필드가 없습니다."
+        assert "some_unknown_field" in body.get("detail", "")
         # service.update 미호출 — DB 오염 차단.
         assert account_service._accounts["test-account"].name == "테스트 계좌"
         # audit 미발행
@@ -983,9 +981,361 @@ class TestUpdateAccount:
         assert resp.status_code == 503
         assert resp.json()["detail"] == "Account service not available"
 
+    # ── 이슈 #1153: PUT request body schema accuracy + Content-Type 415 게이트 ──
+    #
+    # 핸들러 단계 순서(이슈 #1153 Implementation Plan)와 1:1 매핑되는 19개
+    # 시나리오. structural 가드(I1/I4)는 어떤 Content-Type/payload 형태에서도
+    # 우선 적용되며, Content-Type 415 게이트는 dict payload + 비어 있지 않은
+    # mutable payload + non-structural 키만 들어온 경로에서 활성화된다.
+    #
+    # 호환성 보존(이슈 #1153 제약): 빈 body / `{}` / `{"name": null}` 의미는
+    # 기존 400 no-op 유지(#1152 후속에서 422로 정렬).
 
-# PUT requestBody schema accuracy(mutable 모델 노출)는 issue #1143에서 처리.
-# 본 이슈는 cold-path invariant(I1~I4)와 P2(ValidationError 422)에 한정한다.
+    # ── structural priority (단계 5: I4 우선) ─────────────────────
+
+    def test_update_structural_without_content_type_returns_409(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """structural body + Content-Type 부재 → 409 (cold-path 우선)."""
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            content=b'{"credentials": {"app_key": "x"}}',
+            # Content-Type 헤더 없음 — TestClient는 명시 미설정 시 보내지 않음
+        )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "credentials" in detail
+
+    def test_update_structural_with_text_plain_returns_409(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """structural body + Content-Type: text/plain → 409.
+
+        invariant: structural 가드는 Content-Type 415 게이트보다 *먼저*
+        실행되어야 한다(I4 우선). 같은 payload가 415로 새면 cold-path 가드가
+        Content-Type 검증에 의해 우회되는 회귀다.
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            content=b'{"credentials": {"app_key": "x"}}',
+            headers={"Content-Type": "text/plain"},
+        )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "credentials" in detail
+
+    def test_update_structural_null_value_returns_409_via_raw_key(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """structural raw key + null value(예: `{"credentials": null}`) → 409.
+
+        invariant I4 회귀 유지(#1140): 가드는 Pydantic 검증된 ``is not None``
+        값이 아니라 raw body의 키 존재 여부로 판정한다. 이 시나리오는 #1140
+        에서 도입된 raw key 가드가 신규 raw body 파싱 흐름에서도 보존되는지
+        확인한다.
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"credentials": None},
+        )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "credentials" in detail
+
+    # ── 빈 body / `{}` / `{"name": null}` no-op 호환 ─────────────
+
+    def test_update_empty_body_without_content_type_returns_400(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """빈 body(b"") + Content-Type 부재 → 400 no-op (단계 2).
+
+        호환성 보존: 클라이언트가 빈 body로 PUT을 보내면 기존과 동일하게
+        400 "수정할 필드가 없습니다."를 받는다. Content-Type 검사·JSON 파싱을
+        모두 건너뛰고 mutable 단계로 흐른 뒤 ``len(payload) == 0``로 떨어진다.
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            content=b"",
+        )
+        assert resp.status_code == 400
+        assert resp.json().get("detail") == "수정할 필드가 없습니다."
+
+    def test_update_empty_object_with_json_content_type_returns_400(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """`{}` + Content-Type: application/json → 400 no-op (단계 6)."""
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put("/api/accounts/test-account", json={})
+        assert resp.status_code == 400
+        assert resp.json().get("detail") == "수정할 필드가 없습니다."
+
+    def test_update_empty_object_with_text_plain_returns_400(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """`{}` + Content-Type: text/plain → 400 no-op (단계 6).
+
+        명시적 빈 dict는 Content-Type과 무관하게 기존 400 no-op 의미를 보존
+        한다(단계 6이 단계 7 Content-Type 게이트보다 앞).
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            content=b"{}",
+            headers={"Content-Type": "text/plain"},
+        )
+        assert resp.status_code == 400
+        assert resp.json().get("detail") == "수정할 필드가 없습니다."
+
+    def test_update_name_null_with_json_content_type_returns_400(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """`{"name": null}` + Content-Type: application/json → 400 (단계 9).
+
+        ``model_dump(exclude_none=True)``가 결과를 비워 mutable 검증 후
+        400으로 떨어진다(P1 회귀 보호 유지).
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"name": None},
+        )
+        assert resp.status_code == 400
+        assert resp.json().get("detail") == "수정할 필드가 없습니다."
+
+    def test_update_name_null_with_text_plain_returns_415(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """`{"name": null}` + Content-Type: text/plain → 415 (단계 7 게이트 우선).
+
+        ``len(payload) > 0`` 분기에서는 Content-Type 415 게이트가 활성화된다.
+        호환성 보존 범위는 application/json 또는 빈 body에 한정되며, 비-JSON
+        Content-Type은 Content-Type 자체 위반으로 415가 선행한다.
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            content=b'{"name": null}',
+            headers={"Content-Type": "text/plain"},
+        )
+        assert resp.status_code == 415
+
+    # ── mutable + Content-Type 415 게이트 (단계 7) ────────────────
+
+    def test_update_missing_content_type_with_mutable_returns_415(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """Content-Type 부재 + mutable body → 415."""
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            content=b'{"name": "x"}',
+        )
+        assert resp.status_code == 415
+
+    def test_update_text_plain_with_mutable_returns_415(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """Content-Type: text/plain + mutable body → 415."""
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            content=b'{"name": "x"}',
+            headers={"Content-Type": "text/plain"},
+        )
+        assert resp.status_code == 415
+
+    def test_update_charset_suffix_passes(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """Content-Type: application/json; charset=utf-8 → 200 통과 (단계 7).
+
+        media type 비교는 `;` 앞부분 lowercase 매칭이므로 charset suffix는
+        정상 통과해야 한다(브라우저/axios 기본 변형 호환).
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            content=b'{"name": "charset suffix"}',
+            headers={"Content-Type": "application/json; charset=utf-8"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["account"]["name"] == "charset suffix"
+
+    # ── parse 실패 (단계 3) ──────────────────────────────────
+
+    def test_update_non_utf8_bytes_with_json_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """non-UTF-8 bytes + Content-Type: application/json → 422 (parse 실패)."""
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            content=b"\xff\xfe\xfd",  # invalid UTF-8
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 422
+
+    def test_update_non_utf8_bytes_with_text_plain_returns_415(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """non-UTF-8 bytes + Content-Type: text/plain → 415.
+
+        parse 실패 + 비-application/json Content-Type → 415 (Content-Type
+        자체가 더 정보량 있는 위반).
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            content=b"\xff\xfe\xfd",
+            headers={"Content-Type": "text/plain"},
+        )
+        assert resp.status_code == 415
+
+    def test_update_invalid_json_with_json_content_type_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """invalid JSON + Content-Type: application/json → 422 (parse 실패)."""
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            content=b"not-valid-json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 422
+
+    def test_update_invalid_json_with_text_plain_returns_415(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """invalid JSON + Content-Type: text/plain → 415."""
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            content=b"not-valid-json",
+            headers={"Content-Type": "text/plain"},
+        )
+        assert resp.status_code == 415
+
+    # ── non-dict JSON (단계 4) ────────────────────────────
+
+    def test_update_array_json_with_json_content_type_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """non-dict JSON(`[]`) + Content-Type: application/json → 422."""
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json=["array", "not", "object"],
+        )
+        assert resp.status_code == 422
+
+    def test_update_array_json_with_text_plain_returns_415(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """non-dict JSON + Content-Type: text/plain → 415."""
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            content=b'["array"]',
+            headers={"Content-Type": "text/plain"},
+        )
+        assert resp.status_code == 415
+
+    # ── unknown 키 + mutable type (단계 8) ───────────────
+
+    def test_update_unknown_mutable_key_with_json_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """unknown mutable key(`{"foo": "bar"}`) → 422 (additionalProperties: False)."""
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"foo": "bar"},
+        )
+        assert resp.status_code == 422
+        assert "foo" in resp.json().get("detail", "")
+
+
+# PUT requestBody schema accuracy(mutable 모델 노출)는 issue #1153에서 처리됨.
 
 
 class TestSuspendAccount:

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -530,10 +530,28 @@ class TestRFC7807ErrorResponse:
             "/errors/unauthorized",
             "/errors/forbidden",
             "/errors/conflict",
+            "/errors/unsupported-media-type",
             "/errors/internal",
         }
         actual_types = {t for t, _ in ERROR_CATALOG.values()}
         assert required_types == actual_types
+
+    def test_error_catalog_has_415_entry(self):
+        """ERROR_CATALOG 415 entry는 RFC 7807 패턴(이슈 #1153).
+
+        PUT /api/accounts/{account_id}의 Content-Type 게이트가 415를 raise할
+        때 fallback ``("/errors/internal", "Error")``로 떨어지지 않도록 415
+        entry를 명시 등록한다.
+        """
+        from ante.web.errors import ERROR_CATALOG
+
+        assert 415 in ERROR_CATALOG, (
+            "ERROR_CATALOG에 415 entry가 없으면 415 HTTPException이 fallback "
+            "type/title로 직렬화된다."
+        )
+        type_uri, title = ERROR_CATALOG[415]
+        assert type_uri == "/errors/unsupported-media-type"
+        assert title == "Unsupported Media Type"
 
     def test_value_error_returns_400(self, app, client):
         from fastapi import APIRouter
@@ -1242,3 +1260,198 @@ class TestGeneratedTsPostAccountRequestBody:
             "Record<string, unknown>" in field_block
             or "[key: string]: unknown" in field_block
         ), f"broker_config가 open-map 형태로 노출되지 않음:\n{field_block}"
+
+
+# ── 이슈 #1153: PUT request body schema accuracy + Content-Type 415 게이트 ─
+
+
+class TestPutAccountRequestBodySchema:
+    """PUT /api/accounts/{account_id} requestBody OpenAPI schema 노출(이슈 #1153).
+
+    런타임 핸들러는 raw body 파싱 + structural 가드(I1/I4) + Content-Type 415
+    게이트 + mutable 검증 순서로 처리한다. OpenAPI/codegen 클라이언트는 정확한
+    mutable 입력 contract(name/timezone/trading_hours_start/trading_hours_end,
+    additionalProperties: False, nullable 없음)를 발견할 수 있어야 한다.
+
+    ``AccountUpdateRequest.model_json_schema()`` 직접 노출은 금지(다른 소비자
+    호환을 위해 모든 필드가 ``str | None`` 옵션이고 structural 키도 포함).
+    spec-aligned dict 상수 ``ACCOUNT_MUTABLE_UPDATE_REQUEST_SCHEMA``로 별도
+    정의해 노출한다.
+    """
+
+    @staticmethod
+    def _put_request_body(client: TestClient) -> dict:
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        openapi = resp.json()
+        spec = (
+            openapi.get("paths", {})
+            .get("/api/accounts/{account_id}", {})
+            .get("put", {})
+        )
+        request_body = spec.get("requestBody")
+        assert request_body is not None, (
+            "PUT /api/accounts/{account_id} requestBody가 OpenAPI에 노출되지 않음"
+        )
+        return request_body
+
+    @staticmethod
+    def _put_request_schema(client: TestClient) -> dict:
+        request_body = TestPutAccountRequestBodySchema._put_request_body(client)
+        json_content = request_body.get("content", {}).get("application/json")
+        assert json_content is not None, (
+            "PUT /api/accounts/{account_id} requestBody에 application/json content 없음"
+        )
+        schema = json_content.get("schema")
+        assert isinstance(schema, dict), (
+            "PUT /api/accounts/{account_id} requestBody schema가 dict가 아님"
+        )
+        return schema
+
+    def test_openapi_put_account_request_body_is_strict_mutable_schema(self, client):
+        """PUT requestBody가 mutable 4 필드 strict schema."""
+        schema = self._put_request_schema(client)
+
+        assert schema.get("type") == "object", schema
+        # additionalProperties: False — 알 수 없는 키 차단을 contract에 표현
+        ap = schema.get("additionalProperties")
+        assert ap is False, f"additionalProperties가 False가 아님: {ap!r}"
+
+        properties = schema.get("properties", {})
+        expected = {
+            "name",
+            "timezone",
+            "trading_hours_start",
+            "trading_hours_end",
+        }
+        actual = set(properties.keys())
+        assert actual == expected, (
+            f"mutable 필드가 정확히 4개여야 함. expected={expected}, actual={actual}"
+        )
+
+        # 각 property는 단일 type=string, nullable이 아님.
+        for name, prop in properties.items():
+            assert isinstance(prop, dict), f"properties.{name}가 dict가 아님: {prop!r}"
+            assert prop.get("type") == "string", (
+                f"properties.{name}.type이 'string'이 아님: {prop!r}"
+            )
+            assert "nullable" not in prop or prop.get("nullable") is not True, (
+                f"properties.{name}에 nullable: True가 노출됨"
+            )
+            for combinator in ("anyOf", "oneOf"):
+                variants = prop.get(combinator)
+                if variants:
+                    for variant in variants:
+                        assert variant.get("type") != "null", (
+                            f"properties.{name}.{combinator}에 null type 포함"
+                        )
+
+    def test_openapi_put_account_request_body_not_anyof_null(self, client):
+        """PUT requestBody schema 자체가 nullable(anyOf null)이 아님."""
+        schema = self._put_request_schema(client)
+
+        # schema-level anyOf/oneOf에 null type 변형이 없어야 함
+        for combinator in ("anyOf", "oneOf"):
+            variants = schema.get(combinator)
+            if variants:
+                for variant in variants:
+                    assert variant.get("type") != "null", (
+                        f"requestBody schema {combinator}에 null type 포함: {schema!r}"
+                    )
+
+    def test_openapi_put_account_request_body_required_true(self, client):
+        """codegen이 body를 optional로 만들지 않도록 requestBody.required: True."""
+        request_body = self._put_request_body(client)
+        assert request_body.get("required") is True, (
+            f"requestBody.required가 True가 아님: {request_body.get('required')!r}"
+        )
+
+    def test_openapi_put_account_415_references_error_response(self, client):
+        """PUT 415 응답이 ErrorResponse를 가리킨다."""
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        openapi = resp.json()
+        spec = (
+            openapi.get("paths", {})
+            .get("/api/accounts/{account_id}", {})
+            .get("put", {})
+        )
+        responses = spec.get("responses", {})
+        response_415 = responses.get("415")
+        assert response_415 is not None, "PUT 415 응답이 명시 등록되지 않음"
+        json_content = response_415.get("content", {}).get("application/json")
+        assert json_content is not None, "PUT 415에 application/json content 없음"
+        ref = json_content.get("schema", {}).get("$ref", "")
+        assert "ErrorResponse" in ref, (
+            f"PUT 415가 ErrorResponse를 가리키지 않음 (schema ref={ref!r})"
+        )
+
+
+class TestGeneratedTsPutAccountRequestBody:
+    """generated TS api.generated.ts에서 PUT /api/accounts/{account_id} request
+    body가 spec-aligned 형태로 노출되는지 보조 단언(이슈 #1153).
+
+    같은 PR에 ``frontend/src/types/api.generated.ts``가 함께 갱신되어야 하므로
+    generated artifact drift를 차단한다.
+    """
+
+    @staticmethod
+    def _generated_ts_text() -> str:
+        path = (
+            Path(__file__).resolve().parents[2]
+            / "frontend"
+            / "src"
+            / "types"
+            / "api.generated.ts"
+        )
+        assert path.exists(), f"generated TS 파일이 존재하지 않음: {path}"
+        return path.read_text(encoding="utf-8")
+
+    @staticmethod
+    def _put_account_operation_block(text: str) -> str:
+        """update_account_api_accounts__account_id__put operation 블록을 잘라낸다."""
+        marker = "update_account_api_accounts__account_id__put:"
+        idx = text.find(marker)
+        assert idx != -1, "generated TS에 update_account operation이 없음"
+        rest = text[idx:]
+        next_markers = [
+            "delete_account_api_accounts__account_id__delete:",
+            "suspend_account_api_accounts__account_id__suspend_post:",
+            "activate_account_api_accounts__account_id__activate_post:",
+            "get_account_rules_api_accounts__account_id__rules_get:",
+        ]
+        end_offsets = [rest.find(m, 1) for m in next_markers]
+        end_offsets = [o for o in end_offsets if o != -1]
+        end = min(end_offsets) if end_offsets else len(rest)
+        return rest[:end]
+
+    def test_generated_ts_put_account_request_body_not_unknown_or_null(self):
+        """PUT body가 `{ [key: string]: unknown } | null` 패턴이 아니어야 한다."""
+        block = self._put_account_operation_block(self._generated_ts_text())
+        # 회귀 패턴: anyOf null 노출이 sanitize되지 않은 경우 ` | null` 또는
+        # `[key: string]: unknown` 단독 패턴이 등장.
+        assert " | null" not in block, (
+            "PUT body가 nullable로 노출됨(`| null` 회귀):\n" + block
+        )
+        # body가 unknown record로 좁혀지면 안 된다(spec-aligned mutable 4 필드).
+        assert "[key: string]: unknown" not in block, (
+            "PUT body가 unknown record로 좁혀짐:\n" + block
+        )
+
+    def test_generated_ts_put_account_request_body_required_not_optional(self):
+        """PUT body가 optional 표시(?:)가 아닌 required."""
+        block = self._put_account_operation_block(self._generated_ts_text())
+        assert "requestBody?:" not in block, "PUT body가 optional로 노출됨:\n" + block
+        assert "requestBody:" in block, "PUT에 requestBody: 정의가 없음:\n" + block
+
+    def test_generated_ts_put_account_mutable_fields_not_nullable(self):
+        """mutable 필드 4개가 `string | null`이 아니라 `string`."""
+        block = self._put_account_operation_block(self._generated_ts_text())
+        for field in ("name", "timezone", "trading_hours_start", "trading_hours_end"):
+            # `field?: string;` 또는 `field: string;` 패턴 검출. nullable 부재 단언.
+            assert f"{field}?: string | null" not in block, (
+                f"PUT body의 {field}이 nullable로 노출됨:\n" + block
+            )
+            assert f"{field}: string | null" not in block, (
+                f"PUT body의 {field}이 nullable로 노출됨:\n" + block
+            )


### PR DESCRIPTION
Closes #1153

## Summary
- PUT `/api/accounts/{account_id}` 핸들러를 raw `request.body()` + 수동 JSON 파싱 패턴으로 전환 (FastAPI 자동 422 회피, #1140 invariant I1/I4 보존).
- 핸들러 단계 순서 (이슈 본문 1~10단계):
  1. raw bytes
  2. 빈 body → 400 no-op
  3. JSON 파싱 실패 → Content-Type 분기 (415 또는 422)
  4. non-dict JSON → Content-Type 분기 (415 또는 422)
  5. structural 가드 (I4 우선, Content-Type 무관) → 409
  6. `{}` 명시 송신 → 400 no-op
  7. Content-Type 415 게이트 (`application/json` 외 → 415)
  8. unknown 키 / mutable type → 422
  9. 빈 fields → 400
  10. service 호출
- `ACCOUNT_MUTABLE_UPDATE_REQUEST_SCHEMA` dict 상수 신설 (4 mutable 필드 `name/timezone/trading_hours_start/trading_hours_end`, `additionalProperties: False`, nullable 없음, `required` 미포함).
- `MUTABLE_FIELDS` 모듈 상수 신설.
- PUT 데코레이터에 `openapi_extra` + `requestBody` schema 노출.
- ERROR_CATALOG 415 entry 추가 (`/errors/unsupported-media-type`, "Unsupported Media Type").
- `frontend/openapi.json` + `frontend/src/types/api.generated.ts` 재생성.
- spec 갱신 (`docs/specs/account/10-web-api.md`, `docs/specs/web-api/05-resource-endpoints.md`).

## Plan/Review history
- Plan Preflight v1~v4: Codex Plan Review 3회 revise → attempt 4 `approve-implement` (2026-04-27).
- Codex 브랜치 리뷰 attempt 1: PASS × 2 (병렬 review). "변경된 PUT 계좌 수정 경로의 raw body 파싱, Content-Type 415 게이트, OpenAPI/TS 생성물 갱신이 의도한 동작과 일치", "명확한 런타임 회귀나 계약 위반으로 볼 만한 문제를 찾지 못함".

## Risk Flags (이슈 본문 명시)
- `contract-drift` — PUT 핸들러 시그니처 변경(`body: dict | None` 제거 → `request: Request`만), 4xx/5xx 응답 의미 추가(415 신설). 런타임 invariant I1/I4 보존.
- `generated-artifact-sync` — `frontend/openapi.json`/`api.generated.ts` 같은 PR 재생성.
- `multi-consumer` — codegen 클라이언트 (frontend + 향후 agent SDK)가 PUT request body schema를 정확히 인지.

## Test Plan
- TDD 회귀 가드 검증:
  - 단계 5 (structural 우선) 임시 제거 → 4 RED (`test_update_credentials_blocked_409` 외) → 원복 후 PASS.
  - 단계 7 (Content-Type 415 게이트) 임시 제거 → 3 RED (`test_update_missing_content_type_with_mutable_returns_415` 외) → 원복 후 PASS.
- `pytest tests/unit/test_account_api.py tests/unit/test_account.py tests/unit/test_account_immutable_fields.py tests/unit/test_account_delete_events.py tests/unit/test_web_api.py` → **198 passed**
- 전체 unit 회귀: `pytest tests/unit/ -x` → **3342 passed, 2 skipped**
- `ruff check src/ante tests/` → All checks passed
- `ruff format --check src/ante tests/` → 419 files already formatted
- `python -c "from ante.web.app import create_app; create_app().openapi()"` → OpenAPI build OK
- `npm --prefix frontend ci && npm --prefix frontend run generate-types` → success
- `npm --prefix frontend run build` → 480 modules transformed
- C5 freshness: stage → 재추출 → `git diff --exit-code -- frontend/openapi.json frontend/src/types/api.generated.ts` → empty diff

## Acceptance (이슈 본문 완료 조건)
- [x] PUT 핸들러 raw body 전환 (FastAPI 자동 422 회피, invariant I1/I4 보존)
- [x] structural 가드 우선 (Content-Type 무관 409)
- [x] Content-Type 415 게이트 (`application/json` 외 415)
- [x] non-dict JSON / 파싱 실패 분기 일관 (Content-Type 무관 시 415, 정상 시 422)
- [x] mutable fields schema 노출 (4 필드, nullable 없음)
- [x] ERROR_CATALOG 415 entry
- [x] OpenAPI 재추출 + frontend codegen 재생성
- [x] spec 갱신 + 회귀 테스트