### PR TITLE
fix(config,cli,main): resolve db.path through Config.resolve_path to close cold-path split-brain (#1158)

### DIFF
--- a/src/ante/cli/main.py
+++ b/src/ante/cli/main.py
@@ -142,28 +142,30 @@ def get_config_dir(ctx: click.Context | None = None) -> Path:
 
 
 def get_db_path(ctx: click.Context | None = None) -> str:
-    """`--config-dir`/`ANTE_CONFIG_DIR` 기반으로 DB 경로를 반환한다.
+    """server runtime과 동일한 resolver로 DB 경로를 반환한다.
 
-    우선순위는 `resolve_config_dir()`를 그대로 따른다:
-      1. `ctx.obj["config_dir"]` (루트 그룹이 `--config-dir` 또는
-         `ANTE_CONFIG_DIR` 환경변수로부터 확정한 Path) — override로 전달
-      2. `ANTE_CONFIG_DIR` 환경변수
-      3. `~/.config/ante/` (디렉토리가 실제로 존재할 때)
-      4. `./config/` (repo-local 폴백)
+    Spec: docs/specs/cli/02-design-decisions.md:62-70 — `system.toml`의
+    `db.path`를 우선 읽고, 미설정 시 `<config_dir>/db/ante.db` 기본값으로
+    폴백한다. 절대 경로면 그대로, 상대 경로면 `config_dir` 기준으로 정규화
+    한다 (`Config.resolve_path`).
 
     이 함수가 필요한 이유: `ante init`은 `<config_dir>/db/ante.db`를 생성하지만
-    후속 CLI들은 과거 `Database("db/ante.db")`를 CWD 기준으로 하드코딩해 다른
-    DB를 바라보는 문제가 있었다. 모든 CLI는 이 헬퍼를 통해 동일한 DB 경로를
-    사용해야 한다.
+    후속 CLI들이 과거 `Database("db/ante.db")` 처럼 CWD 기준으로 하드코딩하면
+    server runtime과 다른 DB를 바라보는 split-brain이 발생한다. cold-path
+    CLI(`account create/delete/set-credentials`)와 server runtime은 모두
+    이 헬퍼/`Config.resolve_path`를 통해 동일한 DB 경로를 본다.
 
     Args:
         ctx: 선택적 Click 컨텍스트. 전달되지 않으면
             `click.get_current_context(silent=True)`로 현재 컨텍스트를 조회한다.
 
     Returns:
-        `<config_dir>/db/ante.db` 형태의 경로 문자열.
+        절대 경로 문자열. 상대 `db.path` 입력은 `config_dir` 기준 절대 경로로
+        정규화된다.
     """
-    return str(get_config_dir(ctx) / "db" / "ante.db")
+    cfg_dir = get_config_dir(ctx)
+    cfg = Config.load(config_dir=cfg_dir)
+    return str(cfg.resolve_path("db.path", "db/ante.db"))
 
 
 def get_data_path(ctx: click.Context | None = None) -> str:

--- a/src/ante/config/config.py
+++ b/src/ante/config/config.py
@@ -89,20 +89,28 @@ class Config:
     동적 설정은 DynamicConfigService가 별도 담당.
     """
 
-    def __init__(self, static: dict[str, Any], secrets: dict[str, str]) -> None:
+    def __init__(
+        self,
+        static: dict[str, Any],
+        secrets: dict[str, str],
+        config_dir: Path | None = None,
+    ) -> None:
         self._static = static
         self._secrets = secrets
+        self._config_dir = config_dir
 
     @classmethod
     def load(cls, config_dir: Path | None = None) -> Config:
         """설정 파일 로드 및 Config 인스턴스 생성.
 
         config_dir이 None이면 resolve_config_dir()로 자동 탐색.
+        해석된 디렉토리는 인스턴스에 보존되어 path-like 설정의
+        ``resolve_path()`` 정규화 기준으로 사용된다.
         """
         resolved = resolve_config_dir(config_dir)
         static = _load_toml(resolved / "system.toml")
         secrets = _load_dotenv(resolved / "secrets.env")
-        return cls(static=static, secrets=secrets)
+        return cls(static=static, secrets=secrets, config_dir=resolved)
 
     def get(self, key: str, default: Any = None) -> Any:
         """정적 설정 조회. 점(.) 구분자로 중첩 접근.
@@ -116,6 +124,33 @@ class Config:
         if key in DEFAULTS:
             return DEFAULTS[key]
         return default
+
+    def resolve_path(self, key: str, default: str | None = None) -> Path:
+        """path-like 정적 설정을 ``config_dir`` 기준의 절대 경로로 정규화한다.
+
+        Spec: docs/specs/config/03-design-decisions.md `Ante instance/path contract`.
+        절대 경로로 설정된 값은 그대로, 상대 경로는 ``config_dir`` 기준으로 결합한다.
+        ``Config.load()``로 만든 인스턴스는 자동으로 ``config_dir``을 기억하므로
+        호출 시점 CWD와 무관하게 server runtime과 CLI가 같은 경로를 본다.
+
+        직접 ``Config(...)`` 로 만들었거나 ``config_dir``이 ``None``이면
+        ``Path.cwd()``를 폴백으로 사용한다.
+
+        Args:
+            key: 점(.) 구분자로 표현되는 path-like 정적 설정 키 (예: ``"db.path"``).
+            default: ``key``가 TOML/DEFAULTS 어디에도 없을 때 사용할 fallback 문자열.
+
+        Raises:
+            ConfigError: 키 값을 찾을 수 없고 ``default``도 ``None``인 경우.
+        """
+        raw = self.get(key, default)
+        if raw is None:
+            raise ConfigError(f"Path config missing: {key}")
+        p = Path(str(raw))
+        if p.is_absolute():
+            return p
+        base = self._config_dir if self._config_dir is not None else Path.cwd()
+        return base / p
 
     def secret(self, key: str) -> str:
         """비밀값 조회. 환경변수 우선, 없으면 .env에서.

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -120,7 +120,11 @@ async def _init_core(s: Services) -> None:
     logger.info("Ante 시작")
 
     # Database
-    db_path = s.config.get("db.path", "db/ante.db")
+    # `db.path` 는 cold-path CLI(`account create/delete/set-credentials`) 와
+    # 동일한 resolver 를 거쳐야 한다 — 절대 경로면 그대로, 상대 경로면
+    # `config_dir` 기준으로 정규화. 이로써 server runtime 과 CLI 가 같은
+    # DB 를 본다 (Refs #1158).
+    db_path = str(s.config.resolve_path("db.path", "db/ante.db"))
     Path(db_path).parent.mkdir(parents=True, exist_ok=True)
     s.db = Database(db_path)
     await s.db.connect()

--- a/tests/unit/test_cli_main_db_path.py
+++ b/tests/unit/test_cli_main_db_path.py
@@ -161,6 +161,106 @@ def test_get_db_path_env_used_when_ctx_has_no_override(
 
 
 # ---------------------------------------------------------------------------
+# get_db_path × system.toml `db.path` (Refs #1158)
+#
+# Spec: docs/specs/cli/02-design-decisions.md:62-70.
+# `get_db_path` 는 server runtime과 동일한 resolver(`Config.resolve_path`)
+# 를 통해 `db.path` 를 해석해야 한다. 이로써 cold-path CLI(account create
+# /delete/set-credentials)가 보는 DB와 server runtime이 보는 DB가 항상
+# 일치하여 split-brain이 발생하지 않는다.
+# ---------------------------------------------------------------------------
+
+
+def test_get_db_path_reads_relative_db_path_from_system_toml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """system.toml 의 [db].path 가 상대 경로면 config_dir 기준으로 정규화."""
+    monkeypatch.delenv("ANTE_CONFIG_DIR", raising=False)
+    cfg_dir = tmp_path / "instance-rel"
+    cfg_dir.mkdir()
+    (cfg_dir / "system.toml").write_text('[db]\npath = "custom/ante.db"\n')
+
+    ctx = click.Context(cli, obj={"config_dir": cfg_dir})
+    assert get_db_path(ctx) == str(cfg_dir / "custom" / "ante.db")
+
+
+def test_get_db_path_reads_absolute_db_path_from_system_toml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """system.toml 의 [db].path 가 절대 경로면 config_dir과 무관하게 그대로 사용."""
+    monkeypatch.delenv("ANTE_CONFIG_DIR", raising=False)
+    cfg_dir = tmp_path / "instance-abs"
+    cfg_dir.mkdir()
+    absolute_db = tmp_path / "elsewhere" / "ante.db"
+    (cfg_dir / "system.toml").write_text(f'[db]\npath = "{absolute_db}"\n')
+
+    ctx = click.Context(cli, obj={"config_dir": cfg_dir})
+    assert get_db_path(ctx) == str(absolute_db)
+
+
+def test_explicit_db_path_arg_takes_precedence_over_get_db_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`--db-path` 옵션을 가진 커맨드는 자체 인자가 우선이며 get_db_path는 폴백.
+
+    spec: docs/specs/cli/02-design-decisions.md:69 (`--db-path` 가진 커맨드
+    들은 기본값을 None으로 두고, 값이 없을 때 `get_db_path(ctx)`로 폴백).
+    이 테스트는 헬퍼가 system.toml을 읽되, 호출자(서브커맨드 옵션 핸들러)
+    가 명시적 값을 제공하면 헬퍼 결과를 무시할 수 있는 단순 폴백임을 명확히
+    한다 — 즉 헬퍼가 호출자 인자를 가로채지 않는다.
+    """
+    monkeypatch.delenv("ANTE_CONFIG_DIR", raising=False)
+    cfg_dir = tmp_path / "fallback-instance"
+    cfg_dir.mkdir()
+    (cfg_dir / "system.toml").write_text('[db]\npath = "should-not-be-used.db"\n')
+
+    ctx = click.Context(cli, obj={"config_dir": cfg_dir})
+    explicit = "/tmp/explicit-override.db"
+
+    # 호출자(`approval`/`backtest` 등)는 명시적 값이 있으면 헬퍼를 건너뛴다.
+    resolved = explicit or get_db_path(ctx)
+    assert resolved == explicit
+
+
+def test_server_runtime_and_cli_resolve_same_db_path_under_chdir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """CWD를 다른 곳으로 바꾸어도 server runtime과 CLI가 같은 DB 경로를 본다.
+
+    이 테스트는 #1158이 막아야 하는 split-brain 회귀 가드다. cold-path CLI
+    (`account create/delete/set-credentials`)와 server runtime이 동일
+    `config_dir` 위에서 서로 다른 DB를 보면 안 된다. server runtime은
+    `Config.resolve_path("db.path", ...)` 으로, CLI는 `get_db_path(ctx)` 로
+    각각 해석하지만 둘은 같은 결과여야 한다.
+    """
+    from ante.config import Config
+
+    monkeypatch.delenv("ANTE_CONFIG_DIR", raising=False)
+    cfg_dir = tmp_path / "shared-instance"
+    cfg_dir.mkdir()
+    # 상대 경로로 기록해야 split-brain 회귀가 의미 있다 — 절대 경로면
+    # CWD와 무관하므로 회귀 가드 가치가 없다.
+    (cfg_dir / "system.toml").write_text('[db]\npath = "var/ante.db"\n')
+
+    # 호출 시점 CWD를 다른 곳으로 변경 — 과거 구현은 `Path.cwd()` 기준 결합으로
+    # 깨졌을 수 있다.
+    other_cwd = tmp_path / "elsewhere-cwd"
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+
+    # CLI 경로
+    ctx = click.Context(cli, obj={"config_dir": cfg_dir})
+    cli_resolved = get_db_path(ctx)
+
+    # server runtime 경로 (ante.main._init_core가 사용하는 표현식)
+    server_cfg = Config.load(config_dir=cfg_dir)
+    server_resolved = str(server_cfg.resolve_path("db.path", "db/ante.db"))
+
+    assert cli_resolved == server_resolved
+    assert cli_resolved == str(cfg_dir / "var" / "ante.db")
+
+
+# ---------------------------------------------------------------------------
 # get_data_path — Codex 13차 review Finding 1
 #
 # `ante update` 서브프로세스가 v002 Parquet 마이그레이션을 적용할 때

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -157,6 +157,52 @@ class TestConfigValidate:
             config.validate()
 
 
+# ── path-like 정규화 (Refs #1158) ─────────────────
+
+
+class TestConfigResolvePath:
+    """Config.resolve_path() 테스트.
+
+    Spec: docs/specs/config/03-design-decisions.md `Ante instance/path contract`.
+    상대 경로는 `config_dir` 기준, 절대 경로는 그대로, 키 미설정 시 default를 사용한다.
+    """
+
+    def test_resolve_path_returns_absolute_passthrough(self, tmp_path: Path) -> None:
+        """절대 경로로 설정된 키는 `config_dir`과 무관하게 그대로 반환한다."""
+        absolute_db = tmp_path / "elsewhere" / "ante.db"
+        toml_file = tmp_path / "system.toml"
+        toml_file.write_text(f'[db]\npath = "{absolute_db}"\n')
+
+        config = Config.load(config_dir=tmp_path)
+
+        assert config.resolve_path("db.path", "db/ante.db") == absolute_db
+
+    def test_resolve_path_normalizes_relative_against_config_dir(
+        self, tmp_path: Path
+    ) -> None:
+        """상대 경로는 호출 시점 CWD가 아니라 `config_dir` 기준으로 정규화한다."""
+        toml_file = tmp_path / "system.toml"
+        toml_file.write_text('[db]\npath = "custom/ante.db"\n')
+
+        config = Config.load(config_dir=tmp_path)
+
+        assert (
+            config.resolve_path("db.path", "db/ante.db")
+            == tmp_path / "custom" / "ante.db"
+        )
+
+    def test_resolve_path_uses_default_when_key_missing(self, tmp_path: Path) -> None:
+        """TOML에 키가 없으면 default를 `config_dir` 기준으로 정규화한다."""
+        config = Config.load(config_dir=tmp_path)
+
+        # 키가 TOML/DEFAULTS 어디에도 없으면 default가 사용되며,
+        # 결과는 config_dir 기준의 절대 경로여야 한다.
+        assert (
+            config.resolve_path("nonexistent.path", "fallback/ante.db")
+            == tmp_path / "fallback" / "ante.db"
+        )
+
+
 # ── .env 파서 ────────────────────────────────────
 
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from ante.config import Config, DynamicConfigService
 from ante.core import Database
 from ante.eventbus import EventBus, EventHistoryStore
@@ -780,3 +782,48 @@ async def test_init_context_factory_resolves_live_mode_for_live_account(
     assert resolved == TradingMode.LIVE
 
     await db.close()
+
+
+# ── _init_core × Config.resolve_path (Refs #1158) ─────────────
+
+
+async def test_init_core_uses_resolve_path_for_db_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_init_core 가 `db.path`를 `Config.resolve_path` 로 해석하는지 검증.
+
+    spec: docs/specs/cli/02-design-decisions.md:62-70 + docs/specs/config/
+    03-design-decisions.md `Ante instance/path contract`. server runtime은
+    cold-path CLI(`account create/delete/set-credentials`)와 동일 resolver
+    를 사용해 split-brain을 차단해야 한다.
+
+    이 테스트는 system.toml에 상대 경로 `db.path`를 기록한 뒤, _init_core
+    호출 후 `s.db._db_path`가 `<config_dir>/<relative>` 정규화 결과와 같은지
+    확인한다. 호출 시점 CWD를 다른 곳으로 바꾸어도 동일해야 한다 (split-
+    brain 회귀 가드).
+    """
+    from ante.main import Services, _init_core
+
+    cfg_dir = tmp_path / "instance"
+    cfg_dir.mkdir()
+    (cfg_dir / "system.toml").write_text(
+        '[db]\npath = "var/ante.db"\n[web]\nport = 3982\n'
+    )
+
+    # ANTE_CONFIG_DIR 으로 _init_core 가 부르는 Config.load() 가 cfg_dir 을 보게 한다
+    monkeypatch.setenv("ANTE_CONFIG_DIR", str(cfg_dir))
+    # CWD 를 다른 곳으로 — 이전 구현은 `Path.cwd() / db.path`로 결합됐을 수 있다
+    other_cwd = tmp_path / "elsewhere-cwd"
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+
+    s = Services()
+    try:
+        await _init_core(s)
+        assert s.db is not None
+        assert s.db._db_path == str(cfg_dir / "var" / "ante.db")
+        # 부모 디렉토리도 생성되어야 한다 (server runtime 부트 보장)
+        assert (cfg_dir / "var").is_dir()
+    finally:
+        if s.db is not None:
+            await s.db.close()

--- a/tests/unit/test_update_rollback.py
+++ b/tests/unit/test_update_rollback.py
@@ -161,8 +161,11 @@ class TestUpdateMigrationFailureRollback:
             patch("ante.update.executor.snapshot_dependencies", return_value=None),
             # `pathlib.Path.exists` 가 항상 True 를 돌려주는 시나리오에서는
             # `Config.load()` 가 실재하지 않는 system.toml 을 열려다 IOError 가
-            # 난다. update 흐름이 호출하는 get_data_path 를 직접 mocking 한다.
+            # 난다. update 흐름이 호출하는 get_data_path / get_db_path 를 직접
+            # mocking 해 Config.load() 경로를 우회한다 (#1158: get_db_path 도
+            # Config.resolve_path 를 거치므로 같은 mock 가드가 필요하다).
             patch("ante.cli.main.get_data_path", return_value="data/"),
+            patch("ante.cli.main.get_db_path", return_value="db/ante.db"),
         ]
 
     def test_migration_failure_triggers_rollback(self, runner: CliRunner) -> None:
@@ -180,6 +183,7 @@ class TestUpdateMigrationFailureRollback:
             patches[8],
             patches[9],
             patches[10],
+            patches[11],
         ):
             result = runner.invoke(cli, ["update", "-y"])
 
@@ -204,6 +208,7 @@ class TestUpdateMigrationFailureRollback:
             patches[8],
             patches[9],
             patches[10],
+            patches[11],
         ):
             result = runner.invoke(cli, ["update", "-y"])
 
@@ -226,6 +231,7 @@ class TestUpdateMigrationFailureRollback:
             patches[8],
             patches[9],
             patches[10],
+            patches[11],
         ):
             result = runner.invoke(cli, ["update", "-y"])
 

--- a/tests/unit/test_update_snapshot.py
+++ b/tests/unit/test_update_snapshot.py
@@ -139,10 +139,16 @@ class TestSnapshotInRollbackMessage:
             patch("ante.cli.commands.update.check_disk_space", return_value=(True, "")),
             # `pathlib.Path.exists`가 항상 True 를 돌려주는 테스트 시나리오에서는
             # `Config.load()` 가 존재하지도 않는 system.toml 을 열려다 IOError 가
-            # 난다. update 흐름에서 호출되는 get_data_path 를 직접 mocking 한다.
+            # 난다. update 흐름에서 호출되는 get_data_path / get_db_path 를 직접
+            # mocking 해 Config.load() 경로를 우회한다 (#1158: get_db_path 도
+            # Config.resolve_path 를 거치므로 같은 mock 가드가 필요하다).
             patch(
                 "ante.cli.main.get_data_path",
                 return_value="data/",
+            ),
+            patch(
+                "ante.cli.main.get_db_path",
+                return_value="db/ante.db",
             ),
         ]
 
@@ -161,6 +167,7 @@ class TestSnapshotInRollbackMessage:
             patches[8],
             patches[9],
             patches[10],
+            patches[11],
         ):
             result = runner.invoke(cli, ["update", "-y"])
 
@@ -183,6 +190,7 @@ class TestSnapshotInRollbackMessage:
             patches[8],
             patches[9],
             patches[10],
+            patches[11],
         ):
             result = runner.invoke(cli, ["update", "-y"])
 


### PR DESCRIPTION
Closes #1158

## Summary

cold-path CLI(`account create/delete/set-credentials`)와 server runtime이 서로 다른 DB path resolver를 사용해 발생하던 **split-brain**을 닫는다. `Config.resolve_path(key, default)` 공통 resolver를 도입하고 `get_db_path()` + `_init_core` 양쪽이 같은 resolver를 거치게 하여, 절대 경로면 그대로, 상대 경로면 `config_dir` 기준으로 정규화한다.

선행 #1139가 `account delete`를 IPC → direct service로 교체하면서 cold-path가 직접 DB를 mutate하는 표면이 늘어났는데, baseline에는 `<config_dir>/db/ante.db` 고정 vs `Config.get('db.path')` raw값 + CWD 기준 해석이 공존하여 \"성공 메시지를 내고 운영 DB는 untouched\"가 되는 무결성 위험이 있었다.

### 주요 변경

- **`src/ante/config/config.py`**:
  - `Config.__init__`에 `config_dir: Path | None = None` 인자 추가, `self._config_dir`로 저장.
  - `Config.load`가 `resolved` 디렉토리를 그대로 `config_dir`로 전달.
  - `Config.resolve_path(key, default=None) -> Path` 메서드 도입: 절대 passthrough / 상대는 `config_dir` 기준 정규화 / `config_dir` 미설정 시 `Path.cwd()` 폴백.
- **`src/ante/cli/main.py:144-166`**: `get_db_path()`가 `Config.load(config_dir=cfg_dir).resolve_path(\"db.path\", \"db/ante.db\")`를 거치도록 교체. spec(`docs/specs/cli/02-design-decisions.md:62-70`) 계약과 정렬.
- **`src/ante/main.py:123-125`**: `_init_core`가 `s.config.resolve_path(\"db.path\", \"db/ante.db\")`로 정렬. CWD 무관하게 server runtime이 CLI와 동일 경로 해석.
- **신규 회귀 테스트 8개**:
  - `tests/unit/test_config.py::TestConfigResolvePath` 3개 (절대 passthrough / 상대 정규화 / default fallback).
  - `tests/unit/test_cli_main_db_path.py` 4개 (relative / absolute / explicit precedence / **`monkeypatch.chdir` 후 server↔CLI 동일 경로 split-brain 회귀 가드**).
  - `tests/unit/test_main.py::test_init_core_uses_resolve_path_for_db_path` 1개.
- **회귀 보호 mock 보강**: `tests/unit/test_update_rollback.py`, `tests/unit/test_update_snapshot.py`에 `get_db_path` mock 추가 (`get_db_path`가 `Config.load`를 거치게 되면서 발생한 회귀 해소).

### Scope guard (IPC socket 영역은 #1157 처리)

본 PR은 plan v2에 명시된 대로 `db.path` resolver 정렬만 수행한다. IPC socket 영역(`src/ante/main.py:1253-1254`, `src/ante/cli/commands/ipc_helpers.py:40`)에 한 줄도 손대지 않으며 plan v2 Non-Goals와 Stop Conditions(\"IPC socket 영역(#1157) 침범은 본 이슈 범위가 아님\")를 준수한다.

PID 파일과 socket은 같은 lifecycle 안에서 함께 정합되어야 split-brain이 닫히므로 이 영역은 `runtime.pid_path` / `runtime.socket_path` resolver를 함께 다루는 #1157로 분리되어 진행한다. 본 PR이 도입한 `Config.resolve_path`는 #1157에서 `runtime_pid_path()` / `runtime_socket_path()` 편의 메서드의 기반으로 재사용된다.

Codex 브랜치 리뷰 attempt 1의 P2 finding(소켓 경로도 같은 resolver로 정렬)은 plan v2 Non-Goals/Stop Conditions에 정확히 trigger되는 영역을 지적하므로 메타 리뷰(`@code-reviewer`)의 Option A 권고에 따라 본 PR에서 거부하고 #1157로 위임한다. 본 PR 머지부터 #1157 머지 사이 구간의 socket 영역 잠재 위험은 baseline에도 존재하던 위험이며 본 PR이 도입한 회귀가 아니다.

### #1157 우선순위

본 PR이 #1157의 선행 인프라(`Config.resolve_path` + `__init__(config_dir=)`)를 도입하므로 본 PR을 먼저 머지하고 **#1157을 즉시 후속 진행**하는 순서가 옳다.

## Test Plan

- [x] `ruff check src/ tests/` — All checks passed
- [x] `ruff format --check src/ tests/` — 422 files already formatted
- [x] `pytest tests/unit -x -q` — **3384 passed, 2 skipped** (회귀 0건)
- [x] caller regression suite (`test_cli_main_db_path.py`, `test_config.py`, `test_account_cli.py`, `test_cli_system.py`, `test_cli_update.py`, `test_cli_ipc_commands.py`, `test_cli_init.py`, `test_main.py`) — 166 passed
- [x] 신규 회귀 테스트 8개 GREEN
- [x] 정합 grep:
  - `git grep -nE '\\.get\\([\"'\\'']db\\.path[\"'\\'']' src/ante/`: server runtime/CLI 영역 **0건** (`_init_core`와 `get_db_path` 모두 `resolve_path` 단일 경로). IPC 영역 잔존(`ipc_helpers.py:40`, `main.py:1253`)은 #1157 범위로 의도적 보존.
  - `git grep -nE 'get_config_dir\\(ctx\\) / \"db\" / \"ante\\.db\"' src/ante/` → **0건** (구버전 패턴 잔존 없음)
- [x] 메타 리뷰 (`@code-reviewer`): plan 편차 PASS + Option A 권고

## Refs

- 선행: #1139 (CLOSED) — `account delete` IPC → direct service 교체로 split-brain 표면 노출
- 후속: #1157 (OPEN) — IPC socket 영역(`runtime.socket_path` resolver) 정렬. 본 PR의 `Config.resolve_path`를 재사용.
- Spec: `docs/specs/cli/02-design-decisions.md:62-70`, `docs/specs/config/03-design-decisions.md`
- Plan-preflight: done (Codex Plan Review v1: revise-plan → v2: approve-implement)
- 메타 리뷰: plan vs Codex 브랜치 리뷰 attempt 1 충돌 정리 (Option A: plan 그대로 + #1157 위임)
- 부모 에픽: #1142 [chore] 스펙 재정비 후속 이슈 그래프