### PR TITLE
chore(config,main,cli): introduce runtime path canonical resolver (single-canonical cutover) (#1157)

### DIFF
--- a/docs/specs/config/03-design-decisions.md
+++ b/docs/specs/config/03-design-decisions.md
@@ -189,6 +189,12 @@ Ante 1.0은 동일 OS user/home server 기준으로 **단일 active runtime serv
 종료한다. 같은 OS user에서 다중 runtime이 필요하다면 별도 인스턴스 분리/스케줄링은
 1.x 후속 결정 사항으로 분리한다.
 
+`runtime.pid_path` / `runtime.socket_path` 도입에 따라 legacy cwd-relative
+`db/ante.pid` 경로의 read-fallback은 두지 않는다 (#1157). canonical PID 파일이
+부재하면 server는 "running" 판정을 받지 않으며, 기존 환경에서 업그레이드는
+`ante system stop` 후 PR을 적용하는 흐름을 표준 시나리오로 한다. legacy 파일이
+잔존하면 `_remove_pid_file`이 canonical 정리 시 best-effort로 함께 unlink한다.
+
 ### Ante instance/path contract
 
 Ante 인스턴스의 루트는 `config_dir`이다. `system.toml`이 있는 디렉토리와

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -48,13 +48,25 @@ def _assert_no_active_runtime(fmt: OutputFormatter) -> None:
     PID는 alive지만 socket이 부재하면 stale PID로 보고 cold-path 진행을
     허용한다(다른 프로세스가 해당 PID를 차지한 상태일 수 있다).
 
+    Refs #1157: ``--config-dir``로 가리킨 디렉토리의 canonical PID/socket만
+    본다. 명시적으로 ``Config.load(config_dir=get_config_dir())``로 인스턴스를
+    만들어 ``read_pid_file``과 ``get_socket_path`` 양쪽에 같은 ``config_dir``을
+    전파한다 — 0-arg ``read_pid_file()``은 ``ANTE_CONFIG_DIR`` env/default 폴백을
+    보므로, 다른 ``config_dir``로 실행 중인 server runtime을 cold-path가 누락해
+    split-brain 회귀(active server 중에 cold-path mutation 허용)를 일으킬 수 있다.
+
     monkeypatch 호환을 위해 ``ante.main.read_pid_file``과
     ``ante.cli.commands.ipc_helpers.get_socket_path``는 함수 내부에서
     local import한다.
     """
+    from ante.cli.main import get_config_dir
+    from ante.config import Config
     from ante.main import read_pid_file
 
-    pid = read_pid_file()
+    config_dir = get_config_dir()
+    config = Config.load(config_dir=config_dir)
+
+    pid = read_pid_file(config)
     if pid is None:
         return  # PID 파일 부재 → active runtime 없음
 
@@ -66,7 +78,7 @@ def _assert_no_active_runtime(fmt: OutputFormatter) -> None:
     from ante.cli.commands.ipc_helpers import get_socket_path
 
     try:
-        socket_path = get_socket_path()
+        socket_path = get_socket_path(config_dir=config_dir)
     except Exception:
         # socket 경로 해석 실패 시는 차단 측으로 판정하지 않는다
         # (config 부재 등). 그러나 PID alive 단독으로는 단정할 수 없으므로

--- a/src/ante/cli/commands/init.py
+++ b/src/ante/cli/commands/init.py
@@ -42,6 +42,12 @@ timezone = "Asia/Seoul"
 [db]
 path = "{db_path}"
 
+[runtime]
+# `config_dir` 기준 상대 경로. PID/IPC socket 위치 (Refs #1157,
+# docs/specs/config/03-design-decisions.md 200-202).
+pid_path = "run/ante.pid"
+socket_path = "run/ante.sock"
+
 [web]
 host = "0.0.0.0"
 port = 3982

--- a/src/ante/cli/commands/ipc_helpers.py
+++ b/src/ante/cli/commands/ipc_helpers.py
@@ -16,17 +16,17 @@ from ante.ipc.exceptions import IPCTimeoutError, ServerNotRunningError
 def get_socket_path(config_dir: Path | None = None) -> str:
     """IPC 소켓 경로 반환.
 
-    Config에서 db.path를 읽고, 그 부모 디렉토리에 ante.sock을 배치한다.
-    `--config-dir`/`ANTE_CONFIG_DIR`이 주어지면 해당 디렉토리의 Config를
-    로드하여 IPC 소켓 위치를 동일한 트리로 일관시킨다.
+    Refs #1157: ``runtime.socket_path`` resolver를 통해 ``<config_dir>/run/
+    ante.sock``(default)을 산출한다. ``[runtime] socket_path`` override가
+    ``system.toml``에 있으면 사용자 값이 우선한다.
 
     Args:
         config_dir: 선택적 설정 디렉토리. None이면 현재 Click 컨텍스트의
-            `ctx.obj["config_dir"]`을 자동 추출하고, 그것도 없으면
-            `resolve_config_dir()` 폴백으로 자동 탐색한다.
+            ``ctx.obj["config_dir"]``을 자동 추출하고, 그것도 없으면
+            ``resolve_config_dir()`` 폴백으로 자동 탐색한다.
 
     Returns:
-        IPC 유닉스 소켓 절대/상대 경로 문자열.
+        IPC 유닉스 소켓 절대 경로 문자열.
     """
     from ante.config import Config
 
@@ -37,8 +37,7 @@ def get_socket_path(config_dir: Path | None = None) -> str:
         config_dir = get_config_dir()
 
     config = Config.load(config_dir=config_dir)
-    db_path = config.get("db.path", "db/ante.db")
-    return str(Path(db_path).parent / "ante.sock")
+    return str(config.runtime_socket_path())
 
 
 # _ipc.py 호환 별칭

--- a/src/ante/cli/commands/system.py
+++ b/src/ante/cli/commands/system.py
@@ -49,12 +49,31 @@ def _is_process_alive(pid: int) -> bool:
 @require_scope("system:admin")
 def start(ctx: click.Context, config_dir: str | None) -> None:
     """시스템 시작 (포어그라운드)."""
+    from pathlib import Path
+
+    from ante.config import Config
     from ante.main import read_pid_file
 
     fmt = get_formatter(ctx)
 
+    # Refs #1157: PID 조회는 명시적 ``Config`` 인스턴스로 한다. ``--config-dir``
+    # (서브커맨드 또는 루트 ``ctx.obj["config_dir"]``)이 가리키는 디렉토리의
+    # canonical PID 파일만 본다. 0-arg ``read_pid_file()``은 ``ANTE_CONFIG_DIR``
+    # env 또는 default 폴백을 보므로, 다른 ``config_dir``로 실행 중인 server를
+    # 누락해 중복 실행/IPC socket race를 일으킬 수 있다.
+    if config_dir:
+        resolver_config_dir: Path | None = Path(config_dir)
+    else:
+        root_config_dir = ctx.obj.get("config_dir") if ctx.obj else None
+        resolver_config_dir = (
+            root_config_dir if isinstance(root_config_dir, Path) else None
+        )
+        if resolver_config_dir is None and root_config_dir:
+            resolver_config_dir = Path(root_config_dir)
+    config = Config.load(config_dir=resolver_config_dir)
+
     # 이미 실행 중인지 확인
-    existing_pid = read_pid_file()
+    existing_pid = read_pid_file(config)
     if existing_pid is not None and _is_process_alive(existing_pid):
         fmt.error(
             f"시스템이 이미 실행 중입니다 (pid={existing_pid})", code="ALREADY_RUNNING"

--- a/src/ante/cli/commands/system.py
+++ b/src/ante/cli/commands/system.py
@@ -127,9 +127,9 @@ def stop(ctx: click.Context) -> None:
         raise SystemExit(1)
 
     if not _is_process_alive(pid):
-        # 프로세스가 없으면 canonical + legacy `db/ante.pid` 양쪽 stale PID 정리
-        # (Refs #1157, Codex Plan Review v2 high finding 직접 대응 — legacy만
-        # 남은 환경에서 stale loop 차단).
+        # 프로세스가 없으면 canonical + legacy ``db/ante.pid`` 양쪽 stale PID
+        # 정리 (Refs #1157). ``read_pid_file``은 canonical만 보지만, cleanup은
+        # transitional 환경의 legacy 잔여까지 best-effort로 unlink한다.
         _remove_pid_file(config)
         fmt.error(
             f"프로세스가 존재하지 않습니다 (pid={pid}). PID 파일을 정리했습니다.",

--- a/src/ante/cli/commands/system.py
+++ b/src/ante/cli/commands/system.py
@@ -87,21 +87,31 @@ def start(ctx: click.Context, config_dir: str | None) -> None:
 @require_scope("system:admin")
 def stop(ctx: click.Context) -> None:
     """시스템 정상 종료 (SIGTERM)."""
-    from ante.main import PID_FILE, read_pid_file
+    from ante.config import Config
+    from ante.main import _remove_pid_file, read_pid_file
 
     fmt = get_formatter(ctx)
 
-    pid = read_pid_file()
+    # Refs #1157: PID 경로는 `runtime.pid_path` resolver로 결정한다.
+    # 같은 `config_dir`을 쓰는 server runtime/IPC client/cold-path guard와
+    # 동일한 canonical 위치(`<config_dir>/run/ante.pid`)를 본다.
+    config_dir = ctx.obj.get("config_dir") if ctx.obj else None
+    config = Config.load(config_dir=config_dir)
+    pid_path = config.runtime_pid_path()
+
+    pid = read_pid_file(config)
     if pid is None:
         fmt.error(
-            f"PID 파일이 없습니다 ({PID_FILE})",
+            f"PID 파일이 없습니다 ({pid_path})",
             code="PID_NOT_FOUND",
         )
         raise SystemExit(1)
 
     if not _is_process_alive(pid):
-        # 프로세스가 없으면 stale PID 파일 정리
-        PID_FILE.unlink(missing_ok=True)
+        # 프로세스가 없으면 canonical + legacy `db/ante.pid` 양쪽 stale PID 정리
+        # (Refs #1157, Codex Plan Review v2 high finding 직접 대응 — legacy만
+        # 남은 환경에서 stale loop 차단).
+        _remove_pid_file(config)
         fmt.error(
             f"프로세스가 존재하지 않습니다 (pid={pid}). PID 파일을 정리했습니다.",
             code="PROCESS_NOT_FOUND",

--- a/src/ante/cli/commands/update.py
+++ b/src/ante/cli/commands/update.py
@@ -47,10 +47,20 @@ def check_disk_space(db_path: Path) -> tuple[bool, str]:
 
 
 def check_server_running() -> bool:
-    """서버가 실행 중인지 PID 파일로 확인. stale PID는 무시."""
+    """서버가 실행 중인지 PID 파일로 확인. stale PID는 무시.
+
+    Refs #1157: ``--config-dir``로 가리킨 디렉토리의 canonical PID 파일만 본다.
+    명시적으로 ``Config.load(config_dir=get_config_dir())``로 인스턴스를 만들어
+    ``read_pid_file(config)``에 전달한다 — 0-arg ``read_pid_file()``은
+    ``ANTE_CONFIG_DIR`` env/default 폴백을 보므로, 다른 ``config_dir``로 실행 중인
+    server runtime을 누락해 update를 server 실행 중에 진행하는 위험이 있다.
+    """
+    from ante.cli.main import get_config_dir
+    from ante.config import Config
     from ante.main import read_pid_file
 
-    pid = read_pid_file()
+    config = Config.load(config_dir=get_config_dir())
+    pid = read_pid_file(config)
     if pid is None:
         return False
     try:

--- a/src/ante/config/config.py
+++ b/src/ante/config/config.py
@@ -152,6 +152,24 @@ class Config:
         base = self._config_dir if self._config_dir is not None else Path.cwd()
         return base / p
 
+    def runtime_pid_path(self) -> Path:
+        """``runtime.pid_path``를 ``config_dir`` 기준 절대 경로로 반환한다.
+
+        Spec: ``docs/specs/config/03-design-decisions.md`` 200-202, 280-281.
+        Default: ``<config_dir>/run/ante.pid``. ``[runtime] pid_path``를
+        ``system.toml``에 두면 사용자 override가 우선한다.
+        """
+        return self.resolve_path("runtime.pid_path", "run/ante.pid")
+
+    def runtime_socket_path(self) -> Path:
+        """``runtime.socket_path``를 ``config_dir`` 기준 절대 경로로 반환한다.
+
+        Spec: ``docs/specs/ipc/ipc.md`` 181-186,
+        ``docs/specs/config/03-design-decisions.md`` 200-202.
+        Default: ``<config_dir>/run/ante.sock``.
+        """
+        return self.resolve_path("runtime.socket_path", "run/ante.sock")
+
     def secret(self, key: str) -> str:
         """비밀값 조회. 환경변수 우선, 없으면 .env에서.
 

--- a/src/ante/config/defaults.py
+++ b/src/ante/config/defaults.py
@@ -5,6 +5,10 @@ DEFAULTS: dict[str, object] = {
     "system.timezone": "Asia/Seoul",
     "db.path": "db/ante.db",
     "db.event_log_retention_days": 30,
+    # ── runtime PID/IPC socket ──
+    # Refs #1157, docs/specs/config/03-design-decisions.md 200-281
+    "runtime.pid_path": "run/ante.pid",
+    "runtime.socket_path": "run/ante.sock",
     "parquet.base_path": "data/",
     "parquet.compression": "snappy",
     "web.host": "0.0.0.0",

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -30,13 +30,11 @@ from ante.eventbus import EventBus, EventHistoryStore
 
 logger = logging.getLogger(__name__)
 
-# Legacy cwd-relative PID 경로. Refs #1157: 1릴리스 동안 read-fallback 전용으로
-# 보존하며, write/remove 양쪽에서 stale 정리만 수행한다. 새 write는 canonical
-# `<config_dir>/run/ante.pid`로만 한다.
+# Legacy cwd-relative PID 경로. Refs #1157: 1.0 single-canonical resolver 모델로
+# cutover된 이후 새 read는 canonical만 본다. 이 상수는 transitional cleanup 용도로
+# `_remove_pid_file`이 양쪽 unlink할 때만 사용된다 (legacy 환경에서 stale loop를
+# 차단하기 위한 best-effort 정리).
 _LEGACY_PID_FALLBACK = Path("db/ante.pid")
-# legacy fallback deprecation warning은 프로세스 lifetime 동안 1회만 출력한다
-# (Refs #1157, plan v3 권고). 테스트는 caplog 캡처 후 직접 리셋한다.
-_legacy_pid_warning_emitted = False
 
 
 def _write_pid_file(config: Config) -> None:
@@ -55,9 +53,11 @@ def _write_pid_file(config: Config) -> None:
 def _remove_pid_file(config: Config) -> None:
     """canonical + legacy ``db/ante.pid`` 양쪽 PID 파일을 정리한다.
 
-    Refs #1157: legacy `db/ante.pid` read-fallback과 정합되도록 양쪽을 모두
-    ``unlink(missing_ok=True)`` 처리해 transitional 환경에서 stale loop를 차단.
-    Codex Plan Review v2 high finding 직접 대응.
+    Refs #1157: ``read_pid_file``은 canonical만 보지만, legacy cwd-relative
+    ``db/ante.pid``가 과거 환경에서 남아 있을 수 있으므로 cleanup은 양쪽을
+    ``unlink(missing_ok=True)`` 처리해 transitional 환경에서 stale 잔여를
+    제거한다 (best-effort). 이 책임은 ``read_pid_file``의 single-canonical
+    정책과 분리되며, 단지 호환 cleanup만 수행한다.
     """
     canonical = config.runtime_pid_path()
     for path in (canonical, _LEGACY_PID_FALLBACK):
@@ -69,17 +69,16 @@ def _remove_pid_file(config: Config) -> None:
 
 
 def read_pid_file(config: Config | None = None) -> int | None:
-    """PID 파일에서 PID 읽기. 파일이 없거나 파싱 실패 시 None.
+    """PID 파일에서 PID 읽기. canonical 부재/파싱 실패 시 None.
 
-    우선순위:
-      1. canonical ``config.runtime_pid_path()``
-      2. legacy ``db/ante.pid`` (1릴리스 read-fallback, deprecation warning 1회)
-      3. 둘 다 부재 → None.
+    Refs #1157, docs/specs/config/03-design-decisions.md (1.0 단일 active runtime
+    정책). 1.0은 single-canonical resolver 모델을 따르므로 legacy cwd-relative
+    ``db/ante.pid`` read-fallback은 두지 않는다. canonical
+    ``config.runtime_pid_path()``만 본다.
 
-    Refs #1157. ``config``이 ``None``이면 ``Config.load()``로 env/디폴트
-    기준 canonical을 산출한다. 0-arg 호환을 유지해 기존 ``patch("ante.main.
-    read_pid_file", ...)`` monkeypatch 사용처(test_account_cli, test_cli_update
-    등)가 그대로 동작한다.
+    ``config``이 ``None``이면 ``Config.load()``로 env/디폴트 기준 canonical을
+    산출한다. 0-arg 호환을 유지해 기존 ``patch("ante.main.read_pid_file", ...)``
+    monkeypatch 사용처(test_account_cli, test_cli_update 등)가 그대로 동작한다.
     """
     if config is None:
         config = Config.load()
@@ -88,22 +87,7 @@ def read_pid_file(config: Config | None = None) -> int | None:
     try:
         return int(canonical.read_text().strip())
     except (FileNotFoundError, ValueError):
-        pass
-
-    try:
-        pid = int(_LEGACY_PID_FALLBACK.read_text().strip())
-    except (FileNotFoundError, ValueError):
         return None
-
-    global _legacy_pid_warning_emitted
-    if not _legacy_pid_warning_emitted:
-        logger.warning(
-            "legacy %s 사용 — %s로 마이그레이션 필요 (Refs #1157)",
-            _LEGACY_PID_FALLBACK,
-            canonical,
-        )
-        _legacy_pid_warning_emitted = True
-    return pid
 
 
 @dataclass

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -34,6 +34,9 @@ logger = logging.getLogger(__name__)
 # 보존하며, write/remove 양쪽에서 stale 정리만 수행한다. 새 write는 canonical
 # `<config_dir>/run/ante.pid`로만 한다.
 _LEGACY_PID_FALLBACK = Path("db/ante.pid")
+# legacy fallback deprecation warning은 프로세스 lifetime 동안 1회만 출력한다
+# (Refs #1157, plan v3 권고). 테스트는 caplog 캡처 후 직접 리셋한다.
+_legacy_pid_warning_emitted = False
 
 
 def _write_pid_file(config: Config) -> None:
@@ -92,11 +95,14 @@ def read_pid_file(config: Config | None = None) -> int | None:
     except (FileNotFoundError, ValueError):
         return None
 
-    logger.warning(
-        "legacy %s 사용 — %s로 마이그레이션 필요 (Refs #1157)",
-        _LEGACY_PID_FALLBACK,
-        canonical,
-    )
+    global _legacy_pid_warning_emitted
+    if not _legacy_pid_warning_emitted:
+        logger.warning(
+            "legacy %s 사용 — %s로 마이그레이션 필요 (Refs #1157)",
+            _LEGACY_PID_FALLBACK,
+            canonical,
+        )
+        _legacy_pid_warning_emitted = True
     return pid
 
 

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -30,31 +30,74 @@ from ante.eventbus import EventBus, EventHistoryStore
 
 logger = logging.getLogger(__name__)
 
-PID_FILE = Path("db/ante.pid")
+# Legacy cwd-relative PID 경로. Refs #1157: 1릴리스 동안 read-fallback 전용으로
+# 보존하며, write/remove 양쪽에서 stale 정리만 수행한다. 새 write는 canonical
+# `<config_dir>/run/ante.pid`로만 한다.
+_LEGACY_PID_FALLBACK = Path("db/ante.pid")
 
 
-def _write_pid_file() -> None:
-    """PID 파일 기록."""
-    PID_FILE.parent.mkdir(parents=True, exist_ok=True)
-    PID_FILE.write_text(str(os.getpid()))
-    logger.info("PID 파일 기록: %s (pid=%d)", PID_FILE, os.getpid())
+def _write_pid_file(config: Config) -> None:
+    """PID 파일을 ``config.runtime_pid_path()`` canonical 위치에 기록한다.
+
+    Refs #1157, docs/specs/config/03-design-decisions.md 200-202.
+    Server runtime, cold-path CLI guard, IPC client가 같은 ``config_dir``을
+    쓰면 같은 PID 파일을 본다.
+    """
+    path = config.runtime_pid_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(os.getpid()))
+    logger.info("PID 파일 기록: %s (pid=%d)", path, os.getpid())
 
 
-def _remove_pid_file() -> None:
-    """PID 파일 삭제."""
+def _remove_pid_file(config: Config) -> None:
+    """canonical + legacy ``db/ante.pid`` 양쪽 PID 파일을 정리한다.
+
+    Refs #1157: legacy `db/ante.pid` read-fallback과 정합되도록 양쪽을 모두
+    ``unlink(missing_ok=True)`` 처리해 transitional 환경에서 stale loop를 차단.
+    Codex Plan Review v2 high finding 직접 대응.
+    """
+    canonical = config.runtime_pid_path()
+    for path in (canonical, _LEGACY_PID_FALLBACK):
+        try:
+            path.unlink(missing_ok=True)
+            logger.info("PID 파일 삭제: %s", path)
+        except OSError:
+            logger.warning("PID 파일 삭제 실패: %s", path, exc_info=True)
+
+
+def read_pid_file(config: Config | None = None) -> int | None:
+    """PID 파일에서 PID 읽기. 파일이 없거나 파싱 실패 시 None.
+
+    우선순위:
+      1. canonical ``config.runtime_pid_path()``
+      2. legacy ``db/ante.pid`` (1릴리스 read-fallback, deprecation warning 1회)
+      3. 둘 다 부재 → None.
+
+    Refs #1157. ``config``이 ``None``이면 ``Config.load()``로 env/디폴트
+    기준 canonical을 산출한다. 0-arg 호환을 유지해 기존 ``patch("ante.main.
+    read_pid_file", ...)`` monkeypatch 사용처(test_account_cli, test_cli_update
+    등)가 그대로 동작한다.
+    """
+    if config is None:
+        config = Config.load()
+
+    canonical = config.runtime_pid_path()
     try:
-        PID_FILE.unlink(missing_ok=True)
-        logger.info("PID 파일 삭제: %s", PID_FILE)
-    except OSError:
-        logger.warning("PID 파일 삭제 실패: %s", PID_FILE, exc_info=True)
+        return int(canonical.read_text().strip())
+    except (FileNotFoundError, ValueError):
+        pass
 
-
-def read_pid_file() -> int | None:
-    """PID 파일에서 PID 읽기. 파일이 없거나 파싱 실패 시 None."""
     try:
-        return int(PID_FILE.read_text().strip())
+        pid = int(_LEGACY_PID_FALLBACK.read_text().strip())
     except (FileNotFoundError, ValueError):
         return None
+
+    logger.warning(
+        "legacy %s 사용 — %s로 마이그레이션 필요 (Refs #1157)",
+        _LEGACY_PID_FALLBACK,
+        canonical,
+    )
+    return pid
 
 
 @dataclass
@@ -109,8 +152,9 @@ class Services:
 
 async def _init_core(s: Services) -> None:
     """Config, Database, EventBus, DynamicConfig 초기화."""
-    # Config
-    s.config = Config.load()
+    # Config — `main()`이 PID 기록 직전에 미리 로드해 둘 수 있다 (Refs #1157).
+    if s.config is None:
+        s.config = Config.load()
     s.config.validate()
 
     from ante.core.log import setup_logging
@@ -1250,8 +1294,11 @@ async def _init_ipc(s: Services) -> None:
     command_registry = CommandRegistry()
     register_all_handlers(command_registry)
 
-    db_path = s.config.get("db.path", "db/ante.db")
-    socket_path = str(Path(db_path).parent / "ante.sock")
+    # Refs #1157: socket 경로는 `runtime.socket_path` resolver로 통일한다.
+    # default `<config_dir>/run/ante.sock` (또는 `[runtime] socket_path` override).
+    # cold-path CLI guard / IPCClient가 같은 resolver를 쓰므로 같은 socket을 본다.
+    socket_path = str(s.config.runtime_socket_path())
+    Path(socket_path).parent.mkdir(parents=True, exist_ok=True)
     s.ipc_server = IPCServer(socket_path, service_registry, command_registry)
     await s.ipc_server.start()
     logger.info("IPC 서버 초기화 완료: %s", socket_path)
@@ -1473,7 +1520,11 @@ async def main() -> None:
     종료 순서: 역순 (상위 소비자부터 정리)
     """
     s = Services()
-    _write_pid_file()
+    # Refs #1157: PID 기록 전에 Config를 미리 로드해 canonical
+    # `<config_dir>/run/ante.pid` 위치에 기록한다. `_init_core`는 동일
+    # 인스턴스를 그대로 재사용한다.
+    s.config = Config.load()
+    _write_pid_file(s.config)
 
     try:
         await _init_core(s)
@@ -1502,7 +1553,7 @@ async def main() -> None:
         await _init_web(s)
         await _run(s)
     finally:
-        _remove_pid_file()
+        _remove_pid_file(s.config)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cli_config_dir_propagation.py
+++ b/tests/unit/test_cli_config_dir_propagation.py
@@ -4,6 +4,10 @@
 IPC 소켓 경로 계산까지 일관되게 전파되어야 한다. 과거에는 DB만
 override되고 `system.toml`/`ante.sock`은 기본 설치를 바라보는 회귀가
 있었다.
+
+Refs #1157: socket은 더 이상 ``db.path`` 부모가 아니라
+``runtime.socket_path`` resolver(default ``<config_dir>/run/ante.sock``)를
+따른다. 본 모듈의 expected 경로도 그에 맞춰 갱신되었다.
 """
 
 from __future__ import annotations
@@ -75,7 +79,7 @@ class TestGetSocketPathConfigDirPropagation:
         )
 
         result = get_socket_path(config_dir=cfg)
-        assert result == str(cfg / "db" / "ante.sock")
+        assert result == str(cfg / "run" / "ante.sock")
 
     def test_default_uses_env_fallback(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -94,7 +98,7 @@ class TestGetSocketPathConfigDirPropagation:
         monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
 
         result = get_socket_path()
-        assert result == str(cfg / "db" / "ante.sock")
+        assert result == str(cfg / "run" / "ante.sock")
 
     def test_picks_up_ctx_when_no_explicit_arg(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -112,7 +116,7 @@ class TestGetSocketPathConfigDirPropagation:
         ctx = click.Context(cli, obj={"config_dir": cfg})
         with ctx:
             result = get_socket_path()
-        assert result == str(cfg / "db" / "ante.sock")
+        assert result == str(cfg / "run" / "ante.sock")
 
     def test_explicit_arg_beats_ctx(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -134,7 +138,7 @@ class TestGetSocketPathConfigDirPropagation:
         ctx = click.Context(cli, obj={"config_dir": cfg_ctx})
         with ctx:
             result = get_socket_path(config_dir=cfg_explicit)
-        assert result == str(cfg_explicit / "db" / "ante.sock")
+        assert result == str(cfg_explicit / "run" / "ante.sock")
 
 
 class TestConfigLoadAcceptsConfigDir:

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -1216,3 +1216,57 @@ class TestInitSystemTomlAbsoluteDbPath:
         toml_text = (target / "system.toml").read_text()
         expected = (target / "db" / "ante.db").resolve()
         assert f'path = "{expected}"' in toml_text
+
+
+class TestInitSystemTomlRuntimeSection:
+    """Refs #1157: ``ante init``이 만든 ``system.toml``에 ``[runtime]`` 섹션이
+    들어가고, 섹션이 없는 기존 설치도 default fallback으로 동작해야 한다.
+    """
+
+    def test_system_toml_template_includes_runtime_section(self, runner, tmp_path):
+        """fresh init 후 system.toml에 ``[runtime] pid_path/socket_path``가 있다."""
+        from ante.cli.commands.init import SYSTEM_TOML_TEMPLATE
+
+        # 1) 템플릿 자체에 [runtime] 섹션과 두 키가 정의되어 있어야 한다.
+        assert "[runtime]" in SYSTEM_TOML_TEMPLATE
+        assert 'pid_path = "run/ante.pid"' in SYSTEM_TOML_TEMPLATE
+        assert 'socket_path = "run/ante.sock"' in SYSTEM_TOML_TEMPLATE
+
+        # 2) 실제 init이 만든 system.toml에도 같은 섹션이 보존된다.
+        target = tmp_path / "init-runtime"
+
+        patches = _patch_init()
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(cli, ["init", "--dir", str(target)])
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert result.exit_code == 0, result.output
+        toml_text = (target / "system.toml").read_text()
+        assert "[runtime]" in toml_text
+        assert 'pid_path = "run/ante.pid"' in toml_text
+        assert 'socket_path = "run/ante.sock"' in toml_text
+
+    def test_existing_system_toml_without_runtime_section_falls_back_to_defaults(
+        self, tmp_path
+    ):
+        """``[runtime]`` 부재 시 default canonical을 산출.
+
+        기존 ``config_dir``에 자동으로 ``[runtime]`` 섹션을 주입할 필요는 없다 —
+        Config DEFAULTS가 ``run/ante.pid``/``run/ante.sock``을 보장한다.
+        """
+        from ante.config import Config
+
+        # [runtime] 섹션이 없는 baseline system.toml
+        (tmp_path / "system.toml").write_text(
+            '[system]\nlog_level = "INFO"\n\n[db]\npath = "db/ante.db"\n',
+            encoding="utf-8",
+        )
+
+        config = Config.load(config_dir=tmp_path)
+
+        assert config.runtime_pid_path() == tmp_path / "run" / "ante.pid"
+        assert config.runtime_socket_path() == tmp_path / "run" / "ante.sock"

--- a/tests/unit/test_cli_ipc_commands.py
+++ b/tests/unit/test_cli_ipc_commands.py
@@ -312,26 +312,27 @@ class TestIPCErrorResponse:
 
 
 class TestGetSocketPath:
-    def test_default_socket_path(self) -> None:
-        """기본 db.path로부터 소켓 경로 생성."""
+    """Refs #1157: ``get_socket_path``는 ``runtime.socket_path`` resolver를 통해
+    ``<config_dir>/run/ante.sock`` 절대 경로를 산출한다. 더 이상 ``db.path``의
+    부모 디렉토리에 의존하지 않는다.
+    """
+
+    def test_default_socket_path(self, tmp_path) -> None:
+        """default ``runtime.socket_path``로부터 ``<config_dir>/run/ante.sock`` 생성."""
         from ante.cli.commands.ipc_helpers import get_socket_path
 
-        with patch("ante.config.Config") as mock_config_cls:
-            mock_config = mock_config_cls.load.return_value
-            mock_config.get.return_value = "db/ante.db"
+        path = get_socket_path(config_dir=tmp_path)
 
-            path = get_socket_path()
+        assert path == str(tmp_path / "run" / "ante.sock")
 
-        assert path == "db/ante.sock"
-
-    def test_custom_db_path(self) -> None:
-        """커스텀 db.path로부터 소켓 경로 생성."""
+    def test_custom_runtime_socket_path(self, tmp_path) -> None:
+        """``[runtime] socket_path`` override가 적용된다."""
         from ante.cli.commands.ipc_helpers import get_socket_path
 
-        with patch("ante.config.Config") as mock_config_cls:
-            mock_config = mock_config_cls.load.return_value
-            mock_config.get.return_value = "/data/ante/main.db"
+        (tmp_path / "system.toml").write_text(
+            '[runtime]\nsocket_path = "ipc/custom.sock"\n', encoding="utf-8"
+        )
 
-            path = get_socket_path()
+        path = get_socket_path(config_dir=tmp_path)
 
-        assert path == "/data/ante/ante.sock"
+        assert path == str(tmp_path / "ipc" / "custom.sock")

--- a/tests/unit/test_cli_system.py
+++ b/tests/unit/test_cli_system.py
@@ -187,6 +187,51 @@ class TestSystemStop:
             assert data["status"] == "ok"
             assert data["pid"] == 12345
 
+    def test_stop_pid_not_found_message_includes_resolver_path(
+        self, runner, tmp_path, monkeypatch
+    ):
+        """Refs #1157: PID 부재 메시지에 ``<config_dir>/run/ante.pid``가 포함된다."""
+        monkeypatch.setenv("ANTE_CONFIG_DIR", str(tmp_path))
+
+        with patch("ante.main.read_pid_file", return_value=None):
+            result = runner.invoke(cli, ["system", "stop"])
+
+        assert result.exit_code == 1
+        # text 모드 메시지에 resolver-normalized 절대 경로가 포함돼야 한다.
+        expected = str(tmp_path / "run" / "ante.pid")
+        assert expected in result.output
+
+    def test_stop_cleans_legacy_pid_when_stale(self, runner, tmp_path, monkeypatch):
+        """Refs #1157: canonical 부재 + legacy ``db/ante.pid``만 stale인 환경에서
+        ``stop``이 legacy까지 정리해 다음 호출이 무한 루프하지 않아야 한다.
+
+        Codex Plan Review v2 high finding 직접 회귀.
+        """
+        config_dir = tmp_path / "ante-config"
+        config_dir.mkdir()
+        cwd = tmp_path / "workdir"
+        cwd.mkdir()
+        monkeypatch.setenv("ANTE_CONFIG_DIR", str(config_dir))
+        monkeypatch.chdir(cwd)
+
+        # canonical 부재 — `<config_dir>/run/ante.pid` 만들지 않는다
+        canonical = config_dir / "run" / "ante.pid"
+        assert not canonical.exists()
+
+        # legacy `<cwd>/db/ante.pid` 존재 + stale PID
+        legacy = cwd / "db" / "ante.pid"
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text("88888")
+
+        # legacy fallback이 동작하도록 read_pid_file은 monkeypatch하지 않는다
+        with patch("ante.cli.commands.system._is_process_alive", return_value=False):
+            result = runner.invoke(cli, ["system", "stop"])
+
+        assert result.exit_code == 1
+        assert "프로세스가 존재하지 않습니다" in result.output
+        assert not legacy.exists()
+        assert not canonical.exists()
+
 
 class TestPidFileManagement:
     """Refs #1157: PID helpers는 ``Config`` 인자를 받아 ``runtime_pid_path()``로

--- a/tests/unit/test_cli_system.py
+++ b/tests/unit/test_cli_system.py
@@ -201,11 +201,16 @@ class TestSystemStop:
         expected = str(tmp_path / "run" / "ante.pid")
         assert expected in result.output
 
-    def test_stop_cleans_legacy_pid_when_stale(self, runner, tmp_path, monkeypatch):
-        """Refs #1157: canonical 부재 + legacy ``db/ante.pid``만 stale인 환경에서
-        ``stop``이 legacy까지 정리해 다음 호출이 무한 루프하지 않아야 한다.
+    def test_stop_returns_pid_not_found_when_only_legacy_pid_present(
+        self, runner, tmp_path, monkeypatch
+    ):
+        """Refs #1157: ``stop``은 canonical PID만 본다. legacy ``db/ante.pid``가
+        남아 있어도 canonical이 부재하면 ``PID_NOT_FOUND``로 종료한다.
 
-        Codex Plan Review v2 high finding 직접 회귀.
+        1.0 single-canonical resolver cutover 회귀: legacy read-fallback이
+        제거되었으므로 stop은 legacy 잔여를 알 수 없고, 사용자가 stop을
+        호출해도 legacy는 자동 정리되지 않는다 (legacy cleanup은 별도
+        ``_remove_pid_file`` 단위 회귀에서 검증).
         """
         config_dir = tmp_path / "ante-config"
         config_dir.mkdir()
@@ -218,19 +223,56 @@ class TestSystemStop:
         canonical = config_dir / "run" / "ante.pid"
         assert not canonical.exists()
 
-        # legacy `<cwd>/db/ante.pid` 존재 + stale PID
+        # legacy `<cwd>/db/ante.pid` 존재
         legacy = cwd / "db" / "ante.pid"
         legacy.parent.mkdir(parents=True, exist_ok=True)
         legacy.write_text("88888")
 
-        # legacy fallback이 동작하도록 read_pid_file은 monkeypatch하지 않는다
+        result = runner.invoke(cli, ["system", "stop"])
+
+        # canonical 부재 → PID_NOT_FOUND, legacy는 무시
+        assert result.exit_code == 1
+        assert "PID 파일이 없습니다" in result.output
+        assert "PID_NOT_FOUND" in result.output or str(canonical) in result.output
+        # stop은 legacy를 손대지 않는다 (read 안 했으니 정리 분기 진입 X)
+        assert legacy.exists()
+        assert not canonical.exists()
+
+    def test_stop_cleans_legacy_pid_when_canonical_stale(
+        self, runner, tmp_path, monkeypatch
+    ):
+        """Refs #1157: canonical PID는 있지만 프로세스가 죽었을 때 ``stop``이
+        canonical + legacy 양쪽을 정리한다 (``_remove_pid_file`` cleanup 책임).
+
+        legacy unlink 책임이 stop 흐름과 통합되어 있는지 회귀 보호. 단,
+        canonical이 존재해야 read_pid_file이 PID를 반환하므로 본 테스트는
+        canonical을 직접 만들고 legacy도 함께 정리되는지 검증한다.
+        """
+        config_dir = tmp_path / "ante-config"
+        config_dir.mkdir()
+        cwd = tmp_path / "workdir"
+        cwd.mkdir()
+        monkeypatch.setenv("ANTE_CONFIG_DIR", str(config_dir))
+        monkeypatch.chdir(cwd)
+
+        # canonical에 stale PID 작성
+        canonical = config_dir / "run" / "ante.pid"
+        canonical.parent.mkdir(parents=True, exist_ok=True)
+        canonical.write_text("88888")
+
+        # legacy `<cwd>/db/ante.pid`도 같이 잔존
+        legacy = cwd / "db" / "ante.pid"
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text("88888")
+
         with patch("ante.cli.commands.system._is_process_alive", return_value=False):
             result = runner.invoke(cli, ["system", "stop"])
 
         assert result.exit_code == 1
         assert "프로세스가 존재하지 않습니다" in result.output
-        assert not legacy.exists()
+        # _remove_pid_file이 canonical + legacy 양쪽 unlink
         assert not canonical.exists()
+        assert not legacy.exists()
 
 
 class TestPidFileManagement:
@@ -252,18 +294,15 @@ class TestPidFileManagement:
             _remove_pid_file(config)
 
     def test_read_pid_file_missing(self, tmp_path):
-        """canonical/legacy 모두 부재 시 None."""
+        """canonical 부재 시 None (legacy ``db/ante.pid``는 read 대상이 아님)."""
         from ante.config import Config
         from ante.main import read_pid_file
 
-        # legacy 경로(`db/ante.pid`)가 cwd에 없도록 격리된 디렉토리로 chdir.
-        # tmp_path 자체는 canonical(`run/ante.pid`)도 가지지 않음.
-        with patch("ante.main._LEGACY_PID_FALLBACK", tmp_path / "no-legacy"):
-            config = Config.load(config_dir=tmp_path)
-            assert read_pid_file(config) is None
+        config = Config.load(config_dir=tmp_path)
+        assert read_pid_file(config) is None
 
     def test_read_pid_file_invalid(self, tmp_path):
-        """PID 파일 내용이 숫자가 아니면 None."""
+        """canonical PID 파일 내용이 숫자가 아니면 None."""
         from ante.config import Config
         from ante.main import read_pid_file
 
@@ -271,8 +310,7 @@ class TestPidFileManagement:
         canonical = tmp_path / "run" / "ante.pid"
         canonical.parent.mkdir(parents=True, exist_ok=True)
         canonical.write_text("not-a-number")
-        with patch("ante.main._LEGACY_PID_FALLBACK", tmp_path / "no-legacy"):
-            assert read_pid_file(config) is None
+        assert read_pid_file(config) is None
 
     def test_remove_pid_file(self, tmp_path):
         """canonical PID 파일 삭제."""
@@ -285,6 +323,38 @@ class TestPidFileManagement:
         canonical.write_text("12345")
         _remove_pid_file(config)
         assert not canonical.exists()
+
+    def test_remove_pid_file_cleans_legacy_too(self, tmp_path, monkeypatch):
+        """Refs #1157: ``_remove_pid_file``은 canonical + legacy 양쪽을 unlink한다.
+
+        ``read_pid_file``이 single-canonical로 cutover된 이후에도 ``_remove_pid_file``
+        의 cleanup 책임은 transitional 환경의 legacy ``db/ante.pid`` 잔여를
+        best-effort로 제거하는 것을 보존한다 (책임 분리 회귀).
+        """
+        from ante.config import Config
+        from ante.main import _remove_pid_file
+
+        cwd = tmp_path / "workdir"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+
+        config = Config.load(config_dir=tmp_path)
+
+        # canonical 작성
+        canonical = tmp_path / "run" / "ante.pid"
+        canonical.parent.mkdir(parents=True, exist_ok=True)
+        canonical.write_text("12345")
+
+        # legacy `<cwd>/db/ante.pid`도 잔존
+        legacy = cwd / "db" / "ante.pid"
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text("99999")
+
+        _remove_pid_file(config)
+
+        # 양쪽 모두 정리되어야 한다
+        assert not canonical.exists()
+        assert not legacy.exists()
 
     def test_remove_pid_file_missing(self, tmp_path):
         """PID 파일이 없어도 에러 없이 진행."""

--- a/tests/unit/test_cli_system.py
+++ b/tests/unit/test_cli_system.py
@@ -145,20 +145,23 @@ class TestSystemStop:
             data = json.loads(result.output)
             assert data["code"] == "PID_NOT_FOUND"
 
-    def test_stop_stale_pid(self, runner, tmp_path):
-        """프로세스가 없으면 stale PID 정리 후 에러."""
-        pid_file = tmp_path / "ante.pid"
-        pid_file.write_text("99999")
+    def test_stop_stale_pid(self, runner, tmp_path, monkeypatch):
+        """프로세스가 없으면 canonical PID 정리 후 에러 (Refs #1157)."""
+        # Refs #1157: ``runtime.pid_path`` resolver가 결정한 canonical 위치에
+        # 기록된 stale PID를 stop이 정리해야 한다.
+        monkeypatch.setenv("ANTE_CONFIG_DIR", str(tmp_path))
+        canonical = tmp_path / "run" / "ante.pid"
+        canonical.parent.mkdir(parents=True, exist_ok=True)
+        canonical.write_text("99999")
 
         with (
             patch("ante.main.read_pid_file", return_value=99999),
             patch("ante.cli.commands.system._is_process_alive", return_value=False),
-            patch("ante.main.PID_FILE", pid_file),
         ):
             result = runner.invoke(cli, ["system", "stop"])
             assert result.exit_code == 1
             assert "프로세스가 존재하지 않습니다" in result.output
-            assert not pid_file.exists()
+            assert not canonical.exists()
 
     def test_stop_sends_sigterm(self, runner):
         """정상 프로세스에 SIGTERM 전송."""
@@ -186,49 +189,65 @@ class TestSystemStop:
 
 
 class TestPidFileManagement:
-    def test_write_and_read_pid_file(self, tmp_path):
-        """PID 파일 기록 및 읽기."""
-        from ante.main import _write_pid_file, read_pid_file
+    """Refs #1157: PID helpers는 ``Config`` 인자를 받아 ``runtime_pid_path()``로
+    canonical 경로를 산출한다. ``PID_FILE`` 모듈 상수는 제거되었다.
+    """
 
-        pid_file = tmp_path / "ante.pid"
-        with patch("ante.main.PID_FILE", pid_file):
-            _write_pid_file()
-            result = read_pid_file()
-            assert result == os.getpid()
+    def test_write_and_read_pid_file(self, tmp_path):
+        """PID 파일 기록 및 읽기 (canonical resolver 기준)."""
+        from ante.config import Config
+        from ante.main import _remove_pid_file, _write_pid_file, read_pid_file
+
+        config = Config.load(config_dir=tmp_path)
+        try:
+            _write_pid_file(config)
+            assert read_pid_file(config) == os.getpid()
+            assert (tmp_path / "run" / "ante.pid").exists()
+        finally:
+            _remove_pid_file(config)
 
     def test_read_pid_file_missing(self, tmp_path):
-        """PID 파일이 없으면 None."""
+        """canonical/legacy 모두 부재 시 None."""
+        from ante.config import Config
         from ante.main import read_pid_file
 
-        with patch("ante.main.PID_FILE", tmp_path / "nonexistent.pid"):
-            assert read_pid_file() is None
+        # legacy 경로(`db/ante.pid`)가 cwd에 없도록 격리된 디렉토리로 chdir.
+        # tmp_path 자체는 canonical(`run/ante.pid`)도 가지지 않음.
+        with patch("ante.main._LEGACY_PID_FALLBACK", tmp_path / "no-legacy"):
+            config = Config.load(config_dir=tmp_path)
+            assert read_pid_file(config) is None
 
     def test_read_pid_file_invalid(self, tmp_path):
         """PID 파일 내용이 숫자가 아니면 None."""
+        from ante.config import Config
         from ante.main import read_pid_file
 
-        pid_file = tmp_path / "ante.pid"
-        pid_file.write_text("not-a-number")
-        with patch("ante.main.PID_FILE", pid_file):
-            assert read_pid_file() is None
+        config = Config.load(config_dir=tmp_path)
+        canonical = tmp_path / "run" / "ante.pid"
+        canonical.parent.mkdir(parents=True, exist_ok=True)
+        canonical.write_text("not-a-number")
+        with patch("ante.main._LEGACY_PID_FALLBACK", tmp_path / "no-legacy"):
+            assert read_pid_file(config) is None
 
     def test_remove_pid_file(self, tmp_path):
-        """PID 파일 삭제."""
+        """canonical PID 파일 삭제."""
+        from ante.config import Config
         from ante.main import _remove_pid_file
 
-        pid_file = tmp_path / "ante.pid"
-        pid_file.write_text("12345")
-        with patch("ante.main.PID_FILE", pid_file):
-            _remove_pid_file()
-            assert not pid_file.exists()
+        config = Config.load(config_dir=tmp_path)
+        canonical = tmp_path / "run" / "ante.pid"
+        canonical.parent.mkdir(parents=True, exist_ok=True)
+        canonical.write_text("12345")
+        _remove_pid_file(config)
+        assert not canonical.exists()
 
     def test_remove_pid_file_missing(self, tmp_path):
         """PID 파일이 없어도 에러 없이 진행."""
+        from ante.config import Config
         from ante.main import _remove_pid_file
 
-        pid_file = tmp_path / "nonexistent.pid"
-        with patch("ante.main.PID_FILE", pid_file):
-            _remove_pid_file()  # Should not raise
+        config = Config.load(config_dir=tmp_path)
+        _remove_pid_file(config)  # Should not raise
 
 
 class TestIsProcessAlive:

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -1,0 +1,241 @@
+"""Refs #1157 — runtime path resolver 회귀 테스트.
+
+`runtime.pid_path`/`runtime.socket_path`을 ``config_dir`` 기준으로 정규화하는
+편의 메서드(`Config.runtime_pid_path()`/`runtime_socket_path()`)와 그 소비자
+(`main._write_pid_file`/`_remove_pid_file`/`read_pid_file`,
+`cli.commands.ipc_helpers.get_socket_path`, account cold-path guard)가 cwd와
+무관하게 동일한 절대 경로를 보는지 검증한다.
+
+SSOT:
+- ``docs/specs/config/03-design-decisions.md`` (canonical resource table 200-202,
+  default 표 280-281)
+- ``docs/specs/cli/02-design-decisions.md`` 62-70 (resolver 우선순위)
+- ``docs/specs/cli/03-commands.md`` 300-302 (init이 기록하는 키)
+- ``docs/specs/ipc/ipc.md`` 181-186 (socket 경로 정의)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ante.config import Config
+
+# ── Task 1: config resolver 회귀 ─────────────────────────────────
+
+
+def test_runtime_pid_path_default_uses_config_dir(tmp_path: Path) -> None:
+    """default 값으로 ``<config_dir>/run/ante.pid`` 절대 경로를 반환해야 한다."""
+    config = Config.load(config_dir=tmp_path)
+
+    assert config.runtime_pid_path() == tmp_path / "run" / "ante.pid"
+
+
+def test_runtime_socket_path_default_uses_config_dir(tmp_path: Path) -> None:
+    """default 값으로 ``<config_dir>/run/ante.sock`` 절대 경로를 반환해야 한다."""
+    config = Config.load(config_dir=tmp_path)
+
+    assert config.runtime_socket_path() == tmp_path / "run" / "ante.sock"
+
+
+def test_runtime_pid_path_override_in_toml(tmp_path: Path) -> None:
+    """``[runtime] pid_path`` 사용자 override가 적용돼야 한다."""
+    (tmp_path / "system.toml").write_text(
+        '[runtime]\npid_path = "custom/x.pid"\n', encoding="utf-8"
+    )
+
+    config = Config.load(config_dir=tmp_path)
+
+    assert config.runtime_pid_path() == tmp_path / "custom" / "x.pid"
+
+
+def test_runtime_paths_independent_of_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """cwd가 달라져도 같은 ``config_dir``이면 절대 경로가 동일해야 한다."""
+    cwd_a = tmp_path / "cwd_a"
+    cwd_b = tmp_path / "cwd_b"
+    cwd_a.mkdir()
+    cwd_b.mkdir()
+    config_dir = tmp_path / "ante-config"
+    config_dir.mkdir()
+
+    monkeypatch.chdir(cwd_a)
+    pid_a = Config.load(config_dir=config_dir).runtime_pid_path()
+    sock_a = Config.load(config_dir=config_dir).runtime_socket_path()
+
+    monkeypatch.chdir(cwd_b)
+    pid_b = Config.load(config_dir=config_dir).runtime_pid_path()
+    sock_b = Config.load(config_dir=config_dir).runtime_socket_path()
+
+    assert pid_a == pid_b == config_dir / "run" / "ante.pid"
+    assert sock_a == sock_b == config_dir / "run" / "ante.sock"
+
+
+def test_runtime_paths_isolated_per_config_dir(tmp_path: Path) -> None:
+    """서로 다른 ``config_dir``은 서로 다른 PID/socket 경로를 반환해야 한다."""
+    cfg_a = tmp_path / "a"
+    cfg_b = tmp_path / "b"
+    cfg_a.mkdir()
+    cfg_b.mkdir()
+
+    pid_a = Config.load(config_dir=cfg_a).runtime_pid_path()
+    pid_b = Config.load(config_dir=cfg_b).runtime_pid_path()
+    sock_a = Config.load(config_dir=cfg_a).runtime_socket_path()
+    sock_b = Config.load(config_dir=cfg_b).runtime_socket_path()
+
+    assert pid_a != pid_b
+    assert sock_a != sock_b
+
+
+# ── Task 2: main.py PID 회귀 ─────────────────────────────────────
+
+
+def test_main_pid_file_uses_runtime_pid_path(tmp_path: Path) -> None:
+    """``_write_pid_file(config)``이 ``<config_dir>/run/ante.pid``에 기록해야 한다."""
+    from ante.main import _remove_pid_file, _write_pid_file
+
+    config = Config.load(config_dir=tmp_path)
+    expected = tmp_path / "run" / "ante.pid"
+
+    try:
+        _write_pid_file(config)
+        assert expected.exists()
+        assert expected.read_text().strip() == str(os.getpid())
+    finally:
+        _remove_pid_file(config)
+        assert not expected.exists()
+
+
+def test_main_pid_file_independent_of_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """cwd를 바꿔도 PID 파일은 ``config_dir`` 기준 canonical 위치에 기록되어야 한다."""
+    from ante.main import _remove_pid_file, _write_pid_file
+
+    config_dir = tmp_path / "ante-config"
+    config_dir.mkdir()
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    monkeypatch.chdir(other)
+
+    config = Config.load(config_dir=config_dir)
+    expected = config_dir / "run" / "ante.pid"
+
+    try:
+        _write_pid_file(config)
+        assert expected.exists()
+        # cwd-relative legacy 경로에는 파일이 없어야 한다
+        assert not (other / "db" / "ante.pid").exists()
+    finally:
+        _remove_pid_file(config)
+
+
+def test_read_pid_file_zero_arg_uses_canonical_resolver(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """0-arg form: ``Config.load().runtime_pid_path()`` canonical을 본다."""
+    from ante.main import read_pid_file
+
+    config_dir = tmp_path / "ante-config"
+    config_dir.mkdir()
+    monkeypatch.setenv("ANTE_CONFIG_DIR", str(config_dir))
+
+    canonical = config_dir / "run" / "ante.pid"
+    canonical.parent.mkdir(parents=True, exist_ok=True)
+    canonical.write_text("12345")
+
+    assert read_pid_file() == 12345
+
+
+def test_read_pid_file_legacy_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """canonical 부재 + legacy ``db/ante.pid`` 존재 → legacy 읽고 warning."""
+    from ante.main import read_pid_file
+
+    config_dir = tmp_path / "ante-config"
+    config_dir.mkdir()
+    cwd = tmp_path / "workdir"
+    cwd.mkdir()
+    monkeypatch.setenv("ANTE_CONFIG_DIR", str(config_dir))
+    monkeypatch.chdir(cwd)
+
+    # canonical 부재 — 만들지 않는다
+    canonical = config_dir / "run" / "ante.pid"
+    assert not canonical.exists()
+
+    # legacy 존재
+    legacy = cwd / "db" / "ante.pid"
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text("9999")
+
+    with caplog.at_level(logging.WARNING, logger="ante.main"):
+        result = read_pid_file()
+
+    assert result == 9999
+    assert any("legacy" in rec.message.lower() for rec in caplog.records)
+
+
+# ── Task 4: ipc_helpers 회귀 ─────────────────────────────────────
+
+
+def test_get_socket_path_uses_runtime_socket_path(tmp_path: Path) -> None:
+    """``get_socket_path(config_dir=...)`` == ``<config_dir>/run/ante.sock``."""
+    from ante.cli.commands.ipc_helpers import get_socket_path
+
+    expected = tmp_path / "run" / "ante.sock"
+    assert get_socket_path(config_dir=tmp_path) == str(expected)
+
+
+def test_get_socket_path_isolated_from_db_path_parent(tmp_path: Path) -> None:
+    """``db.path``와 무관하게 socket은 ``runtime.socket_path``로만 결정된다."""
+    from ante.cli.commands.ipc_helpers import get_socket_path
+
+    (tmp_path / "system.toml").write_text(
+        '[db]\npath = "custom_db/x.db"\n\n[runtime]\nsocket_path = "run/ante.sock"\n',
+        encoding="utf-8",
+    )
+
+    expected = tmp_path / "run" / "ante.sock"
+    assert get_socket_path(config_dir=tmp_path) == str(expected)
+
+
+# ── Task 6: cold-path guard cwd 독립성 ───────────────────────────
+
+
+def test_account_cold_path_guard_uses_runtime_resolver_under_chdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """cwd 이동 후에도 cold-path guard가 ``config_dir`` 기준 socket을 본다."""
+    from ante.cli.commands.account import _assert_no_active_runtime
+    from ante.cli.formatter import OutputFormatter
+
+    tmp_config = tmp_path / "ante-config"
+    tmp_config.mkdir()
+    monkeypatch.setenv("ANTE_CONFIG_DIR", str(tmp_config))
+
+    tmp_other = tmp_path / "elsewhere"
+    tmp_other.mkdir()
+    monkeypatch.chdir(tmp_other)
+
+    # config_dir 기준 socket이 존재 → active runtime 표식
+    (tmp_config / "run").mkdir()
+    (tmp_config / "run" / "ante.sock").touch()
+
+    # 현재 cwd(tmp_other)에는 run/ante.sock 없음 → guard가 cwd 무관임을 입증
+    assert not (tmp_other / "run" / "ante.sock").exists()
+
+    fmt = OutputFormatter(fmt="text")
+
+    with patch("ante.main.read_pid_file", return_value=os.getpid()):
+        with pytest.raises(SystemExit) as exc_info:
+            _assert_no_active_runtime(fmt)
+
+    assert exc_info.value.code == 1

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -152,13 +152,20 @@ def test_read_pid_file_zero_arg_uses_canonical_resolver(
     assert read_pid_file() == 12345
 
 
-def test_read_pid_file_legacy_fallback(
+def test_read_pid_file_returns_none_when_only_legacy_pid_present(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """canonical 부재 + legacy ``db/ante.pid`` 존재 → legacy 읽고 warning."""
-    from ante import main as main_mod
+    """canonical 부재 + legacy ``db/ante.pid``만 존재 → None, warning 없음.
+
+    Refs #1157, docs/specs/config/03-design-decisions.md (1.0 단일 active
+    runtime 정책). 1.0 single-canonical resolver 모델에서 legacy cwd-relative
+    read-fallback은 비대칭이므로 cutover로 제거되었다. 본 테스트는 그 회귀를
+    보호한다 — 새 ``read_pid_file``은 canonical만 보고, legacy는 무시하며,
+    deprecation warning도 emit하지 않는다. (legacy unlink는 ``_remove_pid_file``
+    이 별도로 책임진다.)
+    """
     from ante.main import read_pid_file
 
     config_dir = tmp_path / "ante-config"
@@ -168,16 +175,11 @@ def test_read_pid_file_legacy_fallback(
     monkeypatch.setenv("ANTE_CONFIG_DIR", str(config_dir))
     monkeypatch.chdir(cwd)
 
-    # 다른 테스트가 이미 deprecation warning을 1회 emit했을 수 있으므로
-    # 본 테스트 진입 시점에 모듈 가드를 명시적으로 reset한다 (Refs #1157,
-    # plan v3 권고: 1회 emit 전제이므로 테스트 격리만 위해 reset).
-    monkeypatch.setattr(main_mod, "_legacy_pid_warning_emitted", False)
-
     # canonical 부재 — 만들지 않는다
     canonical = config_dir / "run" / "ante.pid"
     assert not canonical.exists()
 
-    # legacy 존재
+    # legacy 존재 (cwd 기준 ``db/ante.pid``)
     legacy = cwd / "db" / "ante.pid"
     legacy.parent.mkdir(parents=True, exist_ok=True)
     legacy.write_text("9999")
@@ -185,16 +187,11 @@ def test_read_pid_file_legacy_fallback(
     with caplog.at_level(logging.WARNING, logger="ante.main"):
         result = read_pid_file()
 
-    assert result == 9999
+    # legacy 무시 → None 반환
+    assert result is None
+    # ``ante.main`` logger에서 legacy 관련 warning이 한 건도 emit되지 않아야 한다
     main_records = [rec for rec in caplog.records if rec.name == "ante.main"]
-    assert any("legacy" in rec.message.lower() for rec in main_records)
-    # 두 번째 호출에서는 warning이 emit되지 않는다 (1회 emit 가드 회귀)
-    caplog.clear()
-    with caplog.at_level(logging.WARNING, logger="ante.main"):
-        second = read_pid_file()
-    assert second == 9999
-    main_records_2 = [rec for rec in caplog.records if rec.name == "ante.main"]
-    assert not any("legacy" in rec.message.lower() for rec in main_records_2)
+    assert not any("legacy" in rec.message.lower() for rec in main_records)
 
 
 # ── Task 4: ipc_helpers 회귀 ─────────────────────────────────────

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -158,6 +158,7 @@ def test_read_pid_file_legacy_fallback(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """canonical 부재 + legacy ``db/ante.pid`` 존재 → legacy 읽고 warning."""
+    from ante import main as main_mod
     from ante.main import read_pid_file
 
     config_dir = tmp_path / "ante-config"
@@ -166,6 +167,11 @@ def test_read_pid_file_legacy_fallback(
     cwd.mkdir()
     monkeypatch.setenv("ANTE_CONFIG_DIR", str(config_dir))
     monkeypatch.chdir(cwd)
+
+    # 다른 테스트가 이미 deprecation warning을 1회 emit했을 수 있으므로
+    # 본 테스트 진입 시점에 모듈 가드를 명시적으로 reset한다 (Refs #1157,
+    # plan v3 권고: 1회 emit 전제이므로 테스트 격리만 위해 reset).
+    monkeypatch.setattr(main_mod, "_legacy_pid_warning_emitted", False)
 
     # canonical 부재 — 만들지 않는다
     canonical = config_dir / "run" / "ante.pid"
@@ -180,7 +186,15 @@ def test_read_pid_file_legacy_fallback(
         result = read_pid_file()
 
     assert result == 9999
-    assert any("legacy" in rec.message.lower() for rec in caplog.records)
+    main_records = [rec for rec in caplog.records if rec.name == "ante.main"]
+    assert any("legacy" in rec.message.lower() for rec in main_records)
+    # 두 번째 호출에서는 warning이 emit되지 않는다 (1회 emit 가드 회귀)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="ante.main"):
+        second = read_pid_file()
+    assert second == 9999
+    main_records_2 = [rec for rec in caplog.records if rec.name == "ante.main"]
+    assert not any("legacy" in rec.message.lower() for rec in main_records_2)
 
 
 # ── Task 4: ipc_helpers 회귀 ─────────────────────────────────────

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -253,3 +253,192 @@ def test_account_cold_path_guard_uses_runtime_resolver_under_chdir(
             _assert_no_active_runtime(fmt)
 
     assert exc_info.value.code == 1
+
+
+# ── Codex attempt 1 P1 회귀: --config-dir 경로 PID 격리 ─────────────
+#
+# `read_pid_file()` 0-arg 분기는 `Config.load()` → `resolve_config_dir(None)` →
+# env `ANTE_CONFIG_DIR` 또는 default를 본다. CLI 호출부가 ctx의 `--config-dir A`를
+# env에 주입하지 않은 채 0-arg로 호출하면, A가 아니라 default config_dir의 PID를
+# 본다. 결과:
+#   - `system stop`: A의 server PID를 못 찾음 → 잘못된 PID_NOT_FOUND
+#   - account cold-path guard: A의 alive server를 누락 → split-brain mutation 허용
+#   - update.check_server_running: A의 server를 못 찾음 → server 중에 update 진행
+#
+# 아래 3개 테스트는 default와 다른 ``config_dir`` A를 ``--config-dir``로 명시해
+# 호출했을 때, 각 가드가 *A* 의 canonical PID 파일을 정확히 보는지 검증한다.
+# `ante.main.read_pid_file`을 monkeypatch하지 않고 실제 파일을 통해 검증하므로,
+# CLI 호출부가 명시적 ``Config``를 전달하지 않으면 이 테스트가 깨진다 (attempt 1
+# 재현). 호출부 수정 후에는 GREEN.
+
+
+def test_system_start_uses_explicit_config_dir_pid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``system start``가 ``--config-dir`` A의 canonical PID를 본다.
+
+    Attempt 1 P1 finding 재현: A에 alive PID가 있고 default config_dir에는
+    PID 파일이 없는 환경에서, ``ante --config-dir A system start``가 default를
+    봐 A의 server를 누락하면 ``ALREADY_RUNNING`` 차단을 우회해 중복 실행
+    위험이 발생한다. 명시적 ``Config`` 전달 후에는 A를 정확히 보고 차단해야
+    한다.
+    """
+    from click.testing import CliRunner
+
+    from ante.cli.main import cli
+    from ante.member.models import Member, MemberRole, MemberType
+
+    mock_master = Member(
+        member_id="test-master",
+        type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+        org="default",
+        name="Test Master",
+        status="active",
+        scopes=[],
+    )
+
+    cfg_a = tmp_path / "config-a"
+    cfg_a.mkdir()
+    cfg_default = tmp_path / "default-config"
+    cfg_default.mkdir()
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+
+    # default와 다른 경로
+    monkeypatch.setenv("ANTE_CONFIG_DIR", str(cfg_default))
+    monkeypatch.chdir(cwd)
+
+    # A에 alive PID (self pid). default에는 PID 없음.
+    (cfg_a / "run").mkdir()
+    (cfg_a / "run" / "ante.pid").write_text(str(os.getpid()))
+    assert not (cfg_default / "run" / "ante.pid").exists()
+
+    runner = CliRunner()
+    # 인증 우회: ``authenticate_member``를 mock해 master 멤버를 ctx.obj에 주입.
+    with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+        def _set_member(ctx) -> None:  # type: ignore[no-untyped-def]
+            ctx.ensure_object(dict)
+            ctx.obj["member"] = mock_master
+
+        mock_auth.side_effect = _set_member
+
+        # _is_process_alive는 self pid에 대해 True를 반환해야 한다 (alive PID).
+        # subprocess.run이 호출되면 안 된다 — ALREADY_RUNNING으로 차단되어야 함.
+        with patch(
+            "ante.cli.commands.system._is_process_alive", return_value=True
+        ) as mock_alive:
+            with patch("ante.cli.commands.system.subprocess.run") as mock_subprocess:
+                result = runner.invoke(
+                    cli,
+                    ["--config-dir", str(cfg_a), "system", "start"],
+                    catch_exceptions=False,
+                )
+
+    # 명시 전달이 안 되어 default를 보면 PID 파일 부재로 ALREADY_RUNNING이
+    # 발동하지 않고 subprocess가 실행된다 (중복 실행 위험).
+    assert result.exit_code == 1, (
+        f"start가 A의 alive PID를 무시하고 진행함 (중복 실행 위험). "
+        f"exit_code={result.exit_code}, output={result.output!r}"
+    )
+    assert "ALREADY_RUNNING" in result.output or "이미 실행 중" in result.output, (
+        f"start가 default config_dir만 봐 A의 alive PID를 누락 — "
+        f"중복 실행 차단 실패. output={result.output!r}"
+    )
+    mock_subprocess.assert_not_called()
+    mock_alive.assert_called_with(os.getpid())
+
+
+def test_account_cold_path_guard_uses_explicit_config_dir_pid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """cold-path guard가 ``--config-dir`` A의 canonical PID/socket을 본다.
+
+    A에 alive PID + socket 둘 다 있고 default에는 둘 다 없을 때, cold-path
+    guard는 A 기준으로 active runtime을 감지해 차단해야 한다.
+    """
+    import click
+
+    from ante.cli.commands.account import _assert_no_active_runtime
+    from ante.cli.formatter import OutputFormatter
+
+    cfg_a = tmp_path / "config-a"
+    cfg_a.mkdir()
+    cfg_default = tmp_path / "default-config"
+    cfg_default.mkdir()
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+
+    monkeypatch.setenv("ANTE_CONFIG_DIR", str(cfg_default))
+    monkeypatch.chdir(cwd)
+
+    # A: alive PID + socket
+    (cfg_a / "run").mkdir()
+    (cfg_a / "run" / "ante.pid").write_text(str(os.getpid()))
+    (cfg_a / "run" / "ante.sock").touch()
+
+    # default: 비어 있음
+    assert not (cfg_default / "run" / "ante.pid").exists()
+    assert not (cfg_default / "run" / "ante.sock").exists()
+
+    fmt = OutputFormatter(fmt="text")
+
+    # ctx.obj["config_dir"]에 A를 넣어 get_config_dir()이 A를 반환하도록 한다.
+    @click.command()
+    def _runner() -> None:
+        _assert_no_active_runtime(fmt)
+
+    runner_ctx = click.Context(_runner, obj={"config_dir": cfg_a})
+    with runner_ctx:
+        with pytest.raises(SystemExit) as exc_info:
+            _assert_no_active_runtime(fmt)
+
+    assert exc_info.value.code == 1, (
+        f"cold-path guard가 A의 active runtime을 감지하지 못했다 — "
+        f"default config_dir만 본 것. exit_code={exc_info.value.code}"
+    )
+
+
+def test_update_check_server_running_uses_explicit_config_dir_pid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``update.check_server_running``이 ``--config-dir`` A의 PID를 본다.
+
+    A에 alive PID가 있고 default에는 없을 때 ``check_server_running()``이
+    True를 반환해야 한다. default를 보면 False가 되어 update가 server
+    실행 중에 진행될 수 있다.
+    """
+    import click
+
+    from ante.cli.commands.update import check_server_running
+
+    cfg_a = tmp_path / "config-a"
+    cfg_a.mkdir()
+    cfg_default = tmp_path / "default-config"
+    cfg_default.mkdir()
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+
+    monkeypatch.setenv("ANTE_CONFIG_DIR", str(cfg_default))
+    monkeypatch.chdir(cwd)
+
+    # A: alive PID (self pid)
+    (cfg_a / "run").mkdir()
+    (cfg_a / "run" / "ante.pid").write_text(str(os.getpid()))
+
+    # default: 비어 있음
+    assert not (cfg_default / "run" / "ante.pid").exists()
+
+    @click.command()
+    def _runner() -> None:
+        pass
+
+    runner_ctx = click.Context(_runner, obj={"config_dir": cfg_a})
+    with runner_ctx:
+        result = check_server_running()
+
+    assert result is True, (
+        "update.check_server_running이 A의 alive PID를 감지하지 못했다 — "
+        "default config_dir만 본 것."
+    )


### PR DESCRIPTION
Closes #1157

## Summary

`runtime.pid_path` / `runtime.socket_path` resolver를 1.0 단일 active runtime + `config_dir`-relative 경로 계약에 맞춰 도입. `<config_dir>/run/ante.pid` / `<config_dir>/run/ante.sock`을 canonical로 단일화하고 server runtime + IPC client + cold-path CLI guard + `system start/stop` + `update`가 모두 동일 resolver를 통해 같은 instance를 본다.

본 PR은 #1158(`Config.resolve_path` + `__init__(config_dir=)`) 후속 — #1158이 도입한 공통 resolver 위에 `runtime_pid_path()` / `runtime_socket_path()` 편의 메서드와 PID/socket 마이그레이션을 얹는다.

### 주요 변경

- **`src/ante/config/defaults.py`**: `runtime.pid_path = \"run/ante.pid\"`, `runtime.socket_path = \"run/ante.sock\"` 두 키 추가.
- **`src/ante/config/config.py`**: `runtime_pid_path()` / `runtime_socket_path()` 편의 메서드 추가 (`Config.resolve_path` 위에 얇게 얹음).
- **`src/ante/main.py`**:
  - `PID_FILE = Path(\"db/ante.pid\")` 모듈 상수 제거.
  - `_write_pid_file(config: Config)` — canonical에만 기록.
  - `_remove_pid_file(config: Config)` — canonical + `_LEGACY_PID_FALLBACK` 양쪽 unlink (transitional cleanup).
  - `read_pid_file(config: Config | None = None)` — **canonical만** 본다. legacy read-fallback 제거 (메타 리뷰 Option 1).
  - `_init_ipc` — `socket_path = str(s.config.runtime_socket_path())`.
- **`src/ante/cli/commands/system.py`**: `start`/`stop`이 `Config.load(config_dir=ctx)` 명시 생성 후 `read_pid_file(config)` / `_remove_pid_file(config)` 전달. PID 미존재 메시지에 resolver 결과 경로 포함. stale legacy 정리는 `_remove_pid_file`에 위임.
- **`src/ante/cli/commands/account.py:_assert_no_active_runtime`**: 명시 `Config.load(config_dir=get_config_dir())`로 `read_pid_file(config)` + `get_socket_path(config_dir=config_dir)` 동일 디렉토리 전파.
- **`src/ante/cli/commands/update.py:check_server_running`**: 같은 패턴 명시 Config 전달.
- **`src/ante/cli/commands/ipc_helpers.py:get_socket_path`**: 내부 `Config.load(config_dir).runtime_socket_path()` 위임. 시그니처/리턴 보존.
- **`src/ante/cli/commands/init.py`**: `SYSTEM_TOML_TEMPLATE`에 `[runtime] pid_path = \"run/ante.pid\"\nsocket_path = \"run/ante.sock\"` 섹션 추가.
- **`docs/specs/config/03-design-decisions.md`**: 1.0 single active runtime 정책 섹션에 \"single-canonical cutover\" 명시 (legacy read-fallback 미도입, 업그레이드는 `ante system stop` 후 PR 적용을 표준 시나리오).
- **신규 회귀 테스트** (`tests/unit/test_runtime_paths.py`, 18개):
  - config resolver: default/override/cwd-independent/config_dir-isolated (5)
  - main PID: canonical 기록 / cwd-independent / 0-arg canonical 라우팅 / legacy 무시 (4)
  - ipc_helpers socket: resolver 사용 / db.path-부모와 분리 (2)
  - **CLI 호출부 명시 Config 전달 회귀** (attempt 1 P1 fix): system.start / account.cold-path-guard / update.check_server_running 각각 explicit `--config-dir` PID 정확 사용 (3)
  - cold-path guard cwd 독립성 (chdir + setenv) (1)
  - canonical 부재 + legacy 존재 → None 반환, warning 없음 (Option 1 fix) (1)
  - SYSTEM_TOML_TEMPLATE [runtime] 섹션 / 기존 config_dir default fallback (2)
- **추가 회귀 보강** (`tests/unit/test_cli_system.py`): legacy stale cleanup + remove_pid_file 양쪽 unlink 단위 회귀.

### 메타 리뷰 결정 (Option 1: legacy read-fallback 제거)

attempt 2가 같은 risk class(`lifecycle/PID-locality`) 2회 반복으로 FAIL — `@code-reviewer` 메타 리뷰가 plan v3의 \"1릴리스 read-fallback\" 도입이 single-canonical resolver 모델과 비대칭한 plan-level 미세 결함이라고 판정. **Option 1 권고: legacy read-fallback 완전 제거, `_remove_pid_file`의 legacy unlink는 transitional cleanup 목적으로 유지**.

근거:
- 1.0 single active runtime + `config_dir` canonical 모델과 정합하는 유일한 옵션
- attempt 2 P1×2(`main.py:93-95` cwd-relative legacy + `account.py:80-82` legacy PID + canonical socket 짝짓기 누락) **동시에 자연 소거** — `read_pid_file()`이 더 이상 legacy PID 반환 안 함
- 표준 업그레이드 시나리오(`ante system stop` → PR 적용 → restart)에서 legacy PID는 이미 unlink. 비표준 SIGKILL 잔존만 1회 PID_NOT_FOUND로 회복

이 결정으로 plan v3 Non-Goals의 \"다음 릴리스 cleanup 후속 이슈\" 자체가 제거됨.

## Test Plan

- [x] `ruff check src/ tests/` — All checks passed
- [x] `ruff format --check src/ tests/` — 423 files already formatted
- [x] `pytest tests/unit -x -q` — **3405 passed, 2 skipped**
- [x] 신규 회귀 18개 + `test_cli_system.py` 보강 GREEN
- [x] 정합 grep:
  - `git grep \"PID_FILE\" src/ante/` → 0건 (제거)
  - `git grep \"_legacy_pid_warning_emitted\" src/ante/` → 0건 (제거)
  - `git grep \"_LEGACY_PID_FALLBACK\" src/ante/main.py` → `_remove_pid_file`에서만 사용 (line 37 정의 + line 63 사용)
  - `git grep \"Path(db_path).parent / 'ante.sock'\" src/ante/` → 0건
- [x] Codex 브랜치 리뷰 `/codex:review --base main` — attempt 3 **PASS** (\"명확한 정확성·안전성 회귀 없음\")
- [x] `@code-reviewer` 메타 리뷰: Option 1 권고 + plan-level 결함 정리

## Refs

- 선행: #1139 (CLOSED) — 1.0 single active runtime 정책
- 선행: #1158 (CLOSED, PR #1181) — `Config.resolve_path` + `__init__(config_dir=)` 도입
- Spec: `docs/specs/config/03-design-decisions.md` ([runtime] 섹션 + cutover 명시), `docs/specs/cli/02-design-decisions.md:62-70`, `docs/specs/cli/03-commands.md:300-302`, `docs/specs/ipc/ipc.md:181-183`
- Plan-preflight: done (Codex Plan Review v1: revise → v2: revise → v3: approve-implement)
- 메타 리뷰: plan v3 \"1릴리스 read-fallback\" 항목 제거 권고, single-canonical cutover로 plan-level scope 좁힘
- 부모 에픽: #1142 [chore] 스펙 재정비 후속 이슈 그래프