### PR TITLE
fix(ipc,main): close cold-path race window via 3-phase IPC shutdown ordering (#1159)

### DIFF
--- a/src/ante/ipc/server.py
+++ b/src/ante/ipc/server.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import sys
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -46,7 +47,30 @@ class IPCServer:
         return self._socket_path
 
     async def start(self) -> None:
-        """서버 시작. 기존 소켓 파일이 있으면 삭제 후 재생성."""
+        """서버 시작. 기존 소켓 파일이 있으면 삭제 후 재생성.
+
+        Refs #1159: socket 파일 lifecycle은 ``unlink_socket()``이 단독으로
+        책임진다 — cold-path guard가 shutdown 동안 'PID alive AND socket
+        exists'로 active runtime을 판정해야 race window를 회피할 수 있기
+        때문이다.
+
+        Python 버전별 동작 차이:
+
+        * **Python 3.11 / 3.12**: ``loop.create_unix_server``는 ``server.close()``
+          시 socket 파일을 자동으로 unlink하지 **않는다** (해당 동작 자체가
+          stdlib에 없다). 따라서 별도 옵션 없이도 본 모듈의 lifecycle 가정이
+          성립한다.
+        * **Python 3.13+**: ``loop.create_unix_server``에 ``cleanup_socket``
+          인자가 추가되었고 **기본값이 ``True``** 이다 — 즉 ``server.close()``
+          가 socket 파일을 자동으로 unlink하므로 race window 회귀가 깨진다.
+          이를 막기 위해 3.13+에서만 ``cleanup_socket=False``를 명시적으로
+          전달한다.
+
+        ``cleanup_socket`` 인자를 무조건 전달하면 3.11/3.12에서
+        ``TypeError: create_unix_server() got an unexpected keyword argument
+        'cleanup_socket'`` 으로 부팅이 실패한다 (#1159 attempt 1 회귀). 따라서
+        ``sys.version_info`` 분기로 3.13+에서만 인자를 추가한다.
+        """
         path = Path(self._socket_path)
         path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -54,14 +78,13 @@ class IPCServer:
         if path.exists():
             path.unlink()
 
-        # Refs #1159: cleanup_socket=False로 server.close() 시 asyncio가
-        # 소켓 파일을 unlink하지 않도록 한다. cold-path guard가 shutdown 동안
-        # 'PID alive AND socket exists'로 active runtime을 판정하므로,
-        # socket 파일 lifecycle은 IPCServer.unlink_socket()이 단독 책임진다.
+        kwargs: dict[str, object] = {"path": self._socket_path}
+        if sys.version_info >= (3, 13):
+            kwargs["cleanup_socket"] = False
+
         self._server = await asyncio.start_unix_server(
             self._handle_connection,
-            path=self._socket_path,
-            cleanup_socket=False,
+            **kwargs,
         )
 
         # 소켓 파일 권한 설정 (소유자만 접근)

--- a/src/ante/ipc/server.py
+++ b/src/ante/ipc/server.py
@@ -36,6 +36,10 @@ class IPCServer:
         self._service_registry = service_registry
         self._command_registry = command_registry
         self._server: asyncio.AbstractServer | None = None
+        # Refs #1159: stop_accepting()이 self._server를 None으로 비워도
+        # drain_connections()이 wait_closed()를 호출할 수 있도록
+        # closing reference를 별도 슬롯에 보존한다.
+        self._closing_server: asyncio.AbstractServer | None = None
 
     @property
     def socket_path(self) -> str:
@@ -50,9 +54,14 @@ class IPCServer:
         if path.exists():
             path.unlink()
 
+        # Refs #1159: cleanup_socket=False로 server.close() 시 asyncio가
+        # 소켓 파일을 unlink하지 않도록 한다. cold-path guard가 shutdown 동안
+        # 'PID alive AND socket exists'로 active runtime을 판정하므로,
+        # socket 파일 lifecycle은 IPCServer.unlink_socket()이 단독 책임진다.
         self._server = await asyncio.start_unix_server(
             self._handle_connection,
             path=self._socket_path,
+            cleanup_socket=False,
         )
 
         # 소켓 파일 권한 설정 (소유자만 접근)
@@ -60,18 +69,58 @@ class IPCServer:
 
         logger.info("IPCServer 시작: %s", self._socket_path)
 
-    async def stop(self) -> None:
-        """서버 종료 및 소켓 파일 삭제."""
-        if self._server:
-            self._server.close()
-            await self._server.wait_closed()
-            self._server = None
+    async def stop_accepting(self) -> None:
+        """새 연결 수락 중지. 소켓 파일과 active 연결은 유지.
 
+        ``asyncio.Server.wait_closed``는 detach된 연결까지 모두 기다리므로
+        ``_handle_connection``이 ``while True`` 루프인 IPCServer에서는 hang
+        위험이 있다 (Refs #1159 Codex Plan v1 [high]). 따라서 본 메서드는
+        ``close()``만 호출하고 wait는 별도 ``drain_connections()``이 담당한다.
+
+        cold-path guard(``PID alive AND socket exists``)가 shutdown 동안에도
+        'active runtime'으로 판정하도록, 소켓 파일은 ``unlink_socket()``이
+        호출되기 전까지 유지된다.
+        """
+        if self._server:
+            # drain_connections에서 wait_closed를 호출할 수 있도록 reference 보존
+            self._closing_server = self._server
+            self._server.close()
+            self._server = None
+        logger.info("IPCServer 새 연결 수락 중지: %s", self._socket_path)
+
+    async def drain_connections(self, timeout: float = 5.0) -> None:
+        """active 연결을 timeout 안에 drain 시도. TimeoutError 삼키고 진행.
+
+        ``stop_accepting()``이 보존한 ``_closing_server`` reference를 사용해
+        ``wait_closed()``를 호출한다. timeout 초과 시 경고 로그를 남기고
+        lifecycle은 계속 진행한다 (강제 종료는 asyncio 루프가 처리).
+        """
+        closing = self._closing_server
+        if closing is None:
+            return
+        try:
+            await asyncio.wait_for(closing.wait_closed(), timeout=timeout)
+        except TimeoutError:
+            logger.warning(
+                "IPCServer drain_connections 타임아웃: %s (%.1fs) — 강제 진행",
+                self._socket_path,
+                timeout,
+            )
+        finally:
+            self._closing_server = None
+
+    def unlink_socket(self) -> None:
+        """소켓 파일 제거. lifecycle 마지막 단계에서 호출."""
         path = Path(self._socket_path)
         if path.exists():
             path.unlink()
+        logger.info("IPCServer 소켓 파일 제거: %s", self._socket_path)
 
-        logger.info("IPCServer 종료: %s", self._socket_path)
+    async def stop(self) -> None:
+        """기존 호출자 호환 facade. listener close → drain → unlink."""
+        await self.stop_accepting()
+        await self.drain_connections()
+        self.unlink_socket()
 
     async def _handle_connection(
         self,

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1382,16 +1382,20 @@ async def _run(s: Services) -> None:
 async def _shutdown(s: Services) -> None:
     """종료 정리 (역순).
 
-    종료 순서:
-    1. Telegram, 스케줄러 태스크 취소
-    2. Web API 종료
-    3. DailyReportScheduler, ReconcileScheduler 종료
-    4. 각 계좌의 Treasury sync 중지
-    5. BotManager 전체 봇 중지
-    6. StreamIntegration 종료
-    7. APIGateway 종료
-    8. 각 계좌의 BrokerAdapter disconnect
-    9. Database 종료
+    종료 순서 (Refs #1159 — cold-path race window 차단):
+    1. 종료 알림(NotificationEvent), Telegram, 스케줄러 태스크 취소
+    2. **IPCServer.stop_accepting()** — 새 IPC 연결 차단, **소켓 파일은 유지**
+    3. Web API 종료
+    4. DailyReportScheduler, ReconcileScheduler 종료
+    5. 각 계좌의 Treasury sync 중지
+    6. BotManager 전체 봇 중지
+    7. StreamIntegration 종료
+    8. APIGateway 종료
+    9. 각 계좌의 BrokerAdapter disconnect
+    10. Database 종료
+    11. **IPCServer.drain_connections() + unlink_socket()** — 소켓 파일 제거.
+        cold-path guard(`PID alive AND socket exists`)가 이 시점부터 'active 아님'
+        판정.
     """
     logger.info("Ante 종료 시작")
 
@@ -1427,6 +1431,13 @@ async def _shutdown(s: Services) -> None:
             pass
         logger.info("결재 만료 스케줄러 종료")
 
+    # Refs #1159: 새 IPC 연결만 차단하고 소켓 파일은 유지한다.
+    # cold-path guard(`PID alive AND socket exists`)가 BotManager/DB 종료 전까지
+    # 'active runtime'으로 판정하도록 unlink_socket()은 lifecycle 마지막에서 호출.
+    if s.ipc_server:
+        await s.ipc_server.stop_accepting()
+        logger.info("IPCServer 새 연결 수락 중지")
+
     if s.web_task and not s.web_task.done():
         s.web_task.cancel()
         try:
@@ -1434,10 +1445,6 @@ async def _shutdown(s: Services) -> None:
         except asyncio.CancelledError:
             pass
         logger.info("Web API 종료")
-
-    if s.ipc_server:
-        await s.ipc_server.stop()
-        logger.info("IPCServer 종료")
 
     if s.daily_report_scheduler:
         await s.daily_report_scheduler.stop()
@@ -1489,6 +1496,15 @@ async def _shutdown(s: Services) -> None:
 
     if s.db:
         await s.db.close()
+
+    # Refs #1159: BotManager/DB 종료 후에야 소켓 파일을 제거한다.
+    # 이로써 cold-path guard는 'PID alive AND socket exists' 동안에는 항상
+    # 봇/DB가 살아있는 active runtime을 정확히 가리킨다.
+    if s.ipc_server:
+        await s.ipc_server.drain_connections(timeout=5.0)
+        s.ipc_server.unlink_socket()
+        logger.info("IPCServer 소켓 파일 제거")
+
     logger.info("Ante 종료 완료")
 
 

--- a/tests/unit/ipc/test_server_client.py
+++ b/tests/unit/ipc/test_server_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -175,3 +176,153 @@ async def test_multiple_requests(
             assert response["result"]["count"] == i + 1
     finally:
         await server.stop()
+
+
+# ── #1159: IPCServer.stop 3-phase 분리 (lifecycle race window 차단) ──
+
+
+@pytest.mark.asyncio
+async def test_stop_accepting_keeps_socket_file(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """stop_accepting()은 listener만 close하고 소켓 파일은 그대로 둔다.
+
+    cold-path guard(`PID alive AND socket exists`)가 shutdown 동안에도
+    'active runtime'으로 판정하도록, 소켓 파일은 BotManager/DB가
+    완전히 종료될 때까지 유지되어야 한다 (Refs #1159).
+    """
+    cmd_registry = CommandRegistry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+    assert Path(socket_path).exists()
+
+    await server.stop_accepting()
+
+    # 소켓 파일은 유지 (cold-path guard가 active로 판정해야 함)
+    assert Path(socket_path).exists()
+    # 새 연결은 더 이상 받지 않음
+    assert server._server is None
+
+    # 정리 — 후속 단계 호출 호환 검증도 겸함
+    await server.drain_connections(timeout=0.1)
+    server.unlink_socket()
+    assert not Path(socket_path).exists()
+
+
+@pytest.mark.asyncio
+async def test_stop_accepting_does_not_block_on_active_connection(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """active 연결이 있어도 stop_accepting()은 hang하지 않는다.
+
+    wait_closed를 호출하지 않아야 한다.
+    `_handle_connection`이 `while True` 루프이므로 `wait_closed`를
+    호출하면 TCP/UDS detach된 연결까지 모두 기다리며 영원히 hang될 수
+    있다. stop_accepting은 listener close만 수행하고, drain은 별도
+    `drain_connections(timeout)`로 수행한다 (Refs #1159 Codex Plan v1 [high]).
+    """
+    cmd_registry = CommandRegistry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+
+    # 클라이언트 연결만 열고 요청은 보내지 않음 — 서버 측 _handle_connection이
+    # 첫 decode에서 대기 상태로 머문다 (active 연결).
+    reader, writer = await asyncio.open_unix_connection(socket_path)
+    try:
+        # 1초 안에 stop_accepting이 완료되어야 한다 — wait_closed 미사용 검증.
+        await asyncio.wait_for(server.stop_accepting(), timeout=1.0)
+        assert server._server is None
+        # active 연결은 socket 닫기 전까지 살아 있어도 OK — 소켓 파일도 유지.
+        assert Path(socket_path).exists()
+    finally:
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+        # 후속 정리 (남은 연결 drain + socket 제거)
+        await server.drain_connections(timeout=0.5)
+        server.unlink_socket()
+
+
+@pytest.mark.asyncio
+async def test_drain_connections_with_timeout(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """drain_connections는 timeout 안에 active 연결이 닫히지 않으면 경고 후 통과한다.
+
+    asyncio.TimeoutError를 raise하지 않고 삼키며, lifecycle은 계속 진행된다.
+    """
+    cmd_registry = CommandRegistry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+
+    # 클라이언트 연결을 잡아 둠 (요청 미전송)
+    reader, writer = await asyncio.open_unix_connection(socket_path)
+    try:
+        await server.stop_accepting()
+        # 짧은 timeout으로 drain — TimeoutError가 외부로 전파되면 안 된다.
+        await server.drain_connections(timeout=0.2)
+        # 호출 자체가 정상 종료됐다는 사실을 검증
+    finally:
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+        server.unlink_socket()
+
+
+@pytest.mark.asyncio
+async def test_unlink_socket_removes_file(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """unlink_socket()은 소켓 파일을 제거한다."""
+    cmd_registry = CommandRegistry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+    assert Path(socket_path).exists()
+
+    await server.stop_accepting()
+    assert Path(socket_path).exists()  # stop_accepting 후에도 유지
+
+    server.unlink_socket()
+    assert not Path(socket_path).exists()
+
+
+@pytest.mark.asyncio
+async def test_stop_facade_runs_all_three_phases(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """기존 stop() 호출자 호환 facade — listener close → drain → unlink."""
+    cmd_registry = CommandRegistry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+    assert Path(socket_path).exists()
+
+    # 호출 추적 wrapper로 3단계가 모두 실행되는지 검증
+    calls: list[str] = []
+    original_stop_accepting = server.stop_accepting
+    original_drain = server.drain_connections
+    original_unlink = server.unlink_socket
+
+    async def tracked_stop_accepting() -> None:
+        calls.append("stop_accepting")
+        await original_stop_accepting()
+
+    async def tracked_drain(timeout: float = 5.0) -> None:
+        calls.append("drain_connections")
+        await original_drain(timeout)
+
+    def tracked_unlink() -> None:
+        calls.append("unlink_socket")
+        original_unlink()
+
+    server.stop_accepting = tracked_stop_accepting  # type: ignore[method-assign]
+    server.drain_connections = tracked_drain  # type: ignore[method-assign]
+    server.unlink_socket = tracked_unlink  # type: ignore[method-assign]
+
+    await server.stop()
+
+    assert calls == ["stop_accepting", "drain_connections", "unlink_socket"]
+    assert not Path(socket_path).exists()

--- a/tests/unit/test_main_shutdown_ordering.py
+++ b/tests/unit/test_main_shutdown_ordering.py
@@ -1,0 +1,243 @@
+"""_shutdown 종료 순서 회귀 테스트 (Refs #1159).
+
+cold-path guard(`PID alive AND socket exists`)가 shutdown 전 구간에서
+'active runtime'으로 판정해야 한다. 본 테스트는 IPCServer.stop_accepting()이
+초기에, IPCServer.unlink_socket()이 BotManager/DB 종료 후 마지막에
+호출되도록 ordering이 보존되는지 검증한다.
+
+모든 테스트는 **실제 Unix 소켓 파일**을 사용한다 — 모킹 없이 race window
+회귀를 직접 노출시키는 것이 목적이다.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from ante.core.registry import ServiceRegistry
+from ante.ipc.registry import CommandRegistry
+from ante.ipc.server import IPCServer
+from ante.main import Services, _shutdown
+
+
+def _make_service_registry() -> ServiceRegistry:
+    return ServiceRegistry(
+        account=MagicMock(),
+        bot_manager=MagicMock(),
+        treasury_manager=MagicMock(),
+        dynamic_config=MagicMock(),
+        approval=MagicMock(),
+        reconciler=MagicMock(),
+        eventbus=MagicMock(),
+    )
+
+
+@pytest.fixture
+def socket_path() -> str:
+    """Unix 소켓 경로 길이 제한(104바이트)을 위해 /tmp 직접 사용."""
+    td = tempfile.mkdtemp(prefix="ipc1159", dir="/tmp")
+    return str(Path(td) / "ante.sock")
+
+
+@pytest.mark.asyncio
+async def test_shutdown_keeps_ipc_socket_alive_until_db_closed(
+    socket_path: str,
+) -> None:
+    """_shutdown은 IPC unlink를 BotManager/DB 종료 후로 미룬다.
+
+    호출 순서: stop_accepting < bot_stop_all < db_close < drain <= unlink_socket.
+    cold-path guard가 'PID alive AND socket exists'를 active 기준으로 사용하므로,
+    socket 파일은 BotManager/DB 종료 완료 시점까지 남아 있어야 한다.
+    """
+    cmd_registry = CommandRegistry()
+    service_registry = _make_service_registry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+
+    events: list[str] = []
+
+    # IPCServer 호출 추적 wrapper
+    original_stop_accepting = server.stop_accepting
+    original_drain = server.drain_connections
+    original_unlink = server.unlink_socket
+
+    async def tracked_stop_accepting() -> None:
+        events.append("ipc_stop_accepting")
+        await original_stop_accepting()
+
+    async def tracked_drain(timeout: float = 5.0) -> None:
+        events.append("ipc_drain")
+        await original_drain(timeout)
+
+    def tracked_unlink() -> None:
+        events.append("ipc_unlink_socket")
+        original_unlink()
+
+    server.stop_accepting = tracked_stop_accepting  # type: ignore[method-assign]
+    server.drain_connections = tracked_drain  # type: ignore[method-assign]
+    server.unlink_socket = tracked_unlink  # type: ignore[method-assign]
+
+    # BotManager stub
+    class _StubBotManager:
+        async def stop_all(self) -> None:
+            events.append("bot_stop_all")
+
+    # Database stub (close만 사용)
+    class _StubDatabase:
+        async def close(self) -> None:
+            events.append("db_close")
+
+    s = Services(
+        ipc_server=server,
+        bot_manager=_StubBotManager(),
+        db=_StubDatabase(),
+    )
+
+    try:
+        await _shutdown(s)
+    finally:
+        # 정리: 만약 unlink_socket이 호출되지 않았다면 강제 정리
+        if Path(socket_path).exists():
+            Path(socket_path).unlink()
+
+    # ordering 검증
+    assert "ipc_stop_accepting" in events, f"events: {events}"
+    assert "bot_stop_all" in events, f"events: {events}"
+    assert "db_close" in events, f"events: {events}"
+    assert "ipc_drain" in events, f"events: {events}"
+    assert "ipc_unlink_socket" in events, f"events: {events}"
+
+    idx_stop_accepting = events.index("ipc_stop_accepting")
+    idx_bot = events.index("bot_stop_all")
+    idx_db = events.index("db_close")
+    idx_drain = events.index("ipc_drain")
+    idx_unlink = events.index("ipc_unlink_socket")
+
+    assert idx_stop_accepting < idx_bot, (
+        f"stop_accepting must happen before bot_stop_all; events={events}"
+    )
+    assert idx_bot < idx_db, (
+        f"bot_stop_all must happen before db_close; events={events}"
+    )
+    assert idx_db < idx_drain, f"db_close must happen before ipc_drain; events={events}"
+    assert idx_drain <= idx_unlink, (
+        f"ipc_drain must happen before/at ipc_unlink_socket; events={events}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_socket_file_present_during_bot_and_db_phase(
+    socket_path: str,
+) -> None:
+    """BotManager.stop_all와 Database.close 실행 시점에 socket 파일이 존재해야 한다.
+
+    cold-path guard가 active로 판정해야 하는 구간이다.
+    """
+    cmd_registry = CommandRegistry()
+    service_registry = _make_service_registry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+
+    bot_stop_socket_present: list[bool] = []
+    db_close_socket_present: list[bool] = []
+
+    class _StubBotManager:
+        async def stop_all(self) -> None:
+            bot_stop_socket_present.append(Path(socket_path).exists())
+
+    class _StubDatabase:
+        async def close(self) -> None:
+            db_close_socket_present.append(Path(socket_path).exists())
+
+    s = Services(
+        ipc_server=server,
+        bot_manager=_StubBotManager(),
+        db=_StubDatabase(),
+    )
+
+    try:
+        await _shutdown(s)
+    finally:
+        if Path(socket_path).exists():
+            Path(socket_path).unlink()
+
+    assert bot_stop_socket_present == [True], (
+        "BotManager.stop_all 시점에 socket 파일이 존재해야 한다 "
+        f"(actual: {bot_stop_socket_present})"
+    )
+    assert db_close_socket_present == [True], (
+        "Database.close 시점에 socket 파일이 존재해야 한다 "
+        f"(actual: {db_close_socket_present})"
+    )
+    assert not Path(socket_path).exists(), (
+        "_shutdown 완료 후에는 socket 파일이 제거되어야 한다"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cold_path_guard_blocks_until_socket_unlinked(
+    socket_path: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """stop_accepting 후에는 cold-path guard가 차단, unlink_socket 후에는 통과.
+
+    Real IPCServer + non-patched `_assert_no_active_runtime` 결합 검증.
+    """
+    cmd_registry = CommandRegistry()
+    service_registry = _make_service_registry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+
+    # cold-path guard가 보는 PID/socket을 우리 server로 가리키게 한다
+    monkeypatch.setattr("ante.main.read_pid_file", lambda config=None: os.getpid())
+    monkeypatch.setattr(
+        "ante.cli.commands.ipc_helpers.get_socket_path",
+        lambda config_dir=None: str(socket_path),
+    )
+
+    from ante.cli.commands.account import _assert_no_active_runtime
+    from ante.cli.formatter import OutputFormatter
+
+    fmt = OutputFormatter(fmt="text")
+
+    # === stop_accepting 호출 후, unlink_socket 전: guard가 차단해야 한다 ===
+    await server.stop_accepting()
+    assert Path(socket_path).exists(), (
+        "stop_accepting 후에도 socket 파일은 유지되어야 한다 (cold-path guard용)"
+    )
+
+    with pytest.raises(SystemExit):
+        _assert_no_active_runtime(fmt)
+
+    # === drain_connections + unlink_socket 후: guard가 통과해야 한다 ===
+    await server.drain_connections(timeout=0.5)
+    server.unlink_socket()
+    assert not Path(socket_path).exists()
+
+    # socket missing → stale PID 판정 → SystemExit 발생 안 함
+    _assert_no_active_runtime(fmt)
+
+
+@pytest.mark.asyncio
+async def test_signal_handler_uses_same_shutdown_path() -> None:
+    """SIGTERM/SIGINT 경로가 동일 _shutdown(s) 진입점을 사용함을 source 레벨에서 확인.
+
+    `test_shutdown_has_timeout_in_run`이 wait_for 패턴을 검증하지만, 본 테스트는
+    ordering 회귀가 SIGTERM/SIGINT 모두에서 보존됨을 명시한다.
+    """
+    import inspect
+
+    from ante import main as main_module
+
+    source = inspect.getsource(main_module._run)
+    # 시그널 핸들러가 SIGTERM/SIGINT 모두에 동일 shutdown_event를 set
+    assert "signal.SIGTERM" in source
+    assert "signal.SIGINT" in source
+    # 단일 진입점 _shutdown(s)
+    assert "_shutdown(s)" in source
+    # asyncio.wait_for로 timeout 감싸기
+    assert "asyncio.wait_for(_shutdown(s)" in source


### PR DESCRIPTION
Closes #1159

## Summary

ante 서버 종료 시 IPC socket unlink가 BotManager/DB close보다 먼저 수행되어 cold-path guard(`PID alive AND socket exists`)가 잘못 \"stale PID\" 판정을 내리던 race window를 닫는다. cold-path 명령(`account create/delete/set-credentials`)이 종료 중 서버의 DB와 충돌하던 race window 제거.

### 주요 변경

- **`src/ante/ipc/server.py`**: `IPCServer.stop()`을 3-phase로 분리:
  - `stop_accepting()` — 리스너 close만, socket 파일과 active 연결 유지. **`wait_closed` 미호출** (hang 위험 회피).
  - `drain_connections(timeout=5.0)` — `_closing_server` reference로 `wait_closed`를 timeout-bounded 호출. TimeoutError 삼키고 진행.
  - `unlink_socket()` — socket 파일 제거. lifecycle 마지막 단계.
  - `stop()`은 위 3 단계 facade로 보존 (외부 호출자 호환).
- **Python 호환성** (attempt 1 fix): `cleanup_socket=False`는 Python 3.13+ 인자이므로 version-conditional 적용. 3.11/3.12에서는 인자 미전달, 3.13에서는 명시 (자동 unlink 회피로 race window 일관 보존).
- **`src/ante/main.py:_shutdown`**: IPC ordering 재정렬:
  - 초기: `stop_accepting()` (새 연결 차단, socket 파일 유지)
  - BotManager `stop_all` → DB `close` (그대로)
  - 마지막: `drain_connections(timeout=5.0)` + `unlink_socket()`
- **신규 회귀 테스트**:
  - `tests/unit/ipc/test_server_client.py`: 5개 (real socket file 사용) — `stop_accepting_keeps_socket_file`, `stop_accepting_does_not_block_on_active_connection`, `drain_connections_with_timeout`, `unlink_socket_removes_file`, `stop_facade_runs_all_three_phases`
  - `tests/unit/test_main_shutdown_ordering.py` (신규): 4개 — events 순서 / socket 파일 lifetime / 신호 핸들링 / **cold-path guard 결합** (`_assert_no_active_runtime` patch 없이 직접 호출, stop_accepting 후 차단 → unlink_socket 후 통과 회귀)

### Scope guard (IPC client mutation race는 본 PR 범위 외)

shutdown 중 이미 활성화된 IPC 연결이 `account.suspend/activate`, `bot.create/remove`, `treasury.allocate`, `config.set`, approval mutation 등 mutating 핸들러를 호출하면 BotManager/DB shutdown과 경합하는 별개 race가 존재한다. 본 PR이 닫는 cold-path race(CLI 직접 DB mutation)와 race 도메인·차단 메커니즘·영향 호출자가 모두 다르며, 이슈 #1159 plan v2 Non-Goals 및 Stop Conditions에 명시적으로 후속 이슈로 분리되어 있다 (Codex Plan Review v1·v2 모두 split 합의).

Codex 브랜치 리뷰 attempt 2가 이 영역을 P2로 지적했으나, plan v2가 `approve-implement`로 명시한 경계 안 영역만 본 PR에서 처리한다. 메타 리뷰(`@code-reviewer`)가 plan 편차 PASS + Option A를 권고하여 plan 게이트를 상위로 둠.

### Codex review trail

- attempt 1: FAIL (P1 호환성 — `cleanup_socket=False`가 Python 3.13+ only) → version-conditional 적용 fix
- attempt 2: FAIL (P2 — IPC client mutation race) → 메타 리뷰 Option A: plan v2 Non-Goals 영역, 후속 이슈로 분리

### 후속 이슈 권고

본 PR 머지 직후 신규 이슈 등록 권고: \"IPCServer가 shutdown 중 mutating 명령을 503/SERVICE_UNAVAILABLE로 거부하지 않아 in-flight mutation race window 존재\". (plan v2의 \"#1160(가칭)\" 자리는 이미 다른 이슈[`#1160 ante startup ordering`]에 점유되어 있어 새 번호로 등록 필요.) 본 PR이 도입한 3-phase 분리가 후속 이슈의 lifecycle state 정의 base.

## Test Plan

- [x] `ruff check src/ tests/` — All checks passed
- [x] `ruff format --check src/ tests/` — 424 files already formatted
- [x] `pytest tests/unit -x -q` — **3414 passed, 2 skipped**
- [x] 신규 회귀 9개 GREEN: IPC 5개 (real socket) + main shutdown ordering 4개 (cold-path guard 결합 포함)
- [x] 정합 grep:
  - `git grep \"ipc_server.stop()\" src/ante/main.py` → 0건 (분리)
  - `git grep -E \"s\\.ipc_server\\.(stop_accepting|drain_connections|unlink_socket)\" src/ante/main.py` → 3 위치 (1438 stop_accepting, 1504 drain, 1505 unlink_socket)
  - `git grep -E \"await.*\\.wait_closed\\(\\)\" src/ante/ipc/server.py` → drain_connections 1건만 (`stop_accepting`엔 없음 — hang 회피 입증)
- [x] Codex 브랜치 리뷰 trail: attempt 1 (P1 fix) → attempt 2 (P2, plan Non-Goals — Option A) → 메타 리뷰 PASS

## Refs

- 선행: #1139 (CLOSED) — cold-path guard 도입 (`_assert_no_active_runtime`)
- 선행: #1157 (CLOSED, PR #1182) — runtime path canonical resolver. 본 PR `unlink_socket()`이 사용하는 socket 경로는 `Config.runtime_socket_path()` 결과 그대로
- 후속 (본 PR 머지 후 신규 등록 권고): IPC client mutation race 거부 메커니즘
- Spec: `docs/specs/cli/03-commands.md:117-118`, `docs/specs/account/09-cli.md:49-54`, `docs/specs/ipc/ipc.md`, `docs/specs/config/03-design-decisions.md:194-196` (1.0 단일 active runtime 정책)
- Plan-preflight: done (Codex Plan Review v1: revise → v2: approve-implement, narrow-scope)
- 메타 리뷰: plan 편차 PASS + Option A (mutation race는 후속 이슈로 분리)
- 부모 에픽: #1142 [chore] 스펙 재정비 후속 이슈 그래프