### PR TITLE
fix(ipc): reject shutdown-time mutating dispatch

### DIFF
--- a/docs/specs/ipc/ipc.md
+++ b/docs/specs/ipc/ipc.md
@@ -191,11 +191,13 @@ IPCServer는 shutdown 중 활성 IPC connection이 새 mutating 명령을 dispat
 |------|-----------|------------------|
 | `RUNNING` | `start()`가 Unix socket listener와 파일 권한 설정을 완료한 직후 | 모든 등록 명령을 정상 dispatch |
 | `SHUTTING_DOWN` | `stop_accepting()` 진입 직후, listener `close()` 호출 전 | mutating 명령은 `SERVICE_UNAVAILABLE`로 거부, read-only 명령은 통과 |
+| `DRAINING` | `_shutdown()`이 BrokerAdapter disconnect/DB close 같은 리소스 종료에 들어가기 직전, 또는 `stop()` facade가 drain을 시작하기 직전 | mutating/read-only를 포함한 모든 명령을 `SERVICE_UNAVAILABLE`로 거부 |
 | `STOPPED` | `unlink_socket()` 종료 시점 | mutating/read-only를 포함한 모든 명령을 `SERVICE_UNAVAILABLE`로 거부 |
 
 `SHUTTING_DOWN`에서 read-only 명령을 통과시키는 이유는 BotManager와 DB가 아직 살아
-있는 구간의 운영 가시성을 보존하기 위해서다. 반대로 `STOPPED`는 `_shutdown` 후반부에서
-DB close가 끝난 뒤의 상태이므로 read-only도 closed DB read attempt 위험이 있어 거부한다.
+있는 초기 shutdown 구간의 운영 가시성을 보존하기 위해서다. 반대로 `DRAINING` 이후는
+BrokerAdapter disconnect와 DB close가 시작되는 구간이므로 read-only도 closed resource
+접근 위험이 있어 거부한다.
 
 `stop_accepting()`은 새 연결 수락만 중지하고 소켓 파일을 유지한다. cold-path guard는
 `PID alive AND socket exists`를 active runtime으로 판정하므로, `unlink_socket()`은
@@ -335,9 +337,10 @@ JSON 기반, 길이 접두사(length-prefixed) 프레이밍.
 | `__init__` | `(self, socket_path: str, service_registry: ServiceRegistry, command_registry: CommandRegistry)` | 소켓 경로와 서비스/커맨드 레지스트리 |
 | `start` | `async (self) -> None` | 소켓 서버 시작, `asyncio.start_unix_server` 사용, state를 `RUNNING`으로 전환 |
 | `stop_accepting` | `async (self) -> None` | state를 `SHUTTING_DOWN`으로 전환한 뒤 새 연결 수락 중지, 소켓 파일 유지 |
+| `stop_dispatching` | `(self) -> None` | state를 `DRAINING`으로 전환하여 active connection의 추가 dispatch를 모두 거부 |
 | `drain_connections` | `async (self, timeout: float = 5.0) -> None` | active 연결 drain 대기, timeout 시 경고 후 진행 |
 | `unlink_socket` | `(self) -> None` | 소켓 파일 삭제, state를 `STOPPED`로 전환 |
-| `stop` | `async (self) -> None` | 호환 facade: `stop_accepting()` → `drain_connections()` → `unlink_socket()` |
+| `stop` | `async (self) -> None` | 호환 facade: `stop_accepting()` → `stop_dispatching()` → `drain_connections()` → `unlink_socket()` |
 | `_handle_connection` | `async (self, reader, writer) -> None` | 커넥션별 요청 처리 |
 | `_dispatch` | `async (self, request: dict) -> dict` | lifecycle state/taxonomy 검사 → `CommandRegistry`에서 핸들러 조회 → 실행 → 결과 반환 |
 
@@ -400,6 +403,7 @@ class ServiceRegistry:
 | 서버 내부 에러 | 응답 `status: "error"` 반환. CLI는 `error.code` + `error.message` 출력 |
 | 미등록 커맨드 | `_dispatch`에서 `UNKNOWN_COMMAND` 에러 응답 |
 | shutdown 중 mutating 명령 | `SHUTTING_DOWN` 상태의 mutating 명령은 `SERVICE_UNAVAILABLE` 에러 응답 |
+| 리소스 drain 중 dispatch | `DRAINING` 상태의 모든 명령은 `SERVICE_UNAVAILABLE` 에러 응답 |
 | 서버 종료 후 dispatch | `STOPPED` 상태의 모든 명령은 `SERVICE_UNAVAILABLE` 에러 응답 |
 
 ## 보안 고려

--- a/docs/specs/ipc/ipc.md
+++ b/docs/specs/ipc/ipc.md
@@ -182,6 +182,69 @@ bootstrap, recovery, 비상 revoke 같은 운영 복구를 위해 CLI가 MemberS
 생성할 수 있다. 이 fallback은 account cold-path처럼 서버 topology를 바꾸지는 않지만,
 인증·세션 상태를 바꾸므로 서버 실행 중 직접 DB 수정은 금지한다.
 
+## IPCServer lifecycle state
+
+IPCServer는 shutdown 중 활성 IPC connection이 새 mutating 명령을 dispatch하는 race를
+막기 위해 명시적인 lifecycle state를 가진다.
+
+| 상태 | 진입 시점 | IPC dispatch 정책 |
+|------|-----------|------------------|
+| `RUNNING` | `start()`가 Unix socket listener와 파일 권한 설정을 완료한 직후 | 모든 등록 명령을 정상 dispatch |
+| `SHUTTING_DOWN` | `stop_accepting()` 진입 직후, listener `close()` 호출 전 | mutating 명령은 `SERVICE_UNAVAILABLE`로 거부, read-only 명령은 통과 |
+| `STOPPED` | `unlink_socket()` 종료 시점 | mutating/read-only를 포함한 모든 명령을 `SERVICE_UNAVAILABLE`로 거부 |
+
+`SHUTTING_DOWN`에서 read-only 명령을 통과시키는 이유는 BotManager와 DB가 아직 살아
+있는 구간의 운영 가시성을 보존하기 위해서다. 반대로 `STOPPED`는 `_shutdown` 후반부에서
+DB close가 끝난 뒤의 상태이므로 read-only도 closed DB read attempt 위험이 있어 거부한다.
+
+`stop_accepting()`은 새 연결 수락만 중지하고 소켓 파일을 유지한다. cold-path guard는
+`PID alive AND socket exists`를 active runtime으로 판정하므로, `unlink_socket()`은
+BotManager/DB 종료 이후 lifecycle 마지막 단계에서만 호출된다.
+
+## Handler taxonomy
+
+`CommandRegistry`는 각 등록 명령을 `CommandSpec`으로 보관하며, `is_mutating` taxonomy를
+명시한다. 이 taxonomy는 `SHUTTING_DOWN` 상태에서 mutating 명령만
+`SERVICE_UNAVAILABLE`로 거부하기 위한 서버 측 계약이다.
+
+- **mutating**: 서버 인메모리 상태, DB, 계좌/봇/예산/설정/결재/정산 상태를 변경하거나
+  변경 이벤트를 발행하는 명령
+- **read-only**: 서버가 보유한 live adapter를 통해 상태를 조회하지만 서버/DB 상태를
+  변경하지 않는 명령
+
+현재 `CommandRegistry.register_all_handlers()`에 등록된 IPC handler taxonomy는 아래 18개가
+SSOT다. 새 handler를 추가할 때는 코드의 `is_mutating` 값과 이 표를 함께 갱신해야 한다.
+
+| IPC 커맨드 | taxonomy | 근거 |
+|-----------|----------|------|
+| `system.halt` | mutating | `AccountService.suspend_all()` 호출 |
+| `system.activate` | mutating | `AccountService.activate_all()` 호출 |
+| `account.suspend` | mutating | `AccountService.suspend()` 호출 |
+| `account.activate` | mutating | `AccountService.activate()` 호출 |
+| `bot.create` | mutating | `BotManager.create_bot()` 호출 |
+| `bot.remove` | mutating | `BotManager.remove_bot()` 호출 |
+| `treasury.allocate` | mutating | `Treasury.allocate()` 호출 |
+| `treasury.deallocate` | mutating | `Treasury.deallocate()` 호출 |
+| `config.set` | mutating | `DynamicConfigService.set()` 호출 |
+| `approval.request` | mutating | `ApprovalService.create()` 호출 |
+| `approval.approve` | mutating | `ApprovalService.approve()` 호출 |
+| `approval.reject` | mutating | `ApprovalService.reject()` 호출 |
+| `approval.cancel` | mutating | `ApprovalService.cancel()` 호출 |
+| `approval.reopen` | mutating | `ApprovalService.reopen()` 호출 |
+| `broker.reconcile` | mutating | `PositionReconciler.reconcile()`이 보정/이벤트 경로를 수행 |
+| `broker.status` | read-only | `BrokerAdapter.health_check()` live 조회 |
+| `broker.balance` | read-only | `BrokerAdapter.get_account_balance()` live 조회 |
+| `broker.positions` | read-only | `BrokerAdapter.get_positions()` live 조회 |
+
+`broker.reconcile`은 CLI `--fix=False` 경로에서도 같은 IPC command를 사용하지만, 한 command
+이름에 mutating/read-only 의미를 섞지 않고 일괄 mutating으로 분류한다. dry-run 전용
+IPC command 분리는 별도 이슈 범위다.
+
+`account.delete`처럼 1.0 IPC 계약에서 제외되어 `CommandRegistry`에 등록되지 않는 명령은
+taxonomy 대상이 아니다. `broker.price`, `member.*`, `bot.start/stop`,
+`bot.signal_key.rotate`처럼 CLI/스펙 표에는 runtime IPC로 표현되어 있으나 현재
+`register_all_handlers()`에 없는 명령 추가도 별도 후속 범위다.
+
 ## 통신 프로토콜
 
 ### 전송 계층
@@ -269,11 +332,14 @@ JSON 기반, 길이 접두사(length-prefixed) 프레이밍.
 
 | 메서드 | 시그니처 | 설명 |
 |--------|---------|------|
-| `__init__` | `(self, socket_path: str, registry: ServiceRegistry)` | 소켓 경로와 서비스 레지스트리 |
-| `start` | `async (self) -> None` | 소켓 서버 시작, `asyncio.start_unix_server` 사용 |
-| `stop` | `async (self) -> None` | 소켓 서버 종료, 소켓 파일 삭제 |
+| `__init__` | `(self, socket_path: str, service_registry: ServiceRegistry, command_registry: CommandRegistry)` | 소켓 경로와 서비스/커맨드 레지스트리 |
+| `start` | `async (self) -> None` | 소켓 서버 시작, `asyncio.start_unix_server` 사용, state를 `RUNNING`으로 전환 |
+| `stop_accepting` | `async (self) -> None` | state를 `SHUTTING_DOWN`으로 전환한 뒤 새 연결 수락 중지, 소켓 파일 유지 |
+| `drain_connections` | `async (self, timeout: float = 5.0) -> None` | active 연결 drain 대기, timeout 시 경고 후 진행 |
+| `unlink_socket` | `(self) -> None` | 소켓 파일 삭제, state를 `STOPPED`로 전환 |
+| `stop` | `async (self) -> None` | 호환 facade: `stop_accepting()` → `drain_connections()` → `unlink_socket()` |
 | `_handle_connection` | `async (self, reader, writer) -> None` | 커넥션별 요청 처리 |
-| `_dispatch` | `async (self, command: str, args: dict, actor: str) -> dict` | `CommandRegistry`에서 핸들러 조회 → 실행 → 결과 반환 |
+| `_dispatch` | `async (self, request: dict) -> dict` | lifecycle state/taxonomy 검사 → `CommandRegistry`에서 핸들러 조회 → 실행 → 결과 반환 |
 
 ### IPCClient
 
@@ -298,10 +364,12 @@ CLI 프로세스에서 서버의 Unix socket에 연결하여 커맨드를 전달
 
 | 메서드 | 시그니처 | 설명 |
 |--------|---------|------|
-| `get` | `(self, command: str) -> CommandHandler \| None` | 커맨드에 대한 핸들러 반환 |
-| `register` | `(self, command: str, handler: CommandHandler) -> None` | 커맨드 핸들러 등록 |
+| `get` | `(self, command: str) -> CommandSpec \| None` | 커맨드에 대한 핸들러와 taxonomy 반환 |
+| `register` | `(self, command: str, handler: CommandHandler, *, is_mutating: bool) -> None` | 커맨드 핸들러와 mutating/read-only taxonomy 등록 |
 
 `CommandHandler` 시그니처: `async (registry: ServiceRegistry, args: dict, actor: str) -> dict`
+
+`CommandSpec` 필드: `name: str`, `handler: CommandHandler`, `is_mutating: bool`
 
 ### ServiceRegistry
 
@@ -331,6 +399,8 @@ class ServiceRegistry:
 | 타임아웃 (기본 30초) | `IPCClient`가 `IPCTimeoutError` 발생. CLI는 `"서버 응답 시간 초과"` 출력 후 종료 |
 | 서버 내부 에러 | 응답 `status: "error"` 반환. CLI는 `error.code` + `error.message` 출력 |
 | 미등록 커맨드 | `_dispatch`에서 `UNKNOWN_COMMAND` 에러 응답 |
+| shutdown 중 mutating 명령 | `SHUTTING_DOWN` 상태의 mutating 명령은 `SERVICE_UNAVAILABLE` 에러 응답 |
+| 서버 종료 후 dispatch | `STOPPED` 상태의 모든 명령은 `SERVICE_UNAVAILABLE` 에러 응답 |
 
 ## 보안 고려
 

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -1,12 +1,18 @@
 """CommandRegistry — IPC 커맨드 핸들러 등록 및 조회.
 
 각 커맨드 핸들러는 (ServiceRegistry, args: dict, actor: str) -> dict 시그니처를 따른다.
+
+Refs #1184: 각 등록 핸들러는 ``CommandSpec``으로 wrap되어 ``is_mutating``
+taxonomy를 함께 보유한다. ``IPCServer._dispatch``는 lifecycle state가
+``SHUTTING_DOWN``일 때 mutating 핸들러를 ``SERVICE_UNAVAILABLE``로 거부하기
+위해 이 정보를 사용한다.
 """
 
 from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -17,24 +23,62 @@ CommandHandler = Callable[["ServiceRegistry", dict, str], Awaitable[dict]]
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class CommandSpec:
+    """IPC 커맨드의 메타데이터.
+
+    Refs #1184: lifecycle state machine과 결합하여 shutdown 중
+    mutating 명령을 거부하기 위한 taxonomy를 보유한다.
+
+    Attributes:
+        name: 커맨드 식별자 (예: ``"system.halt"``).
+        handler: 비동기 핸들러 콜러블.
+        is_mutating: 핸들러가 서버 상태/DB를 변경하면 True. 단순 read-only
+            (live 조회) 면 False.
+    """
+
+    name: str
+    handler: CommandHandler
+    is_mutating: bool
+
+
 class CommandRegistry:
-    """커맨드 이름 -> 핸들러 매핑."""
+    """커맨드 이름 -> CommandSpec 매핑.
+
+    Refs #1184: 단순 dict[str, handler]에서 dict[str, CommandSpec]으로
+    전환되었다. 외부 호출자는 ``register(name, handler, *, is_mutating=...)``
+    keyword-only 인자를 명시해야 한다.
+    """
 
     def __init__(self) -> None:
-        self._handlers: dict[str, CommandHandler] = {}
+        self._specs: dict[str, CommandSpec] = {}
 
-    def register(self, command: str, handler: CommandHandler) -> None:
-        """핸들러 등록."""
-        self._handlers[command] = handler
+    def register(
+        self,
+        command: str,
+        handler: CommandHandler,
+        *,
+        is_mutating: bool,
+    ) -> None:
+        """핸들러 등록.
 
-    def get(self, command: str) -> CommandHandler | None:
-        """핸들러 조회. 미등록이면 None."""
-        return self._handlers.get(command)
+        Args:
+            command: 커맨드 이름.
+            handler: 비동기 핸들러.
+            is_mutating: 변경 명령 여부. shutdown 중 reject 분기에서 사용.
+        """
+        self._specs[command] = CommandSpec(
+            name=command, handler=handler, is_mutating=is_mutating
+        )
+
+    def get(self, command: str) -> CommandSpec | None:
+        """CommandSpec 조회. 미등록이면 None."""
+        return self._specs.get(command)
 
     @property
     def commands(self) -> list[str]:
-        """등록된 커맨드 목록."""
-        return list(self._handlers.keys())
+        """등록된 커맨드 목록 (이름만)."""
+        return list(self._specs.keys())
 
 
 # ── 핸들러 구현 ──────────────────────────────────────
@@ -237,24 +281,37 @@ async def _handle_broker_reconcile(
 def register_all_handlers(registry: CommandRegistry) -> None:
     """18개 런타임 커맨드 핸들러를 일괄 등록.
 
+    Refs #1184: 각 핸들러는 mutating(15개) 또는 read-only(3개)로 분류된다.
+    분류는 ``docs/specs/ipc/ipc.md``의 "Handler taxonomy" 섹션과 동기화되어야
+    한다. mutating 명령은 ``IPCServer``가 ``SHUTTING_DOWN`` 상태일 때
+    ``SERVICE_UNAVAILABLE``로 거부된다.
+
     `account.delete`는 1.0 IPC 계약에서 제외되었다 (#1139). cold-path CLI에서
     AccountService.delete()를 직접 호출하므로 IPC 라우팅 대상이 아니다.
     """
-    registry.register("system.halt", _handle_system_halt)
-    registry.register("system.activate", _handle_system_activate)
-    registry.register("account.suspend", _handle_account_suspend)
-    registry.register("account.activate", _handle_account_activate)
-    registry.register("bot.create", _handle_bot_create)
-    registry.register("bot.remove", _handle_bot_remove)
-    registry.register("treasury.allocate", _handle_treasury_allocate)
-    registry.register("treasury.deallocate", _handle_treasury_deallocate)
-    registry.register("config.set", _handle_config_set)
-    registry.register("approval.request", _handle_approval_request)
-    registry.register("approval.approve", _handle_approval_approve)
-    registry.register("approval.reject", _handle_approval_reject)
-    registry.register("approval.cancel", _handle_approval_cancel)
-    registry.register("approval.reopen", _handle_approval_reopen)
-    registry.register("broker.status", _handle_broker_status)
-    registry.register("broker.balance", _handle_broker_balance)
-    registry.register("broker.positions", _handle_broker_positions)
-    registry.register("broker.reconcile", _handle_broker_reconcile)
+    # ── mutating (15개): 서버 상태/DB를 변경 ──────────
+    registry.register("system.halt", _handle_system_halt, is_mutating=True)
+    registry.register("system.activate", _handle_system_activate, is_mutating=True)
+    registry.register("account.suspend", _handle_account_suspend, is_mutating=True)
+    registry.register("account.activate", _handle_account_activate, is_mutating=True)
+    registry.register("bot.create", _handle_bot_create, is_mutating=True)
+    registry.register("bot.remove", _handle_bot_remove, is_mutating=True)
+    registry.register("treasury.allocate", _handle_treasury_allocate, is_mutating=True)
+    registry.register(
+        "treasury.deallocate", _handle_treasury_deallocate, is_mutating=True
+    )
+    registry.register("config.set", _handle_config_set, is_mutating=True)
+    registry.register("approval.request", _handle_approval_request, is_mutating=True)
+    registry.register("approval.approve", _handle_approval_approve, is_mutating=True)
+    registry.register("approval.reject", _handle_approval_reject, is_mutating=True)
+    registry.register("approval.cancel", _handle_approval_cancel, is_mutating=True)
+    registry.register("approval.reopen", _handle_approval_reopen, is_mutating=True)
+    # broker.reconcile은 reconciler.reconcile()이 correct_position/이벤트
+    # publish를 수행하므로 일괄 mutating으로 분류한다. CLI ``--fix=False``
+    # dryrun 분리는 후속 이슈.
+    registry.register("broker.reconcile", _handle_broker_reconcile, is_mutating=True)
+
+    # ── read-only (3개): BrokerAdapter live 조회만 ────
+    registry.register("broker.status", _handle_broker_status, is_mutating=False)
+    registry.register("broker.balance", _handle_broker_balance, is_mutating=False)
+    registry.register("broker.positions", _handle_broker_positions, is_mutating=False)

--- a/src/ante/ipc/server.py
+++ b/src/ante/ipc/server.py
@@ -2,6 +2,9 @@
 
 asyncio.start_unix_server를 사용하여 외부 프로세스(CLI, MCP)의
 명령을 수신하고 처리한다.
+
+Refs #1184: lifecycle state machine을 도입해 shutdown 중 mutating
+명령이 SERVICE_UNAVAILABLE로 거부되도록 한다.
 """
 
 from __future__ import annotations
@@ -11,6 +14,7 @@ import logging
 import os
 import sys
 import uuid
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -22,6 +26,29 @@ if TYPE_CHECKING:
     from ante.ipc.registry import CommandRegistry
 
 logger = logging.getLogger(__name__)
+
+
+class IPCServerState(Enum):
+    """IPCServer lifecycle state.
+
+    Refs #1184: shutdown 중 mutating 명령을 reject하기 위한 명시적 상태 기계.
+
+    State 전이:
+
+    * ``STOPPED`` → ``RUNNING``: ``start()`` 마지막에 전환.
+    * ``RUNNING`` → ``SHUTTING_DOWN``: ``stop_accepting()`` 진입 직후
+      (listener close 호출 **전**)에 전환. 이 시점부터 mutating dispatch는
+      ``SERVICE_UNAVAILABLE``로 거부된다.
+    * ``SHUTTING_DOWN`` → ``STOPPED``: ``unlink_socket()`` 마지막에 전환.
+      이 시점부터는 read-only를 포함한 모든 명령이 거부된다 — db close 이후
+      이므로 read-only도 closed DB read attempt 위험이 있다.
+
+    초기 값은 ``STOPPED`` (start 이전 상태).
+    """
+
+    RUNNING = "running"
+    SHUTTING_DOWN = "shutting_down"
+    STOPPED = "stopped"
 
 
 class IPCServer:
@@ -41,10 +68,17 @@ class IPCServer:
         # drain_connections()이 wait_closed()를 호출할 수 있도록
         # closing reference를 별도 슬롯에 보존한다.
         self._closing_server: asyncio.AbstractServer | None = None
+        # Refs #1184: lifecycle state machine. 초기 상태는 STOPPED.
+        self._state: IPCServerState = IPCServerState.STOPPED
 
     @property
     def socket_path(self) -> str:
         return self._socket_path
+
+    @property
+    def state(self) -> IPCServerState:
+        """현재 lifecycle state (test/debug용 read-only view)."""
+        return self._state
 
     async def start(self) -> None:
         """서버 시작. 기존 소켓 파일이 있으면 삭제 후 재생성.
@@ -53,6 +87,8 @@ class IPCServer:
         책임진다 — cold-path guard가 shutdown 동안 'PID alive AND socket
         exists'로 active runtime을 판정해야 race window를 회피할 수 있기
         때문이다.
+
+        Refs #1184: 메서드 종료 시 state를 ``RUNNING``으로 전환한다.
 
         Python 버전별 동작 차이:
 
@@ -90,6 +126,9 @@ class IPCServer:
         # 소켓 파일 권한 설정 (소유자만 접근)
         os.chmod(self._socket_path, 0o600)
 
+        # Refs #1184: listener 준비 완료 후 RUNNING으로 전환.
+        self._state = IPCServerState.RUNNING
+
         logger.info("IPCServer 시작: %s", self._socket_path)
 
     async def stop_accepting(self) -> None:
@@ -103,7 +142,15 @@ class IPCServer:
         cold-path guard(``PID alive AND socket exists``)가 shutdown 동안에도
         'active runtime'으로 판정하도록, 소켓 파일은 ``unlink_socket()``이
         호출되기 전까지 유지된다.
+
+        Refs #1184: listener close 호출 **전**에 state를 ``SHUTTING_DOWN``으로
+        전환한다. 이래야 close 진행 중에 들어오는 dispatch도 mutating이라면
+        ``SERVICE_UNAVAILABLE``로 거부된다.
         """
+        # Refs #1184: 즉시 SHUTTING_DOWN으로 전환 — close 호출 전에 dispatch
+        # gate가 활성화되어야 race window가 닫힌다.
+        self._state = IPCServerState.SHUTTING_DOWN
+
         if self._server:
             # drain_connections에서 wait_closed를 호출할 수 있도록 reference 보존
             self._closing_server = self._server
@@ -133,14 +180,26 @@ class IPCServer:
             self._closing_server = None
 
     def unlink_socket(self) -> None:
-        """소켓 파일 제거. lifecycle 마지막 단계에서 호출."""
+        """소켓 파일 제거. lifecycle 마지막 단계에서 호출.
+
+        Refs #1184: 메서드 종료 시 state를 ``STOPPED``으로 전환한다. 이 시점
+        이후의 dispatch는 (read-only 포함) 모두 ``SERVICE_UNAVAILABLE``로
+        거부된다 — db close 이후이므로 read-only도 closed DB read attempt
+        위험이 있다.
+        """
         path = Path(self._socket_path)
         if path.exists():
             path.unlink()
+        # Refs #1184: 모든 cleanup 종료 후 STOPPED 전환.
+        self._state = IPCServerState.STOPPED
         logger.info("IPCServer 소켓 파일 제거: %s", self._socket_path)
 
     async def stop(self) -> None:
-        """기존 호출자 호환 facade. listener close → drain → unlink."""
+        """기존 호출자 호환 facade. listener close → drain → unlink.
+
+        Refs #1184: 내부 메서드들이 lifecycle state 전환을 담당한다 —
+        ``stop_accepting()``이 SHUTTING_DOWN, ``unlink_socket()``이 STOPPED.
+        """
         await self.stop_accepting()
         await self.drain_connections()
         self.unlink_socket()
@@ -185,15 +244,47 @@ class IPCServer:
             except Exception:
                 pass
 
+    @staticmethod
+    def _service_unavailable(request_id: str, message: str) -> dict:
+        """``SERVICE_UNAVAILABLE`` error 응답 dict 생성.
+
+        Refs #1184: 기존 error 응답 포맷
+        ``{"id", "status": "error", "error": {"code", "message"}}``과 동일한
+        구조를 사용해 다른 IPC consumer(CLI/MCP/dashboard)가 별도 처리 없이
+        기존 generic error path로 흘러가도록 한다.
+        """
+        return {
+            "id": request_id,
+            "status": "error",
+            "error": {
+                "code": "SERVICE_UNAVAILABLE",
+                "message": message,
+            },
+        }
+
     async def _dispatch(self, request: dict) -> dict:
-        """요청을 적절한 핸들러로 라우팅."""
+        """요청을 적절한 핸들러로 라우팅.
+
+        Refs #1184: lifecycle state-aware reject 분기를 추가한다.
+
+        * ``STOPPED``: 모든 명령(mutating + read-only) ``SERVICE_UNAVAILABLE``.
+          db close 이후이므로 read-only도 closed DB read attempt 위험.
+        * ``SHUTTING_DOWN`` + mutating: ``SERVICE_UNAVAILABLE``.
+        * ``SHUTTING_DOWN`` + read-only: 통과 (BotManager/DB 살아있음 가정,
+          dashboard 가시성 보존).
+        * ``RUNNING``: 정상 dispatch.
+        """
         request_id = request.get("id", str(uuid.uuid4()))
         command = request.get("command", "")
         args = request.get("args", {})
         actor = request.get("actor", "ipc")
 
-        handler = self._command_registry.get(command)
-        if handler is None:
+        # Refs #1184: STOPPED 단계에서는 모든 명령을 즉시 거부.
+        if self._state == IPCServerState.STOPPED:
+            return self._service_unavailable(request_id, "서버가 종료되었습니다.")
+
+        spec = self._command_registry.get(command)
+        if spec is None:
             return {
                 "id": request_id,
                 "status": "error",
@@ -203,8 +294,16 @@ class IPCServer:
                 },
             }
 
+        # Refs #1184: SHUTTING_DOWN 단계에서는 mutating 명령만 거부.
+        # read-only는 통과 (BotManager/DB 아직 살아 있음).
+        if self._state == IPCServerState.SHUTTING_DOWN and spec.is_mutating:
+            return self._service_unavailable(
+                request_id,
+                "서버가 종료 중입니다. 변경 명령을 받지 않습니다.",
+            )
+
         try:
-            result = await handler(self._service_registry, args, actor)
+            result = await spec.handler(self._service_registry, args, actor)
             return {
                 "id": request_id,
                 "status": "ok",

--- a/src/ante/ipc/server.py
+++ b/src/ante/ipc/server.py
@@ -39,15 +39,17 @@ class IPCServerState(Enum):
     * ``RUNNING`` → ``SHUTTING_DOWN``: ``stop_accepting()`` 진입 직후
       (listener close 호출 **전**)에 전환. 이 시점부터 mutating dispatch는
       ``SERVICE_UNAVAILABLE``로 거부된다.
-    * ``SHUTTING_DOWN`` → ``STOPPED``: ``unlink_socket()`` 마지막에 전환.
-      이 시점부터는 read-only를 포함한 모든 명령이 거부된다 — db close 이후
-      이므로 read-only도 closed DB read attempt 위험이 있다.
+    * ``SHUTTING_DOWN`` → ``DRAINING``: ``stop_dispatching()`` 호출 시 전환.
+      이 시점부터는 read-only를 포함한 모든 명령이 거부된다 — broker/db 등
+      서비스 리소스 종료 구간에 들어가기 때문이다.
+    * ``DRAINING`` → ``STOPPED``: ``unlink_socket()`` 마지막에 전환.
 
     초기 값은 ``STOPPED`` (start 이전 상태).
     """
 
     RUNNING = "running"
     SHUTTING_DOWN = "shutting_down"
+    DRAINING = "draining"
     STOPPED = "stopped"
 
 
@@ -179,13 +181,21 @@ class IPCServer:
         finally:
             self._closing_server = None
 
+    def stop_dispatching(self) -> None:
+        """active connection의 추가 dispatch를 모두 거부하도록 전환.
+
+        ``stop_accepting()`` 이후에도 기존 연결은 살아 있을 수 있다.
+        ``SHUTTING_DOWN`` 초기 구간에서는 read-only 조회를 허용하지만, broker
+        disconnect/DB close 같은 리소스 종료 직전에는 read-only도 closed
+        resource를 밟을 수 있으므로 이 메서드로 전 명령 reject 상태에 들어간다.
+        """
+        self._state = IPCServerState.DRAINING
+        logger.info("IPCServer dispatch 거부 시작: %s", self._socket_path)
+
     def unlink_socket(self) -> None:
         """소켓 파일 제거. lifecycle 마지막 단계에서 호출.
 
-        Refs #1184: 메서드 종료 시 state를 ``STOPPED``으로 전환한다. 이 시점
-        이후의 dispatch는 (read-only 포함) 모두 ``SERVICE_UNAVAILABLE``로
-        거부된다 — db close 이후이므로 read-only도 closed DB read attempt
-        위험이 있다.
+        Refs #1184: 메서드 종료 시 state를 ``STOPPED``으로 전환한다.
         """
         path = Path(self._socket_path)
         if path.exists():
@@ -198,9 +208,11 @@ class IPCServer:
         """기존 호출자 호환 facade. listener close → drain → unlink.
 
         Refs #1184: 내부 메서드들이 lifecycle state 전환을 담당한다 —
-        ``stop_accepting()``이 SHUTTING_DOWN, ``unlink_socket()``이 STOPPED.
+        ``stop_accepting()``이 SHUTTING_DOWN, ``stop_dispatching()``이 DRAINING,
+        ``unlink_socket()``이 STOPPED.
         """
         await self.stop_accepting()
+        self.stop_dispatching()
         await self.drain_connections()
         self.unlink_socket()
 
@@ -267,8 +279,9 @@ class IPCServer:
 
         Refs #1184: lifecycle state-aware reject 분기를 추가한다.
 
-        * ``STOPPED``: 모든 명령(mutating + read-only) ``SERVICE_UNAVAILABLE``.
-          db close 이후이므로 read-only도 closed DB read attempt 위험.
+        * ``DRAINING``/``STOPPED``: 모든 명령(mutating + read-only)
+          ``SERVICE_UNAVAILABLE``. 서비스 리소스 종료 구간 또는 종료 이후이므로
+          read-only도 closed resource 접근 위험.
         * ``SHUTTING_DOWN`` + mutating: ``SERVICE_UNAVAILABLE``.
         * ``SHUTTING_DOWN`` + read-only: 통과 (BotManager/DB 살아있음 가정,
           dashboard 가시성 보존).
@@ -279,9 +292,14 @@ class IPCServer:
         args = request.get("args", {})
         actor = request.get("actor", "ipc")
 
-        # Refs #1184: STOPPED 단계에서는 모든 명령을 즉시 거부.
-        if self._state == IPCServerState.STOPPED:
-            return self._service_unavailable(request_id, "서버가 종료되었습니다.")
+        # Refs #1184: 리소스 drain/종료 단계에서는 모든 명령을 즉시 거부.
+        if self._state in {IPCServerState.DRAINING, IPCServerState.STOPPED}:
+            message = (
+                "서버 리소스 종료 중입니다. IPC 명령을 받지 않습니다."
+                if self._state == IPCServerState.DRAINING
+                else "서버가 종료되었습니다."
+            )
+            return self._service_unavailable(request_id, message)
 
         spec = self._command_registry.get(command)
         if spec is None:

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1393,9 +1393,11 @@ async def _shutdown(s: Services) -> None:
     6. BotManager 전체 봇 중지
     7. StreamIntegration 종료
     8. APIGateway 종료
-    9. 각 계좌의 BrokerAdapter disconnect
-    10. Database 종료
-    11. **IPCServer.drain_connections() + unlink_socket()** — 소켓 파일 제거.
+    9. BrokerAdapter/DB 종료 직전 **IPCServer.stop_dispatching()** — active
+        connection의 read-only dispatch까지 `SERVICE_UNAVAILABLE`로 거부.
+    10. 각 계좌의 BrokerAdapter disconnect
+    11. Database 종료
+    12. **IPCServer.drain_connections() + unlink_socket()** — 소켓 파일 제거.
         cold-path guard(`PID alive AND socket exists`)가 이 시점부터 'active 아님'
         판정.
     """
@@ -1482,6 +1484,12 @@ async def _shutdown(s: Services) -> None:
     if s.api_gateway:
         s.api_gateway.stop()
         logger.info("APIGateway 종료")
+
+    # Refs #1184: BrokerAdapter disconnect/DB close 직전에는 read-only도 더는
+    # 안전하지 않다. 기존 active IPC connection의 추가 dispatch를 모두 거부한다.
+    if s.ipc_server:
+        s.ipc_server.stop_dispatching()
+        logger.info("IPCServer dispatch 거부 시작")
 
     # 각 계좌의 BrokerAdapter disconnect
     if s.account_service:

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1384,7 +1384,9 @@ async def _shutdown(s: Services) -> None:
 
     종료 순서 (Refs #1159 — cold-path race window 차단):
     1. 종료 알림(NotificationEvent), Telegram, 스케줄러 태스크 취소
-    2. **IPCServer.stop_accepting()** — 새 IPC 연결 차단, **소켓 파일은 유지**
+    2. **IPCServer.stop_accepting()** — 새 IPC 연결 차단, **소켓 파일은 유지**.
+       이 호출 시작 시 IPCServer state는 `SHUTTING_DOWN`으로 전환되어 이후
+       active connection의 mutating command를 `SERVICE_UNAVAILABLE`로 거부한다.
     3. Web API 종료
     4. DailyReportScheduler, ReconcileScheduler 종료
     5. 각 계좌의 Treasury sync 중지
@@ -1431,7 +1433,9 @@ async def _shutdown(s: Services) -> None:
             pass
         logger.info("결재 만료 스케줄러 종료")
 
-    # Refs #1159: 새 IPC 연결만 차단하고 소켓 파일은 유지한다.
+    # Refs #1159/#1184: 새 IPC 연결만 차단하고 소켓 파일은 유지한다.
+    # stop_accepting() 시작 시 IPCServer state가 SHUTTING_DOWN으로 바뀌어
+    # 이후 active connection의 mutating command는 SERVICE_UNAVAILABLE로 거부된다.
     # cold-path guard(`PID alive AND socket exists`)가 BotManager/DB 종료 전까지
     # 'active runtime'으로 판정하도록 unlink_socket()은 lifecycle 마지막에서 호출.
     if s.ipc_server:

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ante.ipc.registry import CommandRegistry, register_all_handlers
+from ante.ipc.registry import CommandRegistry, CommandSpec, register_all_handlers
 
 
 @pytest.fixture
@@ -16,8 +16,13 @@ def test_register_and_get(registry: CommandRegistry) -> None:
     async def dummy_handler(svc, args, actor):  # type: ignore[no-untyped-def]
         return {"ok": True}
 
-    registry.register("test.command", dummy_handler)
-    assert registry.get("test.command") is dummy_handler
+    registry.register("test.command", dummy_handler, is_mutating=True)
+    spec = registry.get("test.command")
+    assert spec == CommandSpec(
+        name="test.command",
+        handler=dummy_handler,
+        is_mutating=True,
+    )
 
 
 def test_get_unregistered_returns_none(registry: CommandRegistry) -> None:
@@ -31,8 +36,8 @@ def test_commands_property(registry: CommandRegistry) -> None:
     async def handler(svc, args, actor):  # type: ignore[no-untyped-def]
         return {}
 
-    registry.register("a.command", handler)
-    registry.register("b.command", handler)
+    registry.register("a.command", handler, is_mutating=True)
+    registry.register("b.command", handler, is_mutating=False)
     assert set(registry.commands) == {"a.command", "b.command"}
 
 
@@ -69,6 +74,45 @@ def test_register_all_handlers() -> None:
     assert set(registry.commands) == expected
     # account.delete는 cold-path 전용이므로 IPC 등록 대상이 아니다.
     assert "account.delete" not in registry.commands
+
+
+def test_register_all_handlers_taxonomy() -> None:
+    """등록된 18개 핸들러의 mutating/read-only taxonomy가 스펙과 일치한다."""
+    registry = CommandRegistry()
+    register_all_handlers(registry)
+
+    mutating = {
+        "system.halt",
+        "system.activate",
+        "account.suspend",
+        "account.activate",
+        "bot.create",
+        "bot.remove",
+        "treasury.allocate",
+        "treasury.deallocate",
+        "config.set",
+        "approval.request",
+        "approval.approve",
+        "approval.reject",
+        "approval.cancel",
+        "approval.reopen",
+        "broker.reconcile",
+    }
+    read_only = {"broker.status", "broker.balance", "broker.positions"}
+
+    assert len(mutating) == 15
+    assert len(read_only) == 3
+    assert mutating | read_only == set(registry.commands)
+
+    for command in mutating:
+        spec = registry.get(command)
+        assert spec is not None
+        assert spec.is_mutating is True
+
+    for command in read_only:
+        spec = registry.get(command)
+        assert spec is not None
+        assert spec.is_mutating is False
 
 
 # ── _handle_bot_create 변환 로직 테스트 ──────────────

--- a/tests/unit/ipc/test_server_client.py
+++ b/tests/unit/ipc/test_server_client.py
@@ -228,6 +228,9 @@ async def test_lifecycle_state_transitions(
     await server.drain_connections(timeout=0.1)
     assert server.state is IPCServerState.SHUTTING_DOWN
 
+    server.stop_dispatching()
+    assert server.state is IPCServerState.DRAINING
+
     server.unlink_socket()
     assert server.state is IPCServerState.STOPPED
 
@@ -315,6 +318,7 @@ async def test_dispatch_rejects_everything_when_stopped(
     server = IPCServer(socket_path, service_registry, cmd_registry)
     await server.start()
     await server.stop_accepting()
+    server.stop_dispatching()
     await server.drain_connections(timeout=0.1)
     server.unlink_socket()
 
@@ -329,6 +333,37 @@ async def test_dispatch_rejects_everything_when_stopped(
         assert response["status"] == "error"
         assert response["error"]["code"] == "SERVICE_UNAVAILABLE"
         assert "종료되었습니다" in response["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_everything_while_draining(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """DRAINING에서는 read-only 포함 모든 dispatch를 503으로 거부한다."""
+    cmd_registry = CommandRegistry()
+
+    async def read_only_handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {"read": True}
+
+    cmd_registry.register("test.read", read_only_handler, is_mutating=False)
+
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+    try:
+        await server.stop_accepting()
+        server.stop_dispatching()
+
+        response = await server._dispatch(
+            {"id": "r1", "command": "test.read", "args": {}, "actor": "tester"}
+        )
+
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "SERVICE_UNAVAILABLE"
+        assert "리소스 종료 중" in response["error"]["message"]
+    finally:
+        await server.drain_connections(timeout=0.1)
+        if Path(socket_path).exists():
+            server.unlink_socket()
 
 
 @pytest.mark.asyncio
@@ -413,10 +448,10 @@ async def test_unlink_socket_removes_file(
 
 
 @pytest.mark.asyncio
-async def test_stop_facade_runs_all_three_phases(
+async def test_stop_facade_runs_all_phases(
     socket_path: str, service_registry: ServiceRegistry
 ) -> None:
-    """기존 stop() 호출자 호환 facade — listener close → drain → unlink."""
+    """기존 stop() 호출자 호환 facade — listener close → reject → drain → unlink."""
     cmd_registry = CommandRegistry()
     server = IPCServer(socket_path, service_registry, cmd_registry)
     await server.start()
@@ -425,6 +460,7 @@ async def test_stop_facade_runs_all_three_phases(
     # 호출 추적 wrapper로 3단계가 모두 실행되는지 검증
     calls: list[str] = []
     original_stop_accepting = server.stop_accepting
+    original_stop_dispatching = server.stop_dispatching
     original_drain = server.drain_connections
     original_unlink = server.unlink_socket
 
@@ -436,15 +472,25 @@ async def test_stop_facade_runs_all_three_phases(
         calls.append("drain_connections")
         await original_drain(timeout)
 
+    def tracked_stop_dispatching() -> None:
+        calls.append("stop_dispatching")
+        original_stop_dispatching()
+
     def tracked_unlink() -> None:
         calls.append("unlink_socket")
         original_unlink()
 
     server.stop_accepting = tracked_stop_accepting  # type: ignore[method-assign]
+    server.stop_dispatching = tracked_stop_dispatching  # type: ignore[method-assign]
     server.drain_connections = tracked_drain  # type: ignore[method-assign]
     server.unlink_socket = tracked_unlink  # type: ignore[method-assign]
 
     await server.stop()
 
-    assert calls == ["stop_accepting", "drain_connections", "unlink_socket"]
+    assert calls == [
+        "stop_accepting",
+        "stop_dispatching",
+        "drain_connections",
+        "unlink_socket",
+    ]
     assert not Path(socket_path).exists()

--- a/tests/unit/ipc/test_server_client.py
+++ b/tests/unit/ipc/test_server_client.py
@@ -13,7 +13,7 @@ from ante.core.registry import ServiceRegistry
 from ante.ipc.client import IPCClient
 from ante.ipc.exceptions import ServerNotRunningError
 from ante.ipc.registry import CommandRegistry
-from ante.ipc.server import IPCServer
+from ante.ipc.server import IPCServer, IPCServerState
 
 
 def _make_service_registry() -> ServiceRegistry:
@@ -48,7 +48,7 @@ async def test_roundtrip(socket_path: str, service_registry: ServiceRegistry) ->
     async def echo_handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
         return {"echo": args, "actor": actor}
 
-    cmd_registry.register("test.echo", echo_handler)
+    cmd_registry.register("test.echo", echo_handler, is_mutating=False)
 
     server = IPCServer(socket_path, service_registry, cmd_registry)
     await server.start()
@@ -91,7 +91,7 @@ async def test_handler_exception(
     async def failing_handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
         raise ValueError("의도적 예외")
 
-    cmd_registry.register("test.fail", failing_handler)
+    cmd_registry.register("test.fail", failing_handler, is_mutating=True)
 
     server = IPCServer(socket_path, service_registry, cmd_registry)
     await server.start()
@@ -163,7 +163,7 @@ async def test_multiple_requests(
         call_count += 1
         return {"count": call_count}
 
-    cmd_registry.register("test.count", counter_handler)
+    cmd_registry.register("test.count", counter_handler, is_mutating=False)
 
     server = IPCServer(socket_path, service_registry, cmd_registry)
     await server.start()
@@ -207,6 +207,128 @@ async def test_stop_accepting_keeps_socket_file(
     await server.drain_connections(timeout=0.1)
     server.unlink_socket()
     assert not Path(socket_path).exists()
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_state_transitions(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """IPCServer lifecycle state는 start/stop 3-phase와 동기화된다."""
+    cmd_registry = CommandRegistry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+
+    assert server.state is IPCServerState.STOPPED
+
+    await server.start()
+    assert server.state is IPCServerState.RUNNING
+
+    await server.stop_accepting()
+    assert server.state is IPCServerState.SHUTTING_DOWN
+
+    await server.drain_connections(timeout=0.1)
+    assert server.state is IPCServerState.SHUTTING_DOWN
+
+    server.unlink_socket()
+    assert server.state is IPCServerState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_stop_facade_ends_in_stopped_state(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """stop() facade도 최종 STOPPED 상태로 끝난다."""
+    cmd_registry = CommandRegistry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+
+    await server.stop()
+
+    assert server.state is IPCServerState.STOPPED
+    assert not Path(socket_path).exists()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_mutating_only_while_shutting_down(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """SHUTTING_DOWN에서는 mutating만 503으로 거부하고 read-only는 통과한다."""
+    cmd_registry = CommandRegistry()
+
+    async def mutating_handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {"mutated": True}
+
+    async def read_only_handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {"read": True}
+
+    cmd_registry.register("test.mutate", mutating_handler, is_mutating=True)
+    cmd_registry.register("test.read", read_only_handler, is_mutating=False)
+
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+    try:
+        mutating_running = await server._dispatch(
+            {"id": "m1", "command": "test.mutate", "args": {}, "actor": "tester"}
+        )
+        read_running = await server._dispatch(
+            {"id": "r1", "command": "test.read", "args": {}, "actor": "tester"}
+        )
+
+        assert mutating_running["status"] == "ok"
+        assert read_running["status"] == "ok"
+
+        await server.stop_accepting()
+
+        mutating_stopping = await server._dispatch(
+            {"id": "m2", "command": "test.mutate", "args": {}, "actor": "tester"}
+        )
+        read_stopping = await server._dispatch(
+            {"id": "r2", "command": "test.read", "args": {}, "actor": "tester"}
+        )
+
+        assert mutating_stopping["status"] == "error"
+        assert mutating_stopping["error"]["code"] == "SERVICE_UNAVAILABLE"
+        assert "종료 중" in mutating_stopping["error"]["message"]
+        assert read_stopping["status"] == "ok"
+        assert read_stopping["result"] == {"read": True}
+    finally:
+        await server.drain_connections(timeout=0.1)
+        if Path(socket_path).exists():
+            server.unlink_socket()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_everything_when_stopped(
+    socket_path: str, service_registry: ServiceRegistry
+) -> None:
+    """STOPPED에서는 read-only 포함 모든 dispatch를 503으로 거부한다."""
+    cmd_registry = CommandRegistry()
+
+    async def mutating_handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {"mutated": True}
+
+    async def read_only_handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {"read": True}
+
+    cmd_registry.register("test.mutate", mutating_handler, is_mutating=True)
+    cmd_registry.register("test.read", read_only_handler, is_mutating=False)
+
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+    await server.stop_accepting()
+    await server.drain_connections(timeout=0.1)
+    server.unlink_socket()
+
+    mutating_response = await server._dispatch(
+        {"id": "m1", "command": "test.mutate", "args": {}, "actor": "tester"}
+    )
+    read_response = await server._dispatch(
+        {"id": "r1", "command": "test.read", "args": {}, "actor": "tester"}
+    )
+
+    for response in (mutating_response, read_response):
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "SERVICE_UNAVAILABLE"
+        assert "종료되었습니다" in response["error"]["message"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cli_bot_treasury_ipc.py
+++ b/tests/unit/test_cli_bot_treasury_ipc.py
@@ -96,6 +96,32 @@ class TestIpcSend:
             with pytest.raises(click.ClickException, match="EXECUTION_ERROR"):
                 await ipc_send("bot.remove", {"bot_id": "x"})
 
+    @pytest.mark.asyncio
+    async def test_service_unavailable_response(self) -> None:
+        """SERVICE_UNAVAILABLE 응답은 기존 error path로 사용자에게 노출된다."""
+        mock_client = AsyncMock()
+        mock_client.send.return_value = {
+            "id": "abc",
+            "status": "error",
+            "error": {
+                "code": "SERVICE_UNAVAILABLE",
+                "message": "서버가 종료 중입니다. 변경 명령을 받지 않습니다.",
+            },
+        }
+
+        with (
+            patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/test.sock",
+            ),
+            patch("ante.cli.commands.ipc_helpers.IPCClient", return_value=mock_client),
+        ):
+            with pytest.raises(click.ClickException) as excinfo:
+                await ipc_send("bot.remove", {"bot_id": "x"})
+
+        assert "SERVICE_UNAVAILABLE" in str(excinfo.value)
+        assert "서버가 종료 중입니다" in str(excinfo.value)
+
 
 # ── Bot CLI IPC 테스트 ──────────────────────────────
 

--- a/tests/unit/test_ipc_error_code_mapping.py
+++ b/tests/unit/test_ipc_error_code_mapping.py
@@ -77,7 +77,7 @@ async def test_ipc_server_uses_exception_code_attribute_when_present(
             "테스트: 런타임 cold-path 차단"
         )
 
-    cmd_registry.register("test.cold_path", cold_path_handler)
+    cmd_registry.register("test.cold_path", cold_path_handler, is_mutating=True)
 
     server = IPCServer(socket_path, service_registry, cmd_registry)
     await server.start()
@@ -104,7 +104,7 @@ async def test_ipc_server_falls_back_to_execution_error_when_no_code(
     async def value_error_handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
         raise ValueError("no code attribute")
 
-    cmd_registry.register("test.fail", value_error_handler)
+    cmd_registry.register("test.fail", value_error_handler, is_mutating=True)
 
     server = IPCServer(socket_path, service_registry, cmd_registry)
     await server.start()
@@ -133,7 +133,11 @@ async def test_ipc_server_falls_back_for_account_error_without_code(
     async def already_suspended_handler(svc, args, actor):
         raise AccountAlreadySuspendedError("이미 정지됨")
 
-    cmd_registry.register("test.already_suspended", already_suspended_handler)
+    cmd_registry.register(
+        "test.already_suspended",
+        already_suspended_handler,
+        is_mutating=True,
+    )
 
     server = IPCServer(socket_path, service_registry, cmd_registry)
     await server.start()

--- a/tests/unit/test_main_shutdown_ordering.py
+++ b/tests/unit/test_main_shutdown_ordering.py
@@ -328,6 +328,60 @@ async def test_active_connection_read_only_command_allowed_during_shutdown(
 
 
 @pytest.mark.asyncio
+async def test_read_only_command_rejected_before_db_close(
+    socket_path: str,
+) -> None:
+    """DB close 직전 리소스 drain 구간에서는 read-only도 503으로 거부된다."""
+    cmd_registry = CommandRegistry()
+    service_registry = _make_service_registry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+
+    async def read_handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {"read": True}
+
+    cmd_registry.register("test.read", read_handler, is_mutating=False)
+    await server.start()
+
+    responses: list[dict] = []
+    states_at_db_close: list[IPCServerState] = []
+
+    class _StubBotManager:
+        async def stop_all(self) -> None:
+            pass
+
+    class _StubDatabase:
+        async def close(self) -> None:
+            states_at_db_close.append(server.state)
+            responses.append(
+                await server._dispatch(
+                    {
+                        "id": "db-close",
+                        "command": "test.read",
+                        "args": {},
+                        "actor": "active-client",
+                    }
+                )
+            )
+
+    s = Services(
+        ipc_server=server,
+        bot_manager=_StubBotManager(),
+        db=_StubDatabase(),
+    )
+
+    try:
+        await _shutdown(s)
+    finally:
+        if Path(socket_path).exists():
+            Path(socket_path).unlink()
+
+    assert states_at_db_close == [IPCServerState.DRAINING]
+    assert responses[0]["status"] == "error"
+    assert responses[0]["error"]["code"] == "SERVICE_UNAVAILABLE"
+    assert "리소스 종료 중" in responses[0]["error"]["message"]
+
+
+@pytest.mark.asyncio
 async def test_post_stopped_dispatch_rejected(
     socket_path: str,
 ) -> None:

--- a/tests/unit/test_main_shutdown_ordering.py
+++ b/tests/unit/test_main_shutdown_ordering.py
@@ -20,7 +20,7 @@ import pytest
 
 from ante.core.registry import ServiceRegistry
 from ante.ipc.registry import CommandRegistry
-from ante.ipc.server import IPCServer
+from ante.ipc.server import IPCServer, IPCServerState
 from ante.main import Services, _shutdown
 
 
@@ -176,6 +176,198 @@ async def test_shutdown_socket_file_present_during_bot_and_db_phase(
     assert not Path(socket_path).exists(), (
         "_shutdown 완료 후에는 socket 파일이 제거되어야 한다"
     )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_sets_shutting_down_before_bot_stop(
+    socket_path: str,
+) -> None:
+    """_shutdown은 BotManager 정지 전에 IPC state를 SHUTTING_DOWN으로 전환한다."""
+    cmd_registry = CommandRegistry()
+    service_registry = _make_service_registry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+    await server.start()
+
+    state_at_bot_stop: list[IPCServerState] = []
+
+    class _StubBotManager:
+        async def stop_all(self) -> None:
+            state_at_bot_stop.append(server.state)
+
+    class _StubDatabase:
+        async def close(self) -> None:
+            pass
+
+    s = Services(
+        ipc_server=server,
+        bot_manager=_StubBotManager(),
+        db=_StubDatabase(),
+    )
+
+    try:
+        await _shutdown(s)
+    finally:
+        if Path(socket_path).exists():
+            Path(socket_path).unlink()
+
+    assert state_at_bot_stop == [IPCServerState.SHUTTING_DOWN]
+    assert server.state is IPCServerState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_active_connection_mutating_command_rejected_during_shutdown(
+    socket_path: str,
+) -> None:
+    """stop_accepting 이후 active connection의 mutating dispatch는 503으로 거부된다."""
+    cmd_registry = CommandRegistry()
+    service_registry = _make_service_registry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+
+    mutation_calls: list[str] = []
+
+    async def mutate_handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        mutation_calls.append(actor)
+        return {"mutated": True}
+
+    cmd_registry.register("test.mutate", mutate_handler, is_mutating=True)
+    await server.start()
+
+    response_before_shutdown = await server._dispatch(
+        {"id": "before", "command": "test.mutate", "args": {}, "actor": "pre"}
+    )
+    assert response_before_shutdown["status"] == "ok"
+
+    class _StubBotManager:
+        async def stop_all(self) -> None:
+            response = await server._dispatch(
+                {
+                    "id": "during",
+                    "command": "test.mutate",
+                    "args": {},
+                    "actor": "active-client",
+                }
+            )
+            assert response["status"] == "error"
+            assert response["error"]["code"] == "SERVICE_UNAVAILABLE"
+
+    class _StubDatabase:
+        async def close(self) -> None:
+            pass
+
+    s = Services(
+        ipc_server=server,
+        bot_manager=_StubBotManager(),
+        db=_StubDatabase(),
+    )
+
+    try:
+        await _shutdown(s)
+    finally:
+        if Path(socket_path).exists():
+            Path(socket_path).unlink()
+
+    assert mutation_calls == ["pre"]
+
+
+@pytest.mark.asyncio
+async def test_active_connection_read_only_command_allowed_during_shutdown(
+    socket_path: str,
+) -> None:
+    """SHUTTING_DOWN 중 active connection의 read-only dispatch는 통과한다."""
+    cmd_registry = CommandRegistry()
+    service_registry = _make_service_registry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+
+    async def read_handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {"state": server.state.value, "actor": actor}
+
+    cmd_registry.register("test.read", read_handler, is_mutating=False)
+    await server.start()
+
+    responses: list[dict] = []
+
+    class _StubBotManager:
+        async def stop_all(self) -> None:
+            responses.append(
+                await server._dispatch(
+                    {
+                        "id": "during",
+                        "command": "test.read",
+                        "args": {},
+                        "actor": "active-client",
+                    }
+                )
+            )
+
+    class _StubDatabase:
+        async def close(self) -> None:
+            pass
+
+    s = Services(
+        ipc_server=server,
+        bot_manager=_StubBotManager(),
+        db=_StubDatabase(),
+    )
+
+    try:
+        await _shutdown(s)
+    finally:
+        if Path(socket_path).exists():
+            Path(socket_path).unlink()
+
+    assert responses == [
+        {
+            "id": "during",
+            "status": "ok",
+            "result": {
+                "state": IPCServerState.SHUTTING_DOWN.value,
+                "actor": "active-client",
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_post_stopped_dispatch_rejected(
+    socket_path: str,
+) -> None:
+    """unlink_socket 이후 이론적 잔여 dispatch는 read-only도 503으로 거부된다."""
+    cmd_registry = CommandRegistry()
+    service_registry = _make_service_registry()
+    server = IPCServer(socket_path, service_registry, cmd_registry)
+
+    async def read_handler(svc: ServiceRegistry, args: dict, actor: str) -> dict:
+        return {"read": True}
+
+    cmd_registry.register("test.read", read_handler, is_mutating=False)
+    await server.start()
+
+    class _StubBotManager:
+        async def stop_all(self) -> None:
+            pass
+
+    class _StubDatabase:
+        async def close(self) -> None:
+            pass
+
+    s = Services(
+        ipc_server=server,
+        bot_manager=_StubBotManager(),
+        db=_StubDatabase(),
+    )
+
+    try:
+        await _shutdown(s)
+        response = await server._dispatch(
+            {"id": "after", "command": "test.read", "args": {}, "actor": "client"}
+        )
+    finally:
+        if Path(socket_path).exists():
+            Path(socket_path).unlink()
+
+    assert response["status"] == "error"
+    assert response["error"]["code"] == "SERVICE_UNAVAILABLE"
+    assert "종료되었습니다" in response["error"]["message"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1184

## Summary
- add IPCServer lifecycle states and CommandSpec handler taxonomy
- reject mutating IPC commands while SHUTTING_DOWN, and reject all IPC dispatch during DRAINING/STOPPED
- update IPC spec and shutdown ordering docs/tests for active-connection races

## Test Plan
- `/usr/bin/env PYTHONPATH=src /Users/jingulee/Projects/ante/.venv/bin/pytest -q tests/unit/ipc/test_server_client.py tests/unit/ipc/test_registry.py tests/unit/test_ipc_error_code_mapping.py tests/unit/test_cli_bot_treasury_ipc.py tests/unit/test_main_shutdown_ordering.py` → 52 passed
- `/usr/bin/env PYTHONPATH=src /Users/jingulee/Projects/ante/.venv/bin/pytest -q tests/unit/test_cli_bot_treasury_ipc.py tests/unit/test_cli_config_approval_broker_ipc.py tests/unit/test_cli_ipc_commands.py` → 48 passed
- `/Users/jingulee/Projects/ante/.venv/bin/ruff check src/ante/ipc src/ante/main.py tests/unit/ipc/test_server_client.py tests/unit/ipc/test_registry.py tests/unit/test_ipc_error_code_mapping.py tests/unit/test_cli_bot_treasury_ipc.py tests/unit/test_main_shutdown_ordering.py` → pass
- `/Users/jingulee/Projects/ante/.venv/bin/ruff format --check src/ante/ipc src/ante/main.py tests/unit/ipc/test_server_client.py tests/unit/ipc/test_registry.py tests/unit/test_ipc_error_code_mapping.py tests/unit/test_cli_bot_treasury_ipc.py tests/unit/test_main_shutdown_ordering.py` → pass

## Branch Review
- `codex exec review --base origin/main` attempt 1: FAIL ([P2] read-only dispatch during resource drain)
- `codex exec review --base origin/main` attempt 2: PASS at `b27e8c0`