### PR TITLE
fix(ipc): satisfy mypy for unix server kwargs

### DIFF
--- a/src/ante/ipc/server.py
+++ b/src/ante/ipc/server.py
@@ -16,7 +16,7 @@ import sys
 import uuid
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ante.ipc import protocol
 from ante.ipc.exceptions import MessageTooLargeError
@@ -116,7 +116,7 @@ class IPCServer:
         if path.exists():
             path.unlink()
 
-        kwargs: dict[str, object] = {"path": self._socket_path}
+        kwargs: dict[str, Any] = {"path": self._socket_path}
         if sys.version_info >= (3, 13):
             kwargs["cleanup_socket"] = False
 


### PR DESCRIPTION
## Summary
- Follow-up to #1193 / Refs #1184.
- Adjust IPC server `start_unix_server` dynamic kwargs typing from `dict[str, object]` to `dict[str, Any]` so CI mypy accepts the Python 3.13-only guarded `cleanup_socket` kwarg.

## Verification
- `mypy src/`
- `ruff check src/ante/ipc/server.py`
- `ruff format --check src/ante/ipc/server.py`
- `PYTHONPATH=src pytest -q tests/unit/ipc/test_server_client.py tests/unit/ipc/test_registry.py tests/unit/test_main_shutdown_ordering.py` (33 passed; rerun outside sandbox because local sandbox denied `/tmp` Unix socket bind)
- `git diff --check`
- Codex branch review: PASS