### PR TITLE
fix(main): add startup booting marker guard

### DIFF
--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -61,7 +61,7 @@ def _assert_no_active_runtime(fmt: OutputFormatter) -> None:
     """
     from ante.cli.main import get_config_dir
     from ante.config import Config
-    from ante.main import read_pid_file
+    from ante.main import _read_starting_marker_pid, read_pid_file
 
     config_dir = get_config_dir()
     config = Config.load(config_dir=config_dir)
@@ -86,9 +86,15 @@ def _assert_no_active_runtime(fmt: OutputFormatter) -> None:
         return
 
     if not Path(socket_path).exists():
-        return  # PID alive but socket absent → stale PID/타 프로세스 → 통과
+        # Refs #1160: boot 중에는 PID가 이미 alive지만 IPC socket이 아직 없을
+        # 수 있다. 이때 같은 PID가 기록된 starting marker가 있으면 starting도
+        # active runtime으로 보고 차단한다. marker 부재/손상/다른 PID는 stale
+        # 또는 recycled marker로 보고 기존처럼 통과한다.
+        marker_pid = _read_starting_marker_pid(config)
+        if marker_pid != pid:
+            return  # PID alive but neither socket nor matching marker → stale
 
-    # PID alive AND socket exists → active runtime 있음 → 차단.
+    # PID alive AND (socket exists OR matching starting marker) → active runtime.
     # text 출력 경로도 차단 코드를 식별할 수 있도록 메시지에 prefix를 포함한다.
     fmt.error(
         f"{_COLD_PATH_BLOCKED_CODE}: 서버가 실행 중입니다. "

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -50,6 +50,42 @@ def _write_pid_file(config: Config) -> None:
     logger.info("PID 파일 기록: %s (pid=%d)", path, os.getpid())
 
 
+def _starting_marker_path(config: Config) -> Path:
+    """booting marker 경로를 반환한다.
+
+    Refs #1160: PID 파일과 같은 디렉토리의 ``.starting`` 파일을 사용한다.
+    ``runtime.pid_path`` resolver에서 파생하므로 #1157의 single-canonical
+    runtime path 정책과 자동으로 정합된다.
+    """
+    return config.runtime_pid_path().parent / ".starting"
+
+
+def _write_starting_marker(config: Config) -> None:
+    """booting marker에 현재 PID를 기록한다."""
+    path = _starting_marker_path(config)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(os.getpid()))
+    logger.info("Booting marker 기록: %s (pid=%d)", path, os.getpid())
+
+
+def _read_starting_marker_pid(config: Config) -> int | None:
+    """booting marker의 PID를 반환한다. 부재/파싱 실패 시 ``None``."""
+    try:
+        return int(_starting_marker_path(config).read_text().strip())
+    except (FileNotFoundError, ValueError, OSError):
+        return None
+
+
+def _remove_starting_marker(config: Config) -> None:
+    """booting marker를 best-effort로 제거한다."""
+    path = _starting_marker_path(config)
+    try:
+        path.unlink(missing_ok=True)
+        logger.info("Booting marker 제거: %s", path)
+    except OSError:
+        logger.warning("Booting marker 제거 실패: %s", path, exc_info=True)
+
+
 def _remove_pid_file(config: Config) -> None:
     """canonical + legacy ``db/ante.pid`` 양쪽 PID 파일을 정리한다.
 
@@ -1524,6 +1560,7 @@ async def main() -> None:
     """Main asyncio entrypoint.
 
     초기화 순서 (Account 중심):
+    0. Booting marker + PID 기록 (starting도 active runtime으로 표시)
     1. Core: Config, Database, EventBus, DynamicConfig
     2. Services: AuditLogger, MemberService, InstrumentService
     3. Account: AccountService, 테스트 계좌 자동 생성
@@ -1532,7 +1569,7 @@ async def main() -> None:
     6. Feed: DataPipeline, Backtest, Report
     7. Approval: ApprovalService
     8. Notification: Telegram(account_service 주입)
-    9. IPC: Unix 도메인 소켓 서버
+    9. IPC: Unix 도메인 소켓 서버 (성공 후 booting marker 제거)
     10. Web: FastAPI(account_service 주입)
 
     종료 순서: 역순 (상위 소비자부터 정리)
@@ -1542,9 +1579,14 @@ async def main() -> None:
     # `<config_dir>/run/ante.pid` 위치에 기록한다. `_init_core`는 동일
     # 인스턴스를 그대로 재사용한다.
     s.config = Config.load()
-    _write_pid_file(s.config)
 
     try:
+        # Refs #1160: starting 단계도 active runtime으로 판정되도록 marker를
+        # PID보다 먼저 기록한다. marker만 있고 PID가 없는 극소 구간은
+        # cold-path guard가 PID 부재로 통과하므로 mutation race를 만들지 않는다.
+        _write_starting_marker(s.config)
+        _write_pid_file(s.config)
+
         await _init_core(s)
 
         # 서버 시작 시 최신 버전 확인 (non-blocking, fire-and-forget)
@@ -1568,9 +1610,11 @@ async def main() -> None:
         await _init_approval(s)
         await _init_notification(s)
         await _init_ipc(s)
+        _remove_starting_marker(s.config)
         await _init_web(s)
         await _run(s)
     finally:
+        _remove_starting_marker(s.config)
         _remove_pid_file(s.config)
 
 

--- a/tests/unit/test_main_startup_ordering.py
+++ b/tests/unit/test_main_startup_ordering.py
@@ -1,0 +1,209 @@
+"""Refs #1160 — startup booting marker ordering tests."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ante.config import Config
+
+
+def test_starting_marker_path_derives_from_runtime_pid_dir(tmp_path: Path) -> None:
+    """Marker는 canonical runtime PID directory에서 파생된다."""
+    from ante.main import _starting_marker_path
+
+    config = Config.load(config_dir=tmp_path)
+
+    assert _starting_marker_path(config) == tmp_path / "run" / ".starting"
+
+
+def test_write_starting_marker_creates_file_with_current_pid(
+    tmp_path: Path,
+) -> None:
+    """Marker write는 현재 PID를 기록한다."""
+    from ante.main import (
+        _read_starting_marker_pid,
+        _remove_starting_marker,
+        _starting_marker_path,
+        _write_starting_marker,
+    )
+
+    config = Config.load(config_dir=tmp_path)
+    try:
+        _write_starting_marker(config)
+
+        assert _starting_marker_path(config).exists()
+        assert _read_starting_marker_pid(config) == os.getpid()
+    finally:
+        _remove_starting_marker(config)
+
+
+def test_remove_starting_marker_unlinks_file(tmp_path: Path) -> None:
+    """Marker remove는 기존 marker를 제거한다."""
+    from ante.main import (
+        _remove_starting_marker,
+        _starting_marker_path,
+        _write_starting_marker,
+    )
+
+    config = Config.load(config_dir=tmp_path)
+    _write_starting_marker(config)
+
+    _remove_starting_marker(config)
+
+    assert not _starting_marker_path(config).exists()
+
+
+def test_remove_starting_marker_safe_when_missing(tmp_path: Path) -> None:
+    """Marker가 없어도 cleanup은 예외를 내지 않는다."""
+    from ante.main import _remove_starting_marker, _starting_marker_path
+
+    config = Config.load(config_dir=tmp_path)
+
+    _remove_starting_marker(config)
+
+    assert not _starting_marker_path(config).exists()
+
+
+def test_read_starting_marker_pid_returns_none_when_absent_or_corrupt(
+    tmp_path: Path,
+) -> None:
+    """Marker 부재/손상은 stale marker로 해석된다."""
+    from ante.main import _read_starting_marker_pid, _starting_marker_path
+
+    config = Config.load(config_dir=tmp_path)
+    marker = _starting_marker_path(config)
+
+    assert _read_starting_marker_pid(config) is None
+
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("not-a-pid")
+
+    assert _read_starting_marker_pid(config) is None
+
+
+@pytest.mark.asyncio
+async def test_main_writes_marker_before_pid_and_removes_after_init_ipc(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main()은 marker → PID → IPC ready → marker 제거 순서를 보존한다."""
+    import ante.db.migrations as migrations
+    import ante.main as main_module
+    import ante.update.checker as update_checker
+
+    monkeypatch.setenv("ANTE_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        main_module,
+        "_LEGACY_PID_FALLBACK",
+        tmp_path / "legacy" / "ante.pid",
+    )
+
+    calls: list[str] = []
+
+    original_write_marker = main_module._write_starting_marker
+    original_write_pid = main_module._write_pid_file
+    original_remove_marker = main_module._remove_starting_marker
+
+    def tracked_write_marker(config: Config) -> None:
+        calls.append("write_marker")
+        original_write_marker(config)
+
+    def tracked_write_pid(config: Config) -> None:
+        calls.append("write_pid")
+        original_write_pid(config)
+
+    def tracked_remove_marker(config: Config) -> None:
+        calls.append("remove_marker")
+        original_remove_marker(config)
+
+    monkeypatch.setattr(main_module, "_write_starting_marker", tracked_write_marker)
+    monkeypatch.setattr(main_module, "_write_pid_file", tracked_write_pid)
+    monkeypatch.setattr(main_module, "_remove_starting_marker", tracked_remove_marker)
+
+    async def fake_check_update_on_startup() -> None:
+        return None
+
+    async def fake_run_migrations(db: object, data_path: Path) -> list[str]:
+        return []
+
+    monkeypatch.setattr(
+        update_checker, "check_update_on_startup", fake_check_update_on_startup
+    )
+    monkeypatch.setattr(migrations, "run_migrations", fake_run_migrations)
+
+    async def fake_init_core(s: main_module.Services) -> None:
+        calls.append("init_core")
+        s.db = object()
+
+    async def fake_init_ipc(s: main_module.Services) -> None:
+        assert s.config is not None
+        calls.append("init_ipc")
+        assert main_module._read_starting_marker_pid(s.config) == os.getpid()
+        assert s.config.runtime_pid_path().exists()
+        s.config.runtime_socket_path().parent.mkdir(parents=True, exist_ok=True)
+        s.config.runtime_socket_path().touch()
+
+    async def fake_run(s: main_module.Services) -> None:
+        assert s.config is not None
+        calls.append("run")
+        assert not main_module._starting_marker_path(s.config).exists()
+        assert s.config.runtime_pid_path().exists()
+
+    async def fake_init_step(s: main_module.Services) -> None:
+        return None
+
+    for name in (
+        "_init_services",
+        "_init_account",
+        "_init_trading",
+        "_init_gateway",
+        "_init_feed",
+        "_init_approval",
+        "_init_notification",
+        "_init_web",
+    ):
+        monkeypatch.setattr(main_module, name, fake_init_step)
+    monkeypatch.setattr(main_module, "_init_core", fake_init_core)
+    monkeypatch.setattr(main_module, "_init_ipc", fake_init_ipc)
+    monkeypatch.setattr(main_module, "_run", fake_run)
+
+    await main_module.main()
+
+    config = Config.load(config_dir=tmp_path)
+    assert not main_module._starting_marker_path(config).exists()
+    assert not config.runtime_pid_path().exists()
+    assert calls[:4] == ["write_marker", "write_pid", "init_core", "init_ipc"]
+    assert calls[calls.index("init_ipc") + 1] == "remove_marker"
+    assert calls[-1] == "remove_marker"
+
+
+@pytest.mark.asyncio
+async def test_main_removes_marker_on_init_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """초기화 실패 시에도 marker와 PID를 cleanup한다."""
+    import ante.main as main_module
+
+    monkeypatch.setenv("ANTE_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        main_module,
+        "_LEGACY_PID_FALLBACK",
+        tmp_path / "legacy" / "ante.pid",
+    )
+
+    async def failing_init_core(s: Any) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(main_module, "_init_core", failing_init_core)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await main_module.main()
+
+    config = Config.load(config_dir=tmp_path)
+    assert not main_module._starting_marker_path(config).exists()
+    assert not config.runtime_pid_path().exists()

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -252,6 +252,88 @@ def test_account_cold_path_guard_uses_runtime_resolver_under_chdir(
     assert exc_info.value.code == 1
 
 
+# ── #1160: startup booting marker cold-path guard ────────────────
+
+
+def test_account_cold_path_guard_blocks_during_booting_with_matching_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PID alive + socket absent여도 matching marker가 있으면 starting으로 차단."""
+    from ante.cli.commands.account import _assert_no_active_runtime
+    from ante.cli.formatter import OutputFormatter
+    from ante.main import _write_pid_file, _write_starting_marker
+
+    monkeypatch.setenv("ANTE_CONFIG_DIR", str(tmp_path))
+    config = Config.load(config_dir=tmp_path)
+    _write_starting_marker(config)
+    _write_pid_file(config)
+
+    assert not config.runtime_socket_path().exists()
+
+    fmt = OutputFormatter(fmt="text")
+    with pytest.raises(SystemExit) as exc_info:
+        _assert_no_active_runtime(fmt)
+
+    assert exc_info.value.code == 1
+
+
+def test_account_cold_path_guard_passes_when_marker_has_different_pid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """다른 PID가 적힌 marker는 stale/recycled marker로 보고 통과한다."""
+    from ante.cli.commands.account import _assert_no_active_runtime
+    from ante.cli.formatter import OutputFormatter
+    from ante.main import _starting_marker_path, _write_pid_file
+
+    monkeypatch.setenv("ANTE_CONFIG_DIR", str(tmp_path))
+    config = Config.load(config_dir=tmp_path)
+    _write_pid_file(config)
+    marker = _starting_marker_path(config)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(str(os.getpid() + 1))
+
+    assert not config.runtime_socket_path().exists()
+
+    _assert_no_active_runtime(OutputFormatter(fmt="text"))
+
+
+def test_account_cold_path_guard_passes_when_neither_socket_nor_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PID alive지만 socket/marker가 모두 없으면 기존 stale 판정을 유지한다."""
+    from ante.cli.commands.account import _assert_no_active_runtime
+    from ante.cli.formatter import OutputFormatter
+    from ante.main import _write_pid_file
+
+    monkeypatch.setenv("ANTE_CONFIG_DIR", str(tmp_path))
+    config = Config.load(config_dir=tmp_path)
+    _write_pid_file(config)
+
+    assert not config.runtime_socket_path().exists()
+
+    _assert_no_active_runtime(OutputFormatter(fmt="text"))
+
+
+def test_account_cold_path_guard_passes_when_marker_corrupt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """손상된 marker는 stale marker로 보고 차단하지 않는다."""
+    from ante.cli.commands.account import _assert_no_active_runtime
+    from ante.cli.formatter import OutputFormatter
+    from ante.main import _starting_marker_path, _write_pid_file
+
+    monkeypatch.setenv("ANTE_CONFIG_DIR", str(tmp_path))
+    config = Config.load(config_dir=tmp_path)
+    _write_pid_file(config)
+    marker = _starting_marker_path(config)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("not-a-pid")
+
+    assert not config.runtime_socket_path().exists()
+
+    _assert_no_active_runtime(OutputFormatter(fmt="text"))
+
+
 # ── Codex attempt 1 P1 회귀: --config-dir 경로 PID 격리 ─────────────
 #
 # `read_pid_file()` 0-arg 분기는 `Config.load()` → `resolve_config_dir(None)` →


### PR DESCRIPTION
Closes #1160

## Summary
- Add a startup `.starting` marker derived from `runtime.pid_path` before writing the runtime PID.
- Remove the marker after IPC startup succeeds, and clean it up again on failure/shutdown paths.
- Update account cold-path guard so `PID alive AND (socket exists OR matching starting marker)` blocks structural account mutations during boot.
- Cover marker lifecycle, stale/corrupt marker handling, and startup ordering with unit tests.

## Test Plan
- `ruff format --check src/ante/main.py src/ante/cli/commands/account.py tests/unit/test_main_startup_ordering.py tests/unit/test_runtime_paths.py`
- `ruff check src/ante/main.py src/ante/cli/commands/account.py tests/unit/test_main_startup_ordering.py tests/unit/test_runtime_paths.py`
- `ruff check src/ tests/`
- `mypy src/ante/main.py src/ante/cli/commands/account.py`
- `mypy src/`
- `git diff --check`
- `PYTHONPATH=src .venv/bin/pytest -q tests/unit/test_main_startup_ordering.py`
- `PYTHONPATH=src .venv/bin/pytest -q tests/unit/test_runtime_paths.py -k 'starting_marker or booting_with_matching_marker or marker_has_different_pid or neither_socket_nor_marker or marker_corrupt or cold_path_guard_uses_runtime_resolver'`
- `PYTHONPATH=src .venv/bin/pytest -q tests/unit/test_runtime_paths.py tests/unit/test_account_cli.py`
- `PYTHONPATH=src .venv/bin/pytest -q tests/unit/test_main_startup_ordering.py tests/unit/test_main.py tests/unit/test_cli_system.py tests/unit/test_cli_update.py`
- `PYTHONPATH=src .venv/bin/pytest -x -q tests/unit` → `3437 passed, 2 skipped`

Note: the first full unit run inside the sandbox hit `/tmp` Unix socket bind `PermissionError`; the full unit suite was rerun outside the sandbox with the project `.venv` and passed.
