### PR TITLE
fix(bot): support cold-path remove

### DIFF
--- a/docs/specs/account/09-cli.md
+++ b/docs/specs/account/09-cli.md
@@ -56,6 +56,9 @@ runtime이 살아 있으면 `ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER` 
 `ante account delete`는 IPC 런타임 커맨드가 아니다. cold-path CLI에서 직접
 `AccountService.delete()`를 호출하며, 해당 계좌에 활성(non-deleted) 봇이 남아 있으면
 삭제는 `AccountHasActiveBotsError`로 차단된다(orphan bot 무결성).
+활성 봇이 남아 있으면 `ante bot remove <bot_id>`로 먼저 제거한다. `bot remove`는
+서버 실행 중에는 IPC, 서버 정지 중에는 cold-path cleanup으로 동작하므로 계좌 삭제
+복구를 위해 별도의 `ante system start`/`ante system stop` 왕복이 필요하지 않다.
 
 ### CLI 출력 예시
 

--- a/docs/specs/bot/03-design-decisions.md
+++ b/docs/specs/bot/03-design-decisions.md
@@ -204,10 +204,19 @@ BotManager.start_bot(bot_id)
     → BotStoppedEvent 발행
 ```
 
-CLI의 `bot create/start/stop/remove`와 `bot signal-key --rotate`는 위 흐름을 서버
+CLI의 `bot create/start/stop`과 `bot signal-key --rotate`는 위 흐름을 서버
 프로세스 안에서 실행해야 하므로 런타임 IPC 전용이다. 직접 DB 수정으로 봇 status나
 signal key를 바꾸면 `_bots`, 실행 task, EventBus 구독, 외부 signal channel이
 어긋나므로 허용하지 않는다.
+
+`bot remove`는 예외적으로 서버 실행 중에는 런타임 IPC, 서버 정지 상태에서는
+cold-path cleanup을 허용한다. cold-path 삭제는 BotManager를 만들지 않고 DB에
+남은 persisted state만 정리하며, 의미는 hot-path `handle_positions="keep"`과
+같다. 즉 broker live 연결이 필요한 포지션 청산은 하지 않고, `signal_keys` 폐기,
+`strategies/.running/{bot_id}` 스냅샷 삭제, Treasury budget 환수, `bots.status =
+'deleted'` 갱신만 수행한다. DB에 `running`/`stopping` 상태가 남아 있어도 서버가
+정지된 상태에서는 실행 task와 EventBus observer가 이미 부재하므로 stale status로
+보고 정리한다. 다음 서버 부팅 시 BotManager는 `deleted` 봇을 로드하지 않는다.
 
 ### 외부 시그널 채널
 

--- a/docs/specs/bot/06-cli-usage.md
+++ b/docs/specs/bot/06-cli-usage.md
@@ -8,10 +8,11 @@ CLI 명령 시그니처와 실행 분류의 SSOT는
 [cli/03-commands.md](../cli/03-commands.md#커맨드-상세)다. 이 문서는 Bot 관점의
 운영 흐름만 설명한다.
 
-봇의 생성·시작·중지·삭제와 signal key 갱신은 서버 BotManager의 인메모리 상태,
-실행 task, EventBus 구독, 외부 signal channel에 영향을 주므로 런타임 IPC로 처리한다.
-서버 실행 중 조회는 IPC로 live 상태를 우선 조회하고, 서버 정지 중에는 DB에 저장된
-persisted snapshot만 조회한다.
+봇의 생성·시작·중지와 signal key 갱신은 서버 BotManager의 인메모리 상태, 실행 task,
+EventBus 구독, 외부 signal channel에 영향을 주므로 런타임 IPC로 처리한다. `bot remove`는
+서버 실행 중에는 IPC로 BotManager에 위임하고, 서버 정지 중에는 cold-path cleanup으로
+DB의 persisted state를 직접 정리한다. 서버 실행 중 조회는 IPC로 live 상태를 우선
+조회하고, 서버 정지 중에는 DB에 저장된 persisted snapshot만 조회한다.
 
 ```bash
 # 전략 등록 후 봇 생성 — --account로 소속 계좌 지정 (active 계좌가 하나뿐이면 생략 가능)
@@ -34,7 +35,7 @@ ante bot status bot_001
 # 봇 중지
 ante bot stop bot_001
 
-# 봇 삭제
+# 봇 삭제 — 서버 실행 중이면 IPC, 서버 정지 중이면 cold-path cleanup
 ante bot remove bot_001
 
 # 시그널 키 관리
@@ -44,5 +45,11 @@ ante bot signal-key bot_002 --rotate     # 키 재발급
 # 외부 시그널 채널 연결 (양방향 JSON Lines 파이프)
 ante signal connect --key sk_a1b2c3d4
 ```
+
+cold-path `bot remove`는 BotManager를 만들지 않으며, `signal_keys` 행 삭제,
+전략 스냅샷 정리, Treasury budget 환수, `bots.status='deleted'` 갱신만 수행한다.
+PaperExecutor unregister, EventBus 구독 해제, `BotStoppedEvent` 발행은 서버 정지
+상태에서 대상 인메모리 객체가 없으므로 수행하지 않는다. cold-path에서
+`running`/`stopping` 상태는 stale status로 간주하며 포지션 청산은 지원하지 않는다.
 
 > 파일 구조: [docs/architecture/generated/project-structure.md](../../architecture/generated/project-structure.md) 참조

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -21,6 +21,7 @@
 | `offline` | 서버 프로세스와 무관하게 CLI가 직접 서비스/저장소를 생성해 실행한다. 서버 실행 중에도 live 상태를 바꾸지 않는다. |
 | `runtime IPC` | 서버 프로세스의 서비스 인스턴스, EventBus, 인메모리 상태, 외부 연결, 세션 상태가 필요하므로 IPC로 위임한다. |
 | `runtime IPC + snapshot fallback` | 서버 실행 중에는 IPC로 live 상태를 조회하고, 서버 정지 중에는 DB에 저장된 persisted snapshot만 조회한다. |
+| `runtime IPC + cold-path fallback` | 서버 실행 중에는 IPC로 live 상태를 변경하고, 서버 정지 중에는 정해진 persisted cleanup만 직접 수행한다. |
 | `cold-path` | 서버 topology 또는 broker 초기화 입력을 바꾸므로 active Ante runtime이 없는 상태에서만 직접 DB를 수정한다. |
 | `external process` | 별도 프로세스 실행, OS signal, 장기 실행 파이프/스케줄러처럼 CLI 프로세스 경계를 넘는 작업이다. |
 | `bootstrap/maintenance` | 초기화·복구 목적의 인증 면제 또는 서버 정지 fallback 경로다. |
@@ -48,7 +49,7 @@
 | `ante bot create --name <name> --strategy <strategy_id> ...` | `runtime IPC` | 서버 BotManager 생성 |
 | `ante bot start <bot_id>` | `runtime IPC` | 서버 BotManager 실행 task 생성 |
 | `ante bot stop <bot_id>` | `runtime IPC` | 서버 BotManager 실행 task 중지 |
-| `ante bot remove <bot_id>` | `runtime IPC` | 서버 BotManager 정리 |
+| `ante bot remove <bot_id>` | `runtime IPC + cold-path fallback` | 실행 중이면 서버 BotManager 정리, 정지 중이면 persisted bot cleanup |
 | `ante bot signal-key <bot_id> --rotate` | `runtime IPC` | 기존 signal channel 무효화 |
 | `ante trade list [--bot <bot_id>] [--from <date>] [--to <date>] [--limit N]` | `offline` | canonical DB 조회 |
 | `ante trade info <trade_id>` | `offline` | canonical DB 조회 |
@@ -134,11 +135,13 @@ ante bot positions <bot_id>        # 봇 현재 포지션
 ante bot signal-key <bot_id> [--rotate]  # 외부 시그널 키 조회·갱신
 ```
 
-`bot create/start/stop/remove`와 `bot signal-key --rotate`는 서버 BotManager의
-인메모리 `_bots`, 실행 task, EventBus 구독, signal key 연결 상태를 바꾸므로 런타임
-IPC 커맨드다. 서버 실행 중 `bot list/info/status/positions/signal-key` 조회는 IPC로
+`bot create/start/stop`과 `bot signal-key --rotate`는 서버 BotManager의 인메모리
+`_bots`, 실행 task, EventBus 구독, signal key 연결 상태를 바꾸므로 런타임 IPC 커맨드다.
+`bot remove`는 서버 실행 중에는 IPC로 BotManager에 위임하고, 서버 정지 중에는
+cold-path fallback으로 signal key, 전략 스냅샷, Treasury budget, `bots.status`만
+정리한다. 서버 실행 중 `bot list/info/status/positions/signal-key` 조회는 IPC로
 서버의 live 상태를 우선 조회한다. 서버가 정지된 상태에서는 DB의 persisted snapshot만
-읽을 수 있으며, 직접 DB 수정으로 봇 상태를 바꾸는 경로는 허용하지 않는다.
+읽을 수 있으며, `bot remove` 외 직접 DB 수정으로 봇 상태를 바꾸는 경로는 허용하지 않는다.
 
 `--strategy`는 등록된 `strategy_id`다. 전략 파일 경로를 직접 넘기려면 먼저
 `ante strategy submit <path>`로 등록해야 한다.

--- a/docs/specs/ipc/ipc.md
+++ b/docs/specs/ipc/ipc.md
@@ -90,12 +90,15 @@ CLI 명령 시그니처와 전체 실행 분류의 SSOT는
 | `ante bot create` | `bot.create` | `BotManager.create_bot()` | 등록된 `strategy_id`를 서버 StrategyRegistry에서 해석하고 BotManager 인메모리 `_bots` 반영 필요 |
 | `ante bot start` | `bot.start` | `BotManager.start_bot()` | asyncio task 생성 + `BotStartedEvent` 발행 |
 | `ante bot stop` | `bot.stop` | `BotManager.stop_bot()` | 실행 task 취소 + `BotStoppedEvent` 발행 |
-| `ante bot remove` | `bot.remove` | `BotManager.remove_bot()` | 실행 중 봇 중지, EventBus 구독 해제, signal key 회수, 인메모리 제거 필요 |
+| `ante bot remove` | `bot.remove` (server running) / cold-path cleanup (server stopped) | `BotManager.remove_bot()` / `cold_path_remove_bot()` | 실행 중에는 봇 중지, EventBus 구독 해제, signal key 회수, 인메모리 제거 필요. 서버 정지 중에는 persisted cleanup만 수행 |
 | `ante bot signal-key --rotate` | `bot.signal_key.rotate` | `BotManager.rotate_signal_key()` | 기존 signal channel 즉시 차단 + 새 key 발급 |
 
 서버 실행 중 `ante bot list/info/status/positions/signal-key`는 `bot.query` 계열 IPC로
 서버의 live 상태를 우선 조회한다. 서버가 정지된 상태에서는 DB에 저장된 persisted
-snapshot 조회만 허용하며, 직접 DB 수정으로 봇 상태를 변경하지 않는다.
+snapshot 조회만 허용한다. 단, `ante bot remove`는 #1161 cold-path 예외로 server stopped
+상태에서 `signal_keys`, 전략 스냅샷, Treasury budget, `bots.status='deleted'`만 직접
+정리할 수 있다. `handle_positions=liquidate`는 IPC/Web runtime 경로에서만 의미가 있고,
+cold-path 삭제는 항상 keep 의미다.
 
 #### Treasury
 

--- a/guide/cli.md
+++ b/guide/cli.md
@@ -719,7 +719,8 @@ ante bot create [OPTIONS]
 
 ### ante bot remove
 
-봇 삭제.
+봇 삭제. 서버 실행 중에는 IPC로 BotManager에 위임하고, 서버 정지 중에는
+cold-path cleanup으로 persisted state를 정리한다.
 
 - **필요 scope**: `bot:admin`
 - **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
@@ -739,6 +740,16 @@ ante bot remove <BOT_ID> [OPTIONS]
 | 옵션 | 필수 | 타입 | 기본값 | 설명 |
 |------|------|------|--------|------|
 | `--yes` | - | BOOLEAN | false | Confirm the action without prompting. |
+
+서버 정지 상태에서 실행하면 `signal_keys`, 전략 스냅샷, Treasury budget,
+`bots.status='deleted'`만 정리하며 포지션 청산은 하지 않는다.
+
+```bash
+ante bot remove bot_001 --yes
+ante --format json bot remove bot_001 --yes
+```
+
+cold-path JSON 출력에는 `"cold_path": true`가 포함된다.
 
 
 ### ante bot signal-key
@@ -2089,4 +2100,3 @@ ante feed inject <PATH> [OPTIONS]
 
 
 ---
-

--- a/src/ante/account/errors.py
+++ b/src/ante/account/errors.py
@@ -100,11 +100,10 @@ class AccountHasActiveBotsError(AccountError):
     조회하여 동일 ``account_id``의 활성 봇이 있으면 삭제를 거부한다. 이는
     봇이 가리키는 계좌가 사라져 orphan bot이 되는 무결성 위반을 막는다.
 
-    1.0 운영 절차(R-A mitigation): ``ante account delete``는 cold-path 전용,
-    ``ante bot remove``는 IPC runtime command이기 때문에 봇이 남은 계좌를
-    삭제하려면 다음 4단계를 순서대로 실행해야 한다. 메시지에 이 절차가 그대로
-    포함되어 사용자/Agent가 별도 문서를 참조하지 않고도 복구할 수 있다.
-    근본 해소(bot remove cold-path 지원)는 #1161에서 다룬다.
+    1.0 운영 절차: ``ante account delete``는 cold-path 전용이며, 남아 있는
+    봇은 ``ante bot remove``로 먼저 제거해야 한다. ``bot remove``는 서버 실행
+    중에는 IPC, 서버 정지 상태에서는 cold-path cleanup으로 동작하므로 계좌
+    삭제 복구 흐름에서 별도의 server start/stop 왕복이 필요하지 않다.
     """
 
     def __init__(self, account_id: str, bot_count: int) -> None:
@@ -113,10 +112,9 @@ class AccountHasActiveBotsError(AccountError):
         super().__init__(
             f"계좌 '{account_id}'에 연결된 활성 봇이 {bot_count}개 있어 "
             f"삭제할 수 없습니다. 다음 순서로 진행하세요:\n"
-            f"  1) ante system start\n"
-            f"  2) ante bot remove <bot_id>  (각 봇에 대해 반복)\n"
-            f"  3) ante system stop\n"
-            f"  4) ante account delete {account_id}"
+            f"  1) ante bot remove <bot_id>  "
+            f"(각 봇에 대해 반복, 서버 정지 상태에서도 가능)\n"
+            f"  2) ante account delete {account_id}"
         )
 
 

--- a/src/ante/bot/__init__.py
+++ b/src/ante/bot/__init__.py
@@ -9,7 +9,7 @@ from ante.bot.config import (
     validate_interval,
 )
 from ante.bot.context_factory import StrategyContextFactory
-from ante.bot.exceptions import BotError
+from ante.bot.exceptions import BOT_NOT_FOUND_CODE, BotError, BotNotFoundError
 from ante.bot.manager import BotManager
 from ante.bot.signal_key import SignalKeyManager
 
@@ -17,8 +17,10 @@ __all__ = [
     "Bot",
     "BotConfig",
     "BotError",
+    "BotNotFoundError",
     "BotManager",
     "BotStatus",
+    "BOT_NOT_FOUND_CODE",
     "MAX_INTERVAL_SECONDS",
     "MIN_INTERVAL_SECONDS",
     "SignalKeyManager",

--- a/src/ante/bot/cold_path.py
+++ b/src/ante/bot/cold_path.py
@@ -1,0 +1,140 @@
+"""Cold-path bot maintenance helpers.
+
+These helpers run only while the Ante server is stopped. They intentionally do
+not instantiate ``BotManager`` because no in-memory bot task, EventBus
+subscriber, PaperExecutor, or broker adapter exists in cold-path mode.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from ante.bot.config import BotStatus
+from ante.bot.exceptions import BotNotFoundError
+
+if TYPE_CHECKING:
+    from ante.core.database import Database
+
+logger = logging.getLogger(__name__)
+
+
+async def _release_treasury_budget(
+    db: Database,
+    *,
+    bot_id: str,
+    preferred_account_id: str,
+) -> float:
+    """Release persisted Treasury budget for ``bot_id``.
+
+    Mirrors ``BotManager.delete_bot``: try the bot's account first, then scan
+    all persisted budget account ids because legacy or cross-account rows may
+    not match ``bots.account_id`` (Refs #982/#1161).
+    """
+    from ante.eventbus.bus import EventBus
+    from ante.treasury.treasury import Treasury
+
+    async def release_for(account_id: str) -> float:
+        treasury = Treasury(db=db, eventbus=EventBus(), account_id=account_id)
+        await treasury.initialize()
+        return await treasury.release_budget(bot_id)
+
+    checked: set[str] = set()
+    released = await release_for(preferred_account_id)
+    checked.add(preferred_account_id)
+    if released > 0:
+        return released
+
+    # Legacy rows created before account-scoped budgets may have the migration
+    # default ``account_id=''``. Treat those as belonging to the bot row's
+    # account before falling back to the cross-account scan, otherwise the blank
+    # row can survive a cold-path delete.
+    await db.execute(
+        "UPDATE bot_budgets SET account_id = ? WHERE bot_id = ? AND account_id = ''",
+        (preferred_account_id, bot_id),
+    )
+    released = await release_for(preferred_account_id)
+    if released > 0:
+        return released
+
+    rows = await db.fetch_all(
+        "SELECT DISTINCT account_id FROM bot_budgets WHERE bot_id = ?",
+        (bot_id,),
+    )
+    for row in rows:
+        account_id = row.get("account_id")
+        if not account_id:
+            continue
+        if account_id in checked:
+            continue
+        released = await release_for(account_id)
+        checked.add(account_id)
+        if released > 0:
+            return released
+
+    return 0.0
+
+
+async def cold_path_remove_bot(
+    db: Database,
+    bot_id: str,
+    *,
+    strategies_dir: Path,
+) -> dict[str, Any]:
+    """Soft-delete a bot while the Ante server is stopped.
+
+    Cold-path removal is equivalent to hot-path ``handle_positions="keep"``:
+    it never liquidates positions because no live broker adapter exists. If the
+    persisted bot status is ``running``/``stopping``, that status is treated as
+    stale: server tasks and observers are already gone, and the next server boot
+    skips ``status='deleted'`` rows.
+    """
+    from ante.bot.manager import BOT_SCHEMA
+    from ante.bot.signal_key import SignalKeyManager
+    from ante.strategy.snapshot import StrategySnapshot
+
+    await db.execute_script(BOT_SCHEMA)
+    row = await db.fetch_one(
+        "SELECT bot_id, account_id, status FROM bots"
+        " WHERE bot_id = ? AND status != 'deleted'",
+        (bot_id,),
+    )
+    if row is None:
+        raise BotNotFoundError(bot_id)
+
+    account_id = row.get("account_id") or "test"
+    previous_status = row.get("status") or BotStatus.CREATED.value
+
+    signal_key_manager = SignalKeyManager(db)
+    await signal_key_manager.initialize()
+    signal_key_revoked = await signal_key_manager.revoke(bot_id)
+
+    StrategySnapshot(strategies_dir).cleanup(bot_id)
+
+    budget_released = await _release_treasury_budget(
+        db,
+        bot_id=bot_id,
+        preferred_account_id=account_id,
+    )
+
+    await db.execute(
+        "UPDATE bots SET status = 'deleted', updated_at = datetime('now')"
+        " WHERE bot_id = ?",
+        (bot_id,),
+    )
+    logger.info(
+        "cold-path 봇 삭제: %s (previous_status=%s, budget_released=%s)",
+        bot_id,
+        previous_status,
+        budget_released,
+    )
+
+    return {
+        "bot_id": bot_id,
+        "removed": True,
+        "cold_path": True,
+        "previous_status": previous_status,
+        "signal_key_revoked": signal_key_revoked,
+        "budget_released": budget_released,
+    }

--- a/src/ante/bot/exceptions.py
+++ b/src/ante/bot/exceptions.py
@@ -1,7 +1,19 @@
 """Bot 모듈 예외."""
 
+BOT_NOT_FOUND_CODE = "BOT_NOT_FOUND"
+
 
 class BotError(Exception):
     """Bot 기본 예외."""
 
     pass
+
+
+class BotNotFoundError(BotError):
+    """봇을 찾을 수 없음."""
+
+    code: str = BOT_NOT_FOUND_CODE
+
+    def __init__(self, bot_id: str) -> None:
+        self.bot_id = bot_id
+        super().__init__(f"Bot not found: {bot_id}")

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from ante.bot.bot import Bot
 from ante.bot.config import BotConfig, BotStatus
-from ante.bot.exceptions import BotError
+from ante.bot.exceptions import BotError, BotNotFoundError
 
 if TYPE_CHECKING:
     from ante.account.service import AccountService
@@ -574,7 +574,7 @@ class BotManager:
         """봇 조회. 없으면 예외."""
         bot = self._bots.get(bot_id)
         if bot is None:
-            raise BotError(f"Bot not found: {bot_id}")
+            raise BotNotFoundError(bot_id)
         return bot
 
     # ── 전략별 룰 관리 ─────────────────────────────────

--- a/src/ante/cli/cold_path.py
+++ b/src/ante/cli/cold_path.py
@@ -1,0 +1,72 @@
+"""Cold-path runtime guard helpers shared by CLI commands."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ante.cli.formatter import OutputFormatter
+
+ACCOUNT_COLD_PATH_BLOCKED_CODE = "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER"
+BOT_COLD_PATH_REMOVE_BLOCKED_CODE = "BOT_COLD_PATH_REMOVE_REQUIRES_STOPPED_SERVER"
+
+
+def is_active_runtime(
+    *,
+    kill: Callable[[int, int], None] | None = None,
+) -> bool:
+    """Return True when the canonical PID/socket pair marks an active runtime.
+
+    Refs #1157/#1160/#1161. The guard uses the current CLI ``config_dir`` and
+    treats a matching startup marker as active while the IPC socket is still
+    being created. Local imports preserve existing tests that monkeypatch
+    ``ante.main.read_pid_file`` and ``ante.cli.commands.ipc_helpers.get_socket_path``.
+    """
+    from ante.cli.main import get_config_dir
+    from ante.config import Config
+    from ante.main import _read_starting_marker_pid, read_pid_file
+
+    config_dir = get_config_dir()
+    config = Config.load(config_dir=config_dir)
+
+    pid = read_pid_file(config)
+    if pid is None:
+        return False
+
+    kill_fn = kill or os.kill
+    try:
+        kill_fn(pid, 0)
+    except OSError:
+        return False
+
+    from ante.cli.commands.ipc_helpers import get_socket_path
+
+    try:
+        socket_path = get_socket_path(config_dir=config_dir)
+    except Exception:
+        return False
+
+    if Path(socket_path).exists():
+        return True
+
+    # Refs #1160: PID alive + matching marker means the server is booting.
+    marker_pid = _read_starting_marker_pid(config)
+    return marker_pid == pid
+
+
+def assert_no_active_runtime(
+    fmt: OutputFormatter,
+    *,
+    code: str,
+    message: str,
+    kill: Callable[[int, int], None] | None = None,
+) -> None:
+    """Raise ``SystemExit(1)`` after printing ``code`` if runtime is active."""
+    if not is_active_runtime(kill=kill):
+        return
+
+    fmt.error(f"{code}: {message}", code=code)
+    raise SystemExit(1)

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import click
 
+from ante.cli.cold_path import (
+    ACCOUNT_COLD_PATH_BLOCKED_CODE,
+    assert_no_active_runtime,
+)
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
@@ -37,71 +40,27 @@ def _run(coro):  # noqa: ANN001, ANN202
 
 # Cold-path 차단 응답 코드. SSOT는 docs/specs/cli/03-commands.md 117-118줄,
 # docs/specs/account/09-cli.md 49-54줄.
-_COLD_PATH_BLOCKED_CODE = "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER"
+_COLD_PATH_BLOCKED_CODE = ACCOUNT_COLD_PATH_BLOCKED_CODE
 
 
 def _assert_no_active_runtime(fmt: OutputFormatter) -> None:
     """active Ante runtime이 있으면 cold-path 명령을 차단한다.
 
-    1.0 정책(단일 active runtime)에 따라 PID 파일이 가리키는 프로세스가
-    살아 있고 IPC socket이 존재하면 active runtime이 있는 것으로 본다.
-    PID는 alive지만 socket이 부재하면 stale PID로 보고 cold-path 진행을
-    허용한다(다른 프로세스가 해당 PID를 차지한 상태일 수 있다).
-
-    Refs #1157: ``--config-dir``로 가리킨 디렉토리의 canonical PID/socket만
-    본다. 명시적으로 ``Config.load(config_dir=get_config_dir())``로 인스턴스를
-    만들어 ``read_pid_file``과 ``get_socket_path`` 양쪽에 같은 ``config_dir``을
-    전파한다 — 0-arg ``read_pid_file()``은 ``ANTE_CONFIG_DIR`` env/default 폴백을
-    보므로, 다른 ``config_dir``로 실행 중인 server runtime을 cold-path가 누락해
-    split-brain 회귀(active server 중에 cold-path mutation 허용)를 일으킬 수 있다.
-
-    monkeypatch 호환을 위해 ``ante.main.read_pid_file``과
-    ``ante.cli.commands.ipc_helpers.get_socket_path``는 함수 내부에서
-    local import한다.
+    공유 헬퍼는 Refs #1157/#1160의 canonical config-dir, PID/socket, startup
+    marker 규칙을 사용한다. 이 래퍼는 기존 account 테스트와 import 경로를
+    유지하기 위한 호환 계층이다.
     """
-    from ante.cli.main import get_config_dir
-    from ante.config import Config
-    from ante.main import _read_starting_marker_pid, read_pid_file
-
-    config_dir = get_config_dir()
-    config = Config.load(config_dir=config_dir)
-
-    pid = read_pid_file(config)
-    if pid is None:
-        return  # PID 파일 부재 → active runtime 없음
-
-    try:
-        os.kill(pid, 0)
-    except OSError:
-        return  # stale PID → active runtime 없음
-
-    from ante.cli.commands.ipc_helpers import get_socket_path
-
-    try:
-        socket_path = get_socket_path(config_dir=config_dir)
-    except Exception:
-        # socket 경로 해석 실패 시는 차단 측으로 판정하지 않는다
-        # (config 부재 등). 그러나 PID alive 단독으로는 단정할 수 없으므로
-        # offline으로 간주한다.
-        return
-
-    if not Path(socket_path).exists():
-        # Refs #1160: boot 중에는 PID가 이미 alive지만 IPC socket이 아직 없을
-        # 수 있다. 이때 같은 PID가 기록된 starting marker가 있으면 starting도
-        # active runtime으로 보고 차단한다. marker 부재/손상/다른 PID는 stale
-        # 또는 recycled marker로 보고 기존처럼 통과한다.
-        marker_pid = _read_starting_marker_pid(config)
-        if marker_pid != pid:
-            return  # PID alive but neither socket nor matching marker → stale
-
-    # PID alive AND (socket exists OR matching starting marker) → active runtime.
-    # text 출력 경로도 차단 코드를 식별할 수 있도록 메시지에 prefix를 포함한다.
-    fmt.error(
-        f"{_COLD_PATH_BLOCKED_CODE}: 서버가 실행 중입니다. "
-        "cold-path 명령은 서버 정지 상태에서만 실행할 수 있습니다.",
+    # ``kill=os.kill``은 기존 테스트가 ``ante.cli.commands.account.os.kill``을
+    # monkeypatch하던 계약을 유지하기 위한 호환 주입점이다.
+    assert_no_active_runtime(
+        fmt,
         code=_COLD_PATH_BLOCKED_CODE,
+        message=(
+            "서버가 실행 중입니다. "
+            "cold-path 명령은 서버 정지 상태에서만 실행할 수 있습니다."
+        ),
+        kill=os.kill,
     )
-    raise SystemExit(1)
 
 
 async def _create_account_service() -> tuple[AccountService, Database]:

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from pathlib import Path
 
 import click
 
+from ante.cli.cold_path import is_active_runtime
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
 
@@ -49,6 +51,27 @@ async def _audit_log(db, **kwargs) -> None:  # noqa: ANN001
         await al.log(**kwargs)
     except Exception as e:
         logger.warning("감사 로그 기록 실패: %s", e)
+
+
+async def _run_bot_remove_cold_path(bot_id: str) -> dict:
+    """서버 정지 상태에서 BotManager 없이 봇을 soft-delete한다."""
+    from ante.bot.cold_path import cold_path_remove_bot
+    from ante.cli.main import get_config_dir, get_db_path
+    from ante.config import Config
+    from ante.core.database import Database
+
+    db = Database(get_db_path())
+    await db.connect()
+    try:
+        config = Config.load(config_dir=get_config_dir())
+        strategies_dir = Path(str(config.get("strategy.dir", "strategies")))
+        return await cold_path_remove_bot(
+            db,
+            bot_id,
+            strategies_dir=strategies_dir,
+        )
+    finally:
+        await db.close()
 
 
 @bot.command("list")
@@ -256,27 +279,35 @@ def bot_create(
 @require_auth
 @require_scope("bot:admin")
 def bot_remove(ctx: click.Context, bot_id: str) -> None:
-    """봇 삭제."""
+    """봇 삭제.
+
+    서버가 실행 중이면 기존 IPC 경로를 사용하고, 서버가 정지되어 있으면
+    cold-path service가 persisted DB/signal key/snapshot/treasury state를 정리한다.
+    """
     fmt = get_formatter(ctx)
     actor = get_member_id(ctx)
 
     async def _run_remove() -> dict:
         from ante.cli.commands.ipc_helpers import ipc_send
 
-        return await ipc_send("bot.remove", {"bot_id": bot_id}, actor=actor)
+        if is_active_runtime():
+            return await ipc_send("bot.remove", {"bot_id": bot_id}, actor=actor)
+        return await _run_bot_remove_cold_path(bot_id)
 
     try:
         result = _run(_run_remove())
     except click.ClickException:
         raise
     except Exception as e:
-        fmt.error(str(e))
-        return
+        fmt.error(str(e), code=getattr(e, "code", ""))
+        raise SystemExit(1) from e
 
     if result.get("removed"):
-        fmt.success(f"봇 삭제 완료: {bot_id}")
+        suffix = "(cold-path)" if result.get("cold_path") else ""
+        fmt.success(f"봇 삭제 완료{suffix}: {bot_id}", result)
     else:
         fmt.error(f"봇을 찾을 수 없습니다: {bot_id}")
+        raise SystemExit(1)
 
 
 @bot.command("signal-key")

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -26,7 +26,7 @@ from ante.web.schemas import (
 
 router = APIRouter()
 
-_BOT_NOT_FOUND = "봇을 찾을 수 없습니다"
+_BOT_NOT_FOUND = "BOT_NOT_FOUND: 봇을 찾을 수 없습니다"
 
 
 class BotCreateRequest(BaseModel):

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -403,14 +403,10 @@ async def test_delete_succeeds_when_only_deleted_bots(service, db):
 
 
 @pytest.mark.asyncio
-async def test_delete_error_message_includes_multistep_procedure(service, db):
-    """AccountHasActiveBotsError 메시지는 multi-step 복구 절차를 안내한다 (#1139 R-A).
-
-    1.0에서 cold-path delete는 active 봇이 있으면 차단되지만, ``ante bot remove``
-    는 IPC 전용이므로 운영자는 (start → bot remove → stop → account delete) 4단계
-    절차를 따라야 한다. 에러 메시지에 이 절차가 정확한 순서로 포함되어야 하며,
-    ``account_id``와 ``bot_count``도 함께 노출되어야 한다 (#1161까지의 mitigation).
-    """
+async def test_delete_error_message_includes_cold_path_bot_remove_procedure(
+    service, db
+):
+    """AccountHasActiveBotsError 메시지는 cold-path bot remove 복구 절차를 안내한다."""
     import re
 
     from ante.account.errors import AccountHasActiveBotsError
@@ -434,19 +430,20 @@ async def test_delete_error_message_includes_multistep_procedure(service, db):
     assert "test" in message
     assert "1" in message
 
-    # 4개 절차 토큰이 모두 포함되어야 한다
-    assert "ante system start" in message
+    # server start/stop 없이 bot remove → account delete 순서만 안내한다 (#1161).
+    assert "ante system start" not in message
+    assert "ante system stop" not in message
     assert "ante bot remove" in message
-    assert "ante system stop" in message
     assert "ante account delete" in message
+    assert "서버 정지 상태에서도 가능" in message
 
     # 정확한 순서로 등장해야 한다 (multi-step 절차의 핵심)
     order_pattern = re.compile(
-        r"ante system start.*?ante bot remove.*?ante system stop.*?ante account delete",
+        r"ante bot remove.*?ante account delete",
         re.DOTALL,
     )
     assert order_pattern.search(message) is not None, (
-        f"multi-step 절차가 정확한 순서로 메시지에 포함되어야 한다: {message!r}"
+        f"cold-path 복구 절차가 정확한 순서로 메시지에 포함되어야 한다: {message!r}"
     )
 
 

--- a/tests/unit/test_bot_cold_path.py
+++ b/tests/unit/test_bot_cold_path.py
@@ -1,0 +1,173 @@
+"""Refs #1161 — bot remove cold-path cleanup tests."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from ante.core import Database
+
+
+@pytest.fixture
+async def db(tmp_path: Path):
+    database = Database(str(tmp_path / "ante.db"))
+    await database.connect()
+    yield database
+    await asyncio.wait_for(database.close(), timeout=5.0)
+
+
+async def _insert_bot(
+    db: Database,
+    *,
+    bot_id: str = "bot-1",
+    account_id: str = "test",
+    status: str = "created",
+) -> None:
+    from ante.bot.manager import BOT_SCHEMA
+
+    await db.execute_script(BOT_SCHEMA)
+    await db.execute(
+        """INSERT INTO bots
+           (bot_id, name, strategy_id, account_id, config_json, status)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (bot_id, "테스트봇", "strat", account_id, "{}", status),
+    )
+
+
+async def test_cold_path_remove_cleans_persisted_state(
+    db: Database,
+    tmp_path: Path,
+) -> None:
+    """cold-path remove는 signal key, snapshot, treasury budget, bot row를 정리한다."""
+    from ante.bot.cold_path import cold_path_remove_bot
+    from ante.bot.signal_key import SignalKeyManager
+    from ante.eventbus import EventBus
+    from ante.treasury.treasury import Treasury
+
+    await _insert_bot(db, status="running")
+
+    signal_keys = SignalKeyManager(db)
+    await signal_keys.initialize()
+    await signal_keys.generate("bot-1")
+
+    strategies_dir = tmp_path / "strategies"
+    snapshot_dir = strategies_dir / ".running" / "bot-1"
+    snapshot_dir.mkdir(parents=True)
+    (snapshot_dir / "strategy.py").write_text("x = 1\n")
+
+    treasury = Treasury(db=db, eventbus=EventBus(), account_id="test")
+    await treasury.initialize()
+    await treasury.set_account_balance(1_000_000)
+    assert await treasury.allocate("bot-1", 250_000)
+
+    result = await cold_path_remove_bot(db, "bot-1", strategies_dir=strategies_dir)
+
+    assert result["removed"] is True
+    assert result["cold_path"] is True
+    assert result["previous_status"] == "running"
+    assert result["signal_key_revoked"] is True
+    assert result["budget_released"] == 250_000
+
+    bot_row = await db.fetch_one("SELECT status FROM bots WHERE bot_id = ?", ("bot-1",))
+    assert bot_row == {"status": "deleted"}
+    assert await signal_keys.get_key("bot-1") is None
+    assert (
+        await db.fetch_one("SELECT * FROM bot_budgets WHERE bot_id = ?", ("bot-1",))
+        is None
+    )
+    assert not snapshot_dir.exists()
+
+    release_rows = await db.fetch_all(
+        "SELECT * FROM treasury_transactions"
+        " WHERE bot_id = ? AND transaction_type = 'release'",
+        ("bot-1",),
+    )
+    assert len(release_rows) == 1
+
+
+async def test_cold_path_remove_releases_cross_account_budget(
+    db: Database,
+    tmp_path: Path,
+) -> None:
+    """bot row account와 budget account가 달라도 persisted budget을 찾아 환수한다."""
+    from ante.bot.cold_path import cold_path_remove_bot
+    from ante.eventbus import EventBus
+    from ante.treasury.treasury import Treasury
+
+    await _insert_bot(db, account_id="bot-account")
+    treasury = Treasury(db=db, eventbus=EventBus(), account_id="budget-account")
+    await treasury.initialize()
+    await treasury.set_account_balance(500_000)
+    assert await treasury.allocate("bot-1", 100_000)
+
+    result = await cold_path_remove_bot(
+        db,
+        "bot-1",
+        strategies_dir=tmp_path / "strategies",
+    )
+
+    assert result["budget_released"] == 100_000
+    assert (
+        await db.fetch_one("SELECT * FROM bot_budgets WHERE bot_id = ?", ("bot-1",))
+        is None
+    )
+
+
+async def test_cold_path_remove_releases_legacy_empty_account_budget(
+    db: Database,
+    tmp_path: Path,
+) -> None:
+    """마이그레이션 기본값 account_id='' budget도 bot row 계좌로 환수한다."""
+    from ante.bot.cold_path import cold_path_remove_bot
+    from ante.eventbus import EventBus
+    from ante.treasury.treasury import Treasury
+
+    await _insert_bot(db, account_id="bot-account")
+    treasury = Treasury(db=db, eventbus=EventBus(), account_id="bot-account")
+    await treasury.initialize()
+    await treasury.set_account_balance(500_000)
+    assert await treasury.allocate("bot-1", 120_000)
+    await db.execute(
+        "UPDATE bot_budgets SET account_id = '' WHERE bot_id = ?",
+        ("bot-1",),
+    )
+
+    result = await cold_path_remove_bot(
+        db,
+        "bot-1",
+        strategies_dir=tmp_path / "strategies",
+    )
+
+    assert result["budget_released"] == 120_000
+    assert (
+        await db.fetch_one("SELECT * FROM bot_budgets WHERE bot_id = ?", ("bot-1",))
+        is None
+    )
+
+    release = await db.fetch_one(
+        "SELECT account_id FROM treasury_transactions"
+        " WHERE bot_id = ? AND transaction_type = 'release'",
+        ("bot-1",),
+    )
+    assert release == {"account_id": "bot-account"}
+
+
+async def test_cold_path_remove_missing_bot_raises_bot_not_found(
+    db: Database,
+    tmp_path: Path,
+) -> None:
+    """존재하지 않거나 deleted 상태인 bot은 BOT_NOT_FOUND로 실패한다."""
+    from ante.bot.cold_path import cold_path_remove_bot
+    from ante.bot.exceptions import BOT_NOT_FOUND_CODE, BotNotFoundError
+
+    with pytest.raises(BotNotFoundError) as exc_info:
+        await cold_path_remove_bot(
+            db,
+            "missing",
+            strategies_dir=tmp_path / "strategies",
+        )
+
+    assert exc_info.value.code == BOT_NOT_FOUND_CODE
+    assert "missing" in str(exc_info.value)

--- a/tests/unit/test_cli_bot_treasury_ipc.py
+++ b/tests/unit/test_cli_bot_treasury_ipc.py
@@ -249,14 +249,15 @@ class TestBotCreateIpc:
 
 
 class TestBotRemoveIpc:
-    """bot remove 커맨드가 IPC를 통해 서버에 전달되는지 검증."""
+    """bot remove 커맨드가 runtime/cold-path 분기를 선택하는지 검증."""
 
+    @patch("ante.cli.commands.bot.is_active_runtime", return_value=True)
     @patch(
         "ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp/test.sock"
     )
     @patch("ante.cli.commands.ipc_helpers.IPCClient")
-    def test_bot_remove_ipc(self, mock_ipc_cls, mock_socket) -> None:
-        """bot remove가 bot.remove IPC 커맨드를 전송한다."""
+    def test_bot_remove_ipc(self, mock_ipc_cls, mock_socket, mock_active) -> None:
+        """active runtime이면 bot.remove IPC 커맨드를 전송한다."""
         mock_client = AsyncMock()
         mock_client.send.return_value = {
             "id": "req-1",
@@ -275,11 +276,68 @@ class TestBotRemoveIpc:
         assert call_args[0][0] == "bot.remove"
         assert call_args[0][1] == {"bot_id": "bot-abc"}
 
+    @patch("ante.cli.commands.bot.is_active_runtime", return_value=False)
+    @patch("ante.cli.commands.bot._run_bot_remove_cold_path")
+    def test_bot_remove_cold_path(self, mock_cold_path, mock_active) -> None:
+        """server stopped이면 cold-path service를 호출한다."""
+        mock_cold_path.return_value = {
+            "bot_id": "bot-abc",
+            "removed": True,
+            "cold_path": True,
+        }
+
+        result = _invoke_cli(["bot", "remove", "bot-abc", "--yes"])
+
+        assert result.exit_code == 0
+        assert "봇 삭제 완료(cold-path)" in result.output
+        mock_cold_path.assert_awaited_once_with("bot-abc")
+
+    @patch("ante.cli.commands.bot.is_active_runtime", return_value=False)
+    @patch("ante.cli.commands.bot._run_bot_remove_cold_path")
+    def test_bot_remove_cold_path_not_found(self, mock_cold_path, mock_active) -> None:
+        """cold-path service의 BOT_NOT_FOUND는 non-zero exit로 노출된다."""
+        from ante.bot.exceptions import BotNotFoundError
+
+        mock_cold_path.side_effect = BotNotFoundError("bot-xxx")
+
+        result = _invoke_cli(["bot", "remove", "bot-xxx", "--yes"])
+
+        assert result.exit_code == 1
+        assert "Bot not found: bot-xxx" in result.output
+
+    @pytest.mark.asyncio
+    async def test_bot_remove_cold_path_closes_db_on_failure(self) -> None:
+        """cold-path helper는 service 실패 시에도 DB close를 보장한다."""
+        from ante.cli.commands.bot import _run_bot_remove_cold_path
+
+        fake_db = AsyncMock()
+        fake_config = MagicMock()
+        fake_config.get.return_value = "strategies"
+
+        with (
+            patch("ante.cli.main.get_db_path", return_value="/tmp/ante-test.db"),
+            patch("ante.cli.main.get_config_dir", return_value=None),
+            patch("ante.config.Config.load", return_value=fake_config),
+            patch("ante.core.database.Database", return_value=fake_db),
+            patch(
+                "ante.bot.cold_path.cold_path_remove_bot",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                await _run_bot_remove_cold_path("bot-abc")
+
+        fake_db.connect.assert_awaited_once()
+        fake_db.close.assert_awaited_once()
+
+    @patch("ante.cli.commands.bot.is_active_runtime", return_value=True)
     @patch(
         "ante.cli.commands.ipc_helpers.get_socket_path", return_value="/tmp/test.sock"
     )
     @patch("ante.cli.commands.ipc_helpers.IPCClient")
-    def test_bot_remove_server_error(self, mock_ipc_cls, mock_socket) -> None:
+    def test_bot_remove_server_error(
+        self, mock_ipc_cls, mock_socket, mock_active
+    ) -> None:
         """서버 에러 시 사용자에게 에러 메시지를 출력한다."""
         mock_client = AsyncMock()
         mock_client.send.return_value = {


### PR DESCRIPTION
Closes #1161

## Summary
- Add a shared cold-path runtime guard and route `ante bot remove` through IPC only while the server is active.
- Add stopped-server bot removal that soft-deletes the bot row and cleans persisted signal key, strategy snapshot, and Treasury budget state.
- Add `BOT_NOT_FOUND` error typing, update CLI/Web/docs surfaces, and remove the old account-delete start/stop workaround guidance.
- Preserve legacy/cross-account Treasury budget cleanup, including migrated `account_id=''` rows.

## Test Plan
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `mypy src/`
- `git diff --check`
- `pytest -q tests/unit/test_bot_cold_path.py tests/unit/test_cli_bot_treasury_ipc.py tests/unit/test_account.py`
- `pytest -q tests/unit/test_bot_cold_path.py tests/unit/test_cli_bot_treasury_ipc.py tests/unit/test_account.py tests/unit/test_runtime_paths.py tests/unit/test_bot.py tests/unit/test_bot_delete_budget.py tests/unit/test_bot_delete_positions.py tests/unit/test_signal_key.py tests/unit/test_bot_api.py tests/unit/ipc/test_registry.py`
- `pytest -x -q tests/unit`

## Branch Review
- Codex branch review against `origin/main`: PASS at `559f313`
- First review found legacy blank-account Treasury budget cleanup gap; fixed and re-reviewed.
