### PR TITLE
chore(ci): align GitHub Actions Python runtime to 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: "pip"
 
       - name: Install dependencies
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: "pip"
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Build package
         run: |

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install python-semantic-release
         run: pip install python-semantic-release


### PR DESCRIPTION
Closes #1188

## Summary

#1185 에픽 결정 (CPython 3.13 단일 지원)에 따라 GitHub Actions의 Python setup 4곳을 `3.12` → `3.13`으로 정렬합니다. #1186(사용자-facing 문서)이 머지된 다음 단계이며, 본 PR이 머지되면 #1187(pyproject `requires-python = ">=3.13,<3.14"`)의 hard prerequisite가 해소됩니다.

### 변경 라인 (3개 파일, 총 4줄)

- `.github/workflows/ci.yml:25` lint job `python-version: "3.12"` → `"3.13"`
- `.github/workflows/ci.yml:47` test job `python-version: "3.12"` → `"3.13"`
- `.github/workflows/semantic-release.yml:24` `python-version: "3.12"` → `"3.13"`
- `.github/workflows/publish.yml:36` `python-version: "3.12"` → `"3.13"`

### Risk Flags

- `dependency-runtime` — pandas-ta + numpy/pandas/numba/llvmlite의 첫 Python 3.13 hosted runner install. 본 PR `ci`의 `pip install -e ".[dev]"` 단계에서 확인. 실패 시 #1191으로 분기.
- `cache-staleness` — `actions/setup-python@v5`의 pip cache는 Python 버전을 키에 포함하므로 자동 갱신. 별도 `actions/cache` 없음 (확인됨).
- `release-pipeline (운영 검증 한계)` — `semantic-release.yml`은 `workflow_dispatch` 전용, `publish.yml`은 `release.published`+`workflow_dispatch`라 본 PR `ci`로 자동 검증되지 않습니다. 머지 후 다음 manual dispatch 또는 release 시점에 운영자가 Python 3.13 로그를 확인해 주세요.
- `contract-drift (역방향)` — 본 PR 머지 후 일시적으로 CI는 3.13, pyproject는 `>=3.11`, ruff/mypy는 `py311`/`3.11`. 의도된 단계이며 #1187 머지 후 정렬됩니다.

## Test Plan

- [x] failing/passing rg verification 통과
  - `rg -n 'python-version' .github/workflows` → 4개 모두 `"3.13"`
  - `rg -n '3\.11|3\.12' .github/workflows` → 0건
- [x] Non-Goals 무변경 확인 (`pyproject.toml`, `Dockerfile`, `src/`, `tests/`, `.pre-commit-config.yaml`)
- [x] `/codex:review --base origin/main` PASS (blocking finding 없음)
- [ ] 본 PR `ci` (lint + test) PASS — Python 3.13 hosted runner에서 첫 install 검증
- [ ] 본 PR `docker-build` PASS
- [ ] CI 로그에서 Python 3.13.x 버전 출력 확인
- [ ] CI 로그에서 `pandas-ta-...`, `numpy-...`, `pandas-...`, `numba-...`, `llvmlite-...` install 성공 확인

## 후속 unblock

- #1187 (pyproject `requires-python = ">=3.13,<3.14"`) — 본 PR 머지 후 `blocked` 라벨 해제 가능
- #1192 (IPC 분기 단순화) — #1187 머지 후 `blocked` 라벨 해제 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)