### PR TITLE
chore(deps,ipc,docker): align project to Python 3.13 single runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY pyproject.toml ../pyproject.toml
 RUN npm run build
 
 # Stage 2: Python 런타임
-FROM python:3.12-slim AS runtime
+FROM python:3.13-slim AS runtime
 WORKDIR /app
 
 # 시스템 의존성

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,12 @@ build-backend = "hatchling.build"
 name = "ante"
 version = "0.9.0"
 description = "AI-Native Trading Engine"
-requires-python = ">=3.11"
+requires-python = ">=3.13,<3.14"
 dependencies = [
     "aiohttp>=3.9",
     "aiosqlite>=0.20",
     "polars>=1.0",
-    "pandas-ta>=0.4.67b0",
+    "pandas-ta>=0.4.71b0",
     "click>=8.1",
     "fastapi>=0.115",
     "uvicorn>=0.34",
@@ -45,14 +45,14 @@ asyncio_mode = "auto"
 addopts = ["--import-mode=importlib"]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py313"
 src = ["src", "tests"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.13"
 warn_unused_configs = true
 ignore_missing_imports = true
 # CI 단계적 강화: 현재는 위험 오류(attr-defined, operator, call-arg 등)만 차단

--- a/src/ante/ipc/server.py
+++ b/src/ante/ipc/server.py
@@ -12,11 +12,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import sys
 import uuid
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from ante.ipc import protocol
 from ante.ipc.exceptions import MessageTooLargeError
@@ -92,22 +91,13 @@ class IPCServer:
 
         Refs #1184: 메서드 종료 시 state를 ``RUNNING``으로 전환한다.
 
-        Python 버전별 동작 차이:
-
-        * **Python 3.11 / 3.12**: ``loop.create_unix_server``는 ``server.close()``
-          시 socket 파일을 자동으로 unlink하지 **않는다** (해당 동작 자체가
-          stdlib에 없다). 따라서 별도 옵션 없이도 본 모듈의 lifecycle 가정이
-          성립한다.
-        * **Python 3.13+**: ``loop.create_unix_server``에 ``cleanup_socket``
-          인자가 추가되었고 **기본값이 ``True``** 이다 — 즉 ``server.close()``
-          가 socket 파일을 자동으로 unlink하므로 race window 회귀가 깨진다.
-          이를 막기 위해 3.13+에서만 ``cleanup_socket=False``를 명시적으로
-          전달한다.
-
-        ``cleanup_socket`` 인자를 무조건 전달하면 3.11/3.12에서
-        ``TypeError: create_unix_server() got an unexpected keyword argument
-        'cleanup_socket'`` 으로 부팅이 실패한다 (#1159 attempt 1 회귀). 따라서
-        ``sys.version_info`` 분기로 3.13+에서만 인자를 추가한다.
+        Refs #1185, #1187: Ante는 Python 3.13 단일 런타임을 공식 계약으로 한다.
+        Python 3.13의 ``asyncio.start_unix_server``는 ``cleanup_socket`` 인자를
+        받으며 기본값이 ``True``이다. 본 메서드는 ``cleanup_socket=False``를
+        명시적으로 전달해 ``server.close()`` 시 socket 파일이 자동 unlink되지
+        않게 만든다 — 이로써 cold-path guard(``PID alive AND socket exists``)가
+        shutdown 동안에도 'active runtime'을 정확히 판정할 수 있는 race window
+        차단 의도가 유지된다 (Refs #1159).
         """
         path = Path(self._socket_path)
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -116,13 +106,10 @@ class IPCServer:
         if path.exists():
             path.unlink()
 
-        kwargs: dict[str, Any] = {"path": self._socket_path}
-        if sys.version_info >= (3, 13):
-            kwargs["cleanup_socket"] = False
-
         self._server = await asyncio.start_unix_server(
             self._handle_connection,
-            **kwargs,
+            path=self._socket_path,
+            cleanup_socket=False,
         )
 
         # 소켓 파일 권한 설정 (소유자만 접근)


### PR DESCRIPTION
Closes #1187
Closes #1189
Closes #1192

## Summary

#1185 에픽 결정(CPython 3.13 단일 지원, `>=3.13,<3.14`)에 따라 패키지 메타데이터/IPC 코드/Docker 운영 이미지를 같은 기준으로 정렬하는 atomic PR입니다. 처음에는 #1187 단독 PR로 시작했으나, codex 브랜치 리뷰가 두 가지 atomic 의존을 지적해 #1192와 #1189를 흡수했습니다:

- ruff `target-version = "py313"` 변경(#1187)이 `src/ante/ipc/server.py:120`의 `sys.version_info >= (3, 13)` 분기에 UP036을 발동 → #1192 작업이 같은 PR에서 정리되지 않으면 lint 차단
- pyproject `requires-python = ">=3.13,<3.14"`가 머지되면 Dockerfile `python:3.12-slim`의 `pip install`이 Python 버전 불일치로 실패 → #1189 작업이 같은 PR에서 정렬되지 않으면 Docker build 차단

세 이슈가 사실상 하나의 atomic 변경이므로 단일 PR로 통합했습니다 (autopilot 자율 결정, 사후 보고는 각 이슈 코멘트 참조).

## 변경 (3개 파일, +15/-28)

### `pyproject.toml` (#1187)

- `requires-python = ">=3.11"` → `">=3.13,<3.14"`
- `pandas-ta>=0.4.67b0` → `pandas-ta>=0.4.71b0` (검증된 버전 하한 상향)
- `[tool.ruff] target-version = "py311"` → `"py313"`
- `[tool.mypy] python_version = "3.11"` → `"3.13"`

### `src/ante/ipc/server.py` (#1192)

- `import sys` 제거
- `sys.version_info >= (3, 13)` 분기 제거, `cleanup_socket=False`를 unconditional로 전달
- `start()` docstring을 Python 3.13 단일 런타임 기준으로 정리 (race window 차단 의도, cold-path guard, `cleanup_socket=False` 근거 보존)

### `Dockerfile` (#1189)

- line 11: `FROM python:3.12-slim AS runtime` → `FROM python:3.13-slim AS runtime`

## Test Plan

### Static checks (전체 통과)

- [x] `grep -nE 'requires-python|target-version|python_version' pyproject.toml` → 3.13 정렬
- [x] `rg -n "sys\.version_info|^import sys" src/ante/ipc/server.py` → 0건
- [x] `rg -n "race|cold-path|cleanup_socket" src/ante/ipc/server.py` → 의도 보존
- [x] `rg -n "python:3\.12|python3\.12" Dockerfile` → 0건
- [x] `ruff check src/ tests/` PASS (UP036 해소)
- [x] `ruff format --check src/ tests/` PASS
- [x] `mypy src/` PASS (230 source files, 0 issues)
- [x] `pytest tests/unit -q` PASS (3444 passed, 2 skipped)
- [x] `pytest tests/unit/ipc/test_server_client.py -q` PASS (#1159 lifecycle 회귀 케이스 17 passed)
- [x] `pytest tests/unit/test_main_shutdown_ordering.py -q` PASS (9 passed)

### Local Docker smoke (codex P1 안전망)

- [x] `docker build -t ante:python313 .` exit 0 (3분 58초, native wheel source build 0건)
- [x] `docker run --rm ante:python313 python --version` → `Python 3.13.13`
- [x] `docker run --rm ante:python313 python -c "from ante.web import app; print('OK')"` → `OK`
- [x] `pandas_ta` import 정상 (`pandas-ta-0.4.71b0`)
- [x] native wheel install 결과 (모두 cp313/abi3 manylinux 사전빌드):
  - `aiohttp-3.13.5`, `aiosqlite-0.22.1`, `cryptography-47.0.0`(abi3), `llvmlite-0.44.0`, `numba-0.61.2`, `numpy-2.2.6`, `pandas-3.0.2`, `pandas-ta-0.4.71b0`, `polars-1.40.1`, `websockets-16.0`

### Codex 브랜치 리뷰

- [x] 1차: P1 finding 1건 (`Dockerfile python:3.12-slim` 불일치) → #1189 흡수로 해소
- [x] 2차: PASS (blocking 없음, 변경 사항이 기존 동작을 깨는 문제 미발견)

## Risk Flags

- `lifecycle`: IPC Unix socket startup/shutdown 회귀 가능성 — `tests/unit/ipc/test_server_client.py`의 #1159 케이스 + `tests/unit/test_main_shutdown_ordering.py`로 회귀 검증 통과.
- `dependency-runtime`: pandas-ta + numpy/pandas/numba/llvmlite의 cp313 wheel 가용성 — 로컬 Docker build로 모두 사전빌드 wheel 확인 (source build 0건).
- `tooling`: Ruff py313 / MyPy 3.13 변경 — UP036 1건은 #1192 작업으로 해소, 그 외 새 오류 없음.

## 후속 unblock

- #1190 (로컬 런타임 드리프트 방지) — `plan-preflight:done`. 본 PR과 독립.
- #1191 (pandas-ta 회귀 검증) — `plan-preflight` 미시작. 본 PR 머지 후 진행 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)