### PR TITLE
refactor(cli): make bot create/remove non-interactive

### DIFF
--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -165,24 +165,29 @@ def _parse_param(value: str) -> tuple[str, object]:
     return key.strip(), parsed
 
 
-def _select_account_interactive(accounts: list) -> str:
-    """활성 계좌 목록에서 대화형으로 계좌를 선택한다."""
-    if not accounts:
-        click.echo("활성 계좌가 없습니다. 먼저 계좌를 등록하세요.")
-        raise SystemExit(1)
+def _resolve_account_non_interactive(accounts: list, fmt) -> str:  # noqa: ANN001
+    """활성 계좌 목록에서 비대화형으로 계좌를 선택한다.
 
+    - 활성 계좌가 정확히 1개면 자동 선택한다.
+    - 활성 계좌가 0개 또는 2개 이상이면 prompt 없이
+      `BOT_MISSING_REQUIRED_ACCOUNT` 에러로 실패한다.
+    """
     if len(accounts) == 1:
-        selected = accounts[0]
-        msg = f"계좌 자동 선택: {selected.account_id}"
-        msg += f" ({selected.exchange} / {selected.currency})"
-        click.echo(msg)
-        return selected.account_id
+        return accounts[0].account_id
 
-    click.echo("계좌를 선택하세요:")
-    for i, acc in enumerate(accounts, 1):
-        click.echo(f"  {i}) {acc.account_id} ({acc.exchange} / {acc.currency})")
-    choice = click.prompt("", type=click.IntRange(1, len(accounts)))
-    return accounts[choice - 1].account_id
+    if not accounts:
+        fmt.error(
+            "활성 계좌가 없습니다. 먼저 계좌를 등록한 뒤 --account <id>로 지정하세요.",
+            code="BOT_MISSING_REQUIRED_ACCOUNT",
+        )
+    else:
+        ids = ", ".join(acc.account_id for acc in accounts)
+        fmt.error(
+            "활성 계좌가 여러 개입니다. --account <id>로 명시하세요."
+            f" (가능한 계좌: {ids})",
+            code="BOT_MISSING_REQUIRED_ACCOUNT",
+        )
+    raise SystemExit(1)
 
 
 @bot.command("create")
@@ -192,7 +197,7 @@ def _select_account_interactive(accounts: list) -> str:
     "--account",
     "account_id",
     default=None,
-    help="계좌 ID (미지정 시 대화형 선택)",
+    help="계좌 ID (미지정 시 단일 active 계좌 자동 선택, 0개/2개 이상 시 에러)",
 )
 @click.option(
     "--interval",
@@ -233,7 +238,8 @@ def bot_create(
             fmt.error(str(e))
             return
 
-    # 계좌 미지정 시 대화형 선택
+    # 계좌 미지정 시 비대화형 resolver — 단일 active 계좌면 자동 선택,
+    # 그 외(0개/2개 이상)에는 BOT_MISSING_REQUIRED_ACCOUNT로 실패한다.
     if account_id is None:
         from ante.account.models import AccountStatus
 
@@ -242,7 +248,7 @@ def bot_create(
             return await account_service.list(status=AccountStatus.ACTIVE)
 
         accounts = _run(_list_accounts())
-        account_id = _select_account_interactive(accounts)
+        account_id = _resolve_account_non_interactive(accounts, fmt)
 
     resolved_account_id = account_id
 
@@ -274,18 +280,32 @@ def bot_create(
 
 @bot.command("remove")
 @click.argument("bot_id")
-@click.confirmation_option(prompt="봇을 삭제합니다. 계속하시겠습니까?")
+@click.option(
+    "--yes",
+    "yes",
+    is_flag=True,
+    default=False,
+    help="삭제를 확인 (위험 명령). 누락 시 prompt 없이 에러로 실패",
+)
 @click.pass_context
 @require_auth
 @require_scope("bot:admin")
-def bot_remove(ctx: click.Context, bot_id: str) -> None:
+def bot_remove(ctx: click.Context, bot_id: str, yes: bool) -> None:
     """봇 삭제.
 
     서버가 실행 중이면 기존 IPC 경로를 사용하고, 서버가 정지되어 있으면
     cold-path service가 persisted DB/signal key/snapshot/treasury state를 정리한다.
+    `--yes` 누락 시 prompt 없이 `CLI_CONFIRMATION_REQUIRED` 에러로 종료한다.
     """
     fmt = get_formatter(ctx)
     actor = get_member_id(ctx)
+
+    if not yes:
+        fmt.error(
+            "위험 명령입니다. --yes를 명시해야 봇을 삭제합니다.",
+            code="CLI_CONFIRMATION_REQUIRED",
+        )
+        raise SystemExit(1)
 
     async def _run_remove() -> dict:
         from ante.cli.commands.ipc_helpers import ipc_send

--- a/tests/unit/test_cli_account_integration.py
+++ b/tests/unit/test_cli_account_integration.py
@@ -180,7 +180,7 @@ class TestBotListAccountFilter:
         assert data["bots"][0]["account_id"] == "domestic"
 
 
-# ── bot create --account (대화형 선택) ──────────────────
+# ── bot create --account (비대화형) ─────────────────────
 
 
 class TestBotCreateAccountOption:
@@ -221,7 +221,7 @@ class TestBotCreateAccountOption:
         assert sent_args["account_id"] == "domestic"
 
     def test_bot_create_interactive_single_account(self, runner):
-        """계좌 미지정 + 활성 계좌 1개 → 자동 선택."""
+        """계좌 미지정 + 활성 계좌 1개 → 자동 선택 (비대화형)."""
         mock_account_svc = _make_mock_account_service([_MOCK_ACCOUNT_1])
         mock_client = AsyncMock()
         mock_client.send.return_value = {
@@ -250,29 +250,20 @@ class TestBotCreateAccountOption:
             )
 
         assert result.exit_code == 0
-        assert "계좌 자동 선택" in result.output
-        assert "domestic" in result.output
+        # 단일 active 계좌가 자동 선택되어 IPC payload의 account_id로 전달된다.
+        sent_args = mock_client.send.call_args[0][1]
+        assert sent_args["account_id"] == _MOCK_ACCOUNT_1.account_id
 
-    def test_bot_create_interactive_multiple_accounts(self, runner):
-        """계좌 미지정 + 활성 계좌 여러 개 → 대화형 선택."""
+    def test_bot_create_multiple_accounts_requires_explicit_account(self, runner):
+        """계좌 미지정 + 활성 계좌 여러 개 → BOT_MISSING_REQUIRED_ACCOUNT 에러.
+
+        prompt 없이 즉시 실패해야 한다 (비대화형 입력 계약).
+        """
         mock_account_svc = _make_mock_account_service(
             [_MOCK_ACCOUNT_1, _MOCK_ACCOUNT_2]
         )
-        mock_client = AsyncMock()
-        mock_client.send.return_value = {
-            "id": "req-1",
-            "status": "ok",
-            "result": {"bot_id": "bot-abc123"},
-        }
 
-        with (
-            patch("ante.cli.commands.bot._create_services") as mock_cs,
-            patch(
-                "ante.cli.commands.ipc_helpers.get_socket_path",
-                return_value="/tmp/test.sock",
-            ),
-            patch("ante.cli.commands.ipc_helpers.IPCClient", return_value=mock_client),
-        ):
+        with patch("ante.cli.commands.bot._create_services") as mock_cs:
             mock_cs.return_value = (
                 _make_mock_db(),
                 MagicMock(),
@@ -281,17 +272,26 @@ class TestBotCreateAccountOption:
             )
             result = runner.invoke(
                 cli,
-                ["bot", "create", "--name", "테스트봇", "--strategy", "s1"],
-                input="1\n",
+                [
+                    "--format",
+                    "json",
+                    "bot",
+                    "create",
+                    "--name",
+                    "테스트봇",
+                    "--strategy",
+                    "s1",
+                ],
+                input="",
             )
 
-        assert result.exit_code == 0
-        assert "계좌를 선택하세요" in result.output
-        assert "domestic" in result.output
-        assert "overseas" in result.output
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["code"] == "BOT_MISSING_REQUIRED_ACCOUNT"
+        assert "--account" in data["error"]
 
-    def test_bot_create_interactive_no_accounts(self, runner):
-        """계좌 미지정 + 활성 계좌 0개 → 에러."""
+    def test_bot_create_no_accounts_returns_missing_required_account(self, runner):
+        """계좌 미지정 + 활성 계좌 0개 → BOT_MISSING_REQUIRED_ACCOUNT 에러."""
         mock_account_svc = _make_mock_account_service([])
 
         with patch("ante.cli.commands.bot._create_services") as mock_cs:
@@ -303,11 +303,22 @@ class TestBotCreateAccountOption:
             )
             result = runner.invoke(
                 cli,
-                ["bot", "create", "--name", "테스트봇", "--strategy", "s1"],
+                [
+                    "--format",
+                    "json",
+                    "bot",
+                    "create",
+                    "--name",
+                    "테스트봇",
+                    "--strategy",
+                    "s1",
+                ],
+                input="",
             )
 
         assert result.exit_code == 1
-        assert "활성 계좌가 없습니다" in result.output
+        data = json.loads(result.output)
+        assert data["code"] == "BOT_MISSING_REQUIRED_ACCOUNT"
 
 
 # ── system halt/activate (IPC) ──────────────────────────

--- a/tests/unit/test_cli_bot_treasury_ipc.py
+++ b/tests/unit/test_cli_bot_treasury_ipc.py
@@ -257,7 +257,7 @@ class TestBotRemoveIpc:
     )
     @patch("ante.cli.commands.ipc_helpers.IPCClient")
     def test_bot_remove_ipc(self, mock_ipc_cls, mock_socket, mock_active) -> None:
-        """active runtime이면 bot.remove IPC 커맨드를 전송한다."""
+        """active runtime이면 bot.remove IPC 커맨드를 전송한다 (--yes 명시)."""
         mock_client = AsyncMock()
         mock_client.send.return_value = {
             "id": "req-1",
@@ -275,6 +275,28 @@ class TestBotRemoveIpc:
         call_args = mock_client.send.call_args
         assert call_args[0][0] == "bot.remove"
         assert call_args[0][1] == {"bot_id": "bot-abc"}
+
+    @patch("ante.cli.commands.bot.is_active_runtime", return_value=True)
+    @patch("ante.cli.commands.ipc_helpers.IPCClient")
+    def test_bot_remove_without_yes_fails_confirmation_required(
+        self, mock_ipc_cls, mock_active
+    ) -> None:
+        """`--yes` 누락 시 prompt 없이 CLI_CONFIRMATION_REQUIRED 에러로 실패."""
+        mock_client = AsyncMock()
+        mock_ipc_cls.return_value = mock_client
+
+        # JSON 모드로 에러 코드를 직접 검증한다.
+        result = _invoke_cli(["--format", "json", "bot", "remove", "bot-abc"])
+
+        assert result.exit_code == 1
+        # IPC가 호출되지 않아야 한다 (확인 게이트 통과 전 차단).
+        mock_client.send.assert_not_awaited()
+
+        import json as _json
+
+        data = _json.loads(result.output)
+        assert data["code"] == "CLI_CONFIRMATION_REQUIRED"
+        assert "--yes" in data["error"]
 
     @patch("ante.cli.commands.bot.is_active_runtime", return_value=False)
     @patch("ante.cli.commands.bot._run_bot_remove_cold_path")


### PR DESCRIPTION
Closes #1175

## Summary

#1170 에픽 (CLI 비대화형) 세 번째 단계. #1171 (PR #1203, sha 72e2620) 머지로 SSOT 확정 후 `bot create --account` 선택 prompt와 `bot remove` confirmation prompt를 비대화형으로 전환.

## 변경 (3개 파일)

- `src/ante/cli/commands/bot.py`
  - `_select_account_interactive()` → `_resolve_account_non_interactive()`로 교체. `click.prompt(...)` (L184) 제거.
  - `bot create --account` 정책: 단일 active 자동 선택 / 0개·2개 이상 → `BOT_MISSING_REQUIRED_ACCOUNT` 에러
  - `bot remove`: `@click.confirmation_option` 제거 → `@click.option("--yes", is_flag=True)` 추가. `--yes` 누락 시 IPC 호출 전 `CLI_CONFIRMATION_REQUIRED`
- `tests/unit/test_cli_account_integration.py`
  - `test_bot_create_interactive_multiple_accounts` 제거 (`input="1\n"` 더 이상 유효 없음)
  - `test_bot_create_interactive_single_account` 출력 assertion → `exit_code == 0` + IPC payload `account_id` 검증으로 교체
  - `test_bot_create_interactive_no_accounts` → `BOT_MISSING_REQUIRED_ACCOUNT` 교체
  - `test_bot_create_multiple_accounts_requires_explicit_account` 신규
- `tests/unit/test_cli_bot_treasury_ipc.py`
  - `test_bot_remove_without_yes_fails_confirmation_required` 신규
  - `test_bot_remove --yes` IPC 케이스 유지

## Risk Flags

- `single-active-auto-select` — 단일 계좌 자동 선택은 #1171 SSOT가 명시적으로 허용 (stdin prompt 금지와 별개 케이스).
- `ipc-contract` — `bot.create` / `bot.remove` IPC 페이로드 구조 변경 없음.
- `decorator-order` — `@click.option("--yes")`는 `@click.argument("bot_id")` 다음에 배치, 인증·스코프 통과 후 callback 안에서 `--yes` 검사.

## Test Plan

- [x] `pytest tests/unit/test_cli_account_integration.py tests/unit/test_cli_bot_treasury_ipc.py -v` → 35 passed
- [x] `pytest tests/unit -q -k "bot or cli"` → 859 passed (영역 회귀 없음)
- [x] `ruff check src/ante/cli tests/unit` → All checks passed
- [x] `ruff format --check src/ante/cli tests/unit` → 223 files already formatted
- [x] `mypy src/ante/cli` → 28 source files, 0 issues
- [x] `grep -nE "click\.prompt|click\.confirm|confirmation_option" src/ante/cli/commands/bot.py` → 0건
- [x] `/codex:review --base origin/main` PASS (blocking 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)