### PR TITLE
refactor(cli): make account create/set-credentials/delete non-interactive

### DIFF
--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -162,8 +162,15 @@ def _parse_broker_config_value(raw: str) -> Any:
 
     1.0 free-form pass-through 정책(`docs/specs/cli/03-commands.md`
     `--broker-config` 정책 절)을 따른다. 알 수 없는 key는 검증하지 않으며,
-    값만 bool/int/Decimal/str 순서로 변환한다. broker adapter는 자기에게
+    값만 bool/int/float/str 순서로 변환한다. broker adapter는 자기에게
     필요한 known key만 읽고 나머지는 silent ignore할 수 있다.
+
+    소수 값(`"1.5"`, `"0.00015"` 등)은 `float`로 변환한다. KIS adapter는
+    `config.get("retry.backoff_base_seconds", ...)`처럼 numeric 값을 직접
+    소비하므로(`src/ante/broker/kis.py`), 문자열로 저장하면 후속 산술
+    연산에서 `TypeError`가 발생한다. 또한 `Account.broker_config`는
+    `service.create()`에서 `json.dumps(...)`로 직렬화되므로(`Decimal`은
+    JSON serializable이 아님) `float`이 안전한 native JSON 타입이다.
     """
     lowered = raw.strip().lower()
     if lowered in ("true", "false"):
@@ -177,18 +184,15 @@ def _parse_broker_config_value(raw: str) -> Any:
     except ValueError:
         pass
 
-    # Decimal 시도. JSON 직렬화 호환을 위해 str로 보내야 하는 소비자
-    # (`json.dumps`)가 있으므로 Decimal은 service 레이어에서 그대로
-    # `dict[str, Any]`에 저장된다. service.create는 broker_config를
-    # `json.dumps(account.broker_config)`로 직렬화하므로 Decimal은
-    # str(Decimal)로 fallback해야 한다 — 따라서 broker_config에는
-    # str을 보낸다.
+    # Decimal로 파싱 가능하면 float 반환. Decimal로 일단 검증한 뒤
+    # ``float(text)``로 변환하여 KIS adapter의 `float` 소비 계약과
+    # `json.dumps`의 native JSON 타입 요구를 동시에 만족시킨다.
     try:
         Decimal(text)
     except InvalidOperation:
         return raw
 
-    return text
+    return float(text)
 
 
 def _resolve_credentials(
@@ -232,6 +236,20 @@ def _resolve_credentials(
 
     for raw in direct_pairs:
         key, value = _split_key_value(raw, fmt=fmt, option_label="--credential")
+        # 직접 채널도 env/file과 일관되게 빈 값(공란)을 거부한다.
+        # 빈 credential은 broker adapter 인증에 사용할 수 없는 unusable 값이며,
+        # `--credential app_key=` 같은 입력은 사용자 실수일 가능성이 매우 높다.
+        # SSOT: docs/specs/cli/02-design-decisions.md 표준 에러 코드 표 —
+        # ``ACCOUNT_MISSING_REQUIRED_CREDENTIAL``.
+        if value == "":
+            _exit_with_error(
+                fmt,
+                "ACCOUNT_MISSING_REQUIRED_CREDENTIAL",
+                (
+                    f"--credential {key}: 값이 비어 있습니다. "
+                    "credential 값은 비어 있을 수 없습니다."
+                ),
+            )
         _set_or_dup(key, value, "--credential")
 
     for raw in env_pairs:

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -1,11 +1,25 @@
-"""ante account -- 계좌 관리 커맨드."""
+"""ante account -- 계좌 관리 커맨드.
+
+비대화형 입력 계약(`docs/specs/cli/02-design-decisions.md` — 비대화형 입력 계약)을
+구현한다. `account create`, `account set-credentials`, `account delete`는
+stdin prompt/confirm을 사용하지 않고, 옵션/환경변수/파일/명시적 `--yes`로만
+입력을 받는다. 누락 입력은 prompt 없이 구조화된 에러로 종료한다.
+
+에러 코드 SSOT는 `docs/specs/cli/02-design-decisions.md`의 표준 에러 코드 표를
+따른다(`ACCOUNT_MISSING_REQUIRED_CREDENTIAL`, `ACCOUNT_UNKNOWN_CREDENTIAL_KEY`,
+`ACCOUNT_DUPLICATE_CREDENTIAL_KEY`, `ACCOUNT_CREDENTIAL_ENV_NOT_SET`,
+`ACCOUNT_CREDENTIAL_FILE_NOT_FOUND`, `CLI_MISSING_REQUIRED_INPUT`,
+`CLI_CONFIRMATION_REQUIRED`).
+"""
 
 from __future__ import annotations
 
 import asyncio
 import logging
 import os
-from typing import TYPE_CHECKING, Any
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import click
 
@@ -96,15 +110,330 @@ def _get_selectable_broker_types() -> list[str]:
     return list(BROKER_REGISTRY.keys())
 
 
+# ── 비대화형 입력 helper ─────────────────────────────────────────
+
+
+def _exit_with_error(fmt: OutputFormatter, code: str, message: str) -> NoReturn:
+    """구조화된 에러를 출력하고 SystemExit(1)으로 종료한다.
+
+    text/json 양쪽 표면에 에러 코드가 일관되게 노출되도록 한다.
+    JSON 모드(`OutputFormatter.is_json`)에서는 `OutputFormatter.error`가
+    `{"error": ..., "code": ...}` 형식으로 dump한다. text 모드에서는
+    `OutputFormatter.error`가 message만 출력하므로, 사람/Agent가 같은
+    표면에서 코드를 읽을 수 있도록 message 본문에 `CODE: ` prefix를
+    덧붙인다(cold-path 헬퍼 ``cold_path.assert_no_active_runtime``과 동일
+    contract).
+
+    반환 타입은 ``NoReturn``이므로, 호출 후 후속 코드는 mypy 관점에서
+    unreachable하다(env/file 분기에서 None narrowing 등).
+    """
+    fmt.error(f"{code}: {message}", code=code)
+    raise SystemExit(1)
+
+
+def _split_key_value(
+    raw: str, *, fmt: OutputFormatter, option_label: str
+) -> tuple[str, str]:
+    """`key=value` 한 쌍을 파싱한다. 형식 위반 시 즉시 종료.
+
+    `=`가 한 번도 등장하지 않거나, key가 공란이면 `CLI_MISSING_REQUIRED_INPUT`
+    으로 종료한다. 값에는 `=`가 추가로 들어와도 그대로 유지한다(쉘 인자
+    이스케이프와의 호환을 위해 첫 `=`만 분리자로 본다).
+    """
+    if "=" not in raw:
+        _exit_with_error(
+            fmt,
+            "CLI_MISSING_REQUIRED_INPUT",
+            f"{option_label} 옵션은 key=value 형식이어야 합니다: {raw!r}",
+        )
+    key, _, value = raw.partition("=")
+    key = key.strip()
+    if not key:
+        _exit_with_error(
+            fmt,
+            "CLI_MISSING_REQUIRED_INPUT",
+            f"{option_label} 옵션의 key가 비어 있습니다: {raw!r}",
+        )
+    return key, value
+
+
+def _parse_broker_config_value(raw: str) -> Any:
+    """`--broker-config key=value`의 value 부분을 안전하게 파싱한다.
+
+    1.0 free-form pass-through 정책(`docs/specs/cli/03-commands.md`
+    `--broker-config` 정책 절)을 따른다. 알 수 없는 key는 검증하지 않으며,
+    값만 bool/int/Decimal/str 순서로 변환한다. broker adapter는 자기에게
+    필요한 known key만 읽고 나머지는 silent ignore할 수 있다.
+    """
+    lowered = raw.strip().lower()
+    if lowered in ("true", "false"):
+        return lowered == "true"
+
+    text = raw.strip()
+    # int 우선 시도 (음수 포함). bool 다음 순서로 평가하여
+    # "0"/"1" 같은 값이 bool로 잘못 변환되는 회귀를 막는다.
+    try:
+        return int(text)
+    except ValueError:
+        pass
+
+    # Decimal 시도. JSON 직렬화 호환을 위해 str로 보내야 하는 소비자
+    # (`json.dumps`)가 있으므로 Decimal은 service 레이어에서 그대로
+    # `dict[str, Any]`에 저장된다. service.create는 broker_config를
+    # `json.dumps(account.broker_config)`로 직렬화하므로 Decimal은
+    # str(Decimal)로 fallback해야 한다 — 따라서 broker_config에는
+    # str을 보낸다.
+    try:
+        Decimal(text)
+    except InvalidOperation:
+        return raw
+
+    return text
+
+
+def _resolve_credentials(
+    *,
+    fmt: OutputFormatter,
+    required_keys: list[str],
+    direct_pairs: tuple[str, ...],
+    env_pairs: tuple[str, ...],
+    file_pairs: tuple[str, ...],
+) -> dict[str, str]:
+    """credential 입력 채널 3개를 합쳐 최종 credentials를 만든다.
+
+    SSOT(`docs/specs/cli/02-design-decisions.md` 표):
+    - 알 수 없는 key → ``ACCOUNT_UNKNOWN_CREDENTIAL_KEY``
+    - 동일 key 중복 채널 → ``ACCOUNT_DUPLICATE_CREDENTIAL_KEY``
+    - env 미설정/공란 → ``ACCOUNT_CREDENTIAL_ENV_NOT_SET``
+    - file 부재/읽기 실패/공란 → ``ACCOUNT_CREDENTIAL_FILE_NOT_FOUND``
+    - 누락된 required key → ``ACCOUNT_MISSING_REQUIRED_CREDENTIAL``
+
+    required_keys가 빈 리스트(예: 향후 broker preset)면 모든 입력이 unknown
+    이 되므로, 이 경우 credentials는 비어 있어야 한다(빈 dict 반환).
+    """
+    required_set = set(required_keys)
+    seen: dict[str, str] = {}
+
+    def _set_or_dup(key: str, value: str, channel: str) -> None:
+        if required_set and key not in required_set:
+            _exit_with_error(
+                fmt,
+                "ACCOUNT_UNKNOWN_CREDENTIAL_KEY",
+                f"알 수 없는 credential key: {key!r} ({channel}). "
+                f"허용되는 key: {sorted(required_set)}",
+            )
+        if key in seen:
+            _exit_with_error(
+                fmt,
+                "ACCOUNT_DUPLICATE_CREDENTIAL_KEY",
+                f"credential key {key!r}가 둘 이상 채널로 중복 입력되었습니다.",
+            )
+        seen[key] = value
+
+    for raw in direct_pairs:
+        key, value = _split_key_value(raw, fmt=fmt, option_label="--credential")
+        _set_or_dup(key, value, "--credential")
+
+    for raw in env_pairs:
+        key, env_name = _split_key_value(raw, fmt=fmt, option_label="--credential-env")
+        env_name_clean = env_name.strip()
+        if not env_name_clean:
+            _exit_with_error(
+                fmt,
+                "CLI_MISSING_REQUIRED_INPUT",
+                f"--credential-env {key}의 환경변수 이름이 비어 있습니다.",
+            )
+        env_value = os.environ.get(env_name_clean)
+        if env_value is None or env_value == "":
+            _exit_with_error(
+                fmt,
+                "ACCOUNT_CREDENTIAL_ENV_NOT_SET",
+                (
+                    f"--credential-env {key}={env_name_clean}: "
+                    "환경변수가 설정되지 않았거나 공란입니다."
+                ),
+            )
+        _set_or_dup(key, env_value, "--credential-env")
+
+    for raw in file_pairs:
+        key, path_str = _split_key_value(raw, fmt=fmt, option_label="--credential-file")
+        path_clean = path_str.strip()
+        if not path_clean:
+            _exit_with_error(
+                fmt,
+                "CLI_MISSING_REQUIRED_INPUT",
+                f"--credential-file {key}의 파일 경로가 비어 있습니다.",
+            )
+        path = Path(path_clean)
+        try:
+            content = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            _exit_with_error(
+                fmt,
+                "ACCOUNT_CREDENTIAL_FILE_NOT_FOUND",
+                f"--credential-file {key}={path_clean}: 파일을 찾을 수 없습니다.",
+            )
+        except OSError as exc:
+            _exit_with_error(
+                fmt,
+                "ACCOUNT_CREDENTIAL_FILE_NOT_FOUND",
+                (
+                    f"--credential-file {key}={path_clean}: "
+                    f"파일을 읽을 수 없습니다 ({exc})."
+                ),
+            )
+        # 파일 끝의 단일 개행은 제거하되, 그 외 공백·내용은 보존한다.
+        # (PEM/JSON 등 의미 있는 줄바꿈이 포함될 수 있음을 가정하지 않는다 —
+        # credential value는 단일 토큰이라는 1.0 가정.)
+        value = content.rstrip("\r\n")
+        if value == "":
+            _exit_with_error(
+                fmt,
+                "ACCOUNT_CREDENTIAL_FILE_NOT_FOUND",
+                f"--credential-file {key}={path_clean}: 파일이 비어 있습니다.",
+            )
+        _set_or_dup(key, value, "--credential-file")
+
+    if required_set:
+        missing = sorted(required_set - seen.keys())
+        if missing:
+            _exit_with_error(
+                fmt,
+                "ACCOUNT_MISSING_REQUIRED_CREDENTIAL",
+                (
+                    f"필수 credential 누락: {missing}. "
+                    "--credential / --credential-env / --credential-file 중 "
+                    "하나로 모두 제공해야 합니다."
+                ),
+            )
+
+    return seen
+
+
+def _resolve_broker_config(
+    *,
+    fmt: OutputFormatter,
+    pairs: tuple[str, ...],
+) -> dict[str, Any]:
+    """`--broker-config key=value` 반복 옵션을 dict로 파싱한다.
+
+    1.0 free-form pass-through 정책: known key 검증 없이 그대로 통과시킨다.
+    같은 key가 두 번 들어오면 명시적으로 거부한다(silent overwrite는 입력
+    오류의 흔적을 가리므로). 값은 bool/int/str 순으로 안전하게 파싱한다.
+    """
+    out: dict[str, Any] = {}
+    for raw in pairs:
+        key, value_str = _split_key_value(raw, fmt=fmt, option_label="--broker-config")
+        if key in out:
+            _exit_with_error(
+                fmt,
+                "CLI_MISSING_REQUIRED_INPUT",
+                f"--broker-config key {key!r}가 중복 입력되었습니다.",
+            )
+        out[key] = _parse_broker_config_value(value_str)
+    return out
+
+
+def _validate_broker_type(fmt: OutputFormatter, broker_type: str) -> None:
+    """`--broker-type`이 BROKER_REGISTRY에 등록된 값인지 확인한다.
+
+    SSOT: `docs/specs/cli/03-commands.md` Broker 책임 경계 — `BROKER_REGISTRY`가
+    `broker_type` 문자열 → 어댑터 매핑의 SSOT.
+    """
+    selectable = _get_selectable_broker_types()
+    if broker_type not in selectable:
+        _exit_with_error(
+            fmt,
+            "CLI_MISSING_REQUIRED_INPUT",
+            (
+                f"등록되지 않은 broker_type: {broker_type!r}. "
+                f"허용 값: {sorted(selectable)}"
+            ),
+        )
+
+
 # ── create ──────────────────────────────────────
 
 
 @account.command("create")
+@click.option(
+    "--broker-type",
+    "broker_type",
+    required=False,
+    default=None,
+    help="브로커 타입 (BROKER_REGISTRY 등록 값, 예: test, kis-domestic)",
+)
+@click.option(
+    "--account-id",
+    "account_id_opt",
+    required=False,
+    default=None,
+    help="신규 계좌 식별자",
+)
+@click.option(
+    "--name",
+    "name_opt",
+    required=False,
+    default=None,
+    help="계좌 표시 이름",
+)
+@click.option(
+    "--trading-mode",
+    "trading_mode_opt",
+    required=False,
+    default=None,
+    type=click.Choice(["virtual", "live"], case_sensitive=False),
+    help="거래 모드 (virtual 또는 live)",
+)
+@click.option(
+    "--credential",
+    "credentials_direct",
+    multiple=True,
+    metavar="KEY=VALUE",
+    help="credential 직접 값 (테스트/로컬 편의용, 비권장 — shell history 노출)",
+)
+@click.option(
+    "--credential-env",
+    "credentials_env",
+    multiple=True,
+    metavar="KEY=ENV_NAME",
+    help="credential을 환경변수에서 읽는다 (권장 채널)",
+)
+@click.option(
+    "--credential-file",
+    "credentials_file",
+    multiple=True,
+    metavar="KEY=PATH",
+    help="credential을 파일에서 읽는다 (권장 채널)",
+)
+@click.option(
+    "--broker-config",
+    "broker_config_pairs",
+    multiple=True,
+    metavar="KEY=VALUE",
+    help="broker-specific 설정 (free-form pass-through, 예: is_paper=true)",
+)
+@format_option
 @click.pass_context
 @require_auth
 @require_scope("account:write")
-def account_create(ctx: click.Context) -> None:
-    """대화형 계좌 생성."""
+def account_create(
+    ctx: click.Context,
+    broker_type: str | None,
+    account_id_opt: str | None,
+    name_opt: str | None,
+    trading_mode_opt: str | None,
+    credentials_direct: tuple[str, ...],
+    credentials_env: tuple[str, ...],
+    credentials_file: tuple[str, ...],
+    broker_config_pairs: tuple[str, ...],
+) -> None:
+    """비대화형 계좌 생성 (cold-path 전용).
+
+    필수 옵션: ``--broker-type``, ``--account-id``, ``--name``, ``--trading-mode``.
+    credential은 ``BrokerPreset.required_credentials`` 키를 모두 충족해야 하며,
+    ``--credential`` / ``--credential-env`` / ``--credential-file``로만 제공한다.
+    """
     fmt = get_formatter(ctx)
 
     # cold-path: active runtime이 있으면 진입 직후 차단
@@ -113,45 +442,64 @@ def account_create(ctx: click.Context) -> None:
     from ante.account.models import Account, TradingMode
     from ante.account.presets import BROKER_PRESETS
 
-    # 1) 브로커 선택 (BROKER_REGISTRY에 등록된 것만)
-    selectable = _get_selectable_broker_types()
-    click.echo("\n브로커를 선택하세요:")
-    for i, bt in enumerate(selectable, 1):
-        preset = BROKER_PRESETS[bt]
-        click.echo(f"  {i}) {bt} ({preset.default_name})")
+    # 1) 필수 옵션 검증
+    required_inputs: dict[str, str | None] = {
+        "--broker-type": broker_type,
+        "--account-id": account_id_opt,
+        "--name": name_opt,
+        "--trading-mode": trading_mode_opt,
+    }
+    missing = [k for k, v in required_inputs.items() if v is None or v == ""]
+    if missing:
+        _exit_with_error(
+            fmt,
+            "CLI_MISSING_REQUIRED_INPUT",
+            f"필수 옵션 누락: {missing}",
+        )
 
-    choice = click.prompt("선택", type=click.IntRange(1, len(selectable)), default=1)
-    broker_type = selectable[choice - 1]
-    preset = BROKER_PRESETS[broker_type]
+    # mypy: 위 검증으로 모두 not None
+    assert broker_type is not None
+    assert account_id_opt is not None
+    assert name_opt is not None
+    assert trading_mode_opt is not None
 
-    # 2) 계좌 ID, 이름
-    account_id = click.prompt("계좌 ID", default=preset.default_account_id)
-    name = click.prompt("이름", default=preset.default_name)
+    # 2) broker_type enum 검증 (BROKER_REGISTRY SSOT)
+    _validate_broker_type(fmt, broker_type)
 
-    # 3) 거래 모드
-    click.echo("거래 모드를 선택하세요:")
-    click.echo("  1) virtual (가상거래)")
-    click.echo("  2) live (실제거래)")
-    mode_choice = click.prompt("선택", type=click.IntRange(1, 2), default=1)
-    trading_mode = TradingMode.VIRTUAL if mode_choice == 1 else TradingMode.LIVE
+    # 3) BrokerPreset 조회 — required_credentials의 SSOT
+    preset = BROKER_PRESETS.get(broker_type)
+    if preset is None:
+        # BROKER_REGISTRY에는 있지만 BROKER_PRESETS에 없는 경우 — 계약 불일치.
+        # 1.0 범위에서는 두 dict 모두 동일 keys를 가지지만, 방어적으로 가드한다.
+        _exit_with_error(
+            fmt,
+            "CLI_MISSING_REQUIRED_INPUT",
+            f"broker preset 미정의: {broker_type!r}",
+        )
 
-    # 4) 인증 정보
-    credentials: dict[str, str] = {}
-    for cred_key in preset.required_credentials:
-        hide = cred_key.lower() in ("app_secret", "secret", "password")
-        value = click.prompt(cred_key.upper(), hide_input=hide)
-        credentials[cred_key] = value
+    # 4) credential 해석
+    credentials = _resolve_credentials(
+        fmt=fmt,
+        required_keys=list(preset.required_credentials),
+        direct_pairs=credentials_direct,
+        env_pairs=credentials_env,
+        file_pairs=credentials_file,
+    )
 
-    # 5) 브로커 설정 (broker_config)
-    broker_config: dict[str, Any] = {}
-    if broker_type == "kis-domestic":
-        is_paper = click.confirm("모의투자 모드로 사용하시겠습니까?", default=True)
-        broker_config["is_paper"] = is_paper
+    # 5) broker_config 해석 (free-form pass-through)
+    broker_config = _resolve_broker_config(fmt=fmt, pairs=broker_config_pairs)
 
-    # 6) Account 생성
+    # 6) trading_mode 매핑
+    trading_mode = (
+        TradingMode.VIRTUAL
+        if trading_mode_opt.lower() == "virtual"
+        else TradingMode.LIVE
+    )
+
+    # 7) Account 생성
     new_account = Account(
-        account_id=account_id,
-        name=name,
+        account_id=account_id_opt,
+        name=name_opt,
         exchange=preset.exchange,
         currency=preset.currency,
         timezone=preset.timezone,
@@ -355,12 +703,19 @@ def account_delete(ctx: click.Context, account_id: str, skip_confirm: bool) -> N
     runtime이 있으면 차단되며, 서버 정지 상태에서만 AccountService.delete를
     직접 호출한다. 소속 봇이 살아 있는 계좌는 AccountHasActiveBotsError로
     차단된다(orphan bot 무결성).
+
+    SSOT: ``--yes`` 누락 시 prompt 없이 ``CLI_CONFIRMATION_REQUIRED``로 실패
+    (`docs/specs/cli/02-design-decisions.md` 위험 명령 확인 방식 표).
     """
     fmt = get_formatter(ctx)
     member_id = get_member_id(ctx)
 
     if not skip_confirm:
-        click.confirm(f'계좌 "{account_id}"를 삭제하시겠습니까?', abort=True)
+        _exit_with_error(
+            fmt,
+            "CLI_CONFIRMATION_REQUIRED",
+            f'계좌 "{account_id}" 삭제는 확인이 필요합니다. --yes를 명시해 주세요.',
+        )
 
     # cold-path: confirm 통과 직후 active runtime 차단
     _assert_no_active_runtime(fmt)
@@ -445,8 +800,27 @@ def account_credentials(ctx: click.Context, account_id: str) -> None:
 
 @account.command("set-credentials")
 @click.argument("account_id")
-@click.option("--app-key", default=None, help="APP_KEY (비대화형)")
-@click.option("--app-secret", default=None, help="APP_SECRET (비대화형)")
+@click.option(
+    "--credential",
+    "credentials_direct",
+    multiple=True,
+    metavar="KEY=VALUE",
+    help="credential 직접 값 (테스트/로컬 편의용, 비권장 — shell history 노출)",
+)
+@click.option(
+    "--credential-env",
+    "credentials_env",
+    multiple=True,
+    metavar="KEY=ENV_NAME",
+    help="credential을 환경변수에서 읽는다 (권장 채널)",
+)
+@click.option(
+    "--credential-file",
+    "credentials_file",
+    multiple=True,
+    metavar="KEY=PATH",
+    help="credential을 파일에서 읽는다 (권장 채널)",
+)
 @format_option
 @click.pass_context
 @require_auth
@@ -454,10 +828,18 @@ def account_credentials(ctx: click.Context, account_id: str) -> None:
 def account_set_credentials(
     ctx: click.Context,
     account_id: str,
-    app_key: str | None,
-    app_secret: str | None,
+    credentials_direct: tuple[str, ...],
+    credentials_env: tuple[str, ...],
+    credentials_file: tuple[str, ...],
 ) -> None:
-    """인증 정보 재설정 (대화형 또는 --app-key/--app-secret 옵션, cold-path 전용)."""
+    """인증 정보 재설정 (비대화형, cold-path 전용).
+
+    SSOT: ``BrokerPreset.required_credentials``를 **모두** 충족해야 하며,
+    부분 갱신은 허용하지 않는다(`docs/specs/cli/03-commands.md`
+    `account set-credentials` 입력 계약).
+    BREAKING CHANGE: 이전 ``--app-key`` / ``--app-secret`` 옵션은 제거되었다.
+    ``--credential`` / ``--credential-env`` / ``--credential-file``를 사용한다.
+    """
     fmt = get_formatter(ctx)
 
     # cold-path: active runtime이 있으면 진입 직후 차단
@@ -471,28 +853,44 @@ def account_set_credentials(
             acct = await svc.get(account_id)
             preset = BROKER_PRESETS.get(acct.broker_type)
             if not preset or not preset.required_credentials:
+                # broker preset이 credentials를 요구하지 않는 경우(예: 향후 broker)
+                # 입력이 있으면 unknown으로 거부하고, 없으면 no-op으로 안내한다.
+                any_input = bool(
+                    credentials_direct or credentials_env or credentials_file
+                )
+                if any_input:
+                    _exit_with_error(
+                        fmt,
+                        "ACCOUNT_UNKNOWN_CREDENTIAL_KEY",
+                        (
+                            f"브로커 '{acct.broker_type}'은 "
+                            "credentials를 요구하지 않습니다."
+                        ),
+                    )
                 msg = f"브로커 '{acct.broker_type}'에는 인증 정보가 필요하지 않습니다."
                 fmt.output({"message": msg})
                 return
 
-            # CLI 옵션으로 전달된 인증 정보가 있으면 비대화형 처리
-            cli_creds: dict[str, str] = {}
-            if app_key is not None:
-                cli_creds["app_key"] = app_key
-            if app_secret is not None:
-                cli_creds["app_secret"] = app_secret
+            # credential 옵션 누락 검증: 채널 셋이 모두 비어 있으면 실패
+            if not (credentials_direct or credentials_env or credentials_file):
+                required = list(preset.required_credentials)
+                _exit_with_error(
+                    fmt,
+                    "ACCOUNT_MISSING_REQUIRED_CREDENTIAL",
+                    (
+                        "credential 옵션이 누락되었습니다. "
+                        "--credential / --credential-env / --credential-file "
+                        f"중 하나로 required keys {required}를 모두 제공해야 합니다."
+                    ),
+                )
 
-            if cli_creds:
-                # CLI 옵션으로 전달된 값 사용
-                new_credentials = cli_creds
-            else:
-                # 대화형 입력
-                new_credentials = {}
-                click.echo(f"\n인증 정보 재설정 ({account_id})")
-                for cred_key in preset.required_credentials:
-                    hide = cred_key.lower() in ("app_secret", "secret", "password")
-                    value = click.prompt(cred_key.upper(), hide_input=hide)
-                    new_credentials[cred_key] = value
+            new_credentials = _resolve_credentials(
+                fmt=fmt,
+                required_keys=list(preset.required_credentials),
+                direct_pairs=credentials_direct,
+                env_pairs=credentials_env,
+                file_pairs=credentials_file,
+            )
 
             await svc.update(account_id, credentials=new_credentials)
             fmt.success(f'계좌 "{account_id}" 인증 정보 재설정 완료')
@@ -501,6 +899,8 @@ def account_set_credentials(
 
     try:
         _run(_do_set_credentials())
+    except SystemExit:
+        raise
     except Exception as e:
         fmt.error(str(e))
         raise SystemExit(1) from e

--- a/tests/unit/test_account_cli.py
+++ b/tests/unit/test_account_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -290,40 +291,86 @@ def active_runtime():
             yield
 
 
-# ── account create 대화형 테스트 ──────────────────
+# ── account create 비대화형 테스트 ──────────────────
+
+# 비대화형 입력 계약 SSOT: docs/specs/cli/02-design-decisions.md
+# (비대화형 입력 계약 — CLI Non-Interactive Input Contract).
+
+
+def _create_args_test_broker(
+    *,
+    account_id: str = "test2",
+    name: str = "테스트2",
+    trading_mode: str = "virtual",
+    extra: list[str] | None = None,
+) -> list[str]:
+    """``broker-type=test``용 표준 비대화형 인자 세트.
+
+    test broker preset은 ``required_credentials=["app_key", "app_secret"]``이므로
+    두 credential을 ``--credential``로 직접 제공한다.
+    """
+    args = [
+        "account",
+        "create",
+        "--broker-type",
+        "test",
+        "--account-id",
+        account_id,
+        "--name",
+        name,
+        "--trading-mode",
+        trading_mode,
+        "--credential",
+        "app_key=K",
+        "--credential",
+        "app_secret=S",
+    ]
+    if extra:
+        args.extend(extra)
+    return args
 
 
 class TestAccountCreate:
-    """ante account create 테스트."""
+    """ante account create 비대화형 테스트."""
 
-    def test_create_interactive(
+    def test_create_with_options(
         self, mock_account_service: AsyncMock, offline_runtime
     ) -> None:
-        """대화형 생성 흐름이 정상 동작한다."""
-        created = _mock_account("test", "테스트", "TEST", "KRW", "test")
+        """옵션 기반 비대화형 생성이 정상 동작한다."""
+        created = _mock_account("test2", "테스트2", "TEST", "KRW", "test")
         mock_account_service.create.return_value = created
 
-        # 입력: 브로커 1(test), 계좌ID(기본), 이름(기본), 거래모드 1(virtual),
-        # 인증정보: app_key=test, app_secret=test
-        input_text = "1\n\n\n1\ntest\ntest\n"
-        result = _invoke(["account", "create"], input_text=input_text)
-        assert result.exit_code == 0
+        result = _invoke(_create_args_test_broker())
+        assert result.exit_code == 0, result.output
         assert "생성 완료" in result.output
         mock_account_service.create.assert_called_once()
+
+    def test_create_json_output(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """--format json 출력이 success 페이로드를 포함한다."""
+        created = _mock_account("test2", "테스트2", "TEST", "KRW", "test")
+        mock_account_service.create.return_value = created
+
+        result = _invoke(_create_args_test_broker(extra=["--format", "json"]))
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["status"] == "ok"
+        assert data["account_id"] == "test2"
+        assert data["broker_type"] == "test"
 
     def test_create_blocked_when_active_runtime(
         self, mock_account_service: AsyncMock, active_runtime
     ) -> None:
         """active runtime이 있으면 cold-path가 차단된다."""
-        input_text = "1\n\n\n1\ntest\ntest\n"
-        result = _invoke(["account", "create"], input_text=input_text)
+        result = _invoke(_create_args_test_broker())
         assert result.exit_code == 1
         assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in result.output
         mock_account_service.create.assert_not_called()
 
     def test_create_offline_succeeds(self, mock_account_service: AsyncMock) -> None:
         """PID 파일 부재(offline) 시 guard 통과."""
-        created = _mock_account("test", "테스트", "TEST", "KRW", "test")
+        created = _mock_account("test2", "테스트2", "TEST", "KRW", "test")
         mock_account_service.create.return_value = created
 
         with (
@@ -333,16 +380,15 @@ class TestAccountCreate:
                 return_value="/tmp/__ante_does_not_exist__.sock",
             ),
         ):
-            input_text = "1\n\n\n1\ntest\ntest\n"
-            result = _invoke(["account", "create"], input_text=input_text)
-        assert result.exit_code == 0
+            result = _invoke(_create_args_test_broker())
+        assert result.exit_code == 0, result.output
         mock_account_service.create.assert_called_once()
 
     def test_create_offline_when_pid_alive_but_socket_absent(
         self, mock_account_service: AsyncMock
     ) -> None:
         """PID는 alive지만 socket이 부재하면 stale PID로 보고 guard 통과."""
-        created = _mock_account("test", "테스트", "TEST", "KRW", "test")
+        created = _mock_account("test2", "테스트2", "TEST", "KRW", "test")
         mock_account_service.create.return_value = created
 
         with (
@@ -356,10 +402,300 @@ class TestAccountCreate:
                 return_value="/tmp/__ante_no_such_socket_xxx__.sock",
             ),
         ):
-            input_text = "1\n\n\n1\ntest\ntest\n"
-            result = _invoke(["account", "create"], input_text=input_text)
-        assert result.exit_code == 0
+            result = _invoke(_create_args_test_broker())
+        assert result.exit_code == 0, result.output
         mock_account_service.create.assert_called_once()
+
+    def test_create_missing_broker_type(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """필수 옵션 ``--broker-type`` 누락 시 즉시 에러로 종료한다."""
+        result = _invoke(
+            [
+                "account",
+                "create",
+                "--account-id",
+                "x",
+                "--name",
+                "X",
+                "--trading-mode",
+                "virtual",
+                "--credential",
+                "app_key=K",
+                "--credential",
+                "app_secret=S",
+            ]
+        )
+        assert result.exit_code == 1
+        assert "CLI_MISSING_REQUIRED_INPUT" in result.output
+        assert "--broker-type" in result.output
+        mock_account_service.create.assert_not_called()
+
+    def test_create_missing_required_credential(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """``required_credentials``에 정의된 key 누락 시 명시적 에러."""
+        result = _invoke(
+            [
+                "account",
+                "create",
+                "--broker-type",
+                "test",
+                "--account-id",
+                "test2",
+                "--name",
+                "테스트2",
+                "--trading-mode",
+                "virtual",
+                "--credential",
+                "app_key=K",
+                # app_secret 누락
+            ]
+        )
+        assert result.exit_code == 1
+        assert "ACCOUNT_MISSING_REQUIRED_CREDENTIAL" in result.output
+        assert "app_secret" in result.output
+        mock_account_service.create.assert_not_called()
+
+    def test_create_unknown_credential_key(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """``required_credentials`` 외 key는 ``ACCOUNT_UNKNOWN_CREDENTIAL_KEY``."""
+        result = _invoke(
+            [
+                "account",
+                "create",
+                "--broker-type",
+                "test",
+                "--account-id",
+                "test2",
+                "--name",
+                "테스트2",
+                "--trading-mode",
+                "virtual",
+                "--credential",
+                "app_key=K",
+                "--credential",
+                "app_secret=S",
+                "--credential",
+                "extra_key=X",
+            ]
+        )
+        assert result.exit_code == 1
+        assert "ACCOUNT_UNKNOWN_CREDENTIAL_KEY" in result.output
+        mock_account_service.create.assert_not_called()
+
+    def test_create_duplicate_credential_key_across_channels(
+        self, mock_account_service: AsyncMock, offline_runtime, monkeypatch
+    ) -> None:
+        """같은 key를 두 채널로 입력하면 ``ACCOUNT_DUPLICATE_CREDENTIAL_KEY``."""
+        monkeypatch.setenv("TEST_APP_SECRET_ENV", "S")
+        result = _invoke(
+            [
+                "account",
+                "create",
+                "--broker-type",
+                "test",
+                "--account-id",
+                "test2",
+                "--name",
+                "테스트2",
+                "--trading-mode",
+                "virtual",
+                "--credential",
+                "app_key=K",
+                "--credential",
+                "app_secret=S1",
+                "--credential-env",
+                "app_secret=TEST_APP_SECRET_ENV",
+            ]
+        )
+        assert result.exit_code == 1
+        assert "ACCOUNT_DUPLICATE_CREDENTIAL_KEY" in result.output
+        mock_account_service.create.assert_not_called()
+
+    def test_create_credential_env_not_set(
+        self, mock_account_service: AsyncMock, offline_runtime, monkeypatch
+    ) -> None:
+        """``--credential-env``이 참조한 환경변수가 없으면 명시적 에러."""
+        monkeypatch.delenv("TEST_NO_SUCH_ENV", raising=False)
+        result = _invoke(
+            [
+                "account",
+                "create",
+                "--broker-type",
+                "test",
+                "--account-id",
+                "test2",
+                "--name",
+                "테스트2",
+                "--trading-mode",
+                "virtual",
+                "--credential",
+                "app_key=K",
+                "--credential-env",
+                "app_secret=TEST_NO_SUCH_ENV",
+            ]
+        )
+        assert result.exit_code == 1
+        assert "ACCOUNT_CREDENTIAL_ENV_NOT_SET" in result.output
+        mock_account_service.create.assert_not_called()
+
+    def test_create_credential_env_blank(
+        self, mock_account_service: AsyncMock, offline_runtime, monkeypatch
+    ) -> None:
+        """``--credential-env`` 환경변수 값이 공란이면 명시적 에러."""
+        monkeypatch.setenv("TEST_BLANK_ENV", "")
+        result = _invoke(
+            [
+                "account",
+                "create",
+                "--broker-type",
+                "test",
+                "--account-id",
+                "test2",
+                "--name",
+                "테스트2",
+                "--trading-mode",
+                "virtual",
+                "--credential",
+                "app_key=K",
+                "--credential-env",
+                "app_secret=TEST_BLANK_ENV",
+            ]
+        )
+        assert result.exit_code == 1
+        assert "ACCOUNT_CREDENTIAL_ENV_NOT_SET" in result.output
+        mock_account_service.create.assert_not_called()
+
+    def test_create_credential_file(
+        self, mock_account_service: AsyncMock, offline_runtime, tmp_path
+    ) -> None:
+        """``--credential-file`` 경로의 파일을 읽어 credential로 사용한다."""
+        secret_path = tmp_path / "secret.txt"
+        secret_path.write_text("FILE_SECRET\n", encoding="utf-8")
+
+        created = _mock_account("test2", "테스트2", "TEST", "KRW", "test")
+        mock_account_service.create.return_value = created
+
+        result = _invoke(
+            [
+                "account",
+                "create",
+                "--broker-type",
+                "test",
+                "--account-id",
+                "test2",
+                "--name",
+                "테스트2",
+                "--trading-mode",
+                "virtual",
+                "--credential",
+                "app_key=K",
+                "--credential-file",
+                f"app_secret={secret_path}",
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        mock_account_service.create.assert_called_once()
+        # service.create에 전달된 Account의 credentials 검증
+        account_arg = mock_account_service.create.call_args[0][0]
+        assert account_arg.credentials == {"app_key": "K", "app_secret": "FILE_SECRET"}
+
+    def test_create_credential_file_not_found(
+        self, mock_account_service: AsyncMock, offline_runtime, tmp_path
+    ) -> None:
+        """credential-file 경로가 부재하면 ACCOUNT_CREDENTIAL_FILE_NOT_FOUND."""
+        missing = tmp_path / "nonexistent.txt"
+        result = _invoke(
+            [
+                "account",
+                "create",
+                "--broker-type",
+                "test",
+                "--account-id",
+                "test2",
+                "--name",
+                "테스트2",
+                "--trading-mode",
+                "virtual",
+                "--credential",
+                "app_key=K",
+                "--credential-file",
+                f"app_secret={missing}",
+            ]
+        )
+        assert result.exit_code == 1
+        assert "ACCOUNT_CREDENTIAL_FILE_NOT_FOUND" in result.output
+        mock_account_service.create.assert_not_called()
+
+    def test_create_kis_with_env_and_broker_config(
+        self, mock_account_service: AsyncMock, offline_runtime, monkeypatch
+    ) -> None:
+        """KIS 계좌: env credential + ``--broker-config is_paper=true``."""
+        monkeypatch.setenv("ANTE_KIS_APP_KEY", "K")
+        monkeypatch.setenv("ANTE_KIS_APP_SECRET", "S")
+        monkeypatch.setenv("ANTE_KIS_ACCOUNT_NO", "5012XXXX-01")
+
+        created = _mock_account("domestic", "국내 주식", "KRX", "KRW", "kis-domestic")
+        mock_account_service.create.return_value = created
+
+        result = _invoke(
+            [
+                "account",
+                "create",
+                "--broker-type",
+                "kis-domestic",
+                "--account-id",
+                "domestic",
+                "--name",
+                "국내 주식",
+                "--trading-mode",
+                "virtual",
+                "--credential-env",
+                "app_key=ANTE_KIS_APP_KEY",
+                "--credential-env",
+                "app_secret=ANTE_KIS_APP_SECRET",
+                "--credential-env",
+                "account_no=ANTE_KIS_ACCOUNT_NO",
+                "--broker-config",
+                "is_paper=true",
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        account_arg = mock_account_service.create.call_args[0][0]
+        assert account_arg.credentials == {
+            "app_key": "K",
+            "app_secret": "S",
+            "account_no": "5012XXXX-01",
+        }
+        assert account_arg.broker_config == {"is_paper": True}
+
+    def test_create_unknown_broker_type(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """``BROKER_REGISTRY`` 미등록 broker_type은 입력 단계에서 거부한다."""
+        result = _invoke(
+            [
+                "account",
+                "create",
+                "--broker-type",
+                "no-such-broker",
+                "--account-id",
+                "x",
+                "--name",
+                "X",
+                "--trading-mode",
+                "virtual",
+                "--credential",
+                "app_key=K",
+                "--credential",
+                "app_secret=S",
+            ]
+        )
+        assert result.exit_code == 1
+        assert "no-such-broker" in result.output
+        mock_account_service.create.assert_not_called()
 
 
 # ── account suspend/activate/delete 테스트 ──────────
@@ -422,22 +758,17 @@ class TestAccountStateTransitions:
         assert "삭제 완료" in result.output
         mock_account_service.delete.assert_called_once()
 
-    def test_delete_with_confirm(
+    def test_delete_without_yes_requires_confirmation(
         self, mock_account_service: AsyncMock, offline_runtime
     ) -> None:
-        """계좌 삭제 (확인 프롬프트 y 입력, cold-path direct service 호출)."""
-        mock_account_service.delete.return_value = None
+        """``--yes`` 없이 호출하면 prompt 없이 ``CLI_CONFIRMATION_REQUIRED``로 실패한다.
 
-        result = _invoke(["account", "delete", "domestic"], input_text="y\n")
-
-        assert result.exit_code == 0
-        assert "삭제 완료" in result.output
-        mock_account_service.delete.assert_called_once()
-
-    def test_delete_abort(self) -> None:
-        """계좌 삭제 취소 (확인 프롬프트 n 입력)."""
-        result = _invoke(["account", "delete", "domestic"], input_text="n\n")
+        SSOT: docs/specs/cli/02-design-decisions.md — 위험 명령 확인 방식 표.
+        """
+        result = _invoke(["account", "delete", "domestic"])
         assert result.exit_code == 1
+        assert "CLI_CONFIRMATION_REQUIRED" in result.output
+        mock_account_service.delete.assert_not_called()
 
     def test_delete_blocked_when_active_runtime(
         self, mock_account_service: AsyncMock, active_runtime
@@ -502,6 +833,26 @@ class TestAccountStateTransitions:
 # ── account set-credentials cold-path guard 테스트 ──────
 
 
+def _kis_account_for_setcred() -> Any:
+    """KIS 계좌 mock (set-credentials 테스트용)."""
+    from decimal import Decimal
+
+    from ante.account.models import Account, AccountStatus, TradingMode
+
+    return Account(
+        account_id="domestic",
+        name="국내",
+        exchange="KRX",
+        currency="KRW",
+        broker_type="kis-domestic",
+        status=AccountStatus.ACTIVE,
+        trading_mode=TradingMode.VIRTUAL,
+        credentials={},
+        buy_commission_rate=Decimal("0.00015"),
+        sell_commission_rate=Decimal("0.00195"),
+    )
+
+
 class TestAccountSetCredentialsRuntimeGuard:
     """ante account set-credentials cold-path active runtime guard."""
 
@@ -514,10 +865,12 @@ class TestAccountSetCredentialsRuntimeGuard:
                 "account",
                 "set-credentials",
                 "domestic",
-                "--app-key",
-                "k",
-                "--app-secret",
-                "s",
+                "--credential",
+                "app_key=k",
+                "--credential",
+                "app_secret=s",
+                "--credential",
+                "account_no=5012XXXX-01",
             ]
         )
         assert result.exit_code == 1
@@ -528,22 +881,7 @@ class TestAccountSetCredentialsRuntimeGuard:
         self, mock_account_service: AsyncMock
     ) -> None:
         """PID 파일 부재(offline) 시 guard 통과 후 update 호출."""
-        from decimal import Decimal
-
-        from ante.account.models import Account, AccountStatus, TradingMode
-
-        mock_account_service.get.return_value = Account(
-            account_id="domestic",
-            name="국내",
-            exchange="KRX",
-            currency="KRW",
-            broker_type="kis-domestic",
-            status=AccountStatus.ACTIVE,
-            trading_mode=TradingMode.VIRTUAL,
-            credentials={},
-            buy_commission_rate=Decimal("0.00015"),
-            sell_commission_rate=Decimal("0.00195"),
-        )
+        mock_account_service.get.return_value = _kis_account_for_setcred()
         mock_account_service.update.return_value = None
 
         with (
@@ -558,35 +896,28 @@ class TestAccountSetCredentialsRuntimeGuard:
                     "account",
                     "set-credentials",
                     "domestic",
-                    "--app-key",
-                    "k",
-                    "--app-secret",
-                    "s",
+                    "--credential",
+                    "app_key=k",
+                    "--credential",
+                    "app_secret=s",
+                    "--credential",
+                    "account_no=5012XXXX-01",
                 ]
             )
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
         mock_account_service.update.assert_called_once()
+        creds = mock_account_service.update.call_args.kwargs["credentials"]
+        assert creds == {
+            "app_key": "k",
+            "app_secret": "s",
+            "account_no": "5012XXXX-01",
+        }
 
     def test_set_credentials_offline_when_pid_alive_but_socket_absent(
         self, mock_account_service: AsyncMock
     ) -> None:
         """PID alive지만 socket 부재면 stale PID로 보고 guard 통과."""
-        from decimal import Decimal
-
-        from ante.account.models import Account, AccountStatus, TradingMode
-
-        mock_account_service.get.return_value = Account(
-            account_id="domestic",
-            name="국내",
-            exchange="KRX",
-            currency="KRW",
-            broker_type="kis-domestic",
-            status=AccountStatus.ACTIVE,
-            trading_mode=TradingMode.VIRTUAL,
-            credentials={},
-            buy_commission_rate=Decimal("0.00015"),
-            sell_commission_rate=Decimal("0.00195"),
-        )
+        mock_account_service.get.return_value = _kis_account_for_setcred()
         mock_account_service.update.return_value = None
 
         with (
@@ -602,11 +933,141 @@ class TestAccountSetCredentialsRuntimeGuard:
                     "account",
                     "set-credentials",
                     "domestic",
-                    "--app-key",
-                    "k",
-                    "--app-secret",
-                    "s",
+                    "--credential",
+                    "app_key=k",
+                    "--credential",
+                    "app_secret=s",
+                    "--credential",
+                    "account_no=5012XXXX-01",
                 ]
             )
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
         mock_account_service.update.assert_called_once()
+
+
+class TestAccountSetCredentialsContract:
+    """``account set-credentials`` 비대화형 입력 계약 검증."""
+
+    def test_no_options_fails_without_prompt(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """credential 옵션이 하나도 없으면 prompt 없이 즉시 실패."""
+        mock_account_service.get.return_value = _kis_account_for_setcred()
+
+        result = _invoke(["account", "set-credentials", "domestic"])
+        assert result.exit_code == 1
+        assert "ACCOUNT_MISSING_REQUIRED_CREDENTIAL" in result.output
+        mock_account_service.update.assert_not_called()
+
+    def test_partial_credentials_rejected(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """KIS preset의 required_credentials 일부만 제공하면 실패."""
+        mock_account_service.get.return_value = _kis_account_for_setcred()
+
+        result = _invoke(
+            [
+                "account",
+                "set-credentials",
+                "domestic",
+                "--credential",
+                "app_key=k",
+                "--credential",
+                "app_secret=s",
+                # account_no 누락
+            ]
+        )
+        assert result.exit_code == 1
+        assert "ACCOUNT_MISSING_REQUIRED_CREDENTIAL" in result.output
+        assert "account_no" in result.output
+        mock_account_service.update.assert_not_called()
+
+    def test_unknown_credential_key_rejected(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """required_credentials 외 key는 ``ACCOUNT_UNKNOWN_CREDENTIAL_KEY``."""
+        mock_account_service.get.return_value = _kis_account_for_setcred()
+
+        result = _invoke(
+            [
+                "account",
+                "set-credentials",
+                "domestic",
+                "--credential",
+                "app_key=k",
+                "--credential",
+                "app_secret=s",
+                "--credential",
+                "account_no=5012XXXX-01",
+                "--credential",
+                "extra=X",
+            ]
+        )
+        assert result.exit_code == 1
+        assert "ACCOUNT_UNKNOWN_CREDENTIAL_KEY" in result.output
+        mock_account_service.update.assert_not_called()
+
+    def test_duplicate_key_across_channels_rejected(
+        self,
+        mock_account_service: AsyncMock,
+        offline_runtime,
+        monkeypatch,
+    ) -> None:
+        """같은 key가 둘 이상 채널로 들어오면 ``ACCOUNT_DUPLICATE_CREDENTIAL_KEY``."""
+        mock_account_service.get.return_value = _kis_account_for_setcred()
+
+        monkeypatch.setenv("KIS_APP_SECRET", "S")
+        result = _invoke(
+            [
+                "account",
+                "set-credentials",
+                "domestic",
+                "--credential",
+                "app_key=k",
+                "--credential",
+                "app_secret=s1",
+                "--credential-env",
+                "app_secret=KIS_APP_SECRET",
+                "--credential",
+                "account_no=5012XXXX-01",
+            ]
+        )
+        assert result.exit_code == 1
+        assert "ACCOUNT_DUPLICATE_CREDENTIAL_KEY" in result.output
+        mock_account_service.update.assert_not_called()
+
+    def test_env_and_file_resolution(
+        self,
+        mock_account_service: AsyncMock,
+        offline_runtime,
+        monkeypatch,
+        tmp_path,
+    ) -> None:
+        """env + file + direct 채널을 합쳐 update에 그대로 전달한다."""
+        mock_account_service.get.return_value = _kis_account_for_setcred()
+        mock_account_service.update.return_value = None
+
+        monkeypatch.setenv("KIS_APP_KEY", "ENV_KEY")
+        secret_path = tmp_path / "kis_secret.txt"
+        secret_path.write_text("FILE_SECRET\n", encoding="utf-8")
+
+        result = _invoke(
+            [
+                "account",
+                "set-credentials",
+                "domestic",
+                "--credential-env",
+                "app_key=KIS_APP_KEY",
+                "--credential-file",
+                f"app_secret={secret_path}",
+                "--credential",
+                "account_no=5012XXXX-01",
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        creds = mock_account_service.update.call_args.kwargs["credentials"]
+        assert creds == {
+            "app_key": "ENV_KEY",
+            "app_secret": "FILE_SECRET",
+            "account_no": "5012XXXX-01",
+        }

--- a/tests/unit/test_account_cli.py
+++ b/tests/unit/test_account_cli.py
@@ -697,6 +697,88 @@ class TestAccountCreate:
         assert "no-such-broker" in result.output
         mock_account_service.create.assert_not_called()
 
+    def test_create_rejects_empty_direct_credential(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """직접 채널 ``--credential KEY=`` (빈 값)은 env/file과 일관되게 거부한다.
+
+        Codex P2-2: env 채널은 ``ACCOUNT_CREDENTIAL_ENV_NOT_SET``, file 채널은
+        ``ACCOUNT_CREDENTIAL_FILE_NOT_FOUND``로 빈 값을 거부하지만, 직접
+        채널은 빈 문자열을 그대로 통과시켜 unusable 계좌가 만들어질 위험이
+        있었다. broker adapter 인증에 사용할 수 없는 빈 값은
+        ``ACCOUNT_MISSING_REQUIRED_CREDENTIAL``로 즉시 실패한다.
+        """
+        result = _invoke(
+            [
+                "account",
+                "create",
+                "--broker-type",
+                "test",
+                "--account-id",
+                "test2",
+                "--name",
+                "테스트2",
+                "--trading-mode",
+                "virtual",
+                "--credential",
+                "app_key=",  # 빈 값
+                "--credential",
+                "app_secret=S",
+            ]
+        )
+        assert result.exit_code == 1
+        assert "ACCOUNT_MISSING_REQUIRED_CREDENTIAL" in result.output
+        assert "app_key" in result.output
+        mock_account_service.create.assert_not_called()
+
+    def test_create_broker_config_decimal_stored_as_float(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """``--broker-config retry_seconds=1.5`` 같은 소수는 ``float``로 저장한다.
+
+        Codex P2-3: 이전 구현은 ``Decimal(text)`` 검증 후 ``str(text)``를 반환하여
+        broker_config에 string이 저장됐다. KIS adapter는
+        ``config.get("retry.backoff_base_seconds", DEFAULT)``처럼 numeric 값을
+        직접 소비하므로(`src/ante/broker/kis.py`), 문자열 저장은 후속 산술
+        연산에서 ``TypeError``를 유발한다. 또한 ``Account.broker_config``는
+        ``json.dumps(...)``로 직렬화되므로 ``Decimal``은 JSON serializable이
+        아니다 — ``float``로 변환해야 한다.
+        """
+        created = _mock_account("test2", "테스트2", "TEST", "KRW", "test")
+        mock_account_service.create.return_value = created
+
+        result = _invoke(
+            [
+                "account",
+                "create",
+                "--broker-type",
+                "test",
+                "--account-id",
+                "test2",
+                "--name",
+                "테스트2",
+                "--trading-mode",
+                "virtual",
+                "--credential",
+                "app_key=K",
+                "--credential",
+                "app_secret=S",
+                "--broker-config",
+                "retry_seconds=1.5",
+                "--broker-config",
+                "commission_rate=0.00015",
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        account_arg = mock_account_service.create.call_args[0][0]
+        assert account_arg.broker_config == {
+            "retry_seconds": 1.5,
+            "commission_rate": 0.00015,
+        }
+        # 값이 float native 타입인지 명시적으로 확인 (str/Decimal 회귀 방지)
+        assert isinstance(account_arg.broker_config["retry_seconds"], float)
+        assert isinstance(account_arg.broker_config["commission_rate"], float)
+
 
 # ── account suspend/activate/delete 테스트 ──────────
 

--- a/tests/unit/test_cli_format_option.py
+++ b/tests/unit/test_cli_format_option.py
@@ -224,8 +224,11 @@ class TestAccountDeleteYes:
         assert "삭제 완료" in result.output
         svc.delete.assert_called_once()
 
-    def test_delete_without_yes_prompts(self, runner: CliRunner) -> None:
-        """--yes 없이 호출하면 확인 프롬프트가 나타남 (cold-path direct service)."""
+    def test_delete_without_yes_requires_confirmation(self, runner: CliRunner) -> None:
+        """``--yes`` 없이 호출하면 prompt 없이 ``CLI_CONFIRMATION_REQUIRED``로 실패한다.
+
+        SSOT: docs/specs/cli/02-design-decisions.md — 위험 명령 확인 방식 표.
+        """
         svc = AsyncMock()
         db = _mock_db()
         svc.delete.return_value = None
@@ -242,11 +245,11 @@ class TestAccountDeleteYes:
                 return_value="/tmp/__ante_offline_fmt_del2__.sock",
             ),
         ):
-            result = runner.invoke(cli, ["account", "delete", "test-acct"], input="y\n")
+            result = runner.invoke(cli, ["account", "delete", "test-acct"])
 
-        assert result.exit_code == 0
-        assert "삭제 완료" in result.output
-        svc.delete.assert_called_once()
+        assert result.exit_code == 1
+        assert "CLI_CONFIRMATION_REQUIRED" in result.output
+        svc.delete.assert_not_called()
 
 
 # ── treasury status --format json ─────────────────────────
@@ -485,7 +488,7 @@ class TestTradeInfoFormatOption:
 
 
 class TestAccountSetCredentialsNonInteractive:
-    """ante account set-credentials {id} --app-key KEY --app-secret SECRET."""
+    """ante account set-credentials --credential KEY=VALUE (모든 required key)."""
 
     def test_set_credentials_non_interactive(self, runner: CliRunner) -> None:
         from decimal import Decimal
@@ -507,10 +510,17 @@ class TestAccountSetCredentialsNonInteractive:
             sell_commission_rate=Decimal("0.00195"),
         )
 
-        with patch(
-            "ante.cli.commands.account._create_account_service",
-            new_callable=AsyncMock,
-            return_value=(svc, db),
+        with (
+            patch(
+                "ante.cli.commands.account._create_account_service",
+                new_callable=AsyncMock,
+                return_value=(svc, db),
+            ),
+            patch("ante.main.read_pid_file", return_value=None),
+            patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/__ante_offline_fmt_setc__.sock",
+            ),
         ):
             result = runner.invoke(
                 cli,
@@ -518,21 +528,24 @@ class TestAccountSetCredentialsNonInteractive:
                     "account",
                     "set-credentials",
                     "test-acct",
-                    "--app-key",
-                    "my-key",
-                    "--app-secret",
-                    "my-secret",
+                    "--credential",
+                    "app_key=my-key",
+                    "--credential",
+                    "app_secret=my-secret",
+                    "--credential",
+                    "account_no=50123456-01",
                     "--format",
                     "json",
                 ],
             )
-            assert result.exit_code == 0
+            assert result.exit_code == 0, result.output
             assert "재설정 완료" in result.output
             svc.update.assert_called_once()
-            # 전달된 credentials 확인
+            # 전달된 credentials 확인 (kis-domestic preset의 모든 required key 포함)
             call_kwargs = svc.update.call_args
             creds = call_kwargs.kwargs.get("credentials") or call_kwargs[1].get(
                 "credentials"
             )
             assert creds["app_key"] == "my-key"
             assert creds["app_secret"] == "my-secret"
+            assert creds["account_no"] == "50123456-01"

--- a/tests/unit/test_is_paper_migration.py
+++ b/tests/unit/test_is_paper_migration.py
@@ -152,11 +152,15 @@ class TestBrokerConfigMerge:
         assert merged["is_paper"] is True
 
 
-# ── CLI account create is_paper 프롬프트 테스트 ──────────
+# ── CLI account create is_paper 비대화형 테스트 ──────────
+#
+# 1.0 비대화형 입력 계약(docs/specs/cli/02-design-decisions.md)에 따라
+# `ante account create`는 stdin prompt를 사용하지 않는다. ``is_paper``는
+# ``--broker-config is_paper=true|false``로 전달한다.
 
 
 class TestAccountCreateIsPaper:
-    """ante account create에서 kis-domestic 선택 시 is_paper 입력 확인."""
+    """ante account create 비대화형: kis-domestic + ``--broker-config is_paper``."""
 
     @pytest.fixture(autouse=True)
     def bypass_auth(self):
@@ -189,57 +193,121 @@ class TestAccountCreateIsPaper:
         ):
             yield svc
 
-    def test_kis_domestic_asks_is_paper(self, mock_account_service):
-        """kis-domestic 선택 시 모의투자 모드 질문이 표시된다."""
+    @pytest.fixture
+    def offline_runtime(self):
+        """active runtime이 없는 cold-path 통과 환경."""
+        with (
+            patch("ante.main.read_pid_file", return_value=None),
+            patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/__ante_offline_is_paper_test__.sock",
+            ),
+        ):
+            yield
+
+    def test_kis_domestic_is_paper_true(self, mock_account_service, offline_runtime):
+        """--broker-config is_paper=true → broker_config={'is_paper': True}."""
         from ante.cli.main import cli
 
         created = _make_account("domestic", "kis-domestic")
         mock_account_service.create.return_value = created
 
         runner = CliRunner()
-        # 브로커 2(kis-domestic), 계좌ID(기본), 이름(기본), 거래모드 1(virtual),
-        # app_key, app_secret, account_no, is_paper=y
-        input_text = "2\n\n\n1\ntest_key\ntest_secret\n50123456-01\ny\n"
-        result = runner.invoke(cli, ["account", "create"], input=input_text)
+        result = runner.invoke(
+            cli,
+            [
+                "account",
+                "create",
+                "--broker-type",
+                "kis-domestic",
+                "--account-id",
+                "domestic",
+                "--name",
+                "국내 주식",
+                "--trading-mode",
+                "virtual",
+                "--credential",
+                "app_key=test_key",
+                "--credential",
+                "app_secret=test_secret",
+                "--credential",
+                "account_no=50123456-01",
+                "--broker-config",
+                "is_paper=true",
+            ],
+        )
 
         assert result.exit_code == 0, result.output
-        assert "모의투자 모드" in result.output
-        # create에 전달된 Account의 broker_config 확인
         call_args = mock_account_service.create.call_args
         account_arg = call_args[0][0]
         assert account_arg.broker_config == {"is_paper": True}
 
-    def test_kis_domestic_is_paper_false(self, mock_account_service):
-        """모의투자 N 선택 시 is_paper=False로 저장된다."""
+    def test_kis_domestic_is_paper_false(self, mock_account_service, offline_runtime):
+        """--broker-config is_paper=false → broker_config={'is_paper': False}."""
         from ante.cli.main import cli
 
         created = _make_account("domestic", "kis-domestic")
         mock_account_service.create.return_value = created
 
         runner = CliRunner()
-        input_text = "2\n\n\n1\ntest_key\ntest_secret\n50123456-01\nn\n"
-        result = runner.invoke(cli, ["account", "create"], input=input_text)
+        result = runner.invoke(
+            cli,
+            [
+                "account",
+                "create",
+                "--broker-type",
+                "kis-domestic",
+                "--account-id",
+                "domestic",
+                "--name",
+                "국내 주식",
+                "--trading-mode",
+                "virtual",
+                "--credential",
+                "app_key=test_key",
+                "--credential",
+                "app_secret=test_secret",
+                "--credential",
+                "account_no=50123456-01",
+                "--broker-config",
+                "is_paper=false",
+            ],
+        )
 
         assert result.exit_code == 0, result.output
         call_args = mock_account_service.create.call_args
         account_arg = call_args[0][0]
         assert account_arg.broker_config == {"is_paper": False}
 
-    def test_test_broker_no_is_paper(self, mock_account_service):
-        """test 브로커 선택 시 is_paper 질문이 없다."""
+    def test_test_broker_no_broker_config(self, mock_account_service, offline_runtime):
+        """test broker는 --broker-config 없이도 broker_config={}로 생성."""
         from ante.cli.main import cli
 
         created = _make_account("test", "test", broker_config={})
         mock_account_service.create.return_value = created
 
         runner = CliRunner()
-        # 브로커 1(test), 계좌ID(기본), 이름(기본), 거래모드 1(virtual),
-        # app_key, app_secret
-        input_text = "1\n\n\n1\ntest_key\ntest_secret\n"
-        result = runner.invoke(cli, ["account", "create"], input=input_text)
+        result = runner.invoke(
+            cli,
+            [
+                "account",
+                "create",
+                "--broker-type",
+                "test",
+                "--account-id",
+                "test2",
+                "--name",
+                "테스트2",
+                "--trading-mode",
+                "virtual",
+                "--credential",
+                "app_key=test_key",
+                "--credential",
+                "app_secret=test_secret",
+            ],
+        )
 
         assert result.exit_code == 0, result.output
-        assert "모의투자 모드" not in result.output
         call_args = mock_account_service.create.call_args
         account_arg = call_args[0][0]
         assert account_arg.broker_config == {}


### PR DESCRIPTION
Closes #1173

## Summary

#1170 에픽 (CLI 비대화형) 두 번째 구현 단계. #1171 (PR #1203, sha 72e2620) 머지로 SSOT 확정 후 `src/ante/cli/commands/account.py`의 prompt/confirm을 옵션/env/file 기반으로 전환합니다.

## 변경 (4개 파일, 2개 커밋)

### 1차 커밋 (`408313e`) — 비대화형 전환

- `src/ante/cli/commands/account.py`
  - `account_create` (L106~): 옵션 추가 (`--broker-type`, `--account-id`, `--name`, `--trading-mode`, `--credential`, `--credential-env`, `--credential-file`, `--broker-config` 모두 반복). prompt 8건 제거 (L123/128/129/135/142/148, L363, L494)
  - credential 해석: `BrokerPreset.required_credentials` 기준 검증, env/file 부재/공란 에러, 동일 key 중복 → `ACCOUNT_DUPLICATE_CREDENTIAL_KEY`
  - broker_config 해석: free-form pass-through (#1171 SSOT silent ignore trade-off)
  - `account_delete`: `click.confirm` 제거 → `--yes` 누락 시 `CLI_CONFIRMATION_REQUIRED`
  - `account_set_credentials`: `--credential*` 통합, 모든 required_credentials 충족 필요 (부분 갱신 거부)
- `tests/unit/test_account_cli.py`, `tests/unit/test_is_paper_migration.py`, `tests/unit/test_cli_format_option.py`: `input_text` 기반 테스트를 옵션 기반으로 전환

### 2차 커밋 (`ae9c6db`) — Codex P2 fix

- **P2-2 (빈 직접 credential 거부)**: `_resolve_credentials`에서 `--credential app_key=` 빈 값 거부 (env/file 채널과 일관). `ACCOUNT_MISSING_REQUIRED_CREDENTIAL` 에러
- **P2-3 (소수 broker_config float 직렬화)**: `_parse_broker_config_value`에서 Decimal 매칭 후 `float(text)` 반환 (KIS adapter 숫자 호환)
- 신규 테스트 2건: `test_create_rejects_empty_direct_credential`, `test_create_broker_config_decimal_stored_as_float`

## BREAKING CHANGE

`account set-credentials`가 `--app-key`/`--app-secret` 직접 옵션을 더 이상 지원하지 않습니다. 대신 다음 옵션을 사용하세요:

```bash
# Before
ante account set-credentials domestic --app-key K --app-secret S

# After
ante account set-credentials domestic --credential app_key=K --credential app_secret=S --credential account_no=NUM
# 또는 env/file 기반:
ANTE_KIS_APP_SECRET=S ante account set-credentials domestic --credential app_key=K --credential-env app_secret=ANTE_KIS_APP_SECRET --credential account_no=NUM
```

`set-credentials` 의미는 "재설정"이므로 모든 `BrokerPreset.required_credentials`를 충족해야 합니다 (부분 갱신 허용 안 함).

## Codex 브랜치 리뷰 진행

- 1차 (head 408313e): P2 3건 발견
  - P2-1 (JSON 응답 스키마 cross-CLI 불일치) — **별도 이슈 #1205로 분리** (autopilot 자율 결정). 본 PR이 새로 도입한 결함이 아니라 formatter 전반의 기존 SSOT 불일치이며, 머지된 PR #1204 (#1175)도 동일 패턴.
  - P2-2 (빈 직접 credential 거부): 본 PR fix (커밋 ae9c6db)
  - P2-3 (소수 broker_config float 직렬화): 본 PR fix (커밋 ae9c6db)
- 2차 (head ae9c6db): PASS (P2-1만 advisory로 남음, blocking 없음)

## Risk Flags

- `breaking-change`: `set-credentials --app-key`/`--app-secret` 제거. 사용자가 새 옵션으로 마이그레이션 필요.
- `option-explosion`: `account_create` 옵션 8개로 증가 — Click 데코레이터 적층. helper 헬퍼 추출은 본 PR scope 외 (필요 시 별도 리팩터).
- `secret-exposure`: `--credential app_secret=VALUE`는 `ps aux` 평문 노출. `--credential-env`/`--credential-file` 우선 사용 권장 (help 문구).
- `silent-ignore`: `--broker-config`는 free-form pass-through (#1171 SSOT). 알 수 없는 key는 broker adapter가 silent ignore. 후속 이슈에서 `BrokerPreset.optional_broker_config` 모델 도입 가능.

## Test Plan

- [x] `pytest tests/unit/test_account_cli.py -v` → 47 passed (32 기존 + 2 BREAKING migration + 2 새 P2 + ...)
- [x] `pytest tests/unit/test_is_paper_migration.py -v` → 11 passed
- [x] `pytest tests/unit/test_cli_format_option.py -v` → 16 passed
- [x] `pytest tests/unit -q -k "account or cli"` → 850 passed (영역 회귀 없음)
- [x] `ruff check src/ante/cli tests/unit` → All checks passed
- [x] `ruff format --check src/ante/cli tests/unit` → 223 files already formatted
- [x] `mypy src/ante/cli` → no issues found in 28 source files
- [x] `grep -nE "click\.prompt|click\.confirm|confirmation_option" src/ante/cli/commands/account.py` → 0건
- [x] cold-path active runtime guard 회귀 없음 (`test_create_blocked_when_active_runtime`, `test_delete_blocked_when_active_runtime`, `test_set_credentials_blocked_when_active_runtime` 모두 PASS)

## 후속 이슈

- #1205 (CLI JSON error response format 정렬) — cross-CLI 일괄 변경 (`{status, code, message}` SSOT 적용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)