### PR TITLE
refactor(cli): make update non-interactive

### DIFF
--- a/src/ante/cli/commands/update.py
+++ b/src/ante/cli/commands/update.py
@@ -75,7 +75,12 @@ def check_server_running() -> bool:
 @click.option(
     "--version", "target_version", default=None, help="특정 버전으로 업데이트"
 )
-@click.option("--yes", "-y", is_flag=True, help="확인 프롬프트 건너뛰기")
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="실제 업데이트 실행 확인 (위험 명령). 누락 시 prompt 없이 에러로 실패",
+)
 @click.option("--force", is_flag=True, help="서버 실행 중이면 자동 중지")
 @format_option
 @click.pass_context
@@ -86,7 +91,12 @@ def update(
     yes: bool,
     force: bool,
 ) -> None:
-    """ante를 최신 버전으로 업데이트합니다."""
+    """ante를 최신 버전으로 업데이트합니다.
+
+    `--check`은 PyPI 버전 조회만 수행한다 (`--yes` 불필요).
+    `--check`이 아닌 실제 업데이트 실행은 `--yes`가 반드시 필요하며,
+    누락 시 prompt 없이 ``CLI_CONFIRMATION_REQUIRED`` 에러로 종료한다.
+    """
     from ante.update.checker import (
         get_current_version,
         get_latest_version,
@@ -164,10 +174,17 @@ def update(
         click.echo(msg, err=True)
         raise SystemExit(1)
 
+    # 비대화형 입력 계약 (#1170, #1171 SSOT): `--yes`가 없으면 prompt 없이
+    # ``CLI_CONFIRMATION_REQUIRED`` 에러로 종료한다. 이 게이트는 디스크 공간
+    # 검사 직후, backup/pip upgrade/migration 호출 전에 위치하므로 조기 종료
+    # 시 부수 효과(백업 생성, 의존성 스냅샷, pip 호출 등)는 발생하지 않는다.
     if not yes:
-        if not click.confirm(f"{current} → {latest}로 업데이트하시겠습니까?"):
-            click.echo("업데이트를 취소했습니다")
-            return
+        fmt.error(
+            f"업데이트 실행에는 --yes가 필요합니다 ({current} → {latest}). "
+            "재실행: ante update --yes",
+            code="CLI_CONFIRMATION_REQUIRED",
+        )
+        raise SystemExit(1)
 
     # Phase A: 백업 + pip upgrade
 

--- a/src/ante/cli/commands/update.py
+++ b/src/ante/cli/commands/update.py
@@ -148,6 +148,21 @@ def update(
         fmt.error("PyPI 버전 확인 실패")
         raise SystemExit(1)
 
+    # 비대화형 입력 계약 (#1170, #1171 SSOT): `--check`이 아닌 실제 업데이트
+    # 실행 호출에는 `--yes`가 반드시 필요하다. 이 게이트는 no-update 조기
+    # 반환(이미 최신 버전) **앞에** 위치해야 한다 — 그래야 사용자가 명시적
+    # 실행 의사(`--yes`)를 표현하지 않은 호출은 버전 상태와 무관하게
+    # ``CLI_CONFIRMATION_REQUIRED``로 거절된다 (Codex P2 finding).
+    # 게이트 통과 전이므로 backup/pip upgrade/migration 등 부수 효과는
+    # 일체 발생하지 않는다.
+    if not yes:
+        fmt.error(
+            f"업데이트 실행에는 --yes가 필요합니다 ({current} → {latest}). "
+            "재실행: ante update --yes",
+            code="CLI_CONFIRMATION_REQUIRED",
+        )
+        raise SystemExit(1)
+
     if not target_version and not is_update_available(current, latest):
         if fmt.is_json:
             fmt.output(
@@ -172,18 +187,6 @@ def update(
     ok, msg = check_disk_space(db_path)
     if not ok:
         click.echo(msg, err=True)
-        raise SystemExit(1)
-
-    # 비대화형 입력 계약 (#1170, #1171 SSOT): `--yes`가 없으면 prompt 없이
-    # ``CLI_CONFIRMATION_REQUIRED`` 에러로 종료한다. 이 게이트는 디스크 공간
-    # 검사 직후, backup/pip upgrade/migration 호출 전에 위치하므로 조기 종료
-    # 시 부수 효과(백업 생성, 의존성 스냅샷, pip 호출 등)는 발생하지 않는다.
-    if not yes:
-        fmt.error(
-            f"업데이트 실행에는 --yes가 필요합니다 ({current} → {latest}). "
-            "재실행: ante update --yes",
-            code="CLI_CONFIRMATION_REQUIRED",
-        )
         raise SystemExit(1)
 
     # Phase A: 백업 + pip upgrade

--- a/src/ante/cli/commands/update.py
+++ b/src/ante/cli/commands/update.py
@@ -96,6 +96,9 @@ def update(
     `--check`은 PyPI 버전 조회만 수행한다 (`--yes` 불필요).
     `--check`이 아닌 실제 업데이트 실행은 `--yes`가 반드시 필요하며,
     누락 시 prompt 없이 ``CLI_CONFIRMATION_REQUIRED`` 에러로 종료한다.
+    `--yes` 게이트는 PyPI 조회 **앞에** 평가하므로, 네트워크 느림/실패
+    환경에서도 `--yes` 누락 호출은 PyPI 실패가 아닌 동일한 구조화 에러
+    코드로 거절된다.
     """
     from ante.update.checker import (
         get_current_version,
@@ -142,25 +145,26 @@ def update(
             click.echo("이미 최신 버전입니다")
         return
 
-    # 업데이트 실행
-    latest = target_version or get_latest_version()
-    if latest is None:
-        fmt.error("PyPI 버전 확인 실패")
-        raise SystemExit(1)
-
     # 비대화형 입력 계약 (#1170, #1171 SSOT): `--check`이 아닌 실제 업데이트
-    # 실행 호출에는 `--yes`가 반드시 필요하다. 이 게이트는 no-update 조기
-    # 반환(이미 최신 버전) **앞에** 위치해야 한다 — 그래야 사용자가 명시적
-    # 실행 의사(`--yes`)를 표현하지 않은 호출은 버전 상태와 무관하게
-    # ``CLI_CONFIRMATION_REQUIRED``로 거절된다 (Codex P2 finding).
-    # 게이트 통과 전이므로 backup/pip upgrade/migration 등 부수 효과는
-    # 일체 발생하지 않는다.
+    # 실행 호출에는 `--yes`가 반드시 필요하다. 이 게이트는 PyPI 조회
+    # (`get_latest_version()`) **앞에** 위치해야 한다 — 그래야 네트워크
+    # 느림/실패 환경에서도 `--yes` 누락 호출이 PyPI 실패가 아닌
+    # ``CLI_CONFIRMATION_REQUIRED``로 거절된다 (Codex P2 finding 2차).
+    # 자동화는 네트워크 상태와 무관하게 동일한 구조화 에러 코드를 받는다.
+    # 게이트 통과 전이므로 PyPI 조회/backup/pip upgrade/migration 등
+    # 부수 효과는 일체 발생하지 않는다.
     if not yes:
         fmt.error(
-            f"업데이트 실행에는 --yes가 필요합니다 ({current} → {latest}). "
+            f"업데이트 실행에는 --yes가 필요합니다 (현재 {current}). "
             "재실행: ante update --yes",
             code="CLI_CONFIRMATION_REQUIRED",
         )
+        raise SystemExit(1)
+
+    # 업데이트 실행 — `--yes` 게이트 통과 후에만 PyPI를 조회한다.
+    latest = target_version or get_latest_version()
+    if latest is None:
+        fmt.error("PyPI 버전 확인 실패")
         raise SystemExit(1)
 
     if not target_version and not is_update_available(current, latest):

--- a/tests/unit/test_cli_update.py
+++ b/tests/unit/test_cli_update.py
@@ -1,6 +1,7 @@
 """check_server_running 유틸 함수 및 --format json 테스트.
 
 이슈 #920: --format json 옵션 지원 검증.
+이슈 #1176: 비대화형 업데이트 계약(`click.confirm` 제거, `--yes` 게이트) 검증.
 """
 
 from __future__ import annotations
@@ -198,3 +199,103 @@ class TestUpdateFormatJsonError:
         assert result.exit_code == 1
         data = json.loads(result.output)
         assert "error" in data
+
+
+class TestUpdateNonInteractive:
+    """비대화형 업데이트 계약 검증 (#1176).
+
+    `click.confirm`을 제거하고 `--yes`/`--check`/`--force` 의미를 분리한
+    이후의 동작을 검증한다.
+    """
+
+    def test_update_without_yes_fails_confirmation_required(
+        self, runner: CliRunner
+    ) -> None:
+        """``--yes`` 누락 → exit 1, prompt 없음, ``CLI_CONFIRMATION_REQUIRED``.
+
+        - stdin prompt가 발생하지 않아야 한다 (input=None).
+        - ``pip_upgrade`` 등 부수 효과 함수가 호출되지 않아야 한다.
+        - JSON 에러 코드는 ``CLI_CONFIRMATION_REQUIRED``.
+        """
+        with (
+            patch(
+                "ante.cli.commands.update.check_server_running",
+                return_value=False,
+            ),
+            patch("ante.update.checker.get_current_version", return_value="0.6.1"),
+            patch("ante.update.checker.get_latest_version", return_value="0.7.0"),
+            patch(
+                "ante.cli.commands.update.check_disk_space",
+                return_value=(True, ""),
+            ),
+            patch("ante.update.executor.pip_upgrade") as mock_pip_upgrade,
+            patch("ante.db.backup.backup_db") as mock_backup,
+            patch("ante.update.executor.snapshot_dependencies") as mock_snapshot,
+            patch("ante.update.executor.run_post_update_migrations") as mock_migrate,
+        ):
+            # input=None → click.confirm이 남아 있으면 stdin EOF로 실패한다.
+            result = runner.invoke(cli, ["--format", "json", "update"], input=None)
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["code"] == "CLI_CONFIRMATION_REQUIRED"
+        assert "--yes" in data["error"]
+
+        # 부수 효과가 발생하지 않아야 한다 (게이트가 막아야 한다).
+        mock_pip_upgrade.assert_not_called()
+        mock_backup.assert_not_called()
+        mock_snapshot.assert_not_called()
+        mock_migrate.assert_not_called()
+
+    def test_update_with_yes_invokes_pip_upgrade(self, runner: CliRunner) -> None:
+        """업데이트 가능 + ``--yes`` 있음 → 기존 업데이트 플로우 진입.
+
+        - ``--yes`` 게이트를 통과해 ``pip_upgrade``가 호출되어야 한다.
+        - 정상 종료 시 exit 0.
+        """
+        with (
+            patch(
+                "ante.cli.commands.update.check_server_running",
+                return_value=False,
+            ),
+            patch("ante.update.checker.get_current_version", return_value="0.6.1"),
+            patch("ante.update.checker.get_latest_version", return_value="0.7.0"),
+            patch(
+                "ante.cli.commands.update.check_disk_space",
+                return_value=(True, ""),
+            ),
+            patch("ante.db.backup.backup_db"),
+            patch("ante.update.executor.snapshot_dependencies", return_value=None),
+            patch(
+                "ante.update.executor.pip_upgrade", return_value=True
+            ) as mock_pip_upgrade,
+            patch(
+                "ante.update.executor.run_post_update_migrations",
+                return_value=True,
+            ) as mock_migrate,
+            patch("pathlib.Path.exists", return_value=False),
+        ):
+            result = runner.invoke(cli, ["update", "--yes"])
+
+        assert result.exit_code == 0
+        mock_pip_upgrade.assert_called_once()
+        mock_migrate.assert_called_once()
+
+    def test_check_alone_succeeds_without_yes(self, runner: CliRunner) -> None:
+        """``--check`` 단독 → exit 0, ``--yes`` 불필요.
+
+        실제 업데이트를 수행하지 않으므로 ``pip_upgrade``는 호출되지 않는다.
+        """
+        with (
+            patch(
+                "ante.cli.commands.update.check_server_running",
+                return_value=False,
+            ),
+            patch("ante.update.checker.get_current_version", return_value="0.6.1"),
+            patch("ante.update.checker.get_latest_version", return_value="0.7.0"),
+            patch("ante.update.executor.pip_upgrade") as mock_pip_upgrade,
+        ):
+            result = runner.invoke(cli, ["update", "--check"])
+
+        assert result.exit_code == 0
+        mock_pip_upgrade.assert_not_called()

--- a/tests/unit/test_cli_update.py
+++ b/tests/unit/test_cli_update.py
@@ -216,6 +216,8 @@ class TestUpdateNonInteractive:
         - stdin prompt가 발생하지 않아야 한다 (input=None).
         - ``pip_upgrade`` 등 부수 효과 함수가 호출되지 않아야 한다.
         - JSON 에러 코드는 ``CLI_CONFIRMATION_REQUIRED``.
+        - ``get_latest_version`` (PyPI 조회) 호출 횟수가 0이어야 한다 — 게이트가
+          PyPI 조회 앞에 평가되어야 한다 (Codex P2 2차 finding).
         """
         with (
             patch(
@@ -223,7 +225,9 @@ class TestUpdateNonInteractive:
                 return_value=False,
             ),
             patch("ante.update.checker.get_current_version", return_value="0.6.1"),
-            patch("ante.update.checker.get_latest_version", return_value="0.7.0"),
+            patch(
+                "ante.update.checker.get_latest_version", return_value="0.7.0"
+            ) as mock_latest,
             patch(
                 "ante.cli.commands.update.check_disk_space",
                 return_value=(True, ""),
@@ -246,19 +250,26 @@ class TestUpdateNonInteractive:
         mock_backup.assert_not_called()
         mock_snapshot.assert_not_called()
         mock_migrate.assert_not_called()
+        # PyPI 조회도 발생하지 않아야 한다 (게이트가 PyPI 앞에 평가).
+        mock_latest.assert_not_called()
 
     def test_update_without_yes_fails_when_already_latest(
         self, runner: CliRunner
     ) -> None:
         """이미 최신 버전 + ``--yes`` 누락 → exit 1, ``CLI_CONFIRMATION_REQUIRED``.
 
-        Codex P2 finding: ``--yes`` 게이트는 no-update 조기 반환 **앞에**
+        Codex P2 finding (1차): ``--yes`` 게이트는 no-update 조기 반환 **앞에**
         위치해야 한다. 사용자가 명시적 실행 의사(`--yes`)를 표현하지 않은
         ``ante update`` 호출은 버전 상태와 무관하게 거절되어야 한다.
 
-        - ``current == latest`` (이미 최신) 상태에서도 prompt 없이 exit 1.
+        Codex P2 finding (2차): ``--yes`` 게이트는 PyPI 조회 **앞에** 평가되어야
+        한다. 이미 최신 버전 케이스도 PyPI 호출 이전에 거절되므로 mock
+        ``get_latest_version`` 호출 횟수는 0이다.
+
+        - ``--yes`` 누락 → prompt 없이 exit 1.
         - JSON 에러 코드는 ``CLI_CONFIRMATION_REQUIRED``.
         - ``pip_upgrade`` 등 부수 효과 함수는 호출되지 않는다.
+        - ``get_latest_version`` (PyPI) 호출 횟수 0.
         """
         with (
             patch(
@@ -266,7 +277,9 @@ class TestUpdateNonInteractive:
                 return_value=False,
             ),
             patch("ante.update.checker.get_current_version", return_value="0.7.0"),
-            patch("ante.update.checker.get_latest_version", return_value="0.7.0"),
+            patch(
+                "ante.update.checker.get_latest_version", return_value="0.7.0"
+            ) as mock_latest,
             patch(
                 "ante.cli.commands.update.check_disk_space",
                 return_value=(True, ""),
@@ -284,6 +297,63 @@ class TestUpdateNonInteractive:
         assert "--yes" in data["error"]
 
         # 부수 효과가 발생하지 않아야 한다 (게이트가 막아야 한다).
+        mock_pip_upgrade.assert_not_called()
+        mock_backup.assert_not_called()
+        mock_snapshot.assert_not_called()
+        mock_migrate.assert_not_called()
+        # PyPI 조회도 발생하지 않아야 한다 (게이트가 PyPI 앞에 평가).
+        mock_latest.assert_not_called()
+
+    def test_update_without_yes_skips_pypi_when_unreachable(
+        self, runner: CliRunner
+    ) -> None:
+        """PyPI 도달 불가 + ``--yes`` 누락 → ``CLI_CONFIRMATION_REQUIRED`` 우선.
+
+        Codex P2 finding (2차): ``--yes`` 게이트는 PyPI 조회 **앞에** 평가되어야
+        한다. PyPI가 도달 불가(``get_latest_version`` 가 ``None`` 반환,
+        타임아웃/네트워크 실패 시뮬레이션)인 환경에서도, ``--yes`` 누락 호출은
+        PyPI 실패가 아닌 ``CLI_CONFIRMATION_REQUIRED``로 거절되어야 한다 —
+        자동화는 네트워크 상태와 무관하게 동일한 구조화 에러 코드를 받는다.
+
+        - ``get_latest_version`` 가 ``None`` (PyPI 실패) 반환하도록 mock.
+        - ``--yes`` 누락 → exit 1, JSON 에러 코드는 ``CLI_CONFIRMATION_REQUIRED``
+          (``"PyPI 버전 확인 실패"`` 가 아니다).
+        - ``get_latest_version`` 호출 횟수 0 — 게이트가 PyPI 앞에 평가됨을 증명.
+        - 부수 효과(pip upgrade/backup/migration) 호출 횟수 0.
+        """
+        with (
+            patch(
+                "ante.cli.commands.update.check_server_running",
+                return_value=False,
+            ),
+            patch("ante.update.checker.get_current_version", return_value="0.6.1"),
+            # PyPI 도달 불가 시뮬레이션 — 1차 fix에서는 이 mock이 호출되어
+            # ``"PyPI 버전 확인 실패"`` 분기로 빠질 수 있었다. 2차 fix는 이
+            # mock이 호출되지 않음을 보장한다.
+            patch(
+                "ante.update.checker.get_latest_version", return_value=None
+            ) as mock_latest,
+            patch(
+                "ante.cli.commands.update.check_disk_space",
+                return_value=(True, ""),
+            ),
+            patch("ante.update.executor.pip_upgrade") as mock_pip_upgrade,
+            patch("ante.db.backup.backup_db") as mock_backup,
+            patch("ante.update.executor.snapshot_dependencies") as mock_snapshot,
+            patch("ante.update.executor.run_post_update_migrations") as mock_migrate,
+        ):
+            result = runner.invoke(cli, ["--format", "json", "update"], input=None)
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        # PyPI 실패 메시지가 아닌 confirmation 게이트로 fail 해야 한다.
+        assert data["code"] == "CLI_CONFIRMATION_REQUIRED"
+        assert "--yes" in data["error"]
+        assert "PyPI" not in data["error"]
+
+        # 핵심: PyPI 조회가 시도되지 않아야 한다 (게이트가 앞에 위치).
+        mock_latest.assert_not_called()
+        # 부수 효과도 일체 발생하지 않아야 한다.
         mock_pip_upgrade.assert_not_called()
         mock_backup.assert_not_called()
         mock_snapshot.assert_not_called()

--- a/tests/unit/test_cli_update.py
+++ b/tests/unit/test_cli_update.py
@@ -247,6 +247,48 @@ class TestUpdateNonInteractive:
         mock_snapshot.assert_not_called()
         mock_migrate.assert_not_called()
 
+    def test_update_without_yes_fails_when_already_latest(
+        self, runner: CliRunner
+    ) -> None:
+        """이미 최신 버전 + ``--yes`` 누락 → exit 1, ``CLI_CONFIRMATION_REQUIRED``.
+
+        Codex P2 finding: ``--yes`` 게이트는 no-update 조기 반환 **앞에**
+        위치해야 한다. 사용자가 명시적 실행 의사(`--yes`)를 표현하지 않은
+        ``ante update`` 호출은 버전 상태와 무관하게 거절되어야 한다.
+
+        - ``current == latest`` (이미 최신) 상태에서도 prompt 없이 exit 1.
+        - JSON 에러 코드는 ``CLI_CONFIRMATION_REQUIRED``.
+        - ``pip_upgrade`` 등 부수 효과 함수는 호출되지 않는다.
+        """
+        with (
+            patch(
+                "ante.cli.commands.update.check_server_running",
+                return_value=False,
+            ),
+            patch("ante.update.checker.get_current_version", return_value="0.7.0"),
+            patch("ante.update.checker.get_latest_version", return_value="0.7.0"),
+            patch(
+                "ante.cli.commands.update.check_disk_space",
+                return_value=(True, ""),
+            ),
+            patch("ante.update.executor.pip_upgrade") as mock_pip_upgrade,
+            patch("ante.db.backup.backup_db") as mock_backup,
+            patch("ante.update.executor.snapshot_dependencies") as mock_snapshot,
+            patch("ante.update.executor.run_post_update_migrations") as mock_migrate,
+        ):
+            result = runner.invoke(cli, ["--format", "json", "update"], input=None)
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["code"] == "CLI_CONFIRMATION_REQUIRED"
+        assert "--yes" in data["error"]
+
+        # 부수 효과가 발생하지 않아야 한다 (게이트가 막아야 한다).
+        mock_pip_upgrade.assert_not_called()
+        mock_backup.assert_not_called()
+        mock_snapshot.assert_not_called()
+        mock_migrate.assert_not_called()
+
     def test_update_with_yes_invokes_pip_upgrade(self, runner: CliRunner) -> None:
         """업데이트 가능 + ``--yes`` 있음 → 기존 업데이트 플로우 진입.
 


### PR DESCRIPTION
Closes #1176

## Summary
- `ante update`에서 `click.confirm` 제거. `--yes` 누락 시 `CLI_CONFIRMATION_REQUIRED` 구조화 에러로 종료.
- `--yes` 게이트를 PyPI 조회 앞으로 이동 (Codex P2 finding 반영).
- `--check` 경로는 `--yes` 없이 진입 가능, JSON 출력 계약(`current_version`, `latest_version`, `update_available`) 불변.
- 신규 TC 5건 추가 (no-yes/update-available, already-latest, PyPI unreachable, yes success, check-only).
- `--force` graceful shutdown은 Non-Goal로 유지 (`# TODO: graceful shutdown`).

## Test Plan
- [x] `pytest tests/unit/test_cli_update.py -v` → 16 passed
- [x] `ruff check src/ante/cli tests/unit` → PASS
- [x] `ruff format --check src/ante/cli tests/unit` → PASS
- [x] `mypy src/ante/cli` → PASS
- [x] `grep -nE "click\.(prompt|confirm)|confirmation_option" src/ante/cli/commands/update.py` → 0건
- [x] `/codex:review --base origin/main` → PASS (8/8 검증 항목)

🤖 Generated with [Claude Code](https://claude.com/claude-code)