### PR TITLE
refactor(cli): make member revoke/reset-password/regenerate-recovery-key non-interactive

### DIFF
--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -1,8 +1,19 @@
-"""ante member — 멤버 관리 커맨드."""
+"""ante member — 멤버 관리 커맨드.
+
+비대화형 입력 계약(SSOT: docs/specs/cli/02-design-decisions.md):
+- ``member revoke``는 ``--yes`` 누락 시 prompt 없이
+  ``CLI_CONFIRMATION_REQUIRED``로 실패한다.
+- ``member reset-password`` / ``member regenerate-recovery-key``는 비밀값을
+  ``--*-env <ENV_NAME>`` 또는 ``--*-file <PATH>`` 채널로만 받는다. 누락/공란/중복은
+  도메인 prefix 에러 코드(``MEMBER_PASSWORD_ENV_NOT_SET``,
+  ``MEMBER_PASSWORD_FILE_NOT_FOUND``, ``CLI_MISSING_REQUIRED_INPUT``)로 실패한다.
+"""
 
 from __future__ import annotations
 
 import asyncio
+import os
+from pathlib import Path
 
 import click
 
@@ -19,6 +30,72 @@ def member() -> None:
 def _run(coro):  # noqa: ANN001, ANN202
     """동기 CLI에서 async 함수 실행."""
     return asyncio.run(coro)
+
+
+def _resolve_secret_non_interactive(
+    fmt,  # noqa: ANN001
+    *,
+    env_name: str | None,
+    file_path: str | None,
+    env_option_label: str,
+    file_option_label: str,
+    missing_input_message: str,
+) -> str:
+    """``--*-env`` / ``--*-file`` 채널에서 비밀값을 비대화형으로 읽어들인다.
+
+    - 둘 다 없으면 ``CLI_MISSING_REQUIRED_INPUT``로 실패한다.
+    - 둘 다 지정되면 (상호 배타) ``CLI_MISSING_REQUIRED_INPUT``로 실패한다.
+    - env 부재/공란이면 ``MEMBER_PASSWORD_ENV_NOT_SET``로 실패한다.
+    - file 부재/읽기 실패/공란이면 ``MEMBER_PASSWORD_FILE_NOT_FOUND``로 실패한다.
+
+    실패는 모두 ``fmt.error(..., code=...)`` 출력 후 ``SystemExit(1)``로 종료한다.
+    """
+    if env_name is None and file_path is None:
+        fmt.error(
+            missing_input_message
+            + f" {env_option_label} 또는 {file_option_label} 중 하나를 지정하세요.",
+            code="CLI_MISSING_REQUIRED_INPUT",
+        )
+        raise SystemExit(1)
+
+    if env_name is not None and file_path is not None:
+        fmt.error(
+            f"{env_option_label}와 {file_option_label}는 동시에 지정할 수 없습니다."
+            " 둘 중 하나만 사용하세요.",
+            code="CLI_MISSING_REQUIRED_INPUT",
+        )
+        raise SystemExit(1)
+
+    if env_name is not None:
+        value = os.environ.get(env_name)
+        if value is None or value.strip() == "":
+            fmt.error(
+                f"환경변수 {env_name}이(가) 설정되어 있지 않거나 공란입니다."
+                f" {env_option_label}는 비밀값이 든 환경변수의 *이름*만 받습니다.",
+                code="MEMBER_PASSWORD_ENV_NOT_SET",
+            )
+            raise SystemExit(1)
+        return value.strip()
+
+    # file_path is not None
+    assert file_path is not None  # noqa: S101 — 위 분기로 보장
+    path = Path(file_path)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as e:
+        fmt.error(
+            f"{file_option_label} 파일을 읽을 수 없습니다: {file_path} ({e})",
+            code="MEMBER_PASSWORD_FILE_NOT_FOUND",
+        )
+        raise SystemExit(1) from e
+    value = raw.strip()
+    if value == "":
+        fmt.error(
+            f"{file_option_label} 파일이 비어 있습니다: {file_path}",
+            code="MEMBER_PASSWORD_FILE_NOT_FOUND",
+        )
+        raise SystemExit(1)
+    return value
 
 
 async def _create_service():  # noqa: ANN202
@@ -296,14 +373,31 @@ def member_reactivate(ctx: click.Context, member_id: str) -> None:
 
 @member.command("revoke")
 @click.argument("member_id")
-@click.confirmation_option(prompt="이 작업은 되돌릴 수 없습니다. 계속하시겠습니까?")
+@click.option(
+    "--yes",
+    "yes",
+    is_flag=True,
+    default=False,
+    help="삭제를 확인 (위험 명령). 누락 시 prompt 없이 에러로 실패",
+)
 @click.pass_context
 @require_auth
 @require_scope("member:admin")
-def member_revoke(ctx: click.Context, member_id: str) -> None:
-    """멤버 영구 폐기."""
+def member_revoke(ctx: click.Context, member_id: str, yes: bool) -> None:
+    """멤버 영구 폐기.
+
+    ``--yes`` 누락 시 prompt 없이 ``CLI_CONFIRMATION_REQUIRED`` 에러로 종료한다.
+    """
     fmt = get_formatter(ctx)
     actor = get_member_id(ctx)
+
+    if not yes:
+        fmt.error(
+            "위험 명령입니다. --yes를 명시해야 멤버를 폐기합니다."
+            " 이 작업은 되돌릴 수 없습니다.",
+            code="CLI_CONFIRMATION_REQUIRED",
+        )
+        raise SystemExit(1)
 
     async def _run_revoke() -> dict:
         service, db = await _create_service()
@@ -356,12 +450,40 @@ def member_rotate_token(ctx: click.Context, member_id: str) -> None:
 
 @member.command("reset-password")
 @click.option("--recovery-key", required=True, help="Recovery Key")
+@click.option(
+    "--new-password-env",
+    "new_password_env",
+    default=None,
+    help="새 패스워드를 담은 환경변수의 *이름* (값이 아닌 변수명만 받음)",
+)
+@click.option(
+    "--new-password-file",
+    "new_password_file",
+    default=None,
+    type=click.Path(dir_okay=False),
+    help="새 패스워드를 담은 파일의 경로 (파일 내용 strip)",
+)
 @click.pass_context
-def member_reset_password(ctx: click.Context, recovery_key: str) -> None:
-    """Recovery Key로 패스워드 리셋 (인증 불필요)."""
+def member_reset_password(
+    ctx: click.Context,
+    recovery_key: str,
+    new_password_env: str | None,
+    new_password_file: str | None,
+) -> None:
+    """Recovery Key로 패스워드 리셋 (인증 불필요).
+
+    새 패스워드는 ``--new-password-env <ENV_NAME>`` 또는
+    ``--new-password-file <PATH>``로만 받으며, 둘 다 없거나 둘 다 지정하면 prompt
+    없이 ``CLI_MISSING_REQUIRED_INPUT``로 실패한다.
+    """
     fmt = get_formatter(ctx)
-    new_password = click.prompt(
-        "새 패스워드", hide_input=True, confirmation_prompt=True
+    new_password = _resolve_secret_non_interactive(
+        fmt,
+        env_name=new_password_env,
+        file_path=new_password_file,
+        env_option_label="--new-password-env",
+        file_option_label="--new-password-file",
+        missing_input_message="새 패스워드 입력이 필요합니다.",
     )
 
     async def _run_reset() -> None:
@@ -386,11 +508,40 @@ def member_reset_password(ctx: click.Context, recovery_key: str) -> None:
 
 
 @member.command("regenerate-recovery-key")
+@click.option(
+    "--password-env",
+    "password_env",
+    default=None,
+    help="현재 패스워드를 담은 환경변수의 *이름* (값이 아닌 변수명만 받음)",
+)
+@click.option(
+    "--password-file",
+    "password_file",
+    default=None,
+    type=click.Path(dir_okay=False),
+    help="현재 패스워드를 담은 파일의 경로 (파일 내용 strip)",
+)
 @click.pass_context
-def member_regenerate_recovery_key(ctx: click.Context) -> None:
-    """Recovery Key 재발급 (인증 불필요)."""
+def member_regenerate_recovery_key(
+    ctx: click.Context,
+    password_env: str | None,
+    password_file: str | None,
+) -> None:
+    """Recovery Key 재발급 (인증 불필요).
+
+    현재 패스워드는 ``--password-env <ENV_NAME>`` 또는 ``--password-file <PATH>``로만
+    받으며, 둘 다 없거나 둘 다 지정하면 prompt 없이 ``CLI_MISSING_REQUIRED_INPUT``로
+    실패한다.
+    """
     fmt = get_formatter(ctx)
-    password = click.prompt("현재 패스워드", hide_input=True)
+    password = _resolve_secret_non_interactive(
+        fmt,
+        env_name=password_env,
+        file_path=password_file,
+        env_option_label="--password-env",
+        file_option_label="--password-file",
+        missing_input_message="현재 패스워드 입력이 필요합니다.",
+    )
 
     async def _run_regen() -> str:
         service, db = await _create_service()

--- a/tests/unit/test_cli_member_non_interactive.py
+++ b/tests/unit/test_cli_member_non_interactive.py
@@ -1,0 +1,626 @@
+"""Member CLI 비대화형 입력 계약 테스트.
+
+이슈 #1177에서 도입한 비대화형 입력 채널을 검증한다.
+
+- ``member revoke <id> --yes`` / 누락 시 ``CLI_CONFIRMATION_REQUIRED``
+- ``member reset-password --new-password-env`` / ``--new-password-file`` 성공
+- 누락 / 둘 다 지정 / env 부재·공란 / file 부재·공란 실패 케이스
+- ``member regenerate-recovery-key --password-env`` / ``--password-file`` 성공
+- 위 동일 실패 케이스
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+
+def _make_master() -> Member:
+    """테스트용 master Member."""
+    return Member(
+        member_id="master",
+        type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+        org="default",
+        name="Master",
+        status="active",
+        scopes=[],
+    )
+
+
+def _mock_authenticate(ctx) -> None:  # noqa: ANN001
+    """test runner 인증 우회."""
+    ctx.obj["member"] = _make_master()
+
+
+def _invoke_cli(args: list[str]):  # noqa: ANN202
+    """CLI를 실행하고 결과를 반환한다 (인증 우회)."""
+    runner = CliRunner()
+    with patch("ante.cli.main.authenticate_member", side_effect=_mock_authenticate):
+        return runner.invoke(
+            cli,
+            args,
+            obj={"member": _make_master()},
+            env={"ANTE_MEMBER_TOKEN": ""},
+            catch_exceptions=False,
+        )
+
+
+def _patch_create_service(
+    *,
+    list_members_return: list | None = None,
+    revoke_return: Member | None = None,
+    reset_password_side_effect: object | None = None,
+    regenerate_return: str | None = None,
+):
+    """member._create_service를 mock하는 contextmanager."""
+    service = MagicMock()
+    service.list_members = AsyncMock(return_value=list_members_return or [])
+    service.revoke = AsyncMock(
+        return_value=revoke_return
+        if revoke_return is not None
+        else _make_master_with_status("revoked")
+    )
+    service.reset_password = AsyncMock(
+        side_effect=(
+            reset_password_side_effect
+            if reset_password_side_effect is not None
+            else None
+        ),
+        return_value=None,
+    )
+    service.regenerate_recovery_key = AsyncMock(
+        return_value=regenerate_return or "ANTE-RK-NEWNEW-1234"
+    )
+    db = MagicMock()
+    db.close = AsyncMock(return_value=None)
+    return patch(
+        "ante.cli.commands.member._create_service",
+        new_callable=AsyncMock,
+        return_value=(service, db),
+    ), service
+
+
+def _make_master_with_status(status: str) -> Member:
+    """status를 변경한 master Member."""
+    return Member(
+        member_id="master",
+        type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+        org="default",
+        name="Master",
+        status=status,
+        scopes=[],
+    )
+
+
+# ── member revoke ────────────────────────────────────
+
+
+class TestMemberRevokeYes:
+    """`member revoke`의 --yes 비대화형 게이트."""
+
+    def test_revoke_without_yes_fails_confirmation_required(self) -> None:
+        """`--yes` 누락 시 prompt 없이 CLI_CONFIRMATION_REQUIRED로 실패."""
+        # _create_service는 호출되지 않아야 한다 (게이트 통과 전 차단).
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+            revoke_return=_make_master_with_status("revoked"),
+        )
+        with ctx:
+            result = _invoke_cli(
+                ["--format", "json", "member", "revoke", "agent-1"],
+            )
+
+        assert result.exit_code == 1, result.output
+        service.revoke.assert_not_awaited()
+        data = json.loads(result.output)
+        assert data["code"] == "CLI_CONFIRMATION_REQUIRED"
+        assert "--yes" in data["error"]
+
+    def test_revoke_with_yes_invokes_revoke(self) -> None:
+        """`--yes` 명시 시 MemberService.revoke가 실행된다."""
+        revoked_member = Member(
+            member_id="agent-1",
+            type=MemberType.AGENT,
+            role=MemberRole.DEFAULT,
+            org="default",
+            name="Agent",
+            status="revoked",
+            scopes=[],
+        )
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+            revoke_return=revoked_member,
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "revoke",
+                    "agent-1",
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        service.revoke.assert_awaited_once()
+        # actor=master(관리자) 인자도 전달된다.
+        call = service.revoke.await_args
+        assert call.args[0] == "agent-1"
+        assert call.kwargs.get("revoked_by") == "master"
+
+
+# ── member reset-password ────────────────────────────
+
+
+class TestMemberResetPasswordEnvFile:
+    """`member reset-password`의 --new-password-env / --new-password-file."""
+
+    def test_reset_password_via_env_succeeds(self, monkeypatch) -> None:  # noqa: ANN001
+        """ANTE_NEW_PASSWORD 환경변수에서 새 패스워드를 읽어 reset_password 호출."""
+        monkeypatch.setenv("ANTE_NEW_PASSWORD", "supersecret-new-password")
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "member",
+                    "reset-password",
+                    "--recovery-key",
+                    "ANTE-RK-TEST",
+                    "--new-password-env",
+                    "ANTE_NEW_PASSWORD",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        service.reset_password.assert_awaited_once()
+        # (member_id, recovery_key, new_password)
+        call = service.reset_password.await_args
+        assert call.args[0] == "master"
+        assert call.args[1] == "ANTE-RK-TEST"
+        assert call.args[2] == "supersecret-new-password"
+
+    def test_reset_password_via_file_succeeds(self, tmp_path) -> None:  # noqa: ANN001
+        """파일에서 새 패스워드를 읽어 reset_password 호출 (strip 적용)."""
+        pwd_file = tmp_path / "new-password"
+        # trailing newline은 strip되어야 한다.
+        pwd_file.write_text("file-password-99\n", encoding="utf-8")
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "member",
+                    "reset-password",
+                    "--recovery-key",
+                    "ANTE-RK-TEST",
+                    "--new-password-file",
+                    str(pwd_file),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        service.reset_password.assert_awaited_once()
+        call = service.reset_password.await_args
+        assert call.args[2] == "file-password-99"
+
+    def test_reset_password_without_env_or_file_fails(
+        self,
+    ) -> None:
+        """env/file 옵션 모두 누락 → CLI_MISSING_REQUIRED_INPUT."""
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "reset-password",
+                    "--recovery-key",
+                    "ANTE-RK-TEST",
+                ],
+            )
+
+        assert result.exit_code == 1, result.output
+        service.reset_password.assert_not_awaited()
+        data = json.loads(result.output)
+        assert data["code"] == "CLI_MISSING_REQUIRED_INPUT"
+        assert "--new-password-env" in data["error"]
+        assert "--new-password-file" in data["error"]
+
+    def test_reset_password_both_env_and_file_fails(
+        self,
+        tmp_path,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
+        """env/file 옵션 둘 다 지정 → CLI_MISSING_REQUIRED_INPUT (상호 배타)."""
+        monkeypatch.setenv("ANTE_NEW_PASSWORD", "envvalue")
+        pwd_file = tmp_path / "new-password"
+        pwd_file.write_text("filevalue", encoding="utf-8")
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "reset-password",
+                    "--recovery-key",
+                    "ANTE-RK-TEST",
+                    "--new-password-env",
+                    "ANTE_NEW_PASSWORD",
+                    "--new-password-file",
+                    str(pwd_file),
+                ],
+            )
+
+        assert result.exit_code == 1, result.output
+        service.reset_password.assert_not_awaited()
+        data = json.loads(result.output)
+        assert data["code"] == "CLI_MISSING_REQUIRED_INPUT"
+        assert "동시에" in data["error"]
+
+    def test_reset_password_env_unset_fails(
+        self,
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
+        """존재하지 않는 환경변수 → MEMBER_PASSWORD_ENV_NOT_SET."""
+        monkeypatch.delenv("ANTE_NEW_PASSWORD_DOES_NOT_EXIST", raising=False)
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "reset-password",
+                    "--recovery-key",
+                    "ANTE-RK-TEST",
+                    "--new-password-env",
+                    "ANTE_NEW_PASSWORD_DOES_NOT_EXIST",
+                ],
+            )
+
+        assert result.exit_code == 1, result.output
+        service.reset_password.assert_not_awaited()
+        data = json.loads(result.output)
+        assert data["code"] == "MEMBER_PASSWORD_ENV_NOT_SET"
+
+    def test_reset_password_env_empty_fails(
+        self,
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
+        """공란 환경변수 → MEMBER_PASSWORD_ENV_NOT_SET."""
+        monkeypatch.setenv("ANTE_NEW_PASSWORD_BLANK", "   \t\n  ")
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "reset-password",
+                    "--recovery-key",
+                    "ANTE-RK-TEST",
+                    "--new-password-env",
+                    "ANTE_NEW_PASSWORD_BLANK",
+                ],
+            )
+
+        assert result.exit_code == 1, result.output
+        service.reset_password.assert_not_awaited()
+        data = json.loads(result.output)
+        assert data["code"] == "MEMBER_PASSWORD_ENV_NOT_SET"
+
+    def test_reset_password_file_missing_fails(
+        self,
+        tmp_path,  # noqa: ANN001
+    ) -> None:
+        """존재하지 않는 파일 → MEMBER_PASSWORD_FILE_NOT_FOUND."""
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "reset-password",
+                    "--recovery-key",
+                    "ANTE-RK-TEST",
+                    "--new-password-file",
+                    str(tmp_path / "no-such-file"),
+                ],
+            )
+
+        assert result.exit_code == 1, result.output
+        service.reset_password.assert_not_awaited()
+        data = json.loads(result.output)
+        assert data["code"] == "MEMBER_PASSWORD_FILE_NOT_FOUND"
+
+    def test_reset_password_file_empty_fails(
+        self,
+        tmp_path,  # noqa: ANN001
+    ) -> None:
+        """공란 파일 → MEMBER_PASSWORD_FILE_NOT_FOUND."""
+        pwd_file = tmp_path / "empty"
+        pwd_file.write_text("   \n\t\n", encoding="utf-8")
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "reset-password",
+                    "--recovery-key",
+                    "ANTE-RK-TEST",
+                    "--new-password-file",
+                    str(pwd_file),
+                ],
+            )
+
+        assert result.exit_code == 1, result.output
+        service.reset_password.assert_not_awaited()
+        data = json.loads(result.output)
+        assert data["code"] == "MEMBER_PASSWORD_FILE_NOT_FOUND"
+
+
+# ── member regenerate-recovery-key ───────────────────
+
+
+class TestMemberRegenerateRecoveryKeyEnvFile:
+    """`member regenerate-recovery-key`의 --password-env / --password-file."""
+
+    def test_regenerate_via_env_succeeds(self, monkeypatch) -> None:  # noqa: ANN001
+        """ANTE_PASSWORD 환경변수에서 현재 패스워드를 읽어 regenerate 호출."""
+        monkeypatch.setenv("ANTE_PASSWORD", "current-password-22")
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+            regenerate_return="ANTE-RK-NEW-1111",
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "regenerate-recovery-key",
+                    "--password-env",
+                    "ANTE_PASSWORD",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        service.regenerate_recovery_key.assert_awaited_once()
+        # (member_id, password)
+        call = service.regenerate_recovery_key.await_args
+        assert call.args[0] == "master"
+        assert call.args[1] == "current-password-22"
+        data = json.loads(result.output)
+        assert data["recovery_key"] == "ANTE-RK-NEW-1111"
+
+    def test_regenerate_via_file_succeeds(self, tmp_path) -> None:  # noqa: ANN001
+        """파일에서 현재 패스워드를 읽어 regenerate 호출."""
+        pwd_file = tmp_path / "password"
+        pwd_file.write_text("file-current-pwd\n", encoding="utf-8")
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+            regenerate_return="ANTE-RK-NEW-2222",
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "regenerate-recovery-key",
+                    "--password-file",
+                    str(pwd_file),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        service.regenerate_recovery_key.assert_awaited_once()
+        call = service.regenerate_recovery_key.await_args
+        assert call.args[1] == "file-current-pwd"
+
+    def test_regenerate_without_env_or_file_fails(self) -> None:
+        """env/file 옵션 모두 누락 → CLI_MISSING_REQUIRED_INPUT."""
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "regenerate-recovery-key",
+                ],
+            )
+
+        assert result.exit_code == 1, result.output
+        service.regenerate_recovery_key.assert_not_awaited()
+        data = json.loads(result.output)
+        assert data["code"] == "CLI_MISSING_REQUIRED_INPUT"
+        assert "--password-env" in data["error"]
+        assert "--password-file" in data["error"]
+
+    def test_regenerate_both_env_and_file_fails(
+        self,
+        tmp_path,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
+        """env/file 옵션 둘 다 지정 → CLI_MISSING_REQUIRED_INPUT (상호 배타)."""
+        monkeypatch.setenv("ANTE_PASSWORD", "envvalue")
+        pwd_file = tmp_path / "password"
+        pwd_file.write_text("filevalue", encoding="utf-8")
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "regenerate-recovery-key",
+                    "--password-env",
+                    "ANTE_PASSWORD",
+                    "--password-file",
+                    str(pwd_file),
+                ],
+            )
+
+        assert result.exit_code == 1, result.output
+        service.regenerate_recovery_key.assert_not_awaited()
+        data = json.loads(result.output)
+        assert data["code"] == "CLI_MISSING_REQUIRED_INPUT"
+        assert "동시에" in data["error"]
+
+    def test_regenerate_env_unset_fails(
+        self,
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
+        """존재하지 않는 환경변수 → MEMBER_PASSWORD_ENV_NOT_SET."""
+        monkeypatch.delenv("ANTE_PASSWORD_DOES_NOT_EXIST", raising=False)
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "regenerate-recovery-key",
+                    "--password-env",
+                    "ANTE_PASSWORD_DOES_NOT_EXIST",
+                ],
+            )
+
+        assert result.exit_code == 1, result.output
+        service.regenerate_recovery_key.assert_not_awaited()
+        data = json.loads(result.output)
+        assert data["code"] == "MEMBER_PASSWORD_ENV_NOT_SET"
+
+    def test_regenerate_env_empty_fails(
+        self,
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
+        """공란 환경변수 → MEMBER_PASSWORD_ENV_NOT_SET."""
+        monkeypatch.setenv("ANTE_PASSWORD_BLANK", "   ")
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "regenerate-recovery-key",
+                    "--password-env",
+                    "ANTE_PASSWORD_BLANK",
+                ],
+            )
+
+        assert result.exit_code == 1, result.output
+        service.regenerate_recovery_key.assert_not_awaited()
+        data = json.loads(result.output)
+        assert data["code"] == "MEMBER_PASSWORD_ENV_NOT_SET"
+
+    def test_regenerate_file_missing_fails(
+        self,
+        tmp_path,  # noqa: ANN001
+    ) -> None:
+        """존재하지 않는 파일 → MEMBER_PASSWORD_FILE_NOT_FOUND."""
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "regenerate-recovery-key",
+                    "--password-file",
+                    str(tmp_path / "no-such-file"),
+                ],
+            )
+
+        assert result.exit_code == 1, result.output
+        service.regenerate_recovery_key.assert_not_awaited()
+        data = json.loads(result.output)
+        assert data["code"] == "MEMBER_PASSWORD_FILE_NOT_FOUND"
+
+    def test_regenerate_file_empty_fails(
+        self,
+        tmp_path,  # noqa: ANN001
+    ) -> None:
+        """공란 파일 → MEMBER_PASSWORD_FILE_NOT_FOUND."""
+        pwd_file = tmp_path / "empty"
+        pwd_file.write_text("\n", encoding="utf-8")
+        ctx, service = _patch_create_service(
+            list_members_return=[_make_master()],
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "regenerate-recovery-key",
+                    "--password-file",
+                    str(pwd_file),
+                ],
+            )
+
+        assert result.exit_code == 1, result.output
+        service.regenerate_recovery_key.assert_not_awaited()
+        data = json.loads(result.output)
+        assert data["code"] == "MEMBER_PASSWORD_FILE_NOT_FOUND"
+
+
+# ── prompt 사용 금지 회귀 ─────────────────────────────
+
+
+class TestPromptApiAbsent:
+    """member.py에 click.prompt / click.confirm / confirmation_option이 남지 않음."""
+
+    def test_no_prompt_or_confirm_in_member_module(self) -> None:
+        """source 텍스트 회귀 가드 — 비대화형 입력 계약 SSOT 준수."""
+        from pathlib import Path
+
+        import ante.cli.commands.member as member_module
+
+        src = Path(member_module.__file__).read_text(encoding="utf-8")
+        assert "click.prompt" not in src, "click.prompt가 member.py에 남아 있다"
+        assert "click.confirm" not in src, "click.confirm이 member.py에 남아 있다"
+        assert "confirmation_option" not in src, (
+            "confirmation_option이 member.py에 남아 있다"
+        )


### PR DESCRIPTION
Closes #1177

## Summary
- `member revoke`: `@click.confirmation_option` 제거 → `--yes` 플래그. 누락 시 `CLI_CONFIRMATION_REQUIRED` 구조화 에러.
- `member reset-password`: `click.prompt(..., confirmation_prompt=True)` 제거 → `--new-password-env <ENV_NAME>` / `--new-password-file <PATH>` (상호 배타).
- `member regenerate-recovery-key`: `click.prompt("현재 패스워드", hide_input=True)` 제거 → `--password-env` / `--password-file` (상호 배타).
- 공용 helper `_resolve_secret_non_interactive`: env/file 상호 배타, 부재/공란 분기 (`CLI_MISSING_REQUIRED_INPUT`/`MEMBER_PASSWORD_ENV_NOT_SET`/`MEMBER_PASSWORD_FILE_NOT_FOUND`).
- 옵션은 비밀값의 *이름/경로*만 수신, 파일 내용은 `strip()` 처리 (Risk Flags 1·2 준수).
- `_AUTH_EXEMPT_COMMAND_PATHS` 변경 없음 (인증 면제/maintenance fallback 경계 유지).
- MemberService 시그니처 변경 없음.

## Test Plan
- [x] `pytest tests/unit/test_cli_auth.py -v -k "reset_password or regenerate or revoke"` → 3 passed
- [x] `pytest tests/unit/test_cli_member_non_interactive.py -v` → 19 passed
- [x] `pytest tests/unit -q -k "member or cli"` → 642 passed
- [x] `ruff check src/ante/cli tests/unit` → PASS
- [x] `ruff format --check src/ante/cli tests/unit` → PASS
- [x] `mypy src/ante/cli` → PASS
- [x] `grep -nE "click\.(prompt|confirm)|confirmation_option" src/ante/cli/commands/member.py` → 0건
- [x] `/codex:review --base origin/main` → PASS (9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)