### PR TITLE
test(cli): clean up dead input_text helper params and input="" args

### DIFF
--- a/tests/unit/test_account_cli.py
+++ b/tests/unit/test_account_cli.py
@@ -46,12 +46,12 @@ def _make_cli():
     return cli
 
 
-def _invoke(args: list[str], input_text: str | None = None):
+def _invoke(args: list[str]):
     """CLI를 실행하고 결과를 반환한다."""
     runner = CliRunner()
     cli = _make_cli()
     env = {"ANTE_MEMBER_TOKEN": ""}
-    result = runner.invoke(cli, args, env=env, input=input_text, catch_exceptions=False)
+    result = runner.invoke(cli, args, env=env, catch_exceptions=False)
     return result
 
 

--- a/tests/unit/test_cli_account_integration.py
+++ b/tests/unit/test_cli_account_integration.py
@@ -282,7 +282,6 @@ class TestBotCreateAccountOption:
                     "--strategy",
                     "s1",
                 ],
-                input="",
             )
 
         assert result.exit_code == 1
@@ -313,7 +312,6 @@ class TestBotCreateAccountOption:
                     "--strategy",
                     "s1",
                 ],
-                input="",
             )
 
         assert result.exit_code == 1

--- a/tests/unit/test_cli_bot_treasury_ipc.py
+++ b/tests/unit/test_cli_bot_treasury_ipc.py
@@ -144,7 +144,7 @@ def _mock_authenticate(ctx):
     ctx.obj["member"] = _make_member()
 
 
-def _invoke_cli(args: list[str], input_text: str | None = None):
+def _invoke_cli(args: list[str]):
     """CLI를 실행하고 결과를 반환한다 (인증 우회)."""
     from click.testing import CliRunner
 
@@ -157,7 +157,6 @@ def _invoke_cli(args: list[str], input_text: str | None = None):
             args,
             obj={"member": _make_member()},
             env={"ANTE_MEMBER_TOKEN": ""},
-            input=input_text,
             catch_exceptions=False,
         )
     return result


### PR DESCRIPTION
Closes #1174

## Summary
- `tests/unit/test_account_cli.py`: `_invoke(args, input_text=None)` → `_invoke(args)`. 모든 호출자가 `input_text` 미사용 (죽은 파라미터).
- `tests/unit/test_cli_bot_treasury_ipc.py`: `_invoke_cli` 동일 패턴 정리.
- `tests/unit/test_cli_account_integration.py`: `input=""` 인자 2건 제거. 기존 `BOT_MISSING_REQUIRED_ACCOUNT` 어서션 그대로 유지.
- 프로덕션 코드 무수정, `test_cli_update.py`의 `input=None` 회귀 가드(#1176)는 손상 없이 유지.

## 사실 확인
- `rg "click\.(prompt|confirm)|confirmation_option" src/ante/cli` → **0건** (#1170 epic 비대화형 CLI 정리 완료)
- `grep input_text= tests/unit` → **0건**

## Test Plan
- [x] `pytest tests/unit/test_account_cli.py -v` → 47 passed
- [x] `pytest tests/unit/test_cli_bot_treasury_ipc.py -v` → 19 passed
- [x] `pytest tests/unit/test_cli_account_integration.py -v` → 16 passed
- [x] `pytest tests/unit -q -k "cli or account or bot or member or update"` → 1435 passed
- [x] `ruff check tests/unit` → PASS
- [x] `ruff format --check tests/unit` → PASS
- [x] `/codex:review --base origin/main` → PASS (9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)