### PR TITLE
refactor(cli): align JSON error envelope with SSOT (status/code/message)

### DIFF
--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -118,11 +118,11 @@ def _exit_with_error(fmt: OutputFormatter, code: str, message: str) -> NoReturn:
 
     text/json 양쪽 표면에 에러 코드가 일관되게 노출되도록 한다.
     JSON 모드(`OutputFormatter.is_json`)에서는 `OutputFormatter.error`가
-    `{"error": ..., "code": ...}` 형식으로 dump한다. text 모드에서는
-    `OutputFormatter.error`가 message만 출력하므로, 사람/Agent가 같은
-    표면에서 코드를 읽을 수 있도록 message 본문에 `CODE: ` prefix를
-    덧붙인다(cold-path 헬퍼 ``cold_path.assert_no_active_runtime``과 동일
-    contract).
+    `{"status": "error", "code": ..., "message": ...}` 형식으로 dump한다.
+    text 모드에서는 `OutputFormatter.error`가 message만 출력하므로,
+    사람/Agent가 같은 표면에서 코드를 읽을 수 있도록 message 본문에
+    `CODE: ` prefix를 덧붙인다(cold-path 헬퍼
+    ``cold_path.assert_no_active_runtime``과 동일 contract).
 
     반환 타입은 ``NoReturn``이므로, 호출 후 후속 코드는 mypy 관점에서
     unreachable하다(env/file 분기에서 None narrowing 등).

--- a/src/ante/cli/formatter.py
+++ b/src/ante/cli/formatter.py
@@ -78,7 +78,9 @@ class OutputFormatter:
     def error(self, message: str, code: str = "") -> None:
         """에러 출력."""
         if self._format == "json":
-            click.echo(json.dumps({"error": message, "code": code}))
+            click.echo(
+                json.dumps({"status": "error", "code": code, "message": message})
+            )
         else:
             click.echo(f"Error: {message}", err=True)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -135,8 +135,8 @@ class TestOutputFormatter:
         fmt.error("fail", code="ERR01")
         captured = capsys.readouterr()
         data = json.loads(captured.out)
-        assert data["error"] == "fail"
-        assert data["code"] == "ERR01"
+        assert data == {"status": "error", "code": "ERR01", "message": "fail"}
+        assert "error" not in data
 
     def test_success_text(self, capsys):
         fmt = OutputFormatter("text")

--- a/tests/unit/test_cli_account_integration.py
+++ b/tests/unit/test_cli_account_integration.py
@@ -287,7 +287,7 @@ class TestBotCreateAccountOption:
         assert result.exit_code == 1
         data = json.loads(result.output)
         assert data["code"] == "BOT_MISSING_REQUIRED_ACCOUNT"
-        assert "--account" in data["error"]
+        assert "--account" in data["message"]
 
     def test_bot_create_no_accounts_returns_missing_required_account(self, runner):
         """계좌 미지정 + 활성 계좌 0개 → BOT_MISSING_REQUIRED_ACCOUNT 에러."""

--- a/tests/unit/test_cli_bot_treasury_ipc.py
+++ b/tests/unit/test_cli_bot_treasury_ipc.py
@@ -295,7 +295,7 @@ class TestBotRemoveIpc:
 
         data = _json.loads(result.output)
         assert data["code"] == "CLI_CONFIRMATION_REQUIRED"
-        assert "--yes" in data["error"]
+        assert "--yes" in data["message"]
 
     @patch("ante.cli.commands.bot.is_active_runtime", return_value=False)
     @patch("ante.cli.commands.bot._run_bot_remove_cold_path")

--- a/tests/unit/test_cli_format_option.py
+++ b/tests/unit/test_cli_format_option.py
@@ -481,7 +481,7 @@ class TestTradeInfoFormatOption:
             assert result.exit_code == 0
             # Not found case produces JSON error
             data = json.loads(result.output)
-            assert "error" in data
+            assert "message" in data
 
 
 # ── account set-credentials 비대화형 테스트 ────────────────

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -759,8 +759,8 @@ class TestInitJsonErrorContract:
             f"exit=1 기대 (got {result.exit_code}): {result.output}"
         )
         data = self._parse_error_json(result.output)
-        assert "error" in data
-        assert "init이 이미 완료된 상태입니다" in data["error"]
+        assert data["status"] == "error"
+        assert "init이 이미 완료된 상태입니다" in data["message"]
         assert data.get("code") == "already_initialized"
 
     def test_init_bootstrap_failure_json_output(self, runner, tmp_path):
@@ -793,8 +793,8 @@ class TestInitJsonErrorContract:
             f"exit=1 기대 (got {result.exit_code}): {result.output}"
         )
         data = self._parse_error_json(result.output)
-        assert "error" in data
-        assert "패스워드 정책 위반" in data["error"]
+        assert data["status"] == "error"
+        assert "패스워드 정책 위반" in data["message"]
         assert data.get("code") == "bootstrap_failed"
 
     def test_init_test_account_failure_json_output(self, runner, tmp_path):
@@ -827,9 +827,9 @@ class TestInitJsonErrorContract:
             f"exit=1 기대 (got {result.exit_code}): {result.output}"
         )
         data = self._parse_error_json(result.output)
-        assert "error" in data
-        assert "테스트 계좌 생성 실패" in data["error"]
-        assert "DB lock" in data["error"]
+        assert data["status"] == "error"
+        assert "테스트 계좌 생성 실패" in data["message"]
+        assert "DB lock" in data["message"]
         assert data.get("code") == "test_account_failed"
 
     def test_init_already_initialized_text_mode_preserves_message(

--- a/tests/unit/test_cli_member_non_interactive.py
+++ b/tests/unit/test_cli_member_non_interactive.py
@@ -121,7 +121,7 @@ class TestMemberRevokeYes:
         service.revoke.assert_not_awaited()
         data = json.loads(result.output)
         assert data["code"] == "CLI_CONFIRMATION_REQUIRED"
-        assert "--yes" in data["error"]
+        assert "--yes" in data["message"]
 
     def test_revoke_with_yes_invokes_revoke(self) -> None:
         """`--yes` 명시 시 MemberService.revoke가 실행된다."""
@@ -238,8 +238,8 @@ class TestMemberResetPasswordEnvFile:
         service.reset_password.assert_not_awaited()
         data = json.loads(result.output)
         assert data["code"] == "CLI_MISSING_REQUIRED_INPUT"
-        assert "--new-password-env" in data["error"]
-        assert "--new-password-file" in data["error"]
+        assert "--new-password-env" in data["message"]
+        assert "--new-password-file" in data["message"]
 
     def test_reset_password_both_env_and_file_fails(
         self,
@@ -273,7 +273,7 @@ class TestMemberResetPasswordEnvFile:
         service.reset_password.assert_not_awaited()
         data = json.loads(result.output)
         assert data["code"] == "CLI_MISSING_REQUIRED_INPUT"
-        assert "동시에" in data["error"]
+        assert "동시에" in data["message"]
 
     def test_reset_password_env_unset_fails(
         self,
@@ -466,8 +466,8 @@ class TestMemberRegenerateRecoveryKeyEnvFile:
         service.regenerate_recovery_key.assert_not_awaited()
         data = json.loads(result.output)
         assert data["code"] == "CLI_MISSING_REQUIRED_INPUT"
-        assert "--password-env" in data["error"]
-        assert "--password-file" in data["error"]
+        assert "--password-env" in data["message"]
+        assert "--password-file" in data["message"]
 
     def test_regenerate_both_env_and_file_fails(
         self,
@@ -499,7 +499,7 @@ class TestMemberRegenerateRecoveryKeyEnvFile:
         service.regenerate_recovery_key.assert_not_awaited()
         data = json.loads(result.output)
         assert data["code"] == "CLI_MISSING_REQUIRED_INPUT"
-        assert "동시에" in data["error"]
+        assert "동시에" in data["message"]
 
     def test_regenerate_env_unset_fails(
         self,

--- a/tests/unit/test_cli_update.py
+++ b/tests/unit/test_cli_update.py
@@ -182,7 +182,7 @@ class TestUpdateFormatJsonError:
 
         assert result.exit_code == 1
         data = json.loads(result.output)
-        assert "error" in data
+        assert "message" in data
 
     def test_pypi_failure_json_error(self, runner: CliRunner) -> None:
         """PyPI 조회 실패 시 JSON 에러 출력."""
@@ -198,7 +198,7 @@ class TestUpdateFormatJsonError:
 
         assert result.exit_code == 1
         data = json.loads(result.output)
-        assert "error" in data
+        assert "message" in data
 
 
 class TestUpdateNonInteractive:
@@ -243,7 +243,7 @@ class TestUpdateNonInteractive:
         assert result.exit_code == 1
         data = json.loads(result.output)
         assert data["code"] == "CLI_CONFIRMATION_REQUIRED"
-        assert "--yes" in data["error"]
+        assert "--yes" in data["message"]
 
         # 부수 효과가 발생하지 않아야 한다 (게이트가 막아야 한다).
         mock_pip_upgrade.assert_not_called()
@@ -294,7 +294,7 @@ class TestUpdateNonInteractive:
         assert result.exit_code == 1
         data = json.loads(result.output)
         assert data["code"] == "CLI_CONFIRMATION_REQUIRED"
-        assert "--yes" in data["error"]
+        assert "--yes" in data["message"]
 
         # 부수 효과가 발생하지 않아야 한다 (게이트가 막아야 한다).
         mock_pip_upgrade.assert_not_called()
@@ -348,8 +348,8 @@ class TestUpdateNonInteractive:
         data = json.loads(result.output)
         # PyPI 실패 메시지가 아닌 confirmation 게이트로 fail 해야 한다.
         assert data["code"] == "CLI_CONFIRMATION_REQUIRED"
-        assert "--yes" in data["error"]
-        assert "PyPI" not in data["error"]
+        assert "--yes" in data["message"]
+        assert "PyPI" not in data["message"]
 
         # 핵심: PyPI 조회가 시도되지 않아야 한다 (게이트가 앞에 위치).
         mock_latest.assert_not_called()


### PR DESCRIPTION
Closes #1205

## Summary
- `OutputFormatter.error()` JSON dump을 SSOT(`docs/specs/cli/02-design-decisions.md:81`)에 맞춰 `{"status": "error", "code": ..., "message": ...}`로 정렬한다.
- text 분기, 메서드 시그니처(`error(self, message: str, code: str = "")`), CODE prefix 동작은 그대로 유지한다.
- `account.py`의 `_exit_with_error` docstring을 새 envelope 표기로 갱신한다.
- 7개 테스트 파일 24개 assertion을 `data["status"]` / `data["message"]` 기준으로 일괄 정렬하고, `test_error_json`에 exact keyset + `assert "error" not in data` 회귀 가드를 추가한다.

### 명시적 미변경 영역 (이슈 본문 Non-Goals 참조)
- IPC envelope (`{"status": "error", "error": {"code", "message"}}`) — 별개 계약, 그대로 유지
- 도메인 payload `error` 필드 (strategy/broker/instrument)
- `OutputFormatter.success()` JSON 형식 — 후속 이슈로 분리

## Test Plan
- [x] `pytest tests/unit/test_cli.py::TestOutputFormatter -q` — 10 passed
- [x] `pytest tests/unit -q -k "cli or formatter"` — 545 passed
- [x] IPC 회귀 가드: `pytest tests/unit/test_cli_ipc_commands.py tests/unit/ipc/ tests/unit/test_main_shutdown_ordering.py tests/unit/test_ipc_error_code_mapping.py -q` — 56 passed
- [x] `ruff check src/ante/cli tests/unit` — PASS
- [x] `ruff format --check src/ante/cli tests/unit` — PASS (224 files)
- [x] 잔여 누수 점검: `rg 'data["error"]' tests/unit/` 0건, `rg '"error" in data' tests/unit/` 0건 (formatter 계약 0건; IPC 계약은 변경 대상 아님)
- [x] Codex branch review (`/codex:review --base main`) — PASS (review-moprpz3f-5hzq16)

## Plan Preflight
- Codex Plan Review verdict: approve-implement (rev2)
- 이슈 본문 Implementation Plan을 canonical plan으로 따름