### PR TITLE
feat(system): align kill switch backend to halt/clear-halt SSOT

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2181,7 +2181,7 @@
           "system"
         ],
         "summary": "Halt",
-        "description": "전체 거래 중지 (모든 계좌 SUSPENDED).",
+        "description": "전체 거래 중지 (모든 ACTIVE 계좌 SUSPENDED).",
         "operationId": "halt_api_system_halt_post",
         "requestBody": {
           "content": {
@@ -2227,19 +2227,19 @@
         }
       }
     },
-    "/api/system/activate": {
+    "/api/system/clear-halt": {
       "post": {
         "tags": [
           "system"
         ],
-        "summary": "Activate",
-        "description": "전체 거래 재개 (모든 계좌 ACTIVE).",
-        "operationId": "activate_api_system_activate_post",
+        "summary": "Clear Halt",
+        "description": "전역 정지 해제 (모든 SUSPENDED 계좌 ACTIVE).\n\n계좌 상태만 ACTIVE로 복구하며 봇을 자동 재시작하지 않는다.",
+        "operationId": "clear_halt_api_system_clear_halt_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ActivateRequest"
+                "$ref": "#/components/schemas/ClearHaltRequest"
               }
             }
           },
@@ -5011,18 +5011,6 @@
         "title": "AccountSuspendRequest",
         "description": "계좌 정지 요청."
       },
-      "ActivateRequest": {
-        "properties": {
-          "reason": {
-            "type": "string",
-            "title": "Reason",
-            "default": ""
-          }
-        },
-        "type": "object",
-        "title": "ActivateRequest",
-        "description": "거래 재개 요청."
-      },
       "ApprovalDetailResponse": {
         "properties": {
           "approval": {
@@ -5723,6 +5711,18 @@
         "title": "BudgetOperationResponse",
         "description": "예산 할당/회수 응답."
       },
+      "ClearHaltRequest": {
+        "properties": {
+          "reason": {
+            "type": "string",
+            "title": "Reason",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "ClearHaltRequest",
+        "description": "전역 정지 해제 요청."
+      },
       "ConfigItem": {
         "properties": {
           "key": {
@@ -6050,24 +6050,66 @@
         "title": "HealthResponse",
         "description": "헬스체크 응답.\n\n- `ok`: 모든 의존성 체크 통과 여부 (`all(checks.values())`).\n- `checks`: 개별 의존성 체크 결과. 1.0 기준 키는 `db`, `broker`.\n  키 확장은 하위 호환이므로 소비자는 존재하는 키만 확인한다.\n\n`ok`와 `checks` 모두 필수 필드 (OpenAPI `required`)."
       },
+      "KillSwitchAccountChange": {
+        "properties": {
+          "account_id": {
+            "type": "string",
+            "title": "Account Id"
+          },
+          "previous_status": {
+            "type": "string",
+            "title": "Previous Status"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "changed": {
+            "type": "boolean",
+            "title": "Changed"
+          }
+        },
+        "type": "object",
+        "required": [
+          "account_id",
+          "previous_status",
+          "status",
+          "changed"
+        ],
+        "title": "KillSwitchAccountChange",
+        "description": "킬 스위치 처리 대상 계좌의 상태 전환 결과.\n\nSSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답 필드 표.\n필드는 정확히 ``account_id``, ``previous_status``, ``status``, ``changed`` 4개\n키만 사용한다 (``before_status`` / ``after_status`` 사용 금지)."
+      },
       "KillSwitchResponse": {
         "properties": {
           "status": {
             "type": "string",
             "title": "Status"
           },
+          "accounts_changed": {
+            "type": "integer",
+            "title": "Accounts Changed"
+          },
           "changed_at": {
             "type": "string",
             "title": "Changed At"
+          },
+          "accounts": {
+            "items": {
+              "$ref": "#/components/schemas/KillSwitchAccountChange"
+            },
+            "type": "array",
+            "title": "Accounts",
+            "default": []
           }
         },
         "type": "object",
         "required": [
           "status",
+          "accounts_changed",
           "changed_at"
         ],
         "title": "KillSwitchResponse",
-        "description": "킬 스위치 제어 응답."
+        "description": "킬 스위치 제어 응답.\n\nSSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답.\n\n- ``POST /api/system/halt`` → ``status=\"halted\"``\n- ``POST /api/system/clear-halt`` → ``status=\"halt_cleared\"``"
       },
       "LoginRequest": {
         "properties": {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -1079,7 +1079,7 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/api/system/activate": {
+    "/api/system/clear-halt": {
         parameters: {
             query?: never;
             header?: never;
@@ -1089,10 +1089,12 @@ export type paths = {
         get?: never;
         put?: never;
         /**
-         * Activate
-         * @description 전체 거래 재개 (모든 계좌 ACTIVE).
+         * Clear Halt
+         * @description 전역 정지 해제 (모든 SUSPENDED 계좌 ACTIVE).
+         *
+         *     계좌 상태만 ACTIVE로 복구하며 봇을 자동 재시작하지 않는다.
          */
-        post: operations["activate_api_system_activate_post"];
+        post: operations["clear_halt_api_system_clear_halt_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1110,7 +1112,7 @@ export type paths = {
         put?: never;
         /**
          * Halt
-         * @description 전체 거래 중지 (모든 계좌 SUSPENDED).
+         * @description 전체 거래 중지 (모든 ACTIVE 계좌 SUSPENDED).
          */
         post: operations["halt_api_system_halt_post"];
         delete?: never;
@@ -1442,17 +1444,6 @@ export type components = {
          * @description 계좌 정지 요청.
          */
         AccountSuspendRequest: {
-            /**
-             * Reason
-             * @default
-             */
-            reason: string;
-        };
-        /**
-         * ActivateRequest
-         * @description 거래 재개 요청.
-         */
-        ActivateRequest: {
             /**
              * Reason
              * @default
@@ -1828,6 +1819,17 @@ export type components = {
             bot_id: string;
         };
         /**
+         * ClearHaltRequest
+         * @description 전역 정지 해제 요청.
+         */
+        ClearHaltRequest: {
+            /**
+             * Reason
+             * @default
+             */
+            reason: string;
+        };
+        /**
          * ConfigItem
          * @description 동적 설정 아이템.
          */
@@ -2061,10 +2063,40 @@ export type components = {
             detail?: components["schemas"]["ValidationError"][];
         };
         /**
+         * KillSwitchAccountChange
+         * @description 킬 스위치 처리 대상 계좌의 상태 전환 결과.
+         *
+         *     SSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답 필드 표.
+         *     필드는 정확히 ``account_id``, ``previous_status``, ``status``, ``changed`` 4개
+         *     키만 사용한다 (``before_status`` / ``after_status`` 사용 금지).
+         */
+        KillSwitchAccountChange: {
+            /** Account Id */
+            account_id: string;
+            /** Changed */
+            changed: boolean;
+            /** Previous Status */
+            previous_status: string;
+            /** Status */
+            status: string;
+        };
+        /**
          * KillSwitchResponse
          * @description 킬 스위치 제어 응답.
+         *
+         *     SSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답.
+         *
+         *     - ``POST /api/system/halt`` → ``status="halted"``
+         *     - ``POST /api/system/clear-halt`` → ``status="halt_cleared"``
          */
         KillSwitchResponse: {
+            /**
+             * Accounts
+             * @default []
+             */
+            accounts: components["schemas"]["KillSwitchAccountChange"][];
+            /** Accounts Changed */
+            accounts_changed: number;
             /** Changed At */
             changed_at: string;
             /** Status */
@@ -3160,7 +3192,6 @@ export type AccountDetailResponse = components['schemas']['AccountDetailResponse
 export type AccountListResponse = components['schemas']['AccountListResponse'];
 export type AccountResponse = components['schemas']['AccountResponse'];
 export type AccountSuspendRequest = components['schemas']['AccountSuspendRequest'];
-export type ActivateRequest = components['schemas']['ActivateRequest'];
 export type ApprovalDetailResponse = components['schemas']['ApprovalDetailResponse'];
 export type ApprovalItem = components['schemas']['ApprovalItem'];
 export type ApprovalListResponse = components['schemas']['ApprovalListResponse'];
@@ -3179,6 +3210,7 @@ export type BudgetChangeRequest = components['schemas']['BudgetChangeRequest'];
 export type BudgetItem = components['schemas']['BudgetItem'];
 export type BudgetListResponse = components['schemas']['BudgetListResponse'];
 export type BudgetOperationResponse = components['schemas']['BudgetOperationResponse'];
+export type ClearHaltRequest = components['schemas']['ClearHaltRequest'];
 export type ConfigItem = components['schemas']['ConfigItem'];
 export type ConfigListResponse = components['schemas']['ConfigListResponse'];
 export type ConfigUpdateRequest = components['schemas']['ConfigUpdateRequest'];
@@ -3194,6 +3226,7 @@ export type FeedStatusResponse = components['schemas']['FeedStatusResponse'];
 export type HaltRequest = components['schemas']['HaltRequest'];
 export type HealthResponse = components['schemas']['HealthResponse'];
 export type HttpValidationError = components['schemas']['HTTPValidationError'];
+export type KillSwitchAccountChange = components['schemas']['KillSwitchAccountChange'];
 export type KillSwitchResponse = components['schemas']['KillSwitchResponse'];
 export type LoginRequest = components['schemas']['LoginRequest'];
 export type LoginResponse = components['schemas']['LoginResponse'];
@@ -5902,7 +5935,7 @@ export interface operations {
             };
         };
     };
-    activate_api_system_activate_post: {
+    clear_halt_api_system_clear_halt_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -5911,7 +5944,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ActivateRequest"];
+                "application/json": components["schemas"]["ClearHaltRequest"];
             };
         };
         responses: {

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -626,35 +626,82 @@ class AccountService:
 
     # ── 일괄 상태 전이 ──────────────────────────────────
 
-    async def suspend_all(self, reason: str, suspended_by: str) -> int:
-        """모든 ACTIVE 계좌를 SUSPENDED로 전환. DELETED 제외.
+    async def suspend_all(self, reason: str, suspended_by: str) -> list[dict[str, Any]]:
+        """모든 ACTIVE 계좌를 SUSPENDED로 전환. DELETED 계좌는 후보 제외.
 
         Returns:
-            전환된 계좌 수.
+            처리 대상 계좌(ACTIVE/SUSPENDED)별 변경 결과 목록. DELETED 계좌는
+            포함되지 않는다. 각 항목은 다음 키를 가진다:
+
+            - ``account_id`` (str)
+            - ``previous_status`` (str): 호출 직전 상태 (소문자 wire 값)
+            - ``status`` (str): 호출 직후 상태 (소문자 wire 값)
+            - ``changed`` (bool): 실제 전환 여부
+
+        SSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답.
         """
-        count = 0
+        results: list[dict[str, Any]] = []
         for account_id in list(self._accounts.keys()):
             account = self._accounts[account_id]
+            if account.status == AccountStatus.DELETED:
+                continue
+            previous_status = account.status.value
             if account.status == AccountStatus.ACTIVE:
                 await self.suspend(account_id, reason, suspended_by)
-                count += 1
-        logger.info("전체 계좌 정지: %d개 (사유: %s)", count, reason)
-        return count
+                changed = True
+            else:
+                changed = False
+            results.append(
+                {
+                    "account_id": account_id,
+                    "previous_status": previous_status,
+                    "status": AccountStatus.SUSPENDED.value,
+                    "changed": changed,
+                }
+            )
+        changed_count = sum(1 for r in results if r["changed"])
+        logger.info("전체 계좌 정지: %d개 (사유: %s)", changed_count, reason)
+        return results
 
-    async def activate_all(self, activated_by: str) -> int:
-        """모든 SUSPENDED 계좌를 ACTIVE로 복구. DELETED 제외.
+    async def activate_all(self, activated_by: str) -> list[dict[str, Any]]:
+        """모든 SUSPENDED 계좌를 ACTIVE로 복구. DELETED 계좌는 후보 제외.
 
         Returns:
-            전환된 계좌 수.
+            처리 대상 계좌(ACTIVE/SUSPENDED)별 변경 결과 목록. DELETED 계좌는
+            포함되지 않는다. 각 항목은 다음 키를 가진다:
+
+            - ``account_id`` (str)
+            - ``previous_status`` (str): 호출 직전 상태 (소문자 wire 값)
+            - ``status`` (str): 호출 직후 상태 (소문자 wire 값)
+            - ``changed`` (bool): 실제 전환 여부
+
+        계좌 상태만 ACTIVE로 복구하며 봇 자동 재시작은 수행하지 않는다
+        (BotManager는 ``AccountActivatedEvent`` 수신 시 로깅만 수행).
+
+        SSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답.
         """
-        count = 0
+        results: list[dict[str, Any]] = []
         for account_id in list(self._accounts.keys()):
             account = self._accounts[account_id]
+            if account.status == AccountStatus.DELETED:
+                continue
+            previous_status = account.status.value
             if account.status == AccountStatus.SUSPENDED:
                 await self.activate(account_id, activated_by)
-                count += 1
-        logger.info("전체 계좌 활성화: %d개", count)
-        return count
+                changed = True
+            else:
+                changed = False
+            results.append(
+                {
+                    "account_id": account_id,
+                    "previous_status": previous_status,
+                    "status": AccountStatus.ACTIVE.value,
+                    "changed": changed,
+                }
+            )
+        changed_count = sum(1 for r in results if r["changed"])
+        logger.info("전체 계좌 활성화: %d개", changed_count)
+        return results
 
     # ── 브로커 인스턴스 ──────────────────────────────────
 

--- a/src/ante/cli/commands/system.py
+++ b/src/ante/cli/commands/system.py
@@ -209,23 +209,26 @@ def halt(ctx: click.Context, reason: str) -> None:
 
     result = _run(ipc_send("system.halt", {"reason": reason}, actor=actor))
     data = result.get("data", result)
-    count = data.get("suspended_count", 0)
+    count = data.get("accounts_changed", 0)
     fmt.success(f"시스템 HALTED — {count}개 계좌 거래 중지", data)
 
 
-@system.command()
+@system.command(name="clear-halt")
 @click.option("--reason", default="", help="사유")
 @click.pass_context
 @require_auth
 @require_scope("system:admin")
-def activate(ctx: click.Context, reason: str) -> None:
-    """킬 스위치 해제 (거래 재개)."""
+def clear_halt(ctx: click.Context, reason: str) -> None:
+    """킬 스위치 해제 (전역 정지 해제 — 봇은 자동 재시작되지 않음)."""
     from ante.cli.commands.ipc_helpers import ipc_send
 
     fmt = get_formatter(ctx)
     actor = get_member_id(ctx)
 
-    result = _run(ipc_send("system.activate", {"reason": reason}, actor=actor))
+    result = _run(ipc_send("system.clear_halt", {"reason": reason}, actor=actor))
     data = result.get("data", result)
-    count = data.get("activated_count", 0)
-    fmt.success(f"시스템 ACTIVE — {count}개 계좌 거래 재개", data)
+    count = data.get("accounts_changed", 0)
+    fmt.success(
+        f"시스템 정지 해제 — {count}개 계좌 ACTIVE 복구 (봇은 자동 재시작되지 않음)",
+        data,
+    )

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -84,19 +84,36 @@ class CommandRegistry:
 # ── 핸들러 구현 ──────────────────────────────────────
 
 
+def _kill_switch_payload(status: str, accounts: list[dict[str, Any]]) -> dict:
+    """Kill Switch IPC 응답 envelope.
+
+    SSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답 SSOT.
+    Web API와 IPC가 동일한 shape(``status``, ``accounts_changed``, ``changed_at``,
+    ``accounts[]``)을 사용한다.
+    """
+    from datetime import UTC, datetime
+
+    return {
+        "status": status,
+        "accounts_changed": sum(1 for a in accounts if a.get("changed")),
+        "changed_at": datetime.now(UTC).isoformat(),
+        "accounts": accounts,
+    }
+
+
 async def _handle_system_halt(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
     reason = args.get("reason", "IPC halt")
-    count = await svc.account.suspend_all(reason=reason, suspended_by=actor)
-    return {"suspended_count": count}
+    accounts = await svc.account.suspend_all(reason=reason, suspended_by=actor)
+    return _kill_switch_payload("halted", accounts)
 
 
-async def _handle_system_activate(
+async def _handle_system_clear_halt(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
-    count = await svc.account.activate_all(activated_by=actor)
-    return {"activated_count": count}
+    accounts = await svc.account.activate_all(activated_by=actor)
+    return _kill_switch_payload("halt_cleared", accounts)
 
 
 async def _handle_account_suspend(
@@ -291,7 +308,7 @@ def register_all_handlers(registry: CommandRegistry) -> None:
     """
     # ── mutating (15개): 서버 상태/DB를 변경 ──────────
     registry.register("system.halt", _handle_system_halt, is_mutating=True)
-    registry.register("system.activate", _handle_system_activate, is_mutating=True)
+    registry.register("system.clear_halt", _handle_system_clear_halt, is_mutating=True)
     registry.register("account.suspend", _handle_account_suspend, is_mutating=True)
     registry.register("account.activate", _handle_account_activate, is_mutating=True)
     registry.register("bot.create", _handle_bot_create, is_mutating=True)

--- a/src/ante/notification/telegram_receiver.py
+++ b/src/ante/notification/telegram_receiver.py
@@ -18,7 +18,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # 확인이 필요한 위험 명령
-_DANGEROUS_COMMANDS = {"halt", "stop"}
+# SSOT: docs/specs/notification/notification.md (위험 명령 표).
+# `/halt`, `/clear_halt`, `/stop`은 모두 2단계 확인 대상이다.
+_DANGEROUS_COMMANDS = {"halt", "clear_halt", "stop"}
 
 
 class TelegramCommandReceiver:
@@ -271,6 +273,10 @@ class TelegramCommandReceiver:
                 all_suspended = await self._all_accounts_suspended()
                 if all_suspended:
                     return "이미 거래가 중지된 상태입니다."
+            if command == "clear_halt" and self._account_service:
+                all_active = await self._all_accounts_active()
+                if all_active:
+                    return "이미 거래가 활성 상태입니다."
             return self._request_confirmation(command, args, user_id)
 
         # 즉시 실행 명령
@@ -279,7 +285,6 @@ class TelegramCommandReceiver:
             "status": self._cmd_status,
             "bots": self._cmd_bots,
             "balance": self._cmd_balance,
-            "activate": self._cmd_activate,
             "approve": self._cmd_approve,
             "reject": self._cmd_reject,
         }
@@ -305,6 +310,11 @@ class TelegramCommandReceiver:
             return (
                 f"전체 거래를 중지합니다{detail}. 확인하려면 /confirm 을 입력해 주세요."
             )
+        if command == "clear_halt":
+            return (
+                "전역 정지를 해제합니다 (계좌 상태만 ACTIVE로 복구; 봇은 자동 "
+                "재시작되지 않음). 확인하려면 /confirm 을 입력해 주세요."
+            )
         if command == "stop":
             bot_id = args[0] if args else "?"
             return f"{bot_id}을 중지합니다. 확인하려면 /confirm 을 입력해 주세요."
@@ -326,6 +336,8 @@ class TelegramCommandReceiver:
         # 실제 실행
         if command == "halt":
             return await self._cmd_halt(args)
+        if command == "clear_halt":
+            return await self._cmd_clear_halt(args)
         if command == "stop":
             return await self._cmd_stop(args)
 
@@ -344,6 +356,17 @@ class TelegramCommandReceiver:
             return False
         return all(a.status == AccountStatus.SUSPENDED for a in accounts)
 
+    async def _all_accounts_active(self) -> bool:
+        """모든 계좌가 ACTIVE 상태인지 확인."""
+        if not self._account_service:
+            return False
+        from ante.account.models import AccountStatus
+
+        accounts = await self._account_service.list()
+        if not accounts:
+            return False
+        return all(a.status == AccountStatus.ACTIVE for a in accounts)
+
     # ── 명령 핸들러 ─────────────────────────────────
 
     def _cmd_help(self, args: list[str]) -> str:
@@ -354,7 +377,7 @@ class TelegramCommandReceiver:
             "/bots — 봇 목록 + 상태\n"
             "/balance — 자금 현황 요약\n"
             "/halt [reason] — 전체 거래 중지 (확인 필요)\n"
-            "/activate — 거래 재개\n"
+            "/clear_halt — 전역 정지 해제 (확인 필요; 봇은 자동 재시작되지 않음)\n"
             "/stop <bot_id> — 특정 봇 중지 (확인 필요)\n"
             "/approve <id> — 결재 승인\n"
             "/reject <id> [reason] — 결재 거절\n"
@@ -551,23 +574,22 @@ class TelegramCommandReceiver:
         return (
             "\U0001f6a8 전체 거래가 중지되었습니다.\n"
             f"사유: {reason}\n"
-            "해제하려면 /activate 를 입력하세요."
+            "해제하려면 /clear_halt 를 입력하세요."
         )
 
-    async def _cmd_activate(self, args: list[str]) -> str:
-        """거래 재개."""
+    async def _cmd_clear_halt(self, args: list[str]) -> str:
+        """전역 정지 해제 (계좌 상태만 ACTIVE 복구; 봇 자동 재시작 없음)."""
         if not self._account_service:
             return "AccountService가 연결되지 않았습니다."
 
-        from ante.account.models import AccountStatus
-
-        accounts = await self._account_service.list()
-        all_active = all(a.status == AccountStatus.ACTIVE for a in accounts)
-        if all_active:
+        if await self._all_accounts_active():
             return "이미 거래가 활성 상태입니다."
 
         await self._account_service.activate_all(activated_by="telegram")
-        return "✅ 거래가 재개되었습니다."
+        return (
+            "✅ 전역 정지가 해제되었습니다.\n"
+            "계좌 상태만 ACTIVE로 복구되며 봇은 자동 재시작되지 않습니다."
+        )
 
     async def _cmd_stop(self, args: list[str]) -> str:
         """특정 봇 중지."""

--- a/src/ante/web/routes/system.py
+++ b/src/ante/web/routes/system.py
@@ -32,8 +32,8 @@ class HaltRequest(BaseModel):
     reason: str = ""
 
 
-class ActivateRequest(BaseModel):
-    """거래 재개 요청."""
+class ClearHaltRequest(BaseModel):
+    """전역 정지 해제 요청."""
 
     reason: str = ""
 
@@ -128,6 +128,21 @@ async def _check_broker(account_service: Any | None) -> bool:
     return True
 
 
+def _kill_switch_payload(status: str, accounts: list[dict[str, Any]]) -> dict:
+    """Kill Switch 응답 envelope.
+
+    SSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답 SSOT.
+    """
+    from datetime import UTC, datetime
+
+    return {
+        "status": status,
+        "accounts_changed": sum(1 for a in accounts if a.get("changed")),
+        "changed_at": datetime.now(UTC).isoformat(),
+        "accounts": accounts,
+    }
+
+
 @router.post(
     "/halt",
     response_model=KillSwitchResponse,
@@ -148,11 +163,11 @@ async def halt(
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """전체 거래 중지 (모든 계좌 SUSPENDED)."""
-    from datetime import UTC, datetime
-
+    """전체 거래 중지 (모든 ACTIVE 계좌 SUSPENDED)."""
     reason = body.reason or "dashboard"
-    count = await account_service.suspend_all(reason=reason, suspended_by="dashboard")
+    accounts = await account_service.suspend_all(
+        reason=reason, suspended_by="dashboard"
+    )
 
     if audit_logger:
         await audit_logger.log(
@@ -163,14 +178,11 @@ async def halt(
             ip=request.client.host if request.client else "",
         )
 
-    return {
-        "status": f"suspended ({count} accounts)",
-        "changed_at": datetime.now(UTC).isoformat(),
-    }
+    return _kill_switch_payload("halted", accounts)
 
 
 @router.post(
-    "/activate",
+    "/clear-halt",
     response_model=KillSwitchResponse,
     responses={
         503: {
@@ -183,27 +195,25 @@ async def halt(
         },
     },
 )
-async def activate(
-    body: ActivateRequest,
+async def clear_halt(
+    body: ClearHaltRequest,
     request: Request,
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """전체 거래 재개 (모든 계좌 ACTIVE)."""
-    from datetime import UTC, datetime
+    """전역 정지 해제 (모든 SUSPENDED 계좌 ACTIVE).
 
-    count = await account_service.activate_all(activated_by="dashboard")
+    계좌 상태만 ACTIVE로 복구하며 봇을 자동 재시작하지 않는다.
+    """
+    accounts = await account_service.activate_all(activated_by="dashboard")
 
     if audit_logger:
         await audit_logger.log(
             member_id=getattr(request.state, "member_id", "dashboard"),
-            action="system.activate",
+            action="system.clear_halt",
             resource="system:kill_switch",
             detail=body.reason,
             ip=request.client.host if request.client else "",
         )
 
-    return {
-        "status": f"activated ({count} accounts)",
-        "changed_at": datetime.now(UTC).isoformat(),
-    }
+    return _kill_switch_payload("halt_cleared", accounts)

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -135,11 +135,33 @@ class HealthResponse(BaseModel):
     checks: dict[str, bool]
 
 
+class KillSwitchAccountChange(BaseModel):
+    """킬 스위치 처리 대상 계좌의 상태 전환 결과.
+
+    SSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답 필드 표.
+    필드는 정확히 ``account_id``, ``previous_status``, ``status``, ``changed`` 4개
+    키만 사용한다 (``before_status`` / ``after_status`` 사용 금지).
+    """
+
+    account_id: str
+    previous_status: str
+    status: str
+    changed: bool
+
+
 class KillSwitchResponse(BaseModel):
-    """킬 스위치 제어 응답."""
+    """킬 스위치 제어 응답.
+
+    SSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답.
+
+    - ``POST /api/system/halt`` → ``status="halted"``
+    - ``POST /api/system/clear-halt`` → ``status="halt_cleared"``
+    """
 
     status: str
+    accounts_changed: int
     changed_at: str
+    accounts: list[KillSwitchAccountChange] = []
 
 
 # ── 인증 ──────────────────────────────────────────────

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -53,7 +53,7 @@ def test_register_all_handlers() -> None:
 
     expected = {
         "system.halt",
-        "system.activate",
+        "system.clear_halt",
         "account.suspend",
         "account.activate",
         "bot.create",
@@ -74,6 +74,8 @@ def test_register_all_handlers() -> None:
     assert set(registry.commands) == expected
     # account.delete는 cold-path 전용이므로 IPC 등록 대상이 아니다.
     assert "account.delete" not in registry.commands
+    # legacy system.activate는 system.clear_halt로 교체됨 (Refs #1213, #1212 SSOT)
+    assert "system.activate" not in registry.commands
 
 
 def test_register_all_handlers_taxonomy() -> None:
@@ -83,7 +85,7 @@ def test_register_all_handlers_taxonomy() -> None:
 
     mutating = {
         "system.halt",
-        "system.activate",
+        "system.clear_halt",
         "account.suspend",
         "account.activate",
         "bot.create",
@@ -191,3 +193,86 @@ class TestHandleBotCreate:
                 {"strategy_id": "nonexistent"},
                 "cli-user",
             )
+
+
+# ── system.halt / system.clear_halt 응답 shape (Refs #1213) ──
+
+
+class TestSystemKillSwitchHandlers:
+    """system.halt / system.clear_halt IPC 응답 shape 회귀 가드.
+
+    SSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답.
+    Web API와 IPC가 동일한 shape (status, accounts_changed, changed_at, accounts[])을
+    사용한다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_handle_system_halt_response_shape(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ante.ipc.registry import _handle_system_halt
+
+        accounts = [
+            {
+                "account_id": "acc1",
+                "previous_status": "active",
+                "status": "suspended",
+                "changed": True,
+            },
+            {
+                "account_id": "acc2",
+                "previous_status": "suspended",
+                "status": "suspended",
+                "changed": False,
+            },
+        ]
+
+        svc = MagicMock()
+        svc.account = MagicMock()
+        svc.account.suspend_all = AsyncMock(return_value=accounts)
+
+        result = await _handle_system_halt(svc, {"reason": "test"}, "cli-user")
+
+        assert result["status"] == "halted"
+        assert result["accounts_changed"] == 1
+        assert result["accounts"] == accounts
+        assert isinstance(result["changed_at"], str) and result["changed_at"]
+        svc.account.suspend_all.assert_awaited_once_with(
+            reason="test", suspended_by="cli-user"
+        )
+
+    @pytest.mark.asyncio
+    async def test_handle_system_clear_halt_response_shape(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ante.ipc.registry import _handle_system_clear_halt
+
+        accounts = [
+            {
+                "account_id": "acc1",
+                "previous_status": "suspended",
+                "status": "active",
+                "changed": True,
+            },
+        ]
+
+        svc = MagicMock()
+        svc.account = MagicMock()
+        svc.account.activate_all = AsyncMock(return_value=accounts)
+
+        # bot_manager.start*/restart* 같은 메서드가 호출되지 않음을 보장하려면
+        # bot_manager 자체가 호출되지 않아야 한다 (clear_halt 핸들러는 BotManager
+        # 의존성을 직접 보유하지 않는다 — Refs #1213 회귀 가드).
+        svc.bot_manager = MagicMock()
+
+        result = await _handle_system_clear_halt(svc, {}, "cli-user")
+
+        assert result["status"] == "halt_cleared"
+        assert result["accounts_changed"] == 1
+        assert result["accounts"] == accounts
+        assert isinstance(result["changed_at"], str) and result["changed_at"]
+        svc.account.activate_all.assert_awaited_once_with(activated_by="cli-user")
+        # 봇 자동 재시작 회귀 가드: BotManager 메서드가 호출되지 않아야 한다.
+        svc.bot_manager.start_bot.assert_not_called()
+        svc.bot_manager.restart_bot.assert_not_called()
+        svc.bot_manager.start_all.assert_not_called()

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -452,32 +452,112 @@ async def test_delete_error_message_includes_cold_path_bot_remove_procedure(
 
 @pytest.mark.asyncio
 async def test_suspend_all(service):
-    """모든 ACTIVE 계좌 정지. DELETED 제외."""
+    """모든 ACTIVE 계좌 정지. DELETED 제외.
+
+    SSOT (`docs/specs/web-api/04-system-endpoints.md`): 반환은 처리 대상 계좌
+    list (DELETED 제외). 각 항목은 ``account_id``, ``previous_status``, ``status``,
+    ``changed`` 4개 키만 포함한다.
+    """
     await service.create(_make_account("acc1"))
     await service.create(_make_account("acc2"))
     await service.create(_make_account("acc3"))
     await service.delete("acc3", deleted_by="system")
 
-    count = await service.suspend_all(reason="시스템 긴급 정지", suspended_by="system")
+    results = await service.suspend_all(
+        reason="시스템 긴급 정지", suspended_by="system"
+    )
 
-    assert count == 2  # acc3 (DELETED) 제외
+    # acc3 (DELETED)은 후보에서 제외
+    assert isinstance(results, list)
+    assert len(results) == 2
+    account_ids = {r["account_id"] for r in results}
+    assert account_ids == {"acc1", "acc2"}
+    for r in results:
+        assert set(r.keys()) == {"account_id", "previous_status", "status", "changed"}
+        assert r["previous_status"] == "active"
+        assert r["status"] == "suspended"
+        assert r["changed"] is True
+
+    changed_count = sum(1 for r in results if r["changed"])
+    assert changed_count == 2
     accounts = await service.list(status=AccountStatus.ACTIVE)
     assert len(accounts) == 0
 
 
 @pytest.mark.asyncio
+async def test_suspend_all_idempotent_for_already_suspended(service):
+    """이미 SUSPENDED인 계좌는 응답에 포함되지만 changed=False."""
+    await service.create(_make_account("acc1"))
+    await service.create(_make_account("acc2"))
+    await service.suspend("acc1", reason="이미 정지", suspended_by="system")
+
+    results = await service.suspend_all(reason="긴급", suspended_by="system")
+
+    assert {r["account_id"] for r in results} == {"acc1", "acc2"}
+    by_id = {r["account_id"]: r for r in results}
+    assert by_id["acc1"]["previous_status"] == "suspended"
+    assert by_id["acc1"]["status"] == "suspended"
+    assert by_id["acc1"]["changed"] is False
+    assert by_id["acc2"]["previous_status"] == "active"
+    assert by_id["acc2"]["status"] == "suspended"
+    assert by_id["acc2"]["changed"] is True
+
+
+@pytest.mark.asyncio
 async def test_activate_all(service):
-    """모든 SUSPENDED 계좌 활성화. DELETED 제외."""
+    """모든 SUSPENDED 계좌 활성화. DELETED 제외.
+
+    SSOT (`docs/specs/web-api/04-system-endpoints.md`): 반환은 처리 대상 계좌
+    list (DELETED 제외). 각 항목은 ``account_id``, ``previous_status``, ``status``,
+    ``changed`` 4개 키만 포함한다.
+    """
     await service.create(_make_account("acc1"))
     await service.create(_make_account("acc2"))
     await service.suspend("acc1", reason="테스트", suspended_by="system")
     await service.suspend("acc2", reason="테스트", suspended_by="system")
 
-    count = await service.activate_all(activated_by="admin")
+    results = await service.activate_all(activated_by="admin")
 
-    assert count == 2
+    assert isinstance(results, list)
+    assert len(results) == 2
+    for r in results:
+        assert set(r.keys()) == {"account_id", "previous_status", "status", "changed"}
+        assert r["previous_status"] == "suspended"
+        assert r["status"] == "active"
+        assert r["changed"] is True
+
     accounts = await service.list(status=AccountStatus.ACTIVE)
     assert len(accounts) == 2
+
+
+@pytest.mark.asyncio
+async def test_activate_all_idempotent_for_already_active(service):
+    """이미 ACTIVE인 계좌는 응답에 포함되지만 changed=False."""
+    await service.create(_make_account("acc1"))
+    await service.create(_make_account("acc2"))
+    await service.suspend("acc2", reason="테스트", suspended_by="system")
+
+    results = await service.activate_all(activated_by="admin")
+
+    by_id = {r["account_id"]: r for r in results}
+    assert by_id["acc1"]["previous_status"] == "active"
+    assert by_id["acc1"]["status"] == "active"
+    assert by_id["acc1"]["changed"] is False
+    assert by_id["acc2"]["previous_status"] == "suspended"
+    assert by_id["acc2"]["status"] == "active"
+    assert by_id["acc2"]["changed"] is True
+
+
+@pytest.mark.asyncio
+async def test_activate_all_excludes_deleted(service):
+    """DELETED 계좌는 후보에서 제외 (응답 list에 미포함)."""
+    await service.create(_make_account("acc1"))
+    await service.create(_make_account("acc2"))
+    await service.delete("acc2", deleted_by="system")
+
+    results = await service.activate_all(activated_by="admin")
+
+    assert {r["account_id"] for r in results} == {"acc1"}
 
 
 # ── 브로커 인스턴스 (get_broker) ──────────────────────

--- a/tests/unit/test_audit_integration.py
+++ b/tests/unit/test_audit_integration.py
@@ -159,7 +159,16 @@ class TestHandlerAuditLog:
     def test_halt_audit(self, audit_logger):
         """halt 시 system.halt 감사 로그가 기록된다."""
         account_service_mock = AsyncMock()
-        account_service_mock.suspend_all = AsyncMock(return_value=1)
+        account_service_mock.suspend_all = AsyncMock(
+            return_value=[
+                {
+                    "account_id": "domestic",
+                    "previous_status": "active",
+                    "status": "suspended",
+                    "changed": True,
+                }
+            ]
+        )
 
         app = create_app(
             audit_logger=audit_logger,
@@ -182,10 +191,23 @@ class TestHandlerAuditLog:
         assert handler_calls[0].kwargs["resource"] == "system:kill_switch"
         assert handler_calls[0].kwargs["detail"] == "emergency"
 
-    def test_activate_audit(self, audit_logger):
-        """activate 시 system.activate 감사 로그가 기록된다."""
+    def test_clear_halt_audit(self, audit_logger):
+        """clear-halt 시 system.clear_halt 감사 로그가 기록된다 (Refs #1213).
+
+        SSOT: ``docs/specs/audit/audit.md``. action=``system.clear_halt``,
+        resource=``system:kill_switch`` 유지.
+        """
         account_service_mock = AsyncMock()
-        account_service_mock.activate_all = AsyncMock(return_value=1)
+        account_service_mock.activate_all = AsyncMock(
+            return_value=[
+                {
+                    "account_id": "domestic",
+                    "previous_status": "suspended",
+                    "status": "active",
+                    "changed": True,
+                }
+            ]
+        )
 
         app = create_app(
             audit_logger=audit_logger,
@@ -194,7 +216,7 @@ class TestHandlerAuditLog:
         client = TestClient(app)
 
         resp = client.post(
-            "/api/system/activate",
+            "/api/system/clear-halt",
             json={"reason": "recovered"},
         )
         assert resp.status_code == 200
@@ -202,9 +224,18 @@ class TestHandlerAuditLog:
         handler_calls = [
             c
             for c in audit_logger.log.call_args_list
-            if c.kwargs.get("action") == "system.activate"
+            if c.kwargs.get("action") == "system.clear_halt"
         ]
         assert len(handler_calls) == 1
+        # audit resource 명칭은 그대로 유지 (Refs #1213 명시적 비변경)
+        assert handler_calls[0].kwargs["resource"] == "system:kill_switch"
+        # legacy system.activate 감사 로그는 더 이상 발생하지 않는다.
+        legacy_calls = [
+            c
+            for c in audit_logger.log.call_args_list
+            if c.kwargs.get("action") == "system.activate"
+        ]
+        assert len(legacy_calls) == 0
 
     def test_config_update_audit(self, audit_logger):
         """설정 변경 시 config.update 감사 로그가 기록된다."""

--- a/tests/unit/test_cli_account_integration.py
+++ b/tests/unit/test_cli_account_integration.py
@@ -91,8 +91,39 @@ def _make_mock_account_service(accounts=None):
     svc.initialize = AsyncMock()
     svc.list = AsyncMock(return_value=accounts or [])
     svc.get = AsyncMock()
-    svc.suspend_all = AsyncMock(return_value=2)
-    svc.activate_all = AsyncMock(return_value=2)
+    # Refs #1213: list[dict] 반환 타입.
+    svc.suspend_all = AsyncMock(
+        return_value=[
+            {
+                "account_id": "domestic",
+                "previous_status": "active",
+                "status": "suspended",
+                "changed": True,
+            },
+            {
+                "account_id": "overseas",
+                "previous_status": "active",
+                "status": "suspended",
+                "changed": True,
+            },
+        ]
+    )
+    svc.activate_all = AsyncMock(
+        return_value=[
+            {
+                "account_id": "domestic",
+                "previous_status": "suspended",
+                "status": "active",
+                "changed": True,
+            },
+            {
+                "account_id": "overseas",
+                "previous_status": "suspended",
+                "status": "active",
+                "changed": True,
+            },
+        ]
+    )
     return svc
 
 
@@ -319,13 +350,21 @@ class TestBotCreateAccountOption:
         assert data["code"] == "BOT_MISSING_REQUIRED_ACCOUNT"
 
 
-# ── system halt/activate (IPC) ──────────────────────────
+# ── system halt/clear-halt (IPC) ──────────────────────────
 
 
-class TestSystemHaltActivate:
+class TestSystemHaltClearHalt:
     def test_system_halt_sends_ipc(self, runner):
         """system halt가 IPC system.halt 커맨드 전송."""
-        mock_response = {"status": "ok", "data": {"suspended_count": 2}}
+        mock_response = {
+            "status": "ok",
+            "data": {
+                "status": "halted",
+                "accounts_changed": 2,
+                "changed_at": "2026-05-03T05:21:33+00:00",
+                "accounts": [],
+            },
+        }
 
         with patch(
             "ante.cli.commands.ipc_helpers.IPCClient", autospec=True
@@ -344,9 +383,17 @@ class TestSystemHaltActivate:
         assert "HALTED" in result.output
         mock_client.send.assert_called_once()
 
-    def test_system_activate_sends_ipc(self, runner):
-        """system activate가 IPC system.activate 커맨드 전송."""
-        mock_response = {"status": "ok", "data": {"activated_count": 2}}
+    def test_system_clear_halt_sends_ipc(self, runner):
+        """system clear-halt가 IPC system.clear_halt 커맨드 전송."""
+        mock_response = {
+            "status": "ok",
+            "data": {
+                "status": "halt_cleared",
+                "accounts_changed": 2,
+                "changed_at": "2026-05-03T05:21:33+00:00",
+                "accounts": [],
+            },
+        }
 
         with patch(
             "ante.cli.commands.ipc_helpers.IPCClient", autospec=True
@@ -359,10 +406,10 @@ class TestSystemHaltActivate:
                 "ante.cli.commands.ipc_helpers.get_socket_path",
                 return_value="/tmp/test.sock",
             ):
-                result = runner.invoke(cli, ["system", "activate"])
+                result = runner.invoke(cli, ["system", "clear-halt"])
 
         assert result.exit_code == 0
-        assert "ACTIVE" in result.output
+        assert "정지 해제" in result.output
         mock_client.send.assert_called_once()
 
 

--- a/tests/unit/test_cli_ipc_commands.py
+++ b/tests/unit/test_cli_ipc_commands.py
@@ -53,7 +53,19 @@ class TestSystemHaltIPC:
         """system halt가 IPC로 system.halt 커맨드를 전송."""
         mock_response = {
             "status": "ok",
-            "data": {"suspended_count": 3},
+            "data": {
+                "status": "halted",
+                "accounts_changed": 3,
+                "changed_at": "2026-05-03T05:21:33+00:00",
+                "accounts": [
+                    {
+                        "account_id": "acc1",
+                        "previous_status": "active",
+                        "status": "suspended",
+                        "changed": True,
+                    },
+                ],
+            },
         }
 
         with patch(
@@ -78,7 +90,15 @@ class TestSystemHaltIPC:
 
     def test_halt_default_reason(self, runner: CliRunner) -> None:
         """system halt 사유 미지정 시 빈 문자열."""
-        mock_response = {"status": "ok", "data": {"suspended_count": 0}}
+        mock_response = {
+            "status": "ok",
+            "data": {
+                "status": "halted",
+                "accounts_changed": 0,
+                "changed_at": "2026-05-03T05:21:33+00:00",
+                "accounts": [],
+            },
+        }
 
         with patch(
             "ante.cli.commands.ipc_helpers.IPCClient", autospec=True
@@ -99,15 +119,33 @@ class TestSystemHaltIPC:
         )
 
 
-# ── system activate IPC ────────────────────────────
+# ── system clear-halt IPC ────────────────────────────
 
 
-class TestSystemActivateIPC:
-    def test_activate_sends_ipc_command(self, runner: CliRunner) -> None:
-        """system activate가 IPC로 system.activate 커맨드를 전송."""
+class TestSystemClearHaltIPC:
+    def test_clear_halt_sends_ipc_command(self, runner: CliRunner) -> None:
+        """system clear-halt가 IPC로 system.clear_halt 커맨드를 전송."""
         mock_response = {
             "status": "ok",
-            "data": {"activated_count": 2},
+            "data": {
+                "status": "halt_cleared",
+                "accounts_changed": 2,
+                "changed_at": "2026-05-03T05:21:33+00:00",
+                "accounts": [
+                    {
+                        "account_id": "acc1",
+                        "previous_status": "suspended",
+                        "status": "active",
+                        "changed": True,
+                    },
+                    {
+                        "account_id": "acc2",
+                        "previous_status": "suspended",
+                        "status": "active",
+                        "changed": True,
+                    },
+                ],
+            },
         }
 
         with patch(
@@ -121,13 +159,15 @@ class TestSystemActivateIPC:
                 "ante.cli.commands.ipc_helpers.get_socket_path",
                 return_value="/tmp/test.sock",
             ):
-                result = runner.invoke(cli, ["system", "activate"])
+                result = runner.invoke(cli, ["system", "clear-halt"])
 
         assert result.exit_code == 0, result.output
-        assert "ACTIVE" in result.output
+        assert "정지 해제" in result.output
         assert "2" in result.output
+        # 봇 자동 재시작 안내 문구 (Refs #1213 SSOT)
+        assert "자동 재시작" in result.output
         mock_client.send.assert_called_once_with(
-            "system.activate", {"reason": ""}, "test-master"
+            "system.clear_halt", {"reason": ""}, "test-master"
         )
 
 

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -61,8 +61,27 @@ class TestSystemCommands:
 
             acct = SimpleNamespace(account_id="test", status=AccountStatus.ACTIVE)
             mock_svc.list = AsyncMock(return_value=[acct])
-        mock_svc.suspend_all = AsyncMock(return_value=1)
-        mock_svc.activate_all = AsyncMock(return_value=1)
+        # Refs #1213: suspend_all/activate_all 반환 타입은 list[dict].
+        mock_svc.suspend_all = AsyncMock(
+            return_value=[
+                {
+                    "account_id": "test",
+                    "previous_status": "active",
+                    "status": "suspended",
+                    "changed": True,
+                }
+            ]
+        )
+        mock_svc.activate_all = AsyncMock(
+            return_value=[
+                {
+                    "account_id": "test",
+                    "previous_status": "suspended",
+                    "status": "active",
+                    "changed": True,
+                }
+            ]
+        )
         return mock_svc
 
     def test_system_status(self, runner):
@@ -98,7 +117,15 @@ class TestSystemCommands:
                 assert data["bot_count"] == 2
 
     def test_system_halt(self, runner):
-        mock_response = {"status": "ok", "data": {"suspended_count": 2}}
+        mock_response = {
+            "status": "ok",
+            "data": {
+                "status": "halted",
+                "accounts_changed": 2,
+                "changed_at": "2026-05-03T05:21:33+00:00",
+                "accounts": [],
+            },
+        }
 
         with patch(
             "ante.cli.commands.ipc_helpers.IPCClient", autospec=True
@@ -115,8 +142,16 @@ class TestSystemCommands:
                 assert result.exit_code == 0
                 assert "HALTED" in result.output
 
-    def test_system_activate(self, runner):
-        mock_response = {"status": "ok", "data": {"activated_count": 2}}
+    def test_system_clear_halt(self, runner):
+        mock_response = {
+            "status": "ok",
+            "data": {
+                "status": "halt_cleared",
+                "accounts_changed": 2,
+                "changed_at": "2026-05-03T05:21:33+00:00",
+                "accounts": [],
+            },
+        }
 
         with patch(
             "ante.cli.commands.ipc_helpers.IPCClient", autospec=True
@@ -129,9 +164,9 @@ class TestSystemCommands:
                 "ante.cli.commands.ipc_helpers.get_socket_path",
                 return_value="/tmp/test.sock",
             ):
-                result = runner.invoke(cli, ["system", "activate"])
+                result = runner.invoke(cli, ["system", "clear-halt"])
                 assert result.exit_code == 0
-                assert "ACTIVE" in result.output
+                assert "정지 해제" in result.output
 
 
 # ── bot 커맨드 ─────────────────────────────────────

--- a/tests/unit/test_generate_cli_reference.py
+++ b/tests/unit/test_generate_cli_reference.py
@@ -278,6 +278,7 @@ class TestGenerateCliReference:
             "ante bot list",
             "ante strategy validate",
             "ante system halt",
+            "ante system clear-halt",
             "ante trade list",
             "ante feed init",
         ]
@@ -287,6 +288,10 @@ class TestGenerateCliReference:
         # 제거된 커맨드는 문서에 존재하지 않아야 한다 (issue #1125)
         assert "ante member bootstrap" not in content, (
             "제거된 ante member bootstrap이 CLI reference에 남아있습니다"
+        )
+        # legacy `ante system activate`는 #1213에서 제거됨 (SSOT 정책: hard remove)
+        assert "ante system activate" not in content, (
+            "legacy 'ante system activate'가 CLI reference에 남아있습니다 (Refs #1213)"
         )
 
     def test_intro_notice(self) -> None:

--- a/tests/unit/test_response_model_validation.py
+++ b/tests/unit/test_response_model_validation.py
@@ -135,11 +135,75 @@ class TestSystemResponseModels:
         with pytest.raises(ValidationError):
             HealthResponse.model_validate({"checks": {"db": True, "broker": True}})
 
-    def test_kill_switch_response(self):
-        """POST /api/system/kill-switch."""
-        data = {"status": "halted", "changed_at": "2026-03-19T10:00:00+00:00"}
+    def test_kill_switch_response_halt(self):
+        """POST /api/system/halt 응답 SSOT (Refs #1213).
+
+        SSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답.
+        ``status``, ``accounts_changed``, ``changed_at``, ``accounts[]`` 4 필드.
+        """
+        data = {
+            "status": "halted",
+            "accounts_changed": 2,
+            "changed_at": "2026-05-03T05:21:33+00:00",
+            "accounts": [
+                {
+                    "account_id": "domestic",
+                    "previous_status": "active",
+                    "status": "suspended",
+                    "changed": True,
+                },
+                {
+                    "account_id": "overseas",
+                    "previous_status": "active",
+                    "status": "suspended",
+                    "changed": True,
+                },
+            ],
+        }
         model = KillSwitchResponse.model_validate(data)
         assert model.status == "halted"
+        assert model.accounts_changed == 2
+        assert len(model.accounts) == 2
+        assert model.accounts[0].account_id == "domestic"
+        assert model.accounts[0].previous_status == "active"
+        assert model.accounts[0].status == "suspended"
+        assert model.accounts[0].changed is True
+
+    def test_kill_switch_response_clear_halt(self):
+        """POST /api/system/clear-halt 응답 SSOT (Refs #1213)."""
+        data = {
+            "status": "halt_cleared",
+            "accounts_changed": 1,
+            "changed_at": "2026-05-03T05:21:33+00:00",
+            "accounts": [
+                {
+                    "account_id": "domestic",
+                    "previous_status": "suspended",
+                    "status": "active",
+                    "changed": True,
+                },
+                {
+                    "account_id": "overseas",
+                    "previous_status": "active",
+                    "status": "active",
+                    "changed": False,
+                },
+            ],
+        }
+        model = KillSwitchResponse.model_validate(data)
+        assert model.status == "halt_cleared"
+        assert model.accounts_changed == 1
+        assert model.accounts[1].changed is False
+
+    def test_kill_switch_response_empty_accounts_default(self):
+        """``accounts`` 미지정 시 기본 빈 list."""
+        data = {
+            "status": "halted",
+            "accounts_changed": 0,
+            "changed_at": "2026-05-03T05:21:33+00:00",
+        }
+        model = KillSwitchResponse.model_validate(data)
+        assert model.accounts == []
 
 
 # ── 인증 라우트 응답 모델 ──────────────────────────

--- a/tests/unit/test_system_config_api.py
+++ b/tests/unit/test_system_config_api.py
@@ -51,8 +51,27 @@ class FakeDynamicConfig:
 @pytest.fixture
 def account_service():
     mock = AsyncMock()
-    mock.suspend_all = AsyncMock(return_value=1)
-    mock.activate_all = AsyncMock(return_value=1)
+    # Refs #1213: list[dict] 반환 타입 (account_id, previous_status, status, changed).
+    mock.suspend_all = AsyncMock(
+        return_value=[
+            {
+                "account_id": "domestic",
+                "previous_status": "active",
+                "status": "suspended",
+                "changed": True,
+            }
+        ]
+    )
+    mock.activate_all = AsyncMock(
+        return_value=[
+            {
+                "account_id": "domestic",
+                "previous_status": "suspended",
+                "status": "active",
+                "changed": True,
+            }
+        ]
+    )
     return mock
 
 
@@ -67,7 +86,12 @@ def client(account_service, dynamic_config):
     return TestClient(app)
 
 
-class TestHaltActivate:
+class TestHaltClearHalt:
+    """POST /api/system/halt + /api/system/clear-halt SSOT 응답 shape 검증.
+
+    SSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답 SSOT.
+    """
+
     def test_halt(self, client, account_service):
         """POST /halt로 전체 거래 중지."""
         resp = client.post(
@@ -76,36 +100,65 @@ class TestHaltActivate:
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert "suspended" in data["status"]
+        assert data["status"] == "halted"
+        assert data["accounts_changed"] == 1
         assert "changed_at" in data
+        assert data["accounts"] == [
+            {
+                "account_id": "domestic",
+                "previous_status": "active",
+                "status": "suspended",
+                "changed": True,
+            }
+        ]
         account_service.suspend_all.assert_called_once()
 
-    def test_activate(self, client, account_service):
-        """POST /activate로 거래 재개."""
+    def test_clear_halt(self, client, account_service):
+        """POST /clear-halt로 전역 정지 해제."""
         resp = client.post(
-            "/api/system/activate",
+            "/api/system/clear-halt",
             json={"reason": "재개"},
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert "activated" in data["status"]
+        assert data["status"] == "halt_cleared"
+        assert data["accounts_changed"] == 1
+        assert "changed_at" in data
+        assert data["accounts"] == [
+            {
+                "account_id": "domestic",
+                "previous_status": "suspended",
+                "status": "active",
+                "changed": True,
+            }
+        ]
         account_service.activate_all.assert_called_once()
 
-    def test_halt_activate_lifecycle(self, client, account_service):
-        """halt → activate lifecycle."""
+    def test_halt_clear_halt_lifecycle(self, client, account_service):
+        """halt → clear-halt lifecycle."""
         resp = client.post(
             "/api/system/halt",
             json={"reason": ""},
         )
         assert resp.status_code == 200
-        assert "suspended" in resp.json()["status"]
+        assert resp.json()["status"] == "halted"
 
         resp = client.post(
-            "/api/system/activate",
+            "/api/system/clear-halt",
             json={"reason": ""},
         )
         assert resp.status_code == 200
-        assert "activated" in resp.json()["status"]
+        assert resp.json()["status"] == "halt_cleared"
+
+    def test_legacy_activate_route_removed(self, client):
+        """legacy POST /api/system/activate는 hard remove (SSOT 정책)."""
+        resp = client.post("/api/system/activate", json={"reason": ""})
+        assert resp.status_code == 404
+
+    def test_legacy_kill_switch_route_absent(self, client):
+        """legacy POST /api/system/kill-switch는 등록되지 않음 (SSOT 정책)."""
+        resp = client.post("/api/system/kill-switch", json={"action": "halt"})
+        assert resp.status_code == 404
 
 
 class TestDynamicConfig:

--- a/tests/unit/test_telegram_receiver.py
+++ b/tests/unit/test_telegram_receiver.py
@@ -76,8 +76,27 @@ def account_service():
     # 기본: ACTIVE 계좌 1개
     active_account = SimpleNamespace(account_id="test", status=AccountStatus.ACTIVE)
     mock.list.return_value = [active_account]
-    mock.suspend_all = AsyncMock(return_value=1)
-    mock.activate_all = AsyncMock(return_value=1)
+    # Refs #1213: list[dict] 반환 타입.
+    mock.suspend_all = AsyncMock(
+        return_value=[
+            {
+                "account_id": "test",
+                "previous_status": "active",
+                "status": "suspended",
+                "changed": True,
+            }
+        ]
+    )
+    mock.activate_all = AsyncMock(
+        return_value=[
+            {
+                "account_id": "test",
+                "previous_status": "suspended",
+                "status": "active",
+                "changed": True,
+            }
+        ]
+    )
     return mock
 
 
@@ -237,27 +256,34 @@ class TestCommands:
         result = await receiver._execute("unknown", [], 12345, 100)
         assert "알 수 없는 명령" in result
 
-    async def test_activate(self, receiver, account_service):
+    async def test_clear_halt(self, receiver, account_service):
+        """``_cmd_clear_halt``는 ``activate_all``을 호출하고 SSOT 안내 문구를 반환."""
         from ante.account.models import AccountStatus
 
         suspended_account = SimpleNamespace(
             account_id="test", status=AccountStatus.SUSPENDED
         )
         account_service.list.return_value = [suspended_account]
-        result = await receiver._cmd_activate([])
-        assert "거래가 재개되었습니다" in result
+        result = await receiver._cmd_clear_halt([])
+        assert "정지가 해제" in result
+        # SSOT 문구: 봇 자동 재시작 없음
+        assert "자동 재시작되지 않습니다" in result
         account_service.activate_all.assert_called_once_with(activated_by="telegram")
 
-    async def test_activate_already_active(self, receiver, account_service):
-        # fixture default is ACTIVE
-        result = await receiver._cmd_activate([])
+    async def test_clear_halt_already_active(self, receiver, account_service):
+        """이미 ACTIVE면 즉시 안내."""
+        result = await receiver._cmd_clear_halt([])
         assert "이미 거래가 활성 상태입니다" in result
         account_service.activate_all.assert_not_called()
 
-    async def test_activate_no_service(self, receiver):
+    async def test_clear_halt_no_service(self, receiver):
         receiver._account_service = None
-        result = await receiver._cmd_activate([])
+        result = await receiver._cmd_clear_halt([])
         assert "연결되지 않았습니다" in result
+
+    async def test_no_legacy_activate_handler(self, receiver):
+        """legacy ``_cmd_activate`` 메서드는 제거되었다 (Refs #1213)."""
+        assert not hasattr(receiver, "_cmd_activate")
 
     async def test_stop_bot_no_positions(self, receiver, bot_manager):
         """보유 종목 없이 봇 중지 — 메시지 A."""
@@ -331,12 +357,52 @@ class TestCommands:
 class TestConfirmation:
     """위험 명령 확인 절차 테스트."""
 
+    def test_dangerous_commands_set_includes_clear_halt(self):
+        """``_DANGEROUS_COMMANDS``에 ``clear_halt`` 포함 (Refs #1213).
+
+        SSOT: ``docs/specs/notification/notification.md`` 위험 명령 표.
+        ``halt``, ``clear_halt``, ``stop`` 모두 2단계 확인 대상이다.
+        """
+        from ante.notification.telegram_receiver import _DANGEROUS_COMMANDS
+
+        assert _DANGEROUS_COMMANDS == {"halt", "clear_halt", "stop"}
+
     async def test_halt_requires_confirm(self, receiver):
         """halt 명령은 확인을 요구한다."""
         result = await receiver._execute("halt", ["긴급"], 12345, 100)
         assert "/confirm" in result
         assert "긴급" in result
         assert 12345 in receiver._pending_confirm
+
+    async def test_clear_halt_requires_confirm(self, receiver, account_service):
+        """clear_halt 명령은 확인을 요구한다 (Refs #1213, SSOT 위험 명령).
+
+        SSOT: ``docs/specs/notification/notification.md`` 위험 명령 표.
+        """
+        from ante.account.models import AccountStatus
+
+        # SUSPENDED 상태에서 호출해야 confirmation까지 도달.
+        suspended_account = SimpleNamespace(
+            account_id="test", status=AccountStatus.SUSPENDED
+        )
+        account_service.list.return_value = [suspended_account]
+        result = await receiver._execute("clear_halt", [], 12345, 100)
+        assert "/confirm" in result
+        assert "정지" in result
+        assert "자동 재시작" in result
+        assert 12345 in receiver._pending_confirm
+        # confirmation 단계이므로 activate_all은 아직 호출되지 않아야 한다.
+        account_service.activate_all.assert_not_called()
+
+    async def test_clear_halt_short_circuits_when_already_active(
+        self, receiver, account_service
+    ):
+        """이미 ACTIVE이면 confirmation 없이 즉시 안내."""
+        # fixture default is ACTIVE
+        result = await receiver._execute("clear_halt", [], 12345, 100)
+        assert "이미 거래가 활성 상태입니다" in result
+        assert 12345 not in receiver._pending_confirm
+        account_service.activate_all.assert_not_called()
 
     async def test_stop_requires_confirm(self, receiver):
         """stop 명령은 확인을 요구한다."""
@@ -354,6 +420,25 @@ class TestConfirmation:
         account_service.suspend_all.assert_called_once_with(
             reason="점검", suspended_by="telegram"
         )
+
+    async def test_confirm_executes_clear_halt(self, receiver, account_service):
+        """confirm으로 clear_halt가 실행된다 (Refs #1213).
+
+        clear_halt는 SSOT 위험 명령이므로 ``/confirm`` 분기에서 실행되어야 한다.
+        """
+        from ante.account.models import AccountStatus
+
+        suspended_account = SimpleNamespace(
+            account_id="test", status=AccountStatus.SUSPENDED
+        )
+        account_service.list.return_value = [suspended_account]
+
+        await receiver._execute("clear_halt", [], 12345, 100)
+        result = await receiver._handle_confirm(12345)
+        assert "정지가 해제" in result
+        # SSOT: 봇 자동 재시작 없음
+        assert "자동 재시작되지 않습니다" in result
+        account_service.activate_all.assert_called_once_with(activated_by="telegram")
 
     async def test_confirm_executes_stop(self, receiver, bot_manager):
         """confirm으로 stop이 실행된다."""
@@ -519,7 +604,9 @@ class TestIntegrationFlow:
         assert receiver._reply.call_count == 2
         reply_text = receiver._reply.call_args[0][1]
         assert "중지되었습니다" in reply_text
-        assert "/activate" in reply_text
+        # Refs #1213: 안내는 /clear_halt로 정렬 (legacy /activate 제거).
+        assert "/clear_halt" in reply_text
+        assert "/activate" not in reply_text
         account_service.suspend_all.assert_called_once_with(
             reason="긴급 점검", suspended_by="telegram"
         )
@@ -548,6 +635,74 @@ class TestIntegrationFlow:
         assert receiver._reply.call_count == 1
         assert "이미 거래가 중지된 상태입니다" in receiver._reply.call_args[0][1]
         account_service.suspend_all.assert_not_called()
+
+    async def test_full_clear_halt_confirm_flow(self, receiver, account_service):
+        """clear_halt → confirm → 실제 실행 흐름 (Refs #1213).
+
+        SSOT: ``docs/specs/notification/notification.md`` 위험 명령 표.
+        ``/clear_halt``는 2단계 확인 후 ``activate_all``을 호출하며,
+        BotManager 자동 재시작은 수행되지 않는다 (회귀 가드).
+        """
+        from ante.account.models import AccountStatus
+
+        suspended_account = SimpleNamespace(
+            account_id="test", status=AccountStatus.SUSPENDED
+        )
+        account_service.list.return_value = [suspended_account]
+
+        receiver._reply = AsyncMock()
+
+        clear_halt_update = {
+            "message": {
+                "text": "/clear_halt",
+                "from": {"id": 12345},
+                "chat": {"id": 100},
+            }
+        }
+        await receiver._handle_update(clear_halt_update)
+        assert receiver._reply.call_count == 1
+        assert "/confirm" in receiver._reply.call_args[0][1]
+        # 확인 단계에서는 activate_all이 호출되지 않는다.
+        account_service.activate_all.assert_not_called()
+
+        confirm_update = {
+            "message": {
+                "text": "/confirm",
+                "from": {"id": 12345},
+                "chat": {"id": 100},
+            }
+        }
+        await receiver._handle_update(confirm_update)
+        assert receiver._reply.call_count == 2
+        reply_text = receiver._reply.call_args[0][1]
+        assert "정지가 해제" in reply_text
+        assert "자동 재시작되지 않습니다" in reply_text
+        account_service.activate_all.assert_called_once_with(activated_by="telegram")
+
+    async def test_clear_halt_does_not_restart_bots(
+        self, receiver, account_service, bot_manager
+    ):
+        """clear_halt 실행 후 BotManager 자동 재시작이 호출되지 않음 (Refs #1213).
+
+        SSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답 SSOT
+        "계좌 상태만 복구하며 봇 자동 재시작은 수행하지 않는다".
+        BotManager는 ``AccountActivatedEvent`` 수신 시 로깅만 수행한다.
+        """
+        from ante.account.models import AccountStatus
+
+        suspended_account = SimpleNamespace(
+            account_id="test", status=AccountStatus.SUSPENDED
+        )
+        account_service.list.return_value = [suspended_account]
+
+        await receiver._cmd_clear_halt([])
+
+        account_service.activate_all.assert_called_once_with(activated_by="telegram")
+        # BotManager 자동 재시작 메서드들이 호출되지 않아야 한다.
+        bot_manager.start_bot.assert_not_called()
+        bot_manager.restart_bot.assert_not_called()
+        bot_manager.start_all.assert_not_called()
+        bot_manager.start.assert_not_called()
 
     async def test_reply_with_no_chat_id(self, receiver):
         """chat_id가 없어도 에러 없이 처리."""


### PR DESCRIPTION
Closes #1213
Refs #1211 (parent epic), #1214 (frontend follow-up)

## Summary
- `AccountService.suspend_all`/`activate_all` 반환을 `int` → `list[dict]` (`account_id`, `previous_status`, `status`, `changed`)로 확장. DELETED 제외.
- `KillSwitchResponse` 확장: `accounts_changed`, `accounts: list[KillSwitchAccountChange]` 추가.
- IPC: `system.clear_halt` 신규 + legacy `system.activate` 제거. `_handle_system_halt` 응답 shape SSOT 정렬.
- Web API: `POST /api/system/clear-halt` 신규 (audit `system.clear_halt`, resource `system:kill_switch` 유지) + legacy `POST /api/system/activate` 제거.
- CLI: `ante system clear-halt` 신규 + legacy `activate` 제거. `--yes` 미추가 (SSOT 위험 명령 목록 미포함).
- Telegram: `_DANGEROUS_COMMANDS = {halt, clear_halt, stop}` (clear_halt도 2단계 확인). `/confirm` 분기에 `clear_halt` 처리. `_cmd_clear_halt` 신규 + `_cmd_activate` 제거.
- Generated artifacts: `frontend/openapi.json` + `frontend/src/types/api.generated.ts` 재생성.

## ⚠️ Transitional Fragility (Plan body Risk Flag)
- 대시보드 `frontend/src/api/system.ts` `setKillSwitch`는 여전히 legacy `POST /api/system/kill-switch`에 `{action: 'halt' | 'activate'}` 호출 → **이 PR 머지 후 dashboard halt/activate 버튼 일시 404**.
- **#1214가 즉시 follow-up** (autopilot batch sequential 처리)으로 frontend 호출부를 새 라우트로 정렬.
- 이 분리는 의도된 scope (Plan body Spec Path/Non-Goals 명시).

## Test Plan
- `pytest tests/unit -q` — 3504 passed, 2 skipped, 0 failed
- IPC 회귀 가드: `pytest tests/unit/test_main_shutdown_ordering.py tests/unit/test_ipc_error_code_mapping.py -q` — 13 passed
- Telegram 통합: `_DANGEROUS_COMMANDS` set 검증 + clear_halt 2단계 확인 흐름 + BotManager 비-재시작 회귀 가드
- Account: suspend_all/activate_all 반환 list 검증 + DELETED 제외 negative
- Audit: legacy `system.activate` 부재 negative + 신규 `system.clear_halt` positive
- legacy grep (`src/ante`): 모두 0건
- ruff check + format — PASS

## Codex Branch Review
attempt 1 PASS-with-known-finding: P2 finding이 본 issue plan의 transitional fragility risk flag에서 예측한 frontend 깨짐 시나리오. 의도된 scope split이며 #1214가 즉시 follow-up.

## Plan Preflight
- Plan Preflight rev1 invoke-human → rev2 revise (Telegram stale) → rev3 revise (rev1 reflection stale) → rev4 narrow-scope
- canonical plan은 이슈 본문 Implementation Plan