### PR TITLE
feat(dashboard): align kill switch frontend to halt/clear-halt SSOT

### DIFF
--- a/frontend/src/api/system.ts
+++ b/frontend/src/api/system.ts
@@ -1,13 +1,33 @@
 import client from './client'
 import type { SystemStatus, DynamicConfig } from '../types/system'
+import type { KillSwitchResponse } from '../types/api.generated'
 
 export async function getSystemStatus(): Promise<SystemStatus> {
   const res = await client.get('/api/system/status')
   return res.data
 }
 
-export async function setKillSwitch(action: 'halt' | 'activate', reason?: string): Promise<void> {
-  await client.post('/api/system/kill-switch', { action, reason: reason ?? '' })
+/**
+ * 전역 거래 정지 (모든 ACTIVE 계좌 → SUSPENDED).
+ *
+ * SSOT: `docs/specs/web-api/04-system-endpoints.md` Kill Switch.
+ * 백엔드: `POST /api/system/halt` (HaltRequest { reason: string }).
+ */
+export async function haltSystem(reason?: string): Promise<KillSwitchResponse> {
+  const res = await client.post('/api/system/halt', { reason: reason ?? '' })
+  return res.data
+}
+
+/**
+ * 전역 정지 해제 (모든 SUSPENDED 계좌 → ACTIVE).
+ *
+ * 계좌 상태만 ACTIVE로 복구하며 봇은 자동 재시작되지 않는다.
+ * SSOT: `docs/specs/web-api/04-system-endpoints.md` Kill Switch.
+ * 백엔드: `POST /api/system/clear-halt` (ClearHaltRequest { reason: string }).
+ */
+export async function clearHaltSystem(reason?: string): Promise<KillSwitchResponse> {
+  const res = await client.post('/api/system/clear-halt', { reason: reason ?? '' })
+  return res.data
 }
 
 export async function getConfigs(): Promise<DynamicConfig[]> {

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -31,7 +31,10 @@ export default function Header() {
   const location = useLocation()
   const navigate = useNavigate()
   const { data: user } = useUser()
-  const { data: accounts, isLoading: accountsLoading } = useAccounts()
+  // CLI/다른 세션의 system halt/clear-halt를 헤더 상태에 반영하기 위해 30초 폴링.
+  const { data: accounts, isLoading: accountsLoading } = useAccounts(undefined, {
+    refetchInterval: 30_000,
+  })
   const logoutMutation = useLogout()
   const [menuOpen, setMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react'
 import { useLocation, useNavigate, Link } from 'react-router-dom'
 import { useUser, useLogout } from '../../hooks/useAuth'
-import { useSystemStatus } from '../../hooks/useSystemStatus'
+import { useAccounts } from '../../hooks/useAccounts'
 
 const PAGE_TITLES: Record<string, string> = {
   '/approvals': '결재함',
@@ -31,10 +31,23 @@ export default function Header() {
   const location = useLocation()
   const navigate = useNavigate()
   const { data: user } = useUser()
-  const { data: systemStatus } = useSystemStatus()
+  const { data: accounts, isLoading: accountsLoading } = useAccounts()
   const logoutMutation = useLogout()
   const [menuOpen, setMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
+
+  // 시스템 상태는 계좌 집계로 산출 (전역 거래 상태 enum은 SSOT 아님).
+  // - active > 0 && suspended === 0 이면 ACTIVE.
+  // - accounts 로딩 중에는 false negative 방지를 위해 중립 상태.
+  const activeCount = accounts?.filter((a) => a.status === 'active').length ?? 0
+  const suspendedCount = accounts?.filter((a) => a.status === 'suspended').length ?? 0
+  const isActive = !accountsLoading && activeCount > 0 && suspendedCount === 0
+  const dotClass = accountsLoading
+    ? 'bg-border'
+    : isActive
+      ? 'bg-positive'
+      : 'bg-negative'
+  const statusLabel = accountsLoading ? '확인 중' : isActive ? 'ACTIVE' : 'HALTED'
 
   const title = getPageTitle(location.pathname)
   const showBack = isDetailPage(location.pathname)
@@ -65,12 +78,8 @@ export default function Header() {
 
       <div className="flex items-center gap-2 md:gap-4">
         <div className="hidden sm:flex items-center gap-1.5 text-[12px] text-text-muted">
-          <span
-            className={`w-2 h-2 rounded-full ${
-              systemStatus?.trading_status === 'ACTIVE' ? 'bg-positive' : 'bg-negative'
-            }`}
-          />
-          {systemStatus?.trading_status ?? '...'}
+          <span className={`w-2 h-2 rounded-full ${dotClass}`} />
+          {statusLabel}
         </div>
 
         <div ref={menuRef} className="relative">

--- a/frontend/src/hooks/useAccounts.ts
+++ b/frontend/src/hooks/useAccounts.ts
@@ -1,10 +1,14 @@
 import { useQuery } from '@tanstack/react-query'
 import { getAccounts } from '../api/accounts'
 
-export function useAccounts(params?: { status?: string }) {
+export function useAccounts(
+  params?: { status?: string },
+  options?: { refetchInterval?: number },
+) {
   return useQuery({
     queryKey: ['accounts', params],
     queryFn: () => getAccounts(params),
+    refetchInterval: options?.refetchInterval,
   })
 }
 

--- a/frontend/src/hooks/useSystemStatus.ts
+++ b/frontend/src/hooks/useSystemStatus.ts
@@ -1,5 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getSystemStatus, setKillSwitch, getConfigs, updateConfig } from '../api/system'
+import {
+  getSystemStatus,
+  haltSystem,
+  clearHaltSystem,
+  getConfigs,
+  updateConfig,
+} from '../api/system'
 
 export function useSystemStatus() {
   return useQuery({
@@ -9,12 +15,37 @@ export function useSystemStatus() {
   })
 }
 
-export function useKillSwitch() {
+/**
+ * 전역 거래 정지 mutation.
+ *
+ * 성공 시 ['accounts'] + ['system'] 쿼리를 무효화하여 useAccounts 기반
+ * Settings/Header 상태 표시가 즉시 SUSPENDED로 갱신되도록 한다.
+ */
+export function useHaltSystem() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: ({ action, reason }: { action: 'halt' | 'activate'; reason?: string }) =>
-      setKillSwitch(action, reason),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['system'] }),
+    mutationFn: ({ reason }: { reason?: string } = {}) => haltSystem(reason),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts'] })
+      queryClient.invalidateQueries({ queryKey: ['system'] })
+    },
+  })
+}
+
+/**
+ * 전역 정지 해제 mutation.
+ *
+ * 계좌 상태만 ACTIVE로 복구한다. 봇은 자동 재시작되지 않는다.
+ * 성공 시 ['accounts'] + ['system'] 쿼리를 무효화한다.
+ */
+export function useClearHaltSystem() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ reason }: { reason?: string } = {}) => clearHaltSystem(reason),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts'] })
+      queryClient.invalidateQueries({ queryKey: ['system'] })
+    },
   })
 }
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,5 +1,12 @@
 import { useState } from 'react'
-import { useSystemStatus, useKillSwitch, useConfigs, useUpdateConfig } from '../hooks/useSystemStatus'
+import {
+  useSystemStatus,
+  useHaltSystem,
+  useClearHaltSystem,
+  useConfigs,
+  useUpdateConfig,
+} from '../hooks/useSystemStatus'
+import { useAccounts } from '../hooks/useAccounts'
 import { PageSkeleton } from '../components/common/Skeleton'
 import ApiKeyStatusPanel from '../components/data/ApiKeyStatusPanel'
 
@@ -51,28 +58,37 @@ const DISPLAY_CONFIGS: DisplayConfig[] = [
 
 export default function Settings() {
   const { data: status, isLoading: statusLoading } = useSystemStatus()
-  const killSwitch = useKillSwitch()
+  const { data: accounts, isLoading: accountsLoading } = useAccounts()
+  const haltMutation = useHaltSystem()
+  const clearHaltMutation = useClearHaltSystem()
   const { data: configs } = useConfigs()
   const updateConfig = useUpdateConfig()
   const [rowValues, setRowValues] = useState<Record<string, string>>({})
   const [showHaltModal, setShowHaltModal] = useState(false)
+  const [showClearHaltModal, setShowClearHaltModal] = useState(false)
   const [haltReason, setHaltReason] = useState('')
 
   if (statusLoading) return <PageSkeleton />
 
-  const isActive = status?.trading_status === 'ACTIVE'
+  // 시스템 상태는 계좌 집계로 산출 (전역 거래 상태 enum은 SSOT 아님).
+  // - active > 0 && suspended === 0 이면 ACTIVE.
+  // - accounts 로딩 중에는 false negative 방지를 위해 "확인 중" 처리.
+  const activeCount = accounts?.filter((a) => a.status === 'active').length ?? 0
+  const suspendedCount = accounts?.filter((a) => a.status === 'suspended').length ?? 0
+  const isActive = !accountsLoading && activeCount > 0 && suspendedCount === 0
   const configMap = new Map((configs ?? []).map((c) => [c.key, c.value]))
 
   const getConfigValue = (key: string) => configMap.get(key) ?? ''
 
   const handleHalt = () => {
-    killSwitch.mutate({ action: 'halt', reason: haltReason })
+    haltMutation.mutate({ reason: haltReason })
     setShowHaltModal(false)
     setHaltReason('')
   }
 
-  const handleActivate = () => {
-    killSwitch.mutate({ action: 'activate' })
+  const handleClearHalt = () => {
+    clearHaltMutation.mutate({})
+    setShowClearHaltModal(false)
   }
 
   const getRowValue = (key: string) =>
@@ -91,9 +107,24 @@ export default function Settings() {
         {/* 시스템 상태 */}
         <div className="bg-surface border border-border rounded-lg p-5">
           <h3 className="text-[15px] font-semibold mb-4">시스템 상태</h3>
-          {isActive ? (
+          {accountsLoading ? (
             <div className="flex items-center justify-between py-3">
-              <div className="text-[13px] text-text-muted">현재 모든 봇의 거래가 정상 운용 중입니다.</div>
+              <div className="flex items-center gap-2 text-[13px] text-text-muted">
+                <span className="w-2 h-2 rounded-full bg-border" />
+                계좌 상태 확인 중…
+              </div>
+            </div>
+          ) : isActive ? (
+            <div className="flex items-center justify-between py-3">
+              <div>
+                <div className="flex items-center gap-2 text-[13px] text-text-muted">
+                  <span className="w-2 h-2 rounded-full bg-positive" />
+                  현재 모든 봇의 거래가 정상 운용 중입니다.
+                </div>
+                <div className="text-[12px] text-text-muted mt-1">
+                  활성 계좌 {activeCount}개 · 정지 계좌 {suspendedCount}개
+                </div>
+              </div>
               <button
                 onClick={() => setShowHaltModal(true)}
                 className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-on-primary border-none cursor-pointer hover:bg-negative-hover whitespace-nowrap"
@@ -104,7 +135,13 @@ export default function Settings() {
           ) : (
             <div className="flex items-center justify-between py-3">
               <div>
-                <div className="text-[13px] text-negative font-semibold">거래가 정지되었습니다</div>
+                <div className="flex items-center gap-2 text-[13px] text-negative font-semibold">
+                  <span className="w-2 h-2 rounded-full bg-negative" />
+                  거래가 정지되었습니다
+                </div>
+                <div className="text-[12px] text-text-muted mt-1">
+                  활성 계좌 {activeCount}개 · 정지 계좌 {suspendedCount}개
+                </div>
                 {(status?.halt_time || status?.halt_reason) && (
                   <div className="text-[12px] text-text-muted mt-1">
                     {status.halt_time && `정지 시각: ${status.halt_time}`}
@@ -114,7 +151,7 @@ export default function Settings() {
                 )}
               </div>
               <button
-                onClick={handleActivate}
+                onClick={() => setShowClearHaltModal(true)}
                 className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-on-primary border-none cursor-pointer hover:bg-positive-hover whitespace-nowrap"
               >
                 거래 재개
@@ -308,6 +345,25 @@ export default function Settings() {
             <div className="flex justify-end gap-2 pt-4 border-t border-border mt-6">
               <button onClick={() => { setShowHaltModal(false); setHaltReason('') }} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
               <button onClick={handleHalt} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-negative text-on-primary border-none cursor-pointer hover:bg-negative-hover">거래 정지 확인</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 거래 재개(정지 해제) 확인 모달 */}
+      {showClearHaltModal && (
+        <div className="fixed inset-0 bg-overlay flex items-center justify-center z-[200]">
+          <div className="bg-surface border border-border rounded-lg p-6 w-[480px]">
+            <h3 className="text-[18px] font-bold text-positive mb-5">거래 재개</h3>
+            <p className="text-[13px] text-text-muted mb-4">
+              모든 정지된 계좌를 ACTIVE 상태로 되돌립니다.
+            </p>
+            <div className="bg-warning-bg text-warning px-3.5 py-2.5 rounded text-[12px] mb-4">
+              ⚠ 계좌 상태만 복구됩니다. 봇은 자동으로 재시작되지 않으므로 필요 시 봇 관리에서 개별 시작해야 합니다.
+            </div>
+            <div className="flex justify-end gap-2 pt-4 border-t border-border mt-6">
+              <button onClick={() => setShowClearHaltModal(false)} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-transparent text-text-muted border border-border cursor-pointer hover:bg-surface-hover">취소</button>
+              <button onClick={handleClearHalt} className="px-4 py-2 rounded-lg text-[13px] font-medium bg-positive text-on-primary border-none cursor-pointer hover:bg-positive-hover">거래 재개 확인</button>
             </div>
           </div>
         </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -58,7 +58,10 @@ const DISPLAY_CONFIGS: DisplayConfig[] = [
 
 export default function Settings() {
   const { data: status, isLoading: statusLoading } = useSystemStatus()
-  const { data: accounts, isLoading: accountsLoading } = useAccounts()
+  // CLI/다른 세션의 system halt/clear-halt를 설정 화면 상태에 반영하기 위해 30초 폴링.
+  const { data: accounts, isLoading: accountsLoading } = useAccounts(undefined, {
+    refetchInterval: 30_000,
+  })
   const haltMutation = useHaltSystem()
   const clearHaltMutation = useClearHaltSystem()
   const { data: configs } = useConfigs()

--- a/frontend/src/types/system.ts
+++ b/frontend/src/types/system.ts
@@ -1,13 +1,13 @@
 /**
  * System 도메인 타입.
  *
- * generated StatusResponse는 trading_status를 string | null로 선언하므로
- * 프론트엔드에서 유니온 리터럴로 명시한다.
+ * 전역 거래 상태는 SSOT가 아니다. 시스템 정지/재개 상태는
+ * `useAccounts()`로 받아온 계좌별 status (active/suspended) 집계로 계산한다.
+ * SSOT: `docs/specs/account/02-design-decisions.md`.
  */
 
 // ── 프론트엔드 전용 타입 ──────────────────────────────────
 export interface SystemStatus {
-  trading_status: 'ACTIVE' | 'HALTED'
   uptime_seconds: number
   running_bots: number
   version: string


### PR DESCRIPTION
Closes #1214
Refs #1211 (parent epic), depends on #1213 (PR #1237)

## Summary
- API client: `setKillSwitch` 제거 → `haltSystem` + `clearHaltSystem` (분리 라우트 호출).
- Hook: `useKillSwitch` 제거 → `useHaltSystem` + `useClearHaltSystem`. mutation onSuccess에서 `['accounts']` + `['system']` query invalidate.
- Settings page: `trading_status` 의존 제거 → `useAccounts({}, {refetchInterval: 30_000})` 기반 active/suspended counting. accounts loading 중 중립 상태 표시. 거래 재개 confirm에 "봇 자동 재시작 안 됨" 명시.
- Header: 동일 useAccounts 기반 dot/문구. 30초 polling.
- Types: `frontend/src/types/system.ts`에서 manual `trading_status` 필드 제거.
- `useAccounts` 시그니처 확장: optional `{ refetchInterval?: number }` 옵션.

## Restoration
이 PR은 #1213 PR #1237 머지 후 깨진 dashboard halt/clear-halt 버튼을 복구합니다 (transitional fragility 해소).

## Test Plan
- `cd frontend && npm install && npm run build` — PASS (vite + tsc)
- `cd frontend && npm run lint` — pre-existing 이슈만 (변경 파일 무관)
- legacy grep (`/api/system/kill-switch`, `/api/system/activate`, `setKillSwitch`, `useKillSwitch`, `action: 'halt' | 'activate'`, `trading_status`): 모두 0건
- 신규 표면: `haltSystem|clearHaltSystem|useHaltSystem|useClearHaltSystem` 다수, `/api/system/halt|/api/system/clear-halt` 각 1건
- useAccounts 기반 계산 hit (Settings + Header)
- refetchInterval 30_000ms (Settings + Header) 명시 → 외부 halt/clear-halt 변경 30초 내 반영

## Codex Branch Review
- attempt 1: FAIL — useAccounts polling 누락. 수정.
- attempt 2: PASS — 변경 정합 + 타입/린트 OK.

## Plan Preflight
rev1 split-issue (false positive, 워킹트리 stale) → rev2 revise → rev3 revise → rev4 approve-implement.