### PR TITLE
feat(account): add account_id scoping helper with runtime/creation policy split

### DIFF
--- a/docs/specs/account/02-design-decisions.md
+++ b/docs/specs/account/02-design-decisions.md
@@ -103,6 +103,26 @@ ante init [--member-id owner] [--name Owner] [--dir <경로>]
 
 > 상세 init 계약 (생성 산출물·멱등성·플래그)은 [cli/03-commands.md](../cli/03-commands.md#ante-init--시스템-초기-설정) 참조.
 
+### D-ACC-08: Account ID 계약 (runtime/creation 정책 분리)
+
+**문제**: account-scoped 데이터/이벤트/명령에서 빈 문자열, ``None``,
+``"default"`` 같은 fallback 값이 흘러들 때 cross-module 회귀가 발생한다.
+또한 ``ante init``이 자동 생성하는 ``"test"`` 계좌는 runtime valid이지만
+사용자가 같은 ID로 새 계좌를 만들 수 있어서는 안 된다.
+
+**결정**: runtime invalid와 creation invalid를 분리한 helper 모듈
+``ante.account.scoping``을 도입하고 본 helper를 모든 account-scoped
+진입점의 SSOT로 삼는다.
+
+- **runtime invalid**: ``None``/``""``/``"default"``/패턴 위반 — 모든 시점에서 거부
+- **creation invalid**: 위에 더해 ``"test"`` 추가 거부 (bootstrap seed 전용)
+- **bootstrap 우회**: ``AccountService.create_default_test_account``가
+  ``create(_bootstrap=True)``로 helper를 우회. 이 경로 외에는 우회 불가
+
+상세 계약과 helper API는 [14-account-id-contract.md](14-account-id-contract.md)
+참조. 후속 적용은 #1217 (Trade/Treasury), #1218 (CLI/Web/IPC),
+#1219 (Event/EventBus)에서 반영한다.
+
 ### D-ACC-07: Account lifecycle cold-path contract
 
 **결정**: 계좌 구조 변경은 서버 정지 상태에서만 허용한다. 서버 실행 중에는

--- a/docs/specs/account/02-design-decisions.md
+++ b/docs/specs/account/02-design-decisions.md
@@ -117,7 +117,10 @@ ante init [--member-id owner] [--name Owner] [--dir <경로>]
 - **runtime invalid**: ``None``/``""``/``"default"``/패턴 위반 — 모든 시점에서 거부
 - **creation invalid**: 위에 더해 ``"test"`` 추가 거부 (bootstrap seed 전용)
 - **bootstrap 우회**: ``AccountService.create_default_test_account``가
-  ``create(_bootstrap=True)``로 helper를 우회. 이 경로 외에는 우회 불가
+  private :meth:`AccountService._create_seed_account` helper를 통해서만
+  RESTRICTED 가드를 우회한다. public ``create()`` API에는 우회 플래그가 없고,
+  seed helper는 ``(broker_type, default_account_id)`` pair가 ``BROKER_PRESETS``
+  와 정확히 일치할 때만 통과시킨다 (#1216 P2). 이 경로 외에는 우회 불가
 
 상세 계약과 helper API는 [14-account-id-contract.md](14-account-id-contract.md)
 참조. 후속 적용은 #1217 (Trade/Treasury), #1218 (CLI/Web/IPC),

--- a/docs/specs/account/03-data-model.md
+++ b/docs/specs/account/03-data-model.md
@@ -62,7 +62,7 @@ class Account:
 | 필드 | 필수 | 기본값 | 수정 | 설명 |
 |------|------|--------|:----:|------|
 | **식별** | | | | |
-| `account_id` | O | — | 불가 | 고유 식별자 (영문+숫자+하이픈, 3–30자) |
+| `account_id` | O | — | 불가 | 고유 식별자 (영문+숫자+하이픈, 3–30자). 형식·정책 SSOT는 [14-account-id-contract.md](14-account-id-contract.md) |
 | `name` | O | — | 가능 | 사용자에게 표시되는 이름 |
 | **시장** | | | | |
 | `exchange` | O | — | 불가 | 대상 거래소 코드 (KRX, NYSE, NASDAQ, TEST) |

--- a/docs/specs/account/04-account-service.md
+++ b/docs/specs/account/04-account-service.md
@@ -15,7 +15,7 @@ AccountService(db: Database, eventbus: EventBus)
 | 메서드 | 파라미터 | 반환값 | 설명 |
 |--------|----------|--------|------|
 | `initialize` | — | `None` | 스키마 생성 + DB에서 계좌 목록 로드 |
-| `create` | `account: Account` | `Account` | 계좌 생성. **cold-path 전용**. account_id 형식/정책 검증은 [`validate_new_account_id`](14-account-id-contract.md) helper에 위임 (``"test"``, ``"default"``, ``None``, ``""``, 패턴 위반 거부). account_id 중복 시 `AccountAlreadyExistsError`. broker_type 유효성 검증. 내부 키워드 `_bootstrap=True`는 :meth:`create_default_test_account` 전용으로 helper를 우회한다 |
+| `create` | `account: Account` | `Account` | 계좌 생성. **cold-path 전용**. account_id 형식/정책 검증은 [`validate_new_account_id`](14-account-id-contract.md) helper에 위임 (``"test"``, ``"default"``, ``None``, ``""``, 패턴 위반 거부). 우회 플래그를 노출하지 않으므로 외부 호출자는 RESTRICTED ( ``"test"`` ) 예약어를 신규 생성할 수 없다 (#1216 P2). account_id 중복 시 `AccountAlreadyExistsError`. broker_type 유효성 검증. seed 자동 생성은 :meth:`create_default_test_account` 가 private helper :meth:`_create_seed_account` 를 통해서만 수행한다 |
 | `get` | `account_id: str` | `Account` | 계좌 조회. 없으면 `AccountNotFoundError`. DELETED 상태도 조회 가능 |
 | `get_sync` | `account_id: str` | `Account \| None` | 인메모리 캐시에서 동기적으로 계좌 조회. ContextFactory 등 동기 컨텍스트용. 없으면 `None` 반환 |
 | `list` | `status: AccountStatus \| None` | `list[Account]` | 계좌 목록 조회. status 필터 가능. DELETED 제외가 기본 |

--- a/docs/specs/account/04-account-service.md
+++ b/docs/specs/account/04-account-service.md
@@ -15,7 +15,7 @@ AccountService(db: Database, eventbus: EventBus)
 | 메서드 | 파라미터 | 반환값 | 설명 |
 |--------|----------|--------|------|
 | `initialize` | — | `None` | 스키마 생성 + DB에서 계좌 목록 로드 |
-| `create` | `account: Account` | `Account` | 계좌 생성. **cold-path 전용**. account_id 중복 시 `AccountAlreadyExistsError`. broker_type 유효성 검증 |
+| `create` | `account: Account` | `Account` | 계좌 생성. **cold-path 전용**. account_id 형식/정책 검증은 [`validate_new_account_id`](14-account-id-contract.md) helper에 위임 (``"test"``, ``"default"``, ``None``, ``""``, 패턴 위반 거부). account_id 중복 시 `AccountAlreadyExistsError`. broker_type 유효성 검증. 내부 키워드 `_bootstrap=True`는 :meth:`create_default_test_account` 전용으로 helper를 우회한다 |
 | `get` | `account_id: str` | `Account` | 계좌 조회. 없으면 `AccountNotFoundError`. DELETED 상태도 조회 가능 |
 | `get_sync` | `account_id: str` | `Account \| None` | 인메모리 캐시에서 동기적으로 계좌 조회. ContextFactory 등 동기 컨텍스트용. 없으면 `None` 반환 |
 | `list` | `status: AccountStatus \| None` | `list[Account]` | 계좌 목록 조회. status 필터 가능. DELETED 제외가 기본 |

--- a/docs/specs/account/14-account-id-contract.md
+++ b/docs/specs/account/14-account-id-contract.md
@@ -55,12 +55,17 @@ account-scoped 데이터/이벤트/명령은 모두 본 문서가 정의한 형�
 |---|---|
 | seed account_id | ``BROKER_PRESETS["test"].default_account_id`` (= ``"test"``) |
 | 진입점 | :meth:`AccountService.create_default_test_account` |
-| 우회 메커니즘 | ``AccountService.create(account, _bootstrap=True)`` 내부 키워드 |
+| 우회 메커니즘 | private :meth:`AccountService._create_seed_account` helper (only invoked by ``create_default_test_account``) |
+| pair 가드 | ``(broker_type, default_account_id)`` 가 ``BROKER_PRESETS`` 의 동일 항목과 정확히 일치해야 함 (#1216 P2) |
 | broker_type | ``"test"`` |
 | trading_mode | ``VIRTUAL`` |
 
-다른 모든 호출자(CLI ``ante account create``, Web POST ``/api/accounts``,
-IPC handlers)는 ``_bootstrap`` 인자를 사용해서는 안 된다.
+public :meth:`AccountService.create` API에는 ``_bootstrap`` 같은 우회 플래그가
+**노출되지 않는다**. CLI ``ante account create``, Web POST ``/api/accounts``,
+IPC handlers를 비롯한 모든 외부 호출자는 ``validate_new_account_id`` 의
+RESTRICTED ( ``"test"`` ) / fallback ( ``"default"`` ) 거부를 거치며,
+seed 자동 생성은 :meth:`AccountService.create_default_test_account` 만의
+책임이다 (#1216 P2).
 
 ## fallback 금지 정책
 
@@ -119,8 +124,9 @@ account_id 형식이 올바르지 않습니다: '<value>'. 영문, 숫자, 하�
 
 | 호출 위치 | 함수 | 비고 |
 |---|---|---|
-| ``AccountService.create`` | ``validate_new_account_id`` | bootstrap 경로는 ``_bootstrap=True``로 우회 |
-| ``AccountService.create_default_test_account`` | (우회) | seed account_id ``"test"`` 직접 사용 |
+| ``AccountService.create`` (public) | ``validate_new_account_id`` | 우회 수단 없음. seed 예약어 ``"test"`` 도 무조건 거부 (#1216 P2) |
+| ``AccountService._create_seed_account`` (private) | ``require_account_id`` + ``(broker_type, default_account_id)`` pair 가드 | ``create_default_test_account`` 만의 호출 경로 |
+| ``AccountService.create_default_test_account`` | (private helper 호출) | seed account_id ``"test"`` 직접 사용 |
 
 후속 사용처는 #1217/#1218/#1219 영역이다 (본 이슈 범위 외):
 

--- a/docs/specs/account/14-account-id-contract.md
+++ b/docs/specs/account/14-account-id-contract.md
@@ -1,0 +1,140 @@
+# Account 모듈 세부 설계 - Account ID 계약
+
+> 인덱스: [README.md](README.md) | 호환 문서: [account.md](account.md)
+
+이 문서는 Ante 시스템 전역에서 통용되는 **Account ID 계약**의 SSOT다.
+account-scoped 데이터/이벤트/명령은 모두 본 문서가 정의한 형식·정책을
+따라야 하며, 모듈별 fallback (None, 빈 문자열, ``"default"``) 사용은
+허용되지 않는다.
+
+## 형식
+
+| 항목 | 값 |
+|---|---|
+| 정규식 | ``^[a-zA-Z0-9\-]{3,30}$`` |
+| 길이 | 3 ~ 30자 |
+| 허용 문자 | 영문 대소문자, 숫자, 하이픈 |
+| 인코딩 | UTF-8 ASCII subset |
+| 대소문자 구분 | 구분함 (``"Account"``와 ``"account"``는 별개 ID) |
+
+소스 of truth: ``ante.account.scoping.ACCOUNT_ID_PATTERN``.
+
+## Runtime invalid (어떤 시점에도 거부)
+
+다음 값은 account-scoped 데이터/이벤트/명령에서 **항상** invalid이다.
+``ante.account.scoping.is_invalid_account_id``가 ``True``를 반환하고,
+``require_account_id``는 :class:`InvalidAccountIdError`를 raise한다.
+
+- ``None``
+- 빈 문자열 ``""``
+- ``ante.account.scoping.INVALID_RUNTIME_ACCOUNT_IDS`` 멤버:
+  - ``"default"``
+- ``ACCOUNT_ID_PATTERN``과 불일치하는 모든 값
+
+> ``"default"``는 fallback 예약어이므로 신규 생성도, runtime 사용도
+> 불가하다.
+
+## 신규 생성 제한 (creation 시점만 거부)
+
+신규 Account 생성에서는 위 runtime invalid에 더해
+``ante.account.scoping.RESTRICTED_NEW_ACCOUNT_IDS`` 멤버를 추가로 거부한다.
+
+- ``"test"`` — bootstrap seed 전용. ``ante init`` →
+  :meth:`AccountService.create_default_test_account`로만 생성된다.
+
+따라서 ``"test"``는 **runtime valid**이지만 **creation invalid**이다.
+``is_invalid_account_id("test")``는 ``False``,
+``validate_new_account_id("test")``는 :class:`InvalidAccountIdError`를 raise.
+
+## Bootstrap seed
+
+``ante init``이 자동 생성하는 ``"test"`` 계좌는 본 helper를 우회하는
+**유일한** 경로다.
+
+| 항목 | 값 |
+|---|---|
+| seed account_id | ``BROKER_PRESETS["test"].default_account_id`` (= ``"test"``) |
+| 진입점 | :meth:`AccountService.create_default_test_account` |
+| 우회 메커니즘 | ``AccountService.create(account, _bootstrap=True)`` 내부 키워드 |
+| broker_type | ``"test"`` |
+| trading_mode | ``VIRTUAL`` |
+
+다른 모든 호출자(CLI ``ante account create``, Web POST ``/api/accounts``,
+IPC handlers)는 ``_bootstrap`` 인자를 사용해서는 안 된다.
+
+## fallback 금지 정책
+
+account-scoped 데이터/이벤트는 fallback 값을 **저장하거나 발행하지
+않는다**. 다음 경로는 모두 ``require_account_id``로 진입 시점에서
+검증되어야 한다 (후속 #1217/#1218/#1219에서 반영).
+
+- account-scoped 명령: ``ante bot/treasury/account ...`` 등
+  ``--account`` / ``--account-id`` 옵션을 받는 명령
+- account-scoped 이벤트: ``AccountSuspendedEvent``, ``OrderFilledEvent``,
+  ``BotStartedEvent`` 등 ``account_id`` 필드를 가진 이벤트
+- account-scoped 캐시 키 / DB row 식별자
+
+violations:
+
+| 잘못된 패턴 | 올바른 패턴 |
+|---|---|
+| ``account_id = config.get("account_id", "default")`` | ``account_id = require_account_id(config.get("account_id"), context="...")``  |
+| ``account_id = account_id or ""`` | ``account_id = require_account_id(account_id, context="...")`` |
+| 빈 문자열을 wildcard로 해석 | wildcard 의미가 필요하면 별도 sentinel 도입 (1.0 범위 외) |
+
+## Helper API
+
+소스: ``src/ante/account/scoping.py``.
+
+```python
+from ante.account.scoping import (
+    ACCOUNT_ID_PATTERN,           # re.Pattern[str]
+    INVALID_RUNTIME_ACCOUNT_IDS,  # frozenset[str] = {"default"}
+    RESTRICTED_NEW_ACCOUNT_IDS,   # frozenset[str] = {"test"}
+    is_invalid_account_id,        # (str | None) -> bool
+    require_account_id,           # (str | None, *, context: str = "") -> str
+    validate_new_account_id,      # (str | None) -> str
+)
+```
+
+| 함수 | 사용 시점 | 거부 대상 | 예외 |
+|---|---|---|---|
+| ``is_invalid_account_id`` | runtime branch (boolean check만 필요할 때) | ``None``/``""``/``"default"``/패턴 위반 | — (bool 반환) |
+| ``require_account_id`` | account-scoped 명령/이벤트/캐시 진입점 | 위와 동일 | :class:`InvalidAccountIdError` |
+| ``validate_new_account_id`` | 신규 Account 생성 (cold-path) | 위 + ``"test"`` | :class:`InvalidAccountIdError` |
+
+### 메시지 형식 보존
+
+``validate_new_account_id``의 형식 위반 메시지는 기존
+``AccountService.create``의 ``InvalidAccountIdError`` 형식을 보존한다:
+
+```
+account_id 형식이 올바르지 않습니다: '<value>'. 영문, 숫자, 하이픈만 허용하며 3~30자여야 합니다.
+```
+
+이 형식은 ``ante account create`` CLI 표면에서 ``str(e)``로 그대로
+노출되므로 수정하면 사용자/Agent의 에러 처리 표면이 깨진다.
+
+## 사용처 (1.0)
+
+| 호출 위치 | 함수 | 비고 |
+|---|---|---|
+| ``AccountService.create`` | ``validate_new_account_id`` | bootstrap 경로는 ``_bootstrap=True``로 우회 |
+| ``AccountService.create_default_test_account`` | (우회) | seed account_id ``"test"`` 직접 사용 |
+
+후속 사용처는 #1217/#1218/#1219 영역이다 (본 이슈 범위 외):
+
+- **#1217 (Trade/Treasury)** — `account_id` 진입점에서 ``require_account_id``
+  호출, fallback (``"default"``, ``""``) 제거.
+- **#1218 (CLI/Web/IPC)** — account-scoped 명령/엔드포인트 진입점에서
+  ``require_account_id`` 호출.
+- **#1219 (Event/EventBus)** — account-scoped 이벤트 발행 직전
+  ``require_account_id`` 호출, 구독 측 fallback 제거.
+
+## 테스트 게이트
+
+| 테스트 파일 | 보장 |
+|---|---|
+| ``tests/unit/test_account_scoping.py`` | helper 12+ case (runtime/creation 정책 분리, 메시지 형식, ``"test"`` runtime valid / creation invalid) |
+| ``tests/unit/test_account.py`` | ``AccountService.create``가 helper를 사용함 (``"default"``/``""``/``"test"`` 거부, bootstrap 경로 통과, 메시지 형식 보존) |
+| ``tests/unit/test_cli_account_integration.py`` | CLI ``ante account create`` 메시지 형식 보존 (``str(e)`` contract) |

--- a/docs/specs/account/README.md
+++ b/docs/specs/account/README.md
@@ -25,3 +25,4 @@
 | [10-web-api.md](10-web-api.md) | Web API 엔드포인트 |
 | [11-scope-out.md](11-scope-out.md) | Scope Out (1.0에서 제외) |
 | [13-cross-module-notes.md](13-cross-module-notes.md) | 타 모듈 설계 시 참고 |
+| [14-account-id-contract.md](14-account-id-contract.md) | Account ID 형식·정책 계약 (helper SSOT) |

--- a/docs/specs/account/account.md
+++ b/docs/specs/account/account.md
@@ -24,6 +24,7 @@
 | [10-web-api.md](10-web-api.md) | Web API 엔드포인트 |
 | [11-scope-out.md](11-scope-out.md) | Scope Out (1.0에서 제외) |
 | [13-cross-module-notes.md](13-cross-module-notes.md) | 타 모듈 설계 시 참고 |
+| [14-account-id-contract.md](14-account-id-contract.md) | Account ID 형식·정책 계약 (helper SSOT) |
 
 ## 개요
 
@@ -64,6 +65,14 @@
 ### D-ACC-07: Account lifecycle cold-path contract
 
 상세 내용: [02-design-decisions.md](02-design-decisions.md)
+
+### D-ACC-08: Account ID 계약 (runtime/creation 정책 분리)
+
+상세 내용: [02-design-decisions.md](02-design-decisions.md), helper 계약: [14-account-id-contract.md](14-account-id-contract.md)
+
+## Account ID 계약
+
+상세 내용: [14-account-id-contract.md](14-account-id-contract.md)
 
 ## 데이터 모델
 

--- a/src/ante/account/__init__.py
+++ b/src/ante/account/__init__.py
@@ -13,22 +13,36 @@ from ante.account.errors import (
 )
 from ante.account.models import Account, AccountStatus, BrokerPreset, TradingMode
 from ante.account.presets import BROKER_PRESETS
+from ante.account.scoping import (
+    ACCOUNT_ID_PATTERN,
+    INVALID_RUNTIME_ACCOUNT_IDS,
+    RESTRICTED_NEW_ACCOUNT_IDS,
+    is_invalid_account_id,
+    require_account_id,
+    validate_new_account_id,
+)
 from ante.account.service import AccountService
 
 __all__ = [
+    "ACCOUNT_ID_PATTERN",
     "Account",
     "AccountAlreadyExistsError",
     "AccountDeletedException",
     "AccountError",
     "AccountImmutableFieldError",
     "AccountNotFoundError",
-    "AccountSuspendedError",
-    "InvalidAccountIdError",
     "AccountService",
     "AccountStatus",
+    "AccountSuspendedError",
     "BROKER_PRESETS",
     "BrokerPreset",
+    "INVALID_RUNTIME_ACCOUNT_IDS",
+    "InvalidAccountIdError",
     "InvalidBrokerTypeError",
     "MissingCredentialsError",
+    "RESTRICTED_NEW_ACCOUNT_IDS",
     "TradingMode",
+    "is_invalid_account_id",
+    "require_account_id",
+    "validate_new_account_id",
 ]

--- a/src/ante/account/scoping.py
+++ b/src/ante/account/scoping.py
@@ -80,7 +80,7 @@ def require_account_id(account_id: str | None, *, context: str = "") -> str:
         prefix = f"({context}) " if context else ""
         raise InvalidAccountIdError(
             f"{prefix}유효한 account_id가 필요합니다: {account_id!r}. "
-            "fallback (default, '', None, 'test')은 사용할 수 없습니다."
+            "fallback (default, '', None) 또는 형식 위반 값은 사용할 수 없습니다."
         )
     return account_id  # type: ignore[return-value]
 

--- a/src/ante/account/scoping.py
+++ b/src/ante/account/scoping.py
@@ -1,0 +1,128 @@
+"""Account ID scoping helper — fallback 금지, runtime/creation 정책 분리.
+
+이 모듈은 Account ID 계약(`docs/specs/account/14-account-id-contract.md`)의
+SSOT 진입점이다. account-scoped 데이터/이벤트/명령에서 fallback (None,
+빈 문자열, ``"default"``) 사용을 차단하고, 신규 계좌 생성에서는 bootstrap
+seed 예약어(``"test"``)도 추가로 거부한다.
+
+핵심 함수
+~~~~~~~~~
+
+- :func:`is_invalid_account_id` — runtime 시점 빠른 판정. ``"test"``는
+  bootstrap 계좌이므로 runtime valid이다.
+- :func:`require_account_id` — invalid면 :class:`InvalidAccountIdError`
+  raise. fallback 금지 정책의 진입점이다.
+- :func:`validate_new_account_id` — 신규 계좌 생성 정책 (요구 형식 +
+  RESTRICTED 거부). bootstrap seed 경로(``create_default_test_account``)는
+  helper를 우회한다.
+
+상세 계약은 ``docs/specs/account/14-account-id-contract.md``를 참조한다.
+"""
+
+from __future__ import annotations
+
+import re
+
+from ante.account.errors import InvalidAccountIdError
+
+# Account ID 형식: 영문/숫자/하이픈, 3~30자.
+ACCOUNT_ID_PATTERN: re.Pattern[str] = re.compile(r"^[a-zA-Z0-9\-]{3,30}$")
+
+# Runtime invalid: account-scoped 데이터/이벤트는 절대 가질 수 없는 값.
+# ``"default"``는 fallback 예약어로 어떤 시점에도 유효하지 않다.
+INVALID_RUNTIME_ACCOUNT_IDS: frozenset[str] = frozenset({"default"})
+
+# 신규 계좌 생성에서만 거부: bootstrap seed로만 허용한다.
+# ``"test"``는 ``ante init`` → ``create_default_test_account`` 경로로만
+# 생성되며, 사용자/Agent가 명시적으로 새로 만들 수는 없다.
+RESTRICTED_NEW_ACCOUNT_IDS: frozenset[str] = frozenset({"test"})
+
+
+def is_invalid_account_id(account_id: str | None) -> bool:
+    """runtime-invalid 판정.
+
+    다음 중 하나면 ``True``:
+
+    - ``None`` 또는 빈 문자열
+    - ``INVALID_RUNTIME_ACCOUNT_IDS``에 포함 (``"default"``)
+    - ``ACCOUNT_ID_PATTERN``과 불일치
+
+    ``"test"``는 bootstrap 계좌로 runtime valid이므로 ``False``를 반환한다.
+    """
+    if account_id is None or account_id == "":
+        return True
+    if account_id in INVALID_RUNTIME_ACCOUNT_IDS:
+        return True
+    if not ACCOUNT_ID_PATTERN.fullmatch(account_id):
+        return True
+    return False
+
+
+def require_account_id(account_id: str | None, *, context: str = "") -> str:
+    """invalid면 :class:`InvalidAccountIdError` raise. valid면 그대로 반환.
+
+    fallback 금지 정책의 진입점이다. account-scoped 명령/이벤트/캐시 키
+    경로에서 호출하여 ``None``/``""``/``"default"``/패턴 위반 값이 도달
+    하지 못하도록 한다.
+
+    Args:
+        account_id: 검증할 account_id.
+        context: 에러 메시지에 부착할 호출 위치 식별자.
+            예: ``"trade.submit_order"``, ``"treasury.deposit"``.
+
+    Returns:
+        검증된 account_id. type narrow를 위해 ``str``로 반환된다.
+
+    Raises:
+        InvalidAccountIdError: ``is_invalid_account_id``가 ``True``일 때.
+    """
+    if is_invalid_account_id(account_id):
+        prefix = f"({context}) " if context else ""
+        raise InvalidAccountIdError(
+            f"{prefix}유효한 account_id가 필요합니다: {account_id!r}. "
+            "fallback (default, '', None, 'test')은 사용할 수 없습니다."
+        )
+    return account_id  # type: ignore[return-value]
+
+
+def validate_new_account_id(account_id: str | None) -> str:
+    """신규 Account 생성 정책 검증.
+
+    형식 검사(:data:`ACCOUNT_ID_PATTERN`)와 RESTRICTED 거부
+    (:data:`RESTRICTED_NEW_ACCOUNT_IDS`, :data:`INVALID_RUNTIME_ACCOUNT_IDS`)
+    를 모두 수행한다. bootstrap seed (``"test"``) 경로는 본 helper를 우회
+    해야 한다 (``AccountService.create_default_test_account``).
+
+    형식 위반 메시지는 기존 ``AccountService.create`` 메시지 형식을 보존한다
+    (CLI ``str(e)`` contract: ``ante account create`` 표면 메시지).
+
+    Args:
+        account_id: 검증할 account_id.
+
+    Returns:
+        검증된 account_id.
+
+    Raises:
+        InvalidAccountIdError: 형식 위반, 또는 RESTRICTED/INVALID_RUNTIME
+            예약어와 일치할 때.
+    """
+    if account_id is None or account_id == "":
+        raise InvalidAccountIdError(
+            f"account_id 형식이 올바르지 않습니다: '{account_id}'. "
+            "영문, 숫자, 하이픈만 허용하며 3~30자여야 합니다."
+        )
+    if account_id in RESTRICTED_NEW_ACCOUNT_IDS:
+        raise InvalidAccountIdError(
+            f"account_id '{account_id}'는 ante init이 생성하는 시드 계좌로 "
+            "예약되어 있어 신규 생성이 불가합니다."
+        )
+    if account_id in INVALID_RUNTIME_ACCOUNT_IDS:
+        raise InvalidAccountIdError(
+            f"account_id '{account_id}'는 fallback 예약어로 신규 생성이 불가합니다."
+        )
+    if not ACCOUNT_ID_PATTERN.fullmatch(account_id):
+        raise InvalidAccountIdError(
+            f"account_id 형식이 올바르지 않습니다: '{account_id}'. "
+            "영문, 숫자, 하이픈만 허용하며 3~30자여야 합니다."
+        )
+    return account_id

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -142,21 +142,19 @@ class AccountService:
 
     # ── CRUD ──────────────────────────────────────────
 
-    async def create(self, account: Account, *, _bootstrap: bool = False) -> Account:
+    async def create(self, account: Account) -> Account:
         """계좌 생성. **cold-path 전용**.
+
+        모든 public 호출자(CLI ``ante account create``, web POST 라우트, IPC
+        등)는 ``account_id`` 정책 검증( :func:`validate_new_account_id` )을 반드시
+        통과해야 한다. RESTRICTED seed 예약어( ``"test"`` )와 fallback 예약어
+        ( ``"default"`` )는 이 경로에서 우회 수단 없이 차단된다. Bootstrap seed
+        계좌 자동 생성은 별도의 private helper :meth:`_create_seed_account`
+        (only invoked by :meth:`create_default_test_account`) 가 담당한다 —
+        public ``create()`` API에는 우회 플래그를 노출하지 않는다 (#1216 P2).
 
         Args:
             account: 생성할 계좌 정보.
-            _bootstrap: 내부 전용 플래그. ``True``일 때
-                :func:`validate_new_account_id`의 RESTRICTED 거부를 우회해
-                bootstrap seed 계좌 자동 생성을 허용한다. 단, ``broker_type``과
-                ``account_id``가 ``BROKER_PRESETS``의 동일 항목에서 정의된
-                ``(broker_type, default_account_id)`` pair와 정확히 일치해야
-                한다 — 한 preset의 ``default_account_id``를 다른 preset의
-                ``broker_type`` 아래로 끼워 넣어 RESTRICTED 예약어를 우회하는
-                것을 막는다. pair 불일치, seed 형식 위반은
-                ``InvalidAccountIdError``로 차단된다 (#1216).
-                :meth:`create_default_test_account` 외에는 사용하지 않는다.
 
         Returns:
             생성된 Account (created_at, updated_at 포함).
@@ -165,51 +163,98 @@ class AccountService:
             AccountStructuralChangeRequiresStoppedServerError: 서버 실행 중
                 호출됨. 다른 어떤 검사보다 먼저 평가된다 (#1144 invariant S2).
             AccountAlreadyExistsError: 동일 account_id가 이미 존재.
-            InvalidAccountIdError: 일반 경로에서 account_id 형식이 올바르지
-                않거나 ``RESTRICTED_NEW_ACCOUNT_IDS`` (``"test"``) /
-                ``INVALID_RUNTIME_ACCOUNT_IDS`` (``"default"``) 예약어와
-                일치하는 경우. ``_bootstrap=True`` 경로에서도 ``(broker_type,
-                account_id)``가 ``BROKER_PRESETS``의 ``(broker_type,
-                default_account_id)`` pair와 일치하지 않거나 형식 위반이면
-                동일한 예외가 발생한다 (#1216).
+            InvalidAccountIdError: account_id 형식이 올바르지 않거나
+                ``RESTRICTED_NEW_ACCOUNT_IDS`` ( ``"test"`` ) /
+                ``INVALID_RUNTIME_ACCOUNT_IDS`` ( ``"default"`` ) 예약어와
+                일치하는 경우.
             InvalidBrokerTypeError: broker_type이 프리셋에 정의되지 않음.
             MissingCredentialsError: 필수 credentials 키 누락.
         """
         # 런타임 cold-path 가드(invariant S2): 다른 어떤 검사보다 먼저 평가.
+        self._guard_cold_path_create()
+
+        # account_id 형식 + 정책 검증.
+        # public 경로는 validate_new_account_id로 형식 + RESTRICTED + fallback
+        # 거부를 모두 강제한다. seed bootstrap은 _create_seed_account를 통해서만
+        # 가능하며 그 helper가 별도의 (broker_type, default_account_id) pair
+        # 가드를 적용한다 (#1216 P2).
+        # docs/specs/account/14-account-id-contract.md 참조.
+        validate_new_account_id(account.account_id)
+
+        return await self._persist_account(account)
+
+    async def _create_seed_account(self, account: Account) -> Account:
+        """Bootstrap seed 계좌 생성 (**private**).
+
+        :meth:`create_default_test_account` 전용 진입점. public ``create()`` API
+        에 ``_bootstrap`` 플래그를 노출하지 않기 위해 별도 private helper로
+        캡슐화한다. ``broker_type`` 과 ``account_id`` 가 ``BROKER_PRESETS`` 의
+        동일 항목에서 정의된 ``(broker_type, default_account_id)`` pair와
+        정확히 일치할 때만 허용한다 — 한 preset의 ``default_account_id`` 를 다른
+        preset의 ``broker_type`` 아래로 끼워 넣어 RESTRICTED 예약어( ``"test"`` )
+        를 비-test broker 아래에 저장하는 우회를 막는다 (#1216 P2).
+
+        형식 검증( :func:`require_account_id` )은 ``BROKER_PRESETS`` 자체가 잘못
+        변경되는 경우에 대비한 추가 가드로 적용한다. cold-path 가드와 broker_type
+        / credentials 검증 / DB insert는 public ``create()`` 와 동일한 조건을
+        적용한다 ( :meth:`_persist_account` 공유).
+
+        Raises:
+            AccountStructuralChangeRequiresStoppedServerError: 서버 실행 중
+                호출됨 (invariant S2).
+            InvalidAccountIdError: ``(broker_type, account_id)`` 가
+                ``BROKER_PRESETS`` 의 어느 ``(broker_type, default_account_id)``
+                pair와도 일치하지 않거나, pair는 일치해도 형식 위반인 경우.
+            AccountAlreadyExistsError, InvalidBrokerTypeError,
+            MissingCredentialsError: :meth:`_persist_account` 와 동일.
+        """
+        # 런타임 cold-path 가드(invariant S2): 다른 어떤 검사보다 먼저 평가.
+        self._guard_cold_path_create()
+
+        # (broker_type, default_account_id) pair 가드 — RESTRICTED 예약어가
+        # 다른 preset의 broker_type 아래로 새는 것을 차단한다 (#1216 P2).
+        preset = BROKER_PRESETS.get(account.broker_type)
+        if preset is None or preset.default_account_id != account.account_id:
+            valid_pairs = [
+                (bt, p.default_account_id) for bt, p in BROKER_PRESETS.items()
+            ]
+            raise InvalidAccountIdError(
+                f"seed 계좌 생성은 (broker_type, default_account_id) pair만 "
+                f"허용합니다: got broker_type={account.broker_type!r}, "
+                f"account_id={account.account_id!r}; valid pairs={valid_pairs}"
+            )
+        # pair 일치해도 형식 검증은 그대로
+        # (BROKER_PRESETS가 잘못 변경되더라도 가드).
+        require_account_id(account.account_id, context="bootstrap_seed")
+
+        return await self._persist_account(account)
+
+    def _guard_cold_path_create(self) -> None:
+        """``create*()`` 진입 시 런타임 cold-path 가드 (invariant S2).
+
+        ``create()`` 와 ``_create_seed_account()`` 가 동일 메시지/예외 의미론으로
+        가장 먼저 평가하기 위한 공유 helper.
+        """
         if self._runtime_started:
             raise AccountStructuralChangeRequiresStoppedServerError(
                 "계좌 생성은 cold-path 전용입니다. "
                 "서버를 정지한 뒤 ante account create로 수행하세요."
             )
 
-        # account_id 형식 + 정책 검증.
-        # 일반 경로: validate_new_account_id로 형식 + RESTRICTED 거부.
-        # bootstrap 경로: (broker_type, default_account_id) pair가 BROKER_PRESETS와
-        #   정확히 일치할 때만 허용한다. account_id가 어떤 preset의
-        #   default_account_id이기만 해도 되는 건 부족하다 — 호출자가
-        #   account_id='test' + broker_type='kis-domestic'처럼 서로 다른 preset의
-        #   값을 조합해 RESTRICTED ('test') 예약어를 비-test broker 아래에 저장
-        #   하는 우회를 막아야 하기 때문이다 (#1216 P2).
-        #   형식 검증(require_account_id)은 BROKER_PRESETS 자체가 잘못 바뀌는
-        #   경우에 대비한 추가 가드로 그대로 적용한다.
-        # docs/specs/account/14-account-id-contract.md 참조.
-        if not _bootstrap:
-            validate_new_account_id(account.account_id)
-        else:
-            preset = BROKER_PRESETS.get(account.broker_type)
-            if preset is None or preset.default_account_id != account.account_id:
-                valid_pairs = [
-                    (bt, p.default_account_id) for bt, p in BROKER_PRESETS.items()
-                ]
-                raise InvalidAccountIdError(
-                    f"_bootstrap=True는 (broker_type, default_account_id) pair만 "
-                    f"허용합니다: got broker_type={account.broker_type!r}, "
-                    f"account_id={account.account_id!r}; valid pairs={valid_pairs}"
-                )
-            # pair 일치해도 형식 검증은 그대로
-            # (BROKER_PRESETS가 잘못 변경되더라도 가드).
-            require_account_id(account.account_id, context="bootstrap_seed")
+    async def _persist_account(self, account: Account) -> Account:
+        """``account_id`` 검증 이후 공통 검증 + DB insert (private helper).
 
+        ``create()`` 와 ``_create_seed_account()`` 가 공유한다. 진입 전 호출자가
+        이미 ``_guard_cold_path_create()`` 와 account_id 정책 검증을 끝냈다고
+        가정한다 — 이 helper는 ``account_id`` 정책에 대해서는 어떤 가드도
+        적용하지 않는다.
+
+        Raises:
+            AccountAlreadyExistsError: 동일 account_id가 메모리/DELETED DB
+                상태로 이미 존재.
+            InvalidBrokerTypeError: broker_type이 프리셋에 정의되지 않음.
+            MissingCredentialsError: 필수 credentials 키 누락.
+        """
         if account.account_id in self._accounts:
             raise AccountAlreadyExistsError(
                 f"계좌 '{account.account_id}'가 이미 존재합니다."
@@ -795,10 +840,11 @@ class AccountService:
     async def create_default_test_account(self) -> Account:
         """테스트 계좌 자동 생성. 이미 존재하면 기존 계좌 반환.
 
-        bootstrap seed 경로이므로 ``validate_new_account_id``의 RESTRICTED
-        거부(``"test"``)를 우회한다. ``BROKER_PRESETS["test"].default_account_id``
-        가 ``account_id`` SSOT이며, 이 메서드가 helper를 우회할 수 있는
-        유일한 진입점이다 (``_bootstrap=True``).
+        bootstrap seed 경로이므로 ``validate_new_account_id`` 의 RESTRICTED
+        거부( ``"test"`` )가 적용되지 않는 private helper
+        :meth:`_create_seed_account` 를 통해 생성한다.
+        ``BROKER_PRESETS["test"].default_account_id`` 가 ``account_id`` SSOT 이며,
+        이 메서드가 seed helper를 호출하는 유일한 진입점이다 (#1216 P2).
         """
         if "test" in self._accounts:
             return self._accounts["test"]
@@ -818,7 +864,7 @@ class AccountService:
             buy_commission_rate=preset.buy_commission_rate,
             sell_commission_rate=preset.sell_commission_rate,
         )
-        return await self.create(account, _bootstrap=True)
+        return await self._create_seed_account(account)
 
 
 # ── 유틸리티 ──────────────────────────────────────────

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -17,12 +17,13 @@ from ante.account.errors import (
     AccountNotFoundError,
     AccountStructuralChangeRequiresStoppedServerError,
     BrokerReconnectFailedError,
+    InvalidAccountIdError,
     InvalidBrokerTypeError,
     MissingCredentialsError,
 )
 from ante.account.models import Account, AccountStatus, TradingMode
 from ante.account.presets import BROKER_PRESETS
-from ante.account.scoping import validate_new_account_id
+from ante.account.scoping import require_account_id, validate_new_account_id
 
 if TYPE_CHECKING:
     from ante.broker.base import BrokerAdapter
@@ -147,8 +148,11 @@ class AccountService:
         Args:
             account: 생성할 계좌 정보.
             _bootstrap: 내부 전용 플래그. ``True``일 때
-                :func:`validate_new_account_id` 검증을 우회하여 bootstrap
-                seed 계좌(``account_id="test"``) 자동 생성을 허용한다.
+                :func:`validate_new_account_id`의 RESTRICTED 거부를 우회해
+                bootstrap seed 계좌(``BROKER_PRESETS[*].default_account_id``)
+                자동 생성을 허용한다. seed 화이트리스트 외 값은 여전히
+                ``InvalidAccountIdError``로 차단되며, seed라도 형식 검증
+                (:func:`require_account_id`)은 적용된다 (#1216).
                 :meth:`create_default_test_account` 외에는 사용하지 않는다.
 
         Returns:
@@ -158,10 +162,12 @@ class AccountService:
             AccountStructuralChangeRequiresStoppedServerError: 서버 실행 중
                 호출됨. 다른 어떤 검사보다 먼저 평가된다 (#1144 invariant S2).
             AccountAlreadyExistsError: 동일 account_id가 이미 존재.
-            InvalidAccountIdError: account_id 형식이 올바르지 않거나
-                ``RESTRICTED_NEW_ACCOUNT_IDS`` (``"test"``) /
-                ``INVALID_RUNTIME_ACCOUNT_IDS`` (``"default"``) 예약어
-                (``_bootstrap=False``인 일반 경로 한정).
+            InvalidAccountIdError: 일반 경로에서 account_id 형식이 올바르지
+                않거나 ``RESTRICTED_NEW_ACCOUNT_IDS`` (``"test"``) /
+                ``INVALID_RUNTIME_ACCOUNT_IDS`` (``"default"``) 예약어와
+                일치하는 경우. ``_bootstrap=True`` 경로에서도 account_id가
+                ``BROKER_PRESETS``의 ``default_account_id`` 화이트리스트에
+                없거나 형식 위반이면 동일한 예외가 발생한다 (#1216).
             InvalidBrokerTypeError: broker_type이 프리셋에 정의되지 않음.
             MissingCredentialsError: 필수 credentials 키 누락.
         """
@@ -172,10 +178,25 @@ class AccountService:
                 "서버를 정지한 뒤 ante account create로 수행하세요."
             )
 
-        # account_id 형식 + 정책 검증 (bootstrap seed 경로는 우회).
+        # account_id 형식 + 정책 검증.
+        # 일반 경로: validate_new_account_id로 형식 + RESTRICTED 거부.
+        # bootstrap 경로: BROKER_PRESETS의 default_account_id seed만 허용하고,
+        #   형식 검증(require_account_id)은 그대로 적용한다. 이는 내부 호출자가
+        #   _bootstrap=True로 'default'/''/패턴 위반 등을 슬쩍 통과시키지 못하게
+        #   하는 defense-in-depth 가드다 (#1216).
         # docs/specs/account/14-account-id-contract.md 참조.
         if not _bootstrap:
             validate_new_account_id(account.account_id)
+        else:
+            seed_ids = {p.default_account_id for p in BROKER_PRESETS.values()}
+            if account.account_id not in seed_ids:
+                raise InvalidAccountIdError(
+                    f"_bootstrap=True는 BROKER_PRESETS의 seed account_id만 "
+                    f"허용합니다: got '{account.account_id}', "
+                    f"allowed={sorted(seed_ids)}"
+                )
+            # seed라도 형식은 검증 (BROKER_PRESETS가 잘못 변경되더라도 가드).
+            require_account_id(account.account_id, context="bootstrap_seed")
 
         if account.account_id in self._accounts:
             raise AccountAlreadyExistsError(

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
@@ -18,12 +17,12 @@ from ante.account.errors import (
     AccountNotFoundError,
     AccountStructuralChangeRequiresStoppedServerError,
     BrokerReconnectFailedError,
-    InvalidAccountIdError,
     InvalidBrokerTypeError,
     MissingCredentialsError,
 )
 from ante.account.models import Account, AccountStatus, TradingMode
 from ante.account.presets import BROKER_PRESETS
+from ante.account.scoping import validate_new_account_id
 
 if TYPE_CHECKING:
     from ante.broker.base import BrokerAdapter
@@ -142,11 +141,15 @@ class AccountService:
 
     # ── CRUD ──────────────────────────────────────────
 
-    async def create(self, account: Account) -> Account:
+    async def create(self, account: Account, *, _bootstrap: bool = False) -> Account:
         """계좌 생성. **cold-path 전용**.
 
         Args:
             account: 생성할 계좌 정보.
+            _bootstrap: 내부 전용 플래그. ``True``일 때
+                :func:`validate_new_account_id` 검증을 우회하여 bootstrap
+                seed 계좌(``account_id="test"``) 자동 생성을 허용한다.
+                :meth:`create_default_test_account` 외에는 사용하지 않는다.
 
         Returns:
             생성된 Account (created_at, updated_at 포함).
@@ -155,7 +158,10 @@ class AccountService:
             AccountStructuralChangeRequiresStoppedServerError: 서버 실행 중
                 호출됨. 다른 어떤 검사보다 먼저 평가된다 (#1144 invariant S2).
             AccountAlreadyExistsError: 동일 account_id가 이미 존재.
-            InvalidAccountIdError: account_id 형식이 올바르지 않음.
+            InvalidAccountIdError: account_id 형식이 올바르지 않거나
+                ``RESTRICTED_NEW_ACCOUNT_IDS`` (``"test"``) /
+                ``INVALID_RUNTIME_ACCOUNT_IDS`` (``"default"``) 예약어
+                (``_bootstrap=False``인 일반 경로 한정).
             InvalidBrokerTypeError: broker_type이 프리셋에 정의되지 않음.
             MissingCredentialsError: 필수 credentials 키 누락.
         """
@@ -166,12 +172,10 @@ class AccountService:
                 "서버를 정지한 뒤 ante account create로 수행하세요."
             )
 
-        # account_id 형식 검증
-        if not re.fullmatch(r"[a-zA-Z0-9\-]{3,30}", account.account_id):
-            raise InvalidAccountIdError(
-                f"account_id 형식이 올바르지 않습니다: '{account.account_id}'. "
-                "영문, 숫자, 하이픈만 허용하며 3~30자여야 합니다."
-            )
+        # account_id 형식 + 정책 검증 (bootstrap seed 경로는 우회).
+        # docs/specs/account/14-account-id-contract.md 참조.
+        if not _bootstrap:
+            validate_new_account_id(account.account_id)
 
         if account.account_id in self._accounts:
             raise AccountAlreadyExistsError(
@@ -756,7 +760,13 @@ class AccountService:
     # ── 기본 테스트 계좌 ──────────────────────────────────
 
     async def create_default_test_account(self) -> Account:
-        """테스트 계좌 자동 생성. 이미 존재하면 기존 계좌 반환."""
+        """테스트 계좌 자동 생성. 이미 존재하면 기존 계좌 반환.
+
+        bootstrap seed 경로이므로 ``validate_new_account_id``의 RESTRICTED
+        거부(``"test"``)를 우회한다. ``BROKER_PRESETS["test"].default_account_id``
+        가 ``account_id`` SSOT이며, 이 메서드가 helper를 우회할 수 있는
+        유일한 진입점이다 (``_bootstrap=True``).
+        """
         if "test" in self._accounts:
             return self._accounts["test"]
 
@@ -775,7 +785,7 @@ class AccountService:
             buy_commission_rate=preset.buy_commission_rate,
             sell_commission_rate=preset.sell_commission_rate,
         )
-        return await self.create(account)
+        return await self.create(account, _bootstrap=True)
 
 
 # ── 유틸리티 ──────────────────────────────────────────

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -149,10 +149,13 @@ class AccountService:
             account: 생성할 계좌 정보.
             _bootstrap: 내부 전용 플래그. ``True``일 때
                 :func:`validate_new_account_id`의 RESTRICTED 거부를 우회해
-                bootstrap seed 계좌(``BROKER_PRESETS[*].default_account_id``)
-                자동 생성을 허용한다. seed 화이트리스트 외 값은 여전히
-                ``InvalidAccountIdError``로 차단되며, seed라도 형식 검증
-                (:func:`require_account_id`)은 적용된다 (#1216).
+                bootstrap seed 계좌 자동 생성을 허용한다. 단, ``broker_type``과
+                ``account_id``가 ``BROKER_PRESETS``의 동일 항목에서 정의된
+                ``(broker_type, default_account_id)`` pair와 정확히 일치해야
+                한다 — 한 preset의 ``default_account_id``를 다른 preset의
+                ``broker_type`` 아래로 끼워 넣어 RESTRICTED 예약어를 우회하는
+                것을 막는다. pair 불일치, seed 형식 위반은
+                ``InvalidAccountIdError``로 차단된다 (#1216).
                 :meth:`create_default_test_account` 외에는 사용하지 않는다.
 
         Returns:
@@ -165,9 +168,10 @@ class AccountService:
             InvalidAccountIdError: 일반 경로에서 account_id 형식이 올바르지
                 않거나 ``RESTRICTED_NEW_ACCOUNT_IDS`` (``"test"``) /
                 ``INVALID_RUNTIME_ACCOUNT_IDS`` (``"default"``) 예약어와
-                일치하는 경우. ``_bootstrap=True`` 경로에서도 account_id가
-                ``BROKER_PRESETS``의 ``default_account_id`` 화이트리스트에
-                없거나 형식 위반이면 동일한 예외가 발생한다 (#1216).
+                일치하는 경우. ``_bootstrap=True`` 경로에서도 ``(broker_type,
+                account_id)``가 ``BROKER_PRESETS``의 ``(broker_type,
+                default_account_id)`` pair와 일치하지 않거나 형식 위반이면
+                동일한 예외가 발생한다 (#1216).
             InvalidBrokerTypeError: broker_type이 프리셋에 정의되지 않음.
             MissingCredentialsError: 필수 credentials 키 누락.
         """
@@ -180,22 +184,30 @@ class AccountService:
 
         # account_id 형식 + 정책 검증.
         # 일반 경로: validate_new_account_id로 형식 + RESTRICTED 거부.
-        # bootstrap 경로: BROKER_PRESETS의 default_account_id seed만 허용하고,
-        #   형식 검증(require_account_id)은 그대로 적용한다. 이는 내부 호출자가
-        #   _bootstrap=True로 'default'/''/패턴 위반 등을 슬쩍 통과시키지 못하게
-        #   하는 defense-in-depth 가드다 (#1216).
+        # bootstrap 경로: (broker_type, default_account_id) pair가 BROKER_PRESETS와
+        #   정확히 일치할 때만 허용한다. account_id가 어떤 preset의
+        #   default_account_id이기만 해도 되는 건 부족하다 — 호출자가
+        #   account_id='test' + broker_type='kis-domestic'처럼 서로 다른 preset의
+        #   값을 조합해 RESTRICTED ('test') 예약어를 비-test broker 아래에 저장
+        #   하는 우회를 막아야 하기 때문이다 (#1216 P2).
+        #   형식 검증(require_account_id)은 BROKER_PRESETS 자체가 잘못 바뀌는
+        #   경우에 대비한 추가 가드로 그대로 적용한다.
         # docs/specs/account/14-account-id-contract.md 참조.
         if not _bootstrap:
             validate_new_account_id(account.account_id)
         else:
-            seed_ids = {p.default_account_id for p in BROKER_PRESETS.values()}
-            if account.account_id not in seed_ids:
+            preset = BROKER_PRESETS.get(account.broker_type)
+            if preset is None or preset.default_account_id != account.account_id:
+                valid_pairs = [
+                    (bt, p.default_account_id) for bt, p in BROKER_PRESETS.items()
+                ]
                 raise InvalidAccountIdError(
-                    f"_bootstrap=True는 BROKER_PRESETS의 seed account_id만 "
-                    f"허용합니다: got '{account.account_id}', "
-                    f"allowed={sorted(seed_ids)}"
+                    f"_bootstrap=True는 (broker_type, default_account_id) pair만 "
+                    f"허용합니다: got broker_type={account.broker_type!r}, "
+                    f"account_id={account.account_id!r}; valid pairs={valid_pairs}"
                 )
-            # seed라도 형식은 검증 (BROKER_PRESETS가 잘못 변경되더라도 가드).
+            # pair 일치해도 형식 검증은 그대로
+            # (BROKER_PRESETS가 잘못 변경되더라도 가드).
             require_account_id(account.account_id, context="bootstrap_seed")
 
         if account.account_id in self._accounts:

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -918,25 +918,26 @@ async def test_create_default_test_account_idempotent(service):
     ],
 )
 async def test_create_with_bootstrap_rejects_non_seed(service, bad_id):
-    """``_bootstrap=True``는 BROKER_PRESETS seed account_id만 허용한다.
+    """``_bootstrap=True``는 (broker_type, default_account_id) pair만 허용한다.
 
     내부 호출자가 ``_bootstrap=True``로 'default'/패턴 위반/임의 ID를 슬쩍
-    통과시키지 못하게 막는 defense-in-depth 가드 (#1216).
+    통과시키지 못하게 막는 defense-in-depth 가드 (#1216). 여기서는
+    broker_type='test'(default_account_id='test')와 mismatch인 케이스들이다.
     """
-    account = _make_account(account_id=bad_id)
+    account = _make_account(account_id=bad_id, broker_type="test")
 
     with pytest.raises(InvalidAccountIdError) as exc_info:
         await service.create(account, _bootstrap=True)
 
     assert "_bootstrap=True" in str(exc_info.value)
-    assert "BROKER_PRESETS" in str(exc_info.value)
+    assert "valid pairs" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
 async def test_create_with_bootstrap_rejects_empty(service):
-    """``_bootstrap=True``로 빈 문자열 account_id는 거부된다 (seed 화이트리스트 밖)."""
+    """``_bootstrap=True``로 빈 문자열 account_id는 거부된다 (pair 불일치)."""
     # _make_account의 default 분기로 직접 만들지 못하므로 명시적으로 구성.
-    account = _make_account(account_id="")
+    account = _make_account(account_id="", broker_type="test")
 
     with pytest.raises(InvalidAccountIdError):
         await service.create(account, _bootstrap=True)
@@ -944,7 +945,7 @@ async def test_create_with_bootstrap_rejects_empty(service):
 
 @pytest.mark.asyncio
 async def test_create_with_bootstrap_accepts_seed_test(service):
-    """``_bootstrap=True``로 ``"test"`` (seed)는 통과한다."""
+    """``_bootstrap=True``로 정확한 (test, test) pair는 통과한다."""
     preset = BROKER_PRESETS["test"]
     account = _make_account(
         account_id=preset.default_account_id,
@@ -955,7 +956,85 @@ async def test_create_with_bootstrap_accepts_seed_test(service):
     result = await service.create(account, _bootstrap=True)
 
     assert result.account_id == "test"
+    assert result.broker_type == "test"
     assert result.status == AccountStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_create_with_bootstrap_accepts_seed_kis_domestic(service):
+    """``_bootstrap=True``로 정확한 (kis-domestic, domestic) pair는 통과한다.
+
+    BROKER_PRESETS에 정의된 모든 pair가 동일하게 허용되는지 회귀 방지.
+    """
+    preset = BROKER_PRESETS["kis-domestic"]
+    account = _make_account(
+        account_id=preset.default_account_id,
+        broker_type="kis-domestic",
+        credentials={k: "test" for k in preset.required_credentials},
+    )
+
+    result = await service.create(account, _bootstrap=True)
+
+    assert result.account_id == "domestic"
+    assert result.broker_type == "kis-domestic"
+    assert result.status == AccountStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_create_bootstrap_rejects_seed_id_with_wrong_broker_type(service):
+    """``account_id='test'`` + ``broker_type='kis-domestic'``는 거부된다 (#1216 P2).
+
+    이전 구현은 account_id가 BROKER_PRESETS의 default_account_id set에
+    포함되기만 하면 통과시켜, 호출자가 RESTRICTED 예약어 'test'를
+    비-test broker 아래에 저장하는 우회가 가능했다. 새 가드는
+    (broker_type, default_account_id) pair 정확 일치를 요구한다.
+    """
+    preset = BROKER_PRESETS["kis-domestic"]
+    account = _make_account(
+        account_id="test",  # test preset의 seed
+        broker_type="kis-domestic",  # 그러나 broker_type은 다른 preset
+        credentials={k: "test" for k in preset.required_credentials},
+    )
+
+    with pytest.raises(InvalidAccountIdError) as exc_info:
+        await service.create(account, _bootstrap=True)
+
+    msg = str(exc_info.value)
+    assert "_bootstrap=True" in msg
+    assert "valid pairs" in msg
+    assert "'test'" in msg  # 입력된 account_id가 메시지에 포함
+
+
+@pytest.mark.asyncio
+async def test_create_bootstrap_rejects_cross_pair_domestic_with_test_broker(service):
+    """``account_id='domestic'`` + ``broker_type='test'`` (반대 mismatch)도 거부."""
+    account = _make_account(
+        account_id="domestic",  # kis-domestic preset의 seed
+        broker_type="test",  # 그러나 broker_type은 다른 preset
+        credentials={"app_key": "test", "app_secret": "test"},
+    )
+
+    with pytest.raises(InvalidAccountIdError):
+        await service.create(account, _bootstrap=True)
+
+
+@pytest.mark.asyncio
+async def test_create_bootstrap_rejects_unknown_broker_type(service):
+    """알 수 없는 ``broker_type``은 _bootstrap pair 검증에서 거부된다.
+
+    BROKER_PRESETS.get(broker_type)이 None이므로 InvalidBrokerTypeError가
+    아니라 새 _bootstrap pair 가드가 먼저 InvalidAccountIdError로 차단한다.
+    """
+    account = _make_account(
+        account_id="test",
+        broker_type="bogus-broker",
+        credentials={"app_key": "test", "app_secret": "test"},
+    )
+
+    with pytest.raises(InvalidAccountIdError) as exc_info:
+        await service.create(account, _bootstrap=True)
+
+    assert "_bootstrap=True" in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -46,14 +46,20 @@ async def service(db, eventbus):
 
 
 def _make_account(
-    account_id: str = "test",
+    account_id: str = "main",
     name: str = "테스트",
     exchange: str = "TEST",
     currency: str = "KRW",
     broker_type: str = "test",
     **kwargs,
 ) -> Account:
-    """테스트용 Account 생성 헬퍼."""
+    """테스트용 Account 생성 헬퍼.
+
+    default ``account_id``는 ``"main"``이다. ``"test"``는 bootstrap seed
+    예약어라 :func:`validate_new_account_id`가 신규 생성을 거부하므로
+    직접 helper에서는 ``ante.account.scoping.RESTRICTED_NEW_ACCOUNT_IDS``
+    바깥의 valid ID를 사용한다 (``docs/specs/account/14-account-id-contract.md``).
+    """
     if "credentials" not in kwargs:
         kwargs["credentials"] = {"app_key": "test", "app_secret": "test"}
     return Account(
@@ -75,7 +81,7 @@ async def test_create_account(service):
     account = _make_account()
     result = await service.create(account)
 
-    assert result.account_id == "test"
+    assert result.account_id == "main"
     assert result.name == "테스트"
     assert result.exchange == "TEST"
     assert result.currency == "KRW"
@@ -98,7 +104,7 @@ async def test_create_duplicate_raises(service):
 async def test_create_soft_deleted_duplicate_raises(service):
     """soft-delete된 계좌와 동일 ID로 생성 시 AccountAlreadyExistsError."""
     await service.create(_make_account())
-    await service.delete("test", deleted_by="system")
+    await service.delete("main", deleted_by="system")
 
     # 메모리에서는 제거되었지만 DB에 deleted 상태로 남아 있음
     with pytest.raises(AccountAlreadyExistsError, match="삭제 상태"):
@@ -143,11 +149,11 @@ async def test_create_full_credentials_passes(service):
     )
     result = await service.create(account)
 
-    assert result.account_id == "test"
+    assert result.account_id == "main"
     assert result.credentials["app_key"] == "key1"
 
 
-# ── account_id 형식 검증 ──────────────────────────────
+# ── account_id 형식 검증 (helper SSOT) ────────────────
 
 
 @pytest.mark.asyncio
@@ -163,11 +169,47 @@ async def test_create_full_credentials_passes(service):
     ],
 )
 async def test_create_invalid_account_id_raises(service, bad_id):
-    """형식 미준수 account_id로 생성 시 InvalidAccountIdError."""
+    """형식 미준수 account_id로 생성 시 InvalidAccountIdError.
+
+    형식 위반 메시지 형식은 ``ante account create`` CLI 표면 contract이므로
+    ``validate_new_account_id`` helper에서도 동일하게 보존된다
+    (docs/specs/account/14-account-id-contract.md).
+    """
     account = _make_account(account_id=bad_id)
 
-    with pytest.raises(InvalidAccountIdError):
+    with pytest.raises(InvalidAccountIdError) as exc_info:
         await service.create(account)
+
+    msg = str(exc_info.value)
+    assert "account_id 형식이 올바르지 않습니다" in msg
+    assert "영문, 숫자, 하이픈만 허용하며 3~30자여야 합니다." in msg
+
+
+@pytest.mark.asyncio
+async def test_create_default_account_id_raises(service):
+    """``"default"``는 fallback 예약어로 신규 생성 거부 (#1216)."""
+    account = _make_account(account_id="default")
+
+    with pytest.raises(InvalidAccountIdError) as exc_info:
+        await service.create(account)
+
+    assert "fallback" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_create_test_account_id_raises_for_user(service):
+    """``"test"``는 bootstrap seed 예약어로 사용자 신규 생성 거부 (#1216).
+
+    ``ante init`` 경로(:meth:`AccountService.create_default_test_account`)는
+    내부 ``_bootstrap=True``로 helper를 우회하므로 별도 테스트로 검증한다.
+    """
+    account = _make_account(account_id="test")
+
+    with pytest.raises(InvalidAccountIdError) as exc_info:
+        await service.create(account)
+
+    assert "ante init" in str(exc_info.value)
+    assert "시드 계좌" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -176,14 +218,14 @@ async def test_create_invalid_account_id_raises(service, bad_id):
     [
         "abc",
         "a" * 30,
-        "test",
+        "main",
         "my-account-01",
         "ABC",
         "Test-123",
     ],
 )
 async def test_create_valid_account_id_passes(service, good_id):
-    """형식 준수 account_id로 생성 시 정상 통과."""
+    """형식 준수 + non-RESTRICTED account_id로 생성 시 정상 통과."""
     account = _make_account(account_id=good_id)
     result = await service.create(account)
 
@@ -198,8 +240,8 @@ async def test_get_account(service):
     """계좌 조회 성공."""
     await service.create(_make_account())
 
-    result = await service.get("test")
-    assert result.account_id == "test"
+    result = await service.get("main")
+    assert result.account_id == "main"
 
 
 @pytest.mark.asyncio
@@ -243,11 +285,11 @@ async def test_update_account(service):
     """계좌 부분 수정."""
     await service.create(_make_account())
 
-    result = await service.update("test", name="수정된 이름")
+    result = await service.update("main", name="수정된 이름")
     assert result.name == "수정된 이름"
 
     # DB에서 다시 로드해도 동일
-    fetched = await service.get("test")
+    fetched = await service.get("main")
     assert fetched.name == "수정된 이름"
 
 
@@ -255,10 +297,10 @@ async def test_update_account(service):
 async def test_update_deleted_raises(service):
     """삭제된 계좌 수정 시 에러."""
     await service.create(_make_account())
-    await service.delete("test", deleted_by="system")
+    await service.delete("main", deleted_by="system")
 
     with pytest.raises(AccountDeletedException):
-        await service.update("test", name="변경 시도")
+        await service.update("main", name="변경 시도")
 
 
 # ── 정지/활성화 (suspend / activate) ──────────────────
@@ -268,9 +310,9 @@ async def test_update_deleted_raises(service):
 async def test_suspend_account(service):
     """계좌 정지."""
     await service.create(_make_account())
-    await service.suspend("test", reason="위험 감지", suspended_by="rule-engine")
+    await service.suspend("main", reason="위험 감지", suspended_by="rule-engine")
 
-    account = await service.get("test")
+    account = await service.get("main")
     assert account.status == AccountStatus.SUSPENDED
 
 
@@ -278,10 +320,10 @@ async def test_suspend_account(service):
 async def test_activate_account(service):
     """정지된 계좌 활성화."""
     await service.create(_make_account())
-    await service.suspend("test", reason="테스트", suspended_by="system")
-    await service.activate("test", activated_by="admin")
+    await service.suspend("main", reason="테스트", suspended_by="system")
+    await service.activate("main", activated_by="admin")
 
-    account = await service.get("test")
+    account = await service.get("main")
     assert account.status == AccountStatus.ACTIVE
 
 
@@ -289,30 +331,30 @@ async def test_activate_account(service):
 async def test_activate_deleted_raises(service):
     """삭제된 계좌 활성화 시 에러."""
     await service.create(_make_account())
-    await service.delete("test", deleted_by="system")
+    await service.delete("main", deleted_by="system")
 
     with pytest.raises(AccountDeletedException):
-        await service.activate("test", activated_by="admin")
+        await service.activate("main", activated_by="admin")
 
 
 @pytest.mark.asyncio
 async def test_suspend_deleted_account_raises(service):
     """DELETED 계좌에 suspend 시도 시 AccountDeletedException."""
     await service.create(_make_account())
-    await service.delete("test", deleted_by="system")
+    await service.delete("main", deleted_by="system")
 
     with pytest.raises(AccountDeletedException):
-        await service.suspend("test", reason="테스트", suspended_by="system")
+        await service.suspend("main", reason="테스트", suspended_by="system")
 
 
 @pytest.mark.asyncio
 async def test_delete_already_deleted_account_raises(service):
     """이미 DELETED 계좌에 delete 시도 시 AccountDeletedException."""
     await service.create(_make_account())
-    await service.delete("test", deleted_by="system")
+    await service.delete("main", deleted_by="system")
 
     with pytest.raises(AccountDeletedException):
-        await service.delete("test", deleted_by="system")
+        await service.delete("main", deleted_by="system")
 
 
 # ── 삭제 (delete) ──────────────────────────────────
@@ -322,14 +364,14 @@ async def test_delete_already_deleted_account_raises(service):
 async def test_delete_account(service):
     """계좌 소프트 딜리트."""
     await service.create(_make_account())
-    await service.delete("test", deleted_by="admin")
+    await service.delete("main", deleted_by="admin")
 
     # 기본 목록에서는 안 보임
     accounts = await service.list()
     assert len(accounts) == 0
 
     # DELETED 상태도 조회 가능
-    deleted = await service.get("test")
+    deleted = await service.get("main")
     assert deleted.status == AccountStatus.DELETED
 
 
@@ -353,17 +395,17 @@ async def test_delete_raises_when_active_bots_present(service, db):
         """INSERT INTO bots
            (bot_id, name, strategy_id, account_id, config_json, status)
            VALUES (?, ?, ?, ?, ?, ?)""",
-        ("bot-1", "테스트봇", "strat", "test", "{}", "running"),
+        ("bot-1", "테스트봇", "strat", "main", "{}", "running"),
     )
 
     with pytest.raises(AccountHasActiveBotsError) as excinfo:
-        await service.delete("test", deleted_by="admin")
+        await service.delete("main", deleted_by="admin")
 
-    assert excinfo.value.account_id == "test"
+    assert excinfo.value.account_id == "main"
     assert excinfo.value.bot_count == 1
 
     # 계좌 status는 ACTIVE 그대로 유지되어야 함
-    account = await service.get("test")
+    account = await service.get("main")
     assert account.status == AccountStatus.ACTIVE
 
 
@@ -376,9 +418,9 @@ async def test_delete_succeeds_when_no_active_bots(service, db):
     # 빈 bots 테이블
     await db.execute_script(BOT_SCHEMA)
 
-    await service.delete("test", deleted_by="admin")
+    await service.delete("main", deleted_by="admin")
 
-    deleted = await service.get("test")
+    deleted = await service.get("main")
     assert deleted.status == AccountStatus.DELETED
 
 
@@ -393,12 +435,12 @@ async def test_delete_succeeds_when_only_deleted_bots(service, db):
         """INSERT INTO bots
            (bot_id, name, strategy_id, account_id, config_json, status)
            VALUES (?, ?, ?, ?, ?, ?)""",
-        ("bot-old", "삭제봇", "strat", "test", "{}", "deleted"),
+        ("bot-old", "삭제봇", "strat", "main", "{}", "deleted"),
     )
 
-    await service.delete("test", deleted_by="admin")
+    await service.delete("main", deleted_by="admin")
 
-    deleted = await service.get("test")
+    deleted = await service.get("main")
     assert deleted.status == AccountStatus.DELETED
 
 
@@ -418,16 +460,16 @@ async def test_delete_error_message_includes_cold_path_bot_remove_procedure(
         """INSERT INTO bots
            (bot_id, name, strategy_id, account_id, config_json, status)
            VALUES (?, ?, ?, ?, ?, ?)""",
-        ("bot-1", "테스트봇", "strat", "test", "{}", "running"),
+        ("bot-1", "테스트봇", "strat", "main", "{}", "running"),
     )
 
     with pytest.raises(AccountHasActiveBotsError) as excinfo:
-        await service.delete("test", deleted_by="admin")
+        await service.delete("main", deleted_by="admin")
 
     message = str(excinfo.value)
 
     # account_id / bot_count 포함
-    assert "test" in message
+    assert "main" in message
     assert "1" in message
 
     # server start/stop 없이 bot remove → account delete 순서만 안내한다 (#1161).
@@ -568,7 +610,8 @@ async def test_get_broker_test(service):
     """test broker_type으로 TestBrokerAdapter 반환."""
     await service.create(_make_account())
 
-    broker = await service.get_broker("test")
+    broker = await service.get_broker("main")
+    # TestBrokerAdapter.broker_id 클래스 default는 "test" — broker_type SSOT.
     assert broker.broker_id == "test"
 
 
@@ -577,8 +620,8 @@ async def test_get_broker_cached(service):
     """두 번 호출 시 같은 인스턴스 반환 (캐싱)."""
     await service.create(_make_account())
 
-    broker1 = await service.get_broker("test")
-    broker2 = await service.get_broker("test")
+    broker1 = await service.get_broker("main")
+    broker2 = await service.get_broker("main")
     assert broker1 is broker2
 
 
@@ -588,7 +631,7 @@ async def test_get_broker_uses_broker_config(service):
     await service.create(
         _make_account(broker_config={"is_paper": True}),
     )
-    broker = await service.get_broker("test")
+    broker = await service.get_broker("main")
     assert broker.config.get("is_paper") is True
 
 
@@ -596,7 +639,7 @@ async def test_get_broker_uses_broker_config(service):
 async def test_get_broker_broker_config_default(service):
     """broker_config={} -> is_paper 키 없음 (KIS 기본값 사용)."""
     await service.create(_make_account())
-    broker = await service.get_broker("test")
+    broker = await service.get_broker("main")
     assert "is_paper" not in broker.config
 
 
@@ -609,13 +652,13 @@ async def test_update_credentials_invalidates_broker_cache(service):
     수행되어야 이후 호출에서 즉시 사용 가능하다.
     """
     await service.create(_make_account())
-    broker_before = await service.get_broker("test")
+    broker_before = await service.get_broker("main")
     await broker_before.connect()
     assert broker_before.config.get("app_key") == "test"
     assert broker_before.is_connected is True
 
-    await service.update("test", credentials={"app_key": "new", "app_secret": "new"})
-    broker_after = await service.get_broker("test")
+    await service.update("main", credentials={"app_key": "new", "app_secret": "new"})
+    broker_after = await service.get_broker("main")
 
     assert broker_after is not broker_before
     assert broker_after.config.get("app_key") == "new"
@@ -630,12 +673,12 @@ async def test_update_credentials_invalidates_broker_cache(service):
 async def test_update_broker_config_invalidates_broker_cache(service):
     """broker_config 수정 시 캐시된 브로커를 무효화하고 재연결한다."""
     await service.create(_make_account())
-    broker_before = await service.get_broker("test")
+    broker_before = await service.get_broker("main")
     await broker_before.connect()
     assert "is_paper" not in broker_before.config
 
-    await service.update("test", broker_config={"is_paper": True})
-    broker_after = await service.get_broker("test")
+    await service.update("main", broker_config={"is_paper": True})
+    broker_after = await service.get_broker("main")
 
     assert broker_after is not broker_before
     assert broker_after.config.get("is_paper") is True
@@ -654,16 +697,16 @@ async def test_update_commission_rate_invalidates_broker_cache(service):
     값으로 수행된다.
     """
     await service.create(_make_account())
-    broker_before = await service.get_broker("test")
+    broker_before = await service.get_broker("main")
     await broker_before.connect()
     assert float(broker_before.config.get("buy_commission_rate", 0.0)) == 0.0
 
     await service.update(
-        "test",
+        "main",
         buy_commission_rate=Decimal("0.0015"),
         sell_commission_rate=Decimal("0.0025"),
     )
-    broker_after = await service.get_broker("test")
+    broker_after = await service.get_broker("main")
 
     assert broker_after is not broker_before
     assert float(broker_after.config.get("buy_commission_rate")) == pytest.approx(
@@ -679,10 +722,10 @@ async def test_update_commission_rate_invalidates_broker_cache(service):
 async def test_update_non_broker_fields_preserves_broker_cache(service):
     """브로커와 무관한 필드(name 등) 수정 시 캐시는 유지된다."""
     await service.create(_make_account())
-    broker_before = await service.get_broker("test")
+    broker_before = await service.get_broker("main")
 
-    await service.update("test", name="renamed")
-    broker_after = await service.get_broker("test")
+    await service.update("main", name="renamed")
+    broker_after = await service.get_broker("main")
 
     assert broker_after is broker_before
 
@@ -700,7 +743,7 @@ async def test_update_does_not_disconnect_broker_held_by_long_running_consumer(s
     수행할 수 있음을 검증한다.
     """
     await service.create(_make_account())
-    held_by_consumer = await service.get_broker("test")
+    held_by_consumer = await service.get_broker("main")
     await held_by_consumer.connect()
     assert held_by_consumer.is_connected is True
 
@@ -711,7 +754,7 @@ async def test_update_does_not_disconnect_broker_held_by_long_running_consumer(s
     # credentials 업데이트 — 캐시는 새 어댑터로 교체되지만 consumer의 참조는
     # 끊기면 안 된다.
     await service.update(
-        "test", credentials={"app_key": "rotated", "app_secret": "rotated"}
+        "main", credentials={"app_key": "rotated", "app_secret": "rotated"}
     )
 
     # consumer가 붙잡은 어댑터는 여전히 연결된 상태로 동작해야 한다.
@@ -720,7 +763,7 @@ async def test_update_does_not_disconnect_broker_held_by_long_running_consumer(s
     assert isinstance(post_update_balance, dict)
 
     # 새로 get_broker를 호출한 경로(APIGateway 등)는 교체된 어댑터를 받는다.
-    cached_now = await service.get_broker("test")
+    cached_now = await service.get_broker("main")
     assert cached_now is not held_by_consumer
     assert cached_now.is_connected is True
     assert cached_now.config.get("app_key") == "rotated"
@@ -737,18 +780,18 @@ async def test_update_without_cached_broker_is_noop(service):
     통과해야 한다. 이후 get_broker()가 새 설정으로 lazy init한다.
     """
     await service.create(_make_account())
-    assert "test" not in service._brokers  # 아직 get_broker 호출 전
+    assert "main" not in service._brokers  # 아직 get_broker 호출 전
 
     # broker_config 변경 — 캐시가 비어 있어 재연결은 noop이어야 한다
-    await service.update("test", broker_config={"is_paper": True})
+    await service.update("main", broker_config={"is_paper": True})
 
-    account = await service.get("test")
+    account = await service.get("main")
     assert account.broker_config == {"is_paper": True}
     # 캐시는 여전히 비어 있어야 한다 (lazy init은 이후 get_broker가 담당)
-    assert "test" not in service._brokers
+    assert "main" not in service._brokers
 
     # lazy init 후 새 설정이 반영되어야 한다
-    broker = await service.get_broker("test")
+    broker = await service.get_broker("main")
     assert broker.config.get("is_paper") is True
 
 
@@ -765,7 +808,7 @@ async def test_update_preserves_cache_when_new_broker_connect_fails(
     받는다. DB에는 새 설정이 이미 반영된 상태다.
     """
     await service.create(_make_account())
-    broker_before = await service.get_broker("test")
+    broker_before = await service.get_broker("main")
     await broker_before.connect()
     assert broker_before.is_connected is True
 
@@ -779,16 +822,16 @@ async def test_update_preserves_cache_when_new_broker_connect_fails(
 
     with pytest.raises(BrokerReconnectFailedError):
         await service.update(
-            "test", credentials={"app_key": "new", "app_secret": "new"}
+            "main", credentials={"app_key": "new", "app_secret": "new"}
         )
 
     # 캐시는 기존 브로커를 그대로 유지해야 한다
-    cached = await service.get_broker("test")
+    cached = await service.get_broker("main")
     assert cached is broker_before
     assert cached.is_connected is True
 
     # DB에는 새 설정이 반영되어 있음 (재시도 시 새 credentials로 생성됨)
-    account = await service.get("test")
+    account = await service.get("main")
     assert account.credentials == {"app_key": "new", "app_secret": "new"}
 
 
@@ -806,18 +849,18 @@ async def test_broker_operations_work_after_credentials_update(service):
     await service.create(_make_account())
 
     # 1) health check 경로: 미리 get_broker를 호출해 캐시 생성
-    pre_broker = await service.get_broker("test")
+    pre_broker = await service.get_broker("main")
     await pre_broker.connect()
     assert pre_broker.is_connected is True
 
     # 2) 운영 중 credentials 변경
     await service.update(
-        "test",
+        "main",
         credentials={"app_key": "rotated", "app_secret": "rotated"},
     )
 
     # 3) gateway 호출 경로: get_broker가 반환한 어댑터로 즉시 operation 실행
-    post_broker = await service.get_broker("test")
+    post_broker = await service.get_broker("main")
     assert post_broker is not pre_broker
     assert post_broker.is_connected is True
     # 실제 브로커 오퍼레이션이 바로 동작해야 한다 (별도 connect 없이 호출 가능)
@@ -834,7 +877,7 @@ async def test_create_account_with_broker_config(service):
     assert created.broker_config == {"is_paper": True, "hts_id": "myid"}
 
     # DB에서 다시 로드
-    fetched = await service.get("test")
+    fetched = await service.get("main")
     assert fetched.broker_config == {"is_paper": True, "hts_id": "myid"}
 
 
@@ -877,7 +920,7 @@ async def test_db_persistence(db, eventbus):
 
     accounts = await svc2.list()
     assert len(accounts) == 1
-    assert accounts[0].account_id == "test"
+    assert accounts[0].account_id == "main"
 
 
 # ── 프리셋 ──────────────────────────────────────────

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -904,6 +904,77 @@ async def test_create_default_test_account_idempotent(service):
     assert first.account_id == second.account_id
 
 
+# ── _bootstrap seed 가드 (#1216) ────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "default",  # fallback 예약어
+        "random",  # seed 화이트리스트 밖
+        "main",  # 일반 valid이지만 seed 아님
+        "ab",  # 형식 위반 (너무 짧음, 동시에 seed 아님)
+    ],
+)
+async def test_create_with_bootstrap_rejects_non_seed(service, bad_id):
+    """``_bootstrap=True``는 BROKER_PRESETS seed account_id만 허용한다.
+
+    내부 호출자가 ``_bootstrap=True``로 'default'/패턴 위반/임의 ID를 슬쩍
+    통과시키지 못하게 막는 defense-in-depth 가드 (#1216).
+    """
+    account = _make_account(account_id=bad_id)
+
+    with pytest.raises(InvalidAccountIdError) as exc_info:
+        await service.create(account, _bootstrap=True)
+
+    assert "_bootstrap=True" in str(exc_info.value)
+    assert "BROKER_PRESETS" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_create_with_bootstrap_rejects_empty(service):
+    """``_bootstrap=True``로 빈 문자열 account_id는 거부된다 (seed 화이트리스트 밖)."""
+    # _make_account의 default 분기로 직접 만들지 못하므로 명시적으로 구성.
+    account = _make_account(account_id="")
+
+    with pytest.raises(InvalidAccountIdError):
+        await service.create(account, _bootstrap=True)
+
+
+@pytest.mark.asyncio
+async def test_create_with_bootstrap_accepts_seed_test(service):
+    """``_bootstrap=True``로 ``"test"`` (seed)는 통과한다."""
+    preset = BROKER_PRESETS["test"]
+    account = _make_account(
+        account_id=preset.default_account_id,
+        broker_type="test",
+        credentials={k: "test" for k in preset.required_credentials},
+    )
+
+    result = await service.create(account, _bootstrap=True)
+
+    assert result.account_id == "test"
+    assert result.status == AccountStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_create_default_test_account_bootstrap_path_works(service):
+    """``create_default_test_account`` 흐름이 새 가드 적용 후에도 정상 동작.
+
+    회귀 방지: ``_bootstrap=True`` 경로의 seed 화이트리스트 가드가 기존
+    bootstrap seed 자동 생성 흐름을 깨지 않아야 한다.
+    """
+    account = await service.create_default_test_account()
+
+    assert account.account_id == "test"
+    assert account.broker_type == "test"
+    assert account.status == AccountStatus.ACTIVE
+    # 멱등성도 함께 확인 (기존 계약 유지)
+    again = await service.create_default_test_account()
+    assert again.account_id == "test"
+
+
 # ── DB 영속성 ──────────────────────────────────────
 
 

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -200,8 +200,11 @@ async def test_create_default_account_id_raises(service):
 async def test_create_test_account_id_raises_for_user(service):
     """``"test"``는 bootstrap seed 예약어로 사용자 신규 생성 거부 (#1216).
 
-    ``ante init`` 경로(:meth:`AccountService.create_default_test_account`)는
-    내부 ``_bootstrap=True``로 helper를 우회하므로 별도 테스트로 검증한다.
+    ``ante init`` 경로( :meth:`AccountService.create_default_test_account` )는
+    private :meth:`AccountService._create_seed_account` helper를 통해서만
+    seed 계좌를 만들 수 있다 (#1216 P2). public ``create()`` API에는 우회
+    플래그가 노출되지 않으므로, 외부 호출자가 ``"test"`` 를 신규 생성하는
+    경로는 이 가드에서 차단된다.
     """
     account = _make_account(account_id="test")
 
@@ -904,7 +907,41 @@ async def test_create_default_test_account_idempotent(service):
     assert first.account_id == second.account_id
 
 
-# ── _bootstrap seed 가드 (#1216) ────────────────────
+# ── public create() seed 우회 차단 + private _create_seed_account 가드 (#1216 P2) ──
+
+
+@pytest.mark.asyncio
+async def test_create_public_api_has_no_bootstrap_kwarg(service):
+    """public ``create()`` 시그니처는 ``_bootstrap`` 키워드를 받지 않는다 (#1216 P2).
+
+    외부 호출자가 ``_bootstrap=True`` 로 RESTRICTED 예약어( ``"test"`` ) 검증을
+    우회할 수 없도록 시그니처에서 완전히 제거됐는지 회귀 방지.
+    """
+    import inspect
+
+    sig = inspect.signature(service.create)
+    assert "_bootstrap" not in sig.parameters, (
+        f"public create() must not expose _bootstrap kwarg; got params="
+        f"{list(sig.parameters)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_public_api_rejects_seed_id_for_test_broker(service):
+    """seed account_id ``"test"`` 는 public ``create()`` 에서 broker_type 무관 거부.
+
+    seed 우회가 사라졌으므로, 외부 호출자가 정확한 (broker_type, account_id)
+    pair를 넘겨도 public 경로에서는 RESTRICTED 가드가 막아야 한다 (#1216 P2).
+    bootstrap은 :meth:`AccountService.create_default_test_account` 만의 책임.
+    """
+    account = _make_account(account_id="test", broker_type="test")
+
+    with pytest.raises(InvalidAccountIdError) as exc_info:
+        await service.create(account)
+
+    msg = str(exc_info.value)
+    assert "ante init" in msg
+    assert "시드 계좌" in msg
 
 
 @pytest.mark.asyncio
@@ -917,35 +954,37 @@ async def test_create_default_test_account_idempotent(service):
         "ab",  # 형식 위반 (너무 짧음, 동시에 seed 아님)
     ],
 )
-async def test_create_with_bootstrap_rejects_non_seed(service, bad_id):
-    """``_bootstrap=True``는 (broker_type, default_account_id) pair만 허용한다.
+async def test_create_seed_account_rejects_non_seed(service, bad_id):
+    """private seed helper는 (broker_type, default_account_id) pair만 허용.
 
-    내부 호출자가 ``_bootstrap=True``로 'default'/패턴 위반/임의 ID를 슬쩍
-    통과시키지 못하게 막는 defense-in-depth 가드 (#1216). 여기서는
+    오케스트레이션 helper(``create_default_test_account``)가 잘못된 입력을
+    넘기더라도 'default'/패턴 위반/임의 ID가 슬쩍 통과되지 않게 막는
+    defense-in-depth 가드 (#1216 P2). 여기서는
     broker_type='test'(default_account_id='test')와 mismatch인 케이스들이다.
     """
     account = _make_account(account_id=bad_id, broker_type="test")
 
     with pytest.raises(InvalidAccountIdError) as exc_info:
-        await service.create(account, _bootstrap=True)
+        await service._create_seed_account(account)
 
-    assert "_bootstrap=True" in str(exc_info.value)
-    assert "valid pairs" in str(exc_info.value)
+    msg = str(exc_info.value)
+    assert "seed 계좌 생성" in msg
+    assert "valid pairs" in msg
 
 
 @pytest.mark.asyncio
-async def test_create_with_bootstrap_rejects_empty(service):
-    """``_bootstrap=True``로 빈 문자열 account_id는 거부된다 (pair 불일치)."""
+async def test_create_seed_account_rejects_empty(service):
+    """빈 문자열 account_id는 ``_create_seed_account`` 에서 거부된다 (pair 불일치)."""
     # _make_account의 default 분기로 직접 만들지 못하므로 명시적으로 구성.
     account = _make_account(account_id="", broker_type="test")
 
     with pytest.raises(InvalidAccountIdError):
-        await service.create(account, _bootstrap=True)
+        await service._create_seed_account(account)
 
 
 @pytest.mark.asyncio
-async def test_create_with_bootstrap_accepts_seed_test(service):
-    """``_bootstrap=True``로 정확한 (test, test) pair는 통과한다."""
+async def test_create_seed_account_accepts_seed_test(service):
+    """정확한 (test, test) pair는 ``_create_seed_account`` 에서 통과한다."""
     preset = BROKER_PRESETS["test"]
     account = _make_account(
         account_id=preset.default_account_id,
@@ -953,7 +992,7 @@ async def test_create_with_bootstrap_accepts_seed_test(service):
         credentials={k: "test" for k in preset.required_credentials},
     )
 
-    result = await service.create(account, _bootstrap=True)
+    result = await service._create_seed_account(account)
 
     assert result.account_id == "test"
     assert result.broker_type == "test"
@@ -961,8 +1000,8 @@ async def test_create_with_bootstrap_accepts_seed_test(service):
 
 
 @pytest.mark.asyncio
-async def test_create_with_bootstrap_accepts_seed_kis_domestic(service):
-    """``_bootstrap=True``로 정확한 (kis-domestic, domestic) pair는 통과한다.
+async def test_create_seed_account_accepts_seed_kis_domestic(service):
+    """정확한 (kis-domestic, domestic) pair도 ``_create_seed_account`` 에서 통과.
 
     BROKER_PRESETS에 정의된 모든 pair가 동일하게 허용되는지 회귀 방지.
     """
@@ -973,7 +1012,7 @@ async def test_create_with_bootstrap_accepts_seed_kis_domestic(service):
         credentials={k: "test" for k in preset.required_credentials},
     )
 
-    result = await service.create(account, _bootstrap=True)
+    result = await service._create_seed_account(account)
 
     assert result.account_id == "domestic"
     assert result.broker_type == "kis-domestic"
@@ -981,7 +1020,7 @@ async def test_create_with_bootstrap_accepts_seed_kis_domestic(service):
 
 
 @pytest.mark.asyncio
-async def test_create_bootstrap_rejects_seed_id_with_wrong_broker_type(service):
+async def test_create_seed_account_rejects_seed_id_with_wrong_broker_type(service):
     """``account_id='test'`` + ``broker_type='kis-domestic'``는 거부된다 (#1216 P2).
 
     이전 구현은 account_id가 BROKER_PRESETS의 default_account_id set에
@@ -997,16 +1036,18 @@ async def test_create_bootstrap_rejects_seed_id_with_wrong_broker_type(service):
     )
 
     with pytest.raises(InvalidAccountIdError) as exc_info:
-        await service.create(account, _bootstrap=True)
+        await service._create_seed_account(account)
 
     msg = str(exc_info.value)
-    assert "_bootstrap=True" in msg
+    assert "seed 계좌 생성" in msg
     assert "valid pairs" in msg
     assert "'test'" in msg  # 입력된 account_id가 메시지에 포함
 
 
 @pytest.mark.asyncio
-async def test_create_bootstrap_rejects_cross_pair_domestic_with_test_broker(service):
+async def test_create_seed_account_rejects_cross_pair_domestic_with_test_broker(
+    service,
+):
     """``account_id='domestic'`` + ``broker_type='test'`` (반대 mismatch)도 거부."""
     account = _make_account(
         account_id="domestic",  # kis-domestic preset의 seed
@@ -1015,15 +1056,15 @@ async def test_create_bootstrap_rejects_cross_pair_domestic_with_test_broker(ser
     )
 
     with pytest.raises(InvalidAccountIdError):
-        await service.create(account, _bootstrap=True)
+        await service._create_seed_account(account)
 
 
 @pytest.mark.asyncio
-async def test_create_bootstrap_rejects_unknown_broker_type(service):
-    """알 수 없는 ``broker_type``은 _bootstrap pair 검증에서 거부된다.
+async def test_create_seed_account_rejects_unknown_broker_type(service):
+    """알 수 없는 ``broker_type`` 은 ``_create_seed_account`` pair 검증에서 거부된다.
 
     BROKER_PRESETS.get(broker_type)이 None이므로 InvalidBrokerTypeError가
-    아니라 새 _bootstrap pair 가드가 먼저 InvalidAccountIdError로 차단한다.
+    아니라 seed pair 가드가 먼저 InvalidAccountIdError로 차단한다.
     """
     account = _make_account(
         account_id="test",
@@ -1032,17 +1073,17 @@ async def test_create_bootstrap_rejects_unknown_broker_type(service):
     )
 
     with pytest.raises(InvalidAccountIdError) as exc_info:
-        await service.create(account, _bootstrap=True)
+        await service._create_seed_account(account)
 
-    assert "_bootstrap=True" in str(exc_info.value)
+    assert "seed 계좌 생성" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
-async def test_create_default_test_account_bootstrap_path_works(service):
-    """``create_default_test_account`` 흐름이 새 가드 적용 후에도 정상 동작.
+async def test_create_default_test_account_seed_path_works(service):
+    """``create_default_test_account`` 흐름이 새 helper 적용 후에도 정상 동작.
 
-    회귀 방지: ``_bootstrap=True`` 경로의 seed 화이트리스트 가드가 기존
-    bootstrap seed 자동 생성 흐름을 깨지 않아야 한다.
+    회귀 방지: private ``_create_seed_account`` 경로의 pair 화이트리스트
+    가드가 기존 bootstrap seed 자동 생성 흐름을 깨지 않아야 한다 (#1216 P2).
     """
     account = await service.create_default_test_account()
 

--- a/tests/unit/test_account_delete_events.py
+++ b/tests/unit/test_account_delete_events.py
@@ -40,7 +40,7 @@ async def service(db, eventbus):
 
 
 def _make_account(
-    account_id: str = "test",
+    account_id: str = "main",
     name: str = "테스트",
     exchange: str = "TEST",
     currency: str = "KRW",
@@ -95,11 +95,11 @@ class TestAccountDeleteEvents:
 
         eventbus.subscribe(AccountSuspendedEvent, on_suspended)
 
-        await service.delete("test", deleted_by="admin")
+        await service.delete("main", deleted_by="admin")
 
         assert len(published) == 1
         assert published[0][0] == "suspended"
-        assert published[0][1].account_id == "test"
+        assert published[0][1].account_id == "main"
         assert published[0][1].reason == "Account deletion"
         assert published[0][1].suspended_by == "admin"
 
@@ -109,7 +109,7 @@ class TestAccountDeleteEvents:
     ):
         """이미 SUSPENDED인 계좌 삭제 시 SuspendedEvent 미발행."""
         await service.create(_make_account())
-        await service.suspend("test", reason="test reason", suspended_by="system")
+        await service.suspend("main", reason="test reason", suspended_by="system")
 
         published: list = []
 
@@ -118,7 +118,7 @@ class TestAccountDeleteEvents:
 
         eventbus.subscribe(AccountSuspendedEvent, on_suspended)
 
-        await service.delete("test", deleted_by="admin")
+        await service.delete("main", deleted_by="admin")
 
         # AccountSuspendedEvent는 새로 발행되지 않아야 함
         # (이미 suspend 시 1회 발행되었지만 delete()에서는 추가 발행 없음)
@@ -128,11 +128,11 @@ class TestAccountDeleteEvents:
     async def test_delete_sets_status_and_clears_cache(self, service):
         """delete() 후 상태가 DELETED로 변경되고 메모리 캐시에서 제거."""
         await service.create(_make_account())
-        await service.delete("test", deleted_by="admin")
+        await service.delete("main", deleted_by="admin")
 
         # 메모리 캐시에서 제거됨
-        assert "test" not in service._accounts
+        assert "main" not in service._accounts
 
         # DB에서 DELETED 상태로 조회 가능
-        account = await service.get("test")
+        account = await service.get("main")
         assert account.status == AccountStatus.DELETED

--- a/tests/unit/test_account_immutable_fields.py
+++ b/tests/unit/test_account_immutable_fields.py
@@ -34,7 +34,7 @@ async def service(db, eventbus):
     return svc
 
 
-def _make_account(account_id: str = "test") -> Account:
+def _make_account(account_id: str = "main") -> Account:
     return Account(
         account_id=account_id,
         name="테스트",
@@ -53,7 +53,7 @@ async def test_update_immutable_exchange_raises(service):
     """exchange 수정 시도 시 AccountImmutableFieldError 발생."""
     await service.create(_make_account())
     with pytest.raises(AccountImmutableFieldError, match="exchange"):
-        await service.update("test", exchange="NYSE")
+        await service.update("main", exchange="NYSE")
 
 
 @pytest.mark.asyncio
@@ -61,7 +61,7 @@ async def test_update_immutable_currency_raises(service):
     """currency 수정 시도 시 AccountImmutableFieldError 발생."""
     await service.create(_make_account())
     with pytest.raises(AccountImmutableFieldError, match="currency"):
-        await service.update("test", currency="USD")
+        await service.update("main", currency="USD")
 
 
 @pytest.mark.asyncio
@@ -69,7 +69,7 @@ async def test_update_immutable_trading_mode_raises(service):
     """trading_mode 수정 시도 시 AccountImmutableFieldError 발생."""
     await service.create(_make_account())
     with pytest.raises(AccountImmutableFieldError, match="trading_mode"):
-        await service.update("test", trading_mode=TradingMode.LIVE)
+        await service.update("main", trading_mode=TradingMode.LIVE)
 
 
 @pytest.mark.asyncio
@@ -77,7 +77,7 @@ async def test_update_immutable_broker_type_raises(service):
     """broker_type 수정 시도 시 AccountImmutableFieldError 발생."""
     await service.create(_make_account())
     with pytest.raises(AccountImmutableFieldError, match="broker_type"):
-        await service.update("test", broker_type="kis-domestic")
+        await service.update("main", broker_type="kis-domestic")
 
 
 @pytest.mark.asyncio
@@ -85,7 +85,7 @@ async def test_update_multiple_immutable_fields_raises(service):
     """여러 불변 필드 동시 수정 시도 시 AccountImmutableFieldError 발생."""
     await service.create(_make_account())
     with pytest.raises(AccountImmutableFieldError):
-        await service.update("test", exchange="NYSE", currency="USD")
+        await service.update("main", exchange="NYSE", currency="USD")
 
 
 # ── 허용 필드 수정은 정상 동작 ──────────────────────
@@ -95,7 +95,7 @@ async def test_update_multiple_immutable_fields_raises(service):
 async def test_update_mutable_name_succeeds(service):
     """name 수정은 정상 동작."""
     await service.create(_make_account())
-    updated = await service.update("test", name="새이름")
+    updated = await service.update("main", name="새이름")
     assert updated.name == "새이름"
 
 
@@ -103,7 +103,7 @@ async def test_update_mutable_name_succeeds(service):
 async def test_update_mutable_timezone_succeeds(service):
     """timezone 수정은 정상 동작."""
     await service.create(_make_account())
-    updated = await service.update("test", timezone="US/Eastern")
+    updated = await service.update("main", timezone="US/Eastern")
     assert updated.timezone == "US/Eastern"
 
 
@@ -112,7 +112,7 @@ async def test_update_mutable_with_immutable_raises(service):
     """허용 필드와 불변 필드를 함께 보내면 불변 필드 에러가 발생."""
     await service.create(_make_account())
     with pytest.raises(AccountImmutableFieldError, match="exchange"):
-        await service.update("test", name="새이름", exchange="NYSE")
+        await service.update("main", name="새이름", exchange="NYSE")
 
 
 # ── 미인식 필드 거부 ─────────────────────────────────
@@ -123,7 +123,7 @@ async def test_update_unrecognized_field_raises(service):
     """updatable에도 IMMUTABLE_FIELDS에도 없는 필드는 ValueError 발생."""
     await service.create(_make_account())
     with pytest.raises(ValueError, match="foo"):
-        await service.update("test", foo="bar")
+        await service.update("main", foo="bar")
 
 
 @pytest.mark.asyncio
@@ -131,7 +131,7 @@ async def test_update_multiple_unrecognized_fields_raises(service):
     """여러 미인식 필드 전달 시 모든 필드명이 에러 메시지에 포함."""
     await service.create(_make_account())
     with pytest.raises(ValueError, match="abc.*xyz|xyz.*abc"):
-        await service.update("test", abc="1", xyz="2")
+        await service.update("main", abc="1", xyz="2")
 
 
 @pytest.mark.asyncio
@@ -139,4 +139,4 @@ async def test_update_unrecognized_with_valid_raises(service):
     """유효한 필드와 미인식 필드를 함께 보내면 ValueError 발생."""
     await service.create(_make_account())
     with pytest.raises(ValueError, match="unknown"):
-        await service.update("test", name="새이름", unknown="value")
+        await service.update("main", name="새이름", unknown="value")

--- a/tests/unit/test_account_scoping.py
+++ b/tests/unit/test_account_scoping.py
@@ -1,0 +1,167 @@
+"""Account ID scoping helper 단위 테스트.
+
+검증 대상: ``ante.account.scoping``의 runtime/creation 정책 분리.
+계약 SSOT: ``docs/specs/account/14-account-id-contract.md``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.account.errors import InvalidAccountIdError
+from ante.account.scoping import (
+    INVALID_RUNTIME_ACCOUNT_IDS,
+    RESTRICTED_NEW_ACCOUNT_IDS,
+    is_invalid_account_id,
+    require_account_id,
+    validate_new_account_id,
+)
+
+# ── is_invalid_account_id (runtime 판정) ────────────────────
+
+
+def test_is_invalid_rejects_none() -> None:
+    """``None``은 runtime invalid."""
+    assert is_invalid_account_id(None) is True
+
+
+def test_is_invalid_rejects_empty() -> None:
+    """빈 문자열은 runtime invalid."""
+    assert is_invalid_account_id("") is True
+
+
+def test_is_invalid_rejects_default() -> None:
+    """``"default"``는 fallback 예약어로 runtime invalid."""
+    assert is_invalid_account_id("default") is True
+    assert "default" in INVALID_RUNTIME_ACCOUNT_IDS
+
+
+def test_is_invalid_accepts_test() -> None:
+    """``"test"``는 bootstrap 계좌이므로 runtime valid."""
+    assert is_invalid_account_id("test") is False
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "ab",  # 너무 짧음
+        "a" * 31,  # 너무 김
+        "foo!bar",  # 허용되지 않은 특수문자
+        "has space",  # 공백
+        "has_under",  # 언더스코어 비허용
+        "한글계좌",  # non-ASCII
+    ],
+)
+def test_is_invalid_rejects_pattern_mismatch(bad_id: str) -> None:
+    """``ACCOUNT_ID_PATTERN`` 위반은 runtime invalid."""
+    assert is_invalid_account_id(bad_id) is True
+
+
+@pytest.mark.parametrize(
+    "good_id",
+    [
+        "test",  # bootstrap (runtime valid)
+        "domestic",
+        "foo-bar-2",
+        "abc",
+        "a" * 30,
+        "ABC",
+        "Test-123",
+    ],
+)
+def test_is_invalid_accepts_normal(good_id: str) -> None:
+    """형식 준수 + non-fallback ID는 runtime valid."""
+    assert is_invalid_account_id(good_id) is False
+
+
+# ── require_account_id (fallback 금지 진입점) ───────────────
+
+
+def test_require_raises_with_context() -> None:
+    """invalid면 ``InvalidAccountIdError``를 raise하고 context를 메시지에 포함."""
+    with pytest.raises(InvalidAccountIdError) as exc_info:
+        require_account_id(None, context="trade.submit_order")
+
+    msg = str(exc_info.value)
+    assert "trade.submit_order" in msg
+    assert "유효한 account_id가 필요합니다" in msg
+    assert "fallback" in msg
+
+
+def test_require_raises_without_context() -> None:
+    """context 미지정 시에도 invalid는 raise하며 prefix는 비어 있다."""
+    with pytest.raises(InvalidAccountIdError) as exc_info:
+        require_account_id("default")
+
+    msg = str(exc_info.value)
+    # context prefix가 없으므로 "() " 같은 빈 괄호도 없어야 한다.
+    assert not msg.startswith("()")
+    assert "유효한 account_id가 필요합니다" in msg
+
+
+def test_require_returns_value() -> None:
+    """valid한 account_id는 그대로 반환된다."""
+    assert require_account_id("domestic") == "domestic"
+    # bootstrap valid
+    assert require_account_id("test") == "test"
+    # context는 valid 경로에 영향 없음
+    assert require_account_id("foo-bar-2", context="ctx") == "foo-bar-2"
+
+
+# ── validate_new_account_id (creation 정책) ─────────────────
+
+
+def test_validate_new_rejects_test() -> None:
+    """``"test"``는 신규 생성 거부 — bootstrap seed로만 허용."""
+    assert "test" in RESTRICTED_NEW_ACCOUNT_IDS
+    with pytest.raises(InvalidAccountIdError) as exc_info:
+        validate_new_account_id("test")
+    assert "ante init" in str(exc_info.value)
+    assert "시드 계좌" in str(exc_info.value)
+
+
+def test_validate_new_accepts_normal() -> None:
+    """형식 준수 + non-RESTRICTED ID는 신규 생성 가능."""
+    assert validate_new_account_id("domestic") == "domestic"
+    assert validate_new_account_id("foo-bar-2") == "foo-bar-2"
+    assert validate_new_account_id("Test-123") == "Test-123"
+
+
+def test_validate_new_rejects_default() -> None:
+    """``"default"``는 fallback 예약어로 신규 생성 거부."""
+    with pytest.raises(InvalidAccountIdError) as exc_info:
+        validate_new_account_id("default")
+    assert "fallback" in str(exc_info.value)
+
+
+def test_validate_new_rejects_none_and_empty() -> None:
+    """``None``과 빈 문자열은 신규 생성 거부 (CLI 형식 위반 메시지)."""
+    for bad in (None, ""):
+        with pytest.raises(InvalidAccountIdError) as exc_info:
+            validate_new_account_id(bad)
+        assert "account_id 형식이 올바르지 않습니다" in str(exc_info.value)
+
+
+def test_validate_new_message_preserves_format_hint() -> None:
+    """형식 위반 메시지는 기존 ``AccountService.create`` 형식을 보존한다.
+
+    ``ante account create`` CLI 표면에서 ``str(e)``로 노출되므로 형식이
+    바뀌면 사용자/Agent 에러 처리 표면이 깨진다.
+    """
+    with pytest.raises(InvalidAccountIdError) as exc_info:
+        validate_new_account_id("ab")  # 너무 짧음
+
+    msg = str(exc_info.value)
+    assert "account_id 형식이 올바르지 않습니다: 'ab'." in msg
+    assert "영문, 숫자, 하이픈만 허용하며 3~30자여야 합니다." in msg
+
+
+def test_validate_new_message_rejects_test_with_seed_hint() -> None:
+    """``"test"`` 거부 메시지는 bootstrap seed 안내를 포함한다."""
+    with pytest.raises(InvalidAccountIdError) as exc_info:
+        validate_new_account_id("test")
+
+    msg = str(exc_info.value)
+    assert "'test'" in msg
+    assert "ante init" in msg
+    assert "시드 계좌" in msg


### PR DESCRIPTION
Closes #1216
Refs #1215 (parent epic)

## Summary
- 신규 helper 모듈 `src/ante/account/scoping.py`:
  - `ACCOUNT_ID_PATTERN`, `INVALID_RUNTIME_ACCOUNT_IDS = {"default"}`, `RESTRICTED_NEW_ACCOUNT_IDS = {"test"}`
  - `is_invalid_account_id(account_id)` — None/`""`/`"default"`/패턴 위반 → True. `"test"`는 valid (bootstrap).
  - `require_account_id(account_id, *, context)` — invalid면 `InvalidAccountIdError` (fallback 금지).
  - `validate_new_account_id(account_id)` — 신규 생성 정책 (RESTRICTED `"test"` 거부).
- `AccountService.create()`는 항상 `validate_new_account_id` 적용 (public API에 우회 플래그 없음).
- Bootstrap seed 생성은 private `_create_seed_account()`로 캡슐화. `(broker_type, default_account_id)` pair 일치 + `require_account_id` 검증.
- `create_default_test_account()`만 `_create_seed_account()` 호출.
- 신규 normative spec `docs/specs/account/14-account-id-contract.md` (#1217/#1218/#1219의 SSOT).
- 기존 spec(02/03/04, README, account.md) 인덱스 + helper 사용 명시.

## Test Plan
- 신규 `tests/unit/test_account_scoping.py` — 26 case
- `tests/unit/test_account.py` — `default`/`""`/`"test"` 거부 case + bootstrap pair 검증 case + public API 회귀 가드 (`_bootstrap` kwarg 없음 검증)
- `pytest tests/unit -q` — 3545 passed, 2 skipped
- `ruff check` + `ruff format --check` — PASS
- legacy grep 인벤토리 후속 #1217/#1218/#1219 인계 (이슈 본문 참조)

## Codex Branch Review
6 attempts:
- attempt 1: \`_bootstrap\` 우회 너무 광범위 → seed 화이트리스트 추가
- attempt 2: WT noise (\`pip_freeze_v1.0.0.txt\`) reset
- attempt 3: \`_bootstrap\` (broker_type, account_id) pair 검증 추가
- attempt 4: error wording 정정 (\`'test'\` runtime valid 표현)
- attempt 5: public API에서 \`_bootstrap\` 제거, private seed helper로 캡슐화
- attempt 6: PASS

## Plan Preflight
rev1-rev4 모두 inventory 정확성 ping-pong → 자율 narrow-scope 결정 (helper + spec만 본 이슈, inventory는 후속 이슈가 자체 discovery).