### PR TITLE
feat(account)!: split-1 runtime fallback marker for events/treasury/rule/trade/ipc/web (#1240)

### DIFF
--- a/docs/specs/account/02-design-decisions.md
+++ b/docs/specs/account/02-design-decisions.md
@@ -123,8 +123,11 @@ ante init [--member-id owner] [--name Owner] [--dir <경로>]
   와 정확히 일치할 때만 통과시킨다 (#1216 P2). 이 경로 외에는 우회 불가
 
 상세 계약과 helper API는 [14-account-id-contract.md](14-account-id-contract.md)
-참조. 후속 적용은 #1217 (Trade/Treasury), #1218 (CLI/Web/IPC),
-#1219 (Event/EventBus)에서 반영한다.
+참조. 후속 적용은 #1240 (SPLIT-1: Event marker + Trade/Treasury/Rule),
+#1241 (SPLIT-2: Bot/Main + Approval payload),
+#1242 (SPLIT-3: APIGateway/Stream + multi-account lifecycle),
+#1218 (Read query / edge resolver), #1219 (DB schema/index)
+에서 반영한다.
 
 ### D-ACC-07: Account lifecycle cold-path contract
 

--- a/docs/specs/account/14-account-id-contract.md
+++ b/docs/specs/account/14-account-id-contract.md
@@ -128,14 +128,69 @@ account_id 형식이 올바르지 않습니다: '<value>'. 영문, 숫자, 하�
 | ``AccountService._create_seed_account`` (private) | ``require_account_id`` + ``(broker_type, default_account_id)`` pair 가드 | ``create_default_test_account`` 만의 호출 경로 |
 | ``AccountService.create_default_test_account`` | (private helper 호출) | seed account_id ``"test"`` 직접 사용 |
 
-후속 사용처는 #1217/#1218/#1219 영역이다 (본 이슈 범위 외):
+### #1217 후속 SPLIT 분담
 
-- **#1217 (Trade/Treasury)** — `account_id` 진입점에서 ``require_account_id``
-  호출, fallback (``"default"``, ``""``) 제거.
-- **#1218 (CLI/Web/IPC)** — account-scoped 명령/엔드포인트 진입점에서
-  ``require_account_id`` 호출.
-- **#1219 (Event/EventBus)** — account-scoped 이벤트 발행 직전
-  ``require_account_id`` 호출, 구독 측 fallback 제거.
+#1217 (단일 PR)이 9회 Codex review FAIL → SPLIT 권고에 따라 다음 3개
+이슈로 분리되어 진행한다. 각 SPLIT은 lifecycle 영향 / 적용 표면을
+구분하며, write/execute 경로 fallback 제거 + Event marker 패턴은
+SPLIT 단위로 다음 표에 기재된 위치에서만 적용한다.
+
+#### #1240 (SPLIT-1) 적용 위치
+
+write/execute 경로 fallback 제거 + Event marker 패턴 (lifecycle 영향
+없는 contract drift). 본 SPLIT에서 적용된다.
+
+| 호출 위치 | 형태 | 비고 |
+|---|---|---|
+| `Event.__post_init__` (eventbus/events.py) | ClassVar marker `_requires_account_id` + `is_invalid_account_id` 검증 | account-scoped 이벤트 20+개. 마커 정책은 [`docs/specs/eventbus/eventbus.md`](../eventbus/eventbus.md) `Account-scoped 이벤트 marker (#1217 → #1240 SPLIT-1)` 섹션 참조 |
+| `Treasury.__init__` | `account_id: str` (kw-only) + `require_account_id` | account-scoped 자금 관리 |
+| `RuleEngine.__init__` | `account_id: str` (kw-only) + `require_account_id` | account-scoped 룰 엔진 |
+| `RuleContext.__post_init__` | `require_account_id` | account-scoped 룰 평가 |
+| `TradeRecord.__post_init__` | `require_account_id` | trades 테이블 write |
+| `PositionSnapshot.__post_init__` | `require_account_id` | positions 캐시 write |
+| `BotBudget` | `account_id: str` (required field) | bot_budgets 테이블 write |
+| `DailyReportScheduler.__init__` | `account_id: str` (kw-only) + `require_account_id` | 일일 리포트 발행 |
+| `PositionReconciler.reconcile` | `account_id: str` (kw-only) | 포지션 보정 |
+| `TradeService.correct_position/insert_adjustment` | `account_id: str` (kw-only) | trade 보정 |
+| `TradeRecorder.save_adjustment` | `account_id: str` (kw-only) + `require_account_id` | adjustment write |
+| `PositionHistory.force_update/_update_position/_update_cache` | `account_id: str` (kw-only) | 포지션 강제 갱신 |
+| IPC handlers (`broker.status/balance/positions/reconcile`) | `args["account_id"]` 진입 시 `require_account_id` | IPC routing (account-scoped command payload) |
+| CLI commands (`treasury status/snapshot/allocate/deallocate`, `rule list/info`) | `--account` required | CLI UX |
+| Web routes (`treasury`, `trades`) | runtime fallback (`getattr(..., "account_id", "")`) 제거 | write 경로 검증 활용 (read endpoint 정책 미변경) |
+
+#### #1241 (SPLIT-2) 적용 위치
+
+Bot/Main + Approval payload validation. 본 SPLIT 머지 후 진행한다.
+
+| 호출 위치 | 형태 | 비고 |
+|---|---|---|
+| `BotConfig.__post_init__` | `require_account_id` | 봇 생성 진입점 |
+| `ApprovalService.create` | account-scoped type (`budget_change`, `rule_change`, `bot_create`) 시 `params["account_id"]` 검증 | approval payload validation |
+| `auto_approve` mode 추출 | account-scoped approval 검증 통과 후 mode 추출 | 자동 승인 |
+| IPC `bot_*` payload | `args["account_id"]` 진입 시 `require_account_id` | IPC bot routing |
+| CLI `bot create/remove/...`, `approval` 호출부 | `--account` required | CLI UX |
+| `main.py` 진입점 fallback (`params.get("account_id", "test")`) | 제거 | bootstrap 경로 정합 |
+
+#### #1242 (SPLIT-3) 적용 위치
+
+APIGateway/Stream + multi-account lifecycle. 본 SPLIT 머지 후 진행한다.
+
+| 호출 위치 | 형태 | 비고 |
+|---|---|---|
+| `APIGateway.get_ohlcv/get_current_price/get_positions/get_account_balance/submit_order/cancel_order` | `account_id: str` (kw-only) + `require_account_id` | broker routing 진입점 |
+| `StreamIntegration.__init__` | `account_id: str` (kw-only) + `require_account_id` | account-scoped 캐시 키 |
+| `LiveDataProvider.__init__` | `account_id: str` (kw-only) + `require_account_id` | 봇 단위 인스턴스화 (StrategyContextFactory가 BotConfig.account_id로 생성) |
+| multi-account lifecycle pool (`s.stream_integrations: dict[str, StreamIntegration]`) | account 별 인스턴스 분리 | shutdown leak 방지 |
+| `StopOrderManager` P1 fix | account-scoped 흐름 정합 | 단순 marker 호환 patch는 본 SPLIT-1에서 선반영 |
+| `StreamConnected/DisconnectedEvent` account_id 전파 | 이벤트 페이로드 정렬 | account 격리 |
+| `ResponseCache` prefix invalidate | account 별 prefix 키 정리 | broker routing 호환 |
+
+후속 영역은 다음 이슈로 이관:
+
+- **#1218 (Read query 정책)** — account 생략 query의 all-account 정책 정렬,
+  edge resolver, `strategy_performance` 계좌 추출.
+- **#1219 (DB schema)** — bot_budgets/treasury_state/trades/positions 테이블의
+  `DEFAULT 'default'`/`DEFAULT 'test'` 제거 + NOT NULL 강제.
 
 ## 테스트 게이트
 

--- a/docs/specs/eventbus/eventbus.md
+++ b/docs/specs/eventbus/eventbus.md
@@ -37,6 +37,45 @@ EventBus는 Ante의 **핵심 이벤트 발행/구독 인프라**로, 모듈 간 
 - UUID + timestamp로 이벤트 추적/디버깅 용이
 - dataclass는 외부 의존성 없음 (msgspec 등 도입은 성능 필요 시 전환)
 
+### Account-scoped 이벤트 marker (#1217 → #1240 SPLIT-1)
+
+> 계약: [`docs/specs/account/14-account-id-contract.md`](../account/14-account-id-contract.md)
+
+`Event` 기본 클래스에는 `_requires_account_id: ClassVar[bool] = False` marker가
+있다. 하위 이벤트 클래스에서 `_requires_account_id: ClassVar[bool] = True` 로
+override하면, `Event.__post_init__` 이 다음을 수행한다:
+
+1. 인스턴스의 `account_id` 필드 값을 가져온다.
+2. `ante.account.scoping.is_invalid_account_id` 로 검증한다.
+3. invalid (`""`, `None`, `"default"`, 형식 위반) 면 `InvalidAccountIdError`
+   를 raise한다.
+
+**대상 (account-scoped event)**:
+- 주문 흐름 전체: `OrderRequestEvent`, `OrderCancelEvent`, `OrderModifyEvent`,
+  `OrderModifyRejectedEvent`, `OrderValidatedEvent`, `OrderRejectedEvent`,
+  `OrderApprovedEvent`, `OrderSubmittedEvent`, `OrderFilledEvent`,
+  `OrderCancelledEvent`, `OrderFailedEvent`
+- 봇 lifecycle: `BotStartedEvent`, `BotStoppedEvent`, `BotErrorEvent`,
+  `BotStepCompletedEvent`, `BotRestartExhaustedEvent`
+- 계좌/잔고/리포트: `AccountSuspendedEvent`, `AccountActivatedEvent`,
+  `BalanceSyncedEvent`, `DailyReportEvent`
+
+**비대상 (system-wide event)**:
+- `SystemStartedEvent`, `SystemShutdownEvent`, `NotificationEvent`,
+  `BacktestCompleteEvent`, `ConfigChangedEvent`, `ApprovalCreatedEvent`,
+  `ApprovalResolvedEvent`, `MemberRegisteredEvent`, `MemberSuspendedEvent`,
+  `MemberReactivatedEvent`, `MemberRevokedEvent`, `MemberAuthFailedEvent`,
+  `CircuitBreakerEvent`, `OrderCancelFailedEvent`, `StopOrderRegisteredEvent`,
+  `StopOrderTriggeredEvent`, `StopOrderExpiredEvent`, `StreamConnectedEvent`,
+  `StreamDisconnectedEvent`, `BotStopEvent`, `ExternalSignalEvent`,
+  `PositionMismatchEvent`, `ReconcileEvent` (현재 ext spec 단계에서 marker 미적용)
+
+**구현 노트**:
+- dataclass field ordering 제약 때문에 `account_id` 필드는 default `""` 를
+  유지하지만, `__post_init__` 에서 strict 검증으로 빈 값/fallback 차단.
+- 발행자가 명시적으로 `account_id=` 를 전달하지 않으면 즉시 raise되어
+  silent fallback 제거.
+
 ### 이벤트 타입 전체 정의
 
 D-005에서 정의한 EventBus 대상 이벤트. 모든 이벤트는 `Event`를 상속하며, `event_id`와 `timestamp`는 자동 생성된다.

--- a/src/ante/broker/scheduler.py
+++ b/src/ante/broker/scheduler.py
@@ -102,10 +102,18 @@ class ReconcileScheduler:
 
         for bot_info in active_bots:
             bot_id = bot_info["bot_id"]
+            account_id = bot_info.get("account_id")
+            if not account_id:
+                logger.warning(
+                    "대사 스킵: bot=%s account_id 누락 (DB 정리 필요)",
+                    bot_id,
+                )
+                continue
             try:
                 corrections = await self._reconciler.reconcile(
                     bot_id=bot_id,
                     broker_positions=broker_positions,
+                    account_id=account_id,
                 )
                 all_corrections.extend(corrections)
             except Exception:

--- a/src/ante/broker/scheduler.py
+++ b/src/ante/broker/scheduler.py
@@ -24,11 +24,19 @@ DEFAULT_INTERVAL_SECONDS = 1800  # 30분
 class ReconcileScheduler:
     """주기적으로 모든 활성 봇의 포지션 대사를 수행한다.
 
+    이 스케줄러 인스턴스는 단일 broker(``broker_account_id``)에만 바인딩된다.
+    SPLIT-1 단계에서는 multi-account broker pool이 도입되지 않으므로,
+    다른 계좌의 봇이 같은 스케줄러에 잡히는 경우 잘못된 broker positions가
+    적용되지 않도록 ``run_once()`` 안에서 명시적으로 skip한다.
+    multi-broker pool은 SPLIT-3에서 도입한다.
+
     Args:
         reconciler: 포지션 대사 실행기.
         broker: 브로커 어댑터 (실제 잔고 조회용).
         bot_manager: 활성 봇 목록 조회용.
         eventbus: 이벤트 발행용.
+        broker_account_id: 이 스케줄러가 바인딩된 broker의 account_id.
+            ``run_once()``는 이 account_id에 일치하는 봇만 reconcile한다.
         interval_seconds: 대사 반복 주기 (초). 기본 1800(30분).
     """
 
@@ -38,12 +46,19 @@ class ReconcileScheduler:
         broker: BrokerAdapter,
         bot_manager: BotManager,
         eventbus: EventBus,
+        *,
+        broker_account_id: str,
         interval_seconds: float = DEFAULT_INTERVAL_SECONDS,
     ) -> None:
+        if not broker_account_id:
+            raise ValueError(
+                "ReconcileScheduler requires a non-empty broker_account_id"
+            )
         self._reconciler = reconciler
         self._broker = broker
         self._bot_manager = bot_manager
         self._eventbus = eventbus
+        self._broker_account_id = broker_account_id
         self._interval = interval_seconds
         self._task: asyncio.Task[None] | None = None
 
@@ -107,6 +122,20 @@ class ReconcileScheduler:
                 logger.warning(
                     "대사 스킵: bot=%s account_id 누락 (DB 정리 필요)",
                     bot_id,
+                )
+                continue
+            if account_id != self._broker_account_id:
+                # SPLIT-1 가드: 이 스케줄러는 단일 broker(self._broker_account_id)
+                # 에 바인딩돼 있다. 다른 계좌의 봇에 이 broker의 positions를
+                # 적용하면 데이터 정합성이 깨지므로 명시적으로 skip한다.
+                # SPLIT-3에서 multi-broker pool 도입 시 이 가드를 제거한다.
+                logger.warning(
+                    "대사 스킵: scheduler is bound to %s; "
+                    "bot %s belongs to %s — "
+                    "skipping until SPLIT-3 multi-broker pool",
+                    self._broker_account_id,
+                    bot_id,
+                    account_id,
                 )
                 continue
             try:

--- a/src/ante/cli/commands/broker.py
+++ b/src/ante/cli/commands/broker.py
@@ -309,7 +309,12 @@ def reconcile(ctx: click.Context, account_id: str, fix: bool) -> None:
                     await position_history.initialize()
 
                     broker_positions = await adapter.get_account_positions()
-                    internal_positions = await position_history.get_all_positions()
+                    # Refs #1240 review (P2-2): 단일 계좌 reconcile은 해당 계좌
+                    # 포지션끼리만 비교해야 한다. account_id 필터를 빼면 다른
+                    # 계좌의 positions 가 false discrepancy 로 잡힌다.
+                    internal_positions = await position_history.get_all_positions(
+                        account_id=validated_account_id
+                    )
 
                     broker_map = {p["symbol"]: p for p in broker_positions}
                     internal_map = {p.symbol: p for p in internal_positions}

--- a/src/ante/cli/commands/broker.py
+++ b/src/ante/cli/commands/broker.py
@@ -71,39 +71,45 @@ async def _get_broker(account_id: str | None = None):  # noqa: ANN202
         raise ValueError(msg)
 
 
-async def _ipc_broker_command(command: str, account_id: str | None, actor: str) -> dict:
+async def _ipc_broker_command(command: str, account_id: str, actor: str) -> dict:
     """IPC를 통해 서버 브로커 인스턴스에 위임한다.
+
+    ``account_id``는 호출자(``--account`` required CLI 옵션 + helper 통과)
+    에서 이미 검증된 값이어야 한다. fallback 금지 정책(#1217 SPLIT-1)에 따라
+    빈 dict 를 IPC 로 보내지 않는다.
 
     ServerNotRunningError, IPCTimeoutError 시 예외를 전파하여 호출자가 폴백 처리한다.
     """
     from ante.cli.commands.ipc_helpers import ipc_send
 
-    args: dict = {}
-    if account_id:
-        args["account_id"] = account_id
+    args: dict = {"account_id": account_id}
     return await ipc_send(command, args, actor=actor)
 
 
 @broker.command()
-@click.option("--account", "account_id", default=None, help="계좌 ID")
+@click.option("--account", "account_id", required=True, help="계좌 ID")
 @click.pass_context
 @require_auth
 @require_scope("broker:read")
-def status(ctx: click.Context, account_id: str | None) -> None:
+def status(ctx: click.Context, account_id: str) -> None:
     """증권사 연결 상태 조회."""
+    from ante.account.scoping import require_account_id
     from ante.cli.middleware import get_member_id
 
     fmt = get_formatter(ctx)
 
+    # CLI 진입에서 account_id 검증 (fallback 금지, #1217 SPLIT-1).
+    validated_account_id = require_account_id(account_id, context="cli.broker.status")
+
     # IPC 우선 시도
     try:
         actor = get_member_id(ctx)
-        result = _run(_ipc_broker_command("broker.status", account_id, actor))
+        result = _run(_ipc_broker_command("broker.status", validated_account_id, actor))
     except click.ClickException:
         # 서버 미실행 또는 타임아웃 — 기존 직접 연결 폴백
         async def _run_status() -> dict:
             try:
-                adapter, db = await _get_broker(account_id)
+                adapter, db = await _get_broker(validated_account_id)
                 try:
                     healthy = await adapter.health_check()
                     return {
@@ -137,24 +143,30 @@ def status(ctx: click.Context, account_id: str | None) -> None:
 
 
 @broker.command()
-@click.option("--account", "account_id", default=None, help="계좌 ID")
+@click.option("--account", "account_id", required=True, help="계좌 ID")
 @click.pass_context
 @require_auth
 @require_scope("broker:read")
-def balance(ctx: click.Context, account_id: str | None) -> None:
+def balance(ctx: click.Context, account_id: str) -> None:
     """증권사 계좌 잔고 조회."""
+    from ante.account.scoping import require_account_id
     from ante.cli.middleware import get_member_id
 
     fmt = get_formatter(ctx)
 
+    # CLI 진입에서 account_id 검증 (fallback 금지, #1217 SPLIT-1).
+    validated_account_id = require_account_id(account_id, context="cli.broker.balance")
+
     # IPC 우선 시도
     try:
         actor = get_member_id(ctx)
-        result = _run(_ipc_broker_command("broker.balance", account_id, actor))
+        result = _run(
+            _ipc_broker_command("broker.balance", validated_account_id, actor)
+        )
     except click.ClickException:
         # 서버 미실행 — 기존 직접 연결 폴백
         async def _run_balance() -> dict:
-            adapter, db = await _get_broker(account_id)
+            adapter, db = await _get_broker(validated_account_id)
             try:
                 return await adapter.get_account_balance()
             finally:
@@ -179,24 +191,32 @@ def balance(ctx: click.Context, account_id: str | None) -> None:
 
 
 @broker.command()
-@click.option("--account", "account_id", default=None, help="계좌 ID")
+@click.option("--account", "account_id", required=True, help="계좌 ID")
 @click.pass_context
 @require_auth
 @require_scope("broker:read")
-def positions(ctx: click.Context, account_id: str | None) -> None:
+def positions(ctx: click.Context, account_id: str) -> None:
     """증권사 보유 종목 조회."""
+    from ante.account.scoping import require_account_id
     from ante.cli.middleware import get_member_id
 
     fmt = get_formatter(ctx)
 
+    # CLI 진입에서 account_id 검증 (fallback 금지, #1217 SPLIT-1).
+    validated_account_id = require_account_id(
+        account_id, context="cli.broker.positions"
+    )
+
     # IPC 우선 시도
     try:
         actor = get_member_id(ctx)
-        result = _run(_ipc_broker_command("broker.positions", account_id, actor))
+        result = _run(
+            _ipc_broker_command("broker.positions", validated_account_id, actor)
+        )
     except click.ClickException:
         # 서버 미실행 — 기존 직접 연결 폴백
         async def _run_positions() -> list[dict]:
-            adapter, db = await _get_broker(account_id)
+            adapter, db = await _get_broker(validated_account_id)
             try:
                 return await adapter.get_positions()
             finally:
@@ -225,18 +245,24 @@ def positions(ctx: click.Context, account_id: str | None) -> None:
 
 
 @broker.command()
-@click.option("--account", "account_id", default=None, help="계좌 ID")
+@click.option("--account", "account_id", required=True, help="계좌 ID")
 @click.option(
     "--fix", is_flag=True, default=False, help="불일치 발견 시 자동 보정 수행"
 )
 @click.pass_context
 @require_auth
 @require_scope("broker:read")
-def reconcile(ctx: click.Context, account_id: str | None, fix: bool) -> None:
+def reconcile(ctx: click.Context, account_id: str, fix: bool) -> None:
     """내부 데이터와 증권사 데이터 대사."""
+    from ante.account.scoping import require_account_id
     from ante.cli.middleware import get_member_id
 
     fmt = get_formatter(ctx)
+
+    # CLI 진입에서 account_id 검증 (fallback 금지, #1217 SPLIT-1).
+    validated_account_id = require_account_id(
+        account_id, context="cli.broker.reconcile"
+    )
 
     # --fix 옵션이 있으면 IPC로 서버에 위임 (상태 변경)
     if fix:
@@ -245,9 +271,7 @@ def reconcile(ctx: click.Context, account_id: str | None, fix: bool) -> None:
         async def _run_fix() -> dict:
             from ante.cli.commands.ipc_helpers import ipc_send
 
-            args: dict = {"fix": True}
-            if account_id:
-                args["account_id"] = account_id
+            args: dict = {"fix": True, "account_id": validated_account_id}
             return await ipc_send("broker.reconcile", args, actor=actor)
 
         try:
@@ -265,9 +289,7 @@ def reconcile(ctx: click.Context, account_id: str | None, fix: bool) -> None:
             async def _run_ipc_reconcile() -> dict:
                 from ante.cli.commands.ipc_helpers import ipc_send
 
-                args: dict = {"fix": False}
-                if account_id:
-                    args["account_id"] = account_id
+                args: dict = {"fix": False, "account_id": validated_account_id}
                 return await ipc_send("broker.reconcile", args, actor=actor)
 
             result = _run(_run_ipc_reconcile())
@@ -278,7 +300,7 @@ def reconcile(ctx: click.Context, account_id: str | None, fix: bool) -> None:
                 from ante.core.database import Database
                 from ante.trade.position import PositionHistory
 
-                adapter, adapter_db = await _get_broker(account_id)
+                adapter, adapter_db = await _get_broker(validated_account_id)
                 db = adapter_db or Database(get_db_path())
                 if not adapter_db:
                     await db.connect()

--- a/src/ante/cli/commands/rule.py
+++ b/src/ante/cli/commands/rule.py
@@ -22,7 +22,14 @@ def _run(coro):  # noqa: ANN001, ANN202
     return asyncio.run(coro)
 
 
-async def _create_rule_engine():  # noqa: ANN202
+async def _create_rule_engine(account_id: str):  # noqa: ANN202
+    """CLI용 RuleEngine 생성.
+
+    호출자가 ``--account`` 옵션으로 검증된 ``account_id`` 를 반드시 전달
+    해야 한다. fallback 정책상 첫 번째 계좌를 임의로 선택해선 안 된다
+    (#1217). ``RuleEngine`` 생성자가 내부에서 ``require_account_id`` 로
+    재검증한다.
+    """
     from ante.cli.main import get_db_path
     from ante.core.database import Database
     from ante.eventbus.bus import EventBus
@@ -31,7 +38,7 @@ async def _create_rule_engine():  # noqa: ANN202
     db = Database(get_db_path())
     await db.connect()
     eventbus = EventBus()
-    engine = RuleEngine(eventbus=eventbus)
+    engine = RuleEngine(eventbus=eventbus, account_id=account_id)
     return engine, db
 
 
@@ -81,6 +88,7 @@ def _collect_rules(engine) -> list[dict]:  # noqa: ANN001
 
 
 @rule.command("list")
+@click.option("--account", "account_id", required=True, help="계좌 ID")
 @click.option(
     "--scope",
     "scope_filter",
@@ -91,12 +99,12 @@ def _collect_rules(engine) -> list[dict]:  # noqa: ANN001
 @click.pass_context
 @require_auth
 @require_scope("rule:read")
-def rule_list(ctx: click.Context, scope_filter: str | None) -> None:
+def rule_list(ctx: click.Context, account_id: str, scope_filter: str | None) -> None:
     """룰 목록 조회."""
     fmt = get_formatter(ctx)
 
     async def _run_list() -> list[dict]:
-        engine, db = await _create_rule_engine()
+        engine, db = await _create_rule_engine(account_id)
         try:
             try:
                 _load_rules_from_config(engine)
@@ -131,15 +139,16 @@ def rule_list(ctx: click.Context, scope_filter: str | None) -> None:
 
 @rule.command("info")
 @click.argument("rule_id")
+@click.option("--account", "account_id", required=True, help="계좌 ID")
 @click.pass_context
 @require_auth
 @require_scope("rule:read")
-def rule_info(ctx: click.Context, rule_id: str) -> None:
+def rule_info(ctx: click.Context, rule_id: str, account_id: str) -> None:
     """룰 상세 정보 조회."""
     fmt = get_formatter(ctx)
 
     async def _run_info() -> dict | None:
-        engine, db = await _create_rule_engine()
+        engine, db = await _create_rule_engine(account_id)
         try:
             try:
                 _load_rules_from_config(engine)

--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -22,11 +22,14 @@ def _run(coro):  # noqa: ANN001, ANN202
 
 
 async def _create_treasury(account_id: str | None = None):  # noqa: ANN202
+    from ante.account.scoping import require_account_id
     from ante.account.service import AccountService
     from ante.cli.main import get_db_path
     from ante.core.database import Database
     from ante.eventbus.bus import EventBus
     from ante.treasury.treasury import Treasury
+
+    validated_account_id = require_account_id(account_id, context="cli.treasury")
 
     db = Database(get_db_path())
     await db.connect()
@@ -34,30 +37,26 @@ async def _create_treasury(account_id: str | None = None):  # noqa: ANN202
     account_service = AccountService(db=db, eventbus=eventbus)
     await account_service.initialize()
 
-    if account_id:
-        account = await account_service.get(account_id)
-        t = Treasury(
-            db,
-            eventbus,
-            account_id=account.account_id,
-            currency=account.currency,
-            buy_commission_rate=float(account.buy_commission_rate),
-            sell_commission_rate=float(account.sell_commission_rate),
-        )
-    else:
-        t = Treasury(db, eventbus)
-
+    account = await account_service.get(validated_account_id)
+    t = Treasury(
+        db,
+        eventbus,
+        account_id=account.account_id,
+        currency=account.currency,
+        buy_commission_rate=float(account.buy_commission_rate),
+        sell_commission_rate=float(account.sell_commission_rate),
+    )
     await t.initialize()
     return t, db
 
 
 @treasury.command()
-@click.option("--account", "account_id", default=None, help="계좌 ID로 필터링")
+@click.option("--account", "account_id", required=True, help="계좌 ID")
 @format_option
 @click.pass_context
 @require_auth
 @require_scope("treasury:read")
-def status(ctx: click.Context, account_id: str | None) -> None:
+def status(ctx: click.Context, account_id: str) -> None:
     """자금 현황 요약."""
     fmt = get_formatter(ctx)
 
@@ -165,7 +164,7 @@ def deallocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) 
 @click.option("--date", "date_str", default=None, help="특정 날짜 조회 (YYYY-MM-DD)")
 @click.option("--from", "from_date", default=None, help="기간 조회 시작일 (YYYY-MM-DD)")
 @click.option("--to", "to_date", default=None, help="기간 조회 종료일 (YYYY-MM-DD)")
-@click.option("--account", "account_id", default=None, help="계좌 ID로 필터링")
+@click.option("--account", "account_id", required=True, help="계좌 ID")
 @format_option
 @click.pass_context
 @require_auth
@@ -175,7 +174,7 @@ def snapshot(
     date_str: str | None,
     from_date: str | None,
     to_date: str | None,
-    account_id: str | None,
+    account_id: str,
 ) -> None:
     """일별 자산 스냅샷 조회."""
     from datetime import UTC, datetime

--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -2,21 +2,51 @@
 
 모든 이벤트는 Event를 상속하는 frozen dataclass.
 이벤트는 순수 데이터 구조로, 비즈니스 로직을 포함하지 않는다.
+
+account-scoped 이벤트는 ``_requires_account_id: ClassVar[bool] = True``
+마커를 추가하면, ``Event.__post_init__``이 ``account_id`` 필드 값을
+:func:`ante.account.scoping.is_invalid_account_id` 로 검증한다. 검증
+실패 시 :class:`ante.account.errors.InvalidAccountIdError` 가 raise되어
+빈 문자열/``"default"``/None/형식 위반 값이 이벤트로 발행되지 못한다.
+system-wide 이벤트(SystemStartedEvent, SystemShutdownEvent 등)는 marker
+없이 default ``False`` 를 유지하므로 검증되지 않는다.
 """
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from typing import ClassVar
 from uuid import UUID, uuid4
+
+from ante.account.errors import InvalidAccountIdError
+from ante.account.scoping import is_invalid_account_id
 
 
 @dataclass(frozen=True)
 class Event:
-    """모든 이벤트의 기본 클래스."""
+    """모든 이벤트의 기본 클래스.
+
+    Attributes:
+        _requires_account_id: 하위 클래스에서 ``True`` 로 override하면
+            ``__post_init__`` 이 ``account_id`` 필드를 runtime 검증한다.
+            system-wide 이벤트는 ``False`` (default).
+    """
+
+    _requires_account_id: ClassVar[bool] = False
 
     event_id: UUID = field(default_factory=uuid4)
     timestamp: datetime = field(
         default_factory=lambda: datetime.now(UTC),
     )
+
+    def __post_init__(self) -> None:
+        if self._requires_account_id:
+            account_id = getattr(self, "account_id", None)
+            if is_invalid_account_id(account_id):
+                raise InvalidAccountIdError(
+                    f"AccountScopedEvent {type(self).__name__}는 valid account_id가 "
+                    f"필수입니다: {account_id!r}. fallback ('', None, 'default') 또는 "
+                    "형식 위반 값은 사용할 수 없습니다."
+                )
 
 
 # ── 주문 흐름 (Order Flow) ────────────────────────
@@ -25,6 +55,8 @@ class Event:
 @dataclass(frozen=True)
 class OrderRequestEvent(Event):
     """봇 → EventBus: 신규 주문 요청."""
+
+    _requires_account_id: ClassVar[bool] = True
 
     account_id: str = ""
     bot_id: str = ""
@@ -43,6 +75,8 @@ class OrderRequestEvent(Event):
 class OrderCancelEvent(Event):
     """봇 → EventBus: 주문 취소 요청."""
 
+    _requires_account_id: ClassVar[bool] = True
+
     account_id: str = ""
     bot_id: str = ""
     strategy_id: str = ""
@@ -53,6 +87,8 @@ class OrderCancelEvent(Event):
 @dataclass(frozen=True)
 class OrderModifyEvent(Event):
     """봇 → EventBus: 주문 정정 요청."""
+
+    _requires_account_id: ClassVar[bool] = True
 
     account_id: str = ""
     bot_id: str = ""
@@ -69,6 +105,8 @@ class OrderModifyEvent(Event):
 class OrderModifyRejectedEvent(Event):
     """RuleEngine → EventBus: 주문 정정 룰 위반으로 거부."""
 
+    _requires_account_id: ClassVar[bool] = True
+
     account_id: str = ""
     order_id: str = ""
     bot_id: str = ""
@@ -83,6 +121,8 @@ class OrderModifyRejectedEvent(Event):
 @dataclass(frozen=True)
 class OrderValidatedEvent(Event):
     """RuleEngine → EventBus: 룰 검증 통과."""
+
+    _requires_account_id: ClassVar[bool] = True
 
     account_id: str = ""
     order_id: str = ""
@@ -102,6 +142,8 @@ class OrderValidatedEvent(Event):
 class OrderRejectedEvent(Event):
     """RuleEngine/Treasury → EventBus: 주문 거부."""
 
+    _requires_account_id: ClassVar[bool] = True
+
     account_id: str = ""
     order_id: str = ""
     bot_id: str = ""
@@ -118,6 +160,8 @@ class OrderRejectedEvent(Event):
 @dataclass(frozen=True)
 class OrderApprovedEvent(Event):
     """Treasury → EventBus: 자금 확보 완료, 주문 실행 허가."""
+
+    _requires_account_id: ClassVar[bool] = True
 
     account_id: str = ""
     order_id: str = ""
@@ -137,6 +181,8 @@ class OrderApprovedEvent(Event):
 class OrderSubmittedEvent(Event):
     """APIGateway → EventBus: 증권사에 주문 전송됨."""
 
+    _requires_account_id: ClassVar[bool] = True
+
     account_id: str = ""
     order_id: str = ""
     bot_id: str = ""
@@ -152,6 +198,8 @@ class OrderSubmittedEvent(Event):
 @dataclass(frozen=True)
 class OrderFilledEvent(Event):
     """BrokerAdapter → EventBus: 체결 완료."""
+
+    _requires_account_id: ClassVar[bool] = True
 
     account_id: str = ""
     order_id: str = ""
@@ -174,6 +222,8 @@ class OrderFilledEvent(Event):
 class OrderCancelledEvent(Event):
     """BrokerAdapter → EventBus: 취소 완료."""
 
+    _requires_account_id: ClassVar[bool] = True
+
     account_id: str = ""
     order_id: str = ""
     broker_order_id: str = ""
@@ -190,6 +240,8 @@ class OrderCancelledEvent(Event):
 @dataclass(frozen=True)
 class OrderFailedEvent(Event):
     """BrokerAdapter → EventBus: 주문 실패."""
+
+    _requires_account_id: ClassVar[bool] = True
 
     account_id: str = ""
     order_id: str = ""
@@ -232,6 +284,8 @@ class OrderUpdateEvent(Event):
 class BotStartedEvent(Event):
     """BotManager → EventBus: 봇 시작."""
 
+    _requires_account_id: ClassVar[bool] = True
+
     account_id: str = ""
     bot_id: str = ""
 
@@ -248,6 +302,8 @@ class BotStopEvent(Event):
 class BotStoppedEvent(Event):
     """BotManager → EventBus: 봇 중지 완료."""
 
+    _requires_account_id: ClassVar[bool] = True
+
     account_id: str = ""
     bot_id: str = ""
 
@@ -255,6 +311,8 @@ class BotStoppedEvent(Event):
 @dataclass(frozen=True)
 class BotErrorEvent(Event):
     """BotManager → EventBus: 봇 에러 발생."""
+
+    _requires_account_id: ClassVar[bool] = True
 
     account_id: str = ""
     bot_id: str = ""
@@ -269,6 +327,8 @@ class BotStepCompletedEvent(Event):
     result 값: success, timeout, signal_overflow, error
     """
 
+    _requires_account_id: ClassVar[bool] = True
+
     bot_id: str = ""
     account_id: str = ""
     result: str = ""
@@ -278,6 +338,8 @@ class BotStepCompletedEvent(Event):
 @dataclass(frozen=True)
 class BotRestartExhaustedEvent(Event):
     """BotManager → EventBus: 봇 재시작 한도 소진."""
+
+    _requires_account_id: ClassVar[bool] = True
 
     bot_id: str = ""
     account_id: str = ""
@@ -457,6 +519,8 @@ class MemberAuthFailedEvent(Event):
 class DailyReportEvent(Event):
     """DailyReportScheduler → EventBus: 일일 성과 리포트 발행."""
 
+    _requires_account_id: ClassVar[bool] = True
+
     account_id: str = ""
     report_date: str = ""  # YYYY-MM-DD
     trade_count: int = 0
@@ -473,6 +537,8 @@ class DailyReportEvent(Event):
 @dataclass(frozen=True)
 class BalanceSyncedEvent(Event):
     """Treasury → EventBus: 계좌 잔고 동기화 완료."""
+
+    _requires_account_id: ClassVar[bool] = True
 
     account_id: str = ""
     account_balance: float = 0.0
@@ -578,6 +644,8 @@ class StreamDisconnectedEvent(Event):
 class AccountSuspendedEvent(Event):
     """AccountService → EventBus: 계좌 정지."""
 
+    _requires_account_id: ClassVar[bool] = True
+
     account_id: str = ""
     reason: str = ""
     suspended_by: str = ""
@@ -586,6 +654,8 @@ class AccountSuspendedEvent(Event):
 @dataclass(frozen=True)
 class AccountActivatedEvent(Event):
     """AccountService → EventBus: 계좌 활성화."""
+
+    _requires_account_id: ClassVar[bool] = True
 
     account_id: str = ""
     activated_by: str = ""

--- a/src/ante/gateway/gateway.py
+++ b/src/ante/gateway/gateway.py
@@ -239,6 +239,7 @@ class APIGateway:
                     quantity=event.quantity,
                     order_type=event.order_type,
                     stop_price=event.stop_price or 0.0,
+                    account_id=event.account_id,
                     limit_price=event.price,
                     exchange=event.exchange,
                 )

--- a/src/ante/gateway/stop_order.py
+++ b/src/ante/gateway/stop_order.py
@@ -40,6 +40,7 @@ class StopOrder:
     stop_price: float
     limit_price: float | None
     trading_session: str  # "regular" | "extended"
+    account_id: str  # required — trigger 시 OrderRequestEvent에 전파
     registered_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     triggered: bool = False
     expired: bool = False
@@ -91,6 +92,8 @@ class StopOrderManager:
         quantity: float,
         order_type: str,
         stop_price: float,
+        *,
+        account_id: str,
         limit_price: float | None = None,
         trading_session: str = "regular",
         exchange: str = "KRX",
@@ -115,6 +118,7 @@ class StopOrderManager:
             limit_price=limit_price,
             trading_session=trading_session,
             exchange=exchange,
+            account_id=account_id,
         )
         self._orders[stop_order_id] = order
 
@@ -250,6 +254,7 @@ class StopOrderManager:
         # 변환된 주문을 기존 흐름에 주입
         await self._eventbus.publish(
             OrderRequestEvent(
+                account_id=order.account_id,
                 bot_id=order.bot_id,
                 strategy_id=order.strategy_id,
                 symbol=order.symbol,

--- a/src/ante/gateway/stream_integration.py
+++ b/src/ante/gateway/stream_integration.py
@@ -162,15 +162,35 @@ class StreamIntegration:
         """실시간 체결 통보 콜백.
 
         캐시 무효화 + OrderFilledEvent 발행.
+
+        ``account_id``는 broker payload 우선, 없으면 lifecycle에 묶인
+        ``self._account_id``로 fallback한다. 둘 다 비어있으면
+        OrderFilledEvent는 strict marker(``_requires_account_id``)에 의해
+        InvalidAccountIdError를 raise하므로, 발행을 시도하지 않고 WARNING
+        로그 후 skip한다 (캐시 무효화는 그래도 best-effort 수행).
         """
         symbol = execution.get("symbol", "")
-        account_id = execution.get("account_id", self._account_id)
+        account_id = execution.get("account_id", "") or self._account_id
 
         # 캐시 무효화: account_id 범위 내 balance, positions, 해당 종목 시세
-        self._cache.invalidate(f"{account_id}:balance")
-        self._cache.invalidate(f"{account_id}:positions")
-        if symbol:
-            self._cache.invalidate(f"{account_id}:price:{symbol}")
+        # account_id 가 비어 있으면 무효화 키가 의미 없으므로 skip.
+        if account_id:
+            self._cache.invalidate(f"{account_id}:balance")
+            self._cache.invalidate(f"{account_id}:positions")
+            if symbol:
+                self._cache.invalidate(f"{account_id}:price:{symbol}")
+
+        # account_id 가 비어 있으면 strict OrderFilledEvent를 만들 수 없다.
+        # 라이브 경로 보존을 위해 발행을 skip하고 WARNING만 남긴다.
+        if not account_id:
+            logger.warning(
+                "체결 통보에 account_id가 없어 OrderFilledEvent 발행을 skip합니다: "
+                "symbol=%s order_id=%s side=%s",
+                symbol,
+                execution.get("order_id", ""),
+                execution.get("side", ""),
+            )
+            return
 
         # 체결 이벤트 발행
         from ante.eventbus.events import OrderFilledEvent

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -260,7 +260,9 @@ async def _handle_approval_reopen(
 async def _handle_broker_status(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
-    account_id = args.get("account_id", "")
+    from ante.account.scoping import require_account_id
+
+    account_id = require_account_id(args.get("account_id"), context="ipc.broker.status")
     broker = await svc.account.get_broker(account_id)
     healthy = await broker.health_check()
     return {
@@ -273,7 +275,11 @@ async def _handle_broker_status(
 async def _handle_broker_balance(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
-    account_id = args.get("account_id", "")
+    from ante.account.scoping import require_account_id
+
+    account_id = require_account_id(
+        args.get("account_id"), context="ipc.broker.balance"
+    )
     broker = await svc.account.get_broker(account_id)
     return await broker.get_account_balance()
 
@@ -281,7 +287,11 @@ async def _handle_broker_balance(
 async def _handle_broker_positions(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
-    account_id = args.get("account_id", "")
+    from ante.account.scoping import require_account_id
+
+    account_id = require_account_id(
+        args.get("account_id"), context="ipc.broker.positions"
+    )
     broker = await svc.account.get_broker(account_id)
     return {"positions": await broker.get_positions()}
 
@@ -289,9 +299,16 @@ async def _handle_broker_positions(
 async def _handle_broker_reconcile(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
+    from ante.account.scoping import require_account_id
+
     bot_id = args["bot_id"]
+    account_id = require_account_id(
+        args.get("account_id"), context="ipc.broker.reconcile"
+    )
     broker_positions = args.get("broker_positions", [])
-    adjustments = await svc.reconciler.reconcile(bot_id, broker_positions)
+    adjustments = await svc.reconciler.reconcile(
+        bot_id, broker_positions, account_id=account_id
+    )
     return {"bot_id": bot_id, "adjustments": adjustments}
 
 

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -299,12 +299,30 @@ async def _handle_broker_positions(
 async def _handle_broker_reconcile(
     svc: ServiceRegistry, args: dict[str, Any], actor: str
 ) -> dict:
+    from ante.account.errors import InvalidAccountIdError
     from ante.account.scoping import require_account_id
 
     bot_id = args["bot_id"]
     account_id = require_account_id(
         args.get("account_id"), context="ipc.broker.reconcile"
     )
+
+    # Refs #1240 review (P2-1): BotManager로부터 봇의 실제 account_id를 조회해
+    # 요청 payload의 account_id와 일치하지 않으면 거부한다. 잘못된 account_id가
+    # ``correct_position(...)`` 까지 흘러가 다른 계좌의 positions / adjustment
+    # trade가 손상되는 cross-account corruption을 차단하기 위함이다.
+    bot_manager = getattr(svc, "bot_manager", None)
+    if bot_manager is not None:
+        bot = bot_manager.get_bot(bot_id)
+        if bot is not None:
+            bot_account_id = getattr(bot.config, "account_id", None)
+            if bot_account_id and bot_account_id != account_id:
+                raise InvalidAccountIdError(
+                    f"(ipc.broker.reconcile) bot_id={bot_id!r} 의 account_id는 "
+                    f"{bot_account_id!r} 인데 요청은 {account_id!r} 입니다. "
+                    "다른 계좌의 포지션을 조작할 수 없습니다."
+                )
+
     broker_positions = args.get("broker_positions", [])
     adjustments = await svc.reconciler.reconcile(
         bot_id, broker_positions, account_id=account_id

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -570,16 +570,21 @@ async def _init_reconcile_scheduler(s: Services) -> None:
     )
 
     # 첫 번째 연결된 Broker를 ReconcileScheduler에 사용
+    # SPLIT-1: 단일 broker만 주입되므로 해당 broker의 account_id로 scheduler를
+    # 바인딩해, 다른 계좌의 봇에 이 broker의 positions가 잘못 적용되지 않도록
+    # 가드한다. multi-broker pool은 SPLIT-3에서 도입한다.
     broker = None
+    broker_account_id: str | None = None
     accounts = await s.account_service.list()
     for account in accounts:
         try:
             broker = await s.account_service.get_broker(account.account_id)
+            broker_account_id = account.account_id
             break
         except Exception:
             continue
 
-    if not broker:
+    if not broker or not broker_account_id:
         logger.info("ReconcileScheduler 건너뜀 — 연결된 Broker 없음")
         return
 
@@ -588,10 +593,15 @@ async def _init_reconcile_scheduler(s: Services) -> None:
         broker=broker,
         bot_manager=s.bot_manager,
         eventbus=s.eventbus,
+        broker_account_id=broker_account_id,
         interval_seconds=interval,
     )
     await s.reconcile_scheduler.start()
-    logger.info("ReconcileScheduler 시작 완료 (주기: %d초)", interval)
+    logger.info(
+        "ReconcileScheduler 시작 완료 (account=%s, 주기: %d초)",
+        broker_account_id,
+        interval,
+    )
 
 
 async def _init_daily_report_scheduler(s: Services) -> None:

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -500,7 +500,12 @@ async def _init_gateway(s: Services) -> None:
             try:
                 broker = await s.account_service.get_broker(account.account_id)
                 broker_config = {**account.credentials, **account.broker_config}
-                await _init_stream_integration(s, broker_config, stop_order_manager)
+                await _init_stream_integration(
+                    s,
+                    broker_config,
+                    stop_order_manager,
+                    account_id=account.account_id,
+                )
             except Exception:
                 logger.warning(
                     "StreamIntegration 초기화 실패: account=%s",
@@ -637,8 +642,17 @@ async def _init_stream_integration(
     s: Services,
     broker_config: dict,
     stop_order_manager: Any,
+    *,
+    account_id: str = "",
 ) -> None:
-    """KISStreamClient + StreamIntegration 초기화."""
+    """KISStreamClient + StreamIntegration 초기화.
+
+    SPLIT-1 (#1240): ``OrderFilledEvent``는 strict ``_requires_account_id``
+    marker를 가진다. 본 SPLIT 범위에서는 multi-account StreamIntegration
+    pool화는 하지 않고(SPLIT-3 #1242 영역 보존), 단일 인스턴스에 활성
+    KIS 계좌의 ``account_id``를 보강하여 broker payload fallback 시에도
+    체결 이벤트가 정상 발행되도록 한다.
+    """
     assert s.eventbus is not None
 
     from ante.broker.kis_stream import KISStreamClient
@@ -662,6 +676,7 @@ async def _init_stream_integration(
         stream_client=stream_client,
         cache=s.api_gateway._cache,
         eventbus=s.eventbus,
+        account_id=account_id,
         stop_order_manager=stop_order_manager,
         gateway=s.api_gateway,
         bot_manager=s.bot_manager,

--- a/src/ante/rule/base.py
+++ b/src/ante/rule/base.py
@@ -43,6 +43,9 @@ class RuleContext:
     """룰 평가 컨텍스트.
 
     RuleEngine이 OrderRequestEvent와 계좌 상태를 조합하여 생성한다.
+    ``account_id`` 는 dataclass field ordering 때문에 default를 유지
+    하지만, ``__post_init__`` 에서 :func:`require_account_id` 로 runtime
+    검증된다.
     """
 
     # 주문 정보
@@ -81,6 +84,13 @@ class RuleContext:
 
     # 추가 메타데이터
     metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        from ante.account.scoping import require_account_id
+
+        self.account_id = require_account_id(
+            self.account_id, context="rule_context.__post_init__"
+        )
 
 
 @dataclass

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -56,14 +56,19 @@ class RuleEngine:
     def __init__(
         self,
         eventbus: EventBus,
-        account_id: str = "default",
+        *,
+        account_id: str,
         account_service: AccountService | None = None,
         bot_strategy_resolver: Callable[[str], str | None] | None = None,
         treasury: Treasury | None = None,
         trade_service: TradeService | None = None,
     ) -> None:
+        from ante.account.scoping import require_account_id
+
         self._eventbus = eventbus
-        self._account_id = account_id
+        self._account_id = require_account_id(
+            account_id, context="rule_engine.__init__"
+        )
         self._account_service = account_service
         self._bot_strategy_resolver = bot_strategy_resolver
         self._treasury = treasury
@@ -627,6 +632,7 @@ class RuleEngine:
                 )
                 await self._eventbus.publish(
                     OrderModifyRejectedEvent(
+                        account_id=event.account_id,
                         order_id=event.order_id,
                         bot_id=event.bot_id,
                         strategy_id=event.strategy_id,
@@ -645,6 +651,7 @@ class RuleEngine:
             logger.exception("주문 정정 룰 평가 실패: %s", event.order_id)
             await self._eventbus.publish(
                 OrderModifyRejectedEvent(
+                    account_id=event.account_id,
                     order_id=event.order_id,
                     bot_id=event.bot_id,
                     strategy_id=event.strategy_id,

--- a/src/ante/trade/daily_report.py
+++ b/src/ante/trade/daily_report.py
@@ -154,9 +154,12 @@ class DailyReportScheduler:
         yesterday_str = yesterday.isoformat()
 
         # 1) Query today's filled trades
+        # 자기 계좌 거래만 집계 — 단일 계좌 바인딩된 스케줄러가
+        # cross-account 거래를 끌어오지 않도록 명시 필터 (#1240).
         from ante.trade.models import TradeStatus
 
         trades = await self._recorder.get_trades(
+            account_id=self._account_id,
             status=TradeStatus.FILLED,
             from_date=datetime.combine(today, time.min, tzinfo=KST),
             to_date=datetime.combine(today, time.max, tzinfo=KST),
@@ -229,14 +232,18 @@ class DailyReportScheduler:
             return False
 
         # Realized PnL from performance tracker (existing logic)
+        # 자기 계좌 성과만 집계 (#1240).
         summaries = await self._performance.get_daily_summary(
             start_date=today_str,
             end_date=today_str,
+            account_id=self._account_id,
         )
         realized_pnl = summaries[0].realized_pnl if summaries else 0.0
 
-        # Position count
-        all_positions = await self._positions.get_all_positions()
+        # Position count — 자기 계좌 포지션만 집계 (#1240).
+        all_positions = await self._positions.get_all_positions(
+            account_id=self._account_id
+        )
         position_count = len(all_positions)
 
         pnl_formatted = format_currency(realized_pnl, self._currency)

--- a/src/ante/trade/daily_report.py
+++ b/src/ante/trade/daily_report.py
@@ -90,11 +90,15 @@ class DailyReportScheduler:
         trade_recorder: TradeRecorder,
         position_history: PositionHistory,
         eventbus: EventBus,
+        *,
+        account_id: str,
         report_time: time = DEFAULT_REPORT_TIME,
-        account_id: str = "",
         currency: str = "KRW",
         treasury: Treasury | None = None,
     ) -> None:
+        from ante.account.scoping import require_account_id
+
+        account_id = require_account_id(account_id, context="daily_report.__init__")
         self._performance = performance_tracker
         self._recorder = trade_recorder
         self._positions = position_history

--- a/src/ante/trade/models.py
+++ b/src/ante/trade/models.py
@@ -7,6 +7,8 @@ from datetime import datetime
 from enum import StrEnum
 from uuid import UUID
 
+from ante.account.scoping import require_account_id
+
 
 class TradeType(StrEnum):
     """거래 유형."""
@@ -27,7 +29,11 @@ class TradeStatus(StrEnum):
 
 @dataclass
 class TradeRecord:
-    """개별 거래 기록."""
+    """개별 거래 기록.
+
+    ``account_id`` 는 dataclass field ordering 때문에 default를 유지하지만,
+    ``__post_init__`` 에서 :func:`require_account_id` 로 runtime 검증된다.
+    """
 
     trade_id: UUID
     bot_id: str
@@ -43,13 +49,22 @@ class TradeRecord:
     timestamp: datetime | None = None
     order_id: str | None = None
     exchange: str = "KRX"
-    account_id: str = "default"
+    account_id: str = ""
     currency: str = "KRW"
+
+    def __post_init__(self) -> None:
+        self.account_id = require_account_id(
+            self.account_id, context="trade_record.__post_init__"
+        )
 
 
 @dataclass
 class PositionSnapshot:
-    """특정 시점의 포지션 상태."""
+    """특정 시점의 포지션 상태.
+
+    ``account_id`` 는 dataclass field ordering 때문에 default를 유지하지만,
+    ``__post_init__`` 에서 :func:`require_account_id` 로 runtime 검증된다.
+    """
 
     bot_id: str
     symbol: str
@@ -58,7 +73,12 @@ class PositionSnapshot:
     realized_pnl: float = 0.0
     updated_at: str = ""
     exchange: str = "KRX"
-    account_id: str = "default"
+    account_id: str = ""
+
+    def __post_init__(self) -> None:
+        self.account_id = require_account_id(
+            self.account_id, context="position_snapshot.__post_init__"
+        )
 
 
 @dataclass(frozen=True)

--- a/src/ante/trade/performance.py
+++ b/src/ante/trade/performance.py
@@ -105,6 +105,8 @@ class PerformanceTracker:
         bot_id: str | None = None,
         start_date: str | None = None,
         end_date: str | None = None,
+        *,
+        account_id: str | None = None,
     ) -> list[DailySummary]:
         """일별 성과 집계.
 
@@ -112,6 +114,10 @@ class PerformanceTracker:
             bot_id: 봇 ID 필터 (None이면 전체)
             start_date: 시작일 (YYYY-MM-DD)
             end_date: 종료일 (YYYY-MM-DD)
+            account_id: 계좌 ID 필터. ``None`` 이면 모든 계좌의 거래를
+                집계한다 (read query 정책 — #1218 영역). 단일 계좌에
+                바인딩된 호출자(DailyReportScheduler 등)는 자기 계좌만
+                집계되도록 명시적으로 전달해야 한다 (#1240).
         """
         conditions: list[str] = [
             _COND_STATUS_FILLED,
@@ -122,6 +128,9 @@ class PerformanceTracker:
         if bot_id:
             conditions.append(_COND_BOT_ID)
             params.append(bot_id)
+        if account_id:
+            conditions.append("t.account_id = ?")
+            params.append(account_id)
         if start_date:
             conditions.append("date(t.timestamp) >= ?")
             params.append(start_date)

--- a/src/ante/trade/performance.py
+++ b/src/ante/trade/performance.py
@@ -8,6 +8,7 @@ import statistics
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from ante.account.errors import InvalidAccountIdError
 from ante.trade.models import (
     DailySummary,
     MonthlySummary,
@@ -361,7 +362,7 @@ class PerformanceTracker:
         except sqlite3.OperationalError:
             logger.debug("trades 테이블 없음 — 빈 목록 반환")
             return []
-        return [self._row_to_record(row) for row in rows]
+        return self._rows_to_records(rows, context="_get_filled_trades")
 
     async def _calculate_pnl_per_trade(
         self,
@@ -392,6 +393,37 @@ class PerformanceTracker:
                 pnl_list.append(-trade.commission if trade.commission else 0.0)
         return pnl_list
 
+    @classmethod
+    def _rows_to_records(cls, rows: list[dict], *, context: str) -> list[TradeRecord]:
+        """rows → TradeRecord 목록, legacy invalid account_id row는 skip."""
+        records: list[TradeRecord] = []
+        for row in rows:
+            record = cls._row_to_record_safe(row, context=context)
+            if record is not None:
+                records.append(record)
+        return records
+
+    @classmethod
+    def _row_to_record_safe(cls, row: dict, *, context: str) -> TradeRecord | None:
+        """DB row → TradeRecord, legacy invalid account_id row는 skip.
+
+        legacy ``account_id='default'`` (또는 기타 invalid) 값을 가진 row는
+        :class:`InvalidAccountIdError` 로 skip하고 warning만 남긴다.
+        스키마/데이터 마이그레이션(#1219 등)이 완료되기 전에도 성과 산출
+        경로가 실패하지 않도록 하기 위함이다.
+        """
+        try:
+            return cls._row_to_record(row)
+        except InvalidAccountIdError as e:
+            logger.warning(
+                "%s: invalid account_id trade row skip "
+                "(legacy migration 필요): %s, row=%s",
+                context,
+                e,
+                dict(row),
+            )
+            return None
+
     @staticmethod
     def _row_to_record(row: dict) -> TradeRecord:
         """DB row → TradeRecord."""
@@ -419,7 +451,7 @@ class PerformanceTracker:
             commission=float(row.get("commission", 0)),
             timestamp=datetime.fromisoformat(ts) if ts else None,
             order_id=row.get("order_id"),
-            account_id=row.get("account_id", "default"),
+            account_id=row["account_id"],
             currency=row.get("currency", "KRW"),
         )
 

--- a/src/ante/trade/position.py
+++ b/src/ante/trade/position.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from ante.account.errors import InvalidAccountIdError
+from ante.account.scoping import require_account_id
 from ante.trade.models import PositionSnapshot, TradeRecord, TradeStatus
 
 if TYPE_CHECKING:
@@ -60,11 +62,19 @@ class PositionHistory:
         logger.info("PositionHistory 초기화 완료")
 
     async def _warm_cache(self) -> None:
-        """DB에서 전체 포지션을 읽어 인메모리 캐시에 적재."""
+        """DB에서 전체 포지션을 읽어 인메모리 캐시에 적재.
+
+        legacy 'default' (또는 기타 invalid) ``account_id`` row는
+        :class:`InvalidAccountIdError` 로 skip하고 warning만 남긴다.
+        스키마/데이터 마이그레이션(#1219 등)이 완료되기 전에도 서버 부팅이
+        실패하지 않도록 하기 위함이다.
+        """
         rows = await self._db.fetch_all("SELECT * FROM positions WHERE quantity > 0")
         self._position_cache.clear()
         for row in rows:
-            snapshot = self._row_to_snapshot(row)
+            snapshot = self._row_to_snapshot_safe(row, context="warm cache")
+            if snapshot is None:
+                continue
             self._position_cache.setdefault(snapshot.bot_id, {})[snapshot.symbol] = (
                 snapshot
             )
@@ -156,7 +166,12 @@ class PositionHistory:
         bot_id: str,
         include_closed: bool = False,
     ) -> list[PositionSnapshot]:
-        """봇의 현재 포지션 조회."""
+        """봇의 현재 포지션 조회.
+
+        legacy 'default' (또는 기타 invalid) ``account_id`` row는 skip하고
+        warning만 남긴다. dashboard / Treasury 동기화가 마이그레이션 전에도
+        실패하지 않도록 하기 위함이다.
+        """
         if include_closed:
             rows = await self._db.fetch_all(
                 "SELECT * FROM positions WHERE bot_id = ?", (bot_id,)
@@ -166,12 +181,16 @@ class PositionHistory:
                 "SELECT * FROM positions WHERE bot_id = ? AND quantity > 0",
                 (bot_id,),
             )
-        return [self._row_to_snapshot(row) for row in rows]
+        return self._rows_to_snapshots(rows, context="get_positions")
 
     async def get_all_positions(self) -> list[PositionSnapshot]:
-        """전체 봇의 모든 포지션 조회 (대사 계좌 합산 검증용)."""
+        """전체 봇의 모든 포지션 조회 (대사 계좌 합산 검증용).
+
+        legacy 'default' (또는 기타 invalid) ``account_id`` row는 skip하고
+        warning만 남긴다.
+        """
         rows = await self._db.fetch_all("SELECT * FROM positions WHERE quantity > 0")
-        return [self._row_to_snapshot(row) for row in rows]
+        return self._rows_to_snapshots(rows, context="get_all_positions")
 
     async def get_current(self, bot_id: str, symbol: str) -> dict:
         """현재 포지션 조회 (public)."""
@@ -205,20 +224,28 @@ class PositionHistory:
         symbol: str,
         quantity: float,
         avg_entry_price: float,
+        *,
+        account_id: str,
     ) -> None:
         """Reconciler 전용: 포지션 강제 덮어쓰기."""
+        validated_account_id = require_account_id(
+            account_id, context="position.force_update"
+        )
         await self._db.execute(
             """INSERT INTO positions
-               (bot_id, symbol, quantity, avg_entry_price, updated_at)
-               VALUES (?, ?, ?, ?, datetime('now'))
+               (bot_id, symbol, quantity, avg_entry_price, account_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, datetime('now'))
                ON CONFLICT(bot_id, symbol) DO UPDATE SET
                  quantity = excluded.quantity,
                  avg_entry_price = excluded.avg_entry_price,
+                 account_id = excluded.account_id,
                  updated_at = excluded.updated_at""",
-            (bot_id, symbol, quantity, avg_entry_price),
+            (bot_id, symbol, quantity, avg_entry_price, validated_account_id),
         )
         # 인메모리 캐시 갱신
-        self._update_cache(bot_id, symbol, quantity, avg_entry_price)
+        self._update_cache(
+            bot_id, symbol, quantity, avg_entry_price, account_id=account_id
+        )
 
     async def _get_current(self, bot_id: str, symbol: str) -> dict:
         """현재 포지션 조회. 없으면 빈 포지션 반환."""
@@ -242,8 +269,9 @@ class PositionHistory:
         symbol: str,
         quantity: float,
         avg_entry_price: float,
+        *,
+        account_id: str,
         realized_pnl_delta: float = 0.0,
-        account_id: str = "default",
     ) -> None:
         """포지션 상태 갱신."""
         await self._db.execute(
@@ -272,7 +300,12 @@ class PositionHistory:
         )
         # 인메모리 캐시 갱신
         self._update_cache(
-            bot_id, symbol, quantity, avg_entry_price, realized_pnl_delta, account_id
+            bot_id,
+            symbol,
+            quantity,
+            avg_entry_price,
+            account_id=account_id,
+            realized_pnl_delta=realized_pnl_delta,
         )
 
     def _update_cache(
@@ -281,8 +314,9 @@ class PositionHistory:
         symbol: str,
         quantity: float,
         avg_entry_price: float,
+        *,
+        account_id: str,
         realized_pnl_delta: float = 0.0,
-        account_id: str = "default",
     ) -> None:
         """인메모리 포지션 캐시 갱신."""
         bot_cache = self._position_cache.setdefault(bot_id, {})
@@ -333,5 +367,37 @@ class PositionHistory:
             avg_entry_price=float(row["avg_entry_price"]),
             realized_pnl=float(row.get("realized_pnl", 0)),
             updated_at=row.get("updated_at", ""),
-            account_id=row.get("account_id", "default"),
+            account_id=row["account_id"],
         )
+
+    def _row_to_snapshot_safe(
+        self, row: dict, *, context: str
+    ) -> PositionSnapshot | None:
+        """DB row → PositionSnapshot, legacy invalid account_id row는 skip.
+
+        legacy 'default' (또는 기타 invalid) ``account_id`` row는
+        :class:`InvalidAccountIdError` 로 skip하고 warning만 남긴다.
+        스키마/데이터 마이그레이션(#1219 등)이 완료되기 전에도 read 경로가
+        실패하지 않도록 하기 위함이다.
+        """
+        try:
+            return self._row_to_snapshot(row)
+        except InvalidAccountIdError as e:
+            logger.warning(
+                "%s: invalid account_id row skip (legacy migration 필요): %s, row=%s",
+                context,
+                e,
+                dict(row),
+            )
+            return None
+
+    def _rows_to_snapshots(
+        self, rows: list[dict], *, context: str
+    ) -> list[PositionSnapshot]:
+        """rows → snapshots, legacy invalid account_id row는 skip."""
+        snapshots: list[PositionSnapshot] = []
+        for row in rows:
+            snapshot = self._row_to_snapshot_safe(row, context=context)
+            if snapshot is not None:
+                snapshots.append(snapshot)
+        return snapshots

--- a/src/ante/trade/position.py
+++ b/src/ante/trade/position.py
@@ -185,13 +185,31 @@ class PositionHistory:
             )
         return self._rows_to_snapshots(rows, context="get_positions")
 
-    async def get_all_positions(self) -> list[PositionSnapshot]:
+    async def get_all_positions(
+        self,
+        *,
+        account_id: str | None = None,
+    ) -> list[PositionSnapshot]:
         """전체 봇의 모든 포지션 조회 (대사 계좌 합산 검증용).
+
+        Args:
+            account_id: 계좌 ID 필터. ``None`` 이면 모든 계좌의 포지션을
+                반환한다 (read query 정책 — #1218 영역). 단일 계좌에
+                바인딩된 호출자(Treasury, DailyReportScheduler 등)는
+                자기 계좌만 보도록 명시적으로 전달해야 한다.
 
         legacy 'default' (또는 기타 invalid) ``account_id`` row는 skip하고
         warning만 남긴다.
         """
-        rows = await self._db.fetch_all("SELECT * FROM positions WHERE quantity > 0")
+        if account_id is None:
+            rows = await self._db.fetch_all(
+                "SELECT * FROM positions WHERE quantity > 0"
+            )
+        else:
+            rows = await self._db.fetch_all(
+                "SELECT * FROM positions WHERE quantity > 0 AND account_id = ?",
+                (account_id,),
+            )
         return self._rows_to_snapshots(rows, context="get_all_positions")
 
     async def get_current(self, bot_id: str, symbol: str) -> dict:

--- a/src/ante/trade/position.py
+++ b/src/ante/trade/position.py
@@ -115,6 +115,7 @@ class PositionHistory:
                 price=record.price,
                 pnl=0.0,
                 timestamp=record.timestamp,
+                account_id=record.account_id,
                 exchange=record.exchange,
                 trade_id=str(record.trade_id),
             )
@@ -157,6 +158,7 @@ class PositionHistory:
                 price=record.price,
                 pnl=pnl,
                 timestamp=record.timestamp,
+                account_id=record.account_id,
                 exchange=record.exchange,
                 trade_id=str(record.trade_id),
             )
@@ -344,17 +346,38 @@ class PositionHistory:
         price: float,
         pnl: float,
         timestamp: object | None,
+        *,
+        account_id: str,
         exchange: str = "KRX",
         trade_id: str | None = None,
     ) -> None:
-        """포지션 변동 이력 저장."""
+        """포지션 변동 이력 저장.
+
+        ``account_id``는 호출자에서 ``record.account_id``를 그대로 전달하며,
+        :func:`require_account_id`로 검증한다. 누락 시 schema default
+        ``'default'``로 저장되던 회귀(#1240 review)를 차단한다.
+        """
+        validated_account_id = require_account_id(
+            account_id, context="position._save_history"
+        )
         ts = timestamp.isoformat() if hasattr(timestamp, "isoformat") else None
         await self._db.execute(
             """INSERT INTO position_history
                (bot_id, symbol, action, quantity, price, pnl, timestamp,
-                exchange, trade_id)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (bot_id, symbol, action, quantity, price, pnl, ts, exchange, trade_id),
+                exchange, trade_id, account_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                bot_id,
+                symbol,
+                action,
+                quantity,
+                price,
+                pnl,
+                ts,
+                exchange,
+                trade_id,
+                validated_account_id,
+            ),
         )
 
     @staticmethod

--- a/src/ante/trade/reconciler.py
+++ b/src/ante/trade/reconciler.py
@@ -27,6 +27,8 @@ class PositionReconciler:
         self,
         bot_id: str,
         broker_positions: list[dict[str, Any]],
+        *,
+        account_id: str,
     ) -> list[dict[str, Any]]:
         """봇의 내부 포지션과 브로커 포지션을 대조하여 보정.
 
@@ -34,6 +36,7 @@ class PositionReconciler:
             bot_id: 대상 봇 ID.
             broker_positions: 브로커 실제 보유.
                 [{"symbol": str, "quantity": float, "avg_price": float}, ...]
+            account_id: 봇이 귀속된 account_id (포지션 보정 시 명시 필수).
 
         Returns:
             보정 내역 리스트. 불일치가 없으면 빈 리스트.
@@ -123,6 +126,7 @@ class PositionReconciler:
                 quantity=b_qty,
                 avg_price=b_avg if b_avg > 0 else None,
                 reason=reason,
+                account_id=account_id,
             )
             corrections.append(correction)
 

--- a/src/ante/trade/recorder.py
+++ b/src/ante/trade/recorder.py
@@ -300,8 +300,23 @@ class TradeRecorder:
         offset: int = 0,
     ) -> list[TradeRecord]:
         """거래 기록 조회."""
+        from ante.account.scoping import INVALID_RUNTIME_ACCOUNT_IDS
+
         conditions: list[str] = []
         params: list[Any] = []
+
+        # Refs #1240 review (P2-3): legacy invalid account_id row를 SQL 단계에서
+        # 제외해야 LIMIT/OFFSET 페이지네이션이 정확해진다. Python 단계 skip만으로는
+        # legacy default row가 첫 페이지를 가득 채울 때 유효 거래가 다음 페이지에
+        # 묻혀 underflow 가 발생한다. SSOT (``INVALID_RUNTIME_ACCOUNT_IDS``) 와
+        # 빈 문자열/NULL을 함께 제외한다.
+        invalid_ids = sorted(INVALID_RUNTIME_ACCOUNT_IDS)
+        invalid_placeholders = ", ".join("?" for _ in invalid_ids)
+        conditions.append(
+            f"account_id IS NOT NULL AND account_id != '' "
+            f"AND account_id NOT IN ({invalid_placeholders})"
+        )
+        params.extend(invalid_ids)
 
         if account_id:
             conditions.append("account_id = ?")
@@ -325,7 +340,7 @@ class TradeRecorder:
             conditions.append("timestamp <= ?")
             params.append(to_date.isoformat())
 
-        where = " AND ".join(conditions) if conditions else "1=1"
+        where = " AND ".join(conditions)
         query = f"""SELECT * FROM trades
                     WHERE {where}
                     ORDER BY timestamp DESC

--- a/src/ante/trade/recorder.py
+++ b/src/ante/trade/recorder.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+from ante.account.errors import InvalidAccountIdError
 from ante.trade.models import TradeRecord, TradeStatus
 
 if TYPE_CHECKING:
@@ -95,6 +96,7 @@ class TradeRecorder:
             timestamp=event.timestamp,
             order_id=event.order_id,
             exchange=event.exchange,
+            account_id=event.account_id,
         )
         await self._save(record)
         await self._position_history.on_trade(record)
@@ -150,6 +152,7 @@ class TradeRecorder:
             order_type=event.order_type,
             reason=event.reason,
             timestamp=event.timestamp,
+            account_id=event.account_id,
         )
         await self._save(record)
 
@@ -172,6 +175,7 @@ class TradeRecorder:
             order_type=event.order_type,
             reason=event.error_message,
             timestamp=event.timestamp,
+            account_id=event.account_id,
         )
         await self._save(record)
 
@@ -195,6 +199,7 @@ class TradeRecorder:
             reason=event.reason,
             timestamp=event.timestamp,
             order_id=event.order_id,
+            account_id=event.account_id,
         )
         await self._save(record)
 
@@ -257,20 +262,28 @@ class TradeRecorder:
         old_quantity: float,
         new_quantity: float,
         reason: str,
+        *,
+        account_id: str,
     ) -> None:
         """대사 보정 이력 기록."""
+        from ante.account.scoping import require_account_id
+
+        account_id = require_account_id(
+            account_id, context="trade_recorder.save_adjustment"
+        )
         await self._db.execute(
             """INSERT INTO trades
                (trade_id, bot_id, strategy_id, symbol, side, quantity, price,
-                status, order_type, reason, timestamp)
+                status, order_type, reason, timestamp, account_id)
                VALUES (?, ?, '', ?, 'adjustment', ?, 0.0, 'adjusted', '', ?,
-                       datetime('now'))""",
+                       datetime('now'), ?)""",
             (
                 str(uuid4()),
                 bot_id,
                 symbol,
                 abs(new_quantity - old_quantity),
                 reason,
+                account_id,
             ),
         )
 
@@ -320,7 +333,38 @@ class TradeRecorder:
         params.extend([limit, offset])
 
         rows = await self._db.fetch_all(query, tuple(params))
-        return [self._row_to_record(row) for row in rows]
+        return self._rows_to_records(rows, context="get_trades")
+
+    @classmethod
+    def _rows_to_records(cls, rows: list[dict], *, context: str) -> list[TradeRecord]:
+        """rows → TradeRecord 목록, legacy invalid account_id row는 skip."""
+        records: list[TradeRecord] = []
+        for row in rows:
+            record = cls._row_to_record_safe(row, context=context)
+            if record is not None:
+                records.append(record)
+        return records
+
+    @classmethod
+    def _row_to_record_safe(cls, row: dict, *, context: str) -> TradeRecord | None:
+        """DB row → TradeRecord, legacy invalid account_id row는 skip.
+
+        legacy ``account_id='default'`` (또는 기타 invalid) 값을 가진 row는
+        :class:`InvalidAccountIdError` 로 skip하고 warning만 남긴다.
+        스키마/데이터 마이그레이션(#1219 등)이 완료되기 전에도 trade read
+        경로(get_trades, DailyReport 등)가 실패하지 않도록 하기 위함이다.
+        """
+        try:
+            return cls._row_to_record(row)
+        except InvalidAccountIdError as e:
+            logger.warning(
+                "%s: invalid account_id trade row skip "
+                "(legacy migration 필요): %s, row=%s",
+                context,
+                e,
+                dict(row),
+            )
+            return None
 
     @staticmethod
     def _row_to_record(row: dict) -> TradeRecord:
@@ -349,6 +393,6 @@ class TradeRecorder:
             commission=float(row.get("commission", 0)),
             timestamp=datetime.fromisoformat(ts) if ts else None,
             order_id=row.get("order_id"),
-            account_id=row.get("account_id", "default"),
+            account_id=row["account_id"],
             currency=row.get("currency", "KRW"),
         )

--- a/src/ante/trade/service.py
+++ b/src/ante/trade/service.py
@@ -130,10 +130,21 @@ class TradeService:
         bot_id: str,
         symbol: str,
         quantity: float,
+        *,
+        account_id: str,
         avg_price: float | None = None,
         reason: str = "",
     ) -> dict:
-        """포지션을 브로커 기준으로 강제 보정. Reconciler가 호출."""
+        """포지션을 브로커 기준으로 강제 보정. Reconciler가 호출.
+
+        ``account_id`` 는 메서드 진입 시 ``require_account_id`` 로 검증한다.
+        force_update는 즉시 DB commit하므로, invalid 값이 일시적으로라도
+        positions 테이블에 들어가지 않도록 사전 차단해야 한다.
+        """
+        from ante.account.scoping import require_account_id
+
+        account_id = require_account_id(account_id, context="correct_position")
+
         old = await self._position_history.get_current(bot_id=bot_id, symbol=symbol)
         old_qty = old.get("quantity", 0)
         old_avg = old.get("avg_entry_price", 0.0)
@@ -143,6 +154,7 @@ class TradeService:
             symbol=symbol,
             quantity=quantity,
             avg_entry_price=avg_price if avg_price else old_avg,
+            account_id=account_id,
         )
 
         await self._recorder.save_adjustment(
@@ -151,6 +163,7 @@ class TradeService:
             old_quantity=old_qty,
             new_quantity=quantity,
             reason=reason,
+            account_id=account_id,
         )
 
         return {
@@ -167,6 +180,8 @@ class TradeService:
         bot_id: str,
         strategy_id: str,
         fill: dict,
+        *,
+        account_id: str,
         reason: str = "reconciliation",
     ) -> None:
         """누락된 체결 기록을 보정 추가. Reconciler가 호출."""
@@ -184,5 +199,6 @@ class TradeService:
             commission=fill.get("commission", 0.0),
             timestamp=fill.get("timestamp"),
             order_id=fill.get("order_id"),
+            account_id=account_id,
         )
         await self._recorder.save(record)

--- a/src/ante/treasury/models.py
+++ b/src/ante/treasury/models.py
@@ -8,10 +8,15 @@ from datetime import UTC, datetime
 
 @dataclass
 class BotBudget:
-    """봇별 예산 상태."""
+    """봇별 예산 상태.
+
+    ``account_id`` 는 필수다 — write 경로의 fallback 금지 정책
+    (`docs/specs/account/14-account-id-contract.md`) 에 따라 빈 값/
+    fallback 값을 거부한다.
+    """
 
     bot_id: str
-    account_id: str = ""
+    account_id: str
     allocated: float = 0.0
     available: float = 0.0
     reserved: float = 0.0

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -844,8 +844,12 @@ class Treasury:
         await self.sync_balance(balance_data)
 
         # 2) KIS 보유종목 (output1) + Trade 내부 포지션 대조
+        # 자기 계좌 포지션만 조회: 단일 계좌 바인딩 인스턴스에서 cross-account
+        # 데이터가 섞이지 않도록 명시적으로 account_id 필터를 전달한다 (#1240).
         broker_positions = await broker.get_positions()
-        internal_positions = await position_history.get_all_positions()
+        internal_positions = await position_history.get_all_positions(
+            account_id=self._account_id
+        )
         internal_symbols = {p.symbol for p in internal_positions}
 
         external_purchase = 0.0
@@ -894,7 +898,10 @@ class Treasury:
         """
         from ante.eventbus.events import BalanceSyncedEvent
 
-        positions = await position_history.get_all_positions()
+        # 자기 계좌 포지션만 조회 (#1240).
+        positions = await position_history.get_all_positions(
+            account_id=self._account_id
+        )
 
         purchase_amount = 0.0
         eval_amount = 0.0

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -8,6 +8,7 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+from ante.account.scoping import require_account_id
 from ante.treasury.models import BotBudget
 
 if TYPE_CHECKING:
@@ -146,7 +147,8 @@ class Treasury:
         self,
         db: Database,
         eventbus: EventBus,
-        account_id: str = "default",
+        *,
+        account_id: str,
         currency: str = "KRW",
         buy_commission_rate: float = 0.00015,
         sell_commission_rate: float = 0.00195,
@@ -154,7 +156,7 @@ class Treasury:
     ) -> None:
         self._db = db
         self._eventbus = eventbus
-        self._account_id = account_id
+        self._account_id = require_account_id(account_id, context="treasury.__init__")
         self._currency = currency
         self._buy_commission_rate = buy_commission_rate
         self._sell_commission_rate = sell_commission_rate
@@ -575,11 +577,15 @@ class Treasury:
     # -- 이벤트 핸들러 -------------------------------------------
 
     def _is_my_event(self, event: object) -> bool:
-        """이벤트가 이 Treasury의 계좌에 해당하는지 확인."""
-        account_id = getattr(event, "account_id", "")
-        # account_id가 비어있으면 (하위 호환) 처리
-        if not account_id:
-            return True
+        """이벤트가 이 Treasury의 계좌에 해당하는지 확인.
+
+        AccountScopedEvent는 ``__post_init__`` 에서 valid account_id 보장이
+        되므로, 여기서는 단순히 일치 여부만 확인한다. account_id 필드가
+        없는 이벤트는 무시한다.
+        """
+        account_id = getattr(event, "account_id", None)
+        if account_id is None:
+            return False
         return account_id == self._account_id
 
     async def _on_order_validated(self, event: object) -> None:

--- a/src/ante/web/routes/trades.py
+++ b/src/ante/web/routes/trades.py
@@ -47,9 +47,7 @@ async def list_trades(
         {
             "trade_id": str(t.trade_id),
             "bot_id": str(t.bot_id) if t.bot_id else "",
-            "account_id": str(a)
-            if isinstance(a := getattr(t, "account_id", ""), str)
-            else "",
+            "account_id": t.account_id,
             "symbol": t.symbol,
             "side": t.side,
             "quantity": t.quantity,

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -507,7 +507,7 @@ async def get_latest_snapshot(
     today = now.strftime("%Y-%m-%d")
     return {
         "snapshot": {
-            "account_id": getattr(target, "account_id", ""),
+            "account_id": target.account_id,
             "snapshot_date": today,
             "total_asset": summary.get("total_evaluation", 0.0),
             "ante_eval_amount": summary.get("ante_eval_amount", 0.0),

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -203,7 +203,11 @@ class MeResponse(BaseModel):
 
 
 class BotInfo(BaseModel):
-    """봇 정보."""
+    """봇 정보 (read 응답).
+
+    write 경로(``BotConfig``, ``ApprovalService.create``)에서 account_id가
+    검증되므로 read 응답 schema에는 default를 유지한다.
+    """
 
     bot_id: str
     name: str = ""
@@ -742,7 +746,11 @@ class MemberScopesResponse(BaseModel):
 
 
 class TradeItem(BaseModel):
-    """거래 기록 아이템."""
+    """거래 기록 아이템 (read 응답).
+
+    write 경로(``TradeRecord``)에서 account_id가 검증되므로 read 응답
+    schema에는 default를 유지한다.
+    """
 
     trade_id: str
     bot_id: str

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -276,3 +276,122 @@ class TestSystemKillSwitchHandlers:
         svc.bot_manager.start_bot.assert_not_called()
         svc.bot_manager.restart_bot.assert_not_called()
         svc.bot_manager.start_all.assert_not_called()
+
+
+# ── broker.reconcile cross-account guard (Refs #1240 review P2-1) ──
+
+
+class TestHandleBrokerReconcile:
+    """broker.reconcile IPC 핸들러의 account 일치 가드.
+
+    Refs #1240 review (P2-1): 요청자가 ``bot_id`` 와 다른 ``account_id`` 를
+    보내면 잘못된 account_id 가 ``reconciler.reconcile(...)`` 으로 흘러
+    다른 계좌의 positions / adjustment trade 가 손상된다. BotManager 로
+    봇의 실제 account_id 를 조회하여 일치하지 않으면 거부한다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_broker_reconcile_rejects_account_mismatch(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ante.account.errors import InvalidAccountIdError
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        # 봇은 acc-a 소속인데 요청은 acc-b 로 들어옴.
+        fake_bot = MagicMock()
+        fake_bot.config = MagicMock()
+        fake_bot.config.account_id = "acc-a"
+
+        fake_bot_manager = MagicMock()
+        fake_bot_manager.get_bot.return_value = fake_bot
+
+        fake_reconciler = AsyncMock()
+
+        svc = MagicMock()
+        svc.bot_manager = fake_bot_manager
+        svc.reconciler = fake_reconciler
+
+        with pytest.raises(InvalidAccountIdError, match="acc-a"):
+            await _handle_broker_reconcile(
+                svc,
+                {
+                    "bot_id": "bot-1",
+                    "account_id": "acc-b",
+                    "broker_positions": [],
+                },
+                "cli-user",
+            )
+
+        # reconcile 까지 절대 도달하지 않아야 한다.
+        fake_reconciler.reconcile.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_broker_reconcile_passes_when_account_matches(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        fake_bot = MagicMock()
+        fake_bot.config = MagicMock()
+        fake_bot.config.account_id = "acc-a"
+
+        fake_bot_manager = MagicMock()
+        fake_bot_manager.get_bot.return_value = fake_bot
+
+        fake_reconciler = AsyncMock()
+        fake_reconciler.reconcile.return_value = []
+
+        svc = MagicMock()
+        svc.bot_manager = fake_bot_manager
+        svc.reconciler = fake_reconciler
+
+        result = await _handle_broker_reconcile(
+            svc,
+            {
+                "bot_id": "bot-1",
+                "account_id": "acc-a",
+                "broker_positions": [],
+            },
+            "cli-user",
+        )
+
+        assert result == {"bot_id": "bot-1", "adjustments": []}
+        fake_reconciler.reconcile.assert_awaited_once_with(
+            "bot-1", [], account_id="acc-a"
+        )
+
+    @pytest.mark.asyncio
+    async def test_broker_reconcile_passes_when_bot_not_found(self):
+        """알 수 없는 ``bot_id`` 는 reconcile 단계에서 처리되도록 통과시킨다.
+
+        BotManager 에 없는 봇이라도 mismatch 검증 단계에서 false negative 로
+        막아버리면 cold-path / migration 시나리오가 깨진다. account_id 형식
+        검증은 ``require_account_id`` 가 이미 수행하므로 이 단계는 mismatch
+        만 책임진다.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ante.ipc.registry import _handle_broker_reconcile
+
+        fake_bot_manager = MagicMock()
+        fake_bot_manager.get_bot.return_value = None
+
+        fake_reconciler = AsyncMock()
+        fake_reconciler.reconcile.return_value = []
+
+        svc = MagicMock()
+        svc.bot_manager = fake_bot_manager
+        svc.reconciler = fake_reconciler
+
+        result = await _handle_broker_reconcile(
+            svc,
+            {
+                "bot_id": "unknown-bot",
+                "account_id": "acc-a",
+                "broker_positions": [],
+            },
+            "cli-user",
+        )
+
+        assert result == {"bot_id": "unknown-bot", "adjustments": []}
+        fake_reconciler.reconcile.assert_awaited_once()

--- a/tests/unit/test_account_delete_events.py
+++ b/tests/unit/test_account_delete_events.py
@@ -83,8 +83,8 @@ class TestAccountDeleteEvents:
         """delete()는 AccountSuspendedEvent만 발행한다.
 
         AccountDeletedEvent는 1.0 비계약이므로 발행되지 않는다.
-        AccountSuspendedEvent(reason="Account deletion")는 BotManager가 소속
-        봇을 중지시키도록 유지된다.
+        AccountSuspendedEvent(reason="Account deletion")는 BotManager가
+        소속 봇을 중지시키도록 유지된다.
         """
         await service.create(_make_account())
 

--- a/tests/unit/test_api_pagination.py
+++ b/tests/unit/test_api_pagination.py
@@ -132,6 +132,7 @@ class TestTradesEndpointPagination:
             t = MagicMock()
             t.trade_id = f"trd-{i}"
             t.bot_id = "bot-1"
+            t.account_id = "acc-test"
             t.symbol = "005930"
             t.side = "buy"
             t.quantity = 10

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -135,6 +135,7 @@ def simple_config():
         bot_id="bot1",
         strategy_id="simple_v1.0.0",
         interval_seconds=10,  # 테스트용: 최소 유효 간격
+        account_id="acc-test",
     )
 
 
@@ -144,14 +145,16 @@ def simple_config():
 class TestBotConfig:
     def test_defaults(self):
         """BotConfig 기본값."""
-        c = BotConfig(bot_id="b1", strategy_id="s1")
+        c = BotConfig(bot_id="b1", strategy_id="s1", account_id="acc-test")
         assert c.name == ""
-        assert c.account_id == "test"
+        assert c.account_id == "acc-test"
         assert c.interval_seconds == 60
 
     def test_name_field(self):
         """BotConfig name 필드 설정."""
-        c = BotConfig(bot_id="b1", strategy_id="s1", name="테스트 봇")
+        c = BotConfig(
+            bot_id="b1", strategy_id="s1", name="테스트 봇", account_id="acc-test"
+        )
         assert c.name == "테스트 봇"
 
     def test_bot_status_values(self):
@@ -163,28 +166,41 @@ class TestBotConfig:
 
     def test_interval_min_valid(self):
         """최소 간격 10초 허용."""
-        c = BotConfig(bot_id="b1", strategy_id="s1", interval_seconds=10)
+        c = BotConfig(
+            bot_id="b1", strategy_id="s1", interval_seconds=10, account_id="acc-test"
+        )
         assert c.interval_seconds == 10
 
     def test_interval_max_valid(self):
         """최대 간격 3600초 허용."""
-        c = BotConfig(bot_id="b1", strategy_id="s1", interval_seconds=3600)
+        c = BotConfig(
+            bot_id="b1", strategy_id="s1", interval_seconds=3600, account_id="acc-test"
+        )
         assert c.interval_seconds == 3600
 
     def test_interval_below_min_raises(self):
         """10초 미만이면 ValueError."""
         with pytest.raises(ValueError, match="10초 이상"):
-            BotConfig(bot_id="b1", strategy_id="s1", interval_seconds=5)
+            BotConfig(
+                bot_id="b1", strategy_id="s1", interval_seconds=5, account_id="acc-test"
+            )
 
     def test_interval_above_max_raises(self):
         """3600초 초과면 ValueError."""
         with pytest.raises(ValueError, match="3600초 이하"):
-            BotConfig(bot_id="b1", strategy_id="s1", interval_seconds=7200)
+            BotConfig(
+                bot_id="b1",
+                strategy_id="s1",
+                interval_seconds=7200,
+                account_id="acc-test",
+            )
 
     def test_interval_zero_raises(self):
         """0초면 ValueError."""
         with pytest.raises(ValueError):
-            BotConfig(bot_id="b1", strategy_id="s1", interval_seconds=0)
+            BotConfig(
+                bot_id="b1", strategy_id="s1", interval_seconds=0, account_id="acc-test"
+            )
 
 
 # ── Bot 생명주기 ─────────────────────────────────
@@ -269,6 +285,7 @@ class TestBot:
             bot_id="bot1",
             strategy_id="error_v1.0.0",
             interval_seconds=10,
+            account_id="acc-test",
         )
         bot = Bot(
             config=config,
@@ -292,6 +309,7 @@ class TestBot:
             bot_id="bot1",
             strategy_id="buy_v1.0.0",
             interval_seconds=10,
+            account_id="acc-test",
         )
         received = []
         eventbus.subscribe(OrderRequestEvent, lambda e: received.append(e))
@@ -319,6 +337,7 @@ class TestBot:
             bot_id="bot1",
             strategy_id="error_v1.0.0",
             interval_seconds=10,
+            account_id="acc-test",
         )
         received = []
         eventbus.subscribe(BotErrorEvent, lambda e: received.append(e))
@@ -343,6 +362,7 @@ class TestBot:
             bot_id="bot1",
             strategy_id="fill_react_v1.0.0",
             interval_seconds=999,  # 루프 호출 방지
+            account_id="acc-test",
         )
         received = []
         eventbus.subscribe(OrderRequestEvent, lambda e: received.append(e))
@@ -367,6 +387,7 @@ class TestBot:
                 quantity=10.0,
                 price=50000.0,
                 order_type="market",
+                account_id="acc-test",
             )
         )
 
@@ -402,6 +423,7 @@ class TestBot:
                 quantity=10.0,
                 price=50000.0,
                 order_type="market",
+                account_id="acc-test",
             )
         )
 
@@ -439,6 +461,7 @@ class TestBot:
                 quantity=10.0,
                 order_type="market",
                 reason="insufficient funds",
+                account_id="acc-test",
             )
         )
 
@@ -466,6 +489,7 @@ class TestBot:
                 bot_id="bot1",
                 strategy_id="c_v1.0.0",
                 interval_seconds=10,
+                account_id="acc-test",
             ),
             strategy_cls=CancelStrategy,
             ctx=ctx,
@@ -503,6 +527,7 @@ class TestBot:
             strategy_id="s1",
             name="모멘텀 봇",
             interval_seconds=10,
+            account_id="acc-test",
         )
         bot = Bot(
             config=config,
@@ -516,9 +541,7 @@ class TestBot:
     def test_get_info_includes_trading_mode_exchange_currency(self, eventbus, ctx):
         """get_info()에 trading_mode, exchange, currency 포함."""
         config = BotConfig(
-            bot_id="bot1",
-            strategy_id="s1",
-            interval_seconds=10,
+            bot_id="bot1", strategy_id="s1", interval_seconds=10, account_id="acc-test"
         )
         bot = Bot(
             config=config,
@@ -566,21 +589,23 @@ class TestBotManager:
 
     async def test_create_bot(self, manager, eventbus, ctx):
         """봇 생성."""
-        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
         bot = await manager.create_bot(config, SimpleStrategy, ctx)
         assert bot.status == BotStatus.CREATED
         assert manager.get_bot("bot1") is bot
 
     async def test_create_duplicate_raises(self, manager, eventbus, ctx):
         """중복 봇 생성 시 에러."""
-        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
         await manager.create_bot(config, SimpleStrategy, ctx)
         with pytest.raises(BotError, match="already exists"):
             await manager.create_bot(config, SimpleStrategy, ctx)
 
     async def test_start_and_stop(self, manager, eventbus, ctx):
         """봇 시작/중지."""
-        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        config = BotConfig(
+            bot_id="bot1", strategy_id="s1", interval_seconds=999, account_id="acc-test"
+        )
         await manager.create_bot(config, SimpleStrategy, ctx)
         await manager.start_bot("bot1")
         assert manager.get_bot("bot1").status == BotStatus.RUNNING
@@ -590,14 +615,14 @@ class TestBotManager:
 
     async def test_remove_bot(self, manager, eventbus, ctx):
         """봇 삭제 (하위 호환 — remove_bot은 delete_bot 별칭)."""
-        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
         await manager.create_bot(config, SimpleStrategy, ctx)
         await manager.remove_bot("bot1")
         assert manager.get_bot("bot1") is None
 
     async def test_delete_bot_soft_delete(self, manager, eventbus, ctx, db):
         """delete_bot은 DB 레코드를 삭제하지 않고 status를 deleted로 변경."""
-        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
         await manager.create_bot(config, SimpleStrategy, ctx)
         await manager.delete_bot("bot1")
 
@@ -611,7 +636,9 @@ class TestBotManager:
 
     async def test_delete_bot_stops_running(self, manager, eventbus, ctx, db):
         """실행 중인 봇 삭제 시 먼저 중지 후 deleted 처리."""
-        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        config = BotConfig(
+            bot_id="bot1", strategy_id="s1", interval_seconds=999, account_id="acc-test"
+        )
         await manager.create_bot(config, SimpleStrategy, ctx)
         await manager.start_bot("bot1")
         assert manager.get_bot("bot1").status == BotStatus.RUNNING
@@ -635,6 +662,7 @@ class TestBotManager:
                 bot_id=f"bot{i}",
                 strategy_id=f"s{i}",
                 interval_seconds=999,
+                account_id="acc-test",
             )
             await manager.create_bot(config, SimpleStrategy, ctx)
             await manager.start_bot(f"bot{i}")
@@ -645,7 +673,7 @@ class TestBotManager:
 
     async def test_list_bots(self, manager, eventbus, ctx):
         """봇 목록 조회."""
-        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
         await manager.create_bot(config, SimpleStrategy, ctx)
         bots = manager.list_bots()
         assert len(bots) == 1
@@ -653,7 +681,9 @@ class TestBotManager:
 
     async def test_bot_stop_event(self, manager, eventbus, ctx):
         """BotStopEvent 수신 시 봇 중지."""
-        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        config = BotConfig(
+            bot_id="bot1", strategy_id="s1", interval_seconds=999, account_id="acc-test"
+        )
         await manager.create_bot(config, SimpleStrategy, ctx)
         await manager.start_bot("bot1")
 
@@ -663,13 +693,15 @@ class TestBotManager:
 
     async def test_account_suspended_stops_bots(self, manager, eventbus, ctx):
         """AccountSuspendedEvent 시 해당 계좌의 봇만 중지."""
-        config = BotConfig(bot_id="bot1", strategy_id="s1", interval_seconds=999)
+        config = BotConfig(
+            bot_id="bot1", strategy_id="s1", interval_seconds=999, account_id="acc-test"
+        )
         await manager.create_bot(config, SimpleStrategy, ctx)
         await manager.start_bot("bot1")
 
         await eventbus.publish(
             AccountSuspendedEvent(
-                account_id="test",
+                account_id="acc-test",
                 reason="critical",
                 suspended_by="system",
             )
@@ -696,8 +728,18 @@ class TestBotManager:
             portfolio=FakePortfolioView(),
             order_view=FakeOrderView(),
         )
-        config1 = BotConfig(bot_id="bot1", strategy_id="same_stg", interval_seconds=999)
-        config2 = BotConfig(bot_id="bot2", strategy_id="same_stg", interval_seconds=999)
+        config1 = BotConfig(
+            bot_id="bot1",
+            strategy_id="same_stg",
+            interval_seconds=999,
+            account_id="acc-test",
+        )
+        config2 = BotConfig(
+            bot_id="bot2",
+            strategy_id="same_stg",
+            interval_seconds=999,
+            account_id="acc-test",
+        )
         await manager.create_bot(config1, SimpleStrategy, ctx1)
         await manager.start_bot("bot1")
 
@@ -720,8 +762,18 @@ class TestBotManager:
             portfolio=FakePortfolioView(),
             order_view=FakeOrderView(),
         )
-        config1 = BotConfig(bot_id="bot1", strategy_id="same_stg", interval_seconds=999)
-        config2 = BotConfig(bot_id="bot2", strategy_id="same_stg", interval_seconds=999)
+        config1 = BotConfig(
+            bot_id="bot1",
+            strategy_id="same_stg",
+            interval_seconds=999,
+            account_id="acc-test",
+        )
+        config2 = BotConfig(
+            bot_id="bot2",
+            strategy_id="same_stg",
+            interval_seconds=999,
+            account_id="acc-test",
+        )
         await manager.create_bot(config1, SimpleStrategy, ctx1)
         await manager.start_bot("bot1")
         await manager.stop_bot("bot1")
@@ -744,8 +796,18 @@ class TestBotManager:
             portfolio=FakePortfolioView(),
             order_view=FakeOrderView(),
         )
-        config1 = BotConfig(bot_id="bot1", strategy_id="stg_a", interval_seconds=999)
-        config2 = BotConfig(bot_id="bot2", strategy_id="stg_b", interval_seconds=999)
+        config1 = BotConfig(
+            bot_id="bot1",
+            strategy_id="stg_a",
+            interval_seconds=999,
+            account_id="acc-test",
+        )
+        config2 = BotConfig(
+            bot_id="bot2",
+            strategy_id="stg_b",
+            interval_seconds=999,
+            account_id="acc-test",
+        )
         await manager.create_bot(config1, SimpleStrategy, ctx1)
         await manager.start_bot("bot1")
 
@@ -756,7 +818,7 @@ class TestBotManager:
 
     async def test_bot_config_persisted(self, manager, eventbus, ctx, db):
         """봇 설정이 DB에 저장됨."""
-        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
         await manager.create_bot(config, SimpleStrategy, ctx)
 
         row = await db.fetch_one("SELECT * FROM bots WHERE bot_id = 'bot1'")
@@ -765,7 +827,9 @@ class TestBotManager:
 
     async def test_bot_name_persisted(self, manager, eventbus, ctx, db):
         """봇 이름이 DB에 저장됨."""
-        config = BotConfig(bot_id="bot1", strategy_id="s1", name="모멘텀 봇")
+        config = BotConfig(
+            bot_id="bot1", strategy_id="s1", name="모멘텀 봇", account_id="acc-test"
+        )
         await manager.create_bot(config, SimpleStrategy, ctx)
 
         row = await db.fetch_one("SELECT * FROM bots WHERE bot_id = 'bot1'")
@@ -774,15 +838,15 @@ class TestBotManager:
 
     async def test_bot_config_account_id(self, manager, eventbus, ctx, db):
         """account_id 필드 존재 및 기본값."""
-        config = BotConfig(bot_id="bot1", strategy_id="s1")
-        assert config.account_id == "test"
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        assert config.account_id == "acc-test"
 
         config2 = BotConfig(bot_id="bot2", strategy_id="s2", account_id="domestic")
         assert config2.account_id == "domestic"
 
     async def test_bot_config_no_bot_type(self):
         """BotConfig에서 bot_type, exchange 필드가 제거되었음."""
-        config = BotConfig(bot_id="b1", strategy_id="s1")
+        config = BotConfig(bot_id="b1", strategy_id="s1", account_id="acc-test")
         assert not hasattr(config, "bot_type")
         assert not hasattr(config, "exchange")
 
@@ -881,7 +945,7 @@ class TestBotManager:
         )
         info = bot.get_info()
         assert "account_id" in info
-        assert info["account_id"] == "test"
+        assert info["account_id"] == "acc-test"
         assert "bot_type" not in info
 
     async def test_bot_started_event_has_account_id(self, eventbus, ctx):

--- a/tests/unit/test_bot_delete_budget.py
+++ b/tests/unit/test_bot_delete_budget.py
@@ -192,7 +192,7 @@ class TestDeleteBotBudgetRelease:
         m = BotManager(eventbus=eventbus, db=db)
         await m.initialize()
 
-        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
         await m.create_bot(config, SimpleStrategy, ctx)
         await m.delete_bot("bot1")
 
@@ -281,7 +281,7 @@ class TestDeleteBotBudgetReleaseFallback:
         다르지만, 예산은 다른 treasury에 할당되어 있는 경우.
         """
         # Treasury 2개 생성: 'default'와 'other'
-        treasury_default = Treasury(db=db, eventbus=eventbus, account_id="default")
+        treasury_default = Treasury(db=db, eventbus=eventbus, account_id="acc-default")
         await treasury_default.initialize()
         await treasury_default.set_account_balance(1_000_000)
 

--- a/tests/unit/test_bot_providers.py
+++ b/tests/unit/test_bot_providers.py
@@ -57,7 +57,7 @@ async def db(tmp_path):
 class TestLivePortfolioView:
     async def test_get_positions_empty(self, db, eventbus):
         """봇에 포지션이 없으면 빈 dict 반환."""
-        treasury = Treasury(db=db, eventbus=eventbus)
+        treasury = Treasury(db=db, eventbus=eventbus, account_id="acc-test")
         await treasury.initialize()
         position_history = PositionHistory(db=db)
         await position_history.initialize()
@@ -67,7 +67,7 @@ class TestLivePortfolioView:
 
     async def test_get_positions_with_data(self, db, eventbus):
         """포지션이 있으면 심볼별 dict 반환."""
-        treasury = Treasury(db=db, eventbus=eventbus)
+        treasury = Treasury(db=db, eventbus=eventbus, account_id="acc-test")
         await treasury.initialize()
         position_history = PositionHistory(db=db)
         await position_history.initialize()
@@ -85,6 +85,7 @@ class TestLivePortfolioView:
             price=50000.0,
             status=TradeStatus.FILLED,
             order_type="market",
+            account_id="acc-test",
         )
         await position_history.on_trade(record)
 
@@ -96,7 +97,7 @@ class TestLivePortfolioView:
 
     async def test_get_balance_no_budget(self, db, eventbus):
         """예산 미할당 시 0 반환."""
-        treasury = Treasury(db=db, eventbus=eventbus)
+        treasury = Treasury(db=db, eventbus=eventbus, account_id="acc-test")
         await treasury.initialize()
         position_history = PositionHistory(db=db)
         await position_history.initialize()
@@ -108,7 +109,7 @@ class TestLivePortfolioView:
 
     async def test_get_balance_with_budget(self, db, eventbus):
         """예산 할당 시 잔고 반환."""
-        treasury = Treasury(db=db, eventbus=eventbus)
+        treasury = Treasury(db=db, eventbus=eventbus, account_id="acc-test")
         await treasury.initialize()
         await treasury.set_account_balance(10_000_000.0)
         await treasury.allocate("bot1", 1_000_000.0)
@@ -476,10 +477,7 @@ class TestStrategyContextFactory:
             paper_executor=executor,
         )
 
-        config = BotConfig(
-            bot_id="paper1",
-            strategy_id="s1",
-        )
+        config = BotConfig(bot_id="paper1", strategy_id="s1", account_id="acc-test")
         # AccountService 미설정 → VIRTUAL 모드(paper) 기본 동작
         ctx = factory.create(config)
 
@@ -547,7 +545,9 @@ class TestStrategyContextFactory:
         class FakeTreasury:
             def get_budget(self, bot_id):
                 if bot_id == "paper1":
-                    return BotBudget(bot_id="paper1", allocated=2_000_000.0)
+                    return BotBudget(
+                        bot_id="paper1", allocated=2_000_000.0, account_id="acc-test"
+                    )
                 return None
 
         class FakeTreasuryManager:
@@ -641,10 +641,7 @@ class TestBotManagerWithFactory:
         manager = BotManager(eventbus=eventbus, db=db, context_factory=factory)
         await manager.initialize()
 
-        config = BotConfig(
-            bot_id="paper1",
-            strategy_id="s1",
-        )
+        config = BotConfig(bot_id="paper1", strategy_id="s1", account_id="acc-test")
         bot = await manager.create_bot(config, SimpleStrategy)
 
         assert bot.bot_id == "paper1"
@@ -672,7 +669,7 @@ class TestBotManagerWithFactory:
                 PaperPortfolioView(bot_id="bot1", initial_balance=1_000_000.0)
             ),
         )
-        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
         bot = await manager.create_bot(config, SimpleStrategy, ctx)
         assert bot.bot_id == "bot1"
 
@@ -690,7 +687,7 @@ class TestBotManagerWithFactory:
         manager = BotManager(eventbus=eventbus, db=db)
         await manager.initialize()
 
-        config = BotConfig(bot_id="bot1", strategy_id="s1")
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
         with pytest.raises(BotError, match="factory"):
             await manager.create_bot(config, SimpleStrategy)
 
@@ -713,7 +710,7 @@ class TestBotManagerWithFactory:
         manager = BotManager(eventbus=eventbus, db=db, context_factory=factory)
         await manager.initialize()
 
-        config = BotConfig(bot_id="paper1", strategy_id="s1")
+        config = BotConfig(bot_id="paper1", strategy_id="s1", account_id="acc-test")
         await manager.create_bot(config, SimpleStrategy)
         assert "paper1" in executor._portfolios
 
@@ -749,6 +746,7 @@ class TestPositionHistoryCache:
             price=50000.0,
             status=TradeStatus.FILLED,
             order_type="market",
+            account_id="acc-test",
         )
         await ph.on_trade(record)
 
@@ -782,6 +780,7 @@ class TestPositionHistoryCache:
             price=50000.0,
             status=TradeStatus.FILLED,
             order_type="market",
+            account_id="acc-test",
         )
         await ph1.on_trade(record)
 
@@ -810,6 +809,7 @@ class TestPositionHistoryCache:
             price=50000.0,
             status=TradeStatus.FILLED,
             order_type="market",
+            account_id="acc-test",
         )
         await ph.on_trade(buy)
 
@@ -823,6 +823,7 @@ class TestPositionHistoryCache:
             price=55000.0,
             status=TradeStatus.FILLED,
             order_type="market",
+            account_id="acc-test",
         )
         await ph.on_trade(sell)
 

--- a/tests/unit/test_bot_restart.py
+++ b/tests/unit/test_bot_restart.py
@@ -52,7 +52,7 @@ def _make_strategy_cls():
 class TestBotConfigRestartPolicy:
     def test_default_auto_restart(self):
         """기본값 auto_restart=True."""
-        config = BotConfig(bot_id="b1", strategy_id="s1")
+        config = BotConfig(bot_id="b1", strategy_id="s1", account_id="acc-test")
         assert config.auto_restart is True
         assert config.max_restart_attempts == 3
         assert config.restart_cooldown_seconds == 60
@@ -65,6 +65,7 @@ class TestBotConfigRestartPolicy:
             auto_restart=False,
             max_restart_attempts=5,
             restart_cooldown_seconds=30,
+            account_id="acc-test",
         )
         assert config.auto_restart is False
         assert config.max_restart_attempts == 5
@@ -82,6 +83,7 @@ class TestBotAutoRestart:
             strategy_id="s1",
             restart_cooldown_seconds=0,
             max_restart_attempts=3,
+            account_id="acc-test",
         )
         ctx = MagicMock()
         ctx.get_positions.return_value = []
@@ -91,7 +93,9 @@ class TestBotAutoRestart:
         bot = await manager.create_bot(config, _make_strategy_cls(), ctx=ctx)
         bot.status = BotStatus.ERROR
 
-        await eventbus.publish(BotErrorEvent(bot_id="b1", error_message="test"))
+        await eventbus.publish(
+            BotErrorEvent(bot_id="b1", error_message="test", account_id="acc-test")
+        )
         await asyncio.sleep(0.05)  # cooldown=0 + task 실행 대기
 
         # 재시작 성공 확인 (카운터는 reset_after=0이므로 이미 리셋될 수 있음)
@@ -100,14 +104,14 @@ class TestBotAutoRestart:
     async def test_no_restart_when_disabled(self, manager, eventbus):
         """auto_restart=False → 재시작 안 함."""
         config = BotConfig(
-            bot_id="b1",
-            strategy_id="s1",
-            auto_restart=False,
+            bot_id="b1", strategy_id="s1", auto_restart=False, account_id="acc-test"
         )
         bot = await manager.create_bot(config, _make_strategy_cls(), ctx=MagicMock())
         bot.status = BotStatus.ERROR
 
-        await eventbus.publish(BotErrorEvent(bot_id="b1", error_message="test"))
+        await eventbus.publish(
+            BotErrorEvent(bot_id="b1", error_message="test", account_id="acc-test")
+        )
         await asyncio.sleep(0.05)
 
         assert bot.status == BotStatus.ERROR
@@ -120,6 +124,7 @@ class TestBotAutoRestart:
             strategy_id="s1",
             max_restart_attempts=2,
             restart_cooldown_seconds=0,
+            account_id="acc-test",
         )
         bot = await manager.create_bot(config, _make_strategy_cls(), ctx=MagicMock())
 
@@ -130,12 +135,14 @@ class TestBotAutoRestart:
         manager._restart_counts["b1"] = 2
 
         bot.status = BotStatus.ERROR
-        await eventbus.publish(BotErrorEvent(bot_id="b1", error_message="fail"))
+        await eventbus.publish(
+            BotErrorEvent(bot_id="b1", error_message="fail", account_id="acc-test")
+        )
         await asyncio.sleep(0.05)
 
         assert len(exhausted) == 1
         assert exhausted[0].bot_id == "b1"
-        assert exhausted[0].account_id == "test"
+        assert exhausted[0].account_id == "acc-test"
         assert exhausted[0].restart_attempts == 2
 
     async def test_restart_count_increments(self, manager, eventbus):
@@ -145,6 +152,7 @@ class TestBotAutoRestart:
             strategy_id="s1",
             max_restart_attempts=5,
             restart_cooldown_seconds=0,
+            account_id="acc-test",
         )
         ctx = MagicMock()
         ctx.get_positions.return_value = []
@@ -155,20 +163,26 @@ class TestBotAutoRestart:
 
         # 첫 번째 에러 → 재시작
         bot.status = BotStatus.ERROR
-        await eventbus.publish(BotErrorEvent(bot_id="b1", error_message="e1"))
+        await eventbus.publish(
+            BotErrorEvent(bot_id="b1", error_message="e1", account_id="acc-test")
+        )
         await asyncio.sleep(0.05)
         # cooldown=0 → reset_after=0, 카운터 즉시 리셋 가능
         assert bot.status == BotStatus.RUNNING
 
         # 두 번째 에러 → 재시작
         bot.status = BotStatus.ERROR
-        await eventbus.publish(BotErrorEvent(bot_id="b1", error_message="e2"))
+        await eventbus.publish(
+            BotErrorEvent(bot_id="b1", error_message="e2", account_id="acc-test")
+        )
         await asyncio.sleep(0.05)
         assert bot.status == BotStatus.RUNNING
 
     async def test_unknown_bot_error_ignored(self, manager, eventbus):
         """등록되지 않은 봇의 에러는 무시."""
-        await eventbus.publish(BotErrorEvent(bot_id="unknown", error_message="test"))
+        await eventbus.publish(
+            BotErrorEvent(bot_id="unknown", error_message="test", account_id="acc-test")
+        )
         # 에러 없이 통과
 
 
@@ -183,6 +197,7 @@ class TestRestartCounterReset:
             strategy_id="s1",
             max_restart_attempts=3,
             restart_cooldown_seconds=0,
+            account_id="acc-test",
         )
         ctx = MagicMock()
         ctx.get_positions.return_value = []
@@ -193,7 +208,9 @@ class TestRestartCounterReset:
 
         # 에러 → 재시작
         bot.status = BotStatus.ERROR
-        await eventbus.publish(BotErrorEvent(bot_id="b1", error_message="e1"))
+        await eventbus.publish(
+            BotErrorEvent(bot_id="b1", error_message="e1", account_id="acc-test")
+        )
         await asyncio.sleep(0.05)
 
         # reset_after = 0 * 3 = 0초이므로 재시작 성공 직후 카운터가 즉시 리셋됨
@@ -207,6 +224,7 @@ class TestRestartCounterReset:
             strategy_id="s1",
             max_restart_attempts=3,
             restart_cooldown_seconds=0,
+            account_id="acc-test",
         )
         ctx = MagicMock()
         ctx.get_positions.return_value = []
@@ -235,11 +253,14 @@ class TestStopCancelsRestart:
             bot_id="b1",
             strategy_id="s1",
             restart_cooldown_seconds=10,
+            account_id="acc-test",
         )
         bot = await manager.create_bot(config, _make_strategy_cls(), ctx=MagicMock())
         bot.status = BotStatus.ERROR
 
-        await eventbus.publish(BotErrorEvent(bot_id="b1", error_message="test"))
+        await eventbus.publish(
+            BotErrorEvent(bot_id="b1", error_message="test", account_id="acc-test")
+        )
         await asyncio.sleep(0.01)
         assert "b1" in manager._restart_tasks
 
@@ -265,6 +286,6 @@ class TestBotRestartExhaustedEvent:
         assert event.last_error == "connection lost"
 
     def test_account_id_default_empty(self):
-        """account_id 기본값은 빈 문자열."""
-        event = BotRestartExhaustedEvent(bot_id="b1")
-        assert event.account_id == ""
+        """account_id 명시값은 보존된다."""
+        event = BotRestartExhaustedEvent(bot_id="b1", account_id="acc-test")
+        assert event.account_id == "acc-test"

--- a/tests/unit/test_bot_rule_init.py
+++ b/tests/unit/test_bot_rule_init.py
@@ -92,7 +92,7 @@ def mock_account_service():
     """AccountService 목 객체."""
     service = AsyncMock()
     account = Account(
-        account_id="default",
+        account_id="acc-default",
         name="테스트",
         exchange="KRX",
         currency="KRW",
@@ -108,7 +108,7 @@ def mock_account_service():
 def rule_engine(eventbus, mock_account_service):
     engine = RuleEngine(
         eventbus=eventbus,
-        account_id="default",
+        account_id="acc-default",
         account_service=mock_account_service,
     )
     return engine
@@ -153,7 +153,10 @@ class TestBotStartLoadsRules:
     async def test_start_bot_loads_strategy_rules(self, manager, ctx, rule_engine):
         """봇 시작 시 전략별 룰이 RuleEngine에 로드된다."""
         config = BotConfig(
-            bot_id="bot1", strategy_id="momentum_v1", interval_seconds=999
+            bot_id="bot1",
+            strategy_id="momentum_v1",
+            interval_seconds=999,
+            account_id="acc-test",
         )
         await manager.create_bot(config, SimpleStrategy, ctx)
 
@@ -169,7 +172,10 @@ class TestBotStartLoadsRules:
     async def test_start_bot_no_config_no_error(self, manager, ctx, rule_engine):
         """전략별 룰 설정이 없는 전략이면 에러 없이 진행."""
         config = BotConfig(
-            bot_id="bot1", strategy_id="unknown_strategy", interval_seconds=999
+            bot_id="bot1",
+            strategy_id="unknown_strategy",
+            interval_seconds=999,
+            account_id="acc-test",
         )
         await manager.create_bot(config, SimpleStrategy, ctx)
 
@@ -186,7 +192,10 @@ class TestBotStopRemovesRules:
     async def test_stop_bot_removes_strategy_rules(self, manager, ctx, rule_engine):
         """봇 중지 시 전략별 룰이 RuleEngine에서 제거된다."""
         config = BotConfig(
-            bot_id="bot1", strategy_id="momentum_v1", interval_seconds=999
+            bot_id="bot1",
+            strategy_id="momentum_v1",
+            interval_seconds=999,
+            account_id="acc-test",
         )
         await manager.create_bot(config, SimpleStrategy, ctx)
         await manager.start_bot("bot1")
@@ -199,7 +208,10 @@ class TestBotStopRemovesRules:
     async def test_stop_bot_no_rules_no_error(self, manager, ctx, rule_engine):
         """전략별 룰이 없는 봇도 중지 시 에러 없이 진행."""
         config = BotConfig(
-            bot_id="bot1", strategy_id="unknown_strategy", interval_seconds=999
+            bot_id="bot1",
+            strategy_id="unknown_strategy",
+            interval_seconds=999,
+            account_id="acc-test",
         )
         await manager.create_bot(config, SimpleStrategy, ctx)
         await manager.start_bot("bot1")
@@ -216,7 +228,10 @@ class TestRestartRestoresRules:
     async def test_resume_bot_reloads_rules(self, manager, ctx, rule_engine):
         """봇 재시작(resume) 시 전략별 룰이 다시 로드된다."""
         config = BotConfig(
-            bot_id="bot1", strategy_id="momentum_v1", interval_seconds=999
+            bot_id="bot1",
+            strategy_id="momentum_v1",
+            interval_seconds=999,
+            account_id="acc-test",
         )
         await manager.create_bot(config, SimpleStrategy, ctx)
         await manager.start_bot("bot1")
@@ -242,7 +257,10 @@ class TestWithoutRuleEngine:
         m = BotManager(eventbus=eventbus, db=db)
         await m.initialize()
         config = BotConfig(
-            bot_id="bot1", strategy_id="momentum_v1", interval_seconds=999
+            bot_id="bot1",
+            strategy_id="momentum_v1",
+            interval_seconds=999,
+            account_id="acc-test",
         )
         await m.create_bot(config, SimpleStrategy, ctx)
 

--- a/tests/unit/test_bot_step_event.py
+++ b/tests/unit/test_bot_step_event.py
@@ -108,15 +108,17 @@ class TestBotStepCompletedEventDefinition:
 
     def test_event_is_frozen(self):
         """이벤트는 frozen dataclass여야 한다."""
-        evt = BotStepCompletedEvent(bot_id="bot1", result="success")
+        evt = BotStepCompletedEvent(
+            bot_id="bot1", result="success", account_id="acc-test"
+        )
         with pytest.raises(AttributeError):
             evt.bot_id = "changed"  # type: ignore[misc]
 
     def test_default_values(self):
-        """기본값 검증."""
-        evt = BotStepCompletedEvent()
+        """account_id 명시 시 다른 필드는 기본값 ''을 갖는다."""
+        evt = BotStepCompletedEvent(account_id="acc-test")
         assert evt.bot_id == ""
-        assert evt.account_id == ""
+        assert evt.account_id == "acc-test"
         assert evt.result == ""
         assert evt.message == ""
 

--- a/tests/unit/test_bot_stop_release.py
+++ b/tests/unit/test_bot_stop_release.py
@@ -23,7 +23,7 @@ def eventbus():
 
 @pytest.fixture
 async def treasury(db, eventbus):
-    t = Treasury(db=db, eventbus=eventbus)
+    t = Treasury(db=db, eventbus=eventbus, account_id="acc-test")
     await t.initialize()
     await t.set_account_balance(10_000_000.0)
     await t.allocate("bot1", 5_000_000.0)
@@ -79,7 +79,7 @@ class TestBotStopRelease:
         budget_before = treasury.get_budget("bot1")
         available_before = budget_before.available
 
-        await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
+        await eventbus.publish(BotStoppedEvent(bot_id="bot1", account_id="acc-test"))
 
         budget_after = treasury.get_budget("bot1")
         assert budget_after.reserved == 0.0
@@ -91,7 +91,7 @@ class TestBotStopRelease:
         await treasury.reserve_for_order("bot1", "ord1", 100_000.0)
         await treasury.reserve_for_order("bot2", "ord2", 200_000.0)
 
-        await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
+        await eventbus.publish(BotStoppedEvent(bot_id="bot1", account_id="acc-test"))
 
         assert treasury.get_reservations("bot2") == {"ord2": 200_000.0}
         budget2 = treasury.get_budget("bot2")
@@ -101,7 +101,7 @@ class TestBotStopRelease:
         """예약 없는 봇 중지 → 아무 변화 없음."""
         budget_before = treasury.get_budget("bot1")
 
-        await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
+        await eventbus.publish(BotStoppedEvent(bot_id="bot1", account_id="acc-test"))
 
         budget_after = treasury.get_budget("bot1")
         assert budget_after.available == budget_before.available
@@ -111,7 +111,7 @@ class TestBotStopRelease:
         """해제 시 거래 이력에 bot_stopped_release 기록."""
         await treasury.reserve_for_order("bot1", "ord1", 100_000.0)
 
-        await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
+        await eventbus.publish(BotStoppedEvent(bot_id="bot1", account_id="acc-test"))
 
         rows = await db.fetch_all(
             "SELECT * FROM treasury_transactions "
@@ -128,7 +128,7 @@ class TestBotStopRelease:
         await treasury.reserve_for_order("bot1", "ord2", 250_000.0)
         await treasury.reserve_for_order("bot1", "ord3", 100_000.0)
 
-        await eventbus.publish(BotStoppedEvent(bot_id="bot1"))
+        await eventbus.publish(BotStoppedEvent(bot_id="bot1", account_id="acc-test"))
 
         budget = treasury.get_budget("bot1")
         assert budget.reserved == 0.0
@@ -137,7 +137,9 @@ class TestBotStopRelease:
 
     async def test_unknown_bot_stopped_no_error(self, treasury, eventbus):
         """존재하지 않는 봇 중지 → 에러 없이 무시."""
-        await eventbus.publish(BotStoppedEvent(bot_id="unknown_bot"))
+        await eventbus.publish(
+            BotStoppedEvent(bot_id="unknown_bot", account_id="acc-test")
+        )
         # 에러 없이 통과
 
 

--- a/tests/unit/test_cli_account_integration.py
+++ b/tests/unit/test_cli_account_integration.py
@@ -515,17 +515,17 @@ class TestBrokerAccountOption:
         mock_gb.assert_called_once_with("domestic")
 
     def test_broker_balance_without_account(self, runner):
-        """--account 미지정 시 기존 Config 기반 폴백."""
-        mock_adapter = AsyncMock()
-        mock_adapter.get_account_balance = AsyncMock(return_value={"cash": 5000000.0})
-        mock_adapter.disconnect = AsyncMock()
+        """--account 미지정 시 click이 user-friendly 에러로 거부.
 
+        #1217 SPLIT-1: account_id fallback 금지. Config 기반 무계좌 폴백 경로
+        진입을 차단한다. _get_broker 자체는 호출되지 않아야 한다.
+        """
         with patch("ante.cli.commands.broker._get_broker") as mock_gb:
-            mock_gb.return_value = (mock_adapter, None)
             result = runner.invoke(cli, ["broker", "balance"])
 
-        assert result.exit_code == 0
-        mock_gb.assert_called_once_with(None)
+        assert result.exit_code != 0
+        assert "--account" in result.output
+        mock_gb.assert_not_called()
 
     def test_broker_positions_with_account(self, runner):
         """--account 옵션으로 계좌별 포지션 조회."""

--- a/tests/unit/test_cli_account_integration.py
+++ b/tests/unit/test_cli_account_integration.py
@@ -443,7 +443,7 @@ class TestTreasuryStatusAccount:
         mock_ct.assert_called_once_with("domestic")
 
     def test_treasury_status_without_account(self, runner):
-        """--account 미지정 시 기본 자금 현황."""
+        """--account 미지정 시 Click usage error (필수 옵션)."""
         mock_treasury = MagicMock()
         mock_treasury.get_summary.return_value = {
             "account_balance": 10000000,
@@ -462,8 +462,9 @@ class TestTreasuryStatusAccount:
             mock_ct.return_value = (mock_treasury, mock_db)
             result = runner.invoke(cli, ["treasury", "status"])
 
-        assert result.exit_code == 0
-        mock_ct.assert_called_once_with(None)
+        # #1217: --account가 required이므로 missing option은 usage error(2)
+        assert result.exit_code == 2
+        mock_ct.assert_not_called()
 
     def test_treasury_status_with_account_json(self, runner):
         """JSON 모드에서 --account 필터."""

--- a/tests/unit/test_cli_config_approval_broker_ipc.py
+++ b/tests/unit/test_cli_config_approval_broker_ipc.py
@@ -260,25 +260,20 @@ class TestBrokerStatusIPC:
         sent = call_args[0][1]
         assert sent["account_id"] == "acc-1"
 
-    def test_status_without_account(self, runner: CliRunner) -> None:
-        """broker status (계좌 미지정) IPC 전송."""
+    def test_status_without_account_errors(self, runner: CliRunner) -> None:
+        """broker status 미지정 시 click이 user-friendly 에러로 거부한다.
+
+        #1217 SPLIT-1: ``--account`` 는 required. CLI 가 빈 dict 를 IPC 로
+        보내지 않도록 진입 시점에서 차단한다.
+        """
         mock_client, ipc_cls_patch, socket_patch = _patch_ipc()
-        mock_client.send.return_value = {
-            "id": "req-1",
-            "status": "ok",
-            "result": {
-                "connected": True,
-                "healthy": True,
-                "exchange": "KRX",
-            },
-        }
 
         with ipc_cls_patch, socket_patch:
             result = runner.invoke(cli, ["broker", "status"])
 
-        assert result.exit_code == 0, result.output
-        sent = mock_client.send.call_args[0][1]
-        assert "account_id" not in sent
+        assert result.exit_code != 0
+        assert "--account" in result.output
+        mock_client.send.assert_not_called()
 
     def test_status_fallback_on_server_not_running(self, runner: CliRunner) -> None:
         """서버 미실행 시 직접 연결 폴백. 폴백도 실패하면 에러 표시."""
@@ -291,7 +286,7 @@ class TestBrokerStatusIPC:
                 "ante.cli.commands.broker._get_broker",
                 side_effect=Exception("no broker"),
             ):
-                result = runner.invoke(cli, ["broker", "status"])
+                result = runner.invoke(cli, ["broker", "status", "--account", "acc-1"])
 
         assert result.exit_code == 0
         assert "미연결" in result.output
@@ -320,21 +315,19 @@ class TestBrokerBalanceIPC:
         sent = call_args[0][1]
         assert sent["account_id"] == "acc-1"
 
-    def test_balance_without_account(self, runner: CliRunner) -> None:
-        """broker balance (계좌 미지정) IPC 전송."""
+    def test_balance_without_account_errors(self, runner: CliRunner) -> None:
+        """broker balance 미지정 시 click이 user-friendly 에러로 거부한다.
+
+        #1217 SPLIT-1: ``--account`` required. 빈 dict IPC 호출 차단.
+        """
         mock_client, ipc_cls_patch, socket_patch = _patch_ipc()
-        mock_client.send.return_value = {
-            "id": "req-1",
-            "status": "ok",
-            "result": {"total_balance": 1000000.0},
-        }
 
         with ipc_cls_patch, socket_patch:
             result = runner.invoke(cli, ["broker", "balance"])
 
-        assert result.exit_code == 0, result.output
-        sent = mock_client.send.call_args[0][1]
-        assert "account_id" not in sent
+        assert result.exit_code != 0
+        assert "--account" in result.output
+        mock_client.send.assert_not_called()
 
 
 class TestBrokerPositionsIPC:
@@ -376,25 +369,23 @@ class TestBrokerPositionsIPC:
         }
 
         with ipc_cls_patch, socket_patch:
-            result = runner.invoke(cli, ["broker", "positions"])
+            result = runner.invoke(cli, ["broker", "positions", "--account", "acc-1"])
 
         assert result.exit_code == 0, result.output
 
-    def test_positions_without_account(self, runner: CliRunner) -> None:
-        """broker positions (계좌 미지정) IPC 전송."""
+    def test_positions_without_account_errors(self, runner: CliRunner) -> None:
+        """broker positions 미지정 시 click이 user-friendly 에러로 거부한다.
+
+        #1217 SPLIT-1: ``--account`` required. 빈 dict IPC 호출 차단.
+        """
         mock_client, ipc_cls_patch, socket_patch = _patch_ipc()
-        mock_client.send.return_value = {
-            "id": "req-1",
-            "status": "ok",
-            "result": {"positions": []},
-        }
 
         with ipc_cls_patch, socket_patch:
             result = runner.invoke(cli, ["broker", "positions"])
 
-        assert result.exit_code == 0, result.output
-        sent = mock_client.send.call_args[0][1]
-        assert "account_id" not in sent
+        assert result.exit_code != 0
+        assert "--account" in result.output
+        mock_client.send.assert_not_called()
 
 
 # ── Broker reconcile --fix IPC ────────────────────
@@ -429,28 +420,19 @@ class TestBrokerReconcileFixIPC:
         assert sent["fix"] is True
         assert sent["account_id"] == "acc-1"
 
-    def test_reconcile_fix_without_account(self, runner: CliRunner) -> None:
-        """broker reconcile --fix (계좌 미지정)."""
+    def test_reconcile_fix_without_account_errors(self, runner: CliRunner) -> None:
+        """broker reconcile --fix 미지정 시 click이 user-friendly 에러로 거부한다.
+
+        #1217 SPLIT-1: ``--account`` required. 빈 dict IPC 호출 차단.
+        """
         mock_client, ipc_cls_patch, socket_patch = _patch_ipc()
-        mock_client.send.return_value = {
-            "id": "req-1",
-            "status": "ok",
-            "result": {
-                "total_symbols": 0,
-                "discrepancies": [],
-                "match": True,
-                "fix_applied": False,
-                "corrections": 0,
-            },
-        }
 
         with ipc_cls_patch, socket_patch:
             result = runner.invoke(cli, ["broker", "reconcile", "--fix"])
 
-        assert result.exit_code == 0, result.output
-        sent = mock_client.send.call_args[0][1]
-        assert sent["fix"] is True
-        assert "account_id" not in sent
+        assert result.exit_code != 0
+        assert "--account" in result.output
+        mock_client.send.assert_not_called()
 
 
 # ── 서버 미기동 에러 ────────────────────────────────
@@ -485,7 +467,9 @@ class TestServerNotRunningErrors:
         mock_client.send.side_effect = ServerNotRunningError("no server")
 
         with ipc_cls_patch, socket_patch:
-            result = runner.invoke(cli, ["broker", "reconcile", "--fix"])
+            result = runner.invoke(
+                cli, ["broker", "reconcile", "--fix", "--account", "acc-1"]
+            )
 
         assert result.exit_code != 0
         assert "서버가 실행 중이 아닙니다" in result.output

--- a/tests/unit/test_cli_format_option.py
+++ b/tests/unit/test_cli_format_option.py
@@ -277,7 +277,17 @@ class TestTreasuryStatusFormatOption:
             new_callable=AsyncMock,
             return_value=(mock_treasury, db),
         ):
-            result = runner.invoke(cli, ["treasury", "status", "--format", "json"])
+            result = runner.invoke(
+                cli,
+                [
+                    "treasury",
+                    "status",
+                    "--account",
+                    "domestic",
+                    "--format",
+                    "json",
+                ],
+            )
             assert result.exit_code == 0
             data = json.loads(result.output)
             assert data["account_balance"] == 1000000

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -560,7 +560,7 @@ class TestBrokerCommands:
             mock_adapter.exchange = "KRX"
             mock_create.return_value = (mock_adapter, None)
 
-            result = runner.invoke(cli, ["broker", "status"])
+            result = runner.invoke(cli, ["broker", "status", "--account", "acc-1"])
             assert result.exit_code == 0
             assert "연결됨" in result.output
 
@@ -568,7 +568,7 @@ class TestBrokerCommands:
         with patch("ante.cli.commands.broker._get_broker") as mock_create:
             mock_create.side_effect = Exception("connection failed")
 
-            result = runner.invoke(cli, ["broker", "status"])
+            result = runner.invoke(cli, ["broker", "status", "--account", "acc-1"])
             assert result.exit_code == 0
             assert "미연결" in result.output
 
@@ -581,7 +581,9 @@ class TestBrokerCommands:
             mock_adapter.disconnect = AsyncMock()
             mock_create.return_value = (mock_adapter, None)
 
-            result = runner.invoke(cli, ["--format", "json", "broker", "balance"])
+            result = runner.invoke(
+                cli, ["--format", "json", "broker", "balance", "--account", "acc-1"]
+            )
             assert result.exit_code == 0
             data = json.loads(result.output)
             assert data["cash"] == 10000000.0
@@ -593,5 +595,36 @@ class TestBrokerCommands:
             mock_adapter.disconnect = AsyncMock()
             mock_create.return_value = (mock_adapter, None)
 
-            result = runner.invoke(cli, ["broker", "positions"])
+            result = runner.invoke(cli, ["broker", "positions", "--account", "acc-1"])
             assert result.exit_code == 0
+
+    def test_broker_status_requires_account(self, runner):
+        """broker status도 --account 옵션 누락 시 user-friendly 에러로 거부.
+
+        #1217 SPLIT-1: account_id fallback 금지. CLI 진입 시점에서 차단.
+        """
+        result = runner.invoke(cli, ["broker", "status"])
+        assert result.exit_code != 0
+        assert "--account" in result.output
+
+    def test_broker_balance_requires_account(self, runner):
+        """broker balance도 --account 옵션 누락 시 거부."""
+        result = runner.invoke(cli, ["broker", "balance"])
+        assert result.exit_code != 0
+        assert "--account" in result.output
+
+    def test_broker_positions_requires_account(self, runner):
+        """broker positions도 --account 옵션 누락 시 거부."""
+        result = runner.invoke(cli, ["broker", "positions"])
+        assert result.exit_code != 0
+        assert "--account" in result.output
+
+    def test_broker_reconcile_requires_account(self, runner):
+        """broker reconcile (--fix 유무 무관) --account 옵션 누락 시 거부."""
+        result = runner.invoke(cli, ["broker", "reconcile"])
+        assert result.exit_code != 0
+        assert "--account" in result.output
+
+        result_fix = runner.invoke(cli, ["broker", "reconcile", "--fix"])
+        assert result_fix.exit_code != 0
+        assert "--account" in result_fix.output

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -366,7 +366,7 @@ class TestTreasuryCommands:
             mock_db.close = AsyncMock()
             mock_svc.return_value = (mock_treasury, mock_db)
 
-            result = runner.invoke(cli, ["treasury", "status"])
+            result = runner.invoke(cli, ["treasury", "status", "--account", "domestic"])
             assert result.exit_code == 0
             assert "10,000,000" in result.output
 
@@ -387,7 +387,17 @@ class TestTreasuryCommands:
             mock_db.close = AsyncMock()
             mock_svc.return_value = (mock_treasury, mock_db)
 
-            result = runner.invoke(cli, ["--format", "json", "treasury", "status"])
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "treasury",
+                    "status",
+                    "--account",
+                    "domestic",
+                ],
+            )
             assert result.exit_code == 0
             data = json.loads(result.output)
             assert data["account_balance"] == 10000000.0
@@ -472,7 +482,7 @@ class TestRuleCommands:
             mock_svc.return_value = (mock_engine, mock_db)
 
             with patch("ante.cli.commands.rule._load_rules_from_config"):
-                result = runner.invoke(cli, ["rule", "list"])
+                result = runner.invoke(cli, ["rule", "list", "--account", "acc-1"])
                 assert result.exit_code == 0
 
     def test_rule_list_with_rules(self, runner):
@@ -492,7 +502,17 @@ class TestRuleCommands:
             mock_svc.return_value = (mock_engine, mock_db)
 
             with patch("ante.cli.commands.rule._load_rules_from_config"):
-                result = runner.invoke(cli, ["--format", "json", "rule", "list"])
+                result = runner.invoke(
+                    cli,
+                    [
+                        "--format",
+                        "json",
+                        "rule",
+                        "list",
+                        "--account",
+                        "acc-1",
+                    ],
+                )
                 assert result.exit_code == 0
                 data = json.loads(result.output)
                 assert len(data["rules"]) == 1
@@ -508,9 +528,24 @@ class TestRuleCommands:
             mock_svc.return_value = (mock_engine, mock_db)
 
             with patch("ante.cli.commands.rule._load_rules_from_config"):
-                result = runner.invoke(cli, ["rule", "info", "nonexistent"])
+                result = runner.invoke(
+                    cli,
+                    ["rule", "info", "nonexistent", "--account", "acc-1"],
+                )
                 assert result.exit_code == 1
                 assert "찾을 수 없습니다" in result.output
+
+    def test_rule_list_requires_account(self, runner):
+        """--account 옵션 누락 시 click usage error로 실패."""
+        result = runner.invoke(cli, ["rule", "list"])
+        assert result.exit_code != 0
+        assert "--account" in result.output
+
+    def test_rule_info_requires_account(self, runner):
+        """rule info도 --account 옵션 누락 시 실패."""
+        result = runner.invoke(cli, ["rule", "info", "some-rule"])
+        assert result.exit_code != 0
+        assert "--account" in result.output
 
 
 # ── broker 커맨드 ───────────────────────────────────

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -628,3 +628,52 @@ class TestBrokerCommands:
         result_fix = runner.invoke(cli, ["broker", "reconcile", "--fix"])
         assert result_fix.exit_code != 0
         assert "--account" in result_fix.output
+
+    def test_offline_broker_reconcile_filters_other_account(self, runner):
+        """오프라인 fallback 도 ``--account`` 의 포지션만 비교한다.
+
+        Refs #1240 review (P2-2): 서버 미기동 fallback 의
+        ``position_history.get_all_positions()`` 호출이 모든 계좌를 보면
+        다른 계좌의 포지션이 false discrepancy 로 잡힌다. 단일 계좌
+        reconcile 은 해당 계좌만 보도록 ``account_id`` 필터를 전달해야 한다.
+        """
+        with (
+            patch("ante.cli.commands.broker._get_broker") as mock_get_broker,
+            patch("ante.cli.commands.ipc_helpers.IPCClient") as mock_ipc_cls,
+            patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/test.sock",
+            ),
+            patch("ante.core.database.Database") as mock_db_cls,
+            patch("ante.trade.position.PositionHistory") as mock_ph_cls,
+        ):
+            # IPC 는 서버 미기동으로 ClickException → fallback 으로 분기.
+            from ante.ipc.exceptions import ServerNotRunningError
+
+            mock_ipc = AsyncMock()
+            mock_ipc.send = AsyncMock(side_effect=ServerNotRunningError("no server"))
+            mock_ipc_cls.return_value = mock_ipc
+
+            # Broker adapter mock — acc-a 의 포지션만 노출.
+            mock_adapter = AsyncMock()
+            mock_adapter.get_account_positions = AsyncMock(
+                return_value=[{"symbol": "AAA", "quantity": 10.0}]
+            )
+            mock_adapter.disconnect = AsyncMock()
+            mock_db = AsyncMock()
+            mock_db.connect = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_db_cls.return_value = mock_db
+            mock_get_broker.return_value = (mock_adapter, mock_db)
+
+            # PositionHistory.get_all_positions(account_id=...) 의 인자 검증을
+            # 위해 spec 을 정확히 맞춘 AsyncMock 사용.
+            mock_ph = AsyncMock()
+            mock_ph.initialize = AsyncMock()
+            mock_ph.get_all_positions = AsyncMock(return_value=[])
+            mock_ph_cls.return_value = mock_ph
+
+            result = runner.invoke(cli, ["broker", "reconcile", "--account", "acc-a"])
+
+            assert result.exit_code == 0, result.output
+            mock_ph.get_all_positions.assert_awaited_once_with(account_id="acc-a")

--- a/tests/unit/test_cli_treasury_snapshot.py
+++ b/tests/unit/test_cli_treasury_snapshot.py
@@ -99,7 +99,7 @@ class TestSnapshotDefault:
     def test_default_today(self, runner, mock_auth):
         ctx_patch, mock_t = _make_mock_treasury(get_daily_return=SAMPLE_SNAPSHOT)
         with ctx_patch:
-            result = _invoke(runner, ["snapshot"], mock_auth)
+            result = _invoke(runner, ["snapshot", "--account", "domestic"], mock_auth)
 
         assert result.exit_code == 0
         assert "일별 자산 스냅샷" in result.output
@@ -110,7 +110,7 @@ class TestSnapshotDefault:
     def test_default_no_data(self, runner, mock_auth):
         ctx_patch, _ = _make_mock_treasury(get_daily_return=None)
         with ctx_patch:
-            result = _invoke(runner, ["snapshot"], mock_auth)
+            result = _invoke(runner, ["snapshot", "--account", "domestic"], mock_auth)
 
         assert result.exit_code == 0
         assert "스냅샷이 없습니다" in result.output
@@ -122,7 +122,11 @@ class TestSnapshotDate:
     def test_specific_date(self, runner, mock_auth):
         ctx_patch, mock_t = _make_mock_treasury(get_daily_return=SAMPLE_SNAPSHOT)
         with ctx_patch:
-            result = _invoke(runner, ["snapshot", "--date", "2026-03-21"], mock_auth)
+            result = _invoke(
+                runner,
+                ["snapshot", "--account", "domestic", "--date", "2026-03-21"],
+                mock_auth,
+            )
 
         assert result.exit_code == 0
         assert "2026-03-21" in result.output
@@ -131,7 +135,11 @@ class TestSnapshotDate:
     def test_specific_date_not_found(self, runner, mock_auth):
         ctx_patch, _ = _make_mock_treasury(get_daily_return=None)
         with ctx_patch:
-            result = _invoke(runner, ["snapshot", "--date", "2026-01-01"], mock_auth)
+            result = _invoke(
+                runner,
+                ["snapshot", "--account", "domestic", "--date", "2026-01-01"],
+                mock_auth,
+            )
 
         assert result.exit_code == 0
         assert "2026-01-01" in result.output
@@ -147,7 +155,15 @@ class TestSnapshotRange:
         with ctx_patch:
             result = _invoke(
                 runner,
-                ["snapshot", "--from", "2026-03-20", "--to", "2026-03-21"],
+                [
+                    "snapshot",
+                    "--account",
+                    "domestic",
+                    "--from",
+                    "2026-03-20",
+                    "--to",
+                    "2026-03-21",
+                ],
                 mock_auth,
             )
 
@@ -160,7 +176,11 @@ class TestSnapshotRange:
         """--from만 지정하면 오늘까지 조회."""
         ctx_patch, mock_t = _make_mock_treasury(get_range_return=[SAMPLE_SNAPSHOT])
         with ctx_patch:
-            result = _invoke(runner, ["snapshot", "--from", "2026-03-20"], mock_auth)
+            result = _invoke(
+                runner,
+                ["snapshot", "--account", "domestic", "--from", "2026-03-20"],
+                mock_auth,
+            )
 
         assert result.exit_code == 0
         # get_snapshots가 호출되었는지 확인
@@ -173,7 +193,15 @@ class TestSnapshotRange:
         with ctx_patch:
             result = _invoke(
                 runner,
-                ["snapshot", "--from", "2026-01-01", "--to", "2026-01-02"],
+                [
+                    "snapshot",
+                    "--account",
+                    "domestic",
+                    "--from",
+                    "2026-01-01",
+                    "--to",
+                    "2026-01-02",
+                ],
                 mock_auth,
             )
 
@@ -199,7 +227,15 @@ class TestSnapshotJson:
         with ctx_patch:
             result = runner.invoke(
                 treasury,
-                ["snapshot", "--date", "2026-03-21", "--format", "json"],
+                [
+                    "snapshot",
+                    "--account",
+                    "domestic",
+                    "--date",
+                    "2026-03-21",
+                    "--format",
+                    "json",
+                ],
                 obj={
                     "format": "json",
                     "formatter": OutputFormatter("json"),
@@ -231,6 +267,8 @@ class TestSnapshotJson:
                 treasury,
                 [
                     "snapshot",
+                    "--account",
+                    "domestic",
                     "--from",
                     "2026-03-20",
                     "--to",
@@ -261,7 +299,15 @@ class TestSnapshotValidation:
         with ctx_patch:
             result = _invoke(
                 runner,
-                ["snapshot", "--date", "2026-03-21", "--from", "2026-03-20"],
+                [
+                    "snapshot",
+                    "--account",
+                    "domestic",
+                    "--date",
+                    "2026-03-21",
+                    "--from",
+                    "2026-03-20",
+                ],
                 mock_auth,
             )
 

--- a/tests/unit/test_commission.py
+++ b/tests/unit/test_commission.py
@@ -225,6 +225,7 @@ class TestTreasuryCommission:
             eventbus=eventbus,
             buy_commission_rate=0.00015,
             sell_commission_rate=0.00195,
+            account_id="acc-test",
         )
         await t.initialize()
         assert t.buy_commission_rate == 0.00015
@@ -232,13 +233,13 @@ class TestTreasuryCommission:
 
     async def test_treasury_default_sell_commission_rate(self, db, eventbus):
         """Treasury 기본 sell_commission_rate = 0.00195."""
-        t = Treasury(db=db, eventbus=eventbus)
+        t = Treasury(db=db, eventbus=eventbus, account_id="acc-test")
         await t.initialize()
         assert t.sell_commission_rate == 0.00195
 
     async def test_update_commission_rates(self, db, eventbus):
         """수수료율 동적 업데이트."""
-        t = Treasury(db=db, eventbus=eventbus)
+        t = Treasury(db=db, eventbus=eventbus, account_id="acc-test")
         await t.initialize()
 
         t.update_commission_rates(0.0001, 0.0018)
@@ -254,6 +255,7 @@ class TestTreasuryCommission:
             eventbus=eventbus,
             buy_commission_rate=0.001,  # 높은 수수료율로 테스트
             sell_commission_rate=0.002,
+            account_id="acc-test",
         )
         await t.initialize()
         await t.set_account_balance(10_000_000.0)
@@ -272,6 +274,7 @@ class TestTreasuryCommission:
                 quantity=10.0,
                 price=50_000.0,
                 order_type="market",
+                account_id="acc-test",
             )
         )
 

--- a/tests/unit/test_daily_report.py
+++ b/tests/unit/test_daily_report.py
@@ -588,3 +588,52 @@ class TestNoTreasuryFallback:
         assert len(report_events) == 1
         assert report_events[0].daily_pnl == 0.0
         assert report_events[0].unrealized_pnl == 0.0
+
+
+# ── #1240 review: cross-account 필터링 회귀 ─────────
+
+
+class TestCrossAccountFilter:
+    """DailyReportScheduler 가 자기 계좌만 집계하는지 검증.
+
+    SPLIT-1 부터 거래/포지션 row 가 실제 account_id 를 갖기 시작하므로,
+    단일 계좌 바인딩된 스케줄러가 cross-account 데이터를 끌어오면
+    DailyReportEvent 에 타 계좌 거래/포지션이 섞이게 된다. 이를 회귀로
+    차단한다.
+    """
+
+    async def test_daily_report_run_once_filters_other_account_trades(
+        self,
+        scheduler,
+        trade_recorder,
+        performance_tracker,
+        position_history,
+        eventbus,
+        treasury,
+    ):
+        """run_once 가 ``account_id=self._account_id`` 를 모든 집계 호출에
+        명시 전달한다.
+
+        ``trade_recorder.get_trades``, ``performance_tracker.get_daily_summary``,
+        ``position_history.get_all_positions`` 호출에 자기 계좌만 명시되어야
+        타 계좌의 거래/포지션이 DailyReportEvent 에 섞이지 않는다.
+        """
+        # trade_recorder/performance/position 모두 빈 리스트 반환 — 필터링
+        # 자체가 호출 인자로 잘 전달되는지가 핵심 검증 포인트.
+        trade_recorder.get_trades.return_value = [_make_trade("buy")]
+        performance_tracker.get_daily_summary.return_value = []
+        position_history.get_all_positions.return_value = []
+
+        await scheduler.run_once(target_date=date(2026, 3, 19))
+
+        # get_trades: account_id 키워드로 자기 계좌(acc-1) 가 명시 전달됨.
+        get_trades_kwargs = trade_recorder.get_trades.await_args.kwargs
+        assert get_trades_kwargs.get("account_id") == "acc-1"
+
+        # get_daily_summary: account_id 키워드로 자기 계좌가 명시 전달됨.
+        gds_kwargs = performance_tracker.get_daily_summary.await_args.kwargs
+        assert gds_kwargs.get("account_id") == "acc-1"
+
+        # get_all_positions: account_id 키워드로 자기 계좌가 명시 전달됨.
+        gap_kwargs = position_history.get_all_positions.await_args.kwargs
+        assert gap_kwargs.get("account_id") == "acc-1"

--- a/tests/unit/test_daily_report.py
+++ b/tests/unit/test_daily_report.py
@@ -91,6 +91,7 @@ def _make_trade(
         price=price,
         status=TradeStatus.FILLED,
         timestamp=datetime.now(KST),
+        account_id="acc-test",
     )
 
 
@@ -191,6 +192,7 @@ class TestDailyReportEventAlwaysPublished:
                 symbol="005930",
                 quantity=100.0,
                 avg_entry_price=50000.0,
+                account_id="acc-test",
             )
         ]
 
@@ -342,6 +344,7 @@ class TestNotificationEvent:
                 symbol=f"00593{i}",
                 quantity=100.0,
                 avg_entry_price=50000.0,
+                account_id="acc-test",
             )
             for i in range(4)
         ]
@@ -518,6 +521,7 @@ class TestConfiguration:
             trade_recorder=trade_recorder,
             position_history=position_history,
             eventbus=eventbus,
+            account_id="acc-test",
         )
         assert sched._report_time == DEFAULT_REPORT_TIME
         assert DEFAULT_REPORT_TIME == time(16, 0)
@@ -533,6 +537,7 @@ class TestConfiguration:
             position_history=position_history,
             eventbus=eventbus,
             report_time=custom_time,
+            account_id="acc-test",
         )
         assert sched._report_time == custom_time
 
@@ -569,6 +574,7 @@ class TestNoTreasuryFallback:
             trade_recorder=trade_recorder,
             position_history=position_history,
             eventbus=eventbus,
+            account_id="acc-test",
         )
 
         trade_recorder.get_trades.return_value = []

--- a/tests/unit/test_equity_curve.py
+++ b/tests/unit/test_equity_curve.py
@@ -156,6 +156,7 @@ async def test_feedback_get_equity_curve():
             price=50000,
             status=TradeStatus.FILLED,
             timestamp=datetime(2025, 1, 10, tzinfo=UTC),
+            account_id="acc-test",
         ),
         TradeRecord(
             trade_id="t2",
@@ -167,6 +168,7 @@ async def test_feedback_get_equity_curve():
             price=52000,
             status=TradeStatus.FILLED,
             timestamp=datetime(2025, 1, 15, tzinfo=UTC),
+            account_id="acc-test",
         ),
     ]
 

--- a/tests/unit/test_event_history.py
+++ b/tests/unit/test_event_history.py
@@ -24,7 +24,7 @@ async def store(db):
 
 async def test_record_and_query(store):
     """이벤트를 기록하고 조회한다."""
-    event = OrderRequestEvent(symbol="005930", side="buy")
+    event = OrderRequestEvent(symbol="005930", side="buy", account_id="acc-test")
     await store.record(event)
 
     rows = await store.query()
@@ -35,9 +35,9 @@ async def test_record_and_query(store):
 
 async def test_query_by_type(store):
     """이벤트 타입으로 필터링 조회."""
-    await store.record(OrderRequestEvent(symbol="A"))
-    await store.record(BotStartedEvent(bot_id="b"))
-    await store.record(OrderRequestEvent(symbol="B"))
+    await store.record(OrderRequestEvent(symbol="A", account_id="acc-test"))
+    await store.record(BotStartedEvent(bot_id="b", account_id="acc-test"))
+    await store.record(OrderRequestEvent(symbol="B", account_id="acc-test"))
 
     rows = await store.query(event_type="OrderRequestEvent")
     assert len(rows) == 2
@@ -47,7 +47,7 @@ async def test_query_by_type(store):
 async def test_query_limit(store):
     """limit으로 반환 건수를 제한한다."""
     for i in range(10):
-        await store.record(OrderRequestEvent(symbol=str(i)))
+        await store.record(OrderRequestEvent(symbol=str(i), account_id="acc-test"))
 
     rows = await store.query(limit=3)
     assert len(rows) == 3
@@ -55,8 +55,8 @@ async def test_query_limit(store):
 
 async def test_query_order(store):
     """최신순으로 반환한다."""
-    await store.record(OrderRequestEvent(symbol="first"))
-    await store.record(OrderRequestEvent(symbol="second"))
+    await store.record(OrderRequestEvent(symbol="first", account_id="acc-test"))
+    await store.record(OrderRequestEvent(symbol="second", account_id="acc-test"))
 
     rows = await store.query()
     assert rows[0]["payload"]["symbol"] == "second"

--- a/tests/unit/test_eventbus.py
+++ b/tests/unit/test_eventbus.py
@@ -25,7 +25,9 @@ async def test_publish_subscribe(bus):
         received.append(event)
 
     bus.subscribe(OrderRequestEvent, handler)
-    event = OrderRequestEvent(symbol="005930", side="buy", quantity=10.0)
+    event = OrderRequestEvent(
+        symbol="005930", side="buy", quantity=10.0, account_id="acc-test"
+    )
     await bus.publish(event)
 
     assert len(received) == 1
@@ -44,14 +46,14 @@ async def test_multiple_handlers(bus):
 
     bus.subscribe(OrderRequestEvent, h1)
     bus.subscribe(OrderRequestEvent, h2)
-    await bus.publish(OrderRequestEvent())
+    await bus.publish(OrderRequestEvent(account_id="acc-test"))
 
     assert len(calls) == 2
 
 
 async def test_no_subscribers(bus):
     """구독자 없는 이벤트 발행 시 에러 없음."""
-    await bus.publish(OrderRequestEvent())
+    await bus.publish(OrderRequestEvent(account_id="acc-test"))
 
 
 async def test_type_isolation(bus):
@@ -62,7 +64,7 @@ async def test_type_isolation(bus):
         received.append(event)
 
     bus.subscribe(OrderRequestEvent, handler)
-    await bus.publish(BotStartedEvent(bot_id="bot1"))
+    await bus.publish(BotStartedEvent(bot_id="bot1", account_id="acc-test"))
 
     assert len(received) == 0
 
@@ -87,7 +89,7 @@ async def test_priority_order(bus):
     bus.subscribe(OrderRequestEvent, high, priority=100)
     bus.subscribe(OrderRequestEvent, mid, priority=50)
 
-    await bus.publish(OrderRequestEvent())
+    await bus.publish(OrderRequestEvent(account_id="acc-test"))
 
     assert order == ["high", "mid", "low"]
 
@@ -108,7 +110,7 @@ async def test_handler_error_isolation(bus):
     bus.subscribe(OrderRequestEvent, failing, priority=100)
     bus.subscribe(OrderRequestEvent, succeeding, priority=0)
 
-    await bus.publish(OrderRequestEvent())
+    await bus.publish(OrderRequestEvent(account_id="acc-test"))
 
     assert calls == ["ok"]
 
@@ -124,7 +126,7 @@ async def test_sync_handler(bus):
         received.append(event)
 
     bus.subscribe(OrderRequestEvent, sync_handler)
-    await bus.publish(OrderRequestEvent(symbol="sync"))
+    await bus.publish(OrderRequestEvent(symbol="sync", account_id="acc-test"))
 
     assert len(received) == 1
     assert received[0].symbol == "sync"
@@ -141,11 +143,11 @@ async def test_unsubscribe(bus):
         calls.append(1)
 
     bus.subscribe(OrderRequestEvent, handler)
-    await bus.publish(OrderRequestEvent())
+    await bus.publish(OrderRequestEvent(account_id="acc-test"))
     assert len(calls) == 1
 
     bus.unsubscribe(OrderRequestEvent, handler)
-    await bus.publish(OrderRequestEvent())
+    await bus.publish(OrderRequestEvent(account_id="acc-test"))
     assert len(calls) == 1
 
 
@@ -154,8 +156,8 @@ async def test_unsubscribe(bus):
 
 async def test_history_records_events(bus):
     """발행된 이벤트가 히스토리에 기록된다."""
-    await bus.publish(OrderRequestEvent(symbol="A"))
-    await bus.publish(OrderRequestEvent(symbol="B"))
+    await bus.publish(OrderRequestEvent(symbol="A", account_id="acc-test"))
+    await bus.publish(OrderRequestEvent(symbol="B", account_id="acc-test"))
 
     history = bus.get_history()
     assert len(history) == 2
@@ -165,9 +167,9 @@ async def test_history_records_events(bus):
 
 async def test_history_type_filter(bus):
     """히스토리를 이벤트 타입으로 필터링한다."""
-    await bus.publish(OrderRequestEvent(symbol="X"))
-    await bus.publish(BotStartedEvent(bot_id="b"))
-    await bus.publish(OrderRequestEvent(symbol="Y"))
+    await bus.publish(OrderRequestEvent(symbol="X", account_id="acc-test"))
+    await bus.publish(BotStartedEvent(bot_id="b", account_id="acc-test"))
+    await bus.publish(OrderRequestEvent(symbol="Y", account_id="acc-test"))
 
     filtered = bus.get_history(event_type=OrderRequestEvent)
     assert len(filtered) == 2
@@ -177,7 +179,7 @@ async def test_history_type_filter(bus):
 async def test_history_ring_buffer(bus):
     """히스토리 크기가 제한된다."""
     for i in range(100):
-        await bus.publish(OrderRequestEvent(symbol=str(i)))
+        await bus.publish(OrderRequestEvent(symbol=str(i), account_id="acc-test"))
 
     history = bus.get_history(limit=200)
     assert len(history) == 50  # history_size=50
@@ -186,7 +188,7 @@ async def test_history_ring_buffer(bus):
 async def test_history_limit(bus):
     """limit으로 반환 건수를 제한한다."""
     for i in range(10):
-        await bus.publish(OrderRequestEvent(symbol=str(i)))
+        await bus.publish(OrderRequestEvent(symbol=str(i), account_id="acc-test"))
 
     history = bus.get_history(limit=3)
     assert len(history) == 3
@@ -218,6 +220,6 @@ async def test_get_handlers(bus):
 
 async def test_event_immutability():
     """frozen 이벤트는 변경할 수 없다."""
-    event = OrderRequestEvent(symbol="005930")
+    event = OrderRequestEvent(symbol="005930", account_id="acc-test")
     with pytest.raises(AttributeError):
         event.symbol = "other"  # type: ignore[misc]

--- a/tests/unit/test_eventbus_account_events.py
+++ b/tests/unit/test_eventbus_account_events.py
@@ -85,14 +85,14 @@ class TestAccountEvents:
             event.account_id = "changed"  # type: ignore[misc]
 
     async def test_account_events_default_values(self):
-        """Account 이벤트 기본값이 빈 문자열이다."""
-        suspended = AccountSuspendedEvent()
-        assert suspended.account_id == ""
+        """Account 이벤트는 account_id를 보존하고 나머지 필드는 기본값 ''을 가진다."""
+        suspended = AccountSuspendedEvent(account_id="acc-test")
+        assert suspended.account_id == "acc-test"
         assert suspended.reason == ""
         assert suspended.suspended_by == ""
 
-        activated = AccountActivatedEvent()
-        assert activated.account_id == ""
+        activated = AccountActivatedEvent(account_id="acc-test")
+        assert activated.account_id == "acc-test"
         assert activated.activated_by == ""
 
 
@@ -100,44 +100,46 @@ class TestAccountEvents:
 
 
 class TestAccountIdBackwardCompat:
-    """기존 이벤트에 추가된 account_id 필드가 기본값 ''으로 하위 호환된다."""
+    """기존 이벤트에 추가된 account_id 필드가 명시 전달되어 보존된다."""
 
     async def test_order_events_default_account_id(self):
-        """Order 이벤트 기본 account_id는 빈 문자열이다."""
+        """Order 이벤트 account_id는 생성 시 명시값으로 보존된다."""
         events = [
-            OrderRequestEvent(symbol="005930", side="buy", quantity=10.0),
-            OrderCancelEvent(order_id="o1"),
-            OrderModifyEvent(order_id="o1"),
-            OrderModifyRejectedEvent(order_id="o1"),
-            OrderValidatedEvent(order_id="o1"),
-            OrderRejectedEvent(order_id="o1"),
-            OrderApprovedEvent(order_id="o1"),
-            OrderSubmittedEvent(order_id="o1"),
-            OrderFilledEvent(order_id="o1"),
-            OrderCancelledEvent(order_id="o1"),
-            OrderFailedEvent(order_id="o1"),
+            OrderRequestEvent(
+                symbol="005930", side="buy", quantity=10.0, account_id="acc-test"
+            ),
+            OrderCancelEvent(order_id="o1", account_id="acc-test"),
+            OrderModifyEvent(order_id="o1", account_id="acc-test"),
+            OrderModifyRejectedEvent(order_id="o1", account_id="acc-test"),
+            OrderValidatedEvent(order_id="o1", account_id="acc-test"),
+            OrderRejectedEvent(order_id="o1", account_id="acc-test"),
+            OrderApprovedEvent(order_id="o1", account_id="acc-test"),
+            OrderSubmittedEvent(order_id="o1", account_id="acc-test"),
+            OrderFilledEvent(order_id="o1", account_id="acc-test"),
+            OrderCancelledEvent(order_id="o1", account_id="acc-test"),
+            OrderFailedEvent(order_id="o1", account_id="acc-test"),
         ]
         for event in events:
-            assert event.account_id == "", (
-                f"{type(event).__name__}.account_id 기본값이 ''이 아님"
+            assert event.account_id == "acc-test", (
+                f"{type(event).__name__}.account_id 보존 실패"
             )
 
     async def test_bot_events_default_account_id(self):
-        """Bot 이벤트 기본 account_id는 빈 문자열이다."""
+        """Bot 이벤트 account_id는 생성 시 명시값으로 보존된다."""
         events = [
-            BotStartedEvent(bot_id="bot1"),
-            BotStoppedEvent(bot_id="bot1"),
-            BotErrorEvent(bot_id="bot1", error_message="err"),
+            BotStartedEvent(bot_id="bot1", account_id="acc-test"),
+            BotStoppedEvent(bot_id="bot1", account_id="acc-test"),
+            BotErrorEvent(bot_id="bot1", error_message="err", account_id="acc-test"),
         ]
         for event in events:
-            assert event.account_id == "", (
-                f"{type(event).__name__}.account_id 기본값이 ''이 아님"
+            assert event.account_id == "acc-test", (
+                f"{type(event).__name__}.account_id 보존 실패"
             )
 
     async def test_balance_synced_default_account_id(self):
-        """BalanceSyncedEvent 기본 account_id는 빈 문자열이다."""
-        event = BalanceSyncedEvent(account_balance=1000000.0)
-        assert event.account_id == ""
+        """BalanceSyncedEvent account_id는 생성 시 명시값으로 보존된다."""
+        event = BalanceSyncedEvent(account_balance=1000000.0, account_id="acc-test")
+        assert event.account_id == "acc-test"
 
     async def test_order_event_with_account_id(self):
         """account_id를 명시적으로 전달할 수 있다."""

--- a/tests/unit/test_external_signal_subscription.py
+++ b/tests/unit/test_external_signal_subscription.py
@@ -82,9 +82,7 @@ async def db(tmp_path) -> Database:  # noqa: ANN001
 
 def _make_config(bot_id: str = "bot-001") -> BotConfig:
     return BotConfig(
-        bot_id=bot_id,
-        strategy_id="stg-001",
-        interval_seconds=60,
+        bot_id=bot_id, strategy_id="stg-001", interval_seconds=60, account_id="acc-test"
     )
 
 
@@ -241,6 +239,7 @@ class TestChannelEventForwarding:
                 quantity=10.0,
                 price=58200.0,
                 commission=87.3,
+                account_id="acc-test",
             )
             await eventbus.publish(fill_event)
 
@@ -280,6 +279,7 @@ class TestChannelEventForwarding:
             side="buy",
             quantity=10.0,
             price=58200.0,
+            account_id="acc-test",
         )
 
         await eventbus.publish(fill_event)
@@ -309,6 +309,7 @@ class TestChannelEventForwarding:
                 order_id="ORD-002",
                 bot_id="bot-001",
                 reason="insufficient funds",
+                account_id="acc-test",
             )
             await eventbus.publish(event)
 
@@ -360,6 +361,7 @@ class TestChannelEventForwarding:
                 side="buy",
                 quantity=5.0,
                 price=59000.0,
+                account_id="acc-test",
             )
 
             await eventbus.publish(fill_event)

--- a/tests/unit/test_gateway_stop_routing.py
+++ b/tests/unit/test_gateway_stop_routing.py
@@ -87,6 +87,7 @@ class TestStopOrderRouting:
             stop_price=49000.0,
             price=None,
             exchange="KRX",
+            account_id="acc-test",
         )
 
         await gateway._on_order_approved(event)
@@ -101,6 +102,7 @@ class TestStopOrderRouting:
             quantity=10.0,
             order_type="stop",
             stop_price=49000.0,
+            account_id="acc-test",
             limit_price=None,
             exchange="KRX",
         )
@@ -125,6 +127,7 @@ class TestStopOrderRouting:
             stop_price=51000.0,
             price=51500.0,
             exchange="KRX",
+            account_id="acc-test",
         )
 
         await gateway._on_order_approved(event)
@@ -150,6 +153,7 @@ class TestStopOrderRouting:
             quantity=10.0,
             order_type="market",
             exchange="KRX",
+            account_id="acc-test",
         )
 
         await gateway._on_order_approved(event)
@@ -179,6 +183,7 @@ class TestStopOrderRouting:
             order_type="stop",
             stop_price=49000.0,
             exchange="KRX",
+            account_id="acc-test",
         )
 
         await gateway._on_order_approved(event)
@@ -205,6 +210,7 @@ class TestStopOrderRouting:
             order_type="stop",
             stop_price=49000.0,
             exchange="KRX",
+            account_id="acc-test",
         )
 
         await gateway_no_stop._on_order_approved(event)

--- a/tests/unit/test_instrument.py
+++ b/tests/unit/test_instrument.py
@@ -221,18 +221,18 @@ class TestExchangeDefaults:
             OrderRequestEvent,
         )
 
-        req = OrderRequestEvent(symbol="005930")
+        req = OrderRequestEvent(symbol="005930", account_id="acc-test")
         assert req.exchange == "KRX"
 
-        filled = OrderFilledEvent(symbol="005930")
+        filled = OrderFilledEvent(symbol="005930", account_id="acc-test")
         assert filled.exchange == "KRX"
 
     def test_bot_config_default_account_id(self):
-        """BotConfig account_id 기본값 test (exchange는 Account에서 관리)."""
+        """BotConfig account_id는 명시값으로 보존된다 (exchange는 Account에서 관리)."""
         from ante.bot.config import BotConfig
 
-        config = BotConfig(bot_id="bot-1", strategy_id="strat-1")
-        assert config.account_id == "test"
+        config = BotConfig(bot_id="bot-1", strategy_id="strat-1", account_id="acc-test")
+        assert config.account_id == "acc-test"
 
     def test_strategy_meta_default_exchange(self):
         """StrategyMeta exchange 기본값 KRX."""
@@ -256,6 +256,7 @@ class TestExchangeDefaults:
             quantity=10,
             price=70000,
             status=TradeStatus.FILLED,
+            account_id="acc-test",
         )
         assert record.exchange == "KRX"
 
@@ -268,6 +269,7 @@ class TestExchangeDefaults:
             symbol="005930",
             quantity=10,
             avg_entry_price=70000,
+            account_id="acc-test",
         )
         assert pos.exchange == "KRX"
 
@@ -299,5 +301,6 @@ class TestExchangeDefaults:
             side="buy",
             quantity=10,
             order_type="market",
+            account_id="acc-test",
         )
         assert ctx.exchange == "KRX"

--- a/tests/unit/test_kis_error_handling.py
+++ b/tests/unit/test_kis_error_handling.py
@@ -366,6 +366,7 @@ class TestGatewayCancelFailed:
                 strategy_id="s1",
                 order_id="ord1",
                 reason="test cancel",
+                account_id="acc-test",
             )
         )
 
@@ -390,10 +391,7 @@ class TestBotCancelFailedHandling:
         mock_strategy.on_order_update = AsyncMock()
 
         eventbus = EventBus()
-        config = BotConfig(
-            bot_id="bot1",
-            strategy_id="s1",
-        )
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
         bot = Bot(
             config=config,
             strategy_cls=MagicMock(),

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -41,7 +41,9 @@ async def test_full_initialization(tmp_path: Path) -> None:
     await dynamic_config.initialize()
 
     # 검증: 이벤트 발행 → 인메모리 히스토리 + SQLite 영속화
-    event = OrderRequestEvent(symbol="005930", side="buy", quantity=10.0)
+    event = OrderRequestEvent(
+        symbol="005930", side="buy", quantity=10.0, account_id="acc-test"
+    )
     await eventbus.publish(event)
 
     # 인메모리 히스토리
@@ -80,7 +82,9 @@ async def test_eventbus_middleware_records_all_events(
 
     # 여러 이벤트 발행
     for i in range(5):
-        await eventbus.publish(OrderRequestEvent(symbol=f"sym{i}"))
+        await eventbus.publish(
+            OrderRequestEvent(symbol=f"sym{i}", account_id="acc-test")
+        )
 
     rows = await store.query(limit=10)
     assert len(rows) == 5

--- a/tests/unit/test_module_notification_events.py
+++ b/tests/unit/test_module_notification_events.py
@@ -57,7 +57,7 @@ class TestBotManagerNotifications:
         """봇 시작 시 NotificationEvent 발행."""
         from ante.eventbus.events import BotStartedEvent
 
-        await eventbus.publish(BotStartedEvent(bot_id="bot-1"))
+        await eventbus.publish(BotStartedEvent(bot_id="bot-1", account_id="acc-test"))
         assert len(notifications) == 1
         assert notifications[0].level == "info"
         assert notifications[0].category == "bot"
@@ -68,7 +68,7 @@ class TestBotManagerNotifications:
         """봇 중지 시 NotificationEvent 발행."""
         from ante.eventbus.events import BotStoppedEvent
 
-        await eventbus.publish(BotStoppedEvent(bot_id="bot-1"))
+        await eventbus.publish(BotStoppedEvent(bot_id="bot-1", account_id="acc-test"))
         assert len(notifications) == 1
         assert notifications[0].level == "info"
         assert notifications[0].category == "bot"
@@ -80,7 +80,11 @@ class TestBotManagerNotifications:
         from ante.eventbus.events import BotErrorEvent
 
         await eventbus.publish(
-            BotErrorEvent(bot_id="bot-1", error_message="Connection timeout")
+            BotErrorEvent(
+                bot_id="bot-1",
+                error_message="Connection timeout",
+                account_id="acc-test",
+            )
         )
         assert len(notifications) == 1
         assert notifications[0].level == "error"
@@ -146,6 +150,7 @@ class TestTradeRecorderNotifications:
                 quantity=100.0,
                 price=72000.0,
                 order_type="market",
+                account_id="acc-test",
             )
         )
         assert len(notifications) == 1
@@ -170,6 +175,7 @@ class TestTradeRecorderNotifications:
                 quantity=50.0,
                 price=73000.0,
                 order_type="market",
+                account_id="acc-test",
             )
         )
         assert len(notifications) == 1
@@ -329,6 +335,7 @@ class TestReconcilerNotification:
             broker_positions=[
                 {"symbol": "005930", "quantity": 50.0, "avg_price": 70000}
             ],
+            account_id="acc-test",
         )
 
         notifs = [n for n in collected if n.category == "broker"]

--- a/tests/unit/test_reconcile_scheduler.py
+++ b/tests/unit/test_reconcile_scheduler.py
@@ -56,6 +56,7 @@ def scheduler(reconciler, broker, bot_manager, eventbus):
         broker=broker,
         bot_manager=bot_manager,
         eventbus=eventbus,
+        broker_account_id="acc-test",
         interval_seconds=0.1,  # 빠른 테스트용
     )
 
@@ -195,6 +196,7 @@ class TestConfiguration:
             broker=broker,
             bot_manager=bot_manager,
             eventbus=eventbus,
+            broker_account_id="acc-test",
         )
         assert sched._interval == DEFAULT_INTERVAL_SECONDS
         assert DEFAULT_INTERVAL_SECONDS == 1800
@@ -206,6 +208,101 @@ class TestConfiguration:
             broker=broker,
             bot_manager=bot_manager,
             eventbus=eventbus,
+            broker_account_id="acc-test",
             interval_seconds=600,
         )
         assert sched._interval == 600
+
+    def test_requires_broker_account_id(
+        self, reconciler, broker, bot_manager, eventbus
+    ):
+        """broker_account_id가 비어있으면 생성에 실패한다."""
+        with pytest.raises(ValueError, match="broker_account_id"):
+            ReconcileScheduler(
+                reconciler=reconciler,
+                broker=broker,
+                bot_manager=bot_manager,
+                eventbus=eventbus,
+                broker_account_id="",
+            )
+
+
+# ── SPLIT-1 multi-account 가드 회귀 테스트 ──────────────
+
+
+class TestBrokerAccountScoping:
+    """ReconcileScheduler가 자기 broker_account_id에 일치하는 봇만
+    reconcile하는지 확인한다 (SPLIT-1 가드).
+    """
+
+    async def test_scheduler_skips_bot_from_other_account(
+        self, reconciler, broker, bot_manager, eventbus, caplog
+    ):
+        """scheduler가 acc-A 바인딩일 때 acc-B 봇은 reconcile되지 않는다."""
+        import logging
+
+        bot_manager.list_bots.return_value = [
+            {"bot_id": "bot-a", "status": "running", "account_id": "acc-A"},
+            {"bot_id": "bot-b", "status": "running", "account_id": "acc-B"},
+        ]
+        sched = ReconcileScheduler(
+            reconciler=reconciler,
+            broker=broker,
+            bot_manager=bot_manager,
+            eventbus=eventbus,
+            broker_account_id="acc-A",
+            interval_seconds=0.1,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="ante.broker.scheduler"):
+            await sched.run_once()
+
+        # acc-A 봇만 reconcile 호출 — acc-B 봇은 스킵
+        assert reconciler.reconcile.call_count == 1
+        call_args = reconciler.reconcile.call_args
+        assert call_args.kwargs["bot_id"] == "bot-a"
+        assert call_args.kwargs["account_id"] == "acc-A"
+
+        # 미일치 봇에 대한 WARNING 로그
+        skip_logs = [
+            rec
+            for rec in caplog.records
+            if rec.levelno == logging.WARNING
+            and "bot-b" in rec.getMessage()
+            and "acc-B" in rec.getMessage()
+        ]
+        assert skip_logs, (
+            "scheduler가 미일치 봇(bot-b/acc-B)에 대해 WARNING을 남겨야 한다"
+        )
+        assert any("acc-A" in rec.getMessage() for rec in skip_logs), (
+            "WARNING 메시지에 scheduler의 broker_account_id(acc-A)가 포함돼야 한다"
+        )
+
+    async def test_scheduler_processes_matching_account_bot(
+        self, reconciler, broker, bot_manager, eventbus
+    ):
+        """일치하는 봇은 정상 reconcile 호출된다."""
+        bot_manager.list_bots.return_value = [
+            {"bot_id": "bot-a1", "status": "running", "account_id": "acc-A"},
+            {"bot_id": "bot-a2", "status": "running", "account_id": "acc-A"},
+            {"bot_id": "bot-b", "status": "running", "account_id": "acc-B"},
+        ]
+        sched = ReconcileScheduler(
+            reconciler=reconciler,
+            broker=broker,
+            bot_manager=bot_manager,
+            eventbus=eventbus,
+            broker_account_id="acc-A",
+            interval_seconds=0.1,
+        )
+
+        await sched.run_once()
+
+        # acc-A 봇 두 개 모두 reconcile 호출
+        assert reconciler.reconcile.call_count == 2
+        called_bot_ids = {
+            call.kwargs["bot_id"] for call in reconciler.reconcile.call_args_list
+        }
+        assert called_bot_ids == {"bot-a1", "bot-a2"}
+        for call in reconciler.reconcile.call_args_list:
+            assert call.kwargs["account_id"] == "acc-A"

--- a/tests/unit/test_reconcile_scheduler.py
+++ b/tests/unit/test_reconcile_scheduler.py
@@ -35,8 +35,8 @@ def bot_manager():
     mock = MagicMock()
     mock.list_bots = MagicMock(
         return_value=[
-            {"bot_id": "bot-1", "status": "running"},
-            {"bot_id": "bot-2", "status": "stopped"},
+            {"bot_id": "bot-1", "status": "running", "account_id": "acc-test"},
+            {"bot_id": "bot-2", "status": "stopped", "account_id": "acc-test"},
         ]
     )
     return mock
@@ -96,7 +96,7 @@ class TestRunOnce:
     async def test_no_active_bots(self, scheduler, bot_manager, broker):
         """활성 봇이 없으면 브로커 호출하지 않는다."""
         bot_manager.list_bots.return_value = [
-            {"bot_id": "bot-1", "status": "stopped"},
+            {"bot_id": "bot-1", "status": "stopped", "account_id": "acc-test"},
         ]
 
         result = await scheduler.run_once()
@@ -118,8 +118,8 @@ class TestRunOnce:
     ):
         """한 봇의 대사 실패가 다른 봇에 영향주지 않는다."""
         bot_manager.list_bots.return_value = [
-            {"bot_id": "bot-1", "status": "running"},
-            {"bot_id": "bot-2", "status": "running"},
+            {"bot_id": "bot-1", "status": "running", "account_id": "acc-test"},
+            {"bot_id": "bot-2", "status": "running", "account_id": "acc-test"},
         ]
         reconciler.reconcile.side_effect = [
             Exception("bot-1 실패"),

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -61,6 +61,7 @@ async def _set_position(position_history, bot_id, symbol, qty, avg_price):
         symbol=symbol,
         quantity=qty,
         avg_entry_price=avg_price,
+        account_id="acc-test",
     )
 
 
@@ -82,6 +83,7 @@ class TestFullExternalSell:
         corrections = await reconciler.reconcile(
             bot_id="bot-1",
             broker_positions=[],  # 브로커에 없음
+            account_id="acc-test",
         )
 
         assert len(corrections) == 1
@@ -116,6 +118,7 @@ class TestPartialExternalSell:
             broker_positions=[
                 {"symbol": "005930", "quantity": 30, "avg_price": 50000},
             ],
+            account_id="acc-test",
         )
 
         assert len(corrections) == 1
@@ -142,6 +145,7 @@ class TestNoMismatch:
             broker_positions=[
                 {"symbol": "005930", "quantity": 50, "avg_price": 50000},
             ],
+            account_id="acc-test",
         )
 
         assert corrections == []
@@ -150,8 +154,7 @@ class TestNoMismatch:
     async def test_no_correction_both_empty(self, reconciler):
         """내부/브로커 모두 빈 포지션."""
         corrections = await reconciler.reconcile(
-            bot_id="bot-1",
-            broker_positions=[],
+            bot_id="bot-1", broker_positions=[], account_id="acc-test"
         )
         assert corrections == []
 
@@ -167,6 +170,7 @@ class TestExternalBuy:
             broker_positions=[
                 {"symbol": "005930", "quantity": 20, "avg_price": 55000},
             ],
+            account_id="acc-test",
         )
 
         assert len(corrections) == 1
@@ -192,6 +196,7 @@ class TestMultipleSymbols:
                 {"symbol": "005930", "quantity": 0, "avg_price": 0},
                 # 000660 은 브로커에 없음
             ],
+            account_id="acc-test",
         )
 
         assert len(corrections) == 2

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -258,6 +258,7 @@ class TestPerformanceFeedback:
                     quantity=100,
                     avg_entry_price=50000.0,
                     realized_pnl=10000.0,
+                    account_id="acc-test",
                 )
             ]
         )

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -132,7 +132,7 @@ class TestRuleDataModels:
 
     def test_rule_context_no_system_status(self):
         """RuleContext에 system_status 필드가 없다 (account_status로 대체)."""
-        ctx = RuleContext()
+        ctx = RuleContext(account_id="acc-test")
         assert not hasattr(ctx, "system_status")
         assert hasattr(ctx, "account_status")
 
@@ -1228,7 +1228,9 @@ class TestRuleEngineTreasuryIntegration:
 
     async def test_query_treasury_data(self, mock_treasury):
         """Treasury에서 자산/손익 데이터를 정상 조회."""
-        engine = RuleEngine(eventbus=EventBus(), treasury=mock_treasury)
+        engine = RuleEngine(
+            eventbus=EventBus(), treasury=mock_treasury, account_id="acc-test"
+        )
         data = await engine._query_treasury_data()
         assert data["total_pnl"] == 500000.0
         assert data["total_asset"] == 100000000.0
@@ -1238,7 +1240,7 @@ class TestRuleEngineTreasuryIntegration:
 
     async def test_query_treasury_data_none(self):
         """Treasury가 None이면 기본값 반환."""
-        engine = RuleEngine(eventbus=EventBus(), treasury=None)
+        engine = RuleEngine(eventbus=EventBus(), treasury=None, account_id="acc-test")
         data = await engine._query_treasury_data()
         assert all(v == 0.0 for v in data.values())
 
@@ -1247,7 +1249,9 @@ class TestRuleEngineTreasuryIntegration:
         mock_treasury.get_summary.side_effect = Exception("DB error")
         mock_treasury.get_daily_snapshot = AsyncMock(side_effect=Exception("DB error"))
         mock_treasury.get_latest_snapshot = AsyncMock(side_effect=Exception("DB error"))
-        engine = RuleEngine(eventbus=EventBus(), treasury=mock_treasury)
+        engine = RuleEngine(
+            eventbus=EventBus(), treasury=mock_treasury, account_id="acc-test"
+        )
         data = await engine._query_treasury_data()
         assert all(v == 0.0 for v in data.values())
 
@@ -1427,7 +1431,7 @@ class TestRuleEngineStartSync:
         )
 
         # 실제 호출 시 coroutine을 반환하지 않음을 확인
-        engine = RuleEngine(eventbus=EventBus())
+        engine = RuleEngine(eventbus=EventBus(), account_id="acc-test")
         result = engine.start()
         assert not asyncio.iscoroutine(result), (
             "start() 호출 결과가 coroutine이면 안 됩니다"
@@ -1521,7 +1525,7 @@ class TestTradingHoursRuleContextFields:
 
     def test_rule_context_has_trading_hours_fields(self):
         """RuleContext에 trading_hours 필드가 존재하고 기본값이 올바르다."""
-        ctx = RuleContext()
+        ctx = RuleContext(account_id="acc-test")
         assert ctx.trading_hours_start == "09:00"
         assert ctx.trading_hours_end == "15:30"
         assert ctx.timezone == "Asia/Seoul"

--- a/tests/unit/test_signal_channel.py
+++ b/tests/unit/test_signal_channel.py
@@ -235,6 +235,7 @@ class TestEventForwarding:
             quantity=10.0,
             price=58200.0,
             commission=87.3,
+            account_id="acc-test",
         )
 
         await channel._on_fill(event)
@@ -248,7 +249,9 @@ class TestEventForwarding:
         self, channel: SignalChannel, output: io.StringIO
     ) -> None:
         """다른 봇의 체결은 무시."""
-        event = OrderFilledEvent(order_id="ORD-002", bot_id="bot-999")
+        event = OrderFilledEvent(
+            order_id="ORD-002", bot_id="bot-999", account_id="acc-test"
+        )
         await channel._on_fill(event)
         assert output.getvalue() == ""
 
@@ -260,6 +263,7 @@ class TestEventForwarding:
             order_id="ORD-003",
             bot_id="bot-001",
             reason="insufficient funds",
+            account_id="acc-test",
         )
 
         await channel._on_order_update(event)
@@ -277,6 +281,7 @@ class TestEventForwarding:
             order_id="ORD-004",
             bot_id="bot-001",
             reason="user_cancel",
+            account_id="acc-test",
         )
 
         await channel._on_order_update(event)

--- a/tests/unit/test_stop_order.py
+++ b/tests/unit/test_stop_order.py
@@ -45,6 +45,7 @@ class TestRegister:
             quantity=10.0,
             order_type="stop",
             stop_price=49000.0,
+            account_id="acc-test",
         )
 
         assert stop_id.startswith("stop-")
@@ -71,6 +72,7 @@ class TestRegister:
             order_type="stop_limit",
             stop_price=51000.0,
             limit_price=51500.0,
+            account_id="acc-test",
         )
 
         order = manager.get_order(stop_id)
@@ -98,6 +100,7 @@ class TestTrigger:
             quantity=10.0,
             order_type="stop",
             stop_price=49000.0,
+            account_id="acc-test",
         )
 
         eventbus.publish.reset_mock()
@@ -134,6 +137,7 @@ class TestTrigger:
             quantity=5.0,
             order_type="stop",
             stop_price=51000.0,
+            account_id="acc-test",
         )
 
         eventbus.publish.reset_mock()
@@ -160,6 +164,7 @@ class TestTrigger:
             order_type="stop_limit",
             stop_price=51000.0,
             limit_price=51500.0,
+            account_id="acc-test",
         )
 
         eventbus.publish.reset_mock()
@@ -185,6 +190,7 @@ class TestTrigger:
             quantity=10.0,
             order_type="stop",
             stop_price=49000.0,
+            account_id="acc-test",
         )
 
         eventbus.publish.reset_mock()
@@ -209,6 +215,7 @@ class TestTrigger:
             quantity=10.0,
             order_type="stop",
             stop_price=49000.0,
+            account_id="acc-test",
         )
 
         eventbus.publish.reset_mock()
@@ -229,6 +236,7 @@ class TestTrigger:
             quantity=10.0,
             order_type="stop",
             stop_price=49000.0,
+            account_id="acc-test",
         )
 
         eventbus.publish.reset_mock()
@@ -254,6 +262,7 @@ class TestCancel:
             quantity=10.0,
             order_type="stop",
             stop_price=49000.0,
+            account_id="acc-test",
         )
 
         result = manager.cancel(stop_id)
@@ -284,6 +293,7 @@ class TestExpiry:
             quantity=10.0,
             order_type="stop",
             stop_price=49000.0,
+            account_id="acc-test",
         )
 
         eventbus.publish.reset_mock()
@@ -312,6 +322,7 @@ class TestBotOrders:
             quantity=10.0,
             order_type="stop",
             stop_price=49000.0,
+            account_id="acc-test",
         )
         await manager.register(
             order_id="ord-002",
@@ -322,6 +333,7 @@ class TestBotOrders:
             quantity=5.0,
             order_type="stop",
             stop_price=100000.0,
+            account_id="acc-test",
         )
 
         bot1_orders = manager.get_orders_for_bot("bot-001")

--- a/tests/unit/test_stream_integration.py
+++ b/tests/unit/test_stream_integration.py
@@ -173,6 +173,7 @@ async def test_price_callback_calls_stop_order_manager(
             quantity=10.0,
             order_type="stop",
             stop_price=72000.0,
+            account_id="acc-test",
         )
 
         # 세션 시간을 항상 True로 패치 (테스트 시간에 무관하게 동작)
@@ -316,6 +317,7 @@ async def test_fallback_polls_prices(
         quantity=10.0,
         order_type="stop",
         stop_price=60000.0,
+        account_id="acc-test",
     )
 
     await integration.start()
@@ -358,6 +360,7 @@ async def test_subscription_sync_adds_stop_order_symbols(
         quantity=5.0,
         order_type="stop",
         stop_price=100000.0,
+        account_id="acc-test",
     )
 
     await integration.start()
@@ -387,7 +390,7 @@ async def test_subscription_sync_on_bot_event(
     await integration.start()
     try:
         # 봇 시작 이벤트 발행
-        await eventbus.publish(BotStartedEvent(bot_id="bot-1"))
+        await eventbus.publish(BotStartedEvent(bot_id="bot-1", account_id="acc-test"))
         await asyncio.sleep(0.05)
 
         assert "005930" in stream_client.subscribed_symbols
@@ -412,7 +415,7 @@ async def test_subscription_sync_removes_symbols(
 
     await integration.start()
     try:
-        await eventbus.publish(BotStartedEvent(bot_id="bot-1"))
+        await eventbus.publish(BotStartedEvent(bot_id="bot-1", account_id="acc-test"))
         await asyncio.sleep(0.05)
         assert "005930" in stream_client.subscribed_symbols
 
@@ -420,7 +423,7 @@ async def test_subscription_sync_removes_symbols(
         bot_manager_mock.list_bots.return_value = []
         bot_manager_mock.get_bot.return_value = None
 
-        await eventbus.publish(BotStoppedEvent(bot_id="bot-1"))
+        await eventbus.publish(BotStoppedEvent(bot_id="bot-1", account_id="acc-test"))
         await asyncio.sleep(0.05)
 
         assert "005930" not in stream_client.subscribed_symbols

--- a/tests/unit/test_stream_integration.py
+++ b/tests/unit/test_stream_integration.py
@@ -505,3 +505,117 @@ async def test_fallback_not_started_without_gateway(
         assert not integration.is_fallback_active
     finally:
         await integration.stop()
+
+
+# ── account_id 보강 / strict OrderFilledEvent 회귀 (#1240 review) ──
+
+
+@pytest.mark.asyncio
+async def test_execution_without_account_id_skips_event(
+    stream_client: FakeStreamClient,
+    cache: ResponseCache,
+    eventbus: EventBus,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """account_id가 broker payload/lifecycle 모두 없으면 OrderFilledEvent를
+    발행하지 않고 WARNING 로그 후 skip한다 (라이브 경로 보존)."""
+    integration = StreamIntegration(
+        stream_client=stream_client,
+        cache=cache,
+        eventbus=eventbus,
+        # account_id 의도적으로 미주입
+    )
+    await integration.start()
+    try:
+        received: list[OrderFilledEvent] = []
+
+        async def handler(event: OrderFilledEvent) -> None:
+            received.append(event)
+
+        eventbus.subscribe(OrderFilledEvent, handler)
+
+        with caplog.at_level("WARNING", logger="ante.gateway.stream_integration"):
+            await stream_client.fire_execution(
+                {
+                    "symbol": "005930",
+                    "order_id": "ord-noacct",
+                    "side": "buy",
+                    "quantity": 10.0,
+                    "price": 70000.0,
+                }
+            )
+
+        assert received == []
+        assert any(
+            "OrderFilledEvent 발행을 skip" in rec.message for rec in caplog.records
+        )
+    finally:
+        await integration.stop()
+
+
+@pytest.mark.asyncio
+async def test_execution_uses_lifecycle_account_id_when_payload_missing(
+    integration: StreamIntegration,
+    stream_client: FakeStreamClient,
+    eventbus: EventBus,
+) -> None:
+    """broker payload에 account_id가 없으면 lifecycle account_id로 fallback
+    하여 OrderFilledEvent가 정상 발행된다."""
+    await integration.start()
+    try:
+        received: list[OrderFilledEvent] = []
+
+        async def handler(event: OrderFilledEvent) -> None:
+            received.append(event)
+
+        eventbus.subscribe(OrderFilledEvent, handler)
+
+        # broker payload에 account_id 없음 → integration._account_id="acc-001" 사용
+        await stream_client.fire_execution(
+            {
+                "symbol": "005930",
+                "order_id": "ord-1",
+                "side": "buy",
+                "quantity": 10.0,
+                "price": 70000.0,
+            }
+        )
+
+        assert len(received) == 1
+        assert received[0].account_id == "acc-001"
+        assert received[0].order_id == "ord-1"
+    finally:
+        await integration.stop()
+
+
+@pytest.mark.asyncio
+async def test_execution_payload_account_id_overrides_lifecycle(
+    integration: StreamIntegration,
+    stream_client: FakeStreamClient,
+    eventbus: EventBus,
+) -> None:
+    """broker payload의 account_id가 lifecycle account_id를 오버라이드한다."""
+    await integration.start()
+    try:
+        received: list[OrderFilledEvent] = []
+
+        async def handler(event: OrderFilledEvent) -> None:
+            received.append(event)
+
+        eventbus.subscribe(OrderFilledEvent, handler)
+
+        await stream_client.fire_execution(
+            {
+                "symbol": "005930",
+                "order_id": "ord-2",
+                "side": "buy",
+                "quantity": 10.0,
+                "price": 70000.0,
+                "account_id": "acc-other",
+            }
+        )
+
+        assert len(received) == 1
+        assert received[0].account_id == "acc-other"
+    finally:
+        await integration.stop()

--- a/tests/unit/test_trade.py
+++ b/tests/unit/test_trade.py
@@ -78,6 +78,7 @@ def _make_filled_event(
     commission: float = 0.0,
     order_type: str = "market",
     reason: str = "test",
+    account_id: str = "acc-test",
 ) -> OrderFilledEvent:
     now = datetime.now(UTC)
     return OrderFilledEvent(
@@ -94,6 +95,7 @@ def _make_filled_event(
         commission=commission,
         order_type=order_type,
         reason=reason,
+        account_id=account_id,
     )
 
 
@@ -134,6 +136,7 @@ class TestTradeRecorder:
             price=50000.0,
             order_type="market",
             reason="rule violation",
+            account_id="acc-test",
         )
         await recorder._on_rejected(event)
 
@@ -155,6 +158,7 @@ class TestTradeRecorder:
             price=0.0,
             order_type="market",
             error_message="broker error",
+            account_id="acc-test",
         )
         await recorder._on_failed(event)
 
@@ -176,6 +180,7 @@ class TestTradeRecorder:
             quantity=10.0,
             price=0.0,
             reason="user cancel",
+            account_id="acc-test",
         )
         await recorder._on_cancelled(event)
 
@@ -216,6 +221,7 @@ class TestTradeRecorder:
             price=0.0,
             order_type="market",
             error_message="err",
+            account_id="acc-test",
         )
         await recorder._on_failed(event)
 
@@ -233,6 +239,7 @@ class TestTradeRecorder:
             old_quantity=10,
             new_quantity=15,
             reason="broker mismatch",
+            account_id="acc-test",
         )
 
         rows = await db.fetch_all("SELECT * FROM trades WHERE status = 'adjusted'")
@@ -305,6 +312,7 @@ class TestPositionHistory:
             price=50000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(record)
 
@@ -324,6 +332,7 @@ class TestPositionHistory:
             price=50000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(record1)
 
@@ -337,6 +346,7 @@ class TestPositionHistory:
             price=60000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(record2)
 
@@ -357,6 +367,7 @@ class TestPositionHistory:
             price=50000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(buy)
 
@@ -372,6 +383,7 @@ class TestPositionHistory:
             status=TradeStatus.FILLED,
             commission=100,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(sell)
 
@@ -393,6 +405,7 @@ class TestPositionHistory:
             price=50000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(buy)
 
@@ -406,6 +419,7 @@ class TestPositionHistory:
             price=55000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(sell)
 
@@ -425,6 +439,7 @@ class TestPositionHistory:
             price=50000,
             status=TradeStatus.CANCELLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(record)
 
@@ -443,6 +458,7 @@ class TestPositionHistory:
             price=50000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(buy)
 
@@ -457,6 +473,7 @@ class TestPositionHistory:
             price=100000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(buy2)
         sell2 = TradeRecord(
@@ -469,6 +486,7 @@ class TestPositionHistory:
             price=110000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(sell2)
 
@@ -488,6 +506,7 @@ class TestPositionHistory:
             price=50000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(buy)
         sell = TradeRecord(
@@ -500,6 +519,7 @@ class TestPositionHistory:
             price=55000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(sell)
 
@@ -520,6 +540,7 @@ class TestPositionHistory:
                 price=50000,
                 status=TradeStatus.FILLED,
                 timestamp=datetime.now(UTC),
+                account_id="acc-test",
             )
             await position_history.on_trade(buy)
 
@@ -533,6 +554,7 @@ class TestPositionHistory:
             symbol="005930",
             quantity=100,
             avg_entry_price=45000,
+            account_id="acc-test",
         )
 
         pos = await position_history.get_current("bot1", "005930")
@@ -546,6 +568,7 @@ class TestPositionHistory:
             symbol="005930",
             quantity=50,
             avg_entry_price=60000,
+            account_id="acc-test",
         )
 
         cached = position_history.get_positions_sync("bot1")
@@ -559,6 +582,7 @@ class TestPositionHistory:
             symbol="005930",
             quantity=0,
             avg_entry_price=0,
+            account_id="acc-test",
         )
         assert position_history.get_positions_sync("bot1") == []
 
@@ -574,6 +598,7 @@ class TestPositionHistory:
             price=50000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(buy)
         sell = TradeRecord(
@@ -586,6 +611,7 @@ class TestPositionHistory:
             price=55000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(sell)
 
@@ -605,6 +631,7 @@ class TestPositionHistory:
             price=50000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(buy)
 
@@ -620,6 +647,7 @@ class TestPositionHistory:
             status=TradeStatus.FILLED,
             commission=0.0,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(sell)
 
@@ -645,6 +673,7 @@ class TestPositionHistory:
             price=50000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(buy)
 
@@ -658,6 +687,7 @@ class TestPositionHistory:
             price=55000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         with caplog.at_level(logging.WARNING, logger="ante.trade.position"):
             await position_history.on_trade(sell)
@@ -676,6 +706,7 @@ class TestPositionHistory:
             price=50000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(buy)
 
@@ -689,6 +720,7 @@ class TestPositionHistory:
             price=55000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(sell)
 
@@ -709,6 +741,7 @@ class TestPositionHistory:
             price=50000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(buy)
 
@@ -723,6 +756,7 @@ class TestPositionHistory:
             status=TradeStatus.FILLED,
             commission=100,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(sell)
 
@@ -771,6 +805,7 @@ class TestPerformanceTracker:
             price=55000.0,
             commission=100.0,
             order_type="market",
+            account_id="acc-test",
         )
         await recorder._on_filled(sell1)
 
@@ -787,6 +822,7 @@ class TestPerformanceTracker:
             quantity=5.0,
             price=100000.0,
             order_type="market",
+            account_id="acc-test",
         )
         await recorder._on_filled(buy2)
 
@@ -804,10 +840,11 @@ class TestPerformanceTracker:
             price=90000.0,
             commission=50.0,
             order_type="market",
+            account_id="acc-test",
         )
         await recorder._on_filled(sell2)
 
-        metrics = await performance.calculate(account_id="default", bot_id="bot1")
+        metrics = await performance.calculate(account_id="acc-test", bot_id="bot1")
         assert metrics.total_trades == 2  # 매도 2건
         assert metrics.winning_trades == 1
         assert metrics.losing_trades == 1
@@ -889,10 +926,11 @@ class TestPerformanceTracker:
             quantity=10.0,
             price=55000.0,
             order_type="market",
+            account_id="acc-test",
         )
         await recorder._on_filled(sell)
 
-        metrics = await performance.calculate(account_id="default", bot_id="bot1")
+        metrics = await performance.calculate(account_id="acc-test", bot_id="bot1")
         assert metrics.profit_factor == float("inf")
 
 
@@ -906,7 +944,7 @@ class TestTradeService:
             _make_filled_event(side="buy", quantity=10, price=50000)
         )
 
-        summary = await service.get_summary("bot1", account_id="default")
+        summary = await service.get_summary("bot1", account_id="acc-default")
         assert "positions" in summary
         assert "performance" in summary
         assert "recent_trades" in summary
@@ -924,6 +962,7 @@ class TestTradeService:
             price=50000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(buy)
 
@@ -933,6 +972,7 @@ class TestTradeService:
             quantity=15,
             avg_price=48000,
             reason="broker mismatch",
+            account_id="acc-test",
         )
 
         assert result["old_quantity"] == 10
@@ -956,6 +996,7 @@ class TestTradeService:
             strategy_id="s1",
             fill=fill,
             reason="missed fill",
+            account_id="acc-test",
         )
 
         trades = await recorder.get_trades(bot_id="bot1")
@@ -974,6 +1015,7 @@ class TestTradeService:
             price=50000,
             status=TradeStatus.FILLED,
             timestamp=datetime.now(UTC),
+            account_id="acc-test",
         )
         await position_history.on_trade(buy)
 
@@ -983,7 +1025,7 @@ class TestTradeService:
 
     async def test_get_performance_delegates(self, service):
         """성과 조회 위임."""
-        metrics = await service.get_performance(account_id="default", bot_id="bot1")
+        metrics = await service.get_performance(account_id="acc-default", bot_id="bot1")
         assert isinstance(metrics, PerformanceMetrics)
 
 
@@ -1036,7 +1078,7 @@ class TestAccountIdFields:
         assert record.currency == "USD"
 
     def test_trade_record_default_values(self):
-        """기본값 'default', 'KRW' 확인."""
+        """account_id는 명시값으로 보존되고 currency는 'KRW'가 기본값이다."""
         record = TradeRecord(
             trade_id=uuid4(),
             bot_id="bot1",
@@ -1046,8 +1088,9 @@ class TestAccountIdFields:
             quantity=10,
             price=50000,
             status=TradeStatus.FILLED,
+            account_id="acc-test",
         )
-        assert record.account_id == "default"
+        assert record.account_id == "acc-test"
         assert record.currency == "KRW"
 
     def test_position_snapshot_with_account(self):
@@ -1062,14 +1105,15 @@ class TestAccountIdFields:
         assert snapshot.account_id == "my-account"
 
     def test_position_snapshot_default_account(self):
-        """PositionSnapshot 기본 account_id 확인."""
+        """PositionSnapshot account_id는 명시값으로 보존된다."""
         snapshot = PositionSnapshot(
             bot_id="bot1",
             symbol="005930",
             quantity=10,
             avg_entry_price=50000,
+            account_id="acc-test",
         )
-        assert snapshot.account_id == "default"
+        assert snapshot.account_id == "acc-test"
 
 
 class TestAccountIdDbMigration:
@@ -1192,3 +1236,343 @@ class TestAccountIdDbMigration:
         cached = position_history.get_positions_sync("bot1")
         assert len(cached) == 1
         assert cached[0].account_id == "acct-us"
+
+
+# ── #1217: legacy account_id 처리 / correct_position 사전 검증 ──
+
+
+class TestWarmCacheLegacyAccountId:
+    """#1217: 기존 DB의 invalid account_id row를 warm_cache가 skip해야 한다."""
+
+    async def test_warm_cache_skips_invalid_account_id_row(
+        self, db, position_history, caplog
+    ):
+        """positions 테이블에 'default' account_id row가 있어도 부팅 실패하지 않는다."""
+        import logging
+
+        # legacy 'default' row를 직접 삽입 (정상 경로로는 만들 수 없음)
+        await db.execute(
+            "INSERT INTO positions "
+            "(bot_id, symbol, quantity, avg_entry_price, "
+            "realized_pnl, account_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("legacy-bot", "005930", 5.0, 10000.0, 0.0, "default"),
+        )
+        # 정상 row도 함께 삽입하여 skip 외 row는 정상 적재되는지 검증
+        await db.execute(
+            "INSERT INTO positions "
+            "(bot_id, symbol, quantity, avg_entry_price, "
+            "realized_pnl, account_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("ok-bot", "005931", 3.0, 20000.0, 0.0, "acc-test"),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="ante.trade.position"):
+            await position_history._warm_cache()
+
+        # legacy bot은 캐시에 적재되지 않음
+        assert position_history.get_positions_sync("legacy-bot") == []
+        # 정상 bot은 적재됨
+        ok_positions = position_history.get_positions_sync("ok-bot")
+        assert len(ok_positions) == 1
+        assert ok_positions[0].account_id == "acc-test"
+
+        # warning 로그가 기록되어야 함
+        assert any("invalid account_id" in record.message for record in caplog.records)
+
+
+class TestCorrectPositionAccountIdValidation:
+    """#1217: correct_position 진입 시 account_id 사전 검증."""
+
+    async def test_correct_position_rejects_invalid_account_id(
+        self, service, position_history
+    ):
+        """invalid account_id ('default') 입력 시 InvalidAccountIdError raise."""
+        from ante.account.errors import InvalidAccountIdError
+
+        with pytest.raises(InvalidAccountIdError):
+            await service.correct_position(
+                bot_id="bot1",
+                symbol="005930",
+                quantity=5,
+                account_id="default",
+            )
+
+    async def test_correct_position_rejects_empty_account_id(
+        self, service, position_history
+    ):
+        """빈 account_id도 거부."""
+        from ante.account.errors import InvalidAccountIdError
+
+        with pytest.raises(InvalidAccountIdError):
+            await service.correct_position(
+                bot_id="bot1",
+                symbol="005930",
+                quantity=5,
+                account_id="",
+            )
+
+    async def test_correct_position_invalid_account_id_does_not_touch_db(
+        self, service, position_history, db
+    ):
+        """invalid account_id는 force_update commit 전에 차단되어 DB 변경이 없다."""
+        from ante.account.errors import InvalidAccountIdError
+
+        with pytest.raises(InvalidAccountIdError):
+            await service.correct_position(
+                bot_id="bot-x",
+                symbol="005932",
+                quantity=99,
+                account_id="default",
+            )
+
+        rows = await db.fetch_all(
+            "SELECT * FROM positions WHERE bot_id = ? AND symbol = ?",
+            ("bot-x", "005932"),
+        )
+        assert rows == []
+
+
+class TestPositionReadLegacyAccountId:
+    """#1217: get_positions / get_all_positions read 경로도 legacy row skip."""
+
+    async def test_get_positions_skips_legacy_invalid_account_id(
+        self, db, position_history, caplog
+    ):
+        """get_positions가 invalid account_id row를 skip하고 정상 row만 반환한다."""
+        import logging
+
+        # legacy 'default' row + 정상 row 동일 봇에 삽입
+        await db.execute(
+            "INSERT INTO positions "
+            "(bot_id, symbol, quantity, avg_entry_price, "
+            "realized_pnl, account_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("mixed-bot", "005930", 5.0, 10000.0, 0.0, "default"),
+        )
+        await db.execute(
+            "INSERT INTO positions "
+            "(bot_id, symbol, quantity, avg_entry_price, "
+            "realized_pnl, account_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("mixed-bot", "005931", 3.0, 20000.0, 0.0, "acc-test"),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="ante.trade.position"):
+            positions = await position_history.get_positions("mixed-bot")
+
+        # InvalidAccountIdError가 raise되지 않아야 함, 정상 row만 반환
+        assert len(positions) == 1
+        assert positions[0].symbol == "005931"
+        assert positions[0].account_id == "acc-test"
+        # warning 로그가 기록되어야 함
+        assert any(
+            "invalid account_id" in record.message and "get_positions" in record.message
+            for record in caplog.records
+        )
+
+    async def test_get_positions_include_closed_skips_legacy(
+        self, db, position_history, caplog
+    ):
+        """include_closed=True 경로도 legacy row를 skip한다."""
+        import logging
+
+        await db.execute(
+            "INSERT INTO positions "
+            "(bot_id, symbol, quantity, avg_entry_price, "
+            "realized_pnl, account_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("closed-bot", "005930", 0.0, 10000.0, 100.0, "default"),
+        )
+        await db.execute(
+            "INSERT INTO positions "
+            "(bot_id, symbol, quantity, avg_entry_price, "
+            "realized_pnl, account_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("closed-bot", "005931", 0.0, 20000.0, 50.0, "acc-test"),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="ante.trade.position"):
+            positions = await position_history.get_positions(
+                "closed-bot", include_closed=True
+            )
+
+        assert len(positions) == 1
+        assert positions[0].symbol == "005931"
+
+    async def test_get_all_positions_skips_legacy_invalid_account_id(
+        self, db, position_history, caplog
+    ):
+        """get_all_positions가 invalid account_id row를 skip하고 정상 row만 반환한다."""
+        import logging
+
+        await db.execute(
+            "INSERT INTO positions "
+            "(bot_id, symbol, quantity, avg_entry_price, "
+            "realized_pnl, account_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("legacy-bot-a", "005930", 5.0, 10000.0, 0.0, "default"),
+        )
+        await db.execute(
+            "INSERT INTO positions "
+            "(bot_id, symbol, quantity, avg_entry_price, "
+            "realized_pnl, account_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("ok-bot-b", "005931", 3.0, 20000.0, 0.0, "acc-test"),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="ante.trade.position"):
+            positions = await position_history.get_all_positions()
+
+        assert len(positions) == 1
+        assert positions[0].bot_id == "ok-bot-b"
+        assert positions[0].account_id == "acc-test"
+        assert any(
+            "invalid account_id" in record.message
+            and "get_all_positions" in record.message
+            for record in caplog.records
+        )
+
+
+class TestTradeReadLegacyAccountId:
+    """#1217: get_trades / DailyReport read 경로도 legacy row skip."""
+
+    @staticmethod
+    async def _insert_legacy_trade(
+        db,
+        *,
+        trade_id: str,
+        bot_id: str = "legacy-bot",
+        symbol: str = "005930",
+        side: str = "buy",
+        quantity: float = 1.0,
+        price: float = 10000.0,
+        status: str = "filled",
+        timestamp: str | None = None,
+        account_id: str = "default",
+    ) -> None:
+        ts = timestamp or datetime.now(UTC).isoformat()
+        await db.execute(
+            """INSERT INTO trades
+               (trade_id, bot_id, strategy_id, symbol, side, quantity, price,
+                status, order_type, reason, commission, timestamp, order_id,
+                account_id, currency, exchange)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                trade_id,
+                bot_id,
+                "s-legacy",
+                symbol,
+                side,
+                quantity,
+                price,
+                status,
+                "market",
+                "legacy",
+                0.0,
+                ts,
+                None,
+                account_id,
+                "KRW",
+                "KRX",
+            ),
+        )
+
+    async def test_get_trades_skips_legacy_invalid_account_id(
+        self, recorder, db, caplog
+    ):
+        """get_trades가 legacy 'default' account_id row를 skip한다."""
+        import logging
+
+        legacy_id = str(uuid4())
+        valid_id = str(uuid4())
+
+        # legacy 'default' row + 정상 row 혼재 삽입
+        await self._insert_legacy_trade(
+            db,
+            trade_id=legacy_id,
+            bot_id="legacy-bot",
+            account_id="default",
+        )
+        await self._insert_legacy_trade(
+            db,
+            trade_id=valid_id,
+            bot_id="ok-bot",
+            account_id="acc-test",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="ante.trade.recorder"):
+            trades = await recorder.get_trades()
+
+        # InvalidAccountIdError가 raise되지 않아야 함, 정상 row만 반환
+        assert len(trades) == 1
+        assert trades[0].bot_id == "ok-bot"
+        assert trades[0].account_id == "acc-test"
+        # warning 로그가 기록되어야 함
+        assert any(
+            "invalid account_id" in record.message and "get_trades" in record.message
+            for record in caplog.records
+        )
+
+    async def test_get_trades_account_id_filter_does_not_raise_on_default(
+        self, recorder, db, caplog
+    ):
+        """account_id=None 호출도 legacy default row 있을 때 raise 없이 동작."""
+        import logging
+
+        await self._insert_legacy_trade(
+            db,
+            trade_id=str(uuid4()),
+            account_id="default",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="ante.trade.recorder"):
+            trades = await recorder.get_trades(account_id=None)
+
+        assert trades == []
+        assert any("invalid account_id" in record.message for record in caplog.records)
+
+    async def test_performance_get_filled_trades_skips_legacy(
+        self, performance, db, caplog
+    ):
+        """PerformanceTracker._get_filled_trades 경유 (metrics 등) 도 skip."""
+        import logging
+
+        legacy_id = str(uuid4())
+        valid_id = str(uuid4())
+        ts = datetime.now(UTC).isoformat()
+
+        # legacy 'default' row + 정상 row 혼재
+        await TestTradeReadLegacyAccountId._insert_legacy_trade(
+            db,
+            trade_id=legacy_id,
+            bot_id="legacy-bot",
+            side="sell",
+            account_id="default",
+            timestamp=ts,
+        )
+        await TestTradeReadLegacyAccountId._insert_legacy_trade(
+            db,
+            trade_id=valid_id,
+            bot_id="ok-bot",
+            side="sell",
+            account_id="acc-test",
+            timestamp=ts,
+        )
+
+        # 1) account_id='acc-test' 필터: SQL 단계에서 default 제외, 정상 1건 반환
+        with caplog.at_level(logging.WARNING, logger="ante.trade.performance"):
+            valid_trades = await performance._get_filled_trades(account_id="acc-test")
+        assert len(valid_trades) == 1
+        assert valid_trades[0].account_id == "acc-test"
+
+        # 2) account_id='default' 필터: SQL 매칭은 되지만 모델 변환에서 skip
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="ante.trade.performance"):
+            legacy_trades = await performance._get_filled_trades(account_id="default")
+        assert legacy_trades == []
+        assert any(
+            "invalid account_id" in record.message
+            and "_get_filled_trades" in record.message
+            for record in caplog.records
+        )

--- a/tests/unit/test_trade.py
+++ b/tests/unit/test_trade.py
@@ -618,6 +618,49 @@ class TestPositionHistory:
         history = await position_history.get_history("bot1", "005930")
         assert len(history) == 2  # buy + sell
 
+    async def test_save_history_writes_account_id(self, position_history, db):
+        """체결 이력 INSERT 시 account_id가 schema default 'default'가 아닌
+        record.account_id로 저장되어야 한다 (#1240 review P2 회귀)."""
+        buy = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10,
+            price=50000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+            account_id="acc-real",
+        )
+        await position_history.on_trade(buy)
+
+        sell = TradeRecord(
+            trade_id=uuid4(),
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="sell",
+            quantity=5,
+            price=55000,
+            status=TradeStatus.FILLED,
+            timestamp=datetime.now(UTC),
+            account_id="acc-real",
+        )
+        await position_history.on_trade(sell)
+
+        rows = await db.fetch_all(
+            "SELECT action, account_id FROM position_history"
+            " WHERE bot_id = ? ORDER BY id",
+            ("bot1",),
+        )
+        assert len(rows) == 2
+        for row in rows:
+            assert row["account_id"] == "acc-real", (
+                f"position_history.{row['action']} row의 account_id가 "
+                f"{row['account_id']!r} (expected 'acc-real')"
+            )
+
     async def test_oversell_clamps_pnl_to_held_quantity(self, position_history):
         """초과 매도 시 PnL은 보유 수량 기준으로 계산 (#769)."""
         # 50주 매수 @ 50000

--- a/tests/unit/test_trade.py
+++ b/tests/unit/test_trade.py
@@ -231,6 +231,86 @@ class TestTradeRecorder:
         failed = await recorder.get_trades(status=TradeStatus.FAILED)
         assert len(failed) == 1
 
+    async def test_get_trades_pagination_skips_legacy_correctly(self, recorder, db):
+        """legacy invalid account_id row 가 SQL 단계에서 제외되어야 페이지네이션이 정확.
+
+        Refs #1240 review (P2-3): 이전 구현은 SQL ``LIMIT/OFFSET`` 으로 행을
+        뽑은 뒤 Python 단계에서 invalid account_id row 를 skip 했다. 첫 페이지가
+        legacy default row 로 가득 차면 유효 거래가 다음 페이지로 밀려 첫
+        페이지가 빈/과소 페이지로 반환됐다. 이제는 SSOT
+        ``INVALID_RUNTIME_ACCOUNT_IDS`` 와 빈 문자열/NULL 을 SQL ``WHERE`` 로
+        함께 제외해 첫 페이지가 항상 유효 거래로 채워진다.
+        """
+        # legacy default account_id row 5개를 먼저 가장 최근 timestamp 로 넣는다.
+        # SQL 정렬은 ``timestamp DESC`` 이므로 LIMIT 으로 자르면 자연히
+        # 첫 페이지가 legacy 만으로 채워졌어야 했다 (SSOT 적용 전 시나리오).
+        from datetime import UTC, datetime, timedelta
+
+        base = datetime.now(UTC)
+        for i in range(5):
+            await db.execute(
+                "INSERT INTO trades "
+                "(trade_id, bot_id, strategy_id, symbol, side, quantity, price, "
+                " status, order_type, reason, commission, timestamp, order_id, "
+                " account_id, currency, exchange) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    f"legacy-{i}",
+                    "bot-legacy",
+                    "s1",
+                    "005930",
+                    "buy",
+                    1.0,
+                    100.0,
+                    "filled",
+                    "market",
+                    "legacy",
+                    0.0,
+                    (base + timedelta(seconds=100 + i)).isoformat(),
+                    f"ord-legacy-{i}",
+                    "default",  # legacy invalid account_id
+                    "KRW",
+                    "KRX",
+                ),
+            )
+
+        # 유효한 거래 2개를 더 오래된 timestamp 로 넣는다.
+        for i, sym in enumerate(["AAA", "BBB"]):
+            await db.execute(
+                "INSERT INTO trades "
+                "(trade_id, bot_id, strategy_id, symbol, side, quantity, price, "
+                " status, order_type, reason, commission, timestamp, order_id, "
+                " account_id, currency, exchange) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    f"valid-{i}",
+                    "bot-valid",
+                    "s1",
+                    sym,
+                    "buy",
+                    1.0,
+                    100.0,
+                    "filled",
+                    "market",
+                    "ok",
+                    0.0,
+                    (base + timedelta(seconds=i)).isoformat(),
+                    f"ord-valid-{i}",
+                    "acc-a",
+                    "KRW",
+                    "KRX",
+                ),
+            )
+
+        # limit=5, offset=0 첫 페이지: SQL WHERE 로 legacy row 가 이미 빠지므로
+        # 유효 거래 2개가 그대로 첫 페이지에 올라온다.
+        first_page = await recorder.get_trades(limit=5, offset=0)
+        assert len(first_page) == 2
+        symbols = sorted(t.symbol for t in first_page)
+        assert symbols == ["AAA", "BBB"]
+        # 모든 결과의 account_id 는 acc-a 여야 한다 (legacy default 미포함).
+        assert all(t.account_id == "acc-a" for t in first_page)
+
     async def test_save_adjustment(self, recorder, db):
         """대사 보정 이력 기록."""
         await recorder.save_adjustment(
@@ -1592,7 +1672,13 @@ class TestTradeReadLegacyAccountId:
     async def test_get_trades_skips_legacy_invalid_account_id(
         self, recorder, db, caplog
     ):
-        """get_trades가 legacy 'default' account_id row를 skip한다."""
+        """get_trades가 legacy 'default' account_id row를 skip한다.
+
+        Refs #1240 review (P2-3): 이제 SQL ``WHERE`` 단계에서 legacy
+        invalid account_id row 가 제외된다. 따라서 row 가 ``_row_to_record``
+        까지 도달해 warning 을 남기는 일은 없다 (페이지네이션 underflow
+        방지). 결과의 정확성 (정상 row 만 반환) 은 그대로 유지된다.
+        """
         import logging
 
         legacy_id = str(uuid4())
@@ -1619,29 +1705,24 @@ class TestTradeReadLegacyAccountId:
         assert len(trades) == 1
         assert trades[0].bot_id == "ok-bot"
         assert trades[0].account_id == "acc-test"
-        # warning 로그가 기록되어야 함
-        assert any(
-            "invalid account_id" in record.message and "get_trades" in record.message
-            for record in caplog.records
-        )
 
     async def test_get_trades_account_id_filter_does_not_raise_on_default(
-        self, recorder, db, caplog
+        self, recorder, db
     ):
-        """account_id=None 호출도 legacy default row 있을 때 raise 없이 동작."""
-        import logging
+        """account_id=None 호출도 legacy default row 있을 때 raise 없이 동작.
 
+        Refs #1240 review (P2-3): SQL ``WHERE`` 에서 legacy default row 가
+        제외되므로 빈 결과만 반환되고 raise 도 발생하지 않는다.
+        """
         await self._insert_legacy_trade(
             db,
             trade_id=str(uuid4()),
             account_id="default",
         )
 
-        with caplog.at_level(logging.WARNING, logger="ante.trade.recorder"):
-            trades = await recorder.get_trades(account_id=None)
+        trades = await recorder.get_trades(account_id=None)
 
         assert trades == []
-        assert any("invalid account_id" in record.message for record in caplog.records)
 
     async def test_performance_get_filled_trades_skips_legacy(
         self, performance, db, caplog

--- a/tests/unit/test_trade.py
+++ b/tests/unit/test_trade.py
@@ -547,6 +547,47 @@ class TestPositionHistory:
         positions = await position_history.get_all_positions()
         assert len(positions) == 2
 
+    async def test_get_all_positions_filter_by_account_id(self, position_history):
+        """``account_id`` 옵션 인자가 주어지면 해당 계좌 포지션만 반환한다.
+
+        #1240 review: 단일 계좌 바인딩된 호출자(Treasury, DailyReportScheduler)
+        가 자기 계좌만 보도록 명시 필터를 사용할 수 있어야 한다.
+        ``account_id=None`` (기본값) 은 기존 all-account 동작을 유지한다.
+        """
+        for bot, acc in [("bot-a", "acc-a"), ("bot-b", "acc-b")]:
+            buy = TradeRecord(
+                trade_id=uuid4(),
+                bot_id=bot,
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10,
+                price=50000,
+                status=TradeStatus.FILLED,
+                timestamp=datetime.now(UTC),
+                account_id=acc,
+            )
+            await position_history.on_trade(buy)
+
+        # 기본(account_id 생략) 은 all-account.
+        all_positions = await position_history.get_all_positions()
+        assert len(all_positions) == 2
+
+        # acc-a 만 명시.
+        only_a = await position_history.get_all_positions(account_id="acc-a")
+        assert len(only_a) == 1
+        assert only_a[0].account_id == "acc-a"
+        assert only_a[0].bot_id == "bot-a"
+
+        # acc-b 만 명시.
+        only_b = await position_history.get_all_positions(account_id="acc-b")
+        assert len(only_b) == 1
+        assert only_b[0].account_id == "acc-b"
+
+        # 존재하지 않는 계좌.
+        none = await position_history.get_all_positions(account_id="acc-zzz")
+        assert none == []
+
     async def test_force_update(self, position_history):
         """Reconciler 강제 포지션 덮어쓰기."""
         await position_history.force_update(
@@ -1239,6 +1280,33 @@ class TestAccountIdDbMigration:
         trades = await recorder.get_trades(account_id="acct-1")
         assert len(trades) == 1
         assert trades[0].account_id == "acct-1"
+
+    async def test_get_trades_filter_already_supported_does_not_break(self, recorder):
+        """기존 read 경로(account 생략) 가 여전히 all-account 반환.
+
+        #1240 review: SPLIT-1 의 단일 계좌 바인딩 호출자에 account_id 필터를
+        명시 추가했을 때, account 생략 경로의 user-facing default 정책은
+        그대로(=all-account) 유지되어야 한다 (#1218 영역 분리).
+        """
+        for acct in ("acct-1", "acct-2"):
+            record = TradeRecord(
+                trade_id=uuid4(),
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10,
+                price=50000,
+                status=TradeStatus.FILLED,
+                account_id=acct,
+                timestamp=datetime.now(UTC),
+            )
+            await recorder.save(record)
+
+        # account_id 생략 → all-account.
+        trades = await recorder.get_trades()
+        assert len(trades) == 2
+        assert {t.account_id for t in trades} == {"acct-1", "acct-2"}
 
     async def test_position_saved_with_account_id(self, position_history):
         """포지션 갱신 시 account_id가 DB에 저장되는지 확인."""

--- a/tests/unit/test_trade_exchange_column.py
+++ b/tests/unit/test_trade_exchange_column.py
@@ -48,7 +48,7 @@ def _make_record(*, exchange: str = "KRX", side: str = "buy", **kwargs) -> Trade
         exchange=exchange,
     )
     defaults.update(kwargs)
-    return TradeRecord(**defaults)
+    return TradeRecord(**defaults, account_id="acc-test")
 
 
 class TestRecorderExchangeColumn:

--- a/tests/unit/test_trade_id_fk.py
+++ b/tests/unit/test_trade_id_fk.py
@@ -38,6 +38,7 @@ class TestPositionHistoryTradeId:
             price=70000.0,
             status=TradeStatus.FILLED,
             timestamp=datetime(2026, 3, 23, 10, 0, 0),
+            account_id="acc-test",
         )
 
         await ph.on_trade(record)
@@ -82,6 +83,7 @@ class TestPositionHistoryTradeId:
             price=70000.0,
             status=TradeStatus.FILLED,
             timestamp=datetime(2026, 3, 23, 11, 0, 0),
+            account_id="acc-test",
         )
 
         await ph.on_trade(record)
@@ -115,6 +117,7 @@ class TestPerformanceTrackerTradeIdJoin:
             price=70000.0,
             status=TradeStatus.FILLED,
             timestamp=datetime(2026, 3, 23, 11, 0, 0),
+            account_id="acc-test",
         )
 
         pnl_list = await tracker._calculate_pnl_per_trade([sell_trade], "bot-1")
@@ -171,6 +174,7 @@ class TestPerformanceTrackerTradeIdJoin:
             price=70000.0,
             status=TradeStatus.FILLED,
             timestamp=datetime(2026, 3, 23, 11, 0, 0),
+            account_id="acc-test",
         )
         sell_2 = TradeRecord(
             trade_id=trade_id_2,
@@ -182,6 +186,7 @@ class TestPerformanceTrackerTradeIdJoin:
             price=70000.0,
             status=TradeStatus.FILLED,
             timestamp=datetime(2026, 3, 23, 12, 0, 0),
+            account_id="acc-test",
         )
 
         pnl_list = await tracker._calculate_pnl_per_trade([sell_1, sell_2], "bot-1")

--- a/tests/unit/test_trade_id_uuid_parsing.py
+++ b/tests/unit/test_trade_id_uuid_parsing.py
@@ -31,7 +31,7 @@ class TestRowToRecordUUIDParsing:
             "commission": 0.0,
             "timestamp": "2026-03-20 10:00:00",
             "order_id": None,
-            "account_id": "default",
+            "account_id": "acc-test",
             "currency": "KRW",
         }
         base.update(overrides)

--- a/tests/unit/test_treasury.py
+++ b/tests/unit/test_treasury.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from ante.account.errors import InvalidAccountIdError
 from ante.core import Database
 from ante.eventbus import EventBus
 from ante.eventbus.events import (
@@ -55,7 +56,7 @@ async def treasury(db, eventbus):
 class TestBotBudget:
     def test_defaults(self):
         """BotBudget 기본값 확인."""
-        b = BotBudget(bot_id="bot1")
+        b = BotBudget(bot_id="bot1", account_id="acc-test")
         assert b.allocated == 0.0
         assert b.available == 0.0
         assert b.reserved == 0.0
@@ -440,14 +441,11 @@ class TestTreasuryEvents:
         assert budget.available == 1_000_000.0
         assert budget.reserved == 0.0
 
-    async def test_event_without_account_id_processed(self, treasury, eventbus):
-        """account_id가 비어있는 이벤트는 하위 호환으로 처리한다."""
+    async def test_event_without_account_id_rejected(self, treasury, eventbus):
+        """account_id가 비어있는 이벤트는 생성 단계에서 거부된다 (#1217)."""
         await treasury.allocate("bot1", 1_000_000.0)
 
-        received = []
-        eventbus.subscribe(OrderApprovedEvent, lambda e: received.append(e))
-
-        await eventbus.publish(
+        with pytest.raises(InvalidAccountIdError):
             OrderValidatedEvent(
                 order_id="ord1",
                 bot_id="bot1",
@@ -459,10 +457,6 @@ class TestTreasuryEvents:
                 order_type="market",
                 account_id="",
             )
-        )
-
-        # account_id 비어있으면 처리
-        assert len(received) == 1
 
     async def test_filled_event_filtered_by_account(self, treasury, eventbus):
         """다른 계좌의 체결 이벤트는 무시한다."""

--- a/tests/unit/test_treasury_is_virtual.py
+++ b/tests/unit/test_treasury_is_virtual.py
@@ -69,7 +69,7 @@ class TestIsVirtualFromTradingMode:
 
     def test_virtual_account_returns_is_virtual_true(self):
         """trading_mode=VIRTUAL 계좌는 is_virtual=True."""
-        treasury = FakeTreasury(account_id="domestic")
+        treasury = FakeTreasury()
         account_service = AsyncMock()
         account_service.get.return_value = _make_account(
             "domestic", TradingMode.VIRTUAL
@@ -85,7 +85,7 @@ class TestIsVirtualFromTradingMode:
 
     def test_live_account_returns_is_virtual_false(self):
         """trading_mode=LIVE 계좌는 is_virtual=False."""
-        treasury = FakeTreasury(account_id="domestic")
+        treasury = FakeTreasury()
         account_service = AsyncMock()
         account_service.get.return_value = _make_account("domestic", TradingMode.LIVE)
 
@@ -99,7 +99,7 @@ class TestIsVirtualFromTradingMode:
 
     def test_live_is_paper_true_returns_is_virtual_false(self):
         """LIVE + is_paper=true 조합에서 is_virtual=False (수용 조건 #2)."""
-        treasury = FakeTreasury(account_id="domestic")
+        treasury = FakeTreasury()
         account_service = AsyncMock()
         account = _make_account("domestic", TradingMode.LIVE)
         account.broker_config = {"is_paper": True}
@@ -116,7 +116,7 @@ class TestIsVirtualFromTradingMode:
 
     def test_no_account_service_defaults_to_virtual(self):
         """account_service가 없으면 is_virtual=True (안전 기본값)."""
-        treasury = FakeTreasury(account_id="domestic")
+        treasury = FakeTreasury()
 
         app = create_app(treasury=treasury)
         client = TestClient(app)
@@ -128,7 +128,7 @@ class TestIsVirtualFromTradingMode:
 
     def test_account_not_found_defaults_to_virtual(self):
         """account_service.get()이 None 반환 시 is_virtual=True."""
-        treasury = FakeTreasury(account_id="unknown")
+        treasury = FakeTreasury()
         account_service = AsyncMock()
         account_service.get.return_value = None
 

--- a/tests/unit/test_treasury_sync.py
+++ b/tests/unit/test_treasury_sync.py
@@ -67,9 +67,16 @@ class FakePositionHistory:
 
     def __init__(self, positions: list | None = None) -> None:
         self._positions = positions or []
+        self.last_account_id: str | None = "__unset__"  # type: ignore[assignment]
 
-    async def get_all_positions(self) -> list:
-        return self._positions
+    async def get_all_positions(self, *, account_id: str | None = None) -> list:
+        # 호출 시 전달된 account_id 캡처 (테스트 검증용).
+        self.last_account_id = account_id
+        if account_id is None:
+            return list(self._positions)
+        return [
+            p for p in self._positions if getattr(p, "account_id", None) == account_id
+        ]
 
 
 class FailingBroker:
@@ -690,3 +697,101 @@ class TestVirtualSync:
         await treasury.stop_sync()
 
         assert treasury.last_synced_at is not None
+
+
+# ── #1240 review: cross-account 필터링 회귀 ───────
+
+
+class TestCrossAccountFilter:
+    """Treasury 가 자기 계좌 포지션만 집계하는지 검증.
+
+    SPLIT-1 부터 거래/포지션 row 가 실제 account_id 를 갖기 시작하므로,
+    단일 계좌 바인딩된 Treasury 가 cross-account 데이터를 끌어오면
+    treasury_state, BalanceSyncedEvent, 가상 평가금액에 타 계좌 포지션이
+    섞이게 된다. 이를 회귀로 차단한다.
+    """
+
+    async def test_treasury_sync_filters_other_account_positions(
+        self, treasury, eventbus
+    ):
+        """Live sync: Treasury(account='acc-test') 의 sync 가 acc-b 포지션을
+        external 분류에 포함하지 않는다.
+
+        ``FakePositionHistory.get_all_positions(account_id=...)`` 가
+        acc-test 행만 돌려주므로, 005930 도 internal 로 분류되어
+        external_* 가 0 이어야 한다.
+        """
+        broker = FakeBroker(
+            positions=[
+                {
+                    "symbol": "005930",
+                    "quantity": 100.0,
+                    "avg_price": 71000.0,
+                    "eval_amount": 7_200_000.0,
+                },
+            ]
+        )
+        # 같은 symbol 을 acc-test (자기) + acc-b (타) 양쪽이 보유.
+        pos_history = FakePositionHistory(
+            positions=[
+                PositionSnapshot(
+                    bot_id="bot-a",
+                    symbol="005930",
+                    quantity=100.0,
+                    avg_entry_price=71000.0,
+                    account_id="acc-test",
+                ),
+                PositionSnapshot(
+                    bot_id="bot-b",
+                    symbol="999999",
+                    quantity=10.0,
+                    avg_entry_price=10000.0,
+                    account_id="acc-b",
+                ),
+            ]
+        )
+
+        treasury.start_sync(broker, pos_history, interval_seconds=100)
+        await asyncio.sleep(0.05)
+        await treasury.stop_sync()
+
+        # Treasury 가 자기 account_id 로 명시 필터링했어야 한다.
+        assert pos_history.last_account_id == "acc-test"
+        # 005930 은 internal 로 분류되어 external 0.
+        assert treasury._external_purchase_amount == 0.0
+        assert treasury._external_eval_amount == 0.0
+
+    async def test_treasury_virtual_sync_filters_other_account(self, treasury):
+        """Virtual sync: 타 계좌 포지션이 자기 계좌의 평가금액에 섞이지 않는다."""
+        pos_history = FakePositionHistory(
+            positions=[
+                PositionSnapshot(
+                    bot_id="bot-a",
+                    symbol="005930",
+                    quantity=100.0,
+                    avg_entry_price=70000.0,
+                    account_id="acc-test",
+                ),
+                PositionSnapshot(
+                    bot_id="bot-b",
+                    symbol="000660",
+                    quantity=50.0,
+                    avg_entry_price=200000.0,
+                    account_id="acc-b",
+                ),
+            ]
+        )
+
+        treasury.start_sync(
+            broker=None,
+            position_history=pos_history,
+            interval_seconds=100,
+            trading_mode="virtual",
+        )
+        await asyncio.sleep(0.05)
+        await treasury.stop_sync()
+
+        # 자기 account_id 로만 집계되었어야 한다.
+        assert pos_history.last_account_id == "acc-test"
+        assert treasury._purchase_amount == 7_000_000.0  # 100 * 70000
+        assert treasury._eval_amount == 7_000_000.0

--- a/tests/unit/test_treasury_sync.py
+++ b/tests/unit/test_treasury_sync.py
@@ -28,7 +28,9 @@ def eventbus():
 
 @pytest.fixture
 async def treasury(db, eventbus):
-    t = Treasury(db=db, eventbus=eventbus, buy_commission_rate=0.00015)
+    t = Treasury(
+        db=db, eventbus=eventbus, buy_commission_rate=0.00015, account_id="acc-test"
+    )
     await t.initialize()
     return t
 
@@ -153,7 +155,7 @@ class TestSyncBalance:
         )
 
         # 새 인스턴스로 복원 확인 (계좌별 행 구조 — 핵심 필드만 영속화)
-        t2 = Treasury(db=db, eventbus=eventbus)
+        t2 = Treasury(db=db, eventbus=eventbus, account_id="acc-test")
         await t2.initialize()
 
         assert t2._account_balance == 5_000_000.0
@@ -279,6 +281,7 @@ class TestExternalPositions:
                     symbol="005930",
                     quantity=100.0,
                     avg_entry_price=71000.0,
+                    account_id="acc-test",
                 ),
             ]
         )
@@ -309,6 +312,7 @@ class TestExternalPositions:
                     symbol="005930",
                     quantity=100.0,
                     avg_entry_price=71000.0,
+                    account_id="acc-test",
                 ),
             ]
         )
@@ -490,12 +494,14 @@ class TestVirtualSync:
                     symbol="005930",
                     quantity=100.0,
                     avg_entry_price=70000.0,
+                    account_id="acc-test",
                 ),
                 PositionSnapshot(
                     bot_id="bot1",
                     symbol="035720",
                     quantity=50.0,
                     avg_entry_price=60000.0,
+                    account_id="acc-test",
                 ),
             ]
         )
@@ -529,12 +535,14 @@ class TestVirtualSync:
                     symbol="005930",
                     quantity=100.0,
                     avg_entry_price=70000.0,
+                    account_id="acc-test",
                 ),
                 PositionSnapshot(
                     bot_id="bot1",
                     symbol="035720",
                     quantity=50.0,
                     avg_entry_price=60000.0,
+                    account_id="acc-test",
                 ),
             ]
         )
@@ -565,6 +573,7 @@ class TestVirtualSync:
                     symbol="005930",
                     quantity=100.0,
                     avg_entry_price=70000.0,
+                    account_id="acc-test",
                 ),
             ]
         )
@@ -613,6 +622,7 @@ class TestVirtualSync:
                     symbol="005930",
                     quantity=100.0,
                     avg_entry_price=70000.0,
+                    account_id="acc-test",
                 ),
             ]
         )
@@ -646,6 +656,7 @@ class TestVirtualSync:
                     symbol="005930",
                     quantity=100.0,
                     avg_entry_price=70000.0,
+                    account_id="acc-test",
                 ),
             ]
         )


### PR DESCRIPTION
Closes #1240

## Summary

#1217 SPLIT-1: lifecycle 영향 없는 contract drift 만 정리. account-scoped 이벤트 marker, Treasury/Rule write 경로, Trade models + recorder/position/service/reconciler, IPC payload, Web schemas/routes 의 fallback 제거.

- **Event marker**: `Event._requires_account_id: ClassVar[bool]` + base `__post_init__` strict 검증. account-scoped 이벤트 20+개에 marker 부착. dataclass field ordering 제약 때문에 `account_id: str = ""` default 는 유지하되 빈/invalid 값은 즉시 raise.
- **Treasury / Rule write**: `Treasury.__init__` / `RuleEngine.__init__` account_id required (kw-only) + `require_account_id`. `BotBudget` / `RuleContext` 도 동일.
- **Trade**: `TradeRecord` / `PositionSnapshot.__post_init__` `require_account_id`. `TradeService.correct_position/insert_adjustment`, `TradeRecorder.save_adjustment`, `PositionHistory.force_update/_update_position/_update_cache/_save_history`, `PositionReconciler.reconcile` account_id (kw-only) + 검증. legacy invalid row 는 read 경로에서 SQL `WHERE` 으로 제외.
- **DailyReportScheduler**: account_id 필수 + 자기 계좌만 집계 (cross-account 차단).
- **IPC / Web**: account-scoped command payload 의 `account_id` 빈 default 제거. `broker.reconcile` IPC 가 봇의 실제 account_id 와 mismatch 면 거부. Web `BotInfo` / `TradeItem` read schema 는 default 유지 (write 경로에서 검증), routes `getattr(..., "account_id", "")` runtime fallback 제거. all-account read 정책 자체는 #1218 로 분리.
- **CLI**: `treasury` / `rule` / `broker` (`status`/`balance`/`positions`/`reconcile`) `--account` required, helper 통과.
- **마커 호환 minimal patch**: `gateway/stop_order.py`, `gateway.py:_on_order_approved` (1 line), `broker/scheduler.py` (broker_account_id 도입 + 미일치 봇 skip), `gateway/stream_integration.py` (lifecycle account_id fallback + skip-on-empty), `main.py` (StreamIntegration / ReconcileScheduler 에 활성 KIS 계좌 account_id 명시 전달). multi-account broker pool / lifecycle pool / StopOrderManager 자체 변경은 SPLIT-3 (#1242) 영역으로 보존.
- **Spec**: `docs/specs/eventbus/eventbus.md` `_requires_account_id` 정책 + marker 섹션 ownership `(#1217 → #1240 SPLIT-1)`. `docs/specs/account/14-account-id-contract.md` 단일 표를 #1240/#1241/#1242 3개 표로 분할 + 후속 영역 #1218/#1219. `docs/specs/account/02-design-decisions.md` D-ACC-08 후속 적용 문장 #1240/#1241/#1242/#1218/#1219 로 교체.

## Plan Preflight & Branch Review

- Plan Preflight: 4 rounds + 1 hung round → orchestrator override `approve-implement`
- Codex 브랜치 리뷰: attempts 1–5 FAIL (총 8 finding 반영), attempt 6 PASS
- 자세한 수정 이력은 이슈 #1240 코멘트 참조

## Test Plan

- [x] `ruff check src tests`
- [x] `ruff format --check src tests`
- [x] `mypy src/ante` (기존 baseline 외 신규 에러 없음 — `account/service.py:711,748` 2건은 #1216/PR #1239 유입 선행 결함, 본 SPLIT 무관)
- [x] `pytest tests/unit -q` → **3578 passed, 2 skipped**
- [x] `pytest tests/unit/test_eventbus_account_events.py tests/unit/test_treasury.py tests/unit/test_treasury_sync.py tests/unit/test_trade.py tests/unit/test_daily_report.py tests/unit/test_reconcile_scheduler.py tests/unit/test_stream_integration.py tests/unit/test_cli_live.py tests/unit/test_cli_config_approval_broker_ipc.py tests/unit/ipc/test_registry.py -q` 통과

## Stop Conditions 준수

- SPLIT-2 영역 (`bot/`, `approval/`, `main.py` 핵심) 미진입
- SPLIT-3 영역 (multi-account broker pool, lifecycle pool, StopOrderManager 핵심, ResponseCache prefix invalidate, Stream connect/disconnect 이벤트 marker, KIS 종목 분배) 미진입
- #1218 영역 (read query 정책 / edge resolver) 미진입
- #1219 영역 (DB schema/index 변경) 미진입

🤖 Generated with [Claude Code](https://claude.com/claude-code)
