### PR TITLE
feat(account)!: split-3 APIGateway/Stream + multi-account lifecycle pool (#1242)

### DIFF
--- a/docs/specs/account/14-account-id-contract.md
+++ b/docs/specs/account/14-account-id-contract.md
@@ -177,17 +177,23 @@ Bot/Main + Approval payload validation. 본 SPLIT 에서 적용 완료
 
 #### #1242 (SPLIT-3) 적용 위치
 
-APIGateway/Stream + multi-account lifecycle. 본 SPLIT 머지 후 진행한다.
+APIGateway/Stream + multi-account lifecycle. 본 SPLIT 에서 적용 완료
+(`#1217 → #1242 SPLIT-3`). DB schema (#1219) 와 read query 정책 (#1218)
+은 별도 SPLIT 으로 분리되어 있으며, 동적 account add/remove 의 hot
+reconfig 는 1.0 범위 외이다.
 
 | 호출 위치 | 형태 | 비고 |
 |---|---|---|
-| `APIGateway.get_ohlcv/get_current_price/get_positions/get_account_balance/submit_order/cancel_order` | `account_id: str` (kw-only) + `require_account_id` | broker routing 진입점 |
-| `StreamIntegration.__init__` | `account_id: str` (kw-only) + `require_account_id` | account-scoped 캐시 키 |
-| `LiveDataProvider.__init__` | `account_id: str` (kw-only) + `require_account_id` | 봇 단위 인스턴스화 (StrategyContextFactory가 BotConfig.account_id로 생성) |
-| multi-account lifecycle pool (`s.stream_integrations: dict[str, StreamIntegration]`) | account 별 인스턴스 분리 | shutdown leak 방지 |
-| `StopOrderManager` P1 fix | account-scoped 흐름 정합 | 단순 marker 호환 patch는 본 SPLIT-1에서 선반영 |
-| `StreamConnected/DisconnectedEvent` account_id 전파 | 이벤트 페이로드 정렬 | account 격리 |
-| `ResponseCache` prefix invalidate | account 별 prefix 키 정리 | broker routing 호환 |
+| `APIGateway.get_ohlcv/get_current_price/get_positions/get_account_balance/submit_order/cancel_order` | `account_id: str` (kw-only) + `require_account_id` | broker routing 진입점 (#1217 → #1242 SPLIT-3) |
+| `StreamIntegration.__init__` | `account_id: str` (kw-only) + `require_account_id` | account-scoped 캐시 키 / stop_order trigger 격리 (#1217 → #1242 SPLIT-3) |
+| `LiveDataProvider.__init__` | `account_id: str` (kw-only) + `require_account_id`, 내부 `_gateway.get_*` 호출 시 `account_id=self._account_id` 전달 | 봇 단위 인스턴스화 (`context_factory` 가 `BotConfig.account_id` 로 생성, strategy 인터페이스는 closure 방식으로 무변경) (#1217 → #1242 SPLIT-3) |
+| `s.stream_integrations: dict[str, StreamIntegration]` | KIS 활성 계좌마다 인스턴스 등록, shutdown 에서 dict 순회 정리 | multi-account lifecycle pool, leak 방지 (#1217 → #1242 SPLIT-3) |
+| `s.reconcile_schedulers: dict[str, ReconcileScheduler]` | 활성 broker 가 있는 모든 계좌에 dispatch | multi-broker pool, 첫 broker 선택 가드 제거 (#1217 → #1242 SPLIT-3) |
+| `StopOrderManager.on_price_update` | `account_id: str` (kw-only) + `require_account_id`, `active_for_symbol` 에 `o.account_id == account_id` 필터 | cross-account trigger 차단 (#1217 → #1242 SPLIT-3) |
+| `StopOrder.__post_init__` | `require_account_id(self.account_id)` | trigger payload 정합 (#1217 → #1242 SPLIT-3) |
+| `StreamConnectedEvent` / `StreamDisconnectedEvent` | `_requires_account_id: ClassVar[bool] = True` + `account_id` 발행자 전달 | `KISStreamClient` per-account 인스턴스 정책 (#1217 → #1242 SPLIT-3) |
+| `ResponseCache.invalidate` | substring → prefix-exact (`acc-1` invalidate 가 `acc-12` 유지) | account-scoped 캐시 키 격리 (#1217 → #1242 SPLIT-3) |
+| `PaperExecutor` / `_resolve_price` 호출 사이트 | `account_id` 명시 전달 | gateway/stream_integration ctor required 정렬 (#1217 → #1242 SPLIT-3) |
 
 후속 영역은 다음 이슈로 이관:
 

--- a/docs/specs/eventbus/eventbus.md
+++ b/docs/specs/eventbus/eventbus.md
@@ -37,7 +37,7 @@ EventBus는 Ante의 **핵심 이벤트 발행/구독 인프라**로, 모듈 간 
 - UUID + timestamp로 이벤트 추적/디버깅 용이
 - dataclass는 외부 의존성 없음 (msgspec 등 도입은 성능 필요 시 전환)
 
-### Account-scoped 이벤트 marker (#1217 → #1240 SPLIT-1)
+### Account-scoped 이벤트 marker (#1217 → #1240 SPLIT-1, #1242 SPLIT-3)
 
 > 계약: [`docs/specs/account/14-account-id-contract.md`](../account/14-account-id-contract.md)
 
@@ -59,6 +59,10 @@ override하면, `Event.__post_init__` 이 다음을 수행한다:
   `BotStepCompletedEvent`, `BotRestartExhaustedEvent`
 - 계좌/잔고/리포트: `AccountSuspendedEvent`, `AccountActivatedEvent`,
   `BalanceSyncedEvent`, `DailyReportEvent`
+- 실시간 스트림 (#1242 SPLIT-3): `StreamConnectedEvent`,
+  `StreamDisconnectedEvent` — KIS multi-account 환경에서 각 계좌마다 별도의
+  ``KISStreamClient`` 인스턴스가 발행하므로 `account_id` 가 명시 전달되어야
+  한다 (한 계좌 disconnect 가 다른 계좌의 fallback 을 켜지 않도록 격리).
 
 **비대상 (system-wide event)**:
 - `SystemStartedEvent`, `SystemShutdownEvent`, `NotificationEvent`,
@@ -66,8 +70,8 @@ override하면, `Event.__post_init__` 이 다음을 수행한다:
   `ApprovalResolvedEvent`, `MemberRegisteredEvent`, `MemberSuspendedEvent`,
   `MemberReactivatedEvent`, `MemberRevokedEvent`, `MemberAuthFailedEvent`,
   `CircuitBreakerEvent`, `OrderCancelFailedEvent`, `StopOrderRegisteredEvent`,
-  `StopOrderTriggeredEvent`, `StopOrderExpiredEvent`, `StreamConnectedEvent`,
-  `StreamDisconnectedEvent`, `BotStopEvent`, `ExternalSignalEvent`,
+  `StopOrderTriggeredEvent`, `StopOrderExpiredEvent`,
+  `BotStopEvent`, `ExternalSignalEvent`,
   `PositionMismatchEvent`, `ReconcileEvent` (현재 ext spec 단계에서 marker 미적용)
 
 **구현 노트**:
@@ -315,7 +319,13 @@ Bot.on_signal()
 
 | 이벤트 타입 | 발행자 | 구독자 | 핵심 필드 |
 |------------|--------|--------|----------|
-| `StreamConnectedEvent` | KISStreamClient | — | `broker`, `url` |
-| `StreamDisconnectedEvent` | KISStreamClient | — | `broker`, `reason` |
+| `StreamConnectedEvent` | KISStreamClient | StreamIntegration | `account_id`, `broker`, `url` |
+| `StreamDisconnectedEvent` | KISStreamClient | StreamIntegration | `account_id`, `broker`, `reason` |
+
+> #1242 SPLIT-3: KIS multi-account 환경에서 각 계좌마다 별도의
+> `KISStreamClient` 인스턴스가 만들어지고, 발행자는 자신의 `account_id` 를
+> 명시 전달해야 한다. `StreamIntegration` 은 `event.account_id ==
+> self._account_id` 일 때만 fallback toggle 을 변경하므로, 한 계좌의
+> disconnect 가 다른 계좌의 stream 을 fallback 으로 끌고 가지 않는다.
 
 > 파일 구조: [docs/architecture/generated/project-structure.md](../../architecture/generated/project-structure.md) 참조

--- a/src/ante/bot/context_factory.py
+++ b/src/ante/bot/context_factory.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
         LiveOrderView,
         LiveTradeHistoryView,
     )
+    from ante.data.store import ParquetStore
+    from ante.gateway.gateway import APIGateway
     from ante.strategy.base import DataProvider
     from ante.trade.position import PositionHistory
     from ante.treasury.manager import TreasuryManager
@@ -28,6 +30,13 @@ class StrategyContextFactory:
     """Account.trading_mode에 따라 적절한 StrategyContext를 생성.
 
     main.py에서 생성되어 BotManager에 주입된다.
+
+    SPLIT-3 (#1242): live mode 에서는 봇별로 ``LiveDataProvider`` 인스턴스
+    를 새로 생성해 ``account_id`` 를 closure 방식으로 격리한다. strategy
+    인터페이스 (``StrategyContext.get_ohlcv``) 는 변경되지 않는다.
+    ``api_gateway`` / ``parquet_store`` 가 모두 주입되어 있을 때만 봇별
+    인스턴스를 만들고, 미주입이면 fallback ``data_provider`` 를 사용한다
+    (paper-only 환경 호환).
     """
 
     def __init__(
@@ -40,6 +49,8 @@ class StrategyContextFactory:
         live_trade_history: LiveTradeHistoryView | None = None,
         treasury_manager: TreasuryManager | None = None,
         position_history: PositionHistory | None = None,
+        api_gateway: APIGateway | None = None,
+        parquet_store: ParquetStore | None = None,
     ) -> None:
         self._data_provider = data_provider
         self._account_service = account_service
@@ -49,6 +60,8 @@ class StrategyContextFactory:
         self._live_trade_history = live_trade_history
         self._treasury_manager = treasury_manager
         self._position_history = position_history
+        self._api_gateway = api_gateway
+        self._parquet_store = parquet_store
 
     def create(self, config: BotConfig) -> StrategyContext:
         """BotConfig 기반으로 적절한 StrategyContext 생성.
@@ -97,16 +110,32 @@ class StrategyContextFactory:
         raise ValueError(msg)
 
     def _create_live_context(self, config: BotConfig) -> StrategyContext:
-        """Live 봇용 StrategyContext 생성."""
+        """Live 봇용 StrategyContext 생성.
+
+        SPLIT-3 (#1242): ``APIGateway`` 가 주입돼 있으면 봇별로 새
+        ``LiveDataProvider`` 인스턴스를 만들어 ``config.account_id`` 를
+        closure 로 binding 한다. 그 외 환경에서는 공유 ``self._data_provider``
+        를 그대로 사용한다.
+        """
         portfolio = self._get_live_portfolio(config)
 
         if self._live_order_view is None:
             msg = "Live 봇 생성에 필요한 Provider가 설정되지 않았습니다"
             raise ValueError(msg)
 
+        data_provider = self._data_provider
+        if self._api_gateway is not None:
+            from ante.gateway.data_provider import LiveDataProvider
+
+            data_provider = LiveDataProvider(
+                gateway=self._api_gateway,
+                parquet_store=self._parquet_store,
+                account_id=config.account_id,
+            )
+
         ctx = StrategyContext(
             bot_id=config.bot_id,
-            data_provider=self._data_provider,
+            data_provider=data_provider,
             portfolio=portfolio,
             order_view=self._live_order_view,
             trade_history=self._live_trade_history,
@@ -115,7 +144,12 @@ class StrategyContextFactory:
         return ctx
 
     def _create_paper_context(self, config: BotConfig) -> StrategyContext:
-        """Paper 봇용 StrategyContext 생성."""
+        """Paper 봇용 StrategyContext 생성.
+
+        SPLIT-3 (#1242): paper 봇이라도 OHLCV / price 조회는 봇의 account_id
+        로 APIGateway 를 호출해야 한다 (broker routing). live 와 동일하게
+        ``api_gateway`` 가 있으면 봇별 LiveDataProvider 를 생성한다.
+        """
         initial_balance = self._resolve_paper_balance(config)
         paper_portfolio = PaperPortfolioView(
             bot_id=config.bot_id,
@@ -127,9 +161,19 @@ class StrategyContextFactory:
         if self._paper_executor:
             self._paper_executor.register_bot(config.bot_id, paper_portfolio)
 
+        data_provider = self._data_provider
+        if self._api_gateway is not None:
+            from ante.gateway.data_provider import LiveDataProvider
+
+            data_provider = LiveDataProvider(
+                gateway=self._api_gateway,
+                parquet_store=self._parquet_store,
+                account_id=config.account_id,
+            )
+
         ctx = StrategyContext(
             bot_id=config.bot_id,
-            data_provider=self._data_provider,
+            data_provider=data_provider,
             portfolio=paper_portfolio,
             order_view=paper_order_view,
         )

--- a/src/ante/bot/providers/paper.py
+++ b/src/ante/bot/providers/paper.py
@@ -187,9 +187,13 @@ class PaperExecutor:
             fill_price = event.price
         else:
             # market 주문: 현재가 기반 + 슬리피지
+            # SPLIT-3 (#1242): APIGateway.get_current_price 가 account_id 를
+            # required 로 받으므로 OrderApprovedEvent.account_id 를 명시 전달.
             if self._gateway:
                 try:
-                    current_price = await self._gateway.get_current_price(symbol)
+                    current_price = await self._gateway.get_current_price(
+                        symbol, account_id=account_id
+                    )
                 except Exception:
                     logger.warning("현재가 조회 실패: %s, 기본가 사용", symbol)
                     current_price = event.price or 0.0

--- a/src/ante/broker/kis_stream.py
+++ b/src/ante/broker/kis_stream.py
@@ -53,6 +53,8 @@ class KISStreamClient:
         approval_key: str | None = None,
         eventbus: EventBus | None = None,
         ping_interval: float = DEFAULT_PING_INTERVAL,
+        *,
+        account_id: str = "",
     ) -> None:
         self._url = websocket_url
         self._app_key = app_key
@@ -60,6 +62,10 @@ class KISStreamClient:
         self._approval_key = approval_key
         self._eventbus = eventbus
         self._ping_interval = ping_interval
+        # SPLIT-3 (#1242): 각 KIS 계좌마다 별도 인스턴스를 만들고 account_id 를
+        # 명시 전달한다. StreamConnectedEvent / StreamDisconnectedEvent 발행 시
+        # 이 값을 그대로 실어 보낸다.
+        self._account_id = account_id
 
         self._ws: Any = None
         self._running = False
@@ -396,19 +402,35 @@ class KISStreamClient:
             self._ws = None
 
     async def _publish_connected(self) -> None:
-        """연결 이벤트 발행."""
+        """연결 이벤트 발행.
+
+        SPLIT-3 (#1242): ``StreamConnectedEvent`` 는 account-scoped marker 를
+        가진다. 발행 시 ``self._account_id`` 를 명시 전달한다.
+        """
         if self._eventbus:
             from ante.eventbus.events import StreamConnectedEvent
 
             await self._eventbus.publish(
-                StreamConnectedEvent(broker="kis", url=self._url)
+                StreamConnectedEvent(
+                    account_id=self._account_id,
+                    broker="kis",
+                    url=self._url,
+                )
             )
 
     async def _publish_disconnected(self, reason: str) -> None:
-        """연결 해제 이벤트 발행."""
+        """연결 해제 이벤트 발행.
+
+        SPLIT-3 (#1242): ``StreamDisconnectedEvent`` 는 account-scoped marker
+        를 가진다. 자세한 내용은 :meth:`_publish_connected` 참조.
+        """
         if self._eventbus:
             from ante.eventbus.events import StreamDisconnectedEvent
 
             await self._eventbus.publish(
-                StreamDisconnectedEvent(broker="kis", reason=reason)
+                StreamDisconnectedEvent(
+                    account_id=self._account_id,
+                    broker="kis",
+                    reason=reason,
+                )
             )

--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -623,16 +623,33 @@ class StopOrderExpiredEvent(Event):
 
 @dataclass(frozen=True)
 class StreamConnectedEvent(Event):
-    """KISStreamClient → EventBus: WebSocket 연결 성공."""
+    """KISStreamClient → EventBus: WebSocket 연결 성공.
 
+    SPLIT-3 (#1242): KIS multi-account 환경에서 각 계좌마다 별도의
+    ``KISStreamClient`` 인스턴스가 생성되며, 발행자는 자신의
+    ``account_id`` 를 명시 전달해야 한다. ``StreamIntegration`` 의
+    fallback toggle 이 다른 계좌 stream 의 disconnect 로 잘못 켜지지
+    않도록 한다.
+    """
+
+    _requires_account_id: ClassVar[bool] = True
+
+    account_id: str = ""
     broker: str = ""
     url: str = ""
 
 
 @dataclass(frozen=True)
 class StreamDisconnectedEvent(Event):
-    """KISStreamClient → EventBus: WebSocket 연결 해제."""
+    """KISStreamClient → EventBus: WebSocket 연결 해제.
 
+    SPLIT-3 (#1242): account-scoped marker 적용. 자세한 내용은
+    :class:`StreamConnectedEvent` 를 참조한다.
+    """
+
+    _requires_account_id: ClassVar[bool] = True
+
+    account_id: str = ""
     broker: str = ""
     reason: str = ""
 

--- a/src/ante/gateway/cache.py
+++ b/src/ante/gateway/cache.py
@@ -53,11 +53,19 @@ class ResponseCache:
         return f"{endpoint}?{param_str}"
 
     def invalidate(self, pattern: str = "") -> None:
-        """패턴에 매칭되는 캐시 무효화. 빈 문자열이면 전체 초기화."""
+        """``pattern`` 으로 시작하는 캐시 key 무효화. 빈 문자열이면 전체 초기화.
+
+        SPLIT-3 (#1242): substring match → prefix-exact match. multi-account
+        환경에서 ``"balance"`` 같은 substring 으로 다른 namespace 의 cache 가
+        함께 지워지는 cross-account leakage 를 차단한다. 호출 사이트
+        (``stream_integration._on_execution``,
+        ``gateway._on_order_filled``) 는 이미 ``f"{account_id}:..."`` 형태로
+        prefix 를 명시하고 있어 회귀 영향 없음.
+        """
         if not pattern:
             self._cache.clear()
         else:
-            keys_to_delete = [k for k in self._cache if pattern in k]
+            keys_to_delete = [k for k in self._cache if k.startswith(pattern)]
             for k in keys_to_delete:
                 del self._cache[k]
 

--- a/src/ante/gateway/data_provider.py
+++ b/src/ante/gateway/data_provider.py
@@ -32,6 +32,12 @@ class LiveDataProvider(DataProvider):
     과거 봉 데이터는 ParquetStore에서 읽고, 현재가는 APIGateway 캐시를 활용한다.
     ParquetStore에 데이터가 없으면 APIGateway 경유로 폴백한다.
 
+    SPLIT-3 (#1242): 봇별 인스턴스 (per-bot account binding) 로 사용된다.
+    ``account_id`` 는 kw-only required 이며, 내부 ``_gateway.get_*`` 호출 시
+    명시 전달된다. strategy 인터페이스 (``StrategyContext.get_ohlcv``) 는
+    변경되지 않으며, ``StrategyContextFactory.create()`` 가 봇별로 새
+    인스턴스를 생성해 closure 방식으로 account_id 를 격리한다.
+
     Note: DataProvider 인터페이스 준수를 위해 async def를 유지한다.
     """
 
@@ -39,9 +45,16 @@ class LiveDataProvider(DataProvider):
         self,
         gateway: APIGateway,
         parquet_store: ParquetStore | None = None,
+        *,
+        account_id: str,
     ) -> None:
+        from ante.account.scoping import require_account_id
+
+        require_account_id(account_id, context="live_data_provider.__init__")
+
         self._gateway = gateway
         self._store = parquet_store
+        self._account_id = account_id
 
     async def get_ohlcv(
         self,
@@ -77,13 +90,18 @@ class LiveDataProvider(DataProvider):
                 )
 
         records = await self._gateway.get_ohlcv(
-            symbol, timeframe=timeframe, limit=limit
+            symbol,
+            timeframe=timeframe,
+            limit=limit,
+            account_id=self._account_id,
         )
         return _dicts_to_ohlcv_df(records)
 
     async def get_current_price(self, symbol: str) -> float:
         """현재가 조회 (APIGateway 캐시 활용)."""
-        return await self._gateway.get_current_price(symbol)
+        return await self._gateway.get_current_price(
+            symbol, account_id=self._account_id
+        )
 
     async def get_indicator(
         self,

--- a/src/ante/gateway/gateway.py
+++ b/src/ante/gateway/gateway.py
@@ -103,13 +103,21 @@ class APIGateway:
         timeframe: str = "1d",
         limit: int = 100,
         exchange: str = "KRX",
-        account_id: str = "",
+        *,
+        account_id: str,
     ) -> list[dict[str, Any]]:
         """과거 봉 데이터 조회 (캐시 우선).
 
         OHLCV 캐시 키는 exchange 기반을 유지한다 (동일 거래소 데이터 공유).
         BrokerAdapter.get_ohlcv()가 미구현이면 빈 리스트를 반환한다.
+
+        SPLIT-3 (#1242): ``account_id`` 는 broker 라우팅과 rate limiter
+        bucket 결정에 사용되므로 fallback 금지 (``require_account_id``).
         """
+        from ante.account.scoping import require_account_id
+
+        require_account_id(account_id, context="gateway.get_ohlcv")
+
         cache_key = f"ohlcv:{exchange}:{symbol}:{timeframe}:{limit}"
         cached = self._cache.get(cache_key)
         if cached is not None:
@@ -128,9 +136,16 @@ class APIGateway:
         return data
 
     async def get_current_price(
-        self, symbol: str, account_id: str = "", exchange: str = "KRX"
+        self, symbol: str, *, account_id: str, exchange: str = "KRX"
     ) -> float:
-        """현재가 조회 (캐시 우선). account_id로 브로커 라우팅."""
+        """현재가 조회 (캐시 우선). account_id로 브로커 라우팅.
+
+        SPLIT-3 (#1242): ``account_id`` required (``require_account_id``).
+        """
+        from ante.account.scoping import require_account_id
+
+        require_account_id(account_id, context="gateway.get_current_price")
+
         cache_key = f"{account_id}:price:{symbol}"
         cached = self._cache.get(cache_key)
         if cached is not None:
@@ -143,8 +158,15 @@ class APIGateway:
         self._cache.set(cache_key, price, ttl=5)
         return price
 
-    async def get_positions(self, account_id: str = "") -> list[dict[str, Any]]:
-        """포지션 조회 (캐시 우선). account_id로 브로커 라우팅."""
+    async def get_positions(self, *, account_id: str) -> list[dict[str, Any]]:
+        """포지션 조회 (캐시 우선). account_id로 브로커 라우팅.
+
+        SPLIT-3 (#1242): ``account_id`` required (``require_account_id``).
+        """
+        from ante.account.scoping import require_account_id
+
+        require_account_id(account_id, context="gateway.get_positions")
+
         cache_key = f"{account_id}:positions"
         cached = self._cache.get(cache_key)
         if cached is not None:
@@ -157,8 +179,15 @@ class APIGateway:
         self._cache.set(cache_key, positions, ttl=30)
         return positions
 
-    async def get_account_balance(self, account_id: str = "") -> dict[str, float]:
-        """잔고 조회 (캐시 우선). account_id로 브로커 라우팅."""
+    async def get_account_balance(self, *, account_id: str) -> dict[str, float]:
+        """잔고 조회 (캐시 우선). account_id로 브로커 라우팅.
+
+        SPLIT-3 (#1242): ``account_id`` required (``require_account_id``).
+        """
+        from ante.account.scoping import require_account_id
+
+        require_account_id(account_id, context="gateway.get_account_balance")
+
         cache_key = f"{account_id}:balance"
         cached = self._cache.get(cache_key)
         if cached is not None:
@@ -179,9 +208,17 @@ class APIGateway:
         quantity: float,
         order_type: str = "market",
         price: float | None = None,
-        account_id: str = "",
+        *,
+        account_id: str,
     ) -> str:
-        """주문 제출. 캐시 없이 rate limit만 적용. account_id로 브로커 라우팅."""
+        """주문 제출. 캐시 없이 rate limit만 적용. account_id로 브로커 라우팅.
+
+        SPLIT-3 (#1242): ``account_id`` required (``require_account_id``).
+        """
+        from ante.account.scoping import require_account_id
+
+        require_account_id(account_id, context="gateway.submit_order")
+
         rate_limiter = self._get_rate_limiter(account_id)
         await rate_limiter.acquire()
         broker = await self._get_broker(account_id)
@@ -203,8 +240,15 @@ class APIGateway:
         )
         return broker_order_id
 
-    async def cancel_order(self, order_id: str, account_id: str = "") -> bool:
-        """주문 취소. account_id로 브로커 라우팅."""
+    async def cancel_order(self, order_id: str, *, account_id: str) -> bool:
+        """주문 취소. account_id로 브로커 라우팅.
+
+        SPLIT-3 (#1242): ``account_id`` required (``require_account_id``).
+        """
+        from ante.account.scoping import require_account_id
+
+        require_account_id(account_id, context="gateway.cancel_order")
+
         rate_limiter = self._get_rate_limiter(account_id)
         await rate_limiter.acquire()
         broker = await self._get_broker(account_id)

--- a/src/ante/gateway/stop_order.py
+++ b/src/ante/gateway/stop_order.py
@@ -27,7 +27,12 @@ EXTENDED_SESSION_END = (9, 0)  # 18:00 KST = 09:00 UTC
 
 @dataclass
 class StopOrder:
-    """스탑 주문 내부 표현."""
+    """스탑 주문 내부 표현.
+
+    SPLIT-3 (#1242): ``account_id`` 는 runtime 시점부터 ``require_account_id``
+    로 검증된다. multi-account 환경에서 같은 종목의 stop order 가 다른
+    계좌의 시세 tick 으로 잘못 trigger 되지 않도록 격리한다.
+    """
 
     stop_order_id: str
     order_id: str
@@ -45,6 +50,13 @@ class StopOrder:
     triggered: bool = False
     expired: bool = False
     exchange: str = "KRX"
+
+    def __post_init__(self) -> None:
+        from ante.account.scoping import require_account_id
+
+        # SPLIT-3 (#1242): account_id fallback 차단. invalid 값으로
+        # StopOrder 가 만들어지면 이후 OrderRequestEvent 발행 시 실패한다.
+        require_account_id(self.account_id, context="stop_order.register")
 
 
 class StopOrderManager:
@@ -167,19 +179,33 @@ class StopOrderManager:
         """봇의 활성 스탑 주문 목록."""
         return [o for o in self.active_orders if o.bot_id == bot_id]
 
-    async def on_price_update(self, symbol: str, price: float) -> None:
+    async def on_price_update(
+        self, symbol: str, price: float, *, account_id: str
+    ) -> None:
         """실시간 시세 수신 시 트리거 판단.
 
         매수 스탑: 현재가 >= stop_price → 트리거
         매도 스탑: 현재가 <= stop_price → 트리거
+
+        SPLIT-3 (#1242): ``account_id`` 는 호출자가 명시 전달해야 한다.
+        multi-account 환경에서는 각 계좌마다 별도의 ``KISStreamClient``
+        인스턴스를 가지므로, tick 이 들어온 stream 의 ``account_id`` 만
+        매칭되는 stop order 를 평가한다. 다른 계좌의 stop order 는 같은
+        symbol 이라도 무시된다.
         """
+        from ante.account.scoping import require_account_id
+
+        require_account_id(account_id, context="stop_order.on_price_update")
+
         if not self._running:
             return
 
         active_for_symbol = [
             o
             for o in self.active_orders
-            if o.symbol == symbol and self._is_in_session(o)
+            if o.symbol == symbol
+            and o.account_id == account_id
+            and self._is_in_session(o)
         ]
 
         for order in active_for_symbol:

--- a/src/ante/gateway/stream_integration.py
+++ b/src/ante/gateway/stream_integration.py
@@ -216,14 +216,33 @@ class StreamIntegration:
     # ── 스트림 연결/해제 이벤트 ──────────────────────
 
     async def _on_stream_connected(self, event: object) -> None:
-        """스트림 연결 성공 시 폴백 중지."""
+        """스트림 연결 성공 시 폴백 중지.
+
+        SPLIT-3 (#1242): multi-account StreamIntegration pool 에서 다른
+        계좌의 stream 이벤트로 자기 fallback 을 토글하지 않도록
+        ``event.account_id`` 가 ``self._account_id`` 와 일치할 때만 반응한다.
+        ``self._account_id`` 가 비어있는 (fallback test wiring) 경우는
+        호환을 위해 모든 이벤트를 받는다.
+        """
+        if self._account_id:
+            event_account_id = getattr(event, "account_id", "")
+            if event_account_id and event_account_id != self._account_id:
+                return
         await self._stop_fallback()
         logger.info("스트림 연결됨 — REST 폴링 폴백 중지")
 
     async def _on_stream_disconnected(self, event: object) -> None:
-        """스트림 연결 해제 시 REST 폴링 폴백 시작."""
+        """스트림 연결 해제 시 REST 폴링 폴백 시작.
+
+        SPLIT-3 (#1242): account-scoped 필터. 자세한 내용은
+        :meth:`_on_stream_connected` 참조.
+        """
         if not self._running:
             return
+        if self._account_id:
+            event_account_id = getattr(event, "account_id", "")
+            if event_account_id and event_account_id != self._account_id:
+                return
         await self._start_fallback()
         logger.warning("스트림 연결 해제 — REST 폴링 폴백 시작")
 

--- a/src/ante/gateway/stream_integration.py
+++ b/src/ante/gateway/stream_integration.py
@@ -45,13 +45,22 @@ class StreamIntegration:
         stream_client: KISStreamClient,
         cache: ResponseCache,
         eventbus: EventBus,
-        account_id: str = "",
+        *,
+        account_id: str,
         stop_order_manager: StopOrderManager | None = None,
         gateway: APIGateway | None = None,
         bot_manager: BotManager | None = None,
         fallback_poll_interval: float = DEFAULT_FALLBACK_POLL_INTERVAL,
         sync_interval: float = DEFAULT_SYNC_INTERVAL,
     ) -> None:
+        # SPLIT-3 (#1242): multi-account StreamIntegration pool 의 핵심 계약 —
+        # 인스턴스마다 단일 KIS 계좌 lifecycle 에 묶이며, fallback / 캐시
+        # 네임스페이스 / stop_order trigger 격리 모두 self._account_id 에 의존
+        # 한다. fallback 금지 (``require_account_id``).
+        from ante.account.scoping import require_account_id
+
+        require_account_id(account_id, context="stream_integration.__init__")
+
         self._stream = stream_client
         self._cache = cache
         self._eventbus = eventbus
@@ -221,13 +230,10 @@ class StreamIntegration:
         SPLIT-3 (#1242): multi-account StreamIntegration pool 에서 다른
         계좌의 stream 이벤트로 자기 fallback 을 토글하지 않도록
         ``event.account_id`` 가 ``self._account_id`` 와 일치할 때만 반응한다.
-        ``self._account_id`` 가 비어있는 (fallback test wiring) 경우는
-        호환을 위해 모든 이벤트를 받는다.
         """
-        if self._account_id:
-            event_account_id = getattr(event, "account_id", "")
-            if event_account_id and event_account_id != self._account_id:
-                return
+        event_account_id = getattr(event, "account_id", "")
+        if event_account_id != self._account_id:
+            return
         await self._stop_fallback()
         logger.info("스트림 연결됨 — REST 폴링 폴백 중지")
 
@@ -239,10 +245,9 @@ class StreamIntegration:
         """
         if not self._running:
             return
-        if self._account_id:
-            event_account_id = getattr(event, "account_id", "")
-            if event_account_id and event_account_id != self._account_id:
-                return
+        event_account_id = getattr(event, "account_id", "")
+        if event_account_id != self._account_id:
+            return
         await self._start_fallback()
         logger.warning("스트림 연결 해제 — REST 폴링 폴백 시작")
 

--- a/src/ante/gateway/stream_integration.py
+++ b/src/ante/gateway/stream_integration.py
@@ -150,9 +150,13 @@ class StreamIntegration:
         self._cache.set(cache_key, price, ttl=5)
 
         # StopOrderManager 시세 전달
+        # SPLIT-3 (#1242): 각 KISStreamClient 는 단일 계좌 lifecycle 에 묶인다.
+        # tick 의 account_id 는 stream 인스턴스의 ``self._account_id`` 와 동일하다.
         if self._stop_order_manager:
             try:
-                await self._stop_order_manager.on_price_update(symbol, price)
+                await self._stop_order_manager.on_price_update(
+                    symbol, price, account_id=self._account_id
+                )
             except Exception:
                 logger.exception("StopOrderManager 시세 전달 오류: %s", symbol)
 
@@ -270,7 +274,7 @@ class StreamIntegration:
 
                         if self._stop_order_manager:
                             await self._stop_order_manager.on_price_update(
-                                symbol, price
+                                symbol, price, account_id=self._account_id
                             )
                     except Exception:
                         logger.warning("REST 폴링 실패: %s", symbol, exc_info=True)

--- a/src/ante/gateway/stream_integration.py
+++ b/src/ante/gateway/stream_integration.py
@@ -347,19 +347,36 @@ class StreamIntegration:
             logger.debug("종목 구독 해제: %s", symbol)
 
     def _get_monitored_symbols(self) -> set[str]:
-        """모니터링 대상 종목 수집 (활성 봇 + StopOrderManager)."""
+        """모니터링 대상 종목 수집 (활성 봇 + StopOrderManager).
+
+        SPLIT-3 (#1242): multi-account StreamIntegration pool 에서 각 인스턴스
+        는 자신의 ``self._account_id`` 에 해당하는 봇만 선택한다. StopOrder
+        역시 같은 account_id 의 active orders 만 모니터링 종목에 포함시켜
+        다른 계좌의 KIS 40종목 한도를 잠식하지 않게 한다.
+        """
         symbols: set[str] = set()
 
-        # 활성 봇의 종목 (봇 info에서 추출 가능한 경우)
+        # 활성 봇의 종목: 봇 config 의 account_id 가 일치하는 것만.
         if self._bot_manager:
             for bot_info in self._bot_manager.list_bots():
-                if bot_info.get("status") == "running":
-                    bot = self._bot_manager.get_bot(bot_info["bot_id"])
-                    if bot and hasattr(bot, "monitored_symbols"):
-                        symbols.update(bot.monitored_symbols)
+                if bot_info.get("status") != "running":
+                    continue
+                bot = self._bot_manager.get_bot(bot_info["bot_id"])
+                if bot is None:
+                    continue
+                bot_account_id = ""
+                bot_config = getattr(bot, "config", None)
+                if bot_config is not None:
+                    bot_account_id = getattr(bot_config, "account_id", "")
+                if bot_account_id != self._account_id:
+                    continue
+                if hasattr(bot, "monitored_symbols"):
+                    symbols.update(bot.monitored_symbols)
 
-        # StopOrderManager의 모니터링 종목
+        # StopOrderManager의 모니터링 종목 — account_id 매칭만.
         if self._stop_order_manager:
-            symbols.update(self._stop_order_manager.monitored_symbols)
+            for order in self._stop_order_manager.active_orders:
+                if order.account_id == self._account_id:
+                    symbols.add(order.symbol)
 
         return symbols

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -161,7 +161,9 @@ class Services:
     # SPLIT-3 (#1242): multi-account StreamIntegration pool. KIS 활성 계좌마다
     # 하나의 인스턴스를 등록하고 shutdown 에서 dict 순회로 정리한다.
     stream_integrations: dict[str, Any] = field(default_factory=dict)
-    reconcile_scheduler: Any = None
+    # SPLIT-3 (#1242): multi-broker ReconcileScheduler pool. 활성 broker 가
+    # 있는 계좌마다 인스턴스를 만들어 dict 에 account_id 키로 등록한다.
+    reconcile_schedulers: dict[str, Any] = field(default_factory=dict)
     daily_report_scheduler: Any = None
     data_provider: Any = None
     parquet_store: Any = None
@@ -549,7 +551,13 @@ async def _init_gateway(s: Services) -> None:
 
 
 async def _init_reconcile_scheduler(s: Services) -> None:
-    """ReconcileScheduler 생성 및 시작."""
+    """ReconcileScheduler 생성 및 시작.
+
+    SPLIT-3 (#1242): 활성 broker 가 있는 모든 계좌에 대해 ReconcileScheduler
+    를 만들어 ``s.reconcile_schedulers`` dict 에 등록한다 (multi-broker pool).
+    이전 SPLIT-1 패턴은 첫 번째 broker 만 골라 다른 계좌의 봇 reconcile 을
+    건너뛰었다 (가드만 존재). 본 SPLIT 에서 dispatch 까지 분리한다.
+    """
     assert s.eventbus is not None
 
     from ante.broker.scheduler import ReconcileScheduler
@@ -571,37 +579,42 @@ async def _init_reconcile_scheduler(s: Services) -> None:
         eventbus=s.eventbus,
     )
 
-    # 첫 번째 연결된 Broker를 ReconcileScheduler에 사용
-    # SPLIT-1: 단일 broker만 주입되므로 해당 broker의 account_id로 scheduler를
-    # 바인딩해, 다른 계좌의 봇에 이 broker의 positions가 잘못 적용되지 않도록
-    # 가드한다. multi-broker pool은 SPLIT-3에서 도입한다.
-    broker = None
-    broker_account_id: str | None = None
     accounts = await s.account_service.list()
+    started: list[str] = []
     for account in accounts:
         try:
             broker = await s.account_service.get_broker(account.account_id)
-            broker_account_id = account.account_id
-            break
         except Exception:
             continue
 
-    if not broker or not broker_account_id:
+        scheduler = ReconcileScheduler(
+            reconciler=reconciler,
+            broker=broker,
+            bot_manager=s.bot_manager,
+            eventbus=s.eventbus,
+            broker_account_id=account.account_id,
+            interval_seconds=interval,
+        )
+        try:
+            await scheduler.start()
+        except Exception:
+            logger.warning(
+                "ReconcileScheduler 시작 실패: account=%s",
+                account.account_id,
+                exc_info=True,
+            )
+            continue
+        s.reconcile_schedulers[account.account_id] = scheduler
+        started.append(account.account_id)
+
+    if not started:
         logger.info("ReconcileScheduler 건너뜀 — 연결된 Broker 없음")
         return
 
-    s.reconcile_scheduler = ReconcileScheduler(
-        reconciler=reconciler,
-        broker=broker,
-        bot_manager=s.bot_manager,
-        eventbus=s.eventbus,
-        broker_account_id=broker_account_id,
-        interval_seconds=interval,
-    )
-    await s.reconcile_scheduler.start()
     logger.info(
-        "ReconcileScheduler 시작 완료 (account=%s, 주기: %d초)",
-        broker_account_id,
+        "ReconcileScheduler 시작 완료: 계좌 %d개 (%s, 주기: %d초)",
+        len(started),
+        ", ".join(started),
         interval,
     )
 
@@ -1613,9 +1626,18 @@ async def _shutdown(s: Services) -> None:
         await s.daily_report_scheduler.stop()
         logger.info("DailyReportScheduler 종료")
 
-    if s.reconcile_scheduler:
-        await s.reconcile_scheduler.stop()
-        logger.info("ReconcileScheduler 종료")
+    # SPLIT-3 (#1242): multi-broker ReconcileScheduler pool 정리
+    for sched_account_id, scheduler in list(s.reconcile_schedulers.items()):
+        try:
+            await scheduler.stop()
+            logger.info("ReconcileScheduler 종료: account=%s", sched_account_id)
+        except Exception:
+            logger.warning(
+                "ReconcileScheduler 종료 실패: account=%s",
+                sched_account_id,
+                exc_info=True,
+            )
+    s.reconcile_schedulers.clear()
 
     # 각 계좌의 Treasury sync 중지
     if s.treasury_manager:

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -680,6 +680,7 @@ async def _init_stream_integration(
         app_key=broker_config.get("app_key", ""),
         app_secret=broker_config.get("app_secret", ""),
         eventbus=s.eventbus,
+        account_id=account_id,
     )
 
     s.stream_integration = StreamIntegration(

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -158,7 +158,9 @@ class Services:
     live_order_view: Any = None
     strategy_snapshot: Any = None
     api_gateway: Any = None
-    stream_integration: Any = None
+    # SPLIT-3 (#1242): multi-account StreamIntegration pool. KIS 활성 계좌마다
+    # 하나의 인스턴스를 등록하고 shutdown 에서 dict 순회로 정리한다.
+    stream_integrations: dict[str, Any] = field(default_factory=dict)
     reconcile_scheduler: Any = None
     daily_report_scheduler: Any = None
     data_provider: Any = None
@@ -653,17 +655,24 @@ async def _init_stream_integration(
     broker_config: dict,
     stop_order_manager: Any,
     *,
-    account_id: str = "",
+    account_id: str,
 ) -> None:
     """KISStreamClient + StreamIntegration 초기화.
 
-    SPLIT-1 (#1240): ``OrderFilledEvent``는 strict ``_requires_account_id``
-    marker를 가진다. 본 SPLIT 범위에서는 multi-account StreamIntegration
-    pool화는 하지 않고(SPLIT-3 #1242 영역 보존), 단일 인스턴스에 활성
-    KIS 계좌의 ``account_id``를 보강하여 broker payload fallback 시에도
-    체결 이벤트가 정상 발행되도록 한다.
+    SPLIT-3 (#1242): KIS multi-account 환경에서 활성 계좌마다 별도의
+    StreamIntegration 인스턴스를 만들어 ``s.stream_integrations`` dict 에
+    ``account_id`` 키로 등록한다. 한 계좌 stream 의 disconnect 가 다른 계좌
+    의 fallback 을 토글하지 않도록 ``StreamConnectedEvent`` /
+    ``StreamDisconnectedEvent`` 의 account_id marker (C2) 와 함께 작동한다.
+
+    이전 SPLIT-1 패턴 (``s.stream_integration`` 단일 슬롯 덮어쓰기) 은 두 번째
+    KIS 계좌 등록 시 첫 인스턴스를 silently leak 시켰으므로 본 SPLIT 에서
+    수정한다.
     """
     assert s.eventbus is not None
+    from ante.account.scoping import require_account_id
+
+    require_account_id(account_id, context="main._init_stream_integration")
 
     from ante.broker.kis_stream import KISStreamClient
     from ante.gateway.stream_integration import StreamIntegration
@@ -683,7 +692,7 @@ async def _init_stream_integration(
         account_id=account_id,
     )
 
-    s.stream_integration = StreamIntegration(
+    integration = StreamIntegration(
         stream_client=stream_client,
         cache=s.api_gateway._cache,
         eventbus=s.eventbus,
@@ -694,13 +703,19 @@ async def _init_stream_integration(
     )
 
     try:
-        await s.stream_integration.start()
-        logger.info("StreamIntegration 시작 완료 (paper=%s)", is_paper)
+        await integration.start()
+        s.stream_integrations[account_id] = integration
+        logger.info(
+            "StreamIntegration 시작 완료 (account=%s, paper=%s)",
+            account_id,
+            is_paper,
+        )
     except Exception:
         logger.warning(
-            "StreamIntegration 시작 실패 — REST 전용 모드로 운영", exc_info=True
+            "StreamIntegration 시작 실패 — REST 전용 모드로 운영 (account=%s)",
+            account_id,
+            exc_info=True,
         )
-        s.stream_integration = None
 
 
 async def _sync_instruments(s: Services, accounts: list) -> None:
@@ -1619,9 +1634,18 @@ async def _shutdown(s: Services) -> None:
         await s.bot_manager.stop_all()
         logger.info("BotManager 종료 — 모든 봇 중지")
 
-    if s.stream_integration:
-        await s.stream_integration.stop()
-        logger.info("StreamIntegration 종료")
+    # SPLIT-3 (#1242): multi-account StreamIntegration pool 정리
+    for stream_account_id, integration in list(s.stream_integrations.items()):
+        try:
+            await integration.stop()
+            logger.info("StreamIntegration 종료: account=%s", stream_account_id)
+        except Exception:
+            logger.warning(
+                "StreamIntegration 종료 실패: account=%s",
+                stream_account_id,
+                exc_info=True,
+            )
+    s.stream_integrations.clear()
 
     if s.api_gateway:
         s.api_gateway.stop()

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -741,33 +741,73 @@ async def _sync_instruments(s: Services, accounts: list) -> None:
 
 
 def _init_context_factory(s: Services) -> None:
-    """StrategyContextFactory 완성 (Gateway 연결 이후)."""
+    """StrategyContextFactory 완성 (Gateway 연결 이후).
+
+    SPLIT-3 (#1242): ``LiveDataProvider`` 는 봇별로 ``StrategyContextFactory``
+    가 생성한다 (per-bot account binding). ``s.data_provider`` 는 API gateway
+    가 없는 (paper-only test 등) 환경의 fallback 으로 ``_NullDataProvider`` 를
+    설정한다 — 이 경우 strategy 의 OHLCV 호출은 빈 결과를 반환한다.
+    """
     from ante.bot import StrategyContextFactory
     from ante.bot.providers.live import LiveTradeHistoryView
-    from ante.gateway.data_provider import LiveDataProvider
 
     if s.api_gateway:
-        s.data_provider = LiveDataProvider(
-            gateway=s.api_gateway,
-            parquet_store=s.parquet_store,
-        )
         s.paper_executor._gateway = s.api_gateway
 
     live_trade_history = LiveTradeHistoryView(trade_recorder=s.trade_recorder)
 
-    if s.data_provider:
-        context_factory = StrategyContextFactory(
-            data_provider=s.data_provider,
-            account_service=s.account_service,
-            live_portfolio=s.live_portfolio,
-            live_order_view=s.live_order_view,
-            paper_executor=s.paper_executor,
-            live_trade_history=live_trade_history,
-            treasury_manager=s.treasury_manager,
-            position_history=s.position_history,
+    if not s.data_provider:
+        s.data_provider = _NullDataProvider()
+
+    context_factory = StrategyContextFactory(
+        data_provider=s.data_provider,
+        account_service=s.account_service,
+        live_portfolio=s.live_portfolio,
+        live_order_view=s.live_order_view,
+        paper_executor=s.paper_executor,
+        live_trade_history=live_trade_history,
+        treasury_manager=s.treasury_manager,
+        position_history=s.position_history,
+        api_gateway=s.api_gateway,
+        parquet_store=s.parquet_store,
+    )
+    s.bot_manager._context_factory = context_factory
+    logger.info("StrategyContextFactory 설정 완료")
+
+
+class _NullDataProvider:
+    """SPLIT-3 (#1242): API gateway 가 없는 환경에서 사용되는 no-op
+    DataProvider. strategy 인터페이스 호환을 위해 빈 결과를 반환한다."""
+
+    async def get_ohlcv(
+        self,
+        symbol: str,
+        timeframe: str = "1d",
+        limit: int = 100,
+    ) -> Any:
+        import polars as pl
+
+        return pl.DataFrame(
+            schema={
+                "timestamp": pl.Float64,
+                "open": pl.Float64,
+                "high": pl.Float64,
+                "low": pl.Float64,
+                "close": pl.Float64,
+                "volume": pl.Float64,
+            }
         )
-        s.bot_manager._context_factory = context_factory
-        logger.info("StrategyContextFactory 설정 완료")
+
+    async def get_current_price(self, symbol: str) -> float:
+        return 0.0
+
+    async def get_indicator(
+        self,
+        symbol: str,
+        indicator: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return {}
 
 
 async def _init_treasury_sync(s: Services, accounts: list) -> None:

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -787,9 +787,18 @@ async def _init_treasury_sync(s: Services, accounts: list) -> None:
                 price_resolver = None
                 if s.api_gateway:
                     gateway = s.api_gateway
+                    # SPLIT-3 (#1242): APIGateway.get_current_price 가
+                    # account_id 를 required 로 받으므로, 봇 계좌의
+                    # account_id 를 closure 에 명시 binding 한다 (late
+                    # binding 차단을 위해 default 인자 사용).
+                    bound_account_id = account.account_id
 
-                    async def _resolve_price(symbol: str) -> float:
-                        return await gateway.get_current_price(symbol)
+                    async def _resolve_price(
+                        symbol: str, _account_id: str = bound_account_id
+                    ) -> float:
+                        return await gateway.get_current_price(
+                            symbol, account_id=_account_id
+                        )
 
                     price_resolver = _resolve_price
 

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,0 +1,109 @@
+"""ResponseCache 단위 테스트.
+
+SPLIT-3 (#1242): ``invalidate(pattern)`` 은 substring match → prefix-exact
+match 로 변경된다. multi-account 환경에서 ``acc-1`` invalidate 가
+``acc-12`` 의 캐시까지 함께 지우는 cross-account leakage 를 차단한다.
+"""
+
+from __future__ import annotations
+
+from ante.gateway.cache import ResponseCache
+
+
+class TestInvalidateBasic:
+    """기본 invalidate 동작 검증."""
+
+    def test_invalidate_empty_pattern_clears_all(self) -> None:
+        """빈 pattern 은 전체 초기화 (기존 계약 유지)."""
+        cache = ResponseCache()
+        cache.set("acc-1:price:005930", 50000.0, ttl=5)
+        cache.set("acc-2:balance", {"total": 10000}, ttl=30)
+        cache.set("ohlcv:KRX:005930:1d:100", [], ttl=60)
+
+        cache.invalidate("")
+
+        assert cache.size == 0
+        assert cache.get("acc-1:price:005930") is None
+        assert cache.get("acc-2:balance") is None
+
+    def test_invalidate_exact_key_removes_only_that_key(self) -> None:
+        """완전 일치하는 key 만 제거."""
+        cache = ResponseCache()
+        cache.set("acc-1:balance", {"total": 1000}, ttl=30)
+        cache.set("acc-1:positions", [], ttl=30)
+
+        cache.invalidate("acc-1:balance")
+
+        assert cache.get("acc-1:balance") is None
+        assert cache.get("acc-1:positions") is not None
+
+
+class TestInvalidatePrefixIsolation:
+    """SPLIT-3 (#1242) prefix-exact invalidate 회귀."""
+
+    def test_prefix_isolation_acc1_does_not_invalidate_acc12(self) -> None:
+        """``acc-1`` invalidate 가 ``acc-12`` 의 캐시를 지우지 않는다."""
+        cache = ResponseCache()
+        cache.set("acc-1:balance", {"total": 1000}, ttl=30)
+        cache.set("acc-1:positions", [], ttl=30)
+        cache.set("acc-12:balance", {"total": 9999}, ttl=30)
+        cache.set("acc-12:positions", [{"sym": "X"}], ttl=30)
+
+        # acc-1 의 balance 만 invalidate
+        cache.invalidate("acc-1:balance")
+
+        # acc-1:balance 만 사라지고, acc-12:balance 는 유지된다.
+        assert cache.get("acc-1:balance") is None
+        assert cache.get("acc-12:balance") == {"total": 9999}
+        # acc-1:positions 도 유지 (다른 key)
+        assert cache.get("acc-1:positions") == []
+        # acc-12:positions 도 유지
+        assert cache.get("acc-12:positions") == [{"sym": "X"}]
+
+    def test_prefix_isolation_account_namespace(self) -> None:
+        """``acc-1:`` prefix invalidate 가 ``acc-12:*`` 를 지키는지 확인."""
+        cache = ResponseCache()
+        cache.set("acc-1:price:005930", 50000.0, ttl=5)
+        cache.set("acc-1:positions", [], ttl=30)
+        cache.set("acc-12:price:005930", 50000.0, ttl=5)
+        cache.set("acc-12:positions", [], ttl=30)
+
+        # acc-1: 로 시작하는 모든 key 삭제 (실제 호출 형태)
+        cache.invalidate("acc-1:")
+
+        # acc-1: prefix 캐시는 사라진다
+        assert cache.get("acc-1:price:005930") is None
+        assert cache.get("acc-1:positions") is None
+        # acc-12: prefix 캐시는 유지된다 (substring match 였다면 사라졌을 것)
+        assert cache.get("acc-12:price:005930") == 50000.0
+        assert cache.get("acc-12:positions") == []
+
+    def test_prefix_isolation_price_per_symbol(self) -> None:
+        """``acc-1:price:005930`` invalidate 가 다른 symbol 을 지키는지 확인."""
+        cache = ResponseCache()
+        cache.set("acc-1:price:005930", 50000.0, ttl=5)
+        cache.set("acc-1:price:000660", 100000.0, ttl=5)
+        cache.set("acc-1:price:005930-extended", 50100.0, ttl=5)
+
+        cache.invalidate("acc-1:price:005930")
+
+        # 정확히 prefix 매치되는 key 만 삭제 (005930-extended 도 prefix 매치)
+        assert cache.get("acc-1:price:005930") is None
+        # 005930-extended 는 "acc-1:price:005930" 으로 시작하므로 함께 사라진다.
+        assert cache.get("acc-1:price:005930-extended") is None
+        # 000660 은 prefix 가 다르므로 유지
+        assert cache.get("acc-1:price:000660") == 100000.0
+
+    def test_prefix_substring_no_longer_matches_middle(self) -> None:
+        """substring 위치에 있는 pattern 은 매칭되지 않는다 (회귀 차단).
+
+        예: ``balance`` 라는 substring 은 ``acc-1:balance`` 를 지우지 못한다.
+        """
+        cache = ResponseCache()
+        cache.set("acc-1:balance", {"total": 1000}, ttl=30)
+
+        # substring 매치 시도 — prefix-exact 정책에서는 매칭 실패
+        cache.invalidate("balance")
+
+        # acc-1:balance 는 살아있다 (prefix 가 "balance" 가 아님)
+        assert cache.get("acc-1:balance") == {"total": 1000}

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -538,10 +538,13 @@ class TestLiveDataProvider:
         mock_gateway = AsyncMock()
         mock_gateway.get_current_price = AsyncMock(return_value=50000.0)
 
-        provider = LiveDataProvider(mock_gateway)
+        provider = LiveDataProvider(mock_gateway, account_id="acc-test")
         price = await provider.get_current_price("005930")
         assert price == 50000.0
-        mock_gateway.get_current_price.assert_called_once_with("005930")
+        # SPLIT-3 (#1242): account_id 명시 전달
+        mock_gateway.get_current_price.assert_called_once_with(
+            "005930", account_id="acc-test"
+        )
 
     async def test_get_ohlcv_delegates_to_gateway_without_store(self):
         """ParquetStore 미주입 시 gateway.get_ohlcv()를 호출한다."""
@@ -549,12 +552,12 @@ class TestLiveDataProvider:
 
         mock_gateway = AsyncMock()
         mock_gateway.get_ohlcv = AsyncMock(return_value=[{"close": 50000.0}])
-        provider = LiveDataProvider(mock_gateway)
+        provider = LiveDataProvider(mock_gateway, account_id="acc-test")
         result = await provider.get_ohlcv("005930")
         assert isinstance(result, pl.DataFrame)
         assert result.to_dicts() == [{"close": 50000.0}]
         mock_gateway.get_ohlcv.assert_called_once_with(
-            "005930", timeframe="1d", limit=100
+            "005930", timeframe="1d", limit=100, account_id="acc-test"
         )
 
     async def test_get_ohlcv_reads_from_parquet_store(self):
@@ -575,7 +578,9 @@ class TestLiveDataProvider:
         )
         mock_store.read = MagicMock(return_value=df)
 
-        provider = LiveDataProvider(mock_gateway, parquet_store=mock_store)
+        provider = LiveDataProvider(
+            mock_gateway, parquet_store=mock_store, account_id="acc-test"
+        )
         result = await provider.get_ohlcv("005930", timeframe="1d", limit=50)
 
         assert isinstance(result, pl.DataFrame)
@@ -593,7 +598,9 @@ class TestLiveDataProvider:
         mock_store = MagicMock()
         mock_store.read = MagicMock(return_value=pl.DataFrame())
 
-        provider = LiveDataProvider(mock_gateway, parquet_store=mock_store)
+        provider = LiveDataProvider(
+            mock_gateway, parquet_store=mock_store, account_id="acc-test"
+        )
         result = await provider.get_ohlcv("005930")
 
         assert isinstance(result, pl.DataFrame)
@@ -610,7 +617,9 @@ class TestLiveDataProvider:
         mock_store = MagicMock()
         mock_store.read = MagicMock(side_effect=Exception("parquet read error"))
 
-        provider = LiveDataProvider(mock_gateway, parquet_store=mock_store)
+        provider = LiveDataProvider(
+            mock_gateway, parquet_store=mock_store, account_id="acc-test"
+        )
         result = await provider.get_ohlcv("005930")
 
         assert isinstance(result, pl.DataFrame)
@@ -621,6 +630,31 @@ class TestLiveDataProvider:
         """OHLCV 데이터 없을 때 빈 dict 반환."""
         mock_gateway = AsyncMock()
         mock_gateway.get_ohlcv = AsyncMock(return_value=[])
-        provider = LiveDataProvider(mock_gateway)
+        provider = LiveDataProvider(mock_gateway, account_id="acc-test")
         result = await provider.get_indicator("005930", "sma")
         assert result == {}
+
+    def test_construction_without_account_id_raises(self):
+        """SPLIT-3 (#1242): account_id 가 빈 문자열이면 InvalidAccountIdError."""
+        from ante.account.errors import InvalidAccountIdError
+
+        mock_gateway = AsyncMock()
+        with pytest.raises(InvalidAccountIdError):
+            LiveDataProvider(mock_gateway, account_id="")
+
+    async def test_per_bot_isolation_passes_distinct_account_ids(self):
+        """SPLIT-3 (#1242): 봇별로 인스턴스를 만들면 각자의 account_id 가
+        gateway 에 명시 전달되어 요청이 격리된다."""
+        mock_gateway = AsyncMock()
+        mock_gateway.get_current_price = AsyncMock(return_value=50000.0)
+
+        provider_a = LiveDataProvider(mock_gateway, account_id="acc-a")
+        provider_b = LiveDataProvider(mock_gateway, account_id="acc-b")
+
+        await provider_a.get_current_price("005930")
+        await provider_b.get_current_price("005930")
+
+        calls = mock_gateway.get_current_price.call_args_list
+        assert len(calls) == 2
+        assert calls[0].kwargs["account_id"] == "acc-a"
+        assert calls[1].kwargs["account_id"] == "acc-b"

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -304,6 +304,49 @@ class TestAPIGateway:
         await gateway.get_current_price("005930", account_id="acc-001")
         account_service.get_broker.assert_called_with("acc-001")
 
+    async def test_get_current_price_rejects_empty_account_id(self, gateway):
+        """SPLIT-3 (#1242): 빈 account_id 는 InvalidAccountIdError."""
+        from ante.account.errors import InvalidAccountIdError
+
+        with pytest.raises(InvalidAccountIdError):
+            await gateway.get_current_price("005930", account_id="")
+
+    async def test_get_ohlcv_rejects_empty_account_id(self, gateway):
+        from ante.account.errors import InvalidAccountIdError
+
+        with pytest.raises(InvalidAccountIdError):
+            await gateway.get_ohlcv("005930", account_id="")
+
+    async def test_get_positions_rejects_empty_account_id(self, gateway):
+        from ante.account.errors import InvalidAccountIdError
+
+        with pytest.raises(InvalidAccountIdError):
+            await gateway.get_positions(account_id="")
+
+    async def test_get_account_balance_rejects_empty_account_id(self, gateway):
+        from ante.account.errors import InvalidAccountIdError
+
+        with pytest.raises(InvalidAccountIdError):
+            await gateway.get_account_balance(account_id="")
+
+    async def test_submit_order_rejects_empty_account_id(self, gateway):
+        from ante.account.errors import InvalidAccountIdError
+
+        with pytest.raises(InvalidAccountIdError):
+            await gateway.submit_order(
+                bot_id="bot1",
+                symbol="005930",
+                side="buy",
+                quantity=10,
+                account_id="",
+            )
+
+    async def test_cancel_order_rejects_empty_account_id(self, gateway):
+        from ante.account.errors import InvalidAccountIdError
+
+        with pytest.raises(InvalidAccountIdError):
+            await gateway.cancel_order("ORD001", account_id="")
+
 
 # ── APIGateway EventBus 통합 ──────────────────────
 

--- a/tests/unit/test_indicators.py
+++ b/tests/unit/test_indicators.py
@@ -389,6 +389,8 @@ async def test_live_data_provider_get_indicator():
             symbol: str,
             timeframe: str = "1d",
             limit: int = 100,
+            *,
+            account_id: str = "",
         ) -> list[dict[str, float]]:
             rng = np.random.default_rng(42)
             n = limit
@@ -408,12 +410,17 @@ async def test_live_data_provider_get_indicator():
                 for i in range(n)
             ]
 
-        async def get_current_price(self, symbol: str) -> float:
+        async def get_current_price(
+            self, symbol: str, *, account_id: str = ""
+        ) -> float:
             return 50000.0
 
     from ante.gateway.data_provider import LiveDataProvider
 
-    provider = LiveDataProvider(gateway=FakeGateway())  # type: ignore[arg-type]
+    provider = LiveDataProvider(
+        gateway=FakeGateway(),  # type: ignore[arg-type]
+        account_id="acc-test",
+    )
     result = await provider.get_indicator("005930", "rsi", {"length": 14})
     assert "rsi" in result
     assert isinstance(result["rsi"], np.ndarray)
@@ -428,15 +435,22 @@ async def test_live_data_provider_get_indicator_empty_ohlcv():
             symbol: str,
             timeframe: str = "1d",
             limit: int = 100,
+            *,
+            account_id: str = "",
         ) -> list:
             return []
 
-        async def get_current_price(self, symbol: str) -> float:
+        async def get_current_price(
+            self, symbol: str, *, account_id: str = ""
+        ) -> float:
             return 50000.0
 
     from ante.gateway.data_provider import LiveDataProvider
 
-    provider = LiveDataProvider(gateway=FakeGateway())  # type: ignore[arg-type]
+    provider = LiveDataProvider(
+        gateway=FakeGateway(),  # type: ignore[arg-type]
+        account_id="acc-test",
+    )
     result = await provider.get_indicator("005930", "sma")
     assert result == {}
 
@@ -453,15 +467,22 @@ async def test_live_data_provider_get_ohlcv():
             symbol: str,
             timeframe: str = "1d",
             limit: int = 100,
+            *,
+            account_id: str = "",
         ) -> list:
             return expected_data
 
-        async def get_current_price(self, symbol: str) -> float:
+        async def get_current_price(
+            self, symbol: str, *, account_id: str = ""
+        ) -> float:
             return 50000.0
 
     from ante.gateway.data_provider import LiveDataProvider
 
-    provider = LiveDataProvider(gateway=FakeGateway())  # type: ignore[arg-type]
+    provider = LiveDataProvider(
+        gateway=FakeGateway(),  # type: ignore[arg-type]
+        account_id="acc-test",
+    )
     result = await provider.get_ohlcv("005930")
     assert isinstance(result, pl.DataFrame)
     assert result.to_dicts() == expected_data

--- a/tests/unit/test_kis_stream.py
+++ b/tests/unit/test_kis_stream.py
@@ -232,3 +232,69 @@ class TestDisconnect:
         await stream_client.disconnect()
         # clean disconnect에서는 disconnected 이벤트를 발행하지 않음
         # (connection_lost일 때만 발행)
+
+
+class TestPerAccountEventPublication:
+    """SPLIT-3 (#1242): KISStreamClient 가 자신의 ``account_id`` 를 이벤트에
+    명시 전달하는지 검증한다. multi-account 환경에서 다른 stream 의 disconnect
+    가 자기 fallback 을 토글하지 않도록 격리 게이트가 의존하는 핵심 계약이다.
+    """
+
+    async def test_publish_connected_carries_account_id(
+        self, eventbus: MagicMock
+    ) -> None:
+        """``_publish_connected`` 가 account_id 를 실은 StreamConnectedEvent
+        를 발행한다."""
+        from ante.eventbus.events import StreamConnectedEvent
+
+        client = KISStreamClient(
+            websocket_url="ws://ops.koreainvestment.com:31000",
+            app_key="key",
+            app_secret="secret",
+            eventbus=eventbus,
+            account_id="acc-alpha",
+        )
+        await client._publish_connected()
+
+        eventbus.publish.assert_called_once()
+        event = eventbus.publish.call_args[0][0]
+        assert isinstance(event, StreamConnectedEvent)
+        assert event.account_id == "acc-alpha"
+        assert event.broker == "kis"
+
+    async def test_publish_disconnected_carries_account_id(
+        self, eventbus: MagicMock
+    ) -> None:
+        """``_publish_disconnected`` 가 account_id 를 실은
+        StreamDisconnectedEvent 를 발행한다."""
+        from ante.eventbus.events import StreamDisconnectedEvent
+
+        client = KISStreamClient(
+            websocket_url="ws://ops.koreainvestment.com:31000",
+            app_key="key",
+            app_secret="secret",
+            eventbus=eventbus,
+            account_id="acc-beta",
+        )
+        await client._publish_disconnected("connection_lost")
+
+        eventbus.publish.assert_called_once()
+        event = eventbus.publish.call_args[0][0]
+        assert isinstance(event, StreamDisconnectedEvent)
+        assert event.account_id == "acc-beta"
+        assert event.reason == "connection_lost"
+
+    async def test_publish_without_account_id_raises(self, eventbus: MagicMock) -> None:
+        """account_id 가 빈 문자열이면 strict marker 에 의해
+        InvalidAccountIdError 가 raise 된다 (이벤트 발행 차단)."""
+        from ante.account.errors import InvalidAccountIdError
+
+        client = KISStreamClient(
+            websocket_url="ws://ops.koreainvestment.com:31000",
+            app_key="key",
+            app_secret="secret",
+            eventbus=eventbus,
+            # account_id 미설정 (default "")
+        )
+        with pytest.raises(InvalidAccountIdError):
+            await client._publish_connected()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -264,6 +264,78 @@ async def test_services_dataclass_no_single_broker_treasury_rule(
     assert s.account_service is None
 
 
+async def test_services_stream_integrations_pool_default_empty_dict() -> None:
+    """SPLIT-3 (#1242): Services.stream_integrations 는 dict 기본값을 가지며,
+    단일 슬롯 stream_integration 필드는 제거되었다.
+    """
+    from ante.main import Services
+
+    s = Services()
+    assert not hasattr(s, "stream_integration")
+    assert hasattr(s, "stream_integrations")
+    assert isinstance(s.stream_integrations, dict)
+    assert s.stream_integrations == {}
+
+
+async def test_init_stream_integration_registers_per_account_in_pool(
+    tmp_path: Path,
+) -> None:
+    """SPLIT-3 (#1242): _init_stream_integration 이 두 개 KIS 계좌에 대해
+    각각 인스턴스를 만들어 stream_integrations dict 에 account_id 키로
+    등록한다 (이전 단일 슬롯 덮어쓰기 버그 회귀 차단).
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from ante.gateway.cache import ResponseCache
+    from ante.main import Services, _init_stream_integration
+
+    eventbus = EventBus(history_size=100)
+    s = Services(eventbus=eventbus)
+
+    # api_gateway 는 cache 만 노출하면 충분 (StreamIntegration 가 cache 참조).
+    s.api_gateway = MagicMock()
+    s.api_gateway._cache = ResponseCache()
+    s.bot_manager = MagicMock()
+    s.bot_manager.list_bots.return_value = []
+
+    stop_order_manager = MagicMock()
+    stop_order_manager.active_orders = []
+
+    # KISStreamClient.connect 를 mock 으로 가로채 실제 WebSocket 연결을 회피
+    from unittest.mock import patch
+
+    with (
+        patch("ante.broker.kis_stream.KISStreamClient.connect", new_callable=AsyncMock),
+        patch(
+            "ante.broker.kis_stream.KISStreamClient.subscribe_execution",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "ante.broker.kis_stream.KISStreamClient.disconnect", new_callable=AsyncMock
+        ),
+    ):
+        for account_id in ("acc-a", "acc-b"):
+            await _init_stream_integration(
+                s,
+                broker_config={
+                    "is_paper": True,
+                    "app_key": "k",
+                    "app_secret": "s",
+                },
+                stop_order_manager=stop_order_manager,
+                account_id=account_id,
+            )
+
+        try:
+            assert set(s.stream_integrations.keys()) == {"acc-a", "acc-b"}
+            # 각 인스턴스의 account_id 가 정확히 매핑되어야 한다
+            assert s.stream_integrations["acc-a"]._account_id == "acc-a"
+            assert s.stream_integrations["acc-b"]._account_id == "acc-b"
+        finally:
+            for integration in s.stream_integrations.values():
+                await integration.stop()
+
+
 async def test_init_account_creates_test_account(tmp_path: Path) -> None:
     """계좌가 없을 때 _init_account가 테스트 계좌를 자동 생성한다."""
     from ante.main import Services, _init_account

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -277,6 +277,80 @@ async def test_services_stream_integrations_pool_default_empty_dict() -> None:
     assert s.stream_integrations == {}
 
 
+async def test_services_reconcile_schedulers_pool_default_empty_dict() -> None:
+    """SPLIT-3 (#1242): Services.reconcile_schedulers 는 dict 기본값을 가지며,
+    단일 슬롯 reconcile_scheduler 필드는 제거되었다.
+    """
+    from ante.main import Services
+
+    s = Services()
+    assert not hasattr(s, "reconcile_scheduler")
+    assert hasattr(s, "reconcile_schedulers")
+    assert isinstance(s.reconcile_schedulers, dict)
+    assert s.reconcile_schedulers == {}
+
+
+async def test_init_reconcile_scheduler_registers_per_broker_in_pool(
+    tmp_path: Path,
+) -> None:
+    """SPLIT-3 (#1242): _init_reconcile_scheduler 가 활성 broker 가 있는 모든
+    계좌에 대해 별도의 ReconcileScheduler 인스턴스를 만들어 dict 에 등록한다.
+    이전 SPLIT-1 패턴은 첫 번째 broker 만 사용했으므로 본 SPLIT 에서 회귀
+    차단한다.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from ante.main import Services, _init_reconcile_scheduler
+
+    eventbus = EventBus(history_size=100)
+
+    # account_service: 두 계좌 모두 broker 연결 가능
+    account_service = MagicMock()
+    accounts_data = [
+        MagicMock(account_id="acc-a"),
+        MagicMock(account_id="acc-b"),
+    ]
+    account_service.list = AsyncMock(return_value=accounts_data)
+
+    broker_a = MagicMock()
+    broker_b = MagicMock()
+    brokers = {"acc-a": broker_a, "acc-b": broker_b}
+    account_service.get_broker = AsyncMock(side_effect=lambda aid: brokers[aid])
+
+    config = MagicMock()
+    config.get = MagicMock(return_value={"enabled": True, "interval_seconds": 1800})
+
+    bot_manager = MagicMock()
+    bot_manager.list_bots.return_value = []
+
+    trade_service = MagicMock()
+
+    s = Services(
+        eventbus=eventbus,
+        account_service=account_service,
+        config=config,
+        bot_manager=bot_manager,
+        trade_service=trade_service,
+    )
+
+    # ReconcileScheduler.start 의 1회성 run_once 가 broker.get_account_positions 를
+    # 호출하므로 mock 으로 가로챈다.
+    broker_a.get_account_positions = AsyncMock(return_value=[])
+    broker_b.get_account_positions = AsyncMock(return_value=[])
+
+    await _init_reconcile_scheduler(s)
+
+    try:
+        assert set(s.reconcile_schedulers.keys()) == {"acc-a", "acc-b"}
+        assert s.reconcile_schedulers["acc-a"]._broker is broker_a
+        assert s.reconcile_schedulers["acc-b"]._broker is broker_b
+        assert s.reconcile_schedulers["acc-a"]._broker_account_id == "acc-a"
+        assert s.reconcile_schedulers["acc-b"]._broker_account_id == "acc-b"
+    finally:
+        for scheduler in s.reconcile_schedulers.values():
+            await scheduler.stop()
+
+
 async def test_init_stream_integration_registers_per_account_in_pool(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_stop_order.py
+++ b/tests/unit/test_stop_order.py
@@ -106,7 +106,7 @@ class TestTrigger:
         eventbus.publish.reset_mock()
 
         # 가격이 stop_price 이하로 하락
-        await manager.on_price_update("005930", 48500.0)
+        await manager.on_price_update("005930", 48500.0, account_id="acc-test")
 
         # StopOrderTriggeredEvent + OrderRequestEvent 발행
         assert eventbus.publish.call_count == 2
@@ -141,7 +141,7 @@ class TestTrigger:
         )
 
         eventbus.publish.reset_mock()
-        await manager.on_price_update("005930", 51500.0)
+        await manager.on_price_update("005930", 51500.0, account_id="acc-test")
 
         assert eventbus.publish.call_count == 2
         triggered_event = eventbus.publish.call_args_list[0][0][0]
@@ -168,7 +168,7 @@ class TestTrigger:
         )
 
         eventbus.publish.reset_mock()
-        await manager.on_price_update("005930", 51000.0)
+        await manager.on_price_update("005930", 51000.0, account_id="acc-test")
 
         order_event = eventbus.publish.call_args_list[1][0][0]
         assert isinstance(order_event, OrderRequestEvent)
@@ -194,7 +194,9 @@ class TestTrigger:
         )
 
         eventbus.publish.reset_mock()
-        await manager.on_price_update("005930", 50000.0)  # > stop_price
+        await manager.on_price_update(
+            "005930", 50000.0, account_id="acc-test"
+        )  # > stop_price
 
         # 트리거 안 됨
         assert eventbus.publish.call_count == 0
@@ -219,7 +221,7 @@ class TestTrigger:
         )
 
         eventbus.publish.reset_mock()
-        await manager.on_price_update("000660", 48000.0)
+        await manager.on_price_update("000660", 48000.0, account_id="acc-test")
 
         assert eventbus.publish.call_count == 0
 
@@ -240,7 +242,7 @@ class TestTrigger:
         )
 
         eventbus.publish.reset_mock()
-        await manager.on_price_update("005930", 48000.0)
+        await manager.on_price_update("005930", 48000.0, account_id="acc-test")
 
         # running=False이므로 무시
         assert eventbus.publish.call_count == 0
@@ -362,3 +364,147 @@ class TestSignalTradingSession:
             trading_session="extended",
         )
         assert sig.trading_session == "extended"
+
+
+class TestCrossAccountIsolation:
+    """SPLIT-3 (#1242): StopOrderManager는 같은 종목이라도 account_id 가
+    다른 stop order 끼리 trigger를 격리한다.
+
+    multi-account 환경에서는 account마다 별도의 KISStreamClient
+    인스턴스가 ``account_id`` 명시 호출을 통해 ``on_price_update`` 를
+    호출하므로, 시세가 들어온 account 의 stop order만 평가되어야 한다.
+    """
+
+    @patch.object(StopOrderManager, "_is_in_session", return_value=True)
+    async def test_register_requires_valid_account_id(
+        self, _mock_session: MagicMock, manager: StopOrderManager
+    ) -> None:
+        """register 시 account_id 가 invalid 면 InvalidAccountIdError."""
+        from ante.account.errors import InvalidAccountIdError
+
+        with pytest.raises(InvalidAccountIdError):
+            await manager.register(
+                order_id="ord-bad",
+                bot_id="bot-bad",
+                strategy_id="stg-bad",
+                symbol="005930",
+                side="sell",
+                quantity=10.0,
+                order_type="stop",
+                stop_price=49000.0,
+                account_id="",
+            )
+
+    @patch.object(StopOrderManager, "_is_in_session", return_value=True)
+    async def test_on_price_update_requires_account_id(
+        self, _mock_session: MagicMock, manager: StopOrderManager
+    ) -> None:
+        """on_price_update 호출 시 account_id 가 invalid 면 거부."""
+        from ante.account.errors import InvalidAccountIdError
+
+        manager.start()
+
+        with pytest.raises(InvalidAccountIdError):
+            await manager.on_price_update("005930", 50000.0, account_id="")
+
+    @patch.object(StopOrderManager, "_is_in_session", return_value=True)
+    async def test_cross_account_isolation_only_triggers_matching_account(
+        self,
+        _mock_session: MagicMock,
+        manager: StopOrderManager,
+        eventbus: MagicMock,
+    ) -> None:
+        """동일 symbol 이라도 account_id 가 다르면 trigger 되지 않는다."""
+        manager.start()
+
+        # acc-1 의 stop sell 주문 등록
+        await manager.register(
+            order_id="ord-acc1",
+            bot_id="bot-acc1",
+            strategy_id="stg-1",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop",
+            stop_price=49000.0,
+            account_id="acc-1",
+        )
+        # acc-2 의 stop sell 주문 등록 (same symbol, same trigger condition)
+        await manager.register(
+            order_id="ord-acc2",
+            bot_id="bot-acc2",
+            strategy_id="stg-2",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop",
+            stop_price=49000.0,
+            account_id="acc-2",
+        )
+
+        eventbus.publish.reset_mock()
+
+        # acc-1 의 stream 에서 가격이 들어옴 → acc-1 주문만 trigger 되어야 한다
+        await manager.on_price_update("005930", 48500.0, account_id="acc-1")
+
+        # 1 trigger × 2 events (StopOrderTriggeredEvent + OrderRequestEvent)
+        assert eventbus.publish.call_count == 2
+
+        triggered_event = eventbus.publish.call_args_list[0][0][0]
+        order_event = eventbus.publish.call_args_list[1][0][0]
+        assert triggered_event.stop_order_id  # 첫 이벤트 stop order id 존재
+        # OrderRequestEvent 는 acc-1 의 account_id 를 들고 발행되어야 한다.
+        assert order_event.account_id == "acc-1"
+        assert order_event.bot_id == "bot-acc1"
+
+        # acc-2 의 주문은 여전히 active 로 남아 있다.
+        active_for_acc2 = [o for o in manager.active_orders if o.account_id == "acc-2"]
+        assert len(active_for_acc2) == 1
+
+    @patch.object(StopOrderManager, "_is_in_session", return_value=True)
+    async def test_cross_account_each_account_triggers_own_orders(
+        self,
+        _mock_session: MagicMock,
+        manager: StopOrderManager,
+        eventbus: MagicMock,
+    ) -> None:
+        """각 계좌 stream 에서 가격이 들어오면 각자의 주문만 trigger 된다."""
+        manager.start()
+
+        await manager.register(
+            order_id="ord-acc1",
+            bot_id="bot-acc1",
+            strategy_id="stg-1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            order_type="stop",
+            stop_price=51000.0,
+            account_id="acc-1",
+        )
+        await manager.register(
+            order_id="ord-acc2",
+            bot_id="bot-acc2",
+            strategy_id="stg-2",
+            symbol="005930",
+            side="buy",
+            quantity=5.0,
+            order_type="stop",
+            stop_price=51000.0,
+            account_id="acc-2",
+        )
+
+        # acc-1 stream 가격
+        await manager.on_price_update("005930", 51500.0, account_id="acc-1")
+        # acc-2 stream 가격
+        await manager.on_price_update("005930", 51500.0, account_id="acc-2")
+
+        # 두 trigger × 2 events 씩 = 4 events
+        order_events = [
+            call.args[0]
+            for call in eventbus.publish.call_args_list
+            if call.args and type(call.args[0]).__name__ == "OrderRequestEvent"
+        ]
+        assert len(order_events) == 2
+        accounts = sorted(e.account_id for e in order_events)
+        assert accounts == ["acc-1", "acc-2"]

--- a/tests/unit/test_stream_integration.py
+++ b/tests/unit/test_stream_integration.py
@@ -364,7 +364,11 @@ async def test_subscription_sync_adds_stop_order_symbols(
     stop_order_manager: StopOrderManager,
     eventbus: EventBus,
 ) -> None:
-    """StopOrderManager 종목이 스트림에 구독된다."""
+    """StopOrderManager 종목이 스트림에 구독된다.
+
+    SPLIT-3 (#1242): integration._account_id="acc-001" 와 동일한 account_id
+    의 stop order 만 모니터링 대상에 포함된다.
+    """
     await stop_order_manager.register(
         order_id="ord-1",
         bot_id="bot-1",
@@ -374,7 +378,7 @@ async def test_subscription_sync_adds_stop_order_symbols(
         quantity=5.0,
         order_type="stop",
         stop_price=100000.0,
-        account_id="acc-test",
+        account_id="acc-001",
     )
 
     await integration.start()
@@ -394,17 +398,22 @@ async def test_subscription_sync_on_bot_event(
     eventbus: EventBus,
     bot_manager_mock: MagicMock,
 ) -> None:
-    """봇 시작/종료 이벤트 시 종목 구독이 즉시 동기화된다."""
-    # 봇이 모니터링 종목을 가지도록 설정
+    """봇 시작/종료 이벤트 시 종목 구독이 즉시 동기화된다.
+
+    SPLIT-3 (#1242): bot.config.account_id 가 integration._account_id 와
+    동일한 봇만 모니터링 대상에 포함된다.
+    """
+    # 봇이 모니터링 종목을 가지도록 설정 — integration._account_id="acc-001" 와 동일
     mock_bot = MagicMock()
     mock_bot.monitored_symbols = {"005930", "035720"}
+    mock_bot.config.account_id = "acc-001"
     bot_manager_mock.list_bots.return_value = [{"bot_id": "bot-1", "status": "running"}]
     bot_manager_mock.get_bot.return_value = mock_bot
 
     await integration.start()
     try:
         # 봇 시작 이벤트 발행
-        await eventbus.publish(BotStartedEvent(bot_id="bot-1", account_id="acc-test"))
+        await eventbus.publish(BotStartedEvent(bot_id="bot-1", account_id="acc-001"))
         await asyncio.sleep(0.05)
 
         assert "005930" in stream_client.subscribed_symbols
@@ -424,12 +433,13 @@ async def test_subscription_sync_removes_symbols(
     # 먼저 봇이 있는 상태
     mock_bot = MagicMock()
     mock_bot.monitored_symbols = {"005930"}
+    mock_bot.config.account_id = "acc-001"
     bot_manager_mock.list_bots.return_value = [{"bot_id": "bot-1", "status": "running"}]
     bot_manager_mock.get_bot.return_value = mock_bot
 
     await integration.start()
     try:
-        await eventbus.publish(BotStartedEvent(bot_id="bot-1", account_id="acc-test"))
+        await eventbus.publish(BotStartedEvent(bot_id="bot-1", account_id="acc-001"))
         await asyncio.sleep(0.05)
         assert "005930" in stream_client.subscribed_symbols
 
@@ -437,7 +447,7 @@ async def test_subscription_sync_removes_symbols(
         bot_manager_mock.list_bots.return_value = []
         bot_manager_mock.get_bot.return_value = None
 
-        await eventbus.publish(BotStoppedEvent(bot_id="bot-1", account_id="acc-test"))
+        await eventbus.publish(BotStoppedEvent(bot_id="bot-1", account_id="acc-001"))
         await asyncio.sleep(0.05)
 
         assert "005930" not in stream_client.subscribed_symbols
@@ -620,3 +630,133 @@ async def test_execution_payload_account_id_overrides_lifecycle(
         assert received[0].account_id == "acc-other"
     finally:
         await integration.stop()
+
+
+# ── multi_account_pool 회귀 (#1242 SPLIT-3) ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_multi_account_pool_disconnect_does_not_cross_fallback(
+    cache: ResponseCache,
+    eventbus: EventBus,
+    stop_order_manager: StopOrderManager,
+    bot_manager_mock: MagicMock,
+    gateway_mock: MagicMock,
+) -> None:
+    """SPLIT-3 (#1242): multi-account StreamIntegration pool 에서 한 계좌의
+    StreamDisconnectedEvent 가 다른 계좌의 fallback 을 켜지 않는다.
+    """
+    client_a = FakeStreamClient()
+    client_b = FakeStreamClient()
+
+    integration_a = StreamIntegration(
+        stream_client=client_a,
+        cache=cache,
+        eventbus=eventbus,
+        account_id="acc-a",
+        stop_order_manager=stop_order_manager,
+        gateway=gateway_mock,
+        bot_manager=bot_manager_mock,
+        fallback_poll_interval=0.1,
+        sync_interval=0.1,
+    )
+    integration_b = StreamIntegration(
+        stream_client=client_b,
+        cache=cache,
+        eventbus=eventbus,
+        account_id="acc-b",
+        stop_order_manager=stop_order_manager,
+        gateway=gateway_mock,
+        bot_manager=bot_manager_mock,
+        fallback_poll_interval=0.1,
+        sync_interval=0.1,
+    )
+
+    await integration_a.start()
+    await integration_b.start()
+
+    try:
+        assert not integration_a.is_fallback_active
+        assert not integration_b.is_fallback_active
+
+        # acc-a 의 stream 만 disconnect 발생
+        await eventbus.publish(
+            StreamDisconnectedEvent(account_id="acc-a", broker="kis", reason="test")
+        )
+        await asyncio.sleep(0.05)
+
+        # acc-a 만 fallback 활성, acc-b 는 영향 없음
+        assert integration_a.is_fallback_active
+        assert not integration_b.is_fallback_active
+
+        # acc-a reconnect 시 acc-a 만 fallback 종료
+        await eventbus.publish(
+            StreamConnectedEvent(account_id="acc-a", broker="kis", url="ws://a")
+        )
+        await asyncio.sleep(0.05)
+
+        assert not integration_a.is_fallback_active
+        assert not integration_b.is_fallback_active
+    finally:
+        await integration_a.stop()
+        await integration_b.stop()
+
+
+@pytest.mark.asyncio
+async def test_multi_account_pool_monitored_symbols_are_isolated(
+    cache: ResponseCache,
+    eventbus: EventBus,
+    stop_order_manager: StopOrderManager,
+    bot_manager_mock: MagicMock,
+    gateway_mock: MagicMock,
+) -> None:
+    """SPLIT-3 (#1242): 각 StreamIntegration 은 자기 account 의 봇 +
+    StopOrder 만 모니터링 종목으로 수집한다."""
+    client_a = FakeStreamClient()
+    client_b = FakeStreamClient()
+
+    bot_a = MagicMock()
+    bot_a.monitored_symbols = {"005930"}
+    bot_a.config.account_id = "acc-a"
+    bot_b = MagicMock()
+    bot_b.monitored_symbols = {"000660"}
+    bot_b.config.account_id = "acc-b"
+
+    bot_manager_mock.list_bots.return_value = [
+        {"bot_id": "bot-a", "status": "running"},
+        {"bot_id": "bot-b", "status": "running"},
+    ]
+    bot_manager_mock.get_bot.side_effect = lambda bot_id: {
+        "bot-a": bot_a,
+        "bot-b": bot_b,
+    }.get(bot_id)
+
+    integration_a = StreamIntegration(
+        stream_client=client_a,
+        cache=cache,
+        eventbus=eventbus,
+        account_id="acc-a",
+        stop_order_manager=stop_order_manager,
+        gateway=gateway_mock,
+        bot_manager=bot_manager_mock,
+        fallback_poll_interval=0.1,
+        sync_interval=0.1,
+    )
+    integration_b = StreamIntegration(
+        stream_client=client_b,
+        cache=cache,
+        eventbus=eventbus,
+        account_id="acc-b",
+        stop_order_manager=stop_order_manager,
+        gateway=gateway_mock,
+        bot_manager=bot_manager_mock,
+        fallback_poll_interval=0.1,
+        sync_interval=0.1,
+    )
+
+    # 각 instance 가 자기 account 의 봇 종목만 수집해야 한다.
+    symbols_a = integration_a._get_monitored_symbols()
+    symbols_b = integration_b._get_monitored_symbols()
+
+    assert symbols_a == {"005930"}
+    assert symbols_b == {"000660"}

--- a/tests/unit/test_stream_integration.py
+++ b/tests/unit/test_stream_integration.py
@@ -528,46 +528,30 @@ async def test_fallback_not_started_without_gateway(
 
 
 @pytest.mark.asyncio
-async def test_execution_without_account_id_skips_event(
+async def test_construction_without_account_id_raises(
     stream_client: FakeStreamClient,
     cache: ResponseCache,
     eventbus: EventBus,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """account_id가 broker payload/lifecycle 모두 없으면 OrderFilledEvent를
-    발행하지 않고 WARNING 로그 후 skip한다 (라이브 경로 보존)."""
-    integration = StreamIntegration(
-        stream_client=stream_client,
-        cache=cache,
-        eventbus=eventbus,
-        # account_id 의도적으로 미주입
-    )
-    await integration.start()
-    try:
-        received: list[OrderFilledEvent] = []
+    """SPLIT-3 (#1242): StreamIntegration 은 account_id 가 required 이며,
+    빈 문자열로 생성하려 하면 InvalidAccountIdError 가 raise 된다.
 
-        async def handler(event: OrderFilledEvent) -> None:
-            received.append(event)
+    SPLIT-1 의 ``test_execution_without_account_id_skips_event`` 는 lifecycle
+    account_id 가 없는 상태로 인스턴스를 만들 수 있다는 가정에 의존했으나,
+    SPLIT-3 에서 ctor 가 require_account_id 로 fallback 을 차단했다. broker
+    payload 만 없을 때 lifecycle account_id 로 fallback 하는 흐름은
+    ``test_execution_uses_lifecycle_account_id_when_payload_missing`` 가 검증
+    한다.
+    """
+    from ante.account.errors import InvalidAccountIdError
 
-        eventbus.subscribe(OrderFilledEvent, handler)
-
-        with caplog.at_level("WARNING", logger="ante.gateway.stream_integration"):
-            await stream_client.fire_execution(
-                {
-                    "symbol": "005930",
-                    "order_id": "ord-noacct",
-                    "side": "buy",
-                    "quantity": 10.0,
-                    "price": 70000.0,
-                }
-            )
-
-        assert received == []
-        assert any(
-            "OrderFilledEvent 발행을 skip" in rec.message for rec in caplog.records
+    with pytest.raises(InvalidAccountIdError):
+        StreamIntegration(
+            stream_client=stream_client,
+            cache=cache,
+            eventbus=eventbus,
+            account_id="",
         )
-    finally:
-        await integration.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_stream_integration.py
+++ b/tests/unit/test_stream_integration.py
@@ -160,10 +160,14 @@ async def test_price_callback_calls_stop_order_manager(
     stop_order_manager: StopOrderManager,
     eventbus: EventBus,
 ) -> None:
-    """시세 수신 시 StopOrderManager.on_price_update가 호출된다."""
+    """시세 수신 시 StopOrderManager.on_price_update가 호출된다.
+
+    SPLIT-3 (#1242): StreamIntegration 의 account_id 와 StopOrder 의
+    account_id 가 일치할 때만 trigger 된다.
+    """
     await integration.start()
     try:
-        # 스탑 주문 등록
+        # 스탑 주문 등록 — integration._account_id="acc-001" 와 동일하게 설정
         await stop_order_manager.register(
             order_id="ord-1",
             bot_id="bot-1",
@@ -173,7 +177,7 @@ async def test_price_callback_calls_stop_order_manager(
             quantity=10.0,
             order_type="stop",
             stop_price=72000.0,
-            account_id="acc-test",
+            account_id="acc-001",
         )
 
         # 세션 시간을 항상 True로 패치 (테스트 시간에 무관하게 동작)

--- a/tests/unit/test_stream_integration.py
+++ b/tests/unit/test_stream_integration.py
@@ -271,7 +271,9 @@ async def test_fallback_starts_on_stream_disconnect(
     try:
         assert not integration.is_fallback_active
 
-        await eventbus.publish(StreamDisconnectedEvent(broker="kis", reason="test"))
+        await eventbus.publish(
+            StreamDisconnectedEvent(account_id="acc-001", broker="kis", reason="test")
+        )
         # 이벤트 처리 후 폴백 태스크 생성 대기
         await asyncio.sleep(0.05)
 
@@ -289,12 +291,16 @@ async def test_fallback_stops_on_stream_reconnect(
     await integration.start()
     try:
         # 먼저 폴백 시작
-        await eventbus.publish(StreamDisconnectedEvent(broker="kis", reason="test"))
+        await eventbus.publish(
+            StreamDisconnectedEvent(account_id="acc-001", broker="kis", reason="test")
+        )
         await asyncio.sleep(0.05)
         assert integration.is_fallback_active
 
         # 재연결 시 폴백 중지
-        await eventbus.publish(StreamConnectedEvent(broker="kis", url="ws://test"))
+        await eventbus.publish(
+            StreamConnectedEvent(account_id="acc-001", broker="kis", url="ws://test")
+        )
         await asyncio.sleep(0.05)
 
         assert not integration.is_fallback_active
@@ -312,6 +318,8 @@ async def test_fallback_polls_prices(
 ) -> None:
     """REST 폴링 폴백 시 모니터링 종목의 시세를 REST로 조회한다."""
     # 스탑 주문 등록 (모니터링 종목 생성)
+    # SPLIT-3 (#1242): integration._account_id="acc-001" 와 동일하게 설정해야
+    # cross-account isolation 게이트 통과.
     await stop_order_manager.register(
         order_id="ord-1",
         bot_id="bot-1",
@@ -321,13 +329,15 @@ async def test_fallback_polls_prices(
         quantity=10.0,
         order_type="stop",
         stop_price=60000.0,
-        account_id="acc-test",
+        account_id="acc-001",
     )
 
     await integration.start()
     try:
         # 스트림 해제 → 폴백 시작
-        await eventbus.publish(StreamDisconnectedEvent(broker="kis", reason="test"))
+        await eventbus.publish(
+            StreamDisconnectedEvent(account_id="acc-001", broker="kis", reason="test")
+        )
         await asyncio.sleep(0.3)
 
         # REST API가 호출되었는지 확인
@@ -499,11 +509,14 @@ async def test_fallback_not_started_without_gateway(
         stream_client=stream_client,
         cache=cache,
         eventbus=eventbus,
+        account_id="acc-001",
         gateway=None,
     )
     await integration.start()
     try:
-        await eventbus.publish(StreamDisconnectedEvent(broker="kis", reason="test"))
+        await eventbus.publish(
+            StreamDisconnectedEvent(account_id="acc-001", broker="kis", reason="test")
+        )
         await asyncio.sleep(0.05)
 
         assert not integration.is_fallback_active


### PR DESCRIPTION
Closes #1242

Parent epic: #1215. Splits from #1217.
Depends on: #1240 (SPLIT-1, merged via #1243), #1241 (SPLIT-2, merged via #1246) — both ✅

## Summary

#1217 SPLIT 마지막. APIGateway/Stream + multi-account lifecycle pool. SPLIT-1/2가 모델·이벤트·write/IPC 진입점을 정리했으므로 본 SPLIT은 runtime lifecycle 다중화에 집중한다.

### 8 sequential commits

1. `2fdd02b` C1 — `fix(stop-order)!`: StopOrderManager P1 financial correctness. `StopOrder.__post_init__`에 `require_account_id`, `on_price_update(symbol, price, *, account_id)` 시그니처 변경, `active_for_symbol` 필터에 account 일치 추가. cross-account 가격 tick이 다른 계좌 stop order를 트리거하지 않도록 보장.
2. `dda5a37` C2 — `feat(eventbus)!`: `StreamConnectedEvent`/`StreamDisconnectedEvent`에 `account_id: str = ""` + `_requires_account_id: ClassVar[bool] = True` strict marker. `KISStreamClient` 발행자 측에 account_id 명시 전달.
3. `eaa2255` C3 — `fix(gateway)!`: `ResponseCache.invalidate(pattern)` substring → prefix-exact. `acc-1:balance` invalidate가 `acc-12:balance`를 회귀로 무효화하던 문제 차단. 빈 pattern 전체 초기화 유지.
4. `b928077` C4 — `feat(gateway)!`: `APIGateway` 6 메서드(get_ohlcv, get_current_price, get_positions, get_account_balance, submit_order, cancel_order) `account_id` kw-only required + `require_account_id`. `StreamIntegration.__init__` ctor도 동일. 호출자 보강: `paper.py:192` PaperExecutor account_id 보유, `main.py:864-871` `_resolve_price` closure default-arg late-binding.
5. `46e2161` C5 — `feat(gateway)!`: `LiveDataProvider.__init__`에 `account_id` kw-only 추가, 내부 `gateway.get_*(..., account_id=self._account_id)` 명시 전달, `context_factory`에서 봇별 인스턴스 생성. strategy 인터페이스(`StrategyContext.get_ohlcv`)는 closure 방식으로 무변경.
6. `6cfb150` C6 — `feat(account)!`: multi-account StreamIntegration pool. `Services.stream_integration` 단일 슬롯 → `stream_integrations: dict[str, StreamIntegration]`. 각 KIS 활성 계좌마다 새 인스턴스 등록. `_get_monitored_symbols`에 `bot.config.account_id == self._account_id` 필터. 한 계좌 disconnect가 다른 계좌 fallback을 켜지 않도록 격리.
7. `3a3e923` C7 — `feat(broker)!`: multi-broker ReconcileScheduler pool. `Services.reconcile_scheduler` 단일 슬롯 → `reconcile_schedulers: dict`. 활성 broker 각각에 dispatch.
8. `e9a2c78` C9 — `docs(spec)`: `docs/specs/account/14-account-id-contract.md`의 SPLIT-3 표 close 표시, `docs/specs/eventbus/eventbus.md`에 Stream events marker 정책 라인 추가.

C8(Group B 이벤트 점검)은 SPLIT-1 marker로 이미 검증됐고 누락 없음 — 의도적 별도 commit 없음.

### BREAKING changes

운영 호환성 노트:
- `APIGateway.{get_ohlcv,get_current_price,get_positions,get_account_balance,submit_order,cancel_order}` `account_id: str` kw-only required
- `StreamIntegration.__init__` `account_id` kw-only required
- `LiveDataProvider.__init__` `account_id` kw-only required
- `StopOrder.account_id` 필드 + `on_price_update`에 `account_id` kw-only required
- `StreamConnectedEvent`/`StreamDisconnectedEvent` `_requires_account_id=True` strict marker
- `Services.stream_integration` / `Services.reconcile_scheduler` 단일 슬롯 필드 제거 → dict pool로 전환
- `ResponseCache.invalidate(pattern)` substring → prefix-exact match

KIS multi-account 운영 시 startup에서 각 계좌마다 별도 KISStreamClient 인스턴스 + WebSocket 연결이 생성된다. KIS 계좌 수에 비례한 socket/auth 부하 증가. KIS rate limit는 개별 계좌 단위 독립이므로 정상.

### 명시적 제외 (Non-Goals)

- KIS 40종목 분배 알고리즘 → 별도 이슈 (silent fallback + 로그만 본 PR 유지)
- 동적 account add/remove (hot reconfig) → 별도 이슈 (본 PR은 startup/shutdown cold path만)
- Read query / edge resolver 일반화 → #1218
- DB schema/index 정렬 → #1219
- Web `bot create` resolver(`bots.py:189`) → #1218

## Plan Preflight & Branch Review

- Plan Preflight: Codex Plan Review 4회 hang → @code-reviewer 메타 리뷰 게이트 전환 → narrow-scope verdict + 5개 보강(KISStreamClient 인스턴스화 정책, paper.py 호출자 누락, main.py:864-871 closure, StopOrder DB 의존 해제, stream_integrations_pool 회귀 가드)
- 브랜치 리뷰: @code-reviewer attempt 1 PASS — Implementation Plan v2 매핑 정확, brittle 테스트 없음, SPLIT-1/2 contract 일관, Stop Conditions 위반 없음

Follow-up 이슈 권장 (본 PR 차단 사유 아님):
- `KISStreamClient.__init__`의 `account_id: str = ""` ctor default를 fail-fast로 강화

## Test Plan

- [x] `pytest tests/unit -q`: 3622 passed, 2 skipped (SPLIT-2 baseline 3595 → +27 신규)
- [x] `pytest tests/unit/test_stop_order.py -k cross_account -q` (P1 가드)
- [x] `pytest tests/unit/test_cache.py -k prefix_isolation -q`
- [x] `pytest tests/unit/test_stream_integration.py -k multi_account_pool -q`
- [x] `pytest tests/unit/test_main.py -k stream_integrations_pool -q`
- [x] `ruff check src tests && ruff format --check src tests`: PASS
- [x] `mypy src/ante`: SPLIT-2 baseline 2개(`account/service.py:711,748`) 외 신규 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)