### PR TITLE
fix(account): resolve mypy shadow on AccountService.list return types

### DIFF
--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -35,6 +35,11 @@ logger = logging.getLogger(__name__)
 # 브로커 어댑터 레지스트리 — broker_type → 어댑터 클래스
 _BROKER_REGISTRY: dict[str, type[BrokerAdapter]] = {}
 
+# AccountService.list 메서드명이 클래스 내부 후속 메서드의 ``list[...]`` 어노테이션과
+# mypy 평가 시점에 충돌하므로(``Function "AccountService.list" is not valid as a type``)
+# 모듈 스코프에서 builtin ``list``를 캡처한 alias를 사용한다.
+_AccountStatusReport = list[dict[str, Any]]
+
 _CREATE_TABLE_SQL = """\
 CREATE TABLE IF NOT EXISTS accounts (
     account_id   TEXT PRIMARY KEY,
@@ -708,7 +713,7 @@ class AccountService:
 
     # ── 일괄 상태 전이 ──────────────────────────────────
 
-    async def suspend_all(self, reason: str, suspended_by: str) -> list[dict[str, Any]]:
+    async def suspend_all(self, reason: str, suspended_by: str) -> _AccountStatusReport:
         """모든 ACTIVE 계좌를 SUSPENDED로 전환. DELETED 계좌는 후보 제외.
 
         Returns:
@@ -745,7 +750,7 @@ class AccountService:
         logger.info("전체 계좌 정지: %d개 (사유: %s)", changed_count, reason)
         return results
 
-    async def activate_all(self, activated_by: str) -> list[dict[str, Any]]:
+    async def activate_all(self, activated_by: str) -> _AccountStatusReport:
         """모든 SUSPENDED 계좌를 ACTIVE로 복구. DELETED 계좌는 후보 제외.
 
         Returns:


### PR DESCRIPTION
## Summary

`AccountService.list` 메서드명이 클래스 내부 후속 메서드의 `list[dict[str, Any]]` 반환 타입 어노테이션과 mypy 평가 시점에 충돌해 `lint` 잡이 모든 PR에서 빨갛게 떴다 (예: #1246, #1247의 lint 빨간불 원인).

```
src/ante/account/service.py:711: error: Function "ante.account.service.AccountService.list" is not valid as a type  [valid-type]
src/ante/account/service.py:748: error: Function "ante.account.service.AccountService.list" is not valid as a type  [valid-type]
```

## Root cause

`from __future__ import annotations`로 어노테이션이 모두 문자열로 지연 평가되지만, mypy가 클래스 본문 안에서 `list[...]`를 해석할 때 `AccountService.list` 메서드가 이미 정의된 뒤이므로 builtin `list`보다 메서드 이름을 우선 참조한다. 결과적으로 `list[dict[str, Any]]`가 `Callable[..., list[Account]][dict[str, Any]]` 형태로 해석돼 `valid-type` 에러를 던진다.

`list` 메서드 (line 359)의 자기 자신 어노테이션은 정의 시점에 builtin이 아직 가려지지 않아 통과하지만, 그 이후 정의되는 `suspend_all` (line 711)과 `activate_all` (line 748)에서만 충돌한다.

## Fix

메서드명 rename(`list` → `list_accounts`)은 호출자 40+개에 영향이 있어 보류. 대신 모듈 스코프에서 builtin `list`를 캡처한 alias를 도입한다:

```python
# AccountService.list 메서드명이 클래스 내부 후속 메서드의 ``list[...]`` 어노테이션과
# mypy 평가 시점에 충돌하므로 모듈 스코프에서 builtin ``list``를 캡처한 alias를 사용한다.
_AccountStatusReport = list[dict[str, Any]]
```

`suspend_all`, `activate_all`의 반환 타입 어노테이션을 `_AccountStatusReport`로 교체. 모듈 스코프에서 정의되므로 `AccountService.list`가 builtin `list`를 가리기 전에 captured.

## 동작 변경 없음

- 런타임 동작 동일 (alias는 단순 type 어노테이션)
- 메서드 시그니처 동일 (`list[dict[str, Any]]`와 동일한 타입)
- 호출자 변경 없음

## Test Plan

- [x] `mypy src/ante`: **Success: no issues found in 231 source files** (이전 2 errors → 0)
- [x] `ruff check src tests`: PASS
- [x] `ruff format --check src tests`: PASS (432 files)
- [x] `pytest tests/unit -q`: 3622 passed, 2 skipped (회귀 없음)

## 관련

이 baseline mypy 에러는 commit `6304774` (Kill Switch backend, #1213)에서 `suspend_all`/`activate_all` 메서드 추가 시 유입됐다. 이후 모든 PR의 `lint` job FAIL 원인이었으나 `ci` required gate가 아니라 머지에는 영향 없음. 본 PR로 청소.

🤖 Generated with [Claude Code](https://claude.com/claude-code)