### PR TITLE
docs(frontend): align API type SSOT rules

### DIFF
--- a/.agent/agents/frontend-dev.md
+++ b/.agent/agents/frontend-dev.md
@@ -18,7 +18,7 @@ Ante 대시보드(React)를 구현하는 서브에이전트다.
 - `docs/dashboard/architecture.md`의 화면 구성과 레이아웃을 충실히 구현
 - 디자인 산출물/목업이 있으면 픽셀 단위로 일치시킨다
 - 디자인 토큰(`index.css` `@theme`)과 코딩 컨벤션(`architecture.md` § 코딩 컨벤션)을 준수한다
-- API 연동 시 타입 안전성 확보 (API 응답 → TypeScript 타입 → 컴포넌트)
+- API 연동 시 타입 안전성 확보 (`api.generated.ts` raw contract → `api/*.ts` adapter → UI/domain model → 컴포넌트)
 - **백엔드에 존재하지 않는 API를 임의로 만들어 호출하지 않는다**
 
 ## 모델 및 추론 강도 운영 가이드
@@ -47,6 +47,7 @@ Ante 대시보드(React)를 구현하는 서브에이전트다.
 
 - **디자인 토큰 준수**: `index.css`에 정의된 시맨틱 토큰만 사용. Tailwind 기본 색상(`text-white`, `text-green-600` 등) 사용 금지
 - **API 계약 엄수**: 백엔드 OpenAPI 스키마에 정의된 API만 호출. 없는 API를 추측하여 만들지 않는다
-- **타입 안전성**: API 응답 타입은 `api.generated.ts`에서만 import. 수동 API 타입 정의 금지
+- **타입 안전성**: `api.generated.ts`는 wire contract SSOT이며 `frontend/src/api/*.ts`에서만 import한다. hooks/pages/components는 generated type을 직접 소비하지 않고 adapter가 반환한 UI/domain model만 받는다.
+- **adapter 책임**: `api/*.ts`는 generated raw response를 `View` suffix UI model로 변환한다. 수동 `Response`/`Request`/`Payload` 타입으로 API 계약을 shadowing하지 않는다.
 - **컴포넌트 분리**: 페이지 컴포넌트(`pages/`)와 재사용 컴포넌트(`components/`)를 분리
 - **데이터 흐름**: `api/ → hooks/ → pages/ → components/` — 컴포넌트에서 API 직접 호출 금지

--- a/.agent/skills/contract-drift-review.md
+++ b/.agent/skills/contract-drift-review.md
@@ -23,3 +23,6 @@
 - 문서엔 `kill-switch`인데 구현은 `halt` / `activate`
 - OpenAPI는 갱신됐는데 generated type은 예전 필드를 유지
 - response_model은 바뀌었는데 tests가 예전 shape만 본다
+- 프론트 수동 타입(`frontend/src/types/*.ts`)이 generated response를 shadowing한다
+- `res.data as SomeManualType` 또는 mapper 밖 `as unknown as`로 API drift를 숨긴다
+- hooks/pages/components가 `types/api.generated`를 직접 import해 adapter 경계를 우회한다

--- a/.agent/skills/frontend-conventions.md
+++ b/.agent/skills/frontend-conventions.md
@@ -224,39 +224,63 @@ CSS 애니메이션 참조(`animation: 'name ...'`)를 제외하고 `style={}` �
 
 ## 6. 타입 안전성
 
-### 타입 시스템 (자동 생성 전용)
+### 타입 시스템 (wire contract / UI model 분리)
 
-**API 응답 타입은 `api.generated.ts`에서만 import한다. 수동 타입 파일(`types/*.ts`)에 API 응답 인터페이스를 정의하지 않는다.**
+**`api.generated.ts`는 백엔드 Web API wire contract의 유일한 SSOT다.**
+수동 타입 파일(`types/*.ts`)은 API 응답/요청 계약을 정의하지 않고,
+프론트 UI/domain model만 정의한다.
 
 - **`api.generated.ts`**: OpenAPI 스키마에서 `npm run generate-types`로 자동 생성 — 직접 수정 금지
-- **수동 타입 허용 범위**: 컴포넌트 Props, UI 상태, 프론트엔드 전용 유틸리티 타입만
-- 백엔드 스키마 변경 시 `npm run generate-types`로 재생성하여 동기화
+- **`frontend/src/api/*.ts`**: generated raw response/request type을 import할 수 있는 유일한 계층. 이 계층에서 raw contract를 UI/domain model로 변환한다.
+- **`frontend/src/types/*.ts`**: UI/domain model only. API 계약처럼 보이는 `Response`, `Request`, `Payload` suffix를 새로 정의하지 않는다.
+- **`hooks/`, `pages/`, `components/`**: generated type 직접 import 금지. `api/*.ts` adapter가 반환한 UI/domain model만 소비한다.
+- 백엔드 스키마 변경 시 `npm run generate-types`로 재생성하고, 같은 변경에서 관련 `api/*.ts` adapter와 UI/domain model을 함께 갱신한다.
 
 ```bash
 # 타입 재생성
 npm run generate-types
 ```
 
-### import 패턴
+### adapter 패턴
 
 ```tsx
-// API 응답 타입: api.generated.ts에서 import
-import type { BotDetailResponse, BotListResponse } from '../types/api.generated'
+// frontend/src/api/bots.ts
+import client from './client'
+import type { BotDetailResponse } from '../types/api.generated'
+import type { BotView } from '../types/bot'
 
-// 프론트엔드 전용 타입: 컴포넌트 파일 내 정의
+function toBotView(raw: BotDetailResponse): BotView {
+  return {
+    botId: raw.bot.bot_id,
+    status: raw.bot.status,
+  }
+}
+
+export async function getBot(id: string): Promise<BotView> {
+  const { data } = await client.get<BotDetailResponse>(`/api/bots/${id}`)
+  return toBotView(data)
+}
+
+// frontend/src/components/bots/BotCard.tsx
+import type { BotView } from '../../types/bot'
+
 interface BotCardProps {
-  bot: BotDetailResponse
-  onStop: (botId: string) => void
+  bot: BotView
 }
 ```
 
 ### 타입 정의 규칙
 
-- **`type`**: 자동 생성 타입의 re-export, 유니온, 별칭에 사용 (`type BotStatus = BotDetailResponse['status']`)
-- **`interface`**: 컴포넌트 Props 등 프론트엔드 전용 객체 정의
+- **`type`**: UI 상태 유니온, view alias, 폼 타입에 사용
+- **`interface`**: 컴포넌트 Props, UI/domain model 등 프론트엔드 전용 객체 정의
+- **읽기 UI model suffix**: API raw response에서 변환한 읽기 모델은 `View`를 사용 (`BotView`, `TreasurySummaryView`)
+- **입력 UI model suffix**: 사용자 입력과 폼 값은 `Input`, `FormValues`를 사용 (`BotFormValues`)
+- **금지 suffix**: 수동 `Response`, `Request`, `Payload` 타입 선언 금지 (`api.generated.ts` 제외)
+- **mapper 함수명**: 기본은 `toXxxView(raw)`. 같은 View를 여러 raw source에서 만들 때만 `toXxxViewFromSource` 형태를 사용
 - **`enum` 미사용**: 백엔드 enum은 string literal union으로 표현
 - **`I` 접두사 금지**: `IBotProps` ✕ → `BotCardProps` ✓
 - **`any` 사용 금지**
+- **`as unknown as` 제한**: `api/*.ts`의 `toXxxView()` mapper 내부에서만 허용한다. mapper 밖에서는 drift 은폐로 본다.
 
 ## 7. 네이밍 규칙
 

--- a/.agent/skills/generated-artifact-sync.md
+++ b/.agent/skills/generated-artifact-sync.md
@@ -15,6 +15,8 @@
 - 산출물 생성 명령과 결과 파일이 함께 PR에 포함되었는가
 - 수동 편집 금지 산출물을 수동으로만 맞추지 않았는가
 - 생성 산출물이 새 구현을 반영하지만 소비자는 여전히 예전 계약을 쓰지 않는가
+- `frontend/src/types/api.generated.ts` 변경 시 `frontend/src/api/*.ts` adapter와 UI/domain model이 같은 PR에서 맞춰졌는가
+- generated type import가 adapter 계층(`frontend/src/api/*.ts`) 밖으로 새지 않았는가
 
 ## 주요 산출물
 
@@ -29,3 +31,5 @@
 - API 구현만 바뀌고 generated type이 없다
 - DDL이 바뀌었는데 schema 문서가 그대로다
 - 구조 문서가 새 디렉토리를 모른다
+- generated type만 갱신되고 adapter/UI model은 이전 raw shape를 계속 가정한다
+- `api.generated.ts`를 수동 편집해 OpenAPI와 타입 산출물의 출처가 갈라진다

--- a/.agent/skills/review-pr.md
+++ b/.agent/skills/review-pr.md
@@ -159,9 +159,11 @@ release PR이면 추가로 확인한다.
 | G1 | 디자인 토큰 준수 | 시맨틱 토큰만 사용했는가 |
 | G2 | 타이포그래피 체계 | 프로젝트가 정한 타입 스케일을 따르는가 |
 | G3 | API 임의 생성 금지 | 백엔드에 없는 엔드포인트를 만들지 않았는가 |
-| G4 | 자동 생성 타입 사용 | 수동 API 응답 타입 정의가 없는가 |
-| G5 | 데이터 흐름 | `api -> hooks -> pages -> components` 패턴을 따르는가 |
-| G6 | 빌드 통과 | `npm run build` 또는 동등 검증이 성공하는가 |
+| G4 | wire contract SSOT | `api.generated.ts`를 직접 수정하지 않고, generated type import가 `frontend/src/api/*.ts` 밖으로 새지 않았는가 |
+| G5 | adapter 경계 | `api/*.ts`가 generated raw response를 UI/domain `View` model로 변환하고, hooks/pages/components가 generated type을 직접 소비하지 않는가 |
+| G6 | 수동 API 타입 shadowing 금지 | 수동 `Response`/`Request`/`Payload` 타입 선언이나 `res.data as SomeManualType`로 drift를 숨기지 않는가 |
+| G7 | 데이터 흐름 | `api -> hooks -> pages -> components` 패턴을 따르는가 |
+| G8 | 빌드 통과 | `npm run build` 또는 동등 검증이 성공하는가 |
 
 ### 5단계: 결과 구조화
 

--- a/docs/dashboard/architecture.md
+++ b/docs/dashboard/architecture.md
@@ -63,6 +63,7 @@ Ante의 대시보드는 **단일 사용자(운영자)**를 위한 화면이다.
 
 > **SSOT**: 백엔드 OpenAPI 스키마 (`/openapi.json`)가 API 계약의 단일 진실 원천이다.
 > 프론트엔드 타입은 `npm run generate-types`로 자동 생성한다 ([generate-types.sh](../../frontend/scripts/generate-types.sh)).
+> `frontend/src/types/api.generated.ts`는 Web API wire contract SSOT이고, `frontend/src/api/*.ts`는 raw response를 UI/domain `View` model로 변환하는 adapter boundary다. `hooks/`, `pages/`, `components/`는 generated type을 직접 import하지 않는다.
 
 ### 라우터별 구현 현황
 
@@ -218,10 +219,13 @@ export default function BotDetail() {
 
 #### 타입 정의 규칙
 
-- **`interface`**: 객체 형태 정의 (`interface Bot { ... }`)
-- **`type`**: 유니온·별칭 (`type BotStatus = 'running' | 'stopped'`)
+- **wire contract**: `frontend/src/types/api.generated.ts`만 사용한다. OpenAPI에서 생성하며 직접 수정하지 않는다.
+- **adapter boundary**: `frontend/src/api/*.ts`만 generated type을 import하고, raw response를 UI/domain model로 변환한다.
+- **UI/domain model**: `frontend/src/types/*.ts`에는 `View`, `Input`, `FormValues` 등 프론트 전용 타입만 둔다.
+- **금지 suffix**: 수동 `Response`, `Request`, `Payload` 타입 선언 금지 (`api.generated.ts` 제외)
+- **`interface`**: 컴포넌트 Props, UI/domain model 등 프론트 전용 객체 정의
+- **`type`**: UI 상태 유니온·별칭 (`type BotStatus = 'running' | 'stopped'`)
 - **`enum` 미사용**: 백엔드 enum은 string literal union으로 표현
-- **자동 생성 타입**: `api.generated.ts`는 직접 수정 금지. 수동 타입에서 re-export하여 사용
 
 #### React Query 규칙
 

--- a/docs/runbooks/01-development-process.md
+++ b/docs/runbooks/01-development-process.md
@@ -244,6 +244,7 @@ API 스키마 계약의 상세 SSOT는 [docs/dashboard/architecture.md](../dashb
 - API 응답 스키마 변경은 백엔드와 프론트엔드 양쪽에 영향을 주는 계약 변경으로 본다.
 - 구현 이슈 진행 중 스키마 변경이 드러나면 Plan Preflight에서 별도 이슈 분리 또는 `needs-spec-first` 전환을 판단한다.
 - 새 엔드포인트와 응답 변경은 생성 타입 동기화까지 검증 계획에 포함한다.
+- 프론트 소비자가 있으면 `frontend/src/api/*.ts` adapter와 UI/domain model 동기화도 같은 검증 계획에 포함한다. `api.generated.ts`는 wire contract SSOT이고 hooks/pages/components는 generated type을 직접 소비하지 않는다.
 
 ## 9. AGENTS.md 경량화 원칙
 

--- a/docs/runbooks/02-agent-structure.md
+++ b/docs/runbooks/02-agent-structure.md
@@ -44,6 +44,7 @@
 
 - `docs/dashboard/architecture.md` 기준으로 구현
 - API 계약은 백엔드 OpenAPI와 자동 생성 타입을 기준으로 사용
+- `api.generated.ts`는 wire contract SSOT로만 보고, UI 계층에는 `frontend/src/api/*.ts` adapter가 변환한 UI/domain model만 전달
 
 ### 1.4 DevOps 엔지니어 (`@devops`)
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "generate-types": "bash scripts/generate-types.sh"
+    "generate-types": "bash scripts/generate-types.sh",
+    "check-api-types": "node scripts/check-api-type-boundaries.mjs"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.1",

--- a/frontend/scripts/check-api-type-boundaries.mjs
+++ b/frontend/scripts/check-api-type-boundaries.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { relative, sep } from 'node:path'
+
+const root = new URL('..', import.meta.url).pathname.replace(/\/$/, '')
+const srcRoot = `${root}/src`
+const generatedType = `${srcRoot}/types/api.generated.ts`
+const suffixPattern = /\b(?:interface|type)\s+([A-Z][A-Za-z0-9]*(?:Response|Request|Payload))\b/g
+const generatedImportPattern = /from\s+['"][^'"]*types\/api\.generated['"]|from\s+['"][^'"]*api\.generated['"]/g
+const clientCallPattern = /\bclient\.(get|post|put|patch|delete)\s*(?!<)\(/g
+const unknownCastPattern = /\bas\s+unknown\s+as\b/g
+
+const ignoredDirs = new Set(['node_modules', 'dist', '.vite-temp'])
+const sourceExtensions = new Set(['.ts', '.tsx'])
+const findings = []
+
+function walk(dir) {
+  const files = []
+  for (const entry of readdirSync(dir)) {
+    if (ignoredDirs.has(entry)) continue
+    const path = `${dir}/${entry}`
+    const stat = statSync(path)
+    if (stat.isDirectory()) {
+      files.push(...walk(path))
+    } else if ([...sourceExtensions].some((ext) => path.endsWith(ext))) {
+      files.push(path)
+    }
+  }
+  return files
+}
+
+function rel(path) {
+  return relative(root, path).split(sep).join('/')
+}
+
+function lineNumber(text, index) {
+  return text.slice(0, index).split('\n').length
+}
+
+function domainFor(path) {
+  const r = rel(path)
+  if (r.startsWith('src/api/')) return 'api-adapter'
+  if (r.startsWith('src/types/')) return 'types'
+  if (r.startsWith('src/hooks/')) return 'hooks'
+  if (r.startsWith('src/components/')) return 'components'
+  if (r.startsWith('src/pages/')) return 'pages'
+  return 'frontend'
+}
+
+function add(path, index, rule, message) {
+  findings.push({
+    file: rel(path),
+    line: lineNumber(readFileSync(path, 'utf8'), index),
+    rule,
+    domain: domainFor(path),
+    message,
+  })
+}
+
+function isApiFile(path) {
+  return rel(path).startsWith('src/api/')
+}
+
+function isGenerated(path) {
+  return path === generatedType
+}
+
+function isAllowedUnknownCast(path, text, index) {
+  if (!isApiFile(path)) return false
+  const prefix = text.slice(0, index)
+  const lastMapper = Math.max(
+    prefix.lastIndexOf('function to'),
+    prefix.lastIndexOf('const to')
+  )
+  const lastExportedApi = Math.max(
+    prefix.lastIndexOf('export async function'),
+    prefix.lastIndexOf('export function')
+  )
+  return lastMapper > lastExportedApi && /to[A-Z][A-Za-z0-9]*View/.test(prefix.slice(lastMapper, index))
+}
+
+for (const file of walk(srcRoot)) {
+  const text = readFileSync(file, 'utf8')
+
+  if (!isGenerated(file)) {
+    for (const match of text.matchAll(suffixPattern)) {
+      add(
+        file,
+        match.index,
+        'manual-api-type-name',
+        `Manual type '${match[1]}' looks like an API contract. Use View/Input/FormValues or generated types.`
+      )
+    }
+  }
+
+  if (!isApiFile(file) && !isGenerated(file)) {
+    for (const match of text.matchAll(generatedImportPattern)) {
+      add(
+        file,
+        match.index,
+        'generated-import-outside-adapter',
+        'Generated API types may only be imported by frontend/src/api/*.ts adapters.'
+      )
+    }
+  }
+
+  if (isApiFile(file)) {
+    for (const match of text.matchAll(clientCallPattern)) {
+      add(
+        file,
+        match.index,
+        'client-call-without-generated-type',
+        `client.${match[1]} call has no generated type parameter.`
+      )
+    }
+  }
+
+  for (const match of text.matchAll(unknownCastPattern)) {
+    if (!isAllowedUnknownCast(file, text, match.index)) {
+      add(
+        file,
+        match.index,
+        'unknown-cast-outside-mapper',
+        '`as unknown as` is only allowed inside api/*.ts toXxxView() mappers.'
+      )
+    }
+  }
+}
+
+const byRule = findings.reduce((acc, finding) => {
+  acc[finding.rule] = (acc[finding.rule] ?? 0) + 1
+  return acc
+}, {})
+
+console.log('Frontend API type boundary report (report-only)')
+console.log(`Scanned: ${rel(srcRoot)}`)
+console.log(`Findings: ${findings.length}`)
+for (const [rule, count] of Object.entries(byRule).sort()) {
+  console.log(`- ${rule}: ${count}`)
+}
+
+if (findings.length > 0) {
+  console.log('\nfile:line | rule | domain | message')
+  for (const finding of findings) {
+    console.log(
+      `${finding.file}:${finding.line} | ${finding.rule} | ${finding.domain} | ${finding.message}`
+    )
+  }
+}
+
+console.log('\nResult: report-only, exit 0')


### PR DESCRIPTION
## Summary
- codify `api.generated.ts` as the frontend wire contract SSOT
- document the `frontend/src/api/*.ts` adapter boundary and UI/domain model split across agent/runbook/dashboard docs
- add `npm run check-api-types` as a report-only boundary scanner

## Verification
- PASS `cd frontend && npm run check-api-types`
- PASS `cd frontend && npm run build`
- PASS `git diff --cached --check`
- NOTE `cd frontend && npm run lint` still fails on existing frontend lint issues outside this change (`AgentEditModal.tsx`, `BotCreateForm.tsx`, `Pagination.tsx`, `Toast.tsx`, `BacktestData.tsx`)

Closes #1221