### PR TITLE
feat(frontend): align system adapter view contract

### DIFF
--- a/frontend/src/api/system.ts
+++ b/frontend/src/api/system.ts
@@ -1,10 +1,39 @@
 import client from './client'
-import type { SystemStatus, DynamicConfig } from '../types/system'
-import type { KillSwitchResponse } from '../types/api.generated'
+import type { SystemStatusView, DynamicConfigView } from '../types/system'
+import type {
+  ClearHaltRequest,
+  ConfigItem,
+  ConfigListResponse,
+  ConfigUpdateResponse,
+  HaltRequest,
+  KillSwitchResponse,
+  StatusResponse,
+} from '../types/api.generated'
 
-export async function getSystemStatus(): Promise<SystemStatus> {
-  const res = await client.get('/api/system/status')
-  return res.data
+function optionalString(value: string | null | undefined): string | undefined {
+  return value ?? undefined
+}
+
+function toSystemStatusView(raw: StatusResponse): SystemStatusView {
+  return {
+    status: raw.status,
+    version: raw.version,
+    haltTime: optionalString(raw.halt_time),
+    haltReason: optionalString(raw.halt_reason),
+  }
+}
+
+function toDynamicConfigView(raw: ConfigItem): DynamicConfigView {
+  return {
+    key: raw.key,
+    value: raw.value == null ? '' : String(raw.value),
+    description: typeof raw.description === 'string' ? raw.description : undefined,
+  }
+}
+
+export async function getSystemStatus(): Promise<SystemStatusView> {
+  const res = await client.get<StatusResponse>('/api/system/status')
+  return toSystemStatusView(res.data)
 }
 
 /**
@@ -14,7 +43,8 @@ export async function getSystemStatus(): Promise<SystemStatus> {
  * 백엔드: `POST /api/system/halt` (HaltRequest { reason: string }).
  */
 export async function haltSystem(reason?: string): Promise<KillSwitchResponse> {
-  const res = await client.post('/api/system/halt', { reason: reason ?? '' })
+  const body: HaltRequest = { reason: reason ?? '' }
+  const res = await client.post<KillSwitchResponse>('/api/system/halt', body)
   return res.data
 }
 
@@ -26,15 +56,16 @@ export async function haltSystem(reason?: string): Promise<KillSwitchResponse> {
  * 백엔드: `POST /api/system/clear-halt` (ClearHaltRequest { reason: string }).
  */
 export async function clearHaltSystem(reason?: string): Promise<KillSwitchResponse> {
-  const res = await client.post('/api/system/clear-halt', { reason: reason ?? '' })
+  const body: ClearHaltRequest = { reason: reason ?? '' }
+  const res = await client.post<KillSwitchResponse>('/api/system/clear-halt', body)
   return res.data
 }
 
-export async function getConfigs(): Promise<DynamicConfig[]> {
-  const res = await client.get('/api/config')
-  return res.data.configs ?? res.data
+export async function getConfigs(): Promise<DynamicConfigView[]> {
+  const res = await client.get<ConfigListResponse>('/api/config')
+  return res.data.configs.map(toDynamicConfigView)
 }
 
 export async function updateConfig(key: string, value: string): Promise<void> {
-  await client.put(`/api/config/${encodeURIComponent(key)}`, { value })
+  await client.put<ConfigUpdateResponse>(`/api/config/${encodeURIComponent(key)}`, { value })
 }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -145,11 +145,11 @@ export default function Settings() {
                 <div className="text-[12px] text-text-muted mt-1">
                   활성 계좌 {activeCount}개 · 정지 계좌 {suspendedCount}개
                 </div>
-                {(status?.halt_time || status?.halt_reason) && (
+                {(status?.haltTime || status?.haltReason) && (
                   <div className="text-[12px] text-text-muted mt-1">
-                    {status.halt_time && `정지 시각: ${status.halt_time}`}
-                    {status.halt_time && status.halt_reason && ' · '}
-                    {status.halt_reason && `사유: ${status.halt_reason}`}
+                    {status.haltTime && `정지 시각: ${status.haltTime}`}
+                    {status.haltTime && status.haltReason && ' · '}
+                    {status.haltReason && `사유: ${status.haltReason}`}
                   </div>
                 )}
               </div>

--- a/frontend/src/types/system.ts
+++ b/frontend/src/types/system.ts
@@ -6,13 +6,12 @@
  * SSOT: `docs/specs/account/02-design-decisions.md`.
  */
 
-// ── 프론트엔드 전용 타입 ──────────────────────────────────
-export interface SystemStatus {
-  uptime_seconds: number
-  running_bots: number
+// ── 프론트엔드 전용 UI/domain 타입 ──────────────────────────
+export interface SystemStatusView {
+  status: string
   version: string
-  halt_time?: string
-  halt_reason?: string
+  haltTime?: string
+  haltReason?: string
 }
 
 export interface BrokerStatus {
@@ -21,7 +20,7 @@ export interface BrokerStatus {
   token_expires_at?: string
 }
 
-export interface DynamicConfig {
+export interface DynamicConfigView {
   key: string
   value: string
   description?: string


### PR DESCRIPTION
## Summary
- map generated `StatusResponse` into a frontend `SystemStatusView`
- type system halt/clear-halt and config adapter responses with generated contracts
- update Settings to consume the View fields instead of raw system response fields

## Verification
- PASS `cd frontend && npm run check-api-types`
- PASS `cd frontend && npm run build`
- PASS `git diff --check`
- PASS `rg -n "trading_status|\bSystemStatus\b|halt_time|halt_reason" frontend/src/types/system.ts frontend/src/pages/Settings.tsx frontend/src/hooks/useSystemStatus.ts`

Closes #1222