### PR TITLE
feat(frontend): align account bot adapter view contracts

### DIFF
--- a/frontend/src/api/accounts.ts
+++ b/frontend/src/api/accounts.ts
@@ -1,7 +1,32 @@
 import client from './client'
-import type { Account } from '../types/account'
+import type { AccountView, AccountStatus } from '../types/account'
+import type { AccountListResponse, AccountResponse } from '../types/api.generated'
 
-export async function getAccounts(params?: { status?: string }): Promise<Account[]> {
-  const res = await client.get('/api/accounts', { params })
-  return res.data.accounts ?? []
+function toAccountStatus(status: string): AccountStatus {
+  return status
+}
+
+function toAccountView(raw: AccountResponse): AccountView {
+  return {
+    account_id: raw.account_id,
+    name: raw.name,
+    exchange: raw.exchange,
+    currency: raw.currency,
+    timezone: raw.timezone,
+    trading_hours_start: raw.trading_hours_start,
+    trading_hours_end: raw.trading_hours_end,
+    trading_mode: raw.trading_mode,
+    broker_type: raw.broker_type,
+    broker_config: raw.broker_config,
+    buy_commission_rate: raw.buy_commission_rate,
+    sell_commission_rate: raw.sell_commission_rate,
+    status: toAccountStatus(raw.status),
+    created_at: raw.created_at,
+    updated_at: raw.updated_at,
+  }
+}
+
+export async function getAccounts(params?: { status?: string }): Promise<AccountView[]> {
+  const res = await client.get<AccountListResponse>('/api/accounts', { params })
+  return res.data.accounts.map(toAccountView)
 }

--- a/frontend/src/api/bots.ts
+++ b/frontend/src/api/bots.ts
@@ -1,61 +1,233 @@
 import client from './client'
-import type { Bot, BotDetail, BotCreateRequest, BotUpdateRequest, HandlePositions } from '../types/bot'
+import type {
+  BotBudgetDetail,
+  BotConfig,
+  BotCreateInput,
+  BotDetailView,
+  BotLog,
+  BotLogResult,
+  BotMode,
+  BotPosition,
+  BotStatus,
+  BotStrategy,
+  BotUpdateInput,
+  BotView,
+  HandlePositions,
+} from '../types/bot'
+import type {
+  BotCreateRequest,
+  BotDetailResponse,
+  BotInfo,
+  BotListResponse,
+  BotUpdateRequest,
+} from '../types/api.generated'
 
-function mapBot(raw: Record<string, unknown>): Bot {
-  const mapped: Record<string, unknown> = {
-    ...raw,
-    strategy_name: raw.strategy_name ?? raw.strategy_id,
-    mode: raw.mode ?? raw.bot_type,
-  }
+type BotInfoWithExtra = BotInfo & Record<string, unknown>
 
-  // config 블록이 없으면 flat 필드에서 조립
-  if (!mapped.config && raw.auto_restart !== undefined) {
-    mapped.config = {
-      interval_seconds: raw.interval_seconds as number,
-      auto_restart: raw.auto_restart as boolean,
-      max_restart_attempts: raw.max_restart_attempts as number,
-      restart_cooldown_seconds: raw.restart_cooldown_seconds as number,
-      step_timeout_seconds: raw.step_timeout_seconds as number,
-      max_signals_per_step: raw.max_signals_per_step as number,
+const BOT_STATUSES = new Set<BotStatus>([
+  'created',
+  'running',
+  'stopping',
+  'stopped',
+  'error',
+  'deleted',
+])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function stringValue(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+function numberValue(value: unknown, fallback = 0): number {
+  return typeof value === 'number' ? value : fallback
+}
+
+function booleanValue(value: unknown, fallback = false): boolean {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function toBotStatus(value: string): BotStatus {
+  return BOT_STATUSES.has(value as BotStatus) ? (value as BotStatus) : 'error'
+}
+
+function toBotMode(value: unknown): BotMode {
+  return value === 'live' ? 'live' : 'paper'
+}
+
+function toStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function toBotConfig(raw: BotInfoWithExtra): BotConfig | undefined {
+  if (isRecord(raw.config)) {
+    return {
+      interval_seconds: numberValue(raw.config.interval_seconds, raw.interval_seconds),
+      auto_restart: booleanValue(raw.config.auto_restart),
+      max_restart_attempts: numberValue(raw.config.max_restart_attempts),
+      restart_cooldown_seconds: numberValue(raw.config.restart_cooldown_seconds),
+      step_timeout_seconds: numberValue(raw.config.step_timeout_seconds),
+      max_signals_per_step: numberValue(raw.config.max_signals_per_step),
     }
   }
 
-  return mapped as unknown as Bot
+  if (raw.auto_restart === undefined) return undefined
+
+  return {
+    interval_seconds: numberValue(raw.interval_seconds, raw.interval_seconds),
+    auto_restart: booleanValue(raw.auto_restart),
+    max_restart_attempts: numberValue(raw.max_restart_attempts),
+    restart_cooldown_seconds: numberValue(raw.restart_cooldown_seconds),
+    step_timeout_seconds: numberValue(raw.step_timeout_seconds),
+    max_signals_per_step: numberValue(raw.max_signals_per_step),
+  }
 }
 
-export async function getBots(): Promise<{ items: Bot[] }> {
-  const res = await client.get('/api/bots')
-  const bots = (res.data.bots ?? []) as Record<string, unknown>[]
-  return { items: bots.map(mapBot) }
+function toBotStrategy(value: unknown): BotStrategy | undefined {
+  if (!isRecord(value)) return undefined
+  return {
+    name: stringValue(value.name),
+    version: stringValue(value.version),
+    author_name: stringValue(value.author_name),
+    author_id: stringValue(value.author_id),
+    description: stringValue(value.description),
+  }
 }
 
-export async function getBotDetail(botId: string): Promise<BotDetail> {
-  const res = await client.get(`/api/bots/${botId}`)
-  const raw = res.data.bot ?? res.data
-  return mapBot(raw) as BotDetail
+function toBotBudgetDetail(value: unknown): BotBudgetDetail | undefined {
+  if (!isRecord(value)) return undefined
+  return {
+    allocated: numberValue(value.allocated),
+    spent: numberValue(value.spent),
+    reserved: numberValue(value.reserved),
+    available: numberValue(value.available),
+  }
 }
 
-export async function createBot(data: BotCreateRequest): Promise<Bot> {
-  const res = await client.post('/api/bots', data)
-  return res.data
+function toBotPosition(value: unknown): BotPosition | undefined {
+  if (!isRecord(value) || typeof value.symbol !== 'string') return undefined
+  return {
+    symbol: value.symbol,
+    quantity: numberValue(value.quantity),
+    avg_entry_price: numberValue(value.avg_entry_price),
+    current_price: typeof value.current_price === 'number' ? value.current_price : undefined,
+    realized_pnl: numberValue(value.realized_pnl),
+  }
+}
+
+function toBotLogResult(value: unknown): BotLogResult | undefined {
+  return value === 'success' || value === 'failure' || value === 'stopped' ? value : undefined
+}
+
+function toBotLog(value: unknown): BotLog | undefined {
+  if (!isRecord(value)) return undefined
+  return {
+    timestamp: stringValue(value.timestamp),
+    success: booleanValue(value.success),
+    result: toBotLogResult(value.result),
+    message: optionalString(value.message),
+  }
+}
+
+function toBotView(raw: BotInfo): BotView {
+  const extra = raw as BotInfoWithExtra
+  return {
+    bot_id: raw.bot_id,
+    name: raw.name,
+    strategy_name: raw.strategy_name ?? raw.strategy_id,
+    status: toBotStatus(raw.status),
+    mode: toBotMode(extra.mode ?? extra.bot_type),
+    interval_seconds: raw.interval_seconds,
+    created_at: stringValue(extra.created_at),
+  }
+}
+
+function toBotDetailView(raw: BotInfo): BotDetailView {
+  const extra = raw as BotInfoWithExtra
+  const positions = Array.isArray(extra.positions)
+    ? extra.positions.map(toBotPosition).filter((pos): pos is BotPosition => pos !== undefined)
+    : undefined
+  const logs = Array.isArray(extra.logs)
+    ? extra.logs.map(toBotLog).filter((log): log is BotLog => log !== undefined)
+    : []
+
+  return {
+    ...toBotView(raw),
+    interval_seconds: raw.interval_seconds,
+    symbols: toStringArray(extra.symbols),
+    allocated_budget: numberValue(extra.allocated_budget),
+    logs,
+    strategy: toBotStrategy(extra.strategy),
+    strategy_author_name: raw.strategy_author_name ?? undefined,
+    strategy_author_id: raw.strategy_author_id ?? undefined,
+    config: toBotConfig(extra),
+    budget: toBotBudgetDetail(extra.budget),
+    positions,
+  }
+}
+
+function toBotCreateRequest(data: BotCreateInput): BotCreateRequest {
+  return {
+    bot_id: data.bot_id,
+    name: data.name ?? '',
+    strategy_id: data.strategy_id ?? null,
+    strategy_name: data.strategy_name ?? null,
+    account_id: data.account_id ?? null,
+    interval_seconds: data.interval_seconds ?? 60,
+    budget: data.budget ?? null,
+  }
+}
+
+function toBotUpdateRequest(data: BotUpdateInput): BotUpdateRequest {
+  return {
+    name: data.name ?? null,
+    strategy_name: data.strategy_name ?? null,
+    interval_seconds: data.interval_seconds ?? null,
+    budget: data.budget ?? null,
+    auto_restart: data.auto_restart ?? null,
+    max_restart_attempts: data.max_restart_attempts ?? null,
+    restart_cooldown_seconds: data.restart_cooldown_seconds ?? null,
+    step_timeout_seconds: data.step_timeout_seconds ?? null,
+    max_signals_per_step: data.max_signals_per_step ?? null,
+  }
+}
+
+export async function getBots(): Promise<{ items: BotView[] }> {
+  const res = await client.get<BotListResponse>('/api/bots')
+  return { items: res.data.bots.map(toBotView) }
+}
+
+export async function getBotDetail(botId: string): Promise<BotDetailView> {
+  const res = await client.get<BotDetailResponse>(`/api/bots/${botId}`)
+  return toBotDetailView(res.data.bot)
+}
+
+export async function createBot(data: BotCreateInput): Promise<BotView> {
+  const res = await client.post<BotDetailResponse>('/api/bots', toBotCreateRequest(data))
+  return toBotDetailView(res.data.bot)
 }
 
 export async function startBot(botId: string): Promise<void> {
-  await client.post(`/api/bots/${botId}/start`)
+  await client.post<BotDetailResponse>(`/api/bots/${botId}/start`)
 }
 
 export async function stopBot(botId: string): Promise<void> {
-  await client.post(`/api/bots/${botId}/stop`)
+  await client.post<BotDetailResponse>(`/api/bots/${botId}/stop`)
 }
 
-export async function updateBot(botId: string, data: BotUpdateRequest): Promise<BotDetail> {
-  const res = await client.put(`/api/bots/${botId}`, data)
-  const raw = res.data.bot ?? res.data
-  return mapBot(raw) as BotDetail
+export async function updateBot(botId: string, data: BotUpdateInput): Promise<BotDetailView> {
+  const res = await client.put<BotDetailResponse>(`/api/bots/${botId}`, toBotUpdateRequest(data))
+  return toBotDetailView(res.data.bot)
 }
 
 export async function deleteBot(botId: string, handlePositions?: HandlePositions): Promise<void> {
-  await client.delete(`/api/bots/${botId}`, {
+  await client.delete<void>(`/api/bots/${botId}`, {
     params: handlePositions ? { handle_positions: handlePositions } : undefined,
   })
 }

--- a/frontend/src/hooks/useBots.ts
+++ b/frontend/src/hooks/useBots.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getBots, getBotDetail, createBot, updateBot, startBot, stopBot, deleteBot } from '../api/bots'
-import type { BotCreateRequest, BotUpdateRequest, HandlePositions } from '../types/bot'
+import type { BotCreateInput, BotUpdateInput, HandlePositions } from '../types/bot'
 
 export function useBots() {
   return useQuery({
@@ -20,7 +20,7 @@ export function useBotDetail(botId: string) {
 export function useCreateBot() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (data: BotCreateRequest) => createBot(data),
+    mutationFn: (data: BotCreateInput) => createBot(data),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['bots'] }),
   })
 }
@@ -28,7 +28,7 @@ export function useCreateBot() {
 export function useBotUpdate() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: ({ botId, data }: { botId: string; data: BotUpdateRequest }) => updateBot(botId, data),
+    mutationFn: ({ botId, data }: { botId: string; data: BotUpdateInput }) => updateBot(botId, data),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['bots', variables.botId] })
       queryClient.invalidateQueries({ queryKey: ['bots'] })

--- a/frontend/src/types/account.ts
+++ b/frontend/src/types/account.ts
@@ -1,13 +1,13 @@
 /**
  * Account 도메인 타입.
  *
- * 백엔드 AccountResponse 스키마 기반.
- * api.generated.ts에 Account 타입이 아직 없으므로 프론트엔드에서 명시 정의한다.
+ * `api.generated.ts`의 AccountResponse raw contract를
+ * `frontend/src/api/accounts.ts` adapter가 UI/domain model로 변환한다.
  */
 
-export type AccountStatus = 'active' | 'suspended' | 'deleted'
+export type AccountStatus = 'active' | 'suspended' | 'deleted' | (string & {})
 
-export interface Account {
+export interface AccountView {
   account_id: string
   name: string
   exchange: string
@@ -24,3 +24,5 @@ export interface Account {
   created_at: string
   updated_at: string
 }
+
+export type Account = AccountView

--- a/frontend/src/types/bot.ts
+++ b/frontend/src/types/bot.ts
@@ -1,15 +1,15 @@
 /**
  * Bot 도메인 타입.
  *
- * API 응답 타입은 api.generated.ts에서 자동 생성된 타입을 사용한다.
- * 백엔드가 dict 기반(extra="allow") 응답을 반환하므로 상세 필드를 프론트엔드에서 명시한다.
+ * `api.generated.ts`의 BotInfo raw contract를
+ * `frontend/src/api/bots.ts` adapter가 UI/domain model로 변환한다.
  */
 
 // ── 프론트엔드 전용 타입 ──────────────────────────────────
 export type BotStatus = 'created' | 'running' | 'stopping' | 'stopped' | 'error' | 'deleted'
 export type BotMode = 'live' | 'paper'
 
-export interface Bot {
+export interface BotView {
   bot_id: string
   name: string
   strategy_name?: string
@@ -18,6 +18,8 @@ export interface Bot {
   interval_seconds?: number
   created_at: string
 }
+
+export type Bot = BotView
 
 export interface BotConfig {
   interval_seconds: number
@@ -51,7 +53,7 @@ export interface BotPosition {
   realized_pnl: number
 }
 
-export interface BotDetail extends Bot {
+export interface BotDetailView extends BotView {
   interval_seconds: number
   symbols: string[]
   allocated_budget: number
@@ -64,6 +66,8 @@ export interface BotDetail extends Bot {
   positions?: BotPosition[]
 }
 
+export type BotDetail = BotDetailView
+
 export type BotLogResult = 'success' | 'failure' | 'stopped'
 
 export interface BotLog {
@@ -73,7 +77,7 @@ export interface BotLog {
   message?: string
 }
 
-export interface BotCreateRequest {
+export interface BotCreateInput {
   bot_id: string
   name?: string
   strategy_id?: string
@@ -83,7 +87,7 @@ export interface BotCreateRequest {
   budget?: number
 }
 
-export interface BotUpdateRequest {
+export interface BotUpdateInput {
   name?: string
   strategy_name?: string
   interval_seconds?: number


### PR DESCRIPTION
## Summary
- map generated Account and Bot raw contracts into frontend View models
- rename Bot create/update UI payload types to Input names
- remove Bot mapper `as unknown as` casting and add generated generics to Account/Bot adapter calls

## Verification
- PASS `cd frontend && npm run check-api-types`
- PASS `cd frontend && npm run build`
- PASS `git diff --check`
- PASS Account/Bot forbidden-pattern greps

Closes #1223