### PR TITLE
feat(frontend): align treasury portfolio adapter views

### DIFF
--- a/frontend/src/api/portfolio.ts
+++ b/frontend/src/api/portfolio.ts
@@ -1,12 +1,42 @@
 import client from './client'
-import type { PortfolioValue, PortfolioHistoryPoint, Period } from '../types/portfolio'
+import type {
+  PortfolioHistoryPointView,
+  PortfolioValueView,
+  Period,
+} from '../types/portfolio'
+import type {
+  PortfolioHistoryPoint,
+  PortfolioHistoryResponse,
+  PortfolioValueResponse,
+} from '../types/api.generated'
 
-export async function getPortfolioValue(): Promise<PortfolioValue> {
-  const res = await client.get('/api/portfolio/value')
-  return res.data
+function toPortfolioValueView(raw: PortfolioValueResponse): PortfolioValueView {
+  return {
+    total_value: raw.total_value,
+    daily_pnl: raw.daily_pnl,
+    daily_return: raw.daily_return,
+    unrealized_pnl: raw.unrealized_pnl,
+    updated_at: raw.updated_at,
+    snapshot_date: raw.snapshot_date,
+  }
 }
 
-export async function getPortfolioHistory(period: Period): Promise<PortfolioHistoryPoint[]> {
-  const res = await client.get('/api/portfolio/history', { params: { period } })
-  return res.data
+function toPortfolioHistoryPointView(raw: PortfolioHistoryPoint): PortfolioHistoryPointView {
+  return {
+    date: raw.date,
+    total_asset: raw.total_asset,
+    daily_pnl: raw.daily_pnl,
+    daily_return: raw.daily_return,
+    unrealized_pnl: raw.unrealized_pnl,
+  }
+}
+
+export async function getPortfolioValue(): Promise<PortfolioValueView> {
+  const res = await client.get<PortfolioValueResponse>('/api/portfolio/value')
+  return toPortfolioValueView(res.data)
+}
+
+export async function getPortfolioHistory(period: Period): Promise<PortfolioHistoryPointView[]> {
+  const res = await client.get<PortfolioHistoryResponse>('/api/portfolio/history', { params: { period } })
+  return res.data.data.map(toPortfolioHistoryPointView)
 }

--- a/frontend/src/api/treasury.ts
+++ b/frontend/src/api/treasury.ts
@@ -1,31 +1,144 @@
 import client from './client'
-import type { TreasurySummary, BotBudget, TreasuryTransaction, TreasurySnapshot } from '../types/treasury'
+import type {
+  BotBudgetView,
+  TreasurySummaryView,
+  TreasuryTransactionView,
+  TreasurySnapshotView,
+} from '../types/treasury'
+import type {
+  BudgetChangeRequest,
+  BudgetItem,
+  BudgetListResponse,
+  BudgetOperationResponse,
+  SnapshotItem,
+  SnapshotListResponse,
+  TransactionItem,
+  TransactionListResponse,
+  TreasurySummaryResponse,
+} from '../types/api.generated'
 
-export async function getTreasurySummary(): Promise<TreasurySummary> {
-  const res = await client.get('/api/treasury')
-  return res.data
+type ExtraRecord = Record<string, unknown>
+
+function extra(raw: object): ExtraRecord {
+  return raw as ExtraRecord
+}
+
+function numberValue(value: unknown, fallback = 0): number {
+  return typeof value === 'number' ? value : fallback
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function optionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined
+}
+
+function toTreasurySummaryView(raw: TreasurySummaryResponse): TreasurySummaryView {
+  const e = extra(raw)
+  return {
+    total_allocated: raw.total_allocated,
+    total_balance: raw.total_balance,
+    total_evaluation: raw.total_evaluation,
+    total_profit_loss: raw.total_profit_loss,
+    unallocated: raw.unallocated,
+    commission_rate: raw.commission_rate,
+    sell_tax_rate: raw.sell_tax_rate,
+    broker_id: raw.broker_id ?? undefined,
+    broker_name: raw.broker_name ?? undefined,
+    broker_short_name: raw.broker_short_name ?? undefined,
+    exchange: raw.exchange ?? undefined,
+    account_no: raw.account_no ?? undefined,
+    is_virtual: raw.is_virtual ?? undefined,
+    synced_at: raw.synced_at ?? undefined,
+    account_balance: numberValue(e.account_balance, raw.total_balance),
+    purchasable_amount: numberValue(e.purchasable_amount),
+    account_number: optionalString(e.account_number) ?? raw.account_no ?? undefined,
+    is_demo_trading: optionalBoolean(e.is_demo_trading) ?? raw.is_virtual ?? undefined,
+    last_sync_time: optionalString(e.last_sync_time) ?? raw.synced_at ?? undefined,
+    total_reserved: numberValue(e.total_reserved),
+    total_available: numberValue(e.total_available, raw.unallocated),
+    bot_count: numberValue(e.bot_count),
+    ante_purchase_amount: numberValue(e.ante_purchase_amount),
+    ante_eval_amount: numberValue(e.ante_eval_amount),
+    ante_profit_loss: numberValue(e.ante_profit_loss),
+    budget_exceeds_purchasable: optionalBoolean(e.budget_exceeds_purchasable),
+  }
+}
+
+function toBotBudgetView(raw: BudgetItem): BotBudgetView {
+  const e = extra(raw)
+  return {
+    bot_id: raw.bot_id,
+    allocated: raw.allocated,
+    available: raw.available,
+    reserved: raw.reserved,
+    spent: raw.spent,
+    returned: raw.returned,
+    eval_amount: numberValue(e.eval_amount),
+    position_pnl: numberValue(e.position_pnl),
+    position_return: numberValue(e.position_return),
+  }
+}
+
+function toTreasurySnapshotView(raw: SnapshotItem): TreasurySnapshotView {
+  return {
+    account_id: raw.account_id,
+    snapshot_date: raw.snapshot_date,
+    total_asset: raw.total_asset,
+    ante_eval_amount: raw.ante_eval_amount,
+    ante_purchase_amount: raw.ante_purchase_amount,
+    unallocated: raw.unallocated,
+    account_balance: raw.account_balance,
+    total_allocated: raw.total_allocated,
+    bot_count: raw.bot_count,
+    daily_pnl: raw.daily_pnl,
+    daily_return: raw.daily_return,
+    net_trade_amount: raw.net_trade_amount,
+    unrealized_pnl: raw.unrealized_pnl,
+    created_at: raw.created_at,
+  }
+}
+
+function toTreasuryTransactionView(raw: TransactionItem): TreasuryTransactionView {
+  return {
+    id: raw.id,
+    type: raw.type,
+    bot_id: raw.bot_id ?? undefined,
+    amount: raw.amount,
+    description: raw.description,
+    created_at: raw.created_at,
+  }
+}
+
+export async function getTreasurySummary(): Promise<TreasurySummaryView> {
+  const res = await client.get<TreasurySummaryResponse>('/api/treasury')
+  return toTreasurySummaryView(res.data)
 }
 
 export async function getTreasurySnapshots(params: {
   account_id?: string
   start_date?: string
   end_date?: string
-}): Promise<TreasurySnapshot[]> {
-  const res = await client.get('/api/treasury/snapshots', { params })
-  return res.data.snapshots ?? []
+}): Promise<TreasurySnapshotView[]> {
+  const res = await client.get<SnapshotListResponse>('/api/treasury/snapshots', { params })
+  return res.data.snapshots.map(toTreasurySnapshotView)
 }
 
-export async function getBotBudgets(): Promise<BotBudget[]> {
-  const res = await client.get('/api/treasury/budgets')
-  return res.data.budgets ?? res.data
+export async function getBotBudgets(): Promise<BotBudgetView[]> {
+  const res = await client.get<BudgetListResponse>('/api/treasury/budgets')
+  return res.data.budgets.map(toBotBudgetView)
 }
 
 export async function allocateBudget(botId: string, amount: number): Promise<void> {
-  await client.post(`/api/treasury/bots/${botId}/allocate`, { amount })
+  const body: BudgetChangeRequest = { amount }
+  await client.post<BudgetOperationResponse>(`/api/treasury/bots/${botId}/allocate`, body)
 }
 
 export async function deallocateBudget(botId: string, amount: number): Promise<void> {
-  await client.post(`/api/treasury/bots/${botId}/deallocate`, { amount })
+  const body: BudgetChangeRequest = { amount }
+  await client.post<BudgetOperationResponse>(`/api/treasury/bots/${botId}/deallocate`, body)
 }
 
 export async function getTreasuryTransactions(params: {
@@ -35,7 +148,10 @@ export async function getTreasuryTransactions(params: {
   bot_id?: string
   start_date?: string
   end_date?: string
-}): Promise<{ items: TreasuryTransaction[]; total: number }> {
-  const res = await client.get('/api/treasury/transactions', { params })
-  return res.data
+}): Promise<{ items: TreasuryTransactionView[]; total: number }> {
+  const res = await client.get<TransactionListResponse>('/api/treasury/transactions', { params })
+  return {
+    items: res.data.items.map(toTreasuryTransactionView),
+    total: res.data.total,
+  }
 }

--- a/frontend/src/types/portfolio.ts
+++ b/frontend/src/types/portfolio.ts
@@ -1,19 +1,36 @@
 /**
  * Portfolio 도메인 타입.
  *
- * API 응답 타입은 api.generated.ts에서 자동 생성된 타입을 사용한다.
- * 프론트엔드 전용 타입(Period 등)만 이 파일에 직접 정의한다.
+ * `api.generated.ts`의 Portfolio raw contract를
+ * `frontend/src/api/portfolio.ts` adapter가 UI/domain model로 변환한다.
  */
-import type {
-  PortfolioValueResponse,
-  PortfolioHistoryPoint as GeneratedPortfolioHistoryPoint,
-  PortfolioHistoryResponse,
-} from './api.generated'
 
-// ── API 응답 타입 re-export ──────────────────────────────
-export type PortfolioValue = PortfolioValueResponse
-export type PortfolioHistoryPoint = GeneratedPortfolioHistoryPoint
-export type { PortfolioHistoryResponse }
+export interface PortfolioValueView {
+  total_value: number
+  daily_pnl: number
+  daily_return: number
+  unrealized_pnl: number
+  updated_at: string
+  snapshot_date?: string | null
+}
+
+export type PortfolioValue = PortfolioValueView
+
+export interface PortfolioHistoryPointView {
+  date: string
+  total_asset: number
+  daily_pnl: number
+  daily_return: number
+  unrealized_pnl: number
+}
+
+export type PortfolioHistoryPoint = PortfolioHistoryPointView
+
+export interface PortfolioHistoryView {
+  data: PortfolioHistoryPointView[]
+  start_date: string
+  end_date: string
+}
 
 // ── 프론트엔드 전용 타입 ──────────────────────────────────
 export type Period = '1d' | '1w' | '1m' | '3m' | 'all'

--- a/frontend/src/types/treasury.ts
+++ b/frontend/src/types/treasury.ts
@@ -1,36 +1,32 @@
 /**
  * Treasury 도메인 타입.
  *
- * API 응답 타입은 api.generated.ts에서 자동 생성된 타입을 사용한다.
- * generated TreasurySummaryResponse에 index signature가 있어
- * 동적 필드가 unknown이 되므로 프론트엔드에서 확장 정의한다.
+ * `api.generated.ts`의 Treasury raw contract를
+ * `frontend/src/api/treasury.ts` adapter가 UI/domain model로 변환한다.
  */
-import type {
-  TransactionItem,
-  BudgetOperationResponse,
-  BalanceSetResponse,
-  TreasurySummaryResponse,
-} from './api.generated'
-
-// ── API 응답 타입 re-export (generated 완전 대응) ────────
-export type { BudgetOperationResponse, BalanceSetResponse }
-export type TreasuryTransaction = TransactionItem
 
 // ── 프론트엔드 전용 타입 ──────────────────────────────────
 
-/**
- * 자금관리 요약.
- * generated TreasurySummaryResponse를 기반으로, 백엔드가 extra="allow"로
- * 동적 반환하는 필드를 명시적으로 추가 정의한다.
- */
-export interface TreasurySummary extends TreasurySummaryResponse {
-  // KIS 계좌 추가 필드
+export interface TreasurySummaryView {
+  total_allocated: number
+  total_balance: number
+  total_evaluation: number
+  total_profit_loss: number
+  unallocated: number
+  commission_rate: number
+  sell_tax_rate: number
+  broker_id?: string
+  broker_name?: string
+  broker_short_name?: string
+  exchange?: string
+  account_no?: string
+  is_virtual?: boolean
+  synced_at?: string
   account_balance?: number
   purchasable_amount?: number
   account_number?: string
   is_demo_trading?: boolean
   last_sync_time?: string | null
-  // Ante 관리자산 추가 필드
   total_reserved?: number
   total_available?: number
   bot_count?: number
@@ -40,8 +36,10 @@ export interface TreasurySummary extends TreasurySummaryResponse {
   budget_exceeds_purchasable?: boolean
 }
 
+export type TreasurySummary = TreasurySummaryView
+
 /** 봇별 예산 상세 -- 백엔드가 dict 기반 응답을 반환하므로 프론트엔드에서 명시 */
-export interface BotBudget {
+export interface BotBudgetView {
   bot_id: string
   allocated: number
   available: number
@@ -53,10 +51,23 @@ export interface BotBudget {
   position_return: number
 }
 
+export type BotBudget = BotBudgetView
+
 export type TransactionType = 'allocate' | 'deallocate' | 'fill' | 'bot_stopped_release'
 
+export interface TreasuryTransactionView {
+  id: number
+  type: string
+  bot_id?: string | null
+  amount: number
+  description: string
+  created_at: string
+}
+
+export type TreasuryTransaction = TreasuryTransactionView
+
 /** 일별 자산 스냅샷 -- 백엔드 SnapshotItem 대응 */
-export interface TreasurySnapshot {
+export interface TreasurySnapshotView {
   account_id: string
   snapshot_date: string
   total_asset: number
@@ -72,3 +83,5 @@ export interface TreasurySnapshot {
   unrealized_pnl: number
   created_at: string
 }
+
+export type TreasurySnapshot = TreasurySnapshotView


### PR DESCRIPTION
## Summary
- map generated Treasury and Portfolio raw contracts into frontend View models
- remove generated type imports/re-exports from Treasury/Portfolio UI type files
- add generated generics and request contracts to Treasury/Portfolio adapter calls

## Verification
- PASS `cd frontend && npm run check-api-types`
- PASS `cd frontend && npm run build`
- PASS `git diff --check`
- PASS generated import boundary grep

Closes #1224