### PR TITLE
docs(db): align schema constant convention

### DIFF
--- a/.agent/skills/module-conventions.md
+++ b/.agent/skills/module-conventions.md
@@ -262,13 +262,15 @@ total = price * quantity
 
 ## 11. DDL 컨벤션 (db-schema.md SSOT)
 
-모든 모듈의 테이블 정의는 모듈 레벨 `_DDL` 문자열 상수로 관리한다. 이 상수가 `docs/architecture/generated/db-schema.md` 자동 생성의 원본(SSOT)이다.
+모든 모듈의 테이블 정의는 모듈 레벨 `*_SCHEMA` 문자열 상수로 관리한다. 이 상수가 `docs/architecture/generated/db-schema.md` 자동 생성의 원본(SSOT)이다.
+
+기존 Account 모듈의 `_CREATE_TABLE_SQL`은 legacy 예외로만 허용한다. 새 테이블 정의에는 `*_SCHEMA`를 사용한다.
 
 ### 규칙
 
-- 새 테이블 추가 시 해당 모듈의 `store.py` 또는 `service.py`에 `_DDL` 상수 필수
-- `_DDL`에 `CREATE TABLE IF NOT EXISTS`와 `CREATE INDEX IF NOT EXISTS`를 모두 포함
-- 스키마 변경 시 `_DDL`을 먼저 수정 → `python scripts/generate_db_schema.py` 실행으로 문서 재생성
+- 새 테이블 추가 시 해당 모듈의 `store.py` 또는 `service.py`에 `{DOMAIN}_SCHEMA` 상수 필수
+- `{DOMAIN}_SCHEMA`에 `CREATE TABLE IF NOT EXISTS`와 `CREATE INDEX IF NOT EXISTS`를 모두 포함
+- 스키마 변경 시 `{DOMAIN}_SCHEMA`를 먼저 수정 → `python scripts/generate_db_schema.py` 실행으로 문서 재생성
 - `docs/architecture/generated/db-schema.md`를 직접 편집하지 않는다 (스크립트가 SSOT)
 
 ### 패턴
@@ -276,7 +278,7 @@ total = price * quantity
 ```python
 # src/ante/{모듈}/store.py
 
-_DDL = """
+{DOMAIN}_SCHEMA = """
 CREATE TABLE IF NOT EXISTS {테이블명} (
     id        TEXT PRIMARY KEY,
     name      TEXT NOT NULL,

--- a/scripts/generate_db_schema.py
+++ b/scripts/generate_db_schema.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """*_SCHEMA 상수 파싱 기반 DB 스키마 문서 자동 생성.
 
-src/ante/ 하위 모든 .py 파일에서 *_SCHEMA 상수(및 특수 명명 패턴)를 찾아
-DDL을 파싱하고 docs/architecture/generated/db-schema.md를 생성한다.
+src/ante/ 하위 모든 .py 파일에서 공식 DDL 상수인 *_SCHEMA를 찾고,
+legacy 예외인 _CREATE_TABLE_SQL을 함께 파싱하여
+docs/architecture/generated/db-schema.md를 생성한다.
 
 SSOT: 모듈 소스 코드 내 DDL 상수 -> docs/architecture/generated/db-schema.md (자동 생성)
 
@@ -97,12 +98,12 @@ LOGICAL_RELATIONS: list[tuple[str, str, str, str]] = [
 
 # ── AST 기반 스키마 상수 추출 ──────────────────────────────────────────
 
-# *_SCHEMA 상수 + account 모듈의 _CREATE_TABLE_SQL 패턴
+# 공식 *_SCHEMA 상수 + account 모듈의 legacy _CREATE_TABLE_SQL 예외
 _SCHEMA_NAME_RE = re.compile(r"^[A-Z_]*SCHEMA$|^_CREATE_TABLE_SQL$")
 
 
 def _extract_schema_constants(filepath: Path) -> list[tuple[str, str, str]]:
-    """AST를 사용하여 파일에서 *_SCHEMA 상수를 추출한다.
+    """AST를 사용하여 파일에서 공식 스키마 상수를 추출한다.
 
     Returns:
         (상수명, DDL 문자열, 모듈 경로) 튜플 리스트
@@ -256,7 +257,7 @@ class IndexInfo:
 
 
 def collect_schemas() -> tuple[list[TableInfo], list[IndexInfo], str]:
-    """src/ante/ 하위에서 모든 *_SCHEMA 상수를 수집하고 파싱한다.
+    """src/ante/ 하위에서 공식 스키마 상수를 수집하고 파싱한다.
 
     Returns:
         (테이블 리스트, 인덱스 리스트, 전체 DDL 문자열)

--- a/tests/unit/test_generate_db_schema.py
+++ b/tests/unit/test_generate_db_schema.py
@@ -1,0 +1,12 @@
+from scripts import generate_db_schema
+
+
+def test_schema_name_pattern_collects_official_schema_constants() -> None:
+    assert generate_db_schema._SCHEMA_NAME_RE.match("ORDER_REGISTRY_SCHEMA")
+    assert generate_db_schema._SCHEMA_NAME_RE.match("TREASURY_SCHEMA")
+    assert generate_db_schema._SCHEMA_NAME_RE.match("_CREATE_TABLE_SQL")
+
+
+def test_schema_name_pattern_does_not_collect_ddl_suffix() -> None:
+    assert generate_db_schema._SCHEMA_NAME_RE.match("ORDER_REGISTRY_DDL") is None
+    assert generate_db_schema._SCHEMA_NAME_RE.match("_DDL") is None


### PR DESCRIPTION
## Summary
- Align agent module DDL convention with the existing `*_SCHEMA` generator contract.
- Document `_CREATE_TABLE_SQL` as the Account legacy exception only.
- Add focused tests for `_SCHEMA_NAME_RE` collection and non-collection behavior.

## Verification
- `/Users/jingulee/Projects/ante/.venv/bin/python -m ruff check scripts/generate_db_schema.py tests/unit/test_generate_db_schema.py`
- `/Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/test_generate_db_schema.py -q`
- `/Users/jingulee/Projects/ante/.venv/bin/python scripts/generate_db_schema.py --stdout`
- `git diff --check`

Closes #1229