### PR TITLE
test(db): fix schema generator test import

### DIFF
--- a/tests/unit/test_generate_db_schema.py
+++ b/tests/unit/test_generate_db_schema.py
@@ -1,4 +1,13 @@
-from scripts import generate_db_schema
+import importlib.util
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "generate_db_schema.py"
+_SPEC = importlib.util.spec_from_file_location("generate_db_schema", _SCRIPT_PATH)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+
+generate_db_schema = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(generate_db_schema)
 
 
 def test_schema_name_pattern_collects_official_schema_constants() -> None:


### PR DESCRIPTION
## Summary
- Follow-up for #1229 after #1254 merged before the remote test failure was visible.
- Load `scripts/generate_db_schema.py` by file path in the focused test so CI does not depend on `scripts` being importable as a package.

## Verification
- `/Users/jingulee/Projects/ante/.venv/bin/python -m ruff check tests/unit/test_generate_db_schema.py scripts/generate_db_schema.py`
- `/Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/test_generate_db_schema.py -q`
- `git diff --check origin/main..HEAD`

Refs #1229