### PR TITLE
feat(broker): make order registry account-aware

### DIFF
--- a/docs/specs/broker-adapter/15-reconciliation.md
+++ b/docs/specs/broker-adapter/15-reconciliation.md
@@ -20,31 +20,33 @@ PositionReconciler는 `TradeService`, `EventBus`를 주입받아 동작한다.
 
 구현: `src/ante/broker/order_registry.py` 참조
 
-복수 봇이 같은 계좌에서 거래할 때, 브로커가 반환하는 order_id가 어느 봇의 주문인지 추적하기 위한 매핑 테이블이다. 주문 제출 시 `register(order_id, bot_id, symbol)`로 등록하고, 대사 시 `get_bot_id(order_id)`로 조회한다.
+복수 봇이 같은 계좌에서 거래할 때, 브로커가 반환하는 order_id가 어느 봇의 주문인지 추적하기 위한 매핑 테이블이다. 주문 제출 시 `register(order_id, account_id, bot_id, symbol)`로 등록하고, 대사 시 `get_bot_id(order_id, account_id)`로 조회한다.
 
 **SQLite 스키마**:
 ```sql
 CREATE TABLE IF NOT EXISTS order_registry (
     order_id    TEXT PRIMARY KEY,
+    account_id  TEXT NOT NULL,
     bot_id      TEXT NOT NULL,
     symbol      TEXT NOT NULL,
-    account_id  TEXT DEFAULT 'default',
     created_at  TEXT DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_order_registry_bot
     ON order_registry(bot_id);
 CREATE INDEX IF NOT EXISTS idx_order_registry_account
     ON order_registry(account_id);
+CREATE INDEX IF NOT EXISTS idx_order_registry_account_bot
+    ON order_registry(account_id, bot_id);
 ```
 
-**마이그레이션**: `initialize()` 시 `exchange TEXT DEFAULT 'KRX'` 컬럼 자동 추가 (v0.2). `account_id TEXT DEFAULT 'default'` 컬럼 자동 추가 (v0.3).
+**마이그레이션**: 1.0 이전 fresh schema 기준으로 `account_id`는 필수값이며 fallback default를 두지 않는다. 기존 invalid dev DB 데이터 자동 보존/마이그레이션은 이 계약의 범위가 아니다.
 
 **추가 메서드**:
 
 | 메서드 | 파라미터 | 반환값 | 설명 |
 |--------|----------|--------|------|
-| `get_orders_by_bot` | `bot_id: str` | `list[dict]` | 봇의 모든 주문 조회 |
-| `remove` | `order_id: str` | `None` | 매핑 삭제 |
+| `get_orders_by_bot` | `account_id: str`, `bot_id: str` | `list[dict]` | 특정 계좌 안에서 봇의 모든 주문 조회 |
+| `remove` | `order_id: str`, `account_id: str` | `None` | 특정 계좌의 매핑 삭제 |
 
 **등록 시점**: BrokerAdapter가 주문을 증권사에 제출하고 order_id를 받은 직후, OrderSubmittedEvent 발행 전에 등록한다. 또는 OrderSubmittedEvent를 구독하여 자동 등록한다.
 

--- a/src/ante/broker/order_registry.py
+++ b/src/ante/broker/order_registry.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from ante.account.scoping import require_account_id
+
 if TYPE_CHECKING:
     from ante.core.database import Database
 
@@ -17,12 +19,17 @@ logger = logging.getLogger(__name__)
 ORDER_REGISTRY_SCHEMA = """
 CREATE TABLE IF NOT EXISTS order_registry (
     order_id    TEXT PRIMARY KEY,
+    account_id  TEXT NOT NULL,
     bot_id      TEXT NOT NULL,
     symbol      TEXT NOT NULL,
     created_at  TEXT DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_order_registry_bot
     ON order_registry(bot_id);
+CREATE INDEX IF NOT EXISTS idx_order_registry_account
+    ON order_registry(account_id);
+CREATE INDEX IF NOT EXISTS idx_order_registry_account_bot
+    ON order_registry(account_id, bot_id);
 """
 
 
@@ -40,36 +47,63 @@ class OrderRegistry:
         await self._db.execute_script(ORDER_REGISTRY_SCHEMA)
         logger.info("OrderRegistry 초기화 완료")
 
-    async def register(self, order_id: str, bot_id: str, symbol: str) -> None:
+    async def register(
+        self,
+        order_id: str,
+        account_id: str,
+        bot_id: str,
+        symbol: str,
+    ) -> None:
         """주문 제출 시 매핑 등록."""
+        validated_account_id = require_account_id(
+            account_id, context="order_registry.register"
+        )
         await self._db.execute(
-            """INSERT INTO order_registry (order_id, bot_id, symbol)
-               VALUES (?, ?, ?)
+            """INSERT INTO order_registry (order_id, account_id, bot_id, symbol)
+               VALUES (?, ?, ?, ?)
                ON CONFLICT(order_id) DO UPDATE SET
+                 account_id = excluded.account_id,
                  bot_id = excluded.bot_id,
                  symbol = excluded.symbol""",
-            (order_id, bot_id, symbol),
+            (order_id, validated_account_id, bot_id, symbol),
         )
-        logger.debug("주문 등록: %s → %s (%s)", order_id, bot_id, symbol)
+        logger.debug(
+            "주문 등록: %s / %s → %s (%s)",
+            validated_account_id,
+            order_id,
+            bot_id,
+            symbol,
+        )
 
-    async def get_bot_id(self, order_id: str) -> str | None:
+    async def get_bot_id(self, order_id: str, account_id: str) -> str | None:
         """order_id로 bot_id 조회."""
+        validated_account_id = require_account_id(
+            account_id, context="order_registry.get_bot_id"
+        )
         row = await self._db.fetch_one(
-            "SELECT bot_id FROM order_registry WHERE order_id = ?",
-            (order_id,),
+            "SELECT bot_id FROM order_registry WHERE order_id = ? AND account_id = ?",
+            (order_id, validated_account_id),
         )
         return row["bot_id"] if row else None
 
-    async def get_orders_by_bot(self, bot_id: str) -> list[dict]:
+    async def get_orders_by_bot(self, account_id: str, bot_id: str) -> list[dict]:
         """봇의 모든 주문 조회."""
+        validated_account_id = require_account_id(
+            account_id, context="order_registry.get_orders_by_bot"
+        )
         return await self._db.fetch_all(
-            "SELECT * FROM order_registry WHERE bot_id = ? ORDER BY created_at DESC",
-            (bot_id,),
+            """SELECT * FROM order_registry
+               WHERE account_id = ? AND bot_id = ?
+               ORDER BY created_at DESC""",
+            (validated_account_id, bot_id),
         )
 
-    async def remove(self, order_id: str) -> None:
+    async def remove(self, order_id: str, account_id: str) -> None:
         """매핑 삭제."""
+        validated_account_id = require_account_id(
+            account_id, context="order_registry.remove"
+        )
         await self._db.execute(
-            "DELETE FROM order_registry WHERE order_id = ?",
-            (order_id,),
+            "DELETE FROM order_registry WHERE order_id = ? AND account_id = ?",
+            (order_id, validated_account_id),
         )

--- a/tests/unit/test_broker.py
+++ b/tests/unit/test_broker.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ante.account.errors import InvalidAccountIdError
 from ante.broker import (
     APIError,
     AuthenticationError,
@@ -447,38 +448,52 @@ class TestOrderRegistry:
 
     async def test_register_and_get(self, registry):
         """주문 등록 및 조회."""
-        await registry.register("ord1", "bot1", "005930")
-        bot_id = await registry.get_bot_id("ord1")
+        await registry.register("ord1", "acc-test", "bot1", "005930")
+        bot_id = await registry.get_bot_id("ord1", "acc-test")
         assert bot_id == "bot1"
 
     async def test_get_nonexistent(self, registry):
         """존재하지 않는 주문 조회."""
-        bot_id = await registry.get_bot_id("nonexistent")
+        bot_id = await registry.get_bot_id("nonexistent", "acc-test")
         assert bot_id is None
 
     async def test_register_upsert(self, registry):
         """중복 등록 시 업데이트."""
-        await registry.register("ord1", "bot1", "005930")
-        await registry.register("ord1", "bot2", "005930")
-        bot_id = await registry.get_bot_id("ord1")
+        await registry.register("ord1", "acc-test", "bot1", "005930")
+        await registry.register("ord1", "acc-test", "bot2", "005930")
+        bot_id = await registry.get_bot_id("ord1", "acc-test")
         assert bot_id == "bot2"
 
     async def test_get_orders_by_bot(self, registry):
         """봇별 주문 조회."""
-        await registry.register("ord1", "bot1", "005930")
-        await registry.register("ord2", "bot1", "000660")
-        await registry.register("ord3", "bot2", "005930")
+        await registry.register("ord1", "acc-test", "bot1", "005930")
+        await registry.register("ord2", "acc-test", "bot1", "000660")
+        await registry.register("ord3", "acc-test", "bot2", "005930")
 
-        orders = await registry.get_orders_by_bot("bot1")
+        orders = await registry.get_orders_by_bot("acc-test", "bot1")
         assert len(orders) == 2
+        assert {order["account_id"] for order in orders} == {"acc-test"}
+
+    async def test_get_orders_by_bot_filters_account(self, registry):
+        """동일 bot_id라도 account_id별 주문만 조회한다."""
+        await registry.register("ord1", "acc-a", "bot1", "005930")
+        await registry.register("ord2", "acc-b", "bot1", "000660")
+
+        orders = await registry.get_orders_by_bot("acc-a", "bot1")
+        assert [order["order_id"] for order in orders] == ["ord1"]
+
+    async def test_register_rejects_invalid_account_id(self, registry):
+        """fallback account_id는 저장하지 않는다."""
+        with pytest.raises(InvalidAccountIdError, match="account_id"):
+            await registry.register("ord1", "default", "bot1", "005930")
 
     async def test_remove(self, registry):
         """매핑 삭제."""
-        await registry.register("ord1", "bot1", "005930")
-        await registry.remove("ord1")
-        bot_id = await registry.get_bot_id("ord1")
+        await registry.register("ord1", "acc-test", "bot1", "005930")
+        await registry.remove("ord1", "acc-test")
+        bot_id = await registry.get_bot_id("ord1", "acc-test")
         assert bot_id is None
 
     async def test_remove_nonexistent(self, registry):
         """존재하지 않는 주문 삭제 (무시)."""
-        await registry.remove("nonexistent")  # should not raise
+        await registry.remove("nonexistent", "acc-test")  # should not raise


### PR DESCRIPTION
Closes #1256

## Summary
- Add required `account_id` storage and account indexes to OrderRegistry fresh schema.
- Require account_id in registry register/query/remove APIs and validate it with Account scoping helper.
- Update OrderRegistry unit tests and reconciliation spec to the same account-aware contract.

## Test Plan
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/test_broker.py -q`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m ruff check src/ante/broker/order_registry.py tests/unit/test_broker.py`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m ruff format --check src/ante/broker/order_registry.py tests/unit/test_broker.py`
- `git diff --check`