### PR TITLE
feat(trade): enforce account-aware trades schema

### DIFF
--- a/docs/specs/trade/03-05-sqlite-schema.md
+++ b/docs/specs/trade/03-05-sqlite-schema.md
@@ -8,7 +8,7 @@
 -- 개별 거래 기록
 CREATE TABLE trades (
     trade_id       TEXT PRIMARY KEY,
-    account_id     TEXT NOT NULL,
+    account_id     TEXT NOT NULL,          -- fallback default 없음
     bot_id         TEXT NOT NULL,
     strategy_id    TEXT NOT NULL,
     symbol         TEXT NOT NULL,
@@ -32,8 +32,14 @@ CREATE INDEX idx_trades_bot ON trades(bot_id, timestamp);
 CREATE INDEX idx_trades_strategy ON trades(strategy_id, timestamp);
 CREATE INDEX idx_trades_symbol ON trades(symbol, timestamp);
 CREATE INDEX idx_trades_status ON trades(status);
+```
 
--- 봇별 종목 포지션 현재 상태
+`trades.account_id`는 fresh schema에서 필수값이며 `DEFAULT 'default'` 같은
+fallback을 두지 않는다. `TradeRecorder`는 저장 직전과 명시 account 조회
+필터에서 Account ID scoping helper로 `None`, 빈 문자열, `default`를 거부한다.
+
+봇별 종목 포지션 현재 상태:
+```sql
 CREATE TABLE positions (
     account_id       TEXT NOT NULL,
     bot_id           TEXT NOT NULL,

--- a/src/ante/trade/recorder.py
+++ b/src/ante/trade/recorder.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from ante.account.errors import InvalidAccountIdError
+from ante.account.scoping import require_account_id
 from ante.trade.models import TradeRecord, TradeStatus
 
 if TYPE_CHECKING:
@@ -33,10 +34,11 @@ CREATE TABLE IF NOT EXISTS trades (
     timestamp      TEXT,
     order_id       TEXT,
     created_at     TEXT DEFAULT (datetime('now')),
-    account_id     TEXT NOT NULL DEFAULT 'default',
+    account_id     TEXT NOT NULL,
     currency       TEXT DEFAULT 'KRW',
     exchange       TEXT DEFAULT 'KRX'
 );
+CREATE INDEX IF NOT EXISTS idx_trades_account ON trades(account_id, timestamp);
 CREATE INDEX IF NOT EXISTS idx_trades_bot ON trades(bot_id, timestamp);
 CREATE INDEX IF NOT EXISTS idx_trades_strategy ON trades(strategy_id, timestamp);
 CREATE INDEX IF NOT EXISTS idx_trades_symbol ON trades(symbol, timestamp);
@@ -225,6 +227,9 @@ class TradeRecorder:
 
     async def _save(self, record: TradeRecord) -> None:
         """거래 기록을 SQLite에 저장."""
+        account_id = require_account_id(
+            record.account_id, context="trade_recorder._save"
+        )
         await self._db.execute(
             """INSERT OR IGNORE INTO trades
                (trade_id, bot_id, strategy_id, symbol, side, quantity, price,
@@ -245,7 +250,7 @@ class TradeRecorder:
                 record.commission,
                 record.timestamp.isoformat() if record.timestamp else None,
                 record.order_id,
-                record.account_id,
+                account_id,
                 record.currency,
                 record.exchange,
             ),
@@ -304,6 +309,11 @@ class TradeRecorder:
 
         conditions: list[str] = []
         params: list[Any] = []
+        validated_account_id: str | None = None
+        if account_id is not None:
+            validated_account_id = require_account_id(
+                account_id, context="trade_recorder.get_trades"
+            )
 
         # Refs #1240 review (P2-3): legacy invalid account_id row를 SQL 단계에서
         # 제외해야 LIMIT/OFFSET 페이지네이션이 정확해진다. Python 단계 skip만으로는
@@ -318,9 +328,9 @@ class TradeRecorder:
         )
         params.extend(invalid_ids)
 
-        if account_id:
+        if validated_account_id is not None:
             conditions.append("account_id = ?")
-            params.append(account_id)
+            params.append(validated_account_id)
         if bot_id:
             conditions.append("bot_id = ?")
             params.append(bot_id)

--- a/tests/unit/test_trade.py
+++ b/tests/unit/test_trade.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 import pytest
 
+from ante.account.errors import InvalidAccountIdError
 from ante.core.database import Database
 from ante.eventbus import EventBus
 from ante.eventbus.events import (
@@ -103,6 +104,23 @@ def _make_filled_event(
 
 
 class TestTradeRecorder:
+    async def test_trades_schema_requires_account_id_without_default(
+        self, db, recorder
+    ):
+        """fresh trades DDL은 fallback account default를 만들지 않는다."""
+        columns = await db.fetch_all("PRAGMA table_info(trades)")
+        account_col = next(row for row in columns if row["name"] == "account_id")
+        assert account_col["notnull"] == 1
+        assert account_col["dflt_value"] is None
+
+    async def test_trades_schema_has_account_index(self, db, recorder):
+        """account 단위 거래 조회용 index가 존재한다."""
+        indexes = await db.fetch_all(
+            "SELECT name FROM sqlite_master "
+            "WHERE type = 'index' AND tbl_name = 'trades'"
+        )
+        assert "idx_trades_account" in {row["name"] for row in indexes}
+
     async def test_on_filled_records_trade(self, recorder, db):
         """OrderFilledEvent → trades 테이블에 기록."""
         event = _make_filled_event()
@@ -1387,6 +1405,34 @@ class TestAccountIdDbMigration:
         trades = await recorder.get_trades()
         assert len(trades) == 2
         assert {t.account_id for t in trades} == {"acct-1", "acct-2"}
+
+    async def test_get_trades_rejects_invalid_account_filter(self, recorder):
+        """명시 account filter의 fallback 값은 all-account로 해석하지 않는다."""
+        with pytest.raises(InvalidAccountIdError, match="account_id"):
+            await recorder.get_trades(account_id="")
+
+    async def test_save_rejects_invalid_account_id_at_write_boundary(self, recorder):
+        """TradeRecord 생성 우회를 하더라도 recorder write boundary가 막는다."""
+        record = object.__new__(TradeRecord)
+        record.trade_id = uuid4()
+        record.bot_id = "bot1"
+        record.strategy_id = "s1"
+        record.symbol = "005930"
+        record.side = "buy"
+        record.quantity = 10.0
+        record.price = 50000.0
+        record.status = TradeStatus.FILLED
+        record.order_type = "market"
+        record.reason = "test"
+        record.commission = 0.0
+        record.timestamp = datetime.now(UTC)
+        record.order_id = "ord-invalid"
+        record.exchange = "KRX"
+        record.account_id = "default"
+        record.currency = "KRW"
+
+        with pytest.raises(InvalidAccountIdError, match="account_id"):
+            await recorder.save(record)
 
     async def test_position_saved_with_account_id(self, position_history):
         """포지션 갱신 시 account_id가 DB에 저장되는지 확인."""


### PR DESCRIPTION
Closes #1257

## Summary
- Remove the `DEFAULT 'default'` fallback from the fresh trades schema.
- Add an account/timestamp index for trades lookup.
- Validate account IDs at the TradeRecorder write boundary and explicit account-filter query boundary.
- Update focused trade tests and SQLite schema spec.

## Test Plan
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/test_trade.py -q`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m ruff check src/ante/trade/recorder.py tests/unit/test_trade.py`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m ruff format --check src/ante/trade/recorder.py tests/unit/test_trade.py`
- `git diff --check`