### PR TITLE
feat(treasury): align account-aware DB schema

### DIFF
--- a/docs/specs/treasury/06-database-schema.md
+++ b/docs/specs/treasury/06-database-schema.md
@@ -8,7 +8,7 @@
 -- 봇별 예산 상태
 CREATE TABLE bot_budgets (
     bot_id       TEXT PRIMARY KEY,
-    account_id   TEXT NOT NULL,                          -- 소속 계좌 ID
+    account_id   TEXT NOT NULL,                          -- 소속 계좌 ID, fallback default 없음
     allocated    REAL NOT NULL DEFAULT 0.0,
     available    REAL NOT NULL DEFAULT 0.0,
     reserved     REAL NOT NULL DEFAULT 0.0,
@@ -21,7 +21,7 @@ CREATE TABLE bot_budgets (
 CREATE TABLE treasury_transactions (
     id               INTEGER PRIMARY KEY AUTOINCREMENT,
     bot_id           TEXT,
-    account_id       TEXT DEFAULT 'default',              -- 소속 계좌 ID
+    account_id       TEXT NOT NULL,                       -- 소속 계좌 ID, fallback default 없음
     transaction_type TEXT NOT NULL,  -- 'allocate', 'deallocate', 'reserve', 'release', 'fill'
     amount           REAL NOT NULL,
     description      TEXT DEFAULT '',
@@ -37,8 +37,13 @@ CREATE TABLE treasury_state (
     currency           TEXT NOT NULL DEFAULT 'KRW',
     last_synced_at     TEXT
 );
+CREATE INDEX idx_bot_budgets_account ON bot_budgets(account_id);
+CREATE INDEX idx_treasury_transactions_account
+    ON treasury_transactions(account_id);
 ```
 
-> **마이그레이션**: 기존 `treasury_state`는 key-value 구조에서 계좌별 행 구조로 변경되므로, 테이블 재생성이 필요하다. 기존 데이터는 `account_id = "default"` 행으로 변환한다.
+> **마이그레이션**: 1.0 이전 fresh schema 기준으로 Treasury DB는 fallback
+> account 값을 생성하지 않는다. 기존 invalid dev DB 데이터의 자동 보존/변환은
+> 이 계약의 범위가 아니다.
 
 > **참고**: `positions` 테이블은 Trade 모듈이 소유한다. [trade.md](../trade/trade.md) 참조.

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 TREASURY_SCHEMA = """
 CREATE TABLE IF NOT EXISTS bot_budgets (
     bot_id       TEXT PRIMARY KEY,
-    account_id   TEXT NOT NULL DEFAULT '',
+    account_id   TEXT NOT NULL,
     allocated    REAL NOT NULL DEFAULT 0.0,
     available    REAL NOT NULL DEFAULT 0.0,
     reserved     REAL NOT NULL DEFAULT 0.0,
@@ -67,47 +67,19 @@ CREATE TABLE IF NOT EXISTS treasury_daily_snapshots (
     created_at           TEXT    DEFAULT (datetime('now')),
     PRIMARY KEY (account_id, snapshot_date)
 );
+CREATE INDEX IF NOT EXISTS idx_bot_budgets_account
+    ON bot_budgets(account_id);
+CREATE INDEX IF NOT EXISTS idx_treasury_transactions_account
+    ON treasury_transactions(account_id);
 """
 
-# 기존 key-value 테이블에서 계좌별 행 구조로 마이그레이션
+# Legacy compatibility: old dev DB may lack account_id. Do not add fallback default.
 TREASURY_MIGRATION_V2 = """
--- bot_budgets에 account_id 컬럼 추가 (이미 존재하면 무시)
-ALTER TABLE bot_budgets ADD COLUMN account_id TEXT NOT NULL DEFAULT '';
-"""
-
-TREASURY_MIGRATION_V2_STATE = """
--- treasury_state 재생성: key-value -> 계좌별 행 구조
-CREATE TABLE IF NOT EXISTS treasury_state_new (
-    account_id         TEXT PRIMARY KEY,
-    account_balance    REAL NOT NULL DEFAULT 0,
-    purchasable_amount REAL NOT NULL DEFAULT 0,
-    total_evaluation   REAL NOT NULL DEFAULT 0,
-    currency           TEXT NOT NULL DEFAULT 'KRW',
-    last_synced_at     TEXT
-);
-
--- 기존 데이터 마이그레이션
-INSERT OR IGNORE INTO treasury_state_new (
-    account_id, account_balance,
-    purchasable_amount, total_evaluation
-)
-SELECT 'default',
-    COALESCE(
-        (SELECT value FROM treasury_state
-         WHERE key = 'account_balance'), 0),
-    COALESCE(
-        (SELECT value FROM treasury_state
-         WHERE key = 'purchasable_amount'), 0),
-    COALESCE(
-        (SELECT value FROM treasury_state
-         WHERE key = 'total_evaluation'), 0);
-
-DROP TABLE IF EXISTS treasury_state;
-ALTER TABLE treasury_state_new RENAME TO treasury_state;
+ALTER TABLE bot_budgets ADD COLUMN account_id TEXT;
 """
 
 TREASURY_TRANSACTIONS_MIGRATION = """
-ALTER TABLE treasury_transactions ADD COLUMN account_id TEXT DEFAULT '';
+ALTER TABLE treasury_transactions ADD COLUMN account_id TEXT;
 """
 
 # treasury_state에 평가액/매입액 필드 추가 마이그레이션
@@ -1106,6 +1078,9 @@ class Treasury:
 
     async def _save_budget(self, budget: BotBudget) -> None:
         """봇 예산 저장."""
+        account_id = require_account_id(
+            budget.account_id, context="treasury._save_budget"
+        )
         await self._db.execute(
             """INSERT INTO bot_budgets
                (bot_id, account_id, allocated, available, reserved,
@@ -1121,7 +1096,7 @@ class Treasury:
                  last_updated = excluded.last_updated""",
             (
                 budget.bot_id,
-                budget.account_id,
+                account_id,
                 budget.allocated,
                 budget.available,
                 budget.reserved,

--- a/tests/unit/test_treasury.py
+++ b/tests/unit/test_treasury.py
@@ -101,6 +101,37 @@ class TestTreasuryAccountProperties:
         assert summary["currency"] == CURRENCY
 
 
+# -- Treasury DB schema ----------------------------------------
+
+
+class TestTreasurySchema:
+    async def test_bot_budgets_account_id_has_no_fallback_default(self, db, treasury):
+        """fresh bot_budgets DDL은 fallback account default를 만들지 않는다."""
+        columns = await db.fetch_all("PRAGMA table_info(bot_budgets)")
+        account_col = next(row for row in columns if row["name"] == "account_id")
+        assert account_col["notnull"] == 1
+        assert account_col["dflt_value"] is None
+
+    async def test_treasury_account_indexes_exist(self, db, treasury):
+        """Treasury account 단위 조회용 index가 존재한다."""
+        indexes = await db.fetch_all(
+            "SELECT name FROM sqlite_master "
+            "WHERE type = 'index' AND tbl_name IN "
+            "('bot_budgets', 'treasury_transactions')"
+        )
+        names = {row["name"] for row in indexes}
+        assert "idx_bot_budgets_account" in names
+        assert "idx_treasury_transactions_account" in names
+
+    async def test_save_budget_rejects_invalid_account_id(self, treasury):
+        """BotBudget 생성 우회를 하더라도 write boundary가 fallback을 막는다."""
+        budget = BotBudget(bot_id="bot1", account_id=ACCOUNT_ID)
+        budget.account_id = ""
+
+        with pytest.raises(InvalidAccountIdError, match="account_id"):
+            await treasury._save_budget(budget)
+
+
 # -- 계좌 잔고 -----------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- remove fallback account defaults from Treasury fresh DB schema
- add account-scoped indexes for `bot_budgets` and `treasury_transactions`
- validate `BotBudget.account_id` at the Treasury write boundary
- align Treasury DB schema documentation and unit tests

## Verification
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/test_treasury.py -q`
- `ruff check src/ante/treasury/treasury.py tests/unit/test_treasury.py`
- `ruff format --check src/ante/treasury/treasury.py tests/unit/test_treasury.py`
- `git diff --check`

Closes #1258
