### PR TITLE
feat(trade): make positions account-aware

### DIFF
--- a/docs/specs/trade/03-05-sqlite-schema.md
+++ b/docs/specs/trade/03-05-sqlite-schema.md
@@ -49,7 +49,7 @@ CREATE TABLE positions (
     realized_pnl     REAL NOT NULL DEFAULT 0.0,    -- 누적 실현 손익
     exchange         TEXT DEFAULT 'KRX',
     updated_at       TEXT DEFAULT (datetime('now')),
-    PRIMARY KEY (bot_id, symbol)
+    PRIMARY KEY (account_id, bot_id, symbol)
 );
 
 -- 포지션 변동 이력
@@ -63,11 +63,19 @@ CREATE TABLE position_history (
     pnl            REAL DEFAULT 0.0,        -- 이 거래의 실현 손익 (sell 시)
     timestamp      TEXT,
     exchange       TEXT DEFAULT 'KRX',      -- v0.2 마이그레이션으로 추가
+    account_id     TEXT NOT NULL,
     created_at     TEXT DEFAULT (datetime('now'))
 );
 
 CREATE INDEX idx_position_history_bot ON position_history(bot_id, timestamp);
+CREATE INDEX idx_position_history_account
+    ON position_history(account_id, bot_id, timestamp);
 ```
+
+`positions.account_id`와 `position_history.account_id`는 fresh schema에서
+필수값이며 `DEFAULT 'default'` 같은 fallback을 두지 않는다. 현재 포지션의
+유일 키는 account를 포함해 동일 `bot_id`/`symbol`이 다른 account에서
+충돌하지 않아야 한다.
 
 **근거**:
 - `trades` 테이블: 모든 거래 시도를 기록 (체결/취소/거부/실패 모두)

--- a/src/ante/trade/position.py
+++ b/src/ante/trade/position.py
@@ -25,8 +25,8 @@ CREATE TABLE IF NOT EXISTS positions (
     avg_entry_price  REAL NOT NULL DEFAULT 0.0,
     realized_pnl     REAL NOT NULL DEFAULT 0.0,
     updated_at       TEXT DEFAULT (datetime('now')),
-    account_id       TEXT NOT NULL DEFAULT 'default',
-    PRIMARY KEY (bot_id, symbol)
+    account_id       TEXT NOT NULL,
+    PRIMARY KEY (account_id, bot_id, symbol)
 );
 
 CREATE TABLE IF NOT EXISTS position_history (
@@ -39,12 +39,14 @@ CREATE TABLE IF NOT EXISTS position_history (
     pnl            REAL DEFAULT 0.0,
     timestamp      TEXT,
     created_at     TEXT DEFAULT (datetime('now')),
-    account_id     TEXT NOT NULL DEFAULT 'default',
+    account_id     TEXT NOT NULL,
     exchange       TEXT DEFAULT 'KRX',
     trade_id       TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_position_history_bot
     ON position_history(bot_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_position_history_account
+    ON position_history(account_id, bot_id, timestamp);
 """
 
 
@@ -53,7 +55,7 @@ class PositionHistory:
 
     def __init__(self, db: Database) -> None:
         self._db = db
-        self._position_cache: dict[str, dict[str, PositionSnapshot]] = {}
+        self._position_cache: dict[tuple[str, str], dict[str, PositionSnapshot]] = {}
 
     async def initialize(self) -> None:
         """스키마 생성 + 캐시 워밍."""
@@ -75,21 +77,43 @@ class PositionHistory:
             snapshot = self._row_to_snapshot_safe(row, context="warm cache")
             if snapshot is None:
                 continue
-            self._position_cache.setdefault(snapshot.bot_id, {})[snapshot.symbol] = (
-                snapshot
+            cache_key = self._cache_key(snapshot.account_id, snapshot.bot_id)
+            self._position_cache.setdefault(cache_key, {})[snapshot.symbol] = snapshot
+
+    def get_positions_sync(
+        self,
+        bot_id: str,
+        *,
+        account_id: str | None = None,
+    ) -> list[PositionSnapshot]:
+        """봇의 현재 포지션 동기 조회 (인메모리 캐시). PortfolioView용."""
+        if account_id is not None:
+            account_id = require_account_id(
+                account_id, context="position.get_positions_sync"
+            )
+            return list(
+                self._position_cache.get(
+                    self._cache_key(account_id, bot_id), {}
+                ).values()
             )
 
-    def get_positions_sync(self, bot_id: str) -> list[PositionSnapshot]:
-        """봇의 현재 포지션 동기 조회 (인메모리 캐시). PortfolioView용."""
-        bot_positions = self._position_cache.get(bot_id, {})
-        return list(bot_positions.values())
+        positions: list[PositionSnapshot] = []
+        for cache_account_id, cache_bot_id in sorted(self._position_cache):
+            if cache_bot_id != bot_id:
+                continue
+            positions.extend(
+                self._position_cache[(cache_account_id, cache_bot_id)].values()
+            )
+        return positions
 
     async def on_trade(self, record: TradeRecord) -> None:
         """체결 기록을 반영하여 포지션 상태 갱신."""
         if record.status != TradeStatus.FILLED:
             return
 
-        position = await self._get_current(record.bot_id, record.symbol)
+        position = await self._get_current(
+            record.bot_id, record.symbol, account_id=record.account_id
+        )
 
         if record.side == "buy":
             total_cost = position["avg_entry_price"] * position["quantity"]
@@ -167,6 +191,8 @@ class PositionHistory:
         self,
         bot_id: str,
         include_closed: bool = False,
+        *,
+        account_id: str | None = None,
     ) -> list[PositionSnapshot]:
         """봇의 현재 포지션 조회.
 
@@ -174,15 +200,23 @@ class PositionHistory:
         warning만 남긴다. dashboard / Treasury 동기화가 마이그레이션 전에도
         실패하지 않도록 하기 위함이다.
         """
-        if include_closed:
-            rows = await self._db.fetch_all(
-                "SELECT * FROM positions WHERE bot_id = ?", (bot_id,)
+        conditions = ["bot_id = ?"]
+        params: list[object] = [bot_id]
+
+        if account_id is not None:
+            account_id = require_account_id(
+                account_id, context="position.get_positions"
             )
-        else:
-            rows = await self._db.fetch_all(
-                "SELECT * FROM positions WHERE bot_id = ? AND quantity > 0",
-                (bot_id,),
-            )
+            conditions.append("account_id = ?")
+            params.append(account_id)
+
+        if not include_closed:
+            conditions.append("quantity > 0")
+
+        rows = await self._db.fetch_all(
+            f"SELECT * FROM positions WHERE {' AND '.join(conditions)}",
+            tuple(params),
+        )
         return self._rows_to_snapshots(rows, context="get_positions")
 
     async def get_all_positions(
@@ -206,36 +240,51 @@ class PositionHistory:
                 "SELECT * FROM positions WHERE quantity > 0"
             )
         else:
+            account_id = require_account_id(
+                account_id, context="position.get_all_positions"
+            )
             rows = await self._db.fetch_all(
                 "SELECT * FROM positions WHERE quantity > 0 AND account_id = ?",
                 (account_id,),
             )
         return self._rows_to_snapshots(rows, context="get_all_positions")
 
-    async def get_current(self, bot_id: str, symbol: str) -> dict:
+    async def get_current(
+        self,
+        bot_id: str,
+        symbol: str,
+        *,
+        account_id: str | None = None,
+    ) -> dict:
         """현재 포지션 조회 (public)."""
-        return await self._get_current(bot_id, symbol)
+        return await self._get_current(bot_id, symbol, account_id=account_id)
 
     async def get_history(
         self,
         bot_id: str,
         symbol: str | None = None,
+        *,
+        account_id: str | None = None,
     ) -> list[dict]:
         """포지션 변동 이력 조회."""
+        conditions = ["bot_id = ?"]
+        params: list[object] = [bot_id]
+
+        if account_id is not None:
+            account_id = require_account_id(account_id, context="position.get_history")
+            conditions.append("account_id = ?")
+            params.append(account_id)
+
         if symbol:
-            rows = await self._db.fetch_all(
-                "SELECT * FROM position_history"
-                " WHERE bot_id = ? AND symbol = ?"
-                " ORDER BY created_at DESC",
-                (bot_id, symbol),
-            )
-        else:
-            rows = await self._db.fetch_all(
-                "SELECT * FROM position_history"
-                " WHERE bot_id = ?"
-                " ORDER BY created_at DESC",
-                (bot_id,),
-            )
+            conditions.append("symbol = ?")
+            params.append(symbol)
+
+        rows = await self._db.fetch_all(
+            "SELECT * FROM position_history"
+            f" WHERE {' AND '.join(conditions)}"
+            " ORDER BY created_at DESC",
+            tuple(params),
+        )
         return [dict(row) for row in rows]
 
     async def force_update(
@@ -255,33 +304,51 @@ class PositionHistory:
             """INSERT INTO positions
                (bot_id, symbol, quantity, avg_entry_price, account_id, updated_at)
                VALUES (?, ?, ?, ?, ?, datetime('now'))
-               ON CONFLICT(bot_id, symbol) DO UPDATE SET
+               ON CONFLICT(account_id, bot_id, symbol) DO UPDATE SET
                  quantity = excluded.quantity,
                  avg_entry_price = excluded.avg_entry_price,
-                 account_id = excluded.account_id,
                  updated_at = excluded.updated_at""",
             (bot_id, symbol, quantity, avg_entry_price, validated_account_id),
         )
         # 인메모리 캐시 갱신
         self._update_cache(
-            bot_id, symbol, quantity, avg_entry_price, account_id=account_id
+            bot_id, symbol, quantity, avg_entry_price, account_id=validated_account_id
         )
 
-    async def _get_current(self, bot_id: str, symbol: str) -> dict:
+    async def _get_current(
+        self,
+        bot_id: str,
+        symbol: str,
+        *,
+        account_id: str | None = None,
+    ) -> dict:
         """현재 포지션 조회. 없으면 빈 포지션 반환."""
-        row = await self._db.fetch_one(
-            "SELECT * FROM positions WHERE bot_id = ? AND symbol = ?",
-            (bot_id, symbol),
-        )
+        if account_id is None:
+            row = await self._db.fetch_one(
+                "SELECT * FROM positions"
+                " WHERE bot_id = ? AND symbol = ?"
+                " ORDER BY account_id LIMIT 1",
+                (bot_id, symbol),
+            )
+        else:
+            account_id = require_account_id(account_id, context="position.get_current")
+            row = await self._db.fetch_one(
+                "SELECT * FROM positions"
+                " WHERE account_id = ? AND bot_id = ? AND symbol = ?",
+                (account_id, bot_id, symbol),
+            )
         if row:
             return dict(row)
-        return {
+        empty = {
             "bot_id": bot_id,
             "symbol": symbol,
             "quantity": 0.0,
             "avg_entry_price": 0.0,
             "realized_pnl": 0.0,
         }
+        if account_id is not None:
+            empty["account_id"] = account_id
+        return empty
 
     async def _update_position(
         self,
@@ -294,28 +361,26 @@ class PositionHistory:
         realized_pnl_delta: float = 0.0,
     ) -> None:
         """포지션 상태 갱신."""
+        validated_account_id = require_account_id(
+            account_id, context="position._update_position"
+        )
         await self._db.execute(
             """INSERT INTO positions
                (bot_id, symbol, quantity, avg_entry_price,
                 realized_pnl, updated_at, account_id)
                VALUES (?, ?, ?, ?, ?, datetime('now'), ?)
-               ON CONFLICT(bot_id, symbol) DO UPDATE SET
-                 quantity = ?,
-                 avg_entry_price = ?,
-                 realized_pnl = realized_pnl + ?,
-                 account_id = ?,
-                 updated_at = datetime('now')""",
+               ON CONFLICT(account_id, bot_id, symbol) DO UPDATE SET
+                 quantity = excluded.quantity,
+                 avg_entry_price = excluded.avg_entry_price,
+                 realized_pnl = positions.realized_pnl + excluded.realized_pnl,
+                 updated_at = excluded.updated_at""",
             (
                 bot_id,
                 symbol,
                 quantity,
                 avg_entry_price,
                 realized_pnl_delta,
-                account_id,
-                quantity,
-                avg_entry_price,
-                realized_pnl_delta,
-                account_id,
+                validated_account_id,
             ),
         )
         # 인메모리 캐시 갱신
@@ -324,7 +389,7 @@ class PositionHistory:
             symbol,
             quantity,
             avg_entry_price,
-            account_id=account_id,
+            account_id=validated_account_id,
             realized_pnl_delta=realized_pnl_delta,
         )
 
@@ -339,7 +404,8 @@ class PositionHistory:
         realized_pnl_delta: float = 0.0,
     ) -> None:
         """인메모리 포지션 캐시 갱신."""
-        bot_cache = self._position_cache.setdefault(bot_id, {})
+        cache_key = self._cache_key(account_id, bot_id)
+        bot_cache = self._position_cache.setdefault(cache_key, {})
         existing = bot_cache.get(symbol)
         prev_pnl = existing.realized_pnl if existing else 0.0
 
@@ -354,6 +420,8 @@ class PositionHistory:
             )
         else:
             bot_cache.pop(symbol, None)
+            if not bot_cache:
+                self._position_cache.pop(cache_key, None)
 
     async def _save_history(
         self,
@@ -372,8 +440,8 @@ class PositionHistory:
         """포지션 변동 이력 저장.
 
         ``account_id``는 호출자에서 ``record.account_id``를 그대로 전달하며,
-        :func:`require_account_id`로 검증한다. 누락 시 schema default
-        ``'default'``로 저장되던 회귀(#1240 review)를 차단한다.
+        :func:`require_account_id`로 검증한다. 누락 시 fresh schema NOT NULL
+        제약과 runtime 검증으로 저장을 차단한다.
         """
         validated_account_id = require_account_id(
             account_id, context="position._save_history"
@@ -410,6 +478,11 @@ class PositionHistory:
             updated_at=row.get("updated_at", ""),
             account_id=row["account_id"],
         )
+
+    @staticmethod
+    def _cache_key(account_id: str, bot_id: str) -> tuple[str, str]:
+        """계좌와 bot을 함께 사용해 동일 bot/symbol의 cross-account 충돌을 막는다."""
+        return (account_id, bot_id)
 
     def _row_to_snapshot_safe(
         self, row: dict, *, context: str

--- a/src/ante/trade/reconciler.py
+++ b/src/ante/trade/reconciler.py
@@ -47,7 +47,9 @@ class PositionReconciler:
             ReconcileEvent,
         )
 
-        internal = await self._trade_service.get_positions(bot_id)
+        internal = await self._trade_service.get_positions(
+            bot_id, account_id=account_id
+        )
         internal_map: dict[str, dict[str, float]] = {
             p.symbol: {
                 "quantity": p.quantity,

--- a/src/ante/trade/service.py
+++ b/src/ante/trade/service.py
@@ -68,26 +68,34 @@ class TradeService:
         self,
         bot_id: str,
         include_closed: bool = False,
+        *,
+        account_id: str | None = None,
     ) -> list[PositionSnapshot]:
         """봇의 현재 포지션 조회."""
         return await self._position_history.get_positions(
             bot_id=bot_id,
             include_closed=include_closed,
+            account_id=account_id,
         )
 
-    async def get_all_positions(self) -> list[PositionSnapshot]:
+    async def get_all_positions(
+        self, *, account_id: str | None = None
+    ) -> list[PositionSnapshot]:
         """전체 봇의 모든 포지션 조회 (대사 계좌 합산 검증용)."""
-        return await self._position_history.get_all_positions()
+        return await self._position_history.get_all_positions(account_id=account_id)
 
     async def get_position_history(
         self,
         bot_id: str,
         symbol: str | None = None,
+        *,
+        account_id: str | None = None,
     ) -> list[dict]:
         """포지션 변동 이력 조회."""
         return await self._position_history.get_history(
             bot_id=bot_id,
             symbol=symbol,
+            account_id=account_id,
         )
 
     # ── 성과 지표 ────────────────────────────────────
@@ -113,9 +121,11 @@ class TradeService:
 
     async def get_summary(self, bot_id: str, account_id: str) -> dict:
         """봇 요약 정보 (대시보드용)."""
-        positions = await self.get_positions(bot_id)
+        positions = await self.get_positions(bot_id, account_id=account_id)
         performance = await self.get_performance(account_id=account_id, bot_id=bot_id)
-        recent_trades = await self.get_trades(bot_id=bot_id, limit=10)
+        recent_trades = await self.get_trades(
+            account_id=account_id, bot_id=bot_id, limit=10
+        )
 
         return {
             "positions": positions,
@@ -145,7 +155,9 @@ class TradeService:
 
         account_id = require_account_id(account_id, context="correct_position")
 
-        old = await self._position_history.get_current(bot_id=bot_id, symbol=symbol)
+        old = await self._position_history.get_current(
+            bot_id=bot_id, symbol=symbol, account_id=account_id
+        )
         old_qty = old.get("quantity", 0)
         old_avg = old.get("avg_entry_price", 0.0)
 

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -54,14 +54,22 @@ def reconciler(service, eventbus):
     return PositionReconciler(trade_service=service, eventbus=eventbus)
 
 
-async def _set_position(position_history, bot_id, symbol, qty, avg_price):
+async def _set_position(
+    position_history,
+    bot_id,
+    symbol,
+    qty,
+    avg_price,
+    *,
+    account_id="acc-test",
+):
     """테스트용 포지션 설정."""
     await position_history.force_update(
         bot_id=bot_id,
         symbol=symbol,
         quantity=qty,
         avg_entry_price=avg_price,
-        account_id="acc-test",
+        account_id=account_id,
     )
 
 
@@ -157,6 +165,31 @@ class TestNoMismatch:
             bot_id="bot-1", broker_positions=[], account_id="acc-test"
         )
         assert corrections == []
+
+    async def test_other_account_position_is_not_reconciled(
+        self, reconciler, position_history
+    ):
+        """Reconciler는 요청 account_id의 내부 포지션만 대조한다."""
+        await _set_position(
+            position_history,
+            "bot-1",
+            "005930",
+            50,
+            50000,
+            account_id="acc-other",
+        )
+
+        corrections = await reconciler.reconcile(
+            bot_id="bot-1",
+            broker_positions=[],
+            account_id="acc-test",
+        )
+
+        assert corrections == []
+        other = await position_history.get_current(
+            "bot-1", "005930", account_id="acc-other"
+        )
+        assert other["quantity"] == 50
 
 
 # ── 시나리오 4: 외부 매수 ──────────────────────────

--- a/tests/unit/test_trade.py
+++ b/tests/unit/test_trade.py
@@ -398,6 +398,33 @@ class TestTradeRecorder:
 
 
 class TestPositionHistory:
+    async def test_positions_schema_is_account_aware(self, db, position_history):
+        """fresh positions DDL은 account fallback 없이 account-aware PK를 갖는다."""
+        columns = await db.fetch_all("PRAGMA table_info(positions)")
+        account_col = next(row for row in columns if row["name"] == "account_id")
+        assert account_col["notnull"] == 1
+        assert account_col["dflt_value"] is None
+
+        pk_columns = [
+            row["name"]
+            for row in sorted(columns, key=lambda row: row["pk"])
+            if row["pk"]
+        ]
+        assert pk_columns == ["account_id", "bot_id", "symbol"]
+
+    async def test_position_history_schema_is_account_aware(self, db, position_history):
+        """fresh position_history DDL은 account_id와 account 조회 index를 갖는다."""
+        columns = await db.fetch_all("PRAGMA table_info(position_history)")
+        account_col = next(row for row in columns if row["name"] == "account_id")
+        assert account_col["notnull"] == 1
+        assert account_col["dflt_value"] is None
+
+        indexes = await db.fetch_all(
+            "SELECT name FROM sqlite_master "
+            "WHERE type = 'index' AND tbl_name = 'position_history'"
+        )
+        assert "idx_position_history_account" in {row["name"] for row in indexes}
+
     async def test_buy_increases_quantity(self, position_history):
         """매수 시 수량 증가."""
         record = TradeRecord(
@@ -686,6 +713,63 @@ class TestPositionHistory:
         none = await position_history.get_all_positions(account_id="acc-zzz")
         assert none == []
 
+    async def test_same_bot_symbol_keeps_positions_per_account(self, position_history):
+        """동일 bot_id/symbol이라도 account가 다르면 서로 덮어쓰지 않는다."""
+        for account_id, quantity, price in [
+            ("acc-a", 10, 50000),
+            ("acc-b", 3, 70000),
+        ]:
+            await position_history.on_trade(
+                TradeRecord(
+                    trade_id=uuid4(),
+                    bot_id="bot-shared",
+                    strategy_id="s1",
+                    symbol="005930",
+                    side="buy",
+                    quantity=quantity,
+                    price=price,
+                    status=TradeStatus.FILLED,
+                    timestamp=datetime.now(UTC),
+                    account_id=account_id,
+                )
+            )
+
+        pos_a = await position_history.get_current(
+            "bot-shared", "005930", account_id="acc-a"
+        )
+        pos_b = await position_history.get_current(
+            "bot-shared", "005930", account_id="acc-b"
+        )
+        assert pos_a["quantity"] == 10
+        assert pos_a["avg_entry_price"] == 50000
+        assert pos_b["quantity"] == 3
+        assert pos_b["avg_entry_price"] == 70000
+
+        all_positions = await position_history.get_positions("bot-shared")
+        assert {p.account_id for p in all_positions} == {"acc-a", "acc-b"}
+
+        only_a = await position_history.get_positions("bot-shared", account_id="acc-a")
+        assert len(only_a) == 1
+        assert only_a[0].account_id == "acc-a"
+
+    async def test_position_cache_key_includes_account_id(self, position_history):
+        """캐시 key가 account를 포함해 동일 symbol의 account별 snapshot을 보존한다."""
+        for account_id, quantity in [("acc-a", 10), ("acc-b", 20)]:
+            await position_history.force_update(
+                bot_id="bot-cache",
+                symbol="005930",
+                quantity=quantity,
+                avg_entry_price=50000,
+                account_id=account_id,
+            )
+
+        cached_all = position_history.get_positions_sync("bot-cache")
+        assert {p.account_id for p in cached_all} == {"acc-a", "acc-b"}
+
+        cached_a = position_history.get_positions_sync("bot-cache", account_id="acc-a")
+        assert len(cached_a) == 1
+        assert cached_a[0].quantity == 10
+
     async def test_force_update(self, position_history):
         """Reconciler 강제 포지션 덮어쓰기."""
         await position_history.force_update(
@@ -756,6 +840,33 @@ class TestPositionHistory:
 
         history = await position_history.get_history("bot1", "005930")
         assert len(history) == 2  # buy + sell
+
+    async def test_get_history_filters_by_account_id(self, position_history):
+        """position_history 조회가 명시 account_id로 좁혀진다."""
+        for account_id in ["acc-a", "acc-b"]:
+            await position_history.on_trade(
+                TradeRecord(
+                    trade_id=uuid4(),
+                    bot_id="bot-history",
+                    strategy_id="s1",
+                    symbol="005930",
+                    side="buy",
+                    quantity=10,
+                    price=50000,
+                    status=TradeStatus.FILLED,
+                    timestamp=datetime.now(UTC),
+                    account_id=account_id,
+                )
+            )
+
+        all_history = await position_history.get_history("bot-history", "005930")
+        assert {row["account_id"] for row in all_history} == {"acc-a", "acc-b"}
+
+        account_history = await position_history.get_history(
+            "bot-history", "005930", account_id="acc-a"
+        )
+        assert len(account_history) == 1
+        assert account_history[0]["account_id"] == "acc-a"
 
     async def test_save_history_writes_account_id(self, position_history, db):
         """체결 이력 INSERT 시 account_id가 schema default 'default'가 아닌


### PR DESCRIPTION
## Summary
- make the `positions` fresh schema account-aware with `(account_id, bot_id, symbol)` as the primary key
- remove fallback account defaults from `positions` and `position_history`
- make PositionHistory DB reads/writes/cache keys account-aware while preserving optional all-account read compatibility
- pass account context through TradeService summary/correction and PositionReconciler
- align Trade DB schema docs and add regression tests

## Verification
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/test_trade.py tests/unit/test_reconciler.py -q`
- `ANTE_DB_ENCRYPTION_KEY=... PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/ -x -n auto --tb=short -q`
- `ruff check src/ante/trade/position.py src/ante/trade/service.py src/ante/trade/reconciler.py tests/unit/test_trade.py tests/unit/test_reconciler.py`
- `ruff format --check src/ante/trade/position.py src/ante/trade/service.py src/ante/trade/reconciler.py tests/unit/test_trade.py tests/unit/test_reconciler.py`
- `/Users/jingulee/Projects/ante/.venv/bin/mypy src/`
- `git diff --check`

Closes #1259
