### PR TITLE
feat(frontend): adapt auth member generated types

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,16 +1,43 @@
 import client from './client'
-import type { LoginRequest, LoginResponse, User } from '../types/auth'
+import type {
+  LoginRequest as ApiLoginRequest,
+  LoginResponse as ApiLoginResponse,
+  LogoutResponse as ApiLogoutResponse,
+  MeResponse as ApiMeResponse,
+} from '../types/api.generated'
+import type { AuthUserView, LoginInput, LoginResultView } from '../types/auth'
 
-export async function login(data: LoginRequest): Promise<LoginResponse> {
-  const res = await client.post('/api/auth/login', data)
-  return res.data
+export function toLoginResultView(raw: ApiLoginResponse): LoginResultView {
+  return {
+    member_id: raw.member_id,
+    name: raw.name,
+    type: raw.type,
+  }
+}
+
+export function toAuthUserView(raw: ApiMeResponse): AuthUserView {
+  return {
+    member_id: raw.member_id,
+    name: raw.name,
+    type: raw.type,
+    role: raw.role,
+    emoji: raw.emoji || undefined,
+    login_at: raw.login_at || undefined,
+    scopes: [],
+  }
+}
+
+export async function login(data: LoginInput): Promise<LoginResultView> {
+  const payload: ApiLoginRequest = data
+  const res = await client.post<ApiLoginResponse>('/api/auth/login', payload)
+  return toLoginResultView(res.data)
 }
 
 export async function logout(): Promise<void> {
-  await client.post('/api/auth/logout')
+  await client.post<ApiLogoutResponse>('/api/auth/logout')
 }
 
-export async function getMe(): Promise<User> {
-  const res = await client.get('/api/auth/me')
-  return res.data
+export async function getMe(): Promise<AuthUserView> {
+  const res = await client.get<ApiMeResponse>('/api/auth/me')
+  return toAuthUserView(res.data)
 }

--- a/frontend/src/api/members.ts
+++ b/frontend/src/api/members.ts
@@ -1,50 +1,126 @@
 import client from './client'
-import type { Member, MemberDetail, MemberCreateRequest } from '../types/member'
+import type {
+  MemberCreateRequest as ApiMemberCreateRequest,
+  MemberCreateResponse as ApiMemberCreateResponse,
+  MemberDetailResponse as ApiMemberDetailResponse,
+  MemberInfo as ApiMemberInfo,
+  MemberListResponse as ApiMemberListResponse,
+  MemberScopesResponse as ApiMemberScopesResponse,
+  MemberTokenResponse as ApiMemberTokenResponse,
+  OkResponse as ApiOkResponse,
+  PasswordChangeRequest as ApiPasswordChangeRequest,
+  ScopesUpdateRequest as ApiScopesUpdateRequest,
+} from '../types/api.generated'
+import type {
+  HumanRole,
+  Member,
+  MemberCreateInput,
+  MemberDetail,
+  MemberStatus,
+  MemberTokenView,
+  MemberType,
+} from '../types/member'
+
+function toMemberType(value: string): MemberType {
+  return value === 'human' ? 'human' : 'agent'
+}
+
+function toMemberStatus(value: string): MemberStatus {
+  if (value === 'suspended' || value === 'revoked') return value
+  return 'active'
+}
+
+function toHumanRole(value: string): HumanRole | undefined {
+  if (value === 'owner' || value === 'master' || value === 'admin') return value
+  return undefined
+}
+
+function toOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+export function toMemberView(raw: ApiMemberInfo): Member {
+  return {
+    member_id: raw.member_id,
+    name: raw.name,
+    type: toMemberType(raw.type),
+    org: raw.org,
+    emoji: raw.emoji || undefined,
+    role: toHumanRole(raw.role),
+    status: toMemberStatus(raw.status),
+    scopes: raw.scopes,
+    last_active_at: raw.last_active_at || undefined,
+    created_at: raw.created_at,
+  }
+}
+
+export function toMemberDetailView(raw: ApiMemberInfo): MemberDetail {
+  return {
+    ...toMemberView(raw),
+    scopes: raw.scopes,
+    created_by: raw.created_by || undefined,
+    token_prefix: toOptionalString(raw.token_prefix),
+    suspended_at: raw.suspended_at || undefined,
+  }
+}
+
+function toMemberTokenView(raw: ApiMemberCreateResponse | ApiMemberTokenResponse): MemberTokenView {
+  return {
+    member: toMemberDetailView(raw.member),
+    token: raw.token,
+  }
+}
 
 export async function getMembers(params?: {
   type?: string
   org?: string
   status?: string
 }): Promise<Member[]> {
-  const res = await client.get('/api/members', { params })
-  return res.data.members ?? res.data
+  const res = await client.get<ApiMemberListResponse>('/api/members', { params })
+  return res.data.members.map(toMemberView)
 }
 
 export async function getMemberDetail(id: string): Promise<MemberDetail> {
-  const res = await client.get(`/api/members/${id}`)
-  return res.data.member ?? res.data
+  const res = await client.get<ApiMemberDetailResponse>(`/api/members/${id}`)
+  return toMemberDetailView(res.data.member)
 }
 
-export async function createMember(data: MemberCreateRequest): Promise<{ token: string }> {
-  const res = await client.post('/api/members', data)
-  return res.data
+export async function createMember(data: MemberCreateInput): Promise<MemberTokenView> {
+  const payload: ApiMemberCreateRequest = {
+    ...data,
+    role: data.role ?? 'default',
+  }
+  const res = await client.post<ApiMemberCreateResponse>('/api/members', payload)
+  return toMemberTokenView(res.data)
 }
 
 export async function suspendMember(id: string): Promise<void> {
-  await client.post(`/api/members/${id}/suspend`)
+  await client.post<ApiMemberDetailResponse>(`/api/members/${id}/suspend`)
 }
 
 export async function reactivateMember(id: string): Promise<void> {
-  await client.post(`/api/members/${id}/reactivate`)
+  await client.post<ApiMemberDetailResponse>(`/api/members/${id}/reactivate`)
 }
 
 export async function revokeMember(id: string): Promise<void> {
-  await client.post(`/api/members/${id}/revoke`)
+  await client.post<ApiMemberDetailResponse>(`/api/members/${id}/revoke`)
 }
 
-export async function rotateToken(id: string): Promise<{ token: string }> {
-  const res = await client.post(`/api/members/${id}/rotate-token`)
-  return res.data
+export async function rotateToken(id: string): Promise<MemberTokenView> {
+  const res = await client.post<ApiMemberTokenResponse>(`/api/members/${id}/rotate-token`)
+  return toMemberTokenView(res.data)
 }
 
 export async function changePassword(id: string, oldPassword: string, newPassword: string): Promise<void> {
-  await client.patch(`/api/members/${id}/password`, { old_password: oldPassword, new_password: newPassword })
+  const payload: ApiPasswordChangeRequest = { old_password: oldPassword, new_password: newPassword }
+  await client.patch<ApiOkResponse>(`/api/members/${id}/password`, payload)
 }
 
 export async function updateScopes(id: string, scopes: string[]): Promise<void> {
-  await client.put(`/api/members/${id}/scopes`, { scopes })
+  const payload: ApiScopesUpdateRequest = { scopes }
+  await client.put<ApiMemberScopesResponse>(`/api/members/${id}/scopes`, payload)
 }
 
 export async function updateMemberInfo(id: string, data: { name: string; org: string }): Promise<void> {
-  await client.patch(`/api/members/${id}`, data)
+  await client.patch<ApiMemberDetailResponse>(`/api/members/${id}`, data)
 }

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { login, logout, getMe } from '../api/auth'
-import type { LoginRequest } from '../types/auth'
+import type { LoginInput } from '../types/auth'
 
 export function useUser() {
   return useQuery({
@@ -18,7 +18,7 @@ export function useLogin() {
   const [searchParams] = useSearchParams()
 
   return useMutation({
-    mutationFn: (data: LoginRequest) => login(data),
+    mutationFn: (data: LoginInput) => login(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['auth', 'me'] })
       const redirect = searchParams.get('redirect') || '/treasury'

--- a/frontend/src/hooks/useMembers.ts
+++ b/frontend/src/hooks/useMembers.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getMembers, getMemberDetail, createMember, suspendMember, reactivateMember, revokeMember, rotateToken, changePassword, updateScopes, updateMemberInfo } from '../api/members'
-import type { MemberCreateRequest } from '../types/member'
+import type { MemberCreateInput } from '../types/member'
 
 export function useMembers(params?: { type?: string; org?: string; status?: string }) {
   return useQuery({
@@ -20,7 +20,7 @@ export function useMemberDetail(id: string) {
 export function useCreateMember() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (data: MemberCreateRequest) => createMember(data),
+    mutationFn: (data: MemberCreateInput) => createMember(data),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['members'] }),
   })
 }

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,23 +1,31 @@
 /**
  * Auth 도메인 타입.
  *
- * API 응답 타입은 api.generated.ts에서 자동 생성된 타입을 사용한다.
- * 프론트엔드 전용 타입만 이 파일에 직접 정의한다.
+ * API 계약 타입은 frontend/src/api/auth.ts 어댑터 안에서만 사용한다.
+ * 이 파일은 화면과 훅이 공유하는 프론트엔드 전용 타입만 노출한다.
  */
-import type {
-  LoginRequest as GeneratedLoginRequest,
-  LoginResponse as GeneratedLoginResponse,
-  MeResponse,
-} from './api.generated'
-
-// ── API 응답 타입 re-export ──────────────────────────────
-export type LoginRequest = GeneratedLoginRequest
-export type LoginResponse = GeneratedLoginResponse
 
 // ── 프론트엔드 전용 타입 ──────────────────────────────────
 
-/** /api/auth/me 응답 — generated MeResponse에 scopes, org 필드 추가 */
-export interface User extends MeResponse {
-  org: string
+export interface LoginInput {
+  member_id: string
+  password: string
+}
+
+export interface LoginResultView {
+  member_id: string
+  name: string
+  type: string
+}
+
+export interface AuthUserView {
+  member_id: string
+  name: string
+  type: string
+  role: string
+  emoji?: string
+  login_at?: string
   scopes: string[]
 }
+
+export type User = AuthUserView

--- a/frontend/src/types/member.ts
+++ b/frontend/src/types/member.ts
@@ -1,8 +1,8 @@
 /**
  * Member 도메인 타입.
  *
- * 백엔드가 dict 기반(extra="allow") 응답을 반환하므로
- * 프론트엔드에서 상세 필드를 명시적으로 정의한다.
+ * API 계약 타입은 frontend/src/api/members.ts 어댑터 안에서만 사용한다.
+ * 이 파일은 화면과 훅이 공유하는 프론트엔드 전용 타입만 노출한다.
  */
 
 // ── 프론트엔드 전용 타입 ──────────────────────────────────
@@ -10,7 +10,7 @@ export type MemberStatus = 'active' | 'suspended' | 'revoked'
 export type MemberType = 'human' | 'agent'
 export type HumanRole = 'owner' | 'master' | 'admin'
 
-export interface Member {
+export interface MemberView {
   member_id: string
   name: string
   type: MemberType
@@ -23,20 +23,29 @@ export interface Member {
   created_at: string
 }
 
-export interface MemberDetail extends Member {
+export interface MemberDetailView extends MemberView {
   scopes: string[]
   created_by?: string
   token_prefix?: string
   suspended_at?: string
 }
 
-export interface MemberCreateRequest {
+export interface MemberCreateInput {
   member_id: string
   member_type: MemberType
   name: string
   org: string
+  role?: HumanRole | 'default'
   scopes: string[]
 }
+
+export interface MemberTokenView {
+  member: MemberDetailView
+  token: string
+}
+
+export type Member = MemberView
+export type MemberDetail = MemberDetailView
 
 export const ALL_SCOPES = [
   'strategy:read',


### PR DESCRIPTION
## Summary
- Keep auth/member generated OpenAPI contract types inside API adapters
- Expose frontend-facing Input/View types for auth and member hooks/components
- Add generated response type parameters to auth/member Axios calls and mapper functions

## Verification
- `cd frontend && npm run check-api-types` (exit 0; remaining report-only findings are outside #1261 scope)
- `cd frontend && npm run build`
- `git diff --check`

Closes #1261