### PR TITLE
feat(frontend): adapt strategy report data generated types

### DIFF
--- a/frontend/src/api/data.ts
+++ b/frontend/src/api/data.ts
@@ -1,8 +1,115 @@
 import client from './client'
+import type {
+  DatasetDetailResponse as ApiDatasetDetailResponse,
+  DatasetItem as ApiDatasetItem,
+  DatasetListResponse as ApiDatasetListResponse,
+  FeedStatusResponse as ApiFeedStatusResponse,
+  OkResponse as ApiOkResponse,
+  StorageSummaryResponse as ApiStorageSummaryResponse,
+} from '../types/api.generated'
 import type { FeedStatus } from '../types/feed'
 import type { DataType, Dataset, StorageInfo } from '../types/data'
 
 export type { DataType, Dataset, StorageInfo }
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? value as Record<string, unknown> : {}
+}
+
+function toString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function toDataType(value: string): DataType {
+  return value === 'fundamental' ? 'fundamental' : 'ohlcv'
+}
+
+function toDataset(raw: ApiDatasetItem): Dataset {
+  return {
+    id: raw.id,
+    symbol: raw.symbol,
+    timeframe: raw.timeframe,
+    data_type: toDataType(raw.data_type),
+    start_date: raw.start_date ?? '',
+    end_date: raw.end_date ?? '',
+    row_count: raw.row_count,
+    file_size: raw.file_size,
+  }
+}
+
+function toFeedStatus(raw: ApiFeedStatusResponse): FeedStatus {
+  return {
+    initialized: raw.initialized,
+    checkpoints: raw.checkpoints.map((item) => {
+      const row = toRecord(item)
+      return {
+        source: toString(row.source),
+        data_type: toString(row.data_type),
+        last_date: toString(row.last_date),
+        updated_at: toString(row.updated_at),
+      }
+    }),
+    recent_reports: raw.recent_reports.map((item) => {
+      const row = toRecord(item)
+      const summary = toRecord(row.summary)
+      return {
+        mode: toString(row.mode),
+        started_at: toString(row.started_at),
+        finished_at: toString(row.finished_at),
+        duration_seconds: toNumber(row.duration_seconds),
+        target_date: toString(row.target_date),
+        summary: {
+          symbols_total: toNumber(summary.symbols_total),
+          symbols_success: toNumber(summary.symbols_success),
+          symbols_failed: toNumber(summary.symbols_failed),
+          rows_written: toNumber(summary.rows_written),
+          data_types: toStringArray(summary.data_types),
+        },
+        failures: Array.isArray(row.failures)
+          ? row.failures.map((failure) => {
+            const failureRow = toRecord(failure)
+            return {
+              symbol: toString(failureRow.symbol),
+              date: toString(failureRow.date),
+              source: toString(failureRow.source),
+              reason: toString(failureRow.reason),
+              retries: toNumber(failureRow.retries),
+            }
+          })
+          : [],
+        warnings: Array.isArray(row.warnings)
+          ? row.warnings.map((warning) => {
+            const warningRow = toRecord(warning)
+            return {
+              symbol: toString(warningRow.symbol),
+              date: toString(warningRow.date),
+              type: toString(warningRow.type),
+              message: toString(warningRow.message),
+            }
+          })
+          : [],
+        config_errors: toStringArray(row.config_errors),
+      }
+    }),
+    api_keys: raw.api_keys.map((item) => {
+      const row = toRecord(item)
+      return {
+        key: toString(row.key),
+        set: row.set === true,
+        source: toString(row.source),
+      }
+    }),
+  }
+}
 
 export async function getDatasets(params?: {
   symbol?: string
@@ -11,25 +118,36 @@ export async function getDatasets(params?: {
   offset?: number
   limit?: number
 }): Promise<{ items: Dataset[]; total: number }> {
-  const res = await client.get('/api/data/datasets', { params })
-  return res.data
+  const res = await client.get<ApiDatasetListResponse>('/api/data/datasets', { params })
+  return {
+    items: res.data.items.map(toDataset),
+    total: res.data.total,
+  }
 }
 
 export async function getDatasetDetail(id: string): Promise<{ dataset: Dataset; preview: Record<string, unknown>[] }> {
-  const res = await client.get(`/api/data/datasets/${id}`)
-  return res.data
+  const res = await client.get<ApiDatasetDetailResponse>(`/api/data/datasets/${id}`)
+  return {
+    dataset: toDataset(res.data.dataset),
+    preview: res.data.preview,
+  }
 }
 
 export async function getStorageInfo(): Promise<StorageInfo> {
-  const res = await client.get('/api/data/storage')
-  return res.data
+  const res = await client.get<ApiStorageSummaryResponse>('/api/data/storage')
+  return {
+    total_bytes: res.data.total_bytes,
+    total_mb: res.data.total_mb,
+    by_timeframe: res.data.by_timeframe,
+    by_data_type: res.data.by_data_type ?? undefined,
+  }
 }
 
 export async function deleteDataset(id: string, data_type?: DataType): Promise<void> {
-  await client.delete(`/api/data/datasets/${id}`, { params: { data_type } })
+  await client.delete<ApiOkResponse>(`/api/data/datasets/${id}`, { params: { data_type } })
 }
 
 export async function getFeedStatus(): Promise<FeedStatus> {
-  const res = await client.get('/api/data/feed-status')
-  return res.data
+  const res = await client.get<ApiFeedStatusResponse>('/api/data/feed-status')
+  return toFeedStatus(res.data)
 }

--- a/frontend/src/api/reports.ts
+++ b/frontend/src/api/reports.ts
@@ -1,7 +1,113 @@
 import client from './client'
-import type { ReportDetail } from '../types/report'
+import type { ReportDetailResponse as ApiReportDetailResponse } from '../types/api.generated'
+import type { BacktestConfig, DatasetInfo, ReportDetail, ReportStatus, ReportSymbol } from '../types/report'
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? value as Record<string, unknown> : {}
+}
+
+function toString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function toNullableNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function toReportStatus(value: string): ReportStatus {
+  if (value === 'draft' || value === 'reviewed' || value === 'adopted' || value === 'rejected' || value === 'archived') return value
+  return 'submitted'
+}
+
+function toMetrics(value: Record<string, unknown>): Record<string, number> {
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, number] => typeof entry[1] === 'number' && Number.isFinite(entry[1])),
+  )
+}
+
+function toEquityCurve(value: unknown): { date: string; value: number }[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((item) => {
+    const row = toRecord(item)
+    const date = toString(row.date) || toString(row.timestamp)
+    const pointValue = typeof row.value === 'number' ? row.value : row.equity
+    return date && typeof pointValue === 'number' ? [{ date, value: pointValue }] : []
+  })
+}
+
+function toBacktestConfig(value: unknown): BacktestConfig | undefined {
+  const row = toRecord(value)
+  if (Object.keys(row).length === 0) return undefined
+  return {
+    initial_balance: toNullableNumber(row.initial_balance) ?? undefined,
+    timeframe: toString(row.timeframe) || undefined,
+    buy_commission_rate: toNullableNumber(row.buy_commission_rate) ?? undefined,
+    sell_commission_rate: toNullableNumber(row.sell_commission_rate) ?? undefined,
+    slippage_rate: toNullableNumber(row.slippage_rate) ?? undefined,
+  }
+}
+
+function toDatasetInfo(value: unknown): DatasetInfo {
+  const row = toRecord(value)
+  return {
+    symbol: toString(row.symbol),
+    symbol_name: toString(row.symbol_name) || undefined,
+    timeframe: toString(row.timeframe) || undefined,
+    start_date: toString(row.start_date) || undefined,
+    end_date: toString(row.end_date) || undefined,
+  }
+}
+
+function toReportSymbol(value: string | Record<string, unknown>): ReportSymbol {
+  if (typeof value === 'string') {
+    return { symbol: value, name: value, timeframe: '', period: '', rows: 0 }
+  }
+  return {
+    symbol: toString(value.symbol),
+    name: toString(value.name) || toString(value.symbol),
+    timeframe: toString(value.timeframe),
+    period: toString(value.period),
+    rows: toNumber(value.rows),
+  }
+}
+
+function toReportDetail(raw: ApiReportDetailResponse): ReportDetail {
+  return {
+    report_id: raw.report_id,
+    strategy_name: raw.strategy_name,
+    strategy_version: raw.strategy_version,
+    strategy_path: raw.strategy_path,
+    status: toReportStatus(raw.status),
+    submitted_at: raw.submitted_at,
+    submitted_by: raw.submitted_by,
+    submitted_by_id: undefined,
+    backtest_period: raw.backtest_period ?? '',
+    total_return_pct: raw.total_return_pct ?? 0,
+    total_trades: raw.total_trades ?? 0,
+    sharpe_ratio: raw.sharpe_ratio ?? null,
+    max_drawdown_pct: raw.max_drawdown_pct ?? null,
+    win_rate: raw.win_rate ?? null,
+    summary: raw.summary,
+    rationale: raw.rationale,
+    risks: raw.risks,
+    recommendations: raw.recommendations,
+    equity_curve: toEquityCurve(raw.equity_curve),
+    metrics: toMetrics(raw.metrics),
+    initial_balance: raw.initial_balance ?? null,
+    final_balance: raw.final_balance ?? null,
+    symbols: raw.symbols.map(toReportSymbol),
+    user_notes: raw.user_notes,
+    reviewed_at: raw.reviewed_at ?? null,
+    config: toBacktestConfig(raw.config),
+    datasets: raw.datasets.map(toDatasetInfo),
+  }
+}
 
 export async function getReportDetail(id: string): Promise<ReportDetail> {
-  const res = await client.get(`/api/reports/${id}`)
-  return res.data
+  const res = await client.get<ApiReportDetailResponse>(`/api/reports/${id}`)
+  return toReportDetail(res.data)
 }

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -1,65 +1,212 @@
 import client from './client'
+import type {
+  DailySummaryItem as ApiDailySummaryItem,
+  DailySummaryResponse as ApiDailySummaryResponse,
+  MonthlySummaryItem as ApiMonthlySummaryItem,
+  MonthlySummaryResponse as ApiMonthlySummaryResponse,
+  StatusUpdateRequest as ApiStatusUpdateRequest,
+  StrategyDetailResponse as ApiStrategyDetailResponse,
+  StrategyInfo as ApiStrategyInfo,
+  StrategyListItem as ApiStrategyListItem,
+  StrategyListResponse as ApiStrategyListResponse,
+  StrategyPerformanceResponse as ApiStrategyPerformanceResponse,
+  StrategyTradeItem as ApiStrategyTradeItem,
+  StrategyTradesResponse as ApiStrategyTradesResponse,
+  WeeklySummaryItem as ApiWeeklySummaryItem,
+  WeeklySummaryResponse as ApiWeeklySummaryResponse,
+} from '../types/api.generated'
 import type { Strategy, StrategyDetail, StrategyPerformance, Trade, DailySummary, WeeklySummary, MonthlySummary } from '../types/strategy'
 
+function toRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? value as Record<string, unknown> : {}
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function toOptionalNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function toOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function toEquityCurve(value: unknown): { date: string; value: number }[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((item) => {
+    const row = toRecord(item)
+    const date = toOptionalString(row.date) ?? toOptionalString(row.timestamp)
+    const pointValue = toOptionalNumber(row.value) ?? toOptionalNumber(row.equity) ?? toOptionalNumber(row.balance)
+    return date && pointValue != null ? [{ date, value: pointValue }] : []
+  })
+}
+
+function toStrategyListItem(raw: ApiStrategyListItem): Strategy {
+  return {
+    id: raw.id,
+    name: raw.name,
+    version: raw.version,
+    status: raw.status,
+    author_name: raw.author_name,
+    author_id: raw.author_id,
+    bot_id: raw.bot_id,
+    bot_status: raw.bot_status,
+    cumulative_return: raw.cumulative_return ?? undefined,
+  }
+}
+
+function toStrategyDetailView(
+  raw: ApiStrategyInfo,
+  detail: ApiStrategyDetailResponse,
+): StrategyDetail {
+  return {
+    id: raw.strategy_id,
+    name: raw.name,
+    version: raw.version,
+    status: detail.status ?? raw.status,
+    author_name: raw.author_name,
+    author_id: raw.author_id,
+    bot_id: detail.bot?.bot_id,
+    bot_status: detail.bot?.status,
+    created_at: raw.registered_at,
+    description: raw.description,
+    rationale: detail.rationale || raw.rationale,
+    risks: detail.risks.length > 0 ? detail.risks : raw.risks,
+    params: detail.params,
+    param_schema: detail.param_schema,
+    budget_allocated: toOptionalNumber(raw.budget_allocated),
+    unrealized_pnl: toOptionalNumber(raw.unrealized_pnl),
+  }
+}
+
+function toStrategyPerformanceView(raw: ApiStrategyPerformanceResponse): StrategyPerformance {
+  return {
+    total_trades: raw.total_trades,
+    winning_trades: raw.winning_trades,
+    losing_trades: raw.losing_trades,
+    win_rate: raw.win_rate,
+    total_pnl: raw.total_pnl,
+    total_commission: toOptionalNumber(raw.total_commission),
+    net_pnl: toOptionalNumber(raw.net_pnl),
+    avg_profit: toOptionalNumber(raw.avg_profit),
+    avg_loss: toOptionalNumber(raw.avg_loss),
+    avg_pnl: raw.avg_pnl,
+    profit_factor: raw.profit_factor,
+    max_drawdown: raw.max_drawdown,
+    max_drawdown_amount: toOptionalNumber(raw.max_drawdown_amount),
+    sharpe_ratio: raw.sharpe_ratio,
+    active_days: toOptionalNumber(raw.active_days),
+    realized_pnl: toOptionalNumber(raw.realized_pnl),
+    unrealized_pnl: toOptionalNumber(raw.unrealized_pnl),
+    budget_allocated: toOptionalNumber(raw.budget_allocated),
+    equity_curve: toEquityCurve(raw.equity_curve),
+  }
+}
+
+function toTrade(raw: ApiStrategyTradeItem): Trade {
+  return {
+    id: raw.trade_id,
+    trade_id: raw.trade_id,
+    bot_id: raw.bot_id,
+    symbol: raw.symbol,
+    side: raw.side,
+    quantity: raw.quantity,
+    price: raw.price,
+    executed_at: raw.timestamp,
+    timestamp: raw.timestamp,
+    status: raw.status,
+  }
+}
+
+function toDailySummary(raw: ApiDailySummaryItem): DailySummary {
+  return {
+    date: raw.date,
+    realized_pnl: raw.realized_pnl,
+    trade_count: raw.trade_count,
+    win_rate: raw.win_rate,
+  }
+}
+
+function toWeeklySummary(raw: ApiWeeklySummaryItem): WeeklySummary {
+  return {
+    week_start: raw.week_start,
+    week_end: raw.week_end,
+    week_label: raw.week_label,
+    realized_pnl: raw.realized_pnl,
+    trade_count: raw.trade_count,
+    win_rate: raw.win_rate,
+  }
+}
+
+function toMonthlySummary(raw: ApiMonthlySummaryItem): MonthlySummary {
+  return {
+    year: raw.year,
+    month: raw.month,
+    realized_pnl: raw.realized_pnl,
+    trade_count: raw.trade_count,
+    win_rate: raw.win_rate,
+  }
+}
+
 export async function getStrategies(params?: { search?: string }): Promise<Strategy[]> {
-  const res = await client.get('/api/strategies', { params })
-  return res.data.strategies ?? res.data
+  const res = await client.get<ApiStrategyListResponse>('/api/strategies', { params })
+  return res.data.strategies.map(toStrategyListItem)
 }
 
 export async function getStrategyDetail(id: string): Promise<StrategyDetail> {
-  const res = await client.get(`/api/strategies/${id}`)
-  const { strategy, params, param_schema, rationale, risks, ...rest } = res.data
-  if (strategy) {
-    return {
-      ...strategy,
-      params: params ?? strategy.params,
-      param_schema: param_schema ?? strategy.param_schema,
-      rationale: rationale ?? strategy.rationale,
-      risks: risks ?? strategy.risks,
-    }
-  }
-  return rest
+  const res = await client.get<ApiStrategyDetailResponse>(`/api/strategies/${id}`)
+  return toStrategyDetailView(res.data.strategy, res.data)
 }
 
 export async function getStrategyPerformance(id: string): Promise<StrategyPerformance> {
-  const res = await client.get(`/api/strategies/${id}/performance`)
-  return res.data
+  const res = await client.get<ApiStrategyPerformanceResponse>(`/api/strategies/${id}/performance`)
+  return toStrategyPerformanceView(res.data)
 }
 
 export async function getStrategyTrades(
   id: string,
   params?: { cursor?: number; limit?: number },
 ): Promise<{ items: Trade[]; next_cursor?: number }> {
-  const res = await client.get(`/api/strategies/${id}/trades`, { params })
-  return { items: res.data.trades ?? [], next_cursor: res.data.next_cursor }
+  const res = await client.get<ApiStrategyTradesResponse>(`/api/strategies/${id}/trades`, { params })
+  const nextCursor = res.data.next_cursor != null ? Number(res.data.next_cursor) : undefined
+  return {
+    items: res.data.trades.map(toTrade),
+    next_cursor: Number.isFinite(nextCursor) ? nextCursor : undefined,
+  }
 }
 
 export async function getStrategyDailySummary(id: string): Promise<DailySummary[]> {
-  const res = await client.get(`/api/strategies/${id}/daily-summary`)
-  return res.data.items
+  const res = await client.get<ApiDailySummaryResponse>(`/api/strategies/${id}/daily-summary`)
+  return res.data.items.map(toDailySummary)
 }
 
 export async function getStrategyWeeklySummary(id: string): Promise<WeeklySummary[]> {
-  const res = await client.get(`/api/strategies/${id}/weekly-summary`)
-  return res.data.items
+  const res = await client.get<ApiWeeklySummaryResponse>(`/api/strategies/${id}/weekly-summary`)
+  return res.data.items.map(toWeeklySummary)
 }
 
 export async function getStrategyMonthlySummary(id: string): Promise<MonthlySummary[]> {
-  const res = await client.get(`/api/strategies/${id}/monthly-summary`)
-  return res.data.items
+  const res = await client.get<ApiMonthlySummaryResponse>(`/api/strategies/${id}/monthly-summary`)
+  return res.data.items.map(toMonthlySummary)
 }
 
 export async function updateStrategyStatus(
   id: string,
   status: string,
 ): Promise<void> {
-  await client.patch(`/api/strategies/${id}/status`, { status })
+  const payload: ApiStatusUpdateRequest = { status }
+  await client.patch<ApiStrategyDetailResponse>(`/api/strategies/${id}/status`, payload)
 }
 
 export async function getStrategyTradesPaginated(
   id: string,
   params?: { offset?: number; limit?: number; side?: string; start_date?: string; end_date?: string },
 ): Promise<{ items: Trade[]; total: number }> {
-  const res = await client.get(`/api/strategies/${id}/trades`, { params })
-  return { items: res.data.trades ?? [], total: res.data.total ?? 0 }
+  const res = await client.get<ApiStrategyTradesResponse>(`/api/strategies/${id}/trades`, { params })
+  return {
+    items: res.data.trades.map(toTrade),
+    total: toNumber(toRecord(res.data).total, res.data.trades.length),
+  }
 }

--- a/frontend/src/types/strategy.ts
+++ b/frontend/src/types/strategy.ts
@@ -1,21 +1,10 @@
 /**
  * Strategy 도메인 타입.
  *
- * API 응답 타입은 api.generated.ts에서 자동 생성된 타입을 사용한다.
- * generated 타입에 누락된 필드는 프론트엔드에서 확장하여 정의한다.
+ * API 계약 타입은 frontend/src/api/strategies.ts 어댑터 안에서만 사용한다.
+ * 이 파일은 화면과 훅이 공유하는 프론트엔드 전용 타입만 노출한다.
  */
-import type {
-  DailySummaryItem,
-  WeeklySummaryItem,
-  MonthlySummaryItem,
-} from './api.generated'
 
-// ── API 응답 타입 re-export (generated 완전 대응) ────────
-export type DailySummary = DailySummaryItem
-export type WeeklySummary = WeeklySummaryItem
-export type MonthlySummary = MonthlySummaryItem
-
-/** 에쿼티 커브 포인트 — StrategyPerformance.equity_curve 원소 타입. */
 export interface EquityCurvePoint {
   date: string
   value: number
@@ -83,7 +72,7 @@ export interface StrategyPerformance {
   realized_pnl?: number
   unrealized_pnl?: number
   budget_allocated?: number
-  equity_curve: { date: string; value: number }[]
+  equity_curve: EquityCurvePoint[]
 }
 
 /**
@@ -91,7 +80,7 @@ export interface StrategyPerformance {
  * generated StrategyTradeItem과 필드명이 다르므로 프론트엔드에서 명시.
  */
 export interface Trade {
-  id?: number
+  id?: string | number
   trade_id?: string
   strategy_id?: number
   bot_id: string
@@ -105,4 +94,28 @@ export interface Trade {
   status?: string
   pnl?: number
   commission?: number
+}
+
+export interface DailySummary {
+  date: string
+  realized_pnl: number
+  trade_count: number
+  win_rate: number
+}
+
+export interface WeeklySummary {
+  week_start: string
+  week_end: string
+  week_label: string
+  realized_pnl: number
+  trade_count: number
+  win_rate: number
+}
+
+export interface MonthlySummary {
+  year: number
+  month: number
+  realized_pnl: number
+  trade_count: number
+  win_rate: number
 }


### PR DESCRIPTION
## Summary
- Keep Strategy/Report/Data generated OpenAPI contract types inside API adapters
- Map generated raw responses into frontend-facing domain types
- Remove generated type import from `frontend/src/types/strategy.ts`

## Verification
- `cd frontend && npm run check-api-types` (exit 0; remaining 4 report-only findings are #1263 Approval scope)
- `cd frontend && npm run build`
- `git diff --check`

Closes #1262