### PR TITLE
feat(frontend): adapt approval generated types

### DIFF
--- a/frontend/src/api/approvals.ts
+++ b/frontend/src/api/approvals.ts
@@ -1,5 +1,20 @@
 import client from './client'
-import type { Approval, ApprovalDetail, ApprovalStatus, ApprovalType } from '../types/approval'
+import type {
+  ApprovalDetailResponse as ApiApprovalDetailResponse,
+  ApprovalItem as ApiApprovalItem,
+  ApprovalListResponse as ApiApprovalListResponse,
+  ApprovalStatusUpdate as ApiApprovalStatusUpdate,
+  ApprovalUpdateResponse as ApiApprovalUpdateResponse,
+} from '../types/api.generated'
+import type {
+  Approval,
+  ApprovalDetail,
+  ApprovalHistoryEntry,
+  ApprovalListView,
+  ApprovalReview,
+  ApprovalStatus,
+  ApprovalType,
+} from '../types/approval'
 
 interface ApprovalsParams {
   status?: ApprovalStatus | 'all'
@@ -9,40 +24,103 @@ interface ApprovalsParams {
   limit?: number
 }
 
-interface ApprovalsResponse {
-  items: Approval[]
-  total: number
+function toRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? value as Record<string, unknown> : {}
 }
 
-/** API 응답의 created_at을 프론트엔드 타입의 requested_at으로 매핑 */
-function mapApproval<T extends Record<string, unknown>>(raw: T): T & { requested_at: string } {
-  const mapped = { ...raw } as T & { requested_at: string }
-  if (!mapped.requested_at && (raw as Record<string, unknown>).created_at) {
-    mapped.requested_at = (raw as Record<string, unknown>).created_at as string
+function toString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+function toOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function toApprovalStatus(value: string): ApprovalStatus {
+  if (value === 'approved' || value === 'rejected') return value
+  return 'pending'
+}
+
+function toApprovalType(value: string): ApprovalType {
+  if (
+    value === 'strategy_report'
+    || value === 'budget_allocate'
+    || value === 'live_switch'
+    || value === 'risk_alert'
+    || value === 'strategy_adopt'
+    || value === 'budget_change'
+    || value === 'bot_create'
+    || value === 'bot_stop'
+    || value === 'rule_change'
+  ) {
+    return value
   }
-  return mapped
+  return 'strategy_report'
 }
 
-export async function getApprovals(params: ApprovalsParams): Promise<ApprovalsResponse> {
+function toReviewResult(value: unknown): ApprovalReview['result'] {
+  if (value === 'pass' || value === 'fail') return value
+  return 'warn'
+}
+
+function toApprovalReview(value: unknown): ApprovalReview {
+  const row = toRecord(value)
+  return {
+    reviewer: toString(row.reviewer),
+    result: toReviewResult(row.result),
+    detail: toString(row.detail),
+    reviewed_at: toString(row.reviewed_at),
+  }
+}
+
+function toApprovalHistoryEntry(value: unknown): ApprovalHistoryEntry {
+  const row = toRecord(value)
+  return {
+    action: toString(row.action),
+    actor: toString(row.actor),
+    at: toString(row.at),
+    detail: toOptionalString(row.detail),
+  }
+}
+
+function toApproval(raw: ApiApprovalItem): Approval {
+  return {
+    id: raw.id,
+    type: toApprovalType(raw.type),
+    title: raw.title,
+    requester: raw.requester,
+    requested_at: toString(raw.created_at),
+    status: toApprovalStatus(raw.status),
+    reference_id: toOptionalString(raw.reference_id),
+    memo: toOptionalString(raw.memo),
+    resolved_at: toOptionalString(raw.resolved_at),
+    resolved_by: toOptionalString(raw.resolved_by),
+    body: toOptionalString(raw.body),
+    params: raw.params,
+    reviews: raw.reviews.map(toApprovalReview),
+    history: raw.history.map(toApprovalHistoryEntry),
+    expires_at: toOptionalString(raw.expires_at),
+    reject_reason: toOptionalString(raw.reject_reason),
+  }
+}
+
+export async function getApprovals(params: ApprovalsParams): Promise<ApprovalListView> {
   const query: Record<string, string | number> = {}
   if (params.status && params.status !== 'all') query.status = params.status
   if (params.type && params.type !== 'all') query.type = params.type
   if (params.search) query.search = params.search
   if (params.offset) query.offset = params.offset
   if (params.limit) query.limit = params.limit
-  const res = await client.get('/api/approvals', { params: query })
-  const data = res.data
-  const rawItems = data.approvals ?? data.items ?? []
+  const res = await client.get<ApiApprovalListResponse>('/api/approvals', { params: query })
   return {
-    items: rawItems.map(mapApproval),
-    total: data.total ?? rawItems.length,
+    items: res.data.approvals.map(toApproval),
+    total: res.data.total,
   }
 }
 
 export async function getApprovalDetail(id: string): Promise<ApprovalDetail> {
-  const res = await client.get(`/api/approvals/${id}`)
-  const raw = res.data.approval ?? res.data
-  return mapApproval(raw)
+  const res = await client.get<ApiApprovalDetailResponse>(`/api/approvals/${id}`)
+  return toApproval(res.data.approval)
 }
 
 export async function updateApprovalStatus(
@@ -50,5 +128,6 @@ export async function updateApprovalStatus(
   status: 'approved' | 'rejected',
   memo?: string,
 ): Promise<void> {
-  await client.patch(`/api/approvals/${id}/status`, { status, memo })
+  const payload: ApiApprovalStatusUpdate = { status, memo: memo ?? '' }
+  await client.patch<ApiApprovalUpdateResponse>(`/api/approvals/${id}/status`, payload)
 }

--- a/frontend/src/types/approval.ts
+++ b/frontend/src/types/approval.ts
@@ -1,8 +1,8 @@
 /**
  * Approval 도메인 타입.
  *
- * 백엔드가 dict 기반(extra="allow") 응답을 반환하므로
- * 프론트엔드에서 상세 필드를 명시적으로 정의한다.
+ * API 계약 타입은 frontend/src/api/approvals.ts 어댑터 안에서만 사용한다.
+ * 이 파일은 화면과 훅이 공유하는 프론트엔드 전용 타입만 노출한다.
  */
 
 // ── 프론트엔드 전용 타입 ──────────────────────────────────
@@ -52,3 +52,8 @@ export interface Approval {
 }
 
 export type ApprovalDetail = Approval
+
+export interface ApprovalListView {
+  items: Approval[]
+  total: number
+}


### PR DESCRIPTION
## Summary
- Keep Approval generated OpenAPI contract types inside the approval API adapter
- Replace manual `ApprovalsResponse` with frontend-facing `ApprovalListView`
- Map approval raw items into UI/domain types with generated response generics

## Verification
- `cd frontend && npm run check-api-types` (Findings 0)
- `cd frontend && npm run build`
- `git diff --check`

Closes #1263