### PR TITLE
feat(frontend): prepare api type boundary strict gate

### DIFF
--- a/docs/dashboard/architecture.md
+++ b/docs/dashboard/architecture.md
@@ -223,9 +223,17 @@ export default function BotDetail() {
 - **adapter boundary**: `frontend/src/api/*.ts`만 generated type을 import하고, raw response를 UI/domain model로 변환한다.
 - **UI/domain model**: `frontend/src/types/*.ts`에는 `View`, `Input`, `FormValues` 등 프론트 전용 타입만 둔다.
 - **금지 suffix**: 수동 `Response`, `Request`, `Payload` 타입 선언 금지 (`api.generated.ts` 제외)
+- **경계 검사**: `npm run check-api-types`는 report-only 진단, `npm run check-api-types:strict`는 zero-finding blocking 기준이다.
 - **`interface`**: 컴포넌트 Props, UI/domain model 등 프론트 전용 객체 정의
 - **`type`**: UI 상태 유니온·별칭 (`type BotStatus = 'running' | 'stopped'`)
 - **`enum` 미사용**: 백엔드 enum은 string literal union으로 표현
+
+#### API 타입 경계 Gate 준비 기준
+
+- strict gate 정책은 `zero-violation`이다. findings가 0인 상태를 baseline으로 삼고 allowlist는 두지 않는다.
+- 후속 CI 적용 이슈는 `cd frontend && npm run check-api-types:strict`를 blocking command로 사용한다.
+- 새 API adapter는 generated response/request 타입을 `frontend/src/api/*.ts` 내부에서만 import해야 하며, hooks/pages/components/types 계층으로 누수되면 strict gate 실패 대상이다.
+- `as unknown as`는 API adapter의 `toXxxView()` mapper 내부에서만 예외적으로 허용한다.
 
 #### React Query 규칙
 

--- a/docs/runbooks/04-ci-cd.md
+++ b/docs/runbooks/04-ci-cd.md
@@ -79,6 +79,18 @@ PR이 열린 뒤 추가 코드 변경이 발생하면 새 head SHA에서 `/codex
 - **결과**: `ci`
 - **release PR 추가 검증**: head branch가 `release/*`이면 Docker image build를 함께 검증한다. 이 단계에서는 registry push를 하지 않는다.
 
+#### Frontend API Type Boundary Gate 준비 기준
+
+Frontend OpenAPI 타입 경계 검사는 zero-violation 정책을 사용한다.
+
+- Report-only 진단: `cd frontend && npm run check-api-types`
+- Blocking 명령: `cd frontend && npm run check-api-types:strict`
+- Baseline/allowlist: 사용하지 않는다. #1261/#1262/#1263 이후 findings 0을 기준선으로 삼는다.
+- Changed-file mode: 사용하지 않는다. 전체 `frontend/src` 경계를 검사한다.
+- CI workflow required check 적용은 별도 후속 이슈에서 수행한다. 이 문서는 후속 적용의 acceptance criteria만 정의한다.
+
+후속 CI 적용 PR은 `check-api-types:strict`가 findings 0으로 통과하고, 동일 PR에서 `.github/workflows/ci.yml`에 blocking step을 추가해야 한다.
+
 예시:
 
 ```yaml

--- a/docs/runbooks/05-testing.md
+++ b/docs/runbooks/05-testing.md
@@ -136,7 +136,27 @@ pytest tests/unit/test_eventbus.py -v
 pytest tests/unit/test_eventbus.py::test_publish_subscribe -v
 ```
 
-## 7. 배포 이미지 시뮬레이션 테스트
+## 7. 프론트엔드 API 타입 경계 검사
+
+대시보드 API 계약은 OpenAPI generated type을 wire contract로 사용하고,
+`frontend/src/api/*.ts` adapter가 UI/domain model로 변환한다.
+
+```bash
+# report-only 진단
+cd frontend && npm run check-api-types
+
+# blocking 기준 dry-run
+cd frontend && npm run check-api-types:strict
+```
+
+- `check-api-types:strict`는 findings가 1건 이상이면 non-zero로 종료한다.
+- 기준선은 findings 0이다. baseline/allowlist는 두지 않는다.
+- generated type import는 `frontend/src/api/*.ts`와 `frontend/src/types/api.generated.ts`에만 허용한다.
+- 수동 `Response`, `Request`, `Payload` 타입 선언은 `api.generated.ts` 밖에서 금지한다.
+- `client.get/post/put/patch/delete` 호출은 adapter 안에서 generated response type parameter를 명시한다.
+- `as unknown as`는 API adapter의 `toXxxView()` mapper 내부에서만 예외적으로 허용한다.
+
+## 8. 배포 이미지 시뮬레이션 테스트
 
 기존 repo-local QA 체계는 1.0 테스트 계약에서 제외한다.
 저장소는 더 이상 QA 전용 Docker image, QA compose, TC 파일, QA seed script를
@@ -147,9 +167,9 @@ pytest tests/unit/test_eventbus.py::test_publish_subscribe -v
 CLI, process lifecycle, health endpoint를 검증해야 하며, repo 내부 DB 직접
 시딩이나 QA 전용 entrypoint에 의존하지 않는다.
 
-## 8. 에이전트의 테스트 작성 규칙
+## 9. 에이전트의 테스트 작성 규칙
 
-### 8.1 단위/통합 테스트 (`@backend-dev`, `@frontend-dev`)
+### 9.1 단위/통합 테스트 (`@backend-dev`, `@frontend-dev`)
 
 - 모듈 구현 PR에 해당 모듈의 단위 테스트를 반드시 포함
 - 테스트 없는 코드는 내부 `/codex:review` 브랜치 리뷰에서 blocking failure로 판정한다

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "generate-types": "bash scripts/generate-types.sh",
-    "check-api-types": "node scripts/check-api-type-boundaries.mjs"
+    "check-api-types": "node scripts/check-api-type-boundaries.mjs",
+    "check-api-types:strict": "node scripts/check-api-type-boundaries.mjs --fail-on-findings"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.1",

--- a/frontend/scripts/check-api-type-boundaries.mjs
+++ b/frontend/scripts/check-api-type-boundaries.mjs
@@ -14,6 +14,9 @@ const unknownCastPattern = /\bas\s+unknown\s+as\b/g
 const ignoredDirs = new Set(['node_modules', 'dist', '.vite-temp'])
 const sourceExtensions = new Set(['.ts', '.tsx'])
 const findings = []
+const strictMode =
+  process.argv.includes('--fail-on-findings')
+  || process.env.ANTE_API_TYPE_BOUNDARY_STRICT === '1'
 
 function walk(dir) {
   const files = []
@@ -133,7 +136,7 @@ const byRule = findings.reduce((acc, finding) => {
   return acc
 }, {})
 
-console.log('Frontend API type boundary report (report-only)')
+console.log(`Frontend API type boundary report (${strictMode ? 'strict' : 'report-only'})`)
 console.log(`Scanned: ${rel(srcRoot)}`)
 console.log(`Findings: ${findings.length}`)
 for (const [rule, count] of Object.entries(byRule).sort()) {
@@ -149,4 +152,9 @@ if (findings.length > 0) {
   }
 }
 
-console.log('\nResult: report-only, exit 0')
+if (strictMode && findings.length > 0) {
+  console.log('\nResult: strict, exit 1')
+  process.exit(1)
+}
+
+console.log(`\nResult: ${strictMode ? 'strict' : 'report-only'}, exit 0`)


### PR DESCRIPTION
## Summary
- Add strict fail-on-findings mode for the frontend API type boundary checker
- Add `npm run check-api-types:strict` as the follow-up CI input
- Document zero-violation acceptance criteria across dashboard architecture and runbooks

## Policy
- zero-violation strict gate
- no baseline/allowlist
- no changed-file mode
- no workflow/branch protection changes in this PR

## Verification
- `cd frontend && npm run check-api-types`
- `cd frontend && npm run check-api-types:strict`
- `cd frontend && ANTE_API_TYPE_BOUNDARY_STRICT=1 npm run check-api-types`
- `node --check frontend/scripts/check-api-type-boundaries.mjs`
- `git diff --check`

Closes #1264