### PR TITLE
ci(frontend): gate api type boundary checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,18 @@ jobs:
           ANTE_DB_ENCRYPTION_KEY: "sm4fkbGXHVNKjw2OvQIrQX5g9qdRGqNKST8pFixdNPk="
         run: pytest tests/unit/ -x -n auto --tb=short -q --cov=src/ante --cov-fail-under=80
 
+  frontend-api-types:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Check frontend API type boundaries
+        run: cd frontend && npm run check-api-types:strict
+
   docker-build:
     runs-on: ubuntu-latest
     steps:
@@ -75,6 +87,7 @@ jobs:
     needs:
       - lint
       - test
+      - frontend-api-types
       - docker-build
     steps:
       - name: CI gate passed

--- a/docs/runbooks/04-ci-cd.md
+++ b/docs/runbooks/04-ci-cd.md
@@ -85,15 +85,17 @@ Frontend OpenAPI 타입 경계 검사는 zero-violation 정책을 사용한다.
 
 - Report-only 진단: `cd frontend && npm run check-api-types`
 - Blocking 명령: `cd frontend && npm run check-api-types:strict`
+- CI job: `frontend-api-types`
 - Baseline/allowlist: 사용하지 않는다. #1261/#1262/#1263 이후 findings 0을 기준선으로 삼는다.
 - Changed-file mode: 사용하지 않는다. 전체 `frontend/src` 경계를 검사한다.
-- CI workflow required check 적용은 별도 후속 이슈에서 수행한다. 이 문서는 후속 적용의 acceptance criteria만 정의한다.
+- `ci` aggregate job은 `frontend-api-types`를 `needs`에 포함한다. branch protection이 `ci`를 required status check로 사용하면 API 타입 경계 위반도 `ci` 실패로 머지를 차단한다.
 
-후속 CI 적용 PR은 `check-api-types:strict`가 findings 0으로 통과하고, 동일 PR에서 `.github/workflows/ci.yml`에 blocking step을 추가해야 한다.
+branch protection repository setting은 이 저장소 밖 운영 설정이므로 워크플로우가 직접 수정하지 않는다.
 
 예시:
 
 ```yaml
+- cd frontend && npm run check-api-types:strict
 - ruff check src/ tests/
 - ruff format --check src/ tests/
 - mypy src/

--- a/docs/runbooks/05-testing.md
+++ b/docs/runbooks/05-testing.md
@@ -145,11 +145,12 @@ pytest tests/unit/test_eventbus.py::test_publish_subscribe -v
 # report-only 진단
 cd frontend && npm run check-api-types
 
-# blocking 기준 dry-run
+# blocking/CI 기준
 cd frontend && npm run check-api-types:strict
 ```
 
 - `check-api-types:strict`는 findings가 1건 이상이면 non-zero로 종료한다.
+- GitHub Actions job 이름은 `frontend-api-types`이며 최종 `ci` aggregate job의 입력이다.
 - 기준선은 findings 0이다. baseline/allowlist는 두지 않는다.
 - generated type import는 `frontend/src/api/*.ts`와 `frontend/src/types/api.generated.ts`에만 허용한다.
 - 수동 `Response`, `Request`, `Payload` 타입 선언은 `api.generated.ts` 밖에서 금지한다.


### PR DESCRIPTION
## Summary
- Add a `frontend-api-types` CI job that runs `npm run check-api-types:strict`
- Include `frontend-api-types` in the final `ci` aggregate job
- Align runbooks with the actual job name and blocking behavior

## Verification
- `cd frontend && npm run check-api-types:strict`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml')"`
- `git diff --check`

Closes #1265