### PR TITLE
docs(architecture): add project structure generator

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -1,492 +1,759 @@
 # Ante 프로젝트 디렉토리 구조
 
-> 이 문서는 실제 소스 트리에서 생성된 문서입니다.
-> 새 모듈/파일 추가 시 이 문서도 함께 최신화해 주세요.
->
-> 마지막 갱신: 2026-04-24
+> 역할: Agent용 프로젝트 구조 INDEX의 단일 SSOT입니다.
+> 생성 명령: `.venv/bin/python scripts/generate_project_structure.py`
+> Check 명령: `.venv/bin/python scripts/generate_project_structure.py --check`
+> 생성 기준: 현재 Git 추적/비무시 파일 트리 (`git ls-files --cached --others --exclude-standard`)
+> 마지막 생성 시점: 2026-05-05 (KST)
 
 ## 최상위 구조
 
 ```
 ante/
-├── src/ante/            # Python 백엔드 패키지
-├── tests/               # 단위·통합·E2E 테스트
-├── frontend/            # React 대시보드 (Vite + TypeScript)
-├── guide/               # 사용자·운용 가이드 문서
-├── docs/                # 설계 문서
-├── deploy/              # 서비스 배포 파일 (systemd, launchd)
-├── scripts/             # 설치·운영·문서 생성 스크립트
-├── .agent/              # 에이전트 정의/명령/스킬
-├── .claude/             # Claude Code 설정 + .agent 호환 링크
-├── .github/             # GitHub 워크플로/이슈 템플릿/로컬 인증 파일
-├── Dockerfile           # 프로덕션 Docker 이미지
-├── docker-compose.yml        # 프로덕션 Docker Compose (ante-logs named volume 포함)
-├── AGENTS.md            # 개발 Agent 마스터 가이드
-└── CHANGELOG.md         # 변경 이력
+├── src/ante/                         # Python 백엔드 패키지
+├── tests/                            # 단위·통합·E2E 테스트
+├── frontend/                         # React 대시보드 (Vite + TypeScript)
+├── guide/                            # 사용자·운용 가이드 문서
+├── docs/                             # 설계 문서
+├── deploy/                           # 서비스 배포 파일 (systemd, launchd)
+├── scripts/                          # 설치·운영·문서 생성 스크립트
+├── strategies/                       # 전략 템플릿과 예제
+├── config/                           # 런타임 설정 예시와 의존성 스냅샷
+├── .agent/                           # 에이전트 정의/명령/스킬
+├── .claude/                          # Claude Code 설정 + .agent 호환 링크
+├── .github/                          # GitHub 워크플로/이슈 템플릿/로컬 인증 파일
+├── Dockerfile                        # 프로덕션 Docker 이미지
+├── docker-compose.yml                # 프로덕션 Docker Compose (ante-logs named volume 포함)
+├── AGENTS.md                         # 개발 Agent 마스터 가이드
+├── CHANGELOG.md                      # 변경 이력
+├── README.md                         # 프로젝트 개요
+├── CLAUDE.md                         # Claude Code 호환 가이드
+└── LICENSE                           # 라이선스
 ```
 
 ## src/ante/ — Python 백엔드
 
 ```
 src/ante/
-├── __main__.py                  # python -m ante 실행 지원
-├── main.py                      # asyncio 엔트리포인트 (Composition Root)
-│
+├── __main__.py                       # python -m ante 실행 지원
+├── main.py                           # asyncio 엔트리포인트 (Composition Root)
 ├── core/
-│   ├── database.py              # Database — SQLite WAL 연결 관리
-│   └── log/                     # 시스템 로그 인프라 (JSONL 포맷, fingerprint)
-│       ├── __init__.py
-│       ├── _record_keys.py      # LogRecord 속성 / Ante 예약 키 단일 소스 (runtime probe)
-│       ├── formatter.py         # JsonFormatter — JSONL 직렬화
-│       ├── fingerprint.py       # compute_fingerprint() — 예외 dedup 키
-│       ├── handlers.py          # DateNamedTimedRotatingFileHandler (KST 자정 no-rename 회전)
-│       ├── safe_logger.py       # AnteLogger, install_safe_logger() (makeRecord 예약 키 정규화)
-│       └── setup.py             # setup_logging() stdout + JSONL 파일 핸들러 구성
-│
+│   ├── database.py                   # Database — SQLite WAL 연결 관리
+│   ├── log/                          # 시스템 로그 인프라 (JSONL 포맷, fingerprint)
+│   │   ├── __init__.py
+│   │   ├── _record_keys.py           # LogRecord 속성 / Ante 예약 키 단일 소스 (runtime probe)
+│   │   ├── formatter.py              # JsonFormatter — JSONL 직렬화
+│   │   ├── fingerprint.py            # compute_fingerprint() — 예외 dedup 키
+│   │   ├── handlers.py               # DateNamedTimedRotatingFileHandler (KST 자정 no-rename 회전)
+│   │   ├── safe_logger.py            # AnteLogger, install_safe_logger() (makeRecord 예약 키 정규화)
+│   │   └── setup.py                  # setup_logging() stdout + JSONL 파일 핸들러 구성
+│   ├── __init__.py
+│   └── registry.py
 ├── config/
-│   ├── config.py                # ConfigService — 설정 로딩 (system.toml + secrets.env)
-│   ├── defaults.py              # 기본 설정값
-│   ├── dynamic.py               # DynamicConfigService — DB 기반 런타임 설정
+│   ├── config.py                     # ConfigService — 설정 로딩 (system.toml + secrets.env)
+│   ├── defaults.py                   # 기본 설정값
+│   ├── dynamic.py                    # DynamicConfigService — DB 기반 런타임 설정
 │   ├── exceptions.py
-│   └── system_state.py          # SystemState — 시스템 상태 (active/halted)
-│
+│   └── __init__.py
 ├── eventbus/
-│   ├── bus.py                   # EventBus — asyncio.Queue 기반 발행/구독
-│   ├── events.py                # 전체 이벤트 dataclass 정의
-│   └── history.py               # EventHistory — 이벤트 이력 추적
-│
+│   ├── bus.py                        # EventBus — asyncio.Queue 기반 발행/구독
+│   ├── events.py                     # 전체 이벤트 dataclass 정의
+│   ├── history.py                    # EventHistory — 이벤트 이력 추적
+│   └── __init__.py
 ├── audit/
-│   └── logger.py                # AuditLogger — 감사 로그 기록 (SQLite)
-│
+│   ├── logger.py                     # AuditLogger — 감사 로그 기록 (SQLite)
+│   └── __init__.py
 ├── approval/
-│   ├── models.py                # ApprovalRequest, ApprovalStatus, ApprovalType
-│   └── service.py               # ApprovalService — 결재 요청 관리 + 자동 실행
-│
+│   ├── models.py                     # ApprovalRequest, ApprovalStatus, ApprovalType
+│   ├── service.py                    # ApprovalService — 결재 요청 관리 + 자동 실행
+│   ├── __init__.py
+│   └── auto_approve.py
 ├── instrument/
-│   ├── models.py                # Instrument — 종목 메타데이터 (frozen dataclass)
-│   └── service.py               # InstrumentService — 전체 메모리 캐시 + SQLite
-│
+│   ├── models.py                     # Instrument — 종목 메타데이터 (frozen dataclass)
+│   ├── service.py                    # InstrumentService — 전체 메모리 캐시 + SQLite
+│   └── __init__.py
 ├── member/
-│   ├── auth.py                  # 토큰 생성, 복구 키, 인증 유틸리티
-│   ├── models.py                # Member 데이터 모델 (MemberType 등)
-│   └── service.py               # MemberService — 멤버 등록·인증·관리
-│
+│   ├── auth.py                       # 토큰 생성, 복구 키, 인증 유틸리티
+│   ├── models.py                     # Member 데이터 모델 (MemberType 등)
+│   ├── service.py                    # MemberService — 멤버 등록·인증·관리
+│   ├── __init__.py
+│   ├── auth_service.py
+│   ├── errors.py
+│   ├── recovery_key_manager.py
+│   └── token_manager.py
 ├── bot/
-│   ├── bot.py                   # Bot — 봇 실행 루프, 전략 실행, 이벤트 발행
-│   ├── config.py                # BotConfig — 봇 설정 (exchange, 자금 한도 등)
-│   ├── context_factory.py       # BotContextFactory — 봇 실행 컨텍스트 생성
+│   ├── bot.py                        # Bot — 봇 실행 루프, 전략 실행, 이벤트 발행
+│   ├── config.py                     # BotConfig — 봇 설정 (exchange, 자금 한도 등)
+│   ├── context_factory.py            # BotContextFactory — 봇 실행 컨텍스트 생성
 │   ├── exceptions.py
-│   ├── manager.py               # BotManager — 봇 생명주기 관리
-│   ├── signal_channel.py        # SignalChannel — JSON Lines 파이프 기반 양방향 시그널 채널
-│   ├── signal_key.py            # SignalKeyManager — 봇별 시그널 키 발급/관리
-│   └── providers/
-│       ├── live.py              # LiveProvider — 실전 봇 데이터 공급
-│       └── paper.py             # PaperProvider — 모의 봇 데이터 공급
-│
+│   ├── manager.py                    # BotManager — 봇 생명주기 관리
+│   ├── signal_channel.py             # SignalChannel — JSON Lines 파이프 기반 양방향 시그널 채널
+│   ├── signal_key.py                 # SignalKeyManager — 봇별 시그널 키 발급/관리
+│   ├── providers/
+│   │   ├── live.py                   # LiveProvider — 실전 봇 데이터 공급
+│   │   ├── paper.py                  # PaperProvider — 모의 봇 데이터 공급
+│   │   └── __init__.py
+│   ├── __init__.py
+│   └── cold_path.py
 ├── strategy/
-│   ├── base.py                  # Strategy ABC, StrategyMeta, TradeHistoryView
-│   ├── context.py               # StrategyContext — 전략 실행 컨텍스트 (파일 접근, 로깅, 거래 이력)
+│   ├── base.py                       # Strategy ABC, StrategyMeta, TradeHistoryView
+│   ├── context.py                    # StrategyContext — 전략 실행 컨텍스트 (파일 접근, 로깅, 거래 이력)
 │   ├── exceptions.py
-│   ├── indicators.py            # IndicatorCalculator — pandas-ta 기반 기술 지표 계산 (130+종)
-│   ├── snapshot.py              # StrategySnapshot — 전략 파일 스냅샷 생성/정리
-│   ├── loader.py                # StrategyLoader — 전략 파일 동적 로드
-│   ├── registry.py              # StrategyRegistry — 전략 등록/관리
-│   └── validator.py             # StrategyValidator — AST 기반 정적 검증
-│
+│   ├── indicators.py                 # IndicatorCalculator — pandas-ta 기반 기술 지표 계산 (130+종)
+│   ├── snapshot.py                   # StrategySnapshot — 전략 파일 스냅샷 생성/정리
+│   ├── loader.py                     # StrategyLoader — 전략 파일 동적 로드
+│   ├── registry.py                   # StrategyRegistry — 전략 등록/관리
+│   ├── validator.py                  # StrategyValidator — AST 기반 정적 검증
+│   └── __init__.py
 ├── rule/
-│   ├── base.py                  # Rule ABC, RuleContext, RuleEvaluation, EvaluationResult
-│   ├── engine.py                # RuleEngine — 전역/전략별 룰 평가
+│   ├── base.py                       # Rule ABC, RuleContext, RuleEvaluation, EvaluationResult
+│   ├── engine.py                     # RuleEngine — 전역/전략별 룰 평가
 │   ├── exceptions.py
-│   ├── global_rules.py          # 전역 룰 정의
-│   └── strategy_rules.py        # 전략별 룰 정의
-│
+│   ├── global_rules.py               # 전역 룰 정의
+│   ├── strategy_rules.py             # 전략별 룰 정의
+│   ├── __init__.py
+│   └── manager.py
 ├── treasury/
-│   ├── models.py                # TreasuryAllocation — 자금 할당 모델
-│   ├── treasury.py              # Treasury — 자금 배분 및 한도 관리
-│   └── exceptions.py
-│
-├── trade/
-│   ├── models.py                # TradeRecord, PositionSnapshot, PerformanceMetrics
-│   ├── recorder.py              # TradeRecorder — 거래 기록 (SQLite)
-│   ├── position.py              # PositionTracker — 포지션 추적
-│   ├── performance.py           # PerformanceCalculator — 성과 산출
-│   ├── reconciler.py            # PositionReconciler — 포지션 정합성 검증 및 자동 보정
-│   └── service.py               # TradeService — 위 컴포넌트 조합
-│
-├── broker/
-│   ├── base.py                  # BrokerAdapter ABC
-│   ├── models.py                # CommissionInfo dataclass
-│   ├── kis.py                   # KISAdapter — 한국투자증권 API 구현체
-│   ├── kis_stream.py            # KISStreamClient — KIS WebSocket 실시간 시세/체결 통보
-│   ├── circuit_breaker.py       # CircuitBreaker — API 장애 차단
-│   ├── error_codes.py           # KIS API 에러 코드 분류 (영구/일시)
-│   ├── mock.py                  # MockBroker — 테스트/모의투자용 브로커 구현체
-│   ├── order_registry.py        # OrderRegistry — 주문 상태 추적 (SQLite)
-│   └── exceptions.py
-│
-├── gateway/
-│   ├── gateway.py               # APIGateway — rate limit, 캐시, 이벤트 기반 주문
-│   ├── rate_limiter.py          # RateLimiter — 호출 빈도 제한
-│   ├── cache.py                 # ResponseCache — TTL 기반 응답 캐시
-│   ├── queue.py                 # OrderQueue — 주문 큐 관리
-│   ├── data_provider.py         # GatewayDataProvider — 시세 조회 래퍼
-│   └── stop_order.py            # StopOrderManager — 스탑 주문 에뮬레이션 (KRX 대응)
-│
-├── data/
-│   ├── collector.py             # DataCollector — 실시간 시세 수집 → Parquet
-│   ├── normalizer.py            # BaseNormalizer ABC + KIS/Yahoo/Default Normalizer, DataNormalizer 파사드
-│   ├── retention.py             # DataRetention — 보존 정책, 외부 이관
-│   ├── schemas.py               # OHLCV 등 데이터 스키마 정의
-│   └── store.py                 # DataStore — Parquet 읽기/쓰기
-│
-├── feed/                            # DataFeed — 외부 데이터 수집 파이프라인
-│   ├── cli.py                   # ante feed — DataFeed CLI 커맨드 (init/status/inject/config)
-│   ├── config.py                # FeedConfig — DataFeed 설정 관리 (API 키, 경로 등)
-│   ├── injector.py              # FeedInjector — CSV 파일에서 데이터 수동 주입
-│   ├── models/
-│   │   └── result.py            # ValidationResult, CollectionResult — 수집 결과 모델
-│   ├── pipeline/
-│   │   ├── checkpoint.py        # Checkpoint — 체크포인트 저장 및 복원
-│   │   ├── orchestrator.py      # FeedOrchestrator — backfill/daily ETL 파이프라인 오케스트레이션
-│   │   └── scheduler.py         # 날짜 범위 생성 (backfill vs daily 모드)
-│   ├── report/
-│   │   └── generator.py         # ReportGenerator — 수집 리포트 생성
-│   ├── sources/
-│   │   ├── base.py              # DataSource Protocol, RateLimiter 기반 클래스
-│   │   ├── data_go_kr.py        # DataGoKrSource — data.go.kr 주식시세 API 소스 어댑터
-│   │   └── dart.py              # DARTSource — DART OpenAPI 소스 어댑터
-│   └── transform/
-│       └── validate.py          # 4계층 데이터 검증 (transport/syntax/schema/business)
-│
-├── backtest/
-│   ├── context.py               # BacktestContext — 백테스트 실행 환경
-│   ├── data_provider.py         # BacktestDataProvider — Parquet 기반 시세 공급
+│   ├── models.py                     # TreasuryAllocation — 자금 할당 모델
+│   ├── treasury.py                   # Treasury — 자금 배분 및 한도 관리
 │   ├── exceptions.py
-│   ├── executor.py              # BacktestExecutor — 전략 실행 루프
-│   ├── metrics.py               # calculate_metrics — 성과 지표 (Sharpe, MDD 등)
-│   ├── result.py                # BacktestResult, BacktestTrade — 결과 모델
-│   ├── runner.py                # BacktestRunner — subprocess 진입점
-│   └── service.py               # BacktestService — 메인 프로세스 인터페이스
-│
+│   ├── __init__.py
+│   └── manager.py
+├── trade/
+│   ├── models.py                     # TradeRecord, PositionSnapshot, PerformanceMetrics
+│   ├── recorder.py                   # TradeRecorder — 거래 기록 (SQLite)
+│   ├── position.py                   # PositionTracker — 포지션 추적
+│   ├── performance.py                # PerformanceCalculator — 성과 산출
+│   ├── reconciler.py                 # PositionReconciler — 포지션 정합성 검증 및 자동 보정
+│   ├── service.py                    # TradeService — 위 컴포넌트 조합
+│   ├── __init__.py
+│   └── daily_report.py
+├── broker/
+│   ├── base.py                       # BrokerAdapter ABC
+│   ├── models.py                     # CommissionInfo dataclass
+│   ├── kis.py                        # KISAdapter — 한국투자증권 API 구현체
+│   ├── kis_stream.py                 # KISStreamClient — KIS WebSocket 실시간 시세/체결 통보
+│   ├── circuit_breaker.py            # CircuitBreaker — API 장애 차단
+│   ├── error_codes.py                # KIS API 에러 코드 분류 (영구/일시)
+│   ├── mock.py                       # MockBroker — 테스트/모의투자용 브로커 구현체
+│   ├── order_registry.py             # OrderRegistry — 주문 상태 추적 (SQLite)
+│   ├── exceptions.py
+│   ├── __init__.py
+│   ├── registry.py
+│   ├── scheduler.py
+│   └── test.py
+├── gateway/
+│   ├── gateway.py                    # APIGateway — rate limit, 캐시, 이벤트 기반 주문
+│   ├── rate_limiter.py               # RateLimiter — 호출 빈도 제한
+│   ├── cache.py                      # ResponseCache — TTL 기반 응답 캐시
+│   ├── queue.py                      # OrderQueue — 주문 큐 관리
+│   ├── data_provider.py              # GatewayDataProvider — 시세 조회 래퍼
+│   ├── stop_order.py                 # StopOrderManager — 스탑 주문 에뮬레이션 (KRX 대응)
+│   ├── __init__.py
+│   └── stream_integration.py
+├── data/
+│   ├── collector.py                  # DataCollector — 실시간 시세 수집 → Parquet
+│   ├── normalizer.py                 # BaseNormalizer ABC + KIS/Yahoo/Default Normalizer, DataNormalizer 파사드
+│   ├── retention.py                  # DataRetention — 보존 정책, 외부 이관
+│   ├── schemas.py                    # OHLCV 등 데이터 스키마 정의
+│   ├── store.py                      # DataStore — Parquet 읽기/쓰기
+│   └── __init__.py
+├── feed/                             # DataFeed — 외부 데이터 수집 파이프라인
+│   ├── cli.py                        # ante feed — DataFeed CLI 커맨드 (init/status/inject/config)
+│   ├── config.py                     # FeedConfig — DataFeed 설정 관리 (API 키, 경로 등)
+│   ├── injector.py                   # FeedInjector — CSV 파일에서 데이터 수동 주입
+│   ├── models/
+│   │   ├── result.py                 # ValidationResult, CollectionResult — 수집 결과 모델
+│   │   └── __init__.py
+│   ├── pipeline/
+│   │   ├── checkpoint.py             # Checkpoint — 체크포인트 저장 및 복원
+│   │   ├── orchestrator.py           # FeedOrchestrator — backfill/daily ETL 파이프라인 오케스트레이션
+│   │   ├── scheduler.py              # 날짜 범위 생성 (backfill vs daily 모드)
+│   │   ├── __init__.py
+│   │   ├── backfill_runner.py
+│   │   ├── daily_runner.py
+│   │   ├── dart_collector.py
+│   │   ├── data_go_kr_collector.py
+│   │   └── indicator_calculator.py
+│   ├── report/
+│   │   ├── generator.py              # ReportGenerator — 수집 리포트 생성
+│   │   └── __init__.py
+│   ├── sources/
+│   │   ├── base.py                   # DataSource Protocol, RateLimiter 기반 클래스
+│   │   ├── data_go_kr.py             # DataGoKrSource — data.go.kr 주식시세 API 소스 어댑터
+│   │   ├── dart.py                   # DARTSource — DART OpenAPI 소스 어댑터
+│   │   └── __init__.py
+│   ├── transform/
+│   │   ├── validate.py               # 4계층 데이터 검증 (transport/syntax/schema/business)
+│   │   └── __init__.py
+│   ├── __init__.py
+│   ├── cli_output.py
+│   └── cli_scheduler.py
+├── backtest/
+│   ├── context.py                    # BacktestContext — 백테스트 실행 환경
+│   ├── data_provider.py              # BacktestDataProvider — Parquet 기반 시세 공급
+│   ├── exceptions.py
+│   ├── executor.py                   # BacktestExecutor — 전략 실행 루프
+│   ├── metrics.py                    # calculate_metrics — 성과 지표 (Sharpe, MDD 등)
+│   ├── result.py                     # BacktestResult, BacktestTrade — 결과 모델
+│   ├── runner.py                     # BacktestRunner — subprocess 진입점
+│   ├── service.py                    # BacktestService — 메인 프로세스 인터페이스
+│   ├── __init__.py
+│   ├── config.py
+│   └── run_store.py
 ├── report/
-│   ├── draft.py                 # ReportDraftGenerator — 백테스트 완료 시 초안 자동 생성 (equity curve 표준화 포함)
-│   ├── feedback.py              # PerformanceFeedback — Agent 피드백용 실전 성과 조회 (equity curve 생성)
-│   ├── models.py                # StrategyReport (get_equity_curve), ReportStatus (DRAFT 포함)
-│   └── store.py                 # ReportStore — 전략 리포트 저장/조회
-│
+│   ├── draft.py                      # ReportDraftGenerator — 백테스트 완료 시 초안 자동 생성 (equity curve 표준화 포함)
+│   ├── feedback.py                   # PerformanceFeedback — Agent 피드백용 실전 성과 조회 (equity curve 생성)
+│   ├── models.py                     # StrategyReport (get_equity_curve), ReportStatus (DRAFT 포함)
+│   ├── store.py                      # ReportStore — 전략 리포트 저장/조회
+│   └── __init__.py
 ├── notification/
-│   ├── base.py                  # NotificationAdapter ABC, NotificationLevel
-│   ├── telegram.py              # TelegramAdapter — 텔레그램 봇 API 구현체
-│   ├── telegram_receiver.py     # TelegramReceiver — 텔레그램 명령 수신 (양방향)
-│   ├── templates.py             # 알림 메시지 템플릿 상수 (str.format 호환)
-│   └── service.py               # NotificationService — 이벤트 구독, 라우팅, 필터링, 이력 저장
-│
+│   ├── base.py                       # NotificationAdapter ABC, NotificationLevel
+│   ├── telegram.py                   # TelegramAdapter — 텔레그램 봇 API 구현체
+│   ├── telegram_receiver.py          # TelegramReceiver — 텔레그램 명령 수신 (양방향)
+│   ├── service.py                    # NotificationService — 이벤트 구독, 라우팅, 필터링, 이력 저장
+│   └── __init__.py
 ├── web/
-│   ├── app.py                   # FastAPI app 생성
-│   ├── errors.py                # RFC 7807 에러 핸들러
-│   ├── pagination.py            # cursor 기반 페이지네이션 유틸리티
-│   ├── schemas.py               # Pydantic 요청/응답 스키마
-│   ├── session.py               # SessionStore — SQLite 기반 서버사이드 세션 관리
-│   └── routes/
-│       ├── approvals.py         # /api/approvals 라우트 (목록/상세/승인·거부)
-│       ├── audit.py             # /api/audit 라우트 (감사 로그 조회)
-│       ├── auth.py              # /api/auth 라우트 (세션 기반 로그인/로그아웃)
-│       ├── bots.py              # /api/bots 라우트 (cursor 페이지네이션)
-│       ├── config.py            # /api/config 라우트 (동적 설정 조회/변경)
-│       ├── data.py              # /api/data 라우트
-│       ├── members.py           # /api/members 라우트 (멤버 관리)
-│       ├── notifications.py     # /api/notifications 라우트 (cursor 페이지네이션)
-│       ├── portfolio.py         # /api/portfolio 라우트 (자산 가치/추이)
-│       ├── reports.py           # /api/reports 라우트 (cursor 페이지네이션)
-│       ├── strategies.py        # /api/strategies 라우트
-│       ├── system.py            # /api/system 라우트
-│       ├── test_seed.py          # /api/test 시드 데이터 주입 (테스트 모드 전용)
-│       ├── trades.py            # /api/trades 라우트 (cursor 페이지네이션)
-│       └── treasury.py          # /api/treasury 라우트 (자금 관리)
-│
-└── cli/
-    ├── main.py                  # CLI 루트 그룹 (ante 커맨드)
-    ├── middleware.py             # 인증 미들웨어 (require_auth, require_scope)
-    ├── formatter.py             # OutputFormatter — table/json 출력
-    └── commands/
-        ├── _password.py         # generate_password() — CLI용 랜덤 패스워드 유틸
-        ├── approval.py          # ante approval request/list/info/review/cancel/approve/reject
-        ├── audit.py             # ante audit — 감사 로그 조회
-        ├── backtest.py          # ante backtest run (진행률 바, 성과 지표 테이블 포함)
-        ├── bot.py               # ante bot create/list/start/stop/info (--param 전략 파라미터 오버라이드)
-        ├── broker.py            # ante broker 명령
-        ├── config.py            # ante config 명령
-        ├── data.py              # ante data list/schema/inject/validate
-        ├── init.py              # ante init — 비대화형 최소 초기 설정 (master + 테스트 계좌)
-        ├── instrument.py        # ante instrument list/search/sync/import (--listed-only)
-        ├── member.py            # ante member register/list/info/suspend/revoke/set-emoji/... (bootstrap은 init으로 통합)
-        ├── notification.py      # ante notification history
-        ├── report.py            # ante report list/show/schema/performance/view
-        ├── rule.py              # ante rule 명령
-        ├── signal.py            # ante signal — 외부 시그널 채널 관리
-        ├── strategy.py          # ante strategy list/validate/load
-        ├── system.py            # ante system 명령
-        ├── trade.py             # ante trade 명령
-        └── treasury.py          # ante treasury 명령
+│   ├── app.py                        # FastAPI app 생성
+│   ├── errors.py                     # RFC 7807 에러 핸들러
+│   ├── pagination.py                 # cursor 기반 페이지네이션 유틸리티
+│   ├── schemas.py                    # Pydantic 요청/응답 스키마
+│   ├── session.py                    # SessionStore — SQLite 기반 서버사이드 세션 관리
+│   ├── routes/
+│   │   ├── approvals.py              # /api/approvals 라우트 (목록/상세/승인·거부)
+│   │   ├── audit.py                  # /api/audit 라우트 (감사 로그 조회)
+│   │   ├── auth.py                   # /api/auth 라우트 (세션 기반 로그인/로그아웃)
+│   │   ├── bots.py                   # /api/bots 라우트 (cursor 페이지네이션)
+│   │   ├── config.py                 # /api/config 라우트 (동적 설정 조회/변경)
+│   │   ├── data.py                   # /api/data 라우트
+│   │   ├── members.py                # /api/members 라우트 (멤버 관리)
+│   │   ├── notifications.py          # /api/notifications 라우트 (cursor 페이지네이션)
+│   │   ├── portfolio.py              # /api/portfolio 라우트 (자산 가치/추이)
+│   │   ├── reports.py                # /api/reports 라우트 (cursor 페이지네이션)
+│   │   ├── strategies.py             # /api/strategies 라우트
+│   │   ├── system.py                 # /api/system 라우트
+│   │   ├── trades.py                 # /api/trades 라우트 (cursor 페이지네이션)
+│   │   ├── treasury.py               # /api/treasury 라우트 (자금 관리)
+│   │   ├── __init__.py
+│   │   └── accounts.py
+│   ├── middleware/
+│   │   ├── __init__.py
+│   │   ├── audit.py
+│   │   └── token_auth.py
+│   ├── __init__.py
+│   └── deps.py
+├── cli/
+│   ├── main.py                       # CLI 루트 그룹 (ante 커맨드)
+│   ├── middleware.py                 # 인증 미들웨어 (require_auth, require_scope)
+│   ├── formatter.py                  # OutputFormatter — table/json 출력
+│   ├── commands/
+│   │   ├── _password.py              # generate_password() — CLI용 랜덤 패스워드 유틸
+│   │   ├── approval.py               # ante approval request/list/info/review/cancel/approve/reject
+│   │   ├── audit.py                  # ante audit — 감사 로그 조회
+│   │   ├── backtest.py               # ante backtest run (진행률 바, 성과 지표 테이블 포함)
+│   │   ├── bot.py                    # ante bot create/list/start/stop/info (--param 전략 파라미터 오버라이드)
+│   │   ├── broker.py                 # ante broker 명령
+│   │   ├── config.py                 # ante config 명령
+│   │   ├── data.py                   # ante data list/schema/inject/validate
+│   │   ├── init.py                   # ante init — 비대화형 최소 초기 설정 (master + 테스트 계좌)
+│   │   ├── instrument.py             # ante instrument list/search/sync/import (--listed-only)
+│   │   ├── member.py                 # ante member register/list/info/suspend/revoke/set-emoji/... (bootstrap은 init으로 통합)
+│   │   ├── notification.py           # ante notification history
+│   │   ├── report.py                 # ante report list/show/schema/performance/view
+│   │   ├── rule.py                   # ante rule 명령
+│   │   ├── signal.py                 # ante signal — 외부 시그널 채널 관리
+│   │   ├── strategy.py               # ante strategy list/validate/load
+│   │   ├── system.py                 # ante system 명령
+│   │   ├── trade.py                  # ante trade 명령
+│   │   ├── treasury.py               # ante treasury 명령
+│   │   ├── __init__.py
+│   │   ├── account.py
+│   │   ├── ipc_helpers.py
+│   │   └── update.py
+│   ├── __init__.py
+│   └── cold_path.py
+├── account/
+│   ├── __init__.py
+│   ├── crypto.py
+│   ├── errors.py
+│   ├── models.py
+│   ├── presets.py
+│   ├── scoping.py
+│   └── service.py
+├── db/
+│   ├── versions/
+│   │   ├── __init__.py
+│   │   ├── v001_baseline.py
+│   │   ├── v002_parquet_migration.py
+│   │   ├── v003_broker_config.py
+│   │   └── v004_strategy_status_simplify.py
+│   ├── __init__.py
+│   ├── backup.py
+│   └── migrations.py
+├── ipc/
+│   ├── __init__.py
+│   ├── client.py
+│   ├── exceptions.py
+│   ├── protocol.py
+│   ├── registry.py
+│   └── server.py
+├── update/
+│   ├── __init__.py
+│   ├── checker.py
+│   └── executor.py
+└── __init__.py
 ```
 
 ## tests/ — 테스트
 
 ```
 tests/
-├── conftest.py                  # 공통 pytest fixture
+├── conftest.py                       # 공통 pytest fixture
 ├── fixtures/
-│   └── seed/
-│       ├── daily_fixed_buy.py   # 일일 고정 매수 시드 데이터
-│       ├── generate_ohlcv.py    # OHLCV 테스트 데이터 생성
-│       ├── generate_scenario.py # 시나리오별 시드 SQL 생성기
-│       ├── seed.sql             # 통합 시드 SQL
-│       ├── seeder.py            # 시드 데이터 실행기
-│       ├── generators/          # Python 시드 데이터 생성기
-│       │   ├── price.py         # GBM 기반 가상 주가 생성기
-│       │   ├── trading.py       # 매매 시뮬레이션 (trades, positions 생성)
-│       │   ├── treasury.py      # 자금 흐름 계산 (treasury 데이터 생성)
-│       │   └── writer.py        # SQL INSERT 문 출력기
-│       ├── strategies/          # E2E 테스트용 더미 전략
-│       │   └── sma_cross.py     # SMA 크로스 전략
-│       └── scenarios/           # E2E 시나리오별 시드 데이터
-│           ├── _base.sql              # 공통 기반 데이터
-│           ├── approvals.sql          # 결재 시나리오
-│           ├── backtest-data.sql      # 백테스트 데이터 시나리오
-│           ├── bot-management.sql     # 봇 관리 시나리오
-│           ├── login-dashboard.sql    # 로그인/대시보드 시나리오
-│           ├── member-management.sql  # 멤버 관리 시나리오
-│           ├── settings.sql           # 설정 시나리오
-│           ├── strategy-browse.sql    # 전략 탐색 시나리오
-│           ├── treasury.sql           # 자금 관리 시나리오
-│           ├── action-agent-lifecycle.sql  # 에이전트 생명주기 액션 시나리오
-│           ├── action-approval-review.sql # 결재 검토 액션 시나리오
-│           ├── action-bot-lifecycle.sql   # 봇 생명주기 액션 시나리오
-│           ├── action-budget.sql          # 예산 관리 액션 시나리오
-│           └── action-settings.sql        # 설정 액션 시나리오
-├── e2e/                         # E2E 테스트
-│   ├── conftest.py              # E2E 테스트 fixture
-│   ├── pages/                   # Page Object 패턴
-│   │   ├── common.py            # 공통 페이지 유틸리티
-│   │   ├── header.py            # 헤더 Page Object
-│   │   ├── login_page.py        # 로그인 Page Object
-│   │   └── sidebar.py           # 사이드바 Page Object
-│   ├── test_api_endpoints.py    # API 엔드포인트 E2E 테스트
-│   ├── test_dashboard_pages.py  # 대시보드 페이지 E2E 테스트
-│   ├── test_flow_approvals.py   # 결재 승인/거부 플로우
-│   ├── test_flow_backtest_data.py # 백테스트 데이터 관리 플로우
-│   ├── test_flow_bot_management.py # 봇 생명주기 플로우
-│   ├── test_flow_login_dashboard.py # 로그인 → 대시보드 플로우
-│   ├── test_flow_member_management.py # 멤버 관리 플로우
-│   ├── test_flow_settings.py    # 설정 변경 플로우
-│   ├── test_flow_strategy_browse.py # 전략 탐색 플로우
-│   ├── test_flow_treasury.py    # 자금 관리 플로우
-│   ├── test_action_agent_lifecycle.py  # 에이전트 생명주기 액션 테스트
-│   ├── test_action_approval_review.py # 결재 검토 액션 테스트
-│   ├── test_action_bot_lifecycle.py   # 봇 생명주기 액션 테스트
-│   ├── test_action_budget.py    # 예산 관리 액션 테스트
-│   ├── test_action_settings.py  # 설정 액션 테스트
-│   ├── test_full_scenario.py    # 전체 시나리오 E2E 테스트
-│   ├── test_visual_verification.py # 시각적 검증 테스트
-│   └── visual_checker.py        # 시각적 검증 유틸리티
-├── unit/                        # 단위 테스트 (pytest + pytest-asyncio)
-│   ├── test_account_runtime_guard.py  # AccountService 런타임 cold-path 가드 (#1144)
-│   ├── test_account_runtime_init_order.py  # _init_account의 mark_runtime_started 호출 순서 (#1144)
-│   ├── test_api_pagination.py   # Web API cursor 페이지네이션
+│   └── __init__.py
+├── unit/                             # 단위 테스트 (pytest + pytest-asyncio)
+│   ├── test_account_runtime_guard.py # AccountService 런타임 cold-path 가드 (#1144)
+│   ├── test_account_runtime_init_order.py # _init_account의 mark_runtime_started 호출 순서 (#1144)
+│   ├── test_api_pagination.py        # Web API cursor 페이지네이션
 │   ├── test_approval.py
-│   ├── test_approval_api.py     # 결재 API 테스트
-│   ├── test_audit.py            # 감사 로그(AuditLogger) 테스트
+│   ├── test_approval_api.py          # 결재 API 테스트
+│   ├── test_audit.py                 # 감사 로그(AuditLogger) 테스트
 │   ├── test_backtest.py
-│   ├── test_backtest_metrics.py # 성과 지표 (Sharpe, MDD, PnL 추정)
-│   ├── test_backtest_progress.py # 백테스트 진행률 콜백
-│   ├── test_bot_create_params.py # bot create --param 파라미터 오버라이드
+│   ├── test_backtest_metrics.py      # 성과 지표 (Sharpe, MDD, PnL 추정)
+│   ├── test_backtest_progress.py     # 백테스트 진행률 콜백
+│   ├── test_bot_create_params.py     # bot create --param 파라미터 오버라이드
 │   ├── test_bot_providers.py
 │   ├── test_bot_restart.py
 │   ├── test_bot_stop_release.py
 │   ├── test_bot.py
-│   ├── test_bot_api.py          # 봇 CRUD API 테스트
-│   ├── test_broker_meta_api.py # 브로커 메타 정보 API 테스트
+│   ├── test_bot_api.py               # 봇 CRUD API 테스트
+│   ├── test_broker_meta_api.py       # 브로커 메타 정보 API 테스트
 │   ├── test_broker.py
 │   ├── test_cli_auth.py
 │   ├── test_cli_config.py
-│   ├── test_cli_init.py         # ante init (비대화형) CLI 테스트
+│   ├── test_cli_init.py              # ante init (비대화형) CLI 테스트
 │   ├── test_cli_live.py
-│   ├── test_cli_password.py     # generate_password() 유틸 테스트
+│   ├── test_cli_password.py          # generate_password() 유틸 테스트
 │   ├── test_cli.py
 │   ├── test_commission.py
 │   ├── test_config.py
-│   ├── test_config_path.py      # Config 경로 탐색 및 ante init 테스트
+│   ├── test_config_path.py           # Config 경로 탐색 및 ante init 테스트
 │   ├── test_data_pipeline.py
-│   ├── test_dataset_delete_api.py # 데이터셋 삭제 API 테스트
+│   ├── test_dataset_delete_api.py    # 데이터셋 삭제 API 테스트
 │   ├── test_database.py
 │   ├── test_dynamic_config.py
 │   ├── test_event_history.py
 │   ├── test_eventbus.py
-│   ├── test_equity_curve.py     # 자산 곡선 기능 (표준화, 리포트 추출, 피드백 생성)
+│   ├── test_equity_curve.py          # 자산 곡선 기능 (표준화, 리포트 추출, 피드백 생성)
 │   ├── test_external_signal_subscription.py # 외부 시그널 구독
-│   ├── test_external_signals.py # 외부 시그널 처리
-│   ├── test_gateway_stop_routing.py # Gateway 스탑 주문 라우팅
+│   ├── test_external_signals.py      # 외부 시그널 처리
+│   ├── test_gateway_stop_routing.py  # Gateway 스탑 주문 라우팅
 │   ├── test_gateway.py
-│   ├── test_instrument_cache_ttl.py # InstrumentService 캐시 TTL
-│   ├── test_instrument_import.py    # 종목 데이터 CSV/JSON import
-│   ├── test_instrument_sync.py  # KIS API 종목 동기화
+│   ├── test_instrument_cache_ttl.py  # InstrumentService 캐시 TTL
+│   ├── test_instrument_import.py     # 종목 데이터 CSV/JSON import
+│   ├── test_instrument_sync.py       # KIS API 종목 동기화
 │   ├── test_instrument.py
-│   ├── test_ipc_error_code_mapping.py  # IPCServer가 예외 code 속성을 안정 코드로 노출 (#1144)
+│   ├── test_ipc_error_code_mapping.py # IPCServer가 예외 code 속성을 안정 코드로 노출 (#1144)
 │   ├── test_kis_error_handling.py
-│   ├── test_kis_stream.py      # KIS WebSocket 스트리밍
-│   ├── test_listed_only.py      # --listed-only 필터
+│   ├── test_kis_stream.py            # KIS WebSocket 스트리밍
+│   ├── test_listed_only.py           # --listed-only 필터
 │   ├── test_main.py
 │   ├── test_member.py
-│   ├── test_member_api.py       # 멤버 관리 API 테스트
-│   ├── test_mock_broker.py      # MockBroker 테스트
-│   ├── test_notification_dedup.py   # 알림 중복 억제
-│   ├── test_notification_history.py
+│   ├── test_member_api.py            # 멤버 관리 API 테스트
+│   ├── test_mock_broker.py           # MockBroker 테스트
+│   ├── test_notification_dedup.py    # 알림 중복 억제
 │   ├── test_notification.py
-│   ├── test_notification_templates.py # 알림 메시지 템플릿 테스트
-│   ├── test_parquet_validation.py   # Parquet 파일 검증
-│   ├── test_performance_summary.py  # 일간/월간 성과 요약
-│   ├── test_portfolio_api.py    # 포트폴리오 API 테스트
-│   ├── test_reconciler.py       # PositionReconciler 테스트
-│   ├── test_report_draft.py     # 백테스트 초안 자동 생성
-│   ├── test_report_api.py       # 리포트 API 테스트 (상세 조회, equity_curve, metrics)
+│   ├── test_parquet_validation.py    # Parquet 파일 검증
+│   ├── test_performance_summary.py   # 일간/월간 성과 요약
+│   ├── test_portfolio_api.py         # 포트폴리오 API 테스트
+│   ├── test_reconciler.py            # PositionReconciler 테스트
+│   ├── test_report_draft.py          # 백테스트 초안 자동 생성
+│   ├── test_report_api.py            # 리포트 API 테스트 (상세 조회, equity_curve, metrics)
 │   ├── test_report.py
 │   ├── test_rule.py
-│   ├── test_seed_data.py        # 시드 데이터 테스트
-│   ├── test_signal_channel.py   # SignalChannel 파이프 통신
-│   ├── test_signal_key.py       # 시그널 키 발급/관리
-│   ├── test_stop_order.py       # 스탑 주문 에뮬레이션
-│   ├── test_indicators.py       # TA-Lib 기술 지표 계산기
-│   ├── test_normalizer_classes.py # BaseNormalizer ABC + 소스별 Normalizer
-│   ├── test_rule_modify.py      # 주문 정정 룰 검증
-│   ├── test_session_auth.py     # 세션 기반 인증 API 테스트
+│   ├── test_signal_channel.py        # SignalChannel 파이프 통신
+│   ├── test_signal_key.py            # 시그널 키 발급/관리
+│   ├── test_stop_order.py            # 스탑 주문 에뮬레이션
+│   ├── test_indicators.py            # TA-Lib 기술 지표 계산기
+│   ├── test_normalizer_classes.py    # BaseNormalizer ABC + 소스별 Normalizer
+│   ├── test_rule_modify.py           # 주문 정정 룰 검증
+│   ├── test_session_auth.py          # 세션 기반 인증 API 테스트
 │   ├── test_strategy.py
-│   ├── test_strategy_api.py     # 전략 API 테스트
-│   ├── test_strategy_snapshot.py # 전략 파일 스냅샷
-│   ├── test_system_config_api.py # 시스템 설정 API 테스트 (킬스위치 + 동적 설정)
-│   ├── test_system_state.py
+│   ├── test_strategy_api.py          # 전략 API 테스트
+│   ├── test_strategy_snapshot.py     # 전략 파일 스냅샷
+│   ├── test_system_config_api.py     # 시스템 설정 API 테스트 (킬스위치 + 동적 설정)
 │   ├── test_telegram_receiver.py
-│   ├── test_token_expiry.py     # API 토큰 만료 정책
+│   ├── test_token_expiry.py          # API 토큰 만료 정책
 │   ├── test_trade.py
-│   ├── test_trade_history_view.py # TradeHistoryView ABC
+│   ├── test_trade_history_view.py    # TradeHistoryView ABC
 │   ├── test_treasury_sync.py
 │   ├── test_treasury.py
-│   ├── test_treasury_api.py     # 자금관리 API 확장 테스트
+│   ├── test_treasury_api.py          # 자금관리 API 확장 테스트
 │   ├── test_web_api.py
-│   ├── test_bot_guard.py        # 봇 런타임 가드
-│   ├── test_dynamic_log_level.py # 동적 로그 레벨
-│   ├── test_config_audit.py     # 설정 감사
-│   └── feed/                    # DataFeed 모듈 단위 테스트
-│       ├── test_checkpoint.py   # 체크포인트 저장/복원
-│       ├── test_cli_init.py     # ante feed CLI 초기화
-│       ├── test_cli_run.py      # ante feed run CLI 테스트
-│       ├── test_cli_status.py   # ante feed status CLI 테스트
-│       ├── test_config.py       # FeedConfig 설정 관리
-│       ├── test_dart.py         # DART 소스 어댑터
-│       ├── test_data_go_kr.py   # data.go.kr 소스 어댑터
-│       ├── test_injector.py     # FeedInjector 데이터 주입
-│       ├── test_orchestrator.py # FeedOrchestrator ETL 파이프라인
-│       ├── test_report.py       # 수집 리포트 생성
-│       ├── test_scheduler.py    # 날짜 범위 생성
-│       └── test_validate.py     # 4계층 데이터 검증
-├── integration/                 # 통합 테스트
-│   └── test_e2e_flow.py
+│   ├── test_bot_guard.py             # 봇 런타임 가드
+│   ├── test_dynamic_log_level.py     # 동적 로그 레벨
+│   ├── test_config_audit.py          # 설정 감사
+│   ├── feed/                         # DataFeed 모듈 단위 테스트
+│   │   ├── test_checkpoint.py        # 체크포인트 저장/복원
+│   │   ├── test_cli_init.py          # ante feed CLI 초기화
+│   │   ├── test_cli_run.py           # ante feed run CLI 테스트
+│   │   ├── test_cli_status.py        # ante feed status CLI 테스트
+│   │   ├── test_config.py            # FeedConfig 설정 관리
+│   │   ├── test_dart.py              # DART 소스 어댑터
+│   │   ├── test_data_go_kr.py        # data.go.kr 소스 어댑터
+│   │   ├── test_injector.py          # FeedInjector 데이터 주입
+│   │   ├── test_orchestrator.py      # FeedOrchestrator ETL 파이프라인
+│   │   ├── test_report.py            # 수집 리포트 생성
+│   │   ├── test_scheduler.py         # 날짜 범위 생성
+│   │   ├── test_validate.py          # 4계층 데이터 검증
+│   │   ├── __init__.py
+│   │   └── test_dart_collector.py
+│   ├── cli/
+│   │   ├── __init__.py
+│   │   └── test_version.py
+│   ├── ipc/
+│   │   ├── __init__.py
+│   │   ├── test_protocol.py
+│   │   ├── test_registry.py
+│   │   ├── test_server_client.py
+│   │   └── test_service_registry.py
+│   ├── specs/
+│   │   ├── __init__.py
+│   │   └── test_cold_path_terminology.py
+│   ├── __init__.py
+│   ├── test_account.py
+│   ├── test_account_api.py
+│   ├── test_account_cli.py
+│   ├── test_account_crypto.py
+│   ├── test_account_delete_events.py
+│   ├── test_account_immutable_fields.py
+│   ├── test_account_rules_api.py
+│   ├── test_account_scoping.py
+│   ├── test_approval_executors.py
+│   ├── test_approval_strategy_adopt_validator.py
+│   ├── test_approval_strategy_lifecycle.py
+│   ├── test_audit_integration.py
+│   ├── test_auto_approve.py
+│   ├── test_backtest_complete_event.py
+│   ├── test_backtest_config.py
+│   ├── test_backtest_run_store.py
+│   ├── test_backup.py
+│   ├── test_bot_account_status.py
+│   ├── test_bot_cold_path.py
+│   ├── test_bot_delete_budget.py
+│   ├── test_bot_delete_positions.py
+│   ├── test_bot_manager_methods.py
+│   ├── test_bot_rule_init.py
+│   ├── test_bot_step_event.py
+│   ├── test_bot_timeout_error.py
+│   ├── test_broker_adapter_split.py
+│   ├── test_broker_reconcile_offline.py
+│   ├── test_broker_type_switch.py
+│   ├── test_cache.py
+│   ├── test_cli_account_integration.py
+│   ├── test_cli_approval_format_option.py
+│   ├── test_cli_backtest_date_validation.py
+│   ├── test_cli_backtest_report.py
+│   ├── test_cli_bot_treasury_ipc.py
+│   ├── test_cli_config_approval_broker_ipc.py
+│   ├── test_cli_config_dir_propagation.py
+│   ├── test_cli_format_option.py
+│   ├── test_cli_ipc_commands.py
+│   ├── test_cli_main_db_path.py
+│   ├── test_cli_member_non_interactive.py
+│   ├── test_cli_resolve_token.py
+│   ├── test_cli_strategy.py
+│   ├── test_cli_system.py
+│   ├── test_cli_system_status.py
+│   ├── test_cli_treasury_snapshot.py
+│   ├── test_cli_update.py
+│   ├── test_config_defaults_seed.py
+│   ├── test_daily_report.py
+│   ├── test_daily_snapshot.py
+│   ├── test_dataset_detail_api.py
+│   ├── test_datasets_list_api.py
+│   ├── test_disk_space_check.py
+│   ├── test_draft_upsert.py
+│   ├── test_eventbus_account_events.py
+│   ├── test_generate_cli_reference.py
+│   ├── test_generate_db_schema.py
+│   ├── test_is_paper_migration.py
+│   ├── test_kis_websocket_url.py
+│   ├── test_log_fingerprint.py
+│   ├── test_log_formatter.py
+│   ├── test_log_handlers.py
+│   ├── test_log_safe_logger.py
+│   ├── test_log_setup.py
+│   ├── test_main_init_notification.py
+│   ├── test_main_shutdown_ordering.py
+│   ├── test_main_startup_ordering.py
+│   ├── test_migrations.py
+│   ├── test_module_notification_events.py
+│   ├── test_parquet_exchange.py
+│   ├── test_password_change_notification.py
+│   ├── test_password_token_invalidation.py
+│   ├── test_price_simulator.py
+│   ├── test_reconcile_scheduler.py
+│   ├── test_recovery_auth_notification.py
+│   ├── test_response_model_validation.py
+│   ├── test_runtime_paths.py
+│   ├── test_snapshot_api.py
+│   ├── test_strategy_notification.py
+│   ├── test_strategy_submit.py
+│   ├── test_stream_integration.py
+│   ├── test_telegram_approval.py
+│   ├── test_test_broker.py
+│   ├── test_token_auth_middleware.py
+│   ├── test_trade_exchange_column.py
+│   ├── test_trade_id_fk.py
+│   ├── test_trade_id_uuid_parsing.py
+│   ├── test_treasury_bot_check.py
+│   ├── test_treasury_is_virtual.py
+│   ├── test_treasury_manager.py
+│   ├── test_update.py
+│   ├── test_update_rollback.py
+│   ├── test_update_snapshot.py
+│   ├── test_update_startup_check.py
+│   └── test_web_account_filter.py
+└── __init__.py
 ```
 
 ## deploy/ — 서비스 배포
 
 ```
 deploy/
-├── ante.service         # Linux systemd 유닛 파일
-└── com.ante.plist       # macOS launchd plist 파일
+├── ante.service                      # Linux systemd 유닛 파일
+└── com.ante.plist                    # macOS launchd plist 파일
 ```
 
 ## strategies/ — 전략 템플릿과 예제
 
 ```
 strategies/
-├── _template.py                 # 새 전략 작성용 최소 템플릿
-└── _examples/                   # Agent 참고용 예제 전략
-    ├── ma_crossover.py          # 이동평균 크로스오버 예제
-    ├── rsi_mean_reversion.py    # RSI 평균회귀 예제
-    └── volume_breakout.py       # 거래량 돌파 예제
+├── _template.py                      # 새 전략 작성용 최소 템플릿
+└── _examples/                        # Agent 참고용 예제 전략
+    ├── ma_crossover.py               # 이동평균 크로스오버 예제
+    ├── rsi_mean_reversion.py         # RSI 평균회귀 예제
+    └── volume_breakout.py            # 거래량 돌파 예제
 ```
 
-## scripts/ — 설치·운영 스크립트
+## scripts/ — 설치·운영·문서 생성 스크립트
 
 ```
 scripts/
-├── generate_cli_reference.py  # CLI 레퍼런스 문서 자동 생성 (Click introspection)
-├── install-service.sh         # OS 감지 후 systemd/launchd 서비스 설치
-├── uninstall-service.sh       # 서비스 제거
-└── verify-install.py          # 설치 검증 스크립트
+├── generate_cli_reference.py         # CLI 레퍼런스 문서 자동 생성 (Click introspection)
+├── install-service.sh                # OS 감지 후 systemd/launchd 서비스 설치
+├── uninstall-service.sh              # 서비스 제거
+├── verify-install.py                 # 설치 검증 스크립트
+├── ai_review.py
+├── generate_db_schema.py             # DB 스키마 문서 자동 생성
+├── generate_project_structure.py     # 프로젝트 구조 Agent INDEX 생성/check
+├── run_ai_review.sh
+└── setup_actions_runners.sh
 ```
 
 ## docs/ — 설계 문서
 
 ```
 docs/
-├── architecture/               # 시스템 아키텍처 문서 묶음
-│   ├── README.md               # 아키텍처 인덱스 + 기술 스택
-│   ├── system-diagram.md       # 시스템 구성도, 데이터/통신 흐름
-│   ├── module-map.md           # 모듈 책임, 확장성, 배포 산출물
-│   └── generated/              # 소스에서 생성된 문서
-│       ├── db-schema.md        # SQLite 스키마 전체 목록
-│       └── project-structure.md # 이 문서 — 프로젝트 디렉토리 구조
-├── dashboard/                  # 대시보드 설계·목업
-│   ├── architecture.md         # 대시보드 아키텍처
+├── architecture/                     # 시스템 아키텍처 문서 묶음
+│   ├── README.md                     # 아키텍처 인덱스 + 기술 스택
+│   ├── system-diagram.md             # 시스템 구성도, 데이터/통신 흐름
+│   ├── module-map.md                 # 모듈 책임, 확장성, 배포 산출물
+│   └── generated/                    # 소스에서 생성된 문서
+│       ├── db-schema.md              # SQLite 스키마 전체 목록
+│       └── project-structure.md      # 이 문서 — 프로젝트 디렉토리 구조
+├── dashboard/                        # 대시보드 설계·목업
+│   ├── architecture.md               # 대시보드 아키텍처
 │   ├── design-guide.css
 │   ├── design-guide.html
 │   ├── mockups/
+│   │   ├── assets/
+│   │   │   ├── logo-a.svg
+│   │   │   ├── logo-e.svg
+│   │   │   ├── logo-n.svg
+│   │   │   └── logo-t.svg
+│   │   ├── agent-detail.html
+│   │   ├── agents.html
+│   │   ├── approval-detail-bot-stop.html
+│   │   ├── approval-detail-rule-change.html
+│   │   ├── approval-detail-strategy-adopt.html
+│   │   ├── approvals.html
+│   │   ├── backtest-data-fundamental.html
+│   │   ├── backtest-data.html
+│   │   ├── bot-detail-stopped.html
+│   │   ├── bot-detail.html
+│   │   ├── bot-logs.html
+│   │   ├── bots.html
+│   │   ├── common.css
+│   │   ├── login.html
+│   │   ├── performance.html
+│   │   ├── report-detail.html
+│   │   ├── settings.html
+│   │   ├── strategies.html
+│   │   ├── strategy-detail.html
+│   │   ├── trades.html
+│   │   ├── treasury-history.html
+│   │   └── treasury.html
 │   └── user-stories/
-├── decisions/                  # 설계 결정 이력 디렉토리
-│   ├── README.md               # 설계 결정 인덱스
-│   └── D-001.md ... D-014.md
-├── references/                 # 외부 참조 문서
+│       ├── agents.md
+│       ├── approvals.md
+│       ├── backtest-data.md
+│       ├── bots.md
+│       ├── login.md
+│       ├── report-detail.md
+│       ├── settings.md
+│       ├── strategies.md
+│       └── treasury.md
+├── decisions/                        # 설계 결정 이력 디렉토리
+│   ├── README.md                     # 설계 결정 인덱스
+│   ├── D-001.md
+│   ├── D-002.md
+│   ├── D-003.md
+│   ├── D-004.md
+│   ├── D-005.md
+│   ├── D-006.md
+│   ├── D-007.md
+│   ├── D-008.md
+│   ├── D-009.md
+│   ├── D-010.md
+│   ├── D-011.md
+│   ├── D-012.md
+│   ├── D-013.md
+│   └── D-014.md
+├── references/                       # 외부 참조 문서
 │   └── dashboard/
-├── runbooks/                   # 운영 절차서
-│   ├── 00-issue-management.md  # 이슈 등록, 분류, 추적
+│       ├── dart-openapi.md
+│       ├── data-go-kr-stock-price-api.md
+│       └── README.md
+├── runbooks/                         # 운영 절차서
+│   ├── 00-issue-management.md        # 이슈 등록, 분류, 추적
 │   ├── 01-development-process.md
-│   ├── 02-agent-structure.md   # 에이전트 구조
+│   ├── 02-agent-structure.md         # 에이전트 구조
 │   ├── 03-git-workflow.md
-│   ├── 04-ci-cd.md             # CI/CD와 리뷰 게이트
+│   ├── 04-ci-cd.md                   # CI/CD와 리뷰 게이트
 │   ├── 05-testing.md
-│   ├── 06-release.md           # 릴리스 정책
+│   ├── 06-release.md                 # 릴리스 정책
 │   └── README.md
-├── specs/                      # 모듈별 세부 설계
+├── specs/                            # 모듈별 세부 설계
 │   ├── README.md
 │   ├── account/
 │   │   ├── README.md
-│   │   └── account.md
+│   │   ├── account.md
+│   │   ├── 01-overview.md
+│   │   ├── 02-design-decisions.md
+│   │   ├── 03-data-model.md
+│   │   ├── 04-account-service.md
+│   │   ├── 05-eventbus-integration.md
+│   │   ├── 06-database-schema.md
+│   │   ├── 07-account-layout-v1.md
+│   │   ├── 08-config-migration.md
+│   │   ├── 09-cli.md
+│   │   ├── 10-web-api.md
+│   │   ├── 11-scope-out.md
+│   │   ├── 13-cross-module-notes.md
+│   │   └── 14-account-id-contract.md
 │   ├── approval/
 │   │   ├── README.md
-│   │   └── approval.md
+│   │   ├── approval.md
+│   │   ├── 01-overview.md
+│   │   ├── 02-design-decisions.md
+│   │   ├── 03-enums.md
+│   │   ├── 04-approval-request-model.md
+│   │   ├── 05-approval-types.md
+│   │   ├── 06-status-flow.md
+│   │   ├── 07-database-schema.md
+│   │   ├── 08-approval-service.md
+│   │   ├── 09-cli.md
+│   │   ├── 10-eventbus-integration.md
+│   │   ├── 11-notification-events.md
+│   │   └── 12-cross-module-notes.md
 │   ├── api-gateway/
 │   │   └── api-gateway.md
 │   ├── audit/
 │   │   └── audit.md
 │   ├── backtest/
 │   │   ├── README.md
-│   │   └── backtest.md
+│   │   ├── backtest.md
+│   │   ├── 01-overview.md
+│   │   ├── 02-design-decisions.md
+│   │   ├── 03-cli-usage.md
+│   │   └── 05-cross-module-notes.md
 │   ├── bot/
 │   │   ├── README.md
-│   │   └── bot.md
+│   │   ├── bot.md
+│   │   ├── 01-overview.md
+│   │   ├── 02-reference-implementations.md
+│   │   ├── 03-design-decisions.md
+│   │   ├── 04-eventbus-integration.md
+│   │   ├── 05-notification-events.md
+│   │   ├── 06-cli-usage.md
+│   │   ├── 07-testing.md
+│   │   └── 08-cross-module-notes.md
 │   ├── broker-adapter/
 │   │   ├── README.md
-│   │   └── broker-adapter.md
+│   │   ├── broker-adapter.md
+│   │   ├── 01-overview.md
+│   │   ├── 02-reference-implementations.md
+│   │   ├── 03-adapter-layer.md
+│   │   ├── 04-broker-adapter-interface.md
+│   │   ├── 05-broker-registry.md
+│   │   ├── 06-broker-presets.md
+│   │   ├── 07-kis-base-adapter.md
+│   │   ├── 08-kis-domestic-adapter.md
+│   │   ├── 09-kis-overseas-adapter.md
+│   │   ├── 10-commission-info.md
+│   │   ├── 11-order-flow.md
+│   │   ├── 12-test-broker-adapter.md
+│   │   ├── 13-setup-and-initialization.md
+│   │   ├── 14-cli.md
+│   │   ├── 15-reconciliation.md
+│   │   ├── 16-eventbus-integration.md
+│   │   ├── 17-notification-events.md
+│   │   └── 19-scope-out.md
 │   ├── cli/
 │   │   ├── README.md
-│   │   └── cli.md
+│   │   ├── cli.md
+│   │   ├── 01-overview.md
+│   │   ├── 02-design-decisions.md
+│   │   ├── 03-commands.md
+│   │   ├── 04-agent-workflows.md
+│   │   └── 06-cross-module-notes.md
 │   ├── config/
 │   │   ├── README.md
-│   │   └── config.md
+│   │   ├── config.md
+│   │   ├── 01-overview.md
+│   │   ├── 02-reference-implementations.md
+│   │   ├── 03-design-decisions.md
+│   │   ├── 04-system-initialization.md
+│   │   ├── 05-broker-to-account-migration.md
+│   │   └── 07-cross-module-notes.md
 │   ├── core/
 │   │   └── core.md
 │   ├── data-feed/
 │   │   ├── README.md
-│   │   └── data-feed.md
+│   │   ├── data-feed.md
+│   │   ├── 01-overview.md
+│   │   ├── 02-design-decisions.md
+│   │   ├── 03-collection-scope.md
+│   │   ├── 04-schema.md
+│   │   ├── 05-data-sources.md
+│   │   ├── 06-cli.md
+│   │   ├── 07-execution-modes.md
+│   │   ├── 08-resource-protection.md
+│   │   ├── 09-failure-recovery.md
+│   │   ├── 10-checkpoints-and-reports.md
+│   │   ├── 11-module-structure.md
+│   │   └── 13-cross-module-notes.md
 │   ├── data-pipeline/
 │   │   ├── README.md
-│   │   └── data-pipeline.md
+│   │   ├── data-pipeline.md
+│   │   ├── 01-overview.md
+│   │   ├── 02-write-ownership.md
+│   │   ├── 03-design-decisions.md
+│   │   ├── 04-dependencies.md
+│   │   ├── 05-datafeed-relationship.md
+│   │   └── 07-cross-module-notes.md
 │   ├── eventbus/
 │   │   └── eventbus.md
 │   ├── instrument/
@@ -495,217 +762,258 @@ docs/
 │   │   └── ipc.md
 │   ├── member/
 │   │   ├── README.md
-│   │   └── member.md
+│   │   ├── member.md
+│   │   ├── 01-overview.md
+│   │   ├── 02-design-decisions.md
+│   │   ├── 03-member-model.md
+│   │   ├── 04-database-schema.md
+│   │   ├── 05-member-service.md
+│   │   ├── 06-cli.md
+│   │   ├── 07-eventbus-integration.md
+│   │   ├── 08-module-impact.md
+│   │   └── 09-notification-events.md
 │   ├── notification/
 │   │   └── notification.md
 │   ├── report-store/
 │   │   └── report-store.md
 │   ├── rule-engine/
 │   │   ├── README.md
-│   │   └── rule-engine.md
+│   │   ├── rule-engine.md
+│   │   ├── 01-overview.md
+│   │   ├── 02-reference-implementations.md
+│   │   ├── 03-two-layer-evaluation.md
+│   │   ├── 04-rule-interface.md
+│   │   ├── 05-rule-context.md
+│   │   ├── 06-rule-catalog.md
+│   │   ├── 07-rule-engine-core.md
+│   │   ├── 08-notification-events.md
+│   │   ├── 09-rule-management.md
+│   │   ├── 10-rule-engine-manager.md
+│   │   ├── 11-rest-api.md
+│   │   ├── 12-cli.md
+│   │   └── 14-cross-module-notes.md
 │   ├── strategy/
 │   │   ├── README.md
-│   │   └── strategy.md
+│   │   ├── strategy.md
+│   │   ├── 01-overview.md
+│   │   ├── 02-reference-implementations.md
+│   │   ├── 03-01-strategy-interface.md
+│   │   ├── 03-02-signal-fields.md
+│   │   ├── 03-03-order-action-fields.md
+│   │   ├── 03-04-provider-and-views.md
+│   │   ├── 03-05-strategy-context.md
+│   │   ├── 03-06-indicator-calculator.md
+│   │   ├── 03-07-strategy-snapshot.md
+│   │   ├── 03-08-dynamic-loading.md
+│   │   ├── 03-09-strategy-validator.md
+│   │   ├── 03-10-strategy-registry.md
+│   │   ├── 03-11-registration-flow.md
+│   │   ├── 03-12-runtime-model.md
+│   │   ├── 03-13-bot-execution-flow.md
+│   │   ├── 03-14-performance-scoping.md
+│   │   ├── 03-15-backtest-relationship.md
+│   │   ├── 03-design-decisions.md
+│   │   ├── 04-examples.md
+│   │   ├── 05-testing.md
+│   │   └── 07-cross-module-notes.md
 │   ├── trade/
 │   │   ├── README.md
-│   │   └── trade.md
+│   │   ├── trade.md
+│   │   ├── 01-overview.md
+│   │   ├── 02-reference-implementations.md
+│   │   ├── 03-01-trade-record.md
+│   │   ├── 03-02-trade-recorder.md
+│   │   ├── 03-03-position-history.md
+│   │   ├── 03-04-performance-tracker.md
+│   │   ├── 03-05-sqlite-schema.md
+│   │   ├── 03-06-trade-service.md
+│   │   ├── 03-07-position-reconciler.md
+│   │   ├── 03-design-decisions.md
+│   │   ├── 04-eventbus-integration.md
+│   │   ├── 05-cli-usage.md
+│   │   ├── 06-testing.md
+│   │   ├── 07-notification-events.md
+│   │   └── 09-cross-module-notes.md
 │   ├── treasury/
 │   │   ├── README.md
-│   │   └── treasury.md
-│   └── web-api/
-│       └── web-api.md
-└── temp/                       # 임시 작업 문서
+│   │   ├── treasury.md
+│   │   ├── 01-overview.md
+│   │   ├── 02-design-decisions.md
+│   │   ├── 03-treasury-model.md
+│   │   ├── 04-treasury-interface.md
+│   │   ├── 05-treasury-manager.md
+│   │   ├── 06-database-schema.md
+│   │   ├── 07-cli.md
+│   │   ├── 08-daily-asset-snapshots.md
+│   │   ├── 09-virtual-asset-sync.md
+│   │   └── 11-cross-module-notes.md
+│   ├── web-api/
+│   │   ├── web-api.md
+│   │   ├── 01-overview.md
+│   │   ├── 02-design-decisions.md
+│   │   ├── 03-session-service.md
+│   │   ├── 04-system-endpoints.md
+│   │   ├── 05-resource-endpoints.md
+│   │   ├── 06-pagination.md
+│   │   ├── 07-error-format.md
+│   │   ├── 08-pydantic-schemas.md
+│   │   ├── 10-cross-module-notes.md
+│   │   └── README.md
+│   └── logging/
+│       ├── 01-overview.md
+│       ├── 02-design-decisions.md
+│       ├── 03-json-schema.md
+│       ├── 04-fingerprint.md
+│       ├── 05-handlers-and-rotation.md
+│       ├── 06-context-fields.md
+│       ├── 07-implementation.md
+│       ├── logging.md
+│       └── README.md
+├── temp/                             # 임시 작업 문서
+│   └── 05-issue-processing-process-map.md
+└── superpowers/
+    └── specs/
+        └── 2026-04-17-staging-environment-design.md
 ```
 
 ## guide/ — 사용자·운용 가이드
 
 ```
 guide/
-├── agent.md             # AI Agent 온보딩 가이드
-├── cli.md               # CLI 레퍼런스 (자동 생성)
-├── dashboard.md         # 대시보드 사용 가이드
-├── getting-started.md   # 설치·초기 설정 가이드
-├── security.md          # 보안 가이드
-├── strategy.md          # 전략 개발 가이드
-└── assets/              # 가이드 이미지·SVG
-    └── how-it-works.svg # 시스템 구조 도식
+├── agent.md                          # AI Agent 온보딩 가이드
+├── cli.md                            # CLI 레퍼런스 (자동 생성)
+├── dashboard.md                      # 대시보드 사용 가이드
+├── getting-started.md                # 설치·초기 설정 가이드
+├── security.md                       # 보안 가이드
+├── strategy.md                       # 전략 개발 가이드
+└── assets/                           # 가이드 이미지·SVG
+    └── how-it-works.svg              # 시스템 구조 도식
 ```
 
 ## frontend/ — React 대시보드
 
 ```
 frontend/src/
-├── main.tsx                     # Vite 엔트리포인트
-├── App.tsx                      # 라우터 설정, 전역 레이아웃
-├── index.css                    # 글로벌 스타일
-│
 ├── api/
-│   ├── client.ts                # Axios 클라이언트 (baseURL, 인터셉터)
-│   ├── approvals.ts             # 결재 API 호출
-│   ├── auth.ts                  # 인증 API 호출 (로그인/로그아웃)
-│   ├── reports.ts               # 리포트 API 호출
-│   ├── bots.ts                  # 봇 API 호출
-│   ├── data.ts                  # 데이터 API 호출
-│   ├── members.ts               # 멤버 API 호출
-│   ├── portfolio.ts             # 포트폴리오 API 호출
-│   ├── strategies.ts            # 전략 API 호출
-│   ├── system.ts                # 시스템 API 호출
-│   └── treasury.ts              # 자금관리 API 호출
-│
-├── types/
-│   ├── approval.ts              # 결재 타입 정의
-│   ├── auth.ts                  # 인증 타입 정의
-│   ├── bot.ts                   # 봇 타입 정의
-│   ├── member.ts                # 멤버 타입 정의
-│   ├── portfolio.ts             # 포트폴리오 타입 정의
-│   ├── strategy.ts              # 전략 타입 정의
-│   ├── system.ts                # 시스템 타입 정의
-│   ├── feed.ts                  # DataFeed 타입 정의
-│   ├── report.ts                # 리포트 타입 정의
-│   └── treasury.ts              # 자금관리 타입 정의
-│
-├── hooks/
-│   ├── useApprovals.ts          # 결재 데이터 훅
-│   ├── useAuth.ts               # 인증 상태 훅
-│   ├── useBacktestData.ts       # 백테스트 데이터 훅
-│   ├── useBots.ts               # 봇 데이터 훅
-│   ├── useFeed.ts               # DataFeed 데이터 훅
-│   ├── useMembers.ts            # 멤버 데이터 훅
-│   ├── usePortfolio.ts          # 포트폴리오 데이터 훅
-│   ├── useReports.ts            # 리포트 데이터 훅
-│   ├── useStrategies.ts         # 전략 데이터 훅
-│   ├── useSystemStatus.ts       # 시스템 상태 훅
-│   └── useTreasury.ts           # 자금관리 데이터 훅
-│
-├── pages/
-│   ├── AgentDetail.tsx          # 에이전트 상세 페이지
-│   ├── Agents.tsx               # 에이전트 목록 페이지
-│   ├── ApprovalDetail.tsx       # 결재 상세 페이지
-│   ├── Approvals.tsx            # 결재 목록 페이지
-│   ├── BacktestData.tsx         # 백테스트 데이터 관리 페이지
-│   ├── BotDetail.tsx            # 봇 상세 페이지
-│   ├── Bots.tsx                 # 봇 목록 페이지
-│   ├── Dashboard.tsx            # 대시보드 메인 페이지
-│   ├── Login.tsx                # 로그인 페이지
-│   ├── NotFound.tsx             # 404 페이지
-│   ├── Performance.tsx          # 성과 분석 페이지
-│   ├── ReportDetail.tsx         # 리포트 상세 페이지
-│   ├── Settings.tsx             # 시스템 설정 페이지
-│   ├── Strategies.tsx           # 전략 목록 페이지
-│   ├── StrategyDetail.tsx       # 전략 상세 페이지
-│   ├── Trades.tsx               # 거래 내역 페이지
-│   ├── Treasury.tsx             # 자금관리 페이지
-│   └── TreasuryHistory.tsx      # 자금관리 이력 페이지
-│
+│   ├── accounts.ts
+│   ├── approvals.ts
+│   ├── auth.ts
+│   ├── bots.ts
+│   ├── client.ts
+│   ├── data.ts
+│   ├── members.ts
+│   ├── portfolio.ts
+│   ├── reports.ts
+│   ├── strategies.ts
+│   ├── system.ts
+│   └── treasury.ts
 ├── components/
-│   ├── auth/
-│   │   ├── LoginForm.tsx        # 로그인 폼
-│   │   └── ProtectedRoute.tsx   # 인증 필요 라우트 가드
-│   ├── layout/
-│   │   ├── Header.tsx           # 상단 헤더
-│   │   ├── Layout.tsx           # 공통 레이아웃 (헤더 + 사이드바)
-│   │   └── Sidebar.tsx          # 사이드바 네비게이션
-│   ├── common/
-│   │   ├── DataTable.tsx        # 범용 데이터 테이블
-│   │   ├── ErrorBoundary.tsx    # React 에러 바운더리
-│   │   ├── HintTooltip.tsx      # 힌트 툴팁
-│   │   ├── LoadingSpinner.tsx   # 로딩 스피너
-│   │   ├── Pagination.tsx       # 페이지네이션 컨트롤
-│   │   ├── ServiceUnavailable.tsx # 서비스 불가 안내
-│   │   ├── Modal.tsx            # 범용 모달 (ESC/오버레이 닫기)
-│   │   ├── Skeleton.tsx         # 로딩 스켈레톤 UI
-│   │   ├── StatusBadge.tsx      # 상태 뱃지
-│   │   └── Toast.tsx            # 토스트 알림
 │   ├── agents/
-│   │   ├── AgentRegisterForm.tsx # 에이전트 등록 폼
-│   │   ├── AgentTable.tsx       # 에이전트 목록 테이블
-│   │   ├── ChangePasswordModal.tsx # 비밀번호 변경 모달
-│   │   └── MemberCard.tsx       # 멤버 카드 컴포넌트
+│   │   ├── AgentEditModal.tsx
+│   │   ├── AgentRegisterForm.tsx
+│   │   ├── AgentTable.tsx
+│   │   ├── ChangePasswordModal.tsx
+│   │   └── MemberCard.tsx
 │   ├── approvals/
-│   │   ├── ApprovalFilters.tsx  # 결재 필터
-│   │   ├── ApprovalTable.tsx    # 결재 목록 테이블
-│   │   ├── ExecutionContent.tsx # 결재 유형별 실행 내용 렌더러
-│   │   ├── MarkdownBody.tsx     # 마크다운 본문 (lazy 로딩 래퍼)
-│   │   ├── MarkdownRenderer.tsx # react-markdown 기반 마크다운 렌더러
-│   │   └── ReviewControls.tsx   # 승인/거부 컨트롤 (모달 포함)
+│   │   ├── ApprovalFilters.tsx
+│   │   ├── ApprovalTable.tsx
+│   │   ├── MarkdownBody.tsx
+│   │   ├── MarkdownRenderer.tsx
+│   │   └── ReviewControls.tsx
+│   ├── auth/
+│   │   ├── LoginForm.tsx
+│   │   └── ProtectedRoute.tsx
 │   ├── bots/
-│   │   ├── BotCard.tsx          # 봇 카드 컴포넌트
-│   │   ├── BotCreateForm.tsx    # 봇 생성 폼
-│   │   ├── BotDeleteModal.tsx   # 봇 삭제 확인 모달
-│   │   ├── BotStopModal.tsx     # 봇 정지 확인 모달
-│   │   └── BotTable.tsx         # 봇 목록 테이블
+│   │   ├── BotCard.tsx
+│   │   ├── BotCreateForm.tsx
+│   │   ├── BotDeleteModal.tsx
+│   │   ├── BotStopModal.tsx
+│   │   └── BotTable.tsx
 │   ├── charts/
-│   │   ├── AssetTrendChart.tsx  # 자산 추이 차트
-│   │   ├── DailyReturnChart.tsx # 일간 수익률 차트
-│   │   ├── EquityCurveChart.tsx # 자산 곡선 차트
-│   │   └── LightweightChart.tsx # lightweight-charts 래퍼
+│   │   ├── AssetTrendChart.tsx
+│   │   ├── DailyReturnChart.tsx
+│   │   ├── EquityCurveChart.tsx
+│   │   └── LightweightChart.tsx
+│   ├── common/
+│   │   ├── DataTable.tsx
+│   │   ├── ErrorBoundary.tsx
+│   │   ├── HintTooltip.tsx
+│   │   ├── LoadingSpinner.tsx
+│   │   ├── Modal.tsx
+│   │   ├── Pagination.tsx
+│   │   ├── ServiceUnavailable.tsx
+│   │   ├── Skeleton.tsx
+│   │   ├── StatusBadge.tsx
+│   │   ├── Toast.tsx
+│   │   └── VirtualModeBanner.tsx
 │   ├── data/
-│   │   ├── ApiKeyStatusPanel.tsx # API 키 상태 패널
-│   │   └── FeedStatusPanel.tsx  # DataFeed 상태 패널
+│   │   ├── ApiKeyStatusPanel.tsx
+│   │   └── FeedStatusPanel.tsx
+│   ├── layout/
+│   │   ├── Header.tsx
+│   │   ├── Layout.tsx
+│   │   └── Sidebar.tsx
 │   ├── strategies/
-│   │   ├── PerformancePanel.tsx # 전략 성과 패널
-│   │   ├── PeriodPerformance.tsx # 기간별 성과 표시
-│   │   └── StrategyTable.tsx    # 전략 목록 테이블
+│   │   ├── PerformancePanel.tsx
+│   │   ├── PeriodPerformance.tsx
+│   │   └── StrategyTable.tsx
 │   └── treasury/
-│       ├── AccountSummary.tsx   # 계좌 요약
-│       ├── AllocationForm.tsx   # 자금 할당 폼
-│       ├── AnteSummary.tsx      # Ante 자금 요약
-│       ├── BudgetPieChart.tsx   # 예산 배분 파이 차트
-│       ├── BudgetTable.tsx      # 봇별 예산 테이블
-│       └── RecentTransactions.tsx # 최근 거래 내역
-│
-├── globals.d.ts                 # 전역 타입 선언
-│
-└── utils/
-    ├── constants.ts             # 공통 상수
-    └── formatters.ts            # 포맷 유틸리티 (통화, 날짜 등)
-```
-
-## .agent/ — 에이전트 정의/명령/스킬
-
-```
-.agent/
-├── agents/                      # 역할별 에이전트 프로필
-├── commands/                    # 프로젝트 슬래시 커맨드
-│   ├── plan-preflight.md        # /plan-preflight
-│   ├── implement-issue.md       # /implement-issue
-│   ├── autopilot.md             # /autopilot
-│   ├── release.md               # /release
-│   └── api-docs.md              # /api-docs
-└── skills/                      # 프로젝트 스킬 (컨벤션·패턴 참조)
-    ├── asyncio-patterns.md
-    ├── contract-drift-review.md
-    ├── frontend-conventions.md
-    ├── generated-artifact-sync.md
-    ├── github-auth.md           # GitHub CLI 로컬 PAT 인증 절차
-    ├── github-ops.md            # GitHub 조회/코멘트/PR/재실행 공통 절차
-    ├── lifecycle-review.md
-    ├── module-conventions.md
-    ├── receive-review.md
-    ├── review-pr.md
-    └── sqlite-patterns.md
-```
-
-## .github/ — GitHub 워크플로/이슈 템플릿/로컬 인증
-
-```
-.github/
-├── ISSUE_TEMPLATE/              # 이슈 템플릿
-├── workflows/                   # GitHub Actions 워크플로
-├── local/                       # 저장소-로컬 개발용 파일 (.gitignore 제외 대상)
-│   └── github.env.example       # gh CLI 인증 환경변수 예시 (실제 github.env는 커밋 금지)
-└── review-output.schema.json    # 리뷰 게이트 출력 스키마
-```
-
-## .claude/ — Claude Code 설정 및 호환 레이어
-
-```
-.claude/
-├── settings.json                # 권한 설정, 훅 설정
-├── settings.local.json          # 로컬 환경별 설정
-├── settings.local.example.json  # 로컬 설정 예시
-├── hooks/                       # 자동 훅 스크립트 (auto-format, protect-files)
-├── agents -> ../.agent/agents
-├── commands -> ../.agent/commands
-└── skills -> ../.agent/skills
+│       ├── AccountSummary.tsx
+│       ├── AllocationForm.tsx
+│       ├── AnteSummary.tsx
+│       ├── BudgetPieChart.tsx
+│       ├── BudgetTable.tsx
+│       └── RecentTransactions.tsx
+├── hooks/
+│   ├── useAccounts.ts
+│   ├── useApprovals.ts
+│   ├── useAuth.ts
+│   ├── useBacktestData.ts
+│   ├── useBots.ts
+│   ├── useFeed.ts
+│   ├── useMembers.ts
+│   ├── usePortfolio.ts
+│   ├── useReports.ts
+│   ├── useStrategies.ts
+│   ├── useSystemStatus.ts
+│   └── useTreasury.ts
+├── pages/
+│   ├── AgentDetail.tsx
+│   ├── Agents.tsx
+│   ├── ApprovalDetail.tsx
+│   ├── Approvals.tsx
+│   ├── BacktestData.tsx
+│   ├── BotDetail.tsx
+│   ├── Bots.tsx
+│   ├── Login.tsx
+│   ├── NotFound.tsx
+│   ├── Performance.tsx
+│   ├── ReportDetail.tsx
+│   ├── Settings.tsx
+│   ├── Strategies.tsx
+│   ├── StrategyDetail.tsx
+│   ├── Trades.tsx
+│   ├── Treasury.tsx
+│   └── TreasuryHistory.tsx
+├── types/
+│   ├── account.ts
+│   ├── api.generated.ts
+│   ├── approval.ts
+│   ├── auth.ts
+│   ├── bot.ts
+│   ├── data.ts
+│   ├── feed.ts
+│   ├── member.ts
+│   ├── portfolio.ts
+│   ├── report.ts
+│   ├── strategy.ts
+│   ├── system.ts
+│   └── treasury.ts
+├── utils/
+│   ├── constants.ts
+│   └── formatters.ts
+├── App.tsx
+├── globals.d.ts
+├── index.css
+└── main.tsx
 ```

--- a/scripts/generate_project_structure.py
+++ b/scripts/generate_project_structure.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""Git 파일 트리 기반 project-structure.md 생성/check.
+
+Ante의 Agent용 프로젝트 구조 INDEX를 생성한다.
+기존 generated 문서의 경로별 설명을 재사용해 curated 설명을 보존하고,
+현재 Git 추적/비무시 파일 트리에 없는 stale path는 출력하지 않는다.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import TextIO
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT = (
+    PROJECT_ROOT / "docs" / "architecture" / "generated" / "project-structure.md"
+)
+KST = timezone(timedelta(hours=9))
+COMMENT_COLUMN = 38
+
+
+@dataclass(frozen=True)
+class Section:
+    title: str
+    base_path: str
+    root_label: str
+    recursive: bool = True
+
+
+@dataclass
+class TreeNode:
+    name: str
+    path: str
+    is_dir: bool
+    children: dict[str, TreeNode] = field(default_factory=dict)
+
+
+SECTIONS: tuple[Section, ...] = (
+    Section("최상위 구조", "", "ante/", recursive=False),
+    Section("src/ante/ — Python 백엔드", "src/ante", "src/ante/"),
+    Section("tests/ — 테스트", "tests", "tests/"),
+    Section("deploy/ — 서비스 배포", "deploy", "deploy/"),
+    Section("strategies/ — 전략 템플릿과 예제", "strategies", "strategies/"),
+    Section("scripts/ — 설치·운영·문서 생성 스크립트", "scripts", "scripts/"),
+    Section("docs/ — 설계 문서", "docs", "docs/"),
+    Section("guide/ — 사용자·운용 가이드", "guide", "guide/"),
+    Section("frontend/ — React 대시보드", "frontend/src", "frontend/src/"),
+)
+
+ROOT_ENTRIES: tuple[str, ...] = (
+    "src/ante",
+    "tests",
+    "frontend",
+    "guide",
+    "docs",
+    "deploy",
+    "scripts",
+    "strategies",
+    "config",
+    ".agent",
+    ".claude",
+    ".github",
+    "Dockerfile",
+    "docker-compose.yml",
+    "AGENTS.md",
+    "CHANGELOG.md",
+    "README.md",
+    "CLAUDE.md",
+    "LICENSE",
+)
+
+DEFAULT_DESCRIPTIONS: dict[str, str] = {
+    ".agent": "에이전트 정의/명령/스킬",
+    ".claude": "Claude Code 설정 + .agent 호환 링크",
+    ".github": "GitHub 워크플로/이슈 템플릿/로컬 인증 파일",
+    "AGENTS.md": "개발 Agent 마스터 가이드",
+    "CHANGELOG.md": "변경 이력",
+    "CLAUDE.md": "Claude Code 호환 가이드",
+    "Dockerfile": "프로덕션 Docker 이미지",
+    "LICENSE": "라이선스",
+    "README.md": "프로젝트 개요",
+    "config": "런타임 설정 예시와 의존성 스냅샷",
+    "deploy": "서비스 배포 파일 (systemd, launchd)",
+    "docker-compose.yml": "프로덕션 Docker Compose",
+    "docs": "설계 문서",
+    "frontend": "React 대시보드 (Vite + TypeScript)",
+    "guide": "사용자·운용 가이드 문서",
+    "scripts": "설치·운영·문서 생성 스크립트",
+    "scripts/generate_db_schema.py": "DB 스키마 문서 자동 생성",
+    "scripts/generate_project_structure.py": "프로젝트 구조 Agent INDEX 생성/check",
+    "src/ante": "Python 백엔드 패키지",
+    "strategies": "전략 템플릿과 예제",
+    "tests": "단위·통합 테스트",
+}
+
+
+TREE_LINE_RE = re.compile(
+    r"^(?P<prefix>[│ ]*)(?:├|└)── (?P<name>.*?)(?:\s+#\s*(?P<comment>.*))?$"
+)
+GENERATED_AT_RE = re.compile(r"^> 마지막 생성 시점: (?P<value>.+)$", re.MULTILINE)
+
+
+def _run_git_ls_files() -> list[str]:
+    """Git이 추적하거나 무시하지 않는 파일 목록을 반환한다."""
+    result = subprocess.run(
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+        cwd=PROJECT_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return sorted(line for line in result.stdout.splitlines() if line)
+
+
+def _section_base_from_title(title: str) -> str:
+    if title == "최상위 구조":
+        return ""
+    return title.split(" — ", maxsplit=1)[0].rstrip("/")
+
+
+def _parse_existing_doc(
+    path: Path,
+) -> tuple[dict[str, str], dict[str, int], str | None]:
+    """기존 generated 문서에서 경로별 설명과 표시 순서를 읽는다."""
+    if not path.exists():
+        return {}, {}, None
+
+    text = path.read_text(encoding="utf-8")
+    comments: dict[str, str] = {}
+    order: dict[str, int] = {}
+    generated_at = _extract_generated_at(text)
+
+    current_base = ""
+    in_fence = False
+    stack: list[str] = []
+
+    for line in text.splitlines():
+        if line.startswith("## "):
+            current_base = _section_base_from_title(line.removeprefix("## ").strip())
+            continue
+
+        if line == "```":
+            in_fence = not in_fence
+            stack = []
+            continue
+
+        if not in_fence:
+            continue
+
+        match = TREE_LINE_RE.match(line)
+        if match is None:
+            continue
+
+        depth = len(match.group("prefix")) // 4
+        raw_name = match.group("name").rstrip()
+        name = raw_name.rstrip("/")
+        is_dir = raw_name.endswith("/")
+        stack = stack[:depth]
+
+        parts = [part for part in (current_base, *stack, name) if part]
+        rel_path = "/".join(parts)
+        order.setdefault(rel_path, len(order))
+
+        comment = match.group("comment")
+        if comment:
+            comments[rel_path] = comment.rstrip()
+
+        if is_dir:
+            stack.append(name)
+
+    return comments, order, generated_at
+
+
+def _extract_generated_at(text: str) -> str | None:
+    match = GENERATED_AT_RE.search(text)
+    if match is None:
+        return None
+    return match.group("value")
+
+
+def _path_exists(path: str, files: list[str]) -> bool:
+    prefix = f"{path}/"
+    return path in files or any(file_path.startswith(prefix) for file_path in files)
+
+
+def _build_tree(base_path: str, files: list[str]) -> TreeNode:
+    root = TreeNode(
+        name=base_path.rsplit("/", maxsplit=1)[-1],
+        path=base_path,
+        is_dir=True,
+    )
+    prefix = f"{base_path}/" if base_path else ""
+    base_parts = [part for part in base_path.split("/") if part]
+
+    for file_path in files:
+        if prefix and not file_path.startswith(prefix):
+            continue
+        if not prefix and "/" not in file_path:
+            continue
+
+        relative = file_path.removeprefix(prefix)
+        parts = [part for part in relative.split("/") if part]
+        if not parts:
+            continue
+
+        node = root
+        for index, part in enumerate(parts):
+            rel_path = "/".join((*base_parts, *parts[: index + 1]))
+            is_dir = index < len(parts) - 1
+            child = node.children.get(part)
+            if child is None:
+                child = TreeNode(name=part, path=rel_path, is_dir=is_dir)
+                node.children[part] = child
+            elif is_dir:
+                child.is_dir = True
+            node = child
+
+    return root
+
+
+def _sort_children(nodes: dict[str, TreeNode], order: dict[str, int]) -> list[TreeNode]:
+    unknown_order = len(order) + 1
+    return sorted(
+        nodes.values(),
+        key=lambda node: (
+            order.get(node.path, unknown_order),
+            0 if node.is_dir else 1,
+            node.name.lower(),
+        ),
+    )
+
+
+def _format_tree(
+    root: TreeNode,
+    comments: dict[str, str],
+    order: dict[str, int],
+) -> list[str]:
+    lines = [root.path + "/" if root.path else "ante/"]
+    children = _sort_children(root.children, order)
+    for index, child in enumerate(children):
+        lines.extend(
+            _format_node(
+                child,
+                prefix="",
+                is_last=index == len(children) - 1,
+                comments=comments,
+                order=order,
+            )
+        )
+    return lines
+
+
+def _format_node(
+    node: TreeNode,
+    prefix: str,
+    is_last: bool,
+    comments: dict[str, str],
+    order: dict[str, int],
+) -> list[str]:
+    connector = "└── " if is_last else "├── "
+    display_name = f"{node.name}/" if node.is_dir else node.name
+    line = _append_comment(
+        f"{prefix}{connector}{display_name}",
+        _comment_for(node.path, comments),
+    )
+    lines = [line]
+
+    if node.is_dir and node.children:
+        child_prefix = prefix + ("    " if is_last else "│   ")
+        children = _sort_children(node.children, order)
+        for index, child in enumerate(children):
+            lines.extend(
+                _format_node(
+                    child,
+                    prefix=child_prefix,
+                    is_last=index == len(children) - 1,
+                    comments=comments,
+                    order=order,
+                )
+            )
+
+    return lines
+
+
+def _format_root_tree(
+    files: list[str],
+    comments: dict[str, str],
+) -> list[str]:
+    entries = [entry for entry in ROOT_ENTRIES if _path_exists(entry, files)]
+    lines = ["ante/"]
+    for index, entry in enumerate(entries):
+        is_last = index == len(entries) - 1
+        connector = "└── " if is_last else "├── "
+        is_dir = any(file_path.startswith(f"{entry}/") for file_path in files)
+        display_name = f"{entry}/" if is_dir else entry
+        lines.append(
+            _append_comment(
+                f"{connector}{display_name}",
+                _comment_for(entry, comments),
+            )
+        )
+    return lines
+
+
+def _comment_for(path: str, comments: dict[str, str]) -> str | None:
+    return comments.get(path) or DEFAULT_DESCRIPTIONS.get(path)
+
+
+def _append_comment(line: str, comment: str | None) -> str:
+    if not comment:
+        return line
+    spacing = max(1, COMMENT_COLUMN - len(line))
+    return f"{line}{' ' * spacing}# {comment}"
+
+
+def _write_section(
+    out: TextIO,
+    section: Section,
+    files: list[str],
+    comments: dict[str, str],
+    order: dict[str, int],
+) -> None:
+    out.write(f"## {section.title}\n\n")
+    out.write("```\n")
+
+    if section.recursive:
+        tree = _build_tree(section.base_path, files)
+        lines = _format_tree(tree, comments, order)
+    else:
+        lines = _format_root_tree(files, comments)
+
+    out.write("\n".join(lines))
+    out.write("\n```\n\n")
+
+
+def _render_markdown(
+    files: list[str],
+    comments: dict[str, str],
+    order: dict[str, int],
+    generated_at: str,
+) -> str:
+    from io import StringIO
+
+    out = StringIO()
+    out.write("# Ante 프로젝트 디렉토리 구조\n\n")
+    out.write("> 역할: Agent용 프로젝트 구조 INDEX의 단일 SSOT입니다.\n")
+    out.write("> 생성 명령: `.venv/bin/python scripts/generate_project_structure.py`\n")
+    out.write(
+        "> Check 명령: "
+        "`.venv/bin/python scripts/generate_project_structure.py --check`\n"
+    )
+    out.write(
+        "> 생성 기준: 현재 Git 추적/비무시 파일 트리 "
+        "(`git ls-files --cached --others --exclude-standard`)\n"
+    )
+    out.write(f"> 마지막 생성 시점: {generated_at}\n\n")
+
+    for section in SECTIONS:
+        if section.base_path and not _path_exists(section.base_path, files):
+            continue
+        _write_section(out, section, files, comments, order)
+
+    return out.getvalue().rstrip() + "\n"
+
+
+def generate(output_path: Path, *, generated_at: str | None = None) -> str:
+    comments, order, _existing_generated_at = _parse_existing_doc(output_path)
+    files = _run_git_ls_files()
+    generated_at = generated_at or _today_kst()
+    return _render_markdown(files, comments, order, generated_at)
+
+
+def _today_kst() -> str:
+    return datetime.now(tz=KST).strftime("%Y-%m-%d (KST)")
+
+
+def _write_output(output_path: Path, content: str) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(content, encoding="utf-8")
+
+
+def _check_output(output_path: Path, content: str) -> int:
+    current = output_path.read_text(encoding="utf-8") if output_path.exists() else ""
+    if current == content:
+        print(f"{output_path.relative_to(PROJECT_ROOT)} is up to date.")
+        return 0
+
+    rel_output = output_path.relative_to(PROJECT_ROOT)
+    print(f"{rel_output} is stale.")
+    print("Run: .venv/bin/python scripts/generate_project_structure.py")
+    print()
+    _print_diff_summary(current, content, rel_output)
+    return 1
+
+
+def _print_diff_summary(current: str, expected: str, rel_output: Path) -> None:
+    diff = list(
+        difflib.unified_diff(
+            current.splitlines(),
+            expected.splitlines(),
+            fromfile=f"a/{rel_output}",
+            tofile=f"b/{rel_output}",
+            lineterm="",
+        )
+    )
+    max_lines = 120
+    for line in diff[:max_lines]:
+        print(line)
+    if len(diff) > max_lines:
+        print(f"... diff truncated ({len(diff) - max_lines} more lines)")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Git 파일 트리 기반 project-structure.md 생성/check",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="생성할 project-structure.md 경로",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="파일을 수정하지 않고 generated 문서가 최신인지 확인",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    output_path = args.output
+    if not output_path.is_absolute():
+        output_path = PROJECT_ROOT / output_path
+
+    generated_at = _existing_or_today(output_path) if args.check else None
+    content = generate(output_path, generated_at=generated_at)
+
+    if args.check:
+        return _check_output(output_path, content)
+
+    _write_output(output_path, content)
+    print(f"Generated {output_path.relative_to(PROJECT_ROOT)}")
+    return 0
+
+
+def _existing_or_today(output_path: Path) -> str:
+    if output_path.exists():
+        existing = _extract_generated_at(output_path.read_text(encoding="utf-8"))
+        if existing:
+            return existing
+    return _today_kst()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #1266

## Summary
- Add a repo-local project structure generator with a non-mutating --check mode.
- Regenerate docs/architecture/generated/project-structure.md as the Agent-facing structure INDEX SSOT.
- Remove stale project-structure entries for deleted system_state and legacy tests.

## Test Plan
- .venv/bin/python scripts/generate_project_structure.py --check
- rg "system_state|test_notification_history|test_system_state" docs/architecture/generated/project-structure.md (0 matches)
- ruff check scripts/generate_project_structure.py
- ruff format --check scripts/generate_project_structure.py
