### PR TITLE
docs(agent): align generated artifact checklist

### DIFF
--- a/.agent/skills/generated-artifact-sync.md
+++ b/.agent/skills/generated-artifact-sync.md
@@ -13,6 +13,8 @@
 
 - 변경된 계약에 대응하는 생성 산출물이 모두 갱신되었는가
 - 산출물 생성 명령과 결과 파일이 함께 PR에 포함되었는가
+- 전용 check 명령이 있는 산출물은 리뷰/CI 전에 실제 check 명령을 실행했는가
+- 전용 check 명령이 없는 산출물은 생성 명령 실행 후 `git diff -- <산출물>`로 최신 여부를 확인했는가
 - 수동 편집 금지 산출물을 수동으로만 맞추지 않았는가
 - 생성 산출물이 새 구현을 반영하지만 소비자는 여전히 예전 계약을 쓰지 않는가
 - `frontend/src/types/api.generated.ts` 변경 시 `frontend/src/api/*.ts` adapter와 UI/domain model이 같은 PR에서 맞춰졌는가
@@ -20,11 +22,20 @@
 
 ## 주요 산출물
 
-- `frontend/openapi.json`
-- `frontend/src/types/api.generated.ts`
-- `docs/architecture/generated/db-schema.md`
-- `guide/cli.md`
-- `docs/architecture/generated/project-structure.md`
+| 산출물 | 입력/SSOT | Generate | Check | 기대 동작 |
+|---|---|---|---|---|
+| `docs/architecture/generated/project-structure.md` | 현재 Git 추적/비무시 파일 트리 | `.venv/bin/python scripts/generate_project_structure.py` | `.venv/bin/python scripts/generate_project_structure.py --check` | generate는 파일 구조 문서를 재생성한다. check는 산출물이 최신이면 0으로 종료하고, 불일치하면 실패하며 재생성 명령을 안내한다. |
+| `docs/architecture/generated/db-schema.md` | 모듈 소스 코드의 DDL 상수 | `.venv/bin/python scripts/generate_db_schema.py` | `.venv/bin/python scripts/generate_db_schema.py --check` | generate는 DB schema 문서를 재생성한다. check는 산출물이 최신이면 0으로 종료하고, 불일치하면 실패하며 재생성 명령을 안내한다. |
+| `guide/cli.md` | Click CLI command tree | `.venv/bin/python scripts/generate_cli_reference.py` | `.venv/bin/python scripts/generate_cli_reference.py && git diff --exit-code -- guide/cli.md` | generate는 CLI 레퍼런스를 재생성한다. 전용 `--check`가 없으므로 생성 후 diff가 비어 있어야 최신이다. |
+| `frontend/openapi.json` | 실행 중인 백엔드 `/openapi.json` | `curl http://localhost:3982/openapi.json -o frontend/openapi.json` | `git diff --exit-code -- frontend/openapi.json` | 백엔드 API 계약 변경 시 OpenAPI JSON을 갱신한다. 전용 check가 없으므로 재수집 후 diff가 비어 있어야 최신이다. |
+| `frontend/src/types/api.generated.ts` | `frontend/openapi.json` 또는 백엔드 `/openapi.json` | `cd frontend && npm run generate-types` | `cd frontend && npm run generate-types && git diff --exit-code -- src/types/api.generated.ts` | OpenAPI에서 TypeScript wire contract를 재생성한다. 전용 check가 없으므로 생성 후 diff가 비어 있어야 최신이다. |
+
+## 적용 흐름
+
+1. 구현 중 생성 산출물의 입력이 바뀌면 먼저 대응하는 generate 명령을 실행한다.
+2. 생성된 산출물과 소비자 코드/문서가 같은 계약을 쓰는지 확인한다.
+3. 리뷰 또는 CI 전에는 전용 check 명령을 실행한다.
+4. 전용 check가 없는 산출물은 generate 명령을 다시 실행한 뒤 `git diff --exit-code -- <산출물>`로 변경 없음 상태를 확인한다.
 
 ## red flags
 

--- a/.agent/skills/review-pr.md
+++ b/.agent/skills/review-pr.md
@@ -106,7 +106,14 @@ gh pr diff #{PR번호}
 |---|---|---|
 | B1 | 스펙 문서 일치 | 구현이 `docs/specs/`와 일치하는가 |
 | B2 | 계약 표류 없음 | API/CLI/schema/field rename이 소비자와 함께 반영되었는가 |
-| B3 | 생성 산출물 동기화 | OpenAPI, generated types, 생성 문서가 함께 갱신되었는가 |
+| B3 | 생성 산출물 동기화 | OpenAPI, generated types, 생성 문서가 함께 갱신되었고, 산출물별 실제 check 명령 또는 generate 후 diff 확인이 실행되었는가 |
+
+생성 산출물 신호가 있으면 B3 판정 전에 `.agent/skills/generated-artifact-sync.md`를 읽고 아래 검증 증거를 확인한다.
+
+- 프로젝트 구조 변경: `.venv/bin/python scripts/generate_project_structure.py`로 regenerate했는지, 리뷰/CI 전 `.venv/bin/python scripts/generate_project_structure.py --check`를 실행했는지 확인한다.
+- DB DDL/schema 변경: `.venv/bin/python scripts/generate_db_schema.py`로 regenerate했는지, 리뷰/CI 전 `.venv/bin/python scripts/generate_db_schema.py --check`를 실행했는지 확인한다.
+- CLI reference, OpenAPI JSON, frontend generated types처럼 전용 check 명령이 없는 산출물은 대응 generate 명령 실행 후 `git diff --exit-code -- <산출물>` 결과가 검증 증거에 남았는지 확인한다.
+- 실행 증거가 없고 코드 독해로만 최신이라고 추론했다면 B3는 PASS가 아니라 FAIL 또는 follow-up으로 분리한다.
 
 #### C. 상태 전이 및 수명주기
 

--- a/docs/runbooks/01-development-process.md
+++ b/docs/runbooks/01-development-process.md
@@ -234,7 +234,14 @@ release PR은 릴리스 메타데이터와 Docker build 검증만 포함하며, 
 
 - CLI, DB DDL, 프로젝트 구조처럼 생성 산출물의 입력이 바뀌면 해당 생성 문서도 같은 작업에서 갱신한다.
 - 스크립트로 생성되는 문서는 수동 편집하지 않는다.
-- Plan Preflight와 리뷰 단계에서 generated artifact sync 위험을 발견하면 구현 체크리스트에 포함한다.
+- 구현 단계에서 생성 산출물 입력이 바뀌면 먼저 대응하는 regenerate 명령을 실행한다.
+- 리뷰/CI 전에는 전용 check 명령이 있는 산출물을 실제 check 명령으로 검증한다.
+  - 프로젝트 구조: `.venv/bin/python scripts/generate_project_structure.py --check`
+  - DB schema: `.venv/bin/python scripts/generate_db_schema.py --check`
+- 전용 check 명령이 없는 생성 산출물은 generate 명령을 다시 실행한 뒤 `git diff --exit-code -- <산출물>`로 변경 없음 상태를 확인한다.
+- 프로젝트 구조 regenerate 명령은 `.venv/bin/python scripts/generate_project_structure.py`다.
+- DB schema regenerate 명령은 `.venv/bin/python scripts/generate_db_schema.py`다.
+- Plan Preflight와 리뷰 단계에서 generated artifact sync 위험을 발견하면 구현 체크리스트와 검증 체크리스트에 regenerate/check 흐름을 함께 포함한다.
 
 ## 8. API 스키마 변경 규칙
 


### PR DESCRIPTION
Closes #1268

## Summary
- Document generate/check commands for project-structure and db-schema generated artifacts.
- Clarify regenerate during implementation and check-before-review flow in the development runbook.
- Tighten PR review checklist expectations for generated artifact sync evidence.

## Test Plan
- rg "generate_project_structure.py --check|generate_db_schema.py --check" .agent/skills/generated-artifact-sync.md docs/runbooks/01-development-process.md .agent/skills/review-pr.md
- rg "scripts/generate_project_structure.py|scripts/generate_db_schema.py" .agent/skills/generated-artifact-sync.md docs/runbooks/01-development-process.md .agent/skills/review-pr.md
- git diff --check origin/main...HEAD
