### PR TITLE
refactor: align bot_create auto approve with virtual accounts

### DIFF
--- a/config/system.toml.example
+++ b/config/system.toml.example
@@ -36,5 +36,5 @@ enabled = false  # 전결 기능 전체 on/off (기본: false)
 # 유형별 전결 규칙 (enabled = true일 때만 적용)
 [approval.auto_approve.rules]
 bot_stop = true  # 봇 중지는 항상 자동 승인
-bot_create_paper = true  # 모의투자 봇 생성은 자동 승인
+bot_create_virtual = true  # virtual Account 봇 생성은 자동 승인
 budget_change_max = 5000000  # 예산 변경 500만원 이하 자동 승인 (0이면 비활성)

--- a/docs/specs/approval/02-design-decisions.md
+++ b/docs/specs/approval/02-design-decisions.md
@@ -112,7 +112,7 @@ enabled = false                  # 전결 기능 전체 on/off (기본: false)
 # 유형별 전결 규칙 (enabled = true일 때만 적용)
 [approval.auto_approve.rules]
 bot_stop = true                  # 봇 중지는 항상 자동 승인
-bot_create_paper = true          # 모의투자 봇 생성은 자동 승인
+bot_create_virtual = true        # Account.trading_mode == "virtual" 봇 생성은 자동 승인
 budget_change_max = 5000000      # 예산 변경 500만원 이하 자동 승인 (0이면 비활성)
 ```
 
@@ -123,7 +123,7 @@ ApprovalService.create()
   → auto_approve.enabled == true?
     → 유형별 규칙 매칭:
       - bot_stop: 항상 자동 승인
-      - bot_create: params.mode == "paper"이면 자동 승인
+      - bot_create: params.account_id로 Account를 조회해 trading_mode == "virtual"이면 자동 승인
       - budget_change: params.amount <= budget_change_max이면 자동 승인
     → 매칭 시: status를 APPROVED로 설정, executor 즉시 실행
       - history에 actor: "system:auto_approve" 기록

--- a/docs/specs/approval/03-enums.md
+++ b/docs/specs/approval/03-enums.md
@@ -22,7 +22,7 @@
 |----|------|------------------|
 | `STRATEGY_ADOPT` | 전략 채택 | `ReportStore.update_status(report_id, "adopted")` + `StrategyRegistry.update_status(strategy_id, "adopted")` → 전략이 ADOPTED 상태로 전환되어 봇에 배정 가능해진다. 전결 대상에서 제외된다 |
 | `STRATEGY_RETIRE` | 전략 폐기 | `ReportStore.update_status(report_id, "retired")` + `StrategyRegistry.update_status(strategy_id, "archived")` → 전략이 ARCHIVED 상태로 전환된다. 봇은 전략 복제본을 사용하므로 운영 중인 봇에는 영향 없음. 전결 대상에서 제외된다 |
-| `BOT_CREATE` | 봇 신규 생성 | `BotManager.create_bot(**params)` → 전략을 실행하는 새 봇이 생성되고, Treasury에서 예산이 할당된다 |
+| `BOT_CREATE` | 봇 신규 생성 | `BotManager.create_bot(**params)` → 전략을 실행하는 새 봇이 생성되고, Treasury에서 예산이 할당된다. 전결은 Account 조회 결과 `trading_mode == "virtual"`일 때만 가능하다 |
 | `BOT_ASSIGN_STRATEGY` | 봇에 전략 배정 | `BotManager.assign_strategy(bot_id, strategy_id)` → 봇에 채택된 전략을 배정한다. 봇이 running 상태이면 즉시 새 전략으로 전환된다 |
 | `BOT_CHANGE_STRATEGY` | 봇 전략 변경 | `BotManager.change_strategy(bot_id, strategy_id)` → 중지 상태의 봇에 다른 전략을 교체 배정한다. 봇이 running 상태이면 거부된다 |
 | `BOT_STOP` | 봇 중지 | `BotManager.stop_bot(bot_id)` → 봇의 전략 루프가 중지되고, 미체결 주문이 취소된다. 보유 포지션은 유지된다 |

--- a/docs/specs/approval/05-approval-types.md
+++ b/docs/specs/approval/05-approval-types.md
@@ -8,7 +8,7 @@
 |------|------|-------------|------------------|--------------|
 | `strategy_adopt` | 전략 채택 | `{"strategy_name": "...", "strategy_id": "...", "report_id": "..."}` | `ReportStore.update_status(report_id, "adopted")` + `StrategyRegistry.update_status(strategy_id, "adopted")` 호출 → 전략이 ADOPTED 상태로 전환되어 봇에 배정 가능해진다 | 등록됨 |
 | `strategy_retire` | 전략 폐기 | `{"strategy_name": "...", "strategy_id": "...", "report_id": "...", "reason": "성과 부진"}` | `ReportStore.update_status(report_id, "retired")` + `StrategyRegistry.update_status(strategy_id, "archived")` 호출 → 전략이 ARCHIVED 상태로 전환된다. 봇은 전략 복제본을 사용하므로 운영 중인 봇에는 영향 없음 | **미등록** |
-| `bot_create` | 봇 신규 생성 | `{"strategy_name": "...", "budget": 10000000, "mode": "paper"}` | `BotManager.create_bot(**params)` 호출 → 전략을 실행하는 새 봇이 생성되고, Treasury에서 예산이 할당된다 | **미등록** |
+| `bot_create` | 봇 신규 생성 | `{"account_id": "domestic-demo", "strategy_id": "...", "budget": 10000000}` | `BotManager.create_bot(**params)` 호출 → 전략을 실행하는 새 봇이 생성되고, Treasury에서 예산이 할당된다 | **미등록** |
 | `bot_assign_strategy` | 봇에 전략 배정 | `{"bot_id": "...", "strategy_id": "..."}` | `BotManager.assign_strategy(bot_id, strategy_id)` 호출 → 봇에 채택된 전략을 배정한다. running 상태이면 즉시 새 전략으로 전환된다 | **미등록** |
 | `bot_change_strategy` | 봇 전략 변경 | `{"bot_id": "...", "strategy_id": "..."}` | `BotManager.change_strategy(bot_id, strategy_id)` 호출 → 중지 상태의 봇에 다른 전략을 교체 배정한다. running 상태이면 거부된다 | **미등록** |
 | `bot_stop` | 봇 중지 | `{"bot_id": "...", "reason": "손실 누적"}` | `BotManager.stop_bot(bot_id)` 호출 → 봇의 전략 루프가 중지되고, 미체결 주문이 취소된다. 보유 포지션은 유지된다 | 등록됨 |

--- a/docs/specs/approval/08-approval-service.md
+++ b/docs/specs/approval/08-approval-service.md
@@ -12,6 +12,7 @@
 | `eventbus` | EventBus | 이벤트 발행용 |
 | `executors` | dict[str, Callable] | 유형별 승인 시 실행 핸들러 |
 | `validators` | dict[str, Callable] | 유형별 사전 검증 핸들러. `fail` 시 요청 생성 차단, `warn` 시 reviews에 경고 첨부 |
+| `auto_approve_evaluator` | AutoApproveEvaluator \| None | 전결 규칙 평가기. `bot_create` 자동승인은 Account resolver로 조회한 `Account.trading_mode == "virtual"`일 때만 허용 |
 
 **메서드:**
 
@@ -29,6 +30,17 @@
 | `get` | id | ApprovalRequest \| None | 단건 조회 |
 | `list` | status, type, search, limit, offset | list[ApprovalRequest] | 필터 조회. `search`: title/requester LIKE 키워드 검색 |
 | `expire_stale` | — | int | 만료 기한이 지난 요청 일괄 expired 처리. 처리 건수 반환 |
+
+### 전결 평가
+
+`create()`는 요청을 저장하기 전 `AutoApproveEvaluator.should_auto_approve()`를 await한다.
+전결이 성립하면 요청은 즉시 `APPROVED`가 되고, `resolved_by`는
+`"system:auto_approve"`로 기록되며 executor가 실행된다.
+
+`bot_create` 전결은 `params["config"]["account_id"]`를 먼저 보고, 없으면
+`params["account_id"]`를 사용해 Account를 조회한다. 조회된 Account의
+`trading_mode`가 `"virtual"`일 때만 자동 승인한다. `mode` 필드나
+`broker_config.is_paper`는 자동승인 판단에 사용하지 않는다.
 
 ### 만료 스케줄러
 

--- a/src/ante/approval/auto_approve.py
+++ b/src/ante/approval/auto_approve.py
@@ -3,12 +3,33 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from ante.account.models import TradingMode
+
+if TYPE_CHECKING:
+    from ante.account.models import Account
 
 logger = logging.getLogger(__name__)
 
 # 전결 대상에서 제외되는 유형
 EXCLUDED_TYPES: frozenset[str] = frozenset({"strategy_adopt", "strategy_retire"})
+AccountResolver = Callable[[str], Awaitable["Account | None"]]
+
+
+def _extract_bot_create_account_id(params: dict) -> str | None:
+    """bot_create payload 에서 account_id 를 config-first 순서로 추출."""
+    config = params.get("config")
+    if isinstance(config, dict):
+        candidate = config.get("account_id")
+        if candidate is not None:
+            return str(candidate)
+    candidate = params.get("account_id")
+    if candidate is None:
+        return None
+    return str(candidate)
 
 
 @dataclass(frozen=True)
@@ -20,7 +41,7 @@ class AutoApproveConfig:
 
     enabled: bool = False
     bot_stop: bool = True
-    bot_create_paper: bool = True
+    bot_create_virtual: bool = True
     budget_change_max: float = 5_000_000
 
     @classmethod
@@ -33,7 +54,7 @@ class AutoApproveConfig:
         return cls(
             enabled=bool(data.get("enabled", False)),
             bot_stop=bool(rules.get("bot_stop", True)),
-            bot_create_paper=bool(rules.get("bot_create_paper", True)),
+            bot_create_virtual=bool(rules.get("bot_create_virtual", True)),
             budget_change_max=float(rules.get("budget_change_max", 5_000_000)),
         )
 
@@ -47,8 +68,9 @@ class AutoApproveEvaluator:
     """
 
     config: AutoApproveConfig = field(default_factory=AutoApproveConfig)
+    account_resolver: AccountResolver | None = None
 
-    def should_auto_approve(self, type: str, params: dict | None = None) -> bool:
+    async def should_auto_approve(self, type: str, params: dict | None = None) -> bool:
         """전결 조건 평가.
 
         Args:
@@ -69,16 +91,8 @@ class AutoApproveEvaluator:
         if type == "bot_stop" and self.config.bot_stop:
             return True
 
-        if type == "bot_create" and self.config.bot_create_paper:
-            # Refs #1217 → #1241 SPLIT-2: bot_create payload 형태가
-            # config-nested (``params["config"]["mode"]``) / flat
-            # (``params["mode"]``) 둘 다 호환되도록 config-first → flat
-            # fallback. ApprovalService.create() 가 account_id 를 이미
-            # 동일한 우선순위로 검증하므로 여기서도 같은 순서를 사용한다.
-            config = params.get("config") or {}
-            mode = config.get("mode") or params.get("mode")
-            if mode == "paper":
-                return True
+        if type == "bot_create" and self.config.bot_create_virtual:
+            return await self._should_auto_approve_bot_create(params)
 
         if type == "budget_change" and self.config.budget_change_max > 0:
             amount = params.get("amount", 0)
@@ -88,3 +102,17 @@ class AutoApproveEvaluator:
                 return True
 
         return False
+
+    async def _should_auto_approve_bot_create(self, params: dict) -> bool:
+        """Account.trading_mode 기반 bot_create 자동승인 판단."""
+        if self.account_resolver is None:
+            return False
+
+        account_id = _extract_bot_create_account_id(params)
+        if not account_id:
+            return False
+
+        account = await self.account_resolver(account_id)
+        if account is None:
+            return False
+        return account.trading_mode == TradingMode.VIRTUAL

--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -150,7 +150,7 @@ class ApprovalService:
         )
 
         # 전결 평가
-        auto_approved = self._auto_approve.should_auto_approve(type, params)
+        auto_approved = await self._auto_approve.should_auto_approve(type, params)
         if auto_approved:
             request.status = ApprovalStatus.APPROVED
             request.resolved_at = now

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -1250,7 +1250,22 @@ async def _init_approval(s: Services) -> None:
     auto_approve_config = AutoApproveConfig.from_dict(
         auto_approve_raw if isinstance(auto_approve_raw, dict) else {}
     )
-    auto_approve_evaluator = AutoApproveEvaluator(config=auto_approve_config)
+
+    async def _resolve_auto_approve_account(account_id: str):
+        """전결 판단용 Account 조회. 없으면 자동승인하지 않는다."""
+        from ante.account.errors import AccountNotFoundError
+
+        if s.account_service is None:
+            return None
+        try:
+            return await s.account_service.get(account_id)
+        except AccountNotFoundError:
+            return None
+
+    auto_approve_evaluator = AutoApproveEvaluator(
+        config=auto_approve_config,
+        account_resolver=_resolve_auto_approve_account,
+    )
     if auto_approve_config.enabled:
         logger.info("전결 기능 활성화")
 

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -6,6 +6,8 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
+from ante.account.models import Account, TradingMode
+from ante.approval.auto_approve import AutoApproveConfig, AutoApproveEvaluator
 from ante.approval.models import (
     ApprovalRequest,
     ApprovalStatus,
@@ -1817,6 +1819,40 @@ class TestAccountScopedPayloadValidation:
                 title="누락",
                 params={"config": {"strategy_id": "s1"}},
             )
+
+    async def test_bot_create_mode_paper_no_longer_auto_approves(self, db, eventbus):
+        """mode 값은 bot_create 자동승인 근거가 아니다."""
+
+        async def resolve_account(account_id: str) -> Account | None:
+            if account_id == "acc-test":
+                return Account(
+                    account_id="acc-test",
+                    name="실전 계좌",
+                    exchange="KRX",
+                    currency="KRW",
+                    trading_mode=TradingMode.LIVE,
+                )
+            return None
+
+        svc = ApprovalService(
+            db=db,
+            eventbus=eventbus,
+            auto_approve_evaluator=AutoApproveEvaluator(
+                config=AutoApproveConfig(enabled=True, bot_create_virtual=True),
+                account_resolver=resolve_account,
+            ),
+        )
+        await svc.initialize()
+
+        req = await svc.create(
+            type="bot_create",
+            requester="agent",
+            title="mode 값은 무시",
+            params={"account_id": "acc-test", "mode": "paper", "strategy_id": "s1"},
+        )
+
+        assert req.status == ApprovalStatus.PENDING
+        assert req.resolved_by == ""
 
     async def test_approval_create_global_types_pass_without_account(self, service):
         """글로벌 결재 (strategy_*) + bot-id scoped 는 account_id 없이 통과."""

--- a/tests/unit/test_auto_approve.py
+++ b/tests/unit/test_auto_approve.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from ante.account.models import Account, TradingMode
 from ante.approval.auto_approve import (
     EXCLUDED_TYPES,
     AutoApproveConfig,
@@ -18,13 +19,39 @@ from ante.eventbus.events import ApprovalCreatedEvent, ApprovalResolvedEvent
 # ── Fixtures ─────────────────────────────────────────
 
 
+def _account(account_id: str, trading_mode: TradingMode) -> Account:
+    return Account(
+        account_id=account_id,
+        name=account_id,
+        exchange="KRX",
+        currency="KRW",
+        trading_mode=trading_mode,
+    )
+
+
+@pytest.fixture
+def accounts() -> dict[str, Account]:
+    return {
+        "virtual-acc": _account("virtual-acc", TradingMode.VIRTUAL),
+        "live-acc": _account("live-acc", TradingMode.LIVE),
+    }
+
+
+@pytest.fixture
+def account_resolver(accounts):
+    async def resolve(account_id: str) -> Account | None:
+        return accounts.get(account_id)
+
+    return resolve
+
+
 @pytest.fixture
 def enabled_config() -> AutoApproveConfig:
     """전결 활성화 설정."""
     return AutoApproveConfig(
         enabled=True,
         bot_stop=True,
-        bot_create_paper=True,
+        bot_create_virtual=True,
         budget_change_max=5_000_000,
     )
 
@@ -36,8 +63,13 @@ def disabled_config() -> AutoApproveConfig:
 
 
 @pytest.fixture
-def evaluator(enabled_config: AutoApproveConfig) -> AutoApproveEvaluator:
-    return AutoApproveEvaluator(config=enabled_config)
+def evaluator(
+    enabled_config: AutoApproveConfig, account_resolver
+) -> AutoApproveEvaluator:
+    return AutoApproveEvaluator(
+        config=enabled_config,
+        account_resolver=account_resolver,
+    )
 
 
 @pytest.fixture
@@ -66,7 +98,17 @@ async def service_with_auto_approve(db, eventbus, enabled_config):
     async def mock_executor(params: dict) -> None:
         executed.append(params)
 
-    evaluator = AutoApproveEvaluator(config=enabled_config)
+    async def resolve_account(account_id: str) -> Account | None:
+        accounts = {
+            "virtual-acc": _account("virtual-acc", TradingMode.VIRTUAL),
+            "live-acc": _account("live-acc", TradingMode.LIVE),
+        }
+        return accounts.get(account_id)
+
+    evaluator = AutoApproveEvaluator(
+        config=enabled_config,
+        account_resolver=resolve_account,
+    )
     svc = ApprovalService(
         db=db,
         eventbus=eventbus,
@@ -94,7 +136,7 @@ class TestAutoApproveConfig:
         config = AutoApproveConfig()
         assert config.enabled is False
         assert config.bot_stop is True
-        assert config.bot_create_paper is True
+        assert config.bot_create_virtual is True
         assert config.budget_change_max == 5_000_000
 
     def test_from_dict(self):
@@ -103,14 +145,14 @@ class TestAutoApproveConfig:
             "enabled": True,
             "rules": {
                 "bot_stop": True,
-                "bot_create_paper": False,
+                "bot_create_virtual": False,
                 "budget_change_max": 3000000,
             },
         }
         config = AutoApproveConfig.from_dict(data)
         assert config.enabled is True
         assert config.bot_stop is True
-        assert config.bot_create_paper is False
+        assert config.bot_create_virtual is False
         assert config.budget_change_max == 3_000_000
 
     def test_from_dict_empty(self):
@@ -131,138 +173,154 @@ class TestAutoApproveConfig:
 
 
 class TestAutoApproveEvaluator:
-    def test_disabled_returns_false(self, disabled_evaluator):
+    async def test_disabled_returns_false(self, disabled_evaluator):
         """비활성화 시 항상 False."""
-        assert disabled_evaluator.should_auto_approve("bot_stop") is False
-        assert disabled_evaluator.should_auto_approve("budget_change") is False
+        assert await disabled_evaluator.should_auto_approve("bot_stop") is False
+        assert await disabled_evaluator.should_auto_approve("budget_change") is False
 
-    def test_bot_stop_auto_approved(self, evaluator):
+    async def test_bot_stop_auto_approved(self, evaluator):
         """bot_stop은 자동 승인."""
-        assert evaluator.should_auto_approve("bot_stop", {"bot_id": "bot-1"}) is True
-
-    def test_bot_create_paper_auto_approved(self, evaluator):
-        """모의투자 봇 생성은 자동 승인."""
         assert (
-            evaluator.should_auto_approve(
-                "bot_create", {"mode": "paper", "strategy_name": "test"}
+            await evaluator.should_auto_approve("bot_stop", {"bot_id": "bot-1"}) is True
+        )
+
+    async def test_bot_create_virtual_account_auto_approved(self, evaluator):
+        """virtual Account 봇 생성은 자동 승인."""
+        assert (
+            await evaluator.should_auto_approve(
+                "bot_create",
+                {"account_id": "virtual-acc", "strategy_name": "test"},
             )
             is True
         )
 
-    def test_bot_create_live_not_auto_approved(self, evaluator):
-        """실전투자 봇 생성은 자동 승인 안 됨."""
+    async def test_bot_create_live_account_not_auto_approved(self, evaluator):
+        """live Account 봇 생성은 자동 승인 안 됨."""
         assert (
-            evaluator.should_auto_approve(
-                "bot_create", {"mode": "live", "strategy_name": "test"}
+            await evaluator.should_auto_approve(
+                "bot_create",
+                {"account_id": "live-acc", "strategy_name": "test"},
             )
             is False
         )
 
-    def test_bot_create_no_mode_not_auto_approved(self, evaluator):
-        """mode 없는 봇 생성은 자동 승인 안 됨."""
+    async def test_bot_create_no_account_not_auto_approved(self, evaluator):
+        """account_id 없는 봇 생성은 자동 승인 안 됨."""
         assert (
-            evaluator.should_auto_approve("bot_create", {"strategy_name": "test"})
+            await evaluator.should_auto_approve("bot_create", {"strategy_name": "test"})
             is False
         )
 
-    def test_auto_approve_bot_create_paper_config_nested(self, evaluator):
-        """Refs #1241 SPLIT-2: ``params["config"]["mode"]=="paper"`` 도 자동 승인.
-
-        web/CLI 가 BotConfig 형태로 wrap 해서 보내는 신규 payload 형태도
-        호환해야 한다 (config-first → flat fallback).
-        """
+    async def test_bot_create_config_account_id_first(self, evaluator):
+        """config.account_id가 flat account_id보다 우선한다."""
         assert (
-            evaluator.should_auto_approve(
+            await evaluator.should_auto_approve(
                 "bot_create",
                 {
                     "config": {
-                        "account_id": "acc-test",
-                        "mode": "paper",
+                        "account_id": "virtual-acc",
                         "strategy_id": "s1",
-                    }
+                    },
+                    "account_id": "live-acc",
                 },
             )
             is True
         )
 
-    def test_auto_approve_bot_create_paper_flat_legacy(self, evaluator):
-        """Refs #1241 SPLIT-2: legacy flat ``params["mode"]=="paper"`` 도 호환."""
-        # flat-only (config 키 자체가 없음)
+    async def test_bot_create_flat_account_id_fallback(self, evaluator):
+        """flat account_id도 resolver 입력으로 사용한다."""
         assert (
-            evaluator.should_auto_approve(
+            await evaluator.should_auto_approve(
                 "bot_create",
-                {"account_id": "acc-test", "mode": "paper", "strategy_id": "s1"},
+                {"account_id": "virtual-acc", "strategy_id": "s1"},
             )
             is True
         )
 
-    def test_auto_approve_bot_create_config_first_overrides_flat(self, evaluator):
-        """config-nested 가 flat 보다 우선한다 (config-first 우선순위)."""
-        # config 의 mode=live 가 우선되어 자동 승인되지 않는다
+    async def test_bot_create_missing_account_not_auto_approved(self, evaluator):
+        """Account 조회 실패 시 자동 승인하지 않는다."""
         assert (
-            evaluator.should_auto_approve(
+            await evaluator.should_auto_approve(
                 "bot_create",
-                {
-                    "config": {"mode": "live", "strategy_id": "s1"},
-                    "mode": "paper",  # flat 은 무시되어야 함
-                },
+                {"account_id": "missing-acc", "strategy_id": "s1"},
             )
             is False
         )
 
-    def test_budget_change_within_limit(self, evaluator):
+    async def test_bot_create_mode_value_is_ignored(self, evaluator):
+        """mode 값만으로는 자동 승인하지 않는다."""
+        assert (
+            await evaluator.should_auto_approve(
+                "bot_create",
+                {"account_id": "live-acc", "mode": "virtual", "strategy_id": "s1"},
+            )
+            is False
+        )
+
+    async def test_bot_create_without_resolver_not_auto_approved(self, enabled_config):
+        """Account resolver가 없으면 bot_create를 자동 승인하지 않는다."""
+        evaluator = AutoApproveEvaluator(config=enabled_config)
+        assert (
+            await evaluator.should_auto_approve(
+                "bot_create",
+                {"account_id": "virtual-acc", "strategy_id": "s1"},
+            )
+            is False
+        )
+
+    async def test_budget_change_within_limit(self, evaluator):
         """예산 변경이 한도 이내이면 자동 승인."""
         assert (
-            evaluator.should_auto_approve(
+            await evaluator.should_auto_approve(
                 "budget_change",
                 {"bot_id": "bot-1", "amount": 15000000, "current": 10000000},
             )
             is True
         )
 
-    def test_budget_change_at_limit(self, evaluator):
+    async def test_budget_change_at_limit(self, evaluator):
         """예산 변경이 정확히 한도이면 자동 승인."""
         assert (
-            evaluator.should_auto_approve(
+            await evaluator.should_auto_approve(
                 "budget_change",
                 {"bot_id": "bot-1", "amount": 15000000, "current": 10000000},
             )
             is True
         )
 
-    def test_budget_change_over_limit(self, evaluator):
+    async def test_budget_change_over_limit(self, evaluator):
         """예산 변경이 한도 초과이면 자동 승인 안 됨."""
         assert (
-            evaluator.should_auto_approve(
+            await evaluator.should_auto_approve(
                 "budget_change",
                 {"bot_id": "bot-1", "amount": 20000000, "current": 10000000},
             )
             is False
         )
 
-    def test_budget_change_decrease_within_limit(self, evaluator):
+    async def test_budget_change_decrease_within_limit(self, evaluator):
         """예산 감액도 변경액 기준으로 평가."""
         assert (
-            evaluator.should_auto_approve(
+            await evaluator.should_auto_approve(
                 "budget_change",
                 {"bot_id": "bot-1", "amount": 7000000, "current": 10000000},
             )
             is True
         )
 
-    def test_strategy_adopt_excluded(self, evaluator):
+    async def test_strategy_adopt_excluded(self, evaluator):
         """strategy_adopt는 전결 대상에서 제외."""
         assert (
-            evaluator.should_auto_approve(
+            await evaluator.should_auto_approve(
                 "strategy_adopt", {"strategy_name": "test", "report_id": "r1"}
             )
             is False
         )
 
-    def test_strategy_retire_excluded(self, evaluator):
+    async def test_strategy_retire_excluded(self, evaluator):
         """strategy_retire는 전결 대상에서 제외."""
         assert (
-            evaluator.should_auto_approve(
+            await evaluator.should_auto_approve(
                 "strategy_retire", {"strategy_name": "test", "report_id": "r1"}
             )
             is False
@@ -273,28 +331,29 @@ class TestAutoApproveEvaluator:
         assert "strategy_adopt" in EXCLUDED_TYPES
         assert "strategy_retire" in EXCLUDED_TYPES
 
-    def test_unknown_type_not_auto_approved(self, evaluator):
+    async def test_unknown_type_not_auto_approved(self, evaluator):
         """알 수 없는 유형은 자동 승인 안 됨."""
-        assert evaluator.should_auto_approve("unknown_type") is False
+        assert await evaluator.should_auto_approve("unknown_type") is False
 
-    def test_rule_change_not_auto_approved(self, evaluator):
+    async def test_rule_change_not_auto_approved(self, evaluator):
         """rule_change는 전결 규칙에 없으므로 자동 승인 안 됨."""
         assert (
-            evaluator.should_auto_approve("rule_change", {"bot_id": "bot-1"}) is False
+            await evaluator.should_auto_approve("rule_change", {"bot_id": "bot-1"})
+            is False
         )
 
-    def test_bot_stop_disabled_in_config(self):
+    async def test_bot_stop_disabled_in_config(self):
         """bot_stop 규칙이 비활성화된 경우."""
         config = AutoApproveConfig(enabled=True, bot_stop=False)
         ev = AutoApproveEvaluator(config=config)
-        assert ev.should_auto_approve("bot_stop", {"bot_id": "bot-1"}) is False
+        assert await ev.should_auto_approve("bot_stop", {"bot_id": "bot-1"}) is False
 
-    def test_budget_change_max_zero_disables(self):
+    async def test_budget_change_max_zero_disables(self):
         """budget_change_max가 0이면 예산 변경 전결 비활성화."""
         config = AutoApproveConfig(enabled=True, budget_change_max=0)
         ev = AutoApproveEvaluator(config=config)
         assert (
-            ev.should_auto_approve(
+            await ev.should_auto_approve(
                 "budget_change",
                 {"bot_id": "bot-1", "amount": 10000000, "current": 10000000},
             )
@@ -340,6 +399,39 @@ class TestServiceAutoApprove:
 
         assert len(executed) == 1
         assert executed[0]["bot_id"] == "bot-1"
+
+    async def test_bot_create_virtual_account_auto_approved_by_service(
+        self, service_with_auto_approve
+    ):
+        """bot_create는 virtual Account 기준으로 자동 승인된다."""
+        svc, executed = service_with_auto_approve
+        req = await svc.create(
+            type="bot_create",
+            requester="agent:dev",
+            title="봇 생성 요청",
+            params={"account_id": "virtual-acc", "strategy_id": "s1"},
+        )
+
+        assert req.status == ApprovalStatus.APPROVED
+        assert req.resolved_by == "system:auto_approve"
+        assert len(executed) == 1
+        assert executed[0]["account_id"] == "virtual-acc"
+
+    async def test_bot_create_live_account_stays_pending_by_service(
+        self, service_with_auto_approve
+    ):
+        """bot_create live Account는 자동 승인되지 않는다."""
+        svc, executed = service_with_auto_approve
+        req = await svc.create(
+            type="bot_create",
+            requester="agent:dev",
+            title="봇 생성 요청",
+            params={"account_id": "live-acc", "strategy_id": "s1"},
+        )
+
+        assert req.status == ApprovalStatus.PENDING
+        assert req.resolved_by == ""
+        assert len(executed) == 0
 
     async def test_auto_approve_publishes_created_event_with_flag(
         self, service_with_auto_approve, eventbus


### PR DESCRIPTION
Closes #1282

## Summary
- Rename the auto-approve rule from `bot_create_paper` to `bot_create_virtual` without a legacy alias.
- Make bot_create auto-approval resolve Account by `account_id` and approve only `Account.trading_mode == "virtual"`.
- Await auto-approval evaluation from `ApprovalService.create()` and wire an Account resolver in `main.py`.
- Update approval specs, config example, and unit tests for the virtual/live Account contract.

## Test Plan
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/test_auto_approve.py tests/unit/test_approval.py -q`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/test_main.py -q -k approval`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m ruff check src/ante/approval src/ante/main.py tests/unit/test_auto_approve.py tests/unit/test_approval.py`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m ruff format --check src/ante/approval src/ante/main.py tests/unit/test_auto_approve.py tests/unit/test_approval.py`
- `rg "bot_create_paper|mode.*paper" src/ante/approval docs/specs/approval config/system.toml.example`

## Notes
- #1283 remains responsible for aligning the approval `bot_create` executor/validator payload with `BotManager.create_bot(config, strategy_cls, ctx?)`.
