### PR TITLE
refactor: align approval bot_create executor contract

### DIFF
--- a/docs/specs/approval/03-enums.md
+++ b/docs/specs/approval/03-enums.md
@@ -22,7 +22,7 @@
 |----|------|------------------|
 | `STRATEGY_ADOPT` | 전략 채택 | `ReportStore.update_status(report_id, "adopted")` + `StrategyRegistry.update_status(strategy_id, "adopted")` → 전략이 ADOPTED 상태로 전환되어 봇에 배정 가능해진다. 전결 대상에서 제외된다 |
 | `STRATEGY_RETIRE` | 전략 폐기 | `ReportStore.update_status(report_id, "retired")` + `StrategyRegistry.update_status(strategy_id, "archived")` → 전략이 ARCHIVED 상태로 전환된다. 봇은 전략 복제본을 사용하므로 운영 중인 봇에는 영향 없음. 전결 대상에서 제외된다 |
-| `BOT_CREATE` | 봇 신규 생성 | `BotManager.create_bot(**params)` → 전략을 실행하는 새 봇이 생성되고, Treasury에서 예산이 할당된다. 전결은 Account 조회 결과 `trading_mode == "virtual"`일 때만 가능하다 |
+| `BOT_CREATE` | 봇 신규 생성 | `params.config`를 `BotConfig`로 변환하고 `StrategyRegistry`에서 ADOPTED 전략을 조회한 뒤 `StrategyLoader.load(record.filepath)`와 `BotManager.create_bot(config=..., strategy_cls=..., source_path=...)`를 호출한다. 예산 배정은 별도 `budget_change` 요청으로 처리한다. 전결은 Account 조회 결과 `trading_mode == "virtual"`일 때만 가능하다 |
 | `BOT_ASSIGN_STRATEGY` | 봇에 전략 배정 | `BotManager.assign_strategy(bot_id, strategy_id)` → 봇에 채택된 전략을 배정한다. 봇이 running 상태이면 즉시 새 전략으로 전환된다 |
 | `BOT_CHANGE_STRATEGY` | 봇 전략 변경 | `BotManager.change_strategy(bot_id, strategy_id)` → 중지 상태의 봇에 다른 전략을 교체 배정한다. 봇이 running 상태이면 거부된다 |
 | `BOT_STOP` | 봇 중지 | `BotManager.stop_bot(bot_id)` → 봇의 전략 루프가 중지되고, 미체결 주문이 취소된다. 보유 포지션은 유지된다 |

--- a/docs/specs/approval/05-approval-types.md
+++ b/docs/specs/approval/05-approval-types.md
@@ -7,16 +7,16 @@
 | type | 설명 | params 예시 | 승인 시 실행 내용 | executor 상태 |
 |------|------|-------------|------------------|--------------|
 | `strategy_adopt` | 전략 채택 | `{"strategy_name": "...", "strategy_id": "...", "report_id": "..."}` | `ReportStore.update_status(report_id, "adopted")` + `StrategyRegistry.update_status(strategy_id, "adopted")` 호출 → 전략이 ADOPTED 상태로 전환되어 봇에 배정 가능해진다 | 등록됨 |
-| `strategy_retire` | 전략 폐기 | `{"strategy_name": "...", "strategy_id": "...", "report_id": "...", "reason": "성과 부진"}` | `ReportStore.update_status(report_id, "retired")` + `StrategyRegistry.update_status(strategy_id, "archived")` 호출 → 전략이 ARCHIVED 상태로 전환된다. 봇은 전략 복제본을 사용하므로 운영 중인 봇에는 영향 없음 | **미등록** |
-| `bot_create` | 봇 신규 생성 | `{"account_id": "domestic-demo", "strategy_id": "...", "budget": 10000000}` | `BotManager.create_bot(**params)` 호출 → 전략을 실행하는 새 봇이 생성되고, Treasury에서 예산이 할당된다 | **미등록** |
-| `bot_assign_strategy` | 봇에 전략 배정 | `{"bot_id": "...", "strategy_id": "..."}` | `BotManager.assign_strategy(bot_id, strategy_id)` 호출 → 봇에 채택된 전략을 배정한다. running 상태이면 즉시 새 전략으로 전환된다 | **미등록** |
-| `bot_change_strategy` | 봇 전략 변경 | `{"bot_id": "...", "strategy_id": "..."}` | `BotManager.change_strategy(bot_id, strategy_id)` 호출 → 중지 상태의 봇에 다른 전략을 교체 배정한다. running 상태이면 거부된다 | **미등록** |
+| `strategy_retire` | 전략 폐기 | `{"strategy_name": "...", "strategy_id": "...", "report_id": "...", "reason": "성과 부진"}` | `ReportStore.update_status(report_id, "retired")` + `StrategyRegistry.update_status(strategy_id, "archived")` 호출 → 전략이 ARCHIVED 상태로 전환된다. 봇은 전략 복제본을 사용하므로 운영 중인 봇에는 영향 없음 | 등록됨 |
+| `bot_create` | 봇 신규 생성 | `{"config": {"bot_id": "...", "strategy_id": "...", "name": "...", "account_id": "domestic-demo", "interval_seconds": 60}}` | `params.config`를 `BotConfig`로 변환하고 `StrategyRegistry`에서 ADOPTED 전략을 조회한 뒤 `StrategyLoader.load(record.filepath)`와 `BotManager.create_bot(config=..., strategy_cls=..., source_path=...)`를 호출한다. 예산 배정은 별도 `budget_change` 요청으로 처리한다 | 등록됨 |
+| `bot_assign_strategy` | 봇에 전략 배정 | `{"bot_id": "...", "strategy_id": "..."}` | `BotManager.assign_strategy(bot_id, strategy_id)` 호출 → 봇에 채택된 전략을 배정한다. running 상태이면 즉시 새 전략으로 전환된다 | 등록됨 |
+| `bot_change_strategy` | 봇 전략 변경 | `{"bot_id": "...", "strategy_id": "..."}` | `BotManager.change_strategy(bot_id, strategy_id)` 호출 → 중지 상태의 봇에 다른 전략을 교체 배정한다. running 상태이면 거부된다 | 등록됨 |
 | `bot_stop` | 봇 중지 | `{"bot_id": "...", "reason": "손실 누적"}` | `BotManager.stop_bot(bot_id)` 호출 → 봇의 전략 루프가 중지되고, 미체결 주문이 취소된다. 보유 포지션은 유지된다 | 등록됨 |
-| `bot_resume` | 봇 재개 | `{"bot_id": "...", "reason": "에러 해소 확인"}` | `BotManager.resume_bot(bot_id)` 호출 → 중지 또는 에러 상태의 봇을 재시작한다. Agent가 재개 사유를 판단하여 요청한다 | **미등록** |
-| `bot_delete` | 봇 삭제 | `{"bot_id": "...", "reason": "전략 폐기"}` | `BotManager.delete_bot(bot_id)` 호출 → 중지 상태의 봇을 완전히 제거한다. 보유 포지션이 있으면 거부된다. 할당 예산은 Treasury 미할당으로 반환된다 | **미등록** |
-| `budget_change` | 봇 예산 변경 | `{"bot_id": "...", "amount": 25000000, "current": 10000000}` | `Treasury.update_budget(bot_id, amount)` 호출 → 해당 봇의 할당 예산이 변경되고, 미할당 잔액이 재계산된다 | **미등록** |
-| `rule_change` | 전략별 규칙 변경 | `{"bot_id": "...", "rules": {"max_position_pct": 0.2}}` | `RuleEngine.update_rules(bot_id, rules)` 호출 → 해당 봇의 거래 규칙(최대 포지션 비율, 손절선 등)이 즉시 갱신된다 | **미등록** |
+| `bot_resume` | 봇 재개 | `{"bot_id": "...", "reason": "에러 해소 확인"}` | `BotManager.resume_bot(bot_id)` 호출 → 중지 또는 에러 상태의 봇을 재시작한다. Agent가 재개 사유를 판단하여 요청한다 | 등록됨 |
+| `bot_delete` | 봇 삭제 | `{"bot_id": "...", "reason": "전략 폐기"}` | `BotManager.delete_bot(bot_id)` 호출 → 중지 상태의 봇을 완전히 제거한다. 보유 포지션이 있으면 거부된다. 할당 예산은 Treasury 미할당으로 반환된다 | 등록됨 |
+| `budget_change` | 봇 예산 변경 | `{"bot_id": "...", "amount": 25000000, "current": 10000000}` | `Treasury.update_budget(bot_id, amount)` 호출 → 해당 봇의 할당 예산이 변경되고, 미할당 잔액이 재계산된다 | 등록됨 |
+| `rule_change` | 전략별 규칙 변경 | `{"bot_id": "...", "rules": {"max_position_pct": 0.2}}` | `RuleEngine.update_rules(bot_id, rules)` 호출 → 해당 봇의 거래 규칙(최대 포지션 비율, 손절선 등)이 즉시 갱신된다 | 등록됨 |
 
 결재 유형은 열린 구조로, 새로운 유형을 추가할 때 `type` 문자열과 실행 핸들러만 등록하면 된다.
 
-> **구현 현황**: `strategy_adopt`, `bot_stop`만 main.py에 executor가 등록되어 있다. 나머지 8건은 executor 미등록 상태로, 승인해도 실행되지 않는다.
+> **구현 현황**: 10개 결재 유형 모두 main.py에 executor가 등록되어 있다. `bot_create` executor payload는 `params.config`의 `BotConfig` 필드만 사용하며, `mode`, `budget`, `strategy_cls`를 params에 저장하지 않는다.

--- a/docs/specs/approval/08-approval-service.md
+++ b/docs/specs/approval/08-approval-service.md
@@ -42,6 +42,13 @@
 `trading_mode`가 `"virtual"`일 때만 자동 승인한다. `mode` 필드나
 `broker_config.is_paper`는 자동승인 판단에 사용하지 않는다.
 
+`bot_create` 실행 계약은 `params["config"]`를 표준 payload로 사용한다.
+executor는 이 값을 `BotConfig`로 변환하고, `strategy_id`로
+`StrategyRegistry`의 ADOPTED 전략 레코드를 조회한 뒤 `StrategyLoader`로
+전략 클래스를 로드해 `BotManager.create_bot(config=..., strategy_cls=...,
+source_path=...)`를 호출한다. `strategy_cls`는 JSON params에 저장하지 않으며,
+예산 배정은 별도 `budget_change` 결재로 처리한다.
+
 ### 만료 스케줄러
 
 `expire_stale()`은 **주기적 스케줄러**로 호출한다. `main.py`의 `asyncio` 이벤트 루프에서 5분 간격 태스크로 등록한다.
@@ -69,7 +76,7 @@ asyncio.create_task(_expire_loop(approval_service))
 executors = {
     "strategy_adopt": lambda params: report_store.adopt(params["report_id"]),
     "budget_change": lambda params: treasury.update_budget(params["bot_id"], params["amount"]),
-    "bot_create": lambda params: bot_manager.create_bot(**params),
+    "bot_create": exec_bot_create,  # params["config"] -> BotConfig + StrategyLoader
     "bot_stop": lambda params: bot_manager.stop_bot(params["bot_id"]),
     "rule_change": lambda params: rule_engine.update_rules(params["bot_id"], params["rules"]),
 }
@@ -95,8 +102,9 @@ executors = {
 | 유형 | 검증 내용 | 등급 | 검증 주체 |
 |------|----------|------|----------|
 | `strategy_retire` | 전략이 이미 ARCHIVED 상태인가 | `fail` | StrategyRegistry |
-| `bot_create` | 전략이 adopted 상태인가 | `fail` | ReportStore |
-| `bot_create` | 동일 이름의 봇이 이미 존재하는가 | `fail` | BotManager |
+| `bot_create` | `params.config`가 `BotConfig`로 변환 가능한가 | `fail` | BotManager |
+| `bot_create` | 전략이 adopted 상태인가 | `fail` | StrategyRegistry |
+| `bot_create` | 동일 ID의 봇이 이미 존재하는가 | `fail` | BotManager |
 | `bot_delete` | 보유 포지션이 있는가 | `fail` | Trade |
 | `bot_delete` | 봇이 stopped 상태인가 | `fail` | BotManager |
 | `bot_change_strategy` | 봇이 stopped 상태인가 | `fail` | BotManager |
@@ -125,7 +133,7 @@ if validator:
 |------|-----------------|--------|
 | `strategy_retire` | 전략이 REGISTERED 또는 ADOPTED 상태 | 거부 — 이미 ARCHIVED 상태 |
 | `budget_change` | Treasury 미할당 잔액 ≥ 증액분 | 거부 — 자금 부족 |
-| `bot_create` | 전략이 adopted 상태, 동일 봇 미존재 | 거부 — 전략 미채택 또는 봇 중복 |
+| `bot_create` | `params.config`가 `BotConfig`로 변환 가능, 전략이 adopted 상태, 동일 봇 미존재 | 거부 — payload 오류, 전략 미채택 또는 봇 중복 |
 | `bot_delete` | 봇이 stopped 상태, 보유 포지션 없음 | 거부 — 봇 중지 및 포지션 청산 필요 |
 | `bot_change_strategy` | 봇이 stopped 상태 | 거부 — running 중에는 전략 변경 불가 |
 | `bot_resume` | 봇이 stopped 또는 error 상태 | 거부 — 이미 running 상태 |

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -991,6 +991,33 @@ def _approval_account_id(params: dict, *, context: str) -> str:
     return require_account_id(params.get("account_id"), context=context)
 
 
+def _approval_bot_create_config(params: dict) -> Any:
+    """bot_create approval params 를 BotManager.create_bot 계약으로 변환."""
+    from ante.account.scoping import require_account_id
+    from ante.bot.config import BotConfig
+
+    config_params = params.get("config")
+    if not isinstance(config_params, dict):
+        raise ValueError("bot_create params.config가 누락되었습니다")
+
+    strategy_id = str(config_params.get("strategy_id") or "")
+    if not strategy_id:
+        raise ValueError("bot_create config.strategy_id가 누락되었습니다")
+
+    bot_id = str(config_params.get("bot_id") or "")
+    account_id = require_account_id(
+        config_params.get("account_id"), context="approval.bot_create.config"
+    )
+    interval_seconds = int(config_params.get("interval_seconds", 60))
+    return BotConfig(
+        bot_id=bot_id,
+        strategy_id=strategy_id,
+        name=str(config_params.get("name") or bot_id),
+        account_id=account_id,
+        interval_seconds=interval_seconds,
+    )
+
+
 async def _init_approval(s: Services) -> None:
     """ApprovalService 초기화: Executor, Validator, 전결 설정, 만료 스케줄러."""
     assert s.db is not None
@@ -1058,12 +1085,32 @@ async def _init_approval(s: Services) -> None:
                 )
             )
 
+    async def _exec_bot_create(params: dict) -> None:
+        from ante.strategy.loader import StrategyLoader
+
+        config = _approval_bot_create_config(params)
+        record = await s.strategy_registry.get(config.strategy_id)
+        if record is None:
+            raise ValueError(f"전략을 찾을 수 없습니다: {config.strategy_id}")
+        if record.status != StrategyStatus.ADOPTED:
+            raise ValueError(
+                f"전략이 adopted 상태가 아닙니다: {config.strategy_id} "
+                f"({record.status})"
+            )
+
+        strategy_cls = StrategyLoader.load(Path(record.filepath))
+        await s.bot_manager.create_bot(
+            config=config,
+            strategy_cls=strategy_cls,
+            source_path=Path(record.filepath),
+        )
+
     approval_executors: dict = {
         # 전략 관련
         "strategy_adopt": _exec_strategy_adopt,
         "strategy_retire": _exec_strategy_retire,
         # 봇 생명주기
-        "bot_create": lambda params: s.bot_manager.create_bot(**params),
+        "bot_create": _exec_bot_create,
         "bot_assign_strategy": lambda params: s.bot_manager.assign_strategy(
             params["bot_id"], params["strategy_id"]
         ),
@@ -1106,10 +1153,15 @@ async def _init_approval(s: Services) -> None:
             return [ValidationResult("fail", "이미 보관된 전략입니다", "system")]
         return [ValidationResult("pass", "", "system")]
 
-    def _validate_bot_create(params: dict) -> list[ValidationResult]:
+    async def _validate_bot_create(params: dict) -> list[ValidationResult]:
         """봇 생성 사전 검증: 전략 adopted 상태, 동일 봇 미존재."""
         results: list[ValidationResult] = []
-        bot_id = params.get("bot_id", "")
+        try:
+            config = _approval_bot_create_config(params)
+        except Exception as e:
+            return [ValidationResult("fail", str(e), "system:bot_manager")]
+
+        bot_id = config.bot_id
         if bot_id and s.bot_manager.get_bot(bot_id):
             results.append(
                 ValidationResult(
@@ -1118,11 +1170,23 @@ async def _init_approval(s: Services) -> None:
                     "system:bot_manager",
                 )
             )
-        strategy_id = params.get("strategy_id", "")
-        if strategy_id:
-            # strategy_id로 리포트 확인은 비동기 — 동기 호출 불가이므로
-            # 이 검증은 executor 2단계 검증에 위임
-            pass
+        record = await s.strategy_registry.get(config.strategy_id)
+        if record is None:
+            results.append(
+                ValidationResult(
+                    "fail",
+                    f"전략을 찾을 수 없습니다: {config.strategy_id}",
+                    "system:strategy_registry",
+                )
+            )
+        elif record.status != StrategyStatus.ADOPTED:
+            results.append(
+                ValidationResult(
+                    "fail",
+                    f"전략이 adopted 상태가 아닙니다: {config.strategy_id}",
+                    "system:strategy_registry",
+                )
+            )
         return results or [ValidationResult("pass", "", "system:bot_manager")]
 
     def _validate_bot_delete(params: dict) -> list[ValidationResult]:

--- a/tests/unit/test_approval_executors.py
+++ b/tests/unit/test_approval_executors.py
@@ -5,10 +5,13 @@ Refs #446: 8건 executor 신규 등록 검증.
 
 from __future__ import annotations
 
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ante.approval.models import ApprovalValidationError, ValidationResult
 from ante.approval.service import ApprovalService
 from ante.core.database import Database
 from ante.eventbus.bus import EventBus
@@ -36,13 +39,24 @@ def _build_executors() -> tuple[dict, dict]:
     """
     from ante.strategy.registry import StrategyStatus
 
+    class FakeStrategy:
+        pass
+
     report_store = MagicMock()
     report_store.update_status = AsyncMock()
 
     strategy_registry = MagicMock()
+    strategy_record = SimpleNamespace(
+        strategy_id="strat-1",
+        filepath="/tmp/strategy.py",
+        status=StrategyStatus.ADOPTED,
+    )
+    strategy_registry.get = AsyncMock(return_value=strategy_record)
     strategy_registry.update_status = AsyncMock()
+    strategy_loader = MagicMock(return_value=FakeStrategy)
 
     bot_manager = MagicMock()
+    bot_manager.get_bot = MagicMock(return_value=None)
     bot_manager.create_bot = AsyncMock()
     bot_manager.assign_strategy = AsyncMock()
     bot_manager.change_strategy = AsyncMock()
@@ -71,10 +85,26 @@ def _build_executors() -> tuple[dict, dict]:
     async def _exec_rule_change(params: dict) -> None:
         rule_engine.update_rules(params["bot_id"], params["rules"])
 
+    async def _exec_bot_create(params: dict) -> None:
+        from ante.main import _approval_bot_create_config
+
+        config = _approval_bot_create_config(params)
+        record = await strategy_registry.get(config.strategy_id)
+        if record is None:
+            raise ValueError(f"전략을 찾을 수 없습니다: {config.strategy_id}")
+        if record.status != StrategyStatus.ADOPTED:
+            raise ValueError(f"전략이 adopted 상태가 아닙니다: {config.strategy_id}")
+        strategy_cls = strategy_loader(Path(record.filepath))
+        await bot_manager.create_bot(
+            config=config,
+            strategy_cls=strategy_cls,
+            source_path=Path(record.filepath),
+        )
+
     executors = {
         "strategy_adopt": _exec_strategy_adopt,
         "strategy_retire": _exec_strategy_retire,
-        "bot_create": lambda params: bot_manager.create_bot(**params),
+        "bot_create": _exec_bot_create,
         "bot_assign_strategy": lambda params: bot_manager.assign_strategy(
             params["bot_id"], params["strategy_id"]
         ),
@@ -93,6 +123,9 @@ def _build_executors() -> tuple[dict, dict]:
     mocks = {
         "report_store": report_store,
         "strategy_registry": strategy_registry,
+        "strategy_record": strategy_record,
+        "strategy_loader": strategy_loader,
+        "strategy_cls": FakeStrategy,
         "bot_manager": bot_manager,
         "treasury": treasury,
         "rule_engine": rule_engine,
@@ -100,11 +133,61 @@ def _build_executors() -> tuple[dict, dict]:
     return executors, mocks
 
 
+def _build_validators(mocks: dict) -> dict:
+    """mock validator dict를 생성."""
+    from ante.strategy.registry import StrategyStatus
+
+    async def _validate_bot_create(params: dict) -> list[ValidationResult]:
+        from ante.main import _approval_bot_create_config
+
+        try:
+            config = _approval_bot_create_config(params)
+        except Exception as e:
+            return [ValidationResult("fail", str(e), "system:bot_manager")]
+
+        results: list[ValidationResult] = []
+        if config.bot_id and mocks["bot_manager"].get_bot(config.bot_id):
+            results.append(
+                ValidationResult(
+                    "fail",
+                    f"동일 ID의 봇이 이미 존재: {config.bot_id}",
+                    "system:bot_manager",
+                )
+            )
+
+        record = await mocks["strategy_registry"].get(config.strategy_id)
+        if record is None:
+            results.append(
+                ValidationResult(
+                    "fail",
+                    f"전략을 찾을 수 없습니다: {config.strategy_id}",
+                    "system:strategy_registry",
+                )
+            )
+        elif record.status != StrategyStatus.ADOPTED:
+            results.append(
+                ValidationResult(
+                    "fail",
+                    f"전략이 adopted 상태가 아닙니다: {config.strategy_id}",
+                    "system:strategy_registry",
+                )
+            )
+        return results or [ValidationResult("pass", "", "system:bot_manager")]
+
+    return {"bot_create": _validate_bot_create}
+
+
 @pytest.fixture
 async def service_with_executors(db, eventbus):
     """모든 executor가 등록된 ApprovalService."""
     executors, mocks = _build_executors()
-    svc = ApprovalService(db=db, eventbus=eventbus, executors=executors)
+    validators = _build_validators(mocks)
+    svc = ApprovalService(
+        db=db,
+        eventbus=eventbus,
+        executors=executors,
+        validators=validators,
+    )
     await svc.initialize()
     return svc, mocks
 
@@ -165,12 +248,17 @@ class TestBotCreateExecutor:
     """bot_create executor 테스트."""
 
     async def test_approve_calls_create_bot(self, service_with_executors):
+        from ante.bot.config import BotConfig
+
         svc, mocks = service_with_executors
         params = {
-            "account_id": "acc-test",
-            "strategy_name": "momentum",
-            "budget": 10000000,
-            "mode": "paper",
+            "config": {
+                "bot_id": "bot-1",
+                "strategy_id": "strat-1",
+                "name": "momentum-bot",
+                "account_id": "acc-test",
+                "interval_seconds": 60,
+            }
         }
         req = await svc.create(
             type="bot_create",
@@ -179,7 +267,51 @@ class TestBotCreateExecutor:
             params=params,
         )
         await svc.approve(req.id)
-        mocks["bot_manager"].create_bot.assert_awaited_once_with(**params)
+        expected_config = BotConfig(
+            bot_id="bot-1",
+            strategy_id="strat-1",
+            name="momentum-bot",
+            account_id="acc-test",
+            interval_seconds=60,
+        )
+        mocks["bot_manager"].create_bot.assert_awaited_once_with(
+            config=expected_config,
+            strategy_cls=mocks["strategy_cls"],
+            source_path=Path("/tmp/strategy.py"),
+        )
+        mocks["strategy_registry"].get.assert_awaited_with("strat-1")
+        mocks["strategy_loader"].assert_called_once_with(Path("/tmp/strategy.py"))
+
+    async def test_create_rejects_legacy_flat_payload(self, service_with_executors):
+        svc, mocks = service_with_executors
+        with pytest.raises(ApprovalValidationError, match="params.config"):
+            await svc.create(
+                type="bot_create",
+                requester="agent",
+                title="봇 생성",
+                params={"account_id": "acc-test", "strategy_id": "strat-1"},
+            )
+        mocks["bot_manager"].create_bot.assert_not_awaited()
+
+    async def test_create_rejects_unadopted_strategy(self, service_with_executors):
+        from ante.strategy.registry import StrategyStatus
+
+        svc, mocks = service_with_executors
+        mocks["strategy_record"].status = StrategyStatus.REGISTERED
+        with pytest.raises(ApprovalValidationError, match="adopted"):
+            await svc.create(
+                type="bot_create",
+                requester="agent",
+                title="봇 생성",
+                params={
+                    "config": {
+                        "bot_id": "bot-1",
+                        "strategy_id": "strat-1",
+                        "account_id": "acc-test",
+                    }
+                },
+            )
+        mocks["bot_manager"].create_bot.assert_not_awaited()
 
 
 class TestBotAssignStrategyExecutor:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1008,6 +1008,40 @@ def test_approval_account_id_helper_rejects_invalid():
         _approval_account_id({"account_id": "default"}, context="test")
 
 
+def test_approval_bot_create_config_requires_nested_config():
+    """#1283: bot_create approval payload 는 params.config 기반이다."""
+    from ante.main import _approval_bot_create_config
+
+    with pytest.raises(ValueError, match="params.config"):
+        _approval_bot_create_config({"account_id": "acc-test"})
+
+    with pytest.raises(ValueError, match="strategy_id"):
+        _approval_bot_create_config({"config": {"account_id": "acc-test"}})
+
+
+def test_approval_bot_create_config_builds_bot_config():
+    """#1283: params.config 를 BotConfig로 변환한다."""
+    from ante.main import _approval_bot_create_config
+
+    config = _approval_bot_create_config(
+        {
+            "config": {
+                "bot_id": "bot-1",
+                "strategy_id": "strat-1",
+                "name": "momentum-bot",
+                "account_id": "acc-test",
+                "interval_seconds": 60,
+            }
+        }
+    )
+
+    assert config.bot_id == "bot-1"
+    assert config.strategy_id == "strat-1"
+    assert config.name == "momentum-bot"
+    assert config.account_id == "acc-test"
+    assert config.interval_seconds == 60
+
+
 async def test_exec_rule_change_account_scoped_invalid_rejected(tmp_path: Path) -> None:
     """Refs #1217 → #1241 SPLIT-2: rule_change executor 는 invalid
     account_id payload 를 ``InvalidAccountIdError`` 로 거부한다.


### PR DESCRIPTION
## Summary
- align `bot_create` approval executor with `BotManager.create_bot(config=..., strategy_cls=..., source_path=...)`
- add async `bot_create` validation for `params.config`, ADOPTED strategy status, and duplicate bot IDs
- update approval specs and unit tests for the `params.config` payload contract

## Validation
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/test_approval_executors.py tests/unit/test_main.py -q`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/test_approval.py -q -k "account_scoped or bot_create"`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/test_auto_approve.py tests/unit/test_approval.py tests/unit/test_approval_executors.py tests/unit/test_main.py -q`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m ruff check src/ante/main.py tests/unit/test_approval_executors.py tests/unit/test_main.py`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m ruff format --check src/ante/main.py tests/unit/test_approval_executors.py tests/unit/test_main.py`

Closes #1283