### PR TITLE
refactor: rename virtual bot provider internals

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -91,7 +91,7 @@ src/ante/
 │   ├── signal_key.py                 # SignalKeyManager — 봇별 시그널 키 발급/관리
 │   ├── providers/
 │   │   ├── live.py                   # LiveProvider — 실전 봇 데이터 공급
-│   │   ├── paper.py                  # PaperProvider — 모의 봇 데이터 공급
+│   │   ├── virtual.py                # VirtualProvider — 가상 실행 봇 데이터 공급
 │   │   └── __init__.py
 │   ├── __init__.py
 │   └── cold_path.py

--- a/docs/specs/account/03-data-model.md
+++ b/docs/specs/account/03-data-model.md
@@ -89,7 +89,7 @@ class Account:
 
 `exchange`, `currency`, `trading_mode`, `broker_type`는 생성 후 수정할 수 없다. 이 4개 필드는 계좌의 정체성을 결정하는 근본 속성이며, 런타임 중 변경 시 다음 정합성 문제가 발생한다:
 
-- **trading_mode**: 봇 시작 시 Paper/Live 컨텍스트가 결정되므로, 변경 시 실행 중인 컨텍스트와 DB 상태가 불일치
+- **trading_mode**: 봇 시작 시 Virtual/Live 컨텍스트가 결정되므로, 변경 시 실행 중인 컨텍스트와 DB 상태가 불일치
 - **broker_type**: 브로커 어댑터 인스턴스가 캐싱되므로, 변경 시 기존 어댑터와 새 타입이 충돌
 - **exchange / currency**: Treasury 잔고, 거래 기록, 종목 체계가 시장에 종속되므로, 변경 시 모든 하위 데이터의 정합성이 파괴됨
 

--- a/docs/specs/account/14-account-id-contract.md
+++ b/docs/specs/account/14-account-id-contract.md
@@ -193,7 +193,7 @@ reconfig 는 1.0 범위 외이다.
 | `StopOrder.__post_init__` | `require_account_id(self.account_id)` | trigger payload 정합 (#1217 → #1242 SPLIT-3) |
 | `StreamConnectedEvent` / `StreamDisconnectedEvent` | `_requires_account_id: ClassVar[bool] = True` + `account_id` 발행자 전달 | `KISStreamClient` per-account 인스턴스 정책 (#1217 → #1242 SPLIT-3) |
 | `ResponseCache.invalidate` | substring → prefix-exact (`acc-1` invalidate 가 `acc-12` 유지) | account-scoped 캐시 키 격리 (#1217 → #1242 SPLIT-3) |
-| `PaperExecutor` / `_resolve_price` 호출 사이트 | `account_id` 명시 전달 | gateway/stream_integration ctor required 정렬 (#1217 → #1242 SPLIT-3) |
+| `VirtualExecutor` / `_resolve_price` 호출 사이트 | `account_id` 명시 전달 | gateway/stream_integration ctor required 정렬 (#1217 → #1242 SPLIT-3) |
 
 후속 영역은 다음 이슈로 이관:
 

--- a/docs/specs/bot/03-design-decisions.md
+++ b/docs/specs/bot/03-design-decisions.md
@@ -39,7 +39,7 @@ CREATED → RUNNING → STOPPING → STOPPED → DELETED
 **제거된 필드**:
 - `bot_type`: Bot은 trading_mode를 직접 알지 못한다. Account의 `trading_mode`(LIVE/VIRTUAL)에 따라 ContextFactory가 실행 경로를 결정한다.
 - `exchange`: Account의 속성이다. 봇이 독립적으로 exchange를 가지면 Account와 불일치할 수 있으므로 제거. 필요 시 `AccountService.get(account_id).exchange`로 조회한다.
-- `paper_initial_balance`: 가상 자금은 Account 레벨에서 관리한다.
+- `virtual_initial_balance`: 가상 자금은 Account 레벨에서 관리한다.
 
 **실행 간격 제한**: `interval_seconds`는 `MIN_INTERVAL_SECONDS`(10초) 이상 `MAX_INTERVAL_SECONDS`(3600초) 이하여야 한다. 범위 밖이면 `ValueError` 발생. `validate_interval()` 함수로 검증.
 
@@ -61,7 +61,7 @@ CREATED → RUNNING → STOPPING → STOPPED → DELETED
 **설계 근거**:
 
 1. **Bot은 구체 클래스 (ABC 아닌)**
-   - 이전 초안은 Bot을 ABC로 정의하고 LiveBot/PaperBot이 상속
+   - 이전 초안은 Bot을 ABC로 정의하고 LiveBot/VirtualBot이 상속
    - 실제로 실행 루프는 동일 — 차이는 StrategyContext에 주입되는 DataProvider와 PortfolioView
    - LIVE/VIRTUAL 차이는 Bot이 아니라 ContextFactory가 Account의 trading_mode를 참조하여 결정
 
@@ -96,7 +96,7 @@ CREATED → RUNNING → STOPPING → STOPPED → DELETED
 | `start_bot` | `bot_id: str` | `None` | 봇 시작. `bot.start()` 호출 |
 | `stop_bot` | `bot_id: str` | `None` | 봇 중지 |
 | `update_bot` | `bot_id: str, updates: dict` | `Bot` | 봇 설정 수정. **중지 상태에서만 가능** — RUNNING이면 `BotError` 발생. BotConfig는 frozen dataclass이므로 재생성 패턴 적용: 기존 config를 dict로 풀고 → updates 병합 → 새 BotConfig 생성 → Bot.config 교체 → DB 갱신. `budget` 키가 포함되면 `Treasury.deallocate()` + `Treasury.allocate()`로 예산 재조정. `strategy_id` 변경 시 StrategyRegistry 존재 확인 + exchange 호환성 검증 |
-| `delete_bot` | `bot_id: str, handle_positions: str = "keep"` | `None` | 봇 삭제. 실행 중이면 먼저 중지. `handle_positions="liquidate"` 시 TradeService를 통해 보유 종목 시장가 매도 주문 발행 후 삭제 진행. `"keep"`(기본)은 포지션 유지한 채 봇만 삭제. 이벤트 구독 해제 + VIRTUAL 계좌 봇의 PaperExecutor 해제 + 시그널 키 폐기 + DB 레코드 삭제. `remove_bot`은 동일 기능의 별칭(alias) |
+| `delete_bot` | `bot_id: str, handle_positions: str = "keep"` | `None` | 봇 삭제. 실행 중이면 먼저 중지. `handle_positions="liquidate"` 시 TradeService를 통해 보유 종목 시장가 매도 주문 발행 후 삭제 진행. `"keep"`(기본)은 포지션 유지한 채 봇만 삭제. 이벤트 구독 해제 + VIRTUAL 계좌 봇의 VirtualExecutor 해제 + 시그널 키 폐기 + DB 레코드 삭제. `remove_bot`은 동일 기능의 별칭(alias) |
 | `stop_all` | — | `None` | 모든 실행 중 봇 중지 + 재시작 태스크 취소. 시스템 셧다운 시 호출 |
 | `list_bots` | — | `list[dict[str, Any]]` | 봇 목록 조회 |
 | `get_bot` | `bot_id: str` | `Bot \| None` | 봇 조회. 없으면 None |
@@ -134,12 +134,12 @@ CREATED → RUNNING → STOPPING → STOPPED → DELETED
 
 | 측면 | LIVE 계좌 봇 | VIRTUAL 계좌 봇 |
 |------|-------------|----------------|
-| PortfolioView | Treasury(잔고) + Trade(포지션) 경유 | PaperPortfolioView, 가상 자금 인메모리 관리 |
-| 주문 처리 | OrderRequestEvent → RuleEngine → BrokerAdapter → 실제 주문 | OrderRequestEvent → RuleEngine → PaperExecutor → 가상 체결 |
+| PortfolioView | Treasury(잔고) + Trade(포지션) 경유 | VirtualPortfolioView, 가상 자금 인메모리 관리 |
+| 주문 처리 | OrderRequestEvent → RuleEngine → BrokerAdapter → 실제 주문 | OrderRequestEvent → RuleEngine → VirtualExecutor → 가상 체결 |
 | 데이터 | 실시간 시세 (API Gateway 경유) | 실시간 시세 (동일) |
 | 자금 | Treasury에서 할당받은 실제 자금 | Account 레벨에서 설정된 가상 자금 |
-| 체결 | BrokerAdapter가 실제 체결 후 OrderFilledEvent 발행 | PaperExecutor가 즉시 가상 체결 후 OrderFilledEvent 발행 |
-| 브로커 접근 | `AccountService.get_broker(account_id)` | — (PaperExecutor 사용) |
+| 체결 | BrokerAdapter가 실제 체결 후 OrderFilledEvent 발행 | VirtualExecutor가 즉시 가상 체결 후 OrderFilledEvent 발행 |
+| 브로커 접근 | `AccountService.get_broker(account_id)` | — (VirtualExecutor 사용) |
 | 예산 접근 | `TreasuryManager.get(account_id)` | 가상 자금 관리 |
 
 **근거**:

--- a/docs/specs/bot/06-cli-usage.md
+++ b/docs/specs/bot/06-cli-usage.md
@@ -57,7 +57,7 @@ ante signal connect --key sk_a1b2c3d4
 
 cold-path `bot remove`는 BotManager를 만들지 않으며, `signal_keys` 행 삭제,
 전략 스냅샷 정리, Treasury budget 환수, `bots.status='deleted'` 갱신만 수행한다.
-PaperExecutor unregister, EventBus 구독 해제, `BotStoppedEvent` 발행은 서버 정지
+VirtualExecutor unregister, EventBus 구독 해제, `BotStoppedEvent` 발행은 서버 정지
 상태에서 대상 인메모리 객체가 없으므로 수행하지 않는다. cold-path에서
 `running`/`stopping` 상태는 stale status로 간주하며 포지션 청산은 지원하지 않는다.
 

--- a/docs/specs/bot/07-testing.md
+++ b/docs/specs/bot/07-testing.md
@@ -15,7 +15,7 @@
 - 예외 발생 시 해당 봇만 ERROR, 다른 봇 영향 없음 확인
 - stop() → Task 취소 + on_stop() 호출 + BotStoppedEvent 발행 확인
 - OrderFilledEvent 수신 → 해당 bot_id만 on_fill() 호출 확인
-- VIRTUAL 계좌 봇: PaperPortfolioView 가상 자금 관리 정상 동작
+- VIRTUAL 계좌 봇: VirtualPortfolioView 가상 자금 관리 정상 동작
 - BotManager: 복수 봇 동시 운영 + 개별 시작/중지 확인
 - BotManager: 봇 생성 시 Account 존재·상태 검증 확인
 - BotManager: Strategy.meta.exchange와 Account.exchange 불일치 시 에러 확인

--- a/docs/specs/strategy/03-04-provider-and-views.md
+++ b/docs/specs/strategy/03-04-provider-and-views.md
@@ -37,8 +37,8 @@ StrategyContext에 주입되는 인터페이스. 라이브/백테스트/모의�
 
 **구현체 매핑**:
 
-| ABC | live 봇 | paper 봇 | 백테스트 |
+| ABC | live 봇 | virtual 봇 | 백테스트 |
 |-----|---------|---------|---------|
 | DataProvider | LiveDataProvider (API Gateway 경유) | LiveDataProvider (동일) | BacktestDataProvider (Parquet) |
-| PortfolioView | LivePortfolioView (Treasury + Trade) | PaperPortfolioView (인메모리) | BacktestPortfolioView |
-| OrderView | LiveOrderView (BrokerAdapter 경유) | PaperOrderView (인메모리) | BacktestOrderView |
+| PortfolioView | LivePortfolioView (Treasury + Trade) | VirtualPortfolioView (인메모리) | BacktestPortfolioView |
+| OrderView | LiveOrderView (BrokerAdapter 경유) | VirtualOrderView (인메모리) | BacktestOrderView |

--- a/docs/specs/treasury/09-virtual-asset-sync.md
+++ b/docs/specs/treasury/09-virtual-asset-sync.md
@@ -28,7 +28,7 @@ Virtual 모드에는 외부 매매와 비거래 변동이 존재하지 않으므
 Treasury 동기화는 `trading_mode`에 따라 분기한다:
 
 - **Live**: 기존대로 `broker.get_account_balance()` + `broker.get_positions()` 사용
-- **Virtual**: Trade DB(`PositionHistory`)에서 해당 `account_id`의 미청산 Paper 포지션을 조회하여 `_purchase_amount`, `_eval_amount` 계산
+- **Virtual**: Trade DB(`PositionHistory`)에서 해당 `account_id`의 미청산 virtual 포지션을 조회하여 `_purchase_amount`, `_eval_amount` 계산
 
 ```
 Virtual 모드 동기화 흐름:

--- a/src/ante/bot/cold_path.py
+++ b/src/ante/bot/cold_path.py
@@ -2,7 +2,7 @@
 
 These helpers run only while the Ante server is stopped. They intentionally do
 not instantiate ``BotManager`` because no in-memory bot task, EventBus
-subscriber, PaperExecutor, or broker adapter exists in cold-path mode.
+subscriber, VirtualExecutor, or broker adapter exists in cold-path mode.
 """
 
 from __future__ import annotations

--- a/src/ante/bot/context_factory.py
+++ b/src/ante/bot/context_factory.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING
 from ante.account.models import TradingMode
 from ante.bot.config import BotConfig
 from ante.bot.providers.live import LivePortfolioView
-from ante.bot.providers.paper import PaperExecutor, PaperOrderView, PaperPortfolioView
+from ante.bot.providers.virtual import (
+    VirtualExecutor,
+    VirtualOrderView,
+    VirtualPortfolioView,
+)
 from ante.strategy.context import StrategyContext
 
 if TYPE_CHECKING:
@@ -36,7 +40,7 @@ class StrategyContextFactory:
     인터페이스 (``StrategyContext.get_ohlcv``) 는 변경되지 않는다.
     ``api_gateway`` / ``parquet_store`` 가 모두 주입되어 있을 때만 봇별
     인스턴스를 만들고, 미주입이면 fallback ``data_provider`` 를 사용한다
-    (paper-only 환경 호환).
+    (virtual-only 환경 호환).
     """
 
     def __init__(
@@ -45,7 +49,7 @@ class StrategyContextFactory:
         account_service: AccountService | None = None,
         live_portfolio: LivePortfolioView | None = None,
         live_order_view: LiveOrderView | None = None,
-        paper_executor: PaperExecutor | None = None,
+        virtual_executor: VirtualExecutor | None = None,
         live_trade_history: LiveTradeHistoryView | None = None,
         treasury_manager: TreasuryManager | None = None,
         position_history: PositionHistory | None = None,
@@ -56,7 +60,7 @@ class StrategyContextFactory:
         self._account_service = account_service
         self._live_portfolio = live_portfolio
         self._live_order_view = live_order_view
-        self._paper_executor = paper_executor
+        self._virtual_executor = virtual_executor
         self._live_trade_history = live_trade_history
         self._treasury_manager = treasury_manager
         self._position_history = position_history
@@ -67,11 +71,11 @@ class StrategyContextFactory:
         """BotConfig 기반으로 적절한 StrategyContext 생성.
 
         AccountService가 주입된 경우 Account.trading_mode로 분기하고,
-        없으면 기본값(paper)으로 동작한다.
+        없으면 기본값(VIRTUAL)으로 동작한다.
         """
         trading_mode = self._resolve_trading_mode(config)
         if trading_mode == TradingMode.VIRTUAL:
-            return self._create_paper_context(config)
+            return self._create_virtual_context(config)
         return self._create_live_context(config)
 
     def _resolve_trading_mode(self, config: BotConfig) -> TradingMode:
@@ -143,23 +147,23 @@ class StrategyContextFactory:
         logger.info("Live StrategyContext 생성: %s", config.bot_id)
         return ctx
 
-    def _create_paper_context(self, config: BotConfig) -> StrategyContext:
-        """Paper 봇용 StrategyContext 생성.
+    def _create_virtual_context(self, config: BotConfig) -> StrategyContext:
+        """Virtual 계좌 봇용 StrategyContext 생성.
 
-        SPLIT-3 (#1242): paper 봇이라도 OHLCV / price 조회는 봇의 account_id
+        SPLIT-3 (#1242): virtual 계좌 봇이라도 OHLCV / price 조회는 봇의 account_id
         로 APIGateway 를 호출해야 한다 (broker routing). live 와 동일하게
         ``api_gateway`` 가 있으면 봇별 LiveDataProvider 를 생성한다.
         """
-        initial_balance = self._resolve_paper_balance(config)
-        paper_portfolio = PaperPortfolioView(
+        initial_balance = self._resolve_virtual_balance(config)
+        virtual_portfolio = VirtualPortfolioView(
             bot_id=config.bot_id,
             initial_balance=initial_balance,
         )
-        paper_order_view = PaperOrderView(portfolio=paper_portfolio)
+        virtual_order_view = VirtualOrderView(portfolio=virtual_portfolio)
 
-        # PaperExecutor에 봇 등록
-        if self._paper_executor:
-            self._paper_executor.register_bot(config.bot_id, paper_portfolio)
+        # VirtualExecutor에 봇 등록
+        if self._virtual_executor:
+            self._virtual_executor.register_bot(config.bot_id, virtual_portfolio)
 
         data_provider = self._data_provider
         if self._api_gateway is not None:
@@ -174,18 +178,18 @@ class StrategyContextFactory:
         ctx = StrategyContext(
             bot_id=config.bot_id,
             data_provider=data_provider,
-            portfolio=paper_portfolio,
-            order_view=paper_order_view,
+            portfolio=virtual_portfolio,
+            order_view=virtual_order_view,
         )
         logger.info(
-            "Paper StrategyContext 생성: %s (잔고: %s)",
+            "Virtual StrategyContext 생성: %s (잔고: %s)",
             config.bot_id,
             initial_balance,
         )
         return ctx
 
-    def _resolve_paper_balance(self, config: BotConfig) -> float:
-        """Paper 봇의 초기 잔고를 Account 레벨(Treasury)에서 조회.
+    def _resolve_virtual_balance(self, config: BotConfig) -> float:
+        """Virtual 계좌 봇의 초기 잔고를 Account 레벨(Treasury)에서 조회.
 
         Treasury에 해당 봇의 예산이 배정되어 있으면 allocated 값을 사용하고,
         Treasury가 없으면 0.0을 반환한다.
@@ -198,7 +202,7 @@ class StrategyContextFactory:
                     return budget.allocated
             except KeyError:
                 logger.warning(
-                    "Paper 봇 '%s': 계좌 '%s'의 Treasury 미발견 -- 잔고 0",
+                    "Virtual 계좌 봇 '%s': 계좌 '%s'의 Treasury 미발견 -- 잔고 0",
                     config.bot_id,
                     config.account_id,
                 )

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -468,9 +468,9 @@ class BotManager:
 
         self._unregister_bot_events(bot)
 
-        # PaperExecutor 등록 해제 (봇이 등록되어 있는 경우)
-        if self._context_factory and self._context_factory._paper_executor:
-            self._context_factory._paper_executor.unregister_bot(bot_id)
+        # VirtualExecutor 등록 해제 (봇이 등록되어 있는 경우)
+        if self._context_factory and self._context_factory._virtual_executor:
+            self._context_factory._virtual_executor.unregister_bot(bot_id)
 
         # 시그널 키 폐기
         if self._signal_key_manager:

--- a/src/ante/bot/providers/__init__.py
+++ b/src/ante/bot/providers/__init__.py
@@ -1,12 +1,16 @@
-"""Bot Provider 구현체 — live/paper 봇용 DataProvider, PortfolioView, OrderView."""
+"""Bot Provider 구현체 — live/virtual 봇용 DataProvider, PortfolioView, OrderView."""
 
 from ante.bot.providers.live import LiveOrderView, LivePortfolioView
-from ante.bot.providers.paper import PaperExecutor, PaperOrderView, PaperPortfolioView
+from ante.bot.providers.virtual import (
+    VirtualExecutor,
+    VirtualOrderView,
+    VirtualPortfolioView,
+)
 
 __all__ = [
     "LiveOrderView",
     "LivePortfolioView",
-    "PaperExecutor",
-    "PaperOrderView",
-    "PaperPortfolioView",
+    "VirtualExecutor",
+    "VirtualOrderView",
+    "VirtualPortfolioView",
 ]

--- a/src/ante/bot/providers/virtual.py
+++ b/src/ante/bot/providers/virtual.py
@@ -1,4 +1,4 @@
-"""Paper 봇용 Provider 구현체 + PaperExecutor.
+"""Virtual 계좌 봇용 Provider 구현체 + VirtualExecutor.
 
 인메모리 가상 자금/포지션으로 실제 계좌 영향 없이 전략을 검증한다.
 """
@@ -19,8 +19,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class PaperPortfolioView(PortfolioView):
-    """Paper 봇용 PortfolioView. 인메모리 가상 잔고/포지션 관리."""
+class VirtualPortfolioView(PortfolioView):
+    """Virtual 계좌 봇용 PortfolioView. 인메모리 가상 잔고/포지션 관리."""
 
     def __init__(self, bot_id: str, initial_balance: float) -> None:
         self._bot_id = bot_id
@@ -103,10 +103,10 @@ class PaperPortfolioView(PortfolioView):
             self._reserved -= order["amount"]
 
 
-class PaperOrderView(OrderView):
-    """Paper 봇용 OrderView. PaperPortfolioView의 미체결 주문 추적."""
+class VirtualOrderView(OrderView):
+    """Virtual 계좌 봇용 OrderView. VirtualPortfolioView의 미체결 주문 추적."""
 
-    def __init__(self, portfolio: PaperPortfolioView) -> None:
+    def __init__(self, portfolio: VirtualPortfolioView) -> None:
         self._portfolio = portfolio
 
     def get_open_orders(self, bot_id: str) -> list[dict[str, Any]]:
@@ -117,10 +117,10 @@ class PaperOrderView(OrderView):
         ]
 
 
-class PaperExecutor:
-    """Paper 봇의 주문을 가상 체결하는 실행기.
+class VirtualExecutor:
+    """Virtual 계좌 봇의 주문을 가상 체결하는 실행기.
 
-    EventBus에서 OrderApprovedEvent를 구독하여 paper 봇의 주문만 처리한다.
+    EventBus에서 OrderApprovedEvent를 구독하여 virtual 계좌 봇의 주문만 처리한다.
     RuleEngine → Treasury 파이프라인을 거친 승인된 주문만 체결한다.
     """
 
@@ -139,18 +139,18 @@ class PaperExecutor:
             sell_commission_rate=commission_rate + sell_tax_rate,
         )
         self._slippage_rate = slippage_rate
-        self._portfolios: dict[str, PaperPortfolioView] = {}
+        self._portfolios: dict[str, VirtualPortfolioView] = {}
         self._bot_configs: dict[str, Any] = {}
 
-    def register_bot(self, bot_id: str, portfolio: PaperPortfolioView) -> None:
-        """Paper 봇의 PortfolioView 등록."""
+    def register_bot(self, bot_id: str, portfolio: VirtualPortfolioView) -> None:
+        """Virtual 계좌 봇의 PortfolioView 등록."""
         self._portfolios[bot_id] = portfolio
-        logger.info("PaperExecutor: 봇 등록 %s", bot_id)
+        logger.info("VirtualExecutor: 봇 등록 %s", bot_id)
 
     def unregister_bot(self, bot_id: str) -> None:
-        """Paper 봇 등록 해제."""
+        """Virtual 계좌 봇 등록 해제."""
         self._portfolios.pop(bot_id, None)
-        logger.info("PaperExecutor: 봇 해제 %s", bot_id)
+        logger.info("VirtualExecutor: 봇 해제 %s", bot_id)
 
     def subscribe(self) -> None:
         """EventBus에 OrderApprovedEvent 구독."""
@@ -159,10 +159,10 @@ class PaperExecutor:
         self._eventbus.subscribe(
             OrderApprovedEvent, self._on_order_approved, priority=50
         )
-        logger.info("PaperExecutor 구독 완료")
+        logger.info("VirtualExecutor 구독 완료")
 
     async def _on_order_approved(self, event: object) -> None:
-        """OrderApprovedEvent 처리. paper 봇의 주문만 처리."""
+        """OrderApprovedEvent 처리. virtual 계좌 봇의 주문만 처리."""
         from ante.eventbus.events import (
             OrderApprovedEvent,
             OrderFilledEvent,
@@ -219,7 +219,7 @@ class PaperExecutor:
         await self._eventbus.publish(
             OrderFilledEvent(
                 order_id=order_id,
-                broker_order_id=f"paper-{order_id[:8]}",
+                broker_order_id=f"virtual-{order_id[:8]}",
                 bot_id=event.bot_id,
                 strategy_id=event.strategy_id,
                 account_id=account_id,
@@ -233,7 +233,7 @@ class PaperExecutor:
             )
         )
         logger.info(
-            "Paper 체결: %s %s %s qty=%s price=%s commission=%s",
+            "Virtual 체결: %s %s %s qty=%s price=%s commission=%s",
             event.bot_id,
             side,
             symbol,

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -153,7 +153,7 @@ class Services:
     performance_tracker: Any = None
     trade_service: Any = None
     bot_manager: Any = None
-    paper_executor: Any = None
+    virtual_executor: Any = None
     live_portfolio: Any = None
     live_order_view: Any = None
     strategy_snapshot: Any = None
@@ -403,14 +403,14 @@ async def _init_trading(s: Services) -> None:
 
     # BotManager
     from ante.bot import BotManager  # noqa: F401
-    from ante.bot.providers.paper import PaperExecutor
+    from ante.bot.providers.virtual import VirtualExecutor
     from ante.strategy.snapshot import StrategySnapshot
 
-    s.paper_executor = PaperExecutor(
+    s.virtual_executor = VirtualExecutor(
         eventbus=s.eventbus,
         gateway=None,  # APIGateway 연결 후 설정
     )
-    s.paper_executor.subscribe()
+    s.virtual_executor.subscribe()
 
     from ante.bot.providers.live import LiveOrderView
 
@@ -773,14 +773,14 @@ def _init_context_factory(s: Services) -> None:
 
     SPLIT-3 (#1242): ``LiveDataProvider`` 는 봇별로 ``StrategyContextFactory``
     가 생성한다 (per-bot account binding). ``s.data_provider`` 는 API gateway
-    가 없는 (paper-only test 등) 환경의 fallback 으로 ``_NullDataProvider`` 를
+    가 없는 (virtual-only test 등) 환경의 fallback 으로 ``_NullDataProvider`` 를
     설정한다 — 이 경우 strategy 의 OHLCV 호출은 빈 결과를 반환한다.
     """
     from ante.bot import StrategyContextFactory
     from ante.bot.providers.live import LiveTradeHistoryView
 
     if s.api_gateway:
-        s.paper_executor._gateway = s.api_gateway
+        s.virtual_executor._gateway = s.api_gateway
 
     live_trade_history = LiveTradeHistoryView(trade_recorder=s.trade_recorder)
 
@@ -792,7 +792,7 @@ def _init_context_factory(s: Services) -> None:
         account_service=s.account_service,
         live_portfolio=s.live_portfolio,
         live_order_view=s.live_order_view,
-        paper_executor=s.paper_executor,
+        virtual_executor=s.virtual_executor,
         live_trade_history=live_trade_history,
         treasury_manager=s.treasury_manager,
         position_history=s.position_history,

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -943,7 +943,7 @@ class TestBotManager:
             {
                 "bot_id": "old-bot",
                 "strategy_id": "s1",
-                "bot_type": "paper",
+                "bot_type": "legacy",
                 "exchange": "KRX",
                 "interval_seconds": 60,
             }

--- a/tests/unit/test_bot_providers.py
+++ b/tests/unit/test_bot_providers.py
@@ -7,7 +7,11 @@ import pytest
 from ante.bot.config import BotConfig
 from ante.bot.context_factory import StrategyContextFactory
 from ante.bot.providers.live import LiveOrderView, LivePortfolioView
-from ante.bot.providers.paper import PaperExecutor, PaperOrderView, PaperPortfolioView
+from ante.bot.providers.virtual import (
+    VirtualExecutor,
+    VirtualOrderView,
+    VirtualPortfolioView,
+)
 from ante.core import Database
 from ante.eventbus import EventBus
 from ante.eventbus.events import (
@@ -130,97 +134,99 @@ class TestLiveOrderView:
         assert view.get_open_orders("bot1") == []
 
 
-# ── US-2: PaperPortfolioView / PaperOrderView ───
+# ── US-2: VirtualPortfolioView / VirtualOrderView ───
 
 
-class TestPaperPortfolioView:
+class TestVirtualPortfolioView:
     def test_initial_balance(self):
         """초기 잔고 확인."""
-        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
-        balance = pv.get_balance("paper1")
+        pv = VirtualPortfolioView(bot_id="virtual1", initial_balance=10_000_000.0)
+        balance = pv.get_balance("virtual1")
         assert balance["allocated"] == 10_000_000.0
         assert balance["available"] == 10_000_000.0
         assert balance["reserved"] == 0.0
 
     def test_empty_positions(self):
         """초기 포지션 없음."""
-        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
-        assert pv.get_positions("paper1") == {}
+        pv = VirtualPortfolioView(bot_id="virtual1", initial_balance=10_000_000.0)
+        assert pv.get_positions("virtual1") == {}
 
     def test_apply_fill_buy(self):
         """매수 체결 시 포지션/잔고 갱신."""
-        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        pv = VirtualPortfolioView(bot_id="virtual1", initial_balance=10_000_000.0)
         pv.apply_fill("005930", "buy", 10.0, 50000.0, commission=75.0)
 
-        positions = pv.get_positions("paper1")
+        positions = pv.get_positions("virtual1")
         assert positions["005930"]["quantity"] == 10.0
         assert positions["005930"]["avg_entry_price"] == 50000.0
 
-        balance = pv.get_balance("paper1")
+        balance = pv.get_balance("virtual1")
         assert balance["available"] == 10_000_000.0 - 500000.0 - 75.0
 
     def test_apply_fill_sell(self):
         """매도 체결 시 포지션/잔고 갱신."""
-        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        pv = VirtualPortfolioView(bot_id="virtual1", initial_balance=10_000_000.0)
         pv.apply_fill("005930", "buy", 10.0, 50000.0, commission=75.0)
         pv.apply_fill("005930", "sell", 10.0, 55000.0, commission=82.5)
 
-        positions = pv.get_positions("paper1")
+        positions = pv.get_positions("virtual1")
         # 수량 0이면 포지션에서 제외
         assert "005930" not in positions
 
     def test_check_balance_sufficient(self):
         """잔고 충분 확인."""
-        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        pv = VirtualPortfolioView(bot_id="virtual1", initial_balance=10_000_000.0)
         assert pv.check_balance(5_000_000.0) is True
 
     def test_check_balance_insufficient(self):
         """잔고 부족 확인."""
-        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        pv = VirtualPortfolioView(bot_id="virtual1", initial_balance=10_000_000.0)
         assert pv.check_balance(15_000_000.0) is False
 
     def test_reserve_and_release(self):
         """자금 예약/해제."""
-        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        pv = VirtualPortfolioView(bot_id="virtual1", initial_balance=10_000_000.0)
         pv.reserve("ord1", 500_000.0)
 
-        balance = pv.get_balance("paper1")
+        balance = pv.get_balance("virtual1")
         assert balance["reserved"] == 500_000.0
         assert balance["available"] == 9_500_000.0
 
         pv.release_reservation("ord1")
-        balance = pv.get_balance("paper1")
+        balance = pv.get_balance("virtual1")
         assert balance["reserved"] == 0.0
 
 
-class TestPaperOrderView:
+class TestVirtualOrderView:
     def test_empty_orders(self):
         """미체결 주문 없으면 빈 목록."""
-        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
-        ov = PaperOrderView(portfolio=pv)
-        assert ov.get_open_orders("paper1") == []
+        pv = VirtualPortfolioView(bot_id="virtual1", initial_balance=10_000_000.0)
+        ov = VirtualOrderView(portfolio=pv)
+        assert ov.get_open_orders("virtual1") == []
 
     def test_pending_orders_tracked(self):
         """예약된 주문이 미체결 목록에 나타남."""
-        pv = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        pv = VirtualPortfolioView(bot_id="virtual1", initial_balance=10_000_000.0)
         pv.reserve("ord1", 500_000.0)
 
-        ov = PaperOrderView(portfolio=pv)
-        orders = ov.get_open_orders("paper1")
+        ov = VirtualOrderView(portfolio=pv)
+        orders = ov.get_open_orders("virtual1")
         assert len(orders) == 1
         assert orders[0]["order_id"] == "ord1"
 
 
-# ── US-3: PaperExecutor ─────────────────────────
+# ── US-3: VirtualExecutor ─────────────────────────
 
 
-class TestPaperExecutor:
-    async def test_paper_fill_buy(self, eventbus):
-        """Paper 봇의 매수 주문 → 가상 체결."""
-        executor = PaperExecutor(eventbus=eventbus, commission_rate=0.00015)
+class TestVirtualExecutor:
+    async def test_virtual_fill_buy(self, eventbus):
+        """Virtual 계좌 봇의 매수 주문 → 가상 체결."""
+        executor = VirtualExecutor(eventbus=eventbus, commission_rate=0.00015)
 
-        portfolio = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
-        executor.register_bot("paper1", portfolio)
+        portfolio = VirtualPortfolioView(
+            bot_id="virtual1", initial_balance=10_000_000.0
+        )
+        executor.register_bot("virtual1", portfolio)
         executor.subscribe()
 
         filled = []
@@ -230,7 +236,7 @@ class TestPaperExecutor:
             OrderApprovedEvent(
                 order_id="ord-001",
                 account_id="acct1",
-                bot_id="paper1",
+                bot_id="virtual1",
                 strategy_id="s1",
                 symbol="005930",
                 side="buy",
@@ -241,7 +247,7 @@ class TestPaperExecutor:
         )
 
         assert len(filled) == 1
-        assert filled[0].bot_id == "paper1"
+        assert filled[0].bot_id == "virtual1"
         assert filled[0].symbol == "005930"
         assert filled[0].quantity == 10.0
         assert filled[0].price == 50000.0
@@ -250,14 +256,16 @@ class TestPaperExecutor:
         assert filled[0].account_id == "acct1"
 
         # 포지션 반영 확인
-        positions = portfolio.get_positions("paper1")
+        positions = portfolio.get_positions("virtual1")
         assert positions["005930"]["quantity"] == 10.0
 
-    async def test_paper_fill_sell(self, eventbus):
-        """Paper 봇의 매도 주문 → 가상 체결."""
-        executor = PaperExecutor(eventbus=eventbus, commission_rate=0.00015)
-        portfolio = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
-        executor.register_bot("paper1", portfolio)
+    async def test_virtual_fill_sell(self, eventbus):
+        """Virtual 계좌 봇의 매도 주문 → 가상 체결."""
+        executor = VirtualExecutor(eventbus=eventbus, commission_rate=0.00015)
+        portfolio = VirtualPortfolioView(
+            bot_id="virtual1", initial_balance=10_000_000.0
+        )
+        executor.register_bot("virtual1", portfolio)
         executor.subscribe()
 
         # 먼저 매수
@@ -265,7 +273,7 @@ class TestPaperExecutor:
             OrderApprovedEvent(
                 order_id="ord-001",
                 account_id="acct1",
-                bot_id="paper1",
+                bot_id="virtual1",
                 strategy_id="s1",
                 symbol="005930",
                 side="buy",
@@ -283,7 +291,7 @@ class TestPaperExecutor:
             OrderApprovedEvent(
                 order_id="ord-002",
                 account_id="acct1",
-                bot_id="paper1",
+                bot_id="virtual1",
                 strategy_id="s1",
                 symbol="005930",
                 side="sell",
@@ -300,7 +308,7 @@ class TestPaperExecutor:
 
     async def test_ignores_live_bot(self, eventbus):
         """live 봇의 주문은 무시."""
-        executor = PaperExecutor(eventbus=eventbus)
+        executor = VirtualExecutor(eventbus=eventbus)
         executor.subscribe()
 
         filled = []
@@ -324,12 +332,14 @@ class TestPaperExecutor:
 
     async def test_commission_calculation(self, eventbus):
         """수수료 계산 검증."""
-        executor = PaperExecutor(
+        executor = VirtualExecutor(
             eventbus=eventbus,
             commission_rate=0.001,  # 0.1%
         )
-        portfolio = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
-        executor.register_bot("paper1", portfolio)
+        portfolio = VirtualPortfolioView(
+            bot_id="virtual1", initial_balance=10_000_000.0
+        )
+        executor.register_bot("virtual1", portfolio)
         executor.subscribe()
 
         filled = []
@@ -339,7 +349,7 @@ class TestPaperExecutor:
             OrderApprovedEvent(
                 order_id="ord-001",
                 account_id="acct1",
-                bot_id="paper1",
+                bot_id="virtual1",
                 strategy_id="s1",
                 symbol="005930",
                 side="buy",
@@ -353,9 +363,11 @@ class TestPaperExecutor:
 
     async def test_slippage_buy(self, eventbus):
         """매수 슬리피지: 체결가 = 현재가 × (1 + slippage_rate)."""
-        executor = PaperExecutor(eventbus=eventbus, slippage_rate=0.001)
-        portfolio = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
-        executor.register_bot("paper1", portfolio)
+        executor = VirtualExecutor(eventbus=eventbus, slippage_rate=0.001)
+        portfolio = VirtualPortfolioView(
+            bot_id="virtual1", initial_balance=10_000_000.0
+        )
+        executor.register_bot("virtual1", portfolio)
         executor.subscribe()
 
         filled = []
@@ -365,7 +377,7 @@ class TestPaperExecutor:
             OrderApprovedEvent(
                 order_id="ord-001",
                 account_id="acct1",
-                bot_id="paper1",
+                bot_id="virtual1",
                 strategy_id="s1",
                 symbol="005930",
                 side="buy",
@@ -380,11 +392,13 @@ class TestPaperExecutor:
 
     async def test_slippage_sell(self, eventbus):
         """매도 슬리피지: 체결가 = 현재가 × (1 - slippage_rate)."""
-        executor = PaperExecutor(eventbus=eventbus, slippage_rate=0.001)
-        portfolio = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
+        executor = VirtualExecutor(eventbus=eventbus, slippage_rate=0.001)
+        portfolio = VirtualPortfolioView(
+            bot_id="virtual1", initial_balance=10_000_000.0
+        )
         # 먼저 포지션 만들기
         portfolio.apply_fill("005930", "buy", 10.0, 50000.0, 0.0)
-        executor.register_bot("paper1", portfolio)
+        executor.register_bot("virtual1", portfolio)
         executor.subscribe()
 
         filled = []
@@ -394,7 +408,7 @@ class TestPaperExecutor:
             OrderApprovedEvent(
                 order_id="ord-001",
                 account_id="acct1",
-                bot_id="paper1",
+                bot_id="virtual1",
                 strategy_id="s1",
                 symbol="005930",
                 side="sell",
@@ -409,12 +423,14 @@ class TestPaperExecutor:
 
     async def test_limit_order_no_slippage(self, eventbus):
         """지정가 주문: 슬리피지 없이 지정가 그대로 체결."""
-        executor = PaperExecutor(
+        executor = VirtualExecutor(
             eventbus=eventbus,
             slippage_rate=0.01,  # 1% 슬리피지 설정해도
         )
-        portfolio = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
-        executor.register_bot("paper1", portfolio)
+        portfolio = VirtualPortfolioView(
+            bot_id="virtual1", initial_balance=10_000_000.0
+        )
+        executor.register_bot("virtual1", portfolio)
         executor.subscribe()
 
         filled = []
@@ -424,7 +440,7 @@ class TestPaperExecutor:
             OrderApprovedEvent(
                 order_id="ord-001",
                 account_id="acct1",
-                bot_id="paper1",
+                bot_id="virtual1",
                 strategy_id="s1",
                 symbol="005930",
                 side="buy",
@@ -438,12 +454,14 @@ class TestPaperExecutor:
 
     async def test_unregister_bot(self, eventbus):
         """봇 등록 해제 후 주문 무시."""
-        executor = PaperExecutor(eventbus=eventbus)
-        portfolio = PaperPortfolioView(bot_id="paper1", initial_balance=10_000_000.0)
-        executor.register_bot("paper1", portfolio)
+        executor = VirtualExecutor(eventbus=eventbus)
+        portfolio = VirtualPortfolioView(
+            bot_id="virtual1", initial_balance=10_000_000.0
+        )
+        executor.register_bot("virtual1", portfolio)
         executor.subscribe()
 
-        executor.unregister_bot("paper1")
+        executor.unregister_bot("virtual1")
 
         filled = []
         eventbus.subscribe(OrderFilledEvent, lambda e: filled.append(e))
@@ -452,7 +470,7 @@ class TestPaperExecutor:
             OrderApprovedEvent(
                 order_id="ord-001",
                 account_id="acct1",
-                bot_id="paper1",
+                bot_id="virtual1",
                 strategy_id="s1",
                 symbol="005930",
                 side="buy",
@@ -469,23 +487,23 @@ class TestPaperExecutor:
 
 
 class TestStrategyContextFactory:
-    def test_create_paper_context(self, eventbus):
-        """Paper 봇 StrategyContext 생성."""
-        executor = PaperExecutor(eventbus=eventbus)
+    def test_create_virtual_context(self, eventbus):
+        """Virtual 계좌 봇 StrategyContext 생성."""
+        executor = VirtualExecutor(eventbus=eventbus)
         factory = StrategyContextFactory(
             data_provider=FakeDataProvider(),
-            paper_executor=executor,
+            virtual_executor=executor,
         )
 
-        config = BotConfig(bot_id="paper1", strategy_id="s1", account_id="acc-test")
-        # AccountService 미설정 → VIRTUAL 모드(paper) 기본 동작
+        config = BotConfig(bot_id="virtual1", strategy_id="s1", account_id="acc-test")
+        # AccountService 미설정 → VIRTUAL 기본 동작
         ctx = factory.create(config)
 
         assert isinstance(ctx, StrategyContext)
-        assert ctx.bot_id == "paper1"
+        assert ctx.bot_id == "virtual1"
 
-        # Paper 봇이 PaperExecutor에 등록되었는지 확인
-        assert "paper1" in executor._portfolios
+        # Virtual 계좌 봇이 VirtualExecutor에 등록되었는지 확인
+        assert "virtual1" in executor._portfolios
 
         # Treasury 미설정 시 초기 잔고 0
         balance = ctx.get_balance()
@@ -538,15 +556,15 @@ class TestStrategyContextFactory:
         assert isinstance(ctx, StrategyContext)
         assert ctx.bot_id == "live1"
 
-    def test_resolve_paper_balance_with_budget(self, eventbus):
+    def test_resolve_virtual_balance_with_budget(self, eventbus):
         """TreasuryManager 존재 + BotBudget 배정 시 allocated 값 반환."""
         from ante.treasury.models import BotBudget
 
         class FakeTreasury:
             def get_budget(self, bot_id):
-                if bot_id == "paper1":
+                if bot_id == "virtual1":
                     return BotBudget(
-                        bot_id="paper1", allocated=2_000_000.0, account_id="acc-test"
+                        bot_id="virtual1", allocated=2_000_000.0, account_id="acc-test"
                     )
                 return None
 
@@ -554,34 +572,34 @@ class TestStrategyContextFactory:
             def get(self, account_id):
                 return FakeTreasury()
 
-        executor = PaperExecutor(eventbus=eventbus)
+        executor = VirtualExecutor(eventbus=eventbus)
         factory = StrategyContextFactory(
             data_provider=FakeDataProvider(),
-            paper_executor=executor,
+            virtual_executor=executor,
             treasury_manager=FakeTreasuryManager(),
         )
 
-        config = BotConfig(bot_id="paper1", strategy_id="s1", account_id="acct1")
+        config = BotConfig(bot_id="virtual1", strategy_id="s1", account_id="acct1")
         ctx = factory.create(config)
 
         balance = ctx.get_balance()
         assert balance["allocated"] == 2_000_000.0
 
-    def test_resolve_paper_balance_key_error(self, eventbus):
+    def test_resolve_virtual_balance_key_error(self, eventbus):
         """TreasuryManager 존재하나 bot_id 미배정 시 0.0 반환."""
 
         class FakeTreasuryManager:
             def get(self, account_id):
                 raise KeyError(account_id)
 
-        executor = PaperExecutor(eventbus=eventbus)
+        executor = VirtualExecutor(eventbus=eventbus)
         factory = StrategyContextFactory(
             data_provider=FakeDataProvider(),
-            paper_executor=executor,
+            virtual_executor=executor,
             treasury_manager=FakeTreasuryManager(),
         )
 
-        config = BotConfig(bot_id="paper1", strategy_id="s1", account_id="no-acct")
+        config = BotConfig(bot_id="virtual1", strategy_id="s1", account_id="no-acct")
         ctx = factory.create(config)
 
         balance = ctx.get_balance()
@@ -633,19 +651,19 @@ class TestBotManagerWithFactory:
             async def on_step(self, context):
                 return []
 
-        executor = PaperExecutor(eventbus=eventbus)
+        executor = VirtualExecutor(eventbus=eventbus)
         factory = StrategyContextFactory(
             data_provider=FakeDataProvider(),
-            paper_executor=executor,
+            virtual_executor=executor,
         )
         manager = BotManager(eventbus=eventbus, db=db, context_factory=factory)
         await manager.initialize()
 
-        config = BotConfig(bot_id="paper1", strategy_id="s1", account_id="acc-test")
+        config = BotConfig(bot_id="virtual1", strategy_id="s1", account_id="acc-test")
         bot = await manager.create_bot(config, SimpleStrategy)
 
-        assert bot.bot_id == "paper1"
-        assert "paper1" in executor._portfolios
+        assert bot.bot_id == "virtual1"
+        assert "virtual1" in executor._portfolios
 
     async def test_create_bot_with_explicit_ctx(self, eventbus, db):
         """기존 방식: ctx 직접 주입."""
@@ -664,9 +682,9 @@ class TestBotManagerWithFactory:
         ctx = StrategyContext(
             bot_id="bot1",
             data_provider=FakeDataProvider(),
-            portfolio=PaperPortfolioView(bot_id="bot1", initial_balance=1_000_000.0),
-            order_view=PaperOrderView(
-                PaperPortfolioView(bot_id="bot1", initial_balance=1_000_000.0)
+            portfolio=VirtualPortfolioView(bot_id="bot1", initial_balance=1_000_000.0),
+            order_view=VirtualOrderView(
+                VirtualPortfolioView(bot_id="bot1", initial_balance=1_000_000.0)
             ),
         )
         config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
@@ -691,8 +709,8 @@ class TestBotManagerWithFactory:
         with pytest.raises(BotError, match="factory"):
             await manager.create_bot(config, SimpleStrategy)
 
-    async def test_remove_paper_bot_unregisters(self, eventbus, db):
-        """Paper 봇 삭제 시 PaperExecutor에서 등록 해제."""
+    async def test_remove_virtual_bot_unregisters(self, eventbus, db):
+        """Virtual 계좌 봇 삭제 시 VirtualExecutor에서 등록 해제."""
         from ante.bot import BotManager, StrategyContextFactory
         from ante.strategy.base import Strategy, StrategyMeta
 
@@ -702,20 +720,20 @@ class TestBotManagerWithFactory:
             async def on_step(self, context):
                 return []
 
-        executor = PaperExecutor(eventbus=eventbus)
+        executor = VirtualExecutor(eventbus=eventbus)
         factory = StrategyContextFactory(
             data_provider=FakeDataProvider(),
-            paper_executor=executor,
+            virtual_executor=executor,
         )
         manager = BotManager(eventbus=eventbus, db=db, context_factory=factory)
         await manager.initialize()
 
-        config = BotConfig(bot_id="paper1", strategy_id="s1", account_id="acc-test")
+        config = BotConfig(bot_id="virtual1", strategy_id="s1", account_id="acc-test")
         await manager.create_bot(config, SimpleStrategy)
-        assert "paper1" in executor._portfolios
+        assert "virtual1" in executor._portfolios
 
-        await manager.remove_bot("paper1")
-        assert "paper1" not in executor._portfolios
+        await manager.remove_bot("virtual1")
+        assert "virtual1" not in executor._portfolios
 
 
 # ── PositionHistory 캐시 테스트 ──────────────────

--- a/tests/unit/test_commission.py
+++ b/tests/unit/test_commission.py
@@ -95,23 +95,23 @@ class TestKISCommissionInfo:
         assert info.sell_commission_rate == 0.002
 
 
-# ── US-2: PaperExecutor 매도 세금 반영 ────────────
+# ── US-2: VirtualExecutor 매도 세금 반영 ────────────
 
 
-class TestPaperExecutorCommission:
+class TestVirtualExecutorCommission:
     async def test_buy_commission(self):
-        """PaperExecutor 매수 수수료 = buy_commission_rate만 적용."""
-        from ante.bot.providers.paper import PaperExecutor, PaperPortfolioView
+        """VirtualExecutor 매수 수수료 = buy_commission_rate만 적용."""
+        from ante.bot.providers.virtual import VirtualExecutor, VirtualPortfolioView
         from ante.eventbus.events import OrderApprovedEvent
 
         eventbus = EventBus()
-        executor = PaperExecutor(
+        executor = VirtualExecutor(
             eventbus=eventbus,
             commission_rate=0.00015,
             sell_tax_rate=0.0023,
         )
 
-        portfolio = PaperPortfolioView(bot_id="bot1", initial_balance=10_000_000.0)
+        portfolio = VirtualPortfolioView(bot_id="bot1", initial_balance=10_000_000.0)
         executor.register_bot("bot1", portfolio)
         executor.subscribe()
 
@@ -138,18 +138,18 @@ class TestPaperExecutorCommission:
         assert received[0].commission == pytest.approx(expected_commission)
 
     async def test_sell_commission_includes_tax(self):
-        """PaperExecutor 매도 수수료 = commission_rate + sell_tax_rate."""
-        from ante.bot.providers.paper import PaperExecutor, PaperPortfolioView
+        """VirtualExecutor 매도 수수료 = commission_rate + sell_tax_rate."""
+        from ante.bot.providers.virtual import VirtualExecutor, VirtualPortfolioView
         from ante.eventbus.events import OrderApprovedEvent
 
         eventbus = EventBus()
-        executor = PaperExecutor(
+        executor = VirtualExecutor(
             eventbus=eventbus,
             commission_rate=0.00015,
             sell_tax_rate=0.0023,
         )
 
-        portfolio = PaperPortfolioView(bot_id="bot1", initial_balance=10_000_000.0)
+        portfolio = VirtualPortfolioView(bot_id="bot1", initial_balance=10_000_000.0)
         # 먼저 보유 포지션 설정
         portfolio._positions["005930"] = {
             "quantity": 100.0,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -811,11 +811,11 @@ async def test_init_context_factory_wires_account_and_treasury(
     StrategyContextFactory에 모두 주입한다 (#1124 회귀 방지).
 
     이 wiring이 누락되면 _resolve_trading_mode가 VIRTUAL로 단락되어
-    trading_mode=live 계좌의 봇이 Paper context로 생성되는 버그가 재발한다.
+    trading_mode=live 계좌의 봇이 virtual context로 생성되는 버그가 재발한다.
     """
     from ante.account import AccountService
     from ante.bot import BotManager
-    from ante.bot.providers.paper import PaperExecutor
+    from ante.bot.providers.virtual import VirtualExecutor
     from ante.main import Services, _init_context_factory
     from ante.strategy.base import DataProvider
     from ante.trade.position import PositionHistory
@@ -860,7 +860,7 @@ async def test_init_context_factory_wires_account_and_treasury(
         position_history=position_history,
         bot_manager=bot_manager,
         data_provider=_FakeDataProvider(),
-        paper_executor=PaperExecutor(eventbus=eventbus),
+        virtual_executor=VirtualExecutor(eventbus=eventbus),
     )
 
     # trade_recorder는 LiveTradeHistoryView 생성에 필요


### PR DESCRIPTION
## Summary
- rename internal bot provider module from `paper.py` to `virtual.py`
- replace `PaperExecutor`/`PaperPortfolioView`/`PaperOrderView` with `VirtualExecutor`/`VirtualPortfolioView`/`VirtualOrderView` without compatibility aliases
- rename `paper_executor` wiring to `virtual_executor` and update docs/tests for the internal virtual provider contract
- keep KIS `broker_config.is_paper` terminology unchanged because it is broker configuration, not Bot provider mode

## Validation
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/test_bot_providers.py tests/unit/test_commission.py tests/unit/test_main.py tests/unit/test_bot.py -q`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/test_bot_cold_path.py tests/unit/test_bot_manager_methods.py tests/unit/test_main_startup_ordering.py tests/unit/test_main_shutdown_ordering.py -q`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit -q`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m ruff check src/ante/bot src/ante/main.py tests/unit/test_bot_providers.py tests/unit/test_commission.py tests/unit/test_main.py tests/unit/test_bot.py`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m ruff format --check src/ante/bot src/ante/main.py tests/unit/test_bot_providers.py tests/unit/test_commission.py tests/unit/test_main.py tests/unit/test_bot.py`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m mypy src/`
- `rg "PaperExecutor|PaperPortfolioView|PaperOrderView|providers\\.paper|paper_executor" src tests docs/specs/bot`

Closes #1234