### PR TITLE
refactor: align frontend bot trading mode

### DIFF
--- a/frontend/src/api/bots.ts
+++ b/frontend/src/api/bots.ts
@@ -6,10 +6,10 @@ import type {
   BotDetailView,
   BotLog,
   BotLogResult,
-  BotMode,
   BotPosition,
   BotStatus,
   BotStrategy,
+  BotTradingMode,
   BotUpdateInput,
   BotView,
   HandlePositions,
@@ -57,8 +57,8 @@ function toBotStatus(value: string): BotStatus {
   return BOT_STATUSES.has(value as BotStatus) ? (value as BotStatus) : 'error'
 }
 
-function toBotMode(value: unknown): BotMode {
-  return value === 'live' ? 'live' : 'paper'
+function toTradingMode(value: unknown): BotTradingMode {
+  return typeof value === 'string' && value.toLowerCase() === 'live' ? 'live' : 'virtual'
 }
 
 function toStringArray(value: unknown): string[] {
@@ -142,7 +142,7 @@ function toBotView(raw: BotInfo): BotView {
     name: raw.name,
     strategy_name: raw.strategy_name ?? raw.strategy_id,
     status: toBotStatus(raw.status),
-    mode: toBotMode(extra.mode ?? extra.bot_type),
+    trading_mode: toTradingMode(extra.trading_mode),
     interval_seconds: raw.interval_seconds,
     created_at: stringValue(extra.created_at),
   }

--- a/frontend/src/api/treasury.ts
+++ b/frontend/src/api/treasury.ts
@@ -55,7 +55,7 @@ function toTreasurySummaryView(raw: TreasurySummaryResponse): TreasurySummaryVie
     account_balance: numberValue(e.account_balance, raw.total_balance),
     purchasable_amount: numberValue(e.purchasable_amount),
     account_number: optionalString(e.account_number) ?? raw.account_no ?? undefined,
-    is_demo_trading: optionalBoolean(e.is_demo_trading) ?? raw.is_virtual ?? undefined,
+    is_demo_trading: optionalBoolean(e.is_demo_trading),
     last_sync_time: optionalString(e.last_sync_time) ?? raw.synced_at ?? undefined,
     total_reserved: numberValue(e.total_reserved),
     total_available: numberValue(e.total_available, raw.unallocated),

--- a/frontend/src/components/bots/BotTable.tsx
+++ b/frontend/src/components/bots/BotTable.tsx
@@ -44,8 +44,8 @@ export default function BotTable({ items, onStart, onStop, onDelete }: BotTableP
                   <StatusBadge variant={STATUS_VARIANT[bot.status] as 'positive'}>{BOT_STATUS_LABELS[bot.status] || bot.status}</StatusBadge>
                 </td>
                 <td className="px-3 py-3 border-b border-border text-[13px]">
-                  <StatusBadge variant={bot.mode === 'live' ? 'warning' : 'info'}>
-                    {bot.mode === 'live' ? '실전' : '모의'}
+                  <StatusBadge variant={bot.trading_mode === 'live' ? 'warning' : 'info'}>
+                    {bot.trading_mode === 'live' ? '실거래' : '가상거래'}
                   </StatusBadge>
                 </td>
                 <td className="px-3 py-3 border-b border-border text-[13px] text-right">

--- a/frontend/src/components/treasury/AccountSummary.tsx
+++ b/frontend/src/components/treasury/AccountSummary.tsx
@@ -26,9 +26,11 @@ export default function AccountSummary({ summary }: { summary: TreasurySummary }
         {summary.account_number && (
           <span className="text-[13px] font-mono">{summary.account_number}</span>
         )}
-        <span className={`text-[11px] font-bold px-2 py-0.5 rounded ${summary.is_demo_trading ? 'bg-warning-bg text-warning' : 'bg-positive-bg text-positive'}`}>
-          {summary.is_demo_trading ? '모의투자' : '실전투자'}
-        </span>
+        {summary.is_demo_trading !== undefined && (
+          <span className={`text-[11px] font-bold px-2 py-0.5 rounded ${summary.is_demo_trading ? 'bg-warning-bg text-warning' : 'bg-positive-bg text-positive'}`}>
+            {summary.is_demo_trading ? 'KIS 모의투자' : 'KIS 실전투자'}
+          </span>
+        )}
         <div className="ml-auto flex items-center gap-4 text-[13px] text-text-muted">
           <span>수수료 {(summary.commission_rate * 100).toFixed(3)}%</span>
           <span>매도세 {(summary.sell_tax_rate * 100).toFixed(2)}%</span>

--- a/frontend/src/pages/Bots.tsx
+++ b/frontend/src/pages/Bots.tsx
@@ -23,7 +23,7 @@ export default function Bots() {
     .filter((b) => b.status !== 'deleted')
     .sort((a, b) => (STATUS_ORDER[a.status] ?? 99) - (STATUS_ORDER[b.status] ?? 99))
 
-  const isVirtual = allBots.length > 0 && allBots.every((b) => b.mode === 'paper')
+  const isVirtual = allBots.length > 0 && allBots.every((b) => b.trading_mode === 'virtual')
 
   return (
     <>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -56,6 +56,20 @@ const DISPLAY_CONFIGS: DisplayConfig[] = [
   { key: 'notification.min_level', label: '알림 최소 레벨', desc: 'notification.min_level · 이 레벨 미만은 발송하지 않음 (CRITICAL은 항상 발송)', type: 'select', options: ['critical', 'error', 'warning', 'info'], defaultOption: 'info' },
 ]
 
+function formatTradingMode(mode: string | undefined) {
+  const normalized = mode?.toLowerCase()
+  if (normalized === 'live') return '실거래'
+  if (normalized === 'virtual') return '가상거래'
+  return mode || '-'
+}
+
+function formatKisEndpoint(brokerConfig: Record<string, unknown> | undefined) {
+  const isPaper = brokerConfig?.is_paper
+  if (isPaper === true) return 'KIS 모의투자'
+  if (isPaper === false) return 'KIS 실전투자'
+  return '-'
+}
+
 export default function Settings() {
   const { data: status, isLoading: statusLoading } = useSystemStatus()
   // CLI/다른 세션의 system halt/clear-halt를 설정 화면 상태에 반영하기 위해 30초 폴링.
@@ -80,6 +94,7 @@ export default function Settings() {
   const suspendedCount = accounts?.filter((a) => a.status === 'suspended').length ?? 0
   const isActive = !accountsLoading && activeCount > 0 && suspendedCount === 0
   const configMap = new Map((configs ?? []).map((c) => [c.key, c.value]))
+  const primaryAccount = accounts?.[0]
 
   const getConfigValue = (key: string) => configMap.get(key) ?? ''
 
@@ -182,7 +197,13 @@ export default function Settings() {
             <div className="flex justify-between py-2 border-b border-border text-[13px]">
               <span className="text-text-muted">거래 모드</span>
               <span className="inline-flex items-center px-2 py-0.5 rounded-[10px] text-[11px] font-semibold bg-primary/15 text-primary">
-                {getConfigValue('broker.mode') || '실전'}
+                {formatTradingMode(primaryAccount?.trading_mode)}
+              </span>
+            </div>
+            <div className="flex justify-between py-2 border-b border-border text-[13px]">
+              <span className="text-text-muted">KIS 엔드포인트</span>
+              <span className="inline-flex items-center px-2 py-0.5 rounded-[10px] text-[11px] font-semibold bg-warning-bg text-warning">
+                {formatKisEndpoint(primaryAccount?.broker_config)}
               </span>
             </div>
             <div className="flex justify-between py-2 border-b border-border text-[13px]">

--- a/frontend/src/types/bot.ts
+++ b/frontend/src/types/bot.ts
@@ -7,14 +7,14 @@
 
 // ── 프론트엔드 전용 타입 ──────────────────────────────────
 export type BotStatus = 'created' | 'running' | 'stopping' | 'stopped' | 'error' | 'deleted'
-export type BotMode = 'live' | 'paper'
+export type BotTradingMode = 'virtual' | 'live'
 
 export interface BotView {
   bot_id: string
   name: string
   strategy_name?: string
   status: BotStatus
-  mode: BotMode
+  trading_mode: BotTradingMode
   interval_seconds?: number
   created_at: string
 }

--- a/frontend/src/types/system.ts
+++ b/frontend/src/types/system.ts
@@ -16,7 +16,7 @@ export interface SystemStatusView {
 
 export interface BrokerStatus {
   connected: boolean
-  mode: 'live' | 'paper'
+  endpoint?: 'demo' | 'live'
   token_expires_at?: string
 }
 

--- a/frontend/src/types/treasury.ts
+++ b/frontend/src/types/treasury.ts
@@ -25,6 +25,7 @@ export interface TreasurySummaryView {
   account_balance?: number
   purchasable_amount?: number
   account_number?: string
+  /** KIS 모의/실전투자 엔드포인트 메타데이터. Account.trading_mode와 별개다. */
   is_demo_trading?: boolean
   last_sync_time?: string | null
   total_reserved?: number


### PR DESCRIPTION
## Summary
- remove frontend `BotMode` and `Bot.mode` in favor of `trading_mode: "virtual" | "live"`
- remove `raw.mode ?? raw.bot_type` fallback from the bot adapter
- update Bots banner and BotTable labels to use `trading_mode`
- separate KIS endpoint metadata from trading mode in Settings/Treasury views
- keep `broker_config.is_paper` unchanged as broker configuration

## Validation
- `cd frontend && npm run build`
- `cd frontend && npm run check-api-types`
- `cd frontend && npx eslint src/types/bot.ts src/api/bots.ts src/pages/Bots.tsx src/components/bots/BotTable.tsx src/types/system.ts src/pages/Settings.tsx src/types/treasury.ts src/api/treasury.ts src/components/treasury/AccountSummary.tsx`
- `rg "BotMode|raw.mode|raw.bot_type|mode.*paper|b\\.mode|bot\\.mode" frontend/src`
- `rg "is_demo_trading.*is_virtual|is_virtual.*is_demo_trading" frontend/src`

Note: full `npm run lint` still fails on pre-existing unrelated files (`AgentEditModal`, `BotCreateForm`, `Pagination`, `Toast`, `BacktestData`).

Closes #1233