### PR TITLE
test: guard local import path

### DIFF
--- a/.agent/skills/generated-artifact-sync.md
+++ b/.agent/skills/generated-artifact-sync.md
@@ -24,8 +24,8 @@
 
 | 산출물 | 입력/SSOT | Generate | Check | 기대 동작 |
 |---|---|---|---|---|
-| `docs/architecture/generated/project-structure.md` | 현재 Git 추적/비무시 파일 트리 | `.venv/bin/python scripts/generate_project_structure.py` | `.venv/bin/python scripts/generate_project_structure.py --check` | generate는 파일 구조 문서를 재생성한다. check는 산출물이 최신이면 0으로 종료하고, 불일치하면 실패하며 재생성 명령을 안내한다. |
-| `docs/architecture/generated/db-schema.md` | 모듈 소스 코드의 DDL 상수 | `.venv/bin/python scripts/generate_db_schema.py` | `.venv/bin/python scripts/generate_db_schema.py --check` | generate는 DB schema 문서를 재생성한다. check는 산출물이 최신이면 0으로 종료하고, 불일치하면 실패하며 재생성 명령을 안내한다. |
+| `docs/architecture/generated/project-structure.md` | 현재 Git 추적/비무시 파일 트리 | `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py` | `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check` | generate는 파일 구조 문서를 재생성한다. check는 산출물이 최신이면 0으로 종료하고, 불일치하면 실패하며 재생성 명령을 안내한다. |
+| `docs/architecture/generated/db-schema.md` | 모듈 소스 코드의 DDL 상수 | `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_db_schema.py` | `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_db_schema.py --check` | generate는 DB schema 문서를 재생성한다. check는 산출물이 최신이면 0으로 종료하고, 불일치하면 실패하며 재생성 명령을 안내한다. |
 | `guide/cli.md` | Click CLI command tree | `.venv/bin/python scripts/generate_cli_reference.py` | `.venv/bin/python scripts/generate_cli_reference.py && git diff --exit-code -- guide/cli.md` | generate는 CLI 레퍼런스를 재생성한다. 전용 `--check`가 없으므로 생성 후 diff가 비어 있어야 최신이다. |
 | `frontend/openapi.json` | 실행 중인 백엔드 `/openapi.json` | `curl http://localhost:3982/openapi.json -o frontend/openapi.json` | `git diff --exit-code -- frontend/openapi.json` | 백엔드 API 계약 변경 시 OpenAPI JSON을 갱신한다. 전용 check가 없으므로 재수집 후 diff가 비어 있어야 최신이다. |
 | `frontend/src/types/api.generated.ts` | `frontend/openapi.json` 또는 백엔드 `/openapi.json` | `cd frontend && npm run generate-types` | `cd frontend && npm run generate-types && git diff --exit-code -- src/types/api.generated.ts` | OpenAPI에서 TypeScript wire contract를 재생성한다. 전용 check가 없으므로 생성 후 diff가 비어 있어야 최신이다. |

--- a/.agent/skills/review-pr.md
+++ b/.agent/skills/review-pr.md
@@ -110,8 +110,8 @@ gh pr diff #{PR번호}
 
 생성 산출물 신호가 있으면 B3 판정 전에 `.agent/skills/generated-artifact-sync.md`를 읽고 아래 검증 증거를 확인한다.
 
-- 프로젝트 구조 변경: `.venv/bin/python scripts/generate_project_structure.py`로 regenerate했는지, 리뷰/CI 전 `.venv/bin/python scripts/generate_project_structure.py --check`를 실행했는지 확인한다.
-- DB DDL/schema 변경: `.venv/bin/python scripts/generate_db_schema.py`로 regenerate했는지, 리뷰/CI 전 `.venv/bin/python scripts/generate_db_schema.py --check`를 실행했는지 확인한다.
+- 프로젝트 구조 변경: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py`로 regenerate했는지, 리뷰/CI 전 `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check`를 실행했는지 확인한다.
+- DB DDL/schema 변경: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_db_schema.py`로 regenerate했는지, 리뷰/CI 전 `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_db_schema.py --check`를 실행했는지 확인한다.
 - CLI reference, OpenAPI JSON, frontend generated types처럼 전용 check 명령이 없는 산출물은 대응 generate 명령 실행 후 `git diff --exit-code -- <산출물>` 결과가 검증 증거에 남았는지 확인한다.
 - 실행 증거가 없고 코드 독해로만 최신이라고 추론했다면 B3는 PASS가 아니라 FAIL 또는 follow-up으로 분리한다.
 

--- a/docs/architecture/generated/db-schema.md
+++ b/docs/architecture/generated/db-schema.md
@@ -2,8 +2,8 @@
 
 Ante 시스템의 전체 데이터베이스 스키마를 정리한 문서입니다. 각 테이블의 DDL, 인덱스, ER 다이어그램, 보존 정책을 확인할 수 있습니다.
 
-> 생성 명령: `.venv/bin/python scripts/generate_db_schema.py`
-> Check 명령: `.venv/bin/python scripts/generate_db_schema.py --check`
+> 생성 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_db_schema.py`
+> Check 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_db_schema.py --check`
 > 마지막 갱신: 2026-05-05
 
 - 테이블: **22**개

--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -1,8 +1,8 @@
 # Ante 프로젝트 디렉토리 구조
 
 > 역할: Agent용 프로젝트 구조 INDEX의 단일 SSOT입니다.
-> 생성 명령: `.venv/bin/python scripts/generate_project_structure.py`
-> Check 명령: `.venv/bin/python scripts/generate_project_structure.py --check`
+> 생성 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py`
+> Check 명령: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check`
 > 생성 기준: 현재 Git 추적/비무시 파일 트리 (`git ls-files --cached --others --exclude-standard`)
 > 마지막 생성 시점: 2026-05-05 (KST)
 
@@ -515,7 +515,8 @@ tests/
 │   ├── test_update_rollback.py
 │   ├── test_update_snapshot.py
 │   ├── test_update_startup_check.py
-│   └── test_web_account_filter.py
+│   ├── test_web_account_filter.py
+│   └── test_check_import_path.py
 └── __init__.py
 ```
 
@@ -550,7 +551,8 @@ scripts/
 ├── generate_db_schema.py             # DB 스키마 문서 자동 생성
 ├── generate_project_structure.py     # 프로젝트 구조 Agent INDEX 생성/check
 ├── run_ai_review.sh
-└── setup_actions_runners.sh
+├── setup_actions_runners.sh
+└── check_import_path.py              # 현재 worktree import sanity check
 ```
 
 ## docs/ — 설계 문서

--- a/docs/runbooks/01-development-process.md
+++ b/docs/runbooks/01-development-process.md
@@ -236,11 +236,12 @@ release PR은 릴리스 메타데이터와 Docker build 검증만 포함하며, 
 - 스크립트로 생성되는 문서는 수동 편집하지 않는다.
 - 구현 단계에서 생성 산출물 입력이 바뀌면 먼저 대응하는 regenerate 명령을 실행한다.
 - 리뷰/CI 전에는 전용 check 명령이 있는 산출물을 실제 check 명령으로 검증한다.
-  - 프로젝트 구조: `.venv/bin/python scripts/generate_project_structure.py --check`
-  - DB schema: `.venv/bin/python scripts/generate_db_schema.py --check`
+  - 프로젝트 구조: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py --check`
+  - DB schema: `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_db_schema.py --check`
 - 전용 check 명령이 없는 생성 산출물은 generate 명령을 다시 실행한 뒤 `git diff --exit-code -- <산출물>`로 변경 없음 상태를 확인한다.
-- 프로젝트 구조 regenerate 명령은 `.venv/bin/python scripts/generate_project_structure.py`다.
-- DB schema regenerate 명령은 `.venv/bin/python scripts/generate_db_schema.py`다.
+- 프로젝트 구조 regenerate 명령은 `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py`다.
+- DB schema regenerate 명령은 `PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_db_schema.py`다.
+- 로컬 검증 전에는 `PYTHONPATH=$PWD/src .venv/bin/python scripts/check_import_path.py`로 현재 worktree의 `src/ante/__init__.py`가 import되는지 확인한다.
 - Plan Preflight와 리뷰 단계에서 generated artifact sync 위험을 발견하면 구현 체크리스트와 검증 체크리스트에 regenerate/check 흐름을 함께 포함한다.
 
 ## 8. API 스키마 변경 규칙

--- a/docs/runbooks/04-ci-cd.md
+++ b/docs/runbooks/04-ci-cd.md
@@ -96,10 +96,11 @@ branch protection repository setting은 이 저장소 밖 운영 설정이므로
 
 ```yaml
 - cd frontend && npm run check-api-types:strict
-- ruff check src/ tests/
-- ruff format --check src/ tests/
-- mypy src/
-- pytest tests/unit/ -x -n auto --tb=short -q --cov=src/ante --cov-fail-under=80
+- PYTHONPATH=$PWD/src .venv/bin/python scripts/check_import_path.py
+- PYTHONPATH=$PWD/src .venv/bin/python -m ruff check src/ tests/
+- PYTHONPATH=$PWD/src .venv/bin/python -m ruff format --check src/ tests/
+- PYTHONPATH=$PWD/src .venv/bin/python -m mypy src/
+- PYTHONPATH=$PWD/src .venv/bin/python -m pytest tests/unit/ -x -n auto --tb=short -q --cov=src/ante --cov-fail-under=80
 - docker build -t ante:release-pr .  # release/* PR only
 ```
 
@@ -209,10 +210,11 @@ GitHub branch protection에서 required status checks를 사용할 경우, 각 j
 ## 4. 로컬 개발 시 사전 검증
 
 ```bash
-ruff check src/ tests/
-ruff format src/ tests/
-mypy src/ante/
-pytest tests/unit/ -v
+PYTHONPATH=$PWD/src .venv/bin/python scripts/check_import_path.py
+PYTHONPATH=$PWD/src .venv/bin/python -m ruff check src/ tests/
+PYTHONPATH=$PWD/src .venv/bin/python -m ruff format src/ tests/
+PYTHONPATH=$PWD/src .venv/bin/python -m mypy src/ante/
+PYTHONPATH=$PWD/src .venv/bin/python -m pytest tests/unit/ -v
 ```
 
 내부 Codex 브랜치 리뷰 전 이 검증을 통과시켜야 사전 리뷰 루프가 짧아진다.

--- a/docs/runbooks/05-testing.md
+++ b/docs/runbooks/05-testing.md
@@ -120,20 +120,23 @@ def db_path(tmp_path):
 ## 6. 테스트 실행 명령
 
 ```bash
+# 현재 worktree import sanity check
+PYTHONPATH=$PWD/src .venv/bin/python scripts/check_import_path.py
+
 # 단위 테스트만
-pytest tests/unit/ -v
+PYTHONPATH=$PWD/src .venv/bin/python -m pytest tests/unit/ -v
 
 # 통합 테스트만
-pytest tests/integration/ -v
+PYTHONPATH=$PWD/src .venv/bin/python -m pytest tests/integration/ -v
 
 # 전체 + 커버리지
-pytest tests/ -v --cov=src/ante --cov-report=term-missing
+PYTHONPATH=$PWD/src .venv/bin/python -m pytest tests/ -v --cov=src/ante --cov-report=term-missing
 
 # 특정 모듈만
-pytest tests/unit/test_eventbus.py -v
+PYTHONPATH=$PWD/src .venv/bin/python -m pytest tests/unit/test_eventbus.py -v
 
 # 특정 테스트만
-pytest tests/unit/test_eventbus.py::test_publish_subscribe -v
+PYTHONPATH=$PWD/src .venv/bin/python -m pytest tests/unit/test_eventbus.py::test_publish_subscribe -v
 ```
 
 ## 7. 프론트엔드 API 타입 경계 검사

--- a/scripts/check_import_path.py
+++ b/scripts/check_import_path.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Fail fast when local validation imports Ante from another checkout."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_PACKAGE = "ante"
+
+
+@dataclass(frozen=True)
+class ImportPathResult:
+    package: str
+    project_root: Path
+    expected_package_dir: Path
+    expected_init: Path
+    actual_path: Path
+
+
+class ImportPathCheckError(RuntimeError):
+    """Raised when a package resolves outside the current worktree."""
+
+
+def _default_project_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _expected_package_dir(project_root: Path, package: str) -> Path:
+    package_path = Path(*package.split("."))
+    return (project_root / "src" / package_path).resolve()
+
+
+def _recovery_command() -> str:
+    return "PYTHONPATH=$PWD/src .venv/bin/python scripts/check_import_path.py"
+
+
+def _format_failure(
+    *,
+    package: str,
+    project_root: Path,
+    expected_package_dir: Path,
+    expected_init: Path,
+    actual: str,
+) -> str:
+    return "\n".join(
+        [
+            f"Import path sanity check failed for package '{package}'.",
+            f"expected repo root: {project_root}",
+            f"expected package dir: {expected_package_dir}",
+            f"expected package init: {expected_init}",
+            f"actual import path: {actual}",
+            f"recovery: {_recovery_command()}",
+        ]
+    )
+
+
+def validate_import_path(
+    *,
+    actual_path: Path,
+    project_root: Path,
+    package: str = DEFAULT_PACKAGE,
+) -> ImportPathResult:
+    project_root = project_root.resolve()
+    expected_package_dir = _expected_package_dir(project_root, package)
+    expected_init = expected_package_dir / "__init__.py"
+    actual_path = actual_path.resolve()
+
+    try:
+        actual_path.relative_to(expected_package_dir)
+    except ValueError as exc:
+        raise ImportPathCheckError(
+            _format_failure(
+                package=package,
+                project_root=project_root,
+                expected_package_dir=expected_package_dir,
+                expected_init=expected_init,
+                actual=str(actual_path),
+            )
+        ) from exc
+
+    return ImportPathResult(
+        package=package,
+        project_root=project_root,
+        expected_package_dir=expected_package_dir,
+        expected_init=expected_init,
+        actual_path=actual_path,
+    )
+
+
+def check_import_path(
+    project_root: Path | None = None,
+    *,
+    package: str = DEFAULT_PACKAGE,
+) -> ImportPathResult:
+    project_root = (project_root or _default_project_root()).resolve()
+    expected_package_dir = _expected_package_dir(project_root, package)
+    expected_init = expected_package_dir / "__init__.py"
+
+    try:
+        module = importlib.import_module(package)
+    except Exception as exc:  # pragma: no cover - exact import errors vary by env
+        raise ImportPathCheckError(
+            _format_failure(
+                package=package,
+                project_root=project_root,
+                expected_package_dir=expected_package_dir,
+                expected_init=expected_init,
+                actual=f"<import failed: {exc}>",
+            )
+        ) from exc
+
+    module_file = getattr(module, "__file__", None)
+    if module_file is None:
+        raise ImportPathCheckError(
+            _format_failure(
+                package=package,
+                project_root=project_root,
+                expected_package_dir=expected_package_dir,
+                expected_init=expected_init,
+                actual="<module has no __file__>",
+            )
+        )
+
+    return validate_import_path(
+        actual_path=Path(module_file),
+        project_root=project_root,
+        package=package,
+    )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check that Ante imports from the current worktree.",
+    )
+    parser.add_argument("--package", default=DEFAULT_PACKAGE)
+    parser.add_argument("--repo-root", type=Path, default=_default_project_root())
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        result = check_import_path(args.repo_root, package=args.package)
+    except ImportPathCheckError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(
+        f"OK: {result.package} imports from {result.actual_path} "
+        f"(expected under {result.expected_package_dir})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_db_schema.py
+++ b/scripts/generate_db_schema.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import ast
 import difflib
+import importlib.util
 import re
 import sys
 from datetime import datetime, timedelta, timezone
@@ -35,6 +36,27 @@ SRC_DIR = PROJECT_ROOT / "src" / "ante"
 DEFAULT_OUTPUT = PROJECT_ROOT / "docs" / "architecture" / "generated" / "db-schema.md"
 KST = timezone(timedelta(hours=9))
 LAST_UPDATED_RE = re.compile(r"^> 마지막 갱신: (?P<value>.+)$", re.MULTILINE)
+
+
+def _load_import_guard():
+    guard_path = PROJECT_ROOT / "scripts" / "check_import_path.py"
+    spec = importlib.util.spec_from_file_location("check_import_path", guard_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load import guard: {guard_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _assert_current_worktree_import_path() -> None:
+    guard = _load_import_guard()
+    try:
+        guard.check_import_path(PROJECT_ROOT)
+    except guard.ImportPathCheckError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from exc
+
 
 # ── 테이블 설명 매핑 ──────────────────────────────────────────────────────
 
@@ -338,9 +360,13 @@ def _write_header(
         "Ante 시스템의 전체 데이터베이스 스키마를 정리한 문서입니다. "
         "각 테이블의 DDL, 인덱스, ER 다이어그램, 보존 정책을 확인할 수 있습니다.\n\n"
     )
-    out.write("> 생성 명령: `.venv/bin/python scripts/generate_db_schema.py`\n")
     out.write(
-        "> Check 명령: `.venv/bin/python scripts/generate_db_schema.py --check`\n"
+        "> 생성 명령: "
+        "`PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_db_schema.py`\n"
+    )
+    out.write(
+        "> Check 명령: "
+        "`PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_db_schema.py --check`\n"
     )
     out.write(f"> 마지막 갱신: {generated_at}\n\n")
     out.write(f"- 테이블: **{table_count}**개\n")
@@ -550,7 +576,7 @@ def _check_output(output_path: Path, content: str) -> int:
         return 0
 
     print(f"{rel_output} is stale.")
-    print("Run: .venv/bin/python scripts/generate_db_schema.py")
+    print("Run: PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_db_schema.py")
     print()
     _print_diff_summary(current, content, rel_output)
     return 1
@@ -561,6 +587,7 @@ def _check_output(output_path: Path, content: str) -> int:
 
 def main() -> None:
     """스크립트 진입점."""
+    _assert_current_worktree_import_path()
     parser = argparse.ArgumentParser(
         description="*_SCHEMA 상수 파싱 기반 DB 스키마 문서 자동 생성/check",
     )

--- a/scripts/generate_project_structure.py
+++ b/scripts/generate_project_structure.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import difflib
+import importlib.util
 import re
 import subprocess
 import sys
@@ -93,6 +94,7 @@ DEFAULT_DESCRIPTIONS: dict[str, str] = {
     "frontend": "React 대시보드 (Vite + TypeScript)",
     "guide": "사용자·운용 가이드 문서",
     "scripts": "설치·운영·문서 생성 스크립트",
+    "scripts/check_import_path.py": "현재 worktree import sanity check",
     "scripts/generate_db_schema.py": "DB 스키마 문서 자동 생성",
     "scripts/generate_project_structure.py": "프로젝트 구조 Agent INDEX 생성/check",
     "src/ante": "Python 백엔드 패키지",
@@ -105,6 +107,26 @@ TREE_LINE_RE = re.compile(
     r"^(?P<prefix>[│ ]*)(?:├|└)── (?P<name>.*?)(?:\s+#\s*(?P<comment>.*))?$"
 )
 GENERATED_AT_RE = re.compile(r"^> 마지막 생성 시점: (?P<value>.+)$", re.MULTILINE)
+
+
+def _load_import_guard():
+    guard_path = PROJECT_ROOT / "scripts" / "check_import_path.py"
+    spec = importlib.util.spec_from_file_location("check_import_path", guard_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load import guard: {guard_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _assert_current_worktree_import_path() -> None:
+    guard = _load_import_guard()
+    try:
+        guard.check_import_path(PROJECT_ROOT)
+    except guard.ImportPathCheckError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from exc
 
 
 def _run_git_ls_files() -> list[str]:
@@ -351,10 +373,14 @@ def _render_markdown(
     out = StringIO()
     out.write("# Ante 프로젝트 디렉토리 구조\n\n")
     out.write("> 역할: Agent용 프로젝트 구조 INDEX의 단일 SSOT입니다.\n")
-    out.write("> 생성 명령: `.venv/bin/python scripts/generate_project_structure.py`\n")
+    out.write(
+        "> 생성 명령: "
+        "`PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py`\n"
+    )
     out.write(
         "> Check 명령: "
-        "`.venv/bin/python scripts/generate_project_structure.py --check`\n"
+        "`PYTHONPATH=$PWD/src .venv/bin/python "
+        "scripts/generate_project_structure.py --check`\n"
     )
     out.write(
         "> 생성 기준: 현재 Git 추적/비무시 파일 트리 "
@@ -394,7 +420,10 @@ def _check_output(output_path: Path, content: str) -> int:
 
     rel_output = output_path.relative_to(PROJECT_ROOT)
     print(f"{rel_output} is stale.")
-    print("Run: .venv/bin/python scripts/generate_project_structure.py")
+    print(
+        "Run: "
+        "PYTHONPATH=$PWD/src .venv/bin/python scripts/generate_project_structure.py"
+    )
     print()
     _print_diff_summary(current, content, rel_output)
     return 1
@@ -436,6 +465,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:
+    _assert_current_worktree_import_path()
     args = parse_args(argv or sys.argv[1:])
     output_path = args.output
     if not output_path.is_absolute():

--- a/scripts/verify-install.py
+++ b/scripts/verify-install.py
@@ -22,6 +22,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import shutil
 import sqlite3
 import subprocess
@@ -82,6 +83,26 @@ def _ensure_src_path(project_root: Path) -> None:
     src_path = str(project_root / "src")
     if src_path not in sys.path:
         sys.path.insert(0, src_path)
+
+
+def _load_import_guard(project_root: Path):
+    guard_path = project_root / "scripts" / "check_import_path.py"
+    spec = importlib.util.spec_from_file_location("check_import_path", guard_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load import guard: {guard_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _assert_current_worktree_import_path(project_root: Path) -> None:
+    guard = _load_import_guard(project_root)
+    try:
+        guard.check_import_path(project_root)
+    except guard.ImportPathCheckError as exc:
+        log_fail(str(exc))
+        raise SystemExit(1) from exc
 
 
 def _enum_value(value: Any) -> Any:
@@ -150,6 +171,7 @@ def _print_account_create_hint(account_id: str) -> None:
 
 async def _load_kis_adapter_config(account_id: str) -> dict[str, Any] | None:
     project_root = Path(__file__).resolve().parent.parent
+    _assert_current_worktree_import_path(project_root)
     _ensure_src_path(project_root)
 
     from ante.account import AccountNotFoundError, AccountService

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,16 @@ import os
 import pytest
 
 
+def pytest_configure(config: pytest.Config) -> None:
+    """Fail collection if ``ante`` resolves outside this checkout."""
+    from scripts.check_import_path import ImportPathCheckError, check_import_path
+
+    try:
+        check_import_path()
+    except ImportPathCheckError as exc:
+        raise pytest.UsageError(str(exc)) from exc
+
+
 @pytest.fixture(autouse=True, scope="session")
 def _set_encryption_key():
     """테스트용 Fernet 키 자동 설정 (session scope — 전체 세션에서 1회만 생성)."""

--- a/tests/unit/test_check_import_path.py
+++ b/tests/unit/test_check_import_path.py
@@ -1,0 +1,55 @@
+"""Import path guard tests (#1236)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from scripts.check_import_path import (
+    ImportPathCheckError,
+    main,
+    validate_import_path,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_validate_import_path_accepts_current_worktree(tmp_path: Path) -> None:
+    expected = tmp_path / "repo" / "src" / "ante" / "__init__.py"
+    expected.parent.mkdir(parents=True)
+    expected.write_text("", encoding="utf-8")
+
+    result = validate_import_path(
+        actual_path=expected,
+        project_root=tmp_path / "repo",
+    )
+
+    assert result.actual_path == expected.resolve()
+    assert result.expected_package_dir == expected.parent.resolve()
+
+
+def test_validate_import_path_rejects_other_checkout(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    expected = project_root / "src" / "ante" / "__init__.py"
+    expected.parent.mkdir(parents=True)
+    expected.write_text("", encoding="utf-8")
+    actual = tmp_path / "other" / "src" / "ante" / "__init__.py"
+    actual.parent.mkdir(parents=True)
+    actual.write_text("", encoding="utf-8")
+
+    with pytest.raises(ImportPathCheckError) as exc_info:
+        validate_import_path(actual_path=actual, project_root=project_root)
+
+    message = str(exc_info.value)
+    assert f"expected repo root: {project_root.resolve()}" in message
+    assert f"expected package dir: {expected.parent.resolve()}" in message
+    assert f"actual import path: {actual.resolve()}" in message
+    assert "PYTHONPATH=$PWD/src" in message
+
+
+def test_cli_reports_current_checkout(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["--repo-root", str(REPO_ROOT)]) == 0
+
+    captured = capsys.readouterr()
+    assert "OK: ante imports from" in captured.out
+    assert str((REPO_ROOT / "src" / "ante").resolve()) in captured.out


### PR DESCRIPTION
Closes #1236

## Summary
- add `scripts/check_import_path.py` to fail local validation when `ante` imports from another checkout
- wire the guard into pytest collection, generated artifact scripts, and verify-install account-backed stages
- standardize local validation/runbook/generated-artifact commands on `PYTHONPATH=$PWD/src .venv/bin/python ...`
- regenerate generated architecture docs for the new script/test and command headers

## Test Plan
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python scripts/check_import_path.py`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m ruff check scripts/check_import_path.py scripts/generate_project_structure.py scripts/generate_db_schema.py scripts/verify-install.py tests/conftest.py tests/unit/test_check_import_path.py`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m ruff format --check scripts/check_import_path.py scripts/generate_project_structure.py scripts/generate_db_schema.py scripts/verify-install.py tests/conftest.py tests/unit/test_check_import_path.py`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/test_check_import_path.py -q`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python -m pytest tests/unit/ -x -n auto --tb=short -q`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python scripts/generate_project_structure.py --check`
- `PYTHONPATH=$PWD/src /Users/jingulee/Projects/ante/.venv/bin/python scripts/generate_db_schema.py --check`
- `git diff --check`
