### PR TITLE
fix: load import guard by path in pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,18 +3,33 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import os
+import sys
+from pathlib import Path
 
 import pytest
 
 
+def _load_import_guard():
+    guard_path = (
+        Path(__file__).resolve().parents[1] / "scripts" / "check_import_path.py"
+    )
+    spec = importlib.util.spec_from_file_location("check_import_path", guard_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load import guard: {guard_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def pytest_configure(config: pytest.Config) -> None:
     """Fail collection if ``ante`` resolves outside this checkout."""
-    from scripts.check_import_path import ImportPathCheckError, check_import_path
-
+    guard = _load_import_guard()
     try:
-        check_import_path()
-    except ImportPathCheckError as exc:
+        guard.check_import_path()
+    except guard.ImportPathCheckError as exc:
         raise pytest.UsageError(str(exc)) from exc
 
 

--- a/tests/unit/test_check_import_path.py
+++ b/tests/unit/test_check_import_path.py
@@ -2,24 +2,34 @@
 
 from __future__ import annotations
 
+import importlib.util
+import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
-from scripts.check_import_path import (
-    ImportPathCheckError,
-    main,
-    validate_import_path,
-)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def _load_import_guard() -> ModuleType:
+    guard_path = REPO_ROOT / "scripts" / "check_import_path.py"
+    spec = importlib.util.spec_from_file_location("check_import_path", guard_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load import guard: {guard_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_validate_import_path_accepts_current_worktree(tmp_path: Path) -> None:
+    guard = _load_import_guard()
     expected = tmp_path / "repo" / "src" / "ante" / "__init__.py"
     expected.parent.mkdir(parents=True)
     expected.write_text("", encoding="utf-8")
 
-    result = validate_import_path(
+    result = guard.validate_import_path(
         actual_path=expected,
         project_root=tmp_path / "repo",
     )
@@ -29,6 +39,7 @@ def test_validate_import_path_accepts_current_worktree(tmp_path: Path) -> None:
 
 
 def test_validate_import_path_rejects_other_checkout(tmp_path: Path) -> None:
+    guard = _load_import_guard()
     project_root = tmp_path / "repo"
     expected = project_root / "src" / "ante" / "__init__.py"
     expected.parent.mkdir(parents=True)
@@ -37,8 +48,8 @@ def test_validate_import_path_rejects_other_checkout(tmp_path: Path) -> None:
     actual.parent.mkdir(parents=True)
     actual.write_text("", encoding="utf-8")
 
-    with pytest.raises(ImportPathCheckError) as exc_info:
-        validate_import_path(actual_path=actual, project_root=project_root)
+    with pytest.raises(guard.ImportPathCheckError) as exc_info:
+        guard.validate_import_path(actual_path=actual, project_root=project_root)
 
     message = str(exc_info.value)
     assert f"expected repo root: {project_root.resolve()}" in message
@@ -48,7 +59,8 @@ def test_validate_import_path_rejects_other_checkout(tmp_path: Path) -> None:
 
 
 def test_cli_reports_current_checkout(capsys: pytest.CaptureFixture[str]) -> None:
-    assert main(["--repo-root", str(REPO_ROOT)]) == 0
+    guard = _load_import_guard()
+    assert guard.main(["--repo-root", str(REPO_ROOT)]) == 0
 
     captured = capsys.readouterr()
     assert "OK: ante imports from" in captured.out


### PR DESCRIPTION
Closes #1236

## Summary
- load `scripts/check_import_path.py` by file path from pytest configuration
- update the import guard unit test to use the same loader path
- keep #1236 import sanity checks compatible with CI `pytest --import-mode=importlib`

## Root Cause
- PR #1289 merged while the `test` check had failed and aggregate `ci` was skipped.
- The failure was `ModuleNotFoundError: No module named 'scripts'` during pytest collection because `tests/conftest.py` imported `scripts.check_import_path` as a package.\n\n## Test Plan\n- `ruff format tests/conftest.py tests/unit/test_check_import_path.py`\n- `ruff check tests/conftest.py tests/unit/test_check_import_path.py`\n- `pytest tests/unit/test_check_import_path.py -q`\n- `pytest tests/unit/ -x -n auto --tb=short -q`\n- `git diff --check`