### PR TITLE
refactor: nest cli success json data

### DIFF
--- a/src/ante/cli/formatter.py
+++ b/src/ante/cli/formatter.py
@@ -87,9 +87,11 @@ class OutputFormatter:
     def success(self, message: str, data: dict | None = None) -> None:
         """성공 메시지 출력."""
         if self._format == "json":
-            result = {"status": "ok", "message": message}
-            if data:
-                result.update(data)
+            result = {
+                "status": "ok",
+                "message": message,
+                "data": data if data is not None else {},
+            }
             click.echo(json.dumps(result, indent=2, default=str, ensure_ascii=False))
         else:
             click.echo(message)

--- a/tests/unit/test_account_cli.py
+++ b/tests/unit/test_account_cli.py
@@ -356,8 +356,8 @@ class TestAccountCreate:
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
         assert data["status"] == "ok"
-        assert data["account_id"] == "test2"
-        assert data["broker_type"] == "test"
+        assert data["data"]["account_id"] == "test2"
+        assert data["data"]["broker_type"] == "test"
 
     def test_create_blocked_when_active_runtime(
         self, mock_account_service: AsyncMock, active_runtime

--- a/tests/unit/test_bot_create_params.py
+++ b/tests/unit/test_bot_create_params.py
@@ -200,4 +200,4 @@ class TestBotCreateWithParams:
             )
             assert result.exit_code == 0
             data = json.loads(result.output)
-            assert data["params"]["window"] == 30
+            assert data["data"]["params"]["window"] == 30

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -149,8 +149,26 @@ class TestOutputFormatter:
         fmt.success("ok", {"count": 5})
         captured = capsys.readouterr()
         data = json.loads(captured.out)
+        assert set(data) == {"status", "message", "data"}
         assert data["status"] == "ok"
-        assert data["count"] == 5
+        assert data["message"] == "ok"
+        assert data["data"] == {"count": 5}
+        assert "count" not in data
+
+    def test_success_json_no_data(self, capsys):
+        fmt = OutputFormatter("json")
+        fmt.success("done!")
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data == {"status": "ok", "message": "done!", "data": {}}
+
+    def test_success_json_preserves_payload_status(self, capsys):
+        fmt = OutputFormatter("json")
+        fmt.success("member revoked", {"status": "revoked"})
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["status"] == "ok"
+        assert data["data"]["status"] == "revoked"
 
     def test_is_json(self):
         assert OutputFormatter("json").is_json is True

--- a/tests/unit/test_cli_backtest_report.py
+++ b/tests/unit/test_cli_backtest_report.py
@@ -125,7 +125,24 @@ class TestReportSubmitWithRun:
             }
             result = runner.invoke(
                 cli,
-                ["report", "submit", str(report_file), "--run", "run-1"],
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "submit",
+                    str(report_file),
+                    "--run",
+                    "run-1",
+                ],
             )
             assert result.exit_code == 0
-            assert "rpt-123" in result.output
+            data = json.loads(result.output)
+            assert set(data) == {"status", "message", "data"}
+            assert data["status"] == "ok"
+            assert data["message"] == "Report submitted: rpt-123"
+            assert data["data"] == {
+                "report_id": "rpt-123",
+                "strategy": "momentum",
+                "status": "submitted",
+                "backtest_run_id": "run-1",
+            }

--- a/tests/unit/test_cli_system.py
+++ b/tests/unit/test_cli_system.py
@@ -185,7 +185,7 @@ class TestSystemStop:
             assert result.exit_code == 0
             data = json.loads(result.output)
             assert data["status"] == "ok"
-            assert data["pid"] == 12345
+            assert data["data"]["pid"] == 12345
 
     def test_stop_pid_not_found_message_includes_resolver_path(
         self, runner, tmp_path, monkeypatch


### PR DESCRIPTION
Closes #1227

## Summary
- change `OutputFormatter.success()` JSON output to the SSOT `{status, message, data}` envelope
- keep `data: {}` for success calls without payload
- keep domain payload fields, including `status`, under `data` so they cannot overwrite the envelope status
- update CLI success JSON tests and add `report submit --format json` as an Agent workflow representative path

## Breaking Change
- CLI JSON success output no longer flattens payload keys at the top level. Consumers must read payload fields under `data`.

## Test Plan
- `ruff check src/ante/cli/formatter.py tests/unit/test_cli.py tests/unit/test_cli_system.py tests/unit/test_account_cli.py tests/unit/test_bot_create_params.py tests/unit/test_cli_backtest_report.py`
- `ruff format --check src/ante/cli/formatter.py tests/unit/test_cli.py tests/unit/test_cli_system.py tests/unit/test_account_cli.py tests/unit/test_bot_create_params.py tests/unit/test_cli_backtest_report.py`
- `pytest tests/unit/test_cli.py::TestOutputFormatter::test_success_json -q`
- `pytest tests/unit/test_cli.py::TestOutputFormatter -q`
- `pytest tests/unit/test_cli_system.py tests/unit/test_account_cli.py tests/unit/test_cli_backtest_report.py tests/unit/test_cli_bot_treasury_ipc.py tests/unit/test_cli_config_approval_broker_ipc.py tests/unit/test_cli_live.py tests/unit/test_bot_create_params.py -q`
- `pytest tests/unit -q -k "cli or formatter"`
- `pytest tests/unit/ -x -n auto --tb=short -q`
- `git diff --check`