### PR TITLE
fix(treasury): emit terminal reject for market buy without quote

### DIFF
--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -561,7 +561,12 @@ class Treasury:
         return account_id == self._account_id
 
     async def _on_order_validated(self, event: object) -> None:
-        """룰 검증 통과 후 자금 예약 -> 승인/거부 발행."""
+        """룰 검증 통과 후 자금 예약 -> 승인/거부 발행.
+
+        EventBus는 핸들러 예외를 ``logger.exception`` 후 swallow하므로,
+        매수 경로에서 발생할 수 있는 모든 실패는 명시적으로 terminal
+        ``OrderRejectedEvent``로 변환해야 한다 (Order lifecycle invariant).
+        """
         from ante.eventbus.events import (
             OrderApprovedEvent,
             OrderRejectedEvent,
@@ -574,17 +579,40 @@ class Treasury:
         if not self._is_my_event(event):
             return
 
+        # Guard 1: 매수 + 시장가 + price 부재 시그니처는 quote source가 없으면
+        # reserve 금액을 산정할 수 없으므로 즉시 거부한다.
+        # narrow-scope: total_reserve <= 0 전체가 아니라 정확한 quote 부재
+        # 시그니처만 잡아 quantity=0 같은 다른 경계 케이스와 분리한다.
+        if event.side == "buy" and event.order_type == "market" and event.price is None:
+            await self._eventbus.publish(
+                OrderRejectedEvent(
+                    order_id=event.order_id,
+                    bot_id=event.bot_id,
+                    strategy_id=event.strategy_id,
+                    symbol=event.symbol,
+                    side=event.side,
+                    quantity=event.quantity,
+                    price=event.price,
+                    order_type=event.order_type,
+                    account_id=self._account_id,
+                    reason=(
+                        f"market_buy_quote_unavailable: "
+                        f"order_type={event.order_type}, price={event.price}"
+                    ),
+                )
+            )
+            return
+
         price = event.price or 0.0
         estimated_cost = event.quantity * price
         commission_estimate = estimated_cost * self._buy_commission_rate
         total_reserve = estimated_cost + commission_estimate
 
         if event.side == "buy":
-            success = await self.reserve_for_order(
-                event.bot_id, event.order_id, total_reserve
-            )
-            if not success:
-                available = self.get_available(event.bot_id)
+            # Guard 2: quote는 있으나 reserve 금액이 비양수인 경계 케이스
+            # (예: quantity=0). reserve_for_order는 amount > 0을 요구하므로
+            # ValueError로 빠지지 않도록 사전에 거부한다.
+            if total_reserve <= 0:
                 await self._eventbus.publish(
                     OrderRejectedEvent(
                         order_id=event.order_id,
@@ -597,13 +625,82 @@ class Treasury:
                         order_type=event.order_type,
                         account_id=self._account_id,
                         reason=(
-                            f"insufficient_budget: need {total_reserve:,.0f}, "
-                            f"available {available:,.0f}"
+                            f"reserve_amount_invalid: "
+                            f"total_reserve={total_reserve}, "
+                            f"price={event.price}, "
+                            f"quantity={event.quantity}"
                         ),
                     )
                 )
                 return
 
+            # 안전망: reserve_for_order 또는 후속 publish에서 예외가 나도
+            # terminal OrderRejectedEvent로 변환한다. EventBus.publish는
+            # 핸들러 예외를 swallow하므로 핸들러 안에서 막아야 한다.
+            try:
+                success = await self.reserve_for_order(
+                    event.bot_id, event.order_id, total_reserve
+                )
+                if not success:
+                    available = self.get_available(event.bot_id)
+                    await self._eventbus.publish(
+                        OrderRejectedEvent(
+                            order_id=event.order_id,
+                            bot_id=event.bot_id,
+                            strategy_id=event.strategy_id,
+                            symbol=event.symbol,
+                            side=event.side,
+                            quantity=event.quantity,
+                            price=event.price,
+                            order_type=event.order_type,
+                            account_id=self._account_id,
+                            reason=(
+                                f"insufficient_budget: need {total_reserve:,.0f}, "
+                                f"available {available:,.0f}"
+                            ),
+                        )
+                    )
+                    return
+
+                await self._eventbus.publish(
+                    OrderApprovedEvent(
+                        order_id=event.order_id,
+                        bot_id=event.bot_id,
+                        strategy_id=event.strategy_id,
+                        symbol=event.symbol,
+                        side=event.side,
+                        quantity=event.quantity,
+                        price=event.price,
+                        order_type=event.order_type,
+                        stop_price=event.stop_price,
+                        reserved_amount=total_reserve,
+                        account_id=self._account_id,
+                    )
+                )
+                return
+            except Exception as exc:
+                logger.exception(
+                    "Treasury reserve_for_order 실패: order_id=%s, bot_id=%s",
+                    event.order_id,
+                    event.bot_id,
+                )
+                await self._eventbus.publish(
+                    OrderRejectedEvent(
+                        order_id=event.order_id,
+                        bot_id=event.bot_id,
+                        strategy_id=event.strategy_id,
+                        symbol=event.symbol,
+                        side=event.side,
+                        quantity=event.quantity,
+                        price=event.price,
+                        order_type=event.order_type,
+                        account_id=self._account_id,
+                        reason=f"reserve_failed: {exc!s}",
+                    )
+                )
+                return
+
+        # Sell-side: 자금 예약 없이 즉시 승인.
         await self._eventbus.publish(
             OrderApprovedEvent(
                 order_id=event.order_id,
@@ -615,7 +712,7 @@ class Treasury:
                 price=event.price,
                 order_type=event.order_type,
                 stop_price=event.stop_price,
-                reserved_amount=(total_reserve if event.side == "buy" else 0.0),
+                reserved_amount=0.0,
                 account_id=self._account_id,
             )
         )

--- a/tests/unit/test_treasury.py
+++ b/tests/unit/test_treasury.py
@@ -676,6 +676,286 @@ class TestTreasuryEvents:
         assert budget.reserved == 200_000.0
 
 
+# -- _on_order_validated guard 회귀 테스트 (#1292) --------------
+
+
+class TestOnOrderValidatedGuards:
+    """매수 시장가 quote 부재, reserve 실패 등 terminal event 누락 회귀 테스트."""
+
+    async def test_on_order_validated_market_buy_without_price_publishes_rejected(
+        self, treasury, eventbus, monkeypatch
+    ):
+        """market buy + price=None -> reserve 호출 없이 OrderRejected 발행.
+
+        Order lifecycle invariant: terminal event(OrderRejected)가 정확히 1건
+        발행되어야 하고, reserve_for_order는 호출되지 않아야 한다.
+        """
+        await treasury.allocate("bot1", 1_000_000.0)
+
+        rejected: list = []
+        approved: list = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderApprovedEvent, lambda e: approved.append(e))
+
+        reserve_calls: list = []
+
+        async def spy_reserve(bot_id, order_id, amount):
+            reserve_calls.append((bot_id, order_id, amount))
+            return True
+
+        monkeypatch.setattr(treasury, "reserve_for_order", spy_reserve)
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-mkt-buy",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=None,
+                order_type="market",
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        assert len(approved) == 0
+        assert len(rejected) == 1
+        assert rejected[0].reason.startswith("market_buy_quote_unavailable")
+        assert "order_type=market" in rejected[0].reason
+        assert "price=None" in rejected[0].reason
+        assert rejected[0].account_id == ACCOUNT_ID
+        assert rejected[0].order_id == "ord-mkt-buy"
+        # reserve_for_order는 절대 호출되지 않아야 한다.
+        assert reserve_calls == []
+
+        # 예산도 변경 없음.
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.available == 1_000_000.0
+        assert budget.reserved == 0.0
+
+    async def test_on_order_validated_market_sell_without_price_publishes_approved(
+        self, treasury, eventbus
+    ):
+        """market sell + price=None -> Approved 발행 (회귀 가드)."""
+        await treasury.allocate("bot1", 1_000_000.0)
+
+        approved: list = []
+        rejected: list = []
+        eventbus.subscribe(OrderApprovedEvent, lambda e: approved.append(e))
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-mkt-sell",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="sell",
+                quantity=10.0,
+                price=None,
+                order_type="market",
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        assert len(rejected) == 0
+        assert len(approved) == 1
+        assert approved[0].reserved_amount == 0.0
+        assert approved[0].order_id == "ord-mkt-sell"
+
+    async def test_on_order_validated_limit_buy_with_budget_publishes_approved(
+        self, treasury, eventbus
+    ):
+        """limit buy with sufficient budget -> 기존 동작 유지."""
+        await treasury.allocate("bot1", 1_000_000.0)
+
+        approved: list = []
+        rejected: list = []
+        eventbus.subscribe(OrderApprovedEvent, lambda e: approved.append(e))
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-lim-buy",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=50_000.0,
+                order_type="limit",
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        assert len(rejected) == 0
+        assert len(approved) == 1
+        assert approved[0].reserved_amount > 0
+
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.reserved > 0
+
+    async def test_on_order_validated_zero_quantity_market_buy_publishes_rejected_with_reserve_amount_invalid(  # noqa: E501
+        self, treasury, eventbus
+    ):
+        """quantity=0 + price 양수 시장가 매수 -> reserve_amount_invalid 거부.
+
+        price=None이면 market_buy_quote_unavailable이 먼저, price 양수+quantity=0이면
+        reserve_amount_invalid가 발행된다.
+        """
+        await treasury.allocate("bot1", 1_000_000.0)
+
+        rejected: list = []
+        approved: list = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderApprovedEvent, lambda e: approved.append(e))
+
+        # price 양수 + quantity=0 -> Guard 1을 통과하고 Guard 2에서 거부.
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-zero-qty",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=0.0,
+                price=50_000.0,
+                order_type="market",
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        assert len(approved) == 0
+        assert len(rejected) == 1
+        assert rejected[0].reason.startswith("reserve_amount_invalid")
+        assert "total_reserve=0" in rejected[0].reason
+
+        # price=None + quantity=0 -> Guard 1이 먼저 매칭.
+        rejected.clear()
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-zero-qty-no-price",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=0.0,
+                price=None,
+                order_type="market",
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        assert len(rejected) == 1
+        assert rejected[0].reason.startswith("market_buy_quote_unavailable")
+
+    async def test_on_order_validated_reserve_for_order_exception_publishes_rejected(
+        self, treasury, eventbus, monkeypatch
+    ):
+        """reserve_for_order가 예외를 던져도 OrderRejected가 발행된다."""
+        await treasury.allocate("bot1", 1_000_000.0)
+
+        rejected: list = []
+        approved: list = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderApprovedEvent, lambda e: approved.append(e))
+
+        async def boom(bot_id, order_id, amount):
+            raise RuntimeError("simulated reserve failure")
+
+        monkeypatch.setattr(treasury, "reserve_for_order", boom)
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-exc",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=50_000.0,
+                order_type="limit",
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        assert len(approved) == 0
+        assert len(rejected) == 1
+        assert rejected[0].reason.startswith("reserve_failed")
+        assert "simulated reserve failure" in rejected[0].reason
+
+    async def test_on_order_validated_account_id_mismatch_does_not_publish(
+        self, treasury, eventbus
+    ):
+        """다른 account_id 이벤트는 새 guard보다 먼저 _is_my_event 필터에서 무시.
+
+        market buy + price=None 시그니처라도, 다른 계좌의 이벤트라면
+        OrderRejected/OrderApproved 어느 쪽도 publish되지 않아야 한다.
+        """
+        await treasury.allocate("bot1", 1_000_000.0)
+
+        rejected: list = []
+        approved: list = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderApprovedEvent, lambda e: approved.append(e))
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-other",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=None,
+                order_type="market",
+                account_id="other-account",
+            )
+        )
+
+        assert len(rejected) == 0
+        assert len(approved) == 0
+
+    async def test_on_order_validated_warn_path_market_buy_publishes_rejected(
+        self, treasury, eventbus
+    ):
+        """RuleEngine WARN 분기에서 발행된 OrderValidatedEvent도 동일하게 거부.
+
+        WARN 경로에서도 동일한 OrderValidatedEvent가 publish되므로
+        Treasury 핸들러는 같은 guard를 적용해야 한다 (이슈 #1292의
+        실제 재현 경로).
+        """
+        await treasury.allocate("bot1", 1_000_000.0)
+
+        rejected: list = []
+        approved: list = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderApprovedEvent, lambda e: approved.append(e))
+
+        # WARN 분기는 reason 필드에 경고 텍스트를 담아 publish한다.
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-warn",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="005930",
+                side="buy",
+                quantity=10.0,
+                price=None,
+                order_type="market",
+                account_id=ACCOUNT_ID,
+                reason="WARN: position size near limit",
+            )
+        )
+
+        assert len(approved) == 0
+        assert len(rejected) == 1
+        assert rejected[0].reason.startswith("market_buy_quote_unavailable")
+
+
 # -- 모니터링 -------------------------------------------------
 
 


### PR DESCRIPTION
Closes #1292

## Summary
- Treasury._on_order_validated 안에서 `_is_my_event` 필터 직후, market buy + price=None 시그니처를 사전 가드해 `OrderRejectedEvent(reason="market_buy_quote_unavailable: ...")`로 거부한다. `reserve_for_order(..., 0.0)`로 빠지지 않으므로 `ValueError("amount must be positive")` 경로가 사라지고 terminal event 누락이 해소된다.
- quote는 있으나 `total_reserve <= 0`(예: quantity=0)인 경계 케이스는 `reserve_amount_invalid` reason으로 거부한다. quote 부재와 별도 reason으로 분리해 오라클이 원인을 구분할 수 있게 한다.
- buy-side `reserve_for_order` 호출과 후속 OrderApprovedEvent publish 블록을 try/except로 감싸 어떤 예외가 발생해도 `OrderRejectedEvent(reason="reserve_failed: {exc}")`를 publish해 EventBus의 swallow 정책을 보완한다.
- sell-side, limit-buy with budget, account_id mismatch, RuleEngine WARN 분기 동작은 모두 회귀 테스트로 보호한다.

## Test Plan
- [x] `PYTHONPATH=$PWD/src ruff check src/ante/treasury tests/unit/test_treasury.py` PASS
- [x] `PYTHONPATH=$PWD/src ruff format --check src/ante/treasury tests/unit/test_treasury.py` PASS
- [x] `PYTHONPATH=$PWD/src pytest tests/unit/test_treasury.py -v` 74 passed (TestOnOrderValidatedGuards 7개 신규 포함)
- [x] `PYTHONPATH=$PWD/src pytest tests/unit/test_bot_stop_release.py -v` 13 passed
- [x] `PYTHONPATH=$PWD/src pytest tests/unit -q` 3678 passed, 2 skipped
- [x] Codex 브랜치 리뷰 (`/codex:review --base main`) PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)