### PR TITLE
fix(deps): cap cryptography <47 to avoid arm64 wheel SIGILL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
     "fastapi>=0.115",
     "uvicorn>=0.34",
     "websockets>=13.0",
-    "cryptography>=44.0",
+    # cryptography 47/48 arm64 wheels SIGILL on Docker/Apple Silicon (#1293)
+    "cryptography>=44.0,<47",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Closes #1293

## Summary
- linux/arm64 Docker 이미지에서 `ante init`이 `Illegal instruction`(exit 132)으로 실패하는 회귀를 차단한다. cryptography 47/48 arm64 wheel의 Rust/OpenSSL binding import에서 SIGILL이 발생하는 것으로 관찰됐다.
- `pyproject.toml`의 `cryptography>=44.0`을 `cryptography>=44.0,<47`로 좁힌다. release lockfile(`config/db/pip_freeze_v1.0.0.txt`)이 이미 `cryptography==46.0.5`로 정상 환경을 기록 중이므로 SemVer 범위와 정합적이다.
- 다른 dependency 상한, 멀티아키 CI 도입, lockfile 갱신, 암호화 정책 변경은 Non-Goals.

## Test Plan
- [x] `python3 -c "import tomllib; print([d for d in tomllib.load(open('pyproject.toml','rb'))['project']['dependencies'] if d.startswith('cryptography')])"` → `['cryptography>=44.0,<47']`
- [x] `python3 -m pip install --dry-run -e . 2>&1 | grep cryptography` → `Requirement already satisfied: cryptography<47,>=44.0 ... (46.0.5)` (제약이 정확히 적용)
- [x] `PYTHONPATH=$PWD/src ruff check src/ante tests` PASS
- [x] `PYTHONPATH=$PWD/src ruff format --check src/ante tests` PASS
- [x] `PYTHONPATH=$PWD/src pytest tests/unit/test_account_crypto.py -v` 10 passed (Fernet round-trip 회귀 가드)
- [x] `PYTHONPATH=$PWD/src pytest tests/unit -q` 3678 passed, 2 skipped
- [x] Codex 브랜치 리뷰 (`/codex:review --base main`) PASS
- [ ] linux/arm64 Apple Silicon Docker 수동 검증: `docker buildx build --platform linux/arm64 -t ante:1293 .` 후 `docker run --rm -v /tmp/ante-config:/opt/ante-config ante:1293 --format json init --member-id test-member --name Test --dir /opt/ante-config` exit 0 확인 (CI는 amd64 only이므로 reviewer 환경에서 확인 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)