### PR TITLE
fix(rule): reject invalid Signal.side at OrderRequestEvent preflight (#1297)

### DIFF
--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -397,7 +397,9 @@ class RuleEngine:
         # OrderRequestEvent 계약 preflight: Signal.side 허용값 검증.
         # docs/specs/strategy/03-02-signal-fields.md — side ∈ {"buy", "sell"}.
         # 룰 평가/Treasury 조회 이전에 거부하여 사이드이펙트(예약/주문) 차단.
-        if event.side not in _VALID_ORDER_SIDES:
+        # `isinstance(..., str)` 가드로 list/dict 같은 unhashable 값이 들어와도
+        # frozenset membership 검사가 TypeError를 raise하지 않도록 한다.
+        if not isinstance(event.side, str) or event.side not in _VALID_ORDER_SIDES:
             reason = f"Invalid signal side: {event.side!r} (allowed: buy, sell)"
             await self._eventbus.publish(
                 OrderRejectedEvent(

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -401,6 +401,11 @@ class RuleEngine:
         # frozenset membership 검사가 TypeError를 raise하지 않도록 한다.
         if not isinstance(event.side, str) or event.side not in _VALID_ORDER_SIDES:
             reason = f"Invalid signal side: {event.side!r} (allowed: buy, sell)"
+            # OrderRejectedEvent.side는 TradeRecorder가 sqlite TEXT NOT NULL 컬럼에
+            # 바인딩하므로, 비문자열(list/dict/set/None 등)이 들어올 경우
+            # InterfaceError/NOT NULL 위반으로 거부 audit trail이 깨진다.
+            # repr()로 강제 정규화하여 텍스트 호환성을 보장한다.
+            safe_side = event.side if isinstance(event.side, str) else repr(event.side)
             await self._eventbus.publish(
                 OrderRejectedEvent(
                     account_id=self._account_id,
@@ -408,7 +413,7 @@ class RuleEngine:
                     bot_id=event.bot_id,
                     strategy_id=event.strategy_id,
                     symbol=event.symbol,
-                    side=event.side,
+                    side=safe_side,
                     quantity=event.quantity,
                     price=event.price,
                     order_type=event.order_type,

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -33,6 +33,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Signal.side 허용값 — docs/specs/strategy/03-02-signal-fields.md 기준
+_VALID_ORDER_SIDES: frozenset[str] = frozenset({"buy", "sell"})
+
 # 룰 타입 → 클래스 매핑
 RULE_REGISTRY: dict[str, type[Rule]] = {
     "daily_loss_limit": DailyLossLimitRule,
@@ -389,6 +392,28 @@ class RuleEngine:
 
         # account_id 필터링: 자기 계좌 이벤트만 처리
         if event.account_id != self._account_id:
+            return
+
+        # OrderRequestEvent 계약 preflight: Signal.side 허용값 검증.
+        # docs/specs/strategy/03-02-signal-fields.md — side ∈ {"buy", "sell"}.
+        # 룰 평가/Treasury 조회 이전에 거부하여 사이드이펙트(예약/주문) 차단.
+        if event.side not in _VALID_ORDER_SIDES:
+            reason = f"Invalid signal side: {event.side!r} (allowed: buy, sell)"
+            await self._eventbus.publish(
+                OrderRejectedEvent(
+                    account_id=self._account_id,
+                    order_id=str(event.event_id),
+                    bot_id=event.bot_id,
+                    strategy_id=event.strategy_id,
+                    symbol=event.symbol,
+                    side=event.side,
+                    quantity=event.quantity,
+                    price=event.price,
+                    order_type=event.order_type,
+                    reason=reason,
+                    exchange=event.exchange,
+                )
+            )
             return
 
         # 계좌 상태 조회

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -818,6 +818,9 @@ class TestRuleEngineEventBus:
         assert ev.bot_id == "bot1"
         assert ev.strategy_id == "s1"
         assert ev.symbol == "005930"
+        # OrderRejectedEvent.side는 sqlite TEXT NOT NULL 컬럼에 바인딩되므로
+        # 항상 str이어야 한다. 문자열 입력은 그대로 전파된다.
+        assert isinstance(ev.side, str)
         assert ev.side == "hold"
         assert ev.quantity == 10.0
         assert ev.price == 1000.0
@@ -888,7 +891,11 @@ class TestRuleEngineEventBus:
         assert ev.bot_id == "bot1"
         assert ev.strategy_id == "s1"
         assert ev.symbol == "005930"
-        assert ev.side == bad_side
+        # Codex P2 #2 회귀: 비문자열 side는 TradeRecorder가 sqlite TEXT 컬럼에
+        # 바인딩할 수 없으므로 RuleEngine이 repr()로 정규화해야 한다.
+        # ([] → "[]", None → "None", 등)
+        assert isinstance(ev.side, str)
+        assert ev.side == repr(bad_side)
         assert ev.quantity == 10.0
         assert ev.price == 1000.0
         assert ev.order_type == "limit"

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -762,6 +762,69 @@ class TestRuleEngineEventBus:
             suspended_by="rule_engine",
         )
 
+    async def test_rule_engine_rejects_invalid_signal_side(
+        self, engine, eventbus, monkeypatch
+    ):
+        """side가 buy/sell 외 값이면 룰 평가 이전에 거부한다.
+
+        회귀: A7 oracle이 검출한 버그 — Signal.side='hold' 주문이
+        RuleEngine을 통과해 Treasury 예약/broker 호출까지 진행되던 결함.
+        docs/specs/strategy/03-02-signal-fields.md에 따라 side는
+        "buy" | "sell"만 허용된다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        # evaluate / _query_treasury_data가 호출되지 않아야 한다.
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for invalid side")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError("_query_treasury_data must not run for invalid side")
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="hold",
+            quantity=10.0,
+            order_type="limit",
+            price=1000.0,
+            exchange="KRX",
+            reason="A7 oracle regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Invalid signal side" in ev.reason
+        assert "'hold'" in ev.reason
+        assert ev.account_id == "domestic"
+        assert ev.bot_id == "bot1"
+        assert ev.strategy_id == "s1"
+        assert ev.symbol == "005930"
+        assert ev.side == "hold"
+        assert ev.quantity == 10.0
+        assert ev.price == 1000.0
+        assert ev.order_type == "limit"
+        assert ev.exchange == "KRX"
+        assert ev.order_id == str(order.event_id)
+
 
 # ── RuleEngine.update_rules ──────────────────────
 

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -825,6 +825,76 @@ class TestRuleEngineEventBus:
         assert ev.exchange == "KRX"
         assert ev.order_id == str(order.event_id)
 
+    @pytest.mark.parametrize(
+        "bad_side",
+        [[], {}, ["buy"], {"buy": True}, set(), 123, None],
+        ids=["list-empty", "dict-empty", "list-buy", "dict-buy", "set", "int", "none"],
+    )
+    async def test_rule_engine_rejects_unhashable_signal_side(
+        self, engine, eventbus, monkeypatch, bad_side
+    ):
+        """비문자열(특히 unhashable) side 값도 fail-closed 거부한다.
+
+        Codex P2 회귀: list/dict 같은 unhashable 타입이 ``event.side``로
+        들어오면 ``frozenset`` membership 검사가 ``TypeError: unhashable type``을
+        raise해 ``OrderRejectedEvent``가 발행되지 않고 EventBus가 로그만
+        남기던 결함. ``isinstance(event.side, str)`` 가드로 차단한다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for invalid side")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError("_query_treasury_data must not run for invalid side")
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side=bad_side,  # type: ignore[arg-type]
+            quantity=10.0,
+            order_type="limit",
+            price=1000.0,
+            exchange="KRX",
+            reason="Codex P2 unhashable-side regression",
+        )
+
+        # publish가 TypeError를 leak하지 않고 정상적으로 reject 이벤트를
+        # 발행해야 한다 (fail-closed).
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Invalid signal side" in ev.reason
+        assert repr(bad_side) in ev.reason
+        assert ev.account_id == "domestic"
+        assert ev.bot_id == "bot1"
+        assert ev.strategy_id == "s1"
+        assert ev.symbol == "005930"
+        assert ev.side == bad_side
+        assert ev.quantity == 10.0
+        assert ev.price == 1000.0
+        assert ev.order_type == "limit"
+        assert ev.exchange == "KRX"
+        assert ev.order_id == str(order.event_id)
+
 
 # ── RuleEngine.update_rules ──────────────────────
 


### PR DESCRIPTION
Closes #1297

## Summary
- A7 oracle이 검출한 invalid `Signal.side` 회귀 차단. `RuleEngine._on_order_request`에 OrderRequestEvent 계약 preflight 게이트를 추가해 `side`가 `"buy" | "sell"`이 아니면 룰 평가/Treasury query 진입 전에 `OrderRejectedEvent`로 즉시 거부.
- `_VALID_ORDER_SIDES = frozenset({"buy", "sell"})`로 allow-list 제한.
- 비문자열 `event.side`(list/dict/set/None 등)도 `isinstance(..., str)` 가드로 동일 거부 경로 진입 → `TypeError` leak 방지.
- 거부 이벤트의 `side`는 `repr(event.side)`로 정규화해 `TradeRecorder`의 sqlite `TEXT NOT NULL` 바인딩 깨짐을 방지.

## Test Plan
- [x] `uv run pytest tests/unit/test_rule.py -k "invalid or unhashable or order_request" -x` → 10 passed
- [x] `uv run pytest tests/unit/test_rule.py -x` → 109 passed
- [x] `uv run ruff check src/ante/rule/engine.py tests/unit/test_rule.py` → All checks passed
- [x] `uv run ruff format --check src/ante/rule/engine.py tests/unit/test_rule.py`

## Codex Branch Review
- attempt 1 (`2561834`): FAIL — 비문자열 side에서 frozenset membership TypeError → fail-open
- attempt 2 (`3004b72`): FAIL — 비문자열 `side`가 OrderRejectedEvent에 그대로 실려 TradeRecorder sqlite 바인딩 실패
- attempt 3 (`52836d2`): PASS — fail-closed 동작 + audit trail 정상

## Scope Boundary
- 본 PR은 `Signal.side` 한 필드의 OrderRequestEvent 계약 preflight만 다룬다. `order_type`/`quantity`/`price`/`stop_price`/`symbol` 검증은 #1298–#1305 별도 이슈.
