### PR TITLE
fix(rule): reject invalid Signal.order_type at OrderRequestEvent preflight (#1298)

### DIFF
--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -36,6 +36,13 @@ logger = logging.getLogger(__name__)
 # Signal.side 허용값 — docs/specs/strategy/03-02-signal-fields.md 기준
 _VALID_ORDER_SIDES: frozenset[str] = frozenset({"buy", "sell"})
 
+# Signal.order_type 허용값 — docs/specs/strategy/03-02-signal-fields.md 기준.
+# "trail" 등 미지원 order_type은 broker adapter 단계에서 4건 누적 실패를
+# 일으킨 회귀이므로(#1298), 룰 평가 이전에 fail-closed로 거부한다.
+_VALID_ORDER_TYPES: frozenset[str] = frozenset(
+    {"market", "limit", "stop", "stop_limit"}
+)
+
 # 룰 타입 → 클래스 매핑
 RULE_REGISTRY: dict[str, type[Rule]] = {
     "daily_loss_limit": DailyLossLimitRule,
@@ -401,11 +408,18 @@ class RuleEngine:
         # frozenset membership 검사가 TypeError를 raise하지 않도록 한다.
         if not isinstance(event.side, str) or event.side not in _VALID_ORDER_SIDES:
             reason = f"Invalid signal side: {event.side!r} (allowed: buy, sell)"
-            # OrderRejectedEvent.side는 TradeRecorder가 sqlite TEXT NOT NULL 컬럼에
-            # 바인딩하므로, 비문자열(list/dict/set/None 등)이 들어올 경우
-            # InterfaceError/NOT NULL 위반으로 거부 audit trail이 깨진다.
-            # repr()로 강제 정규화하여 텍스트 호환성을 보장한다.
+            # OrderRejectedEvent.side / .order_type은 TradeRecorder가 sqlite
+            # TEXT NOT NULL 컬럼에 바인딩하므로, 비문자열(list/dict/set/None 등)이
+            # 들어올 경우 InterfaceError/NOT NULL 위반으로 거부 audit trail이
+            # 깨진다. repr()로 강제 정규화하여 텍스트 호환성을 보장한다.
+            # cross-field 보강(#1298): side만 invalid해도 동시에 order_type까지
+            # 비문자열이면 reject 이벤트가 broken되므로 양쪽 모두 정규화한다.
             safe_side = event.side if isinstance(event.side, str) else repr(event.side)
+            safe_order_type = (
+                event.order_type
+                if isinstance(event.order_type, str)
+                else repr(event.order_type)
+            )
             await self._eventbus.publish(
                 OrderRejectedEvent(
                     account_id=self._account_id,
@@ -416,7 +430,43 @@ class RuleEngine:
                     side=safe_side,
                     quantity=event.quantity,
                     price=event.price,
-                    order_type=event.order_type,
+                    order_type=safe_order_type,
+                    reason=reason,
+                    exchange=event.exchange,
+                )
+            )
+            return
+
+        # OrderRequestEvent 계약 preflight: Signal.order_type 허용값 검증.
+        # docs/specs/strategy/03-02-signal-fields.md —
+        # order_type ∈ {"market", "limit", "stop", "stop_limit"}.
+        # 회귀(#1298): order_type="trail" 등 미지원 값이 RuleEngine을 통과해
+        # Treasury 예약 → broker adapter 호출까지 진행되어 broker 실패 4건이
+        # 누적되었다. 룰 평가/Treasury 조회 이전에 fail-closed로 거부한다.
+        if (
+            not isinstance(event.order_type, str)
+            or event.order_type not in _VALID_ORDER_TYPES
+        ):
+            safe_order_type = (
+                event.order_type
+                if isinstance(event.order_type, str)
+                else repr(event.order_type)
+            )
+            reason = (
+                f"Invalid order type: {event.order_type!r} "
+                f"(allowed: market, limit, stop, stop_limit)"
+            )
+            await self._eventbus.publish(
+                OrderRejectedEvent(
+                    account_id=self._account_id,
+                    order_id=str(event.event_id),
+                    bot_id=event.bot_id,
+                    strategy_id=event.strategy_id,
+                    symbol=event.symbol,
+                    side=event.side,
+                    quantity=event.quantity,
+                    price=event.price,
+                    order_type=safe_order_type,
                     reason=reason,
                     exchange=event.exchange,
                 )

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -902,6 +902,209 @@ class TestRuleEngineEventBus:
         assert ev.exchange == "KRX"
         assert ev.order_id == str(order.event_id)
 
+    async def test_rule_engine_rejects_invalid_order_type(
+        self, engine, eventbus, monkeypatch
+    ):
+        """order_type이 허용 집합 외 값이면 룰 평가 이전에 거부한다.
+
+        회귀(#1298): A7 oracle이 검출한 버그 — Signal.order_type='trail' 주문이
+        RuleEngine을 통과해 Treasury 예약 → broker adapter 호출까지 진행되어
+        broker 실패 4건이 누적되었다.
+        docs/specs/strategy/03-02-signal-fields.md에 따라 order_type은
+        "market" | "limit" | "stop" | "stop_limit"만 허용된다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for invalid order_type")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run for invalid order_type"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            order_type="trail",
+            price=1000.0,
+            exchange="KRX",
+            reason="A7 oracle order_type regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Invalid order type" in ev.reason
+        assert "'trail'" in ev.reason
+        assert ev.account_id == "domestic"
+        assert ev.bot_id == "bot1"
+        assert ev.strategy_id == "s1"
+        assert ev.symbol == "005930"
+        assert ev.side == "buy"
+        assert ev.quantity == 10.0
+        assert ev.price == 1000.0
+        # 입력이 정상 문자열인 경우 그대로 전파
+        assert isinstance(ev.order_type, str)
+        assert ev.order_type == "trail"
+        assert ev.exchange == "KRX"
+        assert ev.order_id == str(order.event_id)
+
+    @pytest.mark.parametrize(
+        "bad_order_type",
+        [[], {}, set(), {"limit": True}, 123, None],
+        ids=["list-empty", "dict-empty", "set", "dict-limit", "int", "none"],
+    )
+    async def test_rule_engine_rejects_unhashable_order_type(
+        self, engine, eventbus, monkeypatch, bad_order_type
+    ):
+        """비문자열(특히 unhashable) order_type 값도 fail-closed 거부한다.
+
+        회귀(#1298): list/dict 같은 unhashable 타입이 ``event.order_type``으로
+        들어오면 ``frozenset`` membership 검사가 ``TypeError: unhashable type``을
+        raise해 ``OrderRejectedEvent``가 발행되지 않는다. 또한 sqlite TEXT 컬럼에
+        바인딩되므로 ``OrderRejectedEvent.order_type``은 항상 str로 정규화돼야
+        한다(side 게이트와 동일한 패턴).
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for invalid order_type")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run for invalid order_type"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            order_type=bad_order_type,  # type: ignore[arg-type]
+            price=1000.0,
+            exchange="KRX",
+            reason="Codex P2 unhashable-order-type regression",
+        )
+
+        # publish가 TypeError를 leak하지 않고 정상적으로 reject 이벤트를
+        # 발행해야 한다 (fail-closed).
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Invalid order type" in ev.reason
+        assert repr(bad_order_type) in ev.reason
+        assert ev.account_id == "domestic"
+        assert ev.bot_id == "bot1"
+        assert ev.strategy_id == "s1"
+        assert ev.symbol == "005930"
+        assert ev.side == "buy"
+        assert ev.quantity == 10.0
+        assert ev.price == 1000.0
+        # 비문자열 order_type은 sqlite TEXT 컬럼에 바인딩할 수 없으므로
+        # RuleEngine이 repr()로 정규화해야 한다 ([] → "[]", None → "None", 등).
+        assert isinstance(ev.order_type, str)
+        assert ev.order_type == repr(bad_order_type)
+        assert ev.exchange == "KRX"
+        assert ev.order_id == str(order.event_id)
+
+    async def test_rule_engine_rejects_cross_field_invalid_payload(
+        self, engine, eventbus, monkeypatch
+    ):
+        """side와 order_type이 동시에 비문자열이어도 reject 이벤트가 깨지지 않는다.
+
+        회귀(#1298 cross-field 보강): #1306 invalid-side 게이트가 먼저 fire하지만,
+        이때 ``OrderRejectedEvent.order_type``을 정규화하지 않으면 sqlite TEXT
+        바인딩이 실패해 audit trail이 깨진다. 두 필드 모두 ``repr()``로 정규화돼
+        ``str``로 발행돼야 한다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for invalid payload")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run for invalid payload"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side=[],  # type: ignore[arg-type]
+            quantity=10.0,
+            order_type=[],  # type: ignore[arg-type]
+            price=1000.0,
+            exchange="KRX",
+            reason="Cross-field invalid payload regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        # invalid-side 게이트가 먼저 fire한다.
+        assert "Invalid signal side" in ev.reason
+        # 두 필드 모두 sqlite TEXT 바인딩 가능한 str이어야 한다.
+        assert isinstance(ev.side, str)
+        assert ev.side == repr([])  # "[]"
+        # cross-field 보강 회귀 잠금: order_type도 정규화돼야 한다.
+        assert isinstance(ev.order_type, str)
+        assert ev.order_type == repr([])  # "[]"
+
 
 # ── RuleEngine.update_rules ──────────────────────
 


### PR DESCRIPTION
Closes #1298

## Summary
- A7 oracle이 검출한 unsupported `Signal.order_type` 회귀 차단. `RuleEngine._on_order_request`의 invalid-side 게이트 직후에 OrderRequestEvent 계약 preflight 게이트를 추가해 `order_type`이 `"market" | "limit" | "stop" | "stop_limit"`이 아니면 룰 평가/Treasury query 진입 전에 `OrderRejectedEvent`로 즉시 거부.
- `_VALID_ORDER_TYPES = frozenset({"market", "limit", "stop", "stop_limit"})` allow-list 도입.
- 비문자열 `event.order_type`(list/dict/set/None 등)도 `isinstance(..., str)` 가드로 동일 거부 경로 진입 → `TypeError` leak 방지. 거부 이벤트의 `order_type`은 `repr(event.order_type)`으로 정규화해 TradeRecorder의 sqlite TEXT 바인딩 호환 보장.
- **#1306 cross-field 보강**: invalid-side 게이트의 `OrderRejectedEvent.order_type`도 `safe_order_type`로 정규화. `side=[]` AND `order_type=[]` 같은 동시 비문자열 payload에서 side reject 경로의 sqlite 바인딩 깨짐을 방지.

## Test Plan
- [x] `uv run pytest tests/unit/test_rule.py -k "invalid or unhashable or order_request or order_type or cross_field" -x` → 18 passed
- [x] `uv run pytest tests/unit/test_rule.py -x` → 117 passed
- [x] `uv run ruff check src/ante/rule/engine.py tests/unit/test_rule.py`
- [x] `uv run ruff format --check src/ante/rule/engine.py tests/unit/test_rule.py`

## Codex Branch Review
- attempt 1 (`fcd9d80`): PASS — "검토 범위에서 기존 흐름을 깨는 명확한 회귀는 발견되지 않았습니다."

## Scope Boundary
- 본 PR은 `Signal.order_type` 한 필드의 OrderRequestEvent 계약 preflight + #1306 cross-field 보강만 다룬다. `quantity`/`price`/`stop_price`/`symbol` 검증은 #1300–#1305 별도 이슈.
