### PR TITLE
fix(rule): reject invalid KRX numeric symbol at OrderRequestEvent preflight (#1299)

### DIFF
--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -42,6 +43,14 @@ _VALID_ORDER_SIDES: frozenset[str] = frozenset({"buy", "sell"})
 _VALID_ORDER_TYPES: frozenset[str] = frozenset(
     {"market", "limit", "stop", "stop_limit"}
 )
+
+# 현재 Ante KIS-domestic contract: 6자리 숫자 PDNO. KRX 전체 단축코드 SSOT 아님.
+# docs/specs/data-feed/04-schema.md 와
+# docs/specs/broker-adapter/08-kis-domestic-adapter.md 기준으로 KRX 주문 경로는
+# 6자리 numeric 단축코드를 가정한다. "INVALID" 같은 비수치 symbol이 RuleEngine을
+# 통과하면 KIS 40070000(매매불가 종목)을 유발하므로(#1299 A7 oracle 회귀), 룰 평가
+# 이전에 fail-closed로 거부한다.
+_KRX_NUMERIC_SYMBOL_PATTERN = re.compile(r"^[0-9]{6}$")
 
 # 룰 타입 → 클래스 매핑
 RULE_REGISTRY: dict[str, type[Rule]] = {
@@ -408,17 +417,21 @@ class RuleEngine:
         # frozenset membership 검사가 TypeError를 raise하지 않도록 한다.
         if not isinstance(event.side, str) or event.side not in _VALID_ORDER_SIDES:
             reason = f"Invalid signal side: {event.side!r} (allowed: buy, sell)"
-            # OrderRejectedEvent.side / .order_type은 TradeRecorder가 sqlite
-            # TEXT NOT NULL 컬럼에 바인딩하므로, 비문자열(list/dict/set/None 등)이
-            # 들어올 경우 InterfaceError/NOT NULL 위반으로 거부 audit trail이
+            # OrderRejectedEvent.side / .order_type / .symbol은 TradeRecorder가
+            # sqlite TEXT NOT NULL 컬럼에 바인딩하므로, 비문자열(list/dict/set/None
+            # 등)이 들어올 경우 InterfaceError/NOT NULL 위반으로 거부 audit trail이
             # 깨진다. repr()로 강제 정규화하여 텍스트 호환성을 보장한다.
-            # cross-field 보강(#1298): side만 invalid해도 동시에 order_type까지
-            # 비문자열이면 reject 이벤트가 broken되므로 양쪽 모두 정규화한다.
+            # cross-field 보강(#1298/#1299): side만 invalid해도 동시에 order_type
+            # 또는 symbol까지 비문자열이면 reject 이벤트가 broken되므로 세 필드
+            # 모두 정규화한다.
             safe_side = event.side if isinstance(event.side, str) else repr(event.side)
             safe_order_type = (
                 event.order_type
                 if isinstance(event.order_type, str)
                 else repr(event.order_type)
+            )
+            safe_symbol = (
+                event.symbol if isinstance(event.symbol, str) else repr(event.symbol)
             )
             await self._eventbus.publish(
                 OrderRejectedEvent(
@@ -426,7 +439,7 @@ class RuleEngine:
                     order_id=str(event.event_id),
                     bot_id=event.bot_id,
                     strategy_id=event.strategy_id,
-                    symbol=event.symbol,
+                    symbol=safe_symbol,
                     side=safe_side,
                     quantity=event.quantity,
                     price=event.price,
@@ -452,6 +465,11 @@ class RuleEngine:
                 if isinstance(event.order_type, str)
                 else repr(event.order_type)
             )
+            # cross-field 보강(#1299): symbol도 sqlite TEXT 컬럼에 바인딩되므로
+            # 비문자열이면 repr()로 정규화한다.
+            safe_symbol = (
+                event.symbol if isinstance(event.symbol, str) else repr(event.symbol)
+            )
             reason = (
                 f"Invalid order type: {event.order_type!r} "
                 f"(allowed: market, limit, stop, stop_limit)"
@@ -462,11 +480,46 @@ class RuleEngine:
                     order_id=str(event.event_id),
                     bot_id=event.bot_id,
                     strategy_id=event.strategy_id,
-                    symbol=event.symbol,
+                    symbol=safe_symbol,
                     side=event.side,
                     quantity=event.quantity,
                     price=event.price,
                     order_type=safe_order_type,
+                    reason=reason,
+                    exchange=event.exchange,
+                )
+            )
+            return
+
+        # OrderRequestEvent 계약 preflight: KRX numeric symbol 검증.
+        # 회귀(#1299): A7 oracle이 검출한 버그 — Signal.symbol="INVALID",
+        # exchange="KRX" 주문이 RuleEngine→Treasury→broker까지 진행되어
+        # KIS 40070000(매매불가 종목)이 발생했다. 현재 Ante KIS-domestic 경로는
+        # 6자리 숫자 PDNO(예: "005930", "069500")만 가정하므로, 그 형식을
+        # 만족하지 않는 KRX symbol은 룰 평가/Treasury 조회 이전에 fail-closed로
+        # 거부한다. 비-KRX exchange는 broker adapter에 위임한다.
+        if event.exchange == "KRX" and (
+            not isinstance(event.symbol, str)
+            or not _KRX_NUMERIC_SYMBOL_PATTERN.fullmatch(event.symbol)
+        ):
+            safe_symbol = (
+                event.symbol if isinstance(event.symbol, str) else repr(event.symbol)
+            )
+            reason = (
+                f"Invalid KRX numeric symbol: {event.symbol!r} "
+                f"(expected 6-digit numeric per current Ante KIS-domestic contract)"
+            )
+            await self._eventbus.publish(
+                OrderRejectedEvent(
+                    account_id=self._account_id,
+                    order_id=str(event.event_id),
+                    bot_id=event.bot_id,
+                    strategy_id=event.strategy_id,
+                    symbol=safe_symbol,
+                    side=event.side,
+                    quantity=event.quantity,
+                    price=event.price,
+                    order_type=event.order_type,
                     reason=reason,
                     exchange=event.exchange,
                 )

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -1105,6 +1105,305 @@ class TestRuleEngineEventBus:
         assert isinstance(ev.order_type, str)
         assert ev.order_type == repr([])  # "[]"
 
+    async def test_rule_engine_rejects_cross_field_invalid_symbol_payload(
+        self, engine, eventbus, monkeypatch
+    ):
+        """side·order_type·symbol이 동시에 비문자열이어도 reject 이벤트가 깨지지 않는다.
+
+        회귀(#1299 cross-field 보강): invalid-side 게이트가 먼저 fire하지만,
+        ``OrderRejectedEvent.symbol``을 정규화하지 않으면 sqlite TEXT 컬럼 바인딩이
+        실패해 audit trail이 깨진다. 세 필드 모두 ``repr()``로 정규화돼 ``str``로
+        발행돼야 한다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for invalid payload")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run for invalid payload"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol=[],  # type: ignore[arg-type]
+            side=[],  # type: ignore[arg-type]
+            quantity=10.0,
+            order_type=[],  # type: ignore[arg-type]
+            price=1000.0,
+            exchange="KRX",
+            reason="Cross-field invalid symbol payload regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        # invalid-side 게이트가 먼저 fire한다 (symbol 게이트보다 우선).
+        assert "Invalid signal side" in ev.reason
+        # 세 필드 모두 sqlite TEXT 바인딩 가능한 str이어야 한다.
+        assert isinstance(ev.side, str)
+        assert ev.side == repr([])  # "[]"
+        assert isinstance(ev.order_type, str)
+        assert ev.order_type == repr([])  # "[]"
+        # #1299 cross-field 회귀 잠금: symbol도 repr()로 정규화돼야 한다.
+        assert isinstance(ev.symbol, str)
+        assert ev.symbol == repr([])  # "[]"
+
+    async def test_rule_engine_rejects_invalid_krx_numeric_symbol(
+        self, engine, eventbus, monkeypatch
+    ):
+        """exchange='KRX'에서 6자리 숫자가 아닌 symbol은 룰 평가 이전에 거부한다.
+
+        회귀(#1299): A7 oracle이 검출한 버그 — Signal.symbol='INVALID',
+        exchange='KRX' 주문이 RuleEngine→Treasury→broker까지 진행되어
+        KIS 40070000(매매불가 종목)이 발생했다. 현재 Ante KIS-domestic 경로는
+        6자리 숫자 PDNO만 가정하므로, 그 형식을 만족하지 않는 KRX symbol은
+        fail-closed로 거부한다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for invalid KRX symbol")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run for invalid KRX symbol"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="INVALID",
+            side="buy",
+            quantity=10.0,
+            order_type="limit",
+            price=1000.0,
+            exchange="KRX",
+            reason="A7 oracle KRX symbol regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Invalid KRX numeric symbol" in ev.reason
+        assert "'INVALID'" in ev.reason
+        assert ev.account_id == "domestic"
+        assert ev.bot_id == "bot1"
+        assert ev.strategy_id == "s1"
+        assert isinstance(ev.symbol, str)
+        assert ev.symbol == "INVALID"
+        assert ev.side == "buy"
+        assert ev.quantity == 10.0
+        assert ev.price == 1000.0
+        assert ev.order_type == "limit"
+        assert ev.exchange == "KRX"
+        assert ev.order_id == str(order.event_id)
+
+    @pytest.mark.parametrize(
+        "bad_symbol",
+        ["12345", "1234567", "05A123", ""],
+        ids=["too-short", "too-long", "alpha-mixed", "empty"],
+    )
+    async def test_rule_engine_rejects_short_or_long_krx_numeric_symbol(
+        self, engine, eventbus, monkeypatch, bad_symbol
+    ):
+        """6자리 숫자가 아닌 KRX symbol은 모두 거부한다 (5자리/7자리/혼용/빈문자열)."""
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for invalid KRX symbol")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run for invalid KRX symbol"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol=bad_symbol,
+            side="buy",
+            quantity=10.0,
+            order_type="limit",
+            price=1000.0,
+            exchange="KRX",
+            reason="A7 oracle KRX symbol shape regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Invalid KRX numeric symbol" in ev.reason
+        assert isinstance(ev.symbol, str)
+        assert ev.symbol == bad_symbol
+        assert ev.exchange == "KRX"
+
+    async def test_rule_engine_accepts_valid_krx_numeric_symbol(self, engine, eventbus):
+        """6자리 숫자 KRX symbol은 형식 게이트를 통과해 룰 평가 흐름에 진입한다."""
+        validated: list[OrderValidatedEvent] = []
+        rejected: list[OrderRejectedEvent] = []
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="069500",  # KODEX 200 ETF
+            side="buy",
+            quantity=10.0,
+            order_type="limit",
+            price=30000.0,
+            exchange="KRX",
+            reason="valid KRX numeric symbol",
+        )
+        await eventbus.publish(order)
+
+        # 형식 게이트는 통과해야 하므로 KRX-symbol reason의 reject은 없어야 한다.
+        # (룰이 비어있으므로 OrderValidatedEvent가 발행돼야 한다.)
+        assert len(rejected) == 0
+        assert len(validated) == 1
+        assert validated[0].symbol == "069500"
+        assert validated[0].order_id == str(order.event_id)
+
+    @pytest.mark.parametrize(
+        "bad_symbol",
+        [[], {}, set(), 123, None],
+        ids=["list", "dict", "set", "int", "none"],
+    )
+    async def test_rule_engine_rejects_unhashable_krx_symbol(
+        self, engine, eventbus, monkeypatch, bad_symbol
+    ):
+        """비문자열 KRX symbol(unhashable 포함)도 fail-closed 거부 + repr() 정규화."""
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for invalid KRX symbol")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run for invalid KRX symbol"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol=bad_symbol,  # type: ignore[arg-type]
+            side="buy",
+            quantity=10.0,
+            order_type="limit",
+            price=1000.0,
+            exchange="KRX",
+            reason="Codex P2 unhashable-symbol regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Invalid KRX numeric symbol" in ev.reason
+        # OrderRejectedEvent.symbol은 sqlite TEXT NOT NULL 컬럼에 바인딩되므로
+        # 항상 str로 정규화돼야 한다 (#1299 cross-field 보강).
+        assert isinstance(ev.symbol, str)
+        assert ev.symbol == repr(bad_symbol)
+        assert ev.exchange == "KRX"
+
+    async def test_rule_engine_skips_symbol_check_for_non_krx_exchange(
+        self, engine, eventbus
+    ):
+        """비-KRX exchange는 symbol 형식 게이트를 스킵하고 broker adapter에 위임한다."""
+        validated: list[OrderValidatedEvent] = []
+        rejected: list[OrderRejectedEvent] = []
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+
+        # 다른 account_id로 보내면 _on_order_request 핸들러가 즉시 return하므로,
+        # 같은 account_id="domestic"으로 NASDAQ exchange 주문을 보낸다.
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="AAPL",  # 비-숫자, KRX였다면 거부됐을 것
+            side="buy",
+            quantity=10.0,
+            order_type="limit",
+            price=150.0,
+            exchange="NASDAQ",
+            reason="non-KRX exchange should bypass symbol gate",
+        )
+        await eventbus.publish(order)
+
+        # KRX symbol 게이트가 스킵되므로 형식 reject은 없어야 한다.
+        # (룰이 비어있으므로 룰 평가 후 OrderValidatedEvent가 발행돼야 한다.)
+        assert len(rejected) == 0
+        assert len(validated) == 1
+        assert validated[0].symbol == "AAPL"
+
 
 # ── RuleEngine.update_rules ──────────────────────
 


### PR DESCRIPTION
Closes #1299

## Summary
- A7 oracle이 검출한 invalid KRX 종목 코드 회귀 차단. `RuleEngine._on_order_request`의 invalid-order_type 게이트 직후에 KRX numeric symbol 형식 preflight를 추가해 `exchange="KRX"`이고 `symbol`이 6자리 숫자가 아니면 룰 평가/Treasury query 진입 전에 `OrderRejectedEvent`로 즉시 거부.
- `_KRX_NUMERIC_SYMBOL_PATTERN = re.compile(r"^[0-9]{6}$")` 도입. **본 PR은 KRX 전체 단축코드 SSOT 아님** — 현재 Ante KIS-domestic contract가 가정하는 6자리 숫자 PDNO 형식만 잠근다.
- 비-KRX exchange는 broker adapter에 위임. 빈/비정상 exchange는 별도 invalid-exchange 이슈로 분리.
- 비문자열 symbol(list/dict/set/None 등)도 `isinstance(..., str)` 가드로 동일 거부 경로 진입 → `TypeError` leak 방지. rejection event의 `symbol`은 `repr(event.symbol)`로 정규화해 TradeRecorder의 sqlite TEXT NOT NULL 바인딩 호환 보장.
- **#1306/#1307 cross-field 보강**: invalid-side/invalid-order_type 게이트의 `OrderRejectedEvent.symbol`도 `safe_symbol`로 정규화. 동시-비문자열 payload에서 audit trail 호환 보장.

## Test Plan
- [x] `uv run pytest tests/unit/test_rule.py -k "invalid or unhashable or order_request or symbol or cross_field" -x` → 32 passed
- [x] `uv run pytest tests/unit/test_rule.py -x` → 130 passed
- [x] `uv run ruff check src/ante/rule/engine.py tests/unit/test_rule.py`
- [x] `uv run ruff format --check src/ante/rule/engine.py tests/unit/test_rule.py`

## Codex Branch Review
- attempt 1 (`b9dae9c`): PASS — "패치가 의도한 KRX symbol fail-closed 동작을 깨뜨리는 신규 correctness 문제를 발견하지 못했습니다."

## Residual Risk (이슈 본문 v2 명시)
- `existence-gap`: 6자리 숫자지만 `instrument` 마스터 미등록/매매불가 종목은 본 PR에서 reject되지 않고 broker `40070000`으로 진행될 수 있음. 마스터 존재 검증은 별도 이슈.
- `exchange-bypass`: 빈 exchange/비정상 exchange는 게이트 우회 가능. 별도 invalid-exchange 이슈로 분리.
- `krx-code-system-drift`: 2024 이후 KRX alphanumeric 단축코드 개편은 본 PR에서 따라가지 않음. 공식 지원 결정 시 정규식 재설계 필요.

## Scope Boundary
- 본 PR은 `Signal.symbol` 형식 preflight + #1306/#1307 cross-field 보강만 다룬다. `quantity`/`price`/`stop_price` 검증은 #1300–#1305 별도 이슈.
