### PR TITLE
fix(rule): require stop_price for stop/stop_limit at OrderRequestEvent preflight (#1301)

### DIFF
--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -561,6 +561,42 @@ class RuleEngine:
             )
             return
 
+        # OrderRequestEvent 계약 preflight: stop / stop_limit stop_price 필수.
+        # 회귀(#1301): A7 oracle이 검출한 버그 — order_type="stop", side="sell",
+        # stop_price=None 주문이 RuleEngine→OrderApproved→StopOrderRegistered까지
+        # 진행되어 terminal event(체결/거부)가 누락되었다. stop / stop_limit는
+        # 트리거 가격(stop_price) 지정이 invariant이므로, stop_price=None이면
+        # 룰 평가/Treasury 조회 이전에 fail-closed로 거부한다. OrderRejectedEvent
+        # 스키마에 stop_price 필드가 없으므로 reason 문자열에만 명시한다.
+        # 0/음수/NaN stop_price 검증은 본 PR 범위 밖(별도 후속 이슈)이다.
+        if event.order_type in ("stop", "stop_limit") and event.stop_price is None:
+            reason = (
+                f"Missing stop_price for {event.order_type} order: "
+                f"stop_price is required for stop and stop_limit orders"
+            )
+            # symbol은 sqlite TEXT 컬럼에 바인딩되므로 비문자열이면 repr()로
+            # 정규화한다. side / order_type은 본 게이트 도달 시점에 위 게이트들에서
+            # 이미 문자열로 잠겼다.
+            safe_symbol = (
+                event.symbol if isinstance(event.symbol, str) else repr(event.symbol)
+            )
+            await self._eventbus.publish(
+                OrderRejectedEvent(
+                    account_id=self._account_id,
+                    order_id=str(event.event_id),
+                    bot_id=event.bot_id,
+                    strategy_id=event.strategy_id,
+                    symbol=safe_symbol,
+                    side=event.side,
+                    quantity=event.quantity,
+                    price=event.price,
+                    order_type=event.order_type,
+                    reason=reason,
+                    exchange=event.exchange,
+                )
+            )
+            return
+
         # 계좌 상태 조회
         account_status = "active"
         currency = "KRW"

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -1591,6 +1591,289 @@ class TestRuleEngineEventBus:
         assert validated[0].order_type == "limit"
         assert validated[0].price == 1000.0
 
+    @pytest.mark.parametrize("side", ["buy", "sell"])
+    async def test_rule_engine_rejects_stop_order_without_stop_price(
+        self, engine, eventbus, monkeypatch, side
+    ):
+        """order_type='stop'이고 stop_price=None이면 룰 평가 이전에 거부한다.
+
+        회귀(#1301): A7 oracle이 검출한 버그 — Signal.order_type='stop',
+        side='sell', stop_price=None 주문이 RuleEngine→OrderApproved→
+        StopOrderRegistered까지 진행되어 terminal event가 누락되었다.
+        stop은 트리거 가격(stop_price) 지정이 invariant이므로 fail-closed로
+        거부한다. side='buy'/'sell' 양쪽에서 동일하게 동작해야 한다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError(
+                "evaluate must not run for stop order without stop_price"
+            )
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run for stop order without stop_price"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side=side,
+            quantity=10.0,
+            order_type="stop",
+            price=None,
+            stop_price=None,
+            exchange="KRX",
+            reason="A7 oracle stop-without-stop_price regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Missing stop_price" in ev.reason
+        assert "stop" in ev.reason
+        assert ev.account_id == "domestic"
+        assert ev.bot_id == "bot1"
+        assert ev.strategy_id == "s1"
+        assert ev.symbol == "005930"
+        assert ev.side == side
+        assert ev.quantity == 10.0
+        assert ev.order_type == "stop"
+        assert ev.exchange == "KRX"
+        assert ev.order_id == str(order.event_id)
+
+    async def test_rule_engine_rejects_stop_limit_order_without_stop_price(
+        self, engine, eventbus, monkeypatch
+    ):
+        """order_type='stop_limit'이고 stop_price=None이면 룰 평가 이전에 거부한다.
+
+        회귀(#1301): stop_limit도 트리거 가격 지정이 invariant이므로 stop와
+        동일하게 fail-closed로 거부한다. price는 지정되어 있어 #1300 price
+        게이트는 통과하지만, stop_price=None이면 본 게이트에서 거부된다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError(
+                "evaluate must not run for stop_limit order without stop_price"
+            )
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run for stop_limit order "
+                "without stop_price"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop_limit",
+            price=1000.0,
+            stop_price=None,
+            exchange="KRX",
+            reason="A7 oracle stop_limit-without-stop_price regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Missing stop_price" in ev.reason
+        assert "stop_limit" in ev.reason
+        assert ev.symbol == "005930"
+        assert ev.side == "sell"
+        assert ev.order_type == "stop_limit"
+        assert ev.price == 1000.0
+        assert ev.exchange == "KRX"
+
+    async def test_rule_engine_accepts_stop_order_with_stop_price(
+        self, engine, eventbus
+    ):
+        """order_type='stop'이고 stop_price가 지정되면 본 게이트를 통과한다."""
+        validated: list[OrderValidatedEvent] = []
+        rejected: list[OrderRejectedEvent] = []
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop",
+            price=None,
+            stop_price=950.0,
+            exchange="KRX",
+            reason="stop with stop_price should pass gate",
+        )
+        await eventbus.publish(order)
+
+        assert len(rejected) == 0
+        assert len(validated) == 1
+        assert validated[0].symbol == "005930"
+        assert validated[0].order_type == "stop"
+        assert validated[0].stop_price == 950.0
+
+    async def test_rule_engine_accepts_market_order_without_stop_price(
+        self, engine, eventbus
+    ):
+        """order_type='market'이고 stop_price=None이면 본 게이트는 통과한다.
+
+        market은 stop_price 게이트 대상이 아니므로 영향이 없어야 한다.
+        """
+        validated: list[OrderValidatedEvent] = []
+        rejected: list[OrderRejectedEvent] = []
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            order_type="market",
+            price=None,
+            stop_price=None,
+            exchange="KRX",
+            reason="market without stop_price should pass stop_price gate",
+        )
+        await eventbus.publish(order)
+
+        assert len(rejected) == 0
+        assert len(validated) == 1
+        assert validated[0].order_type == "market"
+        assert validated[0].stop_price is None
+
+    async def test_rule_engine_accepts_limit_order_without_stop_price(
+        self, engine, eventbus
+    ):
+        """order_type='limit'이고 stop_price=None이면 본 게이트는 통과한다.
+
+        limit은 stop_price 게이트 대상이 아니므로 영향이 없어야 한다.
+        price만 지정되어 있으면 #1300 price 게이트도 통과해 OrderValidatedEvent가
+        발행된다.
+        """
+        validated: list[OrderValidatedEvent] = []
+        rejected: list[OrderRejectedEvent] = []
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            order_type="limit",
+            price=1000.0,
+            stop_price=None,
+            exchange="KRX",
+            reason="limit without stop_price should pass stop_price gate",
+        )
+        await eventbus.publish(order)
+
+        assert len(rejected) == 0
+        assert len(validated) == 1
+        assert validated[0].order_type == "limit"
+        assert validated[0].price == 1000.0
+        assert validated[0].stop_price is None
+
+    async def test_rule_engine_stop_limit_price_gate_fires_before_stop_price_gate(
+        self, engine, eventbus, monkeypatch
+    ):
+        """stop_limit + price=None + stop_price=None이면 #1300 price 게이트가 우선 fire.
+
+        preflight 체인 우선순위 잠금: limit/stop_limit price 게이트(#1300)가
+        stop/stop_limit stop_price 게이트(#1301)보다 위에 위치해야 한다.
+        reason에 'Missing price'가 포함되고 'Missing stop_price'는 미포함이어야 한다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run when price gate fires")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run when price gate fires"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="sell",
+            quantity=10.0,
+            order_type="stop_limit",
+            price=None,
+            stop_price=None,
+            exchange="KRX",
+            reason="stop_limit missing both price and stop_price",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        # price 게이트(#1300)가 우선 fire — stop_price 게이트보다 먼저 거부
+        assert "Missing price" in ev.reason
+        assert "Missing stop_price" not in ev.reason
+        assert ev.order_type == "stop_limit"
+
 
 # ── RuleEngine.update_rules ──────────────────────
 


### PR DESCRIPTION
Closes #1301

## Summary
- A7 oracle이 검출한 stop 주문 `stop_price=None` 회귀 차단. `RuleEngine._on_order_request`의 limit/stop_limit price 게이트(#1300) 직후에 stop/stop_limit `stop_price` 필수 게이트 추가. `event.order_type in ("stop", "stop_limit") and event.stop_price is None`이면 룰 평가/Treasury query 진입 전에 `OrderRejectedEvent`로 즉시 거부.
- reason: `Missing stop_price for {order_type} order: stop_price is required for stop and stop_limit orders`.
- `OrderRejectedEvent` 스키마에 `stop_price` 필드 없음 → reason에만 명시.
- `safe_symbol`만 정규화 (side/order_type은 이전 게이트가 잠금).
- preflight 체인 우선순위 잠금: `stop_limit + price=None + stop_price=None`이면 #1300 price 게이트가 우선 fire.

## Test Plan
- [x] `uv run pytest tests/unit/test_rule.py -k "stop_order or stop_limit_order or stop_price or order_request" -x` → 9 passed
- [x] `uv run pytest tests/unit/test_rule.py -x` → 142 passed
- [x] `uv run ruff check src/ante/rule/engine.py tests/unit/test_rule.py`
- [x] `uv run ruff format --check src/ante/rule/engine.py tests/unit/test_rule.py`

## Codex Branch Review
- attempt 1 (`2a19ff8`): PASS

## Scope Boundary
- 본 PR은 `event.stop_price is None` 누락만. 0/음수/NaN stop_price는 별도 후속. market+stop_price=950 같은 extra field는 본 PR 비대상. quantity 검증은 #1302/#1304/#1305.
- residual risk: `gateway/gateway.py:274`의 `event.stop_price or 0.0`은 별도 hardening 후보 — 본 PR은 RuleEngine preflight로 도달 차단만.
