### PR TITLE
fix(rule): reject NaN/inf/non-number quantity + safe reject builder (#1302)

### DIFF
--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -92,6 +92,37 @@ def _coerce_finite_quantity(value: object) -> float:
     return float(value)
 
 
+def _coerce_finite_optional_price(value: object) -> float | None:
+    """``OrderRejectedEvent.price`` payload용 안전한 ``float | None`` 정규화.
+
+    회귀(#1302 P2 #4): 본 PR 이전에는 ``_build_safe_rejected_event``가
+    ``price=getattr(event, "price", None)``로 원본 값을 그대로 전파했다.
+    ``price=float("nan")`` / ``inf``, 또는 ``list``/``dict``/``str``/``bool``
+    같은 비-number truthy 값이 들어오면 ``TradeRecorder``의 ``event.price or
+    0.0`` 처리(NaN과 비빈 list는 truthy)에서 그대로 sqlite ``trades.price
+    REAL`` 컬럼에 bind 시도되어 ``InterfaceError`` 또는 NaN 저장을 유발해
+    PnL 계산이 깨지고, 본 PR이 보장하려는 reject audit trail도 깨진다.
+
+    ``None``은 그대로 통과시킨다 — market 주문 등 정상 흐름에서 ``price=None``
+    이 유효하므로, invalid 케이스도 ``None``으로 떨어뜨려 ``trades.price``
+    컬럼(nullable)과 호환을 유지한다. finite numeric은 ``float``로 보존하여
+    정상 reject payload를 깨뜨리지 않는다.
+
+    ``OrderRejectedEvent.stop_price`` 필드는 스키마에 존재하지 않고 builder도
+    싣지 않으므로 본 helper의 cover 범위 밖이다 (#1301 plan 확인).
+    """
+    if value is None:
+        return None
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    try:
+        if not math.isfinite(value):
+            return None
+    except (OverflowError, ValueError, TypeError):
+        return None
+    return float(value)
+
+
 def _safe_str(value: object) -> str:
     """sqlite ``TEXT`` 컬럼 바인딩용 안전한 ``str`` 정규화.
 
@@ -169,7 +200,10 @@ def _build_safe_rejected_event(
       ``exchange``: ``_safe_str``로 정규화 (sqlite ``TEXT`` 컬럼 호환).
     - ``quantity``: ``_coerce_finite_quantity``로 finite ``float`` 정규화
       (NaN/inf/비-number/large-int 모두 0.0).
-    - ``price``: ``None`` 허용 (게이트 통과 후 limit/stop_limit 외에는 nullable).
+    - ``price``: ``_coerce_finite_optional_price``로 finite ``float | None``
+      정규화 (NaN/inf/비-number/large-int 모두 ``None``). ``trades.price``
+      sqlite REAL 컬럼(nullable) 호환 + ``TradeRecorder``의 ``event.price
+      or 0.0`` 처리에서도 NaN/비-number bind를 차단한다 (#1302 P2 #4).
     - ``order_id``: ``getattr``+``_safe_str`` (``event_id``가 없거나 raise하는
       pathological 상황 대응).
     - ``reason``: 호출자가 미리 만든 문자열. 호출자도 ``_safe_str`` 사용 권장.
@@ -184,7 +218,7 @@ def _build_safe_rejected_event(
         symbol=_safe_str(getattr(event, "symbol", "")),
         side=_safe_str(getattr(event, "side", "")),
         quantity=_coerce_finite_quantity(getattr(event, "quantity", 0.0)),
-        price=getattr(event, "price", None),
+        price=_coerce_finite_optional_price(getattr(event, "price", None)),
         order_type=_safe_str(getattr(event, "order_type", "")),
         reason=reason,
         exchange=_safe_str(getattr(event, "exchange", "KRX")),

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
@@ -589,6 +590,55 @@ class RuleEngine:
                     symbol=safe_symbol,
                     side=event.side,
                     quantity=event.quantity,
+                    price=event.price,
+                    order_type=event.order_type,
+                    reason=reason,
+                    exchange=event.exchange,
+                )
+            )
+            return
+
+        # OrderRequestEvent 계약 preflight: quantity는 finite number여야 한다.
+        # 회귀(#1302): A7 oracle이 검출한 버그 — Signal.quantity=NaN, side='buy',
+        # order_type='limit', price=1000 주문이 RuleEngine→OrderValidatedEvent→
+        # Treasury 진입 후 sqlite `bot_budgets.available NOT NULL` 위반으로 실패했다.
+        # NaN/inf/non-number quantity는 Treasury 예약/주문 호출 이전에 fail-closed
+        # 로 거부한다. 0/음수 quantity, NaN price 검증은 본 PR 범위 밖
+        # (#1304/#1305/#1303)이다.
+        # bool은 isinstance(True, int)==True이므로 명시적으로 제외한다.
+        # math.isnan/isinf는 numeric type 확인 뒤에만 호출 (가드 순서 중요).
+        if (
+            not isinstance(event.quantity, (int, float))
+            or isinstance(event.quantity, bool)
+            or math.isnan(event.quantity)
+            or math.isinf(event.quantity)
+        ):
+            reason = (
+                f"Invalid quantity: {event.quantity!r} "
+                f"(quantity must be a finite number)"
+            )
+            safe_symbol = (
+                event.symbol if isinstance(event.symbol, str) else repr(event.symbol)
+            )
+            # OrderRejectedEvent.quantity는 trades.quantity REAL NOT NULL로
+            # 이어지므로 NaN/inf/비-number는 0.0으로 정규화해 audit/PnL 호환을
+            # 유지한다.
+            safe_quantity = (
+                event.quantity
+                if isinstance(event.quantity, (int, float))
+                and not isinstance(event.quantity, bool)
+                and math.isfinite(event.quantity)
+                else 0.0
+            )
+            await self._eventbus.publish(
+                OrderRejectedEvent(
+                    account_id=self._account_id,
+                    order_id=str(event.event_id),
+                    bot_id=event.bot_id,
+                    strategy_id=event.strategy_id,
+                    symbol=safe_symbol,
+                    side=event.side,
+                    quantity=safe_quantity,
                     price=event.price,
                     order_type=event.order_type,
                     reason=reason,

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -62,7 +62,8 @@ def _is_finite_quantity(value: object) -> bool:
     ``math.isfinite`` 호출 시 ``float(value)`` 변환에서
     ``OverflowError`` (또는 ``ValueError``/``TypeError``)를 던진다 (#1302 P2).
     이때도 finite-호환이 아니므로 ``False``로 떨어뜨려 호출부가
-    fail-closed reject 경로로 빠지게 한다.
+    fail-closed reject 경로로 빠지게 한다. helper 자체가 절대 raise하지 않는
+    invariant를 유지하여 outer try 유무와 관계없이 정상 동작을 보장한다.
 
     ``isinstance(True, int) == True`` 이므로 ``bool``을 명시적으로 제외한다.
     ``math.isfinite``는 numeric type 확인 뒤에만 호출한다 (가드 순서 중요).
@@ -89,6 +90,105 @@ def _coerce_finite_quantity(value: object) -> float:
     if not _is_finite_quantity(value):
         return 0.0
     return float(value)
+
+
+def _safe_str(value: object) -> str:
+    """sqlite ``TEXT`` 컬럼 바인딩용 안전한 ``str`` 정규화.
+
+    Python 3.13의 ``int`` ↔ ``str`` 변환 4300자리 제한
+    (``sys.set_int_max_str_digits``), 사용자 정의 ``__repr__``가 raise하는
+    모든 경우, ``MemoryError``까지 포괄한다. builder가 절대 raise하지 않는
+    invariant를 지키기 위한 단일 진입점.
+
+    ``str``은 그대로 통과시켜 sqlite ``TEXT`` 컬럼 호환을 유지하고
+    (``"hold"``→``"hold"``), 그 외 값은 ``repr()`` 시도 후 실패 시
+    ``"<unrenderable {type}>"`` placeholder로 떨어뜨린다.
+
+    ``reason`` 메시지 조립에는 quote 보존이 필요하므로 ``_safe_repr``를 사용한다
+    (``"hold"``→``"'hold'"``).
+    """
+    if isinstance(value, str):
+        return value
+    try:
+        return repr(value)
+    except Exception:  # noqa: BLE001
+        # 사용자 정의 ``__repr__``이 임의의 예외를 던질 수 있으므로
+        # ``BaseException``을 제외한 모든 예외를 잡아 placeholder로 떨어뜨린다.
+        # builder가 절대 raise하지 않는 invariant 유지.
+        return f"<unrenderable {type(value).__name__}>"
+
+
+def _safe_repr(value: object) -> str:
+    """``reason`` 메시지 조립용 안전한 ``repr``-스타일 변환.
+
+    ``_safe_str``과 달리 ``str``도 quote로 감싼 ``repr`` 형태로 반환하여
+    ``"Invalid signal side: 'hold' (allowed: ...)"`` 같은 audit-friendly 포맷을
+    유지한다. 사용자 정의 ``__repr__``이 임의의 예외를 던져도 잡아 placeholder
+    로 떨어뜨린다 (``BaseException`` 제외). builder의 raise-free invariant와
+    동일한 보호.
+
+    builder에는 사용하지 않는다 (sqlite 컬럼 호환은 ``_safe_str`` 책임).
+    """
+    try:
+        return repr(value)
+    except Exception:  # noqa: BLE001
+        return f"<unrenderable {type(value).__name__}>"
+
+
+def _safe_order_id(value: object) -> str:
+    """``OrderRejectedEvent.order_id`` 바인딩용 안전한 평문 ``str`` 변환.
+
+    ``UUID`` 같은 ``__str__``이 안정적인 객체는 ``str()`` 결과를 그대로 사용
+    (``UUID(...)`` 같은 ``repr`` 형식이 아닌 ``"058c026b-..."`` 평문). ``str``은
+    그대로 통과시키고, ``__str__``이 raise하면 ``repr`` 시도 후 placeholder로
+    떨어진다. builder가 절대 raise하지 않는 invariant 유지.
+    """
+    if isinstance(value, str):
+        return value
+    try:
+        return str(value)
+    except Exception:  # noqa: BLE001
+        try:
+            return repr(value)
+        except Exception:  # noqa: BLE001
+            return f"<unrenderable {type(value).__name__}>"
+
+
+def _build_safe_rejected_event(
+    *,
+    account_id: str,
+    event: object,
+    reason: str,
+) -> Any:
+    """모든 source 필드를 정규화한 fail-closed ``OrderRejectedEvent`` 빌더.
+
+    builder 자체가 절대 raise하지 않는다 (#1302 메타 리뷰). 호출자는 catch-all
+    ``except`` 안에서 안전하게 호출할 수 있다.
+
+    - ``symbol`` / ``side`` / ``order_type`` / ``bot_id`` / ``strategy_id`` /
+      ``exchange``: ``_safe_str``로 정규화 (sqlite ``TEXT`` 컬럼 호환).
+    - ``quantity``: ``_coerce_finite_quantity``로 finite ``float`` 정규화
+      (NaN/inf/비-number/large-int 모두 0.0).
+    - ``price``: ``None`` 허용 (게이트 통과 후 limit/stop_limit 외에는 nullable).
+    - ``order_id``: ``getattr``+``_safe_str`` (``event_id``가 없거나 raise하는
+      pathological 상황 대응).
+    - ``reason``: 호출자가 미리 만든 문자열. 호출자도 ``_safe_str`` 사용 권장.
+    """
+    from ante.eventbus.events import OrderRejectedEvent
+
+    return OrderRejectedEvent(
+        account_id=account_id,
+        order_id=_safe_order_id(getattr(event, "event_id", "")),
+        bot_id=_safe_str(getattr(event, "bot_id", "")),
+        strategy_id=_safe_str(getattr(event, "strategy_id", "")),
+        symbol=_safe_str(getattr(event, "symbol", "")),
+        side=_safe_str(getattr(event, "side", "")),
+        quantity=_coerce_finite_quantity(getattr(event, "quantity", 0.0)),
+        price=getattr(event, "price", None),
+        order_type=_safe_str(getattr(event, "order_type", "")),
+        reason=reason,
+        exchange=_safe_str(getattr(event, "exchange", "KRX")),
+    )
 
 
 # 룰 타입 → 클래스 매핑
@@ -434,10 +534,23 @@ class RuleEngine:
     # ── EventBus 핸들러 ──────────────────────────────
 
     async def _on_order_request(self, event: object) -> None:
-        """OrderRequestEvent 수신 시 룰 평가 후 결과 이벤트 발행."""
+        """OrderRequestEvent 수신 시 룰 평가 후 결과 이벤트 발행.
+
+        구조 invariant (#1302 메타 리뷰): isinstance/account_id 필터링 직후부터
+        모든 preflight 게이트(#1297-#1302) + evaluate + Treasury 조회 + reject
+        경로 전체를 단일 ``try`` 블록으로 감싼다. 게이트별 ``raise`` (예: f-string
+        ``repr`` 시 ``OverflowError``, 사용자 정의 ``__repr__`` 예외 등)가 EventBus
+        핸들러까지 leak되어 ``OrderRejectedEvent`` 발행이 swallow되면 audit
+        trail이 끊겨 fail-open이 된다. catch-all ``except``가 잡아 ``_build_safe_
+        rejected_event`` (절대 raise하지 않는 builder)로 generic reject를
+        강제 발행하는 것이 본 함수의 핵심 invariant.
+
+        Pathological large-int 등 strategy 코드가 정상적으로 만들 수 없는 입력은
+        catch-all builder가 receive하며, 게이트별 typed reject reason은 강제하지
+        않는다.
+        """
         from ante.eventbus.events import (
             NotificationEvent,
-            OrderRejectedEvent,
             OrderRequestEvent,
             OrderValidatedEvent,
         )
@@ -449,290 +562,202 @@ class RuleEngine:
         if event.account_id != self._account_id:
             return
 
-        # OrderRequestEvent 계약 preflight: Signal.side 허용값 검증.
-        # docs/specs/strategy/03-02-signal-fields.md — side ∈ {"buy", "sell"}.
-        # 룰 평가/Treasury 조회 이전에 거부하여 사이드이펙트(예약/주문) 차단.
-        # `isinstance(..., str)` 가드로 list/dict 같은 unhashable 값이 들어와도
-        # frozenset membership 검사가 TypeError를 raise하지 않도록 한다.
-        if not isinstance(event.side, str) or event.side not in _VALID_ORDER_SIDES:
-            reason = f"Invalid signal side: {event.side!r} (allowed: buy, sell)"
-            # OrderRejectedEvent.side / .order_type / .symbol은 TradeRecorder가
-            # sqlite TEXT NOT NULL 컬럼에 바인딩하므로, 비문자열(list/dict/set/None
-            # 등)이 들어올 경우 InterfaceError/NOT NULL 위반으로 거부 audit trail이
-            # 깨진다. repr()로 강제 정규화하여 텍스트 호환성을 보장한다.
-            # cross-field 보강(#1298/#1299): side만 invalid해도 동시에 order_type
-            # 또는 symbol까지 비문자열이면 reject 이벤트가 broken되므로 세 필드
-            # 모두 정규화한다.
-            safe_side = event.side if isinstance(event.side, str) else repr(event.side)
-            safe_order_type = (
-                event.order_type
-                if isinstance(event.order_type, str)
-                else repr(event.order_type)
-            )
-            safe_symbol = (
-                event.symbol if isinstance(event.symbol, str) else repr(event.symbol)
-            )
-            await self._eventbus.publish(
-                OrderRejectedEvent(
-                    account_id=self._account_id,
-                    order_id=str(event.event_id),
-                    bot_id=event.bot_id,
-                    strategy_id=event.strategy_id,
-                    symbol=safe_symbol,
-                    side=safe_side,
-                    quantity=_coerce_finite_quantity(event.quantity),
-                    price=event.price,
-                    order_type=safe_order_type,
-                    reason=reason,
-                    exchange=event.exchange,
-                )
-            )
-            return
-
-        # OrderRequestEvent 계약 preflight: Signal.order_type 허용값 검증.
-        # docs/specs/strategy/03-02-signal-fields.md —
-        # order_type ∈ {"market", "limit", "stop", "stop_limit"}.
-        # 회귀(#1298): order_type="trail" 등 미지원 값이 RuleEngine을 통과해
-        # Treasury 예약 → broker adapter 호출까지 진행되어 broker 실패 4건이
-        # 누적되었다. 룰 평가/Treasury 조회 이전에 fail-closed로 거부한다.
-        if (
-            not isinstance(event.order_type, str)
-            or event.order_type not in _VALID_ORDER_TYPES
-        ):
-            safe_order_type = (
-                event.order_type
-                if isinstance(event.order_type, str)
-                else repr(event.order_type)
-            )
-            # cross-field 보강(#1299): symbol도 sqlite TEXT 컬럼에 바인딩되므로
-            # 비문자열이면 repr()로 정규화한다.
-            safe_symbol = (
-                event.symbol if isinstance(event.symbol, str) else repr(event.symbol)
-            )
-            reason = (
-                f"Invalid order type: {event.order_type!r} "
-                f"(allowed: market, limit, stop, stop_limit)"
-            )
-            await self._eventbus.publish(
-                OrderRejectedEvent(
-                    account_id=self._account_id,
-                    order_id=str(event.event_id),
-                    bot_id=event.bot_id,
-                    strategy_id=event.strategy_id,
-                    symbol=safe_symbol,
-                    side=event.side,
-                    quantity=_coerce_finite_quantity(event.quantity),
-                    price=event.price,
-                    order_type=safe_order_type,
-                    reason=reason,
-                    exchange=event.exchange,
-                )
-            )
-            return
-
-        # OrderRequestEvent 계약 preflight: KRX numeric symbol 검증.
-        # 회귀(#1299): A7 oracle이 검출한 버그 — Signal.symbol="INVALID",
-        # exchange="KRX" 주문이 RuleEngine→Treasury→broker까지 진행되어
-        # KIS 40070000(매매불가 종목)이 발생했다. 현재 Ante KIS-domestic 경로는
-        # 6자리 숫자 PDNO(예: "005930", "069500")만 가정하므로, 그 형식을
-        # 만족하지 않는 KRX symbol은 룰 평가/Treasury 조회 이전에 fail-closed로
-        # 거부한다. 비-KRX exchange는 broker adapter에 위임한다.
-        if event.exchange == "KRX" and (
-            not isinstance(event.symbol, str)
-            or not _KRX_NUMERIC_SYMBOL_PATTERN.fullmatch(event.symbol)
-        ):
-            safe_symbol = (
-                event.symbol if isinstance(event.symbol, str) else repr(event.symbol)
-            )
-            reason = (
-                f"Invalid KRX numeric symbol: {event.symbol!r} "
-                f"(expected 6-digit numeric per current Ante KIS-domestic contract)"
-            )
-            await self._eventbus.publish(
-                OrderRejectedEvent(
-                    account_id=self._account_id,
-                    order_id=str(event.event_id),
-                    bot_id=event.bot_id,
-                    strategy_id=event.strategy_id,
-                    symbol=safe_symbol,
-                    side=event.side,
-                    quantity=_coerce_finite_quantity(event.quantity),
-                    price=event.price,
-                    order_type=event.order_type,
-                    reason=reason,
-                    exchange=event.exchange,
-                )
-            )
-            return
-
-        # OrderRequestEvent 계약 preflight: limit / stop_limit price 필수.
-        # 회귀(#1300): A7 oracle이 검출한 버그 — order_type="limit", side="sell",
-        # price=None 주문이 RuleEngine→Treasury→broker까지 진행되어 KIS 호출
-        # 단계에서 HTTP 500이 발생했다. limit / stop_limit는 가격 지정이 invariant
-        # 이므로, price=None이면 룰 평가/Treasury 조회 이전에 fail-closed로 거부한다.
-        # market의 price=None은 스펙상 옵션이므로 통과시키며, 0/음수/NaN/비-number
-        # price 검증은 본 PR 범위 밖(#1303)이다.
-        if event.order_type in ("limit", "stop_limit") and event.price is None:
-            reason = (
-                f"Missing price for {event.order_type} order: "
-                f"price is required for limit and stop_limit orders"
-            )
-            # cross-field 보강(#1297/#1298/#1299): symbol은 sqlite TEXT 컬럼에
-            # 바인딩되므로 비문자열이면 repr()로 정규화한다. side / order_type은
-            # 본 게이트 도달 시점에 위 게이트들에서 이미 문자열로 잠겼다.
-            safe_symbol = (
-                event.symbol if isinstance(event.symbol, str) else repr(event.symbol)
-            )
-            await self._eventbus.publish(
-                OrderRejectedEvent(
-                    account_id=self._account_id,
-                    order_id=str(event.event_id),
-                    bot_id=event.bot_id,
-                    strategy_id=event.strategy_id,
-                    symbol=safe_symbol,
-                    side=event.side,
-                    quantity=_coerce_finite_quantity(event.quantity),
-                    price=event.price,
-                    order_type=event.order_type,
-                    reason=reason,
-                    exchange=event.exchange,
-                )
-            )
-            return
-
-        # OrderRequestEvent 계약 preflight: stop / stop_limit stop_price 필수.
-        # 회귀(#1301): A7 oracle이 검출한 버그 — order_type="stop", side="sell",
-        # stop_price=None 주문이 RuleEngine→OrderApproved→StopOrderRegistered까지
-        # 진행되어 terminal event(체결/거부)가 누락되었다. stop / stop_limit는
-        # 트리거 가격(stop_price) 지정이 invariant이므로, stop_price=None이면
-        # 룰 평가/Treasury 조회 이전에 fail-closed로 거부한다. OrderRejectedEvent
-        # 스키마에 stop_price 필드가 없으므로 reason 문자열에만 명시한다.
-        # 0/음수/NaN stop_price 검증은 본 PR 범위 밖(별도 후속 이슈)이다.
-        if event.order_type in ("stop", "stop_limit") and event.stop_price is None:
-            reason = (
-                f"Missing stop_price for {event.order_type} order: "
-                f"stop_price is required for stop and stop_limit orders"
-            )
-            # symbol은 sqlite TEXT 컬럼에 바인딩되므로 비문자열이면 repr()로
-            # 정규화한다. side / order_type은 본 게이트 도달 시점에 위 게이트들에서
-            # 이미 문자열로 잠겼다.
-            safe_symbol = (
-                event.symbol if isinstance(event.symbol, str) else repr(event.symbol)
-            )
-            await self._eventbus.publish(
-                OrderRejectedEvent(
-                    account_id=self._account_id,
-                    order_id=str(event.event_id),
-                    bot_id=event.bot_id,
-                    strategy_id=event.strategy_id,
-                    symbol=safe_symbol,
-                    side=event.side,
-                    quantity=_coerce_finite_quantity(event.quantity),
-                    price=event.price,
-                    order_type=event.order_type,
-                    reason=reason,
-                    exchange=event.exchange,
-                )
-            )
-            return
-
-        # OrderRequestEvent 계약 preflight: quantity는 finite number여야 한다.
-        # 회귀(#1302): A7 oracle이 검출한 버그 — Signal.quantity=NaN, side='buy',
-        # order_type='limit', price=1000 주문이 RuleEngine→OrderValidatedEvent→
-        # Treasury 진입 후 sqlite `bot_budgets.available NOT NULL` 위반으로 실패했다.
-        # NaN/inf/non-number quantity는 Treasury 예약/주문 호출 이전에 fail-closed
-        # 로 거부한다. 0/음수 quantity, NaN price 검증은 본 PR 범위 밖
-        # (#1304/#1305/#1303)이다.
-        #
-        # _is_finite_quantity는 비-number/bool/NaN/inf뿐 아니라 ``10**10000``
-        # 같은 거대 정수 (float 변환 시 ``OverflowError``)도 함께 잠근다 (#1302 P2).
-        # 게이트가 ``_on_order_request``의 ``try`` 블록 밖에 있으므로
-        # 예외가 EventBus까지 leak되지 않도록 helper 내부에서 가드한다.
-        if not _is_finite_quantity(event.quantity):
-            reason = (
-                f"Invalid quantity: {event.quantity!r} "
-                f"(quantity must be a finite number)"
-            )
-            safe_symbol = (
-                event.symbol if isinstance(event.symbol, str) else repr(event.symbol)
-            )
-            # OrderRejectedEvent.quantity는 trades.quantity REAL NOT NULL로
-            # 이어지므로 NaN/inf/비-number/overflow int는 0.0으로 정규화해
-            # audit/PnL 호환을 유지한다. 본 PR의 cross-field 보강(#1302)에서
-            # 모든 reject 경로가 동일한 _coerce_finite_quantity helper로 통일됐다.
-            safe_quantity = _coerce_finite_quantity(event.quantity)
-            await self._eventbus.publish(
-                OrderRejectedEvent(
-                    account_id=self._account_id,
-                    order_id=str(event.event_id),
-                    bot_id=event.bot_id,
-                    strategy_id=event.strategy_id,
-                    symbol=safe_symbol,
-                    side=event.side,
-                    quantity=safe_quantity,
-                    price=event.price,
-                    order_type=event.order_type,
-                    reason=reason,
-                    exchange=event.exchange,
-                )
-            )
-            return
-
-        # 계좌 상태 조회
-        account_status = "active"
-        currency = "KRW"
-        trading_hours_start = "09:00"
-        trading_hours_end = "15:30"
-        timezone = "Asia/Seoul"
-        if self._account_service is not None:
-            try:
-                account = await self._account_service.get(self._account_id)
-                account_status = account.status.value
-                currency = account.currency
-                trading_hours_start = account.trading_hours_start
-                trading_hours_end = account.trading_hours_end
-                timezone = account.timezone
-            except Exception:
-                logger.warning(
-                    "계좌 상태 조회 실패: %s — 기본값 사용", self._account_id
-                )
-
-        # Treasury 데이터 조회
-        treasury_data = await self._query_treasury_data(bot_id=event.bot_id)
-
-        # 미실현 손익 조회
-        current_price = event.price or 0.0
-        unrealized_pnl = await self._calculate_bot_unrealized_pnl(
-            bot_id=event.bot_id,
-            current_price=current_price,
-            order_symbol=event.symbol,
-        )
-
-        context = RuleContext(
-            bot_id=event.bot_id,
-            account_id=self._account_id,
-            strategy_id=event.strategy_id,
-            symbol=event.symbol,
-            side=event.side,
-            quantity=event.quantity,
-            order_type=event.order_type,
-            price=event.price,
-            current_price=current_price,
-            account_status=account_status,
-            currency=currency,
-            unrealized_pnl=unrealized_pnl,
-            daily_pnl=treasury_data["daily_pnl"],
-            total_pnl=treasury_data["total_pnl"],
-            prev_day_total_asset=treasury_data["prev_day_total_asset"],
-            total_asset=treasury_data["total_asset"],
-            total_exposure=treasury_data["total_exposure"],
-            bot_allocated_budget=treasury_data["bot_allocated_budget"],
-            trading_hours_start=trading_hours_start,
-            trading_hours_end=trading_hours_end,
-            timezone=timezone,
-        )
-
         try:
+            # OrderRequestEvent 계약 preflight: Signal.side 허용값 검증.
+            # docs/specs/strategy/03-02-signal-fields.md — side ∈ {"buy", "sell"}.
+            # 룰 평가/Treasury 조회 이전에 거부하여 사이드이펙트(예약/주문) 차단.
+            # `isinstance(..., str)` 가드로 list/dict 같은 unhashable 값이 들어와도
+            # frozenset membership 검사가 TypeError를 raise하지 않도록 한다.
+            if not isinstance(event.side, str) or event.side not in _VALID_ORDER_SIDES:
+                # cross-field 보강(#1297/#1298/#1299): side만 invalid해도 동시에
+                # order_type/symbol까지 비문자열이면 reject 이벤트가 broken되므로
+                # builder가 모든 sqlite TEXT NOT NULL 필드를 _safe_str로 정규화.
+                reason = (
+                    f"Invalid signal side: {_safe_repr(event.side)} "
+                    f"(allowed: buy, sell)"
+                )
+                await self._eventbus.publish(
+                    _build_safe_rejected_event(
+                        account_id=self._account_id,
+                        event=event,
+                        reason=reason,
+                    )
+                )
+                return
+
+            # OrderRequestEvent 계약 preflight: Signal.order_type 허용값 검증.
+            # docs/specs/strategy/03-02-signal-fields.md —
+            # order_type ∈ {"market", "limit", "stop", "stop_limit"}.
+            # 회귀(#1298): order_type="trail" 등 미지원 값이 RuleEngine을 통과해
+            # Treasury 예약 → broker adapter 호출까지 진행되어 broker 실패 4건이
+            # 누적되었다. 룰 평가/Treasury 조회 이전에 fail-closed로 거부한다.
+            if (
+                not isinstance(event.order_type, str)
+                or event.order_type not in _VALID_ORDER_TYPES
+            ):
+                reason = (
+                    f"Invalid order type: {_safe_repr(event.order_type)} "
+                    f"(allowed: market, limit, stop, stop_limit)"
+                )
+                await self._eventbus.publish(
+                    _build_safe_rejected_event(
+                        account_id=self._account_id,
+                        event=event,
+                        reason=reason,
+                    )
+                )
+                return
+
+            # OrderRequestEvent 계약 preflight: KRX numeric symbol 검증.
+            # 회귀(#1299): A7 oracle이 검출한 버그 — Signal.symbol="INVALID",
+            # exchange="KRX" 주문이 RuleEngine→Treasury→broker까지 진행되어
+            # KIS 40070000(매매불가 종목)이 발생했다. 현재 Ante KIS-domestic 경로는
+            # 6자리 숫자 PDNO(예: "005930", "069500")만 가정하므로, 그 형식을
+            # 만족하지 않는 KRX symbol은 룰 평가/Treasury 조회 이전에 fail-closed로
+            # 거부한다. 비-KRX exchange는 broker adapter에 위임한다.
+            if event.exchange == "KRX" and (
+                not isinstance(event.symbol, str)
+                or not _KRX_NUMERIC_SYMBOL_PATTERN.fullmatch(event.symbol)
+            ):
+                reason = (
+                    f"Invalid KRX numeric symbol: {_safe_repr(event.symbol)} "
+                    f"(expected 6-digit numeric per current Ante "
+                    f"KIS-domestic contract)"
+                )
+                await self._eventbus.publish(
+                    _build_safe_rejected_event(
+                        account_id=self._account_id,
+                        event=event,
+                        reason=reason,
+                    )
+                )
+                return
+
+            # OrderRequestEvent 계약 preflight: limit / stop_limit price 필수.
+            # 회귀(#1300): A7 oracle이 검출한 버그 — order_type="limit", side="sell",
+            # price=None 주문이 RuleEngine→Treasury→broker까지 진행되어 KIS 호출
+            # 단계에서 HTTP 500이 발생했다. limit / stop_limit는 가격 지정이
+            # invariant이므로, price=None이면 룰 평가/Treasury 조회 이전에
+            # fail-closed로 거부한다.
+            # market의 price=None은 스펙상 옵션이므로 통과시키며, 0/음수/NaN/비-number
+            # price 검증은 본 PR 범위 밖(#1303)이다.
+            if event.order_type in ("limit", "stop_limit") and event.price is None:
+                reason = (
+                    f"Missing price for {_safe_str(event.order_type)} order: "
+                    f"price is required for limit and stop_limit orders"
+                )
+                await self._eventbus.publish(
+                    _build_safe_rejected_event(
+                        account_id=self._account_id,
+                        event=event,
+                        reason=reason,
+                    )
+                )
+                return
+
+            # OrderRequestEvent 계약 preflight: stop / stop_limit stop_price 필수.
+            # 회귀(#1301): A7 oracle이 검출한 버그 — order_type="stop", side="sell",
+            # stop_price=None 주문이 RuleEngine→OrderApproved→StopOrderRegistered까지
+            # 진행되어 terminal event(체결/거부)가 누락되었다. stop / stop_limit는
+            # 트리거 가격(stop_price) 지정이 invariant이므로, stop_price=None이면
+            # 룰 평가/Treasury 조회 이전에 fail-closed로 거부한다. OrderRejectedEvent
+            # 스키마에 stop_price 필드가 없으므로 reason 문자열에만 명시한다.
+            # 0/음수/NaN stop_price 검증은 본 PR 범위 밖(별도 후속 이슈)이다.
+            if event.order_type in ("stop", "stop_limit") and event.stop_price is None:
+                reason = (
+                    f"Missing stop_price for {_safe_str(event.order_type)} order: "
+                    f"stop_price is required for stop and stop_limit orders"
+                )
+                await self._eventbus.publish(
+                    _build_safe_rejected_event(
+                        account_id=self._account_id,
+                        event=event,
+                        reason=reason,
+                    )
+                )
+                return
+
+            # OrderRequestEvent 계약 preflight: quantity는 finite number여야 한다.
+            # 회귀(#1302): A7 oracle이 검출한 버그 — Signal.quantity=NaN,
+            # side='buy', order_type='limit', price=1000 주문이 RuleEngine→
+            # OrderValidatedEvent→Treasury 진입 후 sqlite
+            # `bot_budgets.available NOT NULL` 위반으로 실패했다.
+            # NaN/inf/non-number quantity는 Treasury 예약/주문 호출 이전에 fail-closed
+            # 로 거부한다. 0/음수 quantity, NaN price 검증은 본 PR 범위 밖
+            # (#1304/#1305/#1303)이다.
+            #
+            # _is_finite_quantity는 비-number/bool/NaN/inf뿐 아니라 ``10**10000``
+            # 같은 거대 정수 (float 변환 시 ``OverflowError``)도 함께 잠근다 (#1302 P2).
+            # 본 게이트가 outer try 블록 안에 있으므로 reason 조립의 ``_safe_str``
+            # 가 raise해도 catch-all이 receive해 generic reject를 발행한다.
+            if not _is_finite_quantity(event.quantity):
+                reason = (
+                    f"Invalid quantity: {_safe_repr(event.quantity)} "
+                    f"(quantity must be a finite number)"
+                )
+                await self._eventbus.publish(
+                    _build_safe_rejected_event(
+                        account_id=self._account_id,
+                        event=event,
+                        reason=reason,
+                    )
+                )
+                return
+
+            # 계좌 상태 조회
+            account_status = "active"
+            currency = "KRW"
+            trading_hours_start = "09:00"
+            trading_hours_end = "15:30"
+            timezone = "Asia/Seoul"
+            if self._account_service is not None:
+                try:
+                    account = await self._account_service.get(self._account_id)
+                    account_status = account.status.value
+                    currency = account.currency
+                    trading_hours_start = account.trading_hours_start
+                    trading_hours_end = account.trading_hours_end
+                    timezone = account.timezone
+                except Exception:
+                    logger.warning(
+                        "계좌 상태 조회 실패: %s — 기본값 사용", self._account_id
+                    )
+
+            # Treasury 데이터 조회
+            treasury_data = await self._query_treasury_data(bot_id=event.bot_id)
+
+            # 미실현 손익 조회
+            current_price = event.price or 0.0
+            unrealized_pnl = await self._calculate_bot_unrealized_pnl(
+                bot_id=event.bot_id,
+                current_price=current_price,
+                order_symbol=event.symbol,
+            )
+
+            context = RuleContext(
+                bot_id=event.bot_id,
+                account_id=self._account_id,
+                strategy_id=event.strategy_id,
+                symbol=event.symbol,
+                side=event.side,
+                quantity=event.quantity,
+                order_type=event.order_type,
+                price=event.price,
+                current_price=current_price,
+                account_status=account_status,
+                currency=currency,
+                unrealized_pnl=unrealized_pnl,
+                daily_pnl=treasury_data["daily_pnl"],
+                total_pnl=treasury_data["total_pnl"],
+                prev_day_total_asset=treasury_data["prev_day_total_asset"],
+                total_asset=treasury_data["total_asset"],
+                total_exposure=treasury_data["total_exposure"],
+                bot_allocated_budget=treasury_data["bot_allocated_budget"],
+                trading_hours_start=trading_hours_start,
+                trading_hours_end=trading_hours_end,
+                timezone=timezone,
+            )
+
             result = self.evaluate(context)
 
             if result.overall_result in (RuleResult.PASS, RuleResult.WARN):
@@ -764,40 +789,40 @@ class RuleEngine:
             else:
                 # 정상 흐름의 OrderValidatedEvent는 RuleEngine 내부 검증을
                 # 통과한 OrderRequest에서만 가므로 quantity는 이미 finite로
-                # 보장되지만, defensive 차원에서 동일한 helper를 적용해 audit
+                # 보장되지만, defensive 차원에서 builder를 적용해 audit
                 # trail의 finite-float 불변성을 일관되게 잠근다 (#1302).
                 await self._eventbus.publish(
-                    OrderRejectedEvent(
+                    _build_safe_rejected_event(
                         account_id=self._account_id,
-                        order_id=str(event.event_id),
-                        bot_id=event.bot_id,
-                        strategy_id=event.strategy_id,
-                        symbol=event.symbol,
-                        side=event.side,
-                        quantity=_coerce_finite_quantity(event.quantity),
-                        price=event.price,
-                        order_type=event.order_type,
+                        event=event,
                         reason=result.rejection_reason,
                     )
                 )
                 await self._execute_actions(result.actions, event)
 
-        except Exception:
-            logger.exception("룰 평가 실패: %s", event.event_id)
-            await self._eventbus.publish(
-                OrderRejectedEvent(
-                    account_id=self._account_id,
-                    order_id=str(event.event_id),
-                    bot_id=event.bot_id,
-                    strategy_id=event.strategy_id,
-                    symbol=event.symbol,
-                    side=event.side,
-                    quantity=_coerce_finite_quantity(event.quantity),
-                    price=event.price,
-                    order_type=event.order_type,
-                    reason="Rule evaluation error",
-                )
+        except Exception:  # noqa: BLE001
+            # catch-all (#1302 메타 리뷰 invariant): preflight 게이트나 evaluate
+            # 단계 어디에서든 raise가 일어나도 audit trail이 fail-closed로
+            # 잠기도록 generic reject를 강제 발행한다. builder는 절대 raise하지
+            # 않으며, 만약 publish 자체가 raise해도 안쪽 try가 다시 잡아
+            # logger.exception으로만 남긴다.
+            logger.exception(
+                "OrderRequest preflight unexpected failure: event_id=%s",
+                getattr(event, "event_id", "<unknown>"),
             )
+            try:
+                await self._eventbus.publish(
+                    _build_safe_rejected_event(
+                        account_id=self._account_id,
+                        event=event,
+                        reason="OrderRequest preflight error (see logs)",
+                    )
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Failed to publish safe-fallback OrderRejectedEvent: event_id=%s",
+                    getattr(event, "event_id", "<unknown>"),
+                )
 
     async def _execute_actions(self, actions: list[RuleAction], event: object) -> None:
         """룰 위반 조치 실행."""

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -54,22 +54,39 @@ _VALID_ORDER_TYPES: frozenset[str] = frozenset(
 _KRX_NUMERIC_SYMBOL_PATTERN = re.compile(r"^[0-9]{6}$")
 
 
-def _coerce_finite_quantity(value: object) -> float:
-    """``OrderRejectedEvent.quantity`` payload용 안전한 finite ``float`` 변환.
+def _is_finite_quantity(value: object) -> bool:
+    """``value``가 finite ``float``-호환 quantity인지 판정.
 
-    비-number, ``bool``, ``NaN``, ``inf``는 ``0.0``으로 정규화한다.
-    ``trades.quantity REAL NOT NULL`` 컬럼 호환을 보장하여, 임의의
-    cross-field invalid payload (#1297/#1298/#1299/#1300/#1301)에서
-    quantity 자리에 비-finite 값이 함께 실려도 audit trail이 깨지지 않는다.
+    비-number, ``bool``, ``NaN``, ``inf``는 모두 ``False``로 잠근다.
+    Python ``int``는 임의 정밀도라 ``10**10000`` 같은 거대한 정수는
+    ``math.isfinite`` 호출 시 ``float(value)`` 변환에서
+    ``OverflowError`` (또는 ``ValueError``/``TypeError``)를 던진다 (#1302 P2).
+    이때도 finite-호환이 아니므로 ``False``로 떨어뜨려 호출부가
+    fail-closed reject 경로로 빠지게 한다.
 
     ``isinstance(True, int) == True`` 이므로 ``bool``을 명시적으로 제외한다.
     ``math.isfinite``는 numeric type 확인 뒤에만 호출한다 (가드 순서 중요).
     """
-    if (
-        not isinstance(value, (int, float))
-        or isinstance(value, bool)
-        or not math.isfinite(value)
-    ):
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return False
+    try:
+        return math.isfinite(value)
+    except (OverflowError, ValueError, TypeError):
+        return False
+
+
+def _coerce_finite_quantity(value: object) -> float:
+    """``OrderRejectedEvent.quantity`` payload용 안전한 finite ``float`` 변환.
+
+    비-number, ``bool``, ``NaN``, ``inf``, 그리고 ``float`` 변환 시
+    ``OverflowError``를 유발하는 거대 ``int`` (#1302 P2)는 ``0.0``으로
+    정규화한다. ``trades.quantity REAL NOT NULL`` 컬럼 호환을 보장하여,
+    임의의 cross-field invalid payload (#1297/#1298/#1299/#1300/#1301)에서
+    quantity 자리에 비-finite 값이 함께 실려도 audit trail이 깨지지 않는다.
+
+    판정은 ``_is_finite_quantity``에 위임하여 단일 진입점을 유지한다.
+    """
+    if not _is_finite_quantity(value):
         return 0.0
     return float(value)
 
@@ -626,14 +643,12 @@ class RuleEngine:
         # NaN/inf/non-number quantity는 Treasury 예약/주문 호출 이전에 fail-closed
         # 로 거부한다. 0/음수 quantity, NaN price 검증은 본 PR 범위 밖
         # (#1304/#1305/#1303)이다.
-        # bool은 isinstance(True, int)==True이므로 명시적으로 제외한다.
-        # math.isnan/isinf는 numeric type 확인 뒤에만 호출 (가드 순서 중요).
-        if (
-            not isinstance(event.quantity, (int, float))
-            or isinstance(event.quantity, bool)
-            or math.isnan(event.quantity)
-            or math.isinf(event.quantity)
-        ):
+        #
+        # _is_finite_quantity는 비-number/bool/NaN/inf뿐 아니라 ``10**10000``
+        # 같은 거대 정수 (float 변환 시 ``OverflowError``)도 함께 잠근다 (#1302 P2).
+        # 게이트가 ``_on_order_request``의 ``try`` 블록 밖에 있으므로
+        # 예외가 EventBus까지 leak되지 않도록 helper 내부에서 가드한다.
+        if not _is_finite_quantity(event.quantity):
             reason = (
                 f"Invalid quantity: {event.quantity!r} "
                 f"(quantity must be a finite number)"
@@ -642,9 +657,10 @@ class RuleEngine:
                 event.symbol if isinstance(event.symbol, str) else repr(event.symbol)
             )
             # OrderRejectedEvent.quantity는 trades.quantity REAL NOT NULL로
-            # 이어지므로 NaN/inf/비-number는 0.0으로 정규화해 audit/PnL 호환을
-            # 유지한다. 본 PR의 cross-field 보강(#1302)에서 모든 reject 경로가
-            # 동일한 _coerce_finite_quantity helper로 통일됐다.
+            # 이어지므로 NaN/inf/비-number/overflow int는 0.0으로 정규화해
+            # audit/PnL 호환을 유지한다. 본 PR의 cross-field 보강(#1302)에서
+            # 모든 reject 경로가 동일한 _coerce_finite_quantity helper로 통일됐다.
+            safe_quantity = _coerce_finite_quantity(event.quantity)
             await self._eventbus.publish(
                 OrderRejectedEvent(
                     account_id=self._account_id,
@@ -653,7 +669,7 @@ class RuleEngine:
                     strategy_id=event.strategy_id,
                     symbol=safe_symbol,
                     side=event.side,
-                    quantity=_coerce_finite_quantity(event.quantity),
+                    quantity=safe_quantity,
                     price=event.price,
                     order_type=event.order_type,
                     reason=reason,

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -53,6 +53,27 @@ _VALID_ORDER_TYPES: frozenset[str] = frozenset(
 # 이전에 fail-closed로 거부한다.
 _KRX_NUMERIC_SYMBOL_PATTERN = re.compile(r"^[0-9]{6}$")
 
+
+def _coerce_finite_quantity(value: object) -> float:
+    """``OrderRejectedEvent.quantity`` payload용 안전한 finite ``float`` 변환.
+
+    비-number, ``bool``, ``NaN``, ``inf``는 ``0.0``으로 정규화한다.
+    ``trades.quantity REAL NOT NULL`` 컬럼 호환을 보장하여, 임의의
+    cross-field invalid payload (#1297/#1298/#1299/#1300/#1301)에서
+    quantity 자리에 비-finite 값이 함께 실려도 audit trail이 깨지지 않는다.
+
+    ``isinstance(True, int) == True`` 이므로 ``bool``을 명시적으로 제외한다.
+    ``math.isfinite``는 numeric type 확인 뒤에만 호출한다 (가드 순서 중요).
+    """
+    if (
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not math.isfinite(value)
+    ):
+        return 0.0
+    return float(value)
+
+
 # 룰 타입 → 클래스 매핑
 RULE_REGISTRY: dict[str, type[Rule]] = {
     "daily_loss_limit": DailyLossLimitRule,
@@ -442,7 +463,7 @@ class RuleEngine:
                     strategy_id=event.strategy_id,
                     symbol=safe_symbol,
                     side=safe_side,
-                    quantity=event.quantity,
+                    quantity=_coerce_finite_quantity(event.quantity),
                     price=event.price,
                     order_type=safe_order_type,
                     reason=reason,
@@ -483,7 +504,7 @@ class RuleEngine:
                     strategy_id=event.strategy_id,
                     symbol=safe_symbol,
                     side=event.side,
-                    quantity=event.quantity,
+                    quantity=_coerce_finite_quantity(event.quantity),
                     price=event.price,
                     order_type=safe_order_type,
                     reason=reason,
@@ -518,7 +539,7 @@ class RuleEngine:
                     strategy_id=event.strategy_id,
                     symbol=safe_symbol,
                     side=event.side,
-                    quantity=event.quantity,
+                    quantity=_coerce_finite_quantity(event.quantity),
                     price=event.price,
                     order_type=event.order_type,
                     reason=reason,
@@ -553,7 +574,7 @@ class RuleEngine:
                     strategy_id=event.strategy_id,
                     symbol=safe_symbol,
                     side=event.side,
-                    quantity=event.quantity,
+                    quantity=_coerce_finite_quantity(event.quantity),
                     price=event.price,
                     order_type=event.order_type,
                     reason=reason,
@@ -589,7 +610,7 @@ class RuleEngine:
                     strategy_id=event.strategy_id,
                     symbol=safe_symbol,
                     side=event.side,
-                    quantity=event.quantity,
+                    quantity=_coerce_finite_quantity(event.quantity),
                     price=event.price,
                     order_type=event.order_type,
                     reason=reason,
@@ -622,14 +643,8 @@ class RuleEngine:
             )
             # OrderRejectedEvent.quantity는 trades.quantity REAL NOT NULL로
             # 이어지므로 NaN/inf/비-number는 0.0으로 정규화해 audit/PnL 호환을
-            # 유지한다.
-            safe_quantity = (
-                event.quantity
-                if isinstance(event.quantity, (int, float))
-                and not isinstance(event.quantity, bool)
-                and math.isfinite(event.quantity)
-                else 0.0
-            )
+            # 유지한다. 본 PR의 cross-field 보강(#1302)에서 모든 reject 경로가
+            # 동일한 _coerce_finite_quantity helper로 통일됐다.
             await self._eventbus.publish(
                 OrderRejectedEvent(
                     account_id=self._account_id,
@@ -638,7 +653,7 @@ class RuleEngine:
                     strategy_id=event.strategy_id,
                     symbol=safe_symbol,
                     side=event.side,
-                    quantity=safe_quantity,
+                    quantity=_coerce_finite_quantity(event.quantity),
                     price=event.price,
                     order_type=event.order_type,
                     reason=reason,
@@ -731,6 +746,10 @@ class RuleEngine:
                                 )
                             )
             else:
+                # 정상 흐름의 OrderValidatedEvent는 RuleEngine 내부 검증을
+                # 통과한 OrderRequest에서만 가므로 quantity는 이미 finite로
+                # 보장되지만, defensive 차원에서 동일한 helper를 적용해 audit
+                # trail의 finite-float 불변성을 일관되게 잠근다 (#1302).
                 await self._eventbus.publish(
                     OrderRejectedEvent(
                         account_id=self._account_id,
@@ -739,7 +758,7 @@ class RuleEngine:
                         strategy_id=event.strategy_id,
                         symbol=event.symbol,
                         side=event.side,
-                        quantity=event.quantity,
+                        quantity=_coerce_finite_quantity(event.quantity),
                         price=event.price,
                         order_type=event.order_type,
                         reason=result.rejection_reason,
@@ -757,7 +776,7 @@ class RuleEngine:
                     strategy_id=event.strategy_id,
                     symbol=event.symbol,
                     side=event.side,
-                    quantity=event.quantity,
+                    quantity=_coerce_finite_quantity(event.quantity),
                     price=event.price,
                     order_type=event.order_type,
                     reason="Rule evaluation error",

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -6,7 +6,7 @@ import logging
 import math
 import re
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeGuard
 
 from ante.rule.base import (
     EvaluationResult,
@@ -54,7 +54,7 @@ _VALID_ORDER_TYPES: frozenset[str] = frozenset(
 _KRX_NUMERIC_SYMBOL_PATTERN = re.compile(r"^[0-9]{6}$")
 
 
-def _is_finite_quantity(value: object) -> bool:
+def _is_finite_quantity(value: object) -> TypeGuard[int | float]:
     """``value``가 finite ``float``-호환 quantity인지 판정.
 
     비-number, ``bool``, ``NaN``, ``inf``는 모두 ``False``로 잠근다.
@@ -67,6 +67,11 @@ def _is_finite_quantity(value: object) -> bool:
 
     ``isinstance(True, int) == True`` 이므로 ``bool``을 명시적으로 제외한다.
     ``math.isfinite``는 numeric type 확인 뒤에만 호출한다 (가드 순서 중요).
+
+    반환 타입은 ``TypeGuard[int | float]``로 선언하여 mypy가 호출부 ``True``
+    분기에서 ``value``를 ``int | float``로 좁히게 한다 (#1302 P1 #5). 이를
+    통해 ``_coerce_finite_quantity``의 ``float(value)``가 ``object`` 인자
+    overload 미스매치 없이 통과한다.
     """
     if not isinstance(value, (int, float)) or isinstance(value, bool):
         return False

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -2426,6 +2426,196 @@ class TestRuleEngineEventBus:
         assert isinstance(ev.quantity, float)
         assert ev.quantity == 10.0
 
+    @pytest.mark.parametrize(
+        ("price", "side", "order_type", "expected_reason"),
+        [
+            # quantity=NaN 게이트로 fire하면서 price=NaN을 함께 실어 보낸다.
+            (float("nan"), "buy", "limit", "Invalid quantity"),
+            # invalid-side 게이트로 fire하면서 price=inf를 함께 실어 보낸다.
+            (float("inf"), "hold", "market", "Invalid signal side"),
+        ],
+    )
+    async def test_rule_engine_normalizes_nan_price_in_rejected_event(
+        self,
+        engine,
+        eventbus,
+        price,
+        side,
+        order_type,
+        expected_reason,
+    ):
+        """``OrderRejectedEvent.price``의 NaN/inf payload는 ``None``으로 정규화.
+
+        회귀(#1302 P2 #4): 본 PR 이전에는 ``_build_safe_rejected_event``가
+        ``price=getattr(event, "price", None)``으로 원본을 그대로 전파했다.
+        ``price=float("nan")`` / ``inf``가 reject 이벤트에 그대로 실리면
+        ``TradeRecorder``의 ``event.price or 0.0`` 처리(NaN은 truthy)에서
+        sqlite ``trades.price REAL`` 컬럼에 NaN이 bind되어 PnL 계산이 깨지고
+        본 PR이 보장하려는 reject audit trail도 깨진다.
+
+        cross-field 케이스(quantity 게이트 + invalid price, invalid side +
+        invalid price)에서 builder가 ``_coerce_finite_optional_price``로
+        ``None`` 정규화를 강제하는지 잠근다. reason은 먼저 fire한 게이트의
+        reason을 그대로 유지한다 (price-only 검증은 본 PR 범위 밖이므로
+        새 게이트가 fire하면 안 됨).
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side=side,
+            quantity=float("nan") if expected_reason == "Invalid quantity" else 10.0,
+            order_type=order_type,
+            price=price,
+            exchange="KRX",
+            reason="Codex P2 #4 NaN price regression",
+        )
+        await eventbus.publish(order)
+
+        assert len(validated) == 0
+        assert len(rejected) == 1
+        ev = rejected[0]
+        assert expected_reason in ev.reason
+        # price는 trades.price REAL nullable 컬럼 호환 + TradeRecorder의
+        # ``event.price or 0.0`` 처리 안전성을 위해 None으로 정규화돼야 한다.
+        assert ev.price is None
+
+    @pytest.mark.parametrize(
+        "bad_price",
+        [
+            [],
+            {},
+            "100",
+            True,
+            False,
+            object(),
+        ],
+    )
+    async def test_rule_engine_normalizes_non_number_price_in_rejected_event(
+        self,
+        engine,
+        eventbus,
+        bad_price,
+    ):
+        """``OrderRejectedEvent.price``의 비-number payload는 ``None``으로 정규화.
+
+        회귀(#1302 P2 #4): ``list`` (비빈), ``dict``, ``str``, ``bool`` 같은
+        비-number truthy 값이 ``event.price``로 들어오면 builder가 그대로
+        전파해 ``TradeRecorder``가 sqlite ``trades.price REAL`` 컬럼에 bind
+        시도 시 ``InterfaceError``가 발생한다. ``False``/빈 컨테이너 같은
+        falsy 비-number도 일관성을 위해 ``None``으로 떨어뜨린다.
+
+        invalid-side 게이트로 fire시켜 reject 경로를 강제하고, builder의
+        price 정규화만 단독 검증한다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="hold",  # invalid-side 게이트 fire
+            quantity=10.0,
+            order_type="market",
+            price=bad_price,  # type: ignore[arg-type]
+            exchange="KRX",
+            reason="Codex P2 #4 non-number price regression",
+        )
+        await eventbus.publish(order)
+
+        assert len(validated) == 0
+        assert len(rejected) == 1
+        ev = rejected[0]
+        assert "Invalid signal side" in ev.reason
+        # 비-number는 모두 None으로 정규화돼야 한다.
+        assert ev.price is None
+
+    async def test_rule_engine_preserves_finite_price_in_rejected_event(
+        self, engine, eventbus
+    ):
+        """정상 finite ``price`` payload는 ``float``로 보존된다.
+
+        회귀(#1302 P2 #4): builder의 price 정규화가 정상 reject payload까지
+        과도하게 ``None``으로 떨어뜨리면 audit trail의 가격 정보가 손실되어
+        뒤따르는 PnL/보고 계산이 부정확해진다. quantity=NaN 게이트로 fire한
+        cross-field 케이스에서 finite price (1000.0)는 그대로 보존되는지
+        잠근다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=float("nan"),  # quantity 게이트 fire
+            order_type="limit",
+            price=1000.0,
+            exchange="KRX",
+            reason="Codex P2 #4 finite price preservation regression",
+        )
+        await eventbus.publish(order)
+
+        assert len(validated) == 0
+        assert len(rejected) == 1
+        ev = rejected[0]
+        assert "Invalid quantity" in ev.reason
+        # 정상 finite price는 보존돼야 한다 (정규화의 false-positive 방지).
+        assert ev.price == 1000.0
+        assert isinstance(ev.price, float)
+
+    async def test_rule_engine_normalizes_overflow_int_price(self, engine, eventbus):
+        """``float`` 변환 시 ``OverflowError``를 유발하는 거대 ``int`` price 정규화.
+
+        회귀(#1302 P2 #4): Python ``int``는 임의 정밀도라 ``10**400`` 같은
+        거대 정수는 ``math.isfinite`` 호출 시 ``float(value)`` 변환에서
+        ``OverflowError``를 던진다. ``_coerce_finite_optional_price`` helper
+        가 ``OverflowError``/``ValueError``/``TypeError``를 가드해 ``None``
+        으로 떨어뜨리는지 (builder가 절대 raise하지 않는 invariant 유지)
+        잠근다. invalid-side 게이트로 fire시켜 reject 경로를 강제한다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="hold",  # invalid-side 게이트 fire
+            quantity=10.0,
+            order_type="market",
+            price=10**400,  # type: ignore[arg-type]
+            exchange="KRX",
+            reason="Codex P2 #4 overflow int price regression",
+        )
+
+        # builder가 OverflowError를 leak하면 publish가 raise하므로,
+        # 정상 반환되는 것 자체가 fail-closed 잠금 검증.
+        await eventbus.publish(order)
+
+        assert len(validated) == 0
+        assert len(rejected) == 1
+        ev = rejected[0]
+        assert "Invalid signal side" in ev.reason
+        assert ev.price is None
+
 
 # ── RuleEngine.update_rules ──────────────────────
 

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -2104,6 +2104,82 @@ class TestRuleEngineEventBus:
         assert validated[0].order_type == "limit"
         assert validated[0].price == 1000.0
 
+    async def test_rule_engine_rejects_overflow_int_quantity(
+        self, engine, eventbus, monkeypatch
+    ):
+        """``float`` 변환 시 ``OverflowError``를 유발하는 거대 ``int`` quantity 거부.
+
+        회귀(#1302 P2): Python ``int``는 임의 정밀도라 ``10**400`` 같은 거대한
+        정수는 ``math.isfinite`` (또는 ``math.isnan``/``math.isinf``) 호출 시
+        ``float(value)`` 변환에서 ``OverflowError: int too large to convert to
+        float``를 던진다. 본 게이트가 ``_on_order_request``의 ``try`` 블록
+        밖이라 예외가 EventBus 핸들러까지 leak되면 ``OrderRejectedEvent``가
+        발행되지 않아 audit trail이 끊기고 게이트가 fail-open된다.
+        ``_is_finite_quantity`` helper 내부에서 ``OverflowError``를 가드하여
+        fail-closed reject 경로로 빠지는지 잠근다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+        unrealized_calls: list[tuple[str, float, str]] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for overflow int quantity")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run for overflow int quantity"
+            )
+
+        async def _spy_unrealized(bot_id, current_price, order_symbol):
+            unrealized_calls.append((bot_id, current_price, order_symbol))
+            raise AssertionError(
+                "_calculate_bot_unrealized_pnl must not run for overflow int quantity"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+        monkeypatch.setattr(engine, "_calculate_bot_unrealized_pnl", _spy_unrealized)
+
+        # 10**400은 float(...) 변환 시 OverflowError를 안정적으로 재현한다.
+        overflow_quantity = 10**400
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=overflow_quantity,  # type: ignore[arg-type]
+            order_type="limit",
+            price=1000.0,
+            exchange="KRX",
+            reason="A7 oracle overflow-int-quantity regression",
+        )
+
+        # OverflowError가 EventBus 핸들러까지 leak되면 publish가 예외를 던지므로,
+        # 이 호출이 정상 반환되는 것 자체가 게이트가 fail-closed인지 확인하는
+        # primary assertion이다.
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert unrealized_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Invalid quantity" in ev.reason
+        # rejection payload의 quantity는 sqlite REAL NOT NULL 호환을 위해
+        # 0.0으로 정규화된다 (overflow int → 0.0).
+        assert ev.quantity == 0.0
+
     @pytest.mark.parametrize(
         ("quantity", "side", "order_type", "price", "stop_price", "expected_reason"),
         [

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -2300,6 +2300,132 @@ class TestRuleEngineEventBus:
         assert isinstance(ev.quantity, float)
         assert ev.quantity == 0.0
 
+    async def test_rule_engine_safe_builder_handles_unrenderable_repr(
+        self, engine, eventbus, monkeypatch
+    ):
+        """``__repr__``가 raise하는 input에서도 fail-closed reject 발행 잠금.
+
+        회귀(#1302 메타 리뷰): preflight 게이트의 ``raise``가 EventBus 핸들러
+        예외 swallow에 걸려 ``OrderRejectedEvent`` 미발행 → audit fail-open.
+        catch-all ``except``와 ``_build_safe_rejected_event`` (raise하지 않는
+        builder)가 receive하는지 검증한다.
+
+        ``Unrenderable.__repr__``가 ``RuntimeError``를 던지는 ``side``를 넣어
+        invalid-side 게이트의 ``f"...{_safe_str(event.side)}..."`` reason 조립
+        자체가 raise해도 catch-all이 builder로 generic reject를 발행해야 한다.
+
+        ``_safe_str``는 ``repr`` 실패 시 ``"<unrenderable {type}>"`` placeholder
+        를 반환하므로 실제로 reason 조립은 raise하지 않는다 — 하지만 test의
+        목적은 invariant 보호이므로, ``_safe_str`` 구현이 향후 약화되어도
+        catch-all이 잡아내는지 정적으로 확인한다.
+        """
+
+        class Unrenderable:
+            def __repr__(self) -> str:
+                raise RuntimeError("repr deliberately fails")
+
+            def __str__(self) -> str:
+                raise RuntimeError("str deliberately fails")
+
+            def __hash__(self) -> int:
+                return 0
+
+            def __eq__(self, other: object) -> bool:
+                return False
+
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        # 본 입력은 invalid-side 게이트에서 fire (frozenset membership에서
+        # str 가드로 잠긴 후 reason 조립 단계로 진입).
+        bad_side = Unrenderable()
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side=bad_side,  # type: ignore[arg-type]
+            quantity=10.0,
+            order_type="market",
+            exchange="KRX",
+            reason="unrenderable repr regression",
+        )
+
+        # publish가 정상 반환되는 것 자체가 catch-all 안전망 검증.
+        await eventbus.publish(order)
+
+        assert len(validated) == 0
+        # 정확히 1건 발행되어야 한다 (게이트 발행 또는 catch-all 발행 중 하나).
+        assert len(rejected) == 1
+        ev = rejected[0]
+        # quantity는 finite float (10.0 → 정규화된 동일 값) 호환.
+        assert isinstance(ev.quantity, float)
+        # symbol/side/order_type 모두 sqlite TEXT 호환을 위해 str 정규화.
+        assert isinstance(ev.symbol, str)
+        assert isinstance(ev.side, str)
+        assert isinstance(ev.order_type, str)
+        # reason은 typed message 또는 generic "preflight error" 어느 쪽이든 OK.
+        assert isinstance(ev.reason, str)
+        assert ev.reason  # non-empty
+
+    async def test_rule_engine_catch_all_reject_for_synthetic_raise(
+        self, engine, eventbus, monkeypatch
+    ):
+        """preflight 도중 helper가 강제로 raise해도 catch-all이 reject 발행.
+
+        회귀(#1302 메타 리뷰): ``_query_treasury_data``를 monkeypatch로 raise
+        하도록 만들어 preflight 게이트 통과 후 evaluate 진입 직전에 강제 예외를
+        주입한다. catch-all ``except``가 잡아 ``_build_safe_rejected_event``로
+        generic reject를 발행하는지 (audit trail이 fail-closed로 잠기는지)
+        검증한다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            raise RuntimeError("synthetic preflight failure")
+
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+
+        # 모든 preflight 게이트를 통과하는 정상 입력. evaluate 직전 단계인
+        # _query_treasury_data에서 강제 raise → catch-all로 fail-closed.
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            order_type="market",
+            price=50000.0,
+            exchange="KRX",
+            reason="synthetic raise regression",
+        )
+
+        # catch-all 안전망이 동작하면 publish가 정상 반환된다.
+        await eventbus.publish(order)
+
+        assert len(validated) == 0
+        assert len(rejected) == 1
+        ev = rejected[0]
+        # generic catch-all reason
+        assert "preflight error" in ev.reason
+        # 모든 sqlite TEXT 컬럼은 str로 정규화돼야 한다.
+        assert isinstance(ev.symbol, str)
+        assert isinstance(ev.side, str)
+        assert isinstance(ev.order_type, str)
+        assert isinstance(ev.bot_id, str)
+        assert isinstance(ev.strategy_id, str)
+        assert isinstance(ev.exchange, str)
+        # quantity는 finite float
+        assert isinstance(ev.quantity, float)
+        assert ev.quantity == 10.0
+
 
 # ── RuleEngine.update_rules ──────────────────────
 

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -2104,6 +2104,126 @@ class TestRuleEngineEventBus:
         assert validated[0].order_type == "limit"
         assert validated[0].price == 1000.0
 
+    @pytest.mark.parametrize(
+        ("quantity", "side", "order_type", "price", "stop_price", "expected_reason"),
+        [
+            # #1300 limit-price 게이트: NaN quantity + price=None
+            (
+                float("nan"),
+                "buy",
+                "limit",
+                None,
+                None,
+                "Missing price",
+            ),
+            # #1298 invalid-order_type 게이트: inf quantity + order_type='trail'
+            (
+                float("inf"),
+                "buy",
+                "trail",
+                1000.0,
+                None,
+                "Invalid order type",
+            ),
+            # #1301 stop_price 게이트: NaN quantity + stop_price=None
+            (
+                float("nan"),
+                "buy",
+                "stop",
+                None,
+                None,
+                "Missing stop_price",
+            ),
+            # #1297 invalid-side 게이트: str quantity + invalid side
+            (
+                "bad",
+                "hold",
+                "market",
+                None,
+                None,
+                "Invalid signal side",
+            ),
+        ],
+    )
+    async def test_rule_engine_normalizes_nan_quantity_in_cross_field_rejects(
+        self,
+        engine,
+        eventbus,
+        monkeypatch,
+        quantity,
+        side,
+        order_type,
+        price,
+        stop_price,
+        expected_reason,
+    ):
+        """cross-field invalid payload에서 quantity도 0.0으로 정규화된다.
+
+        회귀(#1302 cross-field 보강): 본 PR 이전에는 새 NaN/inf/non-number
+        quantity 게이트가 stop_price 게이트(#1301) 직후에 위치했으나, 그보다
+        앞선 게이트들(invalid-side / invalid-order_type / invalid-krx-symbol /
+        limit-price / stop-price)은 ``OrderRejectedEvent.quantity`` payload에
+        ``event.quantity``를 그대로 실어 NaN/inf/str이 ``trades.quantity REAL
+        NOT NULL`` 컬럼 바인딩을 깨뜨릴 수 있었다. 모든 reject 경로가 동일한
+        ``_coerce_finite_quantity`` helper로 통일됐는지 잠근다.
+
+        각 케이스는 quantity 게이트 도달 전에 다른 게이트가 먼저 fire하므로
+        reason은 첫 게이트의 reason을 그대로 유지하고 ('Invalid quantity'가
+        아님), quantity만 0.0으로 정규화돼야 한다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        # 본 게이트들은 모두 룰 평가/Treasury 조회 이전에 fire하므로
+        # 호출되어선 안 된다.
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError(
+                "evaluate must not run for cross-field invalid payload"
+            )
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run for cross-field invalid payload"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side=side,
+            quantity=quantity,  # type: ignore[arg-type]
+            order_type=order_type,
+            price=price,
+            stop_price=stop_price,
+            exchange="KRX",
+            reason="cross-field quantity normalization regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        # reason은 cross-field로 먼저 fire한 게이트의 reason을 그대로 유지한다.
+        assert expected_reason in ev.reason
+        # rejection payload의 quantity는 trades.quantity REAL NOT NULL 호환을
+        # 위해 finite float (0.0)로 정규화된다.
+        assert isinstance(ev.quantity, float)
+        assert ev.quantity == 0.0
+
 
 # ── RuleEngine.update_rules ──────────────────────
 

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -1874,6 +1874,236 @@ class TestRuleEngineEventBus:
         assert "Missing stop_price" not in ev.reason
         assert ev.order_type == "stop_limit"
 
+    async def test_rule_engine_rejects_nan_quantity(
+        self, engine, eventbus, monkeypatch
+    ):
+        """quantity=NaN이면 룰 평가/Treasury 조회 이전에 거부한다.
+
+        회귀(#1302): A7 oracle이 검출한 버그 — Signal.quantity=NaN, side='buy',
+        order_type='limit', price=1000 주문이 RuleEngine→OrderValidatedEvent→
+        Treasury 진입 후 sqlite `bot_budgets.available NOT NULL` 위반으로
+        실패했다. NaN quantity는 Treasury 예약 호출 이전에 fail-closed로
+        거부해야 한다. rejection payload의 quantity는 sqlite REAL NOT NULL
+        호환을 위해 0.0으로 정규화된다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+        unrealized_calls: list[tuple[str, float, str]] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for NaN quantity")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError("_query_treasury_data must not run for NaN quantity")
+
+        async def _spy_unrealized(bot_id, current_price, order_symbol):
+            unrealized_calls.append((bot_id, current_price, order_symbol))
+            raise AssertionError(
+                "_calculate_bot_unrealized_pnl must not run for NaN quantity"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+        monkeypatch.setattr(engine, "_calculate_bot_unrealized_pnl", _spy_unrealized)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=float("nan"),
+            order_type="limit",
+            price=1000.0,
+            exchange="KRX",
+            reason="A7 oracle NaN-quantity regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert unrealized_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Invalid quantity" in ev.reason
+        assert "nan" in ev.reason.lower()
+        assert ev.account_id == "domestic"
+        assert ev.bot_id == "bot1"
+        assert ev.strategy_id == "s1"
+        assert ev.symbol == "005930"
+        assert ev.side == "buy"
+        assert ev.order_type == "limit"
+        assert ev.price == 1000.0
+        assert ev.exchange == "KRX"
+        assert ev.order_id == str(order.event_id)
+        # rejection payload의 quantity는 sqlite REAL NOT NULL 호환을 위해
+        # 0.0으로 정규화된다.
+        assert ev.quantity == 0.0
+
+    @pytest.mark.parametrize("bad_quantity", [float("inf"), float("-inf")])
+    async def test_rule_engine_rejects_inf_quantity(
+        self, engine, eventbus, monkeypatch, bad_quantity
+    ):
+        """quantity=±inf이면 룰 평가/Treasury 조회 이전에 거부한다."""
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+        unrealized_calls: list[tuple[str, float, str]] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for inf quantity")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError("_query_treasury_data must not run for inf quantity")
+
+        async def _spy_unrealized(bot_id, current_price, order_symbol):
+            unrealized_calls.append((bot_id, current_price, order_symbol))
+            raise AssertionError(
+                "_calculate_bot_unrealized_pnl must not run for inf quantity"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+        monkeypatch.setattr(engine, "_calculate_bot_unrealized_pnl", _spy_unrealized)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=bad_quantity,
+            order_type="limit",
+            price=1000.0,
+            exchange="KRX",
+            reason="A7 oracle inf-quantity regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert unrealized_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Invalid quantity" in ev.reason
+        assert "inf" in ev.reason.lower()
+        assert ev.quantity == 0.0
+        assert ev.symbol == "005930"
+        assert ev.order_type == "limit"
+
+    @pytest.mark.parametrize("bad_quantity", ["10", None, [], True])
+    async def test_rule_engine_rejects_non_number_quantity(
+        self, engine, eventbus, monkeypatch, bad_quantity
+    ):
+        """quantity가 number가 아니면 (str/None/list/bool) 룰 평가 이전에 거부한다.
+
+        bool은 isinstance(True, int)==True이므로 명시적으로 거부 대상에 포함한다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+        unrealized_calls: list[tuple[str, float, str]] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for non-number quantity")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run for non-number quantity"
+            )
+
+        async def _spy_unrealized(bot_id, current_price, order_symbol):
+            unrealized_calls.append((bot_id, current_price, order_symbol))
+            raise AssertionError(
+                "_calculate_bot_unrealized_pnl must not run for non-number quantity"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+        monkeypatch.setattr(engine, "_calculate_bot_unrealized_pnl", _spy_unrealized)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=bad_quantity,  # type: ignore[arg-type]
+            order_type="limit",
+            price=1000.0,
+            exchange="KRX",
+            reason="A7 oracle non-number-quantity regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert unrealized_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Invalid quantity" in ev.reason
+        # reason에 repr(bad_quantity)이 포함되어 audit trail에 원시값 보존
+        assert repr(bad_quantity) in ev.reason
+        # rejection payload의 quantity는 sqlite REAL NOT NULL 호환을 위해
+        # 0.0으로 정규화된다.
+        assert ev.quantity == 0.0
+
+    async def test_rule_engine_accepts_positive_finite_quantity(self, engine, eventbus):
+        """quantity=10.0이면 본 게이트를 통과해 OrderValidatedEvent가 발행된다.
+
+        기존 흐름이 유지됨을 보장하는 회귀 테스트. 본 PR은 NaN/inf/non-number
+        quantity만 거부하므로, 양수 finite quantity는 계속 통과해야 한다.
+        """
+        validated: list[OrderValidatedEvent] = []
+        rejected: list[OrderRejectedEvent] = []
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=10.0,
+            order_type="limit",
+            price=1000.0,
+            exchange="KRX",
+            reason="positive finite quantity should pass quantity gate",
+        )
+        await eventbus.publish(order)
+
+        assert len(rejected) == 0
+        assert len(validated) == 1
+        assert validated[0].quantity == 10.0
+        assert validated[0].order_type == "limit"
+        assert validated[0].price == 1000.0
+
 
 # ── RuleEngine.update_rules ──────────────────────
 


### PR DESCRIPTION
Closes #1302

## Summary
- A7 oracle이 검출한 NaN quantity 회귀 차단. `RuleEngine._on_order_request`의 stop_price 게이트(#1301) 직후에 NaN/inf/non-number/large-int quantity 거부 게이트 추가.
- 모듈 private helper:
  - `_is_finite_quantity` (`TypeGuard[int|float]`) — bool 명시 제외, `OverflowError`/`ValueError` 가드.
  - `_coerce_finite_quantity` — `OrderRejectedEvent.quantity` payload용 0.0 정규화 (sqlite `trades.quantity REAL NOT NULL` 호환).
  - `_coerce_finite_optional_price` — `OrderRejectedEvent.price` payload용 None 정규화 (NaN/비숫자/large-int → None).
  - `_safe_str` — `repr` raise 가능 케이스(Python 3.13 int 4300자리 제한 등)를 `<unrenderable {type}>` fallback.
  - `_build_safe_rejected_event` — 모든 source 필드를 정규화한 fail-closed builder. 절대 raise하지 않음.
- **구조 수정** (메타 리뷰 권고): `_on_order_request` preflight + evaluate 본체를 단일 try로 감싸고 catch-all에서 `_build_safe_rejected_event`(generic reason) 발행. 게이트 안의 raise가 EventBus의 핸들러 예외 swallow에 걸려 audit terminal event 누락하던 fail-open 구조 결함 차단.
- 기존 6개 reject 게이트(#1297–#1301)도 동일 builder를 호출하도록 통일 (cross-field invalid payload 보강).

## Test Plan
- [x] `uv run pytest tests/unit/test_rule.py -k "quantity or price or order_request or invalid or unhashable or symbol or cross_field or limit_order or stop_order or stop_limit or overflow or safe_builder or catch_all" -x` → 69 passed
- [x] `uv run pytest tests/unit/test_rule.py -x` → 167 passed
- [x] `uv run mypy src/ante/rule/engine.py` → Success: no issues
- [x] `uv run ruff check src/ante/rule/engine.py tests/unit/test_rule.py`
- [x] `uv run ruff format --check src/ante/rule/engine.py tests/unit/test_rule.py`

## Codex Branch Review (6 attempts)
1. `926f6db` FAIL — cross-field NaN bypass (다른 게이트 미정규화)
2. `009958e` FAIL — large int(`10**10000`) `math.isfinite` OverflowError → fail-open
3. `772d6d4` FAIL — Python 3.13 int 4300자리 제한으로 `repr(quantity)` ValueError → fail-open. **메타 리뷰 트리거**
4. `d8b70f8` FAIL — builder의 `price` 필드 정규화 누락 (NaN/비숫자 sqlite bind 깨짐)
5. `d55f9a4` FAIL — mypy `_is_finite_quantity`가 TypeGuard가 아니라 `float(value: object)` overload 에러
6. `fc4c873` PASS

## Code-reviewer 메타 리뷰 (attempt 3 후)
- 결론: PR 분할 X, plan 재설계 X. 같은 PR에서 구조 수정 1라운드.
- 핵심 진단: preflight 게이트가 try 밖이라 EventBus.publish 핸들러 예외 swallow에 걸려 audit fail-open. raise 지점을 한 줄씩 가리는 패턴은 4번째 회귀로 이어진다.
- 권고: 전체 try wrapper + safe builder 통일 → attempt 4에서 적용.

## Follow-ups (별도 이슈)
- A: #1297–#1301 inline reject payload 조립을 `_build_safe_rejected_event` 패턴으로 retroactive 통일 — **이번 PR에서 함께 적용 완료**.
- B: EventBus.publish 핸들러 예외 시 dead-letter event 발행 (현재 logger.exception만, audit 사각지대).
- C: Treasury 자체 quantity finite 재검증 (risk flag `treasury-bypass-deferred`).

## Scope Boundary
- 본 PR은 NaN/inf/non-number/large-int quantity만. 0/음수 quantity는 #1304/#1305 별도. NaN price는 #1303 별도. Pathological large-int 등 strategy가 정상적으로 만들 수 없는 입력은 catch-all builder가 receive.
