### PR TITLE
fix(rule): reject NaN/inf/non-number price at OrderRequestEvent preflight (#1303)

### DIFF
--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -743,6 +743,34 @@ class RuleEngine:
                 )
                 return
 
+            # OrderRequestEvent 계약 preflight: price 값이 있으면 finite number.
+            # 회귀(#1303): A7 oracle이 검출한 버그 — Signal.price=NaN, side='buy',
+            # order_type='limit', quantity=1 주문이 RuleEngine→OrderValidatedEvent→
+            # Treasury 진입 후 sqlite NOT NULL 위반으로 실패했다. NaN/inf/non-number
+            # price는 Treasury 예약/주문 호출 이전에 fail-closed로 거부한다.
+            #
+            # ``price=None``은 정상 흐름이다 — market 주문은 None이 옵션이며,
+            # limit/stop_limit의 price=None은 #1300 게이트가 별도 처리한다. 본
+            # 게이트는 price 값이 있을 때만 finite numeric을 강제한다.
+            #
+            # ``_is_finite_quantity``는 비-number/bool/NaN/inf 및 ``10**400`` 같은
+            # 거대 정수 (float 변환 시 ``OverflowError``)를 모두 함께 잠근다.
+            # 0/음수 price 검증, NaN stop_price, OrderModifyEvent price 검증은
+            # 본 PR 범위 밖(별도 후속 이슈)이다.
+            if event.price is not None and not _is_finite_quantity(event.price):
+                reason = (
+                    f"Invalid price: {_safe_repr(event.price)} "
+                    f"(price must be a finite number when provided)"
+                )
+                await self._eventbus.publish(
+                    _build_safe_rejected_event(
+                        account_id=self._account_id,
+                        event=event,
+                        reason=reason,
+                    )
+                )
+                return
+
             # 계좌 상태 조회
             account_status = "active"
             currency = "KRW"

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -2180,6 +2180,301 @@ class TestRuleEngineEventBus:
         # 0.0으로 정규화된다 (overflow int → 0.0).
         assert ev.quantity == 0.0
 
+    async def test_rule_engine_rejects_nan_price(self, engine, eventbus, monkeypatch):
+        """price=NaN이면 룰 평가/Treasury 조회 이전에 거부한다.
+
+        회귀(#1303): A7 oracle이 검출한 버그 — Signal.price=NaN, side='buy',
+        order_type='limit', quantity=1 주문이 RuleEngine→OrderValidatedEvent→
+        Treasury 진입 후 sqlite NOT NULL 위반으로 실패했다. NaN price는
+        Treasury 예약 호출 이전에 fail-closed로 거부해야 한다. rejection
+        payload의 price는 ``_coerce_finite_optional_price``로 ``None``으로
+        정규화된다 (trades.price REAL nullable 호환).
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+        unrealized_calls: list[tuple[str, float, str]] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for NaN price")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError("_query_treasury_data must not run for NaN price")
+
+        async def _spy_unrealized(bot_id, current_price, order_symbol):
+            unrealized_calls.append((bot_id, current_price, order_symbol))
+            raise AssertionError(
+                "_calculate_bot_unrealized_pnl must not run for NaN price"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+        monkeypatch.setattr(engine, "_calculate_bot_unrealized_pnl", _spy_unrealized)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=1.0,
+            order_type="limit",
+            price=float("nan"),
+            exchange="KRX",
+            reason="A7 oracle NaN-price regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert unrealized_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Invalid price" in ev.reason
+        assert "nan" in ev.reason.lower()
+        assert ev.account_id == "domestic"
+        assert ev.bot_id == "bot1"
+        assert ev.strategy_id == "s1"
+        assert ev.symbol == "005930"
+        assert ev.side == "buy"
+        assert ev.order_type == "limit"
+        assert ev.quantity == 1.0
+        assert ev.exchange == "KRX"
+        assert ev.order_id == str(order.event_id)
+        # rejection payload의 price는 trades.price REAL nullable 호환을 위해
+        # None으로 정규화된다 (NaN → None via _coerce_finite_optional_price).
+        assert ev.price is None
+
+    @pytest.mark.parametrize("bad_price", [float("inf"), float("-inf")])
+    async def test_rule_engine_rejects_inf_price(
+        self, engine, eventbus, monkeypatch, bad_price
+    ):
+        """price=±inf이면 룰 평가/Treasury 조회 이전에 거부한다."""
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+        unrealized_calls: list[tuple[str, float, str]] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for inf price")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError("_query_treasury_data must not run for inf price")
+
+        async def _spy_unrealized(bot_id, current_price, order_symbol):
+            unrealized_calls.append((bot_id, current_price, order_symbol))
+            raise AssertionError(
+                "_calculate_bot_unrealized_pnl must not run for inf price"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+        monkeypatch.setattr(engine, "_calculate_bot_unrealized_pnl", _spy_unrealized)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=1.0,
+            order_type="limit",
+            price=bad_price,
+            exchange="KRX",
+            reason="A7 oracle inf-price regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert unrealized_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Invalid price" in ev.reason
+        assert "inf" in ev.reason.lower()
+        # builder가 inf price를 None으로 정규화 (trades.price REAL nullable 호환).
+        assert ev.price is None
+        assert ev.symbol == "005930"
+        assert ev.order_type == "limit"
+
+    @pytest.mark.parametrize("bad_price", ["100", [], {}, True, 10**400])
+    async def test_rule_engine_rejects_non_number_price(
+        self, engine, eventbus, monkeypatch, bad_price
+    ):
+        """price가 number가 아니면 (str/list/dict/bool/large-int) 거부한다.
+
+        - bool은 isinstance(True, int)==True이므로 명시적으로 거부 대상에 포함.
+        - 10**400은 float(...) 변환 시 OverflowError를 유발하는 거대 int.
+          ``_is_finite_quantity`` helper의 OverflowError 가드가 동작해
+          fail-closed 거부 경로로 빠지는지 함께 잠근다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+        unrealized_calls: list[tuple[str, float, str]] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for non-number price")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run for non-number price"
+            )
+
+        async def _spy_unrealized(bot_id, current_price, order_symbol):
+            unrealized_calls.append((bot_id, current_price, order_symbol))
+            raise AssertionError(
+                "_calculate_bot_unrealized_pnl must not run for non-number price"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+        monkeypatch.setattr(engine, "_calculate_bot_unrealized_pnl", _spy_unrealized)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=1.0,
+            order_type="limit",
+            price=bad_price,  # type: ignore[arg-type]
+            exchange="KRX",
+            reason="A7 oracle non-number-price regression",
+        )
+
+        # OverflowError가 EventBus 핸들러까지 leak되면 publish가 예외를 던지므로,
+        # 정상 반환되는 것 자체가 fail-closed 잠금 검증 (large-int 케이스).
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert unrealized_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Invalid price" in ev.reason
+        # reason에 repr(bad_price)가 포함되어 audit trail에 원시값 보존
+        assert repr(bad_price) in ev.reason
+        # rejection payload의 price는 trades.price REAL nullable 호환을 위해
+        # None으로 정규화된다 (비-number → None).
+        assert ev.price is None
+
+    async def test_rule_engine_accepts_market_with_none_price(self, engine, eventbus):
+        """price=None + order_type='market'은 본 게이트를 통과한다.
+
+        market 주문의 price=None은 스펙상 정상이며 #1300 게이트도 limit/stop_limit
+        에만 해당한다. 본 PR이 추가하는 NaN/inf 게이트가 ``price is None`` 케이스를
+        false-positive로 거부하지 않는지 회귀 잠금.
+        """
+        validated: list[OrderValidatedEvent] = []
+        rejected: list[OrderRejectedEvent] = []
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=1.0,
+            order_type="market",
+            price=None,
+            exchange="KRX",
+            reason="market with None price should pass price gate",
+        )
+        await eventbus.publish(order)
+
+        assert len(rejected) == 0
+        assert len(validated) == 1
+        assert validated[0].price is None
+        assert validated[0].order_type == "market"
+
+    async def test_rule_engine_accepts_finite_price(self, engine, eventbus):
+        """price=1000.0 + order_type='limit'은 본 게이트를 통과한다.
+
+        finite numeric price는 본 PR 게이트의 정상 흐름. limit 주문의 정상
+        진행이 깨지지 않는지 회귀 잠금.
+        """
+        validated: list[OrderValidatedEvent] = []
+        rejected: list[OrderRejectedEvent] = []
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=1.0,
+            order_type="limit",
+            price=1000.0,
+            exchange="KRX",
+            reason="finite limit price should pass price gate",
+        )
+        await eventbus.publish(order)
+
+        assert len(rejected) == 0
+        assert len(validated) == 1
+        assert validated[0].price == 1000.0
+        assert validated[0].order_type == "limit"
+
+    async def test_rule_engine_accepts_market_with_finite_price(self, engine, eventbus):
+        """price=1000.0 + order_type='market'은 본 게이트를 통과한다.
+
+        market 주문에 price 값이 함께 실려도 (extra field 거부는 본 PR 비대상)
+        finite numeric이면 본 게이트는 통과해야 한다. 회귀 잠금.
+        """
+        validated: list[OrderValidatedEvent] = []
+        rejected: list[OrderRejectedEvent] = []
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=1.0,
+            order_type="market",
+            price=1000.0,
+            exchange="KRX",
+            reason="market with finite price should pass price gate",
+        )
+        await eventbus.publish(order)
+
+        assert len(rejected) == 0
+        assert len(validated) == 1
+        assert validated[0].price == 1000.0
+        assert validated[0].order_type == "market"
+
     @pytest.mark.parametrize(
         ("quantity", "side", "order_type", "price", "stop_price", "expected_reason"),
         [


### PR DESCRIPTION
Closes #1303

## Summary
- A7 oracle이 검출한 NaN price 회귀 차단. `RuleEngine._on_order_request`의 quantity 게이트(#1302) 직후에 NaN/inf/non-number/large-int price 거부 게이트 추가.
- `event.price is not None and not _is_finite_quantity(event.price)`이면 `_build_safe_rejected_event`로 reject 발행 후 즉시 return. price=None은 통과 (market 정상 + #1300 limit/stop_limit price 게이트가 별도 처리).
- **#1302 helper(`_is_finite_quantity` TypeGuard, `_safe_repr`, `_build_safe_rejected_event`) 재사용**. 새 helper 추가 X.

## Test Plan
- [x] `uv run pytest tests/unit/test_rule.py -k "price or order_request or quantity or limit_order or stop_order" -x` → 47 passed
- [x] `uv run pytest tests/unit/test_rule.py -x` → 178 passed
- [x] `uv run mypy src/ante/rule/engine.py` → Success
- [x] `uv run ruff check src/ante/rule/engine.py tests/unit/test_rule.py`
- [x] `uv run ruff format --check src/ante/rule/engine.py tests/unit/test_rule.py`

## Codex Branch Review
- attempt 1 (`98e0a34`): PASS

## Scope Boundary
- 본 PR은 **NaN/inf/non-number/large-int price만**. 0/음수 price는 별도 후속 이슈(finite지만 도메인 유효성 별도 정책). NaN/inf stop_price, OrderModifyEvent.price는 별도. quantity 0/음수는 #1304/#1305.
- price=None인 limit/stop_limit는 #1300(이미 머지)이 처리. market+price=finite는 통과 (extra field 금지는 본 PR 비대상).

## Residual Risk (이슈 본문 v2 명시)
- `treasury-bypass-deferred`: 정상 경로 SSOT는 RuleEngine. Treasury 자체 finite 재검증 또는 OrderValidatedEvent 직접 발행 producer 방어는 별도 이슈.
