### PR TITLE
fix(rule): inject default trading_hours for KIS + classify 40580000 (#1296)

### DIFF
--- a/docs/specs/rule-engine/09-rule-management.md
+++ b/docs/specs/rule-engine/09-rule-management.md
@@ -42,6 +42,25 @@ fallback으로만 사용한다. 웹/API에서 룰을 수정하면 `dynamic_confi
 
 > `trading_hours` 룰의 시간대와 거래 시간은 Account 모델에서 자동 주입되므로, 룰 설정에서 별도로 지정하지 않는다. Account의 `trading_hours_start`, `trading_hours_end`, `timezone` 필드가 곧 TradingHoursRule의 설정이 된다.
 
+### Stored rules vs effective rules
+
+`accounts.{account_id}.rules` config는 사용자/Agent가 명시한 explicit
+overrides(stored rules)다. 시스템이 RuleEngine에 적용하는 effective rules는
+broker_type별 defaults와 stored overrides의 merge다.
+
+- broker_type별 defaults: `kis-domestic`은 `trading_hours`를 자동 포함한다
+  (KIS 모의투자/실거래 모두 KRX 장중에만 주문 수용; A7 oracle 회귀 #1296).
+  `test` broker는 default가 없다(24h 거래 가정).
+- merge 정책: type-key 기반. stored 항목이 default와 같은 `type`이면 stored가
+  default를 override한다. 사용자/Agent는 `enabled: false`로 default를 명시
+  비활성화할 수 있으며, audit/UI/API 응답에서 그 결정이 드러나야 한다
+  (UI/API의 effective view는 후속 이슈).
+- reload: `ConfigChangedEvent` 처리 시에도 같은 merge 정책이 적용되어, PUT
+  이후 reload 결과가 default를 잃지 않는다.
+
+GET/PUT API(`/api/accounts/{id}/rules*`)는 stored rules만 노출한다. effective
+rules의 별도 노출은 본 스펙의 후속 이슈에서 다룬다.
+
 ### Static TOML seed
 
 정적 TOML은 운영 중 룰 수정의 저장소가 아니다. 초기 계좌 seed나 복구용 기본값이 필요할

--- a/src/ante/broker/error_codes.py
+++ b/src/ante/broker/error_codes.py
@@ -1,6 +1,10 @@
 """KIS API 에러코드 분류.
 
 KIS rt_cd / msg_cd 기반으로 재시도 가능 여부를 판별한다.
+
+KIS msg_cd는 ``APBK*`` 형식 또는 numeric business code(예: ``40580000``)
+모두 가능하다. 두 형식 모두 동일하게 ``PERMANENT_MSG_CODES`` /
+``TRANSIENT_MSG_CODES`` set에 등록한다.
 """
 
 # ── 재시도 불가 (permanent) KIS msg_cd ─────────────────
@@ -19,6 +23,7 @@ PERMANENT_MSG_CODES: frozenset[str] = frozenset(
         "APBK0501",  # 잘못된 계좌번호
         "APBK0502",  # 잘못된 비밀번호
         "APBK0503",  # 잘못된 주문 유형
+        "40580000",  # 장종료 또는 주문불가 시간 (#1296: A7 oracle 회귀)
     }
 )
 
@@ -52,6 +57,7 @@ KIS_ERROR_MESSAGES: dict[str, str] = {
     "APBK0600": "서버 과부하 (재시도 가능)",
     "APBK0601": "처리 지연 (재시도 가능)",
     "APBK0602": "일시적 서비스 불가 (재시도 가능)",
+    "40580000": "장종료 또는 주문불가 시간",
 }
 
 

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -398,7 +398,9 @@ async def _init_trading(s: Services) -> None:
         treasury_manager=s.treasury_manager,
         trade_service=s.trade_service,
     )
-    await s.rule_engine_manager.initialize_all(accounts, config=s.config)
+    await s.rule_engine_manager.initialize_all(
+        accounts, config=s.config, dynamic_config=s.dynamic_config
+    )
     logger.info("RuleEngineManager 초기화 완료: %d개 계좌", len(accounts))
 
     # BotManager

--- a/src/ante/rule/defaults.py
+++ b/src/ante/rule/defaults.py
@@ -1,0 +1,69 @@
+"""Account broker_type별 default rule 해석 helper.
+
+스펙(`docs/specs/rule-engine/09-rule-management.md` "Stored rules vs effective
+rules")에 따라, RuleEngine에 적용되는 effective rule은 다음 두 source의
+type-key 기반 merge다.
+
+- broker_type별 system defaults (예: ``kis-domestic``은 ``trading_hours``
+  자동 포함)
+- ``accounts.{account_id}.rules`` DynamicConfig의 explicit overrides
+
+stored 항목이 default와 같은 ``type``이면 stored가 default를 override한다.
+사용자/Agent는 ``enabled: false``로 default를 명시 비활성화할 수 있다.
+
+회귀: A7 oracle (#1296) — KIS 모의투자 KRX 장종료 상태에서 시장가 매수
+신호가 매 interval 반복 → broker까지 도달 → KIS ``40580000`` 4건 누적.
+근본 원인은 ``RuleEngineManager``가 KIS domestic 계좌에 default
+``TradingHoursRule``을 자동 주입하지 않아 spec(09-rule-management.md L43)
+위반이었다.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ante.account.models import Account
+
+
+# broker_type → list of default rule config dicts.
+# rule config 스키마는 RuleEngine._create_rule이 받는 형태와 동일하다
+# (``type`` 필수, 나머지는 Rule 서브클래스 ``__init__`` config로 전달).
+_DEFAULT_RULES_BY_BROKER_TYPE: dict[str, list[dict[str, Any]]] = {
+    "kis-domestic": [{"type": "trading_hours", "enabled": True}],
+    "test": [],  # test broker는 24h 거래
+}
+
+
+def resolve_effective_rules(
+    account: Account,
+    stored_rules: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Account broker_type별 default + stored explicit override를 merge.
+
+    정책:
+
+    - ``stored_rules``에 ``type``이 같은 항목이 있으면 그것이 default를
+      override한다 (``enabled: false``로 비활성화 포함).
+    - ``stored_rules``에 default ``type``이 없으면 default를 effective에
+      추가한다.
+    - ``stored_rules``의 추가 항목(custom rule)은 그대로 유지한다.
+
+    Args:
+        account: 대상 계좌. ``broker_type``만 default 결정에 쓴다.
+        stored_rules: ``accounts.{account_id}.rules`` DynamicConfig에서
+            읽은 explicit override 리스트. ``None``은 빈 리스트와 동일.
+
+    Returns:
+        RuleEngine.load_rules_from_config()에 그대로 넘길 수 있는 effective
+        rule config 리스트.
+    """
+    defaults = _DEFAULT_RULES_BY_BROKER_TYPE.get(account.broker_type, [])
+    overrides = stored_rules or []
+    override_types = {r.get("type") for r in overrides if isinstance(r, dict)}
+    result: list[dict[str, Any]] = []
+    for d in defaults:
+        if d.get("type") not in override_types:
+            result.append(d)
+    result.extend(overrides)
+    return result

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -28,6 +28,7 @@ from ante.rule.strategy_rules import (
 )
 
 if TYPE_CHECKING:
+    from ante.account.models import Account
     from ante.account.service import AccountService
     from ante.eventbus.bus import EventBus
     from ante.trade.service import TradeService
@@ -259,6 +260,7 @@ class RuleEngine:
         bot_strategy_resolver: Callable[[str], str | None] | None = None,
         treasury: Treasury | None = None,
         trade_service: TradeService | None = None,
+        account: Account | None = None,
     ) -> None:
         from ante.account.scoping import require_account_id
 
@@ -270,6 +272,11 @@ class RuleEngine:
         self._bot_strategy_resolver = bot_strategy_resolver
         self._treasury = treasury
         self._trade_service = trade_service
+        # Account snapshot — reload 경로(``_on_config_changed``)에서 broker_type별
+        # default를 다시 merge할 때 참조한다. 생명주기 동안 broker_type 불변 가정.
+        # 기존 호출자(테스트 fixture 등) 호환을 위해 ``None`` 허용 — None일 때
+        # reload 경로는 helper를 우회하여 stored 그대로 적용한다 (#1296).
+        self._account = account
 
         self._account_rules: list[Rule] = []
         self._strategy_rules: dict[str, list[Rule]] = {}
@@ -1125,7 +1132,16 @@ class RuleEngine:
 
         if event.category in ("rule", "global_rule"):
             self._account_rules.clear()
-            self.load_rules_from_config(new_rules)
+            # account snapshot이 있으면 broker_type별 default를 다시 merge하여
+            # reload 후에도 effective rule 집합이 유지되도록 한다 (#1296).
+            # account가 없는 호출자(테스트 fixture 등)에서는 기존 동작 유지.
+            if self._account is not None:
+                from ante.rule.defaults import resolve_effective_rules
+
+                effective = resolve_effective_rules(self._account, new_rules)
+                self.load_rules_from_config(effective)
+            else:
+                self.load_rules_from_config(new_rules)
             logger.info("계좌 룰 재로드 완료: %d건", len(self._account_rules))
         elif event.category == "strategy_rule":
             # key 형식: "rules.strategy.<strategy_id>" 또는 strategy_id 직접

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -1118,6 +1118,16 @@ class RuleEngine:
         if event.category not in ("rule", "global_rule", "strategy_rule"):
             return
 
+        # 다중 계좌 환경에서 ConfigChangedEvent는 모든 RuleEngine subscriber에게
+        # broadcast된다. category="rule"은 계좌별 룰(`accounts.{account_id}.rules`)
+        # 변경을 의미하므로, 자기 계좌 키가 아니면 무시해야 한다. 그렇지 않으면
+        # 다른 계좌의 stored rules가 자기 effective rules로 잘못 merge되어
+        # 계좌간 default rule(예: trading_hours)이 cross-contamination 된다 (#1296).
+        if event.category == "rule":
+            expected_key = f"accounts.{self._account_id}.rules"
+            if event.key != expected_key:
+                return
+
         logger.info("룰 설정 변경 감지, 재로딩 시작: %s", event.key)
 
         try:

--- a/src/ante/rule/manager.py
+++ b/src/ante/rule/manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from ante.rule.defaults import resolve_effective_rules
 from ante.rule.engine import RuleEngine
 
 if TYPE_CHECKING:
@@ -37,12 +38,20 @@ class RuleEngineManager:
         self,
         account_id: str,
         rule_configs: list[dict[str, Any]] | None = None,
+        *,
+        account: Account | None = None,
     ) -> RuleEngine:
         """계좌별 RuleEngine 생성. EventBus에 자동 구독.
 
         Args:
             account_id: 계좌 ID.
-            rule_configs: 계좌 룰 설정 리스트. None이면 빈 룰.
+            rule_configs: 계좌 룰 설정 리스트. ``None``이면 빈 룰.
+                ``initialize_all`` 호출 경로에서는 broker_type별 default를 이미
+                merge한 effective list가 들어온다.
+            account: 계좌 snapshot. 전달되면 RuleEngine에 캐시되어 reload
+                경로(``_on_config_changed``)에서 broker_type별 default를 다시
+                merge할 때 사용된다. ``None``이면 reload 경로는 stored 그대로
+                적용 (하위 호환).
 
         Returns:
             생성된 RuleEngine 인스턴스.
@@ -60,6 +69,7 @@ class RuleEngineManager:
             account_service=self._account_service,
             treasury=treasury,
             trade_service=self._trade_service,
+            account=account,
         )
 
         if rule_configs:
@@ -99,15 +109,21 @@ class RuleEngineManager:
             config: 전체 설정 객체 (룰 설정 추출용). None이면 빈 룰.
         """
         for account in accounts:
-            rule_configs: list[dict[str, Any]] = []
+            stored_rules: list[dict[str, Any]] | None = None
 
-            # config에서 계좌별 룰 설정 추출
+            # config에서 계좌별 룰 설정 추출 (explicit overrides)
             if config is not None and hasattr(config, "get"):
                 account_rules = config.get(f"accounts.{account.account_id}.rules", None)
                 if isinstance(account_rules, list):
-                    rule_configs = account_rules
+                    stored_rules = account_rules
 
-            self.create_engine(account.account_id, rule_configs)
+            # broker_type별 default + stored override를 merge하여 effective rules 산출.
+            # KIS domestic 계좌는 stored가 비어 있어도 ``trading_hours`` default가
+            # 자동 주입된다 (스펙 09-rule-management.md L43, #1296 회귀).
+            rule_configs = resolve_effective_rules(account, stored_rules)
+
+            # account snapshot을 함께 전달하여 reload 경로에서도 default merge 유지.
+            self.create_engine(account.account_id, rule_configs, account=account)
 
         logger.info("RuleEngineManager 초기화 완료: %d개 계좌", len(self._engines))
 

--- a/src/ante/rule/manager.py
+++ b/src/ante/rule/manager.py
@@ -99,21 +99,43 @@ class RuleEngineManager:
         self,
         accounts: list[Account],
         config: Any = None,
+        dynamic_config: Any = None,
     ) -> None:
         """시스템 시작 시 모든 계좌의 RuleEngine 초기화.
 
         각 계좌에 대해 RuleEngine을 생성하고, 계좌별 룰 설정을 로드한다.
 
+        Stored rules 우선순위 (명시 우선 정책 — #1296 P2):
+
+        1. ``dynamic_config`` (런타임 PUT으로 저장된 override). 재시작 시
+           사용자가 명시적으로 비활성화한 룰이 default 재주입으로 되살아나지
+           않도록 ``static config``보다 우선한다.
+        2. ``config`` (정적 YAML/TOML 등 startup snapshot).
+        3. 둘 다 없으면 ``stored_rules=None`` → broker_type별 default만 적용.
+
         Args:
             accounts: 초기화할 계좌 목록.
-            config: 전체 설정 객체 (룰 설정 추출용). None이면 빈 룰.
+            config: 전체 설정 객체 (룰 설정 추출용). None이면 static fallback 없음.
+            dynamic_config: ``DynamicConfigService`` 인스턴스. None이면 runtime
+                override 조회를 건너뛴다 (하위 호환).
         """
         for account in accounts:
+            key = f"accounts.{account.account_id}.rules"
             stored_rules: list[dict[str, Any]] | None = None
 
-            # config에서 계좌별 룰 설정 추출 (explicit overrides)
-            if config is not None and hasattr(config, "get"):
-                account_rules = config.get(f"accounts.{account.account_id}.rules", None)
+            # 1순위: DynamicConfig (런타임 override). API PUT으로 저장된 명시
+            # 비활성화가 재시작 후에도 살아 있도록 static보다 먼저 본다 (#1296).
+            if dynamic_config is not None:
+                try:
+                    dyn_rules = await dynamic_config.get(key, default=None)
+                except Exception:  # noqa: BLE001 — DynamicConfig 백엔드 불일치 fallback
+                    dyn_rules = None
+                if isinstance(dyn_rules, list):
+                    stored_rules = dyn_rules
+
+            # 2순위: 정적 config fallback.
+            if stored_rules is None and config is not None and hasattr(config, "get"):
+                account_rules = config.get(key, None)
                 if isinstance(account_rules, list):
                     stored_rules = account_rules
 

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -824,6 +824,13 @@ async def update_account_rule(
 
     RULE_REGISTRY에 등록된 타입만 허용하며,
     DynamicConfigService에 위임하여 ConfigChangedEvent를 발행한다.
+
+    저장되는 ``accounts.{account_id}.rules`` 값은 explicit overrides(stored
+    rules)다. RuleEngine이 실제로 적용하는 effective rules는
+    ``ante.rule.defaults.resolve_effective_rules``가 broker_type별 defaults와
+    이 stored rules를 merge한 결과이며, ``ConfigChangedEvent`` reload 시
+    동일 helper가 다시 호출된다. 본 GET/PUT API는 stored rules만 다룬다 —
+    effective view는 후속 이슈에서 별도 엔드포인트로 노출한다 (#1296).
     """
     from ante.account.errors import AccountNotFoundError
     from ante.rule.engine import RULE_REGISTRY

--- a/tests/unit/test_account_rules_api.py
+++ b/tests/unit/test_account_rules_api.py
@@ -559,3 +559,66 @@ class TestRuleConfigValidation:
             json={"enabled": True, "params": {"max_daily_loss_percent": "abc"}},
         )
         assert resp.status_code == 422
+
+
+class TestAccountRulesEffectiveMergeContract:
+    """PUT API와 effective rules merge의 계약 검증 (#1296).
+
+    PUT API는 stored(explicit overrides)만 다룬다. RuleEngine이 reload 시
+    실제 적용하는 effective rules는
+    ``ante.rule.defaults.resolve_effective_rules``가 broker_type별 default와
+    stored를 merge한 결과다.
+
+    회귀: KIS domestic 계좌에서 ``daily_loss_limit`` 같은 custom rule을
+    PUT으로 추가했을 때, default ``trading_hours``가 effective에서 사라지면
+    A7 oracle (#1296) 회귀가 재현된다. 본 테스트는 stored가
+    explicit-only로 저장되되, helper가 merge하면 default + custom이 모두
+    살아 있음을 검증한다.
+    """
+
+    def test_account_rules_api_put_preserves_default(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        dynamic_config: FakeDynamicConfig,
+    ) -> None:
+        """KIS 계좌에 custom rule PUT 후 effective merge에 default가 보존된다."""
+        from ante.rule.defaults import resolve_effective_rules
+
+        # KIS domestic 계좌 등록.
+        kis_account = Account(
+            account_id="acct-kis",
+            name="KIS 국내",
+            exchange="KRX",
+            currency="KRW",
+            timezone="Asia/Seoul",
+            trading_hours_start="09:00",
+            trading_hours_end="15:30",
+            trading_mode=TradingMode.VIRTUAL,
+            broker_type="kis-domestic",
+            credentials={},
+            buy_commission_rate=Decimal("0"),
+            sell_commission_rate=Decimal("0"),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        account_service._accounts["acct-kis"] = kis_account
+
+        # custom rule PUT.
+        resp = client.put(
+            "/api/accounts/acct-kis/rules/daily_loss_limit",
+            json={"enabled": True, "params": {"max_daily_loss_percent": 0.05}},
+        )
+        assert resp.status_code == 200
+
+        # stored에는 explicit override만 — default trading_hours는 빠져 있다.
+        stored = dynamic_config._store["accounts.acct-kis.rules"]
+        stored_types = {r.get("type") for r in stored}
+        assert stored_types == {"daily_loss_limit"}
+
+        # effective merge 시 default trading_hours + custom daily_loss_limit
+        # 모두 살아 있어야 한다 (#1296: reload 후에도 KIS default 보존).
+        effective = resolve_effective_rules(kis_account, stored)
+        effective_types = [r.get("type") for r in effective]
+        assert "trading_hours" in effective_types
+        assert "daily_loss_limit" in effective_types

--- a/tests/unit/test_kis_error_handling.py
+++ b/tests/unit/test_kis_error_handling.py
@@ -27,6 +27,10 @@ class TestErrorCodeClassification:
         assert is_retryable_msg_code("APBK0919") is False  # 잔고 부족
         assert is_retryable_msg_code("APBK0013") is False  # 잘못된 종목코드
         assert is_retryable_msg_code("APBK1002") is False  # 시장 마감
+        # #1296 A7 oracle: 모의투자 KRX 장종료 상태에서 시장가 주문 시
+        # 반환되는 numeric msg_cd. retry/circuit breaker를 더 이상 오염시키면
+        # 안 된다.
+        assert is_retryable_msg_code("40580000") is False
 
     def test_transient_msg_code_retryable(self):
         """서버 과부하 등 transient 에러는 재시도 가능."""
@@ -68,6 +72,8 @@ class TestErrorCodeClassification:
         """알려진 에러코드에 한글 메시지 반환."""
         assert get_error_message("APBK0919") == "잔고 부족"
         assert get_error_message("APBK1002") == "시장 마감"
+        # #1296 A7 oracle 회귀
+        assert get_error_message("40580000") == "장종료 또는 주문불가 시간"
 
     def test_error_message_unknown_code(self):
         """알 수 없는 에러코드에 fallback 메시지."""

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -3621,6 +3621,119 @@ class TestRuleEngineManager:
         assert len(engine1._global_rules) == 1
         assert len(engine2._global_rules) == 0
 
+    async def test_initialize_all_injects_default_trading_hours_for_kis_domestic(
+        self, manager
+    ):
+        """KIS domestic 계좌는 stored rule이 없어도 default ``TradingHoursRule``이
+        자동 주입된다 (#1296 A7 oracle 회귀)."""
+        accounts = [
+            Account(
+                account_id="domestic",
+                name="국내주식",
+                exchange="KRX",
+                currency="KRW",
+                broker_type="kis-domestic",
+            ),
+        ]
+
+        await manager.initialize_all(accounts)  # config 미전달 → stored 없음
+
+        engine = manager.get("domestic")
+        rule_types = {type(r).__name__ for r in engine._account_rules}
+        assert "TradingHoursRule" in rule_types
+
+    async def test_initialize_all_respects_explicit_disable(self, manager):
+        """KIS + ``trading_hours.enabled=False``로 stored되어 있으면 RuleEngine은
+        해당 룰을 건너뛴다 (config 명시 비활성화 존중)."""
+
+        class _FakeConfig:
+            def __init__(self, data):
+                self._data = data
+
+            def get(self, key, default=None):
+                return self._data.get(key, default)
+
+        accounts = [
+            Account(
+                account_id="domestic",
+                name="국내주식",
+                exchange="KRX",
+                currency="KRW",
+                broker_type="kis-domestic",
+            ),
+        ]
+        config = _FakeConfig(
+            {
+                "accounts.domestic.rules": [
+                    {"type": "trading_hours", "enabled": False},
+                ]
+            }
+        )
+
+        await manager.initialize_all(accounts, config=config)
+
+        engine = manager.get("domestic")
+        # 룰 인스턴스는 1개 생성되되 enabled=False여야 한다 — is_applicable이
+        # False를 반환해 평가 시 건너뛴다.
+        trading_hours_rules = [
+            r for r in engine._account_rules if type(r).__name__ == "TradingHoursRule"
+        ]
+        assert len(trading_hours_rules) == 1
+        assert trading_hours_rules[0].enabled is False
+
+    async def test_initialize_all_no_default_for_test_broker(self, manager):
+        """test broker는 default rule이 없으므로 stored=None이면 룰 0건."""
+        accounts = [
+            Account(
+                account_id="domestic",
+                name="국내주식",
+                exchange="KRX",
+                currency="KRW",
+                broker_type="test",
+            ),
+        ]
+
+        await manager.initialize_all(accounts)
+
+        engine = manager.get("domestic")
+        assert engine._account_rules == []
+
+    async def test_initialize_all_kis_domestic_preserves_default_after_reload(
+        self, manager, eventbus
+    ):
+        """KIS engine 생성 후 ``ConfigChangedEvent``로 빈 stored list reload →
+        engine effective rule에 default ``trading_hours``가 여전히 존재한다."""
+        import json
+
+        from ante.eventbus.events import ConfigChangedEvent
+
+        accounts = [
+            Account(
+                account_id="domestic",
+                name="국내주식",
+                exchange="KRX",
+                currency="KRW",
+                broker_type="kis-domestic",
+            ),
+        ]
+        await manager.initialize_all(accounts)
+        engine = manager.get("domestic")
+
+        # 사용자가 stored를 비우는 PUT 흐름 (모든 룰 삭제) — ConfigChangedEvent
+        # new_value=[]이 발행됨.
+        await eventbus.publish(
+            ConfigChangedEvent(
+                category="rule",
+                key="accounts.domestic.rules",
+                new_value=json.dumps([]),
+            )
+        )
+
+        rule_types = {type(r).__name__ for r in engine._account_rules}
+        assert "TradingHoursRule" in rule_types, (
+            "reload 후에도 KIS default trading_hours가 유지되어야 한다 (#1296)"
+        )
+
 
 # ── RuleEngine Treasury 연동 ────────────────────
 

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -3775,6 +3775,133 @@ class TestRuleEngineManager:
             "reload 후에도 KIS default trading_hours가 유지되어야 한다 (#1296)"
         )
 
+    async def test_initialize_all_uses_dynamic_config_override_over_static(
+        self, manager
+    ):
+        """재시작 시 DynamicConfig에 저장된 명시 override는 static config보다
+        우선한다 — default trading_hours가 다시 주입되어 사용자의 비활성화를
+        덮어쓰면 안 된다 (#1296 P2 명시 우선 정책).
+        """
+
+        class _FakeDynamicConfig:
+            def __init__(self, data):
+                self._data = data
+
+            async def get(self, key, default=None):
+                return self._data.get(key, default)
+
+        class _FakeStaticConfig:
+            def get(self, key, default=None):  # noqa: ARG002
+                return default
+
+        accounts = [
+            Account(
+                account_id="domestic",
+                name="국내주식",
+                exchange="KRX",
+                currency="KRW",
+                broker_type="kis-domestic",
+            ),
+        ]
+        # static에는 키가 전혀 없고, dynamic에만 명시 비활성화가 저장된 상태.
+        dyn_cfg = _FakeDynamicConfig(
+            {
+                "accounts.domestic.rules": [
+                    {"type": "trading_hours", "enabled": False},
+                ]
+            }
+        )
+        static_cfg = _FakeStaticConfig()
+
+        await manager.initialize_all(
+            accounts, config=static_cfg, dynamic_config=dyn_cfg
+        )
+
+        engine = manager.get("domestic")
+        trading_hours_rules = [
+            r for r in engine._account_rules if type(r).__name__ == "TradingHoursRule"
+        ]
+        # default가 재주입되면 enabled=True 룰이 새로 생기지만, dynamic override
+        # 가 우선되면 enabled=False 룰 1개만 존재해야 한다.
+        assert len(trading_hours_rules) == 1, (
+            "DynamicConfig override가 default 재주입을 막아야 한다 (#1296 P2)"
+        )
+        assert trading_hours_rules[0].enabled is False, (
+            "사용자가 명시 비활성화한 룰은 재시작 후에도 비활성 상태를 유지해야 한다"
+        )
+
+    async def test_initialize_all_falls_back_to_static_when_dynamic_missing(
+        self, manager
+    ):
+        """DynamicConfig에 키가 없으면 static config가 fallback으로 동작한다."""
+
+        class _FakeDynamicConfig:
+            async def get(self, key, default=None):  # noqa: ARG002
+                return default
+
+        class _FakeStaticConfig:
+            def __init__(self, data):
+                self._data = data
+
+            def get(self, key, default=None):
+                return self._data.get(key, default)
+
+        accounts = [
+            Account(
+                account_id="domestic",
+                name="국내주식",
+                exchange="KRX",
+                currency="KRW",
+                broker_type="kis-domestic",
+            ),
+        ]
+        dyn_cfg = _FakeDynamicConfig()
+        static_cfg = _FakeStaticConfig(
+            {
+                "accounts.domestic.rules": [
+                    {"type": "trading_hours", "enabled": False},
+                ]
+            }
+        )
+
+        await manager.initialize_all(
+            accounts, config=static_cfg, dynamic_config=dyn_cfg
+        )
+
+        engine = manager.get("domestic")
+        trading_hours_rules = [
+            r for r in engine._account_rules if type(r).__name__ == "TradingHoursRule"
+        ]
+        assert len(trading_hours_rules) == 1
+        assert trading_hours_rules[0].enabled is False, (
+            "dynamic이 비어 있으면 static config의 명시 비활성화가 유지되어야 한다"
+        )
+
+    async def test_initialize_all_default_when_neither_static_nor_dynamic(
+        self, manager
+    ):
+        """DynamicConfig·static 모두 stored 없음 → broker_type별 default가 주입된다."""
+        accounts = [
+            Account(
+                account_id="domestic",
+                name="국내주식",
+                exchange="KRX",
+                currency="KRW",
+                broker_type="kis-domestic",
+            ),
+        ]
+
+        await manager.initialize_all(accounts)
+
+        engine = manager.get("domestic")
+        trading_hours_rules = [
+            r for r in engine._account_rules if type(r).__name__ == "TradingHoursRule"
+        ]
+        assert len(trading_hours_rules) == 1
+        assert trading_hours_rules[0].enabled is True, (
+            "stored가 없으면 KIS default trading_hours가 enabled=True로 주입되어야 한다"
+        )
+
     async def test_on_config_changed_ignores_other_account_rule_events(
         self, manager, eventbus
     ):

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -3420,7 +3420,7 @@ class TestRuleEngineConfigReload:
         assert "dl" not in rule_ids
 
     async def test_rule_category_reload(self, engine, eventbus):
-        """category='rule'도 계좌 룰 재로드를 트리거한다."""
+        """category='rule'도 계좌 룰 재로드를 트리거한다 (자기 계좌 키일 때만)."""
         import json
 
         from ante.eventbus.events import ConfigChangedEvent
@@ -3439,13 +3439,54 @@ class TestRuleEngineConfigReload:
         await eventbus.publish(
             ConfigChangedEvent(
                 category="rule",
-                key="rules.global",
+                key="accounts.domestic.rules",
                 new_value=json.dumps(new_rules),
             )
         )
 
         assert len(engine._global_rules) == 1
         assert engine._global_rules[0].rule_id == "exp2"
+
+    async def test_rule_category_ignored_when_key_belongs_to_other_account(
+        self, engine, eventbus
+    ):
+        """category='rule' 이벤트라도 다른 계좌 키면 자기 rules로 merge하지 않는다.
+
+        다중 KIS 계좌 환경에서 ``ConfigChangedEvent``는 모든 RuleEngine subscriber에게
+        broadcast되므로, ``key`` 가드가 없으면 한 계좌의 rule PUT이 다른 계좌의
+        effective rule에 cross-contamination을 일으킨다 (#1296 P1).
+        """
+        import json
+
+        from ante.eventbus.events import ConfigChangedEvent
+
+        # 자기(=domestic) 계좌의 룰을 미리 설정.
+        engine.load_rules_from_config(
+            [{"type": "daily_loss_limit", "id": "dl", "max_daily_loss_percent": 0.05}]
+        )
+        assert len(engine._global_rules) == 1
+        assert engine._global_rules[0].rule_id == "dl"
+
+        # 다른 계좌(other_account)의 rule 변경 이벤트 — 자기 룰은 변경되지 말아야 한다.
+        await eventbus.publish(
+            ConfigChangedEvent(
+                category="rule",
+                key="accounts.other-account.rules",
+                new_value=json.dumps(
+                    [
+                        {
+                            "type": "total_exposure_limit",
+                            "id": "exp_other",
+                            "max_exposure_percent": 0.99,
+                        }
+                    ]
+                ),
+            )
+        )
+
+        # 자기 rule은 그대로여야 한다.
+        assert len(engine._global_rules) == 1
+        assert engine._global_rules[0].rule_id == "dl"
 
     async def test_strategy_rule_reload_on_config_changed(self, engine, eventbus):
         """category='strategy_rule' ConfigChangedEvent로 전략 룰이 재로드된다."""
@@ -3732,6 +3773,81 @@ class TestRuleEngineManager:
         rule_types = {type(r).__name__ for r in engine._account_rules}
         assert "TradingHoursRule" in rule_types, (
             "reload 후에도 KIS default trading_hours가 유지되어야 한다 (#1296)"
+        )
+
+    async def test_on_config_changed_ignores_other_account_rule_events(
+        self, manager, eventbus
+    ):
+        """다중 KIS 계좌 환경에서 한 계좌의 rule PUT은 다른 계좌의 effective rule을
+        오염시키지 않는다 (#1296 P1).
+
+        ``ConfigChangedEvent``는 모든 RuleEngine subscriber에게 broadcast되므로,
+        각 engine은 ``event.key``가 자기 계좌의 ``accounts.{account_id}.rules``인
+        경우에만 reload해야 한다. 그렇지 않으면 다른 계좌의 stored rules가
+        자기 effective rules로 merge되어 default ``trading_hours``가 cross-account로
+        비활성화된다.
+        """
+        import json
+
+        from ante.eventbus.events import ConfigChangedEvent
+
+        accounts = [
+            Account(
+                account_id="domestic-a",
+                name="국내주식 A",
+                exchange="KRX",
+                currency="KRW",
+                broker_type="kis-domestic",
+            ),
+            Account(
+                account_id="domestic-b",
+                name="국내주식 B",
+                exchange="KRX",
+                currency="KRW",
+                broker_type="kis-domestic",
+            ),
+        ]
+        await manager.initialize_all(accounts)
+
+        engine_a = manager.get("domestic-a")
+        engine_b = manager.get("domestic-b")
+
+        # 두 엔진 모두 default trading_hours가 주입되어 있어야 한다.
+        def _trading_hours_rules(engine):
+            return [
+                r
+                for r in engine._account_rules
+                if type(r).__name__ == "TradingHoursRule"
+            ]
+
+        assert len(_trading_hours_rules(engine_a)) == 1
+        assert _trading_hours_rules(engine_a)[0].enabled is True
+        assert len(_trading_hours_rules(engine_b)) == 1
+        assert _trading_hours_rules(engine_b)[0].enabled is True
+
+        # domestic-a의 trading_hours만 비활성화하는 PUT — broadcast됨.
+        await eventbus.publish(
+            ConfigChangedEvent(
+                category="rule",
+                key="accounts.domestic-a.rules",
+                new_value=json.dumps([{"type": "trading_hours", "enabled": False}]),
+            )
+        )
+
+        # domestic-a는 trading_hours가 비활성화되어야 한다.
+        a_rules = _trading_hours_rules(engine_a)
+        assert len(a_rules) == 1
+        assert a_rules[0].enabled is False, (
+            "domestic-a는 자기 키 이벤트에 따라 trading_hours가 비활성화되어야 한다"
+        )
+
+        # domestic-b는 default trading_hours가 그대로 유지되어야 한다.
+        b_rules = _trading_hours_rules(engine_b)
+        assert len(b_rules) == 1, (
+            "domestic-b는 다른 계좌의 rule 이벤트로 영향받지 않아야 한다 (#1296)"
+        )
+        assert b_rules[0].enabled is True, (
+            "domestic-b의 default trading_hours가 오염되면 안 된다 (#1296)"
         )
 
 

--- a/tests/unit/test_rule_defaults.py
+++ b/tests/unit/test_rule_defaults.py
@@ -1,0 +1,131 @@
+"""``ante.rule.defaults.resolve_effective_rules`` 단위 테스트.
+
+회귀: A7 oracle (#1296) — KIS 모의투자 KRX 장종료 상태에 시장가 매수 신호가
+``RuleEngineManager``의 default ``trading_hours`` 미주입으로 인해 broker까지
+도달했다. 본 helper는 broker_type별 default와 stored override를 merge한다.
+"""
+
+from __future__ import annotations
+
+from ante.account.models import Account
+from ante.rule.defaults import resolve_effective_rules
+
+
+def _make_account(broker_type: str, account_id: str = "domestic") -> Account:
+    return Account(
+        account_id=account_id,
+        name="테스트 계좌",
+        exchange="KRX",
+        currency="KRW",
+        broker_type=broker_type,
+    )
+
+
+def test_resolve_effective_rules_kis_domestic_default_only() -> None:
+    """KIS domestic + stored=None → default ``trading_hours``가 자동 주입된다."""
+    account = _make_account("kis-domestic")
+
+    effective = resolve_effective_rules(account, None)
+
+    assert effective == [{"type": "trading_hours", "enabled": True}]
+
+
+def test_resolve_effective_rules_kis_domestic_empty_stored_injects_default() -> None:
+    """KIS domestic + 빈 stored 리스트 → default 동일하게 주입."""
+    account = _make_account("kis-domestic")
+
+    effective = resolve_effective_rules(account, [])
+
+    assert effective == [{"type": "trading_hours", "enabled": True}]
+
+
+def test_resolve_effective_rules_kis_domestic_explicit_disable() -> None:
+    """stored에서 ``trading_hours``를 ``enabled: false``로 명시 비활성화하면
+    default 주입 없이 stored 그대로 유지된다 (Agent가 24h 테스트 모드 등을
+    명시적으로 켤 수 있어야 함)."""
+    account = _make_account("kis-domestic")
+    stored = [{"type": "trading_hours", "enabled": False}]
+
+    effective = resolve_effective_rules(account, stored)
+
+    # default 추가 없이 stored 단일 항목만 남아야 한다.
+    assert effective == [{"type": "trading_hours", "enabled": False}]
+
+
+def test_resolve_effective_rules_kis_domestic_explicit_override_with_options() -> None:
+    """stored에 ``trading_hours``가 추가 파라미터와 함께 있으면 default를
+    override한다 (중복되지 않는다)."""
+    account = _make_account("kis-domestic")
+    stored = [
+        {
+            "type": "trading_hours",
+            "enabled": True,
+            "start_time": "09:30",
+            "end_time": "15:00",
+        }
+    ]
+
+    effective = resolve_effective_rules(account, stored)
+
+    # 같은 type은 stored 1건만 — default가 추가로 들어가면 안 된다.
+    assert len(effective) == 1
+    assert effective[0]["start_time"] == "09:30"
+    assert effective[0]["end_time"] == "15:00"
+
+
+def test_resolve_effective_rules_test_broker_no_default() -> None:
+    """test broker는 default rule이 없다. stored가 None이면 빈 리스트."""
+    account = _make_account("test")
+
+    assert resolve_effective_rules(account, None) == []
+
+
+def test_resolve_effective_rules_test_broker_preserves_stored() -> None:
+    """test broker도 stored가 있으면 그대로 통과한다."""
+    account = _make_account("test")
+    stored = [{"type": "daily_loss_limit", "max_daily_loss_percent": 0.05}]
+
+    effective = resolve_effective_rules(account, stored)
+
+    assert effective == stored
+
+
+def test_resolve_effective_rules_preserves_custom_rules() -> None:
+    """KIS + stored에 default와 다른 custom type → default + custom 둘 다 유지."""
+    account = _make_account("kis-domestic")
+    stored = [
+        {"type": "daily_loss_limit", "max_daily_loss_percent": 0.05},
+    ]
+
+    effective = resolve_effective_rules(account, stored)
+
+    types = [r.get("type") for r in effective]
+    assert types == ["trading_hours", "daily_loss_limit"]
+
+
+def test_resolve_effective_rules_unknown_broker_type_no_default() -> None:
+    """등록되지 않은 broker_type은 default 없이 stored 그대로 통과."""
+    account = _make_account("unknown-broker")
+    stored = [{"type": "daily_loss_limit"}]
+
+    effective = resolve_effective_rules(account, stored)
+
+    assert effective == stored
+
+
+def test_resolve_effective_rules_ignores_non_dict_stored_entries_for_dedup() -> None:
+    """stored에 non-dict 잡음이 들어와도 type-key 기반 중복 검사가 안전하게
+    동작한다 (default가 잘못 사라지지 않는다)."""
+    account = _make_account("kis-domestic")
+    # 첫 항목은 무효 (string). 두 번째 항목은 정상 custom rule.
+    stored = [
+        "garbage",  # type: ignore[list-item]
+        {"type": "daily_loss_limit", "max_daily_loss_percent": 0.05},
+    ]
+
+    effective = resolve_effective_rules(account, stored)  # type: ignore[arg-type]
+
+    types = [r.get("type") for r in effective if isinstance(r, dict)]
+    # default trading_hours가 보존되고 + custom + (passthrough된 garbage)
+    assert "trading_hours" in types
+    assert "daily_loss_limit" in types


### PR DESCRIPTION
Closes #1296

## Summary
A7 oracle이 검출한 KIS 장종료 주문이 `TradingHoursRule` 없이 broker까지 진행되는 회귀를 차단. 스펙(`docs/specs/rule-engine/09-rule-management.md` L43)이 명시한 "Account에서 자동 주입"을 RuleEngineManager에서 실제로 구현.

### 1. Rule wiring (Primary)
- 신규 `src/ante/rule/defaults.py`: `resolve_effective_rules(account, stored_rules)` helper. `_DEFAULT_RULES_BY_BROKER_TYPE`으로 broker_type별 default 정의 (KIS domestic은 `trading_hours: enabled=True`).
- `RuleEngineManager.initialize_all`이 helper 호출. `RuleEngine`이 `Account` snapshot을 캐시 (sync reload용).
- `RuleEngine._on_config_changed`(reload 경로)도 helper를 거치며, **`event.key`가 자기 계좌(`accounts.{self._account_id}.rules`) 일치 시에만 reload** (다중 계좌 cross-contamination 차단).
- `initialize_all`이 **DynamicConfig override를 1순위, static config를 2순위**로 조회. API PUT으로 명시 비활성화한 룰이 재시작 후에도 보존됨.

### 2. Spec 선반영
`docs/specs/rule-engine/09-rule-management.md`에 **Stored rules vs effective rules** 의미 추가. `accounts.{id}.rules`는 explicit overrides; effective는 default + overrides의 type-key 기반 merge. `enabled: false`로 default 비활성화 가능 (audit/UI 표기는 follow-up).

### 3. Defense-in-depth (KIS error code)
`src/ante/broker/error_codes.py`:
- `PERMANENT_MSG_CODES`에 `"40580000"` 추가 (장종료/주문불가).
- `KIS_ERROR_MESSAGES`에 한글 메시지.
- 모듈 docstring/주석에 "KIS msg_cd는 `APBK*` 또는 numeric business code 모두 가능" 명시.

## Test Plan
- [x] `uv run pytest tests/unit/test_rule_defaults.py -x` → 9 passed
- [x] `uv run pytest tests/unit/test_rule.py -k "RuleEngineManager or trading_hours or initialize_all or config_changed or default or dynamic_config or other_account" -x` → 21 passed
- [x] `uv run pytest tests/unit/test_rule.py -x` → 196 passed
- [x] `uv run pytest tests/unit/test_kis_error_handling.py -x` → 34 passed
- [x] `uv run pytest tests/unit/test_account_rules_api.py -x` → 24 passed
- [x] `uv run pytest tests/unit/test_main.py -x`
- [x] `uv run mypy src/ante/rule/defaults.py src/ante/rule/manager.py src/ante/rule/engine.py src/ante/broker/error_codes.py src/ante/main.py` → no issues
- [x] `uv run ruff check ...` + `ruff format --check ...`

## Codex Branch Review (3 attempts)
- attempt 1 (`ba6c3e2`): FAIL P1 — 다중 계좌 reload cross-contamination
- attempt 2 (`e6aec3d`): FAIL P2 — 재시작 시 DynamicConfig override 미반영
- attempt 3 (`8d5e6b5`): PASS

## Follow-ups (별도 이슈)
- `api-visibility`: GET `/accounts/{id}/rules`가 stored 외 effective view + `source: default|override` 표기
- 비-KIS broker_type default rule 정책
- 휴장일/공휴일 캘린더 (이슈 본문 Non-goals)

## Scope Boundary
- 본 PR은 `kis-domestic` default `trading_hours` + 40580000 classification + spec 의미 선반영. 다른 broker_type은 default 없음(`test`는 24h 명시). dedupe/cooldown, 휴장일 캘린더는 본 PR 비대상.
