### PR TITLE
fix(rule): reject zero price at OrderRequestEvent preflight (#1318)

### DIFF
--- a/docs/specs/rule-engine/05-rule-context.md
+++ b/docs/specs/rule-engine/05-rule-context.md
@@ -16,9 +16,9 @@ RuleEngine이 OrderRequestEvent와 Account 상태를 조합하여 생성하는 �
 | `strategy_id` | `str` | — | 전략 ID |
 | `symbol` | `str` | — | 종목 코드 |
 | `side` | `str` | — | 매수/매도 (`"buy"` \| `"sell"`) |
-| `quantity` | `float` | — | 주문 수량 |
+| `quantity` | `float` | — | 주문 수량 (preflight 이후 finite positive) |
 | `order_type` | `str` | — | 주문 유형 |
-| `price` | `float \| None` | `None` | 주문 가격 |
+| `price` | `float \| None` | `None` | 주문 가격 (preflight 이후 limit/stop_limit은 finite positive, market은 None 허용) |
 | `exchange` | `str` | `"KRX"` | 거래소 코드 |
 | `currency` | `str` | `"KRW"` | 통화 코드 |
 | **시장/포지션 정보** | | | |

--- a/docs/specs/rule-engine/07-rule-engine-core.md
+++ b/docs/specs/rule-engine/07-rule-engine-core.md
@@ -25,7 +25,7 @@ RuleEngine(
 
 ### 이벤트 구독
 
-- `OrderRequestEvent` (priority=100): 주문 평가 — `event.account_id` 필터링 → RuleContext 생성 → 계좌/전략별 룰 평가 → 결과 이벤트 발행
+- `OrderRequestEvent` (priority=100): 주문 평가 — `event.account_id` 필터링 → **OrderRequestEvent preflight** (아래 소절 참조) → RuleContext 생성 → 계좌/전략별 룰 평가 → 결과 이벤트 발행
 - `OrderModifyEvent` (priority=100): 주문 정정 평가 — `event.account_id` 필터링 → RuleContext 생성 → 계좌/전략별 룰 평가 → 결과 이벤트 발행. 거부 시 `OrderModifyRejectedEvent` 발행
 - `ConfigChangedEvent`: 룰 설정 변경 감지. `category="rule"` + `key="accounts.{account_id}.rules"`이면 해당 계좌 엔진만 계좌 룰을 재로드하고, `category="strategy_rule"`이면 해당 전략 룰을 재로드한다.
 
@@ -64,3 +64,21 @@ RuleEngine(
 - **결과 발행**: PASS/WARN → `OrderValidatedEvent` 발행 (WARN 시 `NotificationEvent` 추가), BLOCK/REJECT → `OrderRejectedEvent` 발행 + 조치 실행
 - **조치 실행**: `NOTIFY` → NotificationEvent, `STOP_BOT` → BotStopEvent, `HALT_ACCOUNT` → `AccountService.suspend(account_id)` 호출
 - **에러 처리**: 평가 중 예외 발생 시 안전하게 `OrderRejectedEvent` 발행 (fail-closed)
+
+### OrderRequestEvent preflight
+
+RuleEngine은 RuleContext 생성과 룰 평가 이전에 `OrderRequestEvent` payload의 도메인 invariant를 검증한다. invalid payload는 Treasury 예약 호출 이전에 `OrderRejectedEvent`로 fail-closed 거부되며, 룰 평가/Treasury 조회는 호출되지 않는다.
+
+검증 항목:
+- `side`: `"buy"` | `"sell"`만 허용 (그 외 거부)
+- `order_type`: 허용 집합(`limit` / `market` / `stop` / `stop_limit`) 외 거부
+- `symbol`: KRX numeric 형식 (6자리 숫자) 검증
+- `price`: `limit` / `stop_limit`은 finite positive (`None` / `0` / `-x` / `NaN` / `±inf` 거부). `market`은 `None` 허용
+- `stop_price`: `stop` / `stop_limit`은 `None` 거부 (도메인 invariant는 후속 이슈에서 추가)
+- `quantity`: finite positive (`0` / `-x` / `NaN` / `±inf` 거부)
+
+Reject payload 정규화 (`_build_safe_rejected_event`):
+- finite numeric `price` / `quantity`는 원본 부호와 값을 보존한다 (audit trail).
+- non-finite/non-number `quantity`는 `0.0`으로 정규화 (sqlite `trades.quantity REAL NOT NULL` 호환).
+- non-finite/non-number `price`는 `None`으로 정규화 (sqlite `trades.price REAL nullable` 호환).
+- reason 문자열은 `_safe_repr`로 안전 조립하며 `0` / `0.0` / `-0.0` 부호와 값을 그대로 보존한다.

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -805,6 +805,28 @@ class RuleEngine:
                 )
                 return
 
+            # OrderRequestEvent 계약 preflight: price는 0이 아니어야 한다.
+            # 회귀(#1318): A7 oracle이 검출한 버그 — Signal.price=0 주문이 RuleEngine→
+            # OrderValidatedEvent→Treasury까지 진행되어 reserve_amount_invalid
+            # (total_reserve=0) 거부가 발생했다. 0 price는 무의미한 주문이므로
+            # Treasury 예약/주문 호출 이전에 fail-closed로 거부한다.
+            #
+            # price는 #1303 게이트에서 finite int|float로 잠금됐고, #1316 게이트에서
+            # 음수가 거부됐으므로 본 게이트의 비교 대상은 0, 0.0, -0.0이다.
+            # Python에서 0 == 0.0 == -0.0이 True이므로 ``== 0``으로 모두 잠근다
+            # (선례 #1305 zero quantity). reason은 f-string으로 실제 값을 보존하여
+            # audit trail에서 0/0.0/-0.0를 구분한다.
+            if event.price is not None and event.price == 0:
+                reason = f"Zero price: {event.price} (price must be positive)"
+                await self._eventbus.publish(
+                    _build_safe_rejected_event(
+                        account_id=self._account_id,
+                        event=event,
+                        reason=reason,
+                    )
+                )
+                return
+
             # OrderRequestEvent 계약 preflight: quantity는 양수여야 한다.
             # 회귀(#1304): A7 oracle이 검출한 버그 — Signal.quantity=-1, side='buy',
             # order_type='limit', price=1000 주문이 RuleEngine→OrderValidatedEvent→

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -1,5 +1,6 @@
 """Rule Engine 모듈 단위 테스트."""
 
+import math
 from datetime import time
 from unittest.mock import AsyncMock
 
@@ -2651,16 +2652,161 @@ class TestRuleEngineEventBus:
         assert validated[0].price == good_price
         assert validated[0].order_type == "limit"
 
-    @pytest.mark.parametrize("zero_price", [0, 0.0])
-    async def test_rule_engine_zero_price_passes_negative_gate(
-        self, engine, eventbus, zero_price
+    @pytest.mark.parametrize(
+        ("bad_price", "bad_side"),
+        [(0, "buy"), (0.0, "buy"), (-0.0, "sell")],
+    )
+    async def test_rule_engine_rejects_zero_price(
+        self, engine, eventbus, monkeypatch, bad_price, bad_side
     ):
-        """zero price(0/0.0)는 본 게이트를 통과한다.
+        """price==0이면 룰 평가/Treasury 조회 이전에 거부한다.
 
-        본 게이트는 ``price < 0``만 잠그며, ``price == 0`` 거부는 #1318 별도
-        이슈에서 처리된다 (narrow-scope invariant). zero가 본 게이트를 통과해
-        OrderValidatedEvent가 발행되는지 잠금하여, 향후 누군가 본 게이트를
-        ``<= 0``로 합치려고 시도하면 이 테스트가 fail해서 멈추게 한다.
+        회귀(#1318): A7 oracle이 검출한 버그 — Signal.price=0, side='buy',
+        order_type='limit', quantity=1 주문이 RuleEngine→OrderValidatedEvent→
+        Treasury까지 진행되어 ``reserve_amount_invalid``(total_reserve=0)
+        거부가 발생했다. 0 price는 무의미한 주문이므로 Treasury 예약 호출
+        이전에 fail-closed로 거부한다. ``0 == 0.0 == -0.0``이 True이므로
+        ``== 0``이 모두 잠근다 (선례 #1305 zero quantity).
+        ``-0.0`` 케이스는 reason f-string에 부호가 보존되어야 한다 (audit).
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+        unrealized_calls: list[tuple[str, float, str]] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for zero price")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError("_query_treasury_data must not run for zero price")
+
+        async def _spy_unrealized(bot_id, current_price, order_symbol):
+            unrealized_calls.append((bot_id, current_price, order_symbol))
+            raise AssertionError(
+                "_calculate_bot_unrealized_pnl must not run for zero price"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+        monkeypatch.setattr(engine, "_calculate_bot_unrealized_pnl", _spy_unrealized)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side=bad_side,
+            quantity=1,
+            order_type="limit",
+            price=bad_price,
+            exchange="KRX",
+            reason="A7 oracle zero-price regression",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert unrealized_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Zero price" in ev.reason
+        assert ev.account_id == "domestic"
+        assert ev.bot_id == "bot1"
+        assert ev.strategy_id == "s1"
+        assert ev.symbol == "005930"
+        assert ev.side == bad_side
+        assert ev.order_type == "limit"
+        assert ev.exchange == "KRX"
+        assert ev.quantity == 1.0
+        assert ev.order_id == str(order.event_id)
+        # rejection payload의 price는 finite 0/0.0/-0.0 그대로 보존된다.
+        assert ev.price == float(bad_price)
+        # -0.0 케이스에서 reason f-string에 부호가 보존되는지 잠금.
+        if isinstance(bad_price, float) and math.copysign(1.0, bad_price) < 0:
+            assert "-0.0" in ev.reason
+
+    async def test_rule_engine_rejects_zero_price_stop_limit(
+        self, engine, eventbus, monkeypatch
+    ):
+        """order_type='stop_limit'에서도 0 price는 본 게이트로 거부된다.
+
+        본 게이트는 order_type 무관하게 ``price == 0``를 잠그므로, stop_limit
+        주문에 0 price가 실려도 동일하게 fail-closed로 거부되어야 한다
+        (cross-order_type 회귀 잠금).
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+        unrealized_calls: list[tuple[str, float, str]] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for zero stop_limit price")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run for zero stop_limit price"
+            )
+
+        async def _spy_unrealized(bot_id, current_price, order_symbol):
+            unrealized_calls.append((bot_id, current_price, order_symbol))
+            raise AssertionError(
+                "_calculate_bot_unrealized_pnl must not run for zero stop_limit price"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+        monkeypatch.setattr(engine, "_calculate_bot_unrealized_pnl", _spy_unrealized)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=1,
+            order_type="stop_limit",
+            price=0,
+            stop_price=600.0,
+            exchange="KRX",
+            reason="zero price stop_limit regression (#1318)",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert unrealized_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        assert "Zero price" in ev.reason
+        assert ev.price == 0.0
+        assert ev.order_type == "stop_limit"
+        assert ev.order_id == str(order.event_id)
+
+    @pytest.mark.parametrize("good_price", [0.001, 1, 1000.0])
+    async def test_rule_engine_accepts_positive_price_after_zero_gate(
+        self, engine, eventbus, good_price
+    ):
+        """양수 price는 0-price 게이트(#1318)를 통과한다.
+
+        본 PR(#1318)은 ``price == 0``만 차단한다. 양수 finite price (정수/실수,
+        매우 작은 양수까지)는 계속 통과해야 하며, 기존 정상 흐름이 깨지지
+        않는지 회귀 잠금. OrderValidatedEvent 발행을 통해 게이트 통과를 잠근다.
         """
         validated: list[OrderValidatedEvent] = []
         rejected: list[OrderRejectedEvent] = []
@@ -2675,14 +2821,76 @@ class TestRuleEngineEventBus:
             side="buy",
             quantity=1.0,
             order_type="limit",
-            price=zero_price,
+            price=good_price,
             exchange="KRX",
-            reason="zero price should pass negative-price gate (#1318 separate)",
+            reason="positive price should pass zero-price gate",
         )
         await eventbus.publish(order)
 
         assert len(rejected) == 0
         assert len(validated) == 1
+        assert validated[0].price == good_price
+        assert validated[0].order_type == "limit"
+
+    async def test_rule_engine_zero_price_fires_before_negative_quantity_gate(
+        self, engine, eventbus, monkeypatch
+    ):
+        """zero-price 게이트(#1318)가 negative-quantity(#1304) 게이트보다 먼저 fire.
+
+        cross-field invalid (quantity=-1, price=0) payload에서 본 게이트가 먼저
+        fire하여 reason에 "Zero price"가 실린다. 게이트 배치 순서 invariant
+        잠금: 향후 누군가 게이트 순서를 바꾸면 이 테스트가 fail해서 시정
+        필요성을 알린다. ``_coerce_finite_quantity``는 finite 음수를 보존하므로
+        ev.quantity는 -1.0 그대로 audit trail에 실린다.
+        """
+        rejected: list[OrderRejectedEvent] = []
+        validated: list[OrderValidatedEvent] = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderValidatedEvent, lambda e: validated.append(e))
+
+        evaluate_calls: list[object] = []
+        treasury_calls: list[str] = []
+
+        def _spy_evaluate(context):
+            evaluate_calls.append(context)
+            raise AssertionError("evaluate must not run for zero price/negative qty")
+
+        async def _spy_query_treasury(bot_id: str = ""):
+            treasury_calls.append(bot_id)
+            raise AssertionError(
+                "_query_treasury_data must not run for zero price/negative qty"
+            )
+
+        monkeypatch.setattr(engine, "evaluate", _spy_evaluate)
+        monkeypatch.setattr(engine, "_query_treasury_data", _spy_query_treasury)
+
+        order = OrderRequestEvent(
+            account_id="domestic",
+            bot_id="bot1",
+            strategy_id="s1",
+            symbol="005930",
+            side="buy",
+            quantity=-1,
+            order_type="limit",
+            price=0,
+            exchange="KRX",
+            reason="cross-field zero price + negative quantity",
+        )
+        await eventbus.publish(order)
+
+        assert evaluate_calls == []
+        assert treasury_calls == []
+        assert len(validated) == 0
+        assert len(rejected) == 1
+
+        ev = rejected[0]
+        # zero-price 게이트(#1318)가 먼저 fire — reason은 "Zero price"
+        # (NOT "Negative quantity").
+        assert "Zero price" in ev.reason
+        assert "Negative quantity" not in ev.reason
+        # audit 보존: 0 price와 -1 quantity가 그대로 payload에 실린다.
+        assert ev.price == 0.0
+        assert ev.quantity == -1.0
 
     async def test_rule_engine_negative_price_fires_before_negative_quantity_gate(
         self, engine, eventbus, monkeypatch


### PR DESCRIPTION
Closes #1318

## Summary
A7 oracle 회귀: `Signal.price=0`, `side='buy'`, `order_type='limit'`, `quantity=1` 주문이 RuleEngine→OrderValidatedEvent→Treasury까지 진행되어 `reserve_amount_invalid` 거부가 발생했다. #1316 negative-price 게이트 직후, #1304 negative-quantity 게이트 직전에 `event.price == 0` 게이트를 추가해 fail-closed로 거부한다.

- price는 #1303 게이트에서 finite int|float로 잠금됐고, #1316 게이트에서 음수가 거부됐으므로 본 게이트의 비교 대상은 `0`/`0.0`/`-0.0`이다. Python에서 `0 == 0.0 == -0.0`이 True이므로 `== 0`으로 모두 잠근다 (선례 #1305 zero quantity 패턴).
- PR #1326이 #1318 분리를 가정해 추가한 narrow-scope 잠금 `test_rule_engine_zero_price_passes_negative_gate`를 제거하고 새 reject 테스트로 교체 (Codex Plan Review 라운드 1 [high] 반영).
- `_coerce_finite_optional_price` / `_coerce_finite_quantity` / `_build_safe_rejected_event` 정책 변경 없음 — invalid finite price는 reject payload에 그대로 보존되어 audit-trail invariant 유지.

## Spec Sync (Codex Plan Review 라운드 2 [medium] 반영)
- `docs/specs/rule-engine/07-rule-engine-core.md`:
  - 이벤트 흐름에 `OrderRequestEvent preflight` 단계 명시 (`account_id 필터링 → preflight → RuleContext 생성 → 룰 평가`).
  - 새 소절 "OrderRequestEvent preflight"에 검증 항목 + reject payload 정규화 invariant 명시.
- `docs/specs/rule-engine/05-rule-context.md`: `price` / `quantity` 필드에 post-preflight invariant 보강.

## Test Plan
회귀 테스트 4건 추가 (`tests/unit/test_rule.py`, 기존 placeholder 1건 제거):
- `test_rule_engine_rejects_zero_price` — `(price, side)` parametrize: `(0, "buy")`, `(0.0, "buy")`, `(-0.0, "sell")`. evaluate/_query_treasury_data/_calculate_bot_unrealized_pnl 미호출 + `ev.price == float(bad_price)` 보존 + `-0.0` 부호 reason 보존 잠금.
- `test_rule_engine_rejects_zero_price_stop_limit` — `order_type="stop_limit"`, `price=0`, `stop_price=600.0` 같은 게이트로 거부.
- `test_rule_engine_accepts_positive_price_after_zero_gate` — `price=0.001`/`1`/`1000.0` 양수 통과.
- `test_rule_engine_zero_price_fires_before_negative_quantity_gate` — `quantity=-1, price=0` cross-field에서 zero-price 게이트가 먼저 fire하며 양 필드 audit 보존.

검증 결과:
- [x] `pytest tests/unit/test_rule.py -k price -v` — 51 passed (신규 7 케이스 포함)
- [x] `pytest tests/unit/test_rule.py` — 215 passed (회귀 없음)
- [x] `ruff check src/ante/rule/engine.py tests/unit/test_rule.py` — All checks passed
- [x] `mypy src/ante/rule/engine.py` — Success: no issues found
- [x] `/codex:review --base main` — PASS (no blocking findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)