### PR TITLE
fix(modify): emit terminal OrderModifyRejectedEvent for ctx.modify_order (#1331)

### DIFF
--- a/docs/specs/eventbus/eventbus.md
+++ b/docs/specs/eventbus/eventbus.md
@@ -232,6 +232,41 @@ canonical DB 상태를 남긴 뒤 서버 재시작 시 반영된다.
    - 한 핸들러의 예외가 다른 핸들러 실행을 막지 않음
    - 예외 발생 시 로깅 후 다음 핸들러 계속 실행
 
+### Transient `_consumed` marker (Gateway-only stop, OrderModifyEvent — #1331)
+
+`OrderModifyEvent`의 정정 라이프사이클에서 RuleEngine이 거부 결정을 내린 뒤
+같은 이벤트를 후속 `APIGateway._on_order_modify`(priority=50)가 다시 처리하면
+동일 정정 요청에 대해 `OrderModifyRejectedEvent`가 두 번(룰 거부 사유 +
+`"modify_not_implemented"`) 발행되어 audit trail이 깨진다. 이를 막기 위해
+RuleEngine은 거부/예외 경로에서 다음 marker를 set한다.
+
+```python
+object.__setattr__(event, "_consumed", True)
+```
+
+- **dataclass field가 아니다.** `Event`/`OrderModifyEvent`는 frozen
+  dataclass이며 `_consumed`는 정의된 필드가 아니다. 따라서 `__setattr__`은
+  `object.__setattr__`로 우회 주입해야 하고, dataclass 직렬화 경로
+  (영속 history `event_log` payload, msgspec 기반 직렬화 등)에는
+  노출되지 않는다.
+- **본 PR의 적용 범위는 `OrderModifyEvent`의 gateway pass-through 차단에
+  한정한다.** cancel 경로의 동일 결함은 별도 이슈에서 같은 패턴으로
+  다룬다 (#1332).
+- **Gateway-only stop marker 의미.** RuleEngine이 거부한 뒤 marker를
+  set하면 `APIGateway._on_order_modify`(priority=50)는 추가 terminal
+  event 발행을 건너뛴다. priority 50~100 사이의 audit/모니터링 subscriber
+  (예: TradeRecorder, NotificationService 등)는 본 marker의 영향을 받지
+  않으며, 자기 책임 영역에서 동일 이벤트를 정상 처리한다.
+- **인메모리 history 노출 가능성.** `EventBus._history`는 같은 객체 참조를
+  보존하므로, `_consumed=True`가 set된 이벤트가 `get_history()` 결과에서
+  marker가 붙은 채 보일 수 있다. 영속 history(SQLite/middleware 직렬화)에는
+  dataclass 필드가 아니므로 직렬화되지 않는다.
+- **`EventBus.publish` 자체는 marker를 인식하지 않는다.** consumer가 직접
+  `getattr(event, "_consumed", False)`로 확인할 책임이 있다. 새로운
+  실행성 subscriber를 50~100 priority 대역에 추가할 때는, 거부된 이벤트도
+  본인에게 도달할 수 있음을 인지하고 필요 시 marker를 명시적으로 확인
+  하도록 설계한다.
+
 ### 와일드카드/토픽 계층은 도입하지 않음
 
 **근거**:

--- a/src/ante/bot/bot.py
+++ b/src/ante/bot/bot.py
@@ -267,6 +267,7 @@ class Bot:
             OrderCancelFailedEvent,
             OrderCancelledEvent,
             OrderFailedEvent,
+            OrderModifyRejectedEvent,
             OrderRejectedEvent,
             OrderSubmittedEvent,
         )
@@ -314,6 +315,18 @@ class Bot:
                 "symbol": "",
                 "side": "",
                 "reason": event.error_message,
+            }
+        elif isinstance(event, OrderModifyRejectedEvent):
+            # #1331: 정정 거부 (rule reject / rule exception / gateway
+            # not-implemented) 통보를 전략에 전달. status는 신규 키
+            # ``"modify_rejected"``로 분리하여 기존 ``"rejected"``(신규
+            # 주문 거부)와 충돌하지 않도록 한다.
+            update = {
+                "order_id": event.order_id,
+                "status": "modify_rejected",
+                "symbol": event.symbol,
+                "side": event.side,
+                "reason": event.reason,
             }
 
         if update:
@@ -379,19 +392,26 @@ class Bot:
 
         for action in actions:
             if action.action == "cancel":
+                # #1331: ``strategy_id`` 보강. 기존에는 비워서 발행되어 룰
+                # 평가/리포팅/외부 채널이 strategy 단위로 식별하지 못했다.
+                # symbol/side는 ``OrderAction`` 입력에 없고 ``OrderView``가
+                # 보장하지 않으므로 본 PR 범위 밖.
                 await self._eventbus.publish(
                     OrderCancelEvent(
                         bot_id=self.bot_id,
                         account_id=self.config.account_id,
+                        strategy_id=self.config.strategy_id,
                         order_id=action.order_id,
                         reason=action.reason,
                     )
                 )
             elif action.action == "modify":
+                # #1331: ``strategy_id`` 보강. 동일 사유.
                 await self._eventbus.publish(
                     OrderModifyEvent(
                         bot_id=self.bot_id,
                         account_id=self.config.account_id,
+                        strategy_id=self.config.strategy_id,
                         order_id=action.order_id,
                         quantity=action.quantity or 0.0,
                         price=action.price,

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -846,18 +846,23 @@ class BotManager:
             OrderCancelledEvent,
             OrderFailedEvent,
             OrderFilledEvent,
+            OrderModifyRejectedEvent,
             OrderRejectedEvent,
             OrderSubmittedEvent,
         )
 
         self._eventbus.subscribe(OrderFilledEvent, bot.on_order_filled)
         self._eventbus.subscribe(ExternalSignalEvent, bot.on_external_signal)
+        # #1331: ``OrderModifyRejectedEvent`` 추가 — rule reject / rule
+        # exception / gateway not-implemented 통보가 ``Bot.on_order_update``
+        # 를 거쳐 ``strategy.on_order_update``까지 전달되도록 한다.
         for event_type in (
             OrderSubmittedEvent,
             OrderRejectedEvent,
             OrderCancelledEvent,
             OrderFailedEvent,
             OrderCancelFailedEvent,
+            OrderModifyRejectedEvent,
         ):
             self._eventbus.subscribe(event_type, bot.on_order_update)
 
@@ -869,18 +874,21 @@ class BotManager:
             OrderCancelledEvent,
             OrderFailedEvent,
             OrderFilledEvent,
+            OrderModifyRejectedEvent,
             OrderRejectedEvent,
             OrderSubmittedEvent,
         )
 
         self._eventbus.unsubscribe(OrderFilledEvent, bot.on_order_filled)
         self._eventbus.unsubscribe(ExternalSignalEvent, bot.on_external_signal)
+        # #1331: 등록과 동일하게 ``OrderModifyRejectedEvent`` 해지 추가.
         for event_type in (
             OrderSubmittedEvent,
             OrderRejectedEvent,
             OrderCancelledEvent,
             OrderFailedEvent,
             OrderCancelFailedEvent,
+            OrderModifyRejectedEvent,
         ):
             self._eventbus.unsubscribe(event_type, bot.on_order_update)
 

--- a/src/ante/bot/signal_channel.py
+++ b/src/ante/bot/signal_channel.py
@@ -160,17 +160,21 @@ class SignalChannel:
             OrderCancelledEvent,
             OrderFailedEvent,
             OrderFilledEvent,
+            OrderModifyRejectedEvent,
             OrderRejectedEvent,
             OrderSubmittedEvent,
         )
 
         self._eventbus.subscribe(OrderFilledEvent, self._on_fill)
+        # #1331: ``OrderModifyRejectedEvent`` 추가 — 외부 채널 구독자에게도
+        # 정정 거부/미구현 통보를 ``order_update`` 메시지로 전달한다.
         for evt in (
             OrderSubmittedEvent,
             OrderRejectedEvent,
             OrderCancelledEvent,
             OrderFailedEvent,
             OrderCancelFailedEvent,
+            OrderModifyRejectedEvent,
         ):
             self._eventbus.subscribe(evt, self._on_order_update)
 
@@ -181,17 +185,20 @@ class SignalChannel:
             OrderCancelledEvent,
             OrderFailedEvent,
             OrderFilledEvent,
+            OrderModifyRejectedEvent,
             OrderRejectedEvent,
             OrderSubmittedEvent,
         )
 
         self._eventbus.unsubscribe(OrderFilledEvent, self._on_fill)
+        # #1331: 등록과 동일하게 ``OrderModifyRejectedEvent`` 해지 추가.
         for evt in (
             OrderSubmittedEvent,
             OrderRejectedEvent,
             OrderCancelledEvent,
             OrderFailedEvent,
             OrderCancelFailedEvent,
+            OrderModifyRejectedEvent,
         ):
             self._eventbus.unsubscribe(evt, self._on_order_update)
 
@@ -233,6 +240,7 @@ class SignalChannel:
             OrderCancelFailedEvent,
             OrderCancelledEvent,
             OrderFailedEvent,
+            OrderModifyRejectedEvent,
             OrderRejectedEvent,
             OrderSubmittedEvent,
         )
@@ -253,6 +261,14 @@ class SignalChannel:
         elif isinstance(event, OrderCancelFailedEvent):
             status = "cancel_failed"
             reason = event.error_message
+        elif isinstance(event, OrderModifyRejectedEvent):
+            # #1331: 정정 거부/미구현 통보를 status로 잠그고, 외부 dict
+            # shape는 기존 ``{type:"order_update", ...}`` 패턴을 그대로
+            # 유지한다. ``type``을 ``"modify_rejected"`` 같은 새 형태로
+            # 바꾸면 외부 소비자(stdin/stdout 기반 에이전트)가 파싱
+            # 분기를 추가해야 하므로 의도적으로 잠갔다.
+            status = "modify_rejected"
+            reason = event.reason
 
         if status:
             self._write(

--- a/src/ante/gateway/gateway.py
+++ b/src/ante/gateway/gateway.py
@@ -397,15 +397,46 @@ class APIGateway:
             )
 
     async def _on_order_modify(self, event: object) -> None:
-        """주문 정정 요청 → 로깅만 (정정은 추후 구현).
+        """주문 정정 요청 → 미구현이므로 즉시 거부 이벤트 발행 (#1331).
+
+        RuleEngine이 이미 정정 요청을 거부하면 ``_consumed=True`` transient
+        marker를 set한다(``object.__setattr__``). 본 핸들러는 그 경우
+        추가 terminal event를 발행하지 않고 바로 반환하여, 동일 정정 요청에
+        대해 ``OrderModifyRejectedEvent``가 중복 발행되지 않도록 한다.
+
+        그 외 흐름(rule pass / rule이 marker를 set하지 않음)에서는
+        정정이 아직 broker-level로 구현되지 않았음을 전략에 명시 전달하기
+        위해 ``OrderModifyRejectedEvent(reason="modify_not_implemented")``를
+        발행한다. 기존 ``logger.warning`` 트레이스는 유지하여 운영 가시성을
+        보존한다.
 
         Note: EventBus 핸들러 — isawaitable 패턴을 위해 async def 유지.
         """
-        from ante.eventbus.events import OrderModifyEvent
+        from ante.eventbus.events import OrderModifyEvent, OrderModifyRejectedEvent
 
         if not isinstance(event, OrderModifyEvent):
             return
+
+        # rule engine 거부 흐름이 이미 terminal event를 발행했으면 skip.
+        # ``_consumed`` 는 dataclass field가 아닌 transient marker이므로
+        # ``getattr`` default False로 안전하게 확인한다 (#1331).
+        if getattr(event, "_consumed", False):
+            return
+
         logger.warning("주문 정정은 추후 구현: %s", event.order_id)
+        await self._eventbus.publish(
+            OrderModifyRejectedEvent(
+                account_id=event.account_id,
+                order_id=event.order_id,
+                bot_id=event.bot_id,
+                strategy_id=event.strategy_id,
+                symbol=event.symbol,
+                side=event.side,
+                quantity=event.quantity,
+                price=event.price,
+                reason="modify_not_implemented",
+            )
+        )
 
     async def _on_order_filled(self, event: object) -> None:
         """체결 시 해당 account_id 범위 내 캐시 무효화.

--- a/src/ante/rule/engine.py
+++ b/src/ante/rule/engine.py
@@ -1201,9 +1201,14 @@ class RuleEngine:
                         reason=result.rejection_reason,
                     )
                 )
-                # 거부 시 이벤트 소비 — 후속 핸들러(Gateway)에 전달 방지
-                if hasattr(event, "_consumed"):
-                    object.__setattr__(event, "_consumed", True)
+                # 거부 시 이벤트 소비 — 후속 핸들러(Gateway)가 추가 terminal
+                # event를 발행하지 않도록 transient marker를 set한다 (#1331).
+                # ``OrderModifyEvent``는 ``_consumed`` 필드를 정의하지 않은
+                # frozen dataclass이므로 ``hasattr`` guard를 두면 항상 False가
+                # 되어 marker가 전혀 set되지 않는다 (dead code). 가드를 제거하고
+                # ``object.__setattr__``로 직접 주입한다. dataclass 필드가
+                # 아니므로 영속 history 직렬화에는 노출되지 않는다.
+                object.__setattr__(event, "_consumed", True)
 
         except Exception:
             logger.exception("주문 정정 룰 평가 실패: %s", event.order_id)
@@ -1220,6 +1225,12 @@ class RuleEngine:
                     reason="Rule evaluation error",
                 )
             )
+            # 룰 평가 예외 경로도 후속 Gateway가 추가 terminal event를 발행하지
+            # 못하도록 transient marker를 set한다 (#1331). reason은 이미
+            # ``"Rule evaluation error"``로 강제됐으므로 Gateway의
+            # ``"modify_not_implemented"``가 같은 정정 요청에 중첩 발행되면
+            # audit trail이 깨진다.
+            object.__setattr__(event, "_consumed", True)
 
     async def _on_config_changed(self, event: object) -> None:
         """설정 변경 시 룰 재로딩.

--- a/tests/unit/test_bot_manager_modify_subscription.py
+++ b/tests/unit/test_bot_manager_modify_subscription.py
@@ -1,0 +1,177 @@
+"""BotManager `OrderModifyRejectedEvent` 구독 통합 테스트 (#1331).
+
+본 모듈은 BotManager가 봇을 등록할 때 ``OrderModifyRejectedEvent`` 를
+``Bot.on_order_update`` 에 연결하고, 발행 시 전략의
+``on_order_update`` dict 에 ``status="modify_rejected"`` 가 전달되는지를
+잠근다. 등록 누락은 본 PR이 막으려는 핵심 회귀이므로 발행 → 전략 호출
+end-to-end 패스를 검증한다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ante.bot import BotConfig, BotManager
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import OrderModifyRejectedEvent
+from ante.strategy import (
+    DataProvider,
+    OrderView,
+    PortfolioView,
+    Strategy,
+    StrategyContext,
+    StrategyMeta,
+)
+
+
+class _FakeDataProvider(DataProvider):
+    async def get_ohlcv(self, symbol, timeframe="1d", limit=100):  # type: ignore[override]
+        import polars as pl
+
+        return pl.DataFrame({"close": [100.0]})
+
+    async def get_current_price(self, symbol):  # type: ignore[override]
+        return 100.0
+
+    async def get_indicator(self, symbol, indicator, params=None):  # type: ignore[override]
+        return {}
+
+
+class _FakePortfolio(PortfolioView):
+    def get_positions(self, bot_id):  # type: ignore[override]
+        return {}
+
+    def get_balance(self, bot_id):  # type: ignore[override]
+        return {"total": 1.0, "available": 1.0}
+
+
+class _FakeOrders(OrderView):
+    def get_open_orders(self, bot_id):  # type: ignore[override]
+        return []
+
+
+class _CapturingStrategy(Strategy):
+    """``on_order_update`` 호출을 기록하는 테스트 전략."""
+
+    meta = StrategyMeta(name="capture", version="1.0.0", description="test")
+
+    def __init__(self, ctx: StrategyContext) -> None:
+        super().__init__(ctx=ctx)
+        self.updates: list[dict] = []
+
+    async def on_step(self, context):  # type: ignore[override]
+        return []
+
+    async def on_order_update(self, update):  # type: ignore[override]
+        self.updates.append(update)
+
+
+@pytest.fixture
+def eventbus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+def ctx() -> StrategyContext:
+    return StrategyContext(
+        bot_id="bot-1331",
+        data_provider=_FakeDataProvider(),
+        portfolio=_FakePortfolio(),
+        order_view=_FakeOrders(),
+    )
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    try:
+        await asyncio.wait_for(database.close(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+@pytest.fixture
+async def manager(eventbus: EventBus, db: Database) -> BotManager:
+    m = BotManager(eventbus=eventbus, db=db)
+    await m.initialize()
+    yield m
+    for bot in list(m._bots.values()):
+        if bot._task and not bot._task.done():
+            bot._task.cancel()
+    try:
+        await asyncio.wait_for(m.stop_all(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+async def test_modify_rejected_reaches_strategy(
+    manager: BotManager, ctx: StrategyContext, eventbus: EventBus
+) -> None:
+    """``OrderModifyRejectedEvent`` 발행 → 전략 ``on_order_update`` 호출."""
+    config = BotConfig(
+        bot_id="bot-1331",
+        strategy_id="strat-1331",
+        account_id="acc-test",
+    )
+    bot = await manager.create_bot(config, _CapturingStrategy, ctx)
+
+    # 전략 인스턴스화는 ``Bot.start`` 시점에 일어나므로, 본 테스트는
+    # 전략 객체를 미리 instantiate하고 bot에 직접 attach한다.
+    # ``on_order_update`` dispatch는 strategy 존재 + bot_id 매칭만 본다.
+    strategy = _CapturingStrategy(ctx=ctx)
+    bot.strategy = strategy
+
+    event = OrderModifyRejectedEvent(
+        account_id="acc-test",
+        order_id="ord-1331",
+        bot_id="bot-1331",
+        strategy_id="strat-1331",
+        symbol="005930",
+        side="buy",
+        quantity=10.0,
+        price=50000.0,
+        reason="modify_not_implemented",
+    )
+    await eventbus.publish(event)
+
+    assert len(strategy.updates) == 1
+    update = strategy.updates[0]
+    assert update["status"] == "modify_rejected"
+    assert update["order_id"] == "ord-1331"
+    assert update["symbol"] == "005930"
+    assert update["side"] == "buy"
+    assert update["reason"] == "modify_not_implemented"
+
+
+async def test_modify_rejected_other_bot_ignored(
+    manager: BotManager, ctx: StrategyContext, eventbus: EventBus
+) -> None:
+    """다른 ``bot_id`` 의 거부 통보는 봇 전략에 전달되지 않는다."""
+    config = BotConfig(
+        bot_id="bot-1331",
+        strategy_id="strat-1331",
+        account_id="acc-test",
+    )
+    bot = await manager.create_bot(config, _CapturingStrategy, ctx)
+    strategy = _CapturingStrategy(ctx=ctx)
+    bot.strategy = strategy
+
+    event = OrderModifyRejectedEvent(
+        account_id="acc-test",
+        order_id="ord-other",
+        bot_id="bot-other",
+        strategy_id="strat-other",
+        symbol="005930",
+        side="sell",
+        quantity=1.0,
+        price=1.0,
+        reason="modify_not_implemented",
+    )
+    await eventbus.publish(event)
+
+    assert strategy.updates == []

--- a/tests/unit/test_bot_publish_actions_modify.py
+++ b/tests/unit/test_bot_publish_actions_modify.py
@@ -1,0 +1,105 @@
+"""Bot._publish_actions strategy_id 보강 테스트 (#1331).
+
+본 모듈은 Bot이 ``OrderAction(action="cancel"|"modify")``을 EventBus
+이벤트로 변환할 때 ``strategy_id`` 가 ``bot.config.strategy_id`` 로
+정확히 채워지는지 검증한다. 이전 동작은 빈 문자열을 발행하여
+룰/리포팅/외부 채널 단계에서 strategy 단위 식별이 불가능했다.
+
+OrderAction 입력에 ``symbol`` / ``side`` 가 없으므로 본 PR 범위에서는
+해당 필드를 보강하지 않는다 (Stop Conditions).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from ante.bot.bot import Bot
+from ante.bot.config import BotConfig
+from ante.eventbus.events import OrderCancelEvent, OrderModifyEvent
+from ante.strategy.base import OrderAction
+
+
+def _make_bot() -> Bot:
+    config = BotConfig(
+        bot_id="bot-1331",
+        strategy_id="strat-1331",
+        name="modify-test-bot",
+        account_id="acc-1331",
+        interval_seconds=60,
+    )
+    eventbus = MagicMock()
+    eventbus.publish = AsyncMock()
+    ctx = MagicMock()
+    strategy_cls = MagicMock()
+    return Bot(
+        config=config,
+        strategy_cls=strategy_cls,
+        ctx=ctx,
+        eventbus=eventbus,
+    )
+
+
+async def test_publish_actions_cancel_carries_strategy_id() -> None:
+    """cancel 액션 → ``OrderCancelEvent.strategy_id`` 가 봇 설정과 일치."""
+    bot = _make_bot()
+    actions = [
+        OrderAction(
+            action="cancel",
+            order_id="ord-cancel-1",
+            reason="strategy decision",
+        )
+    ]
+
+    await bot._publish_actions(actions)
+
+    assert bot._eventbus.publish.await_count == 1
+    published = bot._eventbus.publish.await_args_list[0].args[0]
+    assert isinstance(published, OrderCancelEvent)
+    assert published.strategy_id == "strat-1331"
+    assert published.bot_id == "bot-1331"
+    assert published.account_id == "acc-1331"
+    assert published.order_id == "ord-cancel-1"
+    assert published.reason == "strategy decision"
+
+
+async def test_publish_actions_modify_carries_strategy_id() -> None:
+    """modify 액션 → ``OrderModifyEvent.strategy_id`` 가 봇 설정과 일치."""
+    bot = _make_bot()
+    actions = [
+        OrderAction(
+            action="modify",
+            order_id="ord-modify-1",
+            quantity=5.0,
+            price=51000.0,
+            reason="price update",
+        )
+    ]
+
+    await bot._publish_actions(actions)
+
+    assert bot._eventbus.publish.await_count == 1
+    published = bot._eventbus.publish.await_args_list[0].args[0]
+    assert isinstance(published, OrderModifyEvent)
+    assert published.strategy_id == "strat-1331"
+    assert published.bot_id == "bot-1331"
+    assert published.account_id == "acc-1331"
+    assert published.order_id == "ord-modify-1"
+    assert published.quantity == 5.0
+    assert published.price == 51000.0
+    assert published.reason == "price update"
+
+
+async def test_publish_actions_mixed_preserve_strategy_id() -> None:
+    """cancel + modify 혼합 시 두 이벤트 모두에 strategy_id 보존."""
+    bot = _make_bot()
+    actions = [
+        OrderAction(action="cancel", order_id="c-1"),
+        OrderAction(action="modify", order_id="m-1", quantity=1.0, price=100.0),
+    ]
+
+    await bot._publish_actions(actions)
+
+    published_events = [call.args[0] for call in bot._eventbus.publish.await_args_list]
+    assert len(published_events) == 2
+    for evt in published_events:
+        assert getattr(evt, "strategy_id") == "strat-1331"

--- a/tests/unit/test_gateway_modify.py
+++ b/tests/unit/test_gateway_modify.py
@@ -1,0 +1,221 @@
+"""APIGateway `_on_order_modify` terminal event 발행 테스트 (#1331).
+
+본 모듈은 다음을 잠근다:
+- ``_consumed=True`` marker가 붙은 ``OrderModifyEvent``는 Gateway가 추가
+  terminal event를 발행하지 않고 즉시 반환한다 (Rule reject 결과 보존).
+- marker가 없거나 False면 Gateway가 ``OrderModifyRejectedEvent``
+  (reason=``"modify_not_implemented"``)를 1회 발행한다.
+- Rule + Gateway end-to-end 시퀀스에서:
+    * Rule BLOCK → 1건만 발행, reason은 룰 거부 사유 (``modify_not_implemented`` 아님).
+    * Rule 예외 → 1건만 발행, reason=``"Rule evaluation error"``.
+    * Rule pass → 1건만 발행, reason=``"modify_not_implemented"``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ante.account.models import Account, AccountStatus
+from ante.eventbus import EventBus
+from ante.eventbus.events import OrderModifyEvent, OrderModifyRejectedEvent
+from ante.gateway import APIGateway, RateLimitConfig
+from ante.rule import RuleEngine
+from ante.rule.base import Rule, RuleAction, RuleContext, RuleEvaluation, RuleResult
+
+
+class _BlockingRule(Rule):
+    def evaluate(self, context: RuleContext) -> RuleEvaluation:
+        return RuleEvaluation(
+            rule_id=self.rule_id,
+            rule_name=self.name,
+            result=RuleResult.BLOCK,
+            action=RuleAction.LOG,
+            message="rule rejection sentinel",
+        )
+
+
+class _ExplodingRule(Rule):
+    def evaluate(self, context: RuleContext) -> RuleEvaluation:
+        raise RuntimeError("rule explosion")
+
+
+@pytest.fixture
+def broker() -> AsyncMock:
+    b = AsyncMock()
+    b.cancel_order = AsyncMock(return_value=True)
+    return b
+
+
+@pytest.fixture
+def account_service(broker: AsyncMock) -> AsyncMock:
+    svc = AsyncMock()
+    svc.get_broker = AsyncMock(return_value=broker)
+    # RuleEngine.get(account_id) 호환 — engine fixture에서 별도 사용.
+    account = Account(
+        account_id="domestic",
+        name="국내주식",
+        exchange="KRX",
+        currency="KRW",
+        broker_type="test",
+        status=AccountStatus.ACTIVE,
+    )
+    svc.get = AsyncMock(return_value=account)
+    svc.suspend = AsyncMock()
+    return svc
+
+
+@pytest.fixture
+def eventbus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+async def gateway(account_service: AsyncMock, eventbus: EventBus) -> APIGateway:
+    gw = APIGateway(
+        account_service=account_service,
+        eventbus=eventbus,
+        rate_config=RateLimitConfig(max_requests=100, window_seconds=60),
+    )
+    gw.start()
+    return gw
+
+
+@pytest.fixture
+def engine(account_service: AsyncMock, eventbus: EventBus) -> RuleEngine:
+    eng = RuleEngine(
+        eventbus=eventbus,
+        account_id="domestic",
+        account_service=account_service,
+    )
+    eng.start()
+    return eng
+
+
+def _make_modify_event(**overrides: object) -> OrderModifyEvent:
+    defaults: dict[str, object] = {
+        "account_id": "domestic",
+        "bot_id": "bot1",
+        "strategy_id": "strat-1331",
+        "order_id": "ord-gw-1331",
+        "symbol": "005930",
+        "side": "buy",
+        "quantity": 10.0,
+        "price": 50000.0,
+        "reason": "test reason",
+    }
+    defaults.update(overrides)
+    return OrderModifyEvent(**defaults)  # type: ignore[arg-type]
+
+
+# ── Gateway 단독 동작 ─────────────────────────────────
+
+
+async def test_gateway_skips_when_consumed(gateway: APIGateway) -> None:
+    """``_consumed=True`` 이벤트는 Gateway가 추가 발행 없이 무시한다."""
+    received: list[OrderModifyRejectedEvent] = []
+    gateway._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    event = _make_modify_event()
+    object.__setattr__(event, "_consumed", True)
+    await gateway._on_order_modify(event)
+
+    assert received == []
+
+
+async def test_gateway_publishes_not_implemented_when_passthrough(
+    gateway: APIGateway,
+) -> None:
+    """marker 미세팅: Gateway는 ``modify_not_implemented`` 거부를 1회 발행한다."""
+    received: list[OrderModifyRejectedEvent] = []
+    gateway._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    event = _make_modify_event()
+    await gateway._on_order_modify(event)
+
+    assert len(received) == 1
+    rejected = received[0]
+    assert rejected.reason == "modify_not_implemented"
+    # 모든 식별자/페이로드 보존 검증.
+    assert rejected.account_id == "domestic"
+    assert rejected.order_id == "ord-gw-1331"
+    assert rejected.bot_id == "bot1"
+    assert rejected.strategy_id == "strat-1331"
+    assert rejected.symbol == "005930"
+    assert rejected.side == "buy"
+    assert rejected.quantity == 10.0
+    assert rejected.price == 50000.0
+
+
+async def test_gateway_publishes_when_consumed_explicitly_false(
+    gateway: APIGateway,
+) -> None:
+    """``_consumed=False`` 명시 이벤트도 정상 pass-through (방어 테스트)."""
+    received: list[OrderModifyRejectedEvent] = []
+    gateway._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    event = _make_modify_event()
+    object.__setattr__(event, "_consumed", False)
+    await gateway._on_order_modify(event)
+
+    assert len(received) == 1
+    assert received[0].reason == "modify_not_implemented"
+
+
+# ── Rule + Gateway 통합 시퀀스 ─────────────────────────
+
+
+async def test_rule_block_then_gateway_only_one_terminal(
+    engine: RuleEngine, gateway: APIGateway
+) -> None:
+    """Rule BLOCK 후 Gateway 호출: terminal event 1건, reason은 룰 거부 사유."""
+    received: list[OrderModifyRejectedEvent] = []
+    # eventbus.publish가 priority 100 RuleEngine → priority 50 Gateway 순서로
+    # 호출하지만, 본 테스트는 두 핸들러를 동기로 직접 invoke하여 동일한
+    # consumer order를 시뮬레이션한다 — Gateway가 marker를 인식해 추가
+    # 발행을 건너뛰는지가 핵심이다.
+    engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    engine.add_account_rule(_BlockingRule("blocker", {"type": "test"}))
+    event = _make_modify_event()
+
+    await engine._on_order_modify(event)
+    await gateway._on_order_modify(event)
+
+    assert len(received) == 1
+    assert received[0].reason == "rule rejection sentinel"
+    assert received[0].reason != "modify_not_implemented"
+
+
+async def test_rule_exception_then_gateway_only_one_terminal(
+    engine: RuleEngine, gateway: APIGateway
+) -> None:
+    """Rule 평가 예외 후 Gateway: terminal 1건, reason=``Rule evaluation error``."""
+    received: list[OrderModifyRejectedEvent] = []
+    engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    engine.add_account_rule(_ExplodingRule("boom", {"type": "test"}))
+    event = _make_modify_event()
+
+    await engine._on_order_modify(event)
+    await gateway._on_order_modify(event)
+
+    assert len(received) == 1
+    assert received[0].reason == "Rule evaluation error"
+
+
+async def test_rule_pass_then_gateway_emits_not_implemented(
+    engine: RuleEngine, gateway: APIGateway
+) -> None:
+    """Rule pass 후 Gateway: terminal 1건, reason=``modify_not_implemented``."""
+    received: list[OrderModifyRejectedEvent] = []
+    engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    event = _make_modify_event()
+
+    await engine._on_order_modify(event)
+    await gateway._on_order_modify(event)
+
+    assert len(received) == 1
+    assert received[0].reason == "modify_not_implemented"

--- a/tests/unit/test_rule_engine_modify.py
+++ b/tests/unit/test_rule_engine_modify.py
@@ -1,0 +1,156 @@
+"""RuleEngine `_on_order_modify` `_consumed` transient marker 테스트 (#1331).
+
+본 모듈은 RuleEngine이 `OrderModifyEvent`를 거부할 때 ``_consumed=True`` 를
+실제로 set하는지 검증한다. ``hasattr`` guard가 살아있으면 marker가
+영원히 set되지 않아 후속 Gateway가 추가 ``OrderModifyRejectedEvent`` 를
+발행하는 dead-code 상태로 회귀할 수 있다 (Codex 2차 review 발견).
+
+세 가지 거부 경로를 잠근다:
+- BLOCK 결과 → marker set + reject event 발행
+- REJECT 결과 → marker set + reject event 발행
+- 룰 평가 예외 → marker set + ``"Rule evaluation error"`` reject 발행
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ante.account.models import Account, AccountStatus
+from ante.eventbus import EventBus
+from ante.eventbus.events import OrderModifyEvent, OrderModifyRejectedEvent
+from ante.rule import RuleEngine
+from ante.rule.base import Rule, RuleAction, RuleContext, RuleEvaluation, RuleResult
+
+
+class _RejectingRule(Rule):
+    """REJECT 결과를 반환하는 테스트 룰."""
+
+    def evaluate(self, context: RuleContext) -> RuleEvaluation:
+        return RuleEvaluation(
+            rule_id=self.rule_id,
+            rule_name=self.name,
+            result=RuleResult.REJECT,
+            action=RuleAction.NOTIFY,
+            message="modify rejected for test",
+        )
+
+
+class _BlockingRule(Rule):
+    """BLOCK 결과를 반환하는 테스트 룰."""
+
+    def evaluate(self, context: RuleContext) -> RuleEvaluation:
+        return RuleEvaluation(
+            rule_id=self.rule_id,
+            rule_name=self.name,
+            result=RuleResult.BLOCK,
+            action=RuleAction.LOG,
+            message="modify blocked for test",
+        )
+
+
+class _ExplodingRule(Rule):
+    """평가 시 예외를 던지는 테스트 룰."""
+
+    def evaluate(self, context: RuleContext) -> RuleEvaluation:
+        raise RuntimeError("rule explosion for test")
+
+
+@pytest.fixture
+def mock_account_service() -> AsyncMock:
+    service = AsyncMock()
+    account = Account(
+        account_id="domestic",
+        name="국내주식",
+        exchange="KRX",
+        currency="KRW",
+        broker_type="test",
+        status=AccountStatus.ACTIVE,
+    )
+    service.get = AsyncMock(return_value=account)
+    service.suspend = AsyncMock()
+    return service
+
+
+@pytest.fixture
+async def engine(mock_account_service: AsyncMock) -> RuleEngine:
+    eventbus = EventBus()
+    engine = RuleEngine(
+        eventbus=eventbus,
+        account_id="domestic",
+        account_service=mock_account_service,
+    )
+    engine.start()
+    return engine
+
+
+def _make_modify_event(**overrides: object) -> OrderModifyEvent:
+    defaults: dict[str, object] = {
+        "account_id": "domestic",
+        "bot_id": "bot1",
+        "strategy_id": "s1",
+        "order_id": "ord-1331",
+        "symbol": "005930",
+        "side": "buy",
+        "quantity": 10.0,
+        "price": 50000.0,
+    }
+    defaults.update(overrides)
+    return OrderModifyEvent(**defaults)  # type: ignore[arg-type]
+
+
+async def test_modify_block_marks_consumed(engine: RuleEngine) -> None:
+    """BLOCK 경로: ``OrderModifyRejectedEvent`` 발행 + ``_consumed=True``."""
+    received: list[OrderModifyRejectedEvent] = []
+    engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    engine.add_account_rule(_BlockingRule("blocker", {"type": "test"}))
+    event = _make_modify_event()
+    await engine._on_order_modify(event)
+
+    assert len(received) == 1
+    assert received[0].order_id == "ord-1331"
+    # transient marker는 dataclass 필드가 아니므로 ``getattr`` default로 확인.
+    assert getattr(event, "_consumed", False) is True
+
+
+async def test_modify_reject_marks_consumed(engine: RuleEngine) -> None:
+    """REJECT 경로: ``OrderModifyRejectedEvent`` 발행 + ``_consumed=True``."""
+    received: list[OrderModifyRejectedEvent] = []
+    engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    engine.add_account_rule(_RejectingRule("rejecter", {"type": "test"}))
+    event = _make_modify_event()
+    await engine._on_order_modify(event)
+
+    assert len(received) == 1
+    assert received[0].reason == "modify rejected for test"
+    assert getattr(event, "_consumed", False) is True
+
+
+async def test_modify_rule_exception_marks_consumed(engine: RuleEngine) -> None:
+    """룰 평가 예외 경로: ``"Rule evaluation error"`` 발행 + ``_consumed=True``."""
+    received: list[OrderModifyRejectedEvent] = []
+    engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    engine.add_account_rule(_ExplodingRule("boom", {"type": "test"}))
+    event = _make_modify_event()
+    await engine._on_order_modify(event)
+
+    assert len(received) == 1
+    assert received[0].reason == "Rule evaluation error"
+    assert getattr(event, "_consumed", False) is True
+
+
+async def test_modify_pass_does_not_mark_consumed(engine: RuleEngine) -> None:
+    """룰 통과 시 marker는 set되지 않아 Gateway pass-through가 가능해야 한다."""
+    received: list[OrderModifyRejectedEvent] = []
+    engine._eventbus.subscribe(OrderModifyRejectedEvent, lambda e: received.append(e))
+
+    event = _make_modify_event()
+    await engine._on_order_modify(event)
+
+    assert len(received) == 0
+    # 룰 거부가 없었으므로 marker는 미세팅 (False default).
+    assert getattr(event, "_consumed", False) is False

--- a/tests/unit/test_signal_channel_modify.py
+++ b/tests/unit/test_signal_channel_modify.py
@@ -1,0 +1,114 @@
+"""SignalChannel `OrderModifyRejectedEvent` 외부 전달 테스트 (#1331).
+
+본 모듈은 다음을 잠근다:
+- ``OrderModifyRejectedEvent`` 가 외부 채널에 ``order_update`` 메시지로
+  전달된다.
+- dict shape는 기존 패턴 ``{"type": "order_update", "order_id": ...,
+  "status": ..., "reason": ...}`` 을 그대로 유지한다.
+  ``type`` 을 ``"modify_rejected"`` 같은 새 값으로 바꾸지 않는다 — 외부
+  소비자(stdin/stdout 기반 에이전트)의 파싱 호환을 보장한다 (Codex 2차
+  review 피드백 반영).
+- ``status`` 는 ``"modify_rejected"`` 로 잠근다 (신규 키).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.bot.signal_channel import SignalChannel
+from ante.eventbus.events import OrderModifyRejectedEvent
+
+
+@pytest.fixture
+def bot() -> MagicMock:
+    b = MagicMock()
+    b.bot_id = "bot-1331"
+    return b
+
+
+@pytest.fixture
+def eventbus() -> MagicMock:
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    bus.subscribe = MagicMock()
+    bus.unsubscribe = MagicMock()
+    return bus
+
+
+@pytest.fixture
+def ctx() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def output() -> io.StringIO:
+    return io.StringIO()
+
+
+@pytest.fixture
+def channel(
+    bot: MagicMock,
+    eventbus: MagicMock,
+    ctx: MagicMock,
+    output: io.StringIO,
+) -> SignalChannel:
+    return SignalChannel(
+        bot=bot,
+        eventbus=eventbus,
+        ctx=ctx,
+        output_stream=output,
+    )
+
+
+async def test_modify_rejected_forwarded_keeps_order_update_shape(
+    channel: SignalChannel, output: io.StringIO
+) -> None:
+    """``OrderModifyRejectedEvent`` → 기존 ``order_update`` shape으로 직렬화."""
+    event = OrderModifyRejectedEvent(
+        account_id="acc-test",
+        order_id="ord-mod-1",
+        bot_id="bot-1331",
+        strategy_id="strat-1331",
+        symbol="005930",
+        side="sell",
+        quantity=2.0,
+        price=51000.0,
+        reason="modify_not_implemented",
+    )
+
+    await channel._on_order_update(event)
+
+    payload = output.getvalue().strip()
+    assert payload, "외부 채널에 메시지가 기록되어야 한다"
+    resp = json.loads(payload)
+
+    # 본 PR의 핵심 잠금: type은 기존 ``order_update`` 그대로.
+    assert resp["type"] == "order_update"
+    assert resp["status"] == "modify_rejected"
+    assert resp["order_id"] == "ord-mod-1"
+    assert resp["reason"] == "modify_not_implemented"
+
+
+async def test_modify_rejected_other_bot_ignored(
+    channel: SignalChannel, output: io.StringIO
+) -> None:
+    """다른 ``bot_id`` 거부 통보는 외부 채널에 기록되지 않는다."""
+    event = OrderModifyRejectedEvent(
+        account_id="acc-test",
+        order_id="ord-mod-2",
+        bot_id="bot-other",
+        strategy_id="strat-other",
+        symbol="005930",
+        side="buy",
+        quantity=1.0,
+        price=1.0,
+        reason="modify_not_implemented",
+    )
+
+    await channel._on_order_update(event)
+
+    assert output.getvalue() == ""


### PR DESCRIPTION
Closes #1331

## Summary
- `ctx.modify_order()` 요청이 terminal event 없이 사라지던 문제 해결.
- Gateway가 modify pass-through 시 `OrderModifyRejectedEvent(reason="modify_not_implemented")`를 발행하고, RuleEngine이 거부했을 때는 `_consumed` transient marker로 중복 발행을 막는다.
- BotManager / SignalChannel이 `OrderModifyRejectedEvent`를 구독해 strategy `on_order_update`까지 status `modify_rejected`로 전달.
- `Bot._publish_actions`가 modify/cancel 이벤트에 `strategy_id`를 채운다 (cancel 경로의 추가 결함은 #1332에서 다룸).
- RuleEngine `_on_order_modify`의 BLOCK/REJECT/예외 경로 모두 `_consumed=True`를 무조건 set하도록 dead-code였던 `hasattr` 가드를 제거.
- `docs/specs/eventbus/eventbus.md`에 `_consumed` transient marker 컨벤션 (Gateway-only stop, in-memory history 노출 가능, 영속 history 비직렬화) 단락 추가.

## Test Plan
- [x] `pytest tests/unit/test_rule_engine_modify.py tests/unit/test_gateway_modify.py tests/unit/test_bot_publish_actions_modify.py tests/unit/test_bot_manager_modify_subscription.py tests/unit/test_signal_channel_modify.py -x` (17 신규 테스트 PASS)
- [x] `pytest tests/unit/ -k "modify or order_update or cancel" -x` (64 PASS, 회귀 없음)
- [x] `pytest tests/unit/` 전체 (3844 passed, 2 skipped)
- [x] `ruff check src/ante/bot src/ante/gateway src/ante/rule src/ante/eventbus`
- [x] `ruff format --check src/ante/bot src/ante/gateway src/ante/rule src/ante/eventbus`
- [x] `mypy src/ante/{bot/{bot,manager,signal_channel},gateway/gateway,rule/engine}.py`
- [x] `/codex:review --base main` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)