### PR TITLE
fix(eventbus): preserve account_id on OrderCancelFailedEvent (#1332)

### DIFF
--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -569,6 +569,9 @@ class CircuitBreakerEvent(Event):
 class OrderCancelFailedEvent(Event):
     """주문 취소 실패."""
 
+    _requires_account_id: ClassVar[bool] = True
+
+    account_id: str = ""
     order_id: str = ""
     bot_id: str = ""
     strategy_id: str = ""

--- a/src/ante/gateway/gateway.py
+++ b/src/ante/gateway/gateway.py
@@ -389,6 +389,7 @@ class APIGateway:
             logger.error("주문 취소 실패: %s — %s", event.order_id, e)
             await self._eventbus.publish(
                 OrderCancelFailedEvent(
+                    account_id=event.account_id,
                     order_id=event.order_id,
                     bot_id=event.bot_id,
                     strategy_id=event.strategy_id,

--- a/tests/unit/test_gateway_cancel_failed.py
+++ b/tests/unit/test_gateway_cancel_failed.py
@@ -1,0 +1,108 @@
+"""APIGateway 주문 취소 실패 이벤트의 account/strategy attribution 보존 테스트.
+
+#1332: ``ctx.cancel_order()`` 경로에서 broker 예외가 발생할 때
+``OrderCancelFailedEvent``가 ``account_id``와 ``strategy_id`` 맥락을 모두
+유지하는지 검증한다. 또한 ``OrderCancelFailedEvent``의 account_id 검증이
+``_requires_account_id`` 마커로 활성화되어 있는지 확인한다.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ante.account.errors import InvalidAccountIdError
+from ante.eventbus import EventBus
+from ante.eventbus.events import (
+    OrderCancelEvent,
+    OrderCancelFailedEvent,
+)
+from ante.gateway import APIGateway
+
+
+@pytest.mark.asyncio
+async def test_cancel_failed_preserves_account_id() -> None:
+    """브로커 cancel 예외 → 발행된 OrderCancelFailedEvent.account_id 보존."""
+    eventbus = EventBus()
+    mock_broker = AsyncMock()
+    mock_broker.cancel_order = AsyncMock(side_effect=Exception("network error"))
+    mock_account_service = AsyncMock()
+    mock_account_service.get_broker = AsyncMock(return_value=mock_broker)
+
+    gw = APIGateway(account_service=mock_account_service, eventbus=eventbus)
+    gw.start()
+
+    received: list[OrderCancelFailedEvent] = []
+    eventbus.subscribe(OrderCancelFailedEvent, lambda e: received.append(e))
+
+    await eventbus.publish(
+        OrderCancelEvent(
+            account_id="acc-test",
+            bot_id="bot1",
+            strategy_id="s1",
+            order_id="ord1",
+            reason="test cancel",
+        )
+    )
+
+    assert len(received) == 1
+    assert received[0].account_id == "acc-test"
+
+
+@pytest.mark.asyncio
+async def test_cancel_failed_includes_strategy_id() -> None:
+    """브로커 cancel 예외 → 발행된 OrderCancelFailedEvent.strategy_id 보존.
+
+    #1331과의 end-to-end 잠금: OrderCancelEvent.strategy_id가 채워진 상태에서
+    실패 이벤트도 동일 strategy_id를 보존해야 한다.
+    """
+    eventbus = EventBus()
+    mock_broker = AsyncMock()
+    mock_broker.cancel_order = AsyncMock(side_effect=Exception("network error"))
+    mock_account_service = AsyncMock()
+    mock_account_service.get_broker = AsyncMock(return_value=mock_broker)
+
+    gw = APIGateway(account_service=mock_account_service, eventbus=eventbus)
+    gw.start()
+
+    received: list[OrderCancelFailedEvent] = []
+    eventbus.subscribe(OrderCancelFailedEvent, lambda e: received.append(e))
+
+    await eventbus.publish(
+        OrderCancelEvent(
+            account_id="acc-test",
+            bot_id="bot1",
+            strategy_id="strategy-xyz",
+            order_id="ord1",
+            reason="test cancel",
+        )
+    )
+
+    assert len(received) == 1
+    assert received[0].strategy_id == "strategy-xyz"
+    assert received[0].order_id == "ord1"
+    assert received[0].bot_id == "bot1"
+
+
+def test_cancel_failed_account_id_required() -> None:
+    """invalid account_id (빈 문자열, "default")로 직접 생성 시 검증 실패."""
+    # 빈 문자열은 invalid (default 값이 그대로 들어가는 경우 차단)
+    with pytest.raises(InvalidAccountIdError):
+        OrderCancelFailedEvent(
+            account_id="",
+            order_id="ord1",
+            bot_id="bot1",
+            strategy_id="s1",
+            error_message="boom",
+        )
+
+    # "default" 예약어는 invalid
+    with pytest.raises(InvalidAccountIdError):
+        OrderCancelFailedEvent(
+            account_id="default",
+            order_id="ord1",
+            bot_id="bot1",
+            strategy_id="s1",
+            error_message="boom",
+        )

--- a/tests/unit/test_kis_error_handling.py
+++ b/tests/unit/test_kis_error_handling.py
@@ -223,6 +223,7 @@ class TestOrderCancelFailedEvent:
     def test_event_fields(self):
         """OrderCancelFailedEvent 필드 확인."""
         event = OrderCancelFailedEvent(
+            account_id="test-account",
             order_id="ord1",
             bot_id="bot1",
             strategy_id="s1",
@@ -240,6 +241,7 @@ class TestOrderCancelFailedEvent:
 
         await eventbus.publish(
             OrderCancelFailedEvent(
+                account_id="test-account",
                 order_id="ord1",
                 bot_id="bot1",
                 strategy_id="s1",
@@ -426,6 +428,7 @@ class TestBotCancelFailedHandling:
 
         await bot.on_order_update(
             OrderCancelFailedEvent(
+                account_id="acc-test",
                 order_id="ord1",
                 bot_id="bot1",
                 strategy_id="s1",

--- a/tests/unit/test_module_notification_events.py
+++ b/tests/unit/test_module_notification_events.py
@@ -187,6 +187,7 @@ class TestTradeRecorderNotifications:
 
         await eventbus.publish(
             OrderCancelFailedEvent(
+                account_id="test-account",
                 order_id="o1",
                 bot_id="bot-1",
                 strategy_id="s1",

--- a/tests/unit/test_signal_channel.py
+++ b/tests/unit/test_signal_channel.py
@@ -296,6 +296,7 @@ class TestEventForwarding:
         from ante.eventbus.events import OrderCancelFailedEvent
 
         event = OrderCancelFailedEvent(
+            account_id="test-account",
             order_id="ORD-005",
             bot_id="bot-001",
             error_message="cancel_rejected",


### PR DESCRIPTION
Closes #1332

## Summary
- `OrderCancelFailedEvent`에 `account_id: str = ""` 필드와 `_requires_account_id: ClassVar[bool] = True` 마커 추가 — 코드/스펙 정합 회복.
- `APIGateway._on_order_cancel()` 예외 분기에서 `account_id=event.account_id`를 전달.
- 영향 받은 기존 테스트 5곳(test_module_notification_events, test_signal_channel, test_kis_error_handling x3)에 `account_id` keyword arg 추가.
- 신규 단위 테스트 3건: account_id/strategy_id 보존, invalid account_id 거부.

## Test Plan
- [x] `pytest tests/unit/test_gateway_cancel_failed.py tests/unit/test_module_notification_events.py tests/unit/test_signal_channel.py tests/unit/test_kis_error_handling.py -x` (70 PASS)
- [x] `pytest tests/unit/ -k "cancel or notification or signal_channel or kis_error" -x` (179 PASS)
- [x] `pytest tests/unit/` 전체 (3847 passed, 2 skipped)
- [x] `ruff check src/ante/eventbus src/ante/gateway`
- [x] `ruff format --check src/ante/eventbus src/ante/gateway`
- [x] `mypy src/ante/eventbus/events.py src/ante/gateway/gateway.py`
- [x] `/codex:review --base main` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)