### PR TITLE
fix(treasury): reject non-finite/negative balance at API and service (#1340)

### DIFF
--- a/docs/specs/treasury/04-treasury-interface.md
+++ b/docs/specs/treasury/04-treasury-interface.md
@@ -49,6 +49,8 @@ Treasury(
 | `update_budget` | bot_id: str, target_amount: float | `None` | 봇 예산 변경. 증가분은 미할당에서 차감, 감소분은 미할당으로 환수 |
 | `set_account_info` | account_number: str, is_demo_trading: bool | `None` | KIS 계좌 메타 정보 설정 (계좌번호, 모의투자 여부) |
 
+`set_account_balance(balance)` 입력 invariant: balance는 finite이며 `>=0`. 위반 시 ValueError. POST /api/treasury/balance도 동일 invariant를 ValidationError로 거부한다.
+
 ### 자산 평가 동기화 계약
 
 `start_sync`는 `Account.trading_mode`에 따라 자산 평가 소스를 분기한다.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -531,7 +531,7 @@
           "accounts"
         ],
         "summary": "Update Account Rule",
-        "description": "계좌 리스크 룰 개별 수정.\n\nRULE_REGISTRY에 등록된 타입만 허용하며,\nDynamicConfigService에 위임하여 ConfigChangedEvent를 발행한다.",
+        "description": "계좌 리스크 룰 개별 수정.\n\nRULE_REGISTRY에 등록된 타입만 허용하며,\nDynamicConfigService에 위임하여 ConfigChangedEvent를 발행한다.\n\n저장되는 ``accounts.{account_id}.rules`` 값은 explicit overrides(stored\nrules)다. RuleEngine이 실제로 적용하는 effective rules는\n``ante.rule.defaults.resolve_effective_rules``가 broker_type별 defaults와\n이 stored rules를 merge한 결과이며, ``ConfigChangedEvent`` reload 시\n동일 helper가 다시 호출된다. 본 GET/PUT API는 stored rules만 다룬다 —\neffective view는 후속 이슈에서 별도 엔드포인트로 노출한다 (#1296).",
         "operationId": "update_account_rule_api_accounts__account_id__rules__rule_type__put",
         "parameters": [
           {
@@ -5255,6 +5255,7 @@
         "properties": {
           "balance": {
             "type": "number",
+            "minimum": 0.0,
             "title": "Balance"
           }
         },
@@ -5472,7 +5473,7 @@
           "bot_id"
         ],
         "title": "BotInfo",
-        "description": "봇 정보."
+        "description": "봇 정보 (read 응답).\n\nwrite 경로(``BotConfig``, ``ApprovalService.create``)에서 account_id가\n검증되므로 read 응답 schema에는 default를 유지한다."
       },
       "BotListResponse": {
         "properties": {
@@ -7813,7 +7814,7 @@
           "status"
         ],
         "title": "TradeItem",
-        "description": "거래 기록 아이템."
+        "description": "거래 기록 아이템 (read 응답).\n\nwrite 경로(``TradeRecord``)에서 account_id가 검증되므로 read 응답\nschema에는 default를 유지한다."
       },
       "TradeListResponse": {
         "properties": {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -175,6 +175,13 @@ export type paths = {
          *
          *     RULE_REGISTRY에 등록된 타입만 허용하며,
          *     DynamicConfigService에 위임하여 ConfigChangedEvent를 발행한다.
+         *
+         *     저장되는 ``accounts.{account_id}.rules`` 값은 explicit overrides(stored
+         *     rules)다. RuleEngine이 실제로 적용하는 effective rules는
+         *     ``ante.rule.defaults.resolve_effective_rules``가 broker_type별 defaults와
+         *     이 stored rules를 merge한 결과이며, ``ConfigChangedEvent`` reload 시
+         *     동일 helper가 다시 호출된다. 본 GET/PUT API는 stored rules만 다룬다 —
+         *     effective view는 후속 이슈에서 별도 엔드포인트로 노출한다 (#1296).
          */
         put: operations["update_account_rule_api_accounts__account_id__rules__rule_type__put"];
         post?: never;
@@ -1671,7 +1678,10 @@ export type components = {
         };
         /**
          * BotInfo
-         * @description 봇 정보.
+         * @description 봇 정보 (read 응답).
+         *
+         *     write 경로(``BotConfig``, ``ApprovalService.create``)에서 account_id가
+         *     검증되므로 read 응답 schema에는 default를 유지한다.
          */
         BotInfo: {
             /**
@@ -3018,7 +3028,10 @@ export type components = {
         };
         /**
          * TradeItem
-         * @description 거래 기록 아이템.
+         * @description 거래 기록 아이템 (read 응답).
+         *
+         *     write 경로(``TradeRecord``)에서 account_id가 검증되므로 read 응답
+         *     schema에는 default를 유지한다.
          */
         TradeItem: {
             /**

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
@@ -230,7 +231,15 @@ class Treasury:
     # -- 계좌 잔고 -----------------------------------------------
 
     async def set_account_balance(self, balance: float) -> None:
-        """계좌 잔고 설정. 미할당 자금을 자동 재계산."""
+        """계좌 잔고 설정. 미할당 자금을 자동 재계산.
+
+        Raises:
+            ValueError: balance가 finite가 아니거나 음수인 경우.
+        """
+        if not (math.isfinite(balance) and balance >= 0):
+            raise ValueError(
+                f"account balance must be finite and >= 0, got {balance!r}"
+            )
         self._account_balance = balance
         total_allocated = sum(b.allocated for b in self._budgets.values())
         self._unallocated = balance - total_allocated

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ante.web.deps import (
     get_audit_logger_optional,
@@ -38,7 +38,7 @@ class BudgetChangeRequest(BaseModel):
 class BalanceSetRequest(BaseModel):
     """잔고 수동 설정 요청."""
 
-    balance: float
+    balance: Annotated[float, Field(ge=0, allow_inf_nan=False)]
 
 
 @router.get(

--- a/tests/unit/test_treasury_routes_balance.py
+++ b/tests/unit/test_treasury_routes_balance.py
@@ -1,0 +1,150 @@
+"""POST /api/treasury/balance 입력 invariant 회귀 테스트.
+
+이슈 #1340: 음수/NaN/Inf 잔고가 200으로 수락되어 treasury state가 오염되는 문제를
+입력 invariant(`Annotated[float, Field(ge=0, allow_inf_nan=False)]`)로 막는다.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402
+
+
+class FakeTreasury:
+    """테스트용 Treasury stub. 거부된 요청이 state를 변경하지 않는지 확인하기 위해
+    인메모리 잔고/미할당만 보관한다."""
+
+    def __init__(self, initial_balance: float = 0.0) -> None:
+        self._balance: float = initial_balance
+        self._unallocated: float = initial_balance
+
+    @property
+    def account_balance(self) -> float:
+        return self._balance
+
+    @property
+    def unallocated(self) -> float:
+        return self._unallocated
+
+    async def set_account_balance(self, balance: float) -> None:
+        # 라우트 단계에서 422로 거부되면 이 메서드는 호출되지 않아야 한다.
+        # 호출이 들어오면 정상 경로로 mutate한다.
+        if not (math.isfinite(balance) and balance >= 0):
+            raise ValueError(
+                f"account balance must be finite and >= 0, got {balance!r}"
+            )
+        self._balance = balance
+        self._unallocated = balance
+
+    def list_budgets(self) -> list:
+        return []
+
+    def get_summary(self) -> dict:
+        return {"account_balance": self._balance, "unallocated": self._unallocated}
+
+    async def get_latest_snapshot(self) -> None:
+        return None
+
+
+@pytest.fixture
+def treasury() -> FakeTreasury:
+    return FakeTreasury()
+
+
+@pytest.fixture
+def client(treasury: FakeTreasury) -> TestClient:
+    app = create_app(treasury=treasury)
+    return TestClient(app)
+
+
+def test_set_balance_rejects_negative_with_422(
+    client: TestClient, treasury: FakeTreasury
+) -> None:
+    """balance=-1.0 → 422 (Field(ge=0))."""
+    resp = client.post("/api/treasury/balance", json={"balance": -1.0})
+    assert resp.status_code == 422
+    assert treasury.account_balance == 0.0
+
+
+def test_set_balance_rejects_nan_with_422(
+    client: TestClient, treasury: FakeTreasury
+) -> None:
+    """balance=NaN → 422 (allow_inf_nan=False).
+
+    표준 JSON 인코더는 NaN을 거부하므로 raw body(`NaN`)를 직접 보낸다.
+    Python json/Pydantic은 비표준 토큰을 파싱할 수 있고 invariant는
+    라우트에서 막아야 한다.
+    """
+    resp = client.post(
+        "/api/treasury/balance",
+        content='{"balance": NaN}',
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 422
+    assert treasury.account_balance == 0.0
+
+
+def test_set_balance_rejects_positive_inf_with_422(
+    client: TestClient, treasury: FakeTreasury
+) -> None:
+    """balance=+Inf → 422 (allow_inf_nan=False)."""
+    resp = client.post(
+        "/api/treasury/balance",
+        content='{"balance": Infinity}',
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 422
+    assert treasury.account_balance == 0.0
+
+
+def test_set_balance_rejects_negative_inf_with_422(
+    client: TestClient, treasury: FakeTreasury
+) -> None:
+    """balance=-Inf → 422 (allow_inf_nan=False)."""
+    resp = client.post(
+        "/api/treasury/balance",
+        content='{"balance": -Infinity}',
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 422
+    assert treasury.account_balance == 0.0
+
+
+def test_set_balance_rejected_does_not_mutate_state() -> None:
+    """초기 잔고 100인 treasury에 -1.0 요청 → 422,
+    treasury.account_balance/unallocated가 100 그대로 유지."""
+    treasury = FakeTreasury(initial_balance=100.0)
+    app = create_app(treasury=treasury)
+    client = TestClient(app)
+
+    resp = client.post("/api/treasury/balance", json={"balance": -1.0})
+    assert resp.status_code == 422
+    assert treasury.account_balance == 100.0
+    assert treasury.unallocated == 100.0
+
+
+def test_set_balance_accepts_zero(client: TestClient, treasury: FakeTreasury) -> None:
+    """balance=0 → 200 (ge=0 경계 허용)."""
+    resp = client.post("/api/treasury/balance", json={"balance": 0})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_balance"] == 0
+    assert treasury.account_balance == 0.0
+
+
+def test_set_balance_accepts_positive(
+    client: TestClient, treasury: FakeTreasury
+) -> None:
+    """balance=10000000 → 200 (정상 경로)."""
+    resp = client.post("/api/treasury/balance", json={"balance": 10_000_000})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_balance"] == 10_000_000
+    assert treasury.account_balance == 10_000_000

--- a/tests/unit/test_treasury_set_balance_invariant.py
+++ b/tests/unit/test_treasury_set_balance_invariant.py
@@ -1,0 +1,105 @@
+"""Treasury.set_account_balance 입력 invariant 단위 테스트.
+
+이슈 #1340: 음수/NaN/Inf 잔고는 계좌 잔고/미할당의 모든 다운스트림 계산을
+오염시킨다. service 진입에 finite + non-negative 가드를 두어 방어한다.
+라우트 단의 Pydantic validation과 함께 다층 방어 (defense in depth)를 구성한다.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.treasury import Treasury
+
+ACCOUNT_ID = "domestic"
+CURRENCY = "KRW"
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+def eventbus():
+    return EventBus()
+
+
+@pytest.fixture
+async def treasury(db, eventbus):
+    t = Treasury(
+        db=db,
+        eventbus=eventbus,
+        account_id=ACCOUNT_ID,
+        currency=CURRENCY,
+        buy_commission_rate=0.00015,
+        sell_commission_rate=0.00195,
+    )
+    await t.initialize()
+    return t
+
+
+class TestSetAccountBalanceInvariant:
+    """set_account_balance 입력 invariant: balance는 finite이며 >= 0."""
+
+    async def test_set_account_balance_rejects_negative(self, treasury):
+        """음수 → ValueError."""
+        with pytest.raises(ValueError, match="must be finite and >= 0"):
+            await treasury.set_account_balance(-1.0)
+
+    async def test_set_account_balance_rejects_nan(self, treasury):
+        """NaN → ValueError."""
+        with pytest.raises(ValueError, match="must be finite and >= 0"):
+            await treasury.set_account_balance(float("nan"))
+
+    async def test_set_account_balance_rejects_positive_inf(self, treasury):
+        """+Inf → ValueError."""
+        with pytest.raises(ValueError, match="must be finite and >= 0"):
+            await treasury.set_account_balance(float("inf"))
+
+    async def test_set_account_balance_rejects_negative_inf(self, treasury):
+        """-Inf → ValueError."""
+        with pytest.raises(ValueError, match="must be finite and >= 0"):
+            await treasury.set_account_balance(-float("inf"))
+
+    async def test_set_account_balance_rejected_does_not_mutate_state(self, treasury):
+        """거부 시 _account_balance와 _unallocated가 호출 전 상태 유지."""
+        # 정상 잔고 설정으로 baseline 구축
+        await treasury.set_account_balance(100.0)
+        assert treasury.account_balance == 100.0
+        assert treasury.unallocated == 100.0
+
+        # 음수 거부 시 상태 변경 없음
+        with pytest.raises(ValueError):
+            await treasury.set_account_balance(-1.0)
+        assert treasury.account_balance == 100.0
+        assert treasury.unallocated == 100.0
+
+        # NaN 거부 시 상태 변경 없음
+        with pytest.raises(ValueError):
+            await treasury.set_account_balance(float("nan"))
+        assert treasury.account_balance == 100.0
+        assert treasury.unallocated == 100.0
+
+        # +Inf 거부 시 상태 변경 없음
+        with pytest.raises(ValueError):
+            await treasury.set_account_balance(float("inf"))
+        assert treasury.account_balance == 100.0
+        assert treasury.unallocated == 100.0
+
+    async def test_set_account_balance_accepts_zero(self, treasury):
+        """0은 경계 허용 — 잔고 0/미할당 0으로 정상 설정."""
+        await treasury.set_account_balance(0.0)
+        assert treasury.account_balance == 0.0
+        assert treasury.unallocated == 0.0
+
+    async def test_set_account_balance_accepts_positive(self, treasury):
+        """양수 정상 경로."""
+        await treasury.set_account_balance(10_000_000.0)
+        assert treasury.account_balance == 10_000_000.0
+        assert treasury.unallocated == 10_000_000.0


### PR DESCRIPTION
Closes #1340

## Summary
- `BalanceSetRequest.balance`를 `Annotated[float, Field(ge=0, allow_inf_nan=False)]`로 교체 — 음수/NaN/Inf를 422로 자동 거부.
- `Treasury.set_account_balance()` 진입에 finite + non-negative invariant 가드(ValueError) 추가 — defense-in-depth.
- 신규 단위 테스트 14건: route 7건 + service 7건 (음수/NaN/+Inf/-Inf 거부, state 미변경, 0/양수 정상 처리).
- `frontend/openapi.json` 및 `frontend/src/types/api.generated.ts` 재생성: `BalanceSetRequest.balance`에 `minimum: 0` 반영.
- 스펙 보강: `docs/specs/treasury/04-treasury-interface.md`에 invariant 한 문장 추가.

## Test Plan
- [x] `pytest tests/unit/test_treasury_routes_balance.py tests/unit/test_treasury_set_balance_invariant.py -x` (14 PASS)
- [x] `pytest tests/unit/ -k "treasury" -x` (223 PASS, 회귀 없음)
- [x] `pytest tests/unit/` 전체 (3861 passed, 2 skipped)
- [x] `ruff check`, `ruff format --check`, `mypy`: PASS
- [x] `/codex:review --base main` PASS
- [x] OpenAPI: BalanceSetRequest.balance에 \`minimum: 0\` 반영 확인

## Non-Goals (별도 후속 이슈)
- 잔고 상한선
- 다른 입력 endpoint 일괄 검증
- 레거시 음수 데이터 마이그레이션
- sync_balance / DB 로드 경로 입력 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)