### PR TITLE
fix(account): validate trading_hours_start/end as strict HH:MM (#1334)

### DIFF
--- a/docs/specs/account/10-web-api.md
+++ b/docs/specs/account/10-web-api.md
@@ -57,6 +57,8 @@ Web API는 서버 프로세스 내부에서 실행되므로 계좌 구조 변경
 
 `PUT /api/accounts/:id` 요청 본문이 빈 dict(`{}`), 빈 body, 또는 `model_dump(exclude_none=True)` 결과가 빈 dict가 되는 페이로드(예: `{"name": null}`)는 422 Unprocessable Entity를 반환한다 (#1152). schema는 `minProperties: 1`로 표현되며, 이는 OpenAPI/runtime 계약이다 — `openapi-typescript`는 이를 TypeScript 타입 제약으로 내리지 않는다. 빈 body / 빈 dict 검사는 단계 6에서 Content-Type 415 게이트(단계 7)보다 앞서 실행되므로 비-application/json + `{}` 조합도 422로 떨어진다.
 
+Account API의 `trading_hours_start`/`trading_hours_end`는 strict `HH:MM` 24시간 형식이다 (regex `^([01]\d|2[0-3]):[0-5]\d$`, OpenAPI `pattern`으로도 노출). 초/마이크로초 포함(`09:30:00`), invalid 시간(`99:99`), 그리고 `PUT`의 빈 문자열(`""`)은 422 Unprocessable Entity로 거부된다. `POST /api/accounts`의 `AccountCreateRequest`는 `""`를 default 의미(생략 동치)로 허용하여 CLI/seed 경로의 BrokerPreset fallback과 정합을 유지하지만, 런타임 `POST` 자체는 항상 409 cold-path로 차단된다 — 실제 검증 효과는 `PUT` 경로와 schema 소비자(CLI 등)에서 발생한다 (#1334).
+
 ### 기존 엔드포인트 계좌 필터
 
 멀티 계좌 환경에서 모든 거래·잔고·봇 관련 API 응답에 계좌 컨텍스트를 포함한다.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -121,14 +121,14 @@
                   "trading_hours_start": {
                     "type": "string",
                     "default": "09:00",
-                    "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
-                    "description": "거래 시작 시각 (현지 시간, strict HH:MM 24시간 형식). 초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334)."
+                    "pattern": "^(([01]\\d|2[0-3]):[0-5]\\d)?$",
+                    "description": "거래 시작 시각 (현지 시간, strict HH:MM 24시간 형식). AccountCreateRequest는 cold-path payload이며 빈 문자열은 BrokerPreset fallback sentinel로 허용된다. 초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334)."
                   },
                   "trading_hours_end": {
                     "type": "string",
                     "default": "15:30",
-                    "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
-                    "description": "거래 종료 시각 (현지 시간, strict HH:MM 24시간 형식). 초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334)."
+                    "pattern": "^(([01]\\d|2[0-3]):[0-5]\\d)?$",
+                    "description": "거래 종료 시각 (현지 시간, strict HH:MM 24시간 형식). AccountCreateRequest는 cold-path payload이며 빈 문자열은 BrokerPreset fallback sentinel로 허용된다. 초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334)."
                   },
                   "trading_mode": {
                     "type": "string",

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -121,12 +121,14 @@
                   "trading_hours_start": {
                     "type": "string",
                     "default": "09:00",
-                    "description": "거래 시작 시각 (현지 시간, HH:MM)."
+                    "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
+                    "description": "거래 시작 시각 (현지 시간, strict HH:MM 24시간 형식). 초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334)."
                   },
                   "trading_hours_end": {
                     "type": "string",
                     "default": "15:30",
-                    "description": "거래 종료 시각 (현지 시간, HH:MM)."
+                    "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
+                    "description": "거래 종료 시각 (현지 시간, strict HH:MM 24시간 형식). 초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334)."
                   },
                   "trading_mode": {
                     "type": "string",
@@ -325,11 +327,13 @@
                   },
                   "trading_hours_start": {
                     "type": "string",
-                    "description": "거래 시작 시각 (현지 시간, HH:MM)."
+                    "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
+                    "description": "거래 시작 시각 (현지 시간, strict HH:MM 24시간 형식). 초/마이크로초 포함, 빈 문자열, invalid 시간은 422로 거부된다 (#1334)."
                   },
                   "trading_hours_end": {
                     "type": "string",
-                    "description": "거래 종료 시각 (현지 시간, HH:MM)."
+                    "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
+                    "description": "거래 종료 시각 (현지 시간, strict HH:MM 24시간 형식). 초/마이크로초 포함, 빈 문자열, invalid 시간은 422로 거부된다 (#1334)."
                   }
                 }
               }

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -3378,12 +3378,12 @@ export interface operations {
                      */
                     timezone?: string;
                     /**
-                     * @description 거래 종료 시각 (현지 시간, strict HH:MM 24시간 형식). 초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334).
+                     * @description 거래 종료 시각 (현지 시간, strict HH:MM 24시간 형식). AccountCreateRequest는 cold-path payload이며 빈 문자열은 BrokerPreset fallback sentinel로 허용된다. 초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334).
                      * @default 15:30
                      */
                     trading_hours_end?: string;
                     /**
-                     * @description 거래 시작 시각 (현지 시간, strict HH:MM 24시간 형식). 초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334).
+                     * @description 거래 시작 시각 (현지 시간, strict HH:MM 24시간 형식). AccountCreateRequest는 cold-path payload이며 빈 문자열은 BrokerPreset fallback sentinel로 허용된다. 초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334).
                      * @default 09:00
                      */
                     trading_hours_start?: string;

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -3378,12 +3378,12 @@ export interface operations {
                      */
                     timezone?: string;
                     /**
-                     * @description 거래 종료 시각 (현지 시간, HH:MM).
+                     * @description 거래 종료 시각 (현지 시간, strict HH:MM 24시간 형식). 초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334).
                      * @default 15:30
                      */
                     trading_hours_end?: string;
                     /**
-                     * @description 거래 시작 시각 (현지 시간, HH:MM).
+                     * @description 거래 시작 시각 (현지 시간, strict HH:MM 24시간 형식). 초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334).
                      * @default 09:00
                      */
                     trading_hours_start?: string;
@@ -3455,9 +3455,9 @@ export interface operations {
                     name?: string;
                     /** @description 거래소 현지 시간대 (IANA). */
                     timezone?: string;
-                    /** @description 거래 종료 시각 (현지 시간, HH:MM). */
+                    /** @description 거래 종료 시각 (현지 시간, strict HH:MM 24시간 형식). 초/마이크로초 포함, 빈 문자열, invalid 시간은 422로 거부된다 (#1334). */
                     trading_hours_end?: string;
-                    /** @description 거래 시작 시각 (현지 시간, HH:MM). */
+                    /** @description 거래 시작 시각 (현지 시간, strict HH:MM 24시간 형식). 초/마이크로초 포함, 빈 문자열, invalid 시간은 422로 거부된다 (#1334). */
                     trading_hours_start?: string;
                 };
             };

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -104,11 +104,19 @@ ACCOUNT_MUTABLE_UPDATE_REQUEST_SCHEMA: dict[str, Any] = {
         },
         "trading_hours_start": {
             "type": "string",
-            "description": "거래 시작 시각 (현지 시간, HH:MM).",
+            "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
+            "description": (
+                "거래 시작 시각 (현지 시간, strict HH:MM 24시간 형식). "
+                "초/마이크로초 포함, 빈 문자열, invalid 시간은 422로 거부된다 (#1334)."
+            ),
         },
         "trading_hours_end": {
             "type": "string",
-            "description": "거래 종료 시각 (현지 시간, HH:MM).",
+            "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
+            "description": (
+                "거래 종료 시각 (현지 시간, strict HH:MM 24시간 형식). "
+                "초/마이크로초 포함, 빈 문자열, invalid 시간은 422로 거부된다 (#1334)."
+            ),
         },
     },
 }
@@ -172,12 +180,20 @@ ACCOUNT_CREATE_REQUEST_SCHEMA: dict[str, Any] = {
         "trading_hours_start": {
             "type": "string",
             "default": "09:00",
-            "description": "거래 시작 시각 (현지 시간, HH:MM).",
+            "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
+            "description": (
+                "거래 시작 시각 (현지 시간, strict HH:MM 24시간 형식). "
+                "초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334)."
+            ),
         },
         "trading_hours_end": {
             "type": "string",
             "default": "15:30",
-            "description": "거래 종료 시각 (현지 시간, HH:MM).",
+            "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
+            "description": (
+                "거래 종료 시각 (현지 시간, strict HH:MM 24시간 형식). "
+                "초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334)."
+            ),
         },
         "trading_mode": {
             "type": "string",

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -180,18 +180,22 @@ ACCOUNT_CREATE_REQUEST_SCHEMA: dict[str, Any] = {
         "trading_hours_start": {
             "type": "string",
             "default": "09:00",
-            "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
+            "pattern": "^(([01]\\d|2[0-3]):[0-5]\\d)?$",
             "description": (
                 "거래 시작 시각 (현지 시간, strict HH:MM 24시간 형식). "
+                "AccountCreateRequest는 cold-path payload이며 "
+                "빈 문자열은 BrokerPreset fallback sentinel로 허용된다. "
                 "초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334)."
             ),
         },
         "trading_hours_end": {
             "type": "string",
             "default": "15:30",
-            "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
+            "pattern": "^(([01]\\d|2[0-3]):[0-5]\\d)?$",
             "description": (
                 "거래 종료 시각 (현지 시간, strict HH:MM 24시간 형식). "
+                "AccountCreateRequest는 cold-path payload이며 "
+                "빈 문자열은 BrokerPreset fallback sentinel로 허용된다. "
                 "초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334)."
             ),
         },

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import re
+from datetime import time as dtime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from ante import __version__
+
+# Account `trading_hours_start`/`trading_hours_end`의 strict HH:MM 24시간 형식.
+# SSOT: docs/specs/account/03-data-model.md (HH:MM), docs/specs/account/10-web-api.md.
+# 초/마이크로초 포함, 빈 문자열(update만), invalid 시간은 422로 거부한다.
+HH_MM_PATTERN = r"^([01]\d|2[0-3]):[0-5]\d$"
+_HH_MM_RE = re.compile(HH_MM_PATTERN)
 
 
 class ErrorResponse(BaseModel):
@@ -71,6 +79,30 @@ class AccountCreateRequest(BaseModel):
     buy_commission_rate: float = 0.0
     sell_commission_rate: float = 0.0
 
+    @field_validator("trading_hours_start", "trading_hours_end")
+    @classmethod
+    def _validate_trading_hours_create(cls, v: str) -> str:
+        """strict HH:MM 24시간 형식 검증.
+
+        ``""``는 default 의미를 보존하기 위해 통과시킨다 — CLI/seed 경로에서
+        BrokerPreset fallback이 ``""``를 preset value로 채우기 때문이다 (#1334
+        plan v5: AccountCreateRequest의 ``""`` 통과는 default 의미 보존).
+        non-empty 값은 regex 매치 후 ``time.fromisoformat``으로 이중 검증한다.
+        """
+        if v == "":
+            return v
+        if not _HH_MM_RE.fullmatch(v):
+            raise ValueError(
+                f"trading_hours는 strict HH:MM 24시간 형식이어야 합니다: {v!r}"
+            )
+        try:
+            dtime.fromisoformat(v)
+        except ValueError as exc:
+            raise ValueError(
+                f"trading_hours는 strict HH:MM 24시간 형식이어야 합니다: {v!r}"
+            ) from exc
+        return v
+
 
 class AccountUpdateRequest(BaseModel):
     """계좌 수정 요청.
@@ -93,6 +125,29 @@ class AccountUpdateRequest(BaseModel):
     broker_config: dict[str, Any] | None = None
     buy_commission_rate: float | None = None
     sell_commission_rate: float | None = None
+
+    @field_validator("trading_hours_start", "trading_hours_end")
+    @classmethod
+    def _validate_trading_hours_update(cls, v: str | None) -> str | None:
+        """strict HH:MM 24시간 형식 검증 (update 경로).
+
+        ``None``은 통과(필드 미제공). 그 외(``""`` 포함)는 regex + fromisoformat
+        검증 — update 경로는 broker preset fallback이 없기 때문이다 (#1334).
+        실패 시 ``ValueError``로 422 Unprocessable Entity를 유도한다.
+        """
+        if v is None:
+            return v
+        if not _HH_MM_RE.fullmatch(v):
+            raise ValueError(
+                f"trading_hours는 strict HH:MM 24시간 형식이어야 합니다: {v!r}"
+            )
+        try:
+            dtime.fromisoformat(v)
+        except ValueError as exc:
+            raise ValueError(
+                f"trading_hours는 strict HH:MM 24시간 형식이어야 합니다: {v!r}"
+            ) from exc
+        return v
 
 
 class AccountSuspendRequest(BaseModel):

--- a/tests/unit/test_account_routes_trading_hours.py
+++ b/tests/unit/test_account_routes_trading_hours.py
@@ -1,0 +1,265 @@
+"""PUT /api/accounts/{id}의 trading_hours strict HH:MM 검증.
+
+이슈 #1334: invalid trading_hours("99:99")가 PUT 200으로 저장되어 generic
+preflight error로 주문이 반복 거부되는 문제를 422로 차단.
+
+POST 라우트 테스트는 본 모듈 비목표 — POST는 항상 cold-path 409이며 (#1143),
+이슈 #1334 plan v5의 stop condition으로 명시되어 있다.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.account.errors import (  # noqa: E402
+    AccountDeletedError,
+    AccountNotFoundError,
+    InvalidBrokerTypeError,
+)
+from ante.account.models import Account, AccountStatus, TradingMode  # noqa: E402
+from ante.web.app import create_app  # noqa: E402
+
+
+class FakeBrokerAdapter:
+    def __init__(self, fail_connect: bool = False) -> None:
+        self.is_connected = False
+        self.fail_connect = fail_connect
+        self.connect_calls = 0
+
+    async def connect(self) -> None:
+        self.connect_calls += 1
+        if self.fail_connect:
+            raise RuntimeError("connect 실패 — 시뮬레이션")
+        self.is_connected = True
+
+    async def disconnect(self) -> None:
+        self.is_connected = False
+
+
+class FakeAccountService:
+    """이슈 #1334 회귀 테스트용 AccountService 모의.
+
+    `tests/unit/test_account_api.py::FakeAccountService`와 같은 분류 정책을
+    유지한다 — 본 모듈은 PUT route 422 검증만 다루므로 분리해서 두어도
+    안전하며, 라우트 가드의 결과만 단언한다.
+    """
+
+    def __init__(self) -> None:
+        self._accounts: dict[str, Account] = {}
+        self._audit_logs: list[dict[str, Any]] = []
+        self._deleted: set[str] = set()
+        self._brokers: dict[str, FakeBrokerAdapter] = {}
+        self._fail_connect_for: set[str] = set()
+        self.update_calls: list[tuple[str, dict[str, Any]]] = []
+
+    UPDATABLE_FIELDS = frozenset(
+        {
+            "name",
+            "timezone",
+            "trading_hours_start",
+            "trading_hours_end",
+            "credentials",
+            "broker_config",
+            "buy_commission_rate",
+            "sell_commission_rate",
+        }
+    )
+    IMMUTABLE_FIELDS = frozenset(
+        {"exchange", "currency", "trading_mode", "broker_type"}
+    )
+
+    async def get(self, account_id: str) -> Account:
+        if account_id not in self._accounts:
+            raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
+        return self._accounts[account_id]
+
+    async def list(self, status: AccountStatus | None = None) -> list[Account]:
+        accounts = list(self._accounts.values())
+        if status is not None:
+            accounts = [a for a in accounts if a.status == status]
+        return accounts
+
+    async def update(self, account_id: str, **fields: Any) -> Account:
+        from ante.account.errors import AccountImmutableFieldError
+
+        self.update_calls.append((account_id, dict(fields)))
+        if account_id not in self._accounts:
+            raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
+        account = self._accounts[account_id]
+        if account.status == AccountStatus.DELETED:
+            raise AccountDeletedError(
+                f"삭제된 계좌 '{account_id}'는 수정할 수 없습니다."
+            )
+        attempted_immutable = set(fields.keys()) & self.IMMUTABLE_FIELDS
+        if attempted_immutable:
+            raise AccountImmutableFieldError(
+                f"다음 필드는 수정할 수 없습니다: {sorted(attempted_immutable)}"
+            )
+        unrecognized = (
+            set(fields.keys()) - self.UPDATABLE_FIELDS - self.IMMUTABLE_FIELDS
+        )
+        if unrecognized:
+            raise ValueError(f"인식할 수 없는 필드입니다: {sorted(unrecognized)}")
+        for key, value in fields.items():
+            setattr(account, key, value)
+        account.updated_at = datetime.now(UTC)
+        return account
+
+    async def get_broker(self, account_id: str) -> Any:
+        account = await self.get(account_id)
+        if account.broker_type not in ("test", "kis-domestic"):
+            raise InvalidBrokerTypeError(
+                f"broker_type '{account.broker_type}'은 BROKER_REGISTRY에 "
+                f"등록되지 않았습니다."
+            )
+        if account_id not in self._brokers:
+            self._brokers[account_id] = FakeBrokerAdapter(
+                fail_connect=(account_id in self._fail_connect_for)
+            )
+        return self._brokers[account_id]
+
+
+class FakeAuditLogger:
+    def __init__(self) -> None:
+        self.logs: list[dict[str, Any]] = []
+
+    async def log(self, **kwargs: Any) -> None:
+        self.logs.append(kwargs)
+
+
+@pytest.fixture
+def account_service() -> FakeAccountService:
+    return FakeAccountService()
+
+
+@pytest.fixture
+def audit_logger() -> FakeAuditLogger:
+    return FakeAuditLogger()
+
+
+@pytest.fixture
+def app(account_service: FakeAccountService, audit_logger: FakeAuditLogger):
+    return create_app(
+        account_service=account_service,
+        audit_logger=audit_logger,
+    )
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app)
+
+
+def _make_account(
+    account_id: str = "oracle-paper",
+    trading_hours_start: str = "09:00",
+    trading_hours_end: str = "15:30",
+) -> Account:
+    return Account(
+        account_id=account_id,
+        name="Oracle Paper",
+        exchange="TEST",
+        currency="KRW",
+        timezone="Asia/Seoul",
+        trading_hours_start=trading_hours_start,
+        trading_hours_end=trading_hours_end,
+        trading_mode=TradingMode.VIRTUAL,
+        broker_type="test",
+        credentials={"secret_key": "hidden"},
+        buy_commission_rate=Decimal("0"),
+        sell_commission_rate=Decimal("0"),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+class TestPutAccountTradingHoursValidation:
+    """PUT /api/accounts/{id} body의 trading_hours_start/end 422 회귀 가드."""
+
+    def test_put_account_invalid_trading_hours_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """trading_hours_start='99:99'는 422로 차단된다 (이슈 #1334 직접 회귀)."""
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/oracle-paper",
+            json={"trading_hours_start": "99:99"},
+        )
+        assert resp.status_code == 422
+        # 422 detail에 trading_hours_start 필드가 포함되어 클라이언트가
+        # 어떤 필드 때문에 거부됐는지 식별 가능해야 한다.
+        assert "trading_hours_start" in str(resp.json())
+
+    def test_put_account_empty_trading_hours_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """update 경로의 ``""``는 broker preset fallback이 없으므로 422 (#1334)."""
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/oracle-paper",
+            json={"trading_hours_end": ""},
+        )
+        assert resp.status_code == 422
+
+    def test_put_account_seconds_in_trading_hours_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """초까지 포함된 '09:30:00'은 strict HH:MM이 아니므로 422 (#1334)."""
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/oracle-paper",
+            json={"trading_hours_start": "09:30:00"},
+        )
+        assert resp.status_code == 422
+
+    def test_put_account_invalid_trading_hours_does_not_mutate_state(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """invalid 입력은 service.update 미호출 + 계좌 필드 보존 + audit 미발행.
+
+        이슈 #1334의 본질적인 회귀 — invalid '99:99'가 DB로 흘러가 generic
+        preflight error를 트리거하면 안 된다.
+        """
+        account = _make_account(
+            trading_hours_start="09:00",
+            trading_hours_end="15:30",
+        )
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/oracle-paper",
+            json={"trading_hours_start": "99:99"},
+        )
+        assert resp.status_code == 422
+        # service.update 미호출 — 계좌 trading_hours_start 보존
+        assert account_service.update_calls == []
+        assert account_service._accounts["oracle-paper"].trading_hours_start == "09:00"
+        assert account_service._accounts["oracle-paper"].trading_hours_end == "15:30"
+        # audit 로그도 남기지 않는다
+        update_logs = [
+            log for log in audit_logger.logs if log["action"] == "account.update"
+        ]
+        assert update_logs == []

--- a/tests/unit/test_account_schema_trading_hours.py
+++ b/tests/unit/test_account_schema_trading_hours.py
@@ -1,0 +1,128 @@
+"""AccountCreateRequest / AccountUpdateRequest의 trading_hours strict HH:MM 검증.
+
+SSOT:
+- docs/specs/account/03-data-model.md (HH:MM 형식)
+- docs/specs/account/10-web-api.md (Account API 입력 invariant)
+- src/ante/web/schemas.py (HH_MM_PATTERN, field_validator)
+
+이슈 #1334: invalid `trading_hours_start`(예: "99:99")가 schema에 그대로
+저장되어 generic preflight error로 주문이 반복 거부되는 문제를
+schema-level 422로 차단한다.
+
+- AccountCreateRequest: ``""`` 통과(default 의미 보존), non-empty는 strict
+  HH:MM regex + ``time.fromisoformat`` 이중 검증.
+- AccountUpdateRequest: ``None`` 통과(필드 미제공), 그 외(``""`` 포함)는
+  검증 적용. update 경로는 broker preset fallback이 없으므로 ``""``는 invalid.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from ante.web.schemas import AccountCreateRequest, AccountUpdateRequest
+
+# ── AccountCreateRequest ──────────────────────────────────────────
+
+
+class TestAccountCreateRequestTradingHours:
+    """AccountCreateRequest의 trading_hours strict HH:MM 검증."""
+
+    @staticmethod
+    def _base_kwargs() -> dict[str, str]:
+        return {
+            "account_id": "test-account",
+            "name": "테스트 계좌",
+        }
+
+    def test_account_create_rejects_invalid_99_99(self) -> None:
+        """trading_hours_start='99:99'는 422로 거부된다 (이슈 #1334 회귀)."""
+        with pytest.raises(ValidationError) as exc_info:
+            AccountCreateRequest(
+                **self._base_kwargs(),
+                trading_hours_start="99:99",
+            )
+        assert "trading_hours_start" in str(exc_info.value)
+
+    def test_account_create_rejects_alphabetic(self) -> None:
+        """알파벳 포함 입력은 422로 거부된다."""
+        with pytest.raises(ValidationError):
+            AccountCreateRequest(
+                **self._base_kwargs(),
+                trading_hours_start="ab:cd",
+            )
+
+    def test_account_create_rejects_with_seconds(self) -> None:
+        """초까지 포함된 입력(예: '09:30:00')은 422로 거부된다."""
+        with pytest.raises(ValidationError):
+            AccountCreateRequest(
+                **self._base_kwargs(),
+                trading_hours_end="09:30:00",
+            )
+
+    def test_account_create_accepts_empty_default(self) -> None:
+        """``""``는 default 의미 보존을 위해 통과한다.
+
+        CLI/seed 경로에서 BrokerPreset fallback이 ``""``를 preset value로
+        채우므로 schema에서 ``""``를 거부하면 안 된다 (#1334 plan v5 stop
+        condition).
+        """
+        req = AccountCreateRequest(
+            **self._base_kwargs(),
+            trading_hours_start="",
+            trading_hours_end="",
+        )
+        assert req.trading_hours_start == ""
+        assert req.trading_hours_end == ""
+
+    def test_account_create_accepts_valid_hhmm_boundaries(self) -> None:
+        """경계값 HH:MM은 통과한다 (00:00, 09:30, 23:59)."""
+        for value in ("00:00", "09:30", "23:59"):
+            req = AccountCreateRequest(
+                **self._base_kwargs(),
+                trading_hours_start=value,
+                trading_hours_end=value,
+            )
+            assert req.trading_hours_start == value
+            assert req.trading_hours_end == value
+
+
+# ── AccountUpdateRequest ──────────────────────────────────────────
+
+
+class TestAccountUpdateRequestTradingHours:
+    """AccountUpdateRequest의 trading_hours strict HH:MM 검증.
+
+    update 경로는 broker preset fallback이 없으므로 ``""``도 거부한다.
+    """
+
+    def test_account_update_rejects_invalid_99_99(self) -> None:
+        """update 경로의 '99:99'도 422로 거부된다 (이슈 #1334 직접 회귀)."""
+        with pytest.raises(ValidationError) as exc_info:
+            AccountUpdateRequest(trading_hours_start="99:99")
+        assert "trading_hours_start" in str(exc_info.value)
+
+    def test_account_update_rejects_empty_string(self) -> None:
+        """update 경로의 ``""``는 422 — broker preset fallback이 없다."""
+        with pytest.raises(ValidationError):
+            AccountUpdateRequest(trading_hours_end="")
+
+    def test_account_update_rejects_with_seconds(self) -> None:
+        """초까지 포함된 '09:30:00'은 422로 거부된다."""
+        with pytest.raises(ValidationError):
+            AccountUpdateRequest(trading_hours_start="09:30:00")
+
+    def test_account_update_allows_none(self) -> None:
+        """``None``은 필드 미제공 의미로 통과한다."""
+        req = AccountUpdateRequest(trading_hours_start=None, trading_hours_end=None)
+        assert req.trading_hours_start is None
+        assert req.trading_hours_end is None
+
+    def test_account_update_accepts_valid(self) -> None:
+        """유효한 HH:MM은 통과한다."""
+        req = AccountUpdateRequest(
+            trading_hours_start="09:30",
+            trading_hours_end="16:00",
+        )
+        assert req.trading_hours_start == "09:30"
+        assert req.trading_hours_end == "16:00"


### PR DESCRIPTION
Closes #1334

## Summary
- `AccountCreateRequest`와 `AccountUpdateRequest`에 strict `HH:MM` 24시간 형식 validator 추가 (regex `^([01]\d|2[0-3]):[0-5]\d$` + `dtime.fromisoformat()` 이중 검증).
  - `AccountCreateRequest`: `""` default 통과 (BrokerPreset fallback sentinel).
  - `AccountUpdateRequest`: `None` 통과, `""`/invalid는 422 거부.
- `ACCOUNT_MUTABLE_UPDATE_REQUEST_SCHEMA`(PUT)와 `ACCOUNT_CREATE_REQUEST_SCHEMA`(POST)의 `trading_hours_start`/`end`에 pattern 반영.
  - PUT: strict `^([01]\d|2[0-3]):[0-5]\d$`.
  - POST(cold-path): `^(([01]\d|2[0-3]):[0-5]\d)?$` (빈 문자열 fallback sentinel 허용).
- `frontend/openapi.json`과 `frontend/src/types/api.generated.ts` 재생성.
- 신규 단위 테스트 14건 (schema 10 + route 4).
- 스펙 보강: `docs/specs/account/10-web-api.md`에 trading_hours 검증 invariant 명시.

## Test Plan
- [x] `pytest tests/unit/test_account_schema_trading_hours.py tests/unit/test_account_routes_trading_hours.py -x` (14 PASS)
- [x] `pytest tests/unit/ -k "account" -x` (604 PASS, 회귀 없음)
- [x] `pytest tests/unit/` 전체 (3875 passed, 2 skipped)
- [x] `ruff check`, `ruff format --check`, `mypy`: PASS
- [x] `/codex:review --base main` (2차) PASS — 1차 P2(POST pattern empty 허용) 반영.

## Non-Goals (별도 후속 이슈)
- TradingHoursRule generic preflight error 메시지 개선
- legacy DB invalid value 검증/마이그레이션
- 시간대(timezone) 검증
- 거래 시간이 거꾸로(start>end) 의미 검증
- Web POST runtime behavior 변경 (현재 항상 409 cold-path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)