### PR TITLE
fix(bot): map create budget failure to 422 with hard rollback (#1335)

### DIFF
--- a/docs/specs/web-api/05-resource-endpoints.md
+++ b/docs/specs/web-api/05-resource-endpoints.md
@@ -34,7 +34,7 @@
 | Method | Path | 설명 |
 |--------|------|------|
 | GET | `/api/bots` | 봇 목록 (cursor 페이지네이션, 필터: account_id, limit, cursor). 응답에 `strategy_name` 포함 — StrategyRegistry 조인 |
-| POST | `/api/bots` | 봇 생성. Body: bot_id, strategy_id, name, bot_type, interval_seconds. 계좌 정지 상태이면 409 Conflict |
+| POST | `/api/bots` | 봇 생성. Body: bot_id, strategy_id, name, bot_type, interval_seconds, budget?. 계좌 정지 상태이면 409 Conflict. **budget 처리 (#1335):** budget 포함 시 봇 생성 후 Treasury 배정을 시도한다. 배정이 `TreasuryError`(insufficient funds, treasury not configured for account 등)로 실패하면 422를 반환하고 신규 봇은 `delete_bot(handle_positions="keep")`로 best-effort 롤백된다. 롤백 자체가 실패하면 500과 함께 `budget allocation failed: ... rollback also failed; bot {bot_id} may be in partial state. Check bot status and treasury manually.` detail이 노출된다. 비-`TreasuryError`는 422로 매핑하지 않고 propagate한다 (bot create + budget 배정은 atomic transaction이 아닌 best-effort 롤백 정책). |
 | GET | `/api/bots/{bot_id}` | 봇 상세 조회 (전략/예산/포지션 포함) |
 | POST | `/api/bots/{bot_id}/start` | 봇 시작 |
 | POST | `/api/bots/{bot_id}/stop` | 봇 중지 |

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3691,7 +3691,17 @@
             }
           },
           "422": {
-            "description": "strategy_id/strategy_name both missing or budget error",
+            "description": "strategy_id/strategy_name both missing, or budget allocation failed (Treasury error: insufficient funds, treasury not configured for account, etc.). On budget failure the newly created bot is rolled back via delete_bot(handle_positions='keep').",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error (e.g. budget allocation failed AND rollback also failed; bot may be left in partial state — manual inspection of bot status and treasury required).",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -4123,8 +4123,17 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description strategy_id/strategy_name both missing or budget error */
+            /** @description strategy_id/strategy_name both missing, or budget allocation failed (Treasury error: insufficient funds, treasury not configured for account, etc.). On budget failure the newly created bot is rolled back via delete_bot(handle_positions='keep'). */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal error (e.g. budget allocation failed AND rollback also failed; bot may be left in partial state — manual inspection of bot status and treasury required). */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -453,14 +453,31 @@ class BotManager:
         await bot.stop()
         self._remove_strategy_rules(bot.config.strategy_id)
 
-    async def delete_bot(self, bot_id: str, handle_positions: str = "keep") -> None:
-        """봇 소프트 딜리트. 실행 중이면 먼저 중지.
+    async def delete_bot(
+        self,
+        bot_id: str,
+        handle_positions: str = "keep",
+        hard: bool = False,
+    ) -> None:
+        """봇 삭제. 실행 중이면 먼저 중지.
 
         Args:
             bot_id: 삭제할 봇 ID.
             handle_positions: 포지션 처리 방식.
                 - ``keep`` (기본): 포지션을 유지한 채 봇만 삭제.
                 - ``liquidate``: 보유 종목 시장가 매도 주문 발행 후 삭제.
+            hard: ``True`` 이면 ``DELETE FROM bots`` 로 row 자체를 삭제한다.
+                기본 ``False`` 는 기존 soft delete 거동 (``status='deleted'``)
+                을 유지한다.
+
+                Refs #1335: ``POST /api/bots`` budget 배정 실패 후 rollback
+                경로에서는 같은 ``bot_id`` 로의 재시도가 가능해야 한다.
+                soft delete 만 수행하면 row 가 ``status='deleted'`` 로
+                남아 ``_save_bot_config()`` UPSERT 가 status 를 복구하지
+                않으므로, 재시도가 ``201`` 을 반환해도 봇은 메모리에만
+                존재하고 재시작 후 ``load_from_db()`` 에서 제외된다.
+                rollback 경로에서는 ``hard=True`` 로 row 자체를 제거해
+                재시도 의미를 보존한다.
         """
         if handle_positions not in ("keep", "liquidate"):
             raise BotError(
@@ -514,16 +531,28 @@ class BotManager:
 
         bot.status = BotStatus.DELETED
         del self._bots[bot_id]
-        await self._db.execute(
-            "UPDATE bots SET status = 'deleted', updated_at = datetime('now')"
-            " WHERE bot_id = ?",
-            (bot_id,),
-        )
-        logger.info("봇 삭제 (soft delete): %s", bot_id)
+        if hard:
+            await self._db.execute(
+                "DELETE FROM bots WHERE bot_id = ?",
+                (bot_id,),
+            )
+            logger.info("봇 삭제 (hard delete): %s", bot_id)
+        else:
+            await self._db.execute(
+                "UPDATE bots SET status = 'deleted', updated_at = datetime('now')"
+                " WHERE bot_id = ?",
+                (bot_id,),
+            )
+            logger.info("봇 삭제 (soft delete): %s", bot_id)
 
-    async def remove_bot(self, bot_id: str, handle_positions: str = "keep") -> None:
+    async def remove_bot(
+        self,
+        bot_id: str,
+        handle_positions: str = "keep",
+        hard: bool = False,
+    ) -> None:
         """봇 삭제. delete_bot()의 별칭 (하위 호환)."""
-        await self.delete_bot(bot_id, handle_positions=handle_positions)
+        await self.delete_bot(bot_id, handle_positions=handle_positions, hard=hard)
 
     async def _liquidate_positions(self, bot: Bot) -> None:
         """봇의 보유 포지션에 대해 시장가 매도 주문을 발행한다.

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -343,16 +343,26 @@ class BotManager:
         # DB 갱신
         await self._save_bot_config(new_config)
 
-        # budget 변경 시 Treasury 연동
-        if new_budget is not None and self._treasury_manager:
+        # budget 변경 시 Treasury 연동.
+        # Refs #1335: 과거에는 ``new_budget is not None`` 인 경로에서도
+        # ``TreasuryManager`` 부재 / account 미등록을 silent 하게 흘려보내
+        # 호출자(POST /api/bots) 가 budget 배정 실패를 감지하지 못했다.
+        # 이제 budget 배정 의도가 있는 경우(``new_budget is not None``)에는
+        # ``TreasuryNotConfiguredError`` 를 raise 하여 라우트 계층이 422 로
+        # 매핑할 수 있도록 한다. ``new_budget is None`` 인 단순 update
+        # 경로는 기존과 동일하게 무영향(no-op)이다.
+        if new_budget is not None:
+            from ante.treasury.exceptions import TreasuryNotConfiguredError
+
+            if self._treasury_manager is None:
+                raise TreasuryNotConfiguredError("treasury manager not configured")
             try:
                 treasury = self._treasury_manager.get(new_config.account_id)
-                await treasury.update_budget(bot_id, new_budget)
-            except KeyError:
-                logger.debug(
-                    "봇 수정 시 Treasury 미존재: account_id=%s",
-                    new_config.account_id,
-                )
+            except KeyError as ke:
+                raise TreasuryNotConfiguredError(
+                    f"treasury not configured for account {new_config.account_id}"
+                ) from ke
+            await treasury.update_budget(bot_id, new_budget)
 
         logger.info("봇 설정 수정: %s (변경: %s)", bot_id, list(updates.keys()))
         return bot

--- a/src/ante/treasury/exceptions.py
+++ b/src/ante/treasury/exceptions.py
@@ -17,3 +17,16 @@ class BotNotStoppedError(TreasuryError):
     """봇이 중지 상태가 아니어서 예산 변경 불가."""
 
     pass
+
+
+class TreasuryNotConfiguredError(TreasuryError):
+    """계좌에 Treasury가 구성되지 않아 budget 작업을 수행할 수 없음.
+
+    Refs #1335: budget 배정 요청이 들어왔지만 ``TreasuryManager`` 자체가
+    주입되지 않았거나, 해당 ``account_id`` 에 등록된 Treasury 가 없어
+    예산을 할당할 수 없을 때 발생한다. 라우트 계층은 이 예외를 422 로
+    매핑한다 (`TreasuryError` 하위 클래스이므로 기존 422 매핑이 자동
+    적용된다).
+    """
+
+    pass

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -298,7 +298,16 @@ async def create_bot(
             # 에 잡혀 500 으로 오분류될 수 있기 때문이다.
             rollback_failed = False
             try:
-                await bot_manager.delete_bot(body.bot_id, handle_positions="keep")
+                # Refs #1335 P2: ``hard=True`` — soft delete 만 수행하면
+                # ``status='deleted'`` row 가 남아 같은 ``bot_id`` 재시도
+                # 시 ``_save_bot_config()`` UPSERT 가 status 를 복구하지
+                # 않으므로, 재시도가 ``201`` 을 반환해도 봇은 메모리에만
+                # 존재하고 재시작 후 ``load_from_db()`` 에서 제외된다.
+                # 생성 실패 rollback 경로에서는 row 자체를 제거해
+                # 재시도 의미를 보존한다.
+                await bot_manager.delete_bot(
+                    body.bot_id, handle_positions="keep", hard=True
+                )
             except Exception as rollback_error:
                 rollback_failed = True
                 logger.exception(

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -23,6 +24,8 @@ from ante.web.schemas import (
     BotListResponse,
     BotUpdateRequest,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -136,7 +139,25 @@ async def list_bots(
             },
         },
         422: {
-            "description": "strategy_id/strategy_name both missing or budget error",
+            "description": (
+                "strategy_id/strategy_name both missing, or budget allocation"
+                " failed (Treasury error: insufficient funds, treasury not"
+                " configured for account, etc.). On budget failure the newly"
+                " created bot is rolled back via delete_bot(handle_positions="
+                "'keep')."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
+        500: {
+            "description": (
+                "Internal error (e.g. budget allocation failed AND rollback"
+                " also failed; bot may be left in partial state — manual"
+                " inspection of bot status and treasury required)."
+            ),
             "content": {
                 "application/problem+json": {
                     "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -261,11 +282,42 @@ async def create_bot(
         raise HTTPException(status_code=409, detail=str(e)) from e
 
     # budget이 지정된 경우 예산 배정 ────────────────────────
+    # Refs #1335: 과거에는 ``except Exception: pass`` 로 모든 실패를 삼켜
+    # client 가 예산 배정 실패를 감지할 수 없었다. 이제 ``TreasuryError``
+    # 는 422 로 매핑하고, 신규 봇은 best-effort 롤백한다. 비-TreasuryError
+    # (예: BotNotFoundError) 는 매핑하지 않고 propagate 시켜 기존 거동을
+    # 유지한다 (대부분 500 으로 표면화).
     if body.budget is not None:
+        from ante.treasury.exceptions import TreasuryError
+
         try:
             await bot_manager.update_bot(body.bot_id, budget=body.budget)
-        except Exception:
-            pass  # 봇은 이미 생성됨, budget 배정 실패는 무시 (이후 수정 가능)
+        except TreasuryError as e:
+            # 롤백 try/except 는 별도 블록으로 분리한다. 같은 try 안에서
+            # 422 HTTPException 을 raise 하면 외부 ``except Exception``
+            # 에 잡혀 500 으로 오분류될 수 있기 때문이다.
+            rollback_failed = False
+            try:
+                await bot_manager.delete_bot(body.bot_id, handle_positions="keep")
+            except Exception as rollback_error:
+                rollback_failed = True
+                logger.exception(
+                    "budget 배정 실패 후 봇 롤백도 실패: %s — 부분 생성 상태 유지",
+                    body.bot_id,
+                )
+                raise HTTPException(
+                    status_code=500,
+                    detail=(
+                        f"budget allocation failed: {e}. "
+                        f"rollback also failed; bot {body.bot_id} may be in "
+                        "partial state. Check bot status and treasury manually."
+                    ),
+                ) from rollback_error
+            # rollback 성공: 원 422 에러를 client 에 전달한다.
+            # (rollback_failed 는 type checker 를 위한 가드 -- 위 raise 후
+            # 도달하지 않지만 명시한다.)
+            if not rollback_failed:
+                raise HTTPException(status_code=422, detail=str(e)) from e
 
     if audit_logger:
         await audit_logger.log(

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -97,8 +97,14 @@ class FakeBotManager:
         if bot:
             bot._status = "stopped"
 
-    async def delete_bot(self, bot_id: str, handle_positions: str = "keep") -> None:
+    async def delete_bot(
+        self,
+        bot_id: str,
+        handle_positions: str = "keep",
+        hard: bool = False,
+    ) -> None:
         self.last_delete_handle_positions = handle_positions
+        self.last_delete_hard = hard
         if bot_id in self._bots:
             del self._bots[bot_id]
 

--- a/tests/unit/test_bot_manager_update_budget.py
+++ b/tests/unit/test_bot_manager_update_budget.py
@@ -1,0 +1,207 @@
+"""BotManager.update_bot — budget 배정 실패 매핑 검증.
+
+Refs #1335: ``new_budget is not None`` 일 때 TreasuryManager 가 부재하거나
+account 에 등록된 Treasury 가 없으면 ``TreasuryNotConfiguredError`` 가
+raise 되어야 한다. ``new_budget is None`` 인 단순 update 경로는 기존과
+동일하게 무영향이어야 한다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ante.bot import BotConfig, BotManager
+from ante.bot.config import BotStatus
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.strategy import (
+    DataProvider,
+    OrderView,
+    PortfolioView,
+    Strategy,
+    StrategyContext,
+    StrategyMeta,
+)
+from ante.treasury.exceptions import TreasuryNotConfiguredError
+from ante.treasury.treasury import Treasury
+
+
+class _FakeDataProvider(DataProvider):
+    async def get_ohlcv(self, symbol, timeframe="1d", limit=100):
+        import polars as pl
+
+        return pl.DataFrame({"close": [100.0]})
+
+    async def get_current_price(self, symbol):
+        return 100.0
+
+    async def get_indicator(self, symbol, indicator, params=None):
+        return {}
+
+
+class _FakePortfolioView(PortfolioView):
+    def get_positions(self, bot_id):
+        return {}
+
+    def get_balance(self, bot_id):
+        return {"total": 1_000_000.0, "available": 500_000.0}
+
+
+class _FakeOrderView(OrderView):
+    def get_open_orders(self, bot_id):
+        return []
+
+
+class _SimpleStrategy(Strategy):
+    meta = StrategyMeta(name="simple", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+
+
+class _FakeTreasuryManager:
+    """경량 TreasuryManager 대체.
+
+    register 되지 않은 account_id 에 대해 ``KeyError`` 를 raise 한다 (실제
+    ``TreasuryManager.get`` 의 거동과 동일).
+    """
+
+    def __init__(self) -> None:
+        self._treasuries: dict[str, Treasury] = {}
+
+    def register(self, account_id: str, treasury: Treasury) -> None:
+        self._treasuries[account_id] = treasury
+
+    def get(self, account_id: str) -> Treasury:
+        if account_id not in self._treasuries:
+            raise KeyError(f"Treasury not found: account_id={account_id}")
+        return self._treasuries[account_id]
+
+    def list_all(self) -> list[Treasury]:
+        return list(self._treasuries.values())
+
+
+@pytest.fixture
+def eventbus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+def ctx() -> StrategyContext:
+    return StrategyContext(
+        bot_id="bot1",
+        data_provider=_FakeDataProvider(),
+        portfolio=_FakePortfolioView(),
+        order_view=_FakeOrderView(),
+    )
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    try:
+        await asyncio.wait_for(database.close(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+async def _make_stopped_bot(
+    manager: BotManager, ctx: StrategyContext, *, account_id: str
+) -> str:
+    """create + force CREATED 상태로 bot1 생성."""
+    config = BotConfig(bot_id="bot1", strategy_id="s1", account_id=account_id)
+    bot = await manager.create_bot(config, _SimpleStrategy, ctx)
+    bot.status = BotStatus.CREATED
+    return "bot1"
+
+
+class TestUpdateBotBudgetTreasuryNotConfigured:
+    """``new_budget is not None`` 인데 Treasury 가 없으면 명시적 예외."""
+
+    async def test_update_bot_budget_raises_when_treasury_manager_none(
+        self, eventbus, db, ctx
+    ) -> None:
+        """treasury_manager 자체가 주입되지 않은 경우 → TreasuryNotConfiguredError."""
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=None)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(manager, ctx, account_id="acc-test")
+
+        with pytest.raises(TreasuryNotConfiguredError) as exc_info:
+            await manager.update_bot(bot_id, budget=100_000.0)
+
+        assert "treasury manager not configured" in str(exc_info.value)
+
+    async def test_update_bot_budget_raises_when_account_treasury_missing(
+        self, eventbus, db, ctx
+    ) -> None:
+        """treasury_manager 는 있지만 해당 account 에 Treasury 미등록 → 명시적 예외."""
+        tm = _FakeTreasuryManager()
+        # 'other' account 에만 등록 — 봇 account 'acc-test' 에는 미등록.
+        treasury = Treasury(db=db, eventbus=eventbus, account_id="other")
+        await treasury.initialize()
+        await treasury.set_account_balance(1_000_000)
+        tm.register("other", treasury)
+
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=tm)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(manager, ctx, account_id="acc-test")
+
+        with pytest.raises(TreasuryNotConfiguredError) as exc_info:
+            await manager.update_bot(bot_id, budget=100_000.0)
+
+        assert "acc-test" in str(exc_info.value)
+
+
+class TestUpdateBotNoBudgetSilentSkip:
+    """``new_budget is None`` 경로는 기존 거동(no-op) 유지."""
+
+    async def test_update_bot_no_budget_silent_skip_when_treasury_missing(
+        self, eventbus, db, ctx
+    ) -> None:
+        """budget 이 없으면 treasury_manager 가 없어도 update 정상."""
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=None)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(manager, ctx, account_id="acc-test")
+
+        # name 만 변경. budget 미지정 → TreasuryNotConfiguredError 가 발생하면 안 된다.
+        bot = await manager.update_bot(bot_id, name="새 이름")
+        assert bot.config.name == "새 이름"
+
+    async def test_update_bot_no_budget_silent_skip_when_account_missing(
+        self, eventbus, db, ctx
+    ) -> None:
+        """budget 미지정이고 account 에 Treasury 미등록이어도 update 정상."""
+        tm = _FakeTreasuryManager()  # 비어 있음
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=tm)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(manager, ctx, account_id="acc-test")
+
+        bot = await manager.update_bot(bot_id, interval_seconds=120)
+        assert bot.config.interval_seconds == 120
+
+
+class TestUpdateBotBudgetSuccess:
+    """정상 경로: Treasury 등록되어 있으면 budget 배정 성공."""
+
+    async def test_update_bot_budget_success_with_treasury_registered(
+        self, eventbus, db, ctx
+    ) -> None:
+        tm = _FakeTreasuryManager()
+        treasury = Treasury(db=db, eventbus=eventbus, account_id="acc-test")
+        await treasury.initialize()
+        await treasury.set_account_balance(1_000_000)
+        tm.register("acc-test", treasury)
+
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=tm)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(manager, ctx, account_id="acc-test")
+
+        await manager.update_bot(bot_id, budget=200_000.0)
+
+        budget = treasury.get_budget(bot_id)
+        assert budget is not None
+        assert budget.allocated == pytest.approx(200_000.0)

--- a/tests/unit/test_bot_manager_update_budget.py
+++ b/tests/unit/test_bot_manager_update_budget.py
@@ -205,3 +205,75 @@ class TestUpdateBotBudgetSuccess:
         budget = treasury.get_budget(bot_id)
         assert budget is not None
         assert budget.allocated == pytest.approx(200_000.0)
+
+
+class TestDeleteBotHard:
+    """Refs #1335 P2: ``hard=True`` 는 row 자체를 삭제한다."""
+
+    async def test_delete_bot_default_soft_deletes_row(self, eventbus, db, ctx) -> None:
+        """기본 ``hard=False`` 는 기존 soft delete 거동 유지."""
+        manager = BotManager(eventbus=eventbus, db=db)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(manager, ctx, account_id="acc-test")
+
+        await manager.delete_bot(bot_id)
+
+        # row 는 status='deleted' 로 남아 있어야 한다.
+        row = await db.fetch_one(
+            "SELECT bot_id, status FROM bots WHERE bot_id = ?", (bot_id,)
+        )
+        assert row is not None
+        assert row["status"] == "deleted"
+
+    async def test_delete_bot_hard_removes_row_from_db(self, eventbus, db, ctx) -> None:
+        """``hard=True`` 는 ``DELETE FROM bots`` 로 row 자체를 제거한다.
+
+        rollback 경로(POST /api/bots budget 실패) 가 사용하는 분기.
+        soft delete 가 남기는 ``status='deleted'`` row 가 같은 bot_id
+        재시도를 막는 문제를 해결한다.
+        """
+        manager = BotManager(eventbus=eventbus, db=db)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(manager, ctx, account_id="acc-test")
+
+        await manager.delete_bot(bot_id, hard=True)
+
+        # row 가 DB 에서 완전히 사라져야 한다.
+        row = await db.fetch_one(
+            "SELECT bot_id, status FROM bots WHERE bot_id = ?", (bot_id,)
+        )
+        assert row is None
+
+        # 인메모리 상태도 정리되어 있어야 한다.
+        assert manager.get_bot(bot_id) is None
+
+    async def test_delete_bot_hard_then_recreate_same_bot_id_succeeds(
+        self, eventbus, db, ctx
+    ) -> None:
+        """hard delete 후 같은 ``bot_id`` 로 재생성 시 정상 row 유지.
+
+        soft delete 였다면 재생성 후 row 가 ``status='deleted'`` 로 남아
+        ``load_from_db()`` 에서 제외되었을 것. hard delete 가 이 문제를
+        해결함을 검증한다.
+        """
+        manager = BotManager(eventbus=eventbus, db=db)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(manager, ctx, account_id="acc-test")
+
+        await manager.delete_bot(bot_id, hard=True)
+
+        # 같은 bot_id 로 재생성.
+        config = BotConfig(bot_id=bot_id, strategy_id="s1", account_id="acc-test")
+        await manager.create_bot(config, _SimpleStrategy, ctx)
+
+        row = await db.fetch_one(
+            "SELECT bot_id, status FROM bots WHERE bot_id = ?", (bot_id,)
+        )
+        assert row is not None
+        # status 는 default ``created`` 로 시작해야 한다 (deleted 잔존 없음).
+        assert row["status"] == "created"
+
+        # load_from_db 도 새 봇을 정상 로드해야 한다 (status != 'deleted').
+        loaded = await manager.load_from_db()
+        assert loaded == 1
+        assert manager.get_bot(bot_id) is not None

--- a/tests/unit/test_bot_routes_create_budget_error.py
+++ b/tests/unit/test_bot_routes_create_budget_error.py
@@ -144,7 +144,12 @@ class TestCreateBotBudgetError:
     def test_create_bot_budget_failure_rolls_back_bot(
         self, client, bot_manager
     ) -> None:
-        """422 후 GET /api/bots/{id} → 404 (롤백 확인)."""
+        """422 후 GET /api/bots/{id} → 404 (롤백 확인).
+
+        Refs #1335 P2: rollback 호출은 ``hard=True`` 로 위임되어 row 가
+        남지 않아야 한다. ``FakeBotManager.delete_bot`` 은 마지막 호출의
+        ``hard`` 인자를 ``last_delete_hard`` 에 기록한다.
+        """
         from ante.treasury.exceptions import InsufficientFundsError
 
         _install_treasury_error_on_update(
@@ -166,6 +171,71 @@ class TestCreateBotBudgetError:
         get_resp = client.get(f"/api/bots/{bot_id}")
         assert get_resp.status_code == 404
         assert bot_manager.get_bot(bot_id) is None
+        # Refs #1335 P2: rollback 은 hard delete 여야 한다.
+        assert getattr(bot_manager, "last_delete_hard", None) is True
+
+    def test_create_bot_budget_failure_then_retry_with_valid_budget_succeeds(
+        self, client, bot_manager
+    ) -> None:
+        """422 rollback 후 같은 bot_id 로 정상 budget 재시도 → 201.
+
+        Refs #1335 P2: soft delete 만 수행하면 row 가 ``status='deleted'``
+        로 남고 ``_save_bot_config()`` UPSERT 가 status 를 복구하지 않아
+        재시도가 ``201`` 을 반환해도 ``load_from_db()`` 에서 제외된다.
+        rollback 경로의 ``hard=True`` 가 row 자체를 제거해 재시도가
+        깔끔하게 동작함을 검증한다.
+
+        이 테스트는 ``FakeBotManager`` 레벨에서 1차만 실패시키고 2차는
+        정상으로 흐르도록 한다 (실제 ``BotManager`` 의 row 상태 영향은
+        ``test_delete_bot_hard_removes_row_from_db`` 에서 별도 검증).
+        """
+        from ante.treasury.exceptions import InsufficientFundsError
+
+        original_update_bot = bot_manager.update_bot
+        call_count = {"n": 0}
+
+        async def _patched(bot_id, **kwargs):
+            if "budget" in kwargs and kwargs["budget"] is not None:
+                call_count["n"] += 1
+                if call_count["n"] == 1:
+                    raise InsufficientFundsError("insufficient")
+            return await original_update_bot(bot_id, **kwargs)
+
+        bot_manager.update_bot = _patched  # type: ignore[assignment]
+
+        bot_id = "bot-retry"
+
+        # 1차: budget 배정 실패 → 422 + rollback.
+        first_resp = client.post(
+            "/api/bots",
+            json={
+                "bot_id": bot_id,
+                "strategy_id": "s1",
+                "account_id": "test",
+                "budget": 1_000_000_000.0,
+            },
+        )
+        assert first_resp.status_code == 422
+        assert bot_manager.get_bot(bot_id) is None
+        assert getattr(bot_manager, "last_delete_hard", None) is True
+
+        # 2차: 정상 budget 재시도 → 201.
+        retry_resp = client.post(
+            "/api/bots",
+            json={
+                "bot_id": bot_id,
+                "strategy_id": "s1",
+                "account_id": "test",
+                "budget": 1_000_000.0,
+            },
+        )
+        assert retry_resp.status_code == 201, retry_resp.text
+        assert retry_resp.json()["bot"]["bot_id"] == bot_id
+        # 메모리에서도 정상 조회되어야 한다.
+        assert bot_manager.get_bot(bot_id) is not None
+
+        get_resp = client.get(f"/api/bots/{bot_id}")
+        assert get_resp.status_code == 200
 
     def test_create_bot_with_valid_budget_succeeds(self, client, bot_manager) -> None:
         """budget 배정 성공 → 201."""
@@ -197,7 +267,7 @@ class TestCreateBotBudgetError:
         )
 
         # delete_bot 도 실패하도록 패치.
-        async def _failing_delete(bot_id, handle_positions="keep"):
+        async def _failing_delete(bot_id, handle_positions="keep", hard=False):
             raise BotError(f"delete failed for {bot_id}")
 
         bot_manager.delete_bot = _failing_delete  # type: ignore[assignment]

--- a/tests/unit/test_bot_routes_create_budget_error.py
+++ b/tests/unit/test_bot_routes_create_budget_error.py
@@ -1,0 +1,242 @@
+"""POST /api/bots — budget 배정 실패 시 422 + 롤백 검증.
+
+Refs #1335: 과거에는 ``except Exception: pass`` 로 budget 배정 실패를
+silent 하게 삼켜 client 가 201 Created 를 받았다. 이제 ``TreasuryError``
+는 422 로 매핑되고 신규 봇은 best-effort 롤백된다.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402
+
+# 기존 테스트 파일의 Fake 들을 재사용한다.
+from tests.unit.test_bot_api import (  # noqa: E402
+    FakeAccount,
+    FakeAccountService,
+    FakeBotManager,
+    FakeStrategyRecord,
+    FakeStrategyRegistry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _mock_strategy_loader(monkeypatch):
+    """StrategyLoader.load 를 모킹해 파일 시스템 의존을 제거."""
+
+    class _FakeStrategy:
+        pass
+
+    monkeypatch.setattr(
+        "ante.strategy.loader.StrategyLoader.load",
+        staticmethod(lambda path: _FakeStrategy),
+    )
+
+
+@pytest.fixture
+def bot_manager() -> FakeBotManager:
+    return FakeBotManager()
+
+
+@pytest.fixture
+def account_service() -> FakeAccountService:
+    svc = FakeAccountService()
+    svc._accounts["test"] = FakeAccount(
+        "test",
+        status="active",
+        credentials={"app_key": "test-key", "app_secret": "test-secret"},
+    )
+    return svc
+
+
+@pytest.fixture
+def strategy_registry() -> FakeStrategyRegistry:
+    reg = FakeStrategyRegistry()
+    reg._strategies["s1"] = FakeStrategyRecord("s1", name="s1")
+    return reg
+
+
+@pytest.fixture
+def client(bot_manager, account_service, strategy_registry) -> TestClient:
+    app = create_app(
+        bot_manager=bot_manager,
+        account_service=account_service,
+        strategy_registry=strategy_registry,
+    )
+    return TestClient(app)
+
+
+def _install_treasury_error_on_update(
+    bot_manager: FakeBotManager, exc: Exception
+) -> None:
+    """update_bot 호출 시 budget 인자가 있으면 ``exc`` 를 raise 하도록 패치.
+
+    실제 ``BotManager.update_bot`` 의 budget 분기 동작을 흉내 낸다.
+    """
+    original_update_bot = bot_manager.update_bot
+
+    async def _patched(bot_id, **kwargs):
+        if "budget" in kwargs and kwargs["budget"] is not None:
+            raise exc
+        return await original_update_bot(bot_id, **kwargs)
+
+    bot_manager.update_bot = _patched  # type: ignore[assignment]
+
+
+class TestCreateBotBudgetError:
+    """POST /api/bots 의 budget 배정 실패 매핑."""
+
+    def test_create_bot_with_oversized_budget_returns_422(
+        self, client, bot_manager
+    ) -> None:
+        """``InsufficientFundsError`` (TreasuryError 하위) → 422."""
+        from ante.treasury.exceptions import InsufficientFundsError
+
+        _install_treasury_error_on_update(
+            bot_manager,
+            InsufficientFundsError(
+                "미할당 잔액 부족: 필요 1,000,000,000,000, 가용 1,000,000"
+            ),
+        )
+
+        resp = client.post(
+            "/api/bots",
+            json={
+                "bot_id": "bot-overbudget",
+                "strategy_id": "s1",
+                "account_id": "test",
+                "budget": 1_000_000_000_000.0,
+            },
+        )
+
+        assert resp.status_code == 422
+        assert "잔액 부족" in resp.json()["detail"]
+
+    def test_create_bot_treasury_not_configured_returns_422(
+        self, client, bot_manager
+    ) -> None:
+        """``TreasuryNotConfiguredError`` → 422 (TreasuryError 하위)."""
+        from ante.treasury.exceptions import TreasuryNotConfiguredError
+
+        _install_treasury_error_on_update(
+            bot_manager,
+            TreasuryNotConfiguredError("treasury manager not configured"),
+        )
+
+        resp = client.post(
+            "/api/bots",
+            json={
+                "bot_id": "bot-noconfig",
+                "strategy_id": "s1",
+                "account_id": "test",
+                "budget": 100_000.0,
+            },
+        )
+
+        assert resp.status_code == 422
+        assert "treasury" in resp.json()["detail"].lower()
+
+    def test_create_bot_budget_failure_rolls_back_bot(
+        self, client, bot_manager
+    ) -> None:
+        """422 후 GET /api/bots/{id} → 404 (롤백 확인)."""
+        from ante.treasury.exceptions import InsufficientFundsError
+
+        _install_treasury_error_on_update(
+            bot_manager, InsufficientFundsError("insufficient")
+        )
+
+        bot_id = "bot-rollback"
+        create_resp = client.post(
+            "/api/bots",
+            json={
+                "bot_id": bot_id,
+                "strategy_id": "s1",
+                "account_id": "test",
+                "budget": 5_000_000.0,
+            },
+        )
+        assert create_resp.status_code == 422
+
+        get_resp = client.get(f"/api/bots/{bot_id}")
+        assert get_resp.status_code == 404
+        assert bot_manager.get_bot(bot_id) is None
+
+    def test_create_bot_with_valid_budget_succeeds(self, client, bot_manager) -> None:
+        """budget 배정 성공 → 201."""
+        # budget 인자가 와도 FakeBotManager.update_bot 은 budget 키를
+        # filter out 하므로 별도 패치 없이 정상 동작한다.
+        resp = client.post(
+            "/api/bots",
+            json={
+                "bot_id": "bot-ok",
+                "strategy_id": "s1",
+                "account_id": "test",
+                "budget": 5_000_000.0,
+            },
+        )
+        assert resp.status_code == 201
+        assert resp.json()["bot"]["bot_id"] == "bot-ok"
+        # 봇이 존재해야 한다.
+        assert bot_manager.get_bot("bot-ok") is not None
+
+    def test_create_bot_budget_failure_with_rollback_failure_returns_500(
+        self, client, bot_manager
+    ) -> None:
+        """budget 배정 실패 + 롤백 실패 → 500 + partial state detail."""
+        from ante.bot.exceptions import BotError
+        from ante.treasury.exceptions import InsufficientFundsError
+
+        _install_treasury_error_on_update(
+            bot_manager, InsufficientFundsError("insufficient")
+        )
+
+        # delete_bot 도 실패하도록 패치.
+        async def _failing_delete(bot_id, handle_positions="keep"):
+            raise BotError(f"delete failed for {bot_id}")
+
+        bot_manager.delete_bot = _failing_delete  # type: ignore[assignment]
+
+        resp = client.post(
+            "/api/bots",
+            json={
+                "bot_id": "bot-doublefail",
+                "strategy_id": "s1",
+                "account_id": "test",
+                "budget": 5_000_000.0,
+            },
+        )
+
+        assert resp.status_code == 500
+        detail = resp.json()["detail"]
+        assert "budget allocation failed" in detail
+        assert "rollback also failed" in detail
+        assert "bot-doublefail" in detail
+        assert "partial state" in detail
+
+    def test_create_bot_other_exception_during_budget_update_propagates(
+        self, client, bot_manager
+    ) -> None:
+        """비-TreasuryError 는 422 로 매핑하지 않고 propagate (FastAPI 가 500)."""
+        # RuntimeError 는 TreasuryError 하위가 아니므로 catch 되지 않아야
+        # 한다. TestClient 는 raise_server_exceptions=True 가 기본이므로
+        # 예외가 그대로 전파된다.
+        _install_treasury_error_on_update(
+            bot_manager, RuntimeError("unexpected internal error")
+        )
+
+        with pytest.raises(RuntimeError, match="unexpected internal error"):
+            client.post(
+                "/api/bots",
+                json={
+                    "bot_id": "bot-otherexc",
+                    "strategy_id": "s1",
+                    "account_id": "test",
+                    "budget": 5_000_000.0,
+                },
+            )


### PR DESCRIPTION
Closes #1335

## Summary
- `POST /api/bots`의 budget 배정 실패가 `except Exception: pass`로 묵살되던 결함 해결.
- `BotManager.update_bot`이 budget 배정 시 Treasury 미존재를 silent swallow하던 결함 수정 — 신규 `TreasuryNotConfiguredError(TreasuryError)` raise.
- create_bot 라우트에서 TreasuryError → 422 매핑 + 신규 봇 hard delete 롤백.
- 롤백 자체가 실패하면 500과 함께 partial state detail.
- `BotManager.delete_bot`에 `hard: bool = False` 옵션 추가 (rollback 전용; 일반 delete는 기존 soft 거동 유지).
- 같은 bot_id 재시도가 정상 동작 (hard delete로 DB row 잔존 없음).

## Test Plan
- [x] `pytest tests/unit/test_bot_routes_create_budget_error.py tests/unit/test_bot_manager_update_budget.py -x` (15 PASS)
- [x] `pytest tests/unit/ -k "bot" -x` (459 PASS, 회귀 없음)
- [x] `pytest tests/unit/` 전체 (3890 passed, 2 skipped)
- [x] `ruff check`, `ruff format --check`, `mypy`: PASS
- [x] `/codex:review --base main` (3차) PASS

## Non-Goals (별도 후속 이슈)
- bot create + budget을 atomic transaction
- BotManager.update_bot의 budget=None silent skip 변경
- audit logger 정책 변경 (실패 케이스)
- 비-TreasuryError를 422로 매핑

🤖 Generated with [Claude Code](https://claude.com/claude-code)