### PR TITLE
feat(treasury): account-scoped quote resolver for market buy reserve (#1333)

### DIFF
--- a/docs/specs/account/03-data-model.md
+++ b/docs/specs/account/03-data-model.md
@@ -48,6 +48,11 @@ class Account:
     # --- 비용 ---
     buy_commission_rate: Decimal = Decimal("0")    # 매수 수수료율
     sell_commission_rate: Decimal = Decimal("0")   # 매도 수수료율 (세금 포함)
+    # 시장가 매수 reserve buffer 비율 (Account-level Treasury reserve policy, #1333).
+    # quote 만으로 reserve 하면 가격 변동을 흡수하지 못하므로
+    # ``reserve_basis = quantity * quote * (1 + market_order_reserve_buffer_rate)``
+    # 식으로 보수적으로 잠근다.
+    market_order_reserve_buffer_rate: Decimal = Decimal("0")
 
     # --- 상태 ---
     status: AccountStatus = AccountStatus.ACTIVE
@@ -79,6 +84,7 @@ class Account:
 | **비용** | | | | |
 | `buy_commission_rate` | - | `0` | cold-path | 매수 수수료율 |
 | `sell_commission_rate` | - | `0` | cold-path | 매도 수수료율 (세금 포함) |
+| `market_order_reserve_buffer_rate` | - | BrokerPreset 기본값 | cold-path | 시장가 매수 reserve buffer 비율 (#1333). Treasury 가 시장가 매수 reserve 산정 시 보수적으로 잠가둘 추가 비율. `broker_config` 가 아니라 Account 소속 reserve policy 다. |
 | **상태** | | | | |
 | `status` | - | `ACTIVE` | 상태 전이 | 계좌 상태 (ACTIVE / SUSPENDED / DELETED) |
 
@@ -109,6 +115,8 @@ class BrokerPreset:
     trading_hours_end: str
     buy_commission_rate: Decimal
     sell_commission_rate: Decimal
+    # #1333: Account 의 ``market_order_reserve_buffer_rate`` 초기값.
+    market_order_reserve_buffer_rate: Decimal
     default_account_id: str
     default_name: str
     required_credentials: list[str]
@@ -124,6 +132,7 @@ BROKER_PRESETS: dict[str, BrokerPreset] = {
         exchange="TEST", currency="KRW", timezone="Asia/Seoul",
         trading_hours_start="00:00", trading_hours_end="23:59",
         buy_commission_rate=Decimal("0"), sell_commission_rate=Decimal("0"),
+        market_order_reserve_buffer_rate=Decimal("0"),  # #1333: 결정적 거동.
         default_account_id="test", default_name="테스트",
         required_credentials=["app_key", "app_secret"],
     ),
@@ -131,30 +140,30 @@ BROKER_PRESETS: dict[str, BrokerPreset] = {
         exchange="KRX", currency="KRW", timezone="Asia/Seoul",
         trading_hours_start="09:00", trading_hours_end="15:30",
         buy_commission_rate=Decimal("0.00015"), sell_commission_rate=Decimal("0.00195"),
+        market_order_reserve_buffer_rate=Decimal("0.005"),  # #1333: 0.5%.
         default_account_id="domestic", default_name="국내 주식",
         required_credentials=["app_key", "app_secret", "account_no"],
     ),
-    # kis-overseas 프리셋은 정의만 해둔다.
-    # KISOverseasAdapter 구현 및 BROKER_REGISTRY 등록은 1.1에서 지원.
-    "kis-overseas": BrokerPreset(
-        exchange="NYSE", currency="USD", timezone="America/New_York",
-        trading_hours_start="09:30", trading_hours_end="16:00",
-        buy_commission_rate=Decimal("0.001"), sell_commission_rate=Decimal("0.001"),
-        default_account_id="us-stock", default_name="미국 주식",
-        required_credentials=["app_key", "app_secret", "account_no"],
-    ),
+    # kis-overseas 프리셋은 1.0 BROKER_REGISTRY 가 미지원이므로 본 1.0 stage
+    # 에서는 정의하지 않는다 (#1333). 1.1 KISOverseasAdapter 도입 시 함께
+    # 추가하며, ``market_order_reserve_buffer_rate`` 는 그때 시장 사례에 맞춰
+    # 결정한다. legacy DB 의 ``broker_type='kis-overseas'`` row 는
+    # ``accounts.market_order_reserve_buffer_rate`` DDL default(0.005) 를
+    # 그대로 유지한다.
 }
 ```
 
 소스: `src/ante/account/presets.py`
 
-| broker_type | exchange | currency | timezone | trading_hours | buy_commission | sell_commission |
-|-------------|----------|----------|----------|--------------|----------------|----------------|
-| `test` | `TEST` | `KRW` | `Asia/Seoul` | 00:00–23:59 | 0 | 0 |
-| `kis-domestic` | `KRX` | `KRW` | `Asia/Seoul` | 09:00–15:30 | 0.015% | 0.195% |
-| `kis-overseas` | `NYSE`, `NASDAQ`, `AMEX` | `USD` | `America/New_York` | 09:30–16:00 | 0.1% | 0.1% |
+| broker_type | exchange | currency | timezone | trading_hours | buy_commission | sell_commission | market_order_buffer |
+|-------------|----------|----------|----------|--------------|----------------|----------------|---------------------|
+| `test` | `TEST` | `KRW` | `Asia/Seoul` | 00:00–23:59 | 0 | 0 | 0 |
+| `kis-domestic` | `KRX` | `KRW` | `Asia/Seoul` | 09:00–15:30 | 0.015% | 0.195% | 0.5% |
 
-> **향후 지원**: `kis-overseas`는 프리셋만 정의해두고, KISOverseasAdapter 구현 및 `BROKER_REGISTRY` 등록은 1.1에서 지원한다. 따라서 "us-stock" Account 생성은 1.1 이후 가능하다. 향후 `ib` (Interactive Brokers) 등 프리셋 추가로 대응.
+> **향후 지원**: `kis-overseas` 는 1.0 단계에서 BROKER_REGISTRY 가 미지원이므로
+> BROKER_PRESETS 에 정의하지 않는다. KISOverseasAdapter 구현, `BROKER_REGISTRY`
+> 등록, 그리고 그에 맞는 `market_order_reserve_buffer_rate` 결정은 1.1 이후로
+> 미룬다. 향후 `ib` (Interactive Brokers) 등 프리셋 추가로 대응.
 
 ### BROKER_REGISTRY
 
@@ -162,9 +171,13 @@ BROKER_PRESETS: dict[str, BrokerPreset] = {
 _BROKER_REGISTRY: dict[str, type[BrokerAdapter]] = {
     "test": TestBrokerAdapter,
     "kis-domestic": KISDomesticAdapter,
-    # "kis-overseas": KISOverseasAdapter,  ← 1.1에서 등록
+    # "kis-overseas": KISOverseasAdapter,  ← 1.1 에서 등록
 }
 ```
+
+`BROKER_PRESETS` 와 `BROKER_REGISTRY` 의 keys 가 일치해야 신규 계좌 생성이
+preset 기본값과 어댑터 클래스를 동시에 찾는다. 1.0 에서는 양쪽 모두
+`{"test", "kis-domestic"}` 만 노출한다 (#1333).
 
 `AccountService.get_broker()`가 `broker_type`으로 이 레지스트리에서 어댑터 클래스를 조회한다. 등록되지 않은 `broker_type`으로 브로커 생성을 시도하면 `InvalidBrokerTypeError`가 발생한다.
 

--- a/docs/specs/account/04-account-service.md
+++ b/docs/specs/account/04-account-service.md
@@ -48,13 +48,14 @@ AccountService(db: Database, eventbus: EventBus)
 - `trading_hours_end`
 - 향후 추가되는 표시/운영 메타데이터 중 브로커 재초기화가 필요 없는 필드
 
-**cold-path 전용 필드/작업**:
+**cold-path 전용 필드/작업** (9 필드):
 - `create()`
 - `delete()`
 - `credentials`
 - `broker_config`
 - `buy_commission_rate`
 - `sell_commission_rate`
+- `market_order_reserve_buffer_rate` (#1333: Treasury 시장가 매수 reserve 정책)
 - 계좌 생성 후 불변 필드: `exchange`, `currency`, `trading_mode`, `broker_type`
 
 #### service-layer 가드 (#1144)
@@ -63,7 +64,7 @@ AccountService(db: Database, eventbus: EventBus)
 
 - **가드 우선순위**: `create()` / `delete()` / `update()`의 런타임 가드는 `get()`/DELETED/IMMUTABLE 등 어떤 다른 검사보다 *먼저* 평가된다. 즉, 존재하지 않거나 DELETED 상태인 계좌에 structural 키가 들어오더라도 cold-path 응답이 우선이다(structural cold-path > existence > deleted > immutable). `update()` 가드는 raw kwargs 키만 보고 값(None 포함)은 무관하다 — `update(account_id, credentials=None)`도 키 존재만으로 차단된다.
 - **mutable-only 흐름**: structural 키와 교집합이 없는 호출(예: `update(account_id, name="…", timezone="…")`)은 런타임에서도 정상 동작한다. 가드는 `set(fields) & STRUCTURAL_FIELDS`가 비어 있으면 통과한다.
-- **structural 필드 정합 (S4)**: service의 `STRUCTURAL_FIELDS` 상수 8개와 `src/ante/web/routes/accounts.py`의 `STRUCTURAL_FIELDS` tuple은 정확히 1:1 일치해야 한다. 두 set이 어긋나면 contract-drift이며 `tests/unit/test_account_runtime_guard.py::test_structural_fields_match_route_constant`가 실패한다.
+- **structural 필드 정합 (S4)**: service의 `STRUCTURAL_FIELDS` 상수 9개(#1333 으로 `market_order_reserve_buffer_rate` 추가)와 `src/ante/web/routes/accounts.py`의 `STRUCTURAL_FIELDS` tuple은 정확히 1:1 일치해야 한다. 두 set이 어긋나면 contract-drift이며 `tests/unit/test_account_runtime_guard.py::test_structural_fields_match_route_constant`가 실패한다.
 - **부팅 mutation 보호 (S3)**: `mark_runtime_started` 호출은 boot mutation 종료 *후*로 고정된다. migration이 플래그 활성 후로 옮겨가면 자기 자신의 structural `broker_config` update가 차단되어 부팅이 깨진다 — `tests/unit/test_account_runtime_init_order.py`가 이 순서를 강제한다.
 
 #### 안정 에러 코드 (#1144 S5)

--- a/docs/specs/account/06-database-schema.md
+++ b/docs/specs/account/06-database-schema.md
@@ -24,6 +24,10 @@ CREATE TABLE IF NOT EXISTS accounts (
     -- 비용
     buy_commission_rate  REAL NOT NULL DEFAULT 0,
     sell_commission_rate REAL NOT NULL DEFAULT 0,
+    -- 시장가 매수 reserve buffer 비율 (#1333). Account-level Treasury reserve
+    -- policy. Decimal 정밀도는 Account dataclass / Treasury 내부에서만
+    -- 유지되고, DB 컬럼은 REAL 로 저장한다.
+    market_order_reserve_buffer_rate REAL NOT NULL DEFAULT 0.005,
     -- 상태
     status       TEXT NOT NULL DEFAULT 'active'
         CHECK(status IN ('active', 'suspended', 'deleted')),
@@ -31,6 +35,29 @@ CREATE TABLE IF NOT EXISTS accounts (
     updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
 );
 ```
+
+### Migration: market_order_reserve_buffer_rate (#1333)
+
+legacy DB(이 컬럼이 없는 단계) 가 켜질 때 `AccountService.initialize` 가 1 회성
+ALTER 와 backfill 을 적용한다.
+
+```sql
+-- 1) 컬럼 추가 (default 0.005). 이미 있으면 OperationalError 로 무시.
+ALTER TABLE accounts
+    ADD COLUMN market_order_reserve_buffer_rate REAL NOT NULL DEFAULT 0.005;
+
+-- 2) broker_type 별 backfill — ALTER 가 실제 성공한 1 회성 마이그레이션
+--    경로에서만 실행한다. 2 회 이상 실행되면 운영자가 CLI 로 직접 지정한
+--    ``test`` 계좌의 buffer 값을 0 으로 덮어쓰는 idempotency 위반이 된다.
+UPDATE accounts SET market_order_reserve_buffer_rate = 0
+    WHERE broker_type = 'test';
+```
+
+`broker_type='kis-domestic'` row 는 DDL default(0.005) 를 그대로 두며,
+`broker_type='kis-overseas'` 같은 1.0 미지원 broker_type 의 legacy row 도
+default 를 유지한다 — 1.1 에서 KISOverseasAdapter 와 함께 적합 값으로
+backfill 한다. NULL/unknown broker_type 도 보수적으로 default 0.005 를
+유지한다.
 
 ### credentials 암호화
 

--- a/docs/specs/account/10-web-api.md
+++ b/docs/specs/account/10-web-api.md
@@ -22,7 +22,7 @@ POST   /api/system/clear-halt             — 시스템 전역 정지 해제 (�
 ### Account payload 필드 계약
 
 Account Web API의 request/response schema는 Account 모델/DB 필드명을 그대로 사용한다.
-표준 structural field는 다음과 같다.
+표준 structural field는 다음과 같다 (#1333: 9 필드).
 
 - `account_id`
 - `exchange`
@@ -33,6 +33,7 @@ Account Web API의 request/response schema는 Account 모델/DB 필드명을 그
 - `broker_config`
 - `buy_commission_rate`
 - `sell_commission_rate`
+- `market_order_reserve_buffer_rate`
 
 `credentials_ref`, `commission_rate`, `sell_tax_rate`는 Web API 필드가 아니다. 이 이름들은
 legacy config migration 입력을 설명할 때만 사용하며, API alias로 허용하지 않는다.
@@ -45,7 +46,8 @@ Web API는 서버 프로세스 내부에서 실행되므로 계좌 구조 변경
 - `POST /api/accounts`
 - `DELETE /api/accounts/:id`
 - `PUT /api/accounts/:id` 중 `credentials`, `broker_config`, `buy_commission_rate`,
-  `sell_commission_rate`, `broker_type`, `exchange`, `currency`, `trading_mode`를 포함한 요청
+  `sell_commission_rate`, `market_order_reserve_buffer_rate`, `broker_type`,
+  `exchange`, `currency`, `trading_mode`를 포함한 요청 (#1333)
 
 에러 코드는 `ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER`이다. 계좌 생성/삭제와
 브로커 재초기화성 변경은 서버를 정지한 뒤 cold-path CLI로 수행하고, 서버 재시작 시 새

--- a/docs/specs/account/13-cross-module-notes.md
+++ b/docs/specs/account/13-cross-module-notes.md
@@ -5,12 +5,12 @@
 # 타 모듈 설계 시 참고
 
 - **Bot 스펙**: `BotConfig.account_id`로 소속 계좌를 지정한다. 봇 생성 시 계좌의 exchange와 전략의 `StrategyMeta.exchange` 호환성을 검증한다. `AccountSuspendedEvent` 구독 시 해당 계좌의 봇만 중지한다.
-- **Treasury 스펙**: Treasury는 계좌별로 인스턴스가 분리된다. Account의 `currency`로 통화를 구분하고, `buy_commission_rate`·`sell_commission_rate`를 Account에서 조회한다.
+- **Treasury 스펙**: Treasury는 계좌별로 인스턴스가 분리된다. Account의 `currency`로 통화를 구분하고, `buy_commission_rate`·`sell_commission_rate`·`market_order_reserve_buffer_rate` (3 rate 필드)를 Account에서 조회한다. `market_order_reserve_buffer_rate`는 시장가 매수 reserve 산정 시 `reserve_basis = quantity * quote * (1 + buffer)` 식으로 적용되는 Account-level 정책이며, broker config 가 아니다 (#1333).
 - **Rule Engine 스펙**: Rule Engine은 계좌별로 인스턴스가 분리된다. 계좌별 설정값(MDD 한도 등)을 Account에 종속하여 관리한다.
 - **Broker Adapter 스펙**: `AccountService.get_broker(account_id)`로 계좌의 BrokerAdapter 인스턴스를 조회한다. `BROKER_REGISTRY`에 등록된 `broker_type`만 인스턴스 생성 가능.
 - **Gateway 스펙**: 주문 요청 시 `account_id`로 대상 계좌를 식별하고, 해당 계좌의 BrokerAdapter로 라우팅한다.
 - **Trade 스펙**: 거래 기록은 `account_id`로 scoping된다. 계좌에 종속되지 않으나 조회·필터링 시 계좌 단위로 분리.
 - **Strategy 스펙**: 전략은 글로벌 Registry에 등록하고, `StrategyMeta.exchange`로 대상 시장을 명시한다. 봇 배정 시 계좌 exchange와 호환성을 검증한다.
-- **Lifecycle cold-path 계약**: 계좌 생성/삭제/credentials 변경/broker_config·commission 변경은 서버 정지 상태에서만 허용한다. 서버 실행 중에는 조회, suspend/activate, 비구조 필드 수정, 계좌별 rule 변경만 허용한다.
+- **Lifecycle cold-path 계약**: 계좌 생성/삭제/credentials 변경/broker_config·commission·market_order_reserve_buffer_rate 변경은 서버 정지 상태에서만 허용한다 (#1333: 9 STRUCTURAL_FIELDS). 서버 실행 중에는 조회, suspend/activate, 비구조 필드 수정, 계좌별 rule 변경만 허용한다.
 - **Web API 스펙**: 런타임 허용 엔드포인트는 `GET /api/accounts`, `GET /api/accounts/:id`, credentials 마스킹 조회, `POST /api/accounts/:id/suspend`, `POST /api/accounts/:id/activate`, `POST /api/system/halt`, `POST /api/system/clear-halt`, 계좌별 rule 변경이다. `POST /api/accounts`, `DELETE /api/accounts/:id`, structural `PUT /api/accounts/:id`는 409로 차단한다.
 - **CLI 스펙**: `ante account create/delete/set-credentials`는 cold-path 전용이며 서버 실행 중이면 거부한다. `list/info/credentials/suspend/activate`, `ante system halt/clear-halt`는 런타임 중 실행 가능하다.

--- a/docs/specs/broker-adapter/04-broker-adapter-interface.md
+++ b/docs/specs/broker-adapter/04-broker-adapter-interface.md
@@ -54,6 +54,8 @@ BrokerAdapter는 증권사 API 어댑터의 추상 기본 클래스다. 생성 �
 
 **`place_order()` 참고사항**: `stop`/`stop_limit` 주문은 BrokerAdapter가 직접 실행하지 않는다. KRX는 stop order를 네이티브로 지원하지 않으므로, 상위 계층(StopOrderManager)이 가격 모니터링 후 market/limit으로 변환하여 호출한다. 향후 네이티브 stop을 지원하는 브로커(예: Interactive Brokers) 구현 시 이 파라미터를 직접 활용할 수 있다.
 
+**시장가 주문과 reserve estimate 의 분리 (#1333)**: `place_order(order_type="market", price=None)` 은 가격을 지정하지 않는 시장가 주문을 의미하며, BrokerAdapter 는 broker 의 시장가 주문 계약을 그대로 사용한다. Treasury 가 시장가 매수 reserve estimate 를 위해 별도로 `get_current_price` 를 호출해 잠금 금액을 산정하지만, 그 quote 는 reserve 산정 입력이지 주문 가격이 아니다. BrokerAdapter 에 새 quote-estimate API 는 추가하지 않는다 — 기본 resolver 경로는 APIGateway / `BrokerAdapter.get_current_price` 다.
+
 **`get_account_positions()` 참고사항**: `get_positions()`와 동일한 API를 호출하되, 대사 전용으로 명시적으로 분리하여 용도를 명확히 한다. 반환 형식: `[{"symbol": "005930", "quantity": 900, "avg_price": 1000.0}, ...]`
 
 **`get_order_history()` 반환 형식**: `[{"order_id": "...", "symbol": "005930", "side": "buy", "quantity": 100, "filled_quantity": 100, "price": 1000.0, "status": "filled", "timestamp": "..."}, ...]`

--- a/docs/specs/broker-adapter/08-kis-domestic-adapter.md
+++ b/docs/specs/broker-adapter/08-kis-domestic-adapter.md
@@ -52,6 +52,12 @@ KISDomesticAdapter는 `order_type` 문자열을 KIS ORD_DVSN 코드로 매핑한
 
 > KIS는 추가로 `05` 장전시간외, `06` 장후시간외, `07` 시간외단일가, `11`~`16` IOC/FOK 변형(실전투자 전용)을 지원한다.
 
+**시장가 매수와 Treasury reserve estimate 분리 (#1333)**: 시장가 매수 시 KIS
+주문 파라미터는 `ORD_DVSN="01"`, `ORD_UNPR="0"` 계약을 그대로 유지한다.
+Treasury 가 reserve estimate 를 위해 `get_current_price` 로 현재가를 조회해
+보수적으로 자금을 잠그더라도, 그 quote 는 reserve 산정 입력일 뿐이며 KIS 에
+전달되는 주문 자체는 limit 으로 변환되지 않는다.
+
 ### KIS 주문 상태 코드 매핑
 
 | KIS 상태 코드 | Ante 상태 | 설명 |

--- a/docs/specs/strategy/03-02-signal-fields.md
+++ b/docs/specs/strategy/03-02-signal-fields.md
@@ -12,7 +12,7 @@
 | `side` | `str` | (필수) | `"buy"` \| `"sell"` |
 | `quantity` | `float` | (필수) | 수량 |
 | `order_type` | `str` | `"market"` | `"market"` \| `"limit"` \| `"stop"` \| `"stop_limit"` |
-| `price` | `float \| None` | `None` | limit/stop_limit의 지정가 |
+| `price` | `float \| None` | `None` | limit/stop_limit 의 지정가. `order_type="market"` + `price=None` 은 "가격을 지정하지 않는 시장가 주문" 을 의미하며, 전략 작성자가 별도 limit hint 를 넣지 않아도 공식 지원된다 (#1333). |
 | `stop_price` | `float \| None` | `None` | stop/stop_limit의 트리거 가격 |
 | `reason` | `str` | `""` | 시그널 생성 사유 (로깅/리포트용) |
 | `trading_session` | `str` | `"regular"` | `"regular"` \| `"extended"` — 거래 세션 구분 |
@@ -35,3 +35,27 @@
 매도 stop은 보유 포지션 기반이므로 본 약속과 무관하다.
 
 상세 invariant 및 모듈 분담은 [`treasury/04-treasury-interface.md`](../treasury/04-treasury-interface.md)의 "Reserve 정책" 섹션과 [`api-gateway/api-gateway.md`](../api-gateway/api-gateway.md)의 "StopOrderManager — 자금 처리 정책 (#1337)" 섹션을 참조한다.
+
+### 시장가 매수 자금 처리 약속 (#1333)
+
+`Signal(order_type="market", side="buy", price=None)` 은 즉시 실행을 우선하는
+공식 지원 시그니처다. 전략 작성자는 시장가 매수에 임의 limit hint 를 넣을
+필요가 없다.
+
+- **즉시 실행 주문은 제출 전에 자금이 잠긴다.** stop 주문 처럼 trigger 대기 단계가
+  없으므로 `OrderApprovedEvent` 발행 전에 Treasury 가 reserve 금액을 산정한다.
+- **현재가는 reserve estimate 일 뿐 주문가가 아니다.** Treasury 는 account-scoped
+  resolver (`APIGateway.get_current_price`) 로 현재가를 조회해 `quantity * quote *
+  (1 + market_order_reserve_buffer_rate)` 식으로 보수적으로 잠근다. resolved
+  quote 는 `OrderApprovedEvent.price` 에 들어가지 않고, BrokerAdapter 는 시장가
+  주문 계약 그대로 제출한다.
+- **체결 가격은 보장되지 않는다.** Treasury 는 체결 후 실제 체결 금액으로 정산하며,
+  reserve 부족분은 `available` 음수까지 허용해 정확히 차감하고
+  `market_order_reserve_shortfall` warning 을 logged 한다.
+- **quote 조회 실패는 terminal reject.** resolver 미주입/예외 시 broker 호출 전
+  `OrderRejectedEvent(reason="market_buy_quote_unavailable: ...")` 가 한 번
+  발행되고, 동일 fingerprint 의 무한 반복은 별도 운영/리포팅 이슈에서 다룬다.
+
+매도 시장가는 보유 포지션 기반이므로 reserve 대상이 아니며 본 약속과 무관하다.
+
+상세 invariant 는 [`treasury/04-treasury-interface.md`](../treasury/04-treasury-interface.md) 의 "시장가 매수 quote resolver invariant" 섹션을 참조한다.

--- a/docs/specs/treasury/04-treasury-interface.md
+++ b/docs/specs/treasury/04-treasury-interface.md
@@ -55,10 +55,12 @@ Treasury(
 
 `OrderValidatedEvent` 수신 시 Treasury가 자금을 잠그는지 여부는 주문 종류에 따라 다르다. 본 정책은 한국 증권사 예약주문 표준(예약주문 등록 시점에 잔고를 체크하지 않고, 본주문 전환 시점에 자금 검증)과 일치한다.
 
-| `side` | `order_type` | 등록 시점 동작 | 비고 |
-|--------|--------------|---------------|------|
-| `buy` | `market`, `limit` | `reserve_for_order(...)` 호출 후 `OrderApprovedEvent(reserved_amount>0)` 발행 | `quantity * price * (1 + buy_commission_rate)` 만큼 잠금. `price=None` 시그니처는 별도 거부. |
-| `buy` | `stop`, `stop_limit` | **자금 잠금 없이** `OrderApprovedEvent(reserved_amount=0.0)` 발행 (#1337) | 트리거 발동 후 변환된 일반 매수 주문이 정상 reserve 절차를 거친다. `price=None`이어도 거부하지 않는다. |
+| `side` | `order_type` / `price` | 등록 시점 동작 | 비고 |
+|--------|------------------------|---------------|------|
+| `buy` | `limit` (price 명시) | `reserve_for_order(...)` 호출 후 `OrderApprovedEvent(reserved_amount>0)` 발행 | `quantity * price * (1 + buy_commission_rate)` 만큼 잠금 (기존 산식). |
+| `buy` | `market` + `price=None` | account-scoped quote resolver 호출 → reserve 산정 후 `OrderApprovedEvent(price=None, reserved_amount>0)` 발행 (#1333) | resolver 가 반환한 현재가에 `market_order_reserve_buffer_rate` 와 `buy_commission_rate` 를 함께 반영해 보수적으로 잠근다. resolved quote 는 `OrderApprovedEvent.price` 에 넣지 않고 reserve estimate 로만 사용한다. resolver 미주입/예외 시 terminal `OrderRejectedEvent(reason="market_buy_quote_unavailable: ...")` 로 종료. |
+| `buy` | `market` (price 명시) | `reserve_for_order(...)` 호출 후 `OrderApprovedEvent(reserved_amount>0)` 발행 | 기존 산식 (`quantity * price * (1 + buy_commission_rate)`). |
+| `buy` | `stop`, `stop_limit` | **자금 잠금 없이** `OrderApprovedEvent(reserved_amount=0.0)` 발행 (#1337) | 트리거 발동 후 변환된 일반 매수 주문이 정상 reserve 절차를 거친다. `price=None` 이어도 거부하지 않는다. **분기 우선순위 1** — market buy quote resolver 분기보다 먼저 평가된다. |
 | `sell` | 모든 타입 | 자금 잠금 없이 즉시 `OrderApprovedEvent(reserved_amount=0.0)` | 매도는 보유 포지션 기반이므로 reserve 대상이 아님. |
 
 **매수 stop / stop_limit no-reserve invariant (#1337)**:
@@ -70,6 +72,48 @@ Treasury(
 - StopOrderManager는 Treasury를 직접 호출하지 않는다. 두 모듈은 자금 처리상 직교한다.
 
 배경 및 사용자 정책 결정 근거는 GitHub 이슈 #1337 본문 "정책 결정 (사용자 승인, 2026-05-08)" 섹션을 참조한다.
+
+**시장가 매수 quote resolver invariant (#1333)**:
+
+- 시장가 매수 (`order_type="market"`, `price=None`) 는 즉시 실행 주문이므로 stop
+  처럼 trigger 대기 없이 제출 전 자금을 잠가야 한다.
+- Treasury 는 account-scoped resolver
+  (`Callable[[str], Awaitable[float]]`) 를 통해 현재가를 조회한다. 기본 경로는
+  `APIGateway.get_current_price(symbol, account_id=...)` 이며 `_init_gateway()`
+  끝에서 `TreasuryManager.set_order_reserve_price_resolver` 로 후속 주입된다.
+  자산 평가 sync 용 `start_sync(price_resolver=...)` 와는 **별도 객체** 다.
+- reserve 산식 (Decimal 정밀도):
+
+  ```text
+  reserve_basis = quantity * quote * (1 + market_order_reserve_buffer_rate)
+  commission_estimate = reserve_basis * buy_commission_rate
+  total_reserve = reserve_basis + commission_estimate
+  ```
+
+  Decimal 연산 결과는 `OrderApprovedEvent.reserved_amount` / Treasury budget 의
+  float 경계에서만 `float` 로 변환한다 (기존 commission/budget float 계약과 일관).
+- resolved quote 는 reserve estimate 일 뿐 주문 가격이 아니다. Treasury 는
+  `OrderApprovedEvent.price` 를 `None` 그대로 유지하며, BrokerAdapter 는 시장가
+  주문 계약을 그대로 사용한다 (KIS 국내: `ORD_DVSN="01"`, `ORD_UNPR="0"`).
+- resolver 미주입 또는 resolver 호출이 예외를 raise 하면 Treasury 는 broker
+  호출 전 terminal `OrderRejectedEvent(reason="market_buy_quote_unavailable: ...")`
+  를 발행한다. EventBus handler 예외로 삼키면 안 된다.
+- `market_order_reserve_buffer_rate` 는 Account-level 정책 (`Account` 필드,
+  cold-path) 이며 broker_config 에 들어가지 않는다. 기본값은 BrokerPreset 이
+  제공한다 (`kis-domestic=0.005`, `test=0`).
+
+**시장가 매수 shortfall 정산 invariant (#1333)**:
+
+- `OrderFilledEvent` 수신 시 Treasury 는 실제 체결 비용
+  (`event.price * event.quantity + event.commission`) 으로 정산한다.
+- `actual_cost <= reserved_amount` 면 잔여 reserve 를 `available` 로 환수한다
+  (기존 거동).
+- `actual_cost > reserved_amount` 면 초과분을 `available` 에서 추가 차감한다 —
+  결과적으로 `available` 이 음수가 될 수 있다. 음수는 정상 운영 상태가 아니지만
+  시장가 매수의 가격 변동을 정확히 정산하기 위해 허용한다. 다음 매수 reserve 가
+  거부되는 것은 자연스러운 결과 (insufficient funds) 다.
+- shortfall 발생 시 `logger.warning("market_order_reserve_shortfall: ...")` 가
+  남고, 별도 EventBus 이벤트는 신설하지 않는다 (Stop Condition 명시).
 
 ### 자산 평가 동기화 계약
 

--- a/docs/specs/web-api/05-resource-endpoints.md
+++ b/docs/specs/web-api/05-resource-endpoints.md
@@ -11,9 +11,9 @@
 | Method | Path | 설명 |
 |--------|------|------|
 | GET | `/api/accounts` | 계좌 목록 |
-| POST | `/api/accounts` | 계좌 등록. cold-path 전용이므로 런타임 서버에서는 409 `ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER` 반환. Body: account_id, exchange, currency, broker_type, trading_mode, credentials, broker_config, buy_commission_rate, sell_commission_rate |
-| GET | `/api/accounts/{account_id}` | 계좌 상세 조회 |
-| PUT | `/api/accounts/{account_id}` | 계좌 수정. 런타임에는 `name`, `timezone`, `trading_hours_start`, `trading_hours_end` 같은 비구조 필드만 허용. `credentials`, `broker_config`, `buy_commission_rate`, `sell_commission_rate`, `broker_type`, `exchange`, `currency`, `trading_mode` 포함 시 409. 본문은 `Content-Type: application/json`(charset suffix 허용)만 허용하며, 그 외 media type은 415 반환. 다른 mutate 라우트의 415 게이트 도입은 본 변경 범위 밖. |
+| POST | `/api/accounts` | 계좌 등록. cold-path 전용이므로 런타임 서버에서는 409 `ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER` 반환. Body: account_id, exchange, currency, broker_type, trading_mode, credentials, broker_config, buy_commission_rate, sell_commission_rate, market_order_reserve_buffer_rate (#1333). |
+| GET | `/api/accounts/{account_id}` | 계좌 상세 조회. 응답에 `market_order_reserve_buffer_rate` (float) 포함 (#1333). |
+| PUT | `/api/accounts/{account_id}` | 계좌 수정. 런타임에는 `name`, `timezone`, `trading_hours_start`, `trading_hours_end` 같은 비구조 필드만 허용. `credentials`, `broker_config`, `buy_commission_rate`, `sell_commission_rate`, `market_order_reserve_buffer_rate`, `broker_type`, `exchange`, `currency`, `trading_mode` 포함 시 409 (#1333: 9 STRUCTURAL_FIELDS). 본문은 `Content-Type: application/json`(charset suffix 허용)만 허용하며, 그 외 media type은 415 반환. 다른 mutate 라우트의 415 게이트 도입은 본 변경 범위 밖. |
 | GET | `/api/accounts/{account_id}/credentials` | 인증 정보 마스킹 조회 |
 | POST | `/api/accounts/{account_id}/suspend` | 계좌 거래 정지. Body: reason. 이미 정지 상태이면 409 Conflict |
 | POST | `/api/accounts/{account_id}/activate` | 계좌 거래 재개. 이미 활성 상태이면 409 Conflict |

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -166,6 +166,10 @@
                     "type": "number",
                     "default": 0,
                     "description": "매도 수수료율, 세금 포함 (cold-path 전용)."
+                  },
+                  "market_order_reserve_buffer_rate": {
+                    "type": "number",
+                    "description": "시장가 매수 reserve buffer 비율 (cold-path 전용, #1333). omit 시 BrokerPreset 기본값을 사용한다 (예: kis-domestic=0.005, test=0)."
                   }
                 }
               }
@@ -4989,6 +4993,11 @@
           "sell_commission_rate": {
             "type": "number",
             "title": "Sell Commission Rate"
+          },
+          "market_order_reserve_buffer_rate": {
+            "type": "number",
+            "title": "Market Order Reserve Buffer Rate",
+            "default": 0.0
           },
           "status": {
             "type": "string",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -1451,6 +1451,11 @@ export type components = {
             currency: string;
             /** Exchange */
             exchange: string;
+            /**
+             * Market Order Reserve Buffer Rate
+             * @default 0
+             */
+            market_order_reserve_buffer_rate: number;
             /** Name */
             name: string;
             /** Sell Commission Rate */
@@ -3390,6 +3395,8 @@ export interface operations {
                      * @enum {string}
                      */
                     exchange: "KRX" | "NYSE" | "NASDAQ" | "TEST";
+                    /** @description 시장가 매수 reserve buffer 비율 (cold-path 전용, #1333). omit 시 BrokerPreset 기본값을 사용한다 (예: kis-domestic=0.005, test=0). */
+                    market_order_reserve_buffer_rate?: number;
                     /** @description 사용자에게 표시되는 이름. */
                     name: string;
                     /**

--- a/src/ante/account/models.py
+++ b/src/ante/account/models.py
@@ -53,6 +53,12 @@ class Account:
     # --- 비용 ---
     buy_commission_rate: Decimal = Decimal("0")
     sell_commission_rate: Decimal = Decimal("0")
+    # 시장가 매수 주문 reserve buffer 비율 (Account-level Treasury reserve policy).
+    # 시장가 매수는 체결 가격이 보장되지 않으므로 현재가만으로 reserve하면 부족할
+    # 수 있다. Treasury는 ``reserve_basis = quantity * quote * (1 + buffer)``
+    # 식으로 자금을 보수적으로 잠근다. ``broker_config``에 들어가지 않으며,
+    # 1.0에서는 cold-path 전용(structural) 필드다 (#1333).
+    market_order_reserve_buffer_rate: Decimal = Decimal("0")
 
     # --- 상태 ---
     status: AccountStatus = AccountStatus.ACTIVE
@@ -74,6 +80,10 @@ class BrokerPreset:
     trading_hours_end: str
     buy_commission_rate: Decimal
     sell_commission_rate: Decimal
+    # 시장가 매수 reserve buffer 비율의 broker별 기본값. Account 생성 시 이
+    # 값이 ``Account.market_order_reserve_buffer_rate``의 초기값으로 사용된다
+    # (#1333).
+    market_order_reserve_buffer_rate: Decimal
     default_account_id: str
     default_name: str
     required_credentials: list[str]

--- a/src/ante/account/presets.py
+++ b/src/ante/account/presets.py
@@ -13,6 +13,8 @@ BROKER_PRESETS: dict[str, BrokerPreset] = {
         trading_hours_end="23:59",
         buy_commission_rate=Decimal("0"),
         sell_commission_rate=Decimal("0"),
+        # 결정적 테스트를 위해 buffer는 0으로 둔다 (#1333).
+        market_order_reserve_buffer_rate=Decimal("0"),
         default_account_id="test",
         default_name="테스트",
         required_credentials=["app_key", "app_secret"],
@@ -25,6 +27,8 @@ BROKER_PRESETS: dict[str, BrokerPreset] = {
         trading_hours_end="15:30",
         buy_commission_rate=Decimal("0.00015"),
         sell_commission_rate=Decimal("0.00195"),
+        # 시장가 매수의 가격 변동 흡수를 위한 0.5% 보수 버퍼 (#1333).
+        market_order_reserve_buffer_rate=Decimal("0.005"),
         default_account_id="domestic",
         default_name="국내 주식",
         required_credentials=["app_key", "app_secret", "account_no"],

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -475,6 +475,7 @@ class AccountService:
             "broker_config",
             "buy_commission_rate",
             "sell_commission_rate",
+            "market_order_reserve_buffer_rate",
         }
         unrecognized = set(fields.keys()) - updatable - self.IMMUTABLE_FIELDS
         if unrecognized:

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -56,12 +56,28 @@ CREATE TABLE IF NOT EXISTS accounts (
     broker_config TEXT NOT NULL DEFAULT '{}',
     buy_commission_rate  REAL NOT NULL DEFAULT 0,
     sell_commission_rate REAL NOT NULL DEFAULT 0,
+    market_order_reserve_buffer_rate REAL NOT NULL DEFAULT 0.005,
     status       TEXT NOT NULL DEFAULT 'active'
         CHECK(status IN ('active', 'suspended', 'deleted')),
     created_at   TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
 );
 """
+
+# Migration: legacy 데이터베이스에 ``market_order_reserve_buffer_rate`` 컬럼을
+# 추가한다. 한 번 ALTER한 뒤 broker_type별 backfill을 수행한다 (#1333).
+# DDL의 default(0.005)는 신규 column 추가 시 모든 row에 적용되며, ``test``
+# broker의 결정적 거동을 위해 backfill로 0으로 정정한다. ``kis-overseas``는
+# 1.0 BROKER_REGISTRY가 지원하지 않지만 legacy row가 있을 가능성에 대비해
+# default 0.005를 유지한다.
+_ACCOUNTS_BUFFER_MIGRATION = (
+    "ALTER TABLE accounts "
+    "ADD COLUMN market_order_reserve_buffer_rate REAL NOT NULL DEFAULT 0.005;"
+)
+_ACCOUNTS_BUFFER_BACKFILL_TEST = (
+    "UPDATE accounts SET market_order_reserve_buffer_rate = 0 "
+    "WHERE broker_type = 'test';"
+)
 
 
 def _register_brokers() -> None:
@@ -81,11 +97,12 @@ def _register_brokers() -> None:
 
 # Cold-path 전용 필드 (서버 실행 중에는 변경 불가).
 # SSOT:
-#   - docs/specs/account/04-account-service.md 51-58줄
-#   - src/ante/web/routes/accounts.py STRUCTURAL_FIELDS (8개 라우트 1차 가드)
+#   - docs/specs/account/04-account-service.md (9개 cold-path 필드)
+#   - src/ante/web/routes/accounts.py STRUCTURAL_FIELDS (라우트 1차 가드)
 #
-# - credentials, broker_config, buy_commission_rate, sell_commission_rate:
-#   broker adapter 재초기화가 필요한 필드.
+# - credentials, broker_config, buy_commission_rate, sell_commission_rate,
+#   market_order_reserve_buffer_rate:
+#   broker adapter / Treasury reserve 정책에 영향을 주는 필드.
 # - exchange, currency, trading_mode, broker_type:
 #   계좌 생성 후 불변 필드 (구조 변경 시 모든 소비자 재구성 필요).
 #
@@ -97,6 +114,7 @@ STRUCTURAL_FIELDS: frozenset[str] = frozenset(
         "broker_config",
         "buy_commission_rate",
         "sell_commission_rate",
+        "market_order_reserve_buffer_rate",
         "broker_type",
         "exchange",
         "currency",
@@ -136,6 +154,32 @@ class AccountService:
     async def initialize(self) -> None:
         """스키마 생성 + DB에서 계좌 목록 로드."""
         await self._db.execute_script(_CREATE_TABLE_SQL)
+        # Migration: legacy DB에 ``market_order_reserve_buffer_rate``가 없으면
+        # 추가하고 broker_type별 backfill을 적용한다 (#1333). 신규 DB는
+        # ``CREATE TABLE``에서 default 값으로 컬럼이 만들어지므로 ALTER가
+        # ``OperationalError(duplicate column name)``로 실패한다.
+        # backfill은 **ALTER가 실제로 성공한 1회성 마이그레이션 경로에서만**
+        # 실행한다. 이미 컬럼이 있는 경우 backfill을 다시 돌리면 운영자가
+        # CLI로 직접 지정한 ``test`` 계좌의 buffer 값을 0으로 덮어쓰는
+        # idempotency 위반이 된다 — Plan v4의 backfill 정책은 첫 마이그레이션
+        # 시점만을 의미한다.
+        migrated = False
+        try:
+            await self._db.execute_script(_ACCOUNTS_BUFFER_MIGRATION)
+            migrated = True
+        except Exception:
+            # 이미 컬럼이 존재 → 1회성 마이그레이션 완료 상태.
+            pass
+        if migrated:
+            try:
+                await self._db.execute(_ACCOUNTS_BUFFER_BACKFILL_TEST)
+            except Exception:
+                # backfill 실패는 운영을 막지 않는다 (테이블이 비어 있거나 권한
+                # 이슈 등의 환경 차이). DDL default(0.005)가 신규 row 안전망.
+                logger.debug(
+                    "market_order_reserve_buffer_rate backfill 무시.",
+                    exc_info=True,
+                )
         rows = await self._db.fetch_all(
             "SELECT * FROM accounts WHERE status != ?",
             (AccountStatus.DELETED,),
@@ -304,8 +348,9 @@ class AccountService:
                 trading_hours_start, trading_hours_end, trading_mode,
                 broker_type, credentials, broker_config,
                 buy_commission_rate, sell_commission_rate,
+                market_order_reserve_buffer_rate,
                 status, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 account.account_id,
                 account.name,
@@ -320,6 +365,7 @@ class AccountService:
                 json.dumps(account.broker_config),
                 float(account.buy_commission_rate),
                 float(account.sell_commission_rate),
+                float(account.market_order_reserve_buffer_rate),
                 account.status.value,
                 now.isoformat(),
                 now.isoformat(),
@@ -454,6 +500,7 @@ class AccountService:
                trading_hours_start=?, trading_hours_end=?, trading_mode=?,
                broker_type=?, credentials=?, broker_config=?,
                buy_commission_rate=?, sell_commission_rate=?,
+               market_order_reserve_buffer_rate=?,
                updated_at=?
                WHERE account_id=?""",
             (
@@ -469,6 +516,7 @@ class AccountService:
                 json.dumps(account.broker_config),
                 float(account.buy_commission_rate),
                 float(account.sell_commission_rate),
+                float(account.market_order_reserve_buffer_rate),
                 now.isoformat(),
                 account_id,
             ),
@@ -868,6 +916,7 @@ class AccountService:
             credentials={k: "test" for k in preset.required_credentials},
             buy_commission_rate=preset.buy_commission_rate,
             sell_commission_rate=preset.sell_commission_rate,
+            market_order_reserve_buffer_rate=preset.market_order_reserve_buffer_rate,
         )
         return await self._create_seed_account(account)
 
@@ -890,6 +939,13 @@ def _row_to_account(row: dict[str, Any]) -> Account:
         else (broker_config_raw or {})
     )
 
+    # legacy DB는 ``market_order_reserve_buffer_rate`` 컬럼이 없을 수 있다.
+    # ``initialize()``의 ALTER + backfill이 정상 경로지만, 마이그레이션 직전
+    # ``_row_to_account``를 통해 fetch하는 환경(예: 단위 테스트의 짧은
+    # in-memory DB lifecycle)에서도 안전하게 fallback한다.
+    buffer_raw = row.get("market_order_reserve_buffer_rate", "0")
+    buffer_value = Decimal("0") if buffer_raw is None else Decimal(str(buffer_raw))
+
     return Account(
         account_id=row["account_id"],
         name=row["name"],
@@ -904,6 +960,7 @@ def _row_to_account(row: dict[str, Any]) -> Account:
         broker_config=broker_config,
         buy_commission_rate=Decimal(str(row["buy_commission_rate"])),
         sell_commission_rate=Decimal(str(row["sell_commission_rate"])),
+        market_order_reserve_buffer_rate=buffer_value,
         status=AccountStatus(row["status"]),
         created_at=datetime.fromisoformat(row["created_at"])
         if row.get("created_at")

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -990,18 +990,23 @@ def _print_account_detail(detail: dict) -> None:
         "trading_mode": "거래 모드",
         "buy_commission_rate": "매수 수수료",
         "sell_commission_rate": "매도 수수료",
+        "market_order_reserve_buffer_rate": "시장가 매수 버퍼",
         "status": "상태",
         "timezone": "시간대",
         "trading_hours": "거래 시간",
         "created_at": "생성일",
     }
+    pct_keys = (
+        "buy_commission_rate",
+        "sell_commission_rate",
+        "market_order_reserve_buffer_rate",
+    )
     for key, label in labels.items():
         value = detail.get(key, "")
-        if key in ("buy_commission_rate", "sell_commission_rate") and value:
-            # 퍼센트로 표시
+        if key in pct_keys and value not in ("", None):
             try:
                 pct = float(value) * 100
                 value = f"{pct:.3f}%"
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
         click.echo(f"  {label:14s}: {value}")

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -431,6 +431,16 @@ def _validate_broker_type(fmt: OutputFormatter, broker_type: str) -> None:
     metavar="KEY=VALUE",
     help="broker-specific 설정 (free-form pass-through, 예: is_paper=true)",
 )
+@click.option(
+    "--market-order-reserve-buffer-rate",
+    "market_order_reserve_buffer_rate_opt",
+    type=float,
+    default=None,
+    help=(
+        "시장가 매수 reserve buffer 비율 (예: 0.005=0.5%). "
+        "omit 시 BrokerPreset 기본값을 사용한다 (#1333)."
+    ),
+)
 @format_option
 @click.pass_context
 @require_auth
@@ -445,6 +455,7 @@ def account_create(
     credentials_env: tuple[str, ...],
     credentials_file: tuple[str, ...],
     broker_config_pairs: tuple[str, ...],
+    market_order_reserve_buffer_rate_opt: float | None,
 ) -> None:
     """비대화형 계좌 생성 (cold-path 전용).
 
@@ -514,6 +525,13 @@ def account_create(
         else TradingMode.LIVE
     )
 
+    # market_order_reserve_buffer_rate: 옵션 omit 시 preset 기본값을 그대로
+    # 사용하고, 명시된 경우 ``Decimal(str(...))``로 정밀도를 보존한다 (#1333).
+    if market_order_reserve_buffer_rate_opt is None:
+        market_order_buffer = preset.market_order_reserve_buffer_rate
+    else:
+        market_order_buffer = Decimal(str(market_order_reserve_buffer_rate_opt))
+
     # 7) Account 생성
     new_account = Account(
         account_id=account_id_opt,
@@ -529,6 +547,7 @@ def account_create(
         broker_config=broker_config,
         buy_commission_rate=preset.buy_commission_rate,
         sell_commission_rate=preset.sell_commission_rate,
+        market_order_reserve_buffer_rate=market_order_buffer,
     )
 
     async def _do_create() -> Account:
@@ -950,6 +969,7 @@ def _account_to_detail(acct: Account) -> dict:
         "trading_mode": acct.trading_mode.value,
         "buy_commission_rate": str(acct.buy_commission_rate),
         "sell_commission_rate": str(acct.sell_commission_rate),
+        "market_order_reserve_buffer_rate": str(acct.market_order_reserve_buffer_rate),
         "status": acct.status.value,
         "timezone": acct.timezone,
         "trading_hours": f"{acct.trading_hours_start}-{acct.trading_hours_end}",

--- a/src/ante/main.py
+++ b/src/ante/main.py
@@ -20,6 +20,7 @@ import asyncio
 import logging
 import os
 import signal
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -539,6 +540,34 @@ async def _init_gateway(s: Services) -> None:
 
     # StrategyContextFactory 완성 (Gateway 연결 이후)
     _init_context_factory(s)
+
+    # #1333: Treasury 의 시장가 매수 reserve estimate 용 quote resolver 주입.
+    # ``_init_trading()`` 시점에는 APIGateway 가 아직 만들어지지 않았으므로
+    # ``initialize_all`` 시점에 주입할 수 없고, 본 ``_init_gateway()`` 끝에서
+    # account-scoped wrapper 로 후속 주입한다. resolver 자체는 자산 평가 sync
+    # 용 ``price_resolver`` 와 별도 객체다.
+    if s.treasury_manager is not None and s.api_gateway is not None:
+        gateway = s.api_gateway
+        for account in accounts:
+
+            def _make_resolver(account_id: str) -> Callable[[str], Awaitable[float]]:
+                async def _resolver(symbol: str) -> float:
+                    return await gateway.get_current_price(
+                        symbol, account_id=account_id
+                    )
+
+                return _resolver
+
+            try:
+                s.treasury_manager.set_order_reserve_price_resolver(
+                    account.account_id, _make_resolver(account.account_id)
+                )
+            except KeyError:
+                # 해당 계좌의 Treasury 가 없는 환경(예: 단위 테스트 partial wiring).
+                logger.debug(
+                    "Treasury 미등록 계좌 — order_reserve_price_resolver 주입 생략: %s",
+                    account.account_id,
+                )
 
     # Treasury 잔고 동기화 (Broker 연결 이후)
     await _init_treasury_sync(s, accounts)

--- a/src/ante/treasury/manager.py
+++ b/src/ante/treasury/manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 from ante.treasury.treasury import Treasury
@@ -27,7 +28,8 @@ class TreasuryManager:
         """Account 정보로 Treasury 인스턴스 생성 및 등록.
 
         Args:
-            account: Account 엔티티. account_id, currency, commission 정보 사용.
+            account: Account 엔티티. account_id, currency, commission, market
+                buy reserve buffer 정보 사용.
 
         Returns:
             생성된 Treasury 인스턴스.
@@ -39,11 +41,36 @@ class TreasuryManager:
             currency=account.currency,
             buy_commission_rate=float(account.buy_commission_rate),
             sell_commission_rate=float(account.sell_commission_rate),
+            market_order_reserve_buffer_rate=account.market_order_reserve_buffer_rate,
         )
         await treasury.initialize()
         self._treasuries[account.account_id] = treasury
         logger.info("Treasury 생성: account_id=%s", account.account_id)
         return treasury
+
+    def set_order_reserve_price_resolver(
+        self,
+        account_id: str,
+        resolver: Callable[[str], Awaitable[float]],
+    ) -> None:
+        """특정 계좌의 Treasury 에 시장가 매수 reserve estimate 용 resolver 주입.
+
+        ``main._init_gateway()`` 끝에서 account-scoped wrapper 로 호출된다 — 부팅
+        순서상 ``initialize_all`` 직후에는 APIGateway 가 아직 준비되지 않았기
+        때문이다 (#1333). resolver 미주입 상태에서 시장가 매수 + price=None
+        시도가 들어오면 Treasury 가 terminal ``market_buy_quote_unavailable`` 로
+        거부한다.
+
+        Raises:
+            KeyError: 해당 계좌의 Treasury 가 등록돼 있지 않을 때.
+        """
+        if account_id not in self._treasuries:
+            raise KeyError(f"Treasury not found: account_id={account_id}")
+        self._treasuries[account_id].set_order_reserve_price_resolver(resolver)
+        logger.info(
+            "TreasuryManager: order_reserve_price_resolver 주입 완료 (account=%s)",
+            account_id,
+        )
 
     def get(self, account_id: str) -> Treasury:
         """계좌의 Treasury 인스턴스 반환.

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -7,6 +7,7 @@ import logging
 import math
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 from ante.account.scoping import require_account_id
@@ -125,6 +126,8 @@ class Treasury:
         currency: str = "KRW",
         buy_commission_rate: float = 0.00015,
         sell_commission_rate: float = 0.00195,
+        market_order_reserve_buffer_rate: Decimal = Decimal("0"),
+        order_reserve_price_resolver: Callable[[str], Awaitable[float]] | None = None,
         bot_status_checker: Callable[[str], str] | None = None,
     ) -> None:
         self._db = db
@@ -133,6 +136,16 @@ class Treasury:
         self._currency = currency
         self._buy_commission_rate = buy_commission_rate
         self._sell_commission_rate = sell_commission_rate
+        # 시장가 매수 reserve buffer (#1333). Account-level Treasury reserve
+        # policy로, broker_config가 아니라 ``Account.market_order_reserve_buffer_rate``
+        # 에서 주입된다. ``_on_order_validated``의 market buy + price=None
+        # 분기에서만 사용한다.
+        self._market_order_reserve_buffer_rate = market_order_reserve_buffer_rate
+        # 시장가 매수 reserve estimate를 위한 account-scoped 현재가 resolver
+        # (#1333). 기존 ``start_sync(price_resolver=...)``의 자산 평가 sync
+        # resolver와 **별도** 객체이며, ``_init_gateway()`` 끝에서
+        # ``set_order_reserve_price_resolver``로 후속 주입된다.
+        self._order_reserve_price_resolver = order_reserve_price_resolver
         self._bot_status_checker = bot_status_checker
 
         self._account_balance: float = 0.0
@@ -296,6 +309,20 @@ class Treasury:
     def set_bot_status_checker(self, checker: Callable[[str], str]) -> None:
         """봇 상태 확인 콜백 설정 (초기화 후 BotManager 연결 시 호출)."""
         self._bot_status_checker = checker
+
+    def set_order_reserve_price_resolver(
+        self, resolver: Callable[[str], Awaitable[float]]
+    ) -> None:
+        """시장가 매수 reserve estimate 용 현재가 resolver 주입 (#1333).
+
+        ``_init_gateway()`` 끝에서 account-scoped wrapper로 주입한다. 기존
+        ``start_sync(price_resolver=...)``의 자산 평가 sync resolver와는
+        별도다. resolver는 ``await resolver(symbol) -> float`` 시그니처를
+        만족해야 하며, 실패 시 예외를 raise하면 Treasury가 terminal
+        ``OrderRejectedEvent(reason="market_buy_quote_unavailable: ...")``로
+        변환한다.
+        """
+        self._order_reserve_price_resolver = resolver
 
     def update_commission_rates(
         self, buy_commission_rate: float, sell_commission_rate: float
@@ -613,29 +640,174 @@ class Treasury:
             )
             return
 
-        # Guard 1: 매수 + 시장가 + price 부재 시그니처는 quote source가 없으면
-        # reserve 금액을 산정할 수 없으므로 즉시 거부한다.
-        # narrow-scope: total_reserve <= 0 전체가 아니라 정확한 quote 부재
-        # 시그니처만 잡아 quantity=0 같은 다른 경계 케이스와 분리한다.
+        # #1333: 매수 + 시장가 + price 부재 시그니처는 즉시 실행 주문이므로
+        # 제출 전에 자금을 잠가야 한다 (stop처럼 trigger 대기 X). resolver 가
+        # 주입돼 있으면 현재가를 조회해 reserve estimate 를 산정하고, 실패
+        # (resolver 미주입/예외)는 terminal ``market_buy_quote_unavailable``
+        # 거부로 종료한다 — 사용자 정책 사전 승인 + Plan v4.
+        # 분기 우선순위: #1337 (직전 stop/stop_limit) > #1333 (이 분기) >
+        # 기존 limit / market(price 있음) 분기.
         if event.side == "buy" and event.order_type == "market" and event.price is None:
-            await self._eventbus.publish(
-                OrderRejectedEvent(
-                    order_id=event.order_id,
-                    bot_id=event.bot_id,
-                    strategy_id=event.strategy_id,
-                    symbol=event.symbol,
-                    side=event.side,
-                    quantity=event.quantity,
-                    price=event.price,
-                    order_type=event.order_type,
-                    account_id=self._account_id,
-                    reason=(
-                        f"market_buy_quote_unavailable: "
-                        f"order_type={event.order_type}, price={event.price}"
-                    ),
+            resolver = self._order_reserve_price_resolver
+            if resolver is None:
+                await self._eventbus.publish(
+                    OrderRejectedEvent(
+                        order_id=event.order_id,
+                        bot_id=event.bot_id,
+                        strategy_id=event.strategy_id,
+                        symbol=event.symbol,
+                        side=event.side,
+                        quantity=event.quantity,
+                        price=event.price,
+                        order_type=event.order_type,
+                        account_id=self._account_id,
+                        reason=(
+                            "market_buy_quote_unavailable: resolver not configured"
+                        ),
+                    )
                 )
-            )
-            return
+                return
+            try:
+                quote = await resolver(event.symbol)
+            except Exception as exc:
+                await self._eventbus.publish(
+                    OrderRejectedEvent(
+                        order_id=event.order_id,
+                        bot_id=event.bot_id,
+                        strategy_id=event.strategy_id,
+                        symbol=event.symbol,
+                        side=event.side,
+                        quantity=event.quantity,
+                        price=event.price,
+                        order_type=event.order_type,
+                        account_id=self._account_id,
+                        reason=f"market_buy_quote_unavailable: {exc!s}",
+                    )
+                )
+                return
+
+            # Decimal 정밀도로 reserve 산정. ``OrderApprovedEvent.reserved_amount``
+            # 와 Treasury budget 의 float 경계에서만 ``float`` 로 변환한다 — 기존
+            # commission/budget float 계약과 일관됨.
+            try:
+                quote_d = Decimal(str(quote))
+            except Exception as exc:
+                await self._eventbus.publish(
+                    OrderRejectedEvent(
+                        order_id=event.order_id,
+                        bot_id=event.bot_id,
+                        strategy_id=event.strategy_id,
+                        symbol=event.symbol,
+                        side=event.side,
+                        quantity=event.quantity,
+                        price=event.price,
+                        order_type=event.order_type,
+                        account_id=self._account_id,
+                        reason=(
+                            f"market_buy_quote_unavailable: "
+                            f"invalid quote {quote!r}: {exc!s}"
+                        ),
+                    )
+                )
+                return
+
+            quantity_d = Decimal(str(event.quantity))
+            buffer = self._market_order_reserve_buffer_rate
+            reserve_basis = quantity_d * quote_d * (Decimal("1") + buffer)
+            commission_d = reserve_basis * Decimal(str(self._buy_commission_rate))
+            total_reserve_d = reserve_basis + commission_d
+            total_reserve_market_buy = float(total_reserve_d)
+
+            if total_reserve_market_buy <= 0:
+                await self._eventbus.publish(
+                    OrderRejectedEvent(
+                        order_id=event.order_id,
+                        bot_id=event.bot_id,
+                        strategy_id=event.strategy_id,
+                        symbol=event.symbol,
+                        side=event.side,
+                        quantity=event.quantity,
+                        price=event.price,
+                        order_type=event.order_type,
+                        account_id=self._account_id,
+                        reason=(
+                            f"reserve_amount_invalid: "
+                            f"total_reserve={total_reserve_market_buy}, "
+                            f"quote={quote}, "
+                            f"quantity={event.quantity}"
+                        ),
+                    )
+                )
+                return
+
+            try:
+                success = await self.reserve_for_order(
+                    event.bot_id, event.order_id, total_reserve_market_buy
+                )
+                if not success:
+                    available = self.get_available(event.bot_id)
+                    await self._eventbus.publish(
+                        OrderRejectedEvent(
+                            order_id=event.order_id,
+                            bot_id=event.bot_id,
+                            strategy_id=event.strategy_id,
+                            symbol=event.symbol,
+                            side=event.side,
+                            quantity=event.quantity,
+                            price=event.price,
+                            order_type=event.order_type,
+                            account_id=self._account_id,
+                            reason=(
+                                f"insufficient_budget: "
+                                f"need {total_reserve_market_buy:,.0f}, "
+                                f"available {available:,.0f}"
+                            ),
+                        )
+                    )
+                    return
+
+                # Stop Condition: resolved quote 를 OrderApprovedEvent.price 에
+                # 절대 넣지 않는다 — quote 는 reserve estimate 이지 주문가가
+                # 아니다. price=None 그대로 유지해 broker adapter 가 시장가
+                # 주문으로 제출하게 한다.
+                await self._eventbus.publish(
+                    OrderApprovedEvent(
+                        order_id=event.order_id,
+                        bot_id=event.bot_id,
+                        strategy_id=event.strategy_id,
+                        symbol=event.symbol,
+                        side=event.side,
+                        quantity=event.quantity,
+                        price=None,
+                        order_type=event.order_type,
+                        stop_price=event.stop_price,
+                        reserved_amount=total_reserve_market_buy,
+                        account_id=self._account_id,
+                    )
+                )
+                return
+            except Exception as exc:
+                logger.exception(
+                    "Treasury reserve_for_order 실패 (market buy): "
+                    "order_id=%s, bot_id=%s",
+                    event.order_id,
+                    event.bot_id,
+                )
+                await self._eventbus.publish(
+                    OrderRejectedEvent(
+                        order_id=event.order_id,
+                        bot_id=event.bot_id,
+                        strategy_id=event.strategy_id,
+                        symbol=event.symbol,
+                        side=event.side,
+                        quantity=event.quantity,
+                        price=event.price,
+                        order_type=event.order_type,
+                        account_id=self._account_id,
+                        reason=f"reserve_failed: {exc!s}",
+                    )
+                )
+                return
 
         price = event.price or 0.0
         estimated_cost = event.quantity * price
@@ -776,7 +948,27 @@ class Treasury:
             budget.spent += actual_cost
             surplus = reserved_amount - actual_cost
             if surplus > 0:
+                # 체결가가 reserve 보다 낮음 — 잔여 reserve 를 available 로 환수.
                 budget.available += surplus
+            elif surplus < 0:
+                # 체결가가 reserve 보다 높음 (시장가 매수의 가격 변동 등).
+                # 초과분을 available 에서 추가 차감한다 — invariant: 결과적으로
+                # available 이 음수가 될 수 있으나 이는 정상 운영 상태가 아니며
+                # 후속 매수 reserve 가 거부되는 것은 자연스러운 결과다 (#1333).
+                # 별도 EventBus 이벤트는 신설하지 않으며 audit 용 warning 만
+                # 남긴다.
+                extra_cost = -surplus
+                budget.available -= extra_cost
+                logger.warning(
+                    "market_order_reserve_shortfall: bot=%s order=%s "
+                    "extra_cost=%s reserved=%s actual=%s "
+                    "(available may be negative)",
+                    event.bot_id,
+                    event.order_id,
+                    f"{extra_cost:,.2f}",
+                    f"{reserved_amount:,.2f}",
+                    f"{actual_cost:,.2f}",
+                )
         else:
             actual_proceeds = fill_value - commission
             budget.returned += actual_proceeds

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -689,6 +689,30 @@ class Treasury:
             # Decimal 정밀도로 reserve 산정. ``OrderApprovedEvent.reserved_amount``
             # 와 Treasury budget 의 float 경계에서만 ``float`` 로 변환한다 — 기존
             # commission/budget float 계약과 일관됨.
+            #
+            # NaN/Inf/non-positive quote 는 ``Decimal(str(quote))`` 가 예외를 내지
+            # 않으므로 명시 거부 (#1333 P2 — Codex 브랜치 리뷰).
+            if not (
+                isinstance(quote, int | float) and math.isfinite(quote) and quote > 0
+            ):
+                await self._eventbus.publish(
+                    OrderRejectedEvent(
+                        order_id=event.order_id,
+                        bot_id=event.bot_id,
+                        strategy_id=event.strategy_id,
+                        symbol=event.symbol,
+                        side=event.side,
+                        quantity=event.quantity,
+                        price=event.price,
+                        order_type=event.order_type,
+                        account_id=self._account_id,
+                        reason=(
+                            f"market_buy_quote_unavailable: "
+                            f"non-finite or non-positive quote {quote!r}"
+                        ),
+                    )
+                )
+                return
             try:
                 quote_d = Decimal(str(quote))
             except Exception as exc:

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -32,16 +32,18 @@ router = APIRouter()
 
 
 # Cold-path 전용 필드: 서버 실행 중에는 변경할 수 없다.
-# 출처: docs/specs/account/04-account-service.md 51-58줄.
-# - credentials, broker_config, buy_commission_rate, sell_commission_rate:
-#   broker adapter 재초기화가 필요한 필드
+# 출처: docs/specs/account/04-account-service.md.
+# - credentials, broker_config, buy_commission_rate, sell_commission_rate,
+#   market_order_reserve_buffer_rate:
+#   broker adapter / Treasury reserve 정책에 영향을 주는 필드.
 # - exchange, currency, trading_mode, broker_type:
-#   계좌 생성 후 불변 필드 (구조 변경 시 모든 소비자 재구성 필요)
+#   계좌 생성 후 불변 필드 (구조 변경 시 모든 소비자 재구성 필요).
 STRUCTURAL_FIELDS: tuple[str, ...] = (
     "credentials",
     "broker_config",
     "buy_commission_rate",
     "sell_commission_rate",
+    "market_order_reserve_buffer_rate",
     "broker_type",
     "exchange",
     "currency",
@@ -235,6 +237,14 @@ ACCOUNT_CREATE_REQUEST_SCHEMA: dict[str, Any] = {
             "default": 0,
             "description": "매도 수수료율, 세금 포함 (cold-path 전용).",
         },
+        "market_order_reserve_buffer_rate": {
+            "type": "number",
+            "description": (
+                "시장가 매수 reserve buffer 비율 (cold-path 전용, #1333). "
+                "omit 시 BrokerPreset 기본값을 사용한다 "
+                "(예: kis-domestic=0.005, test=0)."
+            ),
+        },
     },
 }
 
@@ -266,6 +276,9 @@ def _account_to_response(account: Any) -> dict[str, Any]:
         "broker_config": account.broker_config,
         "buy_commission_rate": float(account.buy_commission_rate),
         "sell_commission_rate": float(account.sell_commission_rate),
+        "market_order_reserve_buffer_rate": float(
+            account.market_order_reserve_buffer_rate
+        ),
         "status": (
             account.status.value
             if hasattr(account.status, "value")

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -45,6 +45,8 @@ class AccountResponse(BaseModel):
     broker_config: dict[str, Any] = {}
     buy_commission_rate: float
     sell_commission_rate: float
+    # 시장가 매수 reserve buffer 비율 (cold-path 전용 — #1333).
+    market_order_reserve_buffer_rate: float = 0.0
     status: str
     created_at: str
     updated_at: str
@@ -78,6 +80,9 @@ class AccountCreateRequest(BaseModel):
     broker_config: dict[str, Any] = {}
     buy_commission_rate: float = 0.0
     sell_commission_rate: float = 0.0
+    # 시장가 매수 reserve buffer 비율. omit 시 service-layer에서 BrokerPreset
+    # 기본값을 사용한다. cold-path 전용 (#1333).
+    market_order_reserve_buffer_rate: float | None = None
 
     @field_validator("trading_hours_start", "trading_hours_end")
     @classmethod
@@ -125,6 +130,9 @@ class AccountUpdateRequest(BaseModel):
     broker_config: dict[str, Any] | None = None
     buy_commission_rate: float | None = None
     sell_commission_rate: float | None = None
+    # 다른 structural 필드와 동일하게 모델에는 노출하지만, PUT 라우트는
+    # ``STRUCTURAL_FIELDS`` 가드로 cold-path 409 차단한다 (#1333).
+    market_order_reserve_buffer_rate: float | None = None
 
     @field_validator("trading_hours_start", "trading_hours_end")
     @classmethod

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -1130,6 +1130,8 @@ def test_broker_preset_test_values():
     assert preset.currency == "KRW"
     assert preset.buy_commission_rate == Decimal("0")
     assert preset.sell_commission_rate == Decimal("0")
+    # #1333: market buy reserve buffer 기본값. test는 결정적 거동을 위해 0.
+    assert preset.market_order_reserve_buffer_rate == Decimal("0")
     assert preset.required_credentials == ["app_key", "app_secret"]
 
 
@@ -1140,4 +1142,66 @@ def test_broker_preset_kis_domestic_values():
     assert preset.currency == "KRW"
     assert preset.buy_commission_rate == Decimal("0.00015")
     assert preset.sell_commission_rate == Decimal("0.00195")
+    # #1333: market buy reserve buffer 기본값 0.5%.
+    assert preset.market_order_reserve_buffer_rate == Decimal("0.005")
     assert "app_key" in preset.required_credentials
+
+
+# ── #1333: market_order_reserve_buffer_rate ──────────────
+
+
+@pytest.mark.asyncio
+async def test_market_order_reserve_buffer_rate_db_roundtrip(service):
+    """Account 의 market_order_reserve_buffer_rate 가 DB 왕복에서 Decimal 정밀도로
+    보존된다 (#1333).
+    """
+    account = _make_account(
+        "buffer-roundtrip",
+        market_order_reserve_buffer_rate=Decimal("0.0075"),
+    )
+    await service.create(account)
+
+    # 캐시 우회: 신규 service 인스턴스로 DB에서 다시 로드.
+    svc2 = AccountService(service._db, service._eventbus)
+    await svc2.initialize()
+    loaded = await svc2.get("buffer-roundtrip")
+
+    assert loaded.market_order_reserve_buffer_rate == Decimal("0.0075")
+    assert isinstance(loaded.market_order_reserve_buffer_rate, Decimal)
+
+
+@pytest.mark.asyncio
+async def test_market_order_reserve_buffer_rate_default_zero(service):
+    """Account dataclass default 는 Decimal('0') (#1333)."""
+    a = _make_account("buffer-default")
+    assert a.market_order_reserve_buffer_rate == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_market_order_reserve_buffer_rate_blocked_at_runtime_update(
+    service,
+) -> None:
+    """런타임에서 ``market_order_reserve_buffer_rate`` 변경 시도는 cold-path
+    409 (``AccountStructuralChangeRequiresStoppedServerError``)로 차단된다 (#1333).
+    """
+    from ante.account.errors import (
+        AccountStructuralChangeRequiresStoppedServerError,
+    )
+
+    await service.create(_make_account("buffer-cold-path"))
+    service.mark_runtime_started()
+
+    with pytest.raises(AccountStructuralChangeRequiresStoppedServerError):
+        await service.update(
+            "buffer-cold-path",
+            market_order_reserve_buffer_rate=Decimal("0.01"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_default_test_account_uses_preset_buffer(service) -> None:
+    """``create_default_test_account`` 가 BrokerPreset 의 buffer(0)를 그대로
+    Account 에 반영한다 (#1333).
+    """
+    acct = await service.create_default_test_account()
+    assert acct.market_order_reserve_buffer_rate == Decimal("0")

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -439,6 +439,26 @@ class TestGetAccount:
         data = resp.json()
         assert "credentials" not in data["account"]
 
+    def test_account_response_exposes_market_order_reserve_buffer_rate(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """AccountResponse 가 ``market_order_reserve_buffer_rate`` 를 float 로
+        노출한다 (#1333).
+        """
+        account = _make_account()
+        account.market_order_reserve_buffer_rate = Decimal("0.005")
+        account_service._accounts[account.account_id] = account
+
+        resp = client.get("/api/accounts/test-account")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "market_order_reserve_buffer_rate" in data["account"]
+        assert data["account"]["market_order_reserve_buffer_rate"] == pytest.approx(
+            0.005
+        )
+
 
 class TestUpdateAccount:
     """PUT /api/accounts/:id.
@@ -601,6 +621,26 @@ class TestUpdateAccount:
         detail = resp.json()["detail"]
         assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
         assert "sell_commission_rate" in detail
+
+    def test_update_market_order_reserve_buffer_rate_blocked_409(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+    ) -> None:
+        """``market_order_reserve_buffer_rate`` 변경 시도는 cold-path 409 차단
+        (#1333).
+        """
+        account = _make_account()
+        account_service._accounts[account.account_id] = account
+
+        resp = client.put(
+            "/api/accounts/test-account",
+            json={"market_order_reserve_buffer_rate": 0.01},
+        )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in detail
+        assert "market_order_reserve_buffer_rate" in detail
 
     def test_update_broker_type_blocked_409(
         self,

--- a/tests/unit/test_account_cli.py
+++ b/tests/unit/test_account_cli.py
@@ -345,6 +345,44 @@ class TestAccountCreate:
         assert "생성 완료" in result.output
         mock_account_service.create.assert_called_once()
 
+    def test_create_market_buffer_default_uses_preset(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """``--market-order-reserve-buffer-rate`` 누락 시 BrokerPreset 기본값을
+        그대로 사용한다 (test broker → 0; #1333).
+        """
+        from decimal import Decimal
+
+        created = _mock_account("test2", "테스트2", "TEST", "KRW", "test")
+        mock_account_service.create.return_value = created
+
+        result = _invoke(_create_args_test_broker())
+        assert result.exit_code == 0, result.output
+        new_account = mock_account_service.create.call_args.args[0]
+        assert new_account.market_order_reserve_buffer_rate == Decimal("0")
+
+    def test_create_market_buffer_explicit_decimal_conversion(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """명시한 ``--market-order-reserve-buffer-rate`` 값이 ``Decimal(str(...))``
+        로 변환되어 Account 에 전달된다 (#1333).
+        """
+        from decimal import Decimal
+
+        created = _mock_account("test2", "테스트2", "TEST", "KRW", "test")
+        mock_account_service.create.return_value = created
+
+        result = _invoke(
+            _create_args_test_broker(
+                extra=["--market-order-reserve-buffer-rate", "0.0075"]
+            )
+        )
+        assert result.exit_code == 0, result.output
+        new_account = mock_account_service.create.call_args.args[0]
+        # ``Decimal(str(0.0075))`` 는 정확히 ``Decimal("0.0075")``.
+        assert new_account.market_order_reserve_buffer_rate == Decimal("0.0075")
+        assert isinstance(new_account.market_order_reserve_buffer_rate, Decimal)
+
     def test_create_json_output(
         self, mock_account_service: AsyncMock, offline_runtime
     ) -> None:

--- a/tests/unit/test_account_runtime_guard.py
+++ b/tests/unit/test_account_runtime_guard.py
@@ -252,21 +252,22 @@ def test_structural_fields_match_route_constant() -> None:
 
     # route는 tuple, service는 frozenset이지만 set 비교로 동일 멤버를 강제.
     assert set(ROUTE_FIELDS) == set(STRUCTURAL_FIELDS)
-    # 8필드 정확히 일치
-    assert len(set(ROUTE_FIELDS)) == 8
-    assert len(STRUCTURAL_FIELDS) == 8
+    # 9필드 정확히 일치 (#1333: market_order_reserve_buffer_rate 추가).
+    assert len(set(ROUTE_FIELDS)) == 9
+    assert len(STRUCTURAL_FIELDS) == 9
 
 
 def test_structural_fields_matches_spec() -> None:
-    """spec에 명시된 8필드와 service ``STRUCTURAL_FIELDS``가 정확히 일치.
+    """spec에 명시된 9필드와 service ``STRUCTURAL_FIELDS``가 정확히 일치.
 
-    spec SSOT: docs/specs/account/04-account-service.md 51-58줄.
+    spec SSOT: docs/specs/account/04-account-service.md.
     """
     expected = {
         "credentials",
         "broker_config",
         "buy_commission_rate",
         "sell_commission_rate",
+        "market_order_reserve_buffer_rate",
         "broker_type",
         "exchange",
         "currency",

--- a/tests/unit/test_treasury.py
+++ b/tests/unit/test_treasury.py
@@ -685,7 +685,8 @@ class TestOnOrderValidatedGuards:
     async def test_on_order_validated_market_buy_without_price_publishes_rejected(
         self, treasury, eventbus, monkeypatch
     ):
-        """market buy + price=None -> reserve 호출 없이 OrderRejected 발행.
+        """market buy + price=None & resolver 미주입 -> reserve 호출 없이
+        OrderRejected 발행 (#1333).
 
         Order lifecycle invariant: terminal event(OrderRejected)가 정확히 1건
         발행되어야 하고, reserve_for_order는 호출되지 않아야 한다.
@@ -721,9 +722,10 @@ class TestOnOrderValidatedGuards:
 
         assert len(approved) == 0
         assert len(rejected) == 1
+        # #1333: reason은 ``market_buy_quote_unavailable: ...`` prefix.
+        # resolver 미주입 시 ``resolver not configured`` detail 이 포함된다.
         assert rejected[0].reason.startswith("market_buy_quote_unavailable")
-        assert "order_type=market" in rejected[0].reason
-        assert "price=None" in rejected[0].reason
+        assert "resolver not configured" in rejected[0].reason
         assert rejected[0].account_id == ACCOUNT_ID
         assert rejected[0].order_id == "ord-mkt-buy"
         # reserve_for_order는 절대 호출되지 않아야 한다.
@@ -954,6 +956,422 @@ class TestOnOrderValidatedGuards:
         assert len(approved) == 0
         assert len(rejected) == 1
         assert rejected[0].reason.startswith("market_buy_quote_unavailable")
+
+
+# -- #1333 시장가 매수 reserve estimate (quote resolver) -----
+
+
+class TestMarketBuyQuoteResolver:
+    """Account-scoped quote resolver 가 주입돼 있을 때 market buy + price=None
+    이 정상 reserve 후 OrderApproved 로 흘러가는지, 미주입/실패 시 terminal
+    reject 인지 검증한다 (#1333).
+    """
+
+    async def _make_treasury_with_buffer(
+        self,
+        db,
+        eventbus,
+        *,
+        buffer: str,
+        resolver=None,
+    ):
+        from decimal import Decimal as _Decimal
+
+        t = Treasury(
+            db=db,
+            eventbus=eventbus,
+            account_id=ACCOUNT_ID,
+            currency=CURRENCY,
+            buy_commission_rate=0.00015,
+            sell_commission_rate=0.00195,
+            market_order_reserve_buffer_rate=_Decimal(buffer),
+            order_reserve_price_resolver=resolver,
+        )
+        await t.initialize()
+        await t.set_account_balance(10_000_000.0)
+        return t
+
+    async def test_market_buy_resolver_success_publishes_approved_with_price_none(
+        self, db, eventbus
+    ):
+        """resolver 가 quote 를 반환하면 reserve 산정 후 OrderApproved 가
+        ``price=None`` + ``reserved_amount > 0`` 로 발행된다.
+        """
+
+        async def resolver(symbol: str) -> float:
+            assert symbol == "069500"
+            return 10_000.0
+
+        t = await self._make_treasury_with_buffer(
+            db, eventbus, buffer="0.005", resolver=resolver
+        )
+        await t.allocate("bot1", 1_000_000.0)
+
+        approved: list = []
+        rejected: list = []
+        eventbus.subscribe(OrderApprovedEvent, lambda e: approved.append(e))
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-mkt-1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="069500",
+                side="buy",
+                quantity=1.0,
+                price=None,
+                order_type="market",
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        assert len(rejected) == 0
+        assert len(approved) == 1
+        ev = approved[0]
+        # resolved quote 는 OrderApprovedEvent.price 에 절대 들어가지 않는다.
+        assert ev.price is None
+        # reserve 금액에 buffer (0.5%) + buy_commission (0.015%) 반영.
+        # 1 * 10_000 * (1 + 0.005) * (1 + 0.00015) = 10_051.5075...
+        expected = 1.0 * 10_000.0 * (1 + 0.005) * (1 + 0.00015)
+        assert ev.reserved_amount == pytest.approx(expected)
+
+    async def test_market_buy_buffer_and_commission_in_reserve_amount(
+        self, db, eventbus
+    ):
+        """buffer = 0 일 때 reserve = quantity * quote * (1 + commission)
+        가 그대로 적용되는지 검증 (commission 단독 영향 분리).
+        """
+
+        async def resolver(symbol: str) -> float:
+            return 5_000.0
+
+        t = await self._make_treasury_with_buffer(
+            db, eventbus, buffer="0", resolver=resolver
+        )
+        await t.allocate("bot1", 1_000_000.0)
+
+        approved: list = []
+        eventbus.subscribe(OrderApprovedEvent, lambda e: approved.append(e))
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-mkt-2",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="A",
+                side="buy",
+                quantity=2.0,
+                price=None,
+                order_type="market",
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        assert len(approved) == 1
+        # 2 * 5_000 * (1 + 0) * (1 + 0.00015) = 10_001.5
+        expected = 2.0 * 5_000.0 * (1 + 0) * (1 + 0.00015)
+        assert approved[0].reserved_amount == pytest.approx(expected)
+
+    async def test_market_buy_resolver_missing_publishes_rejected(self, db, eventbus):
+        """resolver 미주입 상태에서 terminal reject (resolver not configured)."""
+        t = await self._make_treasury_with_buffer(
+            db, eventbus, buffer="0.005", resolver=None
+        )
+        await t.allocate("bot1", 1_000_000.0)
+
+        rejected: list = []
+        approved: list = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+        eventbus.subscribe(OrderApprovedEvent, lambda e: approved.append(e))
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-mkt-3",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="A",
+                side="buy",
+                quantity=1.0,
+                price=None,
+                order_type="market",
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        assert len(approved) == 0
+        assert len(rejected) == 1
+        assert rejected[0].reason.startswith("market_buy_quote_unavailable")
+        assert "resolver not configured" in rejected[0].reason
+
+    async def test_market_buy_resolver_raises_publishes_rejected(self, db, eventbus):
+        """resolver 가 예외를 raise 하면 terminal reject 로 변환."""
+
+        async def resolver(symbol: str) -> float:
+            raise RuntimeError("KIS quote API 503")
+
+        t = await self._make_treasury_with_buffer(
+            db, eventbus, buffer="0.005", resolver=resolver
+        )
+        await t.allocate("bot1", 1_000_000.0)
+
+        rejected: list = []
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-mkt-4",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="A",
+                side="buy",
+                quantity=1.0,
+                price=None,
+                order_type="market",
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        assert len(rejected) == 1
+        assert rejected[0].reason.startswith("market_buy_quote_unavailable")
+        assert "KIS quote API 503" in rejected[0].reason
+
+    async def test_market_sell_price_none_unchanged(self, db, eventbus):
+        """market **sell** + price=None 은 기존 거동대로 reserve 없이 즉시 승인."""
+
+        async def resolver(symbol: str) -> float:
+            return 99_999.0  # 호출돼서는 안 됨
+
+        t = await self._make_treasury_with_buffer(
+            db, eventbus, buffer="0.005", resolver=resolver
+        )
+        await t.allocate("bot1", 1_000_000.0)
+
+        approved: list = []
+        eventbus.subscribe(OrderApprovedEvent, lambda e: approved.append(e))
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-mkt-sell",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="A",
+                side="sell",
+                quantity=1.0,
+                price=None,
+                order_type="market",
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        assert len(approved) == 1
+        # sell-side 는 reserve 0
+        assert approved[0].reserved_amount == 0.0
+        assert approved[0].side == "sell"
+        # resolver 가 호출되더라도 reserve estimate 산정에는 쓰이지 않는다.
+        # budget 도 변동 없음.
+        budget = t.get_budget("bot1")
+        assert budget is not None
+        assert budget.available == 1_000_000.0
+        assert budget.reserved == 0.0
+
+    async def test_limit_buy_unchanged_no_resolver_call(self, db, eventbus):
+        """limit buy (price 명시) 는 기존 reserve 산식이 그대로 적용되며
+        resolver 가 호출되지 않는다.
+        """
+        resolver_calls: list = []
+
+        async def resolver(symbol: str) -> float:
+            resolver_calls.append(symbol)
+            return 99_999.0
+
+        t = await self._make_treasury_with_buffer(
+            db, eventbus, buffer="0.005", resolver=resolver
+        )
+        await t.allocate("bot1", 1_000_000.0)
+
+        approved: list = []
+        eventbus.subscribe(OrderApprovedEvent, lambda e: approved.append(e))
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-limit-buy",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="A",
+                side="buy",
+                quantity=2.0,
+                price=1_000.0,
+                order_type="limit",
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        assert len(approved) == 1
+        # 기존 limit buy 산식: quantity * price + commission (buffer 적용 안 함).
+        expected = 2.0 * 1_000.0 + (2.0 * 1_000.0) * 0.00015
+        assert approved[0].reserved_amount == pytest.approx(expected)
+        # market buy quote resolver 는 호출되지 않는다.
+        assert resolver_calls == []
+
+    async def test_buy_stop_does_not_reach_market_resolver(self, db, eventbus):
+        """buy stop 분기 (#1337) 가 진입 우선순위 1로 유지되어 #1333 resolver
+        분기에 도달하지 않는다 — Stop Condition 반영.
+        """
+        resolver_calls: list = []
+
+        async def resolver(symbol: str) -> float:
+            resolver_calls.append(symbol)
+            return 99_999.0
+
+        t = await self._make_treasury_with_buffer(
+            db, eventbus, buffer="0.005", resolver=resolver
+        )
+        await t.allocate("bot1", 1_000_000.0)
+
+        approved: list = []
+        rejected: list = []
+        eventbus.subscribe(OrderApprovedEvent, lambda e: approved.append(e))
+        eventbus.subscribe(OrderRejectedEvent, lambda e: rejected.append(e))
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-stop",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="A",
+                side="buy",
+                quantity=1.0,
+                price=None,
+                order_type="stop",
+                stop_price=900.0,
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        # #1337: stop 은 트리거 전이라 reserve 0 으로 즉시 OrderApproved.
+        assert len(rejected) == 0
+        assert len(approved) == 1
+        assert approved[0].reserved_amount == 0.0
+        # resolver 는 호출되지 않는다.
+        assert resolver_calls == []
+
+    async def test_buy_stop_limit_does_not_reach_market_resolver(self, db, eventbus):
+        """buy stop_limit 도 #1337 분기 우선순위 1 유지 — resolver 미호출."""
+        resolver_calls: list = []
+
+        async def resolver(symbol: str) -> float:
+            resolver_calls.append(symbol)
+            return 99_999.0
+
+        t = await self._make_treasury_with_buffer(
+            db, eventbus, buffer="0.005", resolver=resolver
+        )
+        await t.allocate("bot1", 1_000_000.0)
+
+        approved: list = []
+        eventbus.subscribe(OrderApprovedEvent, lambda e: approved.append(e))
+
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-stop-limit",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="A",
+                side="buy",
+                quantity=1.0,
+                price=910.0,
+                order_type="stop_limit",
+                stop_price=900.0,
+                account_id=ACCOUNT_ID,
+            )
+        )
+
+        assert len(approved) == 1
+        assert approved[0].reserved_amount == 0.0
+        assert resolver_calls == []
+
+
+# -- #1333 shortfall 정산 -----
+
+
+class TestMarketOrderReserveShortfall:
+    """체결가가 reserve 보다 높은 시장가 매수의 정산 invariant 검증 (#1333)."""
+
+    async def test_buy_fill_actual_cost_exceeds_reserved_warns_and_decrements_available(
+        self, db, eventbus, caplog
+    ):
+        """actual_cost > reserved_amount 면 초과분이 available 에서 추가 차감되며
+        ``market_order_reserve_shortfall`` warning 이 logged 된다. available 이
+        음수가 되는 것이 invariant 다 (#1333 정책 5).
+        """
+        import logging as _logging
+
+        async def resolver(symbol: str) -> float:
+            return 1_000.0  # buffer 0 이라 reserve = 1 * 1000 * (1 + 0.00015)
+
+        from decimal import Decimal as _Decimal
+
+        t = Treasury(
+            db=db,
+            eventbus=eventbus,
+            account_id=ACCOUNT_ID,
+            currency=CURRENCY,
+            buy_commission_rate=0.00015,
+            sell_commission_rate=0.00195,
+            market_order_reserve_buffer_rate=_Decimal("0"),
+            order_reserve_price_resolver=resolver,
+        )
+        await t.initialize()
+        await t.set_account_balance(10_000_000.0)
+        await t.allocate("bot1", 1_100.0)
+
+        # 1) market buy → reserve 산정.
+        await eventbus.publish(
+            OrderValidatedEvent(
+                order_id="ord-fill-1",
+                bot_id="bot1",
+                strategy_id="s1",
+                symbol="A",
+                side="buy",
+                quantity=1.0,
+                price=None,
+                order_type="market",
+                account_id=ACCOUNT_ID,
+            )
+        )
+        budget = t.get_budget("bot1")
+        assert budget is not None
+        reserved_before = budget.reserved
+        assert reserved_before > 0
+
+        # 2) 실체결가가 reserve 보다 높다 → shortfall 정산.
+        with caplog.at_level(_logging.WARNING):
+            await eventbus.publish(
+                OrderFilledEvent(
+                    order_id="ord-fill-1",
+                    bot_id="bot1",
+                    strategy_id="s1",
+                    symbol="A",
+                    side="buy",
+                    quantity=1.0,
+                    price=2_000.0,  # reserve(=1000.15)보다 훨씬 높다
+                    commission=0.3,
+                    account_id=ACCOUNT_ID,
+                )
+            )
+
+        budget = t.get_budget("bot1")
+        assert budget is not None
+        # actual_cost = 1*2000 + 0.3 = 2000.3, reserved ~= 1000.15 → extra 1000.15+
+        # available 은 (1100 - 1000.15) - extra = 음수 가능.
+        assert budget.available < 0
+        assert budget.reserved == pytest.approx(0.0, abs=1e-6)
+        # warning 로그 점검.
+        assert any(
+            "market_order_reserve_shortfall" in rec.getMessage()
+            for rec in caplog.records
+        )
 
 
 # -- 모니터링 -------------------------------------------------

--- a/tests/unit/test_treasury_manager.py
+++ b/tests/unit/test_treasury_manager.py
@@ -143,3 +143,105 @@ class TestTreasuryManager:
         # 잔액 독립
         assert domestic.unallocated == 7_000_000.0
         assert us.unallocated == 3_000.0
+
+
+# -- #1333: market_order_reserve_buffer_rate / resolver wiring -----
+
+
+class TestTreasuryManagerMarketBufferAndResolver:
+    """TreasuryManager 가 Account.market_order_reserve_buffer_rate 를 Treasury 에
+    전달하고, ``set_order_reserve_price_resolver`` 로 후속 resolver 주입을
+    지원하는지 검증한다 (#1333).
+    """
+
+    async def test_buffer_passed_to_treasury(self, manager):
+        """create_treasury 가 Account 의 buffer 값을 Treasury 에 그대로 주입."""
+        account = Account(
+            account_id="domestic",
+            name="국내주식",
+            exchange="KRX",
+            currency="KRW",
+            buy_commission_rate=Decimal("0.00015"),
+            sell_commission_rate=Decimal("0.00195"),
+            market_order_reserve_buffer_rate=Decimal("0.005"),
+        )
+        treasury = await manager.create_treasury(account)
+        assert treasury._market_order_reserve_buffer_rate == Decimal("0.005")
+
+    async def test_set_order_reserve_price_resolver_injects_into_treasury(
+        self, manager, domestic_account
+    ):
+        """setter 가 Treasury 인스턴스에 resolver 를 주입한다."""
+        await manager.create_treasury(domestic_account)
+
+        async def my_resolver(symbol: str) -> float:
+            return 12_345.0
+
+        manager.set_order_reserve_price_resolver("domestic", my_resolver)
+        treasury = manager.get("domestic")
+        # 직접 호출로 주입 여부 검증.
+        assert treasury._order_reserve_price_resolver is my_resolver
+
+    async def test_set_order_reserve_price_resolver_unknown_account_keyerror(
+        self, manager
+    ):
+        """등록되지 않은 계좌에 resolver 주입 시 KeyError."""
+
+        async def r(symbol: str) -> float:
+            return 0.0
+
+        with pytest.raises(KeyError, match="nonexistent"):
+            manager.set_order_reserve_price_resolver("nonexistent", r)
+
+    async def test_main_style_wiring_closure_captures_correct_account_id(
+        self, manager, domestic_account, us_account
+    ):
+        """main._init_gateway 의 closure 패턴이 계좌별로 account_id 를 정확히
+        캡처해 APIGateway.get_current_price 에 전달한다 (#1333 wiring 회귀).
+
+        late binding 회귀(``account_id`` 가 마지막 loop 값으로 고정되는 것)
+        가 발생하면 두 계좌의 resolver 가 동일 account_id 로 호출되어 본
+        테스트의 assertion 이 실패한다.
+        """
+        from collections.abc import Awaitable, Callable
+
+        await manager.initialize_all([domestic_account, us_account])
+
+        # Fake APIGateway: account_id 를 기록하고 deterministic price 반환.
+        seen: dict[str, str] = {}
+
+        class FakeGateway:
+            async def get_current_price(self, symbol: str, *, account_id: str) -> float:
+                seen[account_id] = symbol
+                return 1_000.0
+
+        gateway = FakeGateway()
+
+        # main._init_gateway 의 closure 패턴 그대로 적용.
+        for account in [domestic_account, us_account]:
+
+            def _make_resolver(
+                account_id: str,
+            ) -> Callable[[str], Awaitable[float]]:
+                async def _resolver(symbol: str) -> float:
+                    return await gateway.get_current_price(
+                        symbol, account_id=account_id
+                    )
+
+                return _resolver
+
+            manager.set_order_reserve_price_resolver(
+                account.account_id, _make_resolver(account.account_id)
+            )
+
+        # 각 Treasury 의 resolver 를 호출해서 account_id 캡처가 정확한지 확인.
+        domestic_resolver = manager.get("domestic")._order_reserve_price_resolver
+        us_resolver = manager.get("us-stock")._order_reserve_price_resolver
+        assert domestic_resolver is not None
+        assert us_resolver is not None
+
+        await domestic_resolver("069500")
+        await us_resolver("AAPL")
+
+        # 각 resolver 가 자신의 account_id 로만 gateway 를 호출.
+        assert seen == {"domestic": "069500", "us-stock": "AAPL"}


### PR DESCRIPTION
Closes #1333

## Summary (대규모 정책 변경 — 사용자 사전 승인 2026-05-08)
- `Account.market_order_reserve_buffer_rate: Decimal` 필드 추가 (cold-path, kis-domestic=0.005, test=0).
- `Treasury._on_order_validated`에 `side="buy" + order_type="market" + price=None` 분기 추가:
  - account-scoped `order_reserve_price_resolver`로 quote 조회 → reserve 산정.
  - 산식: `reserve_basis = qty * quote * (1 + buffer); commission = reserve_basis * buy_commission_rate; total_reserve = reserve_basis + commission` (Decimal 정밀도, OrderApprovedEvent.reserved_amount/budget 경계에서만 float).
  - `OrderApprovedEvent.price = None` 유지 (resolved quote는 reserve estimate, 주문 가격 아님).
  - resolver 미주입/예외/NaN/Inf/non-positive → `OrderRejectedEvent(reason="market_buy_quote_unavailable: ...")`.
- `_init_gateway()` 끝에서 `TreasuryManager.set_order_reserve_price_resolver()` post-wiring (TreasuryManager 초기화는 _init_trading()에서 진행).
- shortfall 정산 (`actual_cost > reserved_amount`): `available -= extra`, 음수 허용 + `logger.warning("market_order_reserve_shortfall: ...")`. 별도 EventBus 이벤트 미신설.
- `STRUCTURAL_FIELDS` 9 필드로 확장 (service frozenset + route tuple + spec 04 + 2 runtime guard 테스트 갱신).
- 분기 우선순위: #1337 (stop/stop_limit) → #1333 (market buy + price=None) → 기존 분기 (테스트로 강제).
- AccountCreateRequest/UpdateRequest float 입력 + service layer Decimal 정규화 (기존 commission_rate와 동일 패턴).
- AccountService.update() updatable whitelist에 buffer 추가 (cold-path 일관성).
- CLI `ante account create --market-order-reserve-buffer-rate` 옵션 + `account info` 텍스트 출력에 표시.
- 스펙 보강 8개 문서: `account/03,04,06,10,13`, `treasury/04`, `strategy/03-02`, `broker-adapter/04,08`, `web-api/05`.
- OpenAPI + frontend types 재생성.

## Test Plan
- [x] 신규 테스트 17건 + 기존 1건 갱신.
- [x] `pytest tests/unit/ -k "treasury or market or stop or virtual or account"` (1024 PASS).
- [x] `pytest tests/unit/test_account_runtime_guard.py` (23 PASS, 9필드 기준).
- [x] `pytest tests/unit/` 전체 (3976 passed, 2 skipped).
- [x] `ruff check`, `ruff format --check`, `mypy`: PASS.
- [x] `/codex:review --base main` (3 iterations of P2/P3 finding 모두 반영).

## Non-Goals (이슈 본문 사전 명시)
- 시장가 주문 → limit 변환
- 호가창 depth 기반 정밀 reserve
- KRX 상한가/하한가 broker-specific estimator
- buffer 런타임 DynamicConfig화
- 전략별/봇별 buffer override
- shortfall에 대한 별도 EventBus 이벤트 신설
- kis-overseas preset 추가 (BROKER_REGISTRY 미지원, 1.1 scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)