### PR TITLE
fix(web): reject unknown data_type in /api/data/schema and /api/datasets (#1354)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3328,6 +3328,10 @@
             "schema": {
               "anyOf": [
                 {
+                  "enum": [
+                    "ohlcv",
+                    "fundamental"
+                  ],
                   "type": "string"
                 },
                 {
@@ -3517,6 +3521,10 @@
             "in": "query",
             "required": false,
             "schema": {
+              "enum": [
+                "ohlcv",
+                "fundamental"
+              ],
               "type": "string",
               "description": "데이터 유형 (ohlcv, fundamental)",
               "default": "ohlcv",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -4800,7 +4800,7 @@ export interface operations {
         parameters: {
             query?: {
                 /** @description 데이터 유형 (ohlcv, fundamental, 미지정 시 전체) */
-                data_type?: string | null;
+                data_type?: ("ohlcv" | "fundamental") | null;
                 limit?: number;
                 offset?: number;
                 symbol?: string | null;
@@ -4946,7 +4946,7 @@ export interface operations {
         parameters: {
             query?: {
                 /** @description 데이터 유형 (ohlcv, fundamental) */
-                data_type?: string;
+                data_type?: "ohlcv" | "fundamental";
             };
             header?: never;
             path?: never;

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import shutil
 from concurrent.futures import ThreadPoolExecutor
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
@@ -34,7 +34,7 @@ async def list_datasets(
     store: Annotated[Any | None, Depends(get_data_store)],
     symbol: str | None = None,
     timeframe: str | None = None,
-    data_type: str | None = Query(
+    data_type: Literal["ohlcv", "fundamental"] | None = Query(
         None, description="데이터 유형 (ohlcv, fundamental, 미지정 시 전체)"
     ),
     offset: int = 0,
@@ -201,7 +201,9 @@ async def get_dataset_detail(
 
 @router.get("/schema", response_model=DataSchemaResponse)
 async def get_data_schema(
-    data_type: str = Query("ohlcv", description="데이터 유형 (ohlcv, fundamental)"),
+    data_type: Literal["ohlcv", "fundamental"] = Query(
+        "ohlcv", description="데이터 유형 (ohlcv, fundamental)"
+    ),
 ) -> dict:
     """데이터 스키마 조회. data_type에 따라 해당 스키마를 반환."""
     if data_type == "fundamental":

--- a/tests/unit/test_data_schema_validation.py
+++ b/tests/unit/test_data_schema_validation.py
@@ -1,0 +1,99 @@
+"""data_type Query 파라미터 검증 테스트 (#1354).
+
+`/api/data/schema`와 `/api/data/datasets`는 enum SSOT (DATA_TYPES)에 정의된
+`ohlcv` / `fundamental`만 허용해야 한다. 그 외 값은 422로 거부된다.
+
+Default 동작:
+- `get_data_schema`: data_type 미지정 시 OHLCV schema 반환.
+- `list_datasets`: data_type 미지정 시 전체 (ohlcv + fundamental) 반환.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(create_app())
+
+
+# ── /api/data/schema ─────────────────────────────────────
+
+
+class TestDataSchemaValidation:
+    def test_schema_ohlcv_returns_200(self, client: TestClient) -> None:
+        resp = client.get("/api/data/schema", params={"data_type": "ohlcv"})
+        assert resp.status_code == 200
+        data = resp.json()
+        # OHLCV schema 키 확인
+        assert "timestamp" in data
+        assert "open" in data
+        assert "high" in data
+        assert "low" in data
+        assert "close" in data
+        assert "volume" in data
+
+    def test_schema_fundamental_returns_200(self, client: TestClient) -> None:
+        resp = client.get("/api/data/schema", params={"data_type": "fundamental"})
+        assert resp.status_code == 200
+        data = resp.json()
+        # FUNDAMENTAL schema 키 확인
+        assert "date" in data
+        assert "per" in data
+        assert "pbr" in data
+
+    def test_schema_invalid_returns_422(self, client: TestClient) -> None:
+        resp = client.get(
+            "/api/data/schema", params={"data_type": "oracle_invalid_type"}
+        )
+        assert resp.status_code == 422
+
+    def test_schema_empty_string_returns_422(self, client: TestClient) -> None:
+        resp = client.get("/api/data/schema", params={"data_type": ""})
+        assert resp.status_code == 422
+
+    def test_schema_default_returns_ohlcv(self, client: TestClient) -> None:
+        resp = client.get("/api/data/schema")
+        assert resp.status_code == 200
+        data = resp.json()
+        # OHLCV schema 키 (생략 시 default = ohlcv)
+        assert "timestamp" in data
+        assert "open" in data
+        assert "close" in data
+        # FUNDAMENTAL 전용 키는 없어야 한다
+        assert "per" not in data
+        assert "pbr" not in data
+
+
+# ── /api/data/datasets ───────────────────────────────────
+
+
+class TestDatasetsListValidation:
+    def test_datasets_ohlcv_returns_200(self, client: TestClient) -> None:
+        resp = client.get("/api/data/datasets", params={"data_type": "ohlcv"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "items" in body
+        assert "total" in body
+
+    def test_datasets_invalid_returns_422(self, client: TestClient) -> None:
+        resp = client.get(
+            "/api/data/datasets",
+            params={"data_type": "oracle_invalid_type"},
+        )
+        assert resp.status_code == 422
+
+    def test_datasets_default_returns_all(self, client: TestClient) -> None:
+        # data_type 생략 시 전체 (ohlcv + fundamental) 모드 - 200 응답.
+        resp = client.get("/api/data/datasets")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "items" in body
+        assert "total" in body


### PR DESCRIPTION
Closes #1354

## Summary

이슈 #1354의 oracle finding: `GET /api/data/schema?data_type=oracle_invalid_type`이 OHLCV schema를 200으로 반환. enum SSOT(`DATA_TYPES = ["ohlcv", "fundamental"]`)를 따라 422로 거부해야 함.

## Changes

- **`src/ante/web/routes/data.py::get_data_schema`**: Query `data_type`을 `Literal["ohlcv", "fundamental"] = "ohlcv"`로 변경. invalid 값 → 422 자동.
- **`src/ante/web/routes/data.py::list_datasets`**: 일관성 차원에서 같이 적용. Query `data_type`을 `Literal["ohlcv", "fundamental"] | None = None`로 변경. 현재 invalid 값을 빈 결과로 silently 처리하던 동작이 422로 강화 (Codex Plan Review 권고).
- **`frontend/openapi.json`, `frontend/src/types/api.generated.ts`**: 재생성. `data_type` 파라미터가 `string` → `"ohlcv" | "fundamental"` literal union으로 codegen.
- **`tests/unit/test_data_schema_validation.py`** (8 cases): 회귀 테스트.

## Codex Plan/Branch Review

- Plan Review: approve-implement (after revise-plan 1회 — list_datasets 일관성 추가).
- Branch Review: PASS @ \`78bf1fe\` (1st attempt).

## Test Plan

- \`ruff check\`, \`ruff format --check\`: PASS
- \`python -m pytest tests/unit/test_data_schema_validation.py tests/unit/test_data*.py tests/unit/test_web_api.py -q\`: 195 passed
- frontend \`npx tsc -b && npm run build\`: PASS

## Non-Goals (Follow-up)

- `get_storage_summary`, `delete_dataset` 등 다른 endpoint의 data_type 검증.
- `tick`, `news` 등 새 data_type 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)