### PR TITLE
fix(reports): validate status filter as ReportStatus enum (#1355)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3147,7 +3147,7 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ReportStatus"
                 },
                 {
                   "type": "null"
@@ -6958,6 +6958,19 @@
         "type": "object",
         "title": "ReportSchemaResponse",
         "description": "리포트 스키마 응답."
+      },
+      "ReportStatus": {
+        "type": "string",
+        "enum": [
+          "draft",
+          "submitted",
+          "reviewed",
+          "adopted",
+          "rejected",
+          "archived"
+        ],
+        "title": "ReportStatus",
+        "description": "리포트 상태."
       },
       "ReportSubmitRequest": {
         "properties": {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2647,6 +2647,12 @@ export type components = {
             [key: string]: unknown;
         };
         /**
+         * ReportStatus
+         * @description 리포트 상태.
+         * @enum {string}
+         */
+        ReportStatus: "draft" | "submitted" | "reviewed" | "adopted" | "rejected" | "archived";
+        /**
          * ReportSubmitRequest
          * @description 리포트 제출 요청.
          *
@@ -3377,6 +3383,7 @@ export type ReportDetailResponse = components['schemas']['ReportDetailResponse']
 export type ReportListItem = components['schemas']['ReportListItem'];
 export type ReportListResponse = components['schemas']['ReportListResponse'];
 export type ReportSchemaResponse = components['schemas']['ReportSchemaResponse'];
+export type ReportStatus = components['schemas']['ReportStatus'];
 export type ReportSubmitRequest = components['schemas']['ReportSubmitRequest'];
 export type ReportSubmitResponse = components['schemas']['ReportSubmitResponse'];
 export type RuleItem = components['schemas']['RuleItem'];
@@ -5644,7 +5651,7 @@ export interface operations {
             query?: {
                 cursor?: string | null;
                 limit?: number;
-                status?: string | null;
+                status?: components["schemas"]["ReportStatus"] | null;
             };
             header?: never;
             path?: never;

--- a/src/ante/web/routes/reports.py
+++ b/src/ante/web/routes/reports.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
+from ante.report.models import ReportStatus
 from ante.web.deps import get_audit_logger_optional, get_report_store
 from ante.web.schemas import (
     ReportDetailResponse,
@@ -176,7 +177,7 @@ async def report_view(
 )
 async def list_reports(
     report_store: Annotated[Any, Depends(get_report_store)],
-    status: str | None = None,
+    status: ReportStatus | None = None,
     limit: int = 20,
     cursor: str | None = None,
 ) -> dict:

--- a/tests/unit/test_report_routes_status_filter.py
+++ b/tests/unit/test_report_routes_status_filter.py
@@ -1,0 +1,121 @@
+"""GET /api/reports?status= 쿼리 파라미터 검증 테스트 (#1355).
+
+SSOT:
+- ``src/ante/report/models.py::ReportStatus`` (StrEnum:
+  draft/submitted/reviewed/adopted/rejected/archived).
+- ``src/ante/web/routes/reports.py::list_reports``.
+
+검증 대상:
+- 알려진 ``ReportStatus`` 값은 200 (valid pass-through 회귀 포함).
+- 미정의 status 값, 빈 문자열은 422.
+- ``status`` 미제공은 200 (전체 목록).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.report.models import ReportStatus, StrategyReport  # noqa: E402
+from ante.web.app import create_app  # noqa: E402
+
+
+@pytest.fixture
+async def db(tmp_path):
+    from ante.core import Database
+
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+async def report_store(db):
+    from ante.report.store import ReportStore
+
+    store = ReportStore(db)
+    await store.initialize()
+    return store
+
+
+@pytest.fixture
+def app(report_store):
+    return create_app(report_store=report_store)
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+@pytest.fixture
+async def seeded_reports(report_store):
+    """submitted 1건 + adopted 1건을 시드한다."""
+    await report_store.submit(
+        StrategyReport(
+            report_id="rpt-submitted-001",
+            strategy_name="alpha",
+            strategy_version="1.0",
+            strategy_path="strategies/alpha.py",
+            status=ReportStatus.SUBMITTED,
+            submitted_at=datetime(2026, 1, 2, tzinfo=UTC),
+        )
+    )
+    await report_store.submit(
+        StrategyReport(
+            report_id="rpt-adopted-001",
+            strategy_name="beta",
+            strategy_version="1.0",
+            strategy_path="strategies/beta.py",
+            status=ReportStatus.ADOPTED,
+            submitted_at=datetime(2026, 1, 3, tzinfo=UTC),
+        )
+    )
+
+
+class TestListReportsStatusFilter:
+    """GET /api/reports?status= 쿼리 파라미터 검증."""
+
+    def test_status_submitted_returns_200(self, client, seeded_reports):
+        """valid status='submitted'는 200을 반환한다 (현재는 store가
+        str.value를 호출하다 AttributeError → 500 발생, 본 PR이 수정).
+        """
+        res = client.get("/api/reports?status=submitted")
+        assert res.status_code == 200, res.text
+        data = res.json()
+        ids = [r["report_id"] for r in data["reports"]]
+        assert "rpt-submitted-001" in ids
+        assert "rpt-adopted-001" not in ids
+
+    def test_status_adopted_returns_200(self, client, seeded_reports):
+        """valid status='adopted'는 200을 반환한다."""
+        res = client.get("/api/reports?status=adopted")
+        assert res.status_code == 200, res.text
+        data = res.json()
+        ids = [r["report_id"] for r in data["reports"]]
+        assert "rpt-adopted-001" in ids
+        assert "rpt-submitted-001" not in ids
+
+    def test_status_unknown_value_returns_422(self, client, seeded_reports):
+        """알 수 없는 status는 422 (5xx 아님)."""
+        res = client.get("/api/reports?status=oracle_invalid_status")
+        assert res.status_code == 422, res.text
+
+    def test_status_empty_string_returns_422(self, client, seeded_reports):
+        """빈 문자열 status도 enum value가 아니므로 422."""
+        res = client.get("/api/reports?status=")
+        assert res.status_code == 422, res.text
+
+    def test_status_omitted_returns_all(self, client, seeded_reports):
+        """status 미제공은 전체 목록을 반환한다."""
+        res = client.get("/api/reports")
+        assert res.status_code == 200, res.text
+        data = res.json()
+        ids = {r["report_id"] for r in data["reports"]}
+        assert {"rpt-submitted-001", "rpt-adopted-001"}.issubset(ids)


### PR DESCRIPTION
Closes #1355

## Summary

이슈 #1355: `GET /api/reports?status=oracle_invalid_status`가 500 반환. 원인: `list_reports`가 `status: str`을 store에 그대로 넘기고 store가 `status.value`를 호출 → `AttributeError`.

## Changes

- **`src/ante/web/routes/reports.py`**: `list_reports.status`를 `ReportStatus | None = None` (StrEnum SSOT)로 변경. invalid → 422 자동.
- **`frontend/openapi.json`, `frontend/src/types/api.generated.ts`**: 재생성. `ReportStatus` enum schema export.
- **`tests/unit/test_report_routes_status_filter.py`** (5 cases): `submitted/adopted` → 200 (회귀 동시 fix), `invalid/empty` → 422, 생략 → 200.

## Codex Plan/Branch Review

- Plan: approve-implement (revise-plan 1회 후 — Literal 대안 제거).
- Branch: PASS @ \`3de24a2\` (1st attempt).

## Test Plan

- ruff check / format --check PASS
- `pytest tests/unit/test_report_routes_status_filter.py + 5 modules`: 139 passed
- frontend tsc/build PASS

## Follow-up (Non-Goals)

- `list_reports`의 `cursor` base64 decode 예외, `limit<=0` IndexError → 422 회귀 (별도 이슈).

🤖 Generated with [Claude Code](https://claude.com/claude-code)