### PR TITLE
fix(web): reject negative pagination limit across list endpoints (#1356)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3365,7 +3365,7 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "maximum": 100,
+              "maximum": 10000,
               "minimum": 1,
               "default": 50,
               "title": "Limit"

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1154,7 +1154,7 @@
           "audit"
         ],
         "summary": "List Audit Logs",
-        "description": "감사 로그 조회.",
+        "description": "감사 로그 조회.\n\nNOTE: ``limit``은 다른 list endpoint와 일관된 ``le=100``으로 검증한다.\n이전 구현은 ``min(limit, 200)``로 자동 클램프했으나, #1356에서\npagination contract 일관성을 위해 클램프를 제거하고 Query\nvalidation으로 대체했다 (101..200 범위 요청은 새로 422). 다른 caller가\n이 범위를 강제하면 별도 endpoint로 분리한다.",
         "operationId": "list_audit_logs_api_audit_get",
         "parameters": [
           {
@@ -1227,6 +1227,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
               "default": 50,
               "title": "Limit"
             }
@@ -1237,6 +1239,7 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "minimum": 0,
               "default": 0,
               "title": "Offset"
             }
@@ -3162,6 +3165,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
               "default": 20,
               "title": "Limit"
             }
@@ -3349,6 +3354,7 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "minimum": 0,
               "default": 0,
               "title": "Offset"
             }
@@ -3359,6 +3365,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
               "default": 50,
               "title": "Limit"
             }
@@ -3664,6 +3672,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
               "default": 20,
               "title": "Limit"
             }
@@ -3750,6 +3760,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
               "default": 20,
               "title": "Limit"
             }
@@ -4303,6 +4315,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
               "default": 50,
               "title": "Limit"
             }
@@ -4519,6 +4533,8 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
               "default": 20,
               "title": "Limit"
             }
@@ -4529,6 +4545,7 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "minimum": 0,
               "default": 0,
               "title": "Offset"
             }

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -307,6 +307,12 @@ export type paths = {
         /**
          * List Audit Logs
          * @description 감사 로그 조회.
+         *
+         *     NOTE: ``limit``은 다른 list endpoint와 일관된 ``le=100``으로 검증한다.
+         *     이전 구현은 ``min(limit, 200)``로 자동 클램프했으나, #1356에서
+         *     pagination contract 일관성을 위해 클램프를 제거하고 Query
+         *     validation으로 대체했다 (101..200 범위 요청은 새로 422). 다른 caller가
+         *     이 범위를 강제하면 별도 endpoint로 분리한다.
          */
         get: operations["list_audit_logs_api_audit_get"];
         put?: never;

--- a/src/ante/web/pagination.py
+++ b/src/ante/web/pagination.py
@@ -33,7 +33,15 @@ def paginate(
 
     Returns:
         {"items": [...], "next_cursor": "..." | None}
+
+    Raises:
+        ValueError: ``limit < 1``일 때. 라우트 단의 ``Query(ge=1)``이 1차
+            방어선이지만 helper 자체도 invariant를 보장한다 (#1356).
+            ``ante.web.errors.value_error_handler``가 400으로 매핑.
     """
+    if limit < 1:
+        raise ValueError("limit must be >= 1")
+
     if cursor:
         decoded = decode_cursor(cursor)
         start_idx = 0

--- a/src/ante/web/routes/audit.py
+++ b/src/ante/web/routes/audit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from ante.web.deps import get_audit_logger
 from ante.web.schemas import AuditLogListResponse
@@ -32,11 +32,17 @@ async def list_audit_logs(
     action: str | None = None,
     from_date: str | None = None,
     to_date: str | None = None,
-    limit: int = 50,
-    offset: int = 0,
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
 ) -> dict:
-    """감사 로그 조회."""
-    limit = min(limit, 200)
+    """감사 로그 조회.
+
+    NOTE: ``limit``은 다른 list endpoint와 일관된 ``le=100``으로 검증한다.
+    이전 구현은 ``min(limit, 200)``로 자동 클램프했으나, #1356에서
+    pagination contract 일관성을 위해 클램프를 제거하고 Query
+    validation으로 대체했다 (101..200 범위 요청은 새로 422). 다른 caller가
+    이 범위를 강제하면 별도 endpoint로 분리한다.
+    """
     logs = await audit_logger.query(
         member_id=member_id,
         action=action,

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -6,7 +6,7 @@ import json
 import logging
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field, ValidationError
 
 from ante.web.deps import (
@@ -68,7 +68,7 @@ async def list_bots(
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     registry: Annotated[Any | None, Depends(get_strategy_registry_optional)],
     account_id: str | None = None,
-    limit: int = 20,
+    limit: int = Query(default=20, ge=1, le=100),
     cursor: str | None = None,
 ) -> dict:
     """봇 목록 조회 (cursor 기반 페이지네이션)."""
@@ -893,7 +893,7 @@ async def get_bot_logs(
         Any | None, Depends(get_event_history_store_optional)
     ],
     eventbus: Annotated[Any | None, Depends(get_eventbus_optional)],
-    limit: int = 50,
+    limit: int = Query(default=50, ge=1, le=100),
 ) -> dict:
     """봇 실행 로그 조회.
 

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -38,7 +38,7 @@ async def list_datasets(
         None, description="데이터 유형 (ohlcv, fundamental, 미지정 시 전체)"
     ),
     offset: int = Query(default=0, ge=0),
-    limit: int = Query(default=50, ge=1, le=100),
+    limit: int = Query(default=50, ge=1, le=10000),
 ) -> dict:
     """보유 데이터셋 목록 (페이지네이션 지원).
 

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -37,8 +37,8 @@ async def list_datasets(
     data_type: Literal["ohlcv", "fundamental"] | None = Query(
         None, description="데이터 유형 (ohlcv, fundamental, 미지정 시 전체)"
     ),
-    offset: int = 0,
-    limit: int = 50,
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=50, ge=1, le=100),
 ) -> dict:
     """보유 데이터셋 목록 (페이지네이션 지원).
 

--- a/src/ante/web/routes/reports.py
+++ b/src/ante/web/routes/reports.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from ante.report.models import ReportStatus
 from ante.web.deps import get_audit_logger_optional, get_report_store
@@ -178,7 +178,7 @@ async def report_view(
 async def list_reports(
     report_store: Annotated[Any, Depends(get_report_store)],
     status: ReportStatus | None = None,
-    limit: int = 20,
+    limit: int = Query(default=20, ge=1, le=100),
     cursor: str | None = None,
 ) -> dict:
     """리포트 목록 조회 (cursor 기반 페이지네이션)."""

--- a/src/ante/web/routes/trades.py
+++ b/src/ante/web/routes/trades.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from ante.web.deps import get_trade_service
 from ante.web.schemas import TradeListResponse
@@ -31,7 +31,7 @@ async def list_trades(
     account_id: str | None = None,
     bot_id: str | None = None,
     symbol: str | None = None,
-    limit: int = 20,
+    limit: int = Query(default=20, ge=1, le=100),
     cursor: str | None = None,
 ) -> dict:
     """거래 기록 목록 조회 (cursor 기반 페이지네이션)."""

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -7,7 +7,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from ante.web.deps import (
@@ -200,8 +200,8 @@ async def list_transactions(
     bot_id: str | None = None,
     start_date: str | None = None,
     end_date: str | None = None,
-    limit: int = 20,
-    offset: int = 0,
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
 ) -> dict:
     """자금 변동 이력 조회."""
     db = getattr(treasury, "_db", None)

--- a/tests/unit/test_pagination_limit_validation.py
+++ b/tests/unit/test_pagination_limit_validation.py
@@ -1,0 +1,224 @@
+"""Pagination limit/offset Query 검증 테스트 (#1356).
+
+목록 API의 `limit`은 양수 범위(1..100)로 제한되어야 한다.
+잘못된 쿼리 파라미터(`limit=-1`, `limit=0`, `limit>100`)는
+422로 거부되어야 하며, pagination helper 내부 예외가 5xx로
+노출되어서는 안 된다.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ante.web.pagination import paginate
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# pagination helper invariant
+# ---------------------------------------------------------------------------
+
+
+class TestPaginateHelperLimitInvariant:
+    """`paginate()` helper의 invariant: limit < 1이면 ValueError."""
+
+    def test_paginate_negative_limit_raises(self) -> None:
+        with pytest.raises(ValueError, match="limit must be >= 1"):
+            paginate([{"id": "1"}], cursor_field="id", limit=-1, cursor=None)
+
+    def test_paginate_zero_limit_raises(self) -> None:
+        with pytest.raises(ValueError, match="limit must be >= 1"):
+            paginate([{"id": "1"}], cursor_field="id", limit=0, cursor=None)
+
+    def test_paginate_limit_one_ok(self) -> None:
+        result = paginate(
+            [{"id": "1"}, {"id": "2"}], cursor_field="id", limit=1, cursor=None
+        )
+        assert len(result["items"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# /api/bots
+# ---------------------------------------------------------------------------
+
+
+def _make_bots_app() -> TestClient:
+    mock_manager = MagicMock()
+    mock_manager.list_bots.return_value = [
+        {"bot_id": f"bot-{i}", "status": "running"} for i in range(3)
+    ]
+    return TestClient(create_app(bot_manager=mock_manager))
+
+
+class TestBotsLimitValidation:
+    def test_negative_limit_returns_422(self) -> None:
+        resp = _make_bots_app().get("/api/bots?limit=-1")
+        assert resp.status_code == 422
+
+    def test_zero_limit_returns_422(self) -> None:
+        resp = _make_bots_app().get("/api/bots?limit=0")
+        assert resp.status_code == 422
+
+    def test_limit_one_returns_200(self) -> None:
+        resp = _make_bots_app().get("/api/bots?limit=1")
+        assert resp.status_code == 200
+
+    def test_limit_default_returns_200(self) -> None:
+        resp = _make_bots_app().get("/api/bots?limit=20")
+        assert resp.status_code == 200
+
+    def test_limit_above_max_returns_422(self) -> None:
+        resp = _make_bots_app().get("/api/bots?limit=999")
+        assert resp.status_code == 422
+
+    def test_limit_at_max_returns_200(self) -> None:
+        resp = _make_bots_app().get("/api/bots?limit=100")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# /api/reports
+# ---------------------------------------------------------------------------
+
+
+def _make_reports_app() -> TestClient:
+    mock_store = AsyncMock()
+    r = MagicMock()
+    r.report_id = "rpt-0"
+    r.strategy_name = "s"
+    r.status.value = "submitted"
+    r.submitted_at = "2025-01-01"
+    mock_store.list_reports = AsyncMock(return_value=[r])
+    return TestClient(create_app(report_store=mock_store))
+
+
+class TestReportsLimitValidation:
+    def test_negative_limit_returns_422(self) -> None:
+        resp = _make_reports_app().get("/api/reports?limit=-1")
+        assert resp.status_code == 422
+
+    def test_above_max_returns_422(self) -> None:
+        resp = _make_reports_app().get("/api/reports?limit=999")
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /api/trades
+# ---------------------------------------------------------------------------
+
+
+def _make_trades_app() -> TestClient:
+    mock_service = AsyncMock()
+    t = MagicMock()
+    t.trade_id = "trd-0"
+    t.bot_id = "bot-1"
+    t.account_id = "acc-test"
+    t.symbol = "005930"
+    t.side = "buy"
+    t.quantity = 10
+    t.price = 70000
+    t.status.value = "filled"
+    t.timestamp = "2025-01-01"
+    mock_service.get_trades = AsyncMock(return_value=[t])
+    return TestClient(create_app(trade_service=mock_service))
+
+
+class TestTradesLimitValidation:
+    def test_negative_limit_returns_422(self) -> None:
+        resp = _make_trades_app().get("/api/trades?limit=-1")
+        assert resp.status_code == 422
+
+    def test_above_max_returns_422(self) -> None:
+        resp = _make_trades_app().get("/api/trades?limit=999")
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /api/data/datasets
+# ---------------------------------------------------------------------------
+
+
+def _make_data_app() -> TestClient:
+    # data_store 미주입 → 빈 결과 반환 (data.py: store is None branch)
+    return TestClient(create_app())
+
+
+class TestDataLimitValidation:
+    def test_negative_limit_returns_422(self) -> None:
+        resp = _make_data_app().get("/api/data/datasets?limit=-1")
+        assert resp.status_code == 422
+
+    def test_above_max_returns_422(self) -> None:
+        resp = _make_data_app().get("/api/data/datasets?limit=999")
+        assert resp.status_code == 422
+
+    def test_negative_offset_returns_422(self) -> None:
+        resp = _make_data_app().get("/api/data/datasets?offset=-1")
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /api/treasury/transactions
+# ---------------------------------------------------------------------------
+
+
+def _make_treasury_app() -> TestClient:
+    mock_treasury = MagicMock()
+    mock_treasury._db = None  # service unavailable → 빈 결과
+    return TestClient(create_app(treasury=mock_treasury))
+
+
+class TestTreasuryTxLimitValidation:
+    def test_negative_limit_returns_422(self) -> None:
+        resp = _make_treasury_app().get("/api/treasury/transactions?limit=-1")
+        assert resp.status_code == 422
+
+    def test_above_max_returns_422(self) -> None:
+        resp = _make_treasury_app().get("/api/treasury/transactions?limit=999")
+        assert resp.status_code == 422
+
+    def test_negative_offset_returns_422(self) -> None:
+        resp = _make_treasury_app().get("/api/treasury/transactions?offset=-1")
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /api/audit
+# ---------------------------------------------------------------------------
+
+
+def _make_audit_app() -> TestClient:
+    mock_logger = AsyncMock()
+    mock_logger.query = AsyncMock(return_value=[])
+    mock_logger.count = AsyncMock(return_value=0)
+    return TestClient(create_app(audit_logger=mock_logger))
+
+
+class TestAuditLimitValidation:
+    def test_negative_limit_returns_422(self) -> None:
+        resp = _make_audit_app().get("/api/audit?limit=-1")
+        assert resp.status_code == 422
+
+    def test_limit_at_max_returns_200(self) -> None:
+        resp = _make_audit_app().get("/api/audit?limit=100")
+        assert resp.status_code == 200
+
+    def test_limit_200_returns_422(self) -> None:
+        """Contract tightening: 기존 `min(limit, 200)` 제거. 100 초과는 422.
+
+        기존 audit 라우트는 `limit = min(limit, 200)`로 자동 클램프했으나,
+        다른 list endpoint와의 일관성 (`le=100`)을 위해 클램프 제거.
+        101..200 범위 요청이 새로 422로 거부된다 (breaking change).
+        """
+        resp = _make_audit_app().get("/api/audit?limit=200")
+        assert resp.status_code == 422
+
+    def test_negative_offset_returns_422(self) -> None:
+        resp = _make_audit_app().get("/api/audit?offset=-1")
+        assert resp.status_code == 422

--- a/tests/unit/test_pagination_limit_validation.py
+++ b/tests/unit/test_pagination_limit_validation.py
@@ -150,12 +150,29 @@ def _make_data_app() -> TestClient:
 
 
 class TestDataLimitValidation:
+    """`/api/data/datasets`는 dashboard caller (BacktestData.tsx)가
+    `limit=10000`으로 호출하므로 ceiling을 10000으로 둔다.
+
+    다른 list endpoints는 `le=100` 유지.
+    """
+
     def test_negative_limit_returns_422(self) -> None:
         resp = _make_data_app().get("/api/data/datasets?limit=-1")
         assert resp.status_code == 422
 
-    def test_above_max_returns_422(self) -> None:
+    def test_limit_999_returns_200(self) -> None:
+        """`le=10000` 적용 후 999는 통과 (기존 le=100 시에는 422였음)."""
         resp = _make_data_app().get("/api/data/datasets?limit=999")
+        assert resp.status_code == 200
+
+    def test_limit_at_max_returns_200(self) -> None:
+        """ceiling 값(10000)은 inclusive로 허용."""
+        resp = _make_data_app().get("/api/data/datasets?limit=10000")
+        assert resp.status_code == 200
+
+    def test_above_max_returns_422(self) -> None:
+        """ceiling 초과(10001)는 422."""
+        resp = _make_data_app().get("/api/data/datasets?limit=10001")
         assert resp.status_code == 422
 
     def test_negative_offset_returns_422(self) -> None:


### PR DESCRIPTION
Closes #1356

## Summary

이슈 #1356: `GET /api/bots,/api/reports,/api/trades`에 `limit=-1` 호출이 500 반환. 원인: paginate helper가 `len(items) > -1` 항상 true에서 `page[-1]` IndexError.

## Changes

- **`src/ante/web/routes/{bots,reports,trades}.py`** + **`bots.py:896`**: `limit` Query에 `Query(default=N, ge=1, le=100)` 적용. invalid → 422.
- **`src/ante/web/routes/{data,treasury,audit}.py`**: limit/offset 미검증 endpoint도 일관성 차원에서 같이 적용 (Codex Plan Review 권고). limit `ge=1, le=100` (data/datasets만 frontend BacktestData 호환을 위해 le=10000), offset `ge=0`.
- **`src/ante/web/routes/audit.py`**: 기존 `min(limit, 200)` 제거. **breaking change**: 101-200 범위 audit 요청은 이제 422 (caller 영향 조사 결과 frontend/route caller 0건 — storage 직접 호출만 있어 무관).
- **`src/ante/web/pagination.py::paginate`**: `if limit < 1: raise ValueError` defensive check 추가. errors.py 핸들러가 400으로 매핑.
- **`frontend/openapi.json`, `frontend/src/types/api.generated.ts`**: 재생성. limit/offset minimum/maximum 반영.
- **`tests/unit/test_pagination_limit_validation.py`** (25 cases): 회귀 테스트.

## Codex Plan/Branch Review

- Plan: approve-implement (revise-plan 1회 후 — le=100 일관성 + endpoint 3개 추가).
- Branch: PASS @ \`ec30829\` (2nd attempt — datasets le=10000 호환).

## Test Plan

- ruff PASS
- 광역 회귀 (`pytest -k "pagination or audit or treasury or trades or report or bot or dataset"`): 1021 passed
- frontend tsc/build PASS

## Follow-up (Non-Goals)

- cursor invalid base64 decode 422 (#1355 follow-up).
- pagination spec 재설계.

🤖 Generated with [Claude Code](https://claude.com/claude-code)