### PR TITLE
fix(approvals): validate status filter as ApprovalStatus enum (#1357)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -903,7 +903,7 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ApprovalStatus"
                 },
                 {
                   "type": "null"
@@ -5387,6 +5387,20 @@
         ],
         "title": "ApprovalListResponse",
         "description": "결재 목록 응답."
+      },
+      "ApprovalStatus": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "approved",
+          "execution_failed",
+          "rejected",
+          "on_hold",
+          "expired",
+          "cancelled"
+        ],
+        "title": "ApprovalStatus",
+        "description": "결재 상태."
       },
       "ApprovalStatusUpdate": {
         "properties": {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -1654,6 +1654,12 @@ export type components = {
             total: number;
         };
         /**
+         * ApprovalStatus
+         * @description 결재 상태.
+         * @enum {string}
+         */
+        ApprovalStatus: "pending" | "approved" | "execution_failed" | "rejected" | "on_hold" | "expired" | "cancelled";
+        /**
          * ApprovalStatusUpdate
          * @description 승인/거부 요청.
          */
@@ -3334,6 +3340,7 @@ export type AccountSuspendRequest = components['schemas']['AccountSuspendRequest
 export type ApprovalDetailResponse = components['schemas']['ApprovalDetailResponse'];
 export type ApprovalItem = components['schemas']['ApprovalItem'];
 export type ApprovalListResponse = components['schemas']['ApprovalListResponse'];
+export type ApprovalStatus = components['schemas']['ApprovalStatus'];
 export type ApprovalStatusUpdate = components['schemas']['ApprovalStatusUpdate'];
 export type ApprovalUpdateResponse = components['schemas']['ApprovalUpdateResponse'];
 export type AuditLogItem = components['schemas']['AuditLogItem'];
@@ -3917,7 +3924,7 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 search?: string | null;
-                status?: string | null;
+                status?: components["schemas"]["ApprovalStatus"] | null;
                 type?: string | null;
             };
             header?: never;

--- a/src/ante/web/routes/approvals.py
+++ b/src/ante/web/routes/approvals.py
@@ -9,6 +9,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
+from ante.approval.models import ApprovalStatus
 from ante.web.deps import (
     get_approval_service,
     get_audit_logger_optional,
@@ -48,7 +49,10 @@ class ApprovalStatusUpdate(BaseModel):
 )
 async def list_approvals(
     approval_service: Annotated[Any, Depends(get_approval_service)],
-    status: str | None = Query(default=None),
+    status: ApprovalStatus | None = Query(default=None),
+    # NOTE: ``type``은 본 PR scope 외 (frontend ApprovalType과 backend SSOT
+    # 옵션 정렬이 필요하므로 follow-up). enum 강제 시 frontend 일부 호출이
+    # 깨질 수 있어 ``str | None``을 유지한다 (Refs #1357 follow-up).
     type: str | None = Query(default=None),
     search: str | None = Query(default=None),
     offset: int = Query(default=0, ge=0),

--- a/tests/unit/test_approval_routes_filter_validation.py
+++ b/tests/unit/test_approval_routes_filter_validation.py
@@ -1,0 +1,123 @@
+"""GET /api/approvals?status=&type= 쿼리 파라미터 검증 테스트 (#1357).
+
+SSOT:
+- ``src/ante/approval/models.py::ApprovalStatus`` (StrEnum:
+  pending/approved/execution_failed/rejected/on_hold/expired/cancelled).
+- ``src/ante/approval/models.py::ApprovalType`` (StrEnum) — 본 PR scope 외.
+- ``src/ante/web/routes/approvals.py::list_approvals``.
+
+검증 대상 (본 PR scope):
+- 알려진 ``ApprovalStatus`` 값(pending/approved/rejected/execution_failed)은 200.
+- 미정의 status 값은 422.
+- ``status``+``type`` 둘 다 invalid면 status 우선 422.
+- ``type``만 invalid (현재 frontend mismatch로 deferred)면 200 + 빈 결과.
+- 둘 다 생략은 200 (전체 목록).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402
+
+
+@pytest.fixture
+async def db(tmp_path):
+    from ante.core import Database
+
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+async def approval_service(db):
+    from ante.approval.service import ApprovalService
+    from ante.eventbus.bus import EventBus
+
+    eventbus = EventBus()
+    svc = ApprovalService(db=db, eventbus=eventbus)
+    await svc.initialize()
+    return svc
+
+
+@pytest.fixture
+def app(approval_service):
+    return create_app(approval_service=approval_service)
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+@pytest.fixture
+async def seeded_approval(approval_service):
+    """pending 상태의 strategy_adopt 결재 1건 시드."""
+    return await approval_service.create(
+        type="strategy_adopt",
+        requester="agent-01",
+        title="전략 채택 요청",
+        body="테스트 전략",
+        reference_id="report-001",
+    )
+
+
+class TestListApprovalsStatusFilter:
+    """GET /api/approvals?status= 쿼리 파라미터 검증 (#1357)."""
+
+    def test_status_pending_returns_200(self, client, seeded_approval):
+        """valid status='pending'은 200을 반환한다."""
+        res = client.get("/api/approvals?status=pending")
+        assert res.status_code == 200, res.text
+        data = res.json()
+        assert data["total"] == 1
+        ids = [a["id"] for a in data["approvals"]]
+        assert seeded_approval.id in ids
+
+    def test_status_approved_returns_200(self, client, seeded_approval):
+        """valid status='approved'는 200 (시드는 pending이라 결과 0건)."""
+        res = client.get("/api/approvals?status=approved")
+        assert res.status_code == 200, res.text
+        assert res.json()["total"] == 0
+
+    def test_status_rejected_returns_200(self, client, seeded_approval):
+        """valid status='rejected'는 200."""
+        res = client.get("/api/approvals?status=rejected")
+        assert res.status_code == 200, res.text
+        assert res.json()["total"] == 0
+
+    def test_status_execution_failed_returns_200(self, client, seeded_approval):
+        """valid status='execution_failed'는 200."""
+        res = client.get("/api/approvals?status=execution_failed")
+        assert res.status_code == 200, res.text
+        assert res.json()["total"] == 0
+
+    def test_status_unknown_value_returns_422(self, client, seeded_approval):
+        """알 수 없는 status는 422 (200 빈 목록 아님)."""
+        res = client.get("/api/approvals?status=oracle_invalid")
+        assert res.status_code == 422, res.text
+
+    def test_status_and_type_both_invalid_returns_422(self, client, seeded_approval):
+        """status+type 둘 다 invalid면 status enum 검증이 우선 422를 반환한다."""
+        res = client.get("/api/approvals?status=oracle_invalid&type=oracle_invalid")
+        assert res.status_code == 422, res.text
+
+    def test_type_only_invalid_returns_200(self, client, seeded_approval):
+        """type만 invalid는 본 PR scope 외 (frontend ApprovalType mismatch로
+        follow-up). 현재는 type=str 그대로라 200 + 빈 결과를 반환한다.
+        """
+        res = client.get("/api/approvals?type=oracle_invalid")
+        assert res.status_code == 200, res.text
+        assert res.json()["total"] == 0
+
+    def test_filters_omitted_returns_all(self, client, seeded_approval):
+        """status/type 미제공은 전체 목록 200."""
+        res = client.get("/api/approvals")
+        assert res.status_code == 200, res.text
+        assert res.json()["total"] == 1


### PR DESCRIPTION
Closes #1357

## Summary

이슈 #1357: `GET /api/approvals?status=invalid&type=invalid`이 200 빈 결과 반환. 원인: status/type 문자열을 enum 검증 없이 그대로 전달.

본 PR은 `ApprovalStatus` strict 적용. `ApprovalType`은 frontend mismatch가 있어 follow-up 이슈로 분리.

## Changes

- **`src/ante/web/routes/approvals.py`**: `list_approvals.status: str | None` → `ApprovalStatus | None = None`. invalid → 422 자동.
- `type` 파라미터는 그대로 `str | None` 유지 (follow-up).
- **`frontend/openapi.json`, `frontend/src/types/api.generated.ts`**: 재생성. ApprovalStatus enum schema export.
- **`tests/unit/test_approval_routes_filter_validation.py`** (8 cases).

## Codex Plan/Branch Review

- Plan: approve-implement (revise-plan 1회 후 — type strict를 follow-up으로 분리).
- Branch: PASS @ \`2b44b65\` (1st attempt).

## Test Plan

- ruff PASS
- pytest 통합 (인접 6개 모듈): 166 passed
- 광역 회귀 unit: 4208 passed, 2 skipped
- frontend tsc/build PASS

## Follow-up

- "ApprovalType strict enum sync (frontend ↔ backend ApprovalType)": frontend의 `strategy_report`, `budget_allocate`, `live_switch`, `risk_alert` 옵션과 backend `ApprovalType` SSOT 정렬 후 `list_approvals.type`도 strict enum으로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)