### PR TITLE
fix(members): reject unknown list filter with 422 via enum (#1358)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1437,7 +1437,7 @@
           "members"
         ],
         "summary": "List Members",
-        "description": "멤버 목록 조회.",
+        "description": "멤버 목록 조회.\n\n``type``과 ``status``는 도메인 enum SSOT(``MemberType`` /\n``MemberStatus``)로 강제한다(#1358 — Codex Plan Review). 알 수 없는 값은\nFastAPI/Pydantic이 자동으로 422를 반환하므로 \"200 빈 목록\"으로 가려지지\n않는다. ``MemberService.list_members`` / ``count``는 ``str | None``을\n받으므로 ``StrEnum`` 인스턴스를 그대로 전달해도 SQL 비교(``type = ?`` /\n``status = ?``)에서 문자열로 동작한다.",
         "operationId": "list_members_api_members_get",
         "parameters": [
           {
@@ -1447,7 +1447,7 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "$ref": "#/components/schemas/MemberType"
                 },
                 {
                   "type": "null"
@@ -1479,7 +1479,7 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "$ref": "#/components/schemas/MemberStatus"
                 },
                 {
                   "type": "null"
@@ -6498,6 +6498,16 @@
         "title": "MemberScopesResponse",
         "description": "권한 범위 변경 응답."
       },
+      "MemberStatus": {
+        "type": "string",
+        "enum": [
+          "active",
+          "suspended",
+          "revoked"
+        ],
+        "title": "MemberStatus",
+        "description": "멤버 상태."
+      },
       "MemberTokenResponse": {
         "properties": {
           "member": {
@@ -6515,6 +6525,15 @@
         ],
         "title": "MemberTokenResponse",
         "description": "토큰 재발급 응답."
+      },
+      "MemberType": {
+        "type": "string",
+        "enum": [
+          "human",
+          "agent"
+        ],
+        "title": "MemberType",
+        "description": "멤버 타입."
       },
       "MonthlySummaryItem": {
         "properties": {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -691,6 +691,13 @@ export type paths = {
         /**
          * List Members
          * @description 멤버 목록 조회.
+         *
+         *     ``type``과 ``status``는 도메인 enum SSOT(``MemberType`` /
+         *     ``MemberStatus``)로 강제한다(#1358 — Codex Plan Review). 알 수 없는 값은
+         *     FastAPI/Pydantic이 자동으로 422를 반환하므로 "200 빈 목록"으로 가려지지
+         *     않는다. ``MemberService.list_members`` / ``count``는 ``str | None``을
+         *     받으므로 ``StrEnum`` 인스턴스를 그대로 전달해도 SQL 비교(``type = ?`` /
+         *     ``status = ?``)에서 문자열로 동작한다.
          */
         get: operations["list_members_api_members_get"];
         put?: never;
@@ -2400,6 +2407,12 @@ export type components = {
             member: components["schemas"]["MemberInfo"];
         };
         /**
+         * MemberStatus
+         * @description 멤버 상태.
+         * @enum {string}
+         */
+        MemberStatus: "active" | "suspended" | "revoked";
+        /**
          * MemberTokenResponse
          * @description 토큰 재발급 응답.
          */
@@ -2408,6 +2421,12 @@ export type components = {
             /** Token */
             token: string;
         };
+        /**
+         * MemberType
+         * @description 멤버 타입.
+         * @enum {string}
+         */
+        MemberType: "human" | "agent";
         /**
          * MeResponse
          * @description 현재 사용자 정보 응답.
@@ -3383,7 +3402,9 @@ export type MemberDetailResponse = components['schemas']['MemberDetailResponse']
 export type MemberInfo = components['schemas']['MemberInfo'];
 export type MemberListResponse = components['schemas']['MemberListResponse'];
 export type MemberScopesResponse = components['schemas']['MemberScopesResponse'];
+export type MemberStatus = components['schemas']['MemberStatus'];
 export type MemberTokenResponse = components['schemas']['MemberTokenResponse'];
+export type MemberType = components['schemas']['MemberType'];
 export type MeResponse = components['schemas']['MeResponse'];
 export type MonthlySummaryItem = components['schemas']['MonthlySummaryItem'];
 export type MonthlySummaryResponse = components['schemas']['MonthlySummaryResponse'];
@@ -5020,8 +5041,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 org?: string | null;
-                status?: string | null;
-                type?: string | null;
+                status?: components["schemas"]["MemberStatus"] | null;
+                type?: components["schemas"]["MemberType"] | null;
             };
             header?: never;
             path?: never;

--- a/src/ante/web/routes/members.py
+++ b/src/ante/web/routes/members.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 from ante.member.errors import PermissionDeniedError
+from ante.member.models import MemberStatus, MemberType
 from ante.web.deps import (
     get_audit_logger_optional,
     get_member_service,
@@ -230,13 +231,21 @@ MEMBER_SCOPES_UPDATE_REQUEST_SCHEMA: dict[str, Any] = {
 )
 async def list_members(
     svc: Annotated[Any, Depends(get_member_service)],
-    type: str | None = Query(default=None),
+    type: MemberType | None = Query(default=None),
     org: str | None = Query(default=None),
-    status: str | None = Query(default=None),
+    status: MemberStatus | None = Query(default=None),
     limit: int = Query(default=100, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
 ) -> dict:
-    """멤버 목록 조회."""
+    """멤버 목록 조회.
+
+    ``type``과 ``status``는 도메인 enum SSOT(``MemberType`` /
+    ``MemberStatus``)로 강제한다(#1358 — Codex Plan Review). 알 수 없는 값은
+    FastAPI/Pydantic이 자동으로 422를 반환하므로 "200 빈 목록"으로 가려지지
+    않는다. ``MemberService.list_members`` / ``count``는 ``str | None``을
+    받으므로 ``StrEnum`` 인스턴스를 그대로 전달해도 SQL 비교(``type = ?`` /
+    ``status = ?``)에서 문자열로 동작한다.
+    """
     try:
         members = await svc.list_members(
             member_type=type, org=org, status=status, limit=limit, offset=offset

--- a/tests/unit/test_member_routes_filter_validation.py
+++ b/tests/unit/test_member_routes_filter_validation.py
@@ -1,0 +1,177 @@
+"""GET /api/members?type=&status= 쿼리 파라미터 검증 테스트 (#1358).
+
+SSOT:
+- ``src/ante/member/models.py::MemberType`` (StrEnum: human/agent).
+- ``src/ante/member/models.py::MemberStatus`` (StrEnum:
+  active/suspended/revoked).
+- ``src/ante/web/routes/members.py::list_members``.
+
+검증 대상 (본 PR scope):
+- 알려진 ``MemberType`` 값(human/agent)과 ``MemberStatus``
+  값(active/suspended/revoked)은 200.
+- 미정의 type 값은 422.
+- 미정의 status 값은 422.
+- ``type``+``status`` 둘 다 invalid면 422.
+- 둘 다 생략은 200 (전체 목록).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402
+
+
+@dataclass
+class FakeMember:
+    member_id: str
+    type: str = "agent"
+    role: str = "default"
+    org: str = "default"
+    name: str = ""
+    emoji: str = ""
+    status: str = "active"
+    scopes: list[str] = field(default_factory=list)
+    token_hash: str = ""
+    password_hash: str = ""
+    recovery_key_hash: str = ""
+    created_at: str = ""
+    created_by: str = ""
+    last_active_at: str = ""
+    suspended_at: str = ""
+    revoked_at: str = ""
+    token_expires_at: str = ""
+
+
+class FakeMemberService:
+    """list_members / count만 사용하는 최소 stub."""
+
+    def __init__(self) -> None:
+        self._members: dict[str, FakeMember] = {}
+
+    async def list_members(
+        self,
+        member_type: str | None = None,
+        org: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[FakeMember]:
+        result = self._filtered(member_type=member_type, org=org, status=status)
+        return result[offset : offset + limit]
+
+    async def count(
+        self,
+        member_type: str | None = None,
+        org: str | None = None,
+        status: str | None = None,
+    ) -> int:
+        return len(self._filtered(member_type=member_type, org=org, status=status))
+
+    def _filtered(
+        self,
+        member_type: str | None = None,
+        org: str | None = None,
+        status: str | None = None,
+    ) -> list[FakeMember]:
+        result = list(self._members.values())
+        if member_type:
+            result = [m for m in result if m.type == str(member_type)]
+        if org:
+            result = [m for m in result if m.org == org]
+        if status:
+            result = [m for m in result if m.status == str(status)]
+        return result
+
+
+@pytest.fixture
+def member_service():
+    svc = FakeMemberService()
+    # 다양한 타입/상태 시드.
+    svc._members["agent-active"] = FakeMember(
+        member_id="agent-active", type="agent", status="active"
+    )
+    svc._members["agent-suspended"] = FakeMember(
+        member_id="agent-suspended", type="agent", status="suspended"
+    )
+    svc._members["human-active"] = FakeMember(
+        member_id="human-active", type="human", status="active"
+    )
+    svc._members["human-revoked"] = FakeMember(
+        member_id="human-revoked", type="human", status="revoked"
+    )
+    return svc
+
+
+@pytest.fixture
+def client(member_service):
+    app = create_app(member_service=member_service)
+    return TestClient(app)
+
+
+class TestListMembersTypeFilter:
+    """GET /api/members?type= 쿼리 파라미터 검증 (#1358)."""
+
+    def test_type_human_returns_200(self, client):
+        res = client.get("/api/members?type=human")
+        assert res.status_code == 200, res.text
+        ids = {m["member_id"] for m in res.json()["members"]}
+        assert ids == {"human-active", "human-revoked"}
+
+    def test_type_agent_returns_200(self, client):
+        res = client.get("/api/members?type=agent")
+        assert res.status_code == 200, res.text
+        ids = {m["member_id"] for m in res.json()["members"]}
+        assert ids == {"agent-active", "agent-suspended"}
+
+    def test_type_unknown_value_returns_422(self, client):
+        """알 수 없는 type은 422 (200 빈 목록 아님)."""
+        res = client.get("/api/members?type=oracle_invalid")
+        assert res.status_code == 422, res.text
+
+
+class TestListMembersStatusFilter:
+    """GET /api/members?status= 쿼리 파라미터 검증 (#1358)."""
+
+    def test_status_active_returns_200(self, client):
+        res = client.get("/api/members?status=active")
+        assert res.status_code == 200, res.text
+        ids = {m["member_id"] for m in res.json()["members"]}
+        assert ids == {"agent-active", "human-active"}
+
+    def test_status_suspended_returns_200(self, client):
+        res = client.get("/api/members?status=suspended")
+        assert res.status_code == 200, res.text
+        ids = {m["member_id"] for m in res.json()["members"]}
+        assert ids == {"agent-suspended"}
+
+    def test_status_revoked_returns_200(self, client):
+        res = client.get("/api/members?status=revoked")
+        assert res.status_code == 200, res.text
+        ids = {m["member_id"] for m in res.json()["members"]}
+        assert ids == {"human-revoked"}
+
+    def test_status_unknown_value_returns_422(self, client):
+        res = client.get("/api/members?status=oracle_invalid")
+        assert res.status_code == 422, res.text
+
+
+class TestListMembersBothInvalid:
+    def test_both_invalid_returns_422(self, client):
+        """type+status 모두 invalid면 422."""
+        res = client.get("/api/members?type=oracle_invalid&status=oracle_invalid")
+        assert res.status_code == 422, res.text
+
+
+class TestListMembersFiltersOmitted:
+    def test_filters_omitted_returns_all(self, client):
+        """type/status 미제공은 전체 목록 200."""
+        res = client.get("/api/members")
+        assert res.status_code == 200, res.text
+        assert res.json()["total"] == 4


### PR DESCRIPTION
Closes #1358

## Summary

이슈 #1358: `GET /api/members?type=invalid&status=invalid`이 200 빈 결과 반환. enum 검증 누락. backend MemberType/MemberStatus StrEnum SSOT를 그대로 적용.

## Changes

- **`src/ante/web/routes/members.py::list_members`**: `type: str | None` → `MemberType | None = None`, `status: str | None` → `MemberStatus | None = None`. invalid → 422 자동.
- **`frontend/openapi.json`, `frontend/src/types/api.generated.ts`**: 재생성. components.schemas에 MemberType/MemberStatus 등록.
- **`tests/unit/test_member_routes_filter_validation.py`** (9 cases).

## Codex Plan/Branch Review

- Plan: approve-implement (codex review 1차에서 frontend 도메인 SSOT 일치 확인 + treasury/data 인접 표면 follow-up 분리).
- Branch: `pip_freeze` finding은 worktree unstaged drift에 대한 false positive (PR diff에는 미포함). 다음 review에서 origin diff로 재검증.

## Test Plan

- ruff PASS
- pytest 광역 회귀: 4217 passed, 2 skipped
- 신규 테스트: 9 passed
- frontend tsc/build PASS

## Follow-up (Non-Goals)

- frontend `getMembers/useMembers` 호출자 type 좁힘.
- `/api/treasury/transactions::type` strict enum.
- `DELETE /api/data/datasets/{id}::data_type` strict (#1354 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)