### PR TITLE
fix(audit): require authenticated audit:read for /api/audit (#1359)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1154,7 +1154,7 @@
           "audit"
         ],
         "summary": "List Audit Logs",
-        "description": "감사 로그 조회.\n\n인증/권한:\n    oracle A7 시그니처(#1359)에서 본 라우트는 인증 없이 감사 로그 목록을\n    반환하고 있었다. 감사 로그는 운영 행위 추적 정보(member_id, action,\n    resource, IP 등)를 담으므로 ``require_master_caller`` (#1352에서 도입)\n    를 적용해 master 권한자만 조회 가능하도록 막는다. 인증 누락은 401,\n    non-master는 403. ``audit:read`` scope strict 모델은 ``Member.scopes``\n    가 자유 문자열이라 별도 정의가 필요하므로 본 PR scope 외 follow-up.\n\nNOTE: ``limit``은 다른 list endpoint와 일관된 ``le=100``으로 검증한다.\n이전 구현은 ``min(limit, 200)``로 자동 클램프했으나, #1356에서\npagination contract 일관성을 위해 클램프를 제거하고 Query\nvalidation으로 대체했다 (101..200 범위 요청은 새로 422). 다른 caller가\n이 범위를 강제하면 별도 endpoint로 분리한다.",
+        "description": "감사 로그 조회.\n\n인증/권한:\n    oracle A7 시그니처(#1359)에서 본 라우트는 인증 없이 감사 로그 목록을\n    반환하고 있었다. 감사 로그는 운영 행위 추적 정보(member_id, action,\n    resource, IP 등)를 담으므로 인증 가드를 적용한다. 인증 누락은 401,\n    권한 없음은 403.\n\n    Codex P2 (#1359 fix loop, 2차): 초기 패치는 ``require_master_caller``\n    를 그대로 적용해 ``master`` role만 허용했으나,\n    ``docs/specs/member/02-design-decisions.md:188-229`` 의 모니터링 agent\n    (``audit:read`` scope만 가진 default role)가 차단되는 문제가 있었다.\n    spec은 audit 도메인 read 권한을 ``master`` role 또는 ``audit:read``\n    scope 중 하나로 정의하므로, ``require_audit_read`` (master OR\n    ``audit:read`` ∈ Member.scopes)로 교체해 spec과 일치시켰다.\n\nCodex P2 (#1359 fix loop): FastAPI는 핸들러 매개변수 선언 순서대로\ndependency를 해결한다. ``audit_logger`` (필수 service, 미주입 시 503)를\n``require_audit_read`` 보다 먼저 두면, 인증 정보가 없는 호출자에게\n503이 먼저 반환되어 \"인증 누락은 401\" 계약이 깨진다. 그러므로 인증\n가드(``caller_id``)를 항상 먼저 선언해 401/403이 503보다 우선하도록 한다.\n\nNOTE: ``limit``은 다른 list endpoint와 일관된 ``le=100``으로 검증한다.\n이전 구현은 ``min(limit, 200)``로 자동 클램프했으나, #1356에서\npagination contract 일관성을 위해 클램프를 제거하고 Query\nvalidation으로 대체했다 (101..200 범위 요청은 새로 422). 다른 caller가\n이 범위를 강제하면 별도 endpoint로 분리한다.",
         "operationId": "list_audit_logs_api_audit_get",
         "parameters": [
           {
@@ -1267,7 +1267,7 @@
             }
           },
           "403": {
-            "description": "Master permission required",
+            "description": "Master role or audit:read scope required",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1154,7 +1154,7 @@
           "audit"
         ],
         "summary": "List Audit Logs",
-        "description": "감사 로그 조회.\n\nNOTE: ``limit``은 다른 list endpoint와 일관된 ``le=100``으로 검증한다.\n이전 구현은 ``min(limit, 200)``로 자동 클램프했으나, #1356에서\npagination contract 일관성을 위해 클램프를 제거하고 Query\nvalidation으로 대체했다 (101..200 범위 요청은 새로 422). 다른 caller가\n이 범위를 강제하면 별도 endpoint로 분리한다.",
+        "description": "감사 로그 조회.\n\n인증/권한:\n    oracle A7 시그니처(#1359)에서 본 라우트는 인증 없이 감사 로그 목록을\n    반환하고 있었다. 감사 로그는 운영 행위 추적 정보(member_id, action,\n    resource, IP 등)를 담으므로 ``require_master_caller`` (#1352에서 도입)\n    를 적용해 master 권한자만 조회 가능하도록 막는다. 인증 누락은 401,\n    non-master는 403. ``audit:read`` scope strict 모델은 ``Member.scopes``\n    가 자유 문자열이라 별도 정의가 필요하므로 본 PR scope 외 follow-up.\n\nNOTE: ``limit``은 다른 list endpoint와 일관된 ``le=100``으로 검증한다.\n이전 구현은 ``min(limit, 200)``로 자동 클램프했으나, #1356에서\npagination contract 일관성을 위해 클램프를 제거하고 Query\nvalidation으로 대체했다 (101..200 범위 요청은 새로 422). 다른 caller가\n이 범위를 강제하면 별도 endpoint로 분리한다.",
         "operationId": "list_audit_logs_api_audit_get",
         "parameters": [
           {
@@ -1252,6 +1252,26 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AuditLogListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Master permission required",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -308,6 +308,14 @@ export type paths = {
          * List Audit Logs
          * @description 감사 로그 조회.
          *
+         *     인증/권한:
+         *         oracle A7 시그니처(#1359)에서 본 라우트는 인증 없이 감사 로그 목록을
+         *         반환하고 있었다. 감사 로그는 운영 행위 추적 정보(member_id, action,
+         *         resource, IP 등)를 담으므로 ``require_master_caller`` (#1352에서 도입)
+         *         를 적용해 master 권한자만 조회 가능하도록 막는다. 인증 누락은 401,
+         *         non-master는 403. ``audit:read`` scope strict 모델은 ``Member.scopes``
+         *         가 자유 문자열이라 별도 정의가 필요하므로 본 PR scope 외 follow-up.
+         *
          *     NOTE: ``limit``은 다른 list endpoint와 일관된 ``le=100``으로 검증한다.
          *     이전 구현은 ``min(limit, 200)``로 자동 클램프했으나, #1356에서
          *     pagination contract 일관성을 위해 클램프를 제거하고 Query
@@ -4117,6 +4125,24 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AuditLogListResponse"];
+                };
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Master permission required */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Validation Error */

--- a/src/ante/web/deps.py
+++ b/src/ante/web/deps.py
@@ -257,6 +257,10 @@ _MASTER_AUTH_REQUIRED_DETAIL = (
 
 _MASTER_PERMISSION_DENIED_DETAIL = "이 작업은 master 권한이 필요합니다."
 
+_AUDIT_READ_PERMISSION_DENIED_DETAIL = (
+    "이 작업은 master 권한 또는 audit:read scope가 필요합니다."
+)
+
 
 async def require_master_caller(
     request: Request,
@@ -335,5 +339,90 @@ async def require_master_caller(
     role_value = getattr(role, "value", role)
     if member is None or role_value != MemberRole.MASTER.value:
         raise HTTPException(status_code=403, detail=_MASTER_PERMISSION_DENIED_DETAIL)
+
+    return caller
+
+
+async def require_audit_read(
+    request: Request,
+    member_service: Annotated[Any | None, Depends(get_member_service_optional)],
+    session_service: Annotated[Any | None, Depends(get_session_service_optional)],
+) -> str:
+    """Bearer 토큰 또는 ``ante_session`` 쿠키로 caller를 결정하고
+    ``master`` role 또는 ``audit:read`` scope 보유자를 허용하는 FastAPI dependency.
+
+    배경 (Codex P2 #1359 fix loop):
+        ``require_master_caller``를 ``GET /api/audit``에 그대로 적용하면
+        ``docs/specs/member/02-design-decisions.md:188-229`` 의 모니터링 agent
+        ("``audit:read`` scope만 보유한 default role agent")가 차단된다.
+        spec은 audit 도메인 read 권한을 ``master`` role 또는 ``audit:read``
+        scope 중 하나로 정의하므로, 이 dependency는 두 조건의 OR로 통과시킨다.
+
+    인증 절차는 ``require_master_caller``와 동일하다 (Bearer 우선,
+    ``session_service`` 가용 시 ``ante_session`` 쿠키 fallback,
+    ``session_service`` 미주입/예외/멤버 미존재는 모두 401/403으로 흡수).
+    유일한 차이는 권한 검증 분기다:
+
+    - caller_member.role == ``MemberRole.MASTER`` → 통과
+    - ``"audit:read"`` ∈ ``caller_member.scopes`` → 통과
+    - 둘 다 아니면 ``HTTPException(403)``
+
+    Returns:
+        caller_id (str): 인증/권한 검증을 통과한 member_id.
+
+    Raises:
+        HTTPException(401): 인증 누락/실패.
+        HTTPException(403): 인증은 통과했으나 master도 아니고 audit:read도 없음.
+    """
+    from ante.member.models import MemberRole
+
+    caller = getattr(request.state, "member_id", "") or ""
+
+    # Bearer 인증이 caller를 결정하지 못했고 session_service가 사용 가능하면
+    # ante_session 쿠키 fallback (#1351 SSOT 패턴, require_master_caller와 동일).
+    if not caller and session_service is not None:
+        ante_session = request.cookies.get("ante_session")
+        if ante_session:
+            try:
+                session = await session_service.validate(ante_session)
+            except Exception:
+                logger.exception(
+                    "세션 검증 실패 (session_id 일부=%s...)", ante_session[:8]
+                )
+                session = None
+            if session:
+                resolved = session.get("member_id", "") or ""
+                if resolved:
+                    caller = resolved
+                    request.state.member_id = caller
+
+    if not caller:
+        raise HTTPException(status_code=401, detail=_MASTER_AUTH_REQUIRED_DETAIL)
+
+    if member_service is None:
+        raise HTTPException(status_code=401, detail=_MASTER_AUTH_REQUIRED_DETAIL)
+
+    member = None
+    try:
+        member = await member_service.get(caller)
+    except Exception:
+        logger.exception("멤버 조회 실패 (member_id=%s)", caller)
+
+    if member is None:
+        raise HTTPException(
+            status_code=403, detail=_AUDIT_READ_PERMISSION_DENIED_DETAIL
+        )
+
+    role = getattr(member, "role", None)
+    role_value = getattr(role, "value", role)
+    is_master = role_value == MemberRole.MASTER.value
+
+    scopes = getattr(member, "scopes", None) or []
+    has_audit_read = "audit:read" in scopes
+
+    if not is_master and not has_audit_read:
+        raise HTTPException(
+            status_code=403, detail=_AUDIT_READ_PERMISSION_DENIED_DETAIL
+        )
 
     return caller

--- a/src/ante/web/deps.py
+++ b/src/ante/web/deps.py
@@ -261,6 +261,8 @@ _AUDIT_READ_PERMISSION_DENIED_DETAIL = (
     "이 작업은 human 멤버 또는 audit:read scope를 보유한 agent만 수행할 수 있습니다."
 )
 
+_MEMBER_INACTIVE_DETAIL = "멤버가 비활성 상태입니다."
+
 
 async def require_master_caller(
     request: Request,
@@ -365,6 +367,14 @@ async def require_audit_read(
     - ``"audit:read"`` ∈ caller_member.scopes → 통과 (agent의 정상 경로)
     - 그 외 (agent without scope) → ``HTTPException(403)``
 
+    배경 (Codex P2 #1359 fix loop 4차):
+        ``TokenAuthMiddleware``는 토큰 인증 시점에 비활성 멤버
+        (``status != ACTIVE``)를 거부하지만, ``ante_session`` 쿠키 fallback에서는
+        ``SessionService.validate``가 세션 만료만 검사하므로 suspended/revoked
+        상태로 전환된 멤버가 기존 세션을 그대로 사용해 통과할 수 있었다.
+        본 패치는 권한 분기 직전에 ``MemberStatus.ACTIVE`` 검사를 추가해 두
+        인증 경로 모두에서 비활성 멤버를 차단한다.
+
     인증 절차는 ``require_master_caller``와 동일하다 (Bearer 우선,
     ``session_service`` 가용 시 ``ante_session`` 쿠키 fallback,
     ``session_service`` 미주입/예외/멤버 미존재는 모두 401/403으로 흡수).
@@ -374,9 +384,10 @@ async def require_audit_read(
 
     Raises:
         HTTPException(401): 인증 누락/실패.
-        HTTPException(403): 인증은 통과했으나 audit 도메인 read 권한 없음.
+        HTTPException(403): 인증은 통과했으나 audit 도메인 read 권한 없음
+            또는 멤버 비활성 상태.
     """
-    from ante.member.models import MemberRole, MemberType
+    from ante.member.models import MemberRole, MemberStatus, MemberType
 
     caller = getattr(request.state, "member_id", "") or ""
 
@@ -414,6 +425,16 @@ async def require_audit_read(
         raise HTTPException(
             status_code=403, detail=_AUDIT_READ_PERMISSION_DENIED_DETAIL
         )
+
+    # 비활성 멤버 차단 (Codex P2 #1359 fix loop 4차).
+    # ``TokenAuthMiddleware``는 토큰 인증 시 비활성을 거부하지만 세션 쿠키
+    # fallback에서는 ``SessionService.validate``가 만료만 보므로, suspended/
+    # revoked 상태로 전환된 멤버가 통과할 수 있다. 권한 분기 직전에 명시적으로
+    # 차단해 두 경로 모두에서 일관된 invariant를 유지한다.
+    status = getattr(member, "status", None)
+    status_value = getattr(status, "value", status)
+    if status_value != MemberStatus.ACTIVE.value:
+        raise HTTPException(status_code=403, detail=_MEMBER_INACTIVE_DETAIL)
 
     role = getattr(member, "role", None)
     role_value = getattr(role, "value", role)

--- a/src/ante/web/deps.py
+++ b/src/ante/web/deps.py
@@ -258,7 +258,7 @@ _MASTER_AUTH_REQUIRED_DETAIL = (
 _MASTER_PERMISSION_DENIED_DETAIL = "이 작업은 master 권한이 필요합니다."
 
 _AUDIT_READ_PERMISSION_DENIED_DETAIL = (
-    "이 작업은 master 권한 또는 audit:read scope가 필요합니다."
+    "이 작업은 human 멤버 또는 audit:read scope를 보유한 agent만 수행할 수 있습니다."
 )
 
 
@@ -349,32 +349,34 @@ async def require_audit_read(
     session_service: Annotated[Any | None, Depends(get_session_service_optional)],
 ) -> str:
     """Bearer 토큰 또는 ``ante_session`` 쿠키로 caller를 결정하고
-    ``master`` role 또는 ``audit:read`` scope 보유자를 허용하는 FastAPI dependency.
+    audit 도메인 read 권한을 강제하는 FastAPI dependency.
 
-    배경 (Codex P2 #1359 fix loop):
-        ``require_master_caller``를 ``GET /api/audit``에 그대로 적용하면
-        ``docs/specs/member/02-design-decisions.md:188-229`` 의 모니터링 agent
-        ("``audit:read`` scope만 보유한 default role agent")가 차단된다.
-        spec은 audit 도메인 read 권한을 ``master`` role 또는 ``audit:read``
-        scope 중 하나로 정의하므로, 이 dependency는 두 조건의 OR로 통과시킨다.
+    배경 (Codex P2 #1359 fix loop 3차):
+        spec ``docs/specs/member/02-design-decisions.md:210-221`` 의
+        ``require_scope`` predicate는 ``member.type == "human"`` 이면 scope 검증을
+        무조건 통과시킨다. scope는 오직 agent 멤버를 제한하기 위한 장치이므로,
+        human admin/default 멤버도 audit 로그를 읽을 수 있어야 한다.
+        2차 패치는 master role 또는 ``audit:read`` scope만 허용해 human admin/
+        default 사용자를 403으로 차단하는 회귀가 있었다. 본 패치는 spec
+        predicate를 그대로 반영해 다음 OR 분기로 통과시킨다:
+
+    - caller_member.role == ``MemberRole.MASTER`` → 통과
+    - caller_member.type == ``MemberType.HUMAN`` → 통과 (scope 무관)
+    - ``"audit:read"`` ∈ caller_member.scopes → 통과 (agent의 정상 경로)
+    - 그 외 (agent without scope) → ``HTTPException(403)``
 
     인증 절차는 ``require_master_caller``와 동일하다 (Bearer 우선,
     ``session_service`` 가용 시 ``ante_session`` 쿠키 fallback,
     ``session_service`` 미주입/예외/멤버 미존재는 모두 401/403으로 흡수).
-    유일한 차이는 권한 검증 분기다:
-
-    - caller_member.role == ``MemberRole.MASTER`` → 통과
-    - ``"audit:read"`` ∈ ``caller_member.scopes`` → 통과
-    - 둘 다 아니면 ``HTTPException(403)``
 
     Returns:
         caller_id (str): 인증/권한 검증을 통과한 member_id.
 
     Raises:
         HTTPException(401): 인증 누락/실패.
-        HTTPException(403): 인증은 통과했으나 master도 아니고 audit:read도 없음.
+        HTTPException(403): 인증은 통과했으나 audit 도메인 read 권한 없음.
     """
-    from ante.member.models import MemberRole
+    from ante.member.models import MemberRole, MemberType
 
     caller = getattr(request.state, "member_id", "") or ""
 
@@ -417,10 +419,14 @@ async def require_audit_read(
     role_value = getattr(role, "value", role)
     is_master = role_value == MemberRole.MASTER.value
 
+    member_type = getattr(member, "type", None)
+    member_type_value = getattr(member_type, "value", member_type)
+    is_human = member_type_value == MemberType.HUMAN.value
+
     scopes = getattr(member, "scopes", None) or []
     has_audit_read = "audit:read" in scopes
 
-    if not is_master and not has_audit_read:
+    if not is_master and not is_human and not has_audit_read:
         raise HTTPException(
             status_code=403, detail=_AUDIT_READ_PERMISSION_DENIED_DETAIL
         )

--- a/src/ante/web/routes/audit.py
+++ b/src/ante/web/routes/audit.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query
 
-from ante.web.deps import get_audit_logger
+from ante.web.deps import get_audit_logger, require_master_caller
 from ante.web.schemas import AuditLogListResponse
 
 router = APIRouter()
@@ -16,6 +16,22 @@ router = APIRouter()
     "",
     response_model=AuditLogListResponse,
     responses={
+        401: {
+            "description": "Authentication required",
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
+        403: {
+            "description": "Master permission required",
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
         503: {
             "description": "Audit logger not available",
             "content": {
@@ -28,6 +44,7 @@ router = APIRouter()
 )
 async def list_audit_logs(
     audit_logger: Annotated[Any, Depends(get_audit_logger)],
+    caller_id: Annotated[str, Depends(require_master_caller)],
     member_id: str | None = None,
     action: str | None = None,
     from_date: str | None = None,
@@ -37,12 +54,26 @@ async def list_audit_logs(
 ) -> dict:
     """감사 로그 조회.
 
+    인증/권한:
+        oracle A7 시그니처(#1359)에서 본 라우트는 인증 없이 감사 로그 목록을
+        반환하고 있었다. 감사 로그는 운영 행위 추적 정보(member_id, action,
+        resource, IP 등)를 담으므로 ``require_master_caller`` (#1352에서 도입)
+        를 적용해 master 권한자만 조회 가능하도록 막는다. 인증 누락은 401,
+        non-master는 403. ``audit:read`` scope strict 모델은 ``Member.scopes``
+        가 자유 문자열이라 별도 정의가 필요하므로 본 PR scope 외 follow-up.
+
     NOTE: ``limit``은 다른 list endpoint와 일관된 ``le=100``으로 검증한다.
     이전 구현은 ``min(limit, 200)``로 자동 클램프했으나, #1356에서
     pagination contract 일관성을 위해 클램프를 제거하고 Query
     validation으로 대체했다 (101..200 범위 요청은 새로 422). 다른 caller가
     이 범위를 강제하면 별도 endpoint로 분리한다.
     """
+    # caller_id는 ``require_master_caller``가 ``request.state.member_id``에
+    # 이미 반영하고 ``AuditMiddleware``가 자동 감사 로그 주체로 사용한다.
+    # 핸들러 자체에서 audit query 필터로는 사용하지 않는다 (caller가 master
+    # 인 한 전체 로그 조회 권한을 가지며, 현재는 master-only이므로 이 정책이
+    # 안전하다). 변수 사용 표시를 위한 명시적 reference.
+    _ = caller_id
     logs = await audit_logger.query(
         member_id=member_id,
         action=action,

--- a/src/ante/web/routes/audit.py
+++ b/src/ante/web/routes/audit.py
@@ -43,8 +43,8 @@ router = APIRouter()
     },
 )
 async def list_audit_logs(
-    audit_logger: Annotated[Any, Depends(get_audit_logger)],
     caller_id: Annotated[str, Depends(require_master_caller)],
+    audit_logger: Annotated[Any, Depends(get_audit_logger)],
     member_id: str | None = None,
     action: str | None = None,
     from_date: str | None = None,
@@ -61,6 +61,12 @@ async def list_audit_logs(
         를 적용해 master 권한자만 조회 가능하도록 막는다. 인증 누락은 401,
         non-master는 403. ``audit:read`` scope strict 모델은 ``Member.scopes``
         가 자유 문자열이라 별도 정의가 필요하므로 본 PR scope 외 follow-up.
+
+    Codex P2 (#1359 fix loop): FastAPI는 핸들러 매개변수 선언 순서대로
+    dependency를 해결한다. ``audit_logger`` (필수 service, 미주입 시 503)를
+    ``require_master_caller`` 보다 먼저 두면, 인증 정보가 없는 호출자에게
+    503이 먼저 반환되어 "인증 누락은 401" 계약이 깨진다. 그러므로 인증
+    가드(``caller_id``)를 항상 먼저 선언해 401/403이 503보다 우선하도록 한다.
 
     NOTE: ``limit``은 다른 list endpoint와 일관된 ``le=100``으로 검증한다.
     이전 구현은 ``min(limit, 200)``로 자동 클램프했으나, #1356에서

--- a/src/ante/web/routes/audit.py
+++ b/src/ante/web/routes/audit.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query
 
-from ante.web.deps import get_audit_logger, require_master_caller
+from ante.web.deps import get_audit_logger, require_audit_read
 from ante.web.schemas import AuditLogListResponse
 
 router = APIRouter()
@@ -25,7 +25,7 @@ router = APIRouter()
             },
         },
         403: {
-            "description": "Master permission required",
+            "description": "Master role or audit:read scope required",
             "content": {
                 "application/problem+json": {
                     "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -43,7 +43,7 @@ router = APIRouter()
     },
 )
 async def list_audit_logs(
-    caller_id: Annotated[str, Depends(require_master_caller)],
+    caller_id: Annotated[str, Depends(require_audit_read)],
     audit_logger: Annotated[Any, Depends(get_audit_logger)],
     member_id: str | None = None,
     action: str | None = None,
@@ -57,14 +57,20 @@ async def list_audit_logs(
     인증/권한:
         oracle A7 시그니처(#1359)에서 본 라우트는 인증 없이 감사 로그 목록을
         반환하고 있었다. 감사 로그는 운영 행위 추적 정보(member_id, action,
-        resource, IP 등)를 담으므로 ``require_master_caller`` (#1352에서 도입)
-        를 적용해 master 권한자만 조회 가능하도록 막는다. 인증 누락은 401,
-        non-master는 403. ``audit:read`` scope strict 모델은 ``Member.scopes``
-        가 자유 문자열이라 별도 정의가 필요하므로 본 PR scope 외 follow-up.
+        resource, IP 등)를 담으므로 인증 가드를 적용한다. 인증 누락은 401,
+        권한 없음은 403.
+
+        Codex P2 (#1359 fix loop, 2차): 초기 패치는 ``require_master_caller``
+        를 그대로 적용해 ``master`` role만 허용했으나,
+        ``docs/specs/member/02-design-decisions.md:188-229`` 의 모니터링 agent
+        (``audit:read`` scope만 가진 default role)가 차단되는 문제가 있었다.
+        spec은 audit 도메인 read 권한을 ``master`` role 또는 ``audit:read``
+        scope 중 하나로 정의하므로, ``require_audit_read`` (master OR
+        ``audit:read`` ∈ Member.scopes)로 교체해 spec과 일치시켰다.
 
     Codex P2 (#1359 fix loop): FastAPI는 핸들러 매개변수 선언 순서대로
     dependency를 해결한다. ``audit_logger`` (필수 service, 미주입 시 503)를
-    ``require_master_caller`` 보다 먼저 두면, 인증 정보가 없는 호출자에게
+    ``require_audit_read`` 보다 먼저 두면, 인증 정보가 없는 호출자에게
     503이 먼저 반환되어 "인증 누락은 401" 계약이 깨진다. 그러므로 인증
     가드(``caller_id``)를 항상 먼저 선언해 401/403이 503보다 우선하도록 한다.
 
@@ -74,11 +80,12 @@ async def list_audit_logs(
     validation으로 대체했다 (101..200 범위 요청은 새로 422). 다른 caller가
     이 범위를 강제하면 별도 endpoint로 분리한다.
     """
-    # caller_id는 ``require_master_caller``가 ``request.state.member_id``에
+    # caller_id는 ``require_audit_read``가 ``request.state.member_id``에
     # 이미 반영하고 ``AuditMiddleware``가 자동 감사 로그 주체로 사용한다.
     # 핸들러 자체에서 audit query 필터로는 사용하지 않는다 (caller가 master
-    # 인 한 전체 로그 조회 권한을 가지며, 현재는 master-only이므로 이 정책이
-    # 안전하다). 변수 사용 표시를 위한 명시적 reference.
+    # 또는 audit:read scope를 가진 한 전체 로그 조회 권한을 가지며, 현재는
+    # 두 조건 OR 모델이므로 이 정책이 안전하다). 변수 사용 표시를 위한 명시적
+    # reference.
     _ = caller_id
     logs = await audit_logger.query(
         member_id=member_id,

--- a/tests/unit/test_audit_routes_auth.py
+++ b/tests/unit/test_audit_routes_auth.py
@@ -1,9 +1,9 @@
 """``GET /api/audit`` 인증 가드 테스트 (issue #1359).
 
 oracle A7 시그니처에서 발견된 ``list_audit_logs`` 라우트는 인증 없이도
-감사 로그 목록을 200으로 반환하고 있었다. 본 PR은 #1352에서 도입된
-``require_master_caller`` dependency를 ``GET /api/audit`` 에 적용해
-인증되지 않은 호출자가 감사 로그를 읽지 못하도록 막는다.
+감사 로그 목록을 200으로 반환하고 있었다. 본 PR은 ``GET /api/audit``에
+``require_audit_read`` dependency (master role OR ``audit:read`` scope)를
+적용해 인증되지 않은/권한 없는 호출자가 감사 로그를 읽지 못하도록 막는다.
 
 각 인증 시나리오:
 - Authorization 헤더 + 세션 쿠키 모두 없음 → 401
@@ -12,7 +12,10 @@ oracle A7 시그니처에서 발견된 ``list_audit_logs`` 라우트는 인증 �
 - ``session_service`` is None 배포 + Bearer 없음 → 401 (cookie fallback skip)
 - 정상 Bearer master → 200
 - 정상 ante_session master → 200
-- 인증된 non-master Bearer → 403
+- 인증된 non-master + ``audit:read`` scope 없음 → 403
+- 인증된 non-master + ``audit:read`` scope 보유 → 200
+  (Codex P2 #1359 fix loop 2차: spec
+   ``docs/specs/member/02-design-decisions.md:188-229`` 모니터링 agent 시나리오)
 
 401/403 응답 시 ``AuditLogger.query`` 는 호출되지 않아야 한다 (early return).
 
@@ -65,8 +68,14 @@ class FakeMemberService:
         token: str = "",
         role: str = "default",
         member_type: str = "agent",
+        scopes: list[str] | None = None,
     ) -> FakeMember:
-        member = FakeMember(member_id=member_id, role=role, type=member_type)
+        member = FakeMember(
+            member_id=member_id,
+            role=role,
+            type=member_type,
+            scopes=list(scopes) if scopes else [],
+        )
         self._members[member_id] = member
         if token:
             self._tokens[token] = member_id
@@ -132,6 +141,14 @@ def member_service() -> FakeMemberService:
     svc = FakeMemberService()
     svc.add_member("master-user", token="master-token", role="master")
     svc.add_member("agent-01", token="agent-token", role="default")
+    # 모니터링 agent: default role + audit:read scope만 보유
+    # (spec docs/specs/member/02-design-decisions.md:188-229).
+    svc.add_member(
+        "audit-reader",
+        token="audit-reader-token",
+        role="default",
+        scopes=["bot:read", "trade:read", "audit:read"],
+    )
     return svc
 
 
@@ -317,7 +334,7 @@ class TestSessionCookieMasterSuccess:
 
 
 class TestNonMaster403:
-    """인증된 non-master → 403, audit query 미호출."""
+    """인증된 non-master + ``audit:read`` scope 없음 → 403, audit query 미호출."""
 
     def test_non_master_bearer_returns_403(
         self, client: TestClient, audit_logger: AsyncMock
@@ -333,6 +350,36 @@ class TestNonMaster403:
             "403 차단 시 audit_logger.query가 호출되어선 안 된다"
         )
         assert audit_logger.count.await_count == 0
+
+
+# ── 200: audit:read scope 보유 non-master (Codex P2 #1359 fix loop 2차) ──
+
+
+class TestAuditReadScopeSuccess:
+    """non-master + ``audit:read`` scope → 200.
+
+    spec ``docs/specs/member/02-design-decisions.md:188-229`` 의 모니터링 agent
+    시나리오: default role이지만 ``audit:read`` scope를 가진 agent는 감사 로그
+    조회가 가능해야 한다. 1차 패치는 ``require_master_caller``로 모두 차단했으나,
+    2차 패치(``require_audit_read``)는 master OR ``audit:read`` ∈ scopes를 허용한다.
+    """
+
+    def test_non_master_with_audit_read_scope_succeeds(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        resp = client.get(
+            "/api/audit?limit=1",
+            headers={"Authorization": "Bearer audit-reader-token"},
+        )
+        assert resp.status_code == 200, (
+            f"audit:read scope 보유 default agent가 200이 아님 "
+            f"({resp.status_code}: {resp.text})"
+        )
+        body = resp.json()
+        assert "logs" in body
+        assert "total" in body
+        assert audit_logger.query.await_count == 1
+        assert audit_logger.count.await_count == 1
 
 
 # ── audit_logger 미주입 + 인증 dependency 순서 회귀 (Codex P2 #1359) ───

--- a/tests/unit/test_audit_routes_auth.py
+++ b/tests/unit/test_audit_routes_auth.py
@@ -2,8 +2,9 @@
 
 oracle A7 시그니처에서 발견된 ``list_audit_logs`` 라우트는 인증 없이도
 감사 로그 목록을 200으로 반환하고 있었다. 본 PR은 ``GET /api/audit``에
-``require_audit_read`` dependency (master role OR ``audit:read`` scope)를
-적용해 인증되지 않은/권한 없는 호출자가 감사 로그를 읽지 못하도록 막는다.
+``require_audit_read`` dependency (master role OR human bypass OR
+``audit:read`` scope)를 적용해 인증되지 않은/권한 없는 호출자가 감사 로그를
+읽지 못하도록 막는다.
 
 각 인증 시나리오:
 - Authorization 헤더 + 세션 쿠키 모두 없음 → 401
@@ -12,10 +13,14 @@ oracle A7 시그니처에서 발견된 ``list_audit_logs`` 라우트는 인증 �
 - ``session_service`` is None 배포 + Bearer 없음 → 401 (cookie fallback skip)
 - 정상 Bearer master → 200
 - 정상 ante_session master → 200
-- 인증된 non-master + ``audit:read`` scope 없음 → 403
-- 인증된 non-master + ``audit:read`` scope 보유 → 200
+- 인증된 agent non-master + ``audit:read`` scope 없음 → 403
+- 인증된 agent non-master + ``audit:read`` scope 보유 → 200
   (Codex P2 #1359 fix loop 2차: spec
    ``docs/specs/member/02-design-decisions.md:188-229`` 모니터링 agent 시나리오)
+- 인증된 human admin/default (scope 없어도) → 200
+  (Codex P2 #1359 fix loop 3차: spec
+   ``docs/specs/member/02-design-decisions.md:210-221`` ``require_scope``
+   predicate ``member.type == "human"`` 자동 통과)
 
 401/403 응답 시 ``AuditLogger.query`` 는 호출되지 않아야 한다 (early return).
 
@@ -139,15 +144,43 @@ def _make_audit_logger() -> AsyncMock:
 @pytest.fixture
 def member_service() -> FakeMemberService:
     svc = FakeMemberService()
-    svc.add_member("master-user", token="master-token", role="master")
-    svc.add_member("agent-01", token="agent-token", role="default")
+    # master는 spec상 type=human (docs/specs/member/02-design-decisions.md:236-247).
+    svc.add_member(
+        "master-user",
+        token="master-token",
+        role="master",
+        member_type="human",
+    )
+    # agent default — scope 없음 (403 회귀 케이스).
+    svc.add_member(
+        "agent-01",
+        token="agent-token",
+        role="default",
+        member_type="agent",
+    )
     # 모니터링 agent: default role + audit:read scope만 보유
     # (spec docs/specs/member/02-design-decisions.md:188-229).
     svc.add_member(
         "audit-reader",
         token="audit-reader-token",
         role="default",
+        member_type="agent",
         scopes=["bot:read", "trade:read", "audit:read"],
+    )
+    # human admin — scope 없어도 require_scope predicate 자동 통과
+    # (spec docs/specs/member/02-design-decisions.md:210-221).
+    svc.add_member(
+        "human-admin",
+        token="human-admin-token",
+        role="admin",
+        member_type="human",
+    )
+    # human default — scope 없어도 자동 통과.
+    svc.add_member(
+        "human-default",
+        token="human-default-token",
+        role="default",
+        member_type="human",
     )
     return svc
 
@@ -330,13 +363,13 @@ class TestSessionCookieMasterSuccess:
             client.cookies.delete("ante_session")
 
 
-# ── 403: 인증된 non-master ─────────────────────────────────────────────
+# ── 403: 인증된 agent non-master + scope 없음 ───────────────────────────
 
 
 class TestNonMaster403:
-    """인증된 non-master + ``audit:read`` scope 없음 → 403, audit query 미호출."""
+    """인증된 agent non-master + ``audit:read`` scope 없음 → 403, audit query 미호출."""
 
-    def test_non_master_bearer_returns_403(
+    def test_agent_default_without_scope_returns_403(
         self, client: TestClient, audit_logger: AsyncMock
     ) -> None:
         resp = client.get(
@@ -344,12 +377,59 @@ class TestNonMaster403:
             headers={"Authorization": "Bearer agent-token"},
         )
         assert resp.status_code == 403, (
-            f"non-master Bearer가 403이 아님 ({resp.status_code}: {resp.text})"
+            f"agent non-master Bearer가 403이 아님 ({resp.status_code}: {resp.text})"
         )
         assert audit_logger.query.await_count == 0, (
             "403 차단 시 audit_logger.query가 호출되어선 안 된다"
         )
         assert audit_logger.count.await_count == 0
+
+
+# ── 200: human 멤버 bypass (Codex P2 #1359 fix loop 3차) ───────────────
+
+
+class TestHumanBypassSuccess:
+    """human 멤버는 scope 검증을 자동 통과한다.
+
+    spec ``docs/specs/member/02-design-decisions.md:210-221`` 의
+    ``require_scope`` predicate: ``member.type == "human"`` → True.
+    scope는 오직 agent 제한 장치이므로 human admin/default 사용자는
+    audit:read scope를 보유하지 않아도 audit 로그 조회가 가능해야 한다.
+    """
+
+    def test_human_admin_without_scope_succeeds(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        """human admin (scope 없음) → 200."""
+        resp = client.get(
+            "/api/audit?limit=1",
+            headers={"Authorization": "Bearer human-admin-token"},
+        )
+        assert resp.status_code == 200, (
+            f"human admin (scope 없음)이 200이 아님 ({resp.status_code}: {resp.text})"
+        )
+        body = resp.json()
+        assert "logs" in body
+        assert "total" in body
+        assert audit_logger.query.await_count == 1
+        assert audit_logger.count.await_count == 1
+
+    def test_human_default_without_scope_succeeds(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        """human default (scope 없음) → 200."""
+        resp = client.get(
+            "/api/audit?limit=1",
+            headers={"Authorization": "Bearer human-default-token"},
+        )
+        assert resp.status_code == 200, (
+            f"human default (scope 없음)이 200이 아님 ({resp.status_code}: {resp.text})"
+        )
+        body = resp.json()
+        assert "logs" in body
+        assert "total" in body
+        assert audit_logger.query.await_count == 1
+        assert audit_logger.count.await_count == 1
 
 
 # ── 200: audit:read scope 보유 non-master (Codex P2 #1359 fix loop 2차) ──

--- a/tests/unit/test_audit_routes_auth.py
+++ b/tests/unit/test_audit_routes_auth.py
@@ -1,0 +1,345 @@
+"""``GET /api/audit`` 인증 가드 테스트 (issue #1359).
+
+oracle A7 시그니처에서 발견된 ``list_audit_logs`` 라우트는 인증 없이도
+감사 로그 목록을 200으로 반환하고 있었다. 본 PR은 #1352에서 도입된
+``require_master_caller`` dependency를 ``GET /api/audit`` 에 적용해
+인증되지 않은 호출자가 감사 로그를 읽지 못하도록 막는다.
+
+각 인증 시나리오:
+- Authorization 헤더 + 세션 쿠키 모두 없음 → 401
+- invalid Bearer token → 401
+- invalid 세션 쿠키 → 401
+- ``session_service`` is None 배포 + Bearer 없음 → 401 (cookie fallback skip)
+- 정상 Bearer master → 200
+- 정상 ante_session master → 200
+- 인증된 non-master Bearer → 403
+
+401/403 응답 시 ``AuditLogger.query`` 는 호출되지 않아야 한다 (early return).
+
+#1352 ``test_runtime_mutation_auth.py`` 패턴을 그대로 답습한다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402
+
+# ── Member / Session fakes (#1352 패턴) ──────────────────────────────────
+
+
+@dataclass
+class FakeMember:
+    member_id: str
+    type: str = "agent"
+    role: str = "default"
+    org: str = "default"
+    name: str = ""
+    emoji: str = ""
+    status: str = "active"
+    scopes: list[str] = field(default_factory=list)
+
+
+class FakeMemberService:
+    """테스트용 MemberService stub (#1352 동일 패턴).
+
+    토큰 → member_id 매핑으로 ``authenticate``를 흉내내고, ``get`` 메서드는
+    ``require_master_caller`` dependency가 호출하므로 정확한 ``Member`` 형태를
+    반환해야 한다.
+    """
+
+    def __init__(self) -> None:
+        self._members: dict[str, FakeMember] = {}
+        self._tokens: dict[str, str] = {}
+
+    def add_member(
+        self,
+        member_id: str,
+        token: str = "",
+        role: str = "default",
+        member_type: str = "agent",
+    ) -> FakeMember:
+        member = FakeMember(member_id=member_id, role=role, type=member_type)
+        self._members[member_id] = member
+        if token:
+            self._tokens[token] = member_id
+        return member
+
+    async def authenticate(self, token: str) -> FakeMember:
+        member_id = self._tokens.get(token)
+        if member_id is None:
+            raise PermissionError("유효하지 않은 토큰")
+        return self._members[member_id]
+
+    async def update_last_active(self, member_id: str) -> None:
+        return None
+
+    async def get(self, member_id: str) -> FakeMember | None:
+        return self._members.get(member_id)
+
+
+class FakeSessionService:
+    def __init__(self) -> None:
+        self._sessions: dict[str, str] = {}
+        self.validate_calls: list[str] = []
+
+    def add_session(self, session_id: str, member_id: str) -> None:
+        self._sessions[session_id] = member_id
+
+    async def validate(self, session_id: str) -> dict | None:
+        self.validate_calls.append(session_id)
+        member_id = self._sessions.get(session_id)
+        if member_id is None:
+            return None
+        return {"member_id": member_id, "created_at": "2026-05-09 00:00:00"}
+
+
+# ── audit_logger fake ───────────────────────────────────────────────────
+
+
+def _make_audit_logger() -> AsyncMock:
+    """query/count call_args를 추적할 수 있는 mock audit logger."""
+    mock = AsyncMock()
+    mock.query = AsyncMock(
+        return_value=[
+            {
+                "id": 1,
+                "member_id": "agent-01",
+                "action": "bot.create",
+                "resource": "bot:bot-1",
+                "detail": "",
+                "ip": "127.0.0.1",
+                "created_at": "2026-05-09T00:00:00",
+            }
+        ]
+    )
+    mock.count = AsyncMock(return_value=1)
+    return mock
+
+
+# ── fixtures ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def member_service() -> FakeMemberService:
+    svc = FakeMemberService()
+    svc.add_member("master-user", token="master-token", role="master")
+    svc.add_member("agent-01", token="agent-token", role="default")
+    return svc
+
+
+@pytest.fixture
+def session_service() -> FakeSessionService:
+    svc = FakeSessionService()
+    svc.add_session("master-session-id", member_id="master-user")
+    svc.add_session("agent-session-id", member_id="agent-01")
+    return svc
+
+
+@pytest.fixture
+def audit_logger() -> AsyncMock:
+    return _make_audit_logger()
+
+
+@pytest.fixture
+def client(
+    member_service: FakeMemberService,
+    session_service: FakeSessionService,
+    audit_logger: AsyncMock,
+) -> TestClient:
+    app = create_app(
+        member_service=member_service,
+        session_service=session_service,
+        audit_logger=audit_logger,
+    )
+    return TestClient(app)
+
+
+@pytest.fixture
+def client_no_session_service(
+    member_service: FakeMemberService,
+    audit_logger: AsyncMock,
+) -> TestClient:
+    """``session_service is None`` 배포 분기 시뮬레이션."""
+    app = create_app(
+        member_service=member_service,
+        audit_logger=audit_logger,
+    )
+    return TestClient(app)
+
+
+# ── 401: 인증 자체가 없는 케이스 ──────────────────────────────────────
+
+
+class TestNoAuth401:
+    """Authorization 헤더 + 세션 쿠키 모두 없음 → 401."""
+
+    def test_returns_401_without_any_auth(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        resp = client.get("/api/audit?limit=1")
+        assert resp.status_code == 401, (
+            f"인증 없는 호출이 401이 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert audit_logger.query.await_count == 0, (
+            "401 차단 시 audit_logger.query가 호출되어선 안 된다"
+        )
+        assert audit_logger.count.await_count == 0
+
+
+class TestInvalidBearerToken401:
+    """invalid Bearer token → 401, audit query 미호출."""
+
+    def test_returns_401_with_invalid_bearer(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        resp = client.get(
+            "/api/audit?limit=1",
+            headers={"Authorization": "Bearer invalid-token"},
+        )
+        assert resp.status_code == 401, (
+            f"invalid Bearer가 401이 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert audit_logger.query.await_count == 0
+        assert audit_logger.count.await_count == 0
+
+
+class TestInvalidSessionCookie401:
+    """등록되지 않은 ``ante_session`` 쿠키 → 401."""
+
+    def test_returns_401_with_invalid_session_cookie(
+        self,
+        client: TestClient,
+        audit_logger: AsyncMock,
+        session_service: FakeSessionService,
+    ) -> None:
+        client.cookies.set("ante_session", "unknown-session-id")
+        try:
+            resp = client.get("/api/audit?limit=1")
+            assert resp.status_code == 401, (
+                f"invalid 세션 쿠키가 401이 아님 ({resp.status_code}: {resp.text})"
+            )
+            assert audit_logger.query.await_count == 0
+            assert audit_logger.count.await_count == 0
+            assert "unknown-session-id" in session_service.validate_calls
+        finally:
+            client.cookies.delete("ante_session")
+
+
+class TestSessionServiceNoneFallbackSkip:
+    """``session_service is None`` 배포 분기 + Bearer 없음 → 401."""
+
+    def test_returns_401_when_session_service_none_and_no_bearer(
+        self,
+        client_no_session_service: TestClient,
+        audit_logger: AsyncMock,
+    ) -> None:
+        client_no_session_service.cookies.set("ante_session", "any-session-id")
+        try:
+            resp = client_no_session_service.get("/api/audit?limit=1")
+            assert resp.status_code == 401, (
+                f"session_service None + 쿠키만 있으면 401이어야 함 "
+                f"({resp.status_code}: {resp.text})"
+            )
+            assert audit_logger.query.await_count == 0
+            assert audit_logger.count.await_count == 0
+        finally:
+            client_no_session_service.cookies.delete("ante_session")
+
+
+# ── 200: 정상 인증 케이스 ───────────────────────────────────────────────
+
+
+class TestBearerMasterSuccess:
+    """master Bearer 토큰 → 200."""
+
+    def test_audit_with_master_bearer_succeeds(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        resp = client.get(
+            "/api/audit?limit=1",
+            headers={"Authorization": "Bearer master-token"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "logs" in body
+        assert "total" in body
+        assert audit_logger.query.await_count == 1
+        assert audit_logger.count.await_count == 1
+
+
+class TestSessionCookieMasterSuccess:
+    """master ``ante_session`` 쿠키 → 200."""
+
+    def test_audit_with_master_session_cookie_succeeds(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        client.cookies.set("ante_session", "master-session-id")
+        try:
+            resp = client.get("/api/audit?limit=1")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert "logs" in body
+            assert "total" in body
+            assert audit_logger.query.await_count == 1
+            assert audit_logger.count.await_count == 1
+        finally:
+            client.cookies.delete("ante_session")
+
+
+# ── 403: 인증된 non-master ─────────────────────────────────────────────
+
+
+class TestNonMaster403:
+    """인증된 non-master → 403, audit query 미호출."""
+
+    def test_non_master_bearer_returns_403(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        resp = client.get(
+            "/api/audit?limit=1",
+            headers={"Authorization": "Bearer agent-token"},
+        )
+        assert resp.status_code == 403, (
+            f"non-master Bearer가 403이 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert audit_logger.query.await_count == 0, (
+            "403 차단 시 audit_logger.query가 호출되어선 안 된다"
+        )
+        assert audit_logger.count.await_count == 0
+
+
+# ── OpenAPI 응답 401/403 회귀 ──────────────────────────────────────────
+
+
+class TestOpenAPIResponses401403:
+    """``GET /api/audit`` OpenAPI ``responses``에 401/403 항목이 있어야 한다.
+
+    ``frontend/openapi.json`` codegen 산출물이 401/403 분기를 인식할 수 있도록
+    contract에 명시해야 한다 (#1352와 동일한 contract-drift risk).
+    """
+
+    def test_openapi_lists_401_response(self) -> None:
+        app = create_app()
+        schema = app.openapi()
+        operation = schema["paths"]["/api/audit"]["get"]
+        responses = operation.get("responses", {})
+        assert "401" in responses, (
+            f"GET /api/audit 응답에 401 항목이 없음: {sorted(responses.keys())}"
+        )
+
+    def test_openapi_lists_403_response(self) -> None:
+        app = create_app()
+        schema = app.openapi()
+        operation = schema["paths"]["/api/audit"]["get"]
+        responses = operation.get("responses", {})
+        assert "403" in responses, (
+            f"GET /api/audit 응답에 403 항목이 없음: {sorted(responses.keys())}"
+        )

--- a/tests/unit/test_audit_routes_auth.py
+++ b/tests/unit/test_audit_routes_auth.py
@@ -175,6 +175,25 @@ def client_no_session_service(
     return TestClient(app)
 
 
+@pytest.fixture
+def client_no_audit_logger(
+    member_service: FakeMemberService,
+    session_service: FakeSessionService,
+) -> TestClient:
+    """``audit_logger is None`` 배포 분기 시뮬레이션 (Codex P2 #1359 fix loop).
+
+    ``get_audit_logger`` dependency가 503을 반환하는 환경에서 dependency
+    선언 순서가 잘못되면 인증 누락(401) 보다 503이 먼저 반환된다. 본 fixture는
+    그 분기를 재현해 시그니처 순서가 바뀌지 않았는지 회귀로 막는다.
+    """
+    app = create_app(
+        member_service=member_service,
+        session_service=session_service,
+        # audit_logger를 의도적으로 주입하지 않음 → get_audit_logger가 503
+    )
+    return TestClient(app)
+
+
 # ── 401: 인증 자체가 없는 케이스 ──────────────────────────────────────
 
 
@@ -314,6 +333,43 @@ class TestNonMaster403:
             "403 차단 시 audit_logger.query가 호출되어선 안 된다"
         )
         assert audit_logger.count.await_count == 0
+
+
+# ── audit_logger 미주입 + 인증 dependency 순서 회귀 (Codex P2 #1359) ───
+
+
+class TestAuditLoggerMissingDependencyOrder:
+    """``audit_logger`` 미주입 환경에서 dependency 선언 순서 회귀.
+
+    FastAPI는 핸들러 매개변수 순서대로 dependency를 해결하므로,
+    ``audit_logger`` (필수 service, 미주입 시 503)를 ``require_master_caller``
+    보다 먼저 두면 인증 누락 호출에 503이 먼저 반환되어 "인증 누락은 401"
+    계약을 깨뜨린다. 본 테스트는 그 회귀를 막는다.
+    """
+
+    def test_unauth_returns_401_even_when_audit_logger_missing(
+        self, client_no_audit_logger: TestClient
+    ) -> None:
+        """audit_logger 미주입 + 인증 누락 → 503이 아니라 401."""
+        resp = client_no_audit_logger.get("/api/audit?limit=1")
+        assert resp.status_code == 401, (
+            f"audit_logger 미주입 + 인증 누락은 401이어야 함 "
+            f"(503 우선이면 dependency 순서 회귀): "
+            f"{resp.status_code}: {resp.text}"
+        )
+
+    def test_master_returns_503_when_audit_logger_missing(
+        self, client_no_audit_logger: TestClient
+    ) -> None:
+        """audit_logger 미주입 + master Bearer → 503 (인증 통과 후 503)."""
+        resp = client_no_audit_logger.get(
+            "/api/audit?limit=1",
+            headers={"Authorization": "Bearer master-token"},
+        )
+        assert resp.status_code == 503, (
+            f"인증 통과 후 audit_logger 미주입은 503이어야 함: "
+            f"{resp.status_code}: {resp.text}"
+        )
 
 
 # ── OpenAPI 응답 401/403 회귀 ──────────────────────────────────────────

--- a/tests/unit/test_pagination_limit_validation.py
+++ b/tests/unit/test_pagination_limit_validation.py
@@ -210,20 +210,38 @@ class TestTreasuryTxLimitValidation:
 # ---------------------------------------------------------------------------
 
 
-def _make_audit_app() -> TestClient:
+def _make_audit_app() -> tuple[TestClient, dict[str, str]]:
+    """``GET /api/audit``는 #1359에서 ``require_master_caller`` 가 적용됐다.
+
+    pagination 검증 회귀 테스트용으로 master Bearer 토큰 + member_service stub
+    을 함께 주입해 인증 가드가 422 검증 흐름을 가리지 않도록 한다.
+    """
+    from tests.unit.test_audit_routes_auth import FakeMemberService
+
     mock_logger = AsyncMock()
     mock_logger.query = AsyncMock(return_value=[])
     mock_logger.count = AsyncMock(return_value=0)
-    return TestClient(create_app(audit_logger=mock_logger))
+    member_service = FakeMemberService()
+    member_service.add_member("master-user", token="master-token", role="master")
+    client = TestClient(
+        create_app(
+            audit_logger=mock_logger,
+            member_service=member_service,
+        )
+    )
+    headers = {"Authorization": "Bearer master-token"}
+    return client, headers
 
 
 class TestAuditLimitValidation:
     def test_negative_limit_returns_422(self) -> None:
-        resp = _make_audit_app().get("/api/audit?limit=-1")
+        client, headers = _make_audit_app()
+        resp = client.get("/api/audit?limit=-1", headers=headers)
         assert resp.status_code == 422
 
     def test_limit_at_max_returns_200(self) -> None:
-        resp = _make_audit_app().get("/api/audit?limit=100")
+        client, headers = _make_audit_app()
+        resp = client.get("/api/audit?limit=100", headers=headers)
         assert resp.status_code == 200
 
     def test_limit_200_returns_422(self) -> None:
@@ -233,9 +251,11 @@ class TestAuditLimitValidation:
         다른 list endpoint와의 일관성 (`le=100`)을 위해 클램프 제거.
         101..200 범위 요청이 새로 422로 거부된다 (breaking change).
         """
-        resp = _make_audit_app().get("/api/audit?limit=200")
+        client, headers = _make_audit_app()
+        resp = client.get("/api/audit?limit=200", headers=headers)
         assert resp.status_code == 422
 
     def test_negative_offset_returns_422(self) -> None:
-        resp = _make_audit_app().get("/api/audit?offset=-1")
+        client, headers = _make_audit_app()
+        resp = client.get("/api/audit?offset=-1", headers=headers)
         assert resp.status_code == 422

--- a/tests/unit/test_require_audit_read.py
+++ b/tests/unit/test_require_audit_read.py
@@ -27,7 +27,7 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException
 
-from ante.member.models import MemberRole, MemberType
+from ante.member.models import MemberRole, MemberStatus, MemberType
 from ante.web.deps import require_audit_read
 
 
@@ -37,6 +37,7 @@ class _StubMember:
     role: str
     type: str = MemberType.AGENT.value
     scopes: list[str] = field(default_factory=list)
+    status: str = MemberStatus.ACTIVE.value
 
 
 class _StubMemberService:
@@ -50,12 +51,14 @@ class _StubMemberService:
         role: str = "default",
         member_type: str = MemberType.AGENT.value,
         scopes: list[str] | None = None,
+        status: str = MemberStatus.ACTIVE.value,
     ) -> None:
         self._members[member_id] = _StubMember(
             member_id=member_id,
             role=role,
             type=member_type,
             scopes=list(scopes) if scopes else [],
+            status=status,
         )
 
     async def get(self, member_id: str) -> _StubMember | None:
@@ -383,6 +386,93 @@ async def test_raises_403_when_caller_id_unknown_to_member_service() -> None:
     """
     svc = _StubMemberService()
     request = _make_request(state_member_id="ghost-id")
+
+    with pytest.raises(HTTPException) as exc:
+        await require_audit_read(request, svc, None)
+
+    assert exc.value.status_code == 403
+
+
+# ── 403: 비활성 멤버 차단 (Codex P2 #1359 fix loop 4차) ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_raises_403_when_master_suspended() -> None:
+    """master role이지만 ``status == SUSPENDED`` → 403.
+
+    ``TokenAuthMiddleware``는 토큰 경로에서 비활성 멤버를 거부하지만
+    ``ante_session`` 쿠키 fallback은 ``SessionService.validate``가 만료만
+    검사하므로, 권한 분기 직전에 명시적으로 차단해야 한다.
+    """
+    svc = _StubMemberService()
+    svc.add(
+        "master-suspended",
+        role=MemberRole.MASTER.value,
+        member_type=MemberType.HUMAN.value,
+        status=MemberStatus.SUSPENDED.value,
+    )
+    request = _make_request(state_member_id="master-suspended")
+
+    with pytest.raises(HTTPException) as exc:
+        await require_audit_read(request, svc, None)
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_raises_403_when_master_revoked() -> None:
+    """master role이지만 ``status == REVOKED`` → 403."""
+    svc = _StubMemberService()
+    svc.add(
+        "master-revoked",
+        role=MemberRole.MASTER.value,
+        member_type=MemberType.HUMAN.value,
+        status=MemberStatus.REVOKED.value,
+    )
+    request = _make_request(state_member_id="master-revoked")
+
+    with pytest.raises(HTTPException) as exc:
+        await require_audit_read(request, svc, None)
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_raises_403_when_human_admin_suspended() -> None:
+    """human admin (type bypass 대상)이라도 ``status == SUSPENDED`` → 403.
+
+    type bypass가 status 검사보다 우선해서는 안 된다.
+    """
+    svc = _StubMemberService()
+    svc.add(
+        "human-admin-suspended",
+        role=MemberRole.ADMIN.value,
+        member_type=MemberType.HUMAN.value,
+        status=MemberStatus.SUSPENDED.value,
+    )
+    request = _make_request(state_member_id="human-admin-suspended")
+
+    with pytest.raises(HTTPException) as exc:
+        await require_audit_read(request, svc, None)
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_raises_403_when_agent_with_audit_read_scope_suspended() -> None:
+    """agent + ``audit:read`` scope 보유라도 ``status == SUSPENDED`` → 403.
+
+    scope 보유가 status 검사보다 우선해서는 안 된다.
+    """
+    svc = _StubMemberService()
+    svc.add(
+        "monitor-agent-suspended",
+        role=MemberRole.DEFAULT.value,
+        member_type=MemberType.AGENT.value,
+        scopes=["audit:read"],
+        status=MemberStatus.SUSPENDED.value,
+    )
+    request = _make_request(state_member_id="monitor-agent-suspended")
 
     with pytest.raises(HTTPException) as exc:
         await require_audit_read(request, svc, None)

--- a/tests/unit/test_require_audit_read.py
+++ b/tests/unit/test_require_audit_read.py
@@ -1,16 +1,22 @@
-"""``require_audit_read`` dependency 단위 테스트 (issue #1359 Codex P2 fix loop 2차).
+"""``require_audit_read`` dependency 단위 테스트 (issue #1359 Codex P2 fix loop 3차).
 
 dependency 자체의 동작(Bearer 우선, 쿠키 fallback, session_service None skip,
-master OR ``audit:read`` scope 검증, ``request.state.member_id`` 갱신)을 라우트
-통합 없이 검증한다. 라우트 통합 테스트는
+human bypass / master / ``audit:read`` scope 검증, ``request.state.member_id``
+갱신)을 라우트 통합 없이 검증한다. 라우트 통합 테스트는
 ``tests/unit/test_audit_routes_auth.py``에 있다.
 
 배경:
-    초기 패치는 ``GET /api/audit``에 ``require_master_caller``를 적용해 master
-    role만 허용했다. 그러나 spec ``docs/specs/member/02-design-decisions.md:188-229``
-    은 audit 도메인 read 권한을 ``master`` role 또는 ``audit:read`` scope 중
-    하나로 정의하므로, 모니터링 전용 agent(default role + ``audit:read`` scope)
-    가 차단되는 회귀가 발생했다. 본 dependency는 두 조건의 OR로 통과시킨다.
+    1차 패치는 ``GET /api/audit``에 ``require_master_caller``를 적용해 master
+    role만 허용했다. 2차 패치는 ``master`` 또는 ``audit:read`` scope OR로 완화했지만
+    human admin/default 사용자를 여전히 403으로 차단했다. spec
+    ``docs/specs/member/02-design-decisions.md:210-221`` 의 ``require_scope``
+    predicate는 ``member.type == "human"`` 이면 scope 검증을 무조건 통과시키므로,
+    3차 패치(현재)는 다음 OR 분기를 적용한다:
+
+    - master role → 통과
+    - human 멤버 → 통과 (scope 무관)
+    - ``audit:read`` ∈ scopes → 통과 (agent의 정상 경로)
+    - 그 외 (agent without scope) → 403
 """
 
 from __future__ import annotations
@@ -21,7 +27,7 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException
 
-from ante.member.models import MemberRole
+from ante.member.models import MemberRole, MemberType
 from ante.web.deps import require_audit_read
 
 
@@ -29,6 +35,7 @@ from ante.web.deps import require_audit_read
 class _StubMember:
     member_id: str
     role: str
+    type: str = MemberType.AGENT.value
     scopes: list[str] = field(default_factory=list)
 
 
@@ -41,11 +48,13 @@ class _StubMemberService:
         self,
         member_id: str,
         role: str = "default",
+        member_type: str = MemberType.AGENT.value,
         scopes: list[str] | None = None,
     ) -> None:
         self._members[member_id] = _StubMember(
             member_id=member_id,
             role=role,
+            type=member_type,
             scopes=list(scopes) if scopes else [],
         )
 
@@ -97,7 +106,11 @@ def _make_request(
 async def test_returns_caller_when_bearer_master() -> None:
     """master role → 통과 (scope와 무관)."""
     svc = _StubMemberService()
-    svc.add("master-user", role=MemberRole.MASTER.value)
+    svc.add(
+        "master-user",
+        role=MemberRole.MASTER.value,
+        member_type=MemberType.HUMAN.value,
+    )
     request = _make_request(state_member_id="master-user")
 
     caller = await require_audit_read(request, svc, None)
@@ -107,8 +120,51 @@ async def test_returns_caller_when_bearer_master() -> None:
 
 
 @pytest.mark.asyncio
+async def test_returns_caller_when_human_admin_without_scope() -> None:
+    """human admin 멤버 → 통과 (scope 미보유여도 human bypass).
+
+    spec docs/specs/member/02-design-decisions.md:210-221 ``require_scope``
+    predicate: ``member.type == "human"`` 이면 scope 검증 자동 통과.
+    """
+    svc = _StubMemberService()
+    svc.add(
+        "human-admin",
+        role=MemberRole.ADMIN.value,
+        member_type=MemberType.HUMAN.value,
+        scopes=[],
+    )
+    request = _make_request(state_member_id="human-admin")
+
+    caller = await require_audit_read(request, svc, None)
+
+    assert caller == "human-admin"
+    assert svc.calls == ["human-admin"]
+
+
+@pytest.mark.asyncio
+async def test_returns_caller_when_human_default_without_scope() -> None:
+    """human default 멤버 → 통과 (scope 미보유여도 human bypass).
+
+    spec ``require_scope`` predicate는 type만 보고 scope 비검사.
+    """
+    svc = _StubMemberService()
+    svc.add(
+        "human-default",
+        role=MemberRole.DEFAULT.value,
+        member_type=MemberType.HUMAN.value,
+        scopes=[],
+    )
+    request = _make_request(state_member_id="human-default")
+
+    caller = await require_audit_read(request, svc, None)
+
+    assert caller == "human-default"
+    assert svc.calls == ["human-default"]
+
+
+@pytest.mark.asyncio
 async def test_returns_caller_when_default_with_audit_read_scope() -> None:
-    """default role + ``audit:read`` scope → 통과 (모니터링 agent 시나리오).
+    """agent default role + ``audit:read`` scope → 통과 (모니터링 agent 시나리오).
 
     spec docs/specs/member/02-design-decisions.md:188-229 모니터링 agent.
     """
@@ -116,6 +172,7 @@ async def test_returns_caller_when_default_with_audit_read_scope() -> None:
     svc.add(
         "monitor-agent",
         role=MemberRole.DEFAULT.value,
+        member_type=MemberType.AGENT.value,
         scopes=["bot:read", "trade:read", "audit:read"],
     )
     request = _make_request(state_member_id="monitor-agent")
@@ -128,9 +185,14 @@ async def test_returns_caller_when_default_with_audit_read_scope() -> None:
 
 @pytest.mark.asyncio
 async def test_returns_caller_when_admin_with_audit_read_scope() -> None:
-    """admin role + ``audit:read`` scope → 통과."""
+    """agent admin role + ``audit:read`` scope → 통과."""
     svc = _StubMemberService()
-    svc.add("admin-1", role=MemberRole.ADMIN.value, scopes=["audit:read"])
+    svc.add(
+        "admin-1",
+        role=MemberRole.ADMIN.value,
+        member_type=MemberType.AGENT.value,
+        scopes=["audit:read"],
+    )
     request = _make_request(state_member_id="admin-1")
 
     caller = await require_audit_read(request, svc, None)
@@ -140,11 +202,12 @@ async def test_returns_caller_when_admin_with_audit_read_scope() -> None:
 
 @pytest.mark.asyncio
 async def test_falls_back_to_session_cookie_when_bearer_missing() -> None:
-    """Bearer 미설정 + 유효 세션 쿠키(audit:read 보유) → caller 결정 + state 갱신."""
+    """Bearer 미설정 + 유효 세션 쿠키(agent + audit:read) → caller 결정 + state 갱신."""
     member_svc = _StubMemberService()
     member_svc.add(
         "cookie-monitor",
         role=MemberRole.DEFAULT.value,
+        member_type=MemberType.AGENT.value,
         scopes=["audit:read"],
     )
 
@@ -165,7 +228,11 @@ async def test_falls_back_to_session_cookie_when_bearer_missing() -> None:
 async def test_bearer_caller_takes_precedence_over_cookie() -> None:
     """Bearer 토큰이 caller를 결정하면 쿠키 검증을 다시 호출하지 않는다."""
     member_svc = _StubMemberService()
-    member_svc.add("bearer-master", role=MemberRole.MASTER.value)
+    member_svc.add(
+        "bearer-master",
+        role=MemberRole.MASTER.value,
+        member_type=MemberType.HUMAN.value,
+    )
     session_svc = _StubSessionService()
     session_svc.add_session("sid-1", "cookie-user")
 
@@ -253,10 +320,15 @@ async def test_raises_401_when_member_service_missing() -> None:
 
 
 @pytest.mark.asyncio
-async def test_raises_403_when_default_without_audit_read_scope() -> None:
-    """default role + ``audit:read`` 미보유 → 403."""
+async def test_raises_403_when_agent_default_without_audit_read_scope() -> None:
+    """agent default role + ``audit:read`` 미보유 → 403."""
     svc = _StubMemberService()
-    svc.add("plain-agent", role=MemberRole.DEFAULT.value, scopes=["bot:read"])
+    svc.add(
+        "plain-agent",
+        role=MemberRole.DEFAULT.value,
+        member_type=MemberType.AGENT.value,
+        scopes=["bot:read"],
+    )
     request = _make_request(state_member_id="plain-agent")
 
     with pytest.raises(HTTPException) as exc:
@@ -266,10 +338,15 @@ async def test_raises_403_when_default_without_audit_read_scope() -> None:
 
 
 @pytest.mark.asyncio
-async def test_raises_403_when_default_with_empty_scopes() -> None:
-    """default role + scopes 비어있음 → 403."""
+async def test_raises_403_when_agent_default_with_empty_scopes() -> None:
+    """agent default role + scopes 비어있음 → 403."""
     svc = _StubMemberService()
-    svc.add("plain-agent", role=MemberRole.DEFAULT.value, scopes=[])
+    svc.add(
+        "plain-agent",
+        role=MemberRole.DEFAULT.value,
+        member_type=MemberType.AGENT.value,
+        scopes=[],
+    )
     request = _make_request(state_member_id="plain-agent")
 
     with pytest.raises(HTTPException) as exc:
@@ -279,12 +356,16 @@ async def test_raises_403_when_default_with_empty_scopes() -> None:
 
 
 @pytest.mark.asyncio
-async def test_raises_403_when_admin_without_audit_read_scope() -> None:
-    """admin role + ``audit:read`` 미보유 → 403 (admin도 자동 통과 아님)."""
+async def test_raises_403_when_agent_admin_without_audit_read_scope() -> None:
+    """agent admin role + ``audit:read`` 미보유 → 403 (agent admin은 자동 통과 아님).
+
+    agent는 type bypass 대상이 아니므로 scope 검증을 받는다.
+    """
     svc = _StubMemberService()
     svc.add(
         "admin-no-scope",
         role=MemberRole.ADMIN.value,
+        member_type=MemberType.AGENT.value,
         scopes=["bot:admin", "approval:write"],
     )
     request = _make_request(state_member_id="admin-no-scope")

--- a/tests/unit/test_require_audit_read.py
+++ b/tests/unit/test_require_audit_read.py
@@ -1,0 +1,309 @@
+"""``require_audit_read`` dependency 단위 테스트 (issue #1359 Codex P2 fix loop 2차).
+
+dependency 자체의 동작(Bearer 우선, 쿠키 fallback, session_service None skip,
+master OR ``audit:read`` scope 검증, ``request.state.member_id`` 갱신)을 라우트
+통합 없이 검증한다. 라우트 통합 테스트는
+``tests/unit/test_audit_routes_auth.py``에 있다.
+
+배경:
+    초기 패치는 ``GET /api/audit``에 ``require_master_caller``를 적용해 master
+    role만 허용했다. 그러나 spec ``docs/specs/member/02-design-decisions.md:188-229``
+    은 audit 도메인 read 권한을 ``master`` role 또는 ``audit:read`` scope 중
+    하나로 정의하므로, 모니터링 전용 agent(default role + ``audit:read`` scope)
+    가 차단되는 회귀가 발생했다. 본 dependency는 두 조건의 OR로 통과시킨다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from ante.member.models import MemberRole
+from ante.web.deps import require_audit_read
+
+
+@dataclass
+class _StubMember:
+    member_id: str
+    role: str
+    scopes: list[str] = field(default_factory=list)
+
+
+class _StubMemberService:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self._members: dict[str, _StubMember] = {}
+
+    def add(
+        self,
+        member_id: str,
+        role: str = "default",
+        scopes: list[str] | None = None,
+    ) -> None:
+        self._members[member_id] = _StubMember(
+            member_id=member_id,
+            role=role,
+            scopes=list(scopes) if scopes else [],
+        )
+
+    async def get(self, member_id: str) -> _StubMember | None:
+        self.calls.append(member_id)
+        return self._members.get(member_id)
+
+
+class _StubSessionService:
+    def __init__(self, raise_on_validate: bool = False) -> None:
+        self.calls: list[str] = []
+        self._sessions: dict[str, str] = {}
+        self.raise_on_validate = raise_on_validate
+
+    def add_session(self, session_id: str, member_id: str) -> None:
+        self._sessions[session_id] = member_id
+
+    async def validate(self, session_id: str) -> dict | None:
+        self.calls.append(session_id)
+        if self.raise_on_validate:
+            raise RuntimeError("session backend offline")
+        member_id = self._sessions.get(session_id)
+        if member_id is None:
+            return None
+        return {"member_id": member_id}
+
+
+def _make_request(
+    *,
+    state_member_id: str | None = None,
+    cookies: dict[str, str] | None = None,
+) -> SimpleNamespace:
+    """FastAPI Request 인터페이스를 흉내내는 최소 stub.
+
+    ``require_audit_read``는 ``request.state.member_id`` getattr와
+    ``request.cookies.get`` 만 사용한다.
+    """
+    state = SimpleNamespace()
+    if state_member_id is not None:
+        state.member_id = state_member_id
+    cookies_obj = cookies or {}
+    return SimpleNamespace(state=state, cookies=cookies_obj)
+
+
+# ── 200: 통과 케이스 ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_returns_caller_when_bearer_master() -> None:
+    """master role → 통과 (scope와 무관)."""
+    svc = _StubMemberService()
+    svc.add("master-user", role=MemberRole.MASTER.value)
+    request = _make_request(state_member_id="master-user")
+
+    caller = await require_audit_read(request, svc, None)
+
+    assert caller == "master-user"
+    assert svc.calls == ["master-user"]
+
+
+@pytest.mark.asyncio
+async def test_returns_caller_when_default_with_audit_read_scope() -> None:
+    """default role + ``audit:read`` scope → 통과 (모니터링 agent 시나리오).
+
+    spec docs/specs/member/02-design-decisions.md:188-229 모니터링 agent.
+    """
+    svc = _StubMemberService()
+    svc.add(
+        "monitor-agent",
+        role=MemberRole.DEFAULT.value,
+        scopes=["bot:read", "trade:read", "audit:read"],
+    )
+    request = _make_request(state_member_id="monitor-agent")
+
+    caller = await require_audit_read(request, svc, None)
+
+    assert caller == "monitor-agent"
+    assert svc.calls == ["monitor-agent"]
+
+
+@pytest.mark.asyncio
+async def test_returns_caller_when_admin_with_audit_read_scope() -> None:
+    """admin role + ``audit:read`` scope → 통과."""
+    svc = _StubMemberService()
+    svc.add("admin-1", role=MemberRole.ADMIN.value, scopes=["audit:read"])
+    request = _make_request(state_member_id="admin-1")
+
+    caller = await require_audit_read(request, svc, None)
+
+    assert caller == "admin-1"
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_session_cookie_when_bearer_missing() -> None:
+    """Bearer 미설정 + 유효 세션 쿠키(audit:read 보유) → caller 결정 + state 갱신."""
+    member_svc = _StubMemberService()
+    member_svc.add(
+        "cookie-monitor",
+        role=MemberRole.DEFAULT.value,
+        scopes=["audit:read"],
+    )
+
+    session_svc = _StubSessionService()
+    session_svc.add_session("sid-1", "cookie-monitor")
+
+    request = _make_request(cookies={"ante_session": "sid-1"})
+
+    caller = await require_audit_read(request, member_svc, session_svc)
+
+    assert caller == "cookie-monitor"
+    assert session_svc.calls == ["sid-1"]
+    # AuditMiddleware 일관성을 위해 request.state.member_id가 갱신돼야 한다.
+    assert request.state.member_id == "cookie-monitor"
+
+
+@pytest.mark.asyncio
+async def test_bearer_caller_takes_precedence_over_cookie() -> None:
+    """Bearer 토큰이 caller를 결정하면 쿠키 검증을 다시 호출하지 않는다."""
+    member_svc = _StubMemberService()
+    member_svc.add("bearer-master", role=MemberRole.MASTER.value)
+    session_svc = _StubSessionService()
+    session_svc.add_session("sid-1", "cookie-user")
+
+    request = _make_request(
+        state_member_id="bearer-master",
+        cookies={"ante_session": "sid-1"},
+    )
+
+    caller = await require_audit_read(request, member_svc, session_svc)
+
+    assert caller == "bearer-master"
+    assert session_svc.calls == [], (
+        "Bearer 결정 시 session_service.validate가 호출되어선 안 된다"
+    )
+
+
+# ── 401: 인증 실패 케이스 ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_raises_401_when_no_bearer_and_no_cookie() -> None:
+    """Bearer 없음 + 쿠키 없음 → 401."""
+    svc = _StubMemberService()
+    request = _make_request()
+
+    with pytest.raises(HTTPException) as exc:
+        await require_audit_read(request, svc, _StubSessionService())
+
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_raises_401_when_session_service_none_and_only_cookie() -> None:
+    """``session_service is None`` + Bearer 없음 → 쿠키 fallback skip → 401."""
+    svc = _StubMemberService()
+    request = _make_request(cookies={"ante_session": "sid-1"})
+
+    with pytest.raises(HTTPException) as exc:
+        await require_audit_read(request, svc, None)
+
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_raises_401_when_invalid_cookie() -> None:
+    """유효하지 않은 세션 쿠키 → 401."""
+    svc = _StubMemberService()
+    session_svc = _StubSessionService()
+    request = _make_request(cookies={"ante_session": "unknown-sid"})
+
+    with pytest.raises(HTTPException) as exc:
+        await require_audit_read(request, svc, session_svc)
+
+    assert exc.value.status_code == 401
+    assert session_svc.calls == ["unknown-sid"]
+
+
+@pytest.mark.asyncio
+async def test_session_validate_exception_is_absorbed_as_401() -> None:
+    """``session_service.validate`` 예외는 401로 흡수돼야 한다 (#1351 패턴)."""
+    svc = _StubMemberService()
+    session_svc = _StubSessionService(raise_on_validate=True)
+    request = _make_request(cookies={"ante_session": "sid-1"})
+
+    with pytest.raises(HTTPException) as exc:
+        await require_audit_read(request, svc, session_svc)
+
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_raises_401_when_member_service_missing() -> None:
+    """``member_service is None`` 분기는 cold-path invariant I1을 깨지 않게
+    401로 떨어진다 (``require_master_caller``와 동일 정책).
+    """
+    request = _make_request(state_member_id="some-caller")
+
+    with pytest.raises(HTTPException) as exc:
+        await require_audit_read(request, None, None)
+
+    assert exc.value.status_code == 401
+
+
+# ── 403: 권한 실패 케이스 ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_raises_403_when_default_without_audit_read_scope() -> None:
+    """default role + ``audit:read`` 미보유 → 403."""
+    svc = _StubMemberService()
+    svc.add("plain-agent", role=MemberRole.DEFAULT.value, scopes=["bot:read"])
+    request = _make_request(state_member_id="plain-agent")
+
+    with pytest.raises(HTTPException) as exc:
+        await require_audit_read(request, svc, None)
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_raises_403_when_default_with_empty_scopes() -> None:
+    """default role + scopes 비어있음 → 403."""
+    svc = _StubMemberService()
+    svc.add("plain-agent", role=MemberRole.DEFAULT.value, scopes=[])
+    request = _make_request(state_member_id="plain-agent")
+
+    with pytest.raises(HTTPException) as exc:
+        await require_audit_read(request, svc, None)
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_raises_403_when_admin_without_audit_read_scope() -> None:
+    """admin role + ``audit:read`` 미보유 → 403 (admin도 자동 통과 아님)."""
+    svc = _StubMemberService()
+    svc.add(
+        "admin-no-scope",
+        role=MemberRole.ADMIN.value,
+        scopes=["bot:admin", "approval:write"],
+    )
+    request = _make_request(state_member_id="admin-no-scope")
+
+    with pytest.raises(HTTPException) as exc:
+        await require_audit_read(request, svc, None)
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_raises_403_when_caller_id_unknown_to_member_service() -> None:
+    """인증 미들웨어가 ``request.state.member_id``를 채웠으나 멤버 서비스에
+    해당 id가 없는 경우 → 403 (ghost caller invariant 보호).
+    """
+    svc = _StubMemberService()
+    request = _make_request(state_member_id="ghost-id")
+
+    with pytest.raises(HTTPException) as exc:
+        await require_audit_read(request, svc, None)
+
+    assert exc.value.status_code == 403


### PR DESCRIPTION
Closes #1359

## Summary

이슈 #1359: `GET /api/audit`이 인증 없이 200 반환. spec(`docs/specs/member/02-design-decisions.md`)의 audit:read scope predicate를 web layer에 적용.

## Changes

- **`src/ante/web/deps.py`**: 신규 dependency `require_audit_read` 추가.
  - Bearer 우선 + `ante_session` 쿠키 fallback (#1352 패턴 재사용).
  - caller 빈 / member None / `MemberStatus != ACTIVE` → 401/403.
  - 권한 분기:
    - `MemberRole.MASTER` → 통과
    - `MemberType.HUMAN` → 통과 (scope 무관, spec `@require_scope` predicate 동등)
    - `"audit:read" in member.scopes` → 통과 (agent 정상 경로)
    - 그 외 (agent without scope) → 403
- **`src/ante/web/routes/audit.py::list_audit_logs`**: `Depends(require_audit_read)` 추가, dependency 순서를 `caller_id` → `audit_logger`로 변경 (401이 503보다 먼저).
- responses dict에 401, 403 추가.
- **`frontend/openapi.json`, `frontend/src/types/api.generated.ts`**: 재생성.
- **`tests/unit/test_audit_routes_auth.py`** (15+ cases): unauth/invalid/master/non-master/human bypass/audit:read scope/suspended 등.
- **`tests/unit/test_require_audit_read.py`** (신규): dependency 단위 테스트.
- **`tests/unit/test_pagination_limit_validation.py`**: audit fixture에 master Bearer + member_service stub 주입.

## Codex Plan/Branch Review

- Plan: approve-implement (revise-plan 2회 후 — scope spec 격차, non-master 정책).
- Branch: PASS @ \`8b68cc3\` (5th attempt — dependency 순서, audit:read scope, human bypass, member status 4차 fix loop).

## Test Plan

- ruff PASS
- pytest 통합: 153 passed (audit + auth + master_caller 회귀)
- 광역 회귀: 553 passed
- 전체 unit: 4226+ passed

## Follow-up (Non-Goals)

- Member.scopes strict 모델 + spec scope SSOT 정의.
- 다른 endpoint의 audit:read scope 검증 (write log endpoint 등 있다면).

🤖 Generated with [Claude Code](https://claude.com/claude-code)