### PR TITLE
fix(system): emit Z suffix for kill-switch changed_at (#1360)

### DIFF
--- a/src/ante/core/time.py
+++ b/src/ante/core/time.py
@@ -1,0 +1,39 @@
+"""UTC ISO 8601 직렬화 helper.
+
+SSOT: ``docs/specs/web-api/04-system-endpoints.md``의 Kill Switch 응답은
+``changed_at``을 ``string (ISO 8601 UTC)``로 정의하며 ``Z`` suffix를 사용한다.
+Python ``datetime.isoformat()``은 UTC offset을 ``+00:00``으로 직렬화하므로,
+응답 표면에서는 본 helper로 ``Z`` suffix로 통일한다.
+
+Web API (``ante.web.routes.system``)와 IPC registry
+(``ante.ipc.registry``)는 동일한 Kill Switch envelope을 공유하므로 양쪽이
+이 helper를 호출한다 (Refs #1360).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def format_utc(dt: datetime) -> str:
+    """UTC ``datetime``을 ISO 8601 + ``Z`` suffix 문자열로 직렬화한다.
+
+    Args:
+        dt: tzinfo가 UTC인 ``datetime``. naive 또는 다른 timezone은 reject한다.
+
+    Returns:
+        ISO 8601 UTC 문자열 (suffix는 ``Z``).
+
+    Raises:
+        ValueError: ``dt``가 naive이거나 UTC가 아닌 경우.
+    """
+    if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) != UTC.utcoffset(dt):
+        msg = (
+            "format_utc는 UTC tzinfo가 명시된 datetime만 받는다. "
+            f"got tzinfo={dt.tzinfo!r}"
+        )
+        raise ValueError(msg)
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+__all__ = ["format_utc"]

--- a/src/ante/ipc/registry.py
+++ b/src/ante/ipc/registry.py
@@ -89,14 +89,17 @@ def _kill_switch_payload(status: str, accounts: list[dict[str, Any]]) -> dict:
 
     SSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답 SSOT.
     Web API와 IPC가 동일한 shape(``status``, ``accounts_changed``, ``changed_at``,
-    ``accounts[]``)을 사용한다.
+    ``accounts[]``)을 사용한다. ``changed_at``은 ISO 8601 UTC ``Z`` suffix를
+    사용한다 (Refs #1360).
     """
     from datetime import UTC, datetime
+
+    from ante.core.time import format_utc
 
     return {
         "status": status,
         "accounts_changed": sum(1 for a in accounts if a.get("changed")),
-        "changed_at": datetime.now(UTC).isoformat(),
+        "changed_at": format_utc(datetime.now(UTC)),
         "accounts": accounts,
     }
 

--- a/src/ante/web/routes/system.py
+++ b/src/ante/web/routes/system.py
@@ -132,13 +132,16 @@ def _kill_switch_payload(status: str, accounts: list[dict[str, Any]]) -> dict:
     """Kill Switch 응답 envelope.
 
     SSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답 SSOT.
+    ``changed_at``은 ISO 8601 UTC ``Z`` suffix를 사용한다 (Refs #1360).
     """
     from datetime import UTC, datetime
+
+    from ante.core.time import format_utc
 
     return {
         "status": status,
         "accounts_changed": sum(1 for a in accounts if a.get("changed")),
-        "changed_at": datetime.now(UTC).isoformat(),
+        "changed_at": format_utc(datetime.now(UTC)),
         "accounts": accounts,
     }
 

--- a/tests/unit/test_format_utc.py
+++ b/tests/unit/test_format_utc.py
@@ -1,0 +1,46 @@
+"""``ante.core.time.format_utc`` 단위 테스트 (Refs #1360).
+
+Web API와 IPC가 공유하는 UTC ISO 8601 직렬화 helper. SSOT는
+``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답에서 ``Z`` suffix를
+요구한다. Python ``datetime.isoformat()``의 기본 ``+00:00``을 ``Z``로 치환한다.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+
+from ante.core.time import format_utc
+
+
+def test_format_utc_replaces_plus_zero_offset_with_z() -> None:
+    dt = datetime(2026, 5, 8, 11, 33, 25, tzinfo=UTC)
+    assert format_utc(dt) == "2026-05-08T11:33:25Z"
+
+
+def test_format_utc_keeps_microseconds() -> None:
+    dt = datetime(2026, 5, 8, 11, 33, 25, 123456, tzinfo=UTC)
+    assert format_utc(dt) == "2026-05-08T11:33:25.123456Z"
+
+
+def test_format_utc_does_not_contain_plus_offset() -> None:
+    dt = datetime.now(UTC)
+    result = format_utc(dt)
+    assert "+00:00" not in result
+    assert result.endswith("Z")
+
+
+def test_format_utc_rejects_naive_datetime() -> None:
+    """naive datetime은 UTC 보장이 불가능하므로 reject."""
+    naive = datetime(2026, 5, 8, 11, 33, 25)
+    with pytest.raises(ValueError):
+        format_utc(naive)
+
+
+def test_format_utc_rejects_non_utc_timezone() -> None:
+    """다른 timezone offset은 reject (helper 이름이 ``format_utc``)."""
+    kst = timezone(timedelta(hours=9))
+    dt = datetime(2026, 5, 8, 20, 33, 25, tzinfo=kst)
+    with pytest.raises(ValueError):
+        format_utc(dt)

--- a/tests/unit/test_system_kill_switch_timestamp.py
+++ b/tests/unit/test_system_kill_switch_timestamp.py
@@ -1,0 +1,143 @@
+"""Kill Switch 응답 ``changed_at`` Z suffix 검증 (Refs #1360).
+
+SSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답 SSOT는
+``changed_at``을 ``string (ISO 8601 UTC)``로 정의하고 ``Z`` suffix를 사용한다.
+
+Python ``datetime.isoformat()``은 UTC offset을 ``+00:00``으로 직렬화하므로
+``_kill_switch_payload``는 변환 helper를 통해 ``Z`` suffix로 통일해야 한다.
+
+Web API (`src/ante/web/routes/system.py`)와 IPC registry
+(`src/ante/ipc/registry.py`) 양쪽이 동일 SSOT shape을 공유하므로 두 표면 모두
+검증한다.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import AsyncMock
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.ipc.registry import (  # noqa: E402
+    _handle_system_clear_halt,
+    _handle_system_halt,
+)
+from ante.web.app import create_app  # noqa: E402
+
+# RFC 3339 / ISO 8601 + Z suffix를 받는 strict 정규식.
+ISO8601_UTC_Z = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
+
+
+@pytest.fixture
+def account_service():
+    """suspend_all / activate_all stub. Refs #1213 list[dict] shape."""
+    mock = AsyncMock()
+    mock.suspend_all = AsyncMock(
+        return_value=[
+            {
+                "account_id": "domestic",
+                "previous_status": "active",
+                "status": "suspended",
+                "changed": True,
+            }
+        ]
+    )
+    mock.activate_all = AsyncMock(
+        return_value=[
+            {
+                "account_id": "domestic",
+                "previous_status": "suspended",
+                "status": "active",
+                "changed": True,
+            }
+        ]
+    )
+    return mock
+
+
+@pytest.fixture
+def client(account_service):
+    app = create_app(account_service=account_service)
+    return TestClient(app)
+
+
+class TestWebKillSwitchChangedAtZSuffix:
+    """POST /api/system/halt + /api/system/clear-halt ``changed_at`` Z suffix."""
+
+    def test_halt_changed_at_uses_z_suffix(self, client) -> None:
+        resp = client.post("/api/system/halt", json={"reason": ""})
+        assert resp.status_code == 200
+        changed_at = resp.json()["changed_at"]
+        assert isinstance(changed_at, str)
+        assert changed_at.endswith("Z"), (
+            f"changed_at은 Z suffix여야 한다. got={changed_at!r}"
+        )
+        assert "+00:00" not in changed_at
+        assert ISO8601_UTC_Z.match(changed_at), (
+            f"changed_at이 ISO 8601 UTC + Z suffix 형식이어야 한다. got={changed_at!r}"
+        )
+
+    def test_clear_halt_changed_at_uses_z_suffix(self, client) -> None:
+        resp = client.post("/api/system/clear-halt", json={"reason": ""})
+        assert resp.status_code == 200
+        changed_at = resp.json()["changed_at"]
+        assert isinstance(changed_at, str)
+        assert changed_at.endswith("Z"), (
+            f"changed_at은 Z suffix여야 한다. got={changed_at!r}"
+        )
+        assert "+00:00" not in changed_at
+        assert ISO8601_UTC_Z.match(changed_at), (
+            f"changed_at이 ISO 8601 UTC + Z suffix 형식이어야 한다. got={changed_at!r}"
+        )
+
+
+class TestIPCKillSwitchChangedAtZSuffix:
+    """IPC system.halt / system.clear_halt 핸들러도 동일 shape SSOT."""
+
+    @pytest.mark.asyncio
+    async def test_ipc_halt_changed_at_uses_z_suffix(self) -> None:
+        svc = AsyncMock()
+        svc.account.suspend_all = AsyncMock(
+            return_value=[
+                {
+                    "account_id": "domestic",
+                    "previous_status": "active",
+                    "status": "suspended",
+                    "changed": True,
+                }
+            ]
+        )
+        result = await _handle_system_halt(svc, {"reason": "test"}, "tester")
+        changed_at = result["changed_at"]
+        assert isinstance(changed_at, str)
+        assert changed_at.endswith("Z"), (
+            f"IPC halt changed_at은 Z suffix여야 한다. got={changed_at!r}"
+        )
+        assert "+00:00" not in changed_at
+        assert ISO8601_UTC_Z.match(changed_at)
+
+    @pytest.mark.asyncio
+    async def test_ipc_clear_halt_changed_at_uses_z_suffix(self) -> None:
+        svc = AsyncMock()
+        svc.account.activate_all = AsyncMock(
+            return_value=[
+                {
+                    "account_id": "domestic",
+                    "previous_status": "suspended",
+                    "status": "active",
+                    "changed": True,
+                }
+            ]
+        )
+        result = await _handle_system_clear_halt(svc, {}, "tester")
+        changed_at = result["changed_at"]
+        assert isinstance(changed_at, str)
+        assert changed_at.endswith("Z"), (
+            f"IPC clear_halt changed_at은 Z suffix여야 한다. got={changed_at!r}"
+        )
+        assert "+00:00" not in changed_at
+        assert ISO8601_UTC_Z.match(changed_at)


### PR DESCRIPTION
Closes #1360

## Summary

이슈 #1360: `POST /api/system/halt`/`clear-halt`의 `changed_at`이 `+00:00` suffix 반환. spec(`docs/specs/web-api/04-system-endpoints.md`)은 ISO 8601 UTC `Z` suffix 강제. IPC `system.halt`/`clear_halt`도 동일 버그.

## Changes

- **`src/ante/core/time.py`** (신규): 공통 helper `format_utc(dt: datetime) -> str = dt.isoformat().replace("+00:00", "Z")`. naive/non-UTC datetime은 `ValueError` reject.
- **`src/ante/web/routes/system.py::_kill_switch_payload`**: `format_utc` 사용.
- **`src/ante/ipc/registry.py::_kill_switch_payload`**: `format_utc` 사용 (web과 동일 SSOT).
- **`tests/unit/test_format_utc.py`** (5 cases): helper 단위 테스트.
- **`tests/unit/test_system_kill_switch_timestamp.py`** (4 cases): web halt/clear-halt + IPC halt/clear_halt `changed_at.endswith("Z")` 회귀.

## Codex Plan/Branch Review

- Plan: approve-implement (with conditions: IPC 동시 수정 + helper 추출).
- Branch: PASS @ \`66e9057\` (1st attempt).

## Test Plan

- ruff PASS
- 신규 9 tests + 회귀 통합 236 passed
- 전체 web 회귀 74 passed

## Follow-up (Non-Goals)

- 다른 endpoint(portfolio/treasury/approval)의 timestamp 직렬화 audit.
- `core/log/formatter.py`의 인라인 `replace` 패턴을 helper 호출로 통일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)