### PR TITLE
fix(web): require master auth for bot create/delete (#1371)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3841,18 +3841,8 @@
           "bots"
         ],
         "summary": "Create Bot",
-        "description": "봇 생성.",
+        "description": "봇 생성. 인증된 master만 호출 가능 (#1371).\n\n``update_bot`` (#1352)과 동일한 raw body 파싱 패턴을 적용해 인증 가드가\nbody validation보다 우선 실행되도록 한다. FastAPI가 ``body: BotCreateRequest``\n를 먼저 검증하면 unauth + bad-body 시 401이 아닌 422가 먼저 반환되어\ncontract가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,\n   non-master → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``BotCreateRequest.model_validate`` — ValidationError → 422.\n4. service 호출 (``BotError`` → 409, ``TreasuryError`` → 422).",
         "operationId": "create_bot_api_bots_post",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BotCreateRequest"
-              }
-            }
-          }
-        },
         "responses": {
           "201": {
             "description": "Successful Response",
@@ -3866,6 +3856,26 @@
           },
           "400": {
             "description": "Strategy loading failed",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (master 권한 필요)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -3895,7 +3905,7 @@
             }
           },
           "422": {
-            "description": "strategy_id/strategy_name both missing, or budget allocation failed (Treasury error: insufficient funds, treasury not configured for account, etc.). On budget failure the newly created bot is rolled back via delete_bot(handle_positions='keep').",
+            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, 미지정 필드, strategy_id/strategy_name 동시 누락) 또는 budget allocation 실패 (Treasury error: insufficient funds, treasury not configured for account, etc.). On budget failure the newly created bot is rolled back via delete_bot(handle_positions='keep'). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1371).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -3921,6 +3931,16 @@
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BotCreateRequest"
               }
             }
           }
@@ -3994,7 +4014,7 @@
           "bots"
         ],
         "summary": "Delete Bot",
-        "description": "봇 삭제.\n\nhandle_positions:\n    - keep (기본): 포지션을 유지한 채 봇만 삭제.\n    - liquidate: 보유 종목 시장가 매도 주문 발행 후 삭제.",
+        "description": "봇 삭제. 인증된 master만 호출 가능 (#1371).\n\nbody가 없으므로 raw-body cold-path는 적용하지 않는다. 인증 가드가\nhandle_positions query 파라미터 검증보다 먼저 실행되어 unauth는 401,\nnon-master는 403으로 차단된다.\n\nhandle_positions:\n    - keep (기본): 포지션을 유지한 채 봇만 삭제.\n    - liquidate: 보유 종목 시장가 매도 주문 발행 후 삭제.",
         "operationId": "delete_bot_api_bots__bot_id__delete",
         "parameters": [
           {
@@ -4020,6 +4040,26 @@
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "401": {
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (master 권한 필요)",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "404": {
             "description": "Bot not found",
@@ -5539,77 +5579,6 @@
         ],
         "title": "BalanceSetResponse",
         "description": "잔고 설정 응답."
-      },
-      "BotCreateRequest": {
-        "properties": {
-          "bot_id": {
-            "type": "string",
-            "title": "Bot Id"
-          },
-          "strategy_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Strategy Id"
-          },
-          "strategy_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Strategy Name"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name",
-            "default": ""
-          },
-          "account_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Account Id"
-          },
-          "interval_seconds": {
-            "type": "integer",
-            "maximum": 3600.0,
-            "minimum": 10.0,
-            "title": "Interval Seconds",
-            "default": 60
-          },
-          "budget": {
-            "anyOf": [
-              {
-                "type": "number",
-                "exclusiveMinimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Budget"
-          }
-        },
-        "type": "object",
-        "required": [
-          "bot_id"
-        ],
-        "title": "BotCreateRequest",
-        "description": "봇 생성 요청.\n\nstrategy_id 또는 strategy_name 중 하나를 필수로 전달해야 한다.\nstrategy_name만 전달하면 최신 버전의 strategy_id로 자동 변환된다."
       },
       "BotDetailResponse": {
         "properties": {
@@ -8344,6 +8313,61 @@
               "type": "string"
             },
             "description": "변경할 권한 범위 목록."
+          }
+        }
+      },
+      "BotCreateRequest": {
+        "type": "object",
+        "title": "BotCreateRequest",
+        "description": "POST /api/bots 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1371). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다. strategy_id 또는 strategy_name 중 하나를 필수로 전달해야 한다.",
+        "required": [
+          "bot_id"
+        ],
+        "properties": {
+          "bot_id": {
+            "type": "string",
+            "description": "생성할 봇의 식별자."
+          },
+          "strategy_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "전략 ID. ``strategy_name``과 둘 중 하나는 반드시 전달해야 한다."
+          },
+          "strategy_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "전략 이름. 최신 버전의 strategy_id로 자동 변환된다. ``strategy_id``와 둘 중 하나는 반드시 전달해야 한다."
+          },
+          "name": {
+            "type": "string",
+            "default": "",
+            "description": "사용자에게 표시되는 봇 이름. 비우면 bot_id를 사용한다."
+          },
+          "account_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "사용할 계좌 ID. 미지정 시 단일 active 계좌가 자동 선택된다."
+          },
+          "interval_seconds": {
+            "type": "integer",
+            "minimum": 10,
+            "maximum": 3600,
+            "default": 60,
+            "description": "봇 step 주기 (초)."
+          },
+          "budget": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "exclusiveMinimum": 0,
+            "description": "예산 할당액 (원). 양수만 허용."
           }
         }
       },

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -311,10 +311,22 @@ export type paths = {
          *     인증/권한:
          *         oracle A7 시그니처(#1359)에서 본 라우트는 인증 없이 감사 로그 목록을
          *         반환하고 있었다. 감사 로그는 운영 행위 추적 정보(member_id, action,
-         *         resource, IP 등)를 담으므로 ``require_master_caller`` (#1352에서 도입)
-         *         를 적용해 master 권한자만 조회 가능하도록 막는다. 인증 누락은 401,
-         *         non-master는 403. ``audit:read`` scope strict 모델은 ``Member.scopes``
-         *         가 자유 문자열이라 별도 정의가 필요하므로 본 PR scope 외 follow-up.
+         *         resource, IP 등)를 담으므로 인증 가드를 적용한다. 인증 누락은 401,
+         *         권한 없음은 403.
+         *
+         *         Codex P2 (#1359 fix loop, 2차): 초기 패치는 ``require_master_caller``
+         *         를 그대로 적용해 ``master`` role만 허용했으나,
+         *         ``docs/specs/member/02-design-decisions.md:188-229`` 의 모니터링 agent
+         *         (``audit:read`` scope만 가진 default role)가 차단되는 문제가 있었다.
+         *         spec은 audit 도메인 read 권한을 ``master`` role 또는 ``audit:read``
+         *         scope 중 하나로 정의하므로, ``require_audit_read`` (master OR
+         *         ``audit:read`` ∈ Member.scopes)로 교체해 spec과 일치시켰다.
+         *
+         *     Codex P2 (#1359 fix loop): FastAPI는 핸들러 매개변수 선언 순서대로
+         *     dependency를 해결한다. ``audit_logger`` (필수 service, 미주입 시 503)를
+         *     ``require_audit_read`` 보다 먼저 두면, 인증 정보가 없는 호출자에게
+         *     503이 먼저 반환되어 "인증 누락은 401" 계약이 깨진다. 그러므로 인증
+         *     가드(``caller_id``)를 항상 먼저 선언해 401/403이 503보다 우선하도록 한다.
          *
          *     NOTE: ``limit``은 다른 list endpoint와 일관된 ``le=100``으로 검증한다.
          *     이전 구현은 ``min(limit, 200)``로 자동 클램프했으나, #1356에서
@@ -410,7 +422,20 @@ export type paths = {
         put?: never;
         /**
          * Create Bot
-         * @description 봇 생성.
+         * @description 봇 생성. 인증된 master만 호출 가능 (#1371).
+         *
+         *     ``update_bot`` (#1352)과 동일한 raw body 파싱 패턴을 적용해 인증 가드가
+         *     body validation보다 우선 실행되도록 한다. FastAPI가 ``body: BotCreateRequest``
+         *     를 먼저 검증하면 unauth + bad-body 시 401이 아닌 422가 먼저 반환되어
+         *     contract가 깨진다.
+         *
+         *     핸들러 단계 순서:
+         *
+         *     1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
+         *        non-master → 403.
+         *     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
+         *     3. ``BotCreateRequest.model_validate`` — ValidationError → 422.
+         *     4. service 호출 (``BotError`` → 409, ``TreasuryError`` → 422).
          */
         post: operations["create_bot_api_bots_post"];
         delete?: never;
@@ -452,7 +477,11 @@ export type paths = {
         post?: never;
         /**
          * Delete Bot
-         * @description 봇 삭제.
+         * @description 봇 삭제. 인증된 master만 호출 가능 (#1371).
+         *
+         *     body가 없으므로 raw-body cold-path는 적용하지 않는다. 인증 가드가
+         *     handle_positions query 파라미터 검증보다 먼저 실행되어 unauth는 401,
+         *     non-master는 403으로 차단된다.
          *
          *     handle_positions:
          *         - keep (기본): 포지션을 유지한 채 봇만 삭제.
@@ -1764,31 +1793,28 @@ export type components = {
         };
         /**
          * BotCreateRequest
-         * @description 봇 생성 요청.
-         *
-         *     strategy_id 또는 strategy_name 중 하나를 필수로 전달해야 한다.
-         *     strategy_name만 전달하면 최신 버전의 strategy_id로 자동 변환된다.
+         * @description POST /api/bots 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1371). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다. strategy_id 또는 strategy_name 중 하나를 필수로 전달해야 한다.
          */
         BotCreateRequest: {
-            /** Account Id */
+            /** @description 사용할 계좌 ID. 미지정 시 단일 active 계좌가 자동 선택된다. */
             account_id?: string | null;
-            /** Bot Id */
+            /** @description 생성할 봇의 식별자. */
             bot_id: string;
-            /** Budget */
+            /** @description 예산 할당액 (원). 양수만 허용. */
             budget?: number | null;
             /**
-             * Interval Seconds
+             * @description 봇 step 주기 (초).
              * @default 60
              */
             interval_seconds: number;
             /**
-             * Name
+             * @description 사용자에게 표시되는 봇 이름. 비우면 bot_id를 사용한다.
              * @default
              */
             name: string;
-            /** Strategy Id */
+            /** @description 전략 ID. ``strategy_name``과 둘 중 하나는 반드시 전달해야 한다. */
             strategy_id?: string | null;
-            /** Strategy Name */
+            /** @description 전략 이름. 최신 버전의 strategy_id로 자동 변환된다. ``strategy_id``와 둘 중 하나는 반드시 전달해야 한다. */
             strategy_name?: string | null;
         };
         /**
@@ -4136,7 +4162,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Master permission required */
+            /** @description Master role or audit:read scope required */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -4378,6 +4404,24 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
+            /** @description Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Permission denied (master 권한 필요) */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
             /** @description Strategy not found */
             404: {
                 headers: {
@@ -4396,7 +4440,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description strategy_id/strategy_name both missing, or budget allocation failed (Treasury error: insufficient funds, treasury not configured for account, etc.). On budget failure the newly created bot is rolled back via delete_bot(handle_positions='keep'). */
+            /** @description Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, 미지정 필드, strategy_id/strategy_name 동시 누락) 또는 budget allocation 실패 (Treasury error: insufficient funds, treasury not configured for account, etc.). On budget failure the newly created bot is rolled back via delete_bot(handle_positions='keep'). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1371). */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -4573,6 +4617,24 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Permission denied (master 권한 필요) */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
             };
             /** @description Bot not found */
             404: {

--- a/src/ante/web/app.py
+++ b/src/ante/web/app.py
@@ -141,6 +141,12 @@ def _install_openapi_customizer(app: FastAPI) -> None:
       빌드가 깨진다. ``BOT_UPDATE_REQUEST_SCHEMA`` /
       ``BALANCE_SET_REQUEST_SCHEMA`` 본체를 ``components.schemas``에
       ``setdefault`` 등록한다.
+    - ``BotCreateRequest`` 도 동일 이유로 등록 보장(#1371). POST /api/bots
+      가 raw body 패턴으로 전환되면서 ``body: BotCreateRequest`` 인자가
+      시그니처에서 사라졌고, inline schema로 두면 frontend codegen이
+      ``export type BotCreateRequest``를 만들지 못한다.
+      ``BOT_CREATE_REQUEST_SCHEMA`` 본체를 ``components.schemas``에
+      ``setdefault`` 등록한다.
     - ``AccountSuspendRequest`` 도 동일 이유로 등록 보장(#1352 2차 Codex
       review FAIL). POST /api/accounts/{id}/suspend 가 raw body 패턴으로
       전환되면서 ``body: AccountSuspendRequest`` 인자가 시그니처에서 사라졌고,
@@ -162,7 +168,10 @@ def _install_openapi_customizer(app: FastAPI) -> None:
     # import하므로 모듈 top-level circular import를 피하려면 같은 패턴을
     # 따른다.
     from ante.web.routes.accounts import ACCOUNT_SUSPEND_REQUEST_SCHEMA
-    from ante.web.routes.bots import BOT_UPDATE_REQUEST_SCHEMA
+    from ante.web.routes.bots import (
+        BOT_CREATE_REQUEST_SCHEMA,
+        BOT_UPDATE_REQUEST_SCHEMA,
+    )
     from ante.web.routes.members import (
         MEMBER_CREATE_REQUEST_SCHEMA,
         MEMBER_SCOPES_UPDATE_REQUEST_SCHEMA,
@@ -184,6 +193,7 @@ def _install_openapi_customizer(app: FastAPI) -> None:
         schemas.setdefault("ErrorResponse", ErrorResponse.model_json_schema())
         schemas.setdefault("MemberCreateRequest", MEMBER_CREATE_REQUEST_SCHEMA)
         schemas.setdefault("ScopesUpdateRequest", MEMBER_SCOPES_UPDATE_REQUEST_SCHEMA)
+        schemas.setdefault("BotCreateRequest", BOT_CREATE_REQUEST_SCHEMA)
         schemas.setdefault("BotUpdateRequest", BOT_UPDATE_REQUEST_SCHEMA)
         schemas.setdefault("BalanceSetRequest", BALANCE_SET_REQUEST_SCHEMA)
         schemas.setdefault("AccountSuspendRequest", ACCOUNT_SUSPEND_REQUEST_SCHEMA)

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -50,6 +50,70 @@ class BotCreateRequest(BaseModel):
     budget: float | None = Field(default=None, gt=0)
 
 
+# POST /api/bots OpenAPI request body 문서.
+#
+# 라우트는 raw body 파싱 패턴(인증 가드 우선, body validation 후행)으로
+# 동작한다(이슈 #1371). FastAPI 자동 components 등록 경로를 거치지 않으므로
+# inline schema로 두면 frontend codegen이 ``export type BotCreateRequest``를
+# 만들지 못한다. 따라서 라우트 ``openapi_extra``는 ``$ref`` 매핑만 노출하고
+# 본체 schema는 ``_install_openapi_customizer``가 ``components.schemas``에
+# 등록한다(#1351 ``ScopesUpdateRequest`` SSOT 패턴).
+BOT_CREATE_REQUEST_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "title": "BotCreateRequest",
+    "description": (
+        "POST /api/bots 입력 contract. "
+        "인증된 master 호출자만 사용할 수 있다(#1371). "
+        "Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, "
+        "둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다. "
+        "strategy_id 또는 strategy_name 중 하나를 필수로 전달해야 한다."
+    ),
+    "required": ["bot_id"],
+    "properties": {
+        "bot_id": {
+            "type": "string",
+            "description": "생성할 봇의 식별자.",
+        },
+        "strategy_id": {
+            "type": ["string", "null"],
+            "description": (
+                "전략 ID. ``strategy_name``과 둘 중 하나는 반드시 전달해야 한다."
+            ),
+        },
+        "strategy_name": {
+            "type": ["string", "null"],
+            "description": (
+                "전략 이름. 최신 버전의 strategy_id로 자동 변환된다. "
+                "``strategy_id``와 둘 중 하나는 반드시 전달해야 한다."
+            ),
+        },
+        "name": {
+            "type": "string",
+            "default": "",
+            "description": "사용자에게 표시되는 봇 이름. 비우면 bot_id를 사용한다.",
+        },
+        "account_id": {
+            "type": ["string", "null"],
+            "description": (
+                "사용할 계좌 ID. 미지정 시 단일 active 계좌가 자동 선택된다."
+            ),
+        },
+        "interval_seconds": {
+            "type": "integer",
+            "minimum": 10,
+            "maximum": 3600,
+            "default": 60,
+            "description": "봇 step 주기 (초).",
+        },
+        "budget": {
+            "type": ["number", "null"],
+            "exclusiveMinimum": 0,
+            "description": "예산 할당액 (원). 양수만 허용.",
+        },
+    },
+}
+
+
 @router.get(
     "",
     response_model=BotListResponse,
@@ -124,6 +188,27 @@ async def list_bots(
                 },
             },
         },
+        401: {
+            "description": (
+                "Authentication required (missing or invalid Authorization header "
+                "AND missing or invalid ante_session cookie). 대시보드 사용자는 "
+                "로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 "
+                "Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
+        403: {
+            "description": "Permission denied (master 권한 필요)",
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
         404: {
             "description": "Strategy not found",
             "content": {
@@ -142,11 +227,13 @@ async def list_bots(
         },
         422: {
             "description": (
-                "strategy_id/strategy_name both missing, or budget allocation"
-                " failed (Treasury error: insufficient funds, treasury not"
-                " configured for account, etc.). On budget failure the newly"
-                " created bot is rolled back via delete_bot(handle_positions="
-                "'keep')."
+                "Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, "
+                "미지정 필드, strategy_id/strategy_name 동시 누락) 또는 budget "
+                "allocation 실패 (Treasury error: insufficient funds, treasury "
+                "not configured for account, etc.). On budget failure the newly "
+                "created bot is rolled back via delete_bot(handle_positions="
+                "'keep'). 단, 인증이 실패하면 body validation은 실행되지 않고 "
+                "401이 우선 반환된다(#1371)."
             ),
             "content": {
                 "application/problem+json": {
@@ -175,22 +262,68 @@ async def list_bots(
             },
         },
     },
+    openapi_extra={
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/BotCreateRequest"},
+                },
+            },
+        },
+    },
 )
 async def create_bot(
-    body: BotCreateRequest,
     request: Request,
+    caller_id: Annotated[str, Depends(require_master_caller)],
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     registry: Annotated[Any, Depends(get_strategy_registry)],
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """봇 생성."""
+    """봇 생성. 인증된 master만 호출 가능 (#1371).
+
+    ``update_bot`` (#1352)과 동일한 raw body 파싱 패턴을 적용해 인증 가드가
+    body validation보다 우선 실행되도록 한다. FastAPI가 ``body: BotCreateRequest``
+    를 먼저 검증하면 unauth + bad-body 시 401이 아닌 422가 먼저 반환되어
+    contract가 깨진다.
+
+    핸들러 단계 순서:
+
+    1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
+       non-master → 403.
+    2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
+    3. ``BotCreateRequest.model_validate`` — ValidationError → 422.
+    4. service 호출 (``BotError`` → 409, ``TreasuryError`` → 422).
+    """
     from pathlib import Path
 
+    from ante.account.errors import AccountNotFoundError
     from ante.account.models import AccountStatus
     from ante.bot.config import BotConfig
     from ante.bot.exceptions import BotError
     from ante.strategy.loader import StrategyLoader
+
+    # 1. raw body 읽기 + JSON 파싱 — 인증 통과 후에만 실행된다.
+    raw = await request.body()
+    if raw == b"":
+        raise HTTPException(status_code=422, detail="요청 body가 비어 있습니다.")
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        raise HTTPException(
+            status_code=422, detail="요청 body의 JSON 파싱에 실패했습니다."
+        ) from None
+    if not isinstance(payload, dict):
+        raise HTTPException(
+            status_code=422, detail="요청 body는 JSON object여야 합니다."
+        )
+
+    # 2. Pydantic 검증.
+    try:
+        body = BotCreateRequest.model_validate(payload)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.errors()) from None
 
     # strategy_id / strategy_name 해석 ─────────────────────
     strategy_id = body.strategy_id
@@ -249,8 +382,17 @@ async def create_bot(
             else active[0]["account_id"]
         )
 
-    # 계좌 상태 검증: active가 아니면 봇 생성 거부
-    account = await account_service.get(account_id)
+    # 계좌 상태 검증: active가 아니면 봇 생성 거부.
+    # ``account_id`` 가 명시 전달됐는데 존재하지 않는 경우 account 라우트
+    # SSOT(``accounts.py``)와 동일하게 404로 변환한다(#1371). catch 없이
+    # propagate하면 500이 되어 client는 잘못된 입력 vs 시스템 오류를 구분할 수
+    # 없다.
+    try:
+        account = await account_service.get(account_id)
+    except AccountNotFoundError as e:
+        raise HTTPException(
+            status_code=404, detail=f"계좌를 찾을 수 없습니다: {account_id}"
+        ) from e
     if account.status != AccountStatus.ACTIVE:
         raise HTTPException(
             status_code=409,
@@ -332,7 +474,7 @@ async def create_bot(
 
     if audit_logger:
         await audit_logger.log(
-            member_id=getattr(request.state, "member_id", "anonymous"),
+            member_id=caller_id,
             action="bot.create",
             resource=f"bot:{body.bot_id}",
             detail=f"strategy={strategy_id}",
@@ -561,6 +703,27 @@ async def stop_bot(
     "/{bot_id}",
     status_code=204,
     responses={
+        401: {
+            "description": (
+                "Authentication required (missing or invalid Authorization header "
+                "AND missing or invalid ante_session cookie). 대시보드 사용자는 "
+                "로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 "
+                "Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
+        403: {
+            "description": "Permission denied (master 권한 필요)",
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
         404: {
             "description": "Bot not found",
             "content": {
@@ -598,11 +761,16 @@ async def stop_bot(
 async def delete_bot(
     bot_id: str,
     request: Request,
+    caller_id: Annotated[str, Depends(require_master_caller)],
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
     handle_positions: str = "keep",
 ) -> None:
-    """봇 삭제.
+    """봇 삭제. 인증된 master만 호출 가능 (#1371).
+
+    body가 없으므로 raw-body cold-path는 적용하지 않는다. 인증 가드가
+    handle_positions query 파라미터 검증보다 먼저 실행되어 unauth는 401,
+    non-master는 403으로 차단된다.
 
     handle_positions:
         - keep (기본): 포지션을 유지한 채 봇만 삭제.
@@ -628,7 +796,7 @@ async def delete_bot(
 
     if audit_logger:
         await audit_logger.log(
-            member_id=getattr(request.state, "member_id", "anonymous"),
+            member_id=caller_id,
             action="bot.delete",
             resource=f"bot:{bot_id}",
             detail=f"handle_positions={handle_positions}",

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -569,8 +569,11 @@ class TestCreateBotAccountStatus:
             bot_manager=bot_manager,
             account_service=suspended_account_service,
             strategy_registry=strategy_registry,
+            member_service=_new_member_service(),
         )
-        return TestClient(app)
+        client = TestClient(app)
+        client.headers.update(_MASTER_HEADERS)
+        return client
 
     def test_create_bot_suspended_account_returns_409(self, client_suspended):
         """정지된 계좌에서 봇 생성 → 409 Conflict."""
@@ -597,8 +600,10 @@ class TestCreateBotAccountStatus:
             bot_manager=bot_manager,
             account_service=account_svc,
             strategy_registry=strategy_registry,
+            member_service=_new_member_service(),
         )
         client = TestClient(app)
+        client.headers.update(_MASTER_HEADERS)
         resp = client.post(
             "/api/bots",
             json={
@@ -801,8 +806,11 @@ class TestDeleteBotAuditLog:
             bot_manager=bot_manager,
             account_service=default_account_service,
             audit_logger=fake_audit_logger,
+            member_service=_new_member_service(),
         )
-        return TestClient(app)
+        client = TestClient(app)
+        client.headers.update(_MASTER_HEADERS)
+        return client
 
     def test_audit_log_records_keep(self, client_with_audit, bot_manager, audit_logs):
         """감사 로그에 handle_positions=keep 기록."""
@@ -1019,8 +1027,11 @@ class TestCreateBotStrategyName:
             bot_manager=bot_manager,
             account_service=default_account_service,
             strategy_registry=strategy_registry,
+            member_service=_new_member_service(),
         )
-        return TestClient(app)
+        client = TestClient(app)
+        client.headers.update(_MASTER_HEADERS)
+        return client
 
     def test_create_bot_with_strategy_name(self, client_with_registry):
         """strategy_name으로 봇 생성 성공."""
@@ -1091,8 +1102,10 @@ class TestCreateBotStrategyName:
             bot_manager=bot_manager,
             account_service=empty_svc,
             strategy_registry=strategy_registry,
+            member_service=_new_member_service(),
         )
         client = TestClient(app)
+        client.headers.update(_MASTER_HEADERS)
         resp = client.post(
             "/api/bots",
             json={
@@ -1115,8 +1128,10 @@ class TestCreateBotStrategyName:
             bot_manager=bot_manager,
             account_service=multi_svc,
             strategy_registry=strategy_registry,
+            member_service=_new_member_service(),
         )
         client = TestClient(app)
+        client.headers.update(_MASTER_HEADERS)
         resp = client.post(
             "/api/bots",
             json={

--- a/tests/unit/test_bot_routes_create_budget_error.py
+++ b/tests/unit/test_bot_routes_create_budget_error.py
@@ -17,11 +17,13 @@ from ante.web.app import create_app  # noqa: E402
 
 # 기존 테스트 파일의 Fake 들을 재사용한다.
 from tests.unit.test_bot_api import (  # noqa: E402
+    _MASTER_HEADERS,
     FakeAccount,
     FakeAccountService,
     FakeBotManager,
     FakeStrategyRecord,
     FakeStrategyRegistry,
+    _new_member_service,
 )
 
 
@@ -63,12 +65,17 @@ def strategy_registry() -> FakeStrategyRegistry:
 
 @pytest.fixture
 def client(bot_manager, account_service, strategy_registry) -> TestClient:
+    # POST /api/bots는 master 인증을 요구하므로(#1371), 본 회귀 테스트는
+    # default Authorization 헤더 + member_service stub을 함께 주입한다.
     app = create_app(
         bot_manager=bot_manager,
         account_service=account_service,
         strategy_registry=strategy_registry,
+        member_service=_new_member_service(),
     )
-    return TestClient(app)
+    client = TestClient(app)
+    client.headers.update(_MASTER_HEADERS)
+    return client
 
 
 def _install_treasury_error_on_update(

--- a/tests/unit/test_runtime_mutation_auth.py
+++ b/tests/unit/test_runtime_mutation_auth.py
@@ -1,12 +1,14 @@
-"""Account/Bot/Treasury mutation route 인증 가드 테스트 (issue #1352).
+"""Account/Bot/Treasury mutation route 인증 가드 테스트 (issue #1352, #1371).
 
-oracle A7 시그니처에서 발견된 5개 mutation route는 인증된 master 호출자만
+oracle A7 시그니처에서 발견된 mutation route는 인증된 master 호출자만
 사용할 수 있어야 한다.
 - ``PUT  /api/accounts/{id}``
 - ``POST /api/accounts/{id}/suspend``
 - ``POST /api/accounts/{id}/activate``
 - ``PUT  /api/bots/{id}``
 - ``POST /api/treasury/balance``
+- ``POST /api/bots`` (#1371)
+- ``DELETE /api/bots/{id}`` (#1371)
 
 각 라우트 × 인증 시나리오:
 - Authorization 헤더 + 세션 쿠키 모두 없음 → 401
@@ -221,10 +223,12 @@ class _FakeBot:
 
 
 class FakeBotManager:
-    """``bot_manager.get_bot / update_bot`` stub."""
+    """``bot_manager.get_bot / update_bot / create_bot / delete_bot`` stub."""
 
     def __init__(self) -> None:
         self.update_calls: list[dict] = []
+        self.create_calls: list[dict] = []
+        self.delete_calls: list[dict] = []
         self._bots: dict[str, _FakeBot] = {
             "bot-target": _FakeBot("bot-target", name="Original"),
         }
@@ -243,6 +247,50 @@ class FakeBotManager:
         if "name" in kwargs and kwargs["name"] is not None:
             bot._name = kwargs["name"]
         return bot
+
+    async def create_bot(self, config, strategy_cls, **kwargs):
+        bot_id = getattr(config, "bot_id", "")
+        self.create_calls.append({"bot_id": bot_id})
+        bot = _FakeBot(bot_id, name=getattr(config, "name", "") or bot_id)
+        bot.config.account_id = getattr(config, "account_id", "acc-target")
+        bot.config.strategy_id = getattr(config, "strategy_id", "strat-1")
+        bot.config.interval_seconds = getattr(config, "interval_seconds", 60)
+        self._bots[bot_id] = bot
+        return bot
+
+    async def delete_bot(
+        self, bot_id: str, handle_positions: str = "keep", hard: bool = False
+    ):
+        self.delete_calls.append(
+            {"bot_id": bot_id, "handle_positions": handle_positions, "hard": hard}
+        )
+        self._bots.pop(bot_id, None)
+
+
+@dataclass
+class _FakeStrategyRecord:
+    strategy_id: str = "strat-1"
+    name: str = "test-strategy"
+    version: str = "1.0.0"
+    author_name: str = "tester"
+    author_id: str = "tester"
+    description: str = "test strategy"
+    filepath: str = "/tmp/strat-1.py"
+
+
+class FakeStrategyRegistry:
+    """``registry.get / get_by_name`` stub."""
+
+    def __init__(self) -> None:
+        self._records: dict[str, _FakeStrategyRecord] = {
+            "strat-1": _FakeStrategyRecord(strategy_id="strat-1", name="test-strategy"),
+        }
+
+    async def get(self, strategy_id: str):
+        return self._records.get(strategy_id)
+
+    async def get_by_name(self, name: str):
+        return [r for r in self._records.values() if r.name == name]
 
 
 class FakeTreasury:
@@ -307,12 +355,31 @@ def treasury() -> FakeTreasury:
 
 
 @pytest.fixture
+def strategy_registry() -> FakeStrategyRegistry:
+    return FakeStrategyRegistry()
+
+
+@pytest.fixture
+def _mock_strategy_loader(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``StrategyLoader.load`` 모킹 — 테스트 파일 시스템 의존성 제거."""
+
+    class _FakeStrategy:
+        pass
+
+    monkeypatch.setattr(
+        "ante.strategy.loader.StrategyLoader.load",
+        staticmethod(lambda path: _FakeStrategy),
+    )
+
+
+@pytest.fixture
 def client(
     member_service: FakeMemberService,
     session_service: FakeSessionService,
     account_service: FakeAccountService,
     bot_manager: FakeBotManager,
     treasury: FakeTreasury,
+    strategy_registry: FakeStrategyRegistry,
 ) -> TestClient:
     app = create_app(
         member_service=member_service,
@@ -320,6 +387,7 @@ def client(
         account_service=account_service,
         bot_manager=bot_manager,
         treasury=treasury,
+        strategy_registry=strategy_registry,
     )
     return TestClient(app)
 
@@ -330,6 +398,7 @@ def client_no_session_service(
     account_service: FakeAccountService,
     bot_manager: FakeBotManager,
     treasury: FakeTreasury,
+    strategy_registry: FakeStrategyRegistry,
 ) -> TestClient:
     """``session_service is None`` 배포 분기 시뮬레이션."""
     app = create_app(
@@ -337,6 +406,7 @@ def client_no_session_service(
         account_service=account_service,
         bot_manager=bot_manager,
         treasury=treasury,
+        strategy_registry=strategy_registry,
     )
     return TestClient(app)
 
@@ -1042,10 +1112,10 @@ class TestExtraForbid:
 
 
 class TestOpenAPIResponses401403:
-    """5개 mutation route의 OpenAPI ``responses``에 401/403 항목이 있어야 한다.
+    """mutation route의 OpenAPI ``responses``에 401/403 항목이 있어야 한다.
 
     ``frontend/openapi.json`` codegen 산출물이 401/403 분기를 인식할 수 있도록
-    contract에 명시해야 한다(#1352 risk: contract-drift).
+    contract에 명시해야 한다(#1352 / #1371 risk: contract-drift).
     """
 
     @pytest.mark.parametrize(
@@ -1056,6 +1126,9 @@ class TestOpenAPIResponses401403:
             ("/api/accounts/{account_id}/activate", "post"),
             ("/api/bots/{bot_id}", "put"),
             ("/api/treasury/balance", "post"),
+            # #1371: 봇 lifecycle (create / delete) 인증 가드 추가.
+            ("/api/bots", "post"),
+            ("/api/bots/{bot_id}", "delete"),
         ],
     )
     def test_openapi_lists_401_response(self, path: str, method: str) -> None:
@@ -1076,6 +1149,9 @@ class TestOpenAPIResponses401403:
             ("/api/accounts/{account_id}/activate", "post"),
             ("/api/bots/{bot_id}", "put"),
             ("/api/treasury/balance", "post"),
+            # #1371: 봇 lifecycle (create / delete) 인증 가드 추가.
+            ("/api/bots", "post"),
+            ("/api/bots/{bot_id}", "delete"),
         ],
     )
     def test_openapi_lists_403_response(self, path: str, method: str) -> None:
@@ -1090,13 +1166,13 @@ class TestOpenAPIResponses401403:
 
     @pytest.mark.parametrize(
         "schema_name",
-        ["BotUpdateRequest", "BalanceSetRequest"],
+        ["BotCreateRequest", "BotUpdateRequest", "BalanceSetRequest"],
     )
     def test_openapi_components_schemas_registered(self, schema_name: str) -> None:
-        """``BotUpdateRequest`` / ``BalanceSetRequest``는 raw body 패턴 적용으로
-        FastAPI 자동 등록 경로를 거치지 않으므로, ``_install_openapi_customizer``
-        가 ``components.schemas``에 명시 등록해야 frontend codegen이
-        ``export type``을 만들 수 있다.
+        """``BotCreateRequest`` / ``BotUpdateRequest`` / ``BalanceSetRequest``는
+        raw body 패턴 적용으로 FastAPI 자동 등록 경로를 거치지 않으므로,
+        ``_install_openapi_customizer``가 ``components.schemas``에 명시 등록해야
+        frontend codegen이 ``export type``을 만들 수 있다.
         """
         app = create_app()
         schema = app.openapi()
@@ -1105,3 +1181,282 @@ class TestOpenAPIResponses401403:
             f"components.schemas에 {schema_name}가 등록되어 있지 않음: "
             f"{sorted(components.keys())[:30]}..."
         )
+
+
+# ── #1371: POST /api/bots / DELETE /api/bots/{id} 인증 매트릭스 ─────────
+
+
+_VALID_CREATE_PAYLOAD: dict = {
+    "bot_id": "bot-new",
+    "strategy_name": "test-strategy",
+    "account_id": "acc-target",
+    "interval_seconds": 60,
+}
+
+
+class TestCreateBotAuthMatrix:
+    """``POST /api/bots`` 는 ``update_bot`` (#1352) 와 동일한 raw-body 패턴 +
+    auth-first 계약을 따른다 (#1371). 인증 가드가 body 파싱보다 먼저 실행되어야
+    한다.
+
+    401/403 시 ``bot_manager.create_bot`` 이 호출되지 않음을 mock spy
+    (``create_calls``) 로 검증한다.
+    """
+
+    # 401 — 인증 자체가 없음 ─────────────────────────────────────────
+
+    def test_create_bot_unauth_returns_401(
+        self, client: TestClient, bot_manager: FakeBotManager, _mock_strategy_loader
+    ) -> None:
+        resp = client.post("/api/bots", json=_VALID_CREATE_PAYLOAD)
+        assert resp.status_code == 401, resp.text
+        assert bot_manager.create_calls == []
+
+    def test_create_bot_invalid_bearer_returns_401(
+        self, client: TestClient, bot_manager: FakeBotManager, _mock_strategy_loader
+    ) -> None:
+        resp = client.post(
+            "/api/bots",
+            json=_VALID_CREATE_PAYLOAD,
+            headers={"Authorization": "Bearer invalid-token"},
+        )
+        assert resp.status_code == 401, resp.text
+        assert bot_manager.create_calls == []
+
+    def test_create_bot_invalid_session_cookie_returns_401(
+        self, client: TestClient, bot_manager: FakeBotManager, _mock_strategy_loader
+    ) -> None:
+        client.cookies.set("ante_session", "unknown-session-id")
+        resp = client.post("/api/bots", json=_VALID_CREATE_PAYLOAD)
+        assert resp.status_code == 401, resp.text
+        assert bot_manager.create_calls == []
+        client.cookies.delete("ante_session")
+
+    def test_create_bot_session_service_none_no_bearer_returns_401(
+        self,
+        client_no_session_service: TestClient,
+        bot_manager: FakeBotManager,
+        _mock_strategy_loader,
+    ) -> None:
+        client_no_session_service.cookies.set("ante_session", "any-session-id")
+        resp = client_no_session_service.post("/api/bots", json=_VALID_CREATE_PAYLOAD)
+        assert resp.status_code == 401, resp.text
+        assert bot_manager.create_calls == []
+        client_no_session_service.cookies.delete("ante_session")
+
+    # auth-first: bad body 라도 401 우선 ─────────────────────────────
+
+    def test_create_bot_unauth_invalid_body_returns_401(
+        self, client: TestClient, bot_manager: FakeBotManager, _mock_strategy_loader
+    ) -> None:
+        """unauth + body invalid → 401 (NOT 422). update_bot 패턴 답습."""
+        resp = client.post(
+            "/api/bots",
+            json={"bot_id": "bot-x", "interval_seconds": "not-a-number"},
+        )
+        assert resp.status_code == 401, (
+            f"인증 가드가 body validation보다 먼저 실행되어야 한다 — "
+            f"got {resp.status_code}: {resp.text}"
+        )
+        assert bot_manager.create_calls == []
+
+    def test_create_bot_unauth_malformed_json_returns_401(
+        self, client: TestClient, bot_manager: FakeBotManager, _mock_strategy_loader
+    ) -> None:
+        """unauth + malformed JSON → 401 (NOT 422)."""
+        resp = client.post(
+            "/api/bots",
+            content=b"{not-json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 401, resp.text
+        assert bot_manager.create_calls == []
+
+    # 200 (실제 POST는 201) — master 인증 통과 ─────────────────────────
+
+    def test_create_bot_master_bearer_succeeds(
+        self, client: TestClient, bot_manager: FakeBotManager, _mock_strategy_loader
+    ) -> None:
+        resp = client.post(
+            "/api/bots",
+            json=_VALID_CREATE_PAYLOAD,
+            headers={"Authorization": "Bearer master-token"},
+        )
+        assert resp.status_code == 201, resp.text
+        assert bot_manager.create_calls[-1]["bot_id"] == "bot-new"
+
+    def test_create_bot_master_session_cookie_succeeds(
+        self, client: TestClient, bot_manager: FakeBotManager, _mock_strategy_loader
+    ) -> None:
+        client.cookies.set("ante_session", "master-session-id")
+        resp = client.post("/api/bots", json=_VALID_CREATE_PAYLOAD)
+        assert resp.status_code == 201, resp.text
+        assert bot_manager.create_calls[-1]["bot_id"] == "bot-new"
+        client.cookies.delete("ante_session")
+
+    # 422 — 인증 통과 + body invalid → 정상 검증 경로 ─────────────────
+
+    def test_create_bot_master_invalid_body_returns_422(
+        self, client: TestClient, bot_manager: FakeBotManager, _mock_strategy_loader
+    ) -> None:
+        resp = client.post(
+            "/api/bots",
+            json={"bot_id": "bot-y", "interval_seconds": "not-a-number"},
+            headers={"Authorization": "Bearer master-token"},
+        )
+        assert resp.status_code == 422
+        assert bot_manager.create_calls == []
+
+    def test_create_bot_master_empty_body_returns_422(
+        self, client: TestClient, bot_manager: FakeBotManager, _mock_strategy_loader
+    ) -> None:
+        resp = client.post(
+            "/api/bots",
+            content=b"",
+            headers={
+                "Authorization": "Bearer master-token",
+                "Content-Type": "application/json",
+            },
+        )
+        assert resp.status_code == 422
+        assert bot_manager.create_calls == []
+
+    # 403 — 인증된 non-master ────────────────────────────────────────
+
+    def test_create_bot_non_master_bearer_returns_403(
+        self, client: TestClient, bot_manager: FakeBotManager, _mock_strategy_loader
+    ) -> None:
+        resp = client.post(
+            "/api/bots",
+            json=_VALID_CREATE_PAYLOAD,
+            headers={"Authorization": "Bearer agent-token"},
+        )
+        assert resp.status_code == 403, resp.text
+        assert bot_manager.create_calls == []
+
+    # 404 — master + missing strategy / account ─────────────────────
+
+    def test_create_bot_master_strategy_not_found_returns_404(
+        self, client: TestClient, bot_manager: FakeBotManager, _mock_strategy_loader
+    ) -> None:
+        resp = client.post(
+            "/api/bots",
+            json={
+                "bot_id": "bot-z",
+                "strategy_name": "no-such-strategy",
+                "account_id": "acc-target",
+            },
+            headers={"Authorization": "Bearer master-token"},
+        )
+        assert resp.status_code == 404, resp.text
+        assert bot_manager.create_calls == []
+
+    def test_create_bot_master_account_not_found_returns_404(
+        self,
+        client: TestClient,
+        bot_manager: FakeBotManager,
+        account_service: FakeAccountService,
+        _mock_strategy_loader,
+    ) -> None:
+        """master 인증 통과 + 존재하지 않는 account_id → 404 (AccountNotFoundError).
+
+        ``AccountNotFoundError``는 web layer에서 404로 변환된다 (account 라우트
+        SSOT와 동일). 봇은 생성되지 않아야 한다.
+        """
+        resp = client.post(
+            "/api/bots",
+            json={
+                "bot_id": "bot-q",
+                "strategy_name": "test-strategy",
+                "account_id": "no-such-account",
+            },
+            headers={"Authorization": "Bearer master-token"},
+        )
+        assert resp.status_code == 404, resp.text
+        assert bot_manager.create_calls == []
+
+
+class TestDeleteBotAuthMatrix:
+    """``DELETE /api/bots/{id}`` 인증 가드 매트릭스 (#1371). body 가 없으므로
+    raw-body cold-path는 적용되지 않지만 인증 → 404 → mutation 순서를 따른다.
+
+    401/403 시 ``bot_manager.delete_bot`` 이 호출되지 않음을 mock spy
+    (``delete_calls``) 로 검증한다.
+    """
+
+    def test_delete_bot_unauth_returns_401(
+        self, client: TestClient, bot_manager: FakeBotManager
+    ) -> None:
+        resp = client.delete("/api/bots/bot-target")
+        assert resp.status_code == 401, resp.text
+        assert bot_manager.delete_calls == []
+
+    def test_delete_bot_invalid_bearer_returns_401(
+        self, client: TestClient, bot_manager: FakeBotManager
+    ) -> None:
+        resp = client.delete(
+            "/api/bots/bot-target",
+            headers={"Authorization": "Bearer invalid-token"},
+        )
+        assert resp.status_code == 401, resp.text
+        assert bot_manager.delete_calls == []
+
+    def test_delete_bot_invalid_session_cookie_returns_401(
+        self, client: TestClient, bot_manager: FakeBotManager
+    ) -> None:
+        client.cookies.set("ante_session", "unknown-session-id")
+        resp = client.delete("/api/bots/bot-target")
+        assert resp.status_code == 401, resp.text
+        assert bot_manager.delete_calls == []
+        client.cookies.delete("ante_session")
+
+    def test_delete_bot_session_service_none_no_bearer_returns_401(
+        self,
+        client_no_session_service: TestClient,
+        bot_manager: FakeBotManager,
+    ) -> None:
+        client_no_session_service.cookies.set("ante_session", "any-session-id")
+        resp = client_no_session_service.delete("/api/bots/bot-target")
+        assert resp.status_code == 401, resp.text
+        assert bot_manager.delete_calls == []
+        client_no_session_service.cookies.delete("ante_session")
+
+    def test_delete_bot_master_bearer_succeeds(
+        self, client: TestClient, bot_manager: FakeBotManager
+    ) -> None:
+        resp = client.delete(
+            "/api/bots/bot-target",
+            headers={"Authorization": "Bearer master-token"},
+        )
+        assert resp.status_code == 204, resp.text
+        assert bot_manager.delete_calls[-1]["bot_id"] == "bot-target"
+        assert bot_manager.delete_calls[-1]["handle_positions"] == "keep"
+
+    def test_delete_bot_master_session_cookie_succeeds(
+        self, client: TestClient, bot_manager: FakeBotManager
+    ) -> None:
+        client.cookies.set("ante_session", "master-session-id")
+        resp = client.delete("/api/bots/bot-target")
+        assert resp.status_code == 204, resp.text
+        assert bot_manager.delete_calls[-1]["bot_id"] == "bot-target"
+        client.cookies.delete("ante_session")
+
+    def test_delete_bot_non_master_bearer_returns_403(
+        self, client: TestClient, bot_manager: FakeBotManager
+    ) -> None:
+        resp = client.delete(
+            "/api/bots/bot-target",
+            headers={"Authorization": "Bearer agent-token"},
+        )
+        assert resp.status_code == 403, resp.text
+        assert bot_manager.delete_calls == []
+
+    def test_delete_bot_master_missing_returns_404(
+        self, client: TestClient, bot_manager: FakeBotManager
+    ) -> None:
+        resp = client.delete(
+            "/api/bots/no-such-bot",
+            headers={"Authorization": "Bearer master-token"},
+        )
+        assert resp.status_code == 404, resp.text
+        assert bot_manager.delete_calls == []


### PR DESCRIPTION
Closes #1371

## Summary
- `POST /api/bots`와 `DELETE /api/bots/{bot_id}`가 인증 없이 익명 호출을 받아들이는 oracle A7 finding 수정.
- `create_bot`을 #1352 `update_bot` 패턴으로 raw-body cold-path 변환 + `Depends(require_master_caller)` 가드 + `responses` 401/403/422 + `openapi_extra` 등록.
- `delete_bot`은 body 없으므로 raw-body 불필요, `Depends(require_master_caller)`만 추가.
- `src/ante/web/app.py::_install_openapi_customizer`에 `BotCreateRequest` schema component 수동 등록.
- 기존 `tests/unit/test_bot_api.py` / `test_bot_routes_create_budget_error.py`에 master 인증 fixture 보강.
- `tests/unit/test_runtime_mutation_auth.py`에 `TestCreateBotAuthMatrix` (13) + `TestDeleteBotAuthMatrix` (8) 신규.
- `frontend/openapi.json` + `frontend/src/types/api.generated.ts` 재생성.
- `AccountNotFoundError` → 404 매핑 추가 (인증 후 invalid account_id에서 500 회귀 방지).

## Test Plan
- [x] `ruff check` / `ruff format --check` 통과 (5 files)
- [x] `pytest tests/unit/test_runtime_mutation_auth.py -q` → 98 passed
- [x] `pytest tests/unit/test_bot_api.py -q` → 58 passed
- [x] `pytest tests/unit/test_bot_routes_create_budget_error.py -q` → 7 passed
- [x] `pytest tests/unit -k "bot_routes or bot_api or bot_manager" -q` → 111 passed
- [x] `pytest tests/unit/test_web_api.py -k "openapi" -q` → 18 passed (frontend openapi.json sync)
- [x] `pytest tests/unit -k "web or api or openapi" -q` → 515 passed

## Notes
- Codex Plan Review: approve-implement (revision 2, autopilot batch 20260510-0810)
- Codex 브랜치 리뷰: PASS (3rd attempt; 1-2차는 codex review process silently die — 동일 verdict; 3차 foreground에서 PASS 확인)
- Non-Goals: `start_bot`/`stop_bot`/`set_bot_budget` 등 다른 mutation route 인증 가드는 follow-up
- scope decision: master-only (보수, 사용자 triage 명시); `require_scope("bot:admin")` Web factory는 인프라 follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)