### PR TITLE
fix(config): reject invalid system.log_level value at service boundary (#1379)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2285,7 +2285,7 @@
           "config"
         ],
         "summary": "Update Config",
-        "description": "동적 설정 값 변경. 인증된 master/human 또는 config:write scope 보유\nagent 만 호출 가능 (#1373).\n\n``update_bot`` (#1352) / ``create_bot`` (#1371) / ``allocate`` (#1372)\n와 동일한 raw body 파싱 패턴을 적용해 인증 가드가 body validation 보다\n우선 실행되도록 한다. FastAPI 가 ``body: ConfigUpdateRequest`` 를 먼저\n검증하면 unauth + bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract\n가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_config_write)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``ConfigUpdateRequest.model_validate`` — ValidationError → 422.\n4. config 키 존재 확인 → 404.\n5. ``config_service.set`` 호출 + audit 기록 (changed_by = caller_id).",
+        "description": "동적 설정 값 변경. 인증된 master/human 또는 config:write scope 보유\nagent 만 호출 가능 (#1373).\n\n``update_bot`` (#1352) / ``create_bot`` (#1371) / ``allocate`` (#1372)\n와 동일한 raw body 파싱 패턴을 적용해 인증 가드가 body validation 보다\n우선 실행되도록 한다. FastAPI 가 ``body: ConfigUpdateRequest`` 를 먼저\n검증하면 unauth + bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract\n가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_config_write)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``ConfigUpdateRequest.model_validate`` — ValidationError → 422.\n4. config 키 존재 확인 → 404.\n5. ``config_service.set`` 호출 + audit 기록 (changed_by = caller_id).\n   서비스 경계에서 ``validate_value`` 가 키별 invariant 를 검증하므로\n   ``ValueError`` 가 올라오면 422 로 변환한다 (#1379).",
         "operationId": "update_config_api_config__key__put",
         "parameters": [
           {
@@ -2340,7 +2340,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, value 누락, type mismatch). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1373).",
+            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, value 누락, type mismatch) 또는 키별 invariant 위반 (예: ``system.log_level`` 가 ``_VALID_LOG_LEVELS`` 멤버가 아닌 경우 — 대소문자 구분, #1379). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1373).",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -620,6 +620,8 @@ export type paths = {
          *     3. ``ConfigUpdateRequest.model_validate`` — ValidationError → 422.
          *     4. config 키 존재 확인 → 404.
          *     5. ``config_service.set`` 호출 + audit 기록 (changed_by = caller_id).
+         *        서비스 경계에서 ``validate_value`` 가 키별 invariant 를 검증하므로
+         *        ``ValueError`` 가 올라오면 422 로 변환한다 (#1379).
          */
         put: operations["update_config_api_config__key__put"];
         post?: never;
@@ -5080,7 +5082,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Body validation 실패 (JSON 파싱 실패, 빈 body, value 누락, type mismatch). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1373). */
+            /** @description Body validation 실패 (JSON 파싱 실패, 빈 body, value 누락, type mismatch) 또는 키별 invariant 위반 (예: ``system.log_level`` 가 ``_VALID_LOG_LEVELS`` 멤버가 아닌 경우 — 대소문자 구분, #1379). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1373). */
             422: {
                 headers: {
                     [name: string]: unknown;

--- a/src/ante/config/dynamic.py
+++ b/src/ante/config/dynamic.py
@@ -14,6 +14,31 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+_VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+
+
+def validate_value(key: str, value: Any) -> None:
+    """키별 값 검증 (서비스 경계에서 호출).
+
+    `system.log_level` 처럼 enum SSOT가 정의된 키는 invalid 값을 즉시 거부한다.
+    정의되지 않은 키는 통과(generic CRUD 동작 유지).
+
+    대소문자 정책: `system.log_level` 은 대소문자 구분으로 거부한다. 즉
+    ``_VALID_LOG_LEVELS`` 멤버(전부 대문자)와 정확 일치해야 통과하고,
+    ``"debug"`` 같은 소문자 입력은 ValueError 로 거부된다 (#1379 oracle A7).
+
+    Raises:
+        ValueError: 키별 invariant 를 위반한 경우. 호출자(web/IPC/CLI)는
+            이를 422 등 도메인 응답으로 변환해야 한다.
+    """
+    if key == "system.log_level":
+        if not isinstance(value, str) or value not in _VALID_LOG_LEVELS:
+            raise ValueError(
+                "system.log_level은 _VALID_LOG_LEVELS 멤버여야 합니다 (대소문자 구분)."
+            )
+
+
 DYNAMIC_CONFIG_SCHEMA = """
 CREATE TABLE IF NOT EXISTS dynamic_config (
     key       TEXT PRIMARY KEY,
@@ -66,8 +91,14 @@ class DynamicConfigService:
     async def set(
         self, key: str, value: Any, category: str, changed_by: str = "system"
     ) -> None:
-        """동적 설정 값 변경 + 이력 기록 + EventBus 알림."""
+        """동적 설정 값 변경 + 이력 기록 + EventBus 알림.
+
+        키별 invariant 가 정의된 경우 ``validate_value`` 가 ValueError 를
+        발생시킨다(서비스 경계 검증, IPC/CLI 우회 차단 — #1379).
+        """
         from ante.eventbus.events import ConfigChangedEvent
+
+        validate_value(key, value)
 
         old_value = None
         if await self.exists(key):
@@ -189,11 +220,15 @@ class DynamicConfigService:
         return count
 
 
-_VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
-
-
 def _on_log_level_changed(event: Any) -> None:
-    """system.log_level 변경 시 루트 로거 레벨을 동적으로 갱신한다."""
+    """system.log_level 변경 시 루트 로거 레벨을 동적으로 갱신한다.
+
+    서비스 경계에서 ``validate_value`` 가 invalid 값을 차단하므로 이 callback
+    까지 invalid 값이 도달하는 일은 정상 경로에서는 발생하지 않는다(#1379).
+    그래도 startup hook 이 historical persisted bad-value 를 publish 하거나
+    구독자 순서가 바뀌는 경우를 대비해 silent-drop 을 defense-in-depth 로
+    유지한다.
+    """
     if event.key != "system.log_level":
         return
 

--- a/src/ante/web/routes/config.py
+++ b/src/ante/web/routes/config.py
@@ -124,8 +124,10 @@ async def list_configs(
         422: {
             "description": (
                 "Body validation 실패 (JSON 파싱 실패, 빈 body, value 누락, "
-                "type mismatch). 단, 인증이 실패하면 body validation은 실행되지 "
-                "않고 401이 우선 반환된다(#1373)."
+                "type mismatch) 또는 키별 invariant 위반 (예: "
+                "``system.log_level`` 가 ``_VALID_LOG_LEVELS`` 멤버가 아닌 "
+                "경우 — 대소문자 구분, #1379). 단, 인증이 실패하면 body "
+                "validation은 실행되지 않고 401이 우선 반환된다(#1373)."
             ),
             "content": {
                 "application/problem+json": {
@@ -177,6 +179,8 @@ async def update_config(
     3. ``ConfigUpdateRequest.model_validate`` — ValidationError → 422.
     4. config 키 존재 확인 → 404.
     5. ``config_service.set`` 호출 + audit 기록 (changed_by = caller_id).
+       서비스 경계에서 ``validate_value`` 가 키별 invariant 를 검증하므로
+       ``ValueError`` 가 올라오면 422 로 변환한다 (#1379).
     """
     # 1. raw body 읽기 + JSON 파싱 — 인증 통과 후에만 실행된다.
     raw = await request.body()
@@ -209,7 +213,14 @@ async def update_config(
     category = body.category or key.split(".")[0]
 
     # changed_by 를 caller_id 로 통일 (이전: 하드코딩된 "dashboard").
-    await config_service.set(key, body.value, category=category, changed_by=caller_id)
+    # DynamicConfigService.set 는 키별 invariant 검증 실패 시 ValueError 를
+    # raise 한다 (#1379 oracle A7 — system.log_level enum 검증). 422 변환.
+    try:
+        await config_service.set(
+            key, body.value, category=category, changed_by=caller_id
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from None
 
     if audit_logger:
         await audit_logger.log(

--- a/tests/unit/ipc/test_registry.py
+++ b/tests/unit/ipc/test_registry.py
@@ -458,3 +458,64 @@ class TestHandleBrokerReconcile:
 
         assert result == {"bot_id": "unknown-bot", "adjustments": []}
         fake_reconciler.reconcile.assert_awaited_once()
+
+
+# ── #1379 oracle A7: IPC config.set 핸들러도 서비스 경계 ValueError 전파 ──
+
+
+class TestHandleConfigSetValidation:
+    """``_handle_config_set`` 이 ``DynamicConfigService.set`` 의 ValueError 를
+    그대로 전파하는지 검증한다(IPC 우회 차단, #1379).
+    """
+
+    async def test_invalid_log_level_propagates_value_error(self):
+        """invalid system.log_level → ValueError (IPC 단계 차단)."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ante.ipc.registry import _handle_config_set
+
+        async def _set(key, value, category, changed_by):  # noqa: ANN001, ANN202
+            from ante.config.dynamic import validate_value
+
+            validate_value(key, value)
+
+        fake_dynamic = MagicMock()
+        fake_dynamic.set = AsyncMock(side_effect=_set)
+
+        svc = MagicMock()
+        svc.dynamic_config = fake_dynamic
+
+        with pytest.raises(ValueError, match="system.log_level"):
+            await _handle_config_set(
+                svc,
+                {
+                    "key": "system.log_level",
+                    "value": "ORACLE_INVALID_LEVEL",
+                    "category": "system",
+                },
+                "cli-user",
+            )
+
+    async def test_valid_log_level_succeeds(self):
+        """``DEBUG`` 같은 정상 값은 통과."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ante.ipc.registry import _handle_config_set
+
+        fake_dynamic = MagicMock()
+        fake_dynamic.set = AsyncMock(return_value=None)
+
+        svc = MagicMock()
+        svc.dynamic_config = fake_dynamic
+
+        result = await _handle_config_set(
+            svc,
+            {
+                "key": "system.log_level",
+                "value": "DEBUG",
+                "category": "system",
+            },
+            "cli-user",
+        )
+        assert result == {"key": "system.log_level", "value": "DEBUG"}
+        fake_dynamic.set.assert_awaited_once()

--- a/tests/unit/test_dynamic_config.py
+++ b/tests/unit/test_dynamic_config.py
@@ -112,3 +112,58 @@ async def test_json_complex_types(service):
 
     await service.set("dict_val", {"a": 1}, category="test")
     assert await service.get("dict_val") == {"a": 1}
+
+
+# ── #1379 oracle A7: system.log_level 서비스 경계 검증 ────────────────
+
+
+async def test_set_invalid_log_level_raises_value_error(service, eventbus):
+    """invalid system.log_level 값은 ValueError 로 거부된다 (서비스 경계).
+
+    IPC/CLI/web 어느 경로든 서비스 경계를 통과하지 못해야 한다 — oracle
+    probe 가 보낸 ``ORACLE_INVALID_LEVEL`` 같은 값이 dynamic_config 와
+    history 에 영구 저장되는 경로를 차단한다.
+    """
+    with pytest.raises(ValueError, match="system.log_level"):
+        await service.set("system.log_level", "ORACLE_INVALID_LEVEL", category="system")
+
+    # 영속/이벤트 사이드이펙트가 발생하지 않아야 한다.
+    assert not await service.exists("system.log_level")
+    assert eventbus.published == []
+
+
+async def test_set_valid_log_level_succeeds(service, eventbus):
+    """``_VALID_LOG_LEVELS`` 멤버(대문자) 값은 그대로 통과한다."""
+    await service.set("system.log_level", "DEBUG", category="system")
+    assert await service.get("system.log_level") == "DEBUG"
+    assert len(eventbus.published) == 1
+
+
+async def test_set_unknown_key_no_validation_succeeds(service):
+    """invariant 가 정의되지 않은 키는 generic CRUD 동작 그대로 통과."""
+    # 임의 string/dict/list 모두 통과해야 generic 동작이 유지된다.
+    await service.set("any.unknown.key", "anything", category="misc")
+    assert await service.get("any.unknown.key") == "anything"
+
+    await service.set("another.unknown", {"complex": [1, 2]}, category="misc")
+    assert await service.get("another.unknown") == {"complex": [1, 2]}
+
+
+async def test_set_lowercase_log_level_raises_value_error(service, eventbus):
+    """대소문자 정책: 소문자 ``"debug"`` 는 거부 (대소문자 구분, #1379)."""
+    with pytest.raises(ValueError, match="대소문자 구분"):
+        await service.set("system.log_level", "debug", category="system")
+
+    assert not await service.exists("system.log_level")
+    assert eventbus.published == []
+
+
+async def test_set_non_string_log_level_raises_value_error(service, eventbus):
+    """문자열이 아닌 값(숫자/None 등)도 거부."""
+    with pytest.raises(ValueError, match="system.log_level"):
+        await service.set("system.log_level", 10, category="system")
+    with pytest.raises(ValueError, match="system.log_level"):
+        await service.set("system.log_level", None, category="system")
+
+    assert not await service.exists("system.log_level")
+    assert eventbus.published == []

--- a/tests/unit/test_system_config_api.py
+++ b/tests/unit/test_system_config_api.py
@@ -11,6 +11,7 @@ httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
 from fastapi.testclient import TestClient  # noqa: E402
 
+from ante.config.dynamic import validate_value  # noqa: E402
 from ante.web.app import create_app  # noqa: E402
 
 # ── Member / Session fakes (#1373 update_config 인증 가드 추가) ──────────
@@ -112,6 +113,10 @@ class FakeDynamicConfig:
         category: str = "",
         changed_by: str = "",
     ) -> None:
+        # 실제 DynamicConfigService.set 과 동일하게 서비스 경계에서 invariant
+        # 를 검증한다 (#1379). web 라우트가 ValueError 를 422 로 매핑하는지
+        # 검증하려면 fake stub 도 같은 invariant 를 강제해야 한다.
+        validate_value(key, value)
         self._configs[key] = {"value": value, "category": category}
 
 
@@ -340,3 +345,78 @@ class TestDynamicConfig:
             headers=_MASTER_HEADERS,
         )
         assert resp.status_code == 404
+
+    # ── #1379 oracle A7: system.log_level enum 검증 ─────────────────────
+
+    def test_config_update_invalid_log_level_returns_422(self, client, dynamic_config):
+        """invalid system.log_level 값 → 422 (master 인증, #1379).
+
+        oracle probe 가 ``ORACLE_INVALID_LEVEL`` 같은 값을 인증 토큰과 함께
+        보내도 dynamic_config 가 영구 저장되어선 안 된다. 서비스 경계에서
+        ``ValueError`` 가 발생하고 라우트가 이를 422 로 변환한다.
+        """
+        dynamic_config._configs["system.log_level"] = {
+            "value": "INFO",
+            "category": "system",
+        }
+        resp = client.put(
+            "/api/config/system.log_level",
+            json={"value": "ORACLE_INVALID_LEVEL"},
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 422
+        # 영구 저장은 일어나지 않아야 한다 — 기존 INFO 값이 유지.
+        assert dynamic_config._configs["system.log_level"]["value"] == "INFO"
+
+    def test_config_update_valid_log_level_succeeds(self, client, dynamic_config):
+        """``_VALID_LOG_LEVELS`` 멤버(대문자) → 200 (master 인증, #1379)."""
+        dynamic_config._configs["system.log_level"] = {
+            "value": "INFO",
+            "category": "system",
+        }
+        resp = client.put(
+            "/api/config/system.log_level",
+            json={"value": "DEBUG"},
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["new_value"] == "DEBUG"
+        assert dynamic_config._configs["system.log_level"]["value"] == "DEBUG"
+
+    def test_config_update_lowercase_log_level_returns_422(
+        self, client, dynamic_config
+    ):
+        """소문자 ``"debug"`` → 422 (대소문자 구분 정책, #1379).
+
+        callback ``_on_log_level_changed`` 는 ``.upper()`` 정규화를 하지만
+        web layer 는 사용자 입력을 그대로 검증하여 enum SSOT 와 정확
+        일치만 통과시킨다. 입력 의도 변경(silent normalize)을 거부.
+        """
+        dynamic_config._configs["system.log_level"] = {
+            "value": "INFO",
+            "category": "system",
+        }
+        resp = client.put(
+            "/api/config/system.log_level",
+            json={"value": "debug"},
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 422
+        assert dynamic_config._configs["system.log_level"]["value"] == "INFO"
+
+    def test_config_update_unknown_key_validation_skipped(self, client, dynamic_config):
+        """invariant 가 정의되지 않은 키는 generic 동작 유지 (#1379).
+
+        ``system.log_level`` 만 검증 대상이며, 다른 키는 follow-up scope.
+        기존 동작이 회귀하지 않음을 잠근다.
+        """
+        dynamic_config._configs["risk.max_mdd"] = {
+            "value": 0.1,
+            "category": "risk",
+        }
+        resp = client.put(
+            "/api/config/risk.max_mdd",
+            json={"value": "anything-still-passes"},
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 200


### PR DESCRIPTION
Closes #1379

## Summary
- 인증된 `PUT /api/config/system.log_level`이 invalid value(예: `"NOTSET"`, `"debug"`)를 200으로 통과시키는 oracle A7 finding 수정.
- 검증 위치를 `DynamicConfigService.set()` 서비스 경계로 두어 web/CLI/IPC 모든 경로 차단.
- `validate_value(key, value)` helper 신설: `system.log_level`은 `_VALID_LOG_LEVELS` 정확 일치 (대소문자 구분).
- `update_config` 핸들러에서 `ValueError` → `HTTPException(422)` 매핑.
- `_on_log_level_changed` callback의 silent-drop 동작은 defense-in-depth로 유지 (historical persisted bad-value publish 보호).

## Test Plan
- [x] `tests/unit/test_dynamic_config.py`: 5개 신규 테스트 (서비스 경계, valid/invalid/lowercase/unknown_key)
- [x] `tests/unit/test_system_config_api.py`: 4개 신규 테스트 (web 라우트 422/200, FakeDynamicConfig 정합)
- [x] `tests/unit/ipc/test_registry.py`: IPC `_handle_config_set` ValueError 전파 회귀
- [x] `tests/unit/test_dynamic_log_level.py`: 기존 callback silent-drop 회귀 유지
- [x] `pytest tests/unit -k "config or dynamic_config or dynamic_log_level" -q` → 336 passed
- [x] `pytest tests/unit/test_web_api.py -k openapi -q` → 24 passed
- [x] `ruff check` / `ruff format --check` 통과

## Notes
- Codex Plan Review: approve-implement (revision 3, autopilot batch 20260510-0810)
- Codex 브랜치 리뷰: PASS
- 대소문자 정책: 거부 (silent normalize 회피, 사용자 입력 의도 보존)
- 범위: `system.log_level`만; 다른 키 검증은 follow-up
- `git diff main -- config/db/` 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)