### PR TITLE
fix(rule): reject NaN/Inf in account rule params at service boundary (#1380)

### DIFF
--- a/src/ante/rule/global_rules.py
+++ b/src/ante/rule/global_rules.py
@@ -2,9 +2,30 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 from ante.rule.base import Rule, RuleAction, RuleContext, RuleEvaluation, RuleResult
+
+
+def _is_finite_numeric(value: Any) -> bool:
+    """``value`` 가 finite int/float 인지 판정 (bool 명시 제외).
+
+    이중 방어 layer (#1380): RuleUpdateRequest 단에서 NaN/Inf 가 거부되지만,
+    DynamicConfig load 등 다른 경로에서 invalid value 가 들어와도 RULE_REGISTRY
+    가 fail-closed 로 막아야 한다. ``bool`` 은 numeric 흉내 방지를 위해 명시
+    제외한다 (``isinstance(True, int) == True``). 거대 ``int`` 는 ``float``
+    변환 시 ``OverflowError`` 가 발생하므로 finite 가 아니라고 판정한다 —
+    rule/engine.py:69-80 ``_is_finite_quantity`` 와 동일한 정책.
+    """
+    if isinstance(value, bool):
+        return False
+    if not isinstance(value, (int, float)):
+        return False
+    try:
+        return math.isfinite(value)
+    except (OverflowError, ValueError, TypeError):
+        return False
 
 
 class DailyLossLimitRule(Rule):
@@ -22,7 +43,9 @@ class DailyLossLimitRule(Rule):
         for key, upper in cls._PARAM_LIMITS.items():
             if key in params:
                 v = params[key]
-                if not isinstance(v, int | float) or v < 0:
+                if not _is_finite_numeric(v):
+                    errors.append(f"{key} must be a finite number")
+                elif v < 0:
                     errors.append(f"{key} must be >= 0")
                 elif v > upper:
                     errors.append(f"{key} must be <= {upper}")
@@ -90,13 +113,17 @@ class TotalExposureLimitRule(Rule):
         errors: list[str] = []
         if "max_exposure_percent" in params:
             v = params["max_exposure_percent"]
-            if not isinstance(v, int | float) or v < 0:
+            if not _is_finite_numeric(v):
+                errors.append("max_exposure_percent must be a finite number")
+            elif v < 0:
                 errors.append("max_exposure_percent must be >= 0")
             elif v > 1:
                 errors.append("max_exposure_percent must be <= 1")
         if "max_exposure_amount" in params:
             v = params["max_exposure_amount"]
-            if not isinstance(v, int | float) or v < 0:
+            if not _is_finite_numeric(v):
+                errors.append("max_exposure_amount must be a finite number")
+            elif v < 0:
                 errors.append("max_exposure_amount must be >= 0")
         return errors
 

--- a/src/ante/rule/strategy_rules.py
+++ b/src/ante/rule/strategy_rules.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from ante.rule.base import Rule, RuleAction, RuleContext, RuleEvaluation, RuleResult
+from ante.rule.global_rules import _is_finite_numeric
 
 
 class PositionSizeRule(Rule):
@@ -15,13 +16,17 @@ class PositionSizeRule(Rule):
         errors: list[str] = []
         if "max_position_percent" in params:
             v = params["max_position_percent"]
-            if not isinstance(v, int | float) or v < 0:
+            if not _is_finite_numeric(v):
+                errors.append("max_position_percent must be a finite number")
+            elif v < 0:
                 errors.append("max_position_percent must be >= 0")
             elif v > 1:
                 errors.append("max_position_percent must be <= 1")
         if "max_position_amount" in params:
             v = params["max_position_amount"]
-            if not isinstance(v, int | float) or v < 0:
+            if not _is_finite_numeric(v):
+                errors.append("max_position_amount must be a finite number")
+            elif v < 0:
                 errors.append("max_position_amount must be >= 0")
         return errors
 
@@ -75,7 +80,9 @@ class UnrealizedLossLimitRule(Rule):
         errors: list[str] = []
         if "max_unrealized_loss_percent" in params:
             v = params["max_unrealized_loss_percent"]
-            if not isinstance(v, int | float) or v < 0:
+            if not _is_finite_numeric(v):
+                errors.append("max_unrealized_loss_percent must be a finite number")
+            elif v < 0:
                 errors.append("max_unrealized_loss_percent must be >= 0")
             elif v > 1:
                 errors.append("max_unrealized_loss_percent must be <= 1")
@@ -126,7 +133,9 @@ class TradeFrequencyRule(Rule):
         errors: list[str] = []
         if "max_trades_per_hour" in params:
             v = params["max_trades_per_hour"]
-            if not isinstance(v, int | float) or v < 0:
+            if not _is_finite_numeric(v):
+                errors.append("max_trades_per_hour must be a finite number")
+            elif v < 0:
                 errors.append("max_trades_per_hour must be >= 0")
         return errors
 

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -1190,7 +1190,17 @@ async def update_account_rule(
     try:
         body = RuleUpdateRequest.model_validate(payload)
     except ValidationError as e:
-        raise HTTPException(status_code=422, detail=e.errors()) from None
+        # ``include_context=False, include_input=False`` 로 detail 을 sanitize 한다
+        # (#1380 codex review P1). NaN/Inf 가 ``params`` 안에 들어오면 Pydantic
+        # 기본 ``e.errors()`` 는 ``ctx.error`` 에 ``ValueError`` 객체와
+        # ``input`` 에 non-finite ``float`` 를 그대로 포함시키는데, Starlette
+        # ``JSONResponse(allow_nan=False)`` 가 이를 직렬화하지 못해 의도한 422
+        # 대신 500 이 반환된다. 두 필드를 빼면 detail 은 순수 JSON-호환 dict
+        # list 가 되고, 호출자는 ``loc`` / ``msg`` 만 받게 된다.
+        raise HTTPException(
+            status_code=422,
+            detail=e.errors(include_context=False, include_input=False),
+        ) from None
 
     # 3. 계좌 존재 확인
     try:

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import re
 from datetime import time as dtime
 from typing import Any
@@ -1017,11 +1018,75 @@ class RuleListResponse(BaseModel):
     rules: list[RuleItem]
 
 
+# ``RuleUpdateRequest.params`` 는 룰별로 schema 가 다른 ``dict[str, Any]`` open
+# object 다 (OpenAPI ``additionalProperties: true``). 하지만 모든 룰의 numeric
+# threshold 는 finite real number 여야 한다 — ``NaN`` / ``Inf`` 는 비교 의미가
+# 없어 fail-open 회귀나 ``json.dumps`` 직렬화 후 다운스트림 파싱 에러를 유발한다
+# (#1380 oracle A7). 본 helper 는 finite/Inf 검증을 ``params`` 트리 전체에 재귀
+# 적용하여 service 경계에서 422 로 잘라낸다. RULE_REGISTRY 단의 finite 검사는
+# 이중 방어로 따로 둔다.
+def _reject_non_finite(value: Any) -> None:
+    """``params`` 트리 안에 ``NaN`` / ``Inf`` numeric 이 있으면 ``ValueError``.
+
+    - ``bool`` → 통과 (``isinstance(True, int) == True`` 이므로 numeric 분기에서
+      가로채면 안 된다 — bool 정책은 RULE_REGISTRY ``validate_config`` 에서
+      별도로 거부한다).
+    - ``int`` / ``float`` → ``math.isnan`` / ``math.isinf`` 검사. Python ``int``
+      는 임의 정밀도라 ``10**10000`` 같은 거대 정수 ``float`` 변환에서
+      ``OverflowError`` 가 떨어질 수 있다 (``rule/engine.py:69-80``
+      ``_is_finite_quantity`` 패턴 참조). ``OverflowError`` / ``ValueError`` /
+      ``TypeError`` 는 finite-호환이 아니므로 동일하게 ``ValueError`` 로 매핑한다.
+    - ``dict`` / ``list`` / ``tuple`` → 요소 재귀.
+    - 그 외 (``str``, ``None`` 등) → 통과 (numeric 검증 대상 아님).
+    """
+    if isinstance(value, bool):
+        return
+    if isinstance(value, (int, float)):
+        try:
+            if math.isnan(value) or math.isinf(value):
+                raise ValueError(
+                    "params 의 numeric 값은 finite 여야 합니다 (NaN/Inf 거부)."
+                )
+        except (OverflowError, TypeError) as exc:
+            raise ValueError(
+                "params 의 numeric 값은 finite 여야 합니다 (NaN/Inf 거부)."
+            ) from exc
+        return
+    if isinstance(value, dict):
+        for v in value.values():
+            _reject_non_finite(v)
+        return
+    if isinstance(value, (list, tuple)):
+        for v in value:
+            _reject_non_finite(v)
+        return
+
+
 class RuleUpdateRequest(BaseModel):
-    """룰 설정 변경 요청."""
+    """룰 설정 변경 요청.
+
+    ``params`` 는 룰별 schema 를 갖는 open object 지만, 모든 numeric threshold
+    는 finite 여야 한다 (#1380 oracle A7). ``json.loads`` default 는 ``NaN`` /
+    ``Infinity`` / ``-Infinity`` 를 ``float('nan')`` / ``float('inf')`` 로
+    파싱하므로, raw body parser 가 통과시킨 값을 본 모델 단에서 422 로 거부한다.
+    bool 은 numeric 흉내 방지를 위해 ``_reject_non_finite`` 가 통과시키되,
+    RULE_REGISTRY ``validate_config`` 가 known numeric key 에 대해 별도로
+    거부한다.
+    """
 
     enabled: bool = True
     params: dict[str, Any] = {}
+
+    @field_validator("params")
+    @classmethod
+    def _validate_params_finite(cls, v: dict[str, Any]) -> dict[str, Any]:
+        """``params`` 트리에서 ``NaN`` / ``Inf`` numeric 을 거부.
+
+        실패 시 ``ValueError`` 를 raise 하여 FastAPI 가 ``ValidationError`` →
+        422 로 매핑하도록 한다 (#1380).
+        """
+        _reject_non_finite(v)
+        return v
 
 
 class RuleUpdateResponse(BaseModel):

--- a/tests/unit/test_account_rules_api.py
+++ b/tests/unit/test_account_rules_api.py
@@ -660,6 +660,286 @@ class TestRuleConfigValidation:
         assert resp.status_code == 422
 
 
+class TestRuleConfigNonFiniteRejection:
+    """PUT /api/accounts/{id}/rules/{type} — NaN/Inf 거부 (#1380 oracle A7).
+
+    인증된 master 호출이 ``params`` 안의 ``NaN`` / ``Infinity`` /
+    ``-Infinity`` 같은 non-finite numeric threshold 를 200 으로 통과시키던
+    회귀를 차단한다. raw body 로 ``NaN`` literal 을 보내야 한다 — httpx
+    ``json=`` 은 ``allow_nan=False`` 라 numeric NaN 을 직렬화하지 못하기
+    때문이다. ``json.loads`` default 는 ``NaN`` literal 을 ``float('nan')`` 으로
+    파싱하므로, ``RuleUpdateRequest`` 의 ``field_validator`` 가 그 결과를 422
+    로 잘라내야 한다. 422 시 ``DynamicConfig.set`` / RuleEngine reload 가
+    호출되지 않아야 한다 (spy).
+    """
+
+    def test_account_rule_update_nan_threshold_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        dynamic_config: FakeDynamicConfig,
+    ) -> None:
+        """``max_daily_loss_percent: NaN`` 은 422 로 거부되고 persist 되지 않는다."""
+        _add_account(account_service, "acct-1")
+
+        resp = client.put(
+            "/api/accounts/acct-1/rules/daily_loss_limit",
+            content=b'{"enabled": true, "params": {"max_daily_loss_percent": NaN}}',
+            headers={
+                **_MASTER_HEADERS,
+                "Content-Type": "application/json",
+            },
+        )
+        assert resp.status_code == 422
+        # 응답 body 가 valid JSON 으로 직렬화되어야 한다 (#1380 codex P1).
+        # ``e.errors()`` 기본 출력은 ``ctx.error`` 에 ``ValueError`` 객체와
+        # ``input`` 에 ``float('nan')`` 을 포함시킨다. RFC7807 핸들러
+        # (``ante.web.errors``) 가 ``str(exc.detail)`` 로 stringify 하더라도,
+        # sanitize 안 된 detail 에는 ``ValueError(...)`` repr 과 ``ctx`` /
+        # ``input`` key 가 그대로 노출되어 클라이언트에 내부 디버그 정보가
+        # 누설되며, future 핸들러가 ``detail`` 을 raw list 로 보내면 NaN 이
+        # ``JSONResponse(allow_nan=False)`` 를 깨뜨려 500 으로 회귀한다.
+        # 핸들러는 ``include_context=False, include_input=False`` 로 detail 을
+        # sanitize 하여 순수 ``loc`` / ``msg`` 만 노출해야 한다.
+        body = resp.json()
+        # detail 표현은 RFC7807 핸들러에 의해 string 일 수 있다 — 어느 쪽이든
+        # ``ctx`` / ``input`` / ``ValueError(`` 디버그 토큰이 노출되어서는
+        # 안 된다.
+        detail = body["detail"]
+        detail_str = detail if isinstance(detail, str) else str(detail)
+        assert "ValueError(" not in detail_str
+        assert "'ctx'" not in detail_str
+        assert "'input'" not in detail_str
+        # spy: 422 시 stored 가 비어 있어야 한다 (set 미호출).
+        assert "accounts.acct-1.rules" not in dynamic_config._store
+
+    def test_account_rule_update_positive_inf_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        dynamic_config: FakeDynamicConfig,
+    ) -> None:
+        """``max_daily_loss_percent: Infinity`` 는 422 로 거부된다."""
+        _add_account(account_service, "acct-1")
+
+        resp = client.put(
+            "/api/accounts/acct-1/rules/daily_loss_limit",
+            content=(
+                b'{"enabled": true, "params": {"max_daily_loss_percent": Infinity}}'
+            ),
+            headers={
+                **_MASTER_HEADERS,
+                "Content-Type": "application/json",
+            },
+        )
+        assert resp.status_code == 422
+        # 응답이 valid JSON 으로 직렬화되어야 한다 (#1380 codex P1 sanitize).
+        resp.json()
+        assert "accounts.acct-1.rules" not in dynamic_config._store
+
+    def test_account_rule_update_negative_inf_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        dynamic_config: FakeDynamicConfig,
+    ) -> None:
+        """``max_daily_loss_percent: -Infinity`` 는 422 로 거부된다."""
+        _add_account(account_service, "acct-1")
+
+        resp = client.put(
+            "/api/accounts/acct-1/rules/daily_loss_limit",
+            content=(
+                b'{"enabled": true, "params": {"max_daily_loss_percent": -Infinity}}'
+            ),
+            headers={
+                **_MASTER_HEADERS,
+                "Content-Type": "application/json",
+            },
+        )
+        assert resp.status_code == 422
+        # 응답이 valid JSON 으로 직렬화되어야 한다 (#1380 codex P1 sanitize).
+        resp.json()
+        assert "accounts.acct-1.rules" not in dynamic_config._store
+
+    def test_account_rule_update_nested_dict_nan_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        dynamic_config: FakeDynamicConfig,
+    ) -> None:
+        """nested dict 안의 ``NaN`` 도 재귀적으로 거부된다.
+
+        ``params`` 는 ``dict[str, Any]`` open object 이므로, 룰별로 nested
+        struct (예: ``{"thresholds": {"warn": NaN}}``) 가 등장할 수 있다.
+        helper 가 dict values 를 재귀하여 ``NaN`` 을 잡아야 한다.
+        """
+        _add_account(account_service, "acct-1")
+
+        resp = client.put(
+            "/api/accounts/acct-1/rules/daily_loss_limit",
+            content=(b'{"enabled": true, "params": {"thresholds": {"warn": NaN}}}'),
+            headers={
+                **_MASTER_HEADERS,
+                "Content-Type": "application/json",
+            },
+        )
+        assert resp.status_code == 422
+        # 응답이 valid JSON 으로 직렬화되어야 한다 (#1380 codex P1 sanitize).
+        resp.json()
+        assert "accounts.acct-1.rules" not in dynamic_config._store
+
+    def test_account_rule_update_list_with_nan_returns_422(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        dynamic_config: FakeDynamicConfig,
+    ) -> None:
+        """list 요소 안의 ``NaN`` 도 재귀적으로 거부된다."""
+        _add_account(account_service, "acct-1")
+
+        resp = client.put(
+            "/api/accounts/acct-1/rules/daily_loss_limit",
+            content=(b'{"enabled": true, "params": {"steps": [0.05, NaN, 0.10]}}'),
+            headers={
+                **_MASTER_HEADERS,
+                "Content-Type": "application/json",
+            },
+        )
+        assert resp.status_code == 422
+        # 응답이 valid JSON 으로 직렬화되어야 한다 (#1380 codex P1 sanitize).
+        resp.json()
+        assert "accounts.acct-1.rules" not in dynamic_config._store
+
+    def test_account_rule_update_finite_threshold_succeeds(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        dynamic_config: FakeDynamicConfig,
+    ) -> None:
+        """finite ``max_daily_loss_percent`` happy path 회귀 보호 (#1380)."""
+        _add_account(account_service, "acct-1")
+
+        resp = client.put(
+            "/api/accounts/acct-1/rules/daily_loss_limit",
+            json={"enabled": True, "params": {"max_daily_loss_percent": 0.05}},
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 200
+        # finite 값은 정상 persist 되어야 한다.
+        assert "accounts.acct-1.rules" in dynamic_config._store
+
+    def test_account_rule_update_bool_param_handling(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        dynamic_config: FakeDynamicConfig,
+    ) -> None:
+        """numeric param key 에 ``bool`` 이 오면 RULE_REGISTRY 가 422 로 거부.
+
+        정책 (#1380):
+        - schema 단 ``_reject_non_finite`` 는 ``bool`` 을 통과시킨다 (numeric
+          분기에서 가로채지 않음).
+        - RULE_REGISTRY ``validate_config`` 는 known numeric key 에 대해
+          ``_is_finite_numeric`` 으로 ``bool`` 을 거부한다.
+        - 결과: ``params={"max_daily_loss_percent": True}`` 는 RULE_REGISTRY
+          단계에서 422 가 떨어진다.
+        """
+        _add_account(account_service, "acct-1")
+
+        resp = client.put(
+            "/api/accounts/acct-1/rules/daily_loss_limit",
+            json={"enabled": True, "params": {"max_daily_loss_percent": True}},
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 422
+        assert "max_daily_loss_percent" in resp.json()["detail"]
+        # 422 시 persist 되지 않아야 한다.
+        assert "accounts.acct-1.rules" not in dynamic_config._store
+
+
+class TestRuleUpdateRequestSchema:
+    """``RuleUpdateRequest`` Pydantic 단위 검증 (#1380).
+
+    web 라우트 통합 테스트와 별도로, schema 자체가 ``NaN`` / ``Inf`` 를
+    ``ValidationError`` 로 거부하는지 unit-level 로 보호한다.
+    """
+
+    def test_rule_update_request_field_validator_rejects_nan(self) -> None:
+        from pydantic import ValidationError
+
+        from ante.web.schemas import RuleUpdateRequest
+
+        with pytest.raises(ValidationError):
+            RuleUpdateRequest.model_validate(
+                {
+                    "enabled": True,
+                    "params": {"max_daily_loss_percent": float("nan")},
+                }
+            )
+
+    def test_rule_update_request_field_validator_rejects_positive_inf(self) -> None:
+        from pydantic import ValidationError
+
+        from ante.web.schemas import RuleUpdateRequest
+
+        with pytest.raises(ValidationError):
+            RuleUpdateRequest.model_validate(
+                {
+                    "enabled": True,
+                    "params": {"max_daily_loss_percent": float("inf")},
+                }
+            )
+
+    def test_rule_update_request_field_validator_rejects_negative_inf(self) -> None:
+        from pydantic import ValidationError
+
+        from ante.web.schemas import RuleUpdateRequest
+
+        with pytest.raises(ValidationError):
+            RuleUpdateRequest.model_validate(
+                {
+                    "enabled": True,
+                    "params": {"max_daily_loss_percent": float("-inf")},
+                }
+            )
+
+    def test_rule_update_request_field_validator_rejects_nested_nan(self) -> None:
+        from pydantic import ValidationError
+
+        from ante.web.schemas import RuleUpdateRequest
+
+        with pytest.raises(ValidationError):
+            RuleUpdateRequest.model_validate(
+                {
+                    "enabled": True,
+                    "params": {"nested": {"deeper": [1.0, float("nan")]}},
+                }
+            )
+
+    def test_rule_update_request_field_validator_accepts_finite(self) -> None:
+        from ante.web.schemas import RuleUpdateRequest
+
+        body = RuleUpdateRequest.model_validate(
+            {
+                "enabled": True,
+                "params": {"max_daily_loss_percent": 0.05},
+            }
+        )
+        assert body.params == {"max_daily_loss_percent": 0.05}
+
+    def test_rule_update_request_field_validator_passes_bool(self) -> None:
+        """``bool`` 은 schema 단에서 통과 — RULE_REGISTRY 가 별도로 거부한다."""
+        from ante.web.schemas import RuleUpdateRequest
+
+        body = RuleUpdateRequest.model_validate(
+            {
+                "enabled": True,
+                "params": {"some_flag": True},
+            }
+        )
+        assert body.params == {"some_flag": True}
+
+
 class TestAccountRulesEffectiveMergeContract:
     """PUT API와 effective rules merge의 계약 검증 (#1296).
 


### PR DESCRIPTION
Closes #1380

## Summary
- 인증된 `PUT /api/accounts/{account_id}/rules/{rule_type}`이 `max_daily_loss_percent: NaN`을 200으로 통과시키는 oracle A7 finding 수정.
- 1차 방어: `RuleUpdateRequest.params`에 `field_validator` + 재귀 helper `_reject_non_finite` (dict/list nested traversal, bool 통과, int/float NaN/Inf 거부).
- 2차 방어: RULE_REGISTRY validate_config 보강 (`DailyLossLimitRule`, `TotalExposureLimitRule`, `PositionSizeRule`, `UnrealizedLossLimitRule`, `TradeFrequencyRule`)에서 known numeric key의 finite + bool 명시 거부 (DynamicConfig 직접 load 등 schema 우회 경로 보호).
- 422 응답 sanitize: `update_account_rule`에서 `e.errors(include_context=False, include_input=False)`로 ValueError ctx + non-finite input 노출 방지 (Starlette JSONResponse `allow_nan=False` 직렬화 실패 회피).
- `tests/unit/test_account_rules_api.py`: `TestRuleConfigNonFiniteRejection` (7 케이스, NaN/Inf/nested dict/list with `resp.json()` 직렬화 가드 + 디버그 토큰 누설 회귀 보호) + `TestRuleUpdateRequestSchema` (6 케이스, schema 단위).

## Test Plan
- [x] `ruff check` / `ruff format --check` 통과
- [x] `pytest tests/unit -k "rule or account" -q` → 968 passed
- [x] `pytest tests/unit/test_account_rules_api.py -q` → 37 passed (신규 13 + 기존 24)
- [x] `pytest tests/unit/test_web_api.py -k openapi -q` → 24 passed

## Notes
- Codex Plan Review: approve-implement (revision 2, autopilot batch 20260510-0810)
- Codex 브랜치 리뷰: PASS (2nd attempt; 1차 P1 finding "JSONResponse 직렬화 실패 위험"을 `e.errors(include_context=False, include_input=False)` sanitize로 해결)
- `RuleUpdateRequest.params`는 `dict[str, Any]` open object로 유지 (finite 제약은 JSON schema로 표현 안 됨, 런타임 422가 SSOT)
- 다른 raw-body 라우트의 sanitize는 strict-typed payload라 finding 재현 가능성 낮음 → follow-up issue로 분리 (공통 헬퍼 또는 RequestValidationError 핸들러 단)
- `git diff main -- config/db/` 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)