### PR TITLE
docs(auth): add D-015 default-deny auth gate ADR + Web/CLI spec updates (#1402)

### DIFF
--- a/docs/decisions/D-015-default-deny-auth-gate.md
+++ b/docs/decisions/D-015-default-deny-auth-gate.md
@@ -1,0 +1,97 @@
+# D-015: default-deny 인증 게이트 (2026-05-11)
+
+> Ante 설계 결정 기록.
+> 인덱스: [README.md](README.md)
+
+**결정**: Web API와 CLI 모두 인증을 **default-deny + allowlist (opt-out)** 게이트로
+전환한다. middleware/group factory가 1차 차단(인증)을 담당하고, dependency/decorator는
+scope 검증만 담당한다.
+
+**근거**:
+
+- 기존 Web/CLI는 라우트/명령마다 `Depends(require_*)` 또는 `@require_auth`를 명시적으로
+  부착하는 **opt-in 모델**이다. 70개 Web 라우트 중 30개만 인증이 부착돼 있고, 나머지는
+  `TokenAuthMiddleware`가 Bearer가 있을 때만 인증을 시도한 뒤 그대로 통과시킨다
+  (`src/ante/web/middleware/token_auth.py:42-49`).
+- 그 결과 oracle A7 host probe가 새로운 인증 누락을 사후에 반복적으로 발견하고 있다
+  (#1351, #1352, #1357, #1358, #1359, #1360, #1369, #1370, #1371-#1380).
+- `docs/specs/member/02-design-decisions.md` Authorization SSOT는 "endpoint별 / command별
+  required scope를 검사"라고 정의했지만, **부착 강제 메커니즘 자체는 spec에 빠져 있다**.
+  default-deny가 명시적으로 거부된 게 아니라 단지 정의되지 않았다.
+- default-deny로 전환하면 새 라우트/명령 추가 시 자동으로 401/exit 1이 발생하며, 공개
+  접근이 의도된 표면은 allowlist에 명시적으로 등록해야 한다. 즉 "공개"가 누락이 아닌
+  의도된 결정으로 드러난다.
+- `require_scope` predicate(human bypass + agent scope 검증)는 이미 SSOT에 정의되어
+  있으므로 그대로 유지하고 dependency 단의 책임으로만 둔다.
+
+**책임 분리**:
+
+| 단계 | 책임 | 위치 |
+|------|------|------|
+| 1차 차단 (authentication) | 인증된 principal이 있는지 확인. 없으면 401 (Web) / exit 1 (CLI). | Web: middleware. CLI: group factory. |
+| 2차 차단 (authorization) | required scope를 만족하는지 확인. agent가 부족하면 403. human은 bypass. | Web: dependency. CLI: decorator. |
+
+middleware/factory는 scope를 모른다. dependency/decorator는 인증된 principal을 전제로
+한다. 이 분리로 인증 실패와 권한 부족이 다른 단계에서 다른 코드로 응답된다.
+
+**Web 미들웨어 책임 매트릭스 (Bearer/Session/Gate 분담)**:
+
+Web 1차 차단은 두 인증 transport(Bearer 헤더, `ante_session` 쿠키)를 모두 인식해야
+한다. `POST /api/auth/login`으로 로그인한 dashboard 사용자는 Bearer 헤더 없이 쿠키만
+보내므로, gate 미들웨어가 쿠키 fallback을 직접 수행하거나 별도 단계에서 부착해야
+한다. 그렇지 않으면 정상 로그인 세션도 모든 보호 라우트에서 401을 받는다.
+
+| 미들웨어 | 책임 | principal 부착 결과 |
+|----------|------|---------------------|
+| `TokenAuthMiddleware` | `Authorization: Bearer` 헤더가 있으면 검증해 `request.state.member_id`/`request.state.member`에 caller를 부착. 없거나 실패면 그대로 통과(401 raise 안 함). | Bearer caller |
+| `RequireAuthMiddleware` (신규, #1403) | 아래 **5단계 판정 순서**를 따라 caller를 결정한다(상세는 [web-api/02-design-decisions.md](../specs/web-api/02-design-decisions.md#인증-게이트-단계)). 1) HTTP `OPTIONS` preflight면 즉시 통과. 2) 경로가 `PUBLIC_PATHS` / `PUBLIC_PREFIXES` allowlist 또는 비-`/api` SPA fallback이면 즉시 통과(세션 fallback / ACTIVE 검사도 수행하지 않음). 3) `request.state.member_id`가 이미 부착돼 있으면(=Bearer caller) 그대로 통과. 4) Bearer caller가 없으면 `ante_session` 쿠키를 직접 검증하고 `member.status == ACTIVE`를 명시 확인한 뒤 caller를 부착. 5) 어느 단계로도 caller가 결정되지 않으면 401. | Bearer caller (위 단계에서 부착) 또는 Session caller (gate가 부착) |
+| 라우트 dependency / `@require_scope` | 인증된 principal을 전제로 scope만 검사. agent에 대해서만 required scope를 검증하고, human은 bypass. | — |
+
+`RequireAuthMiddleware`의 세션 쿠키 fallback은 기존 dependency
+(`require_master_caller`, `require_audit_read` 등이 `src/ante/web/deps.py:267-345`에서
+이미 동일한 fallback을 수행)와 같은 SessionService 인터페이스(`session.validate`)를
+사용한다. 미들웨어가 caller를 부착하면 dependency 단의 fallback은 자연스럽게
+no-op이 되고, 두 단이 같은 caller에 합의한다.
+
+대안적으로 `Audit → TokenAuth → SessionAuth → RequireAuth`처럼 세션 fallback을
+별도 미들웨어로 분리할 수 있으나, 본 결정에서는 단일 `RequireAuthMiddleware`가
+"인증된 principal 부착 + 미부착 시 401"을 함께 수행하는 것을 SSOT로 둔다.
+이유: (1) gate가 단일 책임 지점이 되어야 default-deny invariant가 한 곳에서 보장됨,
+(2) 추가 미들웨어 단계는 Audit / OpenAPI / SPA fallback 등과 순서 결합이 늘어
+유지보수가 어렵기 때문.
+
+**판정 순서 SSOT 위치 (Codex review v5 Finding 2)**: 위 책임 매트릭스의
+`RequireAuthMiddleware` 5단계 순서(OPTIONS preflight → PUBLIC allowlist →
+Bearer caller → 세션 fallback + ACTIVE → 미결정 시 401)는 본 ADR과
+[web-api/02-design-decisions.md](../specs/web-api/02-design-decisions.md#인증-게이트-단계)
+양쪽에서 동일하게 유지한다. 두 문서는 cross-link으로 묶여 있으며, 어느 한쪽이
+바뀌면 다른 쪽도 같은 라운드에서 정정해야 한다. 특히 "공개 경로 면제"는 항상
+"세션 fallback / ACTIVE 검사"보다 **먼저** 평가되어야 하며, 이 순서가 깨지면
+`SUSPENDED`/`REVOKED` 멤버가 `/login` SPA 진입이나 `POST /api/auth/logout` 같은
+복구/공개 경로 자체를 차단당해 재로그인 / 쿠키 정리 경로가 막힌다.
+
+**Alternatives considered**:
+
+- **opt-in 유지 + 정적 검증 게이트만 추가**: 라우트 정의에 `Depends(require_*)`가 있는지
+  AST/test로 강제. 누락 시 CI 실패. → 정적 검증은 효과적이지만 런타임 안전망이 없다.
+  검증 게이트 자체에 누락이 생기면 다시 oracle finding으로 회귀한다. default-deny는
+  런타임 차단까지 보장한다.
+- **FastAPI `dependencies=[Depends(...)]` per-router 부착**: APIRouter 생성 시 default
+  dependency를 모든 라우트에 일괄 적용. → 라우터별 boilerplate가 생기고, 공개 라우트는
+  router를 분리해야 한다. middleware 단일 게이트가 라우터 구성 자유도를 더 보존한다.
+
+**Consequences**:
+
+- 새 라우트/명령 추가 시 별도 조치 없이 자동 401/exit 1 차단. 의도된 공개는 allowlist에
+  명시.
+- 공개 라우트는 `PUBLIC_PATHS` / `PUBLIC_PREFIXES` allowlist로 관리한다. SSOT는
+  [docs/specs/web-api/09-public-paths.md](../specs/web-api/09-public-paths.md).
+- CLI 공개 명령은 `_AUTH_EXEMPT_COMMAND_PATHS` allowlist로 관리한다. SSOT는
+  [docs/specs/cli/03-commands.md](../specs/cli/03-commands.md).
+- `require_scope`(human bypass + agent scope 검증)는 dependency/decorator 단에 그대로
+  유지된다. middleware/factory는 scope를 검사하지 않는다.
+- 70-route 전수 결정 표는 본 결정의 SSOT 범위를 벗어나므로 별도 이슈 #1409로 분리한다.
+  본 결정은 정책과 책임 분리만 확정한다.
+- 후속 구현 이슈: #1403 (Web middleware), #1404 (CLI factory), #1405 (정적 검증),
+  #1406 (factory shim), #1407 (라우트 일관 부착), #1408 (import 마이그레이션),
+  #1409 (70-route 결정 표).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -21,9 +21,10 @@
 | [D-012](D-012.md) | 포지션 소유권 및 자금/리스크 관심사 분리 | 2026-03-12 | 포지션은 Trade, 예산은 Treasury, 리스크는 Rule Engine |
 | [D-013](D-013.md) | Stop Order 에뮬레이션 | - | Stop/Stop-Limit 주문을 시스템 내에서 에뮬레이션 |
 | [D-014](D-014.md) | 설정 API 구조 — Config API 단일화 | 2026-03-23 | 설정 화면은 기존 Config API로 일원화 |
+| [D-015](D-015-default-deny-auth-gate.md) | default-deny 인증 게이트 | 2026-05-11 | Web/CLI 모두 default-deny + allowlist (opt-out), middleware=인증·dependency=scope |
 
 ## 사용 규칙
 
-- 새 결정은 `D-015.md` 같은 새 문서로 추가한다.
+- 새 결정은 `D-016.md` 같은 새 문서로 추가한다.
 - 이 인덱스에는 새 문서 링크와 한 줄 요약만 추가한다.
 - 과거 결정을 수정할 때는 해당 `D-xxx.md` 문서를 직접 수정한다.

--- a/docs/runbooks/01-development-process.md
+++ b/docs/runbooks/01-development-process.md
@@ -254,6 +254,20 @@ API 스키마 계약의 상세 SSOT는 [docs/dashboard/architecture.md](../dashb
 - 새 엔드포인트와 응답 변경은 생성 타입 동기화까지 검증 계획에 포함한다.
 - 프론트 소비자가 있으면 `frontend/src/api/*.ts` adapter와 UI/domain model 동기화도 같은 검증 계획에 포함한다. `api.generated.ts`는 wire contract SSOT이고 hooks/pages/components는 generated type을 직접 소비하지 않는다.
 
+### 8.1 default-deny 인증 게이트 — 새 라우트/명령 추가 시
+
+> 정책 SSOT: [D-015 default-deny 인증 게이트](../decisions/D-015-default-deny-auth-gate.md)
+> 공개 라우트 SSOT: [docs/specs/web-api/09-public-paths.md](../specs/web-api/09-public-paths.md)
+> 공개 명령 SSOT: [docs/specs/cli/03-commands.md — 공개 명령 allowlist](../specs/cli/03-commands.md#공개-명령-allowlist--인증-면제)
+
+Web/CLI 모두 default-deny + allowlist (opt-out) 정책이다. 새 라우트/명령 추가 시 다음 단계를 거친다.
+
+1. **PUBLIC_PATHS / 공개 명령 allowlist 검토**: 신설 라우트/명령이 인증 없이 접근 가능해야 하는지 판단한다.
+   - 인증 필요(기본값) → 별도 조치 없음. default-deny가 자동 적용된다. scope가 필요하면 `@require_scope`를 명시한다.
+   - 공개 필요 → 위 SSOT 표(`09-public-paths.md` 또는 `03-commands.md`)에 행을 추가하고, 같은 PR에서 코드 allowlist(`PUBLIC_PATHS`/`PUBLIC_PREFIXES` 또는 `_AUTH_EXEMPT_COMMAND_PATHS`)도 함께 갱신한다.
+2. **#1409 70-route 결정 표 갱신**: Web API 라우트는 [#1409](https://github.com/joshua-jingu-lee/ante/issues/1409)가 SSOT인 70-route 결정 표에 행을 추가한다. 신설 라우트의 분류(`public` / `system:read` / 기타 scope)를 명시한다.
+3. **검증 체크리스트**: PR 검증 단계에서 (1) 공개 라우트/명령 표와 코드 allowlist가 동기 상태인지, (2) 인증 필요 라우트가 default-deny 미들웨어 / `authenticated_group` factory로 보호되는지, (3) scope가 필요하면 `@require_scope`가 부착되었는지를 확인한다.
+
 ## 9. AGENTS.md 경량화 원칙
 
 AGENTS.md는 모든 세션에 주입되므로 핵심 규칙만 유지한다.

--- a/docs/specs/cli/02-design-decisions.md
+++ b/docs/specs/cli/02-design-decisions.md
@@ -170,7 +170,84 @@ CLI는 해당 규칙을 command 실행 전에 적용하는 표면이다.
 
 **인증 면제 커맨드 경로**: `ante init`, `ante member reset-password`, `ante member regenerate-recovery-key` (토큰 없이 실행 가능)
 
-매칭은 leaf 이름이 아니라 **전체 커맨드 경로** 기준이다. `ante feed init`처럼 leaf 이름이 우연히 `init`인 다른 서브커맨드는 면제 대상이 아니다 (`@require_auth` + `@require_scope`로 인증 필요). 구현은 `LeafAwareGroup`(src/ante/cli/main.py)이 루트 그룹 진입 직후 전체 경로 tuple을 `ctx.obj["_leaf_command_path"]`에 저장하고, `authenticate_member`가 이 tuple과 `_AUTH_EXEMPT_COMMAND_PATHS`(src/ante/cli/middleware.py)를 비교한다.
+매칭은 leaf 이름이 아니라 **전체 커맨드 경로** 기준이다. `ante feed init`처럼 leaf 이름이 우연히 `init`인 다른 서브커맨드는 면제 대상이 아니다 (`@require_auth` + `@require_scope`로 인증 필요). 구현은 `LeafAwareGroup`(src/ante/cli/main.py)이 루트 그룹 진입 직후 전체 경로 tuple을 `ctx.obj["_leaf_command_path"]`에 저장하고, `authenticate_member`가 이 tuple과 `_AUTH_EXEMPT_COMMAND_PATHS`(src/ante/cli/middleware.py:29-33)를 비교한다.
+
+### default-deny CLI 인증 게이트
+
+> 정책 SSOT: [D-015 default-deny 인증 게이트](../../decisions/D-015-default-deny-auth-gate.md)
+
+CLI는 default-deny + allowlist (opt-out) 정책을 적용한다. 새 명령 추가 시 별도 조치
+없이 인증이 자동으로 부착되고, 인증 없이 실행할 수 있는 명령은 명시적으로 allowlist에
+등록한다.
+
+**책임 분리**:
+
+| 단계 | 책임 | 위치 |
+|------|------|------|
+| 1차 차단 (authentication) | `ANTE_MEMBER_TOKEN`이 없거나 검증 실패면 exit 1. allowlist 명령은 면제. | `authenticated_group` factory(#1404 구현 예정). 현재는 루트 그룹의 `authenticate_member(ctx)` + 명령 단의 `@require_auth`로 부분 적용. |
+| 2차 차단 (authorization) | `@require_scope(...)` 데코레이터. agent에 대해서만 required scope를 검사하고 human은 bypass. | `src/ante/cli/middleware.py`의 `@require_scope`. |
+
+**현재 상태와 후속 전환**:
+
+- 1.0 현재 CLI는 opt-in 모델(`@require_auth` + `@require_scope` 명령별 부착)을 유지하고
+  있다. default-deny factory(`authenticated_group`) 도입은 #1404에서 구현한다.
+- 본 spec은 정책과 allowlist 결정만 확정한다. factory 시그니처, decorator shim,
+  마이그레이션 순서는 #1404가 SSOT다.
+- 공개 명령 allowlist의 SSOT는 [03-commands.md — 공개 명령 allowlist](03-commands.md#공개-명령-allowlist--인증-면제)다.
+
+**게이트-면제 메타 경로 (allowlist와 분리)**:
+
+다음 경로는 "공개 명령 allowlist"(4개 명령)와는 별개로 인증 게이트 자체가 적용되지
+않는다. 어떤 명령에 대해서도 평등하게 적용되는 메타 입력이기 때문이다.
+
+| 게이트-면제 경로 | 사유 | 코드 cite |
+|-----------------|------|----------|
+| `ante --help` (root) | `click`은 root 그룹의 콜백 실행 **전에** root 레벨 `--help` 플래그를 처리해 도움말을 출력하고 종료한다. 인증 단계까지 진입하지 않는다. | `src/ante/cli/main.py:105`의 root `cli()` 콜백 안 `authenticate_member(ctx)`는 click이 root `--help`를 처리한 뒤에는 호출되지 않는다. |
+| `ante <cmd> --help`, `ante <cmd> <sub> --help` 등 nested `--help` | **주의**: click은 nested `--help`에서 **부모 그룹 콜백을 먼저 실행한 뒤** 서브커맨드 단의 도움말을 출력한다. 즉 `ante member --help`나 `ante member list --help`에서도 root `cli()` 콜백(과 #1404 도입 후 `authenticated_group` factory)이 실행된다. 토큰 없이 인증을 강제하면 보호 서브커맨드의 도움말 자체를 못 받게 되어 학습 경로가 막힌다. | nested help 처리 시 부모 group 콜백이 실행되는 시점의 `ctx.resilient_parsing` 값은 **click 내부 동작에 의존**하며 항상 `True`라고 보장되지 않는다. 따라서 본 spec은 invariant만 정의하고 구체 검사 시그니처는 #1404 plan-preflight에서 확정한다. invariant는 아래 "nested help 면제 invariant" 절을 따른다. raw `sys.argv` 검사(`"--help" in sys.argv[1:]`)는 어떤 경우에도 사용하지 않는다. `ante strategy submit -- --help`처럼 `--` 이후 위치 인자로 들어간 `--help`는 인증을 면제하지 않으며 default-deny 게이트가 정상 발화해야 한다. 도움말은 명령 사용법 그 자체이며 토큰 없이 받을 수 있어야 Agent와 사람이 명령을 학습할 수 있으므로 본 면제는 default-deny의 의도와 충돌하지 않는다(Codex review v4 Finding 2 — raw sys.argv 검사로 인한 우회 차단). |
+| `ante --version` | `@click.version_option`(`src/ante/cli/main.py:94`)이 root 콜백 진입 전 처리. 메타데이터 출력. | 동일. |
+| Click resilient parsing 경로 | `click`이 자동완성(shell completion) 등을 위해 명시적으로 `ctx.resilient_parsing=True`로 옵션 파싱을 시도할 때. 이 모드에서는 부작용을 일으키지 않아야 한다. **nested `--help`는 click 버전에 따라 부모 콜백 invoke 시점에 `resilient_parsing`이 `True`가 아닐 수 있으므로 위 nested help 행과 별도로 다룬다.** | `authenticate_member(ctx)`는 `ctx.resilient_parsing`이 True면 즉시 return하여 인증을 건너뛴다(`src/ante/cli/middleware.py:64-65`). #1404의 `authenticated_group` factory도 동일 가드를 갖는다. |
+
+이 면제 경로는 4개 명령 allowlist와 다른 결로 운영된다.
+
+- **공개 명령 allowlist**: 명령 자체가 인증 없이 실행되어야 하는 부트스트랩/복구 경로.
+  명령 추가 시 도메인 invariant(재진입 가드, 현재 패스워드 요구 등) 검증이 필요하다.
+- **게이트-면제 메타 경로**: `--help` / `--version` / resilient parsing처럼 명령 실행
+  자체가 일어나지 않는 입력. 명령 단위가 아니라 click 프레임워크 레벨에서 결정되며,
+  새 명령이 추가되어도 자동으로 동일하게 적용된다. 별도 allowlist 등록이 필요 없다.
+
+따라서 신규 명령을 추가할 때 "이 명령은 인증이 필요한가?" 질문은 게이트-면제 메타
+경로와 무관하게 명령 자체의 의미에만 답하면 된다. `--help` 통과는 default-deny
+정책과 충돌하지 않는다.
+
+**nested help 면제 invariant (Codex review v5 Finding 3)**:
+
+`ante <group> --help`나 `ante <group> <sub> --help` 같은 nested help는 click이
+부모 group의 콜백을 먼저 invoke한 뒤 자식의 도움말을 렌더링하는 경로다. 이때
+부모 콜백이 호출되는 시점의 `ctx.resilient_parsing` 값은 click 내부 동작에
+의존하며 spec이 "항상 `True`"로 단언할 수 없다. 따라서 본 spec은 **invariant
+세 개만** 정의하고, 정확한 검사 시그니처(`ctx` 필드 조합)는 #1404 plan-preflight
+단계에서 click의 실제 동작을 확인한 뒤 확정한다.
+
+| invariant | 내용 |
+|-----------|------|
+| (H1) 통과해야 한다 | `ante`, `ante <group>`, `ante <group> <sub>`, 더 깊은 임의 경로에 대해 `--help` / `-h`가 명령 인자로 들어온 경우, 토큰이 없어도 도움말이 정상 출력되고 exit 0으로 종료한다. 인증 단계는 부수효과(토큰 검증 실패 로깅, exit 1 등)를 일으키지 않는다. |
+| (H2) 차단해야 한다 | `--help`가 `--` 이후의 위치 인자로 들어온 경우(예: `ante strategy submit -- --help`)는 도움말이 아니라 일반 명령 인자이므로, default-deny 게이트가 정상 발화해 토큰 없으면 exit 1로 차단한다. |
+| (H3) 검사 방식 | nested help 판정은 **Click context가 노출하는 상태만** 본다(예: `ctx.resilient_parsing`, `ctx.protected_args`, `ctx.invoked_subcommand`, `ctx.params`의 click 결과). raw `sys.argv` 검사(`"--help" in sys.argv`)는 어떤 경우에도 사용하지 않는다. (H2)를 만족시키기 위해 click이 이미 `--` 분리를 처리한 뒤의 context를 기준으로 한다. |
+
+대안 패턴(예: `group.no_args_is_help = True` 설정 후 root 콜백 진입 전에 click이
+help를 가로채도록 위임)도 본 invariant를 만족하면 허용된다. #1404 plan-preflight는
+click 버전(`click>=8.0` 등 본 프로젝트 pin)에서 실제 nested help 호출 시 어떤
+context 필드가 어떤 값으로 채워지는지 확인하고 (H1)(H2)(H3)을 동시에 만족하는
+검사 식을 확정한다.
+
+**caveat**: 본 spec은 nested help 면제 검사의 정확한 함수 시그니처를 못박지
+않는다. click 내부 동작 의존 표면이라 spec과 코드를 같은 라운드에 정정하지
+않으면 회귀가 발생하기 쉽기 때문이다. 따라서 (H1)(H2)(H3) invariant 위반은
+#1404 PR에서 단위 테스트로 보증하고, spec은 invariant 정의에 한정한다.
+
+**`ante login` 후보 제거**: 본 이슈 검토 과정에서 거론되었으나 CLI는 `ANTE_MEMBER_TOKEN`
+환경변수 모델이며 별도 `login` 명령은 spec(`docs/specs/cli/03-commands.md`)과 코드
+(`src/ante/cli/commands/`) 모두에 존재하지 않는다. allowlist 후보에서 제거.
 
 ### 인스턴스 경로 일관성 (`config_dir` 기반)
 

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -14,6 +14,52 @@
 `ante backtest run <strategy_path>`에서만 직접 받는다. 봇 생성은 등록된 전략 ID를
 사용한다.
 
+## 공개 명령 allowlist (인증 면제)
+
+> 정책 SSOT: [D-015 default-deny 인증 게이트](../../decisions/D-015-default-deny-auth-gate.md)
+> 게이트 책임 분리: [02-design-decisions.md — default-deny CLI 인증 게이트](02-design-decisions.md#default-deny-cli-인증-게이트)
+
+CLI는 default-deny + allowlist 정책을 적용한다. 다음 명령만 `ANTE_MEMBER_TOKEN`
+없이 실행할 수 있다. 그 외 모든 명령은 토큰이 없으면 자동으로 exit 1로 거부된다.
+
+코드 인용: `_AUTH_EXEMPT_COMMAND_PATHS` 정의는 `src/ante/cli/middleware.py:29-33`.
+매칭은 leaf 이름이 아니라 전체 커맨드 경로 tuple 기준이다(`ante feed init`처럼
+leaf 이름이 우연히 같은 명령은 면제 대상이 아니다).
+
+| 명령 | 경로 tuple | 근거 |
+|------|-----------|------|
+| `ante --version` | — (옵션, 명령 아님) | `@click.version_option`(`src/ante/cli/main.py:94`)이 본 root 그룹에서 인증 단계 진입 전에 처리한다. 메타데이터 출력. |
+| `ante init` | `("init",)` | 부트스트랩: 시스템 파일 골격, master 계정, test account를 1회 생성한다. 토큰 자체가 아직 발급되지 않은 상태. 재진입 가드(`src/ante/cli/commands/init.py:349-356` 부근의 5-state 검증, 테스트 `tests/unit/test_cli_init.py:246` "state1_all_exist_rejects")가 이미 init된 시스템에서 명령을 거부한다. |
+| `ante member reset-password --recovery-key ...` | `("member", "reset-password")` | 패스워드 분실 복구. recovery key 자체가 인증 수단이다. 서버 측에서 recovery key 해시를 검증한 뒤 새 패스워드를 적용한다. |
+| `ante member regenerate-recovery-key (--password-env\|--password-file)` | `("member", "regenerate-recovery-key")` | recovery key 재발급. 현재 패스워드 입력이 인증 수단이다(코드 invariant). |
+
+**후보에서 제거**: `ante login` — CLI는 `ANTE_MEMBER_TOKEN` 환경변수 모델이며 별도
+`login` 명령은 spec과 코드 모두에 존재하지 않는다(`grep -rn 'name="login"|@.*group.command.*login' src/ante/cli/` 결과 empty).
+allowlist 후보에서 제거한다.
+
+### 게이트-면제 메타 경로 (allowlist와 분리)
+
+다음 경로는 공개 명령 allowlist와 별개로 인증 게이트가 적용되지 않는다. 명령 단위가
+아니라 click 프레임워크 레벨에서 결정되므로 본 allowlist 표에 행을 추가할 필요가 없다.
+정책 SSOT는 [02-design-decisions.md — 게이트-면제 메타 경로](02-design-decisions.md#default-deny-cli-인증-게이트)다.
+
+| 메타 경로 | 적용 범위 | 사유 |
+|----------|----------|------|
+| `--help` | `ante --help`, `ante <cmd> --help`, `ante <cmd> <sub> --help` 등 모든 명령 단계 | root `--help`만 root 콜백 진입 전 처리되고, **nested `--help`는 부모 그룹 콜백이 먼저 실행된 뒤** 서브커맨드 단의 도움말이 출력된다(click 동작). 이 때문에 `authenticate_member(ctx)` 및 #1404 `authenticated_group` factory는 invocation에 `--help` 플래그가 있거나 `ctx.resilient_parsing == True`인 경우 인증 검사를 skip한다. 도움말은 명령 사용법 그 자체이며 인증 없이도 받을 수 있어야 Agent와 사람이 명령을 학습할 수 있다. 상세 정정 근거는 [02-design-decisions.md — `--help` 처리 시점](02-design-decisions.md#default-deny-cli-인증-게이트) 참조. |
+| `--version` | `ante --version` | `@click.version_option`이 root 콜백 진입 전 처리. 메타데이터 출력. |
+| resilient parsing | 자동완성 등 click이 `ctx.resilient_parsing=True`로 옵션을 시도 파싱하는 경로 | 부작용 없는 파싱이므로 인증 단계로 진입하지 않는다. `authenticate_member(ctx)`가 `ctx.resilient_parsing`을 확인해 즉시 return(`src/ante/cli/middleware.py:64-65`). |
+
+`--help` / `--version` / resilient parsing은 신규 명령이 추가되어도 자동으로 동일하게
+적용된다. 따라서 새 명령의 인증 여부 판단은 본 메타 경로와 무관하게 명령 자체의
+의미("인증 없이 실행되어야 하는 부트스트랩/복구인가?")로만 답한다.
+
+새 공개 명령 추가 시 다음 순서를 따른다:
+
+1. 본 allowlist 표에 행 추가 (명령, 경로 tuple, 근거)
+2. 코드의 `_AUTH_EXEMPT_COMMAND_PATHS`에 동일 tuple 등록
+3. 인증 없이 호출되어도 안전한지 도메인별 invariant(예: `ante init`의 재진입 가드,
+   `regenerate-recovery-key`의 현재 패스워드 요구) 검증
+
 ## 실행 분류 전수 표
 
 | 분류 | 의미 |

--- a/docs/specs/member/02-design-decisions.md
+++ b/docs/specs/member/02-design-decisions.md
@@ -80,9 +80,13 @@ scope 문자열의 의미와 판정 규칙은 이 문서를 따른다.
 | 영역 | SSOT 책임 |
 |------|-----------|
 | Member | `human`/`agent`/`master` 모델, 토큰 접두어, scope vocabulary, human bypass, agent scope 제한 |
-| Web API | session cookie와 Bearer token을 HTTP 요청에서 추출하고, endpoint별 required scope를 Member 규칙으로 검사 |
-| CLI | `ANTE_MEMBER_TOKEN`을 canonical instance DB에서 검증하고, command별 required scope를 Member 규칙으로 검사 |
+| Web API | session cookie와 Bearer token을 HTTP 요청에서 추출. **default-deny gate(middleware)가 1차 차단(인증)**, dependency는 endpoint별 required scope 검증 책임. 공개 라우트는 `PUBLIC_PATHS`/`PUBLIC_PREFIXES` allowlist(SSOT: [web-api/09-public-paths.md](../web-api/09-public-paths.md))로 명시. |
+| CLI | `ANTE_MEMBER_TOKEN`을 canonical instance DB에서 검증. **default-deny group factory가 1차 차단(인증)**, `@require_scope` decorator는 command별 required scope 검증 책임. 공개 명령은 `_AUTH_EXEMPT_COMMAND_PATHS` allowlist(SSOT: [cli/03-commands.md](../cli/03-commands.md))로 명시. |
 | IPC | 별도 인증/권한 모델을 두지 않음. CLI에서 검증된 `actor`와 command payload를 서버 런타임 실행 경로로 전달 |
+
+> default-deny 정책 결정의 SSOT는 [D-015](../../decisions/D-015-default-deny-auth-gate.md)다.
+> middleware/factory는 scope를 검사하지 않으며 dependency/decorator는 인증된 principal을
+> 전제로 한다.
 
 필요 scope의 연결표는 각 표면의 계약 문서에 둘 수 있다. 예를 들어 CLI command별
 required scope는 `docs/specs/cli/03-commands.md`, HTTP endpoint별 required scope는

--- a/docs/specs/web-api/02-design-decisions.md
+++ b/docs/specs/web-api/02-design-decisions.md
@@ -55,9 +55,194 @@ Member 스펙을 따른다.
 Bearer token 추출은 Web API token auth middleware가 수행하며, 실제 토큰 검증은
 MemberService.authenticate()에 위임한다.
 
+### 인증 게이트 단계
+
+default-deny 정책의 SSOT는 [D-015](../../decisions/D-015-default-deny-auth-gate.md)다.
+Web API는 다음 **요청 처리 순서**로 미들웨어를 적용한다.
+
+```
+요청 → TokenAuthMiddleware → RequireAuthMiddleware → 라우트 → dependency(@require_scope) → 응답 → AuditMiddleware
+```
+
+| 단계 | 책임 |
+|------|------|
+| `TokenAuthMiddleware` | `Authorization: Bearer` 헤더가 있을 때 토큰을 검증해 `request.state.member_id` / `request.state.member`에 principal을 부착. 없거나 실패면 그대로 통과(여기서는 401 raise 안 함). |
+| `RequireAuthMiddleware` (신규, #1403) | (0) 요청 메소드가 `OPTIONS`(CORS preflight)면 인증 검사를 건너뛰고 즉시 통과. (1) 경로가 `PUBLIC_PATHS` / `PUBLIC_PREFIXES` allowlist 또는 비-`/api` SPA fallback 경로에 속하면 caller 결정 시도 없이 즉시 통과(세션 fallback / ACTIVE 검사도 수행하지 않음). (2) `request.state.member_id`가 비어 있지 않으면(=`TokenAuthMiddleware`가 Bearer caller를 부착했으면) 그대로 통과. (3) Bearer caller가 없으면 `ante_session` 쿠키를 직접 검증해 caller를 결정하고 `member_service.get(caller)` + `MemberStatus.ACTIVE` 검사를 거쳐 `request.state`에 부착. (4) 어느 경로로도 caller가 결정되지 않으면 401. **scope는 검사하지 않는다.** CORS preflight 면제 근거는 본 문서의 [CORS 설정](#cors-설정) 절. |
+| 라우트 dependency | endpoint별 `@require_scope(...)`. agent에 대해서만 required scope를 검사하고, human은 bypass. |
+| `AuditMiddleware` | 요청/응답 감사 로그 기록. 응답이 완성된 뒤(상위에서 raise된 예외도 변환된 응답 형태로) 기록되므로 처리 순서상 마지막 outer 단계다. |
+
+**Bearer / 세션 쿠키 동시 지원**:
+
+`POST /api/auth/login`으로 로그인한 dashboard 사용자는 이후 요청에 Bearer 헤더 없이
+`ante_session` 쿠키만 보낸다. 따라서 `RequireAuthMiddleware`는 Bearer 단(`TokenAuth`)
+이 caller를 채우지 못한 경우 **자체적으로 세션 쿠키 fallback**을 수행한다. 이 fallback이
+없으면 정상 로그인 dashboard 사용자가 모든 보호 API에서 401을 받는다(D-015 ADR의
+"Web 미들웨어 책임 매트릭스" 절 참조).
+
+세션 fallback 알고리즘은 `src/ante/web/deps.py:267-345`의 `require_master_caller` /
+`require_audit_read` 등 기존 dependency가 이미 사용 중인 패턴을 따른다
+(`SessionService.validate(ante_session)` → `session["member_id"]`). 미들웨어가 caller를
+부착하면 dependency 단의 같은 fallback은 자연스럽게 no-op이 되고, gate와 dependency
+양쪽이 같은 caller에 합의한다.
+
+**세션 fallback 시 멤버 상태 검증 (Codex review v3 Finding X)**:
+
+`SessionService.validate(ante_session)`은 세션 만료/서명만 검증하며,
+멤버의 `status` 필드는 보지 않는다. 따라서 세션 row가 남아 있는 상태에서 멤버가
+`SUSPENDED`/`REVOKED`/`DELETED`로 전환되어도 세션 fallback만으로 caller가 결정되면
+default-deny 게이트를 통과해 보호 라우트에 도달할 수 있다. 이는 Bearer 경로
+(`TokenAuthMiddleware`가 `member_service.authenticate`에서 ACTIVE 검사)와의 비대칭이며,
+`require_audit_read`(4차 fix, `src/ante/web/deps.py:444-452`)가 dependency 단에서 이미
+정정한 SSOT 패턴을 그대로 따른다.
+
+따라서 `RequireAuthMiddleware`(#1403)는 세션 쿠키 fallback으로 caller를 결정한 뒤,
+caller를 `request.state.member_id`에 부착하기 직전에 `member_service.get(caller)`를
+호출하고 `member.status == MemberStatus.ACTIVE`를 명시적으로 확인한다. ACTIVE가 아니면
+caller를 부착하지 않고 401(인증 실패) 또는 403(비활성 멤버)을 반환한다. Bearer 경로는
+`TokenAuthMiddleware`가 동일 검사를 이미 수행하므로 미들웨어 진입 시점에 부착된 caller는
+ACTIVE 보장이 있다고 가정해도 좋다.
+
+**공개 경로 판정은 세션 fallback / ACTIVE 검사보다 먼저 수행한다 (Codex review v4
+Finding 1)**: 위 ACTIVE 검사는 어디까지나 caller 결정이 필요한 보호 라우트에 대해서만
+적용된다. 공개 경로(OPTIONS preflight, `PUBLIC_PATHS` / `PUBLIC_PREFIXES`, 비-`/api`
+SPA fallback)에 대해서는 미들웨어가 세션 fallback 자체를 시도하지 않으며 ACTIVE 검사도
+수행하지 않는다. 이 순서가 깨지면 `ante_session` 쿠키를 가진 채 멤버 상태가
+`SUSPENDED`/`REVOKED`로 전환된 사용자가 `/login` SPA 진입, `POST /api/auth/login`(재로그인
+시도), `POST /api/auth/logout`(쿠키 정리), `/api/system/health` 등 복구/공개 경로에
+접근할 때 ACTIVE 검사가 먼저 발화해 401/403으로 차단되어 재로그인 / 쿠키 삭제 경로
+자체가 막힌다. 위 단계 표의 (1) 공개 경로 면제 분기는 이 회귀를 막기 위해 (3) 세션
+fallback + ACTIVE 검사보다 앞에 배치된다.
+
+이렇게 ACTIVE 검사가 미들웨어 책임으로 옮겨지면, 기존 dependency
+(`require_audit_read` 등)의 중복 ACTIVE 검사는 #1408에서 제거 대상이 된다. 권한
+검사(`require_scope`/dependency)는 ACTIVE 가정 위에서 scope만 본다.
+
+`AuditMiddleware`는 세션으로 결정된 caller도 정확히 기록할 수 있도록
+`request.state.member_id`(미들웨어가 부착)를 그대로 읽는다.
+
+**add_middleware 순서 vs 실행 순서**:
+
+FastAPI/Starlette는 **마지막에 `add_middleware()`된 사용자 미들웨어가 요청을 가장 먼저
+받는다**(역순 스택). 따라서 위 실행 순서를 얻으려면 `app.add_middleware()`를 **역순**으로
+호출해야 한다.
+
+| 호출 순서 (`add_middleware`) | 결과 (요청 처리 순서) |
+|------------------------------|------------------------|
+| 1. `app.add_middleware(AuditMiddleware)` | 가장 바깥 → 응답 시점에 실행 |
+| 2. `app.add_middleware(RequireAuthMiddleware)` | 중간 |
+| 3. `app.add_middleware(TokenAuthMiddleware)` | 가장 안쪽 → 요청 시점에 가장 먼저 실행 |
+
+즉 코드상 add 순서는 `Audit → RequireAuth → TokenAuth`이고, 런타임 요청 흐름은
+역순인 `TokenAuth → RequireAuth → 라우트 → 응답 → Audit`이다. #1403 구현은 이 매핑을
+그대로 따라야 한다. add 순서를 잘못 적으면(예: 의도된 실행 순서를 그대로 add) Audit가
+가장 먼저 요청을 받게 되어 인증 단계가 감사 기록 안쪽으로 들어가지 않거나,
+RequireAuth가 TokenAuth보다 먼저 실행되어 Bearer caller가 비어 있는 상태로 401을
+던지게 된다.
+
+> 위 표는 인증 관련 3개 미들웨어만 보여주는 단순화 표다. `CORSMiddleware`를 포함한
+> 4개 미들웨어 전체 add 시퀀스 예시는 아래 [CORS 설정](#cors-설정) 절을 참조한다.
+> `CORSMiddleware`는 위 3개 표의 `Audit`보다 **앞에** add되어 가장 안쪽에 위치한다.
+
+**책임 분리**:
+
+- 미들웨어 (`RequireAuthMiddleware`) = 인증(authentication). Bearer 부착 결과를 보고,
+  비어 있으면 세션 쿠키 fallback까지 수행. 그래도 비어 있으면 401(PUBLIC 제외).
+- dependency (`@require_scope(...)`) = 권한(authorization). scope만 검사한다.
+
+이 분리로 401(인증 실패)과 403(권한 부족)이 다른 코드 경로에서 응답된다. 새 라우트
+추가 시 인증은 자동으로 부착되며, scope가 필요한 라우트는 명시적으로 `@require_scope`를
+부착한다. scope 누락은 #1407, default-deny 미들웨어 도입은 #1403, 라우트별 결정 표는
+#1409가 담당한다.
+
+공개 라우트 allowlist의 SSOT는 [09-public-paths.md](09-public-paths.md)다.
+
 ## CORS 설정
 
 홈서버 환경이므로 개발 편의상 전체 origin 허용 (`allow_origins=["*"]`).
+
+**CORS preflight와 인증 게이트의 관계**:
+
+cross-origin 브라우저 클라이언트가 `Authorization: Bearer ...` 같은 non-simple 헤더로
+보호 API를 호출할 때, 브라우저는 본 요청 전에 `OPTIONS /api/...` preflight 요청을
+자격증명 없이 보낸다. preflight 자체에 default-deny 게이트를 적용하면 401이 반환되어
+브라우저가 본 요청을 진행하지 못하고, 결과적으로 정상 토큰을 가진 cross-origin
+클라이언트조차 모든 보호 API에서 차단된다(`tests/unit/web/test_app.py::test_cors_headers`가
+검증하는 동작 회귀).
+
+따라서 `RequireAuthMiddleware`(#1403)는 **HTTP `OPTIONS` 메소드 요청을 게이트에서
+면제**한다. 이는 공개 경로 allowlist와 별개의 메소드 기반 면제 카테고리이며
+[09-public-paths.md](09-public-paths.md)의 PUBLIC_PATHS / PUBLIC_PREFIXES 테이블과
+독립적으로 적용된다. OPTIONS는 CORSMiddleware가 응답을 생성하므로 라우트 단의
+권한 검사로도 진입하지 않는다.
+
+**CORS 등록 순서와 RequireAuth의 관계 (Codex review v3 Finding Y / v5 Finding 1)**:
+
+Starlette `add_middleware()`는 `insert(0)` 시맨틱이므로, 가장 먼저 등록된
+미들웨어가 user middleware 리스트의 가장 뒤로 가고, 빌드 시 `reversed()`로
+wrap된 결과 가장 안쪽(요청을 가장 늦게 받는 쪽)에 위치한다. 마지막에 add된
+미들웨어가 가장 바깥(요청을 가장 먼저 받는 쪽)이다.
+
+`src/ante/web/app.py:48-59` 기준 **현행** 등록 순서는
+`CORSMiddleware → AuditMiddleware → TokenAuthMiddleware`다. 따라서 요청 흐름은
+**TokenAuth → Audit → CORS → 라우트** 순이고, `CORSMiddleware`는 가장 안쪽에 있다.
+
+`RequireAuthMiddleware`(#1403)를 추가할 때 위 "인증 게이트 단계" 표에서 정한
+의도 흐름(`TokenAuth → RequireAuth → Audit → CORS → 라우트`)을 얻으려면, 위
+`add_middleware 순서 vs 실행 순서` 표에 따라 add 순서를 **역순**으로 잡아야 한다.
+즉 `RequireAuthMiddleware`는 `CORSMiddleware`와 `AuditMiddleware` add **뒤**,
+`TokenAuthMiddleware` add **앞**에 끼워 넣는다. 결과 add 순서는
+`CORS → Audit → RequireAuth → TokenAuth`이고, 마지막 add인 `TokenAuth`가
+가장 바깥(요청을 가장 먼저 받음), 그 다음이 `RequireAuth`, 그 다음 `Audit`,
+가장 안쪽이 `CORS`다. 이 배치에서만 Bearer caller가 `TokenAuth` 단계에서
+`request.state.member_id`에 부착된 뒤 `RequireAuth`가 그 값을 보고 통과
+판단을 내릴 수 있다.
+
+반대로 `TokenAuthMiddleware` add **뒤**에 `RequireAuthMiddleware`를 add하면
+`RequireAuth`가 더 바깥(=먼저 실행)이 되어 `request.state.member_id`가 아직
+비어 있는 상태로 default-deny가 발화하고, **정상 Bearer 토큰 사용자도
+모두 401**을 받는다. 본 spec은 이 잘못된 배치를 명시적으로 금지한다.
+
+OPTIONS preflight 안전망: 위 배치에서도 `CORSMiddleware`는 가장 안쪽이므로
+`RequireAuthMiddleware`가 OPTIONS preflight를 먼저 만난다. 따라서 본 spec은
+미들웨어 등록 순서에 의존하지 않도록 **`RequireAuthMiddleware` 자체가 HTTP
+`OPTIONS` 메소드 요청을 무조건 통과시키는 가드**를 갖도록 요구한다. 이 가드가
+있으면 CORS가 안쪽이든 바깥이든, 추후 누군가 등록 순서를 바꿔도 cross-origin
+preflight 회귀가 발생하지 않는다. 실제 CORS 응답 본문 생성은 안쪽의
+`CORSMiddleware`가 라우트 직전 단계에서 수행한다(현행 코드 동작과 동일,
+`tests/unit/web/test_app.py::test_cors_headers`가 보증한다).
+
+대안으로 CORS를 RequireAuth보다 바깥에 두려면 `RequireAuthMiddleware` 등록
+**뒤**에 `CORSMiddleware`를 다시 add해야 한다. 본 spec은 그 변경을 요구하지
+않으며, OPTIONS 면제 가드만으로 동일한 안전성을 확보한다.
+
+**#1403 구현 시 권장 add 시퀀스 (참고용 코드 예시, 단계 표와 분리)**:
+
+위 단계 표는 *요청 처리 순서*를 정의하고, 아래 예시는 그 순서를 얻기 위한
+Starlette `add_middleware()` *호출 순서*를 보여준다. 두 표는 서로 역순이다.
+
+```python
+# 현행 (src/ante/web/app.py:48-59)
+app.add_middleware(CORSMiddleware, ...)          # add 1 → 가장 안쪽
+app.add_middleware(AuditMiddleware)              # add 2
+app.add_middleware(TokenAuthMiddleware)          # add 3 → 가장 바깥 (현행)
+
+# #1403에서 RequireAuthMiddleware를 도입한 뒤 의도 흐름
+# (TokenAuth → RequireAuth → Audit → CORS → 라우트)을 얻으려면
+# TokenAuth add 직전에 끼워 넣는다.
+app.add_middleware(CORSMiddleware, ...)          # add 1 → 가장 안쪽
+app.add_middleware(AuditMiddleware)              # add 2
+app.add_middleware(RequireAuthMiddleware)        # add 3
+app.add_middleware(TokenAuthMiddleware)          # add 4 → 가장 바깥
+```
+
+LIFO 시맨틱이므로 **마지막 add가 가장 먼저 요청을 처리**한다. `TokenAuth`가
+가장 마지막에 add되어야 Bearer caller 부착이 `RequireAuth` 평가보다 먼저
+일어난다.
+
+| 메소드 | 게이트 동작 |
+|--------|------------|
+| `OPTIONS` (preflight) | 인증 검사 면제. 항상 통과(CORS 응답 또는 라우트가 처리). |
+| 그 외 (GET/POST/PUT/PATCH/DELETE 등) | default-deny. PUBLIC_PATHS/PUBLIC_PREFIXES allowlist만 면제. |
 
 ## OpenAPI 자동 문서화
 

--- a/docs/specs/web-api/09-public-paths.md
+++ b/docs/specs/web-api/09-public-paths.md
@@ -1,0 +1,136 @@
+# Web API 모듈 세부 설계 - 공개 경로 allowlist
+
+> 인덱스: [README.md](README.md) | 호환 문서: [web-api.md](web-api.md)
+> 정책 SSOT: [D-015 default-deny 인증 게이트](../../decisions/D-015-default-deny-auth-gate.md)
+> 게이트 단계 SSOT: [02-design-decisions.md — 인증 게이트 단계](02-design-decisions.md#인증-게이트-단계)
+
+# 공개 경로 (PUBLIC_PATHS / PUBLIC_PREFIXES) allowlist
+
+`RequireAuthMiddleware`(#1403)는 default-deny 정책에 따라 인증되지 않은 요청을 401로
+차단한다. 본 문서는 그 게이트에서 **면제**되는 공개 경로의 SSOT다.
+
+> 70개 라우트 전수 결정 표는 본 문서 범위를 벗어나며 [#1409](https://github.com/joshua-jingu-lee/ante/issues/1409)에서 별도로
+> 작성한다. 본 문서는 정책 결정 시점에 코드/스펙으로 확정 가능한 항목만 다룬다.
+
+## 카테고리
+
+allowlist 항목은 다음 세 카테고리 중 하나에 속한다.
+
+| 카테고리 | 의미 | 게이트 처리 | 라우트 책임 |
+|---------|------|------------|-------------|
+| `public` | 인증 없이 누구나 접근 가능. 응답에 민감 정보 없음. | 미들웨어가 401 없이 통과시킨다. | 라우트는 caller-agnostic. 인증 검사 자체를 하지 않는다. |
+| `gate-exempt-self-auth` | 미들웨어 게이트는 면제. 라우트가 자체적으로 세션/토큰을 검증하고 미인증이면 401, 인증되었으면 본인 정보만 응답. | 미들웨어가 401 없이 통과시킨다. | 라우트가 직접 세션 쿠키 / Bearer 토큰을 확인해 401 또는 본인 정보(self-only)를 응답한다. |
+| `unresolved` | 본 이슈에서 결정 보류. #1409 70-route 결정 표에 위임. | 결정 시까지 default-deny가 적용된다. 즉 인증되지 않으면 401이 응답된다. | (결정 후 카테고리에 따름) |
+
+**책임 분리**:
+
+`public`은 응답 자체에 민감 정보가 없거나, 호출자가 누구든 동일한 응답을 줘도 안전한
+표면이다. 인증 무관 응답이 곧 정상 응답이다.
+
+`gate-exempt-self-auth`는 미들웨어 게이트만 면제되며, **응답 자체는 caller에 따라 달라야
+한다**. 미인증이면 라우트가 직접 401을 던지고, 인증되었으면 호출자 본인 정보만
+응답한다. 미들웨어 단의 default-deny를 그대로 적용하면 dashboard 초기 로딩에서
+"내가 누구인지" 조회조차 불가능해지므로 게이트만 면제하고 라우트가 self-only 가드를
+직접 수행한다.
+
+두 카테고리가 섞이지 않도록 새 항목 추가 시 응답 내용을 점검한다. 인증 무관 정보를
+주려는 항목은 `public`, 본인 정보를 주려는 항목은 `gate-exempt-self-auth`다.
+
+## PUBLIC_PATHS (정확 일치)
+
+| 경로 | 카테고리 | 근거 |
+|------|---------|------|
+| `/` | public | SPA 진입점. `src/ante/web/app.py:357-377`의 `SPAFallbackMiddleware`가 비-`/api` 경로의 404 응답을 `index.html`로 폴백한다. 미인증 사용자가 로그인 화면 HTML 자체를 받지 못하면 로그인 자체가 시작되지 않으므로 PUBLIC 필요. |
+| `/index.html` | public | SPA 진입점(직접 요청 경로). `/`와 동일 근거. SPA 자산을 받기 위해 인증을 요구하면 로그인 화면 진입이 불가능. |
+| `/api/system/health` | public | reverse proxy / 모니터링 헬스체크. 인증 요구 시 운영 인프라가 헬스를 판정할 수 없다. 라우트 정의: `src/ante/web/routes/system.py:102`. |
+| `/api/auth/login` | public | 인증 자체를 수행하는 엔드포인트. 인증되지 않은 상태에서 시작되어야 한다. 라우트 정의: `src/ante/web/routes/auth.py:31`. |
+| `/api/auth/logout` | public | 세션 종료. 인증이 만료된 상태에서도 호출 가능해야 한다(클라이언트 측 정리 + 서버 측 best-effort). 라우트 정의: `src/ante/web/routes/auth.py:106`. |
+| `/openapi.json` | public | OpenAPI 스키마 정적 자원. Agent와 외부 도구가 계약을 파싱한다. |
+| `/docs` | public | Swagger UI. OpenAPI 탐색기. |
+| `/redoc` | public | ReDoc. API 레퍼런스 문서. |
+| `/api/auth/me` | gate-exempt-self-auth | 미들웨어 게이트는 면제하되 라우트가 직접 세션 쿠키 또는 Bearer 토큰을 검증해 본인 정보를 응답한다. 미인증이면 라우트가 401, 인증되었으면 self-only 응답. |
+
+## PUBLIC_PREFIXES (접두어 일치)
+
+| 접두어 | 카테고리 | 근거 |
+|--------|---------|------|
+| `/assets/*` | public | Vite 빌드 SPA 자산. `src/ante/web/app.py:347`에서 `app.mount("/assets", StaticFiles(...))`로 마운트된다. 인증된 사용자만 SPA 번들을 받게 하려면 로그인 페이지 자체가 동작할 수 없다. |
+
+### SPA fallback 경로 — 비-`/api` 전체 면제 (정식 채택)
+
+`SPAFallbackMiddleware`(`src/ante/web/app.py:357-377`)는 비-`/api` 경로에서 404가
+나오면 `static_dir/<path>`가 실제 파일이면 그 파일을, 아니면 `index.html`을 돌려준다.
+React Router 같은 client-side routing이 도입되면 임의 경로(`/login`, `/dashboard/...`,
+`/strategies/...`, `/bots/...`, `/accounts/...`, `/treasury/...` 등)가 모두
+`index.html`로 폴백된다. 이러한 SPA fallback 경로 자체는 default-deny 게이트에서
+면제되어야 미인증 사용자가 로그인 화면을 받을 수 있다.
+
+특히 사용자가 브라우저 주소창에 `/login`이나 `/strategies/abc` 같은 deep link로
+**직접 진입**할 때, `RequireAuthMiddleware`가 `SPAFallbackMiddleware` 전에 실행되어
+401을 반환하면 SPA 번들 자체가 로드되지 않아 로그인 화면을 표시할 수단이 없다.
+PUBLIC_PATHS에 `/`와 `/index.html`만 등록하고 `/login` 같은 정확 일치를 누락하면
+이 회귀가 발생한다.
+
+따라서 #1403 구현은 **비-`/api` 모든 경로를 게이트에서 면제**한다. 구체적으로
+`RequireAuthMiddleware`는 다음 단락 조건 중 어느 하나라도 만족하면 401을 던지지
+않고 통과시킨다.
+
+```
+if not request.url.path.startswith("/api/") and request.url.path != "/api":
+    # SPA fallback / 정적 자산 / SPA deep link 경로
+    return await call_next(request)
+```
+
+이 분기 채택의 의미:
+
+- 비-`/api` 경로는 정의상 보호 라우트가 아니다. 실제 응답은 정적 자산(있으면) 또는
+  SPA `index.html` 폴백이며, 어느 쪽도 caller-sensitive 데이터를 노출하지 않는다.
+- SPA가 React Router로 정의하는 모든 client-side route(`/login`, `/dashboard/*`,
+  `/strategies/*`, `/bots/*`, `/accounts/*`, `/treasury/*`, 향후 추가 경로 포함)가
+  자동으로 면제된다. PUBLIC_PATHS 테이블에 client-side route를 일일이 추가하는
+  유지보수 부담이 없으며, 프론트엔드 라우팅 진화 대응이 1차 면제 분기 안에서
+  완결된다.
+- SPA가 로드된 뒤 보호 API를 호출할 때는 그 API가 default-deny + Bearer/세션 쿠키
+  fallback으로 인증을 강제하므로 SPA 진입 단계의 게이트 면제와 충돌하지 않는다.
+
+**비-`/api` 보호 표면이 신설될 경우**: 본 spec 작성 시점에 `src/ante/web/routes/`의
+모든 라우터는 `/api/` 접두를 가진다(02-design-decisions.md "라우터 구성" 표). 향후
+보호되어야 할 비-`/api` 라우트가 신설되면 본 spec의 SPA 면제 분기를 재검토하거나
+해당 라우트만 별도 데코레이터/dependency로 인증을 강제해야 한다. 신설 시 본 표에
+경고를 추가한다.
+
+PUBLIC_PATHS 테이블의 `/`, `/index.html` 행은 본 분기 채택 후에도 SSOT 추적을 위해
+남겨 둔다(코드 단의 명시적 allowlist 등록은 SPA 면제 분기로 흡수되어 사실상 잉여
+이지만, SPA 진입점이 명시적으로 공개라는 의도를 문서가 보존한다).
+
+## 결정 보류 항목 (`unresolved`)
+
+다음 경로는 본 이슈에서 공개 여부를 결정하지 않는다. #1409 70-route 결정 표에서
+호출자 영향(모니터링, 대시보드, Agent)을 검토한 뒤 `public` 또는 `system:read` /
+`report:read` 등 scope 부착으로 확정한다. 결정 시까지는 default-deny가 적용된다.
+
+| 경로 | 결정 보류 사유 |
+|------|---------------|
+| `/api/system/status` | 시스템 상태(uptime, kill switch 등)를 공개로 노출할지 `system:read` scope로 제한할지 호출자 영향(대시보드, 모니터링) 검토 필요. |
+| `/api/reports/schema` | 리포트 스키마 메타데이터의 공개 여부 정책 결정 필요(Agent가 인증 없이 schema를 받을 수 있어야 하는지). |
+
+## 후보에서 제거된 항목
+
+본 이슈 검토 과정에서 거론되었으나 코드/스펙 grep으로 확인되지 않아 allowlist에서
+제거된 후보. 추후 해당 라우트가 신설되면 별도 이슈로 공개 여부를 결정한다.
+
+| 후보 경로 | 제거 사유 |
+|-----------|----------|
+| `/static/*` | 실제 정적 자산 prefix는 `/assets/*`(`src/ante/web/app.py:347`). `/static/*`은 코드에 존재하지 않음. |
+| `/api/signal/{key}/event` | `src/ante/web/routes/` grep에서 라우트 미발견. 1.0 범위에 존재하지 않으므로 allowlist 후보 아님. 신규 라우트 추가 시 별도 결정. |
+
+## SSOT 운용 규칙
+
+- 본 표는 정책 결정의 SSOT다. 실제 `PUBLIC_PATHS` / `PUBLIC_PREFIXES` Python 상수는
+  #1403 구현 시 본 표를 그대로 반영한다.
+- 새 공개 라우트 추가 시 다음 순서를 따른다.
+  1. 본 표에 행 추가 (경로, 카테고리, 근거)
+  2. #1409 70-route 결정 표 갱신
+  3. 코드에서 `PUBLIC_PATHS` / `PUBLIC_PREFIXES`에 등록
+- 공개 라우트가 더 이상 공개 정책에 맞지 않으면 본 표에서 행을 제거하고 같은 PR에서
+  코드의 allowlist도 함께 제거한다. 표와 코드는 항상 동기화 상태를 유지한다.

--- a/docs/specs/web-api/README.md
+++ b/docs/specs/web-api/README.md
@@ -20,4 +20,5 @@
 | [06-pagination.md](06-pagination.md) | Cursor 기반 페이지네이션 |
 | [07-error-format.md](07-error-format.md) | RFC 7807 에러 응답 |
 | [08-pydantic-schemas.md](08-pydantic-schemas.md) | Pydantic 스키마 목록 |
+| [09-public-paths.md](09-public-paths.md) | default-deny 게이트 면제 공개 경로 allowlist (PUBLIC_PATHS / PUBLIC_PREFIXES) |
 | [10-cross-module-notes.md](10-cross-module-notes.md) | 타 모듈 설계 시 참고 |


### PR DESCRIPTION
Closes #1402

## Summary
Epic #1401 (web/CLI default-deny 인증 게이트 도입)의 spec-first 단계. **코드 변경 없음, 9개 문서 신규/갱신**.

- 신규: `docs/decisions/D-015-default-deny-auth-gate.md` (ADR — Context/Decision/Consequences/Alternatives)
- 신규: `docs/specs/web-api/09-public-paths.md` (PUBLIC_PATHS / PUBLIC_PREFIXES / gate-exempt-self-auth / SPA fallback SSOT)
- 갱신: `docs/decisions/README.md` (D-015 인덱스)
- 갱신: `docs/specs/member/02-design-decisions.md` (Authorization SSOT 책임 분리)
- 갱신: `docs/specs/web-api/02-design-decisions.md` (인증 게이트 단계, add_middleware LIFO 순서, CORS/Audit/RequireAuth/TokenAuth 배치)
- 갱신: `docs/specs/web-api/README.md` (09-public-paths 인덱스)
- 갱신: `docs/specs/cli/02-design-decisions.md` (default-deny 정책, authenticated_group factory, 4개 공개 명령, nested --help invariant)
- 갱신: `docs/specs/cli/03-commands.md` (공개 명령 allowlist 표, ante login 후보 제거)
- 갱신: `docs/runbooks/01-development-process.md` (default-deny 게이트 라우트/명령 추가 시 검토 단계)

## Key Decisions
- **책임 분리**: middleware/factory = 인증 (Bearer + session fallback + ACTIVE), dependency/decorator = scope 검증
- **5단계 RequireAuth 판정 순서**: OPTIONS preflight → PUBLIC/SPA 면제 → Bearer caller → session fallback + ACTIVE → 401
- **확정 PUBLIC_PATHS** (6경로): /api/system/health, /api/auth/login, /api/auth/logout, /openapi.json, /docs, /redoc
- **확정 PUBLIC_PREFIXES**: /assets/* (Vite SPA)
- **gate-exempt-self-auth**: /api/auth/me (미들웨어 면제 + 라우트 self-auth)
- **SPA fallback**: 비-/api 모든 경로 면제 (React Router deep link 대응)
- **결정 보류 (#1409 위임)**: /api/system/status, /api/reports/schema
- **CLI 4개 공개 명령**: ante --version, ante init (재진입 guard 보존), ante member reset-password --recovery-key, ante member regenerate-recovery-key
- **ante login**: spec/코드 미존재로 후보 제거

## Plan Preflight
- 5라운드 codex Plan Review 끝에 approve-implement (revision 5)
- 부수적으로 #1409 신규 분리 (70-route 결정 표)

## Codex 브랜치 리뷰 (총 6라운드)
spec의 미묘성으로 매 라운드마다 1-3개 finding이 발견되는 사이클. 처음 5라운드는 정정 후 재리뷰 사이클로 finding을 모두 해소했고, 6라운드에서 잔여 P2 2건이 발견됨. **잔여 finding은 본 PR review 코멘트로 노출하고 #1403/#1404 plan-preflight에서 함께 검토**.

### 잔여 finding (PR review로 처리)

**P2 — CORS를 인증 거부 응답 바깥에 두세요** (`docs/specs/web-api/02-design-decisions.md:214-216`)
- 현재 배치에서 RequireAuthMiddleware가 401/403 직접 반환하면 안쪽 CORSMiddleware까지 도달하지 않아 `Access-Control-Allow-Origin` 헤더가 붙지 않음
- OPTIONS preflight는 면제로 통과하지만 실제 거부 응답은 브라우저 cross-origin 클라이언트가 읽을 수 없음
- 해결 옵션 (#1403에서 결정): CORS를 RequireAuth 바깥에 배치 변경 OR RequireAuth가 거부 응답에도 CORS 헤더 보장

**P2 — 게이트 구현 전 명시적 인증 가드 유지** (`docs/runbooks/01-development-process.md:265-267`)
- 본 PR이 먼저 머지되면 #1403(미들웨어) / #1404(CLI factory) 구현 전 새 라우트/명령 추가 시 현재 opt-in 코드에서는 노출
- 해결 옵션 (#1403/#1404 머지 전 보강): runbook에 "게이트 구현 전에는 명시적 `Depends(require_*)` / `@require_auth` 가드 요구" 임시 조항 추가

## Test Plan
- [x] `git diff main -- src/ tests/ frontend/ config/` → 0 lines (코드/테스트/생성 산출물 무변경)
- [x] PUBLIC_PATHS 후보 라우트 grep 검증 (`/health`, `/login`, `/logout`, `/assets`)
- [x] `ante login` 명령 코드/spec 부재 grep 확인
- [x] D-015가 docs/decisions/README.md 인덱스에 등록됨
- [x] 책임 분리가 Member SSOT + Web API spec + CLI spec + D-015에 일관 명시

## Notes
- Codex Plan Review (Plan 단계): approve-implement (revision 5, 5라운드)
- Codex 브랜치 리뷰: 6라운드 (5라운드까지 정정으로 finding 해소, 6라운드 잔여 P2 2건은 PR review로 처리)
- spec의 미묘성으로 단일 PR에 모든 boundary case를 완벽 명세하기 어려움 — #1403/#1404 plan-preflight에서 잔여 finding을 구현 직전에 재검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)