### PR TITLE
feat(web): RequireAuthMiddleware default-deny gate + 197 fixture migration (#1403)

### DIFF
--- a/docs/runbooks/01-development-process.md
+++ b/docs/runbooks/01-development-process.md
@@ -268,6 +268,17 @@ Web/CLI 모두 default-deny + allowlist (opt-out) 정책이다. 새 라우트/�
 2. **#1409 70-route 결정 표 갱신**: Web API 라우트는 [#1409](https://github.com/joshua-jingu-lee/ante/issues/1409)가 SSOT인 70-route 결정 표에 행을 추가한다. 신설 라우트의 분류(`public` / `system:read` / 기타 scope)를 명시한다.
 3. **검증 체크리스트**: PR 검증 단계에서 (1) 공개 라우트/명령 표와 코드 allowlist가 동기 상태인지, (2) 인증 필요 라우트가 default-deny 미들웨어 / `authenticated_group` factory로 보호되는지, (3) scope가 필요하면 `@require_scope`가 부착되었는지를 확인한다.
 
+#### 8.1.1 게이트 구현 완료 전 임시 조항 (#1403/#1404 close까지)
+
+> 잔여 P2-B (D-015 ADR / #1402 PR #1420 review 잔재).
+
+epic [#1401](https://github.com/joshua-jingu-lee/ante/issues/1401)의 [#1403](https://github.com/joshua-jingu-lee/ante/issues/1403) (Web `RequireAuthMiddleware`) / [#1404](https://github.com/joshua-jingu-lee/ante/issues/1404) (CLI `authenticated_group` factory)가 모두 close되기 전까지는, 새 mutation 라우트/명령 추가 시 자동 default-deny에 의존하지 말고 명시적 가드를 부착한다.
+
+- Web 라우트: `Depends(require_master_caller)` / `Depends(require_audit_read)` / `Depends(require_config_write)` 등 기존 dependency 중 하나를 라우트 시그니처에 명시한다.
+- CLI 명령: `@require_auth` / `@require_scope` 데코레이터를 명령 함수에 명시한다.
+
+두 이슈가 모두 close되고 게이트가 런타임 동작으로 확인되면 [#1408](https://github.com/joshua-jingu-lee/ante/issues/1408) cleanup에서 본 임시 조항을 제거하고, dependency/decorator는 scope 검증 책임만 가진다(D-015 책임 매트릭스). 그 시점부터는 미들웨어/factory가 1차 차단을 보장하므로 누락이 자동 401/exit 1로 드러난다.
+
 ## 9. AGENTS.md 경량화 원칙
 
 AGENTS.md는 모든 세션에 주입되므로 핵심 규칙만 유지한다.

--- a/src/ante/web/app.py
+++ b/src/ante/web/app.py
@@ -45,6 +45,11 @@ def create_app(**services: Any) -> FastAPI:
         description="AI-Native Trading Engine API",
     )
 
+    # 미들웨어 add 순서 SSOT: docs/specs/web-api/02-design-decisions.md
+    # "인증 게이트 단계" + "CORS 설정" 절. Starlette LIFO 시맨틱이므로 마지막
+    # add가 가장 바깥(요청을 가장 먼저 받음). 의도된 요청 처리 순서는
+    # TokenAuth → RequireAuth → Audit → CORS → 라우트 이며, 이를 얻으려면
+    # 역순으로 add 한다.
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],
@@ -53,9 +58,11 @@ def create_app(**services: Any) -> FastAPI:
     )
 
     from ante.web.middleware.audit import AuditMiddleware
+    from ante.web.middleware.require_auth import RequireAuthMiddleware
     from ante.web.middleware.token_auth import TokenAuthMiddleware
 
     app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequireAuthMiddleware)
     app.add_middleware(TokenAuthMiddleware)
 
     for name, service in services.items():

--- a/src/ante/web/middleware/__init__.py
+++ b/src/ante/web/middleware/__init__.py
@@ -1,6 +1,7 @@
 """Web API 미들웨어."""
 
 from ante.web.middleware.audit import AuditMiddleware
+from ante.web.middleware.require_auth import RequireAuthMiddleware
 from ante.web.middleware.token_auth import TokenAuthMiddleware
 
-__all__ = ["AuditMiddleware", "TokenAuthMiddleware"]
+__all__ = ["AuditMiddleware", "RequireAuthMiddleware", "TokenAuthMiddleware"]

--- a/src/ante/web/middleware/require_auth.py
+++ b/src/ante/web/middleware/require_auth.py
@@ -1,0 +1,213 @@
+"""default-deny 인증 게이트 미들웨어 (#1403).
+
+D-015 ADR (``docs/decisions/D-015-default-deny-auth-gate.md``)의 5단계 판정
+순서를 그대로 구현한다. spec SSOT:
+
+- ``docs/specs/web-api/02-design-decisions.md`` — 인증 게이트 단계 / CORS 설정
+- ``docs/specs/web-api/09-public-paths.md`` — PUBLIC_PATHS / PUBLIC_PREFIXES /
+  ``gate-exempt-self-auth`` / 비-``/api`` SPA fallback
+
+요청 처리 순서 (LIFO add 시퀀스 결과):
+    ``TokenAuth → RequireAuth → Audit → CORS → 라우트``
+
+본 미들웨어의 5단계 판정 (D-015 ADR 표):
+    1. ``OPTIONS`` preflight 면제 → 즉시 통과 (CORS 안전망)
+    2. PUBLIC 면제 → ``PUBLIC_PATHS`` exact / ``PUBLIC_PREFIXES`` startswith /
+       비-``/api`` SPA fallback. 면제 시 세션 fallback도 시도하지 않음
+    3. ``gate-exempt-self-auth`` 면제 → PUBLIC과 동일 통과. 라우트가 자체 self-auth
+    4. Bearer caller 확인 → ``request.state.member_id`` 가 비어 있지 않으면 통과
+    5. 세션 쿠키 fallback + ACTIVE 검증 → ``ante_session`` 쿠키로 caller 결정 후
+       ``MemberStatus.ACTIVE`` 검사. ACTIVE 이면 ``request.state.member_id`` 부착
+       후 통과. 그 외 (만료/없음/SUSPENDED/REVOKED) → 401
+    6. caller 미결정 시 → 401 (Origin 헤더가 있으면 ``Access-Control-Allow-Origin``
+       응답 헤더를 함께 포함, 잔여 P2-A)
+
+scope 검사는 본 미들웨어 책임이 아니다. 라우트 dependency / ``@require_scope``
+가 담당한다 (D-015 책임 매트릭스).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from ante.web.errors import PROBLEM_JSON, _build_error
+
+logger = logging.getLogger(__name__)
+
+# PUBLIC_PATHS SSOT: ``docs/specs/web-api/09-public-paths.md``.
+# 정확 일치 (exact match) 공개 경로. 인증 없이 누구나 접근 가능.
+PUBLIC_PATHS: frozenset[str] = frozenset(
+    {
+        "/",
+        "/index.html",
+        "/api/system/health",
+        "/api/auth/login",
+        "/api/auth/logout",
+        "/openapi.json",
+        "/docs",
+        "/redoc",
+    }
+)
+
+# PUBLIC_PREFIXES SSOT: ``docs/specs/web-api/09-public-paths.md``.
+# 접두어 일치. trailing slash 경계를 보장해 ``/assets-foo`` 같은 오인 통과를 막는다.
+PUBLIC_PREFIXES: tuple[str, ...] = ("/assets/",)
+
+# gate-exempt-self-auth SSOT: ``docs/specs/web-api/09-public-paths.md`` 9-43~9-51.
+# 미들웨어 게이트는 면제, 라우트가 자체적으로 세션/Bearer 검증 후 본인 정보만 응답.
+GATE_EXEMPT_SELF_AUTH_PATHS: frozenset[str] = frozenset({"/api/auth/me"})
+
+_AUTH_REQUIRED_DETAIL = (
+    "인증이 필요합니다. Authorization: Bearer <token> 헤더 또는 "
+    "유효한 ante_session 쿠키가 필요합니다."
+)
+
+
+class RequireAuthMiddleware(BaseHTTPMiddleware):
+    """default-deny 인증 게이트.
+
+    D-015 ADR 5단계 판정 순서로 보호 라우트 진입 전에 401을 1차 차단한다.
+    scope 검사는 라우트 dependency (``@require_scope``) 책임.
+    """
+
+    async def dispatch(self, request: Request, call_next: Any) -> Response:
+        # 1단계: OPTIONS preflight 면제 (CORS 안전망).
+        # spec 02-design-decisions.md "CORS 설정" 절: 등록 순서에 의존하지
+        # 않도록 미들웨어 자체가 OPTIONS를 무조건 통과시킨다.
+        if request.method == "OPTIONS":
+            return await call_next(request)
+
+        path = request.url.path
+
+        # 2단계 + 3단계: PUBLIC 면제 / gate-exempt-self-auth 면제.
+        # 두 카테고리 모두 미들웨어 단계에서 동일하게 401 없이 통과시킨다.
+        # 차이는 라우트 단 책임에 있다 (public = caller-agnostic 응답,
+        # gate-exempt-self-auth = 라우트가 자체 self-auth).
+        if _is_public_path(path) or path in GATE_EXEMPT_SELF_AUTH_PATHS:
+            return await call_next(request)
+
+        # 4단계: Bearer caller 확인.
+        # TokenAuthMiddleware가 이미 ``request.state.member_id``를 채웠으면 통과.
+        # Bearer 경로는 ``member_service.authenticate``가 ACTIVE 검사를 이미
+        # 수행하므로 미들웨어 진입 시점에 부착된 caller는 ACTIVE 보장이 있다.
+        caller = getattr(request.state, "member_id", "") or ""
+        if caller:
+            return await call_next(request)
+
+        # 5단계: 세션 쿠키 fallback + ACTIVE 검증.
+        # spec 02-design-decisions.md "세션 fallback 시 멤버 상태 검증" 절을 따른다.
+        session_caller = await _resolve_session_caller(request)
+        if session_caller is not None:
+            request.state.member_id = session_caller
+            return await call_next(request)
+
+        # 6단계: caller 미결정 → 401.
+        return _unauthorized_response(request)
+
+
+def _is_public_path(path: str) -> bool:
+    """spec 09-public-paths.md SSOT 기준으로 공개 경로 여부 판정.
+
+    분기 우선순위:
+    1. ``PUBLIC_PATHS`` exact match
+    2. ``PUBLIC_PREFIXES`` startswith (trailing slash 경계 보장)
+    3. 비-``/api`` SPA fallback (``/login``, ``/dashboard/foo`` 등 client-side route)
+    """
+    if path in PUBLIC_PATHS:
+        return True
+    for prefix in PUBLIC_PREFIXES:
+        if path.startswith(prefix):
+            return True
+    # 비-``/api`` SPA fallback (spec 09-public-paths.md "SPA fallback 경로").
+    # ``/api`` exact 또는 ``/api/...``만 보호 대상. 그 외 (``/login``,
+    # ``/dashboard/...``, ``/strategies/...`` 등 client-side route)는 면제.
+    if path != "/api" and not path.startswith("/api/"):
+        return True
+    return False
+
+
+async def _resolve_session_caller(request: Request) -> str | None:
+    """``ante_session`` 쿠키 fallback. ACTIVE 멤버이면 caller_id 반환, 그 외 None.
+
+    spec 02-design-decisions.md "세션 fallback 시 멤버 상태 검증" 절 (Codex
+    review v3 Finding X)을 따른다:
+
+    - ``SessionService.validate``는 세션 만료/서명만 검증하므로 멤버가
+      ``SUSPENDED``/``REVOKED``로 전환되어도 세션 row가 남아 있으면 통과한다.
+    - 따라서 미들웨어가 ``member_service.get(caller)``를 호출해
+      ``MemberStatus.ACTIVE``를 명시 확인한다.
+    - 비ACTIVE이면 caller 부착 없이 None 반환 (호출자가 401 응답 생성).
+    """
+    ante_session = request.cookies.get("ante_session")
+    if not ante_session:
+        return None
+
+    session_service = getattr(request.app.state, "session_service", None)
+    if session_service is None:
+        return None
+
+    member_service = getattr(request.app.state, "member_service", None)
+    if member_service is None:
+        return None
+
+    try:
+        session = await session_service.validate(ante_session)
+    except Exception:
+        logger.exception("세션 검증 실패 (session_id 일부=%s...)", ante_session[:8])
+        return None
+    if not session:
+        return None
+
+    member_id = session.get("member_id", "") or ""
+    if not member_id:
+        return None
+
+    try:
+        member = await member_service.get(member_id)
+    except Exception:
+        logger.exception("멤버 조회 실패 (member_id=%s)", member_id)
+        return None
+    if member is None:
+        return None
+
+    # MemberStatus.ACTIVE 검사. enum/str 양쪽 안전 처리.
+    from ante.member.models import MemberStatus
+
+    status = getattr(member, "status", None)
+    status_value = getattr(status, "value", status)
+    if status_value != MemberStatus.ACTIVE.value:
+        return None
+
+    return member_id
+
+
+def _unauthorized_response(request: Request) -> JSONResponse:
+    """RFC 7807 형식의 401 응답. Origin 헤더가 있으면 CORS Allow-Origin 동봉.
+
+    spec 02-design-decisions.md "CORS 등록 순서와 RequireAuth의 관계" 절을 따른다.
+    잔여 P2-A: cross-origin 인증 실패도 브라우저가 응답을 읽을 수 있도록
+    ``Access-Control-Allow-Origin`` 헤더를 명시한다. Origin 헤더가 없으면
+    헤더를 추가하지 않는다 (Codex 권장).
+    """
+    error = _build_error(
+        status=401,
+        detail=_AUTH_REQUIRED_DETAIL,
+        instance=request.url.path,
+    )
+    headers: dict[str, str] = {}
+    origin = request.headers.get("origin")
+    if origin:
+        # spec: 홈서버 환경이므로 ``allow_origins=["*"]``. CORS Allow-Origin은
+        # echoed origin이 아닌 ``*``로 통일해 CORSMiddleware 응답 단과 일관성 유지.
+        headers["access-control-allow-origin"] = "*"
+    return JSONResponse(
+        status_code=401,
+        content=error.model_dump(),
+        media_type=PROBLEM_JSON,
+        headers=headers,
+    )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,111 @@
+"""tests/unit 공통 fixture.
+
+``RequireAuthMiddleware`` (#1403) 도입 후 default-deny 가 모든 보호 라우트에
+적용된다. 라우트의 비즈니스 로직만 검증하는 테스트들이 익명 호출로 401 회귀를
+일으키지 않도록, 본 모듈에서 공용 ``master_member_service`` /
+``master_auth_headers`` / ``authed_test_client`` 헬퍼를 제공한다.
+
+설계 의도:
+
+* 미들웨어 게이트 자체의 매트릭스는 ``test_require_auth_middleware.py`` /
+  ``test_runtime_mutation_auth.py`` 가 별도로 보호한다. 본 헬퍼는 그 외의
+  "라우트 동작 검증" 테스트가 인증 게이트를 깔끔하게 통과하도록 돕는
+  공통 stub 일 뿐, 인증 매트릭스를 대체하지 않는다.
+* ``_MasterOnlyMemberService`` 는 단일 master 토큰 ``master-test-token`` 만
+  인증한다. ``TokenAuthMiddleware`` 가 ``authenticate(token)`` 을,
+  ``RequireAuthMiddleware`` 가 세션 fallback 경로에서 ``get(member_id)`` 를
+  호출한다.
+* ``make_authed_client(app)`` 는 master Bearer 토큰을 디폴트 헤더로 부착한
+  ``TestClient`` 를 돌려준다. 라우트 동작 테스트의 표준 진입점이다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field as dc_field
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+
+@dataclass
+class _MasterMember:
+    """tests/unit 공용 master 멤버 stub.
+
+    필드는 ``ante.member.models.Member`` 의 직렬화 가능한 부분 집합과
+    동일한 모양을 가진다. RequireAuthMiddleware 세션 fallback 의
+    ``status`` 검사를 통과하기 위해 ``status="active"`` 를 유지한다.
+    """
+
+    member_id: str = "master-test"
+    type: str = "human"
+    role: str = "master"
+    org: str = "default"
+    name: str = "Test Master"
+    emoji: str = ""
+    status: str = "active"
+    scopes: list[str] = dc_field(default_factory=list)
+
+
+class _MasterOnlyMemberService:
+    """master 토큰 ``master-test-token`` 만 인증하는 최소 stub.
+
+    ``TokenAuthMiddleware`` 가 ``authenticate(token)`` 을, ``RequireAuthMiddleware``
+    가 ``get(member_id)`` 를 호출한다. ``update_last_active`` 는 no-op.
+    """
+
+    def __init__(self) -> None:
+        self._master = _MasterMember()
+
+    async def authenticate(self, token: str) -> _MasterMember:
+        if token != "master-test-token":
+            raise PermissionError("invalid token")
+        return self._master
+
+    async def get(self, member_id: str) -> _MasterMember | None:
+        if member_id == self._master.member_id:
+            return self._master
+        return None
+
+    async def update_last_active(self, member_id: str) -> None:
+        return None
+
+
+# tests/unit 표준 master Bearer 헤더. 공통 helper 가 자동 부착하지만,
+# 인증 없는 동일 라우트 검증 등에서 명시 사용할 수 있도록 노출한다.
+MASTER_AUTH_HEADERS: dict[str, str] = {"Authorization": "Bearer master-test-token"}
+
+
+def make_master_member_service() -> _MasterOnlyMemberService:
+    """라우트 동작 테스트용 master-only ``MemberService`` 인스턴스 생성."""
+    return _MasterOnlyMemberService()
+
+
+def make_authed_client(app: FastAPI) -> TestClient:
+    """master Bearer 토큰을 디폴트 헤더로 부착한 ``TestClient``.
+
+    호출 측은 ``create_app(..., member_service=make_master_member_service())``
+    로 app 을 만든 뒤 본 함수로 client 를 받는다. default-deny 가 적용된 보호
+    라우트가 자동으로 인증을 통과한다.
+    """
+    from fastapi.testclient import TestClient
+
+    test_client = TestClient(app)
+    test_client.headers.update(MASTER_AUTH_HEADERS)
+    return test_client
+
+
+@pytest.fixture
+def master_member_service() -> _MasterOnlyMemberService:
+    """라우트 동작 테스트용 master-only ``MemberService`` fixture."""
+    return make_master_member_service()
+
+
+@pytest.fixture
+def master_auth_headers() -> dict[str, str]:
+    """master Bearer 디폴트 헤더 fixture (인증 없는 client 와 함께 쓸 때 명시 사용)."""
+    return dict(MASTER_AUTH_HEADERS)

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -22,6 +22,10 @@ from ante.account.errors import (  # noqa: E402
 from ante.account.models import Account, AccountStatus, TradingMode  # noqa: E402
 from ante.member.models import MemberRole  # noqa: E402
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 # 인증 가드(#1352) — PUT/POST mutation route는 master 인증이 필요.
 # 본 모듈의 회귀 본질(structural 가드, mutable 검증, audit 등)은 인증 가드와
@@ -267,7 +271,7 @@ def app(account_service: FakeAccountService, audit_logger: FakeAuditLogger):
 
 @pytest.fixture
 def client(app) -> TestClient:
-    client = TestClient(app)
+    client = make_authed_client(app)
     client.headers.update(_MASTER_HEADERS)
     return client
 
@@ -437,10 +441,12 @@ class TestCreateAccount:
         ``get_account_service`` 의존성을 시그니처에서 제거한 게 회귀 차단의
         본질이며, 이 테스트가 그 invariant를 직접 단언한다.
         """
-        app = create_app()  # account_service 미주입
+        app = create_app(
+            member_service=make_master_member_service()
+        )  # account_service 미주입
         # account_service 미주입 확인
         assert getattr(app.state, "account_service", None) is None
-        with TestClient(app) as bare_client:
+        with make_authed_client(app) as bare_client:
             resp = bare_client.post(
                 "/api/accounts",
                 json={
@@ -1048,7 +1054,7 @@ class TestUpdateAccount:
         """
         app = create_app(member_service=_new_member_service())  # account_service 미주입
         assert getattr(app.state, "account_service", None) is None
-        with TestClient(app) as bare_client:
+        with make_authed_client(app) as bare_client:
             resp = bare_client.put(
                 "/api/accounts/some-id",
                 json={"credentials": {"app_key": "x"}},
@@ -1071,7 +1077,7 @@ class TestUpdateAccount:
         """
         app = create_app(member_service=_new_member_service())  # account_service 미주입
         assert getattr(app.state, "account_service", None) is None
-        with TestClient(app) as bare_client:
+        with make_authed_client(app) as bare_client:
             resp = bare_client.put(
                 "/api/accounts/some-id",
                 json={"name": "변경"},
@@ -1631,9 +1637,11 @@ class TestDeleteAccount:
         않아야 하며, account_service가 None일 때도 cold-path 409가 일관되게
         반환되어야 한다.
         """
-        app = create_app()  # account_service 미주입
+        app = create_app(
+            member_service=make_master_member_service()
+        )  # account_service 미주입
         assert getattr(app.state, "account_service", None) is None
-        with TestClient(app) as bare_client:
+        with make_authed_client(app) as bare_client:
             resp = bare_client.delete("/api/accounts/some-id")
         assert resp.status_code == 409
         detail = resp.json()["detail"]

--- a/tests/unit/test_account_rules_api.py
+++ b/tests/unit/test_account_rules_api.py
@@ -25,6 +25,10 @@ from fastapi.testclient import TestClient  # noqa: E402
 from ante.account.errors import AccountNotFoundError  # noqa: E402
 from ante.account.models import Account, AccountStatus, TradingMode  # noqa: E402
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 # ── Member / Session fakes (#1376 update_account_rule 인증 가드) ────────────
 
@@ -223,7 +227,12 @@ def app(
 
 @pytest.fixture
 def client(app) -> TestClient:
-    return TestClient(app)
+    # 본 파일은 자체 ``_FakeMemberService`` 가 ``master-token`` 만 인식한다.
+    # ``RequireAuthMiddleware`` (#1403) default-deny 회귀를 막기 위해 client
+    # 디폴트 헤더에 master-token 을 명시 부착한다.
+    test_client = TestClient(app)
+    test_client.headers.update(_MASTER_HEADERS)
+    return test_client
 
 
 class TestGetAccountRules:
@@ -298,8 +307,9 @@ class TestGetAccountRules:
             audit_logger=audit_logger,
             dynamic_config=FakeDynamicConfig(),
             config=static_config,
+            member_service=make_master_member_service(),
         )
-        client = TestClient(app)
+        client = make_authed_client(app)
 
         resp = client.get("/api/accounts/acct-1/rules")
         assert resp.status_code == 200
@@ -493,7 +503,7 @@ class TestUpdateAccountRule:
             member_service=member_service,
             session_service=session_service,
         )
-        client = TestClient(app)
+        client = make_authed_client(app)
 
         resp = client.put(
             "/api/accounts/acct-1/rules/total_exposure_limit",

--- a/tests/unit/test_api_pagination.py
+++ b/tests/unit/test_api_pagination.py
@@ -10,9 +10,12 @@ from ante.web.pagination import decode_cursor, encode_cursor, paginate
 
 httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
-from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 
 class TestPaginationUtil:
@@ -75,8 +78,10 @@ class TestReportsEndpointPagination:
             reports.append(r)
         mock_store.list_reports = AsyncMock(return_value=reports)
 
-        app = create_app(report_store=mock_store)
-        client = TestClient(app)
+        app = create_app(
+            report_store=mock_store, member_service=make_master_member_service()
+        )
+        client = make_authed_client(app)
         resp = client.get("/api/reports?limit=3")
         assert resp.status_code == 200
         data = resp.json()
@@ -93,8 +98,10 @@ class TestReportsEndpointPagination:
         r.submitted_at = "2025-01-01"
         mock_store.list_reports = AsyncMock(return_value=[r])
 
-        app = create_app(report_store=mock_store)
-        client = TestClient(app)
+        app = create_app(
+            report_store=mock_store, member_service=make_master_member_service()
+        )
+        client = make_authed_client(app)
         resp = client.get("/api/reports?limit=20")
         data = resp.json()
         assert data["next_cursor"] is None
@@ -107,8 +114,10 @@ class TestBotsEndpointPagination:
         bots = [{"bot_id": f"bot-{i}", "status": "running"} for i in range(5)]
         mock_manager.list_bots.return_value = bots
 
-        app = create_app(bot_manager=mock_manager)
-        client = TestClient(app)
+        app = create_app(
+            bot_manager=mock_manager, member_service=make_master_member_service()
+        )
+        client = make_authed_client(app)
         resp = client.get("/api/bots?limit=3")
         assert resp.status_code == 200
         data = resp.json()
@@ -117,8 +126,8 @@ class TestBotsEndpointPagination:
 
     def test_bots_service_unavailable(self):
         """봇 매니저 없으면 503."""
-        app = create_app()
-        client = TestClient(app)
+        app = create_app(member_service=make_master_member_service())
+        client = make_authed_client(app)
         resp = client.get("/api/bots")
         assert resp.status_code == 503
 
@@ -142,8 +151,10 @@ class TestTradesEndpointPagination:
             trades.append(t)
         mock_service.get_trades = AsyncMock(return_value=trades)
 
-        app = create_app(trade_service=mock_service)
-        client = TestClient(app)
+        app = create_app(
+            trade_service=mock_service, member_service=make_master_member_service()
+        )
+        client = make_authed_client(app)
         resp = client.get("/api/trades?limit=3")
         assert resp.status_code == 200
         data = resp.json()

--- a/tests/unit/test_app_middleware_order.py
+++ b/tests/unit/test_app_middleware_order.py
@@ -1,0 +1,144 @@
+"""``create_app`` 미들웨어 등록 순서 회귀 테스트 (#1403).
+
+spec SSOT: ``docs/specs/web-api/02-design-decisions.md`` "인증 게이트 단계" +
+"CORS 설정" 절. Starlette ``add_middleware()`` 는 ``insert(0)`` 시맨틱이므로
+**마지막 add가 가장 바깥** (요청을 가장 먼저 받음)이다.
+
+의도된 요청 처리 순서:
+    ``TokenAuth → RequireAuth → Audit → CORS → 라우트``
+
+이를 위한 add 호출 순서 (역순):
+    1. CORSMiddleware
+    2. AuditMiddleware
+    3. RequireAuthMiddleware
+    4. TokenAuthMiddleware
+
+``app.user_middleware`` 는 ``insert(0)`` 결과 add **역순** 으로 저장되므로
+``[TokenAuth, RequireAuth, Audit, CORS]`` 순서를 가진다.
+
+본 테스트는 위 spec 매핑을 코드 상수로 고정해 잘못된 등록 순서 (예:
+``TokenAuth`` 가 ``RequireAuth`` 앞에 add 되어 Bearer caller 부착 전 default-deny
+가 발화하는 회귀) 가 들어와도 즉시 실패하게 한다.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402
+from ante.web.middleware import (  # noqa: E402
+    AuditMiddleware,
+    RequireAuthMiddleware,
+    TokenAuthMiddleware,
+)
+
+
+def _middleware_classes(app: object) -> list[type]:
+    """``app.user_middleware`` 에 등록된 미들웨어 클래스 리스트."""
+    return [m.cls for m in app.user_middleware]  # type: ignore[attr-defined]
+
+
+class TestMiddlewareOrderWithoutFrontend:
+    """frontend 빌드 미존재 분기 (SPAFallbackMiddleware 미부착)."""
+
+    def test_user_middleware_order_default(self) -> None:
+        """등록 순서: ``TokenAuth → RequireAuth → Audit → CORS`` (user_middleware 시점).
+
+        spec 02-design-decisions.md "add_middleware 순서 vs 실행 순서":
+        마지막 add 가 list 가장 앞으로 가서 가장 바깥에 위치한다.
+        """
+        app = create_app()
+        classes = _middleware_classes(app)
+
+        # SPAFallbackMiddleware 가 추가될 수도 있으므로 위 4개 미들웨어만
+        # 추출해서 상대 순서를 비교한다.
+        target = {
+            TokenAuthMiddleware,
+            RequireAuthMiddleware,
+            AuditMiddleware,
+            CORSMiddleware,
+        }
+        observed = [c for c in classes if c in target]
+        assert observed == [
+            TokenAuthMiddleware,
+            RequireAuthMiddleware,
+            AuditMiddleware,
+            CORSMiddleware,
+        ]
+
+    def test_token_auth_added_after_require_auth(self) -> None:
+        """``TokenAuthMiddleware`` 는 ``RequireAuthMiddleware`` 보다 **나중에** add 되어
+        야 한다 (= 더 바깥, 더 먼저 실행).
+
+        spec 02-design-decisions.md "CORS 등록 순서와 RequireAuth의 관계" 절:
+        반대로 add 하면 Bearer caller 가 부착되기 전에 default-deny 가 발화해
+        **정상 Bearer 토큰 사용자도 모두 401** 을 받는 회귀가 발생한다.
+        """
+        app = create_app()
+        classes = _middleware_classes(app)
+        # user_middleware 는 LIFO add 결과 역순으로 저장.
+        # TokenAuth 가 RequireAuth 보다 **앞**에 와야 더 바깥이다.
+        token_idx = classes.index(TokenAuthMiddleware)
+        require_idx = classes.index(RequireAuthMiddleware)
+        assert token_idx < require_idx
+
+    def test_cors_added_first(self) -> None:
+        """``CORSMiddleware`` 는 가장 안쪽 (마지막 실행).
+
+        Starlette LIFO 시맨틱: 가장 먼저 add → user_middleware list 끝으로 감
+        → 빌드 시 reversed → 가장 안쪽.
+        """
+        app = create_app()
+        classes = _middleware_classes(app)
+        # CORS 가 RequireAuth/Audit/Token 보다 **뒤**에 있어야 한다.
+        cors_idx = classes.index(CORSMiddleware)
+        require_idx = classes.index(RequireAuthMiddleware)
+        audit_idx = classes.index(AuditMiddleware)
+        token_idx = classes.index(TokenAuthMiddleware)
+        assert cors_idx > require_idx
+        assert cors_idx > audit_idx
+        assert cors_idx > token_idx
+
+
+class TestMiddlewareOrderWithFrontend:
+    """frontend 빌드 존재 분기 (SPAFallbackMiddleware 부착).
+
+    ``_mount_frontend`` 가 SPAFallbackMiddleware 를 추가로 add 하지만, 인증
+    관련 4개 미들웨어의 상대 순서는 유지되어야 한다.
+
+    Codex 권장 (3 보강): SPAFallback 존재/부재 두 케이스 모두 회귀 보호.
+    """
+
+    def test_relative_order_preserved_with_spa_fallback(
+        self, tmp_path: object, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SPAFallbackMiddleware 추가 시에도 인증 4단 상대 순서 유지."""
+        from pathlib import Path
+
+        # frontend dist 디렉토리를 가짜로 만들어 _mount_frontend 분기를 활성화.
+        fake_dist = Path(str(tmp_path)) / "dist"
+        fake_dist.mkdir(parents=True)
+        (fake_dist / "index.html").write_text("<html></html>")
+
+        # _get_frontend_dir 가 fake_dist 를 반환하도록 monkeypatch.
+        from ante.web import app as app_module
+
+        monkeypatch.setattr(app_module, "_get_frontend_dir", lambda: fake_dist)
+
+        app = create_app()
+        classes = _middleware_classes(app)
+
+        # SPAFallbackMiddleware 가 추가됐는지 확인.
+        spa_classes = [c for c in classes if c.__name__ == "SPAFallbackMiddleware"]
+        assert spa_classes, "SPAFallbackMiddleware 가 등록되어야 한다"
+
+        # 인증 4단 상대 순서 검증.
+        token_idx = classes.index(TokenAuthMiddleware)
+        require_idx = classes.index(RequireAuthMiddleware)
+        audit_idx = classes.index(AuditMiddleware)
+        cors_idx = classes.index(CORSMiddleware)
+        assert token_idx < require_idx < audit_idx < cors_idx

--- a/tests/unit/test_approval_api.py
+++ b/tests/unit/test_approval_api.py
@@ -6,9 +6,12 @@ import pytest
 
 httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
-from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 
 @pytest.fixture
@@ -34,12 +37,14 @@ async def approval_service(db):
 
 @pytest.fixture
 def app(approval_service):
-    return create_app(approval_service=approval_service)
+    return create_app(
+        approval_service=approval_service, member_service=make_master_member_service()
+    )
 
 
 @pytest.fixture
 def client(app):
-    return TestClient(app)
+    return make_authed_client(app)
 
 
 @pytest.fixture

--- a/tests/unit/test_approval_routes_filter_validation.py
+++ b/tests/unit/test_approval_routes_filter_validation.py
@@ -20,9 +20,12 @@ import pytest
 
 httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
-from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 
 @pytest.fixture
@@ -48,12 +51,14 @@ async def approval_service(db):
 
 @pytest.fixture
 def app(approval_service):
-    return create_app(approval_service=approval_service)
+    return create_app(
+        approval_service=approval_service, member_service=make_master_member_service()
+    )
 
 
 @pytest.fixture
 def client(app):
-    return TestClient(app)
+    return make_authed_client(app)
 
 
 @pytest.fixture

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -9,10 +9,13 @@ import pytest
 
 httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
-from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.member.models import MemberRole  # noqa: E402
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 # 인증 가드(#1352) — PUT /api/bots/{bot_id}에 master 인증이 필요해졌다.
 # 본 모듈의 update_bot 회귀(이름/예산/strategy 등)는 인증 가드와 무관하므로
@@ -274,7 +277,7 @@ def client(bot_manager, default_account_service):
         account_service=default_account_service,
         member_service=_new_member_service(),
     )
-    client = TestClient(app)
+    client = make_authed_client(app)
     client.headers.update(_MASTER_HEADERS)
     return client
 
@@ -288,7 +291,7 @@ def client_with_services(bot_manager, treasury, trade_service, default_account_s
         account_service=default_account_service,
         member_service=_new_member_service(),
     )
-    client = TestClient(app)
+    client = make_authed_client(app)
     client.headers.update(_MASTER_HEADERS)
     return client
 
@@ -364,8 +367,9 @@ class TestStartBotCredentialCheck:
         app = create_app(
             bot_manager=bot_manager,
             account_service=no_credentials_account_service,
+            member_service=make_master_member_service(),
         )
-        return TestClient(app)
+        return make_authed_client(app)
 
     def test_start_bot_without_credentials_returns_422(
         self, client_no_credentials, bot_manager
@@ -382,8 +386,12 @@ class TestStartBotCredentialCheck:
         svc._accounts["test"] = FakeAccount(
             "test", status="active", credentials={"app_key": ""}
         )
-        app = create_app(bot_manager=bot_manager, account_service=svc)
-        client = TestClient(app)
+        app = create_app(
+            bot_manager=bot_manager,
+            account_service=svc,
+            member_service=make_master_member_service(),
+        )
+        client = make_authed_client(app)
         bot_manager._bots["bot-1"] = FakeBot("bot-1", status="created")
         resp = client.post("/api/bots/bot-1/start")
         assert resp.status_code == 422
@@ -571,7 +579,7 @@ class TestCreateBotAccountStatus:
             strategy_registry=strategy_registry,
             member_service=_new_member_service(),
         )
-        client = TestClient(app)
+        client = make_authed_client(app)
         client.headers.update(_MASTER_HEADERS)
         return client
 
@@ -602,7 +610,7 @@ class TestCreateBotAccountStatus:
             strategy_registry=strategy_registry,
             member_service=_new_member_service(),
         )
-        client = TestClient(app)
+        client = make_authed_client(app)
         client.headers.update(_MASTER_HEADERS)
         resp = client.post(
             "/api/bots",
@@ -655,8 +663,9 @@ class TestListBotsStrategyName:
             bot_manager=bot_manager,
             account_service=default_account_service,
             strategy_registry=strategy_registry,
+            member_service=make_master_member_service(),
         )
-        return TestClient(app)
+        return make_authed_client(app)
 
     def test_strategy_name_included(self, client_with_registry, bot_manager):
         """봇 목록에 strategy_name, strategy_author_name, strategy_author_id 포함."""
@@ -708,8 +717,9 @@ class TestGetBotStrategyName:
             bot_manager=bot_manager,
             account_service=default_account_service,
             strategy_registry=strategy_registry,
+            member_service=make_master_member_service(),
         )
-        return TestClient(app)
+        return make_authed_client(app)
 
     def test_strategy_name_included(self, client_with_registry, bot_manager):
         """봇 상세 조회에 strategy_name, strategy_author_name/id 포함."""
@@ -808,7 +818,7 @@ class TestDeleteBotAuditLog:
             audit_logger=fake_audit_logger,
             member_service=_new_member_service(),
         )
-        client = TestClient(app)
+        client = make_authed_client(app)
         client.headers.update(_MASTER_HEADERS)
         return client
 
@@ -929,7 +939,7 @@ class TestUpdateBot:
             account_service=default_account_service,
             member_service=_new_member_service(),
         )
-        client = TestClient(app)
+        client = make_authed_client(app)
         client.headers.update(_MASTER_HEADERS)
         bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
         resp = client.put("/api/bots/bot-1", json={"budget": 2000000})
@@ -963,7 +973,7 @@ class TestUpdateBotStrategy:
             account_service=default_account_service,
             member_service=_new_member_service(),
         )
-        client = TestClient(app)
+        client = make_authed_client(app)
         client.headers.update(_MASTER_HEADERS)
         return client
 
@@ -1029,7 +1039,7 @@ class TestCreateBotStrategyName:
             strategy_registry=strategy_registry,
             member_service=_new_member_service(),
         )
-        client = TestClient(app)
+        client = make_authed_client(app)
         client.headers.update(_MASTER_HEADERS)
         return client
 
@@ -1104,7 +1114,7 @@ class TestCreateBotStrategyName:
             strategy_registry=strategy_registry,
             member_service=_new_member_service(),
         )
-        client = TestClient(app)
+        client = make_authed_client(app)
         client.headers.update(_MASTER_HEADERS)
         resp = client.post(
             "/api/bots",
@@ -1130,7 +1140,7 @@ class TestCreateBotStrategyName:
             strategy_registry=strategy_registry,
             member_service=_new_member_service(),
         )
-        client = TestClient(app)
+        client = make_authed_client(app)
         client.headers.update(_MASTER_HEADERS)
         resp = client.post(
             "/api/bots",

--- a/tests/unit/test_bot_step_event.py
+++ b/tests/unit/test_bot_step_event.py
@@ -240,9 +240,12 @@ class TestBotStepCompletedEventPublish:
 
 httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
-from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 
 class FakeBotConfig:
@@ -329,8 +332,9 @@ class TestBotLogsAPIWithEventBus:
             bot_manager=bot_manager,
             eventbus=eventbus_with_logs,
             account_service=FakeAccountService(),
+            member_service=make_master_member_service(),
         )
-        return TestClient(app)
+        return make_authed_client(app)
 
     async def _publish_events(self, eb):
         """테스트용 이벤트 발행."""

--- a/tests/unit/test_broker_meta_api.py
+++ b/tests/unit/test_broker_meta_api.py
@@ -8,6 +8,10 @@ from starlette.testclient import TestClient
 from ante.broker.base import BrokerAdapter
 from ante.broker.mock import MockBrokerAdapter
 from ante.web.app import create_app
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 
 class FakeTreasury:
@@ -40,13 +44,19 @@ class TestBrokerMetaInTreasury:
     @pytest.fixture
     def client_with_broker(self) -> TestClient:
         broker = MockBrokerAdapter({"exchange": "KRX"})
-        app = create_app(treasury=FakeTreasury(), broker=broker)
-        return TestClient(app)
+        app = create_app(
+            treasury=FakeTreasury(),
+            broker=broker,
+            member_service=make_master_member_service(),
+        )
+        return make_authed_client(app)
 
     @pytest.fixture
     def client_without_broker(self) -> TestClient:
-        app = create_app(treasury=FakeTreasury())
-        return TestClient(app)
+        app = create_app(
+            treasury=FakeTreasury(), member_service=make_master_member_service()
+        )
+        return make_authed_client(app)
 
     def test_broker_meta_fields_present(self, client_with_broker: TestClient) -> None:
         """브로커가 있으면 메타정보 4개 필드가 응답에 포함된다."""

--- a/tests/unit/test_data_schema_validation.py
+++ b/tests/unit/test_data_schema_validation.py
@@ -17,11 +17,15 @@ httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 
 @pytest.fixture
 def client() -> TestClient:
-    return TestClient(create_app())
+    return make_authed_client(create_app(member_service=make_master_member_service()))
 
 
 # ── /api/data/schema ─────────────────────────────────────

--- a/tests/unit/test_dataset_delete_api.py
+++ b/tests/unit/test_dataset_delete_api.py
@@ -9,10 +9,13 @@ import pytest
 
 httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
-from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.data.store import ParquetStore  # noqa: E402
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 
 def _make_ohlcv_df() -> pl.DataFrame:
@@ -60,8 +63,8 @@ def store(tmp_path):
 
 @pytest.fixture
 def client(store):
-    app = create_app(data_store=store)
-    return TestClient(app)
+    app = create_app(data_store=store, member_service=make_master_member_service())
+    return make_authed_client(app)
 
 
 class TestListDatasets:

--- a/tests/unit/test_dataset_detail_api.py
+++ b/tests/unit/test_dataset_detail_api.py
@@ -9,10 +9,13 @@ import pytest
 
 httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
-from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.data.store import ParquetStore  # noqa: E402
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 
 def _make_ohlcv_df(n: int = 10) -> pl.DataFrame:
@@ -60,8 +63,8 @@ def store(tmp_path):
 
 @pytest.fixture
 def client(store):
-    app = create_app(data_store=store)
-    return TestClient(app)
+    app = create_app(data_store=store, member_service=make_master_member_service())
+    return make_authed_client(app)
 
 
 class TestDatasetDetail:
@@ -131,8 +134,8 @@ class TestDatasetDetail:
 
     def test_store_unavailable(self):
         """store가 None이면 503을 반환한다."""
-        app = create_app(data_store=None)
-        c = TestClient(app)
+        app = create_app(data_store=None, member_service=make_master_member_service())
+        c = make_authed_client(app)
         resp = c.get("/api/data/datasets/005930__1d")
         assert resp.status_code == 503
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -8,6 +8,10 @@ from ante.config import Config, DynamicConfigService
 from ante.core import Database
 from ante.eventbus import EventBus, EventHistoryStore
 from ante.eventbus.events import OrderRequestEvent
+from tests.unit.conftest import (
+    make_authed_client,
+    make_master_member_service,
+)
 
 
 async def test_full_initialization(tmp_path: Path) -> None:
@@ -475,8 +479,6 @@ async def test_composition_root_with_web_api(tmp_path: Path) -> None:
 
     httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")  # noqa: F841
 
-    from fastapi.testclient import TestClient
-
     from ante.web.app import create_app
 
     # 최소 인프라
@@ -540,9 +542,10 @@ async def test_composition_root_with_web_api(tmp_path: Path) -> None:
         report_store=report_store,
         data_store=parquet_store,
         account_service=account_service,
+        member_service=make_master_member_service(),
     )
 
-    client = TestClient(app)
+    client = make_authed_client(app)
 
     # 시스템 상태
     resp = client.get("/api/system/status")

--- a/tests/unit/test_member_routes_create_auth.py
+++ b/tests/unit/test_member_routes_create_auth.py
@@ -79,6 +79,12 @@ class FakeMemberService:
             raise PermissionError("유효하지 않은 토큰")
         return self._members[member_id]
 
+    async def get(self, member_id: str) -> FakeMember | None:
+        """``RequireAuthMiddleware`` (#1403)가 세션 fallback의 ACTIVE 검증을 위해
+        호출한다. stub은 등록된 멤버 dict에서 단순 조회한다.
+        """
+        return self._members.get(member_id)
+
     async def update_last_active(self, member_id: str) -> None:
         """TokenAuthMiddleware가 호출하는 throttled update no-op."""
         return None

--- a/tests/unit/test_member_routes_filter_validation.py
+++ b/tests/unit/test_member_routes_filter_validation.py
@@ -23,9 +23,11 @@ import pytest
 
 httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
-from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+)
 
 
 @dataclass
@@ -50,10 +52,31 @@ class FakeMember:
 
 
 class FakeMemberService:
-    """list_members / count만 사용하는 최소 stub."""
+    """list_members / count만 사용하는 최소 stub.
+
+    ``RequireAuthMiddleware`` (#1403) default-deny 게이트도 함께 통과하도록
+    ``authenticate`` / ``get`` / ``update_last_active`` 도 master-test-token
+    한정으로 구현한다. ``tests.unit.conftest.MASTER_AUTH_HEADERS`` 와 짝.
+    """
 
     def __init__(self) -> None:
         self._members: dict[str, FakeMember] = {}
+        self._master = FakeMember(
+            member_id="master-test", type="human", status="active"
+        )
+
+    async def authenticate(self, token: str) -> FakeMember:
+        if token != "master-test-token":
+            raise PermissionError("invalid token")
+        return self._master
+
+    async def get(self, member_id: str) -> FakeMember | None:
+        if member_id == self._master.member_id:
+            return self._master
+        return self._members.get(member_id)
+
+    async def update_last_active(self, member_id: str) -> None:
+        return None
 
     async def list_members(
         self,
@@ -112,7 +135,7 @@ def member_service():
 @pytest.fixture
 def client(member_service):
     app = create_app(member_service=member_service)
-    return TestClient(app)
+    return make_authed_client(app)
 
 
 class TestListMembersTypeFilter:

--- a/tests/unit/test_pagination_limit_validation.py
+++ b/tests/unit/test_pagination_limit_validation.py
@@ -19,6 +19,10 @@ httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 # ---------------------------------------------------------------------------
 # pagination helper invariant
@@ -53,7 +57,11 @@ def _make_bots_app() -> TestClient:
     mock_manager.list_bots.return_value = [
         {"bot_id": f"bot-{i}", "status": "running"} for i in range(3)
     ]
-    return TestClient(create_app(bot_manager=mock_manager))
+    return make_authed_client(
+        create_app(
+            bot_manager=mock_manager, member_service=make_master_member_service()
+        )
+    )
 
 
 class TestBotsLimitValidation:
@@ -95,7 +103,9 @@ def _make_reports_app() -> TestClient:
     r.status.value = "submitted"
     r.submitted_at = "2025-01-01"
     mock_store.list_reports = AsyncMock(return_value=[r])
-    return TestClient(create_app(report_store=mock_store))
+    return make_authed_client(
+        create_app(report_store=mock_store, member_service=make_master_member_service())
+    )
 
 
 class TestReportsLimitValidation:
@@ -126,7 +136,11 @@ def _make_trades_app() -> TestClient:
     t.status.value = "filled"
     t.timestamp = "2025-01-01"
     mock_service.get_trades = AsyncMock(return_value=[t])
-    return TestClient(create_app(trade_service=mock_service))
+    return make_authed_client(
+        create_app(
+            trade_service=mock_service, member_service=make_master_member_service()
+        )
+    )
 
 
 class TestTradesLimitValidation:
@@ -146,7 +160,7 @@ class TestTradesLimitValidation:
 
 def _make_data_app() -> TestClient:
     # data_store 미주입 → 빈 결과 반환 (data.py: store is None branch)
-    return TestClient(create_app())
+    return make_authed_client(create_app(member_service=make_master_member_service()))
 
 
 class TestDataLimitValidation:
@@ -188,7 +202,9 @@ class TestDataLimitValidation:
 def _make_treasury_app() -> TestClient:
     mock_treasury = MagicMock()
     mock_treasury._db = None  # service unavailable → 빈 결과
-    return TestClient(create_app(treasury=mock_treasury))
+    return make_authed_client(
+        create_app(treasury=mock_treasury, member_service=make_master_member_service())
+    )
 
 
 class TestTreasuryTxLimitValidation:
@@ -223,7 +239,7 @@ def _make_audit_app() -> tuple[TestClient, dict[str, str]]:
     mock_logger.count = AsyncMock(return_value=0)
     member_service = FakeMemberService()
     member_service.add_member("master-user", token="master-token", role="master")
-    client = TestClient(
+    client = make_authed_client(
         create_app(
             audit_logger=mock_logger,
             member_service=member_service,

--- a/tests/unit/test_portfolio_api.py
+++ b/tests/unit/test_portfolio_api.py
@@ -8,9 +8,12 @@ import pytest
 
 httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
-from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 _SNAPSHOT = {
     "account_id": "acc-001",
@@ -45,12 +48,12 @@ def treasury():
 
 @pytest.fixture
 def app(treasury):
-    return create_app(treasury=treasury)
+    return create_app(treasury=treasury, member_service=make_master_member_service())
 
 
 @pytest.fixture
 def client(app):
-    return TestClient(app)
+    return make_authed_client(app)
 
 
 class TestPortfolioValue:

--- a/tests/unit/test_report_api.py
+++ b/tests/unit/test_report_api.py
@@ -9,10 +9,13 @@ import pytest
 
 httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
-from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.report.models import ReportStatus, StrategyReport  # noqa: E402
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 
 @pytest.fixture
@@ -36,12 +39,14 @@ async def report_store(db):
 
 @pytest.fixture
 def app(report_store):
-    return create_app(report_store=report_store)
+    return create_app(
+        report_store=report_store, member_service=make_master_member_service()
+    )
 
 
 @pytest.fixture
 def client(app):
-    return TestClient(app)
+    return make_authed_client(app)
 
 
 @pytest.fixture

--- a/tests/unit/test_report_routes_status_filter.py
+++ b/tests/unit/test_report_routes_status_filter.py
@@ -19,10 +19,13 @@ import pytest
 
 httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
-from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.report.models import ReportStatus, StrategyReport  # noqa: E402
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 
 @pytest.fixture
@@ -46,12 +49,14 @@ async def report_store(db):
 
 @pytest.fixture
 def app(report_store):
-    return create_app(report_store=report_store)
+    return create_app(
+        report_store=report_store, member_service=make_master_member_service()
+    )
 
 
 @pytest.fixture
 def client(app):
-    return TestClient(app)
+    return make_authed_client(app)
 
 
 @pytest.fixture

--- a/tests/unit/test_require_auth_middleware.py
+++ b/tests/unit/test_require_auth_middleware.py
@@ -1,0 +1,391 @@
+"""RequireAuthMiddleware 단위 테스트 (#1403).
+
+D-015 ADR (``docs/decisions/D-015-default-deny-auth-gate.md``) 5단계 판정 순서를
+회귀 검증한다. spec SSOT:
+
+- ``docs/specs/web-api/02-design-decisions.md`` — 인증 게이트 단계 + CORS 설정
+- ``docs/specs/web-api/09-public-paths.md`` — PUBLIC_PATHS / PUBLIC_PREFIXES /
+  ``gate-exempt-self-auth`` / 비-``/api`` SPA fallback
+
+본 테스트는 미들웨어 단의 1차 차단만 검증한다. 라우트 dependency 단의 scope
+검증 (``require_scope``)은 ``test_runtime_mutation_auth.py`` 등 별도 매트릭스가
+회귀 보호한다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.member.models import MemberStatus  # noqa: E402
+from ante.web.app import create_app  # noqa: E402
+from ante.web.middleware import token_auth as _ta_mod  # noqa: E402
+
+
+@dataclass
+class FakeMember:
+    member_id: str
+    type: str = "agent"
+    role: str = "default"
+    org: str = "default"
+    name: str = ""
+    emoji: str = ""
+    status: str = MemberStatus.ACTIVE.value
+    scopes: list[str] = field(default_factory=list)
+    token_hash: str = ""
+    password_hash: str = ""
+    recovery_key_hash: str = ""
+    created_at: str = ""
+    created_by: str = ""
+    last_active_at: str = ""
+    suspended_at: str = ""
+    revoked_at: str = ""
+    token_expires_at: str = ""
+
+
+class FakeSessionService:
+    """ante_session 쿠키 fallback 시뮬레이션."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, str] = {}
+        self._expired: set[str] = set()
+
+    def add(self, session_id: str, member_id: str) -> None:
+        self._sessions[session_id] = member_id
+
+    def expire(self, session_id: str) -> None:
+        self._expired.add(session_id)
+
+    async def validate(self, session_id: str) -> dict | None:
+        if session_id in self._expired:
+            return None
+        member_id = self._sessions.get(session_id)
+        if member_id is None:
+            return None
+        return {"member_id": member_id, "created_at": "2026-01-01T00:00:00Z"}
+
+
+class FakeMemberService:
+    """Bearer 인증 + 세션 fallback 멤버 조회 모두 지원."""
+
+    def __init__(self) -> None:
+        self._members: dict[str, FakeMember] = {}
+        self._tokens: dict[str, str] = {}
+
+    def add(
+        self,
+        member_id: str,
+        token: str = "",
+        status: str = MemberStatus.ACTIVE.value,
+        role: str = "default",
+        member_type: str = "agent",
+    ) -> FakeMember:
+        member = FakeMember(
+            member_id=member_id,
+            status=status,
+            role=role,
+            type=member_type,
+        )
+        self._members[member_id] = member
+        if token:
+            self._tokens[token] = member_id
+        return member
+
+    async def authenticate(self, token: str) -> FakeMember:
+        member_id = self._tokens.get(token)
+        if member_id is None:
+            raise PermissionError("invalid token")
+        member = self._members[member_id]
+        # TokenAuthMiddleware SSOT 답습: ACTIVE 아닌 멤버는 인증 거부.
+        if member.status != MemberStatus.ACTIVE.value:
+            raise PermissionError("inactive member")
+        return member
+
+    async def get(self, member_id: str) -> FakeMember | None:
+        return self._members.get(member_id)
+
+    async def update_last_active(self, member_id: str) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _clear_throttle_cache() -> None:
+    """TokenAuthMiddleware 캐시 초기화."""
+    _ta_mod._last_updated.clear()
+
+
+@pytest.fixture
+def member_service() -> FakeMemberService:
+    svc = FakeMemberService()
+    svc.add("master-01", token="ante_ak_master", role="master", member_type="human")
+    svc.add("active-agent", token="ante_ak_active")
+    svc.add("suspended-agent", status=MemberStatus.SUSPENDED.value)
+    svc.add("revoked-agent", status=MemberStatus.REVOKED.value)
+    return svc
+
+
+@pytest.fixture
+def session_service() -> FakeSessionService:
+    svc = FakeSessionService()
+    svc.add("session-active", "master-01")
+    svc.add("session-suspended", "suspended-agent")
+    svc.add("session-revoked", "revoked-agent")
+    svc.add("session-expired", "master-01")
+    svc.expire("session-expired")
+    svc.add("session-orphan", "nonexistent-member")
+    return svc
+
+
+@pytest.fixture
+def app(
+    member_service: FakeMemberService,
+    session_service: FakeSessionService,
+) -> Any:
+    audit_logger = AsyncMock()
+    audit_logger.log = AsyncMock()
+    return create_app(
+        member_service=member_service,
+        session_service=session_service,
+        audit_logger=audit_logger,
+    )
+
+
+@pytest.fixture
+def client(app: Any) -> TestClient:
+    return TestClient(app)
+
+
+# ── 1단계: OPTIONS preflight 면제 ─────────────────────────────────────────
+
+
+class TestOptionsPreflight:
+    def test_options_preflight_passes_without_auth(self, client: TestClient) -> None:
+        """OPTIONS 요청은 인증 없이도 통과 (CORS 안전망)."""
+        resp = client.options(
+            "/api/bots",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        # CORSMiddleware가 200 + Allow-Origin 응답을 생성한다.
+        assert resp.status_code == 200
+        assert "access-control-allow-origin" in resp.headers
+
+
+# ── 2단계: PUBLIC_PATHS / PUBLIC_PREFIXES 면제 ────────────────────────────
+
+
+class TestPublicPaths:
+    def test_public_path_exact_match_health(self, client: TestClient) -> None:
+        """``/api/system/health`` PUBLIC exact match → 인증 없이 200."""
+        resp = client.get("/api/system/health")
+        assert resp.status_code == 200
+
+    def test_public_path_with_query_string(self, client: TestClient) -> None:
+        """PUBLIC 경로 + query string도 PUBLIC으로 인식.
+
+        Codex 권장 추가 회귀 케이스 (6 보강).
+        """
+        resp = client.get("/api/system/health?from=monitor")
+        assert resp.status_code == 200
+
+    def test_public_path_openapi_json(self, client: TestClient) -> None:
+        """``/openapi.json`` PUBLIC → 인증 없이 200."""
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+
+    def test_public_prefix_assets_passes(self, client: TestClient) -> None:
+        """``/assets/*`` PUBLIC prefix → 인증 없이 200 또는 404 (자산 미존재).
+
+        본 미들웨어 책임은 401 차단이 아닌 통과 보장이므로, 자산 자체가
+        없어도 401이 아닌 다른 응답(404)이 나와야 한다.
+        """
+        resp = client.get("/assets/index.js")
+        assert resp.status_code != 401
+
+    def test_public_prefix_boundary_does_not_leak(self, client: TestClient) -> None:
+        """``/assets-foo`` 같이 ``/assets/`` 경계를 넘지 않는 경로는 PUBLIC 아님.
+
+        Codex 권장 (5 보강): trailing slash 경계로 오인 통과 방지.
+        단, 비-``/api`` 경로는 SPA fallback 분기로 면제된다. 본 테스트는
+        ``/api/assets-foo``로 경계 검증을 수행한다.
+        """
+        resp = client.get("/api/assets-foo")
+        # 보호된 ``/api`` 경로이면서 PUBLIC_PREFIXES boundary 외이므로 401.
+        assert resp.status_code == 401
+
+    def test_spa_fallback_login_passes(self, client: TestClient) -> None:
+        """비-``/api`` SPA fallback ``/login`` → 인증 없이 미들웨어 통과.
+
+        실제 응답은 404 (frontend 빌드 미존재) 또는 SPA index.html (빌드 존재)일
+        수 있으나 401이 아니어야 한다.
+        """
+        resp = client.get("/login")
+        assert resp.status_code != 401
+
+    def test_spa_fallback_dashboard_deep_link(self, client: TestClient) -> None:
+        """비-``/api`` SPA deep link ``/dashboard/foo`` → 401 아님."""
+        resp = client.get("/dashboard/foo")
+        assert resp.status_code != 401
+
+
+# ── 3단계: gate-exempt-self-auth ──────────────────────────────────────────
+
+
+class TestGateExemptSelfAuth:
+    def test_auth_me_passes_middleware_route_returns_401(
+        self, client: TestClient
+    ) -> None:
+        """``/api/auth/me``는 미들웨어 면제, 라우트가 self-auth로 401 반환.
+
+        spec 09-public-paths.md ``gate-exempt-self-auth`` 카테고리:
+        미들웨어가 차단하지 않고 라우트 자체가 세션/Bearer 검증해 401 또는
+        본인 정보 응답.
+        """
+        resp = client.get("/api/auth/me")
+        # 미들웨어가 차단했다면 default-deny detail이 나오겠지만, 라우트가
+        # 직접 처리하므로 자체 detail("인증이 필요합니다")이 응답된다.
+        assert resp.status_code == 401
+
+
+# ── 4단계: Bearer caller 확인 ─────────────────────────────────────────────
+
+
+class TestBearerCaller:
+    def test_bearer_token_passes_gate(self, client: TestClient) -> None:
+        """Bearer 토큰 부착 시 미들웨어 통과 (라우트에서 200/4xx 결정)."""
+        # ``/api/system/halt``는 mutation route이지만 master 권한이 필요.
+        # 본 테스트는 미들웨어 통과만 검증하므로 401이 아니면 OK.
+        resp = client.get(
+            "/api/system/health",
+            headers={"Authorization": "Bearer ante_ak_master"},
+        )
+        # PUBLIC 경로지만 Bearer가 와도 200 보장.
+        assert resp.status_code == 200
+
+    def test_bearer_protected_route_passes_gate(self, client: TestClient) -> None:
+        """Bearer master 토큰으로 보호 라우트도 미들웨어 통과."""
+        # ``/api/bots`` 는 GET이며 미들웨어 통과 후 라우트 의존성을 거친다.
+        # bot_manager가 없어도 미들웨어는 통과하고 503 이 응답된다 (401 아님).
+        resp = client.get(
+            "/api/bots",
+            headers={"Authorization": "Bearer ante_ak_master"},
+        )
+        assert resp.status_code != 401
+
+
+# ── 5단계: 세션 fallback + ACTIVE 검증 ────────────────────────────────────
+
+
+class TestSessionFallback:
+    def test_active_session_passes_gate(self, client: TestClient) -> None:
+        """ACTIVE 멤버의 ante_session 쿠키 → 미들웨어 통과."""
+        client.cookies.set("ante_session", "session-active")
+        resp = client.get("/api/bots")
+        assert resp.status_code != 401
+
+    def test_suspended_session_rejected(self, client: TestClient) -> None:
+        """SUSPENDED 멤버의 세션 → 401 (Bearer/세션 비대칭 해소)."""
+        client.cookies.set("ante_session", "session-suspended")
+        resp = client.get("/api/bots")
+        assert resp.status_code == 401
+
+    def test_revoked_session_rejected(self, client: TestClient) -> None:
+        """REVOKED 멤버의 세션 → 401."""
+        client.cookies.set("ante_session", "session-revoked")
+        resp = client.get("/api/bots")
+        assert resp.status_code == 401
+
+    def test_expired_session_rejected(self, client: TestClient) -> None:
+        """만료된 세션 → 401."""
+        client.cookies.set("ante_session", "session-expired")
+        resp = client.get("/api/bots")
+        assert resp.status_code == 401
+
+    def test_orphan_session_rejected(self, client: TestClient) -> None:
+        """세션은 valid하지만 멤버가 삭제된 경우 → 401."""
+        client.cookies.set("ante_session", "session-orphan")
+        resp = client.get("/api/bots")
+        assert resp.status_code == 401
+
+
+# ── 6단계: caller 미결정 → 401 + CORS 헤더 (잔여 P2-A) ──────────────────────
+
+
+class TestUnauthorized:
+    def test_no_auth_returns_401_problem_json(self, client: TestClient) -> None:
+        """헤더/쿠키 둘 다 없으면 401 + RFC 7807 형식."""
+        resp = client.get("/api/bots")
+        assert resp.status_code == 401
+        assert resp.headers.get("content-type", "").startswith(
+            "application/problem+json"
+        )
+        body = resp.json()
+        assert body["status"] == 401
+        assert body["type"] == "/errors/unauthorized"
+        assert body["instance"] == "/api/bots"
+
+    def test_no_auth_with_origin_includes_cors_header(self, client: TestClient) -> None:
+        """잔여 P2-A: cross-origin 인증 실패 시 Allow-Origin 헤더 포함.
+
+        spec 02-design-decisions.md "CORS 설정" 절: 브라우저가 응답을 읽을 수
+        있도록 401 응답에도 CORS 헤더를 동봉한다.
+        """
+        resp = client.get(
+            "/api/bots",
+            headers={"Origin": "http://localhost:3000"},
+        )
+        assert resp.status_code == 401
+        assert "access-control-allow-origin" in resp.headers
+
+    def test_no_auth_without_origin_omits_cors_header(self, client: TestClient) -> None:
+        """Codex 권장 (2 보강): no-Origin 401 응답은 Allow-Origin 헤더 없음."""
+        resp = client.get("/api/bots")
+        assert resp.status_code == 401
+        assert "access-control-allow-origin" not in resp.headers
+
+    def test_invalid_bearer_token_returns_401(self, client: TestClient) -> None:
+        """무효한 Bearer 토큰 → TokenAuth가 caller 미부착 → 미들웨어 401."""
+        resp = client.get(
+            "/api/bots",
+            headers={"Authorization": "Bearer invalid_token"},
+        )
+        assert resp.status_code == 401
+
+    def test_invalid_session_cookie_returns_401(self, client: TestClient) -> None:
+        """무효한 세션 쿠키 → 미들웨어 401."""
+        client.cookies.set("ante_session", "nonexistent-session")
+        resp = client.get("/api/bots")
+        assert resp.status_code == 401
+
+
+# ── 보조: 미들웨어가 PUBLIC/gate-exempt 분기에서 세션 fallback을 시도하지 않음 ──
+
+
+class TestPublicPathSkipsSessionFallback:
+    def test_suspended_session_can_reach_login(self, client: TestClient) -> None:
+        """SUSPENDED 세션이라도 PUBLIC ``/api/auth/login``에는 도달 가능.
+
+        spec 02-design-decisions.md "공개 경로 판정은 세션 fallback / ACTIVE
+        검사보다 먼저 수행한다" (Codex v4 Finding 1): 비ACTIVE 멤버도 재로그인
+        / 쿠키 정리 경로에 접근할 수 있어야 한다.
+        """
+        client.cookies.set("ante_session", "session-suspended")
+        # POST /api/auth/login은 body가 필요하지만 422가 나오더라도 401은
+        # 아니어야 한다.
+        resp = client.post("/api/auth/login", json={})
+        assert resp.status_code != 401
+
+    def test_suspended_session_can_reach_health(self, client: TestClient) -> None:
+        """SUSPENDED 세션이라도 PUBLIC ``/api/system/health`` 200."""
+        client.cookies.set("ante_session", "session-suspended")
+        resp = client.get("/api/system/health")
+        assert resp.status_code == 200

--- a/tests/unit/test_runtime_mutation_auth.py
+++ b/tests/unit/test_runtime_mutation_auth.py
@@ -2192,21 +2192,22 @@ class TestUpdateConfigAuthMatrix:
         assert resp.status_code == 403, resp.text
         assert dynamic_config.set_calls == []
 
-    # 403 — inactive 멤버 (suspended/revoked) ────────────────────────
+    # 401 — inactive 멤버 (suspended/revoked) ────────────────────────
 
-    def test_update_config_inactive_member_returns_403(
+    def test_update_config_inactive_member_returns_401(
         self, client: TestClient, dynamic_config: FakeDynamicConfig
     ) -> None:
-        """suspended human 멤버 → 403 (세션 fallback 경로 차단).
+        """suspended human 멤버 → 401 (RequireAuthMiddleware 1차 차단).
 
-        ``TokenAuthMiddleware`` 는 토큰 인증 시 비활성을 거부하지만 세션 쿠키
-        fallback 에서는 만료만 보므로, ``MemberStatus.ACTIVE`` 가 아닌 멤버는
-        명시적으로 403 으로 차단되어야 한다 (require_audit_read #1359 4차 fix
-        패턴 답습).
+        D-015 ADR + ``docs/specs/web-api/02-design-decisions.md`` "세션 fallback
+        시 멤버 상태 검증": ACTIVE 검사는 ``RequireAuthMiddleware``(#1403)로
+        이관되었다. 비ACTIVE 세션은 미들웨어 단의 5단계 판정에서 caller
+        미결정으로 처리되어 401이 응답된다. dependency 단의 중복 ACTIVE 검사는
+        #1408 cleanup 대상이다.
         """
         client.cookies.set("ante_session", "inactive-session-id")
         resp = client.put(_CONFIG_PATH, json=_VALID_CONFIG_PAYLOAD)
-        assert resp.status_code == 403, resp.text
+        assert resp.status_code == 401, resp.text
         assert dynamic_config.set_calls == []
         client.cookies.delete("ante_session")
 
@@ -2464,21 +2465,22 @@ class TestSubmitReportAuthMatrix:
         assert resp.status_code == 403, resp.text
         assert report_store.submit_calls == []
 
-    # 403 — inactive 멤버 (suspended/revoked) ────────────────────────
+    # 401 — inactive 멤버 (suspended/revoked) ────────────────────────
 
-    def test_submit_report_inactive_member_returns_403(
+    def test_submit_report_inactive_member_returns_401(
         self, client: TestClient, report_store: FakeReportStore
     ) -> None:
-        """suspended human 멤버 → 403 (세션 fallback 경로 차단).
+        """suspended human 멤버 → 401 (RequireAuthMiddleware 1차 차단).
 
-        ``TokenAuthMiddleware`` 는 토큰 인증 시 비활성을 거부하지만 세션 쿠키
-        fallback 에서는 만료만 보므로, ``MemberStatus.ACTIVE`` 가 아닌 멤버는
-        명시적으로 403 으로 차단되어야 한다 (require_audit_read #1359 4차 fix
-        패턴 답습).
+        D-015 ADR + ``docs/specs/web-api/02-design-decisions.md`` "세션 fallback
+        시 멤버 상태 검증": ACTIVE 검사는 ``RequireAuthMiddleware``(#1403)로
+        이관되었다. 비ACTIVE 세션은 미들웨어 단의 5단계 판정에서 caller
+        미결정으로 처리되어 401이 응답된다. dependency 단의 중복 ACTIVE 검사는
+        #1408 cleanup 대상이다.
         """
         client.cookies.set("ante_session", "inactive-session-id")
         resp = client.post(_REPORT_PATH, json=_VALID_REPORT_PAYLOAD)
-        assert resp.status_code == 403, resp.text
+        assert resp.status_code == 401, resp.text
         assert report_store.submit_calls == []
         client.cookies.delete("ante_session")
 
@@ -3307,21 +3309,22 @@ class TestUpdateStrategyStatusAuthMatrix:
         assert resp.status_code == 403, resp.text
         assert strategy_registry.update_status_calls == []
 
-    # 403 — inactive 멤버 (suspended/revoked) ────────────────────────
+    # 401 — inactive 멤버 (suspended/revoked) ────────────────────────
 
-    def test_update_strategy_status_inactive_member_returns_403(
+    def test_update_strategy_status_inactive_member_returns_401(
         self, client: TestClient, strategy_registry: FakeStrategyRegistry
     ) -> None:
-        """suspended human 멤버 → 403 (세션 fallback 경로 차단).
+        """suspended human 멤버 → 401 (RequireAuthMiddleware 1차 차단).
 
-        ``TokenAuthMiddleware`` 는 토큰 인증 시 비활성을 거부하지만 세션 쿠키
-        fallback 에서는 만료만 보므로, ``MemberStatus.ACTIVE`` 가 아닌 멤버는
-        명시적으로 403 으로 차단되어야 한다 (require_audit_read #1359 4차 fix
-        패턴 답습).
+        D-015 ADR + ``docs/specs/web-api/02-design-decisions.md`` "세션 fallback
+        시 멤버 상태 검증": ACTIVE 검사는 ``RequireAuthMiddleware``(#1403)로
+        이관되었다. 비ACTIVE 세션은 미들웨어 단의 5단계 판정에서 caller
+        미결정으로 처리되어 401이 응답된다. dependency 단의 중복 ACTIVE 검사는
+        #1408 cleanup 대상이다.
         """
         client.cookies.set("ante_session", "inactive-session-id")
         resp = client.patch(_STRATEGY_STATUS_PATH, json=_VALID_STRATEGY_STATUS_PAYLOAD)
-        assert resp.status_code == 403, resp.text
+        assert resp.status_code == 401, resp.text
         assert strategy_registry.update_status_calls == []
         client.cookies.delete("ante_session")
 

--- a/tests/unit/test_snapshot_api.py
+++ b/tests/unit/test_snapshot_api.py
@@ -8,9 +8,12 @@ import pytest
 
 httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
-from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 # ── 공통 픽스처 ─────────────────────────────────────────
 
@@ -69,12 +72,12 @@ def treasury():
 
 @pytest.fixture
 def app(treasury):
-    return create_app(treasury=treasury)
+    return create_app(treasury=treasury, member_service=make_master_member_service())
 
 
 @pytest.fixture
 def client(app):
-    return TestClient(app)
+    return make_authed_client(app)
 
 
 # ── Treasury 스냅샷 API 테스트 ──────────────────────────

--- a/tests/unit/test_strategy_api.py
+++ b/tests/unit/test_strategy_api.py
@@ -9,10 +9,13 @@ import pytest
 
 httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
-from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.strategy.registry import StrategyStatus  # noqa: E402
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 
 @dataclass
@@ -179,7 +182,10 @@ def client(registry, bot_manager, trade_service, member_service):
         trade_service=trade_service,
         member_service=member_service,
     )
-    return TestClient(app)
+    test_client = make_authed_client(app)
+    # ``RequireAuthMiddleware`` (#1403) default-deny: master Bearer 디폴트 부착.
+    test_client.headers.update(_MASTER_AUTH_HEADERS)
+    return test_client
 
 
 class TestListStrategies:
@@ -256,8 +262,12 @@ class TestListStrategies:
             FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
         ]
 
-        app = create_app(strategy_registry=registry, db=fake_db)
-        c = TestClient(app)
+        app = create_app(
+            strategy_registry=registry,
+            db=fake_db,
+            member_service=make_master_member_service(),
+        )
+        c = make_authed_client(app)
 
         resp = c.get("/api/strategies")
         assert resp.status_code == 200
@@ -292,8 +302,9 @@ class TestListStrategies:
             strategy_registry=registry,
             bot_manager=bot_manager,
             db=fake_db,
+            member_service=make_master_member_service(),
         )
-        c = TestClient(app)
+        c = make_authed_client(app)
 
         with patch(
             "ante.trade.performance.PerformanceTracker.calculate",
@@ -315,8 +326,12 @@ class TestListStrategies:
             FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
         ]
 
-        app = create_app(strategy_registry=registry, db=fake_db)
-        c = TestClient(app)
+        app = create_app(
+            strategy_registry=registry,
+            db=fake_db,
+            member_service=make_master_member_service(),
+        )
+        c = make_authed_client(app)
 
         with patch(
             "ante.trade.performance.PerformanceTracker.calculate",
@@ -338,8 +353,12 @@ class TestListStrategies:
             FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
         ]
 
-        app = create_app(strategy_registry=registry, db=fake_db)
-        c = TestClient(app)
+        app = create_app(
+            strategy_registry=registry,
+            db=fake_db,
+            member_service=make_master_member_service(),
+        )
+        c = make_authed_client(app)
 
         # PerformanceTracker.calculate가 호출되면 안 된다
         # (account_id를 알 수 없으므로).
@@ -561,8 +580,9 @@ class TestStrategyPerformance:
         app = create_app(
             strategy_registry=registry,
             db=fake_db,
+            member_service=make_master_member_service(),
         )
-        client = TestClient(app)
+        client = make_authed_client(app)
 
         resp = client.get("/api/strategies/s1/performance?account_id=acc-test")
         assert resp.status_code == 200
@@ -590,8 +610,9 @@ class TestStrategyPerformance:
         app = create_app(
             strategy_registry=registry,
             db=fake_db,
+            member_service=make_master_member_service(),
         )
-        client = TestClient(app)
+        client = make_authed_client(app)
 
         resp = client.get("/api/strategies/s1/performance?account_id=acc-test")
         assert resp.status_code == 200
@@ -607,8 +628,9 @@ class TestStrategyPerformance:
         app = create_app(
             strategy_registry=registry,
             db=fake_db,
+            member_service=make_master_member_service(),
         )
-        client = TestClient(app)
+        client = make_authed_client(app)
 
         resp = client.get("/api/strategies/nonexistent/performance")
         assert resp.status_code == 404
@@ -623,8 +645,12 @@ class TestStrategyPerformance:
             FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
         ]
 
-        app = create_app(strategy_registry=registry, db=fake_db)
-        c = TestClient(app)
+        app = create_app(
+            strategy_registry=registry,
+            db=fake_db,
+            member_service=make_master_member_service(),
+        )
+        c = make_authed_client(app)
 
         resp = c.get("/api/strategies/s1/performance")
         assert resp.status_code == 400
@@ -655,8 +681,9 @@ class TestStrategyPerformance:
             strategy_registry=registry,
             bot_manager=bot_manager,
             db=fake_db,
+            member_service=make_master_member_service(),
         )
-        c = TestClient(app)
+        c = make_authed_client(app)
 
         with patch(
             "ante.trade.performance.PerformanceTracker.calculate",
@@ -683,8 +710,12 @@ class TestStrategyPerformance:
             FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
         ]
 
-        app = create_app(strategy_registry=registry, db=fake_db)
-        c = TestClient(app)
+        app = create_app(
+            strategy_registry=registry,
+            db=fake_db,
+            member_service=make_master_member_service(),
+        )
+        c = make_authed_client(app)
 
         with patch(
             "ante.trade.performance.PerformanceTracker.calculate",

--- a/tests/unit/test_system_config_api.py
+++ b/tests/unit/test_system_config_api.py
@@ -162,6 +162,9 @@ def session_service():
     return _FakeSessionService()
 
 
+_MASTER_HEADERS = {"Authorization": "Bearer master-token"}
+
+
 @pytest.fixture
 def client(account_service, dynamic_config, member_service, session_service):
     app = create_app(
@@ -170,13 +173,15 @@ def client(account_service, dynamic_config, member_service, session_service):
         member_service=member_service,
         session_service=session_service,
     )
-    return TestClient(app)
+    # 본 파일의 ``_FakeMemberService`` 는 ``master-token`` 만 인식한다.
+    # ``RequireAuthMiddleware`` (#1403) default-deny 회귀를 막기 위해 client
+    # 디폴트 헤더에 master-token 을 부착한다.
+    test_client = TestClient(app)
+    test_client.headers.update(_MASTER_HEADERS)
+    return test_client
 
 
 # ── #1373 master 인증 헤더 fixture ────────────────────────────────────────
-
-
-_MASTER_HEADERS = {"Authorization": "Bearer master-token"}
 
 
 class TestHaltClearHalt:

--- a/tests/unit/test_treasury_api.py
+++ b/tests/unit/test_treasury_api.py
@@ -9,10 +9,13 @@ import pytest
 
 httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
-from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.member.models import MemberRole  # noqa: E402
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 # 인증 가드(#1352) — POST /api/treasury/balance에 master 인증이 필요해졌다.
 _MASTER_HEADERS = {"Authorization": "Bearer master-token"}
@@ -97,7 +100,7 @@ def treasury():
 @pytest.fixture
 def client(treasury):
     app = create_app(treasury=treasury, member_service=_StubMemberService())
-    client = TestClient(app)
+    client = make_authed_client(app)
     client.headers.update(_MASTER_HEADERS)
     return client
 
@@ -191,16 +194,18 @@ class TestTreasuryFallback:
         """treasury 미설정 시 treasury_manager에서 첫 번째 인스턴스 반환."""
         fake_treasury = FakeTreasury()
         manager = FakeTreasuryManager(treasuries=[fake_treasury])
-        app = create_app(treasury_manager=manager)
-        client = TestClient(app)
+        app = create_app(
+            treasury_manager=manager, member_service=make_master_member_service()
+        )
+        client = make_authed_client(app)
 
         resp = client.get("/api/treasury/budgets")
         assert resp.status_code == 200
 
     def test_no_treasury_no_manager_returns_503(self):
         """treasury도 treasury_manager도 없으면 503."""
-        app = create_app()
-        client = TestClient(app)
+        app = create_app(member_service=make_master_member_service())
+        client = make_authed_client(app)
 
         resp = client.get("/api/treasury/budgets")
         assert resp.status_code == 503
@@ -208,8 +213,10 @@ class TestTreasuryFallback:
     def test_empty_manager_returns_503(self):
         """treasury_manager에 Treasury가 없으면 503."""
         manager = FakeTreasuryManager(treasuries=[])
-        app = create_app(treasury_manager=manager)
-        client = TestClient(app)
+        app = create_app(
+            treasury_manager=manager, member_service=make_master_member_service()
+        )
+        client = make_authed_client(app)
 
         resp = client.get("/api/treasury/budgets")
         assert resp.status_code == 503
@@ -236,8 +243,12 @@ class TestTreasuryAllAccountAggregate:
         treasury.account_id = "acc-1"
         treasury.currency = "KRW"
         manager = FakeTreasuryManager(treasuries=[treasury])
-        app = create_app(treasury=treasury, treasury_manager=manager)
-        c = TestClient(app)
+        app = create_app(
+            treasury=treasury,
+            treasury_manager=manager,
+            member_service=make_master_member_service(),
+        )
+        c = make_authed_client(app)
 
         resp = c.get("/api/treasury?account_id=acc-1")
         assert resp.status_code == 200
@@ -248,8 +259,12 @@ class TestTreasuryAllAccountAggregate:
         treasury.account_id = "acc-1"
         treasury.currency = "KRW"
         manager = FakeTreasuryManager(treasuries=[treasury])
-        app = create_app(treasury=treasury, treasury_manager=manager)
-        c = TestClient(app)
+        app = create_app(
+            treasury=treasury,
+            treasury_manager=manager,
+            member_service=make_master_member_service(),
+        )
+        c = make_authed_client(app)
 
         resp = c.get("/api/treasury?account_id=acc-unknown")
         assert resp.status_code == 404
@@ -259,8 +274,12 @@ class TestTreasuryAllAccountAggregate:
         treasury = FakeTreasury()
         treasury.account_id = "acc-1"
         manager = FakeTreasuryManager(treasuries=[treasury])
-        app = create_app(treasury=treasury, treasury_manager=manager)
-        c = TestClient(app)
+        app = create_app(
+            treasury=treasury,
+            treasury_manager=manager,
+            member_service=make_master_member_service(),
+        )
+        c = make_authed_client(app)
 
         resp = c.get("/api/treasury/snapshots/2026-03-21?account_id=acc-unknown")
         assert resp.status_code == 404

--- a/tests/unit/test_treasury_is_virtual.py
+++ b/tests/unit/test_treasury_is_virtual.py
@@ -10,10 +10,13 @@ import pytest
 
 httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
-from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.account.models import Account, TradingMode  # noqa: E402
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 
 @dataclass
@@ -75,8 +78,12 @@ class TestIsVirtualFromTradingMode:
             "domestic", TradingMode.VIRTUAL
         )
 
-        app = create_app(treasury=treasury, account_service=account_service)
-        client = TestClient(app)
+        app = create_app(
+            treasury=treasury,
+            account_service=account_service,
+            member_service=make_master_member_service(),
+        )
+        client = make_authed_client(app)
 
         resp = client.get("/api/treasury")
         assert resp.status_code == 200
@@ -89,8 +96,12 @@ class TestIsVirtualFromTradingMode:
         account_service = AsyncMock()
         account_service.get.return_value = _make_account("domestic", TradingMode.LIVE)
 
-        app = create_app(treasury=treasury, account_service=account_service)
-        client = TestClient(app)
+        app = create_app(
+            treasury=treasury,
+            account_service=account_service,
+            member_service=make_master_member_service(),
+        )
+        client = make_authed_client(app)
 
         resp = client.get("/api/treasury")
         assert resp.status_code == 200
@@ -106,8 +117,12 @@ class TestIsVirtualFromTradingMode:
         account_service.get.return_value = account
 
         # config에 is_paper=True가 있더라도 is_virtual=False 이어야 한다
-        app = create_app(treasury=treasury, account_service=account_service)
-        client = TestClient(app)
+        app = create_app(
+            treasury=treasury,
+            account_service=account_service,
+            member_service=make_master_member_service(),
+        )
+        client = make_authed_client(app)
 
         resp = client.get("/api/treasury")
         assert resp.status_code == 200
@@ -118,8 +133,8 @@ class TestIsVirtualFromTradingMode:
         """account_service가 없으면 is_virtual=True (안전 기본값)."""
         treasury = FakeTreasury()
 
-        app = create_app(treasury=treasury)
-        client = TestClient(app)
+        app = create_app(treasury=treasury, member_service=make_master_member_service())
+        client = make_authed_client(app)
 
         resp = client.get("/api/treasury")
         assert resp.status_code == 200
@@ -132,8 +147,12 @@ class TestIsVirtualFromTradingMode:
         account_service = AsyncMock()
         account_service.get.return_value = None
 
-        app = create_app(treasury=treasury, account_service=account_service)
-        client = TestClient(app)
+        app = create_app(
+            treasury=treasury,
+            account_service=account_service,
+            member_service=make_master_member_service(),
+        )
+        client = make_authed_client(app)
 
         resp = client.get("/api/treasury")
         assert resp.status_code == 200

--- a/tests/unit/test_web_account_filter.py
+++ b/tests/unit/test_web_account_filter.py
@@ -9,9 +9,12 @@ import pytest
 
 httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
-from fastapi.testclient import TestClient  # noqa: E402
 
 from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
 
 # ── Stubs ───────────────────────────────────────────
 
@@ -210,8 +213,9 @@ def client(bot_manager, treasury, treasury_manager, trade_service):
         treasury=treasury,
         treasury_manager=treasury_manager,
         trade_service=trade_service,
+        member_service=make_master_member_service(),
     )
-    return TestClient(app)
+    return make_authed_client(app)
 
 
 # ── Tests: Bots ────────────────────────────────────

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import tomllib
+from dataclasses import dataclass
+from dataclasses import field as dc_field
 from pathlib import Path
 
 import pytest
@@ -28,13 +30,72 @@ def _expected_release_version() -> str:
 EXPECTED_VERSION = _expected_release_version()
 
 
+# ``RequireAuthMiddleware`` (#1403) 도입 후 default-deny 가 모든 보호 라우트에
+# 적용된다. 본 파일의 client fixture 는 라우트의 비즈니스 로직을 검증하는
+# 용도이므로 master Bearer 인증을 디폴트로 부착한다. 인증 매트릭스 회귀는
+# ``test_runtime_mutation_auth.py`` / ``test_require_auth_middleware.py`` 가
+# 별도로 보호한다.
+@dataclass
+class _MasterMember:
+    member_id: str = "master-test"
+    type: str = "human"
+    role: str = "master"
+    org: str = "default"
+    name: str = "Test Master"
+    emoji: str = ""
+    status: str = "active"
+    scopes: list[str] = dc_field(default_factory=list)
+
+
+class _MasterOnlyMemberService:
+    """master 토큰 ``master-test-token`` 만 인증하는 최소 stub.
+
+    ``TokenAuthMiddleware`` 가 ``authenticate(token)`` 을, ``RequireAuthMiddleware``
+    가 ``get(member_id)`` 를 호출한다.
+    """
+
+    def __init__(self) -> None:
+        self._master = _MasterMember()
+
+    async def authenticate(self, token: str) -> _MasterMember:
+        if token != "master-test-token":
+            raise PermissionError("invalid token")
+        return self._master
+
+    async def get(self, member_id: str) -> _MasterMember | None:
+        if member_id == self._master.member_id:
+            return self._master
+        return None
+
+    async def update_last_active(self, member_id: str) -> None:
+        return None
+
+
+def _authed_client(app) -> TestClient:
+    """master Bearer 토큰을 디폴트 헤더로 부착한 ``TestClient``.
+
+    ``RequireAuthMiddleware`` (#1403) 도입 후 default-deny 가 적용되어 라우트
+    동작 검증 테스트는 인증된 호출이어야 한다. ``app`` 에는
+    ``_MasterOnlyMemberService`` 가 주입되어 있어야 토큰 인증이 통과한다.
+    """
+    test_client = TestClient(app)
+    test_client.headers.update({"Authorization": "Bearer master-test-token"})
+    return test_client
+
+
 @pytest.fixture
 def app():
-    return create_app()
+    return create_app(member_service=_MasterOnlyMemberService())
 
 
 @pytest.fixture
 def client(app):
+    return _authed_client(app)
+
+
+@pytest.fixture
+def unauth_client(app):
+    """인증 없는 ``TestClient`` (default-deny 회귀 / unauth 라우트 검증용)."""
     return TestClient(app)
 
 
@@ -296,8 +357,11 @@ class TestDataRoutes:
         from ante.data.store import ParquetStore
 
         store = ParquetStore(base_path=tmp_path / "data")
-        app = create_app(data_store=store)
-        client = TestClient(app)
+        app = create_app(
+            data_store=store,
+            member_service=_MasterOnlyMemberService(),
+        )
+        client = _authed_client(app)
 
         resp = client.get("/api/data/datasets")
         assert resp.status_code == 200
@@ -310,8 +374,11 @@ class TestDataRoutes:
         from ante.data.store import ParquetStore
 
         store = ParquetStore(base_path=tmp_path / "data")
-        app = create_app(data_store=store)
-        client = TestClient(app)
+        app = create_app(
+            data_store=store,
+            member_service=_MasterOnlyMemberService(),
+        )
+        client = _authed_client(app)
 
         resp = client.get("/api/data/datasets", params={"data_type": "ohlcv"})
         assert resp.status_code == 200
@@ -324,8 +391,11 @@ class TestDataRoutes:
         from ante.data.store import ParquetStore
 
         store = ParquetStore(base_path=tmp_path / "data")
-        app = create_app(data_store=store)
-        client = TestClient(app)
+        app = create_app(
+            data_store=store,
+            member_service=_MasterOnlyMemberService(),
+        )
+        client = _authed_client(app)
 
         resp = client.get("/api/data/datasets", params={"data_type": "fundamental"})
         assert resp.status_code == 200
@@ -337,8 +407,11 @@ class TestDataRoutes:
         from ante.data.store import ParquetStore
 
         store = ParquetStore(base_path=tmp_path / "data")
-        app = create_app(data_store=store)
-        client = TestClient(app)
+        app = create_app(
+            data_store=store,
+            member_service=_MasterOnlyMemberService(),
+        )
+        client = _authed_client(app)
 
         resp = client.get("/api/data/storage")
         assert resp.status_code == 200
@@ -358,8 +431,11 @@ class TestDataRoutes:
         from ante.data.store import ParquetStore
 
         store = ParquetStore(base_path=tmp_path / "data")
-        app = create_app(data_store=store)
-        client = TestClient(app)
+        app = create_app(
+            data_store=store,
+            member_service=_MasterOnlyMemberService(),
+        )
+        client = _authed_client(app)
 
         resp = client.get("/api/data/feed-status")
         assert resp.status_code == 200
@@ -417,8 +493,11 @@ class TestDataRoutes:
             )
         )
 
-        app = create_app(data_store=store)
-        client = TestClient(app)
+        app = create_app(
+            data_store=store,
+            member_service=_MasterOnlyMemberService(),
+        )
+        client = _authed_client(app)
 
         resp = client.get("/api/data/feed-status")
         assert resp.status_code == 200
@@ -449,15 +528,16 @@ class TestReportRoutes:
         assert data["type"] == "/errors/internal"
         assert data["status"] == 503
 
-    def test_submit_unauth_returns_401(self, client):
+    def test_submit_unauth_returns_401(self, unauth_client):
         """#1374: 인증 없는 호출은 401. 인증 가드가 service availability /
         body validation 보다 먼저 실행된다.
 
         과거(``test_submit_no_store``)에는 ``report_store`` 미주입 시 503 을
         반환했으나, ``require_report_write`` dependency 가 라우트 시그니처
-        앞쪽에 위치해 인증 누락이 우선 401 로 차단된다.
+        앞쪽에 위치해 인증 누락이 우선 401 로 차단된다. #1403 도입 후에는
+        ``RequireAuthMiddleware`` 가 동일 위치에서 1차 차단한다.
         """
-        resp = client.post(
+        resp = unauth_client.post(
             "/api/reports",
             json={
                 "strategy_name": "test",


### PR DESCRIPTION
Closes #1403

## Summary
Epic #1401의 Web 미들웨어 단계. #1402 spec SSOT를 기반으로 RequireAuthMiddleware 신설 + 197 라우트 동작 테스트 fixture 일괄 마이그레이션.

### 신설
- `src/ante/web/middleware/require_auth.py` — `RequireAuthMiddleware` 5단계 게이트 (D-015 ADR):
  1. OPTIONS preflight 면제
  2. PUBLIC_PATHS / PREFIXES / 비-`/api` SPA fallback 면제
  3. `gate-exempt-self-auth` (`/api/auth/me`) 통과
  4. Bearer caller 확인 (TokenAuth가 채운 `request.state.member_id`)
  5. 세션 fallback + `MemberStatus.ACTIVE` 검사 → 통과 또는 401
- `tests/unit/conftest.py` — 공통 fixture (`_MasterOnlyMemberService`, `make_authed_client`, `MASTER_AUTH_HEADERS`)

### 변경
- `src/ante/web/middleware/__init__.py` — `RequireAuthMiddleware` export
- `src/ante/web/app.py` — add_middleware LIFO 순서 정정 (`CORS → Audit → RequireAuth → TokenAuth`)
- `docs/runbooks/01-development-process.md` — 임시 조항 (#1403/#1404 close 후 #1408에서 제거)
- 22개 라우트 동작 테스트 파일 — fixture 마이그레이션 (`make_authed_client(app)` + `member_service=make_master_member_service()`)
- `tests/unit/test_runtime_mutation_auth.py` — `_inactive_member_returns_403` → `_returns_401` (미들웨어 ACTIVE 검사 이관, dependency 중복 제거는 #1408에서)

### 잔여 P2 처리 (PR #1420 review 잔재)
- **P2-A (CORS 거부 응답 헤더)**: `Origin` 헤더 있을 때만 401/403 응답에 `Access-Control-Allow-Origin` 추가. no-Origin 요청에는 헤더 없음.
- **P2-B (runbook 임시 조항)**: `docs/runbooks/01-development-process.md` 8.1.1 절 — #1403/#1404 close 전까지 명시적 가드 부착 요구. #1408 cleanup에서 제거.

## Test Plan
- [x] `pytest tests/unit -q` → **4515 passed, 2 skipped, 0 failed** (197 fixture 회귀 모두 해소)
- [x] `pytest tests/unit/test_require_auth_middleware.py tests/unit/test_runtime_mutation_auth.py tests/unit/test_app_middleware_order.py -q` → 270 passed
- [x] `ruff check tests/unit/ src/ante/web/` 통과
- [x] `ruff format --check` 통과 (268 files)

## Notes
- Codex Plan Review (Plan 단계): approve-implement (revision 1, 1라운드)
- Codex 브랜치 리뷰: PASS (1라운드)
- `frontend/openapi.json` 응답 schema 변경 없음 → 재생성 불필요
- `config/db/pip_freeze_v1.0.0.txt` 변경 없음
- 197 fixture 회귀 해소는 default-deny의 자연스러운 결과 (옵션 A 채택, main broken 회피)

🤖 Generated with [Claude Code](https://claude.com/claude-code)