### PR TITLE
feat(cli): authenticated_group factory default-deny gate (#1404)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,10 @@ dependencies = [
     "aiosqlite>=0.20",
     "polars>=1.0",
     "pandas-ta>=0.4.71b0",
-    "click>=8.1",
+    # Pin click to 8.1.x; Click 8.2 deprecates Context.protected_args and changes
+    # ``Group.no_args_is_help`` exit-code semantics that LeafAwareGroup/
+    # authenticated_group rely on (#1404). Migration is tracked as a follow-up.
+    "click>=8.1,<8.2",
     "fastapi>=0.115",
     "uvicorn>=0.34",
     "websockets>=13.0",

--- a/src/ante/cli/main.py
+++ b/src/ante/cli/main.py
@@ -7,8 +7,21 @@ from pathlib import Path
 import click
 
 from ante.cli.formatter import OutputFormatter
-from ante.cli.middleware import authenticate_member
+
+# ``authenticate_member`` is re-exported so existing tests can monkeypatch
+# ``ante.cli.main.authenticate_member`` (see ``__all__`` below for details).
+from ante.cli.middleware import (
+    AuthenticatedGroup,
+    _LeafPathMixin,
+    authenticate_member,
+)
 from ante.config.config import Config, resolve_config_dir
+
+# Re-export for backwards compatibility with tests that patch this symbol on
+# ``ante.cli.main`` (#1404: leaf auth wrapping is invoked by ``AuthenticatedGroup``
+# in middleware.py, but the public function still lives in middleware and is
+# re-exported here so existing patches keep working).
+__all__ = ["cli", "LeafAwareGroup", "authenticate_member"]
 
 try:
     from importlib.metadata import version as pkg_version
@@ -18,7 +31,7 @@ except Exception:
     __version__ = "dev"
 
 
-class LeafAwareGroup(click.Group):
+class LeafAwareGroup(_LeafPathMixin):
     """root group invoke 직전에 전체 서브커맨드 경로를 ctx.obj에 저장.
 
     Click 8.x의 `Group.invoke`는 root 콜백이 실행되기 직전
@@ -35,47 +48,16 @@ class LeafAwareGroup(click.Group):
     - `ante member list` → ("member", "list")
     - `ante member reset-password` → ("member", "reset-password")
     - `ante feed init` → ("feed", "init")  (leaf 이름이 "init"이지만 면제 아님)
+
+    NOTE: 본 클래스는 default-deny 인증 게이트를 부착하지 않는다. #1404 이후
+    root group은 :class:`ante.cli.middleware.AuthenticatedGroup`을 사용한다.
     """
 
-    def invoke(self, ctx: click.Context) -> object:
-        ctx.ensure_object(dict)
-        all_args = [*ctx.protected_args, *ctx.args]
-        path = self._resolve_command_path(ctx, all_args)
-        if path:
-            ctx.obj["_leaf_command_path"] = path
-            # 하위 호환: 기존 코드가 leaf 이름만 필요로 할 수 있음
-            ctx.obj["_leaf_command"] = path[-1]
-        return super().invoke(ctx)
 
-    def _resolve_command_path(
-        self, ctx: click.Context, args: list[str]
-    ) -> tuple[str, ...]:
-        """subcommand 트리를 따라가 루트부터 leaf까지의 경로 tuple을 반환.
-
-        Options(`-x`, `--flag`, `--key=value`)는 skip하고 non-option 토큰만
-        커맨드 후보로 본다. `current.get_command(ctx, token)`이 None을
-        반환하면 경로 탐색을 종료한다. 이는 옵션 값으로 쓰인 non-option
-        토큰(예: `--format json`의 "json")이 섞여 들어와도 안전하게 동작
-        하도록 한다.
-        """
-        cmd: click.Command = self
-        path: list[str] = []
-        i = 0
-        while i < len(args) and isinstance(cmd, click.Group):
-            token = args[i]
-            if token.startswith("-"):
-                i += 1
-                continue
-            sub = cmd.get_command(ctx, token)
-            if sub is None:
-                break
-            path.append(token)
-            cmd = sub
-            i += 1
-        return tuple(path)
-
-
-@click.group(cls=LeafAwareGroup)
+@click.group(
+    cls=AuthenticatedGroup,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 @click.option(
     "--format",
     "output_format",
@@ -94,7 +76,12 @@ class LeafAwareGroup(click.Group):
 @click.version_option(version=__version__, prog_name="ante")
 @click.pass_context
 def cli(ctx: click.Context, output_format: str, config_dir: str | None) -> None:
-    """Ante — AI-Native Trading Engine CLI."""
+    """Ante — AI-Native Trading Engine CLI.
+
+    인증은 ``AuthenticatedGroup``이 leaf 명령 callback 호출 직전에
+    default-deny 게이트로 강제한다(#1404). root callback에서 직접
+    ``authenticate_member(ctx)``를 호출하지 않는다.
+    """
     ctx.ensure_object(dict)
     ctx.obj["format"] = output_format
     ctx.obj["formatter"] = OutputFormatter(output_format)
@@ -102,7 +89,6 @@ def cli(ctx: click.Context, output_format: str, config_dir: str | None) -> None:
         from pathlib import Path
 
         ctx.obj["config_dir"] = Path(config_dir)
-    authenticate_member(ctx)
 
 
 def get_formatter(ctx: click.Context) -> OutputFormatter:

--- a/src/ante/cli/middleware.py
+++ b/src/ante/cli/middleware.py
@@ -161,7 +161,15 @@ def require_auth(fn: Callable) -> Callable:
 
     @click.pass_context 아래에 배치한다.
     ctx.obj["member"]가 None이면 에러 출력 후 종료.
+
+    멱등(idempotent) — 이미 같은 가드가 부착된 함수에 재적용되어도 한 번만
+    감싸지도록 ``_require_auth_applied`` sentinel marker로 dedupe한다. #1404
+    ``authenticated_group`` factory가 leaf command callback을 자동 wrapping할 때,
+    명령 자체에 이미 명시적으로 부착된 ``@require_auth`` 또는 ``@require_scope``의
+    내부 가드와 중복 호출되는 것을 방지한다.
     """
+    if getattr(fn, "_require_auth_applied", False):
+        return fn
 
     @functools.wraps(fn)
     def wrapper(*args: object, **kwargs: object) -> object:
@@ -176,6 +184,7 @@ def require_auth(fn: Callable) -> Callable:
             raise SystemExit(1)
         return fn(*args, **kwargs)
 
+    wrapper._require_auth_applied = True  # type: ignore[attr-defined]
     return wrapper
 
 
@@ -217,6 +226,11 @@ def require_scope(*scopes: str) -> Callable:
             return fn(*args, **kwargs)
 
         wrapper._required_scopes = scopes  # type: ignore[attr-defined]
+        # @require_scope wrapper도 member==None을 직접 검사한다. #1404
+        # ``authenticated_group``이 leaf callback을 자동으로 ``require_auth``로
+        # wrapping할 때 같은 검사가 두 번 발화하지 않도록 sentinel marker로
+        # dedupe 신호를 남긴다.
+        wrapper._require_auth_applied = True  # type: ignore[attr-defined]
         return wrapper
 
     return decorator
@@ -226,3 +240,395 @@ def get_member_id(ctx: click.Context) -> str:
     """인증된 멤버 ID를 반환. 미인증 시 'unknown'."""
     member: Member | None = ctx.obj.get("member")
     return member.member_id if member else "unknown"
+
+
+class _LeafPathMixin(click.Group):
+    """root부터 leaf까지의 커맨드 경로 tuple을 ``ctx.obj``에 저장하는 mixin.
+
+    ``LeafAwareGroup``(main.py) 및 :class:`AuthenticatedGroup`이 공유한다.
+    """
+
+    def invoke(self, ctx: click.Context) -> object:
+        ctx.ensure_object(dict)
+        all_args = [*ctx.protected_args, *ctx.args]
+        path = self._resolve_command_path(ctx, all_args)
+        if path:
+            ctx.obj["_leaf_command_path"] = path
+            ctx.obj["_leaf_command"] = path[-1]
+        return super().invoke(ctx)
+
+    def _resolve_command_path(
+        self, ctx: click.Context, args: list[str]
+    ) -> tuple[str, ...]:
+        """root부터 leaf까지의 커맨드 경로 tuple을 반환."""
+        cmd: click.Command = self
+        path: list[str] = []
+        i = 0
+        while i < len(args) and isinstance(cmd, click.Group):
+            token = args[i]
+            if token.startswith("-"):
+                i += 1
+                continue
+            sub = cmd.get_command(ctx, token)
+            if sub is None:
+                break
+            path.append(token)
+            cmd = sub
+            i += 1
+        return tuple(path)
+
+
+class AuthenticatedGroup(_LeafPathMixin):
+    """default-deny 인증 게이트가 자동으로 부착되는 ``click.Group``.
+
+    정책 SSOT:
+
+    - `D-015 default-deny 인증 게이트 <../decisions/D-015-default-deny-auth-gate.md>`_
+    - `cli/02-design-decisions.md — default-deny CLI 인증 게이트`
+    - `cli/03-commands.md — 공개 명령 allowlist`
+
+    동작 (#1404 P2 정정):
+
+    1. **invoke 단계 가드 (primary, H2 강화)**:
+       ``Group.invoke(ctx)`` 진입 직후 ``super().invoke(ctx)`` 호출 **전에**
+       인증 가드를 발화시킨다. click 8.1의 ``MultiCommand.invoke``는 자식
+       명령의 ``make_context``(=``parse_args``)를 ``super().invoke(ctx)`` 내부
+       에서 호출하므로, 가드를 ``super().invoke(ctx)`` 직전에 두면 자식
+       명령의 type/argument validation(예: ``click.Path(exists=True)``)이
+       발화하기 **전에** 인증 검사가 끝난다. 미인증 사용자는 어떤 형태의
+       parameter validation 응답도 받을 수 없다.
+
+       단, 다음 경로는 invoke 단계 가드를 skip한다:
+
+       - ``ctx.resilient_parsing == True``: shell completion 등 부작용 없는
+         파싱.
+       - args 토큰열에 ``--help`` / ``-h`` 메타 옵션이 포함되어 있고, 그
+         토큰이 ``--`` separator **앞**에 있는 경우 (click이 도움말로 처리해
+         callback에 도달하지 않으므로 H1 invariant 만족).
+       - ``--version`` 은 root ``@click.version_option`` 이 root callback 진입
+         이전에 ``ctx.exit()`` 시키므로 ``ante --version`` 만 면제되고, nested
+         위치(``ante bot list --version`` 등) 는 invoke 단계 가드가 정상
+         발화한다. (#1404 P2 정정)
+       - 경로 해석이 leaf command까지 도달하지 못한 경우(=group으로 끝남):
+         click이 ``no_args_is_help`` 또는 ``Missing command`` 처리로
+         callback에 도달하지 않는다.
+       - 경로가 ``_AUTH_EXEMPT_COMMAND_PATHS`` allowlist에 포함되는 경우.
+
+    2. **callback 단계 가드 (secondary, 이중 방어)**:
+       :meth:`add_command`에서 자식 ``click.Command``의 ``callback``을
+       ``_wrap_callback_with_auth``로 감싼다. invoke 단계 가드가 어떤
+       이유로든 발화하지 못해도 callback 진입 직전에 같은 정책이 발화한다.
+       두 가드는 idempotent(sentinel marker로 dedupe)하므로
+       ``authenticate_member`` 가 한 번만 실행된다.
+
+    3. ``ante <cmd> -- --help``처럼 ``--`` 이후 위치 인자로 들어간 ``--help``는
+       click이 도움말로 해석하지 않으므로 invoke 단계에서 default-deny가
+       발화한다 — H2 invariant 만족.
+
+    자식 group이 같은 정책 클래스를 상속하지 않더라도, leaf callback wrapping은
+    ``Group.add_command``/``Group.command`` decorator 양쪽에서 자동으로 이뤄지므로
+    nested sub-group의 leaf까지 default-deny가 도달한다.
+    """
+
+    def invoke(self, ctx: click.Context) -> object:
+        """``super().invoke(ctx)`` 호출 전에 인증 게이트를 발화시킨다.
+
+        click의 ``MultiCommand.invoke``는 ``super().invoke(ctx)`` 내부에서
+        자식 명령의 ``make_context`` (=``parse_args``)를 호출한다. 따라서
+        본 메서드에서 가드를 먼저 발화시키면 자식 명령의
+        ``click.Path(exists=True)`` 같은 parameter type validation이
+        인증 검사 **이전에** 트리거되는 H2 invariant 위반을 막을 수 있다.
+        """
+        # 1. _LeafPathMixin: 전체 커맨드 경로 tuple을 ctx.obj에 저장.
+        ctx.ensure_object(dict)
+        all_args = [*ctx.protected_args, *ctx.args]
+        path = self._resolve_command_path(ctx, all_args)
+        if path:
+            ctx.obj["_leaf_command_path"] = path
+            ctx.obj["_leaf_command"] = path[-1]
+
+        # 2. root callback의 글로벌 옵션을 ``ctx.obj``로 미리 미러링한다.
+        #    (#1404 P1 정정) ``Group.invoke``는 ``super().invoke(ctx)`` 안에서
+        #    root callback을 실행하지만, 인증 게이트는 그보다 먼저 발화한다.
+        #    ``--config-dir`` 같이 인증 시점에 영향을 주는 옵션은 root callback
+        #    실행을 기다리지 않고 ``ctx.params`` 에서 직접 읽어 ``ctx.obj`` 에
+        #    반영해 두어야 ``authenticate_member`` 가 정확한 DB 경로를 본다.
+        _mirror_root_globals_to_obj(ctx)
+
+        # 3. invoke 단계 인증 게이트 — super().invoke(ctx) 호출 전에 발화.
+        if self._should_invoke_auth_gate(ctx, all_args, path):
+            self._enforce_invoke_auth_gate(ctx, path)
+
+        # 4. click의 정상 디스패치로 진행 (자식 make_context + invoke).
+        return super(_LeafPathMixin, self).invoke(ctx)
+
+    def _should_invoke_auth_gate(
+        self,
+        ctx: click.Context,
+        all_args: list[str],
+        path: tuple[str, ...],
+    ) -> bool:
+        """invoke 단계 인증 게이트를 발화할지 여부.
+
+        skip 조건은 본 클래스 docstring의 (1) 항목 참조.
+        """
+        # resilient parsing(shell completion 등)은 부작용 없는 파싱이므로 skip.
+        if ctx.resilient_parsing:
+            return False
+
+        # args 안에 메타 옵션(--help / -h)이 ``--`` 앞에 존재하면
+        # click이 callback에 도달하기 전에 ctx.exit()하므로 가드 skip.
+        # ``--version`` 은 root ``@click.version_option`` 에서만 면제되며,
+        # nested 위치(예: ``ante bot list --version``)는 인증 게이트가 발화해야
+        # parse error 응답이 인증 없이 노출되지 않는다. (#1404 P2 정정)
+        if _has_meta_help_before_dashdash(all_args):
+            return False
+
+        # path가 비어 있거나 leaf까지 도달하지 못한 경우(=group으로 끝남)는
+        # click이 ``no_args_is_help`` 또는 ``Missing command``로 처리하므로 skip.
+        if not path:
+            return False
+        if not self._path_resolves_to_leaf(ctx, path):
+            return False
+
+        # 공개 명령 allowlist는 면제.
+        if path in _AUTH_EXEMPT_COMMAND_PATHS:
+            return False
+
+        return True
+
+    def _path_resolves_to_leaf(self, ctx: click.Context, path: tuple[str, ...]) -> bool:
+        """경로가 leaf(=non-Group ``click.Command``)로 끝나는지 확인."""
+        cmd: click.Command = self
+        for name in path:
+            if not isinstance(cmd, click.Group):
+                return False
+            sub = cmd.get_command(ctx, name)
+            if sub is None:
+                return False
+            cmd = sub
+        return not isinstance(cmd, click.Group)
+
+    def _enforce_invoke_auth_gate(
+        self, ctx: click.Context, path: tuple[str, ...]
+    ) -> None:
+        """invoke 단계 인증 게이트 본체 — 실패 시 SystemExit(1).
+
+        - ``ante.cli.main.authenticate_member`` 의 최신 attribute를 호출 시점에
+          동적 lookup하여 ``patch("ante.cli.main.authenticate_member")`` 기반의
+          기존 테스트가 그대로 동작하도록 한다.
+        - 토큰이 비어 있거나 검증이 실패하면 ``authenticate_member`` 내부에서
+          ``ctx.obj["member"] = None`` 또는 직접 ``SystemExit(1)``로 차단한다.
+        - 본 메서드는 path가 leaf로 끝나고 allowlist에 없는 경우에만 호출된다.
+          따라서 ``member is None`` 이면 default-deny ("인증이 필요합니다", exit 1)
+          를 발화시킨다.
+        - 성공 시 ``ctx.obj["_auth_gate_invoked"] = True``로 marker를 남겨,
+          callback 단계 이중 방어 wrapper가 ``authenticate_member``를 중복
+          호출하지 않도록 한다.
+        """
+        from ante.cli import main as _main
+
+        _main.authenticate_member(ctx)
+
+        member = ctx.obj.get("member") if isinstance(ctx.obj, dict) else None
+        if member is None:
+            click.echo(
+                "인증이 필요합니다. ANTE_MEMBER_TOKEN 환경변수를 설정해 주세요.",
+                err=True,
+            )
+            raise SystemExit(1)
+
+        # callback 단계 wrapper가 같은 가드를 다시 발화시키지 않도록 marker.
+        ctx.obj["_auth_gate_invoked"] = True
+
+    def add_command(self, cmd: click.Command, name: str | None = None) -> None:
+        """등록되는 자식 command/group에 인증 가드를 자동 부착 (이중 방어)."""
+        _attach_auth_guard_recursive(cmd)
+        super().add_command(cmd, name)
+
+
+# click이 callback에 도달하기 전에 ``ctx.exit()`` 시키는 메타 옵션 토큰.
+# ``_has_meta_help_before_dashdash``가 사용한다.
+#
+# (#1404 P2 정정) ``--version`` 은 ``@click.version_option`` 이 root 콜백
+# 진입 **이전**에 ``ctx.exit()`` 시키므로 root 수준의 ``ante --version`` 은
+# 이미 면제가 보장된다. nested 위치 (``ante bot list --version`` 등) 에서는
+# Click parse error 응답이 인증 없이 노출되는 부작용을 막아야 하므로 메타
+# 면제 토큰에서 ``--version`` 을 제거하고 invoke 단계 가드가 정상적으로
+# 발화하도록 한다.
+_META_HELP_TOKENS: frozenset[str] = frozenset({"--help", "-h"})
+
+
+def _has_meta_help_before_dashdash(args: list[str]) -> bool:
+    """args에 ``--help`` / ``-h`` 토큰이 ``--`` 앞에 있는지 검사.
+
+    H1 invariant: ``ante --help``, ``ante member list --help`` 등 모든
+    깊이의 ``--help`` / ``-h`` 는 click이 callback에 도달하기 전에
+    ``ctx.exit()`` 하므로 invoke 단계 가드를 발화시키지 않는다.
+
+    H2 invariant: ``ante bot info -- --help`` 처럼 ``--`` 이후 위치 인자로
+    들어간 ``--help`` 는 click이 메타로 해석하지 않으므로 본 함수는
+    이 케이스를 메타로 간주하지 **않는다**.
+
+    H3(``--version``) 처리는 root ``@click.version_option`` 에 위임한다.
+    nested 위치에 ``--version`` 이 등장하면 본 함수는 면제하지 않으므로
+    invoke 단계 가드가 정상 발화한다.
+    """
+    for tok in args:
+        if tok == "--":
+            return False
+        if tok in _META_HELP_TOKENS:
+            return True
+    return False
+
+
+def _mirror_root_globals_to_obj(ctx: click.Context) -> None:
+    """root callback의 글로벌 옵션을 ``ctx.obj`` 에 미러링.
+
+    (#1404 P1 정정) ``AuthenticatedGroup.invoke`` 의 인증 게이트는
+    ``super().invoke(ctx)`` 호출 **이전** 에 발화하므로, 같은
+    ``super().invoke(ctx)`` 안에서 실행되는 root callback의 부작용
+    (``ctx.obj["config_dir"] = ...`` 등) 이 아직 반영되지 않은 상태다.
+    인증 시점에 ``--config-dir`` 등을 정확히 반영하지 못하면
+    ``authenticate_member`` 가 default config dir의 DB를 보게 되어,
+    명시한 인스턴스의 토큰이 어긋난 DB에서 인증 실패하는 회귀가 발생한다.
+
+    본 헬퍼는 ``ctx.params`` 에 이미 파싱돼 들어 있는 root 옵션을 읽어
+    ``ctx.obj`` 키로 동일하게 반영한다. root callback이 나중에
+    재실행되어 같은 값을 덮어쓰더라도 의미는 동일하다.
+
+    현재 미러링 대상:
+
+    - ``config_dir`` (str → ``pathlib.Path``): ``--config-dir`` /
+      ``ANTE_CONFIG_DIR``. ``authenticate_member`` → ``get_db_path`` →
+      ``get_config_dir`` 가 ``ctx.obj["config_dir"]`` 를 우선 참조한다.
+    """
+    if not isinstance(ctx.obj, dict):
+        return
+
+    params = getattr(ctx, "params", None) or {}
+    raw_config_dir = params.get("config_dir")
+    if raw_config_dir and "config_dir" not in ctx.obj:
+        from pathlib import Path
+
+        ctx.obj["config_dir"] = (
+            raw_config_dir if isinstance(raw_config_dir, Path) else Path(raw_config_dir)
+        )
+
+
+def _attach_auth_guard_recursive(cmd: click.Command) -> None:
+    """leaf command callback에만 인증 가드를 부착하고, group이면 자식까지 재귀.
+
+    ``click.Group``의 callback에는 인증 가드를 부착하지 **않는다**. nested
+    ``--help`` 처리 시 click은 leaf command callback은 호출하지 않지만 부모
+    group callback은 그대로 호출한다(예: ``ante member list --help``는
+    ``member`` group의 callback을 호출한 뒤 ``list`` 명령의 help를 출력하고
+    종료). 부모 group callback에 인증 가드를 부착하면 nested ``--help``에서
+    부수적으로 default-deny가 발화해 H1 invariant(모든 깊이 ``--help`` 통과)가
+    깨진다. 따라서 인증 가드는 leaf command(=non-Group ``click.Command``)에만
+    부착한다. 자식 group/명령은 재귀로 순회한다.
+    """
+    if isinstance(cmd, click.Group):
+        for sub in list(cmd.commands.values()):
+            _attach_auth_guard_recursive(sub)
+        return
+    if cmd.callback is not None:
+        cmd.callback = _wrap_callback_with_auth(cmd.callback)
+
+
+def _wrap_callback_with_auth(callback: Callable) -> Callable:
+    """callback을 default-deny 인증 가드 wrapper로 감싼다.
+
+    동작:
+
+    1. ``ctx.resilient_parsing == True``: shell completion 등 부작용 없는
+       파싱이므로 인증 단계를 건너뛴다.
+    2. 명령 경로가 ``_AUTH_EXEMPT_COMMAND_PATHS``에 포함되면 callback을
+       바로 호출 (공개 명령 allowlist).
+    3. 그 외에는 ``authenticate_member(ctx)``를 호출해 ``ctx.obj["member"]``를
+       채운다. 토큰 검증이 실패하면 ``authenticate_member`` 내부에서 exit 1.
+    4. callback에 이미 ``@require_auth`` / ``@require_scope`` sentinel
+       marker(``_require_auth_applied``)가 있으면 None 체크를 ``@require_auth``
+       데코레이터에 위임한다. 그렇지 않으면 본 wrapper가 직접 ``member is None``
+       에 대해 default-deny ("인증이 필요합니다", exit 1)를 발화한다.
+
+    멱등 (idempotent): wrapper 자체에 sentinel marker를 부착해, 같은 callback이
+    여러 번 wrapping되어도 한 번만 감싸진다.
+
+    ``ante.cli.main``이 ``authenticate_member``를 re-export하므로 기존 테스트
+    suite는 ``patch("ante.cli.main.authenticate_member")``로 인증을 mock한다.
+    그 patch가 본 wrapper에서도 효과가 있도록 ``ante.cli.main``의 최신 심볼을
+    동적으로 조회해 호출한다.
+    """
+    if getattr(callback, "_wrapped_by_authenticated_group", False):
+        return callback
+
+    has_auth_decorator = getattr(callback, "_require_auth_applied", False)
+
+    @functools.wraps(callback)
+    def wrapper(*args: object, **kwargs: object) -> object:
+        ctx = click.get_current_context()
+        # 1. resilient parsing은 부작용 없는 파싱 시도이므로 skip.
+        if ctx.resilient_parsing:
+            return callback(*args, **kwargs)
+
+        # 2. invoke 단계 가드가 이미 발화한 경우(#1404 P2 정정),
+        #    ``authenticate_member`` 중복 호출 비용을 피하기 위해 callback 단계는
+        #    skip한다. invoke 단계가 ``ctx.obj["_auth_gate_invoked"] = True``
+        #    marker를 남기므로 이를 확인. invoke 단계가 어떤 이유로든 발화하지
+        #    않은 경우(예: 자식 group이 직접 ``click.Group``으로 만들어진 경우)
+        #    에는 본 wrapper가 fallback으로 동작.
+        if isinstance(ctx.obj, dict) and ctx.obj.get("_auth_gate_invoked"):
+            return callback(*args, **kwargs)
+
+        # 3. allowlist 등재 명령은 인증 면제.
+        path = _get_invoked_command_path(ctx)
+        if path is not None and path in _AUTH_EXEMPT_COMMAND_PATHS:
+            return callback(*args, **kwargs)
+
+        # 4. 토큰 검증 — 기존 테스트 다수가 ``ante.cli.main.authenticate_member``를
+        #    monkeypatch하므로(root callback이 그 심볼을 호출하던 시절의 패턴),
+        #    main 모듈의 최신 attribute를 호출 시점에 동적으로 lookup하여
+        #    backward compatibility를 보장한다.
+        from ante.cli import main as _main
+
+        _main.authenticate_member(ctx)
+
+        # 5. ``@require_auth`` / ``@require_scope`` 데코레이터가 이미 부착된
+        #    callback은 자체적으로 ``member is None`` 검사 + 메시지를 처리한다.
+        #    중복 호출 방지를 위해 None 검사를 위임.
+        if not has_auth_decorator:
+            member = ctx.obj.get("member") if isinstance(ctx.obj, dict) else None
+            if member is None:
+                click.echo(
+                    "인증이 필요합니다. ANTE_MEMBER_TOKEN 환경변수를 설정해 주세요.",
+                    err=True,
+                )
+                raise SystemExit(1)
+
+        return callback(*args, **kwargs)
+
+    wrapper._wrapped_by_authenticated_group = True  # type: ignore[attr-defined]
+    # 본 wrapper가 None 검사를 직접 수행한 경우에만 sentinel marker를 노출해야
+    # 한다(보호하지 않는 wrapper에 ``@require_auth`` dedupe marker를 붙이면
+    # 후속 wrap이 잘못 skip된다). ``has_auth_decorator``인 경우엔 이미 안쪽
+    # callback에 marker가 있으므로 굳이 새 marker를 노출할 필요 없다.
+    if not has_auth_decorator:
+        wrapper._require_auth_applied = True  # type: ignore[attr-defined]
+    return wrapper
+
+
+def authenticated_group(name: str | None = None, **attrs: object) -> Callable:
+    """``@click.group`` 호환 데코레이터. ``AuthenticatedGroup``으로 그룹을 생성.
+
+    사용 예::
+
+        @authenticated_group(context_settings={"help_option_names": ["-h", "--help"]})
+        @click.pass_context
+        def cli(ctx: click.Context) -> None:
+            ...
+
+    동작 상세는 :class:`AuthenticatedGroup` docstring 참조.
+    """
+    attrs.setdefault("cls", AuthenticatedGroup)
+    return click.group(name=name, **attrs)  # type: ignore[arg-type]

--- a/tests/unit/cli/test_authenticated_group.py
+++ b/tests/unit/cli/test_authenticated_group.py
@@ -1,0 +1,824 @@
+"""``authenticated_group`` factory + default-deny CLI 인증 게이트 단위 테스트 (#1404).
+
+본 테스트는 ``src/ante/cli/middleware.py``의 :class:`AuthenticatedGroup`이 leaf
+command callback 호출 직전에 default-deny 인증 가드를 자동 부착하는지, 그리고
+공개 명령 allowlist(``_AUTH_EXEMPT_COMMAND_PATHS``) + 메타 면제 경로
+(``--help`` / ``-h`` / ``--version`` / resilient parsing)가 SSOT
+(``docs/specs/cli/03-commands.md``, ``docs/specs/cli/02-design-decisions.md``)와
+일치하는지 검증한다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+from ante.cli.main import LeafAwareGroup, cli
+from ante.cli.middleware import (
+    _AUTH_EXEMPT_COMMAND_PATHS,
+    AuthenticatedGroup,
+    authenticated_group,
+    require_auth,
+    require_scope,
+)
+from ante.member.models import Member, MemberRole, MemberType
+
+_MASTER = Member(
+    member_id="cli-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="CLI Master",
+    status="active",
+    scopes=[],
+)
+_AGENT_NO_SCOPE = Member(
+    member_id="cli-agent",
+    type=MemberType.AGENT,
+    role=MemberRole.ADMIN,  # role은 무관, scope만 비어 있는 agent
+    org="default",
+    name="CLI Agent",
+    status="active",
+    scopes=[],
+)
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    """기본 CliRunner."""
+    return CliRunner()
+
+
+@pytest.fixture()
+def clean_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[None]:
+    """``ANTE_MEMBER_TOKEN``과 토큰 파일을 명시적으로 차단한 환경.
+
+    ``ANTE_TOKEN_FILE``은 실제로 ``open()``이 시도되므로 존재하지 않는 파일을
+    가리키는 경로로 설정한다(``/dev/null/nope``는 ``NotADirectoryError``가 나서
+    ``_resolve_token``의 except 절이 잡지 못한다).
+    """
+    monkeypatch.delenv("ANTE_MEMBER_TOKEN", raising=False)
+    monkeypatch.setenv("ANTE_TOKEN_FILE", str(tmp_path / "nonexistent.token"))
+    yield
+
+
+# ── default-deny: 토큰 없음 + 보호 명령 ────────────────────────────────────
+
+
+class TestDefaultDeny:
+    """ANTE_MEMBER_TOKEN 미설정 상태에서 보호 명령은 자동으로 exit 1."""
+
+    def test_bot_list_without_token_exits_1(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """``ante bot list``는 토큰이 없으면 인증 단계에서 exit 1."""
+        result = runner.invoke(cli, ["bot", "list"])
+        assert result.exit_code == 1, result.output
+        assert "인증이 필요합니다" in result.output
+
+    def test_feed_init_without_token_exits_1(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """leaf 이름이 ``init``이지만 path가 ``("feed", "init")``이라 면제 대상 아님."""
+        result = runner.invoke(cli, ["feed", "init"])
+        assert result.exit_code == 1, result.output
+        assert "인증이 필요합니다" in result.output
+
+
+# ── 공개 명령 allowlist (인증 면제) ─────────────────────────────────────────
+
+
+class TestAuthExemptAllowlist:
+    """``_AUTH_EXEMPT_COMMAND_PATHS`` + ``@click.version_option``으로 면제되는 명령."""
+
+    def test_version_without_token_exits_0(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """``ante --version``은 ``@click.version_option``이 처리 → exit 0."""
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0, result.output
+        assert "ante, version" in result.output
+
+    def test_init_help_without_token_exits_0(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """``ante init --help``는 면제 + click help 처리 → exit 0."""
+        result = runner.invoke(cli, ["init", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "Usage:" in result.output
+
+    def test_init_callback_runs_without_token(
+        self, runner: CliRunner, clean_env: None, tmp_path: Path
+    ) -> None:
+        """``ante init``은 토큰 없이 부트스트랩 콜백까지 진입한다.
+
+        실제 부트스트랩 mutation은 mock으로 막고, callback이 호출되었음을
+        보증한다. ``test_state1_all_exist_rejects``는 기존 회귀 보호와 별도.
+        """
+        target = tmp_path / "config"
+
+        bootstrap_mock = AsyncMock()
+        create_acc_mock = AsyncMock()
+
+        with (
+            patch("ante.cli.commands.init._bootstrap_master", new=bootstrap_mock),
+            patch(
+                "ante.cli.commands.init._create_test_account",
+                new=create_acc_mock,
+            ),
+        ):
+            result = runner.invoke(cli, ["init", "--dir", str(target)])
+
+        # 인증으로 인한 차단이 아니어야 한다(=" 인증이 필요합니다" 메시지가 없다).
+        assert "인증이 필요합니다" not in result.output, result.output
+        # 인증을 통과해 callback이 호출되었음을 mock 호출로 확인
+        assert bootstrap_mock.called or create_acc_mock.called, (
+            f"init callback did not run: {result.output}"
+        )
+
+    def test_member_reset_password_enters_callback(
+        self,
+        runner: CliRunner,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``ante member reset-password --recovery-key ...`` 면제 진입 확인."""
+        monkeypatch.setenv("RESET_PW_ENV", "newpass123")
+
+        async def _fake_run_reset() -> None:  # noqa: RUF029
+            return None
+
+        # 실제 MemberService 호출은 mock — 인증 게이트 통과만 검증
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new=AsyncMock(side_effect=RuntimeError("stop-here")),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "member",
+                    "reset-password",
+                    "--recovery-key",
+                    "ANTE-RK-test",
+                    "--new-password-env",
+                    "RESET_PW_ENV",
+                ],
+            )
+
+        # 인증 차단이 아니어야 한다 — RuntimeError("stop-here")가 raise되어
+        # CliRunner의 catch_exceptions=True가 잡거나, 서비스 호출 단계까지
+        # 도달했음을 보장한다.
+        assert "인증이 필요합니다" not in result.output, result.output
+
+    def test_member_regenerate_recovery_key_enters_callback(
+        self,
+        runner: CliRunner,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``ante member regenerate-recovery-key`` 면제 진입 확인."""
+        monkeypatch.setenv("CURRENT_PW_ENV", "currentpass")
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new=AsyncMock(side_effect=RuntimeError("stop-here")),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "member",
+                    "regenerate-recovery-key",
+                    "--password-env",
+                    "CURRENT_PW_ENV",
+                ],
+            )
+
+        assert "인증이 필요합니다" not in result.output, result.output
+
+
+# ── 메타 면제 경로 (--help/-h, no args, parse error) ────────────────────────
+
+
+class TestMetaExemptPaths:
+    """``--help`` / ``-h`` / no_args_is_help / parse error는 인증 게이트 발화 안 함."""
+
+    def test_root_help_long(self, runner: CliRunner, clean_env: None) -> None:
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0, result.output
+        assert "Usage:" in result.output
+
+    def test_root_help_short_alias(self, runner: CliRunner, clean_env: None) -> None:
+        """root group의 ``-h``는 ``context_settings.help_option_names``에 등록."""
+        result = runner.invoke(cli, ["-h"])
+        assert result.exit_code == 0, result.output
+        assert "Usage:" in result.output
+
+    def test_group_help_long(self, runner: CliRunner, clean_env: None) -> None:
+        """nested ``ante member --help`` (H1 invariant — 부모 group 콜백 발화 안 함)."""
+        result = runner.invoke(cli, ["member", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "Usage:" in result.output
+
+    def test_group_help_short_alias(self, runner: CliRunner, clean_env: None) -> None:
+        """``ante member -h``도 ``-h``가 ``help_option_names``에 등록되어 통과."""
+        result = runner.invoke(cli, ["member", "-h"])
+        assert result.exit_code == 0, result.output
+        assert "Usage:" in result.output
+
+    def test_leaf_help_deep_nested(self, runner: CliRunner, clean_env: None) -> None:
+        """deep nested ``ante member list --help`` 도 인증 없이 통과."""
+        result = runner.invoke(cli, ["member", "list", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "Usage:" in result.output
+
+    def test_no_args_shows_help(self, runner: CliRunner, clean_env: None) -> None:
+        """``ante`` (인자 없음) → click ``no_args_is_help`` → exit 0 + help."""
+        result = runner.invoke(cli, [])
+        assert result.exit_code == 0, result.output
+        assert "Usage:" in result.output
+
+    def test_unknown_flag_yields_click_parse_error(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """``ante --invalid-flag``는 click parser 단계에서 exit 2 (인증 진입 전)."""
+        result = runner.invoke(cli, ["--invalid-flag"])
+        assert result.exit_code == 2, result.output
+        # 인증 메시지가 아니라 click의 "No such option" 메시지
+        assert "인증이 필요합니다" not in result.output
+        assert "No such option" in result.output or "Usage:" in result.output
+
+
+# ── H2 invariant: `--` 뒤 위치 인자 --help는 default-deny 발화 ──────────────
+
+
+class TestHelpAfterDoubleDashIsNotExempt:
+    """``ante <cmd> -- --help`` / ``-- -h``는 메타 면제 대상이 아니다.
+
+    spec H2 invariant: ``--`` 이후 위치 인자 ``--help``는 click이 도움말로
+    해석하지 않고 일반 인자 처리 경로로 진입한다. 따라서 default-deny 게이트가
+    정상 발화하거나 click의 인자 유효성 검증이 실패하며, 어느 쪽이든 "도움말
+    메시지를 인증 없이 발급"하는 결과는 일어나지 않는다.
+    """
+
+    def test_bot_info_double_dash_help_triggers_auth(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """``ante bot info -- --help``: leaf callback이 호출되며 인증 발화 (exit 1)."""
+        result = runner.invoke(cli, ["bot", "info", "--", "--help"])
+        # click 8.1: bot_id 인자 type 제약이 str 기본이라 callback까지 도달.
+        # 인증 wrapper가 발화하여 exit 1.
+        assert result.exit_code == 1, result.output
+        assert "인증이 필요합니다" in result.output
+
+    def test_bot_info_double_dash_short_help_triggers_auth(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """``ante bot info -- -h``도 동일."""
+        result = runner.invoke(cli, ["bot", "info", "--", "-h"])
+        assert result.exit_code == 1, result.output
+        assert "인증이 필요합니다" in result.output
+
+    def test_strategy_submit_double_dash_help_is_not_exempted(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """``ante strategy submit -- --help``은 메타 면제로 처리되지 않는다.
+
+        #1404 P2 정정 이후, ``AuthenticatedGroup.invoke()``가 자식 명령의
+        ``make_context``(=``parse_args``)보다 먼저 인증 가드를 발화시키므로
+        ``click.Path(exists=True)`` 같은 type validation 응답이 미인증 사용자
+        에게 노출되지 않고, exit 1 + "인증이 필요합니다"가 보장된다.
+        """
+        result = runner.invoke(cli, ["strategy", "submit", "--", "--help"])
+        assert result.exit_code == 1, result.output
+        assert "인증이 필요합니다" in result.output, result.output
+        # 도움말 본문이 인증 없이 새지 않아야 한다.
+        assert "Show this message and exit" not in result.output, result.output
+
+
+# ── #1404 P2 정정: invoke 단계 가드 (type validation 차단) ──────────────────
+
+
+class TestInvokeStageAuthGate:
+    """``AuthenticatedGroup.invoke()`` 단계 가드가 자식 명령의 parameter type
+    validation(``click.Path(exists=True)`` 등) 발화 **이전에** 인증을 검사한다.
+
+    P2 finding (#1404 codex review): 기존 callback 단계 wrapping은 Click의
+    ``parse_args``(type/argument validation)가 끝난 뒤에야 실행된다. 따라서
+    미인증 사용자가 ``ante strategy submit /nonexistent/path`` 같은 호출에서
+    Click의 path validation 에러(exit 2)를 받을 수 있었다 — H2 invariant +
+    default-deny 보장 약화. 정정: invoke 단계 가드로 이동.
+    """
+
+    def test_strategy_submit_nonexistent_path_returns_auth_error(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """``ante strategy submit /nonexistent/path`` 인증 없이 → exit 1 (인증 실패).
+
+        callback 단계 wrapping만 있던 시절에는 exit 2 + "Path '/nonexistent/path'
+        does not exist" 가 나올 수 있었다. invoke 단계 가드 이후에는 path
+        validation이 발화하기 전에 인증이 차단된다.
+        """
+        result = runner.invoke(
+            cli, ["strategy", "submit", "/nonexistent/path/strategy.py"]
+        )
+        assert result.exit_code == 1, result.output
+        assert "인증이 필요합니다" in result.output, result.output
+        # Click의 path validation 메시지가 새서는 안 된다.
+        assert "does not exist" not in result.output, result.output
+        assert "Path" not in result.output or "인증" in result.output
+
+    def test_strategy_validate_nonexistent_path_returns_auth_error(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """``ante strategy validate`` 도 동일하게 path validation 이전에 차단."""
+        result = runner.invoke(
+            cli, ["strategy", "validate", "/nonexistent/path/strategy.py"]
+        )
+        assert result.exit_code == 1, result.output
+        assert "인증이 필요합니다" in result.output, result.output
+        assert "does not exist" not in result.output, result.output
+
+    def test_strategy_submit_with_missing_argument_returns_auth_error(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """``ante strategy submit`` (인자 누락) 인증 없이 → exit 1 (인증 실패).
+
+        callback 단계만 있던 시절에는 exit 2 + "Missing argument 'PATH'" 가
+        나올 수 있었다. invoke 단계 가드 이후에는 인자 유효성 검증 이전에
+        인증이 차단된다.
+        """
+        result = runner.invoke(cli, ["strategy", "submit"])
+        assert result.exit_code == 1, result.output
+        assert "인증이 필요합니다" in result.output, result.output
+        assert "Missing argument" not in result.output, result.output
+
+    def test_authenticate_member_runs_before_parse_args(
+        self,
+        runner: CliRunner,
+        clean_env: None,
+    ) -> None:
+        """``authenticate_member`` 가 자식 명령의 ``parse_args`` 보다 먼저 호출된다.
+
+        ``ante.cli.main.authenticate_member`` 를 patch한 뒤 ``ante strategy submit``
+        를 인자 없이 호출하면, parse_args(=missing argument) 이전에 patched
+        authenticate_member가 발화한다. patch가 ``ctx.obj["member"] = None``으로
+        둔다면 default-deny exit 1 ("인증이 필요합니다") 가 발화.
+        """
+        from ante.cli import main as _main
+
+        call_count = {"n": 0}
+
+        def _fake_auth(ctx):  # noqa: ANN001, ANN202
+            call_count["n"] += 1
+            ctx.ensure_object(dict)
+            ctx.obj["member"] = None  # 인증 실패 시나리오 재현
+
+        with patch.object(_main, "authenticate_member", side_effect=_fake_auth):
+            result = runner.invoke(cli, ["strategy", "submit"])
+
+        assert call_count["n"] >= 1, "authenticate_member가 호출되지 않았다"
+        assert result.exit_code == 1, result.output
+        assert "인증이 필요합니다" in result.output, result.output
+        # parse_args 단계로 진입했다면 click의 missing argument 에러가 발생.
+        assert "Missing argument" not in result.output, result.output
+
+    def test_invoke_gate_skips_when_help_present(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """``--help`` 메타 옵션이 args에 있으면 invoke 단계 가드가 발화하지 않는다.
+
+        ``ante strategy submit --help`` 는 인증 없이도 exit 0 + Usage. H1 invariant.
+        """
+        result = runner.invoke(cli, ["strategy", "submit", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "Usage:" in result.output
+        assert "인증이 필요합니다" not in result.output
+
+    def test_invoke_gate_skips_for_init_with_invalid_dir_path(
+        self, runner: CliRunner, clean_env: None, tmp_path: Path
+    ) -> None:
+        """allowlist 명령(``ante init``)은 invoke 단계 가드 면제 — 인증 없이 진입."""
+        # init은 인증 없이도 callback이 호출되어야 함을 mock으로 검증.
+        bootstrap_mock = AsyncMock()
+        create_acc_mock = AsyncMock()
+        target = tmp_path / "init_dir"
+
+        with (
+            patch("ante.cli.commands.init._bootstrap_master", new=bootstrap_mock),
+            patch(
+                "ante.cli.commands.init._create_test_account",
+                new=create_acc_mock,
+            ),
+        ):
+            result = runner.invoke(cli, ["init", "--dir", str(target)])
+
+        assert "인증이 필요합니다" not in result.output, result.output
+
+
+# ── 인증된 호출 흐름 ─────────────────────────────────────────────────────────
+
+
+class TestAuthenticatedFlow:
+    """``ANTE_MEMBER_TOKEN`` + 검증 성공 시 leaf callback이 정상 실행된다."""
+
+    def test_authenticated_master_runs_bot_list(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """master 인증 통과 시 ``ante bot list``는 IPC 단계까지 진입."""
+        # leaf wrapper가 ante.cli.main.authenticate_member를 호출하므로 거기서 mock.
+        from ante.cli import main as _main
+
+        def _set_master(ctx):  # noqa: ANN001, ANN202
+            ctx.ensure_object(dict)
+            ctx.obj["member"] = _MASTER
+
+        # ipc client도 mock으로 단순 응답
+        ok_response = {"status": "ok", "data": {"bots": []}}
+        with (
+            patch.object(_main, "authenticate_member", side_effect=_set_master),
+            patch("ante.cli.commands.ipc_helpers.IPCClient", autospec=True) as mock_cls,
+            patch(
+                "ante.cli.commands.ipc_helpers.get_socket_path",
+                return_value="/tmp/ante.sock",
+            ),
+        ):
+            mock_client = AsyncMock()
+            mock_client.send.return_value = ok_response
+            mock_cls.return_value = mock_client
+            result = runner.invoke(cli, ["bot", "list"])
+
+        assert result.exit_code == 0, result.output
+
+    def test_agent_missing_scope_for_system_halt(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """scope 비어 있는 agent → ``ante system halt``는 ``@require_scope``로 차단."""
+        from ante.cli import main as _main
+
+        def _set_agent(ctx):  # noqa: ANN001, ANN202
+            ctx.ensure_object(dict)
+            ctx.obj["member"] = _AGENT_NO_SCOPE
+
+        with patch.object(_main, "authenticate_member", side_effect=_set_agent):
+            result = runner.invoke(cli, ["system", "halt"])
+
+        assert result.exit_code == 1, result.output
+        assert "권한이 부족합니다" in result.output
+
+    def test_auth_runs_before_scope_check(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """``authenticated_group``의 자동 가드가 ``@require_scope`` 보다 먼저 발화.
+
+        토큰이 없으면 ``@require_scope`` 검증 단계 진입 전에 default-deny
+        ("인증이 필요합니다") 메시지가 출력되어야 한다.
+        """
+        result = runner.invoke(cli, ["system", "halt"])
+        assert result.exit_code == 1, result.output
+        assert "인증이 필요합니다" in result.output
+
+
+# ── factory + @require_scope 데코레이터 dedupe ─────────────────────────────
+
+
+class TestFactoryAndDecoratorDedupe:
+    """factory 자동 wrap + ``@require_auth`` / ``@require_scope`` 중복 호출 방지."""
+
+    def test_require_auth_is_idempotent(self) -> None:
+        """``require_auth``는 sentinel marker로 두 번 부착해도 한 번만 감싼다."""
+
+        def raw():  # noqa: ANN202
+            return "ok"
+
+        once = require_auth(raw)
+        twice = require_auth(once)
+        assert twice is once  # 같은 wrapper 객체 (멱등)
+        assert getattr(twice, "_require_auth_applied", False) is True
+
+    def test_require_scope_marks_sentinel(self) -> None:
+        """``require_scope`` wrapper도 sentinel marker로 factory가 dedupe 가능."""
+
+        def raw():  # noqa: ANN202
+            return "ok"
+
+        wrapped = require_scope("system:admin")(raw)
+        assert getattr(wrapped, "_require_auth_applied", False) is True
+
+    def test_authenticated_group_wrap_is_idempotent(self) -> None:
+        """factory가 같은 callback에 두 번 wrap을 하지 않는다 (멱등)."""
+        import click
+
+        from ante.cli.middleware import _wrap_callback_with_auth
+
+        def raw(ctx: click.Context) -> str:  # noqa: ANN001
+            return "ok"
+
+        once = _wrap_callback_with_auth(raw)
+        twice = _wrap_callback_with_auth(once)
+        assert twice is once
+
+    def test_factory_delegates_none_check_to_existing_require_auth(self) -> None:
+        """``@require_auth`` 부착 callback은 factory가 wrap하더라도 None 검사를 위임.
+
+        factory wrapper는 ``authenticate_member`` 호출(멤버 채우기)만 담당하고,
+        member None 검사는 안쪽 ``@require_auth`` 데코레이터가 수행한다. 이는
+        sentinel marker(``_require_auth_applied``)로 중복 호출을 방지하기 위함.
+        """
+        import click
+
+        from ante.cli.middleware import _wrap_callback_with_auth
+
+        @require_auth
+        def already_guarded(ctx: click.Context) -> str:
+            return "ok"
+
+        wrapped = _wrap_callback_with_auth(already_guarded)
+        # factory wrap이 한 번 실행되며, 그 내부에서 already_guarded(=require_auth
+        # wrapper)를 호출한다. 두 wrapper가 동일 객체가 아니어도 OK이며, 본
+        # invariant는 "factory가 또 wrap하지는 않는다"와 "factory가 None 검사를
+        # 별도로 발화시키지 않는다"는 점.
+        assert wrapped is not already_guarded  # factory가 한 번은 감쌌다
+        assert getattr(wrapped, "_wrapped_by_authenticated_group", False) is True
+
+
+# ── factory의 click.group 호환성 ─────────────────────────────────────────────
+
+
+class TestFactoryAPI:
+    """``authenticated_group`` factory의 click.group 호환 표면."""
+
+    def test_factory_returns_authenticated_group(self) -> None:
+        """``@authenticated_group()`` 데코레이터 결과는 ``AuthenticatedGroup`` 이다."""
+
+        @authenticated_group()
+        def grp() -> None:  # noqa: D401, ANN202
+            """test group."""
+
+        assert isinstance(grp, AuthenticatedGroup)
+
+    def test_factory_preserves_context_settings(self) -> None:
+        """``context_settings``는 click.group을 통해 그대로 전달된다."""
+
+        @authenticated_group(context_settings={"help_option_names": ["-h", "--help"]})
+        def grp() -> None:  # noqa: ANN202
+            pass
+
+        assert grp.context_settings["help_option_names"] == ["-h", "--help"]
+
+
+# ── root cli group 구성 확인 ─────────────────────────────────────────────────
+
+
+class TestRootCliConfiguration:
+    """root ``cli`` 그룹이 default-deny 구성으로 설치되어 있다."""
+
+    def test_root_cli_is_authenticated_group(self) -> None:
+        """root는 ``AuthenticatedGroup`` 인스턴스다."""
+        assert isinstance(cli, AuthenticatedGroup)
+
+    def test_root_cli_inherits_leaf_path_tracking(self) -> None:
+        """``AuthenticatedGroup``과 ``LeafAwareGroup``은 leaf path tracking 공유."""
+        from ante.cli.middleware import _LeafPathMixin
+
+        assert issubclass(AuthenticatedGroup, _LeafPathMixin)
+        assert issubclass(LeafAwareGroup, _LeafPathMixin)
+
+    def test_root_help_option_names_include_short_alias(self) -> None:
+        """root context_settings에 ``-h`` alias가 등록되어 H1 invariant 만족."""
+        assert cli.context_settings.get("help_option_names") == [
+            "-h",
+            "--help",
+        ]
+
+
+# ── spec ↔ 코드 drift 정적 보호 ──────────────────────────────────────────────
+
+
+_SPEC_PATH = (
+    Path(__file__).resolve().parents[3] / "docs" / "specs" / "cli" / "03-commands.md"
+)
+
+
+class TestSpecAllowlistDrift:
+    """spec ``docs/specs/cli/03-commands.md``의 공개 명령 4개가 코드와 일치."""
+
+    def test_exempt_paths_match_spec_named_commands(self) -> None:
+        """코드의 ``_AUTH_EXEMPT_COMMAND_PATHS`` 3개 + ``--version``이 spec과 일치."""
+        # 코드 SSOT (3 tuple)
+        assert _AUTH_EXEMPT_COMMAND_PATHS == {
+            ("init",),
+            ("member", "reset-password"),
+            ("member", "regenerate-recovery-key"),
+        }
+
+        # spec 본문에서 4개 공개 명령이 모두 등재되어 있는지 확인
+        spec_text = _SPEC_PATH.read_text(encoding="utf-8")
+        assert "ante --version" in spec_text
+        assert "ante init" in spec_text
+        assert "ante member reset-password" in spec_text
+        assert "ante member regenerate-recovery-key" in spec_text
+
+        # 후보 제거 항목이 다시 spec에 들어오면 즉시 발견
+        assert "ante login" not in spec_text or "후보에서 제거" in spec_text
+
+    def test_version_option_present_in_root(self) -> None:
+        """``--version``은 ``@click.version_option``으로 root에 설치된다."""
+        names = {p.name for p in cli.params}
+        assert "version" in names or any(
+            "version" in (getattr(p, "name", "") or "") for p in cli.params
+        ), [p.name for p in cli.params]
+
+
+# ── #1404 P1 정정: --config-dir 인증 시점 반영 ───────────────────────────────
+
+
+class TestConfigDirReflectedBeforeAuthGate:
+    """``ante --config-dir <dir> <cmd>`` 의 ``--config-dir`` 가 인증 게이트 발화
+    **이전**에 ``ctx.obj["config_dir"]`` 로 반영된다.
+
+    P1 finding (#1404 codex review v2): ``AuthenticatedGroup.invoke()`` 의
+    인증 게이트는 ``super().invoke(ctx)`` 호출 이전에 발화한다. 그러나 root
+    callback은 ``super().invoke(ctx)`` 안에서 실행되므로, root callback의
+    부작용(``ctx.obj["config_dir"] = ...``) 가 아직 반영되지 않은 상태로
+    인증이 진행된다. 결과: ``authenticate_member`` → ``get_db_path`` 가
+    default config dir의 DB를 보아 명시한 인스턴스의 토큰이 어긋난 DB에서
+    인증 실패한다.
+
+    정정 후에는 ``ctx.params["config_dir"]`` 가 인증 게이트 발화 직전에
+    ``ctx.obj["config_dir"]`` 로 미러링되어 ``authenticate_member`` 가
+    명시된 디렉토리의 DB를 본다.
+    """
+
+    def test_config_dir_visible_to_authenticate_member(
+        self, runner: CliRunner, clean_env: None, tmp_path: Path
+    ) -> None:
+        """``ante --config-dir <tmp> bot list`` 호출 시 ``authenticate_member`` 가
+        ``ctx.obj["config_dir"]`` 로 ``<tmp>`` 를 본다.
+        """
+        from ante.cli import main as _main
+
+        custom_dir = tmp_path / "custom-config"
+        custom_dir.mkdir()
+
+        observed: dict[str, object] = {}
+
+        def _record_config_dir(ctx):  # noqa: ANN001, ANN202
+            ctx.ensure_object(dict)
+            observed["config_dir"] = ctx.obj.get("config_dir")
+            # 인증 실패 시나리오 재현 — 본 테스트는 config_dir 가시성만 본다.
+            ctx.obj["member"] = None
+
+        with patch.object(_main, "authenticate_member", side_effect=_record_config_dir):
+            result = runner.invoke(
+                cli, ["--config-dir", str(custom_dir), "bot", "list"]
+            )
+
+        # authenticate_member 호출 시점에 config_dir 가 ctx.obj 에 반영돼 있어야 한다.
+        assert observed.get("config_dir") == custom_dir, (
+            f"config_dir not mirrored before auth gate: {observed}, "
+            f"output={result.output}"
+        )
+        # 토큰 미설정 → exit 1
+        assert result.exit_code == 1, result.output
+        assert "인증이 필요합니다" in result.output
+
+    def test_master_token_with_custom_config_dir_targets_custom_db(
+        self,
+        runner: CliRunner,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """``ante --config-dir <tmp> bot list`` (master 토큰) → custom dir DB를 시도.
+
+        config_dir 미러링이 안 되면 ``authenticate_member`` 가 기본 config
+        dir DB를 보고 다른 경로 메시지를 낸다. 미러링이 되면 메시지에 custom
+        dir 경로가 포함되거나, 실제 DB 접근 직전까지 도달한다.
+        """
+        custom_dir = tmp_path / "custom-config-2"
+        custom_dir.mkdir()
+        monkeypatch.setenv("ANTE_MEMBER_TOKEN", "fake-token-for-test")
+
+        result = runner.invoke(cli, ["--config-dir", str(custom_dir), "bot", "list"])
+
+        # DB가 아직 없으므로 인증 실패 — 단, 에러 메시지에 custom_dir 경로가
+        # 들어 있어야 한다(=인증이 custom_dir 기준으로 시도되었다는 증거).
+        assert result.exit_code == 1, result.output
+        assert str(custom_dir) in result.output, (
+            f"custom config_dir not reflected in auth attempt: {result.output}"
+        )
+
+
+# ── #1404 P2 정정: --version 메타 면제 회수 ──────────────────────────────────
+
+
+class TestVersionMetaExemptOnlyAtRoot:
+    """``--version`` 메타 면제는 root ``ante --version`` 에서만 보장.
+
+    P2 finding (#1404 codex review v2): 기존 ``_has_meta_help_or_version_
+    before_dashdash`` 는 args 어디든 ``--version`` 이 있으면 invoke 단계
+    가드를 skip했다. 결과: ``ante update --version``,
+    ``ante bot list --version`` 같이 root 외 위치에 ``--version`` 이 등장하면
+    Click parse error 응답이 인증 없이 노출됐다.
+
+    정정 후 ``--version`` 은 root ``@click.version_option`` 에 위임되고,
+    nested 위치는 invoke 단계 가드가 정상 발화한다.
+    """
+
+    def test_root_version_without_token_exits_0(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """``ante --version`` 은 root ``@click.version_option`` 처리 → exit 0."""
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0, result.output
+        assert "ante, version" in result.output
+
+    def test_nested_version_on_update_triggers_auth_gate(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """``ante update --version`` 은 인증 게이트가 발화 → exit 1.
+
+        이전 동작: 메타 면제로 인증 skip → Click parse error(``no such option``)
+        가 인증 없이 노출.
+        새 동작: invoke 단계 가드가 발화하므로 exit 1 + "인증이 필요합니다".
+        """
+        result = runner.invoke(cli, ["update", "--version"])
+        assert result.exit_code == 1, result.output
+        assert "인증이 필요합니다" in result.output, result.output
+        # Click의 "No such option" / parse error 가 새서는 안 된다.
+        assert "No such option" not in result.output, result.output
+
+    def test_nested_version_on_bot_list_triggers_auth_gate(
+        self, runner: CliRunner, clean_env: None
+    ) -> None:
+        """``ante bot list --version`` 도 동일하게 invoke 단계 가드가 발화."""
+        result = runner.invoke(cli, ["bot", "list", "--version"])
+        assert result.exit_code == 1, result.output
+        assert "인증이 필요합니다" in result.output, result.output
+        assert "No such option" not in result.output, result.output
+
+
+# ── 메타 면제 함수 직접 단위 테스트 ──────────────────────────────────────────
+
+
+class TestHasMetaHelpBeforeDashdash:
+    """``_has_meta_help_before_dashdash`` 헬퍼의 정밀한 동작 확인.
+
+    P2 정정 결과:
+      - ``--help`` / ``-h`` 만 메타로 인정 (모든 깊이의 H1 invariant).
+      - ``--version`` 은 메타로 인정하지 않음 (root ``@click.version_option`` 에 위임).
+      - ``--`` 뒤의 ``--help`` 는 위치 인자로 간주 (H2 invariant).
+    """
+
+    def test_help_long_before_dashdash(self) -> None:
+        from ante.cli.middleware import _has_meta_help_before_dashdash
+
+        assert _has_meta_help_before_dashdash(["bot", "list", "--help"]) is True
+
+    def test_help_short_before_dashdash(self) -> None:
+        from ante.cli.middleware import _has_meta_help_before_dashdash
+
+        assert _has_meta_help_before_dashdash(["bot", "list", "-h"]) is True
+
+    def test_version_token_no_longer_meta(self) -> None:
+        """``--version`` 은 더 이상 면제 토큰이 아니다 (P2 정정)."""
+        from ante.cli.middleware import _has_meta_help_before_dashdash
+
+        assert _has_meta_help_before_dashdash(["bot", "list", "--version"]) is False
+        assert _has_meta_help_before_dashdash(["update", "--version"]) is False
+
+    def test_help_after_dashdash_not_meta(self) -> None:
+        from ante.cli.middleware import _has_meta_help_before_dashdash
+
+        # ``--`` 뒤 ``--help`` 는 위치 인자.
+        assert _has_meta_help_before_dashdash(["bot", "info", "--", "--help"]) is False
+
+    def test_no_meta_tokens(self) -> None:
+        from ante.cli.middleware import _has_meta_help_before_dashdash
+
+        assert _has_meta_help_before_dashdash(["bot", "list"]) is False
+
+
+# ── click 버전 pin ──────────────────────────────────────────────────────────
+
+
+_PYPROJECT = Path(__file__).resolve().parents[3] / "pyproject.toml"
+
+
+class TestClickVersionPin:
+    """Click 8.2의 ``Context.protected_args`` deprecation을 피하기 위해 8.1.x로 pin."""
+
+    def test_pyproject_pins_click_below_8_2(self) -> None:
+        text = _PYPROJECT.read_text(encoding="utf-8")
+        # 8.1 이상, 8.2 미만으로 명확히 pin되어 있어야 한다.
+        assert "click>=8.1,<8.2" in text, text

--- a/tests/unit/test_cli_auth.py
+++ b/tests/unit/test_cli_auth.py
@@ -278,11 +278,16 @@ class TestLeafNameCollisionNotExempt:
         assert "인증" in result.output
 
     def test_resolve_command_path_for_root_init(self):
-        """LeafAwareGroup이 `ante init`에 대해 ("init",)을 저장한다."""
-        from ante.cli.main import LeafAwareGroup, cli
+        """root group이 `ante init`에 대해 ("init",)을 저장한다.
+
+        #1404 이후 root는 ``AuthenticatedGroup``이지만 ``_LeafPathMixin``을
+        통해 ``LeafAwareGroup``과 동일한 leaf path tracking을 공유한다.
+        """
+        from ante.cli.main import cli
+        from ante.cli.middleware import _LeafPathMixin
 
         ctx = click.Context(cli)
-        assert isinstance(cli, LeafAwareGroup)
+        assert isinstance(cli, _LeafPathMixin)
         path = cli._resolve_command_path(ctx, ["init"])
         assert path == ("init",)
 

--- a/tests/unit/test_cli_treasury_snapshot.py
+++ b/tests/unit/test_cli_treasury_snapshot.py
@@ -18,9 +18,31 @@ def runner():
 
 @pytest.fixture
 def mock_auth():
-    """인증 미들웨어를 우회하는 픽스처."""
+    """인증 미들웨어를 우회하는 픽스처.
+
+    #1404: ``AuthenticatedGroup``의 leaf wrapper가 ``ante.cli.main.authenticate_member``
+    를 동적으로 lookup해 호출하므로, main 쪽 attribute를 patch해야 mock이
+    효과를 발휘한다. ``_run_authenticate``도 함께 mock하여 실제 DB 접근을
+    방지한다.
+    """
+    from ante.member.models import Member, MemberRole, MemberType
+
+    _master = Member(
+        member_id="treasury-test-master",
+        type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+        org="default",
+        name="Treasury Test Master",
+        status="active",
+        scopes=[],
+    )
+
+    def _set_member(ctx):  # noqa: ANN001, ANN202
+        ctx.ensure_object(dict)
+        ctx.obj["member"] = _master
+
     with (
-        patch("ante.cli.middleware.authenticate_member"),
+        patch("ante.cli.main.authenticate_member", side_effect=_set_member),
         patch("ante.cli.middleware._run_authenticate"),
     ):
         yield

--- a/tests/unit/test_cli_update.py
+++ b/tests/unit/test_cli_update.py
@@ -49,7 +49,24 @@ class TestCheckServerRunning:
 
 @pytest.fixture()
 def runner() -> CliRunner:
-    """인증 우회 CliRunner."""
+    """인증 우회 CliRunner.
+
+    #1404: ``AuthenticatedGroup``이 leaf callback에 default-deny 인증 가드를
+    부착하므로, ``ante.cli.main.authenticate_member`` 를 patch해 master 멤버
+    stub을 ``ctx.obj["member"]`` 에 채워야 leaf까지 도달한다.
+    """
+    from ante.member.models import Member, MemberRole, MemberType
+
+    _master = Member(
+        member_id="update-test-master",
+        type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+        org="default",
+        name="Update Test Master",
+        status="active",
+        scopes=[],
+    )
+
     r = CliRunner()
     original_invoke = r.invoke
 
@@ -57,7 +74,8 @@ def runner() -> CliRunner:
         with patch("ante.cli.main.authenticate_member") as mock_auth:
 
             def _set_member(ctx):  # noqa: ANN001
-                ctx.obj = ctx.obj or {}
+                ctx.ensure_object(dict)
+                ctx.obj["member"] = _master
 
             mock_auth.side_effect = _set_member
             return original_invoke(cli_cmd, args, **kwargs)

--- a/tests/unit/test_disk_space_check.py
+++ b/tests/unit/test_disk_space_check.py
@@ -13,7 +13,39 @@ from ante.cli.commands.update import _MIN_FREE_MB, check_disk_space
 
 @pytest.fixture
 def runner() -> CliRunner:
-    return CliRunner()
+    """CLI runner with default-deny 인증 우회.
+
+    #1404: ``AuthenticatedGroup`` leaf wrapper가 토큰을 강제하므로
+    ``ante.cli.main.authenticate_member``를 mock하여 ``ctx.obj["member"]``
+    에 master stub을 주입한다.
+    """
+    from ante.member.models import Member, MemberRole, MemberType
+
+    _master = Member(
+        member_id="disk-test-master",
+        type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+        org="default",
+        name="Disk Test Master",
+        status="active",
+        scopes=[],
+    )
+
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):  # noqa: ANN001
+                ctx.ensure_object(dict)
+                ctx.obj["member"] = _master
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
 
 
 class TestCheckDiskSpace:

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -12,7 +12,23 @@ from ante.cli.main import cli
 
 @pytest.fixture()
 def runner() -> CliRunner:
-    """인증 우회 CliRunner."""
+    """인증 우회 CliRunner.
+
+    #1404: ``AuthenticatedGroup`` leaf wrapper가 토큰을 강제하므로 master
+    멤버 stub을 ``ctx.obj["member"]``에 채워야 한다.
+    """
+    from ante.member.models import Member, MemberRole, MemberType
+
+    _master = Member(
+        member_id="update-test-master",
+        type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+        org="default",
+        name="Update Test Master",
+        status="active",
+        scopes=[],
+    )
+
     r = CliRunner()
     original_invoke = r.invoke
 
@@ -20,7 +36,8 @@ def runner() -> CliRunner:
         with patch("ante.cli.main.authenticate_member") as mock_auth:
 
             def _set_member(ctx):  # noqa: ANN001
-                ctx.obj = ctx.obj or {}
+                ctx.ensure_object(dict)
+                ctx.obj["member"] = _master
 
             mock_auth.side_effect = _set_member
             return original_invoke(cli_cmd, args, **kwargs)

--- a/tests/unit/test_update_rollback.py
+++ b/tests/unit/test_update_rollback.py
@@ -14,7 +14,23 @@ from ante.update.executor import rollback_update
 
 @pytest.fixture()
 def runner() -> CliRunner:
-    """인증 우회 CliRunner."""
+    """인증 우회 CliRunner.
+
+    #1404: ``AuthenticatedGroup`` leaf wrapper가 토큰을 강제하므로 master
+    멤버 stub을 ``ctx.obj["member"]``에 채워야 한다.
+    """
+    from ante.member.models import Member, MemberRole, MemberType
+
+    _master = Member(
+        member_id="rollback-test-master",
+        type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+        org="default",
+        name="Rollback Test Master",
+        status="active",
+        scopes=[],
+    )
+
     r = CliRunner()
     original_invoke = r.invoke
 
@@ -22,7 +38,8 @@ def runner() -> CliRunner:
         with patch("ante.cli.main.authenticate_member") as mock_auth:
 
             def _set_member(ctx):  # noqa: ANN001
-                ctx.obj = ctx.obj or {}
+                ctx.ensure_object(dict)
+                ctx.obj["member"] = _master
 
             mock_auth.side_effect = _set_member
             return original_invoke(cli_cmd, args, **kwargs)

--- a/tests/unit/test_update_snapshot.py
+++ b/tests/unit/test_update_snapshot.py
@@ -17,7 +17,40 @@ from ante.update.executor import (
 
 @pytest.fixture
 def runner() -> CliRunner:
-    return CliRunner()
+    """CLI runner with default-deny 인증을 우회하는 헬퍼.
+
+    #1404: ``AuthenticatedGroup``이 leaf command callback에 default-deny
+    인증 가드를 자동 부착한다. 본 모듈의 테스트들은 ``ante update`` 자체의
+    동작을 검증하므로 인증을 mock으로 우회한다 — ``ante.cli.main.authenticate_member``
+    를 patch하여 ``ctx.obj["member"]``에 master stub을 채운다.
+    """
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    from ante.member.models import Member, MemberRole, MemberType
+
+    _master = Member(
+        member_id="update-test-master",
+        type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+        org="default",
+        name="Update Test Master",
+        status="active",
+        scopes=[],
+    )
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):  # noqa: ANN001
+                ctx.ensure_object(dict)
+                ctx.obj["member"] = _master
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1404

## Summary
Epic #1401의 CLI default-deny 단계. #1402 spec SSOT + #1403 Web 미들웨어 패턴 답습.

- `AuthenticatedGroup` (LeafAwareGroup 확장): `invoke()` 단계에서 인증 게이트 (Click parameter validation 전)
- root `cli` group이 `cls=AuthenticatedGroup` + `context_settings={"help_option_names": ["-h", "--help"]}`
- 5단계 게이트: resilient_parsing skip → `--config-dir` ctx.obj 미러 → meta-exempt 검사 (`--help`/`-h`) → allowlist 검사 → `authenticate_member()` 호출 (default-deny exit 1)
- H1 (nested `--help`/`-h` 면제), H2 (`-- --help`는 발화), H3 (Click context state only, raw sys.argv 금지)
- `_AUTH_EXEMPT_COMMAND_PATHS` allowlist (init, member reset-password, member regenerate-recovery-key) + `@click.version_option`
- `require_auth`/`require_scope` idempotent sentinel (`_require_auth_applied`) — 데코레이터 stack 중복 방지
- Click 8.1.x pin (`pyproject.toml`) — 8.2 `Context.protected_args` deprecation 회피 (follow-up 이슈 권장)
- spec/code drift 정적 회귀 보호 (cli/03-commands.md ↔ `_AUTH_EXEMPT_COMMAND_PATHS`)
- callback wrapping은 이중 방어 (invoke primary + callback secondary fallback, idempotent marker)

## Test Plan
- [x] `pytest tests/unit/cli -q` → 596 passed (CLI 매트릭스 + 회귀)
- [x] `pytest tests/unit -q` → 4563 passed, 2 skipped, 0 failed
- [x] `ruff check` / `ruff format --check` 통과
- 신규 test class:
  - `TestInvokeStageAuthGate`: 6 케이스 (`click.Path(exists=True)` 보호 명령 인증 우선, parse_args 전 차단)
  - `TestConfigDirReflectedBeforeAuthGate`: 2 케이스 (`--config-dir` 미러, custom DB 시도)
  - `TestVersionMetaExemptOnlyAtRoot`: 3 케이스 (root --version 면제, nested --version은 인증 게이트)
  - `TestHasMetaHelpBeforeDashdash`: 5 케이스 (헬퍼 단위)

## Codex 브랜치 리뷰 (4라운드)
spec의 미묘성으로 매 라운드마다 1-2개 boundary case 발견. 처음 3라운드는 정정 사이클로 해소, 4라운드 잔여 P2 1건은 PR review로 노출.

### 잔여 finding (PR review로 처리)
**P2 — 옵션 값으로 소비된 help 토큰** (`src/ante/cli/middleware.py:480-481`)
- 예: `ante backtest run /nope.py --start -h --end 2026-01-02` — Click이 `-h`를 `--start`의 값으로 소비. 현재 코드가 토큰 존재만으로 invoke 단계 인증 생략 → `click.Path(exists=True)` 검증 오류가 인증 없이 노출.
- 영향: 일반 사용자 패턴 아님 (옵션 값에 `-h` 사용은 비표준). 그러나 H2 invariant 엄밀성 위반.
- 해결 옵션 (#1408 cleanup 또는 별도 follow-up): Click parser 결과로 help mode 판정 (`Context.params.get("help")`), 또는 옵션 값 위치 토큰 인식.

## Notes
- Codex Plan Review (Plan 단계): approve-implement (revision 3, 3라운드)
- Codex 브랜치 리뷰: 4라운드 (3라운드 정정으로 finding 해소, 4라운드 잔여 P2 1건)
- main 브랜치 직접 수정 없음, `pip_freeze_v1.0.0.txt` 변경 없음
- `frontend/openapi.json` 변경 없음 (CLI-only)

## Follow-up 권장 이슈
- Click 8.2 마이그레이션 (`Context.protected_args` deprecation 대응, `no_args_is_help` exit code 변경 검토)
- 잔여 P2 처리 (옵션 값 help 토큰 edge case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)