### PR TITLE
fix(cli): correct mypy type:ignore code for click.group overload

### DIFF
--- a/src/ante/cli/middleware.py
+++ b/src/ante/cli/middleware.py
@@ -631,4 +631,4 @@ def authenticated_group(name: str | None = None, **attrs: object) -> Callable:
     동작 상세는 :class:`AuthenticatedGroup` docstring 참조.
     """
     attrs.setdefault("cls", AuthenticatedGroup)
-    return click.group(name=name, **attrs)  # type: ignore[arg-type]
+    return click.group(name=name, **attrs)  # type: ignore[call-overload]


### PR DESCRIPTION
Follow-up to #1404.

## Summary
#1422 머지 후 main에 잔존한 mypy 실패 정정:

\`\`\`
src/ante/cli/middleware.py:634: error: No overload variant of "group" matches argument types "str | None", "dict[str, object]"  [call-overload]
src/ante/cli/middleware.py:634: note: Error code "call-overload" not covered by "type: ignore" comment
\`\`\`

- `type: ignore[arg-type]` → `[call-overload]` 정정
- mypy 1.19.1 기준 verified (`Success: no issues found in 234 source files`)

## Root cause
#1422가 CI lint=FAILURE 상태에서 머지됨. merge-gate가 lint를 required check에 포함하지 않은 이슈 (별도 보고 필요).

#1404의 #1422 머지 후 amend로 fix을 시도했으나 GitHub PR head sync 이슈 + 같은 branch CI trigger 차단으로 정상 PR로 분리.

## Test Plan
- [x] `mypy src/ante/cli/middleware.py` → Success
- [x] `mypy src/ante` 전체 → Success: no issues found in 234 source files
- [x] `ruff check` / `ruff format` 통과

## Follow-up
- `merge-gate` workflow의 required checks에 lint 포함 검토 (별도 이슈 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)