### PR TITLE
docs(web-api): add 70-route scope decision SSOT (#1409)

### DIFF
--- a/docs/specs/account/02-design-decisions.md
+++ b/docs/specs/account/02-design-decisions.md
@@ -140,7 +140,7 @@ ante init [--member-id owner] [--name Owner] [--dir <경로>]
 | 작업 | CLI | Web API | 실행 경로 |
 |---|---|---|---|
 | 계좌 목록/상세 조회 | `account list`, `account info` | `GET /api/accounts`, `GET /api/accounts/{id}` | 읽기 |
-| 인증 정보 마스킹 조회 | `account credentials` | `GET /api/accounts/{id}/credentials` | 읽기 |
+| 인증 정보 마스킹 조회 | `account credentials` | — (Web API 미제공) | 읽기 |
 | 계좌 거래 정지 | `account suspend` | `POST /api/accounts/{id}/suspend` | IPC/Web API → `AccountService.suspend()` |
 | 계좌 거래 재개 | `account activate` | `POST /api/accounts/{id}/activate` | IPC/Web API → `AccountService.activate()` |
 | 전체 거래 정지 | `system halt` | `POST /api/system/halt` | IPC/Web API → `AccountService.suspend_all()` |

--- a/docs/specs/account/10-web-api.md
+++ b/docs/specs/account/10-web-api.md
@@ -13,7 +13,6 @@ GET    /api/accounts/:id                  — 계좌 상세
 PUT    /api/accounts/:id                  — 계좌 수정 (런타임에는 비구조 필드만 허용)
 POST   /api/accounts/:id/suspend          — 계좌 정지
 POST   /api/accounts/:id/activate         — 계좌 재활성화
-GET    /api/accounts/:id/credentials      — 인증 정보 마스킹 조회
 DELETE /api/accounts/:id                  — 계좌 삭제 (cold-path 전용, 런타임 서버에서는 409)
 POST   /api/system/halt                   — 시스템 전역 정지 (모든 ACTIVE 계좌를 SUSPENDED로 전환)
 POST   /api/system/clear-halt             — 시스템 전역 정지 해제 (모든 SUSPENDED 계좌를 ACTIVE로 복구; 봇 자동 재시작 아님)

--- a/docs/specs/account/13-cross-module-notes.md
+++ b/docs/specs/account/13-cross-module-notes.md
@@ -12,5 +12,5 @@
 - **Trade 스펙**: 거래 기록은 `account_id`로 scoping된다. 계좌에 종속되지 않으나 조회·필터링 시 계좌 단위로 분리.
 - **Strategy 스펙**: 전략은 글로벌 Registry에 등록하고, `StrategyMeta.exchange`로 대상 시장을 명시한다. 봇 배정 시 계좌 exchange와 호환성을 검증한다.
 - **Lifecycle cold-path 계약**: 계좌 생성/삭제/credentials 변경/broker_config·commission·market_order_reserve_buffer_rate 변경은 서버 정지 상태에서만 허용한다 (#1333: 9 STRUCTURAL_FIELDS). 서버 실행 중에는 조회, suspend/activate, 비구조 필드 수정, 계좌별 rule 변경만 허용한다.
-- **Web API 스펙**: 런타임 허용 엔드포인트는 `GET /api/accounts`, `GET /api/accounts/:id`, credentials 마스킹 조회, `POST /api/accounts/:id/suspend`, `POST /api/accounts/:id/activate`, `POST /api/system/halt`, `POST /api/system/clear-halt`, 계좌별 rule 변경이다. `POST /api/accounts`, `DELETE /api/accounts/:id`, structural `PUT /api/accounts/:id`는 409로 차단한다.
+- **Web API 스펙**: 런타임 허용 엔드포인트는 `GET /api/accounts`, `GET /api/accounts/:id`, `POST /api/accounts/:id/suspend`, `POST /api/accounts/:id/activate`, `POST /api/system/halt`, `POST /api/system/clear-halt`, 계좌별 rule 변경이다. `POST /api/accounts`, `DELETE /api/accounts/:id`, structural `PUT /api/accounts/:id`는 409로 차단한다.
 - **CLI 스펙**: `ante account create/delete/set-credentials`는 cold-path 전용이며 서버 실행 중이면 거부한다. `list/info/credentials/suspend/activate`, `ante system halt/clear-halt`는 런타임 중 실행 가능하다.

--- a/docs/specs/web-api/05-resource-endpoints.md
+++ b/docs/specs/web-api/05-resource-endpoints.md
@@ -14,7 +14,6 @@
 | POST | `/api/accounts` | 계좌 등록. cold-path 전용이므로 런타임 서버에서는 409 `ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER` 반환. Body: account_id, exchange, currency, broker_type, trading_mode, credentials, broker_config, buy_commission_rate, sell_commission_rate, market_order_reserve_buffer_rate (#1333). |
 | GET | `/api/accounts/{account_id}` | 계좌 상세 조회. 응답에 `market_order_reserve_buffer_rate` (float) 포함 (#1333). |
 | PUT | `/api/accounts/{account_id}` | 계좌 수정. 런타임에는 `name`, `timezone`, `trading_hours_start`, `trading_hours_end` 같은 비구조 필드만 허용. `credentials`, `broker_config`, `buy_commission_rate`, `sell_commission_rate`, `market_order_reserve_buffer_rate`, `broker_type`, `exchange`, `currency`, `trading_mode` 포함 시 409 (#1333: 9 STRUCTURAL_FIELDS). 본문은 `Content-Type: application/json`(charset suffix 허용)만 허용하며, 그 외 media type은 415 반환. 다른 mutate 라우트의 415 게이트 도입은 본 변경 범위 밖. |
-| GET | `/api/accounts/{account_id}/credentials` | 인증 정보 마스킹 조회 |
 | POST | `/api/accounts/{account_id}/suspend` | 계좌 거래 정지. Body: reason. 이미 정지 상태이면 409 Conflict |
 | POST | `/api/accounts/{account_id}/activate` | 계좌 거래 재개. 이미 활성 상태이면 409 Conflict |
 | DELETE | `/api/accounts/{account_id}` | 계좌 삭제. cold-path 전용이므로 런타임 서버에서는 409 `ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER` 반환 |
@@ -55,6 +54,7 @@
 | GET | `/api/strategies` | 전략 목록 (필터: status). 응답에 `cumulative_return`, `backtest_return` 포함 — 전략별 PerformanceTracker 조회 |
 | GET | `/api/strategies/{strategy_id}` | 전략 상세 조회. 응답에 `params`, `param_schema`, `rationale`, `risks` 포함 — 전략 클래스 런타임 로드 + StrategyRecord 확장 필드 |
 | POST | `/api/strategies/validate` | 전략 파일 검증. Body: `{"path": "..."}` |
+| PATCH | `/api/strategies/{strategy_id}/status` | 전략 상태 변경. Body: `{"status": "..."}`. 허용되지 않은 상태 전환은 400 반환. `require_strategy_write` scope 검증 (#1378). |
 | GET | `/api/strategies/{strategy_id}/performance` | 전략 성과 지표 |
 | GET | `/api/strategies/{strategy_id}/daily-summary` | 전략 일별 성과 집계 |
 | GET | `/api/strategies/{strategy_id}/weekly-summary` | 전략 주별 성과 집계 |

--- a/docs/specs/web-api/09-public-paths.md
+++ b/docs/specs/web-api/09-public-paths.md
@@ -45,6 +45,7 @@ allowlist 항목은 다음 세 카테고리 중 하나에 속한다.
 | `/api/system/health` | public | reverse proxy / 모니터링 헬스체크. 인증 요구 시 운영 인프라가 헬스를 판정할 수 없다. 라우트 정의: `src/ante/web/routes/system.py:102`. |
 | `/api/auth/login` | public | 인증 자체를 수행하는 엔드포인트. 인증되지 않은 상태에서 시작되어야 한다. 라우트 정의: `src/ante/web/routes/auth.py:31`. |
 | `/api/auth/logout` | public | 세션 종료. 인증이 만료된 상태에서도 호출 가능해야 한다(클라이언트 측 정리 + 서버 측 best-effort). 라우트 정의: `src/ante/web/routes/auth.py:106`. |
+| `/api/reports/schema` | public | 리포트 제출 폼 스키마(필드명 + 예시). 비밀값 없음. 클라이언트가 폼 렌더링용으로 사용. `/api/data/schema`(data:read)와 구별: reports schema는 폼 메타데이터, data schema는 운영 데이터 구조. [#1409](https://github.com/joshua-jingu-lee/ante/issues/1409) 70-route 결정 표에서 결정 (자세한 근거: [11-route-scope-table.md](11-route-scope-table.md) reports 섹션). |
 | `/openapi.json` | public | OpenAPI 스키마 정적 자원. Agent와 외부 도구가 계약을 파싱한다. |
 | `/docs` | public | Swagger UI. OpenAPI 탐색기. |
 | `/redoc` | public | ReDoc. API 레퍼런스 문서. |
@@ -105,14 +106,12 @@ PUBLIC_PATHS 테이블의 `/`, `/index.html` 행은 본 분기 채택 후에도 
 
 ## 결정 보류 항목 (`unresolved`)
 
-다음 경로는 본 이슈에서 공개 여부를 결정하지 않는다. #1409 70-route 결정 표에서
-호출자 영향(모니터링, 대시보드, Agent)을 검토한 뒤 `public` 또는 `system:read` /
-`report:read` 등 scope 부착으로 확정한다. 결정 시까지는 default-deny가 적용된다.
+본 표 작성 시점(#1403)에 결정 보류했던 두 항목은 [#1409](https://github.com/joshua-jingu-lee/ante/issues/1409) 70-route 결정 표에서 모두 결정 완료되었다. 현재 보류 항목은 없다.
 
-| 경로 | 결정 보류 사유 |
-|------|---------------|
-| `/api/system/status` | 시스템 상태(uptime, kill switch 등)를 공개로 노출할지 `system:read` scope로 제한할지 호출자 영향(대시보드, 모니터링) 검토 필요. |
-| `/api/reports/schema` | 리포트 스키마 메타데이터의 공개 여부 정책 결정 필요(Agent가 인증 없이 schema를 받을 수 있어야 하는지). |
+| 경로 | 결정 | 결정 출처 |
+|------|------|----------|
+| `/api/system/status` | `system:read` scope 부착 (PUBLIC_PATHS 아님) | [11-route-scope-table.md](11-route-scope-table.md) system 섹션 — 운영 정보(account_count, last_health_check 등) 노출은 인증 토큰 보유자만. 모니터링도 system:read 토큰 사용. `/api/system/health`(public)와 구별. |
+| `/api/reports/schema` | `public` (위 PUBLIC_PATHS 표에 추가됨) | [11-route-scope-table.md](11-route-scope-table.md) reports 섹션 — 리포트 제출 폼 스키마. 비밀값 없음. |
 
 ## 후보에서 제거된 항목
 

--- a/docs/specs/web-api/11-route-scope-table.md
+++ b/docs/specs/web-api/11-route-scope-table.md
@@ -1,0 +1,266 @@
+# Web API 모듈 세부 설계 - 70 라우트 scope 결정 표
+
+> 인덱스: [README.md](README.md) | 호환 문서: [web-api.md](web-api.md)
+> 정책 SSOT: [D-015 default-deny 인증 게이트](../../decisions/D-015-default-deny-auth-gate.md)
+> 게이트 단계 SSOT: [02-design-decisions.md — 인증 게이트 단계](02-design-decisions.md#인증-게이트-단계)
+> 공개 경로 SSOT: [09-public-paths.md](09-public-paths.md)
+> Scope vocabulary SSOT: [../member/02-design-decisions.md](../member/02-design-decisions.md) (도메인별 read/write/admin/run 표)
+
+# 70 라우트 scope 결정 표 (Epic #1401)
+
+본 문서는 `src/ante/web/routes/` 의 **모든 라우트(70개)** 에 대해
+`require_*` dependency 부착 결정 SSOT를 row 단위로 명시한다.
+후속 이슈 #1407(라우트 일관 부착), #1408(import 마이그레이션), #1405(정적 검증)는
+본 표를 직접 인용해 코드 적용 / 검증을 수행한다.
+
+## 결정 카테고리
+
+| 카테고리 | 의미 |
+|---------|------|
+| `public` | [09-public-paths.md](09-public-paths.md) PUBLIC_PATHS allowlist. 인증 게이트 면제. 라우트도 caller-agnostic. |
+| `gate-exempt-self-auth` | 미들웨어 게이트만 면제. 라우트가 자체적으로 세션/토큰을 검증하고 본인 정보만 응답. |
+| `<domain>:<action>` | `require_scope("<domain>:<action>")` dependency 부착. spec scope vocabulary 정합. |
+
+`authenticated-only` 카테고리는 본 표에서 사용하지 않는다. 모든 라우트에 대해
+명시적 `public` / `gate-exempt-self-auth` / `<scope>` 결정을 둔다.
+
+## 표의 컬럼
+
+| 컬럼 | 의미 |
+|------|------|
+| Module | 라우터 파일 (`src/ante/web/routes/<module>.py`) |
+| Method | HTTP method |
+| Path | API path (router prefix 포함) |
+| 현재 부착 dependency | 코드 grep `Depends(require_*)` 결과 — `master_caller` / `<scope>` / `(none)` |
+| 결정 카테고리 | `public` / `gate-exempt-self-auth` / `<scope>` |
+| Scope | `<domain>:<action>` (해당 시) |
+| 근거 | spec vocabulary 정합 + 운영 가시성 |
+| 후속 이슈 | 코드 마이그레이션을 처리할 이슈 (#1407 등) |
+
+## 카운트 요약
+
+총 70 라우트, 14 모듈:
+accounts(9) + approvals(3) + audit(1) + auth(3) + bots(8) + config(2) + data(6)
++ members(9) + portfolio(2) + reports(4) + strategies(9) + system(4) + trades(1)
++ treasury(9) = **70**.
+
+현재 부착 dependency: 17개
+(`require_master_caller` 13 + `require_audit_read` 1 + `require_config_write` 1
++ `require_report_write` 1 + `require_strategy_write` 1).
+
+본 표 결정 적용 대상: 70 라우트 전체.
+이미 부착된 17개는 코드 grep 결과와 cross-check 완료.
+
+**70 라우트 분해**:
+- **17개**: 이미 dependency 부착 완료 (현재 head 기준 코드 부착됨).
+- **48개**: scope 미부착 — 후속 #1407에서 `require_scope("<scope>")` 부착 대상.
+- **5개**: 면제 라우트 — `public` 4개(`/api/system/health`, `/api/auth/login`, `/api/auth/logout`, `/api/reports/schema`) + `gate-exempt-self-auth` 1개(`/api/auth/me`). 본 표에서 결정 + [09-public-paths.md](09-public-paths.md) PUBLIC_PATHS allowlist로 처리 (`/api/reports/schema`는 본 이슈에서 09에 추가됨; 나머지 4개는 #1403 머지로 이미 처리됨).
+
+후속 #1407 작업 대상은 **미부착 48개 scope 라우트만**이며, 5개 면제 라우트는 #1407 변환 대상이 아니다.
+
+## accounts (`/api/accounts`, 9 라우트)
+
+| Module | Method | Path | 현재 부착 dependency | 결정 카테고리 | Scope | 근거 | 후속 이슈 |
+|--------|--------|------|---------------------|--------------|-------|------|----------|
+| accounts | GET | `/api/accounts` | (none) | `<scope>` | `account:read` | spec `account:read` 정합. 계좌 목록은 trading-sensitive하므로 인증 필요. | #1407 |
+| accounts | POST | `/api/accounts` | (none) | `<scope>` | `account:write` | spec `account:write` 정합. 계좌 생성은 cold-path지만 런타임에서도 인증 필요. | #1407 |
+| accounts | GET | `/api/accounts/{account_id}` | (none) | `<scope>` | `account:read` | spec `account:read` 정합. 단건 조회. | #1407 |
+| accounts | PUT | `/api/accounts/{account_id}` | `require_master_caller` | `<scope>` | `account:write` | spec `account:write` 정합. 현재 master_caller → #1407에서 `require_scope("account:write")`로 마이그레이션 예정. | #1407 |
+| accounts | POST | `/api/accounts/{account_id}/suspend` | `require_master_caller` | `<scope>` | `account:write` | spec `account:write` 정합 (계좌 상태 전이). 현재 master_caller → #1407 마이그레이션. | #1407 |
+| accounts | POST | `/api/accounts/{account_id}/activate` | `require_master_caller` | `<scope>` | `account:write` | spec `account:write` 정합 (계좌 상태 전이). 현재 master_caller → #1407 마이그레이션. | #1407 |
+| accounts | DELETE | `/api/accounts/{account_id}` | (none) | `<scope>` | `account:write` | spec `account:write` 정합. 계좌 삭제는 cold-path지만 런타임에서도 인증 필요. | #1407 |
+| accounts | GET | `/api/accounts/{account_id}/rules` | (none) | `<scope>` | `rule:read` | spec `rule` 도메인 read (룰 조회). account 도메인이 아님 — 룰은 별개 도메인. | #1407 |
+| accounts | PUT | `/api/accounts/{account_id}/rules/{rule_type}` | `require_master_caller` | `<scope>` | `rule:admin` | spec `rule:admin` (룰 활성화/비활성화/수정). 현재 master_caller → #1407에서 `require_scope("rule:admin")`로 마이그레이션. | #1407 |
+
+## approvals (`/api/approvals`, 3 라우트)
+
+| Module | Method | Path | 현재 부착 dependency | 결정 카테고리 | Scope | 근거 | 후속 이슈 |
+|--------|--------|------|---------------------|--------------|-------|------|----------|
+| approvals | GET | `/api/approvals` | (none) | `<scope>` | `approval:read` | spec `approval:read` 정합 (결재 조회). | #1407 |
+| approvals | GET | `/api/approvals/{approval_id}` | (none) | `<scope>` | `approval:read` | spec `approval:read` 정합 (결재 상세 조회). | #1407 |
+| approvals | PATCH | `/api/approvals/{approval_id}/status` | (none) | `<scope>` | `approval:admin` | spec `approval:admin` 정합 (결재 승인/거부). `approval:write`(요청/철회)와 구별. | #1407 |
+
+## audit (`/api/audit`, 1 라우트)
+
+| Module | Method | Path | 현재 부착 dependency | 결정 카테고리 | Scope | 근거 | 후속 이슈 |
+|--------|--------|------|---------------------|--------------|-------|------|----------|
+| audit | GET | `/api/audit` | `require_audit_read` | `<scope>` | `audit:read` | spec `audit:read` 정합. 이미 코드 부착됨 (#1359). | — |
+
+## auth (`/api/auth`, 3 라우트)
+
+| Module | Method | Path | 현재 부착 dependency | 결정 카테고리 | Scope | 근거 | 후속 이슈 |
+|--------|--------|------|---------------------|--------------|-------|------|----------|
+| auth | POST | `/api/auth/login` | (none) | `public` | — | PUBLIC_PATHS allowlist ([09-public-paths.md](09-public-paths.md)). 인증 자체를 수행. | — |
+| auth | POST | `/api/auth/logout` | (none) | `public` | — | PUBLIC_PATHS allowlist. 세션 만료 상태에서도 호출 가능해야 함. | — |
+| auth | GET | `/api/auth/me` | (none) | `gate-exempt-self-auth` | — | 미들웨어 게이트만 면제, 라우트가 자체적으로 세션/토큰 검증해 본인 정보만 응답. dashboard 초기 로딩 호환. | — |
+
+## bots (`/api/bots`, 8 라우트)
+
+| Module | Method | Path | 현재 부착 dependency | 결정 카테고리 | Scope | 근거 | 후속 이슈 |
+|--------|--------|------|---------------------|--------------|-------|------|----------|
+| bots | GET | `/api/bots` | (none) | `<scope>` | `bot:read` | spec `bot:read` 정합 (봇 상태 조회). | #1407 |
+| bots | POST | `/api/bots` | `require_master_caller` | `<scope>` | `bot:admin` | spec `bot:admin` 정합 (봇 생성). 현재 master_caller → #1407 마이그레이션. spec 도메인 표에 `bot:write`는 없음, mutation은 `bot:admin`. | #1407 |
+| bots | GET | `/api/bots/{bot_id}` | (none) | `<scope>` | `bot:read` | spec `bot:read` 정합. | #1407 |
+| bots | POST | `/api/bots/{bot_id}/start` | (none) | `<scope>` | `bot:admin` | spec `bot:admin` 정합 (봇 운영 제어). | #1407 |
+| bots | POST | `/api/bots/{bot_id}/stop` | (none) | `<scope>` | `bot:admin` | spec `bot:admin` 정합 (봇 운영 제어). | #1407 |
+| bots | DELETE | `/api/bots/{bot_id}` | `require_master_caller` | `<scope>` | `bot:admin` | spec `bot:admin` 정합 (봇 삭제). 현재 master_caller → #1407 마이그레이션. | #1407 |
+| bots | PUT | `/api/bots/{bot_id}` | `require_master_caller` | `<scope>` | `bot:admin` | spec `bot:admin` 정합 (봇 설정 변경). 현재 master_caller → #1407 마이그레이션. | #1407 |
+| bots | GET | `/api/bots/{bot_id}/logs` | (none) | `<scope>` | `bot:read` | spec `bot:read` 정합 (봇 상태/로그 조회). | #1407 |
+
+## config (`/api/config`, 2 라우트)
+
+| Module | Method | Path | 현재 부착 dependency | 결정 카테고리 | Scope | 근거 | 후속 이슈 |
+|--------|--------|------|---------------------|--------------|-------|------|----------|
+| config | GET | `/api/config` | (none) | `<scope>` | `config:read` | spec `config:read` 정합. | #1407 |
+| config | PUT | `/api/config/{key:path}` | `require_config_write` | `<scope>` | `config:write` | spec `config:write` 정합. 이미 코드 부착됨 (#1373). | — |
+
+## data (`/api/data`, 6 라우트)
+
+| Module | Method | Path | 현재 부착 dependency | 결정 카테고리 | Scope | 근거 | 후속 이슈 |
+|--------|--------|------|---------------------|--------------|-------|------|----------|
+| data | GET | `/api/data/datasets` | (none) | `<scope>` | `data:read` | spec `data:read` 정합. | #1407 |
+| data | GET | `/api/data/datasets/{dataset_id}` | (none) | `<scope>` | `data:read` | spec `data:read` 정합. | #1407 |
+| data | GET | `/api/data/schema` | (none) | `<scope>` | `data:read` | spec `data:read` 정합. data 도메인은 trading-sensitive하므로 스키마도 인증 필요. `/api/reports/schema`(public)와 구별: reports schema는 폼 메타데이터, data schema는 운영 데이터 구조. | #1407 |
+| data | GET | `/api/data/storage` | (none) | `<scope>` | `data:read` | spec `data:read` 정합 (용량 현황 조회). | #1407 |
+| data | DELETE | `/api/data/datasets/{dataset_id}` | (none) | `<scope>` | `data:write` | spec `data:write` 정합 (데이터셋 삭제 = mutation). | #1407 |
+| data | GET | `/api/data/feed-status` | (none) | `<scope>` | `data:read` | spec `data:read` 정합 (Feed 파이프라인 상태 조회). | #1407 |
+
+## members (`/api/members`, 9 라우트)
+
+| Module | Method | Path | 현재 부착 dependency | 결정 카테고리 | Scope | 근거 | 후속 이슈 |
+|--------|--------|------|---------------------|--------------|-------|------|----------|
+| members | GET | `/api/members` | (none) | `<scope>` | `member:read` | spec `member:read` 정합 (멤버 목록). | #1407 |
+| members | POST | `/api/members` | (none) | `<scope>` | `member:admin` | spec `member:admin` 정합 (멤버 등록). MemberService 내부 `_assert_master`로 현재 master만 허용 — #1407에서 `require_scope("member:admin")`로 표면 정합. | #1407 |
+| members | GET | `/api/members/{member_id}` | (none) | `<scope>` | `member:read` | spec `member:read` 정합. | #1407 |
+| members | POST | `/api/members/{member_id}/suspend` | (none) | `<scope>` | `member:admin` | spec `member:admin` 정합 (멤버 정지). | #1407 |
+| members | POST | `/api/members/{member_id}/reactivate` | (none) | `<scope>` | `member:admin` | spec `member:admin` 정합 (멤버 재활성화). | #1407 |
+| members | POST | `/api/members/{member_id}/revoke` | (none) | `<scope>` | `member:admin` | spec `member:admin` 정합 (멤버 영구 폐기). | #1407 |
+| members | POST | `/api/members/{member_id}/rotate-token` | (none) | `<scope>` | `member:admin` | spec `member:admin` 정합 (토큰 재발급). | #1407 |
+| members | PATCH | `/api/members/{member_id}/password` | `require_master_caller` | `<scope>` | `member:admin` | spec `member:admin` 정합 (패스워드 변경). 현재 master_caller → #1407 마이그레이션. | #1407 |
+| members | PUT | `/api/members/{member_id}/scopes` | (none) | `<scope>` | `member:admin` | spec `member:admin` 정합 (권한 범위 변경). | #1407 |
+
+## portfolio (`/api/portfolio`, 2 라우트)
+
+| Module | Method | Path | 현재 부착 dependency | 결정 카테고리 | Scope | 근거 | 후속 이슈 |
+|--------|--------|------|---------------------|--------------|-------|------|----------|
+| portfolio | GET | `/api/portfolio/value` | (none) | `<scope>` | `treasury:read` | portfolio는 `treasury_daily_snapshots` 테이블을 읽어 응답한다. 데이터 출처가 treasury이므로 spec `treasury:read` 정합. 별도 `portfolio` 도메인 신설 안 함. | #1407 |
+| portfolio | GET | `/api/portfolio/history` | (none) | `<scope>` | `treasury:read` | portfolio history도 동일 `treasury_daily_snapshots` 시계열 출처. spec `treasury:read` 정합. | #1407 |
+
+## reports (`/api/reports`, 4 라우트)
+
+| Module | Method | Path | 현재 부착 dependency | 결정 카테고리 | Scope | 근거 | 후속 이슈 |
+|--------|--------|------|---------------------|--------------|-------|------|----------|
+| reports | GET | `/api/reports/schema` | (none) | `public` | — | 리포트 제출 폼 스키마(필드명 + 예시). 비밀값 없음. 클라이언트가 폼 렌더링용으로 사용. `/api/data/schema`(data:read)와 구별: reports schema는 폼 메타데이터, data schema는 운영 데이터 구조. 본 이슈에서 결정. [09-public-paths.md](09-public-paths.md) PUBLIC_PATHS 목록에 추가됨. | — (면제 라우트, #1407 대상 아님) |
+| reports | POST | `/api/reports` | `require_report_write` | `<scope>` | `report:write` | spec `report:write` 정합. 이미 코드 부착됨. | — |
+| reports | GET | `/api/reports/{report_id}` | (none) | `<scope>` | `report:read` | spec `report:read` 정합. | #1407 |
+| reports | GET | `/api/reports` | (none) | `<scope>` | `report:read` | spec `report:read` 정합. | #1407 |
+
+## strategies (`/api/strategies`, 9 라우트)
+
+| Module | Method | Path | 현재 부착 dependency | 결정 카테고리 | Scope | 근거 | 후속 이슈 |
+|--------|--------|------|---------------------|--------------|-------|------|----------|
+| strategies | POST | `/api/strategies/validate` | (none) | `<scope>` | `strategy:write` | spec `strategy:write` 정합 (전략 등록/검증). | #1407 |
+| strategies | GET | `/api/strategies` | (none) | `<scope>` | `strategy:read` | spec `strategy:read` 정합. | #1407 |
+| strategies | PATCH | `/api/strategies/{strategy_id}/status` | `require_strategy_write` | `<scope>` | `strategy:write` | spec `strategy:write` 정합 (전략 상태 변경). 이미 코드 부착됨. | — |
+| strategies | GET | `/api/strategies/{strategy_id}` | (none) | `<scope>` | `strategy:read` | spec `strategy:read` 정합. | #1407 |
+| strategies | GET | `/api/strategies/{strategy_id}/performance` | (none) | `<scope>` | `strategy:read` | spec `strategy:read` 정합 (전략 성과 지표 조회). | #1407 |
+| strategies | GET | `/api/strategies/{strategy_id}/daily-summary` | (none) | `<scope>` | `strategy:read` | spec `strategy:read` 정합. | #1407 |
+| strategies | GET | `/api/strategies/{strategy_id}/weekly-summary` | (none) | `<scope>` | `strategy:read` | spec `strategy:read` 정합. | #1407 |
+| strategies | GET | `/api/strategies/{strategy_id}/monthly-summary` | (none) | `<scope>` | `strategy:read` | spec `strategy:read` 정합. | #1407 |
+| strategies | GET | `/api/strategies/{strategy_id}/trades` | (none) | `<scope>` | `strategy:read` | spec `strategy:read` 정합 (전략 거래 내역). | #1407 |
+
+## system (`/api/system`, 4 라우트)
+
+| Module | Method | Path | 현재 부착 dependency | 결정 카테고리 | Scope | 근거 | 후속 이슈 |
+|--------|--------|------|---------------------|--------------|-------|------|----------|
+| system | GET | `/api/system/health` | (none) | `public` | — | PUBLIC_PATHS allowlist ([09-public-paths.md](09-public-paths.md)). reverse proxy / 모니터링 헬스체크. 인증 요구 시 운영 인프라가 헬스 판정 불가. | — |
+| system | GET | `/api/system/status` | (none) | `<scope>` | `system:read` | spec `system:read` 정합 (시스템 상태 조회). 운영 정보(account_count, last_health_check 등) 노출은 인증 토큰 보유자만. 모니터링도 system:read 토큰 사용. `/api/system/health`만 public. 본 이슈에서 결정. | #1407 |
+| system | POST | `/api/system/halt` | `require_master_caller` | `<scope>` | `system:admin` | spec `system:admin` 정합 (시스템 상태 변경 — kill switch). 현재 master_caller → #1407 마이그레이션. | #1407 |
+| system | POST | `/api/system/clear-halt` | `require_master_caller` | `<scope>` | `system:admin` | spec `system:admin` 정합 (kill switch 해제). 현재 master_caller → #1407 마이그레이션. | #1407 |
+
+## trades (`/api/trades`, 1 라우트)
+
+| Module | Method | Path | 현재 부착 dependency | 결정 카테고리 | Scope | 근거 | 후속 이슈 |
+|--------|--------|------|---------------------|--------------|-------|------|----------|
+| trades | GET | `/api/trades` | (none) | `<scope>` | `trade:read` | spec `trade:read` 정합 (거래 내역 조회). spec 도메인 표에 `trade:write`/`trade:admin`은 없음 — 거래 내역은 시스템이 기록, 사용자 mutation 라우트 없음. | #1407 |
+
+## treasury (`/api/treasury`, 9 라우트)
+
+| Module | Method | Path | 현재 부착 dependency | 결정 카테고리 | Scope | 근거 | 후속 이슈 |
+|--------|--------|------|---------------------|--------------|-------|------|----------|
+| treasury | GET | `/api/treasury` | (none) | `<scope>` | `treasury:read` | spec `treasury:read` 정합 (자금 현황 조회). | #1407 |
+| treasury | GET | `/api/treasury/transactions` | (none) | `<scope>` | `treasury:read` | spec `treasury:read` 정합. | #1407 |
+| treasury | POST | `/api/treasury/bots/{bot_id}/allocate` | `require_master_caller` | `<scope>` | `treasury:admin` | spec `treasury:admin` 정합 (예산 설정/자금 투입). spec 도메인 표에 `treasury:write`는 없음, mutation은 `treasury:admin`. 현재 master_caller → #1407 마이그레이션. | #1407 |
+| treasury | POST | `/api/treasury/bots/{bot_id}/deallocate` | `require_master_caller` | `<scope>` | `treasury:admin` | spec `treasury:admin` 정합 (예산 회수). 현재 master_caller → #1407 마이그레이션. | #1407 |
+| treasury | GET | `/api/treasury/budgets` | (none) | `<scope>` | `treasury:read` | spec `treasury:read` 정합 (봇별 예산 목록). | #1407 |
+| treasury | POST | `/api/treasury/balance` | `require_master_caller` | `<scope>` | `treasury:admin` | spec `treasury:admin` 정합 (계좌 잔고 수동 설정). 현재 master_caller → #1407 마이그레이션. | #1407 |
+| treasury | GET | `/api/treasury/snapshots/latest` | (none) | `<scope>` | `treasury:read` | spec `treasury:read` 정합. | #1407 |
+| treasury | GET | `/api/treasury/snapshots` | (none) | `<scope>` | `treasury:read` | spec `treasury:read` 정합. | #1407 |
+| treasury | GET | `/api/treasury/snapshots/{date}` | (none) | `<scope>` | `treasury:read` | spec `treasury:read` 정합. | #1407 |
+
+## Scope vocabulary 정합
+
+본 표에서 사용한 모든 scope는 [../member/02-design-decisions.md](../member/02-design-decisions.md)
+도메인별 read/write/admin/run 표에 이미 정의되어 있다.
+**신규 scope vocabulary 도입은 없다.**
+
+사용 scope 목록 (15종):
+- `account:read`, `account:write`
+- `approval:read`, `approval:admin`
+- `audit:read`
+- `bot:read`, `bot:admin`
+- `config:read`, `config:write`
+- `data:read`, `data:write`
+- `member:read`, `member:admin`
+- `report:read`, `report:write`
+- `rule:read`, `rule:admin`
+- `strategy:read`, `strategy:write`
+- `system:read`, `system:admin`
+- `trade:read`
+- `treasury:read`, `treasury:admin`
+
+(`portfolio` 도메인은 신설하지 않고 `treasury:read`에 묶었다. portfolio 라우트가 `treasury_daily_snapshots` 데이터를 직접 읽는 view 성격이기 때문이다.)
+
+## 경계 케이스 결정
+
+본 이슈에서 사용자/오케스트레이터 정책 판단이 필요했던 경계 케이스 3건:
+
+| Path | 결정 | 근거 |
+|------|------|------|
+| `GET /api/system/status` | `system:read` | 운영 정보(account_count, last_health_check 등) 노출은 인증 토큰 보유자만. 모니터링도 system:read 토큰 사용. `/api/system/health`(public)와 구별. |
+| `GET /api/reports/schema` | `public` | 리포트 제출 폼 스키마. 비밀값 없음. 클라이언트가 폼 렌더링용으로 사용. `/api/data/schema`(data:read)와 다른 정책 — data 도메인은 trading-sensitive. |
+| `GET /api/auth/me` | `gate-exempt-self-auth` | 미들웨어 게이트는 면제하되 라우트가 자체 세션/토큰 검증해 본인 정보만 응답. dashboard 초기 로딩 호환. |
+
+## 후속 작업 (#1407)
+
+#1407 코드 마이그레이션 대상은 **scope 라우트 48개 + master_caller 마이그레이션 13개**다. 면제 라우트 5개(public 4 + gate-exempt-self-auth 1)는 #1407 대상이 **아니며**, [09-public-paths.md](09-public-paths.md) PUBLIC_PATHS allowlist로 처리한다 (4개는 #1403 머지로 이미 처리, `/api/reports/schema`는 본 이슈에서 09에 추가됨).
+
+- 미부착 **48개 scope 라우트**에 `require_scope("<scope>")` 부착.
+- 이미 부착된 13개 `require_master_caller` 라우트를 `require_scope("<scope>")`로 마이그레이션:
+  - `PUT /api/accounts/{id}` → `account:write`
+  - `POST /api/accounts/{id}/suspend` → `account:write`
+  - `POST /api/accounts/{id}/activate` → `account:write`
+  - `PUT /api/accounts/{id}/rules/{type}` → `rule:admin`
+  - `POST /api/bots` → `bot:admin`
+  - `DELETE /api/bots/{id}` → `bot:admin`
+  - `PUT /api/bots/{id}` → `bot:admin`
+  - `PATCH /api/members/{id}/password` → `member:admin`
+  - `POST /api/system/halt` → `system:admin`
+  - `POST /api/system/clear-halt` → `system:admin`
+  - `POST /api/treasury/bots/{id}/allocate` → `treasury:admin`
+  - `POST /api/treasury/bots/{id}/deallocate` → `treasury:admin`
+  - `POST /api/treasury/balance` → `treasury:admin`
+- `GET /api/reports/schema`를 [09-public-paths.md](09-public-paths.md) PUBLIC_PATHS allowlist에 추가.
+- 이미 부착된 4개 (`audit:read`, `config:write`, `report:write`, `strategy:write`)는 표 결정과 일치 — 변경 없음.
+
+## Spec-Code Drift 처리
+
+본 이슈 작업 중 발견한 [05-resource-endpoints.md](05-resource-endpoints.md) drift 2건을 같이 정정한다:
+
+- `GET /api/accounts/{account_id}/credentials` — spec 표에 있으나 코드에 라우트 없음 → 코드 SSOT 원칙에 따라 spec에서 제거. 다음 spec 위치를 모두 정정한다:
+  - [05-resource-endpoints.md](05-resource-endpoints.md) account 리소스 표 (정정 완료)
+  - [../account/10-web-api.md](../account/10-web-api.md) 계좌 전용 엔드포인트 목록 (정정 완료)
+  - [../account/13-cross-module-notes.md](../account/13-cross-module-notes.md) Web API 런타임 허용 엔드포인트 나열 (정정 완료)
+  - [../account/02-design-decisions.md](../account/02-design-decisions.md) D-ACC-07 런타임 중 허용 표 — CLI(`account credentials`)는 보존하고 Web API 컬럼만 "미제공"으로 표시 (정정 완료)
+  - 실제 인증정보 마스킹 조회는 CLI `account credentials`만 제공한다. Web API 구현이 필요해지면 별도 follow-up 이슈로 추가한다.
+- `PATCH /api/strategies/{strategy_id}/status` — 코드에 있으나 spec 표에 없음 → spec 표에 추가.

--- a/docs/specs/web-api/README.md
+++ b/docs/specs/web-api/README.md
@@ -22,3 +22,4 @@
 | [08-pydantic-schemas.md](08-pydantic-schemas.md) | Pydantic 스키마 목록 |
 | [09-public-paths.md](09-public-paths.md) | default-deny 게이트 면제 공개 경로 allowlist (PUBLIC_PATHS / PUBLIC_PREFIXES) |
 | [10-cross-module-notes.md](10-cross-module-notes.md) | 타 모듈 설계 시 참고 |
+| [11-route-scope-table.md](11-route-scope-table.md) | 70 라우트 scope 결정 SSOT (Epic #1401, #1407 인용 대상) |

--- a/src/ante/web/middleware/require_auth.py
+++ b/src/ante/web/middleware/require_auth.py
@@ -48,6 +48,7 @@ PUBLIC_PATHS: frozenset[str] = frozenset(
         "/api/system/health",
         "/api/auth/login",
         "/api/auth/logout",
+        "/api/reports/schema",
         "/openapi.json",
         "/docs",
         "/redoc",

--- a/tests/unit/test_require_auth_middleware.py
+++ b/tests/unit/test_require_auth_middleware.py
@@ -202,6 +202,19 @@ class TestPublicPaths:
         resp = client.get("/openapi.json")
         assert resp.status_code == 200
 
+    def test_public_path_reports_schema(self, client: TestClient) -> None:
+        """``/api/reports/schema`` PUBLIC → 인증 없이 200.
+
+        spec 09-public-paths.md L48: 리포트 제출 폼 스키마(필드명 + 예시).
+        비밀값 없음. 클라이언트가 폼 렌더링용으로 사용.
+        ``/api/data/schema``(data:read scope 필요)와 구별된다.
+
+        SSOT drift 회귀 보호: 본 케이스가 401이 되면 PUBLIC_PATHS 에서
+        ``/api/reports/schema`` 가 빠진 것이다.
+        """
+        resp = client.get("/api/reports/schema")
+        assert resp.status_code == 200
+
     def test_public_prefix_assets_passes(self, client: TestClient) -> None:
         """``/assets/*`` PUBLIC prefix → 인증 없이 200 또는 404 (자산 미존재).
 


### PR DESCRIPTION
Closes #1409

Epic #1401의 70-route scope 결정 SSOT 작성. #1402 spec/decision + #1403 미들웨어 머지 후 #1407 마이그레이션 SSOT.

## Summary
- `docs/specs/web-api/11-route-scope-table.md` (신규) — 14 모듈 × 70 라우트 row 단위 결정 표
  - 17 부착 + 48 scope 미부착 (#1407 대상) + 5 면제 (public 4 + gate-exempt-self-auth 1)
  - 카테고리: `public` / `gate-exempt-self-auth` / `<scope>`
  - 사용 scope 15종 모두 `docs/specs/member/02-design-decisions.md` 도메인 vocabulary 정합 — 신규 scope 도입 없음
- `docs/specs/web-api/09-public-paths.md`: PUBLIC_PATHS에 `/api/reports/schema` 추가, 결정 보류 섹션을 "결정/결정 출처" 표로 교체
- `docs/specs/web-api/05-resource-endpoints.md`: spec/code drift 2건 정정 (`/api/accounts/{id}/credentials` 제거, `PATCH /api/strategies/{id}/status` 추가)
- `docs/specs/web-api/README.md`: 신규 11- 문서 인덱스
- `docs/specs/account/02-design-decisions.md`, `10-web-api.md`, `13-cross-module-notes.md`: credentials drift 정정 (Web API 컬럼 "미제공", CLI는 보존)
- `src/ante/web/middleware/require_auth.py`: PUBLIC_PATHS에 `/api/reports/schema` 1줄 추가 (spec/code 동기화)
- `tests/unit/test_require_auth_middleware.py`: `/api/reports/schema` PUBLIC 회귀 케이스 추가

## 경계 케이스 결정
- `/api/system/status` → `system:read` (스펙 system 도메인 정합, 모니터링도 인증 토큰 사용; `/api/system/health`만 public)
- `/api/reports/schema` → `public` (API 메타데이터, `/api/data/schema → data:read`와 구별)
- `/api/auth/me` → `gate-exempt-self-auth` (미들웨어 면제 + 라우트 self-auth)

## 13 master-only 라우트 마이그레이션
spec 표가 이상적인 scope 명시 (예: `account:write`, `bot:admin`, `treasury:admin`, `member:admin`, `rule:admin`, `system:admin`, `config:write`). 실제 코드는 현재 `require_master_caller` → #1407에서 `require_scope("<scope>")`로 마이그레이션.

## Test Plan
- [x] `git diff main -- src/ tests/ frontend/ config/`: 1줄 코드 추가 (PUBLIC_PATHS sync) + 1개 회귀 테스트
- [x] `pytest tests/unit/test_require_auth_middleware.py -q` → 24 passed (PUBLIC_PATHS exact match 회귀 + reports/schema 신규)
- [x] 70개 row 모두 명시, scope 15종 모두 spec vocabulary 정합
- [x] 17개 부착 dependency가 표 결정과 일치 (코드 grep cross-check)

## Codex 브랜치 리뷰 (4라운드)
3라운드 정정 후 4라운드 PASS:
- 1차: P2 48 vs 53 분리, PUBLIC SSOT 정합
- 2차: P2 코드 PUBLIC_PATHS 동기화
- 3차: P2 account spec credentials drift 정정
- 4차: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)