### PR TITLE
test: 라우트 인증 정적 검증 + PUBLIC_PATHS 회귀 테스트 (#1405)

### DIFF
--- a/src/ante/web/deps.py
+++ b/src/ante/web/deps.py
@@ -780,3 +780,21 @@ async def require_strategy_write(
         )
 
     return caller
+
+
+# ── 인증 dependency 정적 검증 marker (#1405) ───────────────────────────────
+#
+# ``tests/unit/test_route_auth_coverage.py`` 는 17개 currently-attached 라우트
+# (ATTACHED_ROUTE_ALLOWLIST) 가 본 모듈의 인증 dependency 중 하나에 의해
+# 보호되는지 정적으로 회귀 검증한다. 검증 helper ``_has_auth_marker`` 는
+# FastAPI Dependant 트리를 walk 하면서 각 dependency callable 의
+# ``_is_authentication_dependency`` 속성을 확인한다.
+#
+# 새 인증 dependency 를 추가할 때 본 marker 도 함께 부착해야 정적 검증이
+# 새 가드를 인식한다. 부착이 누락되면 #1405 회귀 테스트가 해당 라우트를
+# "marker 없음" 으로 보고 실패시킨다.
+require_master_caller._is_authentication_dependency = True  # type: ignore[attr-defined]
+require_audit_read._is_authentication_dependency = True  # type: ignore[attr-defined]
+require_config_write._is_authentication_dependency = True  # type: ignore[attr-defined]
+require_report_write._is_authentication_dependency = True  # type: ignore[attr-defined]
+require_strategy_write._is_authentication_dependency = True  # type: ignore[attr-defined]

--- a/tests/unit/test_public_paths_spec_match.py
+++ b/tests/unit/test_public_paths_spec_match.py
@@ -1,0 +1,223 @@
+"""09-public-paths.md SSOT 와 코드 상수 drift 회귀 검증 (#1405).
+
+spec ``docs/specs/web-api/09-public-paths.md`` 는 default-deny 인증 게이트의
+면제 경로 SSOT 다. 본 테스트는 그 spec 의 두 표 (PUBLIC_PATHS 정확 일치,
+PUBLIC_PREFIXES 접두어 일치) 와 ``gate-exempt-self-auth`` 카테고리 행을
+파싱해, 코드 (``src/ante/web/middleware/require_auth.py``) 상수와 정확히
+일치하는지 검사한다.
+
+회귀 시 nightmare 시나리오:
+    - spec 에 PUBLIC_PATHS 행을 추가했는데 코드 상수에 반영을 빠뜨려, 의도된
+      공개 라우트가 default-deny 로 401 차단되는 회귀.
+    - 반대로 코드에서 PUBLIC_PATHS 에 새 경로를 몰래 추가했는데 spec 에는
+      등록하지 않아 게이트 면제 의도가 문서화되지 않는 drift.
+    - ``gate-exempt-self-auth`` 카테고리가 spec 에서 사라졌는데 코드 상수가
+      남아 있어 self-auth 라우트가 게이트 없이 통과되는 회귀.
+
+본 테스트는 spec 표 파싱에 fail-loud 정책을 적용한다 (표가 비어 있거나
+형식이 깨졌으면 즉시 실패). spec 변경 시 본 파서도 함께 갱신해야 한다.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_SPEC_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "docs"
+    / "specs"
+    / "web-api"
+    / "09-public-paths.md"
+)
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+_BACKTICK = re.compile(r"`([^`]+)`")
+
+
+def _strip_backticks(cell: str) -> str:
+    """마크다운 셀에서 ```...``` 백틱을 제거하고 inner 텍스트만 반환.
+
+    셀이 ``` `/api/foo` `` 형태면 ``/api/foo`` 를 반환. 백틱이 없으면 셀
+    raw 그대로 strip 하여 반환.
+    """
+    match = _BACKTICK.search(cell)
+    if match is None:
+        return cell.strip()
+    return match.group(1).strip()
+
+
+def _parse_table_rows(
+    lines: list[str], header_match: str
+) -> list[tuple[str, str, str]]:
+    """spec 의 한 테이블에서 (col1, col2, col3) 데이터 행을 추출.
+
+    Args:
+        lines: spec 파일 라인 리스트.
+        header_match: 헤더 행에서 식별자로 쓸 부분 문자열
+            (예: ``"| 경로 | 카테고리 |"``). 이 부분을 포함하는 헤더 행을
+            찾으면, 그 다음 ``|---|---|---|`` 구분 행을 건너뛰고, ``|`` 로
+            시작하지 않는 행을 만날 때까지 데이터 행을 수집한다.
+
+    Returns:
+        (col1, col2, col3) 튜플 리스트. col1 은 ``_strip_backticks`` 로
+        백틱을 제거한 상태. col2, col3 은 raw strip.
+    """
+    rows: list[tuple[str, str, str]] = []
+    in_table = False
+    seen_separator = False
+    for line in lines:
+        stripped = line.strip()
+        if not in_table:
+            if header_match in stripped:
+                in_table = True
+                seen_separator = False
+            continue
+        # 헤더 다음 라인은 ``|---|...|`` separator.
+        if not seen_separator:
+            if stripped.startswith("|") and set(stripped.replace("|", "").strip()) <= {
+                "-",
+                " ",
+                ":",
+            }:
+                seen_separator = True
+                continue
+            # separator 가 아닌 다른 라인이 먼저 오면 표 형식이 깨진 것.
+            pytest.fail(
+                f"spec 09-public-paths.md 의 '{header_match}' 표 separator 가 "
+                "예상 위치에 없음. spec 파싱 동기화 필요."
+            )
+        # 표 종료 조건: ``|`` 로 시작하지 않는 행 (빈 줄 포함).
+        if not stripped.startswith("|"):
+            break
+        # 데이터 행 파싱. 앞뒤 ``|`` 제거 후 split.
+        # 일부 셀에 escape 된 ``\|`` 가 들어갈 가능성은 본 spec 범위 밖이므로
+        # naive split 으로 충분.
+        parts = [p.strip() for p in stripped.strip("|").split("|")]
+        if len(parts) < 3:
+            pytest.fail(
+                f"spec 09-public-paths.md 의 '{header_match}' 표 행 컬럼 수 부족: "
+                f"{stripped!r}"
+            )
+        col1 = _strip_backticks(parts[0])
+        col2 = parts[1]
+        col3 = parts[2]
+        rows.append((col1, col2, col3))
+    if not in_table:
+        pytest.fail(
+            f"spec 09-public-paths.md 에서 헤더 '{header_match}' 표를 찾지 못함."
+        )
+    if not rows:
+        pytest.fail(
+            f"spec 09-public-paths.md 의 '{header_match}' 표 데이터 행이 비어 있음."
+        )
+    return rows
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def spec_lines() -> list[str]:
+    if not _SPEC_PATH.is_file():
+        pytest.fail(f"spec 파일을 찾지 못함: {_SPEC_PATH}")
+    return _SPEC_PATH.read_text(encoding="utf-8").splitlines()
+
+
+# ── tests ──────────────────────────────────────────────────────────────────
+
+
+def test_public_paths_match_spec(spec_lines: list[str]) -> None:
+    """``PUBLIC_PATHS`` 정확 일치 + ``GATE_EXEMPT_SELF_AUTH_PATHS`` 행이 spec
+    "PUBLIC_PATHS (정확 일치)" 표 와 일치한다.
+
+    spec 표는 ``public`` 카테고리 행과 ``gate-exempt-self-auth`` 카테고리 행을
+    한 표에서 분리하므로, 본 테스트도 카테고리 컬럼으로 분기해 비교한다.
+    """
+    from ante.web.middleware.require_auth import (
+        GATE_EXEMPT_SELF_AUTH_PATHS,
+        PUBLIC_PATHS,
+    )
+
+    rows = _parse_table_rows(spec_lines, "| 경로 | 카테고리 |")
+
+    spec_public: set[str] = set()
+    spec_gate_exempt: set[str] = set()
+    unknown_category: list[tuple[str, str]] = []
+    for path, category, _ in rows:
+        cat = category.strip()
+        if cat == "public":
+            spec_public.add(path)
+        elif cat == "gate-exempt-self-auth":
+            spec_gate_exempt.add(path)
+        else:
+            unknown_category.append((path, cat))
+
+    if unknown_category:
+        pytest.fail(
+            "spec 09-public-paths.md 의 PUBLIC_PATHS 표에 알 수 없는 카테고리: "
+            f"{unknown_category}. 본 파서 또는 spec 갱신 필요."
+        )
+
+    if spec_public != set(PUBLIC_PATHS):
+        only_in_spec = sorted(spec_public - set(PUBLIC_PATHS))
+        only_in_code = sorted(set(PUBLIC_PATHS) - spec_public)
+        pytest.fail(
+            "PUBLIC_PATHS 코드 상수와 09-public-paths.md SSOT drift 발생:\n"
+            f"  spec only (코드 누락): {only_in_spec}\n"
+            f"  code only (spec 누락): {only_in_code}"
+        )
+
+    if spec_gate_exempt != set(GATE_EXEMPT_SELF_AUTH_PATHS):
+        only_in_spec = sorted(spec_gate_exempt - set(GATE_EXEMPT_SELF_AUTH_PATHS))
+        only_in_code = sorted(set(GATE_EXEMPT_SELF_AUTH_PATHS) - spec_gate_exempt)
+        pytest.fail(
+            "GATE_EXEMPT_SELF_AUTH_PATHS 코드 상수와 09-public-paths.md SSOT "
+            "drift 발생:\n"
+            f"  spec only (코드 누락): {only_in_spec}\n"
+            f"  code only (spec 누락): {only_in_code}"
+        )
+
+
+def test_public_prefixes_match_spec(spec_lines: list[str]) -> None:
+    """``PUBLIC_PREFIXES`` 접두어 튜플이 spec "PUBLIC_PREFIXES (접두어 일치)"
+    표 와 일치한다.
+
+    spec 은 ``/assets/*`` 형식으로 wildcard 표기, 코드는 ``/assets/`` 처럼
+    trailing slash 가 명시된 prefix 를 사용한다. 비교를 위해 spec 항목 끝의
+    ``*`` 를 제거해 normalize 한다.
+    """
+    from ante.web.middleware.require_auth import PUBLIC_PREFIXES
+
+    rows = _parse_table_rows(spec_lines, "| 접두어 | 카테고리 |")
+
+    spec_prefixes: set[str] = set()
+    for prefix, category, _ in rows:
+        # spec 은 ``/assets/*`` 표기. trailing ``*`` 만 normalize 한다.
+        normalized = prefix.rstrip("*")
+        if not normalized.endswith("/"):
+            pytest.fail(
+                "spec 09-public-paths.md PUBLIC_PREFIXES 표의 접두어가 trailing "
+                f"slash 로 끝나지 않음: {prefix!r}. 코드 상수와 정합 불가."
+            )
+        spec_prefixes.add(normalized)
+        # 카테고리가 ``public`` 이외이면 본 파서 가정이 깨진 것.
+        if category.strip() != "public":
+            pytest.fail(
+                "spec 09-public-paths.md PUBLIC_PREFIXES 표에 ``public`` 이외 "
+                f"카테고리 항목 발견: {prefix!r} → {category!r}. 본 테스트 갱신 필요."
+            )
+
+    if spec_prefixes != set(PUBLIC_PREFIXES):
+        only_in_spec = sorted(spec_prefixes - set(PUBLIC_PREFIXES))
+        only_in_code = sorted(set(PUBLIC_PREFIXES) - spec_prefixes)
+        pytest.fail(
+            "PUBLIC_PREFIXES 코드 상수와 09-public-paths.md SSOT drift 발생:\n"
+            f"  spec only (코드 누락): {only_in_spec}\n"
+            f"  code only (spec 누락): {only_in_code}"
+        )

--- a/tests/unit/test_route_auth_coverage.py
+++ b/tests/unit/test_route_auth_coverage.py
@@ -1,0 +1,211 @@
+"""라우트 인증 dependency 정적 회귀 검증 (#1405).
+
+본 테스트는 두 invariant 를 정적으로 잠근다.
+
+CASE 1 — ``ATTACHED_ROUTE_ALLOWLIST`` marker 회귀:
+    현재 ``src/ante/web/routes/`` 에서 ``Depends(require_*)`` 로 인증 가드가
+    부착된 17개 mutation 라우트가, 본 PR 시점의 SSOT(11-route-scope-table.md
+    "결정 scope" 컬럼) 와 정합한 상태로 ``src/ante/web/deps.py`` 의
+    ``_is_authentication_dependency = True`` marker 가 붙은 dependency 에 의해
+    보호되고 있음을 확인한다.
+
+    회귀 시 nightmare 시나리오:
+        - 라우트에서 ``Depends(require_*)`` 인자가 사라져도 ``app.routes`` 에는
+          여전히 등록돼 있어, 통합 테스트가 happy-path 만 검사하면 인증
+          누락이 발견되지 않을 수 있다.
+        - dependency 함수가 ``_is_authentication_dependency`` marker 없이
+          rename / refactor 되면 본 정적 회귀가 marker 부재로 즉시 실패한다.
+
+CASE 2 — ``PUBLIC_PATHS`` ∪ ``GATE_EXEMPT_SELF_AUTH_PATHS`` 의 ``/api/*``
+   항목이 실제로 ``app.routes`` 에 등록되어 있는지 sanity 검증:
+    ``/api/*`` 면제 경로는 라우트가 응답을 만들어야 의미가 있다. 코드 상
+    경로 오타(예: ``/api/auht/me``)나 라우트 삭제가 spec/code drift 로
+    이어지면 본 sanity 가 실패해 즉시 차단한다.
+
+본 테스트는 SSOT 와 직접 비교하지 않고 (CASE 1 의 ALLOWLIST 는 #1407 마이그
+레이션 전까지 부착이 narrow 한 상태이므로) "현재 부착된 라우트가 marker 로
+이어지는지" 만 검증한다. #1407 이후 narrow allowlist 가 제거되고 모든
+``/api/*`` 라우트가 enforce 되면, 본 파일을 제거하고 통합 검증으로 교체한다.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from fastapi.dependencies.models import Dependant
+
+
+# ── CASE 1 SSOT ────────────────────────────────────────────────────────────
+#
+# 본 시점 (#1405) 에 ``Depends(require_*)`` 로 인증 가드가 실제 부착된
+# (method, path) 17개. 11-route-scope-table.md "결정 scope" 컬럼과 정합 확인.
+# scope 문자열은 documentation purpose (가독성) 만이며, 본 테스트는
+# marker 부착 여부만 검증한다 (#1407 이 scope 기반 마이그레이션을 담당).
+ATTACHED_ROUTE_ALLOWLIST: dict[tuple[str, str], str] = {
+    # config
+    ("PUT", "/api/config/{key:path}"): "config:write",
+    # system (master-only)
+    ("POST", "/api/system/halt"): "system:admin",
+    ("POST", "/api/system/clear-halt"): "system:admin",
+    # audit
+    ("GET", "/api/audit"): "audit:read",
+    # members (master-only)
+    ("PATCH", "/api/members/{member_id}/password"): "member:admin",
+    # strategies
+    ("PATCH", "/api/strategies/{strategy_id}/status"): "strategy:write",
+    # accounts (master-only)
+    ("PUT", "/api/accounts/{account_id}"): "account:admin",
+    ("POST", "/api/accounts/{account_id}/suspend"): "account:admin",
+    ("POST", "/api/accounts/{account_id}/activate"): "account:admin",
+    ("PUT", "/api/accounts/{account_id}/rules/{rule_type}"): "rule:admin",
+    # bots (master-only)
+    ("POST", "/api/bots"): "bot:admin",
+    ("DELETE", "/api/bots/{bot_id}"): "bot:admin",
+    ("PUT", "/api/bots/{bot_id}"): "bot:admin",
+    # reports
+    ("POST", "/api/reports"): "report:write",
+    # treasury (master-only)
+    ("POST", "/api/treasury/bots/{bot_id}/allocate"): "treasury:write",
+    ("POST", "/api/treasury/bots/{bot_id}/deallocate"): "treasury:write",
+    ("POST", "/api/treasury/balance"): "treasury:write",
+}
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _walk_dependants(dep: Dependant) -> Iterator[Dependant]:
+    """FastAPI Dependant 트리 (루트 + sub-dependants) 를 깊이 우선 walk."""
+    yield dep
+    for sub in dep.dependencies:
+        yield from _walk_dependants(sub)
+
+
+def _has_auth_marker(route: object) -> bool:
+    """라우트의 Dependant 트리에 ``_is_authentication_dependency = True``
+    marker 가 부착된 callable 이 하나라도 존재하면 True.
+
+    인증 dependency 가 ``functools.wraps`` / decorator 로 한 단계 wrap 된 경우도
+    ``__wrapped__`` 를 따라 marker 를 탐색한다.
+    """
+    dependant = getattr(route, "dependant", None)
+    if dependant is None:
+        return False
+    for dep in _walk_dependants(dependant):
+        call = getattr(dep, "call", None)
+        if call is None:
+            continue
+        if getattr(call, "_is_authentication_dependency", False):
+            return True
+        wrapped = getattr(call, "__wrapped__", None)
+        while wrapped is not None:
+            if getattr(wrapped, "_is_authentication_dependency", False):
+                return True
+            wrapped = getattr(wrapped, "__wrapped__", None)
+    return False
+
+
+def _route_keys(route: object) -> Iterator[tuple[str, str]]:
+    """FastAPI ``APIRoute`` 의 ``(method, path)`` 키 시퀀스를 yield.
+
+    ``methods`` 가 여러 개면 각 method 마다 한 번씩 yield 한다.
+    """
+    path = getattr(route, "path", None)
+    methods = getattr(route, "methods", None) or set()
+    if path is None:
+        return
+    for method in methods:
+        yield method.upper(), path
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def app_routes() -> list[object]:
+    """services 없이 ``create_app`` 으로 만든 빈 앱의 라우트 리스트.
+
+    인증 dependency 는 ``app.state`` 의 ``member_service`` / ``session_service``
+    가 없어도 Dependant 트리 자체는 그대로 구성되므로 marker 정적 검증에는
+    충분하다.
+    """
+    from fastapi.routing import APIRoute
+
+    from ante.web.app import create_app
+
+    app = create_app()
+    return [r for r in app.routes if isinstance(r, APIRoute)]
+
+
+# ── CASE 1 ─────────────────────────────────────────────────────────────────
+
+
+def test_attached_routes_have_auth_marker(app_routes: list[object]) -> None:
+    """ALLOWLIST 의 17개 (method, path) 가 모두 marker 부착 dependency 로
+    보호되어 있다."""
+    # ``app.routes`` 에서 (method, path) → route 객체로 인덱싱.
+    index: dict[tuple[str, str], object] = {}
+    for route in app_routes:
+        for key in _route_keys(route):
+            index[key] = route
+
+    missing_routes: list[tuple[str, str]] = []
+    missing_marker: list[tuple[str, str]] = []
+    for key in ATTACHED_ROUTE_ALLOWLIST:
+        route = index.get(key)
+        if route is None:
+            missing_routes.append(key)
+            continue
+        if not _has_auth_marker(route):
+            missing_marker.append(key)
+
+    if missing_routes:
+        pytest.fail(
+            "ATTACHED_ROUTE_ALLOWLIST 에 등록된 라우트가 app.routes 에서 "
+            f"발견되지 않음 (spec/code drift): {missing_routes}"
+        )
+    if missing_marker:
+        pytest.fail(
+            "ATTACHED_ROUTE_ALLOWLIST 에 등록된 라우트가 "
+            "_is_authentication_dependency marker 가 부착된 dependency 로 "
+            f"보호되지 않음 (marker 회귀): {missing_marker}"
+        )
+
+
+# ── CASE 2 ─────────────────────────────────────────────────────────────────
+
+
+def test_public_and_gate_exempt_api_paths_are_registered(
+    app_routes: list[object],
+) -> None:
+    """``PUBLIC_PATHS`` ∪ ``GATE_EXEMPT_SELF_AUTH_PATHS`` 중 ``/api/*`` 항목이
+    실제 ``app.routes`` 에 라우트로 등록되어 있다.
+
+    비-``/api`` 항목 (``/``, ``/index.html``, ``/openapi.json``, ``/docs``,
+    ``/redoc``, ``/assets/*``) 은 FastAPI 가 동적으로 제공하거나 정적 마운트로
+    처리되어 ``APIRoute`` 에 나타나지 않으므로 검증 대상에서 제외한다.
+    """
+    from ante.web.middleware.require_auth import (
+        GATE_EXEMPT_SELF_AUTH_PATHS,
+        PUBLIC_PATHS,
+    )
+
+    registered_paths: set[str] = {
+        getattr(route, "path")
+        for route in app_routes  # noqa: B009
+    }
+
+    api_paths_to_check: set[str] = {
+        p for p in (PUBLIC_PATHS | GATE_EXEMPT_SELF_AUTH_PATHS) if p.startswith("/api/")
+    }
+
+    missing = sorted(p for p in api_paths_to_check if p not in registered_paths)
+    if missing:
+        pytest.fail(
+            "PUBLIC_PATHS / GATE_EXEMPT_SELF_AUTH_PATHS 의 /api/* 항목이 "
+            f"app.routes 에 등록되어 있지 않음 (spec/code drift): {missing}"
+        )


### PR DESCRIPTION
## Summary
- narrow-scope 정적 검증 도입 (#1405): 17 currently-attached 라우트 marker 회귀 + PUBLIC_PATHS/PREFIXES/GATE_EXEMPT_SELF_AUTH_PATHS spec↔code drift
- 5개 dependency 함수에 `_is_authentication_dependency = True` marker 부착

## Implementation notes
- ATTACHED_ROUTE_ALLOWLIST를 실제 부착 코드 + 11-route-scope-table.md SSOT 정합 확인하여 17개 정정 (initial plan 예시의 path drift 6건 정정)
- CASE 1: 17 (method, path) allowlist marker 회귀
- CASE 2: PUBLIC + GATE_EXEMPT `/api/*` 등록 sanity

## Test plan
- [x] `pytest tests/unit/test_route_auth_coverage.py tests/unit/test_public_paths_spec_match.py -q`
- [x] `pytest tests/unit -k "auth or middleware" -q` 회귀

## Codex Plan Review
- verdict: approve-implement (round 6/6)
- session: 019e177d-9c37-70d1-9fbb-a89315b0325f

## Follow-up
- post-#1407: 17-route allowlist 제거 + 모든 `/api/*` 라우트 enforce

Closes #1405

🤖 Generated with Claude Code