### PR TITLE
feat: 70개 Web 라우트 scope 결정 일관 부착 (#1407)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -12,7 +12,7 @@
           "accounts"
         ],
         "summary": "List Accounts",
-        "description": "계좌 목록 조회.",
+        "description": "계좌 목록 조회. 인증된 master/human 또는 ``account:read`` scope 를 보유한\nagent 만 호출 가능 (#1407).",
         "operationId": "list_accounts_api_accounts_get",
         "parameters": [
           {
@@ -60,7 +60,7 @@
           "accounts"
         ],
         "summary": "Create Account",
-        "description": "계좌 생성.\n\n런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.\n실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로\n수행한다.\n\n의존성/Pydantic body schema/audit logger를 모두 시그니처에서 제외해\n핸들러 진입 즉시 409가 반환되도록 한다(invariant I1). OpenAPI에는\nsuccess contract(200/201/204)가 노출되지 않으며, 409 응답은 명시\n``responses[409]`` content map의 ``application/problem+json``으로\n``ErrorResponse``를 노출한다(invariant I2/I3, #1164).\n\n이 경로의 service-layer 회귀 보호는 ``tests/unit/test_account.py``가\n담당한다.\n\n본 PR(#1143)에서 OpenAPI requestBody schema가 spec-aligned\n``ACCOUNT_CREATE_REQUEST_SCHEMA``로 노출되어 codegen 클라이언트가\ncold-path payload 필드를 발견할 수 있게 됐다. 런타임은 어떤 body든\n무시하고 409를 반환한다.",
+        "description": "계좌 생성. 인증된 master/human 또는 ``account:write`` scope 를 보유한\nagent 만 호출 가능 (#1407).\n\n런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.\n실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로\n수행한다.\n\n의존성/Pydantic body schema/audit logger를 모두 시그니처에서 제외해\n핸들러 진입 즉시 409가 반환되도록 한다(invariant I1). OpenAPI에는\nsuccess contract(200/201/204)가 노출되지 않으며, 409 응답은 명시\n``responses[409]`` content map의 ``application/problem+json``으로\n``ErrorResponse``를 노출한다(invariant I2/I3, #1164).\n\n이 경로의 service-layer 회귀 보호는 ``tests/unit/test_account.py``가\n담당한다.\n\n본 PR(#1143)에서 OpenAPI requestBody schema가 spec-aligned\n``ACCOUNT_CREATE_REQUEST_SCHEMA``로 노출되어 codegen 클라이언트가\ncold-path payload 필드를 발견할 수 있게 됐다. 런타임은 어떤 body든\n무시하고 409를 반환한다.",
         "operationId": "create_account_api_accounts_post",
         "responses": {
           "409": {
@@ -184,7 +184,7 @@
           "accounts"
         ],
         "summary": "Get Account",
-        "description": "계좌 상세 조회.",
+        "description": "계좌 상세 조회. 인증된 master/human 또는 ``account:read`` scope 를 보유한\nagent 만 호출 가능 (#1407).",
         "operationId": "get_account_api_accounts__account_id__get",
         "parameters": [
           {
@@ -225,7 +225,7 @@
           "accounts"
         ],
         "summary": "Update Account",
-        "description": "계좌 수정.\n\n인증된 master 호출자만 사용할 수 있다(이슈 #1352 — oracle A7). dependency\n``require_master_caller``가 인증/권한 검증을 담당하며, 401/403은 raw body\n파싱과 cold-path 가드(invariant I1/I4)보다 먼저 평가된다 — Bearer 또는\n``ante_session`` 쿠키 어느 쪽으로도 caller가 결정되지 않으면 401, master가\n아니면 403.\n\n런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도\n포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path\n응답과 ``AccountDeletedError`` 경로의 409를 구분한다.\n\nbody는 raw bytes로 받는다(``request.body()``). FastAPI 선행 Pydantic\n검증을 거치면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가\nstructural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.\n\n핸들러 단계 순서(이슈 #1153 + #1152 Implementation Plan):\n\n1. raw bytes 읽기.\n2. **빈 body**(``b\"\"``) → ``payload = {}``로 두고 Content-Type 검사·JSON\n   파싱 모두 건너뛰고 mutable 단계까지 흘려보낸다(단계 6에서 422로 처리).\n3. **JSON 파싱 실패**: Content-Type ≠ application/json → 415,\n   Content-Type 정상 → 422.\n4. **non-dict JSON**: Content-Type ≠ application/json → 415,\n   Content-Type 정상 → 422.\n5. **structural 가드(I4 우선)**: dict payload에 structural 키 존재 → 409\n   (Content-Type 무관, structural+text/plain도 409).\n6. ``len(payload) == 0`` (``{}`` 명시 송신 또는 빈 body) → 422 no-op\n   (Content-Type 검사 건너뜀; #1152 정렬 완료 — schema의\n   ``minProperties: 1``과 정합).\n7. **Content-Type 415 게이트**: ``application/json``(charset suffix 허용)\n   이외 → 415.\n8. **unknown 키 / mutable type**: structural 제외한 raw dict의 unknown\n   키 → 422. ``AccountUpdateRequest.model_validate`` ValidationError → 422.\n9. ``model_dump(exclude_none=True)`` 결과 비면 422 (예: ``{\"name\": null}``\n   단독 — effective payload empty no-op; #1152 정렬 완료).\n10. service 호출.",
+        "description": "계좌 수정.\n\n인증된 master/human 또는 ``account:write`` scope 를 보유한 agent 만 호출\n가능 (#1407 — spec ``account:write`` 정합, #1352 master_caller 에서\n마이그레이션). dependency ``require_account_write`` 가 인증/권한 검증을\n담당하며, 401/403은 raw body 파싱과 cold-path 가드(invariant I1/I4)보다\n먼저 평가된다 — Bearer 또는 ``ante_session`` 쿠키 어느 쪽으로도 caller가\n결정되지 않으면 401, 권한 없으면 403.\n\n런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도\n포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path\n응답과 ``AccountDeletedError`` 경로의 409를 구분한다.\n\nbody는 raw bytes로 받는다(``request.body()``). FastAPI 선행 Pydantic\n검증을 거치면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가\nstructural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.\n\n핸들러 단계 순서(이슈 #1153 + #1152 Implementation Plan):\n\n1. raw bytes 읽기.\n2. **빈 body**(``b\"\"``) → ``payload = {}``로 두고 Content-Type 검사·JSON\n   파싱 모두 건너뛰고 mutable 단계까지 흘려보낸다(단계 6에서 422로 처리).\n3. **JSON 파싱 실패**: Content-Type ≠ application/json → 415,\n   Content-Type 정상 → 422.\n4. **non-dict JSON**: Content-Type ≠ application/json → 415,\n   Content-Type 정상 → 422.\n5. **structural 가드(I4 우선)**: dict payload에 structural 키 존재 → 409\n   (Content-Type 무관, structural+text/plain도 409).\n6. ``len(payload) == 0`` (``{}`` 명시 송신 또는 빈 body) → 422 no-op\n   (Content-Type 검사 건너뜀; #1152 정렬 완료 — schema의\n   ``minProperties: 1``과 정합).\n7. **Content-Type 415 게이트**: ``application/json``(charset suffix 허용)\n   이외 → 415.\n8. **unknown 키 / mutable type**: structural 제외한 raw dict의 unknown\n   키 → 422. ``AccountUpdateRequest.model_validate`` ValidationError → 422.\n9. ``model_dump(exclude_none=True)`` 결과 비면 422 (예: ``{\"name\": null}``\n   단독 — effective payload empty no-op; #1152 정렬 완료).\n10. service 호출.",
         "operationId": "update_account_api_accounts__account_id__put",
         "parameters": [
           {
@@ -270,7 +270,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master 권한 필요)",
+            "description": "Permission denied (master, human 멤버 또는 account:write scope 보유 agent 만 허용)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -370,7 +370,7 @@
           "accounts"
         ],
         "summary": "Delete Account",
-        "description": "계좌 소프트 딜리트.\n\n런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.\n실제 계좌 삭제는 서버 정지 상태에서 ``ante account delete`` CLI로\n수행한다.\n\n의존성/audit logger를 시그니처에서 제외해 핸들러 진입 즉시 409가\n반환되도록 한다(invariant I1). OpenAPI에는 success contract(200/201/\n204)가 노출되지 않으며, 409 응답은 명시 ``responses[409]`` content\nmap의 ``application/problem+json``으로 ``ErrorResponse``를 노출한다\n(invariant I2/I3, #1164). service-layer 회귀 보호는\n``tests/unit/test_account.py``의 ``test_delete_account``,\n``test_delete_already_deleted_account_raises``가 담당한다.",
+        "description": "계좌 소프트 딜리트. 인증된 master/human 또는 ``account:write`` scope 를\n보유한 agent 만 호출 가능 (#1407).\n\n런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.\n실제 계좌 삭제는 서버 정지 상태에서 ``ante account delete`` CLI로\n수행한다.\n\n의존성/audit logger를 시그니처에서 제외해 핸들러 진입 즉시 409가\n반환되도록 한다(invariant I1). OpenAPI에는 success contract(200/201/\n204)가 노출되지 않으며, 409 응답은 명시 ``responses[409]`` content\nmap의 ``application/problem+json``으로 ``ErrorResponse``를 노출한다\n(invariant I2/I3, #1164). service-layer 회귀 보호는\n``tests/unit/test_account.py``의 ``test_delete_account``,\n``test_delete_already_deleted_account_raises``가 담당한다.",
         "operationId": "delete_account_api_accounts__account_id__delete",
         "parameters": [
           {
@@ -413,7 +413,7 @@
           "accounts"
         ],
         "summary": "Suspend Account",
-        "description": "계좌 정지. 인증된 master만 호출 가능 (#1352).\n\n``update_bot`` / ``set_balance`` / ``update_scopes``와 동일한 raw body 파싱\n패턴을 적용해 인증 가드가 body validation보다 먼저 실행되도록 한다(#1352\nCodex review 2차). FastAPI가 ``body: AccountSuspendRequest``를 typed로\n먼저 검증하면 unauth + malformed body 시 401이 아닌 422가 먼저 반환되어\n``update_bot`` / ``set_balance``의 auth-first 계약과 어긋난다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,\n   non-master → 403.\n2. raw bytes 읽기. 빈 body → default reason (``dashboard``)로 흘려보낸다\n   (기존 의미 보존).\n3. JSON 파싱 실패 → 422.\n4. JSON ``null`` (``payload is None``) → 빈 body와 동일하게 default\n   reason 경로로 흘려보낸다 (이전 ``Optional[Body(...)]`` 계약 호환,\n   #1352 Codex review 3차).\n5. ``AccountSuspendRequest.model_validate`` ValidationError(extra forbid\n   포함) → 422.\n6. service 호출.",
+        "description": "계좌 정지. 인증된 master/human 또는 ``account:write`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``account:write`` 정합, #1352\nmaster_caller 에서 마이그레이션).\n\n``update_bot`` / ``set_balance`` / ``update_scopes``와 동일한 raw body 파싱\n패턴을 적용해 인증 가드가 body validation보다 먼저 실행되도록 한다(#1352\nCodex review 2차). FastAPI가 ``body: AccountSuspendRequest``를 typed로\n먼저 검증하면 unauth + malformed body 시 401이 아닌 422가 먼저 반환되어\n``update_bot`` / ``set_balance``의 auth-first 계약과 어긋난다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_account_write)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기. 빈 body → default reason (``dashboard``)로 흘려보낸다\n   (기존 의미 보존).\n3. JSON 파싱 실패 → 422.\n4. JSON ``null`` (``payload is None``) → 빈 body와 동일하게 default\n   reason 경로로 흘려보낸다 (이전 ``Optional[Body(...)]`` 계약 호환,\n   #1352 Codex review 3차).\n5. ``AccountSuspendRequest.model_validate`` ValidationError(extra forbid\n   포함) → 422.\n6. service 호출.",
         "operationId": "suspend_account_api_accounts__account_id__suspend_post",
         "parameters": [
           {
@@ -448,7 +448,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master 권한 필요)",
+            "description": "Permission denied (master, human 멤버 또는 account:write scope 보유 agent 만 허용)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -513,7 +513,7 @@
           "accounts"
         ],
         "summary": "Activate Account",
-        "description": "계좌 재활성화. 인증된 master만 호출 가능 (#1352).",
+        "description": "계좌 재활성화. 인증된 master/human 또는 ``account:write`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``account:write`` 정합, #1352\nmaster_caller 에서 마이그레이션).",
         "operationId": "activate_account_api_accounts__account_id__activate_post",
         "parameters": [
           {
@@ -548,7 +548,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master 권한 필요)",
+            "description": "Permission denied (master, human 멤버 또는 account:write scope 보유 agent 만 허용)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -596,7 +596,7 @@
           "accounts"
         ],
         "summary": "Get Account Rules",
-        "description": "계좌 리스크 룰 목록 조회.\n\nDynamicConfig를 우선 조회하고, 없으면 정적 Config에서 읽는다.\nRULE_REGISTRY에 등록된 룰 타입만 구조화하여 반환한다.",
+        "description": "계좌 리스크 룰 목록 조회. 인증된 master/human 또는 ``rule:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).\n\nDynamicConfig를 우선 조회하고, 없으면 정적 Config에서 읽는다.\nRULE_REGISTRY에 등록된 룰 타입만 구조화하여 반환한다.",
         "operationId": "get_account_rules_api_accounts__account_id__rules_get",
         "parameters": [
           {
@@ -639,7 +639,7 @@
           "accounts"
         ],
         "summary": "Update Account Rule",
-        "description": "계좌 리스크 룰 개별 수정. 인증된 master 만 호출 가능 (#1376).\n\nRULE_REGISTRY에 등록된 타입만 허용하며,\nDynamicConfigService에 위임하여 ConfigChangedEvent를 발행한다.\n\n저장되는 ``accounts.{account_id}.rules`` 값은 explicit overrides(stored\nrules)다. RuleEngine이 실제로 적용하는 effective rules는\n``ante.rule.defaults.resolve_effective_rules``가 broker_type별 defaults와\n이 stored rules를 merge한 결과이며, ``ConfigChangedEvent`` reload 시\n동일 helper가 다시 호출된다. 본 GET/PUT API는 stored rules만 다룬다 —\neffective view는 후속 이슈에서 별도 엔드포인트로 노출한다 (#1296).\n\n``submit_report`` (#1374) / ``halt`` (#1375) 와 동일한 raw body 파싱\n패턴을 적용해 인증 가드가 body validation 보다 우선 실행되도록 한다.\nFastAPI 가 ``body: RuleUpdateRequest`` 를 먼저 검증하면 unauth + bad-body\n시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다 — 본 라우트는\noracle A7 finding 의 핵심 시그니처 이므로 인증 가드 우선이 가장 중요하다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,\n   non-master → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``RuleUpdateRequest.model_validate`` — ValidationError → 422.\n4. RULE_REGISTRY 룰 타입 확인 — 없으면 400 (기존 계약 보존).\n5. RULE_REGISTRY[rule_type].validate_config — 실패 시 422.\n6. DynamicConfig 저장 + audit 기록 (changed_by / member_id = caller_id).",
+        "description": "계좌 리스크 룰 개별 수정. 인증된 master/human 또는 ``rule:admin`` scope\n를 보유한 agent 만 호출 가능 (#1407 — spec ``rule:admin`` 정합, #1376\nmaster_caller 에서 마이그레이션).\n\nRULE_REGISTRY에 등록된 타입만 허용하며,\nDynamicConfigService에 위임하여 ConfigChangedEvent를 발행한다.\n\n저장되는 ``accounts.{account_id}.rules`` 값은 explicit overrides(stored\nrules)다. RuleEngine이 실제로 적용하는 effective rules는\n``ante.rule.defaults.resolve_effective_rules``가 broker_type별 defaults와\n이 stored rules를 merge한 결과이며, ``ConfigChangedEvent`` reload 시\n동일 helper가 다시 호출된다. 본 GET/PUT API는 stored rules만 다룬다 —\neffective view는 후속 이슈에서 별도 엔드포인트로 노출한다 (#1296).\n\n``submit_report`` (#1374) / ``halt`` (#1375) 와 동일한 raw body 파싱\n패턴을 적용해 인증 가드가 body validation 보다 우선 실행되도록 한다.\nFastAPI 가 ``body: RuleUpdateRequest`` 를 먼저 검증하면 unauth + bad-body\n시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다 — 본 라우트는\noracle A7 finding 의 핵심 시그니처 이므로 인증 가드 우선이 가장 중요하다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_rule_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``RuleUpdateRequest.model_validate`` — ValidationError → 422.\n4. RULE_REGISTRY 룰 타입 확인 — 없으면 400 (기존 계약 보존).\n5. RULE_REGISTRY[rule_type].validate_config — 실패 시 422.\n6. DynamicConfig 저장 + audit 기록 (changed_by / member_id = caller_id).",
         "operationId": "update_account_rule_api_accounts__account_id__rules__rule_type__put",
         "parameters": [
           {
@@ -683,7 +683,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master 권한 필요).",
+            "description": "Permission denied (master, human 멤버 또는 rule:admin scope 보유 agent 만 허용).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1028,7 +1028,7 @@
           "approvals"
         ],
         "summary": "Get Approval",
-        "description": "결재 상세 조회.",
+        "description": "결재 상세 조회. 인증된 master/human 또는 ``approval:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
         "operationId": "get_approval_api_approvals__approval_id__get",
         "parameters": [
           {
@@ -1091,7 +1091,7 @@
           "approvals"
         ],
         "summary": "Update Approval Status",
-        "description": "결재 승인/거부 처리.",
+        "description": "결재 승인/거부 처리. 인증된 master/human 또는 ``approval:admin`` scope\n를 보유한 agent 만 호출 가능 (#1407 — spec ``approval:admin`` 정합).\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. FastAPI 가 ``body: ApprovalStatusUpdate`` 를 먼저 검증하면 unauth +\nbad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_approval_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``ApprovalStatusUpdate.model_validate`` — ValidationError → 422.\n4. service 호출 (``approve`` / ``reject``).",
         "operationId": "update_approval_status_api_approvals__approval_id__status_patch",
         "parameters": [
           {
@@ -1104,16 +1104,6 @@
             }
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ApprovalStatusUpdate"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -1135,8 +1125,38 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (master, human 멤버 또는 approval:admin scope 보유 agent 만 허용).",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Approval not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, 필수 필드 누락, type mismatch). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다(#1407).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1151,16 +1171,6 @@
               "application/problem+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1325,7 +1335,7 @@
           "portfolio"
         ],
         "summary": "Portfolio Value",
-        "description": "총 자산 가치 + 당일 손익 + 수익률 + 미실현 손익 (최신 스냅샷 기반).",
+        "description": "총 자산 가치 + 당일 손익 + 수익률 + 미실현 손익 (최신 스냅샷 기반).\n인증된 master/human 또는 ``treasury:read`` scope 를 보유한 agent 만 호출\n가능 (#1407 — portfolio 라우트는 ``treasury_daily_snapshots`` 를 읽으므로\nspec ``treasury:read`` 정합).",
         "operationId": "portfolio_value_api_portfolio_value_get",
         "parameters": [
           {
@@ -1385,7 +1395,7 @@
           "portfolio"
         ],
         "summary": "Portfolio History",
-        "description": "기간별 자산 추이 (daily_snapshots 시계열 반환).",
+        "description": "기간별 자산 추이 (daily_snapshots 시계열 반환). 인증된 master/human 또는\n``treasury:read`` scope 를 보유한 agent 만 호출 가능 (#1407).",
         "operationId": "portfolio_history_api_portfolio_history_get",
         "parameters": [
           {
@@ -1590,7 +1600,7 @@
           "members"
         ],
         "summary": "Create Member",
-        "description": "멤버 등록. 토큰 1회 반환.\n\n인증 가드는 body validation보다 **반드시 먼저** 실행된다(#1339 P2 — Codex\nfinding). FastAPI가 ``body: MemberCreateRequest`` 파라미터를 먼저 파싱하면\nAuthorization 헤더 미존재 + 필수 필드 누락 케이스에서 401이 아니라 422가\n먼저 응답되어 \"missing or invalid Authorization header는 401\" 계약이 깨진다.\n이 이유로 본 라우트는 ``request: Request``만 받고 raw body를 직접 파싱한다\n(``update_account`` SSOT 패턴 일치).\n\n인증 경로는 두 가지를 모두 받는다(#1339 P1 — Codex finding):\n- **Bearer 토큰**: ``TokenAuthMiddleware``가 ``request.state.member_id``를\n  세팅한다. 에이전트 클라이언트(`MCP`, CLI 등)와 ``frontend`` axios의\n  ``Authorization`` 헤더 호출이 이 경로를 탄다.\n- **세션 쿠키**: 대시보드는 패스워드 로그인 후 ``ante_session`` HttpOnly\n  쿠키만 가진 상태로 axios에 ``Authorization`` 헤더를 추가하지 않는다.\n  ``session_service.validate``로 세션 → ``member_id``를 복원한다.\n\n핸들러 단계 순서:\n1. **인증 가드 (최우선)**: token 또는 세션 쿠키 어느 쪽도 caller를 결정\n   하지 못하면 401.\n2. raw bytes 읽고 JSON 파싱 — 실패 시 422.\n3. ``MemberCreateRequest.model_validate`` — ValidationError → 422.\n4. ``svc.register`` 호출. ``PermissionError`` → 403, ``ValueError`` → 400.",
+        "description": "멤버 등록. 토큰 1회 반환. 인증된 master/human 또는 ``member:admin`` scope\n를 보유한 agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).\n\n인증 가드는 body validation보다 **반드시 먼저** 실행된다(#1339 P2). FastAPI\n가 ``body: MemberCreateRequest`` 파라미터를 먼저 파싱하면 Authorization\n헤더 미존재 + 필수 필드 누락 케이스에서 401 이 아니라 422 가 먼저 응답되어\n\"missing or invalid Authorization header는 401\" 계약이 깨진다. 이 이유로\n본 라우트는 ``request: Request`` 와 ``require_member_admin`` 만 받고 raw\nbody 를 직접 파싱한다 (``update_account`` SSOT 패턴 일치).\n\n핸들러 단계 순서:\n1. **인증 가드 (최우선, ``Depends(require_member_admin)``)** — caller 빈\n   → 401, 권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽고 JSON 파싱 — 실패 시 422.\n3. ``MemberCreateRequest.model_validate`` — ValidationError → 422.\n4. ``svc.register`` 호출. ``PermissionError`` → 403, ``ValueError`` → 400.",
         "operationId": "create_member_api_members_post",
         "responses": {
           "201": {
@@ -1672,7 +1682,7 @@
           "members"
         ],
         "summary": "Get Member",
-        "description": "멤버 상세 조회.",
+        "description": "멤버 상세 조회. 인증된 master/human 또는 ``member:read`` scope 를 보유한\nagent 만 호출 가능 (#1407).",
         "operationId": "get_member_api_members__member_id__get",
         "parameters": [
           {
@@ -1735,7 +1745,7 @@
           "members"
         ],
         "summary": "Suspend Member",
-        "description": "멤버 일시 정지. 인증된 master만 호출 가능 (#1351).",
+        "description": "멤버 일시 정지. 인증된 master/human 또는 ``member:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).",
         "operationId": "suspend_member_api_members__member_id__suspend_post",
         "parameters": [
           {
@@ -1818,7 +1828,7 @@
           "members"
         ],
         "summary": "Reactivate Member",
-        "description": "멤버 재활성화. 인증된 master만 호출 가능 (#1351).",
+        "description": "멤버 재활성화. 인증된 master/human 또는 ``member:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).",
         "operationId": "reactivate_member_api_members__member_id__reactivate_post",
         "parameters": [
           {
@@ -1901,7 +1911,7 @@
           "members"
         ],
         "summary": "Revoke Member",
-        "description": "멤버 영구 폐기. 인증된 master만 호출 가능 (#1351).",
+        "description": "멤버 영구 폐기. 인증된 master/human 또는 ``member:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).",
         "operationId": "revoke_member_api_members__member_id__revoke_post",
         "parameters": [
           {
@@ -1984,7 +1994,7 @@
           "members"
         ],
         "summary": "Rotate Token",
-        "description": "토큰 재발급. 인증된 master만 호출 가능 (#1351).\n\n인증 없이 token rotation 응답에 접근하면 token 값 자체가 노출되므로,\n가장 먼저 차단해야 한다.",
+        "description": "토큰 재발급. 인증된 master/human 또는 ``member:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).\n\n인증 없이 token rotation 응답에 접근하면 token 값 자체가 노출되므로,\n가장 먼저 차단해야 한다.",
         "operationId": "rotate_token_api_members__member_id__rotate_token_post",
         "parameters": [
           {
@@ -2067,7 +2077,7 @@
           "members"
         ],
         "summary": "Change Password",
-        "description": "비밀번호 변경 (human 멤버 전용). 인증된 master만 호출 가능 (#1377).\n\n배경: oracle A7 finding (#1377) — 본 라우트는 인증 없이 credential check\n(``svc.change_password``의 old-password 비교) 까지 도달했다. ``_caller_id``\n만으로 audit 주체만 기록하고 인증 가드는 적용하지 않았기 때문이다. 본\n패치는 ``require_master_caller`` 의존성을 적용하고 ``update_scopes``와\n동일한 raw body 파싱 + auth-first 패턴을 따른다 (#1351 / #1352 SSOT).\n\n범위 결정:\n- master-only (보수). self-change use case (caller_id == member_id 허용)는\n  follow-up 이슈에서 별도 다룬다 (Issue #1377 Non-Goals).\n\n인증 → raw-body → credential check 순서를 보장한다. FastAPI가\n``body: PasswordChangeRequest``를 먼저 검증하면 unauth + bad-body 시 401이\n아닌 422가 먼저 반환되어 contract가 깨진다 — 본 라우트는 oracle A7\nfinding의 핵심 시그니처이므로 인증 가드 우선이 가장 중요하다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,\n   non-master → 403. credential check 도달 전에 모두 차단된다.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``PasswordChangeRequest.model_validate`` — ValidationError → 422.\n4. ``svc.change_password`` 호출. ``ValueError`` → 404,\n   ``PermissionError``/``PermissionDeniedError`` → 403.\n\nAudit 로그의 ``member_id``는 ``caller_id``로 기록한다(SSOT). 대상 멤버는\n``resource=member:{member_id}``로 분리해 추적한다.",
+        "description": "비밀번호 변경 (human 멤버 전용). 인증된 master/human 또는\n``member:admin`` scope 를 보유한 agent 만 호출 가능 (#1407 — spec\n``member:admin`` 정합, #1377 master_caller 에서 마이그레이션).\n\n배경: oracle A7 finding (#1377) — 본 라우트는 인증 없이 credential check\n(``svc.change_password``의 old-password 비교) 까지 도달했다. ``_caller_id``\n만으로 audit 주체만 기록하고 인증 가드는 적용하지 않았기 때문이다. 본\n패치는 ``require_master_caller`` 의존성을 적용하고 ``update_scopes``와\n동일한 raw body 파싱 + auth-first 패턴을 따른다 (#1351 / #1352 SSOT).\n\n범위 결정:\n- master-only (보수). self-change use case (caller_id == member_id 허용)는\n  follow-up 이슈에서 별도 다룬다 (Issue #1377 Non-Goals).\n\n인증 → raw-body → credential check 순서를 보장한다. FastAPI가\n``body: PasswordChangeRequest``를 먼저 검증하면 unauth + bad-body 시 401이\n아닌 422가 먼저 반환되어 contract가 깨진다 — 본 라우트는 oracle A7\nfinding의 핵심 시그니처이므로 인증 가드 우선이 가장 중요하다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_member_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403. credential check 도달 전에 모두\n   차단된다.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``PasswordChangeRequest.model_validate`` — ValidationError → 422.\n4. ``svc.change_password`` 호출. ``ValueError`` → 404,\n   ``PermissionError``/``PermissionDeniedError`` → 403.\n\nAudit 로그의 ``member_id``는 ``caller_id``로 기록한다(SSOT). 대상 멤버는\n``resource=member:{member_id}``로 분리해 추적한다.",
         "operationId": "change_password_api_members__member_id__password_patch",
         "parameters": [
           {
@@ -2102,7 +2112,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master 권한 필요).",
+            "description": "Permission denied (master, human 멤버 또는 member:admin scope 보유 agent 만 허용).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2160,7 +2170,7 @@
           "members"
         ],
         "summary": "Update Scopes",
-        "description": "권한 범위 변경. 인증된 master만 호출 가능 (#1351).\n\n``create_member``와 동일한 raw body 파싱 패턴을 적용해 인증 가드가 body\nvalidation보다 우선 실행되도록 한다(#1351 — Codex Plan Review). FastAPI가\n``body: ScopesUpdateRequest``를 먼저 검증하면 unauth + bad-body 시 401이\n아닌 422가 먼저 반환되어 contract가 깨진다.\n\n핸들러 단계 순서:\n1. 인증 가드 (최우선) — 실패 시 401.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``ScopesUpdateRequest.model_validate`` — ValidationError → 422.\n4. ``svc.update_scopes`` 호출. ``ValueError`` → 404,\n   ``PermissionError``/``PermissionDeniedError`` → 403.",
+        "description": "권한 범위 변경. 인증된 master/human 또는 ``member:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. FastAPI 가 ``body: ScopesUpdateRequest`` 를 먼저 검증하면 unauth +\nbad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n1. 인증 가드 (``Depends(require_member_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``ScopesUpdateRequest.model_validate`` — ValidationError → 422.\n4. ``svc.update_scopes`` 호출. ``ValueError`` → 404,\n   ``PermissionError``/``PermissionDeniedError`` → 403.",
         "operationId": "update_scopes_api_members__member_id__scopes_put",
         "parameters": [
           {
@@ -2253,7 +2263,7 @@
           "config"
         ],
         "summary": "List Configs",
-        "description": "동적 설정 전체 조회.",
+        "description": "동적 설정 전체 조회. 인증된 master/human 또는 ``config:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
         "operationId": "list_configs_api_config_get",
         "responses": {
           "200": {
@@ -2378,7 +2388,7 @@
           "system"
         ],
         "summary": "Get System Status",
-        "description": "시스템 상태 조회.",
+        "description": "시스템 상태 조회. 인증된 master/human 또는 ``system:read`` scope 를 보유한\nagent 만 호출 가능 (#1407). ``/api/system/health`` (public) 와 구별 —\nhealth 는 모니터링 헬스체크용이고 status 는 운영 정보(account_count 등)를\n노출한다.",
         "operationId": "get_system_status_api_system_status_get",
         "responses": {
           "200": {
@@ -2422,7 +2432,7 @@
           "system"
         ],
         "summary": "Halt",
-        "description": "전체 거래 중지 (모든 ACTIVE 계좌 SUSPENDED). 인증된 master 만 호출 가능\n(#1375).\n\n``submit_report`` (#1374) 와 동일한 raw body 파싱 패턴을 적용해 인증 가드가\nbody validation 보다 우선 실행되도록 한다. FastAPI 가\n``body: HaltRequest`` 를 먼저 검증하면 unauth + bad-body 시 401 이 아닌\n422 가 먼저 반환되어 contract 가 깨진다 — 본 라우트는 oracle A7 finding\n의 핵심 시그니처 이므로 인증 가드 우선이 가장 중요하다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,\n   non-master → 403.\n2. raw bytes 읽기 + JSON 파싱 — 빈 body 는 default 허용, 그 외 실패 시 422.\n3. ``HaltRequest.model_validate`` — ValidationError → 422.\n4. ``account_service.suspend_all`` 호출 + audit 기록\n   (``halted_by`` / ``member_id`` = caller_id).",
+        "description": "전체 거래 중지 (모든 ACTIVE 계좌 SUSPENDED). 인증된 master/human 또는\n``system:admin`` scope 를 보유한 agent 만 호출 가능 (#1407 — spec\n``system:admin`` 정합, #1375 master_caller 에서 마이그레이션).\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. FastAPI 가 ``body: HaltRequest`` 를 먼저 검증하면 unauth + bad-body\n시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_system_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 빈 body 는 default 허용, 그 외 실패 시 422.\n3. ``HaltRequest.model_validate`` — ValidationError → 422.\n4. ``account_service.suspend_all`` 호출 + audit 기록\n   (``halted_by`` / ``member_id`` = caller_id).",
         "operationId": "halt_api_system_halt_post",
         "requestBody": {
           "content": {
@@ -2456,7 +2466,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master 권한 필요).",
+            "description": "Permission denied (master, human 멤버 또는 system:admin scope 보유 agent 만 허용).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2494,7 +2504,7 @@
           "system"
         ],
         "summary": "Clear Halt",
-        "description": "전역 정지 해제 (모든 SUSPENDED 계좌 ACTIVE). 인증된 master 만 호출 가능\n(#1375).\n\n계좌 상태만 ACTIVE 로 복구하며 봇을 자동 재시작하지 않는다.\n\n``halt`` 와 동일한 raw body 파싱 + auth-first 패턴을 따른다 (#1375).\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,\n   non-master → 403.\n2. raw bytes 읽기 + JSON 파싱 — 빈 body 는 default 허용, 그 외 실패 시 422.\n3. ``ClearHaltRequest.model_validate`` — ValidationError → 422.\n4. ``account_service.activate_all`` 호출 + audit 기록\n   (``activated_by`` / ``member_id`` = caller_id).",
+        "description": "전역 정지 해제 (모든 SUSPENDED 계좌 ACTIVE). 인증된 master/human 또는\n``system:admin`` scope 를 보유한 agent 만 호출 가능 (#1407 — spec\n``system:admin`` 정합, #1375 master_caller 에서 마이그레이션).\n\n계좌 상태만 ACTIVE 로 복구하며 봇을 자동 재시작하지 않는다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_system_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 빈 body 는 default 허용, 그 외 실패 시 422.\n3. ``ClearHaltRequest.model_validate`` — ValidationError → 422.\n4. ``account_service.activate_all`` 호출 + audit 기록\n   (``activated_by`` / ``member_id`` = caller_id).",
         "operationId": "clear_halt_api_system_clear_halt_post",
         "requestBody": {
           "content": {
@@ -2528,7 +2538,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master 권한 필요).",
+            "description": "Permission denied (master, human 멤버 또는 system:admin scope 보유 agent 만 허용).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2566,20 +2576,8 @@
           "strategies"
         ],
         "summary": "Validate Strategy",
-        "description": "전략 파일 정적 검증.\n\nBody: {\"path\": \"/path/to/strategy.py\"}",
+        "description": "전략 파일 정적 검증. 인증된 master/human 또는 ``strategy:write`` scope\n를 보유한 agent 만 호출 가능 (#1407 — spec ``strategy:write`` 정합).\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. 핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_strategy_write)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``path`` 필드 추출 — 누락 시 400.\n4. 파일 존재 확인 → 404.\n5. ``StrategyValidator.validate`` 호출.\n\nBody: ``{\"path\": \"/path/to/strategy.py\"}``",
         "operationId": "validate_strategy_api_strategies_validate_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "additionalProperties": true,
-                "type": "object",
-                "title": "Body"
-              }
-            }
-          },
-          "required": true
-        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -2601,6 +2599,26 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie).",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (master, human 멤버 또는 strategy:write scope 보유 agent 만 허용).",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Strategy file not found",
             "content": {
@@ -2612,11 +2630,11 @@
             }
           },
           "422": {
-            "description": "Validation Error",
+            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다 (#1407).",
             "content": {
-              "application/json": {
+              "application/problem+json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2630,7 +2648,7 @@
           "strategies"
         ],
         "summary": "List Strategies",
-        "description": "전략 목록 조회.",
+        "description": "전략 목록 조회. 인증된 master/human 또는 ``strategy:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
         "operationId": "list_strategies_api_strategies_get",
         "parameters": [
           {
@@ -2776,7 +2794,7 @@
           "strategies"
         ],
         "summary": "Get Strategy",
-        "description": "전략 상세 조회.",
+        "description": "전략 상세 조회. 인증된 master/human 또는 ``strategy:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
         "operationId": "get_strategy_api_strategies__strategy_id__get",
         "parameters": [
           {
@@ -2839,7 +2857,7 @@
           "strategies"
         ],
         "summary": "Get Strategy Performance",
-        "description": "전략 성과 지표 조회.",
+        "description": "전략 성과 지표 조회. 인증된 master/human 또는 ``strategy:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
         "operationId": "get_strategy_performance_api_strategies__strategy_id__performance_get",
         "parameters": [
           {
@@ -2918,7 +2936,7 @@
           "strategies"
         ],
         "summary": "Get Strategy Daily Summary",
-        "description": "전략 일별 성과 집계.",
+        "description": "전략 일별 성과 집계. 인증된 master/human 또는 ``strategy:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
         "operationId": "get_strategy_daily_summary_api_strategies__strategy_id__daily_summary_get",
         "parameters": [
           {
@@ -2981,7 +2999,7 @@
           "strategies"
         ],
         "summary": "Get Strategy Weekly Summary",
-        "description": "전략 주별 성과 집계.",
+        "description": "전략 주별 성과 집계. 인증된 master/human 또는 ``strategy:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
         "operationId": "get_strategy_weekly_summary_api_strategies__strategy_id__weekly_summary_get",
         "parameters": [
           {
@@ -3044,7 +3062,7 @@
           "strategies"
         ],
         "summary": "Get Strategy Monthly Summary",
-        "description": "전략 월별 성과 집계.",
+        "description": "전략 월별 성과 집계. 인증된 master/human 또는 ``strategy:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
         "operationId": "get_strategy_monthly_summary_api_strategies__strategy_id__monthly_summary_get",
         "parameters": [
           {
@@ -3107,7 +3125,7 @@
           "strategies"
         ],
         "summary": "Get Strategy Trades",
-        "description": "전략 거래 내역 조회 (cursor 기반 페이지네이션).",
+        "description": "전략 거래 내역 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는\n``strategy:read`` scope 를 보유한 agent 만 호출 가능 (#1407).",
         "operationId": "get_strategy_trades_api_strategies__strategy_id__trades_get",
         "parameters": [
           {
@@ -3290,7 +3308,7 @@
           "reports"
         ],
         "summary": "List Reports",
-        "description": "리포트 목록 조회 (cursor 기반 페이지네이션).",
+        "description": "리포트 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는\n``report:read`` scope 를 보유한 agent 만 호출 가능 (#1407).",
         "operationId": "list_reports_api_reports_get",
         "parameters": [
           {
@@ -3378,7 +3396,7 @@
           "reports"
         ],
         "summary": "Report View",
-        "description": "리포트 단건 조회.",
+        "description": "리포트 단건 조회. 인증된 master/human 또는 ``report:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
         "operationId": "report_view_api_reports__report_id__get",
         "parameters": [
           {
@@ -3552,7 +3570,7 @@
           "data"
         ],
         "summary": "Get Dataset Detail",
-        "description": "데이터셋 상세 조회 (메타데이터 + 최근 5행 미리보기).\n\ndataset_id 형식: \"{symbol}__{timeframe}\" (예: \"005930__1d\")",
+        "description": "데이터셋 상세 조회 (메타데이터 + 최근 5행 미리보기). 인증된 master/human\n또는 ``data:read`` scope 를 보유한 agent 만 호출 가능 (#1407).\n\ndataset_id 형식: \"{symbol}__{timeframe}\" (예: \"005930__1d\")",
         "operationId": "get_dataset_detail_api_data_datasets__dataset_id__get",
         "parameters": [
           {
@@ -3593,7 +3611,7 @@
           "data"
         ],
         "summary": "Delete Dataset",
-        "description": "데이터셋 삭제.\n\ndataset_id 형식: \"{symbol}__{timeframe}\" (예: \"005930__1d\")\nfundamental의 경우: \"{symbol}__fundamental\" (예: \"005930__fundamental\")",
+        "description": "데이터셋 삭제. 인증된 master/human 또는 ``data:write`` scope 를 보유한\nagent 만 호출 가능 (#1407).\n\ndataset_id 형식: \"{symbol}__{timeframe}\" (예: \"005930__1d\")\nfundamental의 경우: \"{symbol}__fundamental\" (예: \"005930__fundamental\")",
         "operationId": "delete_dataset_api_data_datasets__dataset_id__delete",
         "parameters": [
           {
@@ -3671,7 +3689,7 @@
           "data"
         ],
         "summary": "Get Data Schema",
-        "description": "데이터 스키마 조회. data_type에 따라 해당 스키마를 반환.",
+        "description": "데이터 스키마 조회. data_type에 따라 해당 스키마를 반환. 인증된\nmaster/human 또는 ``data:read`` scope 를 보유한 agent 만 호출 가능\n(#1407).",
         "operationId": "get_data_schema_api_data_schema_get",
         "parameters": [
           {
@@ -3721,7 +3739,7 @@
           "data"
         ],
         "summary": "Get Storage Summary",
-        "description": "저장 용량 현황.",
+        "description": "저장 용량 현황. 인증된 master/human 또는 ``data:read`` scope 를 보유한\nagent 만 호출 가능 (#1407).",
         "operationId": "get_storage_summary_api_data_storage_get",
         "responses": {
           "200": {
@@ -3743,7 +3761,7 @@
           "data"
         ],
         "summary": "Get Feed Status",
-        "description": "Feed 파이프라인 상태 조회.\n\nFeed 초기화 여부, 소스별 체크포인트 현황, 최근 리포트 요약,\nAPI 키 설정 상태를 반환한다.",
+        "description": "Feed 파이프라인 상태 조회. 인증된 master/human 또는 ``data:read`` scope\n를 보유한 agent 만 호출 가능 (#1407).\n\nFeed 초기화 여부, 소스별 체크포인트 현황, 최근 리포트 요약,\nAPI 키 설정 상태를 반환한다.",
         "operationId": "get_feed_status_api_data_feed_status_get",
         "responses": {
           "200": {
@@ -3765,7 +3783,7 @@
           "trades"
         ],
         "summary": "List Trades",
-        "description": "거래 기록 목록 조회 (cursor 기반 페이지네이션).",
+        "description": "거래 기록 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는\n``trade:read`` scope 를 보유한 agent 만 호출 가능 (#1407).",
         "operationId": "list_trades_api_trades_get",
         "parameters": [
           {
@@ -3885,7 +3903,7 @@
           "bots"
         ],
         "summary": "List Bots",
-        "description": "봇 목록 조회 (cursor 기반 페이지네이션).",
+        "description": "봇 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는\n``bot:read`` scope 를 보유한 agent 만 호출 가능 (#1407).",
         "operationId": "list_bots_api_bots_get",
         "parameters": [
           {
@@ -3971,7 +3989,7 @@
           "bots"
         ],
         "summary": "Create Bot",
-        "description": "봇 생성. 인증된 master만 호출 가능 (#1371).\n\n``update_bot`` (#1352)과 동일한 raw body 파싱 패턴을 적용해 인증 가드가\nbody validation보다 우선 실행되도록 한다. FastAPI가 ``body: BotCreateRequest``\n를 먼저 검증하면 unauth + bad-body 시 401이 아닌 422가 먼저 반환되어\ncontract가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,\n   non-master → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``BotCreateRequest.model_validate`` — ValidationError → 422.\n4. service 호출 (``BotError`` → 409, ``TreasuryError`` → 422).",
+        "description": "봇 생성. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한 agent\n만 호출 가능 (#1407 — spec ``bot:admin`` 정합, #1371 master_caller 에서\n마이그레이션).\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. FastAPI 가 ``body: BotCreateRequest`` 를 먼저 검증하면 unauth +\nbad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_bot_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``BotCreateRequest.model_validate`` — ValidationError → 422.\n4. service 호출 (``BotError`` → 409, ``TreasuryError`` → 422).",
         "operationId": "create_bot_api_bots_post",
         "responses": {
           "201": {
@@ -4005,7 +4023,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master 권한 필요)",
+            "description": "Permission denied (master, human 멤버 또는 bot:admin scope 보유 agent 만 허용)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4083,7 +4101,7 @@
           "bots"
         ],
         "summary": "Get Bot",
-        "description": "봇 상세 조회.",
+        "description": "봇 상세 조회. 인증된 master/human 또는 ``bot:read`` scope 를 보유한\nagent 만 호출 가능 (#1407).",
         "operationId": "get_bot_api_bots__bot_id__get",
         "parameters": [
           {
@@ -4144,7 +4162,7 @@
           "bots"
         ],
         "summary": "Delete Bot",
-        "description": "봇 삭제. 인증된 master만 호출 가능 (#1371).\n\nbody가 없으므로 raw-body cold-path는 적용하지 않는다. 인증 가드가\nhandle_positions query 파라미터 검증보다 먼저 실행되어 unauth는 401,\nnon-master는 403으로 차단된다.\n\nhandle_positions:\n    - keep (기본): 포지션을 유지한 채 봇만 삭제.\n    - liquidate: 보유 종목 시장가 매도 주문 발행 후 삭제.",
+        "description": "봇 삭제. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한 agent\n만 호출 가능 (#1407 — spec ``bot:admin`` 정합, #1371 master_caller 에서\n마이그레이션).\n\nbody가 없으므로 raw-body cold-path는 적용하지 않는다. 인증 가드가\nhandle_positions query 파라미터 검증보다 먼저 실행되어 unauth는 401,\nnon-master는 403으로 차단된다.\n\nhandle_positions:\n    - keep (기본): 포지션을 유지한 채 봇만 삭제.\n    - liquidate: 보유 종목 시장가 매도 주문 발행 후 삭제.",
         "operationId": "delete_bot_api_bots__bot_id__delete",
         "parameters": [
           {
@@ -4182,7 +4200,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master 권한 필요)",
+            "description": "Permission denied (master, human 멤버 또는 bot:admin scope 보유 agent 만 허용)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4238,7 +4256,7 @@
           "bots"
         ],
         "summary": "Update Bot",
-        "description": "봇 설정 수정. 인증된 master만 호출 가능 (#1352). 중지 상태에서만 허용.\n\n``create_member`` / ``update_scopes``와 동일한 raw body 파싱 패턴을 적용해\n인증 가드가 body validation보다 우선 실행되도록 한다(#1352 — Codex Plan\nReview). FastAPI가 ``body: BotUpdateRequest``를 먼저 검증하면 unauth +\nbad-body 시 401이 아닌 422가 먼저 반환되어 contract가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,\n   non-master → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``BotUpdateRequest.model_validate`` — ValidationError → 422.\n4. service 호출 (``BotError`` → 409, ``TreasuryError`` → 422).",
+        "description": "봇 설정 수정. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``bot:admin`` 정합, #1352 master_caller\n에서 마이그레이션). 중지 상태에서만 허용.\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. FastAPI 가 ``body: BotUpdateRequest`` 를 먼저 검증하면 unauth +\nbad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_bot_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``BotUpdateRequest.model_validate`` — ValidationError → 422.\n4. service 호출 (``BotError`` → 409, ``TreasuryError`` → 422).",
         "operationId": "update_bot_api_bots__bot_id__put",
         "parameters": [
           {
@@ -4273,7 +4291,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master 권한 필요)",
+            "description": "Permission denied (master, human 멤버 또는 bot:admin scope 보유 agent 만 허용)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4341,7 +4359,7 @@
           "bots"
         ],
         "summary": "Start Bot",
-        "description": "봇 시작.",
+        "description": "봇 시작. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한 agent\n만 호출 가능 (#1407).",
         "operationId": "start_bot_api_bots__bot_id__start_post",
         "parameters": [
           {
@@ -4414,7 +4432,7 @@
           "bots"
         ],
         "summary": "Stop Bot",
-        "description": "봇 중지.",
+        "description": "봇 중지. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한 agent\n만 호출 가능 (#1407).",
         "operationId": "stop_bot_api_bots__bot_id__stop_post",
         "parameters": [
           {
@@ -4487,7 +4505,7 @@
           "bots"
         ],
         "summary": "Get Bot Logs",
-        "description": "봇 실행 로그 조회.\n\nBotStepCompletedEvent 이력을 반환한다.\nevent_history_store(SQLite)가 있으면 영속 로그를 조회하고,\n없으면 EventBus 인메모리 히스토리에서 조회한다.",
+        "description": "봇 실행 로그 조회. 인증된 master/human 또는 ``bot:read`` scope 를 보유한\nagent 만 호출 가능 (#1407).\n\nBotStepCompletedEvent 이력을 반환한다.\nevent_history_store(SQLite)가 있으면 영속 로그를 조회하고,\n없으면 EventBus 인메모리 히스토리에서 조회한다.",
         "operationId": "get_bot_logs_api_bots__bot_id__logs_get",
         "parameters": [
           {
@@ -4564,7 +4582,7 @@
           "treasury"
         ],
         "summary": "Get Summary",
-        "description": "자금 현황 요약.\n\naccount_id 지정 시 해당 계좌의 Treasury 요약을 반환한다.\n미지정 시 기본 Treasury 요약을 반환한다 (하위 호환).",
+        "description": "자금 현황 요약. 인증된 master/human 또는 ``treasury:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).\n\naccount_id 지정 시 해당 계좌의 Treasury 요약을 반환한다.\n미지정 시 기본 Treasury 요약을 반환한다 (하위 호환).",
         "operationId": "get_summary_api_treasury_get",
         "parameters": [
           {
@@ -4634,7 +4652,7 @@
           "treasury"
         ],
         "summary": "List Transactions",
-        "description": "자금 변동 이력 조회.",
+        "description": "자금 변동 이력 조회. 인증된 master/human 또는 ``treasury:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
         "operationId": "list_transactions_api_treasury_transactions_get",
         "parameters": [
           {
@@ -4781,7 +4799,7 @@
           "treasury"
         ],
         "summary": "Allocate",
-        "description": "봇에 예산 할당. 인증된 master만 호출 가능 (#1372).\n\n``set_balance`` (#1352)와 동일한 raw body 파싱 패턴을 적용해 인증 가드가\nbody validation보다 우선 실행되도록 한다. FastAPI가 ``body:\nBudgetChangeRequest``를 먼저 검증하면 unauth + bad-body 시 401이 아닌\n422가 먼저 반환되어 contract가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,\n   non-master → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``BudgetChangeRequest.model_validate`` — ValidationError → 422.\n4. ``treasury.allocate`` 호출 (``BotNotStoppedError`` → 409).",
+        "description": "봇에 예산 할당. 인증된 master/human 또는 ``treasury:admin`` scope 를\n보유한 agent 만 호출 가능 (#1407 — spec ``treasury:admin`` 정합, #1372\nmaster_caller 에서 마이그레이션).\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. FastAPI 가 ``body: BudgetChangeRequest`` 를 먼저 검증하면 unauth +\nbad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_treasury_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``BudgetChangeRequest.model_validate`` — ValidationError → 422.\n4. ``treasury.allocate`` 호출 (``BotNotStoppedError`` → 409).",
         "operationId": "allocate_api_treasury_bots__bot_id__allocate_post",
         "parameters": [
           {
@@ -4826,7 +4844,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master 권한 필요)",
+            "description": "Permission denied (master, human 멤버 또는 treasury:admin scope 보유 agent 만 허용)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4894,7 +4912,7 @@
           "treasury"
         ],
         "summary": "Deallocate",
-        "description": "봇 예산 회수. 인증된 master만 호출 가능 (#1372).\n\n``allocate`` / ``set_balance`` (#1352)와 동일한 raw body 파싱 패턴을\n적용해 인증 가드가 body validation보다 우선 실행되도록 한다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,\n   non-master → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``BudgetChangeRequest.model_validate`` — ValidationError → 422.\n4. ``treasury.deallocate`` 호출 (``BotNotStoppedError`` → 409).",
+        "description": "봇 예산 회수. 인증된 master/human 또는 ``treasury:admin`` scope 를\n보유한 agent 만 호출 가능 (#1407 — spec ``treasury:admin`` 정합, #1372\nmaster_caller 에서 마이그레이션).\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_treasury_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``BudgetChangeRequest.model_validate`` — ValidationError → 422.\n4. ``treasury.deallocate`` 호출 (``BotNotStoppedError`` → 409).",
         "operationId": "deallocate_api_treasury_bots__bot_id__deallocate_post",
         "parameters": [
           {
@@ -4939,7 +4957,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master 권한 필요)",
+            "description": "Permission denied (master, human 멤버 또는 treasury:admin scope 보유 agent 만 허용)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -5007,7 +5025,7 @@
           "treasury"
         ],
         "summary": "List Budgets",
-        "description": "봇별 예산 목록 조회.",
+        "description": "봇별 예산 목록 조회. 인증된 master/human 또는 ``treasury:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
         "operationId": "list_budgets_api_treasury_budgets_get",
         "responses": {
           "200": {
@@ -5039,7 +5057,7 @@
           "treasury"
         ],
         "summary": "Set Balance",
-        "description": "계좌 총 잔고 수동 설정. 인증된 master만 호출 가능 (#1352).\n\n``create_member`` / ``update_scopes`` / ``update_bot``과 동일한 raw body\n파싱 패턴을 적용해 인증 가드가 body validation보다 우선 실행되도록 한다\n(#1352 — Codex Plan Review). FastAPI가 ``body: BalanceSetRequest``를 먼저\n검증하면 unauth + bad-body 시 401이 아닌 422가 먼저 반환되어 contract가\n깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,\n   non-master → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``BalanceSetRequest.model_validate`` — ValidationError → 422.\n4. ``treasury.set_account_balance`` 호출.",
+        "description": "계좌 총 잔고 수동 설정. 인증된 master/human 또는 ``treasury:admin`` scope\n를 보유한 agent 만 호출 가능 (#1407 — spec ``treasury:admin`` 정합, #1352\nmaster_caller 에서 마이그레이션).\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. FastAPI 가 ``body: BalanceSetRequest`` 를 먼저 검증하면 unauth +\nbad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_treasury_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``BalanceSetRequest.model_validate`` — ValidationError → 422.\n4. ``treasury.set_account_balance`` 호출.",
         "operationId": "set_balance_api_treasury_balance_post",
         "requestBody": {
           "content": {
@@ -5073,7 +5091,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master 권한 필요)",
+            "description": "Permission denied (master, human 멤버 또는 treasury:admin scope 보유 agent 만 허용)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -5111,7 +5129,7 @@
           "treasury"
         ],
         "summary": "Get Latest Snapshot",
-        "description": "가장 최근 일별 스냅샷 조회.",
+        "description": "가장 최근 일별 스냅샷 조회. 인증된 master/human 또는 ``treasury:read``\nscope 를 보유한 agent 만 호출 가능 (#1407).",
         "operationId": "get_latest_snapshot_api_treasury_snapshots_latest_get",
         "parameters": [
           {
@@ -5171,7 +5189,7 @@
           "treasury"
         ],
         "summary": "List Snapshots",
-        "description": "기간별 일별 스냅샷 목록.",
+        "description": "기간별 일별 스냅샷 목록. 인증된 master/human 또는 ``treasury:read`` scope\n를 보유한 agent 만 호출 가능 (#1407).",
         "operationId": "list_snapshots_api_treasury_snapshots_get",
         "parameters": [
           {
@@ -5263,7 +5281,7 @@
           "treasury"
         ],
         "summary": "Get Snapshot By Date",
-        "description": "특정일 스냅샷 조회.",
+        "description": "특정일 스냅샷 조회. 인증된 master/human 또는 ``treasury:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
         "operationId": "get_snapshot_by_date_api_treasury_snapshots__date__get",
         "parameters": [
           {
@@ -5631,25 +5649,6 @@
         ],
         "title": "ApprovalStatus",
         "description": "결재 상태."
-      },
-      "ApprovalStatusUpdate": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "memo": {
-            "type": "string",
-            "title": "Memo",
-            "default": ""
-          }
-        },
-        "type": "object",
-        "required": [
-          "status"
-        ],
-        "title": "ApprovalStatusUpdate",
-        "description": "승인/거부 요청."
       },
       "ApprovalUpdateResponse": {
         "properties": {
@@ -8428,7 +8427,7 @@
       "AccountSuspendRequest": {
         "type": "object",
         "title": "AccountSuspendRequest",
-        "description": "POST /api/accounts/{account_id}/suspend 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1352). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다. 빈 body도 허용되며 reason은 default 'dashboard'로 채워진다.",
+        "description": "POST /api/accounts/{account_id}/suspend 입력 contract. 인증된 master/human 또는 account:write scope 를 보유한 agent 만 사용할 수 있다(#1407, #1352 master_caller migration). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다. 빈 body도 허용되며 reason은 default 'dashboard'로 채워진다.",
         "additionalProperties": false,
         "properties": {
           "reason": {
@@ -8594,7 +8593,7 @@
         "type": "object"
       },
       "RuleUpdateRequest": {
-        "description": "룰 설정 변경 요청.",
+        "description": "룰 설정 변경 요청.\n\n``params`` 는 룰별 schema 를 갖는 open object 지만, 모든 numeric threshold\n는 finite 여야 한다 (#1380 oracle A7). ``json.loads`` default 는 ``NaN`` /\n``Infinity`` / ``-Infinity`` 를 ``float('nan')`` / ``float('inf')`` 로\n파싱하므로, raw body parser 가 통과시킨 값을 본 모델 단에서 422 로 거부한다.\nbool 은 numeric 흉내 방지를 위해 ``_reject_non_finite`` 가 통과시키되,\nRULE_REGISTRY ``validate_config`` 가 known numeric key 에 대해 별도로\n거부한다.",
         "properties": {
           "enabled": {
             "default": true,

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -13,13 +13,15 @@ export type paths = {
         };
         /**
          * List Accounts
-         * @description 계좌 목록 조회.
+         * @description 계좌 목록 조회. 인증된 master/human 또는 ``account:read`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407).
          */
         get: operations["list_accounts_api_accounts_get"];
         put?: never;
         /**
          * Create Account
-         * @description 계좌 생성.
+         * @description 계좌 생성. 인증된 master/human 또는 ``account:write`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407).
          *
          *     런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.
          *     실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로
@@ -55,18 +57,20 @@ export type paths = {
         };
         /**
          * Get Account
-         * @description 계좌 상세 조회.
+         * @description 계좌 상세 조회. 인증된 master/human 또는 ``account:read`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407).
          */
         get: operations["get_account_api_accounts__account_id__get"];
         /**
          * Update Account
          * @description 계좌 수정.
          *
-         *     인증된 master 호출자만 사용할 수 있다(이슈 #1352 — oracle A7). dependency
-         *     ``require_master_caller``가 인증/권한 검증을 담당하며, 401/403은 raw body
-         *     파싱과 cold-path 가드(invariant I1/I4)보다 먼저 평가된다 — Bearer 또는
-         *     ``ante_session`` 쿠키 어느 쪽으로도 caller가 결정되지 않으면 401, master가
-         *     아니면 403.
+         *     인증된 master/human 또는 ``account:write`` scope 를 보유한 agent 만 호출
+         *     가능 (#1407 — spec ``account:write`` 정합, #1352 master_caller 에서
+         *     마이그레이션). dependency ``require_account_write`` 가 인증/권한 검증을
+         *     담당하며, 401/403은 raw body 파싱과 cold-path 가드(invariant I1/I4)보다
+         *     먼저 평가된다 — Bearer 또는 ``ante_session`` 쿠키 어느 쪽으로도 caller가
+         *     결정되지 않으면 401, 권한 없으면 403.
          *
          *     런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,
          *     ``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도
@@ -104,7 +108,8 @@ export type paths = {
         post?: never;
         /**
          * Delete Account
-         * @description 계좌 소프트 딜리트.
+         * @description 계좌 소프트 딜리트. 인증된 master/human 또는 ``account:write`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407).
          *
          *     런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.
          *     실제 계좌 삭제는 서버 정지 상태에서 ``ante account delete`` CLI로
@@ -135,7 +140,9 @@ export type paths = {
         put?: never;
         /**
          * Activate Account
-         * @description 계좌 재활성화. 인증된 master만 호출 가능 (#1352).
+         * @description 계좌 재활성화. 인증된 master/human 또는 ``account:write`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407 — spec ``account:write`` 정합, #1352
+         *     master_caller 에서 마이그레이션).
          */
         post: operations["activate_account_api_accounts__account_id__activate_post"];
         delete?: never;
@@ -153,7 +160,8 @@ export type paths = {
         };
         /**
          * Get Account Rules
-         * @description 계좌 리스크 룰 목록 조회.
+         * @description 계좌 리스크 룰 목록 조회. 인증된 master/human 또는 ``rule:read`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407).
          *
          *     DynamicConfig를 우선 조회하고, 없으면 정적 Config에서 읽는다.
          *     RULE_REGISTRY에 등록된 룰 타입만 구조화하여 반환한다.
@@ -177,7 +185,9 @@ export type paths = {
         get?: never;
         /**
          * Update Account Rule
-         * @description 계좌 리스크 룰 개별 수정. 인증된 master 만 호출 가능 (#1376).
+         * @description 계좌 리스크 룰 개별 수정. 인증된 master/human 또는 ``rule:admin`` scope
+         *     를 보유한 agent 만 호출 가능 (#1407 — spec ``rule:admin`` 정합, #1376
+         *     master_caller 에서 마이그레이션).
          *
          *     RULE_REGISTRY에 등록된 타입만 허용하며,
          *     DynamicConfigService에 위임하여 ConfigChangedEvent를 발행한다.
@@ -197,8 +207,8 @@ export type paths = {
          *
          *     핸들러 단계 순서:
          *
-         *     1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-         *        non-master → 403.
+         *     1. 인증 가드 (``Depends(require_rule_admin)``) — caller 빈 → 401,
+         *        권한 없음 → 403, 비활성 멤버 → 403.
          *     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
          *     3. ``RuleUpdateRequest.model_validate`` — ValidationError → 422.
          *     4. RULE_REGISTRY 룰 타입 확인 — 없으면 400 (기존 계약 보존).
@@ -224,7 +234,9 @@ export type paths = {
         put?: never;
         /**
          * Suspend Account
-         * @description 계좌 정지. 인증된 master만 호출 가능 (#1352).
+         * @description 계좌 정지. 인증된 master/human 또는 ``account:write`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407 — spec ``account:write`` 정합, #1352
+         *     master_caller 에서 마이그레이션).
          *
          *     ``update_bot`` / ``set_balance`` / ``update_scopes``와 동일한 raw body 파싱
          *     패턴을 적용해 인증 가드가 body validation보다 먼저 실행되도록 한다(#1352
@@ -234,8 +246,8 @@ export type paths = {
          *
          *     핸들러 단계 순서:
          *
-         *     1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-         *        non-master → 403.
+         *     1. 인증 가드 (``Depends(require_account_write)``) — caller 빈 → 401,
+         *        권한 없음 → 403, 비활성 멤버 → 403.
          *     2. raw bytes 읽기. 빈 body → default reason (``dashboard``)로 흘려보낸다
          *        (기존 의미 보존).
          *     3. JSON 파싱 실패 → 422.
@@ -282,7 +294,8 @@ export type paths = {
         };
         /**
          * Get Approval
-         * @description 결재 상세 조회.
+         * @description 결재 상세 조회. 인증된 master/human 또는 ``approval:read`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["get_approval_api_approvals__approval_id__get"];
         put?: never;
@@ -308,7 +321,20 @@ export type paths = {
         head?: never;
         /**
          * Update Approval Status
-         * @description 결재 승인/거부 처리.
+         * @description 결재 승인/거부 처리. 인증된 master/human 또는 ``approval:admin`` scope
+         *     를 보유한 agent 만 호출 가능 (#1407 — spec ``approval:admin`` 정합).
+         *
+         *     Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
+         *     한다. FastAPI 가 ``body: ApprovalStatusUpdate`` 를 먼저 검증하면 unauth +
+         *     bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.
+         *
+         *     핸들러 단계 순서:
+         *
+         *     1. 인증 가드 (``Depends(require_approval_admin)``) — caller 빈 → 401,
+         *        권한 없음 → 403, 비활성 멤버 → 403.
+         *     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
+         *     3. ``ApprovalStatusUpdate.model_validate`` — ValidationError → 422.
+         *     4. service 호출 (``approve`` / ``reject``).
          */
         patch: operations["update_approval_status_api_approvals__approval_id__status_patch"];
         trace?: never;
@@ -432,23 +458,25 @@ export type paths = {
         };
         /**
          * List Bots
-         * @description 봇 목록 조회 (cursor 기반 페이지네이션).
+         * @description 봇 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는
+         *     ``bot:read`` scope 를 보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["list_bots_api_bots_get"];
         put?: never;
         /**
          * Create Bot
-         * @description 봇 생성. 인증된 master만 호출 가능 (#1371).
+         * @description 봇 생성. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한 agent
+         *     만 호출 가능 (#1407 — spec ``bot:admin`` 정합, #1371 master_caller 에서
+         *     마이그레이션).
          *
-         *     ``update_bot`` (#1352)과 동일한 raw body 파싱 패턴을 적용해 인증 가드가
-         *     body validation보다 우선 실행되도록 한다. FastAPI가 ``body: BotCreateRequest``
-         *     를 먼저 검증하면 unauth + bad-body 시 401이 아닌 422가 먼저 반환되어
-         *     contract가 깨진다.
+         *     Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
+         *     한다. FastAPI 가 ``body: BotCreateRequest`` 를 먼저 검증하면 unauth +
+         *     bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.
          *
          *     핸들러 단계 순서:
          *
-         *     1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-         *        non-master → 403.
+         *     1. 인증 가드 (``Depends(require_bot_admin)``) — caller 빈 → 401,
+         *        권한 없음 → 403, 비활성 멤버 → 403.
          *     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
          *     3. ``BotCreateRequest.model_validate`` — ValidationError → 422.
          *     4. service 호출 (``BotError`` → 409, ``TreasuryError`` → 422).
@@ -469,22 +497,24 @@ export type paths = {
         };
         /**
          * Get Bot
-         * @description 봇 상세 조회.
+         * @description 봇 상세 조회. 인증된 master/human 또는 ``bot:read`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407).
          */
         get: operations["get_bot_api_bots__bot_id__get"];
         /**
          * Update Bot
-         * @description 봇 설정 수정. 인증된 master만 호출 가능 (#1352). 중지 상태에서만 허용.
+         * @description 봇 설정 수정. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407 — spec ``bot:admin`` 정합, #1352 master_caller
+         *     에서 마이그레이션). 중지 상태에서만 허용.
          *
-         *     ``create_member`` / ``update_scopes``와 동일한 raw body 파싱 패턴을 적용해
-         *     인증 가드가 body validation보다 우선 실행되도록 한다(#1352 — Codex Plan
-         *     Review). FastAPI가 ``body: BotUpdateRequest``를 먼저 검증하면 unauth +
-         *     bad-body 시 401이 아닌 422가 먼저 반환되어 contract가 깨진다.
+         *     Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
+         *     한다. FastAPI 가 ``body: BotUpdateRequest`` 를 먼저 검증하면 unauth +
+         *     bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.
          *
          *     핸들러 단계 순서:
          *
-         *     1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-         *        non-master → 403.
+         *     1. 인증 가드 (``Depends(require_bot_admin)``) — caller 빈 → 401,
+         *        권한 없음 → 403, 비활성 멤버 → 403.
          *     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
          *     3. ``BotUpdateRequest.model_validate`` — ValidationError → 422.
          *     4. service 호출 (``BotError`` → 409, ``TreasuryError`` → 422).
@@ -493,7 +523,9 @@ export type paths = {
         post?: never;
         /**
          * Delete Bot
-         * @description 봇 삭제. 인증된 master만 호출 가능 (#1371).
+         * @description 봇 삭제. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한 agent
+         *     만 호출 가능 (#1407 — spec ``bot:admin`` 정합, #1371 master_caller 에서
+         *     마이그레이션).
          *
          *     body가 없으므로 raw-body cold-path는 적용하지 않는다. 인증 가드가
          *     handle_positions query 파라미터 검증보다 먼저 실행되어 unauth는 401,
@@ -518,7 +550,8 @@ export type paths = {
         };
         /**
          * Get Bot Logs
-         * @description 봇 실행 로그 조회.
+         * @description 봇 실행 로그 조회. 인증된 master/human 또는 ``bot:read`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407).
          *
          *     BotStepCompletedEvent 이력을 반환한다.
          *     event_history_store(SQLite)가 있으면 영속 로그를 조회하고,
@@ -544,7 +577,8 @@ export type paths = {
         put?: never;
         /**
          * Start Bot
-         * @description 봇 시작.
+         * @description 봇 시작. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한 agent
+         *     만 호출 가능 (#1407).
          */
         post: operations["start_bot_api_bots__bot_id__start_post"];
         delete?: never;
@@ -564,7 +598,8 @@ export type paths = {
         put?: never;
         /**
          * Stop Bot
-         * @description 봇 중지.
+         * @description 봇 중지. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한 agent
+         *     만 호출 가능 (#1407).
          */
         post: operations["stop_bot_api_bots__bot_id__stop_post"];
         delete?: never;
@@ -582,7 +617,8 @@ export type paths = {
         };
         /**
          * List Configs
-         * @description 동적 설정 전체 조회.
+         * @description 동적 설정 전체 조회. 인증된 master/human 또는 ``config:read`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["list_configs_api_config_get"];
         put?: never;
@@ -669,7 +705,8 @@ export type paths = {
         };
         /**
          * Get Dataset Detail
-         * @description 데이터셋 상세 조회 (메타데이터 + 최근 5행 미리보기).
+         * @description 데이터셋 상세 조회 (메타데이터 + 최근 5행 미리보기). 인증된 master/human
+         *     또는 ``data:read`` scope 를 보유한 agent 만 호출 가능 (#1407).
          *
          *     dataset_id 형식: "{symbol}__{timeframe}" (예: "005930__1d")
          */
@@ -678,7 +715,8 @@ export type paths = {
         post?: never;
         /**
          * Delete Dataset
-         * @description 데이터셋 삭제.
+         * @description 데이터셋 삭제. 인증된 master/human 또는 ``data:write`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407).
          *
          *     dataset_id 형식: "{symbol}__{timeframe}" (예: "005930__1d")
          *     fundamental의 경우: "{symbol}__fundamental" (예: "005930__fundamental")
@@ -698,7 +736,8 @@ export type paths = {
         };
         /**
          * Get Feed Status
-         * @description Feed 파이프라인 상태 조회.
+         * @description Feed 파이프라인 상태 조회. 인증된 master/human 또는 ``data:read`` scope
+         *     를 보유한 agent 만 호출 가능 (#1407).
          *
          *     Feed 초기화 여부, 소스별 체크포인트 현황, 최근 리포트 요약,
          *     API 키 설정 상태를 반환한다.
@@ -721,7 +760,9 @@ export type paths = {
         };
         /**
          * Get Data Schema
-         * @description 데이터 스키마 조회. data_type에 따라 해당 스키마를 반환.
+         * @description 데이터 스키마 조회. data_type에 따라 해당 스키마를 반환. 인증된
+         *     master/human 또는 ``data:read`` scope 를 보유한 agent 만 호출 가능
+         *     (#1407).
          */
         get: operations["get_data_schema_api_data_schema_get"];
         put?: never;
@@ -741,7 +782,8 @@ export type paths = {
         };
         /**
          * Get Storage Summary
-         * @description 저장 용량 현황.
+         * @description 저장 용량 현황. 인증된 master/human 또는 ``data:read`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407).
          */
         get: operations["get_storage_summary_api_data_storage_get"];
         put?: never;
@@ -774,26 +816,19 @@ export type paths = {
         put?: never;
         /**
          * Create Member
-         * @description 멤버 등록. 토큰 1회 반환.
+         * @description 멤버 등록. 토큰 1회 반환. 인증된 master/human 또는 ``member:admin`` scope
+         *     를 보유한 agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
          *
-         *     인증 가드는 body validation보다 **반드시 먼저** 실행된다(#1339 P2 — Codex
-         *     finding). FastAPI가 ``body: MemberCreateRequest`` 파라미터를 먼저 파싱하면
-         *     Authorization 헤더 미존재 + 필수 필드 누락 케이스에서 401이 아니라 422가
-         *     먼저 응답되어 "missing or invalid Authorization header는 401" 계약이 깨진다.
-         *     이 이유로 본 라우트는 ``request: Request``만 받고 raw body를 직접 파싱한다
-         *     (``update_account`` SSOT 패턴 일치).
-         *
-         *     인증 경로는 두 가지를 모두 받는다(#1339 P1 — Codex finding):
-         *     - **Bearer 토큰**: ``TokenAuthMiddleware``가 ``request.state.member_id``를
-         *       세팅한다. 에이전트 클라이언트(`MCP`, CLI 등)와 ``frontend`` axios의
-         *       ``Authorization`` 헤더 호출이 이 경로를 탄다.
-         *     - **세션 쿠키**: 대시보드는 패스워드 로그인 후 ``ante_session`` HttpOnly
-         *       쿠키만 가진 상태로 axios에 ``Authorization`` 헤더를 추가하지 않는다.
-         *       ``session_service.validate``로 세션 → ``member_id``를 복원한다.
+         *     인증 가드는 body validation보다 **반드시 먼저** 실행된다(#1339 P2). FastAPI
+         *     가 ``body: MemberCreateRequest`` 파라미터를 먼저 파싱하면 Authorization
+         *     헤더 미존재 + 필수 필드 누락 케이스에서 401 이 아니라 422 가 먼저 응답되어
+         *     "missing or invalid Authorization header는 401" 계약이 깨진다. 이 이유로
+         *     본 라우트는 ``request: Request`` 와 ``require_member_admin`` 만 받고 raw
+         *     body 를 직접 파싱한다 (``update_account`` SSOT 패턴 일치).
          *
          *     핸들러 단계 순서:
-         *     1. **인증 가드 (최우선)**: token 또는 세션 쿠키 어느 쪽도 caller를 결정
-         *        하지 못하면 401.
+         *     1. **인증 가드 (최우선, ``Depends(require_member_admin)``)** — caller 빈
+         *        → 401, 권한 없음 → 403, 비활성 멤버 → 403.
          *     2. raw bytes 읽고 JSON 파싱 — 실패 시 422.
          *     3. ``MemberCreateRequest.model_validate`` — ValidationError → 422.
          *     4. ``svc.register`` 호출. ``PermissionError`` → 403, ``ValueError`` → 400.
@@ -814,7 +849,8 @@ export type paths = {
         };
         /**
          * Get Member
-         * @description 멤버 상세 조회.
+         * @description 멤버 상세 조회. 인증된 master/human 또는 ``member:read`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407).
          */
         get: operations["get_member_api_members__member_id__get"];
         put?: never;
@@ -840,7 +876,9 @@ export type paths = {
         head?: never;
         /**
          * Change Password
-         * @description 비밀번호 변경 (human 멤버 전용). 인증된 master만 호출 가능 (#1377).
+         * @description 비밀번호 변경 (human 멤버 전용). 인증된 master/human 또는
+         *     ``member:admin`` scope 를 보유한 agent 만 호출 가능 (#1407 — spec
+         *     ``member:admin`` 정합, #1377 master_caller 에서 마이그레이션).
          *
          *     배경: oracle A7 finding (#1377) — 본 라우트는 인증 없이 credential check
          *     (``svc.change_password``의 old-password 비교) 까지 도달했다. ``_caller_id``
@@ -859,8 +897,9 @@ export type paths = {
          *
          *     핸들러 단계 순서:
          *
-         *     1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-         *        non-master → 403. credential check 도달 전에 모두 차단된다.
+         *     1. 인증 가드 (``Depends(require_member_admin)``) — caller 빈 → 401,
+         *        권한 없음 → 403, 비활성 멤버 → 403. credential check 도달 전에 모두
+         *        차단된다.
          *     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
          *     3. ``PasswordChangeRequest.model_validate`` — ValidationError → 422.
          *     4. ``svc.change_password`` 호출. ``ValueError`` → 404,
@@ -883,7 +922,8 @@ export type paths = {
         put?: never;
         /**
          * Reactivate Member
-         * @description 멤버 재활성화. 인증된 master만 호출 가능 (#1351).
+         * @description 멤버 재활성화. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
          */
         post: operations["reactivate_member_api_members__member_id__reactivate_post"];
         delete?: never;
@@ -903,7 +943,8 @@ export type paths = {
         put?: never;
         /**
          * Revoke Member
-         * @description 멤버 영구 폐기. 인증된 master만 호출 가능 (#1351).
+         * @description 멤버 영구 폐기. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
          */
         post: operations["revoke_member_api_members__member_id__revoke_post"];
         delete?: never;
@@ -923,7 +964,8 @@ export type paths = {
         put?: never;
         /**
          * Rotate Token
-         * @description 토큰 재발급. 인증된 master만 호출 가능 (#1351).
+         * @description 토큰 재발급. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
          *
          *     인증 없이 token rotation 응답에 접근하면 token 값 자체가 노출되므로,
          *     가장 먼저 차단해야 한다.
@@ -945,15 +987,16 @@ export type paths = {
         get?: never;
         /**
          * Update Scopes
-         * @description 권한 범위 변경. 인증된 master만 호출 가능 (#1351).
+         * @description 권한 범위 변경. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
          *
-         *     ``create_member``와 동일한 raw body 파싱 패턴을 적용해 인증 가드가 body
-         *     validation보다 우선 실행되도록 한다(#1351 — Codex Plan Review). FastAPI가
-         *     ``body: ScopesUpdateRequest``를 먼저 검증하면 unauth + bad-body 시 401이
-         *     아닌 422가 먼저 반환되어 contract가 깨진다.
+         *     Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
+         *     한다. FastAPI 가 ``body: ScopesUpdateRequest`` 를 먼저 검증하면 unauth +
+         *     bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.
          *
          *     핸들러 단계 순서:
-         *     1. 인증 가드 (최우선) — 실패 시 401.
+         *     1. 인증 가드 (``Depends(require_member_admin)``) — caller 빈 → 401,
+         *        권한 없음 → 403, 비활성 멤버 → 403.
          *     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
          *     3. ``ScopesUpdateRequest.model_validate`` — ValidationError → 422.
          *     4. ``svc.update_scopes`` 호출. ``ValueError`` → 404,
@@ -978,7 +1021,8 @@ export type paths = {
         put?: never;
         /**
          * Suspend Member
-         * @description 멤버 일시 정지. 인증된 master만 호출 가능 (#1351).
+         * @description 멤버 일시 정지. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
          */
         post: operations["suspend_member_api_members__member_id__suspend_post"];
         delete?: never;
@@ -996,7 +1040,8 @@ export type paths = {
         };
         /**
          * Portfolio History
-         * @description 기간별 자산 추이 (daily_snapshots 시계열 반환).
+         * @description 기간별 자산 추이 (daily_snapshots 시계열 반환). 인증된 master/human 또는
+         *     ``treasury:read`` scope 를 보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["portfolio_history_api_portfolio_history_get"];
         put?: never;
@@ -1017,6 +1062,9 @@ export type paths = {
         /**
          * Portfolio Value
          * @description 총 자산 가치 + 당일 손익 + 수익률 + 미실현 손익 (최신 스냅샷 기반).
+         *     인증된 master/human 또는 ``treasury:read`` scope 를 보유한 agent 만 호출
+         *     가능 (#1407 — portfolio 라우트는 ``treasury_daily_snapshots`` 를 읽으므로
+         *     spec ``treasury:read`` 정합).
          */
         get: operations["portfolio_value_api_portfolio_value_get"];
         put?: never;
@@ -1036,7 +1084,8 @@ export type paths = {
         };
         /**
          * List Reports
-         * @description 리포트 목록 조회 (cursor 기반 페이지네이션).
+         * @description 리포트 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는
+         *     ``report:read`` scope 를 보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["list_reports_api_reports_get"];
         put?: never;
@@ -1074,7 +1123,8 @@ export type paths = {
         };
         /**
          * Report View
-         * @description 리포트 단건 조회.
+         * @description 리포트 단건 조회. 인증된 master/human 또는 ``report:read`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["report_view_api_reports__report_id__get"];
         put?: never;
@@ -1114,7 +1164,8 @@ export type paths = {
         };
         /**
          * List Strategies
-         * @description 전략 목록 조회.
+         * @description 전략 목록 조회. 인증된 master/human 또는 ``strategy:read`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["list_strategies_api_strategies_get"];
         put?: never;
@@ -1134,7 +1185,8 @@ export type paths = {
         };
         /**
          * Get Strategy
-         * @description 전략 상세 조회.
+         * @description 전략 상세 조회. 인증된 master/human 또는 ``strategy:read`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["get_strategy_api_strategies__strategy_id__get"];
         put?: never;
@@ -1154,7 +1206,8 @@ export type paths = {
         };
         /**
          * Get Strategy Daily Summary
-         * @description 전략 일별 성과 집계.
+         * @description 전략 일별 성과 집계. 인증된 master/human 또는 ``strategy:read`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["get_strategy_daily_summary_api_strategies__strategy_id__daily_summary_get"];
         put?: never;
@@ -1174,7 +1227,8 @@ export type paths = {
         };
         /**
          * Get Strategy Monthly Summary
-         * @description 전략 월별 성과 집계.
+         * @description 전략 월별 성과 집계. 인증된 master/human 또는 ``strategy:read`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["get_strategy_monthly_summary_api_strategies__strategy_id__monthly_summary_get"];
         put?: never;
@@ -1194,7 +1248,8 @@ export type paths = {
         };
         /**
          * Get Strategy Performance
-         * @description 전략 성과 지표 조회.
+         * @description 전략 성과 지표 조회. 인증된 master/human 또는 ``strategy:read`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["get_strategy_performance_api_strategies__strategy_id__performance_get"];
         put?: never;
@@ -1249,7 +1304,8 @@ export type paths = {
         };
         /**
          * Get Strategy Trades
-         * @description 전략 거래 내역 조회 (cursor 기반 페이지네이션).
+         * @description 전략 거래 내역 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는
+         *     ``strategy:read`` scope 를 보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["get_strategy_trades_api_strategies__strategy_id__trades_get"];
         put?: never;
@@ -1269,7 +1325,8 @@ export type paths = {
         };
         /**
          * Get Strategy Weekly Summary
-         * @description 전략 주별 성과 집계.
+         * @description 전략 주별 성과 집계. 인증된 master/human 또는 ``strategy:read`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["get_strategy_weekly_summary_api_strategies__strategy_id__weekly_summary_get"];
         put?: never;
@@ -1291,9 +1348,20 @@ export type paths = {
         put?: never;
         /**
          * Validate Strategy
-         * @description 전략 파일 정적 검증.
+         * @description 전략 파일 정적 검증. 인증된 master/human 또는 ``strategy:write`` scope
+         *     를 보유한 agent 만 호출 가능 (#1407 — spec ``strategy:write`` 정합).
          *
-         *     Body: {"path": "/path/to/strategy.py"}
+         *     Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
+         *     한다. 핸들러 단계 순서:
+         *
+         *     1. 인증 가드 (``Depends(require_strategy_write)``) — caller 빈 → 401,
+         *        권한 없음 → 403, 비활성 멤버 → 403.
+         *     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
+         *     3. ``path`` 필드 추출 — 누락 시 400.
+         *     4. 파일 존재 확인 → 404.
+         *     5. ``StrategyValidator.validate`` 호출.
+         *
+         *     Body: ``{"path": "/path/to/strategy.py"}``
          */
         post: operations["validate_strategy_api_strategies_validate_post"];
         delete?: never;
@@ -1313,16 +1381,16 @@ export type paths = {
         put?: never;
         /**
          * Clear Halt
-         * @description 전역 정지 해제 (모든 SUSPENDED 계좌 ACTIVE). 인증된 master 만 호출 가능
-         *     (#1375).
+         * @description 전역 정지 해제 (모든 SUSPENDED 계좌 ACTIVE). 인증된 master/human 또는
+         *     ``system:admin`` scope 를 보유한 agent 만 호출 가능 (#1407 — spec
+         *     ``system:admin`` 정합, #1375 master_caller 에서 마이그레이션).
          *
          *     계좌 상태만 ACTIVE 로 복구하며 봇을 자동 재시작하지 않는다.
          *
-         *     ``halt`` 와 동일한 raw body 파싱 + auth-first 패턴을 따른다 (#1375).
          *     핸들러 단계 순서:
          *
-         *     1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-         *        non-master → 403.
+         *     1. 인증 가드 (``Depends(require_system_admin)``) — caller 빈 → 401,
+         *        권한 없음 → 403, 비활성 멤버 → 403.
          *     2. raw bytes 읽기 + JSON 파싱 — 빈 body 는 default 허용, 그 외 실패 시 422.
          *     3. ``ClearHaltRequest.model_validate`` — ValidationError → 422.
          *     4. ``account_service.activate_all`` 호출 + audit 기록
@@ -1346,19 +1414,18 @@ export type paths = {
         put?: never;
         /**
          * Halt
-         * @description 전체 거래 중지 (모든 ACTIVE 계좌 SUSPENDED). 인증된 master 만 호출 가능
-         *     (#1375).
+         * @description 전체 거래 중지 (모든 ACTIVE 계좌 SUSPENDED). 인증된 master/human 또는
+         *     ``system:admin`` scope 를 보유한 agent 만 호출 가능 (#1407 — spec
+         *     ``system:admin`` 정합, #1375 master_caller 에서 마이그레이션).
          *
-         *     ``submit_report`` (#1374) 와 동일한 raw body 파싱 패턴을 적용해 인증 가드가
-         *     body validation 보다 우선 실행되도록 한다. FastAPI 가
-         *     ``body: HaltRequest`` 를 먼저 검증하면 unauth + bad-body 시 401 이 아닌
-         *     422 가 먼저 반환되어 contract 가 깨진다 — 본 라우트는 oracle A7 finding
-         *     의 핵심 시그니처 이므로 인증 가드 우선이 가장 중요하다.
+         *     Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
+         *     한다. FastAPI 가 ``body: HaltRequest`` 를 먼저 검증하면 unauth + bad-body
+         *     시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.
          *
          *     핸들러 단계 순서:
          *
-         *     1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-         *        non-master → 403.
+         *     1. 인증 가드 (``Depends(require_system_admin)``) — caller 빈 → 401,
+         *        권한 없음 → 403, 비활성 멤버 → 403.
          *     2. raw bytes 읽기 + JSON 파싱 — 빈 body 는 default 허용, 그 외 실패 시 422.
          *     3. ``HaltRequest.model_validate`` — ValidationError → 422.
          *     4. ``account_service.suspend_all`` 호출 + audit 기록
@@ -1406,7 +1473,10 @@ export type paths = {
         };
         /**
          * Get System Status
-         * @description 시스템 상태 조회.
+         * @description 시스템 상태 조회. 인증된 master/human 또는 ``system:read`` scope 를 보유한
+         *     agent 만 호출 가능 (#1407). ``/api/system/health`` (public) 와 구별 —
+         *     health 는 모니터링 헬스체크용이고 status 는 운영 정보(account_count 등)를
+         *     노출한다.
          */
         get: operations["get_system_status_api_system_status_get"];
         put?: never;
@@ -1426,7 +1496,8 @@ export type paths = {
         };
         /**
          * List Trades
-         * @description 거래 기록 목록 조회 (cursor 기반 페이지네이션).
+         * @description 거래 기록 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는
+         *     ``trade:read`` scope 를 보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["list_trades_api_trades_get"];
         put?: never;
@@ -1446,7 +1517,8 @@ export type paths = {
         };
         /**
          * Get Summary
-         * @description 자금 현황 요약.
+         * @description 자금 현황 요약. 인증된 master/human 또는 ``treasury:read`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407).
          *
          *     account_id 지정 시 해당 계좌의 Treasury 요약을 반환한다.
          *     미지정 시 기본 Treasury 요약을 반환한다 (하위 호환).
@@ -1471,18 +1543,18 @@ export type paths = {
         put?: never;
         /**
          * Set Balance
-         * @description 계좌 총 잔고 수동 설정. 인증된 master만 호출 가능 (#1352).
+         * @description 계좌 총 잔고 수동 설정. 인증된 master/human 또는 ``treasury:admin`` scope
+         *     를 보유한 agent 만 호출 가능 (#1407 — spec ``treasury:admin`` 정합, #1352
+         *     master_caller 에서 마이그레이션).
          *
-         *     ``create_member`` / ``update_scopes`` / ``update_bot``과 동일한 raw body
-         *     파싱 패턴을 적용해 인증 가드가 body validation보다 우선 실행되도록 한다
-         *     (#1352 — Codex Plan Review). FastAPI가 ``body: BalanceSetRequest``를 먼저
-         *     검증하면 unauth + bad-body 시 401이 아닌 422가 먼저 반환되어 contract가
-         *     깨진다.
+         *     Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
+         *     한다. FastAPI 가 ``body: BalanceSetRequest`` 를 먼저 검증하면 unauth +
+         *     bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.
          *
          *     핸들러 단계 순서:
          *
-         *     1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-         *        non-master → 403.
+         *     1. 인증 가드 (``Depends(require_treasury_admin)``) — caller 빈 → 401,
+         *        권한 없음 → 403, 비활성 멤버 → 403.
          *     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
          *     3. ``BalanceSetRequest.model_validate`` — ValidationError → 422.
          *     4. ``treasury.set_account_balance`` 호출.
@@ -1505,17 +1577,18 @@ export type paths = {
         put?: never;
         /**
          * Allocate
-         * @description 봇에 예산 할당. 인증된 master만 호출 가능 (#1372).
+         * @description 봇에 예산 할당. 인증된 master/human 또는 ``treasury:admin`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407 — spec ``treasury:admin`` 정합, #1372
+         *     master_caller 에서 마이그레이션).
          *
-         *     ``set_balance`` (#1352)와 동일한 raw body 파싱 패턴을 적용해 인증 가드가
-         *     body validation보다 우선 실행되도록 한다. FastAPI가 ``body:
-         *     BudgetChangeRequest``를 먼저 검증하면 unauth + bad-body 시 401이 아닌
-         *     422가 먼저 반환되어 contract가 깨진다.
+         *     Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
+         *     한다. FastAPI 가 ``body: BudgetChangeRequest`` 를 먼저 검증하면 unauth +
+         *     bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.
          *
          *     핸들러 단계 순서:
          *
-         *     1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-         *        non-master → 403.
+         *     1. 인증 가드 (``Depends(require_treasury_admin)``) — caller 빈 → 401,
+         *        권한 없음 → 403, 비활성 멤버 → 403.
          *     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
          *     3. ``BudgetChangeRequest.model_validate`` — ValidationError → 422.
          *     4. ``treasury.allocate`` 호출 (``BotNotStoppedError`` → 409).
@@ -1538,15 +1611,14 @@ export type paths = {
         put?: never;
         /**
          * Deallocate
-         * @description 봇 예산 회수. 인증된 master만 호출 가능 (#1372).
-         *
-         *     ``allocate`` / ``set_balance`` (#1352)와 동일한 raw body 파싱 패턴을
-         *     적용해 인증 가드가 body validation보다 우선 실행되도록 한다.
+         * @description 봇 예산 회수. 인증된 master/human 또는 ``treasury:admin`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407 — spec ``treasury:admin`` 정합, #1372
+         *     master_caller 에서 마이그레이션).
          *
          *     핸들러 단계 순서:
          *
-         *     1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-         *        non-master → 403.
+         *     1. 인증 가드 (``Depends(require_treasury_admin)``) — caller 빈 → 401,
+         *        권한 없음 → 403, 비활성 멤버 → 403.
          *     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
          *     3. ``BudgetChangeRequest.model_validate`` — ValidationError → 422.
          *     4. ``treasury.deallocate`` 호출 (``BotNotStoppedError`` → 409).
@@ -1567,7 +1639,8 @@ export type paths = {
         };
         /**
          * List Budgets
-         * @description 봇별 예산 목록 조회.
+         * @description 봇별 예산 목록 조회. 인증된 master/human 또는 ``treasury:read`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["list_budgets_api_treasury_budgets_get"];
         put?: never;
@@ -1587,7 +1660,8 @@ export type paths = {
         };
         /**
          * List Snapshots
-         * @description 기간별 일별 스냅샷 목록.
+         * @description 기간별 일별 스냅샷 목록. 인증된 master/human 또는 ``treasury:read`` scope
+         *     를 보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["list_snapshots_api_treasury_snapshots_get"];
         put?: never;
@@ -1607,7 +1681,8 @@ export type paths = {
         };
         /**
          * Get Snapshot By Date
-         * @description 특정일 스냅샷 조회.
+         * @description 특정일 스냅샷 조회. 인증된 master/human 또는 ``treasury:read`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["get_snapshot_by_date_api_treasury_snapshots__date__get"];
         put?: never;
@@ -1627,7 +1702,8 @@ export type paths = {
         };
         /**
          * Get Latest Snapshot
-         * @description 가장 최근 일별 스냅샷 조회.
+         * @description 가장 최근 일별 스냅샷 조회. 인증된 master/human 또는 ``treasury:read``
+         *     scope 를 보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["get_latest_snapshot_api_treasury_snapshots_latest_get"];
         put?: never;
@@ -1647,7 +1723,8 @@ export type paths = {
         };
         /**
          * List Transactions
-         * @description 자금 변동 이력 조회.
+         * @description 자금 변동 이력 조회. 인증된 master/human 또는 ``treasury:read`` scope 를
+         *     보유한 agent 만 호출 가능 (#1407).
          */
         get: operations["list_transactions_api_treasury_transactions_get"];
         put?: never;
@@ -1734,7 +1811,7 @@ export type components = {
         };
         /**
          * AccountSuspendRequest
-         * @description POST /api/accounts/{account_id}/suspend 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1352). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다. 빈 body도 허용되며 reason은 default 'dashboard'로 채워진다.
+         * @description POST /api/accounts/{account_id}/suspend 입력 contract. 인증된 master/human 또는 account:write scope 를 보유한 agent 만 사용할 수 있다(#1407, #1352 master_caller migration). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다. 빈 body도 허용되며 reason은 default 'dashboard'로 채워진다.
          */
         AccountSuspendRequest: {
             /**
@@ -1844,19 +1921,6 @@ export type components = {
          * @enum {string}
          */
         ApprovalStatus: "pending" | "approved" | "execution_failed" | "rejected" | "on_hold" | "expired" | "cancelled";
-        /**
-         * ApprovalStatusUpdate
-         * @description 승인/거부 요청.
-         */
-        ApprovalStatusUpdate: {
-            /**
-             * Memo
-             * @default
-             */
-            memo: string;
-            /** Status */
-            status: string;
-        };
         /**
          * ApprovalUpdateResponse
          * @description 결재 상태 변경 응답.
@@ -2981,6 +3045,14 @@ export type components = {
         /**
          * RuleUpdateRequest
          * @description 룰 설정 변경 요청.
+         *
+         *     ``params`` 는 룰별 schema 를 갖는 open object 지만, 모든 numeric threshold
+         *     는 finite 여야 한다 (#1380 oracle A7). ``json.loads`` default 는 ``NaN`` /
+         *     ``Infinity`` / ``-Infinity`` 를 ``float('nan')`` / ``float('inf')`` 로
+         *     파싱하므로, raw body parser 가 통과시킨 값을 본 모델 단에서 422 로 거부한다.
+         *     bool 은 numeric 흉내 방지를 위해 ``_reject_non_finite`` 가 통과시키되,
+         *     RULE_REGISTRY ``validate_config`` 가 known numeric key 에 대해 별도로
+         *     거부한다.
          */
         RuleUpdateRequest: {
             /**
@@ -3535,7 +3607,6 @@ export type ApprovalDetailResponse = components['schemas']['ApprovalDetailRespon
 export type ApprovalItem = components['schemas']['ApprovalItem'];
 export type ApprovalListResponse = components['schemas']['ApprovalListResponse'];
 export type ApprovalStatus = components['schemas']['ApprovalStatus'];
-export type ApprovalStatusUpdate = components['schemas']['ApprovalStatusUpdate'];
 export type ApprovalUpdateResponse = components['schemas']['ApprovalUpdateResponse'];
 export type AuditLogItem = components['schemas']['AuditLogItem'];
 export type AuditLogListResponse = components['schemas']['AuditLogListResponse'];
@@ -3822,7 +3893,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Permission denied (master 권한 필요) */
+            /** @description Permission denied (master, human 멤버 또는 account:write scope 보유 agent 만 허용) */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -3938,7 +4009,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Permission denied (master 권한 필요) */
+            /** @description Permission denied (master, human 멤버 또는 account:write scope 보유 agent 만 허용) */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -4041,7 +4112,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Permission denied (master 권한 필요). */
+            /** @description Permission denied (master, human 멤버 또는 rule:admin scope 보유 agent 만 허용). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -4094,7 +4165,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Permission denied (master 권한 필요) */
+            /** @description Permission denied (master, human 멤버 또는 account:write scope 보유 agent 만 허용) */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -4234,11 +4305,7 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ApprovalStatusUpdate"];
-            };
-        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {
@@ -4258,6 +4325,24 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
+            /** @description Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Permission denied (master, human 멤버 또는 approval:admin scope 보유 agent 만 허용). */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
             /** @description Approval not found */
             404: {
                 headers: {
@@ -4267,13 +4352,13 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Body validation 실패 (JSON 파싱 실패, 빈 body, 필수 필드 누락, type mismatch). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다(#1407). */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Approval service not available */
@@ -4572,7 +4657,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Permission denied (master 권한 필요) */
+            /** @description Permission denied (master, human 멤버 또는 bot:admin scope 보유 agent 만 허용) */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -4710,7 +4795,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Permission denied (master 권한 필요) */
+            /** @description Permission denied (master, human 멤버 또는 bot:admin scope 보유 agent 만 허용) */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -4786,7 +4871,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Permission denied (master 권한 필요) */
+            /** @description Permission denied (master, human 멤버 또는 bot:admin scope 보유 agent 만 허용) */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -5495,7 +5580,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Permission denied (master 권한 필요). */
+            /** @description Permission denied (master, human 멤버 또는 member:admin scope 보유 agent 만 허용). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -6540,13 +6625,7 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    [key: string]: unknown;
-                };
-            };
-        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {
@@ -6566,6 +6645,24 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
+            /** @description Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Permission denied (master, human 멤버 또는 strategy:write scope 보유 agent 만 허용). */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
+                };
+            };
             /** @description Strategy file not found */
             404: {
                 headers: {
@@ -6575,13 +6672,13 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Body validation 실패 (JSON 파싱 실패, 빈 body). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다 (#1407). */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
         };
@@ -6617,7 +6714,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Permission denied (master 권한 필요). */
+            /** @description Permission denied (master, human 멤버 또는 system:admin scope 보유 agent 만 허용). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -6677,7 +6774,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Permission denied (master 권한 필요). */
+            /** @description Permission denied (master, human 멤버 또는 system:admin scope 보유 agent 만 허용). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -6870,7 +6967,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Permission denied (master 권한 필요) */
+            /** @description Permission denied (master, human 멤버 또는 treasury:admin scope 보유 agent 만 허용) */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -6941,7 +7038,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Permission denied (master 권한 필요) */
+            /** @description Permission denied (master, human 멤버 또는 treasury:admin scope 보유 agent 만 허용) */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -7030,7 +7127,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Permission denied (master 권한 필요) */
+            /** @description Permission denied (master, human 멤버 또는 treasury:admin scope 보유 agent 만 허용) */
             403: {
                 headers: {
                     [name: string]: unknown;

--- a/src/ante/web/deps.py
+++ b/src/ante/web/deps.py
@@ -548,17 +548,45 @@ def require_scope(scope: str) -> Callable[..., Awaitable[str]]:
     return inner_dep
 
 
-# ── Module-level scope alias (#1406) ───────────────────────────────────────
+# ── Module-level scope alias (#1406 + #1407) ───────────────────────────────
 #
 # 라우트 import 호환성과 FastAPI Depends() instance cache 보존을 위해
-# 4개 기존 dependency 를 module-level alias 로 보존한다. 라우트 안에서
+# 모든 scope dependency 를 module-level alias 로 정의한다. 라우트 안에서
 # ``Depends(require_scope("audit:read"))`` 처럼 inline 으로 호출하면 매
 # 라우트 정의마다 새 callable 이 생성되어 cache identity 가 깨지므로,
 # 신규 scope alias 도 반드시 module-level 에 한 번만 정의해야 한다.
+#
+# 기존 4개 (#1406) — detail 은 ``_SCOPE_DENIED_DETAIL_MAP`` 매핑으로 byte-exact
+# 보존된다.
 require_audit_read = require_scope("audit:read")
 require_config_write = require_scope("config:write")
 require_report_write = require_scope("report:write")
 require_strategy_write = require_scope("strategy:write")
+
+# 신규 20개 (#1407) — SSOT ``docs/specs/web-api/11-route-scope-table.md`` 결정
+# scope 컬럼에서 byte-exact 추출. detail 은 ``_default_denied_detail`` 템플릿
+# ("master, human 멤버 또는 {scope} scope ...") 을 사용한다. 라우트는 본 alias
+# 를 import 해 ``Depends(require_X_Y)`` 형태로 부착한다.
+require_account_read = require_scope("account:read")
+require_account_write = require_scope("account:write")
+require_approval_read = require_scope("approval:read")
+require_approval_admin = require_scope("approval:admin")
+require_bot_read = require_scope("bot:read")
+require_bot_admin = require_scope("bot:admin")
+require_config_read = require_scope("config:read")
+require_data_read = require_scope("data:read")
+require_data_write = require_scope("data:write")
+require_member_read = require_scope("member:read")
+require_member_admin = require_scope("member:admin")
+require_report_read = require_scope("report:read")
+require_rule_read = require_scope("rule:read")
+require_rule_admin = require_scope("rule:admin")
+require_strategy_read = require_scope("strategy:read")
+require_system_read = require_scope("system:read")
+require_system_admin = require_scope("system:admin")
+require_trade_read = require_scope("trade:read")
+require_treasury_read = require_scope("treasury:read")
+require_treasury_admin = require_scope("treasury:admin")
 
 
 # ── 인증 dependency 정적 검증 marker (#1405) ───────────────────────────────

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -14,7 +14,10 @@ from ante.web.deps import (
     get_audit_logger_optional,
     get_config,
     get_dynamic_config,
-    require_master_caller,
+    require_account_read,
+    require_account_write,
+    require_rule_admin,
+    require_rule_read,
 )
 from ante.web.schemas import (
     AccountActionResponse,
@@ -292,10 +295,12 @@ def _account_to_response(account: Any) -> dict[str, Any]:
 
 @router.get("", response_model=AccountListResponse)
 async def list_accounts(
+    _caller_id: Annotated[str, Depends(require_account_read)],
     account_service: Annotated[Any, Depends(get_account_service)],
     status: str | None = None,
 ) -> dict[str, Any]:
-    """계좌 목록 조회."""
+    """계좌 목록 조회. 인증된 master/human 또는 ``account:read`` scope 를 보유한
+    agent 만 호출 가능 (#1407)."""
     from ante.account.models import AccountStatus
 
     filter_status: AccountStatus | None = None
@@ -340,8 +345,12 @@ async def list_accounts(
         },
     },
 )
-async def create_account(request: Request) -> None:
-    """계좌 생성.
+async def create_account(
+    request: Request,
+    _caller_id: Annotated[str, Depends(require_account_write)],
+) -> None:
+    """계좌 생성. 인증된 master/human 또는 ``account:write`` scope 를 보유한
+    agent 만 호출 가능 (#1407).
 
     런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.
     실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로
@@ -373,9 +382,11 @@ async def create_account(request: Request) -> None:
 @router.get("/{account_id}", response_model=AccountDetailResponse)
 async def get_account(
     account_id: str,
+    _caller_id: Annotated[str, Depends(require_account_read)],
     account_service: Annotated[Any, Depends(get_account_service)],
 ) -> dict[str, Any]:
-    """계좌 상세 조회."""
+    """계좌 상세 조회. 인증된 master/human 또는 ``account:read`` scope 를 보유한
+    agent 만 호출 가능 (#1407)."""
     from ante.account.errors import AccountNotFoundError
 
     try:
@@ -412,7 +423,10 @@ async def get_account(
             },
         },
         403: {
-            "description": "Permission denied (master 권한 필요)",
+            "description": (
+                "Permission denied (master, human 멤버 또는 account:write scope "
+                "보유 agent 만 허용)"
+            ),
             "content": {
                 "application/problem+json": {
                     "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -483,16 +497,17 @@ async def get_account(
 async def update_account(
     account_id: str,
     request: Request,
-    caller_id: Annotated[str, Depends(require_master_caller)],
+    caller_id: Annotated[str, Depends(require_account_write)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)] = None,
 ) -> dict[str, Any]:
     """계좌 수정.
 
-    인증된 master 호출자만 사용할 수 있다(이슈 #1352 — oracle A7). dependency
-    ``require_master_caller``가 인증/권한 검증을 담당하며, 401/403은 raw body
-    파싱과 cold-path 가드(invariant I1/I4)보다 먼저 평가된다 — Bearer 또는
-    ``ante_session`` 쿠키 어느 쪽으로도 caller가 결정되지 않으면 401, master가
-    아니면 403.
+    인증된 master/human 또는 ``account:write`` scope 를 보유한 agent 만 호출
+    가능 (#1407 — spec ``account:write`` 정합, #1352 master_caller 에서
+    마이그레이션). dependency ``require_account_write`` 가 인증/권한 검증을
+    담당하며, 401/403은 raw body 파싱과 cold-path 가드(invariant I1/I4)보다
+    먼저 평가된다 — Bearer 또는 ``ante_session`` 쿠키 어느 쪽으로도 caller가
+    결정되지 않으면 401, 권한 없으면 403.
 
     런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,
     ``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도
@@ -690,7 +705,10 @@ _AUTH_REQUIRED_RESPONSE: dict[str, Any] = {
 }
 
 _PERMISSION_DENIED_RESPONSE: dict[str, Any] = {
-    "description": "Permission denied (master 권한 필요)",
+    "description": (
+        "Permission denied (master, human 멤버 또는 account:write scope "
+        "보유 agent 만 허용)"
+    ),
     "content": {
         "application/problem+json": {
             "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -716,7 +734,8 @@ ACCOUNT_SUSPEND_REQUEST_SCHEMA: dict[str, Any] = {
     "title": "AccountSuspendRequest",
     "description": (
         "POST /api/accounts/{account_id}/suspend 입력 contract. "
-        "인증된 master 호출자만 사용할 수 있다(#1352). "
+        "인증된 master/human 또는 account:write scope 를 보유한 agent 만 "
+        "사용할 수 있다(#1407, #1352 master_caller migration). "
         "Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, "
         "둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다. "
         "빈 body도 허용되며 reason은 default 'dashboard'로 채워진다."
@@ -791,11 +810,13 @@ ACCOUNT_SUSPEND_REQUEST_SCHEMA: dict[str, Any] = {
 async def suspend_account(
     account_id: str,
     request: Request,
-    caller_id: Annotated[str, Depends(require_master_caller)],
+    caller_id: Annotated[str, Depends(require_account_write)],
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict[str, Any]:
-    """계좌 정지. 인증된 master만 호출 가능 (#1352).
+    """계좌 정지. 인증된 master/human 또는 ``account:write`` scope 를 보유한
+    agent 만 호출 가능 (#1407 — spec ``account:write`` 정합, #1352
+    master_caller 에서 마이그레이션).
 
     ``update_bot`` / ``set_balance`` / ``update_scopes``와 동일한 raw body 파싱
     패턴을 적용해 인증 가드가 body validation보다 먼저 실행되도록 한다(#1352
@@ -805,8 +826,8 @@ async def suspend_account(
 
     핸들러 단계 순서:
 
-    1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-       non-master → 403.
+    1. 인증 가드 (``Depends(require_account_write)``) — caller 빈 → 401,
+       권한 없음 → 403, 비활성 멤버 → 403.
     2. raw bytes 읽기. 빈 body → default reason (``dashboard``)로 흘려보낸다
        (기존 의미 보존).
     3. JSON 파싱 실패 → 422.
@@ -899,11 +920,13 @@ async def suspend_account(
 async def activate_account(
     account_id: str,
     request: Request,
-    caller_id: Annotated[str, Depends(require_master_caller)],
+    caller_id: Annotated[str, Depends(require_account_write)],
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict[str, Any]:
-    """계좌 재활성화. 인증된 master만 호출 가능 (#1352)."""
+    """계좌 재활성화. 인증된 master/human 또는 ``account:write`` scope 를 보유한
+    agent 만 호출 가능 (#1407 — spec ``account:write`` 정합, #1352
+    master_caller 에서 마이그레이션)."""
     from ante.account.errors import AccountDeletedError, AccountNotFoundError
 
     try:
@@ -947,8 +970,13 @@ async def activate_account(
         },
     },
 )
-async def delete_account(account_id: str, request: Request) -> None:
-    """계좌 소프트 딜리트.
+async def delete_account(
+    account_id: str,
+    request: Request,
+    _caller_id: Annotated[str, Depends(require_account_write)],
+) -> None:
+    """계좌 소프트 딜리트. 인증된 master/human 또는 ``account:write`` scope 를
+    보유한 agent 만 호출 가능 (#1407).
 
     런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.
     실제 계좌 삭제는 서버 정지 상태에서 ``ante account delete`` CLI로
@@ -1004,11 +1032,13 @@ def _item_to_rule_config(
 @router.get("/{account_id}/rules", response_model=RuleListResponse)
 async def get_account_rules(
     account_id: str,
+    _caller_id: Annotated[str, Depends(require_rule_read)],
     account_service: Annotated[Any, Depends(get_account_service)],
     config: Annotated[Any | None, Depends(get_config)],
     dynamic_config: Annotated[Any | None, Depends(get_dynamic_config)],
 ) -> dict[str, Any]:
-    """계좌 리스크 룰 목록 조회.
+    """계좌 리스크 룰 목록 조회. 인증된 master/human 또는 ``rule:read`` scope 를
+    보유한 agent 만 호출 가능 (#1407).
 
     DynamicConfig를 우선 조회하고, 없으면 정적 Config에서 읽는다.
     RULE_REGISTRY에 등록된 룰 타입만 구조화하여 반환한다.
@@ -1098,7 +1128,10 @@ RULE_UPDATE_REQUEST_SCHEMA: dict[str, Any] = _build_rule_update_request_schema()
             },
         },
         403: {
-            "description": "Permission denied (master 권한 필요).",
+            "description": (
+                "Permission denied (master, human 멤버 또는 rule:admin scope "
+                "보유 agent 만 허용)."
+            ),
             "content": {
                 "application/problem+json": {
                     "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -1134,13 +1167,15 @@ async def update_account_rule(
     account_id: str,
     rule_type: str,
     request: Request,
-    caller_id: Annotated[str, Depends(require_master_caller)],
+    caller_id: Annotated[str, Depends(require_rule_admin)],
     account_service: Annotated[Any, Depends(get_account_service)],
     config: Annotated[Any | None, Depends(get_config)],
     dynamic_config: Annotated[Any, Depends(get_dynamic_config)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict[str, Any]:
-    """계좌 리스크 룰 개별 수정. 인증된 master 만 호출 가능 (#1376).
+    """계좌 리스크 룰 개별 수정. 인증된 master/human 또는 ``rule:admin`` scope
+    를 보유한 agent 만 호출 가능 (#1407 — spec ``rule:admin`` 정합, #1376
+    master_caller 에서 마이그레이션).
 
     RULE_REGISTRY에 등록된 타입만 허용하며,
     DynamicConfigService에 위임하여 ConfigChangedEvent를 발행한다.
@@ -1160,8 +1195,8 @@ async def update_account_rule(
 
     핸들러 단계 순서:
 
-    1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-       non-master → 403.
+    1. 인증 가드 (``Depends(require_rule_admin)``) — caller 빈 → 401,
+       권한 없음 → 403, 비활성 멤버 → 403.
     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
     3. ``RuleUpdateRequest.model_validate`` — ValidationError → 422.
     4. RULE_REGISTRY 룰 타입 확인 — 없으면 400 (기존 계약 보존).

--- a/src/ante/web/routes/approvals.py
+++ b/src/ante/web/routes/approvals.py
@@ -2,18 +2,21 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import asdict
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from ante.approval.models import ApprovalStatus
 from ante.web.deps import (
     get_approval_service,
     get_audit_logger_optional,
     get_report_store_optional,
+    require_approval_admin,
+    require_approval_read,
 )
 from ante.web.schemas import (
     ApprovalDetailResponse,
@@ -48,6 +51,7 @@ class ApprovalStatusUpdate(BaseModel):
     },
 )
 async def list_approvals(
+    _caller_id: Annotated[str, Depends(require_approval_read)],
     approval_service: Annotated[Any, Depends(get_approval_service)],
     status: ApprovalStatus | None = Query(default=None),
     # NOTE: ``type``은 본 PR scope 외 (frontend ApprovalType과 backend SSOT
@@ -94,10 +98,12 @@ async def list_approvals(
 )
 async def get_approval(
     approval_id: str,
+    _caller_id: Annotated[str, Depends(require_approval_read)],
     approval_service: Annotated[Any, Depends(get_approval_service)],
     report_store: Annotated[Any | None, Depends(get_report_store_optional)],
 ) -> dict:
-    """결재 상세 조회."""
+    """결재 상세 조회. 인증된 master/human 또는 ``approval:read`` scope 를
+    보유한 agent 만 호출 가능 (#1407)."""
     approval = await approval_service.get(approval_id)
     if not approval:
         raise HTTPException(status_code=404, detail="결재 요청을 찾을 수 없습니다")
@@ -127,8 +133,45 @@ async def get_approval(
                 },
             },
         },
+        401: {
+            "description": (
+                "Authentication required (missing or invalid Authorization "
+                "header AND missing or invalid ante_session cookie). 대시보드 "
+                "사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, "
+                "에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 "
+                "하나라도 유효하면 통과한다."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
+        403: {
+            "description": (
+                "Permission denied (master, human 멤버 또는 approval:admin "
+                "scope 보유 agent 만 허용)."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
         404: {
             "description": "Approval not found",
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
+        422: {
+            "description": (
+                "Body validation 실패 (JSON 파싱 실패, 빈 body, 필수 필드 누락, "
+                "type mismatch). 단, 인증이 실패하면 body validation 은 실행되지 "
+                "않고 401 이 우선 반환된다(#1407)."
+            ),
             "content": {
                 "application/problem+json": {
                     "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -147,20 +190,55 @@ async def get_approval(
 )
 async def update_approval_status(
     approval_id: str,
-    body: ApprovalStatusUpdate,
     request: Request,
+    caller_id: Annotated[str, Depends(require_approval_admin)],
     approval_service: Annotated[Any, Depends(get_approval_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """결재 승인/거부 처리."""
+    """결재 승인/거부 처리. 인증된 master/human 또는 ``approval:admin`` scope
+    를 보유한 agent 만 호출 가능 (#1407 — spec ``approval:admin`` 정합).
+
+    Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
+    한다. FastAPI 가 ``body: ApprovalStatusUpdate`` 를 먼저 검증하면 unauth +
+    bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.
+
+    핸들러 단계 순서:
+
+    1. 인증 가드 (``Depends(require_approval_admin)``) — caller 빈 → 401,
+       권한 없음 → 403, 비활성 멤버 → 403.
+    2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
+    3. ``ApprovalStatusUpdate.model_validate`` — ValidationError → 422.
+    4. service 호출 (``approve`` / ``reject``).
+    """
+    # 1. raw body 읽기 + JSON 파싱 — 인증 통과 후에만 실행된다.
+    raw = await request.body()
+    if raw == b"":
+        raise HTTPException(status_code=422, detail="요청 body가 비어 있습니다.")
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        raise HTTPException(
+            status_code=422, detail="요청 body의 JSON 파싱에 실패했습니다."
+        ) from None
+    if not isinstance(payload, dict):
+        raise HTTPException(
+            status_code=422, detail="요청 body는 JSON object여야 합니다."
+        )
+
+    # 2. Pydantic 검증.
+    try:
+        body = ApprovalStatusUpdate.model_validate(payload)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.errors()) from None
+
     try:
         if body.status == "approved":
             approval = await approval_service.approve(
-                id=approval_id, resolved_by="user"
+                id=approval_id, resolved_by=caller_id
             )
         elif body.status == "rejected":
             approval = await approval_service.reject(
-                id=approval_id, resolved_by="user", reject_reason=body.memo
+                id=approval_id, resolved_by=caller_id, reject_reason=body.memo
             )
         else:
             raise HTTPException(
@@ -173,7 +251,7 @@ async def update_approval_status(
     action = "approval.approve" if body.status == "approved" else "approval.reject"
     if audit_logger:
         await audit_logger.log(
-            member_id=getattr(request.state, "member_id", "user"),
+            member_id=caller_id,
             action=action,
             resource=f"approval:{approval_id}",
             detail=body.memo,

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -19,7 +19,8 @@ from ante.web.deps import (
     get_strategy_registry_optional,
     get_trade_service_optional,
     get_treasury_optional,
-    require_master_caller,
+    require_bot_admin,
+    require_bot_read,
 )
 from ante.web.schemas import (
     BotDetailResponse,
@@ -129,13 +130,15 @@ BOT_CREATE_REQUEST_SCHEMA: dict[str, Any] = {
     },
 )
 async def list_bots(
+    _caller_id: Annotated[str, Depends(require_bot_read)],
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     registry: Annotated[Any | None, Depends(get_strategy_registry_optional)],
     account_id: str | None = None,
     limit: int = Query(default=20, ge=1, le=100),
     cursor: str | None = None,
 ) -> dict:
-    """봇 목록 조회 (cursor 기반 페이지네이션)."""
+    """봇 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는
+    ``bot:read`` scope 를 보유한 agent 만 호출 가능 (#1407)."""
     from ante.web.pagination import paginate
 
     bots = bot_manager.list_bots()
@@ -202,7 +205,10 @@ async def list_bots(
             },
         },
         403: {
-            "description": "Permission denied (master 권한 필요)",
+            "description": (
+                "Permission denied (master, human 멤버 또는 bot:admin "
+                "scope 보유 agent 만 허용)"
+            ),
             "content": {
                 "application/problem+json": {
                     "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -275,23 +281,24 @@ async def list_bots(
 )
 async def create_bot(
     request: Request,
-    caller_id: Annotated[str, Depends(require_master_caller)],
+    caller_id: Annotated[str, Depends(require_bot_admin)],
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     registry: Annotated[Any, Depends(get_strategy_registry)],
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """봇 생성. 인증된 master만 호출 가능 (#1371).
+    """봇 생성. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한 agent
+    만 호출 가능 (#1407 — spec ``bot:admin`` 정합, #1371 master_caller 에서
+    마이그레이션).
 
-    ``update_bot`` (#1352)과 동일한 raw body 파싱 패턴을 적용해 인증 가드가
-    body validation보다 우선 실행되도록 한다. FastAPI가 ``body: BotCreateRequest``
-    를 먼저 검증하면 unauth + bad-body 시 401이 아닌 422가 먼저 반환되어
-    contract가 깨진다.
+    Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
+    한다. FastAPI 가 ``body: BotCreateRequest`` 를 먼저 검증하면 unauth +
+    bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.
 
     핸들러 단계 순서:
 
-    1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-       non-master → 403.
+    1. 인증 가드 (``Depends(require_bot_admin)``) — caller 빈 → 401,
+       권한 없음 → 403, 비활성 멤버 → 403.
     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
     3. ``BotCreateRequest.model_validate`` — ValidationError → 422.
     4. service 호출 (``BotError`` → 409, ``TreasuryError`` → 422).
@@ -508,12 +515,14 @@ async def create_bot(
 )
 async def get_bot(
     bot_id: str,
+    _caller_id: Annotated[str, Depends(require_bot_read)],
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     registry: Annotated[Any | None, Depends(get_strategy_registry_optional)],
     treasury: Annotated[Any | None, Depends(get_treasury_optional)],
     trade_service: Annotated[Any | None, Depends(get_trade_service_optional)],
 ) -> dict:
-    """봇 상세 조회."""
+    """봇 상세 조회. 인증된 master/human 또는 ``bot:read`` scope 를 보유한
+    agent 만 호출 가능 (#1407)."""
     bot = bot_manager.get_bot(bot_id)
     if bot is None:
         raise HTTPException(status_code=404, detail=_BOT_NOT_FOUND)
@@ -605,11 +614,13 @@ async def get_bot(
 async def start_bot(
     bot_id: str,
     request: Request,
+    caller_id: Annotated[str, Depends(require_bot_admin)],
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """봇 시작."""
+    """봇 시작. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한 agent
+    만 호출 가능 (#1407)."""
     from ante.bot.exceptions import BotError
 
     bot = bot_manager.get_bot(bot_id)
@@ -631,7 +642,7 @@ async def start_bot(
 
     if audit_logger:
         await audit_logger.log(
-            member_id=getattr(request.state, "member_id", "anonymous"),
+            member_id=caller_id,
             action="bot.start",
             resource=f"bot:{bot_id}",
             ip=request.client.host if request.client else "",
@@ -673,10 +684,12 @@ async def start_bot(
 async def stop_bot(
     bot_id: str,
     request: Request,
+    caller_id: Annotated[str, Depends(require_bot_admin)],
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """봇 중지."""
+    """봇 중지. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한 agent
+    만 호출 가능 (#1407)."""
     from ante.bot.exceptions import BotError
 
     bot = bot_manager.get_bot(bot_id)
@@ -690,7 +703,7 @@ async def stop_bot(
 
     if audit_logger:
         await audit_logger.log(
-            member_id=getattr(request.state, "member_id", "anonymous"),
+            member_id=caller_id,
             action="bot.stop",
             resource=f"bot:{bot_id}",
             ip=request.client.host if request.client else "",
@@ -717,7 +730,10 @@ async def stop_bot(
             },
         },
         403: {
-            "description": "Permission denied (master 권한 필요)",
+            "description": (
+                "Permission denied (master, human 멤버 또는 bot:admin "
+                "scope 보유 agent 만 허용)"
+            ),
             "content": {
                 "application/problem+json": {
                     "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -761,12 +777,14 @@ async def stop_bot(
 async def delete_bot(
     bot_id: str,
     request: Request,
-    caller_id: Annotated[str, Depends(require_master_caller)],
+    caller_id: Annotated[str, Depends(require_bot_admin)],
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
     handle_positions: str = "keep",
 ) -> None:
-    """봇 삭제. 인증된 master만 호출 가능 (#1371).
+    """봇 삭제. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한 agent
+    만 호출 가능 (#1407 — spec ``bot:admin`` 정합, #1371 master_caller 에서
+    마이그레이션).
 
     body가 없으므로 raw-body cold-path는 적용하지 않는다. 인증 가드가
     handle_positions query 파라미터 검증보다 먼저 실행되어 unauth는 401,
@@ -889,7 +907,10 @@ BOT_UPDATE_REQUEST_SCHEMA: dict[str, Any] = {
             },
         },
         403: {
-            "description": "Permission denied (master 권한 필요)",
+            "description": (
+                "Permission denied (master, human 멤버 또는 bot:admin "
+                "scope 보유 agent 만 허용)"
+            ),
             "content": {
                 "application/problem+json": {
                     "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -947,22 +968,23 @@ BOT_UPDATE_REQUEST_SCHEMA: dict[str, Any] = {
 async def update_bot(
     bot_id: str,
     request: Request,
-    caller_id: Annotated[str, Depends(require_master_caller)],
+    caller_id: Annotated[str, Depends(require_bot_admin)],
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     registry: Annotated[Any | None, Depends(get_strategy_registry_optional)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """봇 설정 수정. 인증된 master만 호출 가능 (#1352). 중지 상태에서만 허용.
+    """봇 설정 수정. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한
+    agent 만 호출 가능 (#1407 — spec ``bot:admin`` 정합, #1352 master_caller
+    에서 마이그레이션). 중지 상태에서만 허용.
 
-    ``create_member`` / ``update_scopes``와 동일한 raw body 파싱 패턴을 적용해
-    인증 가드가 body validation보다 우선 실행되도록 한다(#1352 — Codex Plan
-    Review). FastAPI가 ``body: BotUpdateRequest``를 먼저 검증하면 unauth +
-    bad-body 시 401이 아닌 422가 먼저 반환되어 contract가 깨진다.
+    Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
+    한다. FastAPI 가 ``body: BotUpdateRequest`` 를 먼저 검증하면 unauth +
+    bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.
 
     핸들러 단계 순서:
 
-    1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-       non-master → 403.
+    1. 인증 가드 (``Depends(require_bot_admin)``) — caller 빈 → 401,
+       권한 없음 → 403, 비활성 멤버 → 403.
     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
     3. ``BotUpdateRequest.model_validate`` — ValidationError → 422.
     4. service 호출 (``BotError`` → 409, ``TreasuryError`` → 422).
@@ -1056,6 +1078,7 @@ async def update_bot(
 )
 async def get_bot_logs(
     bot_id: str,
+    _caller_id: Annotated[str, Depends(require_bot_read)],
     bot_manager: Annotated[Any, Depends(get_bot_manager)],
     event_history_store: Annotated[
         Any | None, Depends(get_event_history_store_optional)
@@ -1063,7 +1086,8 @@ async def get_bot_logs(
     eventbus: Annotated[Any | None, Depends(get_eventbus_optional)],
     limit: int = Query(default=50, ge=1, le=100),
 ) -> dict:
-    """봇 실행 로그 조회.
+    """봇 실행 로그 조회. 인증된 master/human 또는 ``bot:read`` scope 를 보유한
+    agent 만 호출 가능 (#1407).
 
     BotStepCompletedEvent 이력을 반환한다.
     event_history_store(SQLite)가 있으면 영속 로그를 조회하고,

--- a/src/ante/web/routes/config.py
+++ b/src/ante/web/routes/config.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ValidationError
 from ante.web.deps import (
     get_audit_logger_optional,
     get_dynamic_config,
+    require_config_read,
     require_config_write,
 )
 from ante.web.schemas import ConfigListResponse, ConfigUpdateResponse
@@ -78,9 +79,11 @@ CONFIG_UPDATE_REQUEST_SCHEMA: dict[str, Any] = {
     },
 )
 async def list_configs(
+    _caller_id: Annotated[str, Depends(require_config_read)],
     config_service: Annotated[Any, Depends(get_dynamic_config)],
 ) -> dict:
-    """동적 설정 전체 조회."""
+    """동적 설정 전체 조회. 인증된 master/human 또는 ``config:read`` scope 를
+    보유한 agent 만 호출 가능 (#1407)."""
     configs = await config_service.get_all()
     return {"configs": configs}
 

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -10,7 +10,12 @@ from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
-from ante.web.deps import get_audit_logger_optional, get_data_store
+from ante.web.deps import (
+    get_audit_logger_optional,
+    get_data_store,
+    require_data_read,
+    require_data_write,
+)
 from ante.web.schemas import (
     DataSchemaResponse,
     DatasetDetailResponse,
@@ -31,6 +36,7 @@ _executor = ThreadPoolExecutor(max_workers=2)
 
 @router.get("/datasets", response_model=DatasetListResponse)
 async def list_datasets(
+    _caller_id: Annotated[str, Depends(require_data_read)],
     store: Annotated[Any | None, Depends(get_data_store)],
     symbol: str | None = None,
     timeframe: str | None = None,
@@ -128,9 +134,11 @@ async def list_datasets(
 @router.get("/datasets/{dataset_id}", response_model=DatasetDetailResponse)
 async def get_dataset_detail(
     dataset_id: str,
+    _caller_id: Annotated[str, Depends(require_data_read)],
     store: Annotated[Any | None, Depends(get_data_store)],
 ) -> dict:
-    """데이터셋 상세 조회 (메타데이터 + 최근 5행 미리보기).
+    """데이터셋 상세 조회 (메타데이터 + 최근 5행 미리보기). 인증된 master/human
+    또는 ``data:read`` scope 를 보유한 agent 만 호출 가능 (#1407).
 
     dataset_id 형식: "{symbol}__{timeframe}" (예: "005930__1d")
     """
@@ -201,11 +209,14 @@ async def get_dataset_detail(
 
 @router.get("/schema", response_model=DataSchemaResponse)
 async def get_data_schema(
+    _caller_id: Annotated[str, Depends(require_data_read)],
     data_type: Literal["ohlcv", "fundamental"] = Query(
         "ohlcv", description="데이터 유형 (ohlcv, fundamental)"
     ),
 ) -> dict:
-    """데이터 스키마 조회. data_type에 따라 해당 스키마를 반환."""
+    """데이터 스키마 조회. data_type에 따라 해당 스키마를 반환. 인증된
+    master/human 또는 ``data:read`` scope 를 보유한 agent 만 호출 가능
+    (#1407)."""
     if data_type == "fundamental":
         from ante.data.schemas import FUNDAMENTAL_SCHEMA
 
@@ -218,9 +229,11 @@ async def get_data_schema(
 
 @router.get("/storage", response_model=StorageSummaryResponse)
 async def get_storage_summary(
+    _caller_id: Annotated[str, Depends(require_data_read)],
     store: Annotated[Any | None, Depends(get_data_store)],
 ) -> dict:
-    """저장 용량 현황."""
+    """저장 용량 현황. 인증된 master/human 또는 ``data:read`` scope 를 보유한
+    agent 만 호출 가능 (#1407)."""
     if store is None:
         return {
             "total_bytes": 0,
@@ -283,11 +296,13 @@ async def get_storage_summary(
 async def delete_dataset(
     dataset_id: str,
     request: Request,
+    caller_id: Annotated[str, Depends(require_data_write)],
     store: Annotated[Any | None, Depends(get_data_store)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
     data_type: str = Query("ohlcv", description="데이터 유형 (ohlcv, fundamental)"),
 ) -> None:
-    """데이터셋 삭제.
+    """데이터셋 삭제. 인증된 master/human 또는 ``data:write`` scope 를 보유한
+    agent 만 호출 가능 (#1407).
 
     dataset_id 형식: "{symbol}__{timeframe}" (예: "005930__1d")
     fundamental의 경우: "{symbol}__fundamental" (예: "005930__fundamental")
@@ -315,7 +330,7 @@ async def delete_dataset(
 
     if audit_logger:
         await audit_logger.log(
-            member_id=getattr(request.state, "member_id", "anonymous"),
+            member_id=caller_id,
             action="data.delete_dataset",
             resource=f"dataset:{dataset_id}",
             ip=request.client.host if request.client else "",
@@ -324,9 +339,11 @@ async def delete_dataset(
 
 @router.get("/feed-status", response_model=FeedStatusResponse)
 async def get_feed_status(
+    _caller_id: Annotated[str, Depends(require_data_read)],
     store: Annotated[Any | None, Depends(get_data_store)],
 ) -> dict:
-    """Feed 파이프라인 상태 조회.
+    """Feed 파이프라인 상태 조회. 인증된 master/human 또는 ``data:read`` scope
+    를 보유한 agent 만 호출 가능 (#1407).
 
     Feed 초기화 여부, 소스별 체크포인트 현황, 최근 리포트 요약,
     API 키 설정 상태를 반환한다.

--- a/src/ante/web/routes/members.py
+++ b/src/ante/web/routes/members.py
@@ -15,8 +15,8 @@ from ante.member.models import MemberStatus, MemberType
 from ante.web.deps import (
     get_audit_logger_optional,
     get_member_service,
-    get_session_service_optional,
-    require_master_caller,
+    require_member_admin,
+    require_member_read,
 )
 from ante.web.schemas import (
     MemberCreateResponse,
@@ -32,58 +32,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-def _caller_id(request: Request) -> str:
-    """인증 미들웨어가 설정한 member_id를 반환. 미설정 시 빈 문자열."""
-    return getattr(request.state, "member_id", "")
-
-
-_AUTH_REQUIRED_DETAIL = (
-    "인증이 필요합니다. Authorization: Bearer <token> 헤더 또는 "
-    "유효한 ante_session 쿠키가 필요합니다."
-)
-
 _AUTH_REQUIRED_RESPONSE_DESCRIPTION = (
     "Authentication required (missing or invalid Authorization header "
     "AND missing or invalid ante_session cookie). 대시보드 사용자는 "
     "로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 "
     "Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다."
 )
-
-
-async def _resolve_caller_or_401(
-    request: Request,
-    session_service: Any | None,
-) -> str:
-    """5개 mutation route의 공통 인증 가드 (issue #1351).
-
-    1) ``TokenAuthMiddleware``가 채운 ``request.state.member_id``를 우선 사용.
-    2) Bearer 결정에 실패하면 ``ante_session`` 쿠키 fallback. 단,
-       ``session_service is None`` 배포 분기에서는 fallback을 건너뛴다(빈
-       caller 유지 → 401).
-    3) caller가 비어 있으면 ``HTTPException(401)``을 raise한다.
-    4) 세션 쿠키 fallback에서 caller가 결정되면 ``request.state.member_id``를
-       갱신해 ``AuditMiddleware``의 자동 감사 로그 주체와 일관성을 유지한다.
-
-    ``create_member``의 인증 가드 패턴과 동일한 톤이다(#1339 SSOT).
-    """
-    caller = _caller_id(request)
-    if not caller and session_service is not None:
-        ante_session = request.cookies.get("ante_session")
-        if ante_session:
-            try:
-                session = await session_service.validate(ante_session)
-            except Exception:
-                logger.exception(
-                    "세션 검증 실패 (session_id 일부=%s...)", ante_session[:8]
-                )
-                session = None
-            if session:
-                caller = session.get("member_id", "") or ""
-                if caller:
-                    request.state.member_id = caller
-    if not caller:
-        raise HTTPException(status_code=401, detail=_AUTH_REQUIRED_DETAIL)
-    return caller
 
 
 _AUTH_REQUIRED_RESPONSE: dict[str, Any] = {
@@ -278,6 +232,7 @@ MEMBER_SCOPES_UPDATE_REQUEST_SCHEMA: dict[str, Any] = {
     },
 )
 async def list_members(
+    _caller_id: Annotated[str, Depends(require_member_read)],
     svc: Annotated[Any, Depends(get_member_service)],
     type: MemberType | None = Query(default=None),
     org: str | None = Query(default=None),
@@ -389,63 +344,28 @@ async def list_members(
 )
 async def create_member(
     request: Request,
+    caller: Annotated[str, Depends(require_member_admin)],
     svc: Annotated[Any, Depends(get_member_service)],
-    session_service: Annotated[Any | None, Depends(get_session_service_optional)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """멤버 등록. 토큰 1회 반환.
+    """멤버 등록. 토큰 1회 반환. 인증된 master/human 또는 ``member:admin`` scope
+    를 보유한 agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
 
-    인증 가드는 body validation보다 **반드시 먼저** 실행된다(#1339 P2 — Codex
-    finding). FastAPI가 ``body: MemberCreateRequest`` 파라미터를 먼저 파싱하면
-    Authorization 헤더 미존재 + 필수 필드 누락 케이스에서 401이 아니라 422가
-    먼저 응답되어 "missing or invalid Authorization header는 401" 계약이 깨진다.
-    이 이유로 본 라우트는 ``request: Request``만 받고 raw body를 직접 파싱한다
-    (``update_account`` SSOT 패턴 일치).
-
-    인증 경로는 두 가지를 모두 받는다(#1339 P1 — Codex finding):
-    - **Bearer 토큰**: ``TokenAuthMiddleware``가 ``request.state.member_id``를
-      세팅한다. 에이전트 클라이언트(`MCP`, CLI 등)와 ``frontend`` axios의
-      ``Authorization`` 헤더 호출이 이 경로를 탄다.
-    - **세션 쿠키**: 대시보드는 패스워드 로그인 후 ``ante_session`` HttpOnly
-      쿠키만 가진 상태로 axios에 ``Authorization`` 헤더를 추가하지 않는다.
-      ``session_service.validate``로 세션 → ``member_id``를 복원한다.
+    인증 가드는 body validation보다 **반드시 먼저** 실행된다(#1339 P2). FastAPI
+    가 ``body: MemberCreateRequest`` 파라미터를 먼저 파싱하면 Authorization
+    헤더 미존재 + 필수 필드 누락 케이스에서 401 이 아니라 422 가 먼저 응답되어
+    "missing or invalid Authorization header는 401" 계약이 깨진다. 이 이유로
+    본 라우트는 ``request: Request`` 와 ``require_member_admin`` 만 받고 raw
+    body 를 직접 파싱한다 (``update_account`` SSOT 패턴 일치).
 
     핸들러 단계 순서:
-    1. **인증 가드 (최우선)**: token 또는 세션 쿠키 어느 쪽도 caller를 결정
-       하지 못하면 401.
+    1. **인증 가드 (최우선, ``Depends(require_member_admin)``)** — caller 빈
+       → 401, 권한 없음 → 403, 비활성 멤버 → 403.
     2. raw bytes 읽고 JSON 파싱 — 실패 시 422.
     3. ``MemberCreateRequest.model_validate`` — ValidationError → 422.
     4. ``svc.register`` 호출. ``PermissionError`` → 403, ``ValueError`` → 400.
     """
-    # 1. 인증 가드 (body validation보다 우선).
-    #    1-a) Bearer 토큰 (TokenAuthMiddleware가 request.state.member_id 세팅).
-    caller = _caller_id(request)
-    #    1-b) ante_session 쿠키 fallback (#1339 P1 — 대시보드 axios 호환).
-    if not caller and session_service is not None:
-        ante_session = request.cookies.get("ante_session")
-        if ante_session:
-            try:
-                session = await session_service.validate(ante_session)
-            except Exception:
-                # session_service 실패는 인증 실패로 간주한다 (logged + 401).
-                logger.exception(
-                    "세션 검증 실패 (session_id 일부=%s...)", ante_session[:8]
-                )
-                session = None
-            if session:
-                caller = session.get("member_id", "") or ""
-                if caller:
-                    # AuditMiddleware가 자동 감사 로그에 주체를 남길 수 있도록
-                    # request.state에도 반영한다 (#1339 P2 — Codex finding).
-                    request.state.member_id = caller
-    if not caller:
-        raise HTTPException(
-            status_code=401,
-            detail=(
-                "인증이 필요합니다. Authorization: Bearer <token> 헤더 또는 "
-                "유효한 ante_session 쿠키가 필요합니다."
-            ),
-        )
+    # 1. 인증 가드 — ``require_member_admin`` dependency 가 이미 통과시킴.
 
     # 2. raw body 읽기 + JSON 파싱.
     raw = await request.body()
@@ -525,9 +445,11 @@ async def create_member(
 )
 async def get_member(
     member_id: str,
+    _caller_id: Annotated[str, Depends(require_member_read)],
     svc: Annotated[Any, Depends(get_member_service)],
 ) -> dict:
-    """멤버 상세 조회."""
+    """멤버 상세 조회. 인증된 master/human 또는 ``member:read`` scope 를 보유한
+    agent 만 호출 가능 (#1407)."""
     try:
         member = await svc.get(member_id)
     except Exception:
@@ -574,12 +496,12 @@ async def get_member(
 async def suspend_member(
     member_id: str,
     request: Request,
+    caller: Annotated[str, Depends(require_member_admin)],
     svc: Annotated[Any, Depends(get_member_service)],
-    session_service: Annotated[Any | None, Depends(get_session_service_optional)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """멤버 일시 정지. 인증된 master만 호출 가능 (#1351)."""
-    caller = await _resolve_caller_or_401(request, session_service)
+    """멤버 일시 정지. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
+    agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합)."""
     try:
         member = await svc.suspend(member_id, suspended_by=caller)
     except ValueError as e:
@@ -632,12 +554,12 @@ async def suspend_member(
 async def reactivate_member(
     member_id: str,
     request: Request,
+    caller: Annotated[str, Depends(require_member_admin)],
     svc: Annotated[Any, Depends(get_member_service)],
-    session_service: Annotated[Any | None, Depends(get_session_service_optional)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """멤버 재활성화. 인증된 master만 호출 가능 (#1351)."""
-    caller = await _resolve_caller_or_401(request, session_service)
+    """멤버 재활성화. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
+    agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합)."""
     try:
         member = await svc.reactivate(member_id, reactivated_by=caller)
     except ValueError as e:
@@ -690,12 +612,12 @@ async def reactivate_member(
 async def revoke_member(
     member_id: str,
     request: Request,
+    caller: Annotated[str, Depends(require_member_admin)],
     svc: Annotated[Any, Depends(get_member_service)],
-    session_service: Annotated[Any | None, Depends(get_session_service_optional)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """멤버 영구 폐기. 인증된 master만 호출 가능 (#1351)."""
-    caller = await _resolve_caller_or_401(request, session_service)
+    """멤버 영구 폐기. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
+    agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합)."""
     try:
         member = await svc.revoke(member_id, revoked_by=caller)
     except ValueError as e:
@@ -748,16 +670,16 @@ async def revoke_member(
 async def rotate_token(
     member_id: str,
     request: Request,
+    caller: Annotated[str, Depends(require_member_admin)],
     svc: Annotated[Any, Depends(get_member_service)],
-    session_service: Annotated[Any | None, Depends(get_session_service_optional)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """토큰 재발급. 인증된 master만 호출 가능 (#1351).
+    """토큰 재발급. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
+    agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
 
     인증 없이 token rotation 응답에 접근하면 token 값 자체가 노출되므로,
     가장 먼저 차단해야 한다.
     """
-    caller = await _resolve_caller_or_401(request, session_service)
     try:
         member, token = await svc.rotate_token(member_id, rotated_by=caller)
     except ValueError as e:
@@ -782,7 +704,10 @@ async def rotate_token(
     responses={
         401: _AUTH_REQUIRED_RESPONSE,
         403: {
-            "description": "Permission denied (master 권한 필요).",
+            "description": (
+                "Permission denied (master, human 멤버 또는 member:admin "
+                "scope 보유 agent 만 허용)."
+            ),
             "content": {
                 "application/problem+json": {
                     "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -838,11 +763,13 @@ async def rotate_token(
 async def change_password(
     member_id: str,
     request: Request,
-    caller_id: Annotated[str, Depends(require_master_caller)],
+    caller_id: Annotated[str, Depends(require_member_admin)],
     svc: Annotated[Any, Depends(get_member_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """비밀번호 변경 (human 멤버 전용). 인증된 master만 호출 가능 (#1377).
+    """비밀번호 변경 (human 멤버 전용). 인증된 master/human 또는
+    ``member:admin`` scope 를 보유한 agent 만 호출 가능 (#1407 — spec
+    ``member:admin`` 정합, #1377 master_caller 에서 마이그레이션).
 
     배경: oracle A7 finding (#1377) — 본 라우트는 인증 없이 credential check
     (``svc.change_password``의 old-password 비교) 까지 도달했다. ``_caller_id``
@@ -861,8 +788,9 @@ async def change_password(
 
     핸들러 단계 순서:
 
-    1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-       non-master → 403. credential check 도달 전에 모두 차단된다.
+    1. 인증 가드 (``Depends(require_member_admin)``) — caller 빈 → 401,
+       권한 없음 → 403, 비활성 멤버 → 403. credential check 도달 전에 모두
+       차단된다.
     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
     3. ``PasswordChangeRequest.model_validate`` — ValidationError → 422.
     4. ``svc.change_password`` 호출. ``ValueError`` → 404,
@@ -871,8 +799,7 @@ async def change_password(
     Audit 로그의 ``member_id``는 ``caller_id``로 기록한다(SSOT). 대상 멤버는
     ``resource=member:{member_id}``로 분리해 추적한다.
     """
-    # 1. 인증 가드는 ``require_master_caller`` 의존성에 의해 이미 통과 상태.
-    #    (caller 빈 → 401, non-master → 403)
+    # 1. 인증 가드는 ``require_member_admin`` 의존성에 의해 이미 통과 상태.
 
     # 2. raw body 읽기 + JSON 파싱 — 인증 통과 후에만 실행된다.
     raw = await request.body()
@@ -979,26 +906,26 @@ async def change_password(
 async def update_scopes(
     member_id: str,
     request: Request,
+    caller: Annotated[str, Depends(require_member_admin)],
     svc: Annotated[Any, Depends(get_member_service)],
-    session_service: Annotated[Any | None, Depends(get_session_service_optional)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """권한 범위 변경. 인증된 master만 호출 가능 (#1351).
+    """권한 범위 변경. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
+    agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
 
-    ``create_member``와 동일한 raw body 파싱 패턴을 적용해 인증 가드가 body
-    validation보다 우선 실행되도록 한다(#1351 — Codex Plan Review). FastAPI가
-    ``body: ScopesUpdateRequest``를 먼저 검증하면 unauth + bad-body 시 401이
-    아닌 422가 먼저 반환되어 contract가 깨진다.
+    Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
+    한다. FastAPI 가 ``body: ScopesUpdateRequest`` 를 먼저 검증하면 unauth +
+    bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.
 
     핸들러 단계 순서:
-    1. 인증 가드 (최우선) — 실패 시 401.
+    1. 인증 가드 (``Depends(require_member_admin)``) — caller 빈 → 401,
+       권한 없음 → 403, 비활성 멤버 → 403.
     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
     3. ``ScopesUpdateRequest.model_validate`` — ValidationError → 422.
     4. ``svc.update_scopes`` 호출. ``ValueError`` → 404,
        ``PermissionError``/``PermissionDeniedError`` → 403.
     """
-    # 1. 인증 가드 (body validation보다 우선).
-    caller = await _resolve_caller_or_401(request, session_service)
+    # 1. 인증 가드 — ``require_member_admin`` 이 이미 통과시킴.
 
     # 2. raw body 읽기 + JSON 파싱.
     raw = await request.body()

--- a/src/ante/web/routes/portfolio.py
+++ b/src/ante/web/routes/portfolio.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from ante.web.deps import (
     get_treasury,
     get_treasury_manager_optional,
+    require_treasury_read,
 )
 from ante.web.schemas import (
     PortfolioHistoryResponse,
@@ -55,11 +56,15 @@ def _resolve_treasury(
     },
 )
 async def portfolio_value(
+    _caller_id: Annotated[str, Depends(require_treasury_read)],
     treasury: Annotated[Any, Depends(get_treasury)],
     treasury_manager: Annotated[Any | None, Depends(get_treasury_manager_optional)],
     account_id: str | None = None,
 ) -> dict:
-    """총 자산 가치 + 당일 손익 + 수익률 + 미실현 손익 (최신 스냅샷 기반)."""
+    """총 자산 가치 + 당일 손익 + 수익률 + 미실현 손익 (최신 스냅샷 기반).
+    인증된 master/human 또는 ``treasury:read`` scope 를 보유한 agent 만 호출
+    가능 (#1407 — portfolio 라우트는 ``treasury_daily_snapshots`` 를 읽으므로
+    spec ``treasury:read`` 정합)."""
     target = _resolve_treasury(treasury, treasury_manager, account_id)
     snapshot = await target.get_latest_snapshot()
     if snapshot is not None:
@@ -100,13 +105,15 @@ async def portfolio_value(
     },
 )
 async def portfolio_history(
+    _caller_id: Annotated[str, Depends(require_treasury_read)],
     treasury: Annotated[Any, Depends(get_treasury)],
     treasury_manager: Annotated[Any | None, Depends(get_treasury_manager_optional)],
     account_id: str | None = None,
     start_date: str | None = None,
     end_date: str | None = None,
 ) -> dict:
-    """기간별 자산 추이 (daily_snapshots 시계열 반환)."""
+    """기간별 자산 추이 (daily_snapshots 시계열 반환). 인증된 master/human 또는
+    ``treasury:read`` scope 를 보유한 agent 만 호출 가능 (#1407)."""
     target = _resolve_treasury(treasury, treasury_manager, account_id)
 
     if end_date is None:

--- a/src/ante/web/routes/reports.py
+++ b/src/ante/web/routes/reports.py
@@ -12,6 +12,7 @@ from ante.report.models import ReportStatus
 from ante.web.deps import (
     get_audit_logger_optional,
     get_report_store,
+    require_report_read,
     require_report_write,
 )
 from ante.web.schemas import (
@@ -251,9 +252,11 @@ async def submit_report(
 )
 async def report_view(
     report_id: str,
+    _caller_id: Annotated[str, Depends(require_report_read)],
     report_store: Annotated[Any, Depends(get_report_store)],
 ) -> dict:
-    """리포트 단건 조회."""
+    """리포트 단건 조회. 인증된 master/human 또는 ``report:read`` scope 를
+    보유한 agent 만 호출 가능 (#1407)."""
     import json
 
     report = await report_store.get(report_id)
@@ -310,12 +313,14 @@ async def report_view(
     },
 )
 async def list_reports(
+    _caller_id: Annotated[str, Depends(require_report_read)],
     report_store: Annotated[Any, Depends(get_report_store)],
     status: ReportStatus | None = None,
     limit: int = Query(default=20, ge=1, le=100),
     cursor: str | None = None,
 ) -> dict:
-    """리포트 목록 조회 (cursor 기반 페이지네이션)."""
+    """리포트 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는
+    ``report:read`` scope 를 보유한 agent 만 호출 가능 (#1407)."""
     from ante.web.pagination import paginate
 
     reports = await report_store.list_reports(status=status)

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -19,6 +19,7 @@ from ante.web.deps import (
     get_strategy_registry,
     get_trade_service,
     get_trade_service_optional,
+    require_strategy_read,
     require_strategy_write,
 )
 from ante.web.schemas import (
@@ -88,6 +89,28 @@ def _find_bot_for_strategy(bot_manager: Any, strategy_id: str) -> dict | None:
                 },
             },
         },
+        401: {
+            "description": (
+                "Authentication required (missing or invalid Authorization "
+                "header AND missing or invalid ante_session cookie)."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
+        403: {
+            "description": (
+                "Permission denied (master, human 멤버 또는 strategy:write "
+                "scope 보유 agent 만 허용)."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
         404: {
             "description": "Strategy file not found",
             "content": {
@@ -96,16 +119,56 @@ def _find_bot_for_strategy(bot_manager: Any, strategy_id: str) -> dict | None:
                 },
             },
         },
+        422: {
+            "description": (
+                "Body validation 실패 (JSON 파싱 실패, 빈 body). 단, 인증이 "
+                "실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다 "
+                "(#1407)."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
     },
 )
-async def validate_strategy(body: dict) -> dict:
-    """전략 파일 정적 검증.
+async def validate_strategy(
+    request: Request,
+    _caller_id: Annotated[str, Depends(require_strategy_write)],
+) -> dict:
+    """전략 파일 정적 검증. 인증된 master/human 또는 ``strategy:write`` scope
+    를 보유한 agent 만 호출 가능 (#1407 — spec ``strategy:write`` 정합).
 
-    Body: {"path": "/path/to/strategy.py"}
+    Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
+    한다. 핸들러 단계 순서:
+
+    1. 인증 가드 (``Depends(require_strategy_write)``) — caller 빈 → 401,
+       권한 없음 → 403, 비활성 멤버 → 403.
+    2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
+    3. ``path`` 필드 추출 — 누락 시 400.
+    4. 파일 존재 확인 → 404.
+    5. ``StrategyValidator.validate`` 호출.
+
+    Body: ``{"path": "/path/to/strategy.py"}``
     """
     from ante.strategy.validator import StrategyValidator
 
-    filepath = body.get("path", "")
+    raw = await request.body()
+    if raw == b"":
+        raise HTTPException(status_code=422, detail="요청 body가 비어 있습니다.")
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        raise HTTPException(
+            status_code=422, detail="요청 body의 JSON 파싱에 실패했습니다."
+        ) from None
+    if not isinstance(payload, dict):
+        raise HTTPException(
+            status_code=422, detail="요청 body는 JSON object여야 합니다."
+        )
+
+    filepath = payload.get("path", "")
     if not filepath:
         raise HTTPException(status_code=400, detail="path is required")
 
@@ -138,12 +201,14 @@ async def validate_strategy(body: dict) -> dict:
     },
 )
 async def list_strategies(
+    _caller_id: Annotated[str, Depends(require_strategy_read)],
     registry: Annotated[Any, Depends(get_strategy_registry)],
     bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
     db: Annotated[Any | None, Depends(get_db_optional)],
     status: str | None = Query(default=None),
 ) -> dict:
-    """전략 목록 조회."""
+    """전략 목록 조회. 인증된 master/human 또는 ``strategy:read`` scope 를
+    보유한 agent 만 호출 가능 (#1407)."""
     if status is not None and status not in _VALID_STATUS_FILTERS:
         raise HTTPException(
             status_code=400,
@@ -383,10 +448,12 @@ async def update_strategy_status(
 )
 async def get_strategy(
     strategy_id: str,
+    _caller_id: Annotated[str, Depends(require_strategy_read)],
     registry: Annotated[Any, Depends(get_strategy_registry)],
     bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
 ) -> dict:
-    """전략 상세 조회."""
+    """전략 상세 조회. 인증된 master/human 또는 ``strategy:read`` scope 를
+    보유한 agent 만 호출 가능 (#1407)."""
     record = await registry.get(strategy_id)
     if not record:
         raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
@@ -460,13 +527,15 @@ async def get_strategy(
 )
 async def get_strategy_performance(
     strategy_id: str,
+    _caller_id: Annotated[str, Depends(require_strategy_read)],
     registry: Annotated[Any, Depends(get_strategy_registry)],
     db: Annotated[Any, Depends(get_db)],
     bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
     trade_service: Annotated[Any | None, Depends(get_trade_service_optional)],
     account_id: str | None = None,
 ) -> dict:
-    """전략 성과 지표 조회."""
+    """전략 성과 지표 조회. 인증된 master/human 또는 ``strategy:read`` scope 를
+    보유한 agent 만 호출 가능 (#1407)."""
     record = await registry.get(strategy_id)
     if not record:
         raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
@@ -542,11 +611,13 @@ async def get_strategy_performance(
 )
 async def get_strategy_daily_summary(
     strategy_id: str,
+    _caller_id: Annotated[str, Depends(require_strategy_read)],
     registry: Annotated[Any, Depends(get_strategy_registry)],
     db: Annotated[Any, Depends(get_db)],
     bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
 ) -> dict:
-    """전략 일별 성과 집계."""
+    """전략 일별 성과 집계. 인증된 master/human 또는 ``strategy:read`` scope 를
+    보유한 agent 만 호출 가능 (#1407)."""
     record = await registry.get(strategy_id)
     if not record:
         raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
@@ -597,11 +668,13 @@ async def get_strategy_daily_summary(
 )
 async def get_strategy_weekly_summary(
     strategy_id: str,
+    _caller_id: Annotated[str, Depends(require_strategy_read)],
     registry: Annotated[Any, Depends(get_strategy_registry)],
     db: Annotated[Any, Depends(get_db)],
     bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
 ) -> dict:
-    """전략 주별 성과 집계."""
+    """전략 주별 성과 집계. 인증된 master/human 또는 ``strategy:read`` scope 를
+    보유한 agent 만 호출 가능 (#1407)."""
     record = await registry.get(strategy_id)
     if not record:
         raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
@@ -653,11 +726,13 @@ async def get_strategy_weekly_summary(
 )
 async def get_strategy_monthly_summary(
     strategy_id: str,
+    _caller_id: Annotated[str, Depends(require_strategy_read)],
     registry: Annotated[Any, Depends(get_strategy_registry)],
     db: Annotated[Any, Depends(get_db)],
     bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
 ) -> dict:
-    """전략 월별 성과 집계."""
+    """전략 월별 성과 집계. 인증된 master/human 또는 ``strategy:read`` scope 를
+    보유한 agent 만 호출 가능 (#1407)."""
     record = await registry.get(strategy_id)
     if not record:
         raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
@@ -708,12 +783,14 @@ async def get_strategy_monthly_summary(
 )
 async def get_strategy_trades(
     strategy_id: str,
+    _caller_id: Annotated[str, Depends(require_strategy_read)],
     registry: Annotated[Any, Depends(get_strategy_registry)],
     trade_service: Annotated[Any, Depends(get_trade_service)],
     limit: int = Query(default=20, ge=1, le=100),
     cursor: str | None = Query(default=None),
 ) -> dict:
-    """전략 거래 내역 조회 (cursor 기반 페이지네이션)."""
+    """전략 거래 내역 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는
+    ``strategy:read`` scope 를 보유한 agent 만 호출 가능 (#1407)."""
     from ante.web.pagination import paginate
 
     record = await registry.get(strategy_id)

--- a/src/ante/web/routes/system.py
+++ b/src/ante/web/routes/system.py
@@ -15,7 +15,8 @@ from ante.web.deps import (
     get_account_service_optional,
     get_audit_logger_optional,
     get_db_optional,
-    require_master_caller,
+    require_system_admin,
+    require_system_read,
 )
 from ante.web.schemas import (
     HealthResponse,
@@ -78,9 +79,13 @@ CLEAR_HALT_REQUEST_SCHEMA: dict[str, Any] = _build_request_schema(ClearHaltReque
 
 @router.get("/status", response_model=StatusResponse)
 async def get_system_status(
+    _caller_id: Annotated[str, Depends(require_system_read)],
     account_service: Annotated[Any | None, Depends(get_account_service_optional)],
 ) -> dict:
-    """시스템 상태 조회."""
+    """시스템 상태 조회. 인증된 master/human 또는 ``system:read`` scope 를 보유한
+    agent 만 호출 가능 (#1407). ``/api/system/health`` (public) 와 구별 —
+    health 는 모니터링 헬스체크용이고 status 는 운영 정보(account_count 등)를
+    노출한다."""
     result: dict = {
         "status": "running",
         "version": __version__,
@@ -236,7 +241,10 @@ async def _parse_optional_request_body(
             },
         },
         403: {
-            "description": "Permission denied (master 권한 필요).",
+            "description": (
+                "Permission denied (master, human 멤버 또는 system:admin "
+                "scope 보유 agent 만 허용)."
+            ),
             "content": {
                 "application/problem+json": {
                     "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -278,23 +286,22 @@ async def _parse_optional_request_body(
 )
 async def halt(
     request: Request,
-    caller_id: Annotated[str, Depends(require_master_caller)],
+    caller_id: Annotated[str, Depends(require_system_admin)],
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """전체 거래 중지 (모든 ACTIVE 계좌 SUSPENDED). 인증된 master 만 호출 가능
-    (#1375).
+    """전체 거래 중지 (모든 ACTIVE 계좌 SUSPENDED). 인증된 master/human 또는
+    ``system:admin`` scope 를 보유한 agent 만 호출 가능 (#1407 — spec
+    ``system:admin`` 정합, #1375 master_caller 에서 마이그레이션).
 
-    ``submit_report`` (#1374) 와 동일한 raw body 파싱 패턴을 적용해 인증 가드가
-    body validation 보다 우선 실행되도록 한다. FastAPI 가
-    ``body: HaltRequest`` 를 먼저 검증하면 unauth + bad-body 시 401 이 아닌
-    422 가 먼저 반환되어 contract 가 깨진다 — 본 라우트는 oracle A7 finding
-    의 핵심 시그니처 이므로 인증 가드 우선이 가장 중요하다.
+    Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
+    한다. FastAPI 가 ``body: HaltRequest`` 를 먼저 검증하면 unauth + bad-body
+    시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.
 
     핸들러 단계 순서:
 
-    1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-       non-master → 403.
+    1. 인증 가드 (``Depends(require_system_admin)``) — caller 빈 → 401,
+       권한 없음 → 403, 비활성 멤버 → 403.
     2. raw bytes 읽기 + JSON 파싱 — 빈 body 는 default 허용, 그 외 실패 시 422.
     3. ``HaltRequest.model_validate`` — ValidationError → 422.
     4. ``account_service.suspend_all`` 호출 + audit 기록
@@ -338,7 +345,10 @@ async def halt(
             },
         },
         403: {
-            "description": "Permission denied (master 권한 필요).",
+            "description": (
+                "Permission denied (master, human 멤버 또는 system:admin "
+                "scope 보유 agent 만 허용)."
+            ),
             "content": {
                 "application/problem+json": {
                     "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -380,20 +390,20 @@ async def halt(
 )
 async def clear_halt(
     request: Request,
-    caller_id: Annotated[str, Depends(require_master_caller)],
+    caller_id: Annotated[str, Depends(require_system_admin)],
     account_service: Annotated[Any, Depends(get_account_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """전역 정지 해제 (모든 SUSPENDED 계좌 ACTIVE). 인증된 master 만 호출 가능
-    (#1375).
+    """전역 정지 해제 (모든 SUSPENDED 계좌 ACTIVE). 인증된 master/human 또는
+    ``system:admin`` scope 를 보유한 agent 만 호출 가능 (#1407 — spec
+    ``system:admin`` 정합, #1375 master_caller 에서 마이그레이션).
 
     계좌 상태만 ACTIVE 로 복구하며 봇을 자동 재시작하지 않는다.
 
-    ``halt`` 와 동일한 raw body 파싱 + auth-first 패턴을 따른다 (#1375).
     핸들러 단계 순서:
 
-    1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-       non-master → 403.
+    1. 인증 가드 (``Depends(require_system_admin)``) — caller 빈 → 401,
+       권한 없음 → 403, 비활성 멤버 → 403.
     2. raw bytes 읽기 + JSON 파싱 — 빈 body 는 default 허용, 그 외 실패 시 422.
     3. ``ClearHaltRequest.model_validate`` — ValidationError → 422.
     4. ``account_service.activate_all`` 호출 + audit 기록

--- a/src/ante/web/routes/trades.py
+++ b/src/ante/web/routes/trades.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query
 
-from ante.web.deps import get_trade_service
+from ante.web.deps import get_trade_service, require_trade_read
 from ante.web.schemas import TradeListResponse
 
 router = APIRouter()
@@ -27,6 +27,7 @@ router = APIRouter()
     },
 )
 async def list_trades(
+    _caller_id: Annotated[str, Depends(require_trade_read)],
     trade_service: Annotated[Any, Depends(get_trade_service)],
     account_id: str | None = None,
     bot_id: str | None = None,
@@ -34,7 +35,8 @@ async def list_trades(
     limit: int = Query(default=20, ge=1, le=100),
     cursor: str | None = None,
 ) -> dict:
-    """거래 기록 목록 조회 (cursor 기반 페이지네이션)."""
+    """거래 기록 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는
+    ``trade:read`` scope 를 보유한 agent 만 호출 가능 (#1407)."""
     from ante.web.pagination import paginate
 
     trades = await trade_service.get_trades(

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -15,7 +15,8 @@ from ante.web.deps import (
     get_bot_manager_optional,
     get_treasury,
     get_treasury_manager_optional,
-    require_master_caller,
+    require_treasury_admin,
+    require_treasury_read,
 )
 from ante.web.schemas import (
     BalanceSetResponse,
@@ -138,11 +139,13 @@ BALANCE_SET_REQUEST_SCHEMA: dict[str, Any] = {
 )
 async def get_summary(
     request: Request,
+    _caller_id: Annotated[str, Depends(require_treasury_read)],
     treasury: Annotated[Any, Depends(get_treasury)],
     treasury_manager: Annotated[Any | None, Depends(get_treasury_manager_optional)],
     account_id: str | None = None,
 ) -> dict:
-    """자금 현황 요약.
+    """자금 현황 요약. 인증된 master/human 또는 ``treasury:read`` scope 를
+    보유한 agent 만 호출 가능 (#1407).
 
     account_id 지정 시 해당 계좌의 Treasury 요약을 반환한다.
     미지정 시 기본 Treasury 요약을 반환한다 (하위 호환).
@@ -228,6 +231,7 @@ async def get_summary(
     },
 )
 async def list_transactions(
+    _caller_id: Annotated[str, Depends(require_treasury_read)],
     treasury: Annotated[Any, Depends(get_treasury)],
     account_id: str | None = None,
     type: str | None = None,
@@ -237,7 +241,8 @@ async def list_transactions(
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
 ) -> dict:
-    """자금 변동 이력 조회."""
+    """자금 변동 이력 조회. 인증된 master/human 또는 ``treasury:read`` scope 를
+    보유한 agent 만 호출 가능 (#1407)."""
     db = getattr(treasury, "_db", None)
     if db is None:
         return {"items": [], "total": 0}
@@ -314,7 +319,10 @@ async def list_transactions(
             },
         },
         403: {
-            "description": "Permission denied (master 권한 필요)",
+            "description": (
+                "Permission denied (master, human 멤버 또는 treasury:admin "
+                "scope 보유 agent 만 허용)"
+            ),
             "content": {
                 "application/problem+json": {
                     "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -372,22 +380,23 @@ async def list_transactions(
 async def allocate(
     bot_id: str,
     request: Request,
-    caller_id: Annotated[str, Depends(require_master_caller)],
+    caller_id: Annotated[str, Depends(require_treasury_admin)],
     treasury: Annotated[Any, Depends(get_treasury)],
     bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """봇에 예산 할당. 인증된 master만 호출 가능 (#1372).
+    """봇에 예산 할당. 인증된 master/human 또는 ``treasury:admin`` scope 를
+    보유한 agent 만 호출 가능 (#1407 — spec ``treasury:admin`` 정합, #1372
+    master_caller 에서 마이그레이션).
 
-    ``set_balance`` (#1352)와 동일한 raw body 파싱 패턴을 적용해 인증 가드가
-    body validation보다 우선 실행되도록 한다. FastAPI가 ``body:
-    BudgetChangeRequest``를 먼저 검증하면 unauth + bad-body 시 401이 아닌
-    422가 먼저 반환되어 contract가 깨진다.
+    Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
+    한다. FastAPI 가 ``body: BudgetChangeRequest`` 를 먼저 검증하면 unauth +
+    bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.
 
     핸들러 단계 순서:
 
-    1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-       non-master → 403.
+    1. 인증 가드 (``Depends(require_treasury_admin)``) — caller 빈 → 401,
+       권한 없음 → 403, 비활성 멤버 → 403.
     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
     3. ``BudgetChangeRequest.model_validate`` — ValidationError → 422.
     4. ``treasury.allocate`` 호출 (``BotNotStoppedError`` → 409).
@@ -478,7 +487,10 @@ async def allocate(
             },
         },
         403: {
-            "description": "Permission denied (master 권한 필요)",
+            "description": (
+                "Permission denied (master, human 멤버 또는 treasury:admin "
+                "scope 보유 agent 만 허용)"
+            ),
             "content": {
                 "application/problem+json": {
                     "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -536,20 +548,19 @@ async def allocate(
 async def deallocate(
     bot_id: str,
     request: Request,
-    caller_id: Annotated[str, Depends(require_master_caller)],
+    caller_id: Annotated[str, Depends(require_treasury_admin)],
     treasury: Annotated[Any, Depends(get_treasury)],
     bot_manager: Annotated[Any | None, Depends(get_bot_manager_optional)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """봇 예산 회수. 인증된 master만 호출 가능 (#1372).
-
-    ``allocate`` / ``set_balance`` (#1352)와 동일한 raw body 파싱 패턴을
-    적용해 인증 가드가 body validation보다 우선 실행되도록 한다.
+    """봇 예산 회수. 인증된 master/human 또는 ``treasury:admin`` scope 를
+    보유한 agent 만 호출 가능 (#1407 — spec ``treasury:admin`` 정합, #1372
+    master_caller 에서 마이그레이션).
 
     핸들러 단계 순서:
 
-    1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-       non-master → 403.
+    1. 인증 가드 (``Depends(require_treasury_admin)``) — caller 빈 → 401,
+       권한 없음 → 403, 비활성 멤버 → 403.
     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
     3. ``BudgetChangeRequest.model_validate`` — ValidationError → 422.
     4. ``treasury.deallocate`` 호출 (``BotNotStoppedError`` → 409).
@@ -626,9 +637,11 @@ async def deallocate(
     },
 )
 async def list_budgets(
+    _caller_id: Annotated[str, Depends(require_treasury_read)],
     treasury: Annotated[Any, Depends(get_treasury)],
 ) -> dict:
-    """봇별 예산 목록 조회."""
+    """봇별 예산 목록 조회. 인증된 master/human 또는 ``treasury:read`` scope 를
+    보유한 agent 만 호출 가능 (#1407)."""
     from dataclasses import asdict
 
     budgets = treasury.list_budgets()
@@ -660,7 +673,10 @@ async def list_budgets(
             },
         },
         403: {
-            "description": "Permission denied (master 권한 필요)",
+            "description": (
+                "Permission denied (master, human 멤버 또는 treasury:admin "
+                "scope 보유 agent 만 허용)"
+            ),
             "content": {
                 "application/problem+json": {
                     "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -701,22 +717,22 @@ async def list_budgets(
 )
 async def set_balance(
     request: Request,
-    caller_id: Annotated[str, Depends(require_master_caller)],
+    caller_id: Annotated[str, Depends(require_treasury_admin)],
     treasury: Annotated[Any, Depends(get_treasury)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """계좌 총 잔고 수동 설정. 인증된 master만 호출 가능 (#1352).
+    """계좌 총 잔고 수동 설정. 인증된 master/human 또는 ``treasury:admin`` scope
+    를 보유한 agent 만 호출 가능 (#1407 — spec ``treasury:admin`` 정합, #1352
+    master_caller 에서 마이그레이션).
 
-    ``create_member`` / ``update_scopes`` / ``update_bot``과 동일한 raw body
-    파싱 패턴을 적용해 인증 가드가 body validation보다 우선 실행되도록 한다
-    (#1352 — Codex Plan Review). FastAPI가 ``body: BalanceSetRequest``를 먼저
-    검증하면 unauth + bad-body 시 401이 아닌 422가 먼저 반환되어 contract가
-    깨진다.
+    Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
+    한다. FastAPI 가 ``body: BalanceSetRequest`` 를 먼저 검증하면 unauth +
+    bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.
 
     핸들러 단계 순서:
 
-    1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
-       non-master → 403.
+    1. 인증 가드 (``Depends(require_treasury_admin)``) — caller 빈 → 401,
+       권한 없음 → 403, 비활성 멤버 → 403.
     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
     3. ``BalanceSetRequest.model_validate`` — ValidationError → 422.
     4. ``treasury.set_account_balance`` 호출.
@@ -794,11 +810,13 @@ def _resolve_treasury(
     },
 )
 async def get_latest_snapshot(
+    _caller_id: Annotated[str, Depends(require_treasury_read)],
     treasury: Annotated[Any, Depends(get_treasury)],
     treasury_manager: Annotated[Any | None, Depends(get_treasury_manager_optional)],
     account_id: str | None = None,
 ) -> dict:
-    """가장 최근 일별 스냅샷 조회."""
+    """가장 최근 일별 스냅샷 조회. 인증된 master/human 또는 ``treasury:read``
+    scope 를 보유한 agent 만 호출 가능 (#1407)."""
     target = _resolve_treasury(treasury, treasury_manager, account_id)
     snapshot = await target.get_latest_snapshot()
     if snapshot is not None:
@@ -843,13 +861,15 @@ async def get_latest_snapshot(
     },
 )
 async def list_snapshots(
+    _caller_id: Annotated[str, Depends(require_treasury_read)],
     treasury: Annotated[Any, Depends(get_treasury)],
     treasury_manager: Annotated[Any | None, Depends(get_treasury_manager_optional)],
     account_id: str | None = None,
     start_date: str | None = None,
     end_date: str | None = None,
 ) -> dict:
-    """기간별 일별 스냅샷 목록."""
+    """기간별 일별 스냅샷 목록. 인증된 master/human 또는 ``treasury:read`` scope
+    를 보유한 agent 만 호출 가능 (#1407)."""
     target = _resolve_treasury(treasury, treasury_manager, account_id)
 
     if start_date is None:
@@ -885,11 +905,13 @@ async def list_snapshots(
 )
 async def get_snapshot_by_date(
     date: str,
+    _caller_id: Annotated[str, Depends(require_treasury_read)],
     treasury: Annotated[Any, Depends(get_treasury)],
     treasury_manager: Annotated[Any | None, Depends(get_treasury_manager_optional)],
     account_id: str | None = None,
 ) -> dict:
-    """특정일 스냅샷 조회."""
+    """특정일 스냅샷 조회. 인증된 master/human 또는 ``treasury:read`` scope 를
+    보유한 agent 만 호출 가능 (#1407)."""
     target = _resolve_treasury(treasury, treasury_manager, account_id)
     snapshot = await target.get_daily_snapshot(date)
     if snapshot is None:

--- a/tests/unit/test_datasets_list_api.py
+++ b/tests/unit/test_datasets_list_api.py
@@ -42,7 +42,13 @@ def _make_store(symbols_by_tf: dict[str, list[str]] | None = None) -> MagicMock:
 async def test_list_datasets_returns_empty_when_no_store():
     """store가 None이면 빈 응답을 반환한다."""
     result = await list_datasets(
-        store=None, symbol=None, timeframe=None, data_type="ohlcv", offset=0, limit=50
+        _caller_id="test-caller",
+        store=None,
+        symbol=None,
+        timeframe=None,
+        data_type="ohlcv",
+        offset=0,
+        limit=50,
     )
     assert result == {"items": [], "total": 0}
 
@@ -54,6 +60,7 @@ async def test_list_datasets_pagination_limits_enrichment():
     store = _make_store({"1d": syms})
 
     result = await list_datasets(
+        _caller_id="test-caller",
         store=store,
         symbol=None,
         timeframe="1d",
@@ -74,6 +81,7 @@ async def test_list_datasets_row_count_and_file_size_are_zero():
     store = _make_store({"1d": ["005930"]})
 
     result = await list_datasets(
+        _caller_id="test-caller",
         store=store,
         symbol=None,
         timeframe="1d",
@@ -95,6 +103,7 @@ async def test_list_datasets_date_range_included():
     store = _make_store({"1d": ["005930"]})
 
     result = await list_datasets(
+        _caller_id="test-caller",
         store=store,
         symbol=None,
         timeframe="1d",
@@ -114,6 +123,7 @@ async def test_list_datasets_fundamental_type():
     store = _make_store({"fundamental": ["005930"]})
 
     result = await list_datasets(
+        _caller_id="test-caller",
         store=store,
         symbol=None,
         timeframe=None,
@@ -136,6 +146,7 @@ async def test_list_datasets_symbol_filter():
     store = _make_store({"1d": ["005930", "000660", "035720"]})
 
     result = await list_datasets(
+        _caller_id="test-caller",
         store=store,
         symbol="005930",
         timeframe="1d",
@@ -155,6 +166,7 @@ async def test_list_datasets_offset_pagination():
     store = _make_store({"1d": syms})
 
     result = await list_datasets(
+        _caller_id="test-caller",
         store=store,
         symbol=None,
         timeframe="1d",
@@ -175,6 +187,7 @@ async def test_list_datasets_date_range_exception_handled():
     store.get_date_range.side_effect = Exception("disk error")
 
     result = await list_datasets(
+        _caller_id="test-caller",
         store=store,
         symbol=None,
         timeframe="1d",
@@ -194,6 +207,7 @@ async def test_list_datasets_no_resolve_path_called():
     store = _make_store({"1d": ["005930"]})
 
     await list_datasets(
+        _caller_id="test-caller",
         store=store,
         symbol=None,
         timeframe="1d",
@@ -211,6 +225,7 @@ async def test_list_datasets_no_data_type_returns_all():
     store = _make_store({"1d": ["005930"], "fundamental": ["005930", "000660"]})
 
     result = await list_datasets(
+        _caller_id="test-caller",
         store=store,
         symbol=None,
         timeframe="1d",
@@ -231,6 +246,7 @@ async def test_list_datasets_data_type_ohlcv():
     store = _make_store({"1d": ["005930"], "fundamental": ["005930"]})
 
     result = await list_datasets(
+        _caller_id="test-caller",
         store=store,
         symbol=None,
         timeframe="1d",
@@ -250,6 +266,7 @@ async def test_list_datasets_data_type_fundamental():
     store = _make_store({"1d": ["005930"], "fundamental": ["005930"]})
 
     result = await list_datasets(
+        _caller_id="test-caller",
         store=store,
         symbol=None,
         timeframe=None,

--- a/tests/unit/test_member_api.py
+++ b/tests/unit/test_member_api.py
@@ -177,37 +177,36 @@ def member_service():
 def client(member_service):
     """인증 컨텍스트가 미리 주입된 기본 클라이언트.
 
-    member 라우트 대다수는 인증된 master 호출자를 전제로 한다 (#1351 / #1377).
-    middleware 가 매 요청마다 다음 두 가지를 수행한다:
+    member 라우트 전체는 #1407 이후 인증된 master/member:* scope 호출자를 전제
+    로 한다. middleware 가 매 요청마다 다음 두 가지를 수행한다:
 
-    1. ``request.state.member_id = "master-user"`` 를 주입한다 — Bearer
-       인증 미들웨어가 채우는 자리를 모방해 ``require_master_caller`` /
-       ``_resolve_caller_or_401`` 가 caller 를 결정할 수 있게 한다.
-    2. ``member_service`` 에 ``master-user`` (role=master) 를 자동 등록한다 —
-       ``require_master_caller`` 가 ``member_service.get(caller)`` 로 role
-       검증을 하므로 master 멤버가 service 에 존재해야 한다 (#1377).
-
-    list 테스트는 미들웨어가 master-user 를 등록하지 않도록 GET 분기에서
-    skip 한다 — list/count 의 멤버 카운트 invariant 를 보존한다. mutation
-    (POST/PUT/PATCH/DELETE) 만 master-user 를 자동 등록한다. 인증 자체의
-    동작 검증은 ``test_member_routes_create_auth.py`` /
-    ``test_member_routes_mutation_auth.py`` 에서 별도로 수행한다.
+    1. ``request.state.member_id = "master-user"`` 를 주입한다 — Bearer 인증
+       미들웨어가 채우는 자리를 모방해 ``require_member_admin`` /
+       ``require_member_read`` 가 caller 를 결정할 수 있게 한다.
+    2. ``member_service.get("master-user")`` 가 role=master 인 synthetic 멤버를
+       반환하도록 패치한다 — scope dependency 가 caller 의 role 검증을 통과할
+       수 있게 한다. ``_members`` 딕셔너리는 건드리지 않으므로 list/count
+       invariant 가 보존된다.
     """
     app = create_app(member_service=member_service)
 
+    # #1407: scope dependency 가 service.get 으로 role 검증을 하므로
+    # master-user 를 synthetic 으로 응답하도록 ``get`` 을 wrap 한다.
+    # ``_members`` 는 그대로 두어 list/count 테스트의 카운트 invariant 보존.
+    _master_synthetic = FakeMember(member_id="master-user", role="master")
+    _original_get = member_service.get
+
+    async def _get_with_synthetic_master(member_id: str):
+        if member_id == "master-user":
+            return _master_synthetic
+        return await _original_get(member_id)
+
+    member_service.get = _get_with_synthetic_master
+
     @app.middleware("http")
     async def inject_master_caller(request, call_next):
-        # request.state.member_id 주입 (#1351 _resolve_caller_or_401 / #1377
-        # require_master_caller 의 caller 결정 경로).
+        # request.state.member_id 주입 (Bearer 인증 미들웨어 모방).
         request.state.member_id = "master-user"
-        # mutation route 만 ``require_master_caller`` 의 role 검증을 한다.
-        # GET (list/get) 은 인증 가드가 없으므로 master-user 를 service 에
-        # 등록할 필요 없다 — 등록하면 list/count 테스트의 멤버 카운트
-        # invariant 가 흔들린다. POST/PUT/PATCH/DELETE 만 master 를 등록한다.
-        if request.method != "GET" and "master-user" not in member_service._members:
-            member_service._members["master-user"] = FakeMember(
-                member_id="master-user", role="master"
-            )
         return await call_next(request)
 
     return TestClient(app)
@@ -412,7 +411,12 @@ class TestCallerIdPropagation:
     """request.state.member_id가 서비스 호출로 전달되는지 검증."""
 
     def test_register_passes_caller_id(self, member_service):
-        """인증된 사용자의 member_id가 registered_by로 전달."""
+        """인증된 사용자의 member_id가 registered_by로 전달.
+
+        #1407 이후 ``require_member_admin`` 의존성이 ``member_service.get(caller)``
+        로 caller 의 role 을 검증하므로 ``master-user`` (role=master) 를 service
+        에 등록해 둬야 한다.
+        """
         captured: dict[str, str] = {}
         original_register = member_service.register
 
@@ -421,6 +425,10 @@ class TestCallerIdPropagation:
             return await original_register(**kwargs)
 
         member_service.register = spy_register
+        # #1407: require_member_admin 이 master-user 의 role 을 검증한다.
+        member_service._members["master-user"] = FakeMember(
+            member_id="master-user", role="master"
+        )
 
         app = create_app(member_service=member_service)
 
@@ -438,7 +446,12 @@ class TestCallerIdPropagation:
         assert captured["registered_by"] == "master-user"
 
     def test_update_scopes_passes_caller_id(self, member_service):
-        """인증된 사용자의 member_id가 updated_by로 전달."""
+        """인증된 사용자의 member_id가 updated_by로 전달.
+
+        #1407 이후 ``require_member_admin`` 의존성이 ``member_service.get(caller)``
+        로 caller 의 role/scope 를 검증하므로 ``master-user`` (role=master) 를
+        서비스에 등록해 둬야 한다.
+        """
         captured: dict[str, str] = {}
         original_update = member_service.update_scopes
 
@@ -448,6 +461,10 @@ class TestCallerIdPropagation:
 
         member_service.update_scopes = spy_update
         member_service._members["agent-01"] = FakeMember(member_id="agent-01")
+        # #1407: require_member_admin 이 master-user 의 role 을 검증한다.
+        member_service._members["master-user"] = FakeMember(
+            member_id="master-user", role="master"
+        )
 
         app = create_app(member_service=member_service)
 
@@ -566,12 +583,21 @@ class TestErrorHandlingLogging:
         assert "status=active" in caplog.text
 
     def test_get_member_service_error_returns_503(self, client, member_service):
-        """get_member에서 예외 발생 시 503 반환."""
+        """get_member에서 예외 발생 시 503 반환.
 
-        async def raise_error(member_id):
+        #1407: ``require_member_read`` 가 caller (``master-user``) 검증을 위해
+        ``member_service.get`` 을 먼저 호출하므로, master-user 만 synthetic
+        master 를 반환하고 그 외 lookup 은 RuntimeError 를 raise 하도록 wrap
+        한다.
+        """
+        synthetic_master = FakeMember(member_id="master-user", role="master")
+
+        async def raise_error_except_master(member_id):
+            if member_id == "master-user":
+                return synthetic_master
             raise RuntimeError("DB connection lost")
 
-        member_service.get = raise_error
+        member_service.get = raise_error_except_master
         resp = client.get("/api/members/agent-01")
         assert resp.status_code == 503
         assert "조회할 수 없습니다" in resp.json()["detail"]
@@ -582,10 +608,14 @@ class TestErrorHandlingLogging:
         """get_member 예외 시 member_id가 로그에 포함."""
         import logging
 
-        async def raise_error(member_id):
+        synthetic_master = FakeMember(member_id="master-user", role="master")
+
+        async def raise_error_except_master(member_id):
+            if member_id == "master-user":
+                return synthetic_master
             raise RuntimeError("DB connection lost")
 
-        member_service.get = raise_error
+        member_service.get = raise_error_except_master
         with caplog.at_level(logging.ERROR, logger="ante.web.routes.members"):
             client.get("/api/members/agent-01")
         assert "agent-01" in caplog.text

--- a/tests/unit/test_member_routes_create_auth.py
+++ b/tests/unit/test_member_routes_create_auth.py
@@ -347,17 +347,15 @@ class TestCreateMemberAuthGuard:
         client: TestClient,
         member_service: FakeMemberService,
     ) -> None:
-        """일반 멤버의 세션 쿠키 → 403 (PermissionError 매핑).
+        """일반 멤버의 세션 쿠키 + member:admin scope 없음 → 403.
 
-        세션 쿠키 인증은 통과(401 아님)하지만, ``MemberService.register``가
-        master가 아닌 caller를 거부해서 403으로 매핑되어야 한다. 토큰 경로
-        의 동등 케이스(``test_create_member_with_non_master_token_returns_403``)
-        와 동일한 결과 보장.
+        #1407 이후 ``require_member_admin`` 의존성이 web layer 에서 먼저
+        403 을 raise 하므로 ``register`` 는 호출되지 않는다. 세션 쿠키 인증
+        자체는 통과(401 아님)했음을 status code 로 확인한다.
         """
         client.cookies.set("ante_session", "agent-session-id")
         resp = client.post("/api/members", json=_payload())
         assert resp.status_code == 403, resp.text
         assert "new-agent" not in member_service._members
-        # register는 호출됐어야 한다 (caller 결정 후 진입).
-        assert len(member_service.register_calls) == 1
-        assert member_service.register_calls[0]["registered_by"] == "agent-01"
+        # #1407: web layer 가 먼저 403 → register 호출 없음.
+        assert member_service.register_calls == []

--- a/tests/unit/test_member_routes_mutation_auth.py
+++ b/tests/unit/test_member_routes_mutation_auth.py
@@ -612,16 +612,13 @@ class TestSessionCookieMasterSuccess:
 
 
 class TestNonMaster403:
-    """인증된 non-master → 403 (PermissionDeniedError 매핑).
+    """인증된 non-master + member:admin scope 없음 → 403 (web layer 차단).
 
-    기존 5개 mutation route (suspend / reactivate / revoke / rotate_token /
-    update_scopes) 는 ``_resolve_caller_or_401`` 만 web layer 에서 적용하고,
-    master 검증은 service 가 ``PermissionDeniedError`` 를 raise 해 처리한다.
-    그래서 svc.* 가 1회 호출된 뒤 403 이 반환된다.
+    #1407 이후 5개 mutation route (suspend / reactivate / revoke / rotate_token /
+    update_scopes) 는 ``require_member_admin`` 의존성으로 web layer 에서 먼저
+    403 을 raise 한다. 따라서 service 호출은 일어나지 않는다.
 
-    ``change_password`` 는 ``require_master_caller`` 의존성으로 web layer 에서
-    먼저 403 을 raise 하므로 동작이 다르다. ``TestChangePasswordNonMaster403``
-    에서 별도로 검증한다 (#1377 oracle A7 finding scope 결정).
+    ``change_password`` 도 ``require_member_admin`` 로 동일한 동작.
     """
 
     @pytest.mark.parametrize(
@@ -641,8 +638,8 @@ class TestNonMaster403:
         assert resp.status_code == 403, (
             f"{name}: non-master Bearer가 403이 아님 ({resp.status_code}: {resp.text})"
         )
-        # 인증 자체는 통과 → service 호출은 일어나야 한다.
-        assert len(getattr(member_service, calls_attr)) == 1
+        # #1407: web layer 가 먼저 403 → service 호출 없음.
+        assert len(getattr(member_service, calls_attr)) == 0
 
 
 # ── 404: master + missing member ──────────────────────────────────────────

--- a/tests/unit/test_route_auth_coverage.py
+++ b/tests/unit/test_route_auth_coverage.py
@@ -1,13 +1,20 @@
-"""라우트 인증 dependency 정적 회귀 검증 (#1405).
+"""라우트 인증 dependency 정적 회귀 검증 (#1405 + #1407 enforce mode).
 
 본 테스트는 두 invariant 를 정적으로 잠근다.
 
-CASE 1 — ``ATTACHED_ROUTE_ALLOWLIST`` marker 회귀:
-    현재 ``src/ante/web/routes/`` 에서 ``Depends(require_*)`` 로 인증 가드가
-    부착된 17개 mutation 라우트가, 본 PR 시점의 SSOT(11-route-scope-table.md
-    "결정 scope" 컬럼) 와 정합한 상태로 ``src/ante/web/deps.py`` 의
-    ``_is_authentication_dependency = True`` marker 가 붙은 dependency 에 의해
-    보호되고 있음을 확인한다.
+CASE 1 — enforce mode (#1407):
+    ``src/ante/web/routes/`` 의 모든 ``APIRoute`` 가 다음 둘 중 하나에 해당해야
+    한다:
+
+    - PUBLIC_PATHS / PUBLIC_PREFIXES / GATE_EXEMPT_SELF_AUTH_PATHS 일치 → 인증
+      게이트 면제 (라우트 자체에 인증 dependency 없음을 허용).
+    - 그 외 ``/api/*`` 라우트 → ``src/ante/web/deps.py`` 의
+      ``_is_authentication_dependency = True`` marker 가 부착된 dependency 에
+      의해 보호되어야 한다.
+
+    #1407 마이그레이션으로 모든 70 라우트가 SSOT
+    (``docs/specs/web-api/11-route-scope-table.md``) 결정과 일관되게 부착되었다.
+    본 테스트는 이후 새 라우트 추가 시 부착 누락을 즉시 차단한다.
 
     회귀 시 nightmare 시나리오:
         - 라우트에서 ``Depends(require_*)`` 인자가 사라져도 ``app.routes`` 에는
@@ -21,11 +28,6 @@ CASE 2 — ``PUBLIC_PATHS`` ∪ ``GATE_EXEMPT_SELF_AUTH_PATHS`` 의 ``/api/*``
     ``/api/*`` 면제 경로는 라우트가 응답을 만들어야 의미가 있다. 코드 상
     경로 오타(예: ``/api/auht/me``)나 라우트 삭제가 spec/code drift 로
     이어지면 본 sanity 가 실패해 즉시 차단한다.
-
-본 테스트는 SSOT 와 직접 비교하지 않고 (CASE 1 의 ALLOWLIST 는 #1407 마이그
-레이션 전까지 부착이 narrow 한 상태이므로) "현재 부착된 라우트가 marker 로
-이어지는지" 만 검증한다. #1407 이후 narrow allowlist 가 제거되고 모든
-``/api/*`` 라우트가 enforce 되면, 본 파일을 제거하고 통합 검증으로 교체한다.
 """
 
 from __future__ import annotations
@@ -37,42 +39,6 @@ import pytest
 
 if TYPE_CHECKING:
     from fastapi.dependencies.models import Dependant
-
-
-# ── CASE 1 SSOT ────────────────────────────────────────────────────────────
-#
-# 본 시점 (#1405) 에 ``Depends(require_*)`` 로 인증 가드가 실제 부착된
-# (method, path) 17개. 11-route-scope-table.md "결정 scope" 컬럼과 정합 확인.
-# scope 문자열은 documentation purpose (가독성) 만이며, 본 테스트는
-# marker 부착 여부만 검증한다 (#1407 이 scope 기반 마이그레이션을 담당).
-ATTACHED_ROUTE_ALLOWLIST: dict[tuple[str, str], str] = {
-    # config
-    ("PUT", "/api/config/{key:path}"): "config:write",
-    # system (master-only)
-    ("POST", "/api/system/halt"): "system:admin",
-    ("POST", "/api/system/clear-halt"): "system:admin",
-    # audit
-    ("GET", "/api/audit"): "audit:read",
-    # members (master-only)
-    ("PATCH", "/api/members/{member_id}/password"): "member:admin",
-    # strategies
-    ("PATCH", "/api/strategies/{strategy_id}/status"): "strategy:write",
-    # accounts (master-only)
-    ("PUT", "/api/accounts/{account_id}"): "account:admin",
-    ("POST", "/api/accounts/{account_id}/suspend"): "account:admin",
-    ("POST", "/api/accounts/{account_id}/activate"): "account:admin",
-    ("PUT", "/api/accounts/{account_id}/rules/{rule_type}"): "rule:admin",
-    # bots (master-only)
-    ("POST", "/api/bots"): "bot:admin",
-    ("DELETE", "/api/bots/{bot_id}"): "bot:admin",
-    ("PUT", "/api/bots/{bot_id}"): "bot:admin",
-    # reports
-    ("POST", "/api/reports"): "report:write",
-    # treasury (master-only)
-    ("POST", "/api/treasury/bots/{bot_id}/allocate"): "treasury:write",
-    ("POST", "/api/treasury/bots/{bot_id}/deallocate"): "treasury:write",
-    ("POST", "/api/treasury/balance"): "treasury:write",
-}
 
 
 # ── helpers ────────────────────────────────────────────────────────────────
@@ -122,6 +88,24 @@ def _route_keys(route: object) -> Iterator[tuple[str, str]]:
         yield method.upper(), path
 
 
+def _is_exempt_path(
+    path: str,
+    public_paths: frozenset[str],
+    public_prefixes: tuple[str, ...],
+    gate_exempt_paths: frozenset[str],
+) -> bool:
+    """``path`` 가 PUBLIC_PATHS / PUBLIC_PREFIXES / GATE_EXEMPT_SELF_AUTH_PATHS
+    의 어느 한 카테고리에 속하면 True."""
+    if path in public_paths:
+        return True
+    if path in gate_exempt_paths:
+        return True
+    for prefix in public_prefixes:
+        if path.startswith(prefix):
+            return True
+    return False
+
+
 # ── fixtures ───────────────────────────────────────────────────────────────
 
 
@@ -141,38 +125,41 @@ def app_routes() -> list[object]:
     return [r for r in app.routes if isinstance(r, APIRoute)]
 
 
-# ── CASE 1 ─────────────────────────────────────────────────────────────────
+# ── CASE 1: enforce mode (#1407) ───────────────────────────────────────────
 
 
-def test_attached_routes_have_auth_marker(app_routes: list[object]) -> None:
-    """ALLOWLIST 의 17개 (method, path) 가 모두 marker 부착 dependency 로
-    보호되어 있다."""
-    # ``app.routes`` 에서 (method, path) → route 객체로 인덱싱.
-    index: dict[tuple[str, str], object] = {}
+def test_all_api_routes_have_auth_marker_or_exempt(app_routes: list[object]) -> None:
+    """모든 ``/api/*`` 라우트는 인증 dependency marker 부착 또는 면제 카테고리
+    (PUBLIC_PATHS / PUBLIC_PREFIXES / GATE_EXEMPT_SELF_AUTH_PATHS) 에 속해야
+    한다. #1407 enforce mode — 70 라우트 일관 부착 보장.
+    """
+    from ante.web.middleware.require_auth import (
+        GATE_EXEMPT_SELF_AUTH_PATHS,
+        PUBLIC_PATHS,
+        PUBLIC_PREFIXES,
+    )
+
+    missing_auth: list[tuple[str, str]] = []
     for route in app_routes:
-        for key in _route_keys(route):
-            index[key] = route
-
-    missing_routes: list[tuple[str, str]] = []
-    missing_marker: list[tuple[str, str]] = []
-    for key in ATTACHED_ROUTE_ALLOWLIST:
-        route = index.get(key)
-        if route is None:
-            missing_routes.append(key)
+        path = getattr(route, "path", "")
+        # /api/* 외 (정적/SPA fallback 등) 는 본 정적 검증 대상이 아님.
+        if not path.startswith("/api/"):
+            continue
+        # 면제 경로는 통과.
+        if _is_exempt_path(
+            path, PUBLIC_PATHS, PUBLIC_PREFIXES, GATE_EXEMPT_SELF_AUTH_PATHS
+        ):
             continue
         if not _has_auth_marker(route):
-            missing_marker.append(key)
+            for key in _route_keys(route):
+                missing_auth.append(key)
 
-    if missing_routes:
+    if missing_auth:
         pytest.fail(
-            "ATTACHED_ROUTE_ALLOWLIST 에 등록된 라우트가 app.routes 에서 "
-            f"발견되지 않음 (spec/code drift): {missing_routes}"
-        )
-    if missing_marker:
-        pytest.fail(
-            "ATTACHED_ROUTE_ALLOWLIST 에 등록된 라우트가 "
-            "_is_authentication_dependency marker 가 부착된 dependency 로 "
-            f"보호되지 않음 (marker 회귀): {missing_marker}"
+            "다음 /api/* 라우트가 _is_authentication_dependency marker 부착 "
+            "dependency 로 보호되지 않음 (#1407 enforce mode — SSOT "
+            "docs/specs/web-api/11-route-scope-table.md 결정에 따라 부착 필요):\n"
+            + "\n".join(f"  - {method} {path}" for method, path in sorted(missing_auth))
         )
 
 

--- a/tests/unit/test_runtime_mutation_auth.py
+++ b/tests/unit/test_runtime_mutation_auth.py
@@ -3484,3 +3484,76 @@ class TestUpdateStrategyStatusOpenAPI:
             f"requestBody schema 가 StatusUpdateRequest component 를 참조해야 한다 — "
             f"got {ref}"
         )
+
+
+# ── #1407 신규 scope 부착 smoke matrix ────────────────────────────────────
+
+
+class TestNewlyAttachedScopeRoutes401Smoke:
+    """#1407 에서 신규 부착된 라우트 표본을 대상으로 401 invariant 를 확인.
+
+    SSOT ``docs/specs/web-api/11-route-scope-table.md`` 의 48개 미부착 라우트
+    중 각 모듈에서 한두 개씩 골라, 인증 없는 호출이 401 로 차단되는지 smoke
+    한다. 전체 매트릭스 (70 라우트 × persona) 는 정적 검증
+    ``test_route_auth_coverage.py::test_all_api_routes_have_auth_marker_or_exempt``
+    가 marker 부착으로 보장하고, 본 smoke 는 marker 부착이 실제 런타임 401 응답
+    으로 이어지는지 cross-check 한다.
+    """
+
+    @pytest.mark.parametrize(
+        "method,path",
+        [
+            ("GET", "/api/accounts"),
+            ("GET", "/api/accounts/acc-target"),
+            ("GET", "/api/accounts/acc-target/rules"),
+            ("GET", "/api/approvals"),
+            ("GET", "/api/approvals/some-id"),
+            ("PATCH", "/api/approvals/some-id/status"),
+            ("GET", "/api/bots"),
+            ("GET", "/api/bots/bot-target"),
+            ("POST", "/api/bots/bot-target/start"),
+            ("POST", "/api/bots/bot-target/stop"),
+            ("GET", "/api/bots/bot-target/logs"),
+            ("GET", "/api/config"),
+            ("GET", "/api/data/datasets"),
+            ("GET", "/api/data/datasets/sym__1d"),
+            ("GET", "/api/data/schema"),
+            ("GET", "/api/data/storage"),
+            ("DELETE", "/api/data/datasets/sym__1d"),
+            ("GET", "/api/data/feed-status"),
+            ("GET", "/api/members"),
+            ("GET", "/api/members/m-1"),
+            ("POST", "/api/members/m-1/suspend"),
+            ("POST", "/api/members/m-1/reactivate"),
+            ("POST", "/api/members/m-1/revoke"),
+            ("POST", "/api/members/m-1/rotate-token"),
+            ("GET", "/api/portfolio/value"),
+            ("GET", "/api/portfolio/history"),
+            ("GET", "/api/reports"),
+            ("GET", "/api/reports/r-1"),
+            ("GET", "/api/strategies"),
+            ("POST", "/api/strategies/validate"),
+            ("GET", "/api/strategies/s-1"),
+            ("GET", "/api/strategies/s-1/performance"),
+            ("GET", "/api/strategies/s-1/daily-summary"),
+            ("GET", "/api/strategies/s-1/weekly-summary"),
+            ("GET", "/api/strategies/s-1/monthly-summary"),
+            ("GET", "/api/strategies/s-1/trades"),
+            ("GET", "/api/system/status"),
+            ("GET", "/api/trades"),
+            ("GET", "/api/treasury"),
+            ("GET", "/api/treasury/transactions"),
+            ("GET", "/api/treasury/budgets"),
+            ("GET", "/api/treasury/snapshots/latest"),
+            ("GET", "/api/treasury/snapshots"),
+            ("GET", "/api/treasury/snapshots/2026-05-01"),
+        ],
+    )
+    def test_no_auth_returns_401(
+        self, client: TestClient, method: str, path: str
+    ) -> None:
+        resp = client.request(method, path)
+        assert resp.status_code == 401, (
+            f"{method} {path}: 인증 없는 호출이 401 이 아님 "
+            f"({resp.status_code}: {resp.text})"
+        )


### PR DESCRIPTION
## Summary
- 11-route-scope-table.md SSOT 기준 70개 web route에 scope dependency 일관 적용
- 48 unattached → 신규 `Depends(require_X_Y)` 부착
- 13 master_caller → scope migration (`require_master_caller` → `require_X_Y`)
- 4 existing scope routes: 변경 없음 (검증만)
- 5 public/gate-exempt routes: 변경 없음 (검증만)

## Changes
- `src/ante/web/deps.py`: 신규 module-level alias 20개 추가 (#1406 factory 활용)
- 14개 route file (`src/ante/web/routes/*.py`): scope dependency 부착 + master_caller migration + docstring/OpenAPI description 갱신
- `tests/unit/test_route_auth_coverage.py`: 17-allowlist 제거 → 70-route enforce mode 활성화 (#1405 follow-up)
- `tests/unit/test_runtime_mutation_auth.py`: 44개 신규 부착 라우트 401 smoke matrix 추가 (table-driven)
- `tests/unit/test_member_*`: scope migration 에 따른 service 호출 invariant 갱신
- `tests/unit/test_member_api.py`: client fixture 의 synthetic master-user 분리 (list/count 카운트 invariant 보존)
- `tests/unit/test_datasets_list_api.py`: 신규 `_caller_id` 인자 추가
- `frontend/openapi.json`, `frontend/src/types/api.generated.ts`: regen (401/403 + description 갱신)

## Contract changes
- 13 master_caller migration 라우트의 403 detail 변경: `"master 권한 필요"` → `"master, human 멤버 또는 {scope} scope를 보유한 agent만 수행할 수 있습니다."` (default template)
- 48 unattached 라우트는 신규 인증 부착: 인증 없는 호출자는 401, scope 없는 agent는 403
- POST /api/strategies/validate, PATCH /api/approvals/{id}/status: raw-body 패턴으로 전환 (401 우선)
- members.py: `_resolve_caller_or_401` / `_caller_id` 헬퍼 제거 (require_member_admin 일관 적용)

## Test plan
- [x] `pytest tests/unit/test_route_auth_coverage.py -q` (enforce mode 70 routes)
- [x] `pytest tests/unit/test_runtime_mutation_auth.py -q` (table-driven matrix + 44 신규 smoke)
- [x] `pytest tests/unit/test_require_scope_factory.py -q` (#1406 회귀)
- [x] `pytest tests/unit/test_require_audit_read.py -q` (detail 회귀)
- [x] `pytest tests/unit/test_member_api.py tests/unit/test_member_routes_*.py -q`
- [x] `pytest tests/unit/test_web_api.py -q` (OpenAPI live sync)
- [x] `pytest tests/unit -q` (4621 passed, 2 skipped)
- [x] `ruff check src/ante/web/ tests/unit/` (all checks passed)
- [x] `ruff format --check src/ante/web/ tests/unit/` (already formatted)
- [x] OpenAPI regen 통과

## Codex Plan Review
- verdict: approve-implement (round 2/2)
- session: 019e17ad-8db1-76a3-8014-8afe7eacfbf8

Closes #1407

🤖 Generated with [Claude Code](https://claude.com/claude-code)