### PR TITLE
refactor: dependency scope-only 단순화 — middleware 책임 분리 (#1408)

### DIFF
--- a/src/ante/web/deps.py
+++ b/src/ante/web/deps.py
@@ -279,73 +279,57 @@ _STRATEGY_WRITE_PERMISSION_DENIED_DETAIL = (
 
 _MEMBER_INACTIVE_DETAIL = "멤버가 비활성 상태입니다."
 
+# 미들웨어 invariant 위반 시 사용. ``RequireAuthMiddleware`` (#1403) 가 보호
+# 라우트에 진입 전에 ``request.state.member_id`` 를 반드시 채우므로, dep 시점에
+# caller 가 비어 있다면 client 인증 실패가 아니라 미들웨어 설치 누락/순서 오류
+# 같은 서버 내부 invariant 위반이다. 401 (인증 실패) 와 구분되도록 500 응답.
+_AUTH_MIDDLEWARE_INVARIANT_DETAIL = (
+    "auth middleware did not populate member_id (invariant violation)"
+)
+
 
 async def require_master_caller(
     request: Request,
     member_service: Annotated[Any | None, Depends(get_member_service_optional)],
-    session_service: Annotated[Any | None, Depends(get_session_service_optional)],
 ) -> str:
-    """Bearer 토큰 또는 ``ante_session`` 쿠키로 caller를 결정하고 master 권한을
-    강제하는 FastAPI dependency.
+    """``request.state.member_id`` 가 master 권한을 가지는지 강제하는 FastAPI
+    dependency.
+
+    이슈 #1408: 인증 / caller resolution / ACTIVE 1차 검사는 모두 ``RequireAuth
+    Middleware`` (#1403) 가 담당한다. 본 dep 은 미들웨어가 채운 ``request.state.
+    member_id`` 를 신뢰하고 다음만 수행한다:
+
+    1. ``member_service.get(caller)`` 로 멤버를 조회.
+    2. ``MemberStatus.ACTIVE`` re-check (TOCTOU race guard — 미들웨어 통과 후
+       권한 분기 전 사이에 ``SUSPENDED`` / ``REVOKED`` 로 전환된 경우 차단).
+    3. ``MemberRole.MASTER`` 가 아니면 ``HTTPException(403)``.
 
     이슈 #1352: oracle A7 시그니처에서 발견된 5개 mutation route(account
-    update/suspend/activate, bot update, treasury set_balance)는 인증 없이
-    상태 변경을 허용하고 있었다. 이 dependency는 #1351 ``_resolve_caller_or_401``
-    패턴을 web layer 공통 가드로 끌어올리고, 추가로 caller가 ``MASTER`` role을
-    가지는지 검증한다.
-
-    절차:
-
-    1. ``TokenAuthMiddleware``가 채운 ``request.state.member_id``를 우선 사용
-       (Bearer 토큰 경로).
-    2. 비어 있으면 ``ante_session`` 쿠키 fallback. 단, ``session_service is
-       None`` 배포 분기에서는 fallback을 건너뛰고 caller 빈 상태를 유지 → 401.
-       ``session_service.validate`` 자체가 raise하면 401로 흡수한다.
-    3. caller가 빈 문자열이면 ``HTTPException(401)``을 raise.
-    4. ``member_service.get(caller)``로 멤버를 조회. 멤버가 None이거나
-       role이 ``MemberRole.MASTER``가 아니면 ``HTTPException(403)``.
-    5. 세션 쿠키 fallback에서 caller가 결정된 경우 ``request.state.member_id``
-       를 갱신해 ``AuditMiddleware``의 자동 감사 로그 주체와 일관성 유지.
+    update/suspend/activate, bot update, treasury set_balance) 의 master-only
+    가드를 제공한다.
 
     Returns:
         caller_id (str): 인증/권한 검증을 통과한 master member_id.
 
     Raises:
-        HTTPException(401): 인증 누락/실패.
-        HTTPException(403): 인증은 통과했으나 master가 아님.
+        HTTPException(403): 멤버 비활성 / master 아님 / ``member_service`` 에
+            caller_id 가 없는 ghost caller 케이스.
+        HTTPException(500): 미들웨어 invariant 위반 (``request.state.member_id``
+            미설정). 정상 운영에서는 발생하지 않음.
+        HTTPException(503): ``member_service`` 미주입 (cold-path).
     """
-    from ante.member.models import MemberRole
+    from ante.member.models import MemberRole, MemberStatus
+
+    if member_service is None:
+        # ``member_service`` 미주입은 cold-path invariant. 미들웨어 통과 시점에
+        # 이미 ``member_service.get`` 으로 ACTIVE 검증을 했으므로 정상 배포에서는
+        # 도달하지 않는다. 503 으로 서비스 미가용 표현.
+        raise HTTPException(status_code=503, detail="Member service not available")
 
     caller = getattr(request.state, "member_id", "") or ""
-
-    # Bearer 인증이 caller를 결정하지 못했고 session_service가 사용 가능하면
-    # ante_session 쿠키 fallback (#1351 SSOT 패턴).
-    if not caller and session_service is not None:
-        ante_session = request.cookies.get("ante_session")
-        if ante_session:
-            try:
-                session = await session_service.validate(ante_session)
-            except Exception:
-                logger.exception(
-                    "세션 검증 실패 (session_id 일부=%s...)", ante_session[:8]
-                )
-                session = None
-            if session:
-                resolved = session.get("member_id", "") or ""
-                if resolved:
-                    caller = resolved
-                    # AuditMiddleware의 자동 감사 로그 주체 일관성을 위해
-                    # request.state.member_id에도 반영한다.
-                    request.state.member_id = caller
-
     if not caller:
-        raise HTTPException(status_code=401, detail=_MASTER_AUTH_REQUIRED_DETAIL)
-
-    # ``member_service`` 미주입 분기는 본 dependency가 자체적으로 401로
-    # 떨어뜨려 cold-path invariant I1(``account_service`` 미주입에서도 409
-    # 회복)을 깨지 않는다. 정상 배포에서는 항상 주입돼 있다.
-    if member_service is None:
-        raise HTTPException(status_code=401, detail=_MASTER_AUTH_REQUIRED_DETAIL)
+        # 미들웨어 invariant 위반 — client 인증 실패 (401) 가 아님.
+        raise HTTPException(status_code=500, detail=_AUTH_MIDDLEWARE_INVARIANT_DETAIL)
 
     member = None
     try:
@@ -353,9 +337,20 @@ async def require_master_caller(
     except Exception:
         logger.exception("멤버 조회 실패 (member_id=%s)", caller)
 
-    role = getattr(member, "role", None) if member is not None else None
+    if member is None:
+        # ghost caller (미들웨어가 채운 id 가 멤버 서비스에 없음).
+        raise HTTPException(status_code=403, detail=_MASTER_PERMISSION_DENIED_DETAIL)
+
+    # ACTIVE re-check (TOCTOU race guard). 미들웨어가 1차 검증 후 권한 분기
+    # 전에 ``SUSPENDED`` / ``REVOKED`` 로 전환된 경우 여기서 차단한다.
+    status = getattr(member, "status", None)
+    status_value = getattr(status, "value", status)
+    if status_value != MemberStatus.ACTIVE.value:
+        raise HTTPException(status_code=403, detail=_MEMBER_INACTIVE_DETAIL)
+
+    role = getattr(member, "role", None)
     role_value = getattr(role, "value", role)
-    if member is None or role_value != MemberRole.MASTER.value:
+    if role_value != MemberRole.MASTER.value:
         raise HTTPException(status_code=403, detail=_MASTER_PERMISSION_DENIED_DETAIL)
 
     return caller
@@ -401,66 +396,47 @@ def _default_denied_detail(scope: str) -> str:
 async def _resolve_caller_with_scope(
     request: Request,
     member_service: Any | None,
-    session_service: Any | None,
     scope: str,
     denied_detail: str,
 ) -> str:
-    """Bearer 토큰 또는 ``ante_session`` 쿠키로 caller 를 결정하고 주어진
-    scope 권한을 강제하는 공통 helper.
+    """``request.state.member_id`` 의 scope 권한을 강제하는 공통 helper.
 
-    기존 4개 dependency (``require_audit_read`` / ``require_config_write`` /
-    ``require_report_write`` / ``require_strategy_write``) 의 본문을 그대로
-    옮겨와 통합한다. spec ``docs/specs/member/02-design-decisions.md:210-227``
-    의 ``require_scope`` predicate 와 동일한 OR 분기:
+    이슈 #1408: 인증 / caller resolution / ACTIVE 1차 검사는 모두 ``RequireAuth
+    Middleware`` (#1403) 가 담당한다. 본 helper 는 미들웨어가 채운
+    ``request.state.member_id`` 를 신뢰하고 spec ``docs/specs/member/
+    02-design-decisions.md:210-227`` 의 ``require_scope`` predicate 만 수행한다:
 
     - caller_member.role == ``MemberRole.MASTER`` → 통과
     - caller_member.type == ``MemberType.HUMAN`` → 통과 (scope 무관, spec
       predicate 가 ``human`` 멤버는 scope 검증을 무조건 통과시킨다)
-    - ``scope`` ∈ caller_member.scopes → 통과 (agent의 정상 경로)
+    - ``scope`` ∈ caller_member.scopes → 통과 (agent 정상 경로)
     - 그 외 (agent without scope) → ``HTTPException(403, denied_detail)``
 
-    인증 절차 (Bearer 우선, ``session_service`` 가용 시 ``ante_session`` 쿠키
-    fallback, ``session_service`` 미주입/예외/멤버 미존재는 모두 401/403 으로
-    흡수) 와 비활성 멤버 차단 (#1359 fix loop 4차 패턴) 은 ``require_master_caller``
-    와 일관성을 유지한다.
+    ACTIVE re-check 는 TOCTOU race guard 로 보존된다 — 미들웨어가 1차 검증한
+    뒤 권한 분기 전 사이에 ``SUSPENDED`` / ``REVOKED`` 로 전환된 멤버가 통과
+    하지 않도록 (#1359 fix loop 4차 패턴) 다시 한 번 검사한다.
 
     Returns:
-        caller_id (str): 인증/권한 검증을 통과한 member_id.
+        caller_id (str): 검증을 통과한 member_id.
 
     Raises:
-        HTTPException(401): 인증 누락/실패.
-        HTTPException(403): 인증은 통과했으나 요청 scope 권한 없음 또는
-            멤버 비활성 상태.
+        HTTPException(403): 멤버 비활성 / scope 권한 없음 / ``member_service``
+            에 caller_id 가 없는 ghost caller.
+        HTTPException(500): 미들웨어 invariant 위반 (``request.state.member_id``
+            미설정).
+        HTTPException(503): ``member_service`` 미주입 (cold-path).
     """
     from ante.member.models import MemberRole, MemberStatus, MemberType
 
-    caller = getattr(request.state, "member_id", "") or ""
-
-    # Bearer 인증이 caller를 결정하지 못했고 session_service가 사용 가능하면
-    # ante_session 쿠키 fallback (#1351 SSOT 패턴, require_master_caller 와 동일).
-    if not caller and session_service is not None:
-        ante_session = request.cookies.get("ante_session")
-        if ante_session:
-            try:
-                session = await session_service.validate(ante_session)
-            except Exception:
-                logger.exception(
-                    "세션 검증 실패 (session_id 일부=%s...)", ante_session[:8]
-                )
-                session = None
-            if session:
-                resolved = session.get("member_id", "") or ""
-                if resolved:
-                    caller = resolved
-                    # AuditMiddleware 의 자동 감사 로그 주체 일관성을 위해
-                    # request.state.member_id 에도 반영한다.
-                    request.state.member_id = caller
-
-    if not caller:
-        raise HTTPException(status_code=401, detail=_MASTER_AUTH_REQUIRED_DETAIL)
-
     if member_service is None:
-        raise HTTPException(status_code=401, detail=_MASTER_AUTH_REQUIRED_DETAIL)
+        # ``member_service`` 미주입은 cold-path invariant. 정상 배포에서는
+        # 도달하지 않는다. 503 으로 서비스 미가용 표현.
+        raise HTTPException(status_code=503, detail="Member service not available")
+
+    caller = getattr(request.state, "member_id", "") or ""
+    if not caller:
+        # 미들웨어 invariant 위반 — client 인증 실패 (401) 가 아님.
+        raise HTTPException(status_code=500, detail=_AUTH_MIDDLEWARE_INVARIANT_DETAIL)
 
     member = None
     try:
@@ -469,13 +445,10 @@ async def _resolve_caller_with_scope(
         logger.exception("멤버 조회 실패 (member_id=%s)", caller)
 
     if member is None:
+        # ghost caller (미들웨어가 채운 id 가 멤버 서비스에 없음).
         raise HTTPException(status_code=403, detail=denied_detail)
 
-    # 비활성 멤버 차단 (require_audit_read #1359 fix loop 4차 패턴 답습).
-    # ``TokenAuthMiddleware`` 는 토큰 인증 시 비활성을 거부하지만 세션 쿠키
-    # fallback 에서는 ``SessionService.validate`` 가 만료만 보므로, suspended/
-    # revoked 상태로 전환된 멤버가 통과할 수 있다. 권한 분기 직전에 명시적으로
-    # 차단해 두 경로 모두에서 일관된 invariant 를 유지한다.
+    # ACTIVE re-check (TOCTOU race guard).
     status = getattr(member, "status", None)
     status_value = getattr(status, "value", status)
     if status_value != MemberStatus.ACTIVE.value:
@@ -525,20 +498,20 @@ def require_scope(scope: str) -> Callable[..., Awaitable[str]]:
         on success.
 
     Raises (when invoked as a FastAPI dependency):
-        HTTPException(401): 인증 누락/실패.
-        HTTPException(403): 인증은 통과했으나 ``scope`` 권한 없음 또는
-            멤버 비활성 상태.
+        HTTPException(403): ``scope`` 권한 없음, 멤버 비활성, ghost caller.
+        HTTPException(500): 미들웨어 invariant 위반 (#1408).
+        HTTPException(503): ``member_service`` 미주입 (cold-path).
+
+    인증 자체 (401) 는 ``RequireAuthMiddleware`` (#1403) 가 본 dep 진입 전에
+    처리한다.
     """
     detail = _SCOPE_DENIED_DETAIL_MAP.get(scope) or _default_denied_detail(scope)
 
     async def inner_dep(
         request: Request,
         member_service: Annotated[Any | None, Depends(get_member_service_optional)],
-        session_service: Annotated[Any | None, Depends(get_session_service_optional)],
     ) -> str:
-        return await _resolve_caller_with_scope(
-            request, member_service, session_service, scope, detail
-        )
+        return await _resolve_caller_with_scope(request, member_service, scope, detail)
 
     inner_dep.__name__ = f"require_scope_{scope.replace(':', '_')}"
     # ``test_route_auth_coverage`` 가 본 marker 로 인증 dependency 를 식별한다

--- a/tests/unit/test_require_audit_read.py
+++ b/tests/unit/test_require_audit_read.py
@@ -1,22 +1,24 @@
-"""``require_audit_read`` dependency 단위 테스트 (issue #1359 Codex P2 fix loop 3차).
+"""``require_audit_read`` dependency 단위 테스트 (issues #1359 / #1408).
 
-dependency 자체의 동작(Bearer 우선, 쿠키 fallback, session_service None skip,
-human bypass / master / ``audit:read`` scope 검증, ``request.state.member_id``
-갱신)을 라우트 통합 없이 검증한다. 라우트 통합 테스트는
-``tests/unit/test_audit_routes_auth.py``에 있다.
+#1408 단순화 후 본 dep 은 ``RequireAuthMiddleware`` (#1403) 가 채운
+``request.state.member_id`` 를 신뢰하고 다음만 수행한다:
 
-배경:
-    1차 패치는 ``GET /api/audit``에 ``require_master_caller``를 적용해 master
-    role만 허용했다. 2차 패치는 ``master`` 또는 ``audit:read`` scope OR로 완화했지만
-    human admin/default 사용자를 여전히 403으로 차단했다. spec
-    ``docs/specs/member/02-design-decisions.md:210-221`` 의 ``require_scope``
-    predicate는 ``member.type == "human"`` 이면 scope 검증을 무조건 통과시키므로,
-    3차 패치(현재)는 다음 OR 분기를 적용한다:
+    - ``member_service.get(caller)``
+    - ``MemberStatus.ACTIVE`` re-check (TOCTOU race guard)
+    - ``require_scope`` predicate (master / human bypass / scope ∈ scopes)
+
+spec ``docs/specs/member/02-design-decisions.md:210-221`` 의 ``require_scope``
+predicate 와 동일:
 
     - master role → 통과
     - human 멤버 → 통과 (scope 무관)
-    - ``audit:read`` ∈ scopes → 통과 (agent의 정상 경로)
+    - ``audit:read`` ∈ scopes → 통과 (agent 정상 경로)
     - 그 외 (agent without scope) → 403
+
+Bearer 헤더 / ``ante_session`` 쿠키 해석은 미들웨어 책임으로 이전되었으므로
+본 파일은 더 이상 mock Bearer/cookie 분기를 검증하지 않는다 (#1408). 통합
+경로는 ``tests/unit/test_audit_routes_auth.py`` / ``tests/unit/test_runtime_
+mutation_auth.py`` 가 ``TestClient`` 를 통해 미들웨어 + dep 합산을 검증한다.
 """
 
 from __future__ import annotations
@@ -66,48 +68,24 @@ class _StubMemberService:
         return self._members.get(member_id)
 
 
-class _StubSessionService:
-    def __init__(self, raise_on_validate: bool = False) -> None:
-        self.calls: list[str] = []
-        self._sessions: dict[str, str] = {}
-        self.raise_on_validate = raise_on_validate
+def _make_request(*, state_member_id: str | None = None) -> SimpleNamespace:
+    """FastAPI Request 의 최소 stub.
 
-    def add_session(self, session_id: str, member_id: str) -> None:
-        self._sessions[session_id] = member_id
-
-    async def validate(self, session_id: str) -> dict | None:
-        self.calls.append(session_id)
-        if self.raise_on_validate:
-            raise RuntimeError("session backend offline")
-        member_id = self._sessions.get(session_id)
-        if member_id is None:
-            return None
-        return {"member_id": member_id}
-
-
-def _make_request(
-    *,
-    state_member_id: str | None = None,
-    cookies: dict[str, str] | None = None,
-) -> SimpleNamespace:
-    """FastAPI Request 인터페이스를 흉내내는 최소 stub.
-
-    ``require_audit_read``는 ``request.state.member_id`` getattr와
-    ``request.cookies.get`` 만 사용한다.
+    #1408 단순화 후 dep 은 ``request.state.member_id`` 만 참조한다. 미들웨어가
+    이미 채운 상태를 흉내내기 위해 ``state_member_id`` 만 받는다.
     """
     state = SimpleNamespace()
     if state_member_id is not None:
         state.member_id = state_member_id
-    cookies_obj = cookies or {}
-    return SimpleNamespace(state=state, cookies=cookies_obj)
+    return SimpleNamespace(state=state)
 
 
 # ── 200: 통과 케이스 ────────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_returns_caller_when_bearer_master() -> None:
-    """master role → 통과 (scope와 무관)."""
+async def test_returns_caller_when_master() -> None:
+    """master role → 통과 (scope 와 무관)."""
     svc = _StubMemberService()
     svc.add(
         "master-user",
@@ -116,7 +94,7 @@ async def test_returns_caller_when_bearer_master() -> None:
     )
     request = _make_request(state_member_id="master-user")
 
-    caller = await require_audit_read(request, svc, None)
+    caller = await require_audit_read(request, svc)
 
     assert caller == "master-user"
     assert svc.calls == ["master-user"]
@@ -138,7 +116,7 @@ async def test_returns_caller_when_human_admin_without_scope() -> None:
     )
     request = _make_request(state_member_id="human-admin")
 
-    caller = await require_audit_read(request, svc, None)
+    caller = await require_audit_read(request, svc)
 
     assert caller == "human-admin"
     assert svc.calls == ["human-admin"]
@@ -148,7 +126,7 @@ async def test_returns_caller_when_human_admin_without_scope() -> None:
 async def test_returns_caller_when_human_default_without_scope() -> None:
     """human default 멤버 → 통과 (scope 미보유여도 human bypass).
 
-    spec ``require_scope`` predicate는 type만 보고 scope 비검사.
+    spec ``require_scope`` predicate 는 type 만 보고 scope 비검사.
     """
     svc = _StubMemberService()
     svc.add(
@@ -159,7 +137,7 @@ async def test_returns_caller_when_human_default_without_scope() -> None:
     )
     request = _make_request(state_member_id="human-default")
 
-    caller = await require_audit_read(request, svc, None)
+    caller = await require_audit_read(request, svc)
 
     assert caller == "human-default"
     assert svc.calls == ["human-default"]
@@ -180,7 +158,7 @@ async def test_returns_caller_when_default_with_audit_read_scope() -> None:
     )
     request = _make_request(state_member_id="monitor-agent")
 
-    caller = await require_audit_read(request, svc, None)
+    caller = await require_audit_read(request, svc)
 
     assert caller == "monitor-agent"
     assert svc.calls == ["monitor-agent"]
@@ -198,125 +176,60 @@ async def test_returns_caller_when_admin_with_audit_read_scope() -> None:
     )
     request = _make_request(state_member_id="admin-1")
 
-    caller = await require_audit_read(request, svc, None)
+    caller = await require_audit_read(request, svc)
 
     assert caller == "admin-1"
 
 
-@pytest.mark.asyncio
-async def test_falls_back_to_session_cookie_when_bearer_missing() -> None:
-    """Bearer 미설정 + 유효 세션 쿠키(agent + audit:read) → caller 결정 + state 갱신."""
-    member_svc = _StubMemberService()
-    member_svc.add(
-        "cookie-monitor",
-        role=MemberRole.DEFAULT.value,
-        member_type=MemberType.AGENT.value,
-        scopes=["audit:read"],
-    )
-
-    session_svc = _StubSessionService()
-    session_svc.add_session("sid-1", "cookie-monitor")
-
-    request = _make_request(cookies={"ante_session": "sid-1"})
-
-    caller = await require_audit_read(request, member_svc, session_svc)
-
-    assert caller == "cookie-monitor"
-    assert session_svc.calls == ["sid-1"]
-    # AuditMiddleware 일관성을 위해 request.state.member_id가 갱신돼야 한다.
-    assert request.state.member_id == "cookie-monitor"
+# ── 500: 미들웨어 invariant 위반 (#1408) ─────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_bearer_caller_takes_precedence_over_cookie() -> None:
-    """Bearer 토큰이 caller를 결정하면 쿠키 검증을 다시 호출하지 않는다."""
-    member_svc = _StubMemberService()
-    member_svc.add(
-        "bearer-master",
-        role=MemberRole.MASTER.value,
-        member_type=MemberType.HUMAN.value,
-    )
-    session_svc = _StubSessionService()
-    session_svc.add_session("sid-1", "cookie-user")
+async def test_raises_500_when_state_member_id_missing() -> None:
+    """``request.state.member_id`` 미설정 → 500 invariant violation.
 
-    request = _make_request(
-        state_member_id="bearer-master",
-        cookies={"ante_session": "sid-1"},
-    )
-
-    caller = await require_audit_read(request, member_svc, session_svc)
-
-    assert caller == "bearer-master"
-    assert session_svc.calls == [], (
-        "Bearer 결정 시 session_service.validate가 호출되어선 안 된다"
-    )
-
-
-# ── 401: 인증 실패 케이스 ──────────────────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_raises_401_when_no_bearer_and_no_cookie() -> None:
-    """Bearer 없음 + 쿠키 없음 → 401."""
+    #1408: ``RequireAuthMiddleware`` 가 보호 라우트 진입 전에
+    ``request.state.member_id`` 를 반드시 채우므로, 비어 있다면 client 인증
+    실패 (401) 가 아니라 미들웨어 설치 누락/순서 오류 같은 서버 내부 invariant
+    위반이다.
+    """
     svc = _StubMemberService()
-    request = _make_request()
+    request = _make_request()  # state.member_id 미설정
 
     with pytest.raises(HTTPException) as exc:
-        await require_audit_read(request, svc, _StubSessionService())
+        await require_audit_read(request, svc)
 
-    assert exc.value.status_code == 401
+    assert exc.value.status_code == 500
 
 
 @pytest.mark.asyncio
-async def test_raises_401_when_session_service_none_and_only_cookie() -> None:
-    """``session_service is None`` + Bearer 없음 → 쿠키 fallback skip → 401."""
+async def test_raises_500_when_state_member_id_empty_string() -> None:
+    """``request.state.member_id == ""`` → 500 (빈 문자열도 invariant 위반)."""
     svc = _StubMemberService()
-    request = _make_request(cookies={"ante_session": "sid-1"})
+    request = _make_request(state_member_id="")
 
     with pytest.raises(HTTPException) as exc:
-        await require_audit_read(request, svc, None)
+        await require_audit_read(request, svc)
 
-    assert exc.value.status_code == 401
+    assert exc.value.status_code == 500
 
 
-@pytest.mark.asyncio
-async def test_raises_401_when_invalid_cookie() -> None:
-    """유효하지 않은 세션 쿠키 → 401."""
-    svc = _StubMemberService()
-    session_svc = _StubSessionService()
-    request = _make_request(cookies={"ante_session": "unknown-sid"})
-
-    with pytest.raises(HTTPException) as exc:
-        await require_audit_read(request, svc, session_svc)
-
-    assert exc.value.status_code == 401
-    assert session_svc.calls == ["unknown-sid"]
+# ── 503: member_service 미주입 (cold-path) ──────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_session_validate_exception_is_absorbed_as_401() -> None:
-    """``session_service.validate`` 예외는 401로 흡수돼야 한다 (#1351 패턴)."""
-    svc = _StubMemberService()
-    session_svc = _StubSessionService(raise_on_validate=True)
-    request = _make_request(cookies={"ante_session": "sid-1"})
+async def test_raises_503_when_member_service_missing() -> None:
+    """``member_service is None`` (cold-path invariant) → 503.
 
-    with pytest.raises(HTTPException) as exc:
-        await require_audit_read(request, svc, session_svc)
-
-    assert exc.value.status_code == 401
-
-
-@pytest.mark.asyncio
-async def test_raises_401_when_member_service_missing() -> None:
-    """``member_service is None`` 분기는 cold-path invariant I1을 깨지 않게
-    401로 떨어진다 (``require_master_caller``와 동일 정책).
+    정상 배포에서는 항상 주입되며 미들웨어 통과 시점에도 검증되었으므로
+    도달하지 않는다.
     """
     request = _make_request(state_member_id="some-caller")
 
     with pytest.raises(HTTPException) as exc:
-        await require_audit_read(request, None, None)
+        await require_audit_read(request, None)
 
-    assert exc.value.status_code == 401
+    assert exc.value.status_code == 503
 
 
 # ── 403: 권한 실패 케이스 ──────────────────────────────────────────────
@@ -335,7 +248,7 @@ async def test_raises_403_when_agent_default_without_audit_read_scope() -> None:
     request = _make_request(state_member_id="plain-agent")
 
     with pytest.raises(HTTPException) as exc:
-        await require_audit_read(request, svc, None)
+        await require_audit_read(request, svc)
 
     assert exc.value.status_code == 403
 
@@ -353,16 +266,16 @@ async def test_raises_403_when_agent_default_with_empty_scopes() -> None:
     request = _make_request(state_member_id="plain-agent")
 
     with pytest.raises(HTTPException) as exc:
-        await require_audit_read(request, svc, None)
+        await require_audit_read(request, svc)
 
     assert exc.value.status_code == 403
 
 
 @pytest.mark.asyncio
 async def test_raises_403_when_agent_admin_without_audit_read_scope() -> None:
-    """agent admin role + ``audit:read`` 미보유 → 403 (agent admin은 자동 통과 아님).
+    """agent admin role + ``audit:read`` 미보유 → 403 (agent admin 은 자동 통과 아님).
 
-    agent는 type bypass 대상이 아니므로 scope 검증을 받는다.
+    agent 는 type bypass 대상이 아니므로 scope 검증을 받는다.
     """
     svc = _StubMemberService()
     svc.add(
@@ -374,35 +287,34 @@ async def test_raises_403_when_agent_admin_without_audit_read_scope() -> None:
     request = _make_request(state_member_id="admin-no-scope")
 
     with pytest.raises(HTTPException) as exc:
-        await require_audit_read(request, svc, None)
+        await require_audit_read(request, svc)
 
     assert exc.value.status_code == 403
 
 
 @pytest.mark.asyncio
 async def test_raises_403_when_caller_id_unknown_to_member_service() -> None:
-    """인증 미들웨어가 ``request.state.member_id``를 채웠으나 멤버 서비스에
-    해당 id가 없는 경우 → 403 (ghost caller invariant 보호).
+    """미들웨어가 ``request.state.member_id`` 를 채웠으나 멤버 서비스에 해당
+    id 가 없는 경우 → 403 (ghost caller invariant 보호).
     """
     svc = _StubMemberService()
     request = _make_request(state_member_id="ghost-id")
 
     with pytest.raises(HTTPException) as exc:
-        await require_audit_read(request, svc, None)
+        await require_audit_read(request, svc)
 
     assert exc.value.status_code == 403
 
 
-# ── 403: 비활성 멤버 차단 (Codex P2 #1359 fix loop 4차) ───────────────────
+# ── 403: 비활성 멤버 차단 (TOCTOU race guard, #1359 fix loop 4차 / #1408) ─
 
 
 @pytest.mark.asyncio
 async def test_raises_403_when_master_suspended() -> None:
-    """master role이지만 ``status == SUSPENDED`` → 403.
+    """master role 이지만 ``status == SUSPENDED`` → 403.
 
-    ``TokenAuthMiddleware``는 토큰 경로에서 비활성 멤버를 거부하지만
-    ``ante_session`` 쿠키 fallback은 ``SessionService.validate``가 만료만
-    검사하므로, 권한 분기 직전에 명시적으로 차단해야 한다.
+    미들웨어가 ACTIVE 1차 검증을 했어도 권한 분기 전 race window 에서
+    ``SUSPENDED`` 로 전환된 경우 본 dep 이 차단해야 한다 (#1408 TOCTOU guard).
     """
     svc = _StubMemberService()
     svc.add(
@@ -414,14 +326,14 @@ async def test_raises_403_when_master_suspended() -> None:
     request = _make_request(state_member_id="master-suspended")
 
     with pytest.raises(HTTPException) as exc:
-        await require_audit_read(request, svc, None)
+        await require_audit_read(request, svc)
 
     assert exc.value.status_code == 403
 
 
 @pytest.mark.asyncio
 async def test_raises_403_when_master_revoked() -> None:
-    """master role이지만 ``status == REVOKED`` → 403."""
+    """master role 이지만 ``status == REVOKED`` → 403."""
     svc = _StubMemberService()
     svc.add(
         "master-revoked",
@@ -432,16 +344,16 @@ async def test_raises_403_when_master_revoked() -> None:
     request = _make_request(state_member_id="master-revoked")
 
     with pytest.raises(HTTPException) as exc:
-        await require_audit_read(request, svc, None)
+        await require_audit_read(request, svc)
 
     assert exc.value.status_code == 403
 
 
 @pytest.mark.asyncio
 async def test_raises_403_when_human_admin_suspended() -> None:
-    """human admin (type bypass 대상)이라도 ``status == SUSPENDED`` → 403.
+    """human admin (type bypass 대상) 이라도 ``status == SUSPENDED`` → 403.
 
-    type bypass가 status 검사보다 우선해서는 안 된다.
+    type bypass 가 status 검사보다 우선해서는 안 된다.
     """
     svc = _StubMemberService()
     svc.add(
@@ -453,7 +365,7 @@ async def test_raises_403_when_human_admin_suspended() -> None:
     request = _make_request(state_member_id="human-admin-suspended")
 
     with pytest.raises(HTTPException) as exc:
-        await require_audit_read(request, svc, None)
+        await require_audit_read(request, svc)
 
     assert exc.value.status_code == 403
 
@@ -475,6 +387,6 @@ async def test_raises_403_when_agent_with_audit_read_scope_suspended() -> None:
     request = _make_request(state_member_id="monitor-agent-suspended")
 
     with pytest.raises(HTTPException) as exc:
-        await require_audit_read(request, svc, None)
+        await require_audit_read(request, svc)
 
     assert exc.value.status_code == 403

--- a/tests/unit/test_require_master_caller.py
+++ b/tests/unit/test_require_master_caller.py
@@ -1,8 +1,16 @@
-"""``require_master_caller`` dependency 단위 테스트 (issue #1352).
+"""``require_master_caller`` dependency 단위 테스트 (issues #1352 / #1408).
 
-dependency 자체의 동작(Bearer 우선, 쿠키 fallback, session_service None skip,
-master 검증, ``request.state.member_id`` 갱신)을 라우트 통합 없이 검증한다.
-실 통합 테스트는 ``tests/unit/test_runtime_mutation_auth.py``에 있다.
+#1408 단순화 후 본 dep 은 ``RequireAuthMiddleware`` (#1403) 가 채운
+``request.state.member_id`` 를 신뢰하고 다음만 수행한다:
+
+    - ``member_service.get(caller)``
+    - ``MemberStatus.ACTIVE`` re-check (TOCTOU race guard)
+    - ``MemberRole.MASTER`` 강제
+
+Bearer 헤더 / ``ante_session`` 쿠키 해석은 미들웨어 책임으로 이전되었으므로
+본 파일은 더 이상 mock Bearer/cookie 분기를 검증하지 않는다. 라우트 통합
+경로는 ``tests/unit/test_runtime_mutation_auth.py`` 가 ``TestClient`` 를
+통해 미들웨어 + dep 합산을 검증한다.
 """
 
 from __future__ import annotations
@@ -13,7 +21,7 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException
 
-from ante.member.models import MemberRole
+from ante.member.models import MemberRole, MemberStatus
 from ante.web.deps import require_master_caller
 
 
@@ -21,6 +29,7 @@ from ante.web.deps import require_master_caller
 class _StubMember:
     member_id: str
     role: str
+    status: str = MemberStatus.ACTIVE.value
 
 
 class _StubMemberService:
@@ -28,176 +37,158 @@ class _StubMemberService:
         self.calls: list[str] = []
         self._members: dict[str, _StubMember] = {}
 
-    def add(self, member_id: str, role: str = "default") -> None:
-        self._members[member_id] = _StubMember(member_id=member_id, role=role)
+    def add(
+        self,
+        member_id: str,
+        role: str = "default",
+        status: str = MemberStatus.ACTIVE.value,
+    ) -> None:
+        self._members[member_id] = _StubMember(
+            member_id=member_id, role=role, status=status
+        )
 
     async def get(self, member_id: str) -> _StubMember | None:
         self.calls.append(member_id)
         return self._members.get(member_id)
 
 
-class _StubSessionService:
-    def __init__(self, raise_on_validate: bool = False) -> None:
-        self.calls: list[str] = []
-        self._sessions: dict[str, str] = {}
-        self.raise_on_validate = raise_on_validate
+def _make_request(*, state_member_id: str | None = None) -> SimpleNamespace:
+    """FastAPI Request 의 최소 stub.
 
-    def add_session(self, session_id: str, member_id: str) -> None:
-        self._sessions[session_id] = member_id
-
-    async def validate(self, session_id: str) -> dict | None:
-        self.calls.append(session_id)
-        if self.raise_on_validate:
-            raise RuntimeError("session backend offline")
-        member_id = self._sessions.get(session_id)
-        if member_id is None:
-            return None
-        return {"member_id": member_id}
-
-
-def _make_request(
-    *,
-    state_member_id: str | None = None,
-    cookies: dict[str, str] | None = None,
-) -> SimpleNamespace:
-    """FastAPI Request 인터페이스를 흉내내는 최소 stub.
-
-    ``require_master_caller``는 ``request.state.member_id`` getattr와
-    ``request.cookies.get`` 만 사용한다.
+    #1408 단순화 후 dep 은 ``request.state.member_id`` 만 참조한다. 미들웨어가
+    이미 채운 상태를 흉내내기 위해 ``state_member_id`` 만 받는다.
     """
     state = SimpleNamespace()
     if state_member_id is not None:
         state.member_id = state_member_id
-    cookies_obj = cookies or {}
-    return SimpleNamespace(state=state, cookies=cookies_obj)
+    return SimpleNamespace(state=state)
+
+
+# ── 200: 통과 케이스 ────────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_returns_caller_when_bearer_master() -> None:
-    """``request.state.member_id`` (Bearer 경로)가 master면 caller 반환."""
+async def test_returns_caller_when_master() -> None:
+    """``request.state.member_id`` 가 master 면 caller 반환."""
     svc = _StubMemberService()
     svc.add("master-user", role=MemberRole.MASTER.value)
     request = _make_request(state_member_id="master-user")
 
-    caller = await require_master_caller(request, svc, None)
+    caller = await require_master_caller(request, svc)
 
     assert caller == "master-user"
     assert svc.calls == ["master-user"]
 
 
-@pytest.mark.asyncio
-async def test_falls_back_to_session_cookie_when_bearer_missing() -> None:
-    """Bearer 미설정 + 유효 세션 쿠키 → caller 결정 + state 갱신."""
-    member_svc = _StubMemberService()
-    member_svc.add("master-cookie-user", role=MemberRole.MASTER.value)
-
-    session_svc = _StubSessionService()
-    session_svc.add_session("sid-1", "master-cookie-user")
-
-    request = _make_request(cookies={"ante_session": "sid-1"})
-
-    caller = await require_master_caller(request, member_svc, session_svc)
-
-    assert caller == "master-cookie-user"
-    assert session_svc.calls == ["sid-1"]
-    # AuditMiddleware 일관성을 위해 request.state.member_id가 갱신돼야 한다.
-    assert request.state.member_id == "master-cookie-user"
+# ── 500: 미들웨어 invariant 위반 (#1408) ─────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_raises_401_when_no_bearer_and_no_cookie() -> None:
-    """Bearer 없음 + 쿠키 없음 → 401."""
+async def test_raises_500_when_state_member_id_missing() -> None:
+    """``request.state.member_id`` 미설정 → 500 invariant violation.
+
+    #1408: ``RequireAuthMiddleware`` 가 보호 라우트 진입 전에
+    ``request.state.member_id`` 를 반드시 채우므로, 비어 있다면 client 인증
+    실패 (401) 가 아니라 서버 내부 invariant 위반이다.
+    """
     svc = _StubMemberService()
     request = _make_request()
 
     with pytest.raises(HTTPException) as exc:
-        await require_master_caller(request, svc, _StubSessionService())
+        await require_master_caller(request, svc)
 
-    assert exc.value.status_code == 401
-
-
-@pytest.mark.asyncio
-async def test_raises_401_when_session_service_none_and_only_cookie() -> None:
-    """``session_service is None`` + Bearer 없음 → 쿠키 fallback skip → 401."""
-    svc = _StubMemberService()
-    request = _make_request(cookies={"ante_session": "sid-1"})
-
-    with pytest.raises(HTTPException) as exc:
-        await require_master_caller(request, svc, None)
-
-    assert exc.value.status_code == 401
+    assert exc.value.status_code == 500
 
 
 @pytest.mark.asyncio
-async def test_raises_401_when_invalid_cookie() -> None:
-    """유효하지 않은 세션 쿠키 → 401."""
+async def test_raises_500_when_state_member_id_empty_string() -> None:
+    """``request.state.member_id == ""`` → 500 (빈 문자열도 invariant 위반)."""
     svc = _StubMemberService()
-    session_svc = _StubSessionService()
-    request = _make_request(cookies={"ante_session": "unknown-sid"})
+    request = _make_request(state_member_id="")
 
     with pytest.raises(HTTPException) as exc:
-        await require_master_caller(request, svc, session_svc)
+        await require_master_caller(request, svc)
 
-    assert exc.value.status_code == 401
-    assert session_svc.calls == ["unknown-sid"]
+    assert exc.value.status_code == 500
+
+
+# ── 503: member_service 미주입 (cold-path) ──────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_session_validate_exception_is_absorbed_as_401() -> None:
-    """``session_service.validate`` 예외는 401로 흡수돼야 한다 (#1351 패턴)."""
-    svc = _StubMemberService()
-    session_svc = _StubSessionService(raise_on_validate=True)
-    request = _make_request(cookies={"ante_session": "sid-1"})
+async def test_raises_503_when_member_service_missing() -> None:
+    """``member_service is None`` (cold-path invariant) → 503."""
+    request = _make_request(state_member_id="some-caller")
 
     with pytest.raises(HTTPException) as exc:
-        await require_master_caller(request, svc, session_svc)
+        await require_master_caller(request, None)
 
-    assert exc.value.status_code == 401
+    assert exc.value.status_code == 503
+
+
+# ── 403: 권한 / 비활성 케이스 ──────────────────────────────────────────
 
 
 @pytest.mark.asyncio
 async def test_raises_403_when_caller_is_not_master() -> None:
-    """인증된 non-master → 403, 메시지 톤은 한국어."""
+    """인증된 non-master → 403."""
     svc = _StubMemberService()
     svc.add("agent-01", role=MemberRole.DEFAULT.value)
     request = _make_request(state_member_id="agent-01")
 
     with pytest.raises(HTTPException) as exc:
-        await require_master_caller(request, svc, None)
+        await require_master_caller(request, svc)
 
     assert exc.value.status_code == 403
 
 
 @pytest.mark.asyncio
 async def test_raises_403_when_caller_id_unknown_to_member_service() -> None:
-    """인증 미들웨어가 ``request.state.member_id``를 채웠으나 멤버 서비스에
-    해당 id가 없는 경우 → 403 (ghost caller invariant 보호).
+    """미들웨어가 ``request.state.member_id`` 를 채웠으나 멤버 서비스에 해당
+    id 가 없는 경우 → 403 (ghost caller invariant 보호).
     """
     svc = _StubMemberService()
     request = _make_request(state_member_id="ghost-id")
 
     with pytest.raises(HTTPException) as exc:
-        await require_master_caller(request, svc, None)
+        await require_master_caller(request, svc)
 
     assert exc.value.status_code == 403
 
 
 @pytest.mark.asyncio
-async def test_bearer_caller_takes_precedence_over_cookie() -> None:
-    """Bearer 토큰이 caller를 결정하면 쿠키 검증을 다시 호출하지 않는다."""
-    member_svc = _StubMemberService()
-    member_svc.add("master-bearer", role=MemberRole.MASTER.value)
-    session_svc = _StubSessionService()
-    session_svc.add_session("sid-1", "master-cookie-user")
+async def test_raises_403_when_master_suspended() -> None:
+    """master role 이지만 ``status == SUSPENDED`` → 403 (#1408 TOCTOU race guard).
 
-    request = _make_request(
-        state_member_id="master-bearer",
-        cookies={"ante_session": "sid-1"},
+    미들웨어가 ACTIVE 1차 검증을 했어도 권한 분기 전 race window 에서
+    ``SUSPENDED`` 로 전환된 경우 본 dep 이 차단해야 한다.
+    """
+    svc = _StubMemberService()
+    svc.add(
+        "master-suspended",
+        role=MemberRole.MASTER.value,
+        status=MemberStatus.SUSPENDED.value,
     )
+    request = _make_request(state_member_id="master-suspended")
 
-    caller = await require_master_caller(request, member_svc, session_svc)
+    with pytest.raises(HTTPException) as exc:
+        await require_master_caller(request, svc)
 
-    assert caller == "master-bearer"
-    assert session_svc.calls == [], (
-        "Bearer 결정 시 session_service.validate가 호출되어선 안 된다"
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_raises_403_when_master_revoked() -> None:
+    """master role 이지만 ``status == REVOKED`` → 403 (TOCTOU race guard)."""
+    svc = _StubMemberService()
+    svc.add(
+        "master-revoked",
+        role=MemberRole.MASTER.value,
+        status=MemberStatus.REVOKED.value,
     )
+    request = _make_request(state_member_id="master-revoked")
+
+    with pytest.raises(HTTPException) as exc:
+        await require_master_caller(request, svc)
+
+    assert exc.value.status_code == 403


### PR DESCRIPTION
## Summary
- `src/ante/web/deps.py`의 `_resolve_caller_with_scope` helper와 `require_master_caller` 함수를 단순화
- middleware (#1403 RequireAuthMiddleware)가 채운 `request.state.member_id`만 신뢰
- Bearer/session caller resolution + ACTIVE 1차 검사 제거 (미들웨어 책임 위임)
- dep은 scope-only verification + ACTIVE re-check (TOCTOU race guard)만 수행

## Changes
- `src/ante/web/deps.py`
  - `_resolve_caller_with_scope` Bearer/세션 fallback 해석 코드 제거 (~70 LOC)
  - `require_master_caller` 동일 단순화 + ACTIVE re-check 추가 (이전 누락 보강)
  - `session_service` 의존성 제거 (factory `inner_dep` 시그니처도 정리)
  - caller 미설정 시 401 → 500 invariant violation 으로 분리 (client 인증 실패와 구분)
  - `_AUTH_MIDDLEWARE_INVARIANT_DETAIL` 상수 추가
  - 24 module-level alias 보존 (4 원래 + 20 신규 #1407)
  - 기존 4개 detail (`_AUDIT_READ_PERMISSION_DENIED_DETAIL` 등) byte-exact 보존
- `tests/unit/test_require_audit_read.py`
  - mock Bearer/cookie fallback 케이스 → `request.state.member_id` 사전 주입 패턴으로 재작성
  - 500 invariant / 503 cold-path / 403 ghost+inactive 케이스 추가
- `tests/unit/test_require_master_caller.py`
  - 동일 패턴 적용 + ACTIVE TOCTOU guard 케이스 추가

## Contract preservation
- 403 응답 detail byte-exact 보존 (`audit:read` 특수 case 포함)
- 24 alias signature 보존 (`Depends(require_X_Y)` 라우트 호출 무변경)
- `_is_authentication_dependency` marker 보존 (#1405 정적 검증)
- 라우트 import 무변경

## Test plan
- [x] `pytest tests/unit/test_require_audit_read.py tests/unit/test_require_master_caller.py tests/unit/test_require_scope_factory.py -q` → 33 passed
- [x] `pytest tests/unit/test_runtime_mutation_auth.py tests/unit/test_route_auth_coverage.py tests/unit/test_public_paths_spec_match.py tests/unit/test_require_auth_middleware.py -q` → 315 passed (matrix via TestClient 포함)
- [x] `pytest tests/unit -k "auth or scope or middleware or routes" -q` → 666 passed
- [x] `pytest tests/unit -q` → 4616 passed, 2 skipped
- [x] `ruff check` / `ruff format --check` → 통과

## Codex Plan Review
- verdict: approve-implement (round 1/1)
- session: 019e17d9-ddde-7fc3-a9e4-18759b84914c

## Non-Goals (deferred to follow-up)
- 24 alias 제거
- 라우트 import 마이그레이션
- `session_service` 의존성 완전 제거 (`get_session_service_optional` 함수 유지)

Closes #1408

🤖 Generated with [Claude Code](https://claude.com/claude-code)