### PR TITLE
fix(treasury): enforce finite-positive amount at Web API + Treasury service entry

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -4894,7 +4894,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, amount 누락). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1372).",
+            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, amount 누락, amount가 NaN/±Infinity/0/음수). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1372, #1411).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -5007,7 +5007,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, amount 누락). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1372).",
+            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, amount 누락, amount가 NaN/±Infinity/0/음수). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1372, #1411).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -8440,7 +8440,8 @@
         "properties": {
           "amount": {
             "type": "number",
-            "description": "할당/회수 금액 (원)."
+            "exclusiveMinimum": 0,
+            "description": "할당/회수 금액 (원). finite한 양수(> 0)만 허용된다. NaN, Infinity, -Infinity, 0, 음수는 422로 거부된다(#1411)."
           }
         }
       },

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2133,7 +2133,7 @@ export type components = {
          * @description POST /api/treasury/bots/{bot_id}/allocate, POST /api/treasury/bots/{bot_id}/deallocate 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1372). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.
          */
         BudgetChangeRequest: {
-            /** @description 할당/회수 금액 (원). */
+            /** @description 할당/회수 금액 (원). finite한 양수(> 0)만 허용된다. NaN, Infinity, -Infinity, 0, 음수는 422로 거부된다(#1411). */
             amount: number;
         };
         /**
@@ -7104,7 +7104,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, amount 누락). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1372). */
+            /** @description Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, amount 누락, amount가 NaN/±Infinity/0/음수). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1372, #1411). */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -7193,7 +7193,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, amount 누락). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1372). */
+            /** @description Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, amount 누락, amount가 NaN/±Infinity/0/음수). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1372, #1411). */
             422: {
                 headers: {
                     [name: string]: unknown;

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -371,9 +371,15 @@ class Treasury:
             )
 
     async def allocate(self, bot_id: str, amount: float) -> bool:
-        """봇에 예산 할당. 미할당 자금에서 차감."""
+        """봇에 예산 할당. 미할당 자금에서 차감.
+
+        ``amount``는 finite-positive(``math.isfinite(amount) and amount > 0``)여야
+        한다. ``NaN``/``±Infinity``는 비교 연산이 모두 False가 되어 기존 가드
+        ``amount <= 0``을 우회해 budget state를 오염시키므로 입구에서 거부한다
+        (#1411).
+        """
         self._check_bot_stopped(bot_id)
-        if amount <= 0 or self._unallocated < amount:
+        if not math.isfinite(amount) or amount <= 0 or self._unallocated < amount:
             return False
 
         if bot_id not in self._budgets:
@@ -396,10 +402,21 @@ class Treasury:
         return True
 
     async def deallocate(self, bot_id: str, amount: float) -> bool:
-        """봇에서 예산 회수. 가용 예산 범위 내에서만 가능."""
+        """봇에서 예산 회수. 가용 예산 범위 내에서만 가능.
+
+        ``amount``는 finite-positive(``math.isfinite(amount) and amount > 0``)여야
+        한다. ``NaN``/``±Infinity``는 비교 연산이 모두 False가 되어 기존 가드
+        ``amount <= 0``을 우회해 budget state를 오염시키므로 입구에서 거부한다
+        (#1411).
+        """
         self._check_bot_stopped(bot_id)
         budget = self._budgets.get(bot_id)
-        if not budget or amount <= 0 or budget.available < amount:
+        if (
+            not budget
+            or not math.isfinite(amount)
+            or amount <= 0
+            or budget.available < amount
+        ):
             return False
 
         budget.allocated -= amount

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -39,9 +39,13 @@ class BudgetChangeRequest(BaseModel):
     body validation 후행)으로 동작하므로 FastAPI 자동 components 등록 경로를
     거치지 않는다. 본체 schema는 ``_install_openapi_customizer``가
     ``components.schemas``에 명시 등록한다(#1372).
+
+    ``amount``는 finite-positive 숫자만 허용한다. ``NaN``/``±Infinity``/``0``/
+    음수는 422로 거부된다(#1411). ``extra="forbid"``는 본 변경 scope 외 —
+    frontend 호환 검증이 필요하므로 별도 이슈로 분리.
     """
 
-    amount: float
+    amount: Annotated[float, Field(gt=0, allow_inf_nan=False)]
 
 
 class BalanceSetRequest(BaseModel):
@@ -79,7 +83,11 @@ BUDGET_CHANGE_REQUEST_SCHEMA: dict[str, Any] = {
     "properties": {
         "amount": {
             "type": "number",
-            "description": "할당/회수 금액 (원).",
+            "exclusiveMinimum": 0,
+            "description": (
+                "할당/회수 금액 (원). finite한 양수(> 0)만 허용된다. "
+                "NaN, Infinity, -Infinity, 0, 음수는 422로 거부된다(#1411)."
+            ),
         },
     },
 }
@@ -348,8 +356,8 @@ async def list_transactions(
         422: {
             "description": (
                 "Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, "
-                "amount 누락). 단, 인증이 실패하면 body validation은 실행되지 "
-                "않고 401이 우선 반환된다(#1372)."
+                "amount 누락, amount가 NaN/±Infinity/0/음수). 단, 인증이 실패하면 "
+                "body validation은 실행되지 않고 401이 우선 반환된다(#1372, #1411)."
             ),
             "content": {
                 "application/problem+json": {
@@ -516,8 +524,8 @@ async def allocate(
         422: {
             "description": (
                 "Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, "
-                "amount 누락). 단, 인증이 실패하면 body validation은 실행되지 "
-                "않고 401이 우선 반환된다(#1372)."
+                "amount 누락, amount가 NaN/±Infinity/0/음수). 단, 인증이 실패하면 "
+                "body validation은 실행되지 않고 401이 우선 반환된다(#1372, #1411)."
             ),
             "content": {
                 "application/problem+json": {

--- a/tests/unit/test_treasury.py
+++ b/tests/unit/test_treasury.py
@@ -183,6 +183,32 @@ class TestAllocation:
         assert await treasury.allocate("bot1", 0) is False
         assert await treasury.allocate("bot1", -100) is False
 
+    async def test_allocate_rejects_nan(self, treasury):
+        """NaN 할당 거부. budget state 미오염 확인 (#1411).
+
+        ``NaN`` 비교 연산은 모두 False이므로 기존 ``amount <= 0`` 가드를
+        우회한다. ``math.isfinite`` 가드가 입구에서 거부해야 한다.
+        """
+        result = await treasury.allocate("bot1", float("nan"))
+        assert result is False
+        # state 오염 없음 — _unallocated/budget 둘 다 변경 X
+        assert treasury.unallocated == 10_000_000.0
+        assert treasury.get_budget("bot1") is None
+
+    async def test_allocate_rejects_positive_inf(self, treasury):
+        """+Inf 할당 거부. budget state 미오염 확인 (#1411)."""
+        result = await treasury.allocate("bot1", float("inf"))
+        assert result is False
+        assert treasury.unallocated == 10_000_000.0
+        assert treasury.get_budget("bot1") is None
+
+    async def test_allocate_rejects_negative_inf(self, treasury):
+        """-Inf 할당 거부 (#1411)."""
+        result = await treasury.allocate("bot1", -float("inf"))
+        assert result is False
+        assert treasury.unallocated == 10_000_000.0
+        assert treasury.get_budget("bot1") is None
+
     async def test_deallocate(self, treasury):
         """예산 회수."""
         await treasury.allocate("bot1", 1_000_000.0)
@@ -205,6 +231,35 @@ class TestAllocation:
         """존재하지 않는 봇 회수 실패."""
         result = await treasury.deallocate("nonexistent", 100.0)
         assert result is False
+
+    async def test_deallocate_rejects_nan(self, treasury):
+        """NaN 회수 거부. 이미 할당된 봇의 budget이 오염되지 않아야 한다 (#1411)."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        result = await treasury.deallocate("bot1", float("nan"))
+        assert result is False
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 1_000_000.0
+        assert budget.available == 1_000_000.0
+        assert treasury.unallocated == 9_000_000.0
+
+    async def test_deallocate_rejects_positive_inf(self, treasury):
+        """+Inf 회수 거부 (#1411)."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        result = await treasury.deallocate("bot1", float("inf"))
+        assert result is False
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 1_000_000.0
+
+    async def test_deallocate_rejects_negative_inf(self, treasury):
+        """-Inf 회수 거부 (#1411)."""
+        await treasury.allocate("bot1", 1_000_000.0)
+        result = await treasury.deallocate("bot1", -float("inf"))
+        assert result is False
+        budget = treasury.get_budget("bot1")
+        assert budget is not None
+        assert budget.allocated == 1_000_000.0
 
     async def test_multiple_allocations(self, treasury):
         """동일 봇에 추가 할당."""

--- a/tests/unit/test_treasury_routes_budget_change.py
+++ b/tests/unit/test_treasury_routes_budget_change.py
@@ -1,0 +1,338 @@
+"""POST /api/treasury/bots/{bot_id}/allocate, /deallocate 입력 invariant 회귀 테스트.
+
+이슈 #1411: `amount`가 raw JSON `NaN`/`Infinity`/`-Infinity`로 들어와도
+422가 아닌 500을 반환하고, IPC/CLI 경유 호출은 그대로 `Treasury.allocate`에
+전달돼 `budget.allocated += nan`으로 state를 오염시키는 결함을 막는다.
+
+Web API 계층 입력 invariant(``Annotated[float, Field(gt=0, allow_inf_nan=False)]``)
+가 NaN/±Inf/0/음수를 422로 거부함을 회귀 검증한다. Service 계층의
+``math.isfinite`` 가드는 ``tests/unit/test_treasury.py``에서 검증한다.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from dataclasses import field as dc_field
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.member.models import MemberRole  # noqa: E402
+from ante.web.app import create_app  # noqa: E402
+
+# 인증 가드(#1372/#1407) — POST /api/treasury/bots/<bot>/(allocate|deallocate)는
+# master Bearer 또는 유효한 ante_session 쿠키가 필요하다. 본 모듈은 입력
+# invariant(NaN/±Inf/0/음수 → 422) 회귀 본질을 검증하므로 master 토큰을
+# default 헤더로 적용한다.
+_MASTER_HEADERS = {"Authorization": "Bearer master-token"}
+
+
+@dataclass
+class _StubMember:
+    member_id: str
+    role: str = "default"
+    type: str = "agent"
+    org: str = "default"
+    name: str = ""
+    emoji: str = ""
+    status: str = "active"
+    scopes: list[str] = dc_field(default_factory=list)
+
+
+class _StubMemberService:
+    def __init__(self) -> None:
+        self._members: dict[str, _StubMember] = {
+            "master-user": _StubMember(
+                member_id="master-user", role=MemberRole.MASTER.value
+            ),
+        }
+        self._tokens: dict[str, str] = {"master-token": "master-user"}
+
+    async def authenticate(self, token: str) -> _StubMember:
+        member_id = self._tokens.get(token)
+        if member_id is None:
+            raise PermissionError("invalid token")
+        return self._members[member_id]
+
+    async def update_last_active(self, member_id: str) -> None:
+        return None
+
+    async def get(self, member_id: str) -> _StubMember | None:
+        return self._members.get(member_id)
+
+
+@dataclass
+class _StubBudget:
+    bot_id: str
+    allocated: float = 0.0
+    available: float = 0.0
+
+
+class FakeTreasury:
+    """allocate/deallocate Web API 경로용 Treasury stub.
+
+    Service 계층의 finite-positive 가드(``math.isfinite``)도 함께 적용해
+    Web 계층이 1차 차단을 못 했을 때 state 오염을 방지한다 — Web 라우트가
+    422로 막아주면 본 stub의 allocate/deallocate는 호출되지 않는 게 정상.
+    """
+
+    def __init__(self, initial_unallocated: float = 10_000_000.0) -> None:
+        self._unallocated: float = initial_unallocated
+        self._budgets: dict[str, _StubBudget] = {}
+
+    @property
+    def unallocated(self) -> float:
+        return self._unallocated
+
+    def get_budget(self, bot_id: str) -> _StubBudget | None:
+        return self._budgets.get(bot_id)
+
+    def list_budgets(self) -> list[_StubBudget]:
+        return list(self._budgets.values())
+
+    def get_summary(self) -> dict:
+        return {"account_balance": self._unallocated, "unallocated": self._unallocated}
+
+    async def get_latest_snapshot(self) -> None:
+        return None
+
+    async def allocate(self, bot_id: str, amount: float) -> bool:
+        # Defense in depth: Web 라우트가 막지 못한 invariant를 service에서도 차단.
+        if not math.isfinite(amount) or amount <= 0 or self._unallocated < amount:
+            return False
+        budget = self._budgets.setdefault(bot_id, _StubBudget(bot_id=bot_id))
+        budget.allocated += amount
+        budget.available += amount
+        self._unallocated -= amount
+        return True
+
+    async def deallocate(self, bot_id: str, amount: float) -> bool:
+        budget = self._budgets.get(bot_id)
+        if (
+            not budget
+            or not math.isfinite(amount)
+            or amount <= 0
+            or budget.available < amount
+        ):
+            return False
+        budget.allocated -= amount
+        budget.available -= amount
+        self._unallocated += amount
+        return True
+
+
+@pytest.fixture
+def treasury() -> FakeTreasury:
+    return FakeTreasury()
+
+
+@pytest.fixture
+def client(treasury: FakeTreasury) -> TestClient:
+    app = create_app(treasury=treasury, member_service=_StubMemberService())
+    client = TestClient(app)
+    client.headers.update(_MASTER_HEADERS)
+    return client
+
+
+# ── /allocate: invariant 회귀 ──────────────────────────────────
+
+
+def test_allocate_rejects_nan_with_422(
+    client: TestClient, treasury: FakeTreasury
+) -> None:
+    """body `{"amount": NaN}` → 422 (allow_inf_nan=False).
+
+    표준 JSON 인코더는 NaN을 거부하므로 raw body로 직접 보낸다. Python json/
+    Pydantic은 비표준 토큰을 파싱할 수 있고 invariant는 라우트에서 막아야 한다.
+    """
+    resp = client.post(
+        "/api/treasury/bots/bot1/allocate",
+        content='{"amount": NaN}',
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 422
+    # state 오염 없음
+    assert treasury.unallocated == 10_000_000.0
+    assert treasury.get_budget("bot1") is None
+
+
+def test_allocate_rejects_positive_inf_with_422(
+    client: TestClient, treasury: FakeTreasury
+) -> None:
+    """body `{"amount": Infinity}` → 422 (allow_inf_nan=False)."""
+    resp = client.post(
+        "/api/treasury/bots/bot1/allocate",
+        content='{"amount": Infinity}',
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 422
+    assert treasury.unallocated == 10_000_000.0
+
+
+def test_allocate_rejects_negative_inf_with_422(
+    client: TestClient, treasury: FakeTreasury
+) -> None:
+    """body `{"amount": -Infinity}` → 422 (allow_inf_nan=False)."""
+    resp = client.post(
+        "/api/treasury/bots/bot1/allocate",
+        content='{"amount": -Infinity}',
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 422
+    assert treasury.unallocated == 10_000_000.0
+
+
+def test_allocate_rejects_zero_with_422(
+    client: TestClient, treasury: FakeTreasury
+) -> None:
+    """body `{"amount": 0}` → 422 (Field(gt=0))."""
+    resp = client.post("/api/treasury/bots/bot1/allocate", json={"amount": 0})
+    assert resp.status_code == 422
+    assert treasury.unallocated == 10_000_000.0
+
+
+def test_allocate_rejects_negative_with_422(
+    client: TestClient, treasury: FakeTreasury
+) -> None:
+    """body `{"amount": -1}` → 422 (Field(gt=0))."""
+    resp = client.post("/api/treasury/bots/bot1/allocate", json={"amount": -1})
+    assert resp.status_code == 422
+    assert treasury.unallocated == 10_000_000.0
+
+
+def test_allocate_accepts_positive(client: TestClient, treasury: FakeTreasury) -> None:
+    """body `{"amount": 1000}` → 200 (정상 경로 회귀 보존)."""
+    resp = client.post("/api/treasury/bots/bot1/allocate", json={"amount": 1000.0})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["bot_id"] == "bot1"
+    assert data["allocated"] == 1000.0
+    assert data["available"] == 1000.0
+    assert treasury.unallocated == 10_000_000.0 - 1000.0
+
+
+# ── /deallocate: invariant 회귀 ────────────────────────────────
+
+
+def test_deallocate_rejects_nan_with_422(
+    client: TestClient, treasury: FakeTreasury
+) -> None:
+    """body `{"amount": NaN}` → 422 (allow_inf_nan=False)."""
+    resp = client.post(
+        "/api/treasury/bots/bot1/deallocate",
+        content='{"amount": NaN}',
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 422
+
+
+def test_deallocate_rejects_positive_inf_with_422(
+    client: TestClient, treasury: FakeTreasury
+) -> None:
+    """body `{"amount": Infinity}` → 422."""
+    resp = client.post(
+        "/api/treasury/bots/bot1/deallocate",
+        content='{"amount": Infinity}',
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 422
+
+
+def test_deallocate_rejects_negative_inf_with_422(
+    client: TestClient, treasury: FakeTreasury
+) -> None:
+    """body `{"amount": -Infinity}` → 422."""
+    resp = client.post(
+        "/api/treasury/bots/bot1/deallocate",
+        content='{"amount": -Infinity}',
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 422
+
+
+def test_deallocate_rejects_zero_with_422(
+    client: TestClient, treasury: FakeTreasury
+) -> None:
+    """body `{"amount": 0}` → 422 (Field(gt=0))."""
+    resp = client.post("/api/treasury/bots/bot1/deallocate", json={"amount": 0})
+    assert resp.status_code == 422
+
+
+def test_deallocate_rejects_negative_with_422(
+    client: TestClient, treasury: FakeTreasury
+) -> None:
+    """body `{"amount": -1}` → 422 (Field(gt=0))."""
+    resp = client.post("/api/treasury/bots/bot1/deallocate", json={"amount": -1})
+    assert resp.status_code == 422
+
+
+# ── 거부 시 state 미오염 ───────────────────────────────────────
+
+
+def test_allocate_nan_does_not_mutate_state() -> None:
+    """`{"amount": NaN}` 요청 후 _unallocated/budgets가 호출 전 상태 유지."""
+    treasury = FakeTreasury(initial_unallocated=100.0)
+    app = create_app(treasury=treasury, member_service=_StubMemberService())
+    client = TestClient(app)
+    client.headers.update(_MASTER_HEADERS)
+
+    resp = client.post(
+        "/api/treasury/bots/bot1/allocate",
+        content='{"amount": NaN}',
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 422
+    assert treasury.unallocated == 100.0
+    assert treasury.get_budget("bot1") is None
+
+
+# ── auth-first invariant: unauth + 잘못된 body → 401 우선 ──────
+
+
+def test_allocate_unauth_nan_returns_401_not_422() -> None:
+    """인증 없는 호출 + body NaN → 401 우선(body validation 전에 차단). #1372."""
+    treasury = FakeTreasury()
+    app = create_app(treasury=treasury, member_service=_StubMemberService())
+    client = TestClient(app)
+    # 인증 헤더 의도적으로 제거.
+
+    resp = client.post(
+        "/api/treasury/bots/bot1/allocate",
+        content='{"amount": NaN}',
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 401
+
+
+def test_deallocate_unauth_nan_returns_401_not_422() -> None:
+    """deallocate: 인증 없는 호출 + body NaN → 401."""
+    treasury = FakeTreasury()
+    app = create_app(treasury=treasury, member_service=_StubMemberService())
+    client = TestClient(app)
+
+    resp = client.post(
+        "/api/treasury/bots/bot1/deallocate",
+        content='{"amount": NaN}',
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 401
+
+
+# ── OpenAPI schema 회귀 ────────────────────────────────────────
+
+
+def test_openapi_budget_change_request_schema_has_exclusive_minimum(
+    client: TestClient,
+) -> None:
+    """BudgetChangeRequest.properties.amount.exclusiveMinimum == 0 (#1411)."""
+    resp = client.get("/openapi.json")
+    assert resp.status_code == 200
+    schema = resp.json()
+    budget_change = schema["components"]["schemas"]["BudgetChangeRequest"]
+    amount_prop = budget_change["properties"]["amount"]
+    assert amount_prop["exclusiveMinimum"] == 0
+    assert "finite" in amount_prop["description"].lower()


### PR DESCRIPTION
Closes #1411

## Summary
- `POST /api/treasury/bots/{bot_id}/allocate` 및 `/deallocate`가 raw JSON `NaN`/`Infinity`/`0`/음수 amount를 422로 닫는다. `BudgetChangeRequest.amount`를 `Annotated[float, Field(gt=0, allow_inf_nan=False)]`로 강화하고 `BUDGET_CHANGE_REQUEST_SCHEMA.properties.amount`에 `exclusiveMinimum: 0` + finite/positive description을 반영했다.
- IPC/CLI 우회 경로를 동시에 차단하기 위해 `Treasury.allocate`/`deallocate` 입구에 `not math.isfinite(amount)` 가드를 추가했다. 기존 bool 계약(True=success, False=failure)은 그대로 보존한다.
- `frontend/openapi.json`과 `frontend/src/types/api.generated.ts`를 함께 재생성해 `BudgetChangeRequest.amount`의 새 description/`exclusiveMinimum`을 generated 클라이언트로 반영.
- 회귀 테스트: Web API NaN/±Infinity/0/-1 거부 (allocate, deallocate), auth-first 401, 정상 200; Service NaN/±Infinity 거부 + state 미오염 assert; OpenAPI exclusiveMinimum 회귀.

## Test Plan
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check` (변경 4파일) — 4 files already formatted
- [x] `mypy src/ante/web/routes/treasury.py src/ante/treasury/treasury.py` — Success
- [x] `pytest tests/unit/test_treasury_routes_budget_change.py tests/unit/test_treasury.py -v` — 104 passed
- [x] `pytest tests/unit -k "treasury"` — 308 passed, 4338 deselected
- [x] `cd frontend && npm run generate-types` — 성공
- [x] `cd frontend && npm run check-api-types` — 0 findings
- [x] `cd frontend && npm run build` — 480 modules transformed

## 메모
- `BudgetChangeRequest`에 `extra="forbid"`는 추가하지 않음 (frontend 호환 확인 못함 — 별도 이슈 후속).
- `BalanceSetRequest` 등 다른 treasury 라우트 검증 강화는 별도 이슈 scope.
- Codex Plan Review: narrow-scope (Web API + Service 계층 finite-positive invariant)
- Codex 브랜치 리뷰 (`/codex:review --base main`): PASS