### PR TITLE
fix(config): enforce finite numeric invariant for dynamic config (write + read defense)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2273,7 +2273,7 @@
           "config"
         ],
         "summary": "List Configs",
-        "description": "동적 설정 전체 조회. 인증된 master/human 또는 ``config:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
+        "description": "동적 설정 전체 조회. 인증된 master/human 또는 ``config:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).\n\n저장된 값이 read invariant(예: numeric finite, #1412)를 위반하면 서비스\n경계가 ``ConfigError`` 를 raise 하며, 라우트는 이를 422 로 변환한다.",
         "operationId": "list_configs_api_config_get",
         "responses": {
           "200": {
@@ -2282,6 +2282,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ConfigListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "저장된 dynamic config 값이 invariant 를 위반한 경우 (예: legacy non-finite numeric row — #1412). 서비스 read 경계가 ConfigError 로 격리한 결과를 422 problem+json 으로 변환한다.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/src/ante/config/dynamic.py
+++ b/src/ante/config/dynamic.py
@@ -1,12 +1,16 @@
 """DynamicConfigService — 동적 설정 CRUD + 변경 알림.
 
 Numeric invariant (#1412 oracle A7):
-- write 경계(`validate_value`)에서 numeric 값(`int`/`float`, `bool` 제외)은
-  반드시 finite 여야 한다. `NaN`/`Infinity`/`-Infinity` 는 ValueError 로 거부되며,
-  호출자(web/IPC/CLI)가 422 로 변환한다.
+- write 경계(`validate_value`)에서 numeric `float` 값은 반드시 finite 여야 한다.
+  `NaN`/`Infinity`/`-Infinity` 는 ValueError 로 거부되며, 호출자(web/IPC/CLI)가
+  422 로 변환한다.
 - read 경계(`get`/`get_all`/`get_by_category`)에서 legacy non-finite numeric
   row 는 `_ensure_loaded_value_finite` 가 ConfigError 로 격리한다
   (defense-in-depth, JSON 직렬화 실패/silent corruption 방지).
+- 두 가드는 `_is_value_finite` 헬퍼를 통해 `dict`/`list` 컨테이너 내부까지
+  재귀적으로 검사한다. `int` 는 Python 임의 정밀도 정수가 NaN/Infinity 를
+  표현할 수 없으므로 finite 검사에서 제외한다 (`math.isfinite` 가 큰 정수에
+  대해 `OverflowError` 를 raise 하는 회귀 방지).
 """
 
 from __future__ import annotations
@@ -28,15 +32,56 @@ logger = logging.getLogger(__name__)
 _VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
 
 
+def _is_value_finite(value: Any) -> tuple[bool, Any]:
+    """value 안의 모든 numeric `float` 를 재귀적으로 검사한다 (#1412 oracle A7).
+
+    Returns:
+        ``(ok, first_violating_value)``. ``ok`` 가 ``False`` 이면 두 번째 원소가
+        invariant 를 위반한 non-finite float 값(`NaN`/`Infinity`/`-Infinity`).
+
+    Rules:
+        - ``bool`` 은 `int` 서브클래스이지만 finite 1/0 이므로 통과.
+        - ``int`` 는 항상 finite (Python 임의 정밀도 정수가 NaN/Infinity 를
+          표현할 수 없음). ``math.isfinite`` 가 매우 큰 정수에서
+          ``OverflowError`` 를 raise 하는 회귀(P2-2)를 피하기 위해 short-circuit.
+        - ``float`` 만 ``math.isfinite`` 로 검사.
+        - ``dict`` 는 values 를, ``list`` 는 elements 를 재귀 검사.
+        - ``str``/``None``/그 외 타입은 numeric 이 아니므로 통과.
+    """
+    if isinstance(value, bool):
+        return True, None
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return False, value
+        return True, None
+    if isinstance(value, int):
+        # int 는 항상 finite — math.isfinite OverflowError 회귀 방지 (#1412 P2-2).
+        return True, None
+    if isinstance(value, dict):
+        for v in value.values():
+            ok, bad = _is_value_finite(v)
+            if not ok:
+                return False, bad
+        return True, None
+    if isinstance(value, list):
+        for v in value:
+            ok, bad = _is_value_finite(v)
+            if not ok:
+                return False, bad
+        return True, None
+    # str, None, 그 외 → numeric 아님, 통과.
+    return True, None
+
+
 def validate_value(key: str, value: Any) -> None:
     """키별 값 검증 (서비스 경계에서 호출).
 
     Generic numeric finite 가드 (#1412 oracle A7):
-        모든 numeric 값(`int`/`float`, `bool` 제외)은 finite 여야 한다.
-        `NaN`/`Infinity`/`-Infinity` 는 ValueError 로 거부된다. 이 가드는 키와
-        무관하게 적용되어 IPC/CLI/web 모든 경로에서 동일하게 동작한다.
-        `bool` 은 Python 에서 `int` 의 서브클래스(`isinstance(True, int) == True`)
-        이므로 명시적으로 제외한다.
+        scalar `float` 뿐 아니라 `dict`/`list` 컨테이너 내부의 모든 `float` 도
+        재귀적으로 finite 여야 한다. `NaN`/`Infinity`/`-Infinity` 는 ValueError
+        로 거부된다. 이 가드는 키와 무관하게 적용되어 IPC/CLI/web 모든 경로에서
+        동일하게 동작한다. `bool` 과 `int` 는 finite 검사에서 제외된다(상세
+        규칙은 ``_is_value_finite`` 문서 참고).
 
     `system.log_level` 처럼 enum SSOT가 정의된 키는 invalid 값을 즉시 거부한다.
     정의되지 않은 키는 numeric finite 가드 외에는 통과(generic CRUD 동작 유지).
@@ -49,13 +94,13 @@ def validate_value(key: str, value: Any) -> None:
         ValueError: 키별 invariant 또는 numeric finite invariant 를 위반한 경우.
             호출자(web/IPC/CLI)는 이를 422 등 도메인 응답으로 변환해야 한다.
     """
-    # Generic numeric finite 가드 (#1412). bool 은 int 서브클래스이므로 명시 제외.
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        if not math.isfinite(value):
-            raise ValueError(
-                "numeric config 값은 finite number 여야 합니다 "
-                f"(NaN/Infinity 거부). key={key} value={value!r}"
-            )
+    # Generic numeric finite 가드 (#1412). dict/list 내부까지 재귀 검사한다.
+    ok, bad = _is_value_finite(value)
+    if not ok:
+        raise ValueError(
+            "numeric config 값은 finite number 여야 합니다 "
+            f"(NaN/Infinity 거부). key={key} bad={bad!r}"
+        )
 
     if key == "system.log_level":
         if not isinstance(value, str) or value not in _VALID_LOG_LEVELS:
@@ -70,21 +115,18 @@ def _ensure_loaded_value_finite(key: str, value: Any) -> Any:
     legacy NaN/Infinity row 가 DB 에 남아있더라도 read 경계에서 ConfigError 로
     격리되어 downstream consumer(JSON 직렬화, rule engine 비교 등)로 silent
     하게 흘러가지 않도록 한다. write 경계(`validate_value`)의 finite 가드와
-    짝을 이루는 defense-in-depth.
-
-    `bool` 은 `int` 의 서브클래스이지만 `math.isfinite(True)` 는 True 이므로
-    `validate_value` 와 동일하게 명시 제외하여 의도치 않은 경로를 차단한다.
+    짝을 이루는 defense-in-depth. ``dict``/``list`` 컨테이너 내부의 `float` 도
+    재귀적으로 검사한다(``_is_value_finite``).
 
     Raises:
         ConfigError: 저장된 값이 non-finite numeric 일 때. 호출자(web GET 라우트
             등)는 이를 422 등으로 변환할 수 있다.
     """
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        if not math.isfinite(value):
-            raise ConfigError(
-                "Dynamic config의 numeric 값이 non-finite 입니다. "
-                f"key={key} value={value!r}"
-            )
+    ok, bad = _is_value_finite(value)
+    if not ok:
+        raise ConfigError(
+            f"Dynamic config의 numeric 값이 non-finite 입니다. key={key} bad={bad!r}"
+        )
     return value
 
 

--- a/src/ante/config/dynamic.py
+++ b/src/ante/config/dynamic.py
@@ -1,9 +1,19 @@
-"""DynamicConfigService — 동적 설정 CRUD + 변경 알림."""
+"""DynamicConfigService — 동적 설정 CRUD + 변경 알림.
+
+Numeric invariant (#1412 oracle A7):
+- write 경계(`validate_value`)에서 numeric 값(`int`/`float`, `bool` 제외)은
+  반드시 finite 여야 한다. `NaN`/`Infinity`/`-Infinity` 는 ValueError 로 거부되며,
+  호출자(web/IPC/CLI)가 422 로 변환한다.
+- read 경계(`get`/`get_all`/`get_by_category`)에서 legacy non-finite numeric
+  row 는 `_ensure_loaded_value_finite` 가 ConfigError 로 격리한다
+  (defense-in-depth, JSON 직렬화 실패/silent corruption 방지).
+"""
 
 from __future__ import annotations
 
 import json
 import logging
+import math
 from typing import TYPE_CHECKING, Any
 
 from ante.config.exceptions import ConfigError
@@ -21,22 +31,61 @@ _VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
 def validate_value(key: str, value: Any) -> None:
     """키별 값 검증 (서비스 경계에서 호출).
 
+    Generic numeric finite 가드 (#1412 oracle A7):
+        모든 numeric 값(`int`/`float`, `bool` 제외)은 finite 여야 한다.
+        `NaN`/`Infinity`/`-Infinity` 는 ValueError 로 거부된다. 이 가드는 키와
+        무관하게 적용되어 IPC/CLI/web 모든 경로에서 동일하게 동작한다.
+        `bool` 은 Python 에서 `int` 의 서브클래스(`isinstance(True, int) == True`)
+        이므로 명시적으로 제외한다.
+
     `system.log_level` 처럼 enum SSOT가 정의된 키는 invalid 값을 즉시 거부한다.
-    정의되지 않은 키는 통과(generic CRUD 동작 유지).
+    정의되지 않은 키는 numeric finite 가드 외에는 통과(generic CRUD 동작 유지).
 
     대소문자 정책: `system.log_level` 은 대소문자 구분으로 거부한다. 즉
     ``_VALID_LOG_LEVELS`` 멤버(전부 대문자)와 정확 일치해야 통과하고,
     ``"debug"`` 같은 소문자 입력은 ValueError 로 거부된다 (#1379 oracle A7).
 
     Raises:
-        ValueError: 키별 invariant 를 위반한 경우. 호출자(web/IPC/CLI)는
-            이를 422 등 도메인 응답으로 변환해야 한다.
+        ValueError: 키별 invariant 또는 numeric finite invariant 를 위반한 경우.
+            호출자(web/IPC/CLI)는 이를 422 등 도메인 응답으로 변환해야 한다.
     """
+    # Generic numeric finite 가드 (#1412). bool 은 int 서브클래스이므로 명시 제외.
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if not math.isfinite(value):
+            raise ValueError(
+                "numeric config 값은 finite number 여야 합니다 "
+                f"(NaN/Infinity 거부). key={key} value={value!r}"
+            )
+
     if key == "system.log_level":
         if not isinstance(value, str) or value not in _VALID_LOG_LEVELS:
             raise ValueError(
                 "system.log_level은 _VALID_LOG_LEVELS 멤버여야 합니다 (대소문자 구분)."
             )
+
+
+def _ensure_loaded_value_finite(key: str, value: Any) -> Any:
+    """DB 에서 읽은 dynamic config 값을 격리 검사한다 (#1412 oracle A7).
+
+    legacy NaN/Infinity row 가 DB 에 남아있더라도 read 경계에서 ConfigError 로
+    격리되어 downstream consumer(JSON 직렬화, rule engine 비교 등)로 silent
+    하게 흘러가지 않도록 한다. write 경계(`validate_value`)의 finite 가드와
+    짝을 이루는 defense-in-depth.
+
+    `bool` 은 `int` 의 서브클래스이지만 `math.isfinite(True)` 는 True 이므로
+    `validate_value` 와 동일하게 명시 제외하여 의도치 않은 경로를 차단한다.
+
+    Raises:
+        ConfigError: 저장된 값이 non-finite numeric 일 때. 호출자(web GET 라우트
+            등)는 이를 422 등으로 변환할 수 있다.
+    """
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if not math.isfinite(value):
+            raise ConfigError(
+                "Dynamic config의 numeric 값이 non-finite 입니다. "
+                f"key={key} value={value!r}"
+            )
+    return value
 
 
 DYNAMIC_CONFIG_SCHEMA = """
@@ -78,7 +127,11 @@ class DynamicConfigService:
     _MISSING = object()
 
     async def get(self, key: str, default: Any = _MISSING) -> Any:
-        """동적 설정 값 조회. JSON 역직렬화하여 반환."""
+        """동적 설정 값 조회. JSON 역직렬화하여 반환.
+
+        Read 경계에서 ``_ensure_loaded_value_finite`` 가 legacy non-finite
+        numeric row 를 ConfigError 로 격리한다 (#1412 oracle A7).
+        """
         row = await self._db.fetch_one(
             "SELECT value FROM dynamic_config WHERE key = ?", (key,)
         )
@@ -86,7 +139,7 @@ class DynamicConfigService:
             if default is not self._MISSING:
                 return default
             raise ConfigError(f"Dynamic config not found: {key}")
-        return json.loads(row["value"])
+        return _ensure_loaded_value_finite(key, json.loads(row["value"]))
 
     async def set(
         self, key: str, value: Any, category: str, changed_by: str = "system"
@@ -95,6 +148,11 @@ class DynamicConfigService:
 
         키별 invariant 가 정의된 경우 ``validate_value`` 가 ValueError 를
         발생시킨다(서비스 경계 검증, IPC/CLI 우회 차단 — #1379).
+
+        legacy non-finite numeric row 가 저장돼 있는 키를 정상 값으로 덮어쓰는
+        경로(self-healing)는 막지 않는다 — ``get`` 의 read defense 가
+        ``ConfigError`` 를 raise 하면 ``old_value`` 를 ``None`` 으로 두고 새 값을
+        그대로 저장한다 (#1412 oracle A7).
         """
         from ante.eventbus.events import ConfigChangedEvent
 
@@ -102,7 +160,11 @@ class DynamicConfigService:
 
         old_value = None
         if await self.exists(key):
-            old_value = await self.get(key)
+            try:
+                old_value = await self.get(key)
+            except ConfigError:
+                # legacy non-finite numeric row — self-healing 경로 허용. (#1412)
+                old_value = None
 
         json_value = json.dumps(value)
         old_json = json.dumps(old_value) if old_value is not None else None
@@ -147,14 +209,20 @@ class DynamicConfigService:
         return True
 
     async def get_all(self) -> list[dict[str, Any]]:
-        """전체 동적 설정 조회."""
+        """전체 동적 설정 조회.
+
+        Read 경계에서 ``_ensure_loaded_value_finite`` 가 legacy non-finite
+        numeric row 를 ConfigError 로 격리한다 (#1412 oracle A7).
+        """
         rows = await self._db.fetch_all(
             "SELECT key, value, category, updated_at FROM dynamic_config ORDER BY key"
         )
         return [
             {
                 "key": row["key"],
-                "value": json.loads(row["value"]),
+                "value": _ensure_loaded_value_finite(
+                    row["key"], json.loads(row["value"])
+                ),
                 "category": row["category"],
                 "updated_at": row["updated_at"],
             }
@@ -162,12 +230,21 @@ class DynamicConfigService:
         ]
 
     async def get_by_category(self, category: str) -> dict[str, Any]:
-        """카테고리별 모든 설정 조회."""
+        """카테고리별 모든 설정 조회.
+
+        Read 경계에서 ``_ensure_loaded_value_finite`` 가 legacy non-finite
+        numeric row 를 ConfigError 로 격리한다 (#1412 oracle A7).
+        """
         rows = await self._db.fetch_all(
             "SELECT key, value FROM dynamic_config WHERE category = ?",
             (category,),
         )
-        return {row["key"]: json.loads(row["value"]) for row in rows}
+        return {
+            row["key"]: _ensure_loaded_value_finite(
+                row["key"], json.loads(row["value"])
+            )
+            for row in rows
+        }
 
     async def register_default(self, key: str, value: Any, category: str) -> None:
         """기본값 등록. 이미 값이 존재하면 무시한다."""

--- a/src/ante/config/dynamic.py
+++ b/src/ante/config/dynamic.py
@@ -45,7 +45,10 @@ def _is_value_finite(value: Any) -> tuple[bool, Any]:
           표현할 수 없음). ``math.isfinite`` 가 매우 큰 정수에서
           ``OverflowError`` 를 raise 하는 회귀(P2-2)를 피하기 위해 short-circuit.
         - ``float`` 만 ``math.isfinite`` 로 검사.
-        - ``dict`` 는 values 를, ``list`` 는 elements 를 재귀 검사.
+        - ``dict`` 는 values 를, ``list``/``tuple`` 은 elements 를 재귀 검사.
+          ``tuple`` 도 ``json.dumps`` 가 JSON array 로 직렬화하므로 ``list`` 와
+          동일하게 다룬다 (#1412 P2-B). 그렇지 않으면 ``(NaN,)`` 같은 값이
+          write 경계를 통과해 ``[NaN]`` 으로 저장되고 read guard 가 깨진다.
         - ``str``/``None``/그 외 타입은 numeric 이 아니므로 통과.
     """
     if isinstance(value, bool):
@@ -63,7 +66,9 @@ def _is_value_finite(value: Any) -> tuple[bool, Any]:
             if not ok:
                 return False, bad
         return True, None
-    if isinstance(value, list):
+    if isinstance(value, (list, tuple)):
+        # tuple 도 json.dumps 가 JSON array 로 직렬화하므로 동일 재귀 처리
+        # (#1412 P2-B).
         for v in value:
             ok, bad = _is_value_finite(v)
             if not ok:
@@ -289,7 +294,14 @@ class DynamicConfigService:
         }
 
     async def register_default(self, key: str, value: Any, category: str) -> None:
-        """기본값 등록. 이미 값이 존재하면 무시한다."""
+        """기본값 등록. 이미 값이 존재하면 무시한다.
+
+        ``set`` 과 마찬가지로 ``validate_value`` 를 통과시켜 startup default
+        경로가 finite invariant 를 우회하지 못하도록 보장한다 (#1412 P2-A).
+        그렇지 않으면 ``register_default(key, float('nan'), ...)`` 같은 값이
+        그대로 저장되고 이후 ``get`` 의 read guard 가 ``ConfigError`` 로 깨진다.
+        """
+        validate_value(key, value)
         if not await self.exists(key):
             json_value = json.dumps(value)
             await self._db.execute(

--- a/src/ante/web/routes/config.py
+++ b/src/ante/web/routes/config.py
@@ -8,6 +8,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, ValidationError
 
+from ante.config.exceptions import ConfigError
 from ante.web.deps import (
     get_audit_logger_optional,
     get_dynamic_config,
@@ -68,6 +69,18 @@ CONFIG_UPDATE_REQUEST_SCHEMA: dict[str, Any] = {
     "",
     response_model=ConfigListResponse,
     responses={
+        422: {
+            "description": (
+                "저장된 dynamic config 값이 invariant 를 위반한 경우 (예: legacy "
+                "non-finite numeric row — #1412). 서비스 read 경계가 ConfigError "
+                "로 격리한 결과를 422 problem+json 으로 변환한다."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
         503: {
             "description": "Config service not available",
             "content": {
@@ -83,8 +96,15 @@ async def list_configs(
     config_service: Annotated[Any, Depends(get_dynamic_config)],
 ) -> dict:
     """동적 설정 전체 조회. 인증된 master/human 또는 ``config:read`` scope 를
-    보유한 agent 만 호출 가능 (#1407)."""
-    configs = await config_service.get_all()
+    보유한 agent 만 호출 가능 (#1407).
+
+    저장된 값이 read invariant(예: numeric finite, #1412)를 위반하면 서비스
+    경계가 ``ConfigError`` 를 raise 하며, 라우트는 이를 422 로 변환한다.
+    """
+    try:
+        configs = await config_service.get_all()
+    except ConfigError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from None
     return {"configs": configs}
 
 
@@ -210,7 +230,13 @@ async def update_config(
     if not await config_service.exists(key):
         raise HTTPException(status_code=404, detail=f"설정을 찾을 수 없습니다: {key}")
 
-    old_value = await config_service.get(key)
+    # legacy non-finite numeric row 는 read 경계에서 ConfigError 로 격리되지만
+    # (#1412), PUT 으로 정상 값을 덮어쓰는 self-healing 경로는 허용한다.
+    # ``old_value`` 는 None 으로 두고 새 값으로 set 한다.
+    try:
+        old_value = await config_service.get(key)
+    except ConfigError:
+        old_value = None
 
     # category: 요청에 없으면 key에서 추출 (예: "risk.max_mdd" -> "risk")
     category = body.category or key.split(".")[0]

--- a/tests/unit/test_dynamic_config.py
+++ b/tests/unit/test_dynamic_config.py
@@ -1,11 +1,18 @@
 """DynamicConfigService 단위 테스트."""
 
+import math
+
 import pytest
 
 from ante.config import ConfigError, DynamicConfigService
 from ante.config.dynamic import _is_value_finite, validate_value
 from ante.core import Database
 from ante.eventbus.events import ConfigChangedEvent
+
+
+def _is_nan_float(value: object) -> bool:
+    """NaN != NaN 비교 회피용 테스트 헬퍼."""
+    return isinstance(value, float) and math.isnan(value)
 
 
 class FakeEventBus:
@@ -534,3 +541,104 @@ async def test_set_accepts_nested_large_int(service):
     payload = {"big": 10**500, "items": [10**400, -(10**400), 1]}
     await service.set("foo.nested", payload, category="x")
     assert await service.get("foo.nested") == payload
+
+
+# ── #1412 P2-A 회귀: register_default 가 validate_value 통과 ───────────────
+
+
+class TestRegisterDefaultFiniteInvariant:
+    """``register_default`` 도 ``validate_value`` 를 통과해야 한다 (#1412 P2-A).
+
+    이전 구현은 startup default 경로에서 ``validate_value`` 를 우회하여
+    ``register_default("x", float("nan"), ...)`` 같은 호출이 그대로 저장됐다.
+    이후 ``get`` 의 read guard 가 ``ConfigError`` 로 깨뜨려 GET 이 500 으로
+    실패하는 회귀가 가능했다.
+    """
+
+    async def test_register_default_rejects_nan(self, service):
+        with pytest.raises(ValueError, match="finite"):
+            await service.register_default("foo.bar", float("nan"), "x")
+        # 영속 사이드이펙트가 없어야 한다.
+        assert not await service.exists("foo.bar")
+
+    async def test_register_default_rejects_positive_infinity(self, service):
+        with pytest.raises(ValueError, match="finite"):
+            await service.register_default("foo.bar", float("inf"), "x")
+        assert not await service.exists("foo.bar")
+
+    async def test_register_default_rejects_negative_infinity(self, service):
+        with pytest.raises(ValueError, match="finite"):
+            await service.register_default("foo.bar", float("-inf"), "x")
+        assert not await service.exists("foo.bar")
+
+    async def test_register_default_rejects_nested_nan_in_dict(self, service):
+        """nested dict 안의 NaN 도 거부된다 (P2-A + P2-1 결합)."""
+        with pytest.raises(ValueError, match="finite"):
+            await service.register_default("foo.bar", {"k": float("nan")}, "x")
+        assert not await service.exists("foo.bar")
+
+    async def test_register_default_accepts_finite_numeric(self, service):
+        """정상 finite 값은 그대로 등록된다 (회귀 보존)."""
+        await service.register_default("foo.bar", 0.1, "x")
+        assert await service.get("foo.bar") == 0.1
+
+    async def test_register_default_accepts_finite_numeric_does_not_raise(
+        self, service
+    ):
+        """0.1 등 finite numeric 등록이 예외 없이 통과한다 (명시적 회귀)."""
+        # raise 가 발생하지 않아야 한다.
+        await service.register_default("foo.finite", 0.1, "x")
+
+
+# ── #1412 P2-B 회귀: tuple 도 list 처럼 재귀 검사 ────────────────────────
+
+
+class TestValidateValueTupleFinite:
+    """``tuple`` 도 ``json.dumps`` 가 JSON array 로 직렬화하므로 list 와 동일
+    하게 재귀 검사돼야 한다 (#1412 P2-B).
+
+    이전 구현은 ``isinstance(value, list)`` 만 검사하고 ``tuple`` 은 fall-through
+    로 통과시켜 ``(float('nan'),)`` 같은 값이 write 경계를 우회하여 ``[NaN]``
+    으로 저장되고 read guard 에서 깨졌다.
+    """
+
+    def test_tuple_with_nan_rejected(self):
+        with pytest.raises(ValueError, match="finite"):
+            validate_value("x", (float("nan"),))
+
+    def test_tuple_with_inf_rejected(self):
+        with pytest.raises(ValueError, match="finite"):
+            validate_value("x", (float("inf"),))
+
+    def test_tuple_with_negative_inf_rejected(self):
+        with pytest.raises(ValueError, match="finite"):
+            validate_value("x", (float("-inf"),))
+
+    def test_tuple_of_finite_floats_passes(self):
+        """정상 finite tuple 은 통과한다 (회귀 보존)."""
+        validate_value("x", (0.1, 0.2))
+
+    def test_empty_tuple_passes(self):
+        validate_value("x", ())
+
+    def test_nested_tuple_in_dict_rejected(self):
+        """dict 값으로 들어간 tuple 안의 NaN 도 거부된다."""
+        with pytest.raises(ValueError, match="finite"):
+            validate_value("x", {"k": (float("nan"),)})
+
+    def test_list_of_tuples_with_nan_rejected(self):
+        """list 안의 tuple 안의 NaN 도 거부된다."""
+        with pytest.raises(ValueError, match="finite"):
+            validate_value("x", [(0.1,), (float("nan"),)])
+
+    def test_tuple_of_dicts_with_nan_rejected(self):
+        """tuple 안의 dict 안의 NaN 도 거부된다."""
+        with pytest.raises(ValueError, match="finite"):
+            validate_value("x", ({"v": 0.1}, {"v": float("nan")}))
+
+    def test_helper_returns_violating_value_from_tuple(self):
+        """헬퍼가 tuple 내부의 violating float 자체를 반환한다."""
+        ok, bad = _is_value_finite((0.1, float("nan")))
+        assert not ok
+        # NaN != NaN 이므로 math.isnan 으로 확인.
+        assert _is_nan_float(bad)

--- a/tests/unit/test_dynamic_config.py
+++ b/tests/unit/test_dynamic_config.py
@@ -3,7 +3,7 @@
 import pytest
 
 from ante.config import ConfigError, DynamicConfigService
-from ante.config.dynamic import validate_value
+from ante.config.dynamic import _is_value_finite, validate_value
 from ante.core import Database
 from ante.eventbus.events import ConfigChangedEvent
 
@@ -350,3 +350,187 @@ async def test_set_self_heals_over_legacy_nan_row(service, eventbus):
     assert len(eventbus.published) == 1
     event = eventbus.published[0]
     assert event.key == "risk.max_mdd_pct"
+
+
+# ── #1412 P2-1 회귀: nested dict/list non-finite 검사 ─────────────────────
+
+
+class TestValidateValueNestedFinite:
+    """nested ``dict``/``list`` 내부 float 도 재귀적으로 finite 검사 (#1412 P2-1).
+
+    이전 구현은 top-level scalar 만 검사하여 ``{"threshold": NaN}`` 같은
+    dict 값이 통과되었다. ``_is_value_finite`` helper 가 컨테이너 내부까지
+    재귀 검사함을 보장한다.
+    """
+
+    def test_dict_with_nan_value_rejected(self):
+        with pytest.raises(ValueError, match="finite"):
+            validate_value("risk.params", {"threshold": float("nan")})
+
+    def test_dict_with_inf_value_rejected(self):
+        with pytest.raises(ValueError, match="finite"):
+            validate_value("risk.params", {"threshold": float("inf")})
+
+    def test_dict_with_negative_inf_value_rejected(self):
+        with pytest.raises(ValueError, match="finite"):
+            validate_value("risk.params", {"threshold": float("-inf")})
+
+    def test_dict_with_mixed_values_rejects_on_first_nan(self):
+        """정상 값과 NaN 이 섞이면 NaN 으로 인해 거부된다."""
+        with pytest.raises(ValueError, match="finite"):
+            validate_value("risk.params", {"threshold": 0.1, "limit": float("nan")})
+
+    def test_list_with_nan_element_rejected(self):
+        with pytest.raises(ValueError, match="finite"):
+            validate_value("risk.list", [0.1, float("nan"), 0.5])
+
+    def test_list_with_inf_element_rejected(self):
+        with pytest.raises(ValueError, match="finite"):
+            validate_value("risk.list", [float("inf")])
+
+    def test_deeply_nested_dict_nan_rejected(self):
+        """2단계 이상 중첩된 dict 내부도 재귀 검사된다."""
+        with pytest.raises(ValueError, match="finite"):
+            validate_value("risk.nested", {"outer": {"inner": float("nan")}})
+
+    def test_list_of_dicts_with_nan_rejected(self):
+        """list 안의 dict 안의 NaN 도 거부된다."""
+        with pytest.raises(ValueError, match="finite"):
+            validate_value(
+                "risk.tiers",
+                [{"name": "a", "value": 0.1}, {"name": "b", "value": float("nan")}],
+            )
+
+    def test_dict_with_finite_values_passes(self):
+        """정상 nested dict 는 통과한다 (회귀 보존)."""
+        validate_value("risk.params", {"threshold": 0.1, "limit": 0.5})
+
+    def test_nested_dict_with_finite_values_passes(self):
+        validate_value("risk.params", {"outer": {"inner": 0.1, "other": 2}})
+
+    def test_list_of_finite_floats_passes(self):
+        validate_value("risk.list", [0.1, 0.2, 0.5])
+
+    def test_helper_bool_in_dict_passes(self):
+        """bool 은 dict 안에서도 finite 검사에서 제외된다."""
+        ok, _bad = _is_value_finite({"flag": True, "other_flag": False})
+        assert ok
+
+    def test_helper_string_in_container_passes(self):
+        """str/None 은 numeric 이 아니므로 통과 (회귀 보존)."""
+        ok, _bad = _is_value_finite({"name": "alpha", "missing": None, "list": ["x"]})
+        assert ok
+
+    def test_helper_returns_first_violating_value(self):
+        """헬퍼가 violating float 자체를 함께 반환한다 (오류 메시지 진단성)."""
+        bad_value = float("inf")
+        ok, bad = _is_value_finite({"a": 0.1, "b": bad_value, "c": float("nan")})
+        assert not ok
+        # dict 순회 순서상 b 가 먼저이므로 bad 는 inf.
+        assert bad == bad_value
+
+
+async def test_set_rejects_nested_nan_at_service_boundary(service, eventbus):
+    """``service.set`` 가 nested NaN dict 를 ValueError 로 거부한다 (#1412 P2-1)."""
+    with pytest.raises(ValueError, match="finite"):
+        await service.set(
+            "risk.params", {"threshold": float("nan"), "limit": 0.5}, category="risk"
+        )
+
+    # 영속/이벤트 사이드이펙트가 없어야 한다.
+    assert not await service.exists("risk.params")
+    assert eventbus.published == []
+
+
+async def test_set_rejects_nested_inf_list_at_service_boundary(service, eventbus):
+    """``service.set`` 가 list 안의 Infinity 도 거부한다 (#1412 P2-1)."""
+    with pytest.raises(ValueError, match="finite"):
+        await service.set("risk.tiers", [0.1, float("inf"), 0.5], category="risk")
+
+    assert not await service.exists("risk.tiers")
+    assert eventbus.published == []
+
+
+async def test_get_raises_on_legacy_nested_nan_row(service):
+    """legacy nested NaN dict row 가 ``get`` 에서 ConfigError 로 격리된다 (#1412 P2-1).
+
+    legacy row 가 ``{"threshold": NaN}`` 형태로 DB 에 들어있는 경우 read 경계
+    helper 가 컨테이너 내부까지 재귀 검사하여 격리해야 한다.
+    """
+    # SQLite 에 직접 nested NaN JSON 을 넣는다. json.dumps 는 NaN 을 그대로
+    # 직렬화하므로 raw 문자열을 구성한다.
+    await _insert_legacy_value(
+        service,
+        "risk.params",
+        '{"threshold": NaN, "limit": 0.5}',
+        "risk",
+    )
+
+    with pytest.raises(ConfigError, match="non-finite"):
+        await service.get("risk.params")
+
+
+async def test_get_raises_on_legacy_nested_infinity_list_row(service):
+    """legacy list 안의 Infinity row 도 read 경계에서 격리된다 (#1412 P2-1)."""
+    await _insert_legacy_value(
+        service,
+        "risk.tiers",
+        "[0.1, Infinity, 0.5]",
+        "risk",
+    )
+
+    with pytest.raises(ConfigError, match="non-finite"):
+        await service.get("risk.tiers")
+
+
+async def test_set_accepts_nested_finite_regression(service):
+    """정상 nested finite 값은 그대로 저장/조회된다 (회귀 보존, #1412 P2-1)."""
+    payload = {"threshold": 0.1, "limit": 0.5, "label": "ok", "flag": True}
+    await service.set("risk.params", payload, category="risk")
+    assert await service.get("risk.params") == payload
+
+
+# ── #1412 P2-2 회귀: 큰 정수 OverflowError 방지 ──────────────────────────
+
+
+class TestValidateValueLargeInt:
+    """``int`` 는 finite 검사에서 제외된다 (#1412 P2-2).
+
+    Python ``int`` 는 임의 정밀도이며 NaN/Infinity 를 표현할 수 없다. 이전
+    구현은 ``isinstance(value, (int, float))`` 후 ``math.isfinite(value)`` 를
+    호출해 매우 큰 정수에서 ``OverflowError`` 가 발생, finite 정수의 저장/조회가
+    500 으로 깨졌다.
+    """
+
+    def test_validate_value_large_positive_int_passes(self):
+        validate_value("foo.bar", 10**500)
+
+    def test_validate_value_large_negative_int_passes(self):
+        validate_value("foo.bar", -(10**500))
+
+    def test_validate_value_int_in_dict_passes(self):
+        validate_value("foo.bar", {"big": 10**500, "neg": -(10**400)})
+
+    def test_validate_value_int_in_list_passes(self):
+        validate_value("foo.bar", [10**500, -(10**400), 0, 1])
+
+
+async def test_set_accepts_large_int(service):
+    """``service.set`` 이 임의 정밀도 정수를 정상 저장한다 (#1412 P2-2)."""
+    big = 10**500
+    await service.set("foo.bar", big, category="x")
+    assert await service.get("foo.bar") == big
+
+
+async def test_set_accepts_large_negative_int(service):
+    """음수 큰 정수도 정상 처리된다 (#1412 P2-2)."""
+    big = -(10**500)
+    await service.set("foo.neg", big, category="x")
+    assert await service.get("foo.neg") == big
+
+
+async def test_set_accepts_nested_large_int(service):
+    """dict/list 안의 큰 정수도 통과한다 (#1412 P2-1 + P2-2)."""
+    payload = {"big": 10**500, "items": [10**400, -(10**400), 1]}
+    await service.set("foo.nested", payload, category="x")
+    assert await service.get("foo.nested") == payload

--- a/tests/unit/test_dynamic_config.py
+++ b/tests/unit/test_dynamic_config.py
@@ -3,6 +3,7 @@
 import pytest
 
 from ante.config import ConfigError, DynamicConfigService
+from ante.config.dynamic import validate_value
 from ante.core import Database
 from ante.eventbus.events import ConfigChangedEvent
 
@@ -167,3 +168,185 @@ async def test_set_non_string_log_level_raises_value_error(service, eventbus):
 
     assert not await service.exists("system.log_level")
     assert eventbus.published == []
+
+
+# ── #1412 oracle A7: numeric finite invariant (write + read) ──────────────
+
+
+class TestValidateValueFiniteNumeric:
+    """``validate_value`` 의 generic numeric finite 가드 (#1412).
+
+    write 경계에서 NaN/Infinity/-Infinity 를 거부해야 한다. 이 가드는 키와
+    무관하게 적용되어 IPC/CLI/web 모든 경로에서 동일하게 동작한다.
+    """
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "risk.max_mdd_pct",
+            "anything.else",
+            "rule.max_daily_loss_rate",
+            "completely_unknown_key",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "value",
+        [float("nan"), float("inf"), float("-inf")],
+    )
+    def test_validate_value_rejects_non_finite_numeric(self, key, value):
+        """NaN/Infinity/-Infinity 는 모든 키에서 거부된다."""
+        with pytest.raises(ValueError, match="finite"):
+            validate_value(key, value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [0.1, 0, -1, 1.5, -100.0, 1e10, -1e-10],
+    )
+    def test_validate_value_accepts_finite_numeric(self, value):
+        """finite numeric 값은 통과한다 (회귀 보존)."""
+        # 임의 키로 호출해도 generic 가드가 통과.
+        validate_value("risk.max_mdd_pct", value)
+
+    def test_validate_value_bool_excluded_true(self):
+        """bool True 는 numeric 가드에서 명시 제외된다.
+
+        Python 에서 ``isinstance(True, int)`` 는 True 이지만 ``True`` 는
+        finite (1) 이므로 의도치 않게 거부되어선 안 된다.
+        """
+        validate_value("any.bool.key", True)
+
+    def test_validate_value_bool_excluded_false(self):
+        """bool False 도 numeric 가드에서 명시 제외된다."""
+        validate_value("any.bool.key", False)
+
+    @pytest.mark.parametrize(
+        "value",
+        ["not-numeric", "NaN", "Infinity", None, [], {}, ["nested"]],
+    )
+    def test_validate_value_non_numeric_passes(self, value):
+        """numeric 이 아닌 값은 generic 가드 무영향 (회귀 보존).
+
+        invariant 가 정의되지 않은 키에서는 string/None/list/dict 모두 통과.
+        ``system.log_level`` 같은 키별 검증은 별도 분기에서 처리된다.
+        """
+        validate_value("anything", value)
+
+
+async def test_set_rejects_nan_at_service_boundary(service, eventbus):
+    """``service.set`` 가 NaN 을 ValueError 로 거부한다 (#1412)."""
+    with pytest.raises(ValueError, match="finite"):
+        await service.set("risk.max_mdd_pct", float("nan"), category="risk")
+
+    # 영속/이벤트 사이드이펙트가 발생하지 않아야 한다.
+    assert not await service.exists("risk.max_mdd_pct")
+    assert eventbus.published == []
+
+
+async def test_set_rejects_inf_at_service_boundary(service, eventbus):
+    """``service.set`` 가 Infinity 를 ValueError 로 거부한다 (#1412)."""
+    with pytest.raises(ValueError, match="finite"):
+        await service.set("risk.max_mdd_pct", float("inf"), category="risk")
+    with pytest.raises(ValueError, match="finite"):
+        await service.set("risk.max_mdd_pct", float("-inf"), category="risk")
+
+    assert not await service.exists("risk.max_mdd_pct")
+    assert eventbus.published == []
+
+
+async def test_set_accepts_finite_numeric_regression(service):
+    """정상 finite numeric 값은 그대로 저장된다 (회귀 보존, #1412)."""
+    await service.set("risk.max_mdd_pct", 0.1, category="risk")
+    assert await service.get("risk.max_mdd_pct") == 0.1
+
+
+async def _insert_legacy_value(service, key: str, raw_json: str, category: str) -> None:
+    """DB 에 직접 raw JSON row 를 삽입 (legacy NaN row 시뮬레이션).
+
+    ``service.set`` 는 finite 가드를 통과시키므로 NaN row 를 만들 수 없다.
+    legacy 시나리오를 재현하기 위해 db 를 직접 호출한다.
+    """
+    await service._db.execute(
+        """INSERT INTO dynamic_config (key, value, category, updated_at)
+           VALUES (?, ?, ?, datetime('now'))""",
+        (key, raw_json, category),
+    )
+
+
+async def test_get_raises_on_legacy_nan_row(service):
+    """legacy NaN row 가 DB 에 있으면 ``get`` 이 ConfigError 로 격리한다 (#1412).
+
+    SQLite 에 직접 ``"NaN"`` JSON 을 삽입한 뒤 ``json.loads`` 가 복원하는
+    ``float('nan')`` 가 그대로 downstream 으로 흘러가는 것을 read 경계가
+    막아야 한다.
+    """
+    await _insert_legacy_value(service, "risk.max_mdd_pct", "NaN", "risk")
+
+    with pytest.raises(ConfigError, match="non-finite"):
+        await service.get("risk.max_mdd_pct")
+
+
+async def test_get_raises_on_legacy_infinity_row(service):
+    """legacy Infinity row 도 read 경계에서 ConfigError 로 격리된다 (#1412)."""
+    await _insert_legacy_value(service, "rule.threshold", "Infinity", "rule")
+
+    with pytest.raises(ConfigError, match="non-finite"):
+        await service.get("rule.threshold")
+
+
+async def test_get_returns_finite_numeric_regression(service):
+    """정상 finite 값은 ``get`` 이 그대로 반환한다 (회귀 보존, #1412)."""
+    await service.set("risk.max_mdd_pct", 0.1, category="risk")
+    assert await service.get("risk.max_mdd_pct") == 0.1
+
+
+async def test_get_all_raises_on_legacy_nan_row(service):
+    """``get_all`` 도 legacy NaN row 에서 ConfigError (#1412)."""
+    await _insert_legacy_value(service, "risk.max_mdd_pct", "NaN", "risk")
+    await service.set("risk.other", 0.05, category="risk")
+
+    with pytest.raises(ConfigError, match="non-finite"):
+        await service.get_all()
+
+
+async def test_get_by_category_raises_on_legacy_nan_row(service):
+    """``get_by_category`` 도 legacy NaN row 에서 ConfigError (#1412)."""
+    await _insert_legacy_value(service, "risk.max_mdd_pct", "NaN", "risk")
+
+    with pytest.raises(ConfigError, match="non-finite"):
+        await service.get_by_category("risk")
+
+
+async def test_get_all_returns_finite_values_regression(service):
+    """normal seed 만 있을 때 ``get_all`` 이 정상 동작 (회귀 보존, #1412)."""
+    await service.set("risk.max_mdd_pct", 0.1, category="risk")
+    await service.set("rule.threshold", 5, category="rule")
+    await service.set("flag.enabled", True, category="flag")
+    await service.set("name.label", "hello", category="meta")
+
+    items = await service.get_all()
+    by_key = {item["key"]: item["value"] for item in items}
+    assert by_key["risk.max_mdd_pct"] == 0.1
+    assert by_key["rule.threshold"] == 5
+    assert by_key["flag.enabled"] is True
+    assert by_key["name.label"] == "hello"
+
+
+async def test_set_self_heals_over_legacy_nan_row(service, eventbus):
+    """legacy NaN row 를 정상 finite 값으로 덮어쓰는 self-healing 허용 (#1412).
+
+    Non-Goals 인 자동 cleanup 과는 별개로, 사용자가 ``set`` 으로 정상 값을
+    써넣는 정상 lifecycle 은 막히지 않아야 한다. ``get`` 의 read defense 가
+    ConfigError 를 raise 하더라도 ``set`` 은 ``old_value=None`` 으로 진행한다.
+    """
+    await _insert_legacy_value(service, "risk.max_mdd_pct", "NaN", "risk")
+
+    # ConfigError 가 새어 나오면 안 된다.
+    await service.set("risk.max_mdd_pct", 0.1, category="risk")
+
+    # 덮어쓰기 성공 — 다시 get 하면 정상 값 반환.
+    assert await service.get("risk.max_mdd_pct") == 0.1
+
+    # 이벤트 1개(정상 set) 발행.
+    assert len(eventbus.published) == 1
+    event = eventbus.published[0]
+    assert event.key == "risk.max_mdd_pct"

--- a/tests/unit/test_system_config_api.py
+++ b/tests/unit/test_system_config_api.py
@@ -425,3 +425,121 @@ class TestDynamicConfig:
             headers=_MASTER_HEADERS,
         )
         assert resp.status_code == 200
+
+    # ── #1412 oracle A7: numeric finite invariant (write + read) ─────────
+
+    @pytest.mark.parametrize(
+        "raw_body",
+        [
+            '{"value": NaN, "category": "risk"}',
+            '{"value": Infinity, "category": "risk"}',
+            '{"value": -Infinity, "category": "risk"}',
+        ],
+    )
+    def test_config_update_non_finite_numeric_returns_422(
+        self, client, dynamic_config, raw_body
+    ):
+        """numeric NaN/Infinity/-Infinity 는 422 로 거부된다 (#1412).
+
+        oracle probe 가 ``PUT /api/config/risk.max_mdd_pct`` body 에 NaN 을
+        보내도 dynamic_config 에 영구 저장되어선 안 된다. 서비스 경계에서
+        ``ValueError`` 가 발생하고 라우트가 422 로 변환한다.
+        """
+        dynamic_config._configs["risk.max_mdd_pct"] = {
+            "value": 0.1,
+            "category": "risk",
+        }
+        resp = client.put(
+            "/api/config/risk.max_mdd_pct",
+            content=raw_body,
+            headers={**_MASTER_HEADERS, "Content-Type": "application/json"},
+        )
+        assert resp.status_code == 422
+        # 영구 저장은 일어나지 않아야 한다 — 기존 0.1 값이 유지.
+        assert dynamic_config._configs["risk.max_mdd_pct"]["value"] == 0.1
+
+    def test_config_update_finite_numeric_regression(self, client, dynamic_config):
+        """정상 finite numeric 값 0.1 → 200 (회귀 보존, #1412)."""
+        dynamic_config._configs["risk.max_mdd_pct"] = {
+            "value": 0.5,
+            "category": "risk",
+        }
+        resp = client.put(
+            "/api/config/risk.max_mdd_pct",
+            json={"value": 0.1, "category": "risk"},
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["new_value"] == 0.1
+        assert dynamic_config._configs["risk.max_mdd_pct"]["value"] == 0.1
+
+    def test_config_update_nan_unauth_returns_401_before_body_validation(
+        self, client, dynamic_config
+    ):
+        """auth-first invariant: 인증 실패 + NaN body → 401 (#1412 + #1373).
+
+        ``RequireAuthMiddleware`` 가 인증 가드를 body validation 보다 먼저
+        실행해야 한다. NaN body 라도 401 이 먼저 반환되어야 한다.
+        """
+        dynamic_config._configs["risk.max_mdd_pct"] = {
+            "value": 0.1,
+            "category": "risk",
+        }
+        # 디폴트 master-token 헤더를 빈 헤더로 override 한다.
+        resp = client.put(
+            "/api/config/risk.max_mdd_pct",
+            content='{"value": NaN, "category": "risk"}',
+            headers={
+                "Authorization": "",
+                "Content-Type": "application/json",
+            },
+        )
+        assert resp.status_code == 401
+        # 영구 저장도 일어나지 않아야 한다.
+        assert dynamic_config._configs["risk.max_mdd_pct"]["value"] == 0.1
+
+
+# ── #1412 oracle A7: read defense (legacy NaN row 격리) ─────────────────
+
+
+class _FakeDynamicConfigWithReadDefense:
+    """legacy NaN row 시뮬레이션을 위한 stub.
+
+    실제 ``DynamicConfigService.get_all`` 의 read 경계에서 ConfigError 가
+    발생한 상황을 재현하여, web 라우트가 422 로 변환하는지 검증한다.
+    """
+
+    def __init__(self, error_message: str) -> None:
+        self._error_message = error_message
+
+    async def get_all(self) -> list[dict]:
+        from ante.config.exceptions import ConfigError
+
+        raise ConfigError(self._error_message)
+
+
+def test_list_configs_legacy_non_finite_row_returns_422(
+    account_service, member_service, session_service
+):
+    """legacy non-finite numeric row 가 있을 때 GET /api/config → 422 (#1412).
+
+    서비스 read 경계가 ``ConfigError`` 를 raise 하면 라우트는 이를 422
+    problem+json 으로 변환한다. silent 500 폭증을 방지한다.
+    """
+    fake_config = _FakeDynamicConfigWithReadDefense(
+        "Dynamic config의 numeric 값이 non-finite 입니다. "
+        "key=risk.max_mdd_pct value=nan"
+    )
+    app = create_app(
+        account_service=account_service,
+        dynamic_config=fake_config,
+        member_service=member_service,
+        session_service=session_service,
+    )
+    test_client = TestClient(app)
+    test_client.headers.update(_MASTER_HEADERS)
+
+    resp = test_client.get("/api/config")
+    assert resp.status_code == 422
+    body = resp.json()
+    assert "non-finite" in str(body)


### PR DESCRIPTION
Closes #1412

## Summary
- `validate_value`(`DynamicConfigService.set` write 경계)에 generic numeric finite 가드 추가 — `NaN`/`±Infinity`를 422로 거부. Web API + IPC + CLI 모두 같은 service 경계 검증 사용 (multi-consumer 일관).
- `_ensure_loaded_value_finite` 헬퍼 + `DynamicConfigService.get/get_all/get_by_category` 에서 read defense — DB에 잔존할 수 있는 legacy NaN row가 GET 응답으로 silent corruption/500을 내는 경로 차단 (정렬: `ConfigError`).
- `register_default`도 같은 `validate_value`를 통과시키도록 보강 — 스타트업 default 초기화 경로 우회 차단.
- `_is_value_finite` 헬퍼가 `dict`/`list`/`tuple`을 재귀 검사 (json.dumps가 tuple을 array로 직렬화하므로 동일 처리). `int`는 short-circuit으로 `math.isfinite` `OverflowError` 회피 (임의 정밀도 정수 정상 통과). `bool` 명시 제외.
- GET `/api/config`에서 `ConfigError → HTTPException 422` 변환을 추가하고 OpenAPI 422 응답 shape 동기화. `frontend/openapi.json` 재생성.
- 회귀 테스트: write/read 가드, register_default, large int short-circuit, nested dict/list/tuple, bool 제외, self-healing legacy NaN row 덮어쓰기, Web API 422 + auth-first 401 등.

## Test Plan
- [x] `ruff check src/ante/config tests/unit` — All checks passed
- [x] `ruff format --check` — formatted
- [x] `mypy src/ante/config/dynamic.py src/ante/web/routes/config.py` — Success
- [x] `pytest tests/unit/test_dynamic_config.py` — 94 passed
- [x] `pytest tests/unit -k "config or dynamic"` — 436 passed
- [x] `pytest tests/unit` 전체 회귀 — 4688 passed, 2 skipped
- [x] Codex 브랜치 리뷰 (`/codex:review --base main`) — 3rd attempt PASS

## 메모
- 자동 legacy row cleanup은 Non-Goals (read 가드로 격리만). 사용자가 정상 finite 값으로 set 호출 시 self-heal됨.
- Codex iteration 2번 — nested/tuple/register_default/large int edge cases 모두 회귀 테스트로 잠금.

Refs Plan Preflight: 본문 Implementation Plan v2