### PR TITLE
fix(web-api): enforce ISO 8601 on audit date filter (#1414)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1236,14 +1236,17 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "format": "date-time"
                 },
                 {
                   "type": "null"
                 }
               ],
+              "description": "ISO 8601 datetime (inclusive lower bound)",
               "title": "From Date"
-            }
+            },
+            "description": "ISO 8601 datetime (inclusive lower bound)"
           },
           {
             "name": "to_date",
@@ -1252,14 +1255,17 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "format": "date-time"
                 },
                 {
                   "type": "null"
                 }
               ],
+              "description": "ISO 8601 datetime (inclusive upper bound)",
               "title": "To Date"
-            }
+            },
+            "description": "ISO 8601 datetime (inclusive upper bound)"
           },
           {
             "name": "limit",
@@ -1316,8 +1322,8 @@
               }
             }
           },
-          "503": {
-            "description": "Audit logger not available",
+          "422": {
+            "description": "Invalid date filter (ISO 8601 required). ``from_date``/``to_date``는 ISO 8601 datetime 또는 date(``YYYY-MM-DD``)만 허용한다. 파싱 불가능한 임의 문자열(예: ``not-a-date``)은FastAPI/Pydantic이 422로 거부한다(#1414).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1326,12 +1332,12 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
+          "503": {
+            "description": "Audit logger not available",
             "content": {
-              "application/json": {
+              "application/problem+json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1194,7 +1194,7 @@
           "audit"
         ],
         "summary": "List Audit Logs",
-        "description": "감사 로그 조회.\n\n인증/권한:\n    oracle A7 시그니처(#1359)에서 본 라우트는 인증 없이 감사 로그 목록을\n    반환하고 있었다. 감사 로그는 운영 행위 추적 정보(member_id, action,\n    resource, IP 등)를 담으므로 인증 가드를 적용한다. 인증 누락은 401,\n    권한 없음은 403.\n\n    Codex P2 (#1359 fix loop, 2차): 초기 패치는 ``require_master_caller``\n    를 그대로 적용해 ``master`` role만 허용했으나,\n    ``docs/specs/member/02-design-decisions.md:188-229`` 의 모니터링 agent\n    (``audit:read`` scope만 가진 default role)가 차단되는 문제가 있었다.\n    spec은 audit 도메인 read 권한을 ``master`` role 또는 ``audit:read``\n    scope 중 하나로 정의하므로, ``require_audit_read`` (master OR\n    ``audit:read`` ∈ Member.scopes)로 교체해 spec과 일치시켰다.\n\nCodex P2 (#1359 fix loop): FastAPI는 핸들러 매개변수 선언 순서대로\ndependency를 해결한다. ``audit_logger`` (필수 service, 미주입 시 503)를\n``require_audit_read`` 보다 먼저 두면, 인증 정보가 없는 호출자에게\n503이 먼저 반환되어 \"인증 누락은 401\" 계약이 깨진다. 그러므로 인증\n가드(``caller_id``)를 항상 먼저 선언해 401/403이 503보다 우선하도록 한다.\n\nNOTE: ``limit``은 다른 list endpoint와 일관된 ``le=100``으로 검증한다.\n이전 구현은 ``min(limit, 200)``로 자동 클램프했으나, #1356에서\npagination contract 일관성을 위해 클램프를 제거하고 Query\nvalidation으로 대체했다 (101..200 범위 요청은 새로 422). 다른 caller가\n이 범위를 강제하면 별도 endpoint로 분리한다.",
+        "description": "감사 로그 조회.\n\n인증/권한:\n    oracle A7 시그니처(#1359)에서 본 라우트는 인증 없이 감사 로그 목록을\n    반환하고 있었다. 감사 로그는 운영 행위 추적 정보(member_id, action,\n    resource, IP 등)를 담으므로 인증 가드를 적용한다. 인증 누락은 401,\n    권한 없음은 403.\n\n    Codex P2 (#1359 fix loop, 2차): 초기 패치는 ``require_master_caller``\n    를 그대로 적용해 ``master`` role만 허용했으나,\n    ``docs/specs/member/02-design-decisions.md:188-229`` 의 모니터링 agent\n    (``audit:read`` scope만 가진 default role)가 차단되는 문제가 있었다.\n    spec은 audit 도메인 read 권한을 ``master`` role 또는 ``audit:read``\n    scope 중 하나로 정의하므로, ``require_audit_read`` (master OR\n    ``audit:read`` ∈ Member.scopes)로 교체해 spec과 일치시켰다.\n\nCodex P2 (#1359 fix loop): FastAPI는 핸들러 매개변수 선언 순서대로\ndependency를 해결한다. ``audit_logger`` (필수 service, 미주입 시 503)를\n``require_audit_read`` 보다 먼저 두면, 인증 정보가 없는 호출자에게\n503이 먼저 반환되어 \"인증 누락은 401\" 계약이 깨진다. 그러므로 인증\n가드(``caller_id``)를 항상 먼저 선언해 401/403이 503보다 우선하도록 한다.\n\nNOTE: ``limit``은 다른 list endpoint와 일관된 ``le=100``으로 검증한다.\n이전 구현은 ``min(limit, 200)``로 자동 클램프했으나, #1356에서\npagination contract 일관성을 위해 클램프를 제거하고 Query\nvalidation으로 대체했다 (101..200 범위 요청은 새로 422). 다른 caller가\n이 범위를 강제하면 별도 endpoint로 분리한다.\n\nCodex P2 (#1414 fix loop r1): ``from_date``/``to_date``는 ``str | None``\n타입으로 받아 ``_validate_iso_date`` 헬퍼로 ISO 8601 파싱 가능성만 검증\n하고, 원본 str을 그대로 ``AuditLogger.query/count``에 전달한다. 이전\n구현은 ``Annotated[datetime | None, ...]``로 좁혀 Pydantic이 자동 변환\n하도록 했으나, date-only 입력이 ``\"2026-05-10T00:00:00\"`` (19자리)로\n변환되어 ``AuditLogger`` 내부의 ``len(to_date) == 10`` 자동 확장 분기가\n작동하지 않게 되어 자정 이후 데이터를 누락하는 silent semantic\nregression이 발생했다. 본 구현은 str을 보존해 그 회귀를 해소한다.",
         "operationId": "list_audit_logs_api_audit_get",
         "parameters": [
           {
@@ -1236,17 +1236,16 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string",
-                  "format": "date-time"
+                  "type": "string"
                 },
                 {
                   "type": "null"
                 }
               ],
-              "description": "ISO 8601 datetime (inclusive lower bound)",
+              "description": "ISO 8601 date (``YYYY-MM-DD``) 또는 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive lower bound.",
               "title": "From Date"
             },
-            "description": "ISO 8601 datetime (inclusive lower bound)"
+            "description": "ISO 8601 date (``YYYY-MM-DD``) 또는 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive lower bound."
           },
           {
             "name": "to_date",
@@ -1255,17 +1254,16 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string",
-                  "format": "date-time"
+                  "type": "string"
                 },
                 {
                   "type": "null"
                 }
               ],
-              "description": "ISO 8601 datetime (inclusive upper bound)",
+              "description": "ISO 8601 date (``YYYY-MM-DD``) 또는 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive upper bound. date-only는 ``AuditLogger`` 내부에서 ``T23:59:59``로 확장된다.",
               "title": "To Date"
             },
-            "description": "ISO 8601 datetime (inclusive upper bound)"
+            "description": "ISO 8601 date (``YYYY-MM-DD``) 또는 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive upper bound. date-only는 ``AuditLogger`` 내부에서 ``T23:59:59``로 확장된다."
           },
           {
             "name": "limit",
@@ -1323,7 +1321,7 @@
             }
           },
           "422": {
-            "description": "Invalid date filter (ISO 8601 required). ``from_date``/``to_date``는 ISO 8601 datetime 또는 date(``YYYY-MM-DD``)만 허용한다. 파싱 불가능한 임의 문자열(예: ``not-a-date``)은FastAPI/Pydantic이 422로 거부한다(#1414).",
+            "description": "Invalid date filter (ISO 8601 required). ``from_date``/``to_date``는 ISO 8601 date(``YYYY-MM-DD``) 또는 datetime(``YYYY-MM-DDTHH:MM:SS[Z]``)만 허용한다. 파싱 불가능한임의 문자열(예: ``not-a-date``)은 핸들러가 422로 거부한다(#1414). date-only 입력은 ``AuditLogger.query``의 자동 확장(SQL ``<= 'YYYY-MM-DDT23:59:59'``) 동작을 보존하기 위해 변환 없이 그대로 전달된다.",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -375,6 +375,15 @@ export type paths = {
          *     pagination contract 일관성을 위해 클램프를 제거하고 Query
          *     validation으로 대체했다 (101..200 범위 요청은 새로 422). 다른 caller가
          *     이 범위를 강제하면 별도 endpoint로 분리한다.
+         *
+         *     Codex P2 (#1414 fix loop r1): ``from_date``/``to_date``는 ``str | None``
+         *     타입으로 받아 ``_validate_iso_date`` 헬퍼로 ISO 8601 파싱 가능성만 검증
+         *     하고, 원본 str을 그대로 ``AuditLogger.query/count``에 전달한다. 이전
+         *     구현은 ``Annotated[datetime | None, ...]``로 좁혀 Pydantic이 자동 변환
+         *     하도록 했으나, date-only 입력이 ``"2026-05-10T00:00:00"`` (19자리)로
+         *     변환되어 ``AuditLogger`` 내부의 ``len(to_date) == 10`` 자동 확장 분기가
+         *     작동하지 않게 되어 자정 이후 데이터를 누락하는 silent semantic
+         *     regression이 발생했다. 본 구현은 str을 보존해 그 회귀를 해소한다.
          */
         get: operations["list_audit_logs_api_audit_get"];
         put?: never;
@@ -4414,12 +4423,12 @@ export interface operations {
         parameters: {
             query?: {
                 action?: string | null;
-                /** @description ISO 8601 datetime (inclusive lower bound) */
+                /** @description ISO 8601 date (``YYYY-MM-DD``) 또는 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive lower bound. */
                 from_date?: string | null;
                 limit?: number;
                 member_id?: string | null;
                 offset?: number;
-                /** @description ISO 8601 datetime (inclusive upper bound) */
+                /** @description ISO 8601 date (``YYYY-MM-DD``) 또는 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive upper bound. date-only는 ``AuditLogger`` 내부에서 ``T23:59:59``로 확장된다. */
                 to_date?: string | null;
             };
             header?: never;
@@ -4455,7 +4464,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Invalid date filter (ISO 8601 required). ``from_date``/``to_date``는 ISO 8601 datetime 또는 date(``YYYY-MM-DD``)만 허용한다. 파싱 불가능한 임의 문자열(예: ``not-a-date``)은FastAPI/Pydantic이 422로 거부한다(#1414). */
+            /** @description Invalid date filter (ISO 8601 required). ``from_date``/``to_date``는 ISO 8601 date(``YYYY-MM-DD``) 또는 datetime(``YYYY-MM-DDTHH:MM:SS[Z]``)만 허용한다. 파싱 불가능한임의 문자열(예: ``not-a-date``)은 핸들러가 422로 거부한다(#1414). date-only 입력은 ``AuditLogger.query``의 자동 확장(SQL ``<= 'YYYY-MM-DDT23:59:59'``) 동작을 보존하기 위해 변환 없이 그대로 전달된다. */
             422: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -619,6 +619,9 @@ export type paths = {
          * List Configs
          * @description 동적 설정 전체 조회. 인증된 master/human 또는 ``config:read`` scope 를
          *     보유한 agent 만 호출 가능 (#1407).
+         *
+         *     저장된 값이 read invariant(예: numeric finite, #1412)를 위반하면 서비스
+         *     경계가 ``ConfigError`` 를 raise 하며, 라우트는 이를 422 로 변환한다.
          */
         get: operations["list_configs_api_config_get"];
         put?: never;
@@ -4411,10 +4414,12 @@ export interface operations {
         parameters: {
             query?: {
                 action?: string | null;
+                /** @description ISO 8601 datetime (inclusive lower bound) */
                 from_date?: string | null;
                 limit?: number;
                 member_id?: string | null;
                 offset?: number;
+                /** @description ISO 8601 datetime (inclusive upper bound) */
                 to_date?: string | null;
             };
             header?: never;
@@ -4450,13 +4455,13 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Invalid date filter (ISO 8601 required). ``from_date``/``to_date``는 ISO 8601 datetime 또는 date(``YYYY-MM-DD``)만 허용한다. 파싱 불가능한 임의 문자열(예: ``not-a-date``)은FastAPI/Pydantic이 422로 거부한다(#1414). */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Audit logger not available */
@@ -5138,6 +5143,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ConfigListResponse"];
+                };
+            };
+            /** @description 저장된 dynamic config 값이 invariant 를 위반한 경우 (예: legacy non-finite numeric row — #1412). 서비스 read 경계가 ConfigError 로 격리한 결과를 422 problem+json 으로 변환한다. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Config service not available */

--- a/src/ante/web/routes/audit.py
+++ b/src/ante/web/routes/audit.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -13,13 +13,50 @@ from ante.web.schemas import AuditLogListResponse
 router = APIRouter()
 
 
+def _normalize_iso_datetime(value: str) -> str:
+    """ISO datetime을 ``AuditLogger`` storage format으로 정규화.
+
+    ``AuditLogger.log``는 ``datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")``
+    형식(Z 없는 naive UTC)으로 ``created_at``을 저장한다. ``query``/``count``
+    는 SQL 텍스트 비교(``created_at >= ?``, ``created_at <= ?``)를 사용하므로,
+    입력 str을 **동일한 storage format**으로 맞추지 않으면 inclusive boundary
+    가 깨진다.
+
+    Codex P2 (#1414 fix loop r2):
+        ``from_date=2026-05-10T00:00:00Z``를 검증만 통과시켜 그대로
+        ``AuditLogger.query``에 넘기면 SQL은 ``created_at >=
+        '2026-05-10T00:00:00Z'``가 되고, 저장값은 ``'2026-05-10T00:00:00'``
+        (Z 없음). ASCII ``Z`` > digit이므로 ``'2026-05-10T00:00:00'`` <
+        ``'2026-05-10T00:00:00Z'``로 평가되어, 정확히 같은 시각의 row가
+        inclusive lower bound에서 누락되는 silent regression이 발생한다.
+
+    변환 규칙:
+        - ``Z`` suffix → 제거(UTC 가정 보존)
+        - ``+HH:MM`` / ``-HH:MM`` offset → UTC로 환산 후 ``tzinfo`` 제거
+        - timezone 없는 naive datetime → 그대로 반환(UTC 가정)
+
+    Raises:
+        ``ValueError``: ISO datetime 파싱 실패 시 (caller가 422로 변환).
+    """
+    # ``Z`` → ``+00:00``으로 변환해야 ``fromisoformat``이 timezone-aware로 인식.
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if dt.tzinfo is not None:
+        # UTC로 변환 후 timezone-aware → naive로 평탄화(storage format 일치).
+        dt = dt.astimezone(UTC).replace(tzinfo=None)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+
 def _validate_iso_date(value: str | None, field: str) -> str | None:
     """``value``가 ISO 8601 date(``YYYY-MM-DD``) 또는 datetime인지 검증.
 
-    검증 통과 시 원본 str을 그대로 반환한다. ``AuditLogger.query/count``는
-    10자리 date-only ``to_date``를 받으면 SQL에서 ``T23:59:59``로 자동 확장
-    하여 자정 이후 데이터를 누락하지 않도록 한다. 따라서 핸들러는 입력 str
-    을 **변환 없이** 그대로 전달해야 한다.
+    검증 통과 시:
+        - date-only(``YYYY-MM-DD``, 10자리)는 **변환 없이** 그대로 반환한다.
+          ``AuditLogger.query/count``는 10자리 ``to_date``를 받으면 SQL에서
+          ``T23:59:59``로 자동 확장하여 자정 이후 데이터 누락을 막는다.
+        - datetime은 ``_normalize_iso_datetime``으로 storage format
+          (``%Y-%m-%dT%H:%M:%S``, naive UTC)으로 정규화하여 반환한다.
+          ``Z``/offset suffix를 보존한 채 SQL 텍스트 비교에 넘기면 inclusive
+          boundary가 어긋난다(Codex r2 finding 참고).
 
     파싱 실패 시 422로 거부한다 (FastAPI/Pydantic 422 응답과 동일 형식).
 
@@ -30,7 +67,12 @@ def _validate_iso_date(value: str | None, field: str) -> str | None:
     ``AuditLogger.query``의 ``len(to_date) == 10`` 분기가 작동하지 않게 되었다.
     결과적으로 ``to_date=2026-05-10`` 호출이 자정 이전 데이터만 반환하는
     **silent semantic regression**이 발생했다. 본 헬퍼는 그 회귀를 해소하기
-    위해 입력 str을 보존한다.
+    위해 date-only 입력 str을 보존한다.
+
+    Codex P2 (#1414 fix loop r2): r1 구현은 datetime 입력도 보존했으나,
+    ``Z``/offset suffix를 그대로 SQL 텍스트 비교(``created_at >= ?``)에 넘기면
+    storage format(Z 없는 naive UTC)과 어긋나 inclusive boundary가 깨졌다.
+    datetime 입력은 storage format으로 정규화하여 누락을 막는다.
     """
     if value is None:
         return None
@@ -40,10 +82,9 @@ def _validate_iso_date(value: str | None, field: str) -> str | None:
         return value
     except ValueError:
         pass
-    # ISO datetime 시도 (timezone 'Z' suffix 호환)
+    # ISO datetime 시도 (Z/offset 허용) — storage format으로 정규화
     try:
-        datetime.fromisoformat(value.replace("Z", "+00:00"))
-        return value
+        return _normalize_iso_datetime(value)
     except ValueError:
         pass
     raise HTTPException(
@@ -164,6 +205,12 @@ async def list_audit_logs(
     변환되어 ``AuditLogger`` 내부의 ``len(to_date) == 10`` 자동 확장 분기가
     작동하지 않게 되어 자정 이후 데이터를 누락하는 silent semantic
     regression이 발생했다. 본 구현은 str을 보존해 그 회귀를 해소한다.
+
+    Codex P2 (#1414 fix loop r2): datetime 입력(``2026-05-10T00:00:00Z`` 등)
+    을 r1처럼 그대로 보존하면 SQL 텍스트 비교에서 storage format(Z 없는
+    naive UTC)과 어긋나 inclusive boundary가 깨진다. ``Z``/offset 입력을
+    storage format으로 정규화하도록 헬퍼를 보강했다. date-only는 자동 확장
+    경로를 위해 변환 없이 그대로 보존된다.
     """
     # caller_id는 ``require_audit_read``가 ``request.state.member_id``에
     # 이미 반영하고 ``AuditMiddleware``가 자동 감사 로그 주체로 사용한다.

--- a/src/ante/web/routes/audit.py
+++ b/src/ante/web/routes/audit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query
@@ -32,6 +33,19 @@ router = APIRouter()
                 },
             },
         },
+        422: {
+            "description": (
+                "Invalid date filter (ISO 8601 required). ``from_date``/"
+                "``to_date``는 ISO 8601 datetime 또는 date(``YYYY-MM-DD``)"
+                "만 허용한다. 파싱 불가능한 임의 문자열(예: ``not-a-date``)은"
+                "FastAPI/Pydantic이 422로 거부한다(#1414)."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
         503: {
             "description": "Audit logger not available",
             "content": {
@@ -47,8 +61,14 @@ async def list_audit_logs(
     audit_logger: Annotated[Any, Depends(get_audit_logger)],
     member_id: str | None = None,
     action: str | None = None,
-    from_date: str | None = None,
-    to_date: str | None = None,
+    from_date: Annotated[
+        datetime | None,
+        Query(description="ISO 8601 datetime (inclusive lower bound)"),
+    ] = None,
+    to_date: Annotated[
+        datetime | None,
+        Query(description="ISO 8601 datetime (inclusive upper bound)"),
+    ] = None,
     limit: int = Query(default=50, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
 ) -> dict:
@@ -87,18 +107,26 @@ async def list_audit_logs(
     # 두 조건 OR 모델이므로 이 정책이 안전하다). 변수 사용 표시를 위한 명시적
     # reference.
     _ = caller_id
+    # #1414: ``from_date``/``to_date``는 FastAPI/Pydantic이 ISO 8601로 파싱
+    # 완료한 ``datetime`` 객체이거나 ``None``이다. 임의 문자열은 422로 미리
+    # 거부되어 본 핸들러 진입 자체가 불가능하다. ``AuditLogger.query/count``
+    # 시그니처는 ``str | None``을 유지하므로 ``isoformat()``으로 변환해 전달
+    # 한다(SQL ``created_at`` 컬럼 비교 동작 보존, str + ISO 8601 정렬 가능
+    # 형식).
+    from_date_str = from_date.isoformat() if from_date is not None else None
+    to_date_str = to_date.isoformat() if to_date is not None else None
     logs = await audit_logger.query(
         member_id=member_id,
         action=action,
-        from_date=from_date,
-        to_date=to_date,
+        from_date=from_date_str,
+        to_date=to_date_str,
         limit=limit,
         offset=offset,
     )
     total = await audit_logger.count(
         member_id=member_id,
         action=action,
-        from_date=from_date,
-        to_date=to_date,
+        from_date=from_date_str,
+        to_date=to_date_str,
     )
     return {"logs": logs, "total": total}

--- a/src/ante/web/routes/audit.py
+++ b/src/ante/web/routes/audit.py
@@ -50,7 +50,8 @@ def _validate_iso_date(value: str | None, field: str) -> str | None:
     """``value``가 ISO 8601 date(``YYYY-MM-DD``) 또는 datetime인지 검증.
 
     검증 통과 시:
-        - date-only(``YYYY-MM-DD``, 10자리)는 **변환 없이** 그대로 반환한다.
+        - date-only는 ``date.fromisoformat`` 파싱 후 ``.isoformat()`` 호출로
+          **항상 ``YYYY-MM-DD`` 표준 형식(10자리)으로 정규화**하여 반환한다.
           ``AuditLogger.query/count``는 10자리 ``to_date``를 받으면 SQL에서
           ``T23:59:59``로 자동 확장하여 자정 이후 데이터 누락을 막는다.
         - datetime은 ``_normalize_iso_datetime``으로 storage format
@@ -73,13 +74,24 @@ def _validate_iso_date(value: str | None, field: str) -> str | None:
     ``Z``/offset suffix를 그대로 SQL 텍스트 비교(``created_at >= ?``)에 넘기면
     storage format(Z 없는 naive UTC)과 어긋나 inclusive boundary가 깨졌다.
     datetime 입력은 storage format으로 정규화하여 누락을 막는다.
+
+    Codex P2 (#1414 fix loop r3): Python 3.13의 ``date.fromisoformat()``이
+    ``20260510`` (no dashes), ``2026-W19-1`` (ISO week date) 같은 비표준 ISO
+    date도 허용한다. r2 구현은 검증 통과 시 원본 str을 그대로 반환했으므로,
+    ``20260510``(8자리)이나 ``2026-W19-1``(10자리이긴 하나 비표준 포맷)이
+    ``AuditLogger.query``의 ``len(to_date) == 10`` 자동 확장 분기와
+    ``YYYY-MM-DDT...`` 텍스트 비교 전제를 깨뜨릴 수 있었다. 본 r3 구현은
+    ``date.fromisoformat`` 파싱 후 ``.isoformat()``을 호출해 항상 ``YYYY-MM-DD``
+    표준 형식으로 정규화하여 그 전제를 보장한다.
     """
     if value is None:
         return None
-    # 10자리 YYYY-MM-DD 시도 (AuditLogger.query의 자동 확장 경로 보존)
+    # ISO date 시도 — Python 3.13은 ``20260510``, ``2026-W19-1`` 같은 비표준
+    # 포맷도 수락하므로, ``.isoformat()``으로 항상 ``YYYY-MM-DD`` 표준 형식
+    # (10자리)으로 정규화한다 (AuditLogger.query의 자동 확장 경로 보존).
     try:
-        date.fromisoformat(value)
-        return value
+        parsed = date.fromisoformat(value)
+        return parsed.isoformat()
     except ValueError:
         pass
     # ISO datetime 시도 (Z/offset 허용) — storage format으로 정규화

--- a/src/ante/web/routes/audit.py
+++ b/src/ante/web/routes/audit.py
@@ -2,15 +2,57 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from ante.web.deps import get_audit_logger, require_audit_read
 from ante.web.schemas import AuditLogListResponse
 
 router = APIRouter()
+
+
+def _validate_iso_date(value: str | None, field: str) -> str | None:
+    """``value``가 ISO 8601 date(``YYYY-MM-DD``) 또는 datetime인지 검증.
+
+    검증 통과 시 원본 str을 그대로 반환한다. ``AuditLogger.query/count``는
+    10자리 date-only ``to_date``를 받으면 SQL에서 ``T23:59:59``로 자동 확장
+    하여 자정 이후 데이터를 누락하지 않도록 한다. 따라서 핸들러는 입력 str
+    을 **변환 없이** 그대로 전달해야 한다.
+
+    파싱 실패 시 422로 거부한다 (FastAPI/Pydantic 422 응답과 동일 형식).
+
+    Codex P2 (#1414 fix loop r1): 1차 구현은 ``Annotated[datetime | None,
+    Query(...)]``로 좁혀 422 거부는 통과시켰으나, Pydantic이 date-only
+    (``2026-05-10``)를 ``datetime(2026, 5, 10, 0, 0, 0)``으로 자동 변환한 뒤
+    ``isoformat()`` → ``"2026-05-10T00:00:00"`` (19자리)로 변환되어
+    ``AuditLogger.query``의 ``len(to_date) == 10`` 분기가 작동하지 않게 되었다.
+    결과적으로 ``to_date=2026-05-10`` 호출이 자정 이전 데이터만 반환하는
+    **silent semantic regression**이 발생했다. 본 헬퍼는 그 회귀를 해소하기
+    위해 입력 str을 보존한다.
+    """
+    if value is None:
+        return None
+    # 10자리 YYYY-MM-DD 시도 (AuditLogger.query의 자동 확장 경로 보존)
+    try:
+        date.fromisoformat(value)
+        return value
+    except ValueError:
+        pass
+    # ISO datetime 시도 (timezone 'Z' suffix 호환)
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return value
+    except ValueError:
+        pass
+    raise HTTPException(
+        status_code=422,
+        detail=(
+            f"Invalid ISO 8601 date for {field}: {value!r}. "
+            "허용 형식: ``YYYY-MM-DD`` 또는 ``YYYY-MM-DDTHH:MM:SS[Z]``."
+        ),
+    )
 
 
 @router.get(
@@ -36,9 +78,12 @@ router = APIRouter()
         422: {
             "description": (
                 "Invalid date filter (ISO 8601 required). ``from_date``/"
-                "``to_date``는 ISO 8601 datetime 또는 date(``YYYY-MM-DD``)"
-                "만 허용한다. 파싱 불가능한 임의 문자열(예: ``not-a-date``)은"
-                "FastAPI/Pydantic이 422로 거부한다(#1414)."
+                "``to_date``는 ISO 8601 date(``YYYY-MM-DD``) 또는 "
+                "datetime(``YYYY-MM-DDTHH:MM:SS[Z]``)만 허용한다. 파싱 불가능한"
+                "임의 문자열(예: ``not-a-date``)은 핸들러가 422로 거부한다"
+                "(#1414). date-only 입력은 ``AuditLogger.query``의 자동 확장"
+                "(SQL ``<= 'YYYY-MM-DDT23:59:59'``) 동작을 보존하기 위해 "
+                "변환 없이 그대로 전달된다."
             ),
             "content": {
                 "application/problem+json": {
@@ -62,12 +107,23 @@ async def list_audit_logs(
     member_id: str | None = None,
     action: str | None = None,
     from_date: Annotated[
-        datetime | None,
-        Query(description="ISO 8601 datetime (inclusive lower bound)"),
+        str | None,
+        Query(
+            description=(
+                "ISO 8601 date (``YYYY-MM-DD``) 또는 datetime "
+                "(``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive lower bound."
+            ),
+        ),
     ] = None,
     to_date: Annotated[
-        datetime | None,
-        Query(description="ISO 8601 datetime (inclusive upper bound)"),
+        str | None,
+        Query(
+            description=(
+                "ISO 8601 date (``YYYY-MM-DD``) 또는 datetime "
+                "(``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive upper bound. "
+                "date-only는 ``AuditLogger`` 내부에서 ``T23:59:59``로 확장된다."
+            ),
+        ),
     ] = None,
     limit: int = Query(default=50, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
@@ -99,6 +155,15 @@ async def list_audit_logs(
     pagination contract 일관성을 위해 클램프를 제거하고 Query
     validation으로 대체했다 (101..200 범위 요청은 새로 422). 다른 caller가
     이 범위를 강제하면 별도 endpoint로 분리한다.
+
+    Codex P2 (#1414 fix loop r1): ``from_date``/``to_date``는 ``str | None``
+    타입으로 받아 ``_validate_iso_date`` 헬퍼로 ISO 8601 파싱 가능성만 검증
+    하고, 원본 str을 그대로 ``AuditLogger.query/count``에 전달한다. 이전
+    구현은 ``Annotated[datetime | None, ...]``로 좁혀 Pydantic이 자동 변환
+    하도록 했으나, date-only 입력이 ``"2026-05-10T00:00:00"`` (19자리)로
+    변환되어 ``AuditLogger`` 내부의 ``len(to_date) == 10`` 자동 확장 분기가
+    작동하지 않게 되어 자정 이후 데이터를 누락하는 silent semantic
+    regression이 발생했다. 본 구현은 str을 보존해 그 회귀를 해소한다.
     """
     # caller_id는 ``require_audit_read``가 ``request.state.member_id``에
     # 이미 반영하고 ``AuditMiddleware``가 자동 감사 로그 주체로 사용한다.
@@ -107,26 +172,21 @@ async def list_audit_logs(
     # 두 조건 OR 모델이므로 이 정책이 안전하다). 변수 사용 표시를 위한 명시적
     # reference.
     _ = caller_id
-    # #1414: ``from_date``/``to_date``는 FastAPI/Pydantic이 ISO 8601로 파싱
-    # 완료한 ``datetime`` 객체이거나 ``None``이다. 임의 문자열은 422로 미리
-    # 거부되어 본 핸들러 진입 자체가 불가능하다. ``AuditLogger.query/count``
-    # 시그니처는 ``str | None``을 유지하므로 ``isoformat()``으로 변환해 전달
-    # 한다(SQL ``created_at`` 컬럼 비교 동작 보존, str + ISO 8601 정렬 가능
-    # 형식).
-    from_date_str = from_date.isoformat() if from_date is not None else None
-    to_date_str = to_date.isoformat() if to_date is not None else None
+    # #1414 r1: ISO 8601 검증 후 원본 str을 그대로 전달.
+    from_date_validated = _validate_iso_date(from_date, "from_date")
+    to_date_validated = _validate_iso_date(to_date, "to_date")
     logs = await audit_logger.query(
         member_id=member_id,
         action=action,
-        from_date=from_date_str,
-        to_date=to_date_str,
+        from_date=from_date_validated,
+        to_date=to_date_validated,
         limit=limit,
         offset=offset,
     )
     total = await audit_logger.count(
         member_id=member_id,
         action=action,
-        from_date=from_date_str,
-        to_date=to_date_str,
+        from_date=from_date_validated,
+        to_date=to_date_validated,
     )
     return {"logs": logs, "total": total}

--- a/tests/unit/test_audit_date_filter.py
+++ b/tests/unit/test_audit_date_filter.py
@@ -2,21 +2,26 @@
 
 oracle A7 시그니처에서 발견된 contract drift: ``from_date``/``to_date``가
 임의 문자열(예: ``oracle-not-a-date``)을 200으로 수락하고 있었다. 본 PR은
-파라미터 타입을 ``Annotated[datetime | None, Query(...)]``로 좁혀
-FastAPI/Pydantic이 ISO 8601 파싱에 실패하면 422로 거부하도록 한다.
+핸들러 안에서 ``_validate_iso_date`` 헬퍼로 ISO 8601 파싱 가능성만 검증
+하고, 파싱 실패 시 422로 거부한다.
 
-핵심 invariants (Implementation Plan):
+핵심 invariants (Implementation Plan + Codex r1 finding):
 - 인증 누락 + 잘못된 날짜 → 401 (auth-first 우선순위, dependency 순서 회귀 방지).
 - 인증된 master + 잘못된 날짜 → 422 (``AuditLogger.query`` 미호출).
-- 인증된 master + 정상 ISO 8601 datetime → 200 (회귀 보존).
-- 인증된 master + 정상 date-only (``YYYY-MM-DD``) → 200 (FastAPI/Pydantic
-  이 ISO 8601 date 파싱 허용).
-- OpenAPI ``parameters[from_date]``/``parameters[to_date]``는
-  ``format: date-time`` 스키마로 노출되어야 한다 (contract-drift fix 검증).
+- 인증된 master + 정상 ISO 8601 datetime → 200, **원본 str 그대로 전달**.
+- 인증된 master + 정상 date-only (``YYYY-MM-DD``) → 200, **원본 str(10자리)
+  그대로 전달** → ``AuditLogger.query`` 내부의 ``T23:59:59`` 자동 확장 분기
+  보존. Codex r1 finding: 1차 구현은 Pydantic datetime → ``isoformat()``으로
+  변환했고, date-only가 ``"2026-05-10T00:00:00"`` (19자리)로 바뀌어 자정
+  이후 데이터를 누락하는 silent semantic regression이 발생했다.
+- OpenAPI ``parameters[from_date]``/``parameters[to_date]``는 ``string``
+  스키마로 노출되며 description에 ISO 8601 형식을 명시한다.
 
 SSOT: ``docs/specs/web-api/05-resource-endpoints.md`` (audit 라우트는
 "필터: member_id, action, from_date, to_date, limit, offset" — free-form
 허용 명시 없음 → ISO 8601 강제는 spec 위반이 아니다).
+``docs/specs/audit/audit.md`` Web API 예시는 ``from_date=2026-03-12&to_date=
+2026-03-19`` (date-only) — 본 회귀 테스트는 그 caller 패턴을 보호한다.
 """
 
 from __future__ import annotations
@@ -195,11 +200,12 @@ class TestInvalidDate422:
         assert audit_logger.count.await_count == 0
 
 
-# ── 200: 정상 ISO 8601 회귀 보존 ────────────────────────────────────
+# ── 200: 정상 ISO 8601 + str 보존 회귀 ────────────────────────────────
 
 
 class TestValidIsoDate200:
-    """정상 ISO 8601 입력은 200으로 통과해야 한다 (회귀)."""
+    """정상 ISO 8601 입력은 200으로 통과하며 원본 str이 그대로 ``AuditLogger``
+    에 전달되어야 한다 (Codex r1 finding: silent semantic regression 방지)."""
 
     def test_iso_datetime_returns_200(
         self, client: TestClient, audit_logger: AsyncMock
@@ -213,20 +219,21 @@ class TestValidIsoDate200:
             f"정상 ISO datetime이 200이 아님 ({resp.status_code}: {resp.text})"
         )
         assert audit_logger.query.await_count == 1
-        # ``AuditLogger.query`` 시그니처는 str을 유지한다 — 핸들러는
-        # ``datetime.isoformat()``으로 변환해 전달해야 한다.
+        # ``AuditLogger.query`` 시그니처는 str을 유지한다 — 핸들러는 입력
+        # str을 변환 없이 그대로 전달해야 한다.
         call_kwargs = audit_logger.query.await_args.kwargs
-        assert isinstance(call_kwargs["from_date"], str), (
-            f"from_date가 str로 전달되어야 함: {type(call_kwargs['from_date'])}"
+        assert call_kwargs["from_date"] == "2026-05-10T00:00:00Z", (
+            f"ISO datetime str가 변환 없이 그대로 전달되어야 함: "
+            f"{call_kwargs['from_date']!r}"
         )
-        assert "2026-05-10" in call_kwargs["from_date"]
 
     def test_date_only_returns_200(
         self, client: TestClient, audit_logger: AsyncMock
     ) -> None:
-        """date-only (``2026-05-10``) → 200 (FastAPI/Pydantic은 date를 datetime
-        으로 자동 변환). 기존 ``frontend/src/api/`` caller가 date-only를 보내는
-        경우 회귀 보존."""
+        """date-only (``2026-05-10``) → 200. 10자리 str 그대로 전달되어
+        ``AuditLogger.query`` 내부의 ``T23:59:59`` 자동 확장 분기를 보존한다.
+        Codex r1 finding 핵심 회귀.
+        """
         resp = client.get(
             "/api/audit?from_date=2026-05-10",
             headers=_MASTER_HEADERS,
@@ -235,6 +242,83 @@ class TestValidIsoDate200:
             f"date-only가 200이 아님 ({resp.status_code}: {resp.text})"
         )
         assert audit_logger.query.await_count == 1
+        call_kwargs = audit_logger.query.await_args.kwargs
+        assert call_kwargs["from_date"] == "2026-05-10", (
+            f"date-only str(10자리)가 변환 없이 그대로 전달되어야 함: "
+            f"{call_kwargs['from_date']!r}"
+        )
+
+    def test_date_only_to_date_extended_to_end_of_day(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        """date-only ``to_date``(10자리)가 ``AuditLogger``에 그대로 전달되어
+        자정 이후 데이터 누락을 방지한다.
+
+        Codex r1 finding 핵심 회귀:
+            1차 구현은 Pydantic이 ``2026-05-10`` → ``datetime(2026,5,10,0,0,0)``
+            으로 변환한 뒤 핸들러가 ``isoformat()`` → ``"2026-05-10T00:00:00"``
+            (19자리)로 바꿔 ``AuditLogger.query``의
+            ``if len(to_date) == 10: to_date + "T23:59:59"`` 자동 확장 분기를
+            우회시켰다. 결과적으로 SQL ``created_at <= '2026-05-10T00:00:00'``
+            로 좁혀져 자정 이후 데이터를 모두 누락. 본 테스트는 입력 str이
+            10자리 그대로 ``AuditLogger.query``에 도달하는지 확인한다.
+        """
+        resp = client.get(
+            "/api/audit?to_date=2026-05-10",
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 200, (
+            f"date-only to_date가 200이 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert audit_logger.query.await_count == 1
+        call_kwargs = audit_logger.query.await_args.kwargs
+        # 10자리 그대로 — AuditLogger 내부에서 자동 확장 분기 진입 가능
+        assert call_kwargs["to_date"] == "2026-05-10", (
+            f"date-only to_date가 10자리 그대로 전달되어야 함 (자동 확장 보존): "
+            f"{call_kwargs['to_date']!r}"
+        )
+        assert len(call_kwargs["to_date"]) == 10, (
+            f"to_date 길이가 10이어야 AuditLogger.query 분기 진입 가능: "
+            f"len={len(call_kwargs['to_date'])}, value={call_kwargs['to_date']!r}"
+        )
+        # count도 동일하게 전달되는지 확인
+        count_kwargs = audit_logger.count.await_args.kwargs
+        assert count_kwargs["to_date"] == "2026-05-10", (
+            f"count에도 date-only str 그대로 전달되어야 함: {count_kwargs['to_date']!r}"
+        )
+
+    def test_iso_datetime_to_date_preserved(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        """ISO datetime ``to_date``도 원본 str 그대로 전달."""
+        resp = client.get(
+            "/api/audit?to_date=2026-05-10T12:34:56Z",
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 200, (
+            f"ISO datetime to_date가 200이 아님 ({resp.status_code}: {resp.text})"
+        )
+        call_kwargs = audit_logger.query.await_args.kwargs
+        assert call_kwargs["to_date"] == "2026-05-10T12:34:56Z", (
+            f"ISO datetime to_date str가 변환 없이 그대로 전달되어야 함: "
+            f"{call_kwargs['to_date']!r}"
+        )
+
+    def test_both_dates_passed_as_str(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        """``from_date``+``to_date`` 둘 다 date-only로 보낼 때 양쪽 모두 원본
+        str 보존."""
+        resp = client.get(
+            "/api/audit?from_date=2026-03-12&to_date=2026-03-19",
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 200, (
+            f"date-only 양쪽 전송이 200이 아님 ({resp.status_code}: {resp.text})"
+        )
+        call_kwargs = audit_logger.query.await_args.kwargs
+        assert call_kwargs["from_date"] == "2026-03-12"
+        assert call_kwargs["to_date"] == "2026-03-19"
 
 
 # ── 401: auth-first invariant (Issue #1414 본문) ────────────────────
@@ -247,6 +331,10 @@ class TestAuthFirstWithInvalidDate:
     (require_audit_read)가 ``from_date``/``to_date`` Query parsing 보다 먼저
     실행된다. 인증 정보가 없으면 401이 먼저 반환되어 "auth-first" invariant
     가 유지된다. 본 테스트는 그 회귀를 막는다.
+
+    NOTE (#1414 r1): 422 검증을 핸들러 본문(헬퍼 호출)로 옮기면 Query
+    parsing 단계는 항상 통과하므로, 잘못된 날짜로 호출해도 핸들러 진입
+    전에 401이 발생하는지가 더더욱 중요하다.
     """
 
     def test_unauth_with_invalid_date_returns_401(
@@ -264,79 +352,93 @@ class TestAuthFirstWithInvalidDate:
 # ── OpenAPI 스키마 회귀 (contract-drift fix 검증) ──────────────────
 
 
-class TestOpenAPIDateFormat:
-    """``/openapi.json``의 ``from_date``/``to_date`` 스키마가 ``date-time``
-    포맷으로 노출되어야 한다.
+class TestOpenAPIDateContract:
+    """``/openapi.json``의 ``from_date``/``to_date`` 스키마 + 422 응답 분기
+    회귀.
 
-    issue #1414 직전에는 두 파라미터가 free-form ``string``이었다. 본 PR
-    이후에는 FastAPI가 ``Annotated[datetime | None, Query(...)]``를
-    ``{"anyOf": [{"type": "string", "format": "date-time"}, {"type": "null"}]}``
-    로 노출해야 한다. ``frontend/openapi.json`` codegen 산출물이
-    contract 변경을 인식할 수 있도록 명시적으로 검증한다.
+    issue #1414 r1: 1차 구현은 ``Annotated[datetime | None, Query(...)]``로
+    좁혀 OpenAPI에 ``format: date-time``으로 노출했으나, 그 자동 변환이 SQL
+    의 자동 확장 분기를 깨뜨려 회귀로 판정됐다. r2 구현은 타입을
+    ``str | None``으로 복원하고 description에 ISO 8601 명시. 따라서 OpenAPI
+    schema는 ``string`` 또는 anyOf ``string``/null이며, description에
+    ISO 8601 키워드가 포함되어야 한다. 422 분기는 그대로 유지.
     """
 
     @staticmethod
-    def _audit_query_params() -> dict[str, dict]:
-        """``GET /api/audit`` 의 query parameter 스키마를 name → schema 매핑으로."""
+    def _audit_get_operation() -> dict:
         app = create_app()
         schema = app.openapi()
-        operation = schema["paths"]["/api/audit"]["get"]
+        return schema["paths"]["/api/audit"]["get"]
+
+    @staticmethod
+    def _audit_query_params() -> dict[str, dict]:
+        """``GET /api/audit`` query parameter 객체를 name → param 매핑으로."""
+        operation = TestOpenAPIDateContract._audit_get_operation()
         return {
-            param["name"]: param["schema"]
+            param["name"]: param
             for param in operation.get("parameters", [])
             if param.get("in") == "query"
         }
 
-    def test_from_date_param_has_date_time_format(self) -> None:
+    def test_from_date_param_is_string_type(self) -> None:
         params = self._audit_query_params()
         assert "from_date" in params, (
             f"GET /api/audit에 from_date param이 없음: {sorted(params.keys())}"
         )
-        from_date_schema = params["from_date"]
-        # anyOf 분기 또는 직접 format을 검사한다.
-        formats = self._collect_formats(from_date_schema)
-        assert "date-time" in formats, (
-            f"from_date 스키마에 date-time format이 없음 "
-            f"(contract-drift fix 미반영): {from_date_schema}"
+        types = self._collect_types(params["from_date"]["schema"])
+        assert "string" in types, (
+            f"from_date 스키마에 string type이 없음: {params['from_date']['schema']}"
         )
 
-    def test_to_date_param_has_date_time_format(self) -> None:
+    def test_to_date_param_is_string_type(self) -> None:
         params = self._audit_query_params()
         assert "to_date" in params, (
             f"GET /api/audit에 to_date param이 없음: {sorted(params.keys())}"
         )
-        to_date_schema = params["to_date"]
-        formats = self._collect_formats(to_date_schema)
-        assert "date-time" in formats, (
-            f"to_date 스키마에 date-time format이 없음 "
-            f"(contract-drift fix 미반영): {to_date_schema}"
+        types = self._collect_types(params["to_date"]["schema"])
+        assert "string" in types, (
+            f"to_date 스키마에 string type이 없음: {params['to_date']['schema']}"
+        )
+
+    def test_from_date_description_mentions_iso_8601(self) -> None:
+        """contract drift 방지: description에 ISO 8601 명시 — frontend
+        codegen 산출물이 free-form string으로 노출되지 않도록 한다."""
+        params = self._audit_query_params()
+        description = params["from_date"].get("description", "") or ""
+        assert "ISO 8601" in description, (
+            f"from_date description에 'ISO 8601' 명시가 없음: {description!r}"
+        )
+
+    def test_to_date_description_mentions_iso_8601(self) -> None:
+        params = self._audit_query_params()
+        description = params["to_date"].get("description", "") or ""
+        assert "ISO 8601" in description, (
+            f"to_date description에 'ISO 8601' 명시가 없음: {description!r}"
         )
 
     def test_openapi_lists_422_response(self) -> None:
         """``GET /api/audit`` ``responses``에 422 항목이 있어야 한다.
 
         ``frontend/openapi.json`` codegen 산출물이 422 분기를 인식할 수 있도록
-        contract에 명시한다.
+        contract에 명시한다. 핸들러가 직접 raise한 422도 OpenAPI에 노출된다.
         """
-        app = create_app()
-        schema = app.openapi()
-        operation = schema["paths"]["/api/audit"]["get"]
+        operation = self._audit_get_operation()
         responses = operation.get("responses", {})
         assert "422" in responses, (
             f"GET /api/audit 응답에 422 항목이 없음: {sorted(responses.keys())}"
         )
 
     @staticmethod
-    def _collect_formats(schema: dict) -> set[str]:
-        """``schema`` 트리에서 모든 ``format`` 값을 모아 반환한다.
+    def _collect_types(schema: dict) -> set[str]:
+        """``schema`` 트리에서 모든 ``type`` 값을 모아 반환한다.
 
-        FastAPI는 ``datetime | None``을 ``anyOf: [{type, format}, {null}]``로
+        FastAPI는 ``str | None``을 ``anyOf: [{type: string}, {type: null}]``로
         펼치므로 anyOf branch까지 탐색해야 한다.
         """
-        formats: set[str] = set()
-        if "format" in schema:
-            formats.add(schema["format"])
+        types: set[str] = set()
+        if "type" in schema:
+            types.add(schema["type"])
         for branch in schema.get("anyOf", []) or []:
-            if isinstance(branch, dict) and "format" in branch:
-                formats.add(branch["format"])
-        return formats
+            if isinstance(branch, dict) and "type" in branch:
+                types.add(branch["type"])
+        return types

--- a/tests/unit/test_audit_date_filter.py
+++ b/tests/unit/test_audit_date_filter.py
@@ -1,0 +1,342 @@
+"""``GET /api/audit``의 ``from_date``/``to_date`` ISO 8601 검증 테스트 (issue #1414).
+
+oracle A7 시그니처에서 발견된 contract drift: ``from_date``/``to_date``가
+임의 문자열(예: ``oracle-not-a-date``)을 200으로 수락하고 있었다. 본 PR은
+파라미터 타입을 ``Annotated[datetime | None, Query(...)]``로 좁혀
+FastAPI/Pydantic이 ISO 8601 파싱에 실패하면 422로 거부하도록 한다.
+
+핵심 invariants (Implementation Plan):
+- 인증 누락 + 잘못된 날짜 → 401 (auth-first 우선순위, dependency 순서 회귀 방지).
+- 인증된 master + 잘못된 날짜 → 422 (``AuditLogger.query`` 미호출).
+- 인증된 master + 정상 ISO 8601 datetime → 200 (회귀 보존).
+- 인증된 master + 정상 date-only (``YYYY-MM-DD``) → 200 (FastAPI/Pydantic
+  이 ISO 8601 date 파싱 허용).
+- OpenAPI ``parameters[from_date]``/``parameters[to_date]``는
+  ``format: date-time`` 스키마로 노출되어야 한다 (contract-drift fix 검증).
+
+SSOT: ``docs/specs/web-api/05-resource-endpoints.md`` (audit 라우트는
+"필터: member_id, action, from_date, to_date, limit, offset" — free-form
+허용 명시 없음 → ISO 8601 강제는 spec 위반이 아니다).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402
+
+# ── Member / Session fakes (#1359 / #1352 패턴) ─────────────────────────
+
+
+@dataclass
+class FakeMember:
+    member_id: str
+    type: str = "agent"
+    role: str = "default"
+    org: str = "default"
+    name: str = ""
+    emoji: str = ""
+    status: str = "active"
+    scopes: list[str] = field(default_factory=list)
+
+
+class FakeMemberService:
+    """``test_audit_routes_auth.py`` 패턴을 그대로 재사용한다."""
+
+    def __init__(self) -> None:
+        self._members: dict[str, FakeMember] = {}
+        self._tokens: dict[str, str] = {}
+
+    def add_member(
+        self,
+        member_id: str,
+        token: str = "",
+        role: str = "default",
+        member_type: str = "agent",
+        scopes: list[str] | None = None,
+    ) -> FakeMember:
+        member = FakeMember(
+            member_id=member_id,
+            role=role,
+            type=member_type,
+            scopes=list(scopes) if scopes else [],
+        )
+        self._members[member_id] = member
+        if token:
+            self._tokens[token] = member_id
+        return member
+
+    async def authenticate(self, token: str) -> FakeMember:
+        member_id = self._tokens.get(token)
+        if member_id is None:
+            raise PermissionError("유효하지 않은 토큰")
+        return self._members[member_id]
+
+    async def update_last_active(self, member_id: str) -> None:
+        return None
+
+    async def get(self, member_id: str) -> FakeMember | None:
+        return self._members.get(member_id)
+
+
+# ── audit_logger fake ───────────────────────────────────────────────────
+
+
+def _make_audit_logger() -> AsyncMock:
+    """query/count call_args를 추적할 수 있는 mock audit logger."""
+    mock = AsyncMock()
+    mock.query = AsyncMock(
+        return_value=[
+            {
+                "id": 1,
+                "member_id": "agent-01",
+                "action": "bot.create",
+                "resource": "bot:bot-1",
+                "detail": "",
+                "ip": "127.0.0.1",
+                "created_at": "2026-05-09T00:00:00",
+            }
+        ]
+    )
+    mock.count = AsyncMock(return_value=1)
+    return mock
+
+
+# ── fixtures ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def member_service() -> FakeMemberService:
+    svc = FakeMemberService()
+    svc.add_member(
+        "master-user",
+        token="master-token",
+        role="master",
+        member_type="human",
+    )
+    return svc
+
+
+@pytest.fixture
+def audit_logger() -> AsyncMock:
+    return _make_audit_logger()
+
+
+@pytest.fixture
+def client(
+    member_service: FakeMemberService,
+    audit_logger: AsyncMock,
+) -> TestClient:
+    app = create_app(
+        member_service=member_service,
+        audit_logger=audit_logger,
+    )
+    return TestClient(app)
+
+
+_MASTER_HEADERS = {"Authorization": "Bearer master-token"}
+
+
+# ── 422: 잘못된 날짜 파라미터 (Issue #1414 본문) ──────────────────────
+
+
+class TestInvalidDate422:
+    """파싱 불가능한 ``from_date``/``to_date`` → 422, AuditLogger 미호출."""
+
+    def test_invalid_from_date_returns_422(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        """``GET /api/audit?from_date=oracle-not-a-date`` → 422."""
+        resp = client.get(
+            "/api/audit?from_date=oracle-not-a-date",
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 422, (
+            f"invalid from_date가 422가 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert audit_logger.query.await_count == 0, (
+            "422 차단 시 audit_logger.query가 호출되어선 안 된다"
+        )
+        assert audit_logger.count.await_count == 0
+
+    def test_invalid_to_date_returns_422(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        """``GET /api/audit?to_date=also-not-a-date`` → 422."""
+        resp = client.get(
+            "/api/audit?to_date=also-not-a-date",
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 422, (
+            f"invalid to_date가 422가 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert audit_logger.query.await_count == 0
+        assert audit_logger.count.await_count == 0
+
+    def test_invalid_both_dates_returns_422(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        """``from_date``+``to_date`` 모두 invalid → 422."""
+        resp = client.get(
+            "/api/audit?from_date=oracle-not-a-date&to_date=also-not-a-date",
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 422, (
+            f"양쪽 invalid date가 422가 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert audit_logger.query.await_count == 0
+        assert audit_logger.count.await_count == 0
+
+
+# ── 200: 정상 ISO 8601 회귀 보존 ────────────────────────────────────
+
+
+class TestValidIsoDate200:
+    """정상 ISO 8601 입력은 200으로 통과해야 한다 (회귀)."""
+
+    def test_iso_datetime_returns_200(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        """ISO 8601 datetime (``2026-05-10T00:00:00Z``) → 200."""
+        resp = client.get(
+            "/api/audit?from_date=2026-05-10T00:00:00Z",
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 200, (
+            f"정상 ISO datetime이 200이 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert audit_logger.query.await_count == 1
+        # ``AuditLogger.query`` 시그니처는 str을 유지한다 — 핸들러는
+        # ``datetime.isoformat()``으로 변환해 전달해야 한다.
+        call_kwargs = audit_logger.query.await_args.kwargs
+        assert isinstance(call_kwargs["from_date"], str), (
+            f"from_date가 str로 전달되어야 함: {type(call_kwargs['from_date'])}"
+        )
+        assert "2026-05-10" in call_kwargs["from_date"]
+
+    def test_date_only_returns_200(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        """date-only (``2026-05-10``) → 200 (FastAPI/Pydantic은 date를 datetime
+        으로 자동 변환). 기존 ``frontend/src/api/`` caller가 date-only를 보내는
+        경우 회귀 보존."""
+        resp = client.get(
+            "/api/audit?from_date=2026-05-10",
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 200, (
+            f"date-only가 200이 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert audit_logger.query.await_count == 1
+
+
+# ── 401: auth-first invariant (Issue #1414 본문) ────────────────────
+
+
+class TestAuthFirstWithInvalidDate:
+    """인증 누락 + 잘못된 날짜 → 401 우선 (422 보다 dependency 우선순위 보존).
+
+    FastAPI는 핸들러 매개변수 순서대로 dependency를 해결하므로 ``caller_id``
+    (require_audit_read)가 ``from_date``/``to_date`` Query parsing 보다 먼저
+    실행된다. 인증 정보가 없으면 401이 먼저 반환되어 "auth-first" invariant
+    가 유지된다. 본 테스트는 그 회귀를 막는다.
+    """
+
+    def test_unauth_with_invalid_date_returns_401(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        """unauth + ``from_date=garbage`` → 401, audit_logger 미호출."""
+        resp = client.get("/api/audit?from_date=garbage")
+        assert resp.status_code == 401, (
+            f"unauth + invalid date가 401이 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert audit_logger.query.await_count == 0
+        assert audit_logger.count.await_count == 0
+
+
+# ── OpenAPI 스키마 회귀 (contract-drift fix 검증) ──────────────────
+
+
+class TestOpenAPIDateFormat:
+    """``/openapi.json``의 ``from_date``/``to_date`` 스키마가 ``date-time``
+    포맷으로 노출되어야 한다.
+
+    issue #1414 직전에는 두 파라미터가 free-form ``string``이었다. 본 PR
+    이후에는 FastAPI가 ``Annotated[datetime | None, Query(...)]``를
+    ``{"anyOf": [{"type": "string", "format": "date-time"}, {"type": "null"}]}``
+    로 노출해야 한다. ``frontend/openapi.json`` codegen 산출물이
+    contract 변경을 인식할 수 있도록 명시적으로 검증한다.
+    """
+
+    @staticmethod
+    def _audit_query_params() -> dict[str, dict]:
+        """``GET /api/audit`` 의 query parameter 스키마를 name → schema 매핑으로."""
+        app = create_app()
+        schema = app.openapi()
+        operation = schema["paths"]["/api/audit"]["get"]
+        return {
+            param["name"]: param["schema"]
+            for param in operation.get("parameters", [])
+            if param.get("in") == "query"
+        }
+
+    def test_from_date_param_has_date_time_format(self) -> None:
+        params = self._audit_query_params()
+        assert "from_date" in params, (
+            f"GET /api/audit에 from_date param이 없음: {sorted(params.keys())}"
+        )
+        from_date_schema = params["from_date"]
+        # anyOf 분기 또는 직접 format을 검사한다.
+        formats = self._collect_formats(from_date_schema)
+        assert "date-time" in formats, (
+            f"from_date 스키마에 date-time format이 없음 "
+            f"(contract-drift fix 미반영): {from_date_schema}"
+        )
+
+    def test_to_date_param_has_date_time_format(self) -> None:
+        params = self._audit_query_params()
+        assert "to_date" in params, (
+            f"GET /api/audit에 to_date param이 없음: {sorted(params.keys())}"
+        )
+        to_date_schema = params["to_date"]
+        formats = self._collect_formats(to_date_schema)
+        assert "date-time" in formats, (
+            f"to_date 스키마에 date-time format이 없음 "
+            f"(contract-drift fix 미반영): {to_date_schema}"
+        )
+
+    def test_openapi_lists_422_response(self) -> None:
+        """``GET /api/audit`` ``responses``에 422 항목이 있어야 한다.
+
+        ``frontend/openapi.json`` codegen 산출물이 422 분기를 인식할 수 있도록
+        contract에 명시한다.
+        """
+        app = create_app()
+        schema = app.openapi()
+        operation = schema["paths"]["/api/audit"]["get"]
+        responses = operation.get("responses", {})
+        assert "422" in responses, (
+            f"GET /api/audit 응답에 422 항목이 없음: {sorted(responses.keys())}"
+        )
+
+    @staticmethod
+    def _collect_formats(schema: dict) -> set[str]:
+        """``schema`` 트리에서 모든 ``format`` 값을 모아 반환한다.
+
+        FastAPI는 ``datetime | None``을 ``anyOf: [{type, format}, {null}]``로
+        펼치므로 anyOf branch까지 탐색해야 한다.
+        """
+        formats: set[str] = set()
+        if "format" in schema:
+            formats.add(schema["format"])
+        for branch in schema.get("anyOf", []) or []:
+            if isinstance(branch, dict) and "format" in branch:
+                formats.add(branch["format"])
+        return formats

--- a/tests/unit/test_audit_date_filter.py
+++ b/tests/unit/test_audit_date_filter.py
@@ -5,15 +5,21 @@ oracle A7 시그니처에서 발견된 contract drift: ``from_date``/``to_date``
 핸들러 안에서 ``_validate_iso_date`` 헬퍼로 ISO 8601 파싱 가능성만 검증
 하고, 파싱 실패 시 422로 거부한다.
 
-핵심 invariants (Implementation Plan + Codex r1 finding):
+핵심 invariants (Implementation Plan + Codex r1/r2 findings):
 - 인증 누락 + 잘못된 날짜 → 401 (auth-first 우선순위, dependency 순서 회귀 방지).
 - 인증된 master + 잘못된 날짜 → 422 (``AuditLogger.query`` 미호출).
-- 인증된 master + 정상 ISO 8601 datetime → 200, **원본 str 그대로 전달**.
 - 인증된 master + 정상 date-only (``YYYY-MM-DD``) → 200, **원본 str(10자리)
   그대로 전달** → ``AuditLogger.query`` 내부의 ``T23:59:59`` 자동 확장 분기
   보존. Codex r1 finding: 1차 구현은 Pydantic datetime → ``isoformat()``으로
   변환했고, date-only가 ``"2026-05-10T00:00:00"`` (19자리)로 바뀌어 자정
   이후 데이터를 누락하는 silent semantic regression이 발생했다.
+- 인증된 master + 정상 ISO 8601 datetime (``Z``/offset/naive) → 200, storage
+  format(``%Y-%m-%dT%H:%M:%S``, naive UTC)으로 **정규화** 후 전달. Codex r2
+  finding: ``AuditLogger``는 ``datetime.now(UTC).strftime(...)``로 Z 없는
+  naive 포맷을 저장한다. ``Z``/offset 보존 시 SQL 텍스트 비교
+  (``created_at >= '2026-05-10T00:00:00Z'`` vs storage
+  ``'2026-05-10T00:00:00'``)에서 ASCII ``Z`` > digit이므로 정확히 같은 시각의
+  row가 inclusive lower bound에서 누락되는 silent regression이 발생한다.
 - OpenAPI ``parameters[from_date]``/``parameters[to_date]``는 ``string``
   스키마로 노출되며 description에 ISO 8601 형식을 명시한다.
 
@@ -204,26 +210,89 @@ class TestInvalidDate422:
 
 
 class TestValidIsoDate200:
-    """정상 ISO 8601 입력은 200으로 통과하며 원본 str이 그대로 ``AuditLogger``
-    에 전달되어야 한다 (Codex r1 finding: silent semantic regression 방지)."""
+    """정상 ISO 8601 입력은 200으로 통과하며 ``AuditLogger``로 올바른 형식이
+    전달되어야 한다.
 
-    def test_iso_datetime_returns_200(
+    - date-only(``YYYY-MM-DD``): **원본 str(10자리)** 그대로 전달 → 자동
+      확장 분기 보존(Codex r1 finding).
+    - ISO datetime(``Z``/offset/naive): **storage format
+      (``%Y-%m-%dT%H:%M:%S``, naive UTC)으로 정규화** 후 전달 → inclusive
+      boundary 보존(Codex r2 finding).
+    """
+
+    def test_z_suffix_normalized_to_storage_format(
         self, client: TestClient, audit_logger: AsyncMock
     ) -> None:
-        """ISO 8601 datetime (``2026-05-10T00:00:00Z``) → 200."""
+        """``Z`` suffix는 storage format(Z 제거)으로 정규화되어 전달된다.
+
+        Codex r2 finding 핵심 회귀:
+            ``AuditLogger.log``는
+            ``datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")``로 Z 없는
+            naive 포맷을 저장한다. ``Z``를 그대로 SQL 비교에 넘기면
+            ``'2026-05-10T00:00:00Z' > '2026-05-10T00:00:00'``(ASCII Z > digit)
+            로 평가되어 정확히 같은 시각의 row가 inclusive lower bound에서
+            누락된다. 본 테스트는 ``Z`` suffix가 storage format으로 정규화되어
+            ``AuditLogger.query``에 도달하는지 확인한다.
+        """
         resp = client.get(
             "/api/audit?from_date=2026-05-10T00:00:00Z",
             headers=_MASTER_HEADERS,
         )
         assert resp.status_code == 200, (
-            f"정상 ISO datetime이 200이 아님 ({resp.status_code}: {resp.text})"
+            f"Z suffix datetime이 200이 아님 ({resp.status_code}: {resp.text})"
         )
         assert audit_logger.query.await_count == 1
-        # ``AuditLogger.query`` 시그니처는 str을 유지한다 — 핸들러는 입력
-        # str을 변환 없이 그대로 전달해야 한다.
         call_kwargs = audit_logger.query.await_args.kwargs
-        assert call_kwargs["from_date"] == "2026-05-10T00:00:00Z", (
-            f"ISO datetime str가 변환 없이 그대로 전달되어야 함: "
+        assert call_kwargs["from_date"] == "2026-05-10T00:00:00", (
+            f"Z suffix가 storage format(Z 제거)으로 정규화되어야 함: "
+            f"{call_kwargs['from_date']!r}"
+        )
+        # count에도 동일하게 정규화되어 전달되는지 확인
+        count_kwargs = audit_logger.count.await_args.kwargs
+        assert count_kwargs["from_date"] == "2026-05-10T00:00:00", (
+            f"count에도 Z 제거 정규화 적용되어야 함: {count_kwargs['from_date']!r}"
+        )
+
+    def test_offset_normalized_to_utc(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        """``+HH:MM`` offset이 UTC로 변환되고 timezone-naive로 평탄화된다.
+
+        ``2026-05-10T12:00:00+09:00`` (KST 정오) → UTC 03:00:00 → storage
+        format ``2026-05-10T03:00:00``.
+        """
+        # URL-encoded ``+09:00`` → ``%2B09%3A00``
+        resp = client.get(
+            "/api/audit?from_date=2026-05-10T12:00:00%2B09:00",
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 200, (
+            f"offset datetime이 200이 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert audit_logger.query.await_count == 1
+        call_kwargs = audit_logger.query.await_args.kwargs
+        assert call_kwargs["from_date"] == "2026-05-10T03:00:00", (
+            f"+09:00 offset이 UTC naive로 변환되어야 함 (12:00 KST → 03:00 UTC): "
+            f"{call_kwargs['from_date']!r}"
+        )
+
+    def test_naive_datetime_preserved(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        """timezone 없는 naive datetime은 UTC로 가정하고 그대로 storage format
+        으로 통과한다(이미 19자리 ``%Y-%m-%dT%H:%M:%S``).
+        """
+        resp = client.get(
+            "/api/audit?from_date=2026-05-10T12:34:56",
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 200, (
+            f"naive datetime이 200이 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert audit_logger.query.await_count == 1
+        call_kwargs = audit_logger.query.await_args.kwargs
+        assert call_kwargs["from_date"] == "2026-05-10T12:34:56", (
+            f"naive datetime이 storage format 그대로 전달되어야 함: "
             f"{call_kwargs['from_date']!r}"
         )
 
@@ -262,6 +331,10 @@ class TestValidIsoDate200:
             우회시켰다. 결과적으로 SQL ``created_at <= '2026-05-10T00:00:00'``
             로 좁혀져 자정 이후 데이터를 모두 누락. 본 테스트는 입력 str이
             10자리 그대로 ``AuditLogger.query``에 도달하는지 확인한다.
+
+        Codex r2 finding 보강: date-only 입력에 한해 정규화를 적용하지 않는다.
+        ``len(value) == 10`` 분기 진입을 보존하기 위해 ``_validate_iso_date``는
+        ``date.fromisoformat`` 통과 시 원본을 즉시 반환한다.
         """
         resp = client.get(
             "/api/audit?to_date=2026-05-10",
@@ -287,10 +360,16 @@ class TestValidIsoDate200:
             f"count에도 date-only str 그대로 전달되어야 함: {count_kwargs['to_date']!r}"
         )
 
-    def test_iso_datetime_to_date_preserved(
+    def test_iso_datetime_to_date_normalized(
         self, client: TestClient, audit_logger: AsyncMock
     ) -> None:
-        """ISO datetime ``to_date``도 원본 str 그대로 전달."""
+        """ISO datetime ``to_date``(``Z`` suffix)도 storage format으로 정규화.
+
+        Codex r2 finding 적용: ``Z`` 보존 시 inclusive upper bound도 SQL 텍스트
+        비교에서 어긋난다(저장값보다 항상 크게 평가되어 자정 시각의 row 자체는
+        포함되긴 하나, 동일 시각 비교 일관성이 깨짐). 정규화로 일관된 boundary
+        를 보장한다.
+        """
         resp = client.get(
             "/api/audit?to_date=2026-05-10T12:34:56Z",
             headers=_MASTER_HEADERS,
@@ -299,8 +378,8 @@ class TestValidIsoDate200:
             f"ISO datetime to_date가 200이 아님 ({resp.status_code}: {resp.text})"
         )
         call_kwargs = audit_logger.query.await_args.kwargs
-        assert call_kwargs["to_date"] == "2026-05-10T12:34:56Z", (
-            f"ISO datetime to_date str가 변환 없이 그대로 전달되어야 함: "
+        assert call_kwargs["to_date"] == "2026-05-10T12:34:56", (
+            f"ISO datetime to_date(Z)가 storage format으로 정규화되어야 함: "
             f"{call_kwargs['to_date']!r}"
         )
 

--- a/tests/unit/test_audit_date_filter.py
+++ b/tests/unit/test_audit_date_filter.py
@@ -399,6 +399,81 @@ class TestValidIsoDate200:
         assert call_kwargs["from_date"] == "2026-03-12"
         assert call_kwargs["to_date"] == "2026-03-19"
 
+    def test_compact_iso_date_normalized(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        """비표준 compact ISO date(``20260510``)는 표준 ``YYYY-MM-DD``로 정규화.
+
+        Codex r3 finding 핵심 회귀:
+            Python 3.13의 ``date.fromisoformat()``은 ``20260510`` (no dashes)
+            같은 비표준 ISO date도 수락한다. r2 구현은 검증 통과 시 원본 str
+            (``20260510``, 8자리)을 그대로 반환했으므로 ``AuditLogger.query``의
+            ``len(to_date) == 10`` 자동 확장 분기가 작동하지 않고, SQL
+            ``created_at >= '20260510'`` 텍스트 비교가 ``YYYY-MM-DDT...``
+            저장값과 어긋나는 silent regression을 만든다. 본 테스트는 r3
+            정규화 (``date.isoformat()`` 호출)가 ``2026-05-10`` (10자리 표준
+            형식)으로 변환하여 그 전제를 복원하는지 확인한다.
+        """
+        resp = client.get(
+            "/api/audit?from_date=20260510",
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 200, (
+            f"compact ISO date가 200이 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert audit_logger.query.await_count == 1
+        call_kwargs = audit_logger.query.await_args.kwargs
+        assert call_kwargs["from_date"] == "2026-05-10", (
+            f"compact ISO date가 ``YYYY-MM-DD`` 표준 형식으로 정규화되어야 함: "
+            f"{call_kwargs['from_date']!r}"
+        )
+        # count에도 동일 정규화
+        count_kwargs = audit_logger.count.await_args.kwargs
+        assert count_kwargs["from_date"] == "2026-05-10", (
+            f"count에도 compact ISO date 정규화 적용되어야 함: "
+            f"{count_kwargs['from_date']!r}"
+        )
+
+    def test_iso_week_date_normalized(
+        self, client: TestClient, audit_logger: AsyncMock
+    ) -> None:
+        """ISO week date(``2026-W19-1``)도 표준 ``YYYY-MM-DD``로 정규화.
+
+        Codex r3 finding 보강:
+            Python 3.13은 ``2026-W19-1`` (ISO week date, 10자리이긴 하나 비표준
+            포맷)도 ``date.fromisoformat``로 파싱한다. ``AuditLogger.query``의
+            10자리 길이 분기는 통과하더라도 ``W`` 문자가 SQL 텍스트 비교
+            (``YYYY-MM-DDT...``)와 어긋나는 회귀를 만들 수 있다. 본 테스트는
+            정규화 후 결과가 10자리 ``YYYY-MM-DD`` 형식(``-`` 두 개 포함)임을
+            확인한다.
+        """
+        # ``2026-W19-1`` → ISO week 19 of 2026, Monday → 2026-05-04
+        resp = client.get(
+            "/api/audit?from_date=2026-W19-1",
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 200, (
+            f"ISO week date가 200이 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert audit_logger.query.await_count == 1
+        call_kwargs = audit_logger.query.await_args.kwargs
+        from_date_value = call_kwargs["from_date"]
+        # 길이 / dash 개수 invariant 검증 — AuditLogger.query의 ``len == 10``
+        # 분기와 ``YYYY-MM-DDT...`` 텍스트 비교 전제 보존.
+        assert len(from_date_value) == 10, (
+            f"정규화된 from_date 길이가 10이어야 함 (자동 확장 분기 진입 가능): "
+            f"len={len(from_date_value)}, value={from_date_value!r}"
+        )
+        assert from_date_value.count("-") == 2, (
+            f"정규화된 from_date에 ``-`` 두 개가 있어야 표준 ``YYYY-MM-DD``: "
+            f"{from_date_value!r}"
+        )
+        # isocalendar 기준 명시 — ISO week 19 of 2026의 Monday는 2026-05-04
+        assert from_date_value == "2026-05-04", (
+            f"2026-W19-1 → 2026-05-04 (ISO week 19 Monday)로 정규화되어야 함: "
+            f"{from_date_value!r}"
+        )
+
 
 # ── 401: auth-first invariant (Issue #1414 본문) ────────────────────
 


### PR DESCRIPTION
Closes #1414

## Summary
- `GET /api/audit`의 `from_date`/`to_date` 쿼리 파라미터를 ISO 8601로 검증. 임의 문자열(예: `oracle-not-a-date`)은 422로 거부.
- `_validate_iso_date` helper로 (a) `YYYY-MM-DD` date를 표준 형식으로 정규화 (Python 3.13의 `20260510`/ISO week date도 정규화), (b) ISO datetime을 storage format(`%Y-%m-%dT%H:%M:%S`, naive UTC)으로 정규화하여 SQL 텍스트 비교 boundary 보존.
- `AuditLogger.query`/`count` 시그니처는 변경 없음 (str 유지). date-only 입력의 `to_date` 하루 끝 확장 동작 보존.
- OpenAPI에 422 응답 추가, frontend openapi.json + types 재생성.

## Test Plan
- [x] `pytest tests/unit/test_audit_date_filter.py -v` — 18 passed (신규 회귀 테스트 포함)
- [x] `pytest tests/unit -k audit -v` — 98 passed (회귀 없음)
- [x] `ruff check` / `ruff format --check` PASS
- [x] `cd frontend && npm run generate-types && check-api-types && build` PASS
- [x] `/codex:review --base main` r4 PASS (r1~r3 review에서 date-only semantic, Z/offset normalize, compact ISO date normalize 모두 해소)

## Codex Branch Review 이력
- r1 FAIL: date-only 호환성 silent regression → str 보존 + 핸들러 직접 검증
- r2 FAIL: Z/offset datetime 정규화 누락 → \`_normalize_iso_datetime\` 추가
- r3 FAIL: Python 3.13 비표준 ISO date 정규화 누락 → \`parsed.isoformat()\` 반환
- r4 **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)