### PR TITLE
fix(cli): enforce ReportSubmitRequest invariant on CLI submit + StrategyReport store guard (#1415)

### DIFF
--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -52,7 +52,25 @@ def submit(
     resolved_db_path = db_path or get_db_path(ctx)
 
     with open(json_path) as f:
-        report_data = json.load(f)
+        try:
+            raw_data = json.load(f)
+        except json.JSONDecodeError as exc:
+            fmt.error(f"Invalid JSON: {exc}", code="REPORT_VALIDATION_ERROR")
+            raise SystemExit(1) from exc
+
+    # ── #1415 codex r1 P3: non-object JSON 거부 ─────────────────────────
+    # 파일이 JSON object가 아닌 array/string/number/bool/null이면 아래
+    # ``report_data.pop(...)``/``report_data.get(...)`` 호출이 ``TypeError``/
+    # ``AttributeError``로 raise되어 의도한 ``REPORT_VALIDATION_ERROR`` 구조화
+    # 응답을 우회한다. 명시적으로 dict 검증 후 구조화된 exit 1을 반환한다.
+    if not isinstance(raw_data, dict):
+        fmt.error(
+            f"Report file must be a JSON object, got {type(raw_data).__name__}",
+            code="REPORT_VALIDATION_ERROR",
+        )
+        raise SystemExit(1)
+
+    report_data: dict = dict(raw_data)
 
     # --run 옵션으로 백테스트 run 참조 추가
     if run_id:

--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -6,9 +6,11 @@ import asyncio
 import json
 
 import click
+from pydantic import ValidationError
 
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
+from ante.web.schemas import ReportSubmitRequest
 
 
 @click.group()
@@ -56,6 +58,29 @@ def submit(
     if run_id:
         report_data["backtest_run_id"] = run_id
 
+    # ── #1415: Web API와 동일한 ReportSubmitRequest 검증 ────────────────
+    # SSOT: ``src/ante/web/schemas.py::ReportSubmitRequest``.
+    #
+    # CLI 입력은 Web API와 같은 invariant를 통과해야 한다:
+    # - ``total_trades >= 0``, ``win_rate ∈ [0.0, 100.0]``, metric finite
+    # - ``extra='forbid'`` — 미지정 키는 오타로 간주하여 거부
+    #
+    # CLI 전용 extras 처리:
+    # - ``submitted_by``는 모델 외부 필드 (CLI에서 분리 후 StrategyReport에 주입)
+    # - ``backtest_run_id``는 모델 외부 (run_id 참조용, store 컬럼 아님)
+    # - ``detail_json``이 dict로 들어오면 직렬화 (모델은 str 요구)
+    submitted_by = report_data.pop("submitted_by", "agent")
+    report_data.pop("backtest_run_id", None)  # --run 옵션 결과는 모델 검증 대상 아님
+    raw_detail = report_data.get("detail_json")
+    if isinstance(raw_detail, dict):
+        report_data["detail_json"] = json.dumps(raw_detail)
+
+    try:
+        validated = ReportSubmitRequest.model_validate(report_data)
+    except ValidationError as exc:
+        fmt.error(str(exc), code="REPORT_VALIDATION_ERROR")
+        raise SystemExit(1) from exc
+
     async def _submit() -> dict:
         from ante.core.database import Database
 
@@ -76,7 +101,7 @@ def submit(
             store = ReportStore(db)
             await store.initialize()
 
-            # StrategyReport 생성
+            # StrategyReport 생성 (validated 필드 기준)
             from datetime import UTC, datetime
             from uuid import uuid4
 
@@ -84,23 +109,23 @@ def submit(
 
             report_obj = StrategyReport(
                 report_id=str(uuid4()),
-                strategy_name=report_data["strategy_name"],
-                strategy_version=report_data["strategy_version"],
-                strategy_path=report_data.get("strategy_path", ""),
+                strategy_name=validated.strategy_name,
+                strategy_version=validated.strategy_version,
+                strategy_path=validated.strategy_path,
                 status=ReportStatus.SUBMITTED,
                 submitted_at=datetime.now(tz=UTC),
-                submitted_by=report_data.get("submitted_by", "agent"),
-                backtest_period=report_data.get("backtest_period", ""),
-                total_return_pct=float(report_data.get("total_return_pct", 0)),
-                total_trades=int(report_data.get("total_trades", 0)),
-                sharpe_ratio=report_data.get("sharpe_ratio"),
-                max_drawdown_pct=report_data.get("max_drawdown_pct"),
-                win_rate=report_data.get("win_rate"),
-                summary=report_data.get("summary", ""),
-                rationale=report_data.get("rationale", ""),
-                risks=report_data.get("risks", ""),
-                recommendations=report_data.get("recommendations", ""),
-                detail_json=json.dumps(report_data.get("detail_json", {})),
+                submitted_by=submitted_by,
+                backtest_period=validated.backtest_period,
+                total_return_pct=validated.total_return_pct,
+                total_trades=validated.total_trades,
+                sharpe_ratio=validated.sharpe_ratio,
+                max_drawdown_pct=validated.max_drawdown_pct,
+                win_rate=validated.win_rate,
+                summary=validated.summary,
+                rationale=validated.rationale,
+                risks=validated.risks,
+                recommendations=validated.recommendations,
+                detail_json=validated.detail_json,
             )
 
             report_id = await store.submit(report_obj)

--- a/src/ante/report/models.py
+++ b/src/ante/report/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
@@ -50,6 +51,32 @@ class StrategyReport:
     # 사용자 피드백
     user_notes: str = ""
     reviewed_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        """metric invariant 가드 (defense in depth, #1415).
+
+        SSOT는 ``src/ante/web/schemas.py::ReportSubmitRequest`` (Web API 입력 검증)다.
+        본 가드는 CLI/내부 호출자 경유 invalid 값이 DB까지 흘러가지 않도록 차단한다.
+
+        invariants:
+        - ``total_trades >= 0`` (거래 수는 음수 불가).
+        - ``win_rate``는 ``[0.0, 100.0]`` percent 단위 또는 ``None``.
+        - ``total_return_pct``/``sharpe_ratio``/``max_drawdown_pct``/``win_rate``는
+          finite (NaN/Inf 금지).
+        """
+        if self.total_trades < 0:
+            raise ValueError(f"total_trades must be >= 0 (got {self.total_trades})")
+        if self.win_rate is not None and not (0.0 <= self.win_rate <= 100.0):
+            raise ValueError(f"win_rate must be in [0.0, 100.0] (got {self.win_rate})")
+        for name in (
+            "total_return_pct",
+            "sharpe_ratio",
+            "max_drawdown_pct",
+            "win_rate",
+        ):
+            v = getattr(self, name)
+            if v is not None and not math.isfinite(v):
+                raise ValueError(f"{name} must be finite (got {v!r})")
 
     def get_equity_curve(self) -> list[dict]:
         """detail_json에서 자산 곡선 데이터를 추출.

--- a/src/ante/report/models.py
+++ b/src/ante/report/models.py
@@ -19,9 +19,57 @@ class ReportStatus(StrEnum):
     ARCHIVED = "archived"
 
 
+def validate_strategy_report_metrics(
+    total_trades: int,
+    win_rate: float | None,
+    total_return_pct: float | None,
+    sharpe_ratio: float | None,
+    max_drawdown_pct: float | None,
+) -> None:
+    """``StrategyReport`` metric invariant 명시 검증 (#1415).
+
+    저장 경로 (CLI submit, Web API submit 등 새 값을 DB에 쓰는 경계)에서만 호출한다.
+    DB read path (``ReportStore._row_to_report``)는 **legacy invalid row**를 허용하기
+    위해 호출하지 않는다 — 그렇지 않으면 이 PR 이전에 저장된 invalid row가 존재할 때
+    list/detail 조회가 ``ValueError``로 fail해 사용자가 정리할 수 없다 (codex r1 P2).
+
+    SSOT:
+    - ``src/ante/web/schemas.py::ReportSubmitRequest`` — Web API 입력 검증 SSOT.
+
+    invariants:
+    - ``total_trades >= 0`` (거래 수는 음수 불가).
+    - ``win_rate``는 ``[0.0, 100.0]`` percent 단위 또는 ``None``.
+    - ``total_return_pct``/``sharpe_ratio``/``max_drawdown_pct``/``win_rate``는
+      finite (NaN/Inf 금지).
+
+    Raises:
+        ValueError: invariant 위반 시.
+    """
+    if total_trades < 0:
+        raise ValueError(f"total_trades must be >= 0 (got {total_trades})")
+    if win_rate is not None and not (0.0 <= win_rate <= 100.0):
+        raise ValueError(f"win_rate must be in [0.0, 100.0] (got {win_rate})")
+    for name, v in (
+        ("total_return_pct", total_return_pct),
+        ("sharpe_ratio", sharpe_ratio),
+        ("max_drawdown_pct", max_drawdown_pct),
+        ("win_rate", win_rate),
+    ):
+        if v is not None and not math.isfinite(v):
+            raise ValueError(f"{name} must be finite (got {v!r})")
+
+
 @dataclass
 class StrategyReport:
-    """전략 검증 리포트."""
+    """전략 검증 리포트.
+
+    note:
+        metric invariant 검증은 ``validate_strategy_report_metrics`` 함수로 분리되어
+        있다 (#1415 codex r1). dataclass ``__post_init__`` 검증을 두지 않는 이유는
+        ``ReportStore._row_to_report``의 DB read path가 legacy invalid row를 재구성할
+        때 raise되면 사용자가 list/detail 조회로 잘못된 row를 확인하거나 정리할 길이
+        없어지기 때문이다. 저장 경계 (CLI/Web submit)에서 명시 검증을 수행한다.
+    """
 
     report_id: str
     strategy_name: str
@@ -51,32 +99,6 @@ class StrategyReport:
     # 사용자 피드백
     user_notes: str = ""
     reviewed_at: datetime | None = None
-
-    def __post_init__(self) -> None:
-        """metric invariant 가드 (defense in depth, #1415).
-
-        SSOT는 ``src/ante/web/schemas.py::ReportSubmitRequest`` (Web API 입력 검증)다.
-        본 가드는 CLI/내부 호출자 경유 invalid 값이 DB까지 흘러가지 않도록 차단한다.
-
-        invariants:
-        - ``total_trades >= 0`` (거래 수는 음수 불가).
-        - ``win_rate``는 ``[0.0, 100.0]`` percent 단위 또는 ``None``.
-        - ``total_return_pct``/``sharpe_ratio``/``max_drawdown_pct``/``win_rate``는
-          finite (NaN/Inf 금지).
-        """
-        if self.total_trades < 0:
-            raise ValueError(f"total_trades must be >= 0 (got {self.total_trades})")
-        if self.win_rate is not None and not (0.0 <= self.win_rate <= 100.0):
-            raise ValueError(f"win_rate must be in [0.0, 100.0] (got {self.win_rate})")
-        for name in (
-            "total_return_pct",
-            "sharpe_ratio",
-            "max_drawdown_pct",
-            "win_rate",
-        ):
-            v = getattr(self, name)
-            if v is not None and not math.isfinite(v):
-                raise ValueError(f"{name} must be finite (got {v!r})")
 
     def get_equity_curve(self) -> list[dict]:
         """detail_json에서 자산 곡선 데이터를 추출.

--- a/src/ante/report/store.py
+++ b/src/ante/report/store.py
@@ -6,7 +6,11 @@ import logging
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from ante.report.models import ReportStatus, StrategyReport
+from ante.report.models import (
+    ReportStatus,
+    StrategyReport,
+    validate_strategy_report_metrics,
+)
 
 if TYPE_CHECKING:
     from ante.core.database import Database
@@ -55,7 +59,18 @@ class ReportStore:
         logger.info("ReportStore 초기화 완료")
 
     async def submit(self, report: StrategyReport) -> str:
-        """리포트 제출."""
+        """리포트 제출.
+
+        save boundary guard (#1415 codex r3): metric invariant 위반 시 ``ValueError``.
+        read path (``_row_to_report``)는 legacy invalid row 호환을 위해 우회한다.
+        """
+        validate_strategy_report_metrics(
+            report.total_trades,
+            report.win_rate,
+            report.total_return_pct,
+            report.sharpe_ratio,
+            report.max_drawdown_pct,
+        )
         await self._db.execute(
             """INSERT INTO reports
                (report_id, strategy_name, strategy_version,
@@ -100,7 +115,17 @@ class ReportStore:
 
         동일 strategy_name의 기존 DRAFT가 있으면 덮어쓰고,
         없으면 새로 삽입한다.
+
+        save boundary guard (#1415 codex r3): metric invariant 위반 시 ``ValueError``.
+        read path (``_row_to_report``)는 legacy invalid row 호환을 위해 우회한다.
         """
+        validate_strategy_report_metrics(
+            report.total_trades,
+            report.win_rate,
+            report.total_return_pct,
+            report.sharpe_ratio,
+            report.max_drawdown_pct,
+        )
         existing = await self._db.fetch_one(
             "SELECT report_id FROM reports WHERE strategy_name = ? AND status = ?",
             (report.strategy_name, ReportStatus.DRAFT.value),

--- a/tests/unit/test_cli_report_submit_invariant.py
+++ b/tests/unit/test_cli_report_submit_invariant.py
@@ -1,0 +1,251 @@
+"""ante report submit CLI invariant 회귀 테스트 (#1415).
+
+Web API ``POST /api/reports``는 ``ReportSubmitRequest`` (SSOT)로 invalid
+metric을 422로 거부하지만, 이전까지 ``ante report submit`` CLI는 동일 invariant를
+적용하지 않고 exit 0으로 통과시켜 ReportStore에 invalid 값을 저장했다.
+
+본 모듈은 CLI도 Web API와 동일한 invariants를 통과해야 함을 회귀 검증한다:
+- ``total_trades >= 0``
+- ``win_rate ∈ [0.0, 100.0]`` (percent 단위, ``None`` 허용)
+- 4개 metric (``total_return_pct``, ``sharpe_ratio``, ``max_drawdown_pct``,
+  ``win_rate``)은 finite (NaN/Inf 거부)
+- ``extra='forbid'`` — 미지정 키 거부
+
+SSOT:
+- ``docs/specs/report-store/report-store.md``
+- ``src/ante/web/schemas.py::ReportSubmitRequest``
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """auth bypass가 적용된 CliRunner.
+
+    ``ante.cli.main.authenticate_member`` 패치로 root group의 인증 검사를
+    우회한다 (테스트 픽스처 표준 패턴).
+    """
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _base_payload(**overrides: Any) -> dict[str, Any]:
+    """``ReportSubmitRequest`` 통과 가능한 최소 payload."""
+    payload: dict[str, Any] = {
+        "strategy_name": "cli_probe",
+        "strategy_version": "0.1.0",
+        "strategy_path": "strategies/cli_probe.py",
+        "backtest_period": "2024-01 ~ 2026-03",
+        "total_return_pct": 0.0,
+        "total_trades": 0,
+        "summary": "cli invariant probe",
+        "rationale": "CLI invariant 검증",
+        "detail_json": "{}",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_payload(tmp_path, payload: dict[str, Any]) -> str:
+    """payload를 JSON 파일로 직렬화하여 경로를 반환."""
+    p = tmp_path / "report.json"
+    p.write_text(json.dumps(payload))
+    return str(p)
+
+
+def _invoke_submit(runner: CliRunner, tmp_path, json_path: str) -> Any:
+    """``ante --format json report submit`` 호출."""
+    db_path = str(tmp_path / "test.db")
+    return runner.invoke(
+        cli,
+        ["--format", "json", "report", "submit", json_path, "--db-path", db_path],
+    )
+
+
+# ── total_trades invariant ──────────────────────────────────
+
+
+class TestTotalTradesInvariant:
+    def test_negative_total_trades_rejected(self, runner, tmp_path) -> None:
+        """``total_trades=-1`` → exit 1 + structured JSON error."""
+        path = _write_payload(tmp_path, _base_payload(total_trades=-1))
+        result = _invoke_submit(runner, tmp_path, path)
+
+        assert result.exit_code == 1, result.output
+        body = json.loads(result.output)
+        assert body["status"] == "error"
+        assert body["code"] == "REPORT_VALIDATION_ERROR"
+        assert "total_trades" in body["message"]
+
+    def test_zero_total_trades_accepted(self, runner, tmp_path) -> None:
+        """``total_trades=0`` (default)는 정상 처리."""
+        path = _write_payload(tmp_path, _base_payload(total_trades=0))
+        result = _invoke_submit(runner, tmp_path, path)
+        assert result.exit_code == 0, result.output
+
+
+# ── win_rate invariant ──────────────────────────────────────
+
+
+class TestWinRateInvariant:
+    def test_win_rate_above_100_rejected(self, runner, tmp_path) -> None:
+        """``win_rate=101.0`` → exit 1."""
+        path = _write_payload(tmp_path, _base_payload(win_rate=101.0))
+        result = _invoke_submit(runner, tmp_path, path)
+
+        assert result.exit_code == 1, result.output
+        body = json.loads(result.output)
+        assert body["status"] == "error"
+        assert body["code"] == "REPORT_VALIDATION_ERROR"
+        assert "win_rate" in body["message"]
+
+    def test_win_rate_negative_rejected(self, runner, tmp_path) -> None:
+        """``win_rate=-0.1`` → exit 1."""
+        path = _write_payload(tmp_path, _base_payload(win_rate=-0.1))
+        result = _invoke_submit(runner, tmp_path, path)
+        assert result.exit_code == 1, result.output
+        body = json.loads(result.output)
+        assert body["code"] == "REPORT_VALIDATION_ERROR"
+
+    @pytest.mark.parametrize("value", [0.0, 1.5, 50.0, 58.0, 100.0])
+    def test_win_rate_in_range_accepted(self, runner, tmp_path, value: float) -> None:
+        """percent 단위 [0.0, 100.0] 범위 내 값은 정상."""
+        path = _write_payload(tmp_path, _base_payload(win_rate=value))
+        result = _invoke_submit(runner, tmp_path, path)
+        assert result.exit_code == 0, result.output
+
+    def test_win_rate_null_accepted(self, runner, tmp_path) -> None:
+        """``win_rate=null``은 옵션 필드."""
+        path = _write_payload(tmp_path, _base_payload(win_rate=None))
+        result = _invoke_submit(runner, tmp_path, path)
+        assert result.exit_code == 0, result.output
+
+
+# ── finite invariant (NaN/Inf 거부) ────────────────────────
+
+
+class TestFiniteInvariant:
+    """4개 metric 필드 NaN/Inf 거부.
+
+    Python json 모듈은 ``allow_nan=True`` 기본으로 ``NaN``/``Infinity`` 토큰을
+    출력한다. CLI는 file을 ``json.load``로 읽으므로 file에 NaN/Infinity 토큰을
+    그대로 써두면 Python이 ``float('nan')``/``float('inf')``로 파싱하고
+    ``ReportSubmitRequest`` (``allow_inf_nan=False``)에서 거부된다.
+    """
+
+    @pytest.mark.parametrize(
+        "field",
+        ["total_return_pct", "sharpe_ratio", "max_drawdown_pct", "win_rate"],
+    )
+    @pytest.mark.parametrize("token", ["NaN", "Infinity", "-Infinity"])
+    def test_non_finite_rejected(
+        self, runner, tmp_path, field: str, token: str
+    ) -> None:
+        # JSON file에 비표준 NaN/Inf 토큰을 raw하게 주입한다.
+        payload = _base_payload()
+        payload[field] = 0.0  # placeholder
+        body = json.dumps(payload)
+        body = body.replace(f'"{field}": 0.0', f'"{field}": {token}', 1)
+        p = tmp_path / "report.json"
+        p.write_text(body)
+
+        result = _invoke_submit(runner, tmp_path, str(p))
+        assert result.exit_code == 1, (
+            f"{field}={token} 은 exit 1로 거부되어야 함: {result.output}"
+        )
+        parsed = json.loads(result.output)
+        assert parsed["code"] == "REPORT_VALIDATION_ERROR"
+
+
+# ── extra='forbid' ──────────────────────────────────────────
+
+
+class TestExtraForbid:
+    def test_unknown_key_rejected(self, runner, tmp_path) -> None:
+        """미지정 키(``foo``)는 ``extra='forbid'``로 거부."""
+        path = _write_payload(tmp_path, _base_payload(foo="bar"))
+        result = _invoke_submit(runner, tmp_path, path)
+        assert result.exit_code == 1, result.output
+        body = json.loads(result.output)
+        assert body["code"] == "REPORT_VALIDATION_ERROR"
+
+
+# ── CLI extras (submitted_by, backtest_run_id) ──────────────
+
+
+class TestCliExtras:
+    def test_submitted_by_extracted_before_validation(self, runner, tmp_path) -> None:
+        """``submitted_by``는 모델 외부 필드 — extra='forbid'에 걸리지 않는다."""
+        payload = _base_payload(submitted_by="cli-user-1")
+        path = _write_payload(tmp_path, payload)
+        result = _invoke_submit(runner, tmp_path, path)
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert body["status"] == "ok"
+
+    def test_detail_json_dict_normalized(self, runner, tmp_path) -> None:
+        """``detail_json``이 dict로 들어오면 직렬화 후 검증 통과."""
+        payload = _base_payload()
+        payload["detail_json"] = {
+            "equity_curve": [{"date": "2025-01-01", "value": 100}]
+        }
+        path = _write_payload(tmp_path, payload)
+        result = _invoke_submit(runner, tmp_path, path)
+        assert result.exit_code == 0, result.output
+
+
+# ── 정상 케이스 회귀 ───────────────────────────────────────
+
+
+class TestHappyPath:
+    def test_full_valid_payload(self, runner, tmp_path) -> None:
+        """정상 케이스 회귀: total_trades=10, win_rate=58.0, dict detail_json."""
+        payload = _base_payload(
+            total_trades=10,
+            win_rate=58.0,
+            total_return_pct=12.5,
+            sharpe_ratio=1.4,
+            max_drawdown_pct=-5.2,
+        )
+        # dict 입력 후 normalize 경로
+        payload["detail_json"] = {"k": 1}
+        path = _write_payload(tmp_path, payload)
+        result = _invoke_submit(runner, tmp_path, path)
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert body["status"] == "ok"
+        assert body["data"]["strategy"] == "cli_probe"

--- a/tests/unit/test_cli_report_submit_invariant.py
+++ b/tests/unit/test_cli_report_submit_invariant.py
@@ -249,3 +249,83 @@ class TestHappyPath:
         body = json.loads(result.output)
         assert body["status"] == "ok"
         assert body["data"]["strategy"] == "cli_probe"
+
+
+# ── non-object JSON shape (codex r1 P3) ─────────────────────
+
+
+class TestNonObjectJsonReturnsValidationError:
+    """codex r1 P3: 파일이 JSON object가 아니면 구조화된 REPORT_VALIDATION_ERROR로 거부.
+
+    이전 구현은 ``report_data.pop(...)``/``report_data.get(...)`` 호출이
+    ``AttributeError``/``TypeError``로 raise되어 의도한 구조화 응답을 우회했다.
+    """
+
+    def test_json_array_rejected(self, runner, tmp_path) -> None:
+        """JSON 배열은 dict가 아니므로 거부."""
+        p = tmp_path / "report.json"
+        p.write_text("[1, 2, 3]")
+        db_path = str(tmp_path / "test.db")
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "report", "submit", str(p), "--db-path", db_path],
+        )
+        assert result.exit_code == 1, result.output
+        body = json.loads(result.output)
+        assert body["status"] == "error"
+        assert body["code"] == "REPORT_VALIDATION_ERROR"
+        assert "JSON object" in body["message"] or "object" in body["message"]
+
+    def test_json_string_rejected(self, runner, tmp_path) -> None:
+        """JSON string은 dict가 아니므로 거부."""
+        p = tmp_path / "report.json"
+        p.write_text('"just a string"')
+        db_path = str(tmp_path / "test.db")
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "report", "submit", str(p), "--db-path", db_path],
+        )
+        assert result.exit_code == 1, result.output
+        body = json.loads(result.output)
+        assert body["status"] == "error"
+        assert body["code"] == "REPORT_VALIDATION_ERROR"
+
+    def test_json_number_rejected(self, runner, tmp_path) -> None:
+        """JSON number는 dict가 아니므로 거부."""
+        p = tmp_path / "report.json"
+        p.write_text("42")
+        db_path = str(tmp_path / "test.db")
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "report", "submit", str(p), "--db-path", db_path],
+        )
+        assert result.exit_code == 1, result.output
+        body = json.loads(result.output)
+        assert body["code"] == "REPORT_VALIDATION_ERROR"
+
+    def test_json_null_rejected(self, runner, tmp_path) -> None:
+        """JSON null은 dict가 아니므로 거부."""
+        p = tmp_path / "report.json"
+        p.write_text("null")
+        db_path = str(tmp_path / "test.db")
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "report", "submit", str(p), "--db-path", db_path],
+        )
+        assert result.exit_code == 1, result.output
+        body = json.loads(result.output)
+        assert body["code"] == "REPORT_VALIDATION_ERROR"
+
+    def test_malformed_json_rejected(self, runner, tmp_path) -> None:
+        """파싱 불가능한 JSON 텍스트도 REPORT_VALIDATION_ERROR로 거부."""
+        p = tmp_path / "report.json"
+        p.write_text("{not valid json,,")
+        db_path = str(tmp_path / "test.db")
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "report", "submit", str(p), "--db-path", db_path],
+        )
+        assert result.exit_code == 1, result.output
+        body = json.loads(result.output)
+        assert body["code"] == "REPORT_VALIDATION_ERROR"
+        assert "Invalid JSON" in body["message"]

--- a/tests/unit/test_strategy_report_invariant.py
+++ b/tests/unit/test_strategy_report_invariant.py
@@ -1,0 +1,204 @@
+"""``StrategyReport`` dataclass invariant 가드 단위 테스트 (#1415).
+
+``StrategyReport.__post_init__``는 defense-in-depth 가드로, CLI/Web API/내부
+호출자를 통해 들어오는 invalid 값이 ReportStore까지 흘러가는 것을 차단한다.
+
+SSOT:
+- ``src/ante/web/schemas.py::ReportSubmitRequest`` — 입력 검증 SSOT
+- ``src/ante/report/models.py::StrategyReport`` — dataclass guard (본 모듈)
+
+검증 대상 invariants:
+- ``total_trades >= 0``
+- ``win_rate ∈ [0.0, 100.0]`` 또는 ``None``
+- ``total_return_pct``/``sharpe_ratio``/``max_drawdown_pct``/``win_rate``는 finite
+
+또한 ``ReportStore._row_to_report``가 정상 DB row를 회귀 통과시키는지 검증해
+**legacy DB row 재구성 회귀**를 보호한다.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from ante.core.database import Database
+from ante.report.models import ReportStatus, StrategyReport
+from ante.report.store import ReportStore
+
+
+def _kwargs(**overrides) -> dict:
+    """invariant 통과 가능한 최소 dataclass kwargs."""
+    base = {
+        "report_id": "rpt-invariant",
+        "strategy_name": "invariant_probe",
+        "strategy_version": "0.1.0",
+        "strategy_path": "strategies/probe.py",
+        "status": ReportStatus.SUBMITTED,
+        "submitted_at": datetime.now(tz=UTC),
+    }
+    base.update(overrides)
+    return base
+
+
+# ── total_trades ────────────────────────────────────────────
+
+
+class TestTotalTradesGuard:
+    def test_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="total_trades"):
+            StrategyReport(**_kwargs(total_trades=-1))
+
+    @pytest.mark.parametrize("value", [0, 1, 100])
+    def test_non_negative_ok(self, value: int) -> None:
+        # raises 없으면 통과
+        StrategyReport(**_kwargs(total_trades=value))
+
+
+# ── win_rate ────────────────────────────────────────────────
+
+
+class TestWinRateGuard:
+    def test_above_100_raises(self) -> None:
+        with pytest.raises(ValueError, match="win_rate"):
+            StrategyReport(**_kwargs(win_rate=101.0))
+
+    def test_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="win_rate"):
+            StrategyReport(**_kwargs(win_rate=-0.1))
+
+    @pytest.mark.parametrize("value", [0.0, 0.58, 50.0, 58.0, 100.0])
+    def test_in_range_ok(self, value: float) -> None:
+        StrategyReport(**_kwargs(win_rate=value))
+
+    def test_none_ok(self) -> None:
+        StrategyReport(**_kwargs(win_rate=None))
+
+
+# ── finite invariant ────────────────────────────────────────
+
+
+class TestFiniteGuard:
+    @pytest.mark.parametrize(
+        "field",
+        ["total_return_pct", "sharpe_ratio", "max_drawdown_pct"],
+    )
+    def test_nan_raises(self, field: str) -> None:
+        with pytest.raises(ValueError, match=f"{field}.*finite"):
+            StrategyReport(**_kwargs(**{field: float("nan")}))
+
+    @pytest.mark.parametrize(
+        "field",
+        ["total_return_pct", "sharpe_ratio", "max_drawdown_pct"],
+    )
+    def test_inf_raises(self, field: str) -> None:
+        with pytest.raises(ValueError, match=f"{field}.*finite"):
+            StrategyReport(**_kwargs(**{field: float("inf")}))
+
+    def test_win_rate_nan_raises(self) -> None:
+        # win_rate은 range 가드가 먼저 발동 (NaN은 [0, 100] 비교에서 False가 되어
+        # range 에러로 raise). 두 가드 중 하나라도 차단하면 됨.
+        with pytest.raises(ValueError):
+            StrategyReport(**_kwargs(win_rate=float("nan")))
+
+
+# ── 정상 default 회귀 (draft.py 호환성) ─────────────────────
+
+
+class TestDefaults:
+    def test_minimal_defaults_ok(self) -> None:
+        """``draft.py``의 ``generate_draft``가 default(0, None)로 생성하는 경로 보존."""
+        # 모든 metric None/0 default
+        report = StrategyReport(
+            report_id="rpt-default",
+            strategy_name="default_probe",
+            strategy_version="0.0.0",
+            strategy_path="",
+            status=ReportStatus.DRAFT,
+            submitted_at=datetime.now(tz=UTC),
+        )
+        assert report.total_trades == 0
+        assert report.total_return_pct == 0.0
+        assert report.sharpe_ratio is None
+        assert report.max_drawdown_pct is None
+        assert report.win_rate is None
+
+
+# ── ReportStore._row_to_report 회귀 (legacy DB row 보존) ────
+
+
+class TestRowToReportRegression:
+    """``_row_to_report``가 정상 row를 그대로 재구성하는지 검증.
+
+    ``StrategyReport.__post_init__`` 가드가 추가됨으로써 legacy DB row 로딩 시
+    raise가 발생할 가능성을 회귀 검증한다. 새 DB에서는 invalid 값이 저장될 입구가
+    없으므로 (CLI: #1415로 닫힘, Web API: 이미 닫힘, draft.py: default 통과)
+    정상 row는 그대로 통과해야 한다.
+    """
+
+    @pytest.fixture
+    async def db(self, tmp_path):
+        database = Database(str(tmp_path / "test.db"))
+        await database.connect()
+        yield database
+        await database.close()
+
+    @pytest.fixture
+    async def store(self, db):
+        s = ReportStore(db)
+        await s.initialize()
+        return s
+
+    async def test_round_trip_preserves_valid_row(self, store) -> None:
+        """정상 값을 submit한 뒤 get으로 재구성해도 가드를 통과해야 함."""
+        original = StrategyReport(
+            report_id="rpt-round-trip",
+            strategy_name="round_trip",
+            strategy_version="1.0.0",
+            strategy_path="strategies/rt.py",
+            status=ReportStatus.SUBMITTED,
+            submitted_at=datetime.now(tz=UTC),
+            submitted_by="agent",
+            backtest_period="2024-01 ~ 2026-03",
+            total_return_pct=15.3,
+            total_trades=42,
+            sharpe_ratio=1.2,
+            max_drawdown_pct=-8.5,
+            win_rate=58.0,
+            summary="round trip",
+            rationale="invariant 회귀",
+            risks="",
+            recommendations="",
+            detail_json='{"equity_curve": []}',
+        )
+        await store.submit(original)
+        fetched = await store.get("rpt-round-trip")
+
+        assert fetched is not None
+        assert fetched.report_id == "rpt-round-trip"
+        assert fetched.total_trades == 42
+        assert fetched.win_rate == pytest.approx(58.0)
+        assert fetched.total_return_pct == pytest.approx(15.3)
+        assert fetched.sharpe_ratio == pytest.approx(1.2)
+
+    async def test_row_to_report_with_null_optional_metrics(self, store) -> None:
+        """metric이 None인 row도 그대로 통과 (draft 경로 호환)."""
+        report = StrategyReport(
+            report_id="rpt-null-metrics",
+            strategy_name="null_metrics",
+            strategy_version="1.0.0",
+            strategy_path="",
+            status=ReportStatus.DRAFT,
+            submitted_at=datetime.now(tz=UTC),
+            total_return_pct=0.0,
+            total_trades=0,
+            sharpe_ratio=None,
+            max_drawdown_pct=None,
+            win_rate=None,
+        )
+        await store.submit(report)
+        fetched = await store.get("rpt-null-metrics")
+        assert fetched is not None
+        assert fetched.sharpe_ratio is None
+        assert fetched.max_drawdown_pct is None
+        assert fetched.win_rate is None

--- a/tests/unit/test_strategy_report_invariant.py
+++ b/tests/unit/test_strategy_report_invariant.py
@@ -1,19 +1,20 @@
-"""``StrategyReport`` dataclass invariant 가드 단위 테스트 (#1415).
+"""``StrategyReport`` metric invariant 단위 테스트 (#1415).
 
-``StrategyReport.__post_init__``는 defense-in-depth 가드로, CLI/Web API/내부
-호출자를 통해 들어오는 invalid 값이 ReportStore까지 흘러가는 것을 차단한다.
+``validate_strategy_report_metrics`` 함수는 저장 경계(CLI/Web submit)에서 명시 호출되는
+opt-in invariant 검증이다. DB read path (``ReportStore._row_to_report``)는 legacy
+invalid row를 허용하기 위해 이 함수를 호출하지 않는다.
 
 SSOT:
-- ``src/ante/web/schemas.py::ReportSubmitRequest`` — 입력 검증 SSOT
-- ``src/ante/report/models.py::StrategyReport`` — dataclass guard (본 모듈)
+- ``src/ante/web/schemas.py::ReportSubmitRequest`` — Web API 입력 검증 SSOT
+- ``src/ante/report/models.py::validate_strategy_report_metrics`` — 저장 경계 가드
 
 검증 대상 invariants:
 - ``total_trades >= 0``
 - ``win_rate ∈ [0.0, 100.0]`` 또는 ``None``
 - ``total_return_pct``/``sharpe_ratio``/``max_drawdown_pct``/``win_rate``는 finite
 
-또한 ``ReportStore._row_to_report``가 정상 DB row를 회귀 통과시키는지 검증해
-**legacy DB row 재구성 회귀**를 보호한다.
+또한 ``ReportStore._row_to_report``가 정상 row와 **legacy invalid row** 둘 다
+회귀 통과시키는지 검증해 codex r1 P2 (legacy row 회귀)를 보호한다.
 """
 
 from __future__ import annotations
@@ -23,19 +24,22 @@ from datetime import UTC, datetime
 import pytest
 
 from ante.core.database import Database
-from ante.report.models import ReportStatus, StrategyReport
+from ante.report.models import (
+    ReportStatus,
+    StrategyReport,
+    validate_strategy_report_metrics,
+)
 from ante.report.store import ReportStore
 
 
-def _kwargs(**overrides) -> dict:
-    """invariant 통과 가능한 최소 dataclass kwargs."""
+def _valid_kwargs(**overrides) -> dict:
+    """함수 호출에 통과 가능한 최소 metric kwargs."""
     base = {
-        "report_id": "rpt-invariant",
-        "strategy_name": "invariant_probe",
-        "strategy_version": "0.1.0",
-        "strategy_path": "strategies/probe.py",
-        "status": ReportStatus.SUBMITTED,
-        "submitted_at": datetime.now(tz=UTC),
+        "total_trades": 0,
+        "win_rate": None,
+        "total_return_pct": 0.0,
+        "sharpe_ratio": None,
+        "max_drawdown_pct": None,
     }
     base.update(overrides)
     return base
@@ -47,12 +51,12 @@ def _kwargs(**overrides) -> dict:
 class TestTotalTradesGuard:
     def test_negative_raises(self) -> None:
         with pytest.raises(ValueError, match="total_trades"):
-            StrategyReport(**_kwargs(total_trades=-1))
+            validate_strategy_report_metrics(**_valid_kwargs(total_trades=-1))
 
     @pytest.mark.parametrize("value", [0, 1, 100])
     def test_non_negative_ok(self, value: int) -> None:
         # raises 없으면 통과
-        StrategyReport(**_kwargs(total_trades=value))
+        validate_strategy_report_metrics(**_valid_kwargs(total_trades=value))
 
 
 # ── win_rate ────────────────────────────────────────────────
@@ -61,18 +65,18 @@ class TestTotalTradesGuard:
 class TestWinRateGuard:
     def test_above_100_raises(self) -> None:
         with pytest.raises(ValueError, match="win_rate"):
-            StrategyReport(**_kwargs(win_rate=101.0))
+            validate_strategy_report_metrics(**_valid_kwargs(win_rate=101.0))
 
     def test_negative_raises(self) -> None:
         with pytest.raises(ValueError, match="win_rate"):
-            StrategyReport(**_kwargs(win_rate=-0.1))
+            validate_strategy_report_metrics(**_valid_kwargs(win_rate=-0.1))
 
     @pytest.mark.parametrize("value", [0.0, 0.58, 50.0, 58.0, 100.0])
     def test_in_range_ok(self, value: float) -> None:
-        StrategyReport(**_kwargs(win_rate=value))
+        validate_strategy_report_metrics(**_valid_kwargs(win_rate=value))
 
     def test_none_ok(self) -> None:
-        StrategyReport(**_kwargs(win_rate=None))
+        validate_strategy_report_metrics(**_valid_kwargs(win_rate=None))
 
 
 # ── finite invariant ────────────────────────────────────────
@@ -85,7 +89,7 @@ class TestFiniteGuard:
     )
     def test_nan_raises(self, field: str) -> None:
         with pytest.raises(ValueError, match=f"{field}.*finite"):
-            StrategyReport(**_kwargs(**{field: float("nan")}))
+            validate_strategy_report_metrics(**_valid_kwargs(**{field: float("nan")}))
 
     @pytest.mark.parametrize(
         "field",
@@ -93,13 +97,66 @@ class TestFiniteGuard:
     )
     def test_inf_raises(self, field: str) -> None:
         with pytest.raises(ValueError, match=f"{field}.*finite"):
-            StrategyReport(**_kwargs(**{field: float("inf")}))
+            validate_strategy_report_metrics(**_valid_kwargs(**{field: float("inf")}))
 
     def test_win_rate_nan_raises(self) -> None:
         # win_rate은 range 가드가 먼저 발동 (NaN은 [0, 100] 비교에서 False가 되어
         # range 에러로 raise). 두 가드 중 하나라도 차단하면 됨.
         with pytest.raises(ValueError):
-            StrategyReport(**_kwargs(win_rate=float("nan")))
+            validate_strategy_report_metrics(**_valid_kwargs(win_rate=float("nan")))
+
+
+# ── dataclass __post_init__ 부재 확인 (codex r1 P2) ─────────
+
+
+class TestNoPostInitGuard:
+    """``StrategyReport`` dataclass 자체는 invariant raise하지 않아야 한다.
+
+    codex r1 P2: ``__post_init__`` 가드를 유지하면 ``_row_to_report``의 DB read path가
+    legacy invalid row를 재구성할 때 ``ValueError``로 fail해, 사용자가 잘못된 row를
+    조회/정리할 길이 없어진다. 본 테스트는 가드 부재를 명시 회귀로 고정한다.
+    """
+
+    def test_dataclass_accepts_invalid_total_trades(self) -> None:
+        """dataclass는 ``total_trades=-1`` invalid row를 raise 없이 재구성한다."""
+        report = StrategyReport(
+            report_id="rpt-legacy-neg-trades",
+            strategy_name="legacy_probe",
+            strategy_version="0.0.0",
+            strategy_path="",
+            status=ReportStatus.SUBMITTED,
+            submitted_at=datetime.now(tz=UTC),
+            total_trades=-1,
+        )
+        assert report.total_trades == -1
+
+    def test_dataclass_accepts_out_of_range_win_rate(self) -> None:
+        """dataclass는 ``win_rate=150.0`` invalid row를 raise 없이 재구성한다."""
+        report = StrategyReport(
+            report_id="rpt-legacy-bad-win",
+            strategy_name="legacy_probe",
+            strategy_version="0.0.0",
+            strategy_path="",
+            status=ReportStatus.SUBMITTED,
+            submitted_at=datetime.now(tz=UTC),
+            win_rate=150.0,
+        )
+        assert report.win_rate == 150.0
+
+    def test_dataclass_accepts_nan_metric(self) -> None:
+        """dataclass는 ``sharpe_ratio=NaN`` invalid row를 raise 없이 재구성한다."""
+        import math
+
+        report = StrategyReport(
+            report_id="rpt-legacy-nan",
+            strategy_name="legacy_probe",
+            strategy_version="0.0.0",
+            strategy_path="",
+            status=ReportStatus.SUBMITTED,
+            submitted_at=datetime.now(tz=UTC),
+            sharpe_ratio=float("nan"),
+        )
+        assert math.isnan(report.sharpe_ratio)
 
 
 # ── 정상 default 회귀 (draft.py 호환성) ─────────────────────
@@ -128,12 +185,12 @@ class TestDefaults:
 
 
 class TestRowToReportRegression:
-    """``_row_to_report``가 정상 row를 그대로 재구성하는지 검증.
+    """``_row_to_report``가 정상 row + legacy invalid row를 모두 재구성하는지 검증.
 
-    ``StrategyReport.__post_init__`` 가드가 추가됨으로써 legacy DB row 로딩 시
-    raise가 발생할 가능성을 회귀 검증한다. 새 DB에서는 invalid 값이 저장될 입구가
-    없으므로 (CLI: #1415로 닫힘, Web API: 이미 닫힘, draft.py: default 통과)
-    정상 row는 그대로 통과해야 한다.
+    codex r1 P2: 이번 PR 이전에는 CLI submit이 invariant를 적용하지 않아 invalid row가
+    DB에 저장될 수 있었다. PR 이후 가드가 추가되면 list/detail 조회 시 invalid row에서
+    raise되어 사용자가 정리할 길이 없어진다. 본 테스트는 read path가 raise 없이 통과함을
+    회귀 고정한다.
     """
 
     @pytest.fixture
@@ -150,7 +207,7 @@ class TestRowToReportRegression:
         return s
 
     async def test_round_trip_preserves_valid_row(self, store) -> None:
-        """정상 값을 submit한 뒤 get으로 재구성해도 가드를 통과해야 함."""
+        """정상 값을 submit한 뒤 get으로 재구성해도 통과해야 함."""
         original = StrategyReport(
             report_id="rpt-round-trip",
             strategy_name="round_trip",
@@ -202,3 +259,83 @@ class TestRowToReportRegression:
         assert fetched.sharpe_ratio is None
         assert fetched.max_drawdown_pct is None
         assert fetched.win_rate is None
+
+    async def test_row_to_report_accepts_legacy_invalid_row(self, db) -> None:
+        """codex r1 P2: invariant 위반 legacy row가 DB에 있어도 read는 통과해야 한다.
+
+        이번 PR 이전 CLI는 ``total_trades=-1``, ``win_rate=150.0``, NaN/Inf 등을
+        거부하지 않았다. 시나리오: 운영 중인 사용자가 ante를 업그레이드한 직후,
+        과거에 저장된 invalid row가 DB에 존재. 이 경우 ``ante report list``/
+        ``ante report view``가 ``ValueError``로 죽으면 사용자가 잘못된 row를 확인/정리할
+        수단이 없다. read path는 raise 없이 통과시키고, **저장 경계** (CLI/Web submit
+        에서 호출하는 ``validate_strategy_report_metrics``)에서만 차단한다.
+
+        note: 테이블명은 ``reports`` (``store.py::REPORT_SCHEMA`` 참조). DB execute는
+        자동 commit하므로 별도 commit() 호출 없이 다음 read에서 반영된다.
+        """
+        store = ReportStore(db)
+        await store.initialize()
+
+        # 스토어를 우회해 invalid row를 직접 INSERT (legacy DB 시뮬레이션).
+        await db.execute(
+            """
+            INSERT INTO reports (
+                report_id, strategy_name, strategy_version, strategy_path,
+                status, submitted_at, submitted_by,
+                backtest_period,
+                total_return_pct, total_trades,
+                sharpe_ratio, max_drawdown_pct, win_rate,
+                summary, rationale, risks, recommendations,
+                detail_json, user_notes, reviewed_at
+            ) VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            (
+                "rpt-legacy-invalid",
+                "legacy_invalid",
+                "0.0.1",
+                "strategies/legacy.py",
+                "submitted",
+                datetime.now(tz=UTC).isoformat(),
+                "agent",
+                "2024-01 ~ 2025-12",
+                float("inf"),  # total_return_pct: Inf (legacy)
+                -5,  # total_trades: 음수 (legacy)
+                float("nan"),  # sharpe_ratio: NaN (legacy)
+                -200.0,  # max_drawdown_pct: 범위 외이지만 finite
+                150.0,  # win_rate: 범위 초과 (legacy)
+                "legacy summary",
+                "legacy rationale",
+                "",
+                "",
+                "{}",
+                "",
+                None,
+            ),
+        )
+
+        # read path: list — raise 없이 통과해야 한다. 핵심 회귀: invalid metric이
+        # 든 row를 ``_row_to_report``가 ``ValueError`` 없이 ``StrategyReport``로
+        # 재구성해야 함 (codex r1 P2).
+        #
+        # 주의: SQLite REAL 컬럼은 IEEE-754 NaN을 NULL로 저장한다. ``Inf``는 보존
+        # 되거나 NULL이 될 수 있다(드라이버/플랫폼 의존). 본 테스트는 raise 부재
+        # + ``total_trades``/``win_rate``처럼 결정적으로 보존되는 invalid 값에
+        # 한해 회귀를 고정한다.
+        rows = await store.list_reports()
+        legacy_rows = [r for r in rows if r.report_id == "rpt-legacy-invalid"]
+        assert len(legacy_rows) == 1
+        legacy = legacy_rows[0]
+        assert legacy.total_trades == -5  # INTEGER 컬럼: 음수 그대로 보존
+        assert legacy.win_rate == 150.0  # REAL: 유한값은 그대로 보존
+        # sharpe_ratio (NaN)는 SQLite에서 NULL로 변환될 수 있음 → read 통과만 확인
+        # total_return_pct (Inf)도 마찬가지로 read가 raise 없이 통과하면 충분
+        # (모든 metric 비교는 raise 없이 도달했다는 사실로 갈음)
+
+        # read path: get(report_id) — raise 없이 통과해야 한다.
+        fetched = await store.get("rpt-legacy-invalid")
+        assert fetched is not None
+        assert fetched.report_id == "rpt-legacy-invalid"
+        assert fetched.total_trades == -5
+        assert fetched.win_rate == 150.0

--- a/tests/unit/test_strategy_report_invariant.py
+++ b/tests/unit/test_strategy_report_invariant.py
@@ -339,3 +339,160 @@ class TestRowToReportRegression:
         assert fetched.report_id == "rpt-legacy-invalid"
         assert fetched.total_trades == -5
         assert fetched.win_rate == 150.0
+
+
+# ── ReportStore 저장 경계 가드 회귀 (codex r3) ──────────────
+
+
+class TestReportStoreSaveBoundaryGuard:
+    """``ReportStore.submit`` / ``upsert_draft`` 가 invariant 위반을 차단해야 한다.
+
+    codex r3 P2: ``validate_strategy_report_metrics`` 는 ``StrategyReport`` 를 직접
+    저장하는 경로 (CLI, Web API submit, draft 자동 생성 등) 에 모두 부착해야 한다.
+    그렇지 않으면 잘못된 입력 (예: 백테스트 결과의 NaN sharpe, 음수 trades, 100 초과
+    win_rate) 이 ``submit``/``upsert_draft`` 를 거쳐 DB에 기록될 수 있다.
+
+    read path (``_row_to_report``) 는 codex r1 P2 회귀를 보존하기 위해 가드를 두지
+    않는다 — 위 ``TestRowToReportRegression`` 참조.
+    """
+
+    @pytest.fixture
+    async def db(self, tmp_path):
+        database = Database(str(tmp_path / "test.db"))
+        await database.connect()
+        yield database
+        await database.close()
+
+    @pytest.fixture
+    async def store(self, db):
+        s = ReportStore(db)
+        await s.initialize()
+        return s
+
+    def _make(self, **overrides) -> StrategyReport:
+        base = {
+            "report_id": "rpt-guard",
+            "strategy_name": "guard_probe",
+            "strategy_version": "1.0.0",
+            "strategy_path": "strategies/guard.py",
+            "status": ReportStatus.SUBMITTED,
+            "submitted_at": datetime.now(tz=UTC),
+            "total_return_pct": 0.0,
+            "total_trades": 0,
+            "sharpe_ratio": None,
+            "max_drawdown_pct": None,
+            "win_rate": None,
+        }
+        base.update(overrides)
+        return StrategyReport(**base)
+
+    async def test_submit_rejects_negative_trades(self, store) -> None:
+        with pytest.raises(ValueError, match="total_trades"):
+            await store.submit(self._make(total_trades=-1))
+        # DB 에 기록되지 않아야 한다.
+        assert await store.get("rpt-guard") is None
+
+    async def test_submit_rejects_win_rate_above_100(self, store) -> None:
+        with pytest.raises(ValueError, match="win_rate"):
+            await store.submit(self._make(win_rate=150.0))
+        assert await store.get("rpt-guard") is None
+
+    async def test_submit_rejects_negative_win_rate(self, store) -> None:
+        with pytest.raises(ValueError, match="win_rate"):
+            await store.submit(self._make(win_rate=-0.5))
+        assert await store.get("rpt-guard") is None
+
+    @pytest.mark.parametrize(
+        "field",
+        ["total_return_pct", "sharpe_ratio", "max_drawdown_pct"],
+    )
+    async def test_submit_rejects_nan_metric(self, store, field: str) -> None:
+        with pytest.raises(ValueError, match=f"{field}.*finite"):
+            await store.submit(self._make(**{field: float("nan")}))
+        assert await store.get("rpt-guard") is None
+
+    @pytest.mark.parametrize(
+        "field",
+        ["total_return_pct", "sharpe_ratio", "max_drawdown_pct"],
+    )
+    async def test_submit_rejects_inf_metric(self, store, field: str) -> None:
+        with pytest.raises(ValueError, match=f"{field}.*finite"):
+            await store.submit(self._make(**{field: float("inf")}))
+        assert await store.get("rpt-guard") is None
+
+    async def test_submit_valid_metrics_succeeds(self, store) -> None:
+        """invariant 통과 시 정상 저장 (회귀 보존)."""
+        report = self._make(
+            report_id="rpt-guard-ok",
+            total_trades=42,
+            win_rate=58.0,
+            total_return_pct=15.3,
+            sharpe_ratio=1.2,
+            max_drawdown_pct=-8.5,
+        )
+        rid = await store.submit(report)
+        assert rid == "rpt-guard-ok"
+
+        fetched = await store.get("rpt-guard-ok")
+        assert fetched is not None
+        assert fetched.total_trades == 42
+        assert fetched.win_rate == pytest.approx(58.0)
+
+    async def test_upsert_draft_rejects_negative_trades(self, store) -> None:
+        """``upsert_draft`` 도 진입부 가드를 거친다 (신규 분기)."""
+        with pytest.raises(ValueError, match="total_trades"):
+            await store.upsert_draft(
+                self._make(
+                    report_id="rpt-draft-bad",
+                    status=ReportStatus.DRAFT,
+                    total_trades=-3,
+                )
+            )
+        # 신규 분기에서 거부 → DB에 row 없음
+        rows = await store.list_reports(strategy_name="guard_probe")
+        assert rows == []
+
+    async def test_upsert_draft_rejects_invalid_on_update_branch(self, store) -> None:
+        """기존 DRAFT 갱신 분기에서도 invariant 위반 시 raise (update 경로 회귀)."""
+        # 먼저 정상 DRAFT 저장
+        await store.upsert_draft(
+            self._make(
+                report_id="rpt-draft-update",
+                status=ReportStatus.DRAFT,
+                total_trades=1,
+            )
+        )
+        # 이후 동일 strategy_name으로 invalid 값 upsert → update 분기 진입
+        with pytest.raises(ValueError, match="win_rate"):
+            await store.upsert_draft(
+                self._make(
+                    report_id="rpt-draft-update-2",
+                    status=ReportStatus.DRAFT,
+                    win_rate=200.0,
+                )
+            )
+        # 기존 DRAFT는 그대로 유지 (rollback이 아니라, write 자체가 발생하지 않음)
+        drafts = await store.list_reports(
+            strategy_name="guard_probe",
+            status=ReportStatus.DRAFT,
+        )
+        assert len(drafts) == 1
+        assert drafts[0].total_trades == 1
+
+    async def test_upsert_draft_valid_succeeds(self, store) -> None:
+        """invariant 통과 시 ``upsert_draft`` 정상 동작 (회귀 보존)."""
+        rid = await store.upsert_draft(
+            self._make(
+                report_id="rpt-draft-ok",
+                status=ReportStatus.DRAFT,
+                total_trades=10,
+                win_rate=55.0,
+                total_return_pct=5.0,
+                sharpe_ratio=0.9,
+                max_drawdown_pct=-3.2,
+            )
+        )
+        assert rid == "rpt-draft-ok"
+        fetched = await store.get("rpt-draft-ok")
+        assert fetched is not None
+        assert fetched.total_trades == 10


### PR DESCRIPTION
Closes #1415

## Summary
- CLI `ante report submit`이 Web API와 동일한 invariant(`total_trades>=0`, `win_rate∈[0,100]|None`, finite metrics, `extra='forbid'`)로 invalid input을 거부. Pydantic ValidationError → REPORT_VALIDATION_ERROR exit 1.
- non-object JSON 입력(배열/문자열/숫자/null/malformed)도 구조화된 REPORT_VALIDATION_ERROR로 거부.
- `validate_strategy_report_metrics(...)` 함수 분리 + `ReportStore.submit`/`upsert_draft`에서 호출 — 저장 경계 defense-in-depth.
- `_row_to_report`(DB read path)는 가드 호출 안 함 → legacy invalid row의 list/get 조회 보존.

## Test Plan
- [x] `pytest tests/unit -k report -v` — 254 passed (기존 + 신규 60+ cases)
- [x] CLI: invalid invariant + non-object JSON + happy path + extra='forbid' + dict detail_json + submitted_by extras 모두 검증
- [x] Service: dataclass invariant 함수 단독 + `_row_to_report` legacy 회귀 + store boundary 회귀
- [x] `ruff check` / `ruff format --check` PASS
- [x] `/codex:review --base main` r4 PASS (r1~r3에서 invariant 분리, non-object JSON, store boundary 모두 해소)

## Codex Branch Review 이력
- r1 FAIL: P2 (`__post_init__` legacy row 회귀) + P3 (non-object JSON) → 함수 분리 + dict 검증 선처리
- r2 FAIL (false positive): pip_freeze unstaged change → working tree 정리
- r3 FAIL: P2 (저장 경계 미호출) → ReportStore.submit/upsert_draft에 validate 호출
- r4 **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)