### PR TITLE
fix(web-api): enforce finite-positive budget on BotCreate/Update (#1435)

### DIFF
--- a/docs/specs/web-api/05-resource-endpoints.md
+++ b/docs/specs/web-api/05-resource-endpoints.md
@@ -33,11 +33,11 @@
 | Method | Path | 설명 |
 |--------|------|------|
 | GET | `/api/bots` | 봇 목록 (cursor 페이지네이션, 필터: account_id, limit, cursor). 응답에 `strategy_name` 포함 — StrategyRegistry 조인 |
-| POST | `/api/bots` | 봇 생성. Body: bot_id, strategy_id, name, bot_type, interval_seconds, budget?. 계좌 정지 상태이면 409 Conflict. **budget 처리 (#1335):** budget 포함 시 봇 생성 후 Treasury 배정을 시도한다. 배정이 `TreasuryError`(insufficient funds, treasury not configured for account 등)로 실패하면 422를 반환하고 신규 봇은 `delete_bot(handle_positions="keep")`로 best-effort 롤백된다. 롤백 자체가 실패하면 500과 함께 `budget allocation failed: ... rollback also failed; bot {bot_id} may be in partial state. Check bot status and treasury manually.` detail이 노출된다. 비-`TreasuryError`는 422로 매핑하지 않고 propagate한다 (bot create + budget 배정은 atomic transaction이 아닌 best-effort 롤백 정책). |
+| POST | `/api/bots` | 봇 생성. Body: bot_id, strategy_id, name, bot_type, interval_seconds, budget?. `budget`은 finite positive number (Infinity/NaN은 422로 거부, #1435). 계좌 정지 상태이면 409 Conflict. **budget 처리 (#1335):** budget 포함 시 봇 생성 후 Treasury 배정을 시도한다. 배정이 `TreasuryError`(insufficient funds, treasury not configured for account 등)로 실패하면 422를 반환하고 신규 봇은 `delete_bot(handle_positions="keep")`로 best-effort 롤백된다. 롤백 자체가 실패하면 500과 함께 `budget allocation failed: ... rollback also failed; bot {bot_id} may be in partial state. Check bot status and treasury manually.` detail이 노출된다. 비-`TreasuryError`는 422로 매핑하지 않고 propagate한다 (bot create + budget 배정은 atomic transaction이 아닌 best-effort 롤백 정책). |
 | GET | `/api/bots/{bot_id}` | 봇 상세 조회 (전략/예산/포지션 포함) |
 | POST | `/api/bots/{bot_id}/start` | 봇 시작 |
 | POST | `/api/bots/{bot_id}/stop` | 봇 중지 |
-| PUT | `/api/bots/{bot_id}` | 봇 설정 수정. 중지 상태에서만 가능. Body: name?, interval_seconds?, budget?, auto_restart?, max_restart_attempts?, restart_cooldown_seconds?, step_timeout_seconds?, max_signals_per_step?. BotConfig 재생성 패턴 적용. budget 변경 시 Treasury 연동. 응답: `{bot: {...}}` |
+| PUT | `/api/bots/{bot_id}` | 봇 설정 수정. 중지 상태에서만 가능. Body: name?, interval_seconds?, budget?, auto_restart?, max_restart_attempts?, restart_cooldown_seconds?, step_timeout_seconds?, max_signals_per_step?. `budget`은 finite positive number (Infinity/NaN은 422로 거부, #1435). BotConfig 재생성 패턴 적용. budget 변경 시 Treasury 연동. 응답: `{bot: {...}}` |
 | DELETE | `/api/bots/{bot_id}` | 봇 삭제. Query: handle_positions (`keep`\|`liquidate`, 기본 `keep`). `liquidate` 시 보유 종목 시장가 매도 후 삭제 |
 | GET | `/api/bots/{bot_id}/logs` | 봇 실행 로그 조회. `event_log` 테이블에서 해당 봇의 이벤트를 필터링. 필터: limit(기본 10, 최대 100), offset, start_date, end_date. 대상 이벤트: `BotStepCompletedEvent`, `BotStartedEvent`, `BotStoppedEvent`, `BotErrorEvent`. 응답: `{logs: [{timestamp, result, message}], total}` |
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -8340,7 +8340,7 @@
               "null"
             ],
             "exclusiveMinimum": 0,
-            "description": "예산 할당액 (원). 양수만 허용."
+            "description": "예산 할당액 (원). 양수 finite number만 허용 (Infinity/NaN은 422로 거부, #1435)."
           }
         }
       },
@@ -8379,7 +8379,7 @@
               "null"
             ],
             "exclusiveMinimum": 0,
-            "description": "예산 할당액 (원). 양수만 허용."
+            "description": "예산 할당액 (원). 양수 finite number만 허용 (Infinity/NaN은 422로 거부, #1435)."
           },
           "auto_restart": {
             "type": [

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2048,7 +2048,7 @@ export type components = {
             account_id?: string | null;
             /** @description 생성할 봇의 식별자. */
             bot_id: string;
-            /** @description 예산 할당액 (원). 양수만 허용. */
+            /** @description 예산 할당액 (원). 양수 finite number만 허용 (Infinity/NaN은 422로 거부, #1435). */
             budget?: number | null;
             /**
              * @description 봇 step 주기 (초).
@@ -2139,7 +2139,7 @@ export type components = {
         BotUpdateRequest: {
             /** @description 봇 자동 재시작 여부. */
             auto_restart?: boolean | null;
-            /** @description 예산 할당액 (원). 양수만 허용. */
+            /** @description 예산 할당액 (원). 양수 finite number만 허용 (Infinity/NaN은 422로 거부, #1435). */
             budget?: number | null;
             /** @description 봇 step 주기 (초). */
             interval_seconds?: number | null;

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -48,7 +48,7 @@ class BotCreateRequest(BaseModel):
     name: str = ""
     account_id: str | None = None
     interval_seconds: int = Field(default=60, ge=10, le=3600)
-    budget: float | None = Field(default=None, gt=0)
+    budget: float | None = Field(default=None, gt=0, allow_inf_nan=False)
 
 
 # POST /api/bots OpenAPI request body 문서.
@@ -109,7 +109,10 @@ BOT_CREATE_REQUEST_SCHEMA: dict[str, Any] = {
         "budget": {
             "type": ["number", "null"],
             "exclusiveMinimum": 0,
-            "description": "예산 할당액 (원). 양수만 허용.",
+            "description": (
+                "예산 할당액 (원). 양수 finite number만 허용 "
+                "(Infinity/NaN은 422로 거부, #1435)."
+            ),
         },
     },
 }
@@ -863,7 +866,10 @@ BOT_UPDATE_REQUEST_SCHEMA: dict[str, Any] = {
         "budget": {
             "type": ["number", "null"],
             "exclusiveMinimum": 0,
-            "description": "예산 할당액 (원). 양수만 허용.",
+            "description": (
+                "예산 할당액 (원). 양수 finite number만 허용 "
+                "(Infinity/NaN은 422로 거부, #1435)."
+            ),
         },
         "auto_restart": {
             "type": ["boolean", "null"],

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -311,7 +311,7 @@ class BotUpdateRequest(BaseModel):
     name: str | None = None
     strategy_name: str | None = None
     interval_seconds: int | None = Field(default=None, ge=10, le=3600)
-    budget: float | None = Field(default=None, gt=0)
+    budget: float | None = Field(default=None, gt=0, allow_inf_nan=False)
     auto_restart: bool | None = None
     max_restart_attempts: int | None = None
     restart_cooldown_seconds: int | None = None

--- a/tests/unit/test_bot_routes_budget_finite.py
+++ b/tests/unit/test_bot_routes_budget_finite.py
@@ -1,0 +1,266 @@
+"""POST /api/bots, PUT /api/bots/{bot_id} budget invariant 회귀 테스트.
+
+이슈 #1435: `BotCreateRequest.budget` / `BotUpdateRequest.budget`가 raw JSON
+`NaN`/`Infinity`/`-Infinity`를 422가 아닌 통과로 처리하던 결함을 막는다.
+
+Web API 입력 invariant(``Field(default=None, gt=0, allow_inf_nan=False)``)가
+NaN/±Inf/0/음수를 422로 거부함을 회귀 검증한다. #1432 treasury 패턴을 따라
+Web 계층에서 1차 차단한다.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402
+
+# 기존 테스트 파일의 Fake 들을 재사용한다 (test_bot_routes_create_budget_error.py 패턴).
+from tests.unit.test_bot_api import (  # noqa: E402
+    _MASTER_HEADERS,
+    FakeAccount,
+    FakeAccountService,
+    FakeBot,
+    FakeBotManager,
+    FakeStrategyRecord,
+    FakeStrategyRegistry,
+    _new_member_service,
+)
+
+
+@pytest.fixture(autouse=True)
+def _mock_strategy_loader(monkeypatch):
+    """StrategyLoader.load 를 모킹해 파일 시스템 의존을 제거."""
+
+    class _FakeStrategy:
+        pass
+
+    monkeypatch.setattr(
+        "ante.strategy.loader.StrategyLoader.load",
+        staticmethod(lambda path: _FakeStrategy),
+    )
+
+
+@pytest.fixture
+def bot_manager() -> FakeBotManager:
+    return FakeBotManager()
+
+
+@pytest.fixture
+def account_service() -> FakeAccountService:
+    svc = FakeAccountService()
+    svc._accounts["test"] = FakeAccount(
+        "test",
+        status="active",
+        credentials={"app_key": "test-key", "app_secret": "test-secret"},
+    )
+    return svc
+
+
+@pytest.fixture
+def strategy_registry() -> FakeStrategyRegistry:
+    reg = FakeStrategyRegistry()
+    reg._strategies["s1"] = FakeStrategyRecord("s1", name="s1")
+    return reg
+
+
+@pytest.fixture
+def client(bot_manager, account_service, strategy_registry) -> TestClient:
+    # POST /api/bots, PUT /api/bots/{id}는 master 인증을 요구하므로(#1371/#1352),
+    # default Authorization 헤더 + member_service stub을 함께 주입한다.
+    app = create_app(
+        bot_manager=bot_manager,
+        account_service=account_service,
+        strategy_registry=strategy_registry,
+        member_service=_new_member_service(),
+    )
+    client = TestClient(app)
+    client.headers.update(_MASTER_HEADERS)
+    return client
+
+
+def _create_payload(**overrides) -> dict:
+    """기본 POST /api/bots payload (overrides로 budget만 갈아끼울 수 있도록)."""
+
+    payload: dict = {
+        "bot_id": "bot-x",
+        "strategy_id": "s1",
+        "account_id": "test",
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ── POST /api/bots: budget invariant 회귀 ─────────────────────────
+
+
+class TestCreateBotBudgetInvariant:
+    """``BotCreateRequest.budget`` finite-positive 입력 invariant."""
+
+    def test_create_rejects_positive_inf_with_422(
+        self, client: TestClient, bot_manager: FakeBotManager
+    ) -> None:
+        """body `{"budget": Infinity}` → 422 (allow_inf_nan=False).
+
+        표준 JSON 인코더는 Infinity를 거부하므로 raw content로 전송한다.
+        """
+        resp = client.post(
+            "/api/bots",
+            content=(
+                '{"bot_id": "bot-x", "strategy_id": "s1", '
+                '"account_id": "test", "budget": Infinity}'
+            ),
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 422, resp.text
+        # 봇이 생성되지 않았는지 확인
+        assert "bot-x" not in bot_manager._bots
+
+    def test_create_rejects_negative_inf_with_422(
+        self, client: TestClient, bot_manager: FakeBotManager
+    ) -> None:
+        """body `{"budget": -Infinity}` → 422."""
+        resp = client.post(
+            "/api/bots",
+            content=(
+                '{"bot_id": "bot-x", "strategy_id": "s1", '
+                '"account_id": "test", "budget": -Infinity}'
+            ),
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 422, resp.text
+        assert "bot-x" not in bot_manager._bots
+
+    def test_create_rejects_nan_with_422(
+        self, client: TestClient, bot_manager: FakeBotManager
+    ) -> None:
+        """body `{"budget": NaN}` → 422 (allow_inf_nan=False)."""
+        resp = client.post(
+            "/api/bots",
+            content=(
+                '{"bot_id": "bot-x", "strategy_id": "s1", '
+                '"account_id": "test", "budget": NaN}'
+            ),
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 422, resp.text
+        assert "bot-x" not in bot_manager._bots
+
+    def test_create_rejects_negative_with_422(
+        self, client: TestClient, bot_manager: FakeBotManager
+    ) -> None:
+        """body `{"budget": -1}` → 422 (Field(gt=0) 회귀 보존)."""
+        resp = client.post("/api/bots", json=_create_payload(budget=-1.0))
+        assert resp.status_code == 422, resp.text
+        assert "bot-x" not in bot_manager._bots
+
+    def test_create_rejects_zero_with_422(
+        self, client: TestClient, bot_manager: FakeBotManager
+    ) -> None:
+        """body `{"budget": 0}` → 422 (Field(gt=0) 회귀 보존)."""
+        resp = client.post("/api/bots", json=_create_payload(budget=0.0))
+        assert resp.status_code == 422, resp.text
+        assert "bot-x" not in bot_manager._bots
+
+    def test_create_accepts_positive_finite(
+        self, client: TestClient, bot_manager: FakeBotManager
+    ) -> None:
+        """body `{"budget": 100.0}` → 201 (정상 경로 회귀 보존)."""
+        resp = client.post("/api/bots", json=_create_payload(budget=100.0))
+        # 정상 생성 또는 Treasury 미주입으로 인한 422(=budget allocation 실패).
+        # invariant 가드 본질은 raw float 값이 Pydantic을 통과했는지이므로
+        # 201 또는 422(budget allocation 실패) 둘 다 통과로 본다.
+        # NaN/Infinity와 달리 422 발생 시 detail은 invariant가 아닌
+        # treasury 관련 에러여야 한다.
+        assert resp.status_code in (201, 422), resp.text
+        if resp.status_code == 422:
+            # invariant 위반이 아닌 treasury 관련 422여야 함
+            body = resp.text.lower()
+            assert "infinity" not in body
+            assert "nan" not in body
+
+    def test_create_accepts_budget_omitted(
+        self, client: TestClient, bot_manager: FakeBotManager
+    ) -> None:
+        """budget 생략 시 정상 (필드 자체가 optional)."""
+        resp = client.post("/api/bots", json=_create_payload())
+        assert resp.status_code == 201, resp.text
+
+
+# ── PUT /api/bots/{bot_id}: budget invariant 회귀 ─────────────────
+
+
+class TestUpdateBotBudgetInvariant:
+    """``BotUpdateRequest.budget`` finite-positive 입력 invariant."""
+
+    @pytest.fixture
+    def existing_bot(self, bot_manager: FakeBotManager) -> str:
+        """수정 대상 봇을 미리 생성. stopped 상태여야 PUT이 허용됨."""
+
+        bot_manager._bots["bot-x"] = FakeBot(
+            "bot-x", status="stopped", strategy_id="s1", account_id="test"
+        )
+        return "bot-x"
+
+    def test_update_rejects_positive_inf_with_422(
+        self, client: TestClient, existing_bot: str
+    ) -> None:
+        """body `{"budget": Infinity}` → 422 (allow_inf_nan=False)."""
+        resp = client.put(
+            f"/api/bots/{existing_bot}",
+            content='{"budget": Infinity}',
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_update_rejects_negative_inf_with_422(
+        self, client: TestClient, existing_bot: str
+    ) -> None:
+        """body `{"budget": -Infinity}` → 422."""
+        resp = client.put(
+            f"/api/bots/{existing_bot}",
+            content='{"budget": -Infinity}',
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_update_rejects_nan_with_422(
+        self, client: TestClient, existing_bot: str
+    ) -> None:
+        """body `{"budget": NaN}` → 422."""
+        resp = client.put(
+            f"/api/bots/{existing_bot}",
+            content='{"budget": NaN}',
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_update_rejects_negative_with_422(
+        self, client: TestClient, existing_bot: str
+    ) -> None:
+        """body `{"budget": -1}` → 422 (Field(gt=0) 회귀 보존)."""
+        resp = client.put(f"/api/bots/{existing_bot}", json={"budget": -1.0})
+        assert resp.status_code == 422, resp.text
+
+    def test_update_rejects_zero_with_422(
+        self, client: TestClient, existing_bot: str
+    ) -> None:
+        """body `{"budget": 0}` → 422 (Field(gt=0) 회귀 보존)."""
+        resp = client.put(f"/api/bots/{existing_bot}", json={"budget": 0.0})
+        assert resp.status_code == 422, resp.text
+
+    def test_update_accepts_positive_finite(
+        self, client: TestClient, existing_bot: str
+    ) -> None:
+        """body `{"budget": 100.0}` → 200 (정상 경로 회귀 보존)."""
+        resp = client.put(f"/api/bots/{existing_bot}", json={"budget": 100.0})
+        # 정상 update 또는 Treasury 미주입에 따른 422.
+        # invariant 가드 본질은 finite-positive 통과 여부.
+        assert resp.status_code in (200, 422), resp.text
+        if resp.status_code == 422:
+            body = resp.text.lower()
+            assert "infinity" not in body
+            assert "nan" not in body


### PR DESCRIPTION
Closes #1435

## Summary
- BotCreateRequest.budget + BotUpdateRequest.budget에 `Field(gt=0, allow_inf_nan=False)` 적용. Infinity/NaN 422 차단.
- `BOT_CREATE_REQUEST_SCHEMA` description 강화 + `docs/specs/web-api/05-resource-endpoints.md` 갱신.
- 회귀 테스트 13개 (POST/PUT × Infinity/-Infinity/NaN/-1/0/positive/omitted).

## Test Plan
- [x] `pytest tests/unit -k bot -v` — 551 passed
- [x] `pytest tests/unit -k "bot and (create or update or budget)" -v` — 180 passed
- [x] ruff PASS / frontend build PASS
- [x] `/codex:review --base main` r1 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)