### PR TITLE
fix(web-api): narrow DELETE dataset data_type to enum (#1438)

### DIFF
--- a/docs/specs/web-api/05-resource-endpoints.md
+++ b/docs/specs/web-api/05-resource-endpoints.md
@@ -78,7 +78,7 @@
 | GET | `/api/data/datasets/{dataset_id}` | 데이터셋 상세 조회. 메타데이터(symbol, timeframe, 기간, 행 수) + 데이터 미리보기(최근 5행). dataset_id = `{symbol}__{timeframe}`. ParquetStore.read(limit=5) 활용 |
 | GET | `/api/data/schema` | 데이터 스키마 (필터: data_type) |
 | GET | `/api/data/storage` | 저장 용량 현황 |
-| DELETE | `/api/data/datasets/{dataset_id}` | 데이터셋 삭제 (필터: data_type) |
+| DELETE | `/api/data/datasets/{dataset_id}` | 데이터셋 삭제. `data_type` query는 `ohlcv \| fundamental` enum (기본 `ohlcv`), enum 외 값은 422 |
 | GET | `/api/data/feed-status` | Feed 파이프라인 상태 조회 |
 
 ## 결재 관리 (`/api/approvals`)

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -12,7 +12,7 @@
           "accounts"
         ],
         "summary": "List Accounts",
-        "description": "계좌 목록 조회. 인증된 master/human 또는 ``account:read`` scope 를 보유한\nagent 만 호출 가능 (#1407).",
+        "description": "\uacc4\uc88c \ubaa9\ub85d \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``account:read`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "list_accounts_api_accounts_get",
         "parameters": [
           {
@@ -60,11 +60,11 @@
           "accounts"
         ],
         "summary": "Create Account",
-        "description": "계좌 생성. 인증된 master/human 또는 ``account:write`` scope 를 보유한\nagent 만 호출 가능 (#1407).\n\n런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.\n실제 계좌 생성은 서버 정지 상태에서 ``ante account create`` CLI로\n수행한다.\n\n의존성/Pydantic body schema/audit logger를 모두 시그니처에서 제외해\n핸들러 진입 즉시 409가 반환되도록 한다(invariant I1). OpenAPI에는\nsuccess contract(200/201/204)가 노출되지 않으며, 409 응답은 명시\n``responses[409]`` content map의 ``application/problem+json``으로\n``ErrorResponse``를 노출한다(invariant I2/I3, #1164).\n\n이 경로의 service-layer 회귀 보호는 ``tests/unit/test_account.py``가\n담당한다.\n\n본 PR(#1143)에서 OpenAPI requestBody schema가 spec-aligned\n``ACCOUNT_CREATE_REQUEST_SCHEMA``로 노출되어 codegen 클라이언트가\ncold-path payload 필드를 발견할 수 있게 됐다. 런타임은 어떤 body든\n무시하고 409를 반환한다.",
+        "description": "\uacc4\uc88c \uc0dd\uc131. \uc778\uc99d\ub41c master/human \ub610\ub294 ``account:write`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).\n\n\ub7f0\ud0c0\uc784 Web API\uc5d0\uc11c\ub294 cold-path \uac00\ub4dc\uac00 \ubaa8\ub4e0 \uc694\uccad\uc744 \uc989\uc2dc 409\ub85c \ucc28\ub2e8\ud55c\ub2e4.\n\uc2e4\uc81c \uacc4\uc88c \uc0dd\uc131\uc740 \uc11c\ubc84 \uc815\uc9c0 \uc0c1\ud0dc\uc5d0\uc11c ``ante account create`` CLI\ub85c\n\uc218\ud589\ud55c\ub2e4.\n\n\uc758\uc874\uc131/Pydantic body schema/audit logger\ub97c \ubaa8\ub450 \uc2dc\uadf8\ub2c8\ucc98\uc5d0\uc11c \uc81c\uc678\ud574\n\ud578\ub4e4\ub7ec \uc9c4\uc785 \uc989\uc2dc 409\uac00 \ubc18\ud658\ub418\ub3c4\ub85d \ud55c\ub2e4(invariant I1). OpenAPI\uc5d0\ub294\nsuccess contract(200/201/204)\uac00 \ub178\ucd9c\ub418\uc9c0 \uc54a\uc73c\uba70, 409 \uc751\ub2f5\uc740 \uba85\uc2dc\n``responses[409]`` content map\uc758 ``application/problem+json``\uc73c\ub85c\n``ErrorResponse``\ub97c \ub178\ucd9c\ud55c\ub2e4(invariant I2/I3, #1164).\n\n\uc774 \uacbd\ub85c\uc758 service-layer \ud68c\uadc0 \ubcf4\ud638\ub294 ``tests/unit/test_account.py``\uac00\n\ub2f4\ub2f9\ud55c\ub2e4.\n\n\ubcf8 PR(#1143)\uc5d0\uc11c OpenAPI requestBody schema\uac00 spec-aligned\n``ACCOUNT_CREATE_REQUEST_SCHEMA``\ub85c \ub178\ucd9c\ub418\uc5b4 codegen \ud074\ub77c\uc774\uc5b8\ud2b8\uac00\ncold-path payload \ud544\ub4dc\ub97c \ubc1c\uacac\ud560 \uc218 \uc788\uac8c \ub410\ub2e4. \ub7f0\ud0c0\uc784\uc740 \uc5b4\ub5a4 body\ub4e0\n\ubb34\uc2dc\ud558\uace0 409\ub97c \ubc18\ud658\ud55c\ub2e4.",
         "operationId": "create_account_api_accounts_post",
         "responses": {
           "409": {
-            "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 생성 차단",
+            "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER \u2014 \ub7f0\ud0c0\uc784 \uacc4\uc88c \uc0dd\uc131 \ucc28\ub2e8",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -81,7 +81,7 @@
               "schema": {
                 "type": "object",
                 "title": "AccountCreateRequest",
-                "description": "POST /api/accounts cold-path 입력 contract. 런타임에서는 cold-path 가드가 어떤 입력이든 즉시 409로 차단한다 (ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER). 실제 계좌 생성은 서버 정지 상태에서 ante account create CLI로 수행한다. 스키마 SSOT: docs/specs/account/03-data-model.md 60-87줄.",
+                "description": "POST /api/accounts cold-path \uc785\ub825 contract. \ub7f0\ud0c0\uc784\uc5d0\uc11c\ub294 cold-path \uac00\ub4dc\uac00 \uc5b4\ub5a4 \uc785\ub825\uc774\ub4e0 \uc989\uc2dc 409\ub85c \ucc28\ub2e8\ud55c\ub2e4 (ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER). \uc2e4\uc81c \uacc4\uc88c \uc0dd\uc131\uc740 \uc11c\ubc84 \uc815\uc9c0 \uc0c1\ud0dc\uc5d0\uc11c ante account create CLI\ub85c \uc218\ud589\ud55c\ub2e4. \uc2a4\ud0a4\ub9c8 SSOT: docs/specs/account/03-data-model.md 60-87\uc904.",
                 "additionalProperties": false,
                 "required": [
                   "account_id",
@@ -93,11 +93,11 @@
                 "properties": {
                   "account_id": {
                     "type": "string",
-                    "description": "고유 식별자 (영문+숫자+하이픈, 3–30자)."
+                    "description": "\uace0\uc720 \uc2dd\ubcc4\uc790 (\uc601\ubb38+\uc22b\uc790+\ud558\uc774\ud508, 3\u201330\uc790)."
                   },
                   "name": {
                     "type": "string",
-                    "description": "사용자에게 표시되는 이름."
+                    "description": "\uc0ac\uc6a9\uc790\uc5d0\uac8c \ud45c\uc2dc\ub418\ub294 \uc774\ub984."
                   },
                   "exchange": {
                     "type": "string",
@@ -107,28 +107,28 @@
                       "NASDAQ",
                       "TEST"
                     ],
-                    "description": "대상 거래소 코드."
+                    "description": "\ub300\uc0c1 \uac70\ub798\uc18c \ucf54\ub4dc."
                   },
                   "currency": {
                     "type": "string",
-                    "description": "거래 통화 (ISO 4217)."
+                    "description": "\uac70\ub798 \ud1b5\ud654 (ISO 4217)."
                   },
                   "timezone": {
                     "type": "string",
                     "default": "Asia/Seoul",
-                    "description": "거래소 현지 시간대 (IANA)."
+                    "description": "\uac70\ub798\uc18c \ud604\uc9c0 \uc2dc\uac04\ub300 (IANA)."
                   },
                   "trading_hours_start": {
                     "type": "string",
                     "default": "09:00",
                     "pattern": "^(([01]\\d|2[0-3]):[0-5]\\d)?$",
-                    "description": "거래 시작 시각 (현지 시간, strict HH:MM 24시간 형식). AccountCreateRequest는 cold-path payload이며 빈 문자열은 BrokerPreset fallback sentinel로 허용된다. 초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334)."
+                    "description": "\uac70\ub798 \uc2dc\uc791 \uc2dc\uac01 (\ud604\uc9c0 \uc2dc\uac04, strict HH:MM 24\uc2dc\uac04 \ud615\uc2dd). AccountCreateRequest\ub294 cold-path payload\uc774\uba70 \ube48 \ubb38\uc790\uc5f4\uc740 BrokerPreset fallback sentinel\ub85c \ud5c8\uc6a9\ub41c\ub2e4. \ucd08/\ub9c8\uc774\ud06c\ub85c\ucd08 \ud3ec\ud568, invalid \uc2dc\uac04\uc740 422\ub85c \uac70\ubd80\ub41c\ub2e4 (#1334)."
                   },
                   "trading_hours_end": {
                     "type": "string",
                     "default": "15:30",
                     "pattern": "^(([01]\\d|2[0-3]):[0-5]\\d)?$",
-                    "description": "거래 종료 시각 (현지 시간, strict HH:MM 24시간 형식). AccountCreateRequest는 cold-path payload이며 빈 문자열은 BrokerPreset fallback sentinel로 허용된다. 초/마이크로초 포함, invalid 시간은 422로 거부된다 (#1334)."
+                    "description": "\uac70\ub798 \uc885\ub8cc \uc2dc\uac01 (\ud604\uc9c0 \uc2dc\uac04, strict HH:MM 24\uc2dc\uac04 \ud615\uc2dd). AccountCreateRequest\ub294 cold-path payload\uc774\uba70 \ube48 \ubb38\uc790\uc5f4\uc740 BrokerPreset fallback sentinel\ub85c \ud5c8\uc6a9\ub41c\ub2e4. \ucd08/\ub9c8\uc774\ud06c\ub85c\ucd08 \ud3ec\ud568, invalid \uc2dc\uac04\uc740 422\ub85c \uac70\ubd80\ub41c\ub2e4 (#1334)."
                   },
                   "trading_mode": {
                     "type": "string",
@@ -137,11 +137,11 @@
                       "LIVE"
                     ],
                     "default": "VIRTUAL",
-                    "description": "거래 모드 (VIRTUAL / LIVE)."
+                    "description": "\uac70\ub798 \ubaa8\ub4dc (VIRTUAL / LIVE)."
                   },
                   "broker_type": {
                     "type": "string",
-                    "description": "브로커 어댑터 유형."
+                    "description": "\ube0c\ub85c\ucee4 \uc5b4\ub311\ud130 \uc720\ud615."
                   },
                   "credentials": {
                     "type": "object",
@@ -149,27 +149,27 @@
                       "type": "string"
                     },
                     "default": {},
-                    "description": "브로커 인증 정보 (dict[str, str], 암호화 저장). cold-path 전용."
+                    "description": "\ube0c\ub85c\ucee4 \uc778\uc99d \uc815\ubcf4 (dict[str, str], \uc554\ud638\ud654 \uc800\uc7a5). cold-path \uc804\uc6a9."
                   },
                   "broker_config": {
                     "type": "object",
                     "additionalProperties": true,
                     "default": {},
-                    "description": "브로커 동작 설정 (예: KIS is_paper). 임의 키-값 dict. cold-path 전용."
+                    "description": "\ube0c\ub85c\ucee4 \ub3d9\uc791 \uc124\uc815 (\uc608: KIS is_paper). \uc784\uc758 \ud0a4-\uac12 dict. cold-path \uc804\uc6a9."
                   },
                   "buy_commission_rate": {
                     "type": "number",
                     "default": 0,
-                    "description": "매수 수수료율 (cold-path 전용)."
+                    "description": "\ub9e4\uc218 \uc218\uc218\ub8cc\uc728 (cold-path \uc804\uc6a9)."
                   },
                   "sell_commission_rate": {
                     "type": "number",
                     "default": 0,
-                    "description": "매도 수수료율, 세금 포함 (cold-path 전용)."
+                    "description": "\ub9e4\ub3c4 \uc218\uc218\ub8cc\uc728, \uc138\uae08 \ud3ec\ud568 (cold-path \uc804\uc6a9)."
                   },
                   "market_order_reserve_buffer_rate": {
                     "type": "number",
-                    "description": "시장가 매수 reserve buffer 비율 (cold-path 전용, #1333). omit 시 BrokerPreset 기본값을 사용한다 (예: kis-domestic=0.005, test=0)."
+                    "description": "\uc2dc\uc7a5\uac00 \ub9e4\uc218 reserve buffer \ube44\uc728 (cold-path \uc804\uc6a9, #1333). omit \uc2dc BrokerPreset \uae30\ubcf8\uac12\uc744 \uc0ac\uc6a9\ud55c\ub2e4 (\uc608: kis-domestic=0.005, test=0)."
                   }
                 }
               }
@@ -184,7 +184,7 @@
           "accounts"
         ],
         "summary": "Get Account",
-        "description": "계좌 상세 조회. 인증된 master/human 또는 ``account:read`` scope 를 보유한\nagent 만 호출 가능 (#1407).",
+        "description": "\uacc4\uc88c \uc0c1\uc138 \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``account:read`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "get_account_api_accounts__account_id__get",
         "parameters": [
           {
@@ -225,7 +225,7 @@
           "accounts"
         ],
         "summary": "Update Account",
-        "description": "계좌 수정.\n\n인증된 master/human 또는 ``account:write`` scope 를 보유한 agent 만 호출\n가능 (#1407 — spec ``account:write`` 정합, #1352 master_caller 에서\n마이그레이션). dependency ``require_account_write`` 가 인증/권한 검증을\n담당하며, 401/403은 raw body 파싱과 cold-path 가드(invariant I1/I4)보다\n먼저 평가된다 — Bearer 또는 ``ante_session`` 쿠키 어느 쪽으로도 caller가\n결정되지 않으면 401, 권한 없으면 403.\n\n런타임에서는 비구조 필드(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)만 변경할 수 있다. ``STRUCTURAL_FIELDS`` 중 하나라도\n포함되면 cold-path 409로 즉시 차단된다 — 클라이언트는\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix로 cold-path\n응답과 ``AccountDeletedError`` 경로의 409를 구분한다.\n\nbody는 raw bytes로 받는다(``request.body()``). FastAPI 선행 Pydantic\n검증을 거치면 cold-path 가드(invariant I1/I4) 도달 전 422가 먼저 나가\nstructural 키 존재가 schema validation 신호로 흘러갈 수 있기 때문이다.\n\n핸들러 단계 순서(이슈 #1153 + #1152 Implementation Plan):\n\n1. raw bytes 읽기.\n2. **빈 body**(``b\"\"``) → ``payload = {}``로 두고 Content-Type 검사·JSON\n   파싱 모두 건너뛰고 mutable 단계까지 흘려보낸다(단계 6에서 422로 처리).\n3. **JSON 파싱 실패**: Content-Type ≠ application/json → 415,\n   Content-Type 정상 → 422.\n4. **non-dict JSON**: Content-Type ≠ application/json → 415,\n   Content-Type 정상 → 422.\n5. **structural 가드(I4 우선)**: dict payload에 structural 키 존재 → 409\n   (Content-Type 무관, structural+text/plain도 409).\n6. ``len(payload) == 0`` (``{}`` 명시 송신 또는 빈 body) → 422 no-op\n   (Content-Type 검사 건너뜀; #1152 정렬 완료 — schema의\n   ``minProperties: 1``과 정합).\n7. **Content-Type 415 게이트**: ``application/json``(charset suffix 허용)\n   이외 → 415.\n8. **unknown 키 / mutable type**: structural 제외한 raw dict의 unknown\n   키 → 422. ``AccountUpdateRequest.model_validate`` ValidationError → 422.\n9. ``model_dump(exclude_none=True)`` 결과 비면 422 (예: ``{\"name\": null}``\n   단독 — effective payload empty no-op; #1152 정렬 완료).\n10. service 호출.",
+        "description": "\uacc4\uc88c \uc218\uc815.\n\n\uc778\uc99d\ub41c master/human \ub610\ub294 ``account:write`` scope \ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c\n\uac00\ub2a5 (#1407 \u2014 spec ``account:write`` \uc815\ud569, #1352 master_caller \uc5d0\uc11c\n\ub9c8\uc774\uadf8\ub808\uc774\uc158). dependency ``require_account_write`` \uac00 \uc778\uc99d/\uad8c\ud55c \uac80\uc99d\uc744\n\ub2f4\ub2f9\ud558\uba70, 401/403\uc740 raw body \ud30c\uc2f1\uacfc cold-path \uac00\ub4dc(invariant I1/I4)\ubcf4\ub2e4\n\uba3c\uc800 \ud3c9\uac00\ub41c\ub2e4 \u2014 Bearer \ub610\ub294 ``ante_session`` \ucfe0\ud0a4 \uc5b4\ub290 \ucabd\uc73c\ub85c\ub3c4 caller\uac00\n\uacb0\uc815\ub418\uc9c0 \uc54a\uc73c\uba74 401, \uad8c\ud55c \uc5c6\uc73c\uba74 403.\n\n\ub7f0\ud0c0\uc784\uc5d0\uc11c\ub294 \ube44\uad6c\uc870 \ud544\ub4dc(``name``, ``timezone``, ``trading_hours_start``,\n``trading_hours_end``)\ub9cc \ubcc0\uacbd\ud560 \uc218 \uc788\ub2e4. ``STRUCTURAL_FIELDS`` \uc911 \ud558\ub098\ub77c\ub3c4\n\ud3ec\ud568\ub418\uba74 cold-path 409\ub85c \uc989\uc2dc \ucc28\ub2e8\ub41c\ub2e4 \u2014 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294\n``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER:`` prefix\ub85c cold-path\n\uc751\ub2f5\uacfc ``AccountDeletedError`` \uacbd\ub85c\uc758 409\ub97c \uad6c\ubd84\ud55c\ub2e4.\n\nbody\ub294 raw bytes\ub85c \ubc1b\ub294\ub2e4(``request.body()``). FastAPI \uc120\ud589 Pydantic\n\uac80\uc99d\uc744 \uac70\uce58\uba74 cold-path \uac00\ub4dc(invariant I1/I4) \ub3c4\ub2ec \uc804 422\uac00 \uba3c\uc800 \ub098\uac00\nstructural \ud0a4 \uc874\uc7ac\uac00 schema validation \uc2e0\ud638\ub85c \ud758\ub7ec\uac08 \uc218 \uc788\uae30 \ub54c\ubb38\uc774\ub2e4.\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c(\uc774\uc288 #1153 + #1152 Implementation Plan):\n\n1. raw bytes \uc77d\uae30.\n2. **\ube48 body**(``b\"\"``) \u2192 ``payload = {}``\ub85c \ub450\uace0 Content-Type \uac80\uc0ac\u00b7JSON\n   \ud30c\uc2f1 \ubaa8\ub450 \uac74\ub108\ub6f0\uace0 mutable \ub2e8\uacc4\uae4c\uc9c0 \ud758\ub824\ubcf4\ub0b8\ub2e4(\ub2e8\uacc4 6\uc5d0\uc11c 422\ub85c \ucc98\ub9ac).\n3. **JSON \ud30c\uc2f1 \uc2e4\ud328**: Content-Type \u2260 application/json \u2192 415,\n   Content-Type \uc815\uc0c1 \u2192 422.\n4. **non-dict JSON**: Content-Type \u2260 application/json \u2192 415,\n   Content-Type \uc815\uc0c1 \u2192 422.\n5. **structural \uac00\ub4dc(I4 \uc6b0\uc120)**: dict payload\uc5d0 structural \ud0a4 \uc874\uc7ac \u2192 409\n   (Content-Type \ubb34\uad00, structural+text/plain\ub3c4 409).\n6. ``len(payload) == 0`` (``{}`` \uba85\uc2dc \uc1a1\uc2e0 \ub610\ub294 \ube48 body) \u2192 422 no-op\n   (Content-Type \uac80\uc0ac \uac74\ub108\ub700; #1152 \uc815\ub82c \uc644\ub8cc \u2014 schema\uc758\n   ``minProperties: 1``\uacfc \uc815\ud569).\n7. **Content-Type 415 \uac8c\uc774\ud2b8**: ``application/json``(charset suffix \ud5c8\uc6a9)\n   \uc774\uc678 \u2192 415.\n8. **unknown \ud0a4 / mutable type**: structural \uc81c\uc678\ud55c raw dict\uc758 unknown\n   \ud0a4 \u2192 422. ``AccountUpdateRequest.model_validate`` ValidationError \u2192 422.\n9. ``model_dump(exclude_none=True)`` \uacb0\uacfc \ube44\uba74 422 (\uc608: ``{\"name\": null}``\n   \ub2e8\ub3c5 \u2014 effective payload empty no-op; #1152 \uc815\ub82c \uc644\ub8cc).\n10. service \ud638\ucd9c.",
         "operationId": "update_account_api_accounts__account_id__put",
         "parameters": [
           {
@@ -250,7 +250,7 @@
             }
           },
           "400": {
-            "description": "수정할 필드가 없거나 service-layer가 거부한 비구조 필드",
+            "description": "\uc218\uc815\ud560 \ud544\ub4dc\uac00 \uc5c6\uac70\ub098 service-layer\uac00 \uac70\ubd80\ud55c \ube44\uad6c\uc870 \ud544\ub4dc",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -260,7 +260,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -270,7 +270,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 account:write scope 보유 agent 만 허용)",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 account:write scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -280,7 +280,7 @@
             }
           },
           "404": {
-            "description": "계좌를 찾을 수 없음",
+            "description": "\uacc4\uc88c\ub97c \ucc3e\uc744 \uc218 \uc5c6\uc74c",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -290,7 +290,7 @@
             }
           },
           "409": {
-            "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER (런타임 구조 변경 차단) 또는 삭제된 계좌 수정 시도",
+            "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER (\ub7f0\ud0c0\uc784 \uad6c\uc870 \ubcc0\uacbd \ucc28\ub2e8) \ub610\ub294 \uc0ad\uc81c\ub41c \uacc4\uc88c \uc218\uc815 \uc2dc\ub3c4",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -300,7 +300,7 @@
             }
           },
           "415": {
-            "description": "Content-Type이 application/json이 아님",
+            "description": "Content-Type\uc774 application/json\uc774 \uc544\ub2d8",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -310,7 +310,7 @@
             }
           },
           "422": {
-            "description": "비구조(mutable) 필드 type 검증 실패 또는 unknown 키. structural 필드 키는 422가 아닌 409로 차단된다.",
+            "description": "\ube44\uad6c\uc870(mutable) \ud544\ub4dc type \uac80\uc99d \uc2e4\ud328 \ub610\ub294 unknown \ud0a4. structural \ud544\ub4dc \ud0a4\ub294 422\uac00 \uc544\ub2cc 409\ub85c \ucc28\ub2e8\ub41c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -320,7 +320,7 @@
             }
           },
           "503": {
-            "description": "Account service not available 또는 broker 재연결 실패",
+            "description": "Account service not available \ub610\ub294 broker \uc7ac\uc5f0\uacb0 \uc2e4\ud328",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -337,27 +337,27 @@
               "schema": {
                 "type": "object",
                 "title": "AccountMutableUpdateRequest",
-                "description": "PUT /api/accounts/{account_id} 런타임 mutable 입력 contract. 런타임에는 비구조 필드만 변경할 수 있다. structural 필드(credentials, broker_config, buy_commission_rate, sell_commission_rate, broker_type, exchange, currency, trading_mode)는 cold-path 409로 차단된다. 스키마 SSOT: docs/specs/account/10-web-api.md 16-22줄.",
+                "description": "PUT /api/accounts/{account_id} \ub7f0\ud0c0\uc784 mutable \uc785\ub825 contract. \ub7f0\ud0c0\uc784\uc5d0\ub294 \ube44\uad6c\uc870 \ud544\ub4dc\ub9cc \ubcc0\uacbd\ud560 \uc218 \uc788\ub2e4. structural \ud544\ub4dc(credentials, broker_config, buy_commission_rate, sell_commission_rate, broker_type, exchange, currency, trading_mode)\ub294 cold-path 409\ub85c \ucc28\ub2e8\ub41c\ub2e4. \uc2a4\ud0a4\ub9c8 SSOT: docs/specs/account/10-web-api.md 16-22\uc904.",
                 "additionalProperties": false,
                 "minProperties": 1,
                 "properties": {
                   "name": {
                     "type": "string",
-                    "description": "사용자에게 표시되는 이름."
+                    "description": "\uc0ac\uc6a9\uc790\uc5d0\uac8c \ud45c\uc2dc\ub418\ub294 \uc774\ub984."
                   },
                   "timezone": {
                     "type": "string",
-                    "description": "거래소 현지 시간대 (IANA)."
+                    "description": "\uac70\ub798\uc18c \ud604\uc9c0 \uc2dc\uac04\ub300 (IANA)."
                   },
                   "trading_hours_start": {
                     "type": "string",
                     "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
-                    "description": "거래 시작 시각 (현지 시간, strict HH:MM 24시간 형식). 초/마이크로초 포함, 빈 문자열, invalid 시간은 422로 거부된다 (#1334)."
+                    "description": "\uac70\ub798 \uc2dc\uc791 \uc2dc\uac01 (\ud604\uc9c0 \uc2dc\uac04, strict HH:MM 24\uc2dc\uac04 \ud615\uc2dd). \ucd08/\ub9c8\uc774\ud06c\ub85c\ucd08 \ud3ec\ud568, \ube48 \ubb38\uc790\uc5f4, invalid \uc2dc\uac04\uc740 422\ub85c \uac70\ubd80\ub41c\ub2e4 (#1334)."
                   },
                   "trading_hours_end": {
                     "type": "string",
                     "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
-                    "description": "거래 종료 시각 (현지 시간, strict HH:MM 24시간 형식). 초/마이크로초 포함, 빈 문자열, invalid 시간은 422로 거부된다 (#1334)."
+                    "description": "\uac70\ub798 \uc885\ub8cc \uc2dc\uac01 (\ud604\uc9c0 \uc2dc\uac04, strict HH:MM 24\uc2dc\uac04 \ud615\uc2dd). \ucd08/\ub9c8\uc774\ud06c\ub85c\ucd08 \ud3ec\ud568, \ube48 \ubb38\uc790\uc5f4, invalid \uc2dc\uac04\uc740 422\ub85c \uac70\ubd80\ub41c\ub2e4 (#1334)."
                   }
                 }
               }
@@ -370,7 +370,7 @@
           "accounts"
         ],
         "summary": "Delete Account",
-        "description": "계좌 소프트 딜리트. 인증된 master/human 또는 ``account:write`` scope 를\n보유한 agent 만 호출 가능 (#1407).\n\n런타임 Web API에서는 cold-path 가드가 모든 요청을 즉시 409로 차단한다.\n실제 계좌 삭제는 서버 정지 상태에서 ``ante account delete`` CLI로\n수행한다.\n\n의존성/audit logger를 시그니처에서 제외해 핸들러 진입 즉시 409가\n반환되도록 한다(invariant I1). OpenAPI에는 success contract(200/201/\n204)가 노출되지 않으며, 409 응답은 명시 ``responses[409]`` content\nmap의 ``application/problem+json``으로 ``ErrorResponse``를 노출한다\n(invariant I2/I3, #1164). service-layer 회귀 보호는\n``tests/unit/test_account.py``의 ``test_delete_account``,\n``test_delete_already_deleted_account_raises``가 담당한다.",
+        "description": "\uacc4\uc88c \uc18c\ud504\ud2b8 \ub51c\ub9ac\ud2b8. \uc778\uc99d\ub41c master/human \ub610\ub294 ``account:write`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).\n\n\ub7f0\ud0c0\uc784 Web API\uc5d0\uc11c\ub294 cold-path \uac00\ub4dc\uac00 \ubaa8\ub4e0 \uc694\uccad\uc744 \uc989\uc2dc 409\ub85c \ucc28\ub2e8\ud55c\ub2e4.\n\uc2e4\uc81c \uacc4\uc88c \uc0ad\uc81c\ub294 \uc11c\ubc84 \uc815\uc9c0 \uc0c1\ud0dc\uc5d0\uc11c ``ante account delete`` CLI\ub85c\n\uc218\ud589\ud55c\ub2e4.\n\n\uc758\uc874\uc131/audit logger\ub97c \uc2dc\uadf8\ub2c8\ucc98\uc5d0\uc11c \uc81c\uc678\ud574 \ud578\ub4e4\ub7ec \uc9c4\uc785 \uc989\uc2dc 409\uac00\n\ubc18\ud658\ub418\ub3c4\ub85d \ud55c\ub2e4(invariant I1). OpenAPI\uc5d0\ub294 success contract(200/201/\n204)\uac00 \ub178\ucd9c\ub418\uc9c0 \uc54a\uc73c\uba70, 409 \uc751\ub2f5\uc740 \uba85\uc2dc ``responses[409]`` content\nmap\uc758 ``application/problem+json``\uc73c\ub85c ``ErrorResponse``\ub97c \ub178\ucd9c\ud55c\ub2e4\n(invariant I2/I3, #1164). service-layer \ud68c\uadc0 \ubcf4\ud638\ub294\n``tests/unit/test_account.py``\uc758 ``test_delete_account``,\n``test_delete_already_deleted_account_raises``\uac00 \ub2f4\ub2f9\ud55c\ub2e4.",
         "operationId": "delete_account_api_accounts__account_id__delete",
         "parameters": [
           {
@@ -385,7 +385,7 @@
         ],
         "responses": {
           "409": {
-            "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER — 런타임 계좌 삭제 차단",
+            "description": "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER \u2014 \ub7f0\ud0c0\uc784 \uacc4\uc88c \uc0ad\uc81c \ucc28\ub2e8",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -413,7 +413,7 @@
           "accounts"
         ],
         "summary": "Suspend Account",
-        "description": "계좌 정지. 인증된 master/human 또는 ``account:write`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``account:write`` 정합, #1352\nmaster_caller 에서 마이그레이션).\n\n``update_bot`` / ``set_balance`` / ``update_scopes``와 동일한 raw body 파싱\n패턴을 적용해 인증 가드가 body validation보다 먼저 실행되도록 한다(#1352\nCodex review 2차). FastAPI가 ``body: AccountSuspendRequest``를 typed로\n먼저 검증하면 unauth + malformed body 시 401이 아닌 422가 먼저 반환되어\n``update_bot`` / ``set_balance``의 auth-first 계약과 어긋난다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_account_write)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기. 빈 body → default reason (``dashboard``)로 흘려보낸다\n   (기존 의미 보존).\n3. JSON 파싱 실패 → 422.\n4. JSON ``null`` (``payload is None``) → 빈 body와 동일하게 default\n   reason 경로로 흘려보낸다 (이전 ``Optional[Body(...)]`` 계약 호환,\n   #1352 Codex review 3차).\n5. ``AccountSuspendRequest.model_validate`` ValidationError(extra forbid\n   포함) → 422.\n6. service 호출.",
+        "description": "\uacc4\uc88c \uc815\uc9c0. \uc778\uc99d\ub41c master/human \ub610\ub294 ``account:write`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``account:write`` \uc815\ud569, #1352\nmaster_caller \uc5d0\uc11c \ub9c8\uc774\uadf8\ub808\uc774\uc158).\n\n``update_bot`` / ``set_balance`` / ``update_scopes``\uc640 \ub3d9\uc77c\ud55c raw body \ud30c\uc2f1\n\ud328\ud134\uc744 \uc801\uc6a9\ud574 \uc778\uc99d \uac00\ub4dc\uac00 body validation\ubcf4\ub2e4 \uba3c\uc800 \uc2e4\ud589\ub418\ub3c4\ub85d \ud55c\ub2e4(#1352\nCodex review 2\ucc28). FastAPI\uac00 ``body: AccountSuspendRequest``\ub97c typed\ub85c\n\uba3c\uc800 \uac80\uc99d\ud558\uba74 unauth + malformed body \uc2dc 401\uc774 \uc544\ub2cc 422\uac00 \uba3c\uc800 \ubc18\ud658\ub418\uc5b4\n``update_bot`` / ``set_balance``\uc758 auth-first \uacc4\uc57d\uacfc \uc5b4\uae0b\ub09c\ub2e4.\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n\n1. \uc778\uc99d \uac00\ub4dc (``Depends(require_account_write)``) \u2014 caller \ube48 \u2192 401,\n   \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403.\n2. raw bytes \uc77d\uae30. \ube48 body \u2192 default reason (``dashboard``)\ub85c \ud758\ub824\ubcf4\ub0b8\ub2e4\n   (\uae30\uc874 \uc758\ubbf8 \ubcf4\uc874).\n3. JSON \ud30c\uc2f1 \uc2e4\ud328 \u2192 422.\n4. JSON ``null`` (``payload is None``) \u2192 \ube48 body\uc640 \ub3d9\uc77c\ud558\uac8c default\n   reason \uacbd\ub85c\ub85c \ud758\ub824\ubcf4\ub0b8\ub2e4 (\uc774\uc804 ``Optional[Body(...)]`` \uacc4\uc57d \ud638\ud658,\n   #1352 Codex review 3\ucc28).\n5. ``AccountSuspendRequest.model_validate`` ValidationError(extra forbid\n   \ud3ec\ud568) \u2192 422.\n6. service \ud638\ucd9c.",
         "operationId": "suspend_account_api_accounts__account_id__suspend_post",
         "parameters": [
           {
@@ -438,7 +438,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -448,7 +448,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 account:write scope 보유 agent 만 허용)",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 account:write scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -513,7 +513,7 @@
           "accounts"
         ],
         "summary": "Activate Account",
-        "description": "계좌 재활성화. 인증된 master/human 또는 ``account:write`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``account:write`` 정합, #1352\nmaster_caller 에서 마이그레이션).",
+        "description": "\uacc4\uc88c \uc7ac\ud65c\uc131\ud654. \uc778\uc99d\ub41c master/human \ub610\ub294 ``account:write`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``account:write`` \uc815\ud569, #1352\nmaster_caller \uc5d0\uc11c \ub9c8\uc774\uadf8\ub808\uc774\uc158).",
         "operationId": "activate_account_api_accounts__account_id__activate_post",
         "parameters": [
           {
@@ -538,7 +538,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -548,7 +548,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 account:write scope 보유 agent 만 허용)",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 account:write scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -596,7 +596,7 @@
           "accounts"
         ],
         "summary": "Get Account Rules",
-        "description": "계좌 리스크 룰 목록 조회. 인증된 master/human 또는 ``rule:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).\n\nDynamicConfig를 우선 조회하고, 없으면 정적 Config에서 읽는다.\nRULE_REGISTRY에 등록된 룰 타입만 구조화하여 반환한다.",
+        "description": "\uacc4\uc88c \ub9ac\uc2a4\ud06c \ub8f0 \ubaa9\ub85d \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``rule:read`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).\n\nDynamicConfig\ub97c \uc6b0\uc120 \uc870\ud68c\ud558\uace0, \uc5c6\uc73c\uba74 \uc815\uc801 Config\uc5d0\uc11c \uc77d\ub294\ub2e4.\nRULE_REGISTRY\uc5d0 \ub4f1\ub85d\ub41c \ub8f0 \ud0c0\uc785\ub9cc \uad6c\uc870\ud654\ud558\uc5ec \ubc18\ud658\ud55c\ub2e4.",
         "operationId": "get_account_rules_api_accounts__account_id__rules_get",
         "parameters": [
           {
@@ -639,7 +639,7 @@
           "accounts"
         ],
         "summary": "Update Account Rule",
-        "description": "계좌 리스크 룰 개별 수정. 인증된 master/human 또는 ``rule:admin`` scope\n를 보유한 agent 만 호출 가능 (#1407 — spec ``rule:admin`` 정합, #1376\nmaster_caller 에서 마이그레이션).\n\nRULE_REGISTRY에 등록된 타입만 허용하며,\nDynamicConfigService에 위임하여 ConfigChangedEvent를 발행한다.\n\n저장되는 ``accounts.{account_id}.rules`` 값은 explicit overrides(stored\nrules)다. RuleEngine이 실제로 적용하는 effective rules는\n``ante.rule.defaults.resolve_effective_rules``가 broker_type별 defaults와\n이 stored rules를 merge한 결과이며, ``ConfigChangedEvent`` reload 시\n동일 helper가 다시 호출된다. 본 GET/PUT API는 stored rules만 다룬다 —\neffective view는 후속 이슈에서 별도 엔드포인트로 노출한다 (#1296).\n\n``submit_report`` (#1374) / ``halt`` (#1375) 와 동일한 raw body 파싱\n패턴을 적용해 인증 가드가 body validation 보다 우선 실행되도록 한다.\nFastAPI 가 ``body: RuleUpdateRequest`` 를 먼저 검증하면 unauth + bad-body\n시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다 — 본 라우트는\noracle A7 finding 의 핵심 시그니처 이므로 인증 가드 우선이 가장 중요하다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_rule_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``RuleUpdateRequest.model_validate`` — ValidationError → 422.\n4. RULE_REGISTRY 룰 타입 확인 — 없으면 400 (기존 계약 보존).\n5. RULE_REGISTRY[rule_type].validate_config — 실패 시 422.\n6. DynamicConfig 저장 + audit 기록 (changed_by / member_id = caller_id).",
+        "description": "\uacc4\uc88c \ub9ac\uc2a4\ud06c \ub8f0 \uac1c\ubcc4 \uc218\uc815. \uc778\uc99d\ub41c master/human \ub610\ub294 ``rule:admin`` scope\n\ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``rule:admin`` \uc815\ud569, #1376\nmaster_caller \uc5d0\uc11c \ub9c8\uc774\uadf8\ub808\uc774\uc158).\n\nRULE_REGISTRY\uc5d0 \ub4f1\ub85d\ub41c \ud0c0\uc785\ub9cc \ud5c8\uc6a9\ud558\uba70,\nDynamicConfigService\uc5d0 \uc704\uc784\ud558\uc5ec ConfigChangedEvent\ub97c \ubc1c\ud589\ud55c\ub2e4.\n\n\uc800\uc7a5\ub418\ub294 ``accounts.{account_id}.rules`` \uac12\uc740 explicit overrides(stored\nrules)\ub2e4. RuleEngine\uc774 \uc2e4\uc81c\ub85c \uc801\uc6a9\ud558\ub294 effective rules\ub294\n``ante.rule.defaults.resolve_effective_rules``\uac00 broker_type\ubcc4 defaults\uc640\n\uc774 stored rules\ub97c merge\ud55c \uacb0\uacfc\uc774\uba70, ``ConfigChangedEvent`` reload \uc2dc\n\ub3d9\uc77c helper\uac00 \ub2e4\uc2dc \ud638\ucd9c\ub41c\ub2e4. \ubcf8 GET/PUT API\ub294 stored rules\ub9cc \ub2e4\ub8ec\ub2e4 \u2014\neffective view\ub294 \ud6c4\uc18d \uc774\uc288\uc5d0\uc11c \ubcc4\ub3c4 \uc5d4\ub4dc\ud3ec\uc778\ud2b8\ub85c \ub178\ucd9c\ud55c\ub2e4 (#1296).\n\n``submit_report`` (#1374) / ``halt`` (#1375) \uc640 \ub3d9\uc77c\ud55c raw body \ud30c\uc2f1\n\ud328\ud134\uc744 \uc801\uc6a9\ud574 \uc778\uc99d \uac00\ub4dc\uac00 body validation \ubcf4\ub2e4 \uc6b0\uc120 \uc2e4\ud589\ub418\ub3c4\ub85d \ud55c\ub2e4.\nFastAPI \uac00 ``body: RuleUpdateRequest`` \ub97c \uba3c\uc800 \uac80\uc99d\ud558\uba74 unauth + bad-body\n\uc2dc 401 \uc774 \uc544\ub2cc 422 \uac00 \uba3c\uc800 \ubc18\ud658\ub418\uc5b4 contract \uac00 \uae68\uc9c4\ub2e4 \u2014 \ubcf8 \ub77c\uc6b0\ud2b8\ub294\noracle A7 finding \uc758 \ud575\uc2ec \uc2dc\uadf8\ub2c8\ucc98 \uc774\ubbc0\ub85c \uc778\uc99d \uac00\ub4dc \uc6b0\uc120\uc774 \uac00\uc7a5 \uc911\uc694\ud558\ub2e4.\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n\n1. \uc778\uc99d \uac00\ub4dc (``Depends(require_rule_admin)``) \u2014 caller \ube48 \u2192 401,\n   \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403.\n2. raw bytes \uc77d\uae30 + JSON \ud30c\uc2f1 \u2014 \uc2e4\ud328 \uc2dc 422.\n3. ``RuleUpdateRequest.model_validate`` \u2014 ValidationError \u2192 422.\n4. RULE_REGISTRY \ub8f0 \ud0c0\uc785 \ud655\uc778 \u2014 \uc5c6\uc73c\uba74 400 (\uae30\uc874 \uacc4\uc57d \ubcf4\uc874).\n5. RULE_REGISTRY[rule_type].validate_config \u2014 \uc2e4\ud328 \uc2dc 422.\n6. DynamicConfig \uc800\uc7a5 + audit \uae30\ub85d (changed_by / member_id = caller_id).",
         "operationId": "update_account_rule_api_accounts__account_id__rules__rule_type__put",
         "parameters": [
           {
@@ -673,7 +673,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -683,7 +683,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 rule:admin scope 보유 agent 만 허용).",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 rule:admin scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -693,7 +693,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, 필수 필드 누락, type mismatch, 룰 config 범위 검증 실패). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다 (#1376).",
+            "description": "Body validation \uc2e4\ud328 (JSON \ud30c\uc2f1 \uc2e4\ud328, \ube48 body, \ud544\uc218 \ud544\ub4dc \ub204\ub77d, type mismatch, \ub8f0 config \ubc94\uc704 \uac80\uc99d \uc2e4\ud328). \ub2e8, \uc778\uc99d\uc774 \uc2e4\ud328\ud558\uba74 body validation \uc740 \uc2e4\ud589\ub418\uc9c0 \uc54a\uace0 401 \uc774 \uc6b0\uc120 \ubc18\ud658\ub41c\ub2e4 (#1376).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -721,7 +721,7 @@
           "auth"
         ],
         "summary": "Login",
-        "description": "패스워드 로그인 -> 세션 쿠키 발급.",
+        "description": "\ud328\uc2a4\uc6cc\ub4dc \ub85c\uadf8\uc778 -> \uc138\uc158 \ucfe0\ud0a4 \ubc1c\uae09.",
         "operationId": "login_api_auth_login_post",
         "requestBody": {
           "content": {
@@ -783,7 +783,7 @@
           "auth"
         ],
         "summary": "Logout",
-        "description": "로그아웃 — 세션 삭제 + 쿠키 제거.",
+        "description": "\ub85c\uadf8\uc544\uc6c3 \u2014 \uc138\uc158 \uc0ad\uc81c + \ucfe0\ud0a4 \uc81c\uac70.",
         "operationId": "logout_api_auth_logout_post",
         "parameters": [
           {
@@ -843,7 +843,7 @@
           "auth"
         ],
         "summary": "Me",
-        "description": "현재 로그인 사용자 정보.\n\nBearer 토큰 또는 세션 쿠키로 인증한다.\n- Bearer 토큰: TokenAuthMiddleware가 request.state.member에 설정\n- 세션 쿠키: ante_session 쿠키로 세션 조회",
+        "description": "\ud604\uc7ac \ub85c\uadf8\uc778 \uc0ac\uc6a9\uc790 \uc815\ubcf4.\n\nBearer \ud1a0\ud070 \ub610\ub294 \uc138\uc158 \ucfe0\ud0a4\ub85c \uc778\uc99d\ud55c\ub2e4.\n- Bearer \ud1a0\ud070: TokenAuthMiddleware\uac00 request.state.member\uc5d0 \uc124\uc815\n- \uc138\uc158 \ucfe0\ud0a4: ante_session \ucfe0\ud0a4\ub85c \uc138\uc158 \uc870\ud68c",
         "operationId": "me_api_auth_me_get",
         "parameters": [
           {
@@ -913,7 +913,7 @@
           "approvals"
         ],
         "summary": "List Approvals",
-        "description": "결재 목록 조회.",
+        "description": "\uacb0\uc7ac \ubaa9\ub85d \uc870\ud68c.",
         "operationId": "list_approvals_api_approvals_get",
         "parameters": [
           {
@@ -1028,7 +1028,7 @@
           "approvals"
         ],
         "summary": "Get Approval",
-        "description": "결재 상세 조회. 인증된 master/human 또는 ``approval:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
+        "description": "\uacb0\uc7ac \uc0c1\uc138 \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``approval:read`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "get_approval_api_approvals__approval_id__get",
         "parameters": [
           {
@@ -1091,7 +1091,7 @@
           "approvals"
         ],
         "summary": "Update Approval Status",
-        "description": "결재 승인/거부 처리. 인증된 master/human 또는 ``approval:admin`` scope\n를 보유한 agent 만 호출 가능 (#1407 — spec ``approval:admin`` 정합).\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. FastAPI 가 ``body: ApprovalStatusUpdate`` 를 먼저 검증하면 unauth +\nbad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_approval_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``ApprovalStatusUpdate.model_validate`` — ValidationError → 422.\n   ``status`` 는 ``Literal[\"approved\", \"rejected\"]`` SSOT 이므로 invalid\n   값은 schema 단계에서 422 로 차단된다 (#1434).\n4. service 호출 (``approve`` / ``reject``).",
+        "description": "\uacb0\uc7ac \uc2b9\uc778/\uac70\ubd80 \ucc98\ub9ac. \uc778\uc99d\ub41c master/human \ub610\ub294 ``approval:admin`` scope\n\ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``approval:admin`` \uc815\ud569).\n\nRaw body \ud30c\uc2f1 \ud328\ud134\uc73c\ub85c \uc778\uc99d \uac00\ub4dc\uac00 body validation \ubcf4\ub2e4 \uc6b0\uc120 \uc2e4\ud589\ub418\ub3c4\ub85d\n\ud55c\ub2e4. FastAPI \uac00 ``body: ApprovalStatusUpdate`` \ub97c \uba3c\uc800 \uac80\uc99d\ud558\uba74 unauth +\nbad-body \uc2dc 401 \uc774 \uc544\ub2cc 422 \uac00 \uba3c\uc800 \ubc18\ud658\ub418\uc5b4 contract \uac00 \uae68\uc9c4\ub2e4.\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n\n1. \uc778\uc99d \uac00\ub4dc (``Depends(require_approval_admin)``) \u2014 caller \ube48 \u2192 401,\n   \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403.\n2. raw bytes \uc77d\uae30 + JSON \ud30c\uc2f1 \u2014 \uc2e4\ud328 \uc2dc 422.\n3. ``ApprovalStatusUpdate.model_validate`` \u2014 ValidationError \u2192 422.\n   ``status`` \ub294 ``Literal[\"approved\", \"rejected\"]`` SSOT \uc774\ubbc0\ub85c invalid\n   \uac12\uc740 schema \ub2e8\uacc4\uc5d0\uc11c 422 \ub85c \ucc28\ub2e8\ub41c\ub2e4 (#1434).\n4. service \ud638\ucd9c (``approve`` / ``reject``).",
         "operationId": "update_approval_status_api_approvals__approval_id__status_patch",
         "parameters": [
           {
@@ -1116,7 +1116,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1126,7 +1126,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 approval:admin scope 보유 agent 만 허용).",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 approval:admin scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1146,7 +1146,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, 필수 필드 누락, type mismatch). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다(#1407).",
+            "description": "Body validation \uc2e4\ud328 (JSON \ud30c\uc2f1 \uc2e4\ud328, \ube48 body, \ud544\uc218 \ud544\ub4dc \ub204\ub77d, type mismatch). \ub2e8, \uc778\uc99d\uc774 \uc2e4\ud328\ud558\uba74 body validation \uc740 \uc2e4\ud589\ub418\uc9c0 \uc54a\uace0 401 \uc774 \uc6b0\uc120 \ubc18\ud658\ub41c\ub2e4(#1407).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1184,7 +1184,7 @@
           "audit"
         ],
         "summary": "List Audit Logs",
-        "description": "감사 로그 조회.\n\n인증/권한:\n    oracle A7 시그니처(#1359)에서 본 라우트는 인증 없이 감사 로그 목록을\n    반환하고 있었다. 감사 로그는 운영 행위 추적 정보(member_id, action,\n    resource, IP 등)를 담으므로 인증 가드를 적용한다. 인증 누락은 401,\n    권한 없음은 403.\n\n    Codex P2 (#1359 fix loop, 2차): 초기 패치는 ``require_master_caller``\n    를 그대로 적용해 ``master`` role만 허용했으나,\n    ``docs/specs/member/02-design-decisions.md:188-229`` 의 모니터링 agent\n    (``audit:read`` scope만 가진 default role)가 차단되는 문제가 있었다.\n    spec은 audit 도메인 read 권한을 ``master`` role 또는 ``audit:read``\n    scope 중 하나로 정의하므로, ``require_audit_read`` (master OR\n    ``audit:read`` ∈ Member.scopes)로 교체해 spec과 일치시켰다.\n\nCodex P2 (#1359 fix loop): FastAPI는 핸들러 매개변수 선언 순서대로\ndependency를 해결한다. ``audit_logger`` (필수 service, 미주입 시 503)를\n``require_audit_read`` 보다 먼저 두면, 인증 정보가 없는 호출자에게\n503이 먼저 반환되어 \"인증 누락은 401\" 계약이 깨진다. 그러므로 인증\n가드(``caller_id``)를 항상 먼저 선언해 401/403이 503보다 우선하도록 한다.\n\nNOTE: ``limit``은 다른 list endpoint와 일관된 ``le=100``으로 검증한다.\n이전 구현은 ``min(limit, 200)``로 자동 클램프했으나, #1356에서\npagination contract 일관성을 위해 클램프를 제거하고 Query\nvalidation으로 대체했다 (101..200 범위 요청은 새로 422). 다른 caller가\n이 범위를 강제하면 별도 endpoint로 분리한다.\n\nCodex P2 (#1414 fix loop r1): ``from_date``/``to_date``는 ``str | None``\n타입으로 받아 ``_validate_iso_date`` 헬퍼로 ISO 8601 파싱 가능성만 검증\n하고, 원본 str을 그대로 ``AuditLogger.query/count``에 전달한다. 이전\n구현은 ``Annotated[datetime | None, ...]``로 좁혀 Pydantic이 자동 변환\n하도록 했으나, date-only 입력이 ``\"2026-05-10T00:00:00\"`` (19자리)로\n변환되어 ``AuditLogger`` 내부의 ``len(to_date) == 10`` 자동 확장 분기가\n작동하지 않게 되어 자정 이후 데이터를 누락하는 silent semantic\nregression이 발생했다. 본 구현은 str을 보존해 그 회귀를 해소한다.\n\nCodex P2 (#1414 fix loop r2): datetime 입력(``2026-05-10T00:00:00Z`` 등)\n을 r1처럼 그대로 보존하면 SQL 텍스트 비교에서 storage format(Z 없는\nnaive UTC)과 어긋나 inclusive boundary가 깨진다. ``Z``/offset 입력을\nstorage format으로 정규화하도록 헬퍼를 보강했다. date-only는 자동 확장\n경로를 위해 변환 없이 그대로 보존된다.",
+        "description": "\uac10\uc0ac \ub85c\uadf8 \uc870\ud68c.\n\n\uc778\uc99d/\uad8c\ud55c:\n    oracle A7 \uc2dc\uadf8\ub2c8\ucc98(#1359)\uc5d0\uc11c \ubcf8 \ub77c\uc6b0\ud2b8\ub294 \uc778\uc99d \uc5c6\uc774 \uac10\uc0ac \ub85c\uadf8 \ubaa9\ub85d\uc744\n    \ubc18\ud658\ud558\uace0 \uc788\uc5c8\ub2e4. \uac10\uc0ac \ub85c\uadf8\ub294 \uc6b4\uc601 \ud589\uc704 \ucd94\uc801 \uc815\ubcf4(member_id, action,\n    resource, IP \ub4f1)\ub97c \ub2f4\uc73c\ubbc0\ub85c \uc778\uc99d \uac00\ub4dc\ub97c \uc801\uc6a9\ud55c\ub2e4. \uc778\uc99d \ub204\ub77d\uc740 401,\n    \uad8c\ud55c \uc5c6\uc74c\uc740 403.\n\n    Codex P2 (#1359 fix loop, 2\ucc28): \ucd08\uae30 \ud328\uce58\ub294 ``require_master_caller``\n    \ub97c \uadf8\ub300\ub85c \uc801\uc6a9\ud574 ``master`` role\ub9cc \ud5c8\uc6a9\ud588\uc73c\ub098,\n    ``docs/specs/member/02-design-decisions.md:188-229`` \uc758 \ubaa8\ub2c8\ud130\ub9c1 agent\n    (``audit:read`` scope\ub9cc \uac00\uc9c4 default role)\uac00 \ucc28\ub2e8\ub418\ub294 \ubb38\uc81c\uac00 \uc788\uc5c8\ub2e4.\n    spec\uc740 audit \ub3c4\uba54\uc778 read \uad8c\ud55c\uc744 ``master`` role \ub610\ub294 ``audit:read``\n    scope \uc911 \ud558\ub098\ub85c \uc815\uc758\ud558\ubbc0\ub85c, ``require_audit_read`` (master OR\n    ``audit:read`` \u2208 Member.scopes)\ub85c \uad50\uccb4\ud574 spec\uacfc \uc77c\uce58\uc2dc\ucf30\ub2e4.\n\nCodex P2 (#1359 fix loop): FastAPI\ub294 \ud578\ub4e4\ub7ec \ub9e4\uac1c\ubcc0\uc218 \uc120\uc5b8 \uc21c\uc11c\ub300\ub85c\ndependency\ub97c \ud574\uacb0\ud55c\ub2e4. ``audit_logger`` (\ud544\uc218 service, \ubbf8\uc8fc\uc785 \uc2dc 503)\ub97c\n``require_audit_read`` \ubcf4\ub2e4 \uba3c\uc800 \ub450\uba74, \uc778\uc99d \uc815\ubcf4\uac00 \uc5c6\ub294 \ud638\ucd9c\uc790\uc5d0\uac8c\n503\uc774 \uba3c\uc800 \ubc18\ud658\ub418\uc5b4 \"\uc778\uc99d \ub204\ub77d\uc740 401\" \uacc4\uc57d\uc774 \uae68\uc9c4\ub2e4. \uadf8\ub7ec\ubbc0\ub85c \uc778\uc99d\n\uac00\ub4dc(``caller_id``)\ub97c \ud56d\uc0c1 \uba3c\uc800 \uc120\uc5b8\ud574 401/403\uc774 503\ubcf4\ub2e4 \uc6b0\uc120\ud558\ub3c4\ub85d \ud55c\ub2e4.\n\nNOTE: ``limit``\uc740 \ub2e4\ub978 list endpoint\uc640 \uc77c\uad00\ub41c ``le=100``\uc73c\ub85c \uac80\uc99d\ud55c\ub2e4.\n\uc774\uc804 \uad6c\ud604\uc740 ``min(limit, 200)``\ub85c \uc790\ub3d9 \ud074\ub7a8\ud504\ud588\uc73c\ub098, #1356\uc5d0\uc11c\npagination contract \uc77c\uad00\uc131\uc744 \uc704\ud574 \ud074\ub7a8\ud504\ub97c \uc81c\uac70\ud558\uace0 Query\nvalidation\uc73c\ub85c \ub300\uccb4\ud588\ub2e4 (101..200 \ubc94\uc704 \uc694\uccad\uc740 \uc0c8\ub85c 422). \ub2e4\ub978 caller\uac00\n\uc774 \ubc94\uc704\ub97c \uac15\uc81c\ud558\uba74 \ubcc4\ub3c4 endpoint\ub85c \ubd84\ub9ac\ud55c\ub2e4.\n\nCodex P2 (#1414 fix loop r1): ``from_date``/``to_date``\ub294 ``str | None``\n\ud0c0\uc785\uc73c\ub85c \ubc1b\uc544 ``_validate_iso_date`` \ud5ec\ud37c\ub85c ISO 8601 \ud30c\uc2f1 \uac00\ub2a5\uc131\ub9cc \uac80\uc99d\n\ud558\uace0, \uc6d0\ubcf8 str\uc744 \uadf8\ub300\ub85c ``AuditLogger.query/count``\uc5d0 \uc804\ub2ec\ud55c\ub2e4. \uc774\uc804\n\uad6c\ud604\uc740 ``Annotated[datetime | None, ...]``\ub85c \uc881\ud600 Pydantic\uc774 \uc790\ub3d9 \ubcc0\ud658\n\ud558\ub3c4\ub85d \ud588\uc73c\ub098, date-only \uc785\ub825\uc774 ``\"2026-05-10T00:00:00\"`` (19\uc790\ub9ac)\ub85c\n\ubcc0\ud658\ub418\uc5b4 ``AuditLogger`` \ub0b4\ubd80\uc758 ``len(to_date) == 10`` \uc790\ub3d9 \ud655\uc7a5 \ubd84\uae30\uac00\n\uc791\ub3d9\ud558\uc9c0 \uc54a\uac8c \ub418\uc5b4 \uc790\uc815 \uc774\ud6c4 \ub370\uc774\ud130\ub97c \ub204\ub77d\ud558\ub294 silent semantic\nregression\uc774 \ubc1c\uc0dd\ud588\ub2e4. \ubcf8 \uad6c\ud604\uc740 str\uc744 \ubcf4\uc874\ud574 \uadf8 \ud68c\uadc0\ub97c \ud574\uc18c\ud55c\ub2e4.\n\nCodex P2 (#1414 fix loop r2): datetime \uc785\ub825(``2026-05-10T00:00:00Z`` \ub4f1)\n\uc744 r1\ucc98\ub7fc \uadf8\ub300\ub85c \ubcf4\uc874\ud558\uba74 SQL \ud14d\uc2a4\ud2b8 \ube44\uad50\uc5d0\uc11c storage format(Z \uc5c6\ub294\nnaive UTC)\uacfc \uc5b4\uae0b\ub098 inclusive boundary\uac00 \uae68\uc9c4\ub2e4. ``Z``/offset \uc785\ub825\uc744\nstorage format\uc73c\ub85c \uc815\uaddc\ud654\ud558\ub3c4\ub85d \ud5ec\ud37c\ub97c \ubcf4\uac15\ud588\ub2e4. date-only\ub294 \uc790\ub3d9 \ud655\uc7a5\n\uacbd\ub85c\ub97c \uc704\ud574 \ubcc0\ud658 \uc5c6\uc774 \uadf8\ub300\ub85c \ubcf4\uc874\ub41c\ub2e4.",
         "operationId": "list_audit_logs_api_audit_get",
         "parameters": [
           {
@@ -1232,10 +1232,10 @@
                   "type": "null"
                 }
               ],
-              "description": "ISO 8601 date (``YYYY-MM-DD``) 또는 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive lower bound.",
+              "description": "ISO 8601 date (``YYYY-MM-DD``) \ub610\ub294 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive lower bound.",
               "title": "From Date"
             },
-            "description": "ISO 8601 date (``YYYY-MM-DD``) 또는 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive lower bound."
+            "description": "ISO 8601 date (``YYYY-MM-DD``) \ub610\ub294 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive lower bound."
           },
           {
             "name": "to_date",
@@ -1250,10 +1250,10 @@
                   "type": "null"
                 }
               ],
-              "description": "ISO 8601 date (``YYYY-MM-DD``) 또는 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive upper bound. date-only는 ``AuditLogger`` 내부에서 ``T23:59:59``로 확장된다.",
+              "description": "ISO 8601 date (``YYYY-MM-DD``) \ub610\ub294 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive upper bound. date-only\ub294 ``AuditLogger`` \ub0b4\ubd80\uc5d0\uc11c ``T23:59:59``\ub85c \ud655\uc7a5\ub41c\ub2e4.",
               "title": "To Date"
             },
-            "description": "ISO 8601 date (``YYYY-MM-DD``) 또는 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive upper bound. date-only는 ``AuditLogger`` 내부에서 ``T23:59:59``로 확장된다."
+            "description": "ISO 8601 date (``YYYY-MM-DD``) \ub610\ub294 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive upper bound. date-only\ub294 ``AuditLogger`` \ub0b4\ubd80\uc5d0\uc11c ``T23:59:59``\ub85c \ud655\uc7a5\ub41c\ub2e4."
           },
           {
             "name": "limit",
@@ -1311,7 +1311,7 @@
             }
           },
           "422": {
-            "description": "Invalid date filter (ISO 8601 required). ``from_date``/``to_date``는 ISO 8601 date(``YYYY-MM-DD``) 또는 datetime(``YYYY-MM-DDTHH:MM:SS[Z]``)만 허용한다. 파싱 불가능한임의 문자열(예: ``not-a-date``)은 핸들러가 422로 거부한다(#1414). date-only 입력은 ``AuditLogger.query``의 자동 확장(SQL ``<= 'YYYY-MM-DDT23:59:59'``) 동작을 보존하기 위해 변환 없이 그대로 전달된다.",
+            "description": "Invalid date filter (ISO 8601 required). ``from_date``/``to_date``\ub294 ISO 8601 date(``YYYY-MM-DD``) \ub610\ub294 datetime(``YYYY-MM-DDTHH:MM:SS[Z]``)\ub9cc \ud5c8\uc6a9\ud55c\ub2e4. \ud30c\uc2f1 \ubd88\uac00\ub2a5\ud55c\uc784\uc758 \ubb38\uc790\uc5f4(\uc608: ``not-a-date``)\uc740 \ud578\ub4e4\ub7ec\uac00 422\ub85c \uac70\ubd80\ud55c\ub2e4(#1414). date-only \uc785\ub825\uc740 ``AuditLogger.query``\uc758 \uc790\ub3d9 \ud655\uc7a5(SQL ``<= 'YYYY-MM-DDT23:59:59'``) \ub3d9\uc791\uc744 \ubcf4\uc874\ud558\uae30 \uc704\ud574 \ubcc0\ud658 \uc5c6\uc774 \uadf8\ub300\ub85c \uc804\ub2ec\ub41c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1339,7 +1339,7 @@
           "portfolio"
         ],
         "summary": "Portfolio Value",
-        "description": "총 자산 가치 + 당일 손익 + 수익률 + 미실현 손익 (최신 스냅샷 기반).\n인증된 master/human 또는 ``treasury:read`` scope 를 보유한 agent 만 호출\n가능 (#1407 — portfolio 라우트는 ``treasury_daily_snapshots`` 를 읽으므로\nspec ``treasury:read`` 정합).",
+        "description": "\ucd1d \uc790\uc0b0 \uac00\uce58 + \ub2f9\uc77c \uc190\uc775 + \uc218\uc775\ub960 + \ubbf8\uc2e4\ud604 \uc190\uc775 (\ucd5c\uc2e0 \uc2a4\ub0c5\uc0f7 \uae30\ubc18).\n\uc778\uc99d\ub41c master/human \ub610\ub294 ``treasury:read`` scope \ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c\n\uac00\ub2a5 (#1407 \u2014 portfolio \ub77c\uc6b0\ud2b8\ub294 ``treasury_daily_snapshots`` \ub97c \uc77d\uc73c\ubbc0\ub85c\nspec ``treasury:read`` \uc815\ud569).",
         "operationId": "portfolio_value_api_portfolio_value_get",
         "parameters": [
           {
@@ -1399,7 +1399,7 @@
           "portfolio"
         ],
         "summary": "Portfolio History",
-        "description": "기간별 자산 추이 (daily_snapshots 시계열 반환). 인증된 master/human 또는\n``treasury:read`` scope 를 보유한 agent 만 호출 가능 (#1407).",
+        "description": "\uae30\uac04\ubcc4 \uc790\uc0b0 \ucd94\uc774 (daily_snapshots \uc2dc\uacc4\uc5f4 \ubc18\ud658). \uc778\uc99d\ub41c master/human \ub610\ub294\n``treasury:read`` scope \ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "portfolio_history_api_portfolio_history_get",
         "parameters": [
           {
@@ -1491,7 +1491,7 @@
           "members"
         ],
         "summary": "List Members",
-        "description": "멤버 목록 조회.\n\n``type``과 ``status``는 도메인 enum SSOT(``MemberType`` /\n``MemberStatus``)로 강제한다(#1358 — Codex Plan Review). 알 수 없는 값은\nFastAPI/Pydantic이 자동으로 422를 반환하므로 \"200 빈 목록\"으로 가려지지\n않는다. ``MemberService.list_members`` / ``count``는 ``str | None``을\n받으므로 ``StrEnum`` 인스턴스를 그대로 전달해도 SQL 비교(``type = ?`` /\n``status = ?``)에서 문자열로 동작한다.",
+        "description": "\uba64\ubc84 \ubaa9\ub85d \uc870\ud68c.\n\n``type``\uacfc ``status``\ub294 \ub3c4\uba54\uc778 enum SSOT(``MemberType`` /\n``MemberStatus``)\ub85c \uac15\uc81c\ud55c\ub2e4(#1358 \u2014 Codex Plan Review). \uc54c \uc218 \uc5c6\ub294 \uac12\uc740\nFastAPI/Pydantic\uc774 \uc790\ub3d9\uc73c\ub85c 422\ub97c \ubc18\ud658\ud558\ubbc0\ub85c \"200 \ube48 \ubaa9\ub85d\"\uc73c\ub85c \uac00\ub824\uc9c0\uc9c0\n\uc54a\ub294\ub2e4. ``MemberService.list_members`` / ``count``\ub294 ``str | None``\uc744\n\ubc1b\uc73c\ubbc0\ub85c ``StrEnum`` \uc778\uc2a4\ud134\uc2a4\ub97c \uadf8\ub300\ub85c \uc804\ub2ec\ud574\ub3c4 SQL \ube44\uad50(``type = ?`` /\n``status = ?``)\uc5d0\uc11c \ubb38\uc790\uc5f4\ub85c \ub3d9\uc791\ud55c\ub2e4.",
         "operationId": "list_members_api_members_get",
         "parameters": [
           {
@@ -1604,7 +1604,7 @@
           "members"
         ],
         "summary": "Create Member",
-        "description": "멤버 등록. 토큰 1회 반환. 인증된 master/human 또는 ``member:admin`` scope\n를 보유한 agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).\n\n인증 가드는 body validation보다 **반드시 먼저** 실행된다(#1339 P2). FastAPI\n가 ``body: MemberCreateRequest`` 파라미터를 먼저 파싱하면 Authorization\n헤더 미존재 + 필수 필드 누락 케이스에서 401 이 아니라 422 가 먼저 응답되어\n\"missing or invalid Authorization header는 401\" 계약이 깨진다. 이 이유로\n본 라우트는 ``request: Request`` 와 ``require_member_admin`` 만 받고 raw\nbody 를 직접 파싱한다 (``update_account`` SSOT 패턴 일치).\n\n핸들러 단계 순서:\n1. **인증 가드 (최우선, ``Depends(require_member_admin)``)** — caller 빈\n   → 401, 권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽고 JSON 파싱 — 실패 시 422.\n3. ``MemberCreateRequest.model_validate`` — ValidationError → 422.\n4. ``svc.register`` 호출. ``PermissionError`` → 403, ``ValueError`` → 400.",
+        "description": "\uba64\ubc84 \ub4f1\ub85d. \ud1a0\ud070 1\ud68c \ubc18\ud658. \uc778\uc99d\ub41c master/human \ub610\ub294 ``member:admin`` scope\n\ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``member:admin`` \uc815\ud569).\n\n\uc778\uc99d \uac00\ub4dc\ub294 body validation\ubcf4\ub2e4 **\ubc18\ub4dc\uc2dc \uba3c\uc800** \uc2e4\ud589\ub41c\ub2e4(#1339 P2). FastAPI\n\uac00 ``body: MemberCreateRequest`` \ud30c\ub77c\ubbf8\ud130\ub97c \uba3c\uc800 \ud30c\uc2f1\ud558\uba74 Authorization\n\ud5e4\ub354 \ubbf8\uc874\uc7ac + \ud544\uc218 \ud544\ub4dc \ub204\ub77d \ucf00\uc774\uc2a4\uc5d0\uc11c 401 \uc774 \uc544\ub2c8\ub77c 422 \uac00 \uba3c\uc800 \uc751\ub2f5\ub418\uc5b4\n\"missing or invalid Authorization header\ub294 401\" \uacc4\uc57d\uc774 \uae68\uc9c4\ub2e4. \uc774 \uc774\uc720\ub85c\n\ubcf8 \ub77c\uc6b0\ud2b8\ub294 ``request: Request`` \uc640 ``require_member_admin`` \ub9cc \ubc1b\uace0 raw\nbody \ub97c \uc9c1\uc811 \ud30c\uc2f1\ud55c\ub2e4 (``update_account`` SSOT \ud328\ud134 \uc77c\uce58).\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n1. **\uc778\uc99d \uac00\ub4dc (\ucd5c\uc6b0\uc120, ``Depends(require_member_admin)``)** \u2014 caller \ube48\n   \u2192 401, \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403.\n2. raw bytes \uc77d\uace0 JSON \ud30c\uc2f1 \u2014 \uc2e4\ud328 \uc2dc 422.\n3. ``MemberCreateRequest.model_validate`` \u2014 ValidationError \u2192 422.\n4. ``svc.register`` \ud638\ucd9c. ``PermissionError`` \u2192 403, ``ValueError`` \u2192 400.",
         "operationId": "create_member_api_members_post",
         "responses": {
           "201": {
@@ -1628,7 +1628,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1648,7 +1648,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, 필수 필드 누락, type mismatch). 단, Authorization 헤더와 ante_session 쿠키 모두 유효하지 않으면 body validation은 실행되지 않고 401이 우선 반환된다(#1339 P2 / P1 cookie auth).",
+            "description": "Body validation \uc2e4\ud328 (JSON \ud30c\uc2f1 \uc2e4\ud328, \ube48 body, \ud544\uc218 \ud544\ub4dc \ub204\ub77d, type mismatch). \ub2e8, Authorization \ud5e4\ub354\uc640 ante_session \ucfe0\ud0a4 \ubaa8\ub450 \uc720\ud6a8\ud558\uc9c0 \uc54a\uc73c\uba74 body validation\uc740 \uc2e4\ud589\ub418\uc9c0 \uc54a\uace0 401\uc774 \uc6b0\uc120 \ubc18\ud658\ub41c\ub2e4(#1339 P2 / P1 cookie auth).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1686,7 +1686,7 @@
           "members"
         ],
         "summary": "Get Member",
-        "description": "멤버 상세 조회. 인증된 master/human 또는 ``member:read`` scope 를 보유한\nagent 만 호출 가능 (#1407).",
+        "description": "\uba64\ubc84 \uc0c1\uc138 \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``member:read`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "get_member_api_members__member_id__get",
         "parameters": [
           {
@@ -1749,7 +1749,7 @@
           "members"
         ],
         "summary": "Suspend Member",
-        "description": "멤버 일시 정지. 인증된 master/human 또는 ``member:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).",
+        "description": "\uba64\ubc84 \uc77c\uc2dc \uc815\uc9c0. \uc778\uc99d\ub41c master/human \ub610\ub294 ``member:admin`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``member:admin`` \uc815\ud569).",
         "operationId": "suspend_member_api_members__member_id__suspend_post",
         "parameters": [
           {
@@ -1774,7 +1774,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1832,7 +1832,7 @@
           "members"
         ],
         "summary": "Reactivate Member",
-        "description": "멤버 재활성화. 인증된 master/human 또는 ``member:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).",
+        "description": "\uba64\ubc84 \uc7ac\ud65c\uc131\ud654. \uc778\uc99d\ub41c master/human \ub610\ub294 ``member:admin`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``member:admin`` \uc815\ud569).",
         "operationId": "reactivate_member_api_members__member_id__reactivate_post",
         "parameters": [
           {
@@ -1857,7 +1857,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1915,7 +1915,7 @@
           "members"
         ],
         "summary": "Revoke Member",
-        "description": "멤버 영구 폐기. 인증된 master/human 또는 ``member:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).",
+        "description": "\uba64\ubc84 \uc601\uad6c \ud3d0\uae30. \uc778\uc99d\ub41c master/human \ub610\ub294 ``member:admin`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``member:admin`` \uc815\ud569).",
         "operationId": "revoke_member_api_members__member_id__revoke_post",
         "parameters": [
           {
@@ -1940,7 +1940,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1998,7 +1998,7 @@
           "members"
         ],
         "summary": "Rotate Token",
-        "description": "토큰 재발급. 인증된 master/human 또는 ``member:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).\n\n인증 없이 token rotation 응답에 접근하면 token 값 자체가 노출되므로,\n가장 먼저 차단해야 한다.",
+        "description": "\ud1a0\ud070 \uc7ac\ubc1c\uae09. \uc778\uc99d\ub41c master/human \ub610\ub294 ``member:admin`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``member:admin`` \uc815\ud569).\n\n\uc778\uc99d \uc5c6\uc774 token rotation \uc751\ub2f5\uc5d0 \uc811\uadfc\ud558\uba74 token \uac12 \uc790\uccb4\uac00 \ub178\ucd9c\ub418\ubbc0\ub85c,\n\uac00\uc7a5 \uba3c\uc800 \ucc28\ub2e8\ud574\uc57c \ud55c\ub2e4.",
         "operationId": "rotate_token_api_members__member_id__rotate_token_post",
         "parameters": [
           {
@@ -2023,7 +2023,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2081,7 +2081,7 @@
           "members"
         ],
         "summary": "Change Password",
-        "description": "비밀번호 변경 (human 멤버 전용). 인증된 master/human 또는\n``member:admin`` scope 를 보유한 agent 만 호출 가능 (#1407 — spec\n``member:admin`` 정합, #1377 master_caller 에서 마이그레이션).\n\n배경: oracle A7 finding (#1377) — 본 라우트는 인증 없이 credential check\n(``svc.change_password``의 old-password 비교) 까지 도달했다. ``_caller_id``\n만으로 audit 주체만 기록하고 인증 가드는 적용하지 않았기 때문이다. 본\n패치는 ``require_master_caller`` 의존성을 적용하고 ``update_scopes``와\n동일한 raw body 파싱 + auth-first 패턴을 따른다 (#1351 / #1352 SSOT).\n\n범위 결정:\n- master-only (보수). self-change use case (caller_id == member_id 허용)는\n  follow-up 이슈에서 별도 다룬다 (Issue #1377 Non-Goals).\n\n인증 → raw-body → credential check 순서를 보장한다. FastAPI가\n``body: PasswordChangeRequest``를 먼저 검증하면 unauth + bad-body 시 401이\n아닌 422가 먼저 반환되어 contract가 깨진다 — 본 라우트는 oracle A7\nfinding의 핵심 시그니처이므로 인증 가드 우선이 가장 중요하다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_member_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403. credential check 도달 전에 모두\n   차단된다.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``PasswordChangeRequest.model_validate`` — ValidationError → 422.\n4. ``svc.change_password`` 호출. ``ValueError`` → 404,\n   ``PermissionError``/``PermissionDeniedError`` → 403.\n\nAudit 로그의 ``member_id``는 ``caller_id``로 기록한다(SSOT). 대상 멤버는\n``resource=member:{member_id}``로 분리해 추적한다.",
+        "description": "\ube44\ubc00\ubc88\ud638 \ubcc0\uacbd (human \uba64\ubc84 \uc804\uc6a9). \uc778\uc99d\ub41c master/human \ub610\ub294\n``member:admin`` scope \ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec\n``member:admin`` \uc815\ud569, #1377 master_caller \uc5d0\uc11c \ub9c8\uc774\uadf8\ub808\uc774\uc158).\n\n\ubc30\uacbd: oracle A7 finding (#1377) \u2014 \ubcf8 \ub77c\uc6b0\ud2b8\ub294 \uc778\uc99d \uc5c6\uc774 credential check\n(``svc.change_password``\uc758 old-password \ube44\uad50) \uae4c\uc9c0 \ub3c4\ub2ec\ud588\ub2e4. ``_caller_id``\n\ub9cc\uc73c\ub85c audit \uc8fc\uccb4\ub9cc \uae30\ub85d\ud558\uace0 \uc778\uc99d \uac00\ub4dc\ub294 \uc801\uc6a9\ud558\uc9c0 \uc54a\uc558\uae30 \ub54c\ubb38\uc774\ub2e4. \ubcf8\n\ud328\uce58\ub294 ``require_master_caller`` \uc758\uc874\uc131\uc744 \uc801\uc6a9\ud558\uace0 ``update_scopes``\uc640\n\ub3d9\uc77c\ud55c raw body \ud30c\uc2f1 + auth-first \ud328\ud134\uc744 \ub530\ub978\ub2e4 (#1351 / #1352 SSOT).\n\n\ubc94\uc704 \uacb0\uc815:\n- master-only (\ubcf4\uc218). self-change use case (caller_id == member_id \ud5c8\uc6a9)\ub294\n  follow-up \uc774\uc288\uc5d0\uc11c \ubcc4\ub3c4 \ub2e4\ub8ec\ub2e4 (Issue #1377 Non-Goals).\n\n\uc778\uc99d \u2192 raw-body \u2192 credential check \uc21c\uc11c\ub97c \ubcf4\uc7a5\ud55c\ub2e4. FastAPI\uac00\n``body: PasswordChangeRequest``\ub97c \uba3c\uc800 \uac80\uc99d\ud558\uba74 unauth + bad-body \uc2dc 401\uc774\n\uc544\ub2cc 422\uac00 \uba3c\uc800 \ubc18\ud658\ub418\uc5b4 contract\uac00 \uae68\uc9c4\ub2e4 \u2014 \ubcf8 \ub77c\uc6b0\ud2b8\ub294 oracle A7\nfinding\uc758 \ud575\uc2ec \uc2dc\uadf8\ub2c8\ucc98\uc774\ubbc0\ub85c \uc778\uc99d \uac00\ub4dc \uc6b0\uc120\uc774 \uac00\uc7a5 \uc911\uc694\ud558\ub2e4.\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n\n1. \uc778\uc99d \uac00\ub4dc (``Depends(require_member_admin)``) \u2014 caller \ube48 \u2192 401,\n   \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403. credential check \ub3c4\ub2ec \uc804\uc5d0 \ubaa8\ub450\n   \ucc28\ub2e8\ub41c\ub2e4.\n2. raw bytes \uc77d\uae30 + JSON \ud30c\uc2f1 \u2014 \uc2e4\ud328 \uc2dc 422.\n3. ``PasswordChangeRequest.model_validate`` \u2014 ValidationError \u2192 422.\n4. ``svc.change_password`` \ud638\ucd9c. ``ValueError`` \u2192 404,\n   ``PermissionError``/``PermissionDeniedError`` \u2192 403.\n\nAudit \ub85c\uadf8\uc758 ``member_id``\ub294 ``caller_id``\ub85c \uae30\ub85d\ud55c\ub2e4(SSOT). \ub300\uc0c1 \uba64\ubc84\ub294\n``resource=member:{member_id}``\ub85c \ubd84\ub9ac\ud574 \ucd94\uc801\ud55c\ub2e4.",
         "operationId": "change_password_api_members__member_id__password_patch",
         "parameters": [
           {
@@ -2106,7 +2106,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2116,7 +2116,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 member:admin scope 보유 agent 만 허용).",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 member:admin scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2136,7 +2136,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, 필수 필드 누락, type mismatch). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1377).",
+            "description": "Body validation \uc2e4\ud328 (JSON \ud30c\uc2f1 \uc2e4\ud328, \ube48 body, \ud544\uc218 \ud544\ub4dc \ub204\ub77d, type mismatch). \ub2e8, \uc778\uc99d\uc774 \uc2e4\ud328\ud558\uba74 body validation\uc740 \uc2e4\ud589\ub418\uc9c0 \uc54a\uace0 401\uc774 \uc6b0\uc120 \ubc18\ud658\ub41c\ub2e4(#1377).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2174,7 +2174,7 @@
           "members"
         ],
         "summary": "Update Scopes",
-        "description": "권한 범위 변경. 인증된 master/human 또는 ``member:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. FastAPI 가 ``body: ScopesUpdateRequest`` 를 먼저 검증하면 unauth +\nbad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n1. 인증 가드 (``Depends(require_member_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``ScopesUpdateRequest.model_validate`` — ValidationError → 422.\n4. ``svc.update_scopes`` 호출. ``ValueError`` → 404,\n   ``PermissionError``/``PermissionDeniedError`` → 403.",
+        "description": "\uad8c\ud55c \ubc94\uc704 \ubcc0\uacbd. \uc778\uc99d\ub41c master/human \ub610\ub294 ``member:admin`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``member:admin`` \uc815\ud569).\n\nRaw body \ud30c\uc2f1 \ud328\ud134\uc73c\ub85c \uc778\uc99d \uac00\ub4dc\uac00 body validation \ubcf4\ub2e4 \uc6b0\uc120 \uc2e4\ud589\ub418\ub3c4\ub85d\n\ud55c\ub2e4. FastAPI \uac00 ``body: ScopesUpdateRequest`` \ub97c \uba3c\uc800 \uac80\uc99d\ud558\uba74 unauth +\nbad-body \uc2dc 401 \uc774 \uc544\ub2cc 422 \uac00 \uba3c\uc800 \ubc18\ud658\ub418\uc5b4 contract \uac00 \uae68\uc9c4\ub2e4.\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n1. \uc778\uc99d \uac00\ub4dc (``Depends(require_member_admin)``) \u2014 caller \ube48 \u2192 401,\n   \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403.\n2. raw bytes \uc77d\uae30 + JSON \ud30c\uc2f1 \u2014 \uc2e4\ud328 \uc2dc 422.\n3. ``ScopesUpdateRequest.model_validate`` \u2014 ValidationError \u2192 422.\n4. ``svc.update_scopes`` \ud638\ucd9c. ``ValueError`` \u2192 404,\n   ``PermissionError``/``PermissionDeniedError`` \u2192 403.",
         "operationId": "update_scopes_api_members__member_id__scopes_put",
         "parameters": [
           {
@@ -2199,7 +2199,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2229,7 +2229,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, 필수 필드 누락, type mismatch). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1351).",
+            "description": "Body validation \uc2e4\ud328 (JSON \ud30c\uc2f1 \uc2e4\ud328, \ube48 body, \ud544\uc218 \ud544\ub4dc \ub204\ub77d, type mismatch). \ub2e8, \uc778\uc99d\uc774 \uc2e4\ud328\ud558\uba74 body validation\uc740 \uc2e4\ud589\ub418\uc9c0 \uc54a\uace0 401\uc774 \uc6b0\uc120 \ubc18\ud658\ub41c\ub2e4(#1351).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2267,7 +2267,7 @@
           "config"
         ],
         "summary": "List Configs",
-        "description": "동적 설정 전체 조회. 인증된 master/human 또는 ``config:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).\n\n저장된 값이 read invariant(예: numeric finite, #1412)를 위반하면 서비스\n경계가 ``ConfigError`` 를 raise 하며, 라우트는 이를 422 로 변환한다.",
+        "description": "\ub3d9\uc801 \uc124\uc815 \uc804\uccb4 \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``config:read`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).\n\n\uc800\uc7a5\ub41c \uac12\uc774 read invariant(\uc608: numeric finite, #1412)\ub97c \uc704\ubc18\ud558\uba74 \uc11c\ube44\uc2a4\n\uacbd\uacc4\uac00 ``ConfigError`` \ub97c raise \ud558\uba70, \ub77c\uc6b0\ud2b8\ub294 \uc774\ub97c 422 \ub85c \ubcc0\ud658\ud55c\ub2e4.",
         "operationId": "list_configs_api_config_get",
         "responses": {
           "200": {
@@ -2281,7 +2281,7 @@
             }
           },
           "422": {
-            "description": "저장된 dynamic config 값이 invariant 를 위반한 경우 (예: legacy non-finite numeric row — #1412). 서비스 read 경계가 ConfigError 로 격리한 결과를 422 problem+json 으로 변환한다.",
+            "description": "\uc800\uc7a5\ub41c dynamic config \uac12\uc774 invariant \ub97c \uc704\ubc18\ud55c \uacbd\uc6b0 (\uc608: legacy non-finite numeric row \u2014 #1412). \uc11c\ube44\uc2a4 read \uacbd\uacc4\uac00 ConfigError \ub85c \uaca9\ub9ac\ud55c \uacb0\uacfc\ub97c 422 problem+json \uc73c\ub85c \ubcc0\ud658\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2309,7 +2309,7 @@
           "config"
         ],
         "summary": "Update Config",
-        "description": "동적 설정 값 변경. 인증된 master/human 또는 config:write scope 보유\nagent 만 호출 가능 (#1373).\n\n``update_bot`` (#1352) / ``create_bot`` (#1371) / ``allocate`` (#1372)\n와 동일한 raw body 파싱 패턴을 적용해 인증 가드가 body validation 보다\n우선 실행되도록 한다. FastAPI 가 ``body: ConfigUpdateRequest`` 를 먼저\n검증하면 unauth + bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract\n가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_config_write)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``ConfigUpdateRequest.model_validate`` — ValidationError → 422.\n4. config 키 존재 확인 → 404.\n5. ``config_service.set`` 호출 + audit 기록 (changed_by = caller_id).\n   서비스 경계에서 ``validate_value`` 가 키별 invariant 를 검증하므로\n   ``ValueError`` 가 올라오면 422 로 변환한다 (#1379).",
+        "description": "\ub3d9\uc801 \uc124\uc815 \uac12 \ubcc0\uacbd. \uc778\uc99d\ub41c master/human \ub610\ub294 config:write scope \ubcf4\uc720\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1373).\n\n``update_bot`` (#1352) / ``create_bot`` (#1371) / ``allocate`` (#1372)\n\uc640 \ub3d9\uc77c\ud55c raw body \ud30c\uc2f1 \ud328\ud134\uc744 \uc801\uc6a9\ud574 \uc778\uc99d \uac00\ub4dc\uac00 body validation \ubcf4\ub2e4\n\uc6b0\uc120 \uc2e4\ud589\ub418\ub3c4\ub85d \ud55c\ub2e4. FastAPI \uac00 ``body: ConfigUpdateRequest`` \ub97c \uba3c\uc800\n\uac80\uc99d\ud558\uba74 unauth + bad-body \uc2dc 401 \uc774 \uc544\ub2cc 422 \uac00 \uba3c\uc800 \ubc18\ud658\ub418\uc5b4 contract\n\uac00 \uae68\uc9c4\ub2e4.\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n\n1. \uc778\uc99d \uac00\ub4dc (``Depends(require_config_write)``) \u2014 caller \ube48 \u2192 401,\n   \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403.\n2. raw bytes \uc77d\uae30 + JSON \ud30c\uc2f1 \u2014 \uc2e4\ud328 \uc2dc 422.\n3. ``ConfigUpdateRequest.model_validate`` \u2014 ValidationError \u2192 422.\n4. config \ud0a4 \uc874\uc7ac \ud655\uc778 \u2192 404.\n5. ``config_service.set`` \ud638\ucd9c + audit \uae30\ub85d (changed_by = caller_id).\n   \uc11c\ube44\uc2a4 \uacbd\uacc4\uc5d0\uc11c ``validate_value`` \uac00 \ud0a4\ubcc4 invariant \ub97c \uac80\uc99d\ud558\ubbc0\ub85c\n   ``ValueError`` \uac00 \uc62c\ub77c\uc624\uba74 422 \ub85c \ubcc0\ud658\ud55c\ub2e4 (#1379).",
         "operationId": "update_config_api_config__key__put",
         "parameters": [
           {
@@ -2334,7 +2334,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2344,7 +2344,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 config:write scope 보유 agent 만 허용)",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 config:write scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2364,7 +2364,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, value 누락, type mismatch) 또는 키별 invariant 위반 (예: ``system.log_level`` 가 ``_VALID_LOG_LEVELS`` 멤버가 아닌 경우 — 대소문자 구분, #1379). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1373).",
+            "description": "Body validation \uc2e4\ud328 (JSON \ud30c\uc2f1 \uc2e4\ud328, \ube48 body, value \ub204\ub77d, type mismatch) \ub610\ub294 \ud0a4\ubcc4 invariant \uc704\ubc18 (\uc608: ``system.log_level`` \uac00 ``_VALID_LOG_LEVELS`` \uba64\ubc84\uac00 \uc544\ub2cc \uacbd\uc6b0 \u2014 \ub300\uc18c\ubb38\uc790 \uad6c\ubd84, #1379). \ub2e8, \uc778\uc99d\uc774 \uc2e4\ud328\ud558\uba74 body validation\uc740 \uc2e4\ud589\ub418\uc9c0 \uc54a\uace0 401\uc774 \uc6b0\uc120 \ubc18\ud658\ub41c\ub2e4(#1373).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2402,7 +2402,7 @@
           "system"
         ],
         "summary": "Get System Status",
-        "description": "시스템 상태 조회. 인증된 master/human 또는 ``system:read`` scope 를 보유한\nagent 만 호출 가능 (#1407). ``/api/system/health`` (public) 와 구별 —\nhealth 는 모니터링 헬스체크용이고 status 는 운영 정보(account_count 등)를\n노출한다.",
+        "description": "\uc2dc\uc2a4\ud15c \uc0c1\ud0dc \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``system:read`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407). ``/api/system/health`` (public) \uc640 \uad6c\ubcc4 \u2014\nhealth \ub294 \ubaa8\ub2c8\ud130\ub9c1 \ud5ec\uc2a4\uccb4\ud06c\uc6a9\uc774\uace0 status \ub294 \uc6b4\uc601 \uc815\ubcf4(account_count \ub4f1)\ub97c\n\ub178\ucd9c\ud55c\ub2e4.",
         "operationId": "get_system_status_api_system_status_get",
         "responses": {
           "200": {
@@ -2424,7 +2424,7 @@
           "system"
         ],
         "summary": "Health Check",
-        "description": "헬스체크.\n\n- `db`: `SELECT 1` 성공 여부.\n- `broker`: 모든 계좌의 `broker.is_connected == True` AND 축약.\n  계좌 0개이면 True. account_service 미주입 시 False (unhealthy).\n각 체크는 독립적이며, 예외는 내부에서 포착하고 해당 항목만 False로 기록한다.\nHTTP 상태 코드는 체크 결과와 무관하게 항상 200이다.",
+        "description": "\ud5ec\uc2a4\uccb4\ud06c.\n\n- `db`: `SELECT 1` \uc131\uacf5 \uc5ec\ubd80.\n- `broker`: \ubaa8\ub4e0 \uacc4\uc88c\uc758 `broker.is_connected == True` AND \ucd95\uc57d.\n  \uacc4\uc88c 0\uac1c\uc774\uba74 True. account_service \ubbf8\uc8fc\uc785 \uc2dc False (unhealthy).\n\uac01 \uccb4\ud06c\ub294 \ub3c5\ub9bd\uc801\uc774\uba70, \uc608\uc678\ub294 \ub0b4\ubd80\uc5d0\uc11c \ud3ec\ucc29\ud558\uace0 \ud574\ub2f9 \ud56d\ubaa9\ub9cc False\ub85c \uae30\ub85d\ud55c\ub2e4.\nHTTP \uc0c1\ud0dc \ucf54\ub4dc\ub294 \uccb4\ud06c \uacb0\uacfc\uc640 \ubb34\uad00\ud558\uac8c \ud56d\uc0c1 200\uc774\ub2e4.",
         "operationId": "health_check_api_system_health_get",
         "responses": {
           "200": {
@@ -2446,7 +2446,7 @@
           "system"
         ],
         "summary": "Halt",
-        "description": "전체 거래 중지 (모든 ACTIVE 계좌 SUSPENDED). 인증된 master/human 또는\n``system:admin`` scope 를 보유한 agent 만 호출 가능 (#1407 — spec\n``system:admin`` 정합, #1375 master_caller 에서 마이그레이션).\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. FastAPI 가 ``body: HaltRequest`` 를 먼저 검증하면 unauth + bad-body\n시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_system_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 빈 body 는 default 허용, 그 외 실패 시 422.\n3. ``HaltRequest.model_validate`` — ValidationError → 422.\n4. ``account_service.suspend_all`` 호출 + audit 기록\n   (``halted_by`` / ``member_id`` = caller_id).",
+        "description": "\uc804\uccb4 \uac70\ub798 \uc911\uc9c0 (\ubaa8\ub4e0 ACTIVE \uacc4\uc88c SUSPENDED). \uc778\uc99d\ub41c master/human \ub610\ub294\n``system:admin`` scope \ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec\n``system:admin`` \uc815\ud569, #1375 master_caller \uc5d0\uc11c \ub9c8\uc774\uadf8\ub808\uc774\uc158).\n\nRaw body \ud30c\uc2f1 \ud328\ud134\uc73c\ub85c \uc778\uc99d \uac00\ub4dc\uac00 body validation \ubcf4\ub2e4 \uc6b0\uc120 \uc2e4\ud589\ub418\ub3c4\ub85d\n\ud55c\ub2e4. FastAPI \uac00 ``body: HaltRequest`` \ub97c \uba3c\uc800 \uac80\uc99d\ud558\uba74 unauth + bad-body\n\uc2dc 401 \uc774 \uc544\ub2cc 422 \uac00 \uba3c\uc800 \ubc18\ud658\ub418\uc5b4 contract \uac00 \uae68\uc9c4\ub2e4.\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n\n1. \uc778\uc99d \uac00\ub4dc (``Depends(require_system_admin)``) \u2014 caller \ube48 \u2192 401,\n   \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403.\n2. raw bytes \uc77d\uae30 + JSON \ud30c\uc2f1 \u2014 \ube48 body \ub294 default \ud5c8\uc6a9, \uadf8 \uc678 \uc2e4\ud328 \uc2dc 422.\n3. ``HaltRequest.model_validate`` \u2014 ValidationError \u2192 422.\n4. ``account_service.suspend_all`` \ud638\ucd9c + audit \uae30\ub85d\n   (``halted_by`` / ``member_id`` = caller_id).",
         "operationId": "halt_api_system_halt_post",
         "requestBody": {
           "content": {
@@ -2470,7 +2470,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2480,7 +2480,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 system:admin scope 보유 agent 만 허용).",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 system:admin scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2490,7 +2490,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (malformed JSON, non-object JSON, type mismatch). 빈 body 는 기본 ``reason=\"\"`` 로 허용된다 (기존 동작 보존). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다 (#1375).",
+            "description": "Body validation \uc2e4\ud328 (malformed JSON, non-object JSON, type mismatch). \ube48 body \ub294 \uae30\ubcf8 ``reason=\"\"`` \ub85c \ud5c8\uc6a9\ub41c\ub2e4 (\uae30\uc874 \ub3d9\uc791 \ubcf4\uc874). \ub2e8, \uc778\uc99d\uc774 \uc2e4\ud328\ud558\uba74 body validation \uc740 \uc2e4\ud589\ub418\uc9c0 \uc54a\uace0 401 \uc774 \uc6b0\uc120 \ubc18\ud658\ub41c\ub2e4 (#1375).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2518,7 +2518,7 @@
           "system"
         ],
         "summary": "Clear Halt",
-        "description": "전역 정지 해제 (모든 SUSPENDED 계좌 ACTIVE). 인증된 master/human 또는\n``system:admin`` scope 를 보유한 agent 만 호출 가능 (#1407 — spec\n``system:admin`` 정합, #1375 master_caller 에서 마이그레이션).\n\n계좌 상태만 ACTIVE 로 복구하며 봇을 자동 재시작하지 않는다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_system_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 빈 body 는 default 허용, 그 외 실패 시 422.\n3. ``ClearHaltRequest.model_validate`` — ValidationError → 422.\n4. ``account_service.activate_all`` 호출 + audit 기록\n   (``activated_by`` / ``member_id`` = caller_id).",
+        "description": "\uc804\uc5ed \uc815\uc9c0 \ud574\uc81c (\ubaa8\ub4e0 SUSPENDED \uacc4\uc88c ACTIVE). \uc778\uc99d\ub41c master/human \ub610\ub294\n``system:admin`` scope \ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec\n``system:admin`` \uc815\ud569, #1375 master_caller \uc5d0\uc11c \ub9c8\uc774\uadf8\ub808\uc774\uc158).\n\n\uacc4\uc88c \uc0c1\ud0dc\ub9cc ACTIVE \ub85c \ubcf5\uad6c\ud558\uba70 \ubd07\uc744 \uc790\ub3d9 \uc7ac\uc2dc\uc791\ud558\uc9c0 \uc54a\ub294\ub2e4.\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n\n1. \uc778\uc99d \uac00\ub4dc (``Depends(require_system_admin)``) \u2014 caller \ube48 \u2192 401,\n   \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403.\n2. raw bytes \uc77d\uae30 + JSON \ud30c\uc2f1 \u2014 \ube48 body \ub294 default \ud5c8\uc6a9, \uadf8 \uc678 \uc2e4\ud328 \uc2dc 422.\n3. ``ClearHaltRequest.model_validate`` \u2014 ValidationError \u2192 422.\n4. ``account_service.activate_all`` \ud638\ucd9c + audit \uae30\ub85d\n   (``activated_by`` / ``member_id`` = caller_id).",
         "operationId": "clear_halt_api_system_clear_halt_post",
         "requestBody": {
           "content": {
@@ -2542,7 +2542,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2552,7 +2552,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 system:admin scope 보유 agent 만 허용).",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 system:admin scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2562,7 +2562,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (malformed JSON, non-object JSON, type mismatch). 빈 body 는 기본 ``reason=\"\"`` 로 허용된다 (기존 동작 보존). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다 (#1375).",
+            "description": "Body validation \uc2e4\ud328 (malformed JSON, non-object JSON, type mismatch). \ube48 body \ub294 \uae30\ubcf8 ``reason=\"\"`` \ub85c \ud5c8\uc6a9\ub41c\ub2e4 (\uae30\uc874 \ub3d9\uc791 \ubcf4\uc874). \ub2e8, \uc778\uc99d\uc774 \uc2e4\ud328\ud558\uba74 body validation \uc740 \uc2e4\ud589\ub418\uc9c0 \uc54a\uace0 401 \uc774 \uc6b0\uc120 \ubc18\ud658\ub41c\ub2e4 (#1375).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2590,7 +2590,7 @@
           "strategies"
         ],
         "summary": "Validate Strategy",
-        "description": "전략 파일 정적 검증. 인증된 master/human 또는 ``strategy:write`` scope\n를 보유한 agent 만 호출 가능 (#1407 — spec ``strategy:write`` 정합).\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. 핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_strategy_write)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``StrategyValidateRequest.model_validate`` — ValidationError → 422\n   (#1410 — non-string ``path`` 같은 type mismatch 차단).\n4. ``path`` 필드 추출 — 빈 문자열은 400.\n5. 파일 존재 확인 → 404.\n6. ``StrategyValidator.validate`` 호출.\n\nBody: ``{\"path\": \"/path/to/strategy.py\"}``",
+        "description": "\uc804\ub7b5 \ud30c\uc77c \uc815\uc801 \uac80\uc99d. \uc778\uc99d\ub41c master/human \ub610\ub294 ``strategy:write`` scope\n\ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``strategy:write`` \uc815\ud569).\n\nRaw body \ud30c\uc2f1 \ud328\ud134\uc73c\ub85c \uc778\uc99d \uac00\ub4dc\uac00 body validation \ubcf4\ub2e4 \uc6b0\uc120 \uc2e4\ud589\ub418\ub3c4\ub85d\n\ud55c\ub2e4. \ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n\n1. \uc778\uc99d \uac00\ub4dc (``Depends(require_strategy_write)``) \u2014 caller \ube48 \u2192 401,\n   \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403.\n2. raw bytes \uc77d\uae30 + JSON \ud30c\uc2f1 \u2014 \uc2e4\ud328 \uc2dc 422.\n3. ``StrategyValidateRequest.model_validate`` \u2014 ValidationError \u2192 422\n   (#1410 \u2014 non-string ``path`` \uac19\uc740 type mismatch \ucc28\ub2e8).\n4. ``path`` \ud544\ub4dc \ucd94\ucd9c \u2014 \ube48 \ubb38\uc790\uc5f4\uc740 400.\n5. \ud30c\uc77c \uc874\uc7ac \ud655\uc778 \u2192 404.\n6. ``StrategyValidator.validate`` \ud638\ucd9c.\n\nBody: ``{\"path\": \"/path/to/strategy.py\"}``",
         "operationId": "validate_strategy_api_strategies_validate_post",
         "requestBody": {
           "content": {
@@ -2634,7 +2634,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 strategy:write scope 보유 agent 만 허용).",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 strategy:write scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2654,7 +2654,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, non-string ``path`` 같은 type mismatch — #1410 회귀 방지). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다 (#1407).",
+            "description": "Body validation \uc2e4\ud328 (JSON \ud30c\uc2f1 \uc2e4\ud328, \ube48 body, non-string ``path`` \uac19\uc740 type mismatch \u2014 #1410 \ud68c\uadc0 \ubc29\uc9c0). \ub2e8, \uc778\uc99d\uc774 \uc2e4\ud328\ud558\uba74 body validation \uc740 \uc2e4\ud589\ub418\uc9c0 \uc54a\uace0 401 \uc774 \uc6b0\uc120 \ubc18\ud658\ub41c\ub2e4 (#1407).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2672,7 +2672,7 @@
           "strategies"
         ],
         "summary": "List Strategies",
-        "description": "전략 목록 조회. 인증된 master/human 또는 ``strategy:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
+        "description": "\uc804\ub7b5 \ubaa9\ub85d \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``strategy:read`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "list_strategies_api_strategies_get",
         "parameters": [
           {
@@ -2732,7 +2732,7 @@
           "strategies"
         ],
         "summary": "Update Strategy Status",
-        "description": "전략 상태 변경. 보관 전환용. 인증된 master/human 또는\n``strategy:write`` scope 를 보유한 agent 만 호출 가능 (#1378).\n\n``submit_report`` (#1374) / ``update_config`` (#1373) 와 동일한 raw body\n파싱 패턴을 적용해 인증 가드가 body validation 보다 우선 실행되도록 한다.\nFastAPI 가 ``body: StatusUpdateRequest`` 를 먼저 검증하면 unauth + bad-body\n시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_strategy_write)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``StatusUpdateRequest.model_validate`` — ValidationError → 422.\n4. ``StrategyStatus`` enum 변환 — 실패 시 400.\n5. ``registry.update_status`` 호출 — 누락 strategy → 404, 전환 불가 → 400.",
+        "description": "\uc804\ub7b5 \uc0c1\ud0dc \ubcc0\uacbd. \ubcf4\uad00 \uc804\ud658\uc6a9. \uc778\uc99d\ub41c master/human \ub610\ub294\n``strategy:write`` scope \ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1378).\n\n``submit_report`` (#1374) / ``update_config`` (#1373) \uc640 \ub3d9\uc77c\ud55c raw body\n\ud30c\uc2f1 \ud328\ud134\uc744 \uc801\uc6a9\ud574 \uc778\uc99d \uac00\ub4dc\uac00 body validation \ubcf4\ub2e4 \uc6b0\uc120 \uc2e4\ud589\ub418\ub3c4\ub85d \ud55c\ub2e4.\nFastAPI \uac00 ``body: StatusUpdateRequest`` \ub97c \uba3c\uc800 \uac80\uc99d\ud558\uba74 unauth + bad-body\n\uc2dc 401 \uc774 \uc544\ub2cc 422 \uac00 \uba3c\uc800 \ubc18\ud658\ub418\uc5b4 contract \uac00 \uae68\uc9c4\ub2e4.\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n\n1. \uc778\uc99d \uac00\ub4dc (``Depends(require_strategy_write)``) \u2014 caller \ube48 \u2192 401,\n   \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403.\n2. raw bytes \uc77d\uae30 + JSON \ud30c\uc2f1 \u2014 \uc2e4\ud328 \uc2dc 422.\n3. ``StatusUpdateRequest.model_validate`` \u2014 ValidationError \u2192 422.\n4. ``StrategyStatus`` enum \ubcc0\ud658 \u2014 \uc2e4\ud328 \uc2dc 400.\n5. ``registry.update_status`` \ud638\ucd9c \u2014 \ub204\ub77d strategy \u2192 404, \uc804\ud658 \ubd88\uac00 \u2192 400.",
         "operationId": "update_strategy_status_api_strategies__strategy_id__status_patch",
         "parameters": [
           {
@@ -2750,7 +2750,7 @@
             "description": "Successful Response"
           },
           "400": {
-            "description": "허용되지 않은 상태 전환",
+            "description": "\ud5c8\uc6a9\ub418\uc9c0 \uc54a\uc740 \uc0c1\ud0dc \uc804\ud658",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2760,7 +2760,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2770,7 +2770,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 strategy:write scope 보유 agent 만 허용). spec require_scope predicate 정합.",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 strategy:write scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9). spec require_scope predicate \uc815\ud569.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2790,7 +2790,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, 필수 필드 누락, type mismatch, extra key). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다(#1378).",
+            "description": "Body validation \uc2e4\ud328 (JSON \ud30c\uc2f1 \uc2e4\ud328, \ube48 body, \ud544\uc218 \ud544\ub4dc \ub204\ub77d, type mismatch, extra key). \ub2e8, \uc778\uc99d\uc774 \uc2e4\ud328\ud558\uba74 body validation \uc740 \uc2e4\ud589\ub418\uc9c0 \uc54a\uace0 401 \uc774 \uc6b0\uc120 \ubc18\ud658\ub41c\ub2e4(#1378).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2818,7 +2818,7 @@
           "strategies"
         ],
         "summary": "Get Strategy",
-        "description": "전략 상세 조회. 인증된 master/human 또는 ``strategy:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
+        "description": "\uc804\ub7b5 \uc0c1\uc138 \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``strategy:read`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "get_strategy_api_strategies__strategy_id__get",
         "parameters": [
           {
@@ -2881,7 +2881,7 @@
           "strategies"
         ],
         "summary": "Get Strategy Performance",
-        "description": "전략 성과 지표 조회. 인증된 master/human 또는 ``strategy:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
+        "description": "\uc804\ub7b5 \uc131\uacfc \uc9c0\ud45c \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``strategy:read`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "get_strategy_performance_api_strategies__strategy_id__performance_get",
         "parameters": [
           {
@@ -2960,7 +2960,7 @@
           "strategies"
         ],
         "summary": "Get Strategy Daily Summary",
-        "description": "전략 일별 성과 집계. 인증된 master/human 또는 ``strategy:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
+        "description": "\uc804\ub7b5 \uc77c\ubcc4 \uc131\uacfc \uc9d1\uacc4. \uc778\uc99d\ub41c master/human \ub610\ub294 ``strategy:read`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "get_strategy_daily_summary_api_strategies__strategy_id__daily_summary_get",
         "parameters": [
           {
@@ -3023,7 +3023,7 @@
           "strategies"
         ],
         "summary": "Get Strategy Weekly Summary",
-        "description": "전략 주별 성과 집계. 인증된 master/human 또는 ``strategy:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
+        "description": "\uc804\ub7b5 \uc8fc\ubcc4 \uc131\uacfc \uc9d1\uacc4. \uc778\uc99d\ub41c master/human \ub610\ub294 ``strategy:read`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "get_strategy_weekly_summary_api_strategies__strategy_id__weekly_summary_get",
         "parameters": [
           {
@@ -3086,7 +3086,7 @@
           "strategies"
         ],
         "summary": "Get Strategy Monthly Summary",
-        "description": "전략 월별 성과 집계. 인증된 master/human 또는 ``strategy:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
+        "description": "\uc804\ub7b5 \uc6d4\ubcc4 \uc131\uacfc \uc9d1\uacc4. \uc778\uc99d\ub41c master/human \ub610\ub294 ``strategy:read`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "get_strategy_monthly_summary_api_strategies__strategy_id__monthly_summary_get",
         "parameters": [
           {
@@ -3149,7 +3149,7 @@
           "strategies"
         ],
         "summary": "Get Strategy Trades",
-        "description": "전략 거래 내역 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는\n``strategy:read`` scope 를 보유한 agent 만 호출 가능 (#1407).",
+        "description": "\uc804\ub7b5 \uac70\ub798 \ub0b4\uc5ed \uc870\ud68c (cursor \uae30\ubc18 \ud398\uc774\uc9c0\ub124\uc774\uc158). \uc778\uc99d\ub41c master/human \ub610\ub294\n``strategy:read`` scope \ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "get_strategy_trades_api_strategies__strategy_id__trades_get",
         "parameters": [
           {
@@ -3240,7 +3240,7 @@
           "reports"
         ],
         "summary": "Get Report Schema",
-        "description": "리포트 제출 스키마 조회.",
+        "description": "\ub9ac\ud3ec\ud2b8 \uc81c\ucd9c \uc2a4\ud0a4\ub9c8 \uc870\ud68c.",
         "operationId": "get_report_schema_api_reports_schema_get",
         "responses": {
           "200": {
@@ -3262,7 +3262,7 @@
           "reports"
         ],
         "summary": "Submit Report",
-        "description": "리포트 제출. 인증된 master/human 또는 ``report:write`` scope 를 보유한\nagent 만 호출 가능 (#1374).\n\n``update_config`` (#1373) 와 동일한 raw body 파싱 패턴을 적용해 인증 가드가\nbody validation 보다 우선 실행되도록 한다. FastAPI 가\n``body: ReportSubmitRequest`` 를 먼저 검증하면 unauth + bad-body 시 401 이\n아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_report_write)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``ReportSubmitRequest.model_validate`` — ValidationError → 422.\n4. ``report_store.submit`` 호출 + audit 기록 (submitted_by = caller_id).",
+        "description": "\ub9ac\ud3ec\ud2b8 \uc81c\ucd9c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``report:write`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1374).\n\n``update_config`` (#1373) \uc640 \ub3d9\uc77c\ud55c raw body \ud30c\uc2f1 \ud328\ud134\uc744 \uc801\uc6a9\ud574 \uc778\uc99d \uac00\ub4dc\uac00\nbody validation \ubcf4\ub2e4 \uc6b0\uc120 \uc2e4\ud589\ub418\ub3c4\ub85d \ud55c\ub2e4. FastAPI \uac00\n``body: ReportSubmitRequest`` \ub97c \uba3c\uc800 \uac80\uc99d\ud558\uba74 unauth + bad-body \uc2dc 401 \uc774\n\uc544\ub2cc 422 \uac00 \uba3c\uc800 \ubc18\ud658\ub418\uc5b4 contract \uac00 \uae68\uc9c4\ub2e4.\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n\n1. \uc778\uc99d \uac00\ub4dc (``Depends(require_report_write)``) \u2014 caller \ube48 \u2192 401,\n   \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403.\n2. raw bytes \uc77d\uae30 + JSON \ud30c\uc2f1 \u2014 \uc2e4\ud328 \uc2dc 422.\n3. ``ReportSubmitRequest.model_validate`` \u2014 ValidationError \u2192 422.\n4. ``report_store.submit`` \ud638\ucd9c + audit \uae30\ub85d (submitted_by = caller_id).",
         "operationId": "submit_report_api_reports_post",
         "responses": {
           "201": {
@@ -3276,7 +3276,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -3286,7 +3286,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 report:write scope 보유 agent 만 허용). spec require_scope predicate 정합.",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 report:write scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9). spec require_scope predicate \uc815\ud569.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -3296,7 +3296,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, 필수 필드 누락, type mismatch, NaN/Inf, extra key). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다(#1374).",
+            "description": "Body validation \uc2e4\ud328 (JSON \ud30c\uc2f1 \uc2e4\ud328, \ube48 body, \ud544\uc218 \ud544\ub4dc \ub204\ub77d, type mismatch, NaN/Inf, extra key). \ub2e8, \uc778\uc99d\uc774 \uc2e4\ud328\ud558\uba74 body validation \uc740 \uc2e4\ud589\ub418\uc9c0 \uc54a\uace0 401 \uc774 \uc6b0\uc120 \ubc18\ud658\ub41c\ub2e4(#1374).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -3332,7 +3332,7 @@
           "reports"
         ],
         "summary": "List Reports",
-        "description": "리포트 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는\n``report:read`` scope 를 보유한 agent 만 호출 가능 (#1407).",
+        "description": "\ub9ac\ud3ec\ud2b8 \ubaa9\ub85d \uc870\ud68c (cursor \uae30\ubc18 \ud398\uc774\uc9c0\ub124\uc774\uc158). \uc778\uc99d\ub41c master/human \ub610\ub294\n``report:read`` scope \ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "list_reports_api_reports_get",
         "parameters": [
           {
@@ -3420,7 +3420,7 @@
           "reports"
         ],
         "summary": "Report View",
-        "description": "리포트 단건 조회. 인증된 master/human 또는 ``report:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
+        "description": "\ub9ac\ud3ec\ud2b8 \ub2e8\uac74 \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``report:read`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "report_view_api_reports__report_id__get",
         "parameters": [
           {
@@ -3483,7 +3483,7 @@
           "data"
         ],
         "summary": "List Datasets",
-        "description": "보유 데이터셋 목록 (페이지네이션 지원).\n\ndata_type 미지정 시 모든 유형을 반환하고, 지정 시 해당 유형만 반환한다.\n\n종목 목록만 먼저 수집하여 페이지네이션을 적용한 뒤,\n해당 페이지의 종목에 대해서만 date_range를 계산한다.\nrow_count와 file_size는 상세 조회 전용이므로 기본값(0)을 반환한다.\n\nReturns:\n    {items: [...], total: int}",
+        "description": "\ubcf4\uc720 \ub370\uc774\ud130\uc14b \ubaa9\ub85d (\ud398\uc774\uc9c0\ub124\uc774\uc158 \uc9c0\uc6d0).\n\ndata_type \ubbf8\uc9c0\uc815 \uc2dc \ubaa8\ub4e0 \uc720\ud615\uc744 \ubc18\ud658\ud558\uace0, \uc9c0\uc815 \uc2dc \ud574\ub2f9 \uc720\ud615\ub9cc \ubc18\ud658\ud55c\ub2e4.\n\n\uc885\ubaa9 \ubaa9\ub85d\ub9cc \uba3c\uc800 \uc218\uc9d1\ud558\uc5ec \ud398\uc774\uc9c0\ub124\uc774\uc158\uc744 \uc801\uc6a9\ud55c \ub4a4,\n\ud574\ub2f9 \ud398\uc774\uc9c0\uc758 \uc885\ubaa9\uc5d0 \ub300\ud574\uc11c\ub9cc date_range\ub97c \uacc4\uc0b0\ud55c\ub2e4.\nrow_count\uc640 file_size\ub294 \uc0c1\uc138 \uc870\ud68c \uc804\uc6a9\uc774\ubbc0\ub85c \uae30\ubcf8\uac12(0)\uc744 \ubc18\ud658\ud55c\ub2e4.\n\nReturns:\n    {items: [...], total: int}",
         "operationId": "list_datasets_api_data_datasets_get",
         "parameters": [
           {
@@ -3535,10 +3535,10 @@
                   "type": "null"
                 }
               ],
-              "description": "데이터 유형 (ohlcv, fundamental, 미지정 시 전체)",
+              "description": "\ub370\uc774\ud130 \uc720\ud615 (ohlcv, fundamental, \ubbf8\uc9c0\uc815 \uc2dc \uc804\uccb4)",
               "title": "Data Type"
             },
-            "description": "데이터 유형 (ohlcv, fundamental, 미지정 시 전체)"
+            "description": "\ub370\uc774\ud130 \uc720\ud615 (ohlcv, fundamental, \ubbf8\uc9c0\uc815 \uc2dc \uc804\uccb4)"
           },
           {
             "name": "offset",
@@ -3594,7 +3594,7 @@
           "data"
         ],
         "summary": "Get Dataset Detail",
-        "description": "데이터셋 상세 조회 (메타데이터 + 최근 5행 미리보기). 인증된 master/human\n또는 ``data:read`` scope 를 보유한 agent 만 호출 가능 (#1407).\n\ndataset_id 형식: \"{symbol}__{timeframe}\" (예: \"005930__1d\")",
+        "description": "\ub370\uc774\ud130\uc14b \uc0c1\uc138 \uc870\ud68c (\uba54\ud0c0\ub370\uc774\ud130 + \ucd5c\uadfc 5\ud589 \ubbf8\ub9ac\ubcf4\uae30). \uc778\uc99d\ub41c master/human\n\ub610\ub294 ``data:read`` scope \ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).\n\ndataset_id \ud615\uc2dd: \"{symbol}__{timeframe}\" (\uc608: \"005930__1d\")",
         "operationId": "get_dataset_detail_api_data_datasets__dataset_id__get",
         "parameters": [
           {
@@ -3635,7 +3635,7 @@
           "data"
         ],
         "summary": "Delete Dataset",
-        "description": "데이터셋 삭제. 인증된 master/human 또는 ``data:write`` scope 를 보유한\nagent 만 호출 가능 (#1407).\n\ndataset_id 형식: \"{symbol}__{timeframe}\" (예: \"005930__1d\")\nfundamental의 경우: \"{symbol}__fundamental\" (예: \"005930__fundamental\")",
+        "description": "\ub370\uc774\ud130\uc14b \uc0ad\uc81c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``data:write`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).\n\ndataset_id \ud615\uc2dd: \"{symbol}__{timeframe}\" (\uc608: \"005930__1d\")\nfundamental\uc758 \uacbd\uc6b0: \"{symbol}__fundamental\" (\uc608: \"005930__fundamental\")",
         "operationId": "delete_dataset_api_data_datasets__dataset_id__delete",
         "parameters": [
           {
@@ -3652,12 +3652,16 @@
             "in": "query",
             "required": false,
             "schema": {
+              "enum": [
+                "ohlcv",
+                "fundamental"
+              ],
               "type": "string",
-              "description": "데이터 유형 (ohlcv, fundamental)",
+              "description": "\ub370\uc774\ud130 \uc720\ud615 (ohlcv, fundamental)",
               "default": "ohlcv",
               "title": "Data Type"
             },
-            "description": "데이터 유형 (ohlcv, fundamental)"
+            "description": "\ub370\uc774\ud130 \uc720\ud615 (ohlcv, fundamental)"
           }
         ],
         "responses": {
@@ -3713,7 +3717,7 @@
           "data"
         ],
         "summary": "Get Data Schema",
-        "description": "데이터 스키마 조회. data_type에 따라 해당 스키마를 반환. 인증된\nmaster/human 또는 ``data:read`` scope 를 보유한 agent 만 호출 가능\n(#1407).",
+        "description": "\ub370\uc774\ud130 \uc2a4\ud0a4\ub9c8 \uc870\ud68c. data_type\uc5d0 \ub530\ub77c \ud574\ub2f9 \uc2a4\ud0a4\ub9c8\ub97c \ubc18\ud658. \uc778\uc99d\ub41c\nmaster/human \ub610\ub294 ``data:read`` scope \ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5\n(#1407).",
         "operationId": "get_data_schema_api_data_schema_get",
         "parameters": [
           {
@@ -3726,11 +3730,11 @@
                 "fundamental"
               ],
               "type": "string",
-              "description": "데이터 유형 (ohlcv, fundamental)",
+              "description": "\ub370\uc774\ud130 \uc720\ud615 (ohlcv, fundamental)",
               "default": "ohlcv",
               "title": "Data Type"
             },
-            "description": "데이터 유형 (ohlcv, fundamental)"
+            "description": "\ub370\uc774\ud130 \uc720\ud615 (ohlcv, fundamental)"
           }
         ],
         "responses": {
@@ -3763,7 +3767,7 @@
           "data"
         ],
         "summary": "Get Storage Summary",
-        "description": "저장 용량 현황. 인증된 master/human 또는 ``data:read`` scope 를 보유한\nagent 만 호출 가능 (#1407).",
+        "description": "\uc800\uc7a5 \uc6a9\ub7c9 \ud604\ud669. \uc778\uc99d\ub41c master/human \ub610\ub294 ``data:read`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "get_storage_summary_api_data_storage_get",
         "responses": {
           "200": {
@@ -3785,7 +3789,7 @@
           "data"
         ],
         "summary": "Get Feed Status",
-        "description": "Feed 파이프라인 상태 조회. 인증된 master/human 또는 ``data:read`` scope\n를 보유한 agent 만 호출 가능 (#1407).\n\nFeed 초기화 여부, 소스별 체크포인트 현황, 최근 리포트 요약,\nAPI 키 설정 상태를 반환한다.",
+        "description": "Feed \ud30c\uc774\ud504\ub77c\uc778 \uc0c1\ud0dc \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``data:read`` scope\n\ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).\n\nFeed \ucd08\uae30\ud654 \uc5ec\ubd80, \uc18c\uc2a4\ubcc4 \uccb4\ud06c\ud3ec\uc778\ud2b8 \ud604\ud669, \ucd5c\uadfc \ub9ac\ud3ec\ud2b8 \uc694\uc57d,\nAPI \ud0a4 \uc124\uc815 \uc0c1\ud0dc\ub97c \ubc18\ud658\ud55c\ub2e4.",
         "operationId": "get_feed_status_api_data_feed_status_get",
         "responses": {
           "200": {
@@ -3807,7 +3811,7 @@
           "trades"
         ],
         "summary": "List Trades",
-        "description": "거래 기록 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는\n``trade:read`` scope 를 보유한 agent 만 호출 가능 (#1407).",
+        "description": "\uac70\ub798 \uae30\ub85d \ubaa9\ub85d \uc870\ud68c (cursor \uae30\ubc18 \ud398\uc774\uc9c0\ub124\uc774\uc158). \uc778\uc99d\ub41c master/human \ub610\ub294\n``trade:read`` scope \ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "list_trades_api_trades_get",
         "parameters": [
           {
@@ -3927,7 +3931,7 @@
           "bots"
         ],
         "summary": "List Bots",
-        "description": "봇 목록 조회 (cursor 기반 페이지네이션). 인증된 master/human 또는\n``bot:read`` scope 를 보유한 agent 만 호출 가능 (#1407).",
+        "description": "\ubd07 \ubaa9\ub85d \uc870\ud68c (cursor \uae30\ubc18 \ud398\uc774\uc9c0\ub124\uc774\uc158). \uc778\uc99d\ub41c master/human \ub610\ub294\n``bot:read`` scope \ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "list_bots_api_bots_get",
         "parameters": [
           {
@@ -4013,7 +4017,7 @@
           "bots"
         ],
         "summary": "Create Bot",
-        "description": "봇 생성. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한 agent\n만 호출 가능 (#1407 — spec ``bot:admin`` 정합, #1371 master_caller 에서\n마이그레이션).\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. FastAPI 가 ``body: BotCreateRequest`` 를 먼저 검증하면 unauth +\nbad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_bot_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``BotCreateRequest.model_validate`` — ValidationError → 422.\n4. service 호출 (``BotError`` → 409, ``TreasuryError`` → 422).",
+        "description": "\ubd07 \uc0dd\uc131. \uc778\uc99d\ub41c master/human \ub610\ub294 ``bot:admin`` scope \ub97c \ubcf4\uc720\ud55c agent\n\ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``bot:admin`` \uc815\ud569, #1371 master_caller \uc5d0\uc11c\n\ub9c8\uc774\uadf8\ub808\uc774\uc158).\n\nRaw body \ud30c\uc2f1 \ud328\ud134\uc73c\ub85c \uc778\uc99d \uac00\ub4dc\uac00 body validation \ubcf4\ub2e4 \uc6b0\uc120 \uc2e4\ud589\ub418\ub3c4\ub85d\n\ud55c\ub2e4. FastAPI \uac00 ``body: BotCreateRequest`` \ub97c \uba3c\uc800 \uac80\uc99d\ud558\uba74 unauth +\nbad-body \uc2dc 401 \uc774 \uc544\ub2cc 422 \uac00 \uba3c\uc800 \ubc18\ud658\ub418\uc5b4 contract \uac00 \uae68\uc9c4\ub2e4.\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n\n1. \uc778\uc99d \uac00\ub4dc (``Depends(require_bot_admin)``) \u2014 caller \ube48 \u2192 401,\n   \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403.\n2. raw bytes \uc77d\uae30 + JSON \ud30c\uc2f1 \u2014 \uc2e4\ud328 \uc2dc 422.\n3. ``BotCreateRequest.model_validate`` \u2014 ValidationError \u2192 422.\n4. service \ud638\ucd9c (``BotError`` \u2192 409, ``TreasuryError`` \u2192 422).",
         "operationId": "create_bot_api_bots_post",
         "responses": {
           "201": {
@@ -4037,7 +4041,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4047,7 +4051,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 bot:admin scope 보유 agent 만 허용)",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 bot:admin scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4077,7 +4081,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, 미지정 필드, strategy_id/strategy_name 동시 누락) 또는 budget allocation 실패 (Treasury error: insufficient funds, treasury not configured for account, etc.). On budget failure the newly created bot is rolled back via delete_bot(handle_positions='keep'). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1371).",
+            "description": "Body validation \uc2e4\ud328 (JSON \ud30c\uc2f1 \uc2e4\ud328, \ube48 body, type mismatch, \ubbf8\uc9c0\uc815 \ud544\ub4dc, strategy_id/strategy_name \ub3d9\uc2dc \ub204\ub77d) \ub610\ub294 budget allocation \uc2e4\ud328 (Treasury error: insufficient funds, treasury not configured for account, etc.). On budget failure the newly created bot is rolled back via delete_bot(handle_positions='keep'). \ub2e8, \uc778\uc99d\uc774 \uc2e4\ud328\ud558\uba74 body validation\uc740 \uc2e4\ud589\ub418\uc9c0 \uc54a\uace0 401\uc774 \uc6b0\uc120 \ubc18\ud658\ub41c\ub2e4(#1371).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4087,7 +4091,7 @@
             }
           },
           "500": {
-            "description": "Internal error (e.g. budget allocation failed AND rollback also failed; bot may be left in partial state — manual inspection of bot status and treasury required).",
+            "description": "Internal error (e.g. budget allocation failed AND rollback also failed; bot may be left in partial state \u2014 manual inspection of bot status and treasury required).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4125,7 +4129,7 @@
           "bots"
         ],
         "summary": "Get Bot",
-        "description": "봇 상세 조회. 인증된 master/human 또는 ``bot:read`` scope 를 보유한\nagent 만 호출 가능 (#1407).",
+        "description": "\ubd07 \uc0c1\uc138 \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``bot:read`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "get_bot_api_bots__bot_id__get",
         "parameters": [
           {
@@ -4186,7 +4190,7 @@
           "bots"
         ],
         "summary": "Delete Bot",
-        "description": "봇 삭제. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한 agent\n만 호출 가능 (#1407 — spec ``bot:admin`` 정합, #1371 master_caller 에서\n마이그레이션).\n\nbody가 없으므로 raw-body cold-path는 적용하지 않는다. 인증 가드가\nhandle_positions query 파라미터 검증보다 먼저 실행되어 unauth는 401,\nnon-master는 403으로 차단된다.\n\nhandle_positions:\n    - keep (기본): 포지션을 유지한 채 봇만 삭제.\n    - liquidate: 보유 종목 시장가 매도 주문 발행 후 삭제.",
+        "description": "\ubd07 \uc0ad\uc81c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``bot:admin`` scope \ub97c \ubcf4\uc720\ud55c agent\n\ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``bot:admin`` \uc815\ud569, #1371 master_caller \uc5d0\uc11c\n\ub9c8\uc774\uadf8\ub808\uc774\uc158).\n\nbody\uac00 \uc5c6\uc73c\ubbc0\ub85c raw-body cold-path\ub294 \uc801\uc6a9\ud558\uc9c0 \uc54a\ub294\ub2e4. \uc778\uc99d \uac00\ub4dc\uac00\nhandle_positions query \ud30c\ub77c\ubbf8\ud130 \uac80\uc99d\ubcf4\ub2e4 \uba3c\uc800 \uc2e4\ud589\ub418\uc5b4 unauth\ub294 401,\nnon-master\ub294 403\uc73c\ub85c \ucc28\ub2e8\ub41c\ub2e4.\n\nhandle_positions:\n    - keep (\uae30\ubcf8): \ud3ec\uc9c0\uc158\uc744 \uc720\uc9c0\ud55c \ucc44 \ubd07\ub9cc \uc0ad\uc81c.\n    - liquidate: \ubcf4\uc720 \uc885\ubaa9 \uc2dc\uc7a5\uac00 \ub9e4\ub3c4 \uc8fc\ubb38 \ubc1c\ud589 \ud6c4 \uc0ad\uc81c.",
         "operationId": "delete_bot_api_bots__bot_id__delete",
         "parameters": [
           {
@@ -4214,7 +4218,7 @@
             "description": "Successful Response"
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4224,7 +4228,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 bot:admin scope 보유 agent 만 허용)",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 bot:admin scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4280,7 +4284,7 @@
           "bots"
         ],
         "summary": "Update Bot",
-        "description": "봇 설정 수정. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``bot:admin`` 정합, #1352 master_caller\n에서 마이그레이션). 중지 상태에서만 허용.\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. FastAPI 가 ``body: BotUpdateRequest`` 를 먼저 검증하면 unauth +\nbad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_bot_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``BotUpdateRequest.model_validate`` — ValidationError → 422.\n4. service 호출 (``BotError`` → 409, ``TreasuryError`` → 422).",
+        "description": "\ubd07 \uc124\uc815 \uc218\uc815. \uc778\uc99d\ub41c master/human \ub610\ub294 ``bot:admin`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``bot:admin`` \uc815\ud569, #1352 master_caller\n\uc5d0\uc11c \ub9c8\uc774\uadf8\ub808\uc774\uc158). \uc911\uc9c0 \uc0c1\ud0dc\uc5d0\uc11c\ub9cc \ud5c8\uc6a9.\n\nRaw body \ud30c\uc2f1 \ud328\ud134\uc73c\ub85c \uc778\uc99d \uac00\ub4dc\uac00 body validation \ubcf4\ub2e4 \uc6b0\uc120 \uc2e4\ud589\ub418\ub3c4\ub85d\n\ud55c\ub2e4. FastAPI \uac00 ``body: BotUpdateRequest`` \ub97c \uba3c\uc800 \uac80\uc99d\ud558\uba74 unauth +\nbad-body \uc2dc 401 \uc774 \uc544\ub2cc 422 \uac00 \uba3c\uc800 \ubc18\ud658\ub418\uc5b4 contract \uac00 \uae68\uc9c4\ub2e4.\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n\n1. \uc778\uc99d \uac00\ub4dc (``Depends(require_bot_admin)``) \u2014 caller \ube48 \u2192 401,\n   \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403.\n2. raw bytes \uc77d\uae30 + JSON \ud30c\uc2f1 \u2014 \uc2e4\ud328 \uc2dc 422.\n3. ``BotUpdateRequest.model_validate`` \u2014 ValidationError \u2192 422.\n4. service \ud638\ucd9c (``BotError`` \u2192 409, ``TreasuryError`` \u2192 422).",
         "operationId": "update_bot_api_bots__bot_id__put",
         "parameters": [
           {
@@ -4305,7 +4309,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4315,7 +4319,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 bot:admin scope 보유 agent 만 허용)",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 bot:admin scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4345,7 +4349,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, 미지정 필드) 또는 budget update 실패. 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1352).",
+            "description": "Body validation \uc2e4\ud328 (JSON \ud30c\uc2f1 \uc2e4\ud328, \ube48 body, type mismatch, \ubbf8\uc9c0\uc815 \ud544\ub4dc) \ub610\ub294 budget update \uc2e4\ud328. \ub2e8, \uc778\uc99d\uc774 \uc2e4\ud328\ud558\uba74 body validation\uc740 \uc2e4\ud589\ub418\uc9c0 \uc54a\uace0 401\uc774 \uc6b0\uc120 \ubc18\ud658\ub41c\ub2e4(#1352).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4383,7 +4387,7 @@
           "bots"
         ],
         "summary": "Start Bot",
-        "description": "봇 시작. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한 agent\n만 호출 가능 (#1407).",
+        "description": "\ubd07 \uc2dc\uc791. \uc778\uc99d\ub41c master/human \ub610\ub294 ``bot:admin`` scope \ub97c \ubcf4\uc720\ud55c agent\n\ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "start_bot_api_bots__bot_id__start_post",
         "parameters": [
           {
@@ -4456,7 +4460,7 @@
           "bots"
         ],
         "summary": "Stop Bot",
-        "description": "봇 중지. 인증된 master/human 또는 ``bot:admin`` scope 를 보유한 agent\n만 호출 가능 (#1407).",
+        "description": "\ubd07 \uc911\uc9c0. \uc778\uc99d\ub41c master/human \ub610\ub294 ``bot:admin`` scope \ub97c \ubcf4\uc720\ud55c agent\n\ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "stop_bot_api_bots__bot_id__stop_post",
         "parameters": [
           {
@@ -4529,7 +4533,7 @@
           "bots"
         ],
         "summary": "Get Bot Logs",
-        "description": "봇 실행 로그 조회. 인증된 master/human 또는 ``bot:read`` scope 를 보유한\nagent 만 호출 가능 (#1407).\n\nBotStepCompletedEvent 이력을 반환한다.\nevent_history_store(SQLite)가 있으면 영속 로그를 조회하고,\n없으면 EventBus 인메모리 히스토리에서 조회한다.\n\n응답 형식 (#1437): ``{\"bot_id\", \"logs\": [...], \"total\"}``.\n- ``total``은 bot_id + date range 필터 적용 후의 총 개수 (페이지네이션 전).\n- ``logs``는 ``offset..offset+limit`` 범위의 페이지 데이터.\n\nQuery 파라미터 (#1437):\n    - ``limit``: 페이지 크기 (기본 50, 1..100).\n    - ``offset``: 페이지 시작 인덱스 (기본 0, ge=0).\n    - ``start_date``/``end_date``: ISO 8601 date 또는 datetime. 핸들러는\n      입력을 UTC-naive ``datetime``으로 정규화한 뒤 ``EventHistoryStore``\n      SQL filter(``timestamp >= ? AND timestamp <= ?``)에 전달한다.\n\nCodex P2 (#1437 fix loop r1):\n    r0 구현은 두 가지 silent regression이 있었다.\n\n    (1) ``store.query(limit=limit)`` + in-memory 페이지 슬라이스 — store가\n        처음부터 ``LIMIT limit``만 fetch하기 때문에 ``offset=10&limit=10``\n        요청 시 2페이지가 비거나 짧고, ``total`` 카운트가 처음 limit\n        범위로만 제한된다. 본 r1 구현은 store에 ``offset``/``until``과\n        ``count`` 시그니처를 확장하고, ``bot_id`` 가 payload JSON 안에\n        있어 SQL 직접 필터가 어렵다는 한계를 인정해, **매칭 가능 범위를\n        모두 가져온 뒤 in-memory에서 ``bot_id`` 필터 → ``total`` → 페이지\n        슬라이스** 흐름으로 변경한다. ``EventHistoryStore.query``에 추가된\n        ``offset`` 파라미터는 ``bot_id`` 필터 미적용 호출자(미래 dashboard\n        total badge 등)가 효율적인 페이지네이션을 할 수 있도록 보강해두지만,\n        본 핸들러는 ``bot_id`` 정확성 우선으로 사용하지 않는다.\n        매칭 row 수가 과도하게 커지지 않도록 hard cap\n        ``_BOT_LOGS_FETCH_HARD_CAP``을 둔다(retention 30일 가정 하 충분).\n\n    (2) ``start_date``/``end_date`` 를 입력 그대로(``+09:00`` 등 offset\n        suffix 포함) in-memory ``timestamp >= start_date`` 문자열 비교에\n        사용 — storage timestamp는 UTC-naive ISO 문자열이라 ASCII 정렬\n        규칙으로 실제 UTC 시간과 어긋난다 (#1414 audit r2와 동일 패턴).\n        본 r1 구현은 ``_validate_iso_date_param``으로 입력을 UTC-naive\n        ``datetime``으로 정규화하고, ``EventHistoryStore``의 SQL 텍스트\n        비교에 그대로 사용한다. event timestamp는 dataclass field default\n        ``datetime.now(timezone.utc)``로 tz-aware UTC이지만,\n        ``isoformat()`` 결과를 SQL 텍스트로 비교하므로 ``+00:00`` suffix가\n        있을 수 있다. inclusive boundary는 ``>=``/``<=`` 비교라서\n        ``T00:00:00`` < ``T00:00:00+00:00`` < ``T23:59:59+00:00`` <\n        ``T23:59:59Z`` (ASCII) 관계가 성립하므로, ``date.fromisoformat``\n        확장 datetime(``T00:00:00`` / ``T23:59:59``)이 안전한 하한/상한이\n        된다.\n\nNote: ``bot_id`` 가 payload JSON 안에 있어 SQL 직접 필터가 어렵다는\n    한계로, 매칭 row 수가 hard cap을 초과하는 환경에선 ``total`` 이 cap에\n    clamp된다. SQL JSON1로 ``bot_id`` 를 SQL 필터로 끌어올리는 최적화는\n    본 패치 범위(Non-Goal). 별도 이슈로 분리한다.",
+        "description": "\ubd07 \uc2e4\ud589 \ub85c\uadf8 \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``bot:read`` scope \ub97c \ubcf4\uc720\ud55c\nagent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).\n\nBotStepCompletedEvent \uc774\ub825\uc744 \ubc18\ud658\ud55c\ub2e4.\nevent_history_store(SQLite)\uac00 \uc788\uc73c\uba74 \uc601\uc18d \ub85c\uadf8\ub97c \uc870\ud68c\ud558\uace0,\n\uc5c6\uc73c\uba74 EventBus \uc778\uba54\ubaa8\ub9ac \ud788\uc2a4\ud1a0\ub9ac\uc5d0\uc11c \uc870\ud68c\ud55c\ub2e4.\n\n\uc751\ub2f5 \ud615\uc2dd (#1437): ``{\"bot_id\", \"logs\": [...], \"total\"}``.\n- ``total``\uc740 bot_id + date range \ud544\ud130 \uc801\uc6a9 \ud6c4\uc758 \ucd1d \uac1c\uc218 (\ud398\uc774\uc9c0\ub124\uc774\uc158 \uc804).\n- ``logs``\ub294 ``offset..offset+limit`` \ubc94\uc704\uc758 \ud398\uc774\uc9c0 \ub370\uc774\ud130.\n\nQuery \ud30c\ub77c\ubbf8\ud130 (#1437):\n    - ``limit``: \ud398\uc774\uc9c0 \ud06c\uae30 (\uae30\ubcf8 50, 1..100).\n    - ``offset``: \ud398\uc774\uc9c0 \uc2dc\uc791 \uc778\ub371\uc2a4 (\uae30\ubcf8 0, ge=0).\n    - ``start_date``/``end_date``: ISO 8601 date \ub610\ub294 datetime. \ud578\ub4e4\ub7ec\ub294\n      \uc785\ub825\uc744 UTC-naive ``datetime``\uc73c\ub85c \uc815\uaddc\ud654\ud55c \ub4a4 ``EventHistoryStore``\n      SQL filter(``timestamp >= ? AND timestamp <= ?``)\uc5d0 \uc804\ub2ec\ud55c\ub2e4.\n\nCodex P2 (#1437 fix loop r2):\n    r1 \uad6c\ud604\uc740 \ub450 \uac00\uc9c0 silent failure\uac00 \ub0a8\uc544\uc788\uc5c8\ub2e4.\n\n    (1) ``EventHistoryStore.query`` \uc2dc\uadf8\ub2c8\ucc98 \u2014 r1\uc740 ``until``\uc744 ``limit``\n        \uc55e \uc704\uce58 \uc778\uc790\ub85c \ucd94\uac00\ud574 \uae30\uc874 caller ``store.query(type, since, 50)``\n        \uc758 \uc138 \ubc88\uc9f8 \uc704\uce58 \uc778\uc790 ``50``\uc774 ``limit`` \ub300\uc2e0 ``until``\ub85c\n        \uc798\ubabb \ubc14\uc778\ub529\ub418\ub294 \uc704\ud5d8\uc774 \uc788\uc5c8\ub2e4. r2\ub294 ``until``/``offset``/\n        ``payload_filter``\ub97c keyword-only\ub85c \uc62e\uaca8 \uc704\uce58 \uc778\uc790 \ud638\ud658\uc131\uc744\n        \ubcf5\uc6d0\ud55c\ub2e4.\n\n    (2) hard cap ``_BOT_LOGS_FETCH_HARD_CAP=10000`` \u2014 r1\uc740 ``bot_id`` \uac00\n        payload JSON \uc548\uc774\ub77c SQL \uc9c1\uc811 \ud544\ud130\uac00 \uc5b4\ub835\ub2e4\ub294 \uc774\uc720\ub85c \ub9e4\uce6d \uac00\ub2a5\n        \ubc94\uc704(event_type + since/until)\ub97c \ud55c\ubc88\uc5d0 10000\uac74 fetch\ud55c \ub4a4\n        in-memory ``bot_id`` \ud544\ud130\ub97c \uc801\uc6a9\ud588\ub2e4. \ub2e4\ub978 \ubd07\uc758 \ub85c\uadf8\uac00 cap\uc744\n        \uba3c\uc800 \ucc44\uc6b0\uba74 \ud2b9\uc815 \ubd07\uc758 \ub85c\uadf8\uac00 \uacb0\uacfc\uc5d0\uc11c \ub204\ub77d\ub420 \uc218 \uc788\ub2e4(\uc5ec\ub7ec \ubd07\uc774\n        \ubcd1\ub82c\ub85c step\uc744 \ucc0d\ub294 \ud658\uacbd\uc5d0\uc11c silent under-count). r2\ub294\n        ``EventHistoryStore``\uc5d0 SQL JSON1 ``payload_filter``\ub97c \ucd94\uac00\ud574\n        ``bot_id``\ub97c SQL \ub2e8\uacc4\uc5d0\uc11c \ud544\ud130\ub9c1\ud55c\ub2e4 \u2014 cap\uc774 \ud544\uc694 \uc5c6\uace0\n        ``total``/``logs``\uac00 cap\uc5d0 \ubb34\uad00\ud558\uac8c \uc815\ud655\ud558\ub2e4.\n\n    (3) ``start_date``/``end_date`` \uc758 timezone \uc815\ud569 (r1\uc5d0\uc11c \ud574\uacb0, r2\uc5d0\uc11c\n        \uadf8\ub300\ub85c \uc720\uc9c0): ``_validate_iso_date_param``\uc73c\ub85c \uc785\ub825\uc744 UTC tz-aware\n        ``datetime``\uc73c\ub85c \uc815\uaddc\ud654\ud55c \ub4a4 ``EventHistoryStore``\uc758 SQL \ud14d\uc2a4\ud2b8\n        \ube44\uad50\uc5d0 \uadf8\ub300\ub85c \uc0ac\uc6a9\ud55c\ub2e4. event timestamp\ub294 dataclass field default\n        ``datetime.now(UTC)``\ub85c tz-aware UTC\uc774\uba70, ``isoformat()`` \uacb0\uacfc\uc758\n        ``+00:00`` suffix\uac00 \uc591\ucabd\uc5d0 \uc77c\uad00\ub418\uac8c \ubd99\uc5b4 ASCII \ube44\uad50\uac00 \uc2e4\uc81c UTC\n        \uc2dc\uac04 \uad00\uacc4\uc640 \uc77c\uce58\ud55c\ub2e4.",
         "operationId": "get_bot_logs_api_bots__bot_id__logs_get",
         "parameters": [
           {
@@ -4577,10 +4581,10 @@
                   "type": "null"
                 }
               ],
-              "description": "ISO 8601 date (``YYYY-MM-DD``) 또는 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive lower bound.",
+              "description": "ISO 8601 date (``YYYY-MM-DD``) \ub610\ub294 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive lower bound.",
               "title": "Start Date"
             },
-            "description": "ISO 8601 date (``YYYY-MM-DD``) 또는 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive lower bound."
+            "description": "ISO 8601 date (``YYYY-MM-DD``) \ub610\ub294 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive lower bound."
           },
           {
             "name": "end_date",
@@ -4595,10 +4599,10 @@
                   "type": "null"
                 }
               ],
-              "description": "ISO 8601 date (``YYYY-MM-DD``) 또는 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive upper bound. date-only는 ``T23:59:59``로 확장된다.",
+              "description": "ISO 8601 date (``YYYY-MM-DD``) \ub610\ub294 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive upper bound. date-only\ub294 ``T23:59:59``\ub85c \ud655\uc7a5\ub41c\ub2e4.",
               "title": "End Date"
             },
-            "description": "ISO 8601 date (``YYYY-MM-DD``) 또는 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive upper bound. date-only는 ``T23:59:59``로 확장된다."
+            "description": "ISO 8601 date (``YYYY-MM-DD``) \ub610\ub294 datetime (``YYYY-MM-DDTHH:MM:SS[Z]``). inclusive upper bound. date-only\ub294 ``T23:59:59``\ub85c \ud655\uc7a5\ub41c\ub2e4."
           }
         ],
         "responses": {
@@ -4625,7 +4629,7 @@
             }
           },
           "422": {
-            "description": "Invalid date filter (ISO 8601 required). ``start_date``/``end_date``는 ISO 8601 date(``YYYY-MM-DD``) 또는 datetime(``YYYY-MM-DDTHH:MM:SS[Z]``)만 허용한다.",
+            "description": "Invalid date filter (ISO 8601 required). ``start_date``/``end_date``\ub294 ISO 8601 date(``YYYY-MM-DD``) \ub610\ub294 datetime(``YYYY-MM-DDTHH:MM:SS[Z]``)\ub9cc \ud5c8\uc6a9\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4653,7 +4657,7 @@
           "treasury"
         ],
         "summary": "Get Summary",
-        "description": "자금 현황 요약. 인증된 master/human 또는 ``treasury:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).\n\naccount_id 지정 시 해당 계좌의 Treasury 요약을 반환한다.\n미지정 시 기본 Treasury 요약을 반환한다 (하위 호환).",
+        "description": "\uc790\uae08 \ud604\ud669 \uc694\uc57d. \uc778\uc99d\ub41c master/human \ub610\ub294 ``treasury:read`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).\n\naccount_id \uc9c0\uc815 \uc2dc \ud574\ub2f9 \uacc4\uc88c\uc758 Treasury \uc694\uc57d\uc744 \ubc18\ud658\ud55c\ub2e4.\n\ubbf8\uc9c0\uc815 \uc2dc \uae30\ubcf8 Treasury \uc694\uc57d\uc744 \ubc18\ud658\ud55c\ub2e4 (\ud558\uc704 \ud638\ud658).",
         "operationId": "get_summary_api_treasury_get",
         "parameters": [
           {
@@ -4723,7 +4727,7 @@
           "treasury"
         ],
         "summary": "List Transactions",
-        "description": "자금 변동 이력 조회. 인증된 master/human 또는 ``treasury:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
+        "description": "\uc790\uae08 \ubcc0\ub3d9 \uc774\ub825 \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``treasury:read`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "list_transactions_api_treasury_transactions_get",
         "parameters": [
           {
@@ -4870,7 +4874,7 @@
           "treasury"
         ],
         "summary": "Allocate",
-        "description": "봇에 예산 할당. 인증된 master/human 또는 ``treasury:admin`` scope 를\n보유한 agent 만 호출 가능 (#1407 — spec ``treasury:admin`` 정합, #1372\nmaster_caller 에서 마이그레이션).\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. FastAPI 가 ``body: BudgetChangeRequest`` 를 먼저 검증하면 unauth +\nbad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_treasury_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``BudgetChangeRequest.model_validate`` — ValidationError → 422.\n4. ``treasury.allocate`` 호출 (``BotNotStoppedError`` → 409).",
+        "description": "\ubd07\uc5d0 \uc608\uc0b0 \ud560\ub2f9. \uc778\uc99d\ub41c master/human \ub610\ub294 ``treasury:admin`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``treasury:admin`` \uc815\ud569, #1372\nmaster_caller \uc5d0\uc11c \ub9c8\uc774\uadf8\ub808\uc774\uc158).\n\nRaw body \ud30c\uc2f1 \ud328\ud134\uc73c\ub85c \uc778\uc99d \uac00\ub4dc\uac00 body validation \ubcf4\ub2e4 \uc6b0\uc120 \uc2e4\ud589\ub418\ub3c4\ub85d\n\ud55c\ub2e4. FastAPI \uac00 ``body: BudgetChangeRequest`` \ub97c \uba3c\uc800 \uac80\uc99d\ud558\uba74 unauth +\nbad-body \uc2dc 401 \uc774 \uc544\ub2cc 422 \uac00 \uba3c\uc800 \ubc18\ud658\ub418\uc5b4 contract \uac00 \uae68\uc9c4\ub2e4.\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n\n1. \uc778\uc99d \uac00\ub4dc (``Depends(require_treasury_admin)``) \u2014 caller \ube48 \u2192 401,\n   \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403.\n2. raw bytes \uc77d\uae30 + JSON \ud30c\uc2f1 \u2014 \uc2e4\ud328 \uc2dc 422.\n3. ``BudgetChangeRequest.model_validate`` \u2014 ValidationError \u2192 422.\n4. ``treasury.allocate`` \ud638\ucd9c (``BotNotStoppedError`` \u2192 409).",
         "operationId": "allocate_api_treasury_bots__bot_id__allocate_post",
         "parameters": [
           {
@@ -4905,7 +4909,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4915,7 +4919,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 treasury:admin scope 보유 agent 만 허용)",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 treasury:admin scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4945,7 +4949,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, amount 누락, amount가 NaN/±Infinity/0/음수). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1372, #1411).",
+            "description": "Body validation \uc2e4\ud328 (JSON \ud30c\uc2f1 \uc2e4\ud328, \ube48 body, type mismatch, amount \ub204\ub77d, amount\uac00 NaN/\u00b1Infinity/0/\uc74c\uc218). \ub2e8, \uc778\uc99d\uc774 \uc2e4\ud328\ud558\uba74 body validation\uc740 \uc2e4\ud589\ub418\uc9c0 \uc54a\uace0 401\uc774 \uc6b0\uc120 \ubc18\ud658\ub41c\ub2e4(#1372, #1411).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4983,7 +4987,7 @@
           "treasury"
         ],
         "summary": "Deallocate",
-        "description": "봇 예산 회수. 인증된 master/human 또는 ``treasury:admin`` scope 를\n보유한 agent 만 호출 가능 (#1407 — spec ``treasury:admin`` 정합, #1372\nmaster_caller 에서 마이그레이션).\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_treasury_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``BudgetChangeRequest.model_validate`` — ValidationError → 422.\n4. ``treasury.deallocate`` 호출 (``BotNotStoppedError`` → 409).",
+        "description": "\ubd07 \uc608\uc0b0 \ud68c\uc218. \uc778\uc99d\ub41c master/human \ub610\ub294 ``treasury:admin`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``treasury:admin`` \uc815\ud569, #1372\nmaster_caller \uc5d0\uc11c \ub9c8\uc774\uadf8\ub808\uc774\uc158).\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n\n1. \uc778\uc99d \uac00\ub4dc (``Depends(require_treasury_admin)``) \u2014 caller \ube48 \u2192 401,\n   \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403.\n2. raw bytes \uc77d\uae30 + JSON \ud30c\uc2f1 \u2014 \uc2e4\ud328 \uc2dc 422.\n3. ``BudgetChangeRequest.model_validate`` \u2014 ValidationError \u2192 422.\n4. ``treasury.deallocate`` \ud638\ucd9c (``BotNotStoppedError`` \u2192 409).",
         "operationId": "deallocate_api_treasury_bots__bot_id__deallocate_post",
         "parameters": [
           {
@@ -5018,7 +5022,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -5028,7 +5032,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 treasury:admin scope 보유 agent 만 허용)",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 treasury:admin scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -5058,7 +5062,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, type mismatch, amount 누락, amount가 NaN/±Infinity/0/음수). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1372, #1411).",
+            "description": "Body validation \uc2e4\ud328 (JSON \ud30c\uc2f1 \uc2e4\ud328, \ube48 body, type mismatch, amount \ub204\ub77d, amount\uac00 NaN/\u00b1Infinity/0/\uc74c\uc218). \ub2e8, \uc778\uc99d\uc774 \uc2e4\ud328\ud558\uba74 body validation\uc740 \uc2e4\ud589\ub418\uc9c0 \uc54a\uace0 401\uc774 \uc6b0\uc120 \ubc18\ud658\ub41c\ub2e4(#1372, #1411).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -5096,7 +5100,7 @@
           "treasury"
         ],
         "summary": "List Budgets",
-        "description": "봇별 예산 목록 조회. 인증된 master/human 또는 ``treasury:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
+        "description": "\ubd07\ubcc4 \uc608\uc0b0 \ubaa9\ub85d \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``treasury:read`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "list_budgets_api_treasury_budgets_get",
         "responses": {
           "200": {
@@ -5128,7 +5132,7 @@
           "treasury"
         ],
         "summary": "Set Balance",
-        "description": "계좌 총 잔고 수동 설정. 인증된 master/human 또는 ``treasury:admin`` scope\n를 보유한 agent 만 호출 가능 (#1407 — spec ``treasury:admin`` 정합, #1352\nmaster_caller 에서 마이그레이션).\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. FastAPI 가 ``body: BalanceSetRequest`` 를 먼저 검증하면 unauth +\nbad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_treasury_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``BalanceSetRequest.model_validate`` — ValidationError → 422.\n4. ``treasury.set_account_balance`` 호출.",
+        "description": "\uacc4\uc88c \ucd1d \uc794\uace0 \uc218\ub3d9 \uc124\uc815. \uc778\uc99d\ub41c master/human \ub610\ub294 ``treasury:admin`` scope\n\ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407 \u2014 spec ``treasury:admin`` \uc815\ud569, #1352\nmaster_caller \uc5d0\uc11c \ub9c8\uc774\uadf8\ub808\uc774\uc158).\n\nRaw body \ud30c\uc2f1 \ud328\ud134\uc73c\ub85c \uc778\uc99d \uac00\ub4dc\uac00 body validation \ubcf4\ub2e4 \uc6b0\uc120 \uc2e4\ud589\ub418\ub3c4\ub85d\n\ud55c\ub2e4. FastAPI \uac00 ``body: BalanceSetRequest`` \ub97c \uba3c\uc800 \uac80\uc99d\ud558\uba74 unauth +\nbad-body \uc2dc 401 \uc774 \uc544\ub2cc 422 \uac00 \uba3c\uc800 \ubc18\ud658\ub418\uc5b4 contract \uac00 \uae68\uc9c4\ub2e4.\n\n\ud578\ub4e4\ub7ec \ub2e8\uacc4 \uc21c\uc11c:\n\n1. \uc778\uc99d \uac00\ub4dc (``Depends(require_treasury_admin)``) \u2014 caller \ube48 \u2192 401,\n   \uad8c\ud55c \uc5c6\uc74c \u2192 403, \ube44\ud65c\uc131 \uba64\ubc84 \u2192 403.\n2. raw bytes \uc77d\uae30 + JSON \ud30c\uc2f1 \u2014 \uc2e4\ud328 \uc2dc 422.\n3. ``BalanceSetRequest.model_validate`` \u2014 ValidationError \u2192 422.\n4. ``treasury.set_account_balance`` \ud638\ucd9c.",
         "operationId": "set_balance_api_treasury_balance_post",
         "requestBody": {
           "content": {
@@ -5152,7 +5156,7 @@
             }
           },
           "401": {
-            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). 대시보드 사용자는 로그인 후 ante_session 쿠키만 가지고 호출하며, 에이전트 클라이언트는 Bearer 토큰만 가지고 호출한다. 둘 중 하나라도 유효하면 통과한다.",
+            "description": "Authentication required (missing or invalid Authorization header AND missing or invalid ante_session cookie). \ub300\uc2dc\ubcf4\ub4dc \uc0ac\uc6a9\uc790\ub294 \ub85c\uadf8\uc778 \ud6c4 ante_session \ucfe0\ud0a4\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud558\uba70, \uc5d0\uc774\uc804\ud2b8 \ud074\ub77c\uc774\uc5b8\ud2b8\ub294 Bearer \ud1a0\ud070\ub9cc \uac00\uc9c0\uace0 \ud638\ucd9c\ud55c\ub2e4. \ub458 \uc911 \ud558\ub098\ub77c\ub3c4 \uc720\ud6a8\ud558\uba74 \ud1b5\uacfc\ud55c\ub2e4.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -5162,7 +5166,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 treasury:admin scope 보유 agent 만 허용)",
+            "description": "Permission denied (master, human \uba64\ubc84 \ub610\ub294 treasury:admin scope \ubcf4\uc720 agent \ub9cc \ud5c8\uc6a9)",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -5172,7 +5176,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, 미지정 필드, balance 음수/NaN/Inf). 단, 인증이 실패하면 body validation은 실행되지 않고 401이 우선 반환된다(#1352).",
+            "description": "Body validation \uc2e4\ud328 (JSON \ud30c\uc2f1 \uc2e4\ud328, \ube48 body, \ubbf8\uc9c0\uc815 \ud544\ub4dc, balance \uc74c\uc218/NaN/Inf). \ub2e8, \uc778\uc99d\uc774 \uc2e4\ud328\ud558\uba74 body validation\uc740 \uc2e4\ud589\ub418\uc9c0 \uc54a\uace0 401\uc774 \uc6b0\uc120 \ubc18\ud658\ub41c\ub2e4(#1352).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -5200,7 +5204,7 @@
           "treasury"
         ],
         "summary": "Get Latest Snapshot",
-        "description": "가장 최근 일별 스냅샷 조회. 인증된 master/human 또는 ``treasury:read``\nscope 를 보유한 agent 만 호출 가능 (#1407).",
+        "description": "\uac00\uc7a5 \ucd5c\uadfc \uc77c\ubcc4 \uc2a4\ub0c5\uc0f7 \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``treasury:read``\nscope \ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "get_latest_snapshot_api_treasury_snapshots_latest_get",
         "parameters": [
           {
@@ -5260,7 +5264,7 @@
           "treasury"
         ],
         "summary": "List Snapshots",
-        "description": "기간별 일별 스냅샷 목록. 인증된 master/human 또는 ``treasury:read`` scope\n를 보유한 agent 만 호출 가능 (#1407).",
+        "description": "\uae30\uac04\ubcc4 \uc77c\ubcc4 \uc2a4\ub0c5\uc0f7 \ubaa9\ub85d. \uc778\uc99d\ub41c master/human \ub610\ub294 ``treasury:read`` scope\n\ub97c \ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "list_snapshots_api_treasury_snapshots_get",
         "parameters": [
           {
@@ -5352,7 +5356,7 @@
           "treasury"
         ],
         "summary": "Get Snapshot By Date",
-        "description": "특정일 스냅샷 조회. 인증된 master/human 또는 ``treasury:read`` scope 를\n보유한 agent 만 호출 가능 (#1407).",
+        "description": "\ud2b9\uc815\uc77c \uc2a4\ub0c5\uc0f7 \uc870\ud68c. \uc778\uc99d\ub41c master/human \ub610\ub294 ``treasury:read`` scope \ub97c\n\ubcf4\uc720\ud55c agent \ub9cc \ud638\ucd9c \uac00\ub2a5 (#1407).",
         "operationId": "get_snapshot_by_date_api_treasury_snapshots__date__get",
         "parameters": [
           {
@@ -5444,7 +5448,7 @@
           "message"
         ],
         "title": "AccountActionResponse",
-        "description": "계좌 상태 변경 응답."
+        "description": "\uacc4\uc88c \uc0c1\ud0dc \ubcc0\uacbd \uc751\ub2f5."
       },
       "AccountDetailResponse": {
         "properties": {
@@ -5457,7 +5461,7 @@
           "account"
         ],
         "title": "AccountDetailResponse",
-        "description": "계좌 상세 응답."
+        "description": "\uacc4\uc88c \uc0c1\uc138 \uc751\ub2f5."
       },
       "AccountListResponse": {
         "properties": {
@@ -5474,7 +5478,7 @@
           "accounts"
         ],
         "title": "AccountListResponse",
-        "description": "계좌 목록 응답."
+        "description": "\uacc4\uc88c \ubaa9\ub85d \uc751\ub2f5."
       },
       "AccountResponse": {
         "properties": {
@@ -5564,7 +5568,7 @@
           "updated_at"
         ],
         "title": "AccountResponse",
-        "description": "계좌 응답. credentials는 보안상 포함하지 않는다."
+        "description": "\uacc4\uc88c \uc751\ub2f5. credentials\ub294 \ubcf4\uc548\uc0c1 \ud3ec\ud568\ud558\uc9c0 \uc54a\ub294\ub2e4."
       },
       "ApprovalDetailResponse": {
         "properties": {
@@ -5589,7 +5593,7 @@
           "approval"
         ],
         "title": "ApprovalDetailResponse",
-        "description": "결재 상세 응답."
+        "description": "\uacb0\uc7ac \uc0c1\uc138 \uc751\ub2f5."
       },
       "ApprovalItem": {
         "properties": {
@@ -5683,7 +5687,7 @@
           "title"
         ],
         "title": "ApprovalItem",
-        "description": "결재 요청 아이템."
+        "description": "\uacb0\uc7ac \uc694\uccad \uc544\uc774\ud15c."
       },
       "ApprovalListResponse": {
         "properties": {
@@ -5705,7 +5709,7 @@
           "total"
         ],
         "title": "ApprovalListResponse",
-        "description": "결재 목록 응답."
+        "description": "\uacb0\uc7ac \ubaa9\ub85d \uc751\ub2f5."
       },
       "ApprovalStatus": {
         "type": "string",
@@ -5719,7 +5723,7 @@
           "cancelled"
         ],
         "title": "ApprovalStatus",
-        "description": "결재 상태."
+        "description": "\uacb0\uc7ac \uc0c1\ud0dc."
       },
       "ApprovalUpdateResponse": {
         "properties": {
@@ -5732,7 +5736,7 @@
           "approval"
         ],
         "title": "ApprovalUpdateResponse",
-        "description": "결재 상태 변경 응답."
+        "description": "\uacb0\uc7ac \uc0c1\ud0dc \ubcc0\uacbd \uc751\ub2f5."
       },
       "AuditLogItem": {
         "properties": {
@@ -5777,7 +5781,7 @@
           "id"
         ],
         "title": "AuditLogItem",
-        "description": "감사 로그 아이템."
+        "description": "\uac10\uc0ac \ub85c\uadf8 \uc544\uc774\ud15c."
       },
       "AuditLogListResponse": {
         "properties": {
@@ -5799,7 +5803,7 @@
           "total"
         ],
         "title": "AuditLogListResponse",
-        "description": "감사 로그 목록 응답."
+        "description": "\uac10\uc0ac \ub85c\uadf8 \ubaa9\ub85d \uc751\ub2f5."
       },
       "BalanceSetResponse": {
         "properties": {
@@ -5818,7 +5822,7 @@
           "updated_at"
         ],
         "title": "BalanceSetResponse",
-        "description": "잔고 설정 응답."
+        "description": "\uc794\uace0 \uc124\uc815 \uc751\ub2f5."
       },
       "BotDetailResponse": {
         "properties": {
@@ -5831,7 +5835,7 @@
           "bot"
         ],
         "title": "BotDetailResponse",
-        "description": "봇 상세/생성/시작/중지 응답."
+        "description": "\ubd07 \uc0c1\uc138/\uc0dd\uc131/\uc2dc\uc791/\uc911\uc9c0 \uc751\ub2f5."
       },
       "BotInfo": {
         "properties": {
@@ -5937,7 +5941,7 @@
           "bot_id"
         ],
         "title": "BotInfo",
-        "description": "봇 정보 (read 응답).\n\nwrite 경로(``BotConfig``, ``ApprovalService.create``)에서 account_id가\n검증되므로 read 응답 schema에는 default를 유지한다."
+        "description": "\ubd07 \uc815\ubcf4 (read \uc751\ub2f5).\n\nwrite \uacbd\ub85c(``BotConfig``, ``ApprovalService.create``)\uc5d0\uc11c account_id\uac00\n\uac80\uc99d\ub418\ubbc0\ub85c read \uc751\ub2f5 schema\uc5d0\ub294 default\ub97c \uc720\uc9c0\ud55c\ub2e4."
       },
       "BotListResponse": {
         "properties": {
@@ -5965,7 +5969,7 @@
           "bots"
         ],
         "title": "BotListResponse",
-        "description": "봇 목록 응답."
+        "description": "\ubd07 \ubaa9\ub85d \uc751\ub2f5."
       },
       "BudgetItem": {
         "properties": {
@@ -6010,7 +6014,7 @@
           "bot_id"
         ],
         "title": "BudgetItem",
-        "description": "봇별 예산 아이템."
+        "description": "\ubd07\ubcc4 \uc608\uc0b0 \uc544\uc774\ud15c."
       },
       "BudgetListResponse": {
         "properties": {
@@ -6027,7 +6031,7 @@
           "budgets"
         ],
         "title": "BudgetListResponse",
-        "description": "예산 목록 응답."
+        "description": "\uc608\uc0b0 \ubaa9\ub85d \uc751\ub2f5."
       },
       "BudgetOperationResponse": {
         "properties": {
@@ -6051,7 +6055,7 @@
           "available"
         ],
         "title": "BudgetOperationResponse",
-        "description": "예산 할당/회수 응답."
+        "description": "\uc608\uc0b0 \ud560\ub2f9/\ud68c\uc218 \uc751\ub2f5."
       },
       "ConfigItem": {
         "properties": {
@@ -6079,7 +6083,7 @@
           "key"
         ],
         "title": "ConfigItem",
-        "description": "동적 설정 아이템."
+        "description": "\ub3d9\uc801 \uc124\uc815 \uc544\uc774\ud15c."
       },
       "ConfigListResponse": {
         "properties": {
@@ -6096,7 +6100,7 @@
           "configs"
         ],
         "title": "ConfigListResponse",
-        "description": "동적 설정 목록 응답."
+        "description": "\ub3d9\uc801 \uc124\uc815 \ubaa9\ub85d \uc751\ub2f5."
       },
       "ConfigUpdateResponse": {
         "properties": {
@@ -6116,7 +6120,7 @@
           "key"
         ],
         "title": "ConfigUpdateResponse",
-        "description": "설정 변경 응답."
+        "description": "\uc124\uc815 \ubcc0\uacbd \uc751\ub2f5."
       },
       "DailySummaryItem": {
         "properties": {
@@ -6145,7 +6149,7 @@
           "win_rate"
         ],
         "title": "DailySummaryItem",
-        "description": "일별 성과 집계 아이템."
+        "description": "\uc77c\ubcc4 \uc131\uacfc \uc9d1\uacc4 \uc544\uc774\ud15c."
       },
       "DailySummaryResponse": {
         "properties": {
@@ -6162,14 +6166,14 @@
           "items"
         ],
         "title": "DailySummaryResponse",
-        "description": "일별 성과 집계 응답."
+        "description": "\uc77c\ubcc4 \uc131\uacfc \uc9d1\uacc4 \uc751\ub2f5."
       },
       "DataSchemaResponse": {
         "properties": {},
         "additionalProperties": true,
         "type": "object",
         "title": "DataSchemaResponse",
-        "description": "데이터 스키마 응답 (동적 키-값)."
+        "description": "\ub370\uc774\ud130 \uc2a4\ud0a4\ub9c8 \uc751\ub2f5 (\ub3d9\uc801 \ud0a4-\uac12)."
       },
       "DatasetDetailResponse": {
         "properties": {
@@ -6191,7 +6195,7 @@
           "dataset"
         ],
         "title": "DatasetDetailResponse",
-        "description": "데이터셋 상세 응답 (메타데이터 + 미리보기)."
+        "description": "\ub370\uc774\ud130\uc14b \uc0c1\uc138 \uc751\ub2f5 (\uba54\ud0c0\ub370\uc774\ud130 + \ubbf8\ub9ac\ubcf4\uae30)."
       },
       "DatasetItem": {
         "properties": {
@@ -6252,7 +6256,7 @@
           "data_type"
         ],
         "title": "DatasetItem",
-        "description": "데이터셋 아이템."
+        "description": "\ub370\uc774\ud130\uc14b \uc544\uc774\ud15c."
       },
       "DatasetListResponse": {
         "properties": {
@@ -6274,7 +6278,7 @@
           "total"
         ],
         "title": "DatasetListResponse",
-        "description": "데이터셋 목록 응답."
+        "description": "\ub370\uc774\ud130\uc14b \ubaa9\ub85d \uc751\ub2f5."
       },
       "FeedStatusResponse": {
         "properties": {
@@ -6313,7 +6317,7 @@
         },
         "type": "object",
         "title": "FeedStatusResponse",
-        "description": "Feed 파이프라인 상태 응답."
+        "description": "Feed \ud30c\uc774\ud504\ub77c\uc778 \uc0c1\ud0dc \uc751\ub2f5."
       },
       "HTTPValidationError": {
         "properties": {
@@ -6348,7 +6352,7 @@
           "checks"
         ],
         "title": "HealthResponse",
-        "description": "헬스체크 응답.\n\n- `ok`: 모든 의존성 체크 통과 여부 (`all(checks.values())`).\n- `checks`: 개별 의존성 체크 결과. 1.0 기준 키는 `db`, `broker`.\n  키 확장은 하위 호환이므로 소비자는 존재하는 키만 확인한다.\n\n`ok`와 `checks` 모두 필수 필드 (OpenAPI `required`)."
+        "description": "\ud5ec\uc2a4\uccb4\ud06c \uc751\ub2f5.\n\n- `ok`: \ubaa8\ub4e0 \uc758\uc874\uc131 \uccb4\ud06c \ud1b5\uacfc \uc5ec\ubd80 (`all(checks.values())`).\n- `checks`: \uac1c\ubcc4 \uc758\uc874\uc131 \uccb4\ud06c \uacb0\uacfc. 1.0 \uae30\uc900 \ud0a4\ub294 `db`, `broker`.\n  \ud0a4 \ud655\uc7a5\uc740 \ud558\uc704 \ud638\ud658\uc774\ubbc0\ub85c \uc18c\ube44\uc790\ub294 \uc874\uc7ac\ud558\ub294 \ud0a4\ub9cc \ud655\uc778\ud55c\ub2e4.\n\n`ok`\uc640 `checks` \ubaa8\ub450 \ud544\uc218 \ud544\ub4dc (OpenAPI `required`)."
       },
       "KillSwitchAccountChange": {
         "properties": {
@@ -6377,7 +6381,7 @@
           "changed"
         ],
         "title": "KillSwitchAccountChange",
-        "description": "킬 스위치 처리 대상 계좌의 상태 전환 결과.\n\nSSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답 필드 표.\n필드는 정확히 ``account_id``, ``previous_status``, ``status``, ``changed`` 4개\n키만 사용한다 (``before_status`` / ``after_status`` 사용 금지)."
+        "description": "\ud0ac \uc2a4\uc704\uce58 \ucc98\ub9ac \ub300\uc0c1 \uacc4\uc88c\uc758 \uc0c1\ud0dc \uc804\ud658 \uacb0\uacfc.\n\nSSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch \uc751\ub2f5 \ud544\ub4dc \ud45c.\n\ud544\ub4dc\ub294 \uc815\ud655\ud788 ``account_id``, ``previous_status``, ``status``, ``changed`` 4\uac1c\n\ud0a4\ub9cc \uc0ac\uc6a9\ud55c\ub2e4 (``before_status`` / ``after_status`` \uc0ac\uc6a9 \uae08\uc9c0)."
       },
       "KillSwitchResponse": {
         "properties": {
@@ -6409,7 +6413,7 @@
           "changed_at"
         ],
         "title": "KillSwitchResponse",
-        "description": "킬 스위치 제어 응답.\n\nSSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch 응답.\n\n- ``POST /api/system/halt`` → ``status=\"halted\"``\n- ``POST /api/system/clear-halt`` → ``status=\"halt_cleared\"``"
+        "description": "\ud0ac \uc2a4\uc704\uce58 \uc81c\uc5b4 \uc751\ub2f5.\n\nSSOT: ``docs/specs/web-api/04-system-endpoints.md`` Kill Switch \uc751\ub2f5.\n\n- ``POST /api/system/halt`` \u2192 ``status=\"halted\"``\n- ``POST /api/system/clear-halt`` \u2192 ``status=\"halt_cleared\"``"
       },
       "LoginRequest": {
         "properties": {
@@ -6428,7 +6432,7 @@
           "password"
         ],
         "title": "LoginRequest",
-        "description": "로그인 요청."
+        "description": "\ub85c\uadf8\uc778 \uc694\uccad."
       },
       "LoginResponse": {
         "properties": {
@@ -6452,7 +6456,7 @@
           "type"
         ],
         "title": "LoginResponse",
-        "description": "로그인 성공 응답."
+        "description": "\ub85c\uadf8\uc778 \uc131\uacf5 \uc751\ub2f5."
       },
       "LogoutResponse": {
         "properties": {
@@ -6466,7 +6470,7 @@
           "ok"
         ],
         "title": "LogoutResponse",
-        "description": "로그아웃 응답."
+        "description": "\ub85c\uadf8\uc544\uc6c3 \uc751\ub2f5."
       },
       "MeResponse": {
         "properties": {
@@ -6505,7 +6509,7 @@
           "type"
         ],
         "title": "MeResponse",
-        "description": "현재 사용자 정보 응답."
+        "description": "\ud604\uc7ac \uc0ac\uc6a9\uc790 \uc815\ubcf4 \uc751\ub2f5."
       },
       "MemberCreateResponse": {
         "properties": {
@@ -6523,7 +6527,7 @@
           "token"
         ],
         "title": "MemberCreateResponse",
-        "description": "멤버 생성 응답 (토큰 포함)."
+        "description": "\uba64\ubc84 \uc0dd\uc131 \uc751\ub2f5 (\ud1a0\ud070 \ud3ec\ud568)."
       },
       "MemberDetailResponse": {
         "properties": {
@@ -6536,7 +6540,7 @@
           "member"
         ],
         "title": "MemberDetailResponse",
-        "description": "멤버 상세 응답."
+        "description": "\uba64\ubc84 \uc0c1\uc138 \uc751\ub2f5."
       },
       "MemberInfo": {
         "properties": {
@@ -6634,7 +6638,7 @@
           "role"
         ],
         "title": "MemberInfo",
-        "description": "멤버 정보."
+        "description": "\uba64\ubc84 \uc815\ubcf4."
       },
       "MemberListResponse": {
         "properties": {
@@ -6656,7 +6660,7 @@
           "total"
         ],
         "title": "MemberListResponse",
-        "description": "멤버 목록 응답."
+        "description": "\uba64\ubc84 \ubaa9\ub85d \uc751\ub2f5."
       },
       "MemberScopesResponse": {
         "properties": {
@@ -6669,7 +6673,7 @@
           "member"
         ],
         "title": "MemberScopesResponse",
-        "description": "권한 범위 변경 응답."
+        "description": "\uad8c\ud55c \ubc94\uc704 \ubcc0\uacbd \uc751\ub2f5."
       },
       "MemberStatus": {
         "type": "string",
@@ -6679,7 +6683,7 @@
           "revoked"
         ],
         "title": "MemberStatus",
-        "description": "멤버 상태."
+        "description": "\uba64\ubc84 \uc0c1\ud0dc."
       },
       "MemberTokenResponse": {
         "properties": {
@@ -6697,7 +6701,7 @@
           "token"
         ],
         "title": "MemberTokenResponse",
-        "description": "토큰 재발급 응답."
+        "description": "\ud1a0\ud070 \uc7ac\ubc1c\uae09 \uc751\ub2f5."
       },
       "MemberType": {
         "type": "string",
@@ -6706,7 +6710,7 @@
           "agent"
         ],
         "title": "MemberType",
-        "description": "멤버 타입."
+        "description": "\uba64\ubc84 \ud0c0\uc785."
       },
       "MonthlySummaryItem": {
         "properties": {
@@ -6740,7 +6744,7 @@
           "win_rate"
         ],
         "title": "MonthlySummaryItem",
-        "description": "월별 성과 집계 아이템."
+        "description": "\uc6d4\ubcc4 \uc131\uacfc \uc9d1\uacc4 \uc544\uc774\ud15c."
       },
       "MonthlySummaryResponse": {
         "properties": {
@@ -6757,7 +6761,7 @@
           "items"
         ],
         "title": "MonthlySummaryResponse",
-        "description": "월별 성과 집계 응답."
+        "description": "\uc6d4\ubcc4 \uc131\uacfc \uc9d1\uacc4 \uc751\ub2f5."
       },
       "OkResponse": {
         "properties": {
@@ -6771,7 +6775,7 @@
           "ok"
         ],
         "title": "OkResponse",
-        "description": "단순 성공 응답."
+        "description": "\ub2e8\uc21c \uc131\uacf5 \uc751\ub2f5."
       },
       "PortfolioHistoryPoint": {
         "properties": {
@@ -6805,7 +6809,7 @@
           "unrealized_pnl"
         ],
         "title": "PortfolioHistoryPoint",
-        "description": "자산 추이 데이터 포인트 (스냅샷 기반)."
+        "description": "\uc790\uc0b0 \ucd94\uc774 \ub370\uc774\ud130 \ud3ec\uc778\ud2b8 (\uc2a4\ub0c5\uc0f7 \uae30\ubc18)."
       },
       "PortfolioHistoryResponse": {
         "properties": {
@@ -6832,7 +6836,7 @@
           "end_date"
         ],
         "title": "PortfolioHistoryResponse",
-        "description": "기간별 자산 추이 응답."
+        "description": "\uae30\uac04\ubcc4 \uc790\uc0b0 \ucd94\uc774 \uc751\ub2f5."
       },
       "PortfolioValueResponse": {
         "properties": {
@@ -6877,7 +6881,7 @@
           "updated_at"
         ],
         "title": "PortfolioValueResponse",
-        "description": "총 자산 가치 응답 (스냅샷 기반)."
+        "description": "\ucd1d \uc790\uc0b0 \uac00\uce58 \uc751\ub2f5 (\uc2a4\ub0c5\uc0f7 \uae30\ubc18)."
       },
       "ReportDetailResponse": {
         "properties": {
@@ -7097,7 +7101,7 @@
           "submitted_at"
         ],
         "title": "ReportDetailResponse",
-        "description": "리포트 상세 응답."
+        "description": "\ub9ac\ud3ec\ud2b8 \uc0c1\uc138 \uc751\ub2f5."
       },
       "ReportListItem": {
         "properties": {
@@ -7126,7 +7130,7 @@
           "submitted_at"
         ],
         "title": "ReportListItem",
-        "description": "리포트 목록 아이템."
+        "description": "\ub9ac\ud3ec\ud2b8 \ubaa9\ub85d \uc544\uc774\ud15c."
       },
       "ReportListResponse": {
         "properties": {
@@ -7154,14 +7158,14 @@
           "reports"
         ],
         "title": "ReportListResponse",
-        "description": "리포트 목록 응답."
+        "description": "\ub9ac\ud3ec\ud2b8 \ubaa9\ub85d \uc751\ub2f5."
       },
       "ReportSchemaResponse": {
         "properties": {},
         "additionalProperties": true,
         "type": "object",
         "title": "ReportSchemaResponse",
-        "description": "리포트 스키마 응답."
+        "description": "\ub9ac\ud3ec\ud2b8 \uc2a4\ud0a4\ub9c8 \uc751\ub2f5."
       },
       "ReportStatus": {
         "type": "string",
@@ -7174,7 +7178,7 @@
           "archived"
         ],
         "title": "ReportStatus",
-        "description": "리포트 상태."
+        "description": "\ub9ac\ud3ec\ud2b8 \uc0c1\ud0dc."
       },
       "ReportSubmitResponse": {
         "properties": {
@@ -7198,7 +7202,7 @@
           "status"
         ],
         "title": "ReportSubmitResponse",
-        "description": "리포트 제출 응답."
+        "description": "\ub9ac\ud3ec\ud2b8 \uc81c\ucd9c \uc751\ub2f5."
       },
       "RuleItem": {
         "properties": {
@@ -7223,7 +7227,7 @@
           "type"
         ],
         "title": "RuleItem",
-        "description": "룰 설정 아이템."
+        "description": "\ub8f0 \uc124\uc815 \uc544\uc774\ud15c."
       },
       "RuleListResponse": {
         "properties": {
@@ -7245,7 +7249,7 @@
           "rules"
         ],
         "title": "RuleListResponse",
-        "description": "계좌 룰 목록 응답."
+        "description": "\uacc4\uc88c \ub8f0 \ubaa9\ub85d \uc751\ub2f5."
       },
       "RuleUpdateResponse": {
         "properties": {
@@ -7268,7 +7272,7 @@
           "rule"
         ],
         "title": "RuleUpdateResponse",
-        "description": "룰 설정 변경 응답."
+        "description": "\ub8f0 \uc124\uc815 \ubcc0\uacbd \uc751\ub2f5."
       },
       "SnapshotItem": {
         "properties": {
@@ -7348,7 +7352,7 @@
           "created_at"
         ],
         "title": "SnapshotItem",
-        "description": "일별 자산 스냅샷 아이템."
+        "description": "\uc77c\ubcc4 \uc790\uc0b0 \uc2a4\ub0c5\uc0f7 \uc544\uc774\ud15c."
       },
       "SnapshotListResponse": {
         "properties": {
@@ -7365,7 +7369,7 @@
           "snapshots"
         ],
         "title": "SnapshotListResponse",
-        "description": "스냅샷 목록 응답."
+        "description": "\uc2a4\ub0c5\uc0f7 \ubaa9\ub85d \uc751\ub2f5."
       },
       "SnapshotResponse": {
         "properties": {
@@ -7378,7 +7382,7 @@
           "snapshot"
         ],
         "title": "SnapshotResponse",
-        "description": "단일 스냅샷 응답."
+        "description": "\ub2e8\uc77c \uc2a4\ub0c5\uc0f7 \uc751\ub2f5."
       },
       "StatusResponse": {
         "properties": {
@@ -7430,7 +7434,7 @@
           "status"
         ],
         "title": "StatusResponse",
-        "description": "시스템 상태 응답."
+        "description": "\uc2dc\uc2a4\ud15c \uc0c1\ud0dc \uc751\ub2f5."
       },
       "StorageSummaryResponse": {
         "properties": {
@@ -7471,7 +7475,7 @@
           "by_timeframe"
         ],
         "title": "StorageSummaryResponse",
-        "description": "저장 용량 현황 응답."
+        "description": "\uc800\uc7a5 \uc6a9\ub7c9 \ud604\ud669 \uc751\ub2f5."
       },
       "StrategyDetailResponse": {
         "properties": {
@@ -7532,7 +7536,7 @@
           "strategy"
         ],
         "title": "StrategyDetailResponse",
-        "description": "전략 상세 응답."
+        "description": "\uc804\ub7b5 \uc0c1\uc138 \uc751\ub2f5."
       },
       "StrategyInfo": {
         "properties": {
@@ -7608,7 +7612,7 @@
           "version"
         ],
         "title": "StrategyInfo",
-        "description": "전략 상세 정보."
+        "description": "\uc804\ub7b5 \uc0c1\uc138 \uc815\ubcf4."
       },
       "StrategyListItem": {
         "properties": {
@@ -7680,7 +7684,7 @@
           "status"
         ],
         "title": "StrategyListItem",
-        "description": "전략 목록 아이템."
+        "description": "\uc804\ub7b5 \ubaa9\ub85d \uc544\uc774\ud15c."
       },
       "StrategyListResponse": {
         "properties": {
@@ -7697,7 +7701,7 @@
           "strategies"
         ],
         "title": "StrategyListResponse",
-        "description": "전략 목록 응답."
+        "description": "\uc804\ub7b5 \ubaa9\ub85d \uc751\ub2f5."
       },
       "StrategyPerformanceResponse": {
         "properties": {
@@ -7759,7 +7763,7 @@
         "additionalProperties": true,
         "type": "object",
         "title": "StrategyPerformanceResponse",
-        "description": "전략 성과 지표 응답."
+        "description": "\uc804\ub7b5 \uc131\uacfc \uc9c0\ud45c \uc751\ub2f5."
       },
       "StrategyTradeItem": {
         "properties": {
@@ -7808,7 +7812,7 @@
           "timestamp"
         ],
         "title": "StrategyTradeItem",
-        "description": "전략 거래 아이템."
+        "description": "\uc804\ub7b5 \uac70\ub798 \uc544\uc774\ud15c."
       },
       "StrategyTradesResponse": {
         "properties": {
@@ -7836,7 +7840,7 @@
           "trades"
         ],
         "title": "StrategyTradesResponse",
-        "description": "전략 거래 내역 응답."
+        "description": "\uc804\ub7b5 \uac70\ub798 \ub0b4\uc5ed \uc751\ub2f5."
       },
       "StrategyValidateResponse": {
         "properties": {
@@ -7866,7 +7870,7 @@
           "valid"
         ],
         "title": "StrategyValidateResponse",
-        "description": "전략 검증 응답."
+        "description": "\uc804\ub7b5 \uac80\uc99d \uc751\ub2f5."
       },
       "TradeItem": {
         "properties": {
@@ -7926,7 +7930,7 @@
           "status"
         ],
         "title": "TradeItem",
-        "description": "거래 기록 아이템 (read 응답).\n\nwrite 경로(``TradeRecord``)에서 account_id가 검증되므로 read 응답\nschema에는 default를 유지한다."
+        "description": "\uac70\ub798 \uae30\ub85d \uc544\uc774\ud15c (read \uc751\ub2f5).\n\nwrite \uacbd\ub85c(``TradeRecord``)\uc5d0\uc11c account_id\uac00 \uac80\uc99d\ub418\ubbc0\ub85c read \uc751\ub2f5\nschema\uc5d0\ub294 default\ub97c \uc720\uc9c0\ud55c\ub2e4."
       },
       "TradeListResponse": {
         "properties": {
@@ -7954,7 +7958,7 @@
           "trades"
         ],
         "title": "TradeListResponse",
-        "description": "거래 기록 목록 응답."
+        "description": "\uac70\ub798 \uae30\ub85d \ubaa9\ub85d \uc751\ub2f5."
       },
       "TransactionItem": {
         "properties": {
@@ -7999,7 +8003,7 @@
           "created_at"
         ],
         "title": "TransactionItem",
-        "description": "자금 변동 이력 아이템."
+        "description": "\uc790\uae08 \ubcc0\ub3d9 \uc774\ub825 \uc544\uc774\ud15c."
       },
       "TransactionListResponse": {
         "properties": {
@@ -8021,7 +8025,7 @@
           "total"
         ],
         "title": "TransactionListResponse",
-        "description": "자금 변동 이력 응답."
+        "description": "\uc790\uae08 \ubcc0\ub3d9 \uc774\ub825 \uc751\ub2f5."
       },
       "TreasurySummaryResponse": {
         "properties": {
@@ -8141,7 +8145,7 @@
         "additionalProperties": true,
         "type": "object",
         "title": "TreasurySummaryResponse",
-        "description": "자금 현황 요약 응답."
+        "description": "\uc790\uae08 \ud604\ud669 \uc694\uc57d \uc751\ub2f5."
       },
       "ValidationError": {
         "properties": {
@@ -8220,7 +8224,7 @@
           "win_rate"
         ],
         "title": "WeeklySummaryItem",
-        "description": "주별 성과 집계 아이템."
+        "description": "\uc8fc\ubcc4 \uc131\uacfc \uc9d1\uacc4 \uc544\uc774\ud15c."
       },
       "WeeklySummaryResponse": {
         "properties": {
@@ -8237,10 +8241,10 @@
           "items"
         ],
         "title": "WeeklySummaryResponse",
-        "description": "주별 성과 집계 응답."
+        "description": "\uc8fc\ubcc4 \uc131\uacfc \uc9d1\uacc4 \uc751\ub2f5."
       },
       "ErrorResponse": {
-        "description": "RFC 7807 Problem Details 에러 응답.",
+        "description": "RFC 7807 Problem Details \uc5d0\ub7ec \uc751\ub2f5.",
         "properties": {
           "type": {
             "default": "/errors/internal",
@@ -8274,7 +8278,7 @@
       "MemberCreateRequest": {
         "type": "object",
         "title": "MemberCreateRequest",
-        "description": "POST /api/members 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1339). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.",
+        "description": "POST /api/members \uc785\ub825 contract. \uc778\uc99d\ub41c master \ud638\ucd9c\uc790\ub9cc \uc0ac\uc6a9\ud560 \uc218 \uc788\ub2e4(#1339). Bearer \ud1a0\ud070 \ub610\ub294 \uc720\ud6a8\ud55c ante_session \ucfe0\ud0a4 \uc911 \ud558\ub098\ub77c\ub3c4 \uc788\uc5b4\uc57c \ud558\uba70, \ub458 \ub2e4 \uc5c6\uac70\ub098 \ub458 \ub2e4 invalid\uba74 body validation \uc804\uc5d0 401\ub85c \ucc28\ub2e8\ub41c\ub2e4.",
         "additionalProperties": false,
         "required": [
           "member_id",
@@ -8283,7 +8287,7 @@
         "properties": {
           "member_id": {
             "type": "string",
-            "description": "고유 식별자."
+            "description": "\uace0\uc720 \uc2dd\ubcc4\uc790."
           },
           "member_type": {
             "type": "string",
@@ -8291,22 +8295,22 @@
               "human",
               "agent"
             ],
-            "description": "멤버 타입."
+            "description": "\uba64\ubc84 \ud0c0\uc785."
           },
           "role": {
             "type": "string",
             "default": "default",
-            "description": "역할 (default / master)."
+            "description": "\uc5ed\ud560 (default / master)."
           },
           "org": {
             "type": "string",
             "default": "default",
-            "description": "소속 조직."
+            "description": "\uc18c\uc18d \uc870\uc9c1."
           },
           "name": {
             "type": "string",
             "default": "",
-            "description": "사용자에게 표시되는 이름."
+            "description": "\uc0ac\uc6a9\uc790\uc5d0\uac8c \ud45c\uc2dc\ub418\ub294 \uc774\ub984."
           },
           "scopes": {
             "type": "array",
@@ -8314,14 +8318,14 @@
               "type": "string"
             },
             "default": [],
-            "description": "권한 범위 목록."
+            "description": "\uad8c\ud55c \ubc94\uc704 \ubaa9\ub85d."
           }
         }
       },
       "ScopesUpdateRequest": {
         "type": "object",
         "title": "ScopesUpdateRequest",
-        "description": "PUT /api/members/{member_id}/scopes 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1351). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.",
+        "description": "PUT /api/members/{member_id}/scopes \uc785\ub825 contract. \uc778\uc99d\ub41c master \ud638\ucd9c\uc790\ub9cc \uc0ac\uc6a9\ud560 \uc218 \uc788\ub2e4(#1351). Bearer \ud1a0\ud070 \ub610\ub294 \uc720\ud6a8\ud55c ante_session \ucfe0\ud0a4 \uc911 \ud558\ub098\ub77c\ub3c4 \uc788\uc5b4\uc57c \ud558\uba70, \ub458 \ub2e4 \uc5c6\uac70\ub098 \ub458 \ub2e4 invalid\uba74 body validation \uc804\uc5d0 401\ub85c \ucc28\ub2e8\ub41c\ub2e4.",
         "additionalProperties": false,
         "required": [
           "scopes"
@@ -8332,14 +8336,14 @@
             "items": {
               "type": "string"
             },
-            "description": "변경할 권한 범위 목록."
+            "description": "\ubcc0\uacbd\ud560 \uad8c\ud55c \ubc94\uc704 \ubaa9\ub85d."
           }
         }
       },
       "BotCreateRequest": {
         "type": "object",
         "title": "BotCreateRequest",
-        "description": "POST /api/bots 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1371). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다. Pydantic ``extra='forbid'`` (#1436) — 정의되지 않은 필드(예: legacy ``bot_type``)는 422로 거부된다. strategy_id 또는 strategy_name 중 하나를 필수로 전달해야 하며 (model_validator로 강제, #1436), 둘 다 전달 시 strategy_id를 우선 사용한다. OpenAPI ``anyOf`` 로 strategy 식별자 필수 조건을 명시하여 generated TS/SDK 가 ``{bot_id: ...}`` 만 담긴 payload 를 valid 로 인식하지 못하도록 한다 (codex r1 FAIL). anyOf branches 는 ``type``/``properties`` 까지 명시하여 openapi-typescript 가 ``unknown`` 으로 붕괴되지 않고 ``{strategy_id: string} | {strategy_name: string}`` 으로 narrow 되도록 한다 (codex r2 FAIL).",
+        "description": "POST /api/bots \uc785\ub825 contract. \uc778\uc99d\ub41c master \ud638\ucd9c\uc790\ub9cc \uc0ac\uc6a9\ud560 \uc218 \uc788\ub2e4(#1371). Bearer \ud1a0\ud070 \ub610\ub294 \uc720\ud6a8\ud55c ante_session \ucfe0\ud0a4 \uc911 \ud558\ub098\ub77c\ub3c4 \uc788\uc5b4\uc57c \ud558\uba70, \ub458 \ub2e4 \uc5c6\uac70\ub098 \ub458 \ub2e4 invalid\uba74 body validation \uc804\uc5d0 401\ub85c \ucc28\ub2e8\ub41c\ub2e4. Pydantic ``extra='forbid'`` (#1436) \u2014 \uc815\uc758\ub418\uc9c0 \uc54a\uc740 \ud544\ub4dc(\uc608: legacy ``bot_type``)\ub294 422\ub85c \uac70\ubd80\ub41c\ub2e4. strategy_id \ub610\ub294 strategy_name \uc911 \ud558\ub098\ub97c \ud544\uc218\ub85c \uc804\ub2ec\ud574\uc57c \ud558\uba70 (model_validator\ub85c \uac15\uc81c, #1436), \ub458 \ub2e4 \uc804\ub2ec \uc2dc strategy_id\ub97c \uc6b0\uc120 \uc0ac\uc6a9\ud55c\ub2e4. OpenAPI ``anyOf`` \ub85c strategy \uc2dd\ubcc4\uc790 \ud544\uc218 \uc870\uac74\uc744 \uba85\uc2dc\ud558\uc5ec generated TS/SDK \uac00 ``{bot_id: ...}`` \ub9cc \ub2f4\uae34 payload \ub97c valid \ub85c \uc778\uc2dd\ud558\uc9c0 \ubabb\ud558\ub3c4\ub85d \ud55c\ub2e4 (codex r1 FAIL). anyOf branches \ub294 ``type``/``properties`` \uae4c\uc9c0 \uba85\uc2dc\ud558\uc5ec openapi-typescript \uac00 ``unknown`` \uc73c\ub85c \ubd95\uad34\ub418\uc9c0 \uc54a\uace0 ``{strategy_id: string} | {strategy_name: string}`` \uc73c\ub85c narrow \ub418\ub3c4\ub85d \ud55c\ub2e4 (codex r2 FAIL).",
         "additionalProperties": false,
         "required": [
           "bot_id"
@@ -8371,40 +8375,40 @@
         "properties": {
           "bot_id": {
             "type": "string",
-            "description": "생성할 봇의 식별자."
+            "description": "\uc0dd\uc131\ud560 \ubd07\uc758 \uc2dd\ubcc4\uc790."
           },
           "strategy_id": {
             "type": [
               "string",
               "null"
             ],
-            "description": "전략 ID. ``strategy_name``과 둘 중 하나는 반드시 전달해야 한다."
+            "description": "\uc804\ub7b5 ID. ``strategy_name``\uacfc \ub458 \uc911 \ud558\ub098\ub294 \ubc18\ub4dc\uc2dc \uc804\ub2ec\ud574\uc57c \ud55c\ub2e4."
           },
           "strategy_name": {
             "type": [
               "string",
               "null"
             ],
-            "description": "전략 이름. 최신 버전의 strategy_id로 자동 변환된다. ``strategy_id``와 둘 중 하나는 반드시 전달해야 한다."
+            "description": "\uc804\ub7b5 \uc774\ub984. \ucd5c\uc2e0 \ubc84\uc804\uc758 strategy_id\ub85c \uc790\ub3d9 \ubcc0\ud658\ub41c\ub2e4. ``strategy_id``\uc640 \ub458 \uc911 \ud558\ub098\ub294 \ubc18\ub4dc\uc2dc \uc804\ub2ec\ud574\uc57c \ud55c\ub2e4."
           },
           "name": {
             "type": "string",
             "default": "",
-            "description": "사용자에게 표시되는 봇 이름. 비우면 bot_id를 사용한다."
+            "description": "\uc0ac\uc6a9\uc790\uc5d0\uac8c \ud45c\uc2dc\ub418\ub294 \ubd07 \uc774\ub984. \ube44\uc6b0\uba74 bot_id\ub97c \uc0ac\uc6a9\ud55c\ub2e4."
           },
           "account_id": {
             "type": [
               "string",
               "null"
             ],
-            "description": "사용할 계좌 ID. 미지정 시 단일 active 계좌가 자동 선택된다."
+            "description": "\uc0ac\uc6a9\ud560 \uacc4\uc88c ID. \ubbf8\uc9c0\uc815 \uc2dc \ub2e8\uc77c active \uacc4\uc88c\uac00 \uc790\ub3d9 \uc120\ud0dd\ub41c\ub2e4."
           },
           "interval_seconds": {
             "type": "integer",
             "minimum": 10,
             "maximum": 3600,
             "default": 60,
-            "description": "봇 step 주기 (초)."
+            "description": "\ubd07 step \uc8fc\uae30 (\ucd08)."
           },
           "budget": {
             "type": [
@@ -8412,14 +8416,14 @@
               "null"
             ],
             "exclusiveMinimum": 0,
-            "description": "예산 할당액 (원). 양수 finite number만 허용 (Infinity/NaN은 422로 거부, #1435)."
+            "description": "\uc608\uc0b0 \ud560\ub2f9\uc561 (\uc6d0). \uc591\uc218 finite number\ub9cc \ud5c8\uc6a9 (Infinity/NaN\uc740 422\ub85c \uac70\ubd80, #1435)."
           }
         }
       },
       "BotUpdateRequest": {
         "type": "object",
         "title": "BotUpdateRequest",
-        "description": "PUT /api/bots/{bot_id} 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1352). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다. None/null인 필드는 변경하지 않는다.",
+        "description": "PUT /api/bots/{bot_id} \uc785\ub825 contract. \uc778\uc99d\ub41c master \ud638\ucd9c\uc790\ub9cc \uc0ac\uc6a9\ud560 \uc218 \uc788\ub2e4(#1352). Bearer \ud1a0\ud070 \ub610\ub294 \uc720\ud6a8\ud55c ante_session \ucfe0\ud0a4 \uc911 \ud558\ub098\ub77c\ub3c4 \uc788\uc5b4\uc57c \ud558\uba70, \ub458 \ub2e4 \uc5c6\uac70\ub098 \ub458 \ub2e4 invalid\uba74 body validation \uc804\uc5d0 401\ub85c \ucc28\ub2e8\ub41c\ub2e4. None/null\uc778 \ud544\ub4dc\ub294 \ubcc0\uacbd\ud558\uc9c0 \uc54a\ub294\ub2e4.",
         "additionalProperties": false,
         "properties": {
           "name": {
@@ -8427,14 +8431,14 @@
               "string",
               "null"
             ],
-            "description": "사용자에게 표시되는 봇 이름."
+            "description": "\uc0ac\uc6a9\uc790\uc5d0\uac8c \ud45c\uc2dc\ub418\ub294 \ubd07 \uc774\ub984."
           },
           "strategy_name": {
             "type": [
               "string",
               "null"
             ],
-            "description": "변경할 전략 이름. 최신 버전의 strategy_id로 자동 변환된다."
+            "description": "\ubcc0\uacbd\ud560 \uc804\ub7b5 \uc774\ub984. \ucd5c\uc2e0 \ubc84\uc804\uc758 strategy_id\ub85c \uc790\ub3d9 \ubcc0\ud658\ub41c\ub2e4."
           },
           "interval_seconds": {
             "type": [
@@ -8443,7 +8447,7 @@
             ],
             "minimum": 10,
             "maximum": 3600,
-            "description": "봇 step 주기 (초)."
+            "description": "\ubd07 step \uc8fc\uae30 (\ucd08)."
           },
           "budget": {
             "type": [
@@ -8451,49 +8455,49 @@
               "null"
             ],
             "exclusiveMinimum": 0,
-            "description": "예산 할당액 (원). 양수 finite number만 허용 (Infinity/NaN은 422로 거부, #1435)."
+            "description": "\uc608\uc0b0 \ud560\ub2f9\uc561 (\uc6d0). \uc591\uc218 finite number\ub9cc \ud5c8\uc6a9 (Infinity/NaN\uc740 422\ub85c \uac70\ubd80, #1435)."
           },
           "auto_restart": {
             "type": [
               "boolean",
               "null"
             ],
-            "description": "봇 자동 재시작 여부."
+            "description": "\ubd07 \uc790\ub3d9 \uc7ac\uc2dc\uc791 \uc5ec\ubd80."
           },
           "max_restart_attempts": {
             "type": [
               "integer",
               "null"
             ],
-            "description": "재시작 최대 시도 횟수."
+            "description": "\uc7ac\uc2dc\uc791 \ucd5c\ub300 \uc2dc\ub3c4 \ud69f\uc218."
           },
           "restart_cooldown_seconds": {
             "type": [
               "integer",
               "null"
             ],
-            "description": "재시작 쿨다운(초)."
+            "description": "\uc7ac\uc2dc\uc791 \ucfe8\ub2e4\uc6b4(\ucd08)."
           },
           "step_timeout_seconds": {
             "type": [
               "integer",
               "null"
             ],
-            "description": "step 타임아웃(초)."
+            "description": "step \ud0c0\uc784\uc544\uc6c3(\ucd08)."
           },
           "max_signals_per_step": {
             "type": [
               "integer",
               "null"
             ],
-            "description": "step당 최대 signal 수."
+            "description": "step\ub2f9 \ucd5c\ub300 signal \uc218."
           }
         }
       },
       "BalanceSetRequest": {
         "type": "object",
         "title": "BalanceSetRequest",
-        "description": "POST /api/treasury/balance 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1352). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.",
+        "description": "POST /api/treasury/balance \uc785\ub825 contract. \uc778\uc99d\ub41c master \ud638\ucd9c\uc790\ub9cc \uc0ac\uc6a9\ud560 \uc218 \uc788\ub2e4(#1352). Bearer \ud1a0\ud070 \ub610\ub294 \uc720\ud6a8\ud55c ante_session \ucfe0\ud0a4 \uc911 \ud558\ub098\ub77c\ub3c4 \uc788\uc5b4\uc57c \ud558\uba70, \ub458 \ub2e4 \uc5c6\uac70\ub098 \ub458 \ub2e4 invalid\uba74 body validation \uc804\uc5d0 401\ub85c \ucc28\ub2e8\ub41c\ub2e4.",
         "additionalProperties": false,
         "required": [
           "balance"
@@ -8502,14 +8506,14 @@
           "balance": {
             "type": "number",
             "minimum": 0,
-            "description": "수동 설정할 계좌 총 잔고 (음수 불가, NaN/Inf 불가)."
+            "description": "\uc218\ub3d9 \uc124\uc815\ud560 \uacc4\uc88c \ucd1d \uc794\uace0 (\uc74c\uc218 \ubd88\uac00, NaN/Inf \ubd88\uac00)."
           }
         }
       },
       "BudgetChangeRequest": {
         "type": "object",
         "title": "BudgetChangeRequest",
-        "description": "POST /api/treasury/bots/{bot_id}/allocate, POST /api/treasury/bots/{bot_id}/deallocate 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1372). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.",
+        "description": "POST /api/treasury/bots/{bot_id}/allocate, POST /api/treasury/bots/{bot_id}/deallocate \uc785\ub825 contract. \uc778\uc99d\ub41c master \ud638\ucd9c\uc790\ub9cc \uc0ac\uc6a9\ud560 \uc218 \uc788\ub2e4(#1372). Bearer \ud1a0\ud070 \ub610\ub294 \uc720\ud6a8\ud55c ante_session \ucfe0\ud0a4 \uc911 \ud558\ub098\ub77c\ub3c4 \uc788\uc5b4\uc57c \ud558\uba70, \ub458 \ub2e4 \uc5c6\uac70\ub098 \ub458 \ub2e4 invalid\uba74 body validation \uc804\uc5d0 401\ub85c \ucc28\ub2e8\ub41c\ub2e4.",
         "required": [
           "amount"
         ],
@@ -8517,44 +8521,44 @@
           "amount": {
             "type": "number",
             "exclusiveMinimum": 0,
-            "description": "할당/회수 금액 (원). finite한 양수(> 0)만 허용된다. NaN, Infinity, -Infinity, 0, 음수는 422로 거부된다(#1411)."
+            "description": "\ud560\ub2f9/\ud68c\uc218 \uae08\uc561 (\uc6d0). finite\ud55c \uc591\uc218(> 0)\ub9cc \ud5c8\uc6a9\ub41c\ub2e4. NaN, Infinity, -Infinity, 0, \uc74c\uc218\ub294 422\ub85c \uac70\ubd80\ub41c\ub2e4(#1411)."
           }
         }
       },
       "AccountSuspendRequest": {
         "type": "object",
         "title": "AccountSuspendRequest",
-        "description": "POST /api/accounts/{account_id}/suspend 입력 contract. 인증된 master/human 또는 account:write scope 를 보유한 agent 만 사용할 수 있다(#1407, #1352 master_caller migration). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다. 빈 body도 허용되며 reason은 default 'dashboard'로 채워진다.",
+        "description": "POST /api/accounts/{account_id}/suspend \uc785\ub825 contract. \uc778\uc99d\ub41c master/human \ub610\ub294 account:write scope \ub97c \ubcf4\uc720\ud55c agent \ub9cc \uc0ac\uc6a9\ud560 \uc218 \uc788\ub2e4(#1407, #1352 master_caller migration). Bearer \ud1a0\ud070 \ub610\ub294 \uc720\ud6a8\ud55c ante_session \ucfe0\ud0a4 \uc911 \ud558\ub098\ub77c\ub3c4 \uc788\uc5b4\uc57c \ud558\uba70, \ub458 \ub2e4 \uc5c6\uac70\ub098 \ub458 \ub2e4 invalid\uba74 body validation \uc804\uc5d0 401\ub85c \ucc28\ub2e8\ub41c\ub2e4. \ube48 body\ub3c4 \ud5c8\uc6a9\ub418\uba70 reason\uc740 default 'dashboard'\ub85c \ucc44\uc6cc\uc9c4\ub2e4.",
         "additionalProperties": false,
         "properties": {
           "reason": {
             "type": "string",
             "default": "",
-            "description": "정지 사유. 빈 문자열 또는 omit 시 server-side default 'dashboard'로 기록된다."
+            "description": "\uc815\uc9c0 \uc0ac\uc720. \ube48 \ubb38\uc790\uc5f4 \ub610\ub294 omit \uc2dc server-side default 'dashboard'\ub85c \uae30\ub85d\ub41c\ub2e4."
           }
         }
       },
       "ConfigUpdateRequest": {
         "type": "object",
         "title": "ConfigUpdateRequest",
-        "description": "PUT /api/config/{key} 입력 contract. 인증된 master/human 또는 config:write scope 를 보유한 agent 만 사용할 수 있다(#1373). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.",
+        "description": "PUT /api/config/{key} \uc785\ub825 contract. \uc778\uc99d\ub41c master/human \ub610\ub294 config:write scope \ub97c \ubcf4\uc720\ud55c agent \ub9cc \uc0ac\uc6a9\ud560 \uc218 \uc788\ub2e4(#1373). Bearer \ud1a0\ud070 \ub610\ub294 \uc720\ud6a8\ud55c ante_session \ucfe0\ud0a4 \uc911 \ud558\ub098\ub77c\ub3c4 \uc788\uc5b4\uc57c \ud558\uba70, \ub458 \ub2e4 \uc5c6\uac70\ub098 \ub458 \ub2e4 invalid\uba74 body validation \uc804\uc5d0 401\ub85c \ucc28\ub2e8\ub41c\ub2e4.",
         "required": [
           "value"
         ],
         "properties": {
           "value": {
-            "description": "변경할 설정 값. 타입은 키마다 다르다 — DynamicConfigService 가 키별 schema 검증을 담당한다."
+            "description": "\ubcc0\uacbd\ud560 \uc124\uc815 \uac12. \ud0c0\uc785\uc740 \ud0a4\ub9c8\ub2e4 \ub2e4\ub974\ub2e4 \u2014 DynamicConfigService \uac00 \ud0a4\ubcc4 schema \uac80\uc99d\uc744 \ub2f4\ub2f9\ud55c\ub2e4."
           },
           "category": {
             "type": "string",
             "default": "",
-            "description": "설정 카테고리. 비우면 key 의 dot-prefix(예: ``risk.max_mdd`` → ``risk``)에서 자동 추출된다."
+            "description": "\uc124\uc815 \uce74\ud14c\uace0\ub9ac. \ube44\uc6b0\uba74 key \uc758 dot-prefix(\uc608: ``risk.max_mdd`` \u2192 ``risk``)\uc5d0\uc11c \uc790\ub3d9 \ucd94\ucd9c\ub41c\ub2e4."
           }
         }
       },
       "ReportSubmitRequest": {
         "additionalProperties": false,
-        "description": "리포트 제출 요청.\n\nSSOT: ``docs/specs/report-store/report-store.md`` 리포트 제출 스키마.\n``win_rate``는 percent 단위 (0.0~100.0, ``\"win_rate\": 58.0`` 예시)다.\n\ninvariants (#1353):\n- ``total_trades >= 0`` (거래 수는 음수 불가).\n- ``win_rate``는 ``[0.0, 100.0]`` percent 단위 또는 ``None``.\n- ``total_return_pct``/``sharpe_ratio``/``max_drawdown_pct``/``win_rate``는\n  finite. NaN/Inf는 후속 분석/표시에서 버그 또는 잘못된 결정으로 이어지므로\n  submit 단에서 422로 거부한다.\n- 미지정 키는 ``extra='forbid'``로 거부 — agent의 오타/잘못된 키가 store에\n  유실되는 대신 빠르게 fail하도록 한다.\n\nNote: 단위 통일(percent ↔ ratio)은 detail_json·backtest_runs·CLI submit 등\n시스템 전반의 영향이 커서 본 PR에서는 input validation에만 집중하고,\nratio 통일은 별도 follow-up 이슈에서 다룬다.",
+        "description": "\ub9ac\ud3ec\ud2b8 \uc81c\ucd9c \uc694\uccad.\n\nSSOT: ``docs/specs/report-store/report-store.md`` \ub9ac\ud3ec\ud2b8 \uc81c\ucd9c \uc2a4\ud0a4\ub9c8.\n``win_rate``\ub294 percent \ub2e8\uc704 (0.0~100.0, ``\"win_rate\": 58.0`` \uc608\uc2dc)\ub2e4.\n\ninvariants (#1353):\n- ``total_trades >= 0`` (\uac70\ub798 \uc218\ub294 \uc74c\uc218 \ubd88\uac00).\n- ``win_rate``\ub294 ``[0.0, 100.0]`` percent \ub2e8\uc704 \ub610\ub294 ``None``.\n- ``total_return_pct``/``sharpe_ratio``/``max_drawdown_pct``/``win_rate``\ub294\n  finite. NaN/Inf\ub294 \ud6c4\uc18d \ubd84\uc11d/\ud45c\uc2dc\uc5d0\uc11c \ubc84\uadf8 \ub610\ub294 \uc798\ubabb\ub41c \uacb0\uc815\uc73c\ub85c \uc774\uc5b4\uc9c0\ubbc0\ub85c\n  submit \ub2e8\uc5d0\uc11c 422\ub85c \uac70\ubd80\ud55c\ub2e4.\n- \ubbf8\uc9c0\uc815 \ud0a4\ub294 ``extra='forbid'``\ub85c \uac70\ubd80 \u2014 agent\uc758 \uc624\ud0c0/\uc798\ubabb\ub41c \ud0a4\uac00 store\uc5d0\n  \uc720\uc2e4\ub418\ub294 \ub300\uc2e0 \ube60\ub974\uac8c fail\ud558\ub3c4\ub85d \ud55c\ub2e4.\n\nNote: \ub2e8\uc704 \ud1b5\uc77c(percent \u2194 ratio)\uc740 detail_json\u00b7backtest_runs\u00b7CLI submit \ub4f1\n\uc2dc\uc2a4\ud15c \uc804\ubc18\uc758 \uc601\ud5a5\uc774 \ucee4\uc11c \ubcf8 PR\uc5d0\uc11c\ub294 input validation\uc5d0\ub9cc \uc9d1\uc911\ud558\uace0,\nratio \ud1b5\uc77c\uc740 \ubcc4\ub3c4 follow-up \uc774\uc288\uc5d0\uc11c \ub2e4\ub8ec\ub2e4.",
         "properties": {
           "strategy_name": {
             "title": "Strategy Name",
@@ -8666,7 +8670,7 @@
         "type": "object"
       },
       "HaltRequest": {
-        "description": "거래 중지 요청.",
+        "description": "\uac70\ub798 \uc911\uc9c0 \uc694\uccad.",
         "properties": {
           "reason": {
             "default": "",
@@ -8678,7 +8682,7 @@
         "type": "object"
       },
       "ClearHaltRequest": {
-        "description": "전역 정지 해제 요청.",
+        "description": "\uc804\uc5ed \uc815\uc9c0 \ud574\uc81c \uc694\uccad.",
         "properties": {
           "reason": {
             "default": "",
@@ -8690,7 +8694,7 @@
         "type": "object"
       },
       "RuleUpdateRequest": {
-        "description": "룰 설정 변경 요청.\n\n``params`` 는 룰별 schema 를 갖는 open object 지만, 모든 numeric threshold\n는 finite 여야 한다 (#1380 oracle A7). ``json.loads`` default 는 ``NaN`` /\n``Infinity`` / ``-Infinity`` 를 ``float('nan')`` / ``float('inf')`` 로\n파싱하므로, raw body parser 가 통과시킨 값을 본 모델 단에서 422 로 거부한다.\nbool 은 numeric 흉내 방지를 위해 ``_reject_non_finite`` 가 통과시키되,\nRULE_REGISTRY ``validate_config`` 가 known numeric key 에 대해 별도로\n거부한다.",
+        "description": "\ub8f0 \uc124\uc815 \ubcc0\uacbd \uc694\uccad.\n\n``params`` \ub294 \ub8f0\ubcc4 schema \ub97c \uac16\ub294 open object \uc9c0\ub9cc, \ubaa8\ub4e0 numeric threshold\n\ub294 finite \uc5ec\uc57c \ud55c\ub2e4 (#1380 oracle A7). ``json.loads`` default \ub294 ``NaN`` /\n``Infinity`` / ``-Infinity`` \ub97c ``float('nan')`` / ``float('inf')`` \ub85c\n\ud30c\uc2f1\ud558\ubbc0\ub85c, raw body parser \uac00 \ud1b5\uacfc\uc2dc\ud0a8 \uac12\uc744 \ubcf8 \ubaa8\ub378 \ub2e8\uc5d0\uc11c 422 \ub85c \uac70\ubd80\ud55c\ub2e4.\nbool \uc740 numeric \ud749\ub0b4 \ubc29\uc9c0\ub97c \uc704\ud574 ``_reject_non_finite`` \uac00 \ud1b5\uacfc\uc2dc\ud0a4\ub418,\nRULE_REGISTRY ``validate_config`` \uac00 known numeric key \uc5d0 \ub300\ud574 \ubcc4\ub3c4\ub85c\n\uac70\ubd80\ud55c\ub2e4.",
         "properties": {
           "enabled": {
             "default": true,
@@ -8709,7 +8713,7 @@
       },
       "PasswordChangeRequest": {
         "additionalProperties": false,
-        "description": "PATCH /api/members/{member_id}/password 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1377). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.",
+        "description": "PATCH /api/members/{member_id}/password \uc785\ub825 contract. \uc778\uc99d\ub41c master \ud638\ucd9c\uc790\ub9cc \uc0ac\uc6a9\ud560 \uc218 \uc788\ub2e4(#1377). Bearer \ud1a0\ud070 \ub610\ub294 \uc720\ud6a8\ud55c ante_session \ucfe0\ud0a4 \uc911 \ud558\ub098\ub77c\ub3c4 \uc788\uc5b4\uc57c \ud558\uba70, \ub458 \ub2e4 \uc5c6\uac70\ub098 \ub458 \ub2e4 invalid\uba74 body validation \uc804\uc5d0 401\ub85c \ucc28\ub2e8\ub41c\ub2e4.",
         "properties": {
           "old_password": {
             "title": "Old Password",
@@ -8728,7 +8732,7 @@
         "type": "object"
       },
       "StatusUpdateRequest": {
-        "description": "전략 상태 변경 요청.",
+        "description": "\uc804\ub7b5 \uc0c1\ud0dc \ubcc0\uacbd \uc694\uccad.",
         "properties": {
           "status": {
             "title": "Status",
@@ -8742,7 +8746,7 @@
         "type": "object"
       },
       "StrategyValidateRequest": {
-        "description": "전략 검증 요청.\n\nSSOT: ``docs/specs/web-api/05-resource-endpoints.md`` POST\n``/api/strategies/validate`` body ``{\"path\": \"...\"}``. ``path`` 타입이\nstring 이 아니면 Pydantic 이 422 로 거부한다 (#1410 — non-string\n``path`` 입력에서 ``Path(filepath)`` TypeError 로 500 이 반환되던 회귀를\nruntime validation 으로 차단).",
+        "description": "\uc804\ub7b5 \uac80\uc99d \uc694\uccad.\n\nSSOT: ``docs/specs/web-api/05-resource-endpoints.md`` POST\n``/api/strategies/validate`` body ``{\"path\": \"...\"}``. ``path`` \ud0c0\uc785\uc774\nstring \uc774 \uc544\ub2c8\uba74 Pydantic \uc774 422 \ub85c \uac70\ubd80\ud55c\ub2e4 (#1410 \u2014 non-string\n``path`` \uc785\ub825\uc5d0\uc11c ``Path(filepath)`` TypeError \ub85c 500 \uc774 \ubc18\ud658\ub418\ub358 \ud68c\uadc0\ub97c\nruntime validation \uc73c\ub85c \ucc28\ub2e8).",
         "properties": {
           "path": {
             "title": "Path",
@@ -8756,7 +8760,7 @@
         "type": "object"
       },
       "ApprovalStatusUpdate": {
-        "description": "승인/거부 요청.\n\n``status`` 는 ``approved`` / ``rejected`` 만 허용되며, Pydantic\n``Literal`` SSOT 로 enum 을 OpenAPI 에 노출한다 (#1434). schema 단계에서\ninvalid 값이 차단되므로 handler 내 invalid status 400 분기는 reachable\n하지 않다 — Pydantic 이 422 로 사전 차단한다.",
+        "description": "\uc2b9\uc778/\uac70\ubd80 \uc694\uccad.\n\n``status`` \ub294 ``approved`` / ``rejected`` \ub9cc \ud5c8\uc6a9\ub418\uba70, Pydantic\n``Literal`` SSOT \ub85c enum \uc744 OpenAPI \uc5d0 \ub178\ucd9c\ud55c\ub2e4 (#1434). schema \ub2e8\uacc4\uc5d0\uc11c\ninvalid \uac12\uc774 \ucc28\ub2e8\ub418\ubbc0\ub85c handler \ub0b4 invalid status 400 \ubd84\uae30\ub294 reachable\n\ud558\uc9c0 \uc54a\ub2e4 \u2014 Pydantic \uc774 422 \ub85c \uc0ac\uc804 \ucc28\ub2e8\ud55c\ub2e4.",
         "properties": {
           "status": {
             "enum": [

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -585,42 +585,33 @@ export type paths = {
          *           입력을 UTC-naive ``datetime``으로 정규화한 뒤 ``EventHistoryStore``
          *           SQL filter(``timestamp >= ? AND timestamp <= ?``)에 전달한다.
          *
-         *     Codex P2 (#1437 fix loop r1):
-         *         r0 구현은 두 가지 silent regression이 있었다.
+         *     Codex P2 (#1437 fix loop r2):
+         *         r1 구현은 두 가지 silent failure가 남아있었다.
          *
-         *         (1) ``store.query(limit=limit)`` + in-memory 페이지 슬라이스 — store가
-         *             처음부터 ``LIMIT limit``만 fetch하기 때문에 ``offset=10&limit=10``
-         *             요청 시 2페이지가 비거나 짧고, ``total`` 카운트가 처음 limit
-         *             범위로만 제한된다. 본 r1 구현은 store에 ``offset``/``until``과
-         *             ``count`` 시그니처를 확장하고, ``bot_id`` 가 payload JSON 안에
-         *             있어 SQL 직접 필터가 어렵다는 한계를 인정해, **매칭 가능 범위를
-         *             모두 가져온 뒤 in-memory에서 ``bot_id`` 필터 → ``total`` → 페이지
-         *             슬라이스** 흐름으로 변경한다. ``EventHistoryStore.query``에 추가된
-         *             ``offset`` 파라미터는 ``bot_id`` 필터 미적용 호출자(미래 dashboard
-         *             total badge 등)가 효율적인 페이지네이션을 할 수 있도록 보강해두지만,
-         *             본 핸들러는 ``bot_id`` 정확성 우선으로 사용하지 않는다.
-         *             매칭 row 수가 과도하게 커지지 않도록 hard cap
-         *             ``_BOT_LOGS_FETCH_HARD_CAP``을 둔다(retention 30일 가정 하 충분).
+         *         (1) ``EventHistoryStore.query`` 시그니처 — r1은 ``until``을 ``limit``
+         *             앞 위치 인자로 추가해 기존 caller ``store.query(type, since, 50)``
+         *             의 세 번째 위치 인자 ``50``이 ``limit`` 대신 ``until``로
+         *             잘못 바인딩되는 위험이 있었다. r2는 ``until``/``offset``/
+         *             ``payload_filter``를 keyword-only로 옮겨 위치 인자 호환성을
+         *             복원한다.
          *
-         *         (2) ``start_date``/``end_date`` 를 입력 그대로(``+09:00`` 등 offset
-         *             suffix 포함) in-memory ``timestamp >= start_date`` 문자열 비교에
-         *             사용 — storage timestamp는 UTC-naive ISO 문자열이라 ASCII 정렬
-         *             규칙으로 실제 UTC 시간과 어긋난다 (#1414 audit r2와 동일 패턴).
-         *             본 r1 구현은 ``_validate_iso_date_param``으로 입력을 UTC-naive
-         *             ``datetime``으로 정규화하고, ``EventHistoryStore``의 SQL 텍스트
+         *         (2) hard cap ``_BOT_LOGS_FETCH_HARD_CAP=10000`` — r1은 ``bot_id`` 가
+         *             payload JSON 안이라 SQL 직접 필터가 어렵다는 이유로 매칭 가능
+         *             범위(event_type + since/until)를 한번에 10000건 fetch한 뒤
+         *             in-memory ``bot_id`` 필터를 적용했다. 다른 봇의 로그가 cap을
+         *             먼저 채우면 특정 봇의 로그가 결과에서 누락될 수 있다(여러 봇이
+         *             병렬로 step을 찍는 환경에서 silent under-count). r2는
+         *             ``EventHistoryStore``에 SQL JSON1 ``payload_filter``를 추가해
+         *             ``bot_id``를 SQL 단계에서 필터링한다 — cap이 필요 없고
+         *             ``total``/``logs``가 cap에 무관하게 정확하다.
+         *
+         *         (3) ``start_date``/``end_date`` 의 timezone 정합 (r1에서 해결, r2에서
+         *             그대로 유지): ``_validate_iso_date_param``으로 입력을 UTC tz-aware
+         *             ``datetime``으로 정규화한 뒤 ``EventHistoryStore``의 SQL 텍스트
          *             비교에 그대로 사용한다. event timestamp는 dataclass field default
-         *             ``datetime.now(timezone.utc)``로 tz-aware UTC이지만,
-         *             ``isoformat()`` 결과를 SQL 텍스트로 비교하므로 ``+00:00`` suffix가
-         *             있을 수 있다. inclusive boundary는 ``>=``/``<=`` 비교라서
-         *             ``T00:00:00`` < ``T00:00:00+00:00`` < ``T23:59:59+00:00`` <
-         *             ``T23:59:59Z`` (ASCII) 관계가 성립하므로, ``date.fromisoformat``
-         *             확장 datetime(``T00:00:00`` / ``T23:59:59``)이 안전한 하한/상한이
-         *             된다.
-         *
-         *     Note: ``bot_id`` 가 payload JSON 안에 있어 SQL 직접 필터가 어렵다는
-         *         한계로, 매칭 row 수가 hard cap을 초과하는 환경에선 ``total`` 이 cap에
-         *         clamp된다. SQL JSON1로 ``bot_id`` 를 SQL 필터로 끌어올리는 최적화는
-         *         본 패치 범위(Non-Goal). 별도 이슈로 분리한다.
+         *             ``datetime.now(UTC)``로 tz-aware UTC이며, ``isoformat()`` 결과의
+         *             ``+00:00`` suffix가 양쪽에 일관되게 붙어 ASCII 비교가 실제 UTC
+         *             시간 관계와 일치한다.
          */
         get: operations["get_bot_logs_api_bots__bot_id__logs_get"];
         put?: never;
@@ -5380,7 +5371,7 @@ export interface operations {
         parameters: {
             query?: {
                 /** @description 데이터 유형 (ohlcv, fundamental) */
-                data_type?: string;
+                data_type?: "ohlcv" | "fundamental";
             };
             header?: never;
             path: {

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -299,7 +299,9 @@ async def delete_dataset(
     caller_id: Annotated[str, Depends(require_data_write)],
     store: Annotated[Any | None, Depends(get_data_store)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
-    data_type: str = Query("ohlcv", description="데이터 유형 (ohlcv, fundamental)"),
+    data_type: Literal["ohlcv", "fundamental"] = Query(
+        "ohlcv", description="데이터 유형 (ohlcv, fundamental)"
+    ),
 ) -> None:
     """데이터셋 삭제. 인증된 master/human 또는 ``data:write`` scope 를 보유한
     agent 만 호출 가능 (#1407).

--- a/tests/unit/test_dataset_delete_api.py
+++ b/tests/unit/test_dataset_delete_api.py
@@ -165,6 +165,48 @@ class TestDeleteDataset:
         assert body["items"] == []
         assert body["total"] == 0
 
+    def test_delete_invalid_data_type_rejected(self, client):
+        """enum 외 data_type 값은 422 (#1438).
+
+        과거에는 unknown 값이 ohlcv 경로로 fallback 되어 404 가 반환되었다.
+        Literal narrowing 이후 ingress 에서 거부되어야 한다.
+        """
+        resp = client.delete(
+            "/api/data/datasets/005930__1d",
+            params={"data_type": "oracle_invalid_type"},
+        )
+        assert resp.status_code == 422
+
+    def test_delete_empty_data_type_rejected(self, client):
+        """빈 문자열 data_type 은 422 (#1438)."""
+        resp = client.delete(
+            "/api/data/datasets/005930__1d",
+            params={"data_type": ""},
+        )
+        assert resp.status_code == 422
+
+    async def test_delete_default_data_type_ohlcv(self, client, store):
+        """data_type 미지정 시 기본 ohlcv 회귀 (#1438)."""
+        store.write("005930", "1d", _make_ohlcv_df())
+        resp = client.delete("/api/data/datasets/005930__1d")
+        assert resp.status_code == 204
+
+    def test_delete_ohlcv_explicit_data_type(self, client):
+        """data_type=ohlcv 명시 시 기존 404 회귀 (#1438)."""
+        resp = client.delete(
+            "/api/data/datasets/999999__1d",
+            params={"data_type": "ohlcv"},
+        )
+        assert resp.status_code == 404
+
+    def test_delete_fundamental_explicit_data_type(self, client):
+        """data_type=fundamental 명시 시 기존 404 회귀 (#1438)."""
+        resp = client.delete(
+            "/api/data/datasets/999999__fundamental",
+            params={"data_type": "fundamental"},
+        )
+        assert resp.status_code == 404
+
 
 class TestFundamentalDatasets:
     """fundamental 데이터 유형 API 테스트."""


### PR DESCRIPTION
Closes #1438

## Summary
- DELETE /api/data/datasets/{dataset_id}의 `data_type` query를 `Literal['ohlcv', 'fundamental']`로 좁힘
- 인접 GET list/schema와 enum 정합 (drift 해소)
- invalid (`oracle_invalid_type`) / empty 값은 ingress 단계에서 422
- frontend openapi.json + api.generated.ts enum 노출
- spec doc 갱신 (`docs/specs/web-api/05-resource-endpoints.md` DELETE 행)

## Test Plan
- `pytest tests/unit/test_dataset_delete_api.py`: 19 passed (신규 5건 포함)
- `pytest tests/unit -k 'data and (delete or dataset)'`: 70 passed
- `ruff check` / `ruff format --check`: clean
- frontend `generate-types` / `check-api-types` / `build`: clean

## Codex Branch Review
- r1: PASS — 회귀 없음