### PR TITLE
fix(member): introduce SCOPE_VOCABULARY SSOT + Pydantic/service/CLI validation (#1439)

### DIFF
--- a/docs/specs/member/02-design-decisions.md
+++ b/docs/specs/member/02-design-decisions.md
@@ -195,6 +195,14 @@ master(human)는 scope 제한 없이 모든 작업을 수행할 수 있다. scop
 
 > `signal` 도메인은 봇별 signal key(`sk_`) 인증으로 동작하며, member scope 체계 밖이다.
 
+**Scope vocabulary 코드 SSOT**: 위 매트릭스의 "—"가 아닌 모든 cell 은
+`src/ante/member/scopes.py` 의 `SCOPE_VOCABULARY: frozenset[str]` 에 등록되어
+있다(#1439). Web API ingress(Pydantic field validator), `MemberService.register`
+/ `update_scopes` (defense-in-depth), CLI 입력 모두 이 vocabulary 에 대해
+검증되며, 등록되지 않은 scope 문자열은 입력 시점에 거부된다. spec doc
+매트릭스와 `SCOPE_VOCABULARY` 의 drift 는 `tests/unit/test_member_scope_drift.py`
+가 정적으로 검증한다.
+
 ### Member command runtime boundary
 
 `member list/info`는 오프라인 조회가 가능하다. 등록, 정지, 재활성화, 폐기,

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -21,6 +21,7 @@ from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
 from ante.member.errors import PermissionDeniedError
+from ante.member.scopes import InvalidScopeError
 
 # CLI 핸들러에서 master guard 위반을 사용자 친화 메시지로 종료하기 위한 메시지.
 # ``MemberService._assert_master``가 raise하는 ``PermissionDeniedError``는 Python
@@ -288,6 +289,13 @@ def member_register(
         result, token = _run(_run_register())
     except PermissionDeniedError:
         fmt.error(_MASTER_REQUIRED_MESSAGE)
+        raise SystemExit(1) from None
+    except InvalidScopeError as e:
+        # SCOPE_VOCABULARY (#1439) 위반은 ``ValueError`` 서브클래스이지만
+        # CLI direct path 회귀를 위해 비-0 exit code 로 명시 종료한다.
+        # 다음 분기의 ``except (ValueError, ...)`` 가 먼저 매칭되면 ``return``
+        # 으로 빠져 exit code 0 이 되므로 별도 분기로 둔다.
+        fmt.error(str(e), code="MEMBER_INVALID_SCOPE")
         raise SystemExit(1) from None
     except (ValueError, PermissionError) as e:
         fmt.error(str(e))

--- a/src/ante/member/__init__.py
+++ b/src/ante/member/__init__.py
@@ -4,11 +4,14 @@ from ante.member.auth_service import AuthService
 from ante.member.errors import MemberError, PermissionDeniedError
 from ante.member.models import Member, MemberRole, MemberStatus, MemberType
 from ante.member.recovery_key_manager import RecoveryKeyManager
+from ante.member.scopes import SCOPE_VOCABULARY, InvalidScopeError, is_valid_scope
 from ante.member.service import MemberService
 from ante.member.token_manager import TokenManager
 
 __all__ = [
+    "SCOPE_VOCABULARY",
     "AuthService",
+    "InvalidScopeError",
     "Member",
     "MemberError",
     "MemberRole",
@@ -18,4 +21,5 @@ __all__ = [
     "PermissionDeniedError",
     "RecoveryKeyManager",
     "TokenManager",
+    "is_valid_scope",
 ]

--- a/src/ante/member/scopes.py
+++ b/src/ante/member/scopes.py
@@ -1,0 +1,112 @@
+"""Member scope vocabulary SSOT (#1439).
+
+본 모듈은 Ante 시스템 전반에서 사용하는 scope 문자열 vocabulary 의 단일 진실
+저장소(SSOT)다. 인증 후 권한 판정에 사용되는 모든 scope 토큰은 본 모듈의
+``SCOPE_VOCABULARY`` 에 등록되어 있어야 하며, 등록되지 않은 scope 문자열은
+서비스 계층/Web API ingress/CLI 입력 단계에서 모두 거부된다.
+
+설계 결정 (#1439 — Codex Plan Review r1):
+- SSOT 위치를 ``src/ante/web/deps.py`` 의 require_scope alias 가 아닌 본
+  ``src/ante/member`` 패키지로 둔다. Member 모듈이 principal/credential/scope
+  vocabulary 전체의 SSOT 라는 spec 결정(``docs/specs/member/02-design-decisions.md``
+  "Authorization SSOT")과 일관성을 맞춘다. ``ante.web.deps`` 의 ``require_X_Y``
+  alias 들은 본 vocabulary 의 소비처이며 SSOT 가 아니다.
+- vocabulary 정의는 ``docs/specs/member/02-design-decisions.md`` 의 "권한 범위
+  (Scope)" 매트릭스(read / write / admin / run 컬럼, "—" 셀 제외)에서 직접
+  파생된다. spec doc 매트릭스의 모든 valid cell 은 본 frozenset 의 원소로
+  존재해야 하며, drift 는 ``tests/unit/test_member_scope_drift.py`` 가 정적으로
+  검증한다.
+
+NOTE: ``signal`` 도메인은 봇별 signal key(``sk_``) 인증으로 동작하며 member
+scope 체계 밖이다(spec doc L196). 본 vocabulary 에 포함되지 않는다.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "SCOPE_VOCABULARY",
+    "InvalidScopeError",
+    "is_valid_scope",
+]
+
+
+# spec ``docs/specs/member/02-design-decisions.md`` 권한 범위 매트릭스(L177-194)
+# 의 "—" 가 아닌 모든 cell. 도메인 가나다순(매트릭스 순서)으로 나열하고 같은
+# 도메인 안에서는 read → write → admin → run 순서로 정렬한다.
+SCOPE_VOCABULARY: frozenset[str] = frozenset(
+    {
+        # account
+        "account:read",
+        "account:write",
+        # strategy
+        "strategy:read",
+        "strategy:write",
+        # data
+        "data:read",
+        "data:write",
+        # report
+        "report:read",
+        "report:write",
+        # config
+        "config:read",
+        "config:write",
+        # approval
+        "approval:read",
+        "approval:write",
+        "approval:admin",
+        # bot
+        "bot:read",
+        "bot:admin",
+        # trade
+        "trade:read",
+        # treasury
+        "treasury:read",
+        "treasury:admin",
+        # member
+        "member:read",
+        "member:admin",
+        # system
+        "system:read",
+        "system:admin",
+        # rule
+        "rule:read",
+        "rule:admin",
+        # broker
+        "broker:read",
+        # audit
+        "audit:read",
+        # notification
+        "notification:read",
+        # backtest
+        "backtest:run",
+    }
+)
+
+
+def is_valid_scope(scope: str) -> bool:
+    """``scope`` 문자열이 SCOPE_VOCABULARY 에 포함되어 있는지 확인한다.
+
+    구분자 변형(예: ``account.read``), 대소문자 변형(예: ``Account:Read``),
+    공백/외부 prefix(``oracle:invalid``, ``audit :read``) 는 모두 false 다.
+    빈 문자열은 false 다.
+    """
+    return scope in SCOPE_VOCABULARY
+
+
+class InvalidScopeError(ValueError):
+    """SCOPE_VOCABULARY 에 없는 scope 문자열이 service 계층에 전달된 경우.
+
+    Web API ingress(Pydantic field validator)는 동일 invariant 를 위반한
+    요청을 422 로 차단하므로 본 예외가 ingress 경로에서 raise 되지는 않는다.
+    CLI direct path 와 내부 caller (``MemberService.register`` /
+    ``update_scopes`` 직접 호출) 가 invalid scope 를 넘기는 경우 본 예외가
+    defense-in-depth 로 raise 된다.
+
+    ``ValueError`` 의 서브클래스로 두어 기존 ``except ValueError`` 핸들러가
+    그대로 동작하지만, 호출자가 vocabulary 위반과 다른 도메인 오류
+    (예: 존재하지 않는 멤버) 를 구분하려면 본 클래스로 좁혀 catch 한다.
+    """
+
+    def __init__(self, scope: str) -> None:
+        self.scope = scope
+        super().__init__(f"unsupported scope: {scope!r}")

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -17,6 +17,7 @@ from ante.member.auth import (
 from ante.member.auth_service import AuthService
 from ante.member.models import Member, MemberRole, MemberStatus, MemberType
 from ante.member.recovery_key_manager import RecoveryKeyManager
+from ante.member.scopes import InvalidScopeError, is_valid_scope
 from ante.member.token_manager import TokenManager, _token_expires_at
 
 __all__ = ["MemberService", "ANIMAL_EMOJI_POOL", "MEMBER_SCHEMA", "_token_expires_at"]
@@ -342,10 +343,22 @@ class MemberService:
         scopes: list[str] | None = None,
         registered_by: str = "",
     ) -> tuple[Member, str]:
-        """멤버 등록 + 토큰 반환."""
+        """멤버 등록 + 토큰 반환.
+
+        ``scopes`` 의 각 원소는 ``SCOPE_VOCABULARY`` 에 등록된 문자열이어야
+        한다(#1439). 위반 시 ``InvalidScopeError`` 를 raise 한다. Web API
+        ingress 는 Pydantic field validator 로 동일 invariant 를 검증하지만
+        CLI direct path 와 내부 caller 가 본 메소드를 직접 호출할 수 있으므로
+        service 계층에서 한 번 더 방어한다(defense-in-depth).
+        """
         if registered_by:
             await self._assert_master(registered_by, "register")
         self._assert_type_role(member_type, role)
+
+        # vocabulary 검증은 type/role 검증 이후, DB I/O 이전에 수행한다.
+        # CLI direct path 회귀 (#1439).
+        scopes = scopes or []
+        self._assert_scopes_vocabulary(scopes)
 
         existing = await self.get(member_id)
         if existing:
@@ -360,7 +373,6 @@ class MemberService:
 
         token, t_hash, expires_at = self._token_manager.create_token(member_type)
         now = _now()
-        scopes = scopes or []
 
         member = Member(
             member_id=member_id,
@@ -640,8 +652,15 @@ class MemberService:
         ``updated_by``는 master 권한 caller여야 한다(#1351). 이전에는
         ``if updated_by:`` 가드 때문에 빈 caller가 master 검증을 우회했으나,
         본 가드를 제거해 빈 caller도 거부한다.
+
+        ``scopes`` 의 각 원소는 ``SCOPE_VOCABULARY`` 에 등록된 문자열이어야
+        한다(#1439). 위반 시 ``InvalidScopeError`` 를 raise 한다. Web API
+        ingress 가 Pydantic field validator 로 422 차단하지만 CLI 직접 호출과
+        내부 caller 를 위해 service 계층에서 한 번 더 방어한다.
         """
         await self._assert_master(updated_by, "update_scopes")
+        # vocabulary 검증은 master 검증 직후, 멤버 조회 / DB write 이전에 수행한다.
+        self._assert_scopes_vocabulary(scopes)
         member = await self._get_or_raise(member_id)
         self._assert_active(member, "update_scopes")
 
@@ -682,6 +701,21 @@ class MemberService:
             msg = f"존재하지 않는 멤버: {member_id}"
             raise ValueError(msg)
         return member
+
+    @staticmethod
+    def _assert_scopes_vocabulary(scopes: list[str]) -> None:
+        """``scopes`` 의 각 원소가 ``SCOPE_VOCABULARY`` 에 포함되는지 검증한다.
+
+        위반 시 첫 invalid scope 를 인자로 ``InvalidScopeError`` 를 raise 한다.
+        ``InvalidScopeError`` 는 ``ValueError`` 서브클래스이므로 기존
+        ``except ValueError`` 핸들러도 동일하게 처리된다(#1439).
+
+        빈 리스트는 통과시킨다. ``None`` 은 caller(``register`` /
+        ``update_scopes``) 에서 빈 리스트로 정규화한 뒤 본 헬퍼를 호출한다.
+        """
+        for scope in scopes:
+            if not is_valid_scope(scope):
+                raise InvalidScopeError(scope)
 
     @staticmethod
     def _assert_type_role(member_type: str, role: str) -> None:

--- a/src/ante/web/routes/members.py
+++ b/src/ante/web/routes/members.py
@@ -8,10 +8,11 @@ from dataclasses import asdict
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
 
 from ante.member.errors import PermissionDeniedError
 from ante.member.models import MemberStatus, MemberType
+from ante.member.scopes import SCOPE_VOCABULARY, InvalidScopeError
 from ante.web.deps import (
     get_audit_logger_optional,
     get_member_service,
@@ -50,6 +51,27 @@ _AUTH_REQUIRED_RESPONSE: dict[str, Any] = {
 }
 
 
+def _validate_scopes_vocabulary(value: list[str]) -> list[str]:
+    """scopes 필드 element 가 ``SCOPE_VOCABULARY`` 에 등록되어 있는지 검증한다.
+
+    SSOT 는 ``src/ante/member/scopes.py`` (#1439 — Codex Plan Review r1 결정).
+    invalid 시 ``ValueError`` 를 raise 하여 Pydantic 이 422 로 자동 변환하게
+    한다. ``MemberCreateRequest.scopes`` 와 ``ScopesUpdateRequest.scopes`` 양쪽에
+    동일 invariant 를 강제한다.
+
+    인증 가드 이후에 실행되어야 한다 (#1339 / #1351 — auth-first 순서). 본
+    validator 는 Pydantic ``model_validate`` 단계에서 실행되며, 라우트는 raw
+    body 파싱 패턴으로 인증 가드를 먼저 통과시킨 뒤 ``model_validate`` 를
+    호출하므로 unauth + invalid scope 케이스에서도 401 이 먼저 반환되어
+    contract 가 보존된다.
+    """
+    for scope in value:
+        if scope not in SCOPE_VOCABULARY:
+            msg = f"unsupported scope: {scope!r}"
+            raise ValueError(msg)
+    return value
+
+
 class MemberCreateRequest(BaseModel):
     """멤버 등록 요청."""
 
@@ -61,6 +83,8 @@ class MemberCreateRequest(BaseModel):
     org: str = "default"
     name: str = ""
     scopes: list[str] = []
+
+    _validate_scopes = field_validator("scopes")(_validate_scopes_vocabulary)
 
 
 # POST /api/members OpenAPI request body 문서.
@@ -111,7 +135,11 @@ MEMBER_CREATE_REQUEST_SCHEMA: dict[str, Any] = {
             "type": "array",
             "items": {"type": "string"},
             "default": [],
-            "description": "권한 범위 목록.",
+            "description": (
+                "권한 범위 목록. 각 원소는 SCOPE_VOCABULARY (#1439, SSOT: "
+                "``src/ante/member/scopes.py``) 에 등록된 문자열이어야 한다. "
+                "미등록 문자열은 422 로 거부된다."
+            ),
         },
     },
 }
@@ -178,11 +206,16 @@ class ScopesUpdateRequest(BaseModel):
     false``를 선언한다. 런타임 모델도 ``extra="forbid"``로 동일하게 강제해
     OpenAPI contract와 동작을 일치시킨다(#1351 2차 Codex review FAIL — Finding
     P2: ScopesUpdateRequest contract drift). ``MemberCreateRequest`` SSOT.
+
+    ``scopes`` 각 원소는 ``SCOPE_VOCABULARY`` (``src/ante/member/scopes.py``)
+    에 등록되어야 한다(#1439). 위반 시 Pydantic 이 자동으로 422 를 반환한다.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     scopes: list[str]
+
+    _validate_scopes = field_validator("scopes")(_validate_scopes_vocabulary)
 
 
 # PUT /api/members/{member_id}/scopes OpenAPI request body 문서.
@@ -211,7 +244,11 @@ MEMBER_SCOPES_UPDATE_REQUEST_SCHEMA: dict[str, Any] = {
         "scopes": {
             "type": "array",
             "items": {"type": "string"},
-            "description": "변경할 권한 범위 목록.",
+            "description": (
+                "변경할 권한 범위 목록. 각 원소는 SCOPE_VOCABULARY (#1439, "
+                "SSOT: ``src/ante/member/scopes.py``) 에 등록된 문자열이어야 "
+                "한다. 미등록 문자열은 422 로 거부된다."
+            ),
         },
     },
 }
@@ -404,6 +441,12 @@ async def create_member(
             scopes=body.scopes,
             registered_by=caller,
         )
+    except InvalidScopeError as e:
+        # ingress(Pydantic field_validator) 가 통상 차단하지만 service 가
+        # 별도 경로에서 raise 한 경우 422 로 매핑한다 (#1439 — Codex Plan
+        # Review r1 defense-in-depth). ``ValueError`` 분기보다 먼저 catch
+        # 해야 동일 super class 매칭에서 400 으로 가려지지 않는다.
+        raise HTTPException(status_code=422, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     except (PermissionError, PermissionDeniedError) as e:
@@ -951,6 +994,12 @@ async def update_scopes(
     # 4. service 호출.
     try:
         member = await svc.update_scopes(member_id, body.scopes, updated_by=caller)
+    except InvalidScopeError as e:
+        # ingress(Pydantic field_validator) 가 통상 차단하지만 service 가
+        # 별도 경로에서 raise 한 경우 422 로 매핑한다 (#1439). 매트릭스에서
+        # ``ValueError`` 분기보다 먼저 catch 해야 ``InvalidScopeError`` 가
+        # ``ValueError`` 의 서브클래스인 점이 404 로 새지 않는다.
+        raise HTTPException(status_code=422, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except (PermissionError, PermissionDeniedError) as e:

--- a/tests/unit/test_member_api.py
+++ b/tests/unit/test_member_api.py
@@ -397,14 +397,19 @@ class TestChangePassword:
 
 class TestScopesUpdate:
     def test_update_scopes(self, client, member_service):
-        """권한 범위 변경."""
+        """권한 범위 변경.
+
+        ``trade:write`` 는 spec 매트릭스(``docs/specs/member/02-design-decisions.md``)
+        와 ``SCOPE_VOCABULARY`` (#1439) 에 없는 invalid scope 이므로
+        ``trade:read`` + ``audit:read`` 같은 valid 조합으로 회귀를 잠근다.
+        """
         member_service._members["agent-01"] = FakeMember(member_id="agent-01")
         resp = client.put(
             "/api/members/agent-01/scopes",
-            json={"scopes": ["trade:read", "trade:write"]},
+            json={"scopes": ["trade:read", "audit:read"]},
         )
         assert resp.status_code == 200
-        assert resp.json()["member"]["scopes"] == ["trade:read", "trade:write"]
+        assert resp.json()["member"]["scopes"] == ["trade:read", "audit:read"]
 
 
 class TestCallerIdPropagation:

--- a/tests/unit/test_member_routes_mutation_auth.py
+++ b/tests/unit/test_member_routes_mutation_auth.py
@@ -506,13 +506,16 @@ class TestBearerMasterSuccess:
     def test_update_scopes_with_master_bearer_succeeds(
         self, client: TestClient, member_service: FakeMemberService
     ) -> None:
+        # ``trade:write`` 는 SCOPE_VOCABULARY (#1439) 에 없는 invalid scope 이므로
+        # ``trade:read`` + ``audit:read`` 같은 valid 조합으로 master 인증 성공
+        # path 만 잠근다 (인증 통과 + 정상 service 호출 → 200).
         resp = client.put(
             "/api/members/target-active/scopes",
             headers={"Authorization": "Bearer master-token"},
-            json={"scopes": ["trade:read", "trade:write"]},
+            json={"scopes": ["trade:read", "audit:read"]},
         )
         assert resp.status_code == 200, resp.text
-        assert resp.json()["member"]["scopes"] == ["trade:read", "trade:write"]
+        assert resp.json()["member"]["scopes"] == ["trade:read", "audit:read"]
         assert member_service.update_scopes_calls[-1]["updated_by"] == "master-user"
 
     def test_change_password_with_master_bearer_succeeds(

--- a/tests/unit/test_member_scope_drift.py
+++ b/tests/unit/test_member_scope_drift.py
@@ -1,0 +1,156 @@
+"""Scope vocabulary spec ↔ code drift 검증 (#1439).
+
+``docs/specs/member/02-design-decisions.md`` 의 "권한 범위 (Scope)" 매트릭스
+(L177-194) 와 ``src/ante/member/scopes.py`` 의 ``SCOPE_VOCABULARY`` 가 어긋나지
+않도록 정적으로 잠근다.
+
+본 테스트가 잠그는 invariant:
+
+1. spec doc 매트릭스의 모든 valid cell (``—`` 가 아닌 cell) 은
+   ``SCOPE_VOCABULARY`` 에 등록되어 있어야 한다.
+2. ``SCOPE_VOCABULARY`` 는 spec doc 매트릭스의 valid cell 집합과 정확히
+   같거나(== ) 의도적 superset 이어야 한다. superset 이라면 본 테스트가
+   안내 메시지로 추가 원소를 보고하고, 그 자체가 회귀로 보이지 않게 별도
+   허용 리스트(``_INTENTIONAL_EXTRAS``)를 갱신해야 한다.
+
+매트릭스 파싱 전략 (Stop Conditions: spec doc 매트릭스 파싱이 fragile 하면
+하드코딩 fallback): 매트릭스의 각 라인을 명시적 정규식으로 파싱한다. 파싱이
+실패하면 즉시 fail 하여 fragile 한 형식 변경을 잠근다. spec doc 의 매트릭스
+구조는 D-015 (default-deny auth gate) 결정 이후 안정화되어 있어 broad-match
+보다 직접 파싱이 더 정확하다.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from ante.member.scopes import SCOPE_VOCABULARY
+
+SPEC_DOC_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "docs"
+    / "specs"
+    / "member"
+    / "02-design-decisions.md"
+)
+
+
+# 매트릭스 도메인 행: ``| `account` | ... |`` 형식.
+# 컬럼: domain | read | write | admin | run
+_DOMAIN_ROW_RE = re.compile(
+    r"^\|\s*`(?P<domain>[a-z_]+)`\s*"
+    r"\|\s*(?P<read>[^|]*?)\s*"
+    r"\|\s*(?P<write>[^|]*?)\s*"
+    r"\|\s*(?P<admin>[^|]*?)\s*"
+    r"\|\s*(?P<run>[^|]*?)\s*"
+    r"\|\s*$"
+)
+
+# ``—`` (em-dash) 단독 cell 만 invalid 표기. 빈 cell 도 invalid 로 본다.
+_EMPTY_CELL_RE = re.compile(r"^\s*(?:—|-)?\s*$")
+
+
+# 의도적 vocabulary > spec_matrix 인 scope (현재는 없음). 발생 시 본 리스트에
+# 등록 + 따로 회귀 사유를 주석으로 명시한다. spec 갱신을 후속 이슈로 처리하는
+# 케이스에 한해 사용.
+_INTENTIONAL_EXTRAS: frozenset[str] = frozenset(set())
+
+
+def _parse_spec_matrix() -> frozenset[str]:
+    """spec doc 의 권한 범위 매트릭스를 파싱해 valid scope 집합을 반환한다.
+
+    매트릭스 시작은 헤더 ``| 도메인 | read | write | admin | run |`` 행이고,
+    종료는 비-row (빈 줄 또는 ``> note`` 같은 인용) 행이다.
+    """
+    text = SPEC_DOC_PATH.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    # 매트릭스 헤더 시점 찾기.
+    header_idx: int | None = None
+    for idx, line in enumerate(lines):
+        # 헤더 행 형식. ``| 도메인 | read | write | admin | run |``.
+        stripped = line.strip()
+        if (
+            stripped.startswith("|")
+            and "도메인" in stripped
+            and "read" in stripped
+            and "write" in stripped
+            and "admin" in stripped
+            and "run" in stripped
+        ):
+            header_idx = idx
+            break
+    assert header_idx is not None, (
+        "spec doc 매트릭스 헤더를 찾지 못했습니다. "
+        f"형식 변경 가능성 확인 필요: {SPEC_DOC_PATH}"
+    )
+
+    # 헤더 다음 줄은 separator ``|--------|...``. 그 다음 줄부터 도메인 행.
+    matrix_start = header_idx + 2
+    scopes: set[str] = set()
+    domains_seen: set[str] = set()
+
+    for line in lines[matrix_start:]:
+        if not line.strip().startswith("|"):
+            # 매트릭스 종료 (빈 줄 또는 다른 블록).
+            break
+        m = _DOMAIN_ROW_RE.match(line)
+        if not m:
+            # 매트릭스 내부의 형식 변형. fail-fast 로 fragile parsing 잠금.
+            pytest.fail(f"매트릭스 도메인 행 파싱 실패 — 형식 변경 가능성: {line!r}")
+        domain = m.group("domain")
+        assert domain not in domains_seen, (
+            f"매트릭스 도메인 중복: {domain!r} ({SPEC_DOC_PATH})"
+        )
+        domains_seen.add(domain)
+        for level_name in ("read", "write", "admin", "run"):
+            cell = m.group(level_name)
+            if _EMPTY_CELL_RE.match(cell):
+                continue
+            scopes.add(f"{domain}:{level_name}")
+
+    assert scopes, "spec doc 매트릭스에서 valid scope 를 하나도 파싱하지 못했습니다."
+    return frozenset(scopes)
+
+
+class TestScopeDrift:
+    def test_spec_matrix_subset_of_vocabulary(self) -> None:
+        """spec doc 매트릭스의 모든 valid cell 이 ``SCOPE_VOCABULARY`` 에 있어야 한다.
+
+        매트릭스에 새 cell 이 추가되었는데 ``SCOPE_VOCABULARY`` 가 갱신되지
+        않았다면 본 어서션이 fail 한다.
+        """
+        spec_scopes = _parse_spec_matrix()
+        missing = spec_scopes - SCOPE_VOCABULARY
+        assert not missing, (
+            f"spec doc 매트릭스에 있지만 SCOPE_VOCABULARY 에 없는 scope: "
+            f"{sorted(missing)} — ``src/ante/member/scopes.py`` 갱신 필요"
+        )
+
+    def test_vocabulary_subset_of_spec_matrix_or_intentional(self) -> None:
+        """``SCOPE_VOCABULARY`` 의 원소는 spec doc 매트릭스 또는 의도적
+        ``_INTENTIONAL_EXTRAS`` 둘 중 하나에 속해야 한다.
+
+        ``SCOPE_VOCABULARY`` 가 spec doc 의 superset 으로 늘어났다면 본
+        어서션이 fail 한다. follow-up 이슈로 spec 매트릭스를 갱신하거나
+        ``_INTENTIONAL_EXTRAS`` 에 의도적으로 등록해야 한다.
+        """
+        spec_scopes = _parse_spec_matrix()
+        extra = SCOPE_VOCABULARY - spec_scopes - _INTENTIONAL_EXTRAS
+        assert not extra, (
+            f"SCOPE_VOCABULARY 에 있지만 spec doc 매트릭스에 없는 scope: "
+            f"{sorted(extra)} — spec 갱신 또는 _INTENTIONAL_EXTRAS 등록 필요"
+        )
+
+    def test_vocabulary_equals_spec_matrix(self) -> None:
+        """현재 시점 invariant: vocabulary == spec_matrix (extras 없음).
+
+        ``_INTENTIONAL_EXTRAS`` 가 비어 있는 한 본 테스트는 위 두 테스트의
+        합집합을 한 줄로 잠근다. 추후 의도적 extras 가 추가되면 본 테스트는
+        ``_INTENTIONAL_EXTRAS`` 를 반영해 갱신한다.
+        """
+        spec_scopes = _parse_spec_matrix()
+        assert SCOPE_VOCABULARY - _INTENTIONAL_EXTRAS == spec_scopes

--- a/tests/unit/test_member_scope_vocabulary.py
+++ b/tests/unit/test_member_scope_vocabulary.py
@@ -1,0 +1,596 @@
+"""Member scope vocabulary 회귀 (#1439).
+
+``PUT /api/members/{id}/scopes`` + ``POST /api/members`` 의 ``scopes`` 필드는
+``src/ante/member/scopes.py`` 의 ``SCOPE_VOCABULARY`` 에 등록된 문자열만 허용한다.
+
+이전 동작: invalid scope (예: ``oracle:invalid``) 가 vocabulary 검증 없이
+서비스 호출 단계까지 도달했고, 존재하지 않는 멤버 케이스에서 404 가 반환되어
+입력 invariant 위반이 가려졌다(#1439).
+
+본 테스트는 다음을 잠근다:
+1. Web API ingress (Pydantic field_validator) — invalid scope 가 포함되면
+   member 존재 여부와 무관하게 422 가 반환되어야 한다.
+2. valid scope + 미존재 멤버 → 404 정상 회귀.
+3. ``MemberService.register`` / ``update_scopes`` defense-in-depth — CLI 또는
+   내부 caller 가 service 를 직접 호출해 invalid scope 를 넘기는 경우에도
+   ``InvalidScopeError`` 가 raise 되어야 한다.
+4. CLI direct path — ``ante member register --scopes oracle:invalid`` 가
+   비-0 exit code 로 종료되어야 한다.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.member.errors import PermissionDeniedError  # noqa: E402
+from ante.member.scopes import SCOPE_VOCABULARY, InvalidScopeError  # noqa: E402
+from ante.web.app import create_app  # noqa: E402
+
+# ── FakeMemberService (test_member_routes_create_auth.py 패턴 재사용) ─
+
+
+@dataclass
+class FakeMember:
+    member_id: str
+    type: str = "agent"
+    role: str = "default"
+    org: str = "default"
+    name: str = ""
+    emoji: str = ""
+    status: str = "active"
+    scopes: list[str] = field(default_factory=list)
+    token_hash: str = ""
+    password_hash: str = ""
+    recovery_key_hash: str = ""
+    created_at: str = ""
+    created_by: str = ""
+    last_active_at: str = ""
+    suspended_at: str = ""
+    revoked_at: str = ""
+    token_expires_at: str = ""
+
+
+class FakeMemberService:
+    def __init__(self) -> None:
+        self._members: dict[str, FakeMember] = {}
+        self._tokens: dict[str, str] = {}
+        self._token_counter = 0
+        self.register_calls: list[dict[str, object]] = []
+        self.update_scopes_calls: list[tuple[str, list[str]]] = []
+
+    def add_member(
+        self,
+        member_id: str,
+        token: str,
+        role: str = "default",
+        member_type: str = "agent",
+    ) -> FakeMember:
+        member = FakeMember(member_id=member_id, role=role, type=member_type)
+        self._members[member_id] = member
+        self._tokens[token] = member_id
+        return member
+
+    async def authenticate(self, token: str) -> FakeMember:
+        member_id = self._tokens.get(token)
+        if member_id is None:
+            raise PermissionError("유효하지 않은 토큰")
+        return self._members[member_id]
+
+    async def get(self, member_id: str) -> FakeMember | None:
+        return self._members.get(member_id)
+
+    async def update_last_active(self, member_id: str) -> None:
+        return None
+
+    async def register(
+        self,
+        member_id: str,
+        member_type: str,
+        role: str = "default",
+        org: str = "default",
+        name: str = "",
+        scopes: list[str] | None = None,
+        registered_by: str = "",
+        **kwargs: object,
+    ) -> tuple[FakeMember, str]:
+        self.register_calls.append(
+            {"member_id": member_id, "scopes": list(scopes or [])}
+        )
+        caller = self._members.get(registered_by)
+        if caller is None or caller.role != "master":
+            raise PermissionDeniedError("'register'은(는) master만 수행할 수 있습니다.")
+        if member_id in self._members:
+            raise ValueError(f"이미 존재하는 멤버: {member_id}")
+        member = FakeMember(
+            member_id=member_id,
+            type=member_type,
+            role=role,
+            org=org,
+            name=name,
+            scopes=list(scopes or []),
+            created_by=registered_by,
+        )
+        self._members[member_id] = member
+        self._token_counter += 1
+        return member, f"ante_ak_{self._token_counter}"
+
+    async def update_scopes(
+        self, member_id: str, scopes: list[str], updated_by: str = ""
+    ) -> FakeMember:
+        self.update_scopes_calls.append((member_id, list(scopes)))
+        caller = self._members.get(updated_by)
+        if caller is None or caller.role != "master":
+            raise PermissionDeniedError(
+                "'update_scopes'은(는) master만 수행할 수 있습니다."
+            )
+        member = self._members.get(member_id)
+        if member is None:
+            raise ValueError(f"존재하지 않는 멤버: {member_id}")
+        member.scopes = list(scopes)
+        return member
+
+
+@pytest.fixture
+def member_service() -> FakeMemberService:
+    svc = FakeMemberService()
+    svc.add_member("master-user", token="master-token", role="master")
+    svc.add_member("agent-01", token="agent-token", role="default")
+    return svc
+
+
+@pytest.fixture
+def client(member_service: FakeMemberService) -> TestClient:
+    app = create_app(member_service=member_service)
+    return TestClient(app)
+
+
+def _master_headers() -> dict[str, str]:
+    return {"Authorization": "Bearer master-token"}
+
+
+# ── 1. PUT /api/members/{id}/scopes — Web API ingress 회귀 ─
+
+
+class TestUpdateScopesVocabulary:
+    def test_invalid_scope_returns_422_even_when_member_missing(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        """이슈 #1439 의 핵심 시나리오.
+
+        invalid scope (``oracle:invalid``) 는 vocabulary 단계에서 422 로
+        차단되어야 하며, 미존재 멤버 케이스의 404 로 가려져서는 안 된다.
+        """
+        resp = client.put(
+            "/api/members/nonexistent/scopes",
+            json={"scopes": ["oracle:invalid"]},
+            headers=_master_headers(),
+        )
+        assert resp.status_code == 422, resp.text
+        # service.update_scopes 는 호출되지 않아야 한다 (ingress 차단).
+        assert member_service.update_scopes_calls == []
+
+    def test_mixed_valid_and_invalid_scopes_returns_422(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        """valid + invalid 혼합도 invalid 한 원소 때문에 422."""
+        resp = client.put(
+            "/api/members/agent-01/scopes",
+            json={"scopes": ["audit:read", "invalid:write"]},
+            headers=_master_headers(),
+        )
+        assert resp.status_code == 422, resp.text
+        assert member_service.update_scopes_calls == []
+
+    def test_valid_scope_for_existing_member_returns_200(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        """valid scope + 존재 멤버 → 200 정상 회귀."""
+        resp = client.put(
+            "/api/members/agent-01/scopes",
+            json={"scopes": ["audit:read"]},
+            headers=_master_headers(),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["member"]["scopes"] == ["audit:read"]
+        assert member_service.update_scopes_calls == [("agent-01", ["audit:read"])]
+
+    def test_valid_scope_for_missing_member_returns_404(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        """valid scope + 미존재 멤버 → 404 정상 회귀.
+
+        본 케이스가 vocabulary 검증과 ``svc.update_scopes`` 의 ``ValueError``
+        매핑이 충돌 없이 분리되어 있는지 확인한다.
+        """
+        resp = client.put(
+            "/api/members/nonexistent/scopes",
+            json={"scopes": ["audit:read"]},
+            headers=_master_headers(),
+        )
+        assert resp.status_code == 404, resp.text
+
+    def test_empty_scopes_list_for_existing_member_returns_200(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        """빈 scopes 리스트는 vocabulary 검증을 통과한다 (empty for-loop)."""
+        resp = client.put(
+            "/api/members/agent-01/scopes",
+            json={"scopes": []},
+            headers=_master_headers(),
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_all_vocabulary_scopes_are_accepted(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        """vocabulary 전체 28개를 한 번에 전달 → 200.
+
+        각 원소가 individually accept 되는지 회귀.
+        """
+        all_scopes = sorted(SCOPE_VOCABULARY)
+        resp = client.put(
+            "/api/members/agent-01/scopes",
+            json={"scopes": all_scopes},
+            headers=_master_headers(),
+        )
+        assert resp.status_code == 200, resp.text
+
+
+# ── 2. POST /api/members — Web API ingress 회귀 ─
+
+
+class TestCreateMemberScopesVocabulary:
+    def _payload(self, scopes: list[str]) -> dict[str, Any]:
+        return {
+            "member_id": "new-agent",
+            "member_type": "agent",
+            "role": "default",
+            "scopes": scopes,
+        }
+
+    def test_invalid_scope_returns_422(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        resp = client.post(
+            "/api/members",
+            json=self._payload(["oracle:invalid"]),
+            headers=_master_headers(),
+        )
+        assert resp.status_code == 422, resp.text
+        assert member_service.register_calls == []
+
+    def test_valid_scope_returns_201(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        resp = client.post(
+            "/api/members",
+            json=self._payload(["audit:read"]),
+            headers=_master_headers(),
+        )
+        assert resp.status_code == 201, resp.text
+        assert "new-agent" in member_service._members
+        assert member_service._members["new-agent"].scopes == ["audit:read"]
+
+    def test_empty_scopes_default_returns_201(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        """``scopes`` 누락 시 default ``[]`` 로 통과."""
+        payload = {
+            "member_id": "new-agent",
+            "member_type": "agent",
+            "role": "default",
+        }
+        resp = client.post(
+            "/api/members",
+            json=payload,
+            headers=_master_headers(),
+        )
+        assert resp.status_code == 201, resp.text
+
+
+# ── 3. MemberService defense-in-depth 회귀 ─
+
+
+class TestMemberServiceVocabularyGuard:
+    """service 계층 가드. CLI direct path / 내부 caller 회귀."""
+
+    @pytest.mark.asyncio
+    async def test_update_scopes_raises_invalid_scope_error(self) -> None:
+        """``MemberService.update_scopes`` 가 invalid scope 를 raise.
+
+        DB / EventBus 의존성을 우회하기 위해 ``_assert_scopes_vocabulary``
+        staticmethod 를 직접 호출한다(동일 invariant 를 잠근다).
+        """
+        from ante.member.service import MemberService
+
+        with pytest.raises(InvalidScopeError) as exc_info:
+            MemberService._assert_scopes_vocabulary(["oracle:invalid"])
+        assert exc_info.value.scope == "oracle:invalid"
+
+    @pytest.mark.asyncio
+    async def test_register_raises_invalid_scope_error(self) -> None:
+        """``MemberService.register`` 도 같은 invariant 를 잠근다.
+
+        ``register`` 가 ``_assert_scopes_vocabulary`` 를 호출한다는 사실은
+        본 헬퍼의 동작 검증과 코드 path 의 정적 참조로 충분히 회귀된다.
+        통합 검증은 다음 ``test_register_first_invalid_scope_stops``.
+        """
+        from ante.member.service import MemberService
+
+        with pytest.raises(InvalidScopeError):
+            MemberService._assert_scopes_vocabulary(["valid:write"])
+
+    @pytest.mark.asyncio
+    async def test_first_invalid_scope_in_list_is_reported(self) -> None:
+        """리스트 중 첫 invalid scope 가 raise 의 인자가 된다.
+
+        이후 invalid scope 가 더 있더라도 첫 번째에서 멈춘다(fail-fast).
+        """
+        from ante.member.service import MemberService
+
+        with pytest.raises(InvalidScopeError) as exc_info:
+            MemberService._assert_scopes_vocabulary(
+                ["audit:read", "oracle:invalid", "another:bad"]
+            )
+        assert exc_info.value.scope == "oracle:invalid"
+
+    def test_invalid_scope_error_is_value_error_subclass(self) -> None:
+        """``InvalidScopeError`` 가 ``ValueError`` 의 서브클래스인지 확인.
+
+        기존 ``except ValueError`` 핸들러가 fallthrough 로 동작하면서도, 별도
+        ``except InvalidScopeError`` 분기가 가능해야 한다(라우트 핸들러가
+        422 와 400/404 로 다르게 매핑하기 위함).
+        """
+        err = InvalidScopeError("oracle:invalid")
+        assert isinstance(err, ValueError)
+        assert err.scope == "oracle:invalid"
+
+
+# ── 4. CLI direct path 회귀 ─
+
+
+def _make_master_cli_member():  # noqa: ANN202
+    """CLI 인증 우회용 master Member (test_cli_member_non_interactive.py 패턴)."""
+    from ante.member.models import Member, MemberRole, MemberType
+
+    return Member(
+        member_id="master",
+        type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+        org="default",
+        name="Master",
+        status="active",
+        scopes=[],
+    )
+
+
+def _cli_invoke(args: list[str], service_mock):  # noqa: ANN001, ANN202
+    """CliRunner 로 ``ante`` group 실행. 인증을 모킹하고 ``_create_service`` 도 모킹."""
+    from unittest.mock import patch
+
+    from click.testing import CliRunner
+
+    from ante.cli.main import cli
+
+    master = _make_master_cli_member()
+
+    def _mock_authenticate(ctx) -> None:  # noqa: ANN001
+        ctx.obj["member"] = master
+
+    db_stub = type("DbStub", (), {"close": lambda self: _async_noop()})()
+
+    async def _factory():  # noqa: ANN202
+        return service_mock, db_stub
+
+    runner = CliRunner()
+    with (
+        patch("ante.cli.main.authenticate_member", side_effect=_mock_authenticate),
+        patch("ante.cli.commands.member._create_service", side_effect=_factory),
+    ):
+        return runner.invoke(
+            cli,
+            args,
+            obj={"member": master},
+            env={"ANTE_MEMBER_TOKEN": ""},
+            catch_exceptions=False,
+        )
+
+
+async def _async_noop() -> None:  # noqa: D401
+    """db.close coroutine stub."""
+    return None
+
+
+class TestCLIScopeVocabulary:
+    """``ante member register --scopes oracle:invalid`` 가 비-0 exit code 로
+    종료되는지 회귀(#1439).
+
+    CliRunner 로 인증과 ``_create_service`` 를 모킹한 뒤, service 가
+    ``InvalidScopeError`` 를 raise 했을 때 CLI 핸들러의
+    ``except InvalidScopeError`` 분기가 ``SystemExit(1)`` 으로 종료시키는지
+    잠근다. 기존 subprocess 방식은 인증 부재로 service 단계 도달 전에
+    종료되어 invariant 를 직접 잠그지 못했다.
+    """
+
+    def test_register_invalid_scope_exits_non_zero(self) -> None:
+        from unittest.mock import AsyncMock
+
+        service_mock = type(
+            "SvcStub",
+            (),
+            {"register": AsyncMock(side_effect=InvalidScopeError("oracle:invalid"))},
+        )()
+
+        result = _cli_invoke(
+            [
+                "member",
+                "register",
+                "--id",
+                "test-agent",
+                "--type",
+                "agent",
+                "--scopes",
+                "oracle:invalid",
+            ],
+            service_mock=service_mock,
+        )
+
+        assert result.exit_code != 0, (
+            f"CLI 가 invalid scope 에 대해 비-0 exit 해야 한다 — "
+            f"got exit_code={result.exit_code}\noutput={result.output!r}"
+        )
+        # service 까지 도달했는지 (defense-in-depth 회귀).
+        assert service_mock.register.await_count == 1
+
+    def test_register_valid_scope_success_returns_zero(self) -> None:
+        """valid scope 정상 path 회귀. invalid 차단이 valid 까지 막지 않는지."""
+        from unittest.mock import AsyncMock
+
+        from ante.member.models import MemberRole, MemberType
+
+        # mock 의 return_value 는 (Member, token) tuple.
+        service_mock = type(
+            "SvcStub",
+            (),
+            {
+                "register": AsyncMock(
+                    return_value=(
+                        type(
+                            "M",
+                            (),
+                            {
+                                "member_id": "test-agent",
+                                "type": MemberType.AGENT,
+                                "role": MemberRole.DEFAULT,
+                                "org": "default",
+                                "name": "test-agent",
+                            },
+                        )(),
+                        "ante_ak_test",
+                    )
+                )
+            },
+        )()
+
+        result = _cli_invoke(
+            [
+                "member",
+                "register",
+                "--id",
+                "test-agent",
+                "--type",
+                "agent",
+                "--scopes",
+                "audit:read",
+            ],
+            service_mock=service_mock,
+        )
+
+        assert result.exit_code == 0, (
+            f"valid scope 정상 path 는 exit 0 이어야 한다 — "
+            f"got exit_code={result.exit_code}\noutput={result.output!r}"
+        )
+
+    def test_invalid_scope_error_class_matches_cli_import(self) -> None:
+        """CLI 모듈이 ``InvalidScopeError`` 를 import 한 것과 동일 클래스인지.
+
+        ``except InvalidScopeError`` 분기가 매칭되려면 service 가 raise 하는
+        클래스와 CLI 가 catch 하는 클래스가 동일해야 한다 (회귀: re-export
+        misalignment 잠금).
+        """
+        from ante.cli.commands import member as cli_member
+        from ante.member import scopes as scopes_module
+
+        assert cli_member.InvalidScopeError is scopes_module.InvalidScopeError
+
+
+# ── 5. Vocabulary smoke 검증 ─
+
+
+class TestSCOPEVocabulary:
+    def test_vocabulary_is_frozenset(self) -> None:
+        """SSOT 타입 회귀. mutable set 로 바뀌면 import-time 변형 위험."""
+        assert isinstance(SCOPE_VOCABULARY, frozenset)
+
+    def test_vocabulary_size_matches_spec_doc(self) -> None:
+        """spec doc 매트릭스(L177-194) 의 valid cell 수 = 28.
+
+        Hard-coded 수치 회귀. 매트릭스 변경이 SCOPE_VOCABULARY 갱신 없이
+        merge 되는 케이스를 잠근다. 정밀 drift 검사는
+        ``test_member_scope_drift.py`` 가 수행한다.
+        """
+        assert len(SCOPE_VOCABULARY) == 28
+
+    @pytest.mark.parametrize(
+        "scope",
+        [
+            "account:read",
+            "account:write",
+            "strategy:read",
+            "strategy:write",
+            "data:read",
+            "data:write",
+            "report:read",
+            "report:write",
+            "config:read",
+            "config:write",
+            "approval:read",
+            "approval:write",
+            "approval:admin",
+            "bot:read",
+            "bot:admin",
+            "trade:read",
+            "treasury:read",
+            "treasury:admin",
+            "member:read",
+            "member:admin",
+            "system:read",
+            "system:admin",
+            "rule:read",
+            "rule:admin",
+            "broker:read",
+            "audit:read",
+            "notification:read",
+            "backtest:run",
+        ],
+    )
+    def test_each_expected_scope_present(self, scope: str) -> None:
+        """spec doc 매트릭스의 각 valid cell 이 vocabulary 에 등록되어 있는지."""
+        assert scope in SCOPE_VOCABULARY
+
+    def test_invalid_scopes_are_rejected(self) -> None:
+        """대표적인 invalid 케이스가 명시적으로 거부되는지."""
+        from ante.member.scopes import is_valid_scope
+
+        for bad in (
+            "oracle:invalid",
+            "invalid:write",
+            "audit:write",  # spec 에 없는 cell
+            "trade:admin",  # spec 에 없는 cell
+            "signal:read",  # signal 은 vocabulary 밖
+            "",
+            "audit",
+            "audit.read",
+            "Audit:Read",
+            " audit:read ",
+        ):
+            assert not is_valid_scope(bad), f"{bad!r} 가 vocabulary 에 포함되면 안 됨"
+
+    def test_json_roundtrip_preserves_vocabulary_membership(self) -> None:
+        """``json.dumps`` → ``json.loads`` 가 scope membership 을 보존하는지.
+
+        DB 직렬화 / Web body 파싱에서 인코딩 변환이 일어나도 vocabulary 매칭이
+        깨지지 않는다는 회귀.
+        """
+        all_scopes = sorted(SCOPE_VOCABULARY)
+        roundtripped = json.loads(json.dumps(all_scopes))
+        for scope in roundtripped:
+            assert scope in SCOPE_VOCABULARY

--- a/tests/unit/test_response_model_validation.py
+++ b/tests/unit/test_response_model_validation.py
@@ -1068,18 +1068,24 @@ class TestMemberResponseModels:
         assert model.ok is True
 
     def test_member_scopes_response(self):
-        """PUT /api/members/{member_id}/scopes."""
+        """PUT /api/members/{member_id}/scopes.
+
+        본 테스트는 response model 직렬화만 검증한다. scopes 값은
+        SCOPE_VOCABULARY (#1439, ``src/ante/member/scopes.py``) 에 포함된
+        valid 조합을 사용한다. 이전 fixture 의 ``trade:write`` 는 spec
+        매트릭스에 없는 invalid scope.
+        """
         data = {
             "member": {
                 "member_id": "agent-1",
                 "name": "에이전트",
                 "type": "agent",
                 "role": "agent",
-                "scopes": ["trade:read", "trade:write"],
+                "scopes": ["trade:read", "audit:read"],
             }
         }
         model = MemberScopesResponse.model_validate(data)
-        assert model.member.scopes == ["trade:read", "trade:write"]
+        assert model.member.scopes == ["trade:read", "audit:read"]
 
 
 # ── 감사 로그 라우트 응답 모델 ──────────────────────────


### PR DESCRIPTION
Closes #1439

## Summary
- 신규 `src/ante/member/scopes.py`: `SCOPE_VOCABULARY: frozenset[str]` (28개) + `InvalidScopeError` + `is_valid_scope`
- SSOT를 Member 모듈에 두어 Authorization SSOT spec 정합 (Web API deps.py는 import해 사용)
- `MemberCreateRequest.scopes` / `ScopesUpdateRequest.scopes` Pydantic field validator → invalid 422
- `MemberService.register/update_scopes` defense-in-depth → `InvalidScopeError`
- handler에서 `InvalidScopeError` → 422 매핑 (CLI direct path fallback)
- CLI `member register --scopes`는 service raise → `SystemExit(1)`
- spec ↔ code drift test: `docs/specs/member/02-design-decisions.md` 매트릭스 정규식 파싱 + SCOPE_VOCABULARY 일치 검증
- spec doc 갱신: SSOT 코드 위치 + drift test 명시

## Test Plan
- vocabulary 회귀 50개 + drift 3개 = 53 PASS
- `pytest -k 'member and (scope or vocabulary or invalid)'`: 110 PASS
- `pytest -k 'drift'`: 16 PASS
- 전체 unit suite: 4943 passed, 2 skipped
- ruff check/format clean
- frontend generate-types/check-api-types/build clean

## Codex Plan Review r1 피드백 (모두 반영)
1. SSOT 위치를 deps.py → member-owned module
2. spec doc full vocabulary 포함 (28개)
3. service defense-in-depth
4. CLI direct path 회귀 테스트
5. spec ↔ code drift test

## Codex Branch Review
- r1: PASS — 첫 시도 통과