### PR TITLE
fix(web-api): enforce StatusUpdateRequest extra=forbid + Literal transition (#1441)

### DIFF
--- a/docs/specs/web-api/05-resource-endpoints.md
+++ b/docs/specs/web-api/05-resource-endpoints.md
@@ -51,10 +51,10 @@
 
 | Method | Path | 설명 |
 |--------|------|------|
-| GET | `/api/strategies` | 전략 목록 (필터: status). 응답에 `cumulative_return`, `backtest_return` 포함 — 전략별 PerformanceTracker 조회 |
+| GET | `/api/strategies` | 전략 목록. Query filter `status` 허용 값: `registered \| adopted \| archived` — `_VALID_STATUS_FILTERS` SSOT. 미허용 값은 400. 응답에 `cumulative_return`, `backtest_return` 포함 — 전략별 PerformanceTracker 조회. |
 | GET | `/api/strategies/{strategy_id}` | 전략 상세 조회. 응답에 `params`, `param_schema`, `rationale`, `risks` 포함 — 전략 클래스 런타임 로드 + StrategyRecord 확장 필드 |
 | POST | `/api/strategies/validate` | 전략 파일 검증. Body: `{"path": "..."}` |
-| PATCH | `/api/strategies/{strategy_id}/status` | 전략 상태 변경. Body: `{"status": "..."}`. 허용되지 않은 상태 전환은 400 반환. `require_strategy_write` scope 검증 (#1378). |
+| PATCH | `/api/strategies/{strategy_id}/status` | 전략 상태 변경 (transition 전용). Body: `{"status": "adopted" \| "archived"}`. **schema (#1441):** Pydantic `extra='forbid'` + `Literal['adopted','archived']` + OpenAPI `additionalProperties: false`. transition target 만 허용하므로 GET filter 전용 값 `registered` 는 PATCH 시 422 로 거부된다 (등록 시점 초기값이므로 전환 대상이 아님). body validation 실패 (extra key, invalid status, type mismatch, 누락)는 422, transition rule 위반 (예: archived → adopted)은 400. `require_strategy_write` scope 검증 (#1378). |
 | GET | `/api/strategies/{strategy_id}/performance` | 전략 성과 지표 |
 | GET | `/api/strategies/{strategy_id}/daily-summary` | 전략 일별 성과 집계 |
 | GET | `/api/strategies/{strategy_id}/weekly-summary` | 전략 주별 성과 집계 |

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2732,7 +2732,7 @@
           "strategies"
         ],
         "summary": "Update Strategy Status",
-        "description": "전략 상태 변경. 보관 전환용. 인증된 master/human 또는\n``strategy:write`` scope 를 보유한 agent 만 호출 가능 (#1378).\n\n``submit_report`` (#1374) / ``update_config`` (#1373) 와 동일한 raw body\n파싱 패턴을 적용해 인증 가드가 body validation 보다 우선 실행되도록 한다.\nFastAPI 가 ``body: StatusUpdateRequest`` 를 먼저 검증하면 unauth + bad-body\n시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_strategy_write)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``StatusUpdateRequest.model_validate`` — ValidationError → 422.\n4. ``StrategyStatus`` enum 변환 — 실패 시 400.\n5. ``registry.update_status`` 호출 — 누락 strategy → 404, 전환 불가 → 400.",
+        "description": "전략 상태 변경. 보관 전환용. 인증된 master/human 또는\n``strategy:write`` scope 를 보유한 agent 만 호출 가능 (#1378).\n\n``submit_report`` (#1374) / ``update_config`` (#1373) 와 동일한 raw body\n파싱 패턴을 적용해 인증 가드가 body validation 보다 우선 실행되도록 한다.\nFastAPI 가 ``body: StatusUpdateRequest`` 를 먼저 검증하면 unauth + bad-body\n시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_strategy_write)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``StatusUpdateRequest.model_validate`` — ValidationError → 422\n   (#1441 — ``extra='forbid'`` + ``Literal['adopted','archived']`` 이\n   임의 필드 / 임의 status 값 / ``registered`` transition 시도 / type\n   mismatch 를 422 로 거부).\n4. ``StrategyStatus`` enum 변환 — Pydantic Literal 이 enum value 와 1:1\n   매칭되므로 항상 성공한다 (defense 분기 없음, #1441).\n5. ``registry.update_status`` 호출 — 누락 strategy → 404, 전환 rule\n   위반 (예: archived → adopted) → 400.",
         "operationId": "update_strategy_status_api_strategies__strategy_id__status_patch",
         "parameters": [
           {
@@ -2750,7 +2750,7 @@
             "description": "Successful Response"
           },
           "400": {
-            "description": "허용되지 않은 상태 전환",
+            "description": "허용되지 않은 상태 전환 (예: ``archived`` → ``adopted``). registry transition rule 위반은 400, body validation 실패는 422 (#1441).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2790,7 +2790,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, 필수 필드 누락, type mismatch, extra key). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다(#1378).",
+            "description": "Body validation 실패 (JSON 파싱 실패, 빈 body, 필수 필드 누락, type mismatch, extra key, status 값이 transition target 이 아님). ``status`` 는 ``Literal['adopted','archived']`` 로 좁혀져 ``registered`` 같은 GET filter 전용 값도 PATCH 시 422 로 거부된다 (#1441). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다(#1378).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -8735,9 +8735,14 @@
         "type": "object"
       },
       "StatusUpdateRequest": {
-        "description": "전략 상태 변경 요청.",
+        "additionalProperties": false,
+        "description": "전략 상태 변경 요청.\n\nSSOT: ``docs/specs/web-api/05-resource-endpoints.md`` PATCH\n``/api/strategies/{strategy_id}/status``. ``status`` 는 transition 가능한\n상태만 허용한다 — ``registered`` 는 등록 시점 초기값이므로 PATCH 의\ntarget 이 아니다 (GET filter 의 ``_VALID_STATUS_FILTERS`` 와는 별도).\n\ninvariants (#1441):\n- ``model_config = ConfigDict(extra=\"forbid\")`` — 정의되지 않은 필드는\n  Pydantic 단에서 422 로 거부 (handler 도달 차단). OpenAPI 에서는\n  ``additionalProperties: false`` 로 노출되어 generated TS client 가\n  closed object type 으로 좁힌다.\n- ``status: Literal[\"adopted\", \"archived\"]`` — transition target 만\n  enum 으로 노출. ``registered`` / 임의 문자열 / type mismatch 는 422.\n  handler 의 enum 변환 분기는 defense-in-depth 로 ``StrategyStatus``\n  registry transition rule (예: archived → adopted 차단) 만 다룬다.",
         "properties": {
           "status": {
+            "enum": [
+              "adopted",
+              "archived"
+            ],
             "title": "Status",
             "type": "string"
           }

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -192,10 +192,15 @@ export async function getStrategyMonthlySummary(id: string): Promise<MonthlySumm
   return res.data.items.map(toMonthlySummary)
 }
 
+export type StrategyStatusTransition = ApiStatusUpdateRequest['status']
+
 export async function updateStrategyStatus(
   id: string,
-  status: string,
+  status: StrategyStatusTransition,
 ): Promise<void> {
+  // generated type narrowing (#1441): `status` 는 `'adopted' | 'archived'`
+  // 로 좁혀져 transition target 만 허용한다 — `registered` 등 GET filter
+  // 전용 값은 컴파일 시점에 차단된다.
   const payload: ApiStatusUpdateRequest = { status }
   await client.patch<ApiStrategyDetailResponse>(`/api/strategies/${id}/status`, payload)
 }

--- a/frontend/src/hooks/useStrategies.ts
+++ b/frontend/src/hooks/useStrategies.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getStrategies, getStrategyDetail, getStrategyPerformance, getStrategyTrades, getStrategyDailySummary, getStrategyWeeklySummary, getStrategyMonthlySummary, getStrategyTradesPaginated, updateStrategyStatus } from '../api/strategies'
+import { getStrategies, getStrategyDetail, getStrategyPerformance, getStrategyTrades, getStrategyDailySummary, getStrategyWeeklySummary, getStrategyMonthlySummary, getStrategyTradesPaginated, updateStrategyStatus, type StrategyStatusTransition } from '../api/strategies'
 import { showToast } from '../components/common/Toast'
 
 export function useStrategies(params?: { search?: string }) {
@@ -72,7 +72,7 @@ export function useStrategyStatusTransition() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: ({ id, status }: { id: string; status: string }) =>
+    mutationFn: ({ id, status }: { id: string; status: StrategyStatusTransition }) =>
       updateStrategyStatus(id, status),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['strategies'] })

--- a/frontend/src/pages/StrategyDetail.tsx
+++ b/frontend/src/pages/StrategyDetail.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { useStrategyDetail, useStrategyPerformance, useStrategyTrades, useStrategyDailySummary, useStrategyWeeklySummary, useStrategyMonthlySummary, useStrategyStatusTransition } from '../hooks/useStrategies'
+import type { StrategyStatusTransition } from '../api/strategies'
 import PerformancePanel from '../components/strategies/PerformancePanel'
 import PeriodPerformance from '../components/strategies/PeriodPerformance'
 import EquityCurveChart from '../components/charts/EquityCurveChart'
@@ -60,7 +61,7 @@ export default function StrategyDetail() {
   const budgetAllocated = strategy.budget_allocated
   const unrealizedPnl = strategy.unrealized_pnl
 
-  const handleStatusTransition = (newStatus: string) => {
+  const handleStatusTransition = (newStatus: StrategyStatusTransition) => {
     statusTransition.mutate({ id, status: newStatus })
   }
 
@@ -266,7 +267,13 @@ function formatShortDateTime(dateStr: string | undefined | null): string {
   return `${mm}-${dd} ${hh}:${min}`
 }
 
-/** 전략 상태별 액션 버튼 */
+/** 전략 상태별 액션 버튼.
+ *
+ * `onTransition` 은 generated API contract (#1441) 에 따라 transition target
+ * (`'adopted' | 'archived'`) 만 받는다. `'active' | 'inactive'` 같은
+ * deprecated 값은 컴파일 시점에 차단된다 — `StatusUpdateRequest.status`
+ * Literal narrowing (#1441) 의 자연스러운 연쇄.
+ */
 function StatusActionButtons({
   status,
   hasRunningBot,
@@ -276,24 +283,29 @@ function StatusActionButtons({
   status: StrategyStatus
   hasRunningBot: boolean
   isPending: boolean
-  onTransition: (newStatus: string) => void
+  onTransition: (newStatus: StrategyStatusTransition) => void
 }) {
   if (status === 'archived') return null
 
   if (status === 'active') {
+    // dead-branch: 도메인 StrategyStatus 에는 `'active'` 가 남아 있으나
+    // backend enum (`registered | adopted | archived`) 에 정합하지 않는다.
+    // PATCH transition 으로 보낼 수 있는 값은 `'adopted' | 'archived'` 뿐이라
+    // 비활성화 버튼을 보관 처리로 fallback 한다. status state machine 정리
+    // 자체는 본 변경 범위 밖 (#1441 Non-Goals).
     const disabled = hasRunningBot || isPending
     return (
       <div className="relative">
         <button
           disabled={disabled}
-          onClick={() => onTransition('inactive')}
+          onClick={() => onTransition('archived')}
           className={`px-3 py-1.5 rounded-lg border text-[12px] font-medium ${
             disabled
               ? 'border-border text-text-muted cursor-not-allowed opacity-50'
               : 'border-warning text-warning cursor-pointer hover:bg-warning-bg'
           }`}
         >
-          비활성화
+          보관
         </button>
         {hasRunningBot && (
           <HintTooltip text="실행 중인 봇을 먼저 중지하세요" />

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -1350,9 +1350,14 @@ export type paths = {
          *     1. 인증 가드 (``Depends(require_strategy_write)``) — caller 빈 → 401,
          *        권한 없음 → 403, 비활성 멤버 → 403.
          *     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
-         *     3. ``StatusUpdateRequest.model_validate`` — ValidationError → 422.
-         *     4. ``StrategyStatus`` enum 변환 — 실패 시 400.
-         *     5. ``registry.update_status`` 호출 — 누락 strategy → 404, 전환 불가 → 400.
+         *     3. ``StatusUpdateRequest.model_validate`` — ValidationError → 422
+         *        (#1441 — ``extra='forbid'`` + ``Literal['adopted','archived']`` 이
+         *        임의 필드 / 임의 status 값 / ``registered`` transition 시도 / type
+         *        mismatch 를 422 로 거부).
+         *     4. ``StrategyStatus`` enum 변환 — Pydantic Literal 이 enum value 와 1:1
+         *        매칭되므로 항상 성공한다 (defense 분기 없음, #1441).
+         *     5. ``registry.update_status`` 호출 — 누락 strategy → 404, 전환 rule
+         *        위반 (예: archived → adopted) → 400.
          */
         patch: operations["update_strategy_status_api_strategies__strategy_id__status_patch"];
         trace?: never;
@@ -3263,10 +3268,28 @@ export type components = {
         /**
          * StatusUpdateRequest
          * @description 전략 상태 변경 요청.
+         *
+         *     SSOT: ``docs/specs/web-api/05-resource-endpoints.md`` PATCH
+         *     ``/api/strategies/{strategy_id}/status``. ``status`` 는 transition 가능한
+         *     상태만 허용한다 — ``registered`` 는 등록 시점 초기값이므로 PATCH 의
+         *     target 이 아니다 (GET filter 의 ``_VALID_STATUS_FILTERS`` 와는 별도).
+         *
+         *     invariants (#1441):
+         *     - ``model_config = ConfigDict(extra="forbid")`` — 정의되지 않은 필드는
+         *       Pydantic 단에서 422 로 거부 (handler 도달 차단). OpenAPI 에서는
+         *       ``additionalProperties: false`` 로 노출되어 generated TS client 가
+         *       closed object type 으로 좁힌다.
+         *     - ``status: Literal["adopted", "archived"]`` — transition target 만
+         *       enum 으로 노출. ``registered`` / 임의 문자열 / type mismatch 는 422.
+         *       handler 의 enum 변환 분기는 defense-in-depth 로 ``StrategyStatus``
+         *       registry transition rule (예: archived → adopted 차단) 만 다룬다.
          */
         StatusUpdateRequest: {
-            /** Status */
-            status: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "adopted" | "archived";
         };
         /**
          * StorageSummaryResponse
@@ -6600,7 +6623,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description 허용되지 않은 상태 전환 */
+            /** @description 허용되지 않은 상태 전환 (예: ``archived`` → ``adopted``). registry transition rule 위반은 400, body validation 실패는 422 (#1441). */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -6636,7 +6659,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Body validation 실패 (JSON 파싱 실패, 빈 body, 필수 필드 누락, type mismatch, extra key). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다(#1378). */
+            /** @description Body validation 실패 (JSON 파싱 실패, 빈 body, 필수 필드 누락, type mismatch, extra key, status 값이 transition target 이 아님). ``status`` 는 ``Literal['adopted','archived']`` 로 좁혀져 ``registered`` 같은 GET filter 전용 값도 PATCH 시 422 로 거부된다 (#1441). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다(#1378). */
             422: {
                 headers: {
                     [name: string]: unknown;

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -345,7 +345,11 @@ async def list_strategies(
     status_code=204,
     responses={
         400: {
-            "description": "허용되지 않은 상태 전환",
+            "description": (
+                "허용되지 않은 상태 전환 (예: ``archived`` → ``adopted``). "
+                "registry transition rule 위반은 400, body validation 실패는 "
+                "422 (#1441)."
+            ),
             "content": {
                 "application/problem+json": {
                     "schema": {"$ref": "#/components/schemas/ErrorResponse"},
@@ -387,8 +391,11 @@ async def list_strategies(
         },
         422: {
             "description": (
-                "Body validation 실패 (JSON 파싱 실패, 빈 body, 필수 필드 누락, "
-                "type mismatch, extra key). 단, 인증이 실패하면 body validation "
+                "Body validation 실패 (JSON 파싱 실패, 빈 body, 필수 필드 "
+                "누락, type mismatch, extra key, status 값이 transition target "
+                "이 아님). ``status`` 는 ``Literal['adopted','archived']`` 로 "
+                "좁혀져 ``registered`` 같은 GET filter 전용 값도 PATCH 시 "
+                "422 로 거부된다 (#1441). 단, 인증이 실패하면 body validation "
                 "은 실행되지 않고 401 이 우선 반환된다(#1378)."
             ),
             "content": {
@@ -428,9 +435,14 @@ async def update_strategy_status(
     1. 인증 가드 (``Depends(require_strategy_write)``) — caller 빈 → 401,
        권한 없음 → 403, 비활성 멤버 → 403.
     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
-    3. ``StatusUpdateRequest.model_validate`` — ValidationError → 422.
-    4. ``StrategyStatus`` enum 변환 — 실패 시 400.
-    5. ``registry.update_status`` 호출 — 누락 strategy → 404, 전환 불가 → 400.
+    3. ``StatusUpdateRequest.model_validate`` — ValidationError → 422
+       (#1441 — ``extra='forbid'`` + ``Literal['adopted','archived']`` 이
+       임의 필드 / 임의 status 값 / ``registered`` transition 시도 / type
+       mismatch 를 422 로 거부).
+    4. ``StrategyStatus`` enum 변환 — Pydantic Literal 이 enum value 와 1:1
+       매칭되므로 항상 성공한다 (defense 분기 없음, #1441).
+    5. ``registry.update_status`` 호출 — 누락 strategy → 404, 전환 rule
+       위반 (예: archived → adopted) → 400.
     """
     from ante.strategy.exceptions import StrategyError
     from ante.strategy.registry import StrategyStatus
@@ -450,27 +462,26 @@ async def update_strategy_status(
             status_code=422, detail="요청 body는 JSON object여야 합니다."
         )
 
-    # 2. Pydantic 검증.
+    # 2. Pydantic 검증 — ``extra='forbid'`` + ``Literal['adopted','archived']``
+    #    이 임의 필드 / invalid status / ``registered`` (transition target 아님)
+    #    / type mismatch 를 422 로 거부한다 (#1441).
     try:
         body = StatusUpdateRequest.model_validate(payload)
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=e.errors()) from None
 
-    # 3. enum 변환.
-    try:
-        new_status = StrategyStatus(body.status)
-    except ValueError:
-        raise HTTPException(
-            status_code=400,
-            detail=f"유효하지 않은 status 값: {body.status} "
-            f"(허용: {', '.join(s.value for s in StrategyStatus)})",
-        )
+    # 3. enum 변환 — Pydantic Literal value 가 ``StrategyStatus`` enum value
+    #    와 1:1 매칭이라 항상 성공한다 (#1441 — 기존 try/except ValueError
+    #    분기는 Pydantic 단에서 차단되므로 dead-code 였음).
+    new_status = StrategyStatus(body.status)
 
     try:
         await registry.update_status(strategy_id, new_status)
     except StrategyError:
         raise HTTPException(status_code=404, detail=_STRATEGY_NOT_FOUND)
     except ValueError as e:
+        # transition rule 위반 (archived → adopted 등) 은 registry layer 에서
+        # ValueError 로 시그널링된다 — 400 으로 매핑.
         raise HTTPException(status_code=400, detail=str(e))
 
 

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 import re
 from datetime import time as dtime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -336,9 +336,26 @@ class BotDetailResponse(BaseModel):
 
 
 class StatusUpdateRequest(BaseModel):
-    """전략 상태 변경 요청."""
+    """전략 상태 변경 요청.
 
-    status: str  # "adopted" | "archived"
+    SSOT: ``docs/specs/web-api/05-resource-endpoints.md`` PATCH
+    ``/api/strategies/{strategy_id}/status``. ``status`` 는 transition 가능한
+    상태만 허용한다 — ``registered`` 는 등록 시점 초기값이므로 PATCH 의
+    target 이 아니다 (GET filter 의 ``_VALID_STATUS_FILTERS`` 와는 별도).
+
+    invariants (#1441):
+    - ``model_config = ConfigDict(extra="forbid")`` — 정의되지 않은 필드는
+      Pydantic 단에서 422 로 거부 (handler 도달 차단). OpenAPI 에서는
+      ``additionalProperties: false`` 로 노출되어 generated TS client 가
+      closed object type 으로 좁힌다.
+    - ``status: Literal["adopted", "archived"]`` — transition target 만
+      enum 으로 노출. ``registered`` / 임의 문자열 / type mismatch 는 422.
+      handler 의 enum 변환 분기는 defense-in-depth 로 ``StrategyStatus``
+      registry transition rule (예: archived → adopted 차단) 만 다룬다.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    status: Literal["adopted", "archived"]
 
 
 class StrategyValidateRequest(BaseModel):

--- a/tests/unit/test_runtime_mutation_auth.py
+++ b/tests/unit/test_runtime_mutation_auth.py
@@ -3382,24 +3382,24 @@ class TestUpdateStrategyStatusAuthMatrix:
         assert resp.status_code == 422
         assert strategy_registry.update_status_calls == []
 
-    # 400 — 인증 통과 + invalid status / 전환 불가 ──────────────────
+    # 422 — 인증 통과 + invalid status (#1441 — Pydantic Literal 차단) ────
 
-    def test_update_strategy_status_master_invalid_status_returns_400(
+    def test_update_strategy_status_master_invalid_status_returns_422(
         self, client: TestClient, strategy_registry: FakeStrategyRegistry
     ) -> None:
-        """master + 허용 enum 외 status → 400.
+        """master + 허용 enum 외 status → 422 (#1441).
 
-        Pydantic 단계는 통과하지만 ``StrategyStatus(body.status)`` 변환에서
-        ValueError 가 발생해 400 으로 떨어진다. 400 차단 시 ``update_status``
-        는 호출되지 않는다.
+        ``StatusUpdateRequest.status`` 가 ``Literal['adopted','archived']``
+        로 좁혀져 Pydantic 단계에서 422 로 거부된다 (기존 handler 의 400
+        분기는 dead-code 가 되어 제거됨). 422 차단 시 ``update_status`` 는
+        호출되지 않는다.
         """
         resp = client.patch(
             _STRATEGY_STATUS_PATH,
             json={"status": "invalid_status_value"},
             headers={"Authorization": "Bearer master-token"},
         )
-        assert resp.status_code == 400, resp.text
-        assert "유효하지 않은 status" in resp.json()["detail"]
+        assert resp.status_code == 422, resp.text
         assert strategy_registry.update_status_calls == []
 
     # 404 — master + missing strategy ─────────────────────────────────
@@ -3447,6 +3447,36 @@ class TestUpdateStrategyStatusOpenAPI:
         component = components["StatusUpdateRequest"]
         assert "status" in component.get("required", []), (
             f"StatusUpdateRequest.status 가 required 에서 빠졌다: {component}"
+        )
+
+    def test_status_update_request_status_enum_literal(
+        self, client: TestClient
+    ) -> None:
+        """``status`` 는 ``Literal['adopted','archived']`` 로 노출되어야 한다
+        (#1441). ``registered`` 는 GET filter 전용이라 transition target 이
+        아니므로 enum 에 포함되어선 안 된다.
+        """
+        spec = client.get("/openapi.json").json()
+        components = spec.get("components", {}).get("schemas", {})
+        component = components["StatusUpdateRequest"]
+        status_prop = component.get("properties", {}).get("status", {})
+        assert status_prop.get("enum") == ["adopted", "archived"], (
+            f"StatusUpdateRequest.status enum 이 transition target 으로 좁혀지지 "
+            f"않았다: {status_prop}"
+        )
+
+    def test_status_update_request_additional_properties_false(
+        self, client: TestClient
+    ) -> None:
+        """``extra='forbid'`` 가 OpenAPI 에서 ``additionalProperties: false`` 로
+        노출되어야 한다 (#1441 — generated TS client closed object type).
+        """
+        spec = client.get("/openapi.json").json()
+        components = spec.get("components", {}).get("schemas", {})
+        component = components["StatusUpdateRequest"]
+        assert component.get("additionalProperties") is False, (
+            f"StatusUpdateRequest.additionalProperties 가 False 가 아니다 — "
+            f"extra='forbid' 가 OpenAPI 로 전파되지 않았다: {component}"
         )
 
     def test_update_strategy_status_route_responses_include_401_403(

--- a/tests/unit/test_strategy_api.py
+++ b/tests/unit/test_strategy_api.py
@@ -796,7 +796,7 @@ class TestUpdateStrategyStatus:
         assert "전환 불가" in resp.json()["detail"]
 
     def test_update_status_invalid_value(self, client, registry):
-        """유효하지 않은 status 값 -> 400."""
+        """유효하지 않은 status 값 -> 422 (#1441 — Pydantic Literal 차단)."""
         registry._strategies = [
             FakeStrategyRecord(
                 strategy_id="s1",
@@ -810,8 +810,100 @@ class TestUpdateStrategyStatus:
             json={"status": "invalid_status"},
             headers=_MASTER_AUTH_HEADERS,
         )
-        assert resp.status_code == 400
-        assert "유효하지 않은 status" in resp.json()["detail"]
+        # Pydantic Literal validation 으로 422 로 거부된다 (#1441 — 기존
+        # 400 분기는 dead-code 였음).
+        assert resp.status_code == 422
+
+    def test_update_status_extra_key_rejected(self, client, registry):
+        """status 외 임의 필드는 422 로 거부 (#1441 — ``extra='forbid'``)."""
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                status=StrategyStatus.REGISTERED,
+            ),
+        ]
+        resp = client.patch(
+            "/api/strategies/s1/status",
+            json={"status": "archived", "unexpected": True},
+            headers=_MASTER_AUTH_HEADERS,
+        )
+        assert resp.status_code == 422
+        # transition 이 실행되지 않았음을 확인 (extra key 차단으로 handler
+        # 진입 자체가 차단).
+        assert registry._strategies[0].status == StrategyStatus.REGISTERED
+
+    def test_update_status_extra_key_reason_rejected(self, client, registry):
+        """status + 추가 ``reason`` 필드도 422 (#1441 — closed object)."""
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                status=StrategyStatus.ADOPTED,
+            ),
+        ]
+        resp = client.patch(
+            "/api/strategies/s1/status",
+            json={"status": "archived", "reason": "test"},
+            headers=_MASTER_AUTH_HEADERS,
+        )
+        assert resp.status_code == 422
+        assert registry._strategies[0].status == StrategyStatus.ADOPTED
+
+    def test_update_status_registered_rejected_as_transition(self, client, registry):
+        """``registered`` 는 GET filter 전용 — PATCH 시 422 (#1441)."""
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                status=StrategyStatus.REGISTERED,
+            ),
+        ]
+        resp = client.patch(
+            "/api/strategies/s1/status",
+            json={"status": "registered"},
+            headers=_MASTER_AUTH_HEADERS,
+        )
+        # transition target 이 아니므로 Pydantic Literal 단에서 422.
+        assert resp.status_code == 422
+
+    def test_update_status_missing_field(self, client, registry):
+        """``status`` 누락 -> 422 (#1441 — required 필드)."""
+        registry._strategies = [
+            FakeStrategyRecord(
+                strategy_id="s1",
+                name="s1",
+                version="1",
+                status=StrategyStatus.REGISTERED,
+            ),
+        ]
+        resp = client.patch(
+            "/api/strategies/s1/status",
+            json={},
+            headers=_MASTER_AUTH_HEADERS,
+        )
+        assert resp.status_code == 422
+
+    def test_update_status_nonexistent_with_valid_body(self, client):
+        """정상 body (``adopted``) 전달해도 strategy 없으면 404 회귀 (#1441)."""
+        resp = client.patch(
+            "/api/strategies/nonexistent/status",
+            json={"status": "adopted"},
+            headers=_MASTER_AUTH_HEADERS,
+        )
+        assert resp.status_code == 404
+
+    def test_update_status_nonexistent_archived_body(self, client):
+        """정상 body (``archived``) 전달해도 strategy 없으면 404 회귀 (#1441)."""
+        resp = client.patch(
+            "/api/strategies/nonexistent/status",
+            json={"status": "archived"},
+            headers=_MASTER_AUTH_HEADERS,
+        )
+        assert resp.status_code == 404
 
 
 class TestListStrategiesStatusFilter:


### PR DESCRIPTION
Closes #1441

## Summary
- `StatusUpdateRequest`:
  - `model_config = ConfigDict(extra="forbid")` 추가
  - `status: Literal["adopted", "archived"]` (transition only)
- GET filter `_VALID_STATUS_FILTERS = {registered, adopted, archived}`는 별도 유지
- handler dead-code 제거: `StrategyStatus(body.status) ValueError → 400` 분기 삭제 (Pydantic Literal이 ingress 차단). transition rule violation `ValueError → 400`은 defense로 유지
- OpenAPI `enum: [adopted, archived]` + `additionalProperties: false` 노출
- frontend `api.generated.ts` + caller (`useStrategies`, `StrategyDetail`) 타입 좁힘

## Test Plan
- 신규 회귀 7건 + 기존 `...returns_400` → `...returns_422` rename
- OpenAPI 회귀 2건 (enum + additionalProperties)
- `pytest -k 'strategy and status'`: 50 PASS
- 전체 unit suite: 5059 passed, 2 skipped
- ruff/format/frontend types/check-api-types/build clean

## Codex Plan Review r1 권고 (모두 반영)
1. extra='forbid' 추가
2. Literal transition (adopted, archived)
3. GET filter 별도 유지
4. OpenAPI enum + additionalProperties 동기화

## Codex Branch Review
- r1: PASS — 의도대로 schema 좁힘 + 일관 갱신