### PR TITLE
fix(web-api): enforce HaltRequest/ClearHaltRequest extra=forbid (#1442)

### DIFF
--- a/docs/specs/web-api/04-system-endpoints.md
+++ b/docs/specs/web-api/04-system-endpoints.md
@@ -12,10 +12,10 @@
 |--------|------|------|
 | GET | `/api/system/status` | 시스템 상태 (status, version) |
 | GET | `/api/system/health` | 헬스체크. 응답 스키마는 아래 [헬스체크 상세](#헬스체크-상세-get-apisystemhealth) 참조 |
-| POST | `/api/system/halt` | 시스템 전역 정지. 모든 ACTIVE 계좌를 SUSPENDED로 전환. 파라미터: reason. 응답 shape은 아래 [Kill Switch 응답 SSOT](#kill-switch-응답-ssot-post-apisystemhalt--post-apisystemclear-halt) 참조 |
-| POST | `/api/system/clear-halt` | 시스템 전역 정지 해제. 모든 SUSPENDED 계좌를 ACTIVE로 복구한다. 계좌 상태만 복구하며 봇을 자동 재시작하지 않는다. 응답 shape은 아래 [Kill Switch 응답 SSOT](#kill-switch-응답-ssot-post-apisystemhalt--post-apisystemclear-halt) 참조 |
+| POST | `/api/system/halt` | 시스템 전역 정지. 모든 ACTIVE 계좌를 SUSPENDED로 전환. Body: `{"reason"?: string}` (전체 optional). **schema (#1442):** Pydantic `extra='forbid'` + OpenAPI `additionalProperties: false` — `account_id` 등 정의되지 않은 키는 422 로 거부된다 (silent drop 금지). 응답 shape은 아래 [Kill Switch 응답 SSOT](#kill-switch-응답-ssot-post-apisystemhalt--post-apisystemclear-halt) 참조 |
+| POST | `/api/system/clear-halt` | 시스템 전역 정지 해제. 모든 SUSPENDED 계좌를 ACTIVE로 복구한다. 계좌 상태만 복구하며 봇을 자동 재시작하지 않는다. Body: `{"reason"?: string}` (전체 optional). **schema (#1442):** Pydantic `extra='forbid'` + OpenAPI `additionalProperties: false` — `account_id` 등 정의되지 않은 키는 422 로 거부된다. 응답 shape은 아래 [Kill Switch 응답 SSOT](#kill-switch-응답-ssot-post-apisystemhalt--post-apisystemclear-halt) 참조 |
 
-> 단일 계좌 단위 정지/재개는 Account 모듈 엔드포인트(`POST /api/accounts/{id}/suspend` / `POST /api/accounts/{id}/activate`)를 사용한다. `/api/system/halt` / `/api/system/clear-halt`는 전역 편의 명령이며, 단일 계좌 파라미터를 받지 않는다.
+> 단일 계좌 단위 정지/재개는 Account 모듈 엔드포인트(`POST /api/accounts/{id}/suspend` / `POST /api/accounts/{id}/activate`)를 사용한다. `/api/system/halt` / `/api/system/clear-halt`는 **전역 kill switch** 이며 단일 계좌 파라미터를 받지 않는다 — body 에 `account_id` 를 포함시키면 422 로 거부된다 (#1442). account-scoped halt body 신규 도입은 별도 이슈에서 spec 갱신 후 다룬다.
 
 ## Kill Switch 응답 SSOT (`POST /api/system/halt` / `POST /api/system/clear-halt`)
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2490,7 +2490,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (malformed JSON, non-object JSON, type mismatch). 빈 body 는 기본 ``reason=\"\"`` 로 허용된다 (기존 동작 보존). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다 (#1375).",
+            "description": "Body validation 실패 (malformed JSON, non-object JSON, type mismatch, ``extra='forbid'`` 위반 — ``account_id`` 등 정의되지 않은 키 포함). 빈 body 는 기본 ``reason=\"\"`` 로 허용된다 (기존 동작 보존). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다 (#1375, #1442).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2562,7 +2562,7 @@
             }
           },
           "422": {
-            "description": "Body validation 실패 (malformed JSON, non-object JSON, type mismatch). 빈 body 는 기본 ``reason=\"\"`` 로 허용된다 (기존 동작 보존). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다 (#1375).",
+            "description": "Body validation 실패 (malformed JSON, non-object JSON, type mismatch, ``extra='forbid'`` 위반 — ``account_id`` 등 정의되지 않은 키 포함). 빈 body 는 기본 ``reason=\"\"`` 로 허용된다 (기존 동작 보존). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다 (#1375, #1442).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -8673,7 +8673,8 @@
         "type": "object"
       },
       "HaltRequest": {
-        "description": "거래 중지 요청.",
+        "additionalProperties": false,
+        "description": "거래 중지 요청.\n\nRefs #1442: ``extra='forbid'`` 로 ``account_id`` 등 임의 키를 422 로\n거부한다. ``/api/system/halt`` 는 전역 kill switch 이므로 account-scoped\n요청은 silent drop 이 아닌 명시적 거부가 옳다. 단일 계좌 정지는\n``POST /api/accounts/{id}/suspend`` 로 수행하며, account-scoped halt\nbody 신규 도입은 별도 이슈에서 다룬다.",
         "properties": {
           "reason": {
             "default": "",
@@ -8685,7 +8686,8 @@
         "type": "object"
       },
       "ClearHaltRequest": {
-        "description": "전역 정지 해제 요청.",
+        "additionalProperties": false,
+        "description": "전역 정지 해제 요청.\n\nRefs #1442: ``extra='forbid'`` 로 ``account_id`` 등 임의 키를 422 로\n거부한다. ``/api/system/clear-halt`` 는 전역 kill switch 이므로\naccount-scoped 요청은 silent drop 이 아닌 명시적 거부가 옳다. 단일 계좌\n재개는 ``POST /api/accounts/{id}/activate`` 로 수행한다.",
         "properties": {
           "reason": {
             "default": "",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2292,6 +2292,11 @@ export type components = {
         /**
          * ClearHaltRequest
          * @description 전역 정지 해제 요청.
+         *
+         *     Refs #1442: ``extra='forbid'`` 로 ``account_id`` 등 임의 키를 422 로
+         *     거부한다. ``/api/system/clear-halt`` 는 전역 kill switch 이므로
+         *     account-scoped 요청은 silent drop 이 아닌 명시적 거부가 옳다. 단일 계좌
+         *     재개는 ``POST /api/accounts/{id}/activate`` 로 수행한다.
          */
         ClearHaltRequest: {
             /**
@@ -2502,6 +2507,12 @@ export type components = {
         /**
          * HaltRequest
          * @description 거래 중지 요청.
+         *
+         *     Refs #1442: ``extra='forbid'`` 로 ``account_id`` 등 임의 키를 422 로
+         *     거부한다. ``/api/system/halt`` 는 전역 kill switch 이므로 account-scoped
+         *     요청은 silent drop 이 아닌 명시적 거부가 옳다. 단일 계좌 정지는
+         *     ``POST /api/accounts/{id}/suspend`` 로 수행하며, account-scoped halt
+         *     body 신규 도입은 별도 이슈에서 다룬다.
          */
         HaltRequest: {
             /**
@@ -6880,7 +6891,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Body validation 실패 (malformed JSON, non-object JSON, type mismatch). 빈 body 는 기본 ``reason=""`` 로 허용된다 (기존 동작 보존). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다 (#1375). */
+            /** @description Body validation 실패 (malformed JSON, non-object JSON, type mismatch, ``extra='forbid'`` 위반 — ``account_id`` 등 정의되지 않은 키 포함). 빈 body 는 기본 ``reason=""`` 로 허용된다 (기존 동작 보존). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다 (#1375, #1442). */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -6940,7 +6951,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Body validation 실패 (malformed JSON, non-object JSON, type mismatch). 빈 body 는 기본 ``reason=""`` 로 허용된다 (기존 동작 보존). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다 (#1375). */
+            /** @description Body validation 실패 (malformed JSON, non-object JSON, type mismatch, ``extra='forbid'`` 위반 — ``account_id`` 등 정의되지 않은 키 포함). 빈 body 는 기본 ``reason=""`` 로 허용된다 (기존 동작 보존). 단, 인증이 실패하면 body validation 은 실행되지 않고 401 이 우선 반환된다 (#1375, #1442). */
             422: {
                 headers: {
                     [name: string]: unknown;

--- a/src/ante/web/routes/system.py
+++ b/src/ante/web/routes/system.py
@@ -7,7 +7,7 @@ import logging
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from ante import __version__
 from ante.web.deps import (
@@ -30,13 +30,30 @@ router = APIRouter()
 
 
 class HaltRequest(BaseModel):
-    """거래 중지 요청."""
+    """거래 중지 요청.
+
+    Refs #1442: ``extra='forbid'`` 로 ``account_id`` 등 임의 키를 422 로
+    거부한다. ``/api/system/halt`` 는 전역 kill switch 이므로 account-scoped
+    요청은 silent drop 이 아닌 명시적 거부가 옳다. 단일 계좌 정지는
+    ``POST /api/accounts/{id}/suspend`` 로 수행하며, account-scoped halt
+    body 신규 도입은 별도 이슈에서 다룬다.
+    """
+
+    model_config = ConfigDict(extra="forbid")
 
     reason: str = ""
 
 
 class ClearHaltRequest(BaseModel):
-    """전역 정지 해제 요청."""
+    """전역 정지 해제 요청.
+
+    Refs #1442: ``extra='forbid'`` 로 ``account_id`` 등 임의 키를 422 로
+    거부한다. ``/api/system/clear-halt`` 는 전역 kill switch 이므로
+    account-scoped 요청은 silent drop 이 아닌 명시적 거부가 옳다. 단일 계좌
+    재개는 ``POST /api/accounts/{id}/activate`` 로 수행한다.
+    """
+
+    model_config = ConfigDict(extra="forbid")
 
     reason: str = ""
 
@@ -254,9 +271,10 @@ async def _parse_optional_request_body(
         422: {
             "description": (
                 "Body validation 실패 (malformed JSON, non-object JSON, type "
-                'mismatch). 빈 body 는 기본 ``reason=""`` 로 허용된다 (기존 '
+                "mismatch, ``extra='forbid'`` 위반 — ``account_id`` 등 정의되지 "
+                '않은 키 포함). 빈 body 는 기본 ``reason=""`` 로 허용된다 (기존 '
                 "동작 보존). 단, 인증이 실패하면 body validation 은 실행되지 "
-                "않고 401 이 우선 반환된다 (#1375)."
+                "않고 401 이 우선 반환된다 (#1375, #1442)."
             ),
             "content": {
                 "application/problem+json": {
@@ -358,9 +376,10 @@ async def halt(
         422: {
             "description": (
                 "Body validation 실패 (malformed JSON, non-object JSON, type "
-                'mismatch). 빈 body 는 기본 ``reason=""`` 로 허용된다 (기존 '
+                "mismatch, ``extra='forbid'`` 위반 — ``account_id`` 등 정의되지 "
+                '않은 키 포함). 빈 body 는 기본 ``reason=""`` 로 허용된다 (기존 '
                 "동작 보존). 단, 인증이 실패하면 body validation 은 실행되지 "
-                "않고 401 이 우선 반환된다 (#1375)."
+                "않고 401 이 우선 반환된다 (#1375, #1442)."
             ),
             "content": {
                 "application/problem+json": {

--- a/tests/unit/test_system_config_api.py
+++ b/tests/unit/test_system_config_api.py
@@ -274,6 +274,112 @@ class TestHaltClearHalt:
         )
         assert resp.status_code == 404
 
+    # ── #1442 HaltRequest / ClearHaltRequest extra='forbid' 회귀 ──────
+    #
+    # ``/api/system/halt`` 와 ``/api/system/clear-halt`` 는 전역 kill switch
+    # 이므로 ``account_id`` 등 임의 키를 body 에 받아 silent drop 하면 호출자
+    # 의도(예: 단일 계좌 정지)와 실제 동작(전역 정지)이 어긋난다. Pydantic
+    # ``model_config = ConfigDict(extra='forbid')`` 로 422 거부를 강제하고,
+    # 차단 시 ``suspend_all`` / ``activate_all`` 이 호출되지 않음을 검증한다.
+
+    def test_halt_rejects_account_id_extra_key(self, client, account_service):
+        """``account_id`` 포함 body → 422 + service no-call (#1442).
+
+        전역 kill switch 에 account-scoped body 를 흘려보내면 호출자 의도가
+        전역 동작과 어긋난다. ``extra='forbid'`` 로 명시적 거부한다.
+        """
+        resp = client.post(
+            "/api/system/halt",
+            json={"account_id": "domestic", "reason": "y"},
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 422
+        account_service.suspend_all.assert_not_called()
+
+    def test_clear_halt_rejects_account_id_extra_key(self, client, account_service):
+        """``account_id`` 포함 body → 422 + service no-call (#1442)."""
+        resp = client.post(
+            "/api/system/clear-halt",
+            json={"account_id": "domestic"},
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 422
+        account_service.activate_all.assert_not_called()
+
+    def test_halt_rejects_arbitrary_extra_key(self, client, account_service):
+        """임의 키 (``unexpected``) 포함 body → 422 (#1442 — closed object)."""
+        resp = client.post(
+            "/api/system/halt",
+            json={"unexpected": 1},
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 422
+        account_service.suspend_all.assert_not_called()
+
+    def test_clear_halt_rejects_arbitrary_extra_key(self, client, account_service):
+        """임의 키 포함 body → 422 (#1442 — closed object)."""
+        resp = client.post(
+            "/api/system/clear-halt",
+            json={"unexpected": 1},
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 422
+        account_service.activate_all.assert_not_called()
+
+    def test_halt_valid_reason_regression(self, client, account_service):
+        """정상 body (``{"reason": "valid"}``) → 200 회귀 (#1442)."""
+        resp = client.post(
+            "/api/system/halt",
+            json={"reason": "valid"},
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "halted"
+        account_service.suspend_all.assert_called_once()
+
+    def test_halt_empty_body_regression(self, client, account_service):
+        """빈 body (``{}``) → 200 회귀 (#1442 — ``reason`` default ``""``)."""
+        resp = client.post(
+            "/api/system/halt",
+            json={},
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "halted"
+        account_service.suspend_all.assert_called_once()
+
+    def test_clear_halt_valid_reason_regression(self, client, account_service):
+        """정상 body (``{"reason": "reset"}``) → 200 회귀 (#1442)."""
+        resp = client.post(
+            "/api/system/clear-halt",
+            json={"reason": "reset"},
+            headers=_MASTER_HEADERS,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "halt_cleared"
+        account_service.activate_all.assert_called_once()
+
+    def test_halt_request_openapi_additional_properties_false(self, client):
+        """OpenAPI ``HaltRequest.additionalProperties == False`` (#1442).
+
+        ``_install_openapi_customizer`` 가 ``components.schemas`` 에 등록한
+        ``HaltRequest`` schema 가 ``extra='forbid'`` 를 노출해야 frontend
+        generated client 가 closed object type 으로 좁혀진다.
+        """
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        schema = resp.json()
+        halt_schema = schema["components"]["schemas"]["HaltRequest"]
+        assert halt_schema.get("additionalProperties") is False
+
+    def test_clear_halt_request_openapi_additional_properties_false(self, client):
+        """OpenAPI ``ClearHaltRequest.additionalProperties == False`` (#1442)."""
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        schema = resp.json()
+        clear_schema = schema["components"]["schemas"]["ClearHaltRequest"]
+        assert clear_schema.get("additionalProperties") is False
+
 
 class TestDynamicConfig:
     def test_list_configs(self, client, dynamic_config):


### PR DESCRIPTION
Closes #1442

## Summary
- `HaltRequest` / `ClearHaltRequest`에 `model_config = ConfigDict(extra="forbid")` 추가
- `account_id` / 임의 extra key → 422 (service no-call)
- OpenAPI `additionalProperties: false` 노출
- spec doc 갱신: 전역 kill switch 강조, account-scoped halt는 신규 도입 시 별도 이슈

## Test Plan
- 신규 회귀 9건 (account_id/unexpected → 422 + service spy no-call, valid/empty body 정상)
- `pytest -k 'system and (halt or clear_halt)'`: 64 PASS
- 전체 unit suite: 5068 passed, 2 skipped
- ruff/format clean
- frontend types/check-api-types/build clean (closed object type)

## Codex Branch Review
- r1: PASS — 패턴은 #1436/#1441 동일

## 참고
- 이전 PR #1454는 잘못된 head ref로 close됨