### PR TITLE
fix(web-api,bot): enforce runtime control range on BotUpdateRequest/BotConfig (#1456)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -8472,28 +8472,36 @@
               "integer",
               "null"
             ],
-            "description": "재시작 최대 시도 횟수."
+            "minimum": 1,
+            "maximum": 10,
+            "description": "재시작 최대 시도 횟수. spec 범위 1~10 외 값은 422 (docs/dashboard/user-stories/bots.md B-5, #1456)."
           },
           "restart_cooldown_seconds": {
             "type": [
               "integer",
               "null"
             ],
-            "description": "재시작 쿨다운(초)."
+            "minimum": 10,
+            "maximum": 600,
+            "description": "재시작 쿨다운(초). spec 범위 10~600 외 값은 422 (docs/dashboard/user-stories/bots.md B-5, #1456)."
           },
           "step_timeout_seconds": {
             "type": [
               "integer",
               "null"
             ],
-            "description": "step 타임아웃(초)."
+            "minimum": 5,
+            "maximum": 120,
+            "description": "step 타임아웃(초). spec 범위 5~120 외 값은 422 (docs/dashboard/user-stories/bots.md B-5, #1456)."
           },
           "max_signals_per_step": {
             "type": [
               "integer",
               "null"
             ],
-            "description": "step당 최대 signal 수."
+            "minimum": 1,
+            "maximum": 200,
+            "description": "step당 최대 signal 수. spec 범위 1~200 외 값은 422 (docs/dashboard/user-stories/bots.md B-5, #1456)."
           }
         }
       },

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2208,15 +2208,15 @@ export type components = {
             budget?: number | null;
             /** @description 봇 step 주기 (초). */
             interval_seconds?: number | null;
-            /** @description 재시작 최대 시도 횟수. */
+            /** @description 재시작 최대 시도 횟수. spec 범위 1~10 외 값은 422 (docs/dashboard/user-stories/bots.md B-5, #1456). */
             max_restart_attempts?: number | null;
-            /** @description step당 최대 signal 수. */
+            /** @description step당 최대 signal 수. spec 범위 1~200 외 값은 422 (docs/dashboard/user-stories/bots.md B-5, #1456). */
             max_signals_per_step?: number | null;
             /** @description 사용자에게 표시되는 봇 이름. */
             name?: string | null;
-            /** @description 재시작 쿨다운(초). */
+            /** @description 재시작 쿨다운(초). spec 범위 10~600 외 값은 422 (docs/dashboard/user-stories/bots.md B-5, #1456). */
             restart_cooldown_seconds?: number | null;
-            /** @description step 타임아웃(초). */
+            /** @description step 타임아웃(초). spec 범위 5~120 외 값은 422 (docs/dashboard/user-stories/bots.md B-5, #1456). */
             step_timeout_seconds?: number | null;
             /** @description 변경할 전략 이름. 최신 버전의 strategy_id로 자동 변환된다. */
             strategy_name?: string | null;

--- a/src/ante/bot/config.py
+++ b/src/ante/bot/config.py
@@ -23,6 +23,19 @@ class BotStatus(StrEnum):
 MIN_INTERVAL_SECONDS = 10
 MAX_INTERVAL_SECONDS = 3600
 
+# Runtime control 범위 (#1456 — ``docs/dashboard/user-stories/bots.md`` B-5
+# line 197-200 SSOT, ``docs/specs/web-api/05-resource-endpoints.md`` PUT
+# ``/api/bots/{bot_id}`` body contract). 범위 밖 값은 PUT 단계에서 422,
+# ``BotConfig`` 직접 생성 단계에서 ``ValueError`` 로 거부된다.
+MIN_MAX_RESTART_ATTEMPTS = 1
+MAX_MAX_RESTART_ATTEMPTS = 10
+MIN_RESTART_COOLDOWN_SECONDS = 10
+MAX_RESTART_COOLDOWN_SECONDS = 600
+MIN_STEP_TIMEOUT_SECONDS = 5
+MAX_STEP_TIMEOUT_SECONDS = 120
+MIN_MAX_SIGNALS_PER_STEP = 1
+MAX_MAX_SIGNALS_PER_STEP = 200
+
 
 @dataclass
 class BotConfig:
@@ -30,6 +43,13 @@ class BotConfig:
 
     ``account_id`` 는 봇 생성 진입점에서 검증된다 (#1217 → #1241 SPLIT-2).
     fallback (`""`, ``None``, ``"default"``) 또는 형식 위반 값은 거부된다.
+
+    runtime control 4개 필드 (``max_restart_attempts``,
+    ``restart_cooldown_seconds``, ``step_timeout_seconds``,
+    ``max_signals_per_step``) 는 ``docs/dashboard/user-stories/bots.md`` B-5
+    line 197-200 spec 범위 내에서만 허용된다 (#1456). 범위 밖 값은
+    ``ValueError`` 로 거부되어 ``update_bot`` (manager.py:340) 의 재구성
+    경로에서도 동일하게 차단된다.
     """
 
     bot_id: str
@@ -48,6 +68,12 @@ class BotConfig:
         # ``InvalidAccountIdError`` 가 raise 되어 호출자에 전달된다.
         self.account_id = require_account_id(self.account_id, context="BotConfig")
         validate_interval(self.interval_seconds)
+        validate_runtime_controls(
+            max_restart_attempts=self.max_restart_attempts,
+            restart_cooldown_seconds=self.restart_cooldown_seconds,
+            step_timeout_seconds=self.step_timeout_seconds,
+            max_signals_per_step=self.max_signals_per_step,
+        )
 
 
 def validate_interval(interval: int) -> None:
@@ -57,4 +83,59 @@ def validate_interval(interval: int) -> None:
             f"실행 간격은 {MIN_INTERVAL_SECONDS}초 이상 "
             f"{MAX_INTERVAL_SECONDS}초 이하여야 합니다. "
             f"(입력값: {interval}초)"
+        )
+
+
+def validate_runtime_controls(
+    *,
+    max_restart_attempts: int,
+    restart_cooldown_seconds: int,
+    step_timeout_seconds: int,
+    max_signals_per_step: int,
+) -> None:
+    """Runtime control 4개 필드 범위 검증. 범위 밖이면 ``ValueError`` (#1456).
+
+    SSOT: ``docs/dashboard/user-stories/bots.md`` B-5 line 197-200.
+
+    메시지 포맷은 ``validate_interval`` 과 동일한 ``<필드 이름>은 <min>...
+    <max> ... 이하여야 합니다. (입력값: <value>)`` 구조를 따른다. PUT
+    핸들러는 ``BotUpdateRequest`` Pydantic 검증으로 422 를 먼저 반환하므로,
+    이 함수는 ``BotConfig`` 직접 생성 경로 (``update_bot`` 재구성,
+    bootstrap, IPC registry 등) 의 invariant 만 담당한다.
+    """
+    if (
+        max_restart_attempts < MIN_MAX_RESTART_ATTEMPTS
+        or max_restart_attempts > MAX_MAX_RESTART_ATTEMPTS
+    ):
+        raise ValueError(
+            f"max_restart_attempts는 {MIN_MAX_RESTART_ATTEMPTS} 이상 "
+            f"{MAX_MAX_RESTART_ATTEMPTS} 이하여야 합니다. "
+            f"(입력값: {max_restart_attempts})"
+        )
+    if (
+        restart_cooldown_seconds < MIN_RESTART_COOLDOWN_SECONDS
+        or restart_cooldown_seconds > MAX_RESTART_COOLDOWN_SECONDS
+    ):
+        raise ValueError(
+            f"restart_cooldown_seconds는 {MIN_RESTART_COOLDOWN_SECONDS}초 이상 "
+            f"{MAX_RESTART_COOLDOWN_SECONDS}초 이하여야 합니다. "
+            f"(입력값: {restart_cooldown_seconds}초)"
+        )
+    if (
+        step_timeout_seconds < MIN_STEP_TIMEOUT_SECONDS
+        or step_timeout_seconds > MAX_STEP_TIMEOUT_SECONDS
+    ):
+        raise ValueError(
+            f"step_timeout_seconds는 {MIN_STEP_TIMEOUT_SECONDS}초 이상 "
+            f"{MAX_STEP_TIMEOUT_SECONDS}초 이하여야 합니다. "
+            f"(입력값: {step_timeout_seconds}초)"
+        )
+    if (
+        max_signals_per_step < MIN_MAX_SIGNALS_PER_STEP
+        or max_signals_per_step > MAX_MAX_SIGNALS_PER_STEP
+    ):
+        raise ValueError(
+            f"max_signals_per_step는 {MIN_MAX_SIGNALS_PER_STEP} 이상 "
+            f"{MAX_MAX_SIGNALS_PER_STEP} 이하여야 합니다. "
+            f"(입력값: {max_signals_per_step})"
         )

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -43,6 +43,17 @@ CREATE INDEX IF NOT EXISTS idx_bots_account_id ON bots(account_id);
 """
 
 
+async def _cooldown_sleep(seconds: float) -> None:
+    """BotManager 재시작/리셋 cooldown 전용 sleep.
+
+    Bot._run_loop 등 다른 sleep 경로에 영향을 주지 않고 monkeypatch 할 수
+    있도록 분리한 helper. 운영 환경에서는 ``asyncio.sleep`` 과 동일하게
+    동작하지만, 테스트에서는 이 심볼만 패치하여 cooldown 만 0초로 압축한다.
+    """
+
+    await asyncio.sleep(seconds)
+
+
 class BotManager:
     """봇들의 생명주기를 중앙 관리."""
 
@@ -776,7 +787,7 @@ class BotManager:
             return
 
         try:
-            await asyncio.sleep(bot.config.restart_cooldown_seconds)
+            await _cooldown_sleep(bot.config.restart_cooldown_seconds)
         except asyncio.CancelledError:
             raise
 
@@ -815,7 +826,7 @@ class BotManager:
     async def _reset_restart_count_after(self, bot_id: str, seconds: float) -> None:
         """일정 시간 정상 실행 후 재시작 카운터 초기화."""
         try:
-            await asyncio.sleep(seconds)
+            await _cooldown_sleep(seconds)
         except asyncio.CancelledError:
             raise
 

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -948,19 +948,39 @@ BOT_UPDATE_REQUEST_SCHEMA: dict[str, Any] = {
         },
         "max_restart_attempts": {
             "type": ["integer", "null"],
-            "description": "재시작 최대 시도 횟수.",
+            "minimum": 1,
+            "maximum": 10,
+            "description": (
+                "재시작 최대 시도 횟수. spec 범위 1~10 외 값은 422 "
+                "(docs/dashboard/user-stories/bots.md B-5, #1456)."
+            ),
         },
         "restart_cooldown_seconds": {
             "type": ["integer", "null"],
-            "description": "재시작 쿨다운(초).",
+            "minimum": 10,
+            "maximum": 600,
+            "description": (
+                "재시작 쿨다운(초). spec 범위 10~600 외 값은 422 "
+                "(docs/dashboard/user-stories/bots.md B-5, #1456)."
+            ),
         },
         "step_timeout_seconds": {
             "type": ["integer", "null"],
-            "description": "step 타임아웃(초).",
+            "minimum": 5,
+            "maximum": 120,
+            "description": (
+                "step 타임아웃(초). spec 범위 5~120 외 값은 422 "
+                "(docs/dashboard/user-stories/bots.md B-5, #1456)."
+            ),
         },
         "max_signals_per_step": {
             "type": ["integer", "null"],
-            "description": "step당 최대 signal 수.",
+            "minimum": 1,
+            "maximum": 200,
+            "description": (
+                "step당 최대 signal 수. spec 범위 1~200 외 값은 422 "
+                "(docs/dashboard/user-stories/bots.md B-5, #1456)."
+            ),
         },
     },
 }

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -304,6 +304,13 @@ class BotUpdateRequest(BaseModel):
     OpenAPI ``BOT_UPDATE_REQUEST_SCHEMA``는 ``additionalProperties: false``를
     선언한다. 런타임 모델도 ``extra="forbid"``로 동일하게 강제해 OpenAPI
     contract와 동작을 일치시킨다(#1352 — Codex Plan Review).
+
+    runtime control 4개 필드 (``max_restart_attempts``,
+    ``restart_cooldown_seconds``, ``step_timeout_seconds``,
+    ``max_signals_per_step``) 는 ``docs/dashboard/user-stories/bots.md``
+    B-5 line 197-200 spec 범위 안에서만 허용된다 (#1456). 범위 밖 값은
+    ``ValidationError`` 로 거부되어 PUT 핸들러에서 422 가 반환된다.
+    ``BotConfig`` 단의 ``validate_runtime_controls`` 와 정합한다.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -313,10 +320,10 @@ class BotUpdateRequest(BaseModel):
     interval_seconds: int | None = Field(default=None, ge=10, le=3600)
     budget: float | None = Field(default=None, gt=0, allow_inf_nan=False)
     auto_restart: bool | None = None
-    max_restart_attempts: int | None = None
-    restart_cooldown_seconds: int | None = None
-    step_timeout_seconds: int | None = None
-    max_signals_per_step: int | None = None
+    max_restart_attempts: int | None = Field(default=None, ge=1, le=10)
+    restart_cooldown_seconds: int | None = Field(default=None, ge=10, le=600)
+    step_timeout_seconds: int | None = Field(default=None, ge=5, le=120)
+    max_signals_per_step: int | None = Field(default=None, ge=1, le=200)
 
 
 class BotListResponse(BaseModel):

--- a/tests/unit/test_bot_guard.py
+++ b/tests/unit/test_bot_guard.py
@@ -51,14 +51,26 @@ def _make_bot(
     max_signals: int = 50,
     interval: int = 10,
 ) -> Bot:
+    """테스트용 Bot 생성.
+
+    BotConfig 는 spec 범위 (#1456: ``step_timeout_seconds`` 5~120,
+    ``max_signals_per_step`` 1~200) 안의 값으로 만든 뒤 ``step_timeout``
+    이 spec 범위 밖이면 인스턴스 attribute 를 swap 해서 runtime 비교
+    임계값만 mutate 한다 — invariant validation 은 spec 통과값으로
+    통과시키고, 실제 ``asyncio.wait_for`` timeout 비교는 caller 가 준 짧은
+    값으로 강제한다.
+    """
     config = BotConfig(
         bot_id="bot-test",
         strategy_id="stg-test",
         account_id="acc-test",
         interval_seconds=interval,
-        step_timeout_seconds=step_timeout,
+        step_timeout_seconds=max(step_timeout, 5),
         max_signals_per_step=max_signals,
     )
+    if step_timeout < 5:
+        # 검증 통과 후 짧은 값으로 swap 하여 테스트의 timeout 분기 강제.
+        config.step_timeout_seconds = step_timeout
     ctx = MagicMock()
     ctx.get_positions.return_value = {}
     ctx.get_balance.return_value = {"available": 1000000.0}

--- a/tests/unit/test_bot_restart.py
+++ b/tests/unit/test_bot_restart.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ante.bot import manager as bot_manager_module
 from ante.bot.config import BotConfig, BotStatus
 from ante.bot.manager import BotManager
 from ante.core import Database
@@ -33,6 +34,42 @@ async def manager(eventbus, db):
     mgr = BotManager(eventbus=eventbus, db=db)
     await mgr.initialize()
     return mgr
+
+
+@pytest.fixture
+def _fast_restart_cooldown(monkeypatch):
+    """``BotManager`` 내부 cooldown / reset_after sleep 만 0 으로 압축.
+
+    #1456 이전에는 테스트 헬퍼가 ``restart_cooldown_seconds=0`` 으로
+    BotConfig 를 만들어 sleep 시간을 0초로 압축했다. 1456 에서 spec 범위
+    (10~600초) 외 값을 ``ValueError`` 로 막으면서 sleep 회피 책임이 테스트
+    인프라로 옮겨졌다.
+
+    ``manager.py`` 내부 cooldown / reset_after sleep 두 군데만 wrapping
+    한다. 테스트 자체의 ``await asyncio.sleep(0.05)`` (task scheduling
+    대기) 는 그대로 두기 위해 ``asyncio.sleep`` 자체가 아니라 ``manager``
+    내부 sleep wrapper 로 limit 한다.
+
+    구현 방식: ``BotManager._restart_after_cooldown`` 과
+    ``_reset_restart_count_after`` 가 호출하는 ``asyncio.sleep`` 의 인자
+    크기를 보고 1초 이상이면 0 으로 축소, 그 외(0~1초)는 그대로. 큰
+    cooldown 만 압축하고 작은 즉시 sleep 은 영향 없다.
+
+    Note: ``bot_manager_module.asyncio.sleep`` 을 monkeypatch 하면
+    ``asyncio.sleep`` 글로벌이 swap 된다. fixture scope 안에서만 적용되며,
+    ``await asyncio.sleep(0.05)`` 처럼 작은 값은 wrapper 가 그대로 통과
+    시키므로 부작용 없다.
+    """
+
+    _real_sleep = asyncio.sleep
+
+    async def _maybe_short(seconds, *args, **kwargs):
+        # 1초 이상의 sleep 만 0 으로 압축. 그 외(테스트의 0.05 등)는 그대로.
+        target = 0 if isinstance(seconds, (int, float)) and seconds >= 1 else seconds
+        await _real_sleep(target, *args, **kwargs)
+
+    monkeypatch.setattr(bot_manager_module.asyncio, "sleep", _maybe_short)
+    return _maybe_short
 
 
 def _make_strategy_cls():
@@ -76,12 +113,18 @@ class TestBotConfigRestartPolicy:
 
 
 class TestBotAutoRestart:
-    async def test_restart_on_error(self, manager, eventbus):
-        """BotErrorEvent 수신 시 재시작 예약."""
+    async def test_restart_on_error(self, manager, eventbus, _fast_restart_cooldown):
+        """BotErrorEvent 수신 시 재시작 예약.
+
+        #1456 이전에는 ``restart_cooldown_seconds=0`` 으로 sleep 시간을
+        압축했지만, spec 범위(10~600) 외 값은 ``BotConfig`` 단에서
+        ``ValueError`` 가 된다. spec 통과값 10 을 쓰면서 sleep 자체는
+        ``_fast_restart_cooldown`` fixture 가 0 으로 교체한다.
+        """
         config = BotConfig(
             bot_id="b1",
             strategy_id="s1",
-            restart_cooldown_seconds=0,
+            restart_cooldown_seconds=10,
             max_restart_attempts=3,
             account_id="acc-test",
         )
@@ -96,9 +139,9 @@ class TestBotAutoRestart:
         await eventbus.publish(
             BotErrorEvent(bot_id="b1", error_message="test", account_id="acc-test")
         )
-        await asyncio.sleep(0.05)  # cooldown=0 + task 실행 대기
+        await asyncio.sleep(0.05)  # monkeypatched sleep + task 스케줄 대기
 
-        # 재시작 성공 확인 (카운터는 reset_after=0이므로 이미 리셋될 수 있음)
+        # 재시작 성공 확인 (sleep 0초 → 즉시 reset_restart_count 도 0초로 수렴)
         assert bot.status == BotStatus.RUNNING
 
     async def test_no_restart_when_disabled(self, manager, eventbus):
@@ -117,13 +160,13 @@ class TestBotAutoRestart:
         assert bot.status == BotStatus.ERROR
         assert manager.get_restart_count("b1") == 0
 
-    async def test_restart_exhausted(self, manager, eventbus):
+    async def test_restart_exhausted(self, manager, eventbus, _fast_restart_cooldown):
         """max_restart_attempts 초과 시 BotRestartExhaustedEvent."""
         config = BotConfig(
             bot_id="b1",
             strategy_id="s1",
             max_restart_attempts=2,
-            restart_cooldown_seconds=0,
+            restart_cooldown_seconds=10,
             account_id="acc-test",
         )
         bot = await manager.create_bot(config, _make_strategy_cls(), ctx=MagicMock())
@@ -145,13 +188,15 @@ class TestBotAutoRestart:
         assert exhausted[0].account_id == "acc-test"
         assert exhausted[0].restart_attempts == 2
 
-    async def test_restart_count_increments(self, manager, eventbus):
+    async def test_restart_count_increments(
+        self, manager, eventbus, _fast_restart_cooldown
+    ):
         """재시작마다 카운트 증가."""
         config = BotConfig(
             bot_id="b1",
             strategy_id="s1",
             max_restart_attempts=5,
-            restart_cooldown_seconds=0,
+            restart_cooldown_seconds=10,
             account_id="acc-test",
         )
         ctx = MagicMock()
@@ -167,7 +212,7 @@ class TestBotAutoRestart:
             BotErrorEvent(bot_id="b1", error_message="e1", account_id="acc-test")
         )
         await asyncio.sleep(0.05)
-        # cooldown=0 → reset_after=0, 카운터 즉시 리셋 가능
+        # _fast_restart_cooldown 으로 sleep 0초 → reset_after 도 0초 분기 즉시 리셋
         assert bot.status == BotStatus.RUNNING
 
         # 두 번째 에러 → 재시작
@@ -190,13 +235,15 @@ class TestBotAutoRestart:
 
 
 class TestRestartCounterReset:
-    async def test_counter_resets_after_stable_period(self, manager, eventbus):
+    async def test_counter_resets_after_stable_period(
+        self, manager, eventbus, _fast_restart_cooldown
+    ):
         """정상 실행 유지 시 카운터 리셋."""
         config = BotConfig(
             bot_id="b1",
             strategy_id="s1",
             max_restart_attempts=3,
-            restart_cooldown_seconds=0,
+            restart_cooldown_seconds=10,
             account_id="acc-test",
         )
         ctx = MagicMock()
@@ -213,17 +260,19 @@ class TestRestartCounterReset:
         )
         await asyncio.sleep(0.05)
 
-        # reset_after = 0 * 3 = 0초이므로 재시작 성공 직후 카운터가 즉시 리셋됨
+        # _fast_restart_cooldown → reset_after 도 0초 분기 → 재시작 후 카운터 리셋
         assert bot.status == BotStatus.RUNNING
         assert manager.get_restart_count("b1") == 0
 
-    async def test_counter_not_reset_if_bot_stopped(self, manager, eventbus):
+    async def test_counter_not_reset_if_bot_stopped(
+        self, manager, eventbus, _fast_restart_cooldown
+    ):
         """봇이 중지된 경우 카운터 리셋하지 않음."""
         config = BotConfig(
             bot_id="b1",
             strategy_id="s1",
             max_restart_attempts=3,
-            restart_cooldown_seconds=0,
+            restart_cooldown_seconds=10,
             account_id="acc-test",
         )
         ctx = MagicMock()

--- a/tests/unit/test_bot_restart.py
+++ b/tests/unit/test_bot_restart.py
@@ -45,31 +45,19 @@ def _fast_restart_cooldown(monkeypatch):
     (10~600초) 외 값을 ``ValueError`` 로 막으면서 sleep 회피 책임이 테스트
     인프라로 옮겨졌다.
 
-    ``manager.py`` 내부 cooldown / reset_after sleep 두 군데만 wrapping
-    한다. 테스트 자체의 ``await asyncio.sleep(0.05)`` (task scheduling
-    대기) 는 그대로 두기 위해 ``asyncio.sleep`` 자체가 아니라 ``manager``
-    내부 sleep wrapper 로 limit 한다.
-
-    구현 방식: ``BotManager._restart_after_cooldown`` 과
-    ``_reset_restart_count_after`` 가 호출하는 ``asyncio.sleep`` 의 인자
-    크기를 보고 1초 이상이면 0 으로 축소, 그 외(0~1초)는 그대로. 큰
-    cooldown 만 압축하고 작은 즉시 sleep 은 영향 없다.
-
-    Note: ``bot_manager_module.asyncio.sleep`` 을 monkeypatch 하면
-    ``asyncio.sleep`` 글로벌이 swap 된다. fixture scope 안에서만 적용되며,
-    ``await asyncio.sleep(0.05)`` 처럼 작은 값은 wrapper 가 그대로 통과
-    시키므로 부작용 없다.
+    ``manager._cooldown_sleep`` 만 0초 sleep 으로 교체한다. 이 helper 는
+    ``_restart_after_cooldown`` 과 ``_reset_restart_count_after`` 두 곳에서만
+    사용하므로 ``Bot._run_loop`` 의 ``asyncio.sleep(interval_seconds)`` 등
+    다른 sleep 경로에는 영향이 없다. (#1456 codex review P2)
     """
 
-    _real_sleep = asyncio.sleep
+    async def _no_sleep(seconds):  # noqa: ARG001 — 의도적 매개변수 무시
+        # cooldown 자체를 즉시 종료. task scheduling 대기는 테스트 본문의
+        # ``await asyncio.sleep(0.05)`` 가 담당한다.
+        await asyncio.sleep(0)
 
-    async def _maybe_short(seconds, *args, **kwargs):
-        # 1초 이상의 sleep 만 0 으로 압축. 그 외(테스트의 0.05 등)는 그대로.
-        target = 0 if isinstance(seconds, (int, float)) and seconds >= 1 else seconds
-        await _real_sleep(target, *args, **kwargs)
-
-    monkeypatch.setattr(bot_manager_module.asyncio, "sleep", _maybe_short)
-    return _maybe_short
+    monkeypatch.setattr(bot_manager_module, "_cooldown_sleep", _no_sleep)
+    return _no_sleep
 
 
 def _make_strategy_cls():

--- a/tests/unit/test_bot_runtime_controls_validation.py
+++ b/tests/unit/test_bot_runtime_controls_validation.py
@@ -1,0 +1,330 @@
+"""봇 runtime control 범위 검증 테스트 (#1456).
+
+SSOT:
+    - ``docs/dashboard/user-stories/bots.md`` B-5 line 197-200 — runtime
+      control 4개 필드의 spec 범위 정의.
+    - ``docs/specs/web-api/05-resource-endpoints.md`` PUT ``/api/bots/{bot_id}``
+      body — runtime control 필드 contract.
+
+Spec 범위:
+    - ``max_restart_attempts``: 1~10
+    - ``restart_cooldown_seconds``: 10~600
+    - ``step_timeout_seconds``: 5~120
+    - ``max_signals_per_step``: 1~200
+
+본 모듈은 3개 layer 를 invariant 로 잠근다:
+    1. ``BotConfig.__post_init__`` — 직접 생성 시 ``ValueError``.
+    2. ``BotUpdateRequest`` Pydantic 모델 — PUT body validation 시 422.
+    3. ``BOT_UPDATE_REQUEST_SCHEMA`` JSON Schema + live ``/openapi.json``
+       ``components.schemas.BotUpdateRequest`` — frontend codegen 노출 범위.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from ante.bot.config import (
+    MAX_MAX_RESTART_ATTEMPTS,
+    MAX_MAX_SIGNALS_PER_STEP,
+    MAX_RESTART_COOLDOWN_SECONDS,
+    MAX_STEP_TIMEOUT_SECONDS,
+    MIN_MAX_RESTART_ATTEMPTS,
+    MIN_MAX_SIGNALS_PER_STEP,
+    MIN_RESTART_COOLDOWN_SECONDS,
+    MIN_STEP_TIMEOUT_SECONDS,
+    BotConfig,
+)
+from ante.web.routes.bots import BOT_UPDATE_REQUEST_SCHEMA
+from ante.web.schemas import BotUpdateRequest
+
+
+def _base_payload() -> dict:
+    """spec 범위 안에 있는 baseline payload — single field만 override 해서 테스트."""
+    return {}
+
+
+# ── Layer 1: BotConfig.__post_init__ ──────────────────────
+
+
+class TestBotConfigRuntimeControlsValidation:
+    """``BotConfig`` 직접 생성 시 spec 범위 밖 값은 ``ValueError``."""
+
+    def test_max_restart_attempts_below_min_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_restart_attempts"):
+            BotConfig(
+                bot_id="b1",
+                strategy_id="s1",
+                account_id="acc-test",
+                max_restart_attempts=MIN_MAX_RESTART_ATTEMPTS - 1,
+            )
+
+    def test_max_restart_attempts_above_max_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_restart_attempts"):
+            BotConfig(
+                bot_id="b1",
+                strategy_id="s1",
+                account_id="acc-test",
+                max_restart_attempts=MAX_MAX_RESTART_ATTEMPTS + 1,
+            )
+
+    def test_restart_cooldown_seconds_below_min_raises(self) -> None:
+        with pytest.raises(ValueError, match="restart_cooldown_seconds"):
+            BotConfig(
+                bot_id="b1",
+                strategy_id="s1",
+                account_id="acc-test",
+                restart_cooldown_seconds=MIN_RESTART_COOLDOWN_SECONDS - 1,
+            )
+
+    def test_restart_cooldown_seconds_above_max_raises(self) -> None:
+        with pytest.raises(ValueError, match="restart_cooldown_seconds"):
+            BotConfig(
+                bot_id="b1",
+                strategy_id="s1",
+                account_id="acc-test",
+                restart_cooldown_seconds=MAX_RESTART_COOLDOWN_SECONDS + 1,
+            )
+
+    def test_step_timeout_seconds_below_min_raises(self) -> None:
+        with pytest.raises(ValueError, match="step_timeout_seconds"):
+            BotConfig(
+                bot_id="b1",
+                strategy_id="s1",
+                account_id="acc-test",
+                step_timeout_seconds=MIN_STEP_TIMEOUT_SECONDS - 1,
+            )
+
+    def test_step_timeout_seconds_above_max_raises(self) -> None:
+        with pytest.raises(ValueError, match="step_timeout_seconds"):
+            BotConfig(
+                bot_id="b1",
+                strategy_id="s1",
+                account_id="acc-test",
+                step_timeout_seconds=MAX_STEP_TIMEOUT_SECONDS + 1,
+            )
+
+    def test_max_signals_per_step_below_min_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_signals_per_step"):
+            BotConfig(
+                bot_id="b1",
+                strategy_id="s1",
+                account_id="acc-test",
+                max_signals_per_step=MIN_MAX_SIGNALS_PER_STEP - 1,
+            )
+
+    def test_max_signals_per_step_above_max_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_signals_per_step"):
+            BotConfig(
+                bot_id="b1",
+                strategy_id="s1",
+                account_id="acc-test",
+                max_signals_per_step=MAX_MAX_SIGNALS_PER_STEP + 1,
+            )
+
+    def test_defaults_pass_validation(self) -> None:
+        """spec default (3, 60, 30, 50)는 모두 통과 범위 안."""
+        config = BotConfig(
+            bot_id="b1",
+            strategy_id="s1",
+            account_id="acc-test",
+        )
+        assert config.max_restart_attempts == 3
+        assert config.restart_cooldown_seconds == 60
+        assert config.step_timeout_seconds == 30
+        assert config.max_signals_per_step == 50
+
+    def test_min_boundary_passes(self) -> None:
+        """spec min 값은 통과한다."""
+        config = BotConfig(
+            bot_id="b1",
+            strategy_id="s1",
+            account_id="acc-test",
+            max_restart_attempts=MIN_MAX_RESTART_ATTEMPTS,
+            restart_cooldown_seconds=MIN_RESTART_COOLDOWN_SECONDS,
+            step_timeout_seconds=MIN_STEP_TIMEOUT_SECONDS,
+            max_signals_per_step=MIN_MAX_SIGNALS_PER_STEP,
+        )
+        assert config.max_restart_attempts == MIN_MAX_RESTART_ATTEMPTS
+
+    def test_max_boundary_passes(self) -> None:
+        """spec max 값은 통과한다."""
+        config = BotConfig(
+            bot_id="b1",
+            strategy_id="s1",
+            account_id="acc-test",
+            max_restart_attempts=MAX_MAX_RESTART_ATTEMPTS,
+            restart_cooldown_seconds=MAX_RESTART_COOLDOWN_SECONDS,
+            step_timeout_seconds=MAX_STEP_TIMEOUT_SECONDS,
+            max_signals_per_step=MAX_MAX_SIGNALS_PER_STEP,
+        )
+        assert config.max_restart_attempts == MAX_MAX_RESTART_ATTEMPTS
+
+
+# ── Layer 2: BotUpdateRequest Pydantic ──────────────────────
+
+
+class TestBotUpdateRequestRuntimeControlsValidation:
+    """``BotUpdateRequest`` 가 spec 범위 밖 값을 ``ValidationError`` 로 거부.
+
+    PUT 핸들러는 ``ValidationError`` 를 422 ``HTTPException`` 으로 변환한다
+    (``routes/bots.py:1090``).
+    """
+
+    def test_max_restart_attempts_below_min_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            BotUpdateRequest.model_validate(
+                {"max_restart_attempts": MIN_MAX_RESTART_ATTEMPTS - 1}
+            )
+
+    def test_max_restart_attempts_above_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            BotUpdateRequest.model_validate(
+                {"max_restart_attempts": MAX_MAX_RESTART_ATTEMPTS + 1}
+            )
+
+    def test_restart_cooldown_seconds_below_min_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            BotUpdateRequest.model_validate(
+                {"restart_cooldown_seconds": MIN_RESTART_COOLDOWN_SECONDS - 1}
+            )
+
+    def test_restart_cooldown_seconds_above_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            BotUpdateRequest.model_validate(
+                {"restart_cooldown_seconds": MAX_RESTART_COOLDOWN_SECONDS + 1}
+            )
+
+    def test_step_timeout_seconds_below_min_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            BotUpdateRequest.model_validate(
+                {"step_timeout_seconds": MIN_STEP_TIMEOUT_SECONDS - 1}
+            )
+
+    def test_step_timeout_seconds_above_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            BotUpdateRequest.model_validate(
+                {"step_timeout_seconds": MAX_STEP_TIMEOUT_SECONDS + 1}
+            )
+
+    def test_max_signals_per_step_below_min_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            BotUpdateRequest.model_validate(
+                {"max_signals_per_step": MIN_MAX_SIGNALS_PER_STEP - 1}
+            )
+
+    def test_max_signals_per_step_above_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            BotUpdateRequest.model_validate(
+                {"max_signals_per_step": MAX_MAX_SIGNALS_PER_STEP + 1}
+            )
+
+    def test_min_boundary_accepted(self) -> None:
+        """spec min 값은 ``BotUpdateRequest`` 도 통과한다."""
+        body = BotUpdateRequest.model_validate(
+            {
+                "max_restart_attempts": MIN_MAX_RESTART_ATTEMPTS,
+                "restart_cooldown_seconds": MIN_RESTART_COOLDOWN_SECONDS,
+                "step_timeout_seconds": MIN_STEP_TIMEOUT_SECONDS,
+                "max_signals_per_step": MIN_MAX_SIGNALS_PER_STEP,
+            }
+        )
+        assert body.max_restart_attempts == MIN_MAX_RESTART_ATTEMPTS
+        assert body.restart_cooldown_seconds == MIN_RESTART_COOLDOWN_SECONDS
+        assert body.step_timeout_seconds == MIN_STEP_TIMEOUT_SECONDS
+        assert body.max_signals_per_step == MIN_MAX_SIGNALS_PER_STEP
+
+    def test_max_boundary_accepted(self) -> None:
+        """spec max 값은 ``BotUpdateRequest`` 도 통과한다."""
+        body = BotUpdateRequest.model_validate(
+            {
+                "max_restart_attempts": MAX_MAX_RESTART_ATTEMPTS,
+                "restart_cooldown_seconds": MAX_RESTART_COOLDOWN_SECONDS,
+                "step_timeout_seconds": MAX_STEP_TIMEOUT_SECONDS,
+                "max_signals_per_step": MAX_MAX_SIGNALS_PER_STEP,
+            }
+        )
+        assert body.max_restart_attempts == MAX_MAX_RESTART_ATTEMPTS
+
+    def test_none_remains_acceptable(self) -> None:
+        """``None`` 은 그대로 통과한다 (변경하지 않음 의미)."""
+        body = BotUpdateRequest.model_validate({})
+        assert body.max_restart_attempts is None
+        assert body.restart_cooldown_seconds is None
+        assert body.step_timeout_seconds is None
+        assert body.max_signals_per_step is None
+
+
+# ── Layer 3: JSON Schema (static + live OpenAPI) ──────────────────────
+
+
+class TestBotUpdateRequestJsonSchemaBounds:
+    """``BOT_UPDATE_REQUEST_SCHEMA`` properties 에 ``minimum``/``maximum`` 노출."""
+
+    def test_schema_includes_max_restart_attempts_bounds(self) -> None:
+        prop = BOT_UPDATE_REQUEST_SCHEMA["properties"]["max_restart_attempts"]
+        assert prop["minimum"] == MIN_MAX_RESTART_ATTEMPTS
+        assert prop["maximum"] == MAX_MAX_RESTART_ATTEMPTS
+
+    def test_schema_includes_restart_cooldown_seconds_bounds(self) -> None:
+        prop = BOT_UPDATE_REQUEST_SCHEMA["properties"]["restart_cooldown_seconds"]
+        assert prop["minimum"] == MIN_RESTART_COOLDOWN_SECONDS
+        assert prop["maximum"] == MAX_RESTART_COOLDOWN_SECONDS
+
+    def test_schema_includes_step_timeout_seconds_bounds(self) -> None:
+        prop = BOT_UPDATE_REQUEST_SCHEMA["properties"]["step_timeout_seconds"]
+        assert prop["minimum"] == MIN_STEP_TIMEOUT_SECONDS
+        assert prop["maximum"] == MAX_STEP_TIMEOUT_SECONDS
+
+    def test_schema_includes_max_signals_per_step_bounds(self) -> None:
+        prop = BOT_UPDATE_REQUEST_SCHEMA["properties"]["max_signals_per_step"]
+        assert prop["minimum"] == MIN_MAX_SIGNALS_PER_STEP
+        assert prop["maximum"] == MAX_MAX_SIGNALS_PER_STEP
+
+
+class TestBotUpdateRequestLiveOpenApiBounds:
+    """live ``/openapi.json`` ``components.schemas.BotUpdateRequest`` 노출 검증.
+
+    ``_install_openapi_customizer`` 가 ``BOT_UPDATE_REQUEST_SCHEMA`` 본체를
+    ``components.schemas`` 에 등록한다 (``src/ante/web/app.py:293``). frontend
+    ``openapi-typescript`` codegen 이 이 결과를 그대로 사용하므로, 범위 정보가
+    components 트리에 전달되는지 invariant 로 확인한다.
+    """
+
+    def _schema(self) -> dict:
+        from ante.web.app import create_app
+
+        app = create_app()
+        return app.openapi()
+
+    def test_components_schema_includes_max_restart_attempts_bounds(self) -> None:
+        schema = self._schema()
+        prop = schema["components"]["schemas"]["BotUpdateRequest"]["properties"][
+            "max_restart_attempts"
+        ]
+        assert prop["minimum"] == MIN_MAX_RESTART_ATTEMPTS
+        assert prop["maximum"] == MAX_MAX_RESTART_ATTEMPTS
+
+    def test_components_schema_includes_restart_cooldown_seconds_bounds(self) -> None:
+        schema = self._schema()
+        prop = schema["components"]["schemas"]["BotUpdateRequest"]["properties"][
+            "restart_cooldown_seconds"
+        ]
+        assert prop["minimum"] == MIN_RESTART_COOLDOWN_SECONDS
+        assert prop["maximum"] == MAX_RESTART_COOLDOWN_SECONDS
+
+    def test_components_schema_includes_step_timeout_seconds_bounds(self) -> None:
+        schema = self._schema()
+        prop = schema["components"]["schemas"]["BotUpdateRequest"]["properties"][
+            "step_timeout_seconds"
+        ]
+        assert prop["minimum"] == MIN_STEP_TIMEOUT_SECONDS
+        assert prop["maximum"] == MAX_STEP_TIMEOUT_SECONDS
+
+    def test_components_schema_includes_max_signals_per_step_bounds(self) -> None:
+        schema = self._schema()
+        prop = schema["components"]["schemas"]["BotUpdateRequest"]["properties"][
+            "max_signals_per_step"
+        ]
+        assert prop["minimum"] == MIN_MAX_SIGNALS_PER_STEP
+        assert prop["maximum"] == MAX_MAX_SIGNALS_PER_STEP

--- a/tests/unit/test_bot_step_event.py
+++ b/tests/unit/test_bot_step_event.py
@@ -67,16 +67,24 @@ def ctx():
 
 
 def _make_bot(strategy_cls, eventbus, ctx, *, step_timeout=0.01, max_signals=5):
-    """테스트용 Bot 생성."""
+    """테스트용 Bot 생성.
+
+    BotConfig 는 spec 범위(``step_timeout_seconds`` 5~120, #1456) 안의
+    값으로 만든 뒤 인스턴스 attribute 를 짧게 swap 한다 — invariant
+    validation 은 spec 통과값으로 통과시키고, 실제 ``asyncio.wait_for``
+    timeout 비교만 짧게 만들어 테스트 속도를 확보한다. ``interval_seconds``
+    도 동일 패턴.
+    """
     config = BotConfig(
         bot_id="bot1",
         strategy_id="test_stg",
         account_id="test",
         interval_seconds=60,
-        step_timeout_seconds=step_timeout,
+        step_timeout_seconds=5,
         max_signals_per_step=max_signals,
     )
     config.interval_seconds = 0.01
+    config.step_timeout_seconds = step_timeout
     bot = Bot(
         config=config,
         strategy_cls=strategy_cls,

--- a/tests/unit/test_bot_timeout_error.py
+++ b/tests/unit/test_bot_timeout_error.py
@@ -75,16 +75,24 @@ def ctx():
 
 
 def _make_bot(strategy_cls, eventbus, ctx, *, step_timeout=0.01):
-    """테스트용 Bot 생성. interval 검증 통과 후 짧은 값으로 교체한다."""
+    """테스트용 Bot 생성. invariant 검증 통과 후 짧은 값으로 교체.
+
+    BotConfig 는 spec 범위(``step_timeout_seconds`` 5~120, #1456) 안의
+    값으로 만든 뒤 인스턴스 attribute 를 짧게 swap 한다 — invariant
+    validation 은 spec 통과값으로 통과시키고, 실제 ``asyncio.wait_for``
+    timeout 비교만 짧게 만들어 테스트 속도를 확보한다. ``interval_seconds``
+    도 동일 패턴.
+    """
     config = BotConfig(
         bot_id="bot1",
         strategy_id="test_stg",
         account_id="test",
         interval_seconds=60,
-        step_timeout_seconds=step_timeout,
+        step_timeout_seconds=5,
     )
-    # 검증 통과 후 interval을 짧게 교체하여 테스트 속도 확보
+    # 검증 통과 후 인스턴스 attribute 를 짧게 교체하여 테스트 속도 확보
     config.interval_seconds = 0.01
+    config.step_timeout_seconds = step_timeout
     bot = Bot(
         config=config,
         strategy_cls=strategy_cls,


### PR DESCRIPTION
Closes #1456

## Summary
- `PUT /api/bots/{bot_id}`의 4개 runtime control 필드(`max_restart_attempts`, `restart_cooldown_seconds`, `step_timeout_seconds`, `max_signals_per_step`)가 spec 범위 밖 값을 422로 거부.
- Spec 범위 (`docs/dashboard/user-stories/bots.md` B-5):
  - `max_restart_attempts`: 1~10
  - `restart_cooldown_seconds`: 10~600
  - `step_timeout_seconds`: 5~120
  - `max_signals_per_step`: 1~200
- 3 layer 정렬:
  1. `BotConfig` invariant: 범위 상수 8개 + `validate_runtime_controls()` + `__post_init__` 호출 (모든 BotConfig 생성자 보호).
  2. PUT body validation: `BotUpdateRequest` Field(ge=, le=) (Pydantic 422 매핑).
  3. OpenAPI/generated artifact: `BOT_UPDATE_REQUEST_SCHEMA.properties` `minimum`/`maximum` + `frontend/openapi.json` + `frontend/src/types/api.generated.ts`.

## Test Plan
- [x] `pytest tests/unit -k \"bot\" -v` → 631 passed
- [x] `pytest tests/unit/test_bot_runtime_controls_validation.py -v` (신규, 30 cases)
- [x] `pytest tests/unit/test_bot_restart.py tests/unit/test_bot_step_event.py tests/unit/test_bot_timeout_error.py tests/unit/test_bot_guard.py -v` (마이그레이션 후 회귀 없음, 61 passed)
- [x] `cd frontend && npm run generate-types && npm run check-api-types && npm run build` 통과
- [x] `ruff check src tests` / `ruff format --check src tests` 통과
- [x] Codex 브랜치 리뷰 (\`/codex:review --base main\`): PASS, blocking finding 없음. 1회차 P2 finding(전역 asyncio.sleep monkeypatch 위험)은 `_cooldown_sleep` 모듈-한정 helper로 좁힘.

## Non-goals (별도 split issue)
- Service boundary 재검증 (#1459)
- DB load/save 보존 (#1457)
- `update_bot` 원자성 (#1460)
- GET 응답 계약 확장 (#1458)
- `BotCreateRequest`(POST) 확장 (현재 spec에 runtime control 필드 없음, extra=forbid로 차단됨)
- Legacy DB row 마이그레이션 (DB가 runtime control 필드 미보존 → 마이그레이션 불필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)