### PR TITLE
fix(web-api,member): enforce MemberRole enum on MemberCreateRequest + service register (#1465)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -8302,8 +8302,13 @@
           },
           "role": {
             "type": "string",
+            "enum": [
+              "master",
+              "admin",
+              "default"
+            ],
             "default": "default",
-            "description": "역할 (default / master)."
+            "description": "멤버 역할. ``MemberRole`` enum SSOT 에 따라 ``master`` / ``admin`` / ``default`` 중 하나여야 한다 (#1465, SSOT: ``src/ante/member/models.py``). 알 수 없는 문자열은 422 로 거부된다."
           },
           "org": {
             "type": "string",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2637,10 +2637,11 @@ export type components = {
              */
             org: string;
             /**
-             * @description 역할 (default / master).
+             * @description 멤버 역할. ``MemberRole`` enum SSOT 에 따라 ``master`` / ``admin`` / ``default`` 중 하나여야 한다 (#1465, SSOT: ``src/ante/member/models.py``). 알 수 없는 문자열은 422 로 거부된다.
              * @default default
+             * @enum {string}
              */
-            role: string;
+            role: "master" | "admin" | "default";
             /**
              * @description 권한 범위 목록. 각 원소는 SCOPE_VOCABULARY (#1439, SSOT: ``src/ante/member/scopes.py``) 에 등록된 문자열이어야 한다. 미등록 문자열은 422 로 거부된다.
              * @default []

--- a/frontend/src/types/member.ts
+++ b/frontend/src/types/member.ts
@@ -30,12 +30,24 @@ export interface MemberDetailView extends MemberView {
   suspended_at?: string
 }
 
+/**
+ * POST /api/members 요청 body 의 ``role`` 은 ``MemberRole`` enum SSOT
+ * (``master`` / ``admin`` / ``default``) 만 허용한다 (#1465 — split #1417/A).
+ *
+ * display-only ``owner`` 는 ``HumanRole`` 에서 view 측 sentinel 로 남겨두지만
+ * ``MemberCreateInput.role`` 에서는 배제해야 한다 — generated
+ * ``MemberCreateRequest.role`` enum 이 좁혀지면서 ``owner`` 를 payload 로
+ * 전송하면 422 가 되므로 컴파일 시점에 차단한다. ``HumanRole`` 전체 분리는
+ * #1467 에서 다룬다.
+ */
+export type MemberCreateRole = Exclude<HumanRole, 'owner'> | 'default'
+
 export interface MemberCreateInput {
   member_id: string
   member_type: MemberType
   name: string
   org: string
-  role?: HumanRole | 'default'
+  role?: MemberCreateRole
   scopes: string[]
 }
 

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -350,9 +350,17 @@ class MemberService:
         ingress 는 Pydantic field validator 로 동일 invariant 를 검증하지만
         CLI direct path 와 내부 caller 가 본 메소드를 직접 호출할 수 있으므로
         service 계층에서 한 번 더 방어한다(defense-in-depth).
+
+        ``role`` 은 ``MemberRole`` enum SSOT 멤버이어야 한다 (#1465 — split
+        #1417/A). Web API ingress 는 Pydantic ``MemberRole`` 필드로 422 를
+        강제하지만, CLI direct path 및 내부 caller 가 임의 문자열을 넘길 수
+        있으므로 본 서비스 계층에서도 ``ValueError`` 로 재검증한다. 검증은
+        ``_assert_master`` 직후, ``_assert_type_role`` 직전에 둬서 enum
+        membership 위반이 type-role 분기보다 먼저 거부되도록 한다.
         """
         if registered_by:
             await self._assert_master(registered_by, "register")
+        self._assert_role_enum(role)
         self._assert_type_role(member_type, role)
 
         # vocabulary 검증은 type/role 검증 이후, DB I/O 이전에 수행한다.
@@ -716,6 +724,26 @@ class MemberService:
         for scope in scopes:
             if not is_valid_scope(scope):
                 raise InvalidScopeError(scope)
+
+    @staticmethod
+    def _assert_role_enum(role: str) -> None:
+        """``role`` 이 ``MemberRole`` enum SSOT 의 멤버인지 검증한다 (#1465).
+
+        Web API ingress 는 Pydantic ``MemberRole`` 필드로 422 를 강제하지만,
+        CLI direct path 와 내부 caller 는 본 서비스 메소드를 직접 호출할 수
+        있다. enum 위반이 token 발급/DB INSERT 까지 새지 않도록 service 계층
+        에서 한 번 더 방어한다 (defense-in-depth — Plan Preflight narrow-scope
+        SSOT: ``src/ante/member/models.py``).
+
+        ``StrEnum`` 인스턴스는 곧 문자열이므로 ``MemberRole.DEFAULT`` 같은
+        enum 직접 호출도 통과한다. 알 수 없는 문자열은 ``ValueError`` 로
+        거부되며, Web API 라우터의 ``except ValueError`` 분기가 400 으로
+        매핑한다 (현재 핸들러 시그니처 유지).
+        """
+        valid = {member.value for member in MemberRole}
+        if role not in valid:
+            msg = f"invalid role: {role!r}"
+            raise ValueError(msg)
 
     @staticmethod
     def _assert_type_role(member_type: str, role: str) -> None:

--- a/src/ante/web/routes/members.py
+++ b/src/ante/web/routes/members.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
 
 from ante.member.errors import PermissionDeniedError
-from ante.member.models import MemberStatus, MemberType
+from ante.member.models import MemberRole, MemberStatus, MemberType
 from ante.member.scopes import SCOPE_VOCABULARY, InvalidScopeError
 from ante.web.deps import (
     get_audit_logger_optional,
@@ -73,13 +73,18 @@ def _validate_scopes_vocabulary(value: list[str]) -> list[str]:
 
 
 class MemberCreateRequest(BaseModel):
-    """멤버 등록 요청."""
+    """멤버 등록 요청.
+
+    ``role`` 은 ``MemberRole`` enum SSOT(``master`` / ``admin`` / ``default``)
+    로 강제한다 (#1465 — split #1417/A). 알 수 없는 role 문자열은 Pydantic
+    이 자동으로 422 로 거부하므로 service / token 생성 전에 차단된다.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
     member_id: str
     member_type: str  # "human" | "agent"
-    role: str = "default"
+    role: MemberRole = MemberRole.DEFAULT
     org: str = "default"
     name: str = ""
     scopes: list[str] = []
@@ -118,8 +123,14 @@ MEMBER_CREATE_REQUEST_SCHEMA: dict[str, Any] = {
         },
         "role": {
             "type": "string",
+            "enum": ["master", "admin", "default"],
             "default": "default",
-            "description": "역할 (default / master).",
+            "description": (
+                "멤버 역할. ``MemberRole`` enum SSOT 에 따라 ``master`` / "
+                "``admin`` / ``default`` 중 하나여야 한다 (#1465, SSOT: "
+                "``src/ante/member/models.py``). 알 수 없는 문자열은 422 로 "
+                "거부된다."
+            ),
         },
         "org": {
             "type": "string",

--- a/tests/unit/test_member_create_invalid_role.py
+++ b/tests/unit/test_member_create_invalid_role.py
@@ -1,0 +1,494 @@
+"""POST /api/members + MemberService.register 의 ``role`` enum 강제 회귀
+(issue #1465 — split #1417/A).
+
+검증 대상:
+
+- Web API: 인증 master caller + body ``role`` 이 ``MemberRole`` enum SSOT
+  (``master`` / ``admin`` / ``default``) 외 값이면 422 로 거부되고 service
+  register 가 호출되지 않는다.
+- Web API: 인증 master caller + 정상 role 값 (``master`` / ``admin`` /
+  ``default``) 은 201 회귀.
+- Web API: 인증 master caller + role 생략은 201 + service 가 ``default`` 로
+  받는 회귀.
+- Web API: **미인증** + invalid role 조합은 body validation 보다 401 이
+  우선되어야 한다 (#1339 auth-first invariant 회귀).
+- Service: ``MemberService.register`` 가 enum 외 role 을 ``ValueError`` 로
+  거부한다 (defense-in-depth, CLI direct path 회귀).
+- Service: ``MemberRole`` enum 멤버 (``MASTER`` / ``ADMIN`` / ``DEFAULT``)
+  와 동등 문자열은 통과한다.
+- Service: ``agent + master`` 조합은 기존대로 ``PermissionError`` 로 거부된다
+  (``_assert_type_role`` 호환 회귀).
+- OpenAPI sync: ``/openapi.json`` 의 ``components.schemas.MemberCreateRequest``
+  ``role`` 이 ``enum: [master, admin, default]`` 를 노출한다.
+
+본 모듈은 `tests/unit/test_member_api.py` 의 FakeMemberService 패턴을
+재사용해 Web API 회귀를 잠그고, ``test_member_service_master_guard.py``
+패턴을 재사용해 service 회귀를 잠근다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.core.database import Database  # noqa: E402
+from ante.eventbus import EventBus  # noqa: E402
+from ante.member.models import MemberRole, MemberType  # noqa: E402
+from ante.member.service import MemberService  # noqa: E402
+
+from ante.web.app import create_app  # noqa: E402  # isort: skip
+
+
+# ── Web API fixtures (test_member_api.py 패턴 재사용) ─────────────────────
+
+
+@dataclass
+class FakeMember:
+    member_id: str
+    type: str = "agent"
+    role: str = "default"
+    org: str = "default"
+    name: str = ""
+    emoji: str = ""
+    status: str = "active"
+    scopes: list[str] = field(default_factory=list)
+    token_hash: str = ""
+    password_hash: str = ""
+    recovery_key_hash: str = ""
+    created_at: str = ""
+    created_by: str = ""
+    last_active_at: str = ""
+    suspended_at: str = ""
+    revoked_at: str = ""
+    token_expires_at: str = ""
+
+
+class FakeMemberService:
+    """테스트용 MemberService stub.
+
+    ``register`` 가 호출되는지 추적해 ingress (Pydantic enum validation) 가
+    실제로 service 도달 전에 차단했는지 검증한다.
+    """
+
+    def __init__(self) -> None:
+        self._members: dict[str, FakeMember] = {}
+        self._token_counter = 0
+        self.register_calls: list[dict[str, object]] = []
+
+    async def list_members(self, **kwargs: object) -> list[FakeMember]:
+        return []
+
+    async def count(self, **kwargs: object) -> int:
+        return 0
+
+    async def register(
+        self,
+        member_id: str,
+        member_type: str,
+        role: str = "default",
+        org: str = "default",
+        name: str = "",
+        scopes: list[str] | None = None,
+        registered_by: str = "",
+        **kwargs: object,
+    ) -> tuple[FakeMember, str]:
+        self.register_calls.append(
+            {
+                "member_id": member_id,
+                "member_type": member_type,
+                "role": role,
+                "registered_by": registered_by,
+            }
+        )
+        if member_id in self._members:
+            raise ValueError(f"이미 존재하는 멤버: {member_id}")
+        member = FakeMember(
+            member_id=member_id,
+            type=member_type,
+            role=role,
+            org=org,
+            name=name,
+            scopes=scopes or [],
+            created_by=registered_by,
+        )
+        self._members[member_id] = member
+        self._token_counter += 1
+        return member, f"ante_ak_{self._token_counter}"
+
+    async def get(self, member_id: str) -> FakeMember | None:
+        return self._members.get(member_id)
+
+
+@pytest.fixture
+def member_service() -> FakeMemberService:
+    return FakeMemberService()
+
+
+@pytest.fixture
+def client(member_service: FakeMemberService) -> TestClient:
+    """인증 컨텍스트가 미리 주입된 클라이언트 (master-user, role=master).
+
+    ``test_member_api.py::client`` 와 동일한 synthetic master 패턴을 따른다.
+    """
+    app = create_app(member_service=member_service)
+
+    _master_synthetic = FakeMember(member_id="master-user", role="master")
+    _original_get = member_service.get
+
+    async def _get_with_synthetic_master(member_id: str) -> FakeMember | None:
+        if member_id == "master-user":
+            return _master_synthetic
+        return await _original_get(member_id)
+
+    member_service.get = _get_with_synthetic_master  # type: ignore[assignment]
+
+    @app.middleware("http")
+    async def inject_master_caller(request, call_next):  # type: ignore[no-untyped-def]
+        request.state.member_id = "master-user"
+        return await call_next(request)
+
+    return TestClient(app)
+
+
+@pytest.fixture
+def client_unauthenticated(member_service: FakeMemberService) -> TestClient:
+    """인증 컨텍스트가 주입되지 않은 클라이언트."""
+    app = create_app(member_service=member_service)
+    return TestClient(app)
+
+
+# ── Web API: invalid role → 422 ──────────────────────────────────────────
+
+
+class TestCreateMemberInvalidRoleWebAPI:
+    """POST /api/members 가 알 수 없는 role 을 422 로 거부 (#1465)."""
+
+    def test_unknown_role_oracle_string_rejected_with_422(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        """``oracle_invalid_role`` 같은 임의 문자열은 422 + service 미호출.
+
+        oracle A7 reproduction 시그니처. 과거에는 201 + token 발급으로 새던
+        경로 (#1417) 를 잠근다.
+        """
+        resp = client.post(
+            "/api/members",
+            json={
+                "member_id": "agent-bad-role",
+                "member_type": "agent",
+                "role": "oracle_invalid_role",
+            },
+        )
+        assert resp.status_code == 422, resp.text
+        # ingress 가 차단했으므로 service 까지 도달하지 않는다.
+        assert member_service.register_calls == [], (
+            "ingress validation 이 service 호출을 막아야 한다 — "
+            f"현재 register_calls: {member_service.register_calls!r}"
+        )
+
+    def test_invalid_role_empty_string_rejected_with_422(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        """빈 문자열도 enum 멤버가 아니므로 422."""
+        resp = client.post(
+            "/api/members",
+            json={
+                "member_id": "agent-empty-role",
+                "member_type": "agent",
+                "role": "",
+            },
+        )
+        assert resp.status_code == 422, resp.text
+        assert member_service.register_calls == []
+
+    def test_invalid_role_owner_rejected_with_422(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        """frontend display-only ``owner`` 도 API enum 밖이므로 422.
+
+        frontend ``MemberCreateInput.role`` 에서 ``owner`` 를 배제했지만
+        다른 클라이언트가 보낼 가능성을 차단한다 (#1465 narrow-scope).
+        """
+        resp = client.post(
+            "/api/members",
+            json={
+                "member_id": "human-owner",
+                "member_type": "human",
+                "role": "owner",
+            },
+        )
+        assert resp.status_code == 422, resp.text
+        assert member_service.register_calls == []
+
+
+# ── Web API: valid role 회귀 ────────────────────────────────────────────
+
+
+class TestCreateMemberValidRoleWebAPI:
+    """정상 role 값은 회귀 없이 201 로 통과 (#1465)."""
+
+    @pytest.mark.parametrize(
+        ("role", "member_type"),
+        [
+            ("master", "human"),
+            ("admin", "human"),
+            ("default", "human"),
+            ("admin", "agent"),
+            ("default", "agent"),
+        ],
+    )
+    def test_valid_role_returns_201(
+        self,
+        client: TestClient,
+        member_service: FakeMemberService,
+        role: str,
+        member_type: str,
+    ) -> None:
+        resp = client.post(
+            "/api/members",
+            json={
+                "member_id": f"target-{role}-{member_type}",
+                "member_type": member_type,
+                "role": role,
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["member"]["role"] == role
+
+    def test_role_omitted_defaults_to_default(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        """role 생략 시 ``default`` 로 service 도달 (#1465 회귀)."""
+        resp = client.post(
+            "/api/members",
+            json={
+                "member_id": "agent-no-role",
+                "member_type": "agent",
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        assert len(member_service.register_calls) == 1
+        assert str(member_service.register_calls[0]["role"]) == "default"
+
+
+# ── Web API: auth-first invariant ───────────────────────────────────────
+
+
+class TestCreateMemberAuthFirstWithInvalidRole:
+    """미인증 + invalid role → 401 우선 (#1339 + #1465)."""
+
+    def test_unauth_with_invalid_role_returns_401_not_422(
+        self,
+        client_unauthenticated: TestClient,
+        member_service: FakeMemberService,
+    ) -> None:
+        """인증 가드는 body validation 보다 항상 먼저 실행되어야 한다.
+
+        invalid role 이라도 인증 컨텍스트가 없으면 401 로 응답되고 service
+        register 는 호출되지 않는다 (#1339 P2 auth-first 회귀).
+        """
+        resp = client_unauthenticated.post(
+            "/api/members",
+            json={
+                "member_id": "agent-bad",
+                "member_type": "agent",
+                "role": "oracle_invalid_role",
+            },
+        )
+        assert resp.status_code == 401, resp.text
+        assert member_service.register_calls == []
+
+
+# ── OpenAPI components schema sync ──────────────────────────────────────
+
+
+class TestMemberCreateRequestOpenAPISchema:
+    """``components.schemas.MemberCreateRequest.role`` 이 enum SSOT 노출 (#1465)."""
+
+    def test_role_property_exposes_enum_master_admin_default(self) -> None:
+        app = create_app()
+        schema = app.openapi()
+        schemas = schema.get("components", {}).get("schemas", {})
+        assert "MemberCreateRequest" in schemas, (
+            "MemberCreateRequest schema 가 components 에 등록되지 않음 — "
+            "#1339 P1 회귀 가능성"
+        )
+        role_prop = schemas["MemberCreateRequest"]["properties"]["role"]
+        assert role_prop.get("enum") == ["master", "admin", "default"], (
+            f"MemberCreateRequest.role.enum 이 MemberRole SSOT 와 불일치: {role_prop!r}"
+        )
+        assert role_prop.get("default") == "default", (
+            f"MemberCreateRequest.role.default 가 'default' 가 아님: {role_prop!r}"
+        )
+
+
+# ── Service-layer: invalid role direct path ─────────────────────────────
+
+
+@pytest.fixture
+async def db(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+def eventbus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+async def service(db, eventbus) -> MemberService:
+    svc = MemberService(db, eventbus)
+    await svc.initialize()
+    return svc
+
+
+@pytest.fixture
+async def populated_service(service: MemberService) -> MemberService:
+    """master(``owner``) 만 bootstrap. register 호출자가 ``owner`` 가 된다."""
+    await service.bootstrap_master("owner", "pass123")
+    return service
+
+
+class TestServiceRegisterInvalidRole:
+    """``MemberService.register`` 가 enum 외 role 을 ValueError 로 거부 (#1465).
+
+    CLI direct path (``src/ante/cli/commands/member.py`` ``register``) 와 내부
+    caller 는 Pydantic 검증을 거치지 않으므로 service 단 방어가 필요하다
+    (defense-in-depth).
+    """
+
+    async def test_unknown_role_raises_value_error(
+        self, populated_service: MemberService
+    ) -> None:
+        with pytest.raises(ValueError, match="invalid role"):
+            await populated_service.register(
+                member_id="agent-bad",
+                member_type="human",
+                role="oracle_invalid_role",
+                registered_by="owner",
+            )
+
+    async def test_empty_role_raises_value_error(
+        self, populated_service: MemberService
+    ) -> None:
+        with pytest.raises(ValueError, match="invalid role"):
+            await populated_service.register(
+                member_id="agent-empty",
+                member_type="human",
+                role="",
+                registered_by="owner",
+            )
+
+    async def test_owner_role_raises_value_error(
+        self, populated_service: MemberService
+    ) -> None:
+        """frontend display-only ``owner`` 도 service 에서 거부."""
+        with pytest.raises(ValueError, match="invalid role"):
+            await populated_service.register(
+                member_id="human-owner",
+                member_type="human",
+                role="owner",
+                registered_by="owner",
+            )
+
+    async def test_value_error_raised_before_token_creation(
+        self, populated_service: MemberService
+    ) -> None:
+        """invalid role 거부 시 DB INSERT/토큰 발급이 발생하지 않는다."""
+        with pytest.raises(ValueError, match="invalid role"):
+            await populated_service.register(
+                member_id="agent-no-token",
+                member_type="human",
+                role="oracle_invalid_role",
+                registered_by="owner",
+            )
+        # 새 멤버가 DB 에 추가되지 않았어야 한다.
+        assert await populated_service.get("agent-no-token") is None
+
+
+class TestServiceRegisterValidRole:
+    """정상 role 은 회귀 없이 통과 (#1465)."""
+
+    async def test_register_with_member_role_enum_master_human(
+        self, populated_service: MemberService
+    ) -> None:
+        """enum 인스턴스 (``MemberRole.MASTER``) 도 통과."""
+        member, _ = await populated_service.register(
+            member_id="human-second-master",
+            member_type=MemberType.HUMAN,
+            role=MemberRole.MASTER,
+            registered_by="owner",
+        )
+        assert member.role == "master"
+
+    async def test_register_with_string_master_human(
+        self, populated_service: MemberService
+    ) -> None:
+        member, _ = await populated_service.register(
+            member_id="human-string-master",
+            member_type="human",
+            role="master",
+            registered_by="owner",
+        )
+        assert member.role == "master"
+
+    async def test_register_with_string_default_agent(
+        self, populated_service: MemberService
+    ) -> None:
+        member, _ = await populated_service.register(
+            member_id="agent-string-default",
+            member_type="agent",
+            role="default",
+            registered_by="owner",
+        )
+        assert member.role == "default"
+
+    async def test_register_default_role_omitted_uses_member_role_default(
+        self, populated_service: MemberService
+    ) -> None:
+        """role 인자를 생략하면 ``MemberRole.DEFAULT`` 로 통과."""
+        member, _ = await populated_service.register(
+            member_id="agent-omitted-role",
+            member_type="agent",
+            registered_by="owner",
+        )
+        assert member.role == "default"
+
+
+class TestServiceRegisterTypeRoleCompatRegression:
+    """``_assert_type_role`` 기존 행동이 새 enum 가드와 함께 보존된다 (#1465)."""
+
+    async def test_agent_with_master_role_raises_permission_error(
+        self, populated_service: MemberService
+    ) -> None:
+        """enum membership 통과 + type/role 위반은 여전히 PermissionError.
+
+        ``_assert_role_enum`` 이 ``MemberRole.MASTER`` 를 통과시킨 뒤
+        ``_assert_type_role`` 이 agent+master 조합을 거부한다.
+        """
+        with pytest.raises(PermissionError, match="agent 타입"):
+            await populated_service.register(
+                member_id="agent-bad-master",
+                member_type="agent",
+                role="master",
+                registered_by="owner",
+            )
+
+    async def test_agent_with_admin_role_raises_permission_error(
+        self, populated_service: MemberService
+    ) -> None:
+        with pytest.raises(PermissionError, match="agent 타입"):
+            await populated_service.register(
+                member_id="agent-bad-admin",
+                member_type="agent",
+                role="admin",
+                registered_by="owner",
+            )


### PR DESCRIPTION
Closes #1465

## Summary
- `POST /api/members`가 `MemberRole`(`master/admin/default`) 외 role을 422로 거부.
- 3 layer 정렬 + narrow-scope frontend 분리:
  1. Pydantic ingress: `MemberCreateRequest.role: MemberRole = MemberRole.DEFAULT` (extra=forbid 그대로).
  2. Manual OpenAPI schema: `MEMBER_CREATE_REQUEST_SCHEMA.properties.role.enum = ["master","admin","default"]`.
  3. Service-layer defense-in-depth: `MemberService.register()`의 `_assert_master` 직후/`_assert_type_role` 직전에 `_assert_role_enum` 추가 (CLI direct path 보호).
  4. Frontend `MemberCreateInput.role` = `Exclude<HumanRole, 'owner'> | 'default'` — display-only `owner`가 API payload에 흘러가지 못하도록 좁힘 (#1467의 일부 최소 선반영).
- Generated artifacts(`frontend/openapi.json`, `frontend/src/types/api.generated.ts`) 재생성 — `MemberCreateRequest.role: "master" | "admin" | "default"` 노출.

## Test Plan
- [x] `pytest tests/unit -k "member"` → 354 passed
- [x] `pytest tests/unit/test_member_api.py tests/unit/test_member_routes_mutation_auth.py` → 98 passed
- [x] `pytest tests/unit` (full) → 5098 passed, 2 skipped (회귀 0)
- [x] `pytest tests/unit/test_member_create_invalid_role.py` (신규, 21 cases)
- [x] `cd frontend && npm run generate-types && npm run check-api-types && npm run build` 통과
- [x] `ruff check src tests` / `ruff format --check src tests` 통과
- [x] Codex 브랜치 리뷰: P2 false-positive(pip_freeze 변경)만 발견되었으나 실제 작업 트리에는 존재하지 않음. 본 PR의 모든 변경은 6개 파일에 한정 (member service/route/test + frontend types + generated artifacts).

## Non-goals (별도 split issue)
- legacy invalid-role member/token 차단 (#1466)
- frontend display role `owner` 종합 분리 (#1467) — create payload만 최소 분리
- legacy row cleanup (#1468)

🤖 Generated with [Claude Code](https://claude.com/claude-code)