### PR TITLE
fix(treasury): normalize transaction type vocabulary (5-value) (#1476)

### DIFF
--- a/docs/specs/treasury/06-database-schema.md
+++ b/docs/specs/treasury/06-database-schema.md
@@ -22,7 +22,15 @@ CREATE TABLE treasury_transactions (
     id               INTEGER PRIMARY KEY AUTOINCREMENT,
     bot_id           TEXT,
     account_id       TEXT NOT NULL,                       -- 소속 계좌 ID, fallback default 없음
-    transaction_type TEXT NOT NULL,  -- 'allocate', 'deallocate', 'reserve', 'release', 'fill'
+    -- transaction_type vocabulary (5-value, SSOT):
+    --   'allocate'             : 봇에 예산 할당
+    --   'deallocate'           : 봇에서 예산 회수
+    --   'release'              : 봇 삭제 시 할당 예산 전액 환수
+    --   'fill'                 : 주문 체결로 인한 자금 이동
+    --   'bot_stopped_release'  : 봇 중지 시 잔여 예약 자금 환수
+    -- 코드 SSOT: src/ante/treasury/treasury.py::TRANSACTION_TYPE_VOCABULARY
+    -- 프런트엔드 SSOT: frontend/src/types/treasury.ts::TransactionType
+    transaction_type TEXT NOT NULL,
     amount           REAL NOT NULL,
     description      TEXT DEFAULT '',
     created_at       TEXT DEFAULT (datetime('now'))

--- a/frontend/src/types/treasury.ts
+++ b/frontend/src/types/treasury.ts
@@ -54,7 +54,25 @@ export interface BotBudgetView {
 
 export type BotBudget = BotBudgetView
 
-export type TransactionType = 'allocate' | 'deallocate' | 'fill' | 'bot_stopped_release'
+/**
+ * Treasury transaction type vocabulary (frontend SSOT).
+ *
+ * 5-value vocabulary, drift-checked against:
+ *   - 코드 SSOT: src/ante/treasury/treasury.py::TRANSACTION_TYPE_VOCABULARY
+ *   - 스펙 SSOT: docs/specs/treasury/06-database-schema.md
+ *
+ * - 'allocate'             : 봇에 예산 할당
+ * - 'deallocate'           : 봇에서 예산 회수
+ * - 'release'              : 봇 삭제 시 할당 예산 전액 환수
+ * - 'fill'                 : 주문 체결로 인한 자금 이동
+ * - 'bot_stopped_release'  : 봇 중지 시 잔여 예약 자금 환수
+ */
+export type TransactionType =
+  | 'allocate'
+  | 'deallocate'
+  | 'release'
+  | 'fill'
+  | 'bot_stopped_release'
 
 export interface TreasuryTransactionView {
   id: number

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -34,10 +34,11 @@ export const MEMBER_STATUS_LABELS: Record<string, string> = {
   revoked: '폐기',
 }
 
-/** 자금 변동 유형 라벨 */
+/** 자금 변동 유형 라벨 (#1476: 5-value vocabulary와 일관) */
 export const TRANSACTION_TYPE_LABELS: Record<string, string> = {
   allocate: '할당',
   deallocate: '회수',
+  release: '회수(봇 삭제)',
   fill: '체결',
   bot_stopped_release: '예약해제',
 }
@@ -46,6 +47,7 @@ export const TRANSACTION_TYPE_LABELS: Record<string, string> = {
 export const TRANSACTION_TYPE_VARIANT: Record<string, string> = {
   allocate: 'positive',
   deallocate: 'warning',
+  release: 'warning',
   fill: 'primary',
   bot_stopped_release: 'default',
 }

--- a/src/ante/treasury/treasury.py
+++ b/src/ante/treasury/treasury.py
@@ -8,7 +8,7 @@ import math
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from ante.account.scoping import require_account_id
 from ante.treasury.models import BotBudget
@@ -20,6 +20,33 @@ if TYPE_CHECKING:
     from ante.trade.position import PositionHistory
 
 logger = logging.getLogger(__name__)
+
+# Treasury transaction type vocabulary (code SSOT).
+#
+# 5-value vocabulary, drift-checked against:
+#   - docs/specs/treasury/06-database-schema.md transaction_type 주석
+#   - frontend/src/types/treasury.ts TransactionType union
+#
+# 의미:
+#   - allocate            : 봇에 예산 할당 (Treasury.allocate)
+#   - deallocate          : 봇에서 예산 회수 (Treasury.deallocate)
+#   - release             : 봇 삭제 시 할당 예산 전액 환수 (Treasury.release_budget)
+#   - fill                : 주문 체결로 인한 자금 이동 기록 (_on_order_filled)
+#   - bot_stopped_release : 봇 중지 시 잔여 예약 자금 환수 (_on_bot_stopped)
+#
+# 새 값 추가 시 spec/frontend 동시 갱신과 drift regression 테스트
+# (tests/unit/test_treasury_transaction_vocabulary.py) 통과가 필요하다.
+TransactionType = Literal[
+    "allocate",
+    "deallocate",
+    "release",
+    "fill",
+    "bot_stopped_release",
+]
+
+TRANSACTION_TYPE_VOCABULARY: frozenset[str] = frozenset(
+    {"allocate", "deallocate", "release", "fill", "bot_stopped_release"}
+)
 
 TREASURY_SCHEMA = """
 CREATE TABLE IF NOT EXISTS bot_budgets (
@@ -1689,11 +1716,19 @@ class Treasury:
     async def _log_transaction(
         self,
         bot_id: str,
-        tx_type: str,
+        tx_type: TransactionType,
         amount: float,
         description: str = "",
     ) -> None:
-        """자금 거래 이력 기록."""
+        """자금 거래 이력 기록.
+
+        ``tx_type``는 ``TRANSACTION_TYPE_VOCABULARY``에 속한 값만 허용한다
+        (Literal 타입 힌트로 future drift를 차단). 새 값이 필요하면 spec
+        (``docs/specs/treasury/06-database-schema.md``), frontend
+        (``frontend/src/types/treasury.ts``), drift regression 테스트
+        (``tests/unit/test_treasury_transaction_vocabulary.py``)를 동시에
+        갱신해야 한다.
+        """
         await self._db.execute(
             """INSERT INTO treasury_transactions
                (bot_id, account_id, transaction_type, amount, description)

--- a/tests/unit/test_treasury_transaction_vocabulary.py
+++ b/tests/unit/test_treasury_transaction_vocabulary.py
@@ -1,0 +1,149 @@
+"""Treasury transaction_type vocabulary drift regression.
+
+이슈 #1476 (split of #1443/A): code/spec/frontend 3-way vocabulary 정규화.
+
+5-value vocabulary: ``allocate``, ``deallocate``, ``release``, ``fill``,
+``bot_stopped_release``.
+
+본 테스트는 vocabulary가 3-way drift 없이 일관되게 유지되는지를 검증한다:
+
+1. 코드 SSOT 동결 -- ``TRANSACTION_TYPE_VOCABULARY``가 5-value frozenset인지.
+2. 코드 truth -- ``src/ante/treasury`` 내 모든 ``tx_type="..."`` /
+   ``tx_type, "..."`` literal writer가 vocabulary에 속하는지.
+3. 스펙 동기화 -- ``docs/specs/treasury/06-database-schema.md`` 주석에 5개 값이
+   모두 substring으로 명시되는지.
+4. 프런트엔드 동기화 -- ``frontend/src/types/treasury.ts``의 ``TransactionType``
+   union에 5개 값이 모두 명시되는지.
+
+새 writer가 vocabulary 밖 값을 도입하거나 spec/frontend가 누락하면 이 테스트가
+즉시 FAIL하여 contract-drift를 차단한다.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from ante.treasury.treasury import TRANSACTION_TYPE_VOCABULARY
+
+EXPECTED_VOCABULARY = frozenset(
+    {"allocate", "deallocate", "release", "fill", "bot_stopped_release"}
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TREASURY_SRC_DIR = REPO_ROOT / "src" / "ante" / "treasury"
+SPEC_PATH = REPO_ROOT / "docs" / "specs" / "treasury" / "06-database-schema.md"
+FRONTEND_TYPES_PATH = REPO_ROOT / "frontend" / "src" / "types" / "treasury.ts"
+
+
+def test_vocabulary_constant_is_frozen_to_5_values() -> None:
+    """코드 SSOT (``TRANSACTION_TYPE_VOCABULARY``)가 5-value로 동결되어야 한다."""
+    assert TRANSACTION_TYPE_VOCABULARY == EXPECTED_VOCABULARY
+
+
+def test_vocabulary_constant_is_immutable_frozenset() -> None:
+    """타입이 ``frozenset``이어야 한다 (런타임 mutation 차단)."""
+    assert isinstance(TRANSACTION_TYPE_VOCABULARY, frozenset)
+
+
+def _collect_tx_type_literals_in_treasury_sources() -> set[str]:
+    """``src/ante/treasury`` 하위에서 ``_log_transaction`` writer가 사용하는
+    transaction type literal을 수집한다.
+
+    두 가지 호출 스타일을 모두 커버한다:
+      - keyword: ``tx_type="allocate"``
+      - positional: ``self._log_transaction(bot_id, "allocate", amount)``
+
+    keyword는 직접 정규식으로, positional은 ``_log_transaction(`` 호출의 두 번째
+    인자 위치 string literal을 정규식으로 추출한다.
+    """
+    keyword_pattern = re.compile(r'tx_type\s*=\s*"([^"]+)"')
+    positional_pattern = re.compile(
+        r'_log_transaction\(\s*[^,()]+,\s*"([^"]+)"',
+        flags=re.DOTALL,
+    )
+
+    found: set[str] = set()
+    for py_path in TREASURY_SRC_DIR.rglob("*.py"):
+        text = py_path.read_text(encoding="utf-8")
+        for match in keyword_pattern.finditer(text):
+            found.add(match.group(1))
+        for match in positional_pattern.finditer(text):
+            found.add(match.group(1))
+    return found
+
+
+def test_all_treasury_writers_use_vocabulary_values() -> None:
+    """모든 ``_log_transaction`` writer가 vocabulary에 속한 값만 사용해야 한다.
+
+    새 transaction type을 도입하려는 writer가 vocabulary/spec/frontend 갱신 없이
+    추가되면 즉시 FAIL.
+    """
+    literals = _collect_tx_type_literals_in_treasury_sources()
+    assert literals, (
+        "Treasury source에서 _log_transaction tx_type literal을 하나도 발견하지 "
+        "못했다. 수집 정규식이나 호출 사이트를 점검하라."
+    )
+    unknown = literals - TRANSACTION_TYPE_VOCABULARY
+    assert not unknown, (
+        f"vocabulary에 없는 transaction type literal이 코드에 존재한다: "
+        f"{sorted(unknown)}. spec/frontend/TRANSACTION_TYPE_VOCABULARY를 함께 "
+        f"갱신하라."
+    )
+
+
+def test_all_writer_literals_are_covered_by_vocabulary_subset() -> None:
+    """수집된 writer literal이 vocabulary의 부분집합이어야 한다 (대칭 확인)."""
+    literals = _collect_tx_type_literals_in_treasury_sources()
+    assert literals.issubset(TRANSACTION_TYPE_VOCABULARY)
+
+
+def test_spec_database_schema_lists_all_vocabulary_values() -> None:
+    """``06-database-schema.md`` 주석이 5개 값 모두를 substring으로 명시해야 한다."""
+    assert SPEC_PATH.exists(), f"spec 파일이 없다: {SPEC_PATH}"
+    text = SPEC_PATH.read_text(encoding="utf-8")
+    missing = [value for value in EXPECTED_VOCABULARY if f"'{value}'" not in text]
+    assert not missing, (
+        f"spec ({SPEC_PATH.relative_to(REPO_ROOT)})에 누락된 값: {sorted(missing)}. "
+        f"transaction_type 주석을 갱신하라."
+    )
+
+
+def test_spec_database_schema_does_not_contain_dead_reserve_value() -> None:
+    """제거된 ``'reserve'`` 값이 spec transaction_type 주석에 남아 있지 않아야 한다.
+
+    ``'reserve'``는 코드 writer가 없는 dead value였다. spec 본문 주석에 다시
+    노출되면 contract drift이므로 차단한다 (다른 단락에서 ``reserved`` 컬럼 등은
+    별개 단어이므로 quoted literal만 검사한다).
+    """
+    text = SPEC_PATH.read_text(encoding="utf-8")
+    assert "'reserve'" not in text, (
+        "spec에서 dead transaction type literal 'reserve'를 제거하라."
+    )
+
+
+def test_frontend_transaction_type_union_lists_all_vocabulary_values() -> None:
+    """``frontend/src/types/treasury.ts``의 ``TransactionType`` union이 5개 값을
+    모두 명시해야 한다."""
+    assert FRONTEND_TYPES_PATH.exists(), (
+        f"frontend types 파일이 없다: {FRONTEND_TYPES_PATH}"
+    )
+    text = FRONTEND_TYPES_PATH.read_text(encoding="utf-8")
+
+    # union 선언 영역을 추출하여 단순 substring 누락을 검사한다.
+    union_match = re.search(
+        r"export\s+type\s+TransactionType\s*=\s*([^\n]*(?:\n[^\n]*)*?)\n\n",
+        text,
+    )
+    assert union_match, (
+        "TransactionType union 선언을 frontend types 파일에서 찾지 못했다."
+    )
+    union_block = union_match.group(0)
+
+    missing = [
+        value for value in EXPECTED_VOCABULARY if f"'{value}'" not in union_block
+    ]
+    assert not missing, (
+        f"frontend TransactionType union에 누락된 값: {sorted(missing)}. "
+        f"frontend/src/types/treasury.ts를 갱신하라."
+    )


### PR DESCRIPTION
Closes #1476

## Summary
- Treasury transaction type vocabulary normalize: 5-value (`allocate`, `deallocate`, `release`, `fill`, `bot_stopped_release`).
- Spec의 `reserve` 제거 (코드 미작성). Frontend `release` 추가 (누락이었음). `bot_stopped_release` 채택 (production 데이터 존재).
- `TRANSACTION_TYPE_VOCABULARY: frozenset[str]` + `TransactionType` Literal alias → `_log_transaction` 시그니처 narrowing.
- drift regression 7 tests: vocabulary 동결 / writer literal grep / spec substring / frontend union substring / `'reserve'` 제거 검증.

## Test Plan
- [x] `pytest tests/unit -k treasury` → 373 passed
- [x] `pytest tests/unit/test_treasury_transaction_vocabulary.py` → 7 passed (신규)
- [x] `cd frontend && npm run build` 통과 (TS union 변경)
- [x] `ruff check src tests` / `ruff format --check src tests` 통과

## Non-goals (별도 split issue)
- GET `/api/treasury/transactions` Literal narrowing (#1477)
- DB row 마이그레이션 (compatibility/rollback 미명시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)