### PR TITLE
fix(frontend,member): separate display HumanRole from API ApiMemberRole (#1467)

### DIFF
--- a/frontend/src/api/members.ts
+++ b/frontend/src/api/members.ts
@@ -12,6 +12,7 @@ import type {
   ScopesUpdateRequest as ApiScopesUpdateRequest,
 } from '../types/api.generated'
 import type {
+  ApiMemberRole,
   HumanRole,
   Member,
   MemberCreateInput,
@@ -30,9 +31,33 @@ function toMemberStatus(value: string): MemberStatus {
   return 'active'
 }
 
-function toHumanRole(value: string): HumanRole | undefined {
-  if (value === 'owner' || value === 'master' || value === 'admin') return value
+/**
+ * Backend ``MemberInfo.role`` 을 display 용 {@link HumanRole} 로 변환한다.
+ *
+ * - ``master`` / ``admin`` 은 동일 이름으로 매핑된다.
+ * - ``default`` 는 display 측에서 role 뱃지를 표시하지 않으므로 ``undefined`` 로
+ *   매핑한다.
+ * - ``owner`` 는 backend ``MemberRole`` enum 에 존재하지 않지만, 과거 데이터나
+ *   legacy admin 도구가 ``owner`` 로 기록한 경우 ``undefined`` 로 정규화하고
+ *   display sentinel 은 ``member_id === 'owner'`` 기반 derive 에서 채운다
+ *   (#1467 — split #1417/C). 어떤 경우에도 backend 응답의 ``owner`` 를 그대로
+ *   ``HumanRole`` 로 노출하지 않는다.
+ */
+function toDisplayRole(value: string, memberId: string): HumanRole | undefined {
+  if (memberId === 'owner') return 'owner'
+  if (value === 'master' || value === 'admin') return value
   return undefined
+}
+
+/**
+ * 호출부에서 받은 {@link MemberCreateInput.role} 을 API payload 용
+ * {@link ApiMemberRole} 로 정규화한다. ``MemberCreateInput.role`` 의 타입이
+ * 이미 ``ApiMemberRole | undefined`` 이므로 ``owner`` 는 컴파일 단계에서
+ * 차단되지만, ``default`` 누락 시 명시적으로 채워 generated
+ * ``MemberCreateRequest.role`` 의 required invariant 를 만족시킨다.
+ */
+function toApiMemberRole(role: ApiMemberRole | undefined): ApiMemberRole {
+  return role ?? 'default'
 }
 
 function toOptionalString(value: unknown): string | undefined {
@@ -46,7 +71,7 @@ export function toMemberView(raw: ApiMemberInfo): Member {
     type: toMemberType(raw.type),
     org: raw.org,
     emoji: raw.emoji || undefined,
-    role: toHumanRole(raw.role),
+    role: toDisplayRole(raw.role, raw.member_id),
     status: toMemberStatus(raw.status),
     scopes: raw.scopes,
     last_active_at: raw.last_active_at || undefined,
@@ -86,9 +111,12 @@ export async function getMemberDetail(id: string): Promise<MemberDetail> {
 }
 
 export async function createMember(data: MemberCreateInput): Promise<MemberTokenView> {
+  // `MemberCreateInput.role` 은 `ApiMemberRole` 로 좁혀져 있으므로 display
+  // sentinel `owner` 가 들어올 수 없다 (#1467 — split #1417/C). undefined 일
+  // 때만 백엔드 default 와 동일한 'default' 로 명시 채움.
   const payload: ApiMemberCreateRequest = {
     ...data,
-    role: data.role ?? 'default',
+    role: toApiMemberRole(data.role),
   }
   const res = await client.post<ApiMemberCreateResponse>('/api/members', payload)
   return toMemberTokenView(res.data)

--- a/frontend/src/types/member.ts
+++ b/frontend/src/types/member.ts
@@ -8,7 +8,43 @@
 // ── 프론트엔드 전용 타입 ──────────────────────────────────
 export type MemberStatus = 'active' | 'suspended' | 'revoked'
 export type MemberType = 'human' | 'agent'
+
+/**
+ * UI display 전용 human role.
+ *
+ * - ``owner`` 는 ``member_id === 'owner'`` 로 derive 되는 display sentinel 이다.
+ *   백엔드 `MemberRole` enum 에는 존재하지 않으므로 API payload 로는 절대
+ *   전송되어선 안 된다 (#1467 — split #1417/C).
+ * - ``master`` / ``admin`` 은 backend role 과 1:1 매핑된다.
+ * - backend role 이 ``default`` 인 경우 display 측에서는 role 뱃지를 표시하지
+ *   않으므로 ``HumanRole`` 에 포함시키지 않고 ``MemberView.role`` 을
+ *   ``undefined`` 로 채운다.
+ *
+ * **payload 용도로는 절대 사용하지 말 것.** payload 는 ``ApiMemberRole`` 을
+ * 사용한다.
+ */
 export type HumanRole = 'owner' | 'master' | 'admin'
+
+/**
+ * API payload 용 member role.
+ *
+ * generated ``MemberCreateRequest.role`` 과 동일한 vocabulary (#1465, SSOT:
+ * ``src/ante/member/models.py`` ``MemberRole``). display sentinel ``owner`` 는
+ * 의도적으로 배제되어 컴파일 시점에 payload 전송이 차단된다.
+ *
+ * `MemberCreateRequest.role` 이 좁혀진 후, payload 자리에 ``owner`` 가 섞이지
+ * 않게 하는 SSOT 다 — adapter 와 hooks 는 이 타입만 사용해야 한다.
+ */
+export type ApiMemberRole = 'master' | 'admin' | 'default'
+
+/**
+ * `MemberCreateInput.role` 에 사용하는 별칭. ``ApiMemberRole`` 과 동일하며,
+ * 호출부에서 의미를 명확히 하기 위해 별도 이름을 유지한다.
+ *
+ * @deprecated 새 코드는 {@link ApiMemberRole} 을 직접 사용한다. 기존 호출부
+ *   호환을 위해 별칭만 남긴다.
+ */
+export type MemberCreateRole = ApiMemberRole
 
 export interface MemberView {
   member_id: string
@@ -16,6 +52,11 @@ export interface MemberView {
   type: MemberType
   org: string
   emoji?: string
+  /**
+   * Display 전용 human role. ``HumanRole | undefined`` 이며 payload 로 전송하지
+   * 않는다. backend ``default`` 는 ``undefined`` 로 매핑되고, ``owner`` 는
+   * ``member_id === 'owner'`` 인 경우 adapter 가 derive 한다.
+   */
   role?: HumanRole
   status: MemberStatus
   scopes?: string[]
@@ -31,23 +72,16 @@ export interface MemberDetailView extends MemberView {
 }
 
 /**
- * POST /api/members 요청 body 의 ``role`` 은 ``MemberRole`` enum SSOT
- * (``master`` / ``admin`` / ``default``) 만 허용한다 (#1465 — split #1417/A).
- *
- * display-only ``owner`` 는 ``HumanRole`` 에서 view 측 sentinel 로 남겨두지만
- * ``MemberCreateInput.role`` 에서는 배제해야 한다 — generated
- * ``MemberCreateRequest.role`` enum 이 좁혀지면서 ``owner`` 를 payload 로
- * 전송하면 422 가 되므로 컴파일 시점에 차단한다. ``HumanRole`` 전체 분리는
- * #1467 에서 다룬다.
+ * POST /api/members 요청 body 의 ``role`` 은 {@link ApiMemberRole} 만 허용한다
+ * (#1465, #1467 — split #1417/A·C). display sentinel ``owner`` 는 타입 차원에서
+ * 배제되어, ``createMember()`` 호출부에서 owner role 을 payload 로 보낼 수 없다.
  */
-export type MemberCreateRole = Exclude<HumanRole, 'owner'> | 'default'
-
 export interface MemberCreateInput {
   member_id: string
   member_type: MemberType
   name: string
   org: string
-  role?: MemberCreateRole
+  role?: ApiMemberRole
   scopes: string[]
 }
 


### PR DESCRIPTION
Closes #1467

## Summary
- `HumanRole = 'owner' | 'master' | 'admin'` (display-only; owner is derived from `member_id === 'owner'`).
- New `ApiMemberRole = 'master' | 'admin' | 'default'` SSOT matching backend `MemberRole` enum.
- `MemberCreateInput.role` typed as `ApiMemberRole` — owner cannot reach API payload (compile-time block).
- Adapter `toDisplayRole(value, memberId)` derives owner sentinel from member_id; legacy `role='owner'` responses are ignored.
- MemberCard display code unchanged — already uses member_id derive pattern.

## Test Plan
- [x] `npm run check-api-types` 0 findings
- [x] `npm run build` tsc + vite OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)