### PR TITLE
fix(cli): preflight enum filters + structured error on account/approval/report list (#1462)

### DIFF
--- a/docs/specs/cli/02-design-decisions.md
+++ b/docs/specs/cli/02-design-decisions.md
@@ -102,7 +102,9 @@ JSON 모드(`--format json`)에서는 `{status: "error", code: "...", message: "
 | `BOT_MISSING_REQUIRED_ACCOUNT` | `--account` 생략 시 active 계좌가 0개 또는 2개 이상 | `bot create` |
 | `STRATEGY_VALIDATION_ERROR` | strategy 명령 인자(예: `--status`) 값이 SSOT enum에 없음 | `strategy list` |
 | `UPDATE_SERVER_RUNNING` | `ante update --force` 없이 서버가 실행 중 | `update` |
-| `APPROVAL_VALIDATION_ERROR` | `approval request --type` 값이 SSOT enum에 없음 | `approval request` |
+| `APPROVAL_VALIDATION_ERROR` | approval 명령 인자(`--type`, `--status`) 값이 SSOT enum에 없음 | `approval request`, `approval list` |
+| `ACCOUNT_VALIDATION_ERROR` | account 명령 인자(예: `--status`) 값이 SSOT enum에 없음 | `account list` |
+| `REPORT_VALIDATION_ERROR` | report 명령 인자(예: `--status`) 값이 SSOT enum에 없음 | `report list` |
 
 `--broker-config`는 1.0 범위에서 free-form pass-through(아래 silent ignore trade-off
 참조)이므로 본 이슈에서는 `UNKNOWN_BROKER_CONFIG_KEY`를 정의하지 않는다.

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -40,6 +40,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# CLI preflight copy of AccountStatus values.
+#
+# 실제 SSOT는 `src/ante/account/models.py:12-17`의 `AccountStatus` enum이다.
+# 본 frozenset은 `account.models` heavy import 전에 `--status` 입력을 거부하기
+# 위한 가벼운 차단막이며, enum과의 drift는 동치성 회귀 테스트
+# (`tests/unit/test_cli_account_list_invalid_status.py::
+# test_preflight_set_matches_enum_ssot`)로 차단한다.
+# #1461 strategy list preflight 패턴(#1462에서 일괄 정렬)을 따른다.
+VALID_ACCOUNT_STATUSES: frozenset[str] = frozenset({"active", "suspended", "deleted"})
+
+
 @click.group()
 def account() -> None:
     """계좌 생성·조회·관리."""
@@ -593,9 +604,22 @@ def account_list(ctx: click.Context, status_filter: str | None) -> None:
     """계좌 목록 조회."""
     fmt = get_formatter(ctx)
 
-    from ante.account.models import AccountStatus
+    # Preflight: invalid --status는 account service / DB 진입 전에 차단한다.
+    # `VALID_ACCOUNT_STATUSES`는 `AccountStatus` SSOT의 가벼운 복사본이며,
+    # drift는 enum 동치성 회귀 테스트로 차단한다. 이로써 입력 오타가
+    # `AccountStatus(status_filter)` ValueError → Python traceback으로 새지 않고
+    # flat JSON error로 종료된다. (#1461 strategy list 패턴 정렬 — #1462)
+    if status_filter is not None and status_filter not in VALID_ACCOUNT_STATUSES:
+        fmt.error(
+            f"잘못된 status 값: {status_filter!r}. "
+            f"허용값: {sorted(VALID_ACCOUNT_STATUSES)}",
+            code="ACCOUNT_VALIDATION_ERROR",
+        )
+        raise SystemExit(1)
 
     async def _do_list() -> list[dict]:
+        from ante.account.models import AccountStatus
+
         svc, db = await _create_account_service()
         try:
             status = AccountStatus(status_filter) if status_filter else None
@@ -604,10 +628,15 @@ def account_list(ctx: click.Context, status_filter: str | None) -> None:
         finally:
             await db.close()
 
+    # account.py:683-687 패턴: click.ClickException은 그대로 전파해 click의
+    # 표준 출력 경로를 보존하고, 나머지 일반 Exception은 ACCOUNT_ERROR로
+    # 분류해 구조화된 에러로 종료한다(traceback 노출 차단).
     try:
         rows = _run(_do_list())
+    except click.ClickException:
+        raise
     except Exception as e:
-        fmt.error(str(e))
+        fmt.error(str(e), code="ACCOUNT_ERROR")
         raise SystemExit(1) from e
 
     if not rows:

--- a/src/ante/cli/commands/approval.py
+++ b/src/ante/cli/commands/approval.py
@@ -11,6 +11,41 @@ from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
 
+# CLI preflight copy of ApprovalStatus / ApprovalType values.
+#
+# 실제 SSOT는 `src/ante/approval/models.py:9-33`의 `ApprovalStatus`/`ApprovalType`
+# enum이다. 본 frozenset은 list 명령에서 heavy `ante.approval` 패키지 import
+# 전에 `--status`/`--type` 입력을 거부하기 위한 가벼운 차단막이며, enum과의
+# drift는 동치성 회귀 테스트
+# (`tests/unit/test_cli_approval_list_invalid_filter.py::
+# test_preflight_sets_match_enum_ssot`)로 차단한다.
+# #1461 strategy list preflight 패턴(#1462에서 일괄 정렬)을 따른다.
+VALID_APPROVAL_STATUSES: frozenset[str] = frozenset(
+    {
+        "pending",
+        "approved",
+        "execution_failed",
+        "rejected",
+        "on_hold",
+        "expired",
+        "cancelled",
+    }
+)
+VALID_APPROVAL_TYPES: frozenset[str] = frozenset(
+    {
+        "strategy_adopt",
+        "strategy_retire",
+        "bot_create",
+        "bot_assign_strategy",
+        "bot_change_strategy",
+        "bot_stop",
+        "bot_resume",
+        "bot_delete",
+        "budget_change",
+        "rule_change",
+    }
+)
+
 
 @click.group()
 def approval() -> None:
@@ -103,9 +138,30 @@ def approval_list(
     db_path: str | None,
 ) -> None:
     """결재 목록 조회."""
+    fmt = get_formatter(ctx)
+
+    # Preflight: invalid --status / --type는 heavy `ante.approval` 패키지 / DB
+    # 진입 전에 차단한다. SSOT는 `ApprovalStatus`/`ApprovalType` enum이며,
+    # `VALID_APPROVAL_STATUSES`/`VALID_APPROVAL_TYPES`는 가벼운 복사본이다
+    # (drift는 enum 동치성 회귀 테스트로 차단). 이로써 입력 오타가 service
+    # 내부에서 traceback으로 새지 않고 flat JSON error로 종료된다.
+    # (#1461 strategy list 패턴 정렬 — #1462)
+    if status is not None and status not in VALID_APPROVAL_STATUSES:
+        fmt.error(
+            f"잘못된 status 값: {status!r}. 허용값: {sorted(VALID_APPROVAL_STATUSES)}",
+            code="APPROVAL_VALIDATION_ERROR",
+        )
+        raise SystemExit(1)
+    if approval_type is not None and approval_type not in VALID_APPROVAL_TYPES:
+        fmt.error(
+            f"잘못된 type 값: {approval_type!r}. "
+            f"허용값: {sorted(VALID_APPROVAL_TYPES)}",
+            code="APPROVAL_VALIDATION_ERROR",
+        )
+        raise SystemExit(1)
+
     from ante.cli.main import get_db_path
 
-    fmt = get_formatter(ctx)
     resolved_db_path = db_path or get_db_path(ctx)
 
     async def _list() -> list[dict]:
@@ -133,9 +189,13 @@ def approval_list(
             for r in requests
         ]
 
+    # click.ClickException은 click의 표준 출력 경로를 보존하기 위해 그대로
+    # 전파하고, 그 외 일반 Exception은 APPROVAL_ERROR로 분류한다.
     try:
         rows = asyncio.run(_list())
         fmt.table(rows, ["id", "type", "status", "requester", "title", "created_at"])
+    except click.ClickException:
+        raise
     except Exception as e:
         fmt.error(str(e), code="APPROVAL_ERROR")
         raise SystemExit(1) from e

--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -12,6 +12,19 @@ from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
 from ante.web.schemas import ReportSubmitRequest
 
+# CLI preflight copy of ReportStatus values.
+#
+# 실제 SSOT는 `src/ante/report/models.py:11-19`의 `ReportStatus` enum이다.
+# 본 frozenset은 list 명령에서 heavy `ante.report` 패키지 import 전에
+# `--status` 입력을 거부하기 위한 가벼운 차단막이며, enum과의 drift는 동치성
+# 회귀 테스트
+# (`tests/unit/test_cli_report_list_invalid_status.py::
+# test_preflight_set_matches_enum_ssot`)로 차단한다.
+# #1461 strategy list preflight 패턴(#1462에서 일괄 정렬)을 따른다.
+VALID_REPORT_STATUSES: frozenset[str] = frozenset(
+    {"draft", "submitted", "reviewed", "adopted", "rejected", "archived"}
+)
+
 
 @click.group()
 def report() -> None:
@@ -172,10 +185,23 @@ def submit(
 @require_scope("report:read")
 def report_list(ctx: click.Context, status: str | None, db_path: str | None) -> None:
     """리포트 목록 조회."""
+    fmt = get_formatter(ctx)
+
+    # Preflight: invalid --status는 heavy `ante.report` 패키지 / DB 진입 전에
+    # 차단한다. SSOT는 `ReportStatus` enum이며, `VALID_REPORT_STATUSES`는
+    # 가벼운 복사본이다(drift는 enum 동치성 회귀 테스트로 차단). 이로써 입력
+    # 오타가 `ReportStatus(status)` ValueError → Python traceback으로 새지
+    # 않고 flat JSON error로 종료된다. (#1461 strategy list 패턴 정렬 — #1462)
+    if status is not None and status not in VALID_REPORT_STATUSES:
+        fmt.error(
+            f"잘못된 status 값: {status!r}. 허용값: {sorted(VALID_REPORT_STATUSES)}",
+            code="REPORT_VALIDATION_ERROR",
+        )
+        raise SystemExit(1)
+
     from ante.cli.main import get_db_path
     from ante.report import ReportStore
 
-    fmt = get_formatter(ctx)
     resolved_db_path = db_path or get_db_path(ctx)
 
     async def _list() -> list[dict]:
@@ -198,9 +224,13 @@ def report_list(ctx: click.Context, status: str | None, db_path: str | None) -> 
             for r in reports
         ]
 
+    # click.ClickException은 click의 표준 출력 경로를 보존하기 위해 그대로
+    # 전파하고, 그 외 일반 Exception은 REPORT_ERROR로 분류한다.
     try:
         rows = asyncio.run(_list())
         fmt.table(rows, ["report_id", "strategy", "status", "submitted_at"])
+    except click.ClickException:
+        raise
     except Exception as e:
         fmt.error(str(e), code="REPORT_ERROR")
         raise SystemExit(1) from e

--- a/tests/unit/test_cli_account_list_invalid_status.py
+++ b/tests/unit/test_cli_account_list_invalid_status.py
@@ -1,0 +1,250 @@
+"""CLI account list --status invalid 입력 검증 회귀 테스트 (#1462).
+
+`ante --format json account list --status <invalid>`가 Python traceback이 아닌
+flat JSON error(`ACCOUNT_VALIDATION_ERROR`)로 종료하는지, 그리고 account
+service 진입이 선제 차단되는지 검증한다. #1461 strategy list 패턴을 따른다.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from ante.account.models import AccountStatus
+from ante.cli.commands.account import VALID_ACCOUNT_STATUSES
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _mock_db():
+    db = MagicMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    return db
+
+
+def _mock_service(accounts=None):
+    service = MagicMock()
+    service.list = AsyncMock(return_value=accounts or [])
+    return service
+
+
+class TestAccountListInvalidStatus:
+    """`account list --status <invalid>` 입력 검증 (#1462)."""
+
+    def test_invalid_status_json_returns_flat_error(self, runner):
+        """JSON 모드: invalid status → exit 1 + flat JSON error.
+
+        stdout이 `{"status":"error","code":"ACCOUNT_VALIDATION_ERROR",...}`
+        형태여야 하며 Python traceback 흔적이 없어야 한다.
+        """
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "account",
+                "list",
+                "--status",
+                "oracle_invalid_status",
+            ],
+        )
+        assert result.exit_code == 1
+        data = json.loads(result.output.strip())
+        assert data["status"] == "error"
+        assert data["code"] == "ACCOUNT_VALIDATION_ERROR"
+        assert "oracle_invalid_status" in data["message"]
+        assert "Traceback" not in result.output
+        if result.stderr_bytes is not None:
+            assert "Traceback" not in result.stderr
+
+    def test_invalid_status_does_not_invoke_service(self, runner):
+        """invalid status는 `_create_account_service`를 호출하지 않는다 (preflight)."""
+        with patch(
+            "ante.cli.commands.account._create_account_service",
+            new_callable=AsyncMock,
+        ) as mock_create:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "account",
+                    "list",
+                    "--status",
+                    "oracle_invalid_status",
+                ],
+            )
+            assert result.exit_code == 1
+            mock_create.assert_not_called()
+
+    def test_invalid_status_text_mode(self):
+        """text 모드: invalid status → exit 1 + stderr `Error: ...`, stdout 비어있음.
+
+        CliRunner의 stdout/stderr 분리는 생성자 인자(`mix_stderr=False`)로
+        지정해야 하므로 본 케이스만 fixture와 별개로 runner를 만든다.
+        """
+        if "mix_stderr" in inspect.signature(CliRunner).parameters:
+            r = CliRunner(mix_stderr=False)
+        else:
+            r = CliRunner()
+
+        with (
+            patch("ante.cli.main.authenticate_member") as mock_auth,
+            patch(
+                "ante.cli.commands.account._create_account_service",
+                new_callable=AsyncMock,
+            ) as mock_create,
+        ):
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            result = r.invoke(
+                cli,
+                ["account", "list", "--status", "oracle_invalid_status"],
+            )
+
+        assert result.exit_code == 1
+        mock_create.assert_not_called()
+        assert result.stdout == ""
+        assert "Error:" in result.stderr
+        assert "Traceback" not in result.stderr
+
+    def test_no_status_passes_preflight(self, runner):
+        """status 미지정 → preflight 통과 → exit 0."""
+        db = _mock_db()
+        service = _mock_service([])
+
+        with patch(
+            "ante.cli.commands.account._create_account_service",
+            new_callable=AsyncMock,
+            return_value=(service, db),
+        ):
+            result = runner.invoke(cli, ["--format", "json", "account", "list"])
+            assert result.exit_code == 0
+
+    @pytest.mark.parametrize("valid_status", ["active", "suspended", "deleted"])
+    def test_valid_statuses_pass_preflight(self, runner, valid_status):
+        """SSOT enum의 모든 valid value는 preflight를 통과한다."""
+        db = _mock_db()
+        service = _mock_service([])
+
+        with patch(
+            "ante.cli.commands.account._create_account_service",
+            new_callable=AsyncMock,
+            return_value=(service, db),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "account", "list", "--status", valid_status],
+            )
+            assert result.exit_code == 0
+            service.list.assert_called_once_with(status=AccountStatus(valid_status))
+
+    def test_service_hydration_error_maps_to_account_error(self, runner):
+        """service 단계의 일반 Exception은 `ACCOUNT_ERROR`로 분류된다.
+
+        invalid status preflight는 통과하지만 service 진입에서 실패하는
+        시나리오를 시뮬레이션한다.
+        """
+        db = _mock_db()
+        service = MagicMock()
+        service.list = AsyncMock(side_effect=RuntimeError("hydration boom"))
+
+        with patch(
+            "ante.cli.commands.account._create_account_service",
+            new_callable=AsyncMock,
+            return_value=(service, db),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "account",
+                    "list",
+                    "--status",
+                    "active",
+                ],
+            )
+            assert result.exit_code == 1
+            data = json.loads(result.output.strip())
+            assert data["status"] == "error"
+            assert data["code"] == "ACCOUNT_ERROR"
+            assert "hydration boom" in data["message"]
+            assert "Traceback" not in result.output
+
+    def test_click_exception_propagates_without_formatter(self, runner):
+        """`_do_list()` 내부에서 `click.ClickException`이 발생하면 그대로 전파된다.
+
+        formatter를 거치면 click의 표준 출력 경로(`UsageError`/`ClickException.show`)
+        가 깨지므로, `except click.ClickException: raise` 분기로 보존되어야 한다.
+        """
+        db = _mock_db()
+        service = MagicMock()
+        service.list = AsyncMock(
+            side_effect=click.UsageError("intentional click usage error")
+        )
+
+        with patch(
+            "ante.cli.commands.account._create_account_service",
+            new_callable=AsyncMock,
+            return_value=(service, db),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "account",
+                    "list",
+                    "--status",
+                    "active",
+                ],
+            )
+            # click.UsageError → exit_code 2, formatter JSON 미경유.
+            assert result.exit_code == 2
+            assert "intentional click usage error" in result.output
+            # JSON shape이 아니어야 한다(formatter를 거치지 않았다는 회귀).
+            assert '"code": "ACCOUNT_ERROR"' not in result.output
+
+    def test_preflight_set_matches_enum_ssot(self):
+        """CLI preflight copy가 `AccountStatus` SSOT와 동치인지 회귀."""
+        assert VALID_ACCOUNT_STATUSES == {s.value for s in AccountStatus}

--- a/tests/unit/test_cli_approval_list_invalid_filter.py
+++ b/tests/unit/test_cli_approval_list_invalid_filter.py
@@ -1,0 +1,254 @@
+"""CLI approval list --status/--type invalid 입력 검증 회귀 테스트 (#1462).
+
+`ante --format json approval list --status <invalid>` /
+`--type <invalid>`가 Python traceback이 아닌 flat JSON error
+(`APPROVAL_VALIDATION_ERROR`)로 종료하는지, heavy `ante.approval` 패키지
+진입이 선제 차단되는지 검증한다. #1461 strategy list 패턴을 따른다.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from unittest.mock import patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from ante.approval.models import ApprovalStatus, ApprovalType
+from ante.cli.commands.approval import (
+    VALID_APPROVAL_STATUSES,
+    VALID_APPROVAL_TYPES,
+)
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+class TestApprovalListInvalidFilter:
+    """`approval list --status/--type <invalid>` 입력 검증 (#1462)."""
+
+    def test_invalid_status_json_returns_flat_error(self, runner):
+        """JSON 모드: invalid status → exit 1 + flat JSON error."""
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "approval",
+                "list",
+                "--status",
+                "oracle_invalid_status",
+            ],
+        )
+        assert result.exit_code == 1
+        data = json.loads(result.output.strip())
+        assert data["status"] == "error"
+        assert data["code"] == "APPROVAL_VALIDATION_ERROR"
+        assert "oracle_invalid_status" in data["message"]
+        assert "Traceback" not in result.output
+
+    def test_invalid_type_json_returns_flat_error(self, runner):
+        """JSON 모드: invalid type → exit 1 + flat JSON error."""
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "approval",
+                "list",
+                "--type",
+                "oracle_invalid_type",
+            ],
+        )
+        assert result.exit_code == 1
+        data = json.loads(result.output.strip())
+        assert data["status"] == "error"
+        assert data["code"] == "APPROVAL_VALIDATION_ERROR"
+        assert "oracle_invalid_type" in data["message"]
+        assert "Traceback" not in result.output
+
+    def test_invalid_status_does_not_invoke_service(self, runner):
+        """invalid status는 `ApprovalService`를 import하지 않는다 (preflight).
+
+        `ante.approval.ApprovalService`가 heavy import이므로 preflight 단계에서
+        import 자체가 일어나지 않아야 한다. 본 회귀는 `asyncio.run` mock으로
+        list `_list` coroutine이 실행되지 않음을 검증한다.
+        """
+        with patch(
+            "ante.cli.commands.approval.asyncio.run",
+        ) as mock_run:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "approval",
+                    "list",
+                    "--status",
+                    "oracle_invalid_status",
+                ],
+            )
+            assert result.exit_code == 1
+            mock_run.assert_not_called()
+
+    def test_invalid_type_does_not_invoke_service(self, runner):
+        """invalid type은 `ApprovalService`를 import하지 않는다 (preflight)."""
+        with patch(
+            "ante.cli.commands.approval.asyncio.run",
+        ) as mock_run:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "approval",
+                    "list",
+                    "--type",
+                    "oracle_invalid_type",
+                ],
+            )
+            assert result.exit_code == 1
+            mock_run.assert_not_called()
+
+    def test_invalid_status_text_mode(self):
+        """text 모드: invalid status → exit 1 + stderr `Error: ...`, stdout 비어있음."""
+        if "mix_stderr" in inspect.signature(CliRunner).parameters:
+            r = CliRunner(mix_stderr=False)
+        else:
+            r = CliRunner()
+
+        with (
+            patch("ante.cli.main.authenticate_member") as mock_auth,
+            patch("ante.cli.commands.approval.asyncio.run") as mock_run,
+        ):
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            result = r.invoke(
+                cli,
+                ["approval", "list", "--status", "oracle_invalid_status"],
+            )
+
+        assert result.exit_code == 1
+        mock_run.assert_not_called()
+        assert result.stdout == ""
+        assert "Error:" in result.stderr
+        assert "Traceback" not in result.stderr
+
+    def test_no_filters_passes_preflight(self, runner):
+        """status/type 모두 미지정 → preflight 통과 → exit 0."""
+        with patch(
+            "ante.cli.commands.approval.asyncio.run",
+            return_value=[],
+        ):
+            result = runner.invoke(cli, ["--format", "json", "approval", "list"])
+            assert result.exit_code == 0
+
+    @pytest.mark.parametrize("valid_status", [s.value for s in ApprovalStatus])
+    def test_valid_statuses_pass_preflight(self, runner, valid_status):
+        """SSOT enum의 모든 valid status는 preflight를 통과한다."""
+        with patch(
+            "ante.cli.commands.approval.asyncio.run",
+            return_value=[],
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "approval", "list", "--status", valid_status],
+            )
+            assert result.exit_code == 0
+
+    @pytest.mark.parametrize("valid_type", [t.value for t in ApprovalType])
+    def test_valid_types_pass_preflight(self, runner, valid_type):
+        """SSOT enum의 모든 valid type은 preflight를 통과한다."""
+        with patch(
+            "ante.cli.commands.approval.asyncio.run",
+            return_value=[],
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "approval", "list", "--type", valid_type],
+            )
+            assert result.exit_code == 0
+
+    def test_service_hydration_error_maps_to_approval_error(self, runner):
+        """service 단계의 일반 Exception은 `APPROVAL_ERROR`로 분류된다."""
+        with patch(
+            "ante.cli.commands.approval.asyncio.run",
+            side_effect=RuntimeError("hydration boom"),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "approval",
+                    "list",
+                    "--status",
+                    "pending",
+                ],
+            )
+            assert result.exit_code == 1
+            data = json.loads(result.output.strip())
+            assert data["status"] == "error"
+            assert data["code"] == "APPROVAL_ERROR"
+            assert "hydration boom" in data["message"]
+            assert "Traceback" not in result.output
+
+    def test_click_exception_propagates_without_formatter(self, runner):
+        """내부에서 `click.ClickException`이 발생하면 그대로 전파된다."""
+        with patch(
+            "ante.cli.commands.approval.asyncio.run",
+            side_effect=click.UsageError("intentional click usage error"),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "approval",
+                    "list",
+                    "--status",
+                    "pending",
+                ],
+            )
+            assert result.exit_code == 2
+            assert "intentional click usage error" in result.output
+            assert '"code": "APPROVAL_ERROR"' not in result.output
+
+    def test_preflight_sets_match_enum_ssot(self):
+        """CLI preflight copy가 `ApprovalStatus`/`ApprovalType` SSOT와 동치인지 회귀."""
+        assert VALID_APPROVAL_STATUSES == {s.value for s in ApprovalStatus}
+        assert VALID_APPROVAL_TYPES == {t.value for t in ApprovalType}

--- a/tests/unit/test_cli_report_list_invalid_status.py
+++ b/tests/unit/test_cli_report_list_invalid_status.py
@@ -1,0 +1,192 @@
+"""CLI report list --status invalid 입력 검증 회귀 테스트 (#1462).
+
+`ante --format json report list --status <invalid>`가 Python traceback이 아닌
+flat JSON error(`REPORT_VALIDATION_ERROR`)로 종료하는지, heavy `ante.report`
+패키지 진입이 선제 차단되는지 검증한다. #1461 strategy list 패턴을 따른다.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from unittest.mock import patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.commands.report import VALID_REPORT_STATUSES
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+from ante.report.models import ReportStatus
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+class TestReportListInvalidStatus:
+    """`report list --status <invalid>` 입력 검증 (#1462)."""
+
+    def test_invalid_status_json_returns_flat_error(self, runner):
+        """JSON 모드: invalid status → exit 1 + flat JSON error."""
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "report",
+                "list",
+                "--status",
+                "oracle_invalid_status",
+            ],
+        )
+        assert result.exit_code == 1
+        data = json.loads(result.output.strip())
+        assert data["status"] == "error"
+        assert data["code"] == "REPORT_VALIDATION_ERROR"
+        assert "oracle_invalid_status" in data["message"]
+        assert "Traceback" not in result.output
+
+    def test_invalid_status_does_not_invoke_service(self, runner):
+        """invalid status는 `_list` coroutine을 실행하지 않는다 (preflight)."""
+        with patch(
+            "ante.cli.commands.report.asyncio.run",
+        ) as mock_run:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "list",
+                    "--status",
+                    "oracle_invalid_status",
+                ],
+            )
+            assert result.exit_code == 1
+            mock_run.assert_not_called()
+
+    def test_invalid_status_text_mode(self):
+        """text 모드: invalid status → exit 1 + stderr `Error: ...`, stdout 비어있음."""
+        if "mix_stderr" in inspect.signature(CliRunner).parameters:
+            r = CliRunner(mix_stderr=False)
+        else:
+            r = CliRunner()
+
+        with (
+            patch("ante.cli.main.authenticate_member") as mock_auth,
+            patch("ante.cli.commands.report.asyncio.run") as mock_run,
+        ):
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            result = r.invoke(
+                cli,
+                ["report", "list", "--status", "oracle_invalid_status"],
+            )
+
+        assert result.exit_code == 1
+        mock_run.assert_not_called()
+        assert result.stdout == ""
+        assert "Error:" in result.stderr
+        assert "Traceback" not in result.stderr
+
+    def test_no_status_passes_preflight(self, runner):
+        """status 미지정 → preflight 통과 → exit 0."""
+        with patch(
+            "ante.cli.commands.report.asyncio.run",
+            return_value=[],
+        ):
+            result = runner.invoke(cli, ["--format", "json", "report", "list"])
+            assert result.exit_code == 0
+
+    @pytest.mark.parametrize("valid_status", [s.value for s in ReportStatus])
+    def test_valid_statuses_pass_preflight(self, runner, valid_status):
+        """SSOT enum의 모든 valid value는 preflight를 통과한다."""
+        with patch(
+            "ante.cli.commands.report.asyncio.run",
+            return_value=[],
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "report", "list", "--status", valid_status],
+            )
+            assert result.exit_code == 0
+
+    def test_service_hydration_error_maps_to_report_error(self, runner):
+        """service 단계의 일반 Exception은 `REPORT_ERROR`로 분류된다."""
+        with patch(
+            "ante.cli.commands.report.asyncio.run",
+            side_effect=RuntimeError("hydration boom"),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "list",
+                    "--status",
+                    "submitted",
+                ],
+            )
+            assert result.exit_code == 1
+            data = json.loads(result.output.strip())
+            assert data["status"] == "error"
+            assert data["code"] == "REPORT_ERROR"
+            assert "hydration boom" in data["message"]
+            assert "Traceback" not in result.output
+
+    def test_click_exception_propagates_without_formatter(self, runner):
+        """내부에서 `click.ClickException`이 발생하면 그대로 전파된다."""
+        with patch(
+            "ante.cli.commands.report.asyncio.run",
+            side_effect=click.UsageError("intentional click usage error"),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "list",
+                    "--status",
+                    "submitted",
+                ],
+            )
+            assert result.exit_code == 2
+            assert "intentional click usage error" in result.output
+            assert '"code": "REPORT_ERROR"' not in result.output
+
+    def test_preflight_set_matches_enum_ssot(self):
+        """CLI preflight copy가 `ReportStatus` SSOT와 동치인지 회귀."""
+        assert VALID_REPORT_STATUSES == {s.value for s in ReportStatus}


### PR DESCRIPTION
Closes #1462

## Summary
Applied #1461 pattern (preflight enum + structured error + click.ClickException propagate + heavy import isolation) to:
- `account list --status` → `ACCOUNT_VALIDATION_ERROR`
- `approval list --status/--type` → `APPROVAL_VALIDATION_ERROR`
- `report list --status` → `REPORT_VALIDATION_ERROR`

Excluded (already `click.Choice` strict): `member list`, `rule list`.

## Test Plan
- [x] `pytest tests/unit -k cli` → 703 passed (regression 0)
- [x] `pytest tests/unit -k 'account or approval or report or strategy'` → 1604 passed
- [x] 3 new test files (each 7-9 scenarios mirroring #1461)
- [x] `ruff check` / `ruff format --check` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)