### PR TITLE
feat(approval,cli): audit-types + cancel-invalid for legacy invalid approval cleanup (#1472)

### DIFF
--- a/docs/runbooks/07-legacy-invalid-approval-cleanup.md
+++ b/docs/runbooks/07-legacy-invalid-approval-cleanup.md
@@ -1,0 +1,129 @@
+# Legacy Invalid Approval Type Cleanup
+
+> 운영 런북 — invalid `ApprovalType` row 식별 및 정리 절차 (#1418 → #1472)
+
+## 배경
+
+`ApprovalType` enum SSOT(`src/ante/approval/models.py`)에 정의된 10개 유형 외의
+값은 `ante approval request` 와 `ApprovalService.create()` 양쪽 모두에서 거부된다
+(#1469). 또한 invalid type pending row를 `approve()` 로 진행시키려는 시도는
+`ValueError` 로 차단되며, executor 미등록도 `EXECUTION_FAILED` 로 마감된다 (#1470).
+
+하지만 이 가드들이 도입되기 이전(또는 raw SQL/마이그레이션으로 직접 INSERT된)에
+저장된 invalid type approval row는 DB에 그대로 남을 수 있다. 그 row는 다음 경로
+모두에서 종결될 수 없다.
+
+- `ante approval approve <id>` → #1470 enum 가드가 `ValueError`로 차단.
+- `ante approval reject <id>` → 동작은 하지만 invalid type을 "정상 reject" 처럼
+  처리해 audit trail에 노이즈가 남는다.
+- `ante approval cancel <id>` → `requester` 본인만 호출 가능 (`#1186`). 다른
+  agent가 만든 row 는 운영자가 정리할 수 없다.
+- 자연 만료 (`expire_stale`) → `expires_at` 이 지정된 row 만 만료된다.
+
+이 런북은 운영자가 위 row를 안전하게 식별하고 정리하기 위한 절차를 정의한다.
+
+## 식별
+
+### `ante approval audit-types`
+
+`ApprovalType` SSOT에 없는 모든 approval row를 출력한다 (read-only).
+
+```bash
+# table 모드 (사람 친화)
+ante approval audit-types
+
+# json 모드 (스크립트 친화)
+ante approval audit-types --format json
+```
+
+출력 컬럼:
+
+| 컬럼 | 설명 |
+|------|------|
+| `id` | approval row의 UUID |
+| `type` | 저장된 invalid type 문자열 |
+| `status` | 현재 상태 (pending / approved / rejected / ...) |
+| `requester` | 요청을 만든 member_id |
+| `title` | 요청 제목 |
+| `created_at` | 생성 시각 (ISO 8601) |
+| `resolved_at` | 종결 시각. 비어있으면 미종결. |
+
+`status=pending` 이고 `resolved_at` 이 비어있는 row가 정리 대상이다. 이미 종결된
+(`approved`/`rejected`/`cancelled`/`expired`/`execution_failed`) row도 audit 결과에
+포함되지만, 정리 대상은 아니다 (audit trail 보존).
+
+### 직접 SQL 조회 (참고)
+
+CLI 없이 직접 확인할 때:
+
+```sql
+SELECT id, type, status, requester, title, created_at, resolved_at
+FROM approvals
+WHERE type NOT IN (
+  'strategy_adopt','strategy_retire','bot_create','bot_assign_strategy',
+  'bot_change_strategy','bot_stop','bot_resume','bot_delete',
+  'budget_change','rule_change'
+)
+ORDER BY created_at ASC;
+```
+
+valid type 목록은 `ApprovalType` enum이 SSOT이므로, enum이 변경되면 본 SQL도
+업데이트한다. 자동화 스크립트는 CLI (`audit-types --format json`) 사용을 권장한다.
+
+## Cleanup
+
+### `ante approval cancel-invalid`
+
+invalid type 미종결 row를 운영자 권한으로 cancel 처리한다. `approval:admin`
+scope가 필요하다.
+
+```bash
+ante approval cancel-invalid --id <approval_id> --reason "legacy cleanup"
+```
+
+수행 내용:
+
+1. row를 조회해 `type not in ApprovalType` 인지 확인. valid 면 거부.
+2. `resolved_at` 이 비어있는지 확인. 이미 종결된 row면 거부 (audit 보존).
+3. `status` 를 `cancelled` 로 전이하고 `resolved_at`/`resolved_by` 를 기록.
+4. `history` 에 `force_cancelled` action 을 append.
+   - 일반 `cancelled` action 과 구별되어 사후 audit 시 운영자 강제 정리임을
+     식별할 수 있다.
+5. `ApprovalResolvedEvent` 와 결재 처리 완료 notification을 발행.
+
+### 절차
+
+1. `ante approval audit-types --format json` 으로 invalid row 목록을 확보한다.
+2. 각 row 에 대해 `ante approval info <id>` 로 본문/params 를 확인한다.
+   - row를 만든 agent와 시점, audit 흔적이 보존되는지 확인.
+3. 정리 대상 row마다 `ante approval cancel-invalid --id <id> --reason ...` 실행.
+4. 실행 후 `ante approval info <id>` 로 다음을 검증:
+   - `status == "cancelled"`
+   - `resolved_at` 이 비어있지 않음
+   - `history` 에 `force_cancelled` action 이 마지막에 추가됨
+5. (선택) 처리 완료 알림이 expected notification channel(Telegram 등)에 도달했는지
+   확인한다.
+
+### audit/log 확인
+
+- 모든 force-cancel 동작은 `logger.warning("invalid approval type force-cancel: ...")`
+  로 기록된다. 로그 디렉토리(`<config_dir>/logs/`) 또는 journald에서 추출 가능.
+- DB `approvals.history` 컬럼에 `{"action": "force_cancelled", "actor": ..., "at": ..., "detail": ...}`
+  엔트리가 영구 보존된다. 일반 cancel(`action: "cancelled"`) 과 구별된다.
+- EventBus 의 `ApprovalResolvedEvent` 가 발행되므로 downstream 구독자(notification,
+  audit logger)가 정상 cancel과 동일한 경로로 추적한다.
+
+## Pass condition
+
+- 운영자가 invalid type approval row를 CLI 한 줄로 식별할 수 있다 (`audit-types`).
+- 운영자가 cancel/cleanup 경로로 invalid pending row를 안전하게 종결할 수 있다
+  (`cancel-invalid`).
+- 정리된 row는 `history` 와 `ApprovalResolvedEvent` 양쪽 모두에서 audit 가능하다.
+- 정상 (valid type) approval row는 본 절차로 강제 종결되지 않는다.
+
+## 비범위
+
+- CLI write path 입력 검증 (#1469)
+- approve guard / executor missing 처리 (#1470)
+- frontend unknown type 표시 (#1471)
+- 자동 migration/삭제 — 운영자 명시적 cleanup 만 지원한다.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -16,6 +16,7 @@
 | [04-ci-cd.md](04-ci-cd.md) | CI/CD 파이프라인, 리뷰/승인/머지 게이트, 저장소 설정 |
 | [05-testing.md](05-testing.md) | 테스트 전략 (단위/통합 테스트, 커버리지, 배포 이미지 시뮬레이션 테스트 방향) |
 | [06-release.md](06-release.md) | 릴리스 운영 (release PR, 버전 관리, PyPI/Docker 배포) |
+| [07-legacy-invalid-approval-cleanup.md](07-legacy-invalid-approval-cleanup.md) | legacy invalid `ApprovalType` row 식별 + cleanup 절차 (`ante approval audit-types` / `cancel-invalid`) |
 
 ## 에이전트 커맨드 (작업 절차 SSOT)
 

--- a/docs/specs/approval/09-cli.md
+++ b/docs/specs/approval/09-cli.md
@@ -72,3 +72,21 @@ ante approval reopen <id> \
 ante approval approve <id>
 ante approval reject <id> --reason "현 시점 리스크 과다"
 ```
+
+### `ante approval audit-types` / `ante approval cancel-invalid`
+
+운영자가 `ApprovalType` SSOT(enum)에 없는 legacy invalid type approval row를 식별하고 정리하기
+위한 admin 도구다. `#1469`(write-path 검증) 이전에 저장된 invalid pending row가 DB에 남아 있을
+경우, `approve`/`cancel` 경로로는 종결할 수 없다(#1470 가드가 approve를, requester 제약이 일반
+cancel을 차단한다). 본 명령들은 `approval:admin` scope를 요구한다.
+
+```
+# invalid type row 식별 (read-only)
+ante approval audit-types [--format json] [--db-path <경로>]
+
+# invalid type row 강제 cancel (status → cancelled, history 에 force_cancelled 기록)
+ante approval cancel-invalid --id <approval_id> [--reason "legacy cleanup"] [--format json]
+```
+
+상세 절차는 [runbooks/07-legacy-invalid-approval-cleanup.md](../../runbooks/07-legacy-invalid-approval-cleanup.md)
+를 참조한다.

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -465,6 +465,8 @@ ante approval cancel <approval_id>          # 승인 요청 취소
 ante approval approve <approval_id>         # 승인 요청 승인
 ante approval reject <approval_id>          # 승인 요청 거부
 ante approval reopen <approval_id> [--data <json>]  # 거절된 요청 재상신 (params/body 수정 가능)
+ante approval audit-types                   # ApprovalType SSOT 에 없는 invalid type row 식별 (admin)
+ante approval cancel-invalid --id <approval_id> [--reason <text>]  # legacy invalid type row 강제 cancel (admin)
 ```
 
 ### `ante init` — 시스템 초기 설정

--- a/src/ante/approval/service.py
+++ b/src/ante/approval/service.py
@@ -609,6 +609,131 @@ class ApprovalService:
         logger.info("검토 의견 추가: %s by %s (%s)", id, reviewer, result)
         return request
 
+    async def list_invalid_type_approvals(self) -> list[ApprovalRequest]:
+        """``ApprovalType`` SSOT 에 없는 ``type`` 값을 가진 모든 결재 row를 반환한다.
+
+        Refs #1418 → #1472 SPLIT-D: ``ante approval audit-types`` 운영 도구의
+        백엔드. 운영자가 legacy invalid pending row 를 식별하기 위한 read-only
+        조회. 정렬은 ``created_at`` 오름차순으로, 오래된 row 부터 먼저
+        나오도록 한다. resolved row (approved/rejected/cancelled/expired/
+        execution_failed) 도 포함한다 — audit 목적이므로 종결 여부와 무관.
+
+        type 컬럼이 단순 TEXT 이므로 NOT IN 절에 valid 값을 placeholder로
+        나열한다. ``_VALID_APPROVAL_TYPES`` 는 frozenset 이지만 SQL 파라미터
+        순서가 정해져야 하므로 ``ApprovalType`` enum 순서를 따른다.
+        """
+        valid_values = [t.value for t in ApprovalType]
+        placeholders = ",".join("?" for _ in valid_values)
+        query = (
+            "SELECT * FROM approvals "  # noqa: S608
+            f"WHERE type NOT IN ({placeholders}) "
+            "ORDER BY created_at ASC"
+        )
+        rows = await self._db.fetch_all(query, tuple(valid_values))
+        return [self._row_to_request(row) for row in rows]
+
+    async def force_cancel_invalid_type(
+        self,
+        id: str,
+        actor: str,
+        reason: str = "",
+    ) -> ApprovalRequest:
+        """invalid approval type row 를 운영자 권한으로 cancel 처리한다.
+
+        Refs #1418 → #1472 SPLIT-D: ``ante approval cancel-invalid`` 운영 도구의
+        백엔드. 사용 시나리오:
+
+        - DB 에 #1469 (write-path 검증) 적용 이전에 저장된 legacy invalid
+          approval type row 가 남아 있다.
+        - 일반 ``cancel()`` 은 ``request.requester`` 본인만 호출 가능하지만
+          (#1186), 운영자가 다른 agent 가 생성한 invalid row 를 정리해야
+          한다.
+        - ``approve()`` 는 #1470 에서 invalid type 을 ``ValueError`` 로 차단
+          하므로 정상 lifecycle 로 종결할 방법이 없다.
+
+        이 메서드는 admin 운영 표면이며, 다음 invariant 를 보존한다:
+
+        - ``type not in _VALID_APPROVAL_TYPES`` 인 row 만 처리한다. valid type
+          은 ``ValueError`` 로 거부한다 (운영 도구가 정상 row 를 강제 종결
+          시킬 수 없도록).
+        - 이미 종결된 row (resolved_at 이 비어있지 않음) 는 ``ValueError`` 로
+          거부한다 — audit trail 보존.
+        - history 에 ``force_cancelled`` action 을 기록한다. 일반 ``cancel()``
+          의 ``cancelled`` 와 구별되어 사후 audit 가 가능하다.
+        - status 를 :attr:`ApprovalStatus.CANCELLED` 로 전이하고
+          ``ApprovalResolvedEvent`` 와 결재 처리 완료 notification 을 발행한다.
+        """
+        request = await self.get(id)
+        if not request:
+            msg = f"결재 요청을 찾을 수 없음: {id}"
+            raise ValueError(msg)
+
+        if request.type in _VALID_APPROVAL_TYPES:
+            msg = (
+                "force_cancel_invalid_type 은 invalid type row 전용이다 "
+                f"(현재 type: {request.type!r})"
+            )
+            raise ValueError(msg)
+
+        if request.resolved_at:
+            msg = (
+                "이미 종결된 결재 row 는 force-cancel 할 수 없다 "
+                f"(현재 status: {request.status}, resolved_at: {request.resolved_at})"
+            )
+            raise ValueError(msg)
+
+        now = datetime.now(UTC).isoformat()
+        detail = reason or "legacy invalid approval type cleanup"
+        request.history.append(
+            {
+                "action": "force_cancelled",
+                "actor": actor,
+                "at": now,
+                "detail": detail,
+            }
+        )
+
+        await self._db.execute(
+            """UPDATE approvals
+               SET status = ?, resolved_at = ?, resolved_by = ?,
+                   history = ?
+               WHERE id = ?""",
+            (
+                ApprovalStatus.CANCELLED,
+                now,
+                actor,
+                json.dumps(request.history, ensure_ascii=False),
+                id,
+            ),
+        )
+
+        request.status = ApprovalStatus.CANCELLED
+        request.resolved_at = now
+        request.resolved_by = actor
+
+        logger.warning(
+            "invalid approval type force-cancel: %s (type=%s) by %s",
+            id,
+            request.type,
+            actor,
+        )
+
+        from ante.eventbus.events import ApprovalResolvedEvent
+
+        await self._eventbus.publish(
+            ApprovalResolvedEvent(
+                approval_id=id,
+                approval_type=request.type,
+                resolution=ApprovalStatus.CANCELLED,
+                resolved_by=actor,
+            )
+        )
+        await self._publish_resolved_notification(
+            id, request.type, ApprovalStatus.CANCELLED, actor
+        )
+
+        return request
+
     async def expire_stale(self) -> int:
         """만료 기한이 지난 pending 요청 일괄 expired 처리."""
         now = datetime.now(UTC).isoformat()

--- a/src/ante/cli/commands/approval.py
+++ b/src/ante/cli/commands/approval.py
@@ -390,6 +390,136 @@ def reject(ctx: click.Context, id: str, reason: str) -> None:
         raise SystemExit(1) from e
 
 
+@approval.command("audit-types")
+@click.option("--db-path", default=None, help="DB 경로 (미지정 시 config_dir 기반)")
+@format_option
+@click.pass_context
+@require_auth
+@require_scope("approval:admin")
+def audit_types(ctx: click.Context, db_path: str | None) -> None:
+    """``ApprovalType`` SSOT 에 없는 invalid type row 를 식별한다 (#1472).
+
+    legacy invalid approval type pending row 가 DB 에 남아있을 때 운영자가
+    먼저 식별하기 위한 read-only 운영 도구다. 결과는 table/json 두 모드 모두
+    지원한다.
+    """
+    from ante.cli.main import get_db_path
+
+    fmt = get_formatter(ctx)
+    resolved_db_path = db_path or get_db_path(ctx)
+
+    async def _audit() -> list[dict]:
+        from ante.approval import ApprovalService
+        from ante.core.database import Database
+        from ante.eventbus.bus import EventBus
+
+        db = Database(resolved_db_path)
+        await db.connect()
+        eventbus = EventBus()
+        service = ApprovalService(db=db, eventbus=eventbus)
+        await service.initialize()
+
+        requests = await service.list_invalid_type_approvals()
+        await db.close()
+        return [
+            {
+                "id": r.id,
+                "type": r.type,
+                "status": r.status,
+                "requester": r.requester,
+                "title": r.title,
+                "created_at": r.created_at,
+                "resolved_at": r.resolved_at,
+            }
+            for r in requests
+        ]
+
+    try:
+        rows = asyncio.run(_audit())
+        fmt.table(
+            rows,
+            [
+                "id",
+                "type",
+                "status",
+                "requester",
+                "title",
+                "created_at",
+                "resolved_at",
+            ],
+        )
+    except Exception as e:
+        fmt.error(str(e), code="APPROVAL_ERROR")
+        raise SystemExit(1) from e
+
+
+@approval.command("cancel-invalid")
+@click.option("--id", "approval_id", required=True, help="cancel 할 invalid row ID")
+@click.option(
+    "--reason",
+    default="",
+    help="cancel 사유 (audit history 에 기록). 미지정 시 기본 메시지 사용.",
+)
+@click.option("--db-path", default=None, help="DB 경로 (미지정 시 config_dir 기반)")
+@format_option
+@click.pass_context
+@require_auth
+@require_scope("approval:admin")
+def cancel_invalid(
+    ctx: click.Context,
+    approval_id: str,
+    reason: str,
+    db_path: str | None,
+) -> None:
+    """invalid approval type row 를 운영자 권한으로 cancel 처리한다 (#1472).
+
+    일반 ``ante approval cancel`` 은 요청자 본인만 호출 가능하므로 다른
+    agent 가 생성한 legacy invalid row 를 정리할 수 없다. 본 명령은
+    admin scope 를 요구하며, ``ApprovalType`` SSOT 에 없는 row 만 강제
+    cancel 한다. 이미 종결된 row 는 거부된다.
+    """
+    from ante.cli.main import get_db_path
+
+    fmt = get_formatter(ctx)
+    actor = get_member_id(ctx)
+    resolved_db_path = db_path or get_db_path(ctx)
+
+    async def _cancel_invalid() -> dict:
+        from ante.approval import ApprovalService
+        from ante.core.database import Database
+        from ante.eventbus.bus import EventBus
+
+        db = Database(resolved_db_path)
+        await db.connect()
+        eventbus = EventBus()
+        service = ApprovalService(db=db, eventbus=eventbus)
+        await service.initialize()
+
+        req = await service.force_cancel_invalid_type(
+            id=approval_id,
+            actor=actor,
+            reason=reason,
+        )
+        await db.close()
+        return {
+            "id": req.id,
+            "type": req.type,
+            "status": req.status,
+            "resolved_at": req.resolved_at,
+            "resolved_by": req.resolved_by,
+        }
+
+    try:
+        result = asyncio.run(_cancel_invalid())
+        fmt.success(
+            f"invalid approval type cancelled: {result.get('id', approval_id)}",
+            result,
+        )
+    except Exception as e:
+        fmt.error(str(e), code="APPROVAL_ERROR")
+        raise SystemExit(1) from e
+
+
 async def _find_request(service, id: str):  # type: ignore[no-untyped-def]
     """ID 전체 또는 prefix로 결재 요청 검색."""
     req = await service.get(id)

--- a/tests/unit/test_approval_invalid_type_cleanup.py
+++ b/tests/unit/test_approval_invalid_type_cleanup.py
@@ -1,0 +1,446 @@
+"""Legacy invalid approval type cleanup 테스트 (#1472).
+
+운영자가 ``ApprovalType`` SSOT 에 없는 legacy invalid approval row 를 식별
+(``list_invalid_type_approvals``) 하고, 강제 cancel 처리
+(``force_cancel_invalid_type``) 하는 경로를 검증한다.
+
+검증 대상:
+
+- ``list_invalid_type_approvals``
+  - invalid type row 만 반환한다.
+  - valid type row 는 반환하지 않는다.
+  - ``created_at`` 오름차순 정렬을 보존한다.
+  - 종결/미종결 row 모두 audit 목적으로 포함된다.
+- ``force_cancel_invalid_type``
+  - invalid type pending row → CANCELLED 전이 + ``force_cancelled`` history.
+  - ``ApprovalResolvedEvent`` 와 결재 처리 완료 notification 발행.
+  - valid type row 는 ``ValueError`` 로 거부 (운영 도구가 정상 row 를 강제
+    종결 시키지 못함).
+  - 이미 종결된 row 는 ``ValueError`` 로 거부 (audit trail 보존).
+  - 존재하지 않는 ID 는 ``ValueError`` 로 거부.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from ante.approval.models import ApprovalRequest, ApprovalStatus, ApprovalType
+from ante.approval.service import ApprovalService
+from ante.core.database import Database
+from ante.eventbus.bus import EventBus
+from ante.eventbus.events import ApprovalResolvedEvent, NotificationEvent
+
+# ── 헬퍼 ──────────────────────────────────────────────────────────
+
+
+class _EventCollector:
+    """``ApprovalResolvedEvent`` 와 approval-category notification 캡처."""
+
+    def __init__(self) -> None:
+        self.resolved: list[ApprovalResolvedEvent] = []
+        self.resolved_notifications: list[NotificationEvent] = []
+
+    def attach(self, eventbus: EventBus) -> None:
+        eventbus.subscribe(ApprovalResolvedEvent, self._on_resolved)
+        eventbus.subscribe(NotificationEvent, self._on_notification)
+
+    async def _on_resolved(self, event: ApprovalResolvedEvent) -> None:
+        self.resolved.append(event)
+
+    async def _on_notification(self, event: NotificationEvent) -> None:
+        if event.category == "approval" and event.title == "결재 처리 완료":
+            self.resolved_notifications.append(event)
+
+
+async def _seed_invalid_row(
+    db: Database,
+    *,
+    approval_id: str,
+    approval_type: str = "oracle_invalid_type",
+    requester: str = "agent-oracle",
+    status: str = ApprovalStatus.PENDING,
+    created_at: str = "2026-05-10T22:08:18+00:00",
+    resolved_at: str = "",
+    resolved_by: str = "",
+    title: str = "legacy invalid type row",
+) -> None:
+    """invalid approval type row 를 raw INSERT 로 시드한다."""
+    await db.execute(
+        """INSERT INTO approvals
+           (id, type, status, requester, title, body, params,
+            reviews, history, reference_id, expires_at, created_at,
+            resolved_at, resolved_by)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            approval_id,
+            approval_type,
+            status,
+            requester,
+            title,
+            "",
+            json.dumps({}),
+            json.dumps([]),
+            json.dumps(
+                [
+                    {
+                        "action": "created",
+                        "actor": requester,
+                        "at": created_at,
+                        "detail": "",
+                    }
+                ]
+            ),
+            "",
+            "",
+            created_at,
+            resolved_at,
+            resolved_by,
+        ),
+    )
+
+
+# ── 픽스처 ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def db(tmp_path: Any) -> Database:
+    database = Database(str(tmp_path / "approval-1472.db"))
+    await database.connect()
+    return database
+
+
+@pytest.fixture
+async def eventbus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+async def collector(eventbus: EventBus) -> _EventCollector:
+    c = _EventCollector()
+    c.attach(eventbus)
+    return c
+
+
+@pytest.fixture
+async def service(db: Database, eventbus: EventBus) -> ApprovalService:
+    svc = ApprovalService(db=db, eventbus=eventbus)
+    await svc.initialize()
+    return svc
+
+
+# ── list_invalid_type_approvals ───────────────────────────────────
+
+
+class TestListInvalidTypeApprovals:
+    """invalid type row 식별 (read-only)."""
+
+    async def test_empty_db_returns_empty_list(self, service: ApprovalService) -> None:
+        """row 가 없으면 빈 list 반환."""
+        result = await service.list_invalid_type_approvals()
+        assert result == []
+
+    async def test_only_valid_rows_returns_empty_list(
+        self, service: ApprovalService
+    ) -> None:
+        """valid type row 만 있으면 빈 list 반환."""
+        await service.create(
+            type=ApprovalType.STRATEGY_ADOPT,
+            requester="agent-01",
+            title="happy path",
+            params={"strategy_id": "s-1", "report_id": "r-1"},
+        )
+        result = await service.list_invalid_type_approvals()
+        assert result == []
+
+    async def test_invalid_row_identified(
+        self, service: ApprovalService, db: Database
+    ) -> None:
+        """invalid type row 1건 → 1건 반환."""
+        await _seed_invalid_row(db, approval_id="legacy-1")
+
+        result = await service.list_invalid_type_approvals()
+        assert len(result) == 1
+        assert result[0].id == "legacy-1"
+        assert result[0].type == "oracle_invalid_type"
+        assert result[0].status == ApprovalStatus.PENDING
+
+    async def test_invalid_row_mixed_with_valid_filters_correctly(
+        self, service: ApprovalService, db: Database
+    ) -> None:
+        """valid + invalid 가 섞여있어도 invalid 만 반환."""
+        # valid row 1건
+        await service.create(
+            type=ApprovalType.STRATEGY_ADOPT,
+            requester="agent-01",
+            title="valid",
+            params={"strategy_id": "s-1", "report_id": "r-1"},
+        )
+        # invalid row 2건
+        await _seed_invalid_row(
+            db,
+            approval_id="legacy-A",
+            approval_type="oracle_invalid_type",
+            created_at="2026-05-10T22:08:18+00:00",
+        )
+        await _seed_invalid_row(
+            db,
+            approval_id="legacy-B",
+            approval_type="bogus_type_2",
+            created_at="2026-05-11T01:00:00+00:00",
+        )
+
+        result = await service.list_invalid_type_approvals()
+        ids = {r.id for r in result}
+        assert ids == {"legacy-A", "legacy-B"}
+        types = {r.type for r in result}
+        assert "strategy_adopt" not in types
+
+    async def test_order_by_created_at_ascending(
+        self, service: ApprovalService, db: Database
+    ) -> None:
+        """created_at 오름차순 정렬: 가장 오래된 row 가 먼저."""
+        await _seed_invalid_row(
+            db,
+            approval_id="newer",
+            created_at="2026-05-12T00:00:00+00:00",
+        )
+        await _seed_invalid_row(
+            db,
+            approval_id="older",
+            created_at="2026-05-10T00:00:00+00:00",
+        )
+        await _seed_invalid_row(
+            db,
+            approval_id="middle",
+            created_at="2026-05-11T00:00:00+00:00",
+        )
+
+        result = await service.list_invalid_type_approvals()
+        assert [r.id for r in result] == ["older", "middle", "newer"]
+
+    async def test_resolved_invalid_row_also_returned(
+        self, service: ApprovalService, db: Database
+    ) -> None:
+        """audit 목적 — 이미 종결된 invalid row 도 반환된다."""
+        await _seed_invalid_row(
+            db,
+            approval_id="resolved-invalid",
+            status=ApprovalStatus.REJECTED,
+            resolved_at="2026-05-11T00:00:00+00:00",
+            resolved_by="user-master",
+        )
+
+        result = await service.list_invalid_type_approvals()
+        ids = [r.id for r in result]
+        assert "resolved-invalid" in ids
+
+    async def test_all_valid_enum_members_excluded(
+        self, service: ApprovalService
+    ) -> None:
+        """``ApprovalType`` 의 모든 멤버는 invalid 목록에 포함되지 않는다."""
+        for t in ApprovalType:
+            # account-scoped 타입은 account_id 가 필요
+            params: dict = {"account_id": "acct-test"}
+            if t in (ApprovalType.STRATEGY_ADOPT, ApprovalType.STRATEGY_RETIRE):
+                params = {"strategy_id": "s", "report_id": "r"}
+            await service.create(
+                type=t,
+                requester="agent",
+                title=f"valid-{t.value}",
+                params=params,
+            )
+
+        result = await service.list_invalid_type_approvals()
+        assert result == []
+
+
+# ── force_cancel_invalid_type ─────────────────────────────────────
+
+
+class TestForceCancelInvalidType:
+    """invalid pending row 강제 cancel."""
+
+    async def test_pending_invalid_row_cancelled(
+        self,
+        service: ApprovalService,
+        db: Database,
+        collector: _EventCollector,
+    ) -> None:
+        """invalid pending row → CANCELLED + ``force_cancelled`` history."""
+        await _seed_invalid_row(db, approval_id="legacy-1")
+
+        result = await service.force_cancel_invalid_type(
+            id="legacy-1",
+            actor="user-master",
+            reason="legacy cleanup",
+        )
+
+        assert result.status == ApprovalStatus.CANCELLED
+        assert result.resolved_by == "user-master"
+        assert result.resolved_at != ""
+
+        # DB 검증
+        row = await db.fetch_one(
+            "SELECT status, resolved_at, resolved_by, history FROM approvals "
+            "WHERE id = ?",
+            ("legacy-1",),
+        )
+        assert row is not None
+        assert row["status"] == ApprovalStatus.CANCELLED
+        assert row["resolved_by"] == "user-master"
+        assert row["resolved_at"] != ""
+        history = json.loads(row["history"])
+        actions = [entry["action"] for entry in history]
+        assert "force_cancelled" in actions
+        # 일반 cancelled 와 구별되어야 함 — 운영 강제 정리 표시.
+        assert "cancelled" not in actions
+        force = next(e for e in history if e["action"] == "force_cancelled")
+        assert force["actor"] == "user-master"
+        assert force["detail"] == "legacy cleanup"
+
+    async def test_default_reason_when_omitted(
+        self, service: ApprovalService, db: Database
+    ) -> None:
+        """reason 미지정 시 기본 detail 메시지 사용."""
+        await _seed_invalid_row(db, approval_id="legacy-1")
+
+        await service.force_cancel_invalid_type(id="legacy-1", actor="ops")
+
+        row = await db.fetch_one(
+            "SELECT history FROM approvals WHERE id = ?", ("legacy-1",)
+        )
+        assert row is not None
+        history = json.loads(row["history"])
+        force = next(e for e in history if e["action"] == "force_cancelled")
+        assert force["detail"] == "legacy invalid approval type cleanup"
+
+    async def test_publishes_resolved_event(
+        self,
+        service: ApprovalService,
+        db: Database,
+        collector: _EventCollector,
+    ) -> None:
+        """``ApprovalResolvedEvent`` 가 ``cancelled`` resolution 으로 발행."""
+        await _seed_invalid_row(db, approval_id="legacy-1")
+
+        await service.force_cancel_invalid_type(id="legacy-1", actor="ops")
+
+        assert len(collector.resolved) == 1
+        ev = collector.resolved[0]
+        assert ev.approval_id == "legacy-1"
+        assert ev.resolution == ApprovalStatus.CANCELLED
+        assert ev.resolved_by == "ops"
+
+    async def test_publishes_resolved_notification(
+        self,
+        service: ApprovalService,
+        db: Database,
+        collector: _EventCollector,
+    ) -> None:
+        """결재 처리 완료 notification 발행."""
+        await _seed_invalid_row(db, approval_id="legacy-1")
+
+        await service.force_cancel_invalid_type(id="legacy-1", actor="ops")
+
+        assert len(collector.resolved_notifications) == 1
+        notif = collector.resolved_notifications[0]
+        assert "cancelled" in notif.message
+        assert "legacy-1" in notif.message
+
+    async def test_valid_type_row_rejected(
+        self, service: ApprovalService, collector: _EventCollector
+    ) -> None:
+        """valid type row 는 force-cancel 거부 — 운영 도구가 정상 row 침범 금지."""
+        req = await service.create(
+            type=ApprovalType.STRATEGY_ADOPT,
+            requester="agent-01",
+            title="valid",
+            params={"strategy_id": "s-1", "report_id": "r-1"},
+        )
+
+        with pytest.raises(ValueError, match="invalid type row 전용"):
+            await service.force_cancel_invalid_type(
+                id=req.id, actor="ops", reason="oops"
+            )
+
+        # 상태는 PENDING 유지, event 미발행
+        assert collector.resolved == []
+        assert collector.resolved_notifications == []
+
+    async def test_already_resolved_invalid_row_rejected(
+        self,
+        service: ApprovalService,
+        db: Database,
+        collector: _EventCollector,
+    ) -> None:
+        """이미 종결된 invalid row 는 거부 — audit trail 보존."""
+        await _seed_invalid_row(
+            db,
+            approval_id="resolved-invalid",
+            status=ApprovalStatus.REJECTED,
+            resolved_at="2026-05-11T00:00:00+00:00",
+            resolved_by="user-master",
+        )
+
+        with pytest.raises(ValueError, match="이미 종결된"):
+            await service.force_cancel_invalid_type(id="resolved-invalid", actor="ops")
+
+        # DB row 변경 없음
+        row = await db.fetch_one(
+            "SELECT status, resolved_by FROM approvals WHERE id = ?",
+            ("resolved-invalid",),
+        )
+        assert row is not None
+        assert row["status"] == ApprovalStatus.REJECTED
+        assert row["resolved_by"] == "user-master"
+        # 새 event 미발행
+        assert collector.resolved == []
+
+    async def test_nonexistent_id_rejected(self, service: ApprovalService) -> None:
+        """존재하지 않는 ID 는 거부."""
+        with pytest.raises(ValueError, match="찾을 수 없음"):
+            await service.force_cancel_invalid_type(id="does-not-exist", actor="ops")
+
+    async def test_force_cancel_does_not_revive_approve_path(
+        self, service: ApprovalService, db: Database
+    ) -> None:
+        """force-cancel 한 row 는 이후 approve 시도해도 invalid 가드가 유지된다.
+
+        force_cancel 은 status 만 바꾸고 ``type`` 컬럼은 invalid 그대로
+        둔다. 따라서 ``approve()`` 의 enum 가드(#1470) 가 여전히 ValueError
+        를 던져 audit trail 의 invariant 가 깨지지 않는다.
+        """
+        await _seed_invalid_row(db, approval_id="legacy-1")
+        await service.force_cancel_invalid_type(id="legacy-1", actor="ops")
+
+        # 이미 cancelled 이므로 approve 시도가 invalid type 으로 차단되어야 함.
+        with pytest.raises(ValueError, match="invalid approval type"):
+            await service.approve("legacy-1", resolved_by="user-master")
+
+
+# ── _execute_approved defense-in-depth 회귀 ───────────────────────
+
+
+class TestForceCancelDoesNotBypassApproveGuard:
+    """force-cancel 이 #1470 의 invariant 를 우회하지 않음을 회귀로 확인."""
+
+    async def test_force_cancel_pending_invalid_then_approve_blocked(
+        self, service: ApprovalService, db: Database
+    ) -> None:
+        """force-cancel 한 invalid row 의 ``_execute_approved`` 직접 호출도
+        enum 가드로 차단된다."""
+        await _seed_invalid_row(db, approval_id="legacy-1")
+        await service.force_cancel_invalid_type(id="legacy-1", actor="ops")
+
+        bogus_request = ApprovalRequest(
+            id="legacy-1",
+            type="oracle_invalid_type",
+            status=ApprovalStatus.APPROVED,
+            requester="agent",
+            title="bogus",
+        )
+        with pytest.raises(ValueError, match="invalid approval type"):
+            await service._execute_approved(bogus_request, actor="ops")

--- a/tests/unit/test_cli_approval_format_option.py
+++ b/tests/unit/test_cli_approval_format_option.py
@@ -12,7 +12,9 @@ import pytest
 from ante.cli.commands.approval import (
     approval_list,
     approve,
+    audit_types,
     cancel,
+    cancel_invalid,
     info,
     reject,
     reopen,
@@ -29,6 +31,8 @@ _SUBCOMMANDS = [
     ("cancel", cancel),
     ("approve", approve),
     ("reject", reject),
+    ("audit-types", audit_types),
+    ("cancel-invalid", cancel_invalid),
 ]
 
 

--- a/tests/unit/test_cli_approval_invalid_type_cleanup.py
+++ b/tests/unit/test_cli_approval_invalid_type_cleanup.py
@@ -1,0 +1,376 @@
+"""CLI ``ante approval audit-types`` / ``cancel-invalid`` 테스트 (#1472).
+
+운영자가 ``ApprovalType`` SSOT 에 없는 legacy invalid approval row 를
+CLI 한 줄로 식별하고 정리하는 경로를 검증한다.
+
+검증 대상:
+
+- ``ante approval audit-types``
+  - JSON 모드: invalid row 만 출력. 정렬은 ``created_at`` 오름차순.
+  - JSON 모드: invalid row 가 없으면 빈 array.
+  - admin scope 가 필요 (``approval:admin``).
+- ``ante approval cancel-invalid --id <id>``
+  - JSON 모드: invalid pending row → success + status=cancelled.
+  - invalid row 가 force_cancelled history 와 함께 cancel 종결됨을 DB 로 검증.
+  - 존재하지 않는 ID → exit 1.
+  - 이미 종결된 invalid row → exit 1.
+  - admin scope 가 필요.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.approval.models import ApprovalStatus
+from ante.cli.main import cli
+from ante.core.database import Database
+from ante.member.models import Member, MemberRole, MemberType
+
+# ── 인증 stub ─────────────────────────────────────────────────────
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    """master 인증 stub 이 적용된 CliRunner."""
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+# ── DB 시드 헬퍼 ──────────────────────────────────────────────────
+
+
+async def _seed_db(db_path: str) -> None:
+    """ApprovalService 스키마를 초기화한다."""
+    from ante.approval.service import APPROVAL_SCHEMA
+
+    db = Database(db_path)
+    await db.connect()
+    await db.execute_script(APPROVAL_SCHEMA)
+    await db.close()
+
+
+async def _insert_invalid_row(
+    db_path: str,
+    *,
+    approval_id: str,
+    approval_type: str = "oracle_invalid_type",
+    requester: str = "agent-oracle",
+    status: str = ApprovalStatus.PENDING,
+    created_at: str = "2026-05-10T22:08:18+00:00",
+    resolved_at: str = "",
+    resolved_by: str = "",
+) -> None:
+    db = Database(db_path)
+    await db.connect()
+    await db.execute(
+        """INSERT INTO approvals
+           (id, type, status, requester, title, body, params,
+            reviews, history, reference_id, expires_at, created_at,
+            resolved_at, resolved_by)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            approval_id,
+            approval_type,
+            status,
+            requester,
+            f"legacy {approval_type}",
+            "",
+            json.dumps({}),
+            json.dumps([]),
+            json.dumps(
+                [
+                    {
+                        "action": "created",
+                        "actor": requester,
+                        "at": created_at,
+                        "detail": "",
+                    }
+                ]
+            ),
+            "",
+            "",
+            created_at,
+            resolved_at,
+            resolved_by,
+        ),
+    )
+    await db.close()
+
+
+@pytest.fixture()
+def seeded_db(tmp_path: Path) -> str:
+    """invalid 2건 + valid 0건이 시드된 DB 경로를 반환한다."""
+    db_path = str(tmp_path / "approval.db")
+    asyncio.run(_seed_db(db_path))
+
+    async def _seed() -> None:
+        await _insert_invalid_row(
+            db_path,
+            approval_id="legacy-A",
+            approval_type="oracle_invalid_type",
+            created_at="2026-05-10T22:08:18+00:00",
+        )
+        await _insert_invalid_row(
+            db_path,
+            approval_id="legacy-B",
+            approval_type="bogus_type_2",
+            created_at="2026-05-11T01:00:00+00:00",
+        )
+
+    asyncio.run(_seed())
+    return db_path
+
+
+@pytest.fixture()
+def empty_db(tmp_path: Path) -> str:
+    """approvals 테이블이 비어있는 DB 경로."""
+    db_path = str(tmp_path / "approval-empty.db")
+    asyncio.run(_seed_db(db_path))
+    return db_path
+
+
+# ── audit-types ───────────────────────────────────────────────────
+
+
+class TestAuditTypesCommand:
+    """``ante approval audit-types`` 출력 계약."""
+
+    def test_json_mode_lists_invalid_rows_sorted(
+        self, runner: CliRunner, seeded_db: str
+    ) -> None:
+        """JSON 모드: invalid row 만, created_at 오름차순."""
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "approval",
+                "audit-types",
+                "--db-path",
+                seeded_db,
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        rows = json.loads(result.stdout)
+        assert isinstance(rows, list)
+        assert len(rows) == 2
+        # 오래된 row 가 먼저
+        assert rows[0]["id"] == "legacy-A"
+        assert rows[1]["id"] == "legacy-B"
+        # 모든 row 의 type 이 ApprovalType 에 없는 값
+        types = {r["type"] for r in rows}
+        assert types == {"oracle_invalid_type", "bogus_type_2"}
+        # status / requester / title 컬럼 노출
+        for row in rows:
+            assert "status" in row
+            assert "requester" in row
+            assert "title" in row
+            assert "created_at" in row
+            assert "resolved_at" in row
+
+    def test_json_mode_empty_db_returns_empty_list(
+        self, runner: CliRunner, empty_db: str
+    ) -> None:
+        """invalid row 가 없으면 빈 array 반환."""
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "approval",
+                "audit-types",
+                "--db-path",
+                empty_db,
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        rows = json.loads(result.stdout)
+        assert rows == []
+
+    def test_text_mode_renders_table(self, runner: CliRunner, seeded_db: str) -> None:
+        """text 모드: table 형식 (헤더 + row 라인)."""
+        result = runner.invoke(
+            cli,
+            [
+                "approval",
+                "audit-types",
+                "--db-path",
+                seeded_db,
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "id" in result.output
+        assert "type" in result.output
+        assert "legacy-A" in result.output
+        assert "legacy-B" in result.output
+        assert "oracle_invalid_type" in result.output
+
+
+# ── cancel-invalid ────────────────────────────────────────────────
+
+
+class TestCancelInvalidCommand:
+    """``ante approval cancel-invalid --id <id>``."""
+
+    def test_cancel_invalid_pending_row(
+        self, runner: CliRunner, seeded_db: str
+    ) -> None:
+        """invalid pending row → success + status=cancelled."""
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "approval",
+                "cancel-invalid",
+                "--id",
+                "legacy-A",
+                "--reason",
+                "test cleanup",
+                "--db-path",
+                seeded_db,
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "ok"
+        data = payload["data"]
+        assert data["id"] == "legacy-A"
+        assert data["type"] == "oracle_invalid_type"
+        assert data["status"] == ApprovalStatus.CANCELLED
+
+        # DB 검증: force_cancelled history 가 기록되어야 함
+        async def _fetch() -> dict[str, Any]:
+            db = Database(seeded_db)
+            await db.connect()
+            row = await db.fetch_one(
+                "SELECT status, history, resolved_by FROM approvals WHERE id = ?",
+                ("legacy-A",),
+            )
+            await db.close()
+            assert row is not None
+            return dict(row)
+
+        row = asyncio.run(_fetch())
+        assert row["status"] == ApprovalStatus.CANCELLED
+        assert row["resolved_by"] == "test-master"
+        history = json.loads(row["history"])
+        actions = [e["action"] for e in history]
+        assert "force_cancelled" in actions
+
+    def test_cancel_invalid_nonexistent_id_exits_with_error(
+        self, runner: CliRunner, empty_db: str
+    ) -> None:
+        """존재하지 않는 ID → exit 1 + APPROVAL_ERROR."""
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "approval",
+                "cancel-invalid",
+                "--id",
+                "does-not-exist",
+                "--db-path",
+                empty_db,
+            ],
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout.strip().splitlines()[-1])
+        assert payload["status"] == "error"
+        assert payload["code"] == "APPROVAL_ERROR"
+
+    def test_cancel_invalid_already_resolved_row_rejected(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """이미 종결된 invalid row → exit 1 (audit trail 보존)."""
+        db_path = str(tmp_path / "approval.db")
+        asyncio.run(_seed_db(db_path))
+        asyncio.run(
+            _insert_invalid_row(
+                db_path,
+                approval_id="already-rejected",
+                status=ApprovalStatus.REJECTED,
+                resolved_at="2026-05-11T00:00:00+00:00",
+                resolved_by="user-master",
+            )
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "approval",
+                "cancel-invalid",
+                "--id",
+                "already-rejected",
+                "--db-path",
+                db_path,
+            ],
+        )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout.strip().splitlines()[-1])
+        assert payload["status"] == "error"
+        assert payload["code"] == "APPROVAL_ERROR"
+        assert "이미 종결" in payload["message"]
+
+
+# ── --format / scope 등록 회귀 ─────────────────────────────────────
+
+
+class TestNewCommandsRegistered:
+    """audit-types / cancel-invalid 가 click 그룹에 등록되고 --format 을 가진다."""
+
+    def test_audit_types_registered(self) -> None:
+        from ante.cli.commands.approval import approval
+
+        audit_cmd = approval.commands.get("audit-types")
+        assert audit_cmd is not None
+        param_names = [p.name for p in audit_cmd.params]
+        assert "output_format" in param_names
+        assert "db_path" in param_names
+
+    def test_cancel_invalid_registered(self) -> None:
+        from ante.cli.commands.approval import approval
+
+        cancel_cmd = approval.commands.get("cancel-invalid")
+        assert cancel_cmd is not None
+        param_names = [p.name for p in cancel_cmd.params]
+        assert "output_format" in param_names
+        assert "approval_id" in param_names
+        assert "reason" in param_names
+        assert "db_path" in param_names


### PR DESCRIPTION
Closes #1472

## Summary
- New CLI: `ante approval audit-types` (approval:admin) — read-only scan of `type NOT IN ApprovalType` rows.
- New CLI: `ante approval cancel-invalid --id X [--reason ...]` (approval:admin) — force-cancel invalid pending row with audit trail.
- Service: `list_invalid_type_approvals()` + `force_cancel_invalid_type(...)` reuse `_VALID_APPROVAL_TYPES` and `_publish_resolved_notification`.
- Invariant preservation: type column unchanged → #1470 approve guard still blocks re-approval.
- runbook: `docs/runbooks/07-legacy-invalid-approval-cleanup.md` (new).

## Test Plan
- [x] `pytest tests/unit -k approval` → 288 passed (regression 0)
- [x] 24 new test cases (16 service + 8 CLI)
- [x] `ruff check` / `ruff format --check` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)