### PR TITLE
fix(frontend): expose unknown approval type explicitly + align SSOT (#1471)

### DIFF
--- a/frontend/src/api/approvals.ts
+++ b/frontend/src/api/approvals.ts
@@ -6,14 +6,16 @@ import type {
   ApprovalStatusUpdate as ApiApprovalStatusUpdate,
   ApprovalUpdateResponse as ApiApprovalUpdateResponse,
 } from '../types/api.generated'
-import type {
-  Approval,
-  ApprovalDetail,
-  ApprovalHistoryEntry,
-  ApprovalListView,
-  ApprovalReview,
-  ApprovalStatus,
-  ApprovalType,
+import {
+  isApprovalType,
+  type Approval,
+  type ApprovalDetail,
+  type ApprovalHistoryEntry,
+  type ApprovalListView,
+  type ApprovalReview,
+  type ApprovalStatus,
+  type ApprovalType,
+  type ApprovalTypeRef,
 } from '../types/approval'
 
 interface ApprovalsParams {
@@ -41,21 +43,25 @@ function toApprovalStatus(value: string): ApprovalStatus {
   return 'pending'
 }
 
-function toApprovalType(value: string): ApprovalType {
-  if (
-    value === 'strategy_report'
-    || value === 'budget_allocate'
-    || value === 'live_switch'
-    || value === 'risk_alert'
-    || value === 'strategy_adopt'
-    || value === 'budget_change'
-    || value === 'bot_create'
-    || value === 'bot_stop'
-    || value === 'rule_change'
-  ) {
-    return value
+/**
+ * raw API ``type`` 문자열을 UI 모델 ``ApprovalTypeRef`` 로 변환한다 (#1471 —
+ * split #1418/C).
+ *
+ * backend SSOT 인 ``ApprovalType`` enum (``src/ante/approval/models.py``) 에
+ * 없는 값은 silent fallback 으로 known type 로 변환되지 않는다. 대신
+ * ``kind: 'unknown'`` branch 로 분기해 raw 문자열을 그대로 보존하고,
+ * operator 가 인지할 수 있도록 ``console.warn`` 으로 알린다. legacy invalid
+ * row 또는 contract drift 진단 경로다.
+ */
+function toApprovalTypeRef(value: string): ApprovalTypeRef {
+  if (isApprovalType(value)) {
+    return { kind: 'known', value }
   }
-  return 'strategy_report'
+  // legacy invalid row 또는 contract drift 진단용. silent fallback 금지.
+  console.warn(
+    `[approvals] unknown approval type "${value}" — backend SSOT (ApprovalType) 에 없는 값입니다. legacy invalid row 또는 contract drift 가능성.`,
+  )
+  return { kind: 'unknown', raw: value }
 }
 
 function toReviewResult(value: unknown): ApprovalReview['result'] {
@@ -86,7 +92,7 @@ function toApprovalHistoryEntry(value: unknown): ApprovalHistoryEntry {
 function toApproval(raw: ApiApprovalItem): Approval {
   return {
     id: raw.id,
-    type: toApprovalType(raw.type),
+    type: toApprovalTypeRef(raw.type),
     title: raw.title,
     requester: raw.requester,
     requested_at: toString(raw.created_at),

--- a/frontend/src/components/approvals/ApprovalFilters.tsx
+++ b/frontend/src/components/approvals/ApprovalFilters.tsx
@@ -1,4 +1,5 @@
-import type { ApprovalStatus, ApprovalType } from '../../types/approval'
+import { APPROVAL_TYPES, type ApprovalStatus, type ApprovalType } from '../../types/approval'
+import { APPROVAL_TYPE_LABELS } from '../../utils/constants'
 
 const STATUS_OPTIONS: { key: ApprovalStatus | 'all'; label: string }[] = [
   { key: 'all', label: '전체' },
@@ -7,17 +8,15 @@ const STATUS_OPTIONS: { key: ApprovalStatus | 'all'; label: string }[] = [
   { key: 'rejected', label: '거부' },
 ]
 
+/**
+ * Filter 옵션은 backend SSOT (``ApprovalType`` enum) 와 정확히 일치시킨다
+ * (#1471 — split #1418/C). unknown type 은 filter 옵션에 포함하지 않는다 —
+ * 필터는 known SSOT type 만 노출하고, unknown row 는 ``'all'`` 선택 시 명시
+ * 라벨로 표시된다 (``approvalTypeLabel`` / ``ApprovalTable``).
+ */
 const TYPE_OPTIONS: { key: ApprovalType | 'all'; label: string }[] = [
   { key: 'all', label: '전체 유형' },
-  { key: 'strategy_adopt', label: '전략 채택' },
-  { key: 'strategy_report', label: '전략 리포트' },
-  { key: 'budget_change', label: '예산 변경' },
-  { key: 'budget_allocate', label: '예산 할당' },
-  { key: 'bot_create', label: '봇 생성' },
-  { key: 'bot_stop', label: '봇 중지' },
-  { key: 'live_switch', label: '실전 전환' },
-  { key: 'risk_alert', label: '위험 알림' },
-  { key: 'rule_change', label: '규칙 변경' },
+  ...APPROVAL_TYPES.map((value) => ({ key: value, label: APPROVAL_TYPE_LABELS[value] })),
 ]
 
 interface ApprovalFiltersProps {

--- a/frontend/src/components/approvals/ApprovalTable.tsx
+++ b/frontend/src/components/approvals/ApprovalTable.tsx
@@ -1,20 +1,12 @@
 import { Link } from 'react-router-dom'
 import StatusBadge from '../common/StatusBadge'
 import { formatDateTime } from '../../utils/formatters'
-import type { Approval, ApprovalStatus, ApprovalType } from '../../types/approval'
-import { APPROVAL_STATUS_LABELS } from '../../utils/constants'
-
-const TYPE_LABEL: Record<ApprovalType, string> = {
-  strategy_adopt: '전략 채택',
-  strategy_report: '전략 리포트',
-  budget_change: '예산 변경',
-  budget_allocate: '예산 할당',
-  bot_create: '봇 생성',
-  bot_stop: '봇 중지',
-  live_switch: '실전 전환',
-  risk_alert: '위험 알림',
-  rule_change: '규칙 변경',
-}
+import type { Approval, ApprovalStatus } from '../../types/approval'
+import {
+  APPROVAL_STATUS_LABELS,
+  approvalTypeLabel,
+  approvalTypeVariant,
+} from '../../utils/constants'
 
 const STATUS_VARIANT: Record<ApprovalStatus, string> = {
   pending: 'warning',
@@ -48,7 +40,16 @@ export default function ApprovalTable({ items }: { items: Approval[] }) {
                   className="hover:bg-surface-hover"
                 >
                   <td className="px-3 py-3 border-b border-border text-[13px]">
-                    <StatusBadge variant="muted">{TYPE_LABEL[item.type] || item.type}</StatusBadge>
+                    {/*
+                      #1471: unknown type 은 ``approvalTypeVariant`` 에서
+                      ``negative`` variant 로 표시되어 operator 가 legacy
+                      invalid row / contract drift 를 즉시 식별할 수 있다.
+                      silent fallback (예: 과거의 ``strategy_report``) 으로
+                      잘못 라벨링하지 않는다.
+                    */}
+                    <StatusBadge variant={approvalTypeVariant(item.type)}>
+                      {approvalTypeLabel(item.type)}
+                    </StatusBadge>
                   </td>
                   <td className="px-3 py-3 border-b border-border text-[13px]">
                     <Link to={`/approvals/${item.id}`} className="text-primary no-underline hover:underline">

--- a/frontend/src/components/approvals/ReviewControls.tsx
+++ b/frontend/src/components/approvals/ReviewControls.tsx
@@ -2,26 +2,15 @@ import { useState } from 'react'
 import { useUpdateApprovalStatus } from '../../hooks/useApprovals'
 import Modal from '../common/Modal'
 import StatusBadge from '../common/StatusBadge'
-import type { ApprovalReview, ApprovalType } from '../../types/approval'
-
-const APPROVE_ACTION_TEXT: Record<ApprovalType, string> = {
-  strategy_adopt: '전략이 채택 상태로 전환됩니다.',
-  strategy_report: '전략 리포트가 채택됩니다.',
-  budget_change: 'Treasury에서 예산이 즉시 재배분됩니다.',
-  budget_allocate: 'Treasury에서 예산이 할당됩니다.',
-  bot_create: 'BotManager에서 봇이 즉시 생성됩니다.',
-  bot_stop: '해당 봇의 거래가 즉시 중지됩니다.',
-  live_switch: '봇이 모의투자에서 실전투자로 전환됩니다.',
-  risk_alert: '위험 알림이 처리 완료됩니다.',
-  rule_change: 'RuleEngine에서 해당 봇의 규칙이 즉시 갱신됩니다.',
-}
+import type { ApprovalReview, ApprovalTypeRef } from '../../types/approval'
+import { APPROVE_ACTION_TEXT } from '../../utils/constants'
 
 interface ReviewControlsProps {
   approvalId: string
   isPending: boolean
   title: string
   reviews?: ApprovalReview[]
-  type?: ApprovalType
+  type?: ApprovalTypeRef
   params?: Record<string, unknown>
 }
 
@@ -31,10 +20,10 @@ function formatCurrency(value: unknown): string {
   return `${num.toLocaleString()}원`
 }
 
-function ApproveModalSummary({ type, params }: { type?: ApprovalType; params?: Record<string, unknown> }) {
-  if (!type || !params) return null
+function ApproveModalSummary({ type, params }: { type?: ApprovalTypeRef; params?: Record<string, unknown> }) {
+  if (!type || type.kind !== 'known' || !params) return null
 
-  if (type === 'bot_create') {
+  if (type.value === 'bot_create') {
     const tradeMode = String(params.trade_mode ?? '')
     const isMock = tradeMode === 'mock' || tradeMode === '모의투자'
     return (
@@ -48,7 +37,7 @@ function ApproveModalSummary({ type, params }: { type?: ApprovalType; params?: R
     )
   }
 
-  if (type === 'budget_change') {
+  if (type.value === 'budget_change') {
     const current = Number(params.current_budget ?? 0)
     const requested = Number(params.requested_budget ?? 0)
     const diff = requested - current
@@ -110,14 +99,24 @@ export default function ReviewControls({ approvalId, isPending, title, reviews, 
           <strong className="text-text">{title}</strong>을 승인하시겠습니까?
         </div>
         <ApproveModalSummary type={type} params={params} />
-        {type && (
+        {type && type.kind === 'known' && (
           <div className="bg-info/10 text-info p-3 rounded text-[12px] mb-4">
-            {'\uD83D\uDCA1'} 승인 시 <strong>{APPROVE_ACTION_TEXT[type]}</strong>
+            {'💡'} 승인 시 <strong>{APPROVE_ACTION_TEXT[type.value]}</strong>
+          </div>
+        )}
+        {type && type.kind === 'unknown' && (
+          /*
+            #1471: unknown 유형은 backend SSOT 에 없는 type. #1470 lifecycle
+            guard 에 의해 approve 자체가 실패하지만, operator 가 모달 진입
+            시점에 식별할 수 있도록 명시 경고를 노출한다. silent fallback 금지.
+          */
+          <div className="bg-negative/10 text-negative p-3 rounded text-[12px] mb-4">
+            {'⚠'} 알 수 없는 결재 유형 <strong>{`unknown:${type.raw}`}</strong> — backend SSOT 에 없는 type 이므로 승인 시도가 거부될 수 있습니다 (legacy invalid row 또는 contract drift).
           </div>
         )}
         {hasWarnings && (
           <div className="bg-warning/10 text-warning p-3 rounded text-[12px] mb-4">
-            {'\u26A0'} 검토 의견에 <strong>warn</strong> 또는 <strong>fail</strong> 결과가 포함되어 있습니다. 검증 내용을 확인하세요.
+            {'⚠'} 검토 의견에 <strong>warn</strong> 또는 <strong>fail</strong> 결과가 포함되어 있습니다. 검증 내용을 확인하세요.
           </div>
         )}
         <div className="mb-4">

--- a/frontend/src/pages/ApprovalDetail.tsx
+++ b/frontend/src/pages/ApprovalDetail.tsx
@@ -5,25 +5,17 @@ import MarkdownBody from '../components/approvals/MarkdownBody'
 import StatusBadge from '../components/common/StatusBadge'
 import { PageSkeleton } from '../components/common/Skeleton'
 import { formatDateTime } from '../utils/formatters'
-import { APPROVAL_STATUS_LABELS } from '../utils/constants'
-import type { Approval, ApprovalStatus, ApprovalType, ApprovalReview, ApprovalHistoryEntry } from '../types/approval'
+import {
+  APPROVAL_STATUS_LABELS,
+  approvalTypeLabel,
+  approvalTypeVariant,
+} from '../utils/constants'
+import type { Approval, ApprovalStatus, ApprovalReview, ApprovalHistoryEntry } from '../types/approval'
 
 const STATUS_VARIANT: Record<ApprovalStatus, string> = {
   pending: 'warning',
   approved: 'positive',
   rejected: 'negative',
-}
-
-const TYPE_LABEL: Record<ApprovalType, string> = {
-  strategy_adopt: '전략 채택',
-  strategy_report: '전략 리포트',
-  budget_change: '예산 변경',
-  budget_allocate: '예산 할당',
-  bot_create: '봇 생성',
-  bot_stop: '봇 중지',
-  live_switch: '실전 전환',
-  risk_alert: '위험 알림',
-  rule_change: '규칙 변경',
 }
 
 const REVIEW_RESULT_VARIANT: Record<string, string> = {
@@ -45,7 +37,10 @@ function getActorColor(actor: string, action?: string): string {
 
 /* ── 결재 정보 카드 ── */
 function ApprovalInfoCard({ approval }: { approval: Approval }) {
-  const typeLabel = TYPE_LABEL[approval.type] || approval.type
+  // #1471: unknown type 은 ``approvalTypeLabel`` 이 ``unknown:{raw}`` 로 반환하고
+  // ``approvalTypeVariant`` 는 ``negative`` 를 반환해 operator 가 즉시 식별할 수 있다.
+  const typeLabel = approvalTypeLabel(approval.type)
+  const typeVariant = approvalTypeVariant(approval.type)
   return (
     <div className="bg-surface border border-border rounded-lg p-5">
       <h3 className="text-[15px] font-semibold mb-4">결재 정보</h3>
@@ -53,7 +48,9 @@ function ApprovalInfoCard({ approval }: { approval: Approval }) {
         <InfoRow label="요청자" value={
           <span className="text-primary">{approval.requester}</span>
         } />
-        <InfoRow label="유형" value={typeLabel} />
+        <InfoRow label="유형" value={
+          <StatusBadge variant={typeVariant}>{typeLabel}</StatusBadge>
+        } />
         <InfoRow label="상태" value={
           <StatusBadge variant={STATUS_VARIANT[approval.status] as 'warning'}>
             {APPROVAL_STATUS_LABELS[approval.status]}

--- a/frontend/src/types/approval.ts
+++ b/frontend/src/types/approval.ts
@@ -7,16 +7,49 @@
 
 // ── 프론트엔드 전용 타입 ──────────────────────────────────
 export type ApprovalStatus = 'pending' | 'approved' | 'rejected'
-export type ApprovalType =
-  | 'strategy_report'
-  | 'budget_allocate'
-  | 'live_switch'
-  | 'risk_alert'
-  | 'strategy_adopt'
-  | 'budget_change'
-  | 'bot_create'
-  | 'bot_stop'
-  | 'rule_change'
+
+/**
+ * 결재 유형. backend ``ApprovalType`` enum SSOT 와 정확히 일치한다 (#1471 — split
+ * #1418/C). SSOT: ``src/ante/approval/models.py:ApprovalType``.
+ *
+ * - ``strategy_adopt`` / ``strategy_retire``: 전략 채택/은퇴
+ * - ``bot_create`` / ``bot_assign_strategy`` / ``bot_change_strategy``
+ *   / ``bot_stop`` / ``bot_resume`` / ``bot_delete``: 봇 라이프사이클
+ * - ``budget_change`` / ``rule_change``: 예산/룰 변경
+ *
+ * SSOT 에 정의되지 않은 값(legacy invalid row, contract drift)은 어댑터에서
+ * ``ApprovalTypeRef.kind === 'unknown'`` branch 로 명시적으로 분기되며,
+ * silent fallback (예: 과거의 ``strategy_report``) 으로 잘못 라벨링되지 않는다.
+ */
+export const APPROVAL_TYPES = [
+  'strategy_adopt',
+  'strategy_retire',
+  'bot_create',
+  'bot_assign_strategy',
+  'bot_change_strategy',
+  'bot_stop',
+  'bot_resume',
+  'bot_delete',
+  'budget_change',
+  'rule_change',
+] as const
+export type ApprovalType = typeof APPROVAL_TYPES[number]
+
+export function isApprovalType(value: string): value is ApprovalType {
+  return (APPROVAL_TYPES as readonly string[]).includes(value)
+}
+
+/**
+ * UI 가 다루는 결재 유형 참조.
+ *
+ * ``kind: 'known'`` 인 경우 SSOT enum 값으로 정상 표시한다. ``kind: 'unknown'``
+ * 은 legacy invalid row 또는 backend ↔ frontend contract drift 로 SSOT 에
+ * 없는 type 이 들어왔음을 의미한다 — operator 가 인지할 수 있도록 명시적으로
+ * 표시하며, 알려진 유형으로 silent fallback 하지 않는다.
+ */
+export type ApprovalTypeRef =
+  | { kind: 'known'; value: ApprovalType }
+  | { kind: 'unknown'; raw: string }
 
 export interface ApprovalReview {
   reviewer: string
@@ -34,7 +67,7 @@ export interface ApprovalHistoryEntry {
 
 export interface Approval {
   id: string
-  type: ApprovalType
+  type: ApprovalTypeRef
   title: string
   requester: string
   requested_at: string

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,3 +1,5 @@
+import type { ApprovalTypeRef } from '../types/approval'
+
 /** API 기본 URL */
 export const API_BASE_URL = import.meta.env.VITE_API_URL || ''
 
@@ -26,6 +28,66 @@ export const APPROVAL_STATUS_LABELS: Record<string, string> = {
   approved: '승인',
   rejected: '거부',
 }
+
+/**
+ * 결재 유형 라벨. backend ``ApprovalType`` enum SSOT 와 정확히 일치한다
+ * (#1471 — split #1418/C). SSOT: ``src/ante/approval/models.py:ApprovalType``.
+ */
+export const APPROVAL_TYPE_LABELS = {
+  strategy_adopt: '전략 채택',
+  strategy_retire: '전략 은퇴',
+  bot_create: '봇 생성',
+  bot_assign_strategy: '봇 전략 배정',
+  bot_change_strategy: '봇 전략 변경',
+  bot_stop: '봇 중지',
+  bot_resume: '봇 재개',
+  bot_delete: '봇 삭제',
+  budget_change: '예산 변경',
+  rule_change: '규칙 변경',
+} as const
+
+/**
+ * 결재 승인 시 발생하는 부작용 설명 (승인 확인 모달).
+ *
+ * backend SSOT 와 정합한다 (#1471). 알려진 SSOT 유형이 아닌 경우
+ * (``ApprovalTypeRef.kind === 'unknown'``) approve action 자체가 backend 에서
+ * 거부되므로 (#1470) 별도 fallback 메시지를 두지 않는다.
+ */
+/**
+ * ``ApprovalTypeRef`` 를 화면에 표시할 라벨로 변환한다 (#1471).
+ *
+ * - ``kind === 'known'``: 한국어 라벨.
+ * - ``kind === 'unknown'``: ``unknown:{raw}`` 로 명시 표기 — operator 가 legacy
+ *   invalid row / contract drift 를 즉시 인지할 수 있게 한다. silent fallback
+ *   금지.
+ */
+export function approvalTypeLabel(ref: ApprovalTypeRef): string {
+  if (ref.kind === 'known') return APPROVAL_TYPE_LABELS[ref.value]
+  return `unknown:${ref.raw}`
+}
+
+/**
+ * ``ApprovalTypeRef`` 의 ``StatusBadge`` variant.
+ *
+ * - 알려진 유형: ``muted`` (중립 표시).
+ * - 알려지지 않은 유형: ``negative`` (operator 가 즉시 식별).
+ */
+export function approvalTypeVariant(ref: ApprovalTypeRef): 'muted' | 'negative' {
+  return ref.kind === 'known' ? 'muted' : 'negative'
+}
+
+export const APPROVE_ACTION_TEXT = {
+  strategy_adopt: '전략이 채택 상태로 전환됩니다.',
+  strategy_retire: '전략이 은퇴 상태로 전환됩니다.',
+  bot_create: 'BotManager 에서 봇이 즉시 생성됩니다.',
+  bot_assign_strategy: '봇에 전략이 즉시 배정됩니다.',
+  bot_change_strategy: '봇의 전략이 즉시 변경됩니다.',
+  bot_stop: '해당 봇의 거래가 즉시 중지됩니다.',
+  bot_resume: '해당 봇의 거래가 즉시 재개됩니다.',
+  bot_delete: '해당 봇이 즉시 삭제됩니다.',
+  budget_change: 'Treasury 에서 예산이 즉시 재배분됩니다.',
+  rule_change: 'RuleEngine 에서 해당 봇의 규칙이 즉시 갱신됩니다.',
+} as const
 
 /** 멤버 상태 라벨 */
 export const MEMBER_STATUS_LABELS: Record<string, string> = {


### PR DESCRIPTION
Closes #1471

## Summary
- `ApprovalType` frontend union aligned with backend `ApprovalType` enum (10 values).
- New `ApprovalTypeRef` discriminated union (`known | unknown`); `isApprovalType` type guard.
- `toApprovalTypeRef` replaces silent `toApprovalType` fallback; unknown → `kind: 'unknown'` + console.warn.
- `approvalTypeLabel/Variant` helpers emit `unknown:{raw}` + `negative` badge.
- `ApprovalTable`, `ApprovalFilters`, `ReviewControls`, `ApprovalDetail` updated.

## Test Plan
- [x] `npm run check-api-types:strict` 0 findings
- [x] `npm run build` OK
- [x] `npm run generate-types` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)