### PR TITLE
fix(web-api,bot): expose runtime control config nested object in Bot GET responses (#1458)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -5836,6 +5836,45 @@
         "title": "BalanceSetResponse",
         "description": "잔고 설정 응답."
       },
+      "BotConfigSummary": {
+        "properties": {
+          "interval_seconds": {
+            "type": "integer",
+            "title": "Interval Seconds"
+          },
+          "auto_restart": {
+            "type": "boolean",
+            "title": "Auto Restart"
+          },
+          "max_restart_attempts": {
+            "type": "integer",
+            "title": "Max Restart Attempts"
+          },
+          "restart_cooldown_seconds": {
+            "type": "integer",
+            "title": "Restart Cooldown Seconds"
+          },
+          "step_timeout_seconds": {
+            "type": "integer",
+            "title": "Step Timeout Seconds"
+          },
+          "max_signals_per_step": {
+            "type": "integer",
+            "title": "Max Signals Per Step"
+          }
+        },
+        "type": "object",
+        "required": [
+          "interval_seconds",
+          "auto_restart",
+          "max_restart_attempts",
+          "restart_cooldown_seconds",
+          "step_timeout_seconds",
+          "max_signals_per_step"
+        ],
+        "title": "BotConfigSummary",
+        "description": "봇 runtime control 요약 (GET ``/api/bots/{bot_id}`` 응답 필드, #1458).\n\nSSOT: ``docs/dashboard/user-stories/bots.md`` B-3 line 106-111 ``bot.config.*``\n카드 + B-5 line 194-200 편집 모달 prefill key. 5개 필드 + ``interval_seconds``\n를 묶어 GET 응답에서 한 번에 노출하면 대시보드 편집 모달이\n``bot.config?.<key> ?? <default>`` fallback 으로 떨어지지 않고 실제\n저장값으로 prefill 된다 (#1413 split E).\n\n필드별 spec 범위는 ``BotConfig`` ``validate_runtime_controls`` 와 정합\n(`docs/dashboard/user-stories/bots.md` B-5 line 197-200):\n- ``max_restart_attempts``: 1~10\n- ``restart_cooldown_seconds``: 10~600\n- ``step_timeout_seconds``: 5~120\n- ``max_signals_per_step``: 1~200\n\nrange constraint 는 GET 응답이 아닌 PUT/POST 입력 모델에서 422 로 강제하므로\n본 read-side schema 는 type 만 명시한다 (회귀 시 SSOT 범위는 그대로 유지)."
+      },
       "BotDetailResponse": {
         "properties": {
           "bot": {
@@ -5945,6 +5984,16 @@
               }
             ],
             "title": "Error Message"
+          },
+          "config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BotConfigSummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "additionalProperties": true,
@@ -5953,7 +6002,7 @@
           "bot_id"
         ],
         "title": "BotInfo",
-        "description": "봇 정보 (read 응답).\n\nwrite 경로(``BotConfig``, ``ApprovalService.create``)에서 account_id가\n검증되므로 read 응답 schema에는 default를 유지한다."
+        "description": "봇 정보 (read 응답).\n\nwrite 경로(``BotConfig``, ``ApprovalService.create``)에서 account_id가\n검증되므로 read 응답 schema에는 default를 유지한다.\n\n``config`` 는 GET ``/api/bots/{bot_id}`` 응답에서 runtime control 5개 필드\n+ ``interval_seconds`` 를 묶어 노출한다 (#1458 split #1413/E). 대시보드\n편집 모달이 default 값으로 덮어쓰는 회귀를 차단한다. list 응답\n(``GET /api/bots``) 도 동일 구조로 ``config`` 를 포함한다."
       },
       "BotListResponse": {
         "properties": {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2106,6 +2106,40 @@ export type components = {
             updated_at: string;
         };
         /**
+         * BotConfigSummary
+         * @description 봇 runtime control 요약 (GET ``/api/bots/{bot_id}`` 응답 필드, #1458).
+         *
+         *     SSOT: ``docs/dashboard/user-stories/bots.md`` B-3 line 106-111 ``bot.config.*``
+         *     카드 + B-5 line 194-200 편집 모달 prefill key. 5개 필드 + ``interval_seconds``
+         *     를 묶어 GET 응답에서 한 번에 노출하면 대시보드 편집 모달이
+         *     ``bot.config?.<key> ?? <default>`` fallback 으로 떨어지지 않고 실제
+         *     저장값으로 prefill 된다 (#1413 split E).
+         *
+         *     필드별 spec 범위는 ``BotConfig`` ``validate_runtime_controls`` 와 정합
+         *     (`docs/dashboard/user-stories/bots.md` B-5 line 197-200):
+         *     - ``max_restart_attempts``: 1~10
+         *     - ``restart_cooldown_seconds``: 10~600
+         *     - ``step_timeout_seconds``: 5~120
+         *     - ``max_signals_per_step``: 1~200
+         *
+         *     range constraint 는 GET 응답이 아닌 PUT/POST 입력 모델에서 422 로 강제하므로
+         *     본 read-side schema 는 type 만 명시한다 (회귀 시 SSOT 범위는 그대로 유지).
+         */
+        BotConfigSummary: {
+            /** Auto Restart */
+            auto_restart: boolean;
+            /** Interval Seconds */
+            interval_seconds: number;
+            /** Max Restart Attempts */
+            max_restart_attempts: number;
+            /** Max Signals Per Step */
+            max_signals_per_step: number;
+            /** Restart Cooldown Seconds */
+            restart_cooldown_seconds: number;
+            /** Step Timeout Seconds */
+            step_timeout_seconds: number;
+        };
+        /**
          * BotCreateRequest
          * @description POST /api/bots 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1371). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다. Pydantic ``extra='forbid'`` (#1436) — 정의되지 않은 필드(예: legacy ``bot_type``)는 422로 거부된다. strategy_id 또는 strategy_name 중 하나를 필수로 전달해야 하며 (model_validator로 강제, #1436), 둘 다 전달 시 strategy_id를 우선 사용한다. OpenAPI ``anyOf`` 로 strategy 식별자 필수 조건을 명시하여 generated TS/SDK 가 ``{bot_id: ...}`` 만 담긴 payload 를 valid 로 인식하지 못하도록 한다 (codex r1 FAIL). anyOf branches 는 ``type``/``properties`` 까지 명시하여 openapi-typescript 가 ``unknown`` 으로 붕괴되지 않고 ``{strategy_id: string} | {strategy_name: string}`` 으로 narrow 되도록 한다 (codex r2 FAIL).
          */
@@ -2148,6 +2182,11 @@ export type components = {
          *
          *     write 경로(``BotConfig``, ``ApprovalService.create``)에서 account_id가
          *     검증되므로 read 응답 schema에는 default를 유지한다.
+         *
+         *     ``config`` 는 GET ``/api/bots/{bot_id}`` 응답에서 runtime control 5개 필드
+         *     + ``interval_seconds`` 를 묶어 노출한다 (#1458 split #1413/E). 대시보드
+         *     편집 모달이 default 값으로 덮어쓰는 회귀를 차단한다. list 응답
+         *     (``GET /api/bots``) 도 동일 구조로 ``config`` 를 포함한다.
          */
         BotInfo: {
             /**
@@ -2157,6 +2196,7 @@ export type components = {
             account_id: string;
             /** Bot Id */
             bot_id: string;
+            config?: components["schemas"]["BotConfigSummary"] | null;
             /** Error Message */
             error_message?: string | null;
             /**
@@ -3770,6 +3810,7 @@ export type AuditLogItem = components['schemas']['AuditLogItem'];
 export type AuditLogListResponse = components['schemas']['AuditLogListResponse'];
 export type BalanceSetRequest = components['schemas']['BalanceSetRequest'];
 export type BalanceSetResponse = components['schemas']['BalanceSetResponse'];
+export type BotConfigSummary = components['schemas']['BotConfigSummary'];
 export type BotCreateRequest = components['schemas']['BotCreateRequest'];
 export type BotDetailResponse = components['schemas']['BotDetailResponse'];
 export type BotInfo = components['schemas']['BotInfo'];

--- a/src/ante/bot/bot.py
+++ b/src/ante/bot/bot.py
@@ -464,7 +464,20 @@ class Bot:
                 )
 
     def get_info(self) -> dict[str, Any]:
-        """봇 상태 정보 반환."""
+        """봇 상태 정보 반환.
+
+        runtime control 필드(``auto_restart``, ``max_restart_attempts``,
+        ``restart_cooldown_seconds``, ``step_timeout_seconds``,
+        ``max_signals_per_step``)는 ``config`` nested object 로 노출한다
+        (#1458 split #1413/E). SSOT 는
+        ``docs/dashboard/user-stories/bots.md`` B-3 line 106-111 의
+        ``bot.config.*`` 접근 패턴. ``interval_seconds`` 도 동일 카드에서
+        ``bot.config.interval_seconds`` 로 표시되므로 ``config`` 안에
+        한 번 더 노출한다 (top-level ``interval_seconds`` 는 기존 호환을
+        위해 유지). 이 nested 노출이 빠지면 대시보드 편집 모달이
+        ``bot.config?.* ?? <default>`` fallback 으로 떨어져 valid 한
+        기존 runtime control 값을 default 로 덮어쓰게 된다.
+        """
         return {
             "bot_id": self.bot_id,
             "name": self.config.name,
@@ -478,4 +491,12 @@ class Bot:
             "started_at": (self.started_at.isoformat() if self.started_at else None),
             "stopped_at": (self.stopped_at.isoformat() if self.stopped_at else None),
             "error_message": self.error_message,
+            "config": {
+                "interval_seconds": self.config.interval_seconds,
+                "auto_restart": self.config.auto_restart,
+                "max_restart_attempts": self.config.max_restart_attempts,
+                "restart_cooldown_seconds": self.config.restart_cooldown_seconds,
+                "step_timeout_seconds": self.config.step_timeout_seconds,
+                "max_signals_per_step": self.config.max_signals_per_step,
+            },
         }

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -305,11 +305,44 @@ class MeResponse(BaseModel):
 # ── 봇 ──────────────────────────────────────────────
 
 
+class BotConfigSummary(BaseModel):
+    """봇 runtime control 요약 (GET ``/api/bots/{bot_id}`` 응답 필드, #1458).
+
+    SSOT: ``docs/dashboard/user-stories/bots.md`` B-3 line 106-111 ``bot.config.*``
+    카드 + B-5 line 194-200 편집 모달 prefill key. 5개 필드 + ``interval_seconds``
+    를 묶어 GET 응답에서 한 번에 노출하면 대시보드 편집 모달이
+    ``bot.config?.<key> ?? <default>`` fallback 으로 떨어지지 않고 실제
+    저장값으로 prefill 된다 (#1413 split E).
+
+    필드별 spec 범위는 ``BotConfig`` ``validate_runtime_controls`` 와 정합
+    (`docs/dashboard/user-stories/bots.md` B-5 line 197-200):
+    - ``max_restart_attempts``: 1~10
+    - ``restart_cooldown_seconds``: 10~600
+    - ``step_timeout_seconds``: 5~120
+    - ``max_signals_per_step``: 1~200
+
+    range constraint 는 GET 응답이 아닌 PUT/POST 입력 모델에서 422 로 강제하므로
+    본 read-side schema 는 type 만 명시한다 (회귀 시 SSOT 범위는 그대로 유지).
+    """
+
+    interval_seconds: int
+    auto_restart: bool
+    max_restart_attempts: int
+    restart_cooldown_seconds: int
+    step_timeout_seconds: int
+    max_signals_per_step: int
+
+
 class BotInfo(BaseModel):
     """봇 정보 (read 응답).
 
     write 경로(``BotConfig``, ``ApprovalService.create``)에서 account_id가
     검증되므로 read 응답 schema에는 default를 유지한다.
+
+    ``config`` 는 GET ``/api/bots/{bot_id}`` 응답에서 runtime control 5개 필드
+    + ``interval_seconds`` 를 묶어 노출한다 (#1458 split #1413/E). 대시보드
+    편집 모달이 default 값으로 덮어쓰는 회귀를 차단한다. list 응답
+    (``GET /api/bots``) 도 동일 구조로 ``config`` 를 포함한다.
     """
 
     bot_id: str
@@ -324,6 +357,7 @@ class BotInfo(BaseModel):
     started_at: str | None = None
     stopped_at: str | None = None
     error_message: str | None = None
+    config: BotConfigSummary | None = None
 
     # 봇 상세 조회 시 추가되는 동적 필드 (strategy, budget, positions 등)
     model_config = ConfigDict(extra="allow")

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -590,6 +590,66 @@ class TestBot:
         assert info["exchange"] == "KRX"
         assert info["currency"] == "KRW"
 
+    def test_get_info_includes_config_runtime_controls(self, eventbus, ctx):
+        """get_info()에 runtime control 5개 + interval이 ``config`` nested로
+        포함된다 (#1458 split #1413/E).
+
+        SSOT: ``docs/dashboard/user-stories/bots.md`` B-3 ``bot.config.*`` 카드.
+        BotConfig 의 spec range 안의 valid 한 값이 그대로 반영되어, 대시보드
+        편집 모달이 default 값(``?? 3`` 등)으로 덮어쓰는 회귀를 차단한다.
+        """
+        config = BotConfig(
+            bot_id="bot1",
+            strategy_id="s1",
+            interval_seconds=30,
+            account_id="acc-test",
+            auto_restart=False,
+            max_restart_attempts=7,
+            restart_cooldown_seconds=120,
+            step_timeout_seconds=45,
+            max_signals_per_step=80,
+        )
+        bot = Bot(
+            config=config,
+            strategy_cls=SimpleStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        info = bot.get_info()
+        assert "config" in info, "config nested object missing from get_info()"
+        cfg = info["config"]
+        # 모든 key 가 존재 + valid 한 값 그대로 반영된다 (default 로 덮이지
+        # 않는다).
+        assert cfg["interval_seconds"] == 30
+        assert cfg["auto_restart"] is False
+        assert cfg["max_restart_attempts"] == 7
+        assert cfg["restart_cooldown_seconds"] == 120
+        assert cfg["step_timeout_seconds"] == 45
+        assert cfg["max_signals_per_step"] == 80
+        # 기존 top-level 호환 — interval_seconds 는 양쪽에 노출된다 (이전 read
+        # 응답을 사용하는 호출자 호환 보존).
+        assert info["interval_seconds"] == 30
+
+    def test_get_info_config_uses_defaults_when_unspecified(self, eventbus, ctx):
+        """get_info()의 ``config`` 는 BotConfig dataclass default 도 그대로
+        노출한다 (#1458 split #1413/E). spec range 안의 default value:
+        auto_restart=True, max_restart_attempts=3, restart_cooldown_seconds=60,
+        step_timeout_seconds=30, max_signals_per_step=50.
+        """
+        config = BotConfig(bot_id="bot1", strategy_id="s1", account_id="acc-test")
+        bot = Bot(
+            config=config,
+            strategy_cls=SimpleStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        cfg = bot.get_info()["config"]
+        assert cfg["auto_restart"] is True
+        assert cfg["max_restart_attempts"] == 3
+        assert cfg["restart_cooldown_seconds"] == 60
+        assert cfg["step_timeout_seconds"] == 30
+        assert cfg["max_signals_per_step"] == 50
+
 
 # ── BotManager ───────────────────────────────────
 

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -81,12 +81,24 @@ class FakeBot:
         status: str = "created",
         strategy_id: str = "s1",
         account_id: str = "test",
+        # runtime control (#1458 split #1413/E) — BotConfig dataclass default
+        # 와 동일한 spec range 안 default 값.
+        auto_restart: bool = True,
+        max_restart_attempts: int = 3,
+        restart_cooldown_seconds: int = 60,
+        step_timeout_seconds: int = 30,
+        max_signals_per_step: int = 50,
     ) -> None:
         self.bot_id = bot_id
         self._status = status
         self._strategy_id = strategy_id
         self._name = bot_id
         self._interval_seconds = 60
+        self._auto_restart = auto_restart
+        self._max_restart_attempts = max_restart_attempts
+        self._restart_cooldown_seconds = restart_cooldown_seconds
+        self._step_timeout_seconds = step_timeout_seconds
+        self._max_signals_per_step = max_signals_per_step
         self.config = FakeBotConfig(
             bot_id, account_id=account_id, strategy_id=strategy_id
         )
@@ -96,6 +108,9 @@ class FakeBot:
         return self._status
 
     def get_info(self) -> dict:
+        # ``config`` 는 GET /api/bots/{bot_id} 응답에서 runtime control 5개 +
+        # interval_seconds 를 묶어 노출한다 (#1458 split #1413/E). 실제 Bot
+        # 구현과 동일 구조.
         return {
             "bot_id": self.bot_id,
             "name": self._name,
@@ -109,6 +124,14 @@ class FakeBot:
             "started_at": None,
             "stopped_at": None,
             "error_message": None,
+            "config": {
+                "interval_seconds": self._interval_seconds,
+                "auto_restart": self._auto_restart,
+                "max_restart_attempts": self._max_restart_attempts,
+                "restart_cooldown_seconds": self._restart_cooldown_seconds,
+                "step_timeout_seconds": self._step_timeout_seconds,
+                "max_signals_per_step": self._max_signals_per_step,
+            },
         }
 
 
@@ -179,6 +202,20 @@ class FakeBotManager:
         if "strategy_id" in updates:
             bot._strategy_id = updates["strategy_id"]
             bot.config.strategy_id = updates["strategy_id"]
+        # runtime control (#1458 split #1413/E) — 실제 BotManager.update_bot 는
+        # BotConfig 재구성 패턴으로 같은 필드를 갱신한다. roundtrip 회귀
+        # 테스트(valid 값 PUT → GET 보존, 다른 필드만 PUT → 기존 값 보존) 를
+        # 지원하기 위해 stub 도 동일 동작을 시뮬레이션한다.
+        if "auto_restart" in updates:
+            bot._auto_restart = updates["auto_restart"]
+        if "max_restart_attempts" in updates:
+            bot._max_restart_attempts = updates["max_restart_attempts"]
+        if "restart_cooldown_seconds" in updates:
+            bot._restart_cooldown_seconds = updates["restart_cooldown_seconds"]
+        if "step_timeout_seconds" in updates:
+            bot._step_timeout_seconds = updates["step_timeout_seconds"]
+        if "max_signals_per_step" in updates:
+            bot._max_signals_per_step = updates["max_signals_per_step"]
         return bot
 
 
@@ -324,6 +361,110 @@ class TestGetBot:
         """존재하지 않는 봇 → 404."""
         resp = client.get("/api/bots/nonexistent")
         assert resp.status_code == 404
+
+    def test_get_includes_runtime_control_config(self, client, bot_manager):
+        """GET /api/bots/{bot_id} 응답에 runtime control 5개 + interval 이
+        ``config`` nested object 로 포함된다 (#1458 split #1413/E).
+
+        SSOT: ``docs/dashboard/user-stories/bots.md`` B-3 ``bot.config.*`` 카드.
+        대시보드 편집 모달은 ``bot.config?.<key> ?? <default>`` fallback 으로
+        prefill 되는데, 이 필드가 빠지면 default 값(예: ``?? 3``) 으로
+        덮어쓰여 valid 한 기존 설정이 손실된다.
+        """
+        bot_manager._bots["bot-1"] = FakeBot(
+            "bot-1",
+            auto_restart=False,
+            max_restart_attempts=8,
+            restart_cooldown_seconds=300,
+            step_timeout_seconds=90,
+            max_signals_per_step=150,
+        )
+        resp = client.get("/api/bots/bot-1")
+        assert resp.status_code == 200
+        body = resp.json()["bot"]
+        assert "config" in body, "config nested object missing from GET response"
+        cfg = body["config"]
+        # SSOT 필드 5개 + interval_seconds 모두 노출.
+        assert cfg["auto_restart"] is False
+        assert cfg["max_restart_attempts"] == 8
+        assert cfg["restart_cooldown_seconds"] == 300
+        assert cfg["step_timeout_seconds"] == 90
+        assert cfg["max_signals_per_step"] == 150
+        assert cfg["interval_seconds"] == 60
+
+    def test_get_returns_runtime_control_defaults(self, client, bot_manager):
+        """FakeBot default 값으로 생성된 봇은 BotConfig dataclass default
+        (#1458 SSOT) 와 같은 spec range 안 default 를 GET 응답에 반영한다.
+        """
+        bot_manager._bots["bot-1"] = FakeBot("bot-1")
+        resp = client.get("/api/bots/bot-1")
+        assert resp.status_code == 200
+        cfg = resp.json()["bot"]["config"]
+        assert cfg["auto_restart"] is True
+        assert cfg["max_restart_attempts"] == 3
+        assert cfg["restart_cooldown_seconds"] == 60
+        assert cfg["step_timeout_seconds"] == 30
+        assert cfg["max_signals_per_step"] == 50
+
+
+class TestBotDetailRuntimeControlRoundtrip:
+    """GET/PUT roundtrip 회귀 (#1458 split #1413/E pass condition).
+
+    - valid runtime controls PUT → GET detail → 동일 값 반영
+    - GET detail → 다른 필드(name 등) 만 수정 PUT → runtime control 보존
+    """
+
+    def test_put_runtime_controls_then_get_returns_same_values(
+        self, client, bot_manager
+    ):
+        """valid runtime control 4개 + auto_restart 를 PUT 한 뒤 GET 하면
+        같은 값이 반환된다 (default 로 덮이지 않는다)."""
+        bot_manager._bots["bot-1"] = FakeBot("bot-1", status="stopped")
+        # PUT — spec range 안의 다른 값으로 변경.
+        put_payload = {
+            "auto_restart": False,
+            "max_restart_attempts": 5,
+            "restart_cooldown_seconds": 200,
+            "step_timeout_seconds": 90,
+            "max_signals_per_step": 120,
+        }
+        put_resp = client.put("/api/bots/bot-1", json=put_payload)
+        assert put_resp.status_code == 200, put_resp.text
+        # GET — PUT 으로 반영된 값이 그대로 노출된다.
+        get_resp = client.get("/api/bots/bot-1")
+        assert get_resp.status_code == 200
+        cfg = get_resp.json()["bot"]["config"]
+        assert cfg["auto_restart"] is False
+        assert cfg["max_restart_attempts"] == 5
+        assert cfg["restart_cooldown_seconds"] == 200
+        assert cfg["step_timeout_seconds"] == 90
+        assert cfg["max_signals_per_step"] == 120
+
+    def test_put_other_field_only_preserves_runtime_controls(self, client, bot_manager):
+        """이름만 변경 PUT → runtime control 5개는 GET 응답에 그대로 보존."""
+        bot_manager._bots["bot-1"] = FakeBot(
+            "bot-1",
+            status="stopped",
+            auto_restart=False,
+            max_restart_attempts=7,
+            restart_cooldown_seconds=180,
+            step_timeout_seconds=60,
+            max_signals_per_step=100,
+        )
+        # 다른 필드(name) 만 변경.
+        put_resp = client.put("/api/bots/bot-1", json={"name": "renamed-bot"})
+        assert put_resp.status_code == 200, put_resp.text
+        get_resp = client.get("/api/bots/bot-1")
+        assert get_resp.status_code == 200
+        body = get_resp.json()["bot"]
+        assert body["name"] == "renamed-bot"
+        cfg = body["config"]
+        # 기존 runtime control 값 전부 보존.
+        assert cfg["auto_restart"] is False
+        assert cfg["max_restart_attempts"] == 7
+        assert cfg["restart_cooldown_seconds"] == 180
+        assert cfg["step_timeout_seconds"] == 60
+        assert cfg["max_signals_per_step"] == 100
 
 
 class TestStartStopBot:


### PR DESCRIPTION
Closes #1458

## Summary
- `Bot.get_info()` now returns nested `config` object with `interval_seconds` + 5 runtime controls (`auto_restart`, `max_restart_attempts`, `restart_cooldown_seconds`, `step_timeout_seconds`, `max_signals_per_step`).
- `BotConfigSummary` BaseModel + `BotInfo.config` field added to `web/schemas.py`.
- `frontend/openapi.json` + `frontend/src/types/api.generated.ts` regen (BotConfigSummary export).
- Dashboard edit modal prefill is restored from valid `bot.config.*` (was falling back to defaults previously, causing config overwrite).

## Test Plan
- [x] `pytest tests/unit -k bot` → 650 passed
- [x] 6 new tests: get_info default/valid + bot_api GET/PUT roundtrip (4)
- [x] `cd frontend && npm run generate-types && check-api-types && build` 통과
- [x] `ruff check` / `ruff format --check` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)