### PR TITLE
fix(account): legacy invalid timezone tolerant load + repair command (#1474)

### DIFF
--- a/docs/specs/account/09-cli.md
+++ b/docs/specs/account/09-cli.md
@@ -65,6 +65,13 @@ ante account set-credentials <account_id> \
   --credential-env app_secret=KIS_APP_SECRET \
   --credential account_no=5012XXXX-01
 
+# legacy invalid timezone row 복구 (cold-path 전용 — #1474)
+# GET /api/accounts 응답에 timezone_invalid: true 로 보고된 row 를 명시적으로
+# valid IANA timezone 으로 rewrite 한다. 서비스는 invalid row 도 load 는
+# 성공시키며 fallback (Asia/Seoul) 으로 대체하지만, 원본 row 는 본 명령으로만
+# 교정된다 (silent rewrite 금지).
+ante account repair-timezone --account-id <account_id> --timezone Asia/Seoul
+
 # 시스템 전역 Kill Switch
 ante system halt                    # 전체 거래 정지 (모든 ACTIVE 계좌를 SUSPENDED로 전환)
 ante system clear-halt              # 전역 정지 해제 (모든 SUSPENDED 계좌를 ACTIVE로 복구; 봇 자동 재시작 아님)
@@ -82,6 +89,7 @@ ante system clear-halt              # 전역 정지 해제 (모든 SUSPENDED 계
 | `ante account create --broker-type ... --account-id ... --name ... --trading-mode ... [--credential ...]` | cold-path 전용 | 서버 실행 중이면 DB 수정 전 거부 |
 | `ante account delete <account_id> --yes` | cold-path 전용 | 서버 실행 중이면 DB 수정 전 거부 |
 | `ante account set-credentials <account_id> [--credential ...]` | cold-path 전용 | 서버 실행 중이면 DB 수정 전 거부 |
+| `ante account repair-timezone --account-id <id> --timezone <iana>` | cold-path 전용 | 서버 실행 중이면 DB 수정 전 거부 (#1474) |
 
 cold-path 전용 명령은 active Ante runtime guard로 서버 실행 여부를 먼저 확인한다.
 1.0 정책상 동일 OS user/home server 기준으로 active runtime은 항상 단일이며,
@@ -131,5 +139,35 @@ $ ante account credentials domestic
   APP SECRET    : ************
   계좌번호      : 5012****-01
 ```
+
+### Legacy invalid timezone row 복구 절차 (#1474)
+
+#1473 (split #1419/A) 이전에 `PUT /api/accounts/{id}` 를 통해 invalid IANA
+timezone (예: `Mars/Olympus`) 으로 저장된 row 가 존재할 수 있다. 이런 row
+는 다음과 같이 식별/복구한다:
+
+1. **식별**: `GET /api/accounts` 응답의 각 항목에 `timezone_invalid: true` 가
+   포함되어 있으면 해당 row 의 DB `timezone` 컬럼이 invalid 다. CLI `ante
+   account list` / `ante account info <id>` 는 `timezone_invalid` 를 직접
+   노출하지 않지만 서비스 로그에 `WARNING ante.account.service: 계좌 '<id>' 의
+   DB timezone '<value>' 이 invalid IANA key 입니다. fallback 'Asia/Seoul'
+   로 대체합니다` 가 남는다.
+
+2. **서비스 정지**: `ante system stop` 으로 active runtime 을 종료한다.
+   `repair-timezone` 은 cold-path 전용이므로 runtime 이 살아 있으면
+   `ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER` 로 차단된다.
+
+3. **복구**: `ante account repair-timezone --account-id <id> --timezone <valid_iana>`
+   로 명시적으로 새 valid IANA timezone (예: `Asia/Seoul`, `US/Eastern`) 을
+   지정한다. invalid 값은 사전에 거부된다 (`ACCOUNT_INVALID_TIMEZONE`).
+
+4. **검증**: `ante system start` 후 `GET /api/accounts/<id>` 응답이
+   `timezone_invalid: false` 로 돌아오고 서비스 startup 로그에 invalid timezone
+   warning 이 사라졌는지 확인한다.
+
+`repair-timezone` 은 `ante account update` 와 분리된 별도 진입점이다 —
+`timezone_invalid` 플래그는 update 의 mutable 필드에 포함되지 않으며, 진단
+플래그를 외부 update 입력으로 변경하지 않기 위해 의도적으로 분리되어 있다.
+DELETED 계좌는 복구 대상이 아니다 (`ACCOUNT_ALREADY_DELETED`).
 
 > 파일 구조: [docs/architecture/generated/project-structure.md](../../architecture/generated/project-structure.md) 참조

--- a/docs/specs/account/10-web-api.md
+++ b/docs/specs/account/10-web-api.md
@@ -60,6 +60,29 @@ Web API는 서버 프로세스 내부에서 실행되므로 계좌 구조 변경
 
 Account API의 `trading_hours_start`/`trading_hours_end`는 strict `HH:MM` 24시간 형식이다 (regex `^([01]\d|2[0-3]):[0-5]\d$`, OpenAPI `pattern`으로도 노출). 초/마이크로초 포함(`09:30:00`), invalid 시간(`99:99`), 그리고 `PUT`의 빈 문자열(`""`)은 422 Unprocessable Entity로 거부된다. `POST /api/accounts`의 `AccountCreateRequest`는 `""`를 default 의미(생략 동치)로 허용하여 CLI/seed 경로의 BrokerPreset fallback과 정합을 유지하지만, 런타임 `POST` 자체는 항상 409 cold-path로 차단된다 — 실제 검증 효과는 `PUT` 경로와 schema 소비자(CLI 등)에서 발생한다 (#1334).
 
+### Legacy invalid timezone tolerant load (#1474)
+
+#1473 (split #1419/A) 이전에 `PUT /api/accounts/:id` 가 invalid IANA timezone
+(예: `Mars/Olympus`) 을 저장하던 시기의 DB row 호환을 위해 `_row_to_account`
+는 tolerant load 를 적용한다.
+
+- invalid IANA timezone 으로 저장된 row 는 `GET /api/accounts` /
+  `GET /api/accounts/:id` 가 **fail 없이 200** 으로 응답한다.
+- 응답 `account.timezone` 은 fallback `Asia/Seoul` 로 대체되고
+  `account.timezone_invalid: true` 진단 플래그가 함께 노출된다.
+- 정상 row 는 `account.timezone_invalid: false` 이며 fallback 대체가 일어나지
+  않는다. 신규 row 는 `_validate_timezone_create` / `_validate_timezone_update`
+  가 ingress 에서 invalid 를 거부하므로 `timezone_invalid: true` 로 들어갈
+  경로가 없다.
+- 원본 DB row 의 `timezone` 컬럼은 그대로 invalid 상태로 남는다 — 서비스가
+  silent rewrite 하지 않는다. 운영자는 `ante account repair-timezone
+  --account-id <id> --timezone <valid_iana>` 로 명시적으로 교정해야 한다
+  ([09-cli.md](09-cli.md) Legacy invalid timezone row 복구 절차 참조).
+- `timezone_invalid` 는 진단 전용 응답 필드다. `PUT /api/accounts/:id` 의
+  update mutable 입력에 포함되지 않으며 (`additionalProperties: false`
+  schema 의 unknown key 로 422 거부), `AccountUpdateRequest` 의 다른 필드와
+  분리된 별도 cold-path 진입점 (`repair_timezone`) 으로만 변경된다.
+
 ### 기존 엔드포인트 계좌 필터
 
 멀티 계좌 환경에서 모든 거래·잔고·봇 관련 API 응답에 계좌 컨텍스트를 포함한다.

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -85,6 +85,7 @@ allowlist 후보에서 제거한다.
 | `ante account create --broker-type <type> --account-id <id> --name <name> --trading-mode virtual\|live ...` | `cold-path` | 서버 실행 중 차단 |
 | `ante account set-credentials <account_id> ...` | `cold-path` | 서버 실행 중 차단 |
 | `ante account delete <account_id> --yes` | `cold-path` | 서버 실행 중 차단 |
+| `ante account repair-timezone --account-id <id> --timezone <iana>` | `cold-path` | 서버 실행 중 차단 (#1474 legacy invalid timezone row 복구) |
 | `ante account suspend <account_id> --reason <reason>` | `runtime IPC` | 서버 AccountService + EventBus |
 | `ante account activate <account_id>` | `runtime IPC` | 서버 AccountService + EventBus |
 | `ante bot list [--account <account_id>]` | `runtime IPC + snapshot fallback` | 서버 BotManager live 조회 우선 |
@@ -174,6 +175,9 @@ ante account set-credentials <account_id> \
 ante account suspend <account_id> --reason <사유>  # 계좌 거래 정지
 ante account activate <account_id>            # 계좌 거래 재개
 ante account delete <account_id> --yes        # 계좌 삭제 (cold-path 전용, 연결된 봇이 없을 때만)
+ante account repair-timezone \
+  --account-id <account_id> \
+  --timezone <valid_iana>                     # legacy invalid timezone row 복구 (cold-path 전용, #1474)
 ```
 
 `account create/delete/set-credentials`는 계좌 topology 또는 브로커 초기화 입력을 바꾸므로

--- a/src/ante/account/models.py
+++ b/src/ante/account/models.py
@@ -65,6 +65,22 @@ class Account:
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
+    # --- 진단 플래그 (#1474) ---
+    # DB row 의 ``timezone`` 컬럼이 invalid IANA 값으로 저장되어 있어
+    # ``_row_to_account`` 가 fallback timezone (:data:`DEFAULT_FALLBACK_TIMEZONE`)
+    # 으로 대체한 경우 ``True`` 다. ``False`` 가 default 이며, 정상 row 와
+    # in-memory 신규 생성에는 영향이 없다.
+    #
+    # 의미론: ``True`` 일 때 ``timezone`` 필드는 fallback 값이고, 원본 DB row
+    # 는 그대로 invalid 상태로 남아 있다. 운영자는 ``ante account repair-timezone``
+    # 으로 명시적으로 row 값을 valid 로 교정해야 플래그가 재로드 시 다시
+    # ``False`` 가 된다 (silent rewrite 금지).
+    #
+    # ``IMMUTABLE_FIELDS`` / ``STRUCTURAL_FIELDS`` / ``MUTABLE_FIELDS`` 어느
+    # 분류에도 포함되지 않으며 PUT/CLI update 입력으로 받지 않는다 — 진단 전용
+    # 필드라 외부에서 직접 변경하지 않는다.
+    timezone_invalid: bool = False
+
 
 @dataclass(frozen=True)
 class BrokerPreset:

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -24,7 +24,11 @@ from ante.account.errors import (
 from ante.account.models import Account, AccountStatus, TradingMode
 from ante.account.presets import BROKER_PRESETS
 from ante.account.scoping import require_account_id, validate_new_account_id
-from ante.account.timezone import validate_iana_timezone
+from ante.account.timezone import (
+    DEFAULT_FALLBACK_TIMEZONE,
+    is_valid_iana_timezone,
+    validate_iana_timezone,
+)
 
 if TYPE_CHECKING:
     from ante.broker.base import BrokerAdapter
@@ -912,6 +916,95 @@ class AccountService:
         )
         return broker
 
+    # ── Legacy timezone repair (#1474) ────────────────────
+
+    async def repair_timezone(self, account_id: str, timezone: str) -> Account:
+        """legacy invalid timezone row 를 명시적으로 valid IANA 값으로 교정한다.
+
+        #1473 (split #1419/A) 이전에 저장되어 ``_row_to_account`` 가
+        :data:`ante.account.timezone.DEFAULT_FALLBACK_TIMEZONE` 으로 대체하고
+        ``timezone_invalid=True`` 로 표시한 row 를 운영자가 ``ante account
+        repair-timezone`` 으로 교정할 때 호출한다.
+
+        이 경로는 ``update()`` 와 의도적으로 분리한다:
+
+        - ``timezone_invalid`` 플래그는 ``update()`` 의 mutable 필드가 아니다 —
+          진단 전용이므로 외부 PUT/CLI update 입력으로 받지 않는다.
+        - ``update()`` 는 cold-path / runtime 양쪽에서 호출 가능하지만
+          ``repair_timezone()`` 은 운영 복구 명령이므로 cold-path 전용으로
+          제한해 audit 가능한 별도 진입점을 둔다.
+
+        구현:
+
+        1. 런타임 cold-path 가드 (invariant S2).
+        2. ``validate_iana_timezone`` 로 새 값 검증 — invalid 면 ``ValueError``.
+        3. ``get()`` 으로 row 존재 확인 — DELETED 는 거부 (operator must
+           use 별도 경로). 정상/SUSPENDED 는 허용.
+        4. DB row ``timezone`` 컬럼 UPDATE + cache 의 ``Account.timezone`` +
+           ``timezone_invalid=False`` 동기화 + ``updated_at`` 갱신.
+        5. broker 어댑터 재연결 trigger 는 하지 않는다 — timezone 은
+           ``broker_invalidating`` 4개 필드에 포함되지 않는다 (``service.update()``
+           정합).
+
+        Args:
+            account_id: 교정 대상 계좌.
+            timezone: 새 valid IANA timezone (예: ``"Asia/Seoul"``,
+                ``"US/Eastern"``).
+
+        Returns:
+            교정된 :class:`Account` (``timezone_invalid=False``).
+
+        Raises:
+            AccountStructuralChangeRequiresStoppedServerError: 서버 실행 중.
+            ValueError: ``timezone`` 이 invalid IANA key.
+            AccountNotFoundError: 계좌를 찾을 수 없음.
+            AccountDeletedException: DELETED 계좌는 repair 불가.
+        """
+        # 1. 런타임 cold-path 가드 (invariant S2).
+        if self._runtime_started:
+            raise AccountStructuralChangeRequiresStoppedServerError(
+                "timezone repair 는 cold-path 전용입니다. "
+                "서버를 정지한 뒤 ante account repair-timezone 으로 수행하세요."
+            )
+
+        # 2. 새 timezone 검증.
+        validate_iana_timezone(timezone)
+
+        # 3. row 존재 확인 (메모리 cache + DB DELETED fallback).
+        account = await self.get(account_id)
+        if account.status == AccountStatus.DELETED:
+            raise AccountDeletedException(
+                f"삭제된 계좌 '{account_id}'의 timezone 은 복구할 수 없습니다."
+            )
+
+        previous_timezone = account.timezone
+        previous_invalid = account.timezone_invalid
+
+        # 4. DB + cache 동기화.
+        now = datetime.now(UTC)
+        account.timezone = timezone
+        account.timezone_invalid = False
+        account.updated_at = now
+
+        await self._db.execute(
+            "UPDATE accounts SET timezone=?, updated_at=? WHERE account_id=?",
+            (timezone, now.isoformat(), account_id),
+        )
+
+        # cache 갱신 — ``get()`` 이 DELETED fallback 경로로 DB 에서 재구성한
+        # 경우 cache 에 들어 있지 않을 수 있다(현재 ACTIVE/SUSPENDED 경로에서는
+        # cache hit 이지만, future-proof 를 위해 명시적으로 setdefault).
+        self._accounts[account_id] = account
+
+        logger.info(
+            "계좌 timezone 복구: %s (%r → %r, previously_invalid=%s)",
+            account_id,
+            previous_timezone,
+            timezone,
+            previous_invalid,
+        )
+        return account
+
     # ── 기본 테스트 계좌 ──────────────────────────────────
 
     async def create_default_test_account(self) -> Account:
@@ -949,7 +1042,22 @@ class AccountService:
 
 
 def _row_to_account(row: dict[str, Any]) -> Account:
-    """DB 행을 Account 객체로 변환."""
+    """DB 행을 Account 객체로 변환.
+
+    Tolerant timezone load (#1474):
+
+    legacy DB row 가 invalid IANA timezone (예: ``Mars/Olympus``) 으로 저장된
+    경우 ``_row_to_account`` 는 row load 를 fail 시키지 않는다. 대신
+    fallback timezone (:data:`DEFAULT_FALLBACK_TIMEZONE` = ``Asia/Seoul``) 으로
+    대체하고 ``Account.timezone_invalid=True`` 플래그를 세팅한다. 원본 DB
+    row 의 ``timezone`` 컬럼은 그대로 invalid 상태로 남아 있으며, 운영자는
+    ``ante account repair-timezone`` 으로 명시적으로 교정해야 한다 — silent
+    rewrite 는 하지 않는다 (이슈 #1474 non-goals).
+
+    이 분기는 ``initialize()`` / ``get()`` / ``list()`` 가 #1473 의 service-layer
+    timezone 검증 도입 전에 저장된 legacy invalid row 때문에 crash 하지
+    않도록 보장한다 (이슈 #1419/B).
+    """
     credentials_raw = row.get("credentials", "{}")
     if isinstance(credentials_raw, str):
         credentials = decrypt_credentials(credentials_raw)
@@ -970,12 +1078,35 @@ def _row_to_account(row: dict[str, Any]) -> Account:
     buffer_raw = row.get("market_order_reserve_buffer_rate", "0")
     buffer_value = Decimal("0") if buffer_raw is None else Decimal(str(buffer_raw))
 
+    # Tolerant timezone load (#1474).
+    # row 의 timezone 이 invalid 면 fallback + flag 세팅. ``""`` (cold-path
+    # default sentinel) 은 ``ZoneInfo`` 가 ValueError 로 거부하지만, DB 컬럼
+    # default 가 ``Asia/Seoul`` 이고 ``service.create()`` 도 빈 문자열을
+    # persist 하지 않으므로(BrokerPreset fallback 적용) 정상 경로에서는
+    # ``""`` 가 DB 에 들어가지 않는다. legacy 환경에서 ``""`` 가 발견되면
+    # 동일하게 fallback + flag 로 처리한다.
+    raw_timezone = row["timezone"]
+    if is_valid_iana_timezone(raw_timezone):
+        loaded_timezone = raw_timezone
+        timezone_invalid = False
+    else:
+        logger.warning(
+            "계좌 '%s' 의 DB timezone %r 이 invalid IANA key 입니다. "
+            "fallback %r 로 대체합니다 — 'ante account repair-timezone' 으로 "
+            "복구하세요 (#1474).",
+            row.get("account_id"),
+            raw_timezone,
+            DEFAULT_FALLBACK_TIMEZONE,
+        )
+        loaded_timezone = DEFAULT_FALLBACK_TIMEZONE
+        timezone_invalid = True
+
     return Account(
         account_id=row["account_id"],
         name=row["name"],
         exchange=row["exchange"],
         currency=row["currency"],
-        timezone=row["timezone"],
+        timezone=loaded_timezone,
         trading_hours_start=row["trading_hours_start"],
         trading_hours_end=row["trading_hours_end"],
         trading_mode=TradingMode(row["trading_mode"]),
@@ -992,4 +1123,5 @@ def _row_to_account(row: dict[str, Any]) -> Account:
         updated_at=datetime.fromisoformat(row["updated_at"])
         if row.get("updated_at")
         else None,
+        timezone_invalid=timezone_invalid,
     )

--- a/src/ante/account/timezone.py
+++ b/src/ante/account/timezone.py
@@ -19,6 +19,16 @@ caller 책임:
   ``ValueError`` 그대로 propagate 하여 비-HTTP caller(CLI/IPC) 에서도 동일
   거부 의미론을 갖는다.
 
+Tolerant load (#1474):
+
+- :func:`is_valid_iana_timezone` 은 invalid 여부를 raise 없이 bool 로 판정한다.
+  ``_row_to_account`` 가 legacy DB row 의 invalid timezone(예: ``Mars/Olympus``)
+  을 만났을 때 warning log 를 남기고 fallback timezone 으로 대체할 때 사용한다.
+- caller(:class:`ante.account.service.AccountService`) 는 invalid 감지 시
+  fallback (``DEFAULT_FALLBACK_TIMEZONE`` = ``Asia/Seoul``) 으로 대체하고
+  ``Account.timezone_invalid=True`` 플래그를 세팅한다. row 자체는 그대로
+  남겨두어 ``ante account repair-timezone`` 으로 명시적으로 복구해야 한다.
+
 Non-goals:
 
 - :class:`ante.account.models.Account` ``__post_init__`` hard 검증은 적용하지
@@ -30,6 +40,15 @@ Non-goals:
 from __future__ import annotations
 
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+# Tolerant load fallback timezone (#1474).
+#
+# legacy DB row 가 invalid IANA timezone 으로 저장되어 있을 때 ``_row_to_account``
+# 가 사용한다. ``Asia/Seoul`` 은 ``Account.timezone`` 의 dataclass default 와
+# ``BROKER_PRESETS["test"].timezone`` 의 default 와 동일하므로 fallback 으로
+# 대체했을 때 다른 모듈(TradingHoursRule 등)에서 발생하는 second-order failure
+# 를 최소화한다.
+DEFAULT_FALLBACK_TIMEZONE = "Asia/Seoul"
 
 
 def validate_iana_timezone(value: str) -> str:
@@ -62,4 +81,33 @@ def validate_iana_timezone(value: str) -> str:
     return value
 
 
-__all__ = ["validate_iana_timezone"]
+def is_valid_iana_timezone(value: str) -> bool:
+    """``value`` 가 유효한 IANA timezone key 인지 raise 없이 bool 로 판정한다.
+
+    :func:`validate_iana_timezone` 와 동일한 :class:`zoneinfo.ZoneInfo` 위임을
+    사용하지만 예외를 swallow 한다. ``_row_to_account`` 가 legacy DB row 의
+    invalid timezone 을 만났을 때 warning log + fallback 대체 분기를 평가하기
+    위해 사용된다 (#1474).
+
+    빈 문자열 / 절대 경로 등 :exc:`ValueError` 도 invalid 로 본다 — 즉
+    "ZoneInfo 가 받아들이는 값" 과 동치다.
+
+    Args:
+        value: 판정할 timezone 문자열.
+
+    Returns:
+        ``ZoneInfo(value)`` 가 예외 없이 성공하면 ``True``, 그렇지 않으면
+        ``False``.
+    """
+    try:
+        ZoneInfo(value)
+    except (ZoneInfoNotFoundError, ValueError):
+        return False
+    return True
+
+
+__all__ = [
+    "DEFAULT_FALLBACK_TIMEZONE",
+    "is_valid_iana_timezone",
+    "validate_iana_timezone",
+]

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -943,6 +943,112 @@ def account_set_credentials(
         raise SystemExit(1) from e
 
 
+# ── repair-timezone ──────────────────────────────────────
+
+
+@account.command("repair-timezone")
+@click.option(
+    "--account-id",
+    "account_id_opt",
+    required=False,
+    default=None,
+    help="복구 대상 계좌 식별자",
+)
+@click.option(
+    "--timezone",
+    "timezone_opt",
+    required=False,
+    default=None,
+    help="새 valid IANA timezone (예: Asia/Seoul, US/Eastern)",
+)
+@format_option
+@click.pass_context
+@require_auth
+@require_scope("account:write")
+def account_repair_timezone(
+    ctx: click.Context,
+    account_id_opt: str | None,
+    timezone_opt: str | None,
+) -> None:
+    """legacy invalid timezone row 를 valid IANA 값으로 교정한다 (cold-path 전용).
+
+    #1473 이전에 저장되어 ``GET /api/accounts`` 응답에 ``timezone_invalid: true`` 로
+    보고된 row 를 복구하는 운영 명령. service 는 ``_row_to_account`` 단계에서
+    invalid timezone 을 fallback (``Asia/Seoul``) 으로 대체해 load 자체는
+    성공시키지만, 원본 DB row 는 그대로 invalid 다 — 본 명령으로만 명시적으로
+    rewrite 한다 (silent rewrite 금지).
+
+    필수 옵션: ``--account-id``, ``--timezone``.
+
+    실패 코드:
+
+    - ``CLI_MISSING_REQUIRED_INPUT``: 옵션 누락.
+    - ``ACCOUNT_INVALID_TIMEZONE``: ``--timezone`` 이 invalid IANA key.
+    - ``ACCOUNT_NOT_FOUND``: 계좌 없음.
+    - ``ACCOUNT_ALREADY_DELETED``: DELETED 계좌 (복구 불가).
+
+    SSOT: docs/specs/account/09-cli.md (repair-timezone 절).
+    """
+    fmt = get_formatter(ctx)
+
+    # cold-path: active runtime 차단
+    _assert_no_active_runtime(fmt)
+
+    required_inputs: dict[str, str | None] = {
+        "--account-id": account_id_opt,
+        "--timezone": timezone_opt,
+    }
+    missing = [k for k, v in required_inputs.items() if v is None or v == ""]
+    if missing:
+        _exit_with_error(
+            fmt,
+            "CLI_MISSING_REQUIRED_INPUT",
+            f"필수 옵션 누락: {missing}",
+        )
+
+    assert account_id_opt is not None
+    assert timezone_opt is not None
+
+    from ante.account.errors import (
+        AccountDeletedError,
+        AccountNotFoundError,
+    )
+
+    async def _do_repair() -> Account:
+        svc, db = await _create_account_service()
+        try:
+            return await svc.repair_timezone(account_id_opt, timezone_opt)
+        finally:
+            await db.close()
+
+    try:
+        repaired = _run(_do_repair())
+    except AccountNotFoundError as e:
+        fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
+        raise SystemExit(1) from e
+    except AccountDeletedError as e:
+        fmt.error(str(e), code="ACCOUNT_ALREADY_DELETED")
+        raise SystemExit(1) from e
+    except ValueError as e:
+        # validate_iana_timezone 의 invalid IANA 메시지를 그대로 노출.
+        fmt.error(str(e), code="ACCOUNT_INVALID_TIMEZONE")
+        raise SystemExit(1) from e
+    except click.ClickException:
+        raise
+    except Exception as e:
+        fmt.error(str(e))
+        raise SystemExit(1) from e
+
+    fmt.success(
+        f'계좌 "{repaired.account_id}" timezone 복구 완료 ({repaired.timezone})',
+        data={
+            "account_id": repaired.account_id,
+            "timezone": repaired.timezone,
+            "timezone_invalid": repaired.timezone_invalid,
+        },
+    )
+
+
 # ── 유틸리티 ──────────────────────────────────────
 
 

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -299,6 +299,9 @@ def _account_to_response(account: Any) -> dict[str, Any]:
         ),
         "created_at": (account.created_at.isoformat() if account.created_at else ""),
         "updated_at": (account.updated_at.isoformat() if account.updated_at else ""),
+        # legacy invalid timezone tolerant load 진단 플래그 (#1474). 정상 row
+        # 는 ``False`` 이며, fallback 으로 대체된 row 만 ``True`` 다.
+        "timezone_invalid": bool(getattr(account, "timezone_invalid", False)),
     }
 
 

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -52,6 +52,11 @@ class AccountResponse(BaseModel):
     status: str
     created_at: str
     updated_at: str
+    # legacy invalid timezone row tolerant load 진단 플래그 (#1474).
+    # ``True`` 일 때 ``timezone`` 필드는 fallback (``Asia/Seoul``) 으로 대체된
+    # 값이며, DB row 의 원본 timezone 컬럼은 여전히 invalid 상태다. 운영자는
+    # ``ante account repair-timezone`` 으로 명시적으로 교정해야 한다.
+    timezone_invalid: bool = False
 
 
 class AccountListResponse(BaseModel):

--- a/tests/unit/test_account_legacy_timezone.py
+++ b/tests/unit/test_account_legacy_timezone.py
@@ -1,0 +1,818 @@
+"""Legacy invalid timezone row tolerant load + repair 절차 단위 테스트 (#1474).
+
+SSOT:
+
+- ``src/ante/account/timezone.py`` (``is_valid_iana_timezone``,
+  ``DEFAULT_FALLBACK_TIMEZONE``).
+- ``src/ante/account/service.py`` (``_row_to_account`` tolerant load,
+  ``AccountService.repair_timezone``).
+- ``src/ante/web/routes/accounts.py`` (``_account_to_response``
+  ``timezone_invalid`` 노출).
+- ``src/ante/cli/commands/account.py`` (``account repair-timezone``).
+
+이슈 #1474 (split #1419/B): #1473 이전에 저장된 invalid IANA timezone row
+(예: ``Mars/Olympus``) 가 ``GET`` / ``load`` 경로를 깨지 않도록 fallback
+대체 + 진단 플래그 + 명시적 repair 절차를 제공한다.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from click.testing import CliRunner
+
+from ante.account.crypto import encrypt_credentials
+from ante.account.errors import (
+    AccountDeletedException,
+    AccountNotFoundError,
+    AccountStructuralChangeRequiresStoppedServerError,
+)
+from ante.account.models import Account, AccountStatus, TradingMode
+from ante.account.service import AccountService, _row_to_account
+from ante.account.timezone import (
+    DEFAULT_FALLBACK_TIMEZONE,
+    is_valid_iana_timezone,
+    validate_iana_timezone,
+)
+from ante.core.database import Database
+from ante.eventbus.bus import EventBus
+
+# ── is_valid_iana_timezone 헬퍼 ────────────────────────────
+
+
+class TestIsValidIanaTimezone:
+    """``is_valid_iana_timezone`` 헬퍼의 raise 없는 bool 판정 단위."""
+
+    def test_accepts_asia_seoul(self) -> None:
+        assert is_valid_iana_timezone("Asia/Seoul") is True
+
+    def test_accepts_us_eastern(self) -> None:
+        assert is_valid_iana_timezone("US/Eastern") is True
+
+    def test_accepts_america_new_york(self) -> None:
+        assert is_valid_iana_timezone("America/New_York") is True
+
+    def test_rejects_mars_olympus(self) -> None:
+        assert is_valid_iana_timezone("Mars/Olympus") is False
+
+    def test_rejects_empty_string(self) -> None:
+        assert is_valid_iana_timezone("") is False
+
+    def test_rejects_absolute_path(self) -> None:
+        """절대 경로는 ZoneInfo 가 ValueError — invalid 로 판정."""
+        assert is_valid_iana_timezone("/etc/localtime") is False
+
+    def test_default_fallback_is_valid(self) -> None:
+        """fallback timezone 자체는 valid IANA 여야 한다 (실수 방지)."""
+        assert is_valid_iana_timezone(DEFAULT_FALLBACK_TIMEZONE) is True
+        # 기존 validate_iana_timezone 도 동일하게 통과
+        assert validate_iana_timezone(DEFAULT_FALLBACK_TIMEZONE) == "Asia/Seoul"
+
+
+# ── _row_to_account tolerant load ────────────────────────────
+
+
+def _row_template(
+    account_id: str = "legacy",
+    timezone: str = "Mars/Olympus",
+) -> dict:
+    """``_row_to_account`` 가 기대하는 DB row dict (모든 컬럼 채움)."""
+    return {
+        "account_id": account_id,
+        "name": "legacy account",
+        "exchange": "TEST",
+        "currency": "KRW",
+        "timezone": timezone,
+        "trading_hours_start": "09:00",
+        "trading_hours_end": "15:30",
+        "trading_mode": "virtual",
+        "broker_type": "test",
+        "credentials": encrypt_credentials({"app_key": "k", "app_secret": "s"}),
+        "broker_config": "{}",
+        "buy_commission_rate": 0,
+        "sell_commission_rate": 0,
+        "market_order_reserve_buffer_rate": 0,
+        "status": "active",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+
+class TestRowToAccountTolerantLoad:
+    """``_row_to_account`` 의 invalid timezone fallback 단위."""
+
+    def test_valid_timezone_passes_through(self) -> None:
+        """유효 row 는 그대로 통과, ``timezone_invalid`` 는 False."""
+        row = _row_template(timezone="Asia/Seoul")
+        account = _row_to_account(row)
+        assert account.timezone == "Asia/Seoul"
+        assert account.timezone_invalid is False
+
+    def test_us_eastern_legacy_alias_passes_through(self) -> None:
+        """legacy alias ``US/Eastern`` 도 valid 로 인정 (회귀 보존)."""
+        row = _row_template(timezone="US/Eastern")
+        account = _row_to_account(row)
+        assert account.timezone == "US/Eastern"
+        assert account.timezone_invalid is False
+
+    def test_invalid_timezone_falls_back(self) -> None:
+        """invalid ``Mars/Olympus`` 는 fallback 으로 대체 + flag 세팅."""
+        row = _row_template(timezone="Mars/Olympus")
+        account = _row_to_account(row)
+        assert account.timezone == DEFAULT_FALLBACK_TIMEZONE
+        assert account.timezone == "Asia/Seoul"
+        assert account.timezone_invalid is True
+
+    def test_invalid_timezone_emits_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """fallback 시 WARNING 로그가 남아 운영자가 식별할 수 있다."""
+        row = _row_template(account_id="legacy-mars", timezone="Mars/Olympus")
+        with caplog.at_level(logging.WARNING, logger="ante.account.service"):
+            _row_to_account(row)
+        # warning 메시지에 account_id 와 invalid 값이 포함되어야 한다.
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "legacy-mars" in r.getMessage() and "Mars/Olympus" in r.getMessage()
+            for r in warnings
+        ), f"warning 누락: {[r.getMessage() for r in warnings]}"
+
+    def test_empty_timezone_also_falls_back(self) -> None:
+        """legacy 환경에서 ``""`` 가 발견되어도 fallback 처리."""
+        row = _row_template(timezone="")
+        account = _row_to_account(row)
+        assert account.timezone == DEFAULT_FALLBACK_TIMEZONE
+        assert account.timezone_invalid is True
+
+
+# ── AccountService.initialize / get / list tolerant ────────────
+
+
+@pytest_asyncio.fixture
+async def db(tmp_path):
+    db_path = str(tmp_path / "test_legacy_timezone.db")
+    database = Database(db_path)
+    await database.connect()
+    yield database
+    await database.close()
+
+
+@pytest_asyncio.fixture
+async def initialized_service(db):
+    svc = AccountService(db, EventBus())
+    await svc.initialize()
+    return svc
+
+
+async def _insert_legacy_row(
+    db: Database,
+    *,
+    account_id: str = "legacy-mars",
+    timezone: str = "Mars/Olympus",
+    status: str = "active",
+) -> None:
+    """invalid timezone row 를 DB 에 직접 INSERT 한다 (#1473 service 가드 우회)."""
+    await db.execute(
+        """INSERT INTO accounts
+           (account_id, name, exchange, currency, timezone,
+            trading_hours_start, trading_hours_end, trading_mode,
+            broker_type, credentials, broker_config,
+            buy_commission_rate, sell_commission_rate,
+            market_order_reserve_buffer_rate,
+            status, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            account_id,
+            "legacy account",
+            "TEST",
+            "KRW",
+            timezone,
+            "09:00",
+            "15:30",
+            "virtual",
+            "test",
+            encrypt_credentials({"app_key": "k", "app_secret": "s"}),
+            "{}",
+            0,
+            0,
+            0,
+            status,
+            "2026-01-01T00:00:00+00:00",
+            "2026-01-01T00:00:00+00:00",
+        ),
+    )
+
+
+class TestServiceTolerantLoad:
+    """``initialize`` / ``get`` / ``list`` 가 invalid row 에도 crash 하지 않는다."""
+
+    @pytest.mark.asyncio
+    async def test_initialize_loads_invalid_row_without_crash(self, db) -> None:
+        """invalid row 가 들어 있어도 ``initialize`` 가 성공해야 한다."""
+        # service 의 initialize 가 schema 를 만들도록 한 번 통과시킨 뒤
+        # legacy row 를 직접 INSERT 하고 fresh service 로 다시 load 한다.
+        bootstrap = AccountService(db, EventBus())
+        await bootstrap.initialize()
+        await _insert_legacy_row(db, account_id="legacy-mars", timezone="Mars/Olympus")
+
+        svc = AccountService(db, EventBus())
+        await svc.initialize()  # crash 하지 않아야 한다
+        loaded = await svc.get("legacy-mars")
+        assert loaded.timezone == DEFAULT_FALLBACK_TIMEZONE
+        assert loaded.timezone_invalid is True
+        # 다른 컬럼은 정상 로드
+        assert loaded.name == "legacy account"
+        assert loaded.exchange == "TEST"
+
+    @pytest.mark.asyncio
+    async def test_list_returns_invalid_row(self, db) -> None:
+        """``list()`` 가 invalid row 를 포함해 정상 응답."""
+        bootstrap = AccountService(db, EventBus())
+        await bootstrap.initialize()
+        await _insert_legacy_row(db, account_id="legacy-mars", timezone="Mars/Olympus")
+        await _insert_legacy_row(db, account_id="legacy-valid", timezone="Asia/Seoul")
+
+        svc = AccountService(db, EventBus())
+        await svc.initialize()
+        accounts = await svc.list()
+        ids = {a.account_id for a in accounts}
+        assert ids == {"legacy-mars", "legacy-valid"}
+        by_id = {a.account_id: a for a in accounts}
+        assert by_id["legacy-mars"].timezone_invalid is True
+        assert by_id["legacy-mars"].timezone == DEFAULT_FALLBACK_TIMEZONE
+        assert by_id["legacy-valid"].timezone_invalid is False
+        assert by_id["legacy-valid"].timezone == "Asia/Seoul"
+
+    @pytest.mark.asyncio
+    async def test_get_returns_fallback_with_flag(self, db) -> None:
+        """``get()`` 도 fallback + flag 로 응답 (메모리 cache 경로)."""
+        bootstrap = AccountService(db, EventBus())
+        await bootstrap.initialize()
+        await _insert_legacy_row(db, account_id="legacy-mars", timezone="Mars/Olympus")
+        svc = AccountService(db, EventBus())
+        await svc.initialize()
+
+        account = await svc.get("legacy-mars")
+        assert account.timezone == "Asia/Seoul"
+        assert account.timezone_invalid is True
+
+
+# ── AccountService.repair_timezone ────────────────────────────
+
+
+class TestRepairTimezone:
+    """``AccountService.repair_timezone`` 의 cold-path repair 의미론."""
+
+    @pytest.mark.asyncio
+    async def test_repair_fixes_invalid_row(self, db) -> None:
+        """invalid row 를 valid timezone 으로 교정하면 flag 가 사라진다."""
+        bootstrap = AccountService(db, EventBus())
+        await bootstrap.initialize()
+        await _insert_legacy_row(db, account_id="legacy-mars", timezone="Mars/Olympus")
+        svc = AccountService(db, EventBus())
+        await svc.initialize()
+
+        # pre: fallback + flag
+        before = await svc.get("legacy-mars")
+        assert before.timezone_invalid is True
+
+        # repair
+        repaired = await svc.repair_timezone("legacy-mars", "US/Eastern")
+        assert repaired.timezone == "US/Eastern"
+        assert repaired.timezone_invalid is False
+
+        # post: DB 에 영구 반영. fresh service 로 다시 load 해도 valid.
+        svc2 = AccountService(db, EventBus())
+        await svc2.initialize()
+        after = await svc2.get("legacy-mars")
+        assert after.timezone == "US/Eastern"
+        assert after.timezone_invalid is False
+
+    @pytest.mark.asyncio
+    async def test_repair_rejects_invalid_new_timezone(self, db) -> None:
+        """새 timezone 도 valid IANA 여야 한다 — invalid 면 ValueError."""
+        bootstrap = AccountService(db, EventBus())
+        await bootstrap.initialize()
+        await _insert_legacy_row(db, account_id="legacy-mars", timezone="Mars/Olympus")
+        svc = AccountService(db, EventBus())
+        await svc.initialize()
+
+        with pytest.raises(ValueError, match="invalid IANA timezone"):
+            await svc.repair_timezone("legacy-mars", "Atlantis/Capital")
+
+        # row 변경 없음 — 여전히 fallback 응답.
+        unchanged = await svc.get("legacy-mars")
+        assert unchanged.timezone == DEFAULT_FALLBACK_TIMEZONE
+        assert unchanged.timezone_invalid is True
+
+    @pytest.mark.asyncio
+    async def test_repair_rejects_runtime_started(self, db) -> None:
+        """``mark_runtime_started()`` 후 호출은 cold-path 가드로 차단."""
+        bootstrap = AccountService(db, EventBus())
+        await bootstrap.initialize()
+        await _insert_legacy_row(db, account_id="legacy-mars", timezone="Mars/Olympus")
+        svc = AccountService(db, EventBus())
+        await svc.initialize()
+        svc.mark_runtime_started()
+
+        with pytest.raises(AccountStructuralChangeRequiresStoppedServerError):
+            await svc.repair_timezone("legacy-mars", "Asia/Seoul")
+
+    @pytest.mark.asyncio
+    async def test_repair_not_found(self, initialized_service) -> None:
+        """없는 계좌는 AccountNotFoundError."""
+        with pytest.raises(AccountNotFoundError):
+            await initialized_service.repair_timezone("ghost", "Asia/Seoul")
+
+    @pytest.mark.asyncio
+    async def test_repair_rejects_deleted_account(self, db) -> None:
+        """DELETED 계좌는 복구 대상이 아니다."""
+        bootstrap = AccountService(db, EventBus())
+        await bootstrap.initialize()
+        await _insert_legacy_row(
+            db, account_id="legacy-deleted", timezone="Mars/Olympus", status="deleted"
+        )
+        svc = AccountService(db, EventBus())
+        await svc.initialize()
+
+        with pytest.raises(AccountDeletedException):
+            await svc.repair_timezone("legacy-deleted", "Asia/Seoul")
+
+    @pytest.mark.asyncio
+    async def test_repair_accepts_already_valid_row(self, db) -> None:
+        """invalid 가 아니어도 repair 호출은 허용 — 명시적 rewrite 진입점."""
+        # 정상 row 를 만들고 같은 명령으로 timezone 을 다른 valid 로 교정.
+        bootstrap = AccountService(db, EventBus())
+        await bootstrap.initialize()
+        await _insert_legacy_row(db, account_id="ok-row", timezone="Asia/Seoul")
+        svc = AccountService(db, EventBus())
+        await svc.initialize()
+
+        repaired = await svc.repair_timezone("ok-row", "America/New_York")
+        assert repaired.timezone == "America/New_York"
+        assert repaired.timezone_invalid is False
+
+
+# ── web route timezone_invalid 노출 ────────────────────────────
+
+
+class TestRouteAccountToResponseFlag:
+    """``_account_to_response`` 가 ``timezone_invalid`` 를 노출한다."""
+
+    def test_response_includes_flag_true(self) -> None:
+        from ante.web.routes.accounts import _account_to_response
+
+        account = Account(
+            account_id="legacy",
+            name="legacy",
+            exchange="TEST",
+            currency="KRW",
+            timezone="Asia/Seoul",
+            broker_type="test",
+            credentials={},
+            timezone_invalid=True,
+        )
+        resp = _account_to_response(account)
+        assert resp["timezone_invalid"] is True
+        assert resp["timezone"] == "Asia/Seoul"
+
+    def test_response_includes_flag_false_for_valid(self) -> None:
+        from ante.web.routes.accounts import _account_to_response
+
+        account = Account(
+            account_id="valid",
+            name="valid",
+            exchange="TEST",
+            currency="KRW",
+            timezone="US/Eastern",
+            broker_type="test",
+            credentials={},
+        )
+        resp = _account_to_response(account)
+        assert resp["timezone_invalid"] is False
+        assert resp["timezone"] == "US/Eastern"
+
+
+# ── CLI ante account repair-timezone ────────────────────────────
+
+
+def _invoke(args: list[str]):
+    """CLI runner 헬퍼 (test_account_cli 패턴)."""
+    from ante.cli.main import cli
+
+    runner = CliRunner()
+    env = {"ANTE_MEMBER_TOKEN": ""}
+    return runner.invoke(cli, args, env=env, catch_exceptions=False)
+
+
+@pytest.fixture
+def mock_account_service():
+    """AccountService mock fixture (test_account_cli 패턴)."""
+    svc = AsyncMock()
+    db = AsyncMock()
+
+    async def _create_service():
+        return svc, db
+
+    with patch(
+        "ante.cli.commands.account._create_account_service", new=_create_service
+    ):
+        yield svc
+
+
+@pytest.fixture(autouse=True)
+def bypass_auth():
+    from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+    mock_member = Member(
+        member_id="tester",
+        name="테스터",
+        type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+        status=MemberStatus.ACTIVE,
+        scopes=[],
+    )
+    with patch(
+        "ante.cli.main.authenticate_member",
+        side_effect=lambda ctx: ctx.obj.update({"member": mock_member}),
+    ):
+        yield
+
+
+@pytest.fixture
+def offline_runtime():
+    """active runtime 부재를 모사한다 (cold-path 통과)."""
+    with (
+        patch("ante.main.read_pid_file", return_value=None),
+        patch(
+            "ante.cli.commands.ipc_helpers.get_socket_path",
+            return_value="/tmp/__ante_offline_runtime_repair_tz__.sock",
+        ),
+    ):
+        yield
+
+
+def _repaired_account() -> Account:
+    return Account(
+        account_id="legacy-mars",
+        name="legacy",
+        exchange="TEST",
+        currency="KRW",
+        timezone="Asia/Seoul",
+        broker_type="test",
+        credentials={},
+        buy_commission_rate=Decimal("0"),
+        sell_commission_rate=Decimal("0"),
+        status=AccountStatus.ACTIVE,
+        trading_mode=TradingMode.VIRTUAL,
+        timezone_invalid=False,
+    )
+
+
+class TestCliAccountRepairTimezone:
+    """``ante account repair-timezone`` 비대화형 CLI 계약."""
+
+    def test_repair_success(
+        self,
+        offline_runtime,
+        mock_account_service: AsyncMock,
+    ) -> None:
+        mock_account_service.repair_timezone.return_value = _repaired_account()
+        result = _invoke(
+            [
+                "account",
+                "repair-timezone",
+                "--account-id",
+                "legacy-mars",
+                "--timezone",
+                "Asia/Seoul",
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        # service 호출 인자 검증
+        mock_account_service.repair_timezone.assert_awaited_once_with(
+            "legacy-mars", "Asia/Seoul"
+        )
+        assert "legacy-mars" in result.output
+        assert "Asia/Seoul" in result.output
+
+    def test_repair_json_success(
+        self,
+        offline_runtime,
+        mock_account_service: AsyncMock,
+    ) -> None:
+        mock_account_service.repair_timezone.return_value = _repaired_account()
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "account",
+                "repair-timezone",
+                "--account-id",
+                "legacy-mars",
+                "--timezone",
+                "Asia/Seoul",
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        # JSON 출력에 account_id / timezone / timezone_invalid 키가 노출된다.
+        # OutputFormatter 의 success() 는 data dict 를 그대로 dump 한다.
+        # 정확한 wrap 키 이름은 formatter 구현에 따라 다를 수 있으므로
+        # substring 으로 검증한다.
+        assert "legacy-mars" in result.output
+        assert "Asia/Seoul" in result.output
+        # 진단 플래그가 노출되어야 한다.
+        assert "timezone_invalid" in result.output
+
+    def test_repair_missing_account_id(
+        self,
+        offline_runtime,
+        mock_account_service: AsyncMock,
+    ) -> None:
+        result = _invoke(
+            [
+                "account",
+                "repair-timezone",
+                "--timezone",
+                "Asia/Seoul",
+            ]
+        )
+        assert result.exit_code == 1
+        assert "CLI_MISSING_REQUIRED_INPUT" in result.output
+        assert "--account-id" in result.output
+        mock_account_service.repair_timezone.assert_not_called()
+
+    def test_repair_missing_timezone(
+        self,
+        offline_runtime,
+        mock_account_service: AsyncMock,
+    ) -> None:
+        result = _invoke(
+            [
+                "account",
+                "repair-timezone",
+                "--account-id",
+                "legacy-mars",
+            ]
+        )
+        assert result.exit_code == 1
+        assert "CLI_MISSING_REQUIRED_INPUT" in result.output
+        assert "--timezone" in result.output
+        mock_account_service.repair_timezone.assert_not_called()
+
+    def test_repair_invalid_timezone_value_text(
+        self,
+        offline_runtime,
+        mock_account_service: AsyncMock,
+    ) -> None:
+        """service 가 ValueError 를 raise 하면 text 모드에서 message 노출."""
+        mock_account_service.repair_timezone.side_effect = ValueError(
+            "invalid IANA timezone: 'Mars/Olympus'"
+        )
+        result = _invoke(
+            [
+                "account",
+                "repair-timezone",
+                "--account-id",
+                "legacy-mars",
+                "--timezone",
+                "Mars/Olympus",
+            ]
+        )
+        assert result.exit_code == 1
+        # text 모드 stderr 출력에 메시지가 포함된다.
+        assert "invalid IANA timezone" in result.output
+
+    def test_repair_invalid_timezone_value_json(
+        self,
+        offline_runtime,
+        mock_account_service: AsyncMock,
+    ) -> None:
+        """JSON 모드에서는 ACCOUNT_INVALID_TIMEZONE code 가 노출된다.
+
+        ``OutputFormatter.error`` 는 JSON 모드에서만 ``code`` 를 dump 한다.
+        """
+        mock_account_service.repair_timezone.side_effect = ValueError(
+            "invalid IANA timezone: 'Mars/Olympus'"
+        )
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "account",
+                "repair-timezone",
+                "--account-id",
+                "legacy-mars",
+                "--timezone",
+                "Mars/Olympus",
+            ]
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "ACCOUNT_INVALID_TIMEZONE"
+        assert "invalid IANA timezone" in payload["message"]
+
+    def test_repair_not_found(
+        self,
+        offline_runtime,
+        mock_account_service: AsyncMock,
+    ) -> None:
+        mock_account_service.repair_timezone.side_effect = AccountNotFoundError(
+            "계좌 'ghost'를 찾을 수 없습니다."
+        )
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "account",
+                "repair-timezone",
+                "--account-id",
+                "ghost",
+                "--timezone",
+                "Asia/Seoul",
+            ]
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["code"] == "ACCOUNT_NOT_FOUND"
+
+    def test_repair_deleted(
+        self,
+        offline_runtime,
+        mock_account_service: AsyncMock,
+    ) -> None:
+        mock_account_service.repair_timezone.side_effect = AccountDeletedException(
+            "삭제된 계좌"
+        )
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "account",
+                "repair-timezone",
+                "--account-id",
+                "deleted-acct",
+                "--timezone",
+                "Asia/Seoul",
+            ]
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["code"] == "ACCOUNT_ALREADY_DELETED"
+
+
+# ── 회귀: 기존 valid timezone load + update 경로 ────────────────
+
+
+class TestExistingValidTimezoneRegression:
+    """기존 valid timezone load/update 경로가 깨지지 않아야 한다 (#1473 호환)."""
+
+    @pytest.mark.asyncio
+    async def test_create_load_roundtrip_no_flag(self, initialized_service) -> None:
+        """정상 create → load 시 ``timezone_invalid`` 는 False 그대로."""
+        created = await initialized_service.create(
+            Account(
+                account_id="main",
+                name="ok",
+                exchange="TEST",
+                currency="KRW",
+                timezone="US/Eastern",
+                broker_type="test",
+                credentials={"app_key": "k", "app_secret": "s"},
+            )
+        )
+        assert created.timezone == "US/Eastern"
+        assert created.timezone_invalid is False
+        # cache 경로
+        fetched = await initialized_service.get("main")
+        assert fetched.timezone_invalid is False
+
+    @pytest.mark.asyncio
+    async def test_update_valid_timezone_does_not_set_flag(
+        self, initialized_service
+    ) -> None:
+        await initialized_service.create(
+            Account(
+                account_id="main",
+                name="ok",
+                exchange="TEST",
+                currency="KRW",
+                timezone="Asia/Seoul",
+                broker_type="test",
+                credentials={"app_key": "k", "app_secret": "s"},
+            )
+        )
+        updated = await initialized_service.update("main", timezone="America/New_York")
+        assert updated.timezone == "America/New_York"
+        assert updated.timezone_invalid is False
+
+    @pytest.mark.asyncio
+    async def test_update_rejects_invalid_timezone_preserves_flag(
+        self, initialized_service, db
+    ) -> None:
+        """``update()`` 는 #1473 service 가드로 invalid timezone 을 거부해야 한다.
+
+        결과적으로 legacy invalid row 에 update 로 invalid 값을 추가 저장하는
+        경로가 막혀 있다.
+        """
+        await initialized_service.create(
+            Account(
+                account_id="main",
+                name="ok",
+                exchange="TEST",
+                currency="KRW",
+                timezone="Asia/Seoul",
+                broker_type="test",
+                credentials={"app_key": "k", "app_secret": "s"},
+            )
+        )
+        with pytest.raises(ValueError, match="invalid IANA timezone"):
+            await initialized_service.update("main", timezone="Mars/Olympus")
+        # row 는 그대로 valid
+        fetched = await initialized_service.get("main")
+        assert fetched.timezone == "Asia/Seoul"
+        assert fetched.timezone_invalid is False
+
+
+# ── _account_to_detail / _account_to_row 회귀 ──────────────────
+
+
+def test_account_to_row_includes_existing_fields() -> None:
+    """CLI ``list`` 헬퍼 ``_account_to_row`` 는 timezone_invalid 를 누락해도 무방.
+
+    SSOT: CLI list 출력은 기존 컬럼만 보이며, ``timezone_invalid`` 진단 플래그는
+    WEB API (``_account_to_response``) 와 ``repair-timezone`` 출력에서만 노출된다.
+    list/info 의 출력 컬럼 contract 가 깨지지 않았는지 회귀로 보호한다.
+    """
+    from ante.cli.commands.account import _account_to_row
+
+    account = Account(
+        account_id="legacy",
+        name="legacy",
+        exchange="TEST",
+        currency="KRW",
+        timezone="Asia/Seoul",
+        broker_type="test",
+        credentials={},
+        timezone_invalid=True,
+    )
+    row = _account_to_row(account)
+    # 기존 6개 컬럼이 그대로 유지되어야 한다.
+    assert row == {
+        "account_id": "legacy",
+        "name": "legacy",
+        "exchange": "TEST",
+        "currency": "KRW",
+        "broker_type": "test",
+        "status": "active",
+    }
+
+
+# ── repair_timezone 호출 후 후속 update timezone 회귀 ──────────
+
+
+class TestRepairFollowedByUpdate:
+    """repair 후 update 흐름이 깨지지 않는다 (cache 동기화 확인)."""
+
+    @pytest.mark.asyncio
+    async def test_repair_then_update_name(self, db) -> None:
+        bootstrap = AccountService(db, EventBus())
+        await bootstrap.initialize()
+        await _insert_legacy_row(db, account_id="legacy-mars", timezone="Mars/Olympus")
+        svc = AccountService(db, EventBus())
+        await svc.initialize()
+
+        await svc.repair_timezone("legacy-mars", "US/Eastern")
+        # 후속 mutable update 도 정상 진행
+        updated = await svc.update("legacy-mars", name="renamed")
+        assert updated.name == "renamed"
+        assert updated.timezone == "US/Eastern"
+        assert updated.timezone_invalid is False
+
+
+# Sanity: JSON 직렬화에 timezone_invalid 가 포함된다.
+
+
+def test_account_to_response_json_serializable() -> None:
+    from ante.web.routes.accounts import _account_to_response
+
+    account = Account(
+        account_id="legacy",
+        name="legacy",
+        exchange="TEST",
+        currency="KRW",
+        timezone="Asia/Seoul",
+        broker_type="test",
+        credentials={},
+        timezone_invalid=True,
+    )
+    resp = _account_to_response(account)
+    # JSON dump 가 가능해야 한다.
+    serialized = json.loads(json.dumps(resp))
+    assert serialized["timezone_invalid"] is True


### PR DESCRIPTION
Closes #1474

## Summary
- `src/ante/account/timezone.py`: `is_valid_iana_timezone()` bool helper + `DEFAULT_FALLBACK_TIMEZONE` constant.
- `_row_to_account`: invalid timezone row uses fallback + `Account.timezone_invalid=True` flag + WARNING log; original DB row preserved.
- `AccountService.repair_timezone(account_id, timezone)`: cold-path explicit recovery. Rejects invalid new value, runtime started, deleted, not found.
- `Account.timezone_invalid: bool = False` diagnostic field.
- `AccountResponse.timezone_invalid` exposed in Web API.
- New CLI: `ante account repair-timezone --account-id X --timezone Y` with `ACCOUNT_INVALID_TIMEZONE` / `ACCOUNT_NOT_FOUND` / `ACCOUNT_ALREADY_DELETED` mapping.
- Docs: account spec sections + runbook.

## Test Plan
- [x] 37 new test cases (helper, _row_to_account tolerant, repair branches, web response, CLI)
- [x] `pytest tests/unit -k account` → 770 passed (regression 0)
- [x] `ruff check` / `mypy` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)