### PR TITLE
feat(member,cli): audit-roles + repair-role for legacy invalid-role cleanup (#1468)

### DIFF
--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -128,9 +128,11 @@ allowlist 후보에서 제거한다.
 | `ante approval list/info/review ...` | `offline` | approval 저장소 조회 |
 | `ante init ...` | `bootstrap/maintenance` | 인스턴스 파일 + master/test account 생성 |
 | `ante member list/info ...` | `offline` | member 조회 |
+| `ante member audit-roles` | `offline` | invalid-role row 식별 (read-only, #1468) |
 | `ante member register --id <member_id> --type human|agent ...` | `runtime IPC` | 서버 실행 중 member/session/security 상태 변경 |
 | `ante member set-emoji/suspend/reactivate/rotate-token ...` | `runtime IPC` | 서버 실행 중 member/session/security 상태 변경 |
 | `ante member revoke <member_id> --yes` | `runtime IPC` | 서버 실행 중 member/session/security 상태 변경 |
+| `ante member repair-role --member-id <id> --role admin\|default` | `runtime IPC` | invalid-role row 교정 (master only, #1468) |
 | `ante member reset-password --recovery-key <key> (--new-password-env <ENV>\|--new-password-file <PATH>)` | `runtime IPC` | 서버 실행 중 member/session/security 상태 변경 |
 | `ante member regenerate-recovery-key (--password-env <ENV>\|--password-file <PATH>)` | `runtime IPC` | 서버 실행 중 member/session/security 상태 변경 |
 | 동일 member mutation, 서버 정지 상태 | `bootstrap/maintenance` | recovery/비상 운영 fallback |
@@ -535,6 +537,8 @@ ante init [--member-id owner] [--name Owner] [--dir <경로>]
 ante member register --id <member_id> --type human|agent [--org <org>] [--name <name>] [--scopes <csv>]  # 멤버 등록
 ante member list [--type human|agent] [--org <org>] [--status active|suspended|revoked]  # 멤버 목록
 ante member info <member_id>                            # 멤버 상세
+ante member audit-roles                                  # invalid-role row 식별 (read-only, #1468)
+ante member repair-role --member-id <id> --role admin|default  # invalid-role row 교정 (master only, #1468)
 ante member suspend <member_id>                         # 멤버 일시 정지
 ante member reactivate <member_id>                      # 멤버 재활성화
 ante member revoke <member_id> --yes                    # 멤버 권한 영구 해제 (--yes 누락 시 CLI_CONFIRMATION_REQUIRED)

--- a/docs/specs/member/06-cli.md
+++ b/docs/specs/member/06-cli.md
@@ -82,6 +82,30 @@ ante member revoke strategy-dev-01 --yes [--format json]
 # ⚠️ 이 작업은 되돌릴 수 없습니다. --yes 누락 시 CLI_CONFIRMATION_REQUIRED로 실패합니다.
 ```
 
+### `ante member audit-roles`
+
+`MemberRole` enum SSOT 에 없는 ``role`` 값을 가진 row 를 식별해 출력한다.
+read-only 이며 DB 를 수정하지 않는다. cleanup 결정은 운영자/감사 절차에
+위임한다. 정상 role row 는 결과에 포함되지 않는다.
+
+```
+ante member audit-roles [--format json]
+# text: invalid-role member {N}건 식별됨: ...
+# json: {"invalid_members": [...]}
+```
+
+### `ante member repair-role --member-id <id> --role admin|default`
+
+`audit-roles` 가 식별한 invalid-role row 의 ``role`` 을 ``MemberRole`` enum
+멤버로 교정한다. master 만 호출할 수 있다. ``--role`` 은 ``master`` 로
+지정할 수 없다 (cleanup 의도 위반 — 권한 상승 방지). 이미 valid role 인 row 를
+재교정하는 호출도 거부한다 (정상 role row 영향 없음 회귀). 성공 시
+``MemberRoleRepairedEvent`` 가 발행되어 audit/log 추적이 가능하다.
+
+```
+ante member repair-role --member-id agent-leak-1 --role default [--format json]
+```
+
 ### `ante member rotate-token <member_id>`
 
 ```

--- a/docs/specs/member/10-invalid-role-cleanup.md
+++ b/docs/specs/member/10-invalid-role-cleanup.md
@@ -1,0 +1,118 @@
+# Member 모듈 운영 — invalid-role row cleanup
+
+> 인덱스: [README.md](README.md) | 관련: [05-member-service.md](05-member-service.md), [06-cli.md](06-cli.md), [09-notification-events.md](09-notification-events.md)
+> 도입: #1468 (split #1417/D). 의존: #1465 (write path), #1466 (auth read-path).
+
+## 1. 배경
+
+#1465 (split #1417/A) 가 `MemberService.register` 와 Web API ingress 에서
+`MemberRole` enum 멤버가 아닌 ``role`` 입력을 막고, #1466 (split #1417/B) 가
+auth read-path 에서 invalid-role principal 의 인증을 거부한 뒤에도, 그 이전에
+DB 에 만들어진 `role="oracle_invalid_role"` 같은 row 는 그대로 남는다.
+
+본 cleanup 은 운영자가 그런 legacy row 를 안전하게 식별하고 교정하기 위한
+도구와 절차다. 자동 마이그레이션은 의도적으로 도입하지 않는다 — 잘못된 일괄
+변경이 더 큰 사고를 만들 수 있으므로 식별 / 검토 / 명시적 교정 순서를 강제한다.
+
+## 2. 절차
+
+### 2.1 식별 (read-only)
+
+`ante member audit-roles` 로 invalid-role row 를 식별한다. 본 명령은 DB 를
+수정하지 않는다.
+
+```bash
+# 텍스트 출력 (운영자 확인용)
+$ ante member audit-roles
+invalid-role member 1건 식별됨:
+  agent-leak-1         type=agent  role='oracle_invalid_role'        status=active     created_at=2026-05-09 10:01:23
+
+# JSON 출력 (자동화용)
+$ ante member audit-roles --format json
+{
+  "invalid_members": [
+    {
+      "member_id": "agent-leak-1",
+      "type": "agent",
+      "role": "oracle_invalid_role",
+      "org": "default",
+      "name": "agent-leak-1",
+      "status": "active",
+      "created_at": "2026-05-09 10:01:23",
+      "created_by": "oracle"
+    }
+  ]
+}
+```
+
+`audit-roles` 는 `member:read` scope 로 동작하며, master/admin/default 같은
+정상 role row 는 결과에서 제외된다 (정상 role row 영향 없음 회귀).
+
+### 2.2 검토
+
+식별된 row 별로 cleanup 방향을 결정한다. 후보는 두 가지다:
+
+1. **교정**: row 의 실제 의도 (agent / default 권한) 가 분명하면
+   `repair-role` 로 enum 멤버로 교정한다.
+2. **폐기**: row 가 더 이상 필요 없다면 `member revoke <id> --yes` 로 폐기한다
+   (`#1465` 이후 register 가 막혔으므로 신규 invalid-role row 는 생성되지
+   않는다).
+
+폐기와 교정은 상호 배타가 아니다 — 의심스러운 경우 `suspend` 로 일시 정지한
+뒤 추가 조사 후 결정해도 된다.
+
+### 2.3 교정
+
+`ante member repair-role` 로 invalid-role row 의 ``role`` 을 enum 멤버로
+바꾼다.
+
+```bash
+$ ante member repair-role --member-id agent-leak-1 --role default
+invalid-role 교정 완료: agent-leak-1 → default
+```
+
+invariants (구현 SSOT: `MemberService.repair_role`):
+
+- caller 는 master 여야 한다. 비-master 는 `PermissionDeniedError` 로 거부된다.
+- `--role` 은 `MemberRole` enum 멤버여야 한다 (`admin` / `default`). CLI 단의
+  `click.Choice` 가 `master` 를 옵션에서 제외하며, 서비스 단에서도 권한 상승
+  방지를 위해 한 번 더 차단한다.
+- 대상 row 의 현재 ``role`` 은 enum SSOT 에 없어야 한다. 이미 valid 한 row 를
+  재교정하는 호출은 거부된다.
+- type-role 불변식이 그대로 적용된다 — agent 를 admin 으로 교정할 수 없다.
+
+성공 시 `MemberRoleRepairedEvent` 가 발행된다. 이벤트는 다음 필드를 포함한다:
+
+| 필드 | 의미 |
+|------|------|
+| `member_id` | 교정한 row 의 멤버 ID |
+| `old_role` | 교정 전 invalid role |
+| `new_role` | 교정 후 enum 멤버 (`admin` 또는 `default`) |
+| `repaired_by` | 호출한 master 의 멤버 ID |
+
+### 2.4 폐기 (대안)
+
+row 가 더 이상 필요 없다면 master 권한으로 폐기한다.
+
+```bash
+$ ante member revoke agent-leak-1 --yes
+멤버 폐기 완료: agent-leak-1
+```
+
+revoke 는 `token_hash` 를 초기화해 즉시 인증을 무효화하고 (`#1466` auth
+read-path 가드와 별개의 추가 방어선), `MemberRevokedEvent` 를 발행한다.
+
+## 3. 사후 확인
+
+- `ante member audit-roles` 를 다시 실행해 invalid-role row 가 0건임을 확인한다.
+- `MemberRoleRepairedEvent` / `MemberRevokedEvent` 가 cleanup audit log 에 남아
+  있어야 한다. 모니터링은 NotificationEvent / log subscriber 에 위임한다
+  (`07-eventbus-integration.md`, `09-notification-events.md`).
+
+## 4. 비목표
+
+- **자동 일괄 마이그레이션**: 본 절차는 식별 / 검토 / 명시적 교정을 강제한다.
+  bulk auto-fix 를 제공하지 않는다.
+- **write path 차단**: `#1465` 가 담당한다.
+- **auth read-path 차단**: `#1466` 가 담당한다.
+- **frontend role type 분리**: `#1467` 가 담당한다.

--- a/docs/specs/member/README.md
+++ b/docs/specs/member/README.md
@@ -22,3 +22,4 @@
 | [07-eventbus-integration.md](07-eventbus-integration.md) | 이벤트 버스 연동 (EventBus Integration) |
 | [08-module-impact.md](08-module-impact.md) | 기존 모듈 영향 |
 | [09-notification-events.md](09-notification-events.md) | 알림 이벤트 정의 (Notification Events) |
+| [10-invalid-role-cleanup.md](10-invalid-role-cleanup.md) | invalid-role row 식별/교정 운영 절차 (#1468) |

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -445,6 +445,110 @@ def member_revoke(ctx: click.Context, member_id: str, yes: bool) -> None:
     fmt.success(f"멤버 폐기 완료: {member_id}", result)
 
 
+@member.command("audit-roles")
+@format_option
+@click.pass_context
+@require_auth
+@require_scope("member:read")
+def member_audit_roles(ctx: click.Context) -> None:
+    """legacy invalid-role member row 를 식별해 보고한다 (#1468).
+
+    ``MemberRole`` enum SSOT 에 없는 ``role`` 값을 가진 row 를 list 로 출력한다.
+    출력은 read-only 이며 DB 를 수정하지 않는다. text 모드에서는 표 형식,
+    JSON 모드에서는 ``{"invalid_members": [...]}`` 구조로 직렬화한다.
+
+    정상 role row 는 결과에서 제외된다. invalid row 가 없으면 빈 list 와 함께
+    안내 메시지를 출력한다.
+    """
+    fmt = get_formatter(ctx)
+
+    async def _run_audit() -> list[dict]:
+        service, db = await _create_service()
+        try:
+            members = await service.audit_invalid_roles()
+            return [
+                {
+                    "member_id": m.member_id,
+                    "type": m.type,
+                    "role": m.role,
+                    "org": m.org,
+                    "name": m.name,
+                    "status": m.status,
+                    "created_at": m.created_at,
+                    "created_by": m.created_by,
+                }
+                for m in members
+            ]
+        finally:
+            await db.close()
+
+    result = _run(_run_audit())
+    if fmt.is_json:
+        fmt.output({"invalid_members": result})
+        return
+
+    if not result:
+        click.echo("invalid-role member 가 없습니다.")
+        return
+
+    click.echo(f"invalid-role member {len(result)}건 식별됨:")
+    for m in result:
+        click.echo(
+            f"  {m['member_id']:20s} type={m['type']:6s} role={m['role']!r:30s}"
+            f" status={m['status']:10s} created_at={m['created_at']}"
+        )
+
+
+@member.command("repair-role")
+@click.option("--member-id", "member_id", required=True, help="교정할 member_id")
+@click.option(
+    "--role",
+    "new_role",
+    required=True,
+    type=click.Choice(["admin", "default"]),
+    help="새 role (master 로 변경 불가)",
+)
+@format_option
+@click.pass_context
+@require_auth
+@require_scope("member:admin")
+def member_repair_role(ctx: click.Context, member_id: str, new_role: str) -> None:
+    """invalid-role row 를 valid role 로 교정한다 (#1468).
+
+    master 만 호출 가능. ``--role`` 은 ``MemberRole`` enum 멤버여야 하며,
+    ``master`` 로의 변경은 거부된다 (cleanup 의도 위반 — 권한 상승 방지).
+    이미 valid role 인 row 를 본 명령으로 재교정하는 것도 거부된다.
+
+    성공 시 ``MemberRoleRepairedEvent`` 가 발행되어 audit/log 추적이 가능하다.
+    """
+    fmt = get_formatter(ctx)
+    actor = get_member_id(ctx)
+
+    async def _run_repair() -> dict:
+        service, db = await _create_service()
+        try:
+            m = await service.repair_role(member_id, new_role, repaired_by=actor)
+            return {
+                "member_id": m.member_id,
+                "role": m.role,
+                "type": m.type,
+                "status": m.status,
+            }
+        finally:
+            await db.close()
+
+    try:
+        result = _run(_run_repair())
+    except PermissionDeniedError:
+        fmt.error(_MASTER_REQUIRED_MESSAGE)
+        raise SystemExit(1) from None
+    except (ValueError, PermissionError) as e:
+        fmt.error(str(e))
+        raise SystemExit(1) from None
+
+    fmt.success(f"invalid-role 교정 완료: {member_id} → {result['role']}", result)
+
+
 @member.command("rotate-token")
 @click.argument("member_id")
 @click.pass_context

--- a/src/ante/eventbus/events.py
+++ b/src/ante/eventbus/events.py
@@ -512,6 +512,22 @@ class MemberAuthFailedEvent(Event):
     reason: str = ""
 
 
+@dataclass(frozen=True)
+class MemberRoleRepairedEvent(Event):
+    """MemberService → EventBus: legacy invalid-role member 의 role 을 valid 로 교정.
+
+    #1468 (split #1417/D) cleanup. ``ante member repair-role`` CLI 및 동일
+    서비스 메서드가 master 권한으로 ``MemberRole`` enum 멤버가 아닌 row 의
+    role 을 enum 멤버로 교정할 때 발행한다. ``MemberRegisteredEvent`` /
+    ``MemberRevokedEvent`` 와 동등하게 audit/log 추적에 사용된다.
+    """
+
+    member_id: str = ""
+    old_role: str = ""
+    new_role: str = ""
+    repaired_by: str = ""
+
+
 # ── 일일 리포트 (DailyReport) ──────────────────────
 
 

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -609,6 +609,101 @@ class MemberService:
         member.revoked_at = now
         return member
 
+    # ── invalid-role cleanup (#1468 — split #1417/D) ───
+
+    async def audit_invalid_roles(self) -> list[Member]:
+        """``MemberRole`` enum SSOT 에 없는 ``role`` row 를 식별해 반환한다.
+
+        #1465 (write path) 와 #1466 (auth read-path) 가 막힌 뒤에도, 그 이전에
+        DB 에 남은 ``role="oracle_invalid_role"`` 같은 row 는 그대로 존재할 수
+        있다. 본 메서드는 운영자가 cleanup 대상 row 를 식별할 수 있도록 enum
+        membership 검증을 적용한 list 를 반환한다.
+
+        검증은 read-only 이며 부작용이 없다. 정상 role row 는 결과에 포함되지
+        않는다 (정상 role 영향 없음 회귀 SSOT).
+        """
+        valid = {member.value for member in MemberRole}
+        rows = await self._db.fetch_all(
+            "SELECT * FROM members ORDER BY created_at DESC"
+        )
+        invalid: list[Member] = []
+        for row in rows:
+            if row["role"] not in valid:
+                invalid.append(_row_to_member(row))
+        return invalid
+
+    async def repair_role(
+        self,
+        member_id: str,
+        new_role: str,
+        repaired_by: str = "",
+    ) -> Member:
+        """invalid-role row 를 master-only 권한으로 valid role 로 교정한다.
+
+        invariants (#1468):
+
+        - caller 는 master 여야 한다 (``_assert_master``). 비-master 는
+          ``PermissionDeniedError`` 로 거부된다.
+        - ``new_role`` 은 ``MemberRole`` enum 멤버여야 한다 (``_assert_role_enum``).
+          enum 위반은 ``ValueError`` 로 거부된다.
+        - ``new_role`` 이 ``MemberRole.MASTER`` 인 cleanup 은 거부된다. master
+          승격은 cleanup 의 의도가 아니며, 우발적인 권한 상승을 막기 위해
+          ``ValueError`` 로 거부한다. (``ante init`` master 부트스트랩만 master
+          를 생성한다.)
+        - 대상 row 의 현재 ``role`` 은 enum SSOT 에 없어야 한다. 이미 valid 한
+          row 를 본 메서드로 재교정하는 것은 의도된 cleanup 범위를 벗어나므로
+          ``ValueError`` 로 거부한다 (정상 role row 영향 없음 회귀).
+        - type-role 불변식 (``_assert_type_role``) 도 동일하게 적용된다. agent
+          를 master/admin 으로 cleanup 하지 못한다.
+
+        성공 시 ``MemberRoleRepairedEvent`` 를 발행해 audit/log 추적이 가능하게
+        한다.
+        """
+        await self._assert_master(repaired_by, "repair_role")
+        self._assert_role_enum(new_role)
+        if new_role == MemberRole.MASTER:
+            msg = "repair_role 로 master 역할로 변경할 수 없습니다"
+            raise ValueError(msg)
+
+        member = await self._get_or_raise(member_id)
+
+        valid = {role.value for role in MemberRole}
+        if member.role in valid:
+            msg = (
+                f"이미 valid role 입니다: {member.role!r}."
+                " repair_role 은 invalid-role row 만 교정합니다."
+            )
+            raise ValueError(msg)
+
+        self._assert_type_role(member.type, new_role)
+
+        old_role = member.role
+        await self._db.execute(
+            "UPDATE members SET role = ? WHERE member_id = ?",
+            (new_role, member_id),
+        )
+
+        from ante.eventbus.events import MemberRoleRepairedEvent
+
+        await self._eventbus.publish(
+            MemberRoleRepairedEvent(
+                member_id=member_id,
+                old_role=old_role,
+                new_role=new_role,
+                repaired_by=repaired_by,
+            )
+        )
+
+        logger.info(
+            "invalid-role 교정: %s (%s → %s, by %s)",
+            member_id,
+            old_role,
+            new_role,
+            repaired_by,
+        )
+        member.role = new_role
+        return member
+
     # ── 토큰 관리 (TokenManager 위임) ──────────────────
 
     async def rotate_token(

--- a/tests/unit/test_member_invalid_role_cleanup.py
+++ b/tests/unit/test_member_invalid_role_cleanup.py
@@ -1,0 +1,528 @@
+"""invalid-role member row cleanup 회귀 (#1468 — split #1417/D).
+
+검증 대상:
+
+- ``MemberService.audit_invalid_roles`` 는 ``MemberRole`` enum 외 ``role``
+  값을 가진 row 만 반환한다 (정상 role row 영향 없음).
+- ``MemberService.repair_role`` 은 master-only 이며 ``MemberRole`` enum 멤버
+  로만 교정한다. ``master`` 로의 교정과 valid row 재교정을 거부한다.
+- ``MemberRoleRepairedEvent`` 가 cleanup 시 발행된다 (audit/log 추적).
+- ``ante member audit-roles`` CLI 는 invalid row 를 JSON / text 로 노출한다.
+- ``ante member repair-role`` CLI 는 invalid → valid 로 교정한다 (master only).
+- 정상 role row (master / admin / default) 는 audit / repair 영향 없음.
+
+본 모듈은 ``test_member_auth_invalid_role.py`` 의 service-layer fixture 와
+``test_cli_member_non_interactive.py`` 의 CLI runner 패턴을 재사용한다.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.core.database import Database
+from ante.eventbus import EventBus
+from ante.eventbus.events import MemberRoleRepairedEvent
+from ante.member.errors import PermissionDeniedError
+from ante.member.models import Member, MemberRole, MemberType
+from ante.member.service import MemberService
+
+# ── Service-layer fixtures ─────────────────────────────────────────
+
+
+@pytest.fixture
+async def db(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+def eventbus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+async def service(db, eventbus) -> MemberService:
+    svc = MemberService(db, eventbus)
+    await svc.initialize()
+    return svc
+
+
+async def _seed_invalid_role_agent(
+    db: Database,
+    service: MemberService,
+    member_id: str = "agent-bad",
+    invalid_role: str = "oracle_invalid_role",
+) -> str:
+    """legacy invalid-role agent row 를 DB 에 심는다.
+
+    ``register`` 가 #1465 이후 invalid role 입력을 막으므로 정상 register 후
+    DB 직접 UPDATE 로 ``role`` 을 변조한다 (#1465 이전 row 재현).
+    """
+    await service.register(member_id, MemberType.AGENT)
+    await db.execute(
+        "UPDATE members SET role = ? WHERE member_id = ?",
+        (invalid_role, member_id),
+    )
+    return member_id
+
+
+# ── Service: audit_invalid_roles ───────────────────────────────────
+
+
+class TestAuditInvalidRoles:
+    """``MemberService.audit_invalid_roles`` 식별 정확도."""
+
+    async def test_returns_empty_when_no_invalid_rows(
+        self, service: MemberService
+    ) -> None:
+        """정상 role row 만 있으면 빈 list."""
+        await service.bootstrap_master("owner", "pass123")
+        await service.register("agent-ok", MemberType.AGENT, registered_by="owner")
+        result = await service.audit_invalid_roles()
+        assert result == []
+
+    async def test_identifies_invalid_role_row(
+        self, service: MemberService, db: Database
+    ) -> None:
+        """``MemberRole`` 외 role 값을 가진 row 를 식별한다."""
+        member_id = await _seed_invalid_role_agent(db, service)
+        result = await service.audit_invalid_roles()
+        assert len(result) == 1
+        assert result[0].member_id == member_id
+        assert result[0].role == "oracle_invalid_role"
+
+    async def test_does_not_include_valid_role_rows(
+        self, service: MemberService, db: Database
+    ) -> None:
+        """정상 role row (master / admin / default) 는 결과에서 제외."""
+        await service.bootstrap_master("owner", "pass123")
+        await service.register(
+            "admin-01",
+            MemberType.HUMAN,
+            role=MemberRole.ADMIN,
+            registered_by="owner",
+        )
+        await service.register(
+            "agent-default",
+            MemberType.AGENT,
+            registered_by="owner",
+        )
+        await _seed_invalid_role_agent(db, service, member_id="agent-leak")
+
+        result = await service.audit_invalid_roles()
+        ids = {m.member_id for m in result}
+        assert ids == {"agent-leak"}
+
+    async def test_identifies_multiple_invalid_rows(
+        self, service: MemberService, db: Database
+    ) -> None:
+        """invalid row 가 여러 개여도 모두 반환."""
+        await _seed_invalid_role_agent(db, service, member_id="agent-a")
+        await _seed_invalid_role_agent(
+            db, service, member_id="agent-b", invalid_role="another_invalid"
+        )
+        result = await service.audit_invalid_roles()
+        assert {m.member_id for m in result} == {"agent-a", "agent-b"}
+
+    async def test_audit_is_read_only(
+        self, service: MemberService, db: Database
+    ) -> None:
+        """audit 호출 자체는 DB 를 변경하지 않는다."""
+        member_id = await _seed_invalid_role_agent(db, service)
+        await service.audit_invalid_roles()
+        # role 값이 그대로 invalid 상태로 남아 있어야 한다.
+        row = await db.fetch_one(
+            "SELECT role FROM members WHERE member_id = ?", (member_id,)
+        )
+        assert row["role"] == "oracle_invalid_role"
+
+
+# ── Service: repair_role ───────────────────────────────────────────
+
+
+class TestRepairRoleService:
+    """``MemberService.repair_role`` invariants."""
+
+    async def test_repair_invalid_to_default_succeeds(
+        self, service: MemberService, db: Database
+    ) -> None:
+        """master 가 invalid → default 로 교정."""
+        await service.bootstrap_master("owner", "pass123")
+        member_id = await _seed_invalid_role_agent(db, service)
+
+        m = await service.repair_role(
+            member_id, MemberRole.DEFAULT, repaired_by="owner"
+        )
+        assert m.role == "default"
+
+        row = await db.fetch_one(
+            "SELECT role FROM members WHERE member_id = ?", (member_id,)
+        )
+        assert row["role"] == "default"
+
+    async def test_repair_invalid_to_admin_succeeds_for_human(
+        self, service: MemberService, db: Database
+    ) -> None:
+        """human row 는 admin 으로 교정 가능."""
+        await service.bootstrap_master("owner", "pass123")
+        # human + invalid role row 시드
+        await service.register("human-bad", MemberType.HUMAN, registered_by="owner")
+        await db.execute(
+            "UPDATE members SET role = ? WHERE member_id = ?",
+            ("oracle_invalid_role", "human-bad"),
+        )
+
+        m = await service.repair_role(
+            "human-bad", MemberRole.ADMIN, repaired_by="owner"
+        )
+        assert m.role == "admin"
+
+    async def test_repair_rejects_non_master_caller(
+        self, service: MemberService, db: Database
+    ) -> None:
+        """비-master caller 는 ``PermissionDeniedError``."""
+        await service.bootstrap_master("owner", "pass123")
+        await service.register("agent-actor", MemberType.AGENT, registered_by="owner")
+        member_id = await _seed_invalid_role_agent(db, service, member_id="agent-leak")
+
+        with pytest.raises(PermissionDeniedError):
+            await service.repair_role(
+                member_id, MemberRole.DEFAULT, repaired_by="agent-actor"
+            )
+
+    async def test_repair_rejects_empty_caller(
+        self, service: MemberService, db: Database
+    ) -> None:
+        """빈 caller 도 거부 (``_assert_master`` 정책)."""
+        member_id = await _seed_invalid_role_agent(db, service)
+        with pytest.raises(PermissionDeniedError):
+            await service.repair_role(member_id, MemberRole.DEFAULT, repaired_by="")
+
+    async def test_repair_to_master_role_is_rejected(
+        self, service: MemberService, db: Database
+    ) -> None:
+        """``MemberRole.MASTER`` 로의 교정은 거부 — 권한 상승 방지."""
+        await service.bootstrap_master("owner", "pass123")
+        member_id = await _seed_invalid_role_agent(db, service)
+
+        with pytest.raises(ValueError, match="master"):
+            await service.repair_role(member_id, MemberRole.MASTER, repaired_by="owner")
+
+    async def test_repair_to_invalid_role_is_rejected(
+        self, service: MemberService, db: Database
+    ) -> None:
+        """``MemberRole`` enum 외 ``new_role`` 은 ``ValueError``."""
+        await service.bootstrap_master("owner", "pass123")
+        member_id = await _seed_invalid_role_agent(db, service)
+
+        with pytest.raises(ValueError, match="invalid role"):
+            await service.repair_role(member_id, "still_bogus", repaired_by="owner")
+
+    async def test_repair_does_not_touch_valid_row(
+        self, service: MemberService, db: Database
+    ) -> None:
+        """이미 valid 한 row 를 본 메서드로 재교정하는 호출은 거부."""
+        await service.bootstrap_master("owner", "pass123")
+        await service.register("agent-ok", MemberType.AGENT, registered_by="owner")
+
+        with pytest.raises(ValueError, match="valid role"):
+            await service.repair_role(
+                "agent-ok", MemberRole.DEFAULT, repaired_by="owner"
+            )
+
+        # role 값은 변경되지 않아야 한다.
+        row = await db.fetch_one(
+            "SELECT role FROM members WHERE member_id = ?", ("agent-ok",)
+        )
+        assert row["role"] == "default"
+
+    async def test_repair_respects_type_role_invariant(
+        self, service: MemberService, db: Database
+    ) -> None:
+        """agent → admin 교정은 ``_assert_type_role`` 로 거부."""
+        await service.bootstrap_master("owner", "pass123")
+        member_id = await _seed_invalid_role_agent(db, service)
+
+        with pytest.raises(PermissionError, match="agent"):
+            await service.repair_role(member_id, MemberRole.ADMIN, repaired_by="owner")
+
+    async def test_repair_publishes_event(
+        self,
+        service: MemberService,
+        db: Database,
+        eventbus: EventBus,
+    ) -> None:
+        """성공 시 ``MemberRoleRepairedEvent`` 발행 — audit/log 추적."""
+        await service.bootstrap_master("owner", "pass123")
+        member_id = await _seed_invalid_role_agent(db, service)
+
+        events: list[MemberRoleRepairedEvent] = []
+        eventbus.subscribe(MemberRoleRepairedEvent, lambda e: events.append(e))
+
+        await service.repair_role(member_id, MemberRole.DEFAULT, repaired_by="owner")
+
+        assert len(events) == 1
+        e = events[0]
+        assert e.member_id == member_id
+        assert e.old_role == "oracle_invalid_role"
+        assert e.new_role == "default"
+        assert e.repaired_by == "owner"
+
+
+# ── CLI: audit-roles / repair-role ─────────────────────────────────
+
+
+def _make_master() -> Member:
+    """테스트용 master Member."""
+    return Member(
+        member_id="master",
+        type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+        org="default",
+        name="Master",
+        status="active",
+        scopes=[],
+    )
+
+
+def _mock_authenticate(ctx) -> None:  # noqa: ANN001
+    """test runner 인증 우회."""
+    ctx.obj["member"] = _make_master()
+
+
+def _invoke_cli(args: list[str]):  # noqa: ANN202
+    """CLI 를 실행하고 결과를 반환한다 (인증 우회)."""
+    runner = CliRunner()
+    with patch("ante.cli.main.authenticate_member", side_effect=_mock_authenticate):
+        return runner.invoke(
+            cli,
+            args,
+            obj={"member": _make_master()},
+            env={"ANTE_MEMBER_TOKEN": ""},
+            catch_exceptions=False,
+        )
+
+
+def _patch_audit_repair_service(
+    *,
+    invalid_members: list[Member] | None = None,
+    repair_return: Member | None = None,
+    repair_side_effect: object | None = None,
+):
+    """``audit_invalid_roles`` / ``repair_role`` mock contextmanager."""
+    service = MagicMock()
+    service.audit_invalid_roles = AsyncMock(return_value=invalid_members or [])
+    if repair_side_effect is not None:
+        service.repair_role = AsyncMock(side_effect=repair_side_effect)
+    else:
+        service.repair_role = AsyncMock(
+            return_value=repair_return
+            if repair_return is not None
+            else Member(
+                member_id="agent-leak",
+                type=MemberType.AGENT,
+                role=MemberRole.DEFAULT,
+                org="default",
+                name="agent-leak",
+                status="active",
+                scopes=[],
+            )
+        )
+    db = MagicMock()
+    db.close = AsyncMock(return_value=None)
+    return (
+        patch(
+            "ante.cli.commands.member._create_service",
+            new_callable=AsyncMock,
+            return_value=(service, db),
+        ),
+        service,
+    )
+
+
+class TestAuditRolesCli:
+    """``ante member audit-roles`` 출력."""
+
+    def test_audit_roles_json_lists_invalid_members(self) -> None:
+        invalid = Member(
+            member_id="agent-leak",
+            type=MemberType.AGENT,
+            role="oracle_invalid_role",
+            org="default",
+            name="agent-leak",
+            status="active",
+            scopes=[],
+            created_at="2026-05-09 10:01:23",
+            created_by="oracle",
+        )
+        ctx, service = _patch_audit_repair_service(invalid_members=[invalid])
+        with ctx:
+            result = _invoke_cli(
+                ["--format", "json", "member", "audit-roles"],
+            )
+
+        assert result.exit_code == 0, result.output
+        service.audit_invalid_roles.assert_awaited_once()
+        data = json.loads(result.output)
+        assert "invalid_members" in data
+        assert len(data["invalid_members"]) == 1
+        row = data["invalid_members"][0]
+        assert row["member_id"] == "agent-leak"
+        assert row["role"] == "oracle_invalid_role"
+
+    def test_audit_roles_json_empty_when_no_invalid(self) -> None:
+        ctx, service = _patch_audit_repair_service(invalid_members=[])
+        with ctx:
+            result = _invoke_cli(
+                ["--format", "json", "member", "audit-roles"],
+            )
+
+        assert result.exit_code == 0, result.output
+        service.audit_invalid_roles.assert_awaited_once()
+        data = json.loads(result.output)
+        assert data == {"invalid_members": []}
+
+    def test_audit_roles_text_outputs_count(self) -> None:
+        invalid = Member(
+            member_id="agent-leak",
+            type=MemberType.AGENT,
+            role="oracle_invalid_role",
+            org="default",
+            name="agent-leak",
+            status="active",
+            scopes=[],
+        )
+        ctx, _service = _patch_audit_repair_service(invalid_members=[invalid])
+        with ctx:
+            result = _invoke_cli(["member", "audit-roles"])
+
+        assert result.exit_code == 0, result.output
+        assert "1건" in result.output
+        assert "agent-leak" in result.output
+        assert "oracle_invalid_role" in result.output
+
+
+class TestRepairRoleCli:
+    """``ante member repair-role`` CLI."""
+
+    def test_repair_role_succeeds(self) -> None:
+        repaired = Member(
+            member_id="agent-leak",
+            type=MemberType.AGENT,
+            role=MemberRole.DEFAULT,
+            org="default",
+            name="agent-leak",
+            status="active",
+            scopes=[],
+        )
+        ctx, service = _patch_audit_repair_service(repair_return=repaired)
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "repair-role",
+                    "--member-id",
+                    "agent-leak",
+                    "--role",
+                    "default",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        service.repair_role.assert_awaited_once()
+        call = service.repair_role.await_args
+        assert call.args[0] == "agent-leak"
+        assert call.args[1] == "default"
+        assert call.kwargs.get("repaired_by") == "master"
+        data = json.loads(result.output)
+        assert data["status"] == "ok"
+        assert data["data"]["role"] == "default"
+
+    def test_repair_role_master_choice_rejected_by_click(self) -> None:
+        """CLI 옵션 단에서 ``master`` 는 ``click.Choice`` 로 거부."""
+        ctx, service = _patch_audit_repair_service()
+        with ctx:
+            runner = CliRunner()
+            with patch(
+                "ante.cli.main.authenticate_member",
+                side_effect=_mock_authenticate,
+            ):
+                result = runner.invoke(
+                    cli,
+                    [
+                        "member",
+                        "repair-role",
+                        "--member-id",
+                        "agent-leak",
+                        "--role",
+                        "master",
+                    ],
+                    obj={"member": _make_master()},
+                    env={"ANTE_MEMBER_TOKEN": ""},
+                )
+
+        assert result.exit_code != 0
+        service.repair_role.assert_not_awaited()
+
+    def test_repair_role_non_master_exits_without_traceback(self) -> None:
+        ctx, service = _patch_audit_repair_service(
+            repair_side_effect=PermissionDeniedError(
+                "'repair_role'은(는) master만 수행할 수 있습니다."
+            )
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "repair-role",
+                    "--member-id",
+                    "agent-leak",
+                    "--role",
+                    "default",
+                ],
+            )
+
+        assert result.exit_code == 1, result.output
+        service.repair_role.assert_awaited_once()
+        data = json.loads(result.output)
+        assert "master" in data["message"]
+        assert "Traceback" not in result.output
+
+    def test_repair_role_value_error_exits_one(self) -> None:
+        """이미 valid 한 row 재교정 시도 → ``ValueError`` → exit 1."""
+        ctx, service = _patch_audit_repair_service(
+            repair_side_effect=ValueError(
+                "이미 valid role 입니다: 'default'."
+                " repair_role 은 invalid-role row 만 교정합니다."
+            )
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "member",
+                    "repair-role",
+                    "--member-id",
+                    "agent-ok",
+                    "--role",
+                    "default",
+                ],
+            )
+
+        assert result.exit_code == 1, result.output
+        service.repair_role.assert_awaited_once()
+        data = json.loads(result.output)
+        assert "valid role" in data["message"]
+        assert "Traceback" not in result.output


### PR DESCRIPTION
Closes #1468

## Summary
- New CLI: `ante member audit-roles` (member:read, read-only) scans `role NOT IN MemberRole`.
- New CLI: `ante member repair-role --member-id X --role admin|default` (member:admin, master-only). `click.Choice` excludes master at ingress; service double-checks.
- `MemberService.audit_invalid_roles()` / `repair_role()` enforce master-only caller + invalid-only target + type-role invariant.
- New `MemberRoleRepairedEvent(member_id, old_role, new_role, repaired_by)` for audit.
- runbook: `docs/specs/member/10-invalid-role-cleanup.md`.

## Test Plan
- [x] 21 new test cases
- [x] `pytest tests/unit -k member` → 396 passed (regression 0)
- [x] `pytest tests/unit` → 5253 passed, 2 skipped
- [x] `ruff check` / `ruff format --check` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)