### PR TITLE
fix(bot): persist runtime controls + auto_restart across BotConfig DB roundtrip

### DIFF
--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import json
 import logging
 from pathlib import Path
@@ -41,6 +42,64 @@ CREATE TABLE IF NOT EXISTS bots (
 );
 CREATE INDEX IF NOT EXISTS idx_bots_account_id ON bots(account_id);
 """
+
+# Refs #1457: ``BotConfig`` 직렬화 / 복원 라운드트립 대상 필드.
+# ``interval_seconds`` 는 기존부터 직렬화되던 필드이고, 나머지 5개는 #1456 으로
+# ``BotConfig`` 에 도입된 runtime control. 모두 ``BotConfig`` dataclass field
+# default 가 SSOT 다 (하드코딩 금지).
+_PERSISTED_BOT_CONFIG_FIELDS: tuple[str, ...] = (
+    "interval_seconds",
+    "auto_restart",
+    "max_restart_attempts",
+    "restart_cooldown_seconds",
+    "step_timeout_seconds",
+    "max_signals_per_step",
+)
+
+
+def _runtime_control_default(name: str) -> Any:
+    """``BotConfig`` dataclass field default 를 조회한다 (Refs #1457).
+
+    SSOT 는 :class:`BotConfig` 의 dataclass field default. manager 가 default
+    를 독립적으로 재정의하지 않도록 항상 ``dataclasses.fields`` 를 통해
+    조회한다. default 가 정의되지 않은 필드는 ``KeyError`` 로 즉시 실패시켜
+    SSOT 불일치를 가시화한다.
+    """
+
+    for field in dataclasses.fields(BotConfig):
+        if field.name != name:
+            continue
+        if field.default is not dataclasses.MISSING:
+            return field.default
+        if field.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+            return field.default_factory()  # type: ignore[misc]
+        raise KeyError(
+            f"BotConfig field {name!r} has no default — manager 가 default 를 "
+            "독립적으로 정의할 수 없다 (SSOT: BotConfig dataclass)"
+        )
+    raise KeyError(f"BotConfig has no field {name!r}")
+
+
+def _pick_persisted_runtime_control(config_data: dict[str, Any], name: str) -> Any:
+    """``config_json`` payload 에서 runtime control 값을 안전하게 꺼낸다.
+
+    Refs #1457:
+
+    - key 가 없으면 :func:`_runtime_control_default` 로 dataclass default 복원
+      (missing legacy row 호환).
+    - key 가 있지만 값이 ``None`` 이면 ``ValueError`` 로 거부 — explicit null
+      은 데이터 손상으로 간주하고 ``load_from_db`` 의 새 ``except ValueError``
+      가 row 자체를 skip + warning 처리한다.
+
+    ``auto_restart`` (bool) 와 숫자 필드 모두 동일 경로로 처리한다.
+    """
+
+    if name not in config_data:
+        return _runtime_control_default(name)
+    value = config_data[name]
+    if value is None:
+        raise ValueError(f"invalid persisted runtime control: {name} is null")
+    return value
 
 
 async def _cooldown_sleep(seconds: float) -> None:
@@ -131,18 +190,44 @@ class BotManager:
         )
 
         for row in rows:
+            # NOTE(Refs #1457): ``json.loads`` 는 try 블록 밖에서 실행한다.
+            # ``JSONDecodeError`` 는 ``ValueError`` 의 서브클래스이므로 try 안에
+            # 들어가면 새로 도입한 ``except ValueError`` 가 이를 silent 하게
+            # 흡수해 다른 종류의 corruption 까지 묻혀버린다. JSON 파싱 실패는
+            # 별도 이슈로 다루어야 하므로 의도적으로 try 범위에 포함하지 않는다.
             config_data = json.loads(row["config_json"]) if row["config_json"] else {}
             # bot_type, exchange 키는 무시 (BotConfig에서 제거됨)
             config_data.pop("bot_type", None)
             config_data.pop("exchange", None)
             account_id = row.get("account_id") or ""
             try:
+                # Refs #1457: ``interval_seconds`` 와 4 runtime control +
+                # ``auto_restart`` 를 helper 로 복원한다. helper 는 missing key
+                # 일 때 ``BotConfig`` dataclass default 로 fallback 하고,
+                # explicit null 일 때 ``ValueError`` 를 raise 한다.
                 config = BotConfig(
                     bot_id=row["bot_id"],
                     strategy_id=row["strategy_id"],
                     name=row["name"] or config_data.get("name", row["bot_id"]),
                     account_id=account_id,
-                    interval_seconds=config_data.get("interval_seconds", 60),
+                    interval_seconds=_pick_persisted_runtime_control(
+                        config_data, "interval_seconds"
+                    ),
+                    auto_restart=_pick_persisted_runtime_control(
+                        config_data, "auto_restart"
+                    ),
+                    max_restart_attempts=_pick_persisted_runtime_control(
+                        config_data, "max_restart_attempts"
+                    ),
+                    restart_cooldown_seconds=_pick_persisted_runtime_control(
+                        config_data, "restart_cooldown_seconds"
+                    ),
+                    step_timeout_seconds=_pick_persisted_runtime_control(
+                        config_data, "step_timeout_seconds"
+                    ),
+                    max_signals_per_step=_pick_persisted_runtime_control(
+                        config_data, "max_signals_per_step"
+                    ),
                 )
             except InvalidAccountIdError as e:
                 # SPLIT-1 패턴: invalid account_id row 는 skip + warning.
@@ -152,6 +237,22 @@ class BotManager:
                     " (legacy migration 필요): bot_id=%s account_id=%r — %s",
                     row.get("bot_id"),
                     account_id,
+                    e,
+                )
+                continue
+            except ValueError as e:
+                # Refs #1457: invalid runtime control / invalid interval_seconds
+                # / explicit null persisted row 는 raise 없이 skip + warning.
+                # ``BotConfig.__post_init__`` (validate_interval /
+                # validate_runtime_controls) 와 ``_pick_persisted_runtime_control``
+                # 의 explicit-null guard 가 ``ValueError`` 를 raise 한다.
+                # try 범위는 ``BotConfig(...)`` 호출로만 좁혀져 있으므로
+                # 다른 라이브러리 호출의 ValueError 가 흡수될 위험이 없다.
+                logger.warning(
+                    "BotManager.load_from_db: invalid bot config row skip"
+                    " (legacy migration 필요): bot_id=%s config=%r — %s",
+                    row.get("bot_id"),
+                    config_data,
                     e,
                 )
                 continue
@@ -969,13 +1070,24 @@ class BotManager:
         )
 
     async def _save_bot_config(self, config: BotConfig) -> None:
-        """봇 설정 DB 저장."""
+        """봇 설정 DB 저장.
+
+        Refs #1457: ``interval_seconds`` 외에 runtime control 4개 필드와
+        ``auto_restart`` 도 함께 직렬화한다. 누락 시 ``load_from_db`` 에서
+        dataclass default 로 복원되어 사용자가 PUT 으로 변경한 값이 silent
+        하게 default 로 되돌아가는 회귀(#1413)가 발생한다.
+        """
         config_dict = {
             "bot_id": config.bot_id,
             "name": config.name,
             "strategy_id": config.strategy_id,
             "account_id": config.account_id,
             "interval_seconds": config.interval_seconds,
+            "auto_restart": config.auto_restart,
+            "max_restart_attempts": config.max_restart_attempts,
+            "restart_cooldown_seconds": config.restart_cooldown_seconds,
+            "step_timeout_seconds": config.step_timeout_seconds,
+            "max_signals_per_step": config.max_signals_per_step,
         }
         await self._db.execute(
             """INSERT INTO bots

--- a/tests/unit/test_bot_manager_methods.py
+++ b/tests/unit/test_bot_manager_methods.py
@@ -490,3 +490,357 @@ class TestUpdateBot:
 
         bot = await manager.update_bot("bot1")
         assert bot.config.bot_id == "bot1"
+
+
+# ── Refs #1457: BotConfig DB 라운드트립 보존 ──────────────────────────────
+
+
+def _bot_config_default(name: str):
+    """``BotConfig`` dataclass field default 를 직접 조회한다 (테스트 SSOT).
+
+    Refs #1457 task 7: 테스트도 default 값을 하드코딩하지 않고 dataclass
+    field default 에서 가져온다. manager helper 와 동일한 SSOT 를 사용해
+    SSOT 불일치 회귀를 방지한다.
+    """
+
+    import dataclasses
+
+    for field in dataclasses.fields(BotConfig):
+        if field.name == name:
+            if field.default is not dataclasses.MISSING:
+                return field.default
+            raise KeyError(f"BotConfig field {name!r} has no default")
+    raise KeyError(f"BotConfig has no field {name!r}")
+
+
+class TestBotConfigDBRoundtrip:
+    """``_save_bot_config`` 와 ``load_from_db`` 의 runtime control 라운드트립.
+
+    Refs #1457 — Implementation Plan v2 의 case A/B1/B2/C1/C2/C3/D 를 커버한다.
+    """
+
+    @pytest.mark.parametrize("auto_restart", [True, False])
+    async def test_full_roundtrip_runtime_controls(
+        self, manager, eventbus, ctx, db, auto_restart
+    ):
+        """case A: 5필드 + auto_restart 가 라운드트립 후 보존된다.
+
+        ``auto_restart`` 는 True/False 모두 보존되어야 한다.
+        """
+        config = BotConfig(
+            bot_id="bot-roundtrip",
+            strategy_id="s1",
+            account_id="acc-test",
+            interval_seconds=120,
+            auto_restart=auto_restart,
+            max_restart_attempts=5,
+            restart_cooldown_seconds=180,
+            step_timeout_seconds=45,
+            max_signals_per_step=80,
+        )
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        # 새 매니저로 DB 에서 다시 로드 — 프로세스 재시작 시뮬레이션
+        manager2 = BotManager(eventbus=eventbus, db=db)
+        await manager2.initialize()
+        count = await manager2.load_from_db()
+        assert count == 1
+
+        loaded = manager2.get_bot("bot-roundtrip")
+        assert loaded is not None
+        assert loaded.config.interval_seconds == 120
+        assert loaded.config.auto_restart is auto_restart
+        assert loaded.config.max_restart_attempts == 5
+        assert loaded.config.restart_cooldown_seconds == 180
+        assert loaded.config.step_timeout_seconds == 45
+        assert loaded.config.max_signals_per_step == 80
+
+    async def test_save_persists_all_runtime_control_keys(self, manager, ctx, db):
+        """``_save_bot_config`` 가 5 runtime control 키를 ``config_json`` 에 직렬화한다.
+
+        Refs #1457: 누락 시 ``load_from_db`` 가 default 로 복원해버려 silent
+        값 회귀가 발생한다.
+        """
+        import json as _json
+
+        config = BotConfig(
+            bot_id="bot-save",
+            strategy_id="s1",
+            account_id="acc-test",
+            interval_seconds=90,
+            auto_restart=False,
+            max_restart_attempts=4,
+            restart_cooldown_seconds=120,
+            step_timeout_seconds=60,
+            max_signals_per_step=42,
+        )
+        await manager.create_bot(config, SimpleStrategy, ctx)
+
+        row = await db.fetch_one(
+            "SELECT config_json FROM bots WHERE bot_id = 'bot-save'"
+        )
+        saved = _json.loads(row["config_json"])
+
+        assert saved["interval_seconds"] == 90
+        assert saved["auto_restart"] is False
+        assert saved["max_restart_attempts"] == 4
+        assert saved["restart_cooldown_seconds"] == 120
+        assert saved["step_timeout_seconds"] == 60
+        assert saved["max_signals_per_step"] == 42
+
+    async def test_missing_legacy_row_restores_dataclass_defaults(
+        self, manager, eventbus, db
+    ):
+        """case B1: 5필드가 모두 누락된 legacy row 는 dataclass default 로 복원된다."""
+        import json as _json
+
+        legacy_config = _json.dumps({"interval_seconds": 60})
+        await db.execute(
+            """INSERT INTO bots
+               (bot_id, name, strategy_id, account_id, config_json, status)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("legacy-bot", "legacy", "s1", "acc-test", legacy_config, "created"),
+        )
+
+        manager2 = BotManager(eventbus=eventbus, db=db)
+        await manager2.initialize()
+        count = await manager2.load_from_db()
+        assert count == 1
+
+        bot = manager2.get_bot("legacy-bot")
+        assert bot is not None
+        # SSOT: BotConfig dataclass field default
+        assert bot.config.interval_seconds == 60
+        assert bot.config.auto_restart == _bot_config_default("auto_restart")
+        assert bot.config.max_restart_attempts == _bot_config_default(
+            "max_restart_attempts"
+        )
+        assert bot.config.restart_cooldown_seconds == _bot_config_default(
+            "restart_cooldown_seconds"
+        )
+        assert bot.config.step_timeout_seconds == _bot_config_default(
+            "step_timeout_seconds"
+        )
+        assert bot.config.max_signals_per_step == _bot_config_default(
+            "max_signals_per_step"
+        )
+
+    async def test_partial_legacy_row_preserves_present_fields(
+        self, manager, eventbus, db
+    ):
+        """case B2: 일부 필드만 있는 partial row — 있는 값 보존 + 나머지 default."""
+        import json as _json
+
+        partial = _json.dumps(
+            {
+                "interval_seconds": 60,
+                "auto_restart": False,
+                "max_restart_attempts": 5,
+            }
+        )
+        await db.execute(
+            """INSERT INTO bots
+               (bot_id, name, strategy_id, account_id, config_json, status)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("partial-bot", "partial", "s1", "acc-test", partial, "created"),
+        )
+
+        manager2 = BotManager(eventbus=eventbus, db=db)
+        await manager2.initialize()
+        count = await manager2.load_from_db()
+        assert count == 1
+
+        bot = manager2.get_bot("partial-bot")
+        assert bot is not None
+        # present fields are preserved
+        assert bot.config.interval_seconds == 60
+        assert bot.config.auto_restart is False
+        assert bot.config.max_restart_attempts == 5
+        # missing fields fall back to dataclass default
+        assert bot.config.restart_cooldown_seconds == _bot_config_default(
+            "restart_cooldown_seconds"
+        )
+        assert bot.config.step_timeout_seconds == _bot_config_default(
+            "step_timeout_seconds"
+        )
+        assert bot.config.max_signals_per_step == _bot_config_default(
+            "max_signals_per_step"
+        )
+
+    async def test_invalid_runtime_control_row_is_skipped_with_warning(
+        self, manager, eventbus, db, caplog
+    ):
+        """case C1: ``validate_runtime_controls`` 위반 row 는 skip + warning."""
+        import json as _json
+        import logging
+
+        # valid row 1건
+        valid_config = _json.dumps({"interval_seconds": 60})
+        await db.execute(
+            """INSERT INTO bots
+               (bot_id, name, strategy_id, account_id, config_json, status)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("good-bot", "good", "s1", "acc-test", valid_config, "created"),
+        )
+        # invalid: restart_cooldown_seconds=0 (MIN_RESTART_COOLDOWN_SECONDS=10)
+        invalid_config = _json.dumps(
+            {
+                "interval_seconds": 60,
+                "restart_cooldown_seconds": 0,
+            }
+        )
+        await db.execute(
+            """INSERT INTO bots
+               (bot_id, name, strategy_id, account_id, config_json, status)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("bad-cooldown", "bad", "s1", "acc-test", invalid_config, "created"),
+        )
+
+        manager2 = BotManager(eventbus=eventbus, db=db)
+        await manager2.initialize()
+        with caplog.at_level(logging.WARNING):
+            count = await manager2.load_from_db()
+
+        # invalid row 만 skip — valid row 는 정상 load
+        assert count == 1
+        assert manager2.get_bot("good-bot") is not None
+        assert manager2.get_bot("bad-cooldown") is None
+        warn_messages = [r.message for r in caplog.records if r.levelno >= 30]
+        assert any(
+            "bad-cooldown" in m and "invalid bot config row skip" in m
+            for m in warn_messages
+        )
+
+    async def test_explicit_null_auto_restart_row_is_skipped_with_warning(
+        self, manager, eventbus, db, caplog
+    ):
+        """case C2 (auto_restart=null): explicit null row 는 skip + warning."""
+        import json as _json
+        import logging
+
+        valid_config = _json.dumps({"interval_seconds": 60})
+        await db.execute(
+            """INSERT INTO bots
+               (bot_id, name, strategy_id, account_id, config_json, status)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("good-bot", "good", "s1", "acc-test", valid_config, "created"),
+        )
+        null_config = _json.dumps({"interval_seconds": 60, "auto_restart": None})
+        await db.execute(
+            """INSERT INTO bots
+               (bot_id, name, strategy_id, account_id, config_json, status)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("null-auto", "null", "s1", "acc-test", null_config, "created"),
+        )
+
+        manager2 = BotManager(eventbus=eventbus, db=db)
+        await manager2.initialize()
+        with caplog.at_level(logging.WARNING):
+            count = await manager2.load_from_db()
+
+        # null row 만 skip — 다른 정상 row 는 계속 load
+        assert count == 1
+        assert manager2.get_bot("good-bot") is not None
+        assert manager2.get_bot("null-auto") is None
+        warn_messages = [r.message for r in caplog.records if r.levelno >= 30]
+        assert any(
+            "null-auto" in m and "invalid bot config row skip" in m
+            for m in warn_messages
+        )
+
+    async def test_explicit_null_numeric_field_row_is_skipped_with_warning(
+        self, manager, eventbus, db, caplog
+    ):
+        """case C2 (max_restart_attempts=null): 숫자 필드 explicit null 도 skip."""
+        import json as _json
+        import logging
+
+        null_config = _json.dumps(
+            {"interval_seconds": 60, "max_restart_attempts": None}
+        )
+        await db.execute(
+            """INSERT INTO bots
+               (bot_id, name, strategy_id, account_id, config_json, status)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("null-num", "null", "s1", "acc-test", null_config, "created"),
+        )
+
+        manager2 = BotManager(eventbus=eventbus, db=db)
+        await manager2.initialize()
+        with caplog.at_level(logging.WARNING):
+            count = await manager2.load_from_db()
+
+        assert count == 0
+        assert manager2.get_bot("null-num") is None
+        warn_messages = [r.message for r in caplog.records if r.levelno >= 30]
+        assert any(
+            "null-num" in m and "invalid bot config row skip" in m
+            for m in warn_messages
+        )
+
+    async def test_invalid_interval_seconds_row_is_skipped_with_warning(
+        self, manager, eventbus, db, caplog
+    ):
+        """case C3: invalid ``interval_seconds`` 도 새 except 분기로 skip."""
+        import json as _json
+        import logging
+
+        invalid_config = _json.dumps({"interval_seconds": -1})
+        await db.execute(
+            """INSERT INTO bots
+               (bot_id, name, strategy_id, account_id, config_json, status)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("bad-interval", "bad", "s1", "acc-test", invalid_config, "created"),
+        )
+
+        manager2 = BotManager(eventbus=eventbus, db=db)
+        await manager2.initialize()
+        with caplog.at_level(logging.WARNING):
+            count = await manager2.load_from_db()
+
+        assert count == 0
+        assert manager2.get_bot("bad-interval") is None
+        warn_messages = [r.message for r in caplog.records if r.levelno >= 30]
+        assert any(
+            "bad-interval" in m and "invalid bot config row skip" in m
+            for m in warn_messages
+        )
+
+    async def test_invalid_account_id_row_not_absorbed_by_value_error_branch(
+        self, manager, eventbus, db, caplog
+    ):
+        """case D: InvalidAccountIdError 회귀 — 새 ValueError 분기로 흡수되지 않는다.
+
+        Refs #1241 SPLIT-2 의 기존 skip 분기는 그대로 동작해야 하고, log
+        message 는 invalid runtime control 분기와 구분되어야 한다.
+        """
+        import json as _json
+        import logging
+
+        valid_config = _json.dumps({"interval_seconds": 60})
+        # account_id="" 는 ``require_account_id`` 가 InvalidAccountIdError raise
+        await db.execute(
+            """INSERT INTO bots
+               (bot_id, name, strategy_id, account_id, config_json, status)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("blank-acc", "blank", "s1", "", valid_config, "created"),
+        )
+
+        manager2 = BotManager(eventbus=eventbus, db=db)
+        await manager2.initialize()
+        with caplog.at_level(logging.WARNING):
+            count = await manager2.load_from_db()
+
+        assert count == 0
+        assert manager2.get_bot("blank-acc") is None
+        warn_messages = [r.message for r in caplog.records if r.levelno >= 30]
+        # 기존 SPLIT-2 분기의 메시지 형식이 유지된다 (별도 분기로 라우팅).
+        assert any(
+            "blank-acc" in m and "invalid account_id row skip" in m
+            for m in warn_messages
+        )
+        # 새 ValueError 분기 메시지로 잘못 흡수되지 않는다.
+        assert not any(
+            "blank-acc" in m and "invalid bot config row skip" in m
+            for m in warn_messages
+        )


### PR DESCRIPTION
Closes #1457

## Summary
- `BotManager._save_bot_config`가 `config_json`에 `auto_restart`, `max_restart_attempts`, `restart_cooldown_seconds`, `step_timeout_seconds`, `max_signals_per_step` 5개 필드를 직렬화하도록 확장.
- `BotManager.load_from_db`가 `BotConfig` dataclass field default(`dataclasses.fields`)를 SSOT로 위 필드들을 복원. `missing` key는 default fallback, explicit `null`은 `ValueError`로 격리.
- `load_from_db` 예외 분기 확장: 기존 `except InvalidAccountIdError`는 유지하고 별도 `except ValueError` 블록에서 invalid runtime control / invalid `interval_seconds` / explicit null persisted row를 warning + skip 처리. `json.loads`는 try 블록 외부에 두어 `JSONDecodeError` 흡수 방지.

## Test Plan
- `ruff check src/ante/bot/manager.py tests/unit/test_bot_manager_methods.py` — PASS
- `ruff format --check src/ante/bot/manager.py tests/unit/test_bot_manager_methods.py` — PASS
- `pytest tests/unit/test_bot_manager_methods.py tests/unit/test_bot.py -v` — 95 passed
- `pytest tests/unit -k "bot_manager and (load_from_db or roundtrip or save_load)" -v` — 10 passed
- 본문 v2 Implementation Plan의 case A/B1/B2/C1/C2/C3/D 모두 신규/기존 테스트로 커버.

## Plan Preflight
- verdict: approve-implement (v2)
- 이슈 본문 Implementation Plan 기준 (Codex 브랜치 리뷰 PASS, blocking findings 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)