### PR TITLE
feat(bot,web-api): expose runtime controls via nested BotInfo.config

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -5836,6 +5836,46 @@
         "title": "BalanceSetResponse",
         "description": "잔고 설정 응답."
       },
+      "BotConfigOut": {
+        "properties": {
+          "interval_seconds": {
+            "type": "integer",
+            "title": "Interval Seconds"
+          },
+          "auto_restart": {
+            "type": "boolean",
+            "title": "Auto Restart"
+          },
+          "max_restart_attempts": {
+            "type": "integer",
+            "title": "Max Restart Attempts"
+          },
+          "restart_cooldown_seconds": {
+            "type": "integer",
+            "title": "Restart Cooldown Seconds"
+          },
+          "step_timeout_seconds": {
+            "type": "integer",
+            "title": "Step Timeout Seconds"
+          },
+          "max_signals_per_step": {
+            "type": "integer",
+            "title": "Max Signals Per Step"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "interval_seconds",
+          "auto_restart",
+          "max_restart_attempts",
+          "restart_cooldown_seconds",
+          "step_timeout_seconds",
+          "max_signals_per_step"
+        ],
+        "title": "BotConfigOut",
+        "description": "봇 runtime control 6 필드 nested 응답 (#1458).\n\n``GET /api/bots/{bot_id}`` 응답에 nested 객체 ``config`` 로 직렬화되어\n대시보드 BotDetail edit modal prefill 의 SSOT 가 된다.\n``docs/dashboard/user-stories/bots.md`` B-3/B-5 line 197-200 의 6 필드\n(``interval_seconds``, ``auto_restart``, ``max_restart_attempts``,\n``restart_cooldown_seconds``, ``step_timeout_seconds``,\n``max_signals_per_step``) 만 노출하며 다른 키는 ``extra=\"forbid\"`` 로\n차단한다 (강한 schema 계약)."
+      },
       "BotDetailResponse": {
         "properties": {
           "bot": {
@@ -5945,6 +5985,16 @@
               }
             ],
             "title": "Error Message"
+          },
+          "config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BotConfigOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "additionalProperties": true,
@@ -5953,7 +6003,7 @@
           "bot_id"
         ],
         "title": "BotInfo",
-        "description": "봇 정보 (read 응답).\n\nwrite 경로(``BotConfig``, ``ApprovalService.create``)에서 account_id가\n검증되므로 read 응답 schema에는 default를 유지한다."
+        "description": "봇 정보 (read 응답).\n\nwrite 경로(``BotConfig``, ``ApprovalService.create``)에서 account_id가\n검증되므로 read 응답 schema에는 default를 유지한다.\n\n``config`` (`BotConfigOut`) 는 #1458 에서 추가된 runtime control 6 필드\nnested 객체다. backward compatibility 를 위해 top-level ``interval_seconds``\n는 유지하되, 다른 runtime control 필드는 top-level 에 노출하지 않는다\n(계약 중복 방지)."
       },
       "BotListResponse": {
         "properties": {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2106,6 +2106,32 @@ export type components = {
             updated_at: string;
         };
         /**
+         * BotConfigOut
+         * @description 봇 runtime control 6 필드 nested 응답 (#1458).
+         *
+         *     ``GET /api/bots/{bot_id}`` 응답에 nested 객체 ``config`` 로 직렬화되어
+         *     대시보드 BotDetail edit modal prefill 의 SSOT 가 된다.
+         *     ``docs/dashboard/user-stories/bots.md`` B-3/B-5 line 197-200 의 6 필드
+         *     (``interval_seconds``, ``auto_restart``, ``max_restart_attempts``,
+         *     ``restart_cooldown_seconds``, ``step_timeout_seconds``,
+         *     ``max_signals_per_step``) 만 노출하며 다른 키는 ``extra="forbid"`` 로
+         *     차단한다 (강한 schema 계약).
+         */
+        BotConfigOut: {
+            /** Auto Restart */
+            auto_restart: boolean;
+            /** Interval Seconds */
+            interval_seconds: number;
+            /** Max Restart Attempts */
+            max_restart_attempts: number;
+            /** Max Signals Per Step */
+            max_signals_per_step: number;
+            /** Restart Cooldown Seconds */
+            restart_cooldown_seconds: number;
+            /** Step Timeout Seconds */
+            step_timeout_seconds: number;
+        };
+        /**
          * BotCreateRequest
          * @description POST /api/bots 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1371). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다. Pydantic ``extra='forbid'`` (#1436) — 정의되지 않은 필드(예: legacy ``bot_type``)는 422로 거부된다. strategy_id 또는 strategy_name 중 하나를 필수로 전달해야 하며 (model_validator로 강제, #1436), 둘 다 전달 시 strategy_id를 우선 사용한다. OpenAPI ``anyOf`` 로 strategy 식별자 필수 조건을 명시하여 generated TS/SDK 가 ``{bot_id: ...}`` 만 담긴 payload 를 valid 로 인식하지 못하도록 한다 (codex r1 FAIL). anyOf branches 는 ``type``/``properties`` 까지 명시하여 openapi-typescript 가 ``unknown`` 으로 붕괴되지 않고 ``{strategy_id: string} | {strategy_name: string}`` 으로 narrow 되도록 한다 (codex r2 FAIL).
          */
@@ -2148,6 +2174,11 @@ export type components = {
          *
          *     write 경로(``BotConfig``, ``ApprovalService.create``)에서 account_id가
          *     검증되므로 read 응답 schema에는 default를 유지한다.
+         *
+         *     ``config`` (`BotConfigOut`) 는 #1458 에서 추가된 runtime control 6 필드
+         *     nested 객체다. backward compatibility 를 위해 top-level ``interval_seconds``
+         *     는 유지하되, 다른 runtime control 필드는 top-level 에 노출하지 않는다
+         *     (계약 중복 방지).
          */
         BotInfo: {
             /**
@@ -2157,6 +2188,7 @@ export type components = {
             account_id: string;
             /** Bot Id */
             bot_id: string;
+            config?: components["schemas"]["BotConfigOut"] | null;
             /** Error Message */
             error_message?: string | null;
             /**
@@ -3770,6 +3802,7 @@ export type AuditLogItem = components['schemas']['AuditLogItem'];
 export type AuditLogListResponse = components['schemas']['AuditLogListResponse'];
 export type BalanceSetRequest = components['schemas']['BalanceSetRequest'];
 export type BalanceSetResponse = components['schemas']['BalanceSetResponse'];
+export type BotConfigOut = components['schemas']['BotConfigOut'];
 export type BotCreateRequest = components['schemas']['BotCreateRequest'];
 export type BotDetailResponse = components['schemas']['BotDetailResponse'];
 export type BotInfo = components['schemas']['BotInfo'];

--- a/src/ante/bot/bot.py
+++ b/src/ante/bot/bot.py
@@ -464,7 +464,15 @@ class Bot:
                 )
 
     def get_info(self) -> dict[str, Any]:
-        """봇 상태 정보 반환."""
+        """봇 상태 정보 반환.
+
+        ``config`` nested object 는 ``BotConfig`` 의 runtime control 6 필드
+        (#1458 — ``docs/dashboard/user-stories/bots.md`` B-3/B-5 SSOT) 를
+        대시보드 BotDetail prefill 용도로 노출한다. top-level ``interval_seconds``
+        는 backward compatibility 용으로 유지된다(기존 list/detail 호출자의
+        flat key 의존성). 다른 runtime control 필드는 top-level 에 추가하지
+        않는다 (계약 중복 방지, #1458 Stop Conditions).
+        """
         return {
             "bot_id": self.bot_id,
             "name": self.config.name,
@@ -478,4 +486,12 @@ class Bot:
             "started_at": (self.started_at.isoformat() if self.started_at else None),
             "stopped_at": (self.stopped_at.isoformat() if self.stopped_at else None),
             "error_message": self.error_message,
+            "config": {
+                "interval_seconds": self.config.interval_seconds,
+                "auto_restart": self.config.auto_restart,
+                "max_restart_attempts": self.config.max_restart_attempts,
+                "restart_cooldown_seconds": self.config.restart_cooldown_seconds,
+                "step_timeout_seconds": self.config.step_timeout_seconds,
+                "max_signals_per_step": self.config.max_signals_per_step,
+            },
         }

--- a/src/ante/web/schemas.py
+++ b/src/ante/web/schemas.py
@@ -305,11 +305,38 @@ class MeResponse(BaseModel):
 # ── 봇 ──────────────────────────────────────────────
 
 
+class BotConfigOut(BaseModel):
+    """봇 runtime control 6 필드 nested 응답 (#1458).
+
+    ``GET /api/bots/{bot_id}`` 응답에 nested 객체 ``config`` 로 직렬화되어
+    대시보드 BotDetail edit modal prefill 의 SSOT 가 된다.
+    ``docs/dashboard/user-stories/bots.md`` B-3/B-5 line 197-200 의 6 필드
+    (``interval_seconds``, ``auto_restart``, ``max_restart_attempts``,
+    ``restart_cooldown_seconds``, ``step_timeout_seconds``,
+    ``max_signals_per_step``) 만 노출하며 다른 키는 ``extra="forbid"`` 로
+    차단한다 (강한 schema 계약).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    interval_seconds: int
+    auto_restart: bool
+    max_restart_attempts: int
+    restart_cooldown_seconds: int
+    step_timeout_seconds: int
+    max_signals_per_step: int
+
+
 class BotInfo(BaseModel):
     """봇 정보 (read 응답).
 
     write 경로(``BotConfig``, ``ApprovalService.create``)에서 account_id가
     검증되므로 read 응답 schema에는 default를 유지한다.
+
+    ``config`` (`BotConfigOut`) 는 #1458 에서 추가된 runtime control 6 필드
+    nested 객체다. backward compatibility 를 위해 top-level ``interval_seconds``
+    는 유지하되, 다른 runtime control 필드는 top-level 에 노출하지 않는다
+    (계약 중복 방지).
     """
 
     bot_id: str
@@ -324,6 +351,7 @@ class BotInfo(BaseModel):
     started_at: str | None = None
     stopped_at: str | None = None
     error_message: str | None = None
+    config: BotConfigOut | None = None
 
     # 봇 상세 조회 시 추가되는 동적 필드 (strategy, budget, positions 등)
     model_config = ConfigDict(extra="allow")

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -590,6 +590,94 @@ class TestBot:
         assert info["exchange"] == "KRX"
         assert info["currency"] == "KRW"
 
+    def test_get_info_returns_runtime_controls_in_config(self, eventbus, ctx):
+        """#1458: get_info()["config"]가 runtime control 6필드를 nested로 노출."""
+        config = BotConfig(
+            bot_id="bot1",
+            strategy_id="s1",
+            interval_seconds=10,
+            account_id="acc-test",
+            auto_restart=True,
+            max_restart_attempts=5,
+            restart_cooldown_seconds=120,
+            step_timeout_seconds=45,
+            max_signals_per_step=100,
+        )
+        bot = Bot(
+            config=config,
+            strategy_cls=SimpleStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        info = bot.get_info()
+        assert "config" in info
+        nested = info["config"]
+        assert nested == {
+            "interval_seconds": 10,
+            "auto_restart": True,
+            "max_restart_attempts": 5,
+            "restart_cooldown_seconds": 120,
+            "step_timeout_seconds": 45,
+            "max_signals_per_step": 100,
+        }
+
+    def test_get_info_config_reflects_updated_runtime_controls(
+        self, eventbus, ctx, simple_config
+    ):
+        """#1458: BotConfig 필드 변경 후 get_info()가 새 값을 반영."""
+        bot = Bot(
+            config=simple_config,
+            strategy_cls=SimpleStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        # BotConfig dataclass 의 mutable 필드를 직접 갱신
+        bot.config.auto_restart = False
+        bot.config.max_restart_attempts = 7
+        bot.config.restart_cooldown_seconds = 200
+        bot.config.step_timeout_seconds = 90
+        bot.config.max_signals_per_step = 150
+
+        info = bot.get_info()
+        assert info["config"]["auto_restart"] is False
+        assert info["config"]["max_restart_attempts"] == 7
+        assert info["config"]["restart_cooldown_seconds"] == 200
+        assert info["config"]["step_timeout_seconds"] == 90
+        assert info["config"]["max_signals_per_step"] == 150
+
+    def test_get_info_keeps_flat_interval_seconds(self, eventbus, ctx, simple_config):
+        """#1458: backward compat — top-level interval_seconds 유지."""
+        bot = Bot(
+            config=simple_config,
+            strategy_cls=SimpleStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        info = bot.get_info()
+        assert info["interval_seconds"] == simple_config.interval_seconds
+        # config nested 값과 동일해야 함
+        assert info["config"]["interval_seconds"] == info["interval_seconds"]
+
+    def test_get_info_no_top_level_runtime_controls(self, eventbus, ctx, simple_config):
+        """#1458: 계약 중복 방지 — top-level에는 flat 5필드를 추가하지 않는다."""
+        bot = Bot(
+            config=simple_config,
+            strategy_cls=SimpleStrategy,
+            ctx=ctx,
+            eventbus=eventbus,
+        )
+        info = bot.get_info()
+        for key in (
+            "auto_restart",
+            "max_restart_attempts",
+            "restart_cooldown_seconds",
+            "step_timeout_seconds",
+            "max_signals_per_step",
+        ):
+            assert key not in info, (
+                f"top-level에 {key}가 추가됨 — config nested에만 노출해야 함"
+            )
+
 
 # ── BotManager ───────────────────────────────────
 

--- a/tests/unit/test_bot_api.py
+++ b/tests/unit/test_bot_api.py
@@ -81,12 +81,27 @@ class FakeBot:
         status: str = "created",
         strategy_id: str = "s1",
         account_id: str = "test",
+        *,
+        # #1458: runtime control 6 필드 nested config 노출
+        auto_restart: bool = True,
+        max_restart_attempts: int = 3,
+        restart_cooldown_seconds: int = 60,
+        step_timeout_seconds: int = 30,
+        max_signals_per_step: int = 50,
+        # 테스트용: BotConfigOut.extra="forbid" 검증을 위한 unknown key 주입
+        extra_config_keys: dict | None = None,
     ) -> None:
         self.bot_id = bot_id
         self._status = status
         self._strategy_id = strategy_id
         self._name = bot_id
         self._interval_seconds = 60
+        self._auto_restart = auto_restart
+        self._max_restart_attempts = max_restart_attempts
+        self._restart_cooldown_seconds = restart_cooldown_seconds
+        self._step_timeout_seconds = step_timeout_seconds
+        self._max_signals_per_step = max_signals_per_step
+        self._extra_config_keys = extra_config_keys or {}
         self.config = FakeBotConfig(
             bot_id, account_id=account_id, strategy_id=strategy_id
         )
@@ -96,6 +111,16 @@ class FakeBot:
         return self._status
 
     def get_info(self) -> dict:
+        config_payload: dict = {
+            "interval_seconds": self._interval_seconds,
+            "auto_restart": self._auto_restart,
+            "max_restart_attempts": self._max_restart_attempts,
+            "restart_cooldown_seconds": self._restart_cooldown_seconds,
+            "step_timeout_seconds": self._step_timeout_seconds,
+            "max_signals_per_step": self._max_signals_per_step,
+        }
+        # #1458: BotConfigOut.extra="forbid" 검증용 unknown key 주입 옵션
+        config_payload.update(self._extra_config_keys)
         return {
             "bot_id": self.bot_id,
             "name": self._name,
@@ -109,6 +134,7 @@ class FakeBot:
             "started_at": None,
             "stopped_at": None,
             "error_message": None,
+            "config": config_payload,
         }
 
 
@@ -324,6 +350,74 @@ class TestGetBot:
         """존재하지 않는 봇 → 404."""
         resp = client.get("/api/bots/nonexistent")
         assert resp.status_code == 404
+
+    def test_get_bot_returns_config_with_runtime_controls(self, client, bot_manager):
+        """#1458: GET /api/bots/{bot_id} 응답 bot.config 가 6 필드를 모두 노출."""
+        bot_manager._bots["bot-1"] = FakeBot(
+            "bot-1",
+            auto_restart=False,
+            max_restart_attempts=7,
+            restart_cooldown_seconds=200,
+            step_timeout_seconds=90,
+            max_signals_per_step=120,
+        )
+        resp = client.get("/api/bots/bot-1")
+        assert resp.status_code == 200
+        bot = resp.json()["bot"]
+        assert bot["config"] == {
+            "interval_seconds": 60,
+            "auto_restart": False,
+            "max_restart_attempts": 7,
+            "restart_cooldown_seconds": 200,
+            "step_timeout_seconds": 90,
+            "max_signals_per_step": 120,
+        }
+
+    def test_get_bot_config_is_strict_schema(
+        self, bot_manager, default_account_service
+    ):
+        """#1458: BotConfigOut(extra="forbid") — config nested 의 unknown key 는 거부.
+
+        FakeBot 이 ``config`` payload 에 정의되지 않은 ``unknown_field`` 를
+        주입하면 FastAPI 응답 직렬화 시점에 ``BotConfigOut`` 검증이 실패하여
+        ResponseValidationError 가 발생해야 한다. ``raise_server_exceptions=
+        False`` TestClient 로 raw 500 응답을 확인하고, 별도 TestClient 에서는
+        ``pytest.raises`` 로 ResponseValidationError 의 ``extra_forbidden``
+        에러를 직접 잡아 strict 계약의 SSOT 가 nested ``config`` 에 있음을
+        명시한다.
+        """
+        from fastapi.exceptions import ResponseValidationError
+        from fastapi.testclient import TestClient
+
+        bot_manager._bots["bot-1"] = FakeBot(
+            "bot-1",
+            extra_config_keys={"unknown_field": 999},
+        )
+        app = create_app(
+            bot_manager=bot_manager,
+            account_service=default_account_service,
+            member_service=_new_member_service(),
+        )
+        # 1) raise_server_exceptions=False — raw 500 응답을 확인
+        strict_client = TestClient(app, raise_server_exceptions=False)
+        strict_client.headers.update(_MASTER_HEADERS)
+        resp = strict_client.get("/api/bots/bot-1")
+        assert resp.status_code == 500, (
+            f"BotConfigOut strict schema 가 unknown key 를 통과시켰음. "
+            f"status={resp.status_code}, body={resp.text[:300]}"
+        )
+
+        # 2) ResponseValidationError 본체에서 extra_forbidden 위치 확인
+        raising_client = TestClient(app)
+        raising_client.headers.update(_MASTER_HEADERS)
+        with pytest.raises(ResponseValidationError) as exc_info:
+            raising_client.get("/api/bots/bot-1")
+        errors = exc_info.value.errors()
+        assert any(
+            err.get("type") == "extra_forbidden"
+            and "unknown_field" in tuple(err.get("loc", ()))
+            for err in errors
+        ), f"extra_forbidden on unknown_field not found: {errors}"
 
 
 class TestStartStopBot:


### PR DESCRIPTION
Closes #1458

## Summary
- `Bot.get_info()`가 `config` nested object로 6필드(`interval_seconds`, `auto_restart`, `max_restart_attempts`, `restart_cooldown_seconds`, `step_timeout_seconds`, `max_signals_per_step`)를 반환.
- `BotInfo` schema에 신규 `BotConfigOut(extra="forbid")` nested 모델 추가. `BotInfo`의 `extra="allow"`는 유지.
- 기존 flat `interval_seconds` 키는 backward compatibility로 유지. 다른 runtime control 필드는 top-level에 추가하지 않음 (계약 중복/YAGNI).
- OpenAPI 산출물(`frontend/openapi.json`, `frontend/src/types/api.generated.ts`) 재생성. `frontend/src/types/bot.ts:BotConfig`와 generated `BotConfigOut` 6필드 exact match 확인.

## Test Plan
- `ruff check src/ante/bot/bot.py src/ante/web/schemas.py tests/unit/test_bot.py tests/unit/test_bot_api.py` — PASS
- `ruff format --check ...` — PASS
- `pytest tests/unit/test_bot.py -v` — 58 passed (단위 회귀 4건 신규)
- `pytest tests/unit/test_bot_api.py::TestGetBot -v` — 4 passed (기존 2 + 신규 2: end-to-end 회귀)
- `pytest tests/unit -k "bot_info or bot_get_info" -v` — 6 passed
- `cd frontend && npm run generate-types && npm run check-api-types && npm run build` — 모두 PASS, findings 0

## Plan Preflight
- verdict: approve-implement (v2)
- 이슈 본문 Implementation Plan v2 기준. Codex 브랜치 리뷰 PASS, blocking findings 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)