### PR TITLE
refactor(strategy,cli): lazy-load IndicatorCalculator via PEP 562 __getattr__

### DIFF
--- a/src/ante/cli/commands/strategy.py
+++ b/src/ante/cli/commands/strategy.py
@@ -11,20 +11,12 @@ import click
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
+from ante.strategy.registry import StrategyStatus
 
-# CLI preflight copy of StrategyStatus values.
-#
-# 실제 SSOT는 `src/ante/strategy/registry.py:66-71`의 `StrategyStatus` enum이다.
-# 본 frozenset은 #1463(`ante.strategy.__init__` heavy import 분리)까지의 임시
-# preflight 복사본이며, registry/DB 진입 전에 `--status` 입력을 거부하기 위한
-# 가벼운 차단막으로만 쓴다. enum과의 drift는 동치성 회귀 테스트
-# (`tests/unit/test_cli_strategy_list_invalid_status.py::
-# test_preflight_set_matches_enum_ssot`)로 차단한다.
-# #1463이 끝나면 본 frozenset은 제거하고 `StrategyStatus`를 모듈 최상단에서
-# 직접 import해 사용한다.
-VALID_STRATEGY_STATUSES: frozenset[str] = frozenset(
-    {"registered", "adopted", "archived"}
-)
+# `StrategyStatus` enum이 단일 SSOT이며 (#1463에서 임시 frozenset 복사본 제거),
+# `ante.strategy.__init__`의 lazy ``__getattr__`` 정리로 본 import가 heavy
+# 분석 의존성을 끌지 않는다. CLI dispatch path가 light한지는
+# ``tests/unit/test_cli_dependency_isolation.py``가 fresh subprocess로 차단한다.
 
 
 @click.group()
@@ -206,20 +198,18 @@ def strategy_list(ctx: click.Context, status: str | None) -> None:
     fmt = get_formatter(ctx)
 
     # Preflight: invalid --status는 registry/DB 진입 전에 차단한다.
-    # `VALID_STRATEGY_STATUSES`는 `StrategyStatus` SSOT의 #1463까지의 임시 복사본
-    # (drift는 enum 동치성 회귀 테스트로 차단). 이로써 일반적인 입력 오타가
-    # `StrategyStatus(status)` ValueError → Python traceback으로 새지 않고
-    # flat JSON error로 종료된다.
-    if status is not None and status not in VALID_STRATEGY_STATUSES:
+    # `StrategyStatus` enum이 SSOT이며 직접 비교한다 (#1463 임시 frozenset 제거).
+    # 이로써 일반적인 입력 오타가 `StrategyStatus(status)` ValueError →
+    # Python traceback으로 새지 않고 flat JSON error로 종료된다.
+    valid_statuses = {s.value for s in StrategyStatus}
+    if status is not None and status not in valid_statuses:
         fmt.error(
-            f"잘못된 status 값: {status!r}. 허용값: {sorted(VALID_STRATEGY_STATUSES)}",
+            f"잘못된 status 값: {status!r}. 허용값: {sorted(valid_statuses)}",
             code="STRATEGY_VALIDATION_ERROR",
         )
         raise SystemExit(1)
 
     async def _list() -> list[dict]:
-        from ante.strategy.registry import StrategyStatus
-
         registry, db = await _create_registry()
         try:
             filter_status = StrategyStatus(status) if status else None

--- a/src/ante/strategy/__init__.py
+++ b/src/ante/strategy/__init__.py
@@ -1,4 +1,23 @@
-"""Strategy — 전략 정의·검증·등록·로딩."""
+"""Strategy — 전략 정의·검증·등록·로딩.
+
+본 패키지의 plain ``import ante.strategy``는 의도적으로 light하다.
+``ante.strategy.indicators``는 ``pandas`` / ``pandas-ta`` / ``numpy`` /
+``numba`` 같은 heavy 분석 의존성을 끌어들이므로, CLI dispatch path가
+이를 eager-import하지 않도록 PEP 562 ``__getattr__``로 **lazy 노출**한다
+(#1463).
+
+계약:
+    - ``import ante.strategy`` 는 light: heavy 의존성을 끌지 않는다.
+    - ``from ante.strategy import IndicatorCalculator`` 는 ``__getattr__``
+      을 호출해 indicators 모듈을 lazy load 한다 (호환성 유지).
+    - ``from ante.strategy import *`` 와 ``importlib.reload(...)`` 는
+      본 lazy 보장 범위 밖이다. 와일드카드 import는 ``__all__``을 통해
+      ``IndicatorCalculator``를 끌어가므로 heavy load가 발생한다.
+
+회귀 차단:
+    - ``tests/unit/test_cli_dependency_isolation.py``가 fresh subprocess
+      helper로 ``import ante.strategy`` 시 heavy 모듈 적재 여부를 검사한다.
+"""
 
 from ante.strategy.base import (
     DataProvider,
@@ -18,7 +37,6 @@ from ante.strategy.exceptions import (
     StrategyLoadError,
     StrategyValidationError,
 )
-from ante.strategy.indicators import IndicatorCalculator
 from ante.strategy.loader import StrategyLoader
 from ante.strategy.registry import StrategyRecord, StrategyRegistry, StrategyStatus
 from ante.strategy.snapshot import StrategySnapshot
@@ -55,3 +73,17 @@ __all__ = [
     "ValidationResult",
     "validate_exchange",
 ]
+
+
+def __getattr__(name: str):
+    """PEP 562 lazy attribute access — heavy indicators 모듈을 지연 적재.
+
+    ``from ante.strategy import IndicatorCalculator`` 형태의 기존 import
+    패턴은 그대로 동작하지만, 호출 시점에야 ``ante.strategy.indicators``를
+    적재하므로 plain ``import ante.strategy``는 light한 상태를 유지한다.
+    """
+    if name == "IndicatorCalculator":
+        from ante.strategy.indicators import IndicatorCalculator
+
+        return IndicatorCalculator
+    raise AttributeError(f"module 'ante.strategy' has no attribute {name!r}")

--- a/tests/unit/test_cli_dependency_isolation.py
+++ b/tests/unit/test_cli_dependency_isolation.py
@@ -26,6 +26,12 @@ from pathlib import Path
 
 import pytest
 
+# 추가 패키지 import 회귀 케이스 (#1463 — `ante.strategy.__init__` lazy 분리).
+# plain ``import ante.strategy``는 light해야 하며, ``IndicatorCalculator`` 같은
+# heavy 심볼은 PEP 562 ``__getattr__``로 lazy 노출된다. 본 케이스는 CLI 명령
+# 모듈과 별개로 패키지 자체의 import surface를 회귀 차단한다.
+STRATEGY_PACKAGE_MODULES: tuple[str, ...] = ("ante.strategy",)
+
 # CLI 명령 모듈 (src/ante/cli/commands/ 하위)
 # `_password`처럼 언더스코어로 시작하는 private helper는 제외한다.
 CLI_COMMAND_MODULES: tuple[str, ...] = (
@@ -144,6 +150,23 @@ def test_cli_command_module_does_not_eager_import_heavy_deps(command: str) -> No
     assert loaded == [], (
         f"{target} import 시 heavy 분석 의존성이 적재되었습니다: {loaded}. "
         "CLI dispatch path는 lazy import를 유지해야 합니다 (see #1461/#1463)."
+    )
+
+
+@pytest.mark.parametrize("package", STRATEGY_PACKAGE_MODULES)
+def test_strategy_package_does_not_eager_import_heavy_deps(package: str) -> None:
+    """``ante.strategy`` 패키지 import 시 heavy 분석 의존성이 적재되지 않는다.
+
+    회귀 시나리오: ``ante.strategy.__init__``에서 ``from ante.strategy.indicators
+    import IndicatorCalculator``를 다시 top-level로 끌어오면 본 테스트가 즉시
+    실패한다. PEP 562 ``__getattr__`` lazy 패턴을 유지해야 한다 (#1463).
+    """
+    payload = _run_isolated_import(package)
+    loaded = payload["loaded"]
+    assert loaded == [], (
+        f"{package} import 시 heavy 분석 의존성이 적재되었습니다: {loaded}. "
+        "`ante.strategy.__init__`은 PEP 562 `__getattr__`로 `IndicatorCalculator`만 "
+        "lazy 노출해야 합니다 (see #1463)."
     )
 
 

--- a/tests/unit/test_cli_strategy_list_invalid_status.py
+++ b/tests/unit/test_cli_strategy_list_invalid_status.py
@@ -16,7 +16,6 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from ante.cli.commands.strategy import VALID_STRATEGY_STATUSES
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
 from ante.strategy.registry import StrategyRecord, StrategyStatus
@@ -268,10 +267,3 @@ class TestStrategyListInvalidStatus:
             assert "intentional click usage error" in result.output
             # JSON shape이 아니어야 한다(formatter를 거치지 않았다는 회귀).
             assert '"code": "STRATEGY_ERROR"' not in result.output
-
-    def test_preflight_set_matches_enum_ssot(self):
-        """CLI preflight copy가 `StrategyStatus` SSOT와 동치인지 회귀.
-
-        #1463(heavy import 분리)으로 preflight copy가 제거되기 전까지 drift를 차단한다.
-        """
-        assert VALID_STRATEGY_STATUSES == {s.value for s in StrategyStatus}

--- a/tests/unit/test_strategy.py
+++ b/tests/unit/test_strategy.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import ante.strategy as strategy_pkg
 from ante.core import Database
 from ante.strategy import (
     DataProvider,
@@ -922,3 +923,32 @@ class TestStrategy(Strategy):
 """
         result = validator.validate(self._write_strategy(tmp_path, code))
         assert result.valid
+
+
+# ── ante.strategy lazy attribute access 회귀 (#1463) ──────────────────
+
+
+def test_strategy_package_lazy_indicator_calculator() -> None:
+    """`from ante.strategy import IndicatorCalculator`가 lazy로 정상 동작한다.
+
+    `ante.strategy.__init__`의 PEP 562 ``__getattr__`` 패턴이 외부 호출자에게
+    backward-compatible한 import surface를 제공하는지 확인한다 (#1463).
+    같은 객체를 두 번 가져와도 ``ante.strategy.indicators.IndicatorCalculator``
+    와 동일해야 한다.
+    """
+    from ante.strategy import IndicatorCalculator as Lazy1
+    from ante.strategy import IndicatorCalculator as Lazy2
+    from ante.strategy.indicators import IndicatorCalculator as Direct
+
+    assert Lazy1 is Direct
+    assert Lazy1 is Lazy2
+    # 패키지 attribute 접근 경로도 동일 객체.
+    assert strategy_pkg.IndicatorCalculator is Direct
+
+
+def test_strategy_package_unknown_attribute_raises() -> None:
+    """`__getattr__`은 알 수 없는 attribute에 대해 ``AttributeError``를 던진다."""
+    import pytest as _pytest
+
+    with _pytest.raises(AttributeError, match="no attribute 'NotARealSymbol'"):
+        _ = strategy_pkg.NotARealSymbol  # type: ignore[attr-defined]


### PR DESCRIPTION
Closes #1463

## Summary
- `ante.strategy.__init__`이 더 이상 `IndicatorCalculator`(=`pandas_ta`/`numpy`/`pandas` 의존성 hub)를 eager import하지 않는다. PEP 562 `__getattr__`를 통해 `from ante.strategy import IndicatorCalculator` 및 `ante.strategy.IndicatorCalculator` 접근만 lazy import를 트리거한다.
- `src/ante/cli/commands/strategy.py`의 임시 `VALID_STRATEGY_STATUSES` frozenset을 제거하고 `StrategyStatus` enum을 모듈 상단에서 직접 import해 SSOT 직접 사용.
- `tests/unit/test_cli_dependency_isolation.py`에 `ante.strategy` 패키지 import 케이스 추가 (subprocess fresh-interpreter helper 재사용). `tests/unit/test_cli_strategy_list_invalid_status.py`의 frozenset 동치성 테스트 제거.
- `from ante.strategy import IndicatorCalculator` lazy 회귀 단위 테스트 + unknown attribute AttributeError 테스트 추가.

## Test Plan
- `ruff check ...` — PASS
- `ruff format --check ...` — PASS
- `pytest tests/unit/test_cli_dependency_isolation.py -v` — 23 passed (신규 `test_strategy_package_does_not_eager_import_heavy_deps[ante.strategy]` 포함)
- `pytest tests/unit/test_strategy.py tests/unit/test_indicators.py tests/unit/test_cli_strategy_list_invalid_status.py -v` — 127 passed
- `pytest tests/unit/feed/test_orchestrator.py -v` — 23 passed
- 수동 sanity: `python -c "import sys; import ante.strategy; print(sorted(k for k in sys.modules if 'pandas' in k or 'numba' in k))"` → `[]`

## Plan Preflight
- verdict: approve-implement (v1, v2 권장 반영)
- 이슈 본문 Implementation Plan v2 기준. Codex 브랜치 리뷰 PASS, blocking findings 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)