### PR TITLE
fix(cli): preflight enum validation for account/approval/report list before DB access

### DIFF
--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any, NoReturn
 
 import click
 
+from ante.account.models import AccountStatus
 from ante.cli.cold_path import (
     ACCOUNT_COLD_PATH_BLOCKED_CODE,
     assert_no_active_runtime,
@@ -30,6 +31,12 @@ from ante.cli.cold_path import (
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
+
+# `AccountStatus` enum이 `--status` 필터의 SSOT다. `account list`는 DB 진입 전
+# preflight에서 invalid 값을 차단해야 하며 (#1462), 이를 위해 함수 내부 import
+# 대신 모듈 상단 import을 사용한다. `ante.account.models`은 dataclass + StrEnum
+# 만 노출하는 light 모듈이라 `tests/unit/test_cli_dependency_isolation.py`가
+# 회귀를 차단한다.
 
 if TYPE_CHECKING:
     from ante.account.models import Account
@@ -593,7 +600,18 @@ def account_list(ctx: click.Context, status_filter: str | None) -> None:
     """계좌 목록 조회."""
     fmt = get_formatter(ctx)
 
-    from ante.account.models import AccountStatus
+    # Preflight: invalid `--status`는 `_create_account_service()` (DB 접속) 전에
+    # 차단한다. `AccountStatus` enum이 SSOT이며 (#1462) inline 비교한다.
+    # strategy.py:204-210 패턴과 동형이다.
+    if status_filter is not None and status_filter not in {
+        s.value for s in AccountStatus
+    }:
+        fmt.error(
+            f"잘못된 status 값: {status_filter!r}. "
+            f"허용값: {sorted(s.value for s in AccountStatus)}",
+            code="ACCOUNT_INVALID_STATUS",
+        )
+        raise SystemExit(1)
 
     async def _do_list() -> list[dict]:
         svc, db = await _create_account_service()

--- a/src/ante/cli/commands/approval.py
+++ b/src/ante/cli/commands/approval.py
@@ -7,9 +7,16 @@ import json
 
 import click
 
+from ante.approval.models import ApprovalStatus, ApprovalType
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
+
+# `ApprovalStatus`/`ApprovalType` enum이 `--status`/`--type` 필터의 SSOT다.
+# `approval list`는 DB 진입 전 preflight에서 invalid 값을 차단해야 하며 (#1462),
+# 이를 위해 함수 내부 import 대신 모듈 상단 import을 사용한다.
+# `ante.approval.models`은 dataclass + StrEnum 만 노출하는 light 모듈이라
+# `tests/unit/test_cli_dependency_isolation.py`가 회귀를 차단한다.
 
 
 @click.group()
@@ -38,9 +45,8 @@ def request(
     expires_in: str,
 ) -> None:
     """결재 요청 생성."""
-    # ApprovalType SSOT 검증 — heavy ``ante.approval`` 패키지를 피하기 위해
-    # ``ante.approval.models`` 만 직접 import 한다 (#1469).
-    from ante.approval.models import ApprovalType
+    # ApprovalType SSOT 검증. `ante.approval.models`는 모듈 상단에서 import한다
+    # (#1462; #1469 lazy 패턴은 dependency-isolation smoke가 회귀 차단).
 
     fmt = get_formatter(ctx)
     requester = get_member_id(ctx)
@@ -107,6 +113,27 @@ def approval_list(
 
     fmt = get_formatter(ctx)
     resolved_db_path = db_path or get_db_path(ctx)
+
+    # Preflight: invalid `--status`/`--type`는 `Database` 생성 전에 차단한다.
+    # `ApprovalStatus`/`ApprovalType` enum이 SSOT이며 (#1462) inline 비교한다.
+    # strategy.py:204-210 패턴과 동형이다.
+    if status is not None and status not in {s.value for s in ApprovalStatus}:
+        fmt.error(
+            f"잘못된 status 값: {status!r}. "
+            f"허용값: {sorted(s.value for s in ApprovalStatus)}",
+            code="APPROVAL_INVALID_STATUS",
+        )
+        raise SystemExit(1)
+
+    if approval_type is not None and approval_type not in {
+        t.value for t in ApprovalType
+    }:
+        fmt.error(
+            f"잘못된 type 값: {approval_type!r}. "
+            f"허용값: {sorted(t.value for t in ApprovalType)}",
+            code="APPROVAL_INVALID_TYPE",
+        )
+        raise SystemExit(1)
 
     async def _list() -> list[dict]:
         from ante.approval import ApprovalService

--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -10,7 +10,14 @@ from pydantic import ValidationError
 
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
+from ante.report.models import ReportStatus
 from ante.web.schemas import ReportSubmitRequest
+
+# `ReportStatus` enum이 `--status` 필터의 SSOT다. `report list`는 DB 진입 전
+# preflight에서 invalid 값을 차단해야 하며 (#1462), 이를 위해 함수 내부 import
+# 대신 모듈 상단 import을 사용한다. `ante.report.models`는 dataclass + StrEnum
+# + math 만 노출하는 light 모듈이라 `tests/unit/test_cli_dependency_isolation.py`
+# 가 회귀를 차단한다.
 
 
 @click.group()
@@ -165,7 +172,10 @@ def submit(
 
 
 @report.command("list")
-@click.option("--status", help="상태 필터 (pending/adopted/rejected)")
+@click.option(
+    "--status",
+    help="상태 필터 (draft/submitted/reviewed/adopted/rejected/archived)",
+)
 @click.option("--db-path", default=None, help="DB 경로 (미지정 시 config_dir 기반)")
 @click.pass_context
 @require_auth
@@ -178,9 +188,19 @@ def report_list(ctx: click.Context, status: str | None, db_path: str | None) -> 
     fmt = get_formatter(ctx)
     resolved_db_path = db_path or get_db_path(ctx)
 
+    # Preflight: invalid `--status`는 `Database` 생성 전에 차단한다.
+    # `ReportStatus` enum이 SSOT이며 (#1462) inline 비교한다.
+    # strategy.py:204-210 패턴과 동형이다.
+    if status is not None and status not in {s.value for s in ReportStatus}:
+        fmt.error(
+            f"잘못된 status 값: {status!r}. "
+            f"허용값: {sorted(s.value for s in ReportStatus)}",
+            code="REPORT_INVALID_STATUS",
+        )
+        raise SystemExit(1)
+
     async def _list() -> list[dict]:
         from ante.core.database import Database
-        from ante.report.models import ReportStatus
 
         db = Database(resolved_db_path)
         await db.connect()

--- a/tests/unit/test_account_cli.py
+++ b/tests/unit/test_account_cli.py
@@ -166,6 +166,55 @@ class TestAccountList:
         result = _invoke(["account", "list", "--status", "suspended"])
         assert result.exit_code == 0
 
+    def test_account_list_invalid_status_rejected_before_db(self) -> None:
+        """invalid `--status`는 `_create_account_service` 호출 전 차단된다 (#1462).
+
+        AccountStatus enum (SSOT)에 없는 status 값이 들어오면 preflight가
+        `ACCOUNT_INVALID_STATUS` 구조화 에러로 종료시키며, DB 접속을 위한
+        `_create_account_service`는 호출되지 않아야 한다.
+        """
+        mock_create = AsyncMock()
+        with patch(
+            "ante.cli.commands.account._create_account_service",
+            new=mock_create,
+        ):
+            result = _invoke(
+                [
+                    "--format",
+                    "json",
+                    "account",
+                    "list",
+                    "--status",
+                    "oracle_invalid_status",
+                ]
+            )
+        assert result.exit_code == 1
+        data = json.loads(result.output.strip())
+        assert data["status"] == "error"
+        assert data["code"] == "ACCOUNT_INVALID_STATUS"
+        assert "oracle_invalid_status" in data["message"]
+        assert "Traceback" not in result.output
+        mock_create.assert_not_called()
+
+    def test_account_list_valid_status_still_works(
+        self, mock_account_service: AsyncMock
+    ) -> None:
+        """valid `--status` 입력은 회귀 없이 정상 동작한다 (#1462).
+
+        ACTIVE / SUSPENDED / DELETED 세 가지 valid 값 모두 preflight를 통과하고
+        AccountService.list가 enum 값으로 호출된다.
+        """
+        from ante.account.models import AccountStatus
+
+        mock_account_service.list.return_value = []
+        for valid in ("active", "suspended", "deleted"):
+            mock_account_service.list.reset_mock()
+            result = _invoke(["account", "list", "--status", valid])
+            assert result.exit_code == 0, result.output
+            mock_account_service.list.assert_called_once_with(
+                status=AccountStatus(valid),
+            )
+
 
 # ── account info 테스트 ──────────────────────────────
 

--- a/tests/unit/test_cli_approval_list_filters.py
+++ b/tests/unit/test_cli_approval_list_filters.py
@@ -1,0 +1,242 @@
+"""CLI ``approval list`` invalid `--status`/`--type` preflight 회귀 테스트 (#1462).
+
+`ante --format json approval list --status <invalid>` /
+`ante --format json approval list --type <invalid>`가 Python traceback 없이
+flat JSON error (`APPROVAL_INVALID_STATUS` / `APPROVAL_INVALID_TYPE`)로 종료하고,
+DB 접속(`ante.core.database.Database`)이 일어나기 전에 차단되는지 검증한다.
+
+SSOT:
+- enum: ``src/ante/approval/models.py::ApprovalStatus``,
+  ``src/ante/approval/models.py::ApprovalType``
+- 패턴: ``src/ante/cli/commands/strategy.py:204-210``
+- 계약: ``docs/specs/cli/02-design-decisions.md`` (structured error)
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """auth bypass가 적용된 CliRunner.
+
+    `ante.cli.main.authenticate_member`를 patch하여 root group의 인증 검사를
+    우회한다 (CLI 테스트 표준 패턴).
+    """
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _mock_service_layer(requests=None):
+    """`Database` + `ApprovalService` 생성자 patch 헬퍼.
+
+    valid 입력 케이스에서 list_approvals이 결과를 반환할 수 있도록
+    Database / ApprovalService 가 모두 호출 가능하게 mock한다.
+    """
+    db = MagicMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    db_cls = MagicMock(return_value=db)
+
+    service = MagicMock()
+    service.initialize = AsyncMock()
+    service.list_approvals = AsyncMock(return_value=requests or [])
+    service_cls = MagicMock(return_value=service)
+
+    return db_cls, service_cls, service
+
+
+class TestApprovalListInvalidPreflight:
+    """`approval list` invalid status/type → DB 접속 전 차단 (#1462)."""
+
+    def test_approval_list_invalid_status_rejected_before_db(self, runner) -> None:
+        """invalid `--status`는 `Database` 생성 전 차단된다.
+
+        ApprovalStatus enum (SSOT)에 없는 값이 들어오면 preflight가
+        `APPROVAL_INVALID_STATUS` 구조화 에러로 종료시키며, DB 생성자는
+        호출되지 않아야 한다.
+        """
+        db_cls = MagicMock()
+        with (
+            patch("ante.core.database.Database", db_cls),
+            patch("ante.cli.main.get_db_path", return_value="/tmp/unused-approval.db"),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "approval",
+                    "list",
+                    "--status",
+                    "oracle_invalid_status",
+                ],
+            )
+        assert result.exit_code == 1, result.output
+        data = json.loads(result.output.strip())
+        assert data["status"] == "error"
+        assert data["code"] == "APPROVAL_INVALID_STATUS"
+        assert "oracle_invalid_status" in data["message"]
+        assert "Traceback" not in result.output
+        db_cls.assert_not_called()
+
+    def test_approval_list_invalid_type_rejected_before_db(self, runner) -> None:
+        """invalid `--type`는 `Database` 생성 전 차단된다.
+
+        ApprovalType enum (SSOT)에 없는 값이 들어오면 preflight가
+        `APPROVAL_INVALID_TYPE` 구조화 에러로 종료시키며, DB 생성자는
+        호출되지 않아야 한다.
+        """
+        db_cls = MagicMock()
+        with (
+            patch("ante.core.database.Database", db_cls),
+            patch("ante.cli.main.get_db_path", return_value="/tmp/unused-approval.db"),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "approval",
+                    "list",
+                    "--type",
+                    "oracle_invalid_type",
+                ],
+            )
+        assert result.exit_code == 1, result.output
+        data = json.loads(result.output.strip())
+        assert data["status"] == "error"
+        assert data["code"] == "APPROVAL_INVALID_TYPE"
+        assert "oracle_invalid_type" in data["message"]
+        assert "Traceback" not in result.output
+        db_cls.assert_not_called()
+
+    def test_approval_list_invalid_status_takes_priority_over_invalid_type(
+        self, runner
+    ) -> None:
+        """status invalid가 type invalid보다 먼저 평가된다.
+
+        구현 순서를 회귀 보호 (status check 먼저 → type check 다음).
+        """
+        db_cls = MagicMock()
+        with (
+            patch("ante.core.database.Database", db_cls),
+            patch("ante.cli.main.get_db_path", return_value="/tmp/unused-approval.db"),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "approval",
+                    "list",
+                    "--status",
+                    "bogus_status",
+                    "--type",
+                    "bogus_type",
+                ],
+            )
+        assert result.exit_code == 1, result.output
+        data = json.loads(result.output.strip())
+        assert data["code"] == "APPROVAL_INVALID_STATUS"
+        db_cls.assert_not_called()
+
+
+class TestApprovalListValidFilters:
+    """`approval list` valid status/type은 회귀 없이 정상 동작 (#1462)."""
+
+    def test_approval_list_valid_status_still_works(self, runner, tmp_path) -> None:
+        """valid `--status`는 preflight 통과 후 ApprovalService.list_approvals 호출."""
+        db_cls, service_cls, service = _mock_service_layer([])
+        db_path = str(tmp_path / "approval.db")
+        with (
+            patch("ante.core.database.Database", db_cls),
+            patch("ante.approval.ApprovalService", service_cls),
+            patch("ante.cli.main.get_db_path", return_value=db_path),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "approval",
+                    "list",
+                    "--status",
+                    "pending",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        db_cls.assert_called_once_with(db_path)
+        service.list_approvals.assert_awaited_once_with(status="pending", type=None)
+
+    def test_approval_list_valid_type_still_works(self, runner, tmp_path) -> None:
+        """valid `--type`은 preflight 통과 후 ApprovalService.list_approvals 호출."""
+        db_cls, service_cls, service = _mock_service_layer([])
+        db_path = str(tmp_path / "approval.db")
+        with (
+            patch("ante.core.database.Database", db_cls),
+            patch("ante.approval.ApprovalService", service_cls),
+            patch("ante.cli.main.get_db_path", return_value=db_path),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "approval",
+                    "list",
+                    "--type",
+                    "strategy_adopt",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        service.list_approvals.assert_awaited_once_with(
+            status=None, type="strategy_adopt"
+        )
+
+    def test_approval_list_no_filter_still_works(self, runner, tmp_path) -> None:
+        """필터 미지정 시 status=None, type=None으로 호출."""
+        db_cls, service_cls, service = _mock_service_layer([])
+        db_path = str(tmp_path / "approval.db")
+        with (
+            patch("ante.core.database.Database", db_cls),
+            patch("ante.approval.ApprovalService", service_cls),
+            patch("ante.cli.main.get_db_path", return_value=db_path),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "approval", "list"],
+            )
+        assert result.exit_code == 0, result.output
+        service.list_approvals.assert_awaited_once_with(status=None, type=None)

--- a/tests/unit/test_cli_report_list_filters.py
+++ b/tests/unit/test_cli_report_list_filters.py
@@ -1,0 +1,175 @@
+"""CLI ``report list`` invalid `--status` preflight 회귀 테스트 (#1462).
+
+`ante --format json report list --status <invalid>`가 Python traceback 없이
+flat JSON error (`REPORT_INVALID_STATUS`)로 종료하고, DB 접속
+(`ante.core.database.Database`)이 일어나기 전에 차단되는지 검증한다.
+
+또한 `report list --help`가 6개 ReportStatus 값
+(`draft/submitted/reviewed/adopted/rejected/archived`)을 안내하는지 회귀 보호한다.
+
+SSOT:
+- enum: ``src/ante/report/models.py::ReportStatus``
+- 패턴: ``src/ante/cli/commands/strategy.py:204-210``
+- 계약: ``docs/specs/cli/02-design-decisions.md`` (structured error)
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+from ante.report.models import ReportStatus
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """auth bypass가 적용된 CliRunner."""
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _mock_store_layer(reports=None):
+    """`Database` + `ReportStore` 생성자 patch 헬퍼."""
+    db = MagicMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    db_cls = MagicMock(return_value=db)
+
+    store = MagicMock()
+    store.initialize = AsyncMock()
+    store.list_reports = AsyncMock(return_value=reports or [])
+    # ``from ante.report import ReportStore`` 가 패치된 ReportStore class를 받아야
+    # 한다. 호출 시 store 인스턴스를 반환한다.
+    store_cls = MagicMock(return_value=store)
+
+    return db_cls, store_cls, store
+
+
+class TestReportListInvalidPreflight:
+    """`report list` invalid `--status` → DB 접속 전 차단 (#1462)."""
+
+    def test_report_list_invalid_status_rejected_before_db(self, runner) -> None:
+        """invalid `--status`는 `Database` 생성 전 차단된다.
+
+        ReportStatus enum (SSOT)에 없는 값이 들어오면 preflight가
+        `REPORT_INVALID_STATUS` 구조화 에러로 종료시키며, DB 생성자는
+        호출되지 않아야 한다.
+        """
+        db_cls = MagicMock()
+        with (
+            patch("ante.core.database.Database", db_cls),
+            patch("ante.cli.main.get_db_path", return_value="/tmp/unused-report.db"),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "list",
+                    "--status",
+                    "oracle_invalid_status",
+                ],
+            )
+        assert result.exit_code == 1, result.output
+        data = json.loads(result.output.strip())
+        assert data["status"] == "error"
+        assert data["code"] == "REPORT_INVALID_STATUS"
+        assert "oracle_invalid_status" in data["message"]
+        assert "Traceback" not in result.output
+        db_cls.assert_not_called()
+
+
+class TestReportListValidStatus:
+    """`report list` valid `--status`는 회귀 없이 정상 동작 (#1462)."""
+
+    def test_report_list_valid_status_still_works(self, runner, tmp_path) -> None:
+        """valid `--status`는 preflight 통과 후 ReportStore.list_reports 호출."""
+        db_cls, store_cls, store = _mock_store_layer([])
+        db_path = str(tmp_path / "report.db")
+        with (
+            patch("ante.core.database.Database", db_cls),
+            patch("ante.report.ReportStore", store_cls),
+            patch("ante.cli.main.get_db_path", return_value=db_path),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "list",
+                    "--status",
+                    "submitted",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        db_cls.assert_called_once_with(db_path)
+        store.list_reports.assert_awaited_once_with(
+            status=ReportStatus.SUBMITTED,
+        )
+
+    def test_report_list_no_status_still_works(self, runner, tmp_path) -> None:
+        """`--status` 미지정 시 ReportStore.list_reports(status=None) 호출."""
+        db_cls, store_cls, store = _mock_store_layer([])
+        db_path = str(tmp_path / "report.db")
+        with (
+            patch("ante.core.database.Database", db_cls),
+            patch("ante.report.ReportStore", store_cls),
+            patch("ante.cli.main.get_db_path", return_value=db_path),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "report", "list"],
+            )
+        assert result.exit_code == 0, result.output
+        store.list_reports.assert_awaited_once_with(status=None)
+
+
+class TestReportListHelpString:
+    """`report list --help`가 ReportStatus 6개 값을 안내 (#1462)."""
+
+    def test_help_lists_all_six_statuses(self, runner) -> None:
+        """help 문자열은 ReportStatus enum 값 6개를 모두 포함한다."""
+        result = runner.invoke(cli, ["report", "list", "--help"])
+        assert result.exit_code == 0, result.output
+        expected = (
+            "draft",
+            "submitted",
+            "reviewed",
+            "adopted",
+            "rejected",
+            "archived",
+        )
+        for value in expected:
+            assert value in result.output, (
+                f"`report list --help`에 '{value}' status가 없습니다: {result.output}"
+            )


### PR DESCRIPTION
Closes #1462

## Summary
- `account list`, `approval list`, `report list`의 enum 필터(`--status`, `approval --type`) 검증을 DB 접속 전 preflight로 이동. invalid 값은 traceback 없이 structured error로 닫힘 (exit code 1).
- enum 모델(`AccountStatus`, `ApprovalStatus`/`ApprovalType`, `ReportStatus`)을 각 CLI 모듈 상단에서 직접 import (#1502 이후 strategy.py 패턴과 동일).
- `report list --status` help을 `ReportStatus` 6개 실제 값(`draft/submitted/reviewed/adopted/rejected/archived`)과 정렬.
- error code: `ACCOUNT_INVALID_STATUS` / `APPROVAL_INVALID_STATUS` / `APPROVAL_INVALID_TYPE` / `REPORT_INVALID_STATUS`.
- 회귀 테스트가 `Database`/`_create_account_service` 생성자가 호출되지 않음을 `assert_not_called`로 보증.

## Test Plan
- `ruff check ... && ruff format --check ...` — PASS
- `pytest tests/unit -k "account_list or approval_list or report_list" -v` — 14 passed
- `pytest tests/unit/test_cli_strategy_list_invalid_status.py -v` — 9 passed (#1461 회귀)
- `pytest tests/unit/test_cli_dependency_isolation.py -v` — 23 passed (heavy import 회귀, #1464)
- `pytest tests/unit/test_account_cli.py -v` — 51 passed

## Plan Preflight
- verdict: approve-implement (v2)
- 이슈 본문 Implementation Plan v2 기준. Codex 브랜치 리뷰 PASS, blocking findings 없음.

## Out of Scope
- `bot list` (`--status` 옵션 없음)
- `member list` (이미 `click.Choice` preflight)
- `strategy list` (#1461/#1502 처리 완료)
- `ApprovalService.list_approvals` 내부 검증 (별도 이슈 후보)

🤖 Generated with [Claude Code](https://claude.com/claude-code)