### PR TITLE
fix(account): tolerant load + cold-path repair for legacy invalid timezone

### DIFF
--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -85,6 +85,7 @@ allowlist 후보에서 제거한다.
 | `ante account create --broker-type <type> --account-id <id> --name <name> --trading-mode virtual\|live ...` | `cold-path` | 서버 실행 중 차단 |
 | `ante account set-credentials <account_id> ...` | `cold-path` | 서버 실행 중 차단 |
 | `ante account delete <account_id> --yes` | `cold-path` | 서버 실행 중 차단 |
+| `ante account repair-timezone <account_id> <new_timezone>` | `cold-path` | 서버 실행 중 차단 |
 | `ante account suspend <account_id> --reason <reason>` | `runtime IPC` | 서버 AccountService + EventBus |
 | `ante account activate <account_id>` | `runtime IPC` | 서버 AccountService + EventBus |
 | `ante bot list [--account <account_id>]` | `runtime IPC + snapshot fallback` | 서버 BotManager live 조회 우선 |
@@ -174,6 +175,7 @@ ante account set-credentials <account_id> \
 ante account suspend <account_id> --reason <사유>  # 계좌 거래 정지
 ante account activate <account_id>            # 계좌 거래 재개
 ante account delete <account_id> --yes        # 계좌 삭제 (cold-path 전용, 연결된 봇이 없을 때만)
+ante account repair-timezone <account_id> <new_timezone>  # legacy invalid IANA timezone 행 복구 (cold-path 전용)
 ```
 
 `account create/delete/set-credentials`는 계좌 topology 또는 브로커 초기화 입력을 바꾸므로

--- a/src/ante/account/models.py
+++ b/src/ante/account/models.py
@@ -39,6 +39,14 @@ class Account:
     exchange: str
     currency: str
     timezone: str = "Asia/Seoul"
+    # legacy DB row 가 invalid IANA timezone 으로 저장돼 있을 때 ``True`` 로
+    # 표시하는 marker. ``_row_to_account`` 는 stored value 를 절대 덮어쓰지
+    # 않고 그대로 보존하면서 marker 만 세팅하므로, 후속 ``AccountService.update``
+    # 의 전체 row UPDATE 가 silent data rewrite 를 일으키지 않는다.
+    # 운영자는 ``ante account repair-timezone`` (cold-path) 명령으로 valid
+    # 값으로 복구한다. ``__post_init__`` hard validation 은 호환을 위해
+    # 적용하지 않는다 (#1474).
+    timezone_invalid: bool = False
     trading_hours_start: str = "09:00"
     trading_hours_end: str = "15:30"
 

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -124,6 +124,39 @@ STRUCTURAL_FIELDS: frozenset[str] = frozenset(
 )
 
 
+def _load_persisted_timezone(stored_tz: str, account_id: str) -> tuple[str, bool]:
+    """저장된 timezone 값을 tolerant load 하고 ``timezone_invalid`` marker 반환.
+
+    Read-path (``_row_to_account``) 에서 호출된다. 저장된 ``stored_tz`` 가
+    유효한 IANA timezone key 이면 ``(stored_tz, False)`` 를 그대로 반환한다.
+    invalid 이면 **fallback 으로 덮어쓰지 않고** stored value 를 그대로
+    반환하면서 marker 를 ``True`` 로 세팅한다. 이는 후속
+    ``AccountService.update`` 의 전체 row UPDATE 가 stored invalid 값을
+    silent 하게 default 로 rewrite 하는 회귀를 막기 위한 것이다 (#1474).
+
+    invalid 일 때 ``ACCOUNT_INVALID_TIMEZONE_LEGACY`` 검색 가능 코드를
+    포함한 structured warning 을 한 번 남기고, 운영자에게 cold-path repair
+    명령을 안내한다. 본 헬퍼는 발견 시점마다 warning 을 남기며,
+    ``AccountService.initialize`` 는 별도로 누적 account_ids 요약을 한 줄
+    더 기록한다.
+    """
+    try:
+        validate_iana_timezone(stored_tz)
+    except ValueError as e:
+        logger.warning(
+            "ACCOUNT_INVALID_TIMEZONE_LEGACY: invalid timezone in stored "
+            "account row (legacy migration 필요): account_id=%s stored=%r — %s. "
+            "Repair: `ante account repair-timezone %s <new_iana_timezone>` "
+            "(cold-path).",
+            account_id,
+            stored_tz,
+            e,
+            account_id,
+        )
+        return stored_tz, True
+    return stored_tz, False
+
+
 class AccountService:
     """계좌 CRUD, 상태 관리, 브로커 인스턴스 생성."""
 
@@ -185,10 +218,23 @@ class AccountService:
             "SELECT * FROM accounts WHERE status != ?",
             (AccountStatus.DELETED,),
         )
+        invalid_timezone_account_ids: list[str] = []
         for row in rows:
             account = _row_to_account(row)
+            if account.timezone_invalid:
+                invalid_timezone_account_ids.append(account.account_id)
             self._accounts[account.account_id] = account
         logger.info("AccountService 초기화 완료: %d개 계좌 로드", len(self._accounts))
+        # legacy invalid timezone row 누적 요약 (#1474). load loop 가 끝난 뒤
+        # 한 줄로만 남겨 운영자가 ``rg ACCOUNT_INVALID_TIMEZONE_LEGACY summary``
+        # 같은 grep 으로 회수할 수 있게 한다. count 가 0 일 때는 noise 회피를
+        # 위해 출력하지 않는다.
+        if invalid_timezone_account_ids:
+            logger.warning(
+                "ACCOUNT_INVALID_TIMEZONE_LEGACY summary: count=%d, account_ids=%s",
+                len(invalid_timezone_account_ids),
+                sorted(invalid_timezone_account_ids),
+            )
 
     # ── CRUD ──────────────────────────────────────────
 
@@ -510,10 +556,18 @@ class AccountService:
             "sell_commission_rate",
         }
         invalidate_broker = bool(set(fields.keys()) & broker_invalidating)
+        # ``timezone`` 키가 fields 에 **명시적으로** 들어왔을 때만 marker 를
+        # 리셋한다. 다른 필드만 수정되는 경우에는 stored marker (그리고
+        # stored invalid timezone 자체) 를 그대로 보존해야 silent data
+        # rewrite 가 일어나지 않는다 (#1474). ``timezone_update is None``
+        # (key 자체가 없는 경우) 은 정상 시나리오로 marker 보존.
+        timezone_explicit_update = "timezone" in fields and timezone_update is not None
         for key, value in fields.items():
             if key not in updatable:
                 continue
             setattr(account, key, value)
+        if timezone_explicit_update:
+            account.timezone_invalid = False
 
         now = datetime.now(UTC)
         account.updated_at = now
@@ -551,6 +605,41 @@ class AccountService:
             await self._reconnect_broker(account_id)
         logger.info("계좌 수정: %s", account_id)
         return account
+
+    async def repair_timezone(self, account_id: str, new_timezone: str) -> Account:
+        """legacy invalid IANA timezone row 를 valid 값으로 복구 (**cold-path**).
+
+        ``_row_to_account`` 의 tolerant load 는 stored invalid timezone 을
+        보존하면서 ``Account.timezone_invalid=True`` marker 를 노출한다.
+        본 메서드는 운영자가 ``ante account repair-timezone`` (cold-path
+        CLI) 으로 명시 입력한 valid IANA timezone 으로 DB 와 캐시를
+        갱신하는 단일 진입점이다.
+
+        cold-path 의미론: 서버 runtime 중에는
+        ``AccountStructuralChangeRequiresStoppedServerError`` 로 즉시
+        차단된다. ``update()`` 자체는 timezone 을 updatable field 로
+        허용하므로 cold-path 보장이 본 메서드 책임이다. ingress 검증과
+        DB/캐시 UPDATE 는 ``update(timezone=...)`` 에 위임하여 single
+        SSOT 를 유지한다 (별도 DB UPDATE 중복 금지).
+
+        Raises:
+            AccountStructuralChangeRequiresStoppedServerError: 서버 실행 중
+                호출됨.
+            ValueError: ``new_timezone`` 이 invalid IANA key
+                (``validate_iana_timezone`` 위임).
+            AccountNotFoundError, AccountDeletedException: ``update()`` 와
+                동일.
+        """
+        # cold-path guard: server runtime 중에는 직접 DB 수정을 차단.
+        # AccountService.update 는 timezone 을 updatable 로 허용하므로 본
+        # 메서드 책임으로 cold-path 의미론을 보장한다 (#1474).
+        if self._runtime_started:
+            raise AccountStructuralChangeRequiresStoppedServerError(
+                "account.repair_timezone is a cold-path operation; "
+                "stop the server before invoking this command."
+            )
+        # ingress 검증과 DB/캐시 UPDATE 는 update() 위임 (중복 구현 금지).
+        return await self.update(account_id, timezone=new_timezone)
 
     async def _reconnect_broker(self, account_id: str) -> None:
         """새 브로커 어댑터를 생성·연결한 뒤에만 캐시를 교체한다.
@@ -970,12 +1059,19 @@ def _row_to_account(row: dict[str, Any]) -> Account:
     buffer_raw = row.get("market_order_reserve_buffer_rate", "0")
     buffer_value = Decimal("0") if buffer_raw is None else Decimal(str(buffer_raw))
 
+    # legacy DB row 의 invalid IANA timezone 을 tolerant load 한다 (#1474).
+    # stored value 는 그대로 보존하고 marker 만 세팅한다. fallback 으로
+    # 덮어쓰면 후속 ``AccountService.update`` 의 전체 row UPDATE 가 silent
+    # data rewrite 를 일으킨다.
+    tz_value, tz_invalid = _load_persisted_timezone(row["timezone"], row["account_id"])
+
     return Account(
         account_id=row["account_id"],
         name=row["name"],
         exchange=row["exchange"],
         currency=row["currency"],
-        timezone=row["timezone"],
+        timezone=tz_value,
+        timezone_invalid=tz_invalid,
         trading_hours_start=row["trading_hours_start"],
         trading_hours_end=row["trading_hours_end"],
         trading_mode=TradingMode(row["trading_mode"]),

--- a/src/ante/cli/commands/account.py
+++ b/src/ante/cli/commands/account.py
@@ -961,6 +961,96 @@ def account_set_credentials(
         raise SystemExit(1) from e
 
 
+# ── repair-timezone ──────────────────────────────────────
+
+
+@account.command("repair-timezone")
+@click.argument("account_id")
+@click.argument("new_timezone")
+@format_option
+@click.pass_context
+@require_auth
+@require_scope("account:write")
+def account_repair_timezone(
+    ctx: click.Context, account_id: str, new_timezone: str
+) -> None:
+    """legacy invalid IANA timezone 계좌를 복구한다 (cold-path 전용, #1474).
+
+    ``_row_to_account`` 가 stored invalid timezone 을 보존하면서
+    ``Account.timezone_invalid`` marker 를 노출한 row 를 운영자가 명시한
+    valid IANA timezone 으로 갱신한다. 내부적으로
+    ``AccountService.repair_timezone`` → ``update(timezone=...)`` 으로
+    위임하며, cold-path 의미론 (서버 정지 필요) 은 본 CLI 와 service
+    boundary 양쪽에서 차단한다.
+
+    실패 코드:
+
+    - ``ACCOUNT_RUNTIME_ACTIVE`` 또는
+      ``ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER``: 서버 실행 중
+      차단 (cold-path).
+    - ``ACCOUNT_INVALID_TIMEZONE``: ``new_timezone`` 이 IANA 등록 누락.
+    - ``ACCOUNT_NOT_FOUND``: ``account_id`` 가 존재하지 않음.
+    """
+    fmt = get_formatter(ctx)
+
+    # cold-path: active runtime이 있으면 진입 직후 차단한다.
+    # ``_create_account_service`` 자체가 호출되지 않아야 한다.
+    _assert_no_active_runtime(fmt)
+
+    from ante.account.errors import (
+        AccountDeletedError,
+        AccountNotFoundError,
+        AccountStructuralChangeRequiresStoppedServerError,
+    )
+
+    async def _do_repair() -> Account:
+        svc, db = await _create_account_service()
+        try:
+            return await svc.repair_timezone(account_id, new_timezone)
+        finally:
+            await db.close()
+
+    try:
+        repaired = _run(_do_repair())
+    except ValueError as e:
+        # validate_iana_timezone 위임 실패. invalid IANA key 만 본 경로로
+        # 들어온다 (account_id 형식 검증은 ``update`` 가 별도 코드로 raise
+        # 하지 않으므로 ValueError 만 invalid timezone 으로 매핑한다).
+        _exit_with_error(
+            fmt,
+            "ACCOUNT_INVALID_TIMEZONE",
+            f"invalid IANA timezone: {new_timezone!r} — {e}",
+        )
+    except AccountStructuralChangeRequiresStoppedServerError as e:
+        # service-layer defense-in-depth (CLI guard 우회 시).
+        fmt.error(
+            str(e),
+            code="ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER",
+        )
+        raise SystemExit(1) from e
+    except AccountNotFoundError as e:
+        fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
+        raise SystemExit(1) from e
+    except AccountDeletedError as e:
+        fmt.error(str(e), code="ACCOUNT_ALREADY_DELETED")
+        raise SystemExit(1) from e
+    except click.ClickException:
+        raise
+    except Exception as e:
+        fmt.error(str(e))
+        raise SystemExit(1) from e
+
+    fmt.success(
+        f'계좌 "{repaired.account_id}" timezone 복구 완료 ({repaired.timezone})',
+        data={
+            "code": "ACCOUNT_REPAIR_TIMEZONE_OK",
+            "account_id": repaired.account_id,
+            "timezone": repaired.timezone,
+            "timezone_invalid": repaired.timezone_invalid,
+        },
+    )
+
+
 # ── 유틸리티 ──────────────────────────────────────
 
 

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -1205,3 +1205,289 @@ async def test_create_default_test_account_uses_preset_buffer(service) -> None:
     """
     acct = await service.create_default_test_account()
     assert acct.market_order_reserve_buffer_rate == Decimal("0")
+
+
+# ── legacy invalid timezone tolerant load + repair (#1474) ──────────
+
+
+async def _seed_invalid_timezone_row(
+    db,
+    *,
+    account_id: str = "legacy-tz",
+    timezone: str = "Mars/Olympus",
+    name: str = "레거시",
+    status: str = "active",
+) -> None:
+    """invalid IANA timezone 으로 DB row 를 직접 삽입하는 helper.
+
+    ``AccountService.create`` 는 ingress 검증 (#1473) 으로 invalid 입력을
+    거부하므로, legacy 환경 재현을 위해 raw SQL 로 row 를 심는다. crypto
+    credentials 인코딩은 service.create 가 사용하는 ``encrypt_credentials``
+    를 재사용해 같은 직렬화 계약을 유지한다 (#1474).
+    """
+    from datetime import UTC, datetime
+
+    from ante.account.crypto import encrypt_credentials
+
+    now = datetime.now(UTC).isoformat()
+    await db.execute(
+        """INSERT INTO accounts
+           (account_id, name, exchange, currency, timezone,
+            trading_hours_start, trading_hours_end, trading_mode,
+            broker_type, credentials, broker_config,
+            buy_commission_rate, sell_commission_rate,
+            market_order_reserve_buffer_rate,
+            status, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            account_id,
+            name,
+            "TEST",
+            "KRW",
+            timezone,
+            "09:00",
+            "15:30",
+            "virtual",
+            "test",
+            encrypt_credentials({"app_key": "k", "app_secret": "s"}),
+            "{}",
+            0.0,
+            0.0,
+            0.0,
+            status,
+            now,
+            now,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_invalid_timezone_preserves_stored_value_with_marker(
+    db, eventbus, caplog
+) -> None:
+    """legacy invalid timezone row 가 stored value 보존 + marker 로 노출된다 (#1474).
+
+    initialize 가 crash 없이 완료되고, 로드된 Account 의 ``timezone`` 은
+    stored ``"Mars/Olympus"`` 그대로 보존된다 — fallback ``"Asia/Seoul"``
+    로 덮어쓰면 후속 ``update()`` 의 전체 row UPDATE 가 silent data
+    rewrite 를 일으키므로 절대 안 된다.
+    """
+    import logging
+
+    svc = AccountService(db, eventbus)
+    await svc.initialize()
+    await _seed_invalid_timezone_row(db, account_id="legacy-tz")
+
+    with caplog.at_level(logging.WARNING, logger="ante.account.service"):
+        svc2 = AccountService(db, eventbus)
+        await svc2.initialize()
+
+    acct = await svc2.get("legacy-tz")
+    assert acct.timezone == "Mars/Olympus"
+    assert acct.timezone_invalid is True
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("ACCOUNT_INVALID_TIMEZONE_LEGACY" in m for m in messages)
+    assert any("legacy-tz" in m for m in messages)
+    assert any("ante account repair-timezone" in m for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_initialize_summary_for_mixed_rows(db, eventbus, caplog) -> None:
+    """invalid 와 valid 행이 섞여도 모두 load 되고 summary 한 줄이 남는다 (#1474)."""
+    import logging
+
+    svc = AccountService(db, eventbus)
+    await svc.initialize()
+    await svc.create(_make_account("good-1"))
+    await svc.create(_make_account("good-2"))
+    await _seed_invalid_timezone_row(db, account_id="bad-a", timezone="Mars/Olympus")
+    await _seed_invalid_timezone_row(db, account_id="bad-b", timezone="Foo/Bar")
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="ante.account.service"):
+        svc2 = AccountService(db, eventbus)
+        await svc2.initialize()
+
+    # 모든 4 계좌 load
+    assert len(await svc2.list()) == 4
+
+    summary_lines = [
+        r.getMessage()
+        for r in caplog.records
+        if "ACCOUNT_INVALID_TIMEZONE_LEGACY summary" in r.getMessage()
+    ]
+    assert len(summary_lines) == 1
+    summary = summary_lines[0]
+    assert "count=2" in summary
+    assert "bad-a" in summary
+    assert "bad-b" in summary
+
+
+@pytest.mark.asyncio
+async def test_get_non_cached_invalid_row_preserves_marker(db, eventbus) -> None:
+    """cache miss 경로(``get`` DB fetch) 에서도 marker 가 유지된다 (#1474).
+
+    invalid row 를 ACTIVE 상태로 심고 service 인스턴스를 새로 만든 뒤
+    캐시에 없는 별도의 DELETED row 를 ``get`` 으로 조회하면 DB fetch
+    경로(``_row_to_account``) 에서도 stored value + marker 가 그대로
+    노출돼야 한다.
+    """
+    svc = AccountService(db, eventbus)
+    await svc.initialize()
+    # DELETED 상태 invalid row — initialize 가 캐시에 올리지 않으므로 get()
+    # 호출 시 반드시 DB fetch 경로를 탄다.
+    await _seed_invalid_timezone_row(
+        db, account_id="deleted-tz", timezone="Mars/Olympus", status="deleted"
+    )
+
+    svc2 = AccountService(db, eventbus)
+    await svc2.initialize()
+    assert "deleted-tz" not in svc2._accounts  # cache miss 보장
+
+    acct = await svc2.get("deleted-tz")
+    assert acct.timezone == "Mars/Olympus"
+    assert acct.timezone_invalid is True
+    assert acct.status == AccountStatus.DELETED
+
+
+@pytest.mark.asyncio
+async def test_list_status_deleted_invalid_row_preserves_marker(db, eventbus) -> None:
+    """``list(status=DELETED)`` (DB 직접 조회) 경로도 marker 를 보존한다 (#1474)."""
+    svc = AccountService(db, eventbus)
+    await svc.initialize()
+    await _seed_invalid_timezone_row(
+        db, account_id="deleted-tz", timezone="Mars/Olympus", status="deleted"
+    )
+
+    svc2 = AccountService(db, eventbus)
+    await svc2.initialize()
+    deleted = await svc2.list(status=AccountStatus.DELETED)
+    assert len(deleted) == 1
+    assert deleted[0].account_id == "deleted-tz"
+    assert deleted[0].timezone == "Mars/Olympus"
+    assert deleted[0].timezone_invalid is True
+
+
+@pytest.mark.asyncio
+async def test_update_unrelated_field_preserves_invalid_timezone(db, eventbus) -> None:
+    """invalid row 의 무관 필드(name) update 시 DB stored timezone 이 보존된다 (#1474).
+
+    silent data rewrite 회귀 회피: 전체 row UPDATE 가 stored
+    ``Mars/Olympus`` 를 default 로 덮어쓰면 안 된다.
+    """
+    svc = AccountService(db, eventbus)
+    await svc.initialize()
+    await _seed_invalid_timezone_row(db, account_id="legacy-tz")
+
+    svc2 = AccountService(db, eventbus)
+    await svc2.initialize()
+
+    updated = await svc2.update("legacy-tz", name="새 이름")
+    assert updated.name == "새 이름"
+    assert updated.timezone == "Mars/Olympus"
+    assert updated.timezone_invalid is True
+
+    # DB stored value 가 그대로인지 raw 조회로 확인 — 전체 row UPDATE 가
+    # ``account.timezone`` (stored) 을 그대로 다시 썼는지 검증.
+    row = await db.fetch_one(
+        "SELECT timezone FROM accounts WHERE account_id = ?",
+        ("legacy-tz",),
+    )
+    assert row["timezone"] == "Mars/Olympus"
+
+    # 새 service 인스턴스로 다시 로드해도 marker 가 살아 있어야 한다.
+    svc3 = AccountService(db, eventbus)
+    await svc3.initialize()
+    reloaded = await svc3.get("legacy-tz")
+    assert reloaded.timezone == "Mars/Olympus"
+    assert reloaded.timezone_invalid is True
+
+
+@pytest.mark.asyncio
+async def test_update_timezone_explicit_resets_marker(db, eventbus) -> None:
+    """timezone 을 명시적으로 update 하면 marker 가 False 로 리셋된다 (#1474)."""
+    svc = AccountService(db, eventbus)
+    await svc.initialize()
+    await _seed_invalid_timezone_row(db, account_id="legacy-tz")
+
+    svc2 = AccountService(db, eventbus)
+    await svc2.initialize()
+
+    updated = await svc2.update("legacy-tz", timezone="Asia/Tokyo")
+    assert updated.timezone == "Asia/Tokyo"
+    assert updated.timezone_invalid is False
+
+    row = await db.fetch_one(
+        "SELECT timezone FROM accounts WHERE account_id = ?",
+        ("legacy-tz",),
+    )
+    assert row["timezone"] == "Asia/Tokyo"
+
+
+@pytest.mark.asyncio
+async def test_repair_timezone_delegates_to_update(db, eventbus) -> None:
+    """``repair_timezone`` 이 ``update(timezone=...)`` 과 동등한 결과를 낸다 (#1474)."""
+    svc = AccountService(db, eventbus)
+    await svc.initialize()
+    await _seed_invalid_timezone_row(db, account_id="legacy-tz")
+
+    svc2 = AccountService(db, eventbus)
+    await svc2.initialize()
+
+    repaired = await svc2.repair_timezone("legacy-tz", "America/New_York")
+    assert repaired.timezone == "America/New_York"
+    assert repaired.timezone_invalid is False
+
+    row = await db.fetch_one(
+        "SELECT timezone FROM accounts WHERE account_id = ?",
+        ("legacy-tz",),
+    )
+    assert row["timezone"] == "America/New_York"
+
+
+@pytest.mark.asyncio
+async def test_repair_timezone_invalid_input_rejected(db, eventbus) -> None:
+    """invalid IANA 입력은 ``ValueError`` 로 거부된다 (#1474 — #1473 ingress 재사용)."""
+    svc = AccountService(db, eventbus)
+    await svc.initialize()
+    await _seed_invalid_timezone_row(db, account_id="legacy-tz")
+
+    svc2 = AccountService(db, eventbus)
+    await svc2.initialize()
+
+    with pytest.raises(ValueError, match="invalid IANA timezone"):
+        await svc2.repair_timezone("legacy-tz", "Mars/Olympus")
+
+    # DB 의 stored 값이 그대로 보존됐는지 확인.
+    row = await db.fetch_one(
+        "SELECT timezone FROM accounts WHERE account_id = ?",
+        ("legacy-tz",),
+    )
+    assert row["timezone"] == "Mars/Olympus"
+
+
+@pytest.mark.asyncio
+async def test_repair_timezone_runtime_started_blocked(db, eventbus) -> None:
+    """runtime 시작 후에는 cold-path guard 가 즉시 차단한다 (#1474)."""
+    from ante.account.errors import (
+        AccountStructuralChangeRequiresStoppedServerError,
+    )
+
+    svc = AccountService(db, eventbus)
+    await svc.initialize()
+    await _seed_invalid_timezone_row(db, account_id="legacy-tz")
+
+    svc2 = AccountService(db, eventbus)
+    await svc2.initialize()
+    svc2.mark_runtime_started()
+
+    with pytest.raises(AccountStructuralChangeRequiresStoppedServerError):
+        await svc2.repair_timezone("legacy-tz", "Asia/Tokyo")
+
+    # DB 가 변경되지 않았는지 검증.
+    row = await db.fetch_one(
+        "SELECT timezone FROM accounts WHERE account_id = ?",
+        ("legacy-tz",),
+    )
+    assert row["timezone"] == "Mars/Olympus"

--- a/tests/unit/test_account_cli.py
+++ b/tests/unit/test_account_cli.py
@@ -1240,3 +1240,101 @@ class TestAccountSetCredentialsContract:
             "app_secret": "FILE_SECRET",
             "account_no": "5012XXXX-01",
         }
+
+
+# ── account repair-timezone 테스트 (#1474) ──────────
+
+
+class TestAccountRepairTimezone:
+    """``ante account repair-timezone`` (cold-path) 회귀 테스트."""
+
+    def test_account_repair_timezone_cold_path_success(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """cold-path 에서 valid 입력 → exit 0 + structured success (#1474)."""
+        from decimal import Decimal
+
+        from ante.account.models import Account, AccountStatus, TradingMode
+
+        repaired = Account(
+            account_id="legacy-tz",
+            name="레거시",
+            exchange="TEST",
+            currency="KRW",
+            timezone="Asia/Tokyo",
+            timezone_invalid=False,
+            broker_type="test",
+            status=AccountStatus.ACTIVE,
+            trading_mode=TradingMode.VIRTUAL,
+            credentials={"app_key": "k", "app_secret": "s"},
+            buy_commission_rate=Decimal("0"),
+            sell_commission_rate=Decimal("0"),
+        )
+        mock_account_service.repair_timezone.return_value = repaired
+
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "account",
+                "repair-timezone",
+                "legacy-tz",
+                "Asia/Tokyo",
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["status"] == "ok"
+        assert data["data"]["code"] == "ACCOUNT_REPAIR_TIMEZONE_OK"
+        assert data["data"]["account_id"] == "legacy-tz"
+        assert data["data"]["timezone"] == "Asia/Tokyo"
+        assert data["data"]["timezone_invalid"] is False
+        mock_account_service.repair_timezone.assert_called_once_with(
+            "legacy-tz", "Asia/Tokyo"
+        )
+
+    def test_account_repair_timezone_invalid_input_rejected(
+        self, mock_account_service: AsyncMock, offline_runtime
+    ) -> None:
+        """invalid IANA 입력 → exit 1 + ``ACCOUNT_INVALID_TIMEZONE`` (#1474)."""
+        mock_account_service.repair_timezone.side_effect = ValueError(
+            "invalid IANA timezone: 'Mars/Olympus'"
+        )
+        result = _invoke(
+            [
+                "--format",
+                "json",
+                "account",
+                "repair-timezone",
+                "legacy-tz",
+                "Mars/Olympus",
+            ]
+        )
+        assert result.exit_code == 1
+        data = json.loads(result.output.strip())
+        assert data["status"] == "error"
+        assert data["code"] == "ACCOUNT_INVALID_TIMEZONE"
+        assert "Mars/Olympus" in data["message"]
+
+    def test_account_repair_timezone_active_runtime_blocked(
+        self, active_runtime
+    ) -> None:
+        """active runtime 시 cold-path guard 가 ``_create_account_service`` 호출 이전에
+        차단한다 (#1474). ``account create``/``account delete`` 와 동형 패턴.
+        """
+        mock_create = AsyncMock()
+        with patch(
+            "ante.cli.commands.account._create_account_service",
+            new=mock_create,
+        ):
+            result = _invoke(
+                [
+                    "account",
+                    "repair-timezone",
+                    "legacy-tz",
+                    "Asia/Tokyo",
+                ]
+            )
+        assert result.exit_code == 1
+        assert "ACCOUNT_STRUCTURAL_CHANGE_REQUIRES_STOPPED_SERVER" in result.output
+        mock_create.assert_not_called()


### PR DESCRIPTION
Closes #1474

## Summary
- `Account` dataclass에 `timezone_invalid: bool = False` marker 필드 추가. 기존 생성 경로 호환.
- `_load_persisted_timezone(stored_tz, account_id) -> tuple[str, bool]` module helper로 stored value 그대로 보존 + `validate_iana_timezone` 실패 시 `ACCOUNT_INVALID_TIMEZONE_LEGACY` warning + repair 명령 안내.
- `_row_to_account`이 stored timezone을 그대로 사용하고 marker만 표시 — silent data rewrite 회피.
- `AccountService.initialize`가 누적된 invalid account_ids를 한 줄 summary로 warning.
- `AccountService.update`가 `timezone` 키 명시 수정 시에만 `timezone_invalid=False` 리셋. 다른 필드 수정 시 marker 보존.
- `AccountService.repair_timezone`: `_runtime_started` cold-path guard + `update(timezone=...)` 재사용. 별도 DB UPDATE 중복 없음.
- 신규 CLI `ante account repair-timezone <account_id> <new_timezone>` (cold-path, `_assert_no_active_runtime` guard).
- `docs/specs/cli/03-commands.md` 명령 표/예시에 cold-path 항목 추가.

## Test Plan
- `ruff check && ruff format --check` — PASS (6 files)
- `pytest tests/unit/test_account.py -v` — 87 passed (신규 9 케이스 포함)
- `pytest tests/unit/test_account_cli.py -v` — 54 passed (신규 3 케이스 포함, active_runtime_blocked는 `_create_account_service.assert_not_called()` 검증)
- `pytest tests/unit/test_account_timezone_validation.py -v` — 23 passed (#1473 회귀 미파괴)
- `pytest tests/unit -k "account_service or _row_to_account or repair_timezone or account_repair"` — 15 passed

## Plan Preflight
- verdict: approve-implement (v3)
- 이슈 본문 v3 기준. Codex 브랜치 리뷰 PASS, blocking findings 없음.

## Out of Scope (별도 이슈)
- ingress timezone validation: #1473 (close).
- runtime trading-hours rejection (`TradingHoursRule`): #1475.
- `Account.__post_init__` hard validation.
- `AccountService.update` partial UPDATE refactor.
- runtime IPC handler / HTTP admin endpoint.
- 자동 마이그레이션 (operator-visible `repair-timezone`만).

🤖 Generated with [Claude Code](https://claude.com/claude-code)