### PR TITLE
fix(bot): atomic rollback for BotConfig on budget failure in update_bot

### DIFF
--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -488,17 +488,38 @@ class BotManager:
                 # 둘 다 ``old_config`` 로 rollback. memory rollback 은 단순
                 # 대입이라 raise 가능성이 없으므로 먼저 수행하여 DB rollback
                 # 실패와 무관하게 최소한 메모리 상태는 일관되게 만든다.
-                bot.config = old_config
-                try:
-                    await self._save_bot_config(old_config)
-                except Exception:
-                    # nested rollback failure: 원래 budget 예외를 덮지 않도록
-                    # rollback 실패는 ``logger.exception`` 으로 남기고 bare
-                    # raise 로 원래 예외를 propagate 한다. memory 는 이미
-                    # rollback 된 상태이므로 in-memory 일관성은 유지된다.
-                    logger.exception(
-                        "update_bot rollback DB save failed for bot_id=%s; "
-                        "memory was rolled back but DB may diverge.",
+                #
+                # Concurrent update race 회피: ``treasury.update_budget`` await
+                # 동안 같은 봇에 대한 다른 ``update_bot`` 호출이 끼어들어
+                # ``bot.config`` 를 또 다른 ``new_config`` 로 교체했을 수 있다.
+                # 그 경우 이 요청의 ``old_config`` 로 무조건 rollback 하면 다른
+                # update 의 성공 변경(예: name) 을 덮어쓴다. identity 비교
+                # (``bot.config is new_config``) 로 자기 자신의 변경분만 rollback
+                # 하고, 다른 update 가 끼어든 경우엔 rollback 을 스킵한다.
+                if bot.config is new_config:
+                    bot.config = old_config
+                    try:
+                        await self._save_bot_config(old_config)
+                    except Exception:
+                        # nested rollback failure: 원래 budget 예외를 덮지
+                        # 않도록 rollback 실패는 ``logger.exception`` 으로 남기고
+                        # bare raise 로 원래 예외를 propagate 한다. memory 는
+                        # 이미 rollback 된 상태이므로 in-memory 일관성은
+                        # 유지된다.
+                        logger.exception(
+                            "update_bot rollback DB save failed for bot_id=%s; "
+                            "memory was rolled back but DB may diverge.",
+                            bot_id,
+                        )
+                else:
+                    # 다른 update_bot 이 await 중 끼어들어 bot.config 를 교체한
+                    # 경우. 이 요청의 old_config 로 rollback 하면 그 update 의
+                    # 성공 변경을 덮어쓰므로 memory/DB rollback 모두 스킵하고
+                    # 원래 budget 예외만 propagate 한다.
+                    logger.warning(
+                        "update_bot rollback skipped for bot_id=%s: concurrent "
+                        "update detected (bot.config is not this request's "
+                        "new_config).",
                         bot_id,
                     )
                 raise

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -463,18 +463,45 @@ class BotManager:
         # ``TreasuryNotConfiguredError`` 를 raise 하여 라우트 계층이 422 로
         # 매핑할 수 있도록 한다. ``new_budget is None`` 인 단순 update
         # 경로는 기존과 동일하게 무영향(no-op)이다.
+        #
+        # Refs #1460: budget 처리 실패 시 update_bot 전체가 atomic 하도록
+        # runtime control 변경(memory + DB) 을 ``old_config`` 로 rollback
+        # 한다. TreasuryManager 미주입, account 미등록, treasury.update_budget
+        # 내부 예외, asyncio.CancelledError(요청 취소) 모두 동일하게 rollback
+        # 경로를 탄다. ``treasury.update_budget`` 내부 allocate/deallocate
+        # side effect(예산 부분 commit) 까지는 atomic 보장하지 않는다.
         if new_budget is not None:
-            from ante.treasury.exceptions import TreasuryNotConfiguredError
-
-            if self._treasury_manager is None:
-                raise TreasuryNotConfiguredError("treasury manager not configured")
             try:
-                treasury = self._treasury_manager.get(new_config.account_id)
-            except KeyError as ke:
-                raise TreasuryNotConfiguredError(
-                    f"treasury not configured for account {new_config.account_id}"
-                ) from ke
-            await treasury.update_budget(bot_id, new_budget)
+                from ante.treasury.exceptions import TreasuryNotConfiguredError
+
+                if self._treasury_manager is None:
+                    raise TreasuryNotConfiguredError("treasury manager not configured")
+                try:
+                    treasury = self._treasury_manager.get(new_config.account_id)
+                except KeyError as ke:
+                    raise TreasuryNotConfiguredError(
+                        f"treasury not configured for account {new_config.account_id}"
+                    ) from ke
+                await treasury.update_budget(bot_id, new_budget)
+            except (Exception, asyncio.CancelledError):
+                # Atomicity: budget 실패 시 runtime control 변경을 memory + DB
+                # 둘 다 ``old_config`` 로 rollback. memory rollback 은 단순
+                # 대입이라 raise 가능성이 없으므로 먼저 수행하여 DB rollback
+                # 실패와 무관하게 최소한 메모리 상태는 일관되게 만든다.
+                bot.config = old_config
+                try:
+                    await self._save_bot_config(old_config)
+                except Exception:
+                    # nested rollback failure: 원래 budget 예외를 덮지 않도록
+                    # rollback 실패는 ``logger.exception`` 으로 남기고 bare
+                    # raise 로 원래 예외를 propagate 한다. memory 는 이미
+                    # rollback 된 상태이므로 in-memory 일관성은 유지된다.
+                    logger.exception(
+                        "update_bot rollback DB save failed for bot_id=%s; "
+                        "memory was rolled back but DB may diverge.",
+                        bot_id,
+                    )
+                raise
 
         logger.info("봇 설정 수정: %s (변경: %s)", bot_id, list(updates.keys()))
         return bot

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -482,6 +482,18 @@ class BotManager:
             new_config = BotConfig(**config_fields)  # type: ignore[arg-type]
             bot.config = new_config
 
+            # Refs #1460 (attempt 4): rollback eq 가드용 commit-time snapshot.
+            # ``bot.config`` 와 ``new_config`` 는 같은 객체이므로 같은 lock 을
+            # 쓰지 않는 다른 mutator (예: ``change_strategy``) 가
+            # ``bot.config.<field> = ...`` in-place mutation 을 하면 ``new_config``
+            # 의 필드도 함께 바뀌어 ``bot.config == new_config`` 는 자명하게
+            # True 가 된다. 따라서 commit 시점의 필드값을 별도 객체로 떠두고
+            # rollback 가드에서 그 snapshot 과 ``bot.config`` 를 비교한다.
+            # ``dataclasses.replace`` 는 shallow copy 라서 raise 가능성이 거의
+            # 없는 단순 작업이다 (``BotConfig.__post_init__`` 의 검증은 동일
+            # 필드 값으로 재호출되므로 통과한다).
+            committed_snapshot = dataclasses.replace(new_config)
+
             # DB 갱신
             await self._save_bot_config(new_config)
 
@@ -523,16 +535,30 @@ class BotManager:
                     # DB rollback 실패와 무관하게 최소한 메모리 상태는
                     # 일관되게 만든다.
                     #
-                    # Concurrent update race 회피 (Refs #1460):
-                    # per-bot lock 으로 같은 ``bot_id`` 에 대한 update_bot
-                    # 들이 직렬화되므로 정상 경로에서는 ``bot.config is
-                    # new_config`` 가 True 다. 그러나 외부에서 ``bot.config``
-                    # 를 직접 교체하는 케이스(테스트 / 비정상 코드 경로) 까지
-                    # 방어하기 위해 identity 가드를 안전망으로 유지한다.
-                    # ``bot.config`` 가 이미 다른 객체로 바뀌어 있으면 이
-                    # 요청의 ``old_config`` 로 rollback 하면 그 변경을 덮어쓸
-                    # 수 있으므로 memory/DB rollback 모두 스킵한다.
-                    if bot.config is new_config:
+                    # Atomicity scope (Refs #1460): 본 rollback 은 같은
+                    # ``update_bot`` 호출 내부의 budget 실패 시 ``BotConfig``
+                    # memory/DB 를 원자적으로 되돌린다. 다른 mutator
+                    # (``change_strategy`` / ``assign_strategy`` / ``delete_bot``
+                    # / ``create_bot``) 와의 직렬화는 본 이슈 범위 밖이며,
+                    # 별도 BotManager 동시성 모델 이슈에서 다룬다. 본 가드는
+                    # 다중 safety net 으로 구성된다:
+                    # - per-bot Lock: 같은 ``update_bot`` 호출들의 직렬화.
+                    # - identity check (``bot.config is new_config``): 다른
+                    #   ``update_bot`` 이 끼어들어 ``bot.config`` 를 다른 객체로
+                    #   교체했으면 skip.
+                    # - instance check (``self._bots.get(bot_id) is bot``):
+                    #   ``delete_bot`` (hard) / ``delete_bot`` → ``create_bot``
+                    #   race 시 DB rollback save 를 skip.
+                    # - eq check (``bot.config == committed_snapshot``): 같은
+                    #   lock 을 쓰지 않는 다른 mutator 가 ``bot.config`` 를
+                    #   in-place mutation (예: ``bot.config.strategy_id = "x"``)
+                    #   한 경우, identity 가드는 그대로 True 라서 rollback 이
+                    #   그 변경을 덮어쓸 수 있다. ``bot.config`` 와
+                    #   ``new_config`` 는 같은 객체이므로 ``new_config`` 와의
+                    #   eq 는 자명하게 True 가 되어 in-place 변경을 감지할 수
+                    #   없다. commit 직후에 떠둔 별도 snapshot 객체와의
+                    #   dataclass eq 로 모든 필드가 동등할 때만 rollback 한다.
+                    if bot.config is new_config and bot.config == committed_snapshot:
                         bot.config = old_config
                         # Refs #1460 (attempt 3): DB rollback save 직전에
                         # manager 의 ``_bots`` 메모리 맵에 이 ``bot_id`` 가
@@ -574,7 +600,7 @@ class BotManager:
                                 "(delete/recreate race).",
                                 bot_id,
                             )
-                    else:
+                    elif bot.config is not new_config:
                         # ``bot.config`` 가 외부에 의해 다른 객체로 교체된
                         # 비정상 경로. 이 요청의 old_config 로 rollback 하면
                         # 그 변경을 덮어쓰므로 memory/DB rollback 모두 스킵
@@ -584,6 +610,19 @@ class BotManager:
                             "update_bot rollback skipped for bot_id=%s: "
                             "concurrent update detected (bot.config is not "
                             "this request's new_config).",
+                            bot_id,
+                        )
+                    else:
+                        # identity 는 같지만 eq 는 다른 경로 (attempt 4):
+                        # ``treasury.update_budget`` await 동안 같은 lock 을
+                        # 쓰지 않는 다른 mutator 가 ``bot.config`` 를 in-place
+                        # mutation 한 케이스 (예: ``change_strategy`` /
+                        # ``assign_strategy`` 가 ``bot.config.strategy_id =
+                        # "new"``). 이 요청의 ``old_config`` 로 되돌리면 그
+                        # 변경을 덮어쓰므로 memory/DB rollback 모두 스킵.
+                        logger.warning(
+                            "rollback skipped: bot.config mutated in-place "
+                            "after commit (bot_id=%s).",
                             bot_id,
                         )
                     raise

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -144,6 +144,23 @@ class BotManager:
         self._restart_counts: dict[str, int] = {}
         self._restart_tasks: dict[str, asyncio.Task[None]] = {}
         self._restart_reset_tasks: dict[str, asyncio.Task[None]] = {}
+        # Refs #1460: 같은 ``bot_id`` 에 대한 ``update_bot`` 동시 호출을
+        # 직렬화하기 위한 per-bot asyncio.Lock 저장소. lazy init helper
+        # ``_get_update_lock`` 으로만 노출하여 외부에서 직접 dict 를 만지지
+        # 않도록 한다.
+        self._bot_update_locks: dict[str, asyncio.Lock] = {}
+
+    def _get_update_lock(self, bot_id: str) -> asyncio.Lock:
+        """``update_bot`` 직렬화용 per-bot lock 을 lazy 로 발급한다 (Refs #1460).
+
+        같은 ``bot_id`` 에 대한 ``update_bot`` 호출이 동시에 들어왔을 때
+        runtime control 재생성 → ``_save_bot_config`` → ``treasury.update_budget``
+        시퀀스를 직렬화하여 race 로 인한 atomicity 손상을 막는다. 처음
+        조회되는 ``bot_id`` 에 대해서만 ``asyncio.Lock`` 인스턴스를 생성하고
+        이후 같은 키에는 재사용한다.
+        """
+
+        return self._bot_update_locks.setdefault(bot_id, asyncio.Lock())
 
     async def initialize(self) -> None:
         """스키마 생성 + EventBus 구독 + 잔존 스냅샷 정리."""
@@ -417,115 +434,136 @@ class BotManager:
         Raises:
             BotError: 봇이 중지 상태가 아닌 경우.
         """
-        bot = self._get_bot(bot_id)
-        allowed_statuses = {BotStatus.CREATED, BotStatus.STOPPED, BotStatus.ERROR}
-        if bot.status not in allowed_statuses:
-            raise BotError(
-                f"봇 설정은 중지 상태에서만 수정할 수 있습니다: {bot_id} "
-                f"(현재: {bot.status})"
-            )
+        # Refs #1460: 같은 bot_id 에 대한 update_bot 동시 호출을 직렬화한다.
+        # lock 획득 전에는 ``bot.config`` 가 다른 update_bot 에 의해 임의로
+        # 교체될 수 있으므로 존재 확인과 상태 검증, ``old_config`` 캡처,
+        # ``new_config`` 재생성, save, budget 처리, rollback 모두 lock 안에서
+        # 수행한다. 기존 rollback 의 conditional skip 가드는 lock 이 race 를
+        # 차단하더라도 안전망으로 그대로 유지한다.
+        async with self._get_update_lock(bot_id):
+            # bot 존재/상태 검증을 lock 안에서 (재)수행. lock 획득 전 다른
+            # 코루틴이 봇을 삭제했을 수도 있다.
+            bot = self._get_bot(bot_id)
+            allowed_statuses = {
+                BotStatus.CREATED,
+                BotStatus.STOPPED,
+                BotStatus.ERROR,
+            }
+            if bot.status not in allowed_statuses:
+                raise BotError(
+                    f"봇 설정은 중지 상태에서만 수정할 수 있습니다: {bot_id} "
+                    f"(현재: {bot.status})"
+                )
 
-        # budget은 BotConfig 필드가 아니므로 별도 처리
-        new_budget = kwargs.pop("budget", None)
+            # budget은 BotConfig 필드가 아니므로 별도 처리
+            new_budget = kwargs.pop("budget", None)
 
-        # None이 아닌 값만 필터
-        updates = {k: v for k, v in kwargs.items() if v is not None}
+            # None이 아닌 값만 필터
+            updates = {k: v for k, v in kwargs.items() if v is not None}
 
-        if not updates and new_budget is None:
-            return bot
+            if not updates and new_budget is None:
+                return bot
 
-        # BotConfig 재생성
-        old_config = bot.config
-        config_fields = {
-            "bot_id": old_config.bot_id,
-            "strategy_id": old_config.strategy_id,
-            "name": old_config.name,
-            "account_id": old_config.account_id,
-            "interval_seconds": old_config.interval_seconds,
-            "auto_restart": old_config.auto_restart,
-            "max_restart_attempts": old_config.max_restart_attempts,
-            "restart_cooldown_seconds": old_config.restart_cooldown_seconds,
-            "step_timeout_seconds": old_config.step_timeout_seconds,
-            "max_signals_per_step": old_config.max_signals_per_step,
-        }
-        config_fields.update(updates)
-        new_config = BotConfig(**config_fields)  # type: ignore[arg-type]
-        bot.config = new_config
+            # BotConfig 재생성
+            old_config = bot.config
+            config_fields = {
+                "bot_id": old_config.bot_id,
+                "strategy_id": old_config.strategy_id,
+                "name": old_config.name,
+                "account_id": old_config.account_id,
+                "interval_seconds": old_config.interval_seconds,
+                "auto_restart": old_config.auto_restart,
+                "max_restart_attempts": old_config.max_restart_attempts,
+                "restart_cooldown_seconds": old_config.restart_cooldown_seconds,
+                "step_timeout_seconds": old_config.step_timeout_seconds,
+                "max_signals_per_step": old_config.max_signals_per_step,
+            }
+            config_fields.update(updates)
+            new_config = BotConfig(**config_fields)  # type: ignore[arg-type]
+            bot.config = new_config
 
-        # DB 갱신
-        await self._save_bot_config(new_config)
+            # DB 갱신
+            await self._save_bot_config(new_config)
 
-        # budget 변경 시 Treasury 연동.
-        # Refs #1335: 과거에는 ``new_budget is not None`` 인 경로에서도
-        # ``TreasuryManager`` 부재 / account 미등록을 silent 하게 흘려보내
-        # 호출자(POST /api/bots) 가 budget 배정 실패를 감지하지 못했다.
-        # 이제 budget 배정 의도가 있는 경우(``new_budget is not None``)에는
-        # ``TreasuryNotConfiguredError`` 를 raise 하여 라우트 계층이 422 로
-        # 매핑할 수 있도록 한다. ``new_budget is None`` 인 단순 update
-        # 경로는 기존과 동일하게 무영향(no-op)이다.
-        #
-        # Refs #1460: budget 처리 실패 시 update_bot 전체가 atomic 하도록
-        # runtime control 변경(memory + DB) 을 ``old_config`` 로 rollback
-        # 한다. TreasuryManager 미주입, account 미등록, treasury.update_budget
-        # 내부 예외, asyncio.CancelledError(요청 취소) 모두 동일하게 rollback
-        # 경로를 탄다. ``treasury.update_budget`` 내부 allocate/deallocate
-        # side effect(예산 부분 commit) 까지는 atomic 보장하지 않는다.
-        if new_budget is not None:
-            try:
-                from ante.treasury.exceptions import TreasuryNotConfiguredError
-
-                if self._treasury_manager is None:
-                    raise TreasuryNotConfiguredError("treasury manager not configured")
+            # budget 변경 시 Treasury 연동.
+            # Refs #1335: 과거에는 ``new_budget is not None`` 인 경로에서도
+            # ``TreasuryManager`` 부재 / account 미등록을 silent 하게 흘려보내
+            # 호출자(POST /api/bots) 가 budget 배정 실패를 감지하지 못했다.
+            # 이제 budget 배정 의도가 있는 경우(``new_budget is not None``)에는
+            # ``TreasuryNotConfiguredError`` 를 raise 하여 라우트 계층이 422 로
+            # 매핑할 수 있도록 한다. ``new_budget is None`` 인 단순 update
+            # 경로는 기존과 동일하게 무영향(no-op)이다.
+            #
+            # Refs #1460: budget 처리 실패 시 update_bot 전체가 atomic 하도록
+            # runtime control 변경(memory + DB) 을 ``old_config`` 로 rollback
+            # 한다. TreasuryManager 미주입, account 미등록, treasury.update_budget
+            # 내부 예외, asyncio.CancelledError(요청 취소) 모두 동일하게 rollback
+            # 경로를 탄다. ``treasury.update_budget`` 내부 allocate/deallocate
+            # side effect(예산 부분 commit) 까지는 atomic 보장하지 않는다.
+            if new_budget is not None:
                 try:
-                    treasury = self._treasury_manager.get(new_config.account_id)
-                except KeyError as ke:
-                    raise TreasuryNotConfiguredError(
-                        f"treasury not configured for account {new_config.account_id}"
-                    ) from ke
-                await treasury.update_budget(bot_id, new_budget)
-            except (Exception, asyncio.CancelledError):
-                # Atomicity: budget 실패 시 runtime control 변경을 memory + DB
-                # 둘 다 ``old_config`` 로 rollback. memory rollback 은 단순
-                # 대입이라 raise 가능성이 없으므로 먼저 수행하여 DB rollback
-                # 실패와 무관하게 최소한 메모리 상태는 일관되게 만든다.
-                #
-                # Concurrent update race 회피: ``treasury.update_budget`` await
-                # 동안 같은 봇에 대한 다른 ``update_bot`` 호출이 끼어들어
-                # ``bot.config`` 를 또 다른 ``new_config`` 로 교체했을 수 있다.
-                # 그 경우 이 요청의 ``old_config`` 로 무조건 rollback 하면 다른
-                # update 의 성공 변경(예: name) 을 덮어쓴다. identity 비교
-                # (``bot.config is new_config``) 로 자기 자신의 변경분만 rollback
-                # 하고, 다른 update 가 끼어든 경우엔 rollback 을 스킵한다.
-                if bot.config is new_config:
-                    bot.config = old_config
+                    from ante.treasury.exceptions import TreasuryNotConfiguredError
+
+                    if self._treasury_manager is None:
+                        raise TreasuryNotConfiguredError(
+                            "treasury manager not configured"
+                        )
                     try:
-                        await self._save_bot_config(old_config)
-                    except Exception:
-                        # nested rollback failure: 원래 budget 예외를 덮지
-                        # 않도록 rollback 실패는 ``logger.exception`` 으로 남기고
-                        # bare raise 로 원래 예외를 propagate 한다. memory 는
-                        # 이미 rollback 된 상태이므로 in-memory 일관성은
-                        # 유지된다.
-                        logger.exception(
-                            "update_bot rollback DB save failed for bot_id=%s; "
-                            "memory was rolled back but DB may diverge.",
+                        treasury = self._treasury_manager.get(new_config.account_id)
+                    except KeyError as ke:
+                        raise TreasuryNotConfiguredError(
+                            f"treasury not configured for account "
+                            f"{new_config.account_id}"
+                        ) from ke
+                    await treasury.update_budget(bot_id, new_budget)
+                except (Exception, asyncio.CancelledError):
+                    # Atomicity: budget 실패 시 runtime control 변경을 memory
+                    # + DB 둘 다 ``old_config`` 로 rollback. memory rollback
+                    # 은 단순 대입이라 raise 가능성이 없으므로 먼저 수행하여
+                    # DB rollback 실패와 무관하게 최소한 메모리 상태는
+                    # 일관되게 만든다.
+                    #
+                    # Concurrent update race 회피 (Refs #1460):
+                    # per-bot lock 으로 같은 ``bot_id`` 에 대한 update_bot
+                    # 들이 직렬화되므로 정상 경로에서는 ``bot.config is
+                    # new_config`` 가 True 다. 그러나 외부에서 ``bot.config``
+                    # 를 직접 교체하는 케이스(테스트 / 비정상 코드 경로) 까지
+                    # 방어하기 위해 identity 가드를 안전망으로 유지한다.
+                    # ``bot.config`` 가 이미 다른 객체로 바뀌어 있으면 이
+                    # 요청의 ``old_config`` 로 rollback 하면 그 변경을 덮어쓸
+                    # 수 있으므로 memory/DB rollback 모두 스킵한다.
+                    if bot.config is new_config:
+                        bot.config = old_config
+                        try:
+                            await self._save_bot_config(old_config)
+                        except Exception:
+                            # nested rollback failure: 원래 budget 예외를
+                            # 덮지 않도록 rollback 실패는 ``logger.exception``
+                            # 으로 남기고 bare raise 로 원래 예외를 propagate
+                            # 한다. memory 는 이미 rollback 된 상태이므로
+                            # in-memory 일관성은 유지된다.
+                            logger.exception(
+                                "update_bot rollback DB save failed for "
+                                "bot_id=%s; memory was rolled back but DB "
+                                "may diverge.",
+                                bot_id,
+                            )
+                    else:
+                        # ``bot.config`` 가 외부에 의해 다른 객체로 교체된
+                        # 비정상 경로. 이 요청의 old_config 로 rollback 하면
+                        # 그 변경을 덮어쓰므로 memory/DB rollback 모두 스킵
+                        # 하고 원래 budget 예외만 propagate. lock 도입 후
+                        # 정상 경로에서는 발생하지 않는 안전망.
+                        logger.warning(
+                            "update_bot rollback skipped for bot_id=%s: "
+                            "concurrent update detected (bot.config is not "
+                            "this request's new_config).",
                             bot_id,
                         )
-                else:
-                    # 다른 update_bot 이 await 중 끼어들어 bot.config 를 교체한
-                    # 경우. 이 요청의 old_config 로 rollback 하면 그 update 의
-                    # 성공 변경을 덮어쓰므로 memory/DB rollback 모두 스킵하고
-                    # 원래 budget 예외만 propagate 한다.
-                    logger.warning(
-                        "update_bot rollback skipped for bot_id=%s: concurrent "
-                        "update detected (bot.config is not this request's "
-                        "new_config).",
-                        bot_id,
-                    )
-                raise
+                    raise
 
-        logger.info("봇 설정 수정: %s (변경: %s)", bot_id, list(updates.keys()))
-        return bot
+            logger.info("봇 설정 수정: %s (변경: %s)", bot_id, list(updates.keys()))
+            return bot
 
     async def assign_strategy(self, bot_id: str, strategy_id: str) -> None:
         """봇에 전략 배정.

--- a/src/ante/bot/manager.py
+++ b/src/ante/bot/manager.py
@@ -534,18 +534,44 @@ class BotManager:
                     # 수 있으므로 memory/DB rollback 모두 스킵한다.
                     if bot.config is new_config:
                         bot.config = old_config
-                        try:
-                            await self._save_bot_config(old_config)
-                        except Exception:
-                            # nested rollback failure: 원래 budget 예외를
-                            # 덮지 않도록 rollback 실패는 ``logger.exception``
-                            # 으로 남기고 bare raise 로 원래 예외를 propagate
-                            # 한다. memory 는 이미 rollback 된 상태이므로
-                            # in-memory 일관성은 유지된다.
-                            logger.exception(
-                                "update_bot rollback DB save failed for "
-                                "bot_id=%s; memory was rolled back but DB "
-                                "may diverge.",
+                        # Refs #1460 (attempt 3): DB rollback save 직전에
+                        # manager 의 ``_bots`` 메모리 맵에 이 ``bot_id`` 가
+                        # 여전히 우리가 잡고 있는 같은 ``bot`` 인스턴스로 등록되어
+                        # 있는지 한 번 더 확인한다. ``update_bot`` 의 per-bot
+                        # lock 은 ``update_bot`` 들 사이에서만 직렬화하므로,
+                        # ``treasury.update_budget`` await 동안 같은 ``bot_id``
+                        # 에 대해 ``delete_bot`` (hard delete 포함) 이나
+                        # ``delete_bot`` → ``create_bot`` (재생성) 이 끼어들면:
+                        # - hard delete 후라면 ``_save_bot_config(old_config)`` 가
+                        #   삭제된 row 를 다시 INSERT 하여 좀비 row 가 부활한다.
+                        # - delete+create 후라면 새 봇의 row 를 우리의 옛 설정으로
+                        #   덮어써 데이터 오염이 발생한다.
+                        # 따라서 메모리 맵의 ``bot_id`` 가 더 이상 우리 ``bot``
+                        # 인스턴스를 가리키지 않으면 DB rollback save 는 스킵한다.
+                        # 광범위한 동시성 모델 (delete/create + 같은 lock 공유)
+                        # 변경은 별도 이슈로 다룬다. memory rollback (단순 대입)
+                        # 은 위에서 이미 수행했으므로 caller 가 들고 있는 ``bot``
+                        # 객체의 in-memory 일관성은 유지된다.
+                        if self._bots.get(bot_id) is bot:
+                            try:
+                                await self._save_bot_config(old_config)
+                            except Exception:
+                                # nested rollback failure: 원래 budget 예외를
+                                # 덮지 않도록 rollback 실패는 ``logger.exception``
+                                # 으로 남기고 bare raise 로 원래 예외를 propagate
+                                # 한다. memory 는 이미 rollback 된 상태이므로
+                                # in-memory 일관성은 유지된다.
+                                logger.exception(
+                                    "update_bot rollback DB save failed for "
+                                    "bot_id=%s; memory was rolled back but DB "
+                                    "may diverge.",
+                                    bot_id,
+                                )
+                        else:
+                            logger.warning(
+                                "update_bot rollback DB save skipped for "
+                                "bot_id=%s: bot instance no longer in manager "
+                                "(delete/recreate race).",
                                 bot_id,
                             )
                     else:

--- a/tests/unit/test_bot_manager_update_bot_atomicity.py
+++ b/tests/unit/test_bot_manager_update_bot_atomicity.py
@@ -605,6 +605,100 @@ class TestUpdateBotBudgetRollback:
             for record in caplog.records
         )
 
+    async def test_update_bot_skips_rollback_on_inplace_mutation(
+        self, eventbus, db, ctx, monkeypatch, caplog
+    ) -> None:
+        """Refs #1460 (attempt 4): in-place mutation race 시 rollback 스킵.
+
+        ``update_bot`` 은 per-bot ``asyncio.Lock`` 으로 같은 ``update_bot`` 호출
+        들을 직렬화한다. 그러나 같은 lock 을 쓰지 않는 다른 mutator
+        (``change_strategy`` / ``assign_strategy``) 는 ``treasury.update_budget``
+        await 동안 ``bot.config`` 를 in-place mutation (예:
+        ``bot.config.strategy_id = "new"``) 할 수 있다. identity 가드
+        (``bot.config is new_config``) 는 그대로 True 라서 rollback 이 그 변경을
+        덮어쓸 위험이 있다.
+
+        시나리오:
+        1. ``update_bot(A)`` 가 진입하여 new_config(A) 를 ``bot.config`` 에 대입 +
+           DB commit.
+        2. ``treasury.update_budget`` 의 side_effect 안에서 ``bot.config`` 를
+           **in-place mutation** (``bot.config.strategy_id = "concurrent-..."``)
+           한 직후 raise.
+        3. rollback 진입 — ``bot.config is new_config`` 는 True (같은 객체) 지만
+           ``bot.config == new_config`` 가 False (필드가 바뀌었음) → rollback
+           스킵.
+        4. ``_save_bot_config`` 는 정확히 1회 (A 의 new_config commit) 만 호출.
+        5. ``bot.config.strategy_id`` 가 in-place mutation 값으로 유지된다.
+        6. "rollback skipped: bot.config mutated in-place" warning 흔적이 남는다.
+        7. 원래 budget 예외 propagate.
+        """
+
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=None)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(
+            manager, ctx, account_id="acc-test", interval_seconds=60
+        )
+        bot = manager.get_bot(bot_id)
+        assert bot is not None
+
+        # _save_bot_config 호출 횟수 추적.
+        original_save = manager._save_bot_config
+        save_call_count = {"n": 0}
+
+        async def counting_save(config):
+            save_call_count["n"] += 1
+            return await original_save(config)
+
+        monkeypatch.setattr(manager, "_save_bot_config", counting_save)
+
+        # race 시뮬레이션: treasury.update_budget 안에서 bot.config 를 in-place
+        # mutation (다른 mutator 가 같은 lock 을 쓰지 않고 변경한 상황 모사)
+        # 후 raise.
+        class _BoomError(RuntimeError):
+            pass
+
+        class _InPlaceMutationTreasury:
+            def __init__(self, bot_ref, mutated_strategy_id: str) -> None:
+                self._bot_ref = bot_ref
+                self._mutated_strategy_id = mutated_strategy_id
+                self.update_budget_calls: list[tuple[str, float]] = []
+
+            async def update_budget(
+                self, called_bot_id: str, target_amount: float
+            ) -> None:
+                self.update_budget_calls.append((called_bot_id, target_amount))
+                # 다른 mutator (예: change_strategy) 가 같은 lock 을 쓰지
+                # 않은 채로 in-place mutation 한 상황을 모사.
+                self._bot_ref.config.strategy_id = self._mutated_strategy_id
+                raise _BoomError("boom-after-inplace-mutation")
+
+        mutation_treasury = _InPlaceMutationTreasury(bot, "concurrent-strategy-change")
+        tm = _RaisingTreasuryManager("acc-test", mutation_treasury)  # type: ignore[arg-type]
+        manager._treasury_manager = tm  # type: ignore[assignment]
+
+        with caplog.at_level(logging.WARNING, logger="ante.bot.manager"):
+            with pytest.raises(_BoomError):
+                await manager.update_bot(bot_id, interval_seconds=120, budget=100_000.0)
+
+        # update_budget 진입 보증.
+        assert mutation_treasury.update_budget_calls == [(bot_id, 100_000.0)]
+
+        # 핵심 보증: _save_bot_config 가 정확히 1회만 호출됨 (new_config commit
+        # 만 수행, rollback save 는 eq 가드로 스킵). eq 가드가 빠지면
+        # call_count == 2 가 되어야 한다.
+        assert save_call_count["n"] == 1
+
+        # in-place mutation 값이 그대로 유지된다 (rollback 으로 덮어쓰지 않음).
+        assert bot.config.strategy_id == "concurrent-strategy-change"
+
+        # in-place mutation warning 흔적 확인.
+        assert any(
+            "rollback skipped" in record.message
+            and "mutated in-place" in record.message
+            and record.levelno == logging.WARNING
+            for record in caplog.records
+        )
+
     async def test_update_bot_concurrent_requests_serialized_by_lock(
         self, eventbus, db, ctx
     ) -> None:

--- a/tests/unit/test_bot_manager_update_bot_atomicity.py
+++ b/tests/unit/test_bot_manager_update_bot_atomicity.py
@@ -412,3 +412,99 @@ class TestUpdateBotBudgetRollback:
 
         assert bot.config.interval_seconds == 180
         assert await _read_db_interval(db, bot_id) == 180
+
+    async def test_update_bot_budget_failure_skips_rollback_on_concurrent_update(
+        self, eventbus, db, ctx, monkeypatch, caplog
+    ) -> None:
+        """Refs #1460: concurrent update race 시 rollback 스킵.
+
+        시나리오:
+        1. update_bot(A) 가 진입하여 new_config(A) 를 만들고 ``bot.config`` 에
+           대입 + DB commit 까지 성공.
+        2. ``treasury.update_budget`` await 진입.
+        3. 같은 봇에 대해 update_bot(B) 가 끼어들어 ``bot.config`` 를
+           third_config(B) 로 교체 (성공 가정).
+        4. ``treasury.update_budget`` 이 raise → A 의 rollback 경로 진입.
+        5. ``bot.config is new_config(A)`` 가 False (지금은 third_config(B)) →
+           rollback 스킵, DB save 도 추가로 호출되지 않음.
+        6. 원래 budget 예외만 propagate, ``bot.config`` 는 third_config(B) 유지.
+        7. ``_save_bot_config`` 는 A 의 new_config commit 1회만 수행한다 (즉
+           ``call_count == 1``) — rollback 의 두 번째 save 가 일어나지 않음을
+           보증.
+        """
+
+        # _save_bot_config call count 추적: monkeypatch 로 wrapping.
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=None)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(
+            manager, ctx, account_id="acc-test", interval_seconds=60
+        )
+        bot = manager.get_bot(bot_id)
+        assert bot is not None
+
+        # 같은 bot_id 에 대한 다른 update 가 만들어낸 ``third_config`` 시뮬레이션.
+        third_config = BotConfig(
+            bot_id="bot1",
+            strategy_id="s1",
+            account_id="acc-test",
+            interval_seconds=240,
+            name="concurrent-renamed",
+        )
+
+        # _save_bot_config 호출 횟수 추적.
+        original_save = manager._save_bot_config
+        save_call_count = {"n": 0}
+
+        async def counting_save(config):
+            save_call_count["n"] += 1
+            return await original_save(config)
+
+        monkeypatch.setattr(manager, "_save_bot_config", counting_save)
+
+        # race 시뮬레이션: treasury.update_budget 안에서 bot.config 를
+        # third_config 로 교체한 직후 raise.
+        class _BoomError(RuntimeError):
+            pass
+
+        class _RaceSimulatingTreasury:
+            def __init__(self, bot_ref, replacement: BotConfig) -> None:
+                self._bot_ref = bot_ref
+                self._replacement = replacement
+                self.update_budget_calls: list[tuple[str, float]] = []
+
+            async def update_budget(
+                self, called_bot_id: str, target_amount: float
+            ) -> None:
+                self.update_budget_calls.append((called_bot_id, target_amount))
+                # await 중 끼어든 다른 update_bot 이 bot.config 를 교체한 상황을
+                # 모사 (실제 코드 경로에선 다른 task 가 했을 일이지만, 단위
+                # 테스트에선 side_effect 안에서 직접 변조).
+                self._bot_ref.config = self._replacement
+                raise _BoomError("boom-after-race")
+
+        race_treasury = _RaceSimulatingTreasury(bot, third_config)
+        tm = _RaisingTreasuryManager("acc-test", race_treasury)  # type: ignore[arg-type]
+        manager._treasury_manager = tm  # type: ignore[assignment]
+
+        with caplog.at_level(logging.WARNING, logger="ante.bot.manager"):
+            with pytest.raises(_BoomError):
+                await manager.update_bot(bot_id, interval_seconds=120, budget=100_000.0)
+
+        # update_budget 은 진입했어야 한다.
+        assert race_treasury.update_budget_calls == [(bot_id, 100_000.0)]
+
+        # 핵심 보증: _save_bot_config 가 정확히 1회만 호출됨 (new_config commit
+        # 만 수행, rollback save 는 스킵). 만약 conditional rollback 이 빠지면
+        # call_count == 2 가 되어야 한다.
+        assert save_call_count["n"] == 1
+
+        # bot.config 는 third_config(B) 그대로 유지되어야 한다 (덮어쓰지 않음).
+        assert bot.config is third_config
+        assert bot.config.name == "concurrent-renamed"
+        assert bot.config.interval_seconds == 240
+
+        # "rollback skipped" warning 흔적 확인.
+        assert any(
+            "rollback skipped" in record.message and record.levelno == logging.WARNING
+            for record in caplog.records
+        )

--- a/tests/unit/test_bot_manager_update_bot_atomicity.py
+++ b/tests/unit/test_bot_manager_update_bot_atomicity.py
@@ -509,6 +509,102 @@ class TestUpdateBotBudgetRollback:
             for record in caplog.records
         )
 
+    async def test_update_bot_skips_db_rollback_on_delete_recreate_race(
+        self, eventbus, db, ctx, monkeypatch, caplog
+    ) -> None:
+        """Refs #1460 (attempt 3): delete/recreate race 시 rollback DB save 스킵.
+
+        update_bot 의 per-bot lock 은 같은 update_bot 끼리만 직렬화한다. 따라서
+        ``treasury.update_budget`` await 동안 같은 ``bot_id`` 에 대해
+        ``delete_bot`` (hard) 이 끼어들어 manager 의 ``_bots`` 맵에서 봇을
+        제거하거나, ``delete_bot`` → ``create_bot`` 으로 다른 ``Bot`` 인스턴스로
+        대체될 수 있다. 이런 상황에서 rollback 의
+        ``_save_bot_config(old_config)`` 가 그대로 실행되면:
+
+        - 삭제된 row 를 다시 INSERT 하여 좀비 봇이 부활한다.
+        - 새 봇의 row 를 우리의 옛 설정으로 덮어쓰는 오염이 발생한다.
+
+        시나리오:
+        1. ``update_bot(A)`` 가 진입하여 new_config 를 DB commit.
+        2. ``treasury.update_budget`` 의 side_effect 안에서 manager 의 ``_bots``
+           맵에서 ``bot_id`` 를 ``del`` 해 race 를 모사 후 raise.
+        3. rollback 진입 — ``bot.config is new_config`` 는 True 라서 memory
+           rollback (``bot.config = old_config``) 은 적용된다.
+        4. 그러나 ``self._bots.get(bot_id) is bot`` 가 False 이므로 DB rollback
+           save 는 스킵.
+        5. 결과: ``_save_bot_config`` 는 정확히 1회 (new_config commit) 만 호출.
+           원래 budget 예외 propagate. memory rollback 은 적용. "delete/recreate
+           race" warning 흔적이 남는다.
+        """
+
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=None)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(
+            manager, ctx, account_id="acc-test", interval_seconds=60
+        )
+        bot = manager.get_bot(bot_id)
+        assert bot is not None
+        old_config = bot.config
+
+        # _save_bot_config 호출 횟수 추적.
+        original_save = manager._save_bot_config
+        save_call_count = {"n": 0}
+
+        async def counting_save(config):
+            save_call_count["n"] += 1
+            return await original_save(config)
+
+        monkeypatch.setattr(manager, "_save_bot_config", counting_save)
+
+        # race 시뮬레이션: treasury.update_budget 안에서 manager._bots 에서
+        # bot_id 를 제거 (hard delete 의 마지막 라인 시뮬레이션) 후 raise.
+        class _BoomError(RuntimeError):
+            pass
+
+        class _DeleteRaceTreasury:
+            def __init__(self, mgr: BotManager, target_bot_id: str) -> None:
+                self._mgr = mgr
+                self._target_bot_id = target_bot_id
+                self.update_budget_calls: list[tuple[str, float]] = []
+
+            async def update_budget(
+                self, called_bot_id: str, target_amount: float
+            ) -> None:
+                self.update_budget_calls.append((called_bot_id, target_amount))
+                # delete_bot (hard) 가 끼어든 상황 모사: manager 메모리 맵에서
+                # bot_id 를 제거. bot.config 는 그대로 두어 ``bot.config is
+                # new_config`` 분기를 타게 한다.
+                del self._mgr._bots[self._target_bot_id]
+                raise _BoomError("delete-race-boom")
+
+        race_treasury = _DeleteRaceTreasury(manager, bot_id)
+        tm = _RaisingTreasuryManager("acc-test", race_treasury)  # type: ignore[arg-type]
+        manager._treasury_manager = tm  # type: ignore[assignment]
+
+        with caplog.at_level(logging.WARNING, logger="ante.bot.manager"):
+            with pytest.raises(_BoomError):
+                await manager.update_bot(bot_id, interval_seconds=120, budget=100_000.0)
+
+        # update_budget 진입 보증.
+        assert race_treasury.update_budget_calls == [(bot_id, 100_000.0)]
+
+        # 핵심 보증: _save_bot_config 가 정확히 1회만 호출됨 (new_config commit
+        # 만 수행, rollback save 는 instance check 가드로 스킵). 가드가 빠지면
+        # call_count == 2 가 된다.
+        assert save_call_count["n"] == 1
+
+        # memory rollback 은 적용되어야 한다 (bot 객체는 caller 가 잡고 있을 수
+        # 있으니 in-memory 일관성은 유지).
+        assert bot.config is old_config
+        assert bot.config.interval_seconds == 60
+
+        # delete/recreate race warning 흔적 확인.
+        assert any(
+            "delete/recreate race" in record.message
+            and record.levelno == logging.WARNING
+            for record in caplog.records
+        )
+
     async def test_update_bot_concurrent_requests_serialized_by_lock(
         self, eventbus, db, ctx
     ) -> None:

--- a/tests/unit/test_bot_manager_update_bot_atomicity.py
+++ b/tests/unit/test_bot_manager_update_bot_atomicity.py
@@ -508,3 +508,98 @@ class TestUpdateBotBudgetRollback:
             "rollback skipped" in record.message and record.levelno == logging.WARNING
             for record in caplog.records
         )
+
+    async def test_update_bot_concurrent_requests_serialized_by_lock(
+        self, eventbus, db, ctx
+    ) -> None:
+        """Refs #1460 (attempt 3): per-bot asyncio.Lock 로 update_bot 직렬화.
+
+        시나리오:
+        1. 같은 봇에 대해 update_bot(A) 와 update_bot(B) 를 ``asyncio.gather``
+           로 동시 호출한다.
+        2. A 는 budget 처리에서 ``await asyncio.sleep(0.05)`` 후 raise — A 가
+           먼저 진입했다면 lock 을 0.05 초 이상 잡고 있는다.
+        3. B 는 정상 성공 (treasury.update_budget no-op).
+        4. lock 으로 인해 두 요청은 직렬화된다. 어느 쪽이 먼저 들어와도 다른
+           쪽의 ``new_config`` 가 동시에 ``bot.config`` 에 노출되어 섞이는 일은
+           없다. A 가 raise 한 변경은 rollback 으로 사라지고, B 의 변경만
+           최종 상태에 남는다 (또는 B 가 먼저 끝나고 A 가 뒤이어 진입한
+           경우엔 A 는 raise 로 변경 없음).
+        5. 핵심 보증: 어느 직렬 순서든 ``bot.config.name == "bot-B"`` (B 의
+           변경) 이고, A 의 변경 (``interval_seconds == 3000``) 은 절대로 남지
+           않는다.
+        """
+
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=None)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(
+            manager, ctx, account_id="acc-test", interval_seconds=60
+        )
+        bot = manager.get_bot(bot_id)
+        assert bot is not None
+
+        # A 는 update_budget 안에서 sleep + raise. B 는 같은 treasury 객체를
+        # 쓰면 안 되므로(둘 다 raise 되어 버림) 두 요청의 budget 처리 분기를
+        # 다르게 만들기 위해 A 만 budget 을 지정한다. B 는 budget=None 으로
+        # treasury 경로를 타지 않고 runtime control 변경만 수행한다.
+        class _SleepThenRaiseTreasury:
+            def __init__(self) -> None:
+                self.update_budget_calls: list[tuple[str, float]] = []
+
+            async def update_budget(
+                self, called_bot_id: str, target_amount: float
+            ) -> None:
+                self.update_budget_calls.append((called_bot_id, target_amount))
+                # lock 을 충분히 길게 잡고 있도록 대기 후 raise — 동시 호출된
+                # B 가 끼어들 시간을 확보한다.
+                await asyncio.sleep(0.05)
+                raise RuntimeError("A budget boom")
+
+        sleep_treasury = _SleepThenRaiseTreasury()
+        tm = _RaisingTreasuryManager("acc-test", sleep_treasury)  # type: ignore[arg-type]
+        manager._treasury_manager = tm  # type: ignore[assignment]
+
+        # A: interval=3000 + budget 실패 → rollback 으로 변경 소실.
+        # B: name="bot-B" + budget=None → 정상 성공.
+        async def call_a():
+            try:
+                await manager.update_bot(
+                    bot_id, interval_seconds=3000, budget=100_000.0
+                )
+            except RuntimeError:
+                # 기대된 raise — 결과를 무시하고 직렬화 결과만 본다.
+                return "A-raised"
+            return "A-ok"
+
+        async def call_b():
+            await manager.update_bot(bot_id, name="bot-B")
+            return "B-ok"
+
+        results = await asyncio.gather(call_a(), call_b())
+
+        # A 는 항상 raise, B 는 항상 성공.
+        assert results[0] == "A-raised"
+        assert results[1] == "B-ok"
+
+        # 직렬화 결과 보증:
+        # - A 의 interval_seconds=3000 변경은 어느 직렬 순서에서도 최종
+        #   상태에 절대 남지 않는다 (A 가 raise → rollback 으로 소실).
+        # - B 의 name="bot-B" 변경은 항상 최종 상태에 남는다.
+        # - A 가 먼저 직렬화 → B 가 뒤이어 진입한 경우: A rollback 후
+        #   interval_seconds=60, 그 다음 B 가 name="bot-B" 만 변경. 최종
+        #   ``bot.config.interval_seconds == 60`` and ``bot.config.name ==
+        #   "bot-B"``.
+        # - B 가 먼저 직렬화 → A 가 뒤이어 진입한 경우: B 가 name="bot-B"
+        #   로 변경. 그 다음 A 가 interval_seconds=3000 로 변경 시도 후 raise
+        #   → rollback. rollback 의 old_config 는 이 시점 ``bot.config`` (B
+        #   가 만든 config) 이므로 name="bot-B" 가 보존된 채 A 변경만 사라짐.
+        #   최종 ``bot.config.interval_seconds == 60`` and ``bot.config.name
+        #   == "bot-B"``.
+        assert bot.config.interval_seconds == 60
+        assert bot.config.name == "bot-B"
+
+        # DB 도 동일하게 직렬화 결과를 반영해야 한다.
+        assert await _read_db_interval(db, bot_id) == 60
+
+        # treasury.update_budget 은 정확히 1회 (A 의 호출 1회) 만 일어났다.
+        assert sleep_treasury.update_budget_calls == [(bot_id, 100_000.0)]

--- a/tests/unit/test_bot_manager_update_bot_atomicity.py
+++ b/tests/unit/test_bot_manager_update_bot_atomicity.py
@@ -1,0 +1,414 @@
+"""``BotManager.update_bot`` 의 atomic rollback 동작 검증.
+
+Refs #1460: budget 처리 단계에서 실패가 발생하면 runtime control 변경 (memory
++ DB) 이 ``old_config`` 로 rollback 되어야 한다. TreasuryManager 미주입,
+account 미등록, ``treasury.update_budget`` 내부 예외, ``asyncio.CancelledError``
+(요청 취소) 모두 같은 rollback 경로를 탄다. 또한 rollback 중 DB save 가 다시
+실패해도 원래 budget 예외가 보존되고, in-memory 상태는 일관되게 rollback
+유지된다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from ante.bot import BotConfig, BotManager
+from ante.bot.config import BotStatus
+from ante.core import Database
+from ante.eventbus import EventBus
+from ante.strategy import (
+    DataProvider,
+    OrderView,
+    PortfolioView,
+    Strategy,
+    StrategyContext,
+    StrategyMeta,
+)
+from ante.treasury.exceptions import TreasuryNotConfiguredError
+from ante.treasury.treasury import Treasury
+
+# ----------------------------------------------------------------------------
+# Fakes / fixtures
+# ----------------------------------------------------------------------------
+
+
+class _FakeDataProvider(DataProvider):
+    async def get_ohlcv(self, symbol, timeframe="1d", limit=100):
+        import polars as pl
+
+        return pl.DataFrame({"close": [100.0]})
+
+    async def get_current_price(self, symbol):
+        return 100.0
+
+    async def get_indicator(self, symbol, indicator, params=None):
+        return {}
+
+
+class _FakePortfolioView(PortfolioView):
+    def get_positions(self, bot_id):
+        return {}
+
+    def get_balance(self, bot_id):
+        return {"total": 1_000_000.0, "available": 500_000.0}
+
+
+class _FakeOrderView(OrderView):
+    def get_open_orders(self, bot_id):
+        return []
+
+
+class _SimpleStrategy(Strategy):
+    meta = StrategyMeta(name="simple", version="1.0.0", description="test")
+
+    async def on_step(self, context):
+        return []
+
+
+class _FakeTreasuryManager:
+    """경량 TreasuryManager 대체.
+
+    ``register`` 되지 않은 account_id 에 대해 ``KeyError`` 를 raise 한다 (실제
+    ``TreasuryManager.get`` 의 거동과 동일).
+    """
+
+    def __init__(self) -> None:
+        self._treasuries: dict[str, Treasury] = {}
+
+    def register(self, account_id: str, treasury: Treasury) -> None:
+        self._treasuries[account_id] = treasury
+
+    def get(self, account_id: str) -> Treasury:
+        if account_id not in self._treasuries:
+            raise KeyError(f"Treasury not found: account_id={account_id}")
+        return self._treasuries[account_id]
+
+    def list_all(self) -> list[Treasury]:
+        return list(self._treasuries.values())
+
+
+class _RaisingTreasury:
+    """``update_budget`` 호출 시 명시된 예외를 raise 하는 Treasury 스텁."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+        self.update_budget_calls: list[tuple[str, float]] = []
+
+    async def update_budget(self, bot_id: str, target_amount: float) -> None:
+        self.update_budget_calls.append((bot_id, target_amount))
+        raise self._exc
+
+
+class _RaisingTreasuryManager:
+    """단일 account 에 대해 ``_RaisingTreasury`` 를 돌려주는 매니저."""
+
+    def __init__(self, account_id: str, treasury: _RaisingTreasury) -> None:
+        self._account_id = account_id
+        self._treasury = treasury
+
+    def get(self, account_id: str):
+        if account_id != self._account_id:
+            raise KeyError(f"Treasury not found: account_id={account_id}")
+        return self._treasury
+
+    def list_all(self):
+        return [self._treasury]
+
+
+@pytest.fixture
+def eventbus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+def ctx() -> StrategyContext:
+    return StrategyContext(
+        bot_id="bot1",
+        data_provider=_FakeDataProvider(),
+        portfolio=_FakePortfolioView(),
+        order_view=_FakeOrderView(),
+    )
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = Database(str(tmp_path / "test.db"))
+    await database.connect()
+    yield database
+    try:
+        await asyncio.wait_for(database.close(), timeout=5.0)
+    except TimeoutError:
+        pass
+
+
+async def _make_stopped_bot(
+    manager: BotManager,
+    ctx: StrategyContext,
+    *,
+    account_id: str,
+    interval_seconds: int = 60,
+) -> str:
+    """create + force STOPPED 상태로 ``bot1`` 생성."""
+    config = BotConfig(
+        bot_id="bot1",
+        strategy_id="s1",
+        account_id=account_id,
+        interval_seconds=interval_seconds,
+    )
+    bot = await manager.create_bot(config, _SimpleStrategy, ctx)
+    bot.status = BotStatus.STOPPED
+    return "bot1"
+
+
+async def _read_db_interval(db: Database, bot_id: str) -> int:
+    """DB ``config_json`` 에서 ``interval_seconds`` 를 읽는다."""
+    import json
+
+    row = await db.fetch_one("SELECT config_json FROM bots WHERE bot_id = ?", (bot_id,))
+    assert row is not None
+    payload = json.loads(row["config_json"])
+    return int(payload["interval_seconds"])
+
+
+# ----------------------------------------------------------------------------
+# Tests
+# ----------------------------------------------------------------------------
+
+
+class TestUpdateBotBudgetRollback:
+    """Refs #1460: budget 실패 시 runtime control 변경 atomic rollback."""
+
+    async def test_update_bot_budget_failure_rolls_back_runtime_controls_memory(
+        self, eventbus, db, ctx
+    ) -> None:
+        """memory(in-process ``bot.config``) 가 ``old_config`` 로 rollback 된다."""
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=None)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(
+            manager, ctx, account_id="acc-test", interval_seconds=60
+        )
+        bot = manager.get_bot(bot_id)
+        assert bot is not None
+        old_config = bot.config
+
+        with pytest.raises(TreasuryNotConfiguredError):
+            await manager.update_bot(bot_id, interval_seconds=120, budget=100_000.0)
+
+        # memory 상태는 old_config 로 rollback 되어 있어야 한다 (identity 보장).
+        assert bot.config is old_config
+        assert bot.config.interval_seconds == 60
+
+    async def test_update_bot_budget_failure_rolls_back_runtime_controls_db(
+        self, eventbus, db, ctx
+    ) -> None:
+        """DB ``config_json`` 도 ``old_config`` 로 rollback 된다."""
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=None)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(
+            manager, ctx, account_id="acc-test", interval_seconds=60
+        )
+
+        with pytest.raises(TreasuryNotConfiguredError):
+            await manager.update_bot(bot_id, interval_seconds=120, budget=100_000.0)
+
+        # DB 도 60 으로 복구되어 있어야 한다 (rollback save 적용).
+        assert await _read_db_interval(db, bot_id) == 60
+
+    async def test_update_bot_budget_failure_treasury_not_configured(
+        self, eventbus, db, ctx
+    ) -> None:
+        """``TreasuryManager`` 자체가 None 인 경우에도 rollback 수행."""
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=None)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(
+            manager, ctx, account_id="acc-test", interval_seconds=60
+        )
+
+        with pytest.raises(TreasuryNotConfiguredError) as exc_info:
+            await manager.update_bot(bot_id, interval_seconds=120, budget=100_000.0)
+        assert "treasury manager not configured" in str(exc_info.value)
+
+        bot = manager.get_bot(bot_id)
+        assert bot is not None
+        assert bot.config.interval_seconds == 60
+        assert await _read_db_interval(db, bot_id) == 60
+
+    async def test_update_bot_budget_failure_treasury_account_missing(
+        self, eventbus, db, ctx
+    ) -> None:
+        """``_treasury_manager.get(...)`` 가 KeyError → rollback + 명시적 예외."""
+        tm = _FakeTreasuryManager()
+        # 봇 account 'acc-test' 에는 미등록.
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=tm)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(
+            manager, ctx, account_id="acc-test", interval_seconds=60
+        )
+
+        with pytest.raises(TreasuryNotConfiguredError) as exc_info:
+            await manager.update_bot(bot_id, interval_seconds=120, budget=100_000.0)
+        assert "acc-test" in str(exc_info.value)
+
+        bot = manager.get_bot(bot_id)
+        assert bot is not None
+        assert bot.config.interval_seconds == 60
+        assert await _read_db_interval(db, bot_id) == 60
+
+    async def test_update_bot_budget_failure_inside_update_budget(
+        self, eventbus, db, ctx
+    ) -> None:
+        """``treasury.update_budget`` 내부 raise → rollback + 같은 예외 propagate."""
+
+        class _BoomError(RuntimeError):
+            pass
+
+        raising_treasury = _RaisingTreasury(_BoomError("boom"))
+        tm = _RaisingTreasuryManager("acc-test", raising_treasury)
+
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=tm)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(
+            manager, ctx, account_id="acc-test", interval_seconds=60
+        )
+
+        with pytest.raises(_BoomError):
+            await manager.update_bot(bot_id, interval_seconds=120, budget=100_000.0)
+
+        # update_budget 은 호출되었어야 한다 (treasury 까지 진입 후 raise).
+        assert raising_treasury.update_budget_calls == [(bot_id, 100_000.0)]
+
+        bot = manager.get_bot(bot_id)
+        assert bot is not None
+        assert bot.config.interval_seconds == 60
+        assert await _read_db_interval(db, bot_id) == 60
+
+    async def test_update_bot_budget_failure_cancellation(
+        self, eventbus, db, ctx
+    ) -> None:
+        """``asyncio.CancelledError`` (요청 취소) 도 rollback 범위에 포함된다.
+
+        CancelledError 는 ``BaseException`` 하위지만 ``Exception`` 하위가
+        아니므로, ``except (Exception, asyncio.CancelledError)`` 로 명시 포착
+        되어야 한다. rollback 후 CancelledError 가 그대로 propagate 한다.
+        """
+        raising_treasury = _RaisingTreasury(asyncio.CancelledError())
+        tm = _RaisingTreasuryManager("acc-test", raising_treasury)
+
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=tm)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(
+            manager, ctx, account_id="acc-test", interval_seconds=60
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await manager.update_bot(bot_id, interval_seconds=120, budget=100_000.0)
+
+        bot = manager.get_bot(bot_id)
+        assert bot is not None
+        # memory rollback 확인.
+        assert bot.config.interval_seconds == 60
+        # DB rollback 확인 (CancelledError 도 rollback save 가 동작해야 함).
+        assert await _read_db_interval(db, bot_id) == 60
+
+    async def test_update_bot_budget_failure_rollback_db_save_also_fails(
+        self, eventbus, db, ctx, monkeypatch, caplog
+    ) -> None:
+        """nested rollback failure: 원래 budget 예외 보존 + memory rollback 적용.
+
+        ``_save_bot_config`` 를 monkeypatch 해서 첫 호출(new_config 저장) 은
+        성공, 두 번째 호출(rollback save) 에서 raise 한다. 결과:
+
+        - 원래 budget 예외(``TreasuryNotConfiguredError``) 가 propagate.
+        - memory(``bot.config``) 는 ``old_config`` 로 rollback 적용.
+        - ``logger.exception`` 호출 흔적이 caplog 에 남는다.
+        """
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=None)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(
+            manager, ctx, account_id="acc-test", interval_seconds=60
+        )
+        bot = manager.get_bot(bot_id)
+        assert bot is not None
+        old_config = bot.config
+
+        original_save = manager._save_bot_config
+        call_count = {"n": 0}
+
+        async def flaky_save(config):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # 첫 호출: new_config commit — 정상 동작.
+                return await original_save(config)
+            # 두 번째 호출: rollback save — 의도적으로 raise.
+            raise RuntimeError("rollback save boom")
+
+        # monkeypatch 적용 위치: 이 줄 (`manager._save_bot_config = flaky_save`
+        # 를 monkeypatch.setattr 로 대체). 이후 호출되는 update_bot 안에서
+        # 1) new_config save 성공, 2) budget 처리 단계에서 TreasuryNotConfigured
+        # raise → except 블록 진입, 3) memory rollback (bot.config = old_config)
+        # 적용, 4) rollback DB save 호출 → RuntimeError raise → logger.exception
+        # 만 남기고 원래 budget 예외 propagate.
+        monkeypatch.setattr(manager, "_save_bot_config", flaky_save)
+
+        with caplog.at_level(logging.ERROR, logger="ante.bot.manager"):
+            with pytest.raises(TreasuryNotConfiguredError):
+                await manager.update_bot(bot_id, interval_seconds=120, budget=100_000.0)
+
+        # _save_bot_config 가 정확히 두 번 호출되었는지 검증 (new_config + rollback).
+        assert call_count["n"] == 2
+
+        # memory rollback 보증 검증 위치: 아래 두 assertion.
+        # bot.config 가 old_config 와 identity 일치해야 한다 (단순 대입 rollback).
+        assert bot.config is old_config
+        assert bot.config.interval_seconds == 60
+
+        # logger.exception 흔적 확인.
+        assert any(
+            "rollback DB save failed" in record.message
+            and record.levelno >= logging.ERROR
+            for record in caplog.records
+        )
+
+    async def test_update_bot_budget_success_keeps_runtime_changes(
+        self, eventbus, db, ctx
+    ) -> None:
+        """회귀 보호: budget 성공 경로는 runtime control 변경을 그대로 유지한다."""
+        tm = _FakeTreasuryManager()
+        treasury = Treasury(db=db, eventbus=eventbus, account_id="acc-test")
+        await treasury.initialize()
+        await treasury.set_account_balance(1_000_000)
+        tm.register("acc-test", treasury)
+
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=tm)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(
+            manager, ctx, account_id="acc-test", interval_seconds=60
+        )
+
+        bot = await manager.update_bot(bot_id, interval_seconds=120, budget=200_000.0)
+
+        # runtime control 변경 유지.
+        assert bot.config.interval_seconds == 120
+        assert await _read_db_interval(db, bot_id) == 120
+        # budget 도 정상 배정.
+        budget = treasury.get_budget(bot_id)
+        assert budget is not None
+        assert budget.allocated == pytest.approx(200_000.0)
+
+    async def test_update_bot_no_budget_keeps_runtime_changes(
+        self, eventbus, db, ctx
+    ) -> None:
+        """회귀 보호: ``budget`` 미지정 경로는 기존과 동일하게 변경 유지."""
+        manager = BotManager(eventbus=eventbus, db=db, treasury_manager=None)
+        await manager.initialize()
+        bot_id = await _make_stopped_bot(
+            manager, ctx, account_id="acc-test", interval_seconds=60
+        )
+
+        bot = await manager.update_bot(bot_id, interval_seconds=180)
+
+        assert bot.config.interval_seconds == 180
+        assert await _read_db_interval(db, bot_id) == 180


### PR DESCRIPTION
Closes #1460

## Summary
- `BotManager.update_bot`에서 budget 처리 실패 시 같은 요청의 runtime control 변경을 memory(`bot.config`)와 DB(`config_json`) 둘 다 rollback. `asyncio.CancelledError`도 rollback 범위에 포함.
- per-bot `asyncio.Lock` (`_bot_update_locks`)으로 동시 `update_bot` 직렬화.
- 4중 가드: per-bot Lock + identity check (`bot.config is new_config`) + instance check (`self._bots.get(bot_id) is bot`) + dataclass eq check (`bot.config == committed_snapshot` via `dataclasses.replace`로 떠둔 snapshot).
- nested rollback: `_save_bot_config(old_config)` 자체 실패는 `logger.exception`만 남기고 bare raise로 원래 budget 예외 보존.

## Test Plan
- `ruff check && ruff format --check` — PASS
- `pytest tests/unit/test_bot_manager_update_bot_atomicity.py -v` — 13 passed (신규 atomicity 케이스 13건)
- `pytest tests/unit/test_bot_manager_update_budget.py -v` — 8 passed (회귀 보호)
- `pytest tests/unit/test_bot_manager_methods.py -v` — 41 passed

## Plan Preflight
- verdict: approve-implement (v2)
- 이슈 본문 v2 기준. Codex 브랜치 리뷰 attempt 1~4에서 race 4건 식별→fix→attempt 5 PASS.

## Out of Scope (별도 이슈)
- 입력 검증: #1456 (close).
- DB roundtrip: #1457 (close).
- GET response: #1458 (close).
- Service boundary recheck: #1459.
- `change_strategy`/`assign_strategy`/`delete_bot`/`create_bot`과의 직렬화 (BotManager 전반 동시성 모델 — 별도 이슈).
- `treasury.update_budget` 내부 allocate/deallocate side effect의 atomicity (Treasury 책임).
- POST /api/bots create rollback (#1335).

🤖 Generated with [Claude Code](https://claude.com/claude-code)