### PR TITLE
feat(member,cli): operator cleanup tooling for legacy invalid-role rows

### DIFF
--- a/docs/runbooks/07-member-invalid-role-cleanup.md
+++ b/docs/runbooks/07-member-invalid-role-cleanup.md
@@ -1,0 +1,114 @@
+# Member Invalid-Role Cleanup Runbook
+
+> 관련 이슈: #1417 (epic), #1465 (write path 차단, close), #1466 (auth read-path guard, close), #1468 (본 runbook)
+> SSOT: `src/ante/member/models.py:16` `MemberRole` enum / `src/ante/member/auth_service.py:27` `_VALID_MEMBER_ROLES`
+> 인덱스: [README.md](README.md)
+
+## 목적
+
+`MemberRole` enum SSOT(`master` / `admin` / `default`)에 없는 `role` 값을 가진
+member row 가 DB 에 남아 있을 때, 운영자가 그 row 를 안전하게 식별하고 cleanup
+하는 절차를 정의한다.
+
+#1465 이후 write path 가 invalid role 을 거부하고, #1466 이후 auth read-path 가
+legacy invalid-role token/password 인증을 거부하므로 신규 invalid-role row 는
+생성되지 않는다. 본 runbook 은 **그 이전에 생성된 legacy row** 의 정리 절차다.
+
+## 자동 cleanup 정책 (금지)
+
+- **자동 migration / silent rewrite 금지.** 운영자가 row 단위로 명시 revoke 한다.
+- **자동 삭제 금지.** invalid-role row 도 audit/추적 가치가 있으므로 DB 에서 직접
+  지우지 않는다. `ante member revoke <member_id>` 만 사용한다.
+- 일괄 cleanup 스크립트도 허용하지 않는다. 한 row 씩 검토 → revoke 한다.
+
+## 절차
+
+### 1. 식별 — `ante member list-invalid-roles`
+
+```bash
+ante member list-invalid-roles --format json
+```
+
+분류는 `offline` 이지만 `MemberService.initialize()` 가 schema migration DDL 을
+수반한다 (read-only 가 아니다). runtime IPC 는 우회한다.
+
+JSON 출력 스키마:
+
+```json
+{
+  "recommended_action": "review_then_revoke",
+  "valid_roles": ["master", "admin", "default"],
+  "actionable_count": 1,
+  "legacy_revoked_count": 0,
+  "actionable": [
+    {
+      "member_id": "agent-bad",
+      "role": "oracle_invalid_role",
+      "type": "agent",
+      "name": "agent-bad",
+      "status": "active",
+      "created_at": "2026-04-01 00:00:00",
+      "has_token": true,
+      "token_expires_at": "2026-07-01 00:00:00",
+      "revoke_command": "ante member revoke agent-bad"
+    }
+  ],
+  "legacy_revoked": []
+}
+```
+
+- `actionable`: `role` 이 invalid 이고 `status != revoked` 인 row. 운영자 cleanup 대상.
+- `legacy_revoked`: 이미 revoke 된 invalid-role row. 추가 조치 불필요(audit 추적용).
+- `has_token` / `token_expires_at` 만 노출되고, `token_hash` 자체는 **모든 출력
+  모드에서 절대 표시되지 않는다**.
+
+### 2. 검토
+
+각 `actionable` row 의 `role` 이 정말 invalid 한지, 그리고 그 row 가 실제
+운영자가 의도해서 생성한 것이 아닌지 확인한다.
+
+- `MemberRole` 에 새 값을 추가하려는 게 의도라면 본 runbook 이 아니라 별도 enum
+  변경 스펙 (`src/ante/member/models.py`) 으로 진행한다.
+- legacy migration 잔여물(예: `oracle_invalid_role` 같이 명시적으로 invalid 임을
+  드러내는 값) 이면 다음 단계로 진행한다.
+
+### 3. Revoke — `ante member revoke <member_id> --yes`
+
+```bash
+ante member revoke <member_id> --yes
+```
+
+이 명령은 다음을 수행한다 (`MemberService.revoke`):
+
+- `members.status = 'revoked'`
+- `members.token_hash = ''` (토큰 무효화)
+- `members.revoked_at = <UTC now>`
+
+`--yes` 누락 시 `CLI_CONFIRMATION_REQUIRED` 로 실패한다.
+
+### 4. 사후 검증
+
+```bash
+ante member list-invalid-roles --format json
+```
+
+- `actionable_count == 0` 인지 확인한다.
+- `legacy_revoked_count` 는 누적될 수 있다(이전에 revoke 한 invalid-role row 들이
+  계속 표시됨). 이는 정상이며, 운영자가 동일 row 를 반복 처리하지 않게 도와준다.
+
+## Audit 한계
+
+- Web API revoke 경로(`POST /api/members/<id>/revoke`)는 `audit_logger.log` 로
+  audit 기록을 남긴다.
+- CLI `ante member revoke` 는 본 PR (#1468) 시점에서 audit 기록을 **남기지 않는다.**
+  CLI revoke audit 보강은 별도 audit 정책 이슈에서 다룬다.
+- 따라서 본 runbook 으로 CLI cleanup 을 수행할 때는, 운영 일지에 수동으로 revoke
+  내역(`member_id`, 시각, 사유)을 기록하기를 권장한다.
+
+## 관련 spec 링크
+
+- Epic: #1417 invalid-role member 생성 후속 정리.
+- #1465 — write path `_assert_role_enum` (close).
+- #1466 — auth read-path `_VALID_MEMBER_ROLES` guard (close).
+- 본 runbook (#1468) — operator cleanup 절차.
+- frontend role type 분리: #1467 (별도 범위).

--- a/docs/runbooks/07-member-invalid-role-cleanup.md
+++ b/docs/runbooks/07-member-invalid-role-cleanup.md
@@ -101,6 +101,13 @@ list-invalid-roles` 로 default 가 아닌 인스턴스를 점검했다면, payl
 운영자가 수동으로 `--config-dir` 을 다시 붙일 필요가 없고, default DB 에 잘못
 실행될 위험도 없다.
 
+payload 의 `revoke_command` 에 들어가는 `--config-dir` 값은 **절대 경로로
+정규화**되어 있다 (`Path.expanduser().resolve()` 적용). 따라서 운영자가
+`ante --config-dir custom member list-invalid-roles` 처럼 상대 경로나
+`~/...` 형태로 호출했더라도, payload 를 다른 CWD 에서 복사 실행했을 때 그 CWD
+아래의 `custom` 디렉토리를 가리키는 사고가 발생하지 않는다 — payload 는 항상
+처음 스캔한 인스턴스의 절대 경로를 가리킨다.
+
 이 명령은 다음을 수행한다 (`MemberService.revoke`):
 
 - `members.status = 'revoked'`

--- a/docs/runbooks/07-member-invalid-role-cleanup.md
+++ b/docs/runbooks/07-member-invalid-role-cleanup.md
@@ -50,7 +50,7 @@ JSON 출력 스키마:
       "created_at": "2026-04-01 00:00:00",
       "has_token": true,
       "token_expires_at": "2026-07-01 00:00:00",
-      "revoke_command": "ante member revoke agent-bad"
+      "revoke_command": "ante member revoke agent-bad --yes"
     }
   ],
   "legacy_revoked": []

--- a/docs/runbooks/07-member-invalid-role-cleanup.md
+++ b/docs/runbooks/07-member-invalid-role-cleanup.md
@@ -60,7 +60,11 @@ JSON 출력 스키마:
 - `actionable`: `role` 이 invalid 이고 `status != revoked` 인 row. 운영자 cleanup 대상.
   `revoke_command` 는 즉시 실행 가능한 형태(`--yes` 포함, `member_id` 는
   `shlex.quote` 로 셸 안전 인용, 옵션/포지셔널 경계는 `--` separator 로 명시)로
-  노출된다.
+  노출된다. 또한 `ante list-invalid-roles` 호출에 `--config-dir <path>` 가
+  지정되었다면 동일한 값을 `ante --config-dir <quoted-path> member revoke ...`
+  형태로 **그대로 보존**해 운영자가 payload 를 복사·실행해도 같은 인스턴스(DB)
+  대상으로 동작하도록 보장한다. default config_dir 일 때는 `--config-dir` 인자가
+  생략된다.
 - `legacy_revoked`: 이미 revoke 된 invalid-role row. **추가 조치 불필요**
   (audit 추적용). `MemberService.revoke` 가 `active`/`suspended` 만 허용하므로
   재실행 시 실패하며, 따라서 legacy_revoked row 의 JSON dict 에는
@@ -88,6 +92,14 @@ ante member revoke --yes -- <member_id>
 공백·셸 메타문자·`-`-prefix 가 들어 있어도 인자 splitting / 옵션 파싱으로
 오해석되지 않게 보장한다. JSON payload 의 `revoke_command` 는 동일한 형태로
 `shlex.quote` 처리된 `member_id` 를 포함해 복사·실행만으로 안전하게 동작한다.
+
+**다중 인스턴스 운용 시**: `ante --config-dir /path/to/other-instance member
+list-invalid-roles` 로 default 가 아닌 인스턴스를 점검했다면, payload 의
+`revoke_command` 도 동일한 `--config-dir` 값을 포함한 형태(`ante --config-dir
+/path/to/other-instance member revoke --yes -- <member_id>`)로 자동 생성된다.
+즉 payload 를 그대로 복사 실행하면 항상 **같은 인스턴스(DB)** 가 대상이 된다 —
+운영자가 수동으로 `--config-dir` 을 다시 붙일 필요가 없고, default DB 에 잘못
+실행될 위험도 없다.
 
 이 명령은 다음을 수행한다 (`MemberService.revoke`):
 

--- a/docs/runbooks/07-member-invalid-role-cleanup.md
+++ b/docs/runbooks/07-member-invalid-role-cleanup.md
@@ -50,7 +50,7 @@ JSON 출력 스키마:
       "created_at": "2026-04-01 00:00:00",
       "has_token": true,
       "token_expires_at": "2026-07-01 00:00:00",
-      "revoke_command": "ante member revoke agent-bad --yes"
+      "revoke_command": "ante member revoke --yes -- agent-bad"
     }
   ],
   "legacy_revoked": []
@@ -58,7 +58,13 @@ JSON 출력 스키마:
 ```
 
 - `actionable`: `role` 이 invalid 이고 `status != revoked` 인 row. 운영자 cleanup 대상.
-- `legacy_revoked`: 이미 revoke 된 invalid-role row. 추가 조치 불필요(audit 추적용).
+  `revoke_command` 는 즉시 실행 가능한 형태(`--yes` 포함, `member_id` 는
+  `shlex.quote` 로 셸 안전 인용, 옵션/포지셔널 경계는 `--` separator 로 명시)로
+  노출된다.
+- `legacy_revoked`: 이미 revoke 된 invalid-role row. **추가 조치 불필요**
+  (audit 추적용). `MemberService.revoke` 가 `active`/`suspended` 만 허용하므로
+  재실행 시 실패하며, 따라서 legacy_revoked row 의 JSON dict 에는
+  `revoke_command` 키 자체가 **포함되지 않는다**.
 - `has_token` / `token_expires_at` 만 노출되고, `token_hash` 자체는 **모든 출력
   모드에서 절대 표시되지 않는다**.
 
@@ -72,11 +78,16 @@ JSON 출력 스키마:
 - legacy migration 잔여물(예: `oracle_invalid_role` 같이 명시적으로 invalid 임을
   드러내는 값) 이면 다음 단계로 진행한다.
 
-### 3. Revoke — `ante member revoke <member_id> --yes`
+### 3. Revoke — `ante member revoke --yes -- <member_id>`
 
 ```bash
-ante member revoke <member_id> --yes
+ante member revoke --yes -- <member_id>
 ```
+
+`--` separator 는 옵션과 포지셔널 인자의 경계를 명시한다. `member_id` 에
+공백·셸 메타문자·`-`-prefix 가 들어 있어도 인자 splitting / 옵션 파싱으로
+오해석되지 않게 보장한다. JSON payload 의 `revoke_command` 는 동일한 형태로
+`shlex.quote` 처리된 `member_id` 를 포함해 복사·실행만으로 안전하게 동작한다.
 
 이 명령은 다음을 수행한다 (`MemberService.revoke`):
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -16,6 +16,7 @@
 | [04-ci-cd.md](04-ci-cd.md) | CI/CD 파이프라인, 리뷰/승인/머지 게이트, 저장소 설정 |
 | [05-testing.md](05-testing.md) | 테스트 전략 (단위/통합 테스트, 커버리지, 배포 이미지 시뮬레이션 테스트 방향) |
 | [06-release.md](06-release.md) | 릴리스 운영 (release PR, 버전 관리, PyPI/Docker 배포) |
+| [07-member-invalid-role-cleanup.md](07-member-invalid-role-cleanup.md) | `MemberRole` enum 외 role 을 가진 legacy member row 의 식별 → 검토 → revoke 운영 절차 (#1417/#1465/#1466/#1468) |
 
 ## 에이전트 커맨드 (작업 절차 SSOT)
 

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -129,6 +129,7 @@ allowlist 후보에서 제거한다.
 | `ante approval list/info/review ...` | `offline` | approval 저장소 조회 |
 | `ante init ...` | `bootstrap/maintenance` | 인스턴스 파일 + master/test account 생성 |
 | `ante member list/info ...` | `offline` | member 조회 |
+| `ante member list-invalid-roles` | `offline` | DB 직접 조회 (runtime IPC 우회; `service.initialize` 수반) |
 | `ante member register --id <member_id> --type human|agent ...` | `runtime IPC` | 서버 실행 중 member/session/security 상태 변경 |
 | `ante member set-emoji/suspend/reactivate/rotate-token ...` | `runtime IPC` | 서버 실행 중 member/session/security 상태 변경 |
 | `ante member revoke <member_id> --yes` | `runtime IPC` | 서버 실행 중 member/session/security 상태 변경 |
@@ -537,6 +538,7 @@ ante init [--member-id owner] [--name Owner] [--dir <경로>]
 ante member register --id <member_id> --type human|agent [--org <org>] [--name <name>] [--scopes <csv>]  # 멤버 등록
 ante member list [--type human|agent] [--org <org>] [--status active|suspended|revoked]  # 멤버 목록
 ante member info <member_id>                            # 멤버 상세
+ante member list-invalid-roles [--format json]          # MemberRole enum 외 role 을 가진 legacy row 식별 (운영 cleanup; runbook 07 참조)
 ante member suspend <member_id>                         # 멤버 일시 정지
 ante member reactivate <member_id>                      # 멤버 재활성화
 ante member revoke <member_id> --yes                    # 멤버 권한 영구 해제 (--yes 누락 시 CLI_CONFIRMATION_REQUIRED)
@@ -546,11 +548,21 @@ ante member reset-password --recovery-key <key> (--new-password-env ENV_NAME | -
 ante member regenerate-recovery-key (--password-env ENV_NAME | --password-file PATH)  # 복구 키 재발급
 ```
 
-`member list/info`는 오프라인 조회가 가능하다. 그 외 member 상태·토큰·패스워드·복구키
-변경 커맨드는 서버 실행 중 IPC로 서버에 위임한다. 서버는 MemberService 실행 후
-필요한 세션 무효화, 토큰 무효화, 감사 로그, member/security 알림을 같은 런타임
-경로에서 처리한다. 같은 `config_dir`의 서버가 정지된 상태에서는 bootstrap/recovery
-및 비상 revoke를 위해 직접 MemberService를 생성하는 maintenance fallback을 허용한다.
+`member list/info`와 `member list-invalid-roles`는 오프라인 조회가 가능하다. 단,
+`member list-invalid-roles`는 `MemberService.initialize()`로 schema migration DDL을
+수반하므로 "read-only"가 아니다(runtime IPC는 우회한다). 그 외 member 상태·토큰·
+패스워드·복구키 변경 커맨드는 서버 실행 중 IPC로 서버에 위임한다. 서버는
+MemberService 실행 후 필요한 세션 무효화, 토큰 무효화, 감사 로그, member/security
+알림을 같은 런타임 경로에서 처리한다. 같은 `config_dir`의 서버가 정지된 상태에서는
+bootstrap/recovery 및 비상 revoke를 위해 직접 MemberService를 생성하는
+maintenance fallback을 허용한다.
+
+`member list-invalid-roles`는 `MemberRole` enum SSOT(`master`/`admin`/`default`)에
+없는 `role` 값을 가진 legacy row를 두 카테고리(`actionable` / `legacy_revoked`)로
+분리해 보여준다. 운영자는 `actionable` row를 `ante member revoke <member_id> --yes`로
+cleanup한다. `token_hash`는 모든 출력 모드에서 표시되지 않으며, 토큰 존재 여부는
+`has_token: bool`로만 노출된다. 자세한 절차는
+[runbook 07](../../runbooks/07-member-invalid-role-cleanup.md)에 정의되어 있다.
 
 ### `ante instrument` — 종목 관리
 

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 from pathlib import Path
 
@@ -21,7 +22,10 @@ from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id, require_auth, require_scope
 from ante.member.errors import PermissionDeniedError
+from ante.member.models import MemberRole
 from ante.member.scopes import InvalidScopeError
+
+logger = logging.getLogger(__name__)
 
 # CLI 핸들러에서 master guard 위반을 사용자 친화 메시지로 종료하기 위한 메시지.
 # ``MemberService._assert_master``가 raise하는 ``PermissionDeniedError``는 Python
@@ -233,6 +237,113 @@ def member_info(ctx: click.Context, member_id: str) -> None:
         click.echo(f"  권한      : {', '.join(result['scopes']) or '-'}")
         click.echo(f"  생성일    : {result['created_at']}")
         click.echo(f"  생성자    : {result['created_by']}")
+
+
+def _invalid_role_row_dict(m) -> dict:  # noqa: ANN001
+    """``Member`` row 를 CLI 출력용 dict 로 변환.
+
+    ``token_hash`` 는 보안상 절대 노출하지 않는다 (#1468 secret-exposure). 토큰
+    존재 여부는 ``has_token: bool`` 로만 표현하고 만료시각은 그대로 표시한다.
+    ``valid_roles`` 는 row-level 이 아니라 top-level scan summary 에만 노출한다.
+    """
+    has_token = bool(m.token_hash)
+    return {
+        "member_id": m.member_id,
+        "role": m.role,
+        "type": m.type,
+        "name": m.name,
+        "status": m.status,
+        "created_at": m.created_at,
+        "has_token": has_token,
+        "token_expires_at": m.token_expires_at or None,
+        "revoke_command": f"ante member revoke {m.member_id}",
+    }
+
+
+@member.command("list-invalid-roles")
+@click.option(
+    "--db-path",
+    default=None,
+    help="DB 파일 경로 (생략 시 canonical config 의 db.path 사용)",
+)
+@format_option
+@click.pass_context
+@require_auth
+@require_scope("member:read")
+def member_list_invalid_roles(
+    ctx: click.Context,
+    db_path: str | None,  # noqa: ARG001 — reserved for future explicit DB targeting
+) -> None:
+    """``MemberRole`` enum 외 role 을 가진 legacy member row 식별 (#1468).
+
+    ``actionable`` 카테고리는 ``status != revoked`` 인 invalid-role row 이며,
+    운영자가 ``ante member revoke <member_id>`` 로 cleanup 해야 한다.
+    ``legacy_revoked`` 는 이미 revoke 된 historical row 다.
+
+    분류는 ``offline`` 이지만 ``MemberService.initialize()`` 가 schema migration
+    DDL 을 수반한다 — 따라서 "read-only" 가 아니다. ``ante member list`` /
+    ``info`` 와 동일한 ``_create_service()`` 패턴을 사용하며 runtime IPC 는
+    우회한다.
+
+    ``token_hash`` 는 모든 출력 모드에서 노출되지 않는다 (보안 SSOT).
+    """
+    fmt = get_formatter(ctx)
+    valid_roles = [member.value for member in MemberRole]
+
+    async def _run_scan() -> tuple[list[dict], list[dict]]:
+        service, db = await _create_service()
+        try:
+            scan = await service.find_invalid_role_members()
+            actionable = [_invalid_role_row_dict(m) for m in scan.actionable]
+            legacy = [_invalid_role_row_dict(m) for m in scan.legacy_revoked]
+            return actionable, legacy
+        finally:
+            await db.close()
+
+    actionable_rows, legacy_rows = _run(_run_scan())
+
+    # structured log: 운영자가 invocation 시점마다 count 흐름을 추적한다.
+    logger.info(
+        "MEMBER_INVALID_ROLE_FOUND actionable=%d legacy_revoked=%d",
+        len(actionable_rows),
+        len(legacy_rows),
+    )
+
+    payload = {
+        "recommended_action": "review_then_revoke",
+        "valid_roles": valid_roles,
+        "actionable_count": len(actionable_rows),
+        "legacy_revoked_count": len(legacy_rows),
+        "actionable": actionable_rows,
+        "legacy_revoked": legacy_rows,
+    }
+
+    if fmt.is_json:
+        fmt.output(payload)
+        return
+
+    # text 모드 — 두 섹션 분리.
+    click.echo(f"  recommended_action : {payload['recommended_action']}")
+    click.echo(f"  valid_roles        : {', '.join(valid_roles)}")
+    click.echo(f"  actionable         : {payload['actionable_count']}건")
+    click.echo(f"  legacy_revoked     : {payload['legacy_revoked_count']}건")
+
+    def _emit_section(title: str, rows: list[dict]) -> None:
+        click.echo("")
+        click.echo(f"[{title}]")
+        if not rows:
+            click.echo("  (none)")
+            return
+        for row in rows:
+            click.echo(
+                f"  {row['member_id']:20s} role={row['role']:20s} "
+                f"status={row['status']:10s} "
+                f"created_at={row['created_at']:20s} "
+                f"has_token={row['has_token']!s}"
+            )
+
+    _emit_section("actionable", actionable_rows)
+    _emit_section("legacy_revoked", legacy_rows)
 
 
 @member.command("register")

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import shlex
 from pathlib import Path
 
 import click
@@ -239,15 +240,27 @@ def member_info(ctx: click.Context, member_id: str) -> None:
         click.echo(f"  생성자    : {result['created_by']}")
 
 
-def _invalid_role_row_dict(m) -> dict:  # noqa: ANN001
+def _invalid_role_row_dict(m, *, actionable: bool) -> dict:  # noqa: ANN001
     """``Member`` row 를 CLI 출력용 dict 로 변환.
 
     ``token_hash`` 는 보안상 절대 노출하지 않는다 (#1468 secret-exposure). 토큰
     존재 여부는 ``has_token: bool`` 로만 표현하고 만료시각은 그대로 표시한다.
     ``valid_roles`` 는 row-level 이 아니라 top-level scan summary 에만 노출한다.
+
+    ``revoke_command`` 는 **actionable row 에서만** 노출한다. legacy_revoked row
+    는 이미 ``status=revoked`` 상태이며 ``MemberService.revoke`` 가
+    ``active``/``suspended`` 만 허용하므로 재실행 시 실패한다. 따라서 noop 명령을
+    payload 에 싣지 않고 키 자체를 누락해 "추가 조치 불요" 임을 명시한다
+    (#1468 Codex review attempt 2, P2-B).
+
+    actionable row 의 ``revoke_command`` 는 ``shlex.quote`` 로 ``member_id`` 를
+    셸 안전하게 인용하고, ``--`` separator 로 옵션/포지셔널 경계를 명시한다 — 빈
+    문자열·공백·셸 메타문자·``-``-prefix 가 포함된 ``member_id`` 가 운영자 셸에서
+    인자 splitting 이나 옵션 파싱으로 오해석되는 위험을 차단한다 (#1468 Codex
+    review attempt 2, P2-A).
     """
     has_token = bool(m.token_hash)
-    return {
+    row: dict = {
         "member_id": m.member_id,
         "role": m.role,
         "type": m.type,
@@ -256,11 +269,17 @@ def _invalid_role_row_dict(m) -> dict:  # noqa: ANN001
         "created_at": m.created_at,
         "has_token": has_token,
         "token_expires_at": m.token_expires_at or None,
+    }
+    if actionable:
         # ``member revoke`` 는 ``--yes`` 누락 시 ``CLI_CONFIRMATION_REQUIRED`` 로
         # 실패하므로 (`member_revoke` 본문 참조), JSON payload 의 권장 명령은
-        # ``--yes`` 를 포함해 즉시 실행 가능하게 출력한다.
-        "revoke_command": f"ante member revoke {m.member_id} --yes",
-    }
+        # ``--yes`` 를 포함해 즉시 실행 가능하게 출력한다. ``member_id`` 는
+        # 셸 안전을 위해 ``shlex.quote`` 로 인용하고, 옵션/포지셔널 경계는
+        # ``--`` separator 로 명시한다.
+        row["revoke_command"] = (
+            f"ante member revoke --yes -- {shlex.quote(m.member_id)}"
+        )
+    return row
 
 
 @member.command("list-invalid-roles")
@@ -278,7 +297,7 @@ def member_list_invalid_roles(
     가 아니며, 필요하면 별도 이슈로 분리한다.
 
     ``actionable`` 카테고리는 ``status != revoked`` 인 invalid-role row 이며,
-    운영자가 ``ante member revoke <member_id> --yes`` 로 cleanup 해야 한다.
+    운영자가 ``ante member revoke --yes -- <member_id>`` 로 cleanup 해야 한다.
     ``legacy_revoked`` 는 이미 revoke 된 historical row 다.
 
     분류는 ``offline`` 이지만 ``MemberService.initialize()`` 가 schema migration
@@ -295,8 +314,12 @@ def member_list_invalid_roles(
         service, db = await _create_service()
         try:
             scan = await service.find_invalid_role_members()
-            actionable = [_invalid_role_row_dict(m) for m in scan.actionable]
-            legacy = [_invalid_role_row_dict(m) for m in scan.legacy_revoked]
+            actionable = [
+                _invalid_role_row_dict(m, actionable=True) for m in scan.actionable
+            ]
+            legacy = [
+                _invalid_role_row_dict(m, actionable=False) for m in scan.legacy_revoked
+            ]
             return actionable, legacy
         finally:
             await db.close()

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -240,7 +240,56 @@ def member_info(ctx: click.Context, member_id: str) -> None:
         click.echo(f"  생성자    : {result['created_by']}")
 
 
-def _invalid_role_row_dict(m, *, actionable: bool) -> dict:  # noqa: ANN001
+def _explicit_config_dir(ctx: click.Context) -> str | None:
+    """루트 ``--config-dir`` 옵션이 명시적으로 지정된 경우 그 값(str)을 돌려준다.
+
+    Ante CLI 의 루트 그룹(:func:`ante.cli.main.cli`)은 ``--config-dir`` 이 명시
+    되거나 ``ANTE_CONFIG_DIR`` 환경변수가 set 되었을 때에만
+    ``ctx.obj["config_dir"]`` 를 ``Path`` 로 채운다. 미지정이면 키 자체가 누락된다.
+    본 헬퍼는 그 raw override 값을 문자열 형태로 그대로 반환하며, override 가
+    없으면 ``None`` 을 돌려 default config_dir 를 의미하게 한다.
+
+    이 값은 ``revoke_command`` 생성 시 운영자가 입력한 ``--config-dir`` 을 그대로
+    payload 에 보존하기 위해 사용된다 (#1468 Codex review attempt 3, P2):
+    운영자가 ``ante --config-dir /custom member list-invalid-roles`` 로 다른
+    인스턴스를 스캔했을 때, payload 의 ``revoke_command`` 에 ``--config-dir`` 이
+    빠지면 default config_dir 의 DB 에 실행되어 엉뚱한 인스턴스를 건드릴 위험이
+    있다. 항상 ``ctx`` 의 override 를 같은 자리에 다시 채워 인스턴스 일관성을
+    보장한다.
+    """
+    obj = getattr(ctx, "obj", None)
+    if not isinstance(obj, dict):
+        return None
+    raw = obj.get("config_dir")
+    if raw is None:
+        return None
+    return str(raw)
+
+
+def _build_revoke_command(member_id: str, *, config_dir: str | None) -> str:
+    """``ante member revoke`` payload 명령 문자열을 생성한다.
+
+    - ``config_dir`` 이 주어지면 ``ante --config-dir <quoted>`` 를 앞에 붙여
+      동일 인스턴스(DB) 대상으로 명령이 실행되도록 보존한다 (#1468 attempt 3 P2).
+    - ``--yes`` 는 ``member revoke`` 비대화형 게이트를 통과하기 위해 항상 포함한다
+      (#1468 attempt 1 P2-B).
+    - ``--`` separator 와 ``shlex.quote`` 로 ``member_id`` 를 셸 안전 인용해
+      빈 문자열·공백·셸 메타문자·``-``-prefix 가 포함된 id 도 인자 splitting /
+      옵션 파싱으로 오해석되지 않도록 한다 (#1468 attempt 2 P2-A).
+    """
+    parts = ["ante"]
+    if config_dir is not None:
+        parts.append(f"--config-dir {shlex.quote(config_dir)}")
+    parts.append(f"member revoke --yes -- {shlex.quote(member_id)}")
+    return " ".join(parts)
+
+
+def _invalid_role_row_dict(
+    m,  # noqa: ANN001
+    *,
+    actionable: bool,
+    config_dir: str | None = None,
+) -> dict:
     """``Member`` row 를 CLI 출력용 dict 로 변환.
 
     ``token_hash`` 는 보안상 절대 노출하지 않는다 (#1468 secret-exposure). 토큰
@@ -258,6 +307,12 @@ def _invalid_role_row_dict(m, *, actionable: bool) -> dict:  # noqa: ANN001
     문자열·공백·셸 메타문자·``-``-prefix 가 포함된 ``member_id`` 가 운영자 셸에서
     인자 splitting 이나 옵션 파싱으로 오해석되는 위험을 차단한다 (#1468 Codex
     review attempt 2, P2-A).
+
+    ``config_dir`` 이 주어지면(루트 ``--config-dir`` 이 명시된 경우) 그 값을
+    ``revoke_command`` 앞에 ``--config-dir <quoted>`` 로 보존해, 운영자가 payload
+    를 그대로 복사 실행해도 같은 인스턴스(DB) 대상으로 동작하도록 보장한다
+    (#1468 attempt 3 P2 — config-dir 보존). default config_dir 일 때는 인자 자체
+    를 생략해 기존 표준 호출 형태를 유지한다.
     """
     has_token = bool(m.token_hash)
     row: dict = {
@@ -271,13 +326,8 @@ def _invalid_role_row_dict(m, *, actionable: bool) -> dict:  # noqa: ANN001
         "token_expires_at": m.token_expires_at or None,
     }
     if actionable:
-        # ``member revoke`` 는 ``--yes`` 누락 시 ``CLI_CONFIRMATION_REQUIRED`` 로
-        # 실패하므로 (`member_revoke` 본문 참조), JSON payload 의 권장 명령은
-        # ``--yes`` 를 포함해 즉시 실행 가능하게 출력한다. ``member_id`` 는
-        # 셸 안전을 위해 ``shlex.quote`` 로 인용하고, 옵션/포지셔널 경계는
-        # ``--`` separator 로 명시한다.
-        row["revoke_command"] = (
-            f"ante member revoke --yes -- {shlex.quote(m.member_id)}"
+        row["revoke_command"] = _build_revoke_command(
+            m.member_id, config_dir=config_dir
         )
     return row
 
@@ -309,16 +359,26 @@ def member_list_invalid_roles(
     """
     fmt = get_formatter(ctx)
     valid_roles = [member.value for member in MemberRole]
+    # 루트 ``--config-dir`` 이 명시되어 있으면 payload 의 revoke_command 에
+    # 동일 값을 보존한다 (#1468 attempt 3 P2). default 이면 None 이 돌아오고
+    # ``--config-dir`` 인자는 생략된다.
+    config_dir_override = _explicit_config_dir(ctx)
 
     async def _run_scan() -> tuple[list[dict], list[dict]]:
         service, db = await _create_service()
         try:
             scan = await service.find_invalid_role_members()
             actionable = [
-                _invalid_role_row_dict(m, actionable=True) for m in scan.actionable
+                _invalid_role_row_dict(
+                    m, actionable=True, config_dir=config_dir_override
+                )
+                for m in scan.actionable
             ]
             legacy = [
-                _invalid_role_row_dict(m, actionable=False) for m in scan.legacy_revoked
+                _invalid_role_row_dict(
+                    m, actionable=False, config_dir=config_dir_override
+                )
+                for m in scan.legacy_revoked
             ]
             return actionable, legacy
         finally:

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -246,16 +246,26 @@ def _explicit_config_dir(ctx: click.Context) -> str | None:
     Ante CLI 의 루트 그룹(:func:`ante.cli.main.cli`)은 ``--config-dir`` 이 명시
     되거나 ``ANTE_CONFIG_DIR`` 환경변수가 set 되었을 때에만
     ``ctx.obj["config_dir"]`` 를 ``Path`` 로 채운다. 미지정이면 키 자체가 누락된다.
-    본 헬퍼는 그 raw override 값을 문자열 형태로 그대로 반환하며, override 가
-    없으면 ``None`` 을 돌려 default config_dir 를 의미하게 한다.
+    본 헬퍼는 그 override 값을 **절대 경로**(``expanduser().resolve()``)로 정규화
+    해서 반환하며, override 가 없으면 ``None`` 을 돌려 default config_dir 를
+    의미하게 한다.
 
-    이 값은 ``revoke_command`` 생성 시 운영자가 입력한 ``--config-dir`` 을 그대로
+    이 값은 ``revoke_command`` 생성 시 운영자가 입력한 ``--config-dir`` 을
     payload 에 보존하기 위해 사용된다 (#1468 Codex review attempt 3, P2):
     운영자가 ``ante --config-dir /custom member list-invalid-roles`` 로 다른
     인스턴스를 스캔했을 때, payload 의 ``revoke_command`` 에 ``--config-dir`` 이
     빠지면 default config_dir 의 DB 에 실행되어 엉뚱한 인스턴스를 건드릴 위험이
     있다. 항상 ``ctx`` 의 override 를 같은 자리에 다시 채워 인스턴스 일관성을
     보장한다.
+
+    추가로 attempt 4 P2 회귀: 운영자가 ``ante --config-dir custom member
+    list-invalid-roles`` 처럼 **상대 경로**로 호출한 경우, raw 값을 그대로
+    payload 에 실으면 운영자가 payload(``revoke_command``)를 다른 CWD 에서
+    복사 실행했을 때 그 CWD 아래의 ``custom`` DB 를 가리키게 되어 다시 다른
+    인스턴스가 될 수 있다. 이를 막기 위해 본 헬퍼는 ``Path.expanduser()``
+    (``~/...`` 확장) + ``Path.resolve()`` (절대 경로화 + symlink 해소) 로
+    경로를 고정해, 어느 CWD 에서 실행되더라도 처음 스캔한 인스턴스와 동일한
+    config_dir 를 가리키도록 보장한다.
     """
     obj = getattr(ctx, "obj", None)
     if not isinstance(obj, dict):
@@ -263,7 +273,9 @@ def _explicit_config_dir(ctx: click.Context) -> str | None:
     raw = obj.get("config_dir")
     if raw is None:
         return None
-    return str(raw)
+    # 절대 경로로 정규화 — payload 를 다른 CWD 에서 실행해도 같은 인스턴스를
+    # 가리키도록 한다 (#1468 Codex review attempt 4, P2).
+    return str(Path(raw).expanduser().resolve())
 
 
 def _build_revoke_command(member_id: str, *, config_dir: str | None) -> str:
@@ -312,7 +324,11 @@ def _invalid_role_row_dict(
     ``revoke_command`` 앞에 ``--config-dir <quoted>`` 로 보존해, 운영자가 payload
     를 그대로 복사 실행해도 같은 인스턴스(DB) 대상으로 동작하도록 보장한다
     (#1468 attempt 3 P2 — config-dir 보존). default config_dir 일 때는 인자 자체
-    를 생략해 기존 표준 호출 형태를 유지한다.
+    를 생략해 기존 표준 호출 형태를 유지한다. 값은
+    :func:`_explicit_config_dir` 에서 ``expanduser().resolve()`` 로 **절대 경로
+    화** 되어 들어오므로, 운영자가 상대 경로/``~`` 확장 형태로 호출했더라도
+    payload 는 다른 CWD 에서 실행해도 같은 인스턴스를 가리킨다 (#1468 attempt 4
+    P2).
     """
     has_token = bool(m.token_hash)
     row: dict = {

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -256,28 +256,29 @@ def _invalid_role_row_dict(m) -> dict:  # noqa: ANN001
         "created_at": m.created_at,
         "has_token": has_token,
         "token_expires_at": m.token_expires_at or None,
-        "revoke_command": f"ante member revoke {m.member_id}",
+        # ``member revoke`` 는 ``--yes`` 누락 시 ``CLI_CONFIRMATION_REQUIRED`` 로
+        # 실패하므로 (`member_revoke` 본문 참조), JSON payload 의 권장 명령은
+        # ``--yes`` 를 포함해 즉시 실행 가능하게 출력한다.
+        "revoke_command": f"ante member revoke {m.member_id} --yes",
     }
 
 
 @member.command("list-invalid-roles")
-@click.option(
-    "--db-path",
-    default=None,
-    help="DB 파일 경로 (생략 시 canonical config 의 db.path 사용)",
-)
 @format_option
 @click.pass_context
 @require_auth
 @require_scope("member:read")
 def member_list_invalid_roles(
     ctx: click.Context,
-    db_path: str | None,  # noqa: ARG001 — reserved for future explicit DB targeting
 ) -> None:
     """``MemberRole`` enum 외 role 을 가진 legacy member row 식별 (#1468).
 
+    본 명령은 canonical config 의 ``db.path`` (``get_db_path()``) 단일 DB 에
+    대해서만 invalid-role row 를 식별한다. 다른 DB 파일 대상 점검은 본 PR scope
+    가 아니며, 필요하면 별도 이슈로 분리한다.
+
     ``actionable`` 카테고리는 ``status != revoked`` 인 invalid-role row 이며,
-    운영자가 ``ante member revoke <member_id>`` 로 cleanup 해야 한다.
+    운영자가 ``ante member revoke <member_id> --yes`` 로 cleanup 해야 한다.
     ``legacy_revoked`` 는 이미 revoke 된 historical row 다.
 
     분류는 ``offline`` 이지만 ``MemberService.initialize()`` 가 schema migration

--- a/src/ante/member/service.py
+++ b/src/ante/member/service.py
@@ -6,6 +6,7 @@ import json
 import logging
 import re
 import secrets
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -20,7 +21,33 @@ from ante.member.recovery_key_manager import RecoveryKeyManager
 from ante.member.scopes import InvalidScopeError, is_valid_scope
 from ante.member.token_manager import TokenManager, _token_expires_at
 
-__all__ = ["MemberService", "ANIMAL_EMOJI_POOL", "MEMBER_SCHEMA", "_token_expires_at"]
+__all__ = [
+    "MemberService",
+    "InvalidRoleScan",
+    "ANIMAL_EMOJI_POOL",
+    "MEMBER_SCHEMA",
+    "_token_expires_at",
+]
+
+
+@dataclass
+class InvalidRoleScan:
+    """``MemberService.find_invalid_role_members`` 결과 컨테이너 (#1468).
+
+    ``MemberRole`` enum SSOT 에 없는 ``role`` 을 가진 member row 를 두 카테고리로
+    분리한다. 운영자는 ``actionable`` 만 ``ante member revoke`` 로 cleanup 하고,
+    ``legacy_revoked`` 는 이미 revoke 된 historical row 라 추가 조치가 필요 없다.
+
+    Attributes:
+        actionable: ``role`` invalid AND ``status != revoked`` 인 row 들. 운영자가
+            ``ante member revoke <member_id>`` 로 revoke 해야 할 대상.
+        legacy_revoked: ``role`` invalid AND ``status == revoked`` 인 row 들. 이미
+            revoke 처리된 흔적이며, 운영자가 동일 row 를 반복 처리하지 않게 분리.
+    """
+
+    actionable: list[Member] = field(default_factory=list)
+    legacy_revoked: list[Member] = field(default_factory=list)
+
 
 if TYPE_CHECKING:
     from ante.core.database import Database
@@ -512,6 +539,42 @@ class MemberService:
             tuple(params),
         )
         return row["cnt"] if row else 0
+
+    async def find_invalid_role_members(self) -> InvalidRoleScan:
+        """``MemberRole`` enum SSOT 에 없는 ``role`` 을 가진 member row 를 식별한다.
+
+        #1465(write path 차단), #1466(auth read-path guard)으로 invalid-role row
+        는 더 이상 새로 생성되지 않지만, 이전에 생성된 legacy row 는 DB 에 남아
+        있을 수 있다. 본 메소드는 그런 row 를 운영자가 cleanup 할 수 있도록 두
+        카테고리로 분리해 반환한다.
+
+        반환된 ``Member`` 객체는 ``token_hash`` 등 민감 필드도 포함하지만
+        CLI 출력 계층에서 마스킹/생략한다 (본 메소드는 service-layer SSOT 이므로
+        column projection 을 의도적으로 하지 않는다 — caller 가 보안 결정을 진다).
+
+        정렬: ``created_at ASC, member_id ASC`` (legacy row 정렬 안정성).
+
+        Returns:
+            ``InvalidRoleScan(actionable=[...], legacy_revoked=[...])``. 두 리스트는
+            중복되지 않으며, ``status`` 분기로 정확히 한 쪽에만 속한다.
+        """
+        valid = tuple(member.value for member in MemberRole)
+        placeholders = ",".join("?" for _ in valid)
+        rows = await self._db.fetch_all(
+            "SELECT * FROM members "  # noqa: S608
+            f"WHERE role NOT IN ({placeholders}) "
+            "ORDER BY created_at ASC, member_id ASC",
+            valid,
+        )
+        actionable: list[Member] = []
+        legacy_revoked: list[Member] = []
+        for row in rows:
+            member = _row_to_member(row)
+            if member.status == MemberStatus.REVOKED:
+                legacy_revoked.append(member)
+            else:
+                actionable.append(member)
+        return InvalidRoleScan(actionable=actionable, legacy_revoked=legacy_revoked)
 
     # ── 상태 변경 ──────────────────────────────────────
 

--- a/tests/unit/test_cli_member_non_interactive.py
+++ b/tests/unit/test_cli_member_non_interactive.py
@@ -7,6 +7,8 @@
 - 누락 / 둘 다 지정 / env 부재·공란 / file 부재·공란 실패 케이스
 - ``member regenerate-recovery-key --password-env`` / ``--password-file`` 성공
 - 위 동일 실패 케이스
+- ``member list-invalid-roles`` 두 카테고리 분리 JSON/table 출력, no-row exit 0,
+  ``token_hash`` 비노출 회귀 (#1468)
 """
 
 from __future__ import annotations
@@ -17,7 +19,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from click.testing import CliRunner
 
 from ante.cli.main import cli
-from ante.member.models import Member, MemberRole, MemberType
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+from ante.member.service import InvalidRoleScan
 
 
 def _make_master() -> Member:
@@ -751,3 +754,215 @@ class TestNonMasterCliPermissionDenied:
         data = json.loads(result.output)
         assert "master" in data["message"]
         assert "Traceback" not in result.output
+
+
+# ── member list-invalid-roles (#1468) ─────────────────
+
+
+def _make_invalid_role_member(
+    member_id: str,
+    *,
+    role: str = "oracle_invalid_role",
+    status: str = "active",
+    token_hash: str = "redacted-token-hash-must-not-leak",
+    token_expires_at: str = "2026-07-01 00:00:00",
+    created_at: str = "2026-04-01 00:00:00",
+    member_type: str = "agent",
+    name: str = "",
+) -> Member:
+    """invalid-role legacy Member 픽스처."""
+    return Member(
+        member_id=member_id,
+        type=member_type,
+        role=role,
+        org="default",
+        name=name or member_id,
+        status=status,
+        scopes=[],
+        token_hash=token_hash,
+        token_expires_at=token_expires_at,
+        created_at=created_at,
+    )
+
+
+def _patch_create_service_with_scan(scan: InvalidRoleScan):  # noqa: ANN202
+    """``_create_service`` 가 invalid-role scan 만 mock 된 service 를 반환한다."""
+    service = MagicMock()
+    service.find_invalid_role_members = AsyncMock(return_value=scan)
+    db = MagicMock()
+    db.close = AsyncMock(return_value=None)
+    return patch(
+        "ante.cli.commands.member._create_service",
+        new_callable=AsyncMock,
+        return_value=(service, db),
+    ), service
+
+
+class TestMemberListInvalidRolesNoRows:
+    """invalid-role row 가 0건일 때 CLI 동작."""
+
+    def test_cli_list_invalid_roles_no_rows_exit_zero(self) -> None:
+        """invalid row 없음 → exit 0, JSON 에 count 모두 0 + summary 노출."""
+        ctx, service = _patch_create_service_with_scan(
+            InvalidRoleScan(actionable=[], legacy_revoked=[])
+        )
+        with ctx:
+            result = _invoke_cli(
+                ["--format", "json", "member", "list-invalid-roles"],
+            )
+
+        assert result.exit_code == 0, result.output
+        service.find_invalid_role_members.assert_awaited_once()
+        data = json.loads(result.output)
+        assert data["actionable_count"] == 0
+        assert data["legacy_revoked_count"] == 0
+        assert data["actionable"] == []
+        assert data["legacy_revoked"] == []
+        # summary 키들도 0건일 때 그대로 노출된다.
+        assert data["recommended_action"] == "review_then_revoke"
+        assert data["valid_roles"] == [
+            MemberRole.MASTER.value,
+            MemberRole.ADMIN.value,
+            MemberRole.DEFAULT.value,
+        ]
+
+
+class TestMemberListInvalidRolesJsonSchema:
+    """invalid row 가 있을 때 JSON 스키마 정확성 + token_hash 비노출."""
+
+    def test_cli_list_invalid_roles_command_outputs_json(self) -> None:
+        """JSON 출력이 본문 v2 스키마와 일치하고 token_hash 가 누설되지 않는다."""
+        actionable = _make_invalid_role_member(
+            "agent-bad-1",
+            role="oracle_invalid_role",
+            status="active",
+            token_hash="HASH-MUST-NOT-LEAK-1",
+        )
+        legacy = _make_invalid_role_member(
+            "agent-bad-revoked",
+            role="oracle_invalid_role",
+            status="revoked",
+            token_hash="",  # revoke 후 token_hash 빈 문자열.
+            token_expires_at="",
+        )
+        ctx, service = _patch_create_service_with_scan(
+            InvalidRoleScan(actionable=[actionable], legacy_revoked=[legacy])
+        )
+        with ctx:
+            result = _invoke_cli(
+                ["--format", "json", "member", "list-invalid-roles"],
+            )
+
+        assert result.exit_code == 0, result.output
+        service.find_invalid_role_members.assert_awaited_once()
+
+        data = json.loads(result.output)
+
+        # top-level summary
+        assert data["recommended_action"] == "review_then_revoke"
+        assert data["valid_roles"] == ["master", "admin", "default"]
+        assert data["actionable_count"] == 1
+        assert data["legacy_revoked_count"] == 1
+
+        # actionable row
+        a = data["actionable"][0]
+        assert a["member_id"] == "agent-bad-1"
+        assert a["role"] == "oracle_invalid_role"
+        assert a["type"] == "agent"
+        assert a["name"] == "agent-bad-1"
+        assert a["status"] == "active"
+        assert a["created_at"] == "2026-04-01 00:00:00"
+        assert a["has_token"] is True
+        assert a["token_expires_at"] == "2026-07-01 00:00:00"
+        assert a["revoke_command"] == "ante member revoke agent-bad-1"
+
+        # legacy revoked row
+        legacy_row = data["legacy_revoked"][0]
+        assert legacy_row["member_id"] == "agent-bad-revoked"
+        assert legacy_row["status"] == "revoked"
+        # token_hash 빈 문자열 → has_token False, token_expires_at == null
+        assert legacy_row["has_token"] is False
+        assert legacy_row["token_expires_at"] is None
+
+        # 보안: 어떤 row 에도 token_hash 키가 없어야 한다.
+        for row in data["actionable"] + data["legacy_revoked"]:
+            assert "token_hash" not in row, (
+                f"token_hash 가 출력에 포함되어서는 안 된다: {row}"
+            )
+        # raw token hash 문자열도 출력에 등장하지 않는다.
+        assert "HASH-MUST-NOT-LEAK-1" not in result.output
+
+
+class TestMemberListInvalidRolesTable:
+    """text(table) 모드에서 두 섹션이 모두 표시된다."""
+
+    def test_cli_list_invalid_roles_command_outputs_table(self) -> None:
+        """text 모드 — actionable + legacy_revoked 두 섹션 표시."""
+        actionable = _make_invalid_role_member(
+            "agent-bad-active", role="oracle_invalid_role", status="active"
+        )
+        legacy = _make_invalid_role_member(
+            "agent-bad-revoked",
+            role="oracle_invalid_role",
+            status="revoked",
+            token_hash="",
+            token_expires_at="",
+        )
+        ctx, _service = _patch_create_service_with_scan(
+            InvalidRoleScan(actionable=[actionable], legacy_revoked=[legacy])
+        )
+        with ctx:
+            result = _invoke_cli(
+                ["--format", "text", "member", "list-invalid-roles"],
+            )
+
+        assert result.exit_code == 0, result.output
+        # 두 섹션 헤더가 모두 노출되어야 한다.
+        assert "[actionable]" in result.output
+        assert "[legacy_revoked]" in result.output
+        # 각 row 의 member_id 도 표시된다.
+        assert "agent-bad-active" in result.output
+        assert "agent-bad-revoked" in result.output
+        # summary 도 표시.
+        assert "review_then_revoke" in result.output
+        # text 모드여도 token_hash 는 누출되지 않는다.
+        assert "token_hash" not in result.output
+
+
+class TestMemberListInvalidRolesTokenHashRegression:
+    """``token_hash`` 가 모든 출력 모드에서 노출되지 않는다 (#1468 secret-exposure)."""
+
+    def test_cli_list_invalid_roles_does_not_expose_token_hash(self) -> None:
+        """JSON 모드 + text 모드 모두에서 token_hash 비노출 회귀."""
+        sensitive_hash = "TOP-SECRET-HASH-VALUE-DO-NOT-LEAK"
+        actionable = _make_invalid_role_member(
+            "agent-bad",
+            role="oracle_invalid_role",
+            status=MemberStatus.ACTIVE.value,
+            token_hash=sensitive_hash,
+        )
+        # JSON 모드
+        ctx_json, _svc_json = _patch_create_service_with_scan(
+            InvalidRoleScan(actionable=[actionable], legacy_revoked=[])
+        )
+        with ctx_json:
+            result_json = _invoke_cli(
+                ["--format", "json", "member", "list-invalid-roles"],
+            )
+        assert result_json.exit_code == 0, result_json.output
+        assert sensitive_hash not in result_json.output
+        data = json.loads(result_json.output)
+        for row in data["actionable"] + data["legacy_revoked"]:
+            assert "token_hash" not in row
+
+        # text 모드
+        ctx_text, _svc_text = _patch_create_service_with_scan(
+            InvalidRoleScan(actionable=[actionable], legacy_revoked=[])
+        )
+        with ctx_text:
+            result_text = _invoke_cli(
+                ["--format", "text", "member", "list-invalid-roles"],
+            )
+        assert result_text.exit_code == 0, result_text.output
+        assert sensitive_hash not in result_text.output
+        assert "token_hash" not in result_text.output

--- a/tests/unit/test_cli_member_non_interactive.py
+++ b/tests/unit/test_cli_member_non_interactive.py
@@ -877,7 +877,9 @@ class TestMemberListInvalidRolesJsonSchema:
         # ``member revoke`` 가 ``--yes`` 누락 시 ``CLI_CONFIRMATION_REQUIRED`` 로
         # 실패하므로 (#1468 Codex review attempt 1, P2-B), JSON payload 의
         # ``revoke_command`` 는 ``--yes`` 를 포함해 즉시 실행 가능해야 한다.
-        assert a["revoke_command"] == "ante member revoke agent-bad-1 --yes"
+        # 또한 attempt 2 P2-A: ``member_id`` 를 ``shlex.quote`` 로 셸 안전 인용
+        # 하고, 옵션/포지셔널 경계는 ``--`` separator 로 명시한다.
+        assert a["revoke_command"] == "ante member revoke --yes -- agent-bad-1"
 
         # legacy revoked row
         legacy_row = data["legacy_revoked"][0]
@@ -886,6 +888,10 @@ class TestMemberListInvalidRolesJsonSchema:
         # token_hash 빈 문자열 → has_token False, token_expires_at == null
         assert legacy_row["has_token"] is False
         assert legacy_row["token_expires_at"] is None
+        # attempt 2 P2-B: legacy_revoked row 는 이미 revoked 상태이므로
+        # ``MemberService.revoke`` 가 active/suspended 만 허용해 noop 가 된다.
+        # 키 자체를 누락해 "추가 조치 불요" 임을 명시한다.
+        assert "revoke_command" not in legacy_row
 
         # 보안: 어떤 row 에도 token_hash 키가 없어야 한다.
         for row in data["actionable"] + data["legacy_revoked"]:
@@ -896,12 +902,16 @@ class TestMemberListInvalidRolesJsonSchema:
         assert "HASH-MUST-NOT-LEAK-1" not in result.output
 
     def test_cli_list_invalid_roles_revoke_command_includes_yes_flag(self) -> None:
-        """``revoke_command`` 출력이 ``--yes`` 를 포함한다 (#1468 P2-B 회귀).
+        """actionable row 의 ``revoke_command`` 가 ``--yes`` 를 포함한다 (#1468 회귀).
 
         ``ante member revoke`` 는 ``--yes`` 누락 시 prompt 없이
         ``CLI_CONFIRMATION_REQUIRED`` 로 실패하므로, JSON payload 가 권장 명령으로
         ``--yes`` 없는 형태를 출력하면 운영자가 그대로 복붙해도 실패한다.
         본 명령은 즉시 실행 가능한 형태여야 한다.
+
+        attempt 2 P2-B 후속: legacy_revoked row 는 ``revoke_command`` 키 자체가
+        포함되지 않으므로 (이미 revoked → MemberService.revoke 가 noop 으로 실패),
+        본 어서션은 ``actionable`` 카테고리에만 적용한다.
         """
         actionable = _make_invalid_role_member(
             "agent-must-have-yes", role="oracle_invalid_role", status="active"
@@ -923,13 +933,92 @@ class TestMemberListInvalidRolesJsonSchema:
 
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
-        # actionable 과 legacy_revoked 두 카테고리 모두 ``--yes`` 를 포함해야 한다.
-        for row in data["actionable"] + data["legacy_revoked"]:
+        # actionable 카테고리만 ``revoke_command`` 를 갖고, 형식은
+        # ``ante member revoke --yes -- <quoted member_id>`` 다.
+        for row in data["actionable"]:
             cmd = row["revoke_command"]
-            assert cmd.endswith(" --yes"), (
-                f"revoke_command 는 ``--yes`` 로 끝나야 한다: {cmd!r}"
+            assert "--yes" in cmd, (
+                f"revoke_command 는 ``--yes`` 를 포함해야 한다: {cmd!r}"
             )
-            assert cmd == f"ante member revoke {row['member_id']} --yes"
+            # `member_id` 가 셸 메타문자를 포함하지 않는 단순 토큰일 때
+            # ``shlex.quote`` 는 따옴표 없이 그대로 반환한다.
+            assert cmd == f"ante member revoke --yes -- {row['member_id']}"
+        # legacy_revoked row 에는 키 자체가 없다 (P2-B).
+        for row in data["legacy_revoked"]:
+            assert "revoke_command" not in row, (
+                f"legacy_revoked row 는 revoke_command 키를 가지면 안 된다: {row!r}"
+            )
+
+    def test_cli_list_invalid_roles_revoke_command_shell_safe_quotes_member_id(
+        self,
+    ) -> None:
+        """공백/메타문자가 든 ``member_id`` 는 ``shlex.quote`` 로 안전 인용된다.
+
+        attempt 2 P2-A: ``member_id`` 는 service/API 에서 형식 제한이 없는
+        문자열이라 공백/셸 메타문자/`-`-prefix 가 들어갈 수 있다. 운영자가 payload
+        를 복사 실행할 때 인자 splitting / 옵션 파싱 / 셸 substitution 위험이
+        없도록 actionable row 의 ``revoke_command`` 는 반드시 ``shlex.quote`` 결과
+        를 포함해야 한다.
+        """
+        import shlex as _shlex
+
+        unsafe_id = "agent bad id"  # 공백 포함 → quote 후 따옴표 감싸짐.
+        actionable = _make_invalid_role_member(
+            unsafe_id, role="oracle_invalid_role", status="active"
+        )
+        ctx, _service = _patch_create_service_with_scan(
+            InvalidRoleScan(actionable=[actionable], legacy_revoked=[])
+        )
+        with ctx:
+            result = _invoke_cli(
+                ["--format", "json", "member", "list-invalid-roles"],
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        cmd = data["actionable"][0]["revoke_command"]
+        quoted = _shlex.quote(unsafe_id)
+        # quote 결과는 단순 토큰이 아니라 따옴표로 감싼 형태여야 한다.
+        assert quoted != unsafe_id, (
+            "테스트 가정: 공백이 든 id 는 shlex.quote 가 따옴표로 감싼다"
+        )
+        assert cmd == f"ante member revoke --yes -- {quoted}"
+        # 원본 공백 id 가 그대로 끼지 않았음을 확인한다 (인용된 형태만 노출).
+        assert f"-- {unsafe_id}" not in cmd
+
+    def test_cli_list_invalid_roles_legacy_revoked_omits_revoke_command(self) -> None:
+        """legacy_revoked row 의 JSON dict 에 ``revoke_command`` 키가 없다.
+
+        attempt 2 P2-B: legacy_revoked row 는 이미 ``status=revoked`` 다.
+        ``MemberService.revoke`` 가 active/suspended 만 허용하므로 재실행 시
+        실패한다. payload 에 noop 명령을 싣지 않고 키 자체를 누락해 "추가 조치
+        불요" 임을 명시한다.
+        """
+        legacy_only = _make_invalid_role_member(
+            "legacy-revoked-1",
+            role="oracle_invalid_role",
+            status="revoked",
+            token_hash="",
+            token_expires_at="",
+        )
+        ctx, _service = _patch_create_service_with_scan(
+            InvalidRoleScan(actionable=[], legacy_revoked=[legacy_only])
+        )
+        with ctx:
+            result = _invoke_cli(
+                ["--format", "json", "member", "list-invalid-roles"],
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["legacy_revoked_count"] == 1
+        legacy_row = data["legacy_revoked"][0]
+        assert legacy_row["member_id"] == "legacy-revoked-1"
+        assert legacy_row["status"] == "revoked"
+        # 핵심 회귀: revoke_command 키가 없어야 한다 (None 도 아님).
+        assert "revoke_command" not in legacy_row, (
+            f"legacy_revoked row 의 dict 키 목록: {list(legacy_row.keys())}"
+        )
 
 
 class TestMemberListInvalidRolesTable:

--- a/tests/unit/test_cli_member_non_interactive.py
+++ b/tests/unit/test_cli_member_non_interactive.py
@@ -874,7 +874,10 @@ class TestMemberListInvalidRolesJsonSchema:
         assert a["created_at"] == "2026-04-01 00:00:00"
         assert a["has_token"] is True
         assert a["token_expires_at"] == "2026-07-01 00:00:00"
-        assert a["revoke_command"] == "ante member revoke agent-bad-1"
+        # ``member revoke`` 가 ``--yes`` 누락 시 ``CLI_CONFIRMATION_REQUIRED`` 로
+        # 실패하므로 (#1468 Codex review attempt 1, P2-B), JSON payload 의
+        # ``revoke_command`` 는 ``--yes`` 를 포함해 즉시 실행 가능해야 한다.
+        assert a["revoke_command"] == "ante member revoke agent-bad-1 --yes"
 
         # legacy revoked row
         legacy_row = data["legacy_revoked"][0]
@@ -891,6 +894,42 @@ class TestMemberListInvalidRolesJsonSchema:
             )
         # raw token hash 문자열도 출력에 등장하지 않는다.
         assert "HASH-MUST-NOT-LEAK-1" not in result.output
+
+    def test_cli_list_invalid_roles_revoke_command_includes_yes_flag(self) -> None:
+        """``revoke_command`` 출력이 ``--yes`` 를 포함한다 (#1468 P2-B 회귀).
+
+        ``ante member revoke`` 는 ``--yes`` 누락 시 prompt 없이
+        ``CLI_CONFIRMATION_REQUIRED`` 로 실패하므로, JSON payload 가 권장 명령으로
+        ``--yes`` 없는 형태를 출력하면 운영자가 그대로 복붙해도 실패한다.
+        본 명령은 즉시 실행 가능한 형태여야 한다.
+        """
+        actionable = _make_invalid_role_member(
+            "agent-must-have-yes", role="oracle_invalid_role", status="active"
+        )
+        legacy = _make_invalid_role_member(
+            "legacy-also-yes",
+            role="oracle_invalid_role",
+            status="revoked",
+            token_hash="",
+            token_expires_at="",
+        )
+        ctx, _service = _patch_create_service_with_scan(
+            InvalidRoleScan(actionable=[actionable], legacy_revoked=[legacy])
+        )
+        with ctx:
+            result = _invoke_cli(
+                ["--format", "json", "member", "list-invalid-roles"],
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        # actionable 과 legacy_revoked 두 카테고리 모두 ``--yes`` 를 포함해야 한다.
+        for row in data["actionable"] + data["legacy_revoked"]:
+            cmd = row["revoke_command"]
+            assert cmd.endswith(" --yes"), (
+                f"revoke_command 는 ``--yes`` 로 끝나야 한다: {cmd!r}"
+            )
+            assert cmd == f"ante member revoke {row['member_id']} --yes"
 
 
 class TestMemberListInvalidRolesTable:

--- a/tests/unit/test_cli_member_non_interactive.py
+++ b/tests/unit/test_cli_member_non_interactive.py
@@ -1024,9 +1024,13 @@ class TestMemberListInvalidRolesJsonSchema:
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
         cmd = data["actionable"][0]["revoke_command"]
-        quoted_dir = _shlex.quote(str(custom_dir))
+        # attempt 4 P2: payload 는 ``expanduser().resolve()`` 로 정규화된
+        # 절대 경로를 싣는다. tmp_path 는 이미 절대 경로지만 macOS 등에서는
+        # ``/var/...`` → ``/private/var/...`` symlink 해소가 발생할 수 있으므로
+        # ``resolve()`` 결과를 기준으로 비교한다.
+        quoted_dir = _shlex.quote(str(custom_dir.resolve()))
         # ``--config-dir`` 인자가 ``ante`` 와 ``member`` 사이에 들어가며,
-        # 경로는 ``shlex.quote`` 인용된 형태로 그대로 보존된다.
+        # 경로는 절대 경로 + ``shlex.quote`` 인용된 형태로 보존된다.
         assert cmd == (
             f"ante --config-dir {quoted_dir} "
             f"member revoke --yes -- agent-other-instance"
@@ -1070,9 +1074,11 @@ class TestMemberListInvalidRolesJsonSchema:
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
         cmd = data["actionable"][0]["revoke_command"]
-        quoted_dir = _shlex.quote(str(spaced_dir))
+        # attempt 4 P2: ``resolve()`` 후 절대 경로 기준으로 quote 비교한다.
+        resolved_spaced = spaced_dir.resolve()
+        quoted_dir = _shlex.quote(str(resolved_spaced))
         # quote 가 따옴표로 감싼 형태여야 한다 (단순 토큰이 아님).
-        assert quoted_dir != str(spaced_dir)
+        assert quoted_dir != str(resolved_spaced)
         assert cmd == (
             f"ante --config-dir {quoted_dir} member revoke --yes -- agent-space-dir"
         )
@@ -1104,6 +1110,88 @@ class TestMemberListInvalidRolesJsonSchema:
         # default 일 때는 ``--config-dir`` 인자가 아예 없는 표준 형태.
         assert cmd == "ante member revoke --yes -- agent-default-instance"
         assert "--config-dir" not in cmd
+
+    def test_cli_list_invalid_roles_revoke_command_normalizes_relative_config_dir(
+        self,
+        tmp_path,  # noqa: ANN001
+    ) -> None:
+        """상대 ``--config-dir`` 도 payload 에서는 **절대 경로** 로 정규화된다.
+
+        attempt 4 P2: 운영자가 ``ante --config-dir custom member
+        list-invalid-roles`` 처럼 상대 경로로 호출한 경우, payload 의
+        ``revoke_command`` 가 raw ``custom`` 을 그대로 들고 있으면 그 payload 를
+        다른 CWD 에서 복사 실행했을 때 새로운 CWD 아래의 ``custom`` 디렉토리를
+        가리켜 다른 인스턴스 DB 에 실행될 위험이 있다. ``_explicit_config_dir``
+        가 ``Path.expanduser().resolve()`` 로 절대 경로화하므로 payload 는
+        실행 위치에 관계없이 처음 스캔한 인스턴스를 가리킨다.
+
+        ``tmp_path`` 안에 상대 디렉토리를 만들고 CliRunner 의 isolated_filesystem
+        으로 그 부모를 CWD 로 잡은 뒤, ``--config-dir custom`` 으로 호출한다.
+        payload 에는 ``str((cwd / "custom").resolve())`` 가 들어가야 한다.
+        """
+        import os
+        import shlex as _shlex
+        from pathlib import Path as _Path
+
+        # tmp_path 내에 상대 경로로 접근할 디렉토리를 미리 만든다.
+        # isolated_filesystem 이 잡는 CWD 아래에 동일 이름이 존재해야
+        # ``--config-dir custom`` (상대) 해석이 의미를 갖는다.
+        relative_name = "custom"
+        actionable = _make_invalid_role_member(
+            "agent-relative-cfg", role="oracle_invalid_role", status="active"
+        )
+        ctx, _service = _patch_create_service_with_scan(
+            InvalidRoleScan(actionable=[actionable], legacy_revoked=[])
+        )
+
+        runner = CliRunner()
+        with ctx, runner.isolated_filesystem(temp_dir=tmp_path) as cwd:
+            # 상대 경로 ``custom`` 이 가리킬 절대 위치.
+            absolute_target = (_Path(cwd) / relative_name).resolve()
+            absolute_target.mkdir(parents=True, exist_ok=True)
+            assert not os.path.isabs(relative_name)  # 가정: 상대 경로
+            with patch(
+                "ante.cli.main.authenticate_member", side_effect=_mock_authenticate
+            ):
+                result = runner.invoke(
+                    cli,
+                    [
+                        "--format",
+                        "json",
+                        "--config-dir",
+                        relative_name,
+                        "member",
+                        "list-invalid-roles",
+                    ],
+                    obj={"member": _make_master()},
+                    env={"ANTE_MEMBER_TOKEN": ""},
+                    catch_exceptions=False,
+                )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        cmd = data["actionable"][0]["revoke_command"]
+        # 핵심 회귀: payload 의 ``--config-dir`` 값은 **절대 경로** 다.
+        # raw ``custom`` 이 그대로 들어가면 다른 CWD 실행 시 인스턴스가 바뀐다.
+        assert f"--config-dir {relative_name} " not in cmd, (
+            "attempt 4 회귀: payload 에 raw 상대 경로가 그대로 들어가면 안 된다: "
+            f"{cmd!r}"
+        )
+        # 정규화된 절대 경로(``shlex.quote``)가 들어가야 한다.
+        quoted_abs = _shlex.quote(str(absolute_target))
+        assert cmd == (
+            f"ante --config-dir {quoted_abs} member revoke --yes -- agent-relative-cfg"
+        )
+        # 추가 invariant: payload 의 ``--config-dir`` 토큰 다음 값은 절대 경로
+        # (``/`` 로 시작) 여야 한다.
+        cfg_token_value_start = cmd.index("--config-dir ") + len("--config-dir ")
+        # quote 가 따옴표로 감쌌으면 첫 char 는 따옴표일 수도 있으므로
+        # 따옴표/슬래시 둘 중 하나로 시작해야 한다.
+        first_char = cmd[cfg_token_value_start]
+        assert first_char in ("/", "'", '"'), (
+            "payload 의 --config-dir 값은 절대 경로(또는 quoted 절대 경로)여야 한다:"
+            f" {cmd!r}"
+        )
 
     def test_cli_list_invalid_roles_legacy_revoked_omits_revoke_command(self) -> None:
         """legacy_revoked row 의 JSON dict 에 ``revoke_command`` 키가 없다.

--- a/tests/unit/test_cli_member_non_interactive.py
+++ b/tests/unit/test_cli_member_non_interactive.py
@@ -986,6 +986,125 @@ class TestMemberListInvalidRolesJsonSchema:
         # 원본 공백 id 가 그대로 끼지 않았음을 확인한다 (인용된 형태만 노출).
         assert f"-- {unsafe_id}" not in cmd
 
+    def test_cli_list_invalid_roles_revoke_command_preserves_config_dir(
+        self,
+        tmp_path,  # noqa: ANN001
+    ) -> None:
+        """루트 ``--config-dir`` 가 ``revoke_command`` 에 보존 (#1468 attempt 3).
+
+        ``ante --config-dir /path member list-invalid-roles`` 로 다른 인스턴스를
+        스캔할 때, payload 의 ``revoke_command`` 가 ``--config-dir`` 을 누락하면
+        운영자가 그대로 복사 실행했을 때 default config_dir DB 에 실행되어
+        엉뚱한 인스턴스를 건드린다. 본 회귀 테스트는 actionable row 의
+        ``revoke_command`` 가 동일한 ``--config-dir`` 을 ``shlex.quote`` 인용된
+        형태로 보존하는지 검증한다.
+        """
+        import shlex as _shlex
+
+        custom_dir = tmp_path / "ante-custom"
+        custom_dir.mkdir()
+        actionable = _make_invalid_role_member(
+            "agent-other-instance", role="oracle_invalid_role", status="active"
+        )
+        ctx, _service = _patch_create_service_with_scan(
+            InvalidRoleScan(actionable=[actionable], legacy_revoked=[])
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "--config-dir",
+                    str(custom_dir),
+                    "member",
+                    "list-invalid-roles",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        cmd = data["actionable"][0]["revoke_command"]
+        quoted_dir = _shlex.quote(str(custom_dir))
+        # ``--config-dir`` 인자가 ``ante`` 와 ``member`` 사이에 들어가며,
+        # 경로는 ``shlex.quote`` 인용된 형태로 그대로 보존된다.
+        assert cmd == (
+            f"ante --config-dir {quoted_dir} "
+            f"member revoke --yes -- agent-other-instance"
+        )
+        # 회귀: ``--yes`` / ``--`` separator / quoted member_id 도 같이 유지된다.
+        assert "--yes" in cmd
+        assert " -- " in cmd
+
+    def test_cli_list_invalid_roles_revoke_command_quotes_config_dir_with_spaces(
+        self,
+        tmp_path,  # noqa: ANN001
+    ) -> None:
+        """``--config-dir`` 경로에 공백이 있어도 ``shlex.quote`` 로 안전 인용된다.
+
+        macOS 의 ``~/Library/Application Support/...`` 같은 공백 포함 경로에서
+        운영자가 payload 를 복사 실행할 때 인자 splitting 으로 ``--config-dir``
+        값이 첫 토큰만 잡히는 사고를 막는다 (#1468 attempt 3 P2 회귀).
+        """
+        import shlex as _shlex
+
+        spaced_dir = tmp_path / "ante config with space"
+        spaced_dir.mkdir()
+        actionable = _make_invalid_role_member(
+            "agent-space-dir", role="oracle_invalid_role", status="active"
+        )
+        ctx, _service = _patch_create_service_with_scan(
+            InvalidRoleScan(actionable=[actionable], legacy_revoked=[])
+        )
+        with ctx:
+            result = _invoke_cli(
+                [
+                    "--format",
+                    "json",
+                    "--config-dir",
+                    str(spaced_dir),
+                    "member",
+                    "list-invalid-roles",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        cmd = data["actionable"][0]["revoke_command"]
+        quoted_dir = _shlex.quote(str(spaced_dir))
+        # quote 가 따옴표로 감싼 형태여야 한다 (단순 토큰이 아님).
+        assert quoted_dir != str(spaced_dir)
+        assert cmd == (
+            f"ante --config-dir {quoted_dir} member revoke --yes -- agent-space-dir"
+        )
+
+    def test_cli_list_invalid_roles_revoke_command_omits_config_dir_when_default(
+        self,
+    ) -> None:
+        """``--config-dir`` 미지정 시 ``revoke_command`` 에 인자가 들어가지 않는다.
+
+        default config_dir 케이스에서 기존 호출 형태(``ante member revoke ...``)
+        를 유지해 운영자 워크플로우/문서를 깨지 않게 한다. 본 회귀 테스트는
+        existing test_cli_list_invalid_roles_command_outputs_json 과 함께 default
+        형태가 보존됨을 명시적으로 확인한다.
+        """
+        actionable = _make_invalid_role_member(
+            "agent-default-instance", role="oracle_invalid_role", status="active"
+        )
+        ctx, _service = _patch_create_service_with_scan(
+            InvalidRoleScan(actionable=[actionable], legacy_revoked=[])
+        )
+        with ctx:
+            result = _invoke_cli(
+                ["--format", "json", "member", "list-invalid-roles"],
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        cmd = data["actionable"][0]["revoke_command"]
+        # default 일 때는 ``--config-dir`` 인자가 아예 없는 표준 형태.
+        assert cmd == "ante member revoke --yes -- agent-default-instance"
+        assert "--config-dir" not in cmd
+
     def test_cli_list_invalid_roles_legacy_revoked_omits_revoke_command(self) -> None:
         """legacy_revoked row 의 JSON dict 에 ``revoke_command`` 키가 없다.
 

--- a/tests/unit/test_member_service.py
+++ b/tests/unit/test_member_service.py
@@ -1,0 +1,199 @@
+"""``MemberService.find_invalid_role_members`` 회귀 (#1468).
+
+#1465(write path 차단), #1466(auth read-path guard) 이후 신규 invalid-role row
+는 생성되지 않지만 legacy row 가 DB 에 남아 있을 수 있다. 본 모듈은
+``find_invalid_role_members`` 의 두 카테고리 분리(``actionable`` /
+``legacy_revoked``) 와 CLI revoke 후 이동 동작을 잠근다.
+
+write path 가 invalid role 을 거부하므로 (`MemberService._assert_role_enum`),
+legacy row 재현은 정상 ``register`` 후 DB 를 직접 ``UPDATE`` 해 ``role`` 을 변조한다
+(``test_member_auth_invalid_role.py`` 의 ``_seed_invalid_role_*`` 패턴 재사용).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.core.database import Database
+from ante.eventbus import EventBus
+from ante.member.models import MemberStatus, MemberType
+from ante.member.service import InvalidRoleScan, MemberService
+
+
+@pytest.fixture
+async def db(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+def eventbus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+async def service(db, eventbus) -> MemberService:
+    svc = MemberService(db, eventbus)
+    await svc.initialize()
+    return svc
+
+
+async def _seed_invalid_role_row(
+    db: Database,
+    service: MemberService,
+    *,
+    member_id: str,
+    invalid_role: str = "oracle_invalid_role",
+) -> None:
+    """write path 를 우회해 legacy invalid-role agent row 를 심는다."""
+    await service.register(member_id, MemberType.AGENT)
+    await db.execute(
+        "UPDATE members SET role = ? WHERE member_id = ?",
+        (invalid_role, member_id),
+    )
+
+
+# ── Service-layer regression ───────────────────────────────────────
+
+
+class TestFindInvalidRoleMembers:
+    """``MemberService.find_invalid_role_members`` 의 카테고리 분리 회귀.
+
+    본 클래스의 ``test_find_invalid_role_members_*`` 메소드 이름은 본문 task
+    bullet 과 1:1 매핑된다. 추가로 동일 모듈 하단에 ``test_member_invalid_role_*``
+    모듈-level 함수가 같은 어서션을 호출하는 thin alias 로 노출된다. 이는
+    본문 verification command ``pytest -k "member_invalid_role or
+    list_invalid_roles"`` 의 substring 매칭 요구를 충족시키기 위함이다 (pytest
+    -k 는 literal underscore substring 을 요구한다).
+    """
+
+    async def test_find_invalid_role_members_empty(
+        self, service: MemberService
+    ) -> None:
+        """정상 role row 만 있을 때 두 리스트 모두 비어 있다."""
+        await service.bootstrap_master("owner", "pass123")
+        await service.register("agent-ok-1", MemberType.AGENT, registered_by="owner")
+        await service.register("agent-ok-2", MemberType.AGENT, registered_by="owner")
+
+        scan = await service.find_invalid_role_members()
+
+        assert isinstance(scan, InvalidRoleScan)
+        assert scan.actionable == []
+        assert scan.legacy_revoked == []
+
+    async def test_find_invalid_role_members_with_invalid_rows(
+        self, service: MemberService, db: Database
+    ) -> None:
+        """invalid role row 2건(active 1, suspended 1) + 정상 2건 → actionable 2건.
+
+        suspended 도 ``status != revoked`` 이므로 actionable 로 분류된다.
+        """
+        await service.bootstrap_master("owner", "pass123")
+        await _seed_invalid_role_row(db, service, member_id="agent-bad-active")
+        await _seed_invalid_role_row(db, service, member_id="agent-bad-suspended")
+        # suspended 상태로 전환 (invalid-role row 라도 suspend 자체는 service-layer
+        # 가 role enum 을 검증하지 않으므로 동작한다).
+        await service.suspend("agent-bad-suspended", suspended_by="owner")
+        # 정상 row 도 같이 둔다.
+        await service.register("agent-ok", MemberType.AGENT, registered_by="owner")
+
+        scan = await service.find_invalid_role_members()
+
+        ids = {m.member_id for m in scan.actionable}
+        assert ids == {"agent-bad-active", "agent-bad-suspended"}
+        assert scan.legacy_revoked == []
+        # actionable 안의 status 분포 검증 (active 1 + suspended 1).
+        statuses = {m.status for m in scan.actionable}
+        assert statuses == {MemberStatus.ACTIVE.value, MemberStatus.SUSPENDED.value}
+
+    async def test_find_invalid_role_members_legacy_revoked_category(
+        self, service: MemberService, db: Database
+    ) -> None:
+        """invalid role + ``status=revoked`` 인 row 는 ``legacy_revoked`` 로 분리."""
+        await service.bootstrap_master("owner", "pass123")
+        await _seed_invalid_role_row(db, service, member_id="agent-bad-revoked")
+        # 정상 register 후 revoke 한 다음, role 만 invalid 로 변조하면 status=revoked
+        # 이면서 role invalid 인 legacy row 가 된다. 단 revoke 후 role 변조는
+        # service-layer 가 막지 않는다(DB 직접 UPDATE).
+        await db.execute(
+            "UPDATE members SET status = ?, revoked_at = '2026-01-01 00:00:00', "
+            "token_hash = '' WHERE member_id = ?",
+            (MemberStatus.REVOKED.value, "agent-bad-revoked"),
+        )
+        # 정상 row 1건.
+        await service.register("agent-ok", MemberType.AGENT, registered_by="owner")
+
+        scan = await service.find_invalid_role_members()
+
+        assert scan.actionable == []
+        assert len(scan.legacy_revoked) == 1
+        assert scan.legacy_revoked[0].member_id == "agent-bad-revoked"
+        assert scan.legacy_revoked[0].status == MemberStatus.REVOKED.value
+
+    async def test_find_invalid_role_members_after_cli_revoke(
+        self, service: MemberService, db: Database
+    ) -> None:
+        """actionable invalid row 를 ``revoke`` 후 같은 row 가 legacy_revoked 로 이동.
+
+        본 테스트는 본문 task 의 핵심 invariant 를 잠근다: revoke 후
+        ``actionable_count == 0`` 이고, ``legacy_revoked_count`` 는 누적된다.
+        """
+        await service.bootstrap_master("owner", "pass123")
+        await _seed_invalid_role_row(db, service, member_id="agent-bad")
+
+        scan_before = await service.find_invalid_role_members()
+        assert [m.member_id for m in scan_before.actionable] == ["agent-bad"]
+        assert scan_before.legacy_revoked == []
+
+        # ``ante member revoke`` 와 동일 service call.
+        revoked = await service.revoke("agent-bad", revoked_by="owner")
+        assert revoked.status == MemberStatus.REVOKED.value
+        assert revoked.token_hash == ""
+
+        scan_after = await service.find_invalid_role_members()
+        assert scan_after.actionable == []
+        assert [m.member_id for m in scan_after.legacy_revoked] == ["agent-bad"]
+        # revoke 가 token_hash 를 무효화했다 — has_token 비노출 회귀 보호.
+        assert scan_after.legacy_revoked[0].token_hash == ""
+
+
+# ── pytest -k "member_invalid_role" alias 함수 ───────────────────────
+#
+# 본문 verification command 의 keyword expression 은 substring 매칭 (literal
+# underscore 포함) 이므로, 모듈-level 함수 이름에 ``member_invalid_role`` 토큰을
+# 포함시킨다. 각 alias 는 위 ``TestFindInvalidRoleMembers`` 의 메소드를 동일
+# fixture 로 호출해 동일 invariant 를 재검증한다. test count 가 늘어나지만
+# 회귀 보호 측면에서는 동일 어서션이며, alias 라는 의도를 docstring 으로 명시한다.
+
+
+async def test_member_invalid_role_finder_empty(service: MemberService) -> None:
+    """alias of ``test_find_invalid_role_members_empty`` (-k 매칭용)."""
+    await TestFindInvalidRoleMembers().test_find_invalid_role_members_empty(service)
+
+
+async def test_member_invalid_role_finder_with_invalid_rows(
+    service: MemberService, db: Database
+) -> None:
+    """alias of ``test_find_invalid_role_members_with_invalid_rows`` (-k 매칭용)."""
+    await TestFindInvalidRoleMembers().test_find_invalid_role_members_with_invalid_rows(
+        service, db
+    )
+
+
+async def test_member_invalid_role_finder_legacy_revoked_category(
+    service: MemberService, db: Database
+) -> None:
+    """``test_find_invalid_role_members_legacy_revoked_category`` alias (-k 매칭)."""
+    instance = TestFindInvalidRoleMembers()
+    await instance.test_find_invalid_role_members_legacy_revoked_category(service, db)
+
+
+async def test_member_invalid_role_finder_after_cli_revoke(
+    service: MemberService, db: Database
+) -> None:
+    """alias of ``test_find_invalid_role_members_after_cli_revoke`` (-k 매칭용)."""
+    await TestFindInvalidRoleMembers().test_find_invalid_role_members_after_cli_revoke(
+        service, db
+    )


### PR DESCRIPTION
Closes #1468

## Summary
- 신규 `MemberService.find_invalid_role_members() -> InvalidRoleScan` (actionable + legacy_revoked 분리). `MemberRole` enum SSOT에 없는 role을 가진 row 식별.
- 신규 CLI `ante member list-invalid-roles` (offline 분류, `@require_auth` + `@require_scope("member:read")`). JSON/table 출력, structured log.
- JSON 스키마: `recommended_action`, `valid_roles`, `actionable_count`, `legacy_revoked_count`, per-row `member_id/role/type/name/status/created_at/has_token/token_expires_at` + actionable에만 `revoke_command`. `token_hash` 노출 금지.
- `revoke_command` payload integrity 다중 가드:
  - `shlex.quote(member_id)` 셸 안전 인용 + `--yes -- <id>` separator.
  - `--config-dir` 현재 ctx 값 보존 (운영자가 명시한 인스턴스 그대로 대상).
  - `Path.expanduser().resolve()`로 절대 경로 정규화 (CWD 의존성 제거).
  - `legacy_revoked` row는 revoke_command 키 누락(이미 revoked, 추가 조치 불필요).
- 신규 runbook `docs/runbooks/07-member-invalid-role-cleanup.md` (식별 → 검토 → revoke → 사후 검증, CLI revoke audit gap 명시).
- `docs/runbooks/README.md` 인덱스 표 07번 추가.
- `docs/specs/cli/03-commands.md` 명령 표/예시 갱신.

## Test Plan
- `ruff check && ruff format --check` — PASS
- `pytest tests/unit/test_member_service.py -v` — 8 passed (신규 4 케이스 포함)
- `pytest tests/unit/test_cli_member_non_interactive.py -v` — 35 passed (신규 11+ 케이스 포함)
- `pytest tests/unit -k "member_invalid_role or list_invalid_roles" -v` — 15 passed
- 기존 member 도메인 회귀: `pytest tests/unit/test_member.py tests/unit/test_member_auth_invalid_role.py tests/unit/test_member_create_invalid_role.py tests/unit/test_member_service_master_guard.py` — 139 passed

## Plan Preflight
- verdict: approve-implement (v2)
- 이슈 본문 v2 기준. Codex 브랜치 리뷰 5회 attempt(4 fix → attempt 5 PASS).

## Codex Review History
- attempt 1 FAIL: --db-path 옵션 무시 + revoke --yes 누락 → fix (옵션 제거 + --yes 추가)
- attempt 2 FAIL: shell-safe quoting + legacy_revoked revoke_command 노출 → fix (shlex.quote + key omission)
- attempt 3 FAIL: --config-dir 보존 → fix (ctx에서 추출 + revoke_command에 포함)
- attempt 4 FAIL: --config-dir 절대 경로 정규화 → fix (Path.expanduser().resolve())
- attempt 5 PASS: 기존 동작 깨뜨리는 결함 없음.

## Out of Scope (별도 이슈)
- write path 입력 검증: #1465 (close).
- auth read-path guard: #1466 (close).
- frontend role type 분리: #1467.
- 자동 migration / silent rewrite.
- CLI revoke audit log 추가 (runbook 한계 명시).
- 토큰 단위 별도 cleanup 명령 (member.token_hash가 cascade).
- 다른 DB(`--db-path` 옵션) 점검 (canonical DB만).

🤖 Generated with [Claude Code](https://claude.com/claude-code)