### PR TITLE
fix(web): reject extra body on POST /api/accounts/{id}/activate (#1510)

### DIFF
--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -7,7 +7,7 @@ import logging
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from ante.web.deps import (
     get_account_service,
@@ -902,6 +902,36 @@ async def suspend_account(
     }
 
 
+# POST /api/accounts/{account_id}/activate body 정책 (#1510, v3).
+#
+# ``activate``는 ``suspend``와 동일한 너그러운 no-body 패턴을 따른다:
+#
+# | 입력                              | 동작                                |
+# |-----------------------------------|-------------------------------------|
+# | 빈 body                           | 200, service 호출                   |
+# | JSON ``null``                     | 200, service 호출                   |
+# | ``{}``                            | 200, service 호출                   |
+# | 비-object JSON (``["x"]``, …)    | 422                                 |
+# | invalid JSON                      | 422                                 |
+# | extra key dict (``{"x": 1}``)    | 422 (``extra_forbidden``)           |
+#
+# ``_ActivateNoBody``는 field가 하나도 없는 BaseModel + ``extra="forbid"``로
+# 정의해 ``{}``는 통과시키되 임의의 extra key를 거부한다. ``e.errors()``를
+# detail에 그대로 전달해 ``suspend_account``의 detail 직렬화와 호환된다.
+#
+# OpenAPI route 데코레이터는 변경하지 않는다 — 현재 ``activate``는 requestBody
+# schema를 export하지 않으며(``frontend/src/types/api.generated.ts``의
+# ``requestBody?: never``), generated artifacts 무영향이라는 v3 결단을 따른다.
+class _ActivateNoBody(BaseModel):
+    """``POST /api/accounts/{id}/activate`` mini forbid body 모델.
+
+    필드를 정의하지 않고 ``extra="forbid"``만 적용한다. 빈 dict ``{}``는 통과,
+    extra key 1개 이상이면 ``ValidationError``가 발생한다 (#1510).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+
 @router.post(
     "/{account_id}/activate",
     response_model=AccountActionResponse,
@@ -935,8 +965,35 @@ async def activate_account(
 ) -> dict[str, Any]:
     """계좌 재활성화. 인증된 master/human 또는 ``account:write`` scope 를 보유한
     agent 만 호출 가능 (#1407 — spec ``account:write`` 정합, #1352
-    master_caller 에서 마이그레이션)."""
+    master_caller 에서 마이그레이션).
+
+    ``suspend_account``와 동일한 raw body 파싱 패턴(빈 body / null / ``{}``는
+    통과, 비-object / malformed JSON / extra key dict는 422)을 적용한다
+    (#1510). 인증 가드는 dependency level이므로 body validation보다 먼저
+    실행되며, invalid body 시에는 service / audit 호출이 발생하지 않는다.
+    """
     from ante.account.errors import AccountDeletedError, AccountNotFoundError
+
+    # 1. raw body 읽기 + JSON 파싱 (인증은 dependency에서 이미 통과한 상태).
+    raw = await request.body()
+    if raw != b"":
+        try:
+            payload = json.loads(raw)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise HTTPException(
+                status_code=422, detail="요청 body의 JSON 파싱에 실패했습니다."
+            ) from None
+        # JSON ``null``은 빈 body와 동일하게 통과 (``suspend``와 정합).
+        if payload is not None:
+            if not isinstance(payload, dict):
+                raise HTTPException(
+                    status_code=422, detail="요청 body는 JSON object여야 합니다."
+                )
+            # extra=forbid 검증 — 빈 dict ``{}``는 통과, extra key dict는 422.
+            try:
+                _ActivateNoBody.model_validate(payload)
+            except ValidationError as e:
+                raise HTTPException(status_code=422, detail=e.errors()) from None
 
     try:
         await account_service.activate(account_id, activated_by=caller_id)

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -105,6 +105,9 @@ class FakeAccountService:
         # 테스트가 다음 get_broker 호출에서 실패하는 어댑터를 받도록 하고
         # 싶을 때 계좌 ID를 넣는다.
         self._fail_connect_for: set[str] = set()
+        # invalid body 시 ``activate``가 호출되지 않았음을 단언하기 위한
+        # 카운터 (#1510 — body contract drift fix).
+        self.activate_calls: int = 0
 
     async def create(self, account: Account) -> Account:
         if account.account_id in self._accounts:
@@ -208,6 +211,7 @@ class FakeAccountService:
         self._accounts[account_id].status = AccountStatus.SUSPENDED
 
     async def activate(self, account_id: str, activated_by: str) -> None:
+        self.activate_calls += 1
         if account_id not in self._accounts:
             raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
         account = self._accounts[account_id]
@@ -1593,6 +1597,197 @@ class TestActivateAccount:
 
         resp = client.post("/api/accounts/test-account/activate")
         assert resp.status_code == 409
+
+    # ------------------------------------------------------------------
+    # #1510 — POST /api/accounts/{id}/activate body contract drift fix.
+    #
+    # ``suspend_account``와 동일한 너그러운 no-body 패턴을 적용한다:
+    #   - 빈 body / JSON ``null`` / ``{}``: 200, service 호출
+    #   - 비-object JSON / malformed JSON / extra key dict: 422
+    #   - invalid body 시 service / audit 미발생 (auth-first 가드)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _activate_audit_logs(audit_logger: FakeAuditLogger) -> list[dict[str, Any]]:
+        return [log for log in audit_logger.logs if log["action"] == "account.activate"]
+
+    def test_activate_rejects_extra_body(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """``{"unexpected": "body"}`` 같은 extra key dict는 422 (#1510)."""
+        account = _make_account()
+        account.status = AccountStatus.SUSPENDED
+        account_service._accounts[account.account_id] = account
+
+        resp = client.post(
+            "/api/accounts/test-account/activate",
+            json={"unexpected": "body"},
+        )
+        assert resp.status_code == 422
+        # side-effect 미발생.
+        assert account_service.activate_calls == 0
+        assert self._activate_audit_logs(audit_logger) == []
+        # detail은 ``http_exception_handler``를 거치며 ``str(e.errors())``로
+        # 직렬화된다 (``suspend_account``와 동일 경로). 핵심 정보가 detail
+        # 문자열에 그대로 포함되는지만 확인한다.
+        detail = resp.json()["detail"]
+        assert isinstance(detail, str)
+        assert "extra_forbidden" in detail
+        assert "unexpected" in detail
+
+    def test_activate_rejects_multiple_extra_keys(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """extra key가 2개 이상이면 422, 두 key 모두 detail에 보고된다."""
+        account = _make_account()
+        account.status = AccountStatus.SUSPENDED
+        account_service._accounts[account.account_id] = account
+
+        resp = client.post(
+            "/api/accounts/test-account/activate",
+            json={"a": 1, "b": 2},
+        )
+        assert resp.status_code == 422
+        assert account_service.activate_calls == 0
+        assert self._activate_audit_logs(audit_logger) == []
+        # str(e.errors()) 직렬화 안에 두 extra key가 모두 보고되어야 한다.
+        detail = resp.json()["detail"]
+        assert isinstance(detail, str)
+        assert "extra_forbidden" in detail
+        assert "'a'" in detail and "'b'" in detail
+
+    def test_activate_rejects_non_object_body(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """JSON array 같은 비-object body는 422."""
+        account = _make_account()
+        account.status = AccountStatus.SUSPENDED
+        account_service._accounts[account.account_id] = account
+
+        resp = client.post("/api/accounts/test-account/activate", json=["x"])
+        assert resp.status_code == 422
+        assert account_service.activate_calls == 0
+        assert self._activate_audit_logs(audit_logger) == []
+
+    def test_activate_rejects_string_body(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """JSON string 같은 비-object body도 422."""
+        account = _make_account()
+        account.status = AccountStatus.SUSPENDED
+        account_service._accounts[account.account_id] = account
+
+        resp = client.post("/api/accounts/test-account/activate", json="abc")
+        assert resp.status_code == 422
+        assert account_service.activate_calls == 0
+        assert self._activate_audit_logs(audit_logger) == []
+
+    def test_activate_rejects_invalid_json(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """malformed JSON body는 422."""
+        account = _make_account()
+        account.status = AccountStatus.SUSPENDED
+        account_service._accounts[account.account_id] = account
+
+        resp = client.post(
+            "/api/accounts/test-account/activate",
+            content=b"{not-json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 422
+        assert account_service.activate_calls == 0
+        assert self._activate_audit_logs(audit_logger) == []
+
+    def test_activate_accepts_json_null(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """JSON ``null`` body는 빈 body와 동일하게 200 (``suspend``와 정합)."""
+        account = _make_account()
+        account.status = AccountStatus.SUSPENDED
+        account_service._accounts[account.account_id] = account
+
+        resp = client.post("/api/accounts/test-account/activate", json=None)
+        assert resp.status_code == 200
+        assert account_service.activate_calls == 1
+        assert len(self._activate_audit_logs(audit_logger)) == 1
+        assert resp.json()["account"]["status"] == "active"
+
+    def test_activate_accepts_empty_object(
+        self,
+        client: TestClient,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """``{}`` body는 200 + service 호출 1회."""
+        account = _make_account()
+        account.status = AccountStatus.SUSPENDED
+        account_service._accounts[account.account_id] = account
+
+        resp = client.post("/api/accounts/test-account/activate", json={})
+        assert resp.status_code == 200
+        assert account_service.activate_calls == 1
+        assert len(self._activate_audit_logs(audit_logger)) == 1
+        assert resp.json()["account"]["status"] == "active"
+
+    def test_activate_extra_body_with_no_token_returns_401(
+        self,
+        app,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """auth-first: no token + extra body는 422가 아닌 401, service 미호출."""
+        account = _make_account()
+        account.status = AccountStatus.SUSPENDED
+        account_service._accounts[account.account_id] = account
+
+        with TestClient(app) as no_auth_client:
+            resp = no_auth_client.post(
+                "/api/accounts/test-account/activate",
+                json={"x": 1},
+            )
+        assert resp.status_code == 401
+        assert account_service.activate_calls == 0
+        assert self._activate_audit_logs(audit_logger) == []
+
+    def test_activate_malformed_json_with_no_token_returns_401(
+        self,
+        app,
+        account_service: FakeAccountService,
+        audit_logger: FakeAuditLogger,
+    ) -> None:
+        """auth-first: no token + malformed JSON도 422가 아닌 401."""
+        account = _make_account()
+        account.status = AccountStatus.SUSPENDED
+        account_service._accounts[account.account_id] = account
+
+        with TestClient(app) as no_auth_client:
+            resp = no_auth_client.post(
+                "/api/accounts/test-account/activate",
+                content=b"{not-json",
+                headers={"Content-Type": "application/json"},
+            )
+        assert resp.status_code == 401
+        assert account_service.activate_calls == 0
+        assert self._activate_audit_logs(audit_logger) == []
 
 
 class TestDeleteAccount:


### PR DESCRIPTION
Closes #1510

## Summary
- `activate_account` 핸들러에 `suspend_account`와 동일한 raw-body 파싱 + extra=forbid 패턴 적용
- 빈 body / JSON `null` / `{}`는 200 통과 (기존 동작 보존), 비-object JSON, malformed JSON, extra key dict는 422
- mini forbid 모델 `_ActivateNoBody(BaseModel)` + `ConfigDict(extra="forbid")` 도입, `e.errors()`를 detail로 직렬화 (`suspend`와 동일 경로)
- OpenAPI `responses`/`openapi_extra` 데코레이터 무변경 → `frontend/openapi.json` / `frontend/src/types/api.generated.ts` 재생성 불필요
- invalid body 시 `account_service.activate` / `audit_logger`가 호출되지 않는 side-effect 검증 포함

## Test Plan
- `uv run ruff check src/ante/web/routes/accounts.py tests/unit/test_account_api.py` ✓
- `uv run ruff format --check src/ante/web/routes/accounts.py tests/unit/test_account_api.py` ✓
- `uv run pytest tests/unit/test_account_api.py::TestActivateAccount -x -q` → 12 passed
- `uv run pytest tests/unit/test_account_api.py -x -q` → 74 passed
- `uv run pytest tests/unit/test_runtime_mutation_auth.py -x -q` → 289 passed

신규 테스트 (10개):
- `test_activate_rejects_extra_body` (422 + service/audit 미호출)
- `test_activate_rejects_multiple_extra_keys` (detail에 두 key 모두 보고)
- `test_activate_rejects_non_object_body` / `test_activate_rejects_string_body` (비-object 422)
- `test_activate_rejects_invalid_json` (malformed JSON 422)
- `test_activate_accepts_json_null` / `test_activate_accepts_empty_object` (200 통과 회귀 보존)
- `test_activate_extra_body_with_no_token_returns_401` (auth-first)
- `test_activate_malformed_json_with_no_token_returns_401` (auth-first)

## Review Notes
- Codex 브랜치 리뷰 인프라가 3회 연속 hang되어 `@code-reviewer` 메타 리뷰로 fallback. 메타 리뷰 verdict: **PASS** (이슈 #1510 코멘트 참조).
- v3 Codex Plan Review verdict: **approve-implement**.
- Non-Goals (별도 follow-up 이슈 후보): CLI `ante account activate`, IPC `account.activate` 핸들러 extra args drift, 다른 lifecycle endpoint contract drift, `AccountService.activate` 서비스 경계 invariant, `suspend_account` raw-body 공통화.

## Follow-up
- pydantic ValidationError `e.errors()` repr substring 의존 단언은 마이너 업그레이드 시 fragile 가능. `suspend_account` 테스트와 동일 패턴이라 추가 리스크는 아니지만, detail 검증 강건화는 follow-up 검토 대상.