### PR TITLE
fix(cli): reuse validate_iso_date on trade list --from/--to (#1514)

### DIFF
--- a/src/ante/cli/commands/trade.py
+++ b/src/ante/cli/commands/trade.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 import click
 
+from ante.cli._validators import validate_iso_date
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
@@ -42,8 +43,20 @@ async def _create_trade_service():  # noqa: ANN202
 
 @trade.command("list")
 @click.option("--bot", "bot_id", default=None, help="봇 ID 필터")
-@click.option("--from", "from_date", default=None, help="시작일 (YYYY-MM-DD)")
-@click.option("--to", "to_date", default=None, help="종료일 (YYYY-MM-DD)")
+@click.option(
+    "--from",
+    "from_date",
+    default=None,
+    callback=validate_iso_date,
+    help="시작일 (YYYY-MM-DD)",
+)
+@click.option(
+    "--to",
+    "to_date",
+    default=None,
+    callback=validate_iso_date,
+    help="종료일 (YYYY-MM-DD)",
+)
 @click.option("--limit", default=50, type=click.IntRange(min=1), help="최대 조회 수")
 @format_option
 @click.pass_context

--- a/tests/unit/test_cli_date_validation.py
+++ b/tests/unit/test_cli_date_validation.py
@@ -1,4 +1,4 @@
-"""CLI date 옵션 strict ISO(``YYYY-MM-DD``) 검증 매트릭스 (#1513).
+"""CLI date 옵션 strict ISO(``YYYY-MM-DD``) 검증 매트릭스 (#1513, #1514).
 
 이슈 #1513: 5개 CLI date 옵션 — `audit list --from-date`, `audit list --to-date`,
 `treasury snapshot --date`, `treasury snapshot --from`, `treasury snapshot --to`
@@ -8,10 +8,17 @@ drift를 닫는다. Web API helper(`src/ante/web/utils/date_params.py:29-50`)와
 ``datetime.strptime`` calendar parse)을 CLI Click callback으로 적용한 결과를
 검증한다.
 
+이슈 #1514: `trade list --from/--to`가 `datetime.fromisoformat` ``ValueError``
+전파로 Python traceback + exit 1을 노출하던 ingress drift를 닫는다. #1513의
+``validate_iso_date`` callback을 재사용해 click ``BadParameter`` 표준 경로로
+text stderr + exit 2 + **traceback 미노출**을 보장한다. trade list 케이스는
+기존 매트릭스에 통합하고, traceback 미포함 invariant는 별도 단정으로 명시한다.
+
 스펙 / 분류:
 - `audit list`와 `treasury snapshot`은 `docs/specs/cli/03-commands.md`의 `offline`
   분류이며 IPC route가 없다 (`src/ante/ipc/registry.py`
   `register_all_handlers()` 19개 handler 중 audit/snapshot route 부재).
+- `trade list` 역시 offline CLI (IPC registry 부재 — #1512에서 19 handler 확인).
   따라서 IPC integration 검증은 N/A이며 본 테스트는 CLI Click ingress 경로만
   검증한다.
 
@@ -22,7 +29,7 @@ Non-Goals (follow-up 후보):
 - service-runtime gap(`AuditLogger.query`, `Treasury.get_daily_snapshot`은
   invalid str을 그대로 SQL로 전달) — CLI ingress에서 차단되는 이상 위험이
   실현되지 않으므로 본 PR scope 밖.
-- 다른 CLI date 옵션(`trade list --from/--to`, `backtest run --start/--end`,
+- 다른 CLI date 옵션(`backtest run --start/--end`,
   `report performance --start/--end`, `feed run --since/--until/--date`).
 
 Codex Plan Review v2 권고:
@@ -113,9 +120,10 @@ def _assert_date_rejected(result, *, hint_keywords: tuple[str, ...] = ()) -> Non
 
 # ── 옵션 매트릭스 ────────────────────────────────────────────────
 # audit `--from-date`, `--to-date` + treasury `--date`, `--from`, `--to`
-# 5개 옵션을 (명령, 옵션-args 빌더, hint) 튜플로 표현.
+# + trade `--from`, `--to` 7개 옵션을 (명령, 옵션-args 빌더, hint) 튜플로 표현.
 
-# `treasury snapshot`은 `--account` required, `audit list`는 추가 args 불필요.
+# `treasury snapshot`은 `--account` required, `audit list`/`trade list`는
+# 추가 args 불필요.
 _AUDIT_FROM_DATE = (
     "audit-from-date",
     lambda v: ["audit", "list", "--from-date", v],
@@ -136,6 +144,14 @@ _TREASURY_TO = (
     "treasury-to",
     lambda v: ["treasury", "snapshot", "--to", v, "--account", "test"],
 )
+_TRADE_FROM = (
+    "trade-from",
+    lambda v: ["trade", "list", "--from", v],
+)
+_TRADE_TO = (
+    "trade-to",
+    lambda v: ["trade", "list", "--to", v],
+)
 
 ALL_OPTIONS = [
     _AUDIT_FROM_DATE,
@@ -143,6 +159,8 @@ ALL_OPTIONS = [
     _TREASURY_DATE,
     _TREASURY_FROM,
     _TREASURY_TO,
+    _TRADE_FROM,
+    _TRADE_TO,
 ]
 
 
@@ -357,3 +375,92 @@ class TestFormatJsonInvalidDate:
             ],
         )
         _assert_date_rejected(result, hint_keywords=("not-a-date", "date"))
+
+    def test_trade_list_format_json_invalid_from(self, runner: CliRunner) -> None:
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "trade", "list", "--from", "not-a-date"],
+        )
+        _assert_date_rejected(result, hint_keywords=("not-a-date", "from"))
+
+    def test_trade_list_format_json_invalid_to(self, runner: CliRunner) -> None:
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "trade", "list", "--to", "not-a-date"],
+        )
+        _assert_date_rejected(result, hint_keywords=("not-a-date", "to"))
+
+
+# ── #1514 핵심 invariant: trade list invalid date에서 traceback 미노출 ────
+
+
+class TestTradeListNoTraceback:
+    """#1514: `trade list --from not-a-date`가 Python traceback을 노출하지
+    않아야 한다.
+
+    이전에는 `trade.py`에서 ``datetime.fromisoformat(from_date)``가
+    ``try/except`` 없이 호출되어 invalid str 입력 시 ``ValueError``가 전파되며
+    Python traceback + exit 1이 stderr로 노출됐다. ``validate_iso_date``
+    callback이 click ``BadParameter`` 경로로 처리하면 click 표준 text stderr +
+    exit 2만 출력되고 traceback은 노출되지 않는다.
+
+    본 invariant는 `_assert_date_rejected`의 keyword 매칭과 별개로 출력에
+    ``Traceback`` 문자열이 존재하지 않음을 명시적으로 단정한다.
+    """
+
+    @pytest.mark.parametrize(
+        "option_flag,option_id",
+        [("--from", "trade-from"), ("--to", "trade-to")],
+    )
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "not-a-date",
+            "2026-5-1",  # non-zero-padded
+            "2026-02-30",  # invalid calendar
+            "2026/05/13",  # wrong delimiter
+        ],
+    )
+    def test_invalid_value_does_not_emit_traceback(
+        self,
+        option_flag: str,
+        option_id: str,
+        value: str,
+        runner: CliRunner,
+    ) -> None:
+        result = runner.invoke(cli, ["trade", "list", option_flag, value])
+        assert result.exit_code != 0, (
+            f"exit_code expected != 0, got {result.exit_code}; "
+            f"output={result.output!r}, stderr={getattr(result, 'stderr', '')!r}"
+        )
+        combined = (result.output or "") + (getattr(result, "stderr", "") or "")
+        assert "Traceback" not in combined, (
+            f"trade list {option_flag} {value!r} should not emit Python "
+            f"traceback; got output={result.output!r}, "
+            f"stderr={getattr(result, 'stderr', '')!r}"
+        )
+
+    @pytest.mark.parametrize("option_flag", ["--from", "--to"])
+    def test_invalid_format_json_does_not_emit_traceback(
+        self, option_flag: str, runner: CliRunner
+    ) -> None:
+        """`--format json` 모드에서도 traceback이 노출되지 않아야 한다.
+
+        #1514 oracle probe(`expected_exit=nonzero_json_error`, `traceback=True`,
+        `stdout_json=None`)가 가리키던 핵심 결함. JSON envelope 표준화는
+        Non-Goals이지만 "traceback 미노출"은 본 PR이 닫는 invariant다.
+        """
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "trade", "list", option_flag, "not-a-date"],
+        )
+        assert result.exit_code != 0, (
+            f"exit_code expected != 0, got {result.exit_code}; "
+            f"output={result.output!r}, stderr={getattr(result, 'stderr', '')!r}"
+        )
+        combined = (result.output or "") + (getattr(result, "stderr", "") or "")
+        assert "Traceback" not in combined, (
+            f"trade list --format json {option_flag} 'not-a-date' should not "
+            f"emit Python traceback; got output={result.output!r}, "
+            f"stderr={getattr(result, 'stderr', '')!r}"
+        )


### PR DESCRIPTION
Closes #1514

## Summary
- `trade list --from not-a-date`가 `datetime.fromisoformat` ValueError 전파로 Python traceback + exit 1을 노출하던 ingress drift를 닫음
- #1513에서 도입한 `validate_iso_date` callback을 `trade.py:45-46` `--from`/`--to` 두 옵션에 재사용
- callback이 regex `^\d{4}-\d{2}-\d{2}$` + strptime calendar parse로 invalid 입력을 `click.BadParameter`로 차단 → click 표준 text stderr + exit 2, **traceback 미노출**
- `TestTradeListNoTraceback` 클래스로 `Traceback` 문자열 미포함 invariant 명시 단정

## Test Plan
- `uv run ruff check ...` ✓
- `uv run ruff format --check ...` ✓
- `uv run pytest tests/unit/test_cli_date_validation.py -x -q` → 93 passed (72 기존 + 21 신규 trade 매트릭스)
- `uv run pytest tests/unit/test_cli_format_option.py -x -q` → 16 passed (회귀 보존)

## Review Notes
- Codex Plan Review verdict: **narrow-scope** (이슈 #1514 코멘트)
- 메타 리뷰 verdict: **PASS** (Codex 브랜치 리뷰 인프라 hang으로 fallback)

## Non-Goals / Follow-ups
- `--format json` JSON error envelope 표준화 (CLI 전반 정책, 별도 follow-up — oracle probe `expected_exit=nonzero_json_error` 중 JSON envelope 부분은 본 PR scope 밖)
- 다른 CLI date 옵션 (`backtest --start`/`--end`, `report --start`/`--end`, `feed --since`/`--until`/`--date`) — 별도 이슈
- Service-layer 자체 date validator
- Web API trade date filter