### PR TITLE
fix(cli): exit 1 on missing-resource error in 5 CLI commands (#1515)

### DIFF
--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -137,7 +137,7 @@ def bot_info(ctx: click.Context, bot_id: str) -> None:
 
     if not result:
         fmt.error(f"봇을 찾을 수 없습니다: {bot_id}")
-        return
+        ctx.exit(1)
 
     if fmt.is_json:
         fmt.output(result)
@@ -367,7 +367,7 @@ def bot_signal_key(ctx: click.Context, bot_id: str, rotate: bool) -> None:
 
     if result.get("signal_key") is None:
         fmt.error(f"시그널 키가 없습니다: {bot_id}")
-        return
+        ctx.exit(1)
 
     if result.get("rotated"):
         fmt.success(f"시그널 키 재발급 완료: {bot_id}", result)

--- a/src/ante/cli/commands/config.py
+++ b/src/ante/cli/commands/config.py
@@ -72,10 +72,11 @@ async def _resolve_all(static_config, db) -> list[dict]:  # noqa: ANN001
 
 
 def _render_single(result: dict, fmt) -> None:  # noqa: ANN001
-    """단일 설정 결과 출력."""
-    if result["source"] == "not_found":
-        fmt.error(f"설정을 찾을 수 없습니다: {result['key']}")
-        return
+    """단일 설정 결과 출력 (missing은 caller에서 처리).
+
+    note: missing-resource (`source == "not_found"`) 분기는 caller(`config_get`)가
+    `ctx.exit(1)`로 처리한다. helper는 pure rendering만 담당한다 (#1515).
+    """
     if fmt.is_json:
         fmt.output(result)
     else:
@@ -118,6 +119,9 @@ def config_get(ctx: click.Context, key: str | None) -> None:
     result = _run(_run_get())
 
     if isinstance(result, dict):
+        if result["source"] == "not_found":
+            fmt.error(f"설정을 찾을 수 없습니다: {result['key']}")
+            ctx.exit(1)
         _render_single(result, fmt)
     else:
         _render_list(result, fmt)

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -223,7 +223,7 @@ def member_info(ctx: click.Context, member_id: str) -> None:
     result = _run(_run_info())
     if not result:
         fmt.error(f"멤버를 찾을 수 없습니다: {member_id}")
-        return
+        ctx.exit(1)
 
     if fmt.is_json:
         fmt.output(result)

--- a/src/ante/cli/commands/trade.py
+++ b/src/ante/cli/commands/trade.py
@@ -139,7 +139,7 @@ def trade_info(ctx: click.Context, trade_id: str) -> None:
 
     if not result:
         fmt.error(f"거래를 찾을 수 없습니다: {trade_id}")
-        return
+        ctx.exit(1)
 
     if fmt.is_json:
         fmt.output(result)

--- a/tests/unit/test_cli_format_option.py
+++ b/tests/unit/test_cli_format_option.py
@@ -473,7 +473,12 @@ class TestTradeListFormatOption:
 
 
 class TestTradeInfoFormatOption:
-    """ante trade info {id} --format json."""
+    """ante trade info {id} --format json.
+
+    #1515: missing-resource는 JSON error envelope과 함께 exit code 1을 반환한다.
+    이 테스트는 --format json 옵션의 서브커맨드 뒤 배치 동작을 검증하면서,
+    동시에 missing case가 nonzero exit를 내는지도 확인한다.
+    """
 
     def test_format_after_subcommand(self, runner: CliRunner) -> None:
         mock_db = AsyncMock()
@@ -488,10 +493,11 @@ class TestTradeInfoFormatOption:
             result = runner.invoke(
                 cli, ["trade", "info", "trade-123", "--format", "json"]
             )
-            assert result.exit_code == 0
-            # Not found case produces JSON error
+            # #1515: missing trade는 exit 1 + JSON error envelope.
+            assert result.exit_code == 1
             data = json.loads(result.output)
             assert "message" in data
+            assert data["status"] == "error"
 
 
 # ── account set-credentials 비대화형 테스트 ────────────────

--- a/tests/unit/test_cli_missing_resource_exit.py
+++ b/tests/unit/test_cli_missing_resource_exit.py
@@ -1,0 +1,431 @@
+"""CLI missing-resource 경로의 nonzero exit code 보장 테스트 (#1515).
+
+이슈 #1515 (oracle A7 cli_lookup_errors_exit_zero):
+``trade info``, ``config get``, ``bot info``, ``bot signal-key``, ``member info``
+5개 조회 명령이 missing-resource를 JSON error로 출력하면서도 exit code 0으로
+종료되던 ingress drift를 닫는다. 각 호출자가 ``fmt.error(...)`` 출력 후
+``ctx.exit(1)``을 호출해 nonzero exit를 강제한다.
+
+분류 메모:
+- ``trade info``, ``config get``, ``member info``는 offline CLI (IPC route 없음).
+- ``bot info`` / ``bot signal-key``는 spec ``docs/specs/cli/03-commands.md``상
+  ``runtime IPC + snapshot fallback`` 분류이지만, 본 PR의 target 경로(missing case)는
+  DB 직접 조회 경로 — IPC 동작 변경 없음.
+- ``report view``, ``treasury snapshot``도 같은 ``fmt.error(...) ; return`` 패턴이
+  잔존하지만 oracle probe signature에 미포함되어 본 PR Non-Goals (follow-up 후보).
+- ``Formatter.error()`` 자체는 미변경 — ``strategy validate`` 등 ``fmt.error`` 후
+  추가 errors/warnings를 계속 출력하는 호출자 회귀 회피.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    """인증을 mock으로 우회한 CliRunner.
+
+    stderr/stdout 분리(``mix_stderr=False``)로 text 모드 ``Error:`` 메시지가
+    stderr로 가는지 확인 가능하게 한다.
+    """
+    r = CliRunner(mix_stderr=False)
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _mock_db() -> MagicMock:
+    db = MagicMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    return db
+
+
+# ── trade info ───────────────────────────────────────────
+
+
+class TestTradeInfoMissingExit:
+    """``ante trade info <missing>`` 은 exit 1 + JSON error envelope."""
+
+    def test_missing_exits_nonzero_json(self, runner: CliRunner) -> None:
+        mock_db = MagicMock()
+        mock_db.connect = AsyncMock()
+        mock_db.close = AsyncMock()
+        mock_db.fetch_one = AsyncMock(return_value=None)
+
+        with patch(
+            "ante.core.database.Database",
+            return_value=mock_db,
+        ):
+            result = runner.invoke(
+                cli, ["trade", "info", "nonexistent-trade", "--format", "json"]
+            )
+
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert "nonexistent-trade" in payload["message"]
+
+    def test_missing_exits_nonzero_text(self, runner: CliRunner) -> None:
+        mock_db = AsyncMock()
+        mock_db.connect = AsyncMock()
+        mock_db.close = AsyncMock()
+        mock_db.fetch_one = AsyncMock(return_value=None)
+
+        with patch(
+            "ante.core.database.Database",
+            return_value=mock_db,
+        ):
+            result = runner.invoke(cli, ["trade", "info", "nonexistent-trade"])
+
+        assert result.exit_code == 1
+        assert "Error:" in result.stderr
+
+    def test_valid_exits_zero(self, runner: CliRunner) -> None:
+        """존재하는 trade는 exit 0으로 회귀 보존."""
+        mock_db = AsyncMock()
+        mock_db.connect = AsyncMock()
+        mock_db.close = AsyncMock()
+        mock_db.fetch_one = AsyncMock(
+            return_value={
+                "trade_id": "t-1",
+                "bot_id": "b-1",
+                "symbol": "AAPL",
+                "side": "BUY",
+                "quantity": 10,
+                "price": 150.0,
+                "status": "filled",
+            }
+        )
+
+        with patch(
+            "ante.core.database.Database",
+            return_value=mock_db,
+        ):
+            result = runner.invoke(cli, ["trade", "info", "t-1", "--format", "json"])
+
+        assert result.exit_code == 0, result.stdout + result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["trade_id"] == "t-1"
+
+
+# ── config get ───────────────────────────────────────────
+
+
+class TestConfigGetMissingExit:
+    """``ante config get <missing.key>`` 은 exit 1 (caller-level exit)."""
+
+    def test_missing_exits_nonzero_json(self, runner: CliRunner) -> None:
+        mock_config = MagicMock()
+        mock_config.get.return_value = None  # static 조회 실패
+        mock_dynamic = AsyncMock()
+        mock_dynamic.exists = AsyncMock(return_value=False)
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+
+        with patch(
+            "ante.cli.commands.config._create_services",
+            new_callable=AsyncMock,
+            return_value=(mock_config, mock_dynamic, mock_db),
+        ):
+            result = runner.invoke(
+                cli, ["config", "get", "nonexistent.key", "--format", "json"]
+            )
+
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert "nonexistent.key" in payload["message"]
+
+    def test_missing_exits_nonzero_text(self, runner: CliRunner) -> None:
+        mock_config = MagicMock()
+        mock_config.get.return_value = None
+        mock_dynamic = AsyncMock()
+        mock_dynamic.exists = AsyncMock(return_value=False)
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+
+        with patch(
+            "ante.cli.commands.config._create_services",
+            new_callable=AsyncMock,
+            return_value=(mock_config, mock_dynamic, mock_db),
+        ):
+            result = runner.invoke(cli, ["config", "get", "nonexistent.key"])
+
+        assert result.exit_code == 1
+        assert "Error:" in result.stderr
+
+    def test_valid_exits_zero(self, runner: CliRunner) -> None:
+        """존재하는 static config 키는 exit 0으로 회귀 보존."""
+        mock_config = MagicMock()
+        mock_config.get.return_value = "hello"
+        mock_dynamic = AsyncMock()
+        mock_dynamic.exists = AsyncMock(return_value=False)
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+
+        with patch(
+            "ante.cli.commands.config._create_services",
+            new_callable=AsyncMock,
+            return_value=(mock_config, mock_dynamic, mock_db),
+        ):
+            result = runner.invoke(
+                cli, ["config", "get", "some.key", "--format", "json"]
+            )
+
+        assert result.exit_code == 0, result.stdout + result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["key"] == "some.key"
+        assert payload["value"] == "hello"
+        assert payload["source"] == "static"
+
+
+# ── bot info ─────────────────────────────────────────────
+
+
+class TestBotInfoMissingExit:
+    """``ante bot info <missing>`` 은 exit 1.
+
+    target 경로는 DB 직접 조회 (`bot.py:128`) — IPC 분기 미경유.
+    """
+
+    def test_missing_exits_nonzero_json(self, runner: CliRunner) -> None:
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        mock_db.fetch_one = AsyncMock(return_value=None)
+
+        with patch(
+            "ante.cli.commands.bot._create_services",
+            new_callable=AsyncMock,
+            return_value=(mock_db, None, None, None),
+        ):
+            result = runner.invoke(
+                cli, ["--format", "json", "bot", "info", "nonexistent-bot"]
+            )
+
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert "nonexistent-bot" in payload["message"]
+
+    def test_missing_exits_nonzero_text(self, runner: CliRunner) -> None:
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        mock_db.fetch_one = AsyncMock(return_value=None)
+
+        with patch(
+            "ante.cli.commands.bot._create_services",
+            new_callable=AsyncMock,
+            return_value=(mock_db, None, None, None),
+        ):
+            result = runner.invoke(cli, ["bot", "info", "nonexistent-bot"])
+
+        assert result.exit_code == 1
+        assert "Error:" in result.stderr
+
+    def test_valid_exits_zero(self, runner: CliRunner) -> None:
+        """존재하는 봇은 exit 0으로 회귀 보존."""
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        mock_db.fetch_one = AsyncMock(
+            return_value={
+                "bot_id": "b-1",
+                "name": "test-bot",
+                "strategy_id": "s-1",
+                "account_id": "a-1",
+                "status": "active",
+                "created_at": "2026-01-01T00:00:00",
+            }
+        )
+
+        with patch(
+            "ante.cli.commands.bot._create_services",
+            new_callable=AsyncMock,
+            return_value=(mock_db, None, None, None),
+        ):
+            result = runner.invoke(cli, ["bot", "info", "b-1"])
+
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert "b-1" in result.stdout
+
+
+# ── bot signal-key ───────────────────────────────────────
+
+
+class TestBotSignalKeyMissingExit:
+    """``ante bot signal-key <bot-without-key>`` 은 exit 1."""
+
+    def test_missing_exits_nonzero_json(self, runner: CliRunner) -> None:
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        mock_skm = AsyncMock()
+        mock_skm.initialize = AsyncMock()
+        mock_skm.get_key = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "ante.cli.commands.bot._create_services",
+                new_callable=AsyncMock,
+                return_value=(mock_db, None, None, None),
+            ),
+            patch(
+                "ante.bot.signal_key.SignalKeyManager",
+                return_value=mock_skm,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "bot", "signal-key", "bot-without-key"],
+            )
+
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert "bot-without-key" in payload["message"]
+
+    def test_missing_exits_nonzero_text(self, runner: CliRunner) -> None:
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        mock_skm = AsyncMock()
+        mock_skm.initialize = AsyncMock()
+        mock_skm.get_key = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "ante.cli.commands.bot._create_services",
+                new_callable=AsyncMock,
+                return_value=(mock_db, None, None, None),
+            ),
+            patch(
+                "ante.bot.signal_key.SignalKeyManager",
+                return_value=mock_skm,
+            ),
+        ):
+            result = runner.invoke(cli, ["bot", "signal-key", "bot-without-key"])
+
+        assert result.exit_code == 1
+        assert "Error:" in result.stderr
+
+    def test_valid_exits_zero(self, runner: CliRunner) -> None:
+        """signal_key 존재 시 exit 0 회귀 보존."""
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        mock_skm = AsyncMock()
+        mock_skm.initialize = AsyncMock()
+        mock_skm.get_key = AsyncMock(return_value="sk_test123")
+
+        with (
+            patch(
+                "ante.cli.commands.bot._create_services",
+                new_callable=AsyncMock,
+                return_value=(mock_db, None, None, None),
+            ),
+            patch(
+                "ante.bot.signal_key.SignalKeyManager",
+                return_value=mock_skm,
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["--format", "json", "bot", "signal-key", "b-1"]
+            )
+
+        assert result.exit_code == 0, result.stdout + result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["signal_key"] == "sk_test123"
+
+
+# ── member info ──────────────────────────────────────────
+
+
+class TestMemberInfoMissingExit:
+    """``ante member info <missing>`` 은 exit 1."""
+
+    def test_missing_exits_nonzero_json(self, runner: CliRunner) -> None:
+        svc = MagicMock()
+        svc.get = AsyncMock(return_value=None)
+        db = _mock_db()
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new_callable=AsyncMock,
+            return_value=(svc, db),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "member", "info", "nonexistent-member"],
+            )
+
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert "nonexistent-member" in payload["message"]
+
+    def test_missing_exits_nonzero_text(self, runner: CliRunner) -> None:
+        svc = MagicMock()
+        svc.get = AsyncMock(return_value=None)
+        db = _mock_db()
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new_callable=AsyncMock,
+            return_value=(svc, db),
+        ):
+            result = runner.invoke(cli, ["member", "info", "nonexistent-member"])
+
+        assert result.exit_code == 1
+        assert "Error:" in result.stderr
+
+    def test_valid_exits_zero(self, runner: CliRunner) -> None:
+        """존재하는 member는 exit 0 회귀 보존."""
+        existing = Member(
+            member_id="m-1",
+            type=MemberType.HUMAN,
+            role=MemberRole.DEFAULT,
+            org="default",
+            name="Existing",
+            status="active",
+            scopes=[],
+        )
+        svc = MagicMock()
+        svc.get = AsyncMock(return_value=existing)
+        db = _mock_db()
+
+        with patch(
+            "ante.cli.commands.member._create_service",
+            new_callable=AsyncMock,
+            return_value=(svc, db),
+        ):
+            result = runner.invoke(cli, ["--format", "json", "member", "info", "m-1"])
+
+        assert result.exit_code == 0, result.stdout + result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["member_id"] == "m-1"


### PR DESCRIPTION
Closes #1515

## Summary
- 5개 조회 명령(`trade info`, `config get`, `bot info`, `bot signal-key`, `member info`)의 missing-resource 경로가 `fmt.error(...)` 출력 후 `return`만 수행해 exit code 0으로 종료되던 ingress drift를 닫음
- `trade info`/`bot info`/`bot signal-key`/`member info`: `return` → `ctx.exit(1)` (4 사이트)
- `config get`: `_render_single` helper의 missing 분기를 caller로 이동 (helper는 pure rendering 유지), caller에서 `ctx.exit(1)`
- `Formatter.error()` 자체는 미변경 (`strategy validate` 등 fmt.error 후 추가 출력 호출자 회귀 회피)
- `member.py:66` docstring의 `fmt.error(..., code=...)` + `SystemExit(1)` 패턴과 일관

## Test Plan
- `uv run ruff check ...` ✓
- `uv run ruff format --check ...` ✓
- `uv run pytest tests/unit/test_cli_missing_resource_exit.py -x -q` → 15 passed
- `uv run pytest tests/unit/test_cli_format_option.py -x -q` → 16 passed (1 케이스 본 PR invariant에 맞춰 정정)
- `uv run pytest tests/unit/test_cli_treasury_snapshot.py -x -q` → 11 passed

## Review Notes
- Codex Plan Review v2: **approve-implement**
- 메타 리뷰: **PASS** (Codex 브랜치 리뷰 인프라 hang으로 fallback)

## Non-Goals / Follow-ups
- `report view` (report.py), `treasury snapshot` (treasury.py:228) 동일 패턴 — oracle probe signature 미포함, 별도 follow-up
- `bot.py:238`, `bot.py:275`, `config.py:152`, `member.py:512` 등 일반 error/validation 경로 — Non-Goals
- `Formatter.error()` 자체에 exit 도입 (전체 패턴 변경, spec 결정 필요)
- missing-resource error code 표준화 (`RESOURCE_NOT_FOUND` 등)