### PR TITLE
fix(test): align stale exit-code assertions with #1515 invariant

### DIFF
--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -83,7 +83,8 @@ class TestConfigGet:
             mock_svc.return_value = (mock_config, mock_dynamic, mock_db)
 
             result = runner.invoke(cli, ["config", "get", "nonexistent.key"])
-            assert result.exit_code == 0
+            # #1515: missing-resource는 ctx.exit(1)로 non-zero exit
+            assert result.exit_code == 1
             assert "찾을 수 없습니다" in result.output
 
     def test_get_all_json(self, runner):

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -215,7 +215,8 @@ class TestBotCommands:
             mock_svc.return_value = (mock_db, MagicMock(), MagicMock(), MagicMock())
 
             result = runner.invoke(cli, ["bot", "info", "nonexistent"])
-            assert result.exit_code == 0
+            # #1515: missing-resource는 ctx.exit(1)로 non-zero exit
+            assert result.exit_code == 1
             assert "찾을 수 없습니다" in result.output
 
     def test_bot_info_found(self, runner):


### PR DESCRIPTION
Hotfix for #1525 (closes CI test failure on main).

## Summary
- `tests/unit/test_cli_config.py::TestConfigGet::test_get_not_found` 및 `tests/unit/test_cli_live.py::TestBotCommands::test_bot_info_not_found` 두 stale 케이스가 `assert result.exit_code == 0`을 유지해 #1525 머지 후 CI test job이 실패
- 두 라인의 expected exit code를 `1`로 정정해 #1515 missing-resource invariant와 일관화
- 코드 동작 변경 없음 (test invariant 정정만)

## Test Plan
- Hotfix 후 CI test job 통과 확인 (현재 main에서 fail 중)
- `pytest tests/unit/test_cli_config.py tests/unit/test_cli_live.py` 통과 예상

Refs #1515
Refs #1525