### PR TITLE
fix(test): align trade_info_not_found exit code (#1515 hotfix 2)

### DIFF
--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -342,7 +342,8 @@ class TestTradeCommands:
             mock_db_cls.return_value = mock_db
 
             result = runner.invoke(cli, ["trade", "info", "fake-id"])
-            assert result.exit_code == 0
+            # #1515: missing-resource는 ctx.exit(1)로 non-zero exit
+            assert result.exit_code == 1
             assert "찾을 수 없습니다" in result.output
 
 


### PR DESCRIPTION
2차 hotfix for #1525 / #1526 (closes CI test job failure on main).

## Summary
- `tests/unit/test_cli_live.py::TestTradeCommands::test_trade_info_not_found`가 stale `assert result.exit_code == 0` 유지 → #1525 머지 + #1526 hotfix 후에도 test job fail
- 본 PR이 trade_info_not_found exit code를 `1`로 정정

## Test Plan
- CI test job 통과 확인 (현재 main에서 fail 중)

Refs #1515 #1525 #1526