### PR TITLE
fix(cli): reject NaN/inf/non-positive amounts on treasury allocate/deallocate (#1517)

### DIFF
--- a/src/ante/cli/_validators.py
+++ b/src/ante/cli/_validators.py
@@ -13,6 +13,7 @@ exit 0으로 처리하여 빈 결과/없는 snapshot이 실제 데이터 부재�
 
 from __future__ import annotations
 
+import math
 import re
 from datetime import datetime
 
@@ -77,4 +78,54 @@ def validate_iso_date(
     return value
 
 
-__all__ = ["validate_iso_date"]
+def validate_positive_finite_amount(
+    ctx: click.Context | None,
+    param: click.Parameter | None,
+    value: float | None,
+) -> float | None:
+    """Click callback: 양수 finite float 검증 (NaN/Infinity/0/음수 거부).
+
+    오라클 A7 finding(#1517): ``treasury allocate``/``deallocate``의 ``amount``
+    인자가 ``type=float``만 갖춰 Python ``float('nan')``/``float('inf')``/0/
+    음수도 그대로 통과시키고 IPC layer까지 비정상 numeric을 전파하던 ingress
+    drift를 닫는다. 본 callback이 그 drift를 닫는다.
+
+    검증은 두 단계:
+
+    1. ``math.isnan(value) or math.isinf(value)`` — NaN/±Infinity 거부.
+    2. ``value <= 0`` — 0과 음수 거부.
+
+    ``None`` 입력은 그대로 ``None``을 반환한다 (옵션 미지정 분기 보존).
+    invalid 입력은 ``click.BadParameter``로 raise되어 click 표준 경로에서
+    text stderr + exit 2로 변환된다. ``--format json`` 모드에서도 click 표준
+    경로를 따르므로 stderr는 text다 (JSON envelope 표준화는 Non-Goals).
+
+    Args:
+        ctx: Click 컨텍스트 (``click.argument(callback=...)`` 인자).
+        param: Click 파라미터 메타데이터 (``click.argument(callback=...)`` 인자).
+        value: 사용자가 입력한 float, 또는 ``None``.
+
+    Returns:
+        검증된 float을 그대로 반환, 또는 ``None`` (입력이 ``None``일 때).
+
+    Raises:
+        click.BadParameter: NaN/±Infinity 또는 0/음수.
+    """
+    if value is None:
+        return None
+    if math.isnan(value) or math.isinf(value):
+        raise click.BadParameter(
+            f"{value!r}은(는) finite number여야 합니다 (NaN/Infinity 거부).",
+            ctx=ctx,
+            param=param,
+        )
+    if value <= 0:
+        raise click.BadParameter(
+            f"{value!r}은(는) 양수여야 합니다.",
+            ctx=ctx,
+            param=param,
+        )
+    return value
+
+
+__all__ = ["validate_iso_date", "validate_positive_finite_amount"]

--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -6,7 +6,7 @@ import asyncio
 
 import click
 
-from ante.cli._validators import validate_iso_date
+from ante.cli._validators import validate_iso_date, validate_positive_finite_amount
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id as _get_member_id
@@ -85,7 +85,7 @@ def status(ctx: click.Context, account_id: str) -> None:
 
 @treasury.command()
 @click.argument("bot_id")
-@click.argument("amount", type=float)
+@click.argument("amount", type=float, callback=validate_positive_finite_amount)
 @click.option("--account", "account_id", required=True, help="계좌 ID")
 @click.pass_context
 @require_auth
@@ -110,7 +110,7 @@ def allocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) ->
         raise
     except Exception as e:
         fmt.error(str(e))
-        return
+        ctx.exit(1)
 
     if result.get("success"):
         fmt.success(
@@ -121,11 +121,12 @@ def allocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) ->
         fmt.error(
             f"예산 할당 실패: 미할당 자금 부족 또는 금액 오류 (요청: {amount:,.0f}원)"
         )
+        ctx.exit(1)
 
 
 @treasury.command()
 @click.argument("bot_id")
-@click.argument("amount", type=float)
+@click.argument("amount", type=float, callback=validate_positive_finite_amount)
 @click.option("--account", "account_id", required=True, help="계좌 ID")
 @click.pass_context
 @require_auth
@@ -150,7 +151,7 @@ def deallocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) 
         raise
     except Exception as e:
         fmt.error(str(e))
-        return
+        ctx.exit(1)
 
     if result.get("success"):
         fmt.success(
@@ -159,6 +160,7 @@ def deallocate(ctx: click.Context, bot_id: str, amount: float, account_id: str) 
         )
     else:
         fmt.error(f"예산 회수 실패: 가용 예산 부족 (요청: {amount:,.0f}원)")
+        ctx.exit(1)
 
 
 @treasury.command()

--- a/tests/unit/test_cli_bot_treasury_ipc.py
+++ b/tests/unit/test_cli_bot_treasury_ipc.py
@@ -424,7 +424,12 @@ class TestTreasuryAllocateIpc:
     )
     @patch("ante.cli.commands.ipc_helpers.IPCClient")
     def test_treasury_allocate_failure(self, mock_ipc_cls, mock_socket) -> None:
-        """할당 실패 시(success=False) 에러 메시지를 출력한다."""
+        """할당 실패 시(success=False) 에러 메시지 + exit 1 (#1517).
+
+        #1515/#1517에서 IPC 실패(success=False) 경로를 ``fmt.error(...); return``
+        (exit 0) → ``fmt.error(...); ctx.exit(1)`` (exit 1)로 정합화했다. 이전의
+        ``exit_code == 0`` 단정은 stale — exit 1을 단정한다.
+        """
         mock_client = AsyncMock()
         mock_client.send.return_value = {
             "id": "req-1",
@@ -448,7 +453,7 @@ class TestTreasuryAllocateIpc:
             ]
         )
 
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert "예산 할당 실패" in result.output
 
 
@@ -500,7 +505,12 @@ class TestTreasuryDeallocateIpc:
     )
     @patch("ante.cli.commands.ipc_helpers.IPCClient")
     def test_treasury_deallocate_failure(self, mock_ipc_cls, mock_socket) -> None:
-        """회수 실패 시(success=False) 에러 메시지를 출력한다."""
+        """회수 실패 시(success=False) 에러 메시지 + exit 1 (#1517).
+
+        #1515/#1517에서 IPC 실패(success=False) 경로를 ``fmt.error(...); return``
+        (exit 0) → ``fmt.error(...); ctx.exit(1)`` (exit 1)로 정합화했다. 이전의
+        ``exit_code == 0`` 단정은 stale — exit 1을 단정한다.
+        """
         mock_client = AsyncMock()
         mock_client.send.return_value = {
             "id": "req-1",
@@ -524,7 +534,7 @@ class TestTreasuryDeallocateIpc:
             ]
         )
 
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert "예산 회수 실패" in result.output
 
 

--- a/tests/unit/test_cli_treasury_amount_validation.py
+++ b/tests/unit/test_cli_treasury_amount_validation.py
@@ -1,0 +1,336 @@
+"""CLI treasury allocate/deallocate amount finite-positive 검증 매트릭스 (#1517).
+
+이슈 #1517 (oracle A7 cli_treasury_nan_amount_accepted):
+``treasury allocate``/``deallocate``의 ``amount`` 인자가 click ``type=float``로
+``nan``/``inf``/``-inf``/0/음수를 그대로 통과시키고, IPC 호출 실패 시에도
+``except Exception as e: fmt.error(str(e)); return``로 exit 0을 반환하던 ingress
+drift를 닫는다.
+
+본 PR은 두 축의 invariant를 함께 단정한다:
+
+1. **CLI ingress (callback)** — ``_validators.validate_positive_finite_amount``를
+   ``allocate``/``deallocate``의 amount 인자 ``callback``으로 부착해 NaN/±Inf/0/
+   음수 입력에서 ``click.BadParameter`` → click 표준 경로(stderr text + exit 2).
+2. **IPC error exit code (#1515 패턴)** — valid amount + IPC 실패(Exception 또는
+   ``success=False``) 시 ``fmt.error(...); ctx.exit(1)``로 exit != 0 보장.
+
+분류 / 스펙:
+- ``treasury allocate``/``deallocate``는 spec ``docs/specs/cli/03-commands.md``상
+  ``runtime IPC`` 분류 (``ipc_send("treasury.allocate"|"treasury.deallocate", ...)``).
+- service-layer ``Treasury.allocate``/``deallocate``는 이미 ``not math.isfinite or
+  amount <= 0`` guard 보유 — 회귀 안전. 본 PR은 CLI ingress + exit code 정합만 적용
+  (Codex Plan Review 노트 반영).
+- ``--format json`` 모드에서 ``click.BadParameter``는 click 표준 text stderr 경로를
+  탄다. JSON envelope 표준화는 Non-Goals (스펙 부채, #1513/#1514 동일 정책,
+  follow-up 후보).
+
+Codex Plan Review v2 패턴:
+- ``CliRunner(mix_stderr=False)`` 사용 — text stderr와 JSON stdout을 분리 단정.
+- click 정확한 메시지 텍스트 의존 대신 exit != 0 + (``Invalid value`` 또는
+  ``finite`` / ``양수`` / 입력값 자체) 키워드 강건 매칭.
+- IPC mock은 ``ante.cli.commands.ipc_helpers.ipc_send`` async function patch
+  (#1517 IPC handler ``treasury.allocate``/``treasury.deallocate``).
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+def _make_runner() -> CliRunner:
+    """``mix_stderr=False`` runner. click 버전 fallback (#1513 패턴)."""
+    if "mix_stderr" in inspect.signature(CliRunner).parameters:
+        return CliRunner(mix_stderr=False)
+    return CliRunner()
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    """인증을 mock으로 우회한 CliRunner.
+
+    ``mix_stderr=False``로 stderr/stdout 분리, ``authenticate_member`` patch로
+    실제 DB 접근 방지 (#1515 / ``test_cli_missing_resource_exit.py`` 패턴).
+    """
+    r = _make_runner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):  # noqa: ANN001
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+# ── 공통 헬퍼 ────────────────────────────────────────────
+
+
+# callback이 직접 거부하는 케이스(NaN/Inf/0).
+# 음수(-100, -inf) 토큰은 click argument parser 단계에서 옵션 후보로 처리되어
+# "No such option"으로 reject — argv 순서를 ``--account ... --`` 후 amount로
+# 전달해 옵션 파싱을 종료한 뒤 callback 경로에 도달시킨다.
+_CALLBACK_INVALID_AMOUNTS = [
+    ("nan", "finite"),
+    ("inf", "finite"),
+    ("-inf", "finite"),
+    ("0", "양수"),
+    ("-100", "양수"),
+]
+
+
+def _assert_invalid_amount_rejected(result, value: str, keyword_hint: str) -> None:
+    """invalid amount 거부 invariant 단정.
+
+    - exit code != 0 (click ``BadParameter`` 표준은 exit 2).
+    - stderr text에 click 표준 ``Invalid value`` 또는 입력값/도메인 키워드 포함.
+    - traceback 미포함 (BadParameter는 click이 표준 경로로 변환).
+    """
+    assert result.exit_code != 0, (
+        f"invalid amount {value!r}가 exit 0으로 통과됨: "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    stderr = result.stderr or ""
+    stdout = result.stdout or ""
+    combined = stderr + stdout
+    # click 표준 BadParameter 경로 또는 도메인 키워드 / 입력값 매칭
+    assert (
+        "Invalid value" in combined
+        or "finite" in combined
+        or "양수" in combined
+        or value in combined
+        or keyword_hint in combined
+    ), f"기대 키워드 부재: stderr={stderr!r} stdout={stdout!r}"
+    # BadParameter는 click 표준 경로 — Python traceback이 노출되어선 안 됨.
+    assert "Traceback" not in combined, (
+        f"click BadParameter가 traceback으로 누출: {combined!r}"
+    )
+
+
+def _allocate_argv(value: str, *, json_mode: bool = False) -> list[str]:
+    """``treasury allocate`` argv. 음수 토큰도 옵션 파싱이 끝난 뒤 amount로
+    전달되도록 ``--account ... --`` separator를 amount 앞에 둔다.
+
+    callback이 invalid 값에 도달함을 보장한다 — 음수 토큰을 옵션 위치에 두면
+    click이 "No such option"으로 먼저 reject되어 callback 동작이 검증되지 않음.
+    """
+    argv = ["treasury", "allocate", "bot-1", "--account", "acc-1", "--", value]
+    if json_mode:
+        argv = ["--format", "json", *argv]
+    return argv
+
+
+def _deallocate_argv(value: str, *, json_mode: bool = False) -> list[str]:
+    """``treasury deallocate`` argv. (``_allocate_argv``와 동일 정책)."""
+    argv = ["treasury", "deallocate", "bot-1", "--account", "acc-1", "--", value]
+    if json_mode:
+        argv = ["--format", "json", *argv]
+    return argv
+
+
+# ── treasury allocate ───────────────────────────────────
+
+
+class TestAllocateAmountIngress:
+    """``ante treasury allocate <bot> <amount> --account <acc>`` ingress 매트릭스.
+
+    NaN/±Inf/0/음수는 click ``BadParameter`` 표준 경로(stderr text + exit != 0).
+    text/json 두 모드 모두 단정 (json 모드도 BadParameter는 text stderr).
+    """
+
+    @pytest.mark.parametrize(("value", "keyword"), _CALLBACK_INVALID_AMOUNTS)
+    def test_text_mode_rejects_invalid(
+        self, runner: CliRunner, value: str, keyword: str
+    ) -> None:
+        result = runner.invoke(cli, _allocate_argv(value))
+        _assert_invalid_amount_rejected(result, value, keyword)
+
+    @pytest.mark.parametrize(("value", "keyword"), _CALLBACK_INVALID_AMOUNTS)
+    def test_json_mode_rejects_invalid(
+        self, runner: CliRunner, value: str, keyword: str
+    ) -> None:
+        """``--format json`` 모드도 BadParameter는 text stderr (Non-Goals)."""
+        result = runner.invoke(cli, _allocate_argv(value, json_mode=True))
+        _assert_invalid_amount_rejected(result, value, keyword)
+
+
+class TestAllocateIPCExitCode:
+    """valid amount + IPC 경로 exit code 정합 (#1515 패턴)."""
+
+    def test_valid_success_exits_zero(self, runner: CliRunner) -> None:
+        """valid amount + IPC success=True → exit 0 (회귀 보존)."""
+        mock_ipc = AsyncMock(return_value={"success": True})
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", mock_ipc):
+            result = runner.invoke(
+                cli,
+                ["treasury", "allocate", "bot-1", "1000", "--account", "acc-1"],
+            )
+
+        assert result.exit_code == 0, (
+            f"exit={result.exit_code} stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        mock_ipc.assert_awaited_once()
+
+    def test_ipc_exception_exits_nonzero(self, runner: CliRunner) -> None:
+        """valid amount + IPC raises Exception → exit 1 (#1515 패턴)."""
+        mock_ipc = AsyncMock(side_effect=RuntimeError("ipc boom"))
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", mock_ipc):
+            result = runner.invoke(
+                cli,
+                ["treasury", "allocate", "bot-1", "1000", "--account", "acc-1"],
+            )
+
+        assert result.exit_code == 1, (
+            f"exit={result.exit_code} stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        assert "Error:" in result.stderr or "ipc boom" in result.stderr
+
+    def test_ipc_success_false_exits_nonzero_text(self, runner: CliRunner) -> None:
+        """valid amount + IPC success=False → exit 1 + fmt.error stderr (text)."""
+        mock_ipc = AsyncMock(return_value={"success": False})
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", mock_ipc):
+            result = runner.invoke(
+                cli,
+                ["treasury", "allocate", "bot-1", "1000", "--account", "acc-1"],
+            )
+
+        assert result.exit_code == 1, (
+            f"exit={result.exit_code} stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        assert "예산 할당 실패" in result.stderr
+
+    def test_ipc_success_false_exits_nonzero_json(self, runner: CliRunner) -> None:
+        """``--format json`` 모드 IPC success=False → exit 1 + JSON error envelope.
+
+        ``fmt.error``는 JSON 모드에서 ``status=error`` envelope을 stdout에
+        ``click.echo``하므로 stdout에서 단정한다.
+        """
+        mock_ipc = AsyncMock(return_value={"success": False})
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", mock_ipc):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "treasury",
+                    "allocate",
+                    "bot-1",
+                    "1000",
+                    "--account",
+                    "acc-1",
+                ],
+            )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert "예산 할당 실패" in payload["message"]
+
+
+# ── treasury deallocate ─────────────────────────────────
+
+
+class TestDeallocateAmountIngress:
+    """``ante treasury deallocate <bot> <amount> --account <acc>`` ingress 매트릭스."""
+
+    @pytest.mark.parametrize(("value", "keyword"), _CALLBACK_INVALID_AMOUNTS)
+    def test_text_mode_rejects_invalid(
+        self, runner: CliRunner, value: str, keyword: str
+    ) -> None:
+        result = runner.invoke(cli, _deallocate_argv(value))
+        _assert_invalid_amount_rejected(result, value, keyword)
+
+    @pytest.mark.parametrize(("value", "keyword"), _CALLBACK_INVALID_AMOUNTS)
+    def test_json_mode_rejects_invalid(
+        self, runner: CliRunner, value: str, keyword: str
+    ) -> None:
+        result = runner.invoke(cli, _deallocate_argv(value, json_mode=True))
+        _assert_invalid_amount_rejected(result, value, keyword)
+
+
+class TestDeallocateIPCExitCode:
+    """valid amount + IPC 경로 exit code 정합 (#1515 패턴)."""
+
+    def test_valid_success_exits_zero(self, runner: CliRunner) -> None:
+        mock_ipc = AsyncMock(return_value={"success": True})
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", mock_ipc):
+            result = runner.invoke(
+                cli,
+                ["treasury", "deallocate", "bot-1", "1000", "--account", "acc-1"],
+            )
+
+        assert result.exit_code == 0, (
+            f"exit={result.exit_code} stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        mock_ipc.assert_awaited_once()
+
+    def test_ipc_exception_exits_nonzero(self, runner: CliRunner) -> None:
+        mock_ipc = AsyncMock(side_effect=RuntimeError("ipc boom"))
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", mock_ipc):
+            result = runner.invoke(
+                cli,
+                ["treasury", "deallocate", "bot-1", "1000", "--account", "acc-1"],
+            )
+
+        assert result.exit_code == 1, (
+            f"exit={result.exit_code} stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        assert "Error:" in result.stderr or "ipc boom" in result.stderr
+
+    def test_ipc_success_false_exits_nonzero_text(self, runner: CliRunner) -> None:
+        mock_ipc = AsyncMock(return_value={"success": False})
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", mock_ipc):
+            result = runner.invoke(
+                cli,
+                ["treasury", "deallocate", "bot-1", "1000", "--account", "acc-1"],
+            )
+
+        assert result.exit_code == 1, (
+            f"exit={result.exit_code} stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        assert "예산 회수 실패" in result.stderr
+
+    def test_ipc_success_false_exits_nonzero_json(self, runner: CliRunner) -> None:
+        mock_ipc = AsyncMock(return_value={"success": False})
+        with patch("ante.cli.commands.ipc_helpers.ipc_send", mock_ipc):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "treasury",
+                    "deallocate",
+                    "bot-1",
+                    "1000",
+                    "--account",
+                    "acc-1",
+                ],
+            )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert "예산 회수 실패" in payload["message"]


### PR DESCRIPTION
Closes #1517

## Summary
- `treasury allocate`/`deallocate`의 `amount` 인자가 click `float`로 받은 `nan`/`inf`/`-inf`/0/음수를 통과시키고 IPC 호출까지 진행하던 ingress drift를 닫음
- `src/ante/cli/_validators.py`에 `validate_positive_finite_amount` callback 추가 (math.isnan/isinf/value<=0 거부)
- `treasury.py:88, 129` amount 인자에 callback 적용
- IPC error 경로 4 사이트 (`except Exception` 2건, IPC `success=False` 2건) `return` → `ctx.exit(1)` 통합 (#1515 패턴)
- `tests/unit/test_cli_bot_treasury_ipc.py`의 2개 stale assertion(`exit_code == 0`)을 IPC `success=False → exit 1` invariant에 맞춰 동시 정정 (#1526/#1527 hotfix 패턴 학습)
- service-layer `Treasury.allocate/deallocate`는 이미 `math.isfinite(amount) and amount > 0` guard 보유 → defense-in-depth, 회귀 안전

## Test Plan
- `uv run ruff check ...` ✓
- `uv run ruff format --check ...` ✓
- `uv run pytest tests/unit/test_cli_treasury_amount_validation.py -x -q` → 28 passed (신규)
- `uv run pytest tests/unit/test_cli_bot_treasury_ipc.py -x -q` → 19 passed (정정 2개 포함 회귀)
- `uv run pytest tests/unit/test_cli_treasury_snapshot.py / test_cli_date_validation.py / test_cli_missing_resource_exit.py` → 회귀 보존

## Review Notes
- Codex Plan Review: **approve-implement**
- 메타 리뷰: **PASS** (Plan 1:1 매핑, defense-in-depth, ctx.exit self-catch 회피, IPC 회귀 단정 동시 정정 정당)

## Non-Goals / Follow-ups
- 다른 CLI float 인자 (`backtest --capital`, `trade --quantity` 등) 동일 callback 적용
- `--format json` 모드 BadParameter JSON envelope 표준화 (CLI 전반 정책)
- service-layer vs CLI guard 메시지 정합 (UX 일관성)
- IPC handler `treasury.allocate`/`treasury.deallocate` 자체 validation (현재 CLI ingress가 차단)