### PR TITLE
fix(test): align treasury_allocate_fail exit code (#1517 hotfix)

### DIFF
--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -444,7 +444,8 @@ class TestTreasuryCommands:
                 cli,
                 ["treasury", "allocate", "bot-1", "999999999", "--account", "acc-1"],
             )
-            assert result.exit_code == 0
+            # #1517: IPC success=False는 ctx.exit(1)로 non-zero exit
+            assert result.exit_code == 1
             assert "실패" in result.output
 
     def test_treasury_deallocate_success(self, runner):


### PR DESCRIPTION
Hotfix for #1529 (closes CI test failure on main).

## Summary
- `tests/unit/test_cli_live.py::TestTreasuryCommands::test_treasury_allocate_fail`이 stale `assert result.exit_code == 0` 유지 → #1529 머지 후 test job FAIL
- #1517 invariant(IPC `success=False` → `ctx.exit(1)`)와 동일하게 `1`로 정정

Refs #1517 #1529