### PR TITLE
fix(cli): validate feed backfill --since at CLI boundary

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -416,7 +416,8 @@ tests/
 │   │   ├── test_scheduler.py         # 날짜 범위 생성
 │   │   ├── test_validate.py          # 4계층 데이터 검증
 │   │   ├── __init__.py
-│   │   └── test_dart_collector.py
+│   │   ├── test_dart_collector.py
+│   │   └── test_cli_backfill_date_validation.py
 │   ├── cli/
 │   │   ├── __init__.py
 │   │   ├── test_version.py

--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -220,6 +220,18 @@ def run_backfill(
     if not _ensure_initialized(cfg, fmt, data_path):
         raise SystemExit(1)
 
+    if since is not None:
+        from datetime import date
+
+        try:
+            date.fromisoformat(since)
+        except ValueError:
+            fmt.error(
+                f"잘못된 --since 날짜 형식: '{since}' (YYYY-MM-DD 형식 필요)",
+                code="invalid_date",
+            )
+            raise SystemExit(1)
+
     config = cfg.load_config()
 
     # CLI 옵션으로 schedule 오버라이드

--- a/tests/unit/feed/test_cli_backfill_date_validation.py
+++ b/tests/unit/feed/test_cli_backfill_date_validation.py
@@ -1,0 +1,217 @@
+"""ante feed run backfill --since CLI 검증 테스트.
+
+이슈 #1536: invalid ISO date 입력 시 CLI 경계에서 거부하고
+traceback이 stderr에 노출되지 않아야 한다.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.feed.models.result import CollectionResult
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+_EMPTY_RESULT = CollectionResult(
+    mode="backfill",
+    started_at="2026-03-18T00:00:00Z",
+    finished_at="2026-03-18T00:00:01Z",
+    duration_seconds=1.0,
+    symbols_total=0,
+    symbols_success=0,
+    symbols_failed=0,
+    rows_written=0,
+    data_types=[],
+    failures=[],
+    warnings=[],
+    config_errors=[],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """인증된 상태의 CliRunner. stderr 분리 캡처."""
+    r = CliRunner(mix_stderr=False)
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # type: ignore[no-untyped-def]
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx: object) -> None:
+                import click
+
+                ctx = click.get_current_context()
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+@pytest.fixture
+def initialized_data_path(tmp_path: Path) -> str:
+    """초기화된 데이터 디렉토리 경로."""
+    data_dir = tmp_path / "data"
+    feed_dir = data_dir / ".feed"
+    feed_dir.mkdir(parents=True)
+
+    config_toml = feed_dir / "config.toml"
+    config_toml.write_text(
+        "[schedule]\n"
+        'daily_at = "16:00"\n'
+        'backfill_at = "01:00"\n'
+        'backfill_since = "2024-01-01"\n'
+        "\n"
+        "[guard]\n"
+        "blocked_days = []\n"
+        'blocked_hours = ["09:00-15:30"]\n'
+        "pause_during_trading = true\n"
+    )
+
+    (feed_dir / "checkpoints").mkdir()
+    (feed_dir / "reports").mkdir()
+
+    return str(data_dir)
+
+
+class TestBackfillSinceValidation:
+    """`--since` 옵션 ISO date 검증 (이슈 #1536)."""
+
+    def test_invalid_since_json_mode_returns_structured_error(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """JSON 모드에서 invalid --since는 status=error JSON, exit 1, traceback 없음."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            # orchestrator 자체는 호출되어선 안 된다 — CLI 단계에서 차단
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                    "--since",
+                    "not-a-date",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 1
+            # stderr에 traceback이 노출되지 않아야 한다
+            assert "Traceback" not in (result.stderr or "")
+            # stdout에 구조화된 JSON 에러
+            data = json.loads(result.stdout)
+            assert data["status"] == "error"
+            assert data["code"] == "invalid_date"
+            assert "not-a-date" in data["message"]
+            # orchestrator는 호출되지 않아야 한다
+            mock_orch.run_backfill.assert_not_awaited()
+
+    def test_invalid_since_text_mode_writes_error_to_stderr(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """text 모드에서 invalid --since는 stderr Error, exit 1, traceback 없음."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                    "--since",
+                    "not-a-date",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 1
+            stderr = result.stderr or ""
+            assert "Traceback" not in stderr
+            assert "Error:" in stderr
+            assert "잘못된 --since 날짜 형식" in stderr
+            assert "not-a-date" in stderr
+            mock_orch.run_backfill.assert_not_awaited()
+
+    def test_valid_iso_since_passes_through_to_orchestrator(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """정상 ISO date(--since 2026-01-01)는 orchestrator.run_backfill로 전달된다."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                    "--since",
+                    "2026-01-01",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 0
+            mock_orch.run_backfill.assert_awaited_once()
+            call_args = mock_orch.run_backfill.call_args
+            config = call_args.kwargs["config"]
+            assert config["schedule"]["backfill_since"] == "2026-01-01"
+
+    def test_no_since_option_regression(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """--since 미지정 시 기존 동작 유지 (검증 분기 우회)."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 0
+            mock_orch.run_backfill.assert_awaited_once()


### PR DESCRIPTION
Closes #1536

## Summary

`ante --format json feed run backfill --since not-a-date`가 CLI 단계에서 검증되지 않아 orchestrator 내부 `date.fromisoformat(...)` ValueError가 Python traceback으로 stderr에 노출되던 결함을 수정한다.

- `src/ante/feed/cli.py` `run_backfill` callback의 `_ensure_initialized` 통과 직후에 `date.fromisoformat(since)` 검증을 추가.
- 실패 시 `fmt.error(..., code="invalid_date")` + `raise SystemExit(1)` — JSON/text 모드 모두 envelope에 맞춰 출력, traceback 없음.

Non-Goals (별도 follow-up):
- `--until` 옵션은 현재 dead (orchestrator로 전달되지 않음) — wiring 또는 옵션 제거는 별도 이슈.
- `run_daily --date` 동일 검증 — 별도 follow-up.

## Test Plan

- [x] `pytest tests/unit -k "feed or backfill" -q` (310 passed)
- [x] `pytest tests/unit -q` 전체 회귀 (5605 passed / 4 skipped)
- [x] `ruff check src tests` / `ruff format --check src tests`
- [x] `mypy src` (239 files, no issues)
- [x] `python scripts/generate_project_structure.py --check`
- [x] Codex `/codex:review --base main` PASS (attempt 1)

신규 테스트 4건:
- invalid `--since` JSON mode: stdout JSON envelope + exit 1 + no traceback
- invalid `--since` text mode: stderr Error + exit 1 + no traceback
- 정상 `--since` 회귀: orchestrator pass-through 확인
- `--since` 미지정 회귀: 기존 동작 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)