### PR TITLE
fix(cli): emit JSON envelope for feed config set unsupported key

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -417,7 +417,8 @@ tests/
 │   │   ├── test_validate.py          # 4계층 데이터 검증
 │   │   ├── __init__.py
 │   │   ├── test_dart_collector.py
-│   │   └── test_cli_backfill_date_validation.py
+│   │   ├── test_cli_backfill_date_validation.py
+│   │   └── test_cli_config_set.py
 │   ├── cli/
 │   │   ├── __init__.py
 │   │   ├── test_version.py

--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -74,7 +74,10 @@ def config_set(ctx: click.Context, key: str, value: str, data_path: str) -> None
 
     if key not in API_KEYS:
         supported = ", ".join(API_KEYS)
-        click.echo(f"지원하지 않는 키입니다: {key}\n지원 키: {supported}", err=True)
+        fmt.error(
+            f"지원하지 않는 키입니다: {key}\n지원 키: {supported}",
+            code="unsupported_key",
+        )
         raise SystemExit(1)
 
     cfg = FeedConfig(data_path)

--- a/tests/unit/feed/test_cli_config_set.py
+++ b/tests/unit/feed/test_cli_config_set.py
@@ -1,0 +1,138 @@
+"""ante feed config set CLI 커맨드 테스트.
+
+#1537: unsupported key 거부 시 --format json 일관성 회귀 방지.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """인증된 상태의 CliRunner — stdout/stderr 분리."""
+    r = CliRunner(mix_stderr=False)
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # type: ignore[no-untyped-def]
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx: object) -> None:
+                import click
+
+                ctx = click.get_current_context()
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+@pytest.fixture
+def data_path(tmp_path: Path) -> str:
+    """임시 데이터 디렉토리 경로 (문자열)."""
+    return str(tmp_path / "data")
+
+
+class TestFeedConfigSetUnsupportedKey:
+    """#1537: unsupported key 거부 경로."""
+
+    def test_json_format_emits_envelope(
+        self, runner: CliRunner, data_path: str
+    ) -> None:
+        """--format json: stdout JSON envelope, exit 1."""
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "feed",
+                "config",
+                "set",
+                "unsupported_key",
+                "value",
+                "--data-path",
+                data_path,
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 1, (
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        payload = json.loads(result.stdout.strip())
+        assert payload["status"] == "error"
+        assert payload["code"] == "unsupported_key"
+        assert payload["message"].startswith("지원하지 않는 키입니다: unsupported_key")
+        assert "지원 키:" in payload["message"]
+
+    def test_text_format_emits_stderr(self, runner: CliRunner, data_path: str) -> None:
+        """--format text (default): stderr Error 라인, exit 1."""
+        result = runner.invoke(
+            cli,
+            [
+                "feed",
+                "config",
+                "set",
+                "unsupported_key",
+                "value",
+                "--data-path",
+                data_path,
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 1, (
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        assert "Error: 지원하지 않는 키입니다: unsupported_key" in result.stderr
+        # JSON envelope이 stdout으로 누출되지 않아야 한다.
+        assert result.stdout.strip() == ""
+
+
+class TestFeedConfigSetSupportedKey:
+    """정상 회귀: 지원 키 저장 경로."""
+
+    def test_supported_key_saves_and_reports_success(
+        self, runner: CliRunner, data_path: str
+    ) -> None:
+        """ANTE_DART_API_KEY 저장 시 fmt.success 호출 + .env 파일 기록."""
+        result = runner.invoke(
+            cli,
+            [
+                "feed",
+                "config",
+                "set",
+                "ANTE_DART_API_KEY",
+                "dart_value_123",
+                "--data-path",
+                data_path,
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, (
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        env_path = Path(data_path) / ".feed" / ".env"
+        assert env_path.exists()
+        assert "ANTE_DART_API_KEY=dart_value_123" in env_path.read_text()
+        assert "Saved ANTE_DART_API_KEY" in result.stdout


### PR DESCRIPTION
Closes #1537

## Summary

`ante --format json feed config set unsupported_key value`가 stderr 텍스트로만 실패하던 결함을 수정한다. `src/ante/feed/cli.py:77`의 `click.echo(..., err=True)` 직접 사용을 `fmt.error(..., code="unsupported_key")` 호출로 교체해 JSON 모드에서는 stdout JSON envelope, text 모드에서는 stderr `Error: ...` 텍스트로 일관되게 출력한다. exit code는 그대로 1.

## Test Plan

- [x] `pytest tests/unit -k "feed_config or config_set" -q` (6 passed)
- [x] `pytest tests/unit -q` 전체 회귀 (5608 passed / 4 skipped)
- [x] `ruff check src tests` / `ruff format --check src tests`
- [x] `mypy src` (239 files, no issues)
- [x] `python scripts/generate_project_structure.py --check`
- [x] Codex `/codex:review --base main` PASS (attempt 1) — 4 substantive checks 모두 통과

신규 테스트 3건: invalid key JSON / text / 정상 키 회귀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)