### PR TITLE
fix(cli): exit 1 on report view and treasury snapshot missing-resource

### DIFF
--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -343,8 +343,8 @@ def report_view(ctx: click.Context, report_id: str, db_path: str | None) -> None
     result = asyncio.run(_view())
 
     if not result:
-        fmt.error(f"리포트를 찾을 수 없습니다: {report_id}")
-        return
+        fmt.error(f"리포트를 찾을 수 없습니다: {report_id}", code="report_not_found")
+        raise SystemExit(1)
 
     if fmt.is_json:
         fmt.output(result)

--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -227,8 +227,8 @@ def snapshot(
 
     if result is None:
         target = date_str or datetime.now(UTC).strftime("%Y-%m-%d")
-        fmt.error(f"{target} 날짜의 스냅샷이 없습니다.")
-        return
+        fmt.error(f"{target} 날짜의 스냅샷이 없습니다.", code="snapshot_not_found")
+        raise SystemExit(1)
 
     if fmt.is_json:
         fmt.output(result)

--- a/tests/unit/test_cli_treasury_snapshot.py
+++ b/tests/unit/test_cli_treasury_snapshot.py
@@ -134,7 +134,7 @@ class TestSnapshotDefault:
         with ctx_patch:
             result = _invoke(runner, ["snapshot", "--account", "domestic"], mock_auth)
 
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert "스냅샷이 없습니다" in result.output
 
 
@@ -163,7 +163,7 @@ class TestSnapshotDate:
                 mock_auth,
             )
 
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert "2026-01-01" in result.output
         assert "스냅샷이 없습니다" in result.output
 
@@ -310,6 +310,44 @@ class TestSnapshotJson:
         data = json.loads(result.output)
         assert isinstance(data, list)
         assert len(data) == 2
+
+    def test_json_not_found(self, runner, mock_auth):
+        import json
+
+        from ante.member.models import Member, MemberType
+
+        mock_member = Member(
+            member_id="test-user",
+            name="테스트",
+            type=MemberType.HUMAN,
+            role="master",
+        )
+        ctx_patch, _ = _make_mock_treasury(get_daily_return=None)
+        with ctx_patch:
+            result = runner.invoke(
+                treasury,
+                [
+                    "snapshot",
+                    "--account",
+                    "domestic",
+                    "--date",
+                    "2026-01-01",
+                    "--format",
+                    "json",
+                ],
+                obj={
+                    "format": "json",
+                    "formatter": OutputFormatter("json"),
+                    "member": mock_member,
+                },
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "snapshot_not_found"
+        assert "2026-01-01" in payload["message"]
 
 
 class TestSnapshotValidation:

--- a/tests/unit/test_report_draft.py
+++ b/tests/unit/test_report_draft.py
@@ -219,8 +219,20 @@ class TestReportViewCLI:
         with patch("asyncio.run") as mock_run:
             mock_run.return_value = None
             result = runner.invoke(cli, ["report", "view", "nonexistent"])
-            assert result.exit_code == 0
+            assert result.exit_code == 1
             assert "찾을 수 없습니다" in result.output
+
+    def test_view_not_found_json(self, runner):
+        with patch("asyncio.run") as mock_run:
+            mock_run.return_value = None
+            result = runner.invoke(
+                cli, ["--format", "json", "report", "view", "nonexistent"]
+            )
+            assert result.exit_code == 1
+            payload = json.loads(result.output)
+            assert payload["status"] == "error"
+            assert payload["code"] == "report_not_found"
+            assert "찾을 수 없습니다" in payload["message"]
 
     def test_view_json_format(self, runner):
         with patch("asyncio.run") as mock_run:


### PR DESCRIPTION
Closes #1538

## Summary

`report view <missing-id>`와 `treasury snapshot --date <missing-date>`가 error JSON을 출력하지만 exit code 0으로 끝나던 결함을 수정한다.

- `src/ante/cli/commands/report.py:346-347`: `fmt.error(..., code="report_not_found")` + `raise SystemExit(1)`.
- `src/ante/cli/commands/treasury.py:230-231`: `fmt.error(..., code="snapshot_not_found")` + `raise SystemExit(1)`.
- 기존 테스트의 `exit_code == 0` 단정을 `exit_code == 1`로 갱신 + JSON envelope `code` 필드 단정 신규 추가.

Non-Goals (별도 follow-up):
- `report.py:283-285` (정상 "데이터 없음" 출력) — 결함 아님.
- `treasury.py:207-208` (옵션 충돌) — #1540 scope.
- 다른 `fmt.error(); return` 패턴 일괄 audit.

## Test Plan

- [x] `pytest tests/unit -k "report or treasury or snapshot"` (769 passed)
- [x] `pytest tests/unit -q` 전체 회귀 (5610 passed / 4 skipped)
- [x] `ruff check src tests` / `ruff format --check src tests`
- [x] `mypy src` (239 files, no issues)
- [x] `python scripts/generate_project_structure.py --check`
- [x] Codex `/codex:review --base main` PASS (5 substantive checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)