### PR TITLE
fix(cli): emit JSON envelope on UsageError when --format json

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -425,7 +425,8 @@ tests/
 │   │   ├── test_authenticated_group.py
 │   │   ├── test_auth_format_json.py
 │   │   ├── test_bot_create_exit_code.py
-│   │   └── test_broker_missing_account.py
+│   │   ├── test_broker_missing_account.py
+│   │   └── test_usage_error_json.py
 │   ├── ipc/
 │   │   ├── __init__.py
 │   │   ├── test_protocol.py

--- a/src/ante/cli/middleware.py
+++ b/src/ante/cli/middleware.py
@@ -450,6 +450,123 @@ class AuthenticatedGroup(_LeafPathMixin):
         _attach_auth_guard_recursive(cmd)
         super().add_command(cmd, name)
 
+    def main(  # type: ignore[override]
+        self,
+        args: list[str] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        **extra: object,
+    ) -> object:
+        """``BaseCommand.main`` 오버라이드 — JSON 모드 parsing-stage 에러 envelope 변환.
+
+        Click 8.x의 ``BaseCommand.main()`` 은 ``parse_args``/``invoke`` 를 try/except
+        로 감싸 :class:`click.UsageError` (subclass: ``MissingParameter``,
+        ``BadParameter``, ``BadArgumentUsage``, ``NoSuchOption``) 를 catch 하면
+        ``e.show()`` 로 stderr 에 ``Usage: ... Error: ...`` 텍스트를 출력하고
+        ``sys.exit(e.exit_code)`` (보통 2) 한다. 이는 ``--format json`` 모드의
+        구조화 에러 계약 (스펙 ``docs/specs/cli/02-design-decisions.md:78-81``,
+        ``{status, code, message}`` envelope + exit 1) 과 어긋난다 (#1539).
+
+        본 오버라이드는 ``--format`` raw 토큰을 sniff 해 json 모드일 때만 click
+        의 ``standalone_mode=False`` 로 호출하고 ``UsageError`` 를 직접 catch 해
+        :meth:`OutputFormatter.error` 로 envelope 출력 + ``sys.exit(1)`` 한다.
+
+        텍스트 모드 (`--format text` 기본) 에서는 click 기본 동작
+        (``Usage: ... Error: ...`` stderr + exit 2) 을 그대로 유지한다.
+
+        gate-exempt 경로 (``--help`` / ``--version`` / completion) 는 click 이
+        ``BaseCommand.main`` 내부에서 자체 ``ctx.exit()`` 처리하므로 본 try/except
+        블록에는 진입하지 않는다.
+        """
+        output_format = self._sniff_output_format(args)
+        if output_format != "json":
+            return super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=standalone_mode,
+                **extra,
+            )
+
+        # JSON 모드: UsageError 를 직접 catch 해 envelope 출력 + exit 1.
+        # super().main(standalone_mode=False) 는 click ``ClickException`` /
+        # ``Abort`` 를 re-raise 하고, 정상/``Exit`` 케이스는 값을 반환한다
+        # (click core.py:1083-1120).
+        try:
+            rv = super().main(
+                args=args,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                **extra,
+            )
+        except click.UsageError as e:
+            from ante.cli.formatter import OutputFormatter
+
+            fmt = OutputFormatter("json")
+            # Click 의 ``UsageError.format_message()`` 는 메시지 본문만 반환
+            # (예: ``Missing argument 'VALUE'.``). ``CLI_USAGE_ERROR`` 코드는
+            # 스펙 ``02-design-decisions.md:84-87`` 의 ``CLI_*`` prefix 명명 규칙을
+            # 따른다 (코드 내부 상수, 스펙 정식 등재 없음).
+            fmt.error(e.format_message(), code="CLI_USAGE_ERROR")
+            import sys as _sys
+
+            _sys.exit(1)
+        except click.exceptions.Abort:
+            # ``standalone_mode=True`` 호출자 호환을 위해 click 기본 Abort 동작
+            # (``Aborted!`` stderr + exit 1) 을 그대로 보존한다.
+            if standalone_mode:
+                click.echo("Aborted!", err=True)
+                import sys as _sys
+
+                _sys.exit(1)
+            raise
+
+        # standalone_mode=True 호출자 호환: click 기본은 정상 ``ctx.exit(rv)``
+        # 또는 ``Exit`` 예외 시 ``sys.exit(rv)`` 를 호출한다 (core.py:1092,
+        # 1109-1110). 우리는 standalone_mode=False 로 호출했으므로 click 이
+        # sys.exit 를 부르지 않고 값을 반환한다. 호출 일관성을 위해 standalone
+        # 모드에서 우리도 명시적으로 sys.exit 를 호출한다.
+        if standalone_mode:
+            import sys as _sys
+
+            _sys.exit(rv if isinstance(rv, int) else 0)
+        return rv
+
+    @staticmethod
+    def _sniff_output_format(args: list[str] | None) -> str:
+        """raw args 토큰열에서 ``--format`` 값을 추출 (click parse 이전).
+
+        서브커맨드 ``--format`` 이 root ``--format`` 을 오버라이드하는 패턴
+        (:func:`ante.cli.formatter.format_option`) 을 따라 args 의 **마지막**
+        ``--format`` 값을 우선한다.
+
+        예::
+
+            ante --format json bot list --format text  → "text"
+            ante --format text some cmd --format json  → "json"
+            ante bot list                              → "text" (기본값)
+
+        ``--format=value`` (등호 형태) 와 ``--format value`` (공백 형태) 모두
+        지원한다.
+        """
+        import sys as _sys
+
+        tokens = list(args) if args is not None else _sys.argv[1:]
+        result = "text"
+        i = 0
+        while i < len(tokens):
+            tok = tokens[i]
+            if tok == "--format" and i + 1 < len(tokens):
+                result = tokens[i + 1]
+                i += 2
+                continue
+            if tok.startswith("--format="):
+                result = tok.split("=", 1)[1]
+            i += 1
+        return result
+
 
 # click이 callback에 도달하기 전에 ``ctx.exit()`` 시키는 메타 옵션 토큰.
 # ``_has_meta_help_before_dashdash``가 사용한다.

--- a/tests/unit/cli/test_usage_error_json.py
+++ b/tests/unit/cli/test_usage_error_json.py
@@ -443,3 +443,55 @@ class TestNormalCommandUnaffected:
         assert result.exit_code == 0, result.output
         # Click 의 ``Show this message and exit.`` 같은 help 본문이 포함된다.
         assert "Show this" in result.stdout or "--help" in result.stdout, result.stdout
+
+
+# ── BadArgumentUsage subclass 명시 회귀 ─────────────────────────────────────
+
+
+class TestBadArgumentUsageExplicit:
+    """``UsageError`` 부모 catch 가 ``BadArgumentUsage`` subclass 에도 적용됨을
+    명시적으로 보장하는 회귀.
+
+    배경:
+        실제 ante CLI 표면에서 ``BadArgumentUsage`` 를 직접 raise 하는 경로는
+        흔치 않지만, ``UsageError`` 계층 (``MissingParameter``, ``BadParameter``,
+        ``NoSuchOption``, ``BadArgumentUsage``, ``BadOptionUsage``) 중 어느
+        subclass 가 발화되더라도 동일한 JSON envelope 가 나와야 한다는 것은
+        :meth:`AuthenticatedGroup.main` override 의 핵심 invariant 다.
+
+        synthetic CLI 에서 ``BadArgumentUsage`` 를 직접 raise 해, 부모 catch 의
+        subclass 커버리지를 명시 회귀로 못박는다.
+    """
+
+    def test_bad_argument_usage_emits_json_envelope(self, runner: CliRunner) -> None:
+        """``BadArgumentUsage`` 명시 raise → JSON envelope + exit 1."""
+
+        @click.group(cls=AuthenticatedGroup)
+        @click.option(
+            "--format",
+            "output_format",
+            type=click.Choice(["text", "json"]),
+            default="text",
+        )
+        def synthetic_cli(output_format: str) -> None:  # noqa: ARG001
+            pass
+
+        @synthetic_cli.command()
+        @click.argument("value")
+        def echo(value: str) -> None:
+            if value == "trigger":
+                raise click.exceptions.BadArgumentUsage(
+                    "explicit BadArgumentUsage trigger"
+                )
+            click.echo(value)
+
+        result = runner.invoke(synthetic_cli, ["--format", "json", "echo", "trigger"])
+
+        assert result.exit_code == 1, (
+            f"expected exit 1, got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        payload = _parse_json_line(result.stdout)
+        assert payload["status"] == "error", payload
+        assert payload["code"] == "CLI_USAGE_ERROR", payload
+        assert "explicit BadArgumentUsage trigger" in str(payload["message"]), payload

--- a/tests/unit/cli/test_usage_error_json.py
+++ b/tests/unit/cli/test_usage_error_json.py
@@ -1,0 +1,445 @@
+"""``--format json`` 모드의 click parsing-stage 에러 envelope 회귀 (#1539).
+
+배경:
+    ``ante --format json feed config set ANTE_DART_API_KEY`` 같은 호출은
+    Click 의 ``UsageError`` (subclass: ``MissingParameter``, ``BadParameter``,
+    ``BadArgumentUsage``, ``NoSuchOption``) 를 발화하는데, click 기본 동작은
+    stderr 에 ``Usage: ... Error: Missing argument 'VALUE'.`` 텍스트를 출력하고
+    exit 2 로 종료한다. 이는 비대화형 CLI 입력 계약 (스펙
+    ``docs/specs/cli/02-design-decisions.md:78-81``) 의 JSON envelope + exit 1
+    요구와 어긋난다.
+
+    fix: :meth:`AuthenticatedGroup.main` 오버라이드가 raw args 토큰열에서
+    ``--format`` 마지막 값을 sniff 해 json 일 때 ``standalone_mode=False`` 로
+    click 을 호출, ``UsageError`` 를 직접 catch 해 envelope 출력 + ``sys.exit(1)``.
+
+Coverage map:
+    - missing argument JSON 모드: ``feed config set ANTE_DART_API_KEY`` (value 누락)
+      → stdout JSON envelope + exit 1.
+    - missing argument text 모드 (회귀): 동일 입력 → click 기본 stderr + exit 2.
+    - unknown option JSON 모드: ``bot list --unknown-flag`` → JSON envelope + exit 1.
+    - bad argument type JSON 모드: ``bot create --interval not-a-number`` →
+      JSON envelope + exit 1.
+    - sniff 우선순위: 마지막 ``--format`` 토큰이 효과적인 모드를 결정.
+    - gate-exempt 보존: ``--help`` / ``--version`` / nested ``--help`` 모두
+      ``--format json`` 이 함께 와도 click 기본 동작 (exit 0) 유지.
+    - Abort 보존: ``standalone_mode=True`` 호출에서 ``Abort`` 발생 시
+      ``Aborted!`` stderr + exit 1.
+
+SSOT 참조:
+    - ``src/ante/cli/middleware.py`` (:class:`AuthenticatedGroup`,
+      ``main`` override + ``_sniff_output_format``)
+    - ``src/ante/cli/formatter.py`` (:meth:`OutputFormatter.error`)
+    - ``docs/specs/cli/02-design-decisions.md:78-81`` (JSON envelope + exit 1 계약)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.cli.middleware import AuthenticatedGroup
+from ante.member.models import Member, MemberRole, MemberType
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    """``authenticate_member`` 를 패치해 master member 를 주입하는 runner.
+
+    JSON envelope 가 stdout 으로 가는지 확인해야 하므로 ``mix_stderr=False`` 로
+    stdout/stderr 를 분리한다.
+    """
+    r = CliRunner(mix_stderr=False)
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):  # noqa: ANN001, ANN202
+                ctx.ensure_object(dict)
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth  # type: ignore[method-assign]
+    return r
+
+
+@pytest.fixture()
+def clean_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[None]:
+    """``ANTE_MEMBER_TOKEN`` / 토큰 파일 차단 + ``ANTE_CONFIG_DIR`` 격리."""
+    monkeypatch.delenv("ANTE_MEMBER_TOKEN", raising=False)
+    monkeypatch.setenv("ANTE_TOKEN_FILE", str(tmp_path / "nonexistent.token"))
+    monkeypatch.setenv("ANTE_CONFIG_DIR", str(tmp_path / "config"))
+    yield
+
+
+def _parse_json_line(stdout: str) -> dict[str, object]:
+    """stdout 첫 JSON dict 라인을 파싱해 반환."""
+    for line in stdout.splitlines():
+        text = line.strip()
+        if not text:
+            continue
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    raise AssertionError(f"stdout 에서 JSON dict 를 찾지 못함: {stdout!r}")
+
+
+# ── missing argument: spec primary case (#1539 본문 시나리오) ───────────────
+
+
+class TestMissingArgument:
+    """``ante feed config set ANTE_DART_API_KEY`` (value 누락) 시나리오."""
+
+    def test_missing_argument_json_mode_emits_envelope_and_exits_1(
+        self, runner: CliRunner
+    ) -> None:
+        """JSON 모드: stdout JSON envelope + exit 1 (스펙 02-design-decisions.md:78)."""
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "feed",
+                "config",
+                "set",
+                "ANTE_DART_API_KEY",
+            ],
+        )
+
+        assert result.exit_code == 1, (
+            f"expected exit 1, got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        payload = _parse_json_line(result.stdout)
+        assert payload["status"] == "error", payload
+        assert payload["code"] == "CLI_USAGE_ERROR", payload
+        # click 의 기본 메시지 본문 ("Missing argument 'VALUE'.") 그대로 보존.
+        assert "Missing argument" in str(payload["message"]), payload
+        assert "VALUE" in str(payload["message"]), payload
+        # 텍스트 fallback 이 stderr 로 동시에 새지 않아야 한다 (JSON 모드 단일 표면).
+        assert "Usage:" not in result.stderr, result.stderr
+
+    def test_missing_argument_text_mode_preserves_click_default(
+        self, runner: CliRunner
+    ) -> None:
+        """text 모드 (회귀): click 기본 ``Usage: ... Error: ...`` stderr + exit 2."""
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "text",
+                "feed",
+                "config",
+                "set",
+                "ANTE_DART_API_KEY",
+            ],
+        )
+
+        assert result.exit_code == 2, (
+            f"expected exit 2 (click default), got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        # 텍스트 모드는 stdout 으로 JSON envelope 를 새지 않아야 한다.
+        assert result.stdout.strip() == "", result.stdout
+        # click 기본 텍스트 에러 메시지는 stderr 로 출력된다.
+        assert "Usage:" in result.stderr, result.stderr
+        assert "Missing argument" in result.stderr, result.stderr
+
+
+# ── unknown option (UsageError 다른 subclass) ───────────────────────────────
+
+
+class TestUnknownOption:
+    """``--unknown-flag`` 같이 정의되지 않은 옵션 → ``NoSuchOption``."""
+
+    def test_unknown_option_json_mode_emits_envelope_and_exits_1(
+        self, runner: CliRunner
+    ) -> None:
+        """JSON 모드: stdout JSON envelope + exit 1."""
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "bot", "list", "--unknown-flag"],
+        )
+
+        assert result.exit_code == 1, (
+            f"expected exit 1, got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        payload = _parse_json_line(result.stdout)
+        assert payload["status"] == "error", payload
+        assert payload["code"] == "CLI_USAGE_ERROR", payload
+        assert "no such option" in str(payload["message"]).lower(), payload
+
+
+# ── bad argument type (BadParameter via type=click.IntRange) ────────────────
+
+
+class TestBadArgumentType:
+    """``bot create --interval not-a-number`` → ``BadParameter`` (UsageError)."""
+
+    def test_bad_int_value_json_mode_emits_envelope_and_exits_1(
+        self, runner: CliRunner
+    ) -> None:
+        """JSON 모드: stdout JSON envelope + exit 1."""
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "bot",
+                "create",
+                "--name",
+                "테스트봇",
+                "--strategy",
+                "stg-1",
+                "--account",
+                "test",
+                "--interval",
+                "not-a-number",
+            ],
+        )
+
+        assert result.exit_code == 1, (
+            f"expected exit 1, got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        payload = _parse_json_line(result.stdout)
+        assert payload["status"] == "error", payload
+        assert payload["code"] == "CLI_USAGE_ERROR", payload
+        # click 의 IntRange 타입 변환 실패 메시지 본문이 포함된다.
+        assert (
+            "not-a-number" in str(payload["message"])
+            or "interval" in str(payload["message"]).lower()
+        ), payload
+
+
+# ── sniff 우선순위 (서브커맨드 --format 이 root 를 오버라이드) ───────────────
+
+
+class TestSniffPriority:
+    """``_sniff_output_format`` 은 args 의 **마지막** ``--format`` 값을 우선한다.
+
+    :func:`ante.cli.formatter.format_option` 의 서브커맨드 ``--format`` 오버라이드
+    패턴을 따른다. 이 우선순위는 정상 명령에서도 동일하므로 parsing-stage 에러
+    경로도 같은 순서를 따라야 한다.
+    """
+
+    def test_sniff_static_helper_prefers_last_format_token(self) -> None:
+        """raw args 에서 마지막 ``--format`` 값이 결과를 결정한다."""
+        # root json + subcommand text → text (서브커맨드 override).
+        assert (
+            AuthenticatedGroup._sniff_output_format(
+                ["--format", "json", "bot", "list", "--format", "text"]
+            )
+            == "text"
+        )
+        # root text + subcommand json → json.
+        assert (
+            AuthenticatedGroup._sniff_output_format(
+                ["--format", "text", "bot", "list", "--format", "json"]
+            )
+            == "json"
+        )
+        # 단일 --format json → json.
+        assert (
+            AuthenticatedGroup._sniff_output_format(["--format", "json", "bot", "list"])
+            == "json"
+        )
+        # --format=value (등호 형태) 도 지원.
+        assert (
+            AuthenticatedGroup._sniff_output_format(
+                ["--format=json", "bot", "list", "--format=text"]
+            )
+            == "text"
+        )
+        # --format 없음 → 기본 "text".
+        assert AuthenticatedGroup._sniff_output_format(["bot", "list"]) == "text"
+        # None args → ``sys.argv[1:]`` fallback (간접 검증: 빈 list 와 동일 결과 보장).
+        assert AuthenticatedGroup._sniff_output_format([]) == "text"
+
+    def test_subcommand_format_text_overrides_root_format_json(
+        self, runner: CliRunner
+    ) -> None:
+        """``ante --format json bot list --format text`` → text 모드 → click 기본 동작.
+
+        sniff 가 마지막 토큰 (text) 을 우선하므로, ``--unknown-flag`` 같은
+        UsageError 가 함께 발생해도 click 기본 stderr + exit 2 가 보존된다.
+        """
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "bot",
+                "list",
+                "--unknown-flag",
+                "--format",
+                "text",
+            ],
+        )
+
+        # 마지막 --format 이 text → 우리 catch 진입 안 함 → click 기본 exit 2.
+        assert result.exit_code == 2, (
+            f"expected exit 2 (text mode click default), got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        # JSON envelope 가 stdout 으로 새지 않아야 한다.
+        assert result.stdout.strip() == "", result.stdout
+
+    def test_subcommand_format_json_overrides_root_format_text(
+        self, runner: CliRunner
+    ) -> None:
+        """``ante --format text ... --format json`` → json 모드 → JSON envelope."""
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "text",
+                "bot",
+                "list",
+                "--unknown-flag",
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 1, (
+            f"expected exit 1 (json mode), got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        payload = _parse_json_line(result.stdout)
+        assert payload["status"] == "error", payload
+        assert payload["code"] == "CLI_USAGE_ERROR", payload
+
+
+# ── gate-exempt 보존 (--help / --version) ────────────────────────────────────
+
+
+class TestGateExemptPreserved:
+    """``--help`` / ``--version`` 은 click 이 ``ctx.exit()`` 으로 자체 종료한다.
+
+    우리 main override 의 try/except 블록은 ``UsageError`` / ``Abort`` 만
+    catch 하므로 ``Exit`` 예외는 정상 통과한다. ``--format json`` 이 함께 주어져도
+    click 기본 ``--help`` / ``--version`` 출력과 exit 0 동작이 그대로 유지된다.
+    """
+
+    def test_root_help_with_format_json_exits_0(self, runner: CliRunner) -> None:
+        """``ante --format json --help`` → click 기본 help, exit 0."""
+        result = runner.invoke(cli, ["--format", "json", "--help"])
+        assert result.exit_code == 0, (
+            f"expected exit 0, got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        assert "Usage:" in result.stdout, result.stdout
+
+    def test_root_version_with_format_json_exits_0(self, runner: CliRunner) -> None:
+        """``ante --format json --version`` → click 기본 version, exit 0."""
+        result = runner.invoke(cli, ["--format", "json", "--version"])
+        assert result.exit_code == 0, (
+            f"expected exit 0, got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        assert "ante" in result.stdout.lower(), result.stdout
+
+    def test_subcommand_help_with_format_json_exits_0(self, runner: CliRunner) -> None:
+        """``ante --format json bot list --help`` → click 기본 help, exit 0."""
+        result = runner.invoke(cli, ["--format", "json", "bot", "list", "--help"])
+        assert result.exit_code == 0, (
+            f"expected exit 0, got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        assert "Usage:" in result.stdout, result.stdout
+
+    def test_root_help_text_mode_unchanged(self, runner: CliRunner) -> None:
+        """``ante --help`` (text 기본) → click 기본 help, exit 0."""
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0, (
+            f"expected exit 0, got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        assert "Usage:" in result.stdout, result.stdout
+
+
+# ── Abort 보존 (KeyboardInterrupt 시뮬레이션) ────────────────────────────────
+
+
+class TestAbortPreserved:
+    """``click.exceptions.Abort`` 발생 시 ``Aborted!`` stderr + exit 1 보존.
+
+    ``standalone_mode=False`` 로 호출한 click 은 Abort 를 re-raise 한다
+    (click core.py:1121-1125). 우리 main override 가 이를 catch 해
+    standalone_mode=True 호출자에 한해 ``Aborted!`` 출력 + ``sys.exit(1)``.
+    """
+
+    def test_abort_in_json_mode_emits_aborted_and_exits_1(
+        self, runner: CliRunner
+    ) -> None:
+        """``raise click.exceptions.Abort()`` 시 stderr ``Aborted!`` + exit 1.
+
+        click ``BaseCommand.main`` 은 ``standalone_mode=False`` 일 때 ``Abort``
+        를 re-raise 한다 (click core.py:1121-1125). 우리 main override 가
+        이를 catch 해 ``standalone_mode=True`` 호출자에게 click 기본 Abort
+        동작 (``Aborted!`` stderr + ``sys.exit(1)``) 을 그대로 보존해야 한다.
+
+        ``BaseCommand.invoke`` 를 patch 해 직접 Abort 를 발화시킨다 — 이
+        지점은 우리 main override 의 ``super().main()`` 호출 내부이므로
+        click 이 standalone_mode=False 분기에서 re-raise 한다.
+        """
+
+        def _raise_abort(self, ctx):  # noqa: ANN001, ANN202, ARG001
+            raise click.exceptions.Abort()
+
+        with patch.object(AuthenticatedGroup, "invoke", _raise_abort):
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "bot", "list"],
+            )
+
+        assert result.exit_code == 1, (
+            f"expected exit 1, got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        assert "Aborted!" in result.stderr, result.stderr
+
+
+# ── 회귀: 정상 명령은 영향 없음 ──────────────────────────────────────────────
+
+
+class TestNormalCommandUnaffected:
+    """JSON 모드 정상 명령은 우리 catch 블록을 통과해 click 정상 흐름 그대로."""
+
+    def test_json_mode_help_returns_normally(self, runner: CliRunner) -> None:
+        """``--format json --help`` 은 정상 종료 + click help 출력."""
+        result = runner.invoke(cli, ["--format", "json", "--help"])
+        assert result.exit_code == 0, result.output
+        # Click 의 ``Show this message and exit.`` 같은 help 본문이 포함된다.
+        assert "Show this" in result.stdout or "--help" in result.stdout, result.stdout

--- a/tests/unit/test_cli_strategy_list_invalid_status.py
+++ b/tests/unit/test_cli_strategy_list_invalid_status.py
@@ -235,10 +235,15 @@ class TestStrategyListInvalidStatus:
             assert "Traceback" not in result.output
 
     def test_click_exception_propagates_without_formatter(self, runner):
-        """`_list()` 내부에서 `click.ClickException`이 발생하면 그대로 전파된다.
+        """`_list()` 내부에서 `click.ClickException`이 발생하면 strategy formatter를
+        거치지 않고 root main override 의 ``CLI_USAGE_ERROR`` envelope 로 종료한다.
 
-        formatter를 거치면 click의 표준 출력 경로(`UsageError`/`ClickException.show`)
-        가 깨지므로, `except click.ClickException: raise` 분기로 보존되어야 한다.
+        invariant: ``strategy list`` 내부의 ``except click.ClickException: raise``
+        분기가 보존되어 strategy 도메인 formatter (``STRATEGY_*`` code) 가 거치지
+        않는다. JSON 모드에서는 root ``AuthenticatedGroup.main`` override 가
+        catch 해 :class:`OutputFormatter` 의 ``CLI_USAGE_ERROR`` envelope 로 변환
+        (#1539, 스펙 ``docs/specs/cli/02-design-decisions.md:78-81``: 필수 입력
+        누락은 exit 1 + 구조화 에러 envelope).
         """
         db = _mock_db()
         registry = MagicMock()
@@ -262,8 +267,10 @@ class TestStrategyListInvalidStatus:
                     "adopted",
                 ],
             )
-            # click.UsageError → exit_code 2, formatter JSON 미경유.
-            assert result.exit_code == 2
+            # spec 정정: JSON 모드 UsageError → exit 1 + envelope (#1539).
+            assert result.exit_code == 1
             assert "intentional click usage error" in result.output
-            # JSON shape이 아니어야 한다(formatter를 거치지 않았다는 회귀).
+            # invariant: strategy 도메인 formatter (STRATEGY_ERROR) 를 거치지 않고
+            # root main override 의 CLI_USAGE_ERROR envelope 로 종료한다.
             assert '"code": "STRATEGY_ERROR"' not in result.output
+            assert '"code": "CLI_USAGE_ERROR"' in result.output


### PR DESCRIPTION
Closes #1539

## Summary

`ante --format json feed config set ANTE_DART_API_KEY` (required value 누락) 같은 Click `UsageError` 발생 시, 기존에는 stderr Click 기본 텍스트 + exit 2였으나 spec `docs/specs/cli/02-design-decisions.md:78-81`이 명시한 `{status, code, message}` JSON envelope + exit 1을 따르도록 수정.

핵심 변경:
- `src/ante/cli/middleware.py` `AuthenticatedGroup.main()` override + `_sniff_output_format()` staticmethod 추가.
- raw args의 **마지막** `--format` 토큰 우선 (서브커맨드 override 패턴 준수).
- JSON 모드: `super().main(standalone_mode=False)` 호출 후 `click.UsageError` (subclass: `MissingParameter`, `BadParameter`, `BadArgumentUsage`, `NoSuchOption`) catch → `OutputFormatter("json").error(message, code="CLI_USAGE_ERROR")` + `sys.exit(1)`.
- 텍스트 모드: Click 기본 동작 그대로 (exit 2, stderr Usage 텍스트).
- `--help`/`--version`/completion 등 gate-exempt 경로: 영향 없음 (Click 기본 sys.exit 동작 그대로).
- `click.exceptions.Abort`: standalone_mode 동작 보존.

부수 정정:
- `tests/unit/test_cli_strategy_list_invalid_status.py::test_click_exception_propagates_without_formatter`가 spec과 모순되는 단정(JSON 모드 + UsageError → exit 2 stderr)을 가지고 있어 spec 일치로 갱신. 내부 invariant("strategy 도메인 STRATEGY_ERROR formatter 미경유")는 유지.

## Test Plan

- [x] `pytest tests/unit/cli/test_usage_error_json.py -v` (14 tests PASS — missing argument×JSON/text, unknown option, bad argument type, sniff 우선순위 3건, gate-exempt 보존 4건, Abort 보존, 정상 회귀, BadArgumentUsage subclass 명시)
- [x] `pytest tests/unit -q` 전체 회귀 (5624+ passed / 4 skipped, 베이스라인 5610 + 14)
- [x] `ruff check src tests` / `ruff format --check src tests`
- [x] `mypy src` (239 files, no issues)
- [x] `python scripts/generate_project_structure.py --check`
- [x] Codex `/codex:review --base main` PASS (attempt 2; attempt 1은 BadArgumentUsage 누락 minor finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)