### PR TITLE
fix(cli): exit 1 on treasury snapshot option conflict

### DIFF
--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -204,8 +204,11 @@ def snapshot(
 
     # 옵션 검증: --date 와 --from/--to 는 동시 사용 불가
     if date_str and (from_date or to_date):
-        fmt.error("--date와 --from/--to 옵션은 동시에 사용할 수 없습니다.")
-        return
+        fmt.error(
+            "--date와 --from/--to 옵션은 동시에 사용할 수 없습니다.",
+            code="CLI_OPTION_CONFLICT",
+        )
+        raise SystemExit(1)
 
     async def _run_snapshot() -> dict | list[dict] | None:
         t, db = await _create_treasury(account_id)

--- a/tests/unit/test_cli_treasury_snapshot.py
+++ b/tests/unit/test_cli_treasury_snapshot.py
@@ -353,8 +353,8 @@ class TestSnapshotJson:
 class TestSnapshotValidation:
     """옵션 조합 검증."""
 
-    def test_date_and_from_conflict(self, runner, mock_auth):
-        """--date와 --from을 동시에 사용하면 에러."""
+    def test_date_and_from_conflict_text(self, runner, mock_auth):
+        """--date와 --from을 동시에 사용하면 text 모드에서 exit 1."""
         ctx_patch, _ = _make_mock_treasury()
         with ctx_patch:
             result = _invoke(
@@ -371,8 +371,83 @@ class TestSnapshotValidation:
                 mock_auth,
             )
 
-        assert result.exit_code == 0
+        assert result.exit_code == 1
+        # text 모드: stderr로 Error 출력, stdout에는 메시지 없음
         assert "동시에 사용할 수 없습니다" in result.output
+
+    def test_date_and_from_conflict_json(self, runner, mock_auth):
+        """--date와 --from을 동시에 사용하면 JSON envelope + exit 1."""
+        import json
+
+        from ante.member.models import Member, MemberType
+
+        mock_member = Member(
+            member_id="test-user",
+            name="테스트",
+            type=MemberType.HUMAN,
+            role="master",
+        )
+
+        ctx_patch, _ = _make_mock_treasury()
+        with ctx_patch:
+            result = runner.invoke(
+                treasury,
+                [
+                    "snapshot",
+                    "--account",
+                    "domestic",
+                    "--date",
+                    "2026-03-21",
+                    "--from",
+                    "2026-03-20",
+                ],
+                obj={
+                    "format": "json",
+                    "formatter": OutputFormatter("json"),
+                    "member": mock_member,
+                },
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["status"] == "error"
+        assert payload["code"] == "CLI_OPTION_CONFLICT"
+        assert "동시에 사용할 수 없습니다" in payload["message"]
+
+    def test_date_and_to_conflict(self, runner, mock_auth):
+        """--date와 --to를 동시에 사용해도 동일하게 차단된다(정상 회귀)."""
+        ctx_patch, _ = _make_mock_treasury()
+        with ctx_patch:
+            result = _invoke(
+                runner,
+                [
+                    "snapshot",
+                    "--account",
+                    "domestic",
+                    "--date",
+                    "2026-03-21",
+                    "--to",
+                    "2026-03-22",
+                ],
+                mock_auth,
+            )
+
+        assert result.exit_code == 1
+        assert "동시에 사용할 수 없습니다" in result.output
+
+    def test_single_date_option_ok(self, runner, mock_auth):
+        """단일 옵션(--date)은 정상 동작(정상 회귀)."""
+        ctx_patch, _ = _make_mock_treasury(get_daily_return=SAMPLE_SNAPSHOT)
+        with ctx_patch:
+            result = _invoke(
+                runner,
+                ["snapshot", "--account", "domestic", "--date", "2026-03-21"],
+                mock_auth,
+            )
+
+        assert result.exit_code == 0
+        assert "동시에 사용할 수 없습니다" not in result.output
 
 
 class TestSnapshotAccount:


### PR DESCRIPTION
Closes #1540

## Summary

`treasury snapshot --date X --from Y` (또는 `--to Y`) 옵션 충돌이 error JSON을 출력하지만 exit 0으로 끝나던 결함을 수정한다. `src/ante/cli/commands/treasury.py:207-208`에 `code="CLI_OPTION_CONFLICT"` 인자 추가 + `return` → `raise SystemExit(1)`. 기존 단정 `tests/unit/test_cli_treasury_snapshot.py:356-375`의 exit 0 → exit 1 갱신 + JSON envelope/`--to`/단일옵션 회귀 테스트 추가.

## Test Plan

- [x] `pytest tests/unit/test_cli_treasury_snapshot.py` (15 passed)
- [x] `pytest tests/unit -k "treasury or snapshot"` (516 passed)
- [x] `pytest tests/unit -q` 전체 회귀 (5627 passed / 4 skipped)
- [x] `ruff check src tests` / `ruff format --check src tests`
- [x] `mypy src` (239 files, no issues)
- [x] `python scripts/generate_project_structure.py --check`
- [x] Codex `/codex:review --base main` PASS (5 substantive checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)