### PR TITLE
fix(cli): strategy validate failure emits single JSON envelope and exit 1

### DIFF
--- a/src/ante/cli/commands/strategy.py
+++ b/src/ante/cli/commands/strategy.py
@@ -61,14 +61,32 @@ def validate(ctx: click.Context, path: str) -> None:
     if result.valid:
         fmt.success(f"Strategy validation passed: {path}", data)
     else:
-        fmt.error(f"Validation failed: {path}")
-        if not fmt.is_json:
+        if fmt.is_json:
+            import json as _json
+
+            click.echo(
+                _json.dumps(
+                    {
+                        "status": "error",
+                        "code": "STRATEGY_VALIDATION_FAILED",
+                        "message": f"Validation failed: {path}",
+                        "data": data,
+                    },
+                    indent=2,
+                    default=str,
+                    ensure_ascii=False,
+                )
+            )
+        else:
+            fmt.error(
+                f"Validation failed: {path}",
+                code="STRATEGY_VALIDATION_FAILED",
+            )
             for err in result.errors:
                 click.echo(f"  - {err}", err=True)
             for warn in result.warnings:
                 click.echo(f"  [warn] {warn}", err=True)
-        else:
-            fmt.output(data)
+        raise SystemExit(1)
 
 
 @strategy.command("submit")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -232,11 +232,52 @@ class TestStrategyCommands:
         assert data["status"] == "ok"
 
     def test_validate_invalid(self, runner, invalid_strategy_file):
+        # #1541: validation failure must exit 1 (single source of truth, not 0).
         result = runner.invoke(
             cli, ["strategy", "validate", str(invalid_strategy_file)]
         )
-        assert result.exit_code == 0  # validation failure is not a CLI error
-        assert "Error" in result.output or "failed" in result.output.lower()
+        assert result.exit_code == 1
+        # text 모드에서는 stderr에 "Error: Validation failed: ..."가 들어간다.
+        # CliRunner는 기본적으로 stderr를 stdout과 합치므로 result.output로 점검한다.
+        combined = result.output
+        assert "Validation failed" in combined
+
+    def test_validate_invalid_json_single_envelope(self, runner, invalid_strategy_file):
+        """#1541: JSON 모드 invalid 입력은 단일 envelope + exit 1로 종료한다."""
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "strategy",
+                "validate",
+                str(invalid_strategy_file),
+            ],
+        )
+        assert result.exit_code == 1
+        # 단일 JSON 문서로 파싱 가능해야 한다 (두 개의 문서 출력 금지).
+        data = json.loads(result.output)
+        assert data["status"] == "error"
+        assert data["code"] == "STRATEGY_VALIDATION_FAILED"
+        assert "Validation failed" in data["message"]
+        assert data["data"]["valid"] is False
+        assert isinstance(data["data"]["errors"], list)
+        assert isinstance(data["data"]["warnings"], list)
+
+    def test_validate_invalid_text_stderr(self, runner, invalid_strategy_file):
+        """#1541: text 모드 invalid 입력은 stderr에 에러+상세 라인을 내보낸다."""
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "text",
+                "strategy",
+                "validate",
+                str(invalid_strategy_file),
+            ],
+        )
+        assert result.exit_code == 1
+        assert "Error: Validation failed" in result.output
 
     def test_validate_nonexistent(self, runner):
         result = runner.invoke(cli, ["strategy", "validate", "/nonexistent.py"])


### PR DESCRIPTION
Closes #1541

## Summary

`ante --format json strategy validate <invalid>` 호출이 두 개의 JSON 문서(`fmt.error` 후 `fmt.output(data)`)를 stdout에 출력하고 exit 0으로 끝나던 결함을 수정한다.

- `src/ante/cli/commands/strategy.py:64-71` invalid 분기를 단일 envelope으로 통합:
  - JSON 모드: `{status:"error", code:"STRATEGY_VALIDATION_FAILED", message:..., data:{valid,errors,warnings}}` 단일 문서 출력 (manual `click.echo(json.dumps(...))`로 OutputFormatter 시그니처 변경 회피).
  - text 모드: 기존 `Error: Validation failed: ...` + 각 error/warn 라인 stderr 그대로.
  - 양쪽 모두 `raise SystemExit(1)`.
- 기존 `tests/unit/test_cli.py:234` `test_validate_invalid` 단정 exit 0 → 1 갱신.

## Test Plan

- [x] `pytest tests/unit -k "test_cli"` (726 passed, validate 6건 포함)
- [x] `pytest tests/unit -q` 전체 회귀 (5629 passed / 4 skipped)
- [x] `ruff check src tests` / `ruff format --check src tests`
- [x] `mypy src` (239 files, no issues)
- [x] `python scripts/generate_project_structure.py --check`
- [x] Codex `/codex:review --base main` PASS (5 substantive checks, attempt 1)

신규 테스트 2건: invalid JSON envelope 단일 파싱 + exit 1, invalid text stderr + exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)