### PR TITLE
docs(member): clarify member admin mutation is master-only

### DIFF
--- a/docs/specs/cli/02-design-decisions.md
+++ b/docs/specs/cli/02-design-decisions.md
@@ -174,6 +174,30 @@ CLI는 해당 규칙을 command 실행 전에 적용하는 표면이다.
 
 매칭은 leaf 이름이 아니라 **전체 커맨드 경로** 기준이다. `ante feed init`처럼 leaf 이름이 우연히 `init`인 다른 서브커맨드는 면제 대상이 아니다 (`@require_auth` + `@require_scope`로 인증 필요). 구현은 `LeafAwareGroup`(src/ante/cli/main.py)이 루트 그룹 진입 직후 전체 경로 tuple을 `ctx.obj["_leaf_command_path"]`에 저장하고, `authenticate_member`가 이 tuple과 `_AUTH_EXEMPT_COMMAND_PATHS`(src/ante/cli/middleware.py:29-33)를 비교한다.
 
+**Member admin mutation 권한 모델 (1.0 — master-only)**:
+
+`ante member register`, `ante member suspend`, `ante member reactivate`,
+`ante member revoke`, `ante member rotate-token`, `ante member set-password`(향후),
+`ante member set-emoji` 외 권한 변경 명령 등 member admin mutation CLI 명령은
+1.0 계약에서 **master-only**다. 권한 모델 SSOT는
+[../member/02-design-decisions.md — Member admin mutation 권한 모델](../member/02-design-decisions.md#권한-범위-scope)이며,
+서비스 진입 시점에 `MemberService._assert_master`가 호출자 principal을 검사하고
+master가 아니면 `PermissionError`를 발생시킨다.
+
+`ANTE_MEMBER_TOKEN`이 agent token(`ante_ak_*`)이면 service layer에서 거부되어
+exit 1로 종료한다. CLI 표면 가드(`@require_scope`)는 `member:admin` scope를
+대상으로 하지 않으며, `member:admin` scope는 vocabulary에 정의되어 있으나
+1.0에서는 **reserved (현재 미사용)**이다. agent 위임이 필요해지면 별도 정책
+이슈에서 reserved scope를 활성화한 뒤 표면을 정렬한다.
+
+`ante member reset-password`와 `ante member regenerate-recovery-key`는 인증
+수단이 recovery key 또는 현재 패스워드 자체이므로 위 master-only 정책과 별도로
+공개 명령 allowlist 경로([03-commands.md — 공개 명령 allowlist](03-commands.md#공개-명령-allowlist--인증-면제))를 따른다.
+
+> 후속 implementation 정렬: #1543 (Web API/CLI 표면 가드 master-only로 일치),
+> #1544 (oracle host probe scope 기대값 정렬). 본 결정 SSOT는 #1542이며,
+> 부모 #1511(oracle host probe scope drift)에서 시작된 정합 작업이다.
+
 ### default-deny CLI 인증 게이트
 
 > 정책 SSOT: [D-015 default-deny 인증 게이트](../../decisions/D-015-default-deny-auth-gate.md)

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -538,19 +538,29 @@ ante init [--member-id owner] [--name Owner] [--dir <경로>]
 
 > master 계정 생성은 `ante init`에 통합되었다. 별도 `ante member bootstrap` 명령은 제거됨(재설계 2026-04).
 
+권한 모델 SSOT는 [02-design-decisions.md — Member admin mutation 권한 모델](02-design-decisions.md#인증-미들웨어)와
+[../member/02-design-decisions.md — Member admin mutation 권한 모델](../member/02-design-decisions.md#권한-범위-scope)이다.
+member admin mutation은 1.0 계약에서 **master-only**이며, agent token으로 호출하면
+service layer `MemberService._assert_master`에서 거부되어 exit 1로 종료한다.
+`member:admin` scope는 vocabulary에 정의되어 있으나 reserved (1.0 미사용)다.
+
 ```bash
-ante member register --id <member_id> --type human|agent [--org <org>] [--name <name>] [--scopes <csv>]  # 멤버 등록
-ante member list [--type human|agent] [--org <org>] [--status active|suspended|revoked]  # 멤버 목록
-ante member info <member_id>                            # 멤버 상세
+ante member register --id <member_id> --type human|agent [--org <org>] [--name <name>] [--scopes <csv>]  # 멤버 등록 (master-only)
+ante member list [--type human|agent] [--org <org>] [--status active|suspended|revoked]  # 멤버 목록 (scope: member:read)
+ante member info <member_id>                            # 멤버 상세 (scope: member:read)
 ante member list-invalid-roles [--format json]          # MemberRole enum 외 role 을 가진 legacy row 식별 (운영 cleanup; runbook 07 참조)
-ante member suspend <member_id>                         # 멤버 일시 정지
-ante member reactivate <member_id>                      # 멤버 재활성화
-ante member revoke <member_id> --yes                    # 멤버 권한 영구 해제 (--yes 누락 시 CLI_CONFIRMATION_REQUIRED)
-ante member rotate-token <member_id>                    # 인증 토큰 갱신
-ante member set-emoji <member_id> <emoji>               # 멤버 이모지 설정
-ante member reset-password --recovery-key <key> (--new-password-env ENV_NAME | --new-password-file PATH)  # 비밀번호 초기화
-ante member regenerate-recovery-key (--password-env ENV_NAME | --password-file PATH)  # 복구 키 재발급
+ante member suspend <member_id>                         # 멤버 일시 정지 (master-only)
+ante member reactivate <member_id>                      # 멤버 재활성화 (master-only)
+ante member revoke <member_id> --yes                    # 멤버 권한 영구 해제 (master-only, --yes 누락 시 CLI_CONFIRMATION_REQUIRED)
+ante member rotate-token <member_id>                    # 인증 토큰 갱신 (master-only)
+ante member set-emoji <member_id> <emoji>               # 멤버 이모지 설정 (master-only)
+ante member reset-password --recovery-key <key> (--new-password-env ENV_NAME | --new-password-file PATH)  # 비밀번호 초기화 (공개 명령 allowlist — recovery key가 인증 수단)
+ante member regenerate-recovery-key (--password-env ENV_NAME | --password-file PATH)  # 복구 키 재발급 (공개 명령 allowlist — 현재 패스워드가 인증 수단)
 ```
+
+> 후속 implementation 정렬: #1543 (Web API/CLI 표면 가드 master-only로 일치),
+> #1544 (oracle host probe scope 기대값 정렬). 본 결정 SSOT는 #1542이며,
+> 부모 #1511(oracle host probe scope drift)에서 시작된 정합 작업이다.
 
 `member list/info`와 `member list-invalid-roles`는 오프라인 조회가 가능하다. 단,
 `member list-invalid-roles`는 `MemberService.initialize()`로 schema migration DDL을

--- a/docs/specs/member/02-design-decisions.md
+++ b/docs/specs/member/02-design-decisions.md
@@ -185,7 +185,7 @@ master(human)는 scope 제한 없이 모든 작업을 수행할 수 있다. scop
 | `bot` | 봇 상태 조회 | — | 봇 생성/삭제, 시그널키 발급/갱신 | — |
 | `trade` | 거래 내역 조회 | — | — | — |
 | `treasury` | 자금 현황 조회 | — | 예산 설정/자금 투입 | — |
-| `member` | 멤버 목록/상세 조회 | — | 멤버 등록/정지/폐기/토큰 관리 | — |
+| `member` | 멤버 목록/상세 조회 | — | 멤버 등록/정지/폐기/토큰 관리 (reserved — 1.0 미사용) | — |
 | `system` | 시스템 상태 조회 | — | 시스템 상태 변경 | — |
 | `rule` | 룰 조회 | — | 룰 활성화/비활성화 | — |
 | `broker` | 브로커 상태/잔고/대사 조회 | — | — | — |
@@ -202,6 +202,24 @@ master(human)는 scope 제한 없이 모든 작업을 수행할 수 있다. scop
 검증되며, 등록되지 않은 scope 문자열은 입력 시점에 거부된다. spec doc
 매트릭스와 `SCOPE_VOCABULARY` 의 drift 는 `tests/unit/test_member_scope_drift.py`
 가 정적으로 검증한다.
+
+**`member:admin` scope의 reserved 정책 (1.0)**: `member:admin` scope는
+vocabulary에 정의되어 있으나 1.0 계약에서는 **reserved (현재 미사용)**다.
+agent에게 위임하지 않으며, 향후 agent 위임 정책(target 제한, self-escalation
+금지, token rotation 제한, master/human 보호 규칙)을 별도 이슈에서 설계한 뒤
+활성화한다. vocabulary 자체는 후속 활성화 시 호환을 위해 유지한다.
+
+**Member admin mutation 권한 모델 (1.0 — master-only)**: member admin
+mutation(`register`, `suspend`, `reactivate`, `revoke`, `rotate-token`,
+`update_scopes`, `password`)은 1.0 계약에서 **master-only**다. 모든 호출
+경로(Web API, CLI, IPC)에서 service layer `MemberService._assert_master`가
+master 외 호출자를 `PermissionError`로 거부하며, 표면 계약(Web API endpoint,
+CLI command, route-scope table)도 이 invariant에 정합한다. `member:admin`
+agent token으로의 접근은 1.0에서 허용되지 않는다.
+
+> 후속 implementation 정렬: #1543 (Web API/CLI 표면 가드 master-only로 일치),
+> #1544 (oracle host probe scope 기대값 정렬). 본 결정 SSOT는 #1542이며,
+> 부모 #1511(oracle host probe scope drift)에서 시작된 정합 작업이다.
 
 ### Member command runtime boundary
 

--- a/docs/specs/member/05-member-service.md
+++ b/docs/specs/member/05-member-service.md
@@ -20,20 +20,20 @@ MemberService는 내부적으로 책임을 분리하여 `AuthService`(인증), `
 |--------|----------|--------|------|
 | `initialize` | — | None | 스키마 생성 |
 | `bootstrap_master` | member_id, password, name, emoji | tuple[Member, str, str] | master 생성 + (token, recovery_key) 반환. 최초 1회만. 이미 존재 시 에러. CLI에서는 `ante init`이 내부 호출 |
-| `register` | member_id, type, role, org, name, scopes, registered_by, emoji | tuple[Member, str] | 멤버 등록 + 토큰 반환. master만 호출 가능 |
+| `register` | member_id, type, role, org, name, scopes, registered_by, emoji | tuple[Member, str] | 멤버 등록 + 토큰 반환. **권한: master-only** (`_assert_master` 강제) |
 | `authenticate` | token | Member | 토큰으로 멤버 식별. 타입 접두어 검증 포함 |
 | `authenticate_password` | member_id, password | Member | 패스워드 인증 (human 대시보드 로그인) |
 | `get` | member_id | Member ∣ None | 단건 조회 |
 | `list` | type, org, status, limit, offset | list[Member] | 필터 조회 |
-| `suspend` | member_id, suspended_by | Member | 일시 정지. master는 정지 불가 |
-| `reactivate` | member_id, reactivated_by | Member | 재활성화 |
-| `revoke` | member_id, revoked_by | Member | 영구 폐기. 토큰 해시 삭제. master는 폐기 불가 |
-| `rotate_token` | member_id, rotated_by | tuple[Member, str] | 토큰 재발급 (기존 토큰 즉시 무효화) |
-| `change_password` | member_id, old_password, new_password | None | 패스워드 변경 (human만) |
-| `reset_password` | member_id, recovery_key, new_password | None | recovery key로 패스워드 리셋 (human만) |
-| `regenerate_recovery_key` | member_id, password | str | 복구 키 재발급. 현재 패스워드 확인 필수 |
+| `suspend` | member_id, suspended_by | Member | 일시 정지. master는 정지 불가. **권한: master-only** (`_assert_master` 강제) |
+| `reactivate` | member_id, reactivated_by | Member | 재활성화. **권한: master-only** (`_assert_master` 강제) |
+| `revoke` | member_id, revoked_by | Member | 영구 폐기. 토큰 해시 삭제. master는 폐기 불가. **권한: master-only** (`_assert_master` 강제) |
+| `rotate_token` | member_id, rotated_by | tuple[Member, str] | 토큰 재발급 (기존 토큰 즉시 무효화). **권한: master-only** (`_assert_master` 강제) |
+| `change_password` | member_id, old_password, new_password | None | 패스워드 변경 (human만). **권한: master-only** (`_assert_master` 강제) |
+| `reset_password` | member_id, recovery_key, new_password | None | recovery key로 패스워드 리셋 (human만). 인증 수단이 recovery key 자체이므로 `_assert_master`를 우회한다(공개 명령 allowlist) |
+| `regenerate_recovery_key` | member_id, password | str | 복구 키 재발급. 현재 패스워드 확인 필수. 인증 수단이 현재 패스워드 자체이므로 `_assert_master`를 우회한다(공개 명령 allowlist) |
 | `update_emoji` | member_id, emoji, updated_by | Member | 멤버 이모지 변경. 단일 이모지 검증 + 중복 체크 |
-| `update_scopes` | member_id, scopes, updated_by | Member | 권한 범위 변경. master만 호출 가능 |
+| `update_scopes` | member_id, scopes, updated_by | Member | 권한 범위 변경. **권한: master-only** (`_assert_master` 강제) |
 | `update_last_active` | member_id | None | 마지막 활동 시각 갱신 |
 
 ### 런타임 경계
@@ -70,3 +70,23 @@ def _assert_invariants(self, member: Member, action: str) -> None:
     if member.type == "agent" and member.role in ("master", "admin"):
         raise PermissionError("agent 타입은 master 또는 admin 역할을 가질 수 없습니다")
 ```
+
+### Member admin mutation 권한 모델 (1.0 — master-only)
+
+권한 모델 SSOT는 [02-design-decisions.md — Member admin mutation 권한 모델](02-design-decisions.md#권한-범위-scope)이며, MemberService는 다음을 일관 보장한다.
+
+- `register`, `suspend`, `reactivate`, `revoke`, `rotate_token`, `update_scopes`,
+  `change_password` 등 member admin mutation은 **master-only**다. service layer
+  진입 시점에 `_assert_master(actor)`가 호출자 principal을 검사하고, master가 아니면
+  `PermissionError`를 발생시킨다. 매핑 책임은 표면(Web API/CLI/IPC)이 진다.
+- `member:admin` scope는 vocabulary에 정의되어 있으나 1.0 계약에서는 **reserved
+  (현재 미사용)**다. agent token에 `member:admin`이 부여되어 있어도 mutation은
+  `_assert_master`에서 거부된다. agent 위임 정책이 마련되기 전까지 본 invariant는
+  변경되지 않는다.
+- `reset_password`와 `regenerate_recovery_key`는 인증 수단이 recovery key/현재
+  패스워드 자체이므로 master 토큰을 요구하지 않는 공개 명령 allowlist 경로다
+  ([cli/03-commands.md — 공개 명령 allowlist](../cli/03-commands.md#공개-명령-allowlist--인증-면제) 참조).
+
+> 후속 implementation 정렬: #1543 (Web API/CLI 표면 가드 master-only로 일치),
+> #1544 (oracle host probe scope 기대값 정렬). 본 결정 SSOT는 #1542이며,
+> 부모 #1511(oracle host probe scope drift)에서 시작된 정합 작업이다.

--- a/docs/specs/member/06-cli.md
+++ b/docs/specs/member/06-cli.md
@@ -21,6 +21,30 @@ CLI가 MemberService를 직접 생성하는 maintenance fallback을 허용한다
 account cold-path처럼 서버 topology를 바꾸지는 않지만 인증 상태를 바꾸므로, 서버
 실행 중 직접 DB 수정은 금지한다.
 
+## 권한 모델 (1.0 — master-only)
+
+`member register`, `member suspend`, `member reactivate`, `member revoke`,
+`member rotate-token`, `member update-scopes`(향후), `member set-password` 같은
+member admin mutation CLI 명령은 **master-only**다. 권한 모델 SSOT는
+[02-design-decisions.md — Member admin mutation 권한 모델](02-design-decisions.md#권한-범위-scope)이며,
+서비스 진입 시점에 `MemberService._assert_master`가 호출자 principal을 검사하고
+master가 아니면 `PermissionError`를 발생시킨다.
+
+`ANTE_MEMBER_TOKEN`이 agent token(`ante_ak_*`)이거나 master 외 human 토큰이면
+명령은 service layer에서 거부되어 exit 1로 종료한다. CLI 표면 가드가 사전에 거부할 수도
+있으나, service layer 거부는 1.0 계약의 invariant다. agent 위임이 필요해지면
+별도 정책 이슈에서 reserved scope `member:admin`을 활성화한 뒤 표면을 정렬한다.
+
+`member list`, `member info`, `member list-invalid-roles`는 조회 명령이므로 본
+master-only 정책의 적용 대상이 아니다. `member reset-password`와
+`member regenerate-recovery-key`는 인증 수단이 recovery key 또는 현재 패스워드
+자체이므로 별도 공개 명령 allowlist 경로를 따른다
+([cli/03-commands.md — 공개 명령 allowlist](../cli/03-commands.md#공개-명령-allowlist--인증-면제) 참조).
+
+> 후속 implementation 정렬: #1543 (Web API/CLI 표면 가드 master-only로 일치),
+> #1544 (oracle host probe scope 기대값 정렬). 본 결정 SSOT는 #1542이며,
+> 부모 #1511(oracle host probe scope drift)에서 시작된 정합 작업이다.
+
 ### `ante member list`
 
 ```
@@ -39,7 +63,8 @@ ante member info strategy-dev-01 [--format json]
 
 ### `ante member register`
 
-master만 실행 가능.
+**권한: master-only**. agent token 또는 master 외 human 토큰이면 service layer
+`_assert_master`에서 거부되어 exit 1로 종료한다.
 
 ```
 ante member register \
@@ -65,11 +90,15 @@ ante member set-emoji strategy-dev-01 🦊 [--format json]
 
 ### `ante member suspend <member_id>`
 
+**권한: master-only**. agent token이면 service layer `_assert_master`에서 거부된다.
+
 ```
 ante member suspend strategy-dev-01 [--format json]
 ```
 
 ### `ante member reactivate <member_id>`
+
+**권한: master-only**. agent token이면 service layer `_assert_master`에서 거부된다.
 
 ```
 ante member reactivate strategy-dev-01 [--format json]
@@ -77,12 +106,16 @@ ante member reactivate strategy-dev-01 [--format json]
 
 ### `ante member revoke <member_id> --yes`
 
+**권한: master-only**. agent token이면 service layer `_assert_master`에서 거부된다.
+
 ```
 ante member revoke strategy-dev-01 --yes [--format json]
 # ⚠️ 이 작업은 되돌릴 수 없습니다. --yes 누락 시 CLI_CONFIRMATION_REQUIRED로 실패합니다.
 ```
 
 ### `ante member rotate-token <member_id>`
+
+**권한: master-only**. agent token이면 service layer `_assert_master`에서 거부된다.
 
 ```
 ante member rotate-token strategy-dev-01 [--format json]

--- a/docs/specs/web-api/05-resource-endpoints.md
+++ b/docs/specs/web-api/05-resource-endpoints.md
@@ -123,19 +123,35 @@ Web API는 서버 프로세스 내부에서 실행되므로 member 변경은 항
 상태·토큰·패스워드·복구키 변경은 MemberService 호출 후 세션 무효화, 감사 로그,
 member/security 알림을 같은 프로세스에서 처리한다.
 
-| Method | Path | 설명 |
-|--------|------|------|
-| GET | `/api/members` | 멤버 목록 (필터: type, org, status, limit, offset) |
-| POST | `/api/members` | 멤버 등록 (토큰 1회 반환) |
-| GET | `/api/members/{member_id}` | 멤버 상세 조회 |
-| POST | `/api/members/{member_id}/suspend` | 멤버 일시 정지 |
-| POST | `/api/members/{member_id}/reactivate` | 멤버 재활성화 |
-| POST | `/api/members/{member_id}/revoke` | 멤버 영구 폐기 |
-| POST | `/api/members/{member_id}/rotate-token` | 토큰 재발급 |
-| PATCH | `/api/members/{member_id}/password` | 비밀번호 변경 (human 멤버 전용) |
-| PUT | `/api/members/{member_id}/scopes` | 권한 범위 변경 |
+| Method | Path | 설명 | 권한 (1.0) |
+|--------|------|------|-----------|
+| GET | `/api/members` | 멤버 목록 (필터: type, org, status, limit, offset) | `member:read` |
+| POST | `/api/members` | 멤버 등록 (토큰 1회 반환) | **master-only** |
+| GET | `/api/members/{member_id}` | 멤버 상세 조회 | `member:read` |
+| POST | `/api/members/{member_id}/suspend` | 멤버 일시 정지 | **master-only** |
+| POST | `/api/members/{member_id}/reactivate` | 멤버 재활성화 | **master-only** |
+| POST | `/api/members/{member_id}/revoke` | 멤버 영구 폐기 | **master-only** |
+| POST | `/api/members/{member_id}/rotate-token` | 토큰 재발급 | **master-only** |
+| PATCH | `/api/members/{member_id}/password` | 비밀번호 변경 (human 멤버 전용) | **master-only** |
+| PUT | `/api/members/{member_id}/scopes` | 권한 범위 변경 | **master-only** |
 
-`POST /api/members`는 master 권한 인증된 호출자만 사용할 수 있다. `Authorization: Bearer <token>` 헤더가 없거나 invalid token이면 `401 Unauthorized`로 거부되며 새 멤버나 토큰이 생성되지 않는다. 인증된 non-master 호출자는 `MemberService.register`의 `_assert_master`에서 발생한 `PermissionError` 매핑으로 `403 Forbidden`을 반환한다. 다른 멤버 mutation API(`suspend`, `reactivate`, `revoke`, `rotate-token`, `password`, `scopes`)의 인증 강제는 별도 후속 이슈에서 일괄 정리한다.
+Member admin mutation(`POST /api/members`, `POST /api/members/{id}/suspend`,
+`/reactivate`, `/revoke`, `/rotate-token`, `PATCH /api/members/{id}/password`,
+`PUT /api/members/{id}/scopes`)은 1.0 계약에서 **master-only**다. 권한 모델
+SSOT는 [../member/02-design-decisions.md — Member admin mutation 권한 모델](../member/02-design-decisions.md#권한-범위-scope)이며,
+service layer 진입 시점에 `MemberService._assert_master`가 master 외 호출자를
+`PermissionError`로 거부하고 표면(Web API)이 `403 Forbidden`으로 매핑한다.
+
+`Authorization: Bearer <token>` 헤더가 없거나 invalid token이면 `401 Unauthorized`로
+거부되며 mutation 자체가 일어나지 않는다. agent token(`ante_ak_*`)으로 인증된
+non-master 호출자는 service layer `_assert_master`에서 거부되어 `403 Forbidden`이
+반환된다. `member:admin` scope는 vocabulary에 정의되어 있으나 1.0에서는
+**reserved (현재 미사용)**이며, agent에게 위임하지 않는다.
+
+> 후속 implementation 정렬: #1543 (Web API 표면 가드 master-only로 일치 — 현재
+> `require_scope("member:admin")` 대신 master-only dependency 적용),
+> #1544 (oracle host probe scope 기대값 정렬). 본 결정 SSOT는 #1542이며,
+> 부모 #1511(oracle host probe scope drift)에서 시작된 정합 작업이다.
 
 ## 설정 관리 (`/api/config`)
 

--- a/docs/specs/web-api/11-route-scope-table.md
+++ b/docs/specs/web-api/11-route-scope-table.md
@@ -20,9 +20,10 @@
 | `public` | [09-public-paths.md](09-public-paths.md) PUBLIC_PATHS allowlist. 인증 게이트 면제. 라우트도 caller-agnostic. |
 | `gate-exempt-self-auth` | 미들웨어 게이트만 면제. 라우트가 자체적으로 세션/토큰을 검증하고 본인 정보만 응답. |
 | `<domain>:<action>` | `require_scope("<domain>:<action>")` dependency 부착. spec scope vocabulary 정합. |
+| `master-only` | master 호출자만 허용. service layer `MemberService._assert_master`가 1.0 계약 invariant. agent token / non-master human token이면 `403 Forbidden`. 표면 dependency 정렬은 #1543. (#1511 oracle drift, #1542 결정 방향 B) |
 
 `authenticated-only` 카테고리는 본 표에서 사용하지 않는다. 모든 라우트에 대해
-명시적 `public` / `gate-exempt-self-auth` / `<scope>` 결정을 둔다.
+명시적 `public` / `gate-exempt-self-auth` / `<scope>` / `master-only` 결정을 둔다.
 
 ## 표의 컬럼
 
@@ -54,9 +55,12 @@ accounts(9) + approvals(3) + audit(1) + auth(3) + bots(8) + config(2) + data(6)
 **70 라우트 분해**:
 - **17개**: 이미 dependency 부착 완료 (현재 head 기준 코드 부착됨).
 - **48개**: scope 미부착 — 후속 #1407에서 `require_scope("<scope>")` 부착 대상.
+  단, member admin mutation 7종(아래)은 #1542 결정으로 #1407 대상에서 분리되어
+  `master-only` 카테고리로 이동했고, 표면 가드 정렬은 #1543이 담당한다.
 - **5개**: 면제 라우트 — `public` 4개(`/api/system/health`, `/api/auth/login`, `/api/auth/logout`, `/api/reports/schema`) + `gate-exempt-self-auth` 1개(`/api/auth/me`). 본 표에서 결정 + [09-public-paths.md](09-public-paths.md) PUBLIC_PATHS allowlist로 처리 (`/api/reports/schema`는 본 이슈에서 09에 추가됨; 나머지 4개는 #1403 머지로 이미 처리됨).
 
-후속 #1407 작업 대상은 **미부착 48개 scope 라우트만**이며, 5개 면제 라우트는 #1407 변환 대상이 아니다.
+후속 #1407 작업 대상은 **미부착 scope 라우트만**이며, 5개 면제 라우트와 7개
+master-only 라우트(#1543 정렬 대상)는 #1407 변환 대상이 아니다.
 
 ## accounts (`/api/accounts`, 9 라우트)
 
@@ -130,14 +134,14 @@ accounts(9) + approvals(3) + audit(1) + auth(3) + bots(8) + config(2) + data(6)
 | Module | Method | Path | 현재 부착 dependency | 결정 카테고리 | Scope | 근거 | 후속 이슈 |
 |--------|--------|------|---------------------|--------------|-------|------|----------|
 | members | GET | `/api/members` | (none) | `<scope>` | `member:read` | spec `member:read` 정합 (멤버 목록). | #1407 |
-| members | POST | `/api/members` | (none) | `<scope>` | `member:admin` | spec `member:admin` 정합 (멤버 등록). MemberService 내부 `_assert_master`로 현재 master만 허용 — #1407에서 `require_scope("member:admin")`로 표면 정합. | #1407 |
+| members | POST | `/api/members` | (none) | `master-only` | — | **master-only** (멤버 등록). MemberService `_assert_master`가 1.0 계약 invariant. `member:admin` scope는 reserved (1.0 미사용). 표면 가드 정렬은 #1543. (#1511 oracle drift, #1542 결정 방향 B) | #1543 |
 | members | GET | `/api/members/{member_id}` | (none) | `<scope>` | `member:read` | spec `member:read` 정합. | #1407 |
-| members | POST | `/api/members/{member_id}/suspend` | (none) | `<scope>` | `member:admin` | spec `member:admin` 정합 (멤버 정지). | #1407 |
-| members | POST | `/api/members/{member_id}/reactivate` | (none) | `<scope>` | `member:admin` | spec `member:admin` 정합 (멤버 재활성화). | #1407 |
-| members | POST | `/api/members/{member_id}/revoke` | (none) | `<scope>` | `member:admin` | spec `member:admin` 정합 (멤버 영구 폐기). | #1407 |
-| members | POST | `/api/members/{member_id}/rotate-token` | (none) | `<scope>` | `member:admin` | spec `member:admin` 정합 (토큰 재발급). | #1407 |
-| members | PATCH | `/api/members/{member_id}/password` | `require_master_caller` | `<scope>` | `member:admin` | spec `member:admin` 정합 (패스워드 변경). 현재 master_caller → #1407 마이그레이션. | #1407 |
-| members | PUT | `/api/members/{member_id}/scopes` | (none) | `<scope>` | `member:admin` | spec `member:admin` 정합 (권한 범위 변경). | #1407 |
+| members | POST | `/api/members/{member_id}/suspend` | (none) | `master-only` | — | **master-only** (멤버 정지). `_assert_master` 강제. (#1511 oracle drift, #1542 결정 방향 B) | #1543 |
+| members | POST | `/api/members/{member_id}/reactivate` | (none) | `master-only` | — | **master-only** (멤버 재활성화). `_assert_master` 강제. (#1511 oracle drift, #1542 결정 방향 B) | #1543 |
+| members | POST | `/api/members/{member_id}/revoke` | (none) | `master-only` | — | **master-only** (멤버 영구 폐기). `_assert_master` 강제. (#1511 oracle drift, #1542 결정 방향 B) | #1543 |
+| members | POST | `/api/members/{member_id}/rotate-token` | (none) | `master-only` | — | **master-only** (토큰 재발급). `_assert_master` 강제. (#1511 oracle drift, #1542 결정 방향 B) | #1543 |
+| members | PATCH | `/api/members/{member_id}/password` | `require_master_caller` | `master-only` | — | **master-only** (패스워드 변경). 현재 `require_master_caller` 부착됨 → #1543에서 master-only dependency 정합. (#1511 oracle drift, #1542 결정 방향 B) | #1543 |
+| members | PUT | `/api/members/{member_id}/scopes` | (none) | `master-only` | — | **master-only** (권한 범위 변경). `_assert_master` 강제. (#1511 oracle drift, #1542 결정 방향 B) | #1543 |
 
 ## portfolio (`/api/portfolio`, 2 라우트)
 
@@ -204,14 +208,14 @@ accounts(9) + approvals(3) + audit(1) + auth(3) + bots(8) + config(2) + data(6)
 도메인별 read/write/admin/run 표에 이미 정의되어 있다.
 **신규 scope vocabulary 도입은 없다.**
 
-사용 scope 목록 (15종):
+사용 scope 목록 (1.0 기준):
 - `account:read`, `account:write`
 - `approval:read`, `approval:admin`
 - `audit:read`
 - `bot:read`, `bot:admin`
 - `config:read`, `config:write`
 - `data:read`, `data:write`
-- `member:read`, `member:admin`
+- `member:read` (mutation은 `master-only` 카테고리 사용 — 아래 메모 참조)
 - `report:read`, `report:write`
 - `rule:read`, `rule:admin`
 - `strategy:read`, `strategy:write`
@@ -220,6 +224,13 @@ accounts(9) + approvals(3) + audit(1) + auth(3) + bots(8) + config(2) + data(6)
 - `treasury:read`, `treasury:admin`
 
 (`portfolio` 도메인은 신설하지 않고 `treasury:read`에 묶었다. portfolio 라우트가 `treasury_daily_snapshots` 데이터를 직접 읽는 view 성격이기 때문이다.)
+
+> `member:admin` scope는 vocabulary([../member/02-design-decisions.md](../member/02-design-decisions.md))에
+> 정의되어 있으나 1.0 계약에서는 **reserved (현재 미사용)**다. member admin
+> mutation 7종(`POST /api/members`, `/suspend`, `/reactivate`, `/revoke`,
+> `/rotate-token`, `PATCH .../password`, `PUT .../scopes`)은 본 표에서
+> `master-only` 카테고리로 결정되며, agent에게 위임하지 않는다.
+> (#1511 oracle drift, #1542 결정 방향 B)
 
 ## 경계 케이스 결정
 
@@ -231,12 +242,19 @@ accounts(9) + approvals(3) + audit(1) + auth(3) + bots(8) + config(2) + data(6)
 | `GET /api/reports/schema` | `public` | 리포트 제출 폼 스키마. 비밀값 없음. 클라이언트가 폼 렌더링용으로 사용. `/api/data/schema`(data:read)와 다른 정책 — data 도메인은 trading-sensitive. |
 | `GET /api/auth/me` | `gate-exempt-self-auth` | 미들웨어 게이트는 면제하되 라우트가 자체 세션/토큰 검증해 본인 정보만 응답. dashboard 초기 로딩 호환. |
 
-## 후속 작업 (#1407)
+## 후속 작업 (#1407 / #1543)
 
-#1407 코드 마이그레이션 대상은 **scope 라우트 48개 + master_caller 마이그레이션 13개**다. 면제 라우트 5개(public 4 + gate-exempt-self-auth 1)는 #1407 대상이 **아니며**, [09-public-paths.md](09-public-paths.md) PUBLIC_PATHS allowlist로 처리한다 (4개는 #1403 머지로 이미 처리, `/api/reports/schema`는 본 이슈에서 09에 추가됨).
+#1407 코드 마이그레이션 대상은 **scope 라우트 48개 + master_caller 마이그레이션
+13개**였다. 면제 라우트 5개(public 4 + gate-exempt-self-auth 1)는 #1407 대상이
+**아니며**, [09-public-paths.md](09-public-paths.md) PUBLIC_PATHS allowlist로 처리한다
+(4개는 #1403 머지로 이미 처리, `/api/reports/schema`는 본 이슈에서 09에 추가됨).
 
-- 미부착 **48개 scope 라우트**에 `require_scope("<scope>")` 부착.
-- 이미 부착된 13개 `require_master_caller` 라우트를 `require_scope("<scope>")`로 마이그레이션:
+#1542 결정 방향 B에 따라 member admin mutation 7종은 본 표에서 `master-only`
+카테고리로 분리되었으며, 표면 가드 정렬은 #1543이 담당한다 (#1407 scope dependency
+대상에서 제외).
+
+- 미부착 **scope 라우트**에 `require_scope("<scope>")` 부착.
+- 이미 부착된 `require_master_caller` 라우트를 `require_scope("<scope>")`로 마이그레이션:
   - `PUT /api/accounts/{id}` → `account:write`
   - `POST /api/accounts/{id}/suspend` → `account:write`
   - `POST /api/accounts/{id}/activate` → `account:write`
@@ -244,14 +262,34 @@ accounts(9) + approvals(3) + audit(1) + auth(3) + bots(8) + config(2) + data(6)
   - `POST /api/bots` → `bot:admin`
   - `DELETE /api/bots/{id}` → `bot:admin`
   - `PUT /api/bots/{id}` → `bot:admin`
-  - `PATCH /api/members/{id}/password` → `member:admin`
   - `POST /api/system/halt` → `system:admin`
   - `POST /api/system/clear-halt` → `system:admin`
   - `POST /api/treasury/bots/{id}/allocate` → `treasury:admin`
   - `POST /api/treasury/bots/{id}/deallocate` → `treasury:admin`
   - `POST /api/treasury/balance` → `treasury:admin`
+- `PATCH /api/members/{id}/password`는 현재 `require_master_caller`로 부착되어
+  있으며, #1543에서 master-only dependency로 정합한다(scope vocabulary 매핑이
+  아닌 master-only 정렬). #1542 결정 방향 B로 본 라우트는 `member:admin` scope
+  대상에서 제외됨.
 - `GET /api/reports/schema`를 [09-public-paths.md](09-public-paths.md) PUBLIC_PATHS allowlist에 추가.
 - 이미 부착된 4개 (`audit:read`, `config:write`, `report:write`, `strategy:write`)는 표 결정과 일치 — 변경 없음.
+
+### #1543 master-only 정렬 대상 (member admin mutation 7종)
+
+#1542 결정에 따라 다음 라우트는 표면 dependency를 master-only로 정렬한다.
+
+- `POST /api/members`
+- `POST /api/members/{id}/suspend`
+- `POST /api/members/{id}/reactivate`
+- `POST /api/members/{id}/revoke`
+- `POST /api/members/{id}/rotate-token`
+- `PATCH /api/members/{id}/password`
+- `PUT /api/members/{id}/scopes`
+
+`member:admin` scope는 reserved (1.0 미사용)로 vocabulary에서 유지하되, agent
+token에 부여되어도 service layer `_assert_master`에서 거부된다. 정렬 코드 변경,
+`frontend/openapi.json` / `frontend/src/types/api.generated.ts` 재생성, oracle host
+probe 기대값 정렬은 #1543 / #1544 후속 이슈에서 처리한다.
 
 ## Spec-Code Drift 처리
 


### PR DESCRIPTION
Closes #1542

## Summary

부모 #1511 oracle host probe가 `member:admin` agent token으로 mutation API 호출 시 route scope check는 통과하지만 MemberService `_assert_master`에서 403 reject되는 계약 충돌이 확인됐다. 결정 방향 B(YAGNI — agent에게 인사 운영 위임 미준비)에 따라 7 spec 파일에서 member admin mutation의 공개 계약을 master-only로 정리한다.

핵심 변경 (docs-only, +209/-50):

- `docs/specs/member/02-design-decisions.md`: `member:admin` scope를 reserved (1.0 미사용)으로 라벨링.
- `docs/specs/member/05-member-service.md`: 7개 mutation 메서드 (register/suspend/reactivate/revoke/rotate-token/update_scopes/password)에 master-only (`_assert_master` 강제) 명시.
- `docs/specs/member/06-cli.md`: 5개 mutation CLI 명령 master-only 명시 + agent token 거부.
- `docs/specs/web-api/05-resource-endpoints.md`: `/api/members/*` mutation endpoint 권한 master-only.
- `docs/specs/web-api/11-route-scope-table.md`: 9개 row 갱신, `master-only` 결정 카테고리 도입, #1543/#1544 cite.
- `docs/specs/cli/02-design-decisions.md`: 인증 미들웨어 일반 원칙에 master-only 추가.
- `docs/specs/cli/03-commands.md`: `ante member` 명령별 권한 표기 갱신.

`member:admin` scope vocabulary는 유지(reserved). 코드 변경 없음. `frontend/openapi.json`/`api.generated.ts` downstream stale은 의도적이며 #1543 (Web API/CLI 표면 가드)에서 정렬.

후속:
- #1543 — Web API/CLI 표면 가드 코드 정렬 + frontend artifact 재생성.
- #1544 — Oracle probe 기대값 정렬.

## Test Plan

- [x] `pytest tests/unit -k "scope or member or route_auth_coverage" -q` (497 passed, 단정 변경 0)
- [x] `pytest tests/unit -q` 전체 회귀 (5629 passed / 4 skipped)
- [x] `ruff check src tests` / `ruff format --check src tests`
- [x] `mypy src` (239 files, no issues)
- [x] `python scripts/generate_project_structure.py --check`
- [x] 수동 일관성 점검: 7 파일 grep 결과 모두 master-only + reserved 라벨로 일관 표기
- [x] Codex `/codex:review --base main` PASS (6 substantive checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)