### PR TITLE
fix(member): align Web API + CLI surface guards to master-only contract

### DIFF
--- a/docs/architecture/generated/project-structure.md
+++ b/docs/architecture/generated/project-structure.md
@@ -608,7 +608,9 @@ tests/
 │   ├── test_cli_instrument_import_exit.py
 │   ├── test_cli_missing_resource_exit.py
 │   ├── test_cli_pagination_validation.py
-│   └── test_cli_treasury_amount_validation.py
+│   ├── test_cli_treasury_amount_validation.py
+│   ├── test_cli_member_master_only.py
+│   └── test_member_admin_master_only.py
 └── __init__.py
 ```
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -513,7 +513,7 @@
           "accounts"
         ],
         "summary": "Activate Account",
-        "description": "계좌 재활성화. 인증된 master/human 또는 ``account:write`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``account:write`` 정합, #1352\nmaster_caller 에서 마이그레이션).",
+        "description": "계좌 재활성화. 인증된 master/human 또는 ``account:write`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``account:write`` 정합, #1352\nmaster_caller 에서 마이그레이션).\n\n``suspend_account``와 동일한 raw body 파싱 패턴(빈 body / null / ``{}``는\n통과, 비-object / malformed JSON / extra key dict는 422)을 적용한다\n(#1510). 인증 가드는 dependency level이므로 body validation보다 먼저\n실행되며, invalid body 시에는 service / audit 호출이 발생하지 않는다.",
         "operationId": "activate_account_api_accounts__account_id__activate_post",
         "parameters": [
           {
@@ -1604,7 +1604,7 @@
           "members"
         ],
         "summary": "Create Member",
-        "description": "멤버 등록. 토큰 1회 반환. 인증된 master/human 또는 ``member:admin`` scope\n를 보유한 agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).\n\n인증 가드는 body validation보다 **반드시 먼저** 실행된다(#1339 P2). FastAPI\n가 ``body: MemberCreateRequest`` 파라미터를 먼저 파싱하면 Authorization\n헤더 미존재 + 필수 필드 누락 케이스에서 401 이 아니라 422 가 먼저 응답되어\n\"missing or invalid Authorization header는 401\" 계약이 깨진다. 이 이유로\n본 라우트는 ``request: Request`` 와 ``require_member_admin`` 만 받고 raw\nbody 를 직접 파싱한다 (``update_account`` SSOT 패턴 일치).\n\n핸들러 단계 순서:\n1. **인증 가드 (최우선, ``Depends(require_member_admin)``)** — caller 빈\n   → 401, 권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽고 JSON 파싱 — 실패 시 422.\n3. ``MemberCreateRequest.model_validate`` — ValidationError → 422.\n4. ``svc.register`` 호출. ``PermissionError`` → 403, ``ValueError`` → 400.",
+        "description": "멤버 등록. 토큰 1회 반환. 인증된 master 만 호출 가능\n(#1543 — spec ``master-only`` 정합, #1542 SSOT\n``docs/specs/web-api/11-route-scope-table.md``). ``member:admin`` scope 를\n보유한 agent 도 표면 가드에서 거부된다 (#1511 oracle drift 수렴).\n\n인증 가드는 body validation보다 **반드시 먼저** 실행된다(#1339 P2). FastAPI\n가 ``body: MemberCreateRequest`` 파라미터를 먼저 파싱하면 Authorization\n헤더 미존재 + 필수 필드 누락 케이스에서 401 이 아니라 422 가 먼저 응답되어\n\"missing or invalid Authorization header는 401\" 계약이 깨진다. 이 이유로\n본 라우트는 ``request: Request`` 와 ``require_master_caller`` 만 받고 raw\nbody 를 직접 파싱한다 (``update_account`` SSOT 패턴 일치).\n\n핸들러 단계 순서:\n1. **인증 가드 (최우선, ``Depends(require_master_caller)``)** — caller 빈\n   → 401, master 아님 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽고 JSON 파싱 — 실패 시 422.\n3. ``MemberCreateRequest.model_validate`` — ValidationError → 422.\n4. ``svc.register`` 호출. ``PermissionError`` → 403, ``ValueError`` → 400.",
         "operationId": "create_member_api_members_post",
         "responses": {
           "201": {
@@ -1749,7 +1749,7 @@
           "members"
         ],
         "summary": "Suspend Member",
-        "description": "멤버 일시 정지. 인증된 master/human 또는 ``member:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).",
+        "description": "멤버 일시 정지. 인증된 master 만 호출 가능\n(#1543 — spec ``master-only`` 정합, #1542 SSOT).",
         "operationId": "suspend_member_api_members__member_id__suspend_post",
         "parameters": [
           {
@@ -1832,7 +1832,7 @@
           "members"
         ],
         "summary": "Reactivate Member",
-        "description": "멤버 재활성화. 인증된 master/human 또는 ``member:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).",
+        "description": "멤버 재활성화. 인증된 master 만 호출 가능\n(#1543 — spec ``master-only`` 정합, #1542 SSOT).",
         "operationId": "reactivate_member_api_members__member_id__reactivate_post",
         "parameters": [
           {
@@ -1915,7 +1915,7 @@
           "members"
         ],
         "summary": "Revoke Member",
-        "description": "멤버 영구 폐기. 인증된 master/human 또는 ``member:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).",
+        "description": "멤버 영구 폐기. 인증된 master 만 호출 가능\n(#1543 — spec ``master-only`` 정합, #1542 SSOT).",
         "operationId": "revoke_member_api_members__member_id__revoke_post",
         "parameters": [
           {
@@ -1998,7 +1998,7 @@
           "members"
         ],
         "summary": "Rotate Token",
-        "description": "토큰 재발급. 인증된 master/human 또는 ``member:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).\n\n인증 없이 token rotation 응답에 접근하면 token 값 자체가 노출되므로,\n가장 먼저 차단해야 한다.",
+        "description": "토큰 재발급. 인증된 master 만 호출 가능\n(#1543 — spec ``master-only`` 정합, #1542 SSOT).\n\n인증 없이 token rotation 응답에 접근하면 token 값 자체가 노출되므로,\n가장 먼저 차단해야 한다.",
         "operationId": "rotate_token_api_members__member_id__rotate_token_post",
         "parameters": [
           {
@@ -2081,7 +2081,7 @@
           "members"
         ],
         "summary": "Change Password",
-        "description": "비밀번호 변경 (human 멤버 전용). 인증된 master/human 또는\n``member:admin`` scope 를 보유한 agent 만 호출 가능 (#1407 — spec\n``member:admin`` 정합, #1377 master_caller 에서 마이그레이션).\n\n배경: oracle A7 finding (#1377) — 본 라우트는 인증 없이 credential check\n(``svc.change_password``의 old-password 비교) 까지 도달했다. ``_caller_id``\n만으로 audit 주체만 기록하고 인증 가드는 적용하지 않았기 때문이다. 본\n패치는 ``require_master_caller`` 의존성을 적용하고 ``update_scopes``와\n동일한 raw body 파싱 + auth-first 패턴을 따른다 (#1351 / #1352 SSOT).\n\n범위 결정:\n- master-only (보수). self-change use case (caller_id == member_id 허용)는\n  follow-up 이슈에서 별도 다룬다 (Issue #1377 Non-Goals).\n\n인증 → raw-body → credential check 순서를 보장한다. FastAPI가\n``body: PasswordChangeRequest``를 먼저 검증하면 unauth + bad-body 시 401이\n아닌 422가 먼저 반환되어 contract가 깨진다 — 본 라우트는 oracle A7\nfinding의 핵심 시그니처이므로 인증 가드 우선이 가장 중요하다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_member_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403. credential check 도달 전에 모두\n   차단된다.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``PasswordChangeRequest.model_validate`` — ValidationError → 422.\n4. ``svc.change_password`` 호출. ``ValueError`` → 404,\n   ``PermissionError``/``PermissionDeniedError`` → 403.\n\nAudit 로그의 ``member_id``는 ``caller_id``로 기록한다(SSOT). 대상 멤버는\n``resource=member:{member_id}``로 분리해 추적한다.",
+        "description": "비밀번호 변경 (human 멤버 전용). 인증된 master 만 호출 가능\n(#1543 — spec ``master-only`` 정합, #1542 SSOT, #1377 master_caller 에서\n마이그레이션 후 #1407 ``member:admin`` 표면 가드 회귀 → #1543 master-only\n재정렬).\n\n배경: oracle A7 finding (#1377) — 본 라우트는 인증 없이 credential check\n(``svc.change_password``의 old-password 비교) 까지 도달했다. ``_caller_id``\n만으로 audit 주체만 기록하고 인증 가드는 적용하지 않았기 때문이다. 본\n패치는 ``require_master_caller`` 의존성을 적용하고 ``update_scopes``와\n동일한 raw body 파싱 + auth-first 패턴을 따른다 (#1351 / #1352 SSOT).\n\n범위 결정:\n- master-only (보수). self-change use case (caller_id == member_id 허용)는\n  follow-up 이슈에서 별도 다룬다 (Issue #1377 Non-Goals).\n\n인증 → raw-body → credential check 순서를 보장한다. FastAPI가\n``body: PasswordChangeRequest``를 먼저 검증하면 unauth + bad-body 시 401이\n아닌 422가 먼저 반환되어 contract가 깨진다 — 본 라우트는 oracle A7\nfinding의 핵심 시그니처이므로 인증 가드 우선이 가장 중요하다.\n\n핸들러 단계 순서:\n\n1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,\n   master 아님 → 403, 비활성 멤버 → 403. credential check 도달 전에 모두\n   차단된다.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``PasswordChangeRequest.model_validate`` — ValidationError → 422.\n4. ``svc.change_password`` 호출. ``ValueError`` → 404,\n   ``PermissionError``/``PermissionDeniedError`` → 403.\n\nAudit 로그의 ``member_id``는 ``caller_id``로 기록한다(SSOT). 대상 멤버는\n``resource=member:{member_id}``로 분리해 추적한다.",
         "operationId": "change_password_api_members__member_id__password_patch",
         "parameters": [
           {
@@ -2116,7 +2116,7 @@
             }
           },
           "403": {
-            "description": "Permission denied (master, human 멤버 또는 member:admin scope 보유 agent 만 허용).",
+            "description": "Permission denied (master 만 허용 — #1543, #1542 SSOT). ``member:admin`` scope 를 보유한 agent 도 거부된다.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2174,7 +2174,7 @@
           "members"
         ],
         "summary": "Update Scopes",
-        "description": "권한 범위 변경. 인증된 master/human 또는 ``member:admin`` scope 를 보유한\nagent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. FastAPI 가 ``body: ScopesUpdateRequest`` 를 먼저 검증하면 unauth +\nbad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n1. 인증 가드 (``Depends(require_member_admin)``) — caller 빈 → 401,\n   권한 없음 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``ScopesUpdateRequest.model_validate`` — ValidationError → 422.\n4. ``svc.update_scopes`` 호출. ``ValueError`` → 404,\n   ``PermissionError``/``PermissionDeniedError`` → 403.",
+        "description": "권한 범위 변경. 인증된 master 만 호출 가능\n(#1543 — spec ``master-only`` 정합, #1542 SSOT).\n\nRaw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록\n한다. FastAPI 가 ``body: ScopesUpdateRequest`` 를 먼저 검증하면 unauth +\nbad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.\n\n핸들러 단계 순서:\n1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,\n   master 아님 → 403, 비활성 멤버 → 403.\n2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.\n3. ``ScopesUpdateRequest.model_validate`` — ValidationError → 422.\n4. ``svc.update_scopes`` 호출. ``ValueError`` → 404,\n   ``PermissionError``/``PermissionDeniedError`` → 403.",
         "operationId": "update_scopes_api_members__member_id__scopes_put",
         "parameters": [
           {
@@ -8340,7 +8340,7 @@
       "MemberCreateRequest": {
         "type": "object",
         "title": "MemberCreateRequest",
-        "description": "POST /api/members 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1339). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.",
+        "description": "POST /api/members 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1339, #1543). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.",
         "additionalProperties": false,
         "required": [
           "member_id",
@@ -8392,7 +8392,7 @@
       "ScopesUpdateRequest": {
         "type": "object",
         "title": "ScopesUpdateRequest",
-        "description": "PUT /api/members/{member_id}/scopes 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1351). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.",
+        "description": "PUT /api/members/{member_id}/scopes 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1351, #1543). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.",
         "additionalProperties": false,
         "required": [
           "scopes"
@@ -8790,7 +8790,7 @@
       },
       "PasswordChangeRequest": {
         "additionalProperties": false,
-        "description": "PATCH /api/members/{member_id}/password 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1377). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.",
+        "description": "PATCH /api/members/{member_id}/password 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1377, #1543). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.",
         "properties": {
           "old_password": {
             "title": "Old Password",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -143,6 +143,11 @@ export type paths = {
          * @description 계좌 재활성화. 인증된 master/human 또는 ``account:write`` scope 를 보유한
          *     agent 만 호출 가능 (#1407 — spec ``account:write`` 정합, #1352
          *     master_caller 에서 마이그레이션).
+         *
+         *     ``suspend_account``와 동일한 raw body 파싱 패턴(빈 body / null / ``{}``는
+         *     통과, 비-object / malformed JSON / extra key dict는 422)을 적용한다
+         *     (#1510). 인증 가드는 dependency level이므로 body validation보다 먼저
+         *     실행되며, invalid body 시에는 service / audit 호출이 발생하지 않는다.
          */
         post: operations["activate_account_api_accounts__account_id__activate_post"];
         delete?: never;
@@ -875,19 +880,21 @@ export type paths = {
         put?: never;
         /**
          * Create Member
-         * @description 멤버 등록. 토큰 1회 반환. 인증된 master/human 또는 ``member:admin`` scope
-         *     를 보유한 agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
+         * @description 멤버 등록. 토큰 1회 반환. 인증된 master 만 호출 가능
+         *     (#1543 — spec ``master-only`` 정합, #1542 SSOT
+         *     ``docs/specs/web-api/11-route-scope-table.md``). ``member:admin`` scope 를
+         *     보유한 agent 도 표면 가드에서 거부된다 (#1511 oracle drift 수렴).
          *
          *     인증 가드는 body validation보다 **반드시 먼저** 실행된다(#1339 P2). FastAPI
          *     가 ``body: MemberCreateRequest`` 파라미터를 먼저 파싱하면 Authorization
          *     헤더 미존재 + 필수 필드 누락 케이스에서 401 이 아니라 422 가 먼저 응답되어
          *     "missing or invalid Authorization header는 401" 계약이 깨진다. 이 이유로
-         *     본 라우트는 ``request: Request`` 와 ``require_member_admin`` 만 받고 raw
+         *     본 라우트는 ``request: Request`` 와 ``require_master_caller`` 만 받고 raw
          *     body 를 직접 파싱한다 (``update_account`` SSOT 패턴 일치).
          *
          *     핸들러 단계 순서:
-         *     1. **인증 가드 (최우선, ``Depends(require_member_admin)``)** — caller 빈
-         *        → 401, 권한 없음 → 403, 비활성 멤버 → 403.
+         *     1. **인증 가드 (최우선, ``Depends(require_master_caller)``)** — caller 빈
+         *        → 401, master 아님 → 403, 비활성 멤버 → 403.
          *     2. raw bytes 읽고 JSON 파싱 — 실패 시 422.
          *     3. ``MemberCreateRequest.model_validate`` — ValidationError → 422.
          *     4. ``svc.register`` 호출. ``PermissionError`` → 403, ``ValueError`` → 400.
@@ -935,9 +942,10 @@ export type paths = {
         head?: never;
         /**
          * Change Password
-         * @description 비밀번호 변경 (human 멤버 전용). 인증된 master/human 또는
-         *     ``member:admin`` scope 를 보유한 agent 만 호출 가능 (#1407 — spec
-         *     ``member:admin`` 정합, #1377 master_caller 에서 마이그레이션).
+         * @description 비밀번호 변경 (human 멤버 전용). 인증된 master 만 호출 가능
+         *     (#1543 — spec ``master-only`` 정합, #1542 SSOT, #1377 master_caller 에서
+         *     마이그레이션 후 #1407 ``member:admin`` 표면 가드 회귀 → #1543 master-only
+         *     재정렬).
          *
          *     배경: oracle A7 finding (#1377) — 본 라우트는 인증 없이 credential check
          *     (``svc.change_password``의 old-password 비교) 까지 도달했다. ``_caller_id``
@@ -956,8 +964,8 @@ export type paths = {
          *
          *     핸들러 단계 순서:
          *
-         *     1. 인증 가드 (``Depends(require_member_admin)``) — caller 빈 → 401,
-         *        권한 없음 → 403, 비활성 멤버 → 403. credential check 도달 전에 모두
+         *     1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
+         *        master 아님 → 403, 비활성 멤버 → 403. credential check 도달 전에 모두
          *        차단된다.
          *     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
          *     3. ``PasswordChangeRequest.model_validate`` — ValidationError → 422.
@@ -981,8 +989,8 @@ export type paths = {
         put?: never;
         /**
          * Reactivate Member
-         * @description 멤버 재활성화. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
-         *     agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
+         * @description 멤버 재활성화. 인증된 master 만 호출 가능
+         *     (#1543 — spec ``master-only`` 정합, #1542 SSOT).
          */
         post: operations["reactivate_member_api_members__member_id__reactivate_post"];
         delete?: never;
@@ -1002,8 +1010,8 @@ export type paths = {
         put?: never;
         /**
          * Revoke Member
-         * @description 멤버 영구 폐기. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
-         *     agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
+         * @description 멤버 영구 폐기. 인증된 master 만 호출 가능
+         *     (#1543 — spec ``master-only`` 정합, #1542 SSOT).
          */
         post: operations["revoke_member_api_members__member_id__revoke_post"];
         delete?: never;
@@ -1023,8 +1031,8 @@ export type paths = {
         put?: never;
         /**
          * Rotate Token
-         * @description 토큰 재발급. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
-         *     agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
+         * @description 토큰 재발급. 인증된 master 만 호출 가능
+         *     (#1543 — spec ``master-only`` 정합, #1542 SSOT).
          *
          *     인증 없이 token rotation 응답에 접근하면 token 값 자체가 노출되므로,
          *     가장 먼저 차단해야 한다.
@@ -1046,16 +1054,16 @@ export type paths = {
         get?: never;
         /**
          * Update Scopes
-         * @description 권한 범위 변경. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
-         *     agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
+         * @description 권한 범위 변경. 인증된 master 만 호출 가능
+         *     (#1543 — spec ``master-only`` 정합, #1542 SSOT).
          *
          *     Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
          *     한다. FastAPI 가 ``body: ScopesUpdateRequest`` 를 먼저 검증하면 unauth +
          *     bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.
          *
          *     핸들러 단계 순서:
-         *     1. 인증 가드 (``Depends(require_member_admin)``) — caller 빈 → 401,
-         *        권한 없음 → 403, 비활성 멤버 → 403.
+         *     1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
+         *        master 아님 → 403, 비활성 멤버 → 403.
          *     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
          *     3. ``ScopesUpdateRequest.model_validate`` — ValidationError → 422.
          *     4. ``svc.update_scopes`` 호출. ``ValueError`` → 404,
@@ -1080,8 +1088,8 @@ export type paths = {
         put?: never;
         /**
          * Suspend Member
-         * @description 멤버 일시 정지. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
-         *     agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
+         * @description 멤버 일시 정지. 인증된 master 만 호출 가능
+         *     (#1543 — spec ``master-only`` 정합, #1542 SSOT).
          */
         post: operations["suspend_member_api_members__member_id__suspend_post"];
         delete?: never;
@@ -2653,7 +2661,7 @@ export type components = {
         };
         /**
          * MemberCreateRequest
-         * @description POST /api/members 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1339). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.
+         * @description POST /api/members 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1339, #1543). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.
          */
         MemberCreateRequest: {
             /** @description 고유 식별자. */
@@ -2884,7 +2892,7 @@ export type components = {
         };
         /**
          * PasswordChangeRequest
-         * @description PATCH /api/members/{member_id}/password 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1377). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.
+         * @description PATCH /api/members/{member_id}/password 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1377, #1543). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.
          */
         PasswordChangeRequest: {
             /** New Password */
@@ -3238,7 +3246,7 @@ export type components = {
         };
         /**
          * ScopesUpdateRequest
-         * @description PUT /api/members/{member_id}/scopes 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1351). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.
+         * @description PUT /api/members/{member_id}/scopes 입력 contract. 인증된 master 호출자만 사용할 수 있다(#1351, #1543). Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, 둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다.
          */
         ScopesUpdateRequest: {
             /** @description 변경할 권한 범위 목록. 각 원소는 SCOPE_VOCABULARY (#1439, SSOT: ``src/ante/member/scopes.py``) 에 등록된 문자열이어야 한다. 미등록 문자열은 422 로 거부된다. */
@@ -5783,7 +5791,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Permission denied (master, human 멤버 또는 member:admin scope 보유 agent 만 허용). */
+            /** @description Permission denied (master 만 허용 — #1543, #1542 SSOT). ``member:admin`` scope 를 보유한 agent 도 거부된다. */
             403: {
                 headers: {
                     [name: string]: unknown;

--- a/guide/cli.md
+++ b/guide/cli.md
@@ -2,7 +2,7 @@
 
 Ante가 제공하는 모든 CLI 명령어를 정리한 문서입니다. 각 명령어의 사용법, 옵션, 필수 권한(scope)을 확인할 수 있습니다.
 
-> 마지막 갱신: 2026-05-14
+> 마지막 갱신: 2026-05-15
 
 ## 목차
 
@@ -196,12 +196,12 @@ ante [OPTIONS] <command>
 | `ante member list` | 멤버 목록 조회. | `member:read` | H·A |
 | `ante member info` | 멤버 상세 정보 조회. | `member:read` | H·A |
 | `ante member list-invalid-roles` | ``MemberRole`` enum 외 role 을 가진 legacy member row 식별 (#1468). | `member:read` | H·A |
-| `ante member register` | 멤버 등록 (토큰 발급). | `member:admin` | H·A |
-| `ante member set-emoji` | 멤버 이모지 설정/변경. | `member:admin` | H·A |
-| `ante member suspend` | 멤버 일시 정지. | `member:admin` | H·A |
-| `ante member reactivate` | 멤버 재활성화. | `member:admin` | H·A |
-| `ante member revoke` | 멤버 영구 폐기. | `member:admin` | H·A |
-| `ante member rotate-token` | 토큰 재발급 (기존 토큰 즉시 무효화). | `member:admin` | H·A |
+| `ante member register` | 멤버 등록 (토큰 발급). | master-only | H(master) |
+| `ante member set-emoji` | 멤버 이모지 설정/변경. | master-only | H(master) |
+| `ante member suspend` | 멤버 일시 정지. | master-only | H(master) |
+| `ante member reactivate` | 멤버 재활성화. | master-only | H(master) |
+| `ante member revoke` | 멤버 영구 폐기. | master-only | H(master) |
+| `ante member rotate-token` | 토큰 재발급 (기존 토큰 즉시 무효화). | master-only | H(master) |
 | `ante member reset-password` | Recovery Key로 패스워드 리셋 (인증 불필요). | — | — |
 | `ante member regenerate-recovery-key` | Recovery Key 재발급 (인증 불필요). | — | — |
 | `ante rule list` | 룰 목록 조회. | `rule:read` | H·A |
@@ -229,7 +229,7 @@ ante [OPTIONS] <command>
 | `ante feed status` | 수집 상태를 조회한다. | `data:read` | H·A |
 | `ante feed inject` | 외부 CSV 파일에서 과거 데이터를 수동 주입한다. | `data:write` | H·A |
 
-> **H**: Human 토큰 (scope 무제한) · **A**: Agent 토큰 (해당 scope 필요) · **—**: 인증 불필요
+> **H**: Human 토큰 (scope 무제한) · **A**: Agent 토큰 (해당 scope 필요) · **H(master)**: Human master 전용 (#1543) · **—**: 인증 불필요
 
 ---
 
@@ -505,7 +505,7 @@ ante audit list [OPTIONS]
 | `--from-date` | - | TEXT | — | 시작 날짜 (YYYY-MM-DD) |
 | `--to-date` | - | TEXT | — | 종료 날짜 (YYYY-MM-DD) |
 | `--limit` | - | INT (1~200) | 20 | 조회 건수 |
-| `--offset` | - | INTEGER | 0 | 오프셋 |
+| `--offset` | - | INT (0~) | 0 | 오프셋 |
 
 
 ---
@@ -1079,7 +1079,7 @@ ante config history <KEY> [OPTIONS]
 
 | 옵션 | 필수 | 타입 | 기본값 | 설명 |
 |------|------|------|--------|------|
-| `--limit`, `-n` | - | INTEGER | 20 | 조회 건수 (기본 20) |
+| `--limit`, `-n` | - | INT (1~) | 20 | 조회 건수 (기본 20) |
 | `--format` | - | text / json | — | 출력 형식 (text 또는 json) |
 
 
@@ -1328,7 +1328,7 @@ ante backtest history <STRATEGY_NAME> [OPTIONS]
 
 | 옵션 | 필수 | 타입 | 기본값 | 설명 |
 |------|------|------|--------|------|
-| `--limit` | - | INTEGER | 20 | 조회 건수 |
+| `--limit` | - | INT (1~) | 20 | 조회 건수 |
 | `--db-path` | - | TEXT | — | DB 경로 (미지정 시 config_dir 기반) |
 
 
@@ -1503,7 +1503,7 @@ ante instrument search <KEYWORD> [OPTIONS]
 
 | 옵션 | 필수 | 타입 | 기본값 | 설명 |
 |------|------|------|--------|------|
-| `--limit` | - | INTEGER | 20 | 최대 결과 수 |
+| `--limit` | - | INT (1~) | 20 | 최대 결과 수 |
 | `--listed-only` | - | BOOLEAN | false | 상장 종목만 검색 |
 | `--db-path` | - | TEXT | — | DB 경로 (미지정 시 config_dir 기반) |
 
@@ -1613,8 +1613,8 @@ ante member list-invalid-roles [OPTIONS]
 
 멤버 등록 (토큰 발급).
 
-- **필요 scope**: `member:admin`
-- **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
+- **필요 scope**: master-only
+- **토큰**: 🔑 Human master 전용 (#1543)
 
 ```bash
 ante member register [OPTIONS]
@@ -1636,8 +1636,8 @@ ante member register [OPTIONS]
 
 멤버 이모지 설정/변경.
 
-- **필요 scope**: `member:admin`
-- **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
+- **필요 scope**: master-only
+- **토큰**: 🔑 Human master 전용 (#1543)
 
 ```bash
 ante member set-emoji <MEMBER_ID> <EMOJI>
@@ -1655,8 +1655,8 @@ ante member set-emoji <MEMBER_ID> <EMOJI>
 
 멤버 일시 정지.
 
-- **필요 scope**: `member:admin`
-- **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
+- **필요 scope**: master-only
+- **토큰**: 🔑 Human master 전용 (#1543)
 
 ```bash
 ante member suspend <MEMBER_ID>
@@ -1673,8 +1673,8 @@ ante member suspend <MEMBER_ID>
 
 멤버 재활성화.
 
-- **필요 scope**: `member:admin`
-- **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
+- **필요 scope**: master-only
+- **토큰**: 🔑 Human master 전용 (#1543)
 
 ```bash
 ante member reactivate <MEMBER_ID>
@@ -1693,8 +1693,8 @@ ante member reactivate <MEMBER_ID>
 
 ``--yes`` 누락 시 prompt 없이 ``CLI_CONFIRMATION_REQUIRED`` 에러로 종료한다.
 
-- **필요 scope**: `member:admin`
-- **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
+- **필요 scope**: master-only
+- **토큰**: 🔑 Human master 전용 (#1543)
 
 ```bash
 ante member revoke <MEMBER_ID> [OPTIONS]
@@ -1717,8 +1717,8 @@ ante member revoke <MEMBER_ID> [OPTIONS]
 
 토큰 재발급 (기존 토큰 즉시 무효화).
 
-- **필요 scope**: `member:admin`
-- **토큰**: 🔑 Human(무제한) / Agent(scope 필요)
+- **필요 scope**: master-only
+- **토큰**: 🔑 Human master 전용 (#1543)
 
 ```bash
 ante member rotate-token <MEMBER_ID>
@@ -1961,7 +1961,7 @@ ante trade list [OPTIONS]
 | `--bot` | - | TEXT | — | 봇 ID 필터 |
 | `--from` | - | TEXT | — | 시작일 (YYYY-MM-DD) |
 | `--to` | - | TEXT | — | 종료일 (YYYY-MM-DD) |
-| `--limit` | - | INTEGER | 50 | 최대 조회 수 |
+| `--limit` | - | INT (1~) | 50 | 최대 조회 수 |
 | `--format` | - | text / json | — | 출력 형식 (text 또는 json) |
 
 

--- a/scripts/generate_cli_reference.py
+++ b/scripts/generate_cli_reference.py
@@ -133,6 +133,22 @@ def _param_display_name(param: click.Parameter) -> str:
     return f"`{param.name}`"
 
 
+def _is_master_only(cmd: click.BaseCommand) -> bool:
+    """커맨드의 콜백 체인에서 ``_require_master_applied`` 마커를 찾는다.
+
+    ``ante.cli.middleware.require_master`` 가 부착하는 sentinel marker. master
+    HUMAN 만 통과하는 명령(member admin mutation 등, #1543) 은 scope 가 비어
+    있지만 인증이 필요하므로, ``_required_scopes`` 와 별도로 식별해 문서에
+    명시한다.
+    """
+    cb = cmd.callback
+    while cb:
+        if getattr(cb, "_require_master_applied", False):
+            return True
+        cb = getattr(cb, "__wrapped__", None)
+    return False
+
+
 def _get_required_scopes(cmd: click.BaseCommand) -> tuple[str, ...]:
     """커맨드의 콜백 체인에서 _required_scopes를 추출한다."""
     cb = cmd.callback
@@ -143,22 +159,32 @@ def _get_required_scopes(cmd: click.BaseCommand) -> tuple[str, ...]:
     return ()
 
 
-def _format_scope_cell(scopes: tuple[str, ...]) -> str:
-    """scope 목록을 마크다운 셀 텍스트로 포맷팅한다."""
+def _format_scope_cell(scopes: tuple[str, ...], *, master_only: bool = False) -> str:
+    """scope 목록을 마크다운 셀 텍스트로 포맷팅한다.
+
+    master-only 명령(#1543 — ``@require_master``) 은 scope 가 비어 있어도
+    ``master-only`` 로 표시한다. ``\u2014`` (인증 불필요) 와 혼동되지 않도록 한다.
+    """
+    if master_only:
+        return "master-only"
     if not scopes:
         return "\u2014"
     return ", ".join(f"`{s}`" for s in scopes)
 
 
-def _format_token_cell(scopes: tuple[str, ...]) -> str:
+def _format_token_cell(scopes: tuple[str, ...], *, master_only: bool = False) -> str:
     """토큰 요구 사항을 마크다운 셀 텍스트로 포맷팅한다."""
+    if master_only:
+        return "H(master)"
     if not scopes:
         return "\u2014"
     return "H\u00b7A"
 
 
-def _format_token_detail(scopes: tuple[str, ...]) -> str:
+def _format_token_detail(scopes: tuple[str, ...], *, master_only: bool = False) -> str:
     """커맨드 상세 섹션용 토큰 정보를 포맷팅한다."""
+    if master_only:
+        return "\U0001f511 Human master 전용 (#1543)"
     if not scopes:
         return "인증 불필요"
     return "\U0001f511 Human(무제한) / Agent(scope 필요)"
@@ -261,8 +287,9 @@ def _write_summary_table(
             help_text = cmd.help.strip().split("\n")[0]
 
         scopes = _get_required_scopes(cmd)
-        scope_cell = _format_scope_cell(scopes)
-        token_cell = _format_token_cell(scopes)
+        master_only = _is_master_only(cmd)
+        scope_cell = _format_scope_cell(scopes, master_only=master_only)
+        token_cell = _format_token_cell(scopes, master_only=master_only)
 
         out.write(
             f"| `ante {full_name}` | {help_text} | {scope_cell} | {token_cell} |\n"
@@ -272,6 +299,7 @@ def _write_summary_table(
     out.write(
         "> **H**: Human 토큰 (scope 무제한) · "
         "**A**: Agent 토큰 (해당 scope 필요) · "
+        "**H(master)**: Human master 전용 (#1543) · "
         "**\u2014**: 인증 불필요\n\n"
     )
     out.write("---\n\n")
@@ -295,8 +323,9 @@ def _write_command_detail(
 
     # scope·토큰 정보
     scopes = _get_required_scopes(cmd)
-    scope_text = _format_scope_cell(scopes)
-    token_text = _format_token_detail(scopes)
+    master_only = _is_master_only(cmd)
+    scope_text = _format_scope_cell(scopes, master_only=master_only)
+    token_text = _format_token_detail(scopes, master_only=master_only)
     out.write(f"- **필요 scope**: {scope_text}\n")
     out.write(f"- **토큰**: {token_text}\n\n")
 

--- a/src/ante/cli/commands/member.py
+++ b/src/ante/cli/commands/member.py
@@ -21,7 +21,12 @@ import click
 
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
-from ante.cli.middleware import get_member_id, require_auth, require_scope
+from ante.cli.middleware import (
+    get_member_id,
+    require_auth,
+    require_master,
+    require_scope,
+)
 from ante.member.errors import PermissionDeniedError
 from ante.member.models import MemberRole
 from ante.member.scopes import InvalidScopeError
@@ -461,7 +466,7 @@ def member_list_invalid_roles(
 @format_option
 @click.pass_context
 @require_auth
-@require_scope("member:admin")
+@require_master
 def member_register(
     ctx: click.Context,
     member_id: str,
@@ -525,7 +530,7 @@ def member_register(
 @click.argument("emoji")
 @click.pass_context
 @require_auth
-@require_scope("member:admin")
+@require_master
 def member_set_emoji(ctx: click.Context, member_id: str, emoji: str) -> None:
     """멤버 이모지 설정/변경."""
     fmt = get_formatter(ctx)
@@ -552,7 +557,7 @@ def member_set_emoji(ctx: click.Context, member_id: str, emoji: str) -> None:
 @click.argument("member_id")
 @click.pass_context
 @require_auth
-@require_scope("member:admin")
+@require_master
 def member_suspend(ctx: click.Context, member_id: str) -> None:
     """멤버 일시 정지."""
     fmt = get_formatter(ctx)
@@ -582,7 +587,7 @@ def member_suspend(ctx: click.Context, member_id: str) -> None:
 @click.argument("member_id")
 @click.pass_context
 @require_auth
-@require_scope("member:admin")
+@require_master
 def member_reactivate(ctx: click.Context, member_id: str) -> None:
     """멤버 재활성화."""
     fmt = get_formatter(ctx)
@@ -619,7 +624,7 @@ def member_reactivate(ctx: click.Context, member_id: str) -> None:
 )
 @click.pass_context
 @require_auth
-@require_scope("member:admin")
+@require_master
 def member_revoke(ctx: click.Context, member_id: str, yes: bool) -> None:
     """멤버 영구 폐기.
 
@@ -660,7 +665,7 @@ def member_revoke(ctx: click.Context, member_id: str, yes: bool) -> None:
 @click.argument("member_id")
 @click.pass_context
 @require_auth
-@require_scope("member:admin")
+@require_master
 def member_rotate_token(ctx: click.Context, member_id: str) -> None:
     """토큰 재발급 (기존 토큰 즉시 무효화)."""
     fmt = get_formatter(ctx)

--- a/src/ante/cli/middleware.py
+++ b/src/ante/cli/middleware.py
@@ -202,19 +202,25 @@ def require_master(fn: Callable) -> Callable:
     ``require_master_caller`` 와 동일한 invariant 를 적용한다 (#1543 — #1511
     oracle drift 수렴).
 
-    멱등(idempotent) — 이미 같은 가드가 부착된 함수에 재적용되어도 한 번만
-    감싸지도록 ``_require_auth_applied`` sentinel marker 로 dedupe 한다
-    (``require_auth`` / ``require_scope`` 와 동일 패턴). #1404
-    ``authenticated_group`` factory 가 leaf command callback 을 자동 wrapping
-    할 때, 명령 자체에 이미 부착된 본 가드의 내부 검증과 중복 호출되는 것을
-    방지한다.
+    멱등(idempotent) — 이미 ``require_master`` 가 부착된 함수에 재적용되어도
+    한 번만 감싸지도록 자체 ``_require_master_applied`` sentinel marker 로
+    dedupe 한다. ``_require_auth_applied`` 를 dedupe key 로 쓰면, callback 에
+    ``@require_auth`` 가 먼저 적용되어 있을 때 ``@require_master`` 가 자체 wrap
+    을 건너뛰어 master 검증이 발화하지 않는 idempotent 버그가 생기므로 자체
+    marker 를 분리한다 (#1543 — Codex 브랜치 리뷰 finding 1).
+
+    동시에 ``_require_auth_applied`` marker 도 함께 set 한다. 본 가드는 자체
+    적으로 ``member is None`` 인증 검증을 포함하므로, ``authenticated_group``
+    factory 가 leaf command callback 을 ``require_auth`` 로 자동 wrap 할 때
+    중복 wrap 을 방지하기 위함이다 (``require_auth`` / ``require_scope`` 와
+    동일한 보호 패턴). #1404
 
     Note:
         ``member:admin`` scope vocabulary 는 #1542 결정으로 reserved 상태로
         유지된다 (``src/ante/member/scopes.py`` SSOT). 본 데코레이터는 scope
         보유 여부를 검사하지 않으며, master 가 아니면 무조건 거부한다.
     """
-    if getattr(fn, "_require_auth_applied", False):
+    if getattr(fn, "_require_master_applied", False):
         return fn
 
     @functools.wraps(fn)

--- a/src/ante/cli/middleware.py
+++ b/src/ante/cli/middleware.py
@@ -189,6 +189,72 @@ def require_auth(fn: Callable) -> Callable:
     return wrapper
 
 
+def require_master(fn: Callable) -> Callable:
+    """master-only 데코레이터 (HUMAN type + master role만 통과).
+
+    @click.pass_context 아래에 배치한다.
+    ``ctx.obj["member"]``가 ``None`` 이면 ``auth_required`` 로 종료.
+    member.type != ``MemberType.HUMAN`` 또는 member.role != ``MemberRole.MASTER``
+    이면 ``permission_denied`` 로 종료.
+
+    SSOT: ``docs/specs/web-api/11-route-scope-table.md`` (#1542) 결정에 따라
+    member admin mutation 은 master-only 계약. CLI 표면 가드도 Web API
+    ``require_master_caller`` 와 동일한 invariant 를 적용한다 (#1543 — #1511
+    oracle drift 수렴).
+
+    멱등(idempotent) — 이미 같은 가드가 부착된 함수에 재적용되어도 한 번만
+    감싸지도록 ``_require_auth_applied`` sentinel marker 로 dedupe 한다
+    (``require_auth`` / ``require_scope`` 와 동일 패턴). #1404
+    ``authenticated_group`` factory 가 leaf command callback 을 자동 wrapping
+    할 때, 명령 자체에 이미 부착된 본 가드의 내부 검증과 중복 호출되는 것을
+    방지한다.
+
+    Note:
+        ``member:admin`` scope vocabulary 는 #1542 결정으로 reserved 상태로
+        유지된다 (``src/ante/member/scopes.py`` SSOT). 본 데코레이터는 scope
+        보유 여부를 검사하지 않으며, master 가 아니면 무조건 거부한다.
+    """
+    if getattr(fn, "_require_auth_applied", False):
+        return fn
+
+    @functools.wraps(fn)
+    def wrapper(*args: object, **kwargs: object) -> object:
+        from ante.member.models import MemberRole, MemberType
+
+        ctx = click.get_current_context()
+        member: Member | None = (
+            ctx.obj.get("member") if isinstance(ctx.obj, dict) else None
+        )
+        if member is None:
+            _emit_auth_error(
+                ctx,
+                "auth_required",
+                "인증이 필요합니다. ANTE_MEMBER_TOKEN 환경변수를 설정해 주세요.",
+            )
+            raise SystemExit(1)
+
+        # MemberType.HUMAN + role == MASTER 만 통과. Web API
+        # ``require_master_caller`` 와 동일한 invariant.
+        member_type_value = getattr(member.type, "value", member.type)
+        member_role_value = getattr(member.role, "value", member.role)
+        if (
+            member_type_value != MemberType.HUMAN.value
+            or member_role_value != MemberRole.MASTER.value
+        ):
+            _emit_auth_error(
+                ctx,
+                "permission_denied",
+                "이 작업은 master 권한이 필요합니다.",
+            )
+            raise SystemExit(1)
+
+        return fn(*args, **kwargs)
+
+    wrapper._require_auth_applied = True  # type: ignore[attr-defined]
+    wrapper._require_master_applied = True  # type: ignore[attr-defined]
+    return wrapper
+
+
 def require_scope(*scopes: str) -> Callable:
     """권한 검증 데코레이터.
 

--- a/src/ante/web/deps.py
+++ b/src/ante/web/deps.py
@@ -550,7 +550,18 @@ require_config_read = require_scope("config:read")
 require_data_read = require_scope("data:read")
 require_data_write = require_scope("data:write")
 require_member_read = require_scope("member:read")
-require_member_admin = require_scope("member:admin")
+# ``require_member_admin`` 은 #1407 에서 ``require_scope("member:admin")`` 으로
+# 도입되었으나, #1511 oracle drift 분석 결과 member admin mutation 은 master-only
+# 계약임이 #1542 에서 spec SSOT (``docs/specs/web-api/11-route-scope-table.md``)
+# 로 확정되었다. ``MemberService._assert_master`` 가 런타임에서 거부하므로 표면
+# 가드만 ``member:admin`` agent 를 허용하는 것은 contract drift 였다.
+#
+# #1543: 표면 가드도 master-only 로 정렬한다. backward-compat 을 위해 symbol 은
+# 보존하되 의미를 ``require_master_caller`` 로 재할당한다 — 외부 import (라우트,
+# 테스트) 는 그대로 동작하지만 실제 권한 검증은 master-only 로 강제된다.
+# ``member:admin`` scope vocabulary 는 #1542 결정에 따라 reserved 상태로 유지된다
+# (``src/ante/member/scopes.py`` SSOT, 제거 금지).
+require_member_admin = require_master_caller
 require_report_read = require_scope("report:read")
 require_rule_read = require_scope("rule:read")
 require_rule_admin = require_scope("rule:admin")

--- a/src/ante/web/routes/members.py
+++ b/src/ante/web/routes/members.py
@@ -16,7 +16,7 @@ from ante.member.scopes import SCOPE_VOCABULARY, InvalidScopeError
 from ante.web.deps import (
     get_audit_logger_optional,
     get_member_service,
-    require_member_admin,
+    require_master_caller,
     require_member_read,
 )
 from ante.web.schemas import (
@@ -105,7 +105,7 @@ MEMBER_CREATE_REQUEST_SCHEMA: dict[str, Any] = {
     "title": "MemberCreateRequest",
     "description": (
         "POST /api/members 입력 contract. "
-        "인증된 master 호출자만 사용할 수 있다(#1339). "
+        "인증된 master 호출자만 사용할 수 있다(#1339, #1543). "
         "Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, "
         "둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다."
     ),
@@ -200,7 +200,7 @@ def _build_password_change_request_schema() -> dict[str, Any]:
     schema["title"] = "PasswordChangeRequest"
     schema["description"] = (
         "PATCH /api/members/{member_id}/password 입력 contract. "
-        "인증된 master 호출자만 사용할 수 있다(#1377). "
+        "인증된 master 호출자만 사용할 수 있다(#1377, #1543). "
         "Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, "
         "둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다."
     )
@@ -245,7 +245,7 @@ MEMBER_SCOPES_UPDATE_REQUEST_SCHEMA: dict[str, Any] = {
     "title": "ScopesUpdateRequest",
     "description": (
         "PUT /api/members/{member_id}/scopes 입력 contract. "
-        "인증된 master 호출자만 사용할 수 있다(#1351). "
+        "인증된 master 호출자만 사용할 수 있다(#1351, #1543). "
         "Bearer 토큰 또는 유효한 ante_session 쿠키 중 하나라도 있어야 하며, "
         "둘 다 없거나 둘 다 invalid면 body validation 전에 401로 차단된다."
     ),
@@ -392,28 +392,30 @@ async def list_members(
 )
 async def create_member(
     request: Request,
-    caller: Annotated[str, Depends(require_member_admin)],
+    caller: Annotated[str, Depends(require_master_caller)],
     svc: Annotated[Any, Depends(get_member_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """멤버 등록. 토큰 1회 반환. 인증된 master/human 또는 ``member:admin`` scope
-    를 보유한 agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
+    """멤버 등록. 토큰 1회 반환. 인증된 master 만 호출 가능
+    (#1543 — spec ``master-only`` 정합, #1542 SSOT
+    ``docs/specs/web-api/11-route-scope-table.md``). ``member:admin`` scope 를
+    보유한 agent 도 표면 가드에서 거부된다 (#1511 oracle drift 수렴).
 
     인증 가드는 body validation보다 **반드시 먼저** 실행된다(#1339 P2). FastAPI
     가 ``body: MemberCreateRequest`` 파라미터를 먼저 파싱하면 Authorization
     헤더 미존재 + 필수 필드 누락 케이스에서 401 이 아니라 422 가 먼저 응답되어
     "missing or invalid Authorization header는 401" 계약이 깨진다. 이 이유로
-    본 라우트는 ``request: Request`` 와 ``require_member_admin`` 만 받고 raw
+    본 라우트는 ``request: Request`` 와 ``require_master_caller`` 만 받고 raw
     body 를 직접 파싱한다 (``update_account`` SSOT 패턴 일치).
 
     핸들러 단계 순서:
-    1. **인증 가드 (최우선, ``Depends(require_member_admin)``)** — caller 빈
-       → 401, 권한 없음 → 403, 비활성 멤버 → 403.
+    1. **인증 가드 (최우선, ``Depends(require_master_caller)``)** — caller 빈
+       → 401, master 아님 → 403, 비활성 멤버 → 403.
     2. raw bytes 읽고 JSON 파싱 — 실패 시 422.
     3. ``MemberCreateRequest.model_validate`` — ValidationError → 422.
     4. ``svc.register`` 호출. ``PermissionError`` → 403, ``ValueError`` → 400.
     """
-    # 1. 인증 가드 — ``require_member_admin`` dependency 가 이미 통과시킴.
+    # 1. 인증 가드 — ``require_master_caller`` dependency 가 이미 통과시킴.
 
     # 2. raw body 읽기 + JSON 파싱.
     raw = await request.body()
@@ -550,12 +552,12 @@ async def get_member(
 async def suspend_member(
     member_id: str,
     request: Request,
-    caller: Annotated[str, Depends(require_member_admin)],
+    caller: Annotated[str, Depends(require_master_caller)],
     svc: Annotated[Any, Depends(get_member_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """멤버 일시 정지. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
-    agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합)."""
+    """멤버 일시 정지. 인증된 master 만 호출 가능
+    (#1543 — spec ``master-only`` 정합, #1542 SSOT)."""
     try:
         member = await svc.suspend(member_id, suspended_by=caller)
     except ValueError as e:
@@ -608,12 +610,12 @@ async def suspend_member(
 async def reactivate_member(
     member_id: str,
     request: Request,
-    caller: Annotated[str, Depends(require_member_admin)],
+    caller: Annotated[str, Depends(require_master_caller)],
     svc: Annotated[Any, Depends(get_member_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """멤버 재활성화. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
-    agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합)."""
+    """멤버 재활성화. 인증된 master 만 호출 가능
+    (#1543 — spec ``master-only`` 정합, #1542 SSOT)."""
     try:
         member = await svc.reactivate(member_id, reactivated_by=caller)
     except ValueError as e:
@@ -666,12 +668,12 @@ async def reactivate_member(
 async def revoke_member(
     member_id: str,
     request: Request,
-    caller: Annotated[str, Depends(require_member_admin)],
+    caller: Annotated[str, Depends(require_master_caller)],
     svc: Annotated[Any, Depends(get_member_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """멤버 영구 폐기. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
-    agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합)."""
+    """멤버 영구 폐기. 인증된 master 만 호출 가능
+    (#1543 — spec ``master-only`` 정합, #1542 SSOT)."""
     try:
         member = await svc.revoke(member_id, revoked_by=caller)
     except ValueError as e:
@@ -724,12 +726,12 @@ async def revoke_member(
 async def rotate_token(
     member_id: str,
     request: Request,
-    caller: Annotated[str, Depends(require_member_admin)],
+    caller: Annotated[str, Depends(require_master_caller)],
     svc: Annotated[Any, Depends(get_member_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """토큰 재발급. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
-    agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
+    """토큰 재발급. 인증된 master 만 호출 가능
+    (#1543 — spec ``master-only`` 정합, #1542 SSOT).
 
     인증 없이 token rotation 응답에 접근하면 token 값 자체가 노출되므로,
     가장 먼저 차단해야 한다.
@@ -759,8 +761,8 @@ async def rotate_token(
         401: _AUTH_REQUIRED_RESPONSE,
         403: {
             "description": (
-                "Permission denied (master, human 멤버 또는 member:admin "
-                "scope 보유 agent 만 허용)."
+                "Permission denied (master 만 허용 — #1543, #1542 SSOT). "
+                "``member:admin`` scope 를 보유한 agent 도 거부된다."
             ),
             "content": {
                 "application/problem+json": {
@@ -817,13 +819,14 @@ async def rotate_token(
 async def change_password(
     member_id: str,
     request: Request,
-    caller_id: Annotated[str, Depends(require_member_admin)],
+    caller_id: Annotated[str, Depends(require_master_caller)],
     svc: Annotated[Any, Depends(get_member_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """비밀번호 변경 (human 멤버 전용). 인증된 master/human 또는
-    ``member:admin`` scope 를 보유한 agent 만 호출 가능 (#1407 — spec
-    ``member:admin`` 정합, #1377 master_caller 에서 마이그레이션).
+    """비밀번호 변경 (human 멤버 전용). 인증된 master 만 호출 가능
+    (#1543 — spec ``master-only`` 정합, #1542 SSOT, #1377 master_caller 에서
+    마이그레이션 후 #1407 ``member:admin`` 표면 가드 회귀 → #1543 master-only
+    재정렬).
 
     배경: oracle A7 finding (#1377) — 본 라우트는 인증 없이 credential check
     (``svc.change_password``의 old-password 비교) 까지 도달했다. ``_caller_id``
@@ -842,8 +845,8 @@ async def change_password(
 
     핸들러 단계 순서:
 
-    1. 인증 가드 (``Depends(require_member_admin)``) — caller 빈 → 401,
-       권한 없음 → 403, 비활성 멤버 → 403. credential check 도달 전에 모두
+    1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
+       master 아님 → 403, 비활성 멤버 → 403. credential check 도달 전에 모두
        차단된다.
     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
     3. ``PasswordChangeRequest.model_validate`` — ValidationError → 422.
@@ -853,7 +856,7 @@ async def change_password(
     Audit 로그의 ``member_id``는 ``caller_id``로 기록한다(SSOT). 대상 멤버는
     ``resource=member:{member_id}``로 분리해 추적한다.
     """
-    # 1. 인증 가드는 ``require_member_admin`` 의존성에 의해 이미 통과 상태.
+    # 1. 인증 가드는 ``require_master_caller`` 의존성에 의해 이미 통과 상태.
 
     # 2. raw body 읽기 + JSON 파싱 — 인증 통과 후에만 실행된다.
     raw = await request.body()
@@ -960,26 +963,26 @@ async def change_password(
 async def update_scopes(
     member_id: str,
     request: Request,
-    caller: Annotated[str, Depends(require_member_admin)],
+    caller: Annotated[str, Depends(require_master_caller)],
     svc: Annotated[Any, Depends(get_member_service)],
     audit_logger: Annotated[Any | None, Depends(get_audit_logger_optional)],
 ) -> dict:
-    """권한 범위 변경. 인증된 master/human 또는 ``member:admin`` scope 를 보유한
-    agent 만 호출 가능 (#1407 — spec ``member:admin`` 정합).
+    """권한 범위 변경. 인증된 master 만 호출 가능
+    (#1543 — spec ``master-only`` 정합, #1542 SSOT).
 
     Raw body 파싱 패턴으로 인증 가드가 body validation 보다 우선 실행되도록
     한다. FastAPI 가 ``body: ScopesUpdateRequest`` 를 먼저 검증하면 unauth +
     bad-body 시 401 이 아닌 422 가 먼저 반환되어 contract 가 깨진다.
 
     핸들러 단계 순서:
-    1. 인증 가드 (``Depends(require_member_admin)``) — caller 빈 → 401,
-       권한 없음 → 403, 비활성 멤버 → 403.
+    1. 인증 가드 (``Depends(require_master_caller)``) — caller 빈 → 401,
+       master 아님 → 403, 비활성 멤버 → 403.
     2. raw bytes 읽기 + JSON 파싱 — 실패 시 422.
     3. ``ScopesUpdateRequest.model_validate`` — ValidationError → 422.
     4. ``svc.update_scopes`` 호출. ``ValueError`` → 404,
        ``PermissionError``/``PermissionDeniedError`` → 403.
     """
-    # 1. 인증 가드 — ``require_member_admin`` 이 이미 통과시킴.
+    # 1. 인증 가드 — ``require_master_caller`` 가 이미 통과시킴.
 
     # 2. raw body 읽기 + JSON 파싱.
     raw = await request.body()

--- a/tests/unit/test_cli_member_master_only.py
+++ b/tests/unit/test_cli_member_master_only.py
@@ -1,0 +1,256 @@
+"""CLI member admin command master-only 표면 가드 회귀 테스트 (#1543).
+
+#1542 spec 결정에 따라 6 CLI commands (register / set-emoji / suspend /
+reactivate / revoke / rotate-token) 는 ``@require_master`` 데코레이터로
+표면에서 master-only 검증한다. ``member:admin`` scope 보유 agent 는 이전에는
+``@require_scope("member:admin")`` 로 통과했지만 본 패치 이후엔 표면에서
+``permission_denied`` 로 거부된다.
+
+회귀 매트릭스 (서브셋 — 핵심 commands 만):
+- master HUMAN → service 호출
+- ``member:admin`` scope agent → permission_denied + service 미호출
+- non-master human (admin role) → permission_denied + service 미호출
+- non-master agent without scope → permission_denied + service 미호출
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberStatus, MemberType
+
+
+def _make_member(
+    *,
+    member_id: str,
+    member_type: MemberType,
+    role: MemberRole,
+    scopes: list[str] | None = None,
+) -> Member:
+    return Member(
+        member_id=member_id,
+        type=member_type,
+        role=role,
+        org="default",
+        name=member_id,
+        status=MemberStatus.ACTIVE,
+        scopes=scopes or [],
+    )
+
+
+def _master() -> Member:
+    return _make_member(
+        member_id="master",
+        member_type=MemberType.HUMAN,
+        role=MemberRole.MASTER,
+    )
+
+
+def _agent_with_admin_scope() -> Member:
+    return _make_member(
+        member_id="agent-admin",
+        member_type=MemberType.AGENT,
+        role=MemberRole.DEFAULT,
+        scopes=["member:admin"],
+    )
+
+
+def _human_admin() -> Member:
+    """non-master human (role=admin) — master 가 아니므로 거부 대상."""
+    return _make_member(
+        member_id="human-admin",
+        member_type=MemberType.HUMAN,
+        role=MemberRole.ADMIN,
+    )
+
+
+def _agent_no_scope() -> Member:
+    return _make_member(
+        member_id="agent-default",
+        member_type=MemberType.AGENT,
+        role=MemberRole.DEFAULT,
+    )
+
+
+def _invoke_with_member(args: list[str], member: Member):  # noqa: ANN202
+    """주어진 member 컨텍스트로 CLI 를 실행한다 (인증 우회)."""
+    runner = CliRunner()
+
+    def _mock_auth(ctx) -> None:  # noqa: ANN001
+        ctx.obj["member"] = member
+
+    with patch("ante.cli.main.authenticate_member", side_effect=_mock_auth):
+        return runner.invoke(
+            cli,
+            args,
+            obj={"member": member},
+            env={"ANTE_MEMBER_TOKEN": "any"},
+            catch_exceptions=False,
+        )
+
+
+def _patch_service(method_name: str):  # noqa: ANN202
+    """member._create_service 를 mock 한 채 service.<method_name> 호출 회수를 추적."""
+    service = MagicMock()
+    method = AsyncMock(
+        return_value=Member(
+            member_id="target",
+            type=MemberType.AGENT,
+            role=MemberRole.DEFAULT,
+            org="default",
+            name="target",
+            status=MemberStatus.ACTIVE,
+            scopes=[],
+        )
+    )
+    setattr(service, method_name, method)
+    # rotate_token 은 (Member, str) tuple 반환
+    if method_name == "rotate_token":
+        method.return_value = (
+            Member(
+                member_id="target",
+                type=MemberType.AGENT,
+                role=MemberRole.DEFAULT,
+                org="default",
+                name="target",
+                status=MemberStatus.ACTIVE,
+                scopes=[],
+            ),
+            "ante_ak_test",
+        )
+    # register 는 (Member, str) tuple 반환
+    if method_name == "register":
+        method.return_value = (
+            Member(
+                member_id="new-agent",
+                type=MemberType.AGENT,
+                role=MemberRole.DEFAULT,
+                org="default",
+                name="new",
+                status=MemberStatus.ACTIVE,
+                scopes=[],
+            ),
+            "ante_ak_test",
+        )
+    db = MagicMock()
+    db.close = AsyncMock(return_value=None)
+    return (
+        patch(
+            "ante.cli.commands.member._create_service",
+            new_callable=AsyncMock,
+            return_value=(service, db),
+        ),
+        method,
+    )
+
+
+# (cli_args, service_method_name)
+ADMIN_COMMANDS = [
+    pytest.param(
+        ["member", "register", "--id", "new-agent", "--type", "agent"],
+        "register",
+        id="register",
+    ),
+    pytest.param(
+        ["member", "set-emoji", "target", "🤖"],
+        "update_emoji",
+        id="set-emoji",
+    ),
+    pytest.param(
+        ["member", "suspend", "target"],
+        "suspend",
+        id="suspend",
+    ),
+    pytest.param(
+        ["member", "reactivate", "target"],
+        "reactivate",
+        id="reactivate",
+    ),
+    pytest.param(
+        ["member", "revoke", "target", "--yes"],
+        "revoke",
+        id="revoke",
+    ),
+    pytest.param(
+        ["member", "rotate-token", "target"],
+        "rotate_token",
+        id="rotate-token",
+    ),
+]
+
+
+# ── master 성공 회귀 ─────────────────────────────────────────────────────
+
+
+class TestMasterAllowed:
+    @pytest.mark.parametrize("cli_args,method_name", ADMIN_COMMANDS)
+    def test_master_invokes_service(
+        self, cli_args: list[str], method_name: str
+    ) -> None:
+        ctx, method = _patch_service(method_name)
+        with ctx:
+            result = _invoke_with_member(cli_args, _master())
+        # set-emoji 도 master 통과 가능 (HUMAN+master).
+        assert result.exit_code == 0, (
+            f"master 실행이 실패: exit={result.exit_code} output={result.output!r} "
+            f"exc={result.exception!r}"
+        )
+        assert method.await_count >= 1, (
+            f"master 통과 시 service.{method_name} 가 호출되어야 한다"
+        )
+
+
+# ── member:admin scope agent → 거부 ─────────────────────────────────────
+
+
+class TestMemberAdminScopeAgentDenied:
+    """``member:admin`` scope 보유 agent 도 master-only 표면 가드에서 거부.
+
+    #1543 핵심 회귀: 이전에는 ``@require_scope("member:admin")`` 가 통과시키고
+    service ``_assert_master`` 가 런타임에서 거부했다. 본 패치 이후엔
+    ``@require_master`` 가 표면에서 즉시 거부 + service 호출 없음.
+    """
+
+    @pytest.mark.parametrize("cli_args,method_name", ADMIN_COMMANDS)
+    def test_member_admin_scope_agent_denied(
+        self, cli_args: list[str], method_name: str
+    ) -> None:
+        ctx, method = _patch_service(method_name)
+        with ctx:
+            result = _invoke_with_member(cli_args, _agent_with_admin_scope())
+        assert result.exit_code == 1, (
+            f"``member:admin`` agent 실행이 거부되지 않음: exit={result.exit_code} "
+            f"output={result.output!r}"
+        )
+        # 표면 가드가 service 호출 전에 거부해야 한다.
+        assert method.await_count == 0, (
+            f"``member:admin`` agent 거부 시 service.{method_name} 미호출이어야 한다 "
+            f"(awaits={method.await_count})"
+        )
+
+
+class TestNonMasterHumanDenied:
+    @pytest.mark.parametrize("cli_args,method_name", ADMIN_COMMANDS)
+    def test_human_admin_denied(self, cli_args: list[str], method_name: str) -> None:
+        ctx, method = _patch_service(method_name)
+        with ctx:
+            result = _invoke_with_member(cli_args, _human_admin())
+        assert result.exit_code == 1, (
+            f"non-master human 실행이 거부되지 않음: exit={result.exit_code} "
+            f"output={result.output!r}"
+        )
+        assert method.await_count == 0
+
+
+class TestNonMasterAgentDenied:
+    @pytest.mark.parametrize("cli_args,method_name", ADMIN_COMMANDS)
+    def test_agent_no_scope_denied(self, cli_args: list[str], method_name: str) -> None:
+        ctx, method = _patch_service(method_name)
+        with ctx:
+            result = _invoke_with_member(cli_args, _agent_no_scope())
+        assert result.exit_code == 1
+        assert method.await_count == 0

--- a/tests/unit/test_member_admin_master_only.py
+++ b/tests/unit/test_member_admin_master_only.py
@@ -15,6 +15,18 @@ admin mutation 7 web routes / 6 CLI commands 는 표면 가드에서 master-only
 #1511 oracle drift 의 핵심 시그니처: 이전에는 ``member:admin`` agent 가
 표면 가드를 통과해 ``MemberService._assert_master`` 가 런타임에서 거부했다.
 본 패치 이후엔 표면 가드에서 즉시 차단되어 service 호출이 일어나지 않는다.
+
+Case count (pytest collect 기준): **41 cases** =
+  - 7 web routes × 5 personas (master / member:admin agent / non-master
+    human / non-master agent / unauth) = 35 (parametrize 확장)
+  - + 6 standalone (TestAuthBeforeBodyValidation: create-invalid-body /
+    create-malformed-json / update_scopes-invalid-body /
+    change_password-invalid-body / change_password-invalid-credential /
+    member:admin-agent-invalid-body) = 6
+  - 합계 41
+이전 보고서에 53 cases 로 잘못 기재되었던 것을 #1543 Codex 브랜치 리뷰
+finding 2 에 따라 41 로 정정한다 (matrix 자체는 변경 없음 — 산수 오류 정정).
+CLI 측 회귀는 별도 ``test_cli_member_master_only.py`` (24 cases) 에서 다룬다.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_member_admin_master_only.py
+++ b/tests/unit/test_member_admin_master_only.py
@@ -1,0 +1,525 @@
+"""member admin mutation 표면 가드 master-only 회귀 테스트 (#1543).
+
+#1542 spec 결정 (`docs/specs/web-api/11-route-scope-table.md`) 에 따라 member
+admin mutation 7 web routes / 6 CLI commands 는 표면 가드에서 master-only 로
+정렬되어야 한다. 이 invariant 는 다음 매트릭스로 검증한다:
+
+- master Bearer (HUMAN+master) → 200/201 (정상 mutation 결과)
+- ``member:admin`` scope 보유 agent → 403 + service 미호출
+- non-master human (예: admin role) → 403 + service 미호출
+- non-master agent without scope → 403 + service 미호출
+- unauthenticated → 401 + service 미호출
+- unauthenticated + invalid body → 401 (auth before validation)
+- unauthenticated + invalid JSON → 401 (auth before parsing)
+
+#1511 oracle drift 의 핵심 시그니처: 이전에는 ``member:admin`` agent 가
+표면 가드를 통과해 ``MemberService._assert_master`` 가 런타임에서 거부했다.
+본 패치 이후엔 표면 가드에서 즉시 차단되어 service 호출이 일어나지 않는다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ante.member.errors import PermissionDeniedError  # noqa: E402
+from ante.web.app import create_app  # noqa: E402
+
+
+@dataclass
+class FakeMember:
+    member_id: str
+    type: str = "agent"
+    role: str = "default"
+    org: str = "default"
+    name: str = ""
+    emoji: str = ""
+    status: str = "active"
+    scopes: list[str] = field(default_factory=list)
+    token_hash: str = ""
+    password_hash: str = ""
+    recovery_key_hash: str = ""
+    created_at: str = ""
+    created_by: str = ""
+    last_active_at: str = ""
+    suspended_at: str = ""
+    revoked_at: str = ""
+    token_expires_at: str = ""
+
+
+class FakeMemberService:
+    """master-only 표면 가드 회귀용 stub.
+
+    토큰 → member_id 매핑으로 ``authenticate`` 흉내. mutation 메서드별 호출
+    회수를 추적해, 표면 가드가 service 호출을 차단했는지 확인한다.
+    """
+
+    def __init__(self) -> None:
+        self._members: dict[str, FakeMember] = {}
+        self._tokens: dict[str, str] = {}
+        self._token_counter = 0
+        self.register_calls: list[dict[str, object]] = []
+        self.suspend_calls: list[dict[str, str]] = []
+        self.reactivate_calls: list[dict[str, str]] = []
+        self.revoke_calls: list[dict[str, str]] = []
+        self.rotate_calls: list[dict[str, str]] = []
+        self.update_scopes_calls: list[dict[str, object]] = []
+        self.change_password_calls: list[dict[str, str]] = []
+
+    def add_member(
+        self,
+        member_id: str,
+        token: str = "",
+        role: str = "default",
+        member_type: str = "agent",
+        status: str = "active",
+        scopes: list[str] | None = None,
+        password_hash: str = "",
+    ) -> FakeMember:
+        member = FakeMember(
+            member_id=member_id,
+            role=role,
+            type=member_type,
+            status=status,
+            scopes=list(scopes) if scopes else [],
+            password_hash=password_hash,
+        )
+        self._members[member_id] = member
+        if token:
+            self._tokens[token] = member_id
+        return member
+
+    async def authenticate(self, token: str) -> FakeMember:
+        member_id = self._tokens.get(token)
+        if member_id is None:
+            raise PermissionError("유효하지 않은 토큰")
+        return self._members[member_id]
+
+    async def update_last_active(self, member_id: str) -> None:
+        return None
+
+    async def get(self, member_id: str) -> FakeMember | None:
+        return self._members.get(member_id)
+
+    def _assert_master_or_raise(self, caller_id: str, action: str) -> None:
+        """defense-in-depth — 정상 흐름에서는 표면 가드가 먼저 차단한다."""
+        caller = self._members.get(caller_id)
+        if caller is None or caller.role != "master":
+            raise PermissionDeniedError(
+                f"'{action}'은(는) master만 수행할 수 있습니다."
+            )
+
+    async def register(self, **kwargs: object) -> tuple[FakeMember, str]:
+        self.register_calls.append(dict(kwargs))
+        registered_by = str(kwargs.get("registered_by", ""))
+        self._assert_master_or_raise(registered_by, "register")
+        member_id = str(kwargs.get("member_id", ""))
+        member_type = str(kwargs.get("member_type", "agent"))
+        member = FakeMember(
+            member_id=member_id,
+            type=member_type,
+            role=str(kwargs.get("role", "default")),
+        )
+        self._members[member_id] = member
+        self._token_counter += 1
+        return member, f"ante_ak_{self._token_counter}"
+
+    async def suspend(self, member_id: str, suspended_by: str = "") -> FakeMember:
+        self.suspend_calls.append(
+            {"member_id": member_id, "suspended_by": suspended_by}
+        )
+        self._assert_master_or_raise(suspended_by, "suspend")
+        member = self._members[member_id]
+        member.status = "suspended"
+        return member
+
+    async def reactivate(self, member_id: str, reactivated_by: str = "") -> FakeMember:
+        self.reactivate_calls.append(
+            {"member_id": member_id, "reactivated_by": reactivated_by}
+        )
+        self._assert_master_or_raise(reactivated_by, "reactivate")
+        member = self._members[member_id]
+        member.status = "active"
+        return member
+
+    async def revoke(self, member_id: str, revoked_by: str = "") -> FakeMember:
+        self.revoke_calls.append({"member_id": member_id, "revoked_by": revoked_by})
+        self._assert_master_or_raise(revoked_by, "revoke")
+        member = self._members[member_id]
+        member.status = "revoked"
+        return member
+
+    async def rotate_token(
+        self, member_id: str, rotated_by: str = ""
+    ) -> tuple[FakeMember, str]:
+        self.rotate_calls.append({"member_id": member_id, "rotated_by": rotated_by})
+        self._assert_master_or_raise(rotated_by, "rotate_token")
+        self._token_counter += 1
+        return self._members[member_id], f"ante_ak_{self._token_counter}"
+
+    async def update_scopes(
+        self, member_id: str, scopes: list[str], updated_by: str = ""
+    ) -> FakeMember:
+        self.update_scopes_calls.append(
+            {"member_id": member_id, "scopes": list(scopes), "updated_by": updated_by}
+        )
+        self._assert_master_or_raise(updated_by, "update_scopes")
+        member = self._members[member_id]
+        member.scopes = list(scopes)
+        return member
+
+    async def change_password(
+        self, member_id: str, old_password: str, new_password: str
+    ) -> None:
+        self.change_password_calls.append(
+            {
+                "member_id": member_id,
+                "old_password": old_password,
+                "new_password": new_password,
+            }
+        )
+        member = self._members.get(member_id)
+        if member is None:
+            raise ValueError(f"멤버를 찾을 수 없습니다: {member_id}")
+        member.password_hash = new_password
+
+
+@pytest.fixture
+def member_service() -> FakeMemberService:
+    svc = FakeMemberService()
+    svc.add_member(
+        "master-user", token="master-token", role="master", member_type="human"
+    )
+    # ``member:admin`` scope 를 보유한 agent — 표면 가드는 거부해야 한다.
+    svc.add_member(
+        "agent-with-admin-scope",
+        token="agent-admin-token",
+        role="default",
+        member_type="agent",
+        scopes=["member:admin"],
+    )
+    # non-master human (admin role) — master 가 아니므로 표면 가드 거부.
+    svc.add_member(
+        "human-admin",
+        token="human-admin-token",
+        role="admin",
+        member_type="human",
+    )
+    # non-master agent without scope.
+    svc.add_member(
+        "agent-no-scope",
+        token="agent-no-scope-token",
+        role="default",
+        member_type="agent",
+    )
+    # mutation 대상 멤버
+    svc.add_member("target-active", role="default", status="active")
+    svc.add_member("target-suspended", role="default", status="suspended")
+    svc.add_member(
+        "target-human-active",
+        role="default",
+        member_type="human",
+        status="active",
+        password_hash="known-old-password",
+    )
+    return svc
+
+
+@pytest.fixture
+def client(member_service: FakeMemberService) -> TestClient:
+    app = create_app(member_service=member_service)
+    return TestClient(app)
+
+
+# ── 라우트 헬퍼 ──────────────────────────────────────────────────────────
+
+
+def _create(client: TestClient, headers: dict | None = None) -> httpx.Response:
+    return client.post(
+        "/api/members",
+        json={"member_id": "new-agent-1543", "member_type": "agent"},
+        headers=headers or {},
+    )
+
+
+def _suspend(client: TestClient, headers: dict | None = None) -> httpx.Response:
+    return client.post("/api/members/target-active/suspend", headers=headers or {})
+
+
+def _reactivate(client: TestClient, headers: dict | None = None) -> httpx.Response:
+    return client.post(
+        "/api/members/target-suspended/reactivate", headers=headers or {}
+    )
+
+
+def _revoke(client: TestClient, headers: dict | None = None) -> httpx.Response:
+    return client.post("/api/members/target-active/revoke", headers=headers or {})
+
+
+def _rotate(client: TestClient, headers: dict | None = None) -> httpx.Response:
+    return client.post("/api/members/target-active/rotate-token", headers=headers or {})
+
+
+def _update_scopes(
+    client: TestClient,
+    headers: dict | None = None,
+    payload: dict | None = None,
+) -> httpx.Response:
+    return client.put(
+        "/api/members/target-active/scopes",
+        json=payload if payload is not None else {"scopes": ["data:read"]},
+        headers=headers or {},
+    )
+
+
+def _change_password(
+    client: TestClient,
+    headers: dict | None = None,
+    payload: dict | None = None,
+) -> httpx.Response:
+    return client.patch(
+        "/api/members/target-human-active/password",
+        json=payload
+        if payload is not None
+        else {"old_password": "known-old-password", "new_password": "new-password"},
+        headers=headers or {},
+    )
+
+
+# (route_id, helper, calls_attr, expected_success_status)
+ALL_ADMIN_MUTATION_ROUTES = [
+    ("create", _create, "register_calls", 201),
+    ("suspend", _suspend, "suspend_calls", 200),
+    ("reactivate", _reactivate, "reactivate_calls", 200),
+    ("revoke", _revoke, "revoke_calls", 200),
+    ("rotate_token", _rotate, "rotate_calls", 200),
+    ("update_scopes", _update_scopes, "update_scopes_calls", 200),
+    ("change_password", _change_password, "change_password_calls", 200),
+]
+
+
+# ── master 성공 회귀 ─────────────────────────────────────────────────────
+
+
+class TestMasterAllowed:
+    """master Bearer 토큰 → 정상 mutation 통과."""
+
+    @pytest.mark.parametrize(
+        "name,call,calls_attr,expected_status",
+        ALL_ADMIN_MUTATION_ROUTES,
+        ids=[r[0] for r in ALL_ADMIN_MUTATION_ROUTES],
+    )
+    def test_master_bearer_succeeds(
+        self,
+        client: TestClient,
+        member_service: FakeMemberService,
+        name: str,
+        call,
+        calls_attr: str,
+        expected_status: int,
+    ) -> None:
+        resp = call(client, headers={"Authorization": "Bearer master-token"})
+        assert resp.status_code == expected_status, (
+            f"{name}: master Bearer 가 {expected_status} 가 아님 "
+            f"({resp.status_code}: {resp.text})"
+        )
+        # service 까지 도달해야 한다.
+        assert len(getattr(member_service, calls_attr)) >= 1, (
+            f"{name}: master 통과 시 service 가 호출되어야 한다"
+        )
+
+
+# ── member:admin scope agent → 403 (#1543 핵심 회귀) ─────────────────────
+
+
+class TestMemberAdminScopeAgent403:
+    """``member:admin`` scope 보유 agent → 403 (master-only 표면 가드).
+
+    #1511 oracle drift 의 핵심 시그니처. 이전에는 표면 가드가 ``member:admin``
+    scope 를 통과시키고 ``MemberService._assert_master`` 가 런타임에서 거부했다
+    (contract drift). 본 패치 이후 표면 가드에서 즉시 403 + service 미호출.
+    """
+
+    @pytest.mark.parametrize(
+        "name,call,calls_attr,expected_status",
+        ALL_ADMIN_MUTATION_ROUTES,
+        ids=[r[0] for r in ALL_ADMIN_MUTATION_ROUTES],
+    )
+    def test_member_admin_scope_agent_returns_403_without_service_call(
+        self,
+        client: TestClient,
+        member_service: FakeMemberService,
+        name: str,
+        call,
+        calls_attr: str,
+        expected_status: int,
+    ) -> None:
+        resp = call(client, headers={"Authorization": "Bearer agent-admin-token"})
+        assert resp.status_code == 403, (
+            f"{name}: ``member:admin`` agent 가 403 이 아님 "
+            f"({resp.status_code}: {resp.text})"
+        )
+        # 표면 가드가 service 호출 전에 차단해야 한다 (contract drift 회귀 보호).
+        assert len(getattr(member_service, calls_attr)) == 0, (
+            f"{name}: ``member:admin`` agent 차단 시 service mutation 호출되어선 "
+            f"안 된다 — 호출 기록: {getattr(member_service, calls_attr)}"
+        )
+
+
+class TestNonMasterHuman403:
+    """non-master human (admin role) → 403 + service 미호출."""
+
+    @pytest.mark.parametrize(
+        "name,call,calls_attr,expected_status",
+        ALL_ADMIN_MUTATION_ROUTES,
+        ids=[r[0] for r in ALL_ADMIN_MUTATION_ROUTES],
+    )
+    def test_non_master_human_returns_403_without_service_call(
+        self,
+        client: TestClient,
+        member_service: FakeMemberService,
+        name: str,
+        call,
+        calls_attr: str,
+        expected_status: int,
+    ) -> None:
+        resp = call(client, headers={"Authorization": "Bearer human-admin-token"})
+        assert resp.status_code == 403, (
+            f"{name}: non-master human 이 403 이 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert len(getattr(member_service, calls_attr)) == 0
+
+
+class TestNonMasterAgentNoScope403:
+    """non-master agent without scope → 403 + service 미호출."""
+
+    @pytest.mark.parametrize(
+        "name,call,calls_attr,expected_status",
+        ALL_ADMIN_MUTATION_ROUTES,
+        ids=[r[0] for r in ALL_ADMIN_MUTATION_ROUTES],
+    )
+    def test_non_master_agent_returns_403_without_service_call(
+        self,
+        client: TestClient,
+        member_service: FakeMemberService,
+        name: str,
+        call,
+        calls_attr: str,
+        expected_status: int,
+    ) -> None:
+        resp = call(client, headers={"Authorization": "Bearer agent-no-scope-token"})
+        assert resp.status_code == 403, (
+            f"{name}: non-master agent 가 403 이 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert len(getattr(member_service, calls_attr)) == 0
+
+
+# ── unauthenticated → 401 + auth-first 회귀 ──────────────────────────────
+
+
+class TestUnauthenticated401:
+    """인증 없음 → 401 + service 미호출."""
+
+    @pytest.mark.parametrize(
+        "name,call,calls_attr,expected_status",
+        ALL_ADMIN_MUTATION_ROUTES,
+        ids=[r[0] for r in ALL_ADMIN_MUTATION_ROUTES],
+    )
+    def test_unauthenticated_returns_401_without_service_call(
+        self,
+        client: TestClient,
+        member_service: FakeMemberService,
+        name: str,
+        call,
+        calls_attr: str,
+        expected_status: int,
+    ) -> None:
+        resp = call(client)
+        assert resp.status_code == 401, (
+            f"{name}: 인증 없음 이 401 이 아님 ({resp.status_code}: {resp.text})"
+        )
+        assert len(getattr(member_service, calls_attr)) == 0
+
+
+class TestAuthBeforeBodyValidation:
+    """인증 가드는 body validation 보다 먼저 실행된다.
+
+    각 라우트가 raw-body 패턴으로 ``Depends(require_master_caller)`` 를 우선
+    수행하는지 회귀 검증. unauthenticated + invalid body → 401 (NOT 422).
+    create / update_scopes / change_password 가 raw body 파싱 패턴을 사용하므로
+    핵심 대상이다.
+    """
+
+    def test_create_unauth_invalid_body_returns_401(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        resp = client.post("/api/members", json={"unexpected": "field"})
+        assert resp.status_code == 401, resp.text
+        assert member_service.register_calls == []
+
+    def test_create_unauth_malformed_json_returns_401(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        resp = client.post(
+            "/api/members",
+            content=b"not-json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 401
+        assert member_service.register_calls == []
+
+    def test_update_scopes_unauth_invalid_body_returns_401(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        resp = client.put(
+            "/api/members/target-active/scopes",
+            json={"not_scopes": ["x"]},
+        )
+        assert resp.status_code == 401
+        assert member_service.update_scopes_calls == []
+
+    def test_change_password_unauth_invalid_body_returns_401(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        resp = client.patch(
+            "/api/members/target-human-active/password",
+            json={"not_old_password": "x"},
+        )
+        assert resp.status_code == 401
+        assert member_service.change_password_calls == []
+
+    def test_change_password_unauth_invalid_credential_returns_401(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        """unauth + wrong old_password → 401 (credential check 우회 차단).
+
+        oracle A7 (#1377) 핵심 시그니처가 #1543 master-only 정렬 이후에도
+        보존되는지 확인한다.
+        """
+        resp = client.patch(
+            "/api/members/target-human-active/password",
+            json={"old_password": "wrong", "new_password": "anything"},
+        )
+        assert resp.status_code == 401
+        assert member_service.change_password_calls == []
+
+    def test_member_admin_scope_agent_invalid_body_returns_403(
+        self, client: TestClient, member_service: FakeMemberService
+    ) -> None:
+        """``member:admin`` agent + invalid body → 403 (auth 가드가 body 보다 먼저).
+
+        agent 는 인증은 통과하지만 표면 가드가 거부하므로 body validation 단계
+        (422) 가 아닌 권한 거부 (403) 가 응답된다.
+        """
+        resp = client.post(
+            "/api/members",
+            json={"unexpected": "field"},
+            headers={"Authorization": "Bearer agent-admin-token"},
+        )
+        assert resp.status_code == 403, resp.text
+        assert member_service.register_calls == []

--- a/tests/unit/test_member_api.py
+++ b/tests/unit/test_member_api.py
@@ -177,11 +177,12 @@ def member_service():
 def client(member_service):
     """인증 컨텍스트가 미리 주입된 기본 클라이언트.
 
-    member 라우트 전체는 #1407 이후 인증된 master/member:* scope 호출자를 전제
-    로 한다. middleware 가 매 요청마다 다음 두 가지를 수행한다:
+    member 라우트 전체는 #1543 이후 인증된 master 호출자 (mutation) 또는
+    ``member:read`` scope 보유 호출자 (read) 를 전제로 한다. middleware 가 매
+    요청마다 다음 두 가지를 수행한다:
 
     1. ``request.state.member_id = "master-user"`` 를 주입한다 — Bearer 인증
-       미들웨어가 채우는 자리를 모방해 ``require_member_admin`` /
+       미들웨어가 채우는 자리를 모방해 ``require_master_caller`` /
        ``require_member_read`` 가 caller 를 결정할 수 있게 한다.
     2. ``member_service.get("master-user")`` 가 role=master 인 synthetic 멤버를
        반환하도록 패치한다 — scope dependency 가 caller 의 role 검증을 통과할
@@ -418,9 +419,10 @@ class TestCallerIdPropagation:
     def test_register_passes_caller_id(self, member_service):
         """인증된 사용자의 member_id가 registered_by로 전달.
 
-        #1407 이후 ``require_member_admin`` 의존성이 ``member_service.get(caller)``
+        #1543 이후 ``require_master_caller`` 의존성이 ``member_service.get(caller)``
         로 caller 의 role 을 검증하므로 ``master-user`` (role=master) 를 service
-        에 등록해 둬야 한다.
+        에 등록해 둬야 한다 (#1407 ``require_member_admin`` → #1543 master-only
+        재정렬).
         """
         captured: dict[str, str] = {}
         original_register = member_service.register
@@ -430,7 +432,7 @@ class TestCallerIdPropagation:
             return await original_register(**kwargs)
 
         member_service.register = spy_register
-        # #1407: require_member_admin 이 master-user 의 role 을 검증한다.
+        # #1543: require_master_caller 가 master-user 의 role 을 검증한다.
         member_service._members["master-user"] = FakeMember(
             member_id="master-user", role="master"
         )
@@ -453,9 +455,10 @@ class TestCallerIdPropagation:
     def test_update_scopes_passes_caller_id(self, member_service):
         """인증된 사용자의 member_id가 updated_by로 전달.
 
-        #1407 이후 ``require_member_admin`` 의존성이 ``member_service.get(caller)``
-        로 caller 의 role/scope 를 검증하므로 ``master-user`` (role=master) 를
-        서비스에 등록해 둬야 한다.
+        #1543 이후 ``require_master_caller`` 의존성이 ``member_service.get(caller)``
+        로 caller 의 role 을 검증하므로 ``master-user`` (role=master) 를
+        서비스에 등록해 둬야 한다 (#1407 ``require_member_admin`` → #1543
+        master-only 재정렬).
         """
         captured: dict[str, str] = {}
         original_update = member_service.update_scopes
@@ -466,7 +469,7 @@ class TestCallerIdPropagation:
 
         member_service.update_scopes = spy_update
         member_service._members["agent-01"] = FakeMember(member_id="agent-01")
-        # #1407: require_member_admin 이 master-user 의 role 을 검증한다.
+        # #1543: require_master_caller 가 master-user 의 role 을 검증한다.
         member_service._members["master-user"] = FakeMember(
             member_id="master-user", role="master"
         )

--- a/tests/unit/test_member_routes_create_auth.py
+++ b/tests/unit/test_member_routes_create_auth.py
@@ -347,11 +347,12 @@ class TestCreateMemberAuthGuard:
         client: TestClient,
         member_service: FakeMemberService,
     ) -> None:
-        """일반 멤버의 세션 쿠키 + member:admin scope 없음 → 403.
+        """일반 멤버 (non-master) 의 세션 쿠키 → 403.
 
-        #1407 이후 ``require_member_admin`` 의존성이 web layer 에서 먼저
+        #1543 이후 ``require_master_caller`` 의존성이 web layer 에서 먼저
         403 을 raise 하므로 ``register`` 는 호출되지 않는다. 세션 쿠키 인증
-        자체는 통과(401 아님)했음을 status code 로 확인한다.
+        자체는 통과(401 아님)했음을 status code 로 확인한다. ``member:admin``
+        scope 보유 agent 도 동일하게 거부된다 (#1542 master-only 계약).
         """
         client.cookies.set("ante_session", "agent-session-id")
         resp = client.post("/api/members", json=_payload())

--- a/tests/unit/test_member_routes_mutation_auth.py
+++ b/tests/unit/test_member_routes_mutation_auth.py
@@ -615,13 +615,15 @@ class TestSessionCookieMasterSuccess:
 
 
 class TestNonMaster403:
-    """인증된 non-master + member:admin scope 없음 → 403 (web layer 차단).
+    """인증된 non-master → 403 (web layer 차단, master-only 표면 가드).
 
-    #1407 이후 5개 mutation route (suspend / reactivate / revoke / rotate_token /
-    update_scopes) 는 ``require_member_admin`` 의존성으로 web layer 에서 먼저
-    403 을 raise 한다. 따라서 service 호출은 일어나지 않는다.
+    #1543 이후 6개 mutation route (suspend / reactivate / revoke / rotate_token /
+    update_scopes / change_password) 는 ``require_master_caller`` 의존성으로 web
+    layer 에서 먼저 403 을 raise 한다. 따라서 service 호출은 일어나지 않는다.
 
-    ``change_password`` 도 ``require_member_admin`` 로 동일한 동작.
+    ``member:admin`` scope 를 보유한 agent 도 표면 가드에서 거부된다 (#1542
+    spec 결정 — master-only 계약). 별도 ``TestMemberAdminScopeAgent403`` 에서
+    명시적으로 회귀를 잠근다.
     """
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1543

## Summary

#1542 (PR #1554)에서 master-only 계약을 docs로 정리한 데 이어, Web API/CLI 표면 권한 가드도 master-only로 정렬한다. `require_member_admin` (= `require_scope("member:admin")`)이 표면에서 `member:admin` agent 통과를 허용하지만 `MemberService._assert_master`가 service layer에서 403으로 거부하는 drift를 해소.

핵심 변경 (14 files, +1072 / -143):

- **Web API** (`src/ante/web/routes/members.py`): 7 routes의 `Depends(require_member_admin)` → `Depends(require_master_caller)` 교체.
- **Web API deps** (`src/ante/web/deps.py`): `require_member_admin = require_master_caller` backward compat alias 유지.
- **CLI middleware** (`src/ante/cli/middleware.py`): 신규 `require_master` decorator (HUMAN+master role check, 자체 `_require_master_applied` sentinel).
- **CLI commands** (`src/ante/cli/commands/member.py`): 6 commands `@require_scope("member:admin")` → `@require_master`.
- **Frontend artifact 자동 재생성**: `frontend/openapi.json`, `frontend/src/types/api.generated.ts`, `guide/cli.md` (member:admin agent 허용 문구 사라짐).
- **신규 테스트 65건**: `test_member_admin_master_only.py` 41 cases (7 routes × 5 personas + 6 auth-before-body) + `test_cli_member_master_only.py` 24 cases (6 commands × 4 personas).
- **기존 테스트 docstring 갱신**: 3 파일 (#1407 → #1543 master-only 재정렬 명시).

`MemberService._assert_master` 런타임 invariant 보존 (defense-in-depth). `member:admin` scope vocabulary 유지 (#1542 reserved 결정).

후속:
- #1544 — Oracle probe 기대값 정렬 (이번 PR scope 밖).

## Test Plan

- [x] `pytest tests/unit -q` 전체 회귀 (5694 passed / 4 skipped, 신규 +65)
- [x] `pytest tests/unit/test_member_admin_master_only.py tests/unit/test_cli_member_master_only.py -v` (65 passed)
- [x] `ruff check src tests` / `ruff format --check src tests`
- [x] `mypy src` (239 files, no issues)
- [x] `python scripts/generate_project_structure.py --check`
- [x] frontend openapi.json diff 확인 (member:admin agent 허용 문구 제거)
- [x] Codex `/codex:review --base main` PASS (attempt 2; attempt 1은 require_master sentinel + 카운트 finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)