### PR TITLE
fix(cli): exit 1 on bot positions for missing bot (#1558)

### DIFF
--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -388,7 +388,7 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
     """봇 보유 포지션 조회."""
     fmt = get_formatter(ctx)
 
-    async def _run_positions() -> list[dict]:
+    async def _run_positions() -> list[dict] | None:
         from ante.cli.main import get_db_path
         from ante.core.database import Database
         from ante.trade.performance import PerformanceTracker
@@ -399,6 +399,15 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
         db = Database(get_db_path())
         await db.connect()
         try:
+            # 미존재 bot 을 "실재 bot 의 0 포지션" 과 구분하기 위해 포지션 조회
+            # 전에 bot 존재를 먼저 확인한다. 미존재면 sentinel ``None`` 을
+            # 반환하고, 실재 bot 이면 (0개 포함) list 를 반환한다 (#1558).
+            bot_row = await db.fetch_one(
+                "SELECT 1 FROM bots WHERE bot_id = ?", (bot_id,)
+            )
+            if bot_row is None:
+                return None
+
             position_history = PositionHistory(db)
             await position_history.initialize()
             recorder = TradeRecorder(db, position_history)
@@ -421,7 +430,14 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
 
     result = _run(_run_positions())
 
+    if result is None:
+        # 미존재 bot: 형제 명령(`bot info`/`bot remove`)과 동일하게
+        # code 없는 에러 메시지 + exit 1 (#1558).
+        fmt.error(f"봇을 찾을 수 없습니다: {bot_id}")
+        ctx.exit(1)
+
     if not result:
+        # 실재 bot, 0 포지션: 기존 계약(exit 0 + "보유 포지션 없음") 유지.
         fmt.output({"message": "보유 포지션 없음", "positions": []})
         return
 

--- a/src/ante/cli/commands/bot.py
+++ b/src/ante/cli/commands/bot.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sqlite3
 from pathlib import Path
 
 import click
@@ -402,9 +403,22 @@ def bot_positions(ctx: click.Context, bot_id: str) -> None:
             # 미존재 bot 을 "실재 bot 의 0 포지션" 과 구분하기 위해 포지션 조회
             # 전에 bot 존재를 먼저 확인한다. 미존재면 sentinel ``None`` 을
             # 반환하고, 실재 bot 이면 (0개 포함) list 를 반환한다 (#1558).
-            bot_row = await db.fetch_one(
-                "SELECT 1 FROM bots WHERE bot_id = ?", (bot_id,)
-            )
+            #
+            # ``bots`` 테이블은 ``BotManager.initialize()`` 에서만 생성되는데,
+            # 이 경로는 raw ``Database`` 만 쓰고 ``BotManager`` 를 초기화하지
+            # 않는다(예: ``ante init`` 직후). 테이블 자체가 없으면 정의상
+            # 해당 bot_id 는 존재할 수 없으므로 미존재 bot 과 동일하게
+            # 정규화한다(=sentinel ``None``). 단, malformed db 같은 다른
+            # ``OperationalError`` 까지 삼키지 않도록 "no such table" 메시지
+            # 일 때로만 좁힌다 (#1558).
+            try:
+                bot_row = await db.fetch_one(
+                    "SELECT 1 FROM bots WHERE bot_id = ?", (bot_id,)
+                )
+            except sqlite3.OperationalError as e:
+                if "no such table" in str(e).lower():
+                    return None
+                raise
             if bot_row is None:
                 return None
 

--- a/tests/unit/cli/test_bot_create_exit_code.py
+++ b/tests/unit/cli/test_bot_create_exit_code.py
@@ -21,21 +21,50 @@ Coverage map:
       - JSON 모드: stdout JSON envelope + exit 1.
       - text 모드: stderr ``Error: ...`` + exit 1.
 
+``ante bot positions`` missing-bot exit code 회귀 (#1558):
+    ``ante --format json bot positions oracle-missing-bot`` 호출이
+    missing-resource 오류가 아니라 exit 0 + ``{"message":"보유 포지션 없음",
+    "positions":[]}`` 을 반환해 미존재 bot 이 "실재 bot 의 0 포지션" 과
+    구분되지 않는 결함이 있었다 (``bot_positions`` 가 ``get_positions`` 호출
+    전 bot 존재 확인을 하지 않고 빈 list 를 성공 메시지로 정규화).
+
+    형제 명령(``bot info`` ``bot.py:138-140`` / ``bot remove``
+    ``bot.py:329-330``)과 동일하게 미존재 bot 만 code 없는
+    ``봇을 찾을 수 없습니다: <id>`` 에러 + exit 1 로 분기되고, **실재 bot 의
+    0 포지션은 기존 계약(exit 0 + "보유 포지션 없음")을 그대로 유지**함을
+    회귀 보장한다 (contract-drift 가드).
+
+Coverage map (#1558):
+    - 미존재 bot ``bot positions oracle-missing-bot``
+      - JSON 모드: stdout ``{"status":"error","code":"","message":
+        "봇을 찾을 수 없습니다: oracle-missing-bot"}`` + exit 1.
+      - text 모드: stderr ``Error: 봇을 찾을 수 없습니다: ...`` + exit 1.
+    - 실재 bot, 0 포지션: exit 0 + ``{"message":"보유 포지션 없음",
+      "positions":[]}`` 유지 (regression guard).
+    - 실재 bot, 포지션 >=1: exit 0 + ``{"positions":[...]}`` 유지.
+
 SSOT 참조:
-    - ``src/ante/cli/commands/bot.py`` (``bot_create``, ``_parse_param``)
+    - ``src/ante/cli/commands/bot.py`` (``bot_create``, ``_parse_param``,
+      ``bot_positions``, canonical missing-bot 패턴은 ``bot_info``)
     - ``src/ante/cli/formatter.py`` (``OutputFormatter.error`` 스키마)
+    - ``src/ante/bot/manager.py`` (``BOT_SCHEMA``),
+      ``src/ante/trade/position.py`` (``POSITION_SCHEMA``)
 """
 
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from click.testing import CliRunner
 
+from ante.bot.manager import BOT_SCHEMA
 from ante.cli.main import cli
 from ante.member.models import Member, MemberRole, MemberType
+from ante.trade.position import POSITION_SCHEMA
 
 _MOCK_MASTER = Member(
     member_id="test-master",
@@ -232,3 +261,172 @@ class TestBotCreateIPCExceptionExitCode:
         # text 모드: stdout 에 JSON 이 새지 않아야 한다.
         assert result.stdout.strip() == "", result.stdout
         assert "Error: IPC 연결 실패" in result.stderr, result.stderr
+
+
+# ── bot positions missing-bot exit code 회귀 (#1558) ────────────────────────
+
+
+_MISSING_BOT_ID = "oracle-missing-bot"
+_REAL_BOT_ID = "real-bot-1"
+_BOT_NOT_FOUND_MESSAGE = f"봇을 찾을 수 없습니다: {_MISSING_BOT_ID}"
+
+
+def _seed_db(db_path: Path, *, with_position: bool) -> None:
+    """``bot positions`` 가 여는 실 DB 를 미리 시드한다.
+
+    - ``bots`` 테이블에 ``_REAL_BOT_ID`` 만 넣는다 (``_MISSING_BOT_ID`` 는
+      넣지 않아 미존재 상태를 만든다).
+    - ``with_position`` 이면 ``positions`` 에 실재 bot 의 포지션 1건을 넣는다.
+      아니면 0 포지션 (실재 bot, 빈 결과) 상태로 둔다.
+
+    스키마는 production SSOT(``BOT_SCHEMA`` / ``POSITION_SCHEMA``) 를 그대로
+    사용한다 (테스트 로컬 DDL 하드코딩 금지).
+    """
+    import sqlite3
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(BOT_SCHEMA)
+        conn.executescript(POSITION_SCHEMA)
+        conn.execute(
+            "INSERT INTO bots (bot_id, name, strategy_id, account_id, "
+            "config_json, status) VALUES (?, ?, ?, ?, ?, ?)",
+            (_REAL_BOT_ID, "실재봇", "stg-1", "test", "{}", "created"),
+        )
+        if with_position:
+            conn.execute(
+                "INSERT INTO positions (bot_id, symbol, quantity, "
+                "avg_entry_price, realized_pnl, account_id) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (_REAL_BOT_ID, "005930", 10.0, 70000.0, 1500.0, "test"),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def seeded_db_path(tmp_path: Path) -> Iterator[Path]:
+    """시드된 DB 경로를 ``get_db_path`` 에 주입하는 fixture.
+
+    ``bot_positions._run_positions`` 는 ``from ante.cli.main import
+    get_db_path`` 를 함수 로컬 import 로 호출하므로 ``ante.cli.main.
+    get_db_path`` 모듈 속성을 패치하면 결정적으로 시드된 DB 를 연다.
+    """
+    db_path = tmp_path / "ante.db"
+    yield db_path
+
+
+def _invoke_positions(
+    runner: CliRunner,
+    db_path: Path,
+    *,
+    bot_id: str,
+    fmt: str,
+) -> object:
+    """``get_db_path`` 를 시드 DB 로 패치한 뒤 ``bot positions`` 호출."""
+    with patch("ante.cli.main.get_db_path", return_value=str(db_path)):
+        return runner.invoke(
+            cli,
+            ["--format", fmt, "bot", "positions", bot_id],
+        )
+
+
+class TestBotPositionsMissingBotExitCode:
+    """미존재 bot 은 exit 1 + ``봇을 찾을 수 없습니다`` 에러로 분기된다 (#1558).
+
+    형제 명령(``bot info`` / ``bot remove``)과 동일하게 code 없는 에러
+    메시지 + exit 1. 결함 시점에는 exit 0 + ``보유 포지션 없음`` 이었다.
+    """
+
+    def test_missing_bot_json_mode_emits_envelope_and_exits_1(
+        self, runner: CliRunner, seeded_db_path: Path
+    ) -> None:
+        """JSON 모드: stdout error envelope + exit 1 (결함 재현 케이스)."""
+        _seed_db(seeded_db_path, with_position=False)
+
+        result = _invoke_positions(
+            runner, seeded_db_path, bot_id=_MISSING_BOT_ID, fmt="json"
+        )
+
+        assert result.exit_code == 1, (
+            f"expected exit 1 for missing bot, got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        payload = _parse_json_line(result.stdout)
+        assert payload["status"] == "error", payload
+        # CLI 형제 명령 일관: 미존재 bot 에 code 미부여.
+        assert payload["code"] == "", payload
+        assert _BOT_NOT_FOUND_MESSAGE in str(payload["message"]), payload
+        # 결함 시점의 success envelope 가 더는 새지 않아야 한다.
+        assert "보유 포지션 없음" not in result.stdout, result.stdout
+
+    def test_missing_bot_text_mode_emits_stderr_and_exits_1(
+        self, runner: CliRunner, seeded_db_path: Path
+    ) -> None:
+        """text 모드: stderr ``Error: 봇을 찾을 수 없습니다: ...`` + exit 1."""
+        _seed_db(seeded_db_path, with_position=False)
+
+        result = _invoke_positions(
+            runner, seeded_db_path, bot_id=_MISSING_BOT_ID, fmt="text"
+        )
+
+        assert result.exit_code == 1, (
+            f"expected exit 1 for missing bot, got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        # text 모드: stdout 에 success/JSON 이 새지 않아야 한다.
+        assert "보유 포지션 없음" not in result.stdout, result.stdout
+        assert f"Error: {_BOT_NOT_FOUND_MESSAGE}" in result.stderr, result.stderr
+
+
+class TestBotPositionsRealBotContractUnchanged:
+    """contract-drift 가드: 실재 bot 의 0/N 포지션 출력 계약은 불변 (#1558)."""
+
+    def test_real_bot_zero_positions_keeps_exit_0_envelope(
+        self, runner: CliRunner, seeded_db_path: Path
+    ) -> None:
+        """실재 bot, 0 포지션: exit 0 + ``보유 포지션 없음`` 유지 (regression
+        guard). 미존재 bot 분기가 blanket "빈 결과 → 에러" 로 번지면 실패."""
+        _seed_db(seeded_db_path, with_position=False)
+
+        result = _invoke_positions(
+            runner, seeded_db_path, bot_id=_REAL_BOT_ID, fmt="json"
+        )
+
+        assert result.exit_code == 0, (
+            f"expected exit 0 for real bot w/ 0 positions, "
+            f"got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        # 실재 bot 0 포지션의 정상 계약은 ``fmt.output`` 으로 indent=2
+        # 멀티라인 JSON 을 출력하므로(에러 envelope 의 한 줄 형식이 아님),
+        # stdout 전체를 파싱한다.
+        payload = json.loads(result.stdout)
+        assert payload == {
+            "message": "보유 포지션 없음",
+            "positions": [],
+        }, payload
+
+    def test_real_bot_with_positions_keeps_exit_0_output(
+        self, runner: CliRunner, seeded_db_path: Path
+    ) -> None:
+        """실재 bot, 포지션 >=1: exit 0 + ``{"positions":[...]}`` 유지."""
+        _seed_db(seeded_db_path, with_position=True)
+
+        result = _invoke_positions(
+            runner, seeded_db_path, bot_id=_REAL_BOT_ID, fmt="json"
+        )
+
+        assert result.exit_code == 0, (
+            f"expected exit 0 for real bot w/ positions, "
+            f"got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        payload = json.loads(result.stdout)
+        assert isinstance(payload, dict), payload
+        assert "positions" in payload, payload
+        positions = payload["positions"]
+        assert isinstance(positions, list) and len(positions) == 1, payload
+        assert positions[0]["symbol"] == "005930", payload
+        assert positions[0]["quantity"] == 10.0, payload

--- a/tests/unit/cli/test_bot_create_exit_code.py
+++ b/tests/unit/cli/test_bot_create_exit_code.py
@@ -43,6 +43,19 @@ Coverage map (#1558):
       "positions":[]}`` 유지 (regression guard).
     - 실재 bot, 포지션 >=1: exit 0 + ``{"positions":[...]}`` 유지.
 
+``ante bot positions`` no-bots-table 정규화 회귀 (#1558, Codex P2):
+    ``_run_positions`` 가 bot 존재 선조회를 추가하면서, ``bots`` 테이블이
+    아직 생성되지 않은 DB(``BotManager.initialize()`` 미실행, 예: ``ante
+    init`` 직후)에서 ``sqlite3.OperationalError: no such table: bots`` 가
+    호출자까지 누설되는 신규 회귀가 생겼다. ``bots`` 테이블 부재 ⟹ 해당
+    bot_id 는 정의상 존재할 수 없으므로 미존재 bot 과 동일하게
+    ``봇을 찾을 수 없습니다`` + exit 1 로 정규화됨을 회귀 보장한다.
+
+Coverage map (#1558, Codex P2):
+    - bots 테이블이 없는 DB ``bot positions <any-id>``
+      - JSON 모드: stdout error envelope + exit 1 (OperationalError 누설 X).
+      - text 모드: stderr ``Error: 봇을 찾을 수 없습니다: ...`` + exit 1.
+
 SSOT 참조:
     - ``src/ante/cli/commands/bot.py`` (``bot_create``, ``_parse_param``,
       ``bot_positions``, canonical missing-bot 패턴은 ``bot_info``)
@@ -305,6 +318,26 @@ def _seed_db(db_path: Path, *, with_position: bool) -> None:
         conn.close()
 
 
+def _seed_db_without_bots_table(db_path: Path) -> None:
+    """``bots`` 테이블 DDL 만 생략한 변형 시드 (#1558, Codex P2).
+
+    ``_run_positions`` 는 raw ``Database`` 만 쓰고 ``BotManager.
+    initialize()`` 를 호출하지 않으므로, ``ante init`` 직후처럼 ``bots``
+    테이블이 아직 없는 상태가 실제로 발생한다. 그 상태를 재현하기 위해
+    DB 파일은 만들되 ``BOT_SCHEMA`` 적용만 건너뛴다. (``POSITION_SCHEMA``
+    는 선조회가 ``bots`` 에서 먼저 실패하므로 유무가 결과에 무관하지만,
+    "DB 파일은 존재한다" 는 사실관계를 명확히 하기 위해 적용한다.)
+    """
+    import sqlite3
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(POSITION_SCHEMA)
+        conn.commit()
+    finally:
+        conn.close()
+
+
 @pytest.fixture
 def seeded_db_path(tmp_path: Path) -> Iterator[Path]:
     """시드된 DB 경로를 ``get_db_path`` 에 주입하는 fixture.
@@ -430,3 +463,55 @@ class TestBotPositionsRealBotContractUnchanged:
         assert isinstance(positions, list) and len(positions) == 1, payload
         assert positions[0]["symbol"] == "005930", payload
         assert positions[0]["quantity"] == 10.0, payload
+
+
+class TestBotPositionsNoBotsTableNormalized:
+    """``bots`` 테이블 부재 DB 도 미존재 bot 으로 정규화된다 (#1558, Codex P2).
+
+    bot 존재 선조회가 ``sqlite3.OperationalError: no such table: bots`` 를
+    호출자까지 누설하지 않고, 형제 명령과 동일한 ``봇을 찾을 수 없습니다``
+    + exit 1 계약으로 흡수됨을 잠근다. 수정 전에는 OperationalError 가
+    누설되어 click 가 exit 1 (uncaught) 로 끝나거나 traceback 이 새어
+    ``봇을 찾을 수 없습니다`` 메시지 계약이 깨졌다.
+    """
+
+    def test_no_bots_table_json_mode_emits_envelope_and_exits_1(
+        self, runner: CliRunner, seeded_db_path: Path
+    ) -> None:
+        """JSON 모드: stdout error envelope + exit 1 (OperationalError 누설 X)."""
+        _seed_db_without_bots_table(seeded_db_path)
+
+        result = _invoke_positions(
+            runner, seeded_db_path, bot_id=_MISSING_BOT_ID, fmt="json"
+        )
+
+        assert result.exit_code == 1, (
+            f"expected exit 1 when bots table missing, got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        # OperationalError 가 traceback 으로 새지 않아야 한다.
+        assert "OperationalError" not in result.stdout, result.stdout
+        assert "OperationalError" not in result.stderr, result.stderr
+        assert "no such table" not in result.stdout, result.stdout
+        payload = _parse_json_line(result.stdout)
+        assert payload["status"] == "error", payload
+        assert payload["code"] == "", payload
+        assert _BOT_NOT_FOUND_MESSAGE in str(payload["message"]), payload
+
+    def test_no_bots_table_text_mode_emits_stderr_and_exits_1(
+        self, runner: CliRunner, seeded_db_path: Path
+    ) -> None:
+        """text 모드: stderr ``Error: 봇을 찾을 수 없습니다: ...`` + exit 1."""
+        _seed_db_without_bots_table(seeded_db_path)
+
+        result = _invoke_positions(
+            runner, seeded_db_path, bot_id=_MISSING_BOT_ID, fmt="text"
+        )
+
+        assert result.exit_code == 1, (
+            f"expected exit 1 when bots table missing, got {result.exit_code}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        assert "OperationalError" not in result.stdout, result.stdout
+        assert "OperationalError" not in result.stderr, result.stderr
+        assert f"Error: {_BOT_NOT_FOUND_MESSAGE}" in result.stderr, result.stderr


### PR DESCRIPTION
Closes #1558

## Summary
- `ante bot positions <missing-bot>`이 missing-resource 오류 대신 exit 0 + `{"message":"보유 포지션 없음","positions":[]}`을 반환하던 결함 수정. 미존재 bot을 "실재 bot의 0 포지션"과 구분.
- `_run_positions`에 bot 존재 선조회(`SELECT 1 FROM bots WHERE bot_id=?`) 추가, sentinel `None`(미존재) vs `[]`(실재 0개) 구분. 미존재 → `fmt.error(f"봇을 찾을 수 없습니다: {bot_id}"); ctx.exit(1)` (canonical 형제 `bot info`(bot.py:138-140) 패턴과 정확히 동일, code 없음). 실재 bot 0/N 포지션 exit 0 계약 불변.
- `bots` 테이블 미생성 DB(`BotManager.initialize()` 미실행, 예 `ante init` 직후)에서 선조회가 `sqlite3.OperationalError: no such table`로 빠지지 않도록, 해당 케이스를 미존재 bot으로 정규화(정의상 bot 부재 ⟹ 동일 missing-bot 계약). malformed db 등 다른 OperationalError는 그대로 전파.

## Plan Preflight & Review
- Codex Plan Review: approve-implement (rerun). Codex 브랜치 리뷰: attempt1 FAIL(P2 bots 테이블 부재) → attempt2 PASS.

## Test Plan
- [x] `pytest tests/unit/cli/test_bot_create_exit_code.py -q` → 10 passed (미존재 bot json/text, no-bots-table 정규화, 실재 bot 0·N 회귀 가드)
- [x] `pytest tests/unit/ -q -k "bot and position"` → 34 passed
- [x] `pytest tests/unit/ -q -k bot` → 700 passed (회귀 없음)
- [x] failing→passing 확인 (fix 미적용 시 결함 재현 FAIL → 적용 후 PASS)
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)