### PR TITLE
fix(cli): exit 1 on rule list for missing account (#1559)

### DIFF
--- a/src/ante/cli/commands/rule.py
+++ b/src/ante/cli/commands/rule.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sqlite3
 
 import click
 
@@ -120,10 +121,29 @@ def rule_list(ctx: click.Context, account_id: str, scope_filter: str | None) -> 
             # 미존재 시 동일한 AccountNotFoundError 메시지로 분기한다 — 동일
             # ACCOUNT_NOT_FOUND envelope/message 보존. db.close()는 아래
             # finally가 단독 소유한다(lifecycle 불변).
-            account_row = await db.fetch_one(
-                "SELECT 1 FROM accounts WHERE account_id = ?",
-                (account_id,),
-            )
+            #
+            # ``accounts`` 테이블은 ``AccountService.initialize()`` 의
+            # ``_CREATE_TABLE_SQL`` 에서만 생성된다. 이 경로는 raw
+            # ``Database`` 핸들만 쓰고 ``AccountService`` 를 초기화하지
+            # 않으므로, 부분 초기화/legacy DB(예: ``ante init`` 직후)에서는
+            # 테이블 자체가 없어 ``sqlite3.OperationalError: no such table:
+            # accounts`` 가 호출자까지 전파되어 ACCOUNT_NOT_FOUND 계약을
+            # 우회할 수 있다(#1559). 정의상 accounts 테이블 부재는 해당
+            # account 미존재와 동치이므로 동일한 AccountNotFoundError 로
+            # 정규화한다. 단, malformed db 같은 다른 ``OperationalError``
+            # 까지 삼키지 않도록 "no such table" 메시지일 때로만 좁힌다
+            # (#1558 에서 검증된 패턴).
+            try:
+                account_row = await db.fetch_one(
+                    "SELECT 1 FROM accounts WHERE account_id = ?",
+                    (account_id,),
+                )
+            except sqlite3.OperationalError as e:
+                if "no such table" in str(e).lower():
+                    raise AccountNotFoundError(
+                        f"계좌 '{account_id}'를 찾을 수 없습니다."
+                    ) from e
+                raise
             if account_row is None:
                 raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
 

--- a/src/ante/cli/commands/rule.py
+++ b/src/ante/cli/commands/rule.py
@@ -7,6 +7,7 @@ import logging
 
 import click
 
+from ante.account.errors import AccountNotFoundError
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
 
@@ -106,6 +107,18 @@ def rule_list(ctx: click.Context, account_id: str, scope_filter: str | None) -> 
     async def _run_list() -> list[dict]:
         engine, db = await _create_rule_engine(account_id)
         try:
+            # rule 수집과 독립적으로 account 존재를 검증한다.
+            # 미존재 account는 "실재 account의 0 rules"와 구분되어야 하며
+            # (#1559) AccountNotFoundError로 분기해 exit 1로 종료한다.
+            # 이미 열린 db 핸들을 재사용하고 db.close()는 아래 finally가
+            # 단독 소유한다(lifecycle 불변).
+            from ante.account.service import AccountService
+            from ante.eventbus.bus import EventBus
+
+            account_service = AccountService(db=db, eventbus=EventBus())
+            await account_service.initialize()
+            await account_service.get(account_id)
+
             try:
                 _load_rules_from_config(engine)
             except Exception as e:
@@ -125,9 +138,15 @@ def rule_list(ctx: click.Context, account_id: str, scope_filter: str | None) -> 
         finally:
             await db.close()
 
-    result = _run(_run_list())
+    try:
+        result = _run(_run_list())
+    except AccountNotFoundError as e:
+        fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
+        raise SystemExit(1) from e
 
     if not result:
+        # 실재 account의 0 rules는 정상 계약: exit 0 + 빈 목록 응답을
+        # 그대로 유지한다. 미존재 account만 위에서 exit 1로 분기된다(#1559).
         fmt.output({"message": "등록된 룰이 없습니다.", "rules": []})
         return
 

--- a/src/ante/cli/commands/rule.py
+++ b/src/ante/cli/commands/rule.py
@@ -110,14 +110,22 @@ def rule_list(ctx: click.Context, account_id: str, scope_filter: str | None) -> 
             # rule 수집과 독립적으로 account 존재를 검증한다.
             # 미존재 account는 "실재 account의 0 rules"와 구분되어야 하며
             # (#1559) AccountNotFoundError로 분기해 exit 1로 종료한다.
-            # 이미 열린 db 핸들을 재사용하고 db.close()는 아래 finally가
-            # 단독 소유한다(lifecycle 불변).
-            from ante.account.service import AccountService
-            from ante.eventbus.bus import EventBus
-
-            account_service = AccountService(db=db, eventbus=EventBus())
-            await account_service.initialize()
-            await account_service.get(account_id)
+            #
+            # AccountService.initialize()는 모든 non-deleted account row를
+            # materialize하며 credentials를 복호화하므로, 조회 대상과 무관한
+            # 다른 계좌의 credentials 복호화 실패가 rule list를 깨뜨릴 수
+            # 있다(정상 사용 회귀). 따라서 credentials 복호화 없이 이미 열린
+            # db 핸들로 lightweight 단건 존재 쿼리만 수행한다. 쿼리 의미는
+            # AccountService.get(account_id 단건, status 필터 없음)과 일치하며
+            # 미존재 시 동일한 AccountNotFoundError 메시지로 분기한다 — 동일
+            # ACCOUNT_NOT_FOUND envelope/message 보존. db.close()는 아래
+            # finally가 단독 소유한다(lifecycle 불변).
+            account_row = await db.fetch_one(
+                "SELECT 1 FROM accounts WHERE account_id = ?",
+                (account_id,),
+            )
+            if account_row is None:
+                raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
 
             try:
                 _load_rules_from_config(engine)

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -649,6 +650,99 @@ class TestRuleCommands:
                     "SELECT 1 FROM accounts WHERE account_id = ?",
                     ("acc-1",),
                 )
+
+    def test_rule_list_missing_accounts_table_json_exit_1(self, runner):
+        """accounts 테이블 부재 DB: JSON envelope + ACCOUNT_NOT_FOUND + exit 1.
+
+        Codex 브랜치 리뷰 attempt 2 P2: lightweight 존재 SELECT가 accounts
+        테이블이 없는 부분 초기화/legacy DB에서 ``sqlite3.OperationalError:
+        no such table: accounts`` 를 호출자까지 전파하면 신규
+        ACCOUNT_NOT_FOUND envelope/exit 1 계약을 우회한다. 정의상 테이블
+        부재 ⟹ account 미존재이므로 동일 계약으로 정규화됨을 잠근다
+        (OperationalError 비누설 가드, #1559).
+        """
+        with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
+            mock_engine = MagicMock()
+            mock_engine._global_rules = []
+            mock_engine._strategy_rules = {}
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_db.fetch_one = AsyncMock(
+                side_effect=sqlite3.OperationalError("no such table: accounts")
+            )
+            mock_svc.return_value = (mock_engine, mock_db)
+
+            with patch("ante.cli.commands.rule._load_rules_from_config"):
+                result = runner.invoke(
+                    cli,
+                    [
+                        "--format",
+                        "json",
+                        "rule",
+                        "list",
+                        "--account",
+                        "any-account",
+                    ],
+                )
+                assert result.exit_code == 1
+                data = json.loads(result.output)
+                assert data["status"] == "error"
+                assert data["code"] == "ACCOUNT_NOT_FOUND"
+                # 테이블 부재도 미존재 account와 동일 message로 정규화한다.
+                assert data["message"] == "계좌 'any-account'를 찾을 수 없습니다."
+                # raw OperationalError 텍스트가 누설되지 않는다.
+                assert "no such table" not in result.output
+                # db.close()는 finally가 단독 소유 — lifecycle 불변(#1559).
+                mock_db.close.assert_awaited()
+
+    def test_rule_list_missing_accounts_table_text_exit_1(self, runner):
+        """accounts 테이블 부재 DB: text 출력도 exit 1로 종료 (#1559)."""
+        with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
+            mock_engine = MagicMock()
+            mock_engine._global_rules = []
+            mock_engine._strategy_rules = {}
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_db.fetch_one = AsyncMock(
+                side_effect=sqlite3.OperationalError("no such table: accounts")
+            )
+            mock_svc.return_value = (mock_engine, mock_db)
+
+            with patch("ante.cli.commands.rule._load_rules_from_config"):
+                result = runner.invoke(
+                    cli,
+                    ["rule", "list", "--account", "any-account"],
+                )
+                assert result.exit_code == 1
+                assert "찾을 수 없습니다" in result.output
+                assert "no such table" not in result.output
+
+    def test_rule_list_other_operational_error_not_swallowed(self, runner):
+        """과흡수 방지: "no such table" 이외의 OperationalError는 그대로
+        전파한다(malformed db 등). ACCOUNT_NOT_FOUND로 위장하지 않는다.
+        """
+        with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
+            mock_engine = MagicMock()
+            mock_engine._global_rules = []
+            mock_engine._strategy_rules = {}
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_db.fetch_one = AsyncMock(
+                side_effect=sqlite3.OperationalError("database disk image is malformed")
+            )
+            mock_svc.return_value = (mock_engine, mock_db)
+
+            with patch("ante.cli.commands.rule._load_rules_from_config"):
+                result = runner.invoke(
+                    cli,
+                    ["rule", "list", "--account", "acc-1"],
+                )
+                # ACCOUNT_NOT_FOUND로 정규화되지 않고 그대로 전파된다.
+                assert result.exit_code != 0
+                assert isinstance(result.exception, sqlite3.OperationalError)
+                assert "ACCOUNT_NOT_FOUND" not in (result.output or "")
+                # db.close()는 finally가 단독 소유 — lifecycle 불변(#1559).
+                mock_db.close.assert_awaited()
 
     def test_rule_info_not_found(self, runner):
         with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -476,42 +476,32 @@ class TestTreasuryCommands:
 
 class TestRuleCommands:
     @staticmethod
-    def _patch_account_service(*, exists: bool):
-        """`rule list`가 내부에서 생성하는 AccountService를 mock한다.
+    def _make_mock_db(*, account_exists: bool):
+        """`rule list`가 재사용하는 db 핸들을 mock한다.
 
-        `exists=True`면 `get`이 정상 반환(실재 account),
-        `exists=False`면 `AccountNotFoundError`를 raise(미존재 account, #1559).
+        `rule list`는 AccountService 전체를 materialize/복호화하지 않고
+        이미 열린 db 핸들로 lightweight 단건 존재 쿼리만 수행한다(#1559).
+        `account_exists=True`면 accounts 존재 SELECT가 row를 반환(실재
+        account), `False`면 None을 반환(미존재 account → exit 1).
+
+        credentials 복호화 경로(`_row_to_account`/decrypt)를 전혀 타지
+        않으므로, 다른 계좌의 credentials 복호화 실패가 rule list를 깨뜨릴
+        수 없음을 함께 잠근다(회귀 가드).
         """
-        from ante.account.errors import AccountNotFoundError
-
-        mock_service = AsyncMock()
-        mock_service.initialize = AsyncMock()
-        if exists:
-            mock_service.get = AsyncMock(return_value=MagicMock())
-        else:
-            mock_service.get = AsyncMock(
-                side_effect=AccountNotFoundError(
-                    "계좌 'oracle-missing-account'를 찾을 수 없습니다."
-                )
-            )
-        return patch(
-            "ante.account.service.AccountService",
-            return_value=mock_service,
-        )
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        mock_db.fetch_one = AsyncMock(return_value={"1": 1} if account_exists else None)
+        return mock_db
 
     def test_rule_list_empty(self, runner):
         with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
             mock_engine = MagicMock()
             mock_engine._global_rules = []
             mock_engine._strategy_rules = {}
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
+            mock_db = self._make_mock_db(account_exists=True)
             mock_svc.return_value = (mock_engine, mock_db)
 
-            with (
-                patch("ante.cli.commands.rule._load_rules_from_config"),
-                self._patch_account_service(exists=True),
-            ):
+            with patch("ante.cli.commands.rule._load_rules_from_config"):
                 result = runner.invoke(cli, ["rule", "list", "--account", "acc-1"])
                 assert result.exit_code == 0
 
@@ -527,14 +517,10 @@ class TestRuleCommands:
             mock_engine = MagicMock()
             mock_engine._global_rules = [mock_rule]
             mock_engine._strategy_rules = {}
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
+            mock_db = self._make_mock_db(account_exists=True)
             mock_svc.return_value = (mock_engine, mock_db)
 
-            with (
-                patch("ante.cli.commands.rule._load_rules_from_config"),
-                self._patch_account_service(exists=True),
-            ):
+            with patch("ante.cli.commands.rule._load_rules_from_config"):
                 result = runner.invoke(
                     cli,
                     [
@@ -557,14 +543,10 @@ class TestRuleCommands:
             mock_engine = MagicMock()
             mock_engine._global_rules = []
             mock_engine._strategy_rules = {}
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
+            mock_db = self._make_mock_db(account_exists=False)
             mock_svc.return_value = (mock_engine, mock_db)
 
-            with (
-                patch("ante.cli.commands.rule._load_rules_from_config"),
-                self._patch_account_service(exists=False),
-            ):
+            with patch("ante.cli.commands.rule._load_rules_from_config"):
                 result = runner.invoke(
                     cli,
                     [
@@ -581,6 +563,12 @@ class TestRuleCommands:
                 assert data["status"] == "error"
                 assert data["code"] == "ACCOUNT_NOT_FOUND"
                 assert "찾을 수 없습니다" in data["message"]
+                # 미존재 account: 메시지는 AccountService.get과 동일 문자열을
+                # 그대로 보존한다(동일 envelope/message, #1559).
+                assert (
+                    "계좌 'oracle-missing-account'를 찾을 수 없습니다."
+                    == data["message"]
+                )
                 # db.close()는 finally가 단독 소유 — lifecycle 불변(#1559).
                 mock_db.close.assert_awaited()
 
@@ -590,14 +578,10 @@ class TestRuleCommands:
             mock_engine = MagicMock()
             mock_engine._global_rules = []
             mock_engine._strategy_rules = {}
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
+            mock_db = self._make_mock_db(account_exists=False)
             mock_svc.return_value = (mock_engine, mock_db)
 
-            with (
-                patch("ante.cli.commands.rule._load_rules_from_config"),
-                self._patch_account_service(exists=False),
-            ):
+            with patch("ante.cli.commands.rule._load_rules_from_config"):
                 result = runner.invoke(
                     cli,
                     ["rule", "list", "--account", "oracle-missing-account"],
@@ -614,14 +598,10 @@ class TestRuleCommands:
             mock_engine = MagicMock()
             mock_engine._global_rules = []
             mock_engine._strategy_rules = {}
-            mock_db = AsyncMock()
-            mock_db.close = AsyncMock()
+            mock_db = self._make_mock_db(account_exists=True)
             mock_svc.return_value = (mock_engine, mock_db)
 
-            with (
-                patch("ante.cli.commands.rule._load_rules_from_config"),
-                self._patch_account_service(exists=True),
-            ):
+            with patch("ante.cli.commands.rule._load_rules_from_config"):
                 result = runner.invoke(
                     cli,
                     ["--format", "json", "rule", "list", "--account", "acc-1"],
@@ -630,6 +610,45 @@ class TestRuleCommands:
                 data = json.loads(result.output)
                 assert data["message"] == "등록된 룰이 없습니다."
                 assert data["rules"] == []
+
+    def test_rule_list_real_account_no_credentials_decrypt(self, runner):
+        """회귀 가드: 실재 account 조회가 다른 계좌 credentials 복호화에
+        의존하지 않는다 (#1559).
+
+        Codex 브랜치 리뷰 P2: AccountService.initialize()는 모든 non-deleted
+        account를 materialize하며 credentials를 복호화하므로, 무관한 계좌의
+        복호화 실패가 rule list를 깨뜨릴 수 있었다. lightweight 단건 존재
+        쿼리로 교체 후 이 경로가 _row_to_account/decrypt를 전혀 타지 않고
+        AccountService.initialize조차 호출하지 않음을 잠근다.
+        """
+        with (
+            patch("ante.cli.commands.rule._create_rule_engine") as mock_svc,
+            patch("ante.account.service.AccountService") as mock_account_cls,
+            patch("ante.account.service._row_to_account") as mock_row_to_account,
+        ):
+            mock_engine = MagicMock()
+            mock_engine._global_rules = []
+            mock_engine._strategy_rules = {}
+            mock_db = self._make_mock_db(account_exists=True)
+            mock_svc.return_value = (mock_engine, mock_db)
+
+            with patch("ante.cli.commands.rule._load_rules_from_config"):
+                result = runner.invoke(
+                    cli,
+                    ["--format", "json", "rule", "list", "--account", "acc-1"],
+                )
+                assert result.exit_code == 0
+                data = json.loads(result.output)
+                assert data["message"] == "등록된 룰이 없습니다."
+                # AccountService 자체를 생성/초기화하지 않으므로 전체
+                # materialize/복호화 경로(_row_to_account)가 호출되지 않는다.
+                mock_account_cls.assert_not_called()
+                mock_row_to_account.assert_not_called()
+                # 존재 확인은 lightweight 단건 SELECT 1로만 수행한다.
+                mock_db.fetch_one.assert_awaited_once_with(
+                    "SELECT 1 FROM accounts WHERE account_id = ?",
+                    ("acc-1",),
+                )
 
     def test_rule_info_not_found(self, runner):
         with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:

--- a/tests/unit/test_cli_live.py
+++ b/tests/unit/test_cli_live.py
@@ -475,6 +475,30 @@ class TestTreasuryCommands:
 
 
 class TestRuleCommands:
+    @staticmethod
+    def _patch_account_service(*, exists: bool):
+        """`rule list`가 내부에서 생성하는 AccountService를 mock한다.
+
+        `exists=True`면 `get`이 정상 반환(실재 account),
+        `exists=False`면 `AccountNotFoundError`를 raise(미존재 account, #1559).
+        """
+        from ante.account.errors import AccountNotFoundError
+
+        mock_service = AsyncMock()
+        mock_service.initialize = AsyncMock()
+        if exists:
+            mock_service.get = AsyncMock(return_value=MagicMock())
+        else:
+            mock_service.get = AsyncMock(
+                side_effect=AccountNotFoundError(
+                    "계좌 'oracle-missing-account'를 찾을 수 없습니다."
+                )
+            )
+        return patch(
+            "ante.account.service.AccountService",
+            return_value=mock_service,
+        )
+
     def test_rule_list_empty(self, runner):
         with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
             mock_engine = MagicMock()
@@ -484,7 +508,10 @@ class TestRuleCommands:
             mock_db.close = AsyncMock()
             mock_svc.return_value = (mock_engine, mock_db)
 
-            with patch("ante.cli.commands.rule._load_rules_from_config"):
+            with (
+                patch("ante.cli.commands.rule._load_rules_from_config"),
+                self._patch_account_service(exists=True),
+            ):
                 result = runner.invoke(cli, ["rule", "list", "--account", "acc-1"])
                 assert result.exit_code == 0
 
@@ -504,7 +531,10 @@ class TestRuleCommands:
             mock_db.close = AsyncMock()
             mock_svc.return_value = (mock_engine, mock_db)
 
-            with patch("ante.cli.commands.rule._load_rules_from_config"):
+            with (
+                patch("ante.cli.commands.rule._load_rules_from_config"),
+                self._patch_account_service(exists=True),
+            ):
                 result = runner.invoke(
                     cli,
                     [
@@ -520,6 +550,86 @@ class TestRuleCommands:
                 data = json.loads(result.output)
                 assert len(data["rules"]) == 1
                 assert data["rules"][0]["rule_id"] == "daily_loss"
+
+    def test_rule_list_missing_account_json_exit_1(self, runner):
+        """미존재 account: JSON envelope + ACCOUNT_NOT_FOUND + exit 1 (#1559)."""
+        with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
+            mock_engine = MagicMock()
+            mock_engine._global_rules = []
+            mock_engine._strategy_rules = {}
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_engine, mock_db)
+
+            with (
+                patch("ante.cli.commands.rule._load_rules_from_config"),
+                self._patch_account_service(exists=False),
+            ):
+                result = runner.invoke(
+                    cli,
+                    [
+                        "--format",
+                        "json",
+                        "rule",
+                        "list",
+                        "--account",
+                        "oracle-missing-account",
+                    ],
+                )
+                assert result.exit_code == 1
+                data = json.loads(result.output)
+                assert data["status"] == "error"
+                assert data["code"] == "ACCOUNT_NOT_FOUND"
+                assert "찾을 수 없습니다" in data["message"]
+                # db.close()는 finally가 단독 소유 — lifecycle 불변(#1559).
+                mock_db.close.assert_awaited()
+
+    def test_rule_list_missing_account_text_exit_1(self, runner):
+        """미존재 account: text 출력도 exit 1로 종료 (#1559)."""
+        with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
+            mock_engine = MagicMock()
+            mock_engine._global_rules = []
+            mock_engine._strategy_rules = {}
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_engine, mock_db)
+
+            with (
+                patch("ante.cli.commands.rule._load_rules_from_config"),
+                self._patch_account_service(exists=False),
+            ):
+                result = runner.invoke(
+                    cli,
+                    ["rule", "list", "--account", "oracle-missing-account"],
+                )
+                assert result.exit_code == 1
+                assert "찾을 수 없습니다" in result.output
+
+    def test_rule_list_real_account_zero_rules_exit_0(self, runner):
+        """regression guard: 실재 account + 0 rules는 정상 계약 유지 (#1559).
+
+        exit 0 + {"message":"등록된 룰이 없습니다.","rules":[]} 그대로.
+        """
+        with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:
+            mock_engine = MagicMock()
+            mock_engine._global_rules = []
+            mock_engine._strategy_rules = {}
+            mock_db = AsyncMock()
+            mock_db.close = AsyncMock()
+            mock_svc.return_value = (mock_engine, mock_db)
+
+            with (
+                patch("ante.cli.commands.rule._load_rules_from_config"),
+                self._patch_account_service(exists=True),
+            ):
+                result = runner.invoke(
+                    cli,
+                    ["--format", "json", "rule", "list", "--account", "acc-1"],
+                )
+                assert result.exit_code == 0
+                data = json.loads(result.output)
+                assert data["message"] == "등록된 룰이 없습니다."
+                assert data["rules"] == []
 
     def test_rule_info_not_found(self, runner):
         with patch("ante.cli.commands.rule._create_rule_engine") as mock_svc:


### PR DESCRIPTION
Closes #1559

## Summary
- `ante rule list --account <missing>`이 missing-resource 오류 대신 exit 0 + `{"message":"등록된 룰이 없습니다.","rules":[]}`을 반환하던 결함 수정. 미존재 account를 "실재 account의 0 rules"와 구분.
- `_run_list()`에 credentials 복호화 없는 lightweight `SELECT 1 FROM accounts WHERE account_id=?` 존재 확인 추가. 미존재 → `AccountNotFoundError` → 호출부 `fmt.error(str(e), code="ACCOUNT_NOT_FOUND"); raise SystemExit(1)` (canonical `account.py:798-799` / 머지된 #1556과 정확히 동일). 실재 account 0 rules → 기존 exit 0 + `등록된 룰이 없습니다.` 계약 불변.
- `accounts` 테이블 미생성 DB(`AccountService.initialize()` 미실행)에서 선조회가 `OperationalError: no such table`로 계약을 우회하지 않도록, 해당 케이스를 account-not-found로 정규화(다른 OperationalError는 전파). #1558에서 검증된 패턴.

## Plan Preflight & Review
- Codex Plan Review: approve-implement. Codex 브랜치 리뷰: attempt1 FAIL(P2 AccountService.initialize 전체 복호화) → attempt2 FAIL(P2 accounts 테이블 부재) → attempt3 PASS.

## Test Plan
- [x] `pytest tests/unit/ -q -k rule` → 357 passed (미존재 account json/text exit1+ACCOUNT_NOT_FOUND, 실재 0rules exit0, 실재 Nrules, no-credentials-decrypt 가드, accounts-table 부재 정규화, other-OperationalError 비흡수 가드)
- [x] failing→passing 확인
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)