### PR TITLE
fix(cli): strict YYYY-MM-DD validation for feed date options (#1562)

### DIFF
--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import pathlib
+import re
 from typing import TYPE_CHECKING
 
 import click
@@ -15,6 +16,39 @@ if TYPE_CHECKING:
     from ante.feed.report.generator import ReportGenerator
 
 logger = logging.getLogger(__name__)
+
+# zero-padded YYYY-MM-DD만 허용. date.fromisoformat()은 3.11+/3.13에서
+# basic ISO(20260510)·ISO week date(2026-W19-1) 등 변형도 수락하므로
+# 형태를 정규식으로 먼저 고정한 뒤 캘린더 유효성만 검증한다.
+_ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
+
+
+def _validate_iso_date(value: str, option: str, fmt: object) -> None:
+    """``value``가 엄격한 ``YYYY-MM-DD``인지 검증한다.
+
+    형식이 어긋나거나 캘린더상 유효하지 않으면 ``CLI_INVALID_DATE``
+    구조화 에러를 출력하고 ``SystemExit(1)``로 종료한다. 3개 날짜
+    옵션(``--since`` / ``--until`` / ``--date``)이 공유한다.
+    """
+    from datetime import date
+
+    if _ISO_DATE_RE.fullmatch(value) is None:
+        fmt.error(  # type: ignore[attr-defined]
+            f"잘못된 {option} 날짜 형식: '{value}' (YYYY-MM-DD 형식 필요)",
+            code="CLI_INVALID_DATE",
+        )
+        raise SystemExit(1)
+
+    try:
+        # regex로 형태를 고정했으므로 캘린더 유효성(예: 2026-13-01)만 확인.
+        date.fromisoformat(value)
+    except ValueError:
+        fmt.error(  # type: ignore[attr-defined]
+            f"잘못된 {option} 날짜 형식: '{value}' (YYYY-MM-DD 형식 필요)",
+            code="CLI_INVALID_DATE",
+        )
+        raise SystemExit(1)
+
 
 _DEFAULT_DATA_PATH = "data/"
 _DATA_PATH_HELP = "데이터 저장소 경로"
@@ -224,28 +258,10 @@ def run_backfill(
         raise SystemExit(1)
 
     if since is not None:
-        from datetime import date
-
-        try:
-            date.fromisoformat(since)
-        except ValueError:
-            fmt.error(
-                f"잘못된 --since 날짜 형식: '{since}' (YYYY-MM-DD 형식 필요)",
-                code="CLI_INVALID_DATE",
-            )
-            raise SystemExit(1)
+        _validate_iso_date(since, "--since", fmt)
 
     if until is not None:
-        from datetime import date
-
-        try:
-            date.fromisoformat(until)
-        except ValueError:
-            fmt.error(
-                f"잘못된 --until 날짜 형식: '{until}' (YYYY-MM-DD 형식 필요)",
-                code="CLI_INVALID_DATE",
-            )
-            raise SystemExit(1)
+        _validate_iso_date(until, "--until", fmt)
 
     config = cfg.load_config()
 
@@ -294,16 +310,7 @@ def run_daily(
         raise SystemExit(1)
 
     if target_date is not None:
-        from datetime import date
-
-        try:
-            date.fromisoformat(target_date)
-        except ValueError:
-            fmt.error(
-                f"잘못된 --date 날짜 형식: '{target_date}' (YYYY-MM-DD 형식 필요)",
-                code="CLI_INVALID_DATE",
-            )
-            raise SystemExit(1)
+        _validate_iso_date(target_date, "--date", fmt)
 
     config = cfg.load_config()
 

--- a/src/ante/feed/cli.py
+++ b/src/ante/feed/cli.py
@@ -231,7 +231,19 @@ def run_backfill(
         except ValueError:
             fmt.error(
                 f"잘못된 --since 날짜 형식: '{since}' (YYYY-MM-DD 형식 필요)",
-                code="invalid_date",
+                code="CLI_INVALID_DATE",
+            )
+            raise SystemExit(1)
+
+    if until is not None:
+        from datetime import date
+
+        try:
+            date.fromisoformat(until)
+        except ValueError:
+            fmt.error(
+                f"잘못된 --until 날짜 형식: '{until}' (YYYY-MM-DD 형식 필요)",
+                code="CLI_INVALID_DATE",
             )
             raise SystemExit(1)
 
@@ -280,6 +292,18 @@ def run_daily(
 
     if not _ensure_initialized(cfg, fmt, data_path):
         raise SystemExit(1)
+
+    if target_date is not None:
+        from datetime import date
+
+        try:
+            date.fromisoformat(target_date)
+        except ValueError:
+            fmt.error(
+                f"잘못된 --date 날짜 형식: '{target_date}' (YYYY-MM-DD 형식 필요)",
+                code="CLI_INVALID_DATE",
+            )
+            raise SystemExit(1)
 
     config = cfg.load_config()
 

--- a/tests/unit/feed/test_cli_backfill_date_validation.py
+++ b/tests/unit/feed/test_cli_backfill_date_validation.py
@@ -1,7 +1,9 @@
-"""ante feed run backfill --since CLI 검증 테스트.
+"""ante feed run backfill/daily 날짜 옵션 CLI 검증 테스트.
 
 이슈 #1536: invalid ISO date 입력 시 CLI 경계에서 거부하고
-traceback이 stderr에 노출되지 않아야 한다.
+traceback이 stderr에 노출되지 않아야 한다 (`--since`).
+이슈 #1562: #1536 follow-up — `run backfill --until`/`run daily --date`도
+동일하게 CLI 경계에서 거부하고, 3개 옵션 모두 `CLI_INVALID_DATE` 단일 코드로 통일.
 """
 
 from __future__ import annotations
@@ -29,6 +31,21 @@ _MOCK_MASTER = Member(
 
 _EMPTY_RESULT = CollectionResult(
     mode="backfill",
+    started_at="2026-03-18T00:00:00Z",
+    finished_at="2026-03-18T00:00:01Z",
+    duration_seconds=1.0,
+    symbols_total=0,
+    symbols_success=0,
+    symbols_failed=0,
+    rows_written=0,
+    data_types=[],
+    failures=[],
+    warnings=[],
+    config_errors=[],
+)
+
+_EMPTY_DAILY_RESULT = CollectionResult(
+    mode="daily",
     started_at="2026-03-18T00:00:00Z",
     finished_at="2026-03-18T00:00:01Z",
     duration_seconds=1.0,
@@ -127,7 +144,7 @@ class TestBackfillSinceValidation:
             # stdout에 구조화된 JSON 에러
             data = json.loads(result.stdout)
             assert data["status"] == "error"
-            assert data["code"] == "invalid_date"
+            assert data["code"] == "CLI_INVALID_DATE"
             assert "not-a-date" in data["message"]
             # orchestrator는 호출되지 않아야 한다
             mock_orch.run_backfill.assert_not_awaited()
@@ -215,3 +232,249 @@ class TestBackfillSinceValidation:
 
             assert result.exit_code == 0
             mock_orch.run_backfill.assert_awaited_once()
+
+
+class TestBackfillUntilValidation:
+    """`--until` 옵션 ISO date 검증 (이슈 #1562)."""
+
+    def test_invalid_until_json_mode_returns_structured_error(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """JSON 모드에서 invalid --until은 status=error JSON, exit 1, traceback 없음."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                    "--until",
+                    "oracle-not-a-date",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 1
+            assert "Traceback" not in (result.stderr or "")
+            data = json.loads(result.stdout)
+            assert data["status"] == "error"
+            assert data["code"] == "CLI_INVALID_DATE"
+            assert "oracle-not-a-date" in data["message"]
+            mock_orch.run_backfill.assert_not_awaited()
+
+    def test_invalid_until_text_mode_writes_error_to_stderr(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """text 모드에서 invalid --until은 stderr Error, exit 1, traceback 없음."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                    "--until",
+                    "oracle-not-a-date",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 1
+            stderr = result.stderr or ""
+            assert "Traceback" not in stderr
+            assert "Error:" in stderr
+            assert "잘못된 --until 날짜 형식" in stderr
+            assert "oracle-not-a-date" in stderr
+            mock_orch.run_backfill.assert_not_awaited()
+
+    def test_reproduction_since_valid_until_invalid_exits_1(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """이슈 재현 조합: --since 유효 + --until invalid → exit 1, orch 미호출."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                    "--since",
+                    "2099-01-01",
+                    "--until",
+                    "oracle-not-a-date",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 1
+            data = json.loads(result.stdout)
+            assert data["status"] == "error"
+            assert data["code"] == "CLI_INVALID_DATE"
+            assert "oracle-not-a-date" in data["message"]
+            mock_orch.run_backfill.assert_not_awaited()
+
+    def test_valid_iso_until_passes_through_to_orchestrator(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """정상 ISO date(--until 2099-01-01)는 검증 통과해 orchestrator로 전달된다."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                    "--until",
+                    "2099-01-01",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 0
+            mock_orch.run_backfill.assert_awaited_once()
+
+
+class TestDailyDateValidation:
+    """`run daily --date` 옵션 ISO date 검증 (이슈 #1562)."""
+
+    def test_invalid_date_json_mode_returns_structured_error(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """JSON 모드에서 invalid --date는 status=error JSON, exit 1, traceback 없음."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_daily = AsyncMock(return_value=_EMPTY_DAILY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "feed",
+                    "run",
+                    "daily",
+                    "--data-path",
+                    initialized_data_path,
+                    "--date",
+                    "oracle-not-a-date",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 1
+            assert "Traceback" not in (result.stderr or "")
+            data = json.loads(result.stdout)
+            assert data["status"] == "error"
+            assert data["code"] == "CLI_INVALID_DATE"
+            assert "oracle-not-a-date" in data["message"]
+            mock_orch.run_daily.assert_not_awaited()
+
+    def test_invalid_date_text_mode_writes_error_to_stderr(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """text 모드에서 invalid --date는 stderr Error, exit 1, traceback 없음."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_daily = AsyncMock(return_value=_EMPTY_DAILY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "feed",
+                    "run",
+                    "daily",
+                    "--data-path",
+                    initialized_data_path,
+                    "--date",
+                    "oracle-not-a-date",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 1
+            stderr = result.stderr or ""
+            assert "Traceback" not in stderr
+            assert "Error:" in stderr
+            assert "잘못된 --date 날짜 형식" in stderr
+            assert "oracle-not-a-date" in stderr
+            mock_orch.run_daily.assert_not_awaited()
+
+    def test_valid_iso_date_passes_through_to_orchestrator(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """정상 ISO date(--date 2025-01-01)는 검증 통과해 orchestrator로 전달된다."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_daily = AsyncMock(return_value=_EMPTY_DAILY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "feed",
+                    "run",
+                    "daily",
+                    "--data-path",
+                    initialized_data_path,
+                    "--date",
+                    "2025-01-01",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 0
+            mock_orch.run_daily.assert_awaited_once()
+
+    def test_no_date_option_regression(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """--date 미지정 시 기존 동작 유지 (검증 분기 우회)."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_daily = AsyncMock(return_value=_EMPTY_DAILY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "feed",
+                    "run",
+                    "daily",
+                    "--data-path",
+                    initialized_data_path,
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 0
+            mock_orch.run_daily.assert_awaited_once()

--- a/tests/unit/feed/test_cli_backfill_date_validation.py
+++ b/tests/unit/feed/test_cli_backfill_date_validation.py
@@ -233,6 +233,81 @@ class TestBackfillSinceValidation:
             assert result.exit_code == 0
             mock_orch.run_backfill.assert_awaited_once()
 
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "20260510",  # basic ISO (no separators)
+            "2026-W19-1",  # ISO week date (Codex P2 케이스)
+            "2026-1-1",  # non-zero-padded
+        ],
+    )
+    def test_iso_variant_since_rejected_strict(
+        self, runner: CliRunner, initialized_data_path: str, bad_value: str
+    ) -> None:
+        """ISO 변형(basic/week/non-padded) --since는 strict 거부 (#1562 회귀).
+
+        date.fromisoformat()만 쓰던 이전 구현이라면 통과했을 입력을 잠근다.
+        """
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                    "--since",
+                    bad_value,
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 1
+            assert "Traceback" not in (result.stderr or "")
+            data = json.loads(result.stdout)
+            assert data["status"] == "error"
+            assert data["code"] == "CLI_INVALID_DATE"
+            assert bad_value in data["message"]
+            mock_orch.run_backfill.assert_not_awaited()
+
+    def test_invalid_calendar_since_rejected(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """형태는 맞지만 캘린더상 invalid(2026-13-01) --since는 거부."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                    "--since",
+                    "2026-13-01",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 1
+            data = json.loads(result.stdout)
+            assert data["status"] == "error"
+            assert data["code"] == "CLI_INVALID_DATE"
+            mock_orch.run_backfill.assert_not_awaited()
+
 
 class TestBackfillUntilValidation:
     """`--until` 옵션 ISO date 검증 (이슈 #1562)."""
@@ -361,6 +436,47 @@ class TestBackfillUntilValidation:
             assert result.exit_code == 0
             mock_orch.run_backfill.assert_awaited_once()
 
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "20260510",  # basic ISO (no separators)
+            "2026-W19-1",  # ISO week date (Codex P2 케이스)
+            "2026-1-1",  # non-zero-padded
+        ],
+    )
+    def test_iso_variant_until_rejected_strict(
+        self, runner: CliRunner, initialized_data_path: str, bad_value: str
+    ) -> None:
+        """ISO 변형(basic/week/non-padded) --until은 strict 거부 (#1562 회귀)."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_backfill = AsyncMock(return_value=_EMPTY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "feed",
+                    "run",
+                    "backfill",
+                    "--data-path",
+                    initialized_data_path,
+                    "--until",
+                    bad_value,
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 1
+            assert "Traceback" not in (result.stderr or "")
+            data = json.loads(result.stdout)
+            assert data["status"] == "error"
+            assert data["code"] == "CLI_INVALID_DATE"
+            assert bad_value in data["message"]
+            mock_orch.run_backfill.assert_not_awaited()
+
 
 class TestDailyDateValidation:
     """`run daily --date` 옵션 ISO date 검증 (이슈 #1562)."""
@@ -454,6 +570,82 @@ class TestDailyDateValidation:
 
             assert result.exit_code == 0
             mock_orch.run_daily.assert_awaited_once()
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "20260510",  # basic ISO (no separators)
+            "2026-W19-1",  # ISO week date — Codex P2 지적 케이스
+            "2026-1-1",  # non-zero-padded
+        ],
+    )
+    def test_iso_variant_date_rejected_strict(
+        self, runner: CliRunner, initialized_data_path: str, bad_value: str
+    ) -> None:
+        """ISO 변형(basic/week/non-padded) --date는 strict 거부 (#1562 회귀).
+
+        date.fromisoformat()만 쓰던 이전 구현이라면 `2026-W19-1` 등이
+        통과해 원문이 그대로 하위 수집(basDt)으로 전달됐다.
+        """
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_daily = AsyncMock(return_value=_EMPTY_DAILY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "feed",
+                    "run",
+                    "daily",
+                    "--data-path",
+                    initialized_data_path,
+                    "--date",
+                    bad_value,
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 1
+            assert "Traceback" not in (result.stderr or "")
+            data = json.loads(result.stdout)
+            assert data["status"] == "error"
+            assert data["code"] == "CLI_INVALID_DATE"
+            assert bad_value in data["message"]
+            mock_orch.run_daily.assert_not_awaited()
+
+    def test_invalid_calendar_date_rejected(
+        self, runner: CliRunner, initialized_data_path: str
+    ) -> None:
+        """형태는 맞지만 캘린더상 invalid(2026-13-01) --date는 거부."""
+        with patch("ante.feed.cli._build_orchestrator") as mock_build:
+            mock_orch = AsyncMock()
+            mock_orch.run_daily = AsyncMock(return_value=_EMPTY_DAILY_RESULT)
+            mock_build.return_value = mock_orch
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "feed",
+                    "run",
+                    "daily",
+                    "--data-path",
+                    initialized_data_path,
+                    "--date",
+                    "2026-13-01",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 1
+            data = json.loads(result.stdout)
+            assert data["status"] == "error"
+            assert data["code"] == "CLI_INVALID_DATE"
+            mock_orch.run_daily.assert_not_awaited()
 
     def test_no_date_option_regression(
         self, runner: CliRunner, initialized_data_path: str


### PR DESCRIPTION
Closes #1562

## Summary
- `ante feed run backfill --until` / `feed run daily --date`가 invalid date를 검증 없이 실행하던 결함 수정 (머지된 #1536 `--since` 검증의 명시적 follow-up).
- module-level 공유 helper `_validate_iso_date(value, option, fmt)` 도입: 정규식 `\d{4}-\d{2}-\d{2}` fullmatch로 zero-padded `YYYY-MM-DD` 형태를 강제한 뒤 `date.fromisoformat`로 캘린더 유효성만 확인. Python 3.11+/3.13의 `date.fromisoformat`가 basic ISO(`20260510`)·ISO week(`2026-W19-1`)를 수락하던 contract 위반을 차단.
- `--since`(기존 #1536 inline)·`--until`(신규)·`--date`(신규) **3개 옵션 모두** 공유 helper 경유 + 에러 코드를 SSOT(`docs/specs/cli/02-design-decisions.md:85-87`, domain-less → `CLI_*` SCREAMING_SNAKE)에 맞춰 `CLI_INVALID_DATE`로 통일. `invalid_date`는 표준 코드표 미등재 ad-hoc 값이라 정정.

## Plan Preflight & Review
- Codex Plan Review: approve-implement (attempt 2 — error-code casing SSOT 정합 반영). Codex 브랜치 리뷰: attempt1 FAIL(P2 date.fromisoformat ISO 변형 허용) → attempt2 PASS.

## Test Plan
- [x] `pytest tests/unit/feed/test_cli_backfill_date_validation.py -q` → 23 passed
- [x] `pytest tests/unit/ -q -k feed` → 332 passed (회귀 없음)
- [x] strict 회귀: 3개 옵션 × `20260510`/`2026-W19-1`/`2026-1-1`/`2026-13-01` → exit 1 + `CLI_INVALID_DATE`; 유효 zero-padded·None 기존 동작 유지
- [x] failing→passing 확인, `ruff check`/`ruff format --check` clean
- 신규 테스트 파일 없음(기존 `test_cli_backfill_date_validation.py` 확장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)