### PR TITLE
fix(api,cli): exit/404 on strategy performance for missing account (#1563)

### DIFF
--- a/src/ante/cli/commands/strategy.py
+++ b/src/ante/cli/commands/strategy.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 from dataclasses import asdict
 from pathlib import Path
 
 import click
 
+from ante.account.errors import AccountNotFoundError
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
@@ -466,6 +468,41 @@ def strategy_performance(ctx: click.Context, name: str, account_id: str | None) 
             if not records:
                 return None
 
+            # strategy 존재 확인 후, performance 계산 전에 account 존재를
+            # 검증한다. AccountService.initialize()는 모든 non-deleted
+            # account row를 materialize하며 credentials를 복호화하므로,
+            # 조회 대상과 무관한 다른 계좌의 복호화 실패가 정상 사용을
+            # 깨뜨릴 수 있다. 따라서 credentials 복호화 없이 이미 열린 db
+            # 핸들로 lightweight 단건 존재 쿼리만 수행한다. 쿼리 의미는
+            # AccountService.get(account_id 단건, status 필터 없음)과
+            # 일치하며 미존재 시 동일한 AccountNotFoundError 메시지로
+            # 분기한다 (#1559 일관). db.close()는 아래 finally가 단독
+            # 소유한다(lifecycle 불변).
+            #
+            # ``accounts`` 테이블은 ``AccountService.initialize()`` 에서만
+            # 생성된다. 이 경로는 raw ``Database`` 핸들만 쓰고
+            # ``AccountService`` 를 초기화하지 않으므로, 부분 초기화/legacy
+            # DB(예: ``ante init`` 직후)에서는 테이블 자체가 없어
+            # ``sqlite3.OperationalError: no such table: accounts`` 가
+            # 호출자까지 전파될 수 있다. 정의상 accounts 테이블 부재는
+            # 해당 account 미존재와 동치이므로 동일한
+            # AccountNotFoundError 로 정규화한다. 단, malformed db 같은
+            # 다른 ``OperationalError`` 까지 삼키지 않도록 "no such table"
+            # 메시지일 때로만 좁힌다 (#1558/#1559 에서 검증된 패턴).
+            try:
+                account_row = await db.fetch_one(
+                    "SELECT 1 FROM accounts WHERE account_id = ?",
+                    (account_id,),
+                )
+            except sqlite3.OperationalError as e:
+                if "no such table" in str(e).lower():
+                    raise AccountNotFoundError(
+                        f"계좌 '{account_id}'를 찾을 수 없습니다."
+                    ) from e
+                raise
+            if account_row is None:
+                raise AccountNotFoundError(f"계좌 '{account_id}'를 찾을 수 없습니다.")
+
             tracker = PerformanceTracker(db)
             # 최신 버전의 strategy_id 기준으로 성과 계산
             record = records[0]
@@ -481,7 +518,11 @@ def strategy_performance(ctx: click.Context, name: str, account_id: str | None) 
         finally:
             await db.close()
 
-    result = _run(_perf())
+    try:
+        result = _run(_perf())
+    except AccountNotFoundError as e:
+        fmt.error(str(e), code="ACCOUNT_NOT_FOUND")
+        raise SystemExit(1) from e
 
     if result is None:
         fmt.error(f"전략을 찾을 수 없습니다: {name}")

--- a/src/ante/web/routes/strategies.py
+++ b/src/ante/web/routes/strategies.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import sqlite3
 from dataclasses import asdict
 from pathlib import Path
 from typing import Annotated, Any
@@ -616,6 +617,39 @@ async def get_strategy_performance(
                 "?account_id=<id> 쿼리 파라미터를 지정하거나, "
                 "해당 전략에 연결된 봇이 있어야 합니다."
             ),
+        )
+
+    # resolved_account_id 확정 후, performance 계산 전에 account 존재를
+    # 검증한다. PerformanceTracker.calculate 는 다수 소비자가 쓰는 저수준
+    # metric 계산이므로 검증을 넣지 않고(multi-consumer 불변), ingress
+    # 라우트에서만 검증한다. 쿼리/봇 fallback 어느 경로로 결정됐든 동일한
+    # resolved_account_id 를 lightweight 단건 존재 쿼리로 확인한다. 쿼리
+    # 의미는 AccountService.get(account_id 단건, status 필터 없음)과
+    # 일치하며, credentials 복호화를 트리거하지 않아 무관한 계좌의 복호화
+    # 실패가 정상 사용을 깨뜨리지 않는다 (#1559 일관).
+    #
+    # ``accounts`` 테이블은 ``AccountService.initialize()`` 에서만 생성되며,
+    # 부분 초기화/legacy DB 에서는 테이블 자체가 없어
+    # ``sqlite3.OperationalError: no such table: accounts`` 가 전파될 수
+    # 있다. 정의상 accounts 테이블 부재는 해당 account 미존재와 동치이므로
+    # 동일한 404 로 정규화한다. 단, malformed db 같은 다른
+    # ``OperationalError`` 까지 삼키지 않도록 "no such table" 메시지일
+    # 때로만 좁힌다 (#1558/#1559 에서 검증된 패턴).
+    try:
+        account_row = await db.fetch_one(
+            "SELECT 1 FROM accounts WHERE account_id = ?",
+            (resolved_account_id,),
+        )
+        account_exists = account_row is not None
+    except sqlite3.OperationalError as e:
+        if "no such table" in str(e).lower():
+            account_exists = False
+        else:
+            raise
+    if not account_exists:
+        raise HTTPException(
+            status_code=404,
+            detail=f"계좌를 찾을 수 없습니다: {resolved_account_id}",
         )
 
     from ante.trade.performance import PerformanceTracker

--- a/tests/unit/test_cli_strategy.py
+++ b/tests/unit/test_cli_strategy.py
@@ -462,6 +462,208 @@ class TestStrategyPerformance:
             data = json.loads(result.output)
             assert data["strategy_name"] == "momentum"
 
+    @staticmethod
+    def _patch_perf_internals(
+        *,
+        records,
+        account_row,
+        fetch_one_side_effect=None,
+        metrics=None,
+    ):
+        """`_perf()` 내부 함수 지역 import 대상을 patch하는 컨텍스트 묶음.
+
+        실제 ``_perf`` 코루틴을 실행해 account 존재 검증 분기를 직접 탄다.
+        """
+        db = MagicMock()
+        db.connect = AsyncMock()
+        db.close = AsyncMock()
+        if fetch_one_side_effect is not None:
+            db.fetch_one = AsyncMock(side_effect=fetch_one_side_effect)
+        else:
+            db.fetch_one = AsyncMock(return_value=account_row)
+
+        registry = MagicMock()
+        registry.get_by_name = AsyncMock(return_value=records)
+
+        tracker = MagicMock()
+        tracker.calculate = AsyncMock(
+            return_value=metrics if metrics is not None else _SAMPLE_METRICS
+        )
+
+        return (
+            patch("ante.core.database.Database", return_value=db),
+            patch("ante.cli.main.get_db_path", return_value=":memory:"),
+            patch(
+                "ante.strategy.registry.StrategyRegistry",
+                return_value=registry,
+            ),
+            patch(
+                "ante.trade.performance.PerformanceTracker",
+                return_value=tracker,
+            ),
+            db,
+            tracker,
+        )
+
+    def test_performance_missing_account_json(self, runner):
+        """strategy 존재 + 미존재 account → exit 1 + ACCOUNT_NOT_FOUND (#1563)."""
+        p_db, p_path, p_reg, p_track, db, tracker = self._patch_perf_internals(
+            records=[_SAMPLE_RECORD],
+            account_row=None,
+        )
+        with p_db, p_path, p_reg, p_track:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "strategy",
+                    "performance",
+                    "momentum",
+                    "--account-id",
+                    "oracle-missing-account",
+                ],
+            )
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["status"] == "error"
+        assert data["code"] == "ACCOUNT_NOT_FOUND"
+        assert "oracle-missing-account" in data["message"]
+        # account 미존재이므로 metric 계산까지 가지 않는다.
+        tracker.calculate.assert_not_called()
+
+    def test_performance_missing_account_text(self, runner):
+        """미존재 account → text 모드 단건 에러 출력 + exit 1 (#1563)."""
+        p_db, p_path, p_reg, p_track, db, tracker = self._patch_perf_internals(
+            records=[_SAMPLE_RECORD],
+            account_row=None,
+        )
+        with p_db, p_path, p_reg, p_track:
+            result = runner.invoke(
+                cli,
+                [
+                    "strategy",
+                    "performance",
+                    "momentum",
+                    "--account-id",
+                    "oracle-missing-account",
+                ],
+            )
+        assert result.exit_code == 1
+        assert "계좌 'oracle-missing-account'를 찾을 수 없습니다." in result.output
+        tracker.calculate.assert_not_called()
+
+    def test_performance_real_account_regression(self, runner):
+        """regression guard: 실재 account → exit 0 + metrics 유지 (#1563)."""
+        p_db, p_path, p_reg, p_track, db, tracker = self._patch_perf_internals(
+            records=[_SAMPLE_RECORD],
+            account_row={"1": 1},
+        )
+        with p_db, p_path, p_reg, p_track:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "strategy",
+                    "performance",
+                    "momentum",
+                    "--account-id",
+                    "acc-test",
+                ],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["strategy_name"] == "momentum"
+        assert data["metrics"]["total_trades"] == 10
+        tracker.calculate.assert_awaited_once()
+
+    def test_performance_strategy_not_found_regression(self, runner):
+        """regression guard: strategy 미존재 → 기존 "전략을 찾을 수 없습니다" 유지.
+
+        account 검증은 strategy records 확인 이후이므로, records가 없으면
+        account 검증 분기에 도달하지 않고 기존 strategy-not-found 메시지를
+        그대로 출력한다 (#1563 분기 순서 불변).
+        """
+        p_db, p_path, p_reg, p_track, db, tracker = self._patch_perf_internals(
+            records=[],
+            account_row=None,
+        )
+        with p_db, p_path, p_reg, p_track:
+            result = runner.invoke(
+                cli,
+                [
+                    "strategy",
+                    "performance",
+                    "nonexistent",
+                    "--account-id",
+                    "oracle-missing-account",
+                ],
+            )
+        assert result.exit_code == 1
+        assert "전략을 찾을 수 없습니다" in result.output
+        # strategy 미존재이므로 account 존재 쿼리에 도달하지 않는다.
+        db.fetch_one.assert_not_called()
+
+    def test_performance_missing_account_no_accounts_table(self, runner):
+        """accounts 테이블 부재 → missing-account로 정규화, OperationalError 비누설.
+
+        부분 초기화/legacy DB에서 ``no such table: accounts``가 호출자까지
+        전파되면 ACCOUNT_NOT_FOUND 계약을 우회한다. 동일 분기로 정규화 (#1563).
+        """
+        import sqlite3
+
+        p_db, p_path, p_reg, p_track, db, tracker = self._patch_perf_internals(
+            records=[_SAMPLE_RECORD],
+            account_row=None,
+            fetch_one_side_effect=sqlite3.OperationalError("no such table: accounts"),
+        )
+        with p_db, p_path, p_reg, p_track:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "strategy",
+                    "performance",
+                    "momentum",
+                    "--account-id",
+                    "oracle-missing-account",
+                ],
+            )
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["code"] == "ACCOUNT_NOT_FOUND"
+        assert "no such table" not in result.output
+        tracker.calculate.assert_not_called()
+
+    def test_performance_other_operational_error_propagates(self, runner):
+        """malformed db 등 다른 OperationalError는 삼키지 않고 비정상 종료 (#1563)."""
+        import sqlite3
+
+        p_db, p_path, p_reg, p_track, db, tracker = self._patch_perf_internals(
+            records=[_SAMPLE_RECORD],
+            account_row=None,
+            fetch_one_side_effect=sqlite3.OperationalError(
+                "database disk image is malformed"
+            ),
+        )
+        with p_db, p_path, p_reg, p_track:
+            result = runner.invoke(
+                cli,
+                [
+                    "strategy",
+                    "performance",
+                    "momentum",
+                    "--account-id",
+                    "acc-test",
+                ],
+            )
+        # ACCOUNT_NOT_FOUND로 정규화되지 않고 예외가 전파된다.
+        assert result.exit_code != 0
+        assert "ACCOUNT_NOT_FOUND" not in result.output
+        tracker.calculate.assert_not_called()
+
 
 class TestStrategySubmit:
     """ante strategy submit 커맨드 테스트."""

--- a/tests/unit/test_cli_strategy.py
+++ b/tests/unit/test_cli_strategy.py
@@ -507,7 +507,7 @@ class TestStrategyPerformance:
 
     def test_performance_missing_account_json(self, runner):
         """strategy 존재 + 미존재 account → exit 1 + ACCOUNT_NOT_FOUND (#1563)."""
-        p_db, p_path, p_reg, p_track, db, tracker = self._patch_perf_internals(
+        p_db, p_path, p_reg, p_track, _db, tracker = self._patch_perf_internals(
             records=[_SAMPLE_RECORD],
             account_row=None,
         )
@@ -534,7 +534,7 @@ class TestStrategyPerformance:
 
     def test_performance_missing_account_text(self, runner):
         """미존재 account → text 모드 단건 에러 출력 + exit 1 (#1563)."""
-        p_db, p_path, p_reg, p_track, db, tracker = self._patch_perf_internals(
+        p_db, p_path, p_reg, p_track, _db, tracker = self._patch_perf_internals(
             records=[_SAMPLE_RECORD],
             account_row=None,
         )
@@ -555,7 +555,7 @@ class TestStrategyPerformance:
 
     def test_performance_real_account_regression(self, runner):
         """regression guard: 실재 account → exit 0 + metrics 유지 (#1563)."""
-        p_db, p_path, p_reg, p_track, db, tracker = self._patch_perf_internals(
+        p_db, p_path, p_reg, p_track, _db, tracker = self._patch_perf_internals(
             records=[_SAMPLE_RECORD],
             account_row={"1": 1},
         )
@@ -585,7 +585,7 @@ class TestStrategyPerformance:
         account 검증 분기에 도달하지 않고 기존 strategy-not-found 메시지를
         그대로 출력한다 (#1563 분기 순서 불변).
         """
-        p_db, p_path, p_reg, p_track, db, tracker = self._patch_perf_internals(
+        p_db, p_path, p_reg, p_track, db, _tracker = self._patch_perf_internals(
             records=[],
             account_row=None,
         )
@@ -613,7 +613,7 @@ class TestStrategyPerformance:
         """
         import sqlite3
 
-        p_db, p_path, p_reg, p_track, db, tracker = self._patch_perf_internals(
+        p_db, p_path, p_reg, p_track, _db, tracker = self._patch_perf_internals(
             records=[_SAMPLE_RECORD],
             account_row=None,
             fetch_one_side_effect=sqlite3.OperationalError("no such table: accounts"),
@@ -641,7 +641,7 @@ class TestStrategyPerformance:
         """malformed db 등 다른 OperationalError는 삼키지 않고 비정상 종료 (#1563)."""
         import sqlite3
 
-        p_db, p_path, p_reg, p_track, db, tracker = self._patch_perf_internals(
+        p_db, p_path, p_reg, p_track, _db, tracker = self._patch_perf_internals(
             records=[_SAMPLE_RECORD],
             account_row=None,
             fetch_one_side_effect=sqlite3.OperationalError(

--- a/tests/unit/test_strategy_api.py
+++ b/tests/unit/test_strategy_api.py
@@ -728,6 +728,145 @@ class TestStrategyPerformance:
         kwargs = mock_calc.await_args.kwargs
         assert kwargs["account_id"] == "acc-explicit"
 
+    def test_performance_missing_account(self, registry):
+        """strategy 존재 + 미존재 account → 404 + 계좌 not-found detail (#1563).
+
+        SELECT 1 FROM accounts WHERE account_id=? 가 row None → 404.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        fake_db = AsyncMock()
+        fake_db.fetch_one = AsyncMock(return_value=None)
+
+        registry._strategies = [
+            FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
+        ]
+
+        app = create_app(
+            strategy_registry=registry,
+            db=fake_db,
+            member_service=make_master_member_service(),
+        )
+        c = make_authed_client(app)
+
+        with patch(
+            "ante.trade.performance.PerformanceTracker.calculate",
+            new_callable=AsyncMock,
+        ) as mock_calc:
+            resp = c.get(
+                "/api/strategies/s1/performance?account_id=oracle-missing-account"
+            )
+
+        assert resp.status_code == 404
+        detail = resp.json()["detail"]
+        assert "계좌를 찾을 수 없습니다" in detail
+        assert "oracle-missing-account" in detail
+        # account 미존재이므로 metric 계산까지 가지 않는다.
+        mock_calc.assert_not_awaited()
+
+    def test_performance_real_account_regression(self, registry):
+        """regression guard: 실재 account → 200 + metrics 유지 (#1563)."""
+        from unittest.mock import AsyncMock, patch
+
+        from ante.trade.models import PerformanceMetrics
+
+        fake_db = AsyncMock()
+        fake_db.fetch_one = AsyncMock(return_value={"1": 1})
+        fake_metrics = PerformanceMetrics(total_trades=0)
+
+        registry._strategies = [
+            FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
+        ]
+
+        app = create_app(
+            strategy_registry=registry,
+            db=fake_db,
+            member_service=make_master_member_service(),
+        )
+        c = make_authed_client(app)
+
+        with patch(
+            "ante.trade.performance.PerformanceTracker.calculate",
+            new_callable=AsyncMock,
+            return_value=fake_metrics,
+        ) as mock_calc:
+            resp = c.get("/api/strategies/s1/performance?account_id=acc-real")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_trades"] == 0
+        mock_calc.assert_awaited_once()
+        assert mock_calc.await_args.kwargs["account_id"] == "acc-real"
+
+    def test_performance_missing_account_no_accounts_table(self, registry):
+        """accounts 테이블 부재 → 404 정규화, OperationalError 비누설 (#1563).
+
+        부분 초기화/legacy DB에서 ``no such table: accounts``가 전파되면
+        404 계약을 우회한다. 동일 404로 정규화하고 메시지를 누설하지 않는다.
+        """
+        import sqlite3
+        from unittest.mock import AsyncMock, patch
+
+        fake_db = AsyncMock()
+        fake_db.fetch_one = AsyncMock(
+            side_effect=sqlite3.OperationalError("no such table: accounts")
+        )
+
+        registry._strategies = [
+            FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
+        ]
+
+        app = create_app(
+            strategy_registry=registry,
+            db=fake_db,
+            member_service=make_master_member_service(),
+        )
+        c = make_authed_client(app)
+
+        with patch(
+            "ante.trade.performance.PerformanceTracker.calculate",
+            new_callable=AsyncMock,
+        ) as mock_calc:
+            resp = c.get(
+                "/api/strategies/s1/performance?account_id=oracle-missing-account"
+            )
+
+        assert resp.status_code == 404
+        detail = resp.json()["detail"]
+        assert "계좌를 찾을 수 없습니다" in detail
+        assert "no such table" not in detail
+        mock_calc.assert_not_awaited()
+
+    def test_performance_other_operational_error_propagates(self, registry):
+        """malformed db 등 다른 OperationalError는 삼키지 않고 전파 (#1563)."""
+        import sqlite3
+        from unittest.mock import AsyncMock
+
+        from fastapi.testclient import TestClient
+
+        from tests.unit.conftest import MASTER_AUTH_HEADERS
+
+        fake_db = AsyncMock()
+        fake_db.fetch_one = AsyncMock(
+            side_effect=sqlite3.OperationalError("database disk image is malformed")
+        )
+
+        registry._strategies = [
+            FakeStrategyRecord(strategy_id="s1", name="s1", version="1"),
+        ]
+
+        app = create_app(
+            strategy_registry=registry,
+            db=fake_db,
+            member_service=make_master_member_service(),
+        )
+        c = TestClient(app, raise_server_exceptions=False)
+        c.headers.update(MASTER_AUTH_HEADERS)
+
+        resp = c.get("/api/strategies/s1/performance?account_id=acc-test")
+        # 404로 정규화되지 않고 서버 에러로 전파된다.
+        assert resp.status_code == 500
+
 
 class TestUpdateStrategyStatus:
     """PATCH /api/strategies/{id}/status 테스트."""


### PR DESCRIPTION
Closes #1563

## Summary
- strategy performance가 존재하지 않는 account_id를 빈 성과 성공으로 반환하던 dual-surface 결함 수정.
- **CLI** `strategy performance --account-id <missing>`: strategy records 확인 후·`PerformanceTracker.calculate` 이전에 lightweight `SELECT 1 FROM accounts` 존재 확인 → 미존재 시 `AccountNotFoundError` → `fmt.error(str(e), code="ACCOUNT_NOT_FOUND"); raise SystemExit(1)` (머지된 #1556/#1559 패턴). strategy-not-found 분기는 그대로 우선.
- **API** `GET /api/strategies/{id}/performance?account_id=<missing>`: `resolved_account_id` 확정 후·calculate 이전에 동일 존재 확인 → 미존재 시 `HTTPException(404, "계좌를 찾을 수 없습니다: ...")` (portfolio.py:39 web 컨벤션). 기존 strategy-not-found 404 / account 미해결 400 분기 불변.
- `accounts` 테이블 부재(`sqlite3.OperationalError: no such table`)는 #1558/#1559 패턴대로 account-not-found로 정규화(그 외 OperationalError는 전파). 공통 `PerformanceTracker.calculate`·account_id resolution은 multi-consumer 보호 위해 불변(ingress별 검증).

## Plan Preflight & Review
- Codex Plan Review: approve-implement (dual-surface 단일 invariant, 단일 PR, split 아님). Codex 브랜치 리뷰: attempt1 finding(테스트 미사용 언패킹 — CI 실패 전제는 직접 ruff 실행으로 반증, trivial cleanup만 반영) → attempt2 PASS.

## Test Plan
- [x] `pytest tests/unit/test_cli_strategy.py tests/unit/test_strategy_api.py -q` → 76 passed
- [x] `pytest tests/unit/ -q -k "strategy and performance"` → 27 passed; `-k strategy` → 412 passed (회귀 없음)
- [x] failing→passing (미존재-account 7건: 변경 전 API200/CLI exit0 재현 → 후 404/exit1+ACCOUNT_NOT_FOUND), real-account/strategy-not-found/400 regression guard 유지
- [x] accounts 테이블 부재 정규화 + other-OperationalError 전파 가드 (CLI/API 각)
- [x] `ruff check`/`ruff format --check` clean (신규 파일 없음 — 기존 test 파일 확장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)