### PR TITLE
fix(cli): validate report performance --start/--end at CLI boundary (#1564)

### DIFF
--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -8,6 +8,7 @@ import json
 import click
 from pydantic import ValidationError
 
+from ante.cli._validators import validate_iso_date
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
 from ante.report.models import ReportStatus
@@ -234,8 +235,18 @@ def report_list(ctx: click.Context, status: str | None, db_path: str | None) -> 
     help="집계 기간 (daily 또는 monthly)",
 )
 @click.option("--bot-id", default=None, help="봇 ID 필터")
-@click.option("--start", default=None, help="시작일 (YYYY-MM-DD, daily 전용)")
-@click.option("--end", default=None, help="종료일 (YYYY-MM-DD, daily 전용)")
+@click.option(
+    "--start",
+    default=None,
+    callback=validate_iso_date,
+    help="시작일 (YYYY-MM-DD, daily 전용)",
+)
+@click.option(
+    "--end",
+    default=None,
+    callback=validate_iso_date,
+    help="종료일 (YYYY-MM-DD, daily 전용)",
+)
 @click.option("--year", default=None, type=int, help="연도 필터 (monthly 전용)")
 @click.pass_context
 @require_auth

--- a/tests/unit/test_cli_date_validation.py
+++ b/tests/unit/test_cli_date_validation.py
@@ -152,6 +152,16 @@ _TRADE_TO = (
     "trade-to",
     lambda v: ["trade", "list", "--to", v],
 )
+# `report performance --start/--end`는 daily 전용 date 옵션 (#1564).
+# `--period daily` 명시로 monthly 분기를 배제하고 date filter 경로만 탄다.
+_REPORT_PERF_START = (
+    "report-perf-start",
+    lambda v: ["report", "performance", "--period", "daily", "--start", v],
+)
+_REPORT_PERF_END = (
+    "report-perf-end",
+    lambda v: ["report", "performance", "--period", "daily", "--end", v],
+)
 
 ALL_OPTIONS = [
     _AUDIT_FROM_DATE,
@@ -161,6 +171,8 @@ ALL_OPTIONS = [
     _TREASURY_TO,
     _TRADE_FROM,
     _TRADE_TO,
+    _REPORT_PERF_START,
+    _REPORT_PERF_END,
 ]
 
 
@@ -389,6 +401,72 @@ class TestFormatJsonInvalidDate:
             ["--format", "json", "trade", "list", "--to", "not-a-date"],
         )
         _assert_date_rejected(result, hint_keywords=("not-a-date", "to"))
+
+    def test_report_performance_format_json_invalid_start(
+        self, runner: CliRunner
+    ) -> None:
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "report",
+                "performance",
+                "--period",
+                "daily",
+                "--start",
+                "not-a-date",
+            ],
+        )
+        _assert_date_rejected(result, hint_keywords=("not-a-date", "start"))
+
+    def test_report_performance_format_json_invalid_end(
+        self, runner: CliRunner
+    ) -> None:
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "report",
+                "performance",
+                "--period",
+                "daily",
+                "--end",
+                "not-a-date",
+            ],
+        )
+        _assert_date_rejected(result, hint_keywords=("not-a-date", "end"))
+
+    def test_report_performance_format_json_invalid_start_and_end(
+        self, runner: CliRunner
+    ) -> None:
+        """이슈 #1564 재현 조합: invalid `--start`/`--end` 동시 지정.
+
+        `ante --format json report performance --period daily
+        --start oracle-not-a-date --end also-not-a-date`가 returncode 0 +
+        빈 집계 성공으로 종료되던 ingress drift를 잠근다. callback이 가장
+        먼저 평가되는 `--start`에서 click.BadParameter를 raise하므로 exit
+        != 0이 보장된다.
+        """
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "report",
+                "performance",
+                "--period",
+                "daily",
+                "--start",
+                "oracle-not-a-date",
+                "--end",
+                "also-not-a-date",
+            ],
+        )
+        _assert_date_rejected(
+            result, hint_keywords=("oracle-not-a-date", "also-not-a-date")
+        )
 
 
 # ── #1514 핵심 invariant: trade list invalid date에서 traceback 미노출 ────


### PR DESCRIPTION
Closes #1564

## Summary
- `ante report performance --start/--end`가 invalid date를 검증 없이 `get_daily_summary`로 전달해 빈 집계(exit 0)로 반환하던 결함 수정.
- SSOT 재사용: `report performance`의 `--start`/`--end`에 `callback=validate_iso_date` 추가 (`src/ante/cli/_validators.py`, #1513 도입). audit.py/treasury.py/trade.py와 **동일 wiring**. invalid → `click.BadParameter` → click 표준 경로(text stderr + exit 2; `--format json`이면 #1551 middleware가 JSON error envelope). `None`(미지정)·유효 `YYYY-MM-DD`는 기존 동작 유지.

## Plan Preflight & Review
- Codex Plan Review: approve-implement (attempt 2 — JSON 모드 테스트 커버리지 보강 반영). Codex 브랜치 리뷰: attempt 1 PASS.

## Test Plan
- [x] `pytest tests/unit/test_cli_date_validation.py -q` → 118 passed
- [x] `pytest tests/unit/ -q -k "report or date_validation"` → 409 passed (회귀 없음)
- [x] `ALL_OPTIONS`에 `report-perf-start`/`report-perf-end` 추가(invalid-format/non-zero-padded/calendar/valid-passes 자동) + `TestFormatJsonInvalidDate`에 report-perf JSON 케이스 + 이슈 재현 조합 명시
- [x] failing→passing 확인 (text + `--format json` 모두), `ruff check`/`ruff format --check` clean
- 신규 테스트 파일 없음 (기존 `test_cli_date_validation.py` 확장 — #1513 명시 후속 scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)