### PR TITLE
fix(cli): reject non-finite/non-positive backtest --balance (#1565)

### DIFF
--- a/src/ante/cli/commands/backtest.py
+++ b/src/ante/cli/commands/backtest.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from ante.cli._validators import validate_positive_finite_amount
 from ante.cli.main import get_formatter
 
 if TYPE_CHECKING:
@@ -24,7 +25,13 @@ def backtest() -> None:
 @click.option("--start", required=True, help="시작일 (YYYY-MM-DD)")
 @click.option("--end", required=True, help="종료일 (YYYY-MM-DD)")
 @click.option("--symbols", help="종목 코드 (콤마 구분)")
-@click.option("--balance", default=10_000_000, type=float, help="초기 자금")
+@click.option(
+    "--balance",
+    default=10_000_000,
+    type=float,
+    callback=validate_positive_finite_amount,
+    help="초기 자금",
+)
 @click.option("--timeframe", default="1d", help="타임프레임")
 @click.option("--data-path", default="data/", help="데이터 디렉토리 경로")
 @click.option("--db-path", default=None, help="DB 경로 (미지정 시 config_dir 기반)")

--- a/tests/unit/test_cli_backtest_date_validation.py
+++ b/tests/unit/test_cli_backtest_date_validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
 from ante.cli.main import cli
@@ -125,3 +126,119 @@ class TestBacktestDateValidation:
         )
         assert result.exit_code == 1
         assert "날짜 형식" in result.output
+
+
+class TestBacktestBalanceValidation:
+    """backtest run --balance non-finite/non-positive 거부 (이슈 #1565)."""
+
+    @pytest.mark.parametrize("bad_balance", ["nan", "inf", "-inf", "-1", "0"])
+    def test_non_finite_or_non_positive_balance_rejected(self, tmp_path, bad_balance):
+        """nan/inf/음수/0 balance는 backtest 실행 전 non-zero exit으로 거부."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        with patch("ante.backtest.service.BacktestService") as mock_service:
+            result = runner.invoke(
+                cli,
+                [
+                    "backtest",
+                    "run",
+                    str(strategy),
+                    "--start",
+                    "2026-01-01",
+                    "--end",
+                    "2026-01-01",
+                    "--balance",
+                    bad_balance,
+                ],
+            )
+
+        # click.BadParameter → click 표준 경로 (exit 2, backtest 미실행)
+        assert result.exit_code != 0
+        mock_service.assert_not_called()
+
+    def test_nan_balance_rejected_in_json_mode(self, tmp_path):
+        """--format json 모드에서도 --balance nan은 non-zero exit (이슈 재현).
+
+        click 표준 경로이므로 stderr는 text다 (JSON envelope 표준화는
+        validator의 명시적 Non-Goal — 별도 이슈).
+        """
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        with patch("ante.backtest.service.BacktestService") as mock_service:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "backtest",
+                    "run",
+                    str(strategy),
+                    "--start",
+                    "2026-01-01",
+                    "--end",
+                    "2026-01-01",
+                    "--balance",
+                    "nan",
+                ],
+            )
+
+        assert result.exit_code != 0
+        mock_service.assert_not_called()
+
+    def test_valid_balance_passes_validation(self, tmp_path):
+        """유효한 양수 finite balance는 검증 통과 (기존 backtest 실행 경로 진입)."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        with patch("ante.backtest.service.BacktestService") as mock_service:
+            mock_service.side_effect = RuntimeError("stop after validation")
+            result = runner.invoke(
+                cli,
+                [
+                    "backtest",
+                    "run",
+                    str(strategy),
+                    "--start",
+                    "2026-01-01",
+                    "--end",
+                    "2026-01-01",
+                    "--balance",
+                    "5000000",
+                ],
+            )
+
+        # balance 검증을 통과해야만 BacktestService가 호출됨 (이후 mock이 차단)
+        mock_service.assert_called_once()
+        assert "양수" not in result.output
+        assert "finite" not in result.output
+
+    def test_default_balance_passes_validation(self, tmp_path):
+        """--balance 미지정(default 10_000_000)은 검증 통과 (기존 동작 유지)."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        with patch("ante.backtest.service.BacktestService") as mock_service:
+            mock_service.side_effect = RuntimeError("stop after validation")
+            result = runner.invoke(
+                cli,
+                [
+                    "backtest",
+                    "run",
+                    str(strategy),
+                    "--start",
+                    "2026-01-01",
+                    "--end",
+                    "2026-01-01",
+                ],
+            )
+
+        # default balance도 callback 통과 → BacktestService 진입
+        mock_service.assert_called_once()
+        assert "양수" not in result.output
+        assert "finite" not in result.output


### PR DESCRIPTION
Closes #1565

## Summary
- `ante backtest run --balance nan`(및 inf/음수/0)이 검증 없이 backtest를 실행해 exit 0 + 결과 JSON을 반환하던 결함 수정.
- SSOT 재사용: `backtest run`의 `--balance` 옵션에 `callback=validate_positive_finite_amount` 추가 (`src/ante/cli/_validators.py`, 오라클 #1517 / 머지 #1529). `treasury allocate/deallocate --amount`(treasury.py:88,129)와 동일 wiring. NaN/±Inf/0/음수 → `click.BadParameter` → click 표준 경로(text stderr + exit 2; `--format json`도 동일 경로 — JSON envelope 표준화는 validator 명시적 Non-Goal). default(10_000_000)·유효 양수 finite는 기존 동작 유지.

## Plan Preflight & Review
- Codex Plan Review: approve-implement ((a)-(f) 확인: exit2 treasury 정합, Click option callback default 무해, <=0 거부 정확, --balance 한정 scope 적절, 기존 backtest test 확장, downstream blocker 없음). Codex 브랜치 리뷰: attempt 1 PASS.

## Test Plan
- [x] `pytest tests/unit/test_cli_backtest_date_validation.py -q` → 12 passed (기존 4 date + 신규 8 balance)
- [x] `pytest tests/unit/ -q -k backtest` → 122 passed (회귀 없음)
- [x] failing→passing: callback 부착 전 nan/inf/-inf/-1/0 exit 0 + service 전파 → 부착 후 6 케이스 exit≠0 + service 미호출 (text + `--format json`)
- [x] regression guard: 유효 `--balance 5000000`·default 미지정 통과, `ruff check`/`ruff format --check` clean
- 신규 테스트 파일 없음 (기존 `test_cli_backtest_date_validation.py` 확장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)