### PR TITLE
docs(core,decisions): define canonical exchange vocabulary SSOT (#1575)

### DIFF
--- a/docs/decisions/D-016-canonical-exchange-vocabulary.md
+++ b/docs/decisions/D-016-canonical-exchange-vocabulary.md
@@ -1,0 +1,68 @@
+# D-016: canonical exchange vocabulary (2026-05-15)
+
+> Ante 설계 결정 기록.
+> 인덱스: [README.md](README.md)
+
+**결정**: Ante 전역에서 `exchange`가 의미하는 canonical vocabulary와 적용 범위를
+**단일 계약(SSOT)으로 확정**한다. 계약 본문(canonical set, wildcard 정책,
+canonical-known vs 1.0 account-supported 구분, exchange vs market/source/broker_type
+경계, per-surface 허용/거부·에러 계약 매트릭스, legacy 호환 정책, 소비자 매핑)은
+[docs/specs/core/core.md](../specs/core/core.md#canonical-exchange-vocabulary)
+`## Canonical Exchange Vocabulary` 절에 둔다. 본 ADR은 결정·근거·소비자 영향만
+기록하고 계약 디테일을 중복 기재하지 않는다.
+
+핵심:
+
+- `CanonicalExchange = {KRX, NYSE, NASDAQ, AMEX, TEST}` (대문자 고정 집합).
+- `*`는 실제 exchange가 아니라 `StrategyMeta.exchange` 전용 wildcard이며, 그 외
+  모든 경계(account/instrument/data write·read path/backtest override)에서 거부된다.
+- `KOSPI`/`KOSDAQ`/`KONEX`는 `exchange`가 아니라 KRX 내부 market/category이고,
+  `source`(`data_go_kr`,`dart`,`yahoo`)·`broker_type`(`kis-domestic`,`test`)은
+  exchange와 별개 차원이다.
+- canonical-known(검증 vocabulary 5종)과 1.0 account preset 제공(`KRX`,`TEST`만)은
+  구분한다.
+- 검증은 *신규 입력 경계*에만 적용한다. 기존 영속 row / 기존 Parquet path의
+  out-of-vocab 값은 read에서 거부·자동 삭제·자동 마이그레이션하지 않는다.
+
+**근거**:
+
+- 에픽 #1561은 `instrument` CLI가 `ORACLE_INVALID_EXCHANGE`(invalid exchange 입력)을
+  성공 처리한 A7 oracle 리포트에서 시작했다. 최신 스펙 확인 결과 instrument /
+  account / data / strategy 간 `exchange` 허용값의 SSOT가 부재했다:
+  - Instrument: `exchange: str = "KRX"`, 허용 vocabulary 미정의
+    (`docs/specs/instrument/instrument.md:32-34`).
+  - Strategy: `{KRX, NYSE, NASDAQ, AMEX, TEST, *}`
+    (`src/ante/strategy/validator.py:9` `VALID_EXCHANGES`).
+  - Account: `{KRX, NYSE, NASDAQ, TEST}` (`docs/specs/account/03-data-model.md:34`),
+    1.0 preset은 `KRX`,`TEST`만 (`:132`,`:140`).
+  - DataStore: `{KRX, NYSE, NASDAQ, AMEX, TEST}`를 path migration 판별에 사용
+    (`src/ante/data/store.py:26` `_KNOWN_EXCHANGES`).
+- SSOT가 없으면 oracle A7 host probe가 표면마다 invalid exchange 누락을 사후에
+  반복 발견한다(D-015의 인증 누락 회귀와 같은 구조의 문제). 계약을 먼저 스펙에
+  확정해야 enforcement·회귀 고정이 한 기준으로 수렴한다.
+- 계약 본문 위치를 `docs/specs/core/core.md`로 정한 이유: `exchange`는 특정 모듈
+  소유 개념이 아니라 instrument/account/data/strategy/backtest가 공유하는 식별
+  차원이며, core 모듈 개요가 "모든 모듈이 공유하는 기반 인프라"로 정의되어 있다.
+  D-016을 normative SSOT로 두면 ADR이 계약 본문을 머금게 되어 결정 기록의 역할을
+  벗어나므로, ADR은 core.md 절을 링크하는 결정 기록으로 유지한다.
+- wildcard `*`를 `StrategyMeta.exchange`에만 허용하는 이유: `*`는 거래소 식별자가
+  아니라 "시장 무관 범용 전략"이라는 전략 메타 의미값이다. account/instrument/data
+  경계에서 `*`는 실제 데이터·계좌·경로를 식별할 수 없으므로 거부가 자명하다.
+- legacy 무손상 호환을 택한 이유: 기존 DB/Parquet 마이그레이션 실행은 에픽 #1561
+  비목표다. 검증을 신규 입력 경계로 한정하면 계약 도입이 기존 데이터 읽기 호환성을
+  깨지 않고 점진 적용된다.
+
+**소비자 영향 및 후속 이슈**:
+
+| 소비자 / 작업 | 영향 | 후속 이슈 |
+|---------------|------|-----------|
+| 코드 레벨 SSOT(canonical 상수 단일화) | 표면별 상수 산재를 단일 SSOT로 정렬 | #1576 |
+| Instrument CLI `list`/`sync`/`import` | non-canonical 신규 입력 → non-zero exit + 구조화 error payload (주 신규 입력 표면) | #1577 |
+| account/data/backtest/strategy 경계면 정렬 + backtest `--exchange` 옵션 신설 | 표면별 거부 계약 정렬, backtest override는 현재 spec-vs-impl gap | #1578 |
+| 회귀 테스트 고정 | 표면별 거부 동작 회귀 방지 | #1579 |
+| 에픽 | 결정 사항 링크 | #1561 |
+
+본 ADR과 영향 스펙(instrument/strategy/account/data-pipeline/data-feed/cli)은
+core.md `## Canonical Exchange Vocabulary` 절을 단일 참조점으로 가리킨다. 영향
+스펙의 normative 값 집합은 본 결정에서 재작성하지 않으며, 표면별 enforcement·정렬은
+위 후속 이슈에서 수행한다(docs-only 결정).

--- a/docs/decisions/D-016-canonical-exchange-vocabulary.md
+++ b/docs/decisions/D-016-canonical-exchange-vocabulary.md
@@ -11,18 +11,18 @@ canonical-known vs 1.0 account-supported 구분, exchange vs market/source/broke
 `## Canonical Exchange Vocabulary` 절에 둔다. 본 ADR은 결정·근거·소비자 영향만
 기록하고 계약 디테일을 중복 기재하지 않는다.
 
-핵심:
+핵심 (결정 요약 — 계약 본문은 core.md `## Canonical Exchange Vocabulary`):
 
-- `CanonicalExchange = {KRX, NYSE, NASDAQ, AMEX, TEST}` (대문자 고정 집합).
-- `*`는 실제 exchange가 아니라 `StrategyMeta.exchange` 전용 wildcard이며, 그 외
-  모든 경계(account/instrument/data write·read path/backtest override)에서 거부된다.
-- `KOSPI`/`KOSDAQ`/`KONEX`는 `exchange`가 아니라 KRX 내부 market/category이고,
-  `source`(`data_go_kr`,`dart`,`yahoo`)·`broker_type`(`kis-domestic`,`test`)은
-  exchange와 별개 차원이다.
-- canonical-known(검증 vocabulary 5종)과 1.0 account preset 제공(`KRX`,`TEST`만)은
-  구분한다.
-- 검증은 *신규 입력 경계*에만 적용한다. 기존 영속 row / 기존 Parquet path의
-  out-of-vocab 값은 read에서 거부·자동 삭제·자동 마이그레이션하지 않는다.
+- canonical set·`StrategyMeta.exchange` 전용 wildcard·exchange vs market/source/
+  broker_type 경계·canonical-known vs 1.0 account preset 구분·per-surface 거부
+  계약·legacy 호환을 **단일 계약으로 확정**하고, 그 본문은 D-016이 아니라
+  [core.md `## Canonical Exchange Vocabulary`](../specs/core/core.md#canonical-exchange-vocabulary)
+  절에 둔다. 본 ADR은 계약 디테일(거부 경계·표면별 계약·필드명)을 독립 서술하지
+  않으며, 모든 디테일은 해당 절을 단일 참조점으로 가리킨다.
+- 검증 범위의 결정: 검증은 **신규 입력·경로 식별 경계에만** 적용하고, 기존
+  영속 데이터의 `read` 호환은 깨지 않는다(legacy 무손상 — 에픽 #1561 비목표).
+  `read`가 어떻게 규율되는지의 계약 본문은 core.md의 "Legacy out-of-vocabulary
+  호환 정책" 절이 SSOT다(`read`에 신규 입력 검증 미적용).
 
 **근거**:
 

--- a/docs/decisions/D-016-canonical-exchange-vocabulary.md
+++ b/docs/decisions/D-016-canonical-exchange-vocabulary.md
@@ -34,7 +34,8 @@ canonical-known vs 1.0 account-supported 구분, exchange vs market/source/broke
   - Strategy: `{KRX, NYSE, NASDAQ, AMEX, TEST, *}`
     (`src/ante/strategy/validator.py:9` `VALID_EXCHANGES`).
   - Account: `{KRX, NYSE, NASDAQ, TEST}` (`docs/specs/account/03-data-model.md:34`),
-    1.0 preset은 `KRX`,`TEST`만 (`:132`,`:140`).
+    1.0 preset은 `KRX`,`TEST`만 (`docs/specs/account/03-data-model.md`의
+    `BROKER_PRESETS` `test`/`kis-domestic` 항목).
   - DataStore: `{KRX, NYSE, NASDAQ, AMEX, TEST}`를 path migration 판별에 사용
     (`src/ante/data/store.py:26` `_KNOWN_EXCHANGES`).
 - SSOT가 없으면 oracle A7 host probe가 표면마다 invalid exchange 누락을 사후에

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -22,6 +22,7 @@
 | [D-013](D-013.md) | Stop Order 에뮬레이션 | - | Stop/Stop-Limit 주문을 시스템 내에서 에뮬레이션 |
 | [D-014](D-014.md) | 설정 API 구조 — Config API 단일화 | 2026-03-23 | 설정 화면은 기존 Config API로 일원화 |
 | [D-015](D-015-default-deny-auth-gate.md) | default-deny 인증 게이트 | 2026-05-11 | Web/CLI 모두 default-deny + allowlist (opt-out), middleware=인증·dependency=scope |
+| [D-016](D-016-canonical-exchange-vocabulary.md) | canonical exchange vocabulary | 2026-05-15 | Ante 전역 canonical exchange 집합·wildcard·legacy 호환 계약 SSOT |
 
 ## 사용 규칙
 

--- a/docs/specs/account/03-data-model.md
+++ b/docs/specs/account/03-data-model.md
@@ -103,8 +103,11 @@ class Account:
 
 > canonical exchange 계약 SSOT: [core.md `## Canonical Exchange Vocabulary`](../core/core.md#canonical-exchange-vocabulary).
 > `exchange`는 identity 필드이며 account는 canonical-only(`*` 거부) 표면이다. Web 런타임
-> `POST`/`PUT /api/accounts`는 cold-path 가드가 입력 무관 즉시 409(invariant I1, 422 아님),
-> 1.0 preset은 `KRX`,`TEST`만 제공한다(canonical-known 5종과 별개). 표면별 정렬은 #1578에서 다룬다.
+> `POST /api/accounts`(계좌 생성)와 `PUT /api/accounts/{account_id}`의 structural/identity
+> 필드 변경(`exchange` 등)은 cold-path 가드가 입력 무관 409(invariant I1, 422 아님)다.
+> `PUT`의 mutable-only 필드(`name`/`timezone`/`trading_hours`, `accounts.py:57-61`의
+> `MUTABLE_FIELDS`)는 런타임 허용이며 409가 아니다. 1.0 preset은 `KRX`,`TEST`만 제공한다
+> (canonical-known 5종과 별개). 표면별 정렬은 #1578에서 다룬다.
 
 ### BrokerPreset
 

--- a/docs/specs/account/03-data-model.md
+++ b/docs/specs/account/03-data-model.md
@@ -101,6 +101,11 @@ class Account:
 
 거래 모드나 브로커를 변경해야 하는 경우, 새 계좌를 생성하여 전환한다. `update()` 호출 시 불변 필드가 포함되면 `AccountImmutableFieldError`를 발생시킨다.
 
+> canonical exchange 계약 SSOT: [core.md `## Canonical Exchange Vocabulary`](../core/core.md#canonical-exchange-vocabulary).
+> `exchange`는 identity 필드이며 account는 canonical-only(`*` 거부) 표면이다. Web 런타임
+> `POST`/`PUT /api/accounts`는 cold-path 가드가 입력 무관 즉시 409(invariant I1, 422 아님),
+> 1.0 preset은 `KRX`,`TEST`만 제공한다(canonical-known 5종과 별개). 표면별 정렬은 #1578에서 다룬다.
+
 ### BrokerPreset
 
 브로커별 프리셋을 내부에 정의하여, 계좌 생성 시 거래소·브로커 선택만으로 나머지 필드를 자동 채운다. 사용자가 명시적으로 지정하지 않은 필드는 프리셋 기본값이 적용된다.

--- a/docs/specs/account/03-data-model.md
+++ b/docs/specs/account/03-data-model.md
@@ -105,7 +105,7 @@ class Account:
 > `exchange`는 identity 필드이며 account는 canonical-only(`*` 거부) 표면이다. Web 런타임
 > `POST /api/accounts`(계좌 생성)와 `PUT /api/accounts/{account_id}`의 structural/identity
 > 필드 변경(`exchange` 등)은 cold-path 가드가 입력 무관 409(invariant I1, 422 아님)다.
-> `PUT`의 mutable-only 필드(`name`/`timezone`/`trading_hours`, `accounts.py:57-61`의
+> `PUT`의 mutable-only 필드(`name`/`timezone`/`trading_hours_start`/`trading_hours_end`, `accounts.py:57-61`의
 > `MUTABLE_FIELDS`)는 런타임 허용이며 409가 아니다. 1.0 preset은 `KRX`,`TEST`만 제공한다
 > (canonical-known 5종과 별개). 표면별 정렬은 #1578에서 다룬다.
 > 참고: 이 문서의 `exchange` 설명/표에 남아 있는 `{KRX, NYSE, NASDAQ, TEST}` 나열은

--- a/docs/specs/account/03-data-model.md
+++ b/docs/specs/account/03-data-model.md
@@ -108,6 +108,10 @@ class Account:
 > `PUT`의 mutable-only 필드(`name`/`timezone`/`trading_hours`, `accounts.py:57-61`의
 > `MUTABLE_FIELDS`)는 런타임 허용이며 409가 아니다. 1.0 preset은 `KRX`,`TEST`만 제공한다
 > (canonical-known 5종과 별개). 표면별 정렬은 #1578에서 다룬다.
+> 참고: 이 문서의 `exchange` 설명/표에 남아 있는 `{KRX, NYSE, NASDAQ, TEST}` 나열은
+> canonical-known 5종(`{KRX, NYSE, NASDAQ, AMEX, TEST}`) 대비 **`AMEX` 누락 drift**다.
+> 이 이슈(#1575)는 normative 값 집합을 재작성하지 않으며, account schema/서비스 검증의
+> canonical 정렬(`AMEX` 포함 여부 포함)은 #1578에서 수행한다.
 
 ### BrokerPreset
 

--- a/docs/specs/account/03-data-model.md
+++ b/docs/specs/account/03-data-model.md
@@ -105,8 +105,8 @@ class Account:
 > `exchange`는 identity 필드이며 account는 canonical-only(`*` 거부) 표면이다. Web 런타임
 > `POST /api/accounts`(계좌 생성)와 `PUT /api/accounts/{account_id}`의 structural/identity
 > 필드 변경(`exchange` 등)은 cold-path 가드가 입력 무관 409(invariant I1, 422 아님)다.
-> `PUT`의 mutable-only 필드(`name`/`timezone`/`trading_hours_start`/`trading_hours_end`, `accounts.py:57-61`의
-> `MUTABLE_FIELDS`)는 런타임 허용이며 409가 아니다. 1.0 preset은 `KRX`,`TEST`만 제공한다
+> `PUT`의 mutable-only 필드(`name`/`timezone`/`trading_hours_start`/`trading_hours_end`,
+> `src/ante/web/routes/accounts.py`의 `MUTABLE_FIELDS`)는 런타임 허용이며 409가 아니다. 1.0 preset은 `KRX`,`TEST`만 제공한다
 > (canonical-known 5종과 별개). 표면별 정렬은 #1578에서 다룬다.
 > 참고: 이 문서의 `exchange` 설명/표에 남아 있는 `{KRX, NYSE, NASDAQ, TEST}` 나열은
 > canonical-known 5종(`{KRX, NYSE, NASDAQ, AMEX, TEST}`) 대비 **`AMEX` 누락 drift**다.

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -587,6 +587,11 @@ ante instrument search <query> [--limit N] [--listed-only] [--db-path <경로>] 
 ante instrument import <filepath> [--dry-run] [--db-path <경로>]  # CSV/JSON 종목 데이터 주입
 ```
 
+> canonical exchange 계약 SSOT: [core.md `## Canonical Exchange Vocabulary`](../core/core.md#canonical-exchange-vocabulary).
+> instrument는 canonical-only(`*` 거부) 주 신규 입력 표면이다. `list`/`sync`/`import`의
+> non-canonical `--exchange` / import payload는 non-zero exit + 구조화 error payload로 거부되어야
+> 한다(`ORACLE_INVALID_EXCHANGE` 출처). enforcement 정렬은 #1577에서 다룬다(현재 코드/스펙 drift).
+
 ### `ante notification` — 알림 관리
 
 `notification_history` 테이블 제거 후 public leaf command는 없다. 텔레그램 채팅방 자체가

--- a/docs/specs/core/core.md
+++ b/docs/specs/core/core.md
@@ -128,7 +128,9 @@ canonical-known은 신규 입력이 거부되지 않아야 하는 vocabulary이�
 | Instrument CLI `list`/`sync`/`import` | 허용 | 거부 | non-zero exit + 구조화 error payload (`{status:"error", code, message}`) | #1577 enforcement. **주 신규 입력 표면** (oracle `ORACLE_INVALID_EXCHANGE` 출처) |
 | Account CLI preset (`account add` 등) | preset에 정의된 exchange만 | 거부 | non-zero exit | preset 기반. preset 밖 값은 입력 불가 |
 | AccountService (생성/검증) | runtime-supported만 | 거부 | 서비스 검증 에러 | `exchange`는 identity 필드(`docs/specs/account/03-data-model.md:96`) |
-| Account Web 런타임 `POST`/`PUT /api/accounts` | — | — | **cold-path 가드가 입력 무관 즉시 409** (invariant I1; 계좌 topology는 cold-path 전용, `exchange`는 identity 필드) | **422 아님.** 입력값과 무관하게 런타임 변경 자체가 차단됨 |
+| Account Web — `POST /api/accounts` (cold-path 계좌 생성) | — | — | **cold-path 가드가 입력 무관 즉시 409** (invariant I1; `accounts.py:139,154,364`) | **422 아님.** `exchange` 포함 모든 입력이 런타임에 차단됨 (계좌 생성은 cold-path 전용) |
+| Account Web — `PUT /api/accounts/{account_id}` structural/identity 변경 (`exchange` 등) | — | — | **structural 가드가 409** (invariant I1/I4; `accounts.py:57-61`의 `STRUCTURAL_FIELDS`) | **422 아님.** `exchange`는 생성 후 수정 불가 identity 필드(`docs/specs/account/03-data-model.md:96`)이므로 런타임 변경 시도가 cold-path 409로 차단됨 |
+| Account Web — `PUT /api/accounts/{account_id}` mutable-only (`name`/`timezone`/`trading_hours`) | — | — | (exchange 검증 범위 밖) | **409 아님 — 런타임 허용.** `MUTABLE_FIELDS` 4종(`accounts.py:57-61`)은 정상 런타임 업데이트다. #1578 구현자는 이 경로를 cold-path 409로 막지 않는다 |
 | Account Web OpenAPI/schema 레벨 | — | — | 빈 문자열/형식 오류는 **422** | cold-path 문서(스키마 검증) 전용. 런타임 차단(409)과 다른 층 |
 | DataStore path API 메서드 표면 (`read`/`write`/`append` 등) | 허용 | 거부 | 신규 write/read path 생성 시 거부(스펙상 예외 처리) | feed/data CLI 옵션이 아니라 DataStore 메서드 인자 표면 |
 | `StrategyMeta.exchange` | 허용 | **허용** | validator 에러 | **`*` 유일 허용 표면** (`docs/specs/strategy/03-09-strategy-validator.md`) |

--- a/docs/specs/core/core.md
+++ b/docs/specs/core/core.md
@@ -129,7 +129,7 @@ canonical-known은 신규 입력이 거부되지 않아야 하는 vocabulary이�
 | 표면 | canonical | `*` | non-canonical 신규 입력 거부 계약 | 비고 |
 |------|-----------|-----|-----------------------------------|------|
 | Instrument CLI `list`/`sync`/`import` | 허용 | 거부 | non-zero exit + 구조화 error payload (`{status:"error", code, message}`) | #1577 enforcement. **주 신규 입력 표면** (oracle `ORACLE_INVALID_EXCHANGE` 출처) |
-| Account CLI preset (`account add` 등) | preset에 정의된 exchange만 | 거부 | non-zero exit | preset 기반. preset 밖 값은 입력 불가 |
+| Account CLI preset (`account create` 등) | preset에 정의된 exchange만 | 거부 | non-zero exit | preset 기반. preset 밖 값은 입력 불가 |
 | AccountService (생성/검증) | runtime-supported만 | 거부 | 서비스 검증 에러 | `exchange`는 identity 필드(`docs/specs/account/03-data-model.md:96`) |
 | Account Web — `POST /api/accounts` (cold-path 계좌 생성) | — | — | **cold-path 가드가 입력 무관 즉시 409** (invariant I1; `src/ante/web/routes/accounts.py`의 `create_account` 핸들러가 진입 즉시 409 raise) | **422 아님.** `exchange` 포함 모든 입력이 런타임에 차단됨 (계좌 생성은 cold-path 전용) |
 | Account Web — `PUT /api/accounts/{account_id}` structural/identity 변경 (`exchange` 등) | — | — | **structural 가드가 409** (invariant I1/I4; `src/ante/web/routes/accounts.py`의 `STRUCTURAL_FIELDS`에 `exchange` 포함) | **422 아님.** `exchange`는 생성 후 수정 불가 identity 필드(`docs/specs/account/03-data-model.md:96`)이므로 런타임 변경 시도가 cold-path 409로 차단됨 |

--- a/docs/specs/core/core.md
+++ b/docs/specs/core/core.md
@@ -58,6 +58,112 @@ canonical DB 경로이다. 기본값은 `<config_dir>/db/ante.db`이며, CWD 기
 
 > 파일 구조: [docs/architecture/generated/project-structure.md](../../architecture/generated/project-structure.md) 참조
 
+## Canonical Exchange Vocabulary
+
+> 이 절은 Ante 전역에서 `exchange`가 의미하는 **canonical vocabulary와 적용 범위의 계약 SSOT**다.
+> 결정 배경·근거·소비자 영향은 ADR [D-016](../../decisions/D-016-canonical-exchange-vocabulary.md)에 정리되어 있으며,
+> 본 절이 normative 계약 본문이다. ADR은 본 절을 링크하고 계약 본문을 중복 기재하지 않는다.
+
+`exchange`는 instrument / account / data / strategy / backtest가 공유하는 식별 차원이다.
+1.0 시점에 각 표면이 서로 다른 허용값 집합과 검증 동작을 갖고 있어 SSOT가 부재했고, 본 절이
+그 단일 계약을 확정한다. **런타임 enforcement·코드 동작 변경은 본 절의 범위가 아니다**(후속 이슈
+#1576/#1577/#1578/#1579로 위임). 본 절은 "무엇이 canonical이고 어느 경계에서 어떻게 거부되어야
+하는지"의 계약만 정의한다.
+
+### Canonical set
+
+```
+CanonicalExchange = {KRX, NYSE, NASDAQ, AMEX, TEST}
+```
+
+- canonical exchange 값은 **대문자 고정 집합**이다. 위 5종이 신규 입력 검증 vocabulary 전체다.
+- 대소문자 정규화·별칭(alias)·사용자 정의 exchange set은 1.0 비목표다. 입력은 위 리터럴과
+  정확히 일치해야 한다.
+- 코드 레벨 SSOT(상수 단일화)는 #1576의 범위다. 본 절은 값 집합 자체의 계약만 고정한다.
+
+### Wildcard 정책
+
+- `*`는 **실제 exchange가 아니다.** `StrategyMeta.exchange` 전용 wildcard로, "OHLCV만 있으면
+  어떤 시장에서도 동작하는 범용 전략"을 의미한다.
+- `*`가 허용되는 표면은 **`StrategyMeta.exchange` 단 하나**다.
+- account / instrument / data write·read path / backtest `--exchange` override 등 다른 모든
+  경계에서 `*`는 거부된다(실제 거래소 식별자가 아니므로).
+
+### Canonical-known vs 1.0 runtime/account-supported
+
+canonical-known(=검증 vocabulary)과 1.0 시점 account preset이 실제 제공하는 exchange는 다르다.
+
+| exchange | canonical-known | 1.0 account preset 제공 | 비고 |
+|----------|-----------------|-------------------------|------|
+| `KRX` | O | O | `kis-domestic` preset (`docs/specs/account/03-data-model.md:140`) |
+| `TEST` | O | O | `test` preset (`docs/specs/account/03-data-model.md:132`) |
+| `NYSE` | O | X | canonical-known이나 1.0 account preset 미제공 |
+| `NASDAQ` | O | X | canonical-known이나 1.0 account preset 미제공 |
+| `AMEX` | O | X | canonical-known이나 1.0 account preset 미제공 |
+
+canonical-known은 신규 입력이 거부되지 않아야 하는 vocabulary이고, account preset 제공 여부는
+"1.0에서 실제 계좌를 만들 수 있는가"와 별개 차원이다. `NYSE/NASDAQ/AMEX`는 canonical vocabulary
+이지만 1.0 account preset은 `KRX`,`TEST`만 제공한다.
+
+### exchange vs market vs source vs broker_type
+
+`exchange`는 아래 차원들과 **별개**이며 서로 값을 섞지 않는다.
+
+| 차원 | 값 예 | 의미 | exchange와의 관계 |
+|------|-------|------|-------------------|
+| `exchange` | `KRX`, `NYSE`, `NASDAQ`, `AMEX`, `TEST` | 거래소 (canonical vocabulary) | — |
+| market / category | `KOSPI`, `KOSDAQ`, `KONEX` | KRX 내부 시장구분 | **거래소가 아니다.** `exchange=KRX`의 하위 market. exchange 자리에 올 수 없다 |
+| `source` | `data_go_kr`, `dart`, `yahoo` | 데이터 출처 | exchange와 별개 차원. 검증·경로에서 교차하지 않는다 |
+| `broker_type` | `kis-domestic`, `test` | 브로커 어댑터 종류 | exchange와 별개 차원. preset이 broker_type→exchange를 매핑할 뿐 동일하지 않다 |
+
+`KOSPI`/`KOSDAQ`/`KONEX`는 `exchange` 값이 아니라 KRX 내부 market/category다(`docs/specs/data-feed/04-schema.md`의 `market` 필드 참조). broker adapter market code(`KOSPI`/`KOSDAQ`) 정규화는 1.0 비목표다.
+
+### Per-surface 허용/거부 + 검증·에러 계약 매트릭스
+
+검증은 **표면별로 분리**된다. 같은 vocabulary라도 어느 경계에서 어떤 에러 계약으로 거부되는지는
+표면마다 다르다.
+
+| 표면 | canonical | `*` | non-canonical 신규 입력 거부 계약 | 비고 |
+|------|-----------|-----|-----------------------------------|------|
+| Instrument CLI `list`/`sync`/`import` | 허용 | 거부 | non-zero exit + 구조화 error payload (`{status:"error", code, message}`) | #1577 enforcement. **주 신규 입력 표면** (oracle `ORACLE_INVALID_EXCHANGE` 출처) |
+| Account CLI preset (`account add` 등) | preset에 정의된 exchange만 | 거부 | non-zero exit | preset 기반. preset 밖 값은 입력 불가 |
+| AccountService (생성/검증) | runtime-supported만 | 거부 | 서비스 검증 에러 | `exchange`는 identity 필드(`docs/specs/account/03-data-model.md:96`) |
+| Account Web 런타임 `POST`/`PUT /api/accounts` | — | — | **cold-path 가드가 입력 무관 즉시 409** (invariant I1; 계좌 topology는 cold-path 전용, `exchange`는 identity 필드) | **422 아님.** 입력값과 무관하게 런타임 변경 자체가 차단됨 |
+| Account Web OpenAPI/schema 레벨 | — | — | 빈 문자열/형식 오류는 **422** | cold-path 문서(스키마 검증) 전용. 런타임 차단(409)과 다른 층 |
+| DataStore path API 메서드 표면 (`read`/`write`/`append` 등) | 허용 | 거부 | 신규 write/read path 생성 시 거부(스펙상 예외 처리) | feed/data CLI 옵션이 아니라 DataStore 메서드 인자 표면 |
+| `StrategyMeta.exchange` | 허용 | **허용** | validator 에러 | **`*` 유일 허용 표면** (`docs/specs/strategy/03-09-strategy-validator.md`) |
+| Backtest `--exchange` override | (목표: canonical만) | (목표: 거부) | **현재 CLI/`src/ante/backtest/`에 미구현 — spec-vs-implementation gap** | #1578 정렬 대상(옵션 신설 포함). 기존 표면처럼 서술하지 않는다 |
+
+판정 보조 노트:
+- 시나리오 1(스펙만으로 `*` 허용 여부 판단): 위 표에서 `*` 허용은 `StrategyMeta.exchange`
+  단 하나, `Instrument.exchange`/`Account.exchange`/`DataStore exchange`는 모두 `*` 거부다.
+- 시나리오 2(`ORACLE_INVALID_EXCHANGE`가 신규 입력에서 거부되어야 하는가): Instrument CLI
+  `list`/`sync`/`import` 행에 따라 non-canonical 신규 입력은 non-zero exit + 구조화 error
+  payload로 거부되어야 한다(enforcement는 #1577).
+- 시나리오 3(`KOSPI`는 exchange인가): "exchange vs market vs source vs broker_type" 절에 따라
+  `KOSPI`는 exchange가 아니라 KRX 내부 market/category다.
+
+### Legacy out-of-vocabulary 호환 정책
+
+- 검증은 **신규 입력 경계에만** 적용한다.
+- 기존 영속 row(SQLite) / 기존 Parquet path의 out-of-vocab `exchange` 값은 read에서 거부하지
+  않는다. **자동 삭제·자동 마이그레이션하지 않는다**(에픽 #1561 비목표). 별도 마이그레이션
+  결정이 내려지기 전까지 기존 데이터는 그대로 읽힌다.
+- 즉 "out-of-vocab 값이 거부된다"는 새 데이터를 *쓰거나 입력으로 받을 때*만 적용되며, 이미
+  저장된 데이터의 읽기 호환성은 깨지 않는다.
+
+### 소비자 목록 + 후속 이슈 매핑
+
+본 절은 계약 정의 + 영향 스펙 최소 포인터까지다. 실제 동작 정렬은 후속 이슈로 위임한다.
+
+| 소비자 / 작업 | 후속 이슈 |
+|---------------|-----------|
+| 코드 레벨 SSOT 도입(canonical 상수 단일화) | #1576 |
+| Instrument CLI enforcement(주 신규 입력 표면) | #1577 |
+| account / data / backtest / strategy 경계면 정렬 + backtest `--exchange` 옵션 신설 | #1578 |
+| 회귀 테스트 고정 | #1579 |
+| 에픽 | #1561 |
+
 ## Logging 연계
 
 시스템 로그 인프라는 별도 모듈 스펙 [logging/README.md](../logging/README.md)로 분리되어 있다. Core는 시스템 초기화 순서상 로깅 설정(`setup_logging`)을 Database 이전 단계에서 수행한다.

--- a/docs/specs/core/core.md
+++ b/docs/specs/core/core.md
@@ -140,16 +140,24 @@ canonical-known은 신규 입력이 거부되지 않아야 하는 vocabulary이�
 검증은 **표면별로 분리**된다. 같은 vocabulary라도 어느 경계에서 어떤 에러 계약으로 거부되는지는
 표면마다 다르다.
 
+**범위 불변식**: 본 절은 exchange-vocabulary 유효성 계약(canonical 5종 비거부 / `*` 규칙 /
+legacy read 호환 / 에러 계층 409·422·non-zero / 축 A·B)을 정의한다. surface별 source 지원·
+preset wiring·enforcement·구현 동작·정렬은 #1577/#1578에 위임되며 본 절에서 완전 명세하지
+않는다. #1577/#1578 구현자는 본 절의 vocabulary 계약을 상위 기준으로 삼고 surface 동작을 그
+아래에서 정렬한다. 따라서 아래 표의 각 행은 vocabulary 계약과 에러 계층까지만 계약화하며,
+surface 운영/소스/핸들러 디테일은 후속 이슈 정렬 사안으로 표기한다.
+
 | 표면 | canonical | `*` | non-canonical 신규 입력 거부 계약 | 비고 |
 |------|-----------|-----|-----------------------------------|------|
-| Instrument CLI `list`/`sync`/`import` | 허용 | 거부 | non-zero exit + 구조화 error payload (`{status:"error", code, message}`) | #1577 enforcement. **주 신규 입력 표면** (oracle `ORACLE_INVALID_EXCHANGE` 출처) |
-| Account CLI preset (`account create` 등) | canonical 5종은 invalid-exchange로 거부되지 않음 (축 A); 1.0 preset 자동 구성은 `KRX`/`TEST` preset만 (축 B) | 거부 | non-zero exit | 축 A: `*`/non-canonical은 거부. 축 B: 1.0 preset 경로는 `KRX`(`kis-domestic`)/`TEST`(`test`) preset만 자동 구성하며, preset 미제공 canonical 값(`NYSE/NASDAQ/AMEX`)은 **preset/broker 가용성 제약**이지 invalid-exchange 거부가 아니다(별개 차원) |
+| Instrument CLI `list`/`import` | 허용 | 거부 | non-zero exit + 구조화 error payload (`{status:"error", code, message}`) | #1577 enforcement. **주 신규 입력 표면** (oracle `ORACLE_INVALID_EXCHANGE` 출처) |
+| Instrument CLI `sync` | 허용 (vocabulary 측면은 동일: canonical 5종만 유효, non-canonical 거부) | 거부 | non-zero exit + 구조화 error payload | **source-bound 표면.** `sync`는 KIS API(KRX 도메인)에서만 마스터를 가져와 전달 `exchange`를 저장 라벨로 쓴다(`src/ante/cli/commands/instrument.py`의 `sync`→`KISAdapter.get_instruments`, `docs/specs/instrument/` source 계약). 따라서 canonical이지만 source 미지원 exchange(`NYSE/NASDAQ/AMEX` 등 비-KRX)에 대한 sync 동작·에러 계약은 **source-supported-exchange 정렬 사안으로 #1577에 위임**(backtest `--exchange`처럼 spec-vs-implementation gap). 본 SSOT는 "sync는 source-bound이며 source 미지원 canonical 값 처리 계약은 #1577" 까지만 명시하고 완전 명세하지 않는다 |
+| Account CLI preset (`account create` 등) | canonical 5종은 invalid-exchange로 거부되지 않음 (축 A); preset 미제공 canonical 값은 축 B 제약 | 거부 | non-zero exit | 축 A: `*`/non-canonical은 거부. 축 B: canonical이지만 1.0 preset 미제공 값(`NYSE/NASDAQ/AMEX`)은 **preset/broker 가용성 제약**이지 invalid-exchange 거부가 아니다(별개 차원). 구체적 preset wiring(어떤 preset이 어떤 exchange를 자동 구성하는가)은 축 B canonical-known 표·축 B 정의를 상위 기준으로 삼아 **#1578에서 정렬**한다 — 본 행은 vocabulary 계약(축 A 비거부 / `*`·non-canonical 거부)만 명시한다 |
 | AccountService (생성/검증) | canonical 5종 허용 (축 A: non-canonical만 서비스 검증 에러) | 거부 | 서비스 검증 에러 | `exchange`는 identity 필드(`docs/specs/account/03-data-model.md:96`). canonical 5종은 서비스 exchange 검증에서 거부되지 않는다. 1.0 account preset이 `NYSE/NASDAQ/AMEX`를 미제공하는 것은 **축 B(preset/broker 가용성) 제약**이며 "invalid exchange 거부"가 아니다(별개 차원) |
-| Account Web — `POST /api/accounts` (cold-path 계좌 생성) | — | — | **cold-path 가드가 입력 무관 즉시 409** (invariant I1; `src/ante/web/routes/accounts.py`의 `create_account` 핸들러가 진입 즉시 409 raise) | **422 아님.** `exchange` 포함 모든 입력이 런타임에 차단됨 (계좌 생성은 cold-path 전용) |
-| Account Web — `PUT /api/accounts/{account_id}` structural/identity 변경 (`exchange` 등) | — | — | **structural 가드가 409** (invariant I1/I4; `src/ante/web/routes/accounts.py`의 `STRUCTURAL_FIELDS`에 `exchange` 포함) | **422 아님.** `exchange`는 생성 후 수정 불가 identity 필드(`docs/specs/account/03-data-model.md:96`)이므로 런타임 변경 시도가 cold-path 409로 차단됨 |
-| Account Web — `PUT /api/accounts/{account_id}` mutable-only (`name`/`timezone`/`trading_hours_start`/`trading_hours_end`) | — | — | (exchange 검증 범위 밖) | **409 아님 — 런타임 허용.** `src/ante/web/routes/accounts.py`의 `MUTABLE_FIELDS` 4종은 정상 런타임 업데이트다. #1578 구현자는 이 경로를 cold-path 409로 막지 않는다 |
+| Account Web — `POST /api/accounts` (cold-path 계좌 생성) | — | — | **cold-path 차단 계층은 409** (계좌 생성은 cold-path 전용, `exchange` 포함 입력 무관) | **422 아님.** 진입 가드의 구체 동작·핸들러는 #1578에서 정렬한다 — 본 행은 "cold-path → 409, 스키마 층 422 아님"의 에러 계층만 명시한다 |
+| Account Web — `PUT /api/accounts/{account_id}` structural/identity 변경 (`exchange` 등) | — | — | **structural/identity 변경 차단 계층은 409** | **422 아님.** `exchange`는 생성 후 수정 불가 identity 필드(`docs/specs/account/03-data-model.md:96`)이므로 런타임 변경 시도는 cold-path 계층(409)에서 차단된다. structural 필드 집합·가드 구현은 #1578에서 정렬한다 |
+| Account Web — `PUT /api/accounts/{account_id}` mutable-only (`name`/`timezone`/`trading_hours_start`/`trading_hours_end`) | — | — | (exchange 검증 범위 밖) | **409 아님 — 런타임 허용 계층.** mutable-only 업데이트는 정상 런타임 경로이며 cold-path 409로 차단되지 않는다. mutable 필드 집합의 구현 정렬은 #1578에 위임한다 |
 | Account Web OpenAPI/schema 레벨 | — | — | 빈 문자열/형식 오류는 **422** | cold-path 문서(스키마 검증) 전용. 런타임 차단(409)과 다른 층 |
-| DataStore path API — `write`/`append`/신규 경로 생성 | 허용 | 거부 | 신규 경로 생성 시 non-canonical·`*` 거부(스펙상 예외 처리) | feed/data CLI 옵션이 아니라 DataStore 메서드 인자 표면. `*`는 경로로 해석 불가 |
+| DataStore path API — `write`/`append`/신규 경로 생성 | 허용 | 거부 | 신규 경로 생성 시 non-canonical·`*` 거부 | feed/data CLI 옵션이 아니라 DataStore 메서드 인자 표면. `*`는 경로로 해석 불가. 거부의 구현 동작(예외 처리 방식 등)은 #1578에서 정렬하며, 본 행은 "신규 경로 생성 시 non-canonical·`*` 거부"의 vocabulary 계약만 명시한다 |
 | DataStore path API — `read`(기존 경로, legacy out-of-vocab 포함) | 허용 | (입력 검증 미적용) | **거부하지 않음.** 신규 입력 검증을 기존 경로 read 인자에 적용하지 않는다 | "Legacy out-of-vocabulary 호환 정책" 절 우선. 이미 저장된 legacy 경로(예: `.../ohlcv/1d/LSE/...`)는 그대로 읽힌다 |
 | `StrategyMeta.exchange` | 허용 | **허용** | validator 에러 | **`*` 유일 허용 표면** (`docs/specs/strategy/03-09-strategy-validator.md`) |
 | Backtest `--exchange` override | (목표: canonical만) | (목표: 거부) | **현재 CLI/`src/ante/backtest/`에 미구현 — spec-vs-implementation gap** | #1578 정렬 대상(옵션 신설 포함). 기존 표면처럼 서술하지 않는다 |
@@ -161,8 +169,10 @@ canonical-known은 신규 입력이 거부되지 않아야 하는 vocabulary이�
   신규 입력 검증을 적용하지 않으므로 `*` 거부 판정 대상이 아니다 — `*`는 저장된 legacy
   경로가 될 수 없고, 기존 경로 read 호환은 "Legacy out-of-vocabulary 호환 정책"이 규율한다.
 - 시나리오 2(`ORACLE_INVALID_EXCHANGE`가 신규 입력에서 거부되어야 하는가): Instrument CLI
-  `list`/`sync`/`import` 행에 따라 non-canonical 신규 입력은 non-zero exit + 구조화 error
-  payload로 거부되어야 한다(enforcement는 #1577).
+  `list`/`import`(및 vocabulary 측면에서 동일한 `sync`) 행에 따라 non-canonical 신규 입력은
+  non-zero exit + 구조화 error payload로 거부되어야 한다(enforcement는 #1577). `sync`의
+  source 미지원 canonical 값(`NYSE/NASDAQ/AMEX` 등 비-KRX) 처리 계약은 source-bound 표면
+  사안으로 #1577에 위임된다 — 본 SSOT 단독으로는 vocabulary 거부(non-canonical)만 판정한다.
 - 시나리오 3(`KOSPI`는 exchange인가): "exchange vs market vs source vs broker_type" 절에 따라
   `KOSPI`는 exchange가 아니라 KRX 내부 market/category다.
 

--- a/docs/specs/core/core.md
+++ b/docs/specs/core/core.md
@@ -86,8 +86,11 @@ CanonicalExchange = {KRX, NYSE, NASDAQ, AMEX, TEST}
 - `*`는 **실제 exchange가 아니다.** `StrategyMeta.exchange` 전용 wildcard로, "OHLCV만 있으면
   어떤 시장에서도 동작하는 범용 전략"을 의미한다.
 - `*`가 허용되는 표면은 **`StrategyMeta.exchange` 단 하나**다.
-- account / instrument / data write·read path / backtest `--exchange` override 등 다른 모든
-  경계에서 `*`는 거부된다(실제 거래소 식별자가 아니므로).
+- account / instrument / DataStore write·append·경로 해석(신규 경로 생성) / backtest
+  `--exchange` override 등 다른 모든 신규 입력·경로 식별 경계에서 `*`는 거부된다(실제
+  거래소 식별자·경로가 아니므로). 기존 경로 read 호환은 `*` 거부가 아니라 "Legacy
+  out-of-vocabulary 호환 정책"이 규율한다(`*`는 저장된 legacy 경로가 될 수 없으므로
+  read에 신규 입력 검증을 적용하지 않는다).
 
 ### Canonical-known vs 1.0 runtime/account-supported
 
@@ -95,8 +98,8 @@ canonical-known(=검증 vocabulary)과 1.0 시점 account preset이 실제 제�
 
 | exchange | canonical-known | 1.0 account preset 제공 | 비고 |
 |----------|-----------------|-------------------------|------|
-| `KRX` | O | O | `kis-domestic` preset (`docs/specs/account/03-data-model.md:140`) |
-| `TEST` | O | O | `test` preset (`docs/specs/account/03-data-model.md:132`) |
+| `KRX` | O | O | `kis-domestic` preset (`docs/specs/account/03-data-model.md`의 `BROKER_PRESETS` `kis-domestic` 항목, `exchange="KRX"`) |
+| `TEST` | O | O | `test` preset (`docs/specs/account/03-data-model.md`의 `BROKER_PRESETS` `test` 항목, `exchange="TEST"`) |
 | `NYSE` | O | X | canonical-known이나 1.0 account preset 미제공 |
 | `NASDAQ` | O | X | canonical-known이나 1.0 account preset 미제공 |
 | `AMEX` | O | X | canonical-known이나 1.0 account preset 미제공 |
@@ -128,17 +131,21 @@ canonical-known은 신규 입력이 거부되지 않아야 하는 vocabulary이�
 | Instrument CLI `list`/`sync`/`import` | 허용 | 거부 | non-zero exit + 구조화 error payload (`{status:"error", code, message}`) | #1577 enforcement. **주 신규 입력 표면** (oracle `ORACLE_INVALID_EXCHANGE` 출처) |
 | Account CLI preset (`account add` 등) | preset에 정의된 exchange만 | 거부 | non-zero exit | preset 기반. preset 밖 값은 입력 불가 |
 | AccountService (생성/검증) | runtime-supported만 | 거부 | 서비스 검증 에러 | `exchange`는 identity 필드(`docs/specs/account/03-data-model.md:96`) |
-| Account Web — `POST /api/accounts` (cold-path 계좌 생성) | — | — | **cold-path 가드가 입력 무관 즉시 409** (invariant I1; `accounts.py:139,154,364`) | **422 아님.** `exchange` 포함 모든 입력이 런타임에 차단됨 (계좌 생성은 cold-path 전용) |
-| Account Web — `PUT /api/accounts/{account_id}` structural/identity 변경 (`exchange` 등) | — | — | **structural 가드가 409** (invariant I1/I4; `accounts.py:57-61`의 `STRUCTURAL_FIELDS`) | **422 아님.** `exchange`는 생성 후 수정 불가 identity 필드(`docs/specs/account/03-data-model.md:96`)이므로 런타임 변경 시도가 cold-path 409로 차단됨 |
-| Account Web — `PUT /api/accounts/{account_id}` mutable-only (`name`/`timezone`/`trading_hours_start`/`trading_hours_end`) | — | — | (exchange 검증 범위 밖) | **409 아님 — 런타임 허용.** `MUTABLE_FIELDS` 4종(`accounts.py:57-61`)은 정상 런타임 업데이트다. #1578 구현자는 이 경로를 cold-path 409로 막지 않는다 |
+| Account Web — `POST /api/accounts` (cold-path 계좌 생성) | — | — | **cold-path 가드가 입력 무관 즉시 409** (invariant I1; `src/ante/web/routes/accounts.py`의 `create_account` 핸들러가 진입 즉시 409 raise) | **422 아님.** `exchange` 포함 모든 입력이 런타임에 차단됨 (계좌 생성은 cold-path 전용) |
+| Account Web — `PUT /api/accounts/{account_id}` structural/identity 변경 (`exchange` 등) | — | — | **structural 가드가 409** (invariant I1/I4; `src/ante/web/routes/accounts.py`의 `STRUCTURAL_FIELDS`에 `exchange` 포함) | **422 아님.** `exchange`는 생성 후 수정 불가 identity 필드(`docs/specs/account/03-data-model.md:96`)이므로 런타임 변경 시도가 cold-path 409로 차단됨 |
+| Account Web — `PUT /api/accounts/{account_id}` mutable-only (`name`/`timezone`/`trading_hours_start`/`trading_hours_end`) | — | — | (exchange 검증 범위 밖) | **409 아님 — 런타임 허용.** `src/ante/web/routes/accounts.py`의 `MUTABLE_FIELDS` 4종은 정상 런타임 업데이트다. #1578 구현자는 이 경로를 cold-path 409로 막지 않는다 |
 | Account Web OpenAPI/schema 레벨 | — | — | 빈 문자열/형식 오류는 **422** | cold-path 문서(스키마 검증) 전용. 런타임 차단(409)과 다른 층 |
-| DataStore path API 메서드 표면 (`read`/`write`/`append` 등) | 허용 | 거부 | 신규 write/read path 생성 시 거부(스펙상 예외 처리) | feed/data CLI 옵션이 아니라 DataStore 메서드 인자 표면 |
+| DataStore path API — `write`/`append`/신규 경로 생성 | 허용 | 거부 | 신규 경로 생성 시 non-canonical·`*` 거부(스펙상 예외 처리) | feed/data CLI 옵션이 아니라 DataStore 메서드 인자 표면. `*`는 경로로 해석 불가 |
+| DataStore path API — `read`(기존 경로, legacy out-of-vocab 포함) | 허용 | (입력 검증 미적용) | **거부하지 않음.** 신규 입력 검증을 기존 경로 read 인자에 적용하지 않는다 | "Legacy out-of-vocabulary 호환 정책" 절 우선. 이미 저장된 legacy 경로(예: `.../ohlcv/1d/LSE/...`)는 그대로 읽힌다 |
 | `StrategyMeta.exchange` | 허용 | **허용** | validator 에러 | **`*` 유일 허용 표면** (`docs/specs/strategy/03-09-strategy-validator.md`) |
 | Backtest `--exchange` override | (목표: canonical만) | (목표: 거부) | **현재 CLI/`src/ante/backtest/`에 미구현 — spec-vs-implementation gap** | #1578 정렬 대상(옵션 신설 포함). 기존 표면처럼 서술하지 않는다 |
 
 판정 보조 노트:
 - 시나리오 1(스펙만으로 `*` 허용 여부 판단): 위 표에서 `*` 허용은 `StrategyMeta.exchange`
-  단 하나, `Instrument.exchange`/`Account.exchange`/`DataStore exchange`는 모두 `*` 거부다.
+  단 하나다. `Instrument.exchange`/`Account.exchange`/DataStore `write`·`append`·신규 경로
+  생성은 모두 `*` 거부다(`*`는 실제 거래소 식별자·경로가 아니므로). DataStore `read`는
+  신규 입력 검증을 적용하지 않으므로 `*` 거부 판정 대상이 아니다 — `*`는 저장된 legacy
+  경로가 될 수 없고, 기존 경로 read 호환은 "Legacy out-of-vocabulary 호환 정책"이 규율한다.
 - 시나리오 2(`ORACLE_INVALID_EXCHANGE`가 신규 입력에서 거부되어야 하는가): Instrument CLI
   `list`/`sync`/`import` 행에 따라 non-canonical 신규 입력은 non-zero exit + 구조화 error
   payload로 거부되어야 한다(enforcement는 #1577).
@@ -153,6 +160,10 @@ canonical-known은 신규 입력이 거부되지 않아야 하는 vocabulary이�
   결정이 내려지기 전까지 기존 데이터는 그대로 읽힌다.
 - 즉 "out-of-vocab 값이 거부된다"는 새 데이터를 *쓰거나 입력으로 받을 때*만 적용되며, 이미
   저장된 데이터의 읽기 호환성은 깨지 않는다.
+- 이 정책은 위 매트릭스의 **DataStore `read`(기존 경로, legacy 포함)** 행에 우선한다:
+  DataStore에서 non-canonical·`*` 거부는 `write`/`append`/신규 경로 생성에만 적용되고,
+  기존 경로(예: `.../ohlcv/1d/LSE/...`) read 인자에는 신규 입력 검증을 적용하지 않는다.
+  `*`는 저장된 legacy 경로가 될 수 없으므로 경로 해석·write에서의 `*` 거부와도 충돌하지 않는다.
 
 ### 소비자 목록 + 후속 이슈 매핑
 

--- a/docs/specs/core/core.md
+++ b/docs/specs/core/core.md
@@ -130,7 +130,7 @@ canonical-known은 신규 입력이 거부되지 않아야 하는 vocabulary이�
 | AccountService (생성/검증) | runtime-supported만 | 거부 | 서비스 검증 에러 | `exchange`는 identity 필드(`docs/specs/account/03-data-model.md:96`) |
 | Account Web — `POST /api/accounts` (cold-path 계좌 생성) | — | — | **cold-path 가드가 입력 무관 즉시 409** (invariant I1; `accounts.py:139,154,364`) | **422 아님.** `exchange` 포함 모든 입력이 런타임에 차단됨 (계좌 생성은 cold-path 전용) |
 | Account Web — `PUT /api/accounts/{account_id}` structural/identity 변경 (`exchange` 등) | — | — | **structural 가드가 409** (invariant I1/I4; `accounts.py:57-61`의 `STRUCTURAL_FIELDS`) | **422 아님.** `exchange`는 생성 후 수정 불가 identity 필드(`docs/specs/account/03-data-model.md:96`)이므로 런타임 변경 시도가 cold-path 409로 차단됨 |
-| Account Web — `PUT /api/accounts/{account_id}` mutable-only (`name`/`timezone`/`trading_hours`) | — | — | (exchange 검증 범위 밖) | **409 아님 — 런타임 허용.** `MUTABLE_FIELDS` 4종(`accounts.py:57-61`)은 정상 런타임 업데이트다. #1578 구현자는 이 경로를 cold-path 409로 막지 않는다 |
+| Account Web — `PUT /api/accounts/{account_id}` mutable-only (`name`/`timezone`/`trading_hours_start`/`trading_hours_end`) | — | — | (exchange 검증 범위 밖) | **409 아님 — 런타임 허용.** `MUTABLE_FIELDS` 4종(`accounts.py:57-61`)은 정상 런타임 업데이트다. #1578 구현자는 이 경로를 cold-path 409로 막지 않는다 |
 | Account Web OpenAPI/schema 레벨 | — | — | 빈 문자열/형식 오류는 **422** | cold-path 문서(스키마 검증) 전용. 런타임 차단(409)과 다른 층 |
 | DataStore path API 메서드 표면 (`read`/`write`/`append` 등) | 허용 | 거부 | 신규 write/read path 생성 시 거부(스펙상 예외 처리) | feed/data CLI 옵션이 아니라 DataStore 메서드 인자 표면 |
 | `StrategyMeta.exchange` | 허용 | **허용** | validator 에러 | **`*` 유일 허용 표면** (`docs/specs/strategy/03-09-strategy-validator.md`) |

--- a/docs/specs/core/core.md
+++ b/docs/specs/core/core.md
@@ -108,6 +108,20 @@ canonical-known은 신규 입력이 거부되지 않아야 하는 vocabulary이�
 "1.0에서 실제 계좌를 만들 수 있는가"와 별개 차원이다. `NYSE/NASDAQ/AMEX`는 canonical vocabulary
 이지만 1.0 account preset은 `KRX`,`TEST`만 제공한다.
 
+이 둘은 **별개의 두 축**이다:
+- **축 A — exchange-vocabulary 유효성**: 신규 입력 값이 canonical 5종(`{KRX, NYSE, NASDAQ, AMEX, TEST}`)
+  안인지로 판정한다. canonical 5종은 어떤 표면에서도 "invalid exchange"로 거부되지 않는다.
+  오직 non-canonical(예: `ORACLE_INVALID_EXCHANGE`)만 invalid-exchange 거부 대상이다.
+- **축 B — 1.0 운영/preset 가용성**: 1.0 account preset은 `KRX`,`TEST`만 제공한다. canonical
+  이지만 1.0 preset이 없는 값(`NYSE/NASDAQ/AMEX`)을 특정 경로(예: preset 기반 `account create`)로
+  계좌 생성할 수 있는지는 preset/broker-config 제약이며, 이는 invalid-exchange 거부가 **아니다**
+  (별개 에러/제약 차원).
+
+**불변식**: 어떤 표면도 canonical 5종 값을 "invalid exchange"로 거부하지 않는다. 표면별
+제약(1.0 preset 미제공, cold-path 409, read legacy 호환 등)은 exchange-vocabulary 유효성(축 A)과
+구분되는 별개 축이다. (#1578 구현자는 이 불변식으로 자가검증한다: canonical 입력 `exchange="NYSE"`가
+서비스 검증 에러가 되면 축 A 위반이다.)
+
 ### exchange vs market vs source vs broker_type
 
 `exchange`는 아래 차원들과 **별개**이며 서로 값을 섞지 않는다.
@@ -129,8 +143,8 @@ canonical-known은 신규 입력이 거부되지 않아야 하는 vocabulary이�
 | 표면 | canonical | `*` | non-canonical 신규 입력 거부 계약 | 비고 |
 |------|-----------|-----|-----------------------------------|------|
 | Instrument CLI `list`/`sync`/`import` | 허용 | 거부 | non-zero exit + 구조화 error payload (`{status:"error", code, message}`) | #1577 enforcement. **주 신규 입력 표면** (oracle `ORACLE_INVALID_EXCHANGE` 출처) |
-| Account CLI preset (`account create` 등) | preset에 정의된 exchange만 | 거부 | non-zero exit | preset 기반. preset 밖 값은 입력 불가 |
-| AccountService (생성/검증) | runtime-supported만 | 거부 | 서비스 검증 에러 | `exchange`는 identity 필드(`docs/specs/account/03-data-model.md:96`) |
+| Account CLI preset (`account create` 등) | canonical 5종은 invalid-exchange로 거부되지 않음 (축 A); 1.0 preset 자동 구성은 `KRX`/`TEST` preset만 (축 B) | 거부 | non-zero exit | 축 A: `*`/non-canonical은 거부. 축 B: 1.0 preset 경로는 `KRX`(`kis-domestic`)/`TEST`(`test`) preset만 자동 구성하며, preset 미제공 canonical 값(`NYSE/NASDAQ/AMEX`)은 **preset/broker 가용성 제약**이지 invalid-exchange 거부가 아니다(별개 차원) |
+| AccountService (생성/검증) | canonical 5종 허용 (축 A: non-canonical만 서비스 검증 에러) | 거부 | 서비스 검증 에러 | `exchange`는 identity 필드(`docs/specs/account/03-data-model.md:96`). canonical 5종은 서비스 exchange 검증에서 거부되지 않는다. 1.0 account preset이 `NYSE/NASDAQ/AMEX`를 미제공하는 것은 **축 B(preset/broker 가용성) 제약**이며 "invalid exchange 거부"가 아니다(별개 차원) |
 | Account Web — `POST /api/accounts` (cold-path 계좌 생성) | — | — | **cold-path 가드가 입력 무관 즉시 409** (invariant I1; `src/ante/web/routes/accounts.py`의 `create_account` 핸들러가 진입 즉시 409 raise) | **422 아님.** `exchange` 포함 모든 입력이 런타임에 차단됨 (계좌 생성은 cold-path 전용) |
 | Account Web — `PUT /api/accounts/{account_id}` structural/identity 변경 (`exchange` 등) | — | — | **structural 가드가 409** (invariant I1/I4; `src/ante/web/routes/accounts.py`의 `STRUCTURAL_FIELDS`에 `exchange` 포함) | **422 아님.** `exchange`는 생성 후 수정 불가 identity 필드(`docs/specs/account/03-data-model.md:96`)이므로 런타임 변경 시도가 cold-path 409로 차단됨 |
 | Account Web — `PUT /api/accounts/{account_id}` mutable-only (`name`/`timezone`/`trading_hours_start`/`trading_hours_end`) | — | — | (exchange 검증 범위 밖) | **409 아님 — 런타임 허용.** `src/ante/web/routes/accounts.py`의 `MUTABLE_FIELDS` 4종은 정상 런타임 업데이트다. #1578 구현자는 이 경로를 cold-path 409로 막지 않는다 |

--- a/docs/specs/data-feed/04-schema.md
+++ b/docs/specs/data-feed/04-schema.md
@@ -24,6 +24,10 @@ DataFeed는 `ante.data.schemas`를 직접 import하여 사용한다. 스키마�
 > data.go.kr 수집 시 `srtnCd`(symbol), `itmsNm`(name), `mrktCtg`(market)를 함께 받아오므로 추가 호출 없이 갱신.
 > 수집 결과를 정규화하여 최신 종목 메타데이터 상태를 유지한다.
 
+> canonical exchange 계약 SSOT: [core.md `## Canonical Exchange Vocabulary`](../core/core.md#canonical-exchange-vocabulary).
+> `exchange`(canonical 5종)와 `market`(`KOSPI`/`KOSDAQ`/`KONEX`, KRX 내부 시장구분)은 별개 차원이며
+> 값을 섞지 않는다. 표면별 enforcement 정렬은 #1578에서 다룬다.
+
 ### 파일 규격
 
 | 항목 | 규칙 |

--- a/docs/specs/data-pipeline/03-design-decisions.md
+++ b/docs/specs/data-pipeline/03-design-decisions.md
@@ -234,6 +234,11 @@ Parquet 파일 읽기/쓰기/관리를 담당한다. **모든 모듈이 Parquet�
 
 **기존 데이터 마이그레이션**: exchange 미명시 기존 데이터(OHLCV 경로에 exchange 디렉토리가 없는 경우)는 `KRX/` 하위로 자동 이동한다. 마이그레이션은 시스템 시작 또는 `ante update`의 post-update migration에서 자동 감지·실행한다. 별도 public `ante data migrate` 명령은 CLI SSOT에 포함하지 않는다.
 
+> canonical exchange 계약 SSOT: [core.md `## Canonical Exchange Vocabulary`](../core/core.md#canonical-exchange-vocabulary).
+> DataStore path API는 canonical-only(`*` 거부) 표면이며 신규 write/read path 생성 시 non-canonical
+> 거부가 목표다. 기존 영속 Parquet path의 out-of-vocab 값은 read에서 거부·자동 삭제하지 않는다(legacy
+> 호환 정책). 표면별 enforcement 정렬은 #1578에서 다룬다(현재 코드/스펙 drift).
+
 소스: `src/ante/data/store.py`
 
 ### 데이터 보존 정책

--- a/docs/specs/data-pipeline/03-design-decisions.md
+++ b/docs/specs/data-pipeline/03-design-decisions.md
@@ -235,9 +235,10 @@ Parquet 파일 읽기/쓰기/관리를 담당한다. **모든 모듈이 Parquet�
 **기존 데이터 마이그레이션**: exchange 미명시 기존 데이터(OHLCV 경로에 exchange 디렉토리가 없는 경우)는 `KRX/` 하위로 자동 이동한다. 마이그레이션은 시스템 시작 또는 `ante update`의 post-update migration에서 자동 감지·실행한다. 별도 public `ante data migrate` 명령은 CLI SSOT에 포함하지 않는다.
 
 > canonical exchange 계약 SSOT: [core.md `## Canonical Exchange Vocabulary`](../core/core.md#canonical-exchange-vocabulary).
-> DataStore path API는 canonical-only(`*` 거부) 표면이며 신규 write/read path 생성 시 non-canonical
-> 거부가 목표다. 기존 영속 Parquet path의 out-of-vocab 값은 read에서 거부·자동 삭제하지 않는다(legacy
-> 호환 정책). 표면별 enforcement 정렬은 #1578에서 다룬다(현재 코드/스펙 drift).
+> DataStore path API에서 non-canonical·`*` 거부는 `write`/`append`/신규 경로 생성에만 적용되는
+> 것이 목표다. 기존 영속 Parquet path(legacy out-of-vocab 포함)의 `read`는 거부·자동 삭제하지
+> 않는다(Legacy 호환 정책이 매트릭스 read 행에 우선). 표면별 enforcement 정렬은 #1578에서
+> 다룬다(현재 코드/스펙 drift).
 
 소스: `src/ante/data/store.py`
 

--- a/docs/specs/instrument/instrument.md
+++ b/docs/specs/instrument/instrument.md
@@ -33,6 +33,10 @@ Instrument 모듈은 **종목 마스터 데이터를 중앙 관리하는 모듈*
 
 모든 symbol 관련 필드/파라미터에 `exchange: str = "KRX"` 기본값을 사용하여 하위 호환성을 보장한다.
 
+> canonical exchange 허용값·검증 계약 SSOT: [core.md `## Canonical Exchange Vocabulary`](../core/core.md#canonical-exchange-vocabulary).
+> Instrument는 canonical-only(`*` 거부) 표면이며, instrument CLI `list`/`sync`/`import`의
+> non-canonical 신규 입력 거부 enforcement는 #1577에서 정렬한다(현재 코드/스펙 drift).
+
 ## Instrument 모델
 
 ```python

--- a/docs/specs/strategy/03-01-strategy-interface.md
+++ b/docs/specs/strategy/03-01-strategy-interface.md
@@ -33,6 +33,9 @@
 
 `exchange="*"`는 OHLCV 데이터만 있으면 어떤 시장에서든 동작하는 범용 전략에 사용한다. 예: 이동평균 크로스 전략, RSI 기반 전략 등.
 
+> canonical exchange 계약 SSOT: [core.md `## Canonical Exchange Vocabulary`](../core/core.md#canonical-exchange-vocabulary).
+> `StrategyMeta.exchange`는 `*`가 허용되는 **유일한** 표면이다. 표면별 enforcement 정렬은 #1578에서 다룬다.
+
 봇 배정 시 전략의 `exchange`와 계좌의 `exchange` 호환성을 검증한다. 호환되지 않으면 `IncompatibleExchangeError`를 발생시킨다.
 
 **호환성 검증 매트릭스**:

--- a/docs/specs/strategy/03-09-strategy-validator.md
+++ b/docs/specs/strategy/03-09-strategy-validator.md
@@ -28,6 +28,9 @@
 8. **exchange 유효성 검증** — `meta.exchange` 값이 유효한 거래소 코드인지 검증 (에러). 유효 값: `VALID_EXCHANGES = {"KRX", "NYSE", "NASDAQ", "AMEX", "TEST", "*"}`
 9. **symbols와 exchange 일관성 경고** — `symbols`가 명시된 경우, 심볼 형식이 exchange와 맞는지 경고 표시. 예: KRX 전략에 `"AAPL"`은 KRX 종목코드 형식이 아님 (경고)
 
+> canonical exchange 계약 SSOT: [core.md `## Canonical Exchange Vocabulary`](../core/core.md#canonical-exchange-vocabulary).
+> `VALID_EXCHANGES`는 canonical 5종 + `*`(StrategyMeta 전용 wildcard)다. 표면별 거부 계약·코드 SSOT 정렬은 #1576/#1578에서 다룬다(현재 코드/스펙 drift).
+
 **설계 근거**:
 
 1. **AST 기반 (실행 없이 분석)**

--- a/docs/specs/strategy/03-15-backtest-relationship.md
+++ b/docs/specs/strategy/03-15-backtest-relationship.md
@@ -18,3 +18,7 @@ ante backtest run strategies/universal_ma.py \
 ```
 
 `exchange="*"` 전략은 `--exchange` 옵션으로 백테스트할 시장을 자유롭게 지정할 수 있다.
+
+> canonical exchange 계약 SSOT: [core.md `## Canonical Exchange Vocabulary`](../core/core.md#canonical-exchange-vocabulary).
+> backtest `--exchange` override의 목표 계약은 canonical-only·`*` 거부이나, 현재 CLI/`src/ante/backtest/`에
+> 미구현된 spec-vs-implementation gap이다. 옵션 신설 포함 정렬은 #1578에서 다룬다.


### PR DESCRIPTION
Closes #1575

## Summary
- `docs/specs/core/core.md`에 `## Canonical Exchange Vocabulary` 절 신설 — Ante 전역 exchange의 **계약 SSOT**: canonical set `{KRX,NYSE,NASDAQ,AMEX,TEST}`, `*`=StrategyMeta 전용 wildcard, exchange vs market/source/broker_type 경계, per-surface 허용/거부·에러 계층(409/422/non-zero) 매트릭스, canonical-known vs 1.0 preset 분리(축 A/축 B), legacy out-of-vocab 무손상 read 호환 정책, 범위 불변식(surface enforcement는 #1577/#1578 위임), 소비자·후속 이슈 매핑.
- `docs/decisions/D-016-canonical-exchange-vocabulary.md` 신설 — ADR(결정/근거/소비자 영향), 계약 본문은 core.md 절을 단일 참조점으로 링크(중복 기재 없음). `docs/decisions/README.md` 인덱스 1줄 추가.
- 영향 스펙(instrument / strategy ×3 / account data-model / data-pipeline / data-feed / cli)에 core.md SSOT 포인터 + drift 메모. **normative 값 집합은 재작성하지 않음**(=#1578).
- docs-only. 코드/테스트/generated artifact 변경 없음. 런타임 enforcement·정렬은 #1576/#1577/#1578로 위임.

## Test Plan
- 코드 변경 없음 → pytest/ruff N/A (pre-commit ruff Skipped).
- 문서 점검: `rg "Canonical Exchange Vocabulary" docs/specs/core/core.md`, canonical 집합/매트릭스/legacy 정책/KOSPI=market 명시, D-016/README 인덱스/영향 스펙 포인터 존재, 상대 링크 resolve.
- 검증 시나리오 1~3(`*` 허용 여부 / `ORACLE_INVALID_EXCHANGE` 신규 입력 거부 / `KOSPI`=market) 모두 core.md 단독 판정 가능.
- Codex 브랜치 리뷰 `/codex:review --base main` attempt 9 PASS (read·legacy / canonical-known / 매트릭스 고도 3축 전수 sweep + invariant, attempt 6 @code-reviewer 메타리뷰).

🤖 Generated with [Claude Code](https://claude.com/claude-code)