### PR TITLE
refactor(core): introduce exchange vocabulary SSOT, delegate validator/store (#1576)

### DIFF
--- a/src/ante/core/__init__.py
+++ b/src/ante/core/__init__.py
@@ -1,5 +1,21 @@
-"""Core infrastructure — Database wrapper."""
+"""Core infrastructure — Database wrapper, canonical exchange vocabulary."""
 
 from ante.core.database import Database
+from ante.core.exchange import (
+    CANONICAL_EXCHANGES,
+    STRATEGY_EXCHANGES,
+    STRATEGY_WILDCARD,
+    is_canonical,
+    is_strategy_allowed,
+    normalize_exchange,
+)
 
-__all__ = ["Database"]
+__all__ = [
+    "CANONICAL_EXCHANGES",
+    "STRATEGY_EXCHANGES",
+    "STRATEGY_WILDCARD",
+    "Database",
+    "is_canonical",
+    "is_strategy_allowed",
+    "normalize_exchange",
+]

--- a/src/ante/core/exchange.py
+++ b/src/ante/core/exchange.py
@@ -1,0 +1,65 @@
+"""Canonical exchange vocabulary — 코드 레벨 SSOT.
+
+이 모듈은 Ante 전역에서 `exchange`가 의미하는 canonical vocabulary의
+**코드 레벨 단일 출처(SSOT)** 다. 계약 본문은 스펙에 있으며 본 모듈은
+그 값 집합을 코드에서 단일화한다:
+
+    docs/specs/core/core.md ``## Canonical Exchange Vocabulary``
+    docs/decisions/D-016-canonical-exchange-vocabulary.md
+
+범위 불변식 (#1576 narrow-scope):
+    - 본 모듈은 **축 A — exchange-vocabulary 유효성** (canonical 5종 + `*`
+      정책) 의 값 집합·검증 헬퍼만 정의한다.
+    - surface별 enforcement·에러 계층·preset/broker 가용성(축 B)·신규
+      표면 validation 추가는 본 모듈의 범위가 아니다 (#1577/#1578).
+    - 대소문자 정규화·별칭(alias)·사용자 정의 exchange set은 1.0 비목표다
+      (core.md ``### Canonical set``). 입력은 아래 canonical 리터럴과
+      **정확히 일치**해야 한다 — 본 모듈의 헬퍼는 어떤 변환도 하지 않는다.
+"""
+
+from __future__ import annotations
+
+# canonical exchange — 대문자 고정 5종 (core.md ``### Canonical set``).
+# 신규 입력 검증 vocabulary 전체이며 불변이다.
+CANONICAL_EXCHANGES: frozenset[str] = frozenset(
+    {"KRX", "NYSE", "NASDAQ", "AMEX", "TEST"}
+)
+
+# `*` 는 실제 exchange가 아니라 ``StrategyMeta.exchange`` 전용 wildcard다
+# (core.md ``### Wildcard 정책``). 다른 어떤 표면에서도 허용되지 않는다.
+STRATEGY_WILDCARD: str = "*"
+
+# strategy 표면(``StrategyMeta.exchange``)이 허용하는 집합:
+# canonical 5종 ∪ {`*`}. account/instrument/data 표면은 wildcard를
+# 제외한 ``CANONICAL_EXCHANGES`` 만 허용한다.
+STRATEGY_EXCHANGES: frozenset[str] = CANONICAL_EXCHANGES | {STRATEGY_WILDCARD}
+
+
+def is_canonical(value: str) -> bool:
+    """``value`` 가 canonical exchange 5종 중 하나인지 (exact-literal).
+
+    `*` 는 canonical exchange가 아니므로 ``False`` 다. 대소문자/별칭
+    정규화는 수행하지 않는다 — 입력은 canonical 리터럴과 정확히
+    일치해야 한다 (core.md ``### Canonical set``).
+    """
+    return value in CANONICAL_EXCHANGES
+
+
+def is_strategy_allowed(value: str) -> bool:
+    """``value`` 가 strategy 표면(canonical 5종 ∪ {`*`})에서 허용되는지.
+
+    ``StrategyMeta.exchange`` 전용 wildcard `*` 를 포함한다. 대소문자/
+    별칭 정규화는 수행하지 않는다 (exact-literal).
+    """
+    return value in STRATEGY_EXCHANGES
+
+
+def normalize_exchange(value: str) -> str:
+    """exact-literal passthrough — **변환하지 않는다**.
+
+    core.md ``### Canonical set`` 에 따라 대소문자 정규화·별칭 매핑은
+    1.0 비목표다. 이 헬퍼는 어떤 변환도 수행하지 않고 입력을 그대로
+    돌려준다. 호출자는 반환값을 ``is_canonical`` /
+    ``is_strategy_allowed`` 로 별도 검증해야 한다 (Codex Plan Review q5).
+    """
+    return value

--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -10,6 +10,8 @@ from typing import Literal
 
 import polars as pl
 
+from ante.core.exchange import CANONICAL_EXCHANGES
+
 logger = logging.getLogger(__name__)
 
 # write_parquet compression 타입
@@ -22,8 +24,11 @@ _TIME_COLUMN: dict[str, str] = {
     "tick": "timestamp",
 }
 
-# 알려진 거래소 이름 — 마이그레이션 시 이미 exchange 디렉토리인지 판별용
-_KNOWN_EXCHANGES: frozenset[str] = frozenset({"KRX", "NYSE", "NASDAQ", "AMEX", "TEST"})
+# 알려진 거래소 이름 — 마이그레이션 시 이미 exchange 디렉토리인지 판별용.
+# 코드 레벨 SSOT(`ante.core.exchange.CANONICAL_EXCHANGES`)에 위임한다.
+# 값(canonical 5종 frozenset)·`migrate_parquet_paths()` 동작은 위임
+# 전과 완전히 동일하다(#1576 narrow-scope: zero-change).
+_KNOWN_EXCHANGES: frozenset[str] = CANONICAL_EXCHANGES
 
 # KRX 심볼 형식: 6자리 숫자
 _KRX_SYMBOL_PATTERN: re.Pattern[str] = re.compile(r"^\d{6}$")

--- a/src/ante/strategy/validator.py
+++ b/src/ante/strategy/validator.py
@@ -6,7 +6,12 @@ import ast
 from dataclasses import dataclass, field
 from pathlib import Path
 
-VALID_EXCHANGES: set[str] = {"KRX", "NYSE", "NASDAQ", "AMEX", "TEST", "*"}
+from ante.core.exchange import STRATEGY_EXCHANGES
+
+# 코드 레벨 SSOT(`ante.core.exchange.STRATEGY_EXCHANGES` = canonical 5종 ∪
+# {`*`})에 위임한다. 이름·타입(`set[str]`)·값·검증 결과·에러 메시지는
+# 위임 전과 완전히 동일하게 보존한다(#1576 narrow-scope: zero-change).
+VALID_EXCHANGES: set[str] = set(STRATEGY_EXCHANGES)
 
 
 @dataclass

--- a/tests/unit/test_core_exchange_vocabulary.py
+++ b/tests/unit/test_core_exchange_vocabulary.py
@@ -1,0 +1,176 @@
+"""Unit tests — `ante.core.exchange` canonical exchange vocabulary SSOT (#1576).
+
+본 모듈은 두 가지를 못 박는다:
+  1. SSOT 모듈 자체의 불변식 (집합 값/`*` 정책/exact-literal 검증 헬퍼).
+  2. 위임 후 zero-change 회귀 — strategy validator `VALID_EXCHANGES`와
+     data store `_KNOWN_EXCHANGES`가 SSOT와 동일 값이며 검증 결과·에러
+     메시지 문자열이 위임 전과 완전히 동일하다.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ante.core.exchange import (
+    CANONICAL_EXCHANGES,
+    STRATEGY_EXCHANGES,
+    STRATEGY_WILDCARD,
+    is_canonical,
+    is_strategy_allowed,
+    normalize_exchange,
+)
+
+
+class TestCanonicalSet:
+    """canonical 5종 집합 불변식 (core.md ``### Canonical set``)."""
+
+    def test_canonical_exchanges_exact_value(self):
+        assert CANONICAL_EXCHANGES == frozenset(
+            {"KRX", "NYSE", "NASDAQ", "AMEX", "TEST"}
+        )
+
+    def test_canonical_exchanges_is_frozenset(self):
+        assert isinstance(CANONICAL_EXCHANGES, frozenset)
+
+    def test_canonical_exchanges_immutable(self):
+        with pytest.raises(AttributeError):
+            CANONICAL_EXCHANGES.add("LSE")  # type: ignore[attr-defined]
+
+    def test_wildcard_is_not_canonical(self):
+        assert STRATEGY_WILDCARD == "*"
+        assert STRATEGY_WILDCARD not in CANONICAL_EXCHANGES
+
+
+class TestStrategyExchanges:
+    """strategy 표면 집합 = canonical ∪ {`*`} (core.md ``### Wildcard 정책``)."""
+
+    def test_strategy_exchanges_exact_value(self):
+        assert STRATEGY_EXCHANGES == CANONICAL_EXCHANGES | {"*"}
+        assert STRATEGY_EXCHANGES == frozenset(
+            {"KRX", "NYSE", "NASDAQ", "AMEX", "TEST", "*"}
+        )
+
+    def test_strategy_exchanges_is_frozenset(self):
+        assert isinstance(STRATEGY_EXCHANGES, frozenset)
+
+    def test_strategy_superset_of_canonical(self):
+        assert CANONICAL_EXCHANGES < STRATEGY_EXCHANGES
+        assert STRATEGY_EXCHANGES - CANONICAL_EXCHANGES == {"*"}
+
+
+class TestIsCanonical:
+    """``is_canonical`` — exact-literal, 대소문자/별칭 정규화 없음."""
+
+    @pytest.mark.parametrize("value", ["KRX", "NYSE", "NASDAQ", "AMEX", "TEST"])
+    def test_canonical_values_true(self, value):
+        assert is_canonical(value) is True
+
+    def test_wildcard_is_not_canonical(self):
+        assert is_canonical("*") is False
+
+    @pytest.mark.parametrize(
+        "value", ["krx", "Krx", "nyse", "LSE", "ORACLE_INVALID_EXCHANGE", "", " KRX"]
+    )
+    def test_non_canonical_values_false(self, value):
+        assert is_canonical(value) is False
+
+
+class TestIsStrategyAllowed:
+    """``is_strategy_allowed`` — canonical ∪ {`*`}, exact-literal."""
+
+    @pytest.mark.parametrize("value", ["KRX", "NYSE", "NASDAQ", "AMEX", "TEST", "*"])
+    def test_allowed_values_true(self, value):
+        assert is_strategy_allowed(value) is True
+
+    @pytest.mark.parametrize(
+        "value", ["krx", "LSE", "ORACLE_INVALID_EXCHANGE", "", "**"]
+    )
+    def test_disallowed_values_false(self, value):
+        assert is_strategy_allowed(value) is False
+
+
+class TestNormalizeExchange:
+    """``normalize_exchange`` — exact-literal passthrough, 변환 금지 (q5)."""
+
+    @pytest.mark.parametrize(
+        "value",
+        ["KRX", "krx", "Krx", "*", "LSE", "ORACLE_INVALID_EXCHANGE", "", " KRX "],
+    )
+    def test_passthrough_no_transform(self, value):
+        # 대소문자 정규화/별칭/trim 등 어떤 변환도 하지 않는다.
+        assert normalize_exchange(value) == value
+        assert normalize_exchange(value) is value
+
+
+class TestStrategyValidatorDelegation:
+    """strategy validator가 SSOT에 위임 — 값·에러 메시지 zero-change."""
+
+    def test_valid_exchanges_delegates_to_ssot(self):
+        from ante.strategy.validator import VALID_EXCHANGES
+
+        # 이름 그대로 유지 + 값은 SSOT(STRATEGY_EXCHANGES)와 동치.
+        assert VALID_EXCHANGES == set(STRATEGY_EXCHANGES)
+        assert VALID_EXCHANGES == {"KRX", "NYSE", "NASDAQ", "AMEX", "TEST", "*"}
+
+    def test_valid_exchanges_type_preserved(self):
+        from ante.strategy.validator import VALID_EXCHANGES
+
+        # 위임 전 타입(mutable set[str])을 그대로 유지한다.
+        assert type(VALID_EXCHANGES) is set
+
+    def test_valid_exchanges_reexported_from_strategy_package(self):
+        import ante.strategy as strategy_pkg
+
+        assert strategy_pkg.VALID_EXCHANGES == {
+            "KRX",
+            "NYSE",
+            "NASDAQ",
+            "AMEX",
+            "TEST",
+            "*",
+        }
+
+    def test_validate_exchange_error_messages_unchanged(self):
+        """``validate_exchange`` 한국어 에러 메시지 문자열 스냅샷 보존."""
+        from ante.strategy.validator import (
+            VALID_EXCHANGES,
+            validate_exchange,
+        )
+
+        with pytest.raises(ValueError) as ei_strategy:
+            validate_exchange("INVALID", "KRX")
+        assert str(ei_strategy.value) == (
+            f"유효하지 않은 전략 exchange: 'INVALID'. "
+            f"허용 값: {sorted(VALID_EXCHANGES)}"
+        )
+
+        with pytest.raises(ValueError) as ei_account:
+            validate_exchange("KRX", "INVALID")
+        assert str(ei_account.value) == (
+            f"유효하지 않은 계좌 exchange: 'INVALID'. "
+            f"허용 값: {sorted(VALID_EXCHANGES - {'*'})}"
+        )
+
+        # account 표면은 `*` 거부 (canonical만).
+        with pytest.raises(ValueError) as ei_wildcard:
+            validate_exchange("KRX", "*")
+        assert str(ei_wildcard.value) == (
+            f"유효하지 않은 계좌 exchange: '*'. 허용 값: {sorted(CANONICAL_EXCHANGES)}"
+        )
+
+    def test_validate_exchange_wildcard_strategy_allowed(self):
+        from ante.strategy.validator import validate_exchange
+
+        # `*` 전략은 모든 canonical 계좌와 호환 (raise 없음).
+        for acct in sorted(CANONICAL_EXCHANGES):
+            validate_exchange("*", acct)
+
+
+class TestDataStoreDelegation:
+    """data store `_KNOWN_EXCHANGES`가 SSOT에 위임 — 값 zero-change."""
+
+    def test_known_exchanges_is_canonical_set(self):
+        from ante.data.store import _KNOWN_EXCHANGES
+
+        assert _KNOWN_EXCHANGES is CANONICAL_EXCHANGES
+        assert _KNOWN_EXCHANGES == frozenset({"KRX", "NYSE", "NASDAQ", "AMEX", "TEST"})


### PR DESCRIPTION
Closes #1576

## Summary
- `src/ante/core/exchange.py` 신설 — 코드 레벨 canonical exchange SSOT: `CANONICAL_EXCHANGES`(frozenset 5종), `STRATEGY_WILDCARD`, `STRATEGY_EXCHANGES`(=canonical∪{`*`}), `is_canonical`/검증 헬퍼(대소문자·alias 정규화 없음 — exact-literal). 머지된 core.md `## Canonical Exchange Vocabulary` 계약 준수.
- `strategy/validator.py` `VALID_EXCHANGES`(이름 유지) → `STRATEGY_EXCHANGES` 위임, `data/store.py` `_KNOWN_EXCHANGES` → `CANONICAL_EXCHANGES` 위임. **값·검증 결과·에러 메시지·`__all__` export 무변경(zero-change refactor)**.
- `tests/unit/test_core_exchange_vocabulary.py` 신설(집합 불변/`*` 정책/exact-literal/에러 메시지/위임 동치).
- **narrow-scope**: Account Web 스키마 enum(AMEX 누락, OpenAPI 영향)·신규 표면 enforcement·backtest `--exchange`는 #1577/#1578로 위임. OpenAPI/generated 산출물 무변경.

## Test Plan
- `ruff check .` / `ruff format --check .` 클린.
- `pytest tests/unit/test_core_exchange_vocabulary.py tests/unit/test_parquet_exchange.py -q` → 71 passed/2 skipped.
- `pytest tests/unit -k "validator or exchange or strategy"` → 527 passed/2 skipped (validator 에러 메시지 스냅샷 동일, 회귀 그린).
- `git diff -- frontend/` 빈 결과(OpenAPI/types 무변경). 독립 리터럴 집합 0건.
- Codex 브랜치 리뷰 `/codex:review --base main` attempt 1 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)