### PR TITLE
fix(account): validate canonical exchange in service + align OpenAPI enum (#1583)

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -102,12 +102,13 @@
                   "exchange": {
                     "type": "string",
                     "enum": [
+                      "AMEX",
                       "KRX",
-                      "NYSE",
                       "NASDAQ",
+                      "NYSE",
                       "TEST"
                     ],
-                    "description": "대상 거래소 코드."
+                    "description": "대상 거래소 코드 (canonical exchange vocabulary)."
                   },
                   "currency": {
                     "type": "string",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -3962,10 +3962,10 @@ export interface operations {
                     /** @description 거래 통화 (ISO 4217). */
                     currency: string;
                     /**
-                     * @description 대상 거래소 코드.
+                     * @description 대상 거래소 코드 (canonical exchange vocabulary).
                      * @enum {string}
                      */
-                    exchange: "KRX" | "NYSE" | "NASDAQ" | "TEST";
+                    exchange: "AMEX" | "KRX" | "NASDAQ" | "NYSE" | "TEST";
                     /** @description 시장가 매수 reserve buffer 비율 (cold-path 전용, #1333). omit 시 BrokerPreset 기본값을 사용한다 (예: kis-domestic=0.005, test=0). */
                     market_order_reserve_buffer_rate?: number;
                     /** @description 사용자에게 표시되는 이름. */

--- a/src/ante/account/__init__.py
+++ b/src/ante/account/__init__.py
@@ -9,6 +9,7 @@ from ante.account.errors import (
     AccountSuspendedError,
     InvalidAccountIdError,
     InvalidBrokerTypeError,
+    InvalidExchangeError,
     MissingCredentialsError,
 )
 from ante.account.models import Account, AccountStatus, BrokerPreset, TradingMode
@@ -39,6 +40,7 @@ __all__ = [
     "INVALID_RUNTIME_ACCOUNT_IDS",
     "InvalidAccountIdError",
     "InvalidBrokerTypeError",
+    "InvalidExchangeError",
     "MissingCredentialsError",
     "RESTRICTED_NEW_ACCOUNT_IDS",
     "TradingMode",

--- a/src/ante/account/errors.py
+++ b/src/ante/account/errors.py
@@ -25,6 +25,22 @@ class InvalidBrokerTypeError(AccountError):
     pass
 
 
+class InvalidExchangeError(AccountError):
+    """canonical vocabulary에 없는 exchange (`*`/non-canonical).
+
+    account 입력 경계는 ``ante.core.exchange`` SSOT의 canonical 5종만
+    허용한다(core.md ``## Canonical Exchange Vocabulary`` 축 A). `*` 는
+    ``StrategyMeta.exchange`` 전용 wildcard이므로 account 표면에서는 거부된다.
+
+    클래스 레벨 ``code`` 속성은 IPC 서버가
+    ``getattr(e, "code", "EXECUTION_ERROR")``로 안정 코드
+    ``"VALIDATION_ERROR"``를 노출하도록 한다(``InvalidAccountIdError`` 와
+    동일한 account 검증 에러 SSOT). Web API 라우트는 RFC 7807 422로 매핑된다.
+    """
+
+    code: str = "VALIDATION_ERROR"
+
+
 class MissingCredentialsError(AccountError):
     """필수 credentials 키 누락."""
 

--- a/src/ante/account/service.py
+++ b/src/ante/account/service.py
@@ -19,12 +19,14 @@ from ante.account.errors import (
     BrokerReconnectFailedError,
     InvalidAccountIdError,
     InvalidBrokerTypeError,
+    InvalidExchangeError,
     MissingCredentialsError,
 )
 from ante.account.models import Account, AccountStatus, TradingMode
 from ante.account.presets import BROKER_PRESETS
 from ante.account.scoping import require_account_id, validate_new_account_id
 from ante.account.timezone import validate_iana_timezone
+from ante.core.exchange import CANONICAL_EXCHANGES, is_canonical
 
 if TYPE_CHECKING:
     from ante.broker.base import BrokerAdapter
@@ -362,6 +364,10 @@ class AccountService:
         Raises:
             AccountAlreadyExistsError: 동일 account_id가 메모리/DELETED DB
                 상태로 이미 존재.
+            InvalidExchangeError: exchange가 canonical vocabulary
+                (``ante.core.exchange.CANONICAL_EXCHANGES`` 5종)에 없음
+                (`*`/non-canonical). create + bootstrap seed 공유 chokepoint;
+                ``update()`` 는 exchange immutable 가드로 별도 불요.
             InvalidBrokerTypeError: broker_type이 프리셋에 정의되지 않음.
             MissingCredentialsError: 필수 credentials 키 누락.
         """
@@ -378,6 +384,16 @@ class AccountService:
         if deleted:
             raise AccountAlreadyExistsError(
                 f"계좌 '{account.account_id}'가 이미 존재합니다 (삭제 상태)."
+            )
+
+        # exchange canonical 검증 — ante.core.exchange SSOT (core.md 축 A).
+        # canonical 5종만 허용; `*`(StrategyMeta 전용 wildcard)/non-canonical
+        # 거부. create()/_create_seed_account() 공유 단일 chokepoint이며,
+        # update()는 exchange immutable 가드라 별도 검증 불요.
+        if not is_canonical(account.exchange):
+            raise InvalidExchangeError(
+                f"유효하지 않은 exchange: '{account.exchange}'. "
+                f"가능한 값: {sorted(CANONICAL_EXCHANGES)}"
             )
 
         # broker_type 유효성 검증 (프리셋에 정의된 것만 허용)

--- a/src/ante/web/routes/accounts.py
+++ b/src/ante/web/routes/accounts.py
@@ -9,6 +9,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, ValidationError
 
+from ante.core.exchange import CANONICAL_EXCHANGES
 from ante.web.deps import (
     get_account_service,
     get_audit_logger_optional,
@@ -175,8 +176,11 @@ ACCOUNT_CREATE_REQUEST_SCHEMA: dict[str, Any] = {
         },
         "exchange": {
             "type": "string",
-            "enum": ["KRX", "NYSE", "NASDAQ", "TEST"],
-            "description": "대상 거래소 코드.",
+            # ante.core.exchange SSOT 동적 참조 — canonical 5종(AMEX 포함)과
+            # 영구 정합(drift 봉합). 결정적 알파벳 순으로 직렬화한다
+            # (#1583: ["AMEX", "KRX", "NASDAQ", "NYSE", "TEST"]).
+            "enum": sorted(CANONICAL_EXCHANGES),
+            "description": "대상 거래소 코드 (canonical exchange vocabulary).",
         },
         "currency": {
             "type": "string",

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -12,12 +12,14 @@ from ante.account.errors import (
     BrokerReconnectFailedError,
     InvalidAccountIdError,
     InvalidBrokerTypeError,
+    InvalidExchangeError,
     MissingCredentialsError,
 )
 from ante.account.models import Account, AccountStatus, TradingMode
 from ante.account.presets import BROKER_PRESETS
 from ante.account.service import AccountService
 from ante.core.database import Database
+from ante.core.exchange import CANONICAL_EXCHANGES
 from ante.eventbus.bus import EventBus
 
 
@@ -118,6 +120,50 @@ async def test_create_invalid_broker_type_raises(service):
 
     with pytest.raises(InvalidBrokerTypeError):
         await service.create(account)
+
+
+# ── exchange canonical 검증 (ante.core.exchange SSOT, core.md 축 A) ──
+
+
+@pytest.mark.asyncio
+async def test_create_invalid_exchange_raises(service):
+    """canonical vocabulary 밖 exchange는 InvalidExchangeError로 거부.
+
+    broker_type 검증과 같은 _persist_account chokepoint에서 차단된다
+    (#1583). 메시지에 허용 canonical 값 목록을 노출한다.
+    """
+    account = _make_account(exchange="LSE")
+
+    with pytest.raises(InvalidExchangeError, match="유효하지 않은 exchange"):
+        await service.create(account)
+
+
+@pytest.mark.asyncio
+async def test_create_wildcard_exchange_raises(service):
+    """`*`(StrategyMeta 전용 wildcard)는 account 표면에서 거부 (core.md 축 A)."""
+    account = _make_account(exchange="*")
+
+    with pytest.raises(InvalidExchangeError):
+        await service.create(account)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exchange", sorted(CANONICAL_EXCHANGES))
+async def test_create_canonical_exchange_passes_service_gate(service, exchange):
+    """canonical 5종은 _persist_account exchange 게이트를 통과 (축 A).
+
+    service layer 직접 생성으로 exchange 게이트만 검증한다 — preset/
+    credential 결합(축 B)이 테스트 의미를 왜곡하지 않도록 모든 케이스가
+    test preset을 충족하는 broker_type="test" + test credentials를 쓴다
+    (NYSE/NASDAQ/AMEX는 exchange 게이트 통과만 확인). canonical 5종은
+    어떤 경우에도 invalid exchange로 거부되지 않는다.
+    """
+    account = _make_account(account_id=f"acct-{exchange.lower()}", exchange=exchange)
+
+    result = await service.create(account)
+
+    assert result.exchange == exchange
+    assert result.status == AccountStatus.ACTIVE
 
 
 # ── credentials 필수 키 검증 ──────────────────────────

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -13,6 +13,7 @@ httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
 
 from fastapi.testclient import TestClient  # noqa: E402
 
+from ante.core.exchange import CANONICAL_EXCHANGES  # noqa: E402
 from ante.web.app import create_app  # noqa: E402
 
 
@@ -1974,13 +1975,13 @@ class TestPostAccountRequestBodySchema:
             properties.get("trading_mode")
         )
 
-        # exchange enum
-        assert properties.get("exchange", {}).get("enum") == [
-            "KRX",
-            "NYSE",
-            "NASDAQ",
-            "TEST",
-        ], properties.get("exchange")
+        # exchange enum — ante.core.exchange SSOT와 정합(canonical 5종, AMEX
+        # 포함). 결정적 알파벳 순. SSOT를 import해 향후 drift를 봉합한다
+        # (#1583): sorted(CANONICAL_EXCHANGES) == ["AMEX","KRX","NASDAQ",
+        # "NYSE","TEST"].
+        assert properties.get("exchange", {}).get("enum") == sorted(
+            CANONICAL_EXCHANGES
+        ), properties.get("exchange")
 
         # trading_mode enum (보조)
         assert properties.get("trading_mode", {}).get("enum") == [


### PR DESCRIPTION
Closes #1583

## Summary
- `InvalidExchangeError(AccountError)`(code=`VALIDATION_ERROR`, account 검증 에러 SSOT) 신설, `account/__init__.py` re-export.
- `AccountService._persist_account()`(create + bootstrap seed 공유 단일 chokepoint)에서 `ante.core.exchange` SSOT로 비-canonical·`*` exchange 거부. `update()`는 exchange immutable이라 불요.
- Account POST OpenAPI exchange enum을 `sorted(CANONICAL_EXCHANGES)` 동적 SSOT 참조로 교체(AMEX 포함, drift 영구 봉합). `frontend/openapi.json`·`api.generated.ts` 재생성(enum-only diff, EOF 규약 유지). `tests/unit/test_web_api.py` 기대값 SSOT 참조로 갱신.
- 축 A/B 불변식 준수: canonical 5종은 invalid로 거부 안 함, preset 미제공(NYSE/NASDAQ/AMEX)=축 B 별개 미변경, cold-path 409/runtime Web POST 무변경. (에픽 #1561 4a; 구 #1578 split A)

## Test Plan
- `ruff check .`/`ruff format --check .` 클린.
- `pytest tests/unit/test_account.py tests/unit/test_web_api.py -q` → 187 passed (신규: non-canonical·`*` → InvalidExchangeError, canonical 5종 service-layer 직접 통과, enum 기대값 갱신).
- `rg -n AMEX frontend/openapi.json frontend/src/types/api.generated.ts` → account exchange enum 알파벳 순 AMEX 포함.
- `cd frontend && npm run check-api-types:strict` exit 0.
- Codex 브랜치 리뷰 `/codex:review --base main` attempt 1 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)