### PR TITLE
fix(data): enforce canonical exchange on ParquetStore write/append (#1584)

### DIFF
--- a/src/ante/data/store.py
+++ b/src/ante/data/store.py
@@ -10,7 +10,7 @@ from typing import Literal
 
 import polars as pl
 
-from ante.core.exchange import CANONICAL_EXCHANGES
+from ante.core.exchange import CANONICAL_EXCHANGES, is_canonical
 
 logger = logging.getLogger(__name__)
 
@@ -224,7 +224,22 @@ class ParquetStore:
         data_type: str = "ohlcv",
         exchange: str = "KRX",
     ) -> None:
-        """데이터를 Parquet에 기록. 월별 파티셔닝, 중복 제거(merge)."""
+        """데이터를 Parquet에 기록. 월별 파티셔닝, 중복 제거(merge).
+
+        신규 write/append/경로 생성은 canonical exchange만 허용한다
+        (core.md ``## Canonical Exchange Vocabulary``). `append()`는
+        `self.write(...)`로 위임하므로 이 guard가 append도 함께 커버한다.
+        read/`_resolve_path`/`migrate_parquet_paths` 등 기존·legacy 조회
+        표면에는 검증을 추가하지 않는다(Legacy out-of-vocabulary read 면제).
+        """
+        # 비문자열은 frozenset membership에서 unhashable TypeError를
+        # 유발할 수 있으므로 isinstance 선검사 후 거부(#1577 교훈).
+        if not isinstance(exchange, str) or not is_canonical(exchange):
+            raise ValueError(
+                f"유효하지 않은 exchange: '{exchange}'. "
+                f"허용 값: {sorted(CANONICAL_EXCHANGES)}"
+            )
+
         if data.is_empty():
             return
 
@@ -293,6 +308,8 @@ class ParquetStore:
     ) -> None:
         """버퍼 데이터를 기존 Parquet에 추가."""
         df = pl.DataFrame(rows)
+        # exchange canonical 검증은 write()로 위임되어 자동 커버된다
+        # (별도 guard 불요 — 단일 chokepoint 유지).
         self.write(symbol, timeframe, df, data_type=data_type, exchange=exchange)
 
     def list_symbols(

--- a/tests/unit/test_parquet_exchange.py
+++ b/tests/unit/test_parquet_exchange.py
@@ -217,6 +217,85 @@ class TestReadWriteWithExchange:
         assert result["valid"] == 1
 
 
+class TestCanonicalExchangeEnforcement:
+    """write/append 신규 경로 생성이 canonical exchange만 허용하는지 검증.
+
+    read/legacy 조회 표면은 core.md Legacy out-of-vocabulary read 면제에
+    따라 검증을 추가하지 않는다(회귀로 고정).
+    """
+
+    def test_write_rejects_non_canonical(self, tmp_store: ParquetStore) -> None:
+        """비-canonical exchange write는 ValueError로 거부된다."""
+        df = _make_ohlcv_df()
+        with pytest.raises(ValueError, match="유효하지 않은 exchange"):
+            tmp_store.write("BARC", "1d", df, exchange="LSE")
+
+    def test_write_rejects_wildcard(self, tmp_store: ParquetStore) -> None:
+        """`*` wildcard는 data 표면에서 비-canonical로 거부된다."""
+        df = _make_ohlcv_df()
+        with pytest.raises(ValueError, match="유효하지 않은 exchange"):
+            tmp_store.write("005930", "1d", df, exchange="*")
+
+    def test_write_rejects_non_string(self, tmp_store: ParquetStore) -> None:
+        """비문자열 exchange는 traceback이 아닌 구조화된 ValueError로 거부된다."""
+        df = _make_ohlcv_df()
+        with pytest.raises(ValueError, match="유효하지 않은 exchange"):
+            tmp_store.write("005930", "1d", df, exchange=[])  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="유효하지 않은 exchange"):
+            tmp_store.write("005930", "1d", df, exchange=123)  # type: ignore[arg-type]
+
+    def test_append_rejects_non_canonical(self, tmp_store: ParquetStore) -> None:
+        """append는 write로 위임되므로 비-canonical exchange를 거부한다."""
+        from datetime import datetime
+
+        rows = [
+            {
+                "timestamp": datetime(2026, 1, 1, 9, 0, tzinfo=UTC),
+                "symbol": "BARC",
+                "open": 50000.0,
+                "high": 51000.0,
+                "low": 49000.0,
+                "close": 50500.0,
+                "volume": 1000000,
+                "amount": 50000000000,
+                "source": "test",
+            }
+        ]
+        with pytest.raises(ValueError, match="유효하지 않은 exchange"):
+            tmp_store.append("BARC", "1m", rows, exchange="LSE")
+
+    def test_read_tolerates_legacy_out_of_vocab(
+        self, tmp_store: ParquetStore, tmp_path: Path
+    ) -> None:
+        """핵심 회귀: write LSE는 거부되지만 pre-existing legacy LSE read는 무손상.
+
+        core.md Legacy out-of-vocabulary read 면제 — read/_resolve_path에
+        검증이 누출되면 이 테스트가 깨진다.
+        """
+        # write 경로로는 LSE를 만들 수 없으므로 legacy 디렉토리를 수동 생성
+        legacy_dir = tmp_path / "ohlcv" / "1d" / "LSE" / "BARC"
+        legacy_dir.mkdir(parents=True)
+        df = _make_ohlcv_df(symbol="BARC")
+        df.write_parquet(str(legacy_dir / "2026-01.parquet"))
+
+        # write LSE는 거부됨을 재확인 (enforcement 유지)
+        with pytest.raises(ValueError, match="유효하지 않은 exchange"):
+            tmp_store.write("BARC", "1d", df, exchange="LSE")
+
+        # 그러나 pre-existing legacy LSE read는 정상 동작·데이터 반환
+        result = tmp_store.read("BARC", "1d", exchange="LSE")
+        assert len(result) == 3
+        assert result["symbol"].to_list() == ["BARC"] * 3
+
+    def test_write_canonical_still_works(self, tmp_store: ParquetStore) -> None:
+        """canonical 5종(KRX/NYSE/NASDAQ/AMEX/TEST) write 회귀 green."""
+        for exchange in ("KRX", "NYSE", "NASDAQ", "AMEX", "TEST"):
+            df = _make_ohlcv_df(symbol="005930")
+            tmp_store.write("005930", "1d", df, exchange=exchange)
+            result = tmp_store.read("005930", "1d", exchange=exchange)
+            assert len(result) == 3, f"{exchange} write/read 회귀 실패"
+
+
 class TestMigrateParquetPaths:
     """기존 경로 → exchange 포함 경로 마이그레이션 검증."""
 


### PR DESCRIPTION
Closes #1584

## Summary
- `ParquetStore.write()` 진입부(empty 조기반환 앞)에 `ante.core.exchange` SSOT guard: 비-canonical·`*`·비문자열 exchange → `ValueError`. `append()`는 `write()` 위임으로 자동 커버.
- `read()`/`_resolve_path()`/`resolve_path()`/`list_symbols()`/`get_*`/`validate()`/`delete_file()`/`migrate_parquet_paths()`는 **검증 미추가** — core.md Legacy out-of-vocabulary read 면제(기존/legacy parquet 경로 read 무손상, 자동 삭제·마이그레이션 없음).
- 신규 예외 클래스 없음(ValueError 컨벤션). 비문자열 `isinstance` 선검사로 unhashable TypeError 회피. (에픽 #1561 4b; 구 #1578 split B)

## Test Plan
- `ruff check .`/`ruff format --check .` 클린.
- `pytest tests/unit/test_parquet_exchange.py tests/unit/test_parquet_validation.py -q` → 42 passed/2 skipped; `-k "parquet or store or migrate"` → 142 passed.
- 신규 `TestCanonicalExchangeEnforcement`: write/append 비-canonical·`*`·비문자열 → ValueError; **pre-existing legacy `LSE` parquet read 무손상**(핵심 회귀); canonical 5종 write/read green; migrate 무변경.
- `is_canonical`은 write() 진입부에만(read surface 부재 확인).
- Codex 브랜치 리뷰 `/codex:review --base main` attempt 1 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)