### PR TITLE
feat(backtest): add --exchange override with canonical validation + full propagation (#1585)

### DIFF
--- a/src/ante/backtest/config.py
+++ b/src/ante/backtest/config.py
@@ -12,6 +12,7 @@ class BacktestConfig:
     strategy_path: str = ""
     symbols: list[str] = field(default_factory=list)
     timeframe: str = "1d"
+    exchange: str = "KRX"
     start_date: str = ""
     end_date: str = ""
     initial_balance: float = 10_000_000.0

--- a/src/ante/backtest/data_provider.py
+++ b/src/ante/backtest/data_provider.py
@@ -31,10 +31,12 @@ class BacktestDataProvider(DataProvider):
         store: ParquetStore,
         start_date: str,
         end_date: str,
+        exchange: str = "KRX",
     ) -> None:
         self._store = store
         self._start = start_date
         self._end = end_date
+        self._exchange = exchange
         self._cache: dict[str, pl.DataFrame] = {}
         self._current_idx: int = 0
         self._loaded_datasets: list[DatasetInfo] = []
@@ -59,10 +61,16 @@ class BacktestDataProvider(DataProvider):
     def load(self, symbol: str, timeframe: str) -> int:
         """데이터를 캐시에 로드. 로드된 행 수 반환."""
         key = f"{symbol}:{timeframe}"
-        df = self._store.read(symbol, timeframe, start=self._start, end=self._end)
+        df = self._store.read(
+            symbol,
+            timeframe,
+            start=self._start,
+            end=self._end,
+            exchange=self._exchange,
+        )
         self._cache[key] = df
 
-        data_dir = self._store.resolve_path(symbol, timeframe)
+        data_dir = self._store.resolve_path(symbol, timeframe, exchange=self._exchange)
         file_count = len(list(data_dir.glob("*.parquet"))) if data_dir.exists() else 0
         info = DatasetInfo(
             symbol=symbol,

--- a/src/ante/backtest/executor.py
+++ b/src/ante/backtest/executor.py
@@ -30,6 +30,7 @@ class BacktestExecutor:
         buy_commission_rate: float = 0.00015,
         sell_commission_rate: float = 0.00195,
         slippage_rate: float = 0.001,
+        exchange: str = "KRX",
     ) -> None:
         self._strategy_cls = strategy_cls
         self._data = data_provider
@@ -37,6 +38,7 @@ class BacktestExecutor:
         self._buy_commission_rate = buy_commission_rate
         self._sell_commission_rate = sell_commission_rate
         self._slippage_rate = slippage_rate
+        self._exchange = exchange
 
         self._balance = initial_balance
         self._positions: dict[str, dict[str, float]] = {}
@@ -154,6 +156,7 @@ class BacktestExecutor:
                 commission=commission,
                 slippage=abs(exec_price - price) * signal.quantity,
                 reason=signal.reason,
+                exchange=self._exchange,
             )
         )
 

--- a/src/ante/backtest/result.py
+++ b/src/ante/backtest/result.py
@@ -70,6 +70,7 @@ class BacktestResult:
                     "commission": t.commission,
                     "slippage": t.slippage,
                     "reason": t.reason,
+                    "exchange": t.exchange,
                 }
                 for t in self.trades
             ],

--- a/src/ante/backtest/service.py
+++ b/src/ante/backtest/service.py
@@ -69,6 +69,7 @@ class BacktestService:
             buy_commission_rate=validated.buy_commission_rate,
             sell_commission_rate=validated.sell_commission_rate,
             slippage_rate=validated.slippage_rate,
+            exchange=validated.exchange,
         )
 
         result = await executor.run(progress_callback=progress_callback)

--- a/src/ante/backtest/service.py
+++ b/src/ante/backtest/service.py
@@ -56,6 +56,7 @@ class BacktestService:
             store=store,
             start_date=validated.start_date,
             end_date=validated.end_date,
+            exchange=validated.exchange,
         )
 
         for symbol in validated.symbols:
@@ -139,6 +140,7 @@ class BacktestService:
             strategy_path=config["strategy_path"],
             symbols=config.get("symbols", []),
             timeframe=config.get("timeframe", "1d"),
+            exchange=config.get("exchange", "KRX"),
             start_date=config.get("start_date", ""),
             end_date=config.get("end_date", ""),
             initial_balance=config.get("initial_balance", 10_000_000.0),

--- a/src/ante/cli/commands/backtest.py
+++ b/src/ante/cli/commands/backtest.py
@@ -33,6 +33,7 @@ def backtest() -> None:
     help="초기 자금",
 )
 @click.option("--timeframe", default="1d", help="타임프레임")
+@click.option("--exchange", default="KRX", help="거래소 (기본: KRX)")
 @click.option("--data-path", default="data/", help="데이터 디렉토리 경로")
 @click.option("--db-path", default=None, help="DB 경로 (미지정 시 config_dir 기반)")
 @click.pass_context
@@ -46,6 +47,7 @@ def run(
     symbols: str | None,
     balance: float,
     timeframe: str,
+    exchange: str,
     data_path: str,
     db_path: str | None,
 ) -> None:
@@ -54,6 +56,7 @@ def run(
 
     from ante.backtest.service import BacktestService
     from ante.cli.main import get_db_path
+    from ante.core.exchange import CANONICAL_EXCHANGES, is_canonical
 
     fmt = get_formatter(ctx)
     resolved_db_path = db_path or get_db_path(ctx)
@@ -73,6 +76,15 @@ def run(
         )
         raise SystemExit(1)
 
+    # 거래소 검증 (CLI 경계 단일 지점 — canonical만 허용, `*`/non-canonical 거부)
+    if not is_canonical(exchange):
+        fmt.error(
+            f"유효하지 않은 거래소: {exchange!r}. "
+            f"허용 값: {', '.join(sorted(CANONICAL_EXCHANGES))}",
+            code="BACKTEST_INVALID_EXCHANGE",
+        )
+        raise SystemExit(1)
+
     config = {
         "strategy_path": strategy_path,
         "start_date": start,
@@ -80,6 +92,7 @@ def run(
         "symbols": symbols.split(",") if symbols else [],
         "initial_balance": balance,
         "timeframe": timeframe,
+        "exchange": exchange,
         "data_path": data_path,
     }
 

--- a/tests/unit/test_backtest_exchange_plumbing.py
+++ b/tests/unit/test_backtest_exchange_plumbing.py
@@ -15,6 +15,7 @@ CLI 검증과 분리 — service/provider가 exchange를 무시해도 CLI 테스
 
 from __future__ import annotations
 
+import dataclasses
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -22,10 +23,11 @@ from unittest.mock import MagicMock, patch
 import polars as pl
 import pytest
 
+from ante.backtest import runner
 from ante.backtest.config import BacktestConfig
 from ante.backtest.data_provider import BacktestDataProvider
 from ante.backtest.executor import BacktestExecutor
-from ante.backtest.result import BacktestResult
+from ante.backtest.result import BacktestResult, BacktestTrade
 from ante.backtest.service import BacktestService
 from ante.strategy.base import Signal, Strategy, StrategyMeta
 
@@ -357,3 +359,161 @@ class TestServicePassesExchangeToExecutor:
             }
         )
         assert kwargs["exchange"] == "KRX"
+
+
+class TestResultToDictSerializesExchange:
+    """BacktestResult.to_dict() → trades[i]["exchange"] (직렬화 hop 회귀).
+
+    CLI JSON / subprocess / report draft 세 소비자가 모두 result.to_dict()를
+    무가공 전달하므로, 이 단일 지점에서 exchange가 직렬화되어야 override가
+    구조화 출력 체결 행에 보인다 (Codex branch review [P2] + meta-review).
+    """
+
+    @pytest.mark.asyncio
+    async def test_explicit_exchange_appears_in_to_dict_trades(self):
+        executor = _make_executor("NYSE")
+
+        result = await executor.run()
+
+        out = result.to_dict()
+        assert out["trades"], "1건의 거래가 직렬화되어야 한다"
+        assert all(t["exchange"] == "NYSE" for t in out["trades"])
+
+    @pytest.mark.asyncio
+    async def test_default_exchange_appears_in_to_dict_trades_krx(self):
+        executor = _make_executor(None)
+
+        result = await executor.run()
+
+        out = result.to_dict()
+        assert out["trades"]
+        assert all(t["exchange"] == "KRX" for t in out["trades"])
+
+    def test_to_dict_trade_keeps_exchange_label_verbatim(self):
+        """비-canonical 라벨도 to_dict가 그대로 직렬화 (재검증 없음)."""
+        result = BacktestResult(
+            strategy_name="S",
+            strategy_version="1",
+            start_date="2026-01-01",
+            end_date="2026-01-02",
+            initial_balance=1.0,
+            final_balance=1.0,
+            total_return=0.0,
+            trades=[
+                BacktestTrade(
+                    timestamp=datetime(2026, 1, 1),
+                    symbol="AAPL",
+                    side="buy",
+                    quantity=1.0,
+                    price=100.0,
+                    commission=0.0,
+                    slippage=0.0,
+                    reason="r",
+                    exchange="NASDAQ",
+                )
+            ],
+        )
+
+        out = result.to_dict()
+
+        assert out["trades"][0]["exchange"] == "NASDAQ"
+
+
+class TestRunnerForwardsToDictUnmodified:
+    """runner.run_backtest()는 service 결과의 to_dict()를 무가공 반환.
+
+    subprocess 실제 기동은 무거우므로, runner가 result.to_dict()를
+    그대로 전달함을 가벼운 단위로 갈음한다 (to_dict 출력 단언은 in-process
+    TestResultToDictSerializesExchange가 필수로 커버).
+    """
+
+    @pytest.mark.asyncio
+    async def test_run_backtest_returns_service_result_to_dict_with_exchange(
+        self,
+    ):
+        result = BacktestResult(
+            strategy_name="S",
+            strategy_version="1",
+            start_date="2026-01-01",
+            end_date="2026-01-02",
+            initial_balance=1.0,
+            final_balance=1.0,
+            total_return=0.0,
+            trades=[
+                BacktestTrade(
+                    timestamp=datetime(2026, 1, 1),
+                    symbol="AAPL",
+                    side="buy",
+                    quantity=1.0,
+                    price=100.0,
+                    commission=0.0,
+                    slippage=0.0,
+                    reason="r",
+                    exchange="NYSE",
+                )
+            ],
+        )
+
+        service_instance = MagicMock()
+
+        async def _fake_run(config):
+            return result
+
+        service_instance.run = _fake_run
+
+        with patch(
+            "ante.backtest.service.BacktestService",
+            return_value=service_instance,
+        ):
+            out = await runner.run_backtest(
+                {
+                    "strategy_path": "s.py",
+                    "start_date": "2026-01-01",
+                    "end_date": "2026-01-02",
+                    "exchange": "NYSE",
+                }
+            )
+
+        assert out == result.to_dict()
+        assert out["trades"][0]["exchange"] == "NYSE"
+
+
+class TestTradeSerializationCompletenessInvariant:
+    """직렬화 누락 invariant: BacktestTrade의 public 필드 ⊆ to_dict trade 키.
+
+    향후 BacktestTrade에 필드를 추가하면서 to_dict() 컴프리헨션 갱신을
+    누락하면 이 테스트가 자동으로 감지한다 (이번 exchange 누락 재발 방지).
+    """
+
+    def test_all_trade_dataclass_fields_present_in_to_dict_trade(self):
+        result = BacktestResult(
+            strategy_name="S",
+            strategy_version="1",
+            start_date="2026-01-01",
+            end_date="2026-01-02",
+            initial_balance=1.0,
+            final_balance=1.0,
+            total_return=0.0,
+            trades=[
+                BacktestTrade(
+                    timestamp=datetime(2026, 1, 1),
+                    symbol="AAPL",
+                    side="buy",
+                    quantity=1.0,
+                    price=100.0,
+                    commission=0.0,
+                    slippage=0.0,
+                    reason="r",
+                    exchange="NYSE",
+                )
+            ],
+        )
+
+        trade_dict = result.to_dict()["trades"][0]
+        field_names = {f.name for f in dataclasses.fields(BacktestTrade)}
+
+        missing = field_names - set(trade_dict.keys())
+        assert not missing, (
+            f"BacktestTrade 필드가 to_dict() trade 직렬화에서 누락됨: {missing}. "
+            "result.py to_dict()의 trade 컴프리헨션에 추가하라."
+        )

--- a/tests/unit/test_backtest_exchange_plumbing.py
+++ b/tests/unit/test_backtest_exchange_plumbing.py
@@ -7,10 +7,15 @@ CLI 검증과 분리 — service/provider가 exchange를 무시해도 CLI 테스
 - `BacktestService.run()`: `BacktestDataProvider`를 `exchange=<config.exchange>`로 생성.
 - `BacktestDataProvider.load()`: store.read() **및** store.resolve_path() 양쪽에
   동일 exchange 전달 (resolve_path 메타 hop 회귀 고정).
+- `BacktestExecutor`: `exchange=` ctor 인자를 받아 `_execute_signal`이 만든
+  `BacktestTrade.exchange`에 그대로 라벨링 (executor→trade hop 회귀 고정).
+- `BacktestService.run()`: `BacktestExecutor`를 `exchange=<config.exchange>`로
+  생성 (service→executor hop 회귀 고정).
 """
 
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -19,8 +24,10 @@ import pytest
 
 from ante.backtest.config import BacktestConfig
 from ante.backtest.data_provider import BacktestDataProvider
+from ante.backtest.executor import BacktestExecutor
 from ante.backtest.result import BacktestResult
 from ante.backtest.service import BacktestService
+from ante.strategy.base import Signal, Strategy, StrategyMeta
 
 
 class TestValidateConfigExchangeDefault:
@@ -206,3 +213,147 @@ class TestDataProviderForwardsExchangeToStore:
         assert read_kwargs["exchange"] == "KRX"
         _, resolve_kwargs = store.resolve_path.call_args
         assert resolve_kwargs["exchange"] == "KRX"
+
+
+class _SingleBuyStrategy(Strategy):
+    """첫 스텝에 buy 1건만 내는 최소 전략 (executor hop fixture)."""
+
+    meta = StrategyMeta(name="single_buy", version="1", description="t")
+
+    def __init__(self, ctx):  # noqa: D107
+        super().__init__(ctx)
+        self._fired = False
+
+    async def on_step(self, context) -> list[Signal]:  # noqa: D102
+        if self._fired:
+            return []
+        self._fired = True
+        return [Signal(symbol="TEST", side="buy", quantity=1.0, reason="r")]
+
+
+class _FakeDataProvider:
+    """2스텝짜리 인메모리 data_provider (실제 store/API 호출 없음)."""
+
+    def __init__(self) -> None:
+        self._idx = 0
+        self._ts = [datetime(2026, 1, 1), datetime(2026, 1, 2)]
+        self.start = "2026-01-01"
+        self.end = "2026-01-02"
+        self.loaded_datasets: list = []
+
+    def get_total_steps(self) -> int:
+        return len(self._ts)
+
+    def advance(self) -> bool:
+        self._idx += 1
+        return self._idx < len(self._ts)
+
+    def get_current_timestamp(self):
+        if self._idx >= len(self._ts):
+            return None
+        return self._ts[self._idx]
+
+    async def get_current_price(self, symbol: str) -> float:
+        return 100.0
+
+
+def _make_executor(exchange: str | None) -> BacktestExecutor:
+    kwargs = {"exchange": exchange} if exchange is not None else {}
+    return BacktestExecutor(
+        strategy_cls=_SingleBuyStrategy,
+        data_provider=_FakeDataProvider(),
+        initial_balance=1_000_000.0,
+        **kwargs,
+    )
+
+
+class TestExecutorLabelsTradeWithExchange:
+    """BacktestExecutor(exchange=) → BacktestTrade.exchange (executor→trade hop)."""
+
+    @pytest.mark.asyncio
+    async def test_explicit_exchange_labels_result_trades(self):
+        executor = _make_executor("NYSE")
+
+        result = await executor.run()
+
+        assert result.trades, "1건의 거래가 체결되어야 한다"
+        assert all(t.exchange == "NYSE" for t in result.trades)
+
+    @pytest.mark.asyncio
+    async def test_default_exchange_labels_result_trades_krx(self):
+        executor = _make_executor(None)
+
+        result = await executor.run()
+
+        assert result.trades
+        assert all(t.exchange == "KRX" for t in result.trades)
+
+
+class TestServicePassesExchangeToExecutor:
+    """BacktestService.run() → BacktestExecutor(exchange=...) ctor 전달.
+
+    end-to-end에 가깝게: `_validate_config(exchange=...)`가 만든
+    `validated.exchange`가 executor 생성 인자로 흐르는지 고정.
+    """
+
+    async def _run_capture_executor_kwargs(self, config: dict) -> dict:
+        provider_instance = MagicMock()
+        provider_instance.loaded_datasets = []
+        executor_instance = MagicMock()
+
+        async def _fake_run(progress_callback=None):
+            return BacktestResult(
+                strategy_name="S",
+                strategy_version="1",
+                start_date="2026-01-01",
+                end_date="2026-01-02",
+                initial_balance=1.0,
+                final_balance=1.0,
+                total_return=0.0,
+            )
+
+        executor_instance.run = _fake_run
+
+        with (
+            patch("ante.backtest.service.StrategyLoader") as mock_loader,
+            patch("ante.backtest.service.ParquetStore"),
+            patch(
+                "ante.backtest.service.BacktestDataProvider",
+                return_value=provider_instance,
+            ),
+            patch(
+                "ante.backtest.service.BacktestExecutor",
+                return_value=executor_instance,
+            ) as mock_executor_cls,
+        ):
+            mock_loader.load.return_value = MagicMock()
+            svc = BacktestService()
+            await svc.run(config)
+
+        _, kwargs = mock_executor_cls.call_args
+        return kwargs
+
+    @pytest.mark.asyncio
+    async def test_run_constructs_executor_with_config_exchange(self):
+        kwargs = await self._run_capture_executor_kwargs(
+            {
+                "strategy_path": "s.py",
+                "start_date": "2026-01-01",
+                "end_date": "2026-01-02",
+                "symbols": [],
+                "exchange": "NYSE",
+            }
+        )
+        assert kwargs["exchange"] == "NYSE"
+
+    @pytest.mark.asyncio
+    async def test_run_defaults_executor_exchange_to_krx(self):
+        kwargs = await self._run_capture_executor_kwargs(
+            {
+                "strategy_path": "s.py",
+                "start_date": "2026-01-01",
+                "end_date": "2026-01-02",
+                "symbols": [],
+            }
+        )
+        assert kwargs["exchange"] == "KRX"

--- a/tests/unit/test_backtest_exchange_plumbing.py
+++ b/tests/unit/test_backtest_exchange_plumbing.py
@@ -1,0 +1,208 @@
+"""non-CLI backtest exchange plumbing 테스트 (#1585).
+
+CLI 검증과 분리 — service/provider가 exchange를 무시해도 CLI 테스트는
+통과하므로 별도 고정한다:
+
+- `_validate_config`: exchange 미지정 → KRX 기본 / 명시 → 그대로 (default plumbing).
+- `BacktestService.run()`: `BacktestDataProvider`를 `exchange=<config.exchange>`로 생성.
+- `BacktestDataProvider.load()`: store.read() **및** store.resolve_path() 양쪽에
+  동일 exchange 전달 (resolve_path 메타 hop 회귀 고정).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import polars as pl
+import pytest
+
+from ante.backtest.config import BacktestConfig
+from ante.backtest.data_provider import BacktestDataProvider
+from ante.backtest.result import BacktestResult
+from ante.backtest.service import BacktestService
+
+
+class TestValidateConfigExchangeDefault:
+    """_validate_config exchange default plumbing (검증 아님)."""
+
+    def test_exchange_missing_defaults_to_krx(self):
+        svc = BacktestService()
+        validated = svc._validate_config(
+            {
+                "strategy_path": "s.py",
+                "start_date": "2026-01-01",
+                "end_date": "2026-01-02",
+            }
+        )
+        assert isinstance(validated, BacktestConfig)
+        assert validated.exchange == "KRX"
+
+    def test_explicit_exchange_preserved(self):
+        svc = BacktestService()
+        validated = svc._validate_config(
+            {
+                "strategy_path": "s.py",
+                "start_date": "2026-01-01",
+                "end_date": "2026-01-02",
+                "exchange": "NYSE",
+            }
+        )
+        assert validated.exchange == "NYSE"
+
+    def test_validate_config_does_not_canonical_validate(self):
+        """_validate_config는 canonical 검증을 하지 않는다 (CLI 경계 단일 검증).
+
+        서비스/config 이중검증 금지 — 비-canonical 값도 plumbing은 그대로
+        통과시킨다 (게이트는 CLI ingress).
+        """
+        svc = BacktestService()
+        validated = svc._validate_config(
+            {
+                "strategy_path": "s.py",
+                "start_date": "2026-01-01",
+                "end_date": "2026-01-02",
+                "exchange": "ORACLE_INVALID_EXCHANGE",
+            }
+        )
+        assert validated.exchange == "ORACLE_INVALID_EXCHANGE"
+
+
+class TestServicePassesExchangeToProvider:
+    """BacktestService.run() → BacktestDataProvider(exchange=...) ctor 전달."""
+
+    @pytest.mark.asyncio
+    async def test_run_constructs_provider_with_config_exchange(self):
+        config = {
+            "strategy_path": "s.py",
+            "start_date": "2026-01-01",
+            "end_date": "2026-01-02",
+            "symbols": ["005930"],
+            "exchange": "NYSE",
+        }
+
+        provider_instance = MagicMock()
+        provider_instance.loaded_datasets = []
+
+        executor_instance = MagicMock()
+
+        async def _fake_run(progress_callback=None):
+            return BacktestResult(
+                strategy_name="S",
+                strategy_version="1",
+                start_date="2026-01-01",
+                end_date="2026-01-02",
+                initial_balance=1.0,
+                final_balance=1.0,
+                total_return=0.0,
+            )
+
+        executor_instance.run = _fake_run
+
+        with (
+            patch("ante.backtest.service.StrategyLoader") as mock_loader,
+            patch("ante.backtest.service.ParquetStore") as mock_store_cls,
+            patch(
+                "ante.backtest.service.BacktestDataProvider",
+                return_value=provider_instance,
+            ) as mock_provider_cls,
+            patch(
+                "ante.backtest.service.BacktestExecutor",
+                return_value=executor_instance,
+            ),
+        ):
+            mock_loader.load.return_value = MagicMock()
+            mock_store_cls.return_value = MagicMock()
+            svc = BacktestService()
+            await svc.run(config)
+
+        _, kwargs = mock_provider_cls.call_args
+        assert kwargs["exchange"] == "NYSE"
+
+    @pytest.mark.asyncio
+    async def test_run_defaults_provider_exchange_to_krx(self):
+        config = {
+            "strategy_path": "s.py",
+            "start_date": "2026-01-01",
+            "end_date": "2026-01-02",
+            "symbols": [],
+        }
+
+        provider_instance = MagicMock()
+        provider_instance.loaded_datasets = []
+        executor_instance = MagicMock()
+
+        async def _fake_run(progress_callback=None):
+            return BacktestResult(
+                strategy_name="S",
+                strategy_version="1",
+                start_date="2026-01-01",
+                end_date="2026-01-02",
+                initial_balance=1.0,
+                final_balance=1.0,
+                total_return=0.0,
+            )
+
+        executor_instance.run = _fake_run
+
+        with (
+            patch("ante.backtest.service.StrategyLoader") as mock_loader,
+            patch("ante.backtest.service.ParquetStore"),
+            patch(
+                "ante.backtest.service.BacktestDataProvider",
+                return_value=provider_instance,
+            ) as mock_provider_cls,
+            patch(
+                "ante.backtest.service.BacktestExecutor",
+                return_value=executor_instance,
+            ),
+        ):
+            mock_loader.load.return_value = MagicMock()
+            svc = BacktestService()
+            await svc.run(config)
+
+        _, kwargs = mock_provider_cls.call_args
+        assert kwargs["exchange"] == "KRX"
+
+
+class TestDataProviderForwardsExchangeToStore:
+    """BacktestDataProvider.load() → store.read() + store.resolve_path() 양쪽 hop."""
+
+    def _make_store(self):
+        store = MagicMock()
+        store.read.return_value = pl.DataFrame({"timestamp": [], "close": []})
+        store.resolve_path.return_value = Path("/nonexistent/dir")
+        return store
+
+    def test_load_forwards_explicit_exchange_to_read_and_resolve_path(self):
+        store = self._make_store()
+        provider = BacktestDataProvider(
+            store=store,
+            start_date="2026-01-01",
+            end_date="2026-01-02",
+            exchange="NYSE",
+        )
+
+        provider.load("AAPL", "1d")
+
+        # store.read() hop
+        _, read_kwargs = store.read.call_args
+        assert read_kwargs["exchange"] == "NYSE"
+        # store.resolve_path() 메타 hop (read와 동일 exchange)
+        _, resolve_kwargs = store.resolve_path.call_args
+        assert resolve_kwargs["exchange"] == "NYSE"
+
+    def test_load_defaults_exchange_krx_to_both_hops(self):
+        store = self._make_store()
+        provider = BacktestDataProvider(
+            store=store,
+            start_date="2026-01-01",
+            end_date="2026-01-02",
+        )
+
+        provider.load("005930", "1d")
+
+        _, read_kwargs = store.read.call_args
+        assert read_kwargs["exchange"] == "KRX"
+        _, resolve_kwargs = store.resolve_path.call_args
+        assert resolve_kwargs["exchange"] == "KRX"

--- a/tests/unit/test_cli_backtest_exchange_validation.py
+++ b/tests/unit/test_cli_backtest_exchange_validation.py
@@ -1,0 +1,250 @@
+"""CLI backtest run --exchange canonical 검증 + CLI→config handoff 테스트 (#1585).
+
+CLI 경계 단일 검증:
+- 비-canonical / `*` → exit 1 + 구조화 error payload (text: 메시지만, JSON: code).
+- canonical(NYSE) → invalid-exchange 거부 아님(축 A — canonical은 invalid 아님).
+- 옵션 미지정 → KRX 기본(기존 동작 회귀).
+- CLI→config handoff: CLI가 넘기는 config dict에 exchange가 정확히 실린다.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+def _make_runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+class TestBacktestExchangeValidation:
+    """backtest run --exchange canonical 검증 (CLI 경계 단일 지점)."""
+
+    def test_non_canonical_exchange_text_mode_exit1_message_only(self, tmp_path):
+        """비-canonical 거래소: text 모드 exit 1 + 에러 메시지만(code 미출력)."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "backtest",
+                "run",
+                str(strategy),
+                "--start",
+                "2026-01-01",
+                "--end",
+                "2026-01-01",
+                "--exchange",
+                "ORACLE_INVALID_EXCHANGE",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "유효하지 않은 거래소" in result.output
+        assert "ORACLE_INVALID_EXCHANGE" in result.output
+        # text 모드: OutputFormatter.error는 code를 출력하지 않는다.
+        assert "BACKTEST_INVALID_EXCHANGE" not in result.output
+
+    def test_non_canonical_exchange_json_mode_exit1_with_code(self, tmp_path):
+        """비-canonical 거래소: --format json exit 1 + 구조화 error payload."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "backtest",
+                "run",
+                str(strategy),
+                "--start",
+                "2026-01-01",
+                "--end",
+                "2026-01-01",
+                "--exchange",
+                "ORACLE_INVALID_EXCHANGE",
+            ],
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert payload["code"] == "BACKTEST_INVALID_EXCHANGE"
+
+    def test_wildcard_exchange_rejected_exit1(self, tmp_path):
+        """`*`는 backtest 표면에서 거부 (StrategyMeta 표면 아님)."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "backtest",
+                "run",
+                str(strategy),
+                "--start",
+                "2026-01-01",
+                "--end",
+                "2026-01-01",
+                "--exchange",
+                "*",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "유효하지 않은 거래소" in result.output
+
+    def test_canonical_exchange_nyse_not_rejected(self, tmp_path):
+        """canonical(NYSE)은 invalid-exchange 거부 아님 (축 A)."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        with patch("ante.backtest.service.BacktestService") as mock_service:
+            mock_service.side_effect = RuntimeError("stop after validation")
+            result = runner.invoke(
+                cli,
+                [
+                    "backtest",
+                    "run",
+                    str(strategy),
+                    "--start",
+                    "2026-01-01",
+                    "--end",
+                    "2026-01-01",
+                    "--exchange",
+                    "NYSE",
+                ],
+            )
+
+        # canonical 검증을 통과해야만 BacktestService가 호출됨.
+        mock_service.assert_called_once()
+        assert "유효하지 않은 거래소" not in result.output
+
+    def test_default_exchange_krx_passes(self, tmp_path):
+        """--exchange 미지정은 KRX 기본 — 검증 통과 (기존 동작 회귀)."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+
+        with patch("ante.backtest.service.BacktestService") as mock_service:
+            mock_service.side_effect = RuntimeError("stop after validation")
+            result = runner.invoke(
+                cli,
+                [
+                    "backtest",
+                    "run",
+                    str(strategy),
+                    "--start",
+                    "2026-01-01",
+                    "--end",
+                    "2026-01-01",
+                ],
+            )
+
+        mock_service.assert_called_once()
+        assert "유효하지 않은 거래소" not in result.output
+
+
+def _capture_config():
+    """BacktestService.run에 넘어온 config dict를 캡처하는 스파이.
+
+    CLI가 검증만 통과시키고 config에 exchange를 누락해도 잡아낸다
+    (validation/plumbing 테스트만으로는 못 잡는 hop — q2).
+    """
+    captured: dict = {}
+
+    class _SpyService:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def run(self, config, progress_callback=None):
+            captured["config"] = dict(config)
+            raise RuntimeError("stop after config handoff")
+
+    return captured, _SpyService
+
+
+class TestBacktestExchangeConfigHandoff:
+    """CLI→config handoff: CLI가 넘기는 config dict에 exchange가 실린다."""
+
+    def test_explicit_exchange_in_config(self, tmp_path):
+        """--exchange NYSE → config['exchange'] == 'NYSE'."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+        captured, spy = _capture_config()
+
+        with patch("ante.backtest.service.BacktestService", spy):
+            result = runner.invoke(
+                cli,
+                [
+                    "backtest",
+                    "run",
+                    str(strategy),
+                    "--start",
+                    "2026-01-01",
+                    "--end",
+                    "2026-01-01",
+                    "--exchange",
+                    "NYSE",
+                ],
+            )
+
+        assert result.exit_code == 1
+        assert captured["config"]["exchange"] == "NYSE"
+
+    def test_default_exchange_in_config(self, tmp_path):
+        """--exchange 미지정 → config['exchange'] == 'KRX'."""
+        strategy = tmp_path / "test_strategy.py"
+        strategy.write_text("# dummy")
+        runner = _make_runner()
+        captured, spy = _capture_config()
+
+        with patch("ante.backtest.service.BacktestService", spy):
+            result = runner.invoke(
+                cli,
+                [
+                    "backtest",
+                    "run",
+                    str(strategy),
+                    "--start",
+                    "2026-01-01",
+                    "--end",
+                    "2026-01-01",
+                ],
+            )
+
+        assert result.exit_code == 1
+        assert captured["config"]["exchange"] == "KRX"


### PR DESCRIPTION
Closes #1585

## Summary
- `backtest run --exchange` 옵션 신설(기본 KRX). CLI 경계에서 `ante.core.exchange` SSOT로 canonical 검증(비-canonical·`*` → `BACKTEST_INVALID_EXCHANGE`, non-zero; #1577 CLI 패턴 미러). 서비스/config 이중검증 없음(CLI 단일 지점).
- 전체 propagation: CLI→config→`BacktestConfig.exchange`→`_validate_config`→`BacktestService.run`→`BacktestDataProvider`(`store.read()` + `store.resolve_path()`)→`BacktestExecutor`→`BacktestTrade.exchange`→`BacktestResult.to_dict()` 직렬화. CLI JSON/subprocess/report 초안이 모두 동일 `to_dict()` 소비 → 체결 단위 exchange 관측 가능.
- 회귀/invariant: CLI(text=메시지만/JSON=code) + CLI→config handoff + plumbing(_validate_config·service→provider ctor·load→read+resolve_path) + executor→trade label + to_dict 직렬화(in-process/subprocess) + `BacktestTrade` 필드 ⊆ to_dict 키 완결성 메타 테스트.
- 축 A 불변식 준수(canonical은 invalid 거부 안 함), 기본 KRX로 기존 no-option 동작 보존. `ParquetStore.read`는 #1584 read 면제 유지(검증 미추가). 에픽 #1561 4c (구 #1578 split C).

## 비고 (스펙 근거 비목표)
- backtest는 스펙상 의도적으로 strategy↔exchange compat 게이트 없음(`docs/specs/account/02-design-decisions.md:34,36,58`: "백테스트 시 계좌 없이 자유롭게 실행 가능", 호환성 검증은 "봇 생성 시"만). `--exchange`는 그 자유 실행을 canonical 범위로 안전화. strategy.meta.exchange 대조는 backtest 표면 아님(별도 스펙 결정 영역).
- report 모델에 exchange 스키마 필드 추가는 #1585 범위 밖(별도 followup; to_dict 파급으로 trade 단위는 이미 노출).

## Test Plan
- `ruff check .`/`ruff format --check .` 클린.
- `pytest tests/unit/test_cli_backtest_exchange_validation.py tests/unit/test_backtest_exchange_plumbing.py tests/unit/test_cli_backtest_date_validation.py -q` green; `pytest tests/unit -k backtest` → 145 passed.
- Codex 브랜치 리뷰 3 attempts: attempt1/2 [P2] 수정(executor/trade label, to_dict 직렬화 — @code-reviewer 메타리뷰 후 단일 지점 repair), attempt3 [P2]는 스펙 근거 reject(backtest compat-gate-free 의도, account/02-design-decisions.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)