### PR TITLE
fix(cli): reject period-exclusive option conflicts in report performance (#1593)

### DIFF
--- a/docs/specs/cli/02-design-decisions.md
+++ b/docs/specs/cli/02-design-decisions.md
@@ -92,6 +92,7 @@ JSON 모드(`--format json`)에서는 `{status: "error", code: "...", message: "
 |-----------|------|----------|
 | `CLI_MISSING_REQUIRED_INPUT` | 필수 옵션·인자 누락 (도메인 명확 시 도메인 prefix specialize) | 모든 명령 |
 | `CLI_CONFIRMATION_REQUIRED` | 위험 명령에 `--yes`/`--force` 누락 | `account delete`, `bot remove`, `member revoke`, `update` |
+| `CLI_OPTION_CONFLICT` | 상호 배타적인 옵션을 동시 사용 (period별 전용 옵션을 다른 period와 함께 사용 등) | `report performance`, `treasury snapshot` |
 | `ACCOUNT_MISSING_REQUIRED_CREDENTIAL` | `BrokerPreset.required_credentials`에 정의된 credential key 누락 | `account create`, `account set-credentials` |
 | `ACCOUNT_UNKNOWN_CREDENTIAL_KEY` | broker preset의 `required_credentials`에 정의되지 않은 credential key 제공 | `account create`, `account set-credentials` |
 | `ACCOUNT_DUPLICATE_CREDENTIAL_KEY` | 같은 credential key를 `--credential`/`--credential-env`/`--credential-file` 중 둘 이상 채널로 중복 제공 | `account create`, `account set-credentials` |

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -432,6 +432,11 @@ ante report view <report_id> [--db-path <경로>]        # 리포트 상세 조�
 ante report performance [--period daily|monthly] [--bot-id <봇ID>] [--start <날짜>] [--end <날짜>] [--year <연도>]  # 기간별 성과 집계
 ```
 
+`report performance`의 기간 옵션은 `--period`별로 배타적이다. `--start`/`--end`는
+`--period daily` 전용, `--year`는 `--period monthly` 전용이며 (`--period` 기본값은
+`daily`), period와 맞지 않는 옵션을 함께 지정하면 DB 접근 이전에
+`CLI_OPTION_CONFLICT` 에러 코드와 exit code 1로 거부한다(빈 집계 반환 금지).
+
 ### `ante feed` — 데이터 피드 (DataFeed)
 
 CLI 정의는 `src/ante/feed/cli.py`에 있으며 `ante.cli.main`에서 서브커맨드로 등록된다.

--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -264,6 +264,26 @@ def report_performance(
 
     fmt = get_formatter(ctx)
 
+    # period별 옵션 배타 검증: DB 연결/_run_performance/asyncio.run 이전에
+    # 차단한다 (treasury.py:205-211 동형 패턴). PerformanceTracker는
+    # daily/monthly 메서드가 분리되어 있어 silent-ignore API가 없으므로
+    # (report.py:276-288에서 daily는 start/end만, monthly는 year만 라우팅)
+    # CLI 진입 검증이 실행 경로상 완전한 fix다. `--period` 기본값이 daily
+    # 이므로 `--period` 생략 + `--year` 조합도 여기서 거부된다.
+    if period == "monthly" and (start or end):
+        fmt.error(
+            "--start/--end 옵션은 --period monthly와 함께 사용할 수 없습니다. "
+            "(daily 전용)",
+            code="CLI_OPTION_CONFLICT",
+        )
+        raise SystemExit(1)
+    if period == "daily" and year is not None:
+        fmt.error(
+            "--year 옵션은 --period daily와 함께 사용할 수 없습니다. (monthly 전용)",
+            code="CLI_OPTION_CONFLICT",
+        )
+        raise SystemExit(1)
+
     async def _run_performance() -> list[dict]:
         from ante.cli.main import get_db_path
         from ante.core.database import Database

--- a/tests/unit/test_cli_report_performance_period_options.py
+++ b/tests/unit/test_cli_report_performance_period_options.py
@@ -1,0 +1,321 @@
+"""`ante report performance` period별 옵션 배타 검증 단위 테스트 (#1593).
+
+`--start`/`--end`는 `--period daily` 전용, `--year`는 `--period monthly`
+전용이다. period와 맞지 않는 옵션 조합은 DB 접근 이전에
+``CLI_OPTION_CONFLICT`` + exit 1로 거부되어야 한다.
+
+회귀: period에 맞는 유효 조합은 그대로 통과해야 한다.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+@pytest.fixture
+def runner():
+    r = CliRunner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):
+        with patch("ante.cli.main.authenticate_member") as mock_auth:
+
+            def _set_member(ctx):
+                ctx.obj = ctx.obj or {}
+                ctx.obj["member"] = _MOCK_MASTER
+
+            mock_auth.side_effect = _set_member
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _assert_conflict_json(result) -> None:
+    """JSON 포맷 충돌 응답 공통 검증."""
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["status"] == "error"
+    assert payload["code"] == "CLI_OPTION_CONFLICT"
+
+
+class TestPeriodOptionConflictRejected:
+    """period와 맞지 않는 옵션 조합은 exit 1 + CLI_OPTION_CONFLICT."""
+
+    def test_monthly_with_start_and_end(self, runner):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "performance",
+                    "--period",
+                    "monthly",
+                    "--start",
+                    "2026-01-01",
+                    "--end",
+                    "2026-01-31",
+                ],
+            )
+        _assert_conflict_json(result)
+        assert "--start/--end" in result.output
+        mock_run.assert_not_called()
+
+    def test_monthly_with_start_only(self, runner):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "performance",
+                    "--period",
+                    "monthly",
+                    "--start",
+                    "2026-01-01",
+                ],
+            )
+        _assert_conflict_json(result)
+        mock_run.assert_not_called()
+
+    def test_monthly_with_end_only(self, runner):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "performance",
+                    "--period",
+                    "monthly",
+                    "--end",
+                    "2026-01-31",
+                ],
+            )
+        _assert_conflict_json(result)
+        mock_run.assert_not_called()
+
+    def test_daily_with_year(self, runner):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "performance",
+                    "--period",
+                    "daily",
+                    "--year",
+                    "2026",
+                ],
+            )
+        _assert_conflict_json(result)
+        assert "--year" in result.output
+        mock_run.assert_not_called()
+
+    def test_year_without_period_defaults_daily(self, runner):
+        """`--period` 생략 시 기본값 daily이므로 `--year`는 충돌로 거부."""
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "performance",
+                    "--year",
+                    "2026",
+                ],
+            )
+        _assert_conflict_json(result)
+        mock_run.assert_not_called()
+
+    def test_conflict_does_not_touch_db(self, runner):
+        """진입 검증이 _run_performance(Database/asyncio.run) 이전임을 고정."""
+        with (
+            patch("ante.cli.commands.report.asyncio.run") as mock_run,
+            patch("ante.core.database.Database") as mock_db,
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "performance",
+                    "--period",
+                    "monthly",
+                    "--start",
+                    "2026-01-01",
+                    "--end",
+                    "2026-01-31",
+                ],
+            )
+        assert result.exit_code == 1
+        mock_run.assert_not_called()
+        mock_db.assert_not_called()
+
+    def test_conflict_text_format(self, runner):
+        """text 포맷에서도 exit 1로 거부된다 (formatter.error text 경로)."""
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            result = runner.invoke(
+                cli,
+                [
+                    "report",
+                    "performance",
+                    "--period",
+                    "monthly",
+                    "--start",
+                    "2026-01-01",
+                    "--end",
+                    "2026-01-31",
+                ],
+            )
+        assert result.exit_code == 1
+        assert "--start/--end" in result.output
+        mock_run.assert_not_called()
+
+    def test_daily_year_conflict_text_format(self, runner):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            result = runner.invoke(
+                cli,
+                [
+                    "report",
+                    "performance",
+                    "--period",
+                    "daily",
+                    "--year",
+                    "2026",
+                ],
+            )
+        assert result.exit_code == 1
+        assert "--year" in result.output
+        mock_run.assert_not_called()
+
+
+class TestValidPeriodOptionCombosRegression:
+    """period에 맞는 유효 조합은 회귀 없이 통과한다."""
+
+    def test_daily_with_start_and_end(self, runner):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            mock_run.return_value = [
+                {
+                    "date": "2026-01-15",
+                    "realized_pnl": 12000.0,
+                    "trade_count": 2,
+                    "win_rate": 0.5,
+                }
+            ]
+            result = runner.invoke(
+                cli,
+                [
+                    "report",
+                    "performance",
+                    "--period",
+                    "daily",
+                    "--start",
+                    "2026-01-01",
+                    "--end",
+                    "2026-01-31",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "2026-01-15" in result.output
+        mock_run.assert_called_once()
+
+    def test_monthly_with_year(self, runner):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            mock_run.return_value = [
+                {
+                    "year": 2026,
+                    "month": 1,
+                    "realized_pnl": 50000.0,
+                    "trade_count": 10,
+                    "win_rate": 0.7,
+                }
+            ]
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "performance",
+                    "--period",
+                    "monthly",
+                    "--year",
+                    "2026",
+                ],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["period"] == "monthly"
+        assert data["summaries"][0]["year"] == 2026
+        mock_run.assert_called_once()
+
+    def test_daily_with_bot_id_and_dates(self, runner):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            mock_run.return_value = [
+                {
+                    "date": "2026-01-10",
+                    "realized_pnl": 3000.0,
+                    "trade_count": 1,
+                    "win_rate": 1.0,
+                }
+            ]
+            result = runner.invoke(
+                cli,
+                [
+                    "report",
+                    "performance",
+                    "--period",
+                    "daily",
+                    "--bot-id",
+                    "b1",
+                    "--start",
+                    "2026-01-01",
+                    "--end",
+                    "2026-01-31",
+                ],
+            )
+        assert result.exit_code == 0
+        mock_run.assert_called_once()
+
+    def test_daily_default_no_options(self, runner):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            mock_run.return_value = []
+            result = runner.invoke(cli, ["report", "performance"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once()
+
+    def test_monthly_default_no_options(self, runner):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            mock_run.return_value = []
+            result = runner.invoke(
+                cli,
+                ["report", "performance", "--period", "monthly"],
+            )
+        assert result.exit_code == 0
+        mock_run.assert_called_once()


### PR DESCRIPTION
Closes #1593

## Summary
- `report performance` 가 help에 명시된 period-exclusive 계약(`--start/--end`=daily 전용, `--year`=monthly 전용)을 강제하지 않고 반대 조합을 exit 0 빈 집계로 처리하던 oracle A7 버그 수정
- `report_performance()` 진입부(DB/`asyncio.run` 이전)에 옵션 배타 검증 추가 — `period=monthly`+`start/end` 또는 `period=daily(기본값 포함)`+`year` → `CLI_OPTION_CONFLICT` + exit 1 (treasury.py:205-211 동형 패턴)
- 스펙 갭 형식화: `docs/specs/cli/03-commands.md` period 배타 계약 명시 + `docs/specs/cli/02-design-decisions.md` 에러코드 SSOT 표에 `CLI_OPTION_CONFLICT` 행 추가 (기존 treasury.py 사용처 소급 문서화)

## Test Plan
- `pytest tests/unit/test_cli_report_performance_period_options.py -q` → 13 passed (invalid 5종 + DB/asyncio 미호출 assert + 유효 회귀 5종 + JSON/text)
- 인접 회귀 `pytest tests/unit/test_report.py test_performance_summary.py test_cli_treasury_snapshot.py -q` → 49 passed
- `ruff check` / `ruff format --check` / `mypy src/ante/cli/commands/report.py` 통과
- grep invariant: `CLI_OPTION_CONFLICT` ∈ {02-design-decisions.md, 03-commands.md}
- Codex Plan Review: approve-implement (rev2, session 019e2e16) / Codex 브랜치 리뷰: PASS (session 019e2e29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)