### PR TITLE
fix(web): reject invalid timeframe filter in datasets API (#1594)

### DIFF
--- a/docs/specs/web-api/05-resource-endpoints.md
+++ b/docs/specs/web-api/05-resource-endpoints.md
@@ -74,7 +74,7 @@
 
 | Method | Path | 설명 |
 |--------|------|------|
-| GET | `/api/data/datasets` | 보유 데이터셋 목록 (필터: symbol, timeframe, data_type, offset, limit) |
+| GET | `/api/data/datasets` | 보유 데이터셋 목록 (필터: symbol, timeframe, data_type, offset, limit). `timeframe`은 `TIMEFRAMES` vocabulary(`1m, 5m, 15m, 1h, 1d`, SSOT: `ante.data.schemas.TIMEFRAMES`)만 허용 — vocabulary 외 값은 400 거부 (#1594). `data_type`은 `ohlcv \| fundamental` enum, 외 값은 422. `symbol` vocabulary 거부는 exchange-aware symbol SSOT 후속(후보 0)에 위임 — 현재 invalid `symbol`은 200 empty 유지 |
 | GET | `/api/data/datasets/{dataset_id}` | 데이터셋 상세 조회. 메타데이터(symbol, timeframe, 기간, 행 수) + 데이터 미리보기(최근 5행). dataset_id = `{symbol}__{timeframe}`. ParquetStore.read(limit=5) 활용 |
 | GET | `/api/data/schema` | 데이터 스키마 (필터: data_type) |
 | GET | `/api/data/storage` | 저장 용량 현황 |

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3516,8 +3516,10 @@
                   "type": "null"
                 }
               ],
+              "description": "OHLCV timeframe 필터 (canonical vocabulary: 1m, 5m, 15m, 1h, 1d). 미지정 시 전체 timeframe 반환. 위 vocabulary 외 값은 400으로 거부된다.",
               "title": "Timeframe"
-            }
+            },
+            "description": "OHLCV timeframe 필터 (canonical vocabulary: 1m, 5m, 15m, 1h, 1d). 미지정 시 전체 timeframe 반환. 위 vocabulary 외 값은 400으로 거부된다."
           },
           {
             "name": "data_type",
@@ -3572,6 +3574,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatasetListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "허용되지 않은 ``timeframe`` 값. ``timeframe`` 은 canonical vocabulary (``1m``, ``5m``, ``15m``, ``1h``, ``1d``) 중 하나여야 하며, 그 외 값은 400으로 거부된다 (#1594). 타입은 ``string`` 이지만 위 vocabulary 외 값은 런타임에서 검증된다.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -5406,6 +5406,7 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 symbol?: string | null;
+                /** @description OHLCV timeframe 필터 (canonical vocabulary: 1m, 5m, 15m, 1h, 1d). 미지정 시 전체 timeframe 반환. 위 vocabulary 외 값은 400으로 거부된다. */
                 timeframe?: string | null;
             };
             header?: never;
@@ -5421,6 +5422,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DatasetListResponse"];
+                };
+            };
+            /** @description 허용되지 않은 ``timeframe`` 값. ``timeframe`` 은 canonical vocabulary (``1m``, ``5m``, ``15m``, ``1h``, ``1d``) 중 하나여야 하며, 그 외 값은 400으로 거부된다 (#1594). 타입은 ``string`` 이지만 위 vocabulary 외 값은 런타임에서 검증된다. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Validation Error */

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -35,12 +35,36 @@ DATA_TYPES = ["ohlcv", "fundamental"]
 _executor = ThreadPoolExecutor(max_workers=2)
 
 
-@router.get("/datasets", response_model=DatasetListResponse)
+@router.get(
+    "/datasets",
+    response_model=DatasetListResponse,
+    responses={
+        400: {
+            "description": (
+                "허용되지 않은 ``timeframe`` 값. ``timeframe`` 은 canonical "
+                "vocabulary (``1m``, ``5m``, ``15m``, ``1h``, ``1d``) 중 하나여야 "
+                "하며, 그 외 값은 400으로 거부된다 (#1594). 타입은 ``string`` "
+                "이지만 위 vocabulary 외 값은 런타임에서 검증된다."
+            ),
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/ErrorResponse"},
+                },
+            },
+        },
+    },
+)
 async def list_datasets(
     _caller_id: Annotated[str, Depends(require_data_read)],
     store: Annotated[Any | None, Depends(get_data_store)],
     symbol: str | None = None,
-    timeframe: str | None = None,
+    timeframe: str | None = Query(
+        None,
+        description=(
+            "OHLCV timeframe 필터 (canonical vocabulary: 1m, 5m, 15m, 1h, 1d). "
+            "미지정 시 전체 timeframe 반환. 위 vocabulary 외 값은 400으로 거부된다."
+        ),
+    ),
     data_type: Literal["ohlcv", "fundamental"] | None = Query(
         None, description="데이터 유형 (ohlcv, fundamental, 미지정 시 전체)"
     ),

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -58,10 +58,8 @@ async def list_datasets(
     Returns:
         {items: [...], total: int}
     """
-    if store is None:
-        return {"items": [], "total": 0}
-
     # timeframe 필터는 TIMEFRAMES vocabulary 외 값을 400으로 거부한다 (#1594).
+    # store 유무와 무관하게 API 경계에서 거부해야 하므로 store-None 가드보다 앞.
     # (symbol vocabulary 거부는 exchange-aware symbol SSOT 후속 — 본 PR 범위 외)
     if timeframe is not None and timeframe not in TIMEFRAMES:
         raise HTTPException(
@@ -69,6 +67,9 @@ async def list_datasets(
             detail=f"허용되지 않은 timeframe 값: {timeframe} "
             f"(허용: {', '.join(TIMEFRAMES)})",
         )
+
+    if store is None:
+        return {"items": [], "total": 0}
 
     loop = asyncio.get_event_loop()
 

--- a/src/ante/web/routes/data.py
+++ b/src/ante/web/routes/data.py
@@ -10,6 +10,7 @@ from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from ante.data.schemas import TIMEFRAMES
 from ante.web.deps import (
     get_audit_logger_optional,
     get_data_store,
@@ -60,6 +61,15 @@ async def list_datasets(
     if store is None:
         return {"items": [], "total": 0}
 
+    # timeframe 필터는 TIMEFRAMES vocabulary 외 값을 400으로 거부한다 (#1594).
+    # (symbol vocabulary 거부는 exchange-aware symbol SSOT 후속 — 본 PR 범위 외)
+    if timeframe is not None and timeframe not in TIMEFRAMES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"허용되지 않은 timeframe 값: {timeframe} "
+            f"(허용: {', '.join(TIMEFRAMES)})",
+        )
+
     loop = asyncio.get_event_loop()
 
     def _collect_datasets() -> list[dict[str, Any]]:
@@ -83,8 +93,6 @@ async def list_datasets(
 
         # ohlcv 수집 (data_type이 None 또는 "ohlcv"일 때)
         if data_type is None or data_type == "ohlcv":
-            from ante.data.schemas import TIMEFRAMES
-
             tf_list = [timeframe] if timeframe else TIMEFRAMES
             for tf in tf_list:
                 syms = store.list_symbols(tf)

--- a/tests/unit/test_datasets_list_api.py
+++ b/tests/unit/test_datasets_list_api.py
@@ -488,3 +488,34 @@ def test_list_datasets_invalid_timeframe_http_400(_http_client):
     assert "oracle-invalid-timeframe" in detail
     for tf in TIMEFRAMES:
         assert tf in detail
+
+
+def test_datasets_openapi_documents_400_and_timeframe_vocabulary(_http_client):
+    """OpenAPI 계약-런타임 drift 방지 (#1594 Codex attempt2 blocking).
+
+    수동 검증 + 400 동작을 유지하면서 OpenAPI 스키마에 그 계약을
+    문서화한다. timeframe 타입은 ``string|null`` 을 유지해야 하며
+    (Literal/enum 전환 금지 — Plan Review 019e2e2f deferred),
+    400 response 와 vocabulary description 만 노출한다.
+    """
+    spec = _http_client.get("/openapi.json").json()
+    op = spec["paths"]["/api/data/datasets"]["get"]
+
+    # 400 response 가 problem+json ErrorResponse $ref 로 노출
+    assert "400" in op["responses"]
+    resp_400 = op["responses"]["400"]
+    schema_ref = resp_400["content"]["application/problem+json"]["schema"]["$ref"]
+    assert schema_ref == "#/components/schemas/ErrorResponse"
+    assert "1594" in resp_400["description"]
+
+    # timeframe 파라미터: description 에 vocabulary 노출, 타입은 string|null 유지
+    tf_param = next(p for p in op["parameters"] if p["name"] == "timeframe")
+    assert "1m" in tf_param["description"] and "1d" in tf_param["description"]
+    assert "400" in tf_param["description"]
+    # Literal/enum 전환이 아니어야 한다: anyOf(string, null), enum 없음
+    tf_schema = tf_param["schema"]
+    any_of_types = {s.get("type") for s in tf_schema.get("anyOf", [])}
+    assert any_of_types == {"string", "null"}
+    assert "enum" not in tf_schema
+    for sub in tf_schema.get("anyOf", []):
+        assert "enum" not in sub

--- a/tests/unit/test_datasets_list_api.py
+++ b/tests/unit/test_datasets_list_api.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import HTTPException
 
+from ante.data.schemas import TIMEFRAMES
 from ante.web.routes.data import list_datasets
 
 # --- 헬퍼 ---
@@ -278,3 +280,169 @@ async def test_list_datasets_data_type_fundamental():
     types = {item["data_type"] for item in result["items"]}
     assert types == {"fundamental"}
     assert result["total"] == 1
+
+
+# --- timeframe vocabulary 검증 (#1594) ---
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_invalid_timeframe_rejected_400():
+    """oracle 류 invalid timeframe은 200 empty가 아니라 400으로 거부된다.
+
+    수정 전 RED: store.list_symbols(invalid_tf) -> [] -> 200 empty.
+    수정 후 GREEN: API 경계에서 400 거부.
+    """
+    store = _make_store({"1d": ["005930"]})
+
+    with pytest.raises(HTTPException) as exc_info:
+        await list_datasets(
+            _caller_id="test-caller",
+            store=store,
+            symbol=None,
+            timeframe="oracle-invalid-timeframe",
+            data_type="ohlcv",
+            offset=0,
+            limit=50,
+        )
+
+    assert exc_info.value.status_code == 400
+    detail = exc_info.value.detail
+    assert "oracle-invalid-timeframe" in detail
+    # 허용 목록(TIMEFRAMES 전체)이 detail에 포함되어야 한다
+    for tf in TIMEFRAMES:
+        assert tf in detail
+    # invalid timeframe이면 store 조회 자체가 일어나지 않아야 한다
+    store.list_symbols.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_invalid_timeframe_short_token_rejected_400():
+    """짧은 토큰('invalid')도 동일하게 400으로 거부된다."""
+    store = _make_store({"1d": ["005930"]})
+
+    with pytest.raises(HTTPException) as exc_info:
+        await list_datasets(
+            _caller_id="test-caller",
+            store=store,
+            symbol=None,
+            timeframe="invalid",
+            data_type="ohlcv",
+            offset=0,
+            limit=50,
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tf", ["1m", "5m", "15m", "1h", "1d"])
+async def test_list_datasets_valid_timeframe_ok_regression(tf):
+    """TIMEFRAMES vocabulary 내 모든 값은 200(정상 조회)로 회귀 보장."""
+    store = _make_store({tf: ["005930"]})
+
+    result = await list_datasets(
+        _caller_id="test-caller",
+        store=store,
+        symbol=None,
+        timeframe=tf,
+        data_type="ohlcv",
+        offset=0,
+        limit=50,
+    )
+
+    assert result["total"] == 1
+    assert result["items"][0]["timeframe"] == tf
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_no_timeframe_returns_all_regression():
+    """timeframe 미지정은 기존대로 TIMEFRAMES 전체 조회 (검증 통과)."""
+    store = _make_store({"1d": ["005930"], "1h": ["000660"]})
+
+    result = await list_datasets(
+        _caller_id="test-caller",
+        store=store,
+        symbol=None,
+        timeframe=None,
+        data_type="ohlcv",
+        offset=0,
+        limit=50,
+    )
+
+    assert result["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_fundamental_invalid_timeframe_still_rejected():
+    """data_type=fundamental 이어도 invalid timeframe 파라미터는 400 거부.
+
+    검증은 API 경계(데이터 유형 분기 이전)에서 일어나므로
+    fundamental 조회라도 invalid timeframe은 거부된다.
+    """
+    store = _make_store({"fundamental": ["005930"]})
+
+    with pytest.raises(HTTPException) as exc_info:
+        await list_datasets(
+            _caller_id="test-caller",
+            store=store,
+            symbol=None,
+            timeframe="oracle-invalid-timeframe",
+            data_type="fundamental",
+            offset=0,
+            limit=50,
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+# --- 범위 고정 회귀: symbol·data_type 은 본 PR 범위 외 (HTTP 경계) ---
+
+
+@pytest.fixture
+def _http_client():
+    """FastAPI Request 레이어가 필요한 회귀(422 Literal, symbol 200 empty)용."""
+    pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+    import tempfile
+    from pathlib import Path
+
+    from ante.data.store import ParquetStore
+    from ante.web.app import create_app
+    from tests.unit.conftest import make_authed_client, make_master_member_service
+
+    with tempfile.TemporaryDirectory() as tmp:
+        store = ParquetStore(base_path=Path(tmp) / "data")
+        app = create_app(data_store=store, member_service=make_master_member_service())
+        yield make_authed_client(app)
+
+
+def test_list_datasets_invalid_symbol_still_200_empty_scope_lock(_http_client):
+    """범위 고정: invalid symbol은 본 PR에서 200 empty 유지 (후속 후보 0).
+
+    symbol vocabulary 거부는 exchange-aware symbol SSOT 후속 작업이며,
+    본 PR(#1594)은 timeframe만 거부한다. invalid symbol이 400/422로
+    바뀌면 범위 침범이므로 이 회귀가 막는다.
+    """
+    resp = _http_client.get("/api/data/datasets", params={"symbol": "ABCDEF"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"items": [], "total": 0}
+
+
+def test_list_datasets_bogus_data_type_still_422_regression(_http_client):
+    """data_type enum 외 값은 기존 Literal 동작대로 422 (미변경 회귀)."""
+    resp = _http_client.get("/api/data/datasets", params={"data_type": "bogus"})
+    assert resp.status_code == 422
+
+
+def test_list_datasets_invalid_timeframe_http_400(_http_client):
+    """HTTP 경계에서도 invalid timeframe은 400 + detail(허용 목록)."""
+    resp = _http_client.get(
+        "/api/data/datasets",
+        params={"data_type": "ohlcv", "timeframe": "oracle-invalid-timeframe"},
+    )
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert "oracle-invalid-timeframe" in detail
+    for tf in TIMEFRAMES:
+        assert tf in detail

--- a/tests/unit/test_datasets_list_api.py
+++ b/tests/unit/test_datasets_list_api.py
@@ -56,6 +56,48 @@ async def test_list_datasets_returns_empty_when_no_store():
 
 
 @pytest.mark.asyncio
+async def test_list_datasets_store_none_invalid_timeframe_still_400():
+    """store 미주입(None) 환경에서도 invalid timeframe은 400으로 거부된다.
+
+    Codex 브랜치 리뷰 [P2] blocking 회귀 고정: timeframe 검증이
+    store-None 조기 반환 뒤에 있으면 store 미주입 앱/테스트에서
+    invalid timeframe이 200 empty로 새어 나간다. 검증은 store 유무와
+    무관하게 API 경계에서 일어나야 한다.
+    """
+    with pytest.raises(HTTPException) as exc_info:
+        await list_datasets(
+            _caller_id="test-caller",
+            store=None,
+            symbol=None,
+            timeframe="oracle-invalid-timeframe",
+            data_type="ohlcv",
+            offset=0,
+            limit=50,
+        )
+
+    assert exc_info.value.status_code == 400
+    detail = exc_info.value.detail
+    assert "oracle-invalid-timeframe" in detail
+    for tf in TIMEFRAMES:
+        assert tf in detail
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_store_none_valid_timeframe_still_empty():
+    """store=None + valid timeframe은 기존대로 200 empty (동작 회귀)."""
+    result = await list_datasets(
+        _caller_id="test-caller",
+        store=None,
+        symbol=None,
+        timeframe="1d",
+        data_type="ohlcv",
+        offset=0,
+        limit=50,
+    )
+    assert result == {"items": [], "total": 0}
+
+
+@pytest.mark.asyncio
 async def test_list_datasets_pagination_limits_enrichment():
     """페이지네이션이 적용되어 해당 페이지 종목만 enrich한다."""
     syms = [f"00{i:04d}" for i in range(5)]


### PR DESCRIPTION
Closes #1594

## Summary
- `GET /api/data/datasets`가 invalid timeframe 필터를 400/422가 아니라 200 empty로 처리하던 oracle A7 버그 수정 (narrow-scope: timeframe-only)
- `list_datasets` 진입부(store-None 가드 **이전**)에 timeframe vocabulary 검증 추가 — `TIMEFRAMES` 외 값 → 400 (`strategies.py:263-268` `_VALID_STATUS_FILTERS` 동형, 수동검증 유지·Literal 미전환)
- OpenAPI 계약 동기화: `responses={400:...}` + Query description(허용 vocabulary) 추가, `frontend/openapi.json`·`frontend/src/types/api.generated.ts` 재생성 (계약-런타임 drift 해소)
- spec: `docs/specs/web-api/05-resource-endpoints.md` datasets 행에 timeframe 400 계약 명시; **symbol vocabulary 거부는 exchange-aware public symbol SSOT 후속(후보 0)으로 분리** — 본 PR에서 invalid symbol은 200 empty 유지(범위 고정 테스트로 명시)

## Test Plan
- `pytest tests/unit/test_datasets_list_api.py -q` → 27 passed (invalid 400 / valid 5종 / 미지정 / fundamental / store=None+invalid 400 회귀 / symbol=ABCDEF 200 범위고정 / data_type=bogus 422 / OpenAPI 400 노출)
- 인접 회귀 `test_dataset_detail_api.py test_dataset_delete_api.py test_web_api.py` → 122 passed
- `ruff check`/`ruff format --check`/`mypy src/ante/web/routes/data.py` 통과; TS 타입 재생성 idempotent (frontend-api-types 정합)
- Codex Plan Review: narrow-scope (session 019e2e2f) / Codex 브랜치 리뷰: PASS attempt3 (attempt1 store-None 순서·attempt2 OpenAPI drift 수정 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)