### PR TITLE
fix(web): reject inverted date range across 4 read APIs (#1595)

### DIFF
--- a/docs/specs/web-api/05-resource-endpoints.md
+++ b/docs/specs/web-api/05-resource-endpoints.md
@@ -39,7 +39,7 @@
 | POST | `/api/bots/{bot_id}/stop` | 봇 중지 |
 | PUT | `/api/bots/{bot_id}` | 봇 설정 수정. 중지 상태에서만 가능. Body: name?, interval_seconds?, budget?, auto_restart?, max_restart_attempts?, restart_cooldown_seconds?, step_timeout_seconds?, max_signals_per_step?. `budget`은 finite positive number (Infinity/NaN은 422로 거부, #1435). BotConfig 재생성 패턴 적용. budget 변경 시 Treasury 연동. 응답: `{bot: {...}}` |
 | DELETE | `/api/bots/{bot_id}` | 봇 삭제. Query: handle_positions (`keep`\|`liquidate`, 기본 `keep`). `liquidate` 시 보유 종목 시장가 매도 후 삭제 |
-| GET | `/api/bots/{bot_id}/logs` | 봇 실행 로그 조회. `event_log` 테이블에서 해당 봇의 이벤트를 필터링. 필터: limit(기본 10, 최대 100), offset, start_date, end_date. 대상 이벤트: `BotStepCompletedEvent`, `BotStartedEvent`, `BotStoppedEvent`, `BotErrorEvent`. 응답: `{logs: [{timestamp, result, message}], total}` |
+| GET | `/api/bots/{bot_id}/logs` | 봇 실행 로그 조회. `event_log` 테이블에서 해당 봇의 이벤트를 필터링. 필터: limit(기본 10, 최대 100), offset, start_date, end_date. 대상 이벤트: `BotStepCompletedEvent`, `BotStartedEvent`, `BotStoppedEvent`, `BotErrorEvent`. 응답: `{logs: [{timestamp, result, message}], total}`. UTC 정규화 후 `start_date > end_date` (inverted range)는 422 (#1595) |
 
 ## 거래 이력 (`/api/trades`)
 
@@ -94,13 +94,13 @@
 | Method | Path | 설명 |
 |--------|------|------|
 | GET | `/api/treasury` | 자금 현황 요약 (필터: account_id) |
-| GET | `/api/treasury/transactions` | 자금 변동 이력 (필터: account_id, type, bot_id, start_date, end_date, limit, offset). `type ∈ {allocate, deallocate, release, fill, bot_stopped_release}` (#1476) — vocabulary 외 값은 `Literal` 좁힘으로 422 거부 (#1477). `start_date`/`end_date`는 ISO `YYYY-MM-DD` (date-only)만 허용. invalid date는 422. `treasury_transactions.created_at`은 SQLite `datetime('now')` 포맷(`YYYY-MM-DD HH:MM:SS`)으로 저장되어, `start_date`는 `... 00:00:00`, `end_date`는 `... 23:59:59`로 확장되어 SQL 텍스트 비교에 사용된다 (#1440) |
+| GET | `/api/treasury/transactions` | 자금 변동 이력 (필터: account_id, type, bot_id, start_date, end_date, limit, offset). `type ∈ {allocate, deallocate, release, fill, bot_stopped_release}` (#1476) — vocabulary 외 값은 `Literal` 좁힘으로 422 거부 (#1477). `start_date`/`end_date`는 ISO `YYYY-MM-DD` (date-only)만 허용. invalid date는 422. `treasury_transactions.created_at`은 SQLite `datetime('now')` 포맷(`YYYY-MM-DD HH:MM:SS`)으로 저장되어, `start_date`는 `... 00:00:00`, `end_date`는 `... 23:59:59`로 확장되어 SQL 텍스트 비교에 사용된다 (#1440). `start_date > end_date` (inverted range)는 422 (#1595) |
 | GET | `/api/treasury/budgets` | 봇별 예산 목록 |
 | POST | `/api/treasury/bots/{bot_id}/allocate` | 봇에 예산 할당. Body: amount |
 | POST | `/api/treasury/bots/{bot_id}/deallocate` | 봇 예산 회수. Body: amount |
 | POST | `/api/treasury/balance` | 계좌 총 잔고 수동 설정. Body: balance |
 | GET | `/api/treasury/snapshots/latest` | 가장 최근 일별 스냅샷 조회 (필터: account_id). 자금 관리 T-1 데이터 소스 |
-| GET | `/api/treasury/snapshots` | 기간별 일별 스냅샷 목록 (필터: account_id, start_date, end_date). `start_date`/`end_date`는 ISO `YYYY-MM-DD` (date-only)만 허용. invalid date는 422 (#1440). 자금 관리 T-2 차트 데이터 소스 |
+| GET | `/api/treasury/snapshots` | 기간별 일별 스냅샷 목록 (필터: account_id, start_date, end_date). `start_date`/`end_date`는 ISO `YYYY-MM-DD` (date-only)만 허용. invalid date는 422 (#1440). `start_date > end_date` (inverted range)는 422 (#1595). 자금 관리 T-2 차트 데이터 소스 |
 | GET | `/api/treasury/snapshots/{date}` | 특정일 스냅샷 조회 (필터: account_id). `{date}` path는 ISO `YYYY-MM-DD`만 허용. malformed/캘린더 invalid path는 422 (404 아님, #1440) |
 
 > 스냅샷 스펙: [treasury.md — 일별 자산 스냅샷](../treasury/treasury.md#일별-자산-스냅샷-daily-asset-snapshot)
@@ -112,7 +112,7 @@
 | Method | Path | 설명 |
 |--------|------|------|
 | GET | `/api/portfolio/value` | 총 자산 가치 + 당일 손익 + 당일 수익률 + 미실현 손익 (필터: account_id). 최신 스냅샷 기반 |
-| GET | `/api/portfolio/history` | 기간별 자산 추이 (필터: account_id, start_date, end_date). `start_date`/`end_date`는 ISO `YYYY-MM-DD` (date-only)만 허용. invalid date는 422 (#1440). `treasury_daily_snapshots` 시계열 반환 |
+| GET | `/api/portfolio/history` | 기간별 자산 추이 (필터: account_id, start_date, end_date). `start_date`/`end_date`는 ISO `YYYY-MM-DD` (date-only)만 허용. invalid date는 422 (#1440). `start_date > end_date` (inverted range)는 422 (#1595). `treasury_daily_snapshots` 시계열 반환 |
 
 > `/api/portfolio/value` 응답에는 스냅샷의 `total_asset`, `daily_pnl`, `daily_return`, `unrealized_pnl` 등이 포함된다.
 > `/api/portfolio/history`는 프론트엔드가 기간 버튼(1주/1개월/3개월/전체)에 따라 `start_date`/`end_date`를 계산하여 요청한다. 기간 수익률은 프론트엔드에서 `daily_return`의 기하평균으로 산출.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1464,7 +1464,7 @@
             }
           },
           "422": {
-            "description": "Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 저장되므로 임의 문자열을 허용하지 않는다 (#1440).",
+            "description": "Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 저장되므로 임의 문자열을 허용하지 않는다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4642,7 +4642,7 @@
             }
           },
           "422": {
-            "description": "Invalid date filter (ISO 8601 required). ``start_date``/``end_date``는 ISO 8601 date(``YYYY-MM-DD``) 또는 datetime(``YYYY-MM-DDTHH:MM:SS[Z]``)만 허용한다.",
+            "description": "Invalid date filter (ISO 8601 required). ``start_date``/``end_date``는 ISO 8601 date(``YYYY-MM-DD``) 또는 datetime(``YYYY-MM-DDTHH:MM:SS[Z]``)만 허용한다. UTC 정규화 후 ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4868,7 +4868,7 @@
             }
           },
           "422": {
-            "description": "Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_transactions.created_at``은 SQLite ``datetime('now')`` 포맷(``YYYY-MM-DD HH:MM:SS``)으로 저장되며, 검증된 boundary로만 비교한다 (#1440). ``type`` query는 정규 vocabulary ``{allocate, deallocate, release, fill, bot_stopped_release}`` (#1476) 외 값을 ``Literal`` 좁힘으로 422 거부한다 (#1477).",
+            "description": "Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_transactions.created_at``은 SQLite ``datetime('now')`` 포맷(``YYYY-MM-DD HH:MM:SS``)으로 저장되며, 검증된 boundary로만 비교한다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595). ``type`` query는 정규 vocabulary ``{allocate, deallocate, release, fill, bot_stopped_release}`` (#1476) 외 값을 ``Literal`` 좁힘으로 422 거부한다 (#1477).",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -5350,7 +5350,7 @@
             }
           },
           "422": {
-            "description": "Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 저장되므로 임의 문자열을 허용하지 않는다 (#1440).",
+            "description": "Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 저장되므로 임의 문자열을 허용하지 않는다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595).",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -5153,7 +5153,7 @@ export interface operations {
                     "application/problem+json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Invalid date filter (ISO 8601 required). ``start_date``/``end_date``는 ISO 8601 date(``YYYY-MM-DD``) 또는 datetime(``YYYY-MM-DDTHH:MM:SS[Z]``)만 허용한다. */
+            /** @description Invalid date filter (ISO 8601 required). ``start_date``/``end_date``는 ISO 8601 date(``YYYY-MM-DD``) 또는 datetime(``YYYY-MM-DDTHH:MM:SS[Z]``)만 허용한다. UTC 정규화 후 ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595). */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -6200,7 +6200,7 @@ export interface operations {
                     "application/json": components["schemas"]["PortfolioHistoryResponse"];
                 };
             };
-            /** @description Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 저장되므로 임의 문자열을 허용하지 않는다 (#1440). */
+            /** @description Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 저장되므로 임의 문자열을 허용하지 않는다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595). */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -7450,7 +7450,7 @@ export interface operations {
                     "application/json": components["schemas"]["SnapshotListResponse"];
                 };
             };
-            /** @description Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 저장되므로 임의 문자열을 허용하지 않는다 (#1440). */
+            /** @description Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 저장되므로 임의 문자열을 허용하지 않는다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595). */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -7589,7 +7589,7 @@ export interface operations {
                     "application/json": components["schemas"]["TransactionListResponse"];
                 };
             };
-            /** @description Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_transactions.created_at``은 SQLite ``datetime('now')`` 포맷(``YYYY-MM-DD HH:MM:SS``)으로 저장되며, 검증된 boundary로만 비교한다 (#1440). ``type`` query는 정규 vocabulary ``{allocate, deallocate, release, fill, bot_stopped_release}`` (#1476) 외 값을 ``Literal`` 좁힘으로 422 거부한다 (#1477). */
+            /** @description Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). ``treasury_transactions.created_at``은 SQLite ``datetime('now')`` 포맷(``YYYY-MM-DD HH:MM:SS``)으로 저장되며, 검증된 boundary로만 비교한다 (#1440). ``start_date > end_date`` (inverted range)도 422로 거부한다 (#1595). ``type`` query는 정규 vocabulary ``{allocate, deallocate, release, fill, bot_stopped_release}`` (#1476) 외 값을 ``Literal`` 좁힘으로 422 거부한다 (#1477). */
             422: {
                 headers: {
                     [name: string]: unknown;

--- a/src/ante/web/routes/bots.py
+++ b/src/ante/web/routes/bots.py
@@ -28,6 +28,7 @@ from ante.web.schemas import (
     BotListResponse,
     BotUpdateRequest,
 )
+from ante.web.utils.date_params import reject_inverted_date_range
 
 logger = logging.getLogger(__name__)
 
@@ -1261,7 +1262,9 @@ def _validate_iso_date_param(
             "description": (
                 "Invalid date filter (ISO 8601 required). ``start_date``/"
                 "``end_date``는 ISO 8601 date(``YYYY-MM-DD``) 또는 "
-                "datetime(``YYYY-MM-DDTHH:MM:SS[Z]``)만 허용한다."
+                "datetime(``YYYY-MM-DDTHH:MM:SS[Z]``)만 허용한다. UTC 정규화 "
+                "후 ``start_date > end_date`` (inverted range)도 422로 거부한다 "
+                "(#1595)."
             ),
             "content": {
                 "application/problem+json": {
@@ -1363,6 +1366,10 @@ async def get_bot_logs(
     # end_date는 ``end_of_day=True``로 date-only를 ``T23:59:59.999999``로 확장.
     start_validated = _validate_iso_date_param(start_date, "start_date")
     end_validated = _validate_iso_date_param(end_date, "end_date", end_of_day=True)
+    # 둘 다 UTC-aware datetime으로 정규화된 뒤 비교 → cross-offset 입력도
+    # aware/naive TypeError 없이 실제 UTC 순서로 inverted range만 422 거부.
+    # end_date는 ``end_of_day=True``로 ``T23:59:59``라 동일 날짜는 통과 (#1595).
+    reject_inverted_date_range(start_validated, end_validated)
 
     if event_history_store is not None:
         # r2: ``bot_id``를 SQL JSON1 ``payload_filter``로 끌어올려 SQL 단계

--- a/src/ante/web/routes/portfolio.py
+++ b/src/ante/web/routes/portfolio.py
@@ -17,7 +17,10 @@ from ante.web.schemas import (
     PortfolioHistoryResponse,
     PortfolioValueResponse,
 )
-from ante.web.utils.date_params import validate_iso_date_only
+from ante.web.utils.date_params import (
+    reject_inverted_date_range,
+    validate_iso_date_only,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +102,9 @@ async def portfolio_value(
             "description": (
                 "Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). "
                 "``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 "
-                "저장되므로 임의 문자열을 허용하지 않는다 (#1440)."
+                "저장되므로 임의 문자열을 허용하지 않는다 (#1440). "
+                "``start_date > end_date`` (inverted range)도 422로 거부한다 "
+                "(#1595)."
             ),
             "content": {
                 "application/problem+json": {
@@ -133,6 +138,8 @@ async def portfolio_history(
     """
     start_date = validate_iso_date_only(start_date, "start_date")
     end_date = validate_iso_date_only(end_date, "end_date")
+    # default 적용 이전: 미지정(None)은 통과, start>end (inverted) 만 거부 (#1595).
+    reject_inverted_date_range(start_date, end_date)
 
     target = _resolve_treasury(treasury, treasury_manager, account_id)
 

--- a/src/ante/web/routes/treasury.py
+++ b/src/ante/web/routes/treasury.py
@@ -29,6 +29,7 @@ from ante.web.schemas import (
     TreasurySummaryResponse,
 )
 from ante.web.utils.date_params import (
+    reject_inverted_date_range,
     validate_iso_date_only,
     validate_iso_date_param_for_sql_datetime,
 )
@@ -266,7 +267,8 @@ async def get_summary(
                 "Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required)."
                 " ``treasury_transactions.created_at``은 SQLite ``datetime('now')``"
                 " 포맷(``YYYY-MM-DD HH:MM:SS``)으로 저장되며, 검증된 boundary로만"
-                " 비교한다 (#1440). ``type`` query는 정규 vocabulary"
+                " 비교한다 (#1440). ``start_date > end_date`` (inverted range)도"
+                " 422로 거부한다 (#1595). ``type`` query는 정규 vocabulary"
                 " ``{allocate, deallocate, release, fill, bot_stopped_release}``"
                 " (#1476) 외 값을 ``Literal`` 좁힘으로 422 거부한다 (#1477)."
             ),
@@ -328,6 +330,9 @@ async def list_transactions(
     end_bound = validate_iso_date_param_for_sql_datetime(
         end_date, "end_date", end_of_day=True
     )
+    # boundary str lexicographic 정합: start ``YYYY-MM-DD 00:00:00`` ≤ end
+    # ``YYYY-MM-DD 23:59:59`` 이므로 동일 날짜는 통과, 역전만 422 거부 (#1595).
+    reject_inverted_date_range(start_bound, end_bound)
 
     db = getattr(treasury, "_db", None)
     if db is None:
@@ -940,7 +945,9 @@ async def get_latest_snapshot(
             "description": (
                 "Invalid ``start_date``/``end_date`` (ISO ``YYYY-MM-DD`` required). "
                 "``treasury_daily_snapshots.snapshot_date`` 컬럼이 date-only로 "
-                "저장되므로 임의 문자열을 허용하지 않는다 (#1440)."
+                "저장되므로 임의 문자열을 허용하지 않는다 (#1440). "
+                "``start_date > end_date`` (inverted range)도 422로 거부한다 "
+                "(#1595)."
             ),
             "content": {
                 "application/problem+json": {
@@ -974,6 +981,8 @@ async def list_snapshots(
     """
     start_date = validate_iso_date_only(start_date, "start_date")
     end_date = validate_iso_date_only(end_date, "end_date")
+    # default 적용 이전: 미지정(None)은 통과, start>end (inverted) 만 거부 (#1595).
+    reject_inverted_date_range(start_date, end_date)
 
     target = _resolve_treasury(treasury, treasury_manager, account_id)
 

--- a/src/ante/web/utils/date_params.py
+++ b/src/ante/web/utils/date_params.py
@@ -7,7 +7,7 @@ date-only 입력만 받는다. 그러나 본 PR 이전에는 임의 문자열
 (``oracle-not-a-date``)도 200으로 통과하여 정상 데이터셋과 구분되지 않는
 contract drift가 있었다.
 
-본 모듈은 두 종류의 헬퍼를 제공한다:
+본 모듈은 세 종류의 헬퍼를 제공한다:
 
 * :func:`validate_iso_date_only` — 입력을 ``YYYY-MM-DD`` 표준 형식으로 검증
   하고 그대로 돌려준다. 캘린더상 존재하지 않는 날짜(``2026-13-32``)도 거부.
@@ -19,6 +19,17 @@ contract drift가 있었다.
   boundary 문자열로 확장한다. ``treasury_transactions.created_at`` 컬럼은
   SQLite ``datetime('now')`` 기본값을 쓰므로 SQL 텍스트 비교가 정확한
   inclusive bound를 가지려면 boundary 확장이 필수다.
+
+* :func:`reject_inverted_date_range` — 정규화된 start/end 값이 모두 not
+  ``None``이고 ``start > end`` (불가능한 기간)이면 ``HTTPException(422)``로
+  거부한다 (#1595, oracle A7). portfolio history / treasury transactions /
+  treasury snapshots / bot logs 4개 read API가 inverted range를 400/422가
+  아니라 200 empty로 silently 흡수하던 contract drift를 차단한다. start/end가
+  각 endpoint 내에서 동일 타입(ISO ``YYYY-MM-DD`` str, SQLite boundary str,
+  UTC-aware ``datetime``)이고 모두 ``>`` 비교가 시간 순서와 일치하므로 generic
+  comparator 1개로 4곳을 모두 커버한다. 한쪽/양쪽이 ``None``(미지정)이면
+  통과시켜 caller의 default 분기를 보존한다 — 검증 호출은 default 적용 **전**에
+  배치해야 한다.
 
 본 헬퍼는 ``ante.web.routes.bots._validate_iso_date_param``과 의도적으로
 분리되어 있다. bot logs 페이지네이션은 ``EventHistoryStore``의 ISO 8601
@@ -39,10 +50,12 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
+from typing import Protocol
 
 from fastapi import HTTPException
 
 __all__ = [
+    "reject_inverted_date_range",
     "validate_iso_date_only",
     "validate_iso_date_param_for_sql_datetime",
 ]
@@ -152,3 +165,66 @@ def validate_iso_date_param_for_sql_datetime(
     normalized = _parse_iso_date_only(value, field)
     suffix = " 23:59:59" if end_of_day else " 00:00:00"
     return normalized + suffix
+
+
+class _Orderable(Protocol):
+    """``>`` 비교가 가능한 값의 최소 구조 (generic comparator 제약).
+
+    4개 endpoint가 정규화하는 타입은 ISO ``YYYY-MM-DD`` str, SQLite boundary
+    str(``YYYY-MM-DD HH:MM:SS``), UTC-aware :class:`datetime` 셋이며 모두 같은
+    타입끼리의 ``>`` 비교가 실제 시간 순서와 일치한다. 본 Protocol은 그
+    공통 계약(``__gt__``)만 노출한다.
+    """
+
+    def __gt__(self, other: object, /) -> bool: ...
+
+
+def reject_inverted_date_range[T: _Orderable](
+    start: T | None,
+    end: T | None,
+    *,
+    start_field: str = "start_date",
+    end_field: str = "end_date",
+) -> None:
+    """정규화된 ``start``/``end``가 inverted range면 ``HTTPException(422)``.
+
+    4개 read API(portfolio history, treasury transactions, treasury
+    snapshots, bot logs)는 FastAPI query 레벨에서 날짜 *형식*만 검증하고
+    ``start_date > end_date`` 순서는 검증하지 않아, 불가능한 기간을 400/422가
+    아니라 200 empty result로 silently 흡수했다 (#1595, oracle A7). 본 헬퍼는
+    그 date-order invariant의 SSOT다.
+
+    비교는 generic ``>`` 단 한 번이다. 각 endpoint가 start/end를 동일 타입으로
+    정규화하고(ISO ``YYYY-MM-DD`` str / SQLite boundary str / UTC-aware
+    :class:`datetime`) 그 타입의 ``>``가 실제 시간 순서와 일치하므로 (str은
+    lexicographic, datetime은 native) 추가 파싱 없이 정확하다. 따라서
+    호출부는 검증된/정규화된 값을 넘겨야 한다 (raw 입력 아님). bot logs처럼
+    tz-aware datetime을 넘기는 경우 UTC-aware로 정규화된 뒤 비교되므로
+    cross-offset 입력도 aware/naive ``TypeError`` 없이 실제 UTC 순서로
+    판정된다.
+
+    한쪽 또는 양쪽이 ``None``(사용자 미지정)이면 통과시킨다. 따라서 호출은
+    각 endpoint의 default 적용 **이전**에 배치해야 미지정 케이스가 거부되지
+    않고 기존 default 동작이 보존된다.
+
+    Args:
+        start: 정규화된 start 값 또는 ``None``.
+        end: 정규화된 end 값 또는 ``None``.
+        start_field: 에러 메시지에 사용할 start 필드명.
+        end_field: 에러 메시지에 사용할 end 필드명.
+
+    Raises:
+        HTTPException(422): ``start``/``end``가 모두 not ``None``이고
+            ``start > end`` (inverted range)일 때. detail에 두 필드명과 두
+            값을 포함한다.
+    """
+    if start is None or end is None:
+        return
+    if start > end:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"invalid date range: {start_field} ({start!r}) must not be "
+                f"after {end_field} ({end!r})"
+            ),
+        )

--- a/src/ante/web/utils/date_params.py
+++ b/src/ante/web/utils/date_params.py
@@ -50,7 +50,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from typing import Protocol
+from typing import Any, Protocol
 
 from fastapi import HTTPException
 
@@ -174,9 +174,17 @@ class _Orderable(Protocol):
     str(``YYYY-MM-DD HH:MM:SS``), UTC-aware :class:`datetime` 셋이며 모두 같은
     타입끼리의 ``>`` 비교가 실제 시간 순서와 일치한다. 본 Protocol은 그
     공통 계약(``__gt__``)만 노출한다.
+
+    ``other`` 인자는 :class:`typing.Any`로 둔다. typeshed의
+    ``str.__gt__(self, value: str, /)``/``datetime.__gt__(self, value:
+    datetime, /)``는 ``object``를 받지 않으므로, ``other: object``로 두면
+    str/datetime이 본 Protocol을 구조적으로 만족하지 못해 mypy가 호출부
+    (portfolio/treasury/bots)를 ``expected "None"``으로 거부한다 (#1595
+    Codex r1). ``Any``는 모든 시그니처를 구조적으로 수용하므로 런타임
+    동작을 바꾸지 않고 mypy ``src/`` 전체를 통과시킨다.
     """
 
-    def __gt__(self, other: object, /) -> bool: ...
+    def __gt__(self, other: Any, /) -> bool: ...
 
 
 def reject_inverted_date_range[T: _Orderable](

--- a/tests/unit/test_api_inverted_date_range.py
+++ b/tests/unit/test_api_inverted_date_range.py
@@ -1,0 +1,364 @@
+"""inverted date range (``start_date > end_date``) 422 회귀 (#1595, oracle A7).
+
+4개 read API(portfolio history, treasury transactions, treasury snapshots,
+bot logs)가 ``start_date=2026-02-01&end_date=2026-01-01`` 같은 불가능한 기간을
+400/422가 아니라 200 empty result로 silently 흡수하던 contract drift를
+``ante.web.utils.date_params.reject_inverted_date_range`` 공유 헬퍼로 차단한다.
+
+검증축:
+* inverted → 422 (4 endpoint 전부)
+* 회귀(유효 start<end) → 200
+* 회귀(동일 날짜 start==end) → 200
+* bot logs cross-offset tz-aware: UTC 정규화 후 역전만 422, 같은 UTC 시각/정상
+  cross-offset은 200 (aware/naive ``TypeError`` 없음)
+* 회귀(미지정/한쪽만) → 200 (기존 default 동작 보존)
+* 회귀(기존 invalid date ``2026-13-32``) → 422 (#1440 동작 미변경)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+httpx = pytest.importorskip("httpx", reason="httpx required for web API tests")
+
+
+from ante.eventbus import EventBus  # noqa: E402
+from ante.eventbus.events import BotStepCompletedEvent  # noqa: E402
+from ante.web.app import create_app  # noqa: E402
+from tests.unit.conftest import (  # noqa: E402
+    make_authed_client,
+    make_master_member_service,
+)
+
+INVERTED = {"start_date": "2026-02-01", "end_date": "2026-01-01"}
+VALID = {"start_date": "2026-01-01", "end_date": "2026-02-01"}
+SAME = {"start_date": "2026-01-15", "end_date": "2026-01-15"}
+
+
+# ── 공유 stub ─────────────────────────────────────────────
+
+
+class _StubDB:
+    """``treasury._db`` 자리. transactions 라우트의 SQL은 빈 결과를 돌려준다."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def fetch_one(self, query: str, params: tuple) -> dict | None:
+        self.calls.append(query)
+        if "COUNT(*)" in query:
+            return {"cnt": 0}
+        return None
+
+    async def fetch_all(self, query: str, params: tuple) -> list[dict]:
+        self.calls.append(query)
+        return []
+
+
+def _make_treasury() -> MagicMock:
+    mock = MagicMock()
+    mock._db = _StubDB()
+    mock.get_summary.return_value = {
+        "total_evaluation": 0.0,
+        "total_profit_loss": 0.0,
+        "account_balance": 0.0,
+    }
+    mock.get_latest_snapshot = AsyncMock(return_value=None)
+    mock.get_snapshots = AsyncMock(return_value=[])
+    mock.get_daily_snapshot = AsyncMock(return_value=None)
+    return mock
+
+
+class _FakeBotConfig:
+    def __init__(self, bot_id: str) -> None:
+        self.bot_id = bot_id
+        self.account_id = "test"
+
+
+class _FakeBot:
+    def __init__(self, bot_id: str) -> None:
+        self.bot_id = bot_id
+        self.config = _FakeBotConfig(bot_id)
+
+    def get_info(self) -> dict[str, Any]:
+        return {"bot_id": self.bot_id, "name": self.bot_id, "status": "running"}
+
+
+class _FakeBotManager:
+    def __init__(self) -> None:
+        self._bots: dict[str, _FakeBot] = {"probe-bot": _FakeBot("probe-bot")}
+
+    def get_bot(self, bot_id: str) -> _FakeBot | None:
+        return self._bots.get(bot_id)
+
+
+# ── fixtures ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def treasury() -> MagicMock:
+    return _make_treasury()
+
+
+@pytest.fixture
+def treasury_client(treasury: MagicMock):
+    app = create_app(
+        treasury=treasury,
+        member_service=make_master_member_service(),
+    )
+    return make_authed_client(app)
+
+
+@pytest.fixture
+def bot_logs_client():
+    eb = EventBus()
+    bot_manager = _FakeBotManager()
+    app = create_app(
+        bot_manager=bot_manager,
+        eventbus=eb,
+        member_service=make_master_member_service(),
+    )
+    return make_authed_client(app)
+
+
+# ── 422: inverted range (oracle A7 본문) ──────────────────
+
+
+class TestInvertedRangeRejected422:
+    """``start_date=2026-02-01&end_date=2026-01-01`` → 4곳 모두 422."""
+
+    def test_portfolio_history_inverted_422(self, treasury_client) -> None:
+        resp = treasury_client.get("/api/portfolio/history", params=INVERTED)
+        assert resp.status_code == 422, resp.text
+
+    def test_treasury_transactions_inverted_422(
+        self, treasury_client, treasury: MagicMock
+    ) -> None:
+        resp = treasury_client.get(
+            "/api/treasury/transactions",
+            params={**INVERTED, "limit": 1},
+        )
+        assert resp.status_code == 422, resp.text
+        # defense-in-depth: 422 거부 시 SQL이 호출되어선 안 된다.
+        assert treasury._db.calls == [], treasury._db.calls
+
+    def test_treasury_snapshots_inverted_422(self, treasury_client) -> None:
+        resp = treasury_client.get("/api/treasury/snapshots", params=INVERTED)
+        assert resp.status_code == 422, resp.text
+
+    def test_bot_logs_inverted_422(self, bot_logs_client) -> None:
+        resp = bot_logs_client.get(
+            "/api/bots/probe-bot/logs",
+            params={**INVERTED, "limit": 1},
+        )
+        assert resp.status_code == 422, resp.text
+
+
+# ── 200: 유효/동일 날짜 회귀 ──────────────────────────────
+
+
+class TestValidRangeRegression:
+    """start<end (유효) 와 start==end (동일) 는 200 유지."""
+
+    @pytest.mark.parametrize("params", [VALID, SAME])
+    def test_portfolio_history_200(self, treasury_client, params: dict) -> None:
+        resp = treasury_client.get("/api/portfolio/history", params=params)
+        assert resp.status_code == 200, resp.text
+
+    @pytest.mark.parametrize("params", [VALID, SAME])
+    def test_treasury_transactions_200(self, treasury_client, params: dict) -> None:
+        resp = treasury_client.get(
+            "/api/treasury/transactions",
+            params={**params, "limit": 1},
+        )
+        assert resp.status_code == 200, resp.text
+
+    @pytest.mark.parametrize("params", [VALID, SAME])
+    def test_treasury_snapshots_200(self, treasury_client, params: dict) -> None:
+        resp = treasury_client.get("/api/treasury/snapshots", params=params)
+        assert resp.status_code == 200, resp.text
+
+    @pytest.mark.parametrize("params", [VALID, SAME])
+    def test_bot_logs_200(self, bot_logs_client, params: dict) -> None:
+        resp = bot_logs_client.get(
+            "/api/bots/probe-bot/logs",
+            params={**params, "limit": 1},
+        )
+        assert resp.status_code == 200, resp.text
+
+
+# ── 200: 미지정/한쪽만 (기존 default 동작 보존) ──────────
+
+
+class TestUnspecifiedRangeRegression:
+    """start/end 생략 또는 한쪽만 지정 → 거부하지 않고 200."""
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {},
+            {"start_date": "2026-01-01"},
+            {"end_date": "2026-02-01"},
+        ],
+    )
+    def test_portfolio_history_unspecified_200(
+        self, treasury_client, params: dict
+    ) -> None:
+        resp = treasury_client.get("/api/portfolio/history", params=params)
+        assert resp.status_code == 200, resp.text
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"limit": 1},
+            {"start_date": "2026-01-01", "limit": 1},
+            {"end_date": "2026-02-01", "limit": 1},
+        ],
+    )
+    def test_treasury_transactions_unspecified_200(
+        self, treasury_client, params: dict
+    ) -> None:
+        resp = treasury_client.get("/api/treasury/transactions", params=params)
+        assert resp.status_code == 200, resp.text
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {},
+            {"start_date": "2026-01-01"},
+            {"end_date": "2026-02-01"},
+        ],
+    )
+    def test_treasury_snapshots_unspecified_200(
+        self, treasury_client, params: dict
+    ) -> None:
+        resp = treasury_client.get("/api/treasury/snapshots", params=params)
+        assert resp.status_code == 200, resp.text
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"limit": 1},
+            {"start_date": "2026-01-01", "limit": 1},
+            {"end_date": "2026-02-01", "limit": 1},
+        ],
+    )
+    def test_bot_logs_unspecified_200(self, bot_logs_client, params: dict) -> None:
+        resp = bot_logs_client.get("/api/bots/probe-bot/logs", params=params)
+        assert resp.status_code == 200, resp.text
+
+
+# ── 422: 기존 invalid date (#1440 동작 미변경) ────────────
+
+
+class TestExistingInvalidDateRegression:
+    """``start_date=2026-13-32`` 는 기존대로 422 (inverted 추가가 회귀시키지 않음)."""
+
+    def test_portfolio_history_invalid_date_422(self, treasury_client) -> None:
+        resp = treasury_client.get(
+            "/api/portfolio/history",
+            params={"start_date": "2026-13-32"},
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_treasury_transactions_invalid_date_422(self, treasury_client) -> None:
+        resp = treasury_client.get(
+            "/api/treasury/transactions",
+            params={"start_date": "2026-13-32", "limit": 1},
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_treasury_snapshots_invalid_date_422(self, treasury_client) -> None:
+        resp = treasury_client.get(
+            "/api/treasury/snapshots",
+            params={"start_date": "2026-13-32"},
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_bot_logs_invalid_date_422(self, bot_logs_client) -> None:
+        resp = bot_logs_client.get(
+            "/api/bots/probe-bot/logs",
+            params={"start_date": "2026-13-32", "limit": 1},
+        )
+        assert resp.status_code == 422, resp.text
+
+
+# ── bot logs tz-aware cross-offset ────────────────────────
+
+
+class TestBotLogsTzAwareInverted:
+    """offset 정규화 후 순서로 판정 (aware/naive ``TypeError`` 없음).
+
+    ``start=2026-02-01T00:00:00+09:00`` (UTC 2026-01-31T15:00:00) &
+    ``end=2026-01-01T00:00:00Z`` → UTC 비교 시 start > end → 422.
+    같은 UTC 시각 / 정상 cross-offset range → 200.
+    """
+
+    def test_cross_offset_inverted_422(self, bot_logs_client) -> None:
+        resp = bot_logs_client.get(
+            "/api/bots/probe-bot/logs",
+            params={
+                "start_date": "2026-02-01T00:00:00+09:00",
+                "end_date": "2026-01-01T00:00:00Z",
+                "limit": 1,
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_cross_offset_same_utc_instant_200(self, bot_logs_client) -> None:
+        # 2026-01-01T09:00:00+09:00 == 2026-01-01T00:00:00Z (동일 UTC 시각).
+        # end는 그대로, start==end UTC → 역전 아님 → 200.
+        resp = bot_logs_client.get(
+            "/api/bots/probe-bot/logs",
+            params={
+                "start_date": "2026-01-01T09:00:00+09:00",
+                "end_date": "2026-01-01T00:00:00Z",
+                "limit": 1,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_cross_offset_valid_range_200(self, bot_logs_client) -> None:
+        # start UTC 2026-01-01T00:00 < end UTC 2026-02-01T00:00 → 200.
+        resp = bot_logs_client.get(
+            "/api/bots/probe-bot/logs",
+            params={
+                "start_date": "2026-01-01T09:00:00+09:00",
+                "end_date": "2026-02-01T00:00:00Z",
+                "limit": 1,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_cross_offset_valid_range_returns_events(self, bot_logs_client) -> None:
+        """정상 cross-offset에서 이벤트가 실제로 반환되어 비교가 silently
+        empty가 아님을 확인."""
+
+        async def _publish() -> None:
+            # eventbus는 fixture 내부에서 만들었으므로 app.state로 접근.
+            app = bot_logs_client.app  # type: ignore[attr-defined]
+            eb = app.state.eventbus
+            await eb.publish(
+                BotStepCompletedEvent(
+                    bot_id="probe-bot",
+                    account_id="test",
+                    result="success",
+                    message="signals=1",
+                )
+            )
+
+        asyncio.get_event_loop().run_until_complete(_publish())
+        resp = bot_logs_client.get(
+            "/api/bots/probe-bot/logs",
+            params={
+                "start_date": "2020-01-01T00:00:00Z",
+                "end_date": "2030-01-01T00:00:00Z",
+                "limit": 10,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["logs"], resp.text


### PR DESCRIPTION
Closes #1595

## Summary
- portfolio history / treasury transactions / treasury snapshots / bot logs 4개 read API가 inverted date range(`start_date > end_date`)를 400/422 아닌 200 empty로 처리하던 oracle A7 버그 수정
- `src/ante/web/utils/date_params.py`에 공유 `reject_inverted_date_range` 헬퍼 추가 (generic, str·datetime 공통, 둘 다 not None이고 start>end면 422; 한쪽/양쪽 None 통과). 4개 route의 정규화 직후·default 이전에 호출 (axis-wide sweep, grep invariant 4곳)
- 기존 invalid-date 422(#1440)와 동일 계층 → 422 채택. 4 route `responses[422].description` + `docs/specs/web-api/05-resource-endpoints.md` + `frontend/openapi.json`/`api.generated.ts` 동기화
- `/api/audit`는 `from_date/to_date`라 4-endpoint(`start_date/end_date`) repro 밖 — 별도 follow-up (Non-Goal)

## Test Plan
- `pytest tests/unit/test_api_inverted_date_range.py -q` → 32 passed (4×invalid 422 / valid·same-day 200 / one-sided None 200 / bot logs cross-offset tz-aware / 기존 invalid-date 422 회귀)
- 인접 회귀 (test_web_api/treasury/portfolio/bot logs) → 236 passed
- `mypy src/` 전체 0 errors (240 files), `ruff check`/`ruff format` 통과, grep invariant 4곳
- Codex Plan Review: approve-implement (rev2, session 019e2e46) / Codex 브랜치 리뷰: PASS attempt2 (attempt1 _Orderable mypy src/ 회귀 수정 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)