### PR TITLE
fix(cli): reject inverted date range across 4 read/report commands (#1597)

### DIFF
--- a/docs/specs/cli/02-design-decisions.md
+++ b/docs/specs/cli/02-design-decisions.md
@@ -86,6 +86,15 @@ JSON 모드(`--format json`)에서는 `{status: "error", code: "...", message: "
 명확하면 도메인 prefix를 사용하고(`ACCOUNT_*`, `MEMBER_*`, `BOT_*`, `UPDATE_*`),
 도메인이 없으면 `CLI_*` prefix를 사용한다.
 
+> **명명 규칙 예외 (legacy/common date-range 코드)**: 위 규칙은 domainless
+> 입력 계약 위반에 `CLI_*` prefix를 요구하지만, `INVALID_DATE_RANGE`(시작일 >
+> 종료일)와 `INVALID_DATE`(달력 날짜 형식 오류)는 기존 `backtest run` CLI가
+> 이미 사용 중인(`src/ante/cli/commands/backtest.py:69,75`) 호환 유지용
+> legacy/common date-range 코드로 `CLI_*` prefix 예외다. 신규 코드를 신설하지
+> 않고 동일 의미를 갖는 다른 read/report 명령에도 이 코드를 그대로 재사용한다
+> (#1597). 신규 입력 계약 위반은 이 예외를 따르지 않고 위 표준 명명 규칙을
+> 적용한다.
+
 표준 에러 코드 (이번 이슈에서 SSOT로 확정):
 
 | 에러 코드 | 의미 | 발생 명령 |
@@ -93,6 +102,7 @@ JSON 모드(`--format json`)에서는 `{status: "error", code: "...", message: "
 | `CLI_MISSING_REQUIRED_INPUT` | 필수 옵션·인자 누락 (도메인 명확 시 도메인 prefix specialize) | 모든 명령 |
 | `CLI_CONFIRMATION_REQUIRED` | 위험 명령에 `--yes`/`--force` 누락 | `account delete`, `bot remove`, `member revoke`, `update` |
 | `CLI_OPTION_CONFLICT` | 상호 배타적인 옵션을 동시 사용 (period별 전용 옵션을 다른 period와 함께 사용 등) | `report performance`, `treasury snapshot` |
+| `INVALID_DATE_RANGE` | 시작일 > 종료일 (inverted date range). **legacy/common 코드 — `CLI_*` 명명 규칙 예외**(위 예외 박스 참조) | `backtest run`, `audit list`, `trade list`, `treasury snapshot`, `report performance` |
 | `ACCOUNT_MISSING_REQUIRED_CREDENTIAL` | `BrokerPreset.required_credentials`에 정의된 credential key 누락 | `account create`, `account set-credentials` |
 | `ACCOUNT_UNKNOWN_CREDENTIAL_KEY` | broker preset의 `required_credentials`에 정의되지 않은 credential key 제공 | `account create`, `account set-credentials` |
 | `ACCOUNT_DUPLICATE_CREDENTIAL_KEY` | 같은 credential key를 `--credential`/`--credential-env`/`--credential-file` 중 둘 이상 채널로 중복 제공 | `account create`, `account set-credentials` |

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -347,6 +347,11 @@ ante trade list [--bot <bot_id>] [--from <날짜>] [--to <날짜>] [--limit N]
 ante trade info <trade_id>         # 거래 상세
 ```
 
+`trade list`의 `--from`/`--to`가 모두 지정되고 시작일(`--from`)이 종료일(`--to`)
+이후이면(inverted date range) DB 접근 이전에 `INVALID_DATE_RANGE` 에러 코드와
+exit code 1로 거부한다(빈 결과 반환 금지). 한쪽만 지정·둘 다 미지정·동일
+날짜는 정상 처리한다.
+
 ### `ante strategy` — 전략 관리
 
 ```bash
@@ -372,6 +377,12 @@ ante treasury snapshot [--account <account_id>]                        # 최근 
 ante treasury snapshot --from <날짜> --to <날짜> [--account <account_id>]  # 기간별 스냅샷 (대시보드 D-2 차트)
 ante treasury snapshot --date <날짜> [--account <account_id>]          # 특정일 스냅샷
 ```
+
+`treasury snapshot`의 `--from`/`--to`가 모두 지정되고 시작일(`--from`)이
+종료일(`--to`) 이후이면(inverted date range), `--date`/`--from`/`--to` 배타
+검증(`CLI_OPTION_CONFLICT`) 직후·서비스 호출 이전에 `INVALID_DATE_RANGE` 에러
+코드와 exit code 1로 거부한다(빈 결과 반환 금지). 한쪽만 지정·둘 다
+미지정·동일 날짜는 정상 처리한다.
 
 > 스냅샷 스펙: [treasury.md — 일별 자산 스냅샷](../treasury/treasury.md#일별-자산-스냅샷-daily-asset-snapshot)
 
@@ -436,6 +447,13 @@ ante report performance [--period daily|monthly] [--bot-id <봇ID>] [--start <�
 `--period daily` 전용, `--year`는 `--period monthly` 전용이며 (`--period` 기본값은
 `daily`), period와 맞지 않는 옵션을 함께 지정하면 DB 접근 이전에
 `CLI_OPTION_CONFLICT` 에러 코드와 exit code 1로 거부한다(빈 집계 반환 금지).
+
+추가로 `--period daily`에서 `--start`/`--end`가 모두 지정되고 시작일(`--start`)이
+종료일(`--end`) 이후이면(inverted date range), 위 period-exclusive 검증 직후·DB
+접근 이전에 `INVALID_DATE_RANGE` 에러 코드와 exit code 1로 거부한다(빈 집계 반환
+금지). 검증 순서는 period-exclusive(`CLI_OPTION_CONFLICT`)가 먼저이므로
+`--period monthly --start ... --end ...`는 여전히 `CLI_OPTION_CONFLICT`로
+거부되며 `INVALID_DATE_RANGE`에 도달하지 않는다.
 
 ### `ante feed` — 데이터 피드 (DataFeed)
 
@@ -607,6 +625,11 @@ ante instrument import <filepath> [--dry-run] [--db-path <경로>]  # CSV/JSON �
 ```bash
 ante audit list [--member <member_id>] [--action <prefix>] [--from-date <날짜>] [--to-date <날짜>] [--limit N] [--offset N]
 ```
+
+`audit list`의 `--from-date`/`--to-date`가 모두 지정되고 시작 날짜
+(`--from-date`)가 종료 날짜(`--to-date`) 이후이면(inverted date range) DB 접근
+이전에 `INVALID_DATE_RANGE` 에러 코드와 exit code 1로 거부한다(빈 결과 반환
+금지). 한쪽만 지정·둘 다 미지정·동일 날짜는 정상 처리한다.
 
 ### `ante signal` — 외부 시그널 채널
 

--- a/src/ante/cli/_validators.py
+++ b/src/ante/cli/_validators.py
@@ -15,9 +15,13 @@ from __future__ import annotations
 
 import math
 import re
-from datetime import datetime
+from datetime import date, datetime
+from typing import TYPE_CHECKING
 
 import click
+
+if TYPE_CHECKING:
+    from ante.cli.formatter import OutputFormatter
 
 # Web API helper(`src/ante/web/utils/date_params.py:56`)와 동일한 strict
 # ``YYYY-MM-DD`` (zero-padded 10자) 정규식. ``datetime.strptime`` 단독은
@@ -128,4 +132,72 @@ def validate_positive_finite_amount(
     return value
 
 
-__all__ = ["validate_iso_date", "validate_positive_finite_amount"]
+def reject_inverted_date_range(
+    from_value: str | None,
+    to_value: str | None,
+    fmt: OutputFormatter,
+    *,
+    from_label: str = "시작일",
+    to_label: str = "종료일",
+) -> None:
+    """공유 date-only 헬퍼: ``from > to`` inverted range를 거부한다.
+
+    오라클 A7 finding(#1597): ``audit list``/``trade list``/
+    ``treasury snapshot``/``report performance --period daily`` 4개 read/report
+    명령이 inverted date range(시작일 > 종료일)를 non-zero가 아니라 exit 0 빈
+    결과로 처리하여 실제 데이터 부재와 구별되지 않던 ingress drift가 있었다.
+    ``backtest run``(``backtest.py:72-77``)은 이미 ``INVALID_DATE_RANGE`` +
+    ``SystemExit(1)``로 거부하고 있으며, 본 헬퍼는 그 메시지 톤·종료 코드와
+    동형으로 나머지 4곳에 일괄 적용해 drift를 닫는다.
+
+    **date-only 계약**: 4개 명령의 date 옵션은 전부 기존
+    :func:`validate_iso_date`(``_validators.py:62-78``)가 strict
+    ``YYYY-MM-DD``로 검증·정규화한 뒤 본 헬퍼에 도달한다. 따라서 본 헬퍼는
+    ``datetime.date.fromisoformat(value)`` **단일 타입**만 파싱한다
+    (mixed date/datetime ``TypeError`` 차단). 형식 검증은 본 헬퍼의 책임이
+    아니다 — invalid 형식은 ``validate_iso_date``의 ``click.BadParameter``
+    경로에서 본 헬퍼 도달 전에 이미 거부된다. 방어적으로, 어떤 경로로 형식
+    invalid가 들어오면 ``fromisoformat``이 ``ValueError``를 던지므로 그대로
+    통과시켜 기존 click 표준 경로를 보존한다(형식 검증 책임을 넘지 않는다).
+
+    동작:
+
+    - ``from_value``/``to_value`` 한쪽 또는 양쪽이 ``None`` → 통과 (옵션
+      미지정/한쪽만 지정 분기 보존).
+    - 둘 다 not ``None`` & 둘 다 ``date.fromisoformat`` 파싱 성공 &
+      ``from_date > to_date`` → ``fmt.error(code="INVALID_DATE_RANGE")`` 후
+      ``SystemExit(1)``.
+    - 그 외(파싱 실패 포함) → 통과.
+
+    Args:
+        from_value: 시작일 문자열(``YYYY-MM-DD``) 또는 ``None``.
+        to_value: 종료일 문자열(``YYYY-MM-DD``) 또는 ``None``.
+        fmt: ``get_formatter(ctx)``로 얻은 출력 포맷터. text/json 모드에 따라
+            구조화된 에러를 출력한다.
+        from_label: 에러 메시지의 시작일 라벨 (기본 ``"시작일"``).
+        to_label: 에러 메시지의 종료일 라벨 (기본 ``"종료일"``).
+
+    Raises:
+        SystemExit: inverted range일 때 exit code 1로 종료.
+    """
+    if from_value is None or to_value is None:
+        return
+    try:
+        from_date = date.fromisoformat(from_value)
+        to_date = date.fromisoformat(to_value)
+    except (ValueError, TypeError):
+        # 형식 검증은 본 헬퍼 책임 아님 — validate_iso_date의 click 경로 보존.
+        return
+    if from_date > to_date:
+        fmt.error(
+            f"{from_label}({from_value})이(가) {to_label}({to_value}) 이후입니다.",
+            code="INVALID_DATE_RANGE",
+        )
+        raise SystemExit(1)
+
+
+__all__ = [
+    "reject_inverted_date_range",
+    "validate_iso_date",
+    "validate_positive_finite_amount",
+]

--- a/src/ante/cli/commands/audit.py
+++ b/src/ante/cli/commands/audit.py
@@ -6,7 +6,7 @@ import asyncio
 
 import click
 
-from ante.cli._validators import validate_iso_date
+from ante.cli._validators import reject_inverted_date_range, validate_iso_date
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
 
@@ -51,6 +51,16 @@ def audit_list(
 ) -> None:
     """감사 로그 목록 조회."""
     fmt = get_formatter(ctx)
+
+    # inverted date range(시작일 > 종료일) 거부: DB/AuditLogger.query 진입
+    # 이전에 차단한다 (backtest.py:72-77 동형, INVALID_DATE_RANGE + exit 1).
+    reject_inverted_date_range(
+        from_date,
+        to_date,
+        fmt,
+        from_label="시작 날짜",
+        to_label="종료 날짜",
+    )
 
     async def _run_list() -> list[dict]:
         from ante.audit import AuditLogger

--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -8,7 +8,7 @@ import json
 import click
 from pydantic import ValidationError
 
-from ante.cli._validators import validate_iso_date
+from ante.cli._validators import reject_inverted_date_range, validate_iso_date
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
 from ante.report.models import ReportStatus
@@ -283,6 +283,19 @@ def report_performance(
             code="CLI_OPTION_CONFLICT",
         )
         raise SystemExit(1)
+
+    # inverted date range(시작일 > 종료일) 거부: #1593 period-exclusive 블록
+    # 직후, _run_performance/asyncio.run 이전에 차단한다 (backtest.py:72-77
+    # 동형, INVALID_DATE_RANGE + exit 1). #1593이 monthly+start/end는 이미
+    # CLI_OPTION_CONFLICT로 거부했으므로 여기 도달하는 start/end 조합은
+    # daily 경로뿐이다. #1593 순서/코드는 보존(이 블록은 after 배치).
+    reject_inverted_date_range(
+        start,
+        end,
+        fmt,
+        from_label="시작일",
+        to_label="종료일",
+    )
 
     async def _run_performance() -> list[dict]:
         from ante.cli.main import get_db_path

--- a/src/ante/cli/commands/trade.py
+++ b/src/ante/cli/commands/trade.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 import click
 
-from ante.cli._validators import validate_iso_date
+from ante.cli._validators import reject_inverted_date_range, validate_iso_date
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import require_auth, require_scope
@@ -71,6 +71,17 @@ def trade_list(
 ) -> None:
     """거래 목록 조회."""
     fmt = get_formatter(ctx)
+
+    # inverted date range(시작일 > 종료일) 거부: _create_trade_service/DB
+    # 생성 및 _run_list 내부 datetime.fromisoformat 이전에 차단한다
+    # (backtest.py:72-77 동형, INVALID_DATE_RANGE + exit 1).
+    reject_inverted_date_range(
+        from_date,
+        to_date,
+        fmt,
+        from_label="시작일",
+        to_label="종료일",
+    )
 
     async def _run_list() -> list[dict]:
         service, db = await _create_trade_service()

--- a/src/ante/cli/commands/treasury.py
+++ b/src/ante/cli/commands/treasury.py
@@ -6,7 +6,11 @@ import asyncio
 
 import click
 
-from ante.cli._validators import validate_iso_date, validate_positive_finite_amount
+from ante.cli._validators import (
+    reject_inverted_date_range,
+    validate_iso_date,
+    validate_positive_finite_amount,
+)
 from ante.cli.formatter import format_option
 from ante.cli.main import get_formatter
 from ante.cli.middleware import get_member_id as _get_member_id
@@ -209,6 +213,17 @@ def snapshot(
             code="CLI_OPTION_CONFLICT",
         )
         raise SystemExit(1)
+
+    # inverted date range(시작일 > 종료일) 거부: CLI_OPTION_CONFLICT 검증
+    # 직후, _run_snapshot/서비스 호출 이전에 차단한다 (backtest.py:72-77
+    # 동형, INVALID_DATE_RANGE + exit 1).
+    reject_inverted_date_range(
+        from_date,
+        to_date,
+        fmt,
+        from_label="시작일",
+        to_label="종료일",
+    )
 
     async def _run_snapshot() -> dict | list[dict] | None:
         t, db = await _create_treasury(account_id)

--- a/tests/unit/test_cli_inverted_date_range.py
+++ b/tests/unit/test_cli_inverted_date_range.py
@@ -1,0 +1,457 @@
+"""CLI inverted date range(시작일 > 종료일) 거부 매트릭스 (#1597).
+
+오라클 A7 finding(#1597): 4개 read/report 명령 —
+``audit list --from-date/--to-date``, ``trade list --from/--to``,
+``treasury snapshot --from/--to``, ``report performance --period daily
+--start/--end`` — 이 inverted date range를 non-zero가 아니라 exit 0 빈
+결과로 처리하던 ingress drift를 닫는다. ``backtest run``
+(``src/ante/cli/commands/backtest.py:72-77``)은 이미
+``INVALID_DATE_RANGE`` + ``SystemExit(1)``로 거부 중이며, 본 테스트는
+공유 헬퍼 ``reject_inverted_date_range``가 나머지 4곳에 동형으로 적용된
+결과를 검증한다.
+
+검증 축:
+
+- invalid-range(from > to): exit 1 + ``INVALID_DATE_RANGE``, 서비스/async
+  경로(``_run``/Database/AuditLogger.query/get_trades/treasury/
+  ``_run_performance``) **미호출** mock 단정.
+- 회귀(유효): from < to / from == to / 한쪽만 / 둘 다 미지정 → exit 0.
+- #1593 회귀: ``report performance --period monthly --start ... --end ...``
+  은 여전히 ``CLI_OPTION_CONFLICT`` (period-exclusive 먼저, INVALID_DATE_RANGE
+  아님); ``--period daily --year`` 도 ``CLI_OPTION_CONFLICT``.
+- 형식 invalid(``2026-13-32``)는 기존 click 표준 경로 보존(미변경).
+- JSON + text 두 포맷.
+
+Non-Goals: web audit/treasury sibling 위험(별도 follow-up), 4곳 date
+파싱 통합 리팩터, 신규 에러코드 신설.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ante.cli.main import cli
+from ante.member.models import Member, MemberRole, MemberType
+
+_MOCK_MASTER = Member(
+    member_id="test-master",
+    type=MemberType.HUMAN,
+    role=MemberRole.MASTER,
+    org="default",
+    name="Test Master",
+    status="active",
+    scopes=[],
+)
+
+
+def _make_runner() -> CliRunner:
+    """``mix_stderr=False`` runner. click 버전에 따라 fallback."""
+    if "mix_stderr" in inspect.signature(CliRunner).parameters:
+        return CliRunner(mix_stderr=False)
+    return CliRunner()
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    """인증된 상태의 CliRunner.
+
+    ``authenticate_member``와 ``_run_authenticate``를 모두 patch하여 실제
+    DB 접근을 방지한다 (#1404 / ``test_cli_date_validation.py`` 패턴).
+    """
+    r = _make_runner()
+    original_invoke = r.invoke
+
+    def _invoke_with_auth(cli_cmd, args=None, **kwargs):  # noqa: ANN001, ANN202
+        def _set_member(ctx):  # noqa: ANN001
+            ctx.ensure_object(dict)
+            ctx.obj["member"] = _MOCK_MASTER
+
+        with (
+            patch("ante.cli.main.authenticate_member", side_effect=_set_member),
+            patch("ante.cli.middleware._run_authenticate"),
+        ):
+            return original_invoke(cli_cmd, args, **kwargs)
+
+    r.invoke = _invoke_with_auth
+    return r
+
+
+def _stdout(result) -> str:
+    """mix_stderr 분리 환경에서 stdout만 안전하게 추출."""
+    try:
+        return result.stdout
+    except (ValueError, UnicodeDecodeError):
+        return result.output
+
+
+def _assert_invalid_date_range_json(result) -> None:
+    """JSON 포맷 inverted-range 응답 공통 검증."""
+    assert result.exit_code == 1
+    payload = json.loads(_stdout(result))
+    assert payload["status"] == "error"
+    assert payload["code"] == "INVALID_DATE_RANGE"
+
+
+# 각 명령의 invoke args (invalid range: from=2026-02-01 > to=2026-01-01).
+_INVALID_CASES = {
+    "audit": [
+        "audit",
+        "list",
+        "--from-date",
+        "2026-02-01",
+        "--to-date",
+        "2026-01-01",
+    ],
+    "trade": [
+        "trade",
+        "list",
+        "--from",
+        "2026-02-01",
+        "--to",
+        "2026-01-01",
+    ],
+    "treasury": [
+        "treasury",
+        "snapshot",
+        "--from",
+        "2026-02-01",
+        "--to",
+        "2026-01-01",
+        "--account",
+        "oracle-paper",
+    ],
+    "report": [
+        "report",
+        "performance",
+        "--period",
+        "daily",
+        "--start",
+        "2026-02-01",
+        "--end",
+        "2026-01-01",
+    ],
+}
+
+# 각 명령의 async/service 진입점 — invalid-range 시 호출되면 안 됨.
+_ASYNC_ENTRYPOINTS = {
+    "audit": "ante.cli.commands.audit._run",
+    "trade": "ante.cli.commands.trade._run",
+    "treasury": "ante.cli.commands.treasury._run",
+    "report": "ante.cli.commands.report.asyncio.run",
+}
+
+
+class TestInvertedRangeRejectedJson:
+    """invalid range(from > to) → exit 1 + INVALID_DATE_RANGE (JSON)."""
+
+    @pytest.mark.parametrize("cmd", list(_INVALID_CASES))
+    def test_rejected_json(self, runner, cmd):
+        with patch(_ASYNC_ENTRYPOINTS[cmd]) as mock_async:
+            result = runner.invoke(cli, ["--format", "json", *_INVALID_CASES[cmd]])
+        _assert_invalid_date_range_json(result)
+        mock_async.assert_not_called()
+
+    @pytest.mark.parametrize("cmd", list(_INVALID_CASES))
+    def test_rejected_text(self, runner, cmd):
+        with patch(_ASYNC_ENTRYPOINTS[cmd]) as mock_async:
+            result = runner.invoke(cli, _INVALID_CASES[cmd])
+        assert result.exit_code == 1
+        mock_async.assert_not_called()
+
+
+class TestInvertedRangeNoServiceTouch:
+    """invalid range 시 Database/service 레이어 자체에 도달하지 않는다."""
+
+    def test_audit_no_db_no_logger(self, runner):
+        with (
+            patch("ante.cli.commands.audit._run") as mock_run,
+            patch("ante.core.database.Database") as mock_db,
+            patch("ante.audit.AuditLogger") as mock_logger,
+        ):
+            result = runner.invoke(cli, ["--format", "json", *_INVALID_CASES["audit"]])
+        _assert_invalid_date_range_json(result)
+        mock_run.assert_not_called()
+        mock_db.assert_not_called()
+        mock_logger.assert_not_called()
+
+    def test_trade_no_service_no_db(self, runner):
+        with (
+            patch("ante.cli.commands.trade._run") as mock_run,
+            patch("ante.cli.commands.trade._create_trade_service") as mock_svc,
+            patch("ante.core.database.Database") as mock_db,
+        ):
+            result = runner.invoke(cli, ["--format", "json", *_INVALID_CASES["trade"]])
+        _assert_invalid_date_range_json(result)
+        mock_run.assert_not_called()
+        mock_svc.assert_not_called()
+        mock_db.assert_not_called()
+
+    def test_treasury_no_service_no_db(self, runner):
+        with (
+            patch("ante.cli.commands.treasury._run") as mock_run,
+            patch("ante.cli.commands.treasury._create_treasury") as mock_svc,
+            patch("ante.core.database.Database") as mock_db,
+        ):
+            result = runner.invoke(
+                cli, ["--format", "json", *_INVALID_CASES["treasury"]]
+            )
+        _assert_invalid_date_range_json(result)
+        mock_run.assert_not_called()
+        mock_svc.assert_not_called()
+        mock_db.assert_not_called()
+
+    def test_report_no_run_performance_no_db(self, runner):
+        with (
+            patch("ante.cli.commands.report.asyncio.run") as mock_run,
+            patch("ante.core.database.Database") as mock_db,
+        ):
+            result = runner.invoke(cli, ["--format", "json", *_INVALID_CASES["report"]])
+        _assert_invalid_date_range_json(result)
+        mock_run.assert_not_called()
+        mock_db.assert_not_called()
+
+
+class TestValidRangeRegression:
+    """유효 조합은 회귀 없이 통과(서비스 진입 도달 — exit 0)."""
+
+    @pytest.mark.parametrize(
+        ("cmd", "args"),
+        [
+            (
+                "audit",
+                [
+                    "audit",
+                    "list",
+                    "--from-date",
+                    "2026-01-01",
+                    "--to-date",
+                    "2026-02-01",
+                ],
+            ),
+            (
+                "audit",
+                [
+                    "audit",
+                    "list",
+                    "--from-date",
+                    "2026-01-15",
+                    "--to-date",
+                    "2026-01-15",
+                ],
+            ),
+            (
+                "audit",
+                ["audit", "list", "--from-date", "2026-01-01"],
+            ),
+            (
+                "audit",
+                ["audit", "list", "--to-date", "2026-02-01"],
+            ),
+            (
+                "audit",
+                ["audit", "list"],
+            ),
+            (
+                "trade",
+                ["trade", "list", "--from", "2026-01-01", "--to", "2026-02-01"],
+            ),
+            (
+                "trade",
+                ["trade", "list", "--from", "2026-01-15", "--to", "2026-01-15"],
+            ),
+            (
+                "trade",
+                ["trade", "list", "--from", "2026-01-01"],
+            ),
+            (
+                "trade",
+                ["trade", "list"],
+            ),
+            (
+                "report",
+                [
+                    "report",
+                    "performance",
+                    "--period",
+                    "daily",
+                    "--start",
+                    "2026-01-01",
+                    "--end",
+                    "2026-02-01",
+                ],
+            ),
+            (
+                "report",
+                [
+                    "report",
+                    "performance",
+                    "--period",
+                    "daily",
+                    "--start",
+                    "2026-01-15",
+                    "--end",
+                    "2026-01-15",
+                ],
+            ),
+            (
+                "report",
+                ["report", "performance", "--period", "daily", "--start", "2026-01-01"],
+            ),
+            (
+                "report",
+                ["report", "performance"],
+            ),
+        ],
+    )
+    def test_valid_passes_to_service(self, runner, cmd, args):
+        with patch(_ASYNC_ENTRYPOINTS[cmd]) as mock_async:
+            mock_async.return_value = []
+            result = runner.invoke(cli, args)
+        assert result.exit_code == 0, _stdout(result)
+        mock_async.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            [
+                "treasury",
+                "snapshot",
+                "--from",
+                "2026-01-01",
+                "--to",
+                "2026-02-01",
+                "--account",
+                "oracle-paper",
+            ],
+            [
+                "treasury",
+                "snapshot",
+                "--from",
+                "2026-01-15",
+                "--to",
+                "2026-01-15",
+                "--account",
+                "oracle-paper",
+            ],
+            [
+                "treasury",
+                "snapshot",
+                "--from",
+                "2026-01-01",
+                "--account",
+                "oracle-paper",
+            ],
+            ["treasury", "snapshot", "--account", "oracle-paper"],
+        ],
+    )
+    def test_treasury_valid_passes_to_service(self, runner, args):
+        with patch("ante.cli.commands.treasury._run") as mock_run:
+            mock_run.return_value = {
+                "account_id": "oracle-paper",
+                "snapshot_date": "2026-01-15",
+                "total_asset": 1.0,
+                "ante_eval_amount": 1.0,
+                "ante_purchase_amount": 1.0,
+                "unallocated": 0.0,
+            }
+            result = runner.invoke(cli, ["--format", "json", *args])
+        assert result.exit_code == 0, _stdout(result)
+        mock_run.assert_called_once()
+
+
+class TestRegression1593Preserved:
+    """#1593 period-exclusive 우선순위/코드 보존(순서 엄수)."""
+
+    def test_monthly_with_start_end_still_conflict(self, runner):
+        """monthly + start/end → 여전히 CLI_OPTION_CONFLICT (INVALID_DATE_RANGE 아님).
+
+        inverted(start>end)여도 period-exclusive 검증이 먼저이므로
+        CLI_OPTION_CONFLICT로 거부되어야 한다.
+        """
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "performance",
+                    "--period",
+                    "monthly",
+                    "--start",
+                    "2026-02-01",
+                    "--end",
+                    "2026-01-01",
+                ],
+            )
+        assert result.exit_code == 1
+        payload = json.loads(_stdout(result))
+        assert payload["code"] == "CLI_OPTION_CONFLICT"
+        assert payload["code"] != "INVALID_DATE_RANGE"
+        mock_run.assert_not_called()
+
+    def test_daily_with_year_still_conflict(self, runner):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "performance",
+                    "--period",
+                    "daily",
+                    "--year",
+                    "2026",
+                ],
+            )
+        assert result.exit_code == 1
+        payload = json.loads(_stdout(result))
+        assert payload["code"] == "CLI_OPTION_CONFLICT"
+        mock_run.assert_not_called()
+
+
+class TestFormatInvalidPathPreserved:
+    """형식 invalid는 기존 click.BadParameter/UsageError 경로 보존(미변경)."""
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["audit", "list", "--from-date", "2026-13-32", "--to-date", "2026-01-01"],
+            ["trade", "list", "--from", "2026-13-32", "--to", "2026-01-01"],
+            [
+                "treasury",
+                "snapshot",
+                "--from",
+                "2026-13-32",
+                "--to",
+                "2026-01-01",
+                "--account",
+                "oracle-paper",
+            ],
+            [
+                "report",
+                "performance",
+                "--period",
+                "daily",
+                "--start",
+                "2026-13-32",
+                "--end",
+                "2026-01-01",
+            ],
+        ],
+    )
+    def test_format_invalid_not_invalid_date_range(self, runner, args):
+        """형식 오류는 click 표준 경로 — INVALID_DATE_RANGE가 아니다.
+
+        click ``BadParameter``는 exit 2 + text stderr이며, 본 헬퍼는
+        ``validate_iso_date`` 거부 이후 도달하지 않는다.
+        """
+        result = runner.invoke(cli, args)
+        assert result.exit_code != 0
+        assert "INVALID_DATE_RANGE" not in result.output


### PR DESCRIPTION
Closes #1597

## Summary
- audit list / trade list / treasury snapshot / report performance(--period daily) 4개 CLI 명령이 inverted date range(start>end)를 non-zero 아닌 exit 0 빈 결과로 처리하던 oracle A7 버그 수정 (backtest CLI는 이미 INVALID_DATE_RANGE 거부)
- `src/ante/cli/_validators.py`에 공유 `reject_inverted_date_range` date-only 헬퍼 추가 (validate_iso_date가 이미 YYYY-MM-DD 보장 → date.fromisoformat 단일타입, mixed TypeError 차단). 4 명령 handler entry(서비스/DB 진입 전)에 호출 (grep invariant 4곳)
- report는 #1593 period-exclusive 블록 **직후** daily 경로만 검증 — monthly+start/end는 #1593 CLI_OPTION_CONFLICT 우선 보존
- spec 형식화: `docs/specs/cli/02-design-decisions.md` 에러코드 SSOT 표에 `INVALID_DATE_RANGE` 행 + legacy/common 명명 예외 명시(backtest 호환), `03-commands.md` 4 명령 계약 명시
- web audit/treasury 동일 위험은 별도 API follow-up (Non-Goal); feed backfill inverted timeout도 별도(실행형 path)

## Test Plan
- `pytest tests/unit/test_cli_inverted_date_range.py -q` → 35 passed (invalid 4종 서비스/DB 미호출 mock assert + 유효 회귀 + #1593 monthly/daily CLI_OPTION_CONFLICT 회귀 + 형식 invalid click 경로 보존 + JSON/text)
- #1593+CLI date 회귀 묶음 181 passed, 추가 CLI 회귀 58 passed
- ruff check/format/mypy 통과, grep invariant 4곳 + 스펙 2종 INVALID_DATE_RANGE 반영
- Codex Plan Review: approve-implement (rev2, session 019e2e5d) / Codex 브랜치 리뷰: PASS attempt1

🤖 Generated with [Claude Code](https://claude.com/claude-code)