### PR TITLE
fix(cli): reject non-positive year in monthly report performance (#1599)

### DIFF
--- a/docs/specs/cli/02-design-decisions.md
+++ b/docs/specs/cli/02-design-decisions.md
@@ -114,6 +114,7 @@ JSON 모드(`--format json`)에서는 `{status: "error", code: "...", message: "
 | `STRATEGY_VALIDATION_ERROR` | strategy 명령 인자(예: `--status`) 값이 SSOT enum에 없음 | `strategy list` |
 | `UPDATE_SERVER_RUNNING` | `ante update --force` 없이 서버가 실행 중 | `update` |
 | `APPROVAL_VALIDATION_ERROR` | `approval request --type` 값이 SSOT enum에 없음 | `approval request` |
+| `REPORT_VALIDATION_ERROR` | report 명령 입력 계약 위반 (제출 리포트 JSON/스키마 위반, `report performance --period monthly --year` 가 비양수 calendar year) | `report submit`, `report performance` |
 
 `--broker-config`는 1.0 범위에서 free-form pass-through(아래 silent ignore trade-off
 참조)이므로 본 이슈에서는 `UNKNOWN_BROKER_CONFIG_KEY`를 정의하지 않는다.

--- a/docs/specs/cli/03-commands.md
+++ b/docs/specs/cli/03-commands.md
@@ -455,6 +455,14 @@ ante report performance [--period daily|monthly] [--bot-id <봇ID>] [--start <�
 `--period monthly --start ... --end ...`는 여전히 `CLI_OPTION_CONFLICT`로
 거부되며 `INVALID_DATE_RANGE`에 도달하지 않는다.
 
+또한 `--year`는 `--period monthly` 전용의 양수(>0) calendar year다.
+`--period monthly --year`에 `0` 또는 음수가 지정되면, 위 period-exclusive
+검증 직후·DB 접근 이전에 `REPORT_VALIDATION_ERROR` 에러 코드와 exit code 1로
+거부한다(빈 집계 반환 금지). 상한·미래연도는 검증하지 않는다(양수 여부만 검증).
+검증 순서는 period-exclusive(`CLI_OPTION_CONFLICT`)가 먼저이므로
+`--period daily --year 0`/`--year -1`은 여전히 `CLI_OPTION_CONFLICT`로 거부되며
+(`--year`는 monthly 전용) `REPORT_VALIDATION_ERROR`에 도달하지 않는다.
+
 ### `ante feed` — 데이터 피드 (DataFeed)
 
 CLI 정의는 `src/ante/feed/cli.py`에 있으며 `ante.cli.main`에서 서브커맨드로 등록된다.

--- a/src/ante/cli/commands/report.py
+++ b/src/ante/cli/commands/report.py
@@ -284,6 +284,21 @@ def report_performance(
         )
         raise SystemExit(1)
 
+    # monthly --year 비양수 거부 (#1599 oracle A7): #1593 period-exclusive
+    # 블록 직후, _run_performance/asyncio.run 이전에 차단한다. 캘린더 연도는
+    # 양수(>0)만 유효하므로 0/음수는 거부한다. daily+year는 위 #1593
+    # CLI_OPTION_CONFLICT가 먼저 잡으므로(이 블록은 그 after 배치) 여기 도달
+    # 하는 year는 monthly 경로뿐이며 daily+year<=0도 CLI_OPTION_CONFLICT다.
+    # 에러코드는 report 도메인의 기존 REPORT_VALIDATION_ERROR를 재사용한다
+    # (report submit 검증 report.py:66/77/107과 동일 코드). 상한/미래연도
+    # 검증은 범위 밖(>0만 검증).
+    if period == "monthly" and year is not None and year <= 0:
+        fmt.error(
+            "monthly --year는 양수 calendar year여야 합니다. (0 이하 거부)",
+            code="REPORT_VALIDATION_ERROR",
+        )
+        raise SystemExit(1)
+
     # inverted date range(시작일 > 종료일) 거부: #1593 period-exclusive 블록
     # 직후, _run_performance/asyncio.run 이전에 차단한다 (backtest.py:72-77
     # 동형, INVALID_DATE_RANGE + exit 1). #1593이 monthly+start/end는 이미

--- a/tests/unit/test_cli_report_performance_period_options.py
+++ b/tests/unit/test_cli_report_performance_period_options.py
@@ -56,6 +56,14 @@ def _assert_conflict_json(result) -> None:
     assert payload["code"] == "CLI_OPTION_CONFLICT"
 
 
+def _assert_report_validation_json(result) -> None:
+    """JSON 포맷 REPORT_VALIDATION_ERROR 응답 공통 검증 (#1599)."""
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["status"] == "error"
+    assert payload["code"] == "REPORT_VALIDATION_ERROR"
+
+
 class TestPeriodOptionConflictRejected:
     """period와 맞지 않는 옵션 조합은 exit 1 + CLI_OPTION_CONFLICT."""
 
@@ -213,6 +221,101 @@ class TestPeriodOptionConflictRejected:
         assert result.exit_code == 1
         assert "--year" in result.output
         mock_run.assert_not_called()
+
+    @pytest.mark.parametrize("bad_year", ["0", "-1"])
+    def test_daily_non_positive_year_still_conflict(self, runner, bad_year):
+        """#1593 경계 회귀: daily+year<=0은 monthly year<=0 검증보다
+        먼저 period-exclusive로 잡혀 CLI_OPTION_CONFLICT여야 한다
+        (REPORT_VALIDATION_ERROR 아님 — #1599가 #1593 관할을 침범 금지)."""
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "performance",
+                    "--period",
+                    "daily",
+                    "--year",
+                    bad_year,
+                ],
+            )
+        _assert_conflict_json(result)
+        assert "--year" in result.output
+        mock_run.assert_not_called()
+
+
+class TestMonthlyNonPositiveYearRejected:
+    """monthly --year<=0은 exit 1 + REPORT_VALIDATION_ERROR (#1599 oracle A7).
+
+    이전: invalid calendar year(`-1`/`0`)가 거부되지 않고 exit 0 빈 월간
+    집계로 처리됨. monthly --year는 양수(>0) calendar year만 허용한다.
+    """
+
+    @pytest.mark.parametrize("bad_year", ["-1", "0"])
+    def test_monthly_non_positive_year_json(self, runner, bad_year):
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "performance",
+                    "--period",
+                    "monthly",
+                    "--year",
+                    bad_year,
+                ],
+            )
+        _assert_report_validation_json(result)
+        payload = json.loads(result.output)
+        assert "양수" in payload["message"]
+        mock_run.assert_not_called()
+
+    @pytest.mark.parametrize("bad_year", ["-1", "0"])
+    def test_monthly_non_positive_year_text_format(self, runner, bad_year):
+        """text 포맷에서도 exit 1 + 메시지로 거부된다."""
+        with patch("ante.cli.commands.report.asyncio.run") as mock_run:
+            result = runner.invoke(
+                cli,
+                [
+                    "report",
+                    "performance",
+                    "--period",
+                    "monthly",
+                    "--year",
+                    bad_year,
+                ],
+            )
+        assert result.exit_code == 1
+        assert "양수" in result.output
+        mock_run.assert_not_called()
+
+    def test_monthly_non_positive_year_does_not_touch_db(self, runner):
+        """invalid year 검증이 _run_performance(Database/asyncio.run)
+        이전임을 고정한다."""
+        with (
+            patch("ante.cli.commands.report.asyncio.run") as mock_run,
+            patch("ante.core.database.Database") as mock_db,
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "report",
+                    "performance",
+                    "--period",
+                    "monthly",
+                    "--year",
+                    "-1",
+                ],
+            )
+        assert result.exit_code == 1
+        mock_run.assert_not_called()
+        mock_db.assert_not_called()
 
 
 class TestValidPeriodOptionCombosRegression:


### PR DESCRIPTION
Closes #1599

## Summary
- `ante report performance --period monthly --year -1/0`이 invalid calendar year를 거부하지 않고 exit 0 빈 월간 집계로 처리하던 oracle A7 버그 수정
- `report_performance` #1593 period-exclusive 블록 **직후**(`_run_performance` 이전) inline 검증 추가: `period == "monthly" and year is not None and year <= 0` → `REPORT_VALIDATION_ERROR` + exit 1 (report 도메인 기존 코드 재사용, 신규 CLI_* 미신설)
- #1593 순서 보존: `daily + year`(0/-1 포함)는 여전히 `CLI_OPTION_CONFLICT`(period-exclusive 먼저), `monthly + year<=0`만 신규 `REPORT_VALIDATION_ERROR`
- spec 형식화: `02-design-decisions.md` 에러코드 SSOT 표에 `REPORT_VALIDATION_ERROR` 행(발생 명령 report submit·report performance), `03-commands.md` `--year`>0 계약 명시. service/web 미수정(web monthly는 year 미수신)

## Test Plan
- `pytest tests/unit/test_cli_report_performance_period_options.py -q` → 20 passed (monthly year -1/0 → REPORT_VALIDATION_ERROR exit1 JSON/text + DB 미호출 mock + 유효 year 회귀 + daily year<=0 여전히 CLI_OPTION_CONFLICT 경계 회귀 + #1593 회귀)
- 인접 회귀 `test_report.py test_performance_summary.py` → 34 passed
- ruff check/format/mypy 통과, grep invariant REPORT_VALIDATION_ERROR 스펙 2파일
- Codex Plan Review: approve-implement (rev3, session 019e2e71) / Codex 브랜치 리뷰: PASS attempt1

🤖 Generated with [Claude Code](https://claude.com/claude-code)