### PR TITLE
docs(core): symbol/timeframe canonical vocabulary 계약 SSOT 신설 (#1612)

### DIFF
--- a/docs/decisions/D-017-canonical-symbol-timeframe-vocabulary.md
+++ b/docs/decisions/D-017-canonical-symbol-timeframe-vocabulary.md
@@ -1,0 +1,98 @@
+# D-017: canonical symbol/timeframe vocabulary (2026-05-16)
+
+> Ante 설계 결정 기록.
+> 인덱스: [README.md](README.md)
+
+**결정**: Ante 전역에서 OHLCV bar `timeframe`과 신규 입력 `symbol`이 의미하는
+canonical vocabulary와 적용 범위를 **단일 계약(SSOT)으로 확정**한다. 계약 본문
+(canonical timeframe set·고정 순서, KRX symbol shape, symbol/timeframe 축 구분
+A~F, per-surface 허용/거부·에러 계약 매트릭스, legacy 호환 정책, 소비자 매핑)은
+[docs/specs/core/core.md](../specs/core/core.md#canonical-symboltimeframe-vocabulary)
+`## Canonical Symbol/Timeframe Vocabulary` 절에 둔다. 본 ADR은 결정·근거·소비자
+영향만 기록하고 계약 디테일을 중복 기재하지 않는다.
+
+핵심 (결정 요약 — 계약 본문은 core.md `## Canonical Symbol/Timeframe Vocabulary`):
+
+- canonical OHLCV bar timeframe set `[1m, 5m, 15m, 1h, 1d]`(고정 순서·exact-literal·
+  no-alias·no-normalization), KRX symbol shape(`^[0-9]{6}$`), symbol/timeframe 축
+  구분(A OHLCV bar timeframe / B subminute 파티셔닝 / C `tick`·`fundamental`
+  data_type / D write-ownership / E 신규 입력 vs legacy path 판별 / F fundamental
+  cadence), per-surface 거부 계약·legacy 호환을 **단일 계약으로 확정**하고, 그 본문은
+  D-017이 아니라
+  [core.md `## Canonical Symbol/Timeframe Vocabulary`](../specs/core/core.md#canonical-symboltimeframe-vocabulary)
+  절에 둔다. 본 ADR은 계약 디테일(값 집합·축 정의·거부 경계·표면별 계약)을 독립
+  서술하지 않으며, 모든 디테일은 해당 절을 단일 참조점으로 가리킨다.
+- 검증 범위의 결정: 검증은 **신규 입력 경계에만** 적용하고, 기존 영속 데이터의
+  `read` 호환은 깨지 않는다(legacy 무손상 — 자동 삭제·마이그레이션 없음).
+  legacy parquet path migration 판별(`store.py` `\d` 보존)은 신규 입력 strict
+  검증과 별개 축이다(축 E). `read`가 어떻게 규율되는지의 계약 본문은 core.md의
+  "Legacy out-of-vocabulary 호환 정책" 절이 SSOT다.
+
+**근거**:
+
+- symbol/timeframe vocabulary SSOT 후보(#1602)의 Plan Preflight가 `split-issue`로
+  보류되며, 작업이 `#1612 docs-only 계약` / `#1613 코드 SSOT` / 표면별
+  enforcement(#1603~#1611)로 분리됐다. 최신 스펙 확인 결과 OHLCV timeframe·KRX
+  symbol vocabulary의 SSOT가 부재했고 normative 서술이 여러 스펙에 분산되어 있었다:
+  - `docs/specs/web-api/05-resource-endpoints.md:77` — 인라인 `SSOT:
+    ante.data.schemas.TIMEFRAMES` 선언.
+  - `docs/specs/data-pipeline/03-design-decisions.md:66` — `TIMEFRAMES: list[str]`
+    (소스: `src/ante/data/schemas.py`).
+  - `docs/specs/data-pipeline/02-write-ownership.md` — write-ownership 표(축 D).
+  - `docs/specs/data-feed/04-schema.md:37` — `10s/30s` subminute 파티셔닝(축 B).
+  - `docs/specs/strategy/03-01-strategy-interface.md:19` — `timeframe` 기본값 서술
+    `1m, 5m, 15m, 1h, 1d 등`.
+- SSOT가 없으면 표면마다 invalid timeframe/symbol 누락을 사후에 반복 발견한다.
+  계약을 먼저 스펙에 확정해야 enforcement·회귀 고정이 한 기준으로 수렴한다.
+  exchange 선례(에픽 #1561 → D-016 docs-only 결정으로 core.md `## Canonical
+  Exchange Vocabulary` + ADR + 영향 스펙 단일 참조 pointer, commit 2562168 →
+  코드 SSOT #1576 → 표면별 enforcement)와 동일 순서를 따라 먼저 docs-only 계약을
+  확정한다.
+- 계약 본문 위치를 `docs/specs/core/core.md`로 정한 이유: OHLCV bar timeframe·KRX
+  symbol은 특정 모듈 소유 개념이 아니라 data/web-api/cli/strategy/backtest가
+  공유하는 식별 차원이며, core 모듈 개요가 "모든 모듈이 공유하는 기반 인프라"로
+  정의되어 있다. D-017을 normative SSOT로 두면 ADR이 계약 본문을 머금게 되어 결정
+  기록의 역할을 벗어나므로, ADR은 core.md 절을 링크하는 결정 기록으로 유지한다.
+- timeframe을 **다축(A~F)으로 명문화한 이유**: 같은 `1m`/`1d`/`10s` 리터럴이라도
+  OHLCV bar vocabulary(축 A)·subminute 파티셔닝(축 B)·write-ownership(축 D)·신규
+  입력 vs legacy path(축 E)에 따라 규율 SSOT가 다르다. core.md 축 구분 절을 D-016
+  "exchange vs market vs source vs broker_type" 동형으로 두어 값을 섞지 않는 경계를
+  고정한다.
+- live DataCollector ingress enforcement를 **#1614로 분리한 이유**: `collector.py`
+  는 현재 `data_type='ohlcv'` append만 수행하며 vocabulary enforcement가 미구현인
+  누락 소비자다. 본 docs-only 계약은 매트릭스에 #1614 참조(OHLCV `{1m,5m,15m,1h}`만,
+  `1d`는 write-ownership상 DataFeed 소유라 제외, `tick`은 별도 data_type라 제외)로
+  경계를 명시하고, ingress enforcement 자체는 #1614(Depends on #1613)에 위임한다.
+- fundamental cadence(`quarterly`/`annual`)를 **본 계약에서 제외하고 후보 D로
+  deferral한 이유**: `quarterly`/`annual`이 `dataset.timeframe` 필드에 overload되어
+  있고(dashboard user-stories/mockups, fundamental parquet `quarterly.parquet`/
+  `annual.parquet`), #1594 datasets API는 OHLCV vocabulary 외 값을 400 거부한다.
+  이 cross-surface 불일치는 #1612가 만든 것이 아닌 기존 문제다. 본 canonical
+  OHLCV-timeframe 계약은 `quarterly`/`annual`을 포함하지 않으며, 축 F를 "별개 축,
+  필드 의미 정리는 후보 D" 까지만 명문화한다. 후보 D 이슈는 plan-preflight 계약상
+  자동 생성하지 않고(사람 등록 surface) 경계만 명시·deferral한다.
+- 기존 분산 SSOT를 core.md 단일 계약으로 수렴시킨 이유: 인라인 SSOT 표기·분산된
+  normative 서술이 여러 스펙에 흩어져 있으면 drift가 누적된다. core.md 절을 단일
+  참조점으로 두고 영향 스펙은 pointer-line으로 가리키게 하여 SSOT 위치를 단일화한다
+  (값 집합 자체는 재작성하지 않음 — 위치 단일화·축 명문화만).
+
+**소비자 영향 및 후속 이슈**:
+
+| 소비자 / 작업 | 영향 | 후속 이슈 |
+|---------------|------|-----------|
+| 코드 레벨 SSOT(`ante.core.market_data_vocab` 신설, `TIMEFRAMES`/KRX regex 소비자 위임) | 표면별 상수·regex 산재를 단일 SSOT로 정렬 | #1613 |
+| `DEFAULT_RETENTION` timeframe dict keys (보존 정책 dict 키) | 보존 정책 dict 키도 코드 SSOT 정렬 대상 (보존 기간 값은 retention 정책 고유) | #1613 |
+| Backtest run CLI timeframe enforcement | non-canonical 신규 입력 → non-zero exit + 구조화 error payload | #1603 |
+| Backtest programmatic API timeframe enforcement | non-canonical → 검증 에러 | #1604 |
+| `data validate` CLI timeframe enforcement | non-canonical → non-zero exit + 구조화 error payload | #1605 |
+| `feed inject` timeframe enforcement | non-canonical → 거부 | #1606 |
+| Instrument import KRX symbol shape enforcement | non-`^[0-9]{6}$` → non-zero exit + 구조화 error payload | #1611 |
+| Data API `timeframe` filter (기구현 400) + 잔여 symbol filter | vocabulary 외 timeframe 400 거부 기구현, 잔여 symbol filter 정렬 | #1594 |
+| **Live DataCollector write·경로 생성** (OHLCV `{1m,5m,15m,1h}`만, `1d`·`tick` 제외) | 누락 소비자 ingress enforcement 추적 폐쇄 | **#1614** (Depends on #1613) |
+| fundamental cadence `dataset.timeframe` overload reconciliation (축 F) | dashboard user-stories/mockups ↔ #1594 datasets API OHLCV-only 400 cross-surface 불일치 docs 정합화 | **후보 D** (deferral, 사람 등록) |
+
+본 ADR과 영향 스펙(web-api/data-pipeline/data-feed/strategy)은 core.md
+`## Canonical Symbol/Timeframe Vocabulary` 절을 단일 참조점으로 가리킨다. 영향
+스펙의 normative 값 집합은 본 결정에서 재작성하지 않으며(값 `{1m,5m,15m,1h,1d}`·
+보존 기간 수치·축 정의 불변), 코드 레벨 SSOT·표면별 enforcement·후보 D는 위
+후속 이슈에서 수행한다(docs-only 결정).

--- a/docs/decisions/D-017-canonical-symbol-timeframe-vocabulary.md
+++ b/docs/decisions/D-017-canonical-symbol-timeframe-vocabulary.md
@@ -87,7 +87,8 @@ A~F, per-surface 허용/거부·에러 계약 매트릭스, legacy 호환 정책
 | `data validate` CLI timeframe enforcement | non-canonical → non-zero exit + 구조화 error payload | #1605 |
 | `feed inject` timeframe enforcement | non-canonical → 거부 | #1606 |
 | Instrument import KRX symbol shape enforcement | non-`^[0-9]{6}$` → non-zero exit + 구조화 error payload | #1611 |
-| Data API `timeframe` filter (기구현 400) + 잔여 symbol filter | vocabulary 외 timeframe 400 거부 기구현, 잔여 symbol filter 정렬 | #1594 |
+| Data API `timeframe` filter (기구현 400) | vocabulary 외 timeframe 400 거부 기구현 | #1594 |
+| Data API `symbol` filter 잔여 vocabulary 거부 (현재 200 empty 유지) | invalid `symbol`은 현재 200 empty (web-api/05 계약과 정합, **#1594 아님**) — exchange-aware symbol SSOT 후속 정렬 | **#1613 코드 SSOT 체인** |
 | **Live DataCollector write·경로 생성** (OHLCV `{1m,5m,15m,1h}`만, `1d`·`tick` 제외) | 누락 소비자 ingress enforcement 추적 폐쇄 | **#1614** (Depends on #1613) |
 | fundamental cadence `dataset.timeframe` overload reconciliation (축 F) | dashboard user-stories/mockups ↔ #1594 datasets API OHLCV-only 400 cross-surface 불일치 docs 정합화 | **후보 D** (deferral, 사람 등록) |
 

--- a/docs/decisions/D-017-canonical-symbol-timeframe-vocabulary.md
+++ b/docs/decisions/D-017-canonical-symbol-timeframe-vocabulary.md
@@ -92,7 +92,7 @@ A~F, per-surface 허용/거부·에러 계약 매트릭스, legacy 호환 정책
 | legacy parquet path migration KRX 판별 (축 E legacy — 신규 입력 검증과 별개 축) | `store.py` `_KRX_SYMBOL_PATTERN`/`migrate_parquet_paths` legacy 호환 무손상 보존 | **#1611 enforcement 대상 아님** (축 E legacy) |
 | RuleEngine OrderRequestEvent KRX numeric preflight | `rule/engine.py` `_KRX_NUMERIC_SYMBOL_PATTERN` #1299 기존 동작 — 본 SSOT 도입으로 동작 불변 | **#1299** (불변, #1611 아님) |
 | Data API `timeframe` filter (기구현 400) | vocabulary 외 timeframe 400 거부 기구현 | #1594 |
-| Data API `symbol` filter 잔여 vocabulary 거부 (현재 200 empty 유지) | invalid `symbol`은 현재 200 empty (web-api/05 계약과 정합, **#1594 아님**) — exchange-aware symbol SSOT 후속 정렬 | **#1613 코드 SSOT 체인** |
+| Data API `symbol` filter (exact-match·미거부) | datasets API는 `symbol`을 별도 vocabulary 거부하지 않고 exact-match 필터로만 처리 — 미매칭 200 empty, legacy out-of-vocab symbol dir 저장 시 그 dataset 반환 (web-api/05 계약·Legacy 호환 정책과 정합, **#1594 아님**) — exchange-aware symbol SSOT 후속 정렬 | **#1613 코드 SSOT 체인** |
 | **Live DataCollector write·경로 생성** (OHLCV `{1m,5m,15m,1h}`만, `1d`·`tick` 제외) | 누락 소비자 ingress enforcement 추적 폐쇄 | **#1614** (Depends on #1613) |
 | fundamental cadence `dataset.timeframe` overload reconciliation (축 F) | dashboard user-stories/mockups ↔ #1594 datasets API OHLCV-only 400 cross-surface 불일치 docs 정합화 | **후보 D** (deferral, 사람 등록) |
 

--- a/docs/decisions/D-017-canonical-symbol-timeframe-vocabulary.md
+++ b/docs/decisions/D-017-canonical-symbol-timeframe-vocabulary.md
@@ -14,7 +14,9 @@ A~F, per-surface 허용/거부·에러 계약 매트릭스, legacy 호환 정책
 핵심 (결정 요약 — 계약 본문은 core.md `## Canonical Symbol/Timeframe Vocabulary`):
 
 - canonical OHLCV bar timeframe set `[1m, 5m, 15m, 1h, 1d]`(고정 순서·exact-literal·
-  no-alias·no-normalization), KRX symbol shape(`^[0-9]{6}$`), symbol/timeframe 축
+  no-alias·no-normalization), KRX symbol shape(`^[0-9]{6}$`, **resolved exchange ==
+  KRX인 신규 입력 경계 한정** — 비-KRX exchange symbol format은 본 SSOT 무제약·1.0
+  비목표; exchange vocabulary 자체는 D-016 규율), symbol/timeframe 축
   구분(A OHLCV bar timeframe / B subminute 파티셔닝 / C `tick`·`fundamental`
   data_type / D write-ownership / E 신규 입력 vs legacy path 판별 / F fundamental
   cadence), per-surface 거부 계약·legacy 호환을 **단일 계약으로 확정**하고, 그 본문은
@@ -86,7 +88,9 @@ A~F, per-surface 허용/거부·에러 계약 매트릭스, legacy 호환 정책
 | Backtest programmatic API timeframe enforcement | non-canonical → 검증 에러 | #1604 |
 | `data validate` CLI timeframe enforcement | non-canonical → non-zero exit + 구조화 error payload | #1605 |
 | `feed inject` timeframe enforcement | non-canonical → 거부 | #1606 |
-| Instrument import KRX symbol shape enforcement | non-`^[0-9]{6}$` → non-zero exit + 구조화 error payload | #1611 |
+| Instrument import KRX symbol shape enforcement (primary — `cli/commands/instrument.py` import handler, 현재 exchange만 검증) | exchange=KRX 행 non-`^[0-9]{6}$` → non-zero exit + 구조화 error payload | #1611 |
+| legacy parquet path migration KRX 판별 (축 E legacy — 신규 입력 검증과 별개 축) | `store.py` `_KRX_SYMBOL_PATTERN`/`migrate_parquet_paths` legacy 호환 무손상 보존 | **#1611 enforcement 대상 아님** (축 E legacy) |
+| RuleEngine OrderRequestEvent KRX numeric preflight | `rule/engine.py` `_KRX_NUMERIC_SYMBOL_PATTERN` #1299 기존 동작 — 본 SSOT 도입으로 동작 불변 | **#1299** (불변, #1611 아님) |
 | Data API `timeframe` filter (기구현 400) | vocabulary 외 timeframe 400 거부 기구현 | #1594 |
 | Data API `symbol` filter 잔여 vocabulary 거부 (현재 200 empty 유지) | invalid `symbol`은 현재 200 empty (web-api/05 계약과 정합, **#1594 아님**) — exchange-aware symbol SSOT 후속 정렬 | **#1613 코드 SSOT 체인** |
 | **Live DataCollector write·경로 생성** (OHLCV `{1m,5m,15m,1h}`만, `1d`·`tick` 제외) | 누락 소비자 ingress enforcement 추적 폐쇄 | **#1614** (Depends on #1613) |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -23,6 +23,7 @@
 | [D-014](D-014.md) | 설정 API 구조 — Config API 단일화 | 2026-03-23 | 설정 화면은 기존 Config API로 일원화 |
 | [D-015](D-015-default-deny-auth-gate.md) | default-deny 인증 게이트 | 2026-05-11 | Web/CLI 모두 default-deny + allowlist (opt-out), middleware=인증·dependency=scope |
 | [D-016](D-016-canonical-exchange-vocabulary.md) | canonical exchange vocabulary | 2026-05-15 | Ante 전역 canonical exchange 집합·wildcard·legacy 호환 계약 SSOT |
+| [D-017](D-017-canonical-symbol-timeframe-vocabulary.md) | canonical symbol/timeframe vocabulary | 2026-05-16 | symbol/timeframe canonical 집합·다축 구분·legacy 호환 계약 SSOT |
 
 ## 사용 규칙
 

--- a/docs/specs/core/core.md
+++ b/docs/specs/core/core.md
@@ -232,11 +232,21 @@ CanonicalTimeframe = [1m, 5m, 15m, 1h, 1d]
 
 ### KRX symbol shape
 
-- 신규 입력 KRX `symbol`의 경계는 **6자리 ASCII digit**이다: `^[0-9]{6}$`.
-- 비-KRX symbol format(예: 미국 ticker `AAPL`)은 1.0 비목표다. 1.0 시점 신규 입력
-  symbol 검증 vocabulary는 KRX 6자리 숫자 형태로 한정한다.
+- KRX symbol shape(`^[0-9]{6}$`)는 **resolved exchange == `KRX`인 신규 입력
+  경계에만** 적용된다. 즉 신규 입력 symbol이 KRX exchange에 귀속될 때만 6자리
+  ASCII digit(`^[0-9]{6}$`) 형태 계약을 적용한다.
+- 비-KRX exchange(`NYSE`/`NASDAQ`/`AMEX`/`TEST` 등 D-016 canonical exchange)의
+  symbol format은 **1.0 비목표이며 본 SSOT가 제약하지 않는다** — 예:
+  `exchange=NYSE`의 `AAPL`은 본 계약의 symbol-shape 사유로 거부되지 않는다.
+  (resolved exchange가 KRX가 아니면 symbol shape 검증을 적용하지 않는다.)
+- 1.0은 KRX-exchange symbol shape만 계약화한다. 다른 exchange의 symbol
+  vocabulary 도입은 별도 후속(1.0 비목표)이며 본 절의 범위가 아니다.
+- D-016 관계: `exchange` 자체의 canonical vocabulary는
+  [`## Canonical Exchange Vocabulary`](#canonical-exchange-vocabulary)(D-016)가
+  SSOT이고, 본 절은 그 중 **exchange == KRX인 경우의 symbol shape**만 계약한다
+  (exchange vocabulary는 D-016, KRX symbol shape는 본 절·exchange=KRX 한정).
 - 코드 레벨 SSOT(`_KRX_SYMBOL_PATTERN`/`_KRX_NUMERIC_SYMBOL_PATTERN` 등 산재 regex
-  정렬)는 #1613의 범위다. 본 절은 신규 입력 형태 계약만 고정한다.
+  정렬)는 #1613의 범위다. 본 절은 (exchange=KRX 한정) 신규 입력 형태 계약만 고정한다.
 
 ### symbol/timeframe 축 구분
 
@@ -276,7 +286,7 @@ surface별 enforcement·에러코드·구현 동작·정렬은 아래 후속 이
 | Backtest programmatic API | `{1m,5m,15m,1h,1d}` | 검증 에러 | enforcement·에러 계층은 **#1604 정렬 사안** |
 | `data validate` CLI | `{1m,5m,15m,1h,1d}` | non-zero exit + 구조화 error payload | enforcement·에러코드는 **#1605 정렬 사안** |
 | `feed inject` | `{1m,5m,15m,1h,1d}` | 거부 (구조화 error) | enforcement·에러 계층은 **#1606 정렬 사안** |
-| Instrument import KRX symbol | KRX `^[0-9]{6}$` (축 E 신규 입력) | non-zero exit + 구조화 error payload | symbol shape enforcement는 **#1611 정렬 사안** |
+| Instrument import KRX symbol | **exchange=KRX일 때** `^[0-9]{6}$` (축 E 신규 입력); 비-KRX exchange(`NYSE`/`NASDAQ`/`AMEX`/`TEST`)는 symbol-shape 미적용(1.0 비목표) | non-zero exit + 구조화 error payload (exchange=KRX 행에 한함) | symbol shape enforcement는 **#1611 정렬 사안**. ingress = `src/ante/cli/commands/instrument.py` import handler |
 | Data API `timeframe` filter (`GET /api/data/datasets`) | `{1m,5m,15m,1h,1d}` | **400 (기구현)** | `timeframe`은 #1594에서 vocabulary 외 값 **400 거부 기구현**. `symbol`은 별개 — invalid `symbol` vocabulary 거부는 **#1594 아님**, exchange-aware symbol SSOT 후속(#1613 코드 SSOT 체인) **정렬 사안**이며 현재 invalid `symbol`은 **200 empty 유지**(web-api/05 `GET /api/data/datasets` 계약과 정합) |
 | Live DataCollector write·경로 생성 | **OHLCV `{1m,5m,15m,1h}`만** (`1d`는 write-ownership상 DataFeed 소유라 제외, `tick`은 별도 data_type라 제외) | enforcement 미구현 (현재 spec-vs-impl gap) | ingress enforcement는 **#1614 정렬 사안** (Depends on #1613). 본 행은 "Collector write vocabulary는 OHLCV `{1m,5m,15m,1h}`로 한정(축 D상 `1d`·축 C상 `tick` 제외)" 경계만 명시 |
 
@@ -318,7 +328,9 @@ surface별 enforcement·에러코드·구현 동작·정렬은 아래 후속 이
 | Backtest programmatic API timeframe enforcement | (#1604 범위) | #1604 |
 | `data validate` CLI timeframe enforcement | `src/ante/cli/commands/data.py:27,35` `TIMEFRAMES` 순서 의존 iteration | #1605 |
 | `feed inject` timeframe enforcement | (#1606 범위) | #1606 |
-| Instrument import KRX symbol shape enforcement | `src/ante/data/store.py:34` `_KRX_SYMBOL_PATTERN`(`^\d{6}$`) + `:74` `migrate_parquet_paths` legacy 판별, `src/ante/rule/engine.py:55` `_KRX_NUMERIC_SYMBOL_PATTERN`(`^[0-9]{6}$`) OrderRequestEvent preflight (#1299) | #1611 |
+| Instrument import KRX symbol shape enforcement (primary 소비자 — exchange=KRX 행 symbol 검증 경계) | `src/ante/cli/commands/instrument.py` import handler (`instrument_import`, import row 검증 루프 — 현재 `is_canonical(exchange)`로 exchange만 검증하고 KRX symbol shape는 미검증; #1611이 exchange=KRX 행에 symbol shape 검증 추가 대상) | #1611 |
+| legacy parquet path migration KRX 판별 (축 E legacy 판별 — 신규 입력 검증과 별개 축) | `src/ante/data/store.py:34` `_KRX_SYMBOL_PATTERN`(`^\d{6}$`) + `:74` `migrate_parquet_paths` | **축 E legacy 판별 — #1611 enforcement 대상 아님** (store.py legacy 호환 무손상 보존, "Legacy out-of-vocabulary 호환 정책" 규율) |
+| RuleEngine OrderRequestEvent KRX numeric preflight (#1299 기존 동작) | `src/ante/rule/engine.py:55` `_KRX_NUMERIC_SYMBOL_PATTERN`(`^[0-9]{6}$`) OrderRequestEvent preflight | **#1299 기존 동작 — 본 SSOT 도입으로 동작 불변, #1611 아님** |
 | Data API `timeframe` filter (기구현 400) | `src/ante/web/routes/data.py:65,85` #1594 timeframe 400 filter (기구현) | #1594 |
 | Data API `symbol` filter 잔여 vocabulary 거부 (현재 200 empty 유지 — 독립 행) | `src/ante/web/routes/data.py` datasets `symbol` query (현재 invalid `symbol`은 200 empty, **#1594 아님**, web-api/05 계약과 정합) | **#1613 코드 SSOT 체인** (exchange-aware symbol SSOT 후속 정렬 사안) |
 | **Live DataCollector write·경로 생성** (OHLCV `{1m,5m,15m,1h}`만, `1d`·`tick` 제외 — 독립 행) | `src/ante/data/collector.py:61-150` `DataCollector.start/add_data/_collect_loop/_flush` live write | **#1614** (Depends on #1613) |

--- a/docs/specs/core/core.md
+++ b/docs/specs/core/core.md
@@ -287,7 +287,7 @@ surface별 enforcement·에러코드·구현 동작·정렬은 아래 후속 이
 | `data validate` CLI | `{1m,5m,15m,1h,1d}` | non-zero exit + 구조화 error payload | enforcement·에러코드는 **#1605 정렬 사안** |
 | `feed inject` | `{1m,5m,15m,1h,1d}` | 거부 (구조화 error) | enforcement·에러 계층은 **#1606 정렬 사안** |
 | Instrument import KRX symbol | **exchange=KRX일 때** `^[0-9]{6}$` (축 E 신규 입력); 비-KRX exchange(`NYSE`/`NASDAQ`/`AMEX`/`TEST`)는 symbol-shape 미적용(1.0 비목표) | non-zero exit + 구조화 error payload (exchange=KRX 행에 한함) | symbol shape enforcement는 **#1611 정렬 사안**. ingress = `src/ante/cli/commands/instrument.py` import handler |
-| Data API `timeframe` filter (`GET /api/data/datasets`) | `{1m,5m,15m,1h,1d}` | **400 (기구현)** | `timeframe`은 #1594에서 vocabulary 외 값 **400 거부 기구현**. `symbol`은 별개 — invalid `symbol` vocabulary 거부는 **#1594 아님**, exchange-aware symbol SSOT 후속(#1613 코드 SSOT 체인) **정렬 사안**이며 현재 invalid `symbol`은 **200 empty 유지**(web-api/05 `GET /api/data/datasets` 계약과 정합) |
+| Data API `timeframe` filter (`GET /api/data/datasets`) | `{1m,5m,15m,1h,1d}` | **400 (기구현)** | `timeframe`은 #1594에서 vocabulary 외 값 **400 거부 기구현**. `symbol`은 별개 축 — datasets API는 `symbol`을 별도 vocabulary 거부하지 않고 **exact-match 필터로만** 처리한다(매칭 데이터 미존재 시 **200 empty**, legacy out-of-vocab symbol dir(`ohlcv/<tf>/KRX/<sym>`)이 저장돼 있으면 그 dataset을 반환 — 아래 "Legacy out-of-vocabulary 호환 정책"과 정합). `symbol` vocabulary 거부 자체는 **#1594 아님**, exchange-aware symbol SSOT 후속(#1613 코드 SSOT 체인) **정렬 사안**(web-api/05 `GET /api/data/datasets` 계약과 정합) |
 | Live DataCollector write·경로 생성 | **OHLCV `{1m,5m,15m,1h}`만** (`1d`는 write-ownership상 DataFeed 소유라 제외, `tick`은 별도 data_type라 제외) | enforcement 미구현 (현재 spec-vs-impl gap) | ingress enforcement는 **#1614 정렬 사안** (Depends on #1613). 본 행은 "Collector write vocabulary는 OHLCV `{1m,5m,15m,1h}`로 한정(축 D상 `1d`·축 C상 `tick` 제외)" 경계만 명시 |
 
 판정 보조 노트:
@@ -332,7 +332,7 @@ surface별 enforcement·에러코드·구현 동작·정렬은 아래 후속 이
 | legacy parquet path migration KRX 판별 (축 E legacy 판별 — 신규 입력 검증과 별개 축) | `src/ante/data/store.py:34` `_KRX_SYMBOL_PATTERN`(`^\d{6}$`) + `:74` `migrate_parquet_paths` | **축 E legacy 판별 — #1611 enforcement 대상 아님** (store.py legacy 호환 무손상 보존, "Legacy out-of-vocabulary 호환 정책" 규율) |
 | RuleEngine OrderRequestEvent KRX numeric preflight (#1299 기존 동작) | `src/ante/rule/engine.py:55` `_KRX_NUMERIC_SYMBOL_PATTERN`(`^[0-9]{6}$`) OrderRequestEvent preflight | **#1299 기존 동작 — 본 SSOT 도입으로 동작 불변, #1611 아님** |
 | Data API `timeframe` filter (기구현 400) | `src/ante/web/routes/data.py:65,85` #1594 timeframe 400 filter (기구현) | #1594 |
-| Data API `symbol` filter 잔여 vocabulary 거부 (현재 200 empty 유지 — 독립 행) | `src/ante/web/routes/data.py` datasets `symbol` query (현재 invalid `symbol`은 200 empty, **#1594 아님**, web-api/05 계약과 정합) | **#1613 코드 SSOT 체인** (exchange-aware symbol SSOT 후속 정렬 사안) |
+| Data API `symbol` filter (exact-match·미거부 — 독립 행) | `src/ante/web/routes/data.py` datasets `symbol` query (datasets API는 `symbol`을 별도 vocabulary 거부하지 않고 exact-match 필터로만 처리 — 미매칭 시 200 empty, legacy out-of-vocab symbol dir이 저장돼 있으면 그 dataset 반환; **#1594 아님**, web-api/05 계약·Legacy 호환 정책과 정합) | **#1613 코드 SSOT 체인** (exchange-aware symbol SSOT 후속 정렬 사안) |
 | **Live DataCollector write·경로 생성** (OHLCV `{1m,5m,15m,1h}`만, `1d`·`tick` 제외 — 독립 행) | `src/ante/data/collector.py:61-150` `DataCollector.start/add_data/_collect_loop/_flush` live write | **#1614** (Depends on #1613) |
 | fundamental cadence `dataset.timeframe` overload reconciliation (축 F — 후보 D deferral 행) | `docs/dashboard/user-stories/backtest-data.md`, `docs/dashboard/mockups/backtest-data-fundamental.html` (본 이슈 무편집) | **후보 D** (deferral, 사람 등록 surface) |
 

--- a/docs/specs/core/core.md
+++ b/docs/specs/core/core.md
@@ -201,6 +201,128 @@ surface 운영/소스/핸들러 디테일은 후속 이슈 정렬 사안으로 �
 | 회귀 테스트 고정 | #1579 |
 | 에픽 | #1561 |
 
+## Canonical Symbol/Timeframe Vocabulary
+
+> 이 절은 Ante 전역에서 OHLCV bar `timeframe`과 신규 입력 `symbol`이 의미하는
+> **canonical vocabulary와 적용 범위의 계약 SSOT**다.
+> 결정 배경·근거·소비자 영향은 ADR [D-017](../../decisions/D-017-canonical-symbol-timeframe-vocabulary.md)에 정리되어 있으며,
+> 본 절이 normative 계약 본문이다. ADR은 본 절을 링크하고 계약 본문을 중복 기재하지 않는다.
+
+OHLCV bar `timeframe`과 KRX `symbol`은 data / web-api / cli / strategy / backtest가
+공유하는 식별 차원이다. 1.0 시점에 각 표면이 인라인 SSOT 표기(`ante.data.schemas.TIMEFRAMES`)나
+분산된 normative 서술을 갖고 있어 단일 계약이 부재했고, 본 절이 그 계약을 확정한다.
+**런타임 enforcement·코드 동작 변경은 본 절의 범위가 아니다**(코드 레벨 SSOT는 #1613,
+표면별 enforcement는 #1603/#1604/#1605/#1606/#1611/#1594/#1614로 위임). 본 절은 "무엇이
+canonical이고 어느 경계에서 어떻게 거부되어야 하는지"의 계약만 정의한다.
+
+### Canonical timeframe set
+
+```
+CanonicalTimeframe = [1m, 5m, 15m, 1h, 1d]
+```
+
+- canonical OHLCV bar timeframe 값은 **고정 집합·고정 순서**다. 위 5종이 신규 입력 검증
+  vocabulary 전체이며, 표기 순서(`1m → 5m → 15m → 1h → 1d`)는 순서 의존 소비자(예:
+  `src/ante/cli/commands/data.py`의 iteration)를 위해 계약상 고정한다.
+- 값은 위 리터럴과 **정확히 일치**해야 한다(exact-literal). alias(예: `1min`, `D`,
+  `daily`)·대소문자 정규화·사용자 정의 timeframe set은 1.0 비목표다. 입력 정규화(no-alias·
+  no-normalization)도 적용하지 않는다.
+- 코드 레벨 SSOT(상수 단일화 — `TIMEFRAMES`/`_OHLCV_TIMEFRAMES` 등 산재 상수 정렬)는
+  #1613의 범위다. 본 절은 값 집합·순서 자체의 계약만 고정한다.
+
+### KRX symbol shape
+
+- 신규 입력 KRX `symbol`의 경계는 **6자리 ASCII digit**이다: `^[0-9]{6}$`.
+- 비-KRX symbol format(예: 미국 ticker `AAPL`)은 1.0 비목표다. 1.0 시점 신규 입력
+  symbol 검증 vocabulary는 KRX 6자리 숫자 형태로 한정한다.
+- 코드 레벨 SSOT(`_KRX_SYMBOL_PATTERN`/`_KRX_NUMERIC_SYMBOL_PATTERN` 등 산재 regex
+  정렬)는 #1613의 범위다. 본 절은 신규 입력 형태 계약만 고정한다.
+
+### symbol/timeframe 축 구분
+
+`timeframe`·`symbol` 리터럴이 등장하는 위치는 아래 **여섯 축**으로 분리되며 서로
+규율 SSOT가 다르다. 본 절(축 A의 OHLCV bar timeframe canonical set, 축 E의 KRX
+symbol shape 신규 입력 형태)만 SSOT로 소유한다. 나머지 축은 각자의 스펙이 규율하며
+본 계약이 값을 재정의하지 않는다.
+
+| 축 | 대상 | 의미 | 규율 SSOT | 본 계약과의 관계 |
+|----|------|------|-----------|------------------|
+| **A** | OHLCV bar timeframe (`1m`/`5m`/`15m`/`1h`/`1d`) | 신규 입력 timeframe vocabulary | **본 절(`### Canonical timeframe set`)** | 본 계약 SSOT |
+| **B** | subminute 파티셔닝 해상도 (`10s`/`30s`) | Parquet 일별 파티셔닝 단위 | `docs/specs/data-feed/04-schema.md` | 별개 축. timeframe vocabulary가 아니라 저장 파티셔닝 해상도. 본 계약 밖 |
+| **C** | `tick` / `fundamental` data_type | OHLCV가 아닌 데이터 유형 | `docs/specs/data-pipeline/01·02·03` | 별개 축. timeframe이 아니라 data_type. 본 계약 밖 |
+| **D** | write-ownership (`<1d`+`tick`=Collector / `1d`+`fundamental`=DataFeed) | 파티션 쓰기 소유자 | `docs/specs/data-pipeline/02-write-ownership.md` | 별개 축. 어느 모듈이 쓰는가의 소유권 분배이며 입력 vocabulary 계약이 아니다 |
+| **E** | 신규 입력 strict ASCII 검증 vs legacy parquet path migration 판별 | 신규 입력 경계 vs 기존 경로 호환 | 신규 입력=본 절(`### KRX symbol shape`), legacy path migration 판별=`src/ante/data/store.py`(`\d` 보존) | 신규 입력 형태만 본 계약 SSOT. legacy 경로 판별 regex는 별개 축(아래 "Legacy 호환 정책") |
+| **F** | fundamental cadence/periodicity (`quarterly`/`annual`) | 재무 데이터 주기 | (현재 `dataset.timeframe` 필드에 overload — 정리는 후보 D deferral) | **별개 축. 본 canonical OHLCV-timeframe 계약에 포함하지 않는다.** 현재 `dataset.timeframe` 필드(`docs/dashboard/user-stories/backtest-data.md:79`·`docs/dashboard/mockups/backtest-data-fundamental.html:127`, fundamental parquet `quarterly.parquet`/`annual.parquet`)에 overload된 cross-surface 불일치는 #1612가 만든 것이 아니다. 본 절은 "fundamental cadence는 OHLCV bar timeframe과 별개 축이며 그 필드 의미 정리는 후보 D" 까지만 명문화하고 값 정의·필드 재설계는 하지 않는다 |
+
+(D-016 `### exchange vs market vs source vs broker_type` 절과 동형 구조: 같은 리터럴이라도
+어느 축의 값인지에 따라 규율 SSOT가 다르며 값을 섞지 않는다.)
+
+### Per-surface 허용/거부 + 검증·에러 계약 매트릭스
+
+검증은 **표면별로 분리**된다. 같은 vocabulary라도 어느 경계에서 어떤 에러 계약으로
+거부되는지는 표면마다 다르다.
+
+**범위 불변식**: 본 절은 OHLCV bar timeframe·KRX symbol vocabulary 유효성 계약
+(canonical set·고정 순서·exact-literal / KRX 6자리 / legacy read 호환)을 정의한다.
+surface별 enforcement·에러코드·구현 동작·정렬은 아래 후속 이슈에 위임되며 본 절에서
+완전 명세하지 않는다. 후속 이슈 구현자는 본 절의 vocabulary 계약을 상위 기준으로
+삼고 surface 동작을 그 아래에서 정렬한다. 따라서 아래 표의 각 행은 vocabulary 계약과
+거부 경계까지만 계약화하며, surface 운영/핸들러 디테일은 후속 이슈 정렬 사안으로
+표기한다.
+
+| 표면 | OHLCV timeframe 허용 | non-canonical 거부 계약 | 비고 |
+|------|----------------------|--------------------------|------|
+| Backtest run CLI | `{1m,5m,15m,1h,1d}` | non-zero exit + 구조화 error payload | enforcement·에러코드는 **#1603 정렬 사안**. 본 행은 vocabulary 계약만 명시 |
+| Backtest programmatic API | `{1m,5m,15m,1h,1d}` | 검증 에러 | enforcement·에러 계층은 **#1604 정렬 사안** |
+| `data validate` CLI | `{1m,5m,15m,1h,1d}` | non-zero exit + 구조화 error payload | enforcement·에러코드는 **#1605 정렬 사안** |
+| `feed inject` | `{1m,5m,15m,1h,1d}` | 거부 (구조화 error) | enforcement·에러 계층은 **#1606 정렬 사안** |
+| Instrument import KRX symbol | KRX `^[0-9]{6}$` (축 E 신규 입력) | non-zero exit + 구조화 error payload | symbol shape enforcement는 **#1611 정렬 사안** |
+| Data API `timeframe` filter (`GET /api/data/datasets`) | `{1m,5m,15m,1h,1d}` | **400 (기구현)** | #1594에서 vocabulary 외 값 400 거부 **기구현**. 잔여 symbol filter 정렬은 #1594 잔여 |
+| Live DataCollector write·경로 생성 | **OHLCV `{1m,5m,15m,1h}`만** (`1d`는 write-ownership상 DataFeed 소유라 제외, `tick`은 별도 data_type라 제외) | enforcement 미구현 (현재 spec-vs-impl gap) | ingress enforcement는 **#1614 정렬 사안** (Depends on #1613). 본 행은 "Collector write vocabulary는 OHLCV `{1m,5m,15m,1h}`로 한정(축 D상 `1d`·축 C상 `tick` 제외)" 경계만 명시 |
+
+판정 보조 노트:
+- 시나리오 1(OHLCV timeframe canonical 여부): 위 `### Canonical timeframe set`의
+  `{1m,5m,15m,1h,1d}` 5종만 canonical이며, alias·정규화 없이 exact-literal 일치만
+  허용된다.
+- 시나리오 2(`10s`/`30s`가 canonical timeframe인가): "symbol/timeframe 축 구분"
+  표 축 B에 따라 `10s`/`30s`는 timeframe vocabulary가 아니라 subminute 파티셔닝
+  해상도(`data-feed/04-schema.md` 규율)다.
+- 시나리오 3(`quarterly`/`annual`이 canonical timeframe인가): 축 F에 따라 fundamental
+  cadence는 OHLCV bar timeframe과 별개 축이며, 본 canonical 계약에 포함하지 않는다
+  (`dataset.timeframe` 필드 overload 정리는 후보 D deferral).
+- 시나리오 4(Collector가 `1d`를 쓰는가): 축 D(write-ownership, `data-pipeline/02`
+  규율)에 따라 `1d`는 DataFeed 소유이며 Collector write vocabulary는 OHLCV
+  `{1m,5m,15m,1h}`로 한정된다(#1614).
+
+### Legacy out-of-vocabulary 호환 정책
+
+- 검증은 **신규 입력 경계에만** 적용한다.
+- 기존 영속 Parquet path / SQLite row의 out-of-vocab timeframe·symbol 값은 read에서
+  거부하지 않는다. **자동 삭제·자동 마이그레이션하지 않는다**. 별도 마이그레이션
+  결정이 내려지기 전까지 기존 데이터는 그대로 읽힌다.
+- 즉 "out-of-vocab 값이 거부된다"는 새 데이터를 *쓰거나 입력으로 받을 때*만 적용되며,
+  이미 저장된 데이터의 읽기 호환성은 깨지 않는다.
+- 신규 입력 strict ASCII 검증(축 E)과 legacy parquet path migration 판별은 **별개 축**이다.
+  `src/ante/data/store.py`의 path migration 판별 regex(`\d`)는 기존 경로를 식별하기
+  위한 것이며, 신규 입력 검증(`^[0-9]{6}$`)으로 대체·강화되지 않는다(legacy 무손상 보존).
+
+### 소비자 목록 + 후속 이슈 매핑
+
+본 절은 계약 정의 + 영향 스펙 최소 포인터까지다. 실제 동작 정렬은 후속 이슈로 위임한다.
+
+| 소비자 / 작업 | 위치 (코드 변경 없음, 본 이슈 범위 밖) | 후속 이슈 |
+|---------------|----------------------------------------|-----------|
+| 코드 레벨 SSOT 도입(`ante.core.market_data_vocab` 신설, `TIMEFRAMES`/KRX regex 소비자 위임) | `src/ante/data/schemas.py:56` `TIMEFRAMES`, `src/ante/data/__init__.py:22,41` re-export + `__all__` | #1613 |
+| `DEFAULT_RETENTION` timeframe dict keys (보존 정책 dict 키 — 독립 소비자 행) | `src/ante/data/retention.py:13` `_OHLCV_TIMEFRAMES`, `:37` `DEFAULT_RETENTION` timeframe dict keys | #1613 (코드 SSOT). 보존 기간 값 자체는 retention 정책 고유 (`data-pipeline/03` 보존 정책 표) |
+| Backtest run CLI timeframe enforcement | (#1603 범위) | #1603 |
+| Backtest programmatic API timeframe enforcement | (#1604 범위) | #1604 |
+| `data validate` CLI timeframe enforcement | `src/ante/cli/commands/data.py:27,35` `TIMEFRAMES` 순서 의존 iteration | #1605 |
+| `feed inject` timeframe enforcement | (#1606 범위) | #1606 |
+| Instrument import KRX symbol shape enforcement | `src/ante/data/store.py:34` `_KRX_SYMBOL_PATTERN`(`^\d{6}$`) + `:74` `migrate_parquet_paths` legacy 판별, `src/ante/rule/engine.py:55` `_KRX_NUMERIC_SYMBOL_PATTERN`(`^[0-9]{6}$`) OrderRequestEvent preflight (#1299) | #1611 |
+| Data API `timeframe` filter (기구현 400) + 잔여 symbol filter | `src/ante/web/routes/data.py:65,85` #1594 timeframe 400 filter (기구현) | #1594 |
+| **Live DataCollector write·경로 생성** (OHLCV `{1m,5m,15m,1h}`만, `1d`·`tick` 제외 — 독립 행) | `src/ante/data/collector.py:61-150` `DataCollector.start/add_data/_collect_loop/_flush` live write | **#1614** (Depends on #1613) |
+| fundamental cadence `dataset.timeframe` overload reconciliation (축 F — 후보 D deferral 행) | `docs/dashboard/user-stories/backtest-data.md`, `docs/dashboard/mockups/backtest-data-fundamental.html` (본 이슈 무편집) | **후보 D** (deferral, 사람 등록 surface) |
+
 ## Logging 연계
 
 시스템 로그 인프라는 별도 모듈 스펙 [logging/README.md](../logging/README.md)로 분리되어 있다. Core는 시스템 초기화 순서상 로깅 설정(`setup_logging`)을 Database 이전 단계에서 수행한다.

--- a/docs/specs/core/core.md
+++ b/docs/specs/core/core.md
@@ -277,7 +277,7 @@ surface별 enforcement·에러코드·구현 동작·정렬은 아래 후속 이
 | `data validate` CLI | `{1m,5m,15m,1h,1d}` | non-zero exit + 구조화 error payload | enforcement·에러코드는 **#1605 정렬 사안** |
 | `feed inject` | `{1m,5m,15m,1h,1d}` | 거부 (구조화 error) | enforcement·에러 계층은 **#1606 정렬 사안** |
 | Instrument import KRX symbol | KRX `^[0-9]{6}$` (축 E 신규 입력) | non-zero exit + 구조화 error payload | symbol shape enforcement는 **#1611 정렬 사안** |
-| Data API `timeframe` filter (`GET /api/data/datasets`) | `{1m,5m,15m,1h,1d}` | **400 (기구현)** | #1594에서 vocabulary 외 값 400 거부 **기구현**. 잔여 symbol filter 정렬은 #1594 잔여 |
+| Data API `timeframe` filter (`GET /api/data/datasets`) | `{1m,5m,15m,1h,1d}` | **400 (기구현)** | `timeframe`은 #1594에서 vocabulary 외 값 **400 거부 기구현**. `symbol`은 별개 — invalid `symbol` vocabulary 거부는 **#1594 아님**, exchange-aware symbol SSOT 후속(#1613 코드 SSOT 체인) **정렬 사안**이며 현재 invalid `symbol`은 **200 empty 유지**(web-api/05 `GET /api/data/datasets` 계약과 정합) |
 | Live DataCollector write·경로 생성 | **OHLCV `{1m,5m,15m,1h}`만** (`1d`는 write-ownership상 DataFeed 소유라 제외, `tick`은 별도 data_type라 제외) | enforcement 미구현 (현재 spec-vs-impl gap) | ingress enforcement는 **#1614 정렬 사안** (Depends on #1613). 본 행은 "Collector write vocabulary는 OHLCV `{1m,5m,15m,1h}`로 한정(축 D상 `1d`·축 C상 `tick` 제외)" 경계만 명시 |
 
 판정 보조 노트:
@@ -319,7 +319,8 @@ surface별 enforcement·에러코드·구현 동작·정렬은 아래 후속 이
 | `data validate` CLI timeframe enforcement | `src/ante/cli/commands/data.py:27,35` `TIMEFRAMES` 순서 의존 iteration | #1605 |
 | `feed inject` timeframe enforcement | (#1606 범위) | #1606 |
 | Instrument import KRX symbol shape enforcement | `src/ante/data/store.py:34` `_KRX_SYMBOL_PATTERN`(`^\d{6}$`) + `:74` `migrate_parquet_paths` legacy 판별, `src/ante/rule/engine.py:55` `_KRX_NUMERIC_SYMBOL_PATTERN`(`^[0-9]{6}$`) OrderRequestEvent preflight (#1299) | #1611 |
-| Data API `timeframe` filter (기구현 400) + 잔여 symbol filter | `src/ante/web/routes/data.py:65,85` #1594 timeframe 400 filter (기구현) | #1594 |
+| Data API `timeframe` filter (기구현 400) | `src/ante/web/routes/data.py:65,85` #1594 timeframe 400 filter (기구현) | #1594 |
+| Data API `symbol` filter 잔여 vocabulary 거부 (현재 200 empty 유지 — 독립 행) | `src/ante/web/routes/data.py` datasets `symbol` query (현재 invalid `symbol`은 200 empty, **#1594 아님**, web-api/05 계약과 정합) | **#1613 코드 SSOT 체인** (exchange-aware symbol SSOT 후속 정렬 사안) |
 | **Live DataCollector write·경로 생성** (OHLCV `{1m,5m,15m,1h}`만, `1d`·`tick` 제외 — 독립 행) | `src/ante/data/collector.py:61-150` `DataCollector.start/add_data/_collect_loop/_flush` live write | **#1614** (Depends on #1613) |
 | fundamental cadence `dataset.timeframe` overload reconciliation (축 F — 후보 D deferral 행) | `docs/dashboard/user-stories/backtest-data.md`, `docs/dashboard/mockups/backtest-data-fundamental.html` (본 이슈 무편집) | **후보 D** (deferral, 사람 등록 surface) |
 

--- a/docs/specs/data-feed/02-design-decisions.md
+++ b/docs/specs/data-feed/02-design-decisions.md
@@ -18,6 +18,11 @@ natural key(`timestamp` 또는 `date`) 기준으로 중복을 제거하고 정�
 
 DataFeed가 소유하는 데이터 영역:
 
+> canonical symbol/timeframe 계약 SSOT: [core.md `## Canonical Symbol/Timeframe Vocabulary`](../core/core.md#canonical-symboltimeframe-vocabulary).
+> 본 절의 `1d`·`1d 미만`·`분봉`/`일봉`·`timeframes = ["1d"]` 서술은 core.md 축 구분 표의
+> **축 D(쓰기 소유권 분배, `data-pipeline/02-write-ownership.md`가 규율)** 서술이며 OHLCV bar
+> timeframe vocabulary(축 A)를 재정의하지 않는다.
+
 | 데이터 | 쓰기 방식 | 근거 |
 |--------|----------|------|
 | OHLCV 일봉 (`1d`) | merge/dedup | data.go.kr에서 완전한 일봉을 수집, 더 높은 신뢰도 |

--- a/docs/specs/data-feed/03-collection-scope.md
+++ b/docs/specs/data-feed/03-collection-scope.md
@@ -6,6 +6,10 @@
 
 ### Phase 1 — 국내 백테스트 기반 확보
 
+> canonical symbol/timeframe 계약 SSOT: [core.md `## Canonical Symbol/Timeframe Vocabulary`](../core/core.md#canonical-symboltimeframe-vocabulary).
+> 아래 표의 `API가 제공하는 모든 타임프레임`은 data.go.kr **source 가용성(source-capability)**
+> 축이며 OHLCV bar timeframe vocabulary(축 A) 계약과 별개 차원이다(값 재정의 아님).
+
 | 데이터 | 소스 | 비고 |
 |--------|------|------|
 | OHLCV + 거래대금 | data.go.kr | 주 소스 (일봉, API가 제공하는 모든 타임프레임) |

--- a/docs/specs/data-feed/04-schema.md
+++ b/docs/specs/data-feed/04-schema.md
@@ -30,6 +30,10 @@ DataFeed는 `ante.data.schemas`를 직접 import하여 사용한다. 스키마�
 
 ### 파일 규격
 
+> canonical symbol/timeframe 계약 SSOT: [core.md `## Canonical Symbol/Timeframe Vocabulary`](../core/core.md#canonical-symboltimeframe-vocabulary).
+> 아래 파티셔닝 행의 `10s/30s`는 core.md 축 구분 표의 **축 B(subminute 파티셔닝 해상도)**이며
+> OHLCV bar timeframe vocabulary(축 A)가 아니다. 본 절이 축 B의 규율 SSOT다(값 재정의 아님).
+
 | 항목 | 규칙 |
 |------|------|
 | 형식 | Parquet (snappy 압축) |

--- a/docs/specs/data-pipeline/02-write-ownership.md
+++ b/docs/specs/data-pipeline/02-write-ownership.md
@@ -7,6 +7,11 @@
 같은 Parquet 파티션에 복수 모듈이 동시에 쓰면 데이터 유실 위험이 있다.
 타임프레임·데이터 유형별로 **쓰기 소유권을 단일 모듈에 고정**하여 충돌을 원천 차단한다.
 
+> canonical symbol/timeframe 계약 SSOT: [core.md `## Canonical Symbol/Timeframe Vocabulary`](../core/core.md#canonical-symboltimeframe-vocabulary).
+> 본 절의 write-ownership(Collector `<1d`+`tick` / DataFeed `1d`+`fundamental`)은 core.md 축 구분
+> 표의 **축 D(쓰기 소유권 분배)**이며 OHLCV bar timeframe vocabulary(축 A)와 별개 축이다. 본 절이
+> 축 D의 규율 SSOT다(값 재정의 아님).
+
 | 데이터 | 쓰기 소유자 | 쓰기 모드 | 근거 |
 |--------|-----------|----------|------|
 | OHLCV 일봉 (`1d`) | DataFeed | merge/dedup | data.go.kr에서 완전한 일봉을 수집, 더 높은 신뢰도 |

--- a/docs/specs/data-pipeline/03-design-decisions.md
+++ b/docs/specs/data-pipeline/03-design-decisions.md
@@ -8,6 +8,12 @@
 
 모든 시세 데이터의 공통 스키마 상수:
 
+> 아래 스키마 표의 `symbol` 서술(`종목 코드 (6자리)` 등)은 **Phase1 KRX 데이터 형태**이며,
+> 신규 입력 `symbol` 검증 계약 SSOT는 [core.md `## Canonical Symbol/Timeframe Vocabulary`
+> `### KRX symbol shape`](../core/core.md#canonical-symboltimeframe-vocabulary)(resolved
+> exchange == KRX 한정)이다. 비-KRX exchange의 symbol format은 1.0 비목표이며 본 SSOT가
+> 제약하지 않는다. 본 스키마 표는 저장 형태 서술이며 신규 입력 검증 계약을 재정의하지 않는다.
+
 **OHLCV_SCHEMA**
 
 | 필드 | 타입 | 설명 |

--- a/docs/specs/data-pipeline/03-design-decisions.md
+++ b/docs/specs/data-pipeline/03-design-decisions.md
@@ -60,10 +60,14 @@
 > Phase 1에서 제공되지 않는 필드는 null 허용.
 > PER/PBR/EPS/BPS는 data.go.kr(시가총액, 상장주식수) + DART(순이익, 자본총계)로 **직접 계산**.
 
+> canonical symbol/timeframe 계약 SSOT: [core.md `## Canonical Symbol/Timeframe Vocabulary`](../core/core.md#canonical-symboltimeframe-vocabulary).
+> 아래 `TIMEFRAMES: list[str]`의 OHLCV bar timeframe vocabulary(`1m, 5m, 15m, 1h, 1d`) 계약 본문은
+> core.md 절이 SSOT이며, 이 코드 상수는 #1613(코드 레벨 SSOT 단일화)에서 파생 정렬된다.
+
 **편의 상수 및 검증 함수**:
 - `OHLCV_COLUMNS: list[str]` — `OHLCV_SCHEMA`의 키 목록
 - `FUNDAMENTAL_COLUMNS: list[str]` — `FUNDAMENTAL_SCHEMA`의 키 목록
-- `TIMEFRAMES: list[str]` — 지원 타임프레임 (`["1m", "5m", "15m", "1h", "1d"]`)
+- `TIMEFRAMES: list[str]` — 지원 타임프레임 (`["1m", "5m", "15m", "1h", "1d"]`, 계약 SSOT: core.md canonical timeframe set, 코드 상수 단일화는 #1613 파생)
 - `validate_ohlcv(df) -> bool` — OHLCV DataFrame의 필수 필드(`timestamp`, `symbol`, OHLC, `volume`, `source`) 존재 여부 검증
 - `validate_fundamental(df) -> bool` — FUNDAMENTAL DataFrame의 필수 필드(`date`, `symbol`, `source`) 존재 여부 검증
 
@@ -245,6 +249,14 @@ Parquet 파일 읽기/쓰기/관리를 담당한다. **모든 모듈이 Parquet�
 ### 데이터 보존 정책
 
 오래된 데이터를 삭제하여 용량을 관리한다.
+
+> 아래 보존 정책 표의 OHLCV timeframe 키(`1m`/`5m`/`15m`/`1h`/`1d`)는 [core.md
+> `## Canonical Symbol/Timeframe Vocabulary`](../core/core.md#canonical-symboltimeframe-vocabulary)
+> canonical OHLCV timeframe set에서 **파생**되며(보존 기간 값만 retention 정책 고유,
+> 코드 상수 단일화는 #1613 파생), `fundamental` 행은 timeframe이 아니라 **data_type
+> (축 C) retention 키**다. 따라서 표 헤더 `Timeframe`은 OHLCV bar timeframe 한정
+> 명칭이며 이 표의 키는 OHLCV timeframe + `fundamental` data_type 혼합 retention
+> 키다. 보존 기간 수치·행·코드 범위·#1614·후보 D는 본 pointer로 변경되지 않는다.
 
 **1.0 기본 보존 기간**:
 

--- a/docs/specs/strategy/03-01-strategy-interface.md
+++ b/docs/specs/strategy/03-01-strategy-interface.md
@@ -20,7 +20,7 @@
 | `author_name` | `str` | `"agent"` | 작성자 표시 이름 (예: `"전략 리서치 1호"`) |
 | `author_id` | `str` | `"agent"` | 작성자 ID (예: `"strategy-dev-01"`) |
 | `symbols` | `list[str] \| None` | `None` | 대상 종목 (`None`이면 봇 설정에서 지정) |
-| `timeframe` | `str` | `"1d"` | 기본 타임프레임 (`1m`, `5m`, `15m`, `1h`, `1d` 등) |
+| `timeframe` | `str` | `"1d"` | 기본 타임프레임 (canonical: `1m`, `5m`, `15m`, `1h`, `1d` — core.md `## Canonical Symbol/Timeframe Vocabulary`. exact-literal 5종, alias·추가 timeframe 없음) |
 | `exchange` | `str` | `"KRX"` | 대상 거래소. 유효 값: `"KRX"`, `"NYSE"`, `"NASDAQ"`, `"AMEX"`, `"TEST"`, `"*"`. `"*"`는 시장 무관(범용) 전략 |
 | `accepts_external_signals` | `bool` | `False` | 외부 시그널 수신 가능 여부. `True`인 전략만 시그널 채널 연결 허용 |
 

--- a/docs/specs/strategy/03-01-strategy-interface.md
+++ b/docs/specs/strategy/03-01-strategy-interface.md
@@ -8,6 +8,10 @@
 
 #### StrategyMeta 핵심 필드
 
+> canonical symbol/timeframe 계약 SSOT: [core.md `## Canonical Symbol/Timeframe Vocabulary`](../core/core.md#canonical-symboltimeframe-vocabulary).
+> 아래 `timeframe` 필드의 OHLCV bar vocabulary(`1m, 5m, 15m, 1h, 1d`) 계약 본문은 core.md
+> 절이 SSOT이며(축 A), 코드 상수 단일화·표면별 enforcement는 #1613 및 후속 이슈에 위임된다.
+
 | 필드 | 타입 | 기본값 | 설명 |
 |------|------|--------|------|
 | `name` | `str` | (필수) | 전략 고유 이름 (예: `"momentum_breakout"`) |

--- a/docs/specs/web-api/05-resource-endpoints.md
+++ b/docs/specs/web-api/05-resource-endpoints.md
@@ -72,9 +72,12 @@
 
 ## 데이터 (`/api/data`)
 
+> canonical symbol/timeframe 계약 SSOT: [core.md `## Canonical Symbol/Timeframe Vocabulary`](../core/core.md#canonical-symboltimeframe-vocabulary).
+> `timeframe` vocabulary(`1m, 5m, 15m, 1h, 1d`) 계약 본문은 core.md 절이 SSOT이며 코드 상수 단일화는 #1613에 위임된다. 표면별 enforcement 정렬은 #1594에서 다룬다.
+
 | Method | Path | 설명 |
 |--------|------|------|
-| GET | `/api/data/datasets` | 보유 데이터셋 목록 (필터: symbol, timeframe, data_type, offset, limit). `timeframe`은 `TIMEFRAMES` vocabulary(`1m, 5m, 15m, 1h, 1d`, SSOT: `ante.data.schemas.TIMEFRAMES`)만 허용 — vocabulary 외 값은 400 거부 (#1594). `data_type`은 `ohlcv \| fundamental` enum, 외 값은 422. `symbol` vocabulary 거부는 exchange-aware symbol SSOT 후속(후보 0)에 위임 — 현재 invalid `symbol`은 200 empty 유지 |
+| GET | `/api/data/datasets` | 보유 데이터셋 목록 (필터: symbol, timeframe, data_type, offset, limit). `timeframe`은 OHLCV bar vocabulary(`1m, 5m, 15m, 1h, 1d`, 계약 SSOT: core.md `## Canonical Symbol/Timeframe Vocabulary` (코드 상수 위임 #1613))만 허용 — vocabulary 외 값은 400 거부 (#1594). `data_type`은 `ohlcv \| fundamental` enum, 외 값은 422. `symbol` vocabulary 거부는 exchange-aware symbol SSOT 후속(후보 0)에 위임 — 현재 invalid `symbol`은 200 empty 유지 |
 | GET | `/api/data/datasets/{dataset_id}` | 데이터셋 상세 조회. 메타데이터(symbol, timeframe, 기간, 행 수) + 데이터 미리보기(최근 5행). dataset_id = `{symbol}__{timeframe}`. ParquetStore.read(limit=5) 활용 |
 | GET | `/api/data/schema` | 데이터 스키마 (필터: data_type) |
 | GET | `/api/data/storage` | 저장 용량 현황 |

--- a/docs/specs/web-api/05-resource-endpoints.md
+++ b/docs/specs/web-api/05-resource-endpoints.md
@@ -73,7 +73,7 @@
 ## 데이터 (`/api/data`)
 
 > canonical symbol/timeframe 계약 SSOT: [core.md `## Canonical Symbol/Timeframe Vocabulary`](../core/core.md#canonical-symboltimeframe-vocabulary).
-> `timeframe` vocabulary(`1m, 5m, 15m, 1h, 1d`) 계약 본문은 core.md 절이 SSOT이며 코드 상수 단일화는 #1613에 위임된다. 표면별 enforcement 정렬은 #1594에서 다룬다.
+> `timeframe` vocabulary(`1m, 5m, 15m, 1h, 1d`) 계약 본문은 core.md 절이 SSOT이며 코드 상수 단일화는 #1613에 위임된다. **`timeframe` filter 표면별 enforcement 정렬은 #1594에서 다룬다(`timeframe` 한정).** `symbol` vocabulary 거부는 #1594가 아니라 exchange-aware symbol SSOT 후속(후보 0 / #1613 코드 SSOT 체인) 정렬 사안이며, 현재 invalid `symbol`은 200 empty 유지(아래 `GET /api/data/datasets` 행과 정합).
 
 | Method | Path | 설명 |
 |--------|------|------|

--- a/docs/specs/web-api/05-resource-endpoints.md
+++ b/docs/specs/web-api/05-resource-endpoints.md
@@ -73,11 +73,11 @@
 ## 데이터 (`/api/data`)
 
 > canonical symbol/timeframe 계약 SSOT: [core.md `## Canonical Symbol/Timeframe Vocabulary`](../core/core.md#canonical-symboltimeframe-vocabulary).
-> `timeframe` vocabulary(`1m, 5m, 15m, 1h, 1d`) 계약 본문은 core.md 절이 SSOT이며 코드 상수 단일화는 #1613에 위임된다. **`timeframe` filter 표면별 enforcement 정렬은 #1594에서 다룬다(`timeframe` 한정).** `symbol` vocabulary 거부는 #1594가 아니라 exchange-aware symbol SSOT 후속(후보 0 / #1613 코드 SSOT 체인) 정렬 사안이며, 현재 invalid `symbol`은 200 empty 유지(아래 `GET /api/data/datasets` 행과 정합).
+> `timeframe` vocabulary(`1m, 5m, 15m, 1h, 1d`) 계약 본문은 core.md 절이 SSOT이며 코드 상수 단일화는 #1613에 위임된다. **`timeframe` filter 표면별 enforcement 정렬은 #1594에서 다룬다(`timeframe` 한정).** datasets API는 `symbol`을 **별도 vocabulary 거부하지 않고 exact-match 필터로만** 처리한다 — 매칭 데이터 미존재 시 200 empty, legacy out-of-vocab symbol dir(`ohlcv/<tf>/KRX/<sym>`)이 저장돼 있으면 그 dataset을 반환한다(core.md `## Canonical Symbol/Timeframe Vocabulary` `Legacy out-of-vocabulary 호환 정책`과 정합). `symbol` vocabulary 거부 자체는 #1594가 아니라 exchange-aware symbol SSOT 후속(#1613 코드 SSOT 체인) 정렬 사안이다(아래 `GET /api/data/datasets` 행과 정합).
 
 | Method | Path | 설명 |
 |--------|------|------|
-| GET | `/api/data/datasets` | 보유 데이터셋 목록 (필터: symbol, timeframe, data_type, offset, limit). `timeframe`은 OHLCV bar vocabulary(`1m, 5m, 15m, 1h, 1d`, 계약 SSOT: core.md `## Canonical Symbol/Timeframe Vocabulary` (코드 상수 위임 #1613))만 허용 — vocabulary 외 값은 400 거부 (#1594). `data_type`은 `ohlcv \| fundamental` enum, 외 값은 422. `symbol` vocabulary 거부는 exchange-aware symbol SSOT 후속(후보 0)에 위임 — 현재 invalid `symbol`은 200 empty 유지 |
+| GET | `/api/data/datasets` | 보유 데이터셋 목록 (필터: symbol, timeframe, data_type, offset, limit). `timeframe`은 OHLCV bar vocabulary(`1m, 5m, 15m, 1h, 1d`, 계약 SSOT: core.md `## Canonical Symbol/Timeframe Vocabulary` (코드 상수 위임 #1613))만 허용 — vocabulary 외 값은 400 거부 (#1594). `data_type`은 `ohlcv \| fundamental` enum, 외 값은 422. `symbol`은 별도 vocabulary 거부하지 않고 exact-match 필터로만 처리 — 매칭 데이터 미존재 시 200 empty, legacy out-of-vocab symbol dir(`ohlcv/<tf>/KRX/<sym>`)이 저장돼 있으면 그 dataset 반환(core.md Legacy out-of-vocabulary 호환 정책과 정합). `symbol` vocabulary 거부 자체는 exchange-aware symbol SSOT 후속(#1613 코드 SSOT 체인)에 위임 |
 | GET | `/api/data/datasets/{dataset_id}` | 데이터셋 상세 조회. 메타데이터(symbol, timeframe, 기간, 행 수) + 데이터 미리보기(최근 5행). dataset_id = `{symbol}__{timeframe}`. ParquetStore.read(limit=5) 활용 |
 | GET | `/api/data/schema` | 데이터 스키마 (필터: data_type) |
 | GET | `/api/data/storage` | 저장 용량 현황 |


### PR DESCRIPTION
Closes #1612

## Summary
- `docs/specs/core/core.md`에 `## Canonical Symbol/Timeframe Vocabulary` 절 신설 (D-016 exchange 절 1:1 미러: intro+ADR 단일참조 / Canonical timeframe set `{1m,5m,15m,1h,1d}` / KRX symbol shape `^[0-9]{6}$` exchange=KRX 한정 / 축 구분 A~F / Per-surface 매트릭스 / Legacy 호환 / 소비자+후속 매핑)
- `docs/decisions/D-017-canonical-symbol-timeframe-vocabulary.md` 신설 (D-016 구조 미러, 계약 본문은 core.md 단일 참조) + `docs/decisions/README.md` 인덱스
- 영향 스펙 단일 참조 reconciliation (docs-only): web-api/05, data-pipeline/02·03, data-feed/02·03·04, strategy/03-01
- **코드 변경 0** (Python/tests/dashboard 무변경). 코드 SSOT=#1613 / 표면 enforcement=#1603·1604·1605·1606·1611·1594 / live DataCollector=#1614 / fundamental cadence overload=후보 D(사람 등록) 로 분리

## 범위/불변
- docs-only 10경로만 변경, `git diff --stat src/ tests/` 빈 결과
- 값 집합 `{1m,5m,15m,1h,1d}`·KRX `^[0-9]{6}$`·store.py legacy `^\d{6}$`·보존 기간 수치 불변
- fundamental cadence(quarterly/annual) 본 계약 미포함 (후보 D deferral), #1614 경계 보존

## Test Plan
- Plan Preflight 7라운드 수렴 → Codex `narrow-scope approve-implement` (no material findings)
- Codex 브랜치 리뷰 attempt 4 PASS (attempt1~3 contract-drift → @code-reviewer 메타리뷰 narrow-scope → symbol-축 sweep 게이트 보강 후 수렴)
- 검증 게이트: timeframe 6범주 sweep + table-row sweep + symbol-축 4범주 sweep 전수 분류(누락 0, 신규 경쟁 SSOT 0) + `git diff --stat src/ tests/` 빈 결과 + docs 10경로 한정